### PR TITLE
Pref Controller: avoid scrollbars in I/O tabs if Info tab exceeds page height

### DIFF
--- a/src/controllers/dlgprefcontrollerdlg.ui
+++ b/src/controllers/dlgprefcontrollerdlg.ui
@@ -29,7 +29,13 @@
       <attribute name="title">
        <string>Controller Setup</string>
       </attribute>
-      <layout class="QGridLayout" name="gridLayout_2">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Ignored" vsizetype="Ignored">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <layout class="QGridLayout" name="infoTabLayout">
        <item row="0" column="0">
         <widget class="QLabel" name="labelDeviceName">
          <property name="enabled">


### PR DESCRIPTION
Scroll only Info tab if required while I/O tabs still fit the page. Otherwise the I/O tabs expand equally and Add, Remove, Clear buttons are hidden.

(backported 2.4 fix, didn't check this locally yet)