### PR TITLE
Denon MC6000MK2: Delete mapping for master gain

### DIFF
--- a/res/controllers/Denon-MC6000MK2.midi.xml
+++ b/res/controllers/Denon-MC6000MK2.midi.xml
@@ -1688,15 +1688,6 @@
                 </options>
             </control>
             <control>
-                <group>[Master]</group>
-                <key>gain</key>
-                <status>0xB0</status>
-                <midino>0x19</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
                 <group>[Channel1]</group>
                 <key>DenonMC6000MK2.recvJogSpin</key>
                 <status>0xB0</status>


### PR DESCRIPTION
The master knob also controls the hardware and must not be mapped.

No one ever noticed :shrug: I forgot about this fix in my patched version that became necessary due to a hardware defect.