### PR TITLE
Changelog for 2.3.6 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,14 @@
 * Fixed resyncing when moving an active loop
   [#11152](https://github.com/mixxxdj/mixxx/pull/11152)
   [#11381](https://github.com/mixxxdj/mixxx/issues/11381)
-* Fixed gapless repeat of full tracks
+* Allow true gapless playback when repeating full tracks
   [#11532](https://github.com/mixxxdj/mixxx/pull/11532)
   [#9842](https://github.com/mixxxdj/mixxx/issues/9842)
   [#11704](https://github.com/mixxxdj/mixxx/pull/11704)
 * Rhythmbox: Fixed bulk track imports from playlists
   [#11661](https://github.com/mixxxdj/mixxx/pull/11661)
 * Console log spam reduced
-  [#11690](https://github.com/mixxxdj/mixxx/issues/11690)
+  [#11690](https://github.com/mixxxdj/mixxx/pull/11690)
   [#11691](https://github.com/mixxxdj/mixxx/issues/11691)
 * Numark DJ2GO2 Touch: Add missing loop_out mapping for the right deck
   [#11595](https://github.com/mixxxdj/mixxx/pull/11595)
@@ -28,8 +28,8 @@
 * Fixed a rare crash when disabling quantize form a controller
   [#11744](https://github.com/mixxxdj/mixxx/pull/11744)
   [#11709](https://github.com/mixxxdj/mixxx/issues/11709)
-* Controller Preferences: Avoided a scrollbars in I/O tabs if Info tab exceeds page height
-  [#11756](https://github.com/mixxxdj/mixxx/issues/11756)
+* Controller Preferences: Avoid scrollbars in I/O tabs if Info tab exceeds page height
+  [#11756](https://github.com/mixxxdj/mixxx/pull/11756)
 
 ## [2.3.5](https://github.com/mixxxdj/mixxx/milestone/39) (2023-05-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,30 @@
 
 ## [2.3.6](https://github.com/mixxxdj/mixxx/milestone/40) (unreleased)
 
-* Numark DJ2GO2 Touch: Add missing loop_out mapping for the right deck
-  [#11595](https://github.com/mixxxdj/mixxx/pull/11595)
-* No longer stop a track with an active loop at the very end.
-  [#11558](https://github.com/mixxxdj/mixxx/pull/11558)
-  [#11557](https://github.com/mixxxdj/mixxx/issues/11557)
-* Shade: Fixed VU-Meter and other minor issues
-  [#11598](https://github.com/mixxxdj/mixxx/pull/11598)
 * Fixed possible crash when closing Mixxx while browsing the file system
   [#11593](https://github.com/mixxxdj/mixxx/pull/11593)
   [#11589](https://github.com/mixxxdj/mixxx/issues/11589)
+* No longer stop a track with an active loop at the very end.
+  [#11558](https://github.com/mixxxdj/mixxx/pull/11558)
+  [#11557](https://github.com/mixxxdj/mixxx/issues/11557)
 * Fixed resyncing when moving an active loop
   [#11152](https://github.com/mixxxdj/mixxx/pull/11152)
   [#11381](https://github.com/mixxxdj/mixxx/issues/11381)
+* Fixed gapless repeat of full tracks
+  [#11532](https://github.com/mixxxdj/mixxx/pull/11532)
+  [#9842](https://github.com/mixxxdj/mixxx/issues/9842)
+  [#11704](https://github.com/mixxxdj/mixxx/pull/11704)
+* Rhythmbox: Fixed bulk track imports from playlists
+  [#11661](https://github.com/mixxxdj/mixxx/pull/11661)
+* Console log spam reduced
+  [#11690](https://github.com/mixxxdj/mixxx/issues/11690)
+  [#11691](https://github.com/mixxxdj/mixxx/issues/11691)
+* Numark DJ2GO2 Touch: Add missing loop_out mapping for the right deck
+  [#11595](https://github.com/mixxxdj/mixxx/pull/11595)
+  [#11659](https://github.com/mixxxdj/mixxx/pull/11659)
+* Shade: Fixed VU-Meter and other minor issues
+  [#11598](https://github.com/mixxxdj/mixxx/pull/11598)
+* LateNight PaleMoon: Tweak style
 
 ## [2.3.5](https://github.com/mixxxdj/mixxx/milestone/39) (2023-05-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@
   [#11659](https://github.com/mixxxdj/mixxx/pull/11659)
 * Shade: Fixed VU-Meter and other minor issues
   [#11598](https://github.com/mixxxdj/mixxx/pull/11598)
+* Fixed a rare crash when disabling quantize form a controller
+  [#11744](https://github.com/mixxxdj/mixxx/pull/11744)
+  [#11709](https://github.com/mixxxdj/mixxx/issues/11709)
+* Controller Preferences: Avoided a scrollbars in I/O tabs if Info tab exceeds page height
+  [#11756](https://github.com/mixxxdj/mixxx/issues/11756)
 
 ## [2.3.5](https://github.com/mixxxdj/mixxx/milestone/39) (2023-05-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Fixed possible crash when closing Mixxx while browsing the file system
   [#11593](https://github.com/mixxxdj/mixxx/pull/11593)
   [#11589](https://github.com/mixxxdj/mixxx/issues/11589)
-* No longer stop a track with an active loop at the very end.
+* No longer stop a track with an active loop at the very end
   [#11558](https://github.com/mixxxdj/mixxx/pull/11558)
   [#11557](https://github.com/mixxxdj/mixxx/issues/11557)
 * Fixed resyncing when moving an active loop
@@ -25,7 +25,6 @@
   [#11659](https://github.com/mixxxdj/mixxx/pull/11659)
 * Shade: Fixed VU-Meter and other minor issues
   [#11598](https://github.com/mixxxdj/mixxx/pull/11598)
-* LateNight PaleMoon: Tweak style
 
 ## [2.3.5](https://github.com/mixxxdj/mixxx/milestone/39) (2023-05-10)
 

--- a/res/linux/org.mixxx.Mixxx.metainfo.xml
+++ b/res/linux/org.mixxx.Mixxx.metainfo.xml
@@ -98,7 +98,7 @@
   Do not edit it manually.
   -->
   <releases>
-    <release version="2.3.6" type="development" date="2023-07-18" timestamp="1689658123">
+    <release version="2.3.6" type="development" date="2023-07-18" timestamp="1689659468">
       <description>
  <ul>
   <li>
@@ -107,7 +107,7 @@
    #11589
   </li>
   <li>
-   No longer stop a track with an active loop at the very end.
+   No longer stop a track with an active loop at the very end
    #11558
    #11557
   </li>
@@ -139,9 +139,6 @@
   <li>
    Shade: Fixed VU-Meter and other minor issues
    #11598
-  </li>
-  <li>
-   LateNight PaleMoon: Tweak style
   </li>
  </ul>
 </description>

--- a/res/linux/org.mixxx.Mixxx.metainfo.xml
+++ b/res/linux/org.mixxx.Mixxx.metainfo.xml
@@ -98,7 +98,7 @@
   Do not edit it manually.
   -->
   <releases>
-    <release version="2.3.6" type="development" date="2023-07-18" timestamp="1689659468">
+    <release version="2.3.6" type="development" date="2023-07-19" timestamp="1689743984">
       <description>
  <ul>
   <li>
@@ -139,6 +139,15 @@
   <li>
    Shade: Fixed VU-Meter and other minor issues
    #11598
+  </li>
+  <li>
+   Fixed a rare crash when disabling quantize form a controller
+   #11744
+   #11709
+  </li>
+  <li>
+   Controller Preferences: Avoided a scrollbars in I/O tabs if Info tab exceeds page height
+   #11756
   </li>
  </ul>
 </description>

--- a/res/linux/org.mixxx.Mixxx.metainfo.xml
+++ b/res/linux/org.mixxx.Mixxx.metainfo.xml
@@ -98,7 +98,7 @@
   Do not edit it manually.
   -->
   <releases>
-    <release version="2.3.6" type="development" date="2023-07-19" timestamp="1689743984">
+    <release version="2.3.6" type="development" date="2023-07-28" timestamp="1690529288">
       <description>
  <ul>
   <li>
@@ -117,7 +117,7 @@
    #11381
   </li>
   <li>
-   Fixed gapless repeat of full tracks
+   Allow true gapless playback when repeating full tracks
    #11532
    #9842
    #11704
@@ -146,7 +146,7 @@
    #11709
   </li>
   <li>
-   Controller Preferences: Avoided a scrollbars in I/O tabs if Info tab exceeds page height
+   Controller Preferences: Avoid scrollbars in I/O tabs if Info tab exceeds page height
    #11756
   </li>
  </ul>

--- a/res/linux/org.mixxx.Mixxx.metainfo.xml
+++ b/res/linux/org.mixxx.Mixxx.metainfo.xml
@@ -98,12 +98,13 @@
   Do not edit it manually.
   -->
   <releases>
-    <release version="2.3.6" type="development" date="2023-06-06" timestamp="1686085121">
+    <release version="2.3.6" type="development" date="2023-07-18" timestamp="1689658123">
       <description>
  <ul>
   <li>
-   Numark DJ2GO2 Touch: Add missing loop_out mapping for the right deck
-   #11595
+   Fixed possible crash when closing Mixxx while browsing the file system
+   #11593
+   #11589
   </li>
   <li>
    No longer stop a track with an active loop at the very end.
@@ -111,18 +112,36 @@
    #11557
   </li>
   <li>
+   Fixed resyncing when moving an active loop
+   #11152
+   #11381
+  </li>
+  <li>
+   Fixed gapless repeat of full tracks
+   #11532
+   #9842
+   #11704
+  </li>
+  <li>
+   Rhythmbox: Fixed bulk track imports from playlists
+   #11661
+  </li>
+  <li>
+   Console log spam reduced
+   #11690
+   #11691
+  </li>
+  <li>
+   Numark DJ2GO2 Touch: Add missing loop_out mapping for the right deck
+   #11595
+   #11659
+  </li>
+  <li>
    Shade: Fixed VU-Meter and other minor issues
    #11598
   </li>
   <li>
-   Fixed possible crash when closing Mixxx while browsing the file system
-   #11593
-   #11589
-  </li>
-  <li>
-   Fixed resyncing when moving an active loop
-   #11152
-   #11381
+   LateNight PaleMoon: Tweak style
   </li>
  </ul>
 </description>


### PR DESCRIPTION
I have update the changelog for the upcoming 2.3.6 release. The last release before we release the 2.4.0. 

Please have also a look into with some waiting PRs: 
https://github.com/mixxxdj/mixxx/milestone/40

