### PR TITLE
Qt6 prepare

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1492,11 +1492,8 @@ if(WIN32)
   # max-and-std-cpp-min-not-available-in-visual-c-2010
   target_compile_definitions(mixxx-lib PUBLIC NOMINMAX UNICODE)
 
-  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-    target_compile_definitions(mixxx-lib PUBLIC WIN32)
-  else()
-    target_compile_definitions(mixxx-lib PUBLIC WIN64)
-  endif()
+  # shoutidjc/shout.h checks for WIN32 to see if we are on Windows.
+  target_compile_definitions(mixxx-lib PUBLIC WIN32)
 
   target_link_libraries(mixxx-lib PRIVATE shell32)
 

--- a/cmake/modules/FindSleef.cmake
+++ b/cmake/modules/FindSleef.cmake
@@ -1,0 +1,112 @@
+# This file is part of Mixxx, Digital DJ'ing software.
+# Copyright (C) 2001-2023 Mixxx Development Team
+# Distributed under the GNU General Public Licence (GPL) version 2 or any later
+# later version. See the LICENSE file for details.
+
+#[=======================================================================[.rst:
+FindSleef
+--------------
+
+Finds the Sleef library.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module provides the following imported targets, if found:
+
+``Sleef::sleef``
+  The Sleef library
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This will define the following variables:
+
+``Sleef_FOUND``
+  True if the system has the Sleef library.
+``Sleef_INCLUDE_DIRS``
+  Include directories needed to use Sleef.
+``Sleef_LIBRARIES``
+  Libraries needed to link to Sleef.
+``Sleef_DEFINITIONS``
+  Compile definitions needed to use Sleef.
+
+Cache Variables
+^^^^^^^^^^^^^^^
+
+The following cache variables may also be set:
+
+``Sleef_INCLUDE_DIR``
+  The directory containing ``sleef.h``.
+``Sleef_LIBRARY``
+  The path to the Sleef library.
+
+#]=======================================================================]
+
+find_package(PkgConfig QUIET)
+if(PkgConfig_FOUND)
+  pkg_check_modules(PC_Sleef QUIET sleef)
+endif()
+
+find_path(Sleef_INCLUDE_DIR
+  NAMES sleef.h
+  PATHS ${PC_sleef_INCLUDE_DIRS}
+  DOC "Sleef include directory")
+mark_as_advanced(Sleef_INCLUDE_DIR)
+
+find_library(Sleef_LIBRARY
+  NAMES ${PC_Sleef_LIBRARIES}
+  PATHS ${PC_Sleef_LIBRARY_DIRS})
+mark_as_advanced(Sleef_LIBRARY)
+
+if(DEFINED PC_Sleef_VERSION AND NOT PC_Sleef_VERSION STREQUAL "")
+  set(Sleef_VERSION "${PC_Sleef_VERSION}")
+else()
+  if (EXISTS "${sleef_INCLUDE_DIR}/sleef.h")
+    file(READ "$sleef{SLEEF_INCLUDE_DIR}/sleef.h" SLEEF_FIND_HEADER_CONTENTS)
+
+    set(SLEEF_MAJOR_PREFIX "#define SLEEF_VERSION_MAJOR ")
+    set(SLEEF_MINOR_PREFIX "#define SLEEF_VERSION_MINOR ")
+    set(SLEEF_PATCH_PREFIX "#define SLEEF_VERSION_PATCHLEVEL ")
+
+    string(REGEX MATCH "${SLEEF_MAJOR_PREFIX}[0-9]+"
+      SLEEF_MAJOR_VERSION "${SLEEF_FIND_HEADER_CONTENTS}")
+    string(REPLACE "${SLEEF_MAJOR_PREFIX}" "" SLEEF_MAJOR_VERSION
+      "${SLEEF_MAJOR_VERSION}")
+
+    string(REGEX MATCH "${SLEEF_MINOR_PREFIX}[0-9]+"
+      SLEEF_MINOR_VERSION "${SLEEF_FIND_HEADER_CONTENTS}")
+    string(REPLACE "${SLEEF_MINOR_PREFIX}" "" SLEEF_MINOR_VERSION
+      "${SLEEF_MINOR_VERSION}")
+
+    string(REGEX MATCH "${SLEEF_PATCH_PREFIX}[0-9]+"
+      SLEEF_SUBMINOR_VERSION "${SLEEF_FIND_HEADER_CONTENTS}")
+    string(REPLACE "${SLEEF_PATCH_PREFIX}" "" SLEEF_SUBMINOR_VERSION
+      "${SLEEF_SUBMINOR_VERSION}")
+
+    set(Sleef_VERSION
+      "${SLEEF_MAJOR_VERSION}.${SLEEF_MINOR_VERSION}.${SLEEF_SUBMINOR_VERSION}")
+  endif()
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  Sleef
+  REQUIRED_VARS Sleef_INCLUDE_DIR Sleef_LIBRARY
+  VERSION_VAR Sleef_VERSION)
+
+if(Sleef_FOUND)
+  set(Sleef_LIBRARIES "${Sleef_LIBRARY}")
+  set(Sleef_INCLUDE_DIRS "${Sleef_INCLUDE_DIR}")
+  set(Sleef_DEFINITIONS ${PC_Sleef_CFLAGS_OTHER})
+
+  if(NOT TARGET Sleef::sleef)
+    add_library(Sleef::sleef UNKNOWN IMPORTED)
+    set_target_properties(Sleef::sleef
+      PROPERTIES
+        IMPORTED_LOCATION "${Sleef_LIBRARY}"
+        INTERFACE_COMPILE_OPTIONS "${PC_Sleef_CFLAGS_OTHER}"
+        INTERFACE_INCLUDE_DIRECTORIES "${Sleef_INCLUDE_DIR}"
+    )
+  endif()
+endif()

