### PR TITLE
Pref Sound: auto select free device channels

### DIFF
--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -352,10 +352,6 @@ void DlgPrefSound::addPath(const AudioOutput& output) {
             m_outputDevices,
             false,
             AudioPath::isIndexed(type) ? output.getIndex() : 0);
-    connect(this,
-            &DlgPrefSound::refreshOutputDevices,
-            pSoundItem,
-            &DlgPrefSoundItem::refreshDevices);
     insertItem(pSoundItem, outputVLayout);
     connectSoundItem(pSoundItem);
 
@@ -373,11 +369,6 @@ void DlgPrefSound::addPath(const AudioInput& input) {
             m_inputDevices,
             true,
             AudioPath::isIndexed(type) ? input.getIndex() : 0);
-
-    connect(this,
-            &DlgPrefSound::refreshInputDevices,
-            pSoundItem,
-            &DlgPrefSoundItem::refreshDevices);
     connectSoundItem(pSoundItem);
     insertItem(pSoundItem, inputVLayout);
 
@@ -395,7 +386,14 @@ void DlgPrefSound::connectSoundItem(DlgPrefSoundItem* pItem) {
             &DlgPrefSound::deviceChannelsChanged);
     connect(this, &DlgPrefSound::loadPaths, pItem, &DlgPrefSoundItem::loadPath);
     connect(this, &DlgPrefSound::writePaths, pItem, &DlgPrefSoundItem::writePath);
-    connect(this, &DlgPrefSound::refreshInputDevices, pItem, &DlgPrefSoundItem::refreshDevices);
+    if (pItem->isInput()) {
+        connect(this, &DlgPrefSound::refreshInputDevices, pItem, &DlgPrefSoundItem::refreshDevices);
+    } else {
+        connect(this,
+                &DlgPrefSound::refreshOutputDevices,
+                pItem,
+                &DlgPrefSoundItem::refreshDevices);
+    }
     connect(this, &DlgPrefSound::updatingAPI, pItem, &DlgPrefSoundItem::save);
     connect(this, &DlgPrefSound::updatedAPI, pItem, &DlgPrefSoundItem::reload);
 }

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -32,10 +32,8 @@ bool soundItemAlreadyExists(const AudioPath& output, const QWidget& widget) {
 
 } // namespace
 
-/**
- * Construct a new sound preferences pane. Initializes and populates all the
- * all the controls to the values obtained from SoundManager.
- */
+/// Construct a new sound preferences pane. Initializes and populates
+/// all the controls to the values obtained from SoundManager.
 DlgPrefSound::DlgPrefSound(QWidget* pParent,
         std::shared_ptr<SoundManager> pSoundManager,
         UserSettingsPointer pSettings)
@@ -263,10 +261,8 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
                             MIXXX_WIKI_HARDWARE_COMPATIBILITY_URL)));
 }
 
