### PR TITLE
Refocus library

### DIFF
--- a/src/library/autodj/dlgautodj.cpp
+++ b/src/library/autodj/dlgautodj.cpp
@@ -349,8 +349,9 @@ void DlgAutoDJ::slotTransitionModeChanged(int newIndex) {
     m_pAutoDJProcessor->setTransitionMode(
             static_cast<AutoDJProcessor::TransitionMode>(
                     fadeModeCombobox->itemData(newIndex).toInt()));
-    // Move focus to tracks table to immediately allow keyboard shortcuts again.
-    setFocus();
+    // Clicking on a transition mode item moves keyboard focus to the list widget.
+    // Move focus back to the previously focused library widget.
+    ControlObject::set(ConfigKey("[Library]", "refocus_prev_widget"), 1);
 }
 
 void DlgAutoDJ::slotRepeatPlaylistChanged(int checkState) {
@@ -394,12 +395,13 @@ void DlgAutoDJ::setFocus() {
 }
 
 void DlgAutoDJ::keyPressEvent(QKeyEvent* pEvent) {
-    // Return, Enter and Escape key move focus to the AutoDJ queue to immediately
-    // allow keyboard shortcuts again.
+    // If we receive key events either the mode selector or the spinbox are focused.
+    // Return, Enter and Escape move focus back to the previously focused
+    // library widget in order to immediately allow keyboard shortcuts again.
     if (pEvent->key() == Qt::Key_Return ||
             pEvent->key() == Qt::Key_Enter ||
             pEvent->key() == Qt::Key_Escape) {
-        setFocus();
+        ControlObject::set(ConfigKey("[Library]", "refocus_prev_widget"), 1);
         return;
     }
     return QWidget::keyPressEvent(pEvent);

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -747,11 +747,8 @@ void LibraryControl::emitKeyEvent(QKeyEvent&& event) {
         return;
     }
 
-    switch (m_pFocusedWidget) {
-    case FocusWidget::None:
+    if (m_pFocusedWidget == FocusWidget::None) {
         return setLibraryFocus(FocusWidget::TracksTable);
-    default:
-        break;
     }
 
     // Send the event pointer to the currently focused widget

--- a/src/library/librarycontrol.h
+++ b/src/library/librarycontrol.h
@@ -62,8 +62,10 @@ class LibraryControl : public QObject {
     void sidebarWidgetDeleted();
     void searchboxWidgetDeleted();
 
-    // Update m_pFocusedWidget and m_pFocusedWidgetCO
+    // Update m_focusedWidget and m_pFocusedWidgetCO
+    void slotFocusedWidgetChanged(QWidget* oldW, QWidget* newW);
     void updateFocusedWidgetControls();
+    void refocusPrevLibraryWidget();
 
     void slotMoveUp(double);
     void slotMoveDown(double);
@@ -134,7 +136,9 @@ class LibraryControl : public QObject {
     std::unique_ptr<ControlPushButton> m_pMoveFocusBackward;
     std::unique_ptr<ControlEncoder> m_pMoveFocus;
     std::unique_ptr<ControlPushButton> m_pFocusedWidgetCO;
-    FocusWidget m_pFocusedWidget;
+    FocusWidget m_focusedWidget;
+    std::unique_ptr<ControlPushButton> m_pRefocusPrevWidgetCO;
+    FocusWidget m_prevFocusedWidget;
 
     // Control to choose the currently selected item in focused widget (double click)
     std::unique_ptr<ControlObject> m_pGoToItem;

--- a/src/widget/wbeatspinbox.cpp
+++ b/src/widget/wbeatspinbox.cpp
@@ -286,15 +286,13 @@ bool WBeatSpinBox::event(QEvent* pEvent) {
 }
 
 void WBeatSpinBox::keyPressEvent(QKeyEvent* pEvent) {
-    // By default, Return & Enter keys apply current value.
-    // Here, Return, Enter and Escape apply and move focus to tracks table.
-    // TODO(ronso0) switch to previously focused (library?) widget instead
+    // By default, Return & Enter keys apply the current value.
+    // Additionally, move focus back to the previously focused library widget.
     if (pEvent->key() == Qt::Key_Return ||
             pEvent->key() == Qt::Key_Enter ||
             pEvent->key() == Qt::Key_Escape) {
         QDoubleSpinBox::keyPressEvent(pEvent);
-        ControlObject::set(ConfigKey("[Library]", "focused_widget"),
-                static_cast<double>(FocusWidget::TracksTable));
+        ControlObject::set(ConfigKey("[Library]", "refocus_prev_widget"), 1);
         return;
     }
     return QDoubleSpinBox::keyPressEvent(pEvent);

--- a/src/widget/weffectchainpresetselector.cpp
+++ b/src/widget/weffectchainpresetselector.cpp
@@ -90,11 +90,9 @@ void WEffectChainPresetSelector::populate() {
 void WEffectChainPresetSelector::slotEffectChainPresetSelected(int index) {
     m_pChain->loadChainPreset(
             m_pChainPresetManager->getPreset(currentData().toString()));
-    // After selecting an effect move focus to the tracks table in order
-    // to immediately allow keyboard shortcuts again.
-    // TODO(ronso0) switch to previously focused (library?) widget instead
-    ControlObject::set(ConfigKey("[Library]", "focused_widget"),
-            static_cast<double>(FocusWidget::TracksTable));
+    // Clicking a chain item moves keyboard focus to the list view.
+    // Move focus back to the previously focused library widget.
+    ControlObject::set(ConfigKey("[Library]", "refocus_prev_widget"), 1);
 }
 
 void WEffectChainPresetSelector::slotChainPresetChanged(const QString& name) {

--- a/src/widget/weffectselector.cpp
+++ b/src/widget/weffectselector.cpp
@@ -89,11 +89,9 @@ void WEffectSelector::slotEffectSelected(int newIndex) {
     m_pEffectSlot->loadEffectWithDefaults(pManifest);
 
     setBaseTooltip(itemData(newIndex, Qt::ToolTipRole).toString());
-    // After selecting an effect send Shift+Tab to move focus to tracks table
-    // in order to immediately allow keyboard shortcuts again.
-    // TODO(ronso0) switch to previously focused (library?) widget instead
-    ControlObject::set(ConfigKey("[Library]", "focused_widget"),
-            static_cast<double>(FocusWidget::TracksTable));
+    // Clicking an effect item moves keyboard focus to the list view.
+    // Move focus back to the previously focused library widget.
+    ControlObject::set(ConfigKey("[Library]", "refocus_prev_widget"), 1);
 }
 
 void WEffectSelector::slotEffectUpdated() {


### PR DESCRIPTION
Another little GUI helper:

When clicking into any  beatsize spinbox or selecting an effect/effect chain via the GUI selectors these widgets get keyboad focus. This interrupts the current library workflow (and keyboard shortcuts wouldn't work anymore) since you'd need to Tab, Esc or click to get back to the desired library widget.
Currently the focus is set to the Tracks table since that is the most likely place to be when DJing, but obviously not always.

With this PR the library widget that was focused previously is stored and can be foused again any time by any widget/object that has controlobject.h included via
```cpp
ControlObject::set(ConfigKey("[Library]", "refocus_prev_widget"), 1);
```
(any value except 0 will do, it's just triggering a valueChangeRequest)

Especially helpful for #11755 :)