### PR TITLE
Pref Interface: avoid unneeded skin reload, clean up

### DIFF
--- a/src/preferences/dialog/dlgprefinterface.cpp
+++ b/src/preferences/dialog/dlgprefinterface.cpp
@@ -50,7 +50,6 @@ DlgPrefInterface::DlgPrefInterface(
           m_dScaleFactor(1.0),
           m_minScaleFactor(1.0),
           m_dDevicePixelRatio(1.0),
-          m_bStartWithFullScreen(false),
           m_bRebootMixxxView(false) {
     setupUi(this);
 
@@ -178,10 +177,6 @@ DlgPrefInterface::DlgPrefInterface(
         skinPreviewLabel->hide();
     }
 
-    // Start in fullscreen mode
-    checkBoxStartFullScreen->setChecked(
-            m_pConfig->getValue(ConfigKey(kConfigGroup, kStartInFullscreenKey), 0) == 1);
-
     // Screensaver mode
     comboBoxScreensaver->clear();
     comboBoxScreensaver->addItem(tr("Allow screensaver to run"),
@@ -195,9 +190,6 @@ DlgPrefInterface::DlgPrefInterface(
     comboBoxScreensaver->setCurrentIndex(comboBoxScreensaver->findData(inhibitsettings));
 
     // Tooltip configuration
-    // Initialize checkboxes to match config
-    loadTooltipPreferenceFromConfig();
-    slotSetTooltips();  // Update disabled status of "only library" checkbox
     connect(buttonGroupTooltips,
             QOverload<QAbstractButton*>::of(&QButtonGroup::buttonClicked),
             this,
@@ -264,9 +256,7 @@ void DlgPrefInterface::slotUpdateSchemes() {
 }
 
 void DlgPrefInterface::slotUpdate() {
-    const QString skinNameOnUpdate =
-            m_pConfig->getValue(ConfigKey(kConfigGroup, kResizableSkinKey));
-    const SkinPointer pSkinOnUpdate = m_skins[skinNameOnUpdate];
+    const SkinPointer pSkinOnUpdate = m_pSkinLoader->getConfiguredSkin();
     if (pSkinOnUpdate != nullptr && pSkinOnUpdate->isValid()) {
         m_skinNameOnUpdate = pSkinOnUpdate->name();
     } else {
@@ -287,7 +277,7 @@ void DlgPrefInterface::slotUpdate() {
     spinBoxScaleFactor->setMinimum(m_minScaleFactor * 100);
 
     checkBoxStartFullScreen->setChecked(m_pConfig->getValue(
-            ConfigKey(kConfigGroup, kStartInFullscreenKey), m_bStartWithFullScreen));
+            ConfigKey(kConfigGroup, kStartInFullscreenKey), false));
 
     loadTooltipPreferenceFromConfig();
 

--- a/src/preferences/dialog/dlgprefinterface.cpp
+++ b/src/preferences/dialog/dlgprefinterface.cpp
@@ -99,7 +99,7 @@ DlgPrefInterface::DlgPrefInterface(
         const QString languageName = QLocale::languageToString(locale.language());
         // Ugly hack to skip non-resolvable locales
         if (languageName == QStringLiteral("C")) {
-            qWarning() << "Unsupported locale" << localeNameFixed;
+            qWarning() << "Preferences: skipping unsupported locale" << localeNameFixed;
             continue;
         }
         QString countryName;
@@ -122,6 +122,7 @@ DlgPrefInterface::DlgPrefInterface(
     ComboBoxLocale->model()->sort(0);
     // ...and then insert entry for default system locale at the top
     ComboBoxLocale->insertItem(0, QStringLiteral("System"), "");
+    ComboBoxLocale->insertSeparator(1);
 
     if (pSkinLoader) {
         // Skin configurations

--- a/src/preferences/dialog/dlgprefinterface.h
+++ b/src/preferences/dialog/dlgprefinterface.h
@@ -76,7 +76,6 @@ class DlgPrefInterface : public DlgPreferencePage, public Ui::DlgPrefControlsDlg
     double m_dScaleFactor;
     double m_minScaleFactor;
     double m_dDevicePixelRatio;
-    bool m_bStartWithFullScreen;
     mixxx::ScreenSaverPreference m_screensaverMode;
 
     bool m_bRebootMixxxView;

--- a/src/preferences/dialog/dlgprefinterface.h
+++ b/src/preferences/dialog/dlgprefinterface.h
@@ -71,12 +71,11 @@ class DlgPrefInterface : public DlgPreferencePage, public Ui::DlgPrefControlsDlg
     mixxx::skin::SkinPointer m_pSkin;
     QString m_skinNameOnUpdate;
     QString m_colorScheme;
+    QString m_colorSchemeOnUpdate;
     QString m_localeOnUpdate;
     mixxx::TooltipsPreference m_tooltipMode;
     double m_dScaleFactor;
     double m_minScaleFactor;
     double m_dDevicePixelRatio;
     mixxx::ScreenSaverPreference m_screensaverMode;
-
-    bool m_bRebootMixxxView;
 };

--- a/src/skin/legacy/colorschemeparser.cpp
+++ b/src/skin/legacy/colorschemeparser.cpp
@@ -51,11 +51,12 @@ void ColorSchemeParser::setupLegacyColorSchemes(const QDomElement& docElem,
             WImageStore::setLoader(imsrc);
             WSkinColor::setLoader(imsrc);
 
-            // This calls SkinContext::updateVariables in skincontext.cpp which
-            // iterates over all <SetVariable> nodes in the selected color scheme node
+            // This calls SkinContext::updateVariables which iterates over all
+            // <SetVariable> nodes in the selected color scheme node.
             pContext->updateVariables(schemeNode);
 
             if (pStyle) {
+                // read scheme's stylesheet (node text or stylesheet file)
                 *pStyle = LegacySkinParser::getStyleFromNode(schemeNode);
             }
         }


### PR DESCRIPTION
Previously, on Ok/Apply the skin would be reloaded even though the skin or color scheme configuration didn't actually change, for example if users just checked out the previews of other skins or schemes.

plus a separator in the locale list (below 'System'), improved locale logging and some clean up