### PR TITLE
Broadcast: Improve error message in case of timeout 

### DIFF
--- a/src/engine/sidechain/shoutconnection.cpp
+++ b/src/engine/sidechain/shoutconnection.cpp
@@ -609,6 +609,12 @@ bool ShoutConnection::processConnect() {
             kLogger.warning()
                     << "processConnect() socket error."
                     << "Is socket already in use?";
+        } else if (timeout >= kConnectRetries) {
+            // Not translated, because shout_get_error() returns also English only
+            m_lastErrorStr = QStringLiteral("Connection establishment time-out");
+            kLogger.warning()
+                    << "processConnect() error:"
+                    << m_iShoutStatus << m_lastErrorStr;
         } else if (m_pProfile->getEnabled()) {
             m_lastErrorStr = shout_get_error(m_pShout);
             kLogger.warning()


### PR DESCRIPTION
In case of timeout was the error string "No error" which is confusing. 
See: https://github.com/mixxxdj/mixxx/issues/11740#issuecomment-1650105772
This PR replaces the string with "Connection establishment time-out"

This fits IMHO to other error messages like from libshout: 
""TLS connection can not be established because of bad certificate"