### PR TITLE
Update lxml to 4.9.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -143,7 +143,7 @@ repos:
         language: python
         additional_dependencies:
           - beautifulsoup4==4.11.1
-          - lxml==4.9.1
+          - lxml==4.9.3
           - Markdown==3.4.1
         types: [text]
         files: ^(CHANGELOG\.md|res/linux/org\.mixxx\.Mixxx\.metainfo.xml)$


### PR DESCRIPTION
We had a report on Zulip that 4.9.1 is no longer available on windows. 
https://mixxx.zulipchat.com/#narrow/stream/247620-development-help/topic/Pre-commit-help

The minor update does not hurt ... 
