### PR TITLE
Fix wrong visual play position when inside loop

### DIFF
--- a/src/engine/controls/loopingcontrol.h
+++ b/src/engine/controls/loopingcontrol.h
@@ -58,12 +58,23 @@ class LoopingControl : public EngineControl {
     void setLoop(mixxx::audio::FramePos startPosition,
             mixxx::audio::FramePos endPosition,
             bool enabled);
-    mixxx::audio::FramePos getLoopStartPosition() {
-        return m_loopInfo.getValue().startPosition;
+
+    enum class LoopSeekMode {
+        Changed, // force the playposition to be inside the loop after adjusting it.
+        MovedOut,
+        None,
+    };
+
+    struct LoopInfo {
+        mixxx::audio::FramePos startPosition;
+        mixxx::audio::FramePos endPosition;
+        LoopSeekMode seekMode;
+    };
+
+    LoopInfo getLoopInfo() {
+        return m_loopInfo.getValue();
     }
-    mixxx::audio::FramePos getLoopEndPosition() {
-        return m_loopInfo.getValue().endPosition;
-    }
+
     void setRateControl(RateControl* rateControl);
 
     bool isLoopingEnabled() {
@@ -128,18 +139,6 @@ class LoopingControl : public EngineControl {
     void slotLoopEnabledValueChangeRequest(double enabled);
 
   private:
-    enum class LoopSeekMode {
-        Changed, // force the playposition to be inside the loop after adjusting it.
-        MovedOut,
-        None,
-    };
-
-    struct LoopInfo {
-        mixxx::audio::FramePos startPosition;
-        mixxx::audio::FramePos endPosition;
-        LoopSeekMode seekMode;
-    };
-
     void setLoopingEnabled(bool enabled);
     void setLoopInToCurrentPosition();
     void setLoopOutToCurrentPosition();

--- a/src/engine/controls/loopingcontrol.h
+++ b/src/engine/controls/loopingcontrol.h
@@ -58,6 +58,12 @@ class LoopingControl : public EngineControl {
     void setLoop(mixxx::audio::FramePos startPosition,
             mixxx::audio::FramePos endPosition,
             bool enabled);
+    mixxx::audio::FramePos getLoopStartPosition() {
+        return m_loopInfo.getValue().startPosition;
+    }
+    mixxx::audio::FramePos getLoopEndPosition() {
+        return m_loopInfo.getValue().endPosition;
+    }
     void setRateControl(RateControl* rateControl);
     bool isLoopingEnabled();
     bool isLoopRollActive();

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1405,15 +1405,16 @@ void EngineBuffer::updateIndicators(double speed, int iBufferSize) {
 
     const double fFractionalPlaypos = fractionalPlayposFromAbsolute(m_playPos);
     const double fFractionalSlipPos = fractionalPlayposFromAbsolute(m_slipPos);
+
+    auto loopInfo = m_pLoopingControl->getLoopInfo();
+
     double fFractionalLoopStartPos = 0.0;
-    auto loopStartPos = m_pLoopingControl->getLoopStartPosition();
-    if (loopStartPos.isValid()) {
-        fFractionalLoopStartPos = fractionalPlayposFromAbsolute(loopStartPos);
+    if (loopInfo.startPosition.isValid()) {
+        fFractionalLoopStartPos = fractionalPlayposFromAbsolute(loopInfo.startPosition);
     }
     double fFractionalLoopEndPos = 0.0;
-    auto loopEndPos = m_pLoopingControl->getLoopEndPosition();
-    if (loopEndPos.isValid()) {
-        fFractionalLoopEndPos = fractionalPlayposFromAbsolute(loopEndPos);
+    if (loopInfo.endPosition.isValid()) {
+        fFractionalLoopEndPos = fractionalPlayposFromAbsolute(loopInfo.endPosition);
     }
 
     const double tempoTrackSeconds = m_trackEndPositionOld.value() /

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -35,6 +35,7 @@
 #include "util/logger.h"
 #include "util/sample.h"
 #include "util/timer.h"
+#include "waveform/visualplayposition.h"
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 #include "waveform/waveformwidgetfactory.h"
 #endif
@@ -89,7 +90,7 @@ EngineBuffer::EngineBuffer(const QString& group,
           m_slipPos(mixxx::audio::kStartFramePos),
           m_dSlipRate(1.0),
           m_bSlipEnabledProcessing(false),
-          m_slipModeState(SlipModeStates::Disabled),
+          m_slipModeState(SlipModeState::Disabled),
           m_pRepeat(nullptr),
           m_startButton(nullptr),
           m_endButton(nullptr),
@@ -555,7 +556,7 @@ void EngineBuffer::slotTrackLoaded(TrackPointer pTrack,
     m_bSlipEnabledProcessing = false;
     m_slipPos = mixxx::audio::kStartFramePos;
     m_dSlipRate = 0;
-    m_slipModeState = SlipModeStates::Disabled;
+    m_slipModeState = SlipModeState::Disabled;
 
     m_queuedSeek.setValue(kNoQueuedSeek);
 
@@ -591,7 +592,7 @@ void EngineBuffer::ejectTrack() {
             0.0,
             0.0,
             0.0,
-            SlipModeStates::Disabled,
+            SlipModeState::Disabled,
             false,
             0.0,
             0.0,
@@ -1230,13 +1231,13 @@ void EngineBuffer::processSlip(int iBufferSize) {
             m_slipPos = m_pLoopingControl->adjustedPositionForCurrentLoop(
                     newPos,
                     m_dSlipRate < 0);
-            m_slipModeState = SlipModeStates::Armed;
+            m_slipModeState = SlipModeState::Armed;
         } else {
             m_slipPos += slipDelta;
-            m_slipModeState = SlipModeStates::Running;
+            m_slipModeState = SlipModeState::Running;
         }
     } else {
-        m_slipModeState = SlipModeStates::Disabled;
+        m_slipModeState = SlipModeState::Disabled;
     }
 }
 

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -352,7 +352,7 @@ class EngineBuffer : public EngineObject {
     int m_iSamplesSinceLastIndicatorUpdate;
 
     // The location where the track would have been had slip not been engaged
-    mixxx::audio::FramePos m_slipPosition;
+    mixxx::audio::FramePos m_slipPos;
     // Saved value of rate for slip mode
     double m_dSlipRate;
     // m_bSlipEnabledProcessing is only used by the engine processing thread.

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -12,13 +12,13 @@
 #include "engine/bufferscalers/enginebufferscalerubberband.h"
 #include "engine/cachingreader/cachingreader.h"
 #include "engine/engineobject.h"
+#include "engine/slipmodestate.h"
 #include "engine/sync/syncable.h"
 #include "preferences/usersettings.h"
 #include "track/bpm.h"
 #include "track/track_decl.h"
 #include "util/rotary.h"
 #include "util/types.h"
-#include "waveform/visualplayposition.h"
 
 //for the writer
 #ifdef __SCALER_DEBUG__
@@ -359,7 +359,7 @@ class EngineBuffer : public EngineObject {
     // m_bSlipEnabledProcessing is only used by the engine processing thread.
     bool m_bSlipEnabledProcessing;
 
-    SlipModeStates m_slipModeState;
+    SlipModeState m_slipModeState;
 
     ControlObject* m_pTrackSamples;
     ControlObject* m_pTrackSampleRate;

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -313,7 +313,7 @@ class EngineBuffer : public EngineObject {
     HintVector m_hintList;
 
     // The current sample to play in the file.
-    mixxx::audio::FramePos m_playPosition;
+    mixxx::audio::FramePos m_playPos;
 
     // The previous callback's speed. Used to check if the scaler parameters
     // need updating.

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -18,6 +18,7 @@
 #include "track/track_decl.h"
 #include "util/rotary.h"
 #include "util/types.h"
+#include "waveform/visualplayposition.h"
 
 //for the writer
 #ifdef __SCALER_DEBUG__
@@ -357,6 +358,8 @@ class EngineBuffer : public EngineObject {
     double m_dSlipRate;
     // m_bSlipEnabledProcessing is only used by the engine processing thread.
     bool m_bSlipEnabledProcessing;
+
+    SlipModeStates m_slipModeState;
 
     ControlObject* m_pTrackSamples;
     ControlObject* m_pTrackSampleRate;

--- a/src/engine/slipmodestate.h
+++ b/src/engine/slipmodestate.h
@@ -1,0 +1,7 @@
+#pragma once
+
+enum class SlipModeState {
+    Disabled = 0,
+    Armed = 1,
+    Running = 2,
+};

--- a/src/engine/slipmodestate.h
+++ b/src/engine/slipmodestate.h
@@ -2,6 +2,7 @@
 
 enum class SlipModeState {
     Disabled = 0,
-    Armed = 1,
+    Armed = 1, // Slip mode was enabled while in a loop, the slip position will start running
+               // when this loop get disabled
     Running = 2,
 };

--- a/src/waveform/visualplayposition.cpp
+++ b/src/waveform/visualplayposition.cpp
@@ -30,7 +30,7 @@ void VisualPlayPosition::set(
         double positionStep,
         double slipPosition,
         double slipRate,
-        SlipModeStates m_slipModeState,
+        SlipModeState m_slipModeState,
         bool loopEnabled,
         double loopStartPosition,
         double loopEndPosition,
@@ -125,7 +125,7 @@ void VisualPlayPosition::getPlaySlipAtNextVSync(VSyncThread* pVSyncThread,
         double interpolatedPlayPos = determinePlayPosInLoopBoundries(data, offset);
         *pPlayPosition = interpolatedPlayPos;
 
-        if (data.m_slipModeState == SlipModeStates::Running) {
+        if (data.m_slipModeState == SlipModeState::Running) {
             *pSlipPosition = data.m_slipPos + offset * data.m_slipRate;
         } else {
             *pSlipPosition = interpolatedPlayPos;

--- a/src/waveform/visualplayposition.cpp
+++ b/src/waveform/visualplayposition.cpp
@@ -89,13 +89,13 @@ double VisualPlayPosition::getAtNextVSync(VSyncThread* pVSyncThread) {
         if (data.m_loopEnabled) {
             double loopSize = data.m_loopEndPos - data.m_loopStartPos;
             if (loopSize > 0) {
-                if (interpolatedPlayPos < data.m_loopStartPos) {
+                if ((data.m_playRate < 0.0) && (interpolatedPlayPos < data.m_loopStartPos)) {
                     interpolatedPlayPos = data.m_loopEndPos -
                             std::remainder(
                                     data.m_loopStartPos - interpolatedPlayPos,
                                     loopSize);
                 }
-                if (interpolatedPlayPos > data.m_loopEndPos) {
+                if ((data.m_playRate > 0.0) && (interpolatedPlayPos > data.m_loopEndPos)) {
                     interpolatedPlayPos = data.m_loopStartPos +
                             std::remainder(
                                     interpolatedPlayPos - data.m_loopEndPos,

--- a/src/waveform/visualplayposition.h
+++ b/src/waveform/visualplayposition.h
@@ -5,6 +5,7 @@
 #include <QTime>
 
 #include "control/controlvalue.h"
+#include "engine/slipmodestate.h"
 #include "util/performancetimer.h"
 
 class ControlProxy;
@@ -13,12 +14,6 @@ typedef void VSyncThread;
 #else
 class VSyncThread;
 #endif
-
-enum class SlipModeStates {
-    Disabled = 0,
-    Armed = 1,
-    Running = 2,
-};
 
 // This class is for synchronizing the sound device DAC time with the waveforms, displayed on the
 // graphic device, using the CPU time
@@ -43,7 +38,7 @@ class VisualPlayPositionData {
     double m_positionStep;
     double m_slipPos;
     double m_slipRate;
-    SlipModeStates m_slipModeState;
+    SlipModeState m_slipModeState;
     bool m_loopEnabled;
     double m_loopStartPos;
     double m_loopEndPos;
@@ -65,7 +60,7 @@ class VisualPlayPosition : public QObject {
             double positionStep,
             double slipPos,
             double slipRate,
-            SlipModeStates slipModeState,
+            SlipModeState slipModeState,
             bool loopEnabled,
             double loopStartPos,
             double loopEndPos,

--- a/src/waveform/visualplayposition.h
+++ b/src/waveform/visualplayposition.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <QTime>
-#include <QMap>
 #include <QAtomicPointer>
+#include <QMap>
+#include <QTime>
 
-#include "util/performancetimer.h"
 #include "control/controlvalue.h"
+#include "util/performancetimer.h"
 
 class ControlProxy;
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
@@ -32,11 +32,14 @@ class VisualPlayPositionData {
   public:
     PerformanceTimer m_referenceTime;
     int m_callbackEntrytoDac; // Time from Audio Callback Entry to first sample of Buffer is transferred to DAC
-    double m_enginePlayPos; // Play position of fist Sample in Buffer
-    double m_rate;
+    double m_playPos;         // Play position of first Sample in Buffer
+    double m_playRate;
     double m_positionStep;
-    double m_slipPosition;
+    double m_slipPos;
     double m_slipRate;
+    bool m_loopEnabled;
+    double m_loopStartPos;
+    double m_loopEndPos;
     double m_tempoTrackSeconds; // total track time, taking the current tempo into account
     double m_audioBufferMicroS;
 };
@@ -50,12 +53,14 @@ class VisualPlayPosition : public QObject {
 
     // WARNING: Not thread safe. This function must be called only from the
     // engine thread.
-    void set(
-            double playPos,
-            double rate,
+    void set(double playPos,
+            double playRate,
             double positionStep,
-            double slipPosition,
+            double slipPos,
             double slipRate,
+            bool loopEnabled,
+            double loopStartPos,
+            double loopEndPos,
             double tempoTrackSeconds,
             double audioBufferMicroS);
 

--- a/src/waveform/visualplayposition.h
+++ b/src/waveform/visualplayposition.h
@@ -14,6 +14,12 @@ typedef void VSyncThread;
 class VSyncThread;
 #endif
 
+enum class SlipModeStates {
+    Disabled = 0,
+    Armed = 1,
+    Running = 2,
+};
+
 // This class is for synchronizing the sound device DAC time with the waveforms, displayed on the
 // graphic device, using the CPU time
 //
@@ -37,6 +43,7 @@ class VisualPlayPositionData {
     double m_positionStep;
     double m_slipPos;
     double m_slipRate;
+    SlipModeStates m_slipModeState;
     bool m_loopEnabled;
     double m_loopStartPos;
     double m_loopEndPos;
@@ -58,6 +65,7 @@ class VisualPlayPosition : public QObject {
             double positionStep,
             double slipPos,
             double slipRate,
+            SlipModeStates slipModeState,
             bool loopEnabled,
             double loopStartPos,
             double loopEndPos,
@@ -68,6 +76,8 @@ class VisualPlayPosition : public QObject {
     void getPlaySlipAtNextVSync(VSyncThread* pVSyncThread,
             double* playPosition,
             double* slipPosition);
+    double determinePlayPosInLoopBoundries(
+            const VisualPlayPositionData& data, const double& offset);
     double getEnginePlayPos();
     void getTrackTime(double* pPlayPosition, double* pTempoTrackSeconds);
 


### PR DESCRIPTION
Closes: #11836

The loop is now considered in VisualPlayPosition::getAtNextVSync which determines the visual play position used fo the waveform rendering. The play position indicator is no always inside an active loop. Forward and reverse playing direction is considered.

It wasn't neccessary to change VisualPlayPosition::getPlaySlipAtNextVSync because this is only used for the spinnies, which do not visualize loops. Therefore no special handling for slip position was necesarry.

Furthermore I unified some odd sympol naming in the VisualPlayPosition code.