### PR TITLE
DlgAbout: Add Qt version to the dialog

### DIFF
--- a/src/dialog/dlgabout.cpp
+++ b/src/dialog/dlgabout.cpp
@@ -21,6 +21,7 @@ DlgAbout::DlgAbout()
     version_label->setText(VersionStore::applicationName() +
             QStringLiteral(" ") + VersionStore::version());
     git_version_label->setText(VersionStore::gitVersion());
+    qt_version_label->setText(VersionStore::qtVersion());
     platform_label->setText(VersionStore::platform());
     QLocale locale;
     date_label->setText(locale.toString(VersionStore::date().toLocalTime(), QLocale::LongFormat));

--- a/src/dialog/dlgaboutdlg.ui
+++ b/src/dialog/dlgaboutdlg.ui
@@ -110,12 +110,12 @@
         <item row="1" column="0">
          <widget class="QLabel" name="label_2">
           <property name="text">
-           <string>Date:</string>
+           <string>Qt Version:</string>
           </property>
          </widget>
         </item>
         <item row="1" column="1">
-         <widget class="QLabel" name="date_label">
+         <widget class="QLabel" name="qt_version_label">
           <property name="text">
            <string>Unknown</string>
           </property>
@@ -127,11 +127,28 @@
         <item row="2" column="0">
          <widget class="QLabel" name="label_3">
           <property name="text">
-           <string>Platform:</string>
+           <string>Date:</string>
           </property>
          </widget>
         </item>
         <item row="2" column="1">
+         <widget class="QLabel" name="date_label">
+          <property name="text">
+           <string>Unknown</string>
+          </property>
+          <property name="textInteractionFlags">
+           <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_4">
+          <property name="text">
+           <string>Platform:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
          <widget class="QLabel" name="platform_label">
           <property name="text">
            <string>Unknown</string>

--- a/src/dialog/dlgaboutdlg.ui
+++ b/src/dialog/dlgaboutdlg.ui
@@ -78,23 +78,6 @@
       </item>
       <item>
        <layout class="QGridLayout" name="gridLayout">
-        <item row="2" column="1">
-         <widget class="QLabel" name="platform_label">
-          <property name="text">
-           <string>Unknown</string>
-          </property>
-          <property name="textInteractionFlags">
-           <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_2">
-          <property name="text">
-           <string>Date:</string>
-          </property>
-         </widget>
-        </item>
         <item row="0" column="0">
          <widget class="QLabel" name="label">
           <property name="sizePolicy">
@@ -105,13 +88,6 @@
           </property>
           <property name="text">
            <string>Git Version:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_3">
-          <property name="text">
-           <string>Platform:</string>
           </property>
          </widget>
         </item>
@@ -131,8 +107,32 @@
           </property>
          </widget>
         </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Date:</string>
+          </property>
+         </widget>
+        </item>
         <item row="1" column="1">
          <widget class="QLabel" name="date_label">
+          <property name="text">
+           <string>Unknown</string>
+          </property>
+          <property name="textInteractionFlags">
+           <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_3">
+          <property name="text">
+           <string>Platform:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QLabel" name="platform_label">
           <property name="text">
            <string>Unknown</string>
           </property>

--- a/src/util/versionstore.cpp
+++ b/src/util/versionstore.cpp
@@ -1,5 +1,6 @@
 #include "util/versionstore.h"
 
+#include <qglobal.h>
 #include <soundtouch/SoundTouch.h>
 
 #include <QCoreApplication>
@@ -136,6 +137,11 @@ QString VersionStore::gitVersion() {
     }
 
     return gitVersion;
+}
+
+// static
+QString VersionStore::qtVersion() {
+    return qVersion();
 }
 
 // static

--- a/src/util/versionstore.cpp
+++ b/src/util/versionstore.cpp
@@ -1,6 +1,5 @@
 #include "util/versionstore.h"
 
-#include <qglobal.h>
 #include <soundtouch/SoundTouch.h>
 
 #include <QCoreApplication>

--- a/src/util/versionstore.h
+++ b/src/util/versionstore.h
@@ -34,6 +34,9 @@ class VersionStore {
     /// Returns the output of "git describe" and the branch name (if available)
     static QString gitVersion();
 
+    /// Returns the version of Qt used to build Mixxx.
+    static QString qtVersion();
+
     /// Returns the build flags used to build Mixxx (e.g. "hid=1 modplug=0") or
     /// the null string if the flags are unknown.
     static QString buildFlags();


### PR DESCRIPTION
A small QoL improvement that adds the Qt version to the about dialog:

![Screenshot 2023-08-25 at 00 38 17](https://github.com/mixxxdj/mixxx/assets/30873659/d978ebae-667f-4a34-999a-20c7f3f5f149)