-/**
- * Slot called when the preferences dialog is opened or this pane is
- * selected.
- */
+/// Slot called when the preferences dialog is opened or this pane is
+/// selected.
 void DlgPrefSound::slotUpdate() {
     // this is unfortunate, because slotUpdate is called every time
     // we change to this pane, we lose changed and unapplied settings
@@ -279,9 +275,7 @@ void DlgPrefSound::slotUpdate() {
     m_settingsModified = false;
 }
 
-/**
- * Slot called when the Apply or OK button is pressed.
- */
+/// Slot called when the Apply or OK button is pressed.
 void DlgPrefSound::slotApply() {
     if (!m_settingsModified) {
         return;
@@ -319,13 +313,11 @@ QUrl DlgPrefSound::helpUrl() const {
     return QUrl(MIXXX_MANUAL_SOUND_URL);
 }
 
-/**
- * Initializes (and creates) all the path items. Each path item widget allows
- * the user to input a sound device name and channel number given a description
- * of what will be done with that info. Inputs and outputs are grouped by tab,
- * and each path item has an identifier (Main, Headphones, ...) and an index,
- * if necessary.
- */
+/// Initializes (and creates) all the path items. Each path item widget allows
+/// the user to input a sound device name and channel number given a description
+/// of what will be done with that info. Inputs and outputs are grouped by tab,
+/// and each path item has an identifier (Master, Headphones, ...) and an index,
+/// if necessary.
 void DlgPrefSound::initializePaths() {
     // Pre-sort paths so they're added in the order they'll appear later on
     // so Tab key order matches order in layout:
@@ -419,18 +411,14 @@ void DlgPrefSound::insertItem(DlgPrefSoundItem *pItem, QVBoxLayout *pLayout) {
     pLayout->insertWidget(pos, pItem);
 }
 
-/**
- * Convenience overload to load settings from the SoundManagerConfig owned by
- * SoundManager.
- */
+/// Convenience overload to load settings from the SoundManagerConfig owned by
+/// SoundManager.
 void DlgPrefSound::loadSettings() {
     loadSettings(m_pSoundManager->getConfig());
 }
 
-/**
- * Loads the settings in the given SoundManagerConfig into the dialog.
- */
-void DlgPrefSound::loadSettings(const SoundManagerConfig &config) {
+/// Loads the settings in the given SoundManagerConfig into the dialog.
+void DlgPrefSound::loadSettings(const SoundManagerConfig& config) {
     m_loading = true; // so settingsChanged ignores all our modifications here
     m_config = config;
     int apiIndex = apiComboBox->findData(m_config.getAPI());
@@ -494,12 +482,10 @@ void DlgPrefSound::loadSettings(const SoundManagerConfig &config) {
     emit loadPaths(m_config);
 }
 
-/**
- * Slot called when the user selects a different API, or the
- * software changes it programmatically (for instance, when it
- * loads a value from SoundManager). Refreshes the device lists
- * for the new API and pushes those to the path items.
- */
+/// Slot called when the user selects a different API, or the
+/// software changes it programmatically (for instance, when it
+/// loads a value from SoundManager). Refreshes the device lists
+/// for the new API and pushes those to the path items.
 void DlgPrefSound::apiChanged(int index) {
     m_config.setAPI(apiComboBox->itemData(index).toString());
     refreshDevices();
@@ -518,10 +504,8 @@ void DlgPrefSound::apiChanged(int index) {
     updateAudioBufferSizes(sampleRateComboBox->currentIndex());
 }
 
-/**
- * Updates the list of APIs, trying to keep the API and device selections
- * constant if possible.
- */
+/// Updates the list of APIs, trying to keep the API and device selections
+/// constant if possible.
 void DlgPrefSound::updateAPIs() {
     QString currentAPI(apiComboBox->itemData(apiComboBox->currentIndex()).toString());
     emit updatingAPI();
@@ -538,10 +522,8 @@ void DlgPrefSound::updateAPIs() {
     emit updatedAPI();
 }
 
-/**
- * Slot called when the sample rate combo box changes to update the
- * sample rate in the config.
- */
+/// Slot called when the sample rate combo box changes to update the
+/// sample rate in the config.
 void DlgPrefSound::sampleRateChanged(int index) {
     m_config.setSampleRate(
             sampleRateComboBox->itemData(index).toUInt());
@@ -550,10 +532,8 @@ void DlgPrefSound::sampleRateChanged(int index) {
     checkLatencyCompensation();
 }
 
-/**
- * Slot called when the latency combo box is changed to update the
- * latency in the config.
- */
+/// Slot called when the latency combo box is changed to update the
+/// latency in the config.
 void DlgPrefSound::audioBufferChanged(int index) {
     m_config.setAudioBufferSizeIndex(
             audioBufferComboBox->itemData(index).toUInt());
@@ -637,10 +617,8 @@ void DlgPrefSound::updateAudioBufferSizes(int sampleRateIndex) {
     }
 }
 
-/**
- * Slot called when device lists go bad to refresh them, or the API
- * just changes and we need to display new devices.
- */
+/// Slot called when device lists go bad to refresh them, or the API
+/// just changes and we need to display new devices.
 void DlgPrefSound::refreshDevices() {
     if (m_config.getAPI() == SoundManagerConfig::kDefaultAPI) {
         m_outputDevices.clear();
@@ -655,11 +633,9 @@ void DlgPrefSound::refreshDevices() {
     emit refreshInputDevices(m_inputDevices);
 }
 
-/**
- * Called when any of the combo boxes in this dialog are changed. Enables the
- * apply button and marks that settings have been changed so that
- * DlgPrefSound::slotApply knows to apply them.
- */
+/// Called when any of the combo boxes in this dialog are changed. Enables the
+/// apply button and marks that settings have been changed so that
+/// DlgPrefSound::slotApply knows to apply them.
 void DlgPrefSound::settingChanged() {
     if (m_loading) {
         return; // doesn't count if we're just loading prefs
@@ -675,18 +651,14 @@ void DlgPrefSound::deviceSettingChanged() {
     m_settingsModified = true;
 }
 
-/**
- * Slot called when the "Query Devices" button is clicked.
- */
+/// Slot called when the "Query Devices" button is clicked.
 void DlgPrefSound::queryClicked() {
     ScopedWaitCursor cursor;
     m_pSoundManager->clearAndQueryDevices();
     updateAPIs();
 }
 
-/**
- * Slot called when the "Reset to Defaults" button is clicked.
- */
+/// Slot called when the "Reset to Defaults" button is clicked.
 void DlgPrefSound::slotResetToDefaults() {
     SoundManagerConfig newConfig(m_pSoundManager.get());
     newConfig.loadDefaults(m_pSoundManager.get(), SoundManagerConfig::ALL);

--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -17,15 +17,10 @@ class SoundDevice;
 class DlgPrefSoundItem;
 class ControlProxy;
 
-/*
- * TODO(bkgood) (n-decks) establish a signal/slot connection with a signal
- * on EngineMixer that emits every time a channel is added, and a slot here
- * that updates the dialog accordingly.
- */
+// TODO(bkgood) (n-decks) establish a signal/slot connection with a signal
+// on EngineMaster that emits every time a channel is added, and a slot here
+// that updates the dialog accordingly.
 
-/**
- * Class representing a preferences pane to configure sound devices for Mixxx.
- */
 class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     Q_OBJECT;
   public:

--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -14,6 +14,7 @@ class SoundManager;
 class PlayerManager;
 class ControlObject;
 class SoundDevice;
+class SoundDeviceId;
 class DlgPrefSoundItem;
 class ControlProxy;
 
@@ -67,7 +68,8 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     void engineClockChanged(int index);
     void refreshDevices();
     void settingChanged();
-    void deviceSettingChanged();
+    void deviceChanged();
+    void deviceChannelsChanged();
     void queryClicked();
 
   private:
@@ -92,6 +94,8 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     ControlProxy* m_pMicMonitorMode;
     QList<SoundDevicePointer> m_inputDevices;
     QList<SoundDevicePointer> m_outputDevices;
+    QHash<DlgPrefSoundItem*, QPair<SoundDeviceId, int>> m_selectedOutputChannelIndices;
+    QHash<DlgPrefSoundItem*, QPair<SoundDeviceId, int>> m_selectedInputChannelIndices;
     bool m_settingsModified;
     bool m_bLatencyChanged;
     bool m_bSkipConfigClear;

--- a/src/preferences/dialog/dlgprefsounditem.cpp
+++ b/src/preferences/dialog/dlgprefsounditem.cpp
@@ -6,15 +6,13 @@
 #include "soundio/sounddevice.h"
 #include "soundio/soundmanagerconfig.h"
 
-/**
- * Constructs a new preferences sound item, representing an AudioPath and SoundDevice
- * with a label and two combo boxes.
- * @param type The AudioPathType of the path to be represented
- * @param devices The list of devices for the user to choose from (either a collection
- * of input or output devices).
- * @param isInput true if this is representing an AudioInput, false otherwise
- * @param index the index of the represented AudioPath, if applicable
- */
+/// Constructs a new preferences sound item, representing an AudioPath and SoundDevice
+/// with a label and two combo boxes.
+/// @param type The AudioPathType of the path to be represented
+/// @param devices The list of devices for the user to choose from (either a collection
+/// of input or output devices).
+/// @param isInput true if this is representing an AudioInput, false otherwise
+/// @param index the index of the represented AudioPath, if applicable
 DlgPrefSoundItem::DlgPrefSoundItem(
         QWidget* parent,
         AudioPathType type,
@@ -47,10 +45,8 @@ DlgPrefSoundItem::~DlgPrefSoundItem() {
 
 }
 
-/**
- * Slot called when the parent preferences pane updates its list of sound
- * devices, to update the item widget's list of devices to display.
- */
+/// Slot called when the parent preferences pane updates its list of sound
+/// devices, to update the item widget's list of devices to display.
 void DlgPrefSoundItem::refreshDevices(const QList<SoundDevicePointer>& devices) {
     m_devices = devices;
     SoundDeviceId oldDev = deviceComboBox->itemData(deviceComboBox->currentIndex()).value<SoundDeviceId>();
@@ -72,10 +68,8 @@ void DlgPrefSoundItem::refreshDevices(const QList<SoundDevicePointer>& devices) 
     }
 }
 
-/**
- * Slot called when the device combo box selection changes. Updates the channel
- * combo box.
- */
+/// Slot called when the device combo box selection changes. Updates the channel
+/// combo box.
 void DlgPrefSoundItem::deviceChanged(int index) {
     channelComboBox->clear();
     SoundDeviceId selection = deviceComboBox->itemData(index).value<SoundDeviceId>();
@@ -136,13 +130,11 @@ void DlgPrefSoundItem::channelChanged() {
     }
 }
 
-/**
- * Slot called to load the respective AudioPath from a SoundManagerConfig
- * object.
- * @note If there are multiple AudioPaths matching this instance's type
- *       and index (if applicable), then only the first one is used. A more
- *       advanced preferences pane may one day allow multiples.
- */
+/// Slot called to load the respective AudioPath from a SoundManagerConfig
+/// object.
+/// @note If there are multiple AudioPaths matching this instance's type
+///       and index (if applicable), then only the first one is used. A more
+///       advanced preferences pane may one day allow multiples.
 void DlgPrefSoundItem::loadPath(const SoundManagerConfig &config) {
     if (m_isInput) {
         const auto inputDeviceMap = config.getInputs();
@@ -168,11 +160,9 @@ void DlgPrefSoundItem::loadPath(const SoundManagerConfig &config) {
     setDevice(SoundDeviceId()); // this will blank the channel combo box
 }
 
-/**
- * Slot called when the underlying DlgPrefSound wants this Item to
- * record its respective path with the SoundManagerConfig instance at
- * config.
- */
+/// Slot called when the underlying DlgPrefSound wants this Item to
+/// record its respective path with the SoundManagerConfig instance at
+/// config.
 void DlgPrefSoundItem::writePath(SoundManagerConfig* config) const {
     SoundDevicePointer pDevice = getDevice();
     if (!pDevice) {
@@ -199,17 +189,13 @@ void DlgPrefSoundItem::writePath(SoundManagerConfig* config) const {
     }
 }
 
-/**
- * Slot called to tell the Item to save its selections for later use.
- */
+/// Slot called to tell the Item to save its selections for later use.
 void DlgPrefSoundItem::save() {
     m_savedDevice = deviceComboBox->itemData(deviceComboBox->currentIndex()).value<SoundDeviceId>();
     m_savedChannel = channelComboBox->itemData(channelComboBox->currentIndex()).toPoint();
 }
 
-/**
- * Slot called to reload Item with previously saved settings.
- */
+/// Slot called to reload Item with previously saved settings.
 void DlgPrefSoundItem::reload() {
     int newDevice = deviceComboBox->findData(QVariant::fromValue(m_savedDevice));
     if (newDevice > -1) {
@@ -221,10 +207,8 @@ void DlgPrefSoundItem::reload() {
     }
 }
 
-/**
- * Gets the currently selected SoundDevice
- * @returns pointer to SoundDevice, or NULL if the "None" option is selected.
- */
+/// Gets the currently selected SoundDevice
+/// @returns pointer to SoundDevice, or NULL if the "None" option is selected.
 SoundDevicePointer DlgPrefSoundItem::getDevice() const {
     SoundDeviceId selection = deviceComboBox->itemData(deviceComboBox->currentIndex()).value<SoundDeviceId>();
     if (selection == SoundDeviceId()) {
@@ -241,10 +225,8 @@ SoundDevicePointer DlgPrefSoundItem::getDevice() const {
     return SoundDevicePointer();
 }
 
-/**
- * Selects a device in the device combo box given a SoundDevice
- * internal name, or selects "None" if the device isn't found.
- */
+/// Selects a device in the device combo box given a SoundDevice
+/// internal name, or selects "None" if the device isn't found.
 void DlgPrefSoundItem::setDevice(const SoundDeviceId& device) {
     int index = deviceComboBox->findData(QVariant::fromValue(device));
     //qDebug() << "DlgPrefSoundItem::setDevice" << device;
@@ -258,10 +240,8 @@ void DlgPrefSoundItem::setDevice(const SoundDeviceId& device) {
     }
 }
 
-/**
- * Selects a channel in the channel combo box given a channel number,
- * or selects the first channel if the given channel isn't found.
- */
+/// Selects a channel in the channel combo box given a channel number,
+/// or selects the first channel if the given channel isn't found.
 void DlgPrefSoundItem::setChannel(unsigned int channelBase,
                                   unsigned int channels) {
     // Because QComboBox supports QPoint natively (via QVariant) we use a QPoint
@@ -278,9 +258,7 @@ void DlgPrefSoundItem::setChannel(unsigned int channelBase,
     }
 }
 
-/**
- * Checks that a given device can act as a source/input for our type.
- */
+/// Checks that a given device can act as a source/input for our type.
 int DlgPrefSoundItem::hasSufficientChannels(const SoundDevice& device) const {
     unsigned char needed(AudioPath::minChannelsForType(m_type));
 

--- a/src/preferences/dialog/dlgprefsounditem.cpp
+++ b/src/preferences/dialog/dlgprefsounditem.cpp
@@ -137,6 +137,12 @@ void DlgPrefSoundItem::selectFirstUnusedChannelIndex(const QList<int>& selectedC
     // Go through the list of occupied channel indices and pick the first unoccupied
     for (int i = 0; i < channelComboBox->count(); i++) {
         if (!selectedChannels.contains(i)) {
+            // TODO(xxx) Some ideas to improve auto-select:
+            // * check selected indices and new selection for channel overlap, e.g.
+            //   if the device has 4 channels and ch.1/2 + ch.3/4 are already selected
+            //   don't select next index (ch.1) but fall back to ch.1/2?
+            // * if there are only mono indices selected, try to pick the next mono
+            //   channel index instead of suggesting index 0 (ch.1/)
             channelComboBox->setCurrentIndex(i);
             return;
         }

--- a/src/preferences/dialog/dlgprefsounditem.cpp
+++ b/src/preferences/dialog/dlgprefsounditem.cpp
@@ -23,7 +23,7 @@ DlgPrefSoundItem::DlgPrefSoundItem(
           m_type(type),
           m_index(index),
           m_isInput(isInput),
-          m_inhibitSettingChanged(false) {
+          m_emitSettingChanged(true) {
     setupUi(this);
     typeLabel->setText(AudioPath::getTrStringFromType(type, index));
 
@@ -119,13 +119,13 @@ void DlgPrefSoundItem::deviceChanged(int index) {
         }
     }
 emitAndReturn:
-    if (m_inhibitSettingChanged == false) {
+    if (m_emitSettingChanged) {
         emit settingChanged();
     }
 }
 
 void DlgPrefSoundItem::channelChanged() {
-    if (m_inhibitSettingChanged == false) {
+    if (m_emitSettingChanged) {
         emit settingChanged();
     }
 }
@@ -230,13 +230,13 @@ SoundDevicePointer DlgPrefSoundItem::getDevice() const {
 void DlgPrefSoundItem::setDevice(const SoundDeviceId& device) {
     int index = deviceComboBox->findData(QVariant::fromValue(device));
     //qDebug() << "DlgPrefSoundItem::setDevice" << device;
-    if (index != -1) {
-        m_inhibitSettingChanged = true;
-        deviceComboBox->setCurrentIndex(index);
-        m_inhibitSettingChanged = false;
-    } else {
+    if (index == -1) {
         deviceComboBox->setCurrentIndex(0); // None
         emit settingChanged();
+    } else {
+        m_emitSettingChanged = false;
+        deviceComboBox->setCurrentIndex(index);
+        m_emitSettingChanged = true;
     }
 }
 
@@ -248,13 +248,14 @@ void DlgPrefSoundItem::setChannel(unsigned int channelBase,
     // to store the channel info. x is the channel base and y is the channel
     // count.
     int index = channelComboBox->findData(QPoint(channelBase, channels));
-    if (index != -1) {
-        m_inhibitSettingChanged = true;
-        channelComboBox->setCurrentIndex(index);
-        m_inhibitSettingChanged = false;
-    } else {
+    if (index == -1) {
+        // channel(s) not found
         channelComboBox->setCurrentIndex(0); // 1
         emit settingChanged();
+    } else {
+        m_emitSettingChanged = false;
+        channelComboBox->setCurrentIndex(index);
+        m_emitSettingChanged = true;
     }
 }
 

--- a/src/preferences/dialog/dlgprefsounditem.h
+++ b/src/preferences/dialog/dlgprefsounditem.h
@@ -50,5 +50,5 @@ class DlgPrefSoundItem : public QWidget, public Ui::DlgPrefSoundItem {
     // Because QVariant supports QPoint natively we use a QPoint to store the
     // channel info. x is the channel base and y is the channel count.
     QPoint m_savedChannel;
-    bool m_inhibitSettingChanged;
+    bool m_emitSettingChanged;
 };

--- a/src/preferences/dialog/dlgprefsounditem.h
+++ b/src/preferences/dialog/dlgprefsounditem.h
@@ -23,9 +23,20 @@ class DlgPrefSoundItem : public QWidget, public Ui::DlgPrefSoundItem {
 
     AudioPathType type() const { return m_type; };
     unsigned int index() const { return m_index; };
+    bool isInput() {
+        return m_isInput;
+    }
+    const SoundDeviceId getDeviceId() {
+        return deviceComboBox->itemData(deviceComboBox->currentIndex()).value<SoundDeviceId>();
+    }
+    int getChannelIndex() {
+        return channelComboBox->currentIndex();
+    }
+    void selectFirstUnusedChannelIndex(const QList<int>& selectedChannels);
 
   signals:
-    void settingChanged();
+    void selectedDeviceChanged();
+    void selectedChannelsChanged();
 
   public slots:
     void refreshDevices(const QList<SoundDevicePointer>& devices);

--- a/src/soundio/soundmanagerutil.cpp
+++ b/src/soundio/soundmanagerutil.cpp
@@ -2,36 +2,28 @@
 
 #include "engine/channels/enginechannel.h"
 
-/**
- * Constructs a ChannelGroup.
- * @param channelBase the first channel in the group.
- * @param channels the number of channels.
- */
+/// Constructs a ChannelGroup.
+/// @param channelBase the first channel in the group.
+/// @param channels the number of channels.
 ChannelGroup::ChannelGroup(unsigned char channelBase, unsigned char channels)
   : m_channelBase(channelBase)
   , m_channels(channels) {
 }
 
-/**
- * @return This ChannelGroup's base channel
- */
+/// @return This ChannelGroup's base channel
 unsigned char ChannelGroup::getChannelBase() const {
     return m_channelBase;
 }
 
-/**
- * @return The number of channels in this ChannelGroup
- */
+/// @return The number of channels in this ChannelGroup
 unsigned char ChannelGroup::getChannelCount() const {
     return m_channels;
 }
 
-/**
- * Checks if another ChannelGroup shares channels with this one.
- * @param other the other ChannelGroup to check for a clash with.
- * @return true if the other and this ChannelGroup share any channels,
- *          false otherwise.
- */
+/// Checks if another ChannelGroup shares channels with this one.
+/// @param other the other ChannelGroup to check for a clash with.
+/// @return true if the other and this ChannelGroup share any channels,
+///          false otherwise.
 bool ChannelGroup::clashesWith(const ChannelGroup &other) const {
     if (m_channels == 0 || other.m_channels == 0) {
         return false; // can't clash if there are no channels in use
@@ -44,59 +36,45 @@ bool ChannelGroup::clashesWith(const ChannelGroup &other) const {
         || m_channelBase == other.m_channelBase;
 }
 
-/**
- * Constructs an AudioPath object (must be called by a child class's
- * constructor, AudioPath is abstract).
- * @param channelBase the first channel on a sound device used by this AudioPath.
- * @param channels the number of channels used.
- */
+/// Constructs an AudioPath object (must be called by a child class's
+/// constructor, AudioPath is abstract).
+/// @param channelBase the first channel on a sound device used by this AudioPath.
+/// @param channels the number of channels used.
 AudioPath::AudioPath(unsigned char channelBase, unsigned char channels)
         : m_channelGroup(channelBase, channels),
           m_type(AudioPathType::Invalid),
           m_index(0) {
 }
 
-/**
- * @return This AudioPath's type
- */
+/// @return This AudioPath's type
 AudioPathType AudioPath::getType() const {
     return m_type;
 }
 
-/**
- * @return This AudioPath's ChannelGroup instance.
- */
+/// @return This AudioPath's ChannelGroup instance.
 ChannelGroup AudioPath::getChannelGroup() const {
     return m_channelGroup;
 }
 
-/**
- * @return This AudioPath's index, or 0 if this AudioPath isn't indexable.
- */
+/// @return This AudioPath's index, or 0 if this AudioPath isn't indexable.
 unsigned char AudioPath::getIndex() const {
     return m_index;
 }
 
-/**
- * Checks if this AudioPath's channels clash with another's
- * (see ChannelGroup::clashesWith).
- */
+/// Checks if this AudioPath's channels clash with another's
+/// (see ChannelGroup::clashesWith).
 bool AudioPath::channelsClash(const AudioPath &other) const {
     return m_channelGroup.clashesWith(other.m_channelGroup);
 }
 
-/**
- * Returns a string describing the AudioPath for user benefit.
- */
+/// Returns a string describing the AudioPath for user benefit.
 QString AudioPath::getString() const {
     return getTrStringFromType(m_type, m_index);
 }
 
-/**
- * Returns a string given an AudioPathType.
- * @note This method is static.
- * @note For user-facing usage, see getTrStringFromType
- */
+/// Returns a string given an AudioPathType.
+/// @note This method is static.
+/// @note For user-facing usage, see getTrStringFromType
 QString AudioPath::getStringFromType(AudioPathType type) {
     switch (type) {
     case AudioPathType::Main:
@@ -128,10 +106,8 @@ QString AudioPath::getStringFromType(AudioPathType type) {
     return QObject::tr("Unknown path type %1").arg(static_cast<int>(type));
 }
 
-/**
- * Returns a translated string given an AudioPathType.
- * @note This method is static.
- */
+/// Returns a translated string given an AudioPathType.
+/// @note This method is static.
 QString AudioPath::getTrStringFromType(AudioPathType type, unsigned char index) {
     switch (type) {
     case AudioPathType::Invalid:
@@ -173,10 +149,8 @@ QString AudioPath::getTrStringFromType(AudioPathType type, unsigned char index) 
     return QObject::tr("Unknown path type %1").arg(static_cast<int>(type));
 }
 
-/**
- * Returns an AudioPathType given a string.
- * @note This method is static.
- */
+/// Returns an AudioPathType given a string.
+/// @note This method is static.
 AudioPathType AudioPath::getTypeFromString(QString string) {
     string = string.toLower();
     if (string == AudioPath::getStringFromType(AudioPathType::Main).toLower()) {
@@ -202,10 +176,8 @@ AudioPathType AudioPath::getTypeFromString(QString string) {
     }
 }
 
-/**
- * Defines whether or not an AudioPathType can be indexed.
- * @note This method is static.
- */
+/// Defines whether or not an AudioPathType can be indexed.
+/// @note This method is static.
 bool AudioPath::isIndexed(AudioPathType type) {
     switch (type) {
     case AudioPathType::Bus:
@@ -220,10 +192,8 @@ bool AudioPath::isIndexed(AudioPathType type) {
     return false;
 }
 
-/**
- * Returns an AudioPathType given an int.
- * @note This method is static.
- */
+/// Returns an AudioPathType given an int.
+/// @note This method is static.
 AudioPathType AudioPath::getTypeFromInt(int typeInt) {
     if (typeInt < 0 || typeInt >= static_cast<int>(AudioPathType::Invalid)) {
         return AudioPathType::Invalid;
@@ -247,9 +217,7 @@ unsigned char AudioPath::maxChannelsForType(AudioPathType type) {
     return 2;
 }
 
-/**
- * Constructs an AudioOutput.
- */
+/// Constructs an AudioOutput.
 AudioOutput::AudioOutput(AudioPathType type,
                          unsigned char channelBase,
                          unsigned char channels,
@@ -264,10 +232,8 @@ AudioOutput::AudioOutput(AudioPathType type,
     }
 }
 
-/**
- * Writes this AudioOutput's data to an XML element, preallocated from an XML
- * DOM document.
- */
+/// Writes this AudioOutput's data to an XML element, preallocated from an XML
+/// DOM document.
 QDomElement AudioOutput::toXML(QDomElement *element) const {
     element->setTagName("output");
     element->setAttribute("type", AudioPath::getStringFromType(m_type));
@@ -277,10 +243,8 @@ QDomElement AudioOutput::toXML(QDomElement *element) const {
     return *element;
 }
 
-/**
- * Constructs and returns an AudioOutput given an XML element representing it.
- * @note This method is static.
- */
+/// Constructs and returns an AudioOutput given an XML element representing it.
+/// @note This method is static.
 AudioOutput AudioOutput::fromXML(const QDomElement &xml) {
     AudioPathType type(AudioPath::getTypeFromString(xml.attribute("type")));
     unsigned int index(xml.attribute("index", "0").toUInt());
@@ -296,11 +260,9 @@ AudioOutput AudioOutput::fromXML(const QDomElement &xml) {
     return AudioOutput(type, channel, channels, index);
 }
 
-//static
-/**
- * Enumerates the AudioPathTypes supported by AudioOutput.
- * @note This method is static.
- */
+// static
+/// Enumerates the AudioPathTypes supported by AudioOutput.
+/// @note This method is static.
 QList<AudioPathType> AudioOutput::getSupportedTypes() {
     return QList<AudioPathType>{
             AudioPathType::Main,
@@ -312,10 +274,8 @@ QList<AudioPathType> AudioOutput::getSupportedTypes() {
     };
 }
 
-/**
- * Implements setting the type of an AudioOutput, using
- * AudioOutput::getSupportedTypes.
- */
+/// Implements setting the type of an AudioOutput, using
+/// AudioOutput::getSupportedTypes.
 void AudioOutput::setType(AudioPathType type) {
     if (AudioOutput::getSupportedTypes().contains(type)) {
         m_type = type;
@@ -324,9 +284,7 @@ void AudioOutput::setType(AudioPathType type) {
     }
 }
 
-/**
- * Constructs an AudioInput.
- */
+/// Constructs an AudioInput.
 AudioInput::AudioInput(AudioPathType type,
                        unsigned char channelBase,
                        unsigned char channels,
@@ -345,10 +303,8 @@ AudioInput::~AudioInput() {
 
 }
 
-/**
- * Writes this AudioInput's data to an XML element, preallocated from an XML
- * DOM document.
- */
+/// Writes this AudioInput's data to an XML element, preallocated from an XML
+/// DOM document.
 QDomElement AudioInput::toXML(QDomElement *element) const {
     element->setTagName("input");
     element->setAttribute("type", AudioPath::getStringFromType(m_type));
@@ -358,10 +314,8 @@ QDomElement AudioInput::toXML(QDomElement *element) const {
     return *element;
 }
 
-/**
- * Constructs and returns an AudioInput given an XML element representing it.
- * @note This method is static.
- */
+/// Constructs and returns an AudioInput given an XML element representing it.
+/// @note This method is static.
 AudioInput AudioInput::fromXML(const QDomElement &xml) {
     AudioPathType type(AudioPath::getTypeFromString(xml.attribute("type")));
     unsigned int index(xml.attribute("index", "0").toUInt());
@@ -377,10 +331,8 @@ AudioInput AudioInput::fromXML(const QDomElement &xml) {
     return AudioInput(type, channel, channels, index);
 }
 
-/**
- * Enumerates the AudioPathTypes supported by AudioInput.
- * @note This method is static.
- */
+/// Enumerates the AudioPathTypes supported by AudioInput.
+/// @note This method is static.
 QList<AudioPathType> AudioInput::getSupportedTypes() {
     return QList<AudioPathType>{
 #ifdef __VINYLCONTROL__
@@ -394,10 +346,8 @@ QList<AudioPathType> AudioInput::getSupportedTypes() {
     };
 }
 
-/**
- * Implements setting the type of an AudioInput, using
- * AudioInput::getSupportedTypes.
- */
+/// Implements setting the type of an AudioInput, using
+/// AudioInput::getSupportedTypes.
 void AudioInput::setType(AudioPathType type) {
     if (AudioInput::getSupportedTypes().contains(type)) {
         m_type = type;


### PR DESCRIPTION
I started another coffee break project to add little helper:
when you need to configure multiple sound outputs using _one_ device, like channels 1-2 for Main & 3-4 for headphones as with many controller soundcards, and you configured the first output it is very pleasant if the next free channel pair is selected automatically for the second output.
1. Main: select device XY -> channels 1-2 selected (default from populating the channels box)
2. Headphones: select device XY -> channels 3-4 are selected automatically

That saves one click (yeaiiy!!), but more importantly: it avoids mis(re-)configuration in the Heat of the Night:tm: (assign same channels twice, Apply, error, meeeh, select correct channels, Apply).

**Note:** this does just combobox index matching, i.e. does not check channel overlap like
Mic1: channel 1, Aux1: channels 1-2.

Closes #10163 

This is still WIP but it's working nicely already.
I'll do more testing and polish it.
- [x] remove DEBUG commit