### PR TITLE
DjInterop: Fix Beta PPA and use VCPG static build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2066,69 +2066,81 @@ if(ENGINEPRIME)
   # libdjinterop does not currently have a stable ABI, so we fetch sources for a specific tag, build here, and link
   # statically.  This situation should be reviewed once libdjinterop hits version 1.x.
   set(LIBDJINTEROP_VERSION 0.16.1)
-
-  # On MacOS, Mixxx does not use system SQLite, so we will use libdjinterop's
-  # embedded SQLite in such a case.
-  if (APPLE AND NOT SQLite3_IS_STATIC)
-    message(STATUS "Building libdjinterop sources (with embedded SQLite) fetched from GitHub")
-    set(DJINTEROP_SYSTEM_SQLITE OFF)
-  else()
-    message(STATUS "Building libdjinterop sources (with system SQLite) fetched from GitHub")
-    set(DJINTEROP_SYSTEM_SQLITE ON)
+  # Look whether an existing installation of libdjinterop matches the required version.
+  find_package(DjInterop  ${LIBDJINTEROP_VERSION} EXACT CONFIG)
+  if(NOT DjInterop_FOUND)
+    find_package(DjInterop  ${LIBDJINTEROP_VERSION} EXACT MODULE)
   endif()
+  if(DjInterop_FOUND)
+    # An existing installation of djinterop is available.
+    message(STATUS "STATIC link existing system installation of libdjinterop")
+    target_link_libraries(mixxx-lib PRIVATE DjInterop::DjInterop)
+  else()
+    # On MacOS, Mixxx does not use system SQLite, so we will use libdjinterop's
+    # embedded SQLite in such a case.
+    if (APPLE AND NOT SQLite3_IS_STATIC)
+      message(STATUS "Building libdjinterop sources (with embedded SQLite) fetched from GitHub")
+      set(DJINTEROP_SYSTEM_SQLITE OFF)
+    else()
+      message(STATUS "Building libdjinterop sources (with system SQLite) fetched from GitHub")
+      set(DJINTEROP_SYSTEM_SQLITE ON)
+    endif()
 
-  set(DJINTEROP_INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/lib/libdjinterop-install")
-  set(DJINTEROP_LIBRARY "lib/${CMAKE_STATIC_LIBRARY_PREFIX}djinterop${CMAKE_STATIC_LIBRARY_SUFFIX}")
+    set(DJINTEROP_INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/lib/libdjinterop-install")
+    set(DJINTEROP_LIBRARY "lib/${CMAKE_STATIC_LIBRARY_PREFIX}djinterop${CMAKE_STATIC_LIBRARY_SUFFIX}")
 
-  # CMake does not pass lists of paths properly to external projects.
-  # This is worked around by changing the list separator.
-  string(REPLACE ";" "|" PIPE_DELIMITED_CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH}")
+    # CMake does not pass lists of paths properly to external projects.
+    # This is worked around by changing the list separator.
+    string(REPLACE ";" "|" PIPE_DELIMITED_CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH}")
 
-  # For offline builds download the archive file from the URL and
-  # copy it into DOWNLOAD_DIR under DOWNLOAD_NAME prior to starting
-  # the configuration.
-  ExternalProject_Add(libdjinterop
-    URL "https://github.com/xsco/libdjinterop/archive/refs/tags/${LIBDJINTEROP_VERSION}.tar.gz"
-    URL_HASH SHA256=25461f5cc3ea80850d8400872f4fef08ad3730d9f2051719cccf2460f5ac15ad
-    DOWNLOAD_DIR "${CMAKE_CURRENT_BINARY_DIR}/downloads"
-    DOWNLOAD_NAME "libdjinterop-${LIBDJINTEROP_VERSION}.tar.gz"
-    INSTALL_DIR ${DJINTEROP_INSTALL_DIR}
-    LIST_SEPARATOR "|"
-    CMAKE_ARGS
-      -DBUILD_SHARED_LIBS=OFF
-      -DCMAKE_SKIP_INSTALL_ALL_DEPENDENCY=ON
-      -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-      -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
-      -DCMAKE_PREFIX_PATH=${PIPE_DELIMITED_CMAKE_PREFIX_PATH}
-      -DCMAKE_TOOLCHAIN_FILE:PATH=${CMAKE_TOOLCHAIN_FILE}
-      -DCMAKE_INSTALL_LIBDIR:PATH=lib
-      -DCMAKE_MODULE_PATH:PATH=${CMAKE_MODULE_PATH}
-      -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT}
-      -DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}
-      -DCMAKE_SYSTEM_PROCESSOR=${CMAKE_SYSTEM_PROCESSOR}
-      -DCMAKE_SYSTEM_NAME=${CMAKE_SYSTEM_NAME}
-      -DSYSTEM_SQLITE=${DJINTEROP_SYSTEM_SQLITE}
-    BUILD_COMMAND ${CMAKE_COMMAND} --build . --target DjInterop
-    BUILD_BYPRODUCTS <INSTALL_DIR>/${DJINTEROP_LIBRARY}
-    EXCLUDE_FROM_ALL TRUE
-  )
+    # For offline builds download the archive file from the URL and
+    # copy it into DOWNLOAD_DIR under DOWNLOAD_NAME prior to starting
+    # the configuration.
+    ExternalProject_Add(libdjinterop
+      URL
+        "https://github.com/xsco/libdjinterop/archive/refs/tags/${LIBDJINTEROP_VERSION}.tar.gz"
+        "https://launchpad.net/~xsco/+archive/ubuntu/djinterop/+sourcefiles/libdjinterop/${LIBDJINTEROP_VERSION}-0ubuntu1/libdjinterop_${LIBDJINTEROP_VERSION}.orig.tar.gz"
+      URL_HASH SHA256=25461f5cc3ea80850d8400872f4fef08ad3730d9f2051719cccf2460f5ac15ad
+      DOWNLOAD_DIR "${CMAKE_CURRENT_BINARY_DIR}/downloads"
+      DOWNLOAD_NAME "libdjinterop-${LIBDJINTEROP_VERSION}.tar.gz"
+      INSTALL_DIR ${DJINTEROP_INSTALL_DIR}
+      LIST_SEPARATOR "|"
+      CMAKE_ARGS
+        -DBUILD_SHARED_LIBS=OFF
+        -DCMAKE_SKIP_INSTALL_ALL_DEPENDENCY=ON
+        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+        -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+        -DCMAKE_PREFIX_PATH=${PIPE_DELIMITED_CMAKE_PREFIX_PATH}
+        -DCMAKE_TOOLCHAIN_FILE:PATH=${CMAKE_TOOLCHAIN_FILE}
+        -DCMAKE_INSTALL_LIBDIR:PATH=lib
+        -DCMAKE_MODULE_PATH:PATH=${CMAKE_MODULE_PATH}
+        -DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT}
+        -DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES}
+        -DCMAKE_SYSTEM_PROCESSOR=${CMAKE_SYSTEM_PROCESSOR}
+        -DCMAKE_SYSTEM_NAME=${CMAKE_SYSTEM_NAME}
+        -DSYSTEM_SQLITE=${DJINTEROP_SYSTEM_SQLITE}
+      BUILD_COMMAND ${CMAKE_COMMAND} --build . --target DjInterop
+      BUILD_BYPRODUCTS <INSTALL_DIR>/${DJINTEROP_LIBRARY}
+      EXCLUDE_FROM_ALL TRUE
+    )
 
