### PR TITLE
AnalyzerThread: Pass `AnalyzerTrack` correctly again

### DIFF
--- a/src/analyzer/analyzerthread.cpp
+++ b/src/analyzer/analyzerthread.cpp
@@ -144,7 +144,7 @@ void AnalyzerThread::doRun() {
         for (auto&& analyzer : m_analyzers) {
             // Make sure not to short-circuit initialize(...)
             if (analyzer.initialize(
-                        m_currentTrack->getTrack(),
+                        *m_currentTrack,
                         audioSource->getSignalInfo().getSampleRate(),
                         audioSource->frameLength())) {
                 processTrack = true;

--- a/src/analyzer/analyzertrack.h
+++ b/src/analyzer/analyzertrack.h
@@ -12,7 +12,7 @@ class AnalyzerTrack {
         std::optional<bool> useFixedTempo;
     };
 
-    AnalyzerTrack(TrackPointer track, Options options = Options());
+    explicit AnalyzerTrack(TrackPointer track, Options options = Options());
 
     /// Fetches the (not-null) track to be analyzed.
     const TrackPointer& getTrack() const;

--- a/src/test/analyserwaveformtest.cpp
+++ b/src/test/analyserwaveformtest.cpp
@@ -4,6 +4,7 @@
 #include <QtDebug>
 #include <vector>
 
+#include "analyzer/analyzertrack.h"
 #include "analyzer/analyzerwaveform.h"
 #include "library/dao/analysisdao.h"
 #include "test/mixxxtest.h"
@@ -100,7 +101,7 @@ class AnalyzerWaveformTest : public MixxxTest {
 
 // Basic test to make sure we don't alter the input buffer and don't step out of bounds.
 TEST_F(AnalyzerWaveformTest, canary) {
-    m_aw.initialize(m_pTrack,
+    m_aw.initialize(AnalyzerTrack(m_pTrack),
             m_pTrack->getSampleRate(),
             kBigBufSize / kChannelCount);
     m_aw.processSamples(&m_canaryBigBuf[kCanarySize], kBigBufSize);

--- a/src/test/analyzersilence_test.cpp
+++ b/src/test/analyzersilence_test.cpp
@@ -4,6 +4,7 @@
 
 #include <vector>
 
+#include "analyzer/analyzertrack.h"
 #include "engine/engine.h"
 #include "test/mixxxtest.h"
 #include "track/track.h"
@@ -37,7 +38,7 @@ class AnalyzerSilenceTest : public MixxxTest {
     }
 
     void analyzeTrack() {
-        analyzerSilence.initialize(pTrack,
+        analyzerSilence.initialize(AnalyzerTrack(pTrack),
                 pTrack->getSampleRate(),
                 kTrackLengthFrames);
         analyzerSilence.processSamples(pTrackSampleData.data(), nTrackSampleDataLength);


### PR DESCRIPTION
### Fixes #11872 

With this patch, overriding the constant/variable tempo analysis via the `Reanalyze` menu will work correctly again. Additionally, the `AnalyzerTrack` constructor is now `explicit`, to make this kind of regression harder to overlook in the future.