### PR TITLE
Fix zeros in the first m4a chunk on Linux

### DIFF
--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -929,13 +929,13 @@ bool SoundSourceFFmpeg::adjustCurrentPosition(SINT startIndex) {
     // Need to seek to a new position before continue reading. For
     // sample accurate decoding the actual seek position must be
     // placed BEFORE the position where reading continues.
-    auto seekIndex =
-            math_max(static_cast<SINT>(0), startIndex - m_seekPrerollFrameCount);
+    // At the beginning of the stream, this is a negative position.
+    auto seekIndex = startIndex - m_seekPrerollFrameCount;
+
     // Seek to codec frame boundaries if the frame size is fixed and known
     if (m_pavStream->codecpar->frame_size > 0) {
         seekIndex -= seekIndex % m_pavCodecContext->frame_size;
     }
-    DEBUG_ASSERT(seekIndex >= 0);
     DEBUG_ASSERT(seekIndex <= startIndex);
 
     if (m_frameBuffer.tryContinueReadingFrom(seekIndex)) {


### PR DESCRIPTION
This starts decoding of the first frame with the required preroll, going to < 1. 
Before the reading of the peroll in this region has been skipped (clamped to zero). 
Now the FFmpeg soundsource is head up with CoreAudio

Red Line before, Blue line after.  

 
![grafik](https://github.com/mixxxdj/mixxx/assets/1777442/d0106f8b-bc31-4bad-ba4a-f8adc3049b10)

This fixes #11878

The issue has been discovered by a SoundSourceProxyTest.firstSoundTest in my pipeline. 

Unfortunately this fix required a waveform re-analyzis if the first sound starts in this region (0 ... 23 ms) 
This fix does not introduce an offset so that cue points are not shiftet. 
  


