### PR TITLE
fix: erroneous DirectConnection causing ejects on wrong thread

### DIFF
--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -88,8 +88,7 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(
     connect(m_pEject.get(),
             &ControlObject::valueChanged,
             this,
-            &BaseTrackPlayerImpl::slotEjectTrack,
-            Qt::DirectConnection);
+            &BaseTrackPlayerImpl::slotEjectTrack);
 
     // Get loop point control objects
     m_pLoopInPoint = make_parented<ControlProxy>(


### PR DESCRIPTION
fixes #11819

I don't have access to any controller hardware at the moment of its difficult for me to test whether this actually fixes it, but I'm pretty sure it does. 