### PR TITLE
fix(library): fix `PlaylistDAO::removeHiddenTracks` performance

### DIFF
--- a/src/library/dao/playlistdao.cpp
+++ b/src/library/dao/playlistdao.cpp
@@ -562,7 +562,7 @@ void PlaylistDAO::removeHiddenTracks(const int playlistId) {
             "WHERE p1.id NOT IN ("
             "SELECT p2.id FROM PlaylistTracks AS p2 "
             "INNER JOIN library ON library.id=p2.track_id "
-            "WHERE p2.playlist_id=p1.playlist_id "
+            "WHERE p2.playlist_id=:id "
             "AND library.mixxx_deleted=0) "
             "AND p1.playlist_id=:id"));
     query.bindValue(":id", playlistId);


### PR DESCRIPTION
fixes #11724

The query consists of an outer query and inner subquery. In the previous form, the inner query had a dependency on `p1.playlist_id` of the outer query. Which could change for each row of the outer select statement. This made the inner query a `CORRELATED LIST SUBQUERY`, which caused the subquery to be re-evaluated for each row of the outer query. This dependency however is unnecessary because of the `AND p1.playlist_id=:id` restriction in the outer query. So in theory, `p1.playlist_id` never changes. Unfortunately, the SQLite was not able to make that deduction which lead to the dependency. Manually specifying that the `p1.playlist_id` is constant for the entire subquery, removes the dependecy to the outer query, resulting in a plain `LIST SUBQUERY` which can be evaluated once and then reused for all rows of the outer subquery. This results in reduced algorithmic complexity and thus drastically improved performance for large tables.