### PR TITLE
BaseExternalLibraryFeature: Add ability to import external playlists as crates

### DIFF
--- a/src/library/baseexternallibraryfeature.cpp
+++ b/src/library/baseexternallibraryfeature.cpp
@@ -6,6 +6,7 @@
 #include "library/library.h"
 #include "library/trackcollection.h"
 #include "library/trackcollectionmanager.h"
+#include "library/trackset/crate/crate.h"
 #include "moc_baseexternallibraryfeature.cpp"
 #include "util/logger.h"
 #include "widget/wlibrarysidebar.h"
@@ -40,11 +41,17 @@ BaseExternalLibraryFeature::BaseExternalLibraryFeature(
             this,
             &BaseExternalLibraryFeature::slotAddToAutoDJReplace);
 
-    m_pImportAsMixxxPlaylistAction = make_parented<QAction>(tr("Import Playlist"), this);
+    m_pImportAsMixxxPlaylistAction = make_parented<QAction>(tr("Import as Playlist"), this);
     connect(m_pImportAsMixxxPlaylistAction,
             &QAction::triggered,
             this,
             &BaseExternalLibraryFeature::slotImportAsMixxxPlaylist);
+
+    m_pImportAsMixxxCrateAction = make_parented<QAction>(tr("Import as Crate"), this);
+    connect(m_pImportAsMixxxCrateAction,
+            &QAction::triggered,
+            this,
+            &BaseExternalLibraryFeature::slotImportAsMixxxCrate);
 }
 
 void BaseExternalLibraryFeature::bindSidebarWidget(WLibrarySidebar* pSidebarWidget) {
@@ -68,6 +75,7 @@ void BaseExternalLibraryFeature::onRightClickChild(
     menu.addAction(m_pAddToAutoDJReplaceAction);
     menu.addSeparator();
     menu.addAction(m_pImportAsMixxxPlaylistAction);
+    menu.addAction(m_pImportAsMixxxCrateAction);
     menu.exec(globalPos);
 }
 
@@ -122,6 +130,30 @@ void BaseExternalLibraryFeature::slotImportAsMixxxPlaylist() {
         QMessageBox::warning(nullptr,
                 tr("Playlist Creation Failed"),
                 tr("An unknown error occurred while creating playlist: ") + playlist);
+    }
+}
+
+void BaseExternalLibraryFeature::slotImportAsMixxxCrate() {
+    // qDebug() << "slotImportAsMixxxCrate() row:" << m_lastRightClickedIndex.data();
+
+    QList<TrackId> trackIds;
+    QString playlist;
+    appendTrackIdsFromRightClickIndex(&trackIds, &playlist);
+    if (trackIds.isEmpty()) {
+        return;
+    }
+
+    Crate crate;
+    crate.setName(playlist);
+
+    CrateId crateId;
+
+    if (m_pTrackCollection->insertCrate(crate, &crateId)) {
+        m_pTrackCollection->addCrateTracks(crateId, trackIds);
+    } else {
+        QMessageBox::warning(nullptr,
+                tr("Crate Creation Failed"),
+                tr("Could not create crate, it most likely already exists: ") + playlist);
     }
 }
 

--- a/src/library/baseexternallibraryfeature.cpp
+++ b/src/library/baseexternallibraryfeature.cpp
@@ -101,7 +101,7 @@ void BaseExternalLibraryFeature::addToAutoDJ(PlaylistDAO::AutoDJSendLoc loc) {
 }
 
 void BaseExternalLibraryFeature::slotImportAsMixxxPlaylist() {
-    // qDebug() << "slotAddToAutoDJ() row:" << m_lastRightClickedIndex.data();
+    // qDebug() << "slotImportAsMixxxPlaylist() row:" << m_lastRightClickedIndex.data();
 
     QList<TrackId> trackIds;
     QString playlist;

--- a/src/library/baseexternallibraryfeature.h
+++ b/src/library/baseexternallibraryfeature.h
@@ -38,6 +38,7 @@ class BaseExternalLibraryFeature : public LibraryFeature {
     void slotAddToAutoDJTop();
     void slotAddToAutoDJReplace();
     void slotImportAsMixxxPlaylist();
+    void slotImportAsMixxxCrate();
 
   protected:
     QModelIndex lastRightClickedIndex() const {
@@ -60,6 +61,7 @@ class BaseExternalLibraryFeature : public LibraryFeature {
     parented_ptr<QAction> m_pAddToAutoDJTopAction;
     parented_ptr<QAction> m_pAddToAutoDJReplaceAction;
     parented_ptr<QAction> m_pImportAsMixxxPlaylistAction;
+    parented_ptr<QAction> m_pImportAsMixxxCrateAction;
 
     QPointer<WLibrarySidebar> m_pSidebarWidget;
 };


### PR DESCRIPTION
This is a small extension to the existing import-as-playlist action found in `BaseExternalLibraryFeature` that enables users to import external playlists as crates too:

<img width="343" alt="image" src="https://github.com/mixxxdj/mixxx/assets/30873659/d07d32ac-607d-4384-8017-2ac38225711b">

Crates have the unique property that their names must be unique, so the import can fail if the name already exists. Currently this is dealt with by presenting an error dialog, but we may consider prompting the user e.g. to specify a custom name instead or to merge the tracks into the existing crate. Ideas welcome.

Something else to consider is that the import is currently synchronous and can be quite slow for large external playlists (thousands of songs). This applies to the existing playlist import too though, therefore I would consider any optimizations to be out-of-scope for this PR.