### PR TITLE
tooltips: add 'track_comment'

### DIFF
--- a/src/skin/legacy/tooltips.cpp
+++ b/src/skin/legacy/tooltips.cpp
@@ -818,6 +818,15 @@ void Tooltips::addStandardTooltips() {
             << tr("Displays the musical key of the loaded track.")
             << trackTags;
 
+    add("track_comment")
+            << tr("Track Comment")
+            << tr("Displays the comment tag of the loaded track.")
+            << trackTags + "\n"
+            << dropTracksHere
+            << dragItem
+            << QString("%1: %2").arg(doubleClick, trackProperties)
+            << QString("%1: %2").arg(rightClick, trackMenu);
+
     add("text")
             << tr("Track Artist/Title")
             << tr("Displays the artist and title of the loaded track.")


### PR DESCRIPTION
Just for sake of completeness, there's currently no WTrackProperty for the comment in official skins.