--- a/cmake/modules/Findrubberband.cmake
+++ b/cmake/modules/Findrubberband.cmake
@@ -85,14 +85,32 @@ if(rubberband_FOUND)
         INTERFACE_COMPILE_OPTIONS "${PC_rubberband_CFLAGS_OTHER}"
         INTERFACE_INCLUDE_DIRECTORIES "${rubberband_INCLUDE_DIR}"
     )
-    is_static_library(rubberband_IS_STATIC Chromaprint::Chromaprint)
+    is_static_library(rubberband_IS_STATIC rubberband::rubberband)
     if(rubberband_IS_STATIC)
-      find_package(FFTW REQUIRED)
       find_library(SAMPLERATE_LIBRARY samplerate REQUIRED)
       set_property(TARGET rubberband::rubberband APPEND PROPERTY INTERFACE_LINK_LIBRARIES
-        FFTW::FFTW
         ${SAMPLERATE_LIBRARY}
       )
+      find_package(FFTW)
+      if (FFTW_FOUND)
+        set_property(TARGET rubberband::rubberband APPEND PROPERTY INTERFACE_LINK_LIBRARIES
+          FFTW::FFTW
+        )
+      endif()
+      find_package(FFTW)
+      if (FFTW_FOUND)
+        set_property(TARGET rubberband::rubberband APPEND PROPERTY INTERFACE_LINK_LIBRARIES
+          FFTW::FFTW
+        )
+      endif()
+      find_package(Sleef)
+      if (Sleef_FOUND)
+        find_library(sleefdft_path sleefdft REQUIRED)
+        set_property(TARGET rubberband::rubberband APPEND PROPERTY INTERFACE_LINK_LIBRARIES
+          Sleef::sleef
+          ${sleefdft_path}
+        )
+      endif()
     endif()
   endif()
 endif()

--- a/cmake/modules/Findrubberband.cmake
+++ b/cmake/modules/Findrubberband.cmake
@@ -97,12 +97,6 @@ if(rubberband_FOUND)
           FFTW::FFTW
         )
       endif()
-      find_package(FFTW)
-      if (FFTW_FOUND)
-        set_property(TARGET rubberband::rubberband APPEND PROPERTY INTERFACE_LINK_LIBRARIES
-          FFTW::FFTW
-        )
-      endif()
       find_package(Sleef)
       if (Sleef_FOUND)
         find_library(sleefdft_path sleefdft REQUIRED)

--- a/src/broadcast/broadcastmanager.cpp
+++ b/src/broadcast/broadcastmanager.cpp
@@ -1,11 +1,4 @@
-// shout.h checks for WIN32 to see if we are on Windows.
-#ifdef WIN64
-#define WIN32
-#endif
 #include <shoutidjc/shout.h>
-#ifdef WIN64
-#undef WIN32
-#endif
 
 #include "broadcast/broadcastmanager.h"
 #include "broadcast/defs_broadcast.h"

--- a/src/engine/sidechain/shoutconnection.cpp
+++ b/src/engine/sidechain/shoutconnection.cpp
@@ -6,14 +6,7 @@
 #include <unistd.h>
 #endif
 
-// shout.h checks for WIN32 to see if we are on Windows.
-#ifdef WIN64
-#define WIN32
-#endif
 #include <shoutidjc/shout.h>
-#ifdef WIN64
-#undef WIN32
-#endif
 
 #include "broadcast/defs_broadcast.h"
 #include "control/controlpushbutton.h"

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1381,7 +1381,7 @@ TrackPointer TrackDAO::getTrackById(TrackId trackId) const {
         QString columnsStr;
         int columnsSize = 0;
         for (int i = 0; i < columnsCount; ++i) {
-            columnsSize += qstrlen(columns[i].name) + 1;
+            columnsSize += static_cast<int>(qstrlen(columns[i].name)) + 1;
         }
         columnsStr.reserve(columnsSize);
         for (int i = 0; i < columnsCount; ++i) {

--- a/src/preferences/dialog/dlgprefbroadcast.cpp
+++ b/src/preferences/dialog/dlgprefbroadcast.cpp
@@ -6,15 +6,8 @@
 #include <QMessageBox>
 #include <QHeaderView>
 
-// shout.h checks for WIN32 to see if we are on Windows
-#ifdef WIN64
-#define WIN32
-#endif
 // this is needed to define SHOUT_META_* macros used in version guard
 #include <shoutidjc/shout.h>
-#ifdef WIN64
-#undef WIN32
-#endif
 
 #include "broadcast/defs_broadcast.h"
 #include "control/controlproxy.h"

--- a/src/util/versionstore.cpp
+++ b/src/util/versionstore.cpp
@@ -8,15 +8,8 @@
 #include <QtDebug>
 #include <QtGlobal>
 
-// shout.h checks for WIN32 to see if we are on Windows.
-#ifdef WIN64
-#define WIN32
-#endif
 #ifdef __BROADCAST__
 #include <shoutidjc/shout.h>
-#endif
-#ifdef WIN64
-#undef WIN32
 #endif
 
 #include <FLAC/format.h>


### PR DESCRIPTION
It turns out that this is required to build main with the new Qt6 vcpkg environment. 
I like to merge this first to verify the Qt5 compatibility which I like to maintain during 2.5 beta to be able to compare certain behaviors.

* Sleef is a FFT library used on macOS from Rubberband 3.1
* The logic around WIN32/WIN64 definitions was inverted which proves that it was wrong. The WIN32 define is correct even on a 64 bit system, because it has still the so called WIN32 API.  