### PR TITLE
add `ConfigObject::get-/setValue<EnumType>`

### DIFF
--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -2250,10 +2250,7 @@ bool CueControl::isTrackAtIntroCue() {
 }
 
 SeekOnLoadMode CueControl::getSeekOnLoadPreference() {
-    int configValue =
-            getConfig()->getValue(ConfigKey("[Controls]", "CueRecall"),
-                    static_cast<int>(SeekOnLoadMode::IntroStart));
-    return static_cast<SeekOnLoadMode>(configValue);
+    return getConfig()->getValue(ConfigKey("[Controls]", "CueRecall"), SeekOnLoadMode::IntroStart);
 }
 
 void CueControl::hotcueFocusColorPrev(double value) {

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -174,8 +174,9 @@ EngineMaster::EngineMaster(
     m_pXFaderReverse->setButtonMode(ControlPushButton::TOGGLE);
 
     m_pKeylockEngine = new ControlObject(ConfigKey(group, "keylock_engine"), true, false, true);
-    m_pKeylockEngine->set(pConfig->getValue(ConfigKey(group, "keylock_engine"),
-            static_cast<double>(EngineBuffer::defaultKeylockEngine())));
+    m_pKeylockEngine->set(static_cast<double>(
+            pConfig->getValue(ConfigKey(group, "keylock_engine"),
+                    EngineBuffer::defaultKeylockEngine())));
 
     // TODO: Make this read only and make EngineMaster decide whether
     // processing the master mix is necessary.

--- a/src/engine/sync/enginesync.cpp
+++ b/src/engine/sync/enginesync.cpp
@@ -252,10 +252,9 @@ Syncable* EngineSync::pickLeader(Syncable* enabling_syncable) {
             stopped_deck_count++;
         }
     }
-
-    const SyncLockAlgorithm picker = static_cast<SyncLockAlgorithm>(
-            m_pConfig->getValue<int>(ConfigKey("[BPM]", "sync_lock_algorithm"),
-                    PREFER_IMPLICIT_LEADER));
+    const SyncLockAlgorithm picker = m_pConfig->getValue(
+            ConfigKey("[BPM]", "sync_lock_algorithm"),
+            PREFER_IMPLICIT_LEADER);
     switch (picker) {
     case PREFER_IMPLICIT_LEADER:
         // Always pick a deck for a new leader.

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -176,10 +176,8 @@ AutoDJProcessor::AutoDJProcessor(
         m_transitionTime = str_autoDjTransition.toDouble();
     }
 
-    int configuredTransitionMode = m_pConfig->getValue(
-            ConfigKey(kConfigKey, kTransitionModePreferenceName),
-            static_cast<int>(TransitionMode::FullIntroOutro));
-    m_transitionMode = static_cast<TransitionMode>(configuredTransitionMode);
+    m_transitionMode = m_pConfig->getValue(
+            ConfigKey(kConfigKey, kTransitionModePreferenceName), TransitionMode::FullIntroOutro);
 }
 
 AutoDJProcessor::~AutoDJProcessor() {

--- a/src/library/autodj/dlgautodj.cpp
+++ b/src/library/autodj/dlgautodj.cpp
@@ -354,8 +354,7 @@ void DlgAutoDJ::slotTransitionModeChanged(int newIndex) {
     ControlObject::set(ConfigKey("[Library]", "refocus_prev_widget"), 1);
 }
 
-void DlgAutoDJ::slotRepeatPlaylistChanged(int checkState) {
-    bool checked = static_cast<bool>(checkState);
+void DlgAutoDJ::slotRepeatPlaylistChanged(bool checked) {
     m_pConfig->setValue(ConfigKey(kPreferenceGroupName, kRepeatPlaylistPreference),
             checked);
 }

--- a/src/library/autodj/dlgautodj.h
+++ b/src/library/autodj/dlgautodj.h
@@ -48,7 +48,7 @@ class DlgAutoDJ : public QWidget, public Ui::DlgAutoDJ, public LibraryView {
     void autoDJStateChanged(AutoDJProcessor::AutoDJState state);
     void updateSelectionInfo();
     void slotTransitionModeChanged(int comboboxIndex);
-    void slotRepeatPlaylistChanged(int checkedState);
+    void slotRepeatPlaylistChanged(bool checked);
 
   signals:
     void addRandomTrackButton(bool buttonChecked);

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -544,9 +544,8 @@ void DlgTagFetcher::slotCoverFound(
 
 void DlgTagFetcher::slotStartFetchCoverArt(const QList<QString>& allUrls) {
     DlgPrefLibrary::CoverArtFetcherQuality fetcherQuality =
-            static_cast<DlgPrefLibrary::CoverArtFetcherQuality>(
-                    m_pConfig->getValue(mixxx::library::prefs::kCoverArtFetcherQualityConfigKey,
-                            static_cast<int>(DlgPrefLibrary::CoverArtFetcherQuality::Medium)));
+            m_pConfig->getValue(mixxx::library::prefs::kCoverArtFetcherQualityConfigKey,
+                    DlgPrefLibrary::CoverArtFetcherQuality::Medium);
 
     // Cover art links task can retrieve us variable number of links with different cover art sizes
     // Every single successful response has 2 links.

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -577,7 +577,7 @@ void BaseTrackPlayerImpl::slotTrackLoaded(TrackPointer pNewTrack,
         }
 
         if (!m_pChannelToCloneFrom) {
-            int reset = m_pConfig->getValue<int>(
+            BaseTrackPlayer::TrackLoadReset reset = m_pConfig->getValue(
                     ConfigKey("[Controls]", "SpeedAutoReset"), RESET_PITCH);
             if (reset == RESET_SPEED || reset == RESET_PITCH_AND_SPEED) {
                 // Avoid resetting speed if sync lock is enabled and other decks with sync enabled

--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -696,10 +696,8 @@ void PlayerManager::slotLoadLocationToPlayer(
 void PlayerManager::slotLoadLocationToPlayerMaybePlay(
         const QString& location, const QString& group) {
     bool play = false;
-    LoadWhenDeckPlaying loadWhenDeckPlaying =
-            static_cast<LoadWhenDeckPlaying>(
-                    m_pConfig->getValue(kConfigKeyLoadWhenDeckPlaying,
-                            static_cast<int>(kDefaultLoadWhenDeckPlaying)));
+    LoadWhenDeckPlaying loadWhenDeckPlaying = m_pConfig->getValue(
+            kConfigKeyLoadWhenDeckPlaying, kDefaultLoadWhenDeckPlaying);
     switch (loadWhenDeckPlaying) {
     case LoadWhenDeckPlaying::AllowButStopDeck:
     case LoadWhenDeckPlaying::Reject:

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -176,9 +176,9 @@ void MixxxMainWindow::initialize() {
     UserSettingsPointer pConfig = m_pCoreServices->getSettings();
 
     // Set the visibility of tooltips, default "1" = ON
-    m_toolTipsCfg = static_cast<mixxx::TooltipsPreference>(
-            pConfig->getValue(ConfigKey("[Controls]", "Tooltips"),
-                    static_cast<int>(mixxx::TooltipsPreference::TOOLTIPS_ON)));
+    m_toolTipsCfg = pConfig->getValue(
+            ConfigKey("[Controls]", "Tooltips"),
+            mixxx::TooltipsPreference::TOOLTIPS_ON);
 #ifdef MIXXX_USE_QOPENGL
     ToolTipQOpenGL::singleton().setActive(m_toolTipsCfg == mixxx::TooltipsPreference::TOOLTIPS_ON);
 #endif

--- a/src/preferences/dialog/dlgprefautodj.cpp
+++ b/src/preferences/dialog/dlgprefautodj.cpp
@@ -18,9 +18,8 @@ DlgPrefAutoDJ::DlgPrefAutoDJ(QWidget* pParent,
             &DlgPrefAutoDJ::slotSetMinimumAvailable);
 
     // The auto-DJ replay-age for randomly-selected tracks
-    RequeueIgnoreCheckBox->setChecked(
-            (bool)m_pConfig->getValue(
-                    ConfigKey("[Auto DJ]", "UseIgnoreTime"), 0));
+    RequeueIgnoreCheckBox->setChecked(m_pConfig->getValue(
+            ConfigKey("[Auto DJ]", "UseIgnoreTime"), false));
     connect(RequeueIgnoreCheckBox,
             &QCheckBox::stateChanged,
             this,
@@ -38,9 +37,8 @@ DlgPrefAutoDJ::DlgPrefAutoDJ(QWidget* pParent,
             &DlgPrefAutoDJ::slotSetRequeueIgnoreTime);
 
     // Auto DJ random enqueue
-    RandomQueueCheckBox->setChecked(
-            (bool)m_pConfig->getValue(
-                    ConfigKey("[Auto DJ]", "EnableRandomQueue"), 0));
+    RandomQueueCheckBox->setChecked(m_pConfig->getValue(
+            ConfigKey("[Auto DJ]", "EnableRandomQueue"), false));
     // 5-arbitrary
     RandomQueueMinimumSpinBox->setValue(
             m_pConfig->getValue(
@@ -48,10 +46,12 @@ DlgPrefAutoDJ::DlgPrefAutoDJ(QWidget* pParent,
     // "[Auto DJ], Requeue" is set by 'Repeat Playlist' toggle in DlgAutoDj GUI.
     // If it's checked un-check 'Random Queue'
     slotConsiderRepeatPlaylistState(
-            m_pConfig->getValueString(ConfigKey("[Auto DJ]", "Requeue")).toInt());
+            m_pConfig->getValue<bool>(ConfigKey("[Auto DJ]", "Requeue")));
     slotToggleRandomQueue(
-            m_pConfig->getValue<int>(
-                    ConfigKey("[Auto DJ]", "EnableRandomQueue")));
+            m_pConfig->getValue<bool>(
+                    ConfigKey("[Auto DJ]", "EnableRandomQueue"))
+                    ? Qt::Checked
+                    : Qt::Unchecked);
     // Be ready to enable and modify the minimum number and un/check the checkbox
     connect(RandomQueueCheckBox,
             &QCheckBox::stateChanged,
@@ -63,9 +63,6 @@ DlgPrefAutoDJ::DlgPrefAutoDJ(QWidget* pParent,
             &DlgPrefAutoDJ::slotSetRandomQueueMin);
 
     setScrollSafeGuardForAllInputWidgets(this);
-}
-
-DlgPrefAutoDJ::~DlgPrefAutoDJ() {
 }
 
 void DlgPrefAutoDJ::slotUpdate() {
@@ -82,14 +79,14 @@ void DlgPrefAutoDJ::slotApply() {
                     ConfigKey("[Auto DJ]", "IgnoreTimeBuff"), "23:59"));
     m_pConfig->setValue(ConfigKey("[Auto DJ]", "UseIgnoreTime"),
             m_pConfig->getValue(
-                    ConfigKey("[Auto DJ]", "UseIgnoreTimeBuff"), "0"));
+                    ConfigKey("[Auto DJ]", "UseIgnoreTimeBuff"), false));
 
     m_pConfig->setValue(ConfigKey("[Auto DJ]", "RandomQueueMinimumAllowed"),
             m_pConfig->getValue(
                     ConfigKey("[Auto DJ]", "RandomQueueMinimumAllowedBuff"), 5));
     m_pConfig->setValue(ConfigKey("[Auto DJ]", "EnableRandomQueue"),
             m_pConfig->getValue(
-                    ConfigKey("[Auto DJ]", "EnableRandomQueueBuff"), 0));
+                    ConfigKey("[Auto DJ]", "EnableRandomQueueBuff"), false));
 }
 
 void DlgPrefAutoDJ::slotCancel() {
@@ -110,7 +107,7 @@ void DlgPrefAutoDJ::slotCancel() {
             RequeueIgnoreCheckBox->checkState() == Qt::Checked);
     m_pConfig->setValue(ConfigKey("[Auto DJ]", "UseIgnoreTimeBuff"),
             m_pConfig->getValue(
-                    ConfigKey("[Auto DJ]", "UseIgnoreTime"), 0));
+                    ConfigKey("[Auto DJ]", "UseIgnoreTime"), false));
 
     RandomQueueMinimumSpinBox->setValue(
             m_pConfig->getValue(
@@ -120,12 +117,14 @@ void DlgPrefAutoDJ::slotCancel() {
                     ConfigKey("[Auto DJ]", "EnableRandomQueue"), false));
     m_pConfig->setValue(ConfigKey("[Auto DJ]", "EnableRandomQueueBuff"),
             m_pConfig->getValue(
-                    ConfigKey("[Auto DJ]", "EnableRandomQueue"), 0));
+                    ConfigKey("[Auto DJ]", "EnableRandomQueue"), false));
     slotToggleRandomQueue(
             m_pConfig->getValue(
-                    ConfigKey("[Auto DJ]", "EnableRandomQueue"), 0));
+                    ConfigKey("[Auto DJ]", "EnableRandomQueue"), false)
+                    ? Qt::Checked
+                    : Qt::Unchecked);
     slotToggleRandomQueue(
-            m_pConfig->getValue<int>(ConfigKey("[Auto DJ]", "Requeue")));
+            m_pConfig->getValue<bool>(ConfigKey("[Auto DJ]", "Requeue")));
 }
 
 void DlgPrefAutoDJ::slotResetToDefaults() {
@@ -135,50 +134,44 @@ void DlgPrefAutoDJ::slotResetToDefaults() {
     RequeueIgnoreTimeEdit->setTime(QTime::fromString(
             "23:59", RequeueIgnoreTimeEdit->displayFormat()));
     RequeueIgnoreCheckBox->setChecked(false);
-    m_pConfig->set(ConfigKey("[Auto DJ]", "UseIgnoreTimeBuff"),QString("0"));
+    m_pConfig->setValue(ConfigKey("[Auto DJ]", "UseIgnoreTimeBuff"), false);
     RequeueIgnoreTimeEdit->setEnabled(false);
 
     RandomQueueMinimumSpinBox->setValue(5);
     RandomQueueCheckBox->setChecked(false);
-    m_pConfig->set(ConfigKey("[Auto DJ]", "EnableRandomQueueBuff"),QString("0"));
+    m_pConfig->setValue(ConfigKey("[Auto DJ]", "EnableRandomQueueBuff"), false);
     RandomQueueMinimumSpinBox->setEnabled(false);
     RandomQueueCheckBox->setEnabled(true);
 }
 
 void DlgPrefAutoDJ::slotSetMinimumAvailable(int a_iValue) {
-    QString str;
-    str.setNum(a_iValue);
-    m_pConfig->set(ConfigKey("[Auto DJ]","MinimumAvailableBuff"),str);
+    m_pConfig->setValue(ConfigKey("[Auto DJ]", "MinimumAvailableBuff"), a_iValue);
 }
 
-void DlgPrefAutoDJ::slotToggleRequeueIgnore(int a_iState) {
-    bool bChecked = (a_iState == Qt::Checked);
-    QString strChecked = (bChecked) ? "1" : "0";
-    m_pConfig->set(ConfigKey("[Auto DJ]", "UseIgnoreTimeBuff"), strChecked);
-    RequeueIgnoreTimeEdit->setEnabled(bChecked);
+void DlgPrefAutoDJ::slotToggleRequeueIgnore(int buttonState) {
+    bool checked = buttonState == Qt::Checked;
+    m_pConfig->setValue(ConfigKey("[Auto DJ]", "UseIgnoreTimeBuff"), checked);
+    RequeueIgnoreTimeEdit->setEnabled(checked);
 }
 
 void DlgPrefAutoDJ::slotSetRequeueIgnoreTime(const QTime& a_rTime) {
     QString str = a_rTime.toString(RequeueIgnoreTimeEdit->displayFormat());
-    m_pConfig->set(ConfigKey("[Auto DJ]", "IgnoreTimeBuff"),str);
+    m_pConfig->set(ConfigKey("[Auto DJ]", "IgnoreTimeBuff"), str);
 }
 
 void DlgPrefAutoDJ::slotSetRandomQueueMin(int a_iValue) {
-    QString str;
-    //qDebug() << "min allowed " << a_iValue;
-    str.setNum(a_iValue);
-    m_pConfig->set(ConfigKey("[Auto DJ]", "RandomQueueMinimumAllowedBuff"), str);
+    m_pConfig->setValue(ConfigKey("[Auto DJ]", "RandomQueueMinimumAllowedBuff"), a_iValue);
 }
 
-void DlgPrefAutoDJ::slotConsiderRepeatPlaylistState(int a_iValue) {
-    if (a_iValue == 1) {
+void DlgPrefAutoDJ::slotConsiderRepeatPlaylistState(bool enable) {
+    if (enable) {
         // Requeue is enabled
         RandomQueueCheckBox->setChecked(false);
         // ToDo(ronso0): Redundant? If programmatic checkbox change is signaled
         // to slotToggleRandomQueue
         RandomQueueMinimumSpinBox->setEnabled(false);
-        m_pConfig->set(ConfigKey("[Auto DJ]", "EnableRandomQueueBuff"),
-                ConfigValue(0));
+        m_pConfig->setValue(ConfigKey("[Auto DJ]", "EnableRandomQueueBuff"),
+                false);
     } else {
         RandomQueueMinimumSpinBox->setEnabled(
                 m_pConfig->getValue(
@@ -186,15 +179,10 @@ void DlgPrefAutoDJ::slotConsiderRepeatPlaylistState(int a_iValue) {
     }
 }
 
-void DlgPrefAutoDJ::slotToggleRandomQueue(int a_iValue) {
+void DlgPrefAutoDJ::slotToggleRandomQueue(int buttonState) {
+    bool enable = buttonState == Qt::Checked;
     // Toggle the option to select minimum tracks
-    if (a_iValue == 0) {
-        RandomQueueMinimumSpinBox->setEnabled(false);
-        m_pConfig->set(ConfigKey("[Auto DJ]", "EnableRandomQueueBuff"),
-                ConfigValue(0));
-    } else {
-        RandomQueueMinimumSpinBox->setEnabled(true);
-        m_pConfig->set(ConfigKey("[Auto DJ]", "EnableRandomQueueBuff"),
-                ConfigValue(1));
-    }
+    RandomQueueMinimumSpinBox->setEnabled(enable);
+    m_pConfig->setValue(ConfigKey("[Auto DJ]", "EnableRandomQueueBuff"),
+            enable);
 }

--- a/src/preferences/dialog/dlgprefautodj.h
+++ b/src/preferences/dialog/dlgprefautodj.h
@@ -10,7 +10,6 @@ class DlgPrefAutoDJ : public DlgPreferencePage, public Ui::DlgPrefAutoDJDlg {
     Q_OBJECT
   public:
     DlgPrefAutoDJ(QWidget* pParent, UserSettingsPointer pConfig);
-    virtual ~DlgPrefAutoDJ();
 
   public slots:
     void slotUpdate() override;
@@ -20,11 +19,11 @@ class DlgPrefAutoDJ : public DlgPreferencePage, public Ui::DlgPrefAutoDJDlg {
 
   private slots:
     void slotSetMinimumAvailable(int);
-    void slotToggleRequeueIgnore(int);
+    void slotToggleRequeueIgnore(int buttonState);
     void slotSetRequeueIgnoreTime(const QTime& a_rTime);
     void slotSetRandomQueueMin(int);
-    void slotConsiderRepeatPlaylistState(int);
-    void slotToggleRandomQueue(int);
+    void slotConsiderRepeatPlaylistState(bool);
+    void slotToggleRandomQueue(int buttonState);
 
   private:
     UserSettingsPointer m_pConfig;

--- a/src/preferences/dialog/dlgprefdeck.cpp
+++ b/src/preferences/dialog/dlgprefdeck.cpp
@@ -699,11 +699,11 @@ void DlgPrefDeck::slotApply() {
     for (ControlProxy* pControl : qAsConst(m_cueControls)) {
         pControl->set(static_cast<int>(m_cueMode));
     }
-    m_pConfig->setValue(ConfigKey("[Controls]", "CueDefault"), static_cast<int>(m_cueMode));
+    m_pConfig->setValue(ConfigKey("[Controls]", "CueDefault"), m_cueMode);
 
-    m_pConfig->setValue(kConfigKeyLoadWhenDeckPlaying, static_cast<int>(m_loadWhenDeckPlaying));
+    m_pConfig->setValue(kConfigKeyLoadWhenDeckPlaying, m_loadWhenDeckPlaying);
 
-    m_pConfig->setValue(ConfigKey("[Controls]", "CueRecall"), static_cast<int>(m_seekOnLoadMode));
+    m_pConfig->setValue(ConfigKey("[Controls]", "CueRecall"), m_seekOnLoadMode);
     m_pConfig->setValue(ConfigKey("[Controls]", "CloneDeckOnLoadDoubleTap"),
             m_bCloneDeckOnLoadDoubleTap);
 
@@ -714,9 +714,9 @@ void DlgPrefDeck::slotApply() {
 
     setRateDirectionForAllDecks(m_bRateDownIncreasesSpeed);
     m_pConfig->setValue(ConfigKey("[Controls]", "RateDir"),
-            static_cast<int>(m_bRateDownIncreasesSpeed));
+            m_bRateDownIncreasesSpeed);
 
-    int configSPAutoReset = BaseTrackPlayer::RESET_NONE;
+    BaseTrackPlayer::TrackLoadReset configSPAutoReset = BaseTrackPlayer::RESET_NONE;
 
     if (m_speedAutoReset && m_pitchAutoReset) {
         configSPAutoReset = BaseTrackPlayer::RESET_PITCH_AND_SPEED;
@@ -726,25 +726,25 @@ void DlgPrefDeck::slotApply() {
         configSPAutoReset = BaseTrackPlayer::RESET_PITCH;
     }
 
-    m_pConfig->set(ConfigKey("[Controls]", "SpeedAutoReset"),
-                   ConfigValue(configSPAutoReset));
+    m_pConfig->setValue(ConfigKey("[Controls]", "SpeedAutoReset"),
+            configSPAutoReset);
 
     m_pConfig->setValue(ConfigKey("[Controls]", "keylockMode"),
-                        static_cast<int>(m_keylockMode));
+            m_keylockMode);
     // Set key lock behavior for every group
     for (ControlProxy* pControl : qAsConst(m_keylockModeControls)) {
         pControl->set(static_cast<double>(m_keylockMode));
     }
 
     m_pConfig->setValue(ConfigKey("[Controls]", "keyunlockMode"),
-                        static_cast<int>(m_keyunlockMode));
+            m_keyunlockMode);
     // Set key un-lock behavior for every group
     for (ControlProxy* pControl : qAsConst(m_keyunlockModeControls)) {
         pControl->set(static_cast<double>(m_keyunlockMode));
     }
 
     RateControl::setRateRampMode(m_bRateRamping);
-    m_pConfig->setValue(ConfigKey("[Controls]", "RateRamp"), static_cast<int>(m_bRateRamping));
+    m_pConfig->setValue(ConfigKey("[Controls]", "RateRamp"), m_bRateRamping);
 
     RateControl::setRateRampSensitivity(m_iRateRampSensitivity);
     m_pConfig->setValue(ConfigKey("[Controls]", "RateRampSensitivity"), m_iRateRampSensitivity);

--- a/src/util/screensavermanager.cpp
+++ b/src/util/screensavermanager.cpp
@@ -7,12 +7,10 @@ namespace mixxx {
 
 ScreensaverManager::ScreensaverManager(UserSettingsPointer pConfig, QObject* pParent)
         : QObject(pParent), m_pConfig(pConfig) {
-    int inhibit = pConfig->getValue<int>(ConfigKey("[Config]", "InhibitScreensaver"), -1);
-    if (inhibit == -1) {
-        inhibit = static_cast<int>(mixxx::ScreenSaverPreference::PREVENT_ON);
-        pConfig->setValue<int>(ConfigKey("[Config]", "InhibitScreensaver"), inhibit);
-    }
-    m_inhibitScreensaver = static_cast<mixxx::ScreenSaverPreference>(inhibit);
+    m_inhibitScreensaver =
+            pConfig->getValue(ConfigKey("[Config]", "InhibitScreensaver"),
+                    mixxx::ScreenSaverPreference::PREVENT_ON);
+    pConfig->setValue(ConfigKey("[Config]", "InhibitScreensaver"), m_inhibitScreensaver);
     if (m_inhibitScreensaver == mixxx::ScreenSaverPreference::PREVENT_ON) {
         mixxx::ScreenSaverHelper::inhibit();
     }
@@ -29,15 +27,12 @@ void ScreensaverManager::setStatus(mixxx::ScreenSaverPreference newInhibit) {
         mixxx::ScreenSaverHelper::uninhibit();
     }
 
-    if (newInhibit == mixxx::ScreenSaverPreference::PREVENT_ON) {
-        mixxx::ScreenSaverHelper::inhibit();
-    } else if (newInhibit ==
-                    mixxx::ScreenSaverPreference::PREVENT_ON_PLAY &&
-            PlayerInfo::instance().getCurrentPlayingDeck() != -1) {
+    if (newInhibit == mixxx::ScreenSaverPreference::PREVENT_ON ||
+            (newInhibit == mixxx::ScreenSaverPreference::PREVENT_ON_PLAY &&
+                    PlayerInfo::instance().getCurrentPlayingDeck() != -1)) {
         mixxx::ScreenSaverHelper::inhibit();
     }
-    int inhibit_int = static_cast<int>(newInhibit);
-    m_pConfig->setValue<int>(ConfigKey("[Config]", "InhibitScreensaver"), inhibit_int);
+    m_pConfig->setValue(ConfigKey("[Config]", "InhibitScreensaver"), newInhibit);
     m_inhibitScreensaver = newInhibit;
 }
 

--- a/src/vinylcontrol/vinylcontrolmanager.cpp
+++ b/src/vinylcontrol/vinylcontrolmanager.cpp
@@ -42,12 +42,12 @@ VinylControlManager::~VinylControlManager() {
     for (int i = 0; i < m_iNumConfiguredDecks; ++i) {
         QString group = PlayerManager::groupForDeck(i);
         m_pConfig->setValue(ConfigKey(group, "vinylcontrol_enabled"), false);
-        m_pConfig->set(ConfigKey(VINYL_PREF_KEY, QString("cueing_ch%1").arg(i + 1)),
-            ConfigValue(static_cast<int>(ControlObject::get(
-                ConfigKey(group, "vinylcontrol_cueing")))));
-        m_pConfig->set(ConfigKey(VINYL_PREF_KEY, QString("mode_ch%1").arg(i + 1)),
-            ConfigValue(static_cast<int>(ControlObject::get(
-                ConfigKey(group, "vinylcontrol_mode")))));
+        m_pConfig->set(ConfigKey(VINYL_PREF_KEY, QStringLiteral("cueing_ch%1").arg(i + 1)),
+                ConfigValue(static_cast<int>(ControlObject::get(
+                        ConfigKey(group, "vinylcontrol_cueing")))));
+        m_pConfig->set(ConfigKey(VINYL_PREF_KEY, QStringLiteral("mode_ch%1").arg(i + 1)),
+                ConfigValue(static_cast<int>(ControlObject::get(
+                        ConfigKey(group, "vinylcontrol_mode")))));
     }
 }
 

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -537,25 +537,13 @@ bool WaveformWidgetFactory::setWidgetType(
 
     // check if type is acceptable
     int index = findHandleIndexFromType(type);
-    if (index > -1) {
-        // type is acceptable
-        *pCurrentType = type;
-        if (m_config) {
-            m_config->setValue(
-                    ConfigKey("[Waveform]", "WaveformType"),
-                    static_cast<int>(*pCurrentType));
-        }
-        return true;
-    }
-
-    // fallback
-    *pCurrentType = WaveformWidgetType::EmptyWaveform;
+    bool isAcceptable = index > -1;
+    *pCurrentType = isAcceptable ? type : WaveformWidgetType::EmptyWaveform;
     if (m_config) {
         m_config->setValue(
-                ConfigKey("[Waveform]", "WaveformType"),
-                static_cast<int>(*pCurrentType));
+                ConfigKey("[Waveform]", "WaveformType"), *pCurrentType);
     }
-    return false;
+    return isAcceptable;
 }
 
 bool WaveformWidgetFactory::setWidgetTypeFromConfig() {


### PR DESCRIPTION
This allows the callsites to avoid verbose `static_cast`s (see 491b43639506e5cba2330199451c599d2fad2da2). It also makes it easier to change the machanism used when storing enums in the config easier in the future. The remaining commits are cleanups I did along the way while making use of the new overload. 