### PR TITLE
Update to libdjinterop 0.19

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2065,12 +2065,13 @@ option(ENGINEPRIME "Support for library export to Denon Engine Prime" ON)
 if(ENGINEPRIME)
   # libdjinterop does not currently have a stable ABI, so we fetch sources for a specific tag, build here, and link
   # statically.  This situation should be reviewed once libdjinterop hits version 1.x.
-  set(LIBDJINTEROP_VERSION 0.16.1)
+  set(LIBDJINTEROP_VERSION 0.19.1)
   # Look whether an existing installation of libdjinterop matches the required version.
   find_package(DjInterop  ${LIBDJINTEROP_VERSION} EXACT CONFIG)
   if(NOT DjInterop_FOUND)
     find_package(DjInterop  ${LIBDJINTEROP_VERSION} EXACT MODULE)
   endif()
+
   if(DjInterop_FOUND)
     # An existing installation of djinterop is available.
     message(STATUS "STATIC link existing system installation of libdjinterop")
@@ -2100,7 +2101,7 @@ if(ENGINEPRIME)
       URL
         "https://github.com/xsco/libdjinterop/archive/refs/tags/${LIBDJINTEROP_VERSION}.tar.gz"
         "https://launchpad.net/~xsco/+archive/ubuntu/djinterop/+sourcefiles/libdjinterop/${LIBDJINTEROP_VERSION}-0ubuntu1/libdjinterop_${LIBDJINTEROP_VERSION}.orig.tar.gz"
-      URL_HASH SHA256=25461f5cc3ea80850d8400872f4fef08ad3730d9f2051719cccf2460f5ac15ad
+      URL_HASH SHA256=fd03a7ed54bf4e58da0075b517a6e7382546227a1ac165769987d57e1cf5e36e
       DOWNLOAD_DIR "${CMAKE_CURRENT_BINARY_DIR}/downloads"
       DOWNLOAD_NAME "libdjinterop-${LIBDJINTEROP_VERSION}.tar.gz"
       INSTALL_DIR ${DJINTEROP_INSTALL_DIR}

--- a/src/library/export/dlglibraryexport.cpp
+++ b/src/library/export/dlglibraryexport.cpp
@@ -18,7 +18,7 @@
 #include "library/trackset/crate/cratestorage.h"
 #include "moc_dlglibraryexport.cpp"
 
-namespace el = djinterop::engine;
+namespace e = djinterop::engine;
 
 namespace mixxx {
 
@@ -193,14 +193,14 @@ void DlgLibraryExport::exportRequested() {
 
     QDir baseExportDirectory{m_pExportDirectoryTextField->text()};
     const auto databaseDirectory = baseExportDirectory.filePath(
-            el::default_database_dir_name);
+            e::default_database_dir_name);
     const auto musicDirectory = baseExportDirectory.filePath(kDefaultMixxxExportDirName);
 
     // Work out what version was requested.
     // If there is an existing database, the version does not matter.
     int versionIndex = m_pVersionCombo->currentData().toInt();
-    el::engine_version exportVersion =
-            versionIndex == -1 ? el::latest_os : el::all_versions[versionIndex];
+    e::engine_version exportVersion =
+            versionIndex == -1 ? e::latest_os : e::all_versions[versionIndex];
 
     // Construct a request to export the library/crates.
     auto pRequest = QSharedPointer<EnginePrimeExportRequest>::create();
@@ -222,24 +222,24 @@ void DlgLibraryExport::exportRequested() {
 void DlgLibraryExport::checkExistingDatabase() {
     QDir baseExportDirectory{m_pExportDirectoryTextField->text()};
     const auto databaseDirectory = baseExportDirectory.filePath(
-            el::default_database_dir_name);
+            e::default_database_dir_name);
 
     try {
         // See if an EL DB exists in the chosen dir already.
-        bool exists = el::database_exists(databaseDirectory.toStdString());
+        bool exists = e::database_exists(databaseDirectory.toStdString());
         if (!exists) {
             // The user can freely choose a schema version for their new database.
             m_pExistingDatabaseLabel->setText("");
             m_pVersionCombo->clear();
             m_pVersionCombo->setEnabled(true);
             for (int versionIndex = 0;
-                    versionIndex < (int)el::all_versions.size();
+                    versionIndex < (int)e::all_versions.size();
                     ++versionIndex) {
-                el::engine_version version = el::all_versions[versionIndex];
+                e::engine_version version = e::all_versions[versionIndex];
                 m_pVersionCombo->insertItem(0,
                         QString::fromStdString(version.name),
                         QVariant{versionIndex});
-                if (version == el::latest_os) {
+                if (version == e::latest_os) {
                     // Latest firmware version is the default selection.
                     m_pVersionCombo->setCurrentIndex(0);
                 }
@@ -250,7 +250,7 @@ void DlgLibraryExport::checkExistingDatabase() {
         // Load the existing database, and set the displayed version widget
         // accordingly.  Changing the schema version of existing databases is
         // not currently supported.
-        djinterop::database db = el::load_database(databaseDirectory.toStdString());
+        djinterop::database db = e::load_database(databaseDirectory.toStdString());
         m_pExistingDatabaseLabel->setText(
                 tr("A database already exists in the chosen directory. "
                    "Exported tracks will be added into this database."));

--- a/src/library/export/dlglibraryexport.cpp
+++ b/src/library/export/dlglibraryexport.cpp
@@ -233,7 +233,7 @@ void DlgLibraryExport::checkExistingDatabase() {
             m_pVersionCombo->clear();
             m_pVersionCombo->setEnabled(true);
             for (int versionIndex = 0;
-                    versionIndex < (int)e::all_versions.size();
+                    versionIndex < static_cast<int>(e::all_versions.size());
                     ++versionIndex) {
                 e::engine_version version = e::all_versions[versionIndex];
                 m_pVersionCombo->insertItem(0,

--- a/src/library/export/engineprimeexportjob.cpp
+++ b/src/library/export/engineprimeexportjob.cpp
@@ -19,7 +19,7 @@
 #include "util/thread_affinity.h"
 #include "waveform/waveformfactory.h"
 
-namespace el = djinterop::engine;
+namespace e = djinterop::engine;
 
 namespace mixxx {
 
@@ -164,14 +164,14 @@ bool tryGetBeatgrid(BeatsPointer pBeats,
     std::vector<djinterop::beatgrid_marker> beatgrid{
             {0, firstBarAlignedBeatPlayPos.value()},
             {numBeats, lastBeatPlayPos.value()}};
-    beatgrid = el::normalize_beatgrid(std::move(beatgrid), frameCount);
+    beatgrid = e::normalize_beatgrid(std::move(beatgrid), frameCount);
     pBeatgrid->assign(std::begin(beatgrid), std::end(beatgrid));
     return true;
 }
 
 void exportMetadata(
         djinterop::database* pDatabase,
-        const el::engine_version& dbVersion,
+        const e::engine_version& dbVersion,
         QHash<TrackId, int64_t>* pMixxxToEnginePrimeTrackIdMap,
         TrackPointer pTrack,
         const Waveform* pWaveform,
@@ -287,9 +287,9 @@ void exportMetadata(
     // Write waveform.
     if (pWaveform) {
         djinterop::waveform_extents extents = dbVersion.is_v2_schema()
-                ? el::calculate_overview_waveform_extents(
+                ? e::calculate_overview_waveform_extents(
                           frameCount, pTrack->getSampleRate())
-                : el::calculate_high_resolution_waveform_extents(
+                : e::calculate_high_resolution_waveform_extents(
                           frameCount, pTrack->getSampleRate());
         std::vector<djinterop::waveform_entry> externalWaveform;
         externalWaveform.reserve(extents.size);
@@ -321,7 +321,7 @@ void exportMetadata(
 void exportTrack(
         const QSharedPointer<EnginePrimeExportRequest> pRequest,
         djinterop::database* pDatabase,
-        const el::engine_version& dbVersion,
+        const e::engine_version& dbVersion,
         QHash<TrackId, int64_t>* pMixxxToEnginePrimeTrackIdMap,
         const TrackPointer pTrack,
         const Waveform* pWaveform) {
@@ -509,10 +509,10 @@ void EnginePrimeExportJob::run() {
 
     // Ensure that the database exists, creating an empty one if not.
     std::unique_ptr<djinterop::database> pDb;
-    el::engine_version dbVersion;
+    e::engine_version dbVersion;
     try {
         bool created;
-        pDb = std::make_unique<djinterop::database>(el::create_or_load_database(
+        pDb = std::make_unique<djinterop::database>(e::create_or_load_database(
                 m_pRequest->engineLibraryDbDir.path().toStdString(),
                 m_pRequest->exportVersion,
                 created,

--- a/src/library/export/engineprimeexportrequest.h
+++ b/src/library/export/engineprimeexportrequest.h
@@ -18,7 +18,7 @@ struct EnginePrimeExportRequest {
     QDir musicFilesDir;
 
     /// Version of Engine Prime database to use when exporting.
-    djinterop::semantic_version exportVersion;
+    djinterop::engine::engine_version exportVersion;
 
     /// Set of crates to export, if `exportSelectedCrates` is set to true.
     ///


### PR DESCRIPTION
This PR updates Mixxx to use version 0.19 of libdjinterop, which supports Denon firmware up to version 3.0.0.

There are no functional changes as part of this PR - the changes are limited to those necessary to adhere to the evolving public API of libdjinterop whilst it is in its early 0.x state.