### PR TITLE
Fix overlapping buffers when decoding m4a files using ffmpeg

### DIFF
--- a/src/sources/readaheadframebuffer.cpp
+++ b/src/sources/readaheadframebuffer.cpp
@@ -285,9 +285,8 @@ WritableSampleFrames ReadAheadFrameBuffer::consumeAndFillBuffer(
     DEBUG_ASSERT(inputRange.orientation() != IndexRange::Orientation::Backward);
     DEBUG_ASSERT(isEmpty() || writeIndex() == inputRange.start());
 
-    // output sample data is optional, i.e. input samples will be dropped
-    // and not copied if no output buffer is provided
     CSAMPLE* pOutputSampleData = outputBuffer.writableData();
+    DEBUG_ASSERT(pOutputSampleData);
     DEBUG_ASSERT(outputRange.orientation() != IndexRange::Orientation::Backward);
     DEBUG_ASSERT(isEmpty() || outputRange.empty());
     DEBUG_ASSERT(minOutputIndex <= outputRange.start());
@@ -314,9 +313,7 @@ WritableSampleFrames ReadAheadFrameBuffer::consumeAndFillBuffer(
             DEBUG_ASSERT(!"Unexpected overlap");
 #endif
             const SINT overlapingFrames = overlapRange.length();
-            if (pOutputSampleData) {
-                pOutputSampleData -= m_signalInfo.frames2samples(overlapingFrames);
-            }
+            pOutputSampleData -= m_signalInfo.frames2samples(overlapingFrames);
             outputRange.growFront(overlapingFrames);
         }
     }
