### PR TITLE
iTunes: Permit duplicate playlist names by identifying playlists by id (rather than name)

### DIFF
--- a/src/library/baseexternalplaylistmodel.cpp
+++ b/src/library/baseexternalplaylistmodel.cpp
@@ -111,6 +111,10 @@ void BaseExternalPlaylistModel::setPlaylist(const QString& playlist_path) {
         return;
     }
 
+    setPlaylistById(playlistId);
+}
+
+void BaseExternalPlaylistModel::setPlaylistById(int playlistId) {
     // Store search text
     QString currSearch = currentSearch();
     if (m_currentPlaylistId != kInvalidPlaylistId) {

--- a/src/library/baseexternalplaylistmodel.h
+++ b/src/library/baseexternalplaylistmodel.h
@@ -22,6 +22,7 @@ class BaseExternalPlaylistModel : public BaseSqlTableModel {
     ~BaseExternalPlaylistModel() override;
 
     void setPlaylist(const QString& path_name);
+    void setPlaylistById(int playlistId);
 
     TrackPointer getTrack(const QModelIndex& index) const override;
     TrackId getTrackId(const QModelIndex& index) const override;

--- a/src/library/itunes/itunesdao.cpp
+++ b/src/library/itunes/itunesdao.cpp
@@ -158,7 +158,7 @@ void ITunesDAO::appendPlaylistTree(gsl::not_null<TreeItem*> item, int playlistId
             [this, &item](auto childEntry) {
                 int childId = childEntry.second;
                 QString childName = m_playlistNameById[childId];
-                TreeItem* child = item->appendChild(childName);
+                TreeItem* child = item->appendChild(childName, childId);
                 appendPlaylistTree(child, childId);
             });
 }

--- a/src/library/itunes/itunesdao.cpp
+++ b/src/library/itunes/itunesdao.cpp
@@ -107,7 +107,7 @@ bool ITunesDAO::importPlaylist(const ITunesPlaylist& playlist) {
         }
     }
 
-    m_playlistNameById[playlist.id] = uniqueName;
+    m_playlistNameById[playlist.id] = playlist.name;
 
     return true;
 }

--- a/src/library/itunes/itunesfeature.cpp
+++ b/src/library/itunes/itunesfeature.cpp
@@ -23,6 +23,7 @@
 #include "library/library.h"
 #include "library/queryutil.h"
 #include "library/trackcollectionmanager.h"
+#include "library/treeitem.h"
 #include "library/treeitemmodel.h"
 #include "moc_itunesfeature.cpp"
 #include "util/sandbox.h"
@@ -231,9 +232,11 @@ void ITunesFeature::activate(bool forceReload) {
 
 void ITunesFeature::activateChild(const QModelIndex& index) {
     //qDebug() << "ITunesFeature::activateChild()" << index;
-    QString playlist = index.data().toString();
-    qDebug() << "Activating " << playlist;
-    m_pITunesPlaylistModel->setPlaylist(playlist);
+    TreeItem* treeItem = static_cast<TreeItem*>(index.internalPointer());
+    const QString& playlistName = treeItem->getLabel();
+    int playlistId = treeItem->getData().toInt();
+    qDebug() << "Activating playlist" << playlistName << "with id" << playlistId;
+    m_pITunesPlaylistModel->setPlaylistById(playlistId);
     emit showTrackModel(m_pITunesPlaylistModel);
     emit enableCoverArtDisplay(false);
 }


### PR DESCRIPTION
This patches the iTunes feature to identify playlists by id rather than their name and updates the created `TreeItem`s to also use the original, non-suffixed names (without `... #n`). Given that the corresponding database column has a `UNIQUE` constraint, the suffixed name will still be used there for backwards compatibility/to avoid a schema change, but no longer presented in the UI.

Thus if the user e.g. has two playlists named `A`, they will now both be presented as `A` in the sidebar, rather than `A` and `A #2`, which generally looks cleaner since it mirrors the "original" naming of the playlists.

For comparison:

| Before | After |
| - | - |
| ![Screenshot 2023-08-06 at 23 53 08](https://github.com/mixxxdj/mixxx/assets/30873659/2548a298-a851-4d60-81fe-feaebffe3cf5) | ![Screenshot 2023-08-06 at 23 51 33](https://github.com/mixxxdj/mixxx/assets/30873659/ccbdf054-dedb-40c3-8e25-7ab22e184e4e) |