### PR TITLE
Fixed unnecessary transfer of the ownership before release which returns the pointer itself

### DIFF
--- a/src/track/taglib/trackmetadata_id3v2.cpp
+++ b/src/track/taglib/trackmetadata_id3v2.cpp
@@ -382,10 +382,10 @@ void writeTextIdentificationFrame(
         auto pFrame =
                 std::make_unique<TagLib::ID3v2::TextIdentificationFrame>(id, stringType);
         pFrame->setText(toTString(text));
-        pTag->addFrame(pFrame.get());
-        // Now that the plain pointer in pFrame is owned and managed by
-        // pTag we need to release the ownership to avoid double deletion!
-        pFrame.release();
+
+        // Release returns a pointer to the managed object and releases the ownership,
+        // the plain pointer in pFrame is owned and managed by pTag
+        pTag->addFrame(pFrame.release());
     }
 }
 
@@ -414,10 +414,10 @@ void writeUserTextIdentificationFrame(
                     std::make_unique<TagLib::ID3v2::UserTextIdentificationFrame>(stringType);
             pFrame->setDescription(toTString(description));
             pFrame->setText(toTString(text));
-            pTag->addFrame(pFrame.get());
-            // Now that the plain pointer in pFrame is owned and managed by
-            // pTag we need to release the ownership to avoid double deletion!
-            pFrame.release();
+
+            // Release returns a pointer to the managed object and releases the ownership,
+            // the plain pointer in pFrame is owned and managed by pTag
+            pTag->addFrame(pFrame.release());
         }
     }
 }
@@ -488,10 +488,10 @@ void writeCommentsFrame(
                     std::make_unique<TagLib::ID3v2::CommentsFrame>(stringType);
             pFrame->setDescription(toTString(description));
             pFrame->setText(text);
-            pTag->addFrame(pFrame.get());
-            // Now that the plain pointer in pFrame is owned and managed by
-            // pTag we need to release the ownership to avoid double deletion!
-            pFrame.release();
+
+            // Release returns a pointer to the managed object and releases the ownership,
+            // the plain pointer in pFrame is owned and managed by pTag
+            pTag->addFrame(pFrame.release());
         }
     }
     // Cleanup: Remove non-standard comment frames to avoid redundant and
@@ -576,10 +576,10 @@ void writeGeneralEncapsulatedObjectFrame(
         pFrame->setDescription(toTString(description));
         pFrame->setObject(toTByteVector(data));
         pFrame->setMimeType(mimeType);
-        pTag->addFrame(pFrame.get());
-        // Now that the plain pointer in pFrame is owned and managed by
-        // pTag we need to release the ownership to avoid double deletion!
-        pFrame.release();
+
+        // Release returns a pointer to the managed object and releases the ownership,
+        // the plain pointer in pFrame is owned and managed by pTag
+        pTag->addFrame(pFrame.release());
     }
 }
 

--- a/src/track/taglib/trackmetadata_id3v2.cpp
+++ b/src/track/taglib/trackmetadata_id3v2.cpp
@@ -383,8 +383,7 @@ void writeTextIdentificationFrame(
                 std::make_unique<TagLib::ID3v2::TextIdentificationFrame>(id, stringType);
         pFrame->setText(toTString(text));
 
-        // Release returns a pointer to the managed object and releases the ownership,
-        // the plain pointer in pFrame is owned and managed by pTag
+        // pTag takes the ownership of pFrame
         pTag->addFrame(pFrame.release());
     }
 }
@@ -415,8 +414,7 @@ void writeUserTextIdentificationFrame(
             pFrame->setDescription(toTString(description));
             pFrame->setText(toTString(text));
 
-            // Release returns a pointer to the managed object and releases the ownership,
-            // the plain pointer in pFrame is owned and managed by pTag
+            // pTag takes the ownership of pFrame
             pTag->addFrame(pFrame.release());
         }
     }
@@ -489,8 +487,7 @@ void writeCommentsFrame(
             pFrame->setDescription(toTString(description));
             pFrame->setText(text);
 
-            // Release returns a pointer to the managed object and releases the ownership,
-            // the plain pointer in pFrame is owned and managed by pTag
+            // pTag takes the ownership of pFrame
             pTag->addFrame(pFrame.release());
         }
     }
@@ -577,8 +574,7 @@ void writeGeneralEncapsulatedObjectFrame(
         pFrame->setObject(toTByteVector(data));
         pFrame->setMimeType(mimeType);
 
-        // Release returns a pointer to the managed object and releases the ownership,
-        // the plain pointer in pFrame is owned and managed by pTag
+        // pTag takes the ownership of pFrame
         pTag->addFrame(pFrame.release());
     }
 }

--- a/src/util/db/dbconnectionpool.cpp
+++ b/src/util/db/dbconnectionpool.cpp
@@ -32,8 +32,11 @@ bool DbConnectionPool::createThreadLocalConnection() {
                 << *pConnection;
         return false; // abort
     }
-    m_threadLocalConnections.setLocalData(pConnection.get()); // transfer ownership
-    pConnection.release(); // release ownership
+
+    // Release returns a pointer to the managed object and releases the ownership,
+    // the plain pointer in pConnection is owned and managed by m_threadLocalConnections
+    m_threadLocalConnections.setLocalData(pConnection.release());
+
     DEBUG_ASSERT(m_threadLocalConnections.hasLocalData());
     DEBUG_ASSERT(m_threadLocalConnections.localData());
     kLogger.info()

--- a/src/util/db/dbconnectionpool.cpp
+++ b/src/util/db/dbconnectionpool.cpp
@@ -33,8 +33,7 @@ bool DbConnectionPool::createThreadLocalConnection() {
         return false; // abort
     }
 
-    // Release returns a pointer to the managed object and releases the ownership,
-    // the plain pointer in pConnection is owned and managed by m_threadLocalConnections
+    // m_threadLocalConnections takes the ownership of pConnection
     m_threadLocalConnections.setLocalData(pConnection.release());
 
     DEBUG_ASSERT(m_threadLocalConnections.hasLocalData());


### PR DESCRIPTION
These were reported as resoource leak by Coverity Scan, not real issues, but also an unnecessary commands. So this is the cleanest way to silence the warning.
While going through these warnings I noticed also #11725 which looks similar, but is a real ressource leak.