### PR TITLE
VinylSignalQuality in WSpinnyGLSL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1213,6 +1213,7 @@ else()
       src/shaders/shader.cpp
       src/shaders/textureshader.cpp
       src/shaders/unicolorshader.cpp
+      src/shaders/vinylqualityshader.cpp
       src/util/texture.cpp
       src/waveform/renderers/allshader/matrixforwidgetgeometry.cpp
       src/waveform/renderers/allshader/waveformrenderbackground.cpp

--- a/src/shaders/vinylqualityshader.cpp
+++ b/src/shaders/vinylqualityshader.cpp
@@ -1,0 +1,35 @@
+#include "shaders/vinylqualityshader.h"
+
+using namespace mixxx;
+
+void VinylQualityShader::init() {
+    QString vertexShaderCode = QStringLiteral(R"--(
+uniform mat4 matrix;
+attribute vec4 position;
+attribute vec3 texcoor;
+varying vec3 vTexcoor;
+void main()
+{
+    vTexcoor = texcoor;
+    gl_Position = matrix * position;
+}
+)--");
+
+    QString fragmentShaderCode = QStringLiteral(R"--(
+uniform sampler2D sampler;
+uniform vec4 color;
+varying vec3 vTexcoor;
+void main()
+{
+    gl_FragColor = vec4(color.xyz, texture2D(sampler, vTexcoor.xy) * 0.75);
+}
+)--");
+
+    load(vertexShaderCode, fragmentShaderCode);
+
+    m_matrixLocation = uniformLocation("matrix");
+    m_samplerLocation = uniformLocation("sampler");
+    m_colorLocation = uniformLocation("color");
+    m_positionLocation = attributeLocation("position");
+    m_texcoordLocation = attributeLocation("texcoor");
+}

--- a/src/shaders/vinylqualityshader.h
+++ b/src/shaders/vinylqualityshader.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "shaders/shader.h"
+
+namespace mixxx {
+class VinylQualityShader;
+}
+
+class mixxx::VinylQualityShader final : public mixxx::Shader {
+  public:
+    VinylQualityShader() = default;
+    ~VinylQualityShader() = default;
+    void init();
+
+    int matrixLocation() const {
+        return m_matrixLocation;
+    }
+    int samplerLocation() const {
+        return m_samplerLocation;
+    }
+    int colorLocation() const {
+        return m_colorLocation;
+    }
+    int positionLocation() const {
+        return m_positionLocation;
+    }
+    int texcoordLocation() const {
+        return m_texcoordLocation;
+    }
+
+  private:
+    int m_matrixLocation;
+    int m_samplerLocation;
+    int m_colorLocation;
+    int m_positionLocation;
+    int m_texcoordLocation;
+
+    DISALLOW_COPY_AND_ASSIGN(VinylQualityShader)
+};

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -35,7 +35,7 @@ void WSpinny::draw() {
 
 #ifdef __VINYLCONTROL__
     // Overlay the signal quality drawing if vinyl is active
-    if (m_bVinylActive && m_bSignalActive) {
+    if (shouldDrawVinylQuality()) {
         // draw the last good image
         p.drawImage(this->rect(), m_qImage);
     }
@@ -71,6 +71,27 @@ void WSpinny::draw() {
         p.drawImage(QPointF(-m_fgImageScaled.width() / scaleFactor / 2.0,
                             -m_fgImageScaled.height() / scaleFactor / 2.0),
                 m_fgImageScaled);
+    }
+}
+
+void WSpinny::setupVinylSignalQuality() {
+    m_qImage = QImage(m_iVinylScopeSize, m_iVinylScopeSize, QImage::Format_ARGB32);
+}
+
+void WSpinny::updateVinylSignalQualityImage(const QColor& qual_color, const unsigned char* data) {
+    int r, g, b;
+    qual_color.getRgb(&r, &g, &b);
+
+    for (int y = 0; y < m_iVinylScopeSize; ++y) {
+        QRgb* line = reinterpret_cast<QRgb*>(m_qImage.scanLine(y));
+        for (int x = 0; x < m_iVinylScopeSize; ++x) {
+            // use xwax's bitmap to set alpha data only
+            // adjust alpha by 3/4 so it's not quite so distracting
+            // setpixel is slow, use scanlines instead
+            // m_qImage.setPixel(x, y, qRgba(r,g,b,(int)buf[x+m_iVinylScopeSize*y] * .75));
+            *line = qRgba(r, g, b, static_cast<int>(data[x + m_iVinylScopeSize * y] * .75));
+            line++;
+        }
     }
 }
 

--- a/src/widget/wspinny.cpp
+++ b/src/widget/wspinny.cpp
@@ -33,13 +33,11 @@ void WSpinny::draw() {
         p.drawImage(rect(), *m_pMaskImage, m_pMaskImage->rect());
     }
 
-#ifdef __VINYLCONTROL__
     // Overlay the signal quality drawing if vinyl is active
     if (shouldDrawVinylQuality()) {
         // draw the last good image
         p.drawImage(this->rect(), m_qImage);
     }
-#endif
 
     // To rotate the foreground image around the center of the image,
     // we use the classic trick of translating the coordinate system such that

--- a/src/widget/wspinny.h
+++ b/src/widget/wspinny.h
@@ -12,6 +12,11 @@ class WSpinny : public WSpinnyBase {
             BaseTrackPlayer* pPlayer);
 
   private:
+    QImage m_qImage;
+
     void draw() override;
+    void setupVinylSignalQuality() override;
+    void updateVinylSignalQualityImage(
+            const QColor& qual_color, const unsigned char* data) override;
     void coverChanged() override;
 };