@@ -411,13 +408,11 @@ WritableSampleFrames ReadAheadFrameBuffer::consumeAndFillBuffer(
             DEBUG_ASSERT(outputRange.start() == inputRange.start());
             const auto copyFrameCount = copyableFrameRange.length();
             const auto copySampleCount = m_signalInfo.frames2samples(copyFrameCount);
-            if (pOutputSampleData) {
-                SampleUtil::copy(
-                        pOutputSampleData,
-                        pInputSampleData,
-                        copySampleCount);
-                pOutputSampleData += copySampleCount;
-            }
+            SampleUtil::copy(
+                    pOutputSampleData,
+                    pInputSampleData,
+                    copySampleCount);
+            pOutputSampleData += copySampleCount;
             pInputSampleData += copySampleCount;
             inputRange.shrinkFront(copyFrameCount);
             outputRange.shrinkFront(copyFrameCount);

--- a/src/sources/readaheadframebuffer.h
+++ b/src/sources/readaheadframebuffer.h
@@ -119,9 +119,6 @@ class ReadAheadFrameBuffer final {
     /// All discontinuities in the output stream, i.e. both gaps and overlapping
     /// regions are unexpected and will trigger a debug assertion.
     ///
-    /// The output sample buffer may be null. In this case the consumed
-    /// samples are dropped instead of copied.
-    ///
     /// Returns the remaining portion that could not be filled from
     /// the buffer.
     WritableSampleFrames consumeAndFillBuffer(ReadableSampleFrames inputBuffer,

--- a/src/sources/readaheadframebuffer.h
+++ b/src/sources/readaheadframebuffer.h
@@ -121,7 +121,8 @@ class ReadAheadFrameBuffer final {
     ///
     /// Returns the remaining portion that could not be filled from
     /// the buffer.
-    WritableSampleFrames consumeAndFillBuffer(ReadableSampleFrames inputBuffer,
+    WritableSampleFrames consumeAndFillBuffer(
+            const ReadableSampleFrames& inputBuffer,
             const WritableSampleFrames& outputBuffer,
             FrameIndex minOutputIndex);
 
@@ -135,10 +136,8 @@ class ReadAheadFrameBuffer final {
     /// frame. The buffering mode controls how a gap between the
     /// last buffered frame and the next input frame is handled.
     ///
-    /// Returns the unread portion of the readable sample frames,
-    /// which should typically be empty.
-    ReadableSampleFrames fillBuffer(
-            const ReadableSampleFrames& inputBuffer);
+    /// Returns true on success
+    bool fillBuffer(const ReadableSampleFrames& inputBuffer);
 
     /// Advance the read position thereby discarding samples
     /// from the front of the FIFO buffer.

--- a/src/sources/readaheadframebuffer.h
+++ b/src/sources/readaheadframebuffer.h
@@ -92,17 +92,6 @@ class ReadAheadFrameBuffer final {
     bool tryContinueReadingFrom(
             FrameIndex readIndex);
 
-    enum class DiscontinuityOverlapMode {
-        Ignore,
-        Rewind,
-        Default = Rewind, // recommended default
-    };
-    enum class DiscontinuityGapMode {
-        Skip,
-        FillWithSilence,
-        Default = FillWithSilence, // recommended default
-    };
-
     /// Drain as many buffered sample frames as possible and copy them
     /// into the output buffer.
     ///
@@ -137,11 +126,7 @@ class ReadAheadFrameBuffer final {
     /// the buffer.
     WritableSampleFrames consumeAndFillBuffer(ReadableSampleFrames inputBuffer,
             const WritableSampleFrames& outputBuffer,
-            FrameIndex minOutputIndex,
-            std::pair<DiscontinuityOverlapMode, DiscontinuityGapMode>
-                    discontinuityModes = std::make_pair(
-                            DiscontinuityOverlapMode::Default,
-                            DiscontinuityGapMode::Default));
+            FrameIndex minOutputIndex);
 
   private:
     void adjustCapacityBeforeBuffering(
@@ -156,8 +141,7 @@ class ReadAheadFrameBuffer final {
     /// Returns the unread portion of the readable sample frames,
     /// which should typically be empty.
     ReadableSampleFrames fillBuffer(
-            const ReadableSampleFrames& inputBuffer,
-            DiscontinuityGapMode discontinuityGapMode);
+            const ReadableSampleFrames& inputBuffer);
 
     /// Advance the read position thereby discarding samples
     /// from the front of the FIFO buffer.

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -477,7 +477,8 @@ SoundSourceFFmpeg::SoundSourceFFmpeg(const QUrl& url)
           m_pavPacket(av_packet_alloc()),
           m_pavDecodedFrame(nullptr),
           m_pavResampledFrame(nullptr),
-          m_seekPrerollFrameCount(0) {
+          m_seekPrerollFrameCount(0),
+          m_avutilVersion(avutil_version()) {
     DEBUG_ASSERT(m_pavPacket);
 #if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(57, 28, 100) // FFmpeg 5.1
     av_channel_layout_default(&m_avStreamChannelLayout, 0);

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -122,7 +122,7 @@ int64_t getStreamStartTime(const AVStream& avStream) {
             // the test file cover-test-itunes-12.7.0-aac.m4a has a valid
             // start_time of 0. Unfortunately, this special case cannot be
             // detected and compensated.
-            start_time = math_max(kavStreamDefaultStartTime, kavStreamDecoderFrameDelayAAC);
+            start_time = kavStreamDecoderFrameDelayAAC;
             break;
         }
         default:
@@ -134,7 +134,6 @@ int64_t getStreamStartTime(const AVStream& avStream) {
                 << start_time;
 #endif
     }
-    DEBUG_ASSERT(start_time != AV_NOPTS_VALUE);
     return start_time;
 }
 

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -61,9 +61,6 @@ inline FrameCount frameBufferCapacityForStream(
 // See also: https://developer.apple.com/library/archive/documentation/QuickTime/QTFF/QTFFAppenG/QTFFAppenG.html
 constexpr int64_t kavStreamDecoderFrameDelayAAC = 2112;
 
-// Use 0-based sample frame indexing
-constexpr SINT kMinFrameIndex = 0;
-
 constexpr SINT kMaxSamplesPerMP3Frame = 1152;
 
 const Logger kLogger("SoundSourceFFmpeg");
@@ -149,19 +146,18 @@ inline int64_t getStreamEndTime(const AVStream& avStream) {
 
 inline SINT convertStreamTimeToFrameIndex(const AVStream& avStream, int64_t pts) {
     DEBUG_ASSERT(pts != AV_NOPTS_VALUE);
-    // getStreamStartTime(avStream) -> 1st audible frame at kMinFrameIndex
-    return kMinFrameIndex +
-            av_rescale_q(
-                    pts - getStreamStartTime(avStream),
-                    avStream.time_base,
-                    av_make_q(1, avStream.codecpar->sample_rate));
+    // getStreamStartTime(avStream) -> 1st audible frame at FrameIndex 0
+    return av_rescale_q(
+            pts - getStreamStartTime(avStream),
+            avStream.time_base,
+            av_make_q(1, avStream.codecpar->sample_rate));
 }
 
 inline int64_t convertFrameIndexToStreamTime(const AVStream& avStream, SINT frameIndex) {
     // Inverse mapping of convertStreamTimeToFrameIndex()
     return getStreamStartTime(avStream) +
             av_rescale_q(
-                    frameIndex - kMinFrameIndex,
+                    frameIndex,
                     av_make_q(1, avStream.codecpar->sample_rate),
                     avStream.time_base);
 }
@@ -697,11 +693,11 @@ SoundSource::OpenResult SoundSourceFFmpeg::tryOpen(
 
     // Decoding MP3/AAC files manually into WAV using the ffmpeg CLI and
     // comparing the audio data revealed that we need to map the nominal
-    // range of the stream onto our internal range starting at kMinFrameIndex.
+    // range of the stream onto our internal range starting at FrameIndex 0.
     // See also the discussion regarding cue point shift/offset:
     // https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/Cue.20shift.2Foffset
     const auto frameIndexRange = IndexRange::forward(
-            kMinFrameIndex,
+            0,
             streamFrameIndexRange.length());
     if (!initFrameIndexRangeOnce(frameIndexRange)) {
         kLogger.warning()
@@ -936,13 +932,12 @@ bool SoundSourceFFmpeg::adjustCurrentPosition(SINT startIndex) {
     // sample accurate decoding the actual seek position must be
     // placed BEFORE the position where reading continues.
     auto seekIndex =
-            math_max(kMinFrameIndex, startIndex - m_seekPrerollFrameCount);
+            math_max(static_cast<SINT>(0), startIndex - m_seekPrerollFrameCount);
     // Seek to codec frame boundaries if the frame size is fixed and known
     if (m_pavStream->codecpar->frame_size > 0) {
-        seekIndex -=
-                (seekIndex - kMinFrameIndex) % m_pavCodecContext->frame_size;
+        seekIndex -= seekIndex % m_pavCodecContext->frame_size;
     }
-    DEBUG_ASSERT(seekIndex >= kMinFrameIndex);
+    DEBUG_ASSERT(seekIndex >= 0);
     DEBUG_ASSERT(seekIndex <= startIndex);
 
     if (m_frameBuffer.tryContinueReadingFrom(seekIndex)) {
@@ -1167,16 +1162,15 @@ ReadableSampleFrames SoundSourceFFmpeg::readSampleFramesClamped(
                     // From ffmpeg 4.4 only audible samples are counted, i.e. any inaudible aka
                     // "priming" samples are not included in nb_samples!
                     // https://github.com/mixxxdj/mixxx/issues/10464
-                    if (streamFrameIndex < kMinFrameIndex) {
+                    if (streamFrameIndex < 0) {
 #if VERBOSE_DEBUG_LOG
-                        const auto inaudibleFrameCountUntilStartOfStream =
-                                kMinFrameIndex - streamFrameIndex;
+                        const auto inaudibleFrameCountUntilStartOfStream = -streamFrameIndex;
                         kLogger.debug()
                                 << "Skipping"
                                 << inaudibleFrameCountUntilStartOfStream
                                 << "inaudible sample frames before the start of the stream";
 #endif
-                        streamFrameIndex = kMinFrameIndex;
+                        streamFrameIndex = 0;
                     }
                 }
 

--- a/src/sources/soundsourceffmpeg.h
+++ b/src/sources/soundsourceffmpeg.h
@@ -190,6 +190,8 @@ class SoundSourceFFmpeg : public SoundSource {
     FrameCount m_seekPrerollFrameCount;
 
     ReadAheadFrameBuffer m_frameBuffer;
+
+    const unsigned int m_avutilVersion;
 };
 
 class SoundSourceProviderFFmpeg : public SoundSourceProvider {


### PR DESCRIPTION
This fixes: https://github.com/mixxxdj/mixxx/issues/11545

The actual fix is in https://github.com/mixxxdj/mixxx/commit/07a90995c30ea1c0a4067afdfb7065c76ec30a3a

The rest removed unused code and improves const. 

To make it work with  shared libraries, we now read the ffmpge version at runtime and Apply the patch form https://github.com/mixxxdj/mixxx/issues/10464 only if required. 
I have tested this on Ubuntu Focal using FFmpeg 4.2 and 4.4 via a PPA.



