### PR TITLE
Traktor Kontrol S2 Mk2 fix loaded chain preset CO

### DIFF
--- a/res/controllers/Traktor-Kontrol-S2-MK2-hid-scripts.js
+++ b/res/controllers/Traktor-Kontrol-S2-MK2-hid-scripts.js
@@ -1017,7 +1017,7 @@ TraktorS2MK2.effectFocusButton = function(field) {
     if (field.value > 0) {
         var effectUnitNumber = field.group.slice(-2, -1);
         if (TraktorS2MK2.shiftPressed["[Channel" + effectUnitNumber + "]"]) {
-            engine.setValue(field.group, "load_preset", 1);
+            engine.setValue(field.group, "loaded_chain_preset", 1);
             return;
         }
         TraktorS2MK2.effectFocusLongPressTimer[field.group] = engine.beginTimer(TraktorS2MK2.longPressTimeoutMilliseconds, function() {
@@ -1099,7 +1099,7 @@ TraktorS2MK2.effectButton = function(field) {
 
     if (field.value > 0) {
         if (TraktorS2MK2.shiftPressed["[Channel" + effectUnitNumber + "]"]) {
-            engine.setValue(effectUnitGroup, "load_preset", buttonNumber+1);
+            engine.setValue(effectUnitGroup, "loaded_chain_preset", buttonNumber+1);
         } else {
             if (TraktorS2MK2.effectFocusChooseModeActive[effectUnitGroup]) {
                 if (focusedEffect === buttonNumber) {


### PR DESCRIPTION
Closes: #10667

I don't have this controller and therefore did only this minimal change without running pre-commit. Therefore pre-commit might fail on CI.

The change was verified to work on the very similar S2 Mk1 (only the jog wheels differ between these controllers) in https://github.com/mixxxdj/mixxx/pull/11237/commits/add0f497bf1176b95486ccc0e68f8f776ec58727