### PR TITLE
CMakeLists: Add `QT_RELEASE` flag to force linking a release build of Qt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,7 @@ endif()
 option(QT6 "Build with Qt6" OFF)
 option(QML "Build with QML" OFF)
 option(QOPENGL "Use QOpenGLWindow based widget instead of QGLWidget" ON)
+option(QT_RELEASE "Always build with a release version of Qt, even in Debug mode" OFF)
 
 if(QML AND NOT QT6)
   message(FATAL_ERROR "Building with option QML=ON requires QT6=ON")
@@ -2404,42 +2405,52 @@ if(QT6)
 else()
   find_package(QT 5.12 NAMES Qt5 COMPONENTS Core REQUIRED)
 endif()
+set(QT_COMPONENTS
+  Concurrent
+  Core
+  Gui
+  Network
+  OpenGL
+  PrintSupport
+  Qml
+  QuickWidgets
+  Sql
+  Svg
+  Test
+  Widgets
+  Xml
+)
 find_package(Qt${QT_VERSION_MAJOR}
   COMPONENTS
-    Concurrent
-    Core
-    Gui
-    Network
-    OpenGL
-    PrintSupport
-    Qml
-    QuickWidgets
-    Sql
-    Svg
-    Test
-    Widgets
-    Xml
+    ${QT_COMPONENTS}
     ${QT6_NEW_COMPONENTS}
   REQUIRED
 )
-# PUBLIC is required below to find included headers
-target_link_libraries(mixxx-lib PUBLIC
-  Qt${QT_VERSION_MAJOR}::Concurrent
-  Qt${QT_VERSION_MAJOR}::Core
-  Qt${QT_VERSION_MAJOR}::Gui
-  Qt${QT_VERSION_MAJOR}::Network
-  Qt${QT_VERSION_MAJOR}::OpenGL
-  Qt${QT_VERSION_MAJOR}::PrintSupport
-  Qt${QT_VERSION_MAJOR}::Qml
-  Qt${QT_VERSION_MAJOR}::QuickWidgets
-  Qt${QT_VERSION_MAJOR}::Sql
-  Qt${QT_VERSION_MAJOR}::Svg
-  Qt${QT_VERSION_MAJOR}::Test
-  Qt${QT_VERSION_MAJOR}::Widgets
-  Qt${QT_VERSION_MAJOR}::Xml)
+foreach(COMPONENT ${QT_COMPONENTS})
+  # PUBLIC is required below to find included headers
+  target_link_libraries(mixxx-lib PUBLIC Qt${QT_VERSION_MAJOR}::${COMPONENT})
+  if(QT_RELEASE)
+    set_target_properties(
+      Qt${QT_VERSION_MAJOR}::${COMPONENT}
+      PROPERTIES
+      MAP_IMPORTED_CONFIG_RELEASE Release
+      MAP_IMPORTED_CONFIG_DEBUG Release
+      MAP_IMPORTED_CONFIG_RELWITHDEBUGINFO Release
+    )
+  endif()
+endforeach()
 if(QT6)
   foreach(COMPONENT ${QT6_NEW_COMPONENTS})
     target_link_libraries(mixxx-lib PUBLIC Qt6::${COMPONENT})
+    if(QT_RELEASE)
+      set_target_properties(
+        Qt6::${COMPONENT}
+        PROPERTIES
+        MAP_IMPORTED_CONFIG_RELEASE Release
+        MAP_IMPORTED_CONFIG_DEBUG Release
+        MAP_IMPORTED_CONFIG_RELWITHDEBUGINFO Release
+      )
+    endif()
   endforeach()
 endif()
 


### PR DESCRIPTION
Qt 6 debug builds can be quite slow, especially during startup (~20 seconds for debug builds, ~3 seconds for release builds of Qt). To get around this issue during development, this introduces a new flag, `QT_RELEASE` that lets the user build Mixxx in debug mode while still linking release binaries of Qt.

The approach is based on

- https://stackoverflow.com/questions/58402517/how-to-link-to-release-build-of-qt-in-cmake-with-debug-build
- https://stackoverflow.com/questions/57223210/cmake-link-to-only-release-config-of-target-in-both-debug-and-release/57223840#57223840

> Side note: While mixing release and debug binaries seems to be discouraged on Windows, it seems to be fine and even encouraged on Linux/macOS. See [this thread](https://stackoverflow.com/questions/11658915/mixing-debug-and-release-library-binary-bad-practice) for details. In any case, the flag is opt-in, so it wouldn't break anything about the current build.