### PR TITLE
WWidget: Disable touch events on macOS (fixing trackpad issues on Qt 6)

### DIFF
--- a/src/widget/wwidget.cpp
+++ b/src/widget/wwidget.cpp
@@ -14,7 +14,9 @@ WWidget::WWidget(QWidget* parent, Qt::WindowFlags flags)
           m_scaleFactor(1.0) {
     m_pTouchShift = new ControlProxy("[Controls]", "touch_shift");
     setAttribute(Qt::WA_StaticContents);
+#ifndef __APPLE__
     setAttribute(Qt::WA_AcceptTouchEvents);
+#endif
     setFocusPolicy(Qt::ClickFocus);
 }
 

--- a/src/widget/wwidget.cpp
+++ b/src/widget/wwidget.cpp
@@ -14,6 +14,14 @@ WWidget::WWidget(QWidget* parent, Qt::WindowFlags flags)
           m_scaleFactor(1.0) {
     m_pTouchShift = new ControlProxy("[Controls]", "touch_shift");
     setAttribute(Qt::WA_StaticContents);
+    // Touch events are disabled on macOS to work around the issue that Mac
+    // trackpad events are not processed correctly with Qt 6. Since these events
+    // aren't needed anyway, we can safely disable them. Once upstream (Qt)
+    // fixes the issue, the `#ifndef` can be removed to re-enable touch events.
+    // For details on both the issue and the fix, see
+    // - https://bugreports.qt.io/browse/QTBUG-103935?focusedId=739905#comment-739905
+    // - https://github.com/mixxxdj/mixxx/issues/11869
+    // - https://github.com/mixxxdj/mixxx/pull/11870
 #ifndef __APPLE__
     setAttribute(Qt::WA_AcceptTouchEvents);
 #endif


### PR DESCRIPTION
This fixes #11869, an issue where Mac trackpad events wouldn't be recognized correctly on Qt 6.

Since there are no touchscreen Macs, disabling it until [the issue is fixed in Qt](https://bugreports.qt.io/browse/QTBUG-103935?focusedId=739905&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-739905) seems like a workable solution.

Unfortunately, this fix cannot be tested as-is, since `main` doesn't build with Qt 6 yet, it has to be rebased onto [`qt6_switch`](https://github.com/daschuer/mixxx/tree/qt6_switch). Since it's sufficiently trivial, I would consider it safe to merge though.