### PR TITLE
CMakeLists: Fix `QT_TRANSLATION_FILE` path for Qt 6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2646,7 +2646,7 @@ if(APPLE OR WIN32)
   # qt_de.qm is just one arbitrary file in the directory that needs to be located;
   # there is no particular reason to look for this file versus any other one in the directory.
   if(QT6)
-    find_file(QT_TRANSLATION_FILE qt_de.qm PATHS "${Qt6_DIR}/../../../translations" "${Qt6_DIR}/../../qt5/translations" REQUIRED NO_DEFAULT_PATH)
+    find_file(QT_TRANSLATION_FILE qt_de.qm PATHS "${Qt6_DIR}/../../translations/Qt6" REQUIRED NO_DEFAULT_PATH)
   else()
     find_file(QT_TRANSLATION_FILE qt_de.qm PATHS "${Qt5_DIR}/../../../translations" "${Qt5_DIR}/../../qt5/translations" REQUIRED NO_DEFAULT_PATH)
   endif()


### PR DESCRIPTION
This fixes the (currently broken) Qt 6 configure for me. It is effectively an adaptation of 06aec1dfe482c073f759e43cf47f7e17c2600487 from the [`qt6_switch`](https://github.com/daschuer/mixxx/tree/qt6_switch) branch, which, however, still uses the `Qt5_DIR` variable instead of `Qt6_DIR` (not sure why that worked in the first place).

cc @daschuer 