### PR TITLE
Looping: fix asserts for loop move

### DIFF
--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -1744,11 +1744,11 @@ mixxx::audio::FramePos LoopingControl::adjustedPositionInsideAdjustedLoop(
         adjustedPosition -= adjustSteps * newLoopSize;
         DEBUG_ASSERT(adjustedPosition < newLoopEndPosition);
         VERIFY_OR_DEBUG_ASSERT(adjustedPosition >= newLoopStartPosition) {
-            // I'm not even sure this is possible.  The new loop would have to be bigger than the
-            // old loop, and the playhead was somehow outside the old loop.
+            // This can happen when offset calculation above has double precision
+            // issues (noticed around 0.00) which shifts the pos beyond loop in
             qWarning()
                     << "SHOULDN'T HAPPEN: adjustedPositionInsideAdjustedLoop "
-                       "couldn't find a new position --"
+                       "set new position to before in point --"
                     << " seeking to in point";
             adjustedPosition = newLoopStartPosition;
         }
@@ -1761,9 +1761,11 @@ mixxx::audio::FramePos LoopingControl::adjustedPositionInsideAdjustedLoop(
         adjustedPosition += adjustSteps * newLoopSize;
         DEBUG_ASSERT(adjustedPosition >= newLoopStartPosition);
         VERIFY_OR_DEBUG_ASSERT(adjustedPosition < newLoopEndPosition) {
+            // This can happen when offset calculation above has double precision
+            // issues (noticed around 0.00) which shifts the pos beyond loop out
             qWarning()
                     << "SHOULDN'T HAPPEN: adjustedPositionInsideAdjustedLoop "
-                       "couldn't find a new position --"
+                       "set new position to out point or later--"
                     << " seeking to in point";
             adjustedPosition = newLoopStartPosition;
         }

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -1742,8 +1742,8 @@ mixxx::audio::FramePos LoopingControl::adjustedPositionInsideAdjustedLoop(
                 ceil((adjustedPosition.value() - newLoopEndPosition.value()) /
                         newLoopSize);
         adjustedPosition -= adjustSteps * newLoopSize;
-        DEBUG_ASSERT(adjustedPosition <= newLoopEndPosition);
-        VERIFY_OR_DEBUG_ASSERT(adjustedPosition > newLoopStartPosition) {
+        DEBUG_ASSERT(adjustedPosition < newLoopEndPosition);
+        VERIFY_OR_DEBUG_ASSERT(adjustedPosition >= newLoopStartPosition) {
             // I'm not even sure this is possible.  The new loop would have to be bigger than the
             // old loop, and the playhead was somehow outside the old loop.
             qWarning()


### PR DESCRIPTION
`adjustedPosition <= newLoopEndPosition` is wrong since `newLoopEndPosition` is considered outside the loop and jumping there would disable the loop.

I hit those assertions while trying to reproduce #11732, while moving a loop (set exactly at track start 0.00) back and forth crossing track start sample (where rounding issues occur.. ?)