### PR TITLE
Effectchain tooltip

### DIFF
--- a/src/widget/weffectchainpresetbutton.cpp
+++ b/src/widget/weffectchainpresetbutton.cpp
@@ -61,12 +61,17 @@ void WEffectChainPresetButton::populateMenu() {
                     QChar(' ') + title;
             presetIsReadOnly = pChainPreset->isReadOnly();
         }
-        QStringList tooltip;
-        tooltip.append(QStringLiteral("<b>") + pChainPreset->name() + QStringLiteral("</b>"));
+        QString tooltip =
+                QStringLiteral("<b>") + pChainPreset->name() + QStringLiteral("</b>");
+        QStringList effectNames;
         for (const auto& pEffectPreset : pChainPreset->effectPresets()) {
             if (!pEffectPreset->isEmpty()) {
-                tooltip.append(bem->getDisplayNameForEffectPreset(pEffectPreset));
+                effectNames.append(bem->getDisplayNameForEffectPreset(pEffectPreset));
             }
+        }
+        if (effectNames.size() > 1) {
+            tooltip.append("<br/>");
+            tooltip.append(effectNames.join("<br/>"));
         }
         parented_ptr<QAction> pAction = make_parented<QAction>(title, this);
         connect(pAction,
@@ -75,7 +80,7 @@ void WEffectChainPresetButton::populateMenu() {
                 [this, pChainPreset]() {
                     m_pChain->loadChainPreset(pChainPreset);
                 });
-        pAction->setToolTip(tooltip.join("<br/>"));
+        pAction->setToolTip(tooltip);
         m_pMenu->addAction(pAction);
     }
     m_pMenu->addSeparator();

--- a/src/widget/weffectchainpresetbutton.cpp
+++ b/src/widget/weffectchainpresetbutton.cpp
@@ -5,6 +5,7 @@
 
 #include "effects/presets/effectpresetmanager.h"
 #include "moc_weffectchainpresetbutton.cpp"
+#include "util/parented_ptr.h"
 #include "widget/effectwidgetutils.h"
 
 WEffectChainPresetButton::WEffectChainPresetButton(QWidget* parent, EffectsManager* pEffectsManager)
@@ -43,6 +44,7 @@ void WEffectChainPresetButton::setup(const QDomNode& node, const SkinContext& co
                 this,
                 &WEffectChainPresetButton::populateMenu);
     }
+    m_pMenu->setToolTipsVisible(true);
     populateMenu();
 }
 
@@ -50,6 +52,7 @@ void WEffectChainPresetButton::populateMenu() {
     m_pMenu->clear();
 
     // Chain preset items
+    const EffectsBackendManagerPointer bem = m_pEffectsManager->getBackendManager();
     bool presetIsReadOnly = true;
     for (const auto& pChainPreset : m_pChainPresetManager->getPresetsSorted()) {
         QString title = pChainPreset->name();
@@ -58,9 +61,22 @@ void WEffectChainPresetButton::populateMenu() {
                     QChar(' ') + title;
             presetIsReadOnly = pChainPreset->isReadOnly();
         }
-        m_pMenu->addAction(title, this, [this, pChainPreset]() {
-            m_pChain->loadChainPreset(pChainPreset);
-        });
+        QStringList tooltip;
+        tooltip.append(QStringLiteral("<b>") + pChainPreset->name() + QStringLiteral("</b>"));
+        for (const auto& pEffectPreset : pChainPreset->effectPresets()) {
+            if (!pEffectPreset->isEmpty()) {
+                tooltip.append(bem->getDisplayNameForEffectPreset(pEffectPreset));
+            }
+        }
+        parented_ptr<QAction> pAction = make_parented<QAction>(title, this);
+        connect(pAction,
+                &QAction::triggered,
+                this,
+                [this, pChainPreset]() {
+                    m_pChain->loadChainPreset(pChainPreset);
+                });
+        pAction->setToolTip(tooltip.join("<br/>"));
+        m_pMenu->addAction(pAction);
     }
     m_pMenu->addSeparator();
     // This prevents showing the Update button for the empty '---' preset, in case

--- a/src/widget/weffectchainpresetselector.cpp
+++ b/src/widget/weffectchainpresetselector.cpp
@@ -74,13 +74,21 @@ void WEffectChainPresetSelector::populate() {
         presetList = m_pEffectsManager->getChainPresetManager()->getPresetsSorted();
     }
 
+    const EffectsBackendManagerPointer bem = m_pEffectsManager->getBackendManager();
     for (int i = 0; i < presetList.size(); i++) {
         auto pChainPreset = presetList.at(i);
         QString elidedDisplayName = metrics.elidedText(pChainPreset->name(),
                 Qt::ElideMiddle,
                 view()->width() - 2);
         addItem(elidedDisplayName, QVariant(pChainPreset->name()));
-        setItemData(i, pChainPreset->name(), Qt::ToolTipRole);
+        QStringList tooltip;
+        tooltip.append(QStringLiteral("<b>") + pChainPreset->name() + QStringLiteral("</b>"));
+        for (const auto& pEffectPreset : pChainPreset->effectPresets()) {
+            if (!pEffectPreset->isEmpty()) {
+                tooltip.append(bem->getDisplayNameForEffectPreset(pEffectPreset));
+            }
+        }
+        setItemData(i, tooltip.join("<br/>"), Qt::ToolTipRole);
     }
 
     slotChainPresetChanged(m_pChain->presetName());

--- a/src/widget/weffectchainpresetselector.cpp
+++ b/src/widget/weffectchainpresetselector.cpp
@@ -81,14 +81,19 @@ void WEffectChainPresetSelector::populate() {
                 Qt::ElideMiddle,
                 view()->width() - 2);
         addItem(elidedDisplayName, QVariant(pChainPreset->name()));
-        QStringList tooltip;
-        tooltip.append(QStringLiteral("<b>") + pChainPreset->name() + QStringLiteral("</b>"));
+        QString tooltip =
+                QStringLiteral("<b>") + pChainPreset->name() + QStringLiteral("</b>");
+        QStringList effectNames;
         for (const auto& pEffectPreset : pChainPreset->effectPresets()) {
             if (!pEffectPreset->isEmpty()) {
-                tooltip.append(bem->getDisplayNameForEffectPreset(pEffectPreset));
+                effectNames.append(bem->getDisplayNameForEffectPreset(pEffectPreset));
             }
         }
-        setItemData(i, tooltip.join("<br/>"), Qt::ToolTipRole);
+        if (effectNames.size() > 1) {
+            tooltip.append("<br/>");
+            tooltip.append(effectNames.join("<br/>"));
+        }
+        setItemData(i, tooltip, Qt::ToolTipRole);
     }
 
     slotChainPresetChanged(m_pChain->presetName());


### PR DESCRIPTION
picking another low-hanging fruit to polish the new effects frontend:
show chained effects in tooltip of
* WEffectChainPresetSelector
* WEffectChainPresetButton menu
![image](https://github.com/mixxxdj/mixxx/assets/5934199/63717a48-1bb2-4c1a-988b-c48b92d4e8c1)
![image](https://github.com/mixxxdj/mixxx/assets/5934199/17359717-2ac5-4446-bdde-809aaeeea86e)


Close #10605