### PR TITLE
WTrackProperty: double-clicked property field is focused in DlgTrackInfo

### DIFF
--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -62,6 +62,22 @@ void DlgTrackInfo::init() {
     setupUi(this);
     setWindowIcon(QIcon(MIXXX_ICON_PATH));
 
+    // Store tag edit widget pointers to allow focusing a specific widgets when
+    // this is opened by double-clicking a WTrackProperty label.
+    // Associate with property strings taken from library/dao/trackdao.h
+    m_propertyWidgets.insert("artist", txtArtist);
+    m_propertyWidgets.insert("title", txtTrackName);
+    m_propertyWidgets.insert("album", txtAlbum);
+    m_propertyWidgets.insert("album_artist", txtAlbumArtist);
+    m_propertyWidgets.insert("composer", txtComposer);
+    m_propertyWidgets.insert("genre", txtGenre);
+    m_propertyWidgets.insert("year", txtYear);
+    m_propertyWidgets.insert("bpm", spinBpm);
+    m_propertyWidgets.insert("tracknumber", txtTrackNumber);
+    m_propertyWidgets.insert("key", txtKey);
+    m_propertyWidgets.insert("grouping", txtGrouping);
+    m_propertyWidgets.insert("comment", txtComment);
+
     coverLayout->setAlignment(Qt::AlignRight | Qt::AlignTop);
     coverLayout->setSpacing(0);
     coverLayout->setContentsMargins(0, 0, 0, 0);
@@ -481,6 +497,16 @@ void DlgTrackInfo::loadTrack(const QModelIndex& index) {
     loadTrackInternal(pTrack);
     if (m_pDlgTagFetcher && m_pDlgTagFetcher->isVisible()) {
         m_pDlgTagFetcher->loadTrack(m_currentTrackIndex);
+    }
+}
+
+void DlgTrackInfo::focusField(const QString& property) {
+    if (property.isEmpty()) {
+        return;
+    }
+    QWidget* w = m_propertyWidgets.find(property).value();
+    if (w) {
+        w->setFocus();
     }
 }
 

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QDialog>
+#include <QHash>
 #include <QModelIndex>
 #include <memory>
 
@@ -40,6 +41,7 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     // directly!
     void loadTrack(TrackPointer pTrack);
     void loadTrack(const QModelIndex& index);
+    void focusField(const QString& property);
 
   signals:
     void next();
@@ -120,6 +122,8 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
 
     TapFilter m_tapFilter;
     mixxx::Bpm m_lastTapedBpm;
+
+    QHash<QString, QWidget*> m_propertyWidgets;
 
     parented_ptr<WCoverArtMenu> m_pWCoverArtMenu;
     parented_ptr<WCoverArtLabel> m_pWCoverArtLabel;

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -2181,6 +2181,16 @@ void WTrackMenu::slotShowDlgTrackInfo() {
     m_pDlgTrackInfo->show();
 }
 
+void WTrackMenu::showDlgTrackInfo(const QString& property) {
+    if (isEmpty()) {
+        return;
+    }
+    slotShowDlgTrackInfo();
+    if (m_pDlgTrackInfo->isVisible()) {
+        m_pDlgTrackInfo->focusField(property);
+    }
+}
+
 void WTrackMenu::slotShowDlgTagFetcher() {
     if (isEmpty()) {
         return;

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -84,6 +84,7 @@ class WTrackMenu : public QMenu {
     // This has been done on purpose to ensure menu doesn't popup without loaded track(s).
     void popup(const QPoint& pos, QAction* at = nullptr);
     void slotShowDlgTrackInfo();
+    void showDlgTrackInfo(const QString& property = QString());
     // Library management
     void slotRemoveFromDisk();
 

--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -103,7 +103,7 @@ void WTrackProperty::mouseDoubleClickEvent(QMouseEvent* event) {
     Q_UNUSED(event);
     if (m_pCurrentTrack) {
         m_pTrackMenu->loadTrack(m_pCurrentTrack, m_group);
-        m_pTrackMenu->slotShowDlgTrackInfo();
+        m_pTrackMenu->showDlgTrackInfo(m_property);
     }
 }
 


### PR DESCRIPTION
A little helper for tag editing:
* double-click [property] label to open Track Info
* if there is a line edit for [property] it is focused, start typing