### PR TITLE
Star rating: scale with library font

### DIFF
--- a/src/library/stardelegate.cpp
+++ b/src/library/stardelegate.cpp
@@ -27,10 +27,7 @@ void StarDelegate::paintItem(
     paintItemBackground(painter, option, index);
 
     StarRating starRating = index.data().value<StarRating>();
-    // Make star size somehow match the library current font height.
-    // Note: capHeight() is too small, ascent() is too tall. Use the mean value.
-    QFontMetrics mf(option.font);
-    int height = (mf.capHeight() + mf.ascent()) / 2;
+    const int height = starRating.getMeanStarHeightFromFont(option.fontMetrics);
     starRating.paint(painter, option.rect, height);
 }
 
@@ -38,7 +35,8 @@ QSize StarDelegate::sizeHint(const QStyleOptionViewItem& option,
                              const QModelIndex& index) const {
     Q_UNUSED(option);
     StarRating starRating = index.data().value<StarRating>();
-    return starRating.sizeHint();
+    // Still uses the default scale factor, hence calculate it here
+    return QSize(option.fontMetrics.capHeight() * starRating.getNormalizedSize());
 }
 
 QWidget* StarDelegate::createEditor(QWidget* parent,

--- a/src/library/stardelegate.cpp
+++ b/src/library/stardelegate.cpp
@@ -31,11 +31,15 @@ void StarDelegate::paintItem(
     starRating.paint(painter, option.rect, height);
 }
 
+/// The sizeHint is used to auto-adjust the column to minimal width
+/// when double-clicking the right-hand column separator
 QSize StarDelegate::sizeHint(const QStyleOptionViewItem& option,
                              const QModelIndex& index) const {
     Q_UNUSED(option);
     StarRating starRating = index.data().value<StarRating>();
-    // Still uses the default scale factor, hence calculate it here
+    // StarRating was initialized with the default scale factor. To make it match
+    // the current library font size we need calculate the desired size using the
+    // capital height of the font.
     return QSize(option.fontMetrics.capHeight() * starRating.getNormalizedSize());
 }
 

--- a/src/library/stardelegate.cpp
+++ b/src/library/stardelegate.cpp
@@ -27,7 +27,11 @@ void StarDelegate::paintItem(
     paintItemBackground(painter, option, index);
 
     StarRating starRating = index.data().value<StarRating>();
-    starRating.paint(painter, option.rect);
+    // Make star size somehow match the library current font height.
+    // Note: capHeight() is too small, ascent() is too tall. Use the mean value.
+    QFontMetrics mf(option.font);
+    int height = (mf.capHeight() + mf.ascent()) / 2;
+    starRating.paint(painter, option.rect, height);
 }
 
 QSize StarDelegate::sizeHint(const QStyleOptionViewItem& option,

--- a/src/library/stareditor.cpp
+++ b/src/library/stareditor.cpp
@@ -62,7 +62,7 @@ void StarEditor::renderHelper(QPainter* painter,
         painter->setBrush(option.palette.color(cg, QPalette::Text));
     }
 
-    pStarRating->paint(painter, option.rect);
+    pStarRating->paint(painter, option.rect, option.fontMetrics.capHeight());
 }
 
 void StarEditor::paintEvent(QPaintEvent*) {

--- a/src/library/stareditor.cpp
+++ b/src/library/stareditor.cpp
@@ -88,7 +88,7 @@ void StarEditor::mouseMoveEvent(QMouseEvent *event) {
 #else
     const int eventPosition = event->x();
 #endif
-    int star = starAtPosition(eventPosition);
+    int star = m_starRating.starAtPosition(eventPosition);
 
     if (star != m_starRating.starCount() && star != -1) {
         m_starRating.setStarCount(star);
@@ -103,20 +103,4 @@ void StarEditor::leaveEvent(QEvent*) {
 
 void StarEditor::mouseReleaseEvent(QMouseEvent* /* event */) {
     emit editingFinished();
-}
-
-int StarEditor::starAtPosition(int x) {
-    // If the mouse is very close to the left edge, set 0 stars.
-    if (x < m_starRating.sizeHint().width() * 0.05) {
-        return 0;
-    }
-    int star = (x / (m_starRating.sizeHint().width() / m_starRating.maxStarCount())) + 1;
-
-    if (star <= 0) {
-        return 0;
-    } else if (star > m_starRating.maxStarCount()) {
-        // Pointer outside the right-hand edge, reset to current rating
-        return m_starRating.starCount();
-    }
-    return star;
 }

--- a/src/library/stareditor.cpp
+++ b/src/library/stareditor.cpp
@@ -62,7 +62,8 @@ void StarEditor::renderHelper(QPainter* painter,
         painter->setBrush(option.palette.color(cg, QPalette::Text));
     }
 
-    pStarRating->paint(painter, option.rect, option.fontMetrics.capHeight());
+    const int height = pStarRating->getMeanStarHeightFromFont(option.fontMetrics);
+    pStarRating->paint(painter, option.rect, height);
 }
 
 void StarEditor::paintEvent(QPaintEvent*) {

--- a/src/library/stareditor.cpp
+++ b/src/library/stareditor.cpp
@@ -6,10 +6,10 @@
 #include "moc_stareditor.cpp"
 #include "util/painterscope.h"
 
-// We enable mouse tracking on the widget so we can follow the cursor even
-// when the user doesn't hold down any mouse button. We also turn on
-// QWidget's auto-fill background feature to obtain an opaque background.
-// (Without the call, the view's background would shine through the editor.)
+/// We enable mouse tracking on the widget so we can follow the cursor even
+/// when the user doesn't hold down any mouse button. We also turn on
+/// QWidget's auto-fill background feature to obtain an opaque background.
+/// (Without the call, the view's background would shine through the editor.)
 
 /// StarEditor inherits QWidget and is used by StarDelegate to let the user
 /// edit a star rating in the library using the mouse.

--- a/src/library/stareditor.cpp
+++ b/src/library/stareditor.cpp
@@ -111,8 +111,11 @@ int StarEditor::starAtPosition(int x) {
     }
     int star = (x / (m_starRating.sizeHint().width() / m_starRating.maxStarCount())) + 1;
 
-    if (star <= 0 || star > m_starRating.maxStarCount()) {
+    if (star <= 0) {
         return 0;
+    } else if (star > m_starRating.maxStarCount()) {
+        // Pointer outside the right-hand edge, reset to current rating
+        return m_starRating.starCount();
     }
     return star;
 }

--- a/src/library/stareditor.h
+++ b/src/library/stareditor.h
@@ -36,7 +36,7 @@ class StarEditor : public QWidget {
     void paintEvent(QPaintEvent* event);
     void mouseMoveEvent(QMouseEvent* event);
     void mouseReleaseEvent(QMouseEvent* event);
-    //if the mouse leaves the editing index set starCount to 0
+    // If the mouse leaves the editing index set starCount to 0
     void leaveEvent(QEvent*);
 
   private:

--- a/src/library/stareditor.h
+++ b/src/library/stareditor.h
@@ -40,8 +40,6 @@ class StarEditor : public QWidget {
     void leaveEvent(QEvent*);
 
   private:
-    int starAtPosition(int x);
-
     QTableView* m_pTableView;
     QModelIndex m_index;
     QStyleOptionViewItem m_styleOption;

--- a/src/library/starrating.cpp
+++ b/src/library/starrating.cpp
@@ -31,7 +31,7 @@ StarRating::StarRating(
 }
 
 QSize StarRating::sizeHint() const {
-    return m_scaleFactor * QSize(m_maxStarCount, 1);
+    return m_scaleFactor * getNormalizedSize();
 }
 
 void StarRating::paint(QPainter* painter, const QRect& rect, int height) {

--- a/src/library/starrating.cpp
+++ b/src/library/starrating.cpp
@@ -5,7 +5,7 @@
 
 #include "util/math.h"
 
-// Default height of the rating rectangle
+// Default width/height of the rectangle for painting one star/diamond polygon
 constexpr int kDefaultPaintingScaleFactor = 15;
 
 StarRating::StarRating(
@@ -40,12 +40,12 @@ void StarRating::paint(QPainter* painter, const QRect& rect, int height) {
     painter->setRenderHint(QPainter::Antialiasing, true);
     painter->setPen(Qt::NoPen);
 
-    // Center the painter baseline (y-origin of the polygons)
+    // Shift the painter rectangle to center the polygons vertically
     int yOffset = (rect.height() - m_scaleFactor) / 2;
     painter->translate(rect.x(), rect.y() + yOffset);
     painter->scale(m_scaleFactor, m_scaleFactor);
 
-    //determine number of stars that are possible to paint
+    // Determine number of stars that are possible to paint
     int n = rect.width() / m_scaleFactor;
 
     for (int i = 0; i < m_maxStarCount && i < n; ++i) {

--- a/src/library/starrating.cpp
+++ b/src/library/starrating.cpp
@@ -34,6 +34,25 @@ QSize StarRating::sizeHint() const {
     return m_scaleFactor * getNormalizedSize();
 }
 
+int StarRating::starAtPosition(int x) const {
+    int width = sizeHint().width();
+    // If the pointer is very close to the left edge, set 0 stars.
+    if (x < width * 0.05) {
+        return 0;
+    } else if (x > width) {
+        return m_starCount;
+    }
+    int star = (x / (width / m_maxStarCount)) + 1;
+
+    if (star <= 0) {
+        return 0;
+    } else if (star > m_maxStarCount) {
+        // Pointer outside the right-hand edge, reset to current rating
+        return m_starCount;
+    }
+    return star;
+}
+
 void StarRating::paint(QPainter* painter, const QRect& rect, int height) {
     m_scaleFactor = height > 0 ? height : kDefaultPaintingScaleFactor;
     // Assume the painter is configured with the right brush.

--- a/src/library/starrating.cpp
+++ b/src/library/starrating.cpp
@@ -5,14 +5,15 @@
 
 #include "util/math.h"
 
-// Magic number? Explain what this factor affects and how
-constexpr int PaintingScaleFactor = 15;
+// Default height of the rating rectangle
+constexpr int kDefaultPaintingScaleFactor = 15;
 
 StarRating::StarRating(
         int starCount,
         int maxStarCount)
         : m_starCount(starCount),
-          m_maxStarCount(maxStarCount) {
+          m_maxStarCount(maxStarCount),
+          m_scaleFactor(kDefaultPaintingScaleFactor) {
     DEBUG_ASSERT(m_starCount >= kMinStarCount);
     DEBUG_ASSERT(m_starCount <= m_maxStarCount);
     // 1st star cusp at 0° of the unit circle whose center is shifted to adapt the 0,0-based paint area
@@ -30,20 +31,22 @@ StarRating::StarRating(
 }
 
 QSize StarRating::sizeHint() const {
-    return PaintingScaleFactor * QSize(m_maxStarCount, 1);
+    return m_scaleFactor * QSize(m_maxStarCount, 1);
 }
 
-void StarRating::paint(QPainter *painter, const QRect &rect) const {
+void StarRating::paint(QPainter* painter, const QRect& rect, int height) {
+    m_scaleFactor = height > 0 ? height : kDefaultPaintingScaleFactor;
     // Assume the painter is configured with the right brush.
     painter->setRenderHint(QPainter::Antialiasing, true);
     painter->setPen(Qt::NoPen);
 
-    int yOffset = (rect.height() - PaintingScaleFactor) / 2;
+    // Center the painter baseline (y-origin of the polygons)
+    int yOffset = (rect.height() - m_scaleFactor) / 2;
     painter->translate(rect.x(), rect.y() + yOffset);
-    painter->scale(PaintingScaleFactor, PaintingScaleFactor);
+    painter->scale(m_scaleFactor, m_scaleFactor);
 
     //determine number of stars that are possible to paint
-    int n = rect.width() / PaintingScaleFactor;
+    int n = rect.width() / m_scaleFactor;
 
     for (int i = 0; i < m_maxStarCount && i < n; ++i) {
         if (i < m_starCount) {

--- a/src/library/starrating.h
+++ b/src/library/starrating.h
@@ -22,6 +22,16 @@ class StarRating {
 
     static constexpr int kMinStarCount = 0;
 
+    static QSize getNormalizedSize() {
+        return QSize(mixxx::TrackRecord::kMaxRating - mixxx::TrackRecord::kMinRating, 1);
+    }
+
+    static int getMeanStarHeightFromFont(const QFontMetrics& fm) {
+        // Make star size somehow match the library current font height.
+        // Note: capHeight() is too small, ascent() is too tall. Use the mean value.
+        return (fm.capHeight() + fm.ascent()) / 2;
+    }
+
     explicit StarRating(
             int starCount = kMinStarCount,
             int maxStarCount = mixxx::TrackRecord::kMaxRating - mixxx::TrackRecord::kMinRating);

--- a/src/library/starrating.h
+++ b/src/library/starrating.h
@@ -26,7 +26,7 @@ class StarRating {
             int starCount = kMinStarCount,
             int maxStarCount = mixxx::TrackRecord::kMaxRating - mixxx::TrackRecord::kMinRating);
 
-    void paint(QPainter* painter, const QRect& rect) const;
+    void paint(QPainter* painter, const QRect& rect, int height = 0);
     QSize sizeHint() const;
 
     int starCount() const {
@@ -46,6 +46,7 @@ class StarRating {
     QPolygonF m_diamondPolygon;
     int m_starCount;
     int m_maxStarCount;
+    int m_scaleFactor;
 };
 
 Q_DECLARE_METATYPE(StarRating)

--- a/src/library/starrating.h
+++ b/src/library/starrating.h
@@ -45,6 +45,8 @@ class StarRating {
     int maxStarCount() const {
         return m_maxStarCount;
     }
+    int starAtPosition(int x) const;
+
     void setStarCount(int starCount) {
         DEBUG_ASSERT(starCount >= kMinStarCount);
         DEBUG_ASSERT(starCount <= m_maxStarCount);

--- a/src/widget/wstarrating.cpp
+++ b/src/widget/wstarrating.cpp
@@ -36,16 +36,17 @@ void WStarRating::setup(const QDomNode& node, const SkinContext& context) {
 QSize WStarRating::sizeHint() const {
     QStyleOption option;
     option.initFrom(this);
-    QSize widgetSize = style()->sizeFromContents(QStyle::CT_PushButton,
+    const QSize preferredSize = m_visualStarRating.sizeHint();
+    const QSize widgetSize = style()->sizeFromContents(QStyle::CT_PushButton,
             &option,
-            m_visualStarRating.sizeHint(),
+            preferredSize,
             this);
 
     m_contentRect.setRect(
-            (widgetSize.width() - m_visualStarRating.sizeHint().width()) / 2,
-            (widgetSize.height() - m_visualStarRating.sizeHint().height()) / 2,
-            m_visualStarRating.sizeHint().width(),
-            m_visualStarRating.sizeHint().height());
+            (widgetSize.width() - preferredSize.width()) / 2,
+            (widgetSize.height() - preferredSize.height()) / 2,
+            preferredSize.width(),
+            preferredSize.height());
 
     return widgetSize;
 }

--- a/src/widget/wstarrating.cpp
+++ b/src/widget/wstarrating.cpp
@@ -42,6 +42,7 @@ QSize WStarRating::sizeHint() const {
             preferredSize,
             this);
 
+    // Center the rating inside the frame
     m_contentRect.setRect(
             (widgetSize.width() - preferredSize.width()) / 2,
             (widgetSize.height() - preferredSize.height()) / 2,

--- a/src/widget/wstarrating.cpp
+++ b/src/widget/wstarrating.cpp
@@ -75,10 +75,11 @@ void WStarRating::paintEvent(QPaintEvent * /*unused*/) {
 
 void WStarRating::mouseMoveEvent(QMouseEvent *event) {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    int star = starAtPosition(event->position().toPoint().x());
+    const int x = event->position().toPoint().x();
 #else
-    int star = starAtPosition(event->x());
+    const int x = event->x();
 #endif
+    int star = m_visualStarRating.starAtPosition(x);
 
     if (star != -1) {
         updateVisualRating(star);
@@ -107,24 +108,6 @@ void WStarRating::updateVisualRating(int starCount) {
     }
     m_visualStarRating.setStarCount(starCount);
     update();
-}
-
-// The method uses basic linear algebra to find out which star is under the cursor.
-int WStarRating::starAtPosition(int x) const {
-    // If the mouse is very close to the left edge, set 0 stars.
-    if (x < m_visualStarRating.sizeHint().width() * 0.05) {
-        return 0;
-    }
-    int star = (x /
-                       (m_visualStarRating.sizeHint().width() /
-                               m_visualStarRating.maxStarCount())) +
-            1;
-
-    if (star <= 0 || star > m_visualStarRating.maxStarCount()) {
-        return 0;
-    }
-
-    return star;
 }
 
 void WStarRating::mouseReleaseEvent(QMouseEvent* /*unused*/) {

--- a/src/widget/wstarrating.h
+++ b/src/widget/wstarrating.h
@@ -45,7 +45,6 @@ class WStarRating : public WWidget {
     StarRating m_visualStarRating;
     mutable QRect m_contentRect;
 
-    int starAtPosition(int x) const;
     void updateVisualRating(int starCount);
     void resetVisualRating() {
         updateVisualRating(m_starCount);


### PR DESCRIPTION
Helpful with font sizes < ~70% or > ~150% of the default font size.
Ratings in decks and Track Info dialog still use the default scale factor.

![image](https://github.com/mixxxdj/mixxx/assets/5934199/bde9c195-8c7c-467f-bc7c-0c98f0dbe897)
![image](https://github.com/mixxxdj/mixxx/assets/5934199/bc46818f-9049-4007-b445-b7bab2ed750e)

Previous size with default library font:
![image](https://github.com/mixxxdj/mixxx/assets/5934199/0e280be4-3580-4836-bebf-9972962e3c03)


Played checkbox is next ;)