### PR TITLE
shortkeys to cut/copy/paste/remove tracks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1008,6 +1008,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/track/taglib/trackmetadata_xiph.cpp
   src/util/battery/battery.cpp
   src/util/cache.cpp
+  src/util/clipboard.cpp
   src/util/cmdlineargs.cpp
   src/util/colorcomponents.cpp
   src/util/color/color.cpp

--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -28,6 +28,7 @@
 #endif
 #include "soundio/soundmanager.h"
 #include "sources/soundsourceproxy.h"
+#include "util/clipboard.h"
 #include "util/db/dbconnectionpooled.h"
 #include "util/font.h"
 #include "util/logger.h"
@@ -332,6 +333,7 @@ void CoreServices::initialize(QApplication* pApp) {
 
     emit initializationProgressUpdate(50, tr("library"));
     CoverArtCache::createInstance();
+    Clipboard::createInstance();
 
     m_pTrackCollectionManager = std::make_shared<TrackCollectionManager>(
             this,
@@ -587,6 +589,8 @@ void CoreServices::finalize() {
 
     // CoverArtCache is fairly independent of everything else.
     CoverArtCache::destroy();
+
+    Clipboard::destroy();
 
     // PlayerManager depends on Engine, SoundManager, VinylControlManager, and Config
     // The player manager has to be deleted before the library to ensure

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -369,13 +369,13 @@ void BaseTrackTableModel::cutTracks(const QModelIndexList& indices) {
 }
 
 void BaseTrackTableModel::copyTracks(const QModelIndexList& indices) const {
-    Clipboard::begin();
+    Clipboard::start();
     for (const QModelIndex& index : indices) {
         if (index.isValid()) {
             Clipboard::add(QUrl::fromLocalFile(getTrackLocation(index)));
         }
     }
-    Clipboard::end();
+    Clipboard::finish();
 }
 
 int BaseTrackTableModel::pasteTracks(const QModelIndex& insertionIndex) {

--- a/src/library/basetracktablemodel.h
+++ b/src/library/basetracktablemodel.h
@@ -82,6 +82,10 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
         return m_columnCache.fieldIndex(fieldName);
     }
 
+    void cutTracks(const QModelIndexList& indices) override;
+    void copyTracks(const QModelIndexList& indices) const override;
+    int pasteTracks(const QModelIndex& index) override;
+
     bool isColumnHiddenByDefault(
             int column) override;
 

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -404,6 +404,10 @@ void Library::bindLibraryWidget(
             &Library::slotLoadTrackToPlayer);
     m_pLibraryWidget->registerView(m_sTrackViewName, pTrackTableView);
 
+    connect(m_pLibraryWidget,
+            &WLibrary::setLibraryFocus,
+            m_pLibraryControl,
+            &LibraryControl::setLibraryFocus);
     connect(this,
             &Library::switchToView,
             m_pLibraryWidget,

--- a/src/library/playlisttablemodel.cpp
+++ b/src/library/playlisttablemodel.cpp
@@ -189,14 +189,11 @@ void PlaylistTableModel::selectPlaylist(int playlistId) {
     setSort(defaultSortColumn(), defaultSortOrder());
 }
 
-int PlaylistTableModel::addTracks(const QModelIndex& index,
-        const QList<QString>& locations) {
-    if (locations.isEmpty()) {
+int PlaylistTableModel::addTracksWithTrackIds(const QModelIndex& index,
+        const QList<TrackId>& trackIds) {
+    if (trackIds.isEmpty()) {
         return 0;
     }
-
-    QList<TrackId> trackIds = m_pTrackCollectionManager->resolveTrackIdsFromLocations(
-            locations);
 
     const int positionColumn = fieldIndex(ColumnCache::COLUMN_PLAYLISTTRACKSTABLE_POSITION);
     int position = index.sibling(index.row(), positionColumn).data().toInt();
@@ -209,9 +206,9 @@ int PlaylistTableModel::addTracks(const QModelIndex& index,
     int tracksAdded = m_pTrackCollectionManager->internalCollection()->getPlaylistDAO().insertTracksIntoPlaylist(
             trackIds, m_iPlaylistId, position);
 
-    if (locations.size() - tracksAdded > 0) {
+    if (trackIds.size() - tracksAdded > 0) {
         qDebug() << "PlaylistTableModel::addTracks could not add"
-                 << locations.size() - tracksAdded
+                 << trackIds.size() - tracksAdded
                  << "to playlist" << m_iPlaylistId;
     }
     return tracksAdded;

--- a/src/library/playlisttablemodel.h
+++ b/src/library/playlisttablemodel.h
@@ -25,7 +25,7 @@ class PlaylistTableModel final : public TrackSetTableModel {
     /// This function should only be used by AUTODJ
     void removeTracks(const QModelIndexList& indices) final;
     /// Returns the number of successful additions.
-    int addTracks(const QModelIndex& index, const QList<QString>& locations) final;
+    int addTracksWithTrackIds(const QModelIndex& index, const QList<TrackId>& trackIds) final;
     bool isLocked() final;
 
     Capabilities getCapabilities() const final;

--- a/src/library/sidebarmodel.cpp
+++ b/src/library/sidebarmodel.cpp
@@ -477,7 +477,7 @@ QModelIndex SidebarModel::translateIndex(
 }
 
 void SidebarModel::slotDataChanged(const QModelIndex& topLeft, const QModelIndex& bottomRight) {
-    //qDebug() << "slotDataChanged topLeft:" << topLeft << "bottomRight:" << bottomRight;
+    // qDebug() << "slotDataChanged topLeft:" << topLeft << "bottomRight:" << bottomRight;
     QModelIndex topLeftTranslated = translateSourceIndex(topLeft);
     QModelIndex bottomRightTranslated = translateSourceIndex(bottomRight);
     emit dataChanged(topLeftTranslated, bottomRightTranslated);
@@ -501,8 +501,8 @@ void SidebarModel::slotRowsInserted(const QModelIndex& parent, int start, int en
     Q_UNUSED(parent);
     Q_UNUSED(start);
     Q_UNUSED(end);
-    //qDebug() << "slotRowsInserted" << parent << start << end;
-    //QModelIndex newParent = translateSourceIndex(parent);
+    // qDebug() << "slotRowsInserted" << parent << start << end;
+    // QModelIndex newParent = translateSourceIndex(parent);
     endInsertRows();
 }
 

--- a/src/library/trackmodel.h
+++ b/src/library/trackmodel.h
@@ -140,6 +140,16 @@ class TrackModel {
     virtual void removeTracks(const QModelIndexList& indices) {
         Q_UNUSED(indices);
     }
+    virtual void cutTracks(const QModelIndexList& indices) {
+        Q_UNUSED(indices);
+    }
+    virtual void copyTracks(const QModelIndexList& indices) const {
+        Q_UNUSED(indices);
+    }
+    virtual int pasteTracks(const QModelIndex& index) {
+        Q_UNUSED(index);
+        return 0;
+    }
     virtual void hideTracks(const QModelIndexList& indices) {
         Q_UNUSED(indices);
     }
@@ -152,6 +162,11 @@ class TrackModel {
     virtual int addTracks(const QModelIndex& index, const QList<QString>& locations) {
         Q_UNUSED(index);
         Q_UNUSED(locations);
+        return 0;
+    }
+    virtual int addTracksWithTrackIds(const QModelIndex& index, const QList<TrackId>& tracks) {
+        Q_UNUSED(index);
+        Q_UNUSED(tracks);
         return 0;
     }
     virtual void moveTrack(const QModelIndex& sourceIndex,

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -169,7 +169,7 @@ void BasePlaylistFeature::connectPlaylistDAO() {
             &BasePlaylistFeature::slotPlaylistTableRenamed);
 }
 
-int BasePlaylistFeature::playlistIdFromIndex(const QModelIndex& index) {
+int BasePlaylistFeature::playlistIdFromIndex(const QModelIndex& index) const {
     TreeItem* item = static_cast<TreeItem*>(index.internalPointer());
     if (item == nullptr) {
         return kInvalidPlaylistId;

--- a/src/library/trackset/baseplaylistfeature.h
+++ b/src/library/trackset/baseplaylistfeature.h
@@ -90,7 +90,7 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
     virtual void decorateChild(TreeItem* pChild, int playlistId) = 0;
     virtual void addToAutoDJ(PlaylistDAO::AutoDJSendLoc loc);
 
-    int playlistIdFromIndex(const QModelIndex& index);
+    int playlistIdFromIndex(const QModelIndex& index) const;
     // Get the QModelIndex of a playlist based on its id.  Returns QModelIndex()
     // on failure.
     QModelIndex indexFromPlaylistId(int playlistId);

--- a/src/library/trackset/crate/cratetablemodel.cpp
+++ b/src/library/trackset/crate/cratetablemodel.cpp
@@ -150,17 +150,15 @@ TrackModel::Capabilities CrateTableModel::getCapabilities() const {
     return caps;
 }
 
-int CrateTableModel::addTracks(
-        const QModelIndex& index, const QList<QString>& locations) {
+int CrateTableModel::addTracksWithTrackIds(
+        const QModelIndex& index, const QList<TrackId>& trackIds) {
     Q_UNUSED(index);
     // If a track is dropped but it isn't in the library, then add it because
     // the user probably dropped a file from outside Mixxx into this crate.
-    QList<TrackId> trackIds =
-            m_pTrackCollectionManager->resolveTrackIdsFromLocations(locations);
     if (!m_pTrackCollectionManager->internalCollection()->addCrateTracks(
                 m_selectedCrate, trackIds)) {
         qWarning() << "CrateTableModel::addTracks could not add"
-                   << locations.size() << "tracks to crate" << m_selectedCrate;
+                   << trackIds.size() << "tracks to crate" << m_selectedCrate;
         return 0;
     }
 

--- a/src/library/trackset/crate/cratetablemodel.h
+++ b/src/library/trackset/crate/cratetablemodel.h
@@ -20,7 +20,7 @@ class CrateTableModel final : public TrackSetTableModel {
 
     void removeTracks(const QModelIndexList& indices) final;
     /// Returns the number of unsuccessful additions.
-    int addTracks(const QModelIndex& index, const QList<QString>& locations) final;
+    int addTracksWithTrackIds(const QModelIndex& index, const QList<TrackId>& tracks) final;
 
     Capabilities getCapabilities() const final;
     QString modelKey(bool noSearch) const override;

--- a/src/library/trackset/tracksettablemodel.cpp
+++ b/src/library/trackset/tracksettablemodel.cpp
@@ -26,3 +26,15 @@ bool TrackSetTableModel::isColumnInternal(int column) {
             column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COVERART_DIGEST) ||
             column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COVERART_HASH);
 }
+
+int TrackSetTableModel::addTracks(const QModelIndex& index,
+        const QList<QString>& locations) {
+    if (locations.isEmpty()) {
+        return 0;
+    }
+
+    QList<TrackId> trackIds = m_pTrackCollectionManager->resolveTrackIdsFromLocations(
+            locations);
+
+    return addTracksWithTrackIds(index, trackIds);
+}

--- a/src/library/trackset/tracksettablemodel.h
+++ b/src/library/trackset/tracksettablemodel.h
@@ -11,4 +11,6 @@ class TrackSetTableModel : public BaseSqlTableModel {
             const char* settingsNamespace);
 
     bool isColumnInternal(int column) override;
+
+    int addTracks(const QModelIndex& index, const QList<QString>& locations) final;
 };

--- a/src/util/clipboard.cpp
+++ b/src/util/clipboard.cpp
@@ -3,21 +3,16 @@
 #include <QApplication>
 #include <QClipboard>
 
-QString& Clipboard::text() {
-    static QString s_text;
-    return s_text;
-}
-
-void Clipboard::begin() {
-    text() = "";
+void Clipboard::start() {
+    instance()->m_text.clear();
 }
 
 void Clipboard::add(const QUrl& url) {
-    text().append(url.toString() + "\n");
+    instance()->m_text.append(url.toString() + "\n");
 }
 
-void Clipboard::end() {
-    QApplication::clipboard()->setText(text());
+void Clipboard::finish() {
+    QApplication::clipboard()->setText(instance()->m_text);
 }
 
 QList<QUrl> Clipboard::urls() {
@@ -28,7 +23,7 @@ QList<QUrl> Clipboard::urls() {
     QStringList strings = text.split("\n", QString::SkipEmptyParts);
 #endif
     QList<QUrl> result;
-    for (QString string : strings) {
+    for (const QString& string : strings) {
         result.append(QUrl(string));
     }
     return result;

--- a/src/util/clipboard.cpp
+++ b/src/util/clipboard.cpp
@@ -1,0 +1,35 @@
+#include "clipboard.h"
+
+#include <QApplication>
+#include <QClipboard>
+
+QString& Clipboard::text() {
+    static QString s_text;
+    return s_text;
+}
+
+void Clipboard::begin() {
+    text() = "";
+}
+
+void Clipboard::add(const QUrl& url) {
+    text().append(url.toString() + "\n");
+}
+
+void Clipboard::end() {
+    QApplication::clipboard()->setText(text());
+}
+
+QList<QUrl> Clipboard::urls() {
+    const QString text = QApplication::clipboard()->text();
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+    QStringList strings = text.split("\n", Qt::SkipEmptyParts);
+#else
+    QStringList strings = text.split("\n", QString::SkipEmptyParts);
+#endif
+    QList<QUrl> result;
+    for (QString string : strings) {
+        result.append(QUrl(string));
+    }
+    return result;
+}

--- a/src/util/clipboard.cpp
+++ b/src/util/clipboard.cpp
@@ -2,29 +2,23 @@
 
 #include <QApplication>
 #include <QClipboard>
+#include <QMimeData>
 
 void Clipboard::start() {
-    instance()->m_text.clear();
+    instance()->m_urls.clear();
 }
 
 void Clipboard::add(const QUrl& url) {
-    instance()->m_text.append(url.toString() + "\n");
+    instance()->m_urls.append(url);
 }
 
 void Clipboard::finish() {
-    QApplication::clipboard()->setText(instance()->m_text);
+    QMimeData* data = new QMimeData;
+    data->setUrls(instance()->m_urls);
+    QApplication::clipboard()->setMimeData(data);
 }
 
 QList<QUrl> Clipboard::urls() {
-    const QString text = QApplication::clipboard()->text();
-#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
-    QStringList strings = text.split("\n", Qt::SkipEmptyParts);
-#else
-    QStringList strings = text.split("\n", QString::SkipEmptyParts);
-#endif
-    QList<QUrl> result;
-    for (const QString& string : strings) {
-        result.append(QUrl(string));
-    }
-    return result;
+    const QMimeData* data = QApplication::clipboard()->mimeData();
+    return data ? data->urls() : QList<QUrl>();
 }

--- a/src/util/clipboard.h
+++ b/src/util/clipboard.h
@@ -3,12 +3,14 @@
 #include <QString>
 #include <QUrl>
 
-class Clipboard {
-    static QString& text();
+#include "util/singleton.h"
+
+class Clipboard : public Singleton<Clipboard> {
+    QString m_text;
 
   public:
     static QList<QUrl> urls();
-    static void begin();
-    static void end();
+    static void start();
+    static void finish();
     static void add(const QUrl& url);
 };

--- a/src/util/clipboard.h
+++ b/src/util/clipboard.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <QString>
+#include <QUrl>
+
+class Clipboard {
+    static QString& text();
+
+  public:
+    static QList<QUrl> urls();
+    static void begin();
+    static void end();
+    static void add(const QUrl& url);
+};

--- a/src/util/clipboard.h
+++ b/src/util/clipboard.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <QString>
+#include <QList>
 #include <QUrl>
 
 #include "util/singleton.h"
 
 class Clipboard : public Singleton<Clipboard> {
-    QString m_text;
+    QList<QUrl> m_urls;
 
   public:
     static QList<QUrl> urls();

--- a/src/widget/wlibrary.cpp
+++ b/src/widget/wlibrary.cpp
@@ -142,3 +142,9 @@ bool WLibrary::event(QEvent* pEvent) {
     }
     return QStackedWidget::event(pEvent);
 }
+
+void WLibrary::keyPressEvent(QKeyEvent* event) {
+    if (event->key() == Qt::Key_Left && event->modifiers() & Qt::ControlModifier) {
+        emit setLibraryFocus(FocusWidget::Sidebar);
+    }
+}

--- a/src/widget/wlibrary.cpp
+++ b/src/widget/wlibrary.cpp
@@ -147,4 +147,5 @@ void WLibrary::keyPressEvent(QKeyEvent* event) {
     if (event->key() == Qt::Key_Left && event->modifiers() & Qt::ControlModifier) {
         emit setLibraryFocus(FocusWidget::Sidebar);
     }
+    QStackedWidget::keyPressEvent(event);
 }

--- a/src/widget/wlibrary.h
+++ b/src/widget/wlibrary.h
@@ -5,6 +5,7 @@
 #include <QStackedWidget>
 #include <QString>
 
+#include "library/library_decl.h"
 #include "library/libraryview.h"
 #include "skin/legacy/skincontext.h"
 #include "util/compatibility/qmutex.h"
@@ -48,6 +49,9 @@ class WLibrary : public QStackedWidget, public WBaseWidget {
         return m_bShowButtonText;
     }
 
+  signals:
+    FocusWidget setLibraryFocus(FocusWidget newFocus);
+
   public slots:
     // Show the view registered with the given name. Does nothing if the current
     // view is the specified view, or if the name does not specify any
@@ -59,6 +63,7 @@ class WLibrary : public QStackedWidget, public WBaseWidget {
 
   protected:
     bool event(QEvent* pEvent) override;
+    void keyPressEvent(QKeyEvent* event) override;
 
   private:
     QT_RECURSIVE_MUTEX m_mutex;

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -269,6 +269,14 @@ void WLibrarySidebar::keyPressEvent(QKeyEvent* event) {
         emit pressed(selIndex);
         return;
     }
+    case Qt::Key_Right: {
+        if (event->modifiers() & Qt::ControlModifier) {
+            emit setLibraryFocus(FocusWidget::TracksTable);
+        } else {
+            QTreeView::keyPressEvent(event);
+        }
+        return;
+    }
     case Qt::Key_Left: {
         QModelIndexList selectedIndices = selectionModel()->selectedRows();
         if (selectedIndices.isEmpty()) {

--- a/src/widget/wlibrarytableview.cpp
+++ b/src/widget/wlibrarytableview.cpp
@@ -267,12 +267,15 @@ void WLibraryTableView::focusInEvent(QFocusEvent* event) {
     QTableView::focusInEvent(event);
 
     if (event->reason() == Qt::TabFocusReason ||
-            event->reason() == Qt::BacktabFocusReason) {
+            event->reason() == Qt::BacktabFocusReason ||
+            event->reason() == Qt::OtherFocusReason) {
         // On FocusIn caused by a tab action with no focused item, select the
         // current or first track which can then instantly be loaded to a deck.
         // This is especially helpful if the table has only one track, which can
         // not be selected with up/down buttons, either physical or emulated via
         // [Library],MoveVertical controls. See #9548
+        // Qt::OtherFocusReason is setFocus called by LibraryControl::setLibraryFocus,
+        // in response to shortkey Ctrl-Right
         if (model()->rowCount() > 0) {
             if (selectionModel()->hasSelection()) {
                 DEBUG_ASSERT(!selectionModel()->selectedIndexes().isEmpty());

--- a/src/widget/wlibrarytableview.h
+++ b/src/widget/wlibrarytableview.h
@@ -6,6 +6,7 @@
 #include <QString>
 #include <QTableView>
 
+#include "library/library_decl.h"
 #include "library/libraryview.h"
 #include "preferences/usersettings.h"
 #include "track/track_decl.h"
@@ -58,6 +59,7 @@ class WLibraryTableView : public QTableView, public virtual LibraryView {
     void trackSelected(TrackPointer pTrack);
     void onlyCachedCoverArt(bool);
     void scrollValueChanged(int);
+    FocusWidget setLibraryFocus(FocusWidget newFocus);
 
   public slots:
     void setTrackTableFont(const QFont& font);

--- a/src/widget/wlibrarytextbrowser.cpp
+++ b/src/widget/wlibrarytextbrowser.cpp
@@ -1,5 +1,7 @@
 #include "widget/wlibrarytextbrowser.h"
 
+#include <QKeyEvent>
+
 #include "moc_wlibrarytextbrowser.cpp"
 
 WLibraryTextBrowser::WLibraryTextBrowser(QWidget* parent)
@@ -12,4 +14,12 @@ bool WLibraryTextBrowser::hasFocus() const {
 
 void WLibraryTextBrowser::setFocus() {
     QWidget::setFocus();
+}
+
+void WLibraryTextBrowser::keyPressEvent(QKeyEvent* event) {
+    if (event->key() == Qt::Key_Left && event->modifiers() & Qt::ControlModifier) {
+        event->ignore();
+        return;
+    }
+    QTextBrowser::keyPressEvent(event);
 }

--- a/src/widget/wlibrarytextbrowser.h
+++ b/src/widget/wlibrarytextbrowser.h
@@ -2,6 +2,7 @@
 
 #include <QTextBrowser>
 
+#include "library/library_decl.h"
 #include "library/libraryview.h"
 
 class WLibraryTextBrowser : public QTextBrowser, public LibraryView {
@@ -11,4 +12,7 @@ class WLibraryTextBrowser : public QTextBrowser, public LibraryView {
     void onShow() override {}
     bool hasFocus() const override;
     void setFocus() override;
+    void keyPressEvent(QKeyEvent* event) override;
+  signals:
+    FocusWidget setLibraryFocus(FocusWidget newFocus);
 };

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -46,6 +46,11 @@ class WTrackTableView : public WLibraryTableView {
     TrackId getCurrentTrackId() const;
     bool setCurrentTrackId(const TrackId& trackId, int column = 0, bool scrollToTrack = false);
 
+    void removeSelectedTracks();
+    void cutSelectedTracks();
+    void copySelectedTracks();
+    void pasteTracks();
+
     double getBackgroundColorOpacity() const {
         return m_backgroundColorOpacity;
     }


### PR DESCRIPTION
(Below where I say Ctrl, this is Cmd on macOS)

This PR implements short-keys for Cut, Copy, Paste (keysequences as in https://doc.qt.io/qt-6/qkeysequence.html, typically Ctrl-x Ctrl-c Ctrl-v) and Remove (Delete, Backspace) of tracks in the library table view (Tracks, Playlists, Crates and the Auto DJ queue).

The focus has to be on the table view for the short-keys to work.

- Copy copies the selected track(s) to the clipboard. (What is actually copied are the urls, so you can paste the clipboard in a text editor as well)

- Cut is as copy, but removes the tracks from their original location.

- Remove just removes, without places the tracks on the clipboard.

- Paste inserts the track(s) from the clipboard at the position of the currently selected track in the case of Playlists and the Auto DJ queue. In the case of Crates or when no track is selected, the track(s) from the clipboard are appended at the end.

In addition to this:

- Esc will clear the selection

- Ctrl Left and Ctrl Right move the focus between the sidebar panel and the library panel. This could already be done with Tab and Shift-Tab, but I find this much more intuitive, and much easier if you already are with one hand on Ctrl for Ctrl X/C/V and the other hand on the cursors for navigating the table view.

Notes:

- I have had my doubts about the insertion point for paste. My only reference is Spotify, which inserts below the currently selected track (or below the selected track lowest in the list, when multiple tracks or selected). But this means that you cannot paste at the first position, so to place a track at the first position you will have to do multiple operations. I am using the currently selected row is the insert point. This solves this problem and it is straightforwards: my current row is where I insert.

But I am open to reconsidering this. Does this work for you? Can you compare with other applications? I can even imagine that this should be a preference (a radio button "Paste below selected row(s)" / "Paste inserts at currently selected row"

- As mentioned, the short-keys only work when the focus is on the table view. I have found myself trying to paste immediately after selecting a Playlist, a Crate or the Auto DJ queue, without first changing the focus to the table view and wondering why nothing was happening.

It would make sense to implement paste in this situation (appending at the end of the selected track set). But it does open a pandora’s box. What to do with the other short-keys when the focus is on the sidebar? In any case, I prefer to go one step at a time and I think this PR is valid without this addition.

