### PR TITLE
Revive #11441

### DIFF
--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -195,6 +195,7 @@ void DlgPrefLibrary::slotUpdate() {
             ConfigKey("[Library]","SyncTrackMetadataExport"), false));
     checkBox_SeratoMetadataExport->setChecked(m_pConfig->getValue(
             ConfigKey("[Library]", "SeratoMetadataExport"), false));
+    setSeratoMetadataEnabled(checkBox_SyncTrackMetadataExport->isChecked());
     checkBox_use_relative_path->setChecked(m_pConfig->getValue(
             ConfigKey("[Library]","UseRelativePathOnExport"), false));
     checkBox_show_rhythmbox->setChecked(m_pConfig->getValue(
@@ -444,7 +445,16 @@ void DlgPrefLibrary::slotSearchDebouncingTimeoutMillisChanged(int searchDebounci
 }
 
 void DlgPrefLibrary::slotSyncTrackMetadataExportToggled() {
-    if (isVisible() && checkBox_SyncTrackMetadataExport->isChecked()) {
+    bool shouldSyncTrackMetadata = checkBox_SyncTrackMetadataExport->isChecked();
+    if (isVisible() && shouldSyncTrackMetadata) {
         mixxx::DlgTrackMetadataExport::showMessageBoxOncePerSession();
+    }
+    setSeratoMetadataEnabled(shouldSyncTrackMetadata);
+}
+
+void DlgPrefLibrary::setSeratoMetadataEnabled(bool shouldSyncTrackMetadata) {
+    checkBox_SeratoMetadataExport->setEnabled(shouldSyncTrackMetadata);
+    if (!shouldSyncTrackMetadata) {
+        checkBox_SeratoMetadataExport->setChecked(false);
     }
 }

--- a/src/preferences/dialog/dlgpreflibrary.h
+++ b/src/preferences/dialog/dlgpreflibrary.h
@@ -60,6 +60,7 @@ class DlgPrefLibrary : public DlgPreferencePage, public Ui::DlgPrefLibraryDlg  {
   private:
     void initializeDirList();
     void setLibraryFont(const QFont& font);
+    void setSeratoMetadataEnabled(bool shouldSyncTrackMetadata);
 
     QStandardItemModel m_dirListModel;
     UserSettingsPointer m_pConfig;


### PR DESCRIPTION
Fixes #11226, Supersedes #11441

I added another little feature where it disables the serato metadata export when the general metadata export is also disabled. I'm not sure if enforcing that in the UI is the best solution, suggestions welcome. 