### PR TITLE
Mixtrack pro fx update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -143,7 +143,7 @@ repos:
         language: python
         additional_dependencies:
           - beautifulsoup4==4.11.1
-          - lxml==4.9.1
+          - lxml==4.9.2
           - Markdown==3.4.1
         types: [text]
         files: ^(CHANGELOG\.md|res/linux/org\.mixxx\.Mixxx\.metainfo.xml)$

--- a/res/controllers/Numark-Mixtrack-Pro-FX-scripts.js
+++ b/res/controllers/Numark-Mixtrack-Pro-FX-scripts.js
@@ -11,7 +11,7 @@ MixtrackProFX.pitchRanges = [0.08, 0.16, 1];
 MixtrackProFX.waveformsSynced = true;
 
 // FX encoder controls meta
-// Controls whether encoder manages FX1 Effect1 meta and FX2 Effect1 meta (shfted) or
+// Controls whether encoder manages FX1 Effect1 meta and FX2 Effect1 meta (shifted) or
 // Encoder manages FX1&2 Effect1 Param1 & Param2(shifted)
 MixtrackProFX.fxControlsMeta = false;
 
@@ -146,9 +146,8 @@ MixtrackProFX.EffectUnit = function(deckNumber) {
     this.effectParam = new components.Encoder({
         group: "[EffectRack1_EffectUnit" + deckNumber + "_Effect1]",
         shift: function() {
-            if(MixtrackProFX.fxControlsMeta)
-            {
-                this.group = "[EffectRack1_EffectUnit" + 2 + "_Effect1]"
+            if (MixtrackProFX.fxControlsMeta) {
+                this.group = "[EffectRack1_EffectUnit" + 2 + "_Effect1]";
                 this.inKey = "meta";
                 return;
             }
@@ -156,9 +155,8 @@ MixtrackProFX.EffectUnit = function(deckNumber) {
             this.inKey = "parameter2";
         },
         unshift: function() {
-            if(MixtrackProFX.fxControlsMeta)
-            {
-                this.group = "[EffectRack1_EffectUnit" + 1 + "_Effect1]"
+            if (MixtrackProFX.fxControlsMeta) {
+                this.group = "[EffectRack1_EffectUnit" + 1 + "_Effect1]";
                 this.inKey = "meta";
                 return;
             }

--- a/res/controllers/Numark-Mixtrack-Pro-FX-scripts.js
+++ b/res/controllers/Numark-Mixtrack-Pro-FX-scripts.js
@@ -147,7 +147,7 @@ MixtrackProFX.EffectUnit = function(deckNumber) {
         group: "[EffectRack1_EffectUnit" + deckNumber + "_Effect1]",
         shift: function() {
             if (MixtrackProFX.fxControlsMeta) {
-                this.group = "[EffectRack1_EffectUnit" + 2 + "_Effect1]";
+                this.group = "[EffectRack1_EffectUnit2_Effect1]";
                 this.inKey = "meta";
                 return;
             }
@@ -156,7 +156,7 @@ MixtrackProFX.EffectUnit = function(deckNumber) {
         },
         unshift: function() {
             if (MixtrackProFX.fxControlsMeta) {
-                this.group = "[EffectRack1_EffectUnit" + 1 + "_Effect1]";
+                this.group = "[EffectRack1_EffectUnit1_Effect1]";
                 this.inKey = "meta";
                 return;
             }

--- a/res/controllers/Numark-Mixtrack-Pro-FX-scripts.js
+++ b/res/controllers/Numark-Mixtrack-Pro-FX-scripts.js
@@ -10,6 +10,11 @@ MixtrackProFX.pitchRanges = [0.08, 0.16, 1];
 // (Settings -> Preferences -> Waveforms -> Synchronize zoom level across all waveforms)
 MixtrackProFX.waveformsSynced = true;
 
+// FX encoder controls meta
+// Controls whether encoder manages FX1 Effect1 meta and FX2 Effect1 meta (shfted) or
+// Encoder manages FX1&2 Effect1 Param1 & Param2(shifted)
+MixtrackProFX.fxControlsMeta = false;
+
 // jogwheel
 MixtrackProFX.jogScratchSensitivity = 1024;
 MixtrackProFX.jogScratchAlpha = 1; // do NOT set to 2 or higher
@@ -141,9 +146,23 @@ MixtrackProFX.EffectUnit = function(deckNumber) {
     this.effectParam = new components.Encoder({
         group: "[EffectRack1_EffectUnit" + deckNumber + "_Effect1]",
         shift: function() {
+            if(MixtrackProFX.fxControlsMeta)
+            {
+                this.group = "[EffectRack1_EffectUnit" + 2 + "_Effect1]"
+                this.inKey = "meta";
+                return;
+            }
+
             this.inKey = "parameter2";
         },
         unshift: function() {
+            if(MixtrackProFX.fxControlsMeta)
+            {
+                this.group = "[EffectRack1_EffectUnit" + 1 + "_Effect1]"
+                this.inKey = "meta";
+                return;
+            }
+
             this.inKey = "parameter1";
         },
         input: function(channel, control, value) {


### PR DESCRIPTION
Adding a switch to allow the FX encoder to control the meta knobs of Effect 1 on FX 1 and FX 2 (when shifted).