### PR TITLE
replace qstylepainter with qpainter in vumeterlegacy, use by default

### DIFF
--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -23,7 +23,7 @@ CmdlineArgs::CmdlineArgs()
           m_controllerAbortOnWarning(false),
           m_developer(false),
           m_safeMode(false),
-          m_useVuMeterGL(true),
+          m_useVuMeterGL(false),
           m_debugAssertBreak(false),
           m_settingsPathSet(false),
           m_scaleFactor(1.0),
@@ -172,15 +172,11 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
     parser.addOption(timelinePath);
     parser.addOption(timelinePathDeprecated);
 
-    const QCommandLineOption disableVuMeterGL(QStringLiteral("disable-vumetergl"),
+    const QCommandLineOption enableVuMeterGL(QStringLiteral("enable-vumetergl"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
-                                      "Do not use OpenGL vu meter")
+                                      "Use OpenGL vu meter")
                             : QString());
-    QCommandLineOption disableVuMeterGLDeprecated(
-            QStringLiteral("disableVuMeterGL"), disableVuMeterGL.description());
-    disableVuMeterGLDeprecated.setFlags(QCommandLineOption::HiddenFromHelp);
-    parser.addOption(disableVuMeterGL);
-    parser.addOption(disableVuMeterGLDeprecated);
+    parser.addOption(enableVuMeterGL);
 
     const QCommandLineOption controllerDebug(QStringLiteral("controller-debug"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
@@ -342,7 +338,7 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
         m_timelinePath = parser.value(timelinePathDeprecated);
     }
 
-    m_useVuMeterGL = !(parser.isSet(disableVuMeterGL) || parser.isSet(disableVuMeterGLDeprecated));
+    m_useVuMeterGL = parser.isSet(enableVuMeterGL);
     m_controllerDebug = parser.isSet(controllerDebug) || parser.isSet(controllerDebugDeprecated);
     m_controllerAbortOnWarning = parser.isSet(controllerAbortOnWarning);
     m_developer = parser.isSet(developer);

--- a/src/widget/wvumeterlegacy.cpp
+++ b/src/widget/wvumeterlegacy.cpp
@@ -1,11 +1,9 @@
 #include "widget/wvumeterlegacy.h"
 
-#include <QStyleOption>
-#include <QStylePainter>
-
 #include "moc_wvumeterlegacy.cpp"
 #include "util/math.h"
 #include "util/timer.h"
+#include "util/widgethelper.h"
 #include "widget/wpixmapstore.h"
 
 #define DEFAULT_FALLTIME 20
@@ -27,6 +25,7 @@ WVuMeterLegacy::WVuMeterLegacy(QWidget* pParent)
           m_iPeakFallTime(0),
           m_dPeakHoldCountdownMs(0) {
     m_timer.start();
+    setAutoFillBackground(true);
 }
 
 void WVuMeterLegacy::setup(const QDomNode& node, const SkinContext& context) {
@@ -152,13 +151,22 @@ void WVuMeterLegacy::maybeUpdate() {
     }
 }
 
+void WVuMeterLegacy::showEvent(QShowEvent* e) {
+    Q_UNUSED(e);
+    WWidget::showEvent(e);
+    // Find the base color recursively in parent widget.
+    const auto bgColor = mixxx::widgethelper::findBaseColor(this);
+    QPalette pal = QPalette();
+
+    pal.setColor(QPalette::Window, bgColor);
+
+    setPalette(pal);
+}
+
 void WVuMeterLegacy::paintEvent(QPaintEvent* /*unused*/) {
     ScopedTimer t("WVuMeterLegacy::paintEvent");
 
-    QStyleOption option;
-    option.initFrom(this);
-    QStylePainter p(this);
-    p.drawPrimitive(QStyle::PE_Widget, option);
+    QPainter p(this);
 
     if (!m_pPixmapBack.isNull() && !m_pPixmapBack->isNull()) {
         // Draw background. DrawMode takes care of whether to stretch or not.

--- a/src/widget/wvumeterlegacy.h
+++ b/src/widget/wvumeterlegacy.h
@@ -30,6 +30,7 @@ class WVuMeterLegacy : public WWidget {
 
   private:
     void paintEvent(QPaintEvent* /*unused*/) override;
+    void showEvent(QShowEvent* /*unused*/) override;
     void setPeak(double parameter);
 
     // Current parameter and peak parameter.


### PR DESCRIPTION
The GL-based vumeters reportedly cause lag on Windows, but also on macOS I notice they take relatively a lot of time (maybe QOpenGLWindow doesn't play nice with multiple small windows?)

This PR reenables the legacy VuMeter by default, replacing the command line option --disable-vumetergl with --enable-vumetergl. It has one important change which improved it's behaviour on macOS drastically: using QPainter instead of QStylePainter. The background color is determined in the same way as the GL VuMeter.

Also on macOS this seem to behave better than when using the GL-based VuMeter. At least not worse. If we confirm this works well for everyone on all platforms, I propose to remove the GL VuMeter code altogether, as well as the command line option.