### PR TITLE
AutoDJ: don't use removed Intro end and outro start makers, use transition time instead

### DIFF
--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -1106,7 +1106,7 @@ double AutoDJProcessor::getIntroStartSecond(DeckAttributes* pDeck) {
             if (introStartFromTime > firstSoundSecond) {
                 // The introStart is automatically placed by AnalyzerSilence at the first sound
                 // Here the user has removed it, but has placed an intro end.
-                // Use the transition time instead the dismissed first sound position.
+                // Use the transition time instead of the dismissed first sound position.
                 return introStartFromTime;
             }
             return firstSoundSecond;
@@ -1160,7 +1160,7 @@ double AutoDJProcessor::getOutroEndSecond(DeckAttributes* pDeck) {
             if (outroEndFromTime < lastSoundSecond) {
                 // The outroEnd is automatically placed by AnalyzerSilence at the last sound
                 // Here the user has removed it, but has placed a outro start.
-                // Use the transition time instead the dismissed last sound position.
+                // Use the transition time instead of the dismissed last sound position.
                 return outroEndFromTime;
             }
             return lastSoundSecond;

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -1148,10 +1148,12 @@ double AutoDJProcessor::getOutroEndSecond(DeckAttributes* pDeck) {
     const mixxx::audio::FramePos outroEndPosition = pDeck->outroEndPosition();
     if (!outroEndPosition.isValid() || outroEndPosition > trackEndPosition) {
         double lastSoundSecond = getLastSoundSecond(pDeck);
+        DEBUG_ASSERT(lastSoundSecond <= framePositionToSeconds(trackEndPosition, pDeck));
         if (!outroStartPosition.isValid() || outroStartPosition > trackEndPosition) {
             // No outro start and outro end set, use Last Sound.
             return lastSoundSecond;
         }
+        // Try to find a better Outro End using Outro Start and transition time
         double outroStartSecond = framePositionToSeconds(outroStartPosition, pDeck);
         if (m_transitionTime >= 0 && lastSoundSecond > outroStartSecond) {
             double outroEndFromTime = outroStartSecond + m_transitionTime;

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -1101,15 +1101,8 @@ double AutoDJProcessor::getIntroStartSecond(DeckAttributes* pDeck) {
             return firstSoundSecond;
         }
         double introEndSecond = framePositionToSeconds(introEndPosition, pDeck);
-        if (m_transitionTime >= 0 && firstSoundSecond < introEndSecond) {
-            double introStartFromTime = introEndSecond - m_transitionTime;
-            if (introStartFromTime > firstSoundSecond) {
-                // The introStart is automatically placed by AnalyzerSilence at the first sound
-                // Here the user has removed it, but has placed an intro end.
-                // Use the transition time instead of the dismissed first sound position.
-                return introStartFromTime;
-            }
-            return firstSoundSecond;
+        if (m_transitionTime >= 0) {
+            return introEndSecond - m_transitionTime;
         }
         return introEndSecond;
     }


### PR DESCRIPTION
This is one part of #11648 