### PR TITLE
Logging: Include timestamps in messages by default

### DIFF
--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -4,6 +4,7 @@
 #include <stdio.h>
 
 #include <QByteArray>
+#include <QDateTime>
 #include <QFile>
 #include <QFileInfo>
 #include <QIODevice>
@@ -121,6 +122,8 @@ inline QString formatLogFileMessage(
         QtMsgType type,
         const QString& message,
         const QString& threadName) {
+    QString timestamp = QDateTime::currentDateTime().toString("hh:mm:ss.zzz");
+
     QString levelName;
     switch (type) {
     case QtDebugMsg:
@@ -140,7 +143,7 @@ inline QString formatLogFileMessage(
         break;
     }
 
-    return levelName + QStringLiteral(" [") + threadName + QStringLiteral("] ") + message;
+    return QStringLiteral("%1 %2 [%3] %4").arg(timestamp, levelName, threadName, message);
 }
 
 /// Actually write a log message to a file.


### PR DESCRIPTION
This is a small patch that updates the log file format to include `hh:mm:ss.zzz` timestamps.

Timestamps are particularly valuable for understanding timing-related issues and the program's execution in general, and the latter would get them included in user-submitted reports. The only drawback I see is that this would result in slightly larger log files.