### PR TITLE
fix(fx): don't reset fxunit "super" and "mix" knob on startup

### DIFF
--- a/src/effects/effectchain.cpp
+++ b/src/effects/effectchain.cpp
@@ -68,7 +68,6 @@ EffectChain::EffectChain(const QString& group,
     m_pControlChainMix = std::make_unique<ControlPotmeter>(
             ConfigKey(m_group, "mix"), 0.0, 1.0, false, true, false, true, 1.0);
     m_pControlChainMix->setDefaultValue(0.0);
-    m_pControlChainMix->set(0.0);
     connect(m_pControlChainMix.get(),
             &ControlObject::valueChanged,
             this,
@@ -83,7 +82,6 @@ EffectChain::EffectChain(const QString& group,
             &ControlObject::valueChanged,
             this,
             [=, this](double value) { slotControlChainSuperParameter(value, false); });
-    m_pControlChainSuperParameter->set(0.0);
     m_pControlChainSuperParameter->setDefaultValue(0.0);
 
     m_pControlChainMixMode =


### PR DESCRIPTION
fixes #11773

I assume this was an oversight from the original PR?