### PR TITLE
Use `SampleRate` type consistently

### DIFF
--- a/src/effects/backends/builtin/balanceeffect.cpp
+++ b/src/effects/backends/builtin/balanceeffect.cpp
@@ -79,7 +79,7 @@ BalanceGroupState::BalanceGroupState(const mixxx::EngineParameters& engineParame
     m_high->setStartFromDry(true);
 }
 
-void BalanceGroupState::setFilters(int sampleRate, double freq) {
+void BalanceGroupState::setFilters(mixxx::audio::SampleRate sampleRate, double freq) {
     m_low->setFrequencyCorners(sampleRate, freq);
     m_high->setFrequencyCorners(sampleRate, freq);
 }

--- a/src/effects/backends/builtin/balanceeffect.h
+++ b/src/effects/backends/builtin/balanceeffect.h
@@ -12,7 +12,7 @@ class BalanceGroupState : public EffectState {
     BalanceGroupState(const mixxx::EngineParameters& engineParameters);
     ~BalanceGroupState() override = default;
 
-    void setFilters(int sampleRate, double freq);
+    void setFilters(mixxx::audio::SampleRate sampleRate, double freq);
 
     std::unique_ptr<EngineFilterLinkwitzRiley4Low> m_low;
     std::unique_ptr<EngineFilterLinkwitzRiley4High> m_high;

--- a/src/effects/backends/builtin/filtereffect.cpp
+++ b/src/effects/backends/builtin/filtereffect.cpp
@@ -69,8 +69,8 @@ FilterGroupState::FilterGroupState(const mixxx::EngineParameters& engineParamete
           m_q(0.707106781),
           m_hiFreq(kMinCorner / engineParameters.sampleRate()) {
     m_buffer = mixxx::SampleBuffer(engineParameters.samplesPerBuffer());
-    m_pLowFilter = new EngineFilterBiquad1Low(1, m_loFreq, m_q, true);
-    m_pHighFilter = new EngineFilterBiquad1High(1, m_hiFreq, m_q, true);
+    m_pLowFilter = new EngineFilterBiquad1Low(mixxx::audio::SampleRate(1), m_loFreq, m_q, true);
+    m_pHighFilter = new EngineFilterBiquad1High(mixxx::audio::SampleRate(1), m_hiFreq, m_q, true);
 }
 
 FilterGroupState::~FilterGroupState() {
@@ -128,8 +128,8 @@ void FilterEffect::processChannel(
             double qmax = 4 - 2 / 0.6 * ratio;
             clampedQ = math_min(clampedQ, qmax);
         }
-        pState->m_pLowFilter->setFrequencyCorners(1, lpf, clampedQ);
-        pState->m_pHighFilter->setFrequencyCorners(1, hpf, clampedQ);
+        pState->m_pLowFilter->setFrequencyCorners(mixxx::audio::SampleRate(1), lpf, clampedQ);
+        pState->m_pHighFilter->setFrequencyCorners(mixxx::audio::SampleRate(1), hpf, clampedQ);
     }
 
     const CSAMPLE* pLpfInput = pState->m_buffer.data();

--- a/src/effects/backends/builtin/filtereffect.cpp
+++ b/src/effects/backends/builtin/filtereffect.cpp
@@ -65,12 +65,12 @@ EffectManifestPointer FilterEffect::getManifest() {
 
 FilterGroupState::FilterGroupState(const mixxx::EngineParameters& engineParameters)
         : EffectState(engineParameters),
-          m_loFreq(kMaxCorner / engineParameters.sampleRate()),
+          m_loFreq(kMaxCorner),
           m_q(0.707106781),
-          m_hiFreq(kMinCorner / engineParameters.sampleRate()) {
+          m_hiFreq(kMinCorner) {
     m_buffer = mixxx::SampleBuffer(engineParameters.samplesPerBuffer());
-    m_pLowFilter = new EngineFilterBiquad1Low(mixxx::audio::SampleRate(1), m_loFreq, m_q, true);
-    m_pHighFilter = new EngineFilterBiquad1High(mixxx::audio::SampleRate(1), m_hiFreq, m_q, true);
+    m_pLowFilter = new EngineFilterBiquad1Low(engineParameters.sampleRate(), m_loFreq, m_q, true);
+    m_pHighFilter = new EngineFilterBiquad1High(engineParameters.sampleRate(), m_hiFreq, m_q, true);
 }
 
 FilterGroupState::~FilterGroupState() {
@@ -98,16 +98,13 @@ void FilterEffect::processChannel(
     double lpf;
     double q = m_pQ->value();
 
-    const double minCornerNormalized = kMinCorner / engineParameters.sampleRate();
-    const double maxCornerNormalized = kMaxCorner / engineParameters.sampleRate();
-
     if (enableState == EffectEnableState::Disabling) {
         // Ramp to dry, when disabling, this will ramp from dry when enabling as well
-        hpf = minCornerNormalized;
-        lpf = maxCornerNormalized;
+        hpf = kMinCorner;
+        lpf = kMaxCorner;
     } else {
-        hpf = m_pHPF->value() / engineParameters.sampleRate();
-        lpf = m_pLPF->value() / engineParameters.sampleRate();
+        hpf = m_pHPF->value();
+        lpf = m_pLPF->value();
     }
 
     if ((pState->m_loFreq != lpf) ||
@@ -128,22 +125,22 @@ void FilterEffect::processChannel(
             double qmax = 4 - 2 / 0.6 * ratio;
             clampedQ = math_min(clampedQ, qmax);
         }
-        pState->m_pLowFilter->setFrequencyCorners(mixxx::audio::SampleRate(1), lpf, clampedQ);
-        pState->m_pHighFilter->setFrequencyCorners(mixxx::audio::SampleRate(1), hpf, clampedQ);
+        pState->m_pLowFilter->setFrequencyCorners(engineParameters.sampleRate(), lpf, clampedQ);
+        pState->m_pHighFilter->setFrequencyCorners(engineParameters.sampleRate(), hpf, clampedQ);
     }
 
     const CSAMPLE* pLpfInput = pState->m_buffer.data();
     CSAMPLE* pHpfOutput = pState->m_buffer.data();
-    if (lpf >= maxCornerNormalized && pState->m_loFreq >= maxCornerNormalized) {
+    if (lpf >= kMaxCorner && pState->m_loFreq >= kMaxCorner) {
         // Lpf disabled Hpf can write directly to output
         pHpfOutput = pOutput;
         pLpfInput = pHpfOutput;
     }
 
-    if (hpf > minCornerNormalized) {
+    if (hpf > kMinCorner) {
         // hpf enabled, fade-in is handled in the filter when starting from pause
         pState->m_pHighFilter->process(pInput, pHpfOutput, engineParameters.samplesPerBuffer());
-    } else if (pState->m_hiFreq > minCornerNormalized) {
+    } else if (pState->m_hiFreq > kMinCorner) {
         // hpf disabling
         pState->m_pHighFilter->processAndPauseFilter(pInput,
                 pHpfOutput,
@@ -153,10 +150,10 @@ void FilterEffect::processChannel(
         pLpfInput = pInput;
     }
 
-    if (lpf < maxCornerNormalized) {
+    if (lpf < kMaxCorner) {
         // lpf enabled, fade-in is handled in the filter when starting from pause
         pState->m_pLowFilter->process(pLpfInput, pOutput, engineParameters.samplesPerBuffer());
-    } else if (pState->m_loFreq < maxCornerNormalized) {
+    } else if (pState->m_loFreq < kMaxCorner) {
         // hpf disabling
         pState->m_pLowFilter->processAndPauseFilter(pLpfInput,
                 pOutput,

--- a/src/effects/backends/builtin/filtereffect.h
+++ b/src/effects/backends/builtin/filtereffect.h
@@ -14,7 +14,7 @@ struct FilterGroupState : public EffectState {
     FilterGroupState(const mixxx::EngineParameters& engineParameters);
     ~FilterGroupState() override;
 
-    void setFilters(int sampleRate, double lowFreq, double highFreq);
+    void setFilters(mixxx::audio::SampleRate sampleRate, double lowFreq, double highFreq);
 
     mixxx::SampleBuffer m_buffer;
     EngineFilterBiquad1Low* m_pLowFilter;

--- a/src/effects/backends/builtin/graphiceqeffect.cpp
+++ b/src/effects/backends/builtin/graphiceqeffect.cpp
@@ -1,9 +1,11 @@
 #include "effects/backends/builtin/graphiceqeffect.h"
 
+#include "audio/types.h"
 #include "util/math.h"
 
 namespace {
 constexpr double kQ = 1.2247449;
+constexpr auto kDefaultSampleRate = mixxx::audio::SampleRate(44100);
 } // namespace
 
 // static
@@ -94,10 +96,10 @@ GraphicEQEffectGroupState::GraphicEQEffectGroupState(
     m_centerFrequencies[7] = 9828;
 
     // Initialize the filters with default parameters
-    m_low = new EngineFilterBiquad1LowShelving(44100, m_centerFrequencies[0], kQ);
-    m_high = new EngineFilterBiquad1HighShelving(44100, m_centerFrequencies[7], kQ);
+    m_low = new EngineFilterBiquad1LowShelving(kDefaultSampleRate, m_centerFrequencies[0], kQ);
+    m_high = new EngineFilterBiquad1HighShelving(kDefaultSampleRate, m_centerFrequencies[7], kQ);
     for (int i = 1; i < 7; i++) {
-        m_bands.append(new EngineFilterBiquad1Peaking(44100,
+        m_bands.append(new EngineFilterBiquad1Peaking(kDefaultSampleRate,
                 m_centerFrequencies[i],
                 kQ));
     }
@@ -116,7 +118,7 @@ GraphicEQEffectGroupState::~GraphicEQEffectGroupState() {
     }
 }
 
-void GraphicEQEffectGroupState::setFilters(int sampleRate) {
+void GraphicEQEffectGroupState::setFilters(mixxx::audio::SampleRate sampleRate) {
     m_low->setFrequencyCorners(sampleRate, m_centerFrequencies[0], kQ, m_oldLow);
     m_high->setFrequencyCorners(sampleRate, m_centerFrequencies[7], kQ, m_oldHigh);
     for (int i = 0; i < 6; i++) {

--- a/src/effects/backends/builtin/graphiceqeffect.cpp
+++ b/src/effects/backends/builtin/graphiceqeffect.cpp
@@ -2,7 +2,9 @@
 
 #include "util/math.h"
 
-#define Q 1.2247449
+namespace {
+constexpr double kQ = 1.2247449;
+} // namespace
 
 // static
 QString GraphicEQEffect::getId() {
@@ -92,12 +94,12 @@ GraphicEQEffectGroupState::GraphicEQEffectGroupState(
     m_centerFrequencies[7] = 9828;
 
     // Initialize the filters with default parameters
-    m_low = new EngineFilterBiquad1LowShelving(44100, m_centerFrequencies[0], Q);
-    m_high = new EngineFilterBiquad1HighShelving(44100, m_centerFrequencies[7], Q);
+    m_low = new EngineFilterBiquad1LowShelving(44100, m_centerFrequencies[0], kQ);
+    m_high = new EngineFilterBiquad1HighShelving(44100, m_centerFrequencies[7], kQ);
     for (int i = 1; i < 7; i++) {
         m_bands.append(new EngineFilterBiquad1Peaking(44100,
                 m_centerFrequencies[i],
-                Q));
+                kQ));
     }
 }
 
@@ -115,10 +117,10 @@ GraphicEQEffectGroupState::~GraphicEQEffectGroupState() {
 }
 
 void GraphicEQEffectGroupState::setFilters(int sampleRate) {
-    m_low->setFrequencyCorners(sampleRate, m_centerFrequencies[0], Q, m_oldLow);
-    m_high->setFrequencyCorners(sampleRate, m_centerFrequencies[7], Q, m_oldHigh);
+    m_low->setFrequencyCorners(sampleRate, m_centerFrequencies[0], kQ, m_oldLow);
+    m_high->setFrequencyCorners(sampleRate, m_centerFrequencies[7], kQ, m_oldHigh);
     for (int i = 0; i < 6; i++) {
-        m_bands[i]->setFrequencyCorners(sampleRate, m_centerFrequencies[i + 1], Q, m_oldMid[i]);
+        m_bands[i]->setFrequencyCorners(sampleRate, m_centerFrequencies[i + 1], kQ, m_oldMid[i]);
     }
 }
 
@@ -170,20 +172,20 @@ void GraphicEQEffect::processChannel(
     if (fLow != pState->m_oldLow) {
         pState->m_low->setFrequencyCorners(engineParameters.sampleRate(),
                 pState->m_centerFrequencies[0],
-                Q,
+                kQ,
                 fLow);
     }
     if (fHigh != pState->m_oldHigh) {
         pState->m_high->setFrequencyCorners(engineParameters.sampleRate(),
                 pState->m_centerFrequencies[7],
-                Q,
+                kQ,
                 fHigh);
     }
     for (int i = 0; i < 6; i++) {
         if (fMid[i] != pState->m_oldMid[i]) {
             pState->m_bands[i]->setFrequencyCorners(engineParameters.sampleRate(),
                     pState->m_centerFrequencies[i + 1],
-                    Q,
+                    kQ,
                     fMid[i]);
         }
     }

--- a/src/effects/backends/builtin/graphiceqeffect.cpp
+++ b/src/effects/backends/builtin/graphiceqeffect.cpp
@@ -5,7 +5,6 @@
 
 namespace {
 constexpr double kQ = 1.2247449;
-constexpr auto kDefaultSampleRate = mixxx::audio::SampleRate(44100);
 } // namespace
 
 // static
@@ -96,10 +95,16 @@ GraphicEQEffectGroupState::GraphicEQEffectGroupState(
     m_centerFrequencies[7] = 9828;
 
     // Initialize the filters with default parameters
-    m_low = new EngineFilterBiquad1LowShelving(kDefaultSampleRate, m_centerFrequencies[0], kQ);
-    m_high = new EngineFilterBiquad1HighShelving(kDefaultSampleRate, m_centerFrequencies[7], kQ);
+    m_low = new EngineFilterBiquad1LowShelving(
+            engineParameters.sampleRate(),
+            m_centerFrequencies[0],
+            kQ);
+    m_high = new EngineFilterBiquad1HighShelving(
+            engineParameters.sampleRate(),
+            m_centerFrequencies[7],
+            kQ);
     for (int i = 1; i < 7; i++) {
-        m_bands.append(new EngineFilterBiquad1Peaking(kDefaultSampleRate,
+        m_bands.append(new EngineFilterBiquad1Peaking(engineParameters.sampleRate(),
                 m_centerFrequencies[i],
                 kQ));
     }

--- a/src/effects/backends/builtin/graphiceqeffect.h
+++ b/src/effects/backends/builtin/graphiceqeffect.h
@@ -17,7 +17,7 @@ class GraphicEQEffectGroupState : public EffectState {
     GraphicEQEffectGroupState(const mixxx::EngineParameters& engineParameters);
     ~GraphicEQEffectGroupState() override;
 
-    void setFilters(int sampleRate);
+    void setFilters(mixxx::audio::SampleRate sampleRate);
 
     EngineFilterBiquad1LowShelving* m_low;
     QList<EngineFilterBiquad1Peaking*> m_bands;

--- a/src/effects/backends/builtin/linkwitzriley8eqeffect.cpp
+++ b/src/effects/backends/builtin/linkwitzriley8eqeffect.cpp
@@ -4,7 +4,6 @@
 #include "util/math.h"
 
 namespace {
-constexpr auto kStartupSamplerate = mixxx::audio::SampleRate(44100);
 constexpr unsigned int kStartupLoFreq = 246;
 constexpr unsigned int kStartupHiFreq = 2484;
 } // namespace
@@ -39,17 +38,17 @@ LinkwitzRiley8EQEffectGroupState::LinkwitzRiley8EQEffectGroupState(
           old_low(1.0),
           old_mid(1.0),
           old_high(1.0),
-          m_oldSampleRate(kStartupSamplerate),
+          m_oldSampleRate(engineParameters.sampleRate()),
           m_loFreq(kStartupLoFreq),
           m_hiFreq(kStartupHiFreq) {
     m_pLowBuf = SampleUtil::alloc(MAX_BUFFER_LEN);
     m_pMidBuf = SampleUtil::alloc(MAX_BUFFER_LEN);
     m_pHighBuf = SampleUtil::alloc(MAX_BUFFER_LEN);
 
-    m_low1 = new EngineFilterLinkwitzRiley8Low(kStartupSamplerate, kStartupLoFreq);
-    m_high1 = new EngineFilterLinkwitzRiley8High(kStartupSamplerate, kStartupLoFreq);
-    m_low2 = new EngineFilterLinkwitzRiley8Low(kStartupSamplerate, kStartupHiFreq);
-    m_high2 = new EngineFilterLinkwitzRiley8High(kStartupSamplerate, kStartupHiFreq);
+    m_low1 = new EngineFilterLinkwitzRiley8Low(engineParameters.sampleRate(), kStartupLoFreq);
+    m_high1 = new EngineFilterLinkwitzRiley8High(engineParameters.sampleRate(), kStartupLoFreq);
+    m_low2 = new EngineFilterLinkwitzRiley8Low(engineParameters.sampleRate(), kStartupHiFreq);
+    m_high2 = new EngineFilterLinkwitzRiley8High(engineParameters.sampleRate(), kStartupHiFreq);
 }
 
 LinkwitzRiley8EQEffectGroupState::~LinkwitzRiley8EQEffectGroupState() {

--- a/src/effects/backends/builtin/linkwitzriley8eqeffect.cpp
+++ b/src/effects/backends/builtin/linkwitzriley8eqeffect.cpp
@@ -3,9 +3,11 @@
 #include "effects/backends/builtin/equalizer_util.h"
 #include "util/math.h"
 
-static constexpr unsigned int kStartupSamplerate = 44100;
-static constexpr unsigned int kStartupLoFreq = 246;
-static constexpr unsigned int kStartupHiFreq = 2484;
+namespace {
+constexpr auto kStartupSamplerate = mixxx::audio::SampleRate(44100);
+constexpr unsigned int kStartupLoFreq = 246;
+constexpr unsigned int kStartupHiFreq = 2484;
+} // namespace
 
 // static
 QString LinkwitzRiley8EQEffect::getId() {
@@ -60,7 +62,8 @@ LinkwitzRiley8EQEffectGroupState::~LinkwitzRiley8EQEffectGroupState() {
     SampleUtil::free(m_pHighBuf);
 }
 
-void LinkwitzRiley8EQEffectGroupState::setFilters(int sampleRate, int lowFreq, int highFreq) {
+void LinkwitzRiley8EQEffectGroupState::setFilters(
+        mixxx::audio::SampleRate sampleRate, int lowFreq, int highFreq) {
     m_low1->setFrequencyCorners(sampleRate, lowFreq);
     m_high1->setFrequencyCorners(sampleRate, lowFreq);
     m_low2->setFrequencyCorners(sampleRate, highFreq);

--- a/src/effects/backends/builtin/linkwitzriley8eqeffect.h
+++ b/src/effects/backends/builtin/linkwitzriley8eqeffect.h
@@ -17,7 +17,7 @@ class LinkwitzRiley8EQEffectGroupState : public EffectState {
     LinkwitzRiley8EQEffectGroupState(const mixxx::EngineParameters& engineParameters);
     ~LinkwitzRiley8EQEffectGroupState() override;
 
-    void setFilters(int sampleRate, int lowFreq, int highFreq);
+    void setFilters(mixxx::audio::SampleRate sampleRate, int lowFreq, int highFreq);
 
     EngineFilterLinkwitzRiley8Low* m_low1;
     EngineFilterLinkwitzRiley8High* m_high1;

--- a/src/effects/backends/builtin/loudnesscontoureffect.cpp
+++ b/src/effects/backends/builtin/loudnesscontoureffect.cpp
@@ -80,7 +80,7 @@ LoudnessContourEffectGroupState::~LoudnessContourEffectGroupState() {
     SampleUtil::free(m_pBuf);
 }
 
-void LoudnessContourEffectGroupState::setFilters(int sampleRate, double gain) {
+void LoudnessContourEffectGroupState::setFilters(mixxx::audio::SampleRate sampleRate, double gain) {
     m_low->setFrequencyCorners(
             sampleRate, kLoPeakFreq, kLoPleakQ, gain);
     m_high->setFrequencyCorners(

--- a/src/effects/backends/builtin/loudnesscontoureffect.h
+++ b/src/effects/backends/builtin/loudnesscontoureffect.h
@@ -16,7 +16,7 @@ class LoudnessContourEffectGroupState final : public EffectState {
     LoudnessContourEffectGroupState(const mixxx::EngineParameters& engineParameters);
     ~LoudnessContourEffectGroupState() override;
 
-    void setFilters(int sampleRate, double gain);
+    void setFilters(mixxx::audio::SampleRate sampleRate, double gain);
 
     std::unique_ptr<EngineFilterBiquad1Peaking> m_low;
     std::unique_ptr<EngineFilterBiquad1HighShelving> m_high;
@@ -49,7 +49,7 @@ class LoudnessContourEffect
             const EffectEnableState enableState,
             const GroupFeatureState& groupFeatureState) override;
 
-    void setFilters(int sampleRate);
+    void setFilters(mixxx::audio::SampleRate sampleRate);
 
   private:
     LoudnessContourEffect(const LoudnessContourEffect&) = delete;

--- a/src/effects/backends/builtin/moogladder4filtereffect.h
+++ b/src/effects/backends/builtin/moogladder4filtereffect.h
@@ -13,7 +13,7 @@ class MoogLadder4FilterGroupState : public EffectState {
     MoogLadder4FilterGroupState(const mixxx::EngineParameters& engineParameters);
     ~MoogLadder4FilterGroupState() override;
 
-    void setFilters(int sampleRate, double lowFreq, double highFreq);
+    void setFilters(mixxx::audio::SampleRate sampleRate, double lowFreq, double highFreq);
 
     CSAMPLE* m_pBuf;
     EngineFilterMoogLadder4Low* m_pLowFilter;

--- a/src/effects/backends/builtin/parametriceqeffect.cpp
+++ b/src/effects/backends/builtin/parametriceqeffect.cpp
@@ -119,7 +119,7 @@ ParametricEQEffectGroupState::ParametricEQEffectGroupState(
     }
 }
 
-void ParametricEQEffectGroupState::setFilters(int sampleRate) {
+void ParametricEQEffectGroupState::setFilters(mixxx::audio::SampleRate sampleRate) {
     for (int i = 0; i < kBandCount; i++) {
         m_bands[i]->setFrequencyCorners(
                 sampleRate, m_oldCenter[i], m_oldQ[i], m_oldGain[i]);

--- a/src/effects/backends/builtin/parametriceqeffect.h
+++ b/src/effects/backends/builtin/parametriceqeffect.h
@@ -26,7 +26,7 @@ class ParametricEQEffectGroupState final : public EffectState {
     ParametricEQEffectGroupState(const mixxx::EngineParameters& engineParameters);
     ~ParametricEQEffectGroupState() override = default;
 
-    void setFilters(int sampleRate);
+    void setFilters(mixxx::audio::SampleRate sampleRate);
 
     // These containers are only appended in the constructor which is called on
     // the main thread, so there is no risk of allocation in the audio thread.

--- a/src/effects/backends/builtin/threebandbiquadeqeffect.cpp
+++ b/src/effects/backends/builtin/threebandbiquadeqeffect.cpp
@@ -97,7 +97,7 @@ ThreeBandBiquadEQEffectGroupState::ThreeBandBiquadEQEffectGroupState(
 }
 
 void ThreeBandBiquadEQEffectGroupState::setFilters(
-        int sampleRate, double lowFreqCorner, double highFreqCorner) {
+        mixxx::audio::SampleRate sampleRate, double lowFreqCorner, double highFreqCorner) {
     double lowCenter = getCenterFrequency(kMinimumFrequency, lowFreqCorner);
     double midCenter = getCenterFrequency(lowFreqCorner, highFreqCorner);
     double highCenter = getCenterFrequency(highFreqCorner, kMaximumFrequency);

--- a/src/effects/backends/builtin/threebandbiquadeqeffect.h
+++ b/src/effects/backends/builtin/threebandbiquadeqeffect.h
@@ -18,7 +18,7 @@ class ThreeBandBiquadEQEffectGroupState final : public EffectState {
     ~ThreeBandBiquadEQEffectGroupState() override = default;
 
     void setFilters(
-            int sampleRate, double lowFreqCorner, double highFreqCorner);
+            mixxx::audio::SampleRate sampleRate, double lowFreqCorner, double highFreqCorner);
 
     std::unique_ptr<EngineFilterBiquad1Peaking> m_lowBoost;
     std::unique_ptr<EngineFilterBiquad1Peaking> m_midBoost;
@@ -59,7 +59,9 @@ class ThreeBandBiquadEQEffect : public EffectProcessorImpl<ThreeBandBiquadEQEffe
             const EffectEnableState enableState,
             const GroupFeatureState& groupFeatureState) override;
 
-    void setFilters(int sampleRate, double lowFreqCorner, double highFreqCorner);
+    void setFilters(mixxx::audio::SampleRate sampleRate,
+            double lowFreqCorner,
+            double highFreqCorner);
 
   private:
     ThreeBandBiquadEQEffect(const ThreeBandBiquadEQEffect&) = delete;

--- a/src/engine/cachingreader/cachingreader.h
+++ b/src/engine/cachingreader/cachingreader.h
@@ -121,7 +121,9 @@ class CachingReader : public QObject {
   signals:
     // Emitted once a new track is loaded and ready to be read from.
     void trackLoading();
-    void trackLoaded(TrackPointer pTrack, int trackSampleRate, double trackNumSamples);
+    void trackLoaded(TrackPointer pTrack,
+            mixxx::audio::SampleRate trackSampleRate,
+            double trackNumSamples);
     void trackLoadFailed(TrackPointer pTrack, const QString& reason);
 
   private:

--- a/src/engine/cachingreader/cachingreaderworker.h
+++ b/src/engine/cachingreader/cachingreaderworker.h
@@ -7,6 +7,7 @@
 #include <QtDebug>
 
 #include "audio/frame.h"
+#include "audio/types.h"
 #include "engine/cachingreader/cachingreaderchunk.h"
 #include "engine/engineworker.h"
 #include "sources/audiosource.h"
@@ -114,7 +115,7 @@ class CachingReaderWorker : public EngineWorker {
   signals:
     // Emitted once a new track is loaded and ready to be read from.
     void trackLoading();
-    void trackLoaded(TrackPointer pTrack, int sampleRate, double numSamples);
+    void trackLoaded(TrackPointer pTrack, mixxx::audio::SampleRate sampleRate, double numSamples);
     void trackLoadFailed(TrackPointer pTrack, const QString& reason);
 
   private:

--- a/src/engine/channelmixer.cpp
+++ b/src/engine/channelmixer.cpp
@@ -10,7 +10,7 @@ void ChannelMixer::applyEffectsAndMixChannels(const EngineMaster::GainCalculator
         CSAMPLE* pOutput,
         const ChannelHandle& outputHandle,
         unsigned int iBufferSize,
-        unsigned int iSampleRate,
+        mixxx::audio::SampleRate sampleRate,
         EngineEffectsManager* pEngineEffectsManager) {
     // Signal flow overview:
     // 1. Clear pOutput buffer
@@ -42,7 +42,7 @@ void ChannelMixer::applyEffectsAndMixChannels(const EngineMaster::GainCalculator
                 pChannelInfo->m_pBuffer,
                 pOutput,
                 iBufferSize,
-                iSampleRate,
+                sampleRate,
                 pChannelInfo->m_features,
                 oldGain,
                 newGain,
@@ -59,7 +59,7 @@ void ChannelMixer::applyEffectsInPlaceAndMixChannels(
         CSAMPLE* pOutput,
         const ChannelHandle& outputHandle,
         unsigned int iBufferSize,
-        unsigned int iSampleRate,
+        mixxx::audio::SampleRate sampleRate,
         EngineEffectsManager* pEngineEffectsManager) {
     // Signal flow overview:
     // 1. Calculate gains for each channel
@@ -87,7 +87,7 @@ void ChannelMixer::applyEffectsInPlaceAndMixChannels(
                 outputHandle,
                 pChannelInfo->m_pBuffer,
                 iBufferSize,
-                iSampleRate,
+                sampleRate,
                 pChannelInfo->m_features,
                 oldGain,
                 newGain,

--- a/src/engine/channelmixer.h
+++ b/src/engine/channelmixer.h
@@ -2,9 +2,10 @@
 
 #include <QVarLengthArray>
 
-#include "util/types.h"
-#include "engine/enginemaster.h"
+#include "audio/types.h"
 #include "effects/engineeffectsmanager.h"
+#include "engine/enginemaster.h"
+#include "util/types.h"
 
 class ChannelMixer {
   public:
@@ -20,7 +21,7 @@ class ChannelMixer {
             CSAMPLE* pOutput,
             const ChannelHandle& outputHandle,
             unsigned int iBufferSize,
-            unsigned int iSampleRate,
+            mixxx::audio::SampleRate sampleRate,
             EngineEffectsManager* pEngineEffectsManager);
     // This does modify the input channel buffers, then mixes them to make the output buffer.
     static void applyEffectsInPlaceAndMixChannels(
@@ -32,6 +33,6 @@ class ChannelMixer {
             CSAMPLE* pOutput,
             const ChannelHandle& outputHandle,
             unsigned int iBufferSize,
-            unsigned int iSampleRate,
+            mixxx::audio::SampleRate sampleRate,
             EngineEffectsManager* pEngineEffectsManager);
 };

--- a/src/engine/channels/engineaux.cpp
+++ b/src/engine/channels/engineaux.cpp
@@ -79,10 +79,11 @@ void EngineAux::process(CSAMPLE* pOut, const int iBufferSize) {
         SampleUtil::copyWithGain(pOut, sampleBuffer, pregain, iBufferSize);
         EngineEffectsManager* pEngineEffectsManager = m_pEffectsManager->getEngineEffectsManager();
         if (pEngineEffectsManager != nullptr) {
-            pEngineEffectsManager->processPreFaderInPlace(
-                    m_group.handle(), m_pEffectsManager->getMasterHandle(), pOut, iBufferSize,
-                    // TODO(jholthuis): Use mixxx::audio::SampleRate instead
-                    static_cast<unsigned int>(m_sampleRate.get()));
+            pEngineEffectsManager->processPreFaderInPlace(m_group.handle(),
+                    m_pEffectsManager->getMasterHandle(),
+                    pOut,
+                    iBufferSize,
+                    mixxx::audio::SampleRate::fromDouble(m_sampleRate.get()));
         }
         m_sampleBuffer = nullptr;
     } else {

--- a/src/engine/channels/enginedeck.cpp
+++ b/src/engine/channels/enginedeck.cpp
@@ -76,8 +76,7 @@ void EngineDeck::process(CSAMPLE* pOut, const int iBufferSize) {
                 m_pEffectsManager->getMasterHandle(),
                 pOut,
                 iBufferSize,
-                // TODO(jholthuis): Use mixxx::audio::SampleRate instead
-                static_cast<unsigned int>(m_sampleRate.get()));
+                mixxx::audio::SampleRate::fromDouble(m_sampleRate.get()));
     }
 
     // Update VU meter

--- a/src/engine/channels/enginemicrophone.cpp
+++ b/src/engine/channels/enginemicrophone.cpp
@@ -2,6 +2,7 @@
 
 #include <QtDebug>
 
+#include "audio/types.h"
 #include "control/control.h"
 #include "control/controlaudiotaperpot.h"
 #include "effects/effectsmanager.h"
@@ -79,10 +80,11 @@ void EngineMicrophone::process(CSAMPLE* pOut, const int iBufferSize) {
         SampleUtil::copyWithGain(pOut, sampleBuffer, pregain, iBufferSize);
         EngineEffectsManager* pEngineEffectsManager = m_pEffectsManager->getEngineEffectsManager();
         if (pEngineEffectsManager != nullptr) {
-            pEngineEffectsManager->processPreFaderInPlace(
-                    m_group.handle(), m_pEffectsManager->getMasterHandle(), pOut, iBufferSize,
-                    // TODO(jholthuis): Use mixxx::audio::SampleRate instead
-                    static_cast<unsigned int>(m_sampleRate.get()));
+            pEngineEffectsManager->processPreFaderInPlace(m_group.handle(),
+                    m_pEffectsManager->getMasterHandle(),
+                    pOut,
+                    iBufferSize,
+                    mixxx::audio::SampleRate::fromDouble(m_sampleRate.get()));
         }
     } else {
         SampleUtil::clear(pOut, iBufferSize);

--- a/src/engine/effects/engineeffect.cpp
+++ b/src/engine/effects/engineeffect.cpp
@@ -128,7 +128,7 @@ bool EngineEffect::process(const ChannelHandle& inputHandle,
         const CSAMPLE* pInput,
         CSAMPLE* pOutput,
         const unsigned int numSamples,
-        const unsigned int sampleRate,
+        const mixxx::audio::SampleRate sampleRate,
         const EffectEnableState chainEnableState,
         const GroupFeatureState& groupFeatures) {
     // Compute the effective enable state from the combination of the effect's state
@@ -179,7 +179,7 @@ bool EngineEffect::process(const ChannelHandle& inputHandle,
     if (effectiveEffectEnableState != EffectEnableState::Disabled) {
         //TODO: refactor rest of audio engine to use mixxx::AudioParameters
         const mixxx::EngineParameters engineParameters(
-                mixxx::audio::SampleRate(sampleRate),
+                sampleRate,
                 numSamples / mixxx::kEngineChannelCount);
 
         m_pProcessor->process(inputHandle,

--- a/src/engine/effects/engineeffect.h
+++ b/src/engine/effects/engineeffect.h
@@ -7,6 +7,7 @@
 #include <QVector>
 #include <QtDebug>
 
+#include "audio/types.h"
 #include "effects/backends/effectmanifest.h"
 #include "effects/backends/effectprocessor.h"
 #include "effects/effectsmanager.h"
@@ -46,7 +47,7 @@ class EngineEffect final : public EffectsRequestHandler {
             const CSAMPLE* pInput,
             CSAMPLE* pOutput,
             const unsigned int numSamples,
-            const unsigned int sampleRate,
+            const mixxx::audio::SampleRate sampleRate,
             const EffectEnableState chainEnableState,
             const GroupFeatureState& groupFeatures);
 

--- a/src/engine/effects/engineeffectchain.cpp
+++ b/src/engine/effects/engineeffectchain.cpp
@@ -176,7 +176,7 @@ bool EngineEffectChain::process(const ChannelHandle& inputHandle,
         CSAMPLE* pIn,
         CSAMPLE* pOut,
         const unsigned int numSamples,
-        const unsigned int sampleRate,
+        const mixxx::audio::SampleRate sampleRate,
         const GroupFeatureState& groupFeatures,
         bool fadeout) {
     // Compute the effective enable state from the channel input routing switch and

--- a/src/engine/effects/engineeffectchain.h
+++ b/src/engine/effects/engineeffectchain.h
@@ -3,6 +3,7 @@
 #include <QList>
 #include <QString>
 
+#include "audio/types.h"
 #include "engine/channelhandle.h"
 #include "engine/effects/engineeffectsdelay.h"
 #include "engine/effects/groupfeaturestate.h"
@@ -42,7 +43,7 @@ class EngineEffectChain final : public EffectsRequestHandler {
             CSAMPLE* pIn,
             CSAMPLE* pOut,
             const unsigned int numSamples,
-            const unsigned int sampleRate,
+            const mixxx::audio::SampleRate sampleRate,
             const GroupFeatureState& groupFeatures,
             bool fadeout);
 

--- a/src/engine/effects/engineeffectsmanager.cpp
+++ b/src/engine/effects/engineeffectsmanager.cpp
@@ -1,5 +1,6 @@
 #include "engine/effects/engineeffectsmanager.h"
 
+#include "audio/types.h"
 #include "engine/effects/engineeffect.h"
 #include "engine/effects/engineeffectchain.h"
 #include "util/defs.h"
@@ -95,7 +96,7 @@ void EngineEffectsManager::processPreFaderInPlace(const ChannelHandle& inputHand
         const ChannelHandle& outputHandle,
         CSAMPLE* pInOut,
         unsigned int numSamples,
-        unsigned int sampleRate) {
+        mixxx::audio::SampleRate sampleRate) {
     // Feature state is gathered after prefader effects processing.
     // This is okay because the equalizer effects do not make use of it.
     GroupFeatureState featureState;
@@ -114,7 +115,7 @@ void EngineEffectsManager::processPostFaderInPlace(
         const ChannelHandle& outputHandle,
         CSAMPLE* pInOut,
         unsigned int numSamples,
-        unsigned int sampleRate,
+        mixxx::audio::SampleRate sampleRate,
         const GroupFeatureState& groupFeatures,
         CSAMPLE_GAIN oldGain,
         CSAMPLE_GAIN newGain,
@@ -138,7 +139,7 @@ void EngineEffectsManager::processPostFaderAndMix(
         CSAMPLE* pIn,
         CSAMPLE* pOut,
         unsigned int numSamples,
-        unsigned int sampleRate,
+        mixxx::audio::SampleRate sampleRate,
         const GroupFeatureState& groupFeatures,
         CSAMPLE_GAIN oldGain,
         CSAMPLE_GAIN newGain,
@@ -163,7 +164,7 @@ void EngineEffectsManager::processInner(
         CSAMPLE* pIn,
         CSAMPLE* pOut,
         unsigned int numSamples,
-        unsigned int sampleRate,
+        mixxx::audio::SampleRate sampleRate,
         const GroupFeatureState& groupFeatures,
         CSAMPLE_GAIN oldGain,
         CSAMPLE_GAIN newGain,

--- a/src/engine/effects/engineeffectsmanager.h
+++ b/src/engine/effects/engineeffectsmanager.h
@@ -2,6 +2,7 @@
 
 #include <QScopedPointer>
 
+#include "audio/types.h"
 #include "engine/channelhandle.h"
 #include "engine/effects/groupfeaturestate.h"
 #include "engine/effects/message.h"
@@ -34,7 +35,7 @@ class EngineEffectsManager final : public EffectsRequestHandler {
             const ChannelHandle& outputHandle,
             CSAMPLE* pInOut,
             unsigned int numSamples,
-            unsigned int sampleRate);
+            mixxx::audio::SampleRate sampleRate);
 
     /// Process the postfader EngineEffectChains on the pInOut buffer, modifying
     /// the contents of the input buffer.
@@ -43,7 +44,7 @@ class EngineEffectsManager final : public EffectsRequestHandler {
             const ChannelHandle& outputHandle,
             CSAMPLE* pInOut,
             unsigned int numSamples,
-            unsigned int sampleRate,
+            mixxx::audio::SampleRate sampleRate,
             const GroupFeatureState& groupFeatures,
             CSAMPLE_GAIN oldGain = CSAMPLE_GAIN_ONE,
             CSAMPLE_GAIN newGain = CSAMPLE_GAIN_ONE,
@@ -60,7 +61,7 @@ class EngineEffectsManager final : public EffectsRequestHandler {
             CSAMPLE* pIn,
             CSAMPLE* pOut,
             unsigned int numSamples,
-            unsigned int sampleRate,
+            mixxx::audio::SampleRate sampleRate,
             const GroupFeatureState& groupFeatures,
             CSAMPLE_GAIN oldGain = CSAMPLE_GAIN_ONE,
             CSAMPLE_GAIN newGain = CSAMPLE_GAIN_ONE,
@@ -91,7 +92,7 @@ class EngineEffectsManager final : public EffectsRequestHandler {
             CSAMPLE* pIn,
             CSAMPLE* pOut,
             unsigned int numSamples,
-            unsigned int sampleRate,
+            mixxx::audio::SampleRate sampleRate,
             const GroupFeatureState& groupFeatures,
             CSAMPLE_GAIN oldGain = CSAMPLE_GAIN_ONE,
             CSAMPLE_GAIN newGain = CSAMPLE_GAIN_ONE,

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -535,7 +535,7 @@ void EngineBuffer::loadFakeTrack(TrackPointer pTrack, bool bPlay) {
 
 // WARNING: Always called from the EngineWorker thread pool
 void EngineBuffer::slotTrackLoaded(TrackPointer pTrack,
-        int trackSampleRate,
+        mixxx::audio::SampleRate trackSampleRate,
         double trackNumSamples) {
     if (kLogger.traceEnabled()) {
         kLogger.trace() << getGroup() << "EngineBuffer::slotTrackLoaded";
@@ -547,7 +547,7 @@ void EngineBuffer::slotTrackLoaded(TrackPointer pTrack,
     m_playPosition = kInitialPlayPosition; // for execute seeks to 0.0
     m_pCurrentTrack = pTrack;
     m_pTrackSamples->set(trackNumSamples);
-    m_pTrackSampleRate->set(trackSampleRate);
+    m_pTrackSampleRate->set(trackSampleRate.toDouble());
     m_pTrackLoaded->forceSet(1);
 
     // Reset slip mode

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -8,6 +8,7 @@
 #include <initializer_list>
 
 #include "audio/frame.h"
+#include "audio/types.h"
 #include "control/controlvalue.h"
 #include "engine/bufferscalers/enginebufferscalerubberband.h"
 #include "engine/cachingreader/cachingreader.h"
@@ -215,7 +216,7 @@ class EngineBuffer : public EngineObject {
     void slotTrackLoading();
     void slotTrackLoaded(
             TrackPointer pTrack,
-            int trackSampleRate,
+            mixxx::audio::SampleRate trackSampleRate,
             double trackNumSamples);
     void slotTrackLoadFailed(TrackPointer pTrack,
             const QString& reason);

--- a/src/engine/enginemaster.cpp
+++ b/src/engine/enginemaster.cpp
@@ -439,7 +439,7 @@ void EngineMaster::process(const int iBufferSize) {
                 m_pHead,
                 m_headphoneHandle.handle(),
                 iBufferSize,
-                static_cast<int>(m_sampleRate.value()),
+                m_sampleRate,
                 m_pEngineEffectsManager);
 
         // Process headphone channel effects
@@ -459,7 +459,7 @@ void EngineMaster::process(const int iBufferSize) {
                     m_headphoneHandle.handle(),
                     m_pHead,
                     iBufferSize,
-                    static_cast<int>(m_sampleRate.value()),
+                    m_sampleRate,
                     headphoneFeatures);
         }
     }
@@ -473,7 +473,7 @@ void EngineMaster::process(const int iBufferSize) {
             m_pTalkover,
             m_masterHandle.handle(),
             iBufferSize,
-            static_cast<int>(m_sampleRate.value()),
+            m_sampleRate,
             m_pEngineEffectsManager);
 
     // Process effects on all microphones mixed together
@@ -485,7 +485,7 @@ void EngineMaster::process(const int iBufferSize) {
                 m_masterHandle.handle(),
                 m_pTalkover,
                 iBufferSize,
-                static_cast<int>(m_sampleRate.value()),
+                m_sampleRate,
                 busFeatures,
                 CSAMPLE_GAIN_ONE,
                 CSAMPLE_GAIN_ONE,
@@ -533,7 +533,7 @@ void EngineMaster::process(const int iBufferSize) {
                 m_pOutputBusBuffers[o],
                 m_masterHandle.handle(),
                 iBufferSize,
-                static_cast<int>(m_sampleRate.value()),
+                m_sampleRate,
                 m_pEngineEffectsManager);
     }
 
@@ -544,7 +544,7 @@ void EngineMaster::process(const int iBufferSize) {
                 m_masterHandle.handle(),
                 m_pOutputBusBuffers[EngineChannel::LEFT],
                 iBufferSize,
-                static_cast<int>(m_sampleRate.value()),
+                m_sampleRate,
                 busFeatures,
                 CSAMPLE_GAIN_ONE,
                 CSAMPLE_GAIN_ONE,
@@ -554,7 +554,7 @@ void EngineMaster::process(const int iBufferSize) {
                 m_masterHandle.handle(),
                 m_pOutputBusBuffers[EngineChannel::CENTER],
                 iBufferSize,
-                static_cast<int>(m_sampleRate.value()),
+                m_sampleRate,
                 busFeatures,
                 CSAMPLE_GAIN_ONE,
                 CSAMPLE_GAIN_ONE,
@@ -564,7 +564,7 @@ void EngineMaster::process(const int iBufferSize) {
                 m_masterHandle.handle(),
                 m_pOutputBusBuffers[EngineChannel::RIGHT],
                 iBufferSize,
-                static_cast<int>(m_sampleRate.value()),
+                m_sampleRate,
                 busFeatures,
                 CSAMPLE_GAIN_ONE,
                 CSAMPLE_GAIN_ONE,
@@ -756,7 +756,7 @@ void EngineMaster::process(const int iBufferSize) {
                     m_masterHandle.handle(),
                     m_pMaster,
                     iBufferSize,
-                    static_cast<int>(m_sampleRate.value()),
+                    m_sampleRate,
                     masterFeatures);
         }
 
@@ -815,7 +815,7 @@ void EngineMaster::applyMasterEffects(int iBufferSize) {
                 m_masterHandle.handle(),
                 m_pMaster,
                 iBufferSize,
-                static_cast<int>(m_sampleRate.value()),
+                m_sampleRate,
                 masterFeatures,
                 CSAMPLE_GAIN_ONE,
                 CSAMPLE_GAIN_ONE,

--- a/src/engine/enginevumeter.cpp
+++ b/src/engine/enginevumeter.cpp
@@ -61,14 +61,14 @@ void EngineVuMeter::process(CSAMPLE* pIn, const int iBufferSize) {
     m_fRMSvolumeSumL += fVolSumL;
     m_fRMSvolumeSumR += fVolSumR;
 
-    m_iSamplesCalculated += static_cast<unsigned int>(iBufferSize / 2);
+    m_samplesCalculated += static_cast<unsigned int>(iBufferSize / 2);
 
     // Are we ready to update the VU meter?:
-    if (m_iSamplesCalculated > (sampleRate / kVuUpdateRate)) {
+    if (m_samplesCalculated > (sampleRate / kVuUpdateRate)) {
         doSmooth(m_fRMSvolumeL,
-                std::log10(SHRT_MAX * m_fRMSvolumeSumL / (m_iSamplesCalculated * 1000) + 1));
+                std::log10(SHRT_MAX * m_fRMSvolumeSumL / (m_samplesCalculated * 1000) + 1));
         doSmooth(m_fRMSvolumeR,
-                std::log10(SHRT_MAX * m_fRMSvolumeSumR / (m_iSamplesCalculated * 1000) + 1));
+                std::log10(SHRT_MAX * m_fRMSvolumeSumR / (m_samplesCalculated * 1000) + 1));
 
         const double epsilon = .0001;
 
@@ -89,7 +89,7 @@ void EngineVuMeter::process(CSAMPLE* pIn, const int iBufferSize) {
         }
 
         // Reset calculation:
-        m_iSamplesCalculated = 0;
+        m_samplesCalculated = 0;
         m_fRMSvolumeSumL = 0;
         m_fRMSvolumeSumR = 0;
     }
@@ -141,7 +141,7 @@ void EngineVuMeter::reset() {
     m_ctrlPeakIndicatorL->set(0);
     m_ctrlPeakIndicatorR->set(0);
 
-    m_iSamplesCalculated = 0;
+    m_samplesCalculated = 0;
     m_fRMSvolumeL = 0;
     m_fRMSvolumeSumL = 0;
     m_fRMSvolumeR = 0;

--- a/src/engine/enginevumeter.cpp
+++ b/src/engine/enginevumeter.cpp
@@ -1,5 +1,6 @@
 #include "engine/enginevumeter.h"
 
+#include "audio/types.h"
 #include "control/controlpotmeter.h"
 #include "control/controlproxy.h"
 #include "moc_enginevumeter.cpp"
@@ -8,7 +9,7 @@
 namespace {
 
 // Rate at which the vumeter is updated (using a sample rate of 44100 Hz):
-constexpr int kVuUpdateRate = 30;  // in 1/s, fits to display frame rate
+constexpr unsigned int kVuUpdateRate = 30; // in Hz (1/s), fits to display frame rate
 constexpr int kPeakDuration = 500; // in ms
 
 // Smoothing Factors
@@ -53,14 +54,14 @@ EngineVuMeter::~EngineVuMeter()
 void EngineVuMeter::process(CSAMPLE* pIn, const int iBufferSize) {
     CSAMPLE fVolSumL, fVolSumR;
 
-    int sampleRate = static_cast<int>(m_sampleRate.get());
+    const auto sampleRate = mixxx::audio::SampleRate::fromDouble(m_sampleRate.get());
 
     SampleUtil::CLIP_STATUS clipped = SampleUtil::sumAbsPerChannel(&fVolSumL,
             &fVolSumR, pIn, iBufferSize);
     m_fRMSvolumeSumL += fVolSumL;
     m_fRMSvolumeSumR += fVolSumR;
 
-    m_iSamplesCalculated += iBufferSize / 2;
+    m_iSamplesCalculated += static_cast<unsigned int>(iBufferSize / 2);
 
     // Are we ready to update the VU meter?:
     if (m_iSamplesCalculated > (sampleRate / kVuUpdateRate)) {

--- a/src/engine/enginevumeter.h
+++ b/src/engine/enginevumeter.h
@@ -25,7 +25,7 @@ class EngineVuMeter : public EngineObject {
     CSAMPLE m_fRMSvolumeSumL;
     CSAMPLE m_fRMSvolumeR;
     CSAMPLE m_fRMSvolumeSumR;
-    unsigned int m_iSamplesCalculated;
+    unsigned int m_samplesCalculated;
 
     ControlPotmeter* m_ctrlPeakIndicator;
     ControlPotmeter* m_ctrlPeakIndicatorL;

--- a/src/engine/enginevumeter.h
+++ b/src/engine/enginevumeter.h
@@ -25,7 +25,7 @@ class EngineVuMeter : public EngineObject {
     CSAMPLE m_fRMSvolumeSumL;
     CSAMPLE m_fRMSvolumeR;
     CSAMPLE m_fRMSvolumeSumR;
-    int m_iSamplesCalculated;
+    unsigned int m_iSamplesCalculated;
 
     ControlPotmeter* m_ctrlPeakIndicator;
     ControlPotmeter* m_ctrlPeakIndicatorL;

--- a/src/engine/filters/enginefilterbessel4.cpp
+++ b/src/engine/filters/enginefilterbessel4.cpp
@@ -9,13 +9,13 @@ constexpr char kFidSpecBandPassBessel4[] = "BpBe4";
 constexpr char kFidSpecHighPassBessel4[] = "HpBe4";
 } // namespace
 
-EngineFilterBessel4Low::EngineFilterBessel4Low(int sampleRate,
-                                               double freqCorner1) {
+EngineFilterBessel4Low::EngineFilterBessel4Low(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1) {
     setFrequencyCorners(sampleRate, freqCorner1);
 }
 
-void EngineFilterBessel4Low::setFrequencyCorners(int sampleRate,
-                                                 double freqCorner1) {
+void EngineFilterBessel4Low::setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1) {
     // Copy the old coefficients into m_oldCoef
     setCoefs(kFidSpecLowPassBessel4, sizeof(kFidSpecLowPassBessel4), sampleRate, freqCorner1);
 }
@@ -64,15 +64,15 @@ int EngineFilterBessel4Low::setFrequencyCornersForIntDelay(
     return iDelay;
 }
 
-EngineFilterBessel4Band::EngineFilterBessel4Band(int sampleRate,
-                                                 double freqCorner1,
-                                                 double freqCorner2) {
+EngineFilterBessel4Band::EngineFilterBessel4Band(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1,
+        double freqCorner2) {
     setFrequencyCorners(sampleRate, freqCorner1, freqCorner2);
 }
 
-void EngineFilterBessel4Band::setFrequencyCorners(int sampleRate,
-                                                  double freqCorner1,
-                                                  double freqCorner2) {
+void EngineFilterBessel4Band::setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1,
+        double freqCorner2) {
     setCoefs(kFidSpecBandPassBessel4,
             sizeof(kFidSpecBandPassBessel4),
             sampleRate,
@@ -80,13 +80,12 @@ void EngineFilterBessel4Band::setFrequencyCorners(int sampleRate,
             freqCorner2);
 }
 
-
-EngineFilterBessel4High::EngineFilterBessel4High(int sampleRate,
-                                                 double freqCorner1) {
+EngineFilterBessel4High::EngineFilterBessel4High(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1) {
     setFrequencyCorners(sampleRate, freqCorner1);
 }
 
-void EngineFilterBessel4High::setFrequencyCorners(int sampleRate,
-                                                  double freqCorner1) {
+void EngineFilterBessel4High::setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1) {
     setCoefs(kFidSpecHighPassBessel4, sizeof(kFidSpecHighPassBessel4), sampleRate, freqCorner1);
 }

--- a/src/engine/filters/enginefilterbessel4.h
+++ b/src/engine/filters/enginefilterbessel4.h
@@ -1,12 +1,13 @@
 #pragma once
 
+#include "audio/types.h"
 #include "engine/filters/enginefilteriir.h"
 
 class EngineFilterBessel4Low : public EngineFilterIIR<4, IIR_LP> {
     Q_OBJECT
   public:
-    EngineFilterBessel4Low(int sampleRate, double freqCorner1);
-    void setFrequencyCorners(int sampleRate, double freqCorner1);
+    EngineFilterBessel4Low(mixxx::audio::SampleRate sampleRate, double freqCorner1);
+    void setFrequencyCorners(mixxx::audio::SampleRate sampleRate, double freqCorner1);
     // This function selects a corner frequency near the
     // desiredCorner1Ratio freqCorner / sampleRate
     // the produces an integer group delay at the passband
@@ -17,15 +18,17 @@ class EngineFilterBessel4Low : public EngineFilterIIR<4, IIR_LP> {
 class EngineFilterBessel4Band : public EngineFilterIIR<8, IIR_BP> {
     Q_OBJECT
   public:
-    EngineFilterBessel4Band(int sampleRate, double freqCorner1,
+    EngineFilterBessel4Band(mixxx::audio::SampleRate sampleRate,
+            double freqCorner1,
             double freqCorner2);
-    void setFrequencyCorners(int sampleRate, double freqCorner1,
+    void setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+            double freqCorner1,
             double freqCorner2);
 };
 
 class EngineFilterBessel4High : public EngineFilterIIR<4, IIR_HP> {
     Q_OBJECT
   public:
-    EngineFilterBessel4High(int sampleRate, double freqCorner1);
-    void setFrequencyCorners(int sampleRate, double freqCorner1);
+    EngineFilterBessel4High(mixxx::audio::SampleRate sampleRate, double freqCorner1);
+    void setFrequencyCorners(mixxx::audio::SampleRate sampleRate, double freqCorner1);
 };

--- a/src/engine/filters/enginefilterbessel8.cpp
+++ b/src/engine/filters/enginefilterbessel8.cpp
@@ -9,17 +9,16 @@ constexpr char kFidSpecBandPassBessel8[] = "BpBe8";
 constexpr char kFidSpecHighPassBessel8[] = "HpBe8";
 } // namespace
 
-EngineFilterBessel8Low::EngineFilterBessel8Low(int sampleRate,
-                                               double freqCorner1) {
+EngineFilterBessel8Low::EngineFilterBessel8Low(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1) {
     setFrequencyCorners(sampleRate, freqCorner1);
 }
 
-void EngineFilterBessel8Low::setFrequencyCorners(int sampleRate,
-                                                 double freqCorner1) {
+void EngineFilterBessel8Low::setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1) {
     // Copy the old coefficients into m_oldCoef
     setCoefs(kFidSpecLowPassBessel8, sizeof(kFidSpecLowPassBessel8), sampleRate, freqCorner1);
 }
-
 
 int EngineFilterBessel8Low::setFrequencyCornersForIntDelay(
         double desiredCorner1Ratio, int maxDelay) {
@@ -72,15 +71,15 @@ int EngineFilterBessel8Low::setFrequencyCornersForIntDelay(
     return iDelay;
 }
 
-EngineFilterBessel8Band::EngineFilterBessel8Band(int sampleRate,
-                                                 double freqCorner1,
-                                                 double freqCorner2) {
+EngineFilterBessel8Band::EngineFilterBessel8Band(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1,
+        double freqCorner2) {
     setFrequencyCorners(sampleRate, freqCorner1, freqCorner2);
 }
 
-void EngineFilterBessel8Band::setFrequencyCorners(int sampleRate,
-                                                  double freqCorner1,
-                                                  double freqCorner2) {
+void EngineFilterBessel8Band::setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1,
+        double freqCorner2) {
     setCoefs(kFidSpecBandPassBessel8,
             sizeof(kFidSpecBandPassBessel8),
             sampleRate,
@@ -88,13 +87,12 @@ void EngineFilterBessel8Band::setFrequencyCorners(int sampleRate,
             freqCorner2);
 }
 
-
-EngineFilterBessel8High::EngineFilterBessel8High(int sampleRate,
-                                                 double freqCorner1) {
+EngineFilterBessel8High::EngineFilterBessel8High(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1) {
     setFrequencyCorners(sampleRate, freqCorner1);
 }
 
-void EngineFilterBessel8High::setFrequencyCorners(int sampleRate,
-                                                  double freqCorner1) {
+void EngineFilterBessel8High::setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1) {
     setCoefs(kFidSpecHighPassBessel8, sizeof(kFidSpecHighPassBessel8), sampleRate, freqCorner1);
 }

--- a/src/engine/filters/enginefilterbessel8.h
+++ b/src/engine/filters/enginefilterbessel8.h
@@ -1,12 +1,13 @@
 #pragma once
 
+#include "audio/types.h"
 #include "engine/filters/enginefilteriir.h"
 
 class EngineFilterBessel8Low : public EngineFilterIIR<8, IIR_LP> {
     Q_OBJECT
   public:
-    EngineFilterBessel8Low(int sampleRate, double freqCorner1);
-    void setFrequencyCorners(int sampleRate, double freqCorner1);
+    EngineFilterBessel8Low(mixxx::audio::SampleRate sampleRate, double freqCorner1);
+    void setFrequencyCorners(mixxx::audio::SampleRate sampleRate, double freqCorner1);
     // This function selects a corner frequency near the
     // desiredCorner1Ratio freqCorner / sampleRate
     // the produces an integer group delay at the passband
@@ -17,15 +18,17 @@ class EngineFilterBessel8Low : public EngineFilterIIR<8, IIR_LP> {
 class EngineFilterBessel8Band : public EngineFilterIIR<16, IIR_BP> {
     Q_OBJECT
   public:
-    EngineFilterBessel8Band(int sampleRate, double freqCorner1,
+    EngineFilterBessel8Band(mixxx::audio::SampleRate sampleRate,
+            double freqCorner1,
             double freqCorner2);
-    void setFrequencyCorners(int sampleRate, double freqCorner1,
+    void setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+            double freqCorner1,
             double freqCorner2);
 };
 
 class EngineFilterBessel8High : public EngineFilterIIR<8, IIR_HP> {
     Q_OBJECT
   public:
-    EngineFilterBessel8High(int sampleRate, double freqCorner1);
-    void setFrequencyCorners(int sampleRate, double freqCorner1);
+    EngineFilterBessel8High(mixxx::audio::SampleRate sampleRate, double freqCorner1);
+    void setFrequencyCorners(mixxx::audio::SampleRate sampleRate, double freqCorner1);
 };

--- a/src/engine/filters/enginefilterbiquad1.cpp
+++ b/src/engine/filters/enginefilterbiquad1.cpp
@@ -4,89 +4,89 @@
 
 #include "moc_enginefilterbiquad1.cpp"
 
-EngineFilterBiquad1LowShelving::EngineFilterBiquad1LowShelving(int sampleRate,
-                                                               double centerFreq,
-                                                               double Q) {
+EngineFilterBiquad1LowShelving::EngineFilterBiquad1LowShelving(mixxx::audio::SampleRate sampleRate,
+        double centerFreq,
+        double Q) {
     m_startFromDry = true;
     setFrequencyCorners(sampleRate, centerFreq, Q, 0);
 }
 
-void EngineFilterBiquad1LowShelving::setFrequencyCorners(int sampleRate,
-                                                         double centerFreq,
-                                                         double Q,
-                                                         double dBgain) {
+void EngineFilterBiquad1LowShelving::setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+        double centerFreq,
+        double Q,
+        double dBgain) {
     format_fidspec(m_spec, sizeof(m_spec), "LsBq/%.10f/%.10f", Q, dBgain);
     setCoefs(m_spec, sizeof(m_spec), sampleRate, centerFreq);
 }
 
-EngineFilterBiquad1Peaking::EngineFilterBiquad1Peaking(int sampleRate,
-                                                       double centerFreq, double Q) {
+EngineFilterBiquad1Peaking::EngineFilterBiquad1Peaking(mixxx::audio::SampleRate sampleRate,
+        double centerFreq,
+        double Q) {
     m_startFromDry = true;
     setFrequencyCorners(sampleRate, centerFreq, Q, 0);
 }
 
-void EngineFilterBiquad1Peaking::setFrequencyCorners(int sampleRate,
-                                                     double centerFreq,
-                                                     double Q,
-                                                     double dBgain) {
+void EngineFilterBiquad1Peaking::setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+        double centerFreq,
+        double Q,
+        double dBgain) {
     format_fidspec(m_spec, sizeof(m_spec), "PkBq/%.10f/%.10f", Q, dBgain);
     setCoefs(m_spec, sizeof(m_spec), sampleRate, centerFreq);
 }
 
-EngineFilterBiquad1HighShelving::EngineFilterBiquad1HighShelving(int sampleRate,
-                                                                 double centerFreq,
-                                                                 double Q) {
+EngineFilterBiquad1HighShelving::EngineFilterBiquad1HighShelving(
+        mixxx::audio::SampleRate sampleRate, double centerFreq, double Q) {
     m_startFromDry = true;
     setFrequencyCorners(sampleRate, centerFreq, Q, 0);
 }
 
-void EngineFilterBiquad1HighShelving::setFrequencyCorners(int sampleRate,
-                                                          double centerFreq,
-                                                          double Q,
-                                                          double dBgain) {
+void EngineFilterBiquad1HighShelving::setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+        double centerFreq,
+        double Q,
+        double dBgain) {
     format_fidspec(m_spec, sizeof(m_spec), "HsBq/%.10f/%.10f", Q, dBgain);
     setCoefs(m_spec, sizeof(m_spec), sampleRate, centerFreq);
 }
 
-EngineFilterBiquad1Low::EngineFilterBiquad1Low(int sampleRate,
-                                               double centerFreq,
-                                               double Q,
-                                               bool startFromDry) {
+EngineFilterBiquad1Low::EngineFilterBiquad1Low(mixxx::audio::SampleRate sampleRate,
+        double centerFreq,
+        double Q,
+        bool startFromDry) {
     m_startFromDry = startFromDry;
     setFrequencyCorners(sampleRate, centerFreq, Q);
 }
 
-void EngineFilterBiquad1Low::setFrequencyCorners(int sampleRate,
-                                                 double centerFreq,
-                                                 double Q) {
+void EngineFilterBiquad1Low::setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+        double centerFreq,
+        double Q) {
     format_fidspec(m_spec, sizeof(m_spec), "LpBq/%.10f", Q);
     setCoefs(m_spec, sizeof(m_spec), sampleRate, centerFreq);
 }
 
-EngineFilterBiquad1Band::EngineFilterBiquad1Band(int sampleRate,
-                                                 double centerFreq,
-                                                 double Q) {
+EngineFilterBiquad1Band::EngineFilterBiquad1Band(mixxx::audio::SampleRate sampleRate,
+        double centerFreq,
+        double Q) {
     setFrequencyCorners(sampleRate, centerFreq, Q);
 }
 
-void EngineFilterBiquad1Band::setFrequencyCorners(int sampleRate,
-                                                  double centerFreq,
-                                                  double Q) {
+void EngineFilterBiquad1Band::setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+        double centerFreq,
+        double Q) {
     format_fidspec(m_spec, sizeof(m_spec), "BpBq/%.10f", Q);
     setCoefs(m_spec, sizeof(m_spec), sampleRate, centerFreq);
 }
 
-EngineFilterBiquad1High::EngineFilterBiquad1High(int sampleRate,
-                                                 double centerFreq,
-                                                 double Q,
-                                                 bool startFromDry) {
+EngineFilterBiquad1High::EngineFilterBiquad1High(mixxx::audio::SampleRate sampleRate,
+        double centerFreq,
+        double Q,
+        bool startFromDry) {
     m_startFromDry = startFromDry;
     setFrequencyCorners(sampleRate, centerFreq, Q);
 }
 
-void EngineFilterBiquad1High::setFrequencyCorners(int sampleRate,
-                                                  double centerFreq,
-                                                  double Q) {
+void EngineFilterBiquad1High::setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+        double centerFreq,
+        double Q) {
     format_fidspec(m_spec, sizeof(m_spec), "HpBq/%.10f", Q);
     setCoefs(m_spec, sizeof(m_spec), sampleRate, centerFreq);
 }

--- a/src/engine/filters/enginefilterbiquad1.h
+++ b/src/engine/filters/enginefilterbiquad1.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "audio/types.h"
 #include "engine/filters/enginefilteriir.h"
 
 #ifdef _MSC_VER
@@ -12,9 +13,12 @@
 class EngineFilterBiquad1LowShelving : public EngineFilterIIR<5, IIR_BP> {
     Q_OBJECT
   public:
-    EngineFilterBiquad1LowShelving(int sampleRate, double centerFreq, double Q);
-    void setFrequencyCorners(int sampleRate, double centerFreq,
-                             double Q, double dBgain);
+    EngineFilterBiquad1LowShelving(
+            mixxx::audio::SampleRate sampleRate, double centerFreq, double Q);
+    void setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+            double centerFreq,
+            double Q,
+            double dBgain);
 
   private:
     char m_spec[FIDSPEC_LENGTH];
@@ -23,9 +27,11 @@ class EngineFilterBiquad1LowShelving : public EngineFilterIIR<5, IIR_BP> {
 class EngineFilterBiquad1Peaking : public EngineFilterIIR<5, IIR_BP> {
     Q_OBJECT
   public:
-    EngineFilterBiquad1Peaking(int sampleRate, double centerFreq, double Q);
-    void setFrequencyCorners(int sampleRate, double centerFreq,
-                             double Q, double dBgain);
+    EngineFilterBiquad1Peaking(mixxx::audio::SampleRate sampleRate, double centerFreq, double Q);
+    void setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+            double centerFreq,
+            double Q,
+            double dBgain);
 
   private:
     char m_spec[FIDSPEC_LENGTH];
@@ -34,9 +40,12 @@ class EngineFilterBiquad1Peaking : public EngineFilterIIR<5, IIR_BP> {
 class EngineFilterBiquad1HighShelving : public EngineFilterIIR<5, IIR_BP> {
     Q_OBJECT
   public:
-    EngineFilterBiquad1HighShelving(int sampleRate, double centerFreq, double Q);
-    void setFrequencyCorners(int sampleRate, double centerFreq,
-                             double Q, double dBgain);
+    EngineFilterBiquad1HighShelving(
+            mixxx::audio::SampleRate sampleRate, double centerFreq, double Q);
+    void setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+            double centerFreq,
+            double Q,
+            double dBgain);
 
   private:
     char m_spec[FIDSPEC_LENGTH];
@@ -45,9 +54,11 @@ class EngineFilterBiquad1HighShelving : public EngineFilterIIR<5, IIR_BP> {
 class EngineFilterBiquad1Low : public EngineFilterIIR<2, IIR_LP> {
     Q_OBJECT
   public:
-    EngineFilterBiquad1Low(int sampleRate, double centerFreq, double Q,
-                           bool startFromDry);
-    void setFrequencyCorners(int sampleRate, double centerFreq, double Q);
+    EngineFilterBiquad1Low(mixxx::audio::SampleRate sampleRate,
+            double centerFreq,
+            double Q,
+            bool startFromDry);
+    void setFrequencyCorners(mixxx::audio::SampleRate sampleRate, double centerFreq, double Q);
 
   private:
     char m_spec[FIDSPEC_LENGTH];
@@ -56,8 +67,8 @@ class EngineFilterBiquad1Low : public EngineFilterIIR<2, IIR_LP> {
 class EngineFilterBiquad1Band : public EngineFilterIIR<2, IIR_BP> {
     Q_OBJECT
   public:
-    EngineFilterBiquad1Band(int sampleRate, double centerFreq, double Q);
-    void setFrequencyCorners(int sampleRate, double centerFreq, double Q);
+    EngineFilterBiquad1Band(mixxx::audio::SampleRate sampleRate, double centerFreq, double Q);
+    void setFrequencyCorners(mixxx::audio::SampleRate sampleRate, double centerFreq, double Q);
 
   private:
     char m_spec[FIDSPEC_LENGTH];
@@ -66,9 +77,11 @@ class EngineFilterBiquad1Band : public EngineFilterIIR<2, IIR_BP> {
 class EngineFilterBiquad1High : public EngineFilterIIR<2, IIR_HP> {
     Q_OBJECT
   public:
-    EngineFilterBiquad1High(int sampleRate, double centerFreq, double Q,
-                            bool startFromDry);
-    void setFrequencyCorners(int sampleRate, double centerFreq, double Q);
+    EngineFilterBiquad1High(mixxx::audio::SampleRate sampleRate,
+            double centerFreq,
+            double Q,
+            bool startFromDry);
+    void setFrequencyCorners(mixxx::audio::SampleRate sampleRate, double centerFreq, double Q);
 
   private:
     char m_spec[FIDSPEC_LENGTH];

--- a/src/engine/filters/enginefilterbutterworth4.cpp
+++ b/src/engine/filters/enginefilterbutterworth4.cpp
@@ -8,12 +8,13 @@ constexpr char kFidSpecBandPassButterworth4[] = "BpBu4";
 constexpr char kFidSpecHighPassButterworth4[] = "HpBu4";
 } // namespace
 
-EngineFilterButterworth4Low::EngineFilterButterworth4Low(int sampleRate, double freqCorner1) {
+EngineFilterButterworth4Low::EngineFilterButterworth4Low(
+        mixxx::audio::SampleRate sampleRate, double freqCorner1) {
     setFrequencyCorners(sampleRate, freqCorner1);
 }
 
-void EngineFilterButterworth4Low::setFrequencyCorners(int sampleRate,
-                                             double freqCorner1) {
+void EngineFilterButterworth4Low::setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1) {
     // Copy the old coefficients into m_oldCoef
     setCoefs(kFidSpecLowPassButterworth4,
             sizeof(kFidSpecLowPassButterworth4),
@@ -21,15 +22,16 @@ void EngineFilterButterworth4Low::setFrequencyCorners(int sampleRate,
             freqCorner1);
 }
 
-
-EngineFilterButterworth4Band::EngineFilterButterworth4Band(int sampleRate, double freqCorner1,
-                                         double freqCorner2) {
+EngineFilterButterworth4Band::EngineFilterButterworth4Band(
+        mixxx::audio::SampleRate sampleRate,
+        double freqCorner1,
+        double freqCorner2) {
     setFrequencyCorners(sampleRate, freqCorner1, freqCorner2);
 }
 
-void EngineFilterButterworth4Band::setFrequencyCorners(int sampleRate,
-                                             double freqCorner1,
-                                             double freqCorner2) {
+void EngineFilterButterworth4Band::setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1,
+        double freqCorner2) {
     setCoefs(kFidSpecBandPassButterworth4,
             sizeof(kFidSpecBandPassButterworth4),
             sampleRate,
@@ -37,13 +39,13 @@ void EngineFilterButterworth4Band::setFrequencyCorners(int sampleRate,
             freqCorner2);
 }
 
-
-EngineFilterButterworth4High::EngineFilterButterworth4High(int sampleRate, double freqCorner1) {
+EngineFilterButterworth4High::EngineFilterButterworth4High(
+        mixxx::audio::SampleRate sampleRate, double freqCorner1) {
     setFrequencyCorners(sampleRate, freqCorner1);
 }
 
-void EngineFilterButterworth4High::setFrequencyCorners(int sampleRate,
-                                             double freqCorner1) {
+void EngineFilterButterworth4High::setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1) {
     setCoefs(kFidSpecHighPassButterworth4,
             sizeof(kFidSpecHighPassButterworth4),
             sampleRate,

--- a/src/engine/filters/enginefilterbutterworth4.h
+++ b/src/engine/filters/enginefilterbutterworth4.h
@@ -1,26 +1,29 @@
 #pragma once
 
+#include "audio/types.h"
 #include "engine/filters/enginefilteriir.h"
 
 class EngineFilterButterworth4Low : public EngineFilterIIR<4, IIR_LP> {
     Q_OBJECT
   public:
-    EngineFilterButterworth4Low(int sampleRate, double freqCorner1);
-    void setFrequencyCorners(int sampleRate, double freqCorner1);
+    EngineFilterButterworth4Low(mixxx::audio::SampleRate sampleRate, double freqCorner1);
+    void setFrequencyCorners(mixxx::audio::SampleRate sampleRate, double freqCorner1);
 };
 
 class EngineFilterButterworth4Band : public EngineFilterIIR<8, IIR_BP> {
     Q_OBJECT
   public:
-    EngineFilterButterworth4Band(int sampleRate, double freqCorner1,
+    EngineFilterButterworth4Band(mixxx::audio::SampleRate sampleRate,
+            double freqCorner1,
             double freqCorner2);
-    void setFrequencyCorners(int sampleRate, double freqCorner1,
+    void setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+            double freqCorner1,
             double freqCorner2);
 };
 
 class EngineFilterButterworth4High : public EngineFilterIIR<4, IIR_HP> {
     Q_OBJECT
   public:
-    EngineFilterButterworth4High(int sampleRate, double freqCorner1);
-    void setFrequencyCorners(int sampleRate, double freqCorner1);
+    EngineFilterButterworth4High(mixxx::audio::SampleRate sampleRate, double freqCorner1);
+    void setFrequencyCorners(mixxx::audio::SampleRate sampleRate, double freqCorner1);
 };

--- a/src/engine/filters/enginefilterbutterworth8.cpp
+++ b/src/engine/filters/enginefilterbutterworth8.cpp
@@ -8,12 +8,13 @@ constexpr char kFidSpecBandPassButterworth8[] = "BpBu8";
 constexpr char kFidSpecHighPassButterworth8[] = "HpBu8";
 } // namespace
 
-EngineFilterButterworth8Low::EngineFilterButterworth8Low(int sampleRate, double freqCorner1) {
+EngineFilterButterworth8Low::EngineFilterButterworth8Low(
+        mixxx::audio::SampleRate sampleRate, double freqCorner1) {
     setFrequencyCorners(sampleRate, freqCorner1);
 }
 
-void EngineFilterButterworth8Low::setFrequencyCorners(int sampleRate,
-                                             double freqCorner1) {
+void EngineFilterButterworth8Low::setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1) {
     // Copy the old coefficients into m_oldCoef
     setCoefs(kFidSpecLowPassButterworth8,
             sizeof(kFidSpecLowPassButterworth8),
@@ -21,15 +22,16 @@ void EngineFilterButterworth8Low::setFrequencyCorners(int sampleRate,
             freqCorner1);
 }
 
-
-EngineFilterButterworth8Band::EngineFilterButterworth8Band(int sampleRate, double freqCorner1,
-                                         double freqCorner2) {
+EngineFilterButterworth8Band::EngineFilterButterworth8Band(
+        mixxx::audio::SampleRate sampleRate,
+        double freqCorner1,
+        double freqCorner2) {
     setFrequencyCorners(sampleRate, freqCorner1, freqCorner2);
 }
 
-void EngineFilterButterworth8Band::setFrequencyCorners(int sampleRate,
-                                             double freqCorner1,
-                                             double freqCorner2) {
+void EngineFilterButterworth8Band::setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1,
+        double freqCorner2) {
     setCoefs(kFidSpecBandPassButterworth8,
             sizeof(kFidSpecBandPassButterworth8),
             sampleRate,
@@ -37,12 +39,13 @@ void EngineFilterButterworth8Band::setFrequencyCorners(int sampleRate,
             freqCorner2);
 }
 
-EngineFilterButterworth8High::EngineFilterButterworth8High(int sampleRate, double freqCorner1) {
+EngineFilterButterworth8High::EngineFilterButterworth8High(
+        mixxx::audio::SampleRate sampleRate, double freqCorner1) {
     setFrequencyCorners(sampleRate, freqCorner1);
 }
 
-void EngineFilterButterworth8High::setFrequencyCorners(int sampleRate,
-                                             double freqCorner1) {
+void EngineFilterButterworth8High::setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1) {
     setCoefs(kFidSpecHighPassButterworth8,
             sizeof(kFidSpecHighPassButterworth8),
             sampleRate,

--- a/src/engine/filters/enginefilterbutterworth8.h
+++ b/src/engine/filters/enginefilterbutterworth8.h
@@ -1,26 +1,29 @@
 #pragma once
 
+#include "audio/types.h"
 #include "engine/filters/enginefilteriir.h"
 
 class EngineFilterButterworth8Low : public EngineFilterIIR<8, IIR_LP> {
     Q_OBJECT
   public:
-    EngineFilterButterworth8Low(int sampleRate, double freqCorner1);
-    void setFrequencyCorners(int sampleRate, double freqCorner1);
+    EngineFilterButterworth8Low(mixxx::audio::SampleRate sampleRate, double freqCorner1);
+    void setFrequencyCorners(mixxx::audio::SampleRate sampleRate, double freqCorner1);
 };
 
 class EngineFilterButterworth8Band : public EngineFilterIIR<16, IIR_BP> {
     Q_OBJECT
   public:
-    EngineFilterButterworth8Band(int sampleRate, double freqCorner1,
+    EngineFilterButterworth8Band(mixxx::audio::SampleRate sampleRate,
+            double freqCorner1,
             double freqCorner2);
-    void setFrequencyCorners(int sampleRate, double freqCorner1,
+    void setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+            double freqCorner1,
             double freqCorner2);
 };
 
 class EngineFilterButterworth8High : public EngineFilterIIR<8, IIR_HP> {
     Q_OBJECT
   public:
-    EngineFilterButterworth8High(int sampleRate, double freqCorner1);
-    void setFrequencyCorners(int sampleRate, double freqCorner1);
+    EngineFilterButterworth8High(mixxx::audio::SampleRate sampleRate, double freqCorner1);
+    void setFrequencyCorners(mixxx::audio::SampleRate sampleRate, double freqCorner1);
 };

--- a/src/engine/filters/enginefilterlinkwitzriley2.cpp
+++ b/src/engine/filters/enginefilterlinkwitzriley2.cpp
@@ -7,12 +7,13 @@ constexpr char kFidSpecLowPassButterworth1[] = "LpBu1";
 constexpr char kFidSpecHighPassButterworth1[] = "HpBu1";
 } // namespace
 
-EngineFilterLinkwitzRiley2Low::EngineFilterLinkwitzRiley2Low(int sampleRate, double freqCorner1) {
+EngineFilterLinkwitzRiley2Low::EngineFilterLinkwitzRiley2Low(
+        mixxx::audio::SampleRate sampleRate, double freqCorner1) {
     setFrequencyCorners(sampleRate, freqCorner1);
 }
 
-void EngineFilterLinkwitzRiley2Low::setFrequencyCorners(int sampleRate,
-                                             double freqCorner1) {
+void EngineFilterLinkwitzRiley2Low::setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1) {
     // Copy the old coefficients into m_oldCoef
     setCoefs2(sampleRate,
             1,
@@ -28,12 +29,13 @@ void EngineFilterLinkwitzRiley2Low::setFrequencyCorners(int sampleRate,
             0);
 }
 
-EngineFilterLinkwitzRiley2High::EngineFilterLinkwitzRiley2High(int sampleRate, double freqCorner1) {
+EngineFilterLinkwitzRiley2High::EngineFilterLinkwitzRiley2High(
+        mixxx::audio::SampleRate sampleRate, double freqCorner1) {
     setFrequencyCorners(sampleRate, freqCorner1);
 }
 
-void EngineFilterLinkwitzRiley2High::setFrequencyCorners(int sampleRate,
-                                             double freqCorner1) {
+void EngineFilterLinkwitzRiley2High::setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1) {
     setCoefs2(sampleRate,
             1,
             kFidSpecHighPassButterworth1,

--- a/src/engine/filters/enginefilterlinkwitzriley2.h
+++ b/src/engine/filters/enginefilterlinkwitzriley2.h
@@ -1,18 +1,19 @@
 #pragma once
 
+#include "audio/types.h"
 #include "engine/filters/enginefilteriir.h"
 
 class EngineFilterLinkwitzRiley2Low : public EngineFilterIIR<2, IIR_LP2> {
     Q_OBJECT
   public:
-    EngineFilterLinkwitzRiley2Low(int sampleRate, double freqCorner1);
-    void setFrequencyCorners(int sampleRate, double freqCorner1);
+    EngineFilterLinkwitzRiley2Low(mixxx::audio::SampleRate sampleRate, double freqCorner1);
+    void setFrequencyCorners(mixxx::audio::SampleRate sampleRate, double freqCorner1);
 };
 
 
 class EngineFilterLinkwitzRiley2High : public EngineFilterIIR<2, IIR_HP2> {
     Q_OBJECT
   public:
-    EngineFilterLinkwitzRiley2High(int sampleRate, double freqCorner1);
-    void setFrequencyCorners(int sampleRate, double freqCorner1);
+    EngineFilterLinkwitzRiley2High(mixxx::audio::SampleRate sampleRate, double freqCorner1);
+    void setFrequencyCorners(mixxx::audio::SampleRate sampleRate, double freqCorner1);
 };

--- a/src/engine/filters/enginefilterlinkwitzriley4.cpp
+++ b/src/engine/filters/enginefilterlinkwitzriley4.cpp
@@ -7,12 +7,13 @@ constexpr char kFidSpecLowPassButterworth2[] = "LpBu2";
 constexpr char kFidSpecHighPassButterworth2[] = "HpBu2";
 } // namespace
 
-EngineFilterLinkwitzRiley4Low::EngineFilterLinkwitzRiley4Low(int sampleRate, double freqCorner1) {
+EngineFilterLinkwitzRiley4Low::EngineFilterLinkwitzRiley4Low(
+        mixxx::audio::SampleRate sampleRate, double freqCorner1) {
     setFrequencyCorners(sampleRate, freqCorner1);
 }
 
-void EngineFilterLinkwitzRiley4Low::setFrequencyCorners(int sampleRate,
-                                             double freqCorner1) {
+void EngineFilterLinkwitzRiley4Low::setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1) {
     // Copy the old coefficients into m_oldCoef
     setCoefs2(sampleRate,
             2,
@@ -28,12 +29,13 @@ void EngineFilterLinkwitzRiley4Low::setFrequencyCorners(int sampleRate,
             0);
 }
 
-EngineFilterLinkwitzRiley4High::EngineFilterLinkwitzRiley4High(int sampleRate, double freqCorner1) {
+EngineFilterLinkwitzRiley4High::EngineFilterLinkwitzRiley4High(
+        mixxx::audio::SampleRate sampleRate, double freqCorner1) {
     setFrequencyCorners(sampleRate, freqCorner1);
 }
 
-void EngineFilterLinkwitzRiley4High::setFrequencyCorners(int sampleRate,
-                                             double freqCorner1) {
+void EngineFilterLinkwitzRiley4High::setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1) {
     setCoefs2(sampleRate,
             2,
             kFidSpecHighPassButterworth2,

--- a/src/engine/filters/enginefilterlinkwitzriley4.h
+++ b/src/engine/filters/enginefilterlinkwitzriley4.h
@@ -1,18 +1,19 @@
 #pragma once
 
+#include "audio/types.h"
 #include "engine/filters/enginefilteriir.h"
 
 class EngineFilterLinkwitzRiley4Low : public EngineFilterIIR<4, IIR_LP> {
     Q_OBJECT
   public:
-    EngineFilterLinkwitzRiley4Low(int sampleRate, double freqCorner1);
-    void setFrequencyCorners(int sampleRate, double freqCorner1);
+    EngineFilterLinkwitzRiley4Low(mixxx::audio::SampleRate sampleRate, double freqCorner1);
+    void setFrequencyCorners(mixxx::audio::SampleRate sampleRate, double freqCorner1);
 };
 
 
 class EngineFilterLinkwitzRiley4High : public EngineFilterIIR<4, IIR_HP> {
     Q_OBJECT
   public:
-    EngineFilterLinkwitzRiley4High(int sampleRate, double freqCorner1);
-    void setFrequencyCorners(int sampleRate, double freqCorner1);
+    EngineFilterLinkwitzRiley4High(mixxx::audio::SampleRate sampleRate, double freqCorner1);
+    void setFrequencyCorners(mixxx::audio::SampleRate sampleRate, double freqCorner1);
 };

--- a/src/engine/filters/enginefilterlinkwitzriley8.cpp
+++ b/src/engine/filters/enginefilterlinkwitzriley8.cpp
@@ -7,12 +7,13 @@ constexpr char kFidSpecLowPassButterworth4[] = "LpBu4";
 constexpr char kFidSpecHighPassButterworth4[] = "HpBu4";
 } // namespace
 
-EngineFilterLinkwitzRiley8Low::EngineFilterLinkwitzRiley8Low(int sampleRate, double freqCorner1) {
+EngineFilterLinkwitzRiley8Low::EngineFilterLinkwitzRiley8Low(
+        mixxx::audio::SampleRate sampleRate, double freqCorner1) {
     setFrequencyCorners(sampleRate, freqCorner1);
 }
 
-void EngineFilterLinkwitzRiley8Low::setFrequencyCorners(int sampleRate,
-                                             double freqCorner1) {
+void EngineFilterLinkwitzRiley8Low::setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1) {
     // Copy the old coefficients into m_oldCoef
     setCoefs2(sampleRate,
             4,
@@ -28,12 +29,13 @@ void EngineFilterLinkwitzRiley8Low::setFrequencyCorners(int sampleRate,
             0);
 }
 
-EngineFilterLinkwitzRiley8High::EngineFilterLinkwitzRiley8High(int sampleRate, double freqCorner1) {
+EngineFilterLinkwitzRiley8High::EngineFilterLinkwitzRiley8High(
+        mixxx::audio::SampleRate sampleRate, double freqCorner1) {
     setFrequencyCorners(sampleRate, freqCorner1);
 }
 
-void EngineFilterLinkwitzRiley8High::setFrequencyCorners(int sampleRate,
-                                             double freqCorner1) {
+void EngineFilterLinkwitzRiley8High::setFrequencyCorners(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1) {
     setCoefs2(sampleRate,
             4,
             kFidSpecHighPassButterworth4,

--- a/src/engine/filters/enginefilterlinkwitzriley8.h
+++ b/src/engine/filters/enginefilterlinkwitzriley8.h
@@ -1,18 +1,19 @@
 #pragma once
 
+#include "audio/types.h"
 #include "engine/filters/enginefilteriir.h"
 
 class EngineFilterLinkwitzRiley8Low : public EngineFilterIIR<8, IIR_LP> {
     Q_OBJECT
   public:
-    EngineFilterLinkwitzRiley8Low(int sampleRate, double freqCorner1);
-    void setFrequencyCorners(int sampleRate, double freqCorner1);
+    EngineFilterLinkwitzRiley8Low(mixxx::audio::SampleRate sampleRate, double freqCorner1);
+    void setFrequencyCorners(mixxx::audio::SampleRate sampleRate, double freqCorner1);
 };
 
 
 class EngineFilterLinkwitzRiley8High : public EngineFilterIIR<8, IIR_HP> {
     Q_OBJECT
   public:
-    EngineFilterLinkwitzRiley8High(int sampleRate, double freqCorner1);
-    void setFrequencyCorners(int sampleRate, double freqCorner1);
+    EngineFilterLinkwitzRiley8High(mixxx::audio::SampleRate sampleRate, double freqCorner1);
+    void setFrequencyCorners(mixxx::audio::SampleRate sampleRate, double freqCorner1);
 };

--- a/src/engine/filters/enginefiltermoogladder4.cpp
+++ b/src/engine/filters/enginefiltermoogladder4.cpp
@@ -2,14 +2,14 @@
 
 #include "moc_enginefiltermoogladder4.cpp"
 
-EngineFilterMoogLadder4Low::EngineFilterMoogLadder4Low(int sampleRate,
-                                               double freqCorner1,
-                                               double resonance)
+EngineFilterMoogLadder4Low::EngineFilterMoogLadder4Low(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1,
+        double resonance)
         : EngineFilterMoogLadderBase(sampleRate, (float)freqCorner1, (float)resonance) {
 }
 
-EngineFilterMoogLadder4High::EngineFilterMoogLadder4High(int sampleRate,
-                                                 double freqCorner1,
-                                                 double resonance)
+EngineFilterMoogLadder4High::EngineFilterMoogLadder4High(mixxx::audio::SampleRate sampleRate,
+        double freqCorner1,
+        double resonance)
         : EngineFilterMoogLadderBase(sampleRate, (float)freqCorner1, (float)resonance) {
 }

--- a/src/engine/filters/enginefiltermoogladder4.h
+++ b/src/engine/filters/enginefiltermoogladder4.h
@@ -15,6 +15,7 @@
 
 #include <QDebug>
 
+#include "audio/types.h"
 #include "engine/engineobject.h"
 #include "util/math.h"
 #include "util/sample.h"
@@ -53,12 +54,12 @@ class EngineFilterMoogLadderBase : public EngineObjectConstIn {
 
   public:
     EngineFilterMoogLadderBase(
-            unsigned int sampleRate, float cutoff, float resonance) {
-        initBuffers();
-        setParameter(sampleRate, cutoff, resonance);
-        m_postGain = m_postGainNew;
-        m_kacr = m_kacrNew;
-        m_k2vg = m_k2vgNew;
+            mixxx::audio::SampleRate sampleRate, float cutoff, float resonance) {
+         initBuffers();
+         setParameter(sampleRate, cutoff, resonance);
+         m_postGain = m_postGainNew;
+         m_kacr = m_kacrNew;
+         m_k2vg = m_k2vgNew;
     }
 
     virtual ~EngineFilterMoogLadderBase() {
@@ -72,7 +73,7 @@ class EngineFilterMoogLadderBase : public EngineObjectConstIn {
 
     // cutoff  in Hz
     // resonance  range 0 ... 4 (4 = self resonance)
-    void setParameter(int sampleRate, float cutoff, float resonance) {
+    void setParameter(mixxx::audio::SampleRate sampleRate, float cutoff, float resonance) {
         constexpr float v2 = 2 + kVt; // twice the 'thermal voltage of a transistor'
 
         float kfc = cutoff / sampleRate;
@@ -271,12 +272,16 @@ class EngineFilterMoogLadderBase : public EngineObjectConstIn {
 class EngineFilterMoogLadder4Low : public EngineFilterMoogLadderBase<MoogMode::LowPassOversampling> {
     Q_OBJECT
   public:
-    EngineFilterMoogLadder4Low(int sampleRate, double freqCorner1, double resonance);
+    EngineFilterMoogLadder4Low(mixxx::audio::SampleRate sampleRate,
+            double freqCorner1,
+            double resonance);
 };
 
 
 class EngineFilterMoogLadder4High : public EngineFilterMoogLadderBase<MoogMode::HighPassOversampling> {
     Q_OBJECT
   public:
-    EngineFilterMoogLadder4High(int sampleRate, double freqCorner1, double resonance);
+    EngineFilterMoogLadder4High(mixxx::audio::SampleRate sampleRate,
+            double freqCorner1,
+            double resonance);
 };

--- a/src/engine/sidechain/enginenetworkstream.cpp
+++ b/src/engine/sidechain/enginenetworkstream.cpp
@@ -36,15 +36,15 @@ const mixxx::Logger kLogger("EngineNetworkStream");
 } // namespace
 
 EngineNetworkStream::EngineNetworkStream(int numOutputChannels,
-                                         int numInputChannels)
-    : m_pInputFifo(nullptr),
-      m_numOutputChannels(numOutputChannels),
-      m_numInputChannels(numInputChannels),
-      m_sampleRate(0),
-      m_inputStreamStartTimeUs(-1),
-      m_inputStreamFramesWritten(0),
-      m_inputStreamFramesRead(0),
-      m_outputWorkers(BROADCAST_MAX_CONNECTIONS) {
+        int numInputChannels)
+        : m_pInputFifo(nullptr),
+          m_numOutputChannels(numOutputChannels),
+          m_numInputChannels(numInputChannels),
+          m_sampleRate(),
+          m_inputStreamStartTimeUs(-1),
+          m_inputStreamFramesWritten(0),
+          m_inputStreamFramesRead(0),
+          m_outputWorkers(BROADCAST_MAX_CONNECTIONS) {
     if (numInputChannels) {
         m_pInputFifo = new FIFO<CSAMPLE>(numInputChannels * kBufferFrames);
     }
@@ -73,7 +73,7 @@ EngineNetworkStream::~EngineNetworkStream() {
     delete m_pInputFifo;
 }
 
-void EngineNetworkStream::startStream(double sampleRate) {
+void EngineNetworkStream::startStream(mixxx::audio::SampleRate sampleRate) {
     m_sampleRate = sampleRate;
     m_inputStreamStartTimeUs = getNetworkTimeUs();
     m_inputStreamFramesWritten = 0;
@@ -122,7 +122,7 @@ void EngineNetworkStream::read(CSAMPLE* buffer, int frames) {
 
 qint64 EngineNetworkStream::getInputStreamTimeFrames() {
     return static_cast<qint64>(static_cast<double>(getInputStreamTimeUs()) *
-            m_sampleRate / 1000000.0);
+            m_sampleRate.toDouble() / 1000000.0);
 }
 
 qint64 EngineNetworkStream::getInputStreamTimeUs() {

--- a/src/engine/sidechain/enginenetworkstream.h
+++ b/src/engine/sidechain/enginenetworkstream.h
@@ -1,11 +1,12 @@
 #pragma once
 
-#include <engine/sidechain/networkoutputstreamworker.h>
-#include <engine/sidechain/networkinputstreamworker.h>
 #include <QVector>
 
-#include "util/types.h"
+#include "audio/types.h"
+#include "engine/sidechain/networkinputstreamworker.h"
+#include "engine/sidechain/networkoutputstreamworker.h"
 #include "util/fifo.h"
+#include "util/types.h"
 
 class EngineNetworkStream {
   public:
@@ -13,7 +14,7 @@ class EngineNetworkStream {
             int numInputChannels);
     virtual ~EngineNetworkStream();
 
-    void startStream(double sampleRate);
+    void startStream(mixxx::audio::SampleRate sampleRate);
     void stopStream();
 
     int getReadExpected();
@@ -47,7 +48,7 @@ class EngineNetworkStream {
     FIFO<CSAMPLE>* m_pInputFifo;
     int m_numOutputChannels;
     int m_numInputChannels;
-    double m_sampleRate;
+    mixxx::audio::SampleRate m_sampleRate;
     qint64 m_inputStreamStartTimeUs;
     qint64 m_inputStreamFramesWritten;
     qint64 m_inputStreamFramesRead;

--- a/src/engine/sidechain/networkoutputstreamworker.cpp
+++ b/src/engine/sidechain/networkoutputstreamworker.cpp
@@ -9,8 +9,7 @@ const mixxx::Logger kLogger("NetworkStreamWorker");
 } // namespace
 
 NetworkOutputStreamWorker::NetworkOutputStreamWorker()
-        : m_sampleRate(),
-          m_numOutputChannels(0),
+        : m_numOutputChannels(0),
           m_workerState(NETWORKSTREAMWORKER_STATE_NEW),
           m_functionCode(0),
           m_runCount(0),

--- a/src/engine/sidechain/networkoutputstreamworker.cpp
+++ b/src/engine/sidechain/networkoutputstreamworker.cpp
@@ -9,15 +9,15 @@ const mixxx::Logger kLogger("NetworkStreamWorker");
 } // namespace
 
 NetworkOutputStreamWorker::NetworkOutputStreamWorker()
-    : m_sampleRate(0),
-      m_numOutputChannels(0),
-      m_workerState(NETWORKSTREAMWORKER_STATE_NEW),
-      m_functionCode(0),
-      m_runCount(0),
-      m_streamStartTimeUs(-1),
-      m_streamFramesWritten(0),
-      m_writeOverflowCount(0),
-      m_outputDrift(false) {
+        : m_sampleRate(),
+          m_numOutputChannels(0),
+          m_workerState(NETWORKSTREAMWORKER_STATE_NEW),
+          m_functionCode(0),
+          m_runCount(0),
+          m_streamStartTimeUs(-1),
+          m_streamFramesWritten(0),
+          m_writeOverflowCount(0),
+          m_outputDrift(false) {
 }
 
 void NetworkOutputStreamWorker::outputAvailable() {
@@ -31,8 +31,9 @@ QSharedPointer<FIFO<CSAMPLE>> NetworkOutputStreamWorker::getOutputFifo() {
     return QSharedPointer<FIFO<CSAMPLE>>();
 }
 
-void NetworkOutputStreamWorker::startStream(double samplerate, int numOutputChannels) {
-    m_sampleRate = samplerate;
+void NetworkOutputStreamWorker::startStream(
+        mixxx::audio::SampleRate sampleRate, int numOutputChannels) {
+    m_sampleRate = sampleRate;
     m_numOutputChannels = numOutputChannels;
 
     m_streamStartTimeUs = EngineNetworkStream::getNetworkTimeUs();
@@ -40,7 +41,7 @@ void NetworkOutputStreamWorker::startStream(double samplerate, int numOutputChan
 }
 
 void NetworkOutputStreamWorker::stopStream() {
-    m_sampleRate = 0;
+    m_sampleRate = mixxx::audio::SampleRate();
     m_numOutputChannels = 0;
 
     m_streamStartTimeUs = -1;
@@ -51,7 +52,8 @@ bool NetworkOutputStreamWorker::threadWaiting() {
 }
 
 qint64 NetworkOutputStreamWorker::getStreamTimeFrames() {
-    return static_cast<qint64>(static_cast<double>(getStreamTimeUs()) * m_sampleRate / 1000000.0);
+    return static_cast<qint64>(static_cast<double>(getStreamTimeUs()) *
+            m_sampleRate.toDouble() / 1000000.0);
 }
 
 qint64 NetworkOutputStreamWorker::getStreamTimeUs() {

--- a/src/engine/sidechain/networkoutputstreamworker.h
+++ b/src/engine/sidechain/networkoutputstreamworker.h
@@ -2,8 +2,9 @@
 
 #include <QSharedPointer>
 
-#include "util/types.h"
+#include "audio/types.h"
 #include "util/fifo.h"
+#include "util/types.h"
 
 /*
  * States:
@@ -52,7 +53,7 @@ class NetworkOutputStreamWorker {
     virtual void setOutputFifo(QSharedPointer<FIFO<CSAMPLE>> pOutputFifo);
     virtual QSharedPointer<FIFO<CSAMPLE>> getOutputFifo();
 
-    void startStream(double samplerate, int numOutputChannels);
+    void startStream(mixxx::audio::SampleRate sampleRate, int numOutputChannels);
     void stopStream();
 
     virtual bool threadWaiting();
@@ -83,17 +84,17 @@ protected:
     void incRunCount();
 
 private:
-    double m_sampleRate;
-    int m_numOutputChannels;
+  mixxx::audio::SampleRate m_sampleRate;
+  int m_numOutputChannels;
 
-    int m_workerState;
-    int m_functionCode;
-    int m_runCount;
+  int m_workerState;
+  int m_functionCode;
+  int m_runCount;
 
-    qint64 m_streamStartTimeUs;
-    qint64 m_streamFramesWritten;
-    int m_writeOverflowCount;
-    bool m_outputDrift;
+  qint64 m_streamStartTimeUs;
+  qint64 m_streamFramesWritten;
+  int m_writeOverflowCount;
+  bool m_outputDrift;
 };
 
 typedef QSharedPointer<NetworkOutputStreamWorker> NetworkOutputStreamWorkerPtr;

--- a/src/preferences/dialog/dlgprefmodplug.cpp
+++ b/src/preferences/dialog/dlgprefmodplug.cpp
@@ -151,11 +151,11 @@ void DlgPrefModplug::applySettings() {
     // Currently this is fixed to 16bit 44.1kHz stereo
 
     // Number of channels - 1 for mono or 2 for stereo
-    settings.mChannels = mixxx::SoundSourceModPlug::kChannelCount;
+    settings.mChannels = mixxx::SoundSourceModPlug::kChannelCount.value();
     // Bits per sample - 8, 16, or 32
     settings.mBits = mixxx::SoundSourceModPlug::kBitsPerSample;
     // Sample rate - 11025, 22050, or 44100
-    settings.mFrequency = mixxx::SoundSourceModPlug::kSampleRate;
+    settings.mFrequency = mixxx::SoundSourceModPlug::kSampleRate.value();
 
     // enabled features flags
     settings.mFlags = 0;

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -47,7 +47,7 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
             &DlgPrefSound::apiChanged);
 
     sampleRateComboBox->clear();
-    for (auto& sampleRate : m_pSoundManager->getSampleRates()) {
+    for (const auto& sampleRate : m_pSoundManager->getSampleRates()) {
         if (sampleRate.isValid()) {
             // no ridiculous sample rate values. prohibiting zero means
             // avoiding a potential div-by-0 error in ::updateLatencies

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -47,11 +47,12 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
             &DlgPrefSound::apiChanged);
 
     sampleRateComboBox->clear();
-    for (auto& srate : m_pSoundManager->getSampleRates()) {
-        if (srate > 0) {
+    for (auto& sampleRate : m_pSoundManager->getSampleRates()) {
+        if (sampleRate.isValid()) {
             // no ridiculous sample rate values. prohibiting zero means
             // avoiding a potential div-by-0 error in ::updateLatencies
-            sampleRateComboBox->addItem(tr("%1 Hz").arg(srate), srate);
+            sampleRateComboBox->addItem(tr("%1 Hz").arg(sampleRate.value()),
+                    QVariant::fromValue(sampleRate));
         }
     }
     connect(sampleRateComboBox,
@@ -435,7 +436,8 @@ void DlgPrefSound::loadSettings(const SoundManagerConfig &config) {
     if (apiIndex != -1) {
         apiComboBox->setCurrentIndex(apiIndex);
     }
-    int sampleRateIndex = sampleRateComboBox->findData(m_config.getSampleRate());
+    int sampleRateIndex = sampleRateComboBox->findData(
+            QVariant::fromValue(m_config.getSampleRate()));
     if (sampleRateIndex != -1) {
         sampleRateComboBox->setCurrentIndex(sampleRateIndex);
         if (audioBufferComboBox->count() <= 0) {
@@ -541,8 +543,7 @@ void DlgPrefSound::updateAPIs() {
  * sample rate in the config.
  */
 void DlgPrefSound::sampleRateChanged(int index) {
-    m_config.setSampleRate(
-            sampleRateComboBox->itemData(index).toUInt());
+    m_config.setSampleRate(mixxx::audio::SampleRate(sampleRateComboBox->itemData(index).toUInt()));
     m_bLatencyChanged = true;
     updateAudioBufferSizes(index);
     checkLatencyCompensation();

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -543,7 +543,7 @@ void DlgPrefSound::updateAPIs() {
  * sample rate in the config.
  */
 void DlgPrefSound::sampleRateChanged(int index) {
-    m_config.setSampleRate(mixxx::audio::SampleRate(sampleRateComboBox->itemData(index).toUInt()));
+    m_config.setSampleRate(sampleRateComboBox->itemData(index).value<mixxx::audio::SampleRate>());
     m_bLatencyChanged = true;
     updateAudioBufferSizes(index);
     checkLatencyCompensation();

--- a/src/soundio/sounddevice.cpp
+++ b/src/soundio/sounddevice.cpp
@@ -4,13 +4,12 @@
 #include <cstring> // for memcpy and strcmp
 
 #include "soundio/soundmanager.h"
+#include "soundio/soundmanagerconfig.h"
 #include "soundio/soundmanagerutil.h"
+#include "soundmanagerconfig.h"
 #include "util/debug.h"
 #include "util/defs.h"
 #include "util/sample.h"
-
-constexpr mixxx::audio::SampleRate SoundDevice::kFallbackSampleRate =
-        mixxx::audio::SampleRate(44100);
 
 SoundDevice::SoundDevice(UserSettingsPointer config, SoundManager* sm)
         : m_pConfig(config),
@@ -18,7 +17,7 @@ SoundDevice::SoundDevice(UserSettingsPointer config, SoundManager* sm)
           m_strDisplayName("Unknown Soundcard"),
           m_iNumOutputChannels(2),
           m_iNumInputChannels(2),
-          m_sampleRate(kFallbackSampleRate),
+          m_sampleRate(SoundManagerConfig::kMixxxDefaultSampleRate),
           m_hostAPI("Unknown API"),
           m_configFramesPerBuffer(0) {
 }
@@ -32,7 +31,7 @@ int SoundDevice::getNumOutputChannels() const {
 }
 
 void SoundDevice::setSampleRate(mixxx::audio::SampleRate sampleRate) {
-    m_sampleRate = sampleRate.isValid() ? sampleRate : kFallbackSampleRate;
+    m_sampleRate = sampleRate.isValid() ? sampleRate : SoundManagerConfig::kMixxxDefaultSampleRate;
 }
 
 void SoundDevice::setConfigFramesPerBuffer(unsigned int framesPerBuffer) {

--- a/src/soundio/sounddevice.cpp
+++ b/src/soundio/sounddevice.cpp
@@ -9,13 +9,16 @@
 #include "util/defs.h"
 #include "util/sample.h"
 
+constexpr mixxx::audio::SampleRate SoundDevice::kFallbackSampleRate =
+        mixxx::audio::SampleRate(44100);
+
 SoundDevice::SoundDevice(UserSettingsPointer config, SoundManager* sm)
         : m_pConfig(config),
           m_pSoundManager(sm),
           m_strDisplayName("Unknown Soundcard"),
           m_iNumOutputChannels(2),
           m_iNumInputChannels(2),
-          m_dSampleRate(44100.0),
+          m_sampleRate(kFallbackSampleRate),
           m_hostAPI("Unknown API"),
           m_configFramesPerBuffer(0) {
 }
@@ -28,12 +31,8 @@ int SoundDevice::getNumOutputChannels() const {
     return m_iNumOutputChannels;
 }
 
-void SoundDevice::setSampleRate(double sampleRate) {
-    if (sampleRate <= 0.0) {
-        // this is the default value used elsewhere in this file
-        sampleRate = 44100.0;
-    }
-    m_dSampleRate = sampleRate;
+void SoundDevice::setSampleRate(mixxx::audio::SampleRate sampleRate) {
+    m_sampleRate = sampleRate.isValid() ? sampleRate : kFallbackSampleRate;
 }
 
 void SoundDevice::setConfigFramesPerBuffer(unsigned int framesPerBuffer) {

--- a/src/soundio/sounddevice.h
+++ b/src/soundio/sounddevice.h
@@ -3,6 +3,7 @@
 #include <QList>
 #include <QString>
 
+#include "audio/types.h"
 #include "preferences/usersettings.h"
 #include "soundio/sounddevicestatus.h"
 #include "soundio/soundmanagerutil.h"
@@ -31,7 +32,7 @@ class SoundDevice {
     inline const QString& getHostAPI() const {
         return m_hostAPI;
     }
-    void setSampleRate(double sampleRate);
+    void setSampleRate(mixxx::audio::SampleRate sampleRate);
     void setConfigFramesPerBuffer(unsigned int framesPerBuffer);
     virtual SoundDeviceStatus open(bool isClkRefDevice, int syncBuffers) = 0;
     virtual bool isOpen() const = 0;
@@ -39,7 +40,7 @@ class SoundDevice {
     virtual void readProcess(SINT framesPerBuffer) = 0;
     virtual void writeProcess(SINT framesPerBuffer) = 0;
     virtual QString getError() const = 0;
-    virtual unsigned int getDefaultSampleRate() const = 0;
+    virtual mixxx::audio::SampleRate getDefaultSampleRate() const = 0;
     int getNumOutputChannels() const;
     int getNumInputChannels() const;
     SoundDeviceStatus addOutput(const AudioOutputBuffer& out);
@@ -57,6 +58,8 @@ class SoundDevice {
     bool operator==(const QString &other) const;
 
   protected:
+    static const mixxx::audio::SampleRate kFallbackSampleRate;
+
     void composeOutputBuffer(CSAMPLE* outputBuffer,
                              const SINT iFramesPerBuffer,
                              const SINT readOffset,
@@ -81,7 +84,7 @@ class SoundDevice {
     // The number of input channels that the soundcard has
     int m_iNumInputChannels;
     // The current samplerate for the sound device.
-    double m_dSampleRate;
+    mixxx::audio::SampleRate m_sampleRate;
     // The name of the audio API used by this device.
     QString m_hostAPI;
     // The **configured** number of frames per buffer. We'll tell PortAudio we

--- a/src/soundio/sounddevice.h
+++ b/src/soundio/sounddevice.h
@@ -58,8 +58,6 @@ class SoundDevice {
     bool operator==(const QString &other) const;
 
   protected:
-    static const mixxx::audio::SampleRate kFallbackSampleRate;
-
     void composeOutputBuffer(CSAMPLE* outputBuffer,
                              const SINT iFramesPerBuffer,
                              const SINT readOffset,

--- a/src/soundio/sounddevicenetwork.cpp
+++ b/src/soundio/sounddevicenetwork.cpp
@@ -26,8 +26,6 @@ constexpr int kNetworkLatencyFrames = 8192; // 185 ms @ 44100 Hz
 // Which results in case of ogg in a dynamic latency from 0.14 ms to to 185 ms
 // Now we have switched to a fixed latency of 8192 frames (stereo samples) =
 // which is 185 @ 44100 ms and twice the maximum of the max mixxx audio buffer
-//
-constexpr auto kDefaultSampleRate = mixxx::audio::SampleRate(44100);
 
 const mixxx::Logger kLogger("SoundDeviceNetwork");
 } // namespace
@@ -45,7 +43,7 @@ SoundDeviceNetwork::SoundDeviceNetwork(
           m_targetTime(0) {
     // Setting parent class members:
     m_hostAPI = "Network stream";
-    m_sampleRate = SoundDevice::kFallbackSampleRate;
+    m_sampleRate = SoundManagerConfig::kMixxxDefaultSampleRate;
     m_deviceId.name = kNetworkDeviceInternalName;
     m_strDisplayName = QObject::tr("Network stream");
     m_iNumInputChannels = pNetworkStream->getNumInputChannels();
@@ -61,7 +59,7 @@ SoundDeviceStatus SoundDeviceNetwork::open(bool isClkRefDevice, int syncBuffers)
 
     // Sample rate
     if (!m_sampleRate.isValid()) {
-        m_sampleRate = SoundDevice::kFallbackSampleRate;
+        m_sampleRate = SoundManagerConfig::kMixxxDefaultSampleRate;
     }
 
     const SINT framesPerBuffer = m_configFramesPerBuffer;
@@ -128,7 +126,7 @@ SoundDeviceStatus SoundDeviceNetwork::close() {
 }
 
 mixxx::audio::SampleRate SoundDeviceNetwork::getDefaultSampleRate() const {
-    return kDefaultSampleRate;
+    return SoundManagerConfig::kMixxxDefaultSampleRate;
 }
 
 QString SoundDeviceNetwork::getError() const {

--- a/src/soundio/sounddevicenetwork.cpp
+++ b/src/soundio/sounddevicenetwork.cpp
@@ -26,6 +26,8 @@ constexpr int kNetworkLatencyFrames = 8192; // 185 ms @ 44100 Hz
 // Which results in case of ogg in a dynamic latency from 0.14 ms to to 185 ms
 // Now we have switched to a fixed latency of 8192 frames (stereo samples) =
 // which is 185 @ 44100 ms and twice the maximum of the max mixxx audio buffer
+//
+constexpr auto kDefaultSampleRate = mixxx::audio::SampleRate(44100);
 
 const mixxx::Logger kLogger("SoundDeviceNetwork");
 } // namespace
@@ -43,7 +45,7 @@ SoundDeviceNetwork::SoundDeviceNetwork(
           m_targetTime(0) {
     // Setting parent class members:
     m_hostAPI = "Network stream";
-    m_dSampleRate = 44100.0;
+    m_sampleRate = SoundDevice::kFallbackSampleRate;
     m_deviceId.name = kNetworkDeviceInternalName;
     m_strDisplayName = QObject::tr("Network stream");
     m_iNumInputChannels = pNetworkStream->getNumInputChannels();
@@ -58,13 +60,13 @@ SoundDeviceStatus SoundDeviceNetwork::open(bool isClkRefDevice, int syncBuffers)
     kLogger.debug() << "open:" << m_deviceId.name;
 
     // Sample rate
-    if (m_dSampleRate <= 0) {
-        m_dSampleRate = 44100.0;
+    if (!m_sampleRate.isValid()) {
+        m_sampleRate = SoundDevice::kFallbackSampleRate;
     }
 
     const SINT framesPerBuffer = m_configFramesPerBuffer;
     const auto requestedBufferTime = mixxx::Duration::fromSeconds(
-            framesPerBuffer / m_dSampleRate);
+            framesPerBuffer / m_sampleRate.toDouble());
 
     // Feed the network device buffer directly from the
     // clock reference device callback
@@ -78,18 +80,18 @@ SoundDeviceStatus SoundDeviceNetwork::open(bool isClkRefDevice, int syncBuffers)
                 m_iNumInputChannels * framesPerBuffer * 2);
     }
 
-    m_pNetworkStream->startStream(m_dSampleRate);
+    m_pNetworkStream->startStream(m_sampleRate);
 
     // Create the callback Thread if requested
     if (isClkRefDevice) {
         kLogger.debug() << "Clock Reference with:" << framesPerBuffer << "frames/buffer @"
-                        << m_dSampleRate << "Hz =" << requestedBufferTime.formatMillisWithUnit();
+                        << m_sampleRate << "Hz =" << requestedBufferTime.formatMillisWithUnit();
 
         // Update the samplerate and latency ControlObjects, which allow the
         // waveform view to properly correct for the latency.
         ControlObject::set(ConfigKey("[Master]", "latency"),
                 requestedBufferTime.toDoubleMillis());
-        ControlObject::set(ConfigKey("[Master]", "samplerate"), m_dSampleRate);
+        ControlObject::set(ConfigKey("[Master]", "samplerate"), m_sampleRate);
 
         // Network stream was just started above so we have to wait until
         // we can pass one chunk.
@@ -100,7 +102,7 @@ SoundDeviceStatus SoundDeviceNetwork::open(bool isClkRefDevice, int syncBuffers)
         m_pThread->start(QThread::TimeCriticalPriority);
     } else {
         kLogger.debug() << "Maximum:" << framesPerBuffer << "frames/buffer @"
-                        << m_dSampleRate << "Hz =" << requestedBufferTime.formatMillisWithUnit();
+                        << m_sampleRate << "Hz =" << requestedBufferTime.formatMillisWithUnit();
     }
 
     return SoundDeviceStatus::Ok;
@@ -123,6 +125,10 @@ SoundDeviceStatus SoundDeviceNetwork::close() {
     m_inputFifo.reset();
 
     return SoundDeviceStatus::Ok;
+}
+
+mixxx::audio::SampleRate SoundDeviceNetwork::getDefaultSampleRate() const {
+    return kDefaultSampleRate;
 }
 
 QString SoundDeviceNetwork::getError() const {
@@ -501,7 +507,7 @@ void SoundDeviceNetwork::updateCallbackEntryToDacTime(SINT framesPerBuffer) {
     m_clkRefTimer.start();
     qint64 currentTime = m_pNetworkStream->getInputStreamTimeUs();
     // This deadline for the next buffer in microseconds since the Unix epoch
-    m_targetTime += static_cast<qint64>(framesPerBuffer / m_dSampleRate * 1000000);
+    m_targetTime += static_cast<qint64>(framesPerBuffer / m_sampleRate.toDouble() * 1000000);
     double callbackEntrytoDacSecs = (m_targetTime - currentTime) / 1000000.0;
     callbackEntrytoDacSecs = math_max(callbackEntrytoDacSecs, 0.0001);
     VisualPlayPosition::setCallbackEntryToDacSecs(callbackEntrytoDacSecs, m_clkRefTimer);
@@ -510,11 +516,10 @@ void SoundDeviceNetwork::updateCallbackEntryToDacTime(SINT framesPerBuffer) {
 
 void SoundDeviceNetwork::updateAudioLatencyUsage(SINT framesPerBuffer) {
     m_framesSinceAudioLatencyUsageUpdate += framesPerBuffer;
-    if (m_framesSinceAudioLatencyUsageUpdate
-            > (m_dSampleRate / CPU_USAGE_UPDATE_RATE)) {
+    if (m_framesSinceAudioLatencyUsageUpdate > (m_sampleRate.toDouble() / CPU_USAGE_UPDATE_RATE)) {
         double secInAudioCb = m_timeInAudioCallback.toDoubleSeconds();
         m_masterAudioLatencyUsage.set(secInAudioCb /
-                (m_framesSinceAudioLatencyUsageUpdate / m_dSampleRate));
+                (m_framesSinceAudioLatencyUsageUpdate / m_sampleRate.toDouble()));
         m_timeInAudioCallback = mixxx::Duration::empty();
         m_framesSinceAudioLatencyUsageUpdate = 0;
         //qDebug() << m_pMasterAudioLatencyUsage->get();

--- a/src/soundio/sounddevicenetwork.h
+++ b/src/soundio/sounddevicenetwork.h
@@ -22,7 +22,6 @@ class ControlProxy;
 class EngineNetworkStream;
 class SoundDeviceNetworkThread;
 
-
 class SoundDeviceNetwork : public SoundDevice {
   public:
     SoundDeviceNetwork(UserSettingsPointer config,
@@ -37,9 +36,7 @@ class SoundDeviceNetwork : public SoundDevice {
     void writeProcess(SINT framesPerBuffer) override;
     QString getError() const override;
 
-    unsigned int getDefaultSampleRate() const override {
-        return 44100;
-    }
+    mixxx::audio::SampleRate getDefaultSampleRate() const override;
 
     // NOTE: This does not take a frames per buffer argument because that is
     //       always equal to the configured buffer size for network streams

--- a/src/soundio/sounddevicenotfound.h
+++ b/src/soundio/sounddevicenotfound.h
@@ -35,7 +35,7 @@ class SoundDeviceNotFound : public SoundDevice {
         return QObject::tr("Device not found");
     };
 
-    unsigned int getDefaultSampleRate() const override {
-        return 44100;
+    mixxx::audio::SampleRate getDefaultSampleRate() const override {
+        return SoundDevice::kFallbackSampleRate;
     }
 };

--- a/src/soundio/sounddevicenotfound.h
+++ b/src/soundio/sounddevicenotfound.h
@@ -3,7 +3,7 @@
 #include <QString>
 
 #include "soundio/sounddevice.h"
-
+#include "soundio/soundmanagerconfig.h"
 
 class SoundManager;
 class EngineNetworkStream;
@@ -36,6 +36,6 @@ class SoundDeviceNotFound : public SoundDevice {
     };
 
     mixxx::audio::SampleRate getDefaultSampleRate() const override {
-        return SoundDevice::kFallbackSampleRate;
+        return SoundManagerConfig::kMixxxDefaultSampleRate;
     }
 };

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -8,6 +8,7 @@
 
 #include "control/controlobject.h"
 #include "control/controlproxy.h"
+#include "sounddevicenetwork.h"
 #include "soundio/sounddevice.h"
 #include "soundio/soundmanager.h"
 #include "soundio/soundmanagerutil.h"
@@ -208,7 +209,7 @@ SoundDeviceStatus SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffer
 
     // Sample rate
     if (!m_sampleRate.isValid()) {
-        m_sampleRate = SoundDevice::kFallbackSampleRate;
+        m_sampleRate = SoundManagerConfig::kMixxxDefaultSampleRate;
     }
 
     SINT framesPerBuffer = m_configFramesPerBuffer;

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -97,7 +97,7 @@ SoundDevicePortAudio::SoundDevicePortAudio(UserSettingsPointer config,
           m_lastCallbackEntrytoDacSecs(0) {
     // Setting parent class members:
     m_hostAPI = Pa_GetHostApiInfo(deviceInfo->hostApi)->name;
-    m_dSampleRate = deviceInfo->defaultSampleRate;
+    m_sampleRate = mixxx::audio::SampleRate::fromDouble(deviceInfo->defaultSampleRate);
     if (m_deviceTypeId == paALSA) {
         // PortAudio gives the device name including the ALSA hw device. The
         // ALSA hw device is an only somewhat reliable identifier; it may change
@@ -207,8 +207,8 @@ SoundDeviceStatus SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffer
     }
 
     // Sample rate
-    if (m_dSampleRate <= 0) {
-        m_dSampleRate = 44100.0;
+    if (!m_sampleRate.isValid()) {
+        m_sampleRate = SoundDevice::kFallbackSampleRate;
     }
 
     SINT framesPerBuffer = m_configFramesPerBuffer;
@@ -226,8 +226,8 @@ SoundDeviceStatus SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffer
     } else {
         qDebug() << "framesPerBuffer:" << framesPerBuffer;
     }
-    double bufferMSec = framesPerBuffer / m_dSampleRate * 1000;
-    qDebug() << "Requested sample rate: " << m_dSampleRate << "Hz and buffer size:"
+    double bufferMSec = framesPerBuffer / m_sampleRate.toDouble() * 1000;
+    qDebug() << "Requested sample rate: " << m_sampleRate << "Hz and buffer size:"
              << bufferMSec << "ms";
 
     qDebug() << "Output channels:" << m_outputParams.channelCount
@@ -338,7 +338,7 @@ SoundDeviceStatus SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffer
     err = Pa_OpenStream(&pStream,
             pInputParams,
             pOutputParams,
-            m_dSampleRate,
+            m_sampleRate.toDouble(),
             framesPerBuffer,
             paClipOff, // Stream flags
             pCallback,
@@ -376,16 +376,16 @@ SoundDeviceStatus SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffer
 
     // Get the actual details of the stream & update Mixxx's data
     const PaStreamInfo* streamDetails = Pa_GetStreamInfo(pStream);
-    m_dSampleRate = streamDetails->sampleRate;
+    m_sampleRate = mixxx::audio::SampleRate::fromDouble(streamDetails->sampleRate);
     double currentLatencyMSec = streamDetails->outputLatency * 1000;
-    qDebug() << "   Actual sample rate: " << m_dSampleRate << "Hz, latency:"
+    qDebug() << "   Actual sample rate: " << m_sampleRate << "Hz, latency:"
              << currentLatencyMSec << "ms";
 
     if (isClkRefDevice) {
         // Update the samplerate and latency ControlObjects, which allow the
         // waveform view to properly correct for the latency.
         ControlObject::set(ConfigKey("[Master]", "latency"), currentLatencyMSec);
-        ControlObject::set(ConfigKey("[Master]", "samplerate"), m_dSampleRate);
+        ControlObject::set(ConfigKey("[Master]", "samplerate"), m_sampleRate);
         m_invalidTimeInfoCount = 0;
         m_clkRefTimer.start();
     }
@@ -1042,7 +1042,7 @@ void SoundDevicePortAudio::updateCallbackEntryToDacTime(
 
     PaTime callbackEntrytoDacSecs = timeInfo->outputBufferDacTime
             - timeInfo->currentTime;
-    double bufferSizeSec = framesPerBuffer / m_dSampleRate;
+    double bufferSizeSec = framesPerBuffer / m_sampleRate.toDouble();
 
     double diff = (timeSinceLastCbSecs + callbackEntrytoDacSecs) -
             (m_lastCallbackEntrytoDacSecs + bufferSizeSec);
@@ -1085,10 +1085,10 @@ void SoundDevicePortAudio::updateCallbackEntryToDacTime(
 void SoundDevicePortAudio::updateAudioLatencyUsage(
         const SINT framesPerBuffer) {
     m_framesSinceAudioLatencyUsageUpdate += framesPerBuffer;
-    if (m_framesSinceAudioLatencyUsageUpdate > (m_dSampleRate / kCpuUsageUpdateRate)) {
+    if (m_framesSinceAudioLatencyUsageUpdate > (m_sampleRate.toDouble() / kCpuUsageUpdateRate)) {
         double secInAudioCb = m_timeInAudioCallback.toDoubleSeconds();
         m_masterAudioLatencyUsage.set(
-                secInAudioCb / (m_framesSinceAudioLatencyUsageUpdate / m_dSampleRate));
+                secInAudioCb / (m_framesSinceAudioLatencyUsageUpdate / m_sampleRate.toDouble()));
         m_timeInAudioCallback = mixxx::Duration::fromSeconds(0);
         m_framesSinceAudioLatencyUsageUpdate = 0;
         //qDebug() << m_pMasterAudioLatencyUsage

--- a/src/soundio/sounddeviceportaudio.h
+++ b/src/soundio/sounddeviceportaudio.h
@@ -7,6 +7,7 @@
 
 #include "control/pollingcontrolproxy.h"
 #include "soundio/sounddevice.h"
+#include "soundio/soundmanagerconfig.h"
 #include "util/duration.h"
 #include "util/performancetimer.h"
 
@@ -49,7 +50,7 @@ class SoundDevicePortAudio : public SoundDevice {
     mixxx::audio::SampleRate getDefaultSampleRate() const override {
         return m_deviceInfo ? mixxx::audio::SampleRate::fromDouble(
                                       m_deviceInfo->defaultSampleRate)
-                            : SoundDevice::kFallbackSampleRate;
+                            : SoundManagerConfig::kMixxxDefaultSampleRate;
     }
 
   private:

--- a/src/soundio/sounddeviceportaudio.h
+++ b/src/soundio/sounddeviceportaudio.h
@@ -46,9 +46,10 @@ class SoundDevicePortAudio : public SoundDevice {
                         const PaStreamCallbackTimeInfo *timeInfo,
                         PaStreamCallbackFlags statusFlags);
 
-    unsigned int getDefaultSampleRate() const override {
-        return m_deviceInfo ? static_cast<unsigned int>(
-            m_deviceInfo->defaultSampleRate) : 44100;
+    mixxx::audio::SampleRate getDefaultSampleRate() const override {
+        return m_deviceInfo ? mixxx::audio::SampleRate::fromDouble(
+                                      m_deviceInfo->defaultSampleRate)
+                            : SoundDevice::kFallbackSampleRate;
     }
 
   private:

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -65,9 +65,9 @@ SoundManager::SoundManager(UserSettingsPointer pConfig,
             ConfigKey(VINYL_PREF_KEY, "gain"));
 
     //Hack because PortAudio samplerate enumeration is slow as hell on Linux (ALSA dmix sucks, so we can't blame PortAudio)
-    m_samplerates.push_back(44100);
-    m_samplerates.push_back(48000);
-    m_samplerates.push_back(96000);
+    m_samplerates.push_back(mixxx::audio::SampleRate(44100));
+    m_samplerates.push_back(mixxx::audio::SampleRate(48000));
+    m_samplerates.push_back(mixxx::audio::SampleRate(96000));
 
     m_pNetworkStream = QSharedPointer<EngineNetworkStream>(
             new EngineNetworkStream(2, 0));
@@ -215,11 +215,11 @@ void SoundManager::clearDeviceList(bool sleepAfterClosing) {
     }
 }
 
-QList<unsigned int> SoundManager::getSampleRates(const QString& api) const {
+QList<mixxx::audio::SampleRate> SoundManager::getSampleRates(const QString& api) const {
     if (api == MIXXX_PORTAUDIO_JACK_STRING) {
         // queryDevices must have been called for this to work, but the
         // ctor calls it -bkgood
-        QList<unsigned int> samplerates;
+        QList<mixxx::audio::SampleRate> samplerates;
         if (m_jackSampleRate.isValid()) {
             samplerates.append(m_jackSampleRate);
         }
@@ -228,7 +228,7 @@ QList<unsigned int> SoundManager::getSampleRates(const QString& api) const {
     return m_samplerates;
 }
 
-QList<unsigned int> SoundManager::getSampleRates() const {
+QList<mixxx::audio::SampleRate> SoundManager::getSampleRates() const {
     return getSampleRates("");
 }
 
@@ -559,8 +559,8 @@ SoundDeviceStatus SoundManager::setConfig(const SoundManagerConfig& config) {
     // certain parts of mixxx rely on this being here, for the time being, just
     // letting those be -- bkgood
     // Do this first so vinyl control gets the right samplerate -- Owen W.
-    m_pConfig->set(ConfigKey("[Soundcard]","Samplerate"),
-                   ConfigValue(static_cast<int>(m_config.getSampleRate())));
+    m_pConfig->set(ConfigKey("[Soundcard]", "Samplerate"),
+            ConfigValue(static_cast<int>(m_config.getSampleRate().value())));
 
     status = setupDevices();
     if (status == SoundDeviceStatus::Ok) {

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -68,10 +68,10 @@ class SoundManager : public QObject {
     QString getLastErrorMessage(SoundDeviceStatus status) const;
 
     // Returns a list of samplerates we will attempt to support for a given API.
-    QList<unsigned int> getSampleRates(const QString& api) const;
+    QList<mixxx::audio::SampleRate> getSampleRates(const QString& api) const;
 
     // Convenience overload for SoundManager::getSampleRates(QString)
-    QList<unsigned int> getSampleRates() const;
+    QList<mixxx::audio::SampleRate> getSampleRates() const;
 
     // Get a list of host APIs supported by PortAudio.
     QList<QString> getHostAPIList() const;
@@ -135,7 +135,7 @@ class SoundManager : public QObject {
     bool m_paInitialized;
     mixxx::audio::SampleRate m_jackSampleRate;
     QList<SoundDevicePointer> m_devices;
-    QList<unsigned int> m_samplerates;
+    QList<mixxx::audio::SampleRate> m_samplerates;
     QList<CSAMPLE*> m_inputBuffers;
 
     SoundManagerConfig m_config;

--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -409,15 +409,9 @@ unsigned int SoundManagerConfig::getFramesPerBuffer() const {
     VERIFY_OR_DEBUG_ASSERT(audioBufferSizeIndex > 0) {
         audioBufferSizeIndex = kDefaultAudioBufferSizeIndex;
     }
-    unsigned int framesPerBuffer = 1;
-    // first, get to the framesPerBuffer value corresponding to latency index 1
-    for (; framesPerBuffer / m_sampleRate.toDouble() * 1000 < 1.0; framesPerBuffer *= 2) {
-    }
-    // then, keep going until we get to our desired latency index (if not 1)
-    for (unsigned int latencyIndex = 1; latencyIndex < audioBufferSizeIndex; ++latencyIndex) {
-        framesPerBuffer <<= 1; // *= 2
-    }
-    return framesPerBuffer;
+
+    const unsigned int sampleRateKhz = static_cast<unsigned int>(m_sampleRate / 1000);
+    return std::bit_ceil(sampleRateKhz) << (audioBufferSizeIndex - 1);
 }
 
 // Set the audio buffer size

--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -10,10 +10,6 @@
 
 const QString SoundManagerConfig::kDefaultAPI = QStringLiteral("None");
 const QString SoundManagerConfig::kEmptyComboBox = QStringLiteral("---");
-constexpr mixxx::audio::SampleRate SoundManagerConfig::kMixxxDefaultSampleRate =
-        mixxx::audio::SampleRate(44100);
-constexpr mixxx::audio::SampleRate SoundManagerConfig::kFallbackSampleRate =
-        mixxx::audio::SampleRate(48000);
 const unsigned int SoundManagerConfig::kDefaultDeckCount = 2;
 
 const int SoundManagerConfig::kDefaultSyncBuffers = 2;

--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -10,8 +10,9 @@
 
 const QString SoundManagerConfig::kDefaultAPI = QStringLiteral("None");
 const QString SoundManagerConfig::kEmptyComboBox = QStringLiteral("---");
-// Sample Rate even the cheap sound Devices will support most likely
-const mixxx::audio::SampleRate SoundManagerConfig::kFallbackSampleRate =
+constexpr mixxx::audio::SampleRate SoundManagerConfig::kMixxxDefaultSampleRate =
+        mixxx::audio::SampleRate(44100);
+constexpr mixxx::audio::SampleRate SoundManagerConfig::kFallbackSampleRate =
         mixxx::audio::SampleRate(48000);
 const unsigned int SoundManagerConfig::kDefaultDeckCount = 2;
 

--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -11,7 +11,8 @@
 const QString SoundManagerConfig::kDefaultAPI = QStringLiteral("None");
 const QString SoundManagerConfig::kEmptyComboBox = QStringLiteral("---");
 // Sample Rate even the cheap sound Devices will support most likely
-const unsigned int SoundManagerConfig::kFallbackSampleRate = 48000;
+const mixxx::audio::SampleRate SoundManagerConfig::kFallbackSampleRate =
+        mixxx::audio::SampleRate(48000);
 const unsigned int SoundManagerConfig::kDefaultDeckCount = 2;
 
 const int SoundManagerConfig::kDefaultSyncBuffers = 2;
@@ -68,7 +69,8 @@ bool SoundManagerConfig::readFromDisk() {
     file.close();
     rootElement = doc.documentElement();
     setAPI(rootElement.attribute(xmlAttributeApi));
-    setSampleRate(rootElement.attribute(xmlAttributeSampleRate, "0").toUInt());
+    setSampleRate(mixxx::audio::SampleRate(
+            rootElement.attribute(xmlAttributeSampleRate, "0").toUInt()));
     // audioBufferSizeIndex is refereed as "latency" in the config file
     setAudioBufferSizeIndex(rootElement.attribute(xmlAttributeBufferSize, "0").toUInt());
     setSyncBuffers(rootElement.attribute(xmlAttributeSyncBuffers, "2").toUInt());
@@ -223,7 +225,7 @@ bool SoundManagerConfig::writeToDisk() const {
     QDomDocument doc(xmlRootElement);
     QDomElement docElement(doc.createElement(xmlRootElement));
     docElement.setAttribute(xmlAttributeApi, m_api);
-    docElement.setAttribute(xmlAttributeSampleRate, m_sampleRate);
+    docElement.setAttribute(xmlAttributeSampleRate, m_sampleRate.value());
     docElement.setAttribute(xmlAttributeBufferSize, m_audioBufferSizeIndex);
     docElement.setAttribute(xmlAttributeSyncBuffers, m_syncBuffers);
     docElement.setAttribute(xmlAttributeForceNetworkClock, m_forceNetworkClock);
@@ -292,15 +294,14 @@ bool SoundManagerConfig::checkAPI() {
     return true;
 }
 
-unsigned int SoundManagerConfig::getSampleRate() const {
+mixxx::audio::SampleRate SoundManagerConfig::getSampleRate() const {
     return m_sampleRate;
 }
 
-void SoundManagerConfig::setSampleRate(unsigned int sampleRate) {
+void SoundManagerConfig::setSampleRate(mixxx::audio::SampleRate sampleRate) {
     // making sure we don't divide by zero elsewhere
-    m_sampleRate = sampleRate != 0 ? sampleRate : kFallbackSampleRate;
+    m_sampleRate = sampleRate.isValid() ? sampleRate : kFallbackSampleRate;
 }
-
 
 unsigned int SoundManagerConfig::getSyncBuffers() const {
     return m_syncBuffers;
@@ -409,9 +410,8 @@ unsigned int SoundManagerConfig::getFramesPerBuffer() const {
         audioBufferSizeIndex = kDefaultAudioBufferSizeIndex;
     }
     unsigned int framesPerBuffer = 1;
-    double sampleRate = m_sampleRate; // need this to avoid int division
     // first, get to the framesPerBuffer value corresponding to latency index 1
-    for (; framesPerBuffer / sampleRate * 1000 < 1.0; framesPerBuffer *= 2) {
+    for (; framesPerBuffer / m_sampleRate.toDouble() * 1000 < 1.0; framesPerBuffer *= 2) {
     }
     // then, keep going until we get to our desired latency index (if not 1)
     for (unsigned int latencyIndex = 1; latencyIndex < audioBufferSizeIndex; ++latencyIndex) {
@@ -509,7 +509,7 @@ void SoundManagerConfig::loadDefaults(SoundManager* soundManager, unsigned int f
         }
     }
 
-    unsigned int defaultSampleRate = kFallbackSampleRate;
+    mixxx::audio::SampleRate defaultSampleRate = kFallbackSampleRate;
     if (flags & SoundManagerConfig::DEVICES) {
         clearOutputs();
         clearInputs();
@@ -527,7 +527,7 @@ void SoundManagerConfig::loadDefaults(SoundManager* soundManager, unsigned int f
         }
     }
     if (flags & SoundManagerConfig::OTHER) {
-        QList<unsigned int> sampleRates = soundManager->getSampleRates(m_api);
+        QList<mixxx::audio::SampleRate> sampleRates = soundManager->getSampleRates(m_api);
         if (sampleRates.contains(defaultSampleRate)) {
             m_sampleRate = defaultSampleRate;
         } else if (sampleRates.contains(kFallbackSampleRate)) {

--- a/src/soundio/soundmanagerconfig.h
+++ b/src/soundio/soundmanagerconfig.h
@@ -57,9 +57,10 @@ class SoundManagerConfig {
     static const QString kEmptyComboBox;
 
     /// The default sample rate that Mixxx uses.
-    static const mixxx::audio::SampleRate kMixxxDefaultSampleRate;
+    static constexpr mixxx::audio::SampleRate kMixxxDefaultSampleRate =
+            mixxx::audio::SampleRate(44100);
     /// A sample rate that likely every soundcard supports, even cheap ones.
-    static const mixxx::audio::SampleRate kFallbackSampleRate;
+    static constexpr mixxx::audio::SampleRate kFallbackSampleRate = mixxx::audio::SampleRate(48000);
     static const unsigned int kDefaultDeckCount;
     static const int kDefaultSyncBuffers;
 

--- a/src/soundio/soundmanagerconfig.h
+++ b/src/soundio/soundmanagerconfig.h
@@ -55,6 +55,10 @@ class SoundManagerConfig {
 
     static const QString kDefaultAPI;
     static const QString kEmptyComboBox;
+
+    /// The default sample rate that Mixxx uses.
+    static const mixxx::audio::SampleRate kMixxxDefaultSampleRate;
+    /// A sample rate that likely every soundcard supports, even cheap ones.
     static const mixxx::audio::SampleRate kFallbackSampleRate;
     static const unsigned int kDefaultDeckCount;
     static const int kDefaultSyncBuffers;

--- a/src/soundio/soundmanagerconfig.h
+++ b/src/soundio/soundmanagerconfig.h
@@ -4,10 +4,11 @@
 #define SOUNDMANAGERCONFIG_FILENAME "soundconfig.xml"
 #endif
 
-#include <QString>
-#include <QMultiHash>
 #include <QFileInfo>
+#include <QMultiHash>
+#include <QString>
 
+#include "audio/types.h"
 #include "soundio/soundmanagerutil.h"
 
 class SoundDevice;
@@ -54,7 +55,7 @@ class SoundManagerConfig {
 
     static const QString kDefaultAPI;
     static const QString kEmptyComboBox;
-    static const unsigned int kFallbackSampleRate;
+    static const mixxx::audio::SampleRate kFallbackSampleRate;
     static const unsigned int kDefaultDeckCount;
     static const int kDefaultSyncBuffers;
 
@@ -63,8 +64,8 @@ class SoundManagerConfig {
     QString getAPI() const;
     void setAPI(const QString& api);
     bool checkAPI();
-    unsigned int getSampleRate() const;
-    void setSampleRate(unsigned int sampleRate);
+    mixxx::audio::SampleRate getSampleRate() const;
+    void setSampleRate(mixxx::audio::SampleRate sampleRate);
     bool checkSampleRate(const SoundManager& soundManager);
 
     // Record the number of decks configured with this setup so they can
@@ -78,7 +79,7 @@ class SoundManagerConfig {
     unsigned int getFramesPerBuffer() const;
     void setAudioBufferSizeIndex(unsigned int latency);
     unsigned int getSyncBuffers() const;
-    void setSyncBuffers(unsigned int sampleRate);
+    void setSyncBuffers(unsigned int syncBuffers);
     bool getForceNetworkClock() const;
     void setForceNetworkClock(bool force);
     void addOutput(const SoundDeviceId& device, const AudioOutput& out);
@@ -96,7 +97,7 @@ class SoundManagerConfig {
     QString m_api;
     // none of our sample rates are actually decimals, this avoids
     // the weirdness using floating point can introduce
-    unsigned int m_sampleRate;
+    mixxx::audio::SampleRate m_sampleRate;
     unsigned int m_deckCount;
     // m_latency is an index > 0, where 1 is a latency of 1ms and
     // higher indices represent subsequently higher latencies (storing

--- a/src/sources/soundsourcemodplug.cpp
+++ b/src/sources/soundsourcemodplug.cpp
@@ -1,14 +1,15 @@
 #include "sources/soundsourcemodplug.h"
 
+#include <stdlib.h>
+
+#include <QFile>
+
 #include "audio/streaminfo.h"
+#include "audio/types.h"
 #include "track/trackmetadata.h"
 #include "util/logger.h"
 #include "util/sample.h"
 #include "util/timer.h"
-
-#include <QFile>
-
-#include <stdlib.h>
 
 namespace mixxx {
 
@@ -100,8 +101,8 @@ SoundSourceModPlug::importTrackMetadataAndCoverImage(
         pTrackMetadata->refTrackInfo().setTitle(QString(ModPlug::ModPlug_GetName(pModFile)));
         pTrackMetadata->setStreamInfo(audio::StreamInfo{
                 audio::SignalInfo{
-                        audio::ChannelCount(kChannelCount),
-                        audio::SampleRate(kSampleRate),
+                        kChannelCount,
+                        kSampleRate,
                 },
                 audio::Bitrate(8),
                 Duration::fromMillis(ModPlug::ModPlug_GetLength(pModFile)),

--- a/src/sources/soundsourcemodplug.h
+++ b/src/sources/soundsourcemodplug.h
@@ -15,8 +15,8 @@ namespace mixxx {
 // in RAM to allow seeking and smooth operation in Mixxx.
 class SoundSourceModPlug final : public SoundSource {
   public:
-    static constexpr int kChannelCount = 2;
-    static constexpr int kSampleRate = 44100;
+    static constexpr auto kChannelCount = mixxx::audio::ChannelCount::stereo();
+    static constexpr auto kSampleRate = mixxx::audio::SampleRate(44100);
     static constexpr int kBitsPerSample = 16;
 
     // apply settings for decoding

--- a/src/sources/soundsourcemp3.cpp
+++ b/src/sources/soundsourcemp3.cpp
@@ -276,11 +276,11 @@ SoundSource::OpenResult SoundSourceMp3::tryOpen(
         }
 
         // Grab data from madHeader
-        const unsigned int madSampleRate = madHeader.samplerate;
+        const audio::SampleRate madSampleRate = audio::SampleRate(madHeader.samplerate);
 
         // MAD must not change its enum values!
         static_assert(MAD_UNITS_8000_HZ == 8000);
-        const mad_units madUnits = static_cast<mad_units>(madSampleRate);
+        const mad_units madUnits = static_cast<mad_units>(madSampleRate.value());
 
         const long madFrameLength = mad_timer_count(madHeader.duration, madUnits);
         if (0 >= madFrameLength) {
@@ -342,8 +342,7 @@ SoundSource::OpenResult SoundSourceMp3::tryOpen(
                     << m_file.fileName();
         }
 
-        const int sampleRateIndex = getIndexBySampleRate(
-                audio::SampleRate(madSampleRate));
+        const int sampleRateIndex = getIndexBySampleRate(madSampleRate);
         if (sampleRateIndex >= kSampleRateCount) {
             kLogger.warning() << "Invalid sample rate:" << m_file.fileName()
                               << madSampleRate;

--- a/src/test/beatgridtest.cpp
+++ b/src/test/beatgridtest.cpp
@@ -2,6 +2,7 @@
 
 #include <QtDebug>
 
+#include "audio/types.h"
 #include "track/beats.h"
 #include "track/track.h"
 #include "util/memory.h"
@@ -10,21 +11,21 @@ using namespace mixxx;
 
 namespace {
 
+constexpr auto kSampleRate = mixxx::audio::SampleRate(44100);
 const double kMaxBeatError = 1e-9;
 
-TrackPointer newTrack(int sampleRate) {
+TrackPointer newTrack(mixxx::audio::SampleRate sampleRate) {
     TrackPointer pTrack(Track::newTemporary());
     pTrack->setAudioProperties(
             mixxx::audio::ChannelCount(2),
-            mixxx::audio::SampleRate(sampleRate),
+            sampleRate,
             mixxx::audio::Bitrate(),
             mixxx::Duration::fromSeconds(180));
     return pTrack;
 }
 
 TEST(BeatGridTest, Scale) {
-    int sampleRate = 44100;
-    TrackPointer pTrack = newTrack(sampleRate);
+    TrackPointer pTrack = newTrack(kSampleRate);
 
     constexpr mixxx::Bpm bpm(60.0);
     pTrack->trySetBpm(bpm.value());
@@ -69,12 +70,11 @@ TEST(BeatGridTest, Scale) {
 }
 
 TEST(BeatGridTest, TestNthBeatWhenOnBeat) {
-    constexpr int sampleRate = 44100;
-    TrackPointer pTrack = newTrack(sampleRate);
+    TrackPointer pTrack = newTrack(kSampleRate);
 
     constexpr double bpm = 60.1;
     pTrack->trySetBpm(bpm);
-    constexpr mixxx::audio::FrameDiff_t beatLengthFrames = 60.0 * sampleRate / bpm;
+    constexpr mixxx::audio::FrameDiff_t beatLengthFrames = 60.0 * kSampleRate / bpm;
 
     auto pGrid = Beats::fromConstTempo(pTrack->getSampleRate(),
             mixxx::audio::kStartFramePos,
@@ -113,12 +113,11 @@ TEST(BeatGridTest, TestNthBeatWhenOnBeat) {
 }
 
 TEST(BeatGridTest, TestNthBeatWhenNotOnBeat) {
-    constexpr int sampleRate = 44100;
-    TrackPointer pTrack = newTrack(sampleRate);
+    TrackPointer pTrack = newTrack(kSampleRate);
 
     constexpr mixxx::Bpm bpm(60.1);
     pTrack->trySetBpm(bpm.value());
-    const mixxx::audio::FrameDiff_t beatLengthFrames = 60.0 * sampleRate / bpm.value();
+    const mixxx::audio::FrameDiff_t beatLengthFrames = 60.0 * kSampleRate / bpm.value();
 
     auto pGrid = Beats::fromConstTempo(pTrack->getSampleRate(),
             mixxx::audio::kStartFramePos,
@@ -156,8 +155,7 @@ TEST(BeatGridTest, TestNthBeatWhenNotOnBeat) {
 }
 
 TEST(BeatGridTest, FromMetadata) {
-    int sampleRate = 44100;
-    TrackPointer pTrack = newTrack(sampleRate);
+    TrackPointer pTrack = newTrack(kSampleRate);
 
     constexpr mixxx::Bpm bpm(60.1);
     ASSERT_TRUE(pTrack->trySetBpm(bpm.value()));

--- a/src/test/beatmaptest.cpp
+++ b/src/test/beatmaptest.cpp
@@ -14,17 +14,17 @@ class BeatMapTest : public testing::Test {
   protected:
     BeatMapTest()
             : m_pTrack(Track::newTemporary()),
-              m_iSampleRate(10000),
+              m_sampleRate(mixxx::audio::SampleRate(10000)),
               m_iFrameSize(2) {
         m_pTrack->setAudioProperties(
                 mixxx::audio::ChannelCount(2),
-                mixxx::audio::SampleRate(m_iSampleRate),
+                m_sampleRate,
                 mixxx::audio::Bitrate(),
                 mixxx::Duration::fromSeconds(180));
     }
 
     mixxx::audio::FrameDiff_t getBeatLengthFrames(mixxx::Bpm bpm) {
-        return (60.0 * m_iSampleRate / bpm.value());
+        return (60.0 * m_sampleRate.value() / bpm.value());
     }
 
     QVector<mixxx::audio::FramePos> createBeatVector(mixxx::audio::FramePos first_beat,
@@ -38,7 +38,7 @@ class BeatMapTest : public testing::Test {
     }
 
     TrackPointer m_pTrack;
-    int m_iSampleRate;
+    mixxx::audio::SampleRate m_sampleRate;
     int m_iFrameSize;
 };
 

--- a/src/test/bpmcontrol_test.cpp
+++ b/src/test/bpmcontrol_test.cpp
@@ -5,6 +5,7 @@
 #include <QScopedPointer>
 #include <QtDebug>
 
+#include "audio/types.h"
 #include "control/controlobject.h"
 #include "control/controlpushbutton.h"
 #include "mixxxtest.h"
@@ -23,7 +24,7 @@ TEST_F(BpmControlTest, ShortestPercentageChange) {
 }
 
 TEST_F(BpmControlTest, BeatContext_BeatGrid) {
-    constexpr int sampleRate = 44100;
+    constexpr auto sampleRate = mixxx::audio::SampleRate(44100);
 
     TrackPointer pTrack = Track::newTemporary();
     pTrack->setAudioProperties(

--- a/src/test/cuecontrol_test.cpp
+++ b/src/test/cuecontrol_test.cpp
@@ -190,7 +190,7 @@ TEST_F(CueControlTest, LoadAutodetectedCues_QuantizeEnabled) {
     TrackPointer pTrack = createTestTrack();
     pTrack->trySetBpm(120.0);
 
-    const int sampleRate = pTrack->getSampleRate();
+    const mixxx::audio::SampleRate sampleRate = pTrack->getSampleRate();
     const double bpm = pTrack->getBpm();
     const double beatLengthFrames = (60.0 * sampleRate / bpm);
 
@@ -370,7 +370,7 @@ TEST_F(CueControlTest, FollowCueOnQuantize) {
     TrackPointer pTrack = createTestTrack();
     pTrack->trySetBpm(120.0);
 
-    const int sampleRate = pTrack->getSampleRate();
+    const mixxx::audio::SampleRate sampleRate = pTrack->getSampleRate();
     const double bpm = pTrack->getBpm();
     const mixxx::audio::FrameDiff_t beatLengthFrames = (60.0 * sampleRate / bpm);
     const auto cuePos = mixxx::audio::FramePos(1.8 * beatLengthFrames);
@@ -410,7 +410,7 @@ TEST_F(CueControlTest, SeekOnSetCueCDJ) {
     TrackPointer pTrack = createTestTrack();
     pTrack->trySetBpm(120.0);
 
-    const int sampleRate = pTrack->getSampleRate();
+    const mixxx::audio::SampleRate sampleRate = pTrack->getSampleRate();
     const double bpm = pTrack->getBpm();
     const mixxx::audio::FrameDiff_t beatLengthFrames = (60.0 * sampleRate / bpm);
     const auto cuePos = mixxx::audio::FramePos(10 * beatLengthFrames);
@@ -440,7 +440,7 @@ TEST_F(CueControlTest, SeekOnSetCuePlay) {
     TrackPointer pTrack = createTestTrack();
     pTrack->trySetBpm(120.0);
 
-    const int sampleRate = pTrack->getSampleRate();
+    const mixxx::audio::SampleRate sampleRate = pTrack->getSampleRate();
     const double bpm = pTrack->getBpm();
     const mixxx::audio::FrameDiff_t beatLengthFrames = (60.0 * sampleRate / bpm);
     const auto cuePos = mixxx::audio::FramePos(10 * beatLengthFrames);

--- a/src/test/searchqueryparsertest.cpp
+++ b/src/test/searchqueryparsertest.cpp
@@ -8,11 +8,11 @@
 #include "track/track.h"
 #include "util/assert.h"
 
-TrackPointer newTestTrack(int sampleRate) {
+TrackPointer newTestTrack() {
     TrackPointer pTrack(Track::newTemporary());
     pTrack->setAudioProperties(
             mixxx::audio::ChannelCount(2),
-            mixxx::audio::SampleRate(sampleRate),
+            mixxx::audio::SampleRate(44100),
             mixxx::audio::Bitrate(),
             mixxx::Duration::fromSeconds(180));
     return pTrack;
@@ -326,7 +326,7 @@ TEST_F(SearchQueryParserTest, NumericFilter) {
     auto pQuery(
             m_parser.parseQuery("bpm:127.12", QString()));
 
-    TrackPointer pTrack = newTestTrack(44100);
+    TrackPointer pTrack = newTestTrack();
     pTrack->trySetBpm(127);
     EXPECT_FALSE(pQuery->match(pTrack));
     pTrack->trySetBpm(127.12);
@@ -343,7 +343,7 @@ TEST_F(SearchQueryParserTest, NumericFilterYear) {
     auto pQuery(
             m_parser.parseQuery("year:1969", QString()));
 
-    TrackPointer pTrack = newTestTrack(44100);
+    TrackPointer pTrack = newTestTrack();
     EXPECT_FALSE(pQuery->match(pTrack));
     // Note: The sourounding spaces are checking that a user input is popperly trimmed.
     pTrack->setYear(" 1969-08-15 ");
@@ -363,7 +363,7 @@ TEST_F(SearchQueryParserTest, NumericFilterEmpty) {
     auto pQuery(
             m_parser.parseQuery("bpm:", QString()));
 
-    TrackPointer pTrack = newTestTrack(44100);
+    TrackPointer pTrack = newTestTrack();
     pTrack->trySetBpm(127);
     EXPECT_TRUE(pQuery->match(pTrack));
 
@@ -377,7 +377,7 @@ TEST_F(SearchQueryParserTest, NumericFilterNegation) {
     auto pQuery(
             m_parser.parseQuery("-bpm:127.12", QString()));
 
-    TrackPointer pTrack = newTestTrack(44100);
+    TrackPointer pTrack = newTestTrack();
     pTrack->trySetBpm(127);
     EXPECT_TRUE(pQuery->match(pTrack));
     pTrack->trySetBpm(127.12);
@@ -393,7 +393,7 @@ TEST_F(SearchQueryParserTest, NumericFilterAllowsSpace) {
     auto pQuery(
             m_parser.parseQuery("bpm: 127.12", QString()));
 
-    TrackPointer pTrack = newTestTrack(44100);
+    TrackPointer pTrack = newTestTrack();
     pTrack->trySetBpm(127);
     EXPECT_FALSE(pQuery->match(pTrack));
     pTrack->trySetBpm(127.12);
@@ -409,7 +409,7 @@ TEST_F(SearchQueryParserTest, NumericFilterOperators) {
     auto pQuery(
             m_parser.parseQuery("bpm:>127.12", QString()));
 
-    TrackPointer pTrack = newTestTrack(44100);
+    TrackPointer pTrack = newTestTrack();
     pTrack->trySetBpm(127.12);
     EXPECT_FALSE(pQuery->match(pTrack));
     pTrack->trySetBpm(127.13);
@@ -451,7 +451,7 @@ TEST_F(SearchQueryParserTest, NumericRangeFilter) {
     auto pQuery(
             m_parser.parseQuery("bpm:127.12-129", QString()));
 
-    TrackPointer pTrack = newTestTrack(44100);
+    TrackPointer pTrack = newTestTrack();
     pTrack->trySetBpm(125);
     EXPECT_FALSE(pQuery->match(pTrack));
     pTrack->trySetBpm(127.12);
@@ -469,7 +469,7 @@ TEST_F(SearchQueryParserTest, MultipleFilters) {
     auto pQuery(
             m_parser.parseQuery("bpm:127.12-129 artist:\"com truise\" Colorvision", QString()));
 
-    TrackPointer pTrack = newTestTrack(44100);
+    TrackPointer pTrack = newTestTrack();
     pTrack->trySetBpm(128);
     EXPECT_FALSE(pQuery->match(pTrack));
     pTrack->setArtist("Com Truise");
@@ -490,7 +490,7 @@ TEST_F(SearchQueryParserTest, ExtraFilterAppended) {
     auto pQuery(
             m_parser.parseQuery("asdf", "1 > 2"));
 
-    TrackPointer pTrack = newTestTrack(44100);
+    TrackPointer pTrack = newTestTrack();
     pTrack->setArtist("zxcv");
     EXPECT_FALSE(pQuery->match(pTrack));
     pTrack->setArtist("asdf");
@@ -506,7 +506,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearch) {
     auto pQuery(
             m_parser.parseQuery("duration:1:30", QString()));
 
-    TrackPointer pTrack = newTestTrack(44100);
+    TrackPointer pTrack = newTestTrack();
     pTrack->setDuration(91);
     EXPECT_FALSE(pQuery->match(pTrack));
     pTrack->setDuration(90);
@@ -542,7 +542,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchWithOperators) {
     auto pQuery(
             m_parser.parseQuery("duration:>1:30", QString()));
 
-    TrackPointer pTrack = newTestTrack(44100);
+    TrackPointer pTrack = newTestTrack();
     pTrack->setDuration(89);
     EXPECT_FALSE(pQuery->match(pTrack));
     pTrack->setDuration(91);
@@ -644,7 +644,7 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithRangeFilter) {
     auto pQuery(
             m_parser.parseQuery("duration:2:30-3:20", QString()));
 
-    TrackPointer pTrack = newTestTrack(44100);
+    TrackPointer pTrack = newTestTrack();
     pTrack->setDuration(80);
     EXPECT_FALSE(pQuery->match(pTrack));
     pTrack->setDuration(150);

--- a/src/track/keyfactory.cpp
+++ b/src/track/keyfactory.cpp
@@ -88,10 +88,8 @@ QString KeyFactory::getPreferredSubVersion(
 Keys KeyFactory::makePreferredKeys(
         const KeyChangeList& key_changes,
         const QHash<QString, QString>& extraVersionInfo,
-        const int iSampleRate,
+        const mixxx::audio::SampleRate sampleRate,
         SINT totalFrames) {
-    Q_UNUSED(iSampleRate);
-
     const QString version = getPreferredVersion();
     const QString subVersion = getPreferredSubVersion(extraVersionInfo);
 
@@ -107,7 +105,7 @@ Keys KeyFactory::makePreferredKeys(
             pChange->set_key(it->first);
             pChange->set_frame_position(static_cast<int>(frame));
         }
-        key_map.set_global_key(KeyUtils::calculateGlobalKey(key_changes, totalFrames, iSampleRate));
+        key_map.set_global_key(KeyUtils::calculateGlobalKey(key_changes, totalFrames, sampleRate));
         key_map.set_source(mixxx::track::io::key::ANALYZER);
         Keys keys(key_map);
         keys.setSubVersion(subVersion);

--- a/src/track/keyfactory.h
+++ b/src/track/keyfactory.h
@@ -4,6 +4,7 @@
 #include <QString>
 #include <QVector>
 
+#include "audio/types.h"
 #include "proto/keys.pb.h"
 #include "track/keys.h"
 #include "util/types.h"
@@ -39,6 +40,6 @@ class KeyFactory {
     static Keys makePreferredKeys(
             const KeyChangeList& key_changes,
             const QHash<QString, QString>& extraVersionInfo,
-            int iSampleRate,
+            mixxx::audio::SampleRate sampleRate,
             SINT totalFrames);
 };

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -510,7 +510,7 @@ ChromaticKey KeyUtils::scaleKeySteps(ChromaticKey key, int key_changes) {
 
 // static
 mixxx::track::io::key::ChromaticKey KeyUtils::calculateGlobalKey(
-        const KeyChangeList& key_changes, SINT totalFrames, int iSampleRate) {
+        const KeyChangeList& key_changes, SINT totalFrames, mixxx::audio::SampleRate sampleRate) {
     if (key_changes.size() == 1) {
         qDebug() << keyDebugName(key_changes[0].first);
         return key_changes[0].first;
@@ -532,7 +532,7 @@ mixxx::track::io::key::ChromaticKey KeyUtils::calculateGlobalKey(
     qDebug() << "Key Histogram";
     for (auto it = key_histogram.constBegin();
          it != key_histogram.constEnd(); ++it) {
-        qDebug() << it.key() << ":" << keyDebugName(it.key()) << it.value() / iSampleRate;
+        qDebug() << it.key() << ":" << keyDebugName(it.key()) << it.value() / sampleRate;
         if (it.value() > max_delta) {
             max_key = it.key();
             max_delta = it.value();

--- a/src/track/keyutils.h
+++ b/src/track/keyutils.h
@@ -4,6 +4,7 @@
 #include <QMutex>
 #include <QString>
 
+#include "audio/types.h"
 #include "control/controlproxy.h"
 #include "proto/keys.pb.h"
 #include "track/keys.h"
@@ -91,7 +92,9 @@ class KeyUtils {
     static mixxx::track::io::key::ChromaticKey guessKeyFromText(const QString& text);
 
     static mixxx::track::io::key::ChromaticKey calculateGlobalKey(
-            const KeyChangeList& key_changes, SINT totalFrames, int iSampleRate);
+            const KeyChangeList& key_changes,
+            SINT totalFrames,
+            mixxx::audio::SampleRate sampleRate);
 
     static void setNotation(
         const QMap<mixxx::track::io::key::ChromaticKey, QString>& notation);

--- a/src/vinylcontrol/vinylcontrolxwax.cpp
+++ b/src/vinylcontrol/vinylcontrolxwax.cpp
@@ -4,6 +4,7 @@
 
 #include <QtDebug>
 
+#include "audio/types.h"
 #include "control/controlobject.h"
 #include "control/controlproxy.h"
 #include "moc_vinylcontrolxwax.cpp"
@@ -134,22 +135,23 @@ VinylControlXwax::VinylControlXwax(UserSettingsPointer pConfig, const QString& g
         latency = 20;
     }
 
-    int iSampleRate = m_pConfig->getValueString(
-        ConfigKey("[Soundcard]","Samplerate")).toULong();
+    const auto sampleRate = mixxx::audio::SampleRate(
+            m_pConfig->getValueString(ConfigKey("[Soundcard]", "Samplerate"))
+                    .toUInt());
 
     // Set pitch ring size to 1/4 of one revolution -- a full revolution adds
     // too much stickiness to the pitch.
     m_iPitchRingSize = static_cast<int>(60000 / (rpm * latency * 4));
     m_pPitchRing.resize(m_iPitchRingSize);
 
-    qDebug() << "Xwax Vinyl control starting with a sample rate of:" << iSampleRate;
+    qDebug() << "Xwax Vinyl control starting with a sample rate of:" << sampleRate;
     qDebug() << "Building timecode lookup tables for" << strVinylType << "with speed" << strVinylSpeed;
 
     // Initialize the timecoder structure. Use the static mutex so that we only
     // do this once across the VinylControlXwax instances.
     s_xwaxLUTMutex.lock();
 
-    timecoder_init(&timecoder, tc_def, speed, iSampleRate, /* phono */ false);
+    timecoder_init(&timecoder, tc_def, speed, sampleRate.value(), /* phono */ false);
     timecoder_monitor_init(&timecoder, MIXXX_VINYL_SCOPE_SIZE);
     //Note that timecoder_init will not double-malloc the LUTs, and after this we are guaranteed
     //that the LUT has been generated unless we ran out of memory.


### PR DESCRIPTION
This replaces all remaining occurrences of integer sample rates that I found via `git grep` and uses the semantic `mixxx::audio::SampleRate` type instead.