### PR TITLE
After disabling Explicit leader, request always follower mode 

### DIFF
--- a/src/engine/sync/enginesync.cpp
+++ b/src/engine/sync/enginesync.cpp
@@ -60,11 +60,18 @@ void EngineSync::requestSyncMode(Syncable* pSyncable, SyncMode mode) {
     }
     case SyncMode::Follower: {
         // A request for follower mode may be converted into an enabling of soft
-        // leader mode.
-        activateFollower(pSyncable);
+        // leader mode if this still be best choice
+        if (m_pLeaderSyncable == pSyncable) {
+            // Avoid that pickLeader() returns pSyncable with SyncMode::LeaderExplicit
+            m_pLeaderSyncable = nullptr;
+        }
         Syncable* newLeader = pickLeader(pSyncable);
+        if (newLeader != pSyncable) {
+            activateFollower(pSyncable);
+        }
         if (newLeader && newLeader != m_pLeaderSyncable) {
             // if the leader has changed, activate it (this updates m_pLeaderSyncable)
+            // But don't make an an explicit leader soft.
             activateLeader(newLeader, SyncMode::LeaderSoft);
         }
         break;

--- a/src/engine/sync/enginesync.cpp
+++ b/src/engine/sync/enginesync.cpp
@@ -46,17 +46,24 @@ void EngineSync::requestSyncMode(Syncable* pSyncable, SyncMode mode) {
     // decks that need to change as a result.
     Syncable* oldLeader = m_pLeaderSyncable;
     switch (mode) {
-    case SyncMode::LeaderExplicit:
-    case SyncMode::LeaderSoft: {
+    case SyncMode::LeaderExplicit: {
         if (pSyncable->getBaseBpm().isValid()) {
             activateLeader(pSyncable, mode);
-        } else {
-            // Because we don't have a valid bpm, we can't be the leader
-            // (or else everyone would try to be syncing to zero bpm).
-            // Override and make us a follower instead.
-            activateFollower(pSyncable);
+            break;
         }
-        break;
+        // Because we don't have a valid bpm, we can't be the leader
+        // (or else everyone would try to be syncing to zero bpm).
+        // Fall threough to SyncMode::Follower instead
+        [[fallthrough]];
+    }
+    case SyncMode::LeaderSoft: {
+        if (pSyncable->getBaseBpm().isValid() &&
+                pSyncable->isPlaying() &&
+                pSyncable->isAudible()) {
+            activateLeader(pSyncable, mode);
+            break;
+        }
+        [[fallthrough]];
     }
     case SyncMode::Follower: {
         // This request is also used to verifies and moves a soft leader

--- a/src/engine/sync/enginesync.h
+++ b/src/engine/sync/enginesync.h
@@ -66,6 +66,10 @@ class EngineSync : public SyncableListener {
     /// Iterate over decks, and based on sync and play status, pick a new Leader.
     /// if enabling_syncable is not null, we treat it as if it were enabled because we may
     /// be in the process of enabling it.
+    Syncable* pickNewLeader(Syncable* enabling_syncable);
+
+    /// Return the explicit leader if the one has been selected or picks a new leader using
+    /// pickNewLeader();
     Syncable* pickLeader(Syncable* enabling_syncable);
 
     /// Find a deck to match against, used in the case where there is no sync Leader.

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -519,6 +519,8 @@ void SyncControl::slotSyncLeaderEnabledChangeRequest(double state) {
         // Turning off leader goes back to follower mode.
         switch (mode) {
         case SyncMode::LeaderExplicit:
+            m_pChannel->getEngineBuffer()->requestSyncMode(SyncMode::LeaderSoft);
+            break;
         case SyncMode::LeaderSoft:
             m_pChannel->getEngineBuffer()->requestSyncMode(SyncMode::Follower);
             break;

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -519,8 +519,6 @@ void SyncControl::slotSyncLeaderEnabledChangeRequest(double state) {
         // Turning off leader goes back to follower mode.
         switch (mode) {
         case SyncMode::LeaderExplicit:
-            m_pChannel->getEngineBuffer()->requestSyncMode(SyncMode::LeaderSoft);
-            break;
         case SyncMode::LeaderSoft:
             m_pChannel->getEngineBuffer()->requestSyncMode(SyncMode::Follower);
             break;

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -581,11 +581,28 @@ TEST_F(EngineSyncTest, SetExplicitLeaderByLights) {
     EXPECT_TRUE(isExplicitLeader(m_sGroup1));
     EXPECT_TRUE(isFollower(m_sGroup2));
 
-    // Now set channel 1 to not-leader. The system will choose deck 2 as the next best
-    // option for soft leader
+    // Now set channel 1 to not-leader.
+    // This will choose automatically a Soft Leader, but prefers the old
+    // explicit leader it is still playing with a valid BPM
     pButtonSyncLeader1->set(0);
     ProcessBuffer();
 
+    EXPECT_TRUE(isFollower(m_sInternalClockGroup));
+    EXPECT_TRUE(isSoftLeader(m_sGroup1));
+    EXPECT_TRUE(isFollower(m_sGroup2));
+
+    // Try again without playing
+    pButtonSyncLeader1->set(1);
+    ProcessBuffer();
+
+    EXPECT_TRUE(isExplicitLeader(m_sGroup1));
+    EXPECT_TRUE(isFollower(m_sGroup2));
+
+    ControlObject::set(ConfigKey(m_sGroup1, "play"), 0.0);
+    pButtonSyncLeader1->set(0);
+    ProcessBuffer();
+
+    // Now the m_sGroup2 should be leader because m_sGroup1 can't lead without playing
     EXPECT_TRUE(isFollower(m_sInternalClockGroup));
     EXPECT_TRUE(isSoftLeader(m_sGroup2));
     EXPECT_TRUE(isFollower(m_sGroup1));

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -582,8 +582,8 @@ TEST_F(EngineSyncTest, SetExplicitLeaderByLights) {
     ProcessBuffer();
 
     EXPECT_TRUE(isFollower(m_sInternalClockGroup));
-    EXPECT_TRUE(isSoftLeader(m_sGroup1));
-    EXPECT_TRUE(isFollower(m_sGroup2));
+    EXPECT_TRUE(isSoftLeader(m_sGroup2));
+    EXPECT_TRUE(isFollower(m_sGroup1));
 }
 
 TEST_F(EngineSyncTest, SetExplicitLeaderByLightsNoTracks) {

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -401,11 +401,13 @@ TEST_F(EngineSyncTest, InternalLeaderSetFollowerSliderMoves) {
     // If internal is leader, and we turn on a follower, the slider should move.
     auto pButtonLeaderSyncInternal = std::make_unique<ControlProxy>(
             m_sInternalClockGroup, "sync_leader");
-    auto pLeaderSyncSlider =
+    auto pInternalClockBpm =
             std::make_unique<ControlProxy>(m_sInternalClockGroup, "bpm");
 
-    pLeaderSyncSlider->set(100.0);
+    pInternalClockBpm->set(100.0);
+    // Request internal clock to become SyncMode::LeaderExplicit
     pButtonLeaderSyncInternal->set(1);
+    EXPECT_TRUE(isExplicitLeader(m_sInternalClockGroup));
 
     // Set the file bpm of channel 1 to 80 bpm.
     mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
@@ -416,6 +418,9 @@ TEST_F(EngineSyncTest, InternalLeaderSetFollowerSliderMoves) {
             std::make_unique<ControlProxy>(m_sGroup1, "sync_mode");
     pButtonLeaderSync1->set(static_cast<double>(SyncMode::Follower));
     ProcessBuffer();
+
+    EXPECT_TRUE(isFollower(m_sGroup1));
+    EXPECT_TRUE(isExplicitLeader(m_sInternalClockGroup));
 
     EXPECT_DOUBLE_EQ(getRateSliderValue(1.25),
             ControlObject::getControl(ConfigKey(m_sGroup1, "rate"))->get());


### PR DESCRIPTION
… and let Mixxx pick a new Soft leader.

This fixes the bug that a stopped or silenced deck can become a Soft leader. #11829 