### PR TITLE
Fix for randomly not loaded CoverArt in Spinnies

### DIFF
--- a/src/widget/wspinnybase.cpp
+++ b/src/widget/wspinnybase.cpp
@@ -297,8 +297,7 @@ void WSpinnyBase::slotCoverFound(
         bool coverInfoUpdated) {
     Q_UNUSED(requestedCacheKey);
     Q_UNUSED(coverInfoUpdated); // CoverArtCache has taken care, updating the Track.
-    if (pRequestor == this &&
-            m_pLoadedTrack &&
+    if (m_pLoadedTrack &&
             m_pLoadedTrack->getLocation() == coverInfo.trackLocation) {
         setLoadedCover(pixmap);
         coverChanged();


### PR DESCRIPTION
Im not sure if this fix is the appropriated solution, but it fixes the issue #11131 for me. 
The problem is, that the requestor of cached CoverArt is not always WSpinnyBase - it can also be WCoverArt.