### PR TITLE
Qt6: Use constInsert() template

### DIFF
--- a/src/util/rangelist.cpp
+++ b/src/util/rangelist.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 
 #include "util/assert.h"
+#include "util/make_const_iterator.h"
 
 namespace {
 
@@ -36,9 +37,9 @@ QList<int> parseRangeList(const QString& input) {
         }
         for (int currentIndex = startIndex; currentIndex <= endIndex; currentIndex++) {
             // Add values sorted and skip duplicates
-            auto insertPos = std::lower_bound(intList.begin(), intList.end(), currentIndex);
-            if (insertPos == intList.end() || *insertPos != currentIndex) {
-                intList.insert(insertPos, currentIndex);
+            auto insertPos = std::lower_bound(intList.cbegin(), intList.cend(), currentIndex);
+            if (insertPos == intList.cend() || *insertPos != currentIndex) {
+                constInsert(&intList, insertPos, currentIndex);
             }
         }
     }


### PR DESCRIPTION
This is a follow up of #11701
Fortunately clazy is still complaining
https://github.com/daschuer/mixxx/actions/runs/5919227496/job/16049296854
```
Error: /home/runner/work/mixxx/mixxx/src/util/rangelist.cpp:41:32: error: Mixing iterators with const_iterators [-Wclazy-strict-iterators]
                intList.insert(insertPos, currentIndex);
                               ^
1 error generated.
```