--- a/src/widget/wspinnybase.cpp
+++ b/src/widget/wspinnybase.cpp
@@ -220,11 +220,13 @@ void WSpinnyBase::setup(const QDomNode& node,
 
     m_pVinylControlEnabled = new ControlProxy(
             m_group, "vinylcontrol_enabled", this, ControlFlag::NoAssertIfMissing);
+    updateVinylControlEnabled(m_pVinylControlEnabled->get());
     m_pVinylControlEnabled->connectValueChanged(this,
             &WSpinnyBase::updateVinylControlEnabled);
 
     m_pSignalEnabled = new ControlProxy(
             m_group, "vinylcontrol_signal_enabled", this, ControlFlag::NoAssertIfMissing);
+    updateVinylControlSignalEnabled(m_pSignalEnabled->get());
     m_pSignalEnabled->connectValueChanged(this,
             &WSpinnyBase::updateVinylControlSignalEnabled);
 

--- a/src/widget/wspinnybase.cpp
+++ b/src/widget/wspinnybase.cpp
@@ -108,7 +108,11 @@ WSpinnyBase::~WSpinnyBase() {
 }
 
 bool WSpinnyBase::shouldDrawVinylQuality() const {
+#ifdef __VINYLCONTROL__
     return m_bVinylActive && m_bSignalActive && m_bDrawVinylSignalQuality;
+#else
+    return false;
+#endif
 }
 
 void WSpinnyBase::onVinylSignalQualityUpdate(const VinylSignalQualityReport& report) {

--- a/src/widget/wspinnybase.h
+++ b/src/widget/wspinnybase.h
@@ -37,6 +37,10 @@ class WSpinnyBase : public WGLWidget,
 
     void onVinylSignalQualityUpdate(const VinylSignalQualityReport& report) override;
 
+    virtual void setupVinylSignalQuality() = 0;
+    virtual void updateVinylSignalQualityImage(
+            const QColor& qual_color, const unsigned char* data) = 0;
+
     void setup(const QDomNode& node,
             const SkinContext& context,
             const ConfigKey& showCoverConfigKey);
@@ -88,6 +92,8 @@ class WSpinnyBase : public WGLWidget,
 
     void setLoadedCover(const QPixmap& pixmap);
 
+    bool shouldDrawVinylQuality() const;
+
   private:
     virtual void draw() = 0;
     virtual void coverChanged() = 0;
@@ -130,7 +136,7 @@ class WSpinnyBase : public WGLWidget,
     int m_iVinylInput;
     bool m_bVinylActive;
     bool m_bSignalActive;
-    QImage m_qImage;
+    bool m_bDrawVinylSignalQuality;
     int m_iVinylScopeSize;
 
     float m_fAngle; // Degrees

--- a/src/widget/wspinnyglsl.cpp
+++ b/src/widget/wspinnyglsl.cpp
@@ -55,7 +55,32 @@ void WSpinnyGLSL::updateTextures() {
     m_pFgTextureScaled.reset(createTexture(m_fgImageScaled));
     m_pGhostTextureScaled.reset(createTexture(m_ghostImageScaled));
     m_pLoadedCoverTextureScaled.reset(createTexture(m_loadedCoverScaled));
-    m_pQTexture.reset(createTexture(m_qImage));
+}
+
+void WSpinnyGLSL::setupVinylSignalQuality() {
+}
+
+void WSpinnyGLSL::updateVinylSignalQualityImage(
+        const QColor& qual_color, const unsigned char* data) {
+    m_vinylQualityColor = qual_color;
+    if (m_pQTexture) {
+        makeCurrentIfNeeded();
+        m_pQTexture->bind();
+        // Using a texture of one byte per pixel so we can store the vinyl
+        // signal quality data directly. The VinylQualityShader will draw this
+        // colorized with alpha transparency.
+        glTexSubImage2D(GL_TEXTURE_2D,
+                0,
+                0,
+                0,
+                m_iVinylScopeSize,
+                m_iVinylScopeSize,
+                GL_RED,
+                GL_UNSIGNED_BYTE,
+                data);
+        m_pQTexture->release();
+        doneCurrent();
+    }
 }
 
 void WSpinnyGLSL::paintGL() {
@@ -92,9 +117,10 @@ void WSpinnyGLSL::paintGL() {
 
 #ifdef __VINYLCONTROL__
     // Overlay the signal quality drawing if vinyl is active
-    if (m_bVinylActive && m_bSignalActive) {
-        // draw the last good image
-        drawTexture(m_pQTexture.get());
+    if (shouldDrawVinylQuality()) {
+        m_textureShader.release();
+        drawVinylQuality();
+        m_textureShader.bind();
     }
 #endif
 
@@ -128,12 +154,19 @@ void WSpinnyGLSL::paintGL() {
 void WSpinnyGLSL::initializeGL() {
     updateTextures();
 
+    m_pQTexture.reset(new QOpenGLTexture(QOpenGLTexture::Target2D));
+    m_pQTexture->setMinMagFilters(QOpenGLTexture::Linear, QOpenGLTexture::Linear);
+    m_pQTexture->setSize(m_iVinylScopeSize, m_iVinylScopeSize);
+    m_pQTexture->setFormat(QOpenGLTexture::R8_UNorm);
+    m_pQTexture->allocateStorage(QOpenGLTexture::Red, QOpenGLTexture::UInt8);
+
     m_textureShader.init();
+    m_vinylQualityShader.init();
 }
 
 void WSpinnyGLSL::drawTexture(QOpenGLTexture* texture) {
     const float texx1 = 0.f;
-    const float texy1 = 1.f;
+    const float texy1 = 1.0;
     const float texx2 = 1.f;
     const float texy2 = 0.f;
 
@@ -162,4 +195,48 @@ void WSpinnyGLSL::drawTexture(QOpenGLTexture* texture) {
     glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 
     texture->release();
+}
+
+void WSpinnyGLSL::drawVinylQuality() {
+    const float texx1 = 0.f;
+    const float texy1 = 1.f;
+    const float texx2 = 1.f;
+    const float texy2 = 0.f;
+
+    const float posx2 = 1.f;
+    const float posy2 = 1.f;
+    const float posx1 = -1.f;
+    const float posy1 = -1.f;
+
+    const float posarray[] = {posx1, posy1, posx2, posy1, posx1, posy2, posx2, posy2};
+    const float texarray[] = {texx1, texy1, texx2, texy1, texx1, texy2, texx2, texy2};
+
+    m_vinylQualityShader.bind();
+    int matrixLocation = m_vinylQualityShader.matrixLocation();
+    int colorLocation = m_vinylQualityShader.colorLocation();
+    int samplerLocation = m_vinylQualityShader.samplerLocation();
+    int positionLocation = m_vinylQualityShader.positionLocation();
+    int texcoordLocation = m_vinylQualityShader.texcoordLocation();
+
+    QMatrix4x4 matrix;
+    m_vinylQualityShader.setUniformValue(matrixLocation, matrix);
+    m_vinylQualityShader.setUniformValue(colorLocation, m_vinylQualityColor);
+
+    m_vinylQualityShader.enableAttributeArray(positionLocation);
+    m_vinylQualityShader.enableAttributeArray(texcoordLocation);
+
+    m_vinylQualityShader.setUniformValue(samplerLocation, 0);
+
+    m_textureShader.setAttributeArray(
+            positionLocation, GL_FLOAT, posarray, 2);
+    m_textureShader.setAttributeArray(
+            texcoordLocation, GL_FLOAT, texarray, 2);
+
+    m_pQTexture->bind();
+
+    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+
+    m_pQTexture->release();
+
+    m_vinylQualityShader.release();
 }

--- a/src/widget/wspinnyglsl.cpp
+++ b/src/widget/wspinnyglsl.cpp
@@ -115,14 +115,12 @@ void WSpinnyGLSL::paintGL() {
         drawTexture(m_pMaskTexture.get());
     }
 
-#ifdef __VINYLCONTROL__
     // Overlay the signal quality drawing if vinyl is active
     if (shouldDrawVinylQuality()) {
         m_textureShader.release();
         drawVinylQuality();
         m_textureShader.bind();
     }
-#endif
 
     // To rotate the foreground image around the center of the image,
     // we use the classic trick of translating the coordinate system such that

--- a/src/widget/wspinnyglsl.h
+++ b/src/widget/wspinnyglsl.h
@@ -3,6 +3,7 @@
 #include <QOpenGLTexture>
 
 #include "shaders/textureshader.h"
+#include "shaders/vinylqualityshader.h"
 #include "widget/wspinnybase.h"
 
 class WSpinnyGLSL : public WSpinnyBase {
@@ -25,11 +26,18 @@ class WSpinnyGLSL : public WSpinnyBase {
     void cleanupGL();
     void updateTextures();
 
+    void setupVinylSignalQuality() override;
+    void updateVinylSignalQualityImage(
+            const QColor& qual_color, const unsigned char* data) override;
+    void drawVinylQuality();
+
     mixxx::TextureShader m_textureShader;
+    mixxx::VinylQualityShader m_vinylQualityShader;
     std::unique_ptr<QOpenGLTexture> m_pBgTexture;
     std::unique_ptr<QOpenGLTexture> m_pMaskTexture;
     std::unique_ptr<QOpenGLTexture> m_pFgTextureScaled;
     std::unique_ptr<QOpenGLTexture> m_pGhostTextureScaled;
     std::unique_ptr<QOpenGLTexture> m_pLoadedCoverTextureScaled;
     std::unique_ptr<QOpenGLTexture> m_pQTexture;
+    QColor m_vinylQualityColor;
 };


### PR DESCRIPTION
transfer the VinylSignalQualityReport scope to a texture with glTexSubImage2D and use a special shader to draw the VinylSignalQuality overlay on WSpinnyGLSL

Fixes https://github.com/mixxxdj/mixxx/issues/11734