-  # Assemble a library based on the external project.
-  add_library(mixxx-libdjinterop STATIC IMPORTED)
-  add_dependencies(mixxx-libdjinterop libdjinterop)
-  set(DJINTEROP_INCLUDE_DIR "${DJINTEROP_INSTALL_DIR}/include")
-  set(DJINTEROP_LIBRARY_PATH "${DJINTEROP_INSTALL_DIR}/${DJINTEROP_LIBRARY}")
-  set_target_properties(mixxx-libdjinterop PROPERTIES IMPORTED_LOCATION "${DJINTEROP_LIBRARY_PATH}")
-  target_include_directories(mixxx-lib PUBLIC ${DJINTEROP_INCLUDE_DIR})
-  target_link_libraries(mixxx-lib PRIVATE mixxx-libdjinterop)
+    # Assemble a library based on the external project.
+    add_library(mixxx-libdjinterop STATIC IMPORTED)
+    add_dependencies(mixxx-libdjinterop libdjinterop)
+    set(DJINTEROP_INCLUDE_DIR "${DJINTEROP_INSTALL_DIR}/include")
+    set(DJINTEROP_LIBRARY_PATH "${DJINTEROP_INSTALL_DIR}/${DJINTEROP_LIBRARY}")
+    set_target_properties(mixxx-libdjinterop PROPERTIES IMPORTED_LOCATION "${DJINTEROP_LIBRARY_PATH}")
+    target_include_directories(mixxx-lib PUBLIC ${DJINTEROP_INCLUDE_DIR})
+    target_link_libraries(mixxx-lib PRIVATE mixxx-libdjinterop)
 
-  # Since we have built libdjinterop from sources as a static library, its
-  # transitive dependencies are not automatically recognised.  libdjinterop
-  # depends on zlib and optionally sqlite3.  If libdjinterop was configured
-  # to depend on system SQLite, Mixxx will already have the dependency.
-  # But it does not have zlib, so we explicitly add that here.
-  find_package(ZLIB 1.2.8 REQUIRED)
-  target_link_libraries(mixxx-lib PRIVATE ${ZLIB_LIBRARIES})
+    # Since we have built libdjinterop from sources as a static library, its
+    # transitive dependencies are not automatically recognised.  libdjinterop
+    # depends on zlib and optionally sqlite3.  If libdjinterop was configured
+    # to depend on system SQLite, Mixxx will already have the dependency.
+    # But it does not have zlib, so we explicitly add that here.
+    find_package(ZLIB 1.2.8 REQUIRED)
+    target_link_libraries(mixxx-lib PRIVATE ${ZLIB_LIBRARIES})
+  endif()
 
   # Include conditional sources only required with Engine Prime export support.
   target_sources(mixxx-lib PRIVATE

--- a/cmake/modules/FindDjInterop.cmake
+++ b/cmake/modules/FindDjInterop.cmake
@@ -68,7 +68,7 @@ endif()
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
   DjInterop
-  REQUIRED_VARS DjInterop_LIBRARY DjInterop_INCLUDE_DIR
+  REQUIRED_VARS DjInterop_LIBRARY DjInterop_INCLUDE_DIR DjInterop_VERSION
   VERSION_VAR DjInterop_VERSION
 )
 


### PR DESCRIPTION
In https://github.com/mixxxdj/mixxx/pull/11714 we have decided to download DjInterop always and do a static build. 

Accordingly I have prepared a vcpkg environment that has a pre-build STATIC version of DjInterop that will save us some build time. Since the cmake.config issue was fixed upstream it is now found reliable (see https://github.com/mixxxdj/vcpkg/pull/74)
So we can here re-enable the package_find() stage. 

The PPA build is not able to reach the GitHub tar ball. @mr-smidge has uploaded it to Launchpad as well so that we can use the Launchpad mirror that should be reach-able. 
This should fix our currently broken beta PPA builds. 



