### PR TITLE
Pref Mixer: fix reset of EQ auto-reset checkbox

### DIFF
--- a/src/preferences/dialog/dlgprefmixer.cpp
+++ b/src/preferences/dialog/dlgprefmixer.cpp
@@ -391,7 +391,6 @@ void DlgPrefMixer::loadSettings() {
     checkBoxReverse->setChecked(m_xFaderReverse);
 
     slotUpdateXFader();
-    slotApply();
 
     // EQ ////////////////////////////////////////////////
     QString highEqCourse = m_pConfig->getValueString(ConfigKey(kConfigGroup, "HiEQFrequency"));
@@ -452,6 +451,7 @@ void DlgPrefMixer::loadSettings() {
                 ConfigKey(kConfigGroup, kEnableEqs), "yes") == "yes") {
         CheckBoxBypass->setChecked(false);
     }
+    slotApply();
 }
 
 void DlgPrefMixer::setDefaultShelves() {


### PR DESCRIPTION
Closes #11817 

`slotApply()` called too early during init.

Note that this page is still messy in terms of UX / consistency.
I won't do anymore quick fixes. I already fixed this bug (and others, see #11271) and improved UX in #11527. Let's merge that asap to finally clean up that page. There are no tr changes, hence it's even a 2.4.0 candidate.