### PR TITLE
Slip mode: consider loop for background position only if it was enabled  before slip

### DIFF
--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -49,6 +49,7 @@ LoopingControl::LoopingControl(const QString& group,
         : EngineControl(group, pConfig),
           m_bLoopingEnabled(false),
           m_bLoopRollActive(false),
+          m_bLoopWasEnabledBeforeSlipEnable(false),
           m_bAdjustingLoopIn(false),
           m_bAdjustingLoopOut(false),
           m_bAdjustingLoopInOld(false),
@@ -1164,6 +1165,8 @@ void LoopingControl::notifySeek(mixxx::audio::FramePos newPosition) {
 }
 
 void LoopingControl::setLoopingEnabled(bool enabled) {
+    m_bLoopWasEnabledBeforeSlipEnable =
+            !m_pSlipEnabled->toBool() && enabled && !m_bLoopRollActive;
     if (m_bLoopingEnabled == enabled) {
         return;
     }
@@ -1180,14 +1183,6 @@ void LoopingControl::setLoopingEnabled(bool enabled) {
     }
 
     emit loopEnabledChanged(enabled);
-}
-
-bool LoopingControl::isLoopingEnabled() {
-    return m_bLoopingEnabled;
-}
-
-bool LoopingControl::isLoopRollActive() {
-    return m_bLoopRollActive;
 }
 
 void LoopingControl::trackLoaded(TrackPointer pNewTrack) {

--- a/src/engine/controls/loopingcontrol.h
+++ b/src/engine/controls/loopingcontrol.h
@@ -59,8 +59,16 @@ class LoopingControl : public EngineControl {
             mixxx::audio::FramePos endPosition,
             bool enabled);
     void setRateControl(RateControl* rateControl);
-    bool isLoopingEnabled();
-    bool isLoopRollActive();
+
+    bool isLoopingEnabled() {
+        return m_bLoopingEnabled;
+    }
+    bool isLoopRollActive() {
+        return m_bLoopRollActive;
+    }
+    bool loopWasEnabledBeforeSlipEnable() {
+        return m_bLoopWasEnabledBeforeSlipEnable;
+    }
 
     void trackLoaded(TrackPointer pNewTrack) override;
     void trackBeatsUpdated(mixxx::BeatsPointer pBeats) override;
@@ -175,6 +183,7 @@ class LoopingControl : public EngineControl {
 
     bool m_bLoopingEnabled;
     bool m_bLoopRollActive;
+    bool m_bLoopWasEnabledBeforeSlipEnable;
     bool m_bAdjustingLoopIn;
     bool m_bAdjustingLoopOut;
     bool m_bAdjustingLoopInOld;

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1213,6 +1213,7 @@ void EngineBuffer::processSlip(int iBufferSize) {
                 static_cast<mixxx::audio::FrameDiff_t>(bufferFrameCount) * m_dSlipRate;
         // Simulate looping if a regular loop is active
         if (m_pLoopingControl->isLoopingEnabled() &&
+                m_pLoopingControl->loopWasEnabledBeforeSlipEnable() &&
                 !m_pLoopingControl->isLoopRollActive()) {
             const mixxx::audio::FramePos newPos = m_slipPosition + slipDelta;
             m_slipPosition = m_pLoopingControl->adjustedPositionForCurrentLoop(


### PR DESCRIPTION
This restores 2.3 behaviour (broken by c5127eb):
* enable slip mode (no active loop)
* active loop (NOT rolling loop since that would quit slip mode when disabling it)
* let it do a few interations so the slip position and the background position can be clearly distinguished
* disable loop
* quit slip mode = position is where it would have been without slip mode

Closes #11844 

@JoergAtGithub please test!