### PR TITLE
Protobuf: Use package provided config if available 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2059,7 +2059,7 @@ if(STATIC_DEPS)
   mark_as_advanced(Protobuf_USE_STATIC_LIBS)
 endif()
 add_subdirectory(src/proto)
-target_link_libraries(mixxx-lib PRIVATE mixxx-proto)
+target_link_libraries(mixxx-lib PUBLIC mixxx-proto)
 
 # Rigtorp SPSC Queue
 # https://github.com/rigtorp/SPSCQueue

--- a/src/proto/CMakeLists.txt
+++ b/src/proto/CMakeLists.txt
@@ -8,6 +8,15 @@ if(NOT Protobuf_FOUND)
 endif()
 
 add_library(mixxx-proto OBJECT)
+
+if(TARGET protobuf::libprotobuf-lite)
+    target_link_libraries(mixxx-proto PUBLIC protobuf::libprotobuf-lite)
+elseif(TARGET protobuf::libprotobuf)
+    target_link_libraries(mixxx-proto PUBLIC protobuf::libprotobuf)
+else()
+    message(FATAL_ERROR "Protobuf or Protobuf-lite libraries are required to compile Mixxx.")
+endif()
+
 protobuf_generate(
   LANGUAGE cpp
   TARGET mixxx-proto
@@ -18,11 +27,3 @@ protobuf_generate(
     skin.proto
     waveform.proto
 )
-
-if(TARGET protobuf::libprotobuf-lite)
-    target_link_libraries(mixxx-proto PRIVATE protobuf::libprotobuf-lite)
-elseif(TARGET protobuf::libprotobuf)
-    target_link_libraries(mixxx-proto PRIVATE protobuf::libprotobuf)
-else()
-    message(FATAL_ERROR "Protobuf or Protobuf-lite libraries are required to compile Mixxx.")
-endif()

--- a/src/proto/CMakeLists.txt
+++ b/src/proto/CMakeLists.txt
@@ -1,5 +1,12 @@
 # Protobuf
-find_package(Protobuf)
+
+# first try the package provided config
+find_package(Protobuf CONFIG)
+if(NOT Protobuf_FOUND)
+  # Fall back to the CMake provide module
+  find_package(Protobuf MODULE REQUIRED)
+endif()
+
 add_library(mixxx-proto OBJECT)
 protobuf_generate(
   LANGUAGE cpp


### PR DESCRIPTION
This is a workaround for a probably outdated CMake Modul. 

This aims to fix linking with protobuf v23.4 and the required Abseil. 

https://mixxx.zulipchat.com/#narrow/stream/247620-development-help/topic/Compiling.20Error.20on.20Arch