### PR TITLE
Fix crash disabling quantize

### DIFF
--- a/src/waveform/renderers/waveformmark.h
+++ b/src/waveform/renderers/waveformmark.h
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <QDomNode>
 #include <QImage>
 
@@ -92,6 +91,11 @@ class WaveformMark {
 
 typedef QSharedPointer<WaveformMark> WaveformMarkPointer;
 
+// This class provides an immutable sortkey for the WaveformMark using sample
+// position and hotcue number. IMPORTANT: The Mark's position may be changed after
+// a key's creation, and those updates will not be reflected in these sortkeys.
+// Currently they are used to render marks on the Overview, a situation where
+// temporarily incorrect sort order is acceptable.
 class WaveformMarkSortKey {
   public:
     WaveformMarkSortKey(double samplePosition, int hotcue)

--- a/src/waveform/renderers/waveformmark.h
+++ b/src/waveform/renderers/waveformmark.h
@@ -92,21 +92,29 @@ class WaveformMark {
 
 typedef QSharedPointer<WaveformMark> WaveformMarkPointer;
 
-inline bool operator<(const WaveformMarkPointer& lhs, const WaveformMarkPointer& rhs) {
-    double leftPosition = lhs->getSamplePosition();
-    int leftHotcue = lhs->getHotCue();
-    double rightPosition = rhs->getSamplePosition();
-    int rightHotcue = rhs->getHotCue();
-    if (leftPosition == rightPosition) {
-        // Sort WaveformMarks without hotcues before those with hotcues;
-        // if both have hotcues, sort numerically by hotcue number.
-        if (leftHotcue == Cue::kNoHotCue && rightHotcue != Cue::kNoHotCue) {
-            return true;
-        } else if (leftHotcue != Cue::kNoHotCue && rightHotcue == Cue::kNoHotCue) {
-            return false;
-        } else {
-            return leftHotcue < rightHotcue;
-        }
+class WaveformMarkSortKey {
+  public:
+    WaveformMarkSortKey(double samplePosition, int hotcue)
+            : m_samplePosition(samplePosition),
+              m_hotcue(hotcue) {
     }
-    return leftPosition < rightPosition;
-}
+
+    bool operator<(const WaveformMarkSortKey& other) const {
+        if (m_samplePosition == other.m_samplePosition) {
+            // Sort WaveformMarks without hotcues before those with hotcues;
+            // if both have hotcues, sort numerically by hotcue number.
+            if (m_hotcue == Cue::kNoHotCue && other.m_hotcue != Cue::kNoHotCue) {
+                return true;
+            } else if (m_hotcue != Cue::kNoHotCue && other.m_hotcue == Cue::kNoHotCue) {
+                return false;
+            } else {
+                return m_hotcue < other.m_hotcue;
+            }
+        }
+        return m_samplePosition < other.m_samplePosition;
+    }
+
+  private:
+    double m_samplePosition;
+    int m_hotcue;
+};

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -434,6 +434,9 @@ void WOverview::updateCues(const QList<CuePointer> &loadedCues) {
         if (pMark->isValid() && pMark->isVisible()) {
             double samplePosition = pMark->getSamplePosition();
             if (samplePosition != Cue::kNoPosition) {
+                // Create a stable key for sorting, because the WaveformMark's samplePosition is a
+                // ControlObject which can change at any time by other threads. Such a change causes
+                // another updateCues() call, rebuilding m_marksToRender.
                 auto key = WaveformMarkSortKey(samplePosition, pMark->getHotCue());
                 m_marksToRender.emplace(key, pMark);
             }

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -427,18 +427,18 @@ void WOverview::updateCues(const QList<CuePointer> &loadedCues) {
                     pMark->m_text = newLabel;
                 }
             }
-
-            m_marksToRender.append(pMark);
         }
     }
 
-    // The loop above only adds WaveformMarks for hotcues to m_marksToRender.
     for (const auto& pMark : m_marks) {
-        if (!m_marksToRender.contains(pMark) && pMark->isValid() && pMark->getSamplePosition() != Cue::kNoPosition && pMark->isVisible()) {
-            m_marksToRender.append(pMark);
+        if (pMark->isValid() && pMark->isVisible()) {
+            double samplePosition = pMark->getSamplePosition();
+            if (samplePosition != Cue::kNoPosition) {
+                auto key = WaveformMarkSortKey(samplePosition, pMark->getHotCue());
+                m_marksToRender.emplace(key, pMark);
+            }
         }
     }
-    std::sort(m_marksToRender.begin(), m_marksToRender.end());
 }
 
 // connecting the tracks cuesUpdated and onMarkChanged is not possible
@@ -475,8 +475,8 @@ void WOverview::mouseMoveEvent(QMouseEvent* e) {
     // the hotcue rendered on top must be assigned to m_pHoveredMark to show
     // the CueMenuPopup. To accomplish this, m_marksToRender is iterated in
     // reverse and the loop breaks as soon as m_pHoveredMark is set.
-    for (int i = m_marksToRender.size() - 1; i >= 0; --i) {
-        WaveformMarkPointer pMark = m_marksToRender.at(i);
+    for (auto i = m_marksToRender.crbegin(); i != m_marksToRender.crend(); ++i) {
+        const WaveformMarkPointer& pMark = i->second;
         if (pMark->contains(e->pos(), m_orientation)) {
             m_pHoveredMark = pMark;
             break;
@@ -826,12 +826,13 @@ void WOverview::drawMarks(QPainter* pPainter, const float offset, const float ga
     // the view of labels is not obscured by the playhead.
 
     bool markHovered = false;
-    for (int i = 0; i < m_marksToRender.size(); ++i) {
-        WaveformMarkPointer pMark = m_marksToRender.at(i);
-        PainterScope painterScope(pPainter);
 
+    for (auto i = m_marksToRender.cbegin(); i != m_marksToRender.cend(); ++i) {
+        PainterScope painterScope(pPainter);
+        const WaveformMarkPointer& pMark = i->second;
+        double samplePosition = pMark->getSamplePosition();
         const float markPosition = math_clamp(
-                offset + static_cast<float>(m_marksToRender.at(i)->getSamplePosition()) * gain,
+                offset + static_cast<float>(samplePosition) * gain,
                 0.0f,
                 static_cast<float>(width()));
         pMark->m_linePosition = markPosition;
@@ -862,10 +863,11 @@ void WOverview::drawMarks(QPainter* pPainter, const float offset, const float ga
             // hovering over it. Elide it if it would render over the next
             // label, but do not elide it if the next mark's label is not at the
             // same vertical position.
-            if (pMark != m_pHoveredMark && i < m_marksToRender.size() - 1) {
+
+            if (pMark != m_pHoveredMark) {
                 float nextMarkPosition = -1.0f;
-                for (int m = i + 1; m < m_marksToRender.size() - 1; ++m) {
-                    WaveformMarkPointer otherMark = m_marksToRender.at(m);
+                for (auto m = std::next(i); m != m_marksToRender.cend(); ++m) {
+                    const WaveformMarkPointer& otherMark = m->second;
                     bool otherAtSameHeight = valign == (otherMark->m_align & Qt::AlignVertical_Mask);
                     // Hotcues always show at least their number.
                     bool otherHasLabel = !otherMark->m_text.isEmpty() || otherMark->getHotCue() != Cue::kNoHotCue;
@@ -1116,7 +1118,8 @@ void WOverview::drawMarkLabels(QPainter* pPainter, const float offset, const flo
     QFontMetricsF fontMetrics(markerFont);
 
     // Draw WaveformMark labels
-    for (const auto& pMark : qAsConst(m_marksToRender)) {
+    for (const auto& pair : m_marksToRender) {
+        const WaveformMarkPointer& pMark = pair.second;
         if (m_pHoveredMark != nullptr && pMark != m_pHoveredMark) {
             if (pMark->m_label.intersects(m_pHoveredMark->m_label)) {
                 continue;

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -194,7 +194,7 @@ class WOverview : public WWidget, public TrackDropTarget {
     // All WaveformMarks
     WaveformMarkSet m_marks;
     // List of visible WaveformMarks sorted by the order they appear in the track
-    QList<WaveformMarkPointer> m_marksToRender;
+    std::map<WaveformMarkSortKey, WaveformMarkPointer> m_marksToRender;
     std::vector<WaveformMarkRange> m_markRanges;
     WaveformMarkLabel m_cuePositionLabel;
     WaveformMarkLabel m_cueTimeDistanceLabel;


### PR DESCRIPTION
Make m_marksToRender a std::map to have a constant sort key.

This fixes the crash due to changing sort keys reported in https://github.com/mixxxdj/mixxx/issues/11709