### PR TITLE
Update Novation Launchpad controller scripts to v3.1.1

### DIFF
--- a/res/controllers/Novation Launchpad MK2.midi.xml
+++ b/res/controllers/Novation Launchpad MK2.midi.xml
@@ -3,649 +3,648 @@
     <info>
         <name>Novation Launchpad MK2</name>
         <author>Midiparse</author>
-        <description>Novation Launchpad mapping for Mixxx</description>
+        <description>Novation Launchpad MK2 mapping for Mixxx</description>
         <forums>https://github.com/dszakallas/mixxx-launchpad</forums>
     </info>
     <controller id="Novation Launchpad MK2">
         <scriptfiles>
-            <file functionprefix="NovationLaunchpadMK2" filename="Novation-Launchpad MK2-scripts.js"/>
+            <file functionprefix="NLMK2" filename="Novation-Launchpad MK2-scripts.js"/>
         </scriptfiles>
         <controls>
             <control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0xB0_0x68</key>
+                <key>NLMK2.__midi_0xB0_0x68</key>
                 <status>0xB0</status>
                 <midino>0x68</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0xB0_0x69</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0xB0_0x69</key>
                 <status>0xB0</status>
                 <midino>0x69</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0xB0_0x6A</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0xB0_0x6A</key>
                 <status>0xB0</status>
                 <midino>0x6A</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0xB0_0x6B</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0xB0_0x6B</key>
                 <status>0xB0</status>
                 <midino>0x6B</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0xB0_0x6C</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0xB0_0x6C</key>
                 <status>0xB0</status>
                 <midino>0x6C</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0xB0_0x6D</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0xB0_0x6D</key>
                 <status>0xB0</status>
                 <midino>0x6D</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0xB0_0x6E</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0xB0_0x6E</key>
                 <status>0xB0</status>
                 <midino>0x6E</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0xB0_0x6F</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0xB0_0x6F</key>
                 <status>0xB0</status>
                 <midino>0x6F</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x59</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x59</key>
                 <status>0x90</status>
                 <midino>0x59</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x4F</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x4F</key>
                 <status>0x90</status>
                 <midino>0x4F</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x45</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x45</key>
                 <status>0x90</status>
                 <midino>0x45</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x3B</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x3B</key>
                 <status>0x90</status>
                 <midino>0x3B</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x31</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x31</key>
                 <status>0x90</status>
                 <midino>0x31</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x27</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x27</key>
                 <status>0x90</status>
                 <midino>0x27</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x1D</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x1D</key>
                 <status>0x90</status>
                 <midino>0x1D</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x13</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x13</key>
                 <status>0x90</status>
                 <midino>0x13</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x51</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x51</key>
                 <status>0x90</status>
                 <midino>0x51</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x52</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x52</key>
                 <status>0x90</status>
                 <midino>0x52</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x53</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x53</key>
                 <status>0x90</status>
                 <midino>0x53</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x54</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x54</key>
                 <status>0x90</status>
                 <midino>0x54</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x55</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x55</key>
                 <status>0x90</status>
                 <midino>0x55</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x56</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x56</key>
                 <status>0x90</status>
                 <midino>0x56</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x57</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x57</key>
                 <status>0x90</status>
                 <midino>0x57</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x58</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x58</key>
                 <status>0x90</status>
                 <midino>0x58</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x47</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x47</key>
                 <status>0x90</status>
                 <midino>0x47</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x48</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x48</key>
                 <status>0x90</status>
                 <midino>0x48</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x49</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x49</key>
                 <status>0x90</status>
                 <midino>0x49</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x4A</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x4A</key>
                 <status>0x90</status>
                 <midino>0x4A</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x4B</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x4B</key>
                 <status>0x90</status>
                 <midino>0x4B</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x4C</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x4C</key>
                 <status>0x90</status>
                 <midino>0x4C</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x4D</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x4D</key>
                 <status>0x90</status>
                 <midino>0x4D</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x4E</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x4E</key>
                 <status>0x90</status>
                 <midino>0x4E</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x3D</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x3D</key>
                 <status>0x90</status>
                 <midino>0x3D</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x3E</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x3E</key>
                 <status>0x90</status>
                 <midino>0x3E</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x3F</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x3F</key>
                 <status>0x90</status>
                 <midino>0x3F</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x40</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x40</key>
                 <status>0x90</status>
                 <midino>0x40</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x41</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x41</key>
                 <status>0x90</status>
                 <midino>0x41</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x42</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x42</key>
                 <status>0x90</status>
                 <midino>0x42</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x43</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x43</key>
                 <status>0x90</status>
                 <midino>0x43</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x44</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x44</key>
                 <status>0x90</status>
                 <midino>0x44</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x33</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x33</key>
                 <status>0x90</status>
                 <midino>0x33</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x34</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x34</key>
                 <status>0x90</status>
                 <midino>0x34</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x35</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x35</key>
                 <status>0x90</status>
                 <midino>0x35</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x36</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x36</key>
                 <status>0x90</status>
                 <midino>0x36</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x37</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x37</key>
                 <status>0x90</status>
                 <midino>0x37</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x38</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x38</key>
                 <status>0x90</status>
                 <midino>0x38</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x39</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x39</key>
                 <status>0x90</status>
                 <midino>0x39</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x3A</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x3A</key>
                 <status>0x90</status>
                 <midino>0x3A</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x29</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x29</key>
                 <status>0x90</status>
                 <midino>0x29</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x2A</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x2A</key>
                 <status>0x90</status>
                 <midino>0x2A</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x2B</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x2B</key>
                 <status>0x90</status>
                 <midino>0x2B</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x2C</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x2C</key>
                 <status>0x90</status>
                 <midino>0x2C</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x2D</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x2D</key>
                 <status>0x90</status>
                 <midino>0x2D</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x2E</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x2E</key>
                 <status>0x90</status>
                 <midino>0x2E</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x2F</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x2F</key>
                 <status>0x90</status>
                 <midino>0x2F</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x30</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x30</key>
                 <status>0x90</status>
                 <midino>0x30</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x1F</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x1F</key>
                 <status>0x90</status>
                 <midino>0x1F</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x20</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x20</key>
                 <status>0x90</status>
                 <midino>0x20</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x21</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x21</key>
                 <status>0x90</status>
                 <midino>0x21</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x22</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x22</key>
                 <status>0x90</status>
                 <midino>0x22</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x23</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x23</key>
                 <status>0x90</status>
                 <midino>0x23</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x24</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x24</key>
                 <status>0x90</status>
                 <midino>0x24</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x25</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x25</key>
                 <status>0x90</status>
                 <midino>0x25</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x26</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x26</key>
                 <status>0x90</status>
                 <midino>0x26</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x15</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x15</key>
                 <status>0x90</status>
                 <midino>0x15</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x16</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x16</key>
                 <status>0x90</status>
                 <midino>0x16</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x17</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x17</key>
                 <status>0x90</status>
                 <midino>0x17</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x18</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x18</key>
                 <status>0x90</status>
                 <midino>0x18</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x19</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x19</key>
                 <status>0x90</status>
                 <midino>0x19</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x1A</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x1A</key>
                 <status>0x90</status>
                 <midino>0x1A</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x1B</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x1B</key>
                 <status>0x90</status>
                 <midino>0x1B</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x1C</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x1C</key>
                 <status>0x90</status>
                 <midino>0x1C</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x0B</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x0B</key>
                 <status>0x90</status>
                 <midino>0x0B</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x0C</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x0C</key>
                 <status>0x90</status>
                 <midino>0x0C</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x0D</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x0D</key>
                 <status>0x90</status>
                 <midino>0x0D</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x0E</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x0E</key>
                 <status>0x90</status>
                 <midino>0x0E</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x0F</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x0F</key>
                 <status>0x90</status>
                 <midino>0x0F</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x10</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x10</key>
                 <status>0x90</status>
                 <midino>0x10</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x11</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x11</key>
                 <status>0x90</status>
                 <midino>0x11</midino>
                 <options>
                     <script-binding/>
                 </options>
-            </control><control>
-                <group>[Master]</group>
-                <key>NovationLaunchpadMK2.__midi_0x90_0x12</key>
+            </control>
+            <control>
+                <key>NLMK2.__midi_0x90_0x12</key>
                 <status>0x90</status>
                 <midino>0x12</midino>
                 <options>

--- a/res/controllers/Novation Launchpad MK2.midi.xml
+++ b/res/controllers/Novation Launchpad MK2.midi.xml
@@ -1,4 +1,14 @@
 <?xml version='1.0' encoding='utf-8'?>
+<!--
+  Novation Launchpad MK2 MIDI mapping for Mixxx
+
+  This file is generated. Do not edit directly.
+  Instead, edit the source file and regenerate it.
+  See https://github.com/dszakallas/mixxx-launchpad#building-from-source.
+
+  Commit tag: v3.1.1-4-g4acd883-dirty
+  Commit hash: 4acd8832e0e93fef400055f7938c9f919036b7d6
+-->
 <MixxxControllerPreset mixxxVersion="1.11+" schemaVersion="1">
     <info>
         <name>Novation Launchpad MK2</name>

--- a/res/controllers/Novation Launchpad Mini MK3.midi.xml
+++ b/res/controllers/Novation Launchpad Mini MK3.midi.xml
@@ -1,4 +1,14 @@
 <?xml version='1.0' encoding='utf-8'?>
+<!--
+  Novation Launchpad Mini MK3 MIDI mapping for Mixxx
+
+  This file is generated. Do not edit directly.
+  Instead, edit the source file and regenerate it.
+  See https://github.com/dszakallas/mixxx-launchpad#building-from-source.
+
+  Commit tag: v3.1.1-4-g4acd883-dirty
+  Commit hash: 4acd8832e0e93fef400055f7938c9f919036b7d6
+-->
 <MixxxControllerPreset mixxxVersion="1.11+" schemaVersion="1">
     <info>
         <name>Novation Launchpad Mini MK3</name>

--- a/res/controllers/Novation Launchpad Mini MK3.midi.xml
+++ b/res/controllers/Novation Launchpad Mini MK3.midi.xml
@@ -1,474 +1,146 @@
 <?xml version='1.0' encoding='utf-8'?>
 <MixxxControllerPreset mixxxVersion="1.11+" schemaVersion="1">
     <info>
-        <name>Novation Launchpad</name>
-        <author>Midiparse</author>
-        <description>Novation Launchpad MK1 mapping for Mixxx</description>
+        <name>Novation Launchpad Mini MK3</name>
+        <author>Christian Neumann</author>
+        <description>Novation Launchpad Mini MK3 mapping for Mixxx</description>
         <forums>https://github.com/dszakallas/mixxx-launchpad</forums>
     </info>
-    <controller id="Novation Launchpad">
+    <controller id="Novation Launchpad Mini MK3">
         <scriptfiles>
-            <file functionprefix="NLMK1" filename="Novation-Launchpad-scripts.js"/>
+            <file functionprefix="NLMMK3" filename="Novation-Launchpad Mini MK3-scripts.js"/>
         </scriptfiles>
         <controls>
             <control>
-                <key>NLMK1.__midi_0xB0_0x68</key>
+                <key>NLMMK3.__midi_0xB0_0x5B</key>
                 <status>0xB0</status>
-                <midino>0x68</midino>
+                <midino>0x5B</midino>
                 <options>
                     <script-binding/>
                 </options>
             </control>
             <control>
-                <key>NLMK1.__midi_0xB0_0x69</key>
+                <key>NLMMK3.__midi_0xB0_0x5C</key>
                 <status>0xB0</status>
-                <midino>0x69</midino>
+                <midino>0x5C</midino>
                 <options>
                     <script-binding/>
                 </options>
             </control>
             <control>
-                <key>NLMK1.__midi_0xB0_0x6A</key>
+                <key>NLMMK3.__midi_0xB0_0x5D</key>
                 <status>0xB0</status>
-                <midino>0x6A</midino>
+                <midino>0x5D</midino>
                 <options>
                     <script-binding/>
                 </options>
             </control>
             <control>
-                <key>NLMK1.__midi_0xB0_0x6B</key>
+                <key>NLMMK3.__midi_0xB0_0x5E</key>
                 <status>0xB0</status>
-                <midino>0x6B</midino>
+                <midino>0x5E</midino>
                 <options>
                     <script-binding/>
                 </options>
             </control>
             <control>
-                <key>NLMK1.__midi_0xB0_0x6C</key>
+                <key>NLMMK3.__midi_0xB0_0x5F</key>
                 <status>0xB0</status>
-                <midino>0x6C</midino>
+                <midino>0x5F</midino>
                 <options>
                     <script-binding/>
                 </options>
             </control>
             <control>
-                <key>NLMK1.__midi_0xB0_0x6D</key>
+                <key>NLMMK3.__midi_0xB0_0x60</key>
                 <status>0xB0</status>
-                <midino>0x6D</midino>
+                <midino>0x60</midino>
                 <options>
                     <script-binding/>
                 </options>
             </control>
             <control>
-                <key>NLMK1.__midi_0xB0_0x6E</key>
+                <key>NLMMK3.__midi_0xB0_0x61</key>
                 <status>0xB0</status>
-                <midino>0x6E</midino>
+                <midino>0x61</midino>
                 <options>
                     <script-binding/>
                 </options>
             </control>
             <control>
-                <key>NLMK1.__midi_0xB0_0x6F</key>
+                <key>NLMMK3.__midi_0xB0_0x62</key>
                 <status>0xB0</status>
-                <midino>0x6F</midino>
+                <midino>0x62</midino>
                 <options>
                     <script-binding/>
                 </options>
             </control>
             <control>
-                <key>NLMK1.__midi_0x90_0x08</key>
-                <status>0x90</status>
-                <midino>0x08</midino>
+                <key>NLMMK3.__midi_0xB0_0x59</key>
+                <status>0xB0</status>
+                <midino>0x59</midino>
                 <options>
                     <script-binding/>
                 </options>
             </control>
             <control>
-                <key>NLMK1.__midi_0x90_0x18</key>
-                <status>0x90</status>
-                <midino>0x18</midino>
+                <key>NLMMK3.__midi_0xB0_0x4F</key>
+                <status>0xB0</status>
+                <midino>0x4F</midino>
                 <options>
                     <script-binding/>
                 </options>
             </control>
             <control>
-                <key>NLMK1.__midi_0x90_0x28</key>
-                <status>0x90</status>
-                <midino>0x28</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x38</key>
-                <status>0x90</status>
-                <midino>0x38</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x48</key>
-                <status>0x90</status>
-                <midino>0x48</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x58</key>
-                <status>0x90</status>
-                <midino>0x58</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x68</key>
-                <status>0x90</status>
-                <midino>0x68</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x78</key>
-                <status>0x90</status>
-                <midino>0x78</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x00</key>
-                <status>0x90</status>
-                <midino>0x00</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x01</key>
-                <status>0x90</status>
-                <midino>0x01</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x02</key>
-                <status>0x90</status>
-                <midino>0x02</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x03</key>
-                <status>0x90</status>
-                <midino>0x03</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x04</key>
-                <status>0x90</status>
-                <midino>0x04</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x05</key>
-                <status>0x90</status>
-                <midino>0x05</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x06</key>
-                <status>0x90</status>
-                <midino>0x06</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x07</key>
-                <status>0x90</status>
-                <midino>0x07</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x10</key>
-                <status>0x90</status>
-                <midino>0x10</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x11</key>
-                <status>0x90</status>
-                <midino>0x11</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x12</key>
-                <status>0x90</status>
-                <midino>0x12</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x13</key>
-                <status>0x90</status>
-                <midino>0x13</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x14</key>
-                <status>0x90</status>
-                <midino>0x14</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x15</key>
-                <status>0x90</status>
-                <midino>0x15</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x16</key>
-                <status>0x90</status>
-                <midino>0x16</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x17</key>
-                <status>0x90</status>
-                <midino>0x17</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x20</key>
-                <status>0x90</status>
-                <midino>0x20</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x21</key>
-                <status>0x90</status>
-                <midino>0x21</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x22</key>
-                <status>0x90</status>
-                <midino>0x22</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x23</key>
-                <status>0x90</status>
-                <midino>0x23</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x24</key>
-                <status>0x90</status>
-                <midino>0x24</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x25</key>
-                <status>0x90</status>
-                <midino>0x25</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x26</key>
-                <status>0x90</status>
-                <midino>0x26</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x27</key>
-                <status>0x90</status>
-                <midino>0x27</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x30</key>
-                <status>0x90</status>
-                <midino>0x30</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x31</key>
-                <status>0x90</status>
-                <midino>0x31</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x32</key>
-                <status>0x90</status>
-                <midino>0x32</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x33</key>
-                <status>0x90</status>
-                <midino>0x33</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x34</key>
-                <status>0x90</status>
-                <midino>0x34</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x35</key>
-                <status>0x90</status>
-                <midino>0x35</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x36</key>
-                <status>0x90</status>
-                <midino>0x36</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x37</key>
-                <status>0x90</status>
-                <midino>0x37</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x40</key>
-                <status>0x90</status>
-                <midino>0x40</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x41</key>
-                <status>0x90</status>
-                <midino>0x41</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x42</key>
-                <status>0x90</status>
-                <midino>0x42</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x43</key>
-                <status>0x90</status>
-                <midino>0x43</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x44</key>
-                <status>0x90</status>
-                <midino>0x44</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <key>NLMK1.__midi_0x90_0x45</key>
-                <status>0x90</status>
+                <key>NLMMK3.__midi_0xB0_0x45</key>
+                <status>0xB0</status>
                 <midino>0x45</midino>
                 <options>
                     <script-binding/>
                 </options>
             </control>
             <control>
-                <key>NLMK1.__midi_0x90_0x46</key>
-                <status>0x90</status>
-                <midino>0x46</midino>
+                <key>NLMMK3.__midi_0xB0_0x3B</key>
+                <status>0xB0</status>
+                <midino>0x3B</midino>
                 <options>
                     <script-binding/>
                 </options>
             </control>
             <control>
-                <key>NLMK1.__midi_0x90_0x47</key>
-                <status>0x90</status>
-                <midino>0x47</midino>
+                <key>NLMMK3.__midi_0xB0_0x31</key>
+                <status>0xB0</status>
+                <midino>0x31</midino>
                 <options>
                     <script-binding/>
                 </options>
             </control>
             <control>
-                <key>NLMK1.__midi_0x90_0x50</key>
-                <status>0x90</status>
-                <midino>0x50</midino>
+                <key>NLMMK3.__midi_0xB0_0x27</key>
+                <status>0xB0</status>
+                <midino>0x27</midino>
                 <options>
                     <script-binding/>
                 </options>
             </control>
             <control>
-                <key>NLMK1.__midi_0x90_0x51</key>
+                <key>NLMMK3.__midi_0xB0_0x1D</key>
+                <status>0xB0</status>
+                <midino>0x1D</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0xB0_0x13</key>
+                <status>0xB0</status>
+                <midino>0x13</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x51</key>
                 <status>0x90</status>
                 <midino>0x51</midino>
                 <options>
@@ -476,7 +148,7 @@
                 </options>
             </control>
             <control>
-                <key>NLMK1.__midi_0x90_0x52</key>
+                <key>NLMMK3.__midi_0x90_0x52</key>
                 <status>0x90</status>
                 <midino>0x52</midino>
                 <options>
@@ -484,7 +156,7 @@
                 </options>
             </control>
             <control>
-                <key>NLMK1.__midi_0x90_0x53</key>
+                <key>NLMMK3.__midi_0x90_0x53</key>
                 <status>0x90</status>
                 <midino>0x53</midino>
                 <options>
@@ -492,7 +164,7 @@
                 </options>
             </control>
             <control>
-                <key>NLMK1.__midi_0x90_0x54</key>
+                <key>NLMMK3.__midi_0x90_0x54</key>
                 <status>0x90</status>
                 <midino>0x54</midino>
                 <options>
@@ -500,7 +172,7 @@
                 </options>
             </control>
             <control>
-                <key>NLMK1.__midi_0x90_0x55</key>
+                <key>NLMMK3.__midi_0x90_0x55</key>
                 <status>0x90</status>
                 <midino>0x55</midino>
                 <options>
@@ -508,7 +180,7 @@
                 </options>
             </control>
             <control>
-                <key>NLMK1.__midi_0x90_0x56</key>
+                <key>NLMMK3.__midi_0x90_0x56</key>
                 <status>0x90</status>
                 <midino>0x56</midino>
                 <options>
@@ -516,7 +188,7 @@
                 </options>
             </control>
             <control>
-                <key>NLMK1.__midi_0x90_0x57</key>
+                <key>NLMMK3.__midi_0x90_0x57</key>
                 <status>0x90</status>
                 <midino>0x57</midino>
                 <options>
@@ -524,129 +196,457 @@
                 </options>
             </control>
             <control>
-                <key>NLMK1.__midi_0x90_0x60</key>
+                <key>NLMMK3.__midi_0x90_0x58</key>
                 <status>0x90</status>
-                <midino>0x60</midino>
+                <midino>0x58</midino>
                 <options>
                     <script-binding/>
                 </options>
             </control>
             <control>
-                <key>NLMK1.__midi_0x90_0x61</key>
+                <key>NLMMK3.__midi_0x90_0x47</key>
                 <status>0x90</status>
-                <midino>0x61</midino>
+                <midino>0x47</midino>
                 <options>
                     <script-binding/>
                 </options>
             </control>
             <control>
-                <key>NLMK1.__midi_0x90_0x62</key>
+                <key>NLMMK3.__midi_0x90_0x48</key>
                 <status>0x90</status>
-                <midino>0x62</midino>
+                <midino>0x48</midino>
                 <options>
                     <script-binding/>
                 </options>
             </control>
             <control>
-                <key>NLMK1.__midi_0x90_0x63</key>
+                <key>NLMMK3.__midi_0x90_0x49</key>
                 <status>0x90</status>
-                <midino>0x63</midino>
+                <midino>0x49</midino>
                 <options>
                     <script-binding/>
                 </options>
             </control>
             <control>
-                <key>NLMK1.__midi_0x90_0x64</key>
+                <key>NLMMK3.__midi_0x90_0x4A</key>
                 <status>0x90</status>
-                <midino>0x64</midino>
+                <midino>0x4A</midino>
                 <options>
                     <script-binding/>
                 </options>
             </control>
             <control>
-                <key>NLMK1.__midi_0x90_0x65</key>
+                <key>NLMMK3.__midi_0x90_0x4B</key>
                 <status>0x90</status>
-                <midino>0x65</midino>
+                <midino>0x4B</midino>
                 <options>
                     <script-binding/>
                 </options>
             </control>
             <control>
-                <key>NLMK1.__midi_0x90_0x66</key>
+                <key>NLMMK3.__midi_0x90_0x4C</key>
                 <status>0x90</status>
-                <midino>0x66</midino>
+                <midino>0x4C</midino>
                 <options>
                     <script-binding/>
                 </options>
             </control>
             <control>
-                <key>NLMK1.__midi_0x90_0x67</key>
+                <key>NLMMK3.__midi_0x90_0x4D</key>
                 <status>0x90</status>
-                <midino>0x67</midino>
+                <midino>0x4D</midino>
                 <options>
                     <script-binding/>
                 </options>
             </control>
             <control>
-                <key>NLMK1.__midi_0x90_0x70</key>
+                <key>NLMMK3.__midi_0x90_0x4E</key>
                 <status>0x90</status>
-                <midino>0x70</midino>
+                <midino>0x4E</midino>
                 <options>
                     <script-binding/>
                 </options>
             </control>
             <control>
-                <key>NLMK1.__midi_0x90_0x71</key>
+                <key>NLMMK3.__midi_0x90_0x3D</key>
                 <status>0x90</status>
-                <midino>0x71</midino>
+                <midino>0x3D</midino>
                 <options>
                     <script-binding/>
                 </options>
             </control>
             <control>
-                <key>NLMK1.__midi_0x90_0x72</key>
+                <key>NLMMK3.__midi_0x90_0x3E</key>
                 <status>0x90</status>
-                <midino>0x72</midino>
+                <midino>0x3E</midino>
                 <options>
                     <script-binding/>
                 </options>
             </control>
             <control>
-                <key>NLMK1.__midi_0x90_0x73</key>
+                <key>NLMMK3.__midi_0x90_0x3F</key>
                 <status>0x90</status>
-                <midino>0x73</midino>
+                <midino>0x3F</midino>
                 <options>
                     <script-binding/>
                 </options>
             </control>
             <control>
-                <key>NLMK1.__midi_0x90_0x74</key>
+                <key>NLMMK3.__midi_0x90_0x40</key>
                 <status>0x90</status>
-                <midino>0x74</midino>
+                <midino>0x40</midino>
                 <options>
                     <script-binding/>
                 </options>
             </control>
             <control>
-                <key>NLMK1.__midi_0x90_0x75</key>
+                <key>NLMMK3.__midi_0x90_0x41</key>
                 <status>0x90</status>
-                <midino>0x75</midino>
+                <midino>0x41</midino>
                 <options>
                     <script-binding/>
                 </options>
             </control>
             <control>
-                <key>NLMK1.__midi_0x90_0x76</key>
+                <key>NLMMK3.__midi_0x90_0x42</key>
                 <status>0x90</status>
-                <midino>0x76</midino>
+                <midino>0x42</midino>
                 <options>
                     <script-binding/>
                 </options>
             </control>
             <control>
-                <key>NLMK1.__midi_0x90_0x77</key>
+                <key>NLMMK3.__midi_0x90_0x43</key>
                 <status>0x90</status>
-                <midino>0x77</midino>
+                <midino>0x43</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x44</key>
+                <status>0x90</status>
+                <midino>0x44</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x33</key>
+                <status>0x90</status>
+                <midino>0x33</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x34</key>
+                <status>0x90</status>
+                <midino>0x34</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x35</key>
+                <status>0x90</status>
+                <midino>0x35</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x36</key>
+                <status>0x90</status>
+                <midino>0x36</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x37</key>
+                <status>0x90</status>
+                <midino>0x37</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x38</key>
+                <status>0x90</status>
+                <midino>0x38</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x39</key>
+                <status>0x90</status>
+                <midino>0x39</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x3A</key>
+                <status>0x90</status>
+                <midino>0x3A</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x29</key>
+                <status>0x90</status>
+                <midino>0x29</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x2A</key>
+                <status>0x90</status>
+                <midino>0x2A</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x2B</key>
+                <status>0x90</status>
+                <midino>0x2B</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x2C</key>
+                <status>0x90</status>
+                <midino>0x2C</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x2D</key>
+                <status>0x90</status>
+                <midino>0x2D</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x2E</key>
+                <status>0x90</status>
+                <midino>0x2E</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x2F</key>
+                <status>0x90</status>
+                <midino>0x2F</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x30</key>
+                <status>0x90</status>
+                <midino>0x30</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x1F</key>
+                <status>0x90</status>
+                <midino>0x1F</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x20</key>
+                <status>0x90</status>
+                <midino>0x20</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x21</key>
+                <status>0x90</status>
+                <midino>0x21</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x22</key>
+                <status>0x90</status>
+                <midino>0x22</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x23</key>
+                <status>0x90</status>
+                <midino>0x23</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x24</key>
+                <status>0x90</status>
+                <midino>0x24</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x25</key>
+                <status>0x90</status>
+                <midino>0x25</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x26</key>
+                <status>0x90</status>
+                <midino>0x26</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x15</key>
+                <status>0x90</status>
+                <midino>0x15</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x16</key>
+                <status>0x90</status>
+                <midino>0x16</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x17</key>
+                <status>0x90</status>
+                <midino>0x17</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x18</key>
+                <status>0x90</status>
+                <midino>0x18</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x19</key>
+                <status>0x90</status>
+                <midino>0x19</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x1A</key>
+                <status>0x90</status>
+                <midino>0x1A</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x1B</key>
+                <status>0x90</status>
+                <midino>0x1B</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x1C</key>
+                <status>0x90</status>
+                <midino>0x1C</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x0B</key>
+                <status>0x90</status>
+                <midino>0x0B</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x0C</key>
+                <status>0x90</status>
+                <midino>0x0C</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x0D</key>
+                <status>0x90</status>
+                <midino>0x0D</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x0E</key>
+                <status>0x90</status>
+                <midino>0x0E</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x0F</key>
+                <status>0x90</status>
+                <midino>0x0F</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x10</key>
+                <status>0x90</status>
+                <midino>0x10</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x11</key>
+                <status>0x90</status>
+                <midino>0x11</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <key>NLMMK3.__midi_0x90_0x12</key>
+                <status>0x90</status>
+                <midino>0x12</midino>
                 <options>
                     <script-binding/>
                 </options>

--- a/res/controllers/Novation Launchpad.midi.xml
+++ b/res/controllers/Novation Launchpad.midi.xml
@@ -1,4 +1,14 @@
 <?xml version='1.0' encoding='utf-8'?>
+<!--
+  Novation Launchpad MIDI mapping for Mixxx
+
+  This file is generated. Do not edit directly.
+  Instead, edit the source file and regenerate it.
+  See https://github.com/dszakallas/mixxx-launchpad#building-from-source.
+
+  Commit tag: v3.1.1-4-g4acd883-dirty
+  Commit hash: 4acd8832e0e93fef400055f7938c9f919036b7d6
+-->
 <MixxxControllerPreset mixxxVersion="1.11+" schemaVersion="1">
     <info>
         <name>Novation Launchpad</name>

--- a/res/controllers/Novation-Launchpad MK2-scripts.js
+++ b/res/controllers/Novation-Launchpad MK2-scripts.js
@@ -1,10856 +1,7486 @@
-var NovationLaunchpadMK2 = (function () {
-  function _classCallCheck(instance, Constructor) {
-    if (!(instance instanceof Constructor)) {
-      throw new TypeError("Cannot call a class as a function");
-    }
-  }
-
-  function _defineProperties(target, props) {
-    for (var i = 0; i < props.length; i++) {
-      var descriptor = props[i];
-      descriptor.enumerable = descriptor.enumerable || false;
-      descriptor.configurable = true;
-      if ("value" in descriptor) descriptor.writable = true;
-      Object.defineProperty(target, descriptor.key, descriptor);
-    }
-  }
-
-  function _createClass(Constructor, protoProps, staticProps) {
-    if (protoProps) _defineProperties(Constructor.prototype, protoProps);
-    if (staticProps) _defineProperties(Constructor, staticProps);
-    return Constructor;
-  }
-
-  function _defineProperty(obj, key, value) {
-    if (key in obj) {
-      Object.defineProperty(obj, key, {
-        value: value,
-        enumerable: true,
-        configurable: true,
-        writable: true
-      });
-    } else {
-      obj[key] = value;
-    }
-
-    return obj;
-  }
-
-  function _assertThisInitialized(self) {
-    if (self === void 0) {
-      throw new ReferenceError("this hasn't been initialised - super() hasn't been called");
-    }
-
-    return self;
-  }
-
-  function _typeof(obj) {
-    "@babel/helpers - typeof";
-
-    if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") {
-      _typeof = function _typeof(obj) {
-        return typeof obj;
-      };
-    } else {
-      _typeof = function _typeof(obj) {
-        return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
-      };
-    }
-
-    return _typeof(obj);
-  }
-
-  function _possibleConstructorReturn(self, call) {
-    if (call && (_typeof(call) === "object" || typeof call === "function")) {
-      return call;
-    }
-
-    return _assertThisInitialized(self);
-  }
-
-  function _getPrototypeOf(o) {
-    _getPrototypeOf = Object.setPrototypeOf ? Object.getPrototypeOf : function _getPrototypeOf(o) {
-      return o.__proto__ || Object.getPrototypeOf(o);
-    };
-    return _getPrototypeOf(o);
-  }
-
-  function _setPrototypeOf(o, p) {
-    _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) {
-      o.__proto__ = p;
-      return o;
-    };
-
-    return _setPrototypeOf(o, p);
-  }
-
-  function _inherits(subClass, superClass) {
-    if (typeof superClass !== "function" && superClass !== null) {
-      throw new TypeError("Super expression must either be null or a function");
-    }
-
-    subClass.prototype = Object.create(superClass && superClass.prototype, {
-      constructor: {
-        value: subClass,
-        writable: true,
-        configurable: true
-      }
-    });
-    if (superClass) _setPrototypeOf(subClass, superClass);
-  }
-
-  function _classCallCheck$1(instance, Constructor) {
-    if (!(instance instanceof Constructor)) {
-      throw new TypeError("Cannot call a class as a function");
-    }
-  }
-
-  function _defineProperties$1(target, props) {
-    for (var i = 0; i < props.length; i++) {
-      var descriptor = props[i];
-      descriptor.enumerable = descriptor.enumerable || false;
-      descriptor.configurable = true;
-      if ("value" in descriptor) descriptor.writable = true;
-      Object.defineProperty(target, descriptor.key, descriptor);
-    }
-  }
-
-  function _createClass$1(Constructor, protoProps, staticProps) {
-    if (protoProps) _defineProperties$1(Constructor.prototype, protoProps);
-    if (staticProps) _defineProperties$1(Constructor, staticProps);
-    return Constructor;
-  }
-
-  function _defineProperty$1(obj, key, value) {
-    if (key in obj) {
-      Object.defineProperty(obj, key, {
-        value: value,
-        enumerable: true,
-        configurable: true,
-        writable: true
-      });
-    } else {
-      obj[key] = value;
-    }
-
-    return obj;
-  }
-
-  function _arrayWithHoles(arr) {
-    if (Array.isArray(arr)) return arr;
-  }
-
-  function _iterableToArrayLimit(arr, i) {
-    if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return;
-    var _arr = [];
-    var _n = true;
-    var _d = false;
-    var _e = undefined;
-
-    try {
-      for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) {
-        _arr.push(_s.value);
-
-        if (i && _arr.length === i) break;
-      }
-    } catch (err) {
-      _d = true;
-      _e = err;
-    } finally {
-      try {
-        if (!_n && _i["return"] != null) _i["return"]();
-      } finally {
-        if (_d) throw _e;
-      }
-    }
-
-    return _arr;
-  }
-
-  function _arrayLikeToArray(arr, len) {
-    if (len == null || len > arr.length) len = arr.length;
-
-    for (var i = 0, arr2 = new Array(len); i < len; i++) {
-      arr2[i] = arr[i];
-    }
-
-    return arr2;
-  }
-
-  function _unsupportedIterableToArray(o, minLen) {
-    if (!o) return;
-    if (typeof o === "string") return _arrayLikeToArray(o, minLen);
-    var n = Object.prototype.toString.call(o).slice(8, -1);
-    if (n === "Object" && o.constructor) n = o.constructor.name;
-    if (n === "Map" || n === "Set") return Array.from(n);
-    if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen);
-  }
-
-  function _nonIterableRest() {
-    throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
-  }
-
-  function _slicedToArray(arr, i) {
-    return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest();
-  }
-
-  /* global engine, midi, script */
-  var engine_1 = engine;
-  var midi_1 = midi;
-  var script_1 = script;
-
-  /** Detect free variable `global` from Node.js. */
-  var freeGlobal = (typeof global === "undefined" ? "undefined" : _typeof(global)) == 'object' && global && global.Object === Object && global;
-
-  /** Detect free variable `self`. */
-
-  var freeSelf = (typeof self === "undefined" ? "undefined" : _typeof(self)) == 'object' && self && self.Object === Object && self;
-  /** Used as a reference to the global object. */
-
-  var root = freeGlobal || freeSelf || Function('return this')();
-
-  /** Built-in value references. */
-
-  var _Symbol = root.Symbol;
-
-  /** Used for built-in method references. */
-
-  var objectProto = Object.prototype;
-  /** Used to check objects for own properties. */
-
-  var hasOwnProperty = objectProto.hasOwnProperty;
-  /**
-   * Used to resolve the
-   * [`toStringTag`](http://ecma-international.org/ecma-262/7.0/#sec-object.prototype.tostring)
-   * of values.
-   */
-
-  var nativeObjectToString = objectProto.toString;
-  /** Built-in value references. */
-
-  var symToStringTag = _Symbol ? _Symbol.toStringTag : undefined;
-  /**
-   * A specialized version of `baseGetTag` which ignores `Symbol.toStringTag` values.
-   *
-   * @private
-   * @param {*} value The value to query.
-   * @returns {string} Returns the raw `toStringTag`.
-   */
-
-  function getRawTag(value) {
-    var isOwn = hasOwnProperty.call(value, symToStringTag),
-        tag = value[symToStringTag];
-
-    try {
-      value[symToStringTag] = undefined;
-      var unmasked = true;
-    } catch (e) {}
-
-    var result = nativeObjectToString.call(value);
-
-    if (unmasked) {
-      if (isOwn) {
-        value[symToStringTag] = tag;
-      } else {
-        delete value[symToStringTag];
-      }
-    }
-
-    return result;
-  }
-
-  /** Used for built-in method references. */
-  var objectProto$1 = Object.prototype;
-  /**
-   * Used to resolve the
-   * [`toStringTag`](http://ecma-international.org/ecma-262/7.0/#sec-object.prototype.tostring)
-   * of values.
-   */
-
-  var nativeObjectToString$1 = objectProto$1.toString;
-  /**
-   * Converts `value` to a string using `Object.prototype.toString`.
-   *
-   * @private
-   * @param {*} value The value to convert.
-   * @returns {string} Returns the converted string.
-   */
-
-  function objectToString(value) {
-    return nativeObjectToString$1.call(value);
-  }
-
-  /** `Object#toString` result references. */
-
-  var nullTag = '[object Null]',
-      undefinedTag = '[object Undefined]';
-  /** Built-in value references. */
-
-  var symToStringTag$1 = _Symbol ? _Symbol.toStringTag : undefined;
-  /**
-   * The base implementation of `getTag` without fallbacks for buggy environments.
-   *
-   * @private
-   * @param {*} value The value to query.
-   * @returns {string} Returns the `toStringTag`.
-   */
-
-  function baseGetTag(value) {
-    if (value == null) {
-      return value === undefined ? undefinedTag : nullTag;
-    }
-
-    return symToStringTag$1 && symToStringTag$1 in Object(value) ? getRawTag(value) : objectToString(value);
-  }
-
-  /**
-   * Checks if `value` is the
-   * [language type](http://www.ecma-international.org/ecma-262/7.0/#sec-ecmascript-language-types)
-   * of `Object`. (e.g. arrays, functions, objects, regexes, `new Number(0)`, and `new String('')`)
-   *
-   * @static
-   * @memberOf _
-   * @since 0.1.0
-   * @category Lang
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is an object, else `false`.
-   * @example
-   *
-   * _.isObject({});
-   * // => true
-   *
-   * _.isObject([1, 2, 3]);
-   * // => true
-   *
-   * _.isObject(_.noop);
-   * // => true
-   *
-   * _.isObject(null);
-   * // => false
-   */
-  function isObject(value) {
-    var type = _typeof(value);
-
-    return value != null && (type == 'object' || type == 'function');
-  }
-
-  /** `Object#toString` result references. */
-
-  var asyncTag = '[object AsyncFunction]',
-      funcTag = '[object Function]',
-      genTag = '[object GeneratorFunction]',
-      proxyTag = '[object Proxy]';
-  /**
-   * Checks if `value` is classified as a `Function` object.
-   *
-   * @static
-   * @memberOf _
-   * @since 0.1.0
-   * @category Lang
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is a function, else `false`.
-   * @example
-   *
-   * _.isFunction(_);
-   * // => true
-   *
-   * _.isFunction(/abc/);
-   * // => false
-   */
-
-  function isFunction(value) {
-    if (!isObject(value)) {
-      return false;
-    } // The use of `Object#toString` avoids issues with the `typeof` operator
-    // in Safari 9 which returns 'object' for typed arrays and other constructors.
-
-
-    var tag = baseGetTag(value);
-    return tag == funcTag || tag == genTag || tag == asyncTag || tag == proxyTag;
-  }
-
-  /** Used to detect overreaching core-js shims. */
-
-  var coreJsData = root['__core-js_shared__'];
-
-  /** Used to detect methods masquerading as native. */
-
-  var maskSrcKey = function () {
-    var uid = /[^.]+$/.exec(coreJsData && coreJsData.keys && coreJsData.keys.IE_PROTO || '');
-    return uid ? 'Symbol(src)_1.' + uid : '';
-  }();
-  /**
-   * Checks if `func` has its source masked.
-   *
-   * @private
-   * @param {Function} func The function to check.
-   * @returns {boolean} Returns `true` if `func` is masked, else `false`.
-   */
-
-
-  function isMasked(func) {
-    return !!maskSrcKey && maskSrcKey in func;
-  }
-
-  /** Used for built-in method references. */
-  var funcProto = Function.prototype;
-  /** Used to resolve the decompiled source of functions. */
-
-  var funcToString = funcProto.toString;
-  /**
-   * Converts `func` to its source code.
-   *
-   * @private
-   * @param {Function} func The function to convert.
-   * @returns {string} Returns the source code.
-   */
-
-  function toSource(func) {
-    if (func != null) {
-      try {
-        return funcToString.call(func);
-      } catch (e) {}
-
-      try {
-        return func + '';
-      } catch (e) {}
-    }
-
-    return '';
-  }
-
-  /**
-   * Used to match `RegExp`
-   * [syntax characters](http://ecma-international.org/ecma-262/7.0/#sec-patterns).
-   */
-
-  var reRegExpChar = /[\\^$.*+?()[\]{}|]/g;
-  /** Used to detect host constructors (Safari). */
-
-  var reIsHostCtor = /^\[object .+?Constructor\]$/;
-  /** Used for built-in method references. */
-
-  var funcProto$1 = Function.prototype,
-      objectProto$2 = Object.prototype;
-  /** Used to resolve the decompiled source of functions. */
-
-  var funcToString$1 = funcProto$1.toString;
-  /** Used to check objects for own properties. */
-
-  var hasOwnProperty$1 = objectProto$2.hasOwnProperty;
-  /** Used to detect if a method is native. */
-
-  var reIsNative = RegExp('^' + funcToString$1.call(hasOwnProperty$1).replace(reRegExpChar, '\\$&').replace(/hasOwnProperty|(function).*?(?=\\\()| for .+?(?=\\\])/g, '$1.*?') + '$');
-  /**
-   * The base implementation of `_.isNative` without bad shim checks.
-   *
-   * @private
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is a native function,
-   *  else `false`.
-   */
-
-  function baseIsNative(value) {
-    if (!isObject(value) || isMasked(value)) {
-      return false;
-    }
-
-    var pattern = isFunction(value) ? reIsNative : reIsHostCtor;
-    return pattern.test(toSource(value));
-  }
-
-  /**
-   * Gets the value at `key` of `object`.
-   *
-   * @private
-   * @param {Object} [object] The object to query.
-   * @param {string} key The key of the property to get.
-   * @returns {*} Returns the property value.
-   */
-  function getValue(object, key) {
-    return object == null ? undefined : object[key];
-  }
-
-  /**
-   * Gets the native function at `key` of `object`.
-   *
-   * @private
-   * @param {Object} object The object to query.
-   * @param {string} key The key of the method to get.
-   * @returns {*} Returns the function if it's native, else `undefined`.
-   */
-
-  function getNative(object, key) {
-    var value = getValue(object, key);
-    return baseIsNative(value) ? value : undefined;
-  }
-
-  var defineProperty = function () {
-    try {
-      var func = getNative(Object, 'defineProperty');
-      func({}, '', {});
-      return func;
-    } catch (e) {}
-  }();
-
-  /**
-   * The base implementation of `assignValue` and `assignMergeValue` without
-   * value checks.
-   *
-   * @private
-   * @param {Object} object The object to modify.
-   * @param {string} key The key of the property to assign.
-   * @param {*} value The value to assign.
-   */
-
-  function baseAssignValue(object, key, value) {
-    if (key == '__proto__' && defineProperty) {
-      defineProperty(object, key, {
-        'configurable': true,
-        'enumerable': true,
-        'value': value,
-        'writable': true
-      });
-    } else {
-      object[key] = value;
-    }
-  }
-
-  /**
-   * Performs a
-   * [`SameValueZero`](http://ecma-international.org/ecma-262/7.0/#sec-samevaluezero)
-   * comparison between two values to determine if they are equivalent.
-   *
-   * @static
-   * @memberOf _
-   * @since 4.0.0
-   * @category Lang
-   * @param {*} value The value to compare.
-   * @param {*} other The other value to compare.
-   * @returns {boolean} Returns `true` if the values are equivalent, else `false`.
-   * @example
-   *
-   * var object = { 'a': 1 };
-   * var other = { 'a': 1 };
-   *
-   * _.eq(object, object);
-   * // => true
-   *
-   * _.eq(object, other);
-   * // => false
-   *
-   * _.eq('a', 'a');
-   * // => true
-   *
-   * _.eq('a', Object('a'));
-   * // => false
-   *
-   * _.eq(NaN, NaN);
-   * // => true
-   */
-  function eq(value, other) {
-    return value === other || value !== value && other !== other;
-  }
-
-  /** Used for built-in method references. */
-
-  var objectProto$3 = Object.prototype;
-  /** Used to check objects for own properties. */
-
-  var hasOwnProperty$2 = objectProto$3.hasOwnProperty;
-  /**
-   * Assigns `value` to `key` of `object` if the existing value is not equivalent
-   * using [`SameValueZero`](http://ecma-international.org/ecma-262/7.0/#sec-samevaluezero)
-   * for equality comparisons.
-   *
-   * @private
-   * @param {Object} object The object to modify.
-   * @param {string} key The key of the property to assign.
-   * @param {*} value The value to assign.
-   */
-
-  function assignValue(object, key, value) {
-    var objValue = object[key];
-
-    if (!(hasOwnProperty$2.call(object, key) && eq(objValue, value)) || value === undefined && !(key in object)) {
-      baseAssignValue(object, key, value);
-    }
-  }
-
-  /**
-   * Copies properties of `source` to `object`.
-   *
-   * @private
-   * @param {Object} source The object to copy properties from.
-   * @param {Array} props The property identifiers to copy.
-   * @param {Object} [object={}] The object to copy properties to.
-   * @param {Function} [customizer] The function to customize copied values.
-   * @returns {Object} Returns `object`.
-   */
-
-  function copyObject(source, props, object, customizer) {
-    var isNew = !object;
-    object || (object = {});
-    var index = -1,
-        length = props.length;
-
-    while (++index < length) {
-      var key = props[index];
-      var newValue = customizer ? customizer(object[key], source[key], key, object, source) : undefined;
-
-      if (newValue === undefined) {
-        newValue = source[key];
-      }
-
-      if (isNew) {
-        baseAssignValue(object, key, newValue);
-      } else {
-        assignValue(object, key, newValue);
-      }
-    }
-
-    return object;
-  }
-
-  /**
-   * This method returns the first argument it receives.
-   *
-   * @static
-   * @since 0.1.0
-   * @memberOf _
-   * @category Util
-   * @param {*} value Any value.
-   * @returns {*} Returns `value`.
-   * @example
-   *
-   * var object = { 'a': 1 };
-   *
-   * console.log(_.identity(object) === object);
-   * // => true
-   */
-  function identity(value) {
-    return value;
-  }
-
-  /**
-   * A faster alternative to `Function#apply`, this function invokes `func`
-   * with the `this` binding of `thisArg` and the arguments of `args`.
-   *
-   * @private
-   * @param {Function} func The function to invoke.
-   * @param {*} thisArg The `this` binding of `func`.
-   * @param {Array} args The arguments to invoke `func` with.
-   * @returns {*} Returns the result of `func`.
-   */
-  function apply(func, thisArg, args) {
-    switch (args.length) {
-      case 0:
-        return func.call(thisArg);
-
-      case 1:
-        return func.call(thisArg, args[0]);
-
-      case 2:
-        return func.call(thisArg, args[0], args[1]);
-
-      case 3:
-        return func.call(thisArg, args[0], args[1], args[2]);
-    }
-
-    return func.apply(thisArg, args);
-  }
-
-  /* Built-in method references for those with the same name as other `lodash` methods. */
-
-  var nativeMax = Math.max;
-  /**
-   * A specialized version of `baseRest` which transforms the rest array.
-   *
-   * @private
-   * @param {Function} func The function to apply a rest parameter to.
-   * @param {number} [start=func.length-1] The start position of the rest parameter.
-   * @param {Function} transform The rest array transform.
-   * @returns {Function} Returns the new function.
-   */
-
-  function overRest(func, start, transform) {
-    start = nativeMax(start === undefined ? func.length - 1 : start, 0);
-    return function () {
-      var args = arguments,
-          index = -1,
-          length = nativeMax(args.length - start, 0),
-          array = Array(length);
-
-      while (++index < length) {
-        array[index] = args[start + index];
-      }
-
-      index = -1;
-      var otherArgs = Array(start + 1);
-
-      while (++index < start) {
-        otherArgs[index] = args[index];
-      }
-
-      otherArgs[start] = transform(array);
-      return apply(func, this, otherArgs);
-    };
-  }
-
-  /**
-   * Creates a function that returns `value`.
-   *
-   * @static
-   * @memberOf _
-   * @since 2.4.0
-   * @category Util
-   * @param {*} value The value to return from the new function.
-   * @returns {Function} Returns the new constant function.
-   * @example
-   *
-   * var objects = _.times(2, _.constant({ 'a': 1 }));
-   *
-   * console.log(objects);
-   * // => [{ 'a': 1 }, { 'a': 1 }]
-   *
-   * console.log(objects[0] === objects[1]);
-   * // => true
-   */
-  function constant(value) {
-    return function () {
-      return value;
-    };
-  }
-
-  /**
-   * The base implementation of `setToString` without support for hot loop shorting.
-   *
-   * @private
-   * @param {Function} func The function to modify.
-   * @param {Function} string The `toString` result.
-   * @returns {Function} Returns `func`.
-   */
-
-  var baseSetToString = !defineProperty ? identity : function (func, string) {
-    return defineProperty(func, 'toString', {
-      'configurable': true,
-      'enumerable': false,
-      'value': constant(string),
-      'writable': true
-    });
-  };
-
-  /** Used to detect hot functions by number of calls within a span of milliseconds. */
-  var HOT_COUNT = 800,
-      HOT_SPAN = 16;
-  /* Built-in method references for those with the same name as other `lodash` methods. */
-
-  var nativeNow = Date.now;
-  /**
-   * Creates a function that'll short out and invoke `identity` instead
-   * of `func` when it's called `HOT_COUNT` or more times in `HOT_SPAN`
-   * milliseconds.
-   *
-   * @private
-   * @param {Function} func The function to restrict.
-   * @returns {Function} Returns the new shortable function.
-   */
-
-  function shortOut(func) {
-    var count = 0,
-        lastCalled = 0;
-    return function () {
-      var stamp = nativeNow(),
-          remaining = HOT_SPAN - (stamp - lastCalled);
-      lastCalled = stamp;
-
-      if (remaining > 0) {
-        if (++count >= HOT_COUNT) {
-          return arguments[0];
-        }
-      } else {
-        count = 0;
-      }
-
-      return func.apply(undefined, arguments);
-    };
-  }
-
-  /**
-   * Sets the `toString` method of `func` to return `string`.
-   *
-   * @private
-   * @param {Function} func The function to modify.
-   * @param {Function} string The `toString` result.
-   * @returns {Function} Returns `func`.
-   */
-
-  var setToString = shortOut(baseSetToString);
-
-  /**
-   * The base implementation of `_.rest` which doesn't validate or coerce arguments.
-   *
-   * @private
-   * @param {Function} func The function to apply a rest parameter to.
-   * @param {number} [start=func.length-1] The start position of the rest parameter.
-   * @returns {Function} Returns the new function.
-   */
-
-  function baseRest(func, start) {
-    return setToString(overRest(func, start, identity), func + '');
-  }
-
-  /** Used as references for various `Number` constants. */
-  var MAX_SAFE_INTEGER = 9007199254740991;
-  /**
-   * Checks if `value` is a valid array-like length.
-   *
-   * **Note:** This method is loosely based on
-   * [`ToLength`](http://ecma-international.org/ecma-262/7.0/#sec-tolength).
-   *
-   * @static
-   * @memberOf _
-   * @since 4.0.0
-   * @category Lang
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is a valid length, else `false`.
-   * @example
-   *
-   * _.isLength(3);
-   * // => true
-   *
-   * _.isLength(Number.MIN_VALUE);
-   * // => false
-   *
-   * _.isLength(Infinity);
-   * // => false
-   *
-   * _.isLength('3');
-   * // => false
-   */
-
-  function isLength(value) {
-    return typeof value == 'number' && value > -1 && value % 1 == 0 && value <= MAX_SAFE_INTEGER;
-  }
-
-  /**
-   * Checks if `value` is array-like. A value is considered array-like if it's
-   * not a function and has a `value.length` that's an integer greater than or
-   * equal to `0` and less than or equal to `Number.MAX_SAFE_INTEGER`.
-   *
-   * @static
-   * @memberOf _
-   * @since 4.0.0
-   * @category Lang
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is array-like, else `false`.
-   * @example
-   *
-   * _.isArrayLike([1, 2, 3]);
-   * // => true
-   *
-   * _.isArrayLike(document.body.children);
-   * // => true
-   *
-   * _.isArrayLike('abc');
-   * // => true
-   *
-   * _.isArrayLike(_.noop);
-   * // => false
-   */
-
-  function isArrayLike(value) {
-    return value != null && isLength(value.length) && !isFunction(value);
-  }
-
-  /** Used as references for various `Number` constants. */
-  var MAX_SAFE_INTEGER$1 = 9007199254740991;
-  /** Used to detect unsigned integer values. */
-
-  var reIsUint = /^(?:0|[1-9]\d*)$/;
-  /**
-   * Checks if `value` is a valid array-like index.
-   *
-   * @private
-   * @param {*} value The value to check.
-   * @param {number} [length=MAX_SAFE_INTEGER] The upper bounds of a valid index.
-   * @returns {boolean} Returns `true` if `value` is a valid index, else `false`.
-   */
-
-  function isIndex(value, length) {
-    var type = _typeof(value);
-
-    length = length == null ? MAX_SAFE_INTEGER$1 : length;
-    return !!length && (type == 'number' || type != 'symbol' && reIsUint.test(value)) && value > -1 && value % 1 == 0 && value < length;
-  }
-
-  /**
-   * Checks if the given arguments are from an iteratee call.
-   *
-   * @private
-   * @param {*} value The potential iteratee value argument.
-   * @param {*} index The potential iteratee index or key argument.
-   * @param {*} object The potential iteratee object argument.
-   * @returns {boolean} Returns `true` if the arguments are from an iteratee call,
-   *  else `false`.
-   */
-
-  function isIterateeCall(value, index, object) {
-    if (!isObject(object)) {
-      return false;
-    }
-
-    var type = _typeof(index);
-
-    if (type == 'number' ? isArrayLike(object) && isIndex(index, object.length) : type == 'string' && index in object) {
-      return eq(object[index], value);
-    }
-
-    return false;
-  }
-
-  /**
-   * Creates a function like `_.assign`.
-   *
-   * @private
-   * @param {Function} assigner The function to assign values.
-   * @returns {Function} Returns the new assigner function.
-   */
-
-  function createAssigner(assigner) {
-    return baseRest(function (object, sources) {
-      var index = -1,
-          length = sources.length,
-          customizer = length > 1 ? sources[length - 1] : undefined,
-          guard = length > 2 ? sources[2] : undefined;
-      customizer = assigner.length > 3 && typeof customizer == 'function' ? (length--, customizer) : undefined;
-
-      if (guard && isIterateeCall(sources[0], sources[1], guard)) {
-        customizer = length < 3 ? undefined : customizer;
-        length = 1;
-      }
-
-      object = Object(object);
-
-      while (++index < length) {
-        var source = sources[index];
-
-        if (source) {
-          assigner(object, source, index, customizer);
-        }
-      }
-
-      return object;
-    });
-  }
-
-  /** Used for built-in method references. */
-  var objectProto$4 = Object.prototype;
-  /**
-   * Checks if `value` is likely a prototype object.
-   *
-   * @private
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is a prototype, else `false`.
-   */
-
-  function isPrototype(value) {
-    var Ctor = value && value.constructor,
-        proto = typeof Ctor == 'function' && Ctor.prototype || objectProto$4;
-    return value === proto;
-  }
-
-  /**
-   * The base implementation of `_.times` without support for iteratee shorthands
-   * or max array length checks.
-   *
-   * @private
-   * @param {number} n The number of times to invoke `iteratee`.
-   * @param {Function} iteratee The function invoked per iteration.
-   * @returns {Array} Returns the array of results.
-   */
-  function baseTimes(n, iteratee) {
-    var index = -1,
-        result = Array(n);
-
-    while (++index < n) {
-      result[index] = iteratee(index);
-    }
-
-    return result;
-  }
-
-  /**
-   * Checks if `value` is object-like. A value is object-like if it's not `null`
-   * and has a `typeof` result of "object".
-   *
-   * @static
-   * @memberOf _
-   * @since 4.0.0
-   * @category Lang
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is object-like, else `false`.
-   * @example
-   *
-   * _.isObjectLike({});
-   * // => true
-   *
-   * _.isObjectLike([1, 2, 3]);
-   * // => true
-   *
-   * _.isObjectLike(_.noop);
-   * // => false
-   *
-   * _.isObjectLike(null);
-   * // => false
-   */
-  function isObjectLike(value) {
-    return value != null && _typeof(value) == 'object';
-  }
-
-  /** `Object#toString` result references. */
-
-  var argsTag = '[object Arguments]';
-  /**
-   * The base implementation of `_.isArguments`.
-   *
-   * @private
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is an `arguments` object,
-   */
-
-  function baseIsArguments(value) {
-    return isObjectLike(value) && baseGetTag(value) == argsTag;
-  }
-
-  /** Used for built-in method references. */
-
-  var objectProto$5 = Object.prototype;
-  /** Used to check objects for own properties. */
-
-  var hasOwnProperty$3 = objectProto$5.hasOwnProperty;
-  /** Built-in value references. */
-
-  var propertyIsEnumerable = objectProto$5.propertyIsEnumerable;
-  /**
-   * Checks if `value` is likely an `arguments` object.
-   *
-   * @static
-   * @memberOf _
-   * @since 0.1.0
-   * @category Lang
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is an `arguments` object,
-   *  else `false`.
-   * @example
-   *
-   * _.isArguments(function() { return arguments; }());
-   * // => true
-   *
-   * _.isArguments([1, 2, 3]);
-   * // => false
-   */
-
-  var isArguments = baseIsArguments(function () {
-    return arguments;
-  }()) ? baseIsArguments : function (value) {
-    return isObjectLike(value) && hasOwnProperty$3.call(value, 'callee') && !propertyIsEnumerable.call(value, 'callee');
-  };
-
-  /**
-   * Checks if `value` is classified as an `Array` object.
-   *
-   * @static
-   * @memberOf _
-   * @since 0.1.0
-   * @category Lang
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is an array, else `false`.
-   * @example
-   *
-   * _.isArray([1, 2, 3]);
-   * // => true
-   *
-   * _.isArray(document.body.children);
-   * // => false
-   *
-   * _.isArray('abc');
-   * // => false
-   *
-   * _.isArray(_.noop);
-   * // => false
-   */
-  var isArray = Array.isArray;
-
-  /**
-   * This method returns `false`.
-   *
-   * @static
-   * @memberOf _
-   * @since 4.13.0
-   * @category Util
-   * @returns {boolean} Returns `false`.
-   * @example
-   *
-   * _.times(2, _.stubFalse);
-   * // => [false, false]
-   */
-  function stubFalse() {
-    return false;
-  }
-
-  /** Detect free variable `exports`. */
-
-  var freeExports = (typeof exports === "undefined" ? "undefined" : _typeof(exports)) == 'object' && exports && !exports.nodeType && exports;
-  /** Detect free variable `module`. */
-
-  var freeModule = freeExports && (typeof module === "undefined" ? "undefined" : _typeof(module)) == 'object' && module && !module.nodeType && module;
-  /** Detect the popular CommonJS extension `module.exports`. */
-
-  var moduleExports = freeModule && freeModule.exports === freeExports;
-  /** Built-in value references. */
-
-  var Buffer = moduleExports ? root.Buffer : undefined;
-  /* Built-in method references for those with the same name as other `lodash` methods. */
-
-  var nativeIsBuffer = Buffer ? Buffer.isBuffer : undefined;
-  /**
-   * Checks if `value` is a buffer.
-   *
-   * @static
-   * @memberOf _
-   * @since 4.3.0
-   * @category Lang
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is a buffer, else `false`.
-   * @example
-   *
-   * _.isBuffer(new Buffer(2));
-   * // => true
-   *
-   * _.isBuffer(new Uint8Array(2));
-   * // => false
-   */
-
-  var isBuffer = nativeIsBuffer || stubFalse;
-
-  /** `Object#toString` result references. */
-
-  var argsTag$1 = '[object Arguments]',
-      arrayTag = '[object Array]',
-      boolTag = '[object Boolean]',
-      dateTag = '[object Date]',
-      errorTag = '[object Error]',
-      funcTag$1 = '[object Function]',
-      mapTag = '[object Map]',
-      numberTag = '[object Number]',
-      objectTag = '[object Object]',
-      regexpTag = '[object RegExp]',
-      setTag = '[object Set]',
-      stringTag = '[object String]',
-      weakMapTag = '[object WeakMap]';
-  var arrayBufferTag = '[object ArrayBuffer]',
-      dataViewTag = '[object DataView]',
-      float32Tag = '[object Float32Array]',
-      float64Tag = '[object Float64Array]',
-      int8Tag = '[object Int8Array]',
-      int16Tag = '[object Int16Array]',
-      int32Tag = '[object Int32Array]',
-      uint8Tag = '[object Uint8Array]',
-      uint8ClampedTag = '[object Uint8ClampedArray]',
-      uint16Tag = '[object Uint16Array]',
-      uint32Tag = '[object Uint32Array]';
-  /** Used to identify `toStringTag` values of typed arrays. */
-
-  var typedArrayTags = {};
-  typedArrayTags[float32Tag] = typedArrayTags[float64Tag] = typedArrayTags[int8Tag] = typedArrayTags[int16Tag] = typedArrayTags[int32Tag] = typedArrayTags[uint8Tag] = typedArrayTags[uint8ClampedTag] = typedArrayTags[uint16Tag] = typedArrayTags[uint32Tag] = true;
-  typedArrayTags[argsTag$1] = typedArrayTags[arrayTag] = typedArrayTags[arrayBufferTag] = typedArrayTags[boolTag] = typedArrayTags[dataViewTag] = typedArrayTags[dateTag] = typedArrayTags[errorTag] = typedArrayTags[funcTag$1] = typedArrayTags[mapTag] = typedArrayTags[numberTag] = typedArrayTags[objectTag] = typedArrayTags[regexpTag] = typedArrayTags[setTag] = typedArrayTags[stringTag] = typedArrayTags[weakMapTag] = false;
-  /**
-   * The base implementation of `_.isTypedArray` without Node.js optimizations.
-   *
-   * @private
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is a typed array, else `false`.
-   */
-
-  function baseIsTypedArray(value) {
-    return isObjectLike(value) && isLength(value.length) && !!typedArrayTags[baseGetTag(value)];
-  }
-
-  /**
-   * The base implementation of `_.unary` without support for storing metadata.
-   *
-   * @private
-   * @param {Function} func The function to cap arguments for.
-   * @returns {Function} Returns the new capped function.
-   */
-  function baseUnary(func) {
-    return function (value) {
-      return func(value);
-    };
-  }
-
-  /** Detect free variable `exports`. */
-
-  var freeExports$1 = (typeof exports === "undefined" ? "undefined" : _typeof(exports)) == 'object' && exports && !exports.nodeType && exports;
-  /** Detect free variable `module`. */
-
-  var freeModule$1 = freeExports$1 && (typeof module === "undefined" ? "undefined" : _typeof(module)) == 'object' && module && !module.nodeType && module;
-  /** Detect the popular CommonJS extension `module.exports`. */
-
-  var moduleExports$1 = freeModule$1 && freeModule$1.exports === freeExports$1;
-  /** Detect free variable `process` from Node.js. */
-
-  var freeProcess = moduleExports$1 && freeGlobal.process;
-  /** Used to access faster Node.js helpers. */
-
-  var nodeUtil = function () {
-    try {
-      // Use `util.types` for Node.js 10+.
-      var types = freeModule$1 && freeModule$1.require && freeModule$1.require('util').types;
-
-      if (types) {
-        return types;
-      } // Legacy `process.binding('util')` for Node.js < 10.
-
-
-      return freeProcess && freeProcess.binding && freeProcess.binding('util');
-    } catch (e) {}
-  }();
-
-  /* Node.js helper references. */
-
-  var nodeIsTypedArray = nodeUtil && nodeUtil.isTypedArray;
-  /**
-   * Checks if `value` is classified as a typed array.
-   *
-   * @static
-   * @memberOf _
-   * @since 3.0.0
-   * @category Lang
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is a typed array, else `false`.
-   * @example
-   *
-   * _.isTypedArray(new Uint8Array);
-   * // => true
-   *
-   * _.isTypedArray([]);
-   * // => false
-   */
-
-  var isTypedArray = nodeIsTypedArray ? baseUnary(nodeIsTypedArray) : baseIsTypedArray;
-
-  /** Used for built-in method references. */
-
-  var objectProto$6 = Object.prototype;
-  /** Used to check objects for own properties. */
-
-  var hasOwnProperty$4 = objectProto$6.hasOwnProperty;
-  /**
-   * Creates an array of the enumerable property names of the array-like `value`.
-   *
-   * @private
-   * @param {*} value The value to query.
-   * @param {boolean} inherited Specify returning inherited property names.
-   * @returns {Array} Returns the array of property names.
-   */
-
-  function arrayLikeKeys(value, inherited) {
-    var isArr = isArray(value),
-        isArg = !isArr && isArguments(value),
-        isBuff = !isArr && !isArg && isBuffer(value),
-        isType = !isArr && !isArg && !isBuff && isTypedArray(value),
-        skipIndexes = isArr || isArg || isBuff || isType,
-        result = skipIndexes ? baseTimes(value.length, String) : [],
-        length = result.length;
-
-    for (var key in value) {
-      if ((inherited || hasOwnProperty$4.call(value, key)) && !(skipIndexes && ( // Safari 9 has enumerable `arguments.length` in strict mode.
-      key == 'length' || // Node.js 0.10 has enumerable non-index properties on buffers.
-      isBuff && (key == 'offset' || key == 'parent') || // PhantomJS 2 has enumerable non-index properties on typed arrays.
-      isType && (key == 'buffer' || key == 'byteLength' || key == 'byteOffset') || // Skip index properties.
-      isIndex(key, length)))) {
-        result.push(key);
-      }
-    }
-
-    return result;
-  }
-
-  /**
-   * Creates a unary function that invokes `func` with its argument transformed.
-   *
-   * @private
-   * @param {Function} func The function to wrap.
-   * @param {Function} transform The argument transform.
-   * @returns {Function} Returns the new function.
-   */
-  function overArg(func, transform) {
-    return function (arg) {
-      return func(transform(arg));
-    };
-  }
-
-  /* Built-in method references for those with the same name as other `lodash` methods. */
-
-  var nativeKeys = overArg(Object.keys, Object);
-
-  /** Used for built-in method references. */
-
-  var objectProto$7 = Object.prototype;
-  /** Used to check objects for own properties. */
-
-  var hasOwnProperty$5 = objectProto$7.hasOwnProperty;
-  /**
-   * The base implementation of `_.keys` which doesn't treat sparse arrays as dense.
-   *
-   * @private
-   * @param {Object} object The object to query.
-   * @returns {Array} Returns the array of property names.
-   */
-
-  function baseKeys(object) {
-    if (!isPrototype(object)) {
-      return nativeKeys(object);
-    }
-
-    var result = [];
-
-    for (var key in Object(object)) {
-      if (hasOwnProperty$5.call(object, key) && key != 'constructor') {
-        result.push(key);
-      }
-    }
-
-    return result;
-  }
-
-  /**
-   * Creates an array of the own enumerable property names of `object`.
-   *
-   * **Note:** Non-object values are coerced to objects. See the
-   * [ES spec](http://ecma-international.org/ecma-262/7.0/#sec-object.keys)
-   * for more details.
-   *
-   * @static
-   * @since 0.1.0
-   * @memberOf _
-   * @category Object
-   * @param {Object} object The object to query.
-   * @returns {Array} Returns the array of property names.
-   * @example
-   *
-   * function Foo() {
-   *   this.a = 1;
-   *   this.b = 2;
-   * }
-   *
-   * Foo.prototype.c = 3;
-   *
-   * _.keys(new Foo);
-   * // => ['a', 'b'] (iteration order is not guaranteed)
-   *
-   * _.keys('hi');
-   * // => ['0', '1']
-   */
-
-  function keys(object) {
-    return isArrayLike(object) ? arrayLikeKeys(object) : baseKeys(object);
-  }
-
-  /** Used for built-in method references. */
-
-  var objectProto$8 = Object.prototype;
-  /** Used to check objects for own properties. */
-
-  var hasOwnProperty$6 = objectProto$8.hasOwnProperty;
-  /**
-   * Assigns own enumerable string keyed properties of source objects to the
-   * destination object. Source objects are applied from left to right.
-   * Subsequent sources overwrite property assignments of previous sources.
-   *
-   * **Note:** This method mutates `object` and is loosely based on
-   * [`Object.assign`](https://mdn.io/Object/assign).
-   *
-   * @static
-   * @memberOf _
-   * @since 0.10.0
-   * @category Object
-   * @param {Object} object The destination object.
-   * @param {...Object} [sources] The source objects.
-   * @returns {Object} Returns `object`.
-   * @see _.assignIn
-   * @example
-   *
-   * function Foo() {
-   *   this.a = 1;
-   * }
-   *
-   * function Bar() {
-   *   this.c = 3;
-   * }
-   *
-   * Foo.prototype.b = 2;
-   * Bar.prototype.d = 4;
-   *
-   * _.assign({ 'a': 0 }, new Foo, new Bar);
-   * // => { 'a': 1, 'c': 3 }
-   */
-
-  var assign = createAssigner(function (object, source) {
-    if (isPrototype(source) || isArrayLike(source)) {
-      copyObject(source, keys(source), object);
-      return;
-    }
-
-    for (var key in source) {
-      if (hasOwnProperty$6.call(source, key)) {
-        assignValue(object, key, source[key]);
-      }
-    }
-  });
-
-  /* Built-in method references for those with the same name as other `lodash` methods. */
-  var nativeCeil = Math.ceil,
-      nativeMax$1 = Math.max;
-  /**
-   * The base implementation of `_.range` and `_.rangeRight` which doesn't
-   * coerce arguments.
-   *
-   * @private
-   * @param {number} start The start of the range.
-   * @param {number} end The end of the range.
-   * @param {number} step The value to increment or decrement by.
-   * @param {boolean} [fromRight] Specify iterating from right to left.
-   * @returns {Array} Returns the range of numbers.
-   */
-
-  function baseRange(start, end, step, fromRight) {
-    var index = -1,
-        length = nativeMax$1(nativeCeil((end - start) / (step || 1)), 0),
-        result = Array(length);
-
-    while (length--) {
-      result[fromRight ? length : ++index] = start;
-      start += step;
-    }
-
-    return result;
-  }
-
-  /** `Object#toString` result references. */
-
-  var symbolTag = '[object Symbol]';
-  /**
-   * Checks if `value` is classified as a `Symbol` primitive or object.
-   *
-   * @static
-   * @memberOf _
-   * @since 4.0.0
-   * @category Lang
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is a symbol, else `false`.
-   * @example
-   *
-   * _.isSymbol(Symbol.iterator);
-   * // => true
-   *
-   * _.isSymbol('abc');
-   * // => false
-   */
-
-  function isSymbol(value) {
-    return _typeof(value) == 'symbol' || isObjectLike(value) && baseGetTag(value) == symbolTag;
-  }
-
-  /** Used as references for various `Number` constants. */
-
-  var NAN = 0 / 0;
-  /** Used to match leading and trailing whitespace. */
-
-  var reTrim = /^\s+|\s+$/g;
-  /** Used to detect bad signed hexadecimal string values. */
-
-  var reIsBadHex = /^[-+]0x[0-9a-f]+$/i;
-  /** Used to detect binary string values. */
-
-  var reIsBinary = /^0b[01]+$/i;
-  /** Used to detect octal string values. */
-
-  var reIsOctal = /^0o[0-7]+$/i;
-  /** Built-in method references without a dependency on `root`. */
-
-  var freeParseInt = parseInt;
-  /**
-   * Converts `value` to a number.
-   *
-   * @static
-   * @memberOf _
-   * @since 4.0.0
-   * @category Lang
-   * @param {*} value The value to process.
-   * @returns {number} Returns the number.
-   * @example
-   *
-   * _.toNumber(3.2);
-   * // => 3.2
-   *
-   * _.toNumber(Number.MIN_VALUE);
-   * // => 5e-324
-   *
-   * _.toNumber(Infinity);
-   * // => Infinity
-   *
-   * _.toNumber('3.2');
-   * // => 3.2
-   */
-
-  function toNumber(value) {
-    if (typeof value == 'number') {
-      return value;
-    }
-
-    if (isSymbol(value)) {
-      return NAN;
-    }
-
-    if (isObject(value)) {
-      var other = typeof value.valueOf == 'function' ? value.valueOf() : value;
-      value = isObject(other) ? other + '' : other;
-    }
-
-    if (typeof value != 'string') {
-      return value === 0 ? value : +value;
-    }
-
-    value = value.replace(reTrim, '');
-    var isBinary = reIsBinary.test(value);
-    return isBinary || reIsOctal.test(value) ? freeParseInt(value.slice(2), isBinary ? 2 : 8) : reIsBadHex.test(value) ? NAN : +value;
-  }
-
-  /** Used as references for various `Number` constants. */
-
-  var INFINITY = 1 / 0,
-      MAX_INTEGER = 1.7976931348623157e+308;
-  /**
-   * Converts `value` to a finite number.
-   *
-   * @static
-   * @memberOf _
-   * @since 4.12.0
-   * @category Lang
-   * @param {*} value The value to convert.
-   * @returns {number} Returns the converted number.
-   * @example
-   *
-   * _.toFinite(3.2);
-   * // => 3.2
-   *
-   * _.toFinite(Number.MIN_VALUE);
-   * // => 5e-324
-   *
-   * _.toFinite(Infinity);
-   * // => 1.7976931348623157e+308
-   *
-   * _.toFinite('3.2');
-   * // => 3.2
-   */
-
-  function toFinite(value) {
-    if (!value) {
-      return value === 0 ? value : 0;
-    }
-
-    value = toNumber(value);
-
-    if (value === INFINITY || value === -INFINITY) {
-      var sign = value < 0 ? -1 : 1;
-      return sign * MAX_INTEGER;
-    }
-
-    return value === value ? value : 0;
-  }
-
-  /**
-   * Creates a `_.range` or `_.rangeRight` function.
-   *
-   * @private
-   * @param {boolean} [fromRight] Specify iterating from right to left.
-   * @returns {Function} Returns the new range function.
-   */
-
-  function createRange(fromRight) {
-    return function (start, end, step) {
-      if (step && typeof step != 'number' && isIterateeCall(start, end, step)) {
-        end = step = undefined;
-      } // Ensure the sign of `-0` is preserved.
-
-
-      start = toFinite(start);
-
-      if (end === undefined) {
-        end = start;
-        start = 0;
-      } else {
-        end = toFinite(end);
-      }
-
-      step = step === undefined ? start < end ? 1 : -1 : toFinite(step);
-      return baseRange(start, end, step, fromRight);
-    };
-  }
-
-  /**
-   * Creates an array of numbers (positive and/or negative) progressing from
-   * `start` up to, but not including, `end`. A step of `-1` is used if a negative
-   * `start` is specified without an `end` or `step`. If `end` is not specified,
-   * it's set to `start` with `start` then set to `0`.
-   *
-   * **Note:** JavaScript follows the IEEE-754 standard for resolving
-   * floating-point values which can produce unexpected results.
-   *
-   * @static
-   * @since 0.1.0
-   * @memberOf _
-   * @category Util
-   * @param {number} [start=0] The start of the range.
-   * @param {number} end The end of the range.
-   * @param {number} [step=1] The value to increment or decrement by.
-   * @returns {Array} Returns the range of numbers.
-   * @see _.inRange, _.rangeRight
-   * @example
-   *
-   * _.range(4);
-   * // => [0, 1, 2, 3]
-   *
-   * _.range(-4);
-   * // => [0, -1, -2, -3]
-   *
-   * _.range(1, 5);
-   * // => [1, 2, 3, 4]
-   *
-   * _.range(0, 20, 5);
-   * // => [0, 5, 10, 15]
-   *
-   * _.range(0, -4, -1);
-   * // => [0, -1, -2, -3]
-   *
-   * _.range(1, 4, 0);
-   * // => [1, 1, 1]
-   *
-   * _.range(0);
-   * // => []
-   */
-
-  var range = createRange();
-
-  var Control = /*#__PURE__*/function () {
-    function Control(def) {
-      _classCallCheck$1(this, Control);
-
-      _defineProperty$1(this, "def", void 0);
-
-      this.def = def;
-    }
-
-    _createClass$1(Control, [{
-      key: "setValue",
-      value: function setValue(value) {
-        engine_1.setValue(this.def.group, this.def.name, value);
-      }
-    }, {
-      key: "getValue",
-      value: function getValue() {
-        return engine_1.getValue(this.def.group, this.def.name);
-      }
-    }]);
-
-    return Control;
-  }();
-  var playListControlDef = {
-    LoadSelectedIntoFirstStopped: {
-      group: '[Playlist]',
-      name: 'LoadSelectedIntoFirstStopped',
-      type: 'binary',
-      description: 'Loads the currently highlighted song into the first stopped deck'
-    },
-    SelectNextPlaylist: {
-      group: '[Playlist]',
-      name: 'SelectNextPlaylist',
-      type: 'binary',
-      description: 'Switches to the next view (Library, Queue, etc.)'
-    },
-    SelectPrevPlaylist: {
-      group: '[Playlist]',
-      name: 'SelectPrevPlaylist',
-      type: 'binary',
-      description: 'Switches to the previous view (Library, Queue, etc.)'
-    },
-    ToggleSelectedSidebarItem: {
-      group: '[Playlist]',
-      name: 'ToggleSelectedSidebarItem',
-      type: 'binary',
-      description: 'Toggles (expands/collapses) the currently selected sidebar item.'
-    },
-    SelectNextTrack: {
-      group: '[Playlist]',
-      name: 'SelectNextTrack',
-      type: 'binary',
-      description: 'Scrolls to the next track in the track table.'
-    },
-    SelectPrevTrack: {
-      group: '[Playlist]',
-      name: 'SelectPrevTrack',
-      type: 'binary',
-      description: 'Scrolls to the previous track in the track table.'
-    },
-    SelectTrackKnob: {
-      group: '[Playlist]',
-      name: 'SelectTrackKnob',
-      type: 'relative value',
-      description: 'Scrolls the given number of tracks in the track table (can be negative for reverse direction).'
-    },
-    AutoDjAddBottom: {
-      group: '[Playlist]',
-      name: 'AutoDjAddBottom',
-      type: 'binary',
-      description: 'Add selected track(s) to Auto DJ Queue (bottom).'
-    },
-    AutoDjAddTop: {
-      group: '[Playlist]',
-      name: 'AutoDjAddTop',
-      type: 'binary',
-      description: 'Add selected track(s) to Auto DJ Queue (top).'
-    }
-  };
-  var playListControl = Object.keys(playListControlDef).reduce(function (obj, key) {
-    return assign(obj, _defineProperty$1({}, key, new Control(playListControlDef[key])));
-  }, {});
-
-  var channelDef = function channelDef(type, i) {
-    return {
-      back: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'back',
-        type: 'binary'
-      },
-      beat_active: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'beat_active',
-        type: 'binary'
-      },
-      beatjump: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'beatjump',
-        type: 'real number'
-      },
-      beatjumps: function beatjumps(x) {
-        return {
-          forward: {
-            group: "[".concat(type).concat(i, "]"),
-            name: "beatjump_".concat(x, "_forward"),
-            type: 'binary'
-          },
-          backward: {
-            group: "[".concat(type).concat(i, "]"),
-            name: "beatjump_".concat(x, "_backward"),
-            type: 'binary'
-          }
-        };
-      },
-      beatloop: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'beatloop',
-        type: 'positive real number'
-      },
-      beatloops: function beatloops(x) {
-        return {
-          activate: {
-            group: "[".concat(type).concat(i, "]"),
-            name: "beatloop_".concat(x, "_activate"),
-            type: 'binary'
-          },
-          toggle: {
-            group: "[".concat(type).concat(i, "]"),
-            name: "beatloop_".concat(x, "_toggle"),
-            type: 'binary'
-          },
-          enabled: {
-            group: "[".concat(type).concat(i, "]"),
-            name: "beatloop_".concat(x, "_enabled"),
-            type: 'binary'
-          }
-        };
-      },
-      beats_adjust_faster: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'beats_adjust_faster',
-        type: 'binary'
-      },
-      beats_adjust_slower: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'beats_adjust_slower',
-        type: 'binary'
-      },
-      beats_translate_curpos: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'beats_translate_curpos',
-        type: 'binary'
-      },
-      beats_translate_match_alignment: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'beats_translate_match_alignment',
-        type: 'binary'
-      },
-      beats_translate_earlier: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'beats_translate_earlier',
-        type: 'binary'
-      },
-      beats_translate_later: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'beats_translate_later',
-        type: 'binary'
-      },
-      beatsync: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'beatsync',
-        type: 'binary'
-      },
-      beatsync_phase: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'beatsync_phase',
-        type: 'binary'
-      },
-      beatsync_tempo: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'beatsync_tempo',
-        type: 'binary'
-      },
-      bpm: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'bpm',
-        type: 'real-valued'
-      },
-      bpm_tap: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'bpm_tap',
-        type: 'binary'
-      },
-      cue_default: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'cue_default',
-        type: 'binary'
-      },
-      cue_gotoandplay: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'cue_gotoandplay',
-        type: 'binary'
-      },
-      cue_gotoandstop: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'cue_gotoandstop',
-        type: 'binary'
-      },
-      cue_indicator: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'cue_indicator',
-        type: 'binary'
-      },
-      cue_cdj: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'cue_cdj',
-        type: 'binary'
-      },
-      cue_play: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'cue_play',
-        type: 'binary'
-      },
-      cue_point: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'cue_point',
-        type: 'absolute value'
-      },
-      cue_preview: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'cue_preview',
-        type: 'binary'
-      },
-      cue_set: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'cue_set',
-        type: 'binary'
-      },
-      cue_simple: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'cue_simple',
-        type: 'binary'
-      },
-      duration: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'duration',
-        type: 'absolute value'
-      },
-      eject: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'eject',
-        type: 'binary'
-      },
-      end: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'end',
-        type: 'binary'
-      },
-      file_bpm: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'file_bpm',
-        type: 'positive value'
-      },
-      file_key: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'file_key',
-        type: '?'
-      },
-      fwd: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'fwd',
-        type: 'binary'
-      },
-      hotcues: function hotcues(x) {
-        return {
-          activate: {
-            group: "[".concat(type).concat(i, "]"),
-            name: "hotcue_".concat(x, "_activate"),
-            type: 'binary'
-          },
-          clear: {
-            group: "[".concat(type).concat(i, "]"),
-            name: "hotcue_".concat(x, "_clear"),
-            type: 'binary'
-          },
-          enabled: {
-            group: "[".concat(type).concat(i, "]"),
-            name: "hotcue_".concat(x, "_enabled"),
-            type: 'read-only, binary'
-          },
-          "goto": {
-            group: "[".concat(type).concat(i, "]"),
-            name: "hotcue_".concat(x, "_goto"),
-            type: 'binary'
-          },
-          gotoandplay: {
-            group: "[".concat(type).concat(i, "]"),
-            name: "hotcue_".concat(x, "_gotoandplay"),
-            type: 'binary'
-          },
-          gotoandstop: {
-            group: "[".concat(type).concat(i, "]"),
-            name: "hotcue_".concat(x, "_gotoandstop"),
-            type: 'binary'
-          },
-          position: {
-            group: "[".concat(type).concat(i, "]"),
-            name: "hotcue_".concat(x, "_position"),
-            type: 'positive integer'
-          },
-          set: {
-            group: "[".concat(type).concat(i, "]"),
-            name: "hotcue_".concat(x, "_set"),
-            type: 'binary'
-          }
-        };
-      },
-      key: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'key',
-        type: 'real-valued'
-      },
-      keylock: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'keylock',
-        type: 'binary'
-      },
-      LoadSelectedTrack: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'LoadSelectedTrack',
-        type: 'binary'
-      },
-      LoadSelectedTrackAndPlay: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'LoadSelectedTrackAndPlay',
-        type: 'binary'
-      },
-      loop_double: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'loop_double',
-        type: 'binary'
-      },
-      loop_enabled: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'loop_enabled',
-        type: 'read-only, binary'
-      },
-      loop_end_position: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'loop_end_position',
-        type: 'positive integer'
-      },
-      loop_halve: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'loop_halve',
-        type: 'binary'
-      },
-      loop_in: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'loop_in',
-        type: 'binary'
-      },
-      loop_out: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'loop_out',
-        type: 'binary'
-      },
-      loop_move: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'loop_move',
-        type: 'real number'
-      },
-      loop_scale: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'loop_scale',
-        type: '0.0 - infinity'
-      },
-      loop_start_position: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'loop_start_position',
-        type: 'positive integer'
-      },
-      orientation: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'orientation',
-        type: '0-2'
-      },
-      passthrough: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'passthrough',
-        type: 'binary'
-      },
-      PeakIndicator: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'PeakIndicator',
-        type: 'binary'
-      },
-      pfl: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'pfl',
-        type: 'binary'
-      },
-      pitch: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'pitch',
-        type: '-6.0..6.0'
-      },
-      pitch_adjust: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'pitch_adjust',
-        type: '-3.0..3.0'
-      },
-      play: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'play',
-        type: 'binary'
-      },
-      play_indicator: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'play_indicator',
-        type: 'binary'
-      },
-      play_stutter: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'play_stutter',
-        type: 'binary'
-      },
-      playposition: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'playposition',
-        type: 'default'
-      },
-      pregain: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'pregain',
-        type: '0.0..1.0..4.0'
-      },
-      quantize: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'quantize',
-        type: 'binary'
-      },
-      rate: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'rate',
-        type: '-1.0..1.0'
-      },
-      rate_dir: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'rate_dir',
-        type: '-1 or 1'
-      },
-      rate_perm_down: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'rate_perm_down',
-        type: 'binary'
-      },
-      rate_perm_down_small: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'rate_perm_down_small',
-        type: 'binary'
-      },
-      rate_perm_up: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'rate_perm_up',
-        type: 'binary'
-      },
-      rate_perm_up_small: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'rate_perm_up_small',
-        type: 'binary'
-      },
-      rate_temp_down: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'rate_temp_down',
-        type: 'binary'
-      },
-      rate_temp_down_small: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'rate_temp_down_small',
-        type: 'binary'
-      },
-      rate_temp_up: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'rate_temp_up',
-        type: 'binary'
-      },
-      rate_temp_up_small: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'rate_temp_up_small',
-        type: 'binary'
-      },
-      rateRange: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'rateRange',
-        type: '0.0..3.0'
-      },
-      reloop_andstop: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'reloop_andstop',
-        type: 'binary'
-      },
-      reloop_exit: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'reloop_exit',
-        type: 'binary'
-      },
-      repeat: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'repeat',
-        type: 'binary'
-      },
-      reset_key: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'reset_key',
-        type: 'binary'
-      },
-      reverse: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'reverse',
-        type: 'binary'
-      },
-      reverseroll: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'reverseroll',
-        type: 'binary'
-      },
-      slip_enabled: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'slip_enabled',
-        type: 'binary'
-      },
-      start: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'start',
-        type: 'binary'
-      },
-      start_play: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'start_play',
-        type: 'binary'
-      },
-      start_stop: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'start_stop',
-        type: 'binary'
-      },
-      stop: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'stop',
-        type: 'binary'
-      },
-      sync_enabled: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'sync_enabled',
-        type: 'binary'
-      },
-      sync_leader: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'sync_leader',
-        type: 'binary'
-      },
-      sync_mode: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'sync_mode',
-        type: 'binary'
-      },
-      sync_key: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'sync_key',
-        type: '?'
-      },
-      track_samplerate: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'track_samplerate',
-        type: 'absolute value'
-      },
-      track_samples: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'track_samples',
-        type: 'absolute value'
-      },
-      volume: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'volume',
-        type: 'default'
-      },
-      mute: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'mute',
-        type: 'binary'
-      },
-      vinylcontrol_enabled: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'vinylcontrol_enabled',
-        type: 'binary'
-      },
-      vinylcontrol_cueing: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'vinylcontrol_cueing',
-        type: '0.0-2.0'
-      },
-      vinylcontrol_mode: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'vinylcontrol_mode',
-        type: '0.0-2.0'
-      },
-      vinylcontrol_status: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'vinylcontrol_status',
-        type: '0.0-3.0 (read-only)'
-      },
-      visual_bpm: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'visual_bpm',
-        type: '?'
-      },
-      visual_key: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'visual_key',
-        type: '?'
-      },
-      visual_key_distance: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'visual_key_distance',
-        type: '-0.5..0.5'
-      },
-      VuMeter: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'VuMeter',
-        type: 'default'
-      },
-      VuMeterL: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'VuMeterL',
-        type: 'default'
-      },
-      VuMeterR: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'VuMeterR',
-        type: 'default'
-      },
-      waveform_zoom: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'waveform_zoom',
-        type: '1.0 - 6.0'
-      },
-      waveform_zoom_up: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'waveform_zoom_up',
-        type: '?'
-      },
-      waveform_zoom_down: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'waveform_zoom_down',
-        type: '?'
-      },
-      waveform_zoom_set_default: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'waveform_zoom_set_default',
-        type: '?'
-      },
-      wheel: {
-        group: "[".concat(type).concat(i, "]"),
-        name: 'wheel',
-        type: '-3.0..3.0'
-      }
-    };
-  };
-
-  var beatjumps = [0.03125, 0.0625, 0.125, 0.25, 0.5, 1, 2, 4, 8, 16, 32, 64];
-  var beatloops = beatjumps;
-
-  var createEnumeratedControl = function createEnumeratedControl(array, one) {
-    return array.reduce(function (arr, i) {
-      var def = one(i);
-      var control = Object.keys(def).reduce(function (obj, key) {
-        return assign(obj, _defineProperty$1({}, key, new Control(def[key])));
-      }, {});
-      return assign(arr, _defineProperty$1({}, i, control));
-    }, {});
-  };
-
-  var createChannelControl = function createChannelControl(i) {
-    var _ref = i < 5 ? ['Channel', i] : ['Sampler', i - 4],
-        _ref2 = _slicedToArray(_ref, 2),
-        name = _ref2[0],
-        number = _ref2[1];
-
-    var channelDefInstance = channelDef(name, number);
-    var channel = Object.keys(channelDefInstance).filter(function (key) {
-      return key !== 'beatjumps' && key !== 'beatloops' && key !== 'hotcues';
-    }).reduce(function (obj, key) {
-      return assign(obj, _defineProperty$1({}, key, new Control(channelDefInstance[key])));
-    }, {});
-    return assign(channel, {
-      beatjumps: createEnumeratedControl(beatjumps, channelDefInstance.beatjumps),
-      beatloops: createEnumeratedControl(beatloops, channelDefInstance.beatloops),
-      hotcues: createEnumeratedControl(range(16).map(function (x) {
-        return x + 1;
-      }), channelDefInstance.hotcues)
-    });
-  };
-  var channelControls = range(8).map(function (i) {
-    return createChannelControl(i + 1);
-  });
-
-  var callbackPrefix = '__ctrl';
-
-  var sanitize = function sanitize(name) {
-    return name.replace('.', '$dot$').replace('[', '$sbs$').replace(']', '$sbe$');
-  };
-
-  var ControlBus = /*#__PURE__*/function () {
-    _createClass$1(ControlBus, null, [{
-      key: "create",
-      value: function create(moduleName, registry) {
-        return new ControlBus(moduleName, registry);
-      }
-    }]);
-
-    function ControlBus(registryName, registry) {
-      _classCallCheck$1(this, ControlBus);
-
-      _defineProperty$1(this, "_registryName", void 0);
-
-      _defineProperty$1(this, "_registry", void 0);
-
-      _defineProperty$1(this, "_callbackList", void 0);
-
-      this._registryName = registryName;
-      this._registry = registry;
-      this._callbackList = {};
-    }
-
-    _createClass$1(ControlBus, [{
-      key: "connect",
-      value: function connect(id, control, cb) {
-        var _this = this;
-
-        var group = control.group,
-            name = control.name;
-        var key = "".concat(sanitize(group), "_").concat(sanitize(name));
-        var engineCb = "".concat(callbackPrefix, "_").concat(key);
-
-        if (!this._callbackList[key]) {
-          this._callbackList[key] = {};
-        }
-
-        this._callbackList[key][id] = cb;
-
-        if (!this._registry[engineCb]) {
-          this._registry[engineCb] = function (value) {
-            for (var _id in _this._callbackList[key]) {
-              _this._callbackList[key][_id]({
-                value: value,
-                control: control,
-                id: _id
-              });
-            }
-          };
-
-          engine_1.connectControl(group, name, "".concat(this._registryName, ".").concat(engineCb));
-        }
-
-        return {
-          id: id,
-          group: group,
-          name: name,
-          key: key
-        };
-      }
-    }, {
-      key: "disconnect",
-      value: function disconnect(handle) {
-        var id = handle.id,
-            group = handle.group,
-            name = handle.name,
-            key = handle.key;
-        var engineCb = "".concat(callbackPrefix, "_").concat(key);
-
-        if (this._callbackList[key] && this._callbackList[key][id]) {
-          delete this._callbackList[key][id];
-        }
-
-        if (!Object.keys(this._callbackList[key]).length && this._registry[engineCb]) {
-          engine_1.connectControl(group, name, "".concat(this._registryName, ".").concat(engineCb), true);
-          delete this._callbackList[key];
-          delete this._registry[engineCb];
-        }
-      }
-    }]);
-
-    return ControlBus;
-  }();
-
-  var timerPrefix = '__timer';
-  var Timer = /*#__PURE__*/function () {
-    function Timer(registryName, registry, task) {
-      _classCallCheck$1(this, Timer);
-
-      _defineProperty$1(this, "task", void 0);
-
-      _defineProperty$1(this, "_state", void 0);
-
-      _defineProperty$1(this, "_registryName", void 0);
-
-      _defineProperty$1(this, "_registry", void 0);
-
-      this._registryName = registryName;
-      this._registry = registry;
-      this.task = task;
-      this._state = undefined;
-    }
-
-    _createClass$1(Timer, [{
-      key: "start",
-      value: function start(interval) {
-        if (this._state == null) {
-          var started = Date.now();
-          var key = "".concat(timerPrefix, "_").concat(started, "_").concat(parseInt(Math.random() * 100));
-          var handle = engine_1.beginTimer(interval, "".concat(this._registryName, ".").concat(key));
-          this._state = {
-            handle: handle,
-            key: key,
-            started: started
-          };
-          this._registry[key] = this.task;
-          return started;
-        }
-      }
-    }, {
-      key: "end",
-      value: function end() {
-        var state = this._state;
-
-        if (state != null) {
-          engine_1.stopTimer(state.handle);
-          delete this._registry[state.key];
-          this._state = undefined;
-        }
-      }
-    }, {
-      key: "restart",
-      value: function restart(interval) {
-        if (this._state != null) {
-          this.end();
-          return this.start(interval);
-        }
-      }
-    }, {
-      key: "getStartTime",
-      value: function getStartTime() {
-        return this._state && this._state.started;
-      }
-    }]);
-
-    return Timer;
-  }();
-  var makeTimer = function makeTimer(moduleName, registry) {
-    return function (task) {
-      return new Timer(moduleName, registry, task);
-    };
-  };
-
-  function createCommonjsModule(fn, module) {
-  	return module = { exports: {} }, fn(module, module.exports), module.exports;
-  }
-
-  var stringify_1 = createCommonjsModule(function (module, exports) {
-  exports = module.exports = stringify;
-  exports.getSerialize = serializer;
-
-  function stringify(obj, replacer, spaces, cycleReplacer) {
-    return JSON.stringify(obj, serializer(replacer, cycleReplacer), spaces);
-  }
-
-  function serializer(replacer, cycleReplacer) {
-    var stack = [],
-        keys = [];
-    if (cycleReplacer == null) cycleReplacer = function cycleReplacer(key, value) {
-      if (stack[0] === value) return "[Circular ~]";
-      return "[Circular ~." + keys.slice(0, stack.indexOf(value)).join(".") + "]";
-    };
-    return function (key, value) {
-      if (stack.length > 0) {
-        var thisPos = stack.indexOf(this);
-        ~thisPos ? stack.splice(thisPos + 1) : stack.push(this);
-        ~thisPos ? keys.splice(thisPos, Infinity, key) : keys.push(key);
-        if (~stack.indexOf(value)) value = cycleReplacer.call(this, key, value);
-      } else stack.push(value);
-
-      return replacer == null ? value : replacer.call(this, key, value);
-    };
-  }
-  });
-  var stringify_2 = stringify_1.getSerialize;
-
-  var eventemitter3 = createCommonjsModule(function (module) {
-
-  var has = Object.prototype.hasOwnProperty,
-      prefix = '~';
-  /**
-   * Constructor to create a storage for our `EE` objects.
-   * An `Events` instance is a plain object whose properties are event names.
-   *
-   * @constructor
-   * @private
-   */
-
-  function Events() {} //
-  // We try to not inherit from `Object.prototype`. In some engines creating an
-  // instance in this way is faster than calling `Object.create(null)` directly.
-  // If `Object.create(null)` is not supported we prefix the event names with a
-  // character to make sure that the built-in object properties are not
-  // overridden or used as an attack vector.
-  //
-
-
-  if (Object.create) {
-    Events.prototype = Object.create(null); //
-    // This hack is needed because the `__proto__` property is still inherited in
-    // some old browsers like Android 4, iPhone 5.1, Opera 11 and Safari 5.
-    //
-
-    if (!new Events().__proto__) prefix = false;
-  }
-  /**
-   * Representation of a single event listener.
-   *
-   * @param {Function} fn The listener function.
-   * @param {*} context The context to invoke the listener with.
-   * @param {Boolean} [once=false] Specify if the listener is a one-time listener.
-   * @constructor
-   * @private
-   */
-
-
-  function EE(fn, context, once) {
-    this.fn = fn;
-    this.context = context;
-    this.once = once || false;
-  }
-  /**
-   * Add a listener for a given event.
-   *
-   * @param {EventEmitter} emitter Reference to the `EventEmitter` instance.
-   * @param {(String|Symbol)} event The event name.
-   * @param {Function} fn The listener function.
-   * @param {*} context The context to invoke the listener with.
-   * @param {Boolean} once Specify if the listener is a one-time listener.
-   * @returns {EventEmitter}
-   * @private
-   */
-
-
-  function addListener(emitter, event, fn, context, once) {
-    if (typeof fn !== 'function') {
-      throw new TypeError('The listener must be a function');
-    }
-
-    var listener = new EE(fn, context || emitter, once),
-        evt = prefix ? prefix + event : event;
-    if (!emitter._events[evt]) emitter._events[evt] = listener, emitter._eventsCount++;else if (!emitter._events[evt].fn) emitter._events[evt].push(listener);else emitter._events[evt] = [emitter._events[evt], listener];
-    return emitter;
-  }
-  /**
-   * Clear event by name.
-   *
-   * @param {EventEmitter} emitter Reference to the `EventEmitter` instance.
-   * @param {(String|Symbol)} evt The Event name.
-   * @private
-   */
-
-
-  function clearEvent(emitter, evt) {
-    if (--emitter._eventsCount === 0) emitter._events = new Events();else delete emitter._events[evt];
-  }
-  /**
-   * Minimal `EventEmitter` interface that is molded against the Node.js
-   * `EventEmitter` interface.
-   *
-   * @constructor
-   * @public
-   */
-
-
-  function EventEmitter() {
-    this._events = new Events();
-    this._eventsCount = 0;
-  }
-  /**
-   * Return an array listing the events for which the emitter has registered
-   * listeners.
-   *
-   * @returns {Array}
-   * @public
-   */
-
-
-  EventEmitter.prototype.eventNames = function eventNames() {
-    var names = [],
-        events,
-        name;
-    if (this._eventsCount === 0) return names;
-
-    for (name in events = this._events) {
-      if (has.call(events, name)) names.push(prefix ? name.slice(1) : name);
-    }
-
-    if (Object.getOwnPropertySymbols) {
-      return names.concat(Object.getOwnPropertySymbols(events));
-    }
-
-    return names;
-  };
-  /**
-   * Return the listeners registered for a given event.
-   *
-   * @param {(String|Symbol)} event The event name.
-   * @returns {Array} The registered listeners.
-   * @public
-   */
-
-
-  EventEmitter.prototype.listeners = function listeners(event) {
-    var evt = prefix ? prefix + event : event,
-        handlers = this._events[evt];
-    if (!handlers) return [];
-    if (handlers.fn) return [handlers.fn];
-
-    for (var i = 0, l = handlers.length, ee = new Array(l); i < l; i++) {
-      ee[i] = handlers[i].fn;
-    }
-
-    return ee;
-  };
-  /**
-   * Return the number of listeners listening to a given event.
-   *
-   * @param {(String|Symbol)} event The event name.
-   * @returns {Number} The number of listeners.
-   * @public
-   */
-
-
-  EventEmitter.prototype.listenerCount = function listenerCount(event) {
-    var evt = prefix ? prefix + event : event,
-        listeners = this._events[evt];
-    if (!listeners) return 0;
-    if (listeners.fn) return 1;
-    return listeners.length;
-  };
-  /**
-   * Calls each of the listeners registered for a given event.
-   *
-   * @param {(String|Symbol)} event The event name.
-   * @returns {Boolean} `true` if the event had listeners, else `false`.
-   * @public
-   */
-
-
-  EventEmitter.prototype.emit = function emit(event, a1, a2, a3, a4, a5) {
-    var evt = prefix ? prefix + event : event;
-    if (!this._events[evt]) return false;
-    var listeners = this._events[evt],
-        len = arguments.length,
-        args,
-        i;
-
-    if (listeners.fn) {
-      if (listeners.once) this.removeListener(event, listeners.fn, undefined, true);
-
-      switch (len) {
-        case 1:
-          return listeners.fn.call(listeners.context), true;
-
-        case 2:
-          return listeners.fn.call(listeners.context, a1), true;
-
-        case 3:
-          return listeners.fn.call(listeners.context, a1, a2), true;
-
-        case 4:
-          return listeners.fn.call(listeners.context, a1, a2, a3), true;
-
-        case 5:
-          return listeners.fn.call(listeners.context, a1, a2, a3, a4), true;
-
-        case 6:
-          return listeners.fn.call(listeners.context, a1, a2, a3, a4, a5), true;
-      }
-
-      for (i = 1, args = new Array(len - 1); i < len; i++) {
-        args[i - 1] = arguments[i];
-      }
-
-      listeners.fn.apply(listeners.context, args);
-    } else {
-      var length = listeners.length,
-          j;
-
-      for (i = 0; i < length; i++) {
-        if (listeners[i].once) this.removeListener(event, listeners[i].fn, undefined, true);
-
-        switch (len) {
-          case 1:
-            listeners[i].fn.call(listeners[i].context);
-            break;
-
-          case 2:
-            listeners[i].fn.call(listeners[i].context, a1);
-            break;
-
-          case 3:
-            listeners[i].fn.call(listeners[i].context, a1, a2);
-            break;
-
-          case 4:
-            listeners[i].fn.call(listeners[i].context, a1, a2, a3);
-            break;
-
-          default:
-            if (!args) for (j = 1, args = new Array(len - 1); j < len; j++) {
-              args[j - 1] = arguments[j];
-            }
-            listeners[i].fn.apply(listeners[i].context, args);
-        }
-      }
-    }
-
-    return true;
-  };
-  /**
-   * Add a listener for a given event.
-   *
-   * @param {(String|Symbol)} event The event name.
-   * @param {Function} fn The listener function.
-   * @param {*} [context=this] The context to invoke the listener with.
-   * @returns {EventEmitter} `this`.
-   * @public
-   */
-
-
-  EventEmitter.prototype.on = function on(event, fn, context) {
-    return addListener(this, event, fn, context, false);
-  };
-  /**
-   * Add a one-time listener for a given event.
-   *
-   * @param {(String|Symbol)} event The event name.
-   * @param {Function} fn The listener function.
-   * @param {*} [context=this] The context to invoke the listener with.
-   * @returns {EventEmitter} `this`.
-   * @public
-   */
-
-
-  EventEmitter.prototype.once = function once(event, fn, context) {
-    return addListener(this, event, fn, context, true);
-  };
-  /**
-   * Remove the listeners of a given event.
-   *
-   * @param {(String|Symbol)} event The event name.
-   * @param {Function} fn Only remove the listeners that match this function.
-   * @param {*} context Only remove the listeners that have this context.
-   * @param {Boolean} once Only remove one-time listeners.
-   * @returns {EventEmitter} `this`.
-   * @public
-   */
-
-
-  EventEmitter.prototype.removeListener = function removeListener(event, fn, context, once) {
-    var evt = prefix ? prefix + event : event;
-    if (!this._events[evt]) return this;
-
-    if (!fn) {
-      clearEvent(this, evt);
-      return this;
-    }
-
-    var listeners = this._events[evt];
-
-    if (listeners.fn) {
-      if (listeners.fn === fn && (!once || listeners.once) && (!context || listeners.context === context)) {
-        clearEvent(this, evt);
-      }
-    } else {
-      for (var i = 0, events = [], length = listeners.length; i < length; i++) {
-        if (listeners[i].fn !== fn || once && !listeners[i].once || context && listeners[i].context !== context) {
-          events.push(listeners[i]);
-        }
-      } //
-      // Reset the array, or remove it completely if we have no more listeners.
-      //
-
-
-      if (events.length) this._events[evt] = events.length === 1 ? events[0] : events;else clearEvent(this, evt);
-    }
-
-    return this;
-  };
-  /**
-   * Remove all listeners, or those of the specified event.
-   *
-   * @param {(String|Symbol)} [event] The event name.
-   * @returns {EventEmitter} `this`.
-   * @public
-   */
-
-
-  EventEmitter.prototype.removeAllListeners = function removeAllListeners(event) {
-    var evt;
-
-    if (event) {
-      evt = prefix ? prefix + event : event;
-      if (this._events[evt]) clearEvent(this, evt);
-    } else {
-      this._events = new Events();
-      this._eventsCount = 0;
-    }
-
-    return this;
-  }; //
-  // Alias methods names because people roll like that.
-  //
-
-
-  EventEmitter.prototype.off = EventEmitter.prototype.removeListener;
-  EventEmitter.prototype.addListener = EventEmitter.prototype.on; //
-  // Expose the prefix.
-  //
-
-  EventEmitter.prefixed = prefix; //
-  // Allow `EventEmitter` to be imported as module namespace.
-  //
-
-  EventEmitter.EventEmitter = EventEmitter; //
-  // Expose the module.
-  //
-
-  {
-    module.exports = EventEmitter;
-  }
-  });
-
-  function _createSuper(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
-
-  function _isNativeReflectConstruct() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
-  var callbackPrefix$1 = '__midi';
-
-  var leftPad = function leftPad(str, padString, length) {
-    var buf = str;
-
-    while (buf.length < length) {
-      buf = padString + buf;
-    }
-
-    return buf;
-  };
-
-  var hexFormat = function hexFormat(n, d) {
-    return '0x' + leftPad(n.toString(16).toUpperCase(), '0', d);
-  };
-
-  var MidiBus = /*#__PURE__*/function (_EventEmitter) {
-    _inherits(MidiBus, _EventEmitter);
-
-    var _super = _createSuper(MidiBus);
-
-    _createClass$1(MidiBus, null, [{
-      key: "create",
-      value: function create(registry, device) {
-        return new MidiBus(registry, device);
-      }
-    }]);
-
-    function MidiBus(registry, device) {
-      var _this;
-
-      _classCallCheck$1(this, MidiBus);
-
-      _this = _super.call(this);
-
-      _defineProperty$1(_assertThisInitialized(_this), "registry", void 0);
-
-      _defineProperty$1(_assertThisInitialized(_this), "device", void 0);
-
-      _this.registry = registry;
-      _this.device = device;
-      Object.keys(device.buttons).forEach(function (buttonName) {
-        var button = device.buttons[buttonName];
-        var def = button.def;
-
-        _this.registry["".concat(callbackPrefix$1, "_").concat(hexFormat(def.status, 2), "_").concat(hexFormat(def.midino, 2))] = function (channel, control, value, status) {
-          var message = {
-            value: value,
-            button: button,
-            device: _this.device
-          };
-
-          _this.emit(def.name, message);
-        };
-      });
-      return _this;
-    }
-
-    return MidiBus;
-  }(eventemitter3);
-
-  function _superPropBase(object, property) {
-    while (!Object.prototype.hasOwnProperty.call(object, property)) {
-      object = _getPrototypeOf(object);
-      if (object === null) break;
-    }
-
-    return object;
-  }
-
-  function _get(target, property, receiver) {
-    if (typeof Reflect !== "undefined" && Reflect.get) {
-      _get = Reflect.get;
-    } else {
-      _get = function _get(target, property, receiver) {
-        var base = _superPropBase(target, property);
-        if (!base) return;
-        var desc = Object.getOwnPropertyDescriptor(base, property);
-
-        if (desc.get) {
-          return desc.get.call(receiver);
-        }
-
-        return desc.value;
-      };
-    }
-
-    return _get(target, property, receiver || target);
-  }
-
-  function _createSuper$1(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct$1()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
-
-  function _isNativeReflectConstruct$1() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
-
-  var Component = /*#__PURE__*/function (_EventEmitter) {
-    _inherits(Component, _EventEmitter);
-
-    var _super = _createSuper$1(Component);
-
-    function Component() {
-      _classCallCheck$1(this, Component);
-
-      return _super.apply(this, arguments);
-    }
-
-    _createClass$1(Component, [{
-      key: "mount",
-      value: function mount() {
-        this.onMount();
-        this.emit('mount', this);
-      }
-    }, {
-      key: "unmount",
-      value: function unmount() {
-        this.onUnmount();
-        this.emit('unmount', this);
-      }
-    }, {
-      key: "onMount",
-      value: function onMount() {}
-    }, {
-      key: "onUnmount",
-      value: function onUnmount() {}
-    }]);
-
-    return Component;
-  }(eventemitter3);
-
-  function _createSuper$2(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct$2()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
-
-  function _isNativeReflectConstruct$2() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
-
-  var MidiComponent = /*#__PURE__*/function (_Component) {
-    _inherits(MidiComponent, _Component);
-
-    var _super = _createSuper$2(MidiComponent);
-
-    function MidiComponent(midibus) {
-      var _this;
-
-      _classCallCheck$1(this, MidiComponent);
-
-      _this = _super.call(this);
-
-      _defineProperty$1(_assertThisInitialized(_this), "midibus", void 0);
-
-      _defineProperty$1(_assertThisInitialized(_this), "device", void 0);
-
-      _this.midibus = midibus;
-      _this.device = midibus.device;
-      return _this;
-    }
-
-    _createClass$1(MidiComponent, [{
-      key: "onMount",
-      value: function onMount() {
-        _get(_getPrototypeOf(MidiComponent.prototype), "onMount", this).call(this);
-      }
-    }, {
-      key: "onUnmount",
-      value: function onUnmount() {
-        _get(_getPrototypeOf(MidiComponent.prototype), "onUnmount", this).call(this);
-      }
-    }]);
-
-    return MidiComponent;
-  }(Component);
-
-  function _createSuper$3(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct$3()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
-
-  function _isNativeReflectConstruct$3() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
-
-  var MidiButtonComponent = /*#__PURE__*/function (_MidiComponent) {
-    _inherits(MidiButtonComponent, _MidiComponent);
-
-    var _super = _createSuper$3(MidiButtonComponent);
-
-    function MidiButtonComponent(midibus, button) {
-      var _this;
-
-      _classCallCheck$1(this, MidiButtonComponent);
-
-      _this = _super.call(this, midibus);
-
-      _defineProperty$1(_assertThisInitialized(_this), "button", void 0);
-
-      _defineProperty$1(_assertThisInitialized(_this), "_cb", void 0);
-
-      _this.midibus = midibus;
-      _this.button = button;
-      _this.device = midibus.device;
-
-      _this._cb = function (data) {
-        if (data.value) {
-          _this.emit('attack', data);
-        } else {
-          _this.emit('release', data);
-        }
-
-        _this.emit('midi', data);
-      };
-
-      return _this;
-    }
-
-    _createClass$1(MidiButtonComponent, [{
-      key: "onMount",
-      value: function onMount() {
-        _get(_getPrototypeOf(MidiButtonComponent.prototype), "onMount", this).call(this);
-
-        this.midibus.on(this.button.def.name, this._cb);
-      }
-    }, {
-      key: "onUnmount",
-      value: function onUnmount() {
-        this.midibus.removeListener(this.button.def.name, this._cb);
-
-        _get(_getPrototypeOf(MidiButtonComponent.prototype), "onUnmount", this).call(this);
-      }
-    }]);
-
-    return MidiButtonComponent;
-  }(MidiComponent);
-
-  function _createSuper$4(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct$4()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
-
-  function _isNativeReflectConstruct$4() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
-
-  var autoscrolled = function autoscrolled(binding) {
-    return function (timerBuilder) {
-      var started;
-      var minInterval = 32;
-      var interval;
-      var timer;
-      binding.on('midi', function (data) {
-        if (data.value) {
-          interval = 250;
-          started = timer.start(interval);
-        } else {
-          timer.end();
-        }
-      });
-      binding.on('mount', function () {
-        timer = timerBuilder(function () {
-          binding.emit('scroll');
-
-          if (interval > minInterval) {
-            var current = Date.now(); // silence Flow with unsafe casts
-
-            if (interval === 250 && current - started > 1500) {
-              interval = 125;
-              timer.restart(interval);
-            } else if (interval === 125 && current - started > 3000) {
-              interval = 63;
-              timer.restart(interval);
-            } else if (interval === 63 && current - started > 6000) {
-              interval = minInterval;
-              timer.restart(interval);
-            }
-          }
-        });
-      });
-      binding.on('unmount', function () {
-        timer.end();
-      });
-      return binding;
-    };
-  };
-
-  var onScroll = function onScroll(control) {
-    return function () {
-      control.setValue(1);
-    };
-  };
-
-  var onMidi = function onMidi(control) {
-    return function (_ref) {
-      var value = _ref.value,
-          button = _ref.button,
-          device = _ref.device;
-
-      if (value) {
-        control.setValue(1);
-        button.sendColor(device.colors.hi_red);
-      } else {
-        button.sendColor(device.colors.hi_yellow);
-      }
-    };
-  };
-
-  var onMount = function onMount(_ref2) {
-    var button = _ref2.button,
-        device = _ref2.device;
-    button.sendColor(device.colors.hi_yellow);
-  };
-
-  var onUnmount = function onUnmount(_ref3) {
-    var button = _ref3.button,
-        device = _ref3.device;
-    button.sendColor(device.colors.black);
-  };
-
-  var PlaylistSidebar = /*#__PURE__*/function (_MidiComponent) {
-    _inherits(PlaylistSidebar, _MidiComponent);
-
-    var _super = _createSuper$4(PlaylistSidebar);
-
-    function PlaylistSidebar(midibus, timerBuilder) {
-      var _this;
-
-      _classCallCheck$1(this, PlaylistSidebar);
-
-      _this = _super.call(this, midibus);
-
-      _defineProperty$1(_assertThisInitialized(_this), "buttons", void 0);
-
-      var btns = [new MidiButtonComponent(midibus, _this.device.buttons.vol), new MidiButtonComponent(midibus, _this.device.buttons.pan), new MidiButtonComponent(midibus, _this.device.buttons.snda), new MidiButtonComponent(midibus, _this.device.buttons.sndb), new MidiButtonComponent(midibus, _this.device.buttons.stop)];
-      var prevPlaylist = autoscrolled(btns[0])(timerBuilder);
-      var nextPlaylist = autoscrolled(btns[1])(timerBuilder);
-      var toggleItem = btns[2];
-      var prevTrack = autoscrolled(btns[3])(timerBuilder);
-      var nextTrack = autoscrolled(btns[4])(timerBuilder);
-      prevPlaylist.on('scroll', onScroll(playListControl.SelectPrevPlaylist));
-      prevPlaylist.on('midi', onMidi(playListControl.SelectPrevPlaylist));
-      prevPlaylist.on('mount', onMount);
-      prevPlaylist.on('unmount', onUnmount);
-      nextPlaylist.on('scroll', onScroll(playListControl.SelectNextPlaylist));
-      nextPlaylist.on('midi', onMidi(playListControl.SelectNextPlaylist));
-      nextPlaylist.on('mount', onMount);
-      nextPlaylist.on('unmount', onUnmount);
-      prevTrack.on('scroll', onScroll(playListControl.SelectPrevTrack));
-      prevTrack.on('midi', onMidi(playListControl.SelectPrevTrack));
-      prevTrack.on('mount', onMount);
-      prevTrack.on('unmount', onUnmount);
-      nextTrack.on('scroll', onScroll(playListControl.SelectNextTrack));
-      nextTrack.on('midi', onMidi(playListControl.SelectNextTrack));
-      nextTrack.on('mount', onMount);
-      nextTrack.on('unmount', onUnmount);
-      toggleItem.on('midi', onMidi(playListControl.ToggleSelectedSidebarItem));
-      toggleItem.on('mount', onMount);
-      toggleItem.on('unmount', onUnmount);
-      _this.buttons = btns;
-      return _this;
-    }
-
-    _createClass$1(PlaylistSidebar, [{
-      key: "onMount",
-      value: function onMount() {
-        this.buttons.forEach(function (button) {
-          return button.mount();
-        });
-      }
-    }, {
-      key: "onUnmount",
-      value: function onUnmount() {
-        this.buttons.forEach(function (button) {
-          return button.unmount();
-        });
-      }
-    }]);
-
-    return PlaylistSidebar;
-  }(MidiComponent);
-
-  function _createSuper$5(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct$5()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
-
-  function _isNativeReflectConstruct$5() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
-
-  var ModifierSidebar = /*#__PURE__*/function (_MidiComponent) {
-    _inherits(ModifierSidebar, _MidiComponent);
-
-    var _super = _createSuper$5(ModifierSidebar);
-
-    function ModifierSidebar(midibus) {
-      var _this;
-
-      _classCallCheck$1(this, ModifierSidebar);
-
-      _this = _super.call(this, midibus);
-
-      _defineProperty$1(_assertThisInitialized(_this), "shift", void 0);
-
-      _defineProperty$1(_assertThisInitialized(_this), "ctrl", void 0);
-
-      _defineProperty$1(_assertThisInitialized(_this), "state", void 0);
-
-      _defineProperty$1(_assertThisInitialized(_this), "listener", void 0);
-
-      _this.shift = new MidiButtonComponent(_this.midibus, _this.device.buttons.solo);
-      _this.ctrl = new MidiButtonComponent(_this.midibus, _this.device.buttons.arm);
-      _this.state = {
-        shift: false,
-        ctrl: false
-      };
-
-      _this.listener = function (_ref) {
-        var value = _ref.value,
-            button = _ref.button,
-            device = _ref.device;
-
-        if (value) {
-          button.sendColor(device.colors.hi_red);
-        } else {
-          button.sendColor(device.colors.black);
-        }
-
-        if (button.def.name === _this.device.buttons.solo.def.name) {
-          _this.state.shift = !!value;
-
-          _this.emit('shift', value);
-        } else {
-          _this.state.ctrl = !!value;
-
-          _this.emit('ctrl', value);
-        }
-      };
-
-      return _this;
-    }
-
-    _createClass$1(ModifierSidebar, [{
-      key: "onMount",
-      value: function onMount() {
-        this.shift.mount();
-        this.ctrl.mount();
-        this.shift.on('midi', this.listener);
-        this.ctrl.on('midi', this.listener);
-      }
-    }, {
-      key: "onUnmount",
-      value: function onUnmount() {
-        this.shift.removeListener('midi', this.listener);
-        this.ctrl.removeListener('midi', this.listener);
-        this.shift.unmount();
-        this.ctrl.unmount();
-      }
-    }, {
-      key: "getState",
-      value: function getState() {
-        return this.state;
-      }
-    }]);
-
-    return ModifierSidebar;
-  }(MidiComponent);
-  var modes = function modes(ctx, n, c, s, cs) {
-    if (ctx.shift && ctx.ctrl) {
-      cs && cs();
-    } else if (ctx.shift) {
-      s && s();
-    } else if (ctx.ctrl) {
-      c && c();
-    } else {
-      n && n();
-    }
-  };
-  var retainAttackMode = function retainAttackMode(modifier, cb) {
-    var state = {
-      shift: false,
-      ctrl: false
-    };
-    return function (data) {
-      if (data.value) {
-        state = modifier.getState();
-      }
-
-      for (var _len = arguments.length, rest = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
-        rest[_key - 1] = arguments[_key];
-      }
-
-      return cb.apply(void 0, [state, data].concat(rest));
-    };
-  };
-
-  function _arrayWithoutHoles(arr) {
-    if (Array.isArray(arr)) return _arrayLikeToArray(arr);
-  }
-
-  function _iterableToArray(iter) {
-    if (typeof Symbol !== "undefined" && Symbol.iterator in Object(iter)) return Array.from(iter);
-  }
-
-  function _nonIterableSpread() {
-    throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
-  }
-
-  function _toConsumableArray(arr) {
-    return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _unsupportedIterableToArray(arr) || _nonIterableSpread();
-  }
-
-  /** Detect free variable `global` from Node.js. */
-  var freeGlobal$1 = (typeof global === "undefined" ? "undefined" : _typeof(global)) == 'object' && global && global.Object === Object && global;
-
-  /** Detect free variable `self`. */
-
-  var freeSelf$1 = (typeof self === "undefined" ? "undefined" : _typeof(self)) == 'object' && self && self.Object === Object && self;
-  /** Used as a reference to the global object. */
-
-  var root$1 = freeGlobal$1 || freeSelf$1 || Function('return this')();
-
-  /** Built-in value references. */
-
-  var _Symbol$1 = root$1.Symbol;
-
-  /** Used for built-in method references. */
-
-  var objectProto$9 = Object.prototype;
-  /** Used to check objects for own properties. */
-
-  var hasOwnProperty$7 = objectProto$9.hasOwnProperty;
-  /**
-   * Used to resolve the
-   * [`toStringTag`](http://ecma-international.org/ecma-262/7.0/#sec-object.prototype.tostring)
-   * of values.
-   */
-
-  var nativeObjectToString$2 = objectProto$9.toString;
-  /** Built-in value references. */
-
-  var symToStringTag$2 = _Symbol$1 ? _Symbol$1.toStringTag : undefined;
-  /**
-   * A specialized version of `baseGetTag` which ignores `Symbol.toStringTag` values.
-   *
-   * @private
-   * @param {*} value The value to query.
-   * @returns {string} Returns the raw `toStringTag`.
-   */
-
-  function getRawTag$1(value) {
-    var isOwn = hasOwnProperty$7.call(value, symToStringTag$2),
-        tag = value[symToStringTag$2];
-
-    try {
-      value[symToStringTag$2] = undefined;
-      var unmasked = true;
-    } catch (e) {}
-
-    var result = nativeObjectToString$2.call(value);
-
-    if (unmasked) {
-      if (isOwn) {
-        value[symToStringTag$2] = tag;
-      } else {
-        delete value[symToStringTag$2];
-      }
-    }
-
-    return result;
-  }
-
-  /** Used for built-in method references. */
-  var objectProto$a = Object.prototype;
-  /**
-   * Used to resolve the
-   * [`toStringTag`](http://ecma-international.org/ecma-262/7.0/#sec-object.prototype.tostring)
-   * of values.
-   */
-
-  var nativeObjectToString$3 = objectProto$a.toString;
-  /**
-   * Converts `value` to a string using `Object.prototype.toString`.
-   *
-   * @private
-   * @param {*} value The value to convert.
-   * @returns {string} Returns the converted string.
-   */
-
-  function objectToString$1(value) {
-    return nativeObjectToString$3.call(value);
-  }
-
-  /** `Object#toString` result references. */
-
-  var nullTag$1 = '[object Null]',
-      undefinedTag$1 = '[object Undefined]';
-  /** Built-in value references. */
-
-  var symToStringTag$3 = _Symbol$1 ? _Symbol$1.toStringTag : undefined;
-  /**
-   * The base implementation of `getTag` without fallbacks for buggy environments.
-   *
-   * @private
-   * @param {*} value The value to query.
-   * @returns {string} Returns the `toStringTag`.
-   */
-
-  function baseGetTag$1(value) {
-    if (value == null) {
-      return value === undefined ? undefinedTag$1 : nullTag$1;
-    }
-
-    return symToStringTag$3 && symToStringTag$3 in Object(value) ? getRawTag$1(value) : objectToString$1(value);
-  }
-
-  /**
-   * Checks if `value` is the
-   * [language type](http://www.ecma-international.org/ecma-262/7.0/#sec-ecmascript-language-types)
-   * of `Object`. (e.g. arrays, functions, objects, regexes, `new Number(0)`, and `new String('')`)
-   *
-   * @static
-   * @memberOf _
-   * @since 0.1.0
-   * @category Lang
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is an object, else `false`.
-   * @example
-   *
-   * _.isObject({});
-   * // => true
-   *
-   * _.isObject([1, 2, 3]);
-   * // => true
-   *
-   * _.isObject(_.noop);
-   * // => true
-   *
-   * _.isObject(null);
-   * // => false
-   */
-  function isObject$1(value) {
-    var type = _typeof(value);
-
-    return value != null && (type == 'object' || type == 'function');
-  }
-
-  /** `Object#toString` result references. */
-
-  var asyncTag$1 = '[object AsyncFunction]',
-      funcTag$2 = '[object Function]',
-      genTag$1 = '[object GeneratorFunction]',
-      proxyTag$1 = '[object Proxy]';
-  /**
-   * Checks if `value` is classified as a `Function` object.
-   *
-   * @static
-   * @memberOf _
-   * @since 0.1.0
-   * @category Lang
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is a function, else `false`.
-   * @example
-   *
-   * _.isFunction(_);
-   * // => true
-   *
-   * _.isFunction(/abc/);
-   * // => false
-   */
-
-  function isFunction$1(value) {
-    if (!isObject$1(value)) {
-      return false;
-    } // The use of `Object#toString` avoids issues with the `typeof` operator
-    // in Safari 9 which returns 'object' for typed arrays and other constructors.
-
-
-    var tag = baseGetTag$1(value);
-    return tag == funcTag$2 || tag == genTag$1 || tag == asyncTag$1 || tag == proxyTag$1;
-  }
-
-  /** Used to detect overreaching core-js shims. */
-
-  var coreJsData$1 = root$1['__core-js_shared__'];
-
-  /** Used to detect methods masquerading as native. */
-
-  var maskSrcKey$1 = function () {
-    var uid = /[^.]+$/.exec(coreJsData$1 && coreJsData$1.keys && coreJsData$1.keys.IE_PROTO || '');
-    return uid ? 'Symbol(src)_1.' + uid : '';
-  }();
-  /**
-   * Checks if `func` has its source masked.
-   *
-   * @private
-   * @param {Function} func The function to check.
-   * @returns {boolean} Returns `true` if `func` is masked, else `false`.
-   */
-
-
-  function isMasked$1(func) {
-    return !!maskSrcKey$1 && maskSrcKey$1 in func;
-  }
-
-  /** Used for built-in method references. */
-  var funcProto$2 = Function.prototype;
-  /** Used to resolve the decompiled source of functions. */
-
-  var funcToString$2 = funcProto$2.toString;
-  /**
-   * Converts `func` to its source code.
-   *
-   * @private
-   * @param {Function} func The function to convert.
-   * @returns {string} Returns the source code.
-   */
-
-  function toSource$1(func) {
-    if (func != null) {
-      try {
-        return funcToString$2.call(func);
-      } catch (e) {}
-
-      try {
-        return func + '';
-      } catch (e) {}
-    }
-
-    return '';
-  }
-
-  /**
-   * Used to match `RegExp`
-   * [syntax characters](http://ecma-international.org/ecma-262/7.0/#sec-patterns).
-   */
-
-  var reRegExpChar$1 = /[\\^$.*+?()[\]{}|]/g;
-  /** Used to detect host constructors (Safari). */
-
-  var reIsHostCtor$1 = /^\[object .+?Constructor\]$/;
-  /** Used for built-in method references. */
-
-  var funcProto$3 = Function.prototype,
-      objectProto$b = Object.prototype;
-  /** Used to resolve the decompiled source of functions. */
-
-  var funcToString$3 = funcProto$3.toString;
-  /** Used to check objects for own properties. */
-
-  var hasOwnProperty$8 = objectProto$b.hasOwnProperty;
-  /** Used to detect if a method is native. */
-
-  var reIsNative$1 = RegExp('^' + funcToString$3.call(hasOwnProperty$8).replace(reRegExpChar$1, '\\$&').replace(/hasOwnProperty|(function).*?(?=\\\()| for .+?(?=\\\])/g, '$1.*?') + '$');
-  /**
-   * The base implementation of `_.isNative` without bad shim checks.
-   *
-   * @private
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is a native function,
-   *  else `false`.
-   */
-
-  function baseIsNative$1(value) {
-    if (!isObject$1(value) || isMasked$1(value)) {
-      return false;
-    }
-
-    var pattern = isFunction$1(value) ? reIsNative$1 : reIsHostCtor$1;
-    return pattern.test(toSource$1(value));
-  }
-
-  /**
-   * Gets the value at `key` of `object`.
-   *
-   * @private
-   * @param {Object} [object] The object to query.
-   * @param {string} key The key of the property to get.
-   * @returns {*} Returns the property value.
-   */
-  function getValue$1(object, key) {
-    return object == null ? undefined : object[key];
-  }
-
-  /**
-   * Gets the native function at `key` of `object`.
-   *
-   * @private
-   * @param {Object} object The object to query.
-   * @param {string} key The key of the method to get.
-   * @returns {*} Returns the function if it's native, else `undefined`.
-   */
-
-  function getNative$1(object, key) {
-    var value = getValue$1(object, key);
-    return baseIsNative$1(value) ? value : undefined;
-  }
-
-  var defineProperty$1 = function () {
-    try {
-      var func = getNative$1(Object, 'defineProperty');
-      func({}, '', {});
-      return func;
-    } catch (e) {}
-  }();
-
-  /**
-   * The base implementation of `assignValue` and `assignMergeValue` without
-   * value checks.
-   *
-   * @private
-   * @param {Object} object The object to modify.
-   * @param {string} key The key of the property to assign.
-   * @param {*} value The value to assign.
-   */
-
-  function baseAssignValue$1(object, key, value) {
-    if (key == '__proto__' && defineProperty$1) {
-      defineProperty$1(object, key, {
-        'configurable': true,
-        'enumerable': true,
-        'value': value,
-        'writable': true
-      });
-    } else {
-      object[key] = value;
-    }
-  }
-
-  /**
-   * Performs a
-   * [`SameValueZero`](http://ecma-international.org/ecma-262/7.0/#sec-samevaluezero)
-   * comparison between two values to determine if they are equivalent.
-   *
-   * @static
-   * @memberOf _
-   * @since 4.0.0
-   * @category Lang
-   * @param {*} value The value to compare.
-   * @param {*} other The other value to compare.
-   * @returns {boolean} Returns `true` if the values are equivalent, else `false`.
-   * @example
-   *
-   * var object = { 'a': 1 };
-   * var other = { 'a': 1 };
-   *
-   * _.eq(object, object);
-   * // => true
-   *
-   * _.eq(object, other);
-   * // => false
-   *
-   * _.eq('a', 'a');
-   * // => true
-   *
-   * _.eq('a', Object('a'));
-   * // => false
-   *
-   * _.eq(NaN, NaN);
-   * // => true
-   */
-  function eq$1(value, other) {
-    return value === other || value !== value && other !== other;
-  }
-
-  /** Used for built-in method references. */
-
-  var objectProto$c = Object.prototype;
-  /** Used to check objects for own properties. */
-
-  var hasOwnProperty$9 = objectProto$c.hasOwnProperty;
-  /**
-   * Assigns `value` to `key` of `object` if the existing value is not equivalent
-   * using [`SameValueZero`](http://ecma-international.org/ecma-262/7.0/#sec-samevaluezero)
-   * for equality comparisons.
-   *
-   * @private
-   * @param {Object} object The object to modify.
-   * @param {string} key The key of the property to assign.
-   * @param {*} value The value to assign.
-   */
-
-  function assignValue$1(object, key, value) {
-    var objValue = object[key];
-
-    if (!(hasOwnProperty$9.call(object, key) && eq$1(objValue, value)) || value === undefined && !(key in object)) {
-      baseAssignValue$1(object, key, value);
-    }
-  }
-
-  /**
-   * Copies properties of `source` to `object`.
-   *
-   * @private
-   * @param {Object} source The object to copy properties from.
-   * @param {Array} props The property identifiers to copy.
-   * @param {Object} [object={}] The object to copy properties to.
-   * @param {Function} [customizer] The function to customize copied values.
-   * @returns {Object} Returns `object`.
-   */
-
-  function copyObject$1(source, props, object, customizer) {
-    var isNew = !object;
-    object || (object = {});
-    var index = -1,
-        length = props.length;
-
-    while (++index < length) {
-      var key = props[index];
-      var newValue = customizer ? customizer(object[key], source[key], key, object, source) : undefined;
-
-      if (newValue === undefined) {
-        newValue = source[key];
-      }
-
-      if (isNew) {
-        baseAssignValue$1(object, key, newValue);
-      } else {
-        assignValue$1(object, key, newValue);
-      }
-    }
-
-    return object;
-  }
-
-  /**
-   * This method returns the first argument it receives.
-   *
-   * @static
-   * @since 0.1.0
-   * @memberOf _
-   * @category Util
-   * @param {*} value Any value.
-   * @returns {*} Returns `value`.
-   * @example
-   *
-   * var object = { 'a': 1 };
-   *
-   * console.log(_.identity(object) === object);
-   * // => true
-   */
-  function identity$1(value) {
-    return value;
-  }
-
-  /**
-   * A faster alternative to `Function#apply`, this function invokes `func`
-   * with the `this` binding of `thisArg` and the arguments of `args`.
-   *
-   * @private
-   * @param {Function} func The function to invoke.
-   * @param {*} thisArg The `this` binding of `func`.
-   * @param {Array} args The arguments to invoke `func` with.
-   * @returns {*} Returns the result of `func`.
-   */
-  function apply$1(func, thisArg, args) {
-    switch (args.length) {
-      case 0:
-        return func.call(thisArg);
-
-      case 1:
-        return func.call(thisArg, args[0]);
-
-      case 2:
-        return func.call(thisArg, args[0], args[1]);
-
-      case 3:
-        return func.call(thisArg, args[0], args[1], args[2]);
-    }
-
-    return func.apply(thisArg, args);
-  }
-
-  /* Built-in method references for those with the same name as other `lodash` methods. */
-
-  var nativeMax$2 = Math.max;
-  /**
-   * A specialized version of `baseRest` which transforms the rest array.
-   *
-   * @private
-   * @param {Function} func The function to apply a rest parameter to.
-   * @param {number} [start=func.length-1] The start position of the rest parameter.
-   * @param {Function} transform The rest array transform.
-   * @returns {Function} Returns the new function.
-   */
-
-  function overRest$1(func, start, transform) {
-    start = nativeMax$2(start === undefined ? func.length - 1 : start, 0);
-    return function () {
-      var args = arguments,
-          index = -1,
-          length = nativeMax$2(args.length - start, 0),
-          array = Array(length);
-
-      while (++index < length) {
-        array[index] = args[start + index];
-      }
-
-      index = -1;
-      var otherArgs = Array(start + 1);
-
-      while (++index < start) {
-        otherArgs[index] = args[index];
-      }
-
-      otherArgs[start] = transform(array);
-      return apply$1(func, this, otherArgs);
-    };
-  }
-
-  /**
-   * Creates a function that returns `value`.
-   *
-   * @static
-   * @memberOf _
-   * @since 2.4.0
-   * @category Util
-   * @param {*} value The value to return from the new function.
-   * @returns {Function} Returns the new constant function.
-   * @example
-   *
-   * var objects = _.times(2, _.constant({ 'a': 1 }));
-   *
-   * console.log(objects);
-   * // => [{ 'a': 1 }, { 'a': 1 }]
-   *
-   * console.log(objects[0] === objects[1]);
-   * // => true
-   */
-  function constant$1(value) {
-    return function () {
-      return value;
-    };
-  }
-
-  /**
-   * The base implementation of `setToString` without support for hot loop shorting.
-   *
-   * @private
-   * @param {Function} func The function to modify.
-   * @param {Function} string The `toString` result.
-   * @returns {Function} Returns `func`.
-   */
-
-  var baseSetToString$1 = !defineProperty$1 ? identity$1 : function (func, string) {
-    return defineProperty$1(func, 'toString', {
-      'configurable': true,
-      'enumerable': false,
-      'value': constant$1(string),
-      'writable': true
-    });
-  };
-
-  /** Used to detect hot functions by number of calls within a span of milliseconds. */
-  var HOT_COUNT$1 = 800,
-      HOT_SPAN$1 = 16;
-  /* Built-in method references for those with the same name as other `lodash` methods. */
-
-  var nativeNow$1 = Date.now;
-  /**
-   * Creates a function that'll short out and invoke `identity` instead
-   * of `func` when it's called `HOT_COUNT` or more times in `HOT_SPAN`
-   * milliseconds.
-   *
-   * @private
-   * @param {Function} func The function to restrict.
-   * @returns {Function} Returns the new shortable function.
-   */
-
-  function shortOut$1(func) {
-    var count = 0,
-        lastCalled = 0;
-    return function () {
-      var stamp = nativeNow$1(),
-          remaining = HOT_SPAN$1 - (stamp - lastCalled);
-      lastCalled = stamp;
-
-      if (remaining > 0) {
-        if (++count >= HOT_COUNT$1) {
-          return arguments[0];
-        }
-      } else {
-        count = 0;
-      }
-
-      return func.apply(undefined, arguments);
-    };
-  }
-
-  /**
-   * Sets the `toString` method of `func` to return `string`.
-   *
-   * @private
-   * @param {Function} func The function to modify.
-   * @param {Function} string The `toString` result.
-   * @returns {Function} Returns `func`.
-   */
-
-  var setToString$1 = shortOut$1(baseSetToString$1);
-
-  /**
-   * The base implementation of `_.rest` which doesn't validate or coerce arguments.
-   *
-   * @private
-   * @param {Function} func The function to apply a rest parameter to.
-   * @param {number} [start=func.length-1] The start position of the rest parameter.
-   * @returns {Function} Returns the new function.
-   */
-
-  function baseRest$1(func, start) {
-    return setToString$1(overRest$1(func, start, identity$1), func + '');
-  }
-
-  /** Used as references for various `Number` constants. */
-  var MAX_SAFE_INTEGER$2 = 9007199254740991;
-  /**
-   * Checks if `value` is a valid array-like length.
-   *
-   * **Note:** This method is loosely based on
-   * [`ToLength`](http://ecma-international.org/ecma-262/7.0/#sec-tolength).
-   *
-   * @static
-   * @memberOf _
-   * @since 4.0.0
-   * @category Lang
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is a valid length, else `false`.
-   * @example
-   *
-   * _.isLength(3);
-   * // => true
-   *
-   * _.isLength(Number.MIN_VALUE);
-   * // => false
-   *
-   * _.isLength(Infinity);
-   * // => false
-   *
-   * _.isLength('3');
-   * // => false
-   */
-
-  function isLength$1(value) {
-    return typeof value == 'number' && value > -1 && value % 1 == 0 && value <= MAX_SAFE_INTEGER$2;
-  }
-
-  /**
-   * Checks if `value` is array-like. A value is considered array-like if it's
-   * not a function and has a `value.length` that's an integer greater than or
-   * equal to `0` and less than or equal to `Number.MAX_SAFE_INTEGER`.
-   *
-   * @static
-   * @memberOf _
-   * @since 4.0.0
-   * @category Lang
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is array-like, else `false`.
-   * @example
-   *
-   * _.isArrayLike([1, 2, 3]);
-   * // => true
-   *
-   * _.isArrayLike(document.body.children);
-   * // => true
-   *
-   * _.isArrayLike('abc');
-   * // => true
-   *
-   * _.isArrayLike(_.noop);
-   * // => false
-   */
-
-  function isArrayLike$1(value) {
-    return value != null && isLength$1(value.length) && !isFunction$1(value);
-  }
-
-  /** Used as references for various `Number` constants. */
-  var MAX_SAFE_INTEGER$3 = 9007199254740991;
-  /** Used to detect unsigned integer values. */
-
-  var reIsUint$1 = /^(?:0|[1-9]\d*)$/;
-  /**
-   * Checks if `value` is a valid array-like index.
-   *
-   * @private
-   * @param {*} value The value to check.
-   * @param {number} [length=MAX_SAFE_INTEGER] The upper bounds of a valid index.
-   * @returns {boolean} Returns `true` if `value` is a valid index, else `false`.
-   */
-
-  function isIndex$1(value, length) {
-    var type = _typeof(value);
-
-    length = length == null ? MAX_SAFE_INTEGER$3 : length;
-    return !!length && (type == 'number' || type != 'symbol' && reIsUint$1.test(value)) && value > -1 && value % 1 == 0 && value < length;
-  }
-
-  /**
-   * Checks if the given arguments are from an iteratee call.
-   *
-   * @private
-   * @param {*} value The potential iteratee value argument.
-   * @param {*} index The potential iteratee index or key argument.
-   * @param {*} object The potential iteratee object argument.
-   * @returns {boolean} Returns `true` if the arguments are from an iteratee call,
-   *  else `false`.
-   */
-
-  function isIterateeCall$1(value, index, object) {
-    if (!isObject$1(object)) {
-      return false;
-    }
-
-    var type = _typeof(index);
-
-    if (type == 'number' ? isArrayLike$1(object) && isIndex$1(index, object.length) : type == 'string' && index in object) {
-      return eq$1(object[index], value);
-    }
-
-    return false;
-  }
-
-  /**
-   * Creates a function like `_.assign`.
-   *
-   * @private
-   * @param {Function} assigner The function to assign values.
-   * @returns {Function} Returns the new assigner function.
-   */
-
-  function createAssigner$1(assigner) {
-    return baseRest$1(function (object, sources) {
-      var index = -1,
-          length = sources.length,
-          customizer = length > 1 ? sources[length - 1] : undefined,
-          guard = length > 2 ? sources[2] : undefined;
-      customizer = assigner.length > 3 && typeof customizer == 'function' ? (length--, customizer) : undefined;
-
-      if (guard && isIterateeCall$1(sources[0], sources[1], guard)) {
-        customizer = length < 3 ? undefined : customizer;
-        length = 1;
-      }
-
-      object = Object(object);
-
-      while (++index < length) {
-        var source = sources[index];
-
-        if (source) {
-          assigner(object, source, index, customizer);
-        }
-      }
-
-      return object;
-    });
-  }
-
-  /** Used for built-in method references. */
-  var objectProto$d = Object.prototype;
-  /**
-   * Checks if `value` is likely a prototype object.
-   *
-   * @private
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is a prototype, else `false`.
-   */
-
-  function isPrototype$1(value) {
-    var Ctor = value && value.constructor,
-        proto = typeof Ctor == 'function' && Ctor.prototype || objectProto$d;
-    return value === proto;
-  }
-
-  /**
-   * The base implementation of `_.times` without support for iteratee shorthands
-   * or max array length checks.
-   *
-   * @private
-   * @param {number} n The number of times to invoke `iteratee`.
-   * @param {Function} iteratee The function invoked per iteration.
-   * @returns {Array} Returns the array of results.
-   */
-  function baseTimes$1(n, iteratee) {
-    var index = -1,
-        result = Array(n);
-
-    while (++index < n) {
-      result[index] = iteratee(index);
-    }
-
-    return result;
-  }
-
-  /**
-   * Checks if `value` is object-like. A value is object-like if it's not `null`
-   * and has a `typeof` result of "object".
-   *
-   * @static
-   * @memberOf _
-   * @since 4.0.0
-   * @category Lang
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is object-like, else `false`.
-   * @example
-   *
-   * _.isObjectLike({});
-   * // => true
-   *
-   * _.isObjectLike([1, 2, 3]);
-   * // => true
-   *
-   * _.isObjectLike(_.noop);
-   * // => false
-   *
-   * _.isObjectLike(null);
-   * // => false
-   */
-  function isObjectLike$1(value) {
-    return value != null && _typeof(value) == 'object';
-  }
-
-  /** `Object#toString` result references. */
-
-  var argsTag$2 = '[object Arguments]';
-  /**
-   * The base implementation of `_.isArguments`.
-   *
-   * @private
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is an `arguments` object,
-   */
-
-  function baseIsArguments$1(value) {
-    return isObjectLike$1(value) && baseGetTag$1(value) == argsTag$2;
-  }
-
-  /** Used for built-in method references. */
-
-  var objectProto$e = Object.prototype;
-  /** Used to check objects for own properties. */
-
-  var hasOwnProperty$a = objectProto$e.hasOwnProperty;
-  /** Built-in value references. */
-
-  var propertyIsEnumerable$1 = objectProto$e.propertyIsEnumerable;
-  /**
-   * Checks if `value` is likely an `arguments` object.
-   *
-   * @static
-   * @memberOf _
-   * @since 0.1.0
-   * @category Lang
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is an `arguments` object,
-   *  else `false`.
-   * @example
-   *
-   * _.isArguments(function() { return arguments; }());
-   * // => true
-   *
-   * _.isArguments([1, 2, 3]);
-   * // => false
-   */
-
-  var isArguments$1 = baseIsArguments$1(function () {
-    return arguments;
-  }()) ? baseIsArguments$1 : function (value) {
-    return isObjectLike$1(value) && hasOwnProperty$a.call(value, 'callee') && !propertyIsEnumerable$1.call(value, 'callee');
-  };
-
-  /**
-   * Checks if `value` is classified as an `Array` object.
-   *
-   * @static
-   * @memberOf _
-   * @since 0.1.0
-   * @category Lang
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is an array, else `false`.
-   * @example
-   *
-   * _.isArray([1, 2, 3]);
-   * // => true
-   *
-   * _.isArray(document.body.children);
-   * // => false
-   *
-   * _.isArray('abc');
-   * // => false
-   *
-   * _.isArray(_.noop);
-   * // => false
-   */
-  var isArray$1 = Array.isArray;
-
-  /**
-   * This method returns `false`.
-   *
-   * @static
-   * @memberOf _
-   * @since 4.13.0
-   * @category Util
-   * @returns {boolean} Returns `false`.
-   * @example
-   *
-   * _.times(2, _.stubFalse);
-   * // => [false, false]
-   */
-  function stubFalse$1() {
-    return false;
-  }
-
-  /** Detect free variable `exports`. */
-
-  var freeExports$2 = (typeof exports === "undefined" ? "undefined" : _typeof(exports)) == 'object' && exports && !exports.nodeType && exports;
-  /** Detect free variable `module`. */
-
-  var freeModule$2 = freeExports$2 && (typeof module === "undefined" ? "undefined" : _typeof(module)) == 'object' && module && !module.nodeType && module;
-  /** Detect the popular CommonJS extension `module.exports`. */
-
-  var moduleExports$2 = freeModule$2 && freeModule$2.exports === freeExports$2;
-  /** Built-in value references. */
-
-  var Buffer$1 = moduleExports$2 ? root$1.Buffer : undefined;
-  /* Built-in method references for those with the same name as other `lodash` methods. */
-
-  var nativeIsBuffer$1 = Buffer$1 ? Buffer$1.isBuffer : undefined;
-  /**
-   * Checks if `value` is a buffer.
-   *
-   * @static
-   * @memberOf _
-   * @since 4.3.0
-   * @category Lang
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is a buffer, else `false`.
-   * @example
-   *
-   * _.isBuffer(new Buffer(2));
-   * // => true
-   *
-   * _.isBuffer(new Uint8Array(2));
-   * // => false
-   */
-
-  var isBuffer$1 = nativeIsBuffer$1 || stubFalse$1;
-
-  /** `Object#toString` result references. */
-
-  var argsTag$3 = '[object Arguments]',
-      arrayTag$1 = '[object Array]',
-      boolTag$1 = '[object Boolean]',
-      dateTag$1 = '[object Date]',
-      errorTag$1 = '[object Error]',
-      funcTag$3 = '[object Function]',
-      mapTag$1 = '[object Map]',
-      numberTag$1 = '[object Number]',
-      objectTag$1 = '[object Object]',
-      regexpTag$1 = '[object RegExp]',
-      setTag$1 = '[object Set]',
-      stringTag$1 = '[object String]',
-      weakMapTag$1 = '[object WeakMap]';
-  var arrayBufferTag$1 = '[object ArrayBuffer]',
-      dataViewTag$1 = '[object DataView]',
-      float32Tag$1 = '[object Float32Array]',
-      float64Tag$1 = '[object Float64Array]',
-      int8Tag$1 = '[object Int8Array]',
-      int16Tag$1 = '[object Int16Array]',
-      int32Tag$1 = '[object Int32Array]',
-      uint8Tag$1 = '[object Uint8Array]',
-      uint8ClampedTag$1 = '[object Uint8ClampedArray]',
-      uint16Tag$1 = '[object Uint16Array]',
-      uint32Tag$1 = '[object Uint32Array]';
-  /** Used to identify `toStringTag` values of typed arrays. */
-
-  var typedArrayTags$1 = {};
-  typedArrayTags$1[float32Tag$1] = typedArrayTags$1[float64Tag$1] = typedArrayTags$1[int8Tag$1] = typedArrayTags$1[int16Tag$1] = typedArrayTags$1[int32Tag$1] = typedArrayTags$1[uint8Tag$1] = typedArrayTags$1[uint8ClampedTag$1] = typedArrayTags$1[uint16Tag$1] = typedArrayTags$1[uint32Tag$1] = true;
-  typedArrayTags$1[argsTag$3] = typedArrayTags$1[arrayTag$1] = typedArrayTags$1[arrayBufferTag$1] = typedArrayTags$1[boolTag$1] = typedArrayTags$1[dataViewTag$1] = typedArrayTags$1[dateTag$1] = typedArrayTags$1[errorTag$1] = typedArrayTags$1[funcTag$3] = typedArrayTags$1[mapTag$1] = typedArrayTags$1[numberTag$1] = typedArrayTags$1[objectTag$1] = typedArrayTags$1[regexpTag$1] = typedArrayTags$1[setTag$1] = typedArrayTags$1[stringTag$1] = typedArrayTags$1[weakMapTag$1] = false;
-  /**
-   * The base implementation of `_.isTypedArray` without Node.js optimizations.
-   *
-   * @private
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is a typed array, else `false`.
-   */
-
-  function baseIsTypedArray$1(value) {
-    return isObjectLike$1(value) && isLength$1(value.length) && !!typedArrayTags$1[baseGetTag$1(value)];
-  }
-
-  /**
-   * The base implementation of `_.unary` without support for storing metadata.
-   *
-   * @private
-   * @param {Function} func The function to cap arguments for.
-   * @returns {Function} Returns the new capped function.
-   */
-  function baseUnary$1(func) {
-    return function (value) {
-      return func(value);
-    };
-  }
-
-  /** Detect free variable `exports`. */
-
-  var freeExports$3 = (typeof exports === "undefined" ? "undefined" : _typeof(exports)) == 'object' && exports && !exports.nodeType && exports;
-  /** Detect free variable `module`. */
-
-  var freeModule$3 = freeExports$3 && (typeof module === "undefined" ? "undefined" : _typeof(module)) == 'object' && module && !module.nodeType && module;
-  /** Detect the popular CommonJS extension `module.exports`. */
-
-  var moduleExports$3 = freeModule$3 && freeModule$3.exports === freeExports$3;
-  /** Detect free variable `process` from Node.js. */
-
-  var freeProcess$1 = moduleExports$3 && freeGlobal$1.process;
-  /** Used to access faster Node.js helpers. */
-
-  var nodeUtil$1 = function () {
-    try {
-      // Use `util.types` for Node.js 10+.
-      var types = freeModule$3 && freeModule$3.require && freeModule$3.require('util').types;
-
-      if (types) {
-        return types;
-      } // Legacy `process.binding('util')` for Node.js < 10.
-
-
-      return freeProcess$1 && freeProcess$1.binding && freeProcess$1.binding('util');
-    } catch (e) {}
-  }();
-
-  /* Node.js helper references. */
-
-  var nodeIsTypedArray$1 = nodeUtil$1 && nodeUtil$1.isTypedArray;
-  /**
-   * Checks if `value` is classified as a typed array.
-   *
-   * @static
-   * @memberOf _
-   * @since 3.0.0
-   * @category Lang
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is a typed array, else `false`.
-   * @example
-   *
-   * _.isTypedArray(new Uint8Array);
-   * // => true
-   *
-   * _.isTypedArray([]);
-   * // => false
-   */
-
-  var isTypedArray$1 = nodeIsTypedArray$1 ? baseUnary$1(nodeIsTypedArray$1) : baseIsTypedArray$1;
-
-  /** Used for built-in method references. */
-
-  var objectProto$f = Object.prototype;
-  /** Used to check objects for own properties. */
-
-  var hasOwnProperty$b = objectProto$f.hasOwnProperty;
-  /**
-   * Creates an array of the enumerable property names of the array-like `value`.
-   *
-   * @private
-   * @param {*} value The value to query.
-   * @param {boolean} inherited Specify returning inherited property names.
-   * @returns {Array} Returns the array of property names.
-   */
-
-  function arrayLikeKeys$1(value, inherited) {
-    var isArr = isArray$1(value),
-        isArg = !isArr && isArguments$1(value),
-        isBuff = !isArr && !isArg && isBuffer$1(value),
-        isType = !isArr && !isArg && !isBuff && isTypedArray$1(value),
-        skipIndexes = isArr || isArg || isBuff || isType,
-        result = skipIndexes ? baseTimes$1(value.length, String) : [],
-        length = result.length;
-
-    for (var key in value) {
-      if ((inherited || hasOwnProperty$b.call(value, key)) && !(skipIndexes && ( // Safari 9 has enumerable `arguments.length` in strict mode.
-      key == 'length' || // Node.js 0.10 has enumerable non-index properties on buffers.
-      isBuff && (key == 'offset' || key == 'parent') || // PhantomJS 2 has enumerable non-index properties on typed arrays.
-      isType && (key == 'buffer' || key == 'byteLength' || key == 'byteOffset') || // Skip index properties.
-      isIndex$1(key, length)))) {
-        result.push(key);
-      }
-    }
-
-    return result;
-  }
-
-  /**
-   * Creates a unary function that invokes `func` with its argument transformed.
-   *
-   * @private
-   * @param {Function} func The function to wrap.
-   * @param {Function} transform The argument transform.
-   * @returns {Function} Returns the new function.
-   */
-  function overArg$1(func, transform) {
-    return function (arg) {
-      return func(transform(arg));
-    };
-  }
-
-  /* Built-in method references for those with the same name as other `lodash` methods. */
-
-  var nativeKeys$1 = overArg$1(Object.keys, Object);
-
-  /** Used for built-in method references. */
-
-  var objectProto$g = Object.prototype;
-  /** Used to check objects for own properties. */
-
-  var hasOwnProperty$c = objectProto$g.hasOwnProperty;
-  /**
-   * The base implementation of `_.keys` which doesn't treat sparse arrays as dense.
-   *
-   * @private
-   * @param {Object} object The object to query.
-   * @returns {Array} Returns the array of property names.
-   */
-
-  function baseKeys$1(object) {
-    if (!isPrototype$1(object)) {
-      return nativeKeys$1(object);
-    }
-
-    var result = [];
-
-    for (var key in Object(object)) {
-      if (hasOwnProperty$c.call(object, key) && key != 'constructor') {
-        result.push(key);
-      }
-    }
-
-    return result;
-  }
-
-  /**
-   * Creates an array of the own enumerable property names of `object`.
-   *
-   * **Note:** Non-object values are coerced to objects. See the
-   * [ES spec](http://ecma-international.org/ecma-262/7.0/#sec-object.keys)
-   * for more details.
-   *
-   * @static
-   * @since 0.1.0
-   * @memberOf _
-   * @category Object
-   * @param {Object} object The object to query.
-   * @returns {Array} Returns the array of property names.
-   * @example
-   *
-   * function Foo() {
-   *   this.a = 1;
-   *   this.b = 2;
-   * }
-   *
-   * Foo.prototype.c = 3;
-   *
-   * _.keys(new Foo);
-   * // => ['a', 'b'] (iteration order is not guaranteed)
-   *
-   * _.keys('hi');
-   * // => ['0', '1']
-   */
-
-  function keys$1(object) {
-    return isArrayLike$1(object) ? arrayLikeKeys$1(object) : baseKeys$1(object);
-  }
-
-  /** Used for built-in method references. */
-
-  var objectProto$h = Object.prototype;
-  /** Used to check objects for own properties. */
-
-  var hasOwnProperty$d = objectProto$h.hasOwnProperty;
-  /**
-   * Assigns own enumerable string keyed properties of source objects to the
-   * destination object. Source objects are applied from left to right.
-   * Subsequent sources overwrite property assignments of previous sources.
-   *
-   * **Note:** This method mutates `object` and is loosely based on
-   * [`Object.assign`](https://mdn.io/Object/assign).
-   *
-   * @static
-   * @memberOf _
-   * @since 0.10.0
-   * @category Object
-   * @param {Object} object The destination object.
-   * @param {...Object} [sources] The source objects.
-   * @returns {Object} Returns `object`.
-   * @see _.assignIn
-   * @example
-   *
-   * function Foo() {
-   *   this.a = 1;
-   * }
-   *
-   * function Bar() {
-   *   this.c = 3;
-   * }
-   *
-   * Foo.prototype.b = 2;
-   * Bar.prototype.d = 4;
-   *
-   * _.assign({ 'a': 0 }, new Foo, new Bar);
-   * // => { 'a': 1, 'c': 3 }
-   */
-
-  var assign$1 = createAssigner$1(function (object, source) {
-    if (isPrototype$1(source) || isArrayLike$1(source)) {
-      copyObject$1(source, keys$1(source), object);
-      return;
-    }
-
-    for (var key in source) {
-      if (hasOwnProperty$d.call(source, key)) {
-        assignValue$1(object, key, source[key]);
-      }
-    }
-  });
-
-  /**
-   * The base implementation of `_.findIndex` and `_.findLastIndex` without
-   * support for iteratee shorthands.
-   *
-   * @private
-   * @param {Array} array The array to inspect.
-   * @param {Function} predicate The function invoked per iteration.
-   * @param {number} fromIndex The index to search from.
-   * @param {boolean} [fromRight] Specify iterating from right to left.
-   * @returns {number} Returns the index of the matched value, else `-1`.
-   */
-  function baseFindIndex(array, predicate, fromIndex, fromRight) {
-    var length = array.length,
-        index = fromIndex + (fromRight ? 1 : -1);
-
-    while (fromRight ? index-- : ++index < length) {
-      if (predicate(array[index], index, array)) {
-        return index;
-      }
-    }
-
-    return -1;
-  }
-
-  /**
-   * Removes all key-value entries from the list cache.
-   *
-   * @private
-   * @name clear
-   * @memberOf ListCache
-   */
-  function listCacheClear() {
-    this.__data__ = [];
-    this.size = 0;
-  }
-
-  /**
-   * Gets the index at which the `key` is found in `array` of key-value pairs.
-   *
-   * @private
-   * @param {Array} array The array to inspect.
-   * @param {*} key The key to search for.
-   * @returns {number} Returns the index of the matched value, else `-1`.
-   */
-
-  function assocIndexOf(array, key) {
-    var length = array.length;
-
-    while (length--) {
-      if (eq$1(array[length][0], key)) {
-        return length;
-      }
-    }
-
-    return -1;
-  }
-
-  /** Used for built-in method references. */
-
-  var arrayProto = Array.prototype;
-  /** Built-in value references. */
-
-  var splice = arrayProto.splice;
-  /**
-   * Removes `key` and its value from the list cache.
-   *
-   * @private
-   * @name delete
-   * @memberOf ListCache
-   * @param {string} key The key of the value to remove.
-   * @returns {boolean} Returns `true` if the entry was removed, else `false`.
-   */
-
-  function listCacheDelete(key) {
-    var data = this.__data__,
-        index = assocIndexOf(data, key);
-
-    if (index < 0) {
-      return false;
-    }
-
-    var lastIndex = data.length - 1;
-
-    if (index == lastIndex) {
-      data.pop();
-    } else {
-      splice.call(data, index, 1);
-    }
-
-    --this.size;
-    return true;
-  }
-
-  /**
-   * Gets the list cache value for `key`.
-   *
-   * @private
-   * @name get
-   * @memberOf ListCache
-   * @param {string} key The key of the value to get.
-   * @returns {*} Returns the entry value.
-   */
-
-  function listCacheGet(key) {
-    var data = this.__data__,
-        index = assocIndexOf(data, key);
-    return index < 0 ? undefined : data[index][1];
-  }
-
-  /**
-   * Checks if a list cache value for `key` exists.
-   *
-   * @private
-   * @name has
-   * @memberOf ListCache
-   * @param {string} key The key of the entry to check.
-   * @returns {boolean} Returns `true` if an entry for `key` exists, else `false`.
-   */
-
-  function listCacheHas(key) {
-    return assocIndexOf(this.__data__, key) > -1;
-  }
-
-  /**
-   * Sets the list cache `key` to `value`.
-   *
-   * @private
-   * @name set
-   * @memberOf ListCache
-   * @param {string} key The key of the value to set.
-   * @param {*} value The value to set.
-   * @returns {Object} Returns the list cache instance.
-   */
-
-  function listCacheSet(key, value) {
-    var data = this.__data__,
-        index = assocIndexOf(data, key);
-
-    if (index < 0) {
-      ++this.size;
-      data.push([key, value]);
-    } else {
-      data[index][1] = value;
-    }
-
-    return this;
-  }
-
-  /**
-   * Creates an list cache object.
-   *
-   * @private
-   * @constructor
-   * @param {Array} [entries] The key-value pairs to cache.
-   */
-
-  function ListCache(entries) {
-    var index = -1,
-        length = entries == null ? 0 : entries.length;
-    this.clear();
-
-    while (++index < length) {
-      var entry = entries[index];
-      this.set(entry[0], entry[1]);
-    }
-  } // Add methods to `ListCache`.
-
-
-  ListCache.prototype.clear = listCacheClear;
-  ListCache.prototype['delete'] = listCacheDelete;
-  ListCache.prototype.get = listCacheGet;
-  ListCache.prototype.has = listCacheHas;
-  ListCache.prototype.set = listCacheSet;
-
-  /**
-   * Removes all key-value entries from the stack.
-   *
-   * @private
-   * @name clear
-   * @memberOf Stack
-   */
-
-  function stackClear() {
-    this.__data__ = new ListCache();
-    this.size = 0;
-  }
-
-  /**
-   * Removes `key` and its value from the stack.
-   *
-   * @private
-   * @name delete
-   * @memberOf Stack
-   * @param {string} key The key of the value to remove.
-   * @returns {boolean} Returns `true` if the entry was removed, else `false`.
-   */
-  function stackDelete(key) {
-    var data = this.__data__,
-        result = data['delete'](key);
-    this.size = data.size;
-    return result;
-  }
-
-  /**
-   * Gets the stack value for `key`.
-   *
-   * @private
-   * @name get
-   * @memberOf Stack
-   * @param {string} key The key of the value to get.
-   * @returns {*} Returns the entry value.
-   */
-  function stackGet(key) {
-    return this.__data__.get(key);
-  }
-
-  /**
-   * Checks if a stack value for `key` exists.
-   *
-   * @private
-   * @name has
-   * @memberOf Stack
-   * @param {string} key The key of the entry to check.
-   * @returns {boolean} Returns `true` if an entry for `key` exists, else `false`.
-   */
-  function stackHas(key) {
-    return this.__data__.has(key);
-  }
-
-  /* Built-in method references that are verified to be native. */
-
-  var Map = getNative$1(root$1, 'Map');
-
-  /* Built-in method references that are verified to be native. */
-
-  var nativeCreate = getNative$1(Object, 'create');
-
-  /**
-   * Removes all key-value entries from the hash.
-   *
-   * @private
-   * @name clear
-   * @memberOf Hash
-   */
-
-  function hashClear() {
-    this.__data__ = nativeCreate ? nativeCreate(null) : {};
-    this.size = 0;
-  }
-
-  /**
-   * Removes `key` and its value from the hash.
-   *
-   * @private
-   * @name delete
-   * @memberOf Hash
-   * @param {Object} hash The hash to modify.
-   * @param {string} key The key of the value to remove.
-   * @returns {boolean} Returns `true` if the entry was removed, else `false`.
-   */
-  function hashDelete(key) {
-    var result = this.has(key) && delete this.__data__[key];
-    this.size -= result ? 1 : 0;
-    return result;
-  }
-
-  /** Used to stand-in for `undefined` hash values. */
-
-  var HASH_UNDEFINED = '__lodash_hash_undefined__';
-  /** Used for built-in method references. */
-
-  var objectProto$i = Object.prototype;
-  /** Used to check objects for own properties. */
-
-  var hasOwnProperty$e = objectProto$i.hasOwnProperty;
-  /**
-   * Gets the hash value for `key`.
-   *
-   * @private
-   * @name get
-   * @memberOf Hash
-   * @param {string} key The key of the value to get.
-   * @returns {*} Returns the entry value.
-   */
-
-  function hashGet(key) {
-    var data = this.__data__;
-
-    if (nativeCreate) {
-      var result = data[key];
-      return result === HASH_UNDEFINED ? undefined : result;
-    }
-
-    return hasOwnProperty$e.call(data, key) ? data[key] : undefined;
-  }
-
-  /** Used for built-in method references. */
-
-  var objectProto$j = Object.prototype;
-  /** Used to check objects for own properties. */
-
-  var hasOwnProperty$f = objectProto$j.hasOwnProperty;
-  /**
-   * Checks if a hash value for `key` exists.
-   *
-   * @private
-   * @name has
-   * @memberOf Hash
-   * @param {string} key The key of the entry to check.
-   * @returns {boolean} Returns `true` if an entry for `key` exists, else `false`.
-   */
-
-  function hashHas(key) {
-    var data = this.__data__;
-    return nativeCreate ? data[key] !== undefined : hasOwnProperty$f.call(data, key);
-  }
-
-  /** Used to stand-in for `undefined` hash values. */
-
-  var HASH_UNDEFINED$1 = '__lodash_hash_undefined__';
-  /**
-   * Sets the hash `key` to `value`.
-   *
-   * @private
-   * @name set
-   * @memberOf Hash
-   * @param {string} key The key of the value to set.
-   * @param {*} value The value to set.
-   * @returns {Object} Returns the hash instance.
-   */
-
-  function hashSet(key, value) {
-    var data = this.__data__;
-    this.size += this.has(key) ? 0 : 1;
-    data[key] = nativeCreate && value === undefined ? HASH_UNDEFINED$1 : value;
-    return this;
-  }
-
-  /**
-   * Creates a hash object.
-   *
-   * @private
-   * @constructor
-   * @param {Array} [entries] The key-value pairs to cache.
-   */
-
-  function Hash(entries) {
-    var index = -1,
-        length = entries == null ? 0 : entries.length;
-    this.clear();
-
-    while (++index < length) {
-      var entry = entries[index];
-      this.set(entry[0], entry[1]);
-    }
-  } // Add methods to `Hash`.
-
-
-  Hash.prototype.clear = hashClear;
-  Hash.prototype['delete'] = hashDelete;
-  Hash.prototype.get = hashGet;
-  Hash.prototype.has = hashHas;
-  Hash.prototype.set = hashSet;
-
-  /**
-   * Removes all key-value entries from the map.
-   *
-   * @private
-   * @name clear
-   * @memberOf MapCache
-   */
-
-  function mapCacheClear() {
-    this.size = 0;
-    this.__data__ = {
-      'hash': new Hash(),
-      'map': new (Map || ListCache)(),
-      'string': new Hash()
-    };
-  }
-
-  /**
-   * Checks if `value` is suitable for use as unique object key.
-   *
-   * @private
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is suitable, else `false`.
-   */
-  function isKeyable(value) {
-    var type = _typeof(value);
-
-    return type == 'string' || type == 'number' || type == 'symbol' || type == 'boolean' ? value !== '__proto__' : value === null;
-  }
-
-  /**
-   * Gets the data for `map`.
-   *
-   * @private
-   * @param {Object} map The map to query.
-   * @param {string} key The reference key.
-   * @returns {*} Returns the map data.
-   */
-
-  function getMapData(map, key) {
-    var data = map.__data__;
-    return isKeyable(key) ? data[typeof key == 'string' ? 'string' : 'hash'] : data.map;
-  }
-
-  /**
-   * Removes `key` and its value from the map.
-   *
-   * @private
-   * @name delete
-   * @memberOf MapCache
-   * @param {string} key The key of the value to remove.
-   * @returns {boolean} Returns `true` if the entry was removed, else `false`.
-   */
-
-  function mapCacheDelete(key) {
-    var result = getMapData(this, key)['delete'](key);
-    this.size -= result ? 1 : 0;
-    return result;
-  }
-
-  /**
-   * Gets the map value for `key`.
-   *
-   * @private
-   * @name get
-   * @memberOf MapCache
-   * @param {string} key The key of the value to get.
-   * @returns {*} Returns the entry value.
-   */
-
-  function mapCacheGet(key) {
-    return getMapData(this, key).get(key);
-  }
-
-  /**
-   * Checks if a map value for `key` exists.
-   *
-   * @private
-   * @name has
-   * @memberOf MapCache
-   * @param {string} key The key of the entry to check.
-   * @returns {boolean} Returns `true` if an entry for `key` exists, else `false`.
-   */
-
-  function mapCacheHas(key) {
-    return getMapData(this, key).has(key);
-  }
-
-  /**
-   * Sets the map `key` to `value`.
-   *
-   * @private
-   * @name set
-   * @memberOf MapCache
-   * @param {string} key The key of the value to set.
-   * @param {*} value The value to set.
-   * @returns {Object} Returns the map cache instance.
-   */
-
-  function mapCacheSet(key, value) {
-    var data = getMapData(this, key),
-        size = data.size;
-    data.set(key, value);
-    this.size += data.size == size ? 0 : 1;
-    return this;
-  }
-
-  /**
-   * Creates a map cache object to store key-value pairs.
-   *
-   * @private
-   * @constructor
-   * @param {Array} [entries] The key-value pairs to cache.
-   */
-
-  function MapCache(entries) {
-    var index = -1,
-        length = entries == null ? 0 : entries.length;
-    this.clear();
-
-    while (++index < length) {
-      var entry = entries[index];
-      this.set(entry[0], entry[1]);
-    }
-  } // Add methods to `MapCache`.
-
-
-  MapCache.prototype.clear = mapCacheClear;
-  MapCache.prototype['delete'] = mapCacheDelete;
-  MapCache.prototype.get = mapCacheGet;
-  MapCache.prototype.has = mapCacheHas;
-  MapCache.prototype.set = mapCacheSet;
-
-  /** Used as the size to enable large array optimizations. */
-
-  var LARGE_ARRAY_SIZE = 200;
-  /**
-   * Sets the stack `key` to `value`.
-   *
-   * @private
-   * @name set
-   * @memberOf Stack
-   * @param {string} key The key of the value to set.
-   * @param {*} value The value to set.
-   * @returns {Object} Returns the stack cache instance.
-   */
-
-  function stackSet(key, value) {
-    var data = this.__data__;
-
-    if (data instanceof ListCache) {
-      var pairs = data.__data__;
-
-      if (!Map || pairs.length < LARGE_ARRAY_SIZE - 1) {
-        pairs.push([key, value]);
-        this.size = ++data.size;
-        return this;
-      }
-
-      data = this.__data__ = new MapCache(pairs);
-    }
-
-    data.set(key, value);
-    this.size = data.size;
-    return this;
-  }
-
-  /**
-   * Creates a stack cache object to store key-value pairs.
-   *
-   * @private
-   * @constructor
-   * @param {Array} [entries] The key-value pairs to cache.
-   */
-
-  function Stack(entries) {
-    var data = this.__data__ = new ListCache(entries);
-    this.size = data.size;
-  } // Add methods to `Stack`.
-
-
-  Stack.prototype.clear = stackClear;
-  Stack.prototype['delete'] = stackDelete;
-  Stack.prototype.get = stackGet;
-  Stack.prototype.has = stackHas;
-  Stack.prototype.set = stackSet;
-
-  /** Used to stand-in for `undefined` hash values. */
-  var HASH_UNDEFINED$2 = '__lodash_hash_undefined__';
-  /**
-   * Adds `value` to the array cache.
-   *
-   * @private
-   * @name add
-   * @memberOf SetCache
-   * @alias push
-   * @param {*} value The value to cache.
-   * @returns {Object} Returns the cache instance.
-   */
-
-  function setCacheAdd(value) {
-    this.__data__.set(value, HASH_UNDEFINED$2);
-
-    return this;
-  }
-
-  /**
-   * Checks if `value` is in the array cache.
-   *
-   * @private
-   * @name has
-   * @memberOf SetCache
-   * @param {*} value The value to search for.
-   * @returns {number} Returns `true` if `value` is found, else `false`.
-   */
-  function setCacheHas(value) {
-    return this.__data__.has(value);
-  }
-
-  /**
-   *
-   * Creates an array cache object to store unique values.
-   *
-   * @private
-   * @constructor
-   * @param {Array} [values] The values to cache.
-   */
-
-  function SetCache(values) {
-    var index = -1,
-        length = values == null ? 0 : values.length;
-    this.__data__ = new MapCache();
-
-    while (++index < length) {
-      this.add(values[index]);
-    }
-  } // Add methods to `SetCache`.
-
-
-  SetCache.prototype.add = SetCache.prototype.push = setCacheAdd;
-  SetCache.prototype.has = setCacheHas;
-
-  /**
-   * A specialized version of `_.some` for arrays without support for iteratee
-   * shorthands.
-   *
-   * @private
-   * @param {Array} [array] The array to iterate over.
-   * @param {Function} predicate The function invoked per iteration.
-   * @returns {boolean} Returns `true` if any element passes the predicate check,
-   *  else `false`.
-   */
-  function arraySome(array, predicate) {
-    var index = -1,
-        length = array == null ? 0 : array.length;
-
-    while (++index < length) {
-      if (predicate(array[index], index, array)) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  /**
-   * Checks if a `cache` value for `key` exists.
-   *
-   * @private
-   * @param {Object} cache The cache to query.
-   * @param {string} key The key of the entry to check.
-   * @returns {boolean} Returns `true` if an entry for `key` exists, else `false`.
-   */
-  function cacheHas(cache, key) {
-    return cache.has(key);
-  }
-
-  /** Used to compose bitmasks for value comparisons. */
-
-  var COMPARE_PARTIAL_FLAG = 1,
-      COMPARE_UNORDERED_FLAG = 2;
-  /**
-   * A specialized version of `baseIsEqualDeep` for arrays with support for
-   * partial deep comparisons.
-   *
-   * @private
-   * @param {Array} array The array to compare.
-   * @param {Array} other The other array to compare.
-   * @param {number} bitmask The bitmask flags. See `baseIsEqual` for more details.
-   * @param {Function} customizer The function to customize comparisons.
-   * @param {Function} equalFunc The function to determine equivalents of values.
-   * @param {Object} stack Tracks traversed `array` and `other` objects.
-   * @returns {boolean} Returns `true` if the arrays are equivalent, else `false`.
-   */
-
-  function equalArrays(array, other, bitmask, customizer, equalFunc, stack) {
-    var isPartial = bitmask & COMPARE_PARTIAL_FLAG,
-        arrLength = array.length,
-        othLength = other.length;
-
-    if (arrLength != othLength && !(isPartial && othLength > arrLength)) {
-      return false;
-    } // Assume cyclic values are equal.
-
-
-    var stacked = stack.get(array);
-
-    if (stacked && stack.get(other)) {
-      return stacked == other;
-    }
-
-    var index = -1,
-        result = true,
-        seen = bitmask & COMPARE_UNORDERED_FLAG ? new SetCache() : undefined;
-    stack.set(array, other);
-    stack.set(other, array); // Ignore non-index properties.
-
-    while (++index < arrLength) {
-      var arrValue = array[index],
-          othValue = other[index];
-
-      if (customizer) {
-        var compared = isPartial ? customizer(othValue, arrValue, index, other, array, stack) : customizer(arrValue, othValue, index, array, other, stack);
-      }
-
-      if (compared !== undefined) {
-        if (compared) {
-          continue;
-        }
-
-        result = false;
-        break;
-      } // Recursively compare arrays (susceptible to call stack limits).
-
-
-      if (seen) {
-        if (!arraySome(other, function (othValue, othIndex) {
-          if (!cacheHas(seen, othIndex) && (arrValue === othValue || equalFunc(arrValue, othValue, bitmask, customizer, stack))) {
-            return seen.push(othIndex);
-          }
-        })) {
-          result = false;
-          break;
-        }
-      } else if (!(arrValue === othValue || equalFunc(arrValue, othValue, bitmask, customizer, stack))) {
-        result = false;
-        break;
-      }
-    }
-
-    stack['delete'](array);
-    stack['delete'](other);
-    return result;
-  }
-
-  /** Built-in value references. */
-
-  var Uint8Array = root$1.Uint8Array;
-
-  /**
-   * Converts `map` to its key-value pairs.
-   *
-   * @private
-   * @param {Object} map The map to convert.
-   * @returns {Array} Returns the key-value pairs.
-   */
-  function mapToArray(map) {
-    var index = -1,
-        result = Array(map.size);
-    map.forEach(function (value, key) {
-      result[++index] = [key, value];
-    });
-    return result;
-  }
-
-  /**
-   * Converts `set` to an array of its values.
-   *
-   * @private
-   * @param {Object} set The set to convert.
-   * @returns {Array} Returns the values.
-   */
-  function setToArray(set) {
-    var index = -1,
-        result = Array(set.size);
-    set.forEach(function (value) {
-      result[++index] = value;
-    });
-    return result;
-  }
-
-  /** Used to compose bitmasks for value comparisons. */
-
-  var COMPARE_PARTIAL_FLAG$1 = 1,
-      COMPARE_UNORDERED_FLAG$1 = 2;
-  /** `Object#toString` result references. */
-
-  var boolTag$2 = '[object Boolean]',
-      dateTag$2 = '[object Date]',
-      errorTag$2 = '[object Error]',
-      mapTag$2 = '[object Map]',
-      numberTag$2 = '[object Number]',
-      regexpTag$2 = '[object RegExp]',
-      setTag$2 = '[object Set]',
-      stringTag$2 = '[object String]',
-      symbolTag$1 = '[object Symbol]';
-  var arrayBufferTag$2 = '[object ArrayBuffer]',
-      dataViewTag$2 = '[object DataView]';
-  /** Used to convert symbols to primitives and strings. */
-
-  var symbolProto = _Symbol$1 ? _Symbol$1.prototype : undefined,
-      symbolValueOf = symbolProto ? symbolProto.valueOf : undefined;
-  /**
-   * A specialized version of `baseIsEqualDeep` for comparing objects of
-   * the same `toStringTag`.
-   *
-   * **Note:** This function only supports comparing values with tags of
-   * `Boolean`, `Date`, `Error`, `Number`, `RegExp`, or `String`.
-   *
-   * @private
-   * @param {Object} object The object to compare.
-   * @param {Object} other The other object to compare.
-   * @param {string} tag The `toStringTag` of the objects to compare.
-   * @param {number} bitmask The bitmask flags. See `baseIsEqual` for more details.
-   * @param {Function} customizer The function to customize comparisons.
-   * @param {Function} equalFunc The function to determine equivalents of values.
-   * @param {Object} stack Tracks traversed `object` and `other` objects.
-   * @returns {boolean} Returns `true` if the objects are equivalent, else `false`.
-   */
-
-  function equalByTag(object, other, tag, bitmask, customizer, equalFunc, stack) {
-    switch (tag) {
-      case dataViewTag$2:
-        if (object.byteLength != other.byteLength || object.byteOffset != other.byteOffset) {
-          return false;
-        }
-
-        object = object.buffer;
-        other = other.buffer;
-
-      case arrayBufferTag$2:
-        if (object.byteLength != other.byteLength || !equalFunc(new Uint8Array(object), new Uint8Array(other))) {
-          return false;
-        }
-
-        return true;
-
-      case boolTag$2:
-      case dateTag$2:
-      case numberTag$2:
-        // Coerce booleans to `1` or `0` and dates to milliseconds.
-        // Invalid dates are coerced to `NaN`.
-        return eq$1(+object, +other);
-
-      case errorTag$2:
-        return object.name == other.name && object.message == other.message;
-
-      case regexpTag$2:
-      case stringTag$2:
-        // Coerce regexes to strings and treat strings, primitives and objects,
-        // as equal. See http://www.ecma-international.org/ecma-262/7.0/#sec-regexp.prototype.tostring
-        // for more details.
-        return object == other + '';
-
-      case mapTag$2:
-        var convert = mapToArray;
-
-      case setTag$2:
-        var isPartial = bitmask & COMPARE_PARTIAL_FLAG$1;
-        convert || (convert = setToArray);
-
-        if (object.size != other.size && !isPartial) {
-          return false;
-        } // Assume cyclic values are equal.
-
-
-        var stacked = stack.get(object);
-
-        if (stacked) {
-          return stacked == other;
-        }
-
-        bitmask |= COMPARE_UNORDERED_FLAG$1; // Recursively compare objects (susceptible to call stack limits).
-
-        stack.set(object, other);
-        var result = equalArrays(convert(object), convert(other), bitmask, customizer, equalFunc, stack);
-        stack['delete'](object);
-        return result;
-
-      case symbolTag$1:
-        if (symbolValueOf) {
-          return symbolValueOf.call(object) == symbolValueOf.call(other);
-        }
-
-    }
-
-    return false;
-  }
-
-  /**
-   * Appends the elements of `values` to `array`.
-   *
-   * @private
-   * @param {Array} array The array to modify.
-   * @param {Array} values The values to append.
-   * @returns {Array} Returns `array`.
-   */
-  function arrayPush(array, values) {
-    var index = -1,
-        length = values.length,
-        offset = array.length;
-
-    while (++index < length) {
-      array[offset + index] = values[index];
-    }
-
-    return array;
-  }
-
-  /**
-   * The base implementation of `getAllKeys` and `getAllKeysIn` which uses
-   * `keysFunc` and `symbolsFunc` to get the enumerable property names and
-   * symbols of `object`.
-   *
-   * @private
-   * @param {Object} object The object to query.
-   * @param {Function} keysFunc The function to get the keys of `object`.
-   * @param {Function} symbolsFunc The function to get the symbols of `object`.
-   * @returns {Array} Returns the array of property names and symbols.
-   */
-
-  function baseGetAllKeys(object, keysFunc, symbolsFunc) {
-    var result = keysFunc(object);
-    return isArray$1(object) ? result : arrayPush(result, symbolsFunc(object));
-  }
-
-  /**
-   * A specialized version of `_.filter` for arrays without support for
-   * iteratee shorthands.
-   *
-   * @private
-   * @param {Array} [array] The array to iterate over.
-   * @param {Function} predicate The function invoked per iteration.
-   * @returns {Array} Returns the new filtered array.
-   */
-  function arrayFilter(array, predicate) {
-    var index = -1,
-        length = array == null ? 0 : array.length,
-        resIndex = 0,
-        result = [];
-
-    while (++index < length) {
-      var value = array[index];
-
-      if (predicate(value, index, array)) {
-        result[resIndex++] = value;
-      }
-    }
-
-    return result;
-  }
-
-  /**
-   * This method returns a new empty array.
-   *
-   * @static
-   * @memberOf _
-   * @since 4.13.0
-   * @category Util
-   * @returns {Array} Returns the new empty array.
-   * @example
-   *
-   * var arrays = _.times(2, _.stubArray);
-   *
-   * console.log(arrays);
-   * // => [[], []]
-   *
-   * console.log(arrays[0] === arrays[1]);
-   * // => false
-   */
-  function stubArray() {
-    return [];
-  }
-
-  /** Used for built-in method references. */
-
-  var objectProto$k = Object.prototype;
-  /** Built-in value references. */
-
-  var propertyIsEnumerable$2 = objectProto$k.propertyIsEnumerable;
-  /* Built-in method references for those with the same name as other `lodash` methods. */
-
-  var nativeGetSymbols = Object.getOwnPropertySymbols;
-  /**
-   * Creates an array of the own enumerable symbols of `object`.
-   *
-   * @private
-   * @param {Object} object The object to query.
-   * @returns {Array} Returns the array of symbols.
-   */
-
-  var getSymbols = !nativeGetSymbols ? stubArray : function (object) {
-    if (object == null) {
-      return [];
-    }
-
-    object = Object(object);
-    return arrayFilter(nativeGetSymbols(object), function (symbol) {
-      return propertyIsEnumerable$2.call(object, symbol);
-    });
-  };
-
-  /**
-   * Creates an array of own enumerable property names and symbols of `object`.
-   *
-   * @private
-   * @param {Object} object The object to query.
-   * @returns {Array} Returns the array of property names and symbols.
-   */
-
-  function getAllKeys(object) {
-    return baseGetAllKeys(object, keys$1, getSymbols);
-  }
-
-  /** Used to compose bitmasks for value comparisons. */
-
-  var COMPARE_PARTIAL_FLAG$2 = 1;
-  /** Used for built-in method references. */
-
-  var objectProto$l = Object.prototype;
-  /** Used to check objects for own properties. */
-
-  var hasOwnProperty$g = objectProto$l.hasOwnProperty;
-  /**
-   * A specialized version of `baseIsEqualDeep` for objects with support for
-   * partial deep comparisons.
-   *
-   * @private
-   * @param {Object} object The object to compare.
-   * @param {Object} other The other object to compare.
-   * @param {number} bitmask The bitmask flags. See `baseIsEqual` for more details.
-   * @param {Function} customizer The function to customize comparisons.
-   * @param {Function} equalFunc The function to determine equivalents of values.
-   * @param {Object} stack Tracks traversed `object` and `other` objects.
-   * @returns {boolean} Returns `true` if the objects are equivalent, else `false`.
-   */
-
-  function equalObjects(object, other, bitmask, customizer, equalFunc, stack) {
-    var isPartial = bitmask & COMPARE_PARTIAL_FLAG$2,
-        objProps = getAllKeys(object),
-        objLength = objProps.length,
-        othProps = getAllKeys(other),
-        othLength = othProps.length;
-
-    if (objLength != othLength && !isPartial) {
-      return false;
-    }
-
-    var index = objLength;
-
-    while (index--) {
-      var key = objProps[index];
-
-      if (!(isPartial ? key in other : hasOwnProperty$g.call(other, key))) {
-        return false;
-      }
-    } // Assume cyclic values are equal.
-
-
-    var stacked = stack.get(object);
-
-    if (stacked && stack.get(other)) {
-      return stacked == other;
-    }
-
-    var result = true;
-    stack.set(object, other);
-    stack.set(other, object);
-    var skipCtor = isPartial;
-
-    while (++index < objLength) {
-      key = objProps[index];
-      var objValue = object[key],
-          othValue = other[key];
-
-      if (customizer) {
-        var compared = isPartial ? customizer(othValue, objValue, key, other, object, stack) : customizer(objValue, othValue, key, object, other, stack);
-      } // Recursively compare objects (susceptible to call stack limits).
-
-
-      if (!(compared === undefined ? objValue === othValue || equalFunc(objValue, othValue, bitmask, customizer, stack) : compared)) {
-        result = false;
-        break;
-      }
-
-      skipCtor || (skipCtor = key == 'constructor');
-    }
-
-    if (result && !skipCtor) {
-      var objCtor = object.constructor,
-          othCtor = other.constructor; // Non `Object` object instances with different constructors are not equal.
-
-      if (objCtor != othCtor && 'constructor' in object && 'constructor' in other && !(typeof objCtor == 'function' && objCtor instanceof objCtor && typeof othCtor == 'function' && othCtor instanceof othCtor)) {
-        result = false;
-      }
-    }
-
-    stack['delete'](object);
-    stack['delete'](other);
-    return result;
-  }
-
-  /* Built-in method references that are verified to be native. */
-
-  var DataView = getNative$1(root$1, 'DataView');
-
-  /* Built-in method references that are verified to be native. */
-
-  var Promise = getNative$1(root$1, 'Promise');
-
-  /* Built-in method references that are verified to be native. */
-
-  var Set = getNative$1(root$1, 'Set');
-
-  /* Built-in method references that are verified to be native. */
-
-  var WeakMap = getNative$1(root$1, 'WeakMap');
-
-  /** `Object#toString` result references. */
-
-  var mapTag$3 = '[object Map]',
-      objectTag$2 = '[object Object]',
-      promiseTag = '[object Promise]',
-      setTag$3 = '[object Set]',
-      weakMapTag$2 = '[object WeakMap]';
-  var dataViewTag$3 = '[object DataView]';
-  /** Used to detect maps, sets, and weakmaps. */
-
-  var dataViewCtorString = toSource$1(DataView),
-      mapCtorString = toSource$1(Map),
-      promiseCtorString = toSource$1(Promise),
-      setCtorString = toSource$1(Set),
-      weakMapCtorString = toSource$1(WeakMap);
-  /**
-   * Gets the `toStringTag` of `value`.
-   *
-   * @private
-   * @param {*} value The value to query.
-   * @returns {string} Returns the `toStringTag`.
-   */
-
-  var getTag = baseGetTag$1; // Fallback for data views, maps, sets, and weak maps in IE 11 and promises in Node.js < 6.
-
-  if (DataView && getTag(new DataView(new ArrayBuffer(1))) != dataViewTag$3 || Map && getTag(new Map()) != mapTag$3 || Promise && getTag(Promise.resolve()) != promiseTag || Set && getTag(new Set()) != setTag$3 || WeakMap && getTag(new WeakMap()) != weakMapTag$2) {
-    getTag = function getTag(value) {
-      var result = baseGetTag$1(value),
-          Ctor = result == objectTag$2 ? value.constructor : undefined,
-          ctorString = Ctor ? toSource$1(Ctor) : '';
-
-      if (ctorString) {
-        switch (ctorString) {
-          case dataViewCtorString:
-            return dataViewTag$3;
-
-          case mapCtorString:
-            return mapTag$3;
-
-          case promiseCtorString:
-            return promiseTag;
-
-          case setCtorString:
-            return setTag$3;
-
-          case weakMapCtorString:
-            return weakMapTag$2;
-        }
-      }
-
-      return result;
-    };
-  }
-
-  var getTag$1 = getTag;
-
-  /** Used to compose bitmasks for value comparisons. */
-
-  var COMPARE_PARTIAL_FLAG$3 = 1;
-  /** `Object#toString` result references. */
-
-  var argsTag$4 = '[object Arguments]',
-      arrayTag$2 = '[object Array]',
-      objectTag$3 = '[object Object]';
-  /** Used for built-in method references. */
-
-  var objectProto$m = Object.prototype;
-  /** Used to check objects for own properties. */
-
-  var hasOwnProperty$h = objectProto$m.hasOwnProperty;
-  /**
-   * A specialized version of `baseIsEqual` for arrays and objects which performs
-   * deep comparisons and tracks traversed objects enabling objects with circular
-   * references to be compared.
-   *
-   * @private
-   * @param {Object} object The object to compare.
-   * @param {Object} other The other object to compare.
-   * @param {number} bitmask The bitmask flags. See `baseIsEqual` for more details.
-   * @param {Function} customizer The function to customize comparisons.
-   * @param {Function} equalFunc The function to determine equivalents of values.
-   * @param {Object} [stack] Tracks traversed `object` and `other` objects.
-   * @returns {boolean} Returns `true` if the objects are equivalent, else `false`.
-   */
-
-  function baseIsEqualDeep(object, other, bitmask, customizer, equalFunc, stack) {
-    var objIsArr = isArray$1(object),
-        othIsArr = isArray$1(other),
-        objTag = objIsArr ? arrayTag$2 : getTag$1(object),
-        othTag = othIsArr ? arrayTag$2 : getTag$1(other);
-    objTag = objTag == argsTag$4 ? objectTag$3 : objTag;
-    othTag = othTag == argsTag$4 ? objectTag$3 : othTag;
-    var objIsObj = objTag == objectTag$3,
-        othIsObj = othTag == objectTag$3,
-        isSameTag = objTag == othTag;
-
-    if (isSameTag && isBuffer$1(object)) {
-      if (!isBuffer$1(other)) {
-        return false;
-      }
-
-      objIsArr = true;
-      objIsObj = false;
-    }
-
-    if (isSameTag && !objIsObj) {
-      stack || (stack = new Stack());
-      return objIsArr || isTypedArray$1(object) ? equalArrays(object, other, bitmask, customizer, equalFunc, stack) : equalByTag(object, other, objTag, bitmask, customizer, equalFunc, stack);
-    }
-
-    if (!(bitmask & COMPARE_PARTIAL_FLAG$3)) {
-      var objIsWrapped = objIsObj && hasOwnProperty$h.call(object, '__wrapped__'),
-          othIsWrapped = othIsObj && hasOwnProperty$h.call(other, '__wrapped__');
-
-      if (objIsWrapped || othIsWrapped) {
-        var objUnwrapped = objIsWrapped ? object.value() : object,
-            othUnwrapped = othIsWrapped ? other.value() : other;
-        stack || (stack = new Stack());
-        return equalFunc(objUnwrapped, othUnwrapped, bitmask, customizer, stack);
-      }
-    }
-
-    if (!isSameTag) {
-      return false;
-    }
-
-    stack || (stack = new Stack());
-    return equalObjects(object, other, bitmask, customizer, equalFunc, stack);
-  }
-
-  /**
-   * The base implementation of `_.isEqual` which supports partial comparisons
-   * and tracks traversed objects.
-   *
-   * @private
-   * @param {*} value The value to compare.
-   * @param {*} other The other value to compare.
-   * @param {boolean} bitmask The bitmask flags.
-   *  1 - Unordered comparison
-   *  2 - Partial comparison
-   * @param {Function} [customizer] The function to customize comparisons.
-   * @param {Object} [stack] Tracks traversed `value` and `other` objects.
-   * @returns {boolean} Returns `true` if the values are equivalent, else `false`.
-   */
-
-  function baseIsEqual(value, other, bitmask, customizer, stack) {
-    if (value === other) {
-      return true;
-    }
-
-    if (value == null || other == null || !isObjectLike$1(value) && !isObjectLike$1(other)) {
-      return value !== value && other !== other;
-    }
-
-    return baseIsEqualDeep(value, other, bitmask, customizer, baseIsEqual, stack);
-  }
-
-  /** Used to compose bitmasks for value comparisons. */
-
-  var COMPARE_PARTIAL_FLAG$4 = 1,
-      COMPARE_UNORDERED_FLAG$2 = 2;
-  /**
-   * The base implementation of `_.isMatch` without support for iteratee shorthands.
-   *
-   * @private
-   * @param {Object} object The object to inspect.
-   * @param {Object} source The object of property values to match.
-   * @param {Array} matchData The property names, values, and compare flags to match.
-   * @param {Function} [customizer] The function to customize comparisons.
-   * @returns {boolean} Returns `true` if `object` is a match, else `false`.
-   */
-
-  function baseIsMatch(object, source, matchData, customizer) {
-    var index = matchData.length,
-        length = index,
-        noCustomizer = !customizer;
-
-    if (object == null) {
-      return !length;
-    }
-
-    object = Object(object);
-
-    while (index--) {
-      var data = matchData[index];
-
-      if (noCustomizer && data[2] ? data[1] !== object[data[0]] : !(data[0] in object)) {
-        return false;
-      }
-    }
-
-    while (++index < length) {
-      data = matchData[index];
-      var key = data[0],
-          objValue = object[key],
-          srcValue = data[1];
-
-      if (noCustomizer && data[2]) {
-        if (objValue === undefined && !(key in object)) {
-          return false;
-        }
-      } else {
-        var stack = new Stack();
-
-        if (customizer) {
-          var result = customizer(objValue, srcValue, key, object, source, stack);
-        }
-
-        if (!(result === undefined ? baseIsEqual(srcValue, objValue, COMPARE_PARTIAL_FLAG$4 | COMPARE_UNORDERED_FLAG$2, customizer, stack) : result)) {
-          return false;
-        }
-      }
-    }
-
-    return true;
-  }
-
-  /**
-   * Checks if `value` is suitable for strict equality comparisons, i.e. `===`.
-   *
-   * @private
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` if suitable for strict
-   *  equality comparisons, else `false`.
-   */
-
-  function isStrictComparable(value) {
-    return value === value && !isObject$1(value);
-  }
-
-  /**
-   * Gets the property names, values, and compare flags of `object`.
-   *
-   * @private
-   * @param {Object} object The object to query.
-   * @returns {Array} Returns the match data of `object`.
-   */
-
-  function getMatchData(object) {
-    var result = keys$1(object),
-        length = result.length;
-
-    while (length--) {
-      var key = result[length],
-          value = object[key];
-      result[length] = [key, value, isStrictComparable(value)];
-    }
-
-    return result;
-  }
-
-  /**
-   * A specialized version of `matchesProperty` for source values suitable
-   * for strict equality comparisons, i.e. `===`.
-   *
-   * @private
-   * @param {string} key The key of the property to get.
-   * @param {*} srcValue The value to match.
-   * @returns {Function} Returns the new spec function.
-   */
-  function matchesStrictComparable(key, srcValue) {
-    return function (object) {
-      if (object == null) {
-        return false;
-      }
-
-      return object[key] === srcValue && (srcValue !== undefined || key in Object(object));
-    };
-  }
-
-  /**
-   * The base implementation of `_.matches` which doesn't clone `source`.
-   *
-   * @private
-   * @param {Object} source The object of property values to match.
-   * @returns {Function} Returns the new spec function.
-   */
-
-  function baseMatches(source) {
-    var matchData = getMatchData(source);
-
-    if (matchData.length == 1 && matchData[0][2]) {
-      return matchesStrictComparable(matchData[0][0], matchData[0][1]);
-    }
-
-    return function (object) {
-      return object === source || baseIsMatch(object, source, matchData);
-    };
-  }
-
-  /** `Object#toString` result references. */
-
-  var symbolTag$2 = '[object Symbol]';
-  /**
-   * Checks if `value` is classified as a `Symbol` primitive or object.
-   *
-   * @static
-   * @memberOf _
-   * @since 4.0.0
-   * @category Lang
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is a symbol, else `false`.
-   * @example
-   *
-   * _.isSymbol(Symbol.iterator);
-   * // => true
-   *
-   * _.isSymbol('abc');
-   * // => false
-   */
-
-  function isSymbol$1(value) {
-    return _typeof(value) == 'symbol' || isObjectLike$1(value) && baseGetTag$1(value) == symbolTag$2;
-  }
-
-  /** Used to match property names within property paths. */
-
-  var reIsDeepProp = /\.|\[(?:[^[\]]*|(["'])(?:(?!\1)[^\\]|\\.)*?\1)\]/,
-      reIsPlainProp = /^\w*$/;
-  /**
-   * Checks if `value` is a property name and not a property path.
-   *
-   * @private
-   * @param {*} value The value to check.
-   * @param {Object} [object] The object to query keys on.
-   * @returns {boolean} Returns `true` if `value` is a property name, else `false`.
-   */
-
-  function isKey(value, object) {
-    if (isArray$1(value)) {
-      return false;
-    }
-
-    var type = _typeof(value);
-
-    if (type == 'number' || type == 'symbol' || type == 'boolean' || value == null || isSymbol$1(value)) {
-      return true;
-    }
-
-    return reIsPlainProp.test(value) || !reIsDeepProp.test(value) || object != null && value in Object(object);
-  }
-
-  /** Error message constants. */
-
-  var FUNC_ERROR_TEXT = 'Expected a function';
-  /**
-   * Creates a function that memoizes the result of `func`. If `resolver` is
-   * provided, it determines the cache key for storing the result based on the
-   * arguments provided to the memoized function. By default, the first argument
-   * provided to the memoized function is used as the map cache key. The `func`
-   * is invoked with the `this` binding of the memoized function.
-   *
-   * **Note:** The cache is exposed as the `cache` property on the memoized
-   * function. Its creation may be customized by replacing the `_.memoize.Cache`
-   * constructor with one whose instances implement the
-   * [`Map`](http://ecma-international.org/ecma-262/7.0/#sec-properties-of-the-map-prototype-object)
-   * method interface of `clear`, `delete`, `get`, `has`, and `set`.
-   *
-   * @static
-   * @memberOf _
-   * @since 0.1.0
-   * @category Function
-   * @param {Function} func The function to have its output memoized.
-   * @param {Function} [resolver] The function to resolve the cache key.
-   * @returns {Function} Returns the new memoized function.
-   * @example
-   *
-   * var object = { 'a': 1, 'b': 2 };
-   * var other = { 'c': 3, 'd': 4 };
-   *
-   * var values = _.memoize(_.values);
-   * values(object);
-   * // => [1, 2]
-   *
-   * values(other);
-   * // => [3, 4]
-   *
-   * object.a = 2;
-   * values(object);
-   * // => [1, 2]
-   *
-   * // Modify the result cache.
-   * values.cache.set(object, ['a', 'b']);
-   * values(object);
-   * // => ['a', 'b']
-   *
-   * // Replace `_.memoize.Cache`.
-   * _.memoize.Cache = WeakMap;
-   */
-
-  function memoize(func, resolver) {
-    if (typeof func != 'function' || resolver != null && typeof resolver != 'function') {
-      throw new TypeError(FUNC_ERROR_TEXT);
-    }
-
-    var memoized = function memoized() {
-      var args = arguments,
-          key = resolver ? resolver.apply(this, args) : args[0],
-          cache = memoized.cache;
-
-      if (cache.has(key)) {
-        return cache.get(key);
-      }
-
-      var result = func.apply(this, args);
-      memoized.cache = cache.set(key, result) || cache;
-      return result;
-    };
-
-    memoized.cache = new (memoize.Cache || MapCache)();
-    return memoized;
-  } // Expose `MapCache`.
-
-
-  memoize.Cache = MapCache;
-
-  /** Used as the maximum memoize cache size. */
-
-  var MAX_MEMOIZE_SIZE = 500;
-  /**
-   * A specialized version of `_.memoize` which clears the memoized function's
-   * cache when it exceeds `MAX_MEMOIZE_SIZE`.
-   *
-   * @private
-   * @param {Function} func The function to have its output memoized.
-   * @returns {Function} Returns the new memoized function.
-   */
-
-  function memoizeCapped(func) {
-    var result = memoize(func, function (key) {
-      if (cache.size === MAX_MEMOIZE_SIZE) {
-        cache.clear();
-      }
-
-      return key;
-    });
-    var cache = result.cache;
-    return result;
-  }
-
-  /** Used to match property names within property paths. */
-
-  var rePropName = /[^.[\]]+|\[(?:(-?\d+(?:\.\d+)?)|(["'])((?:(?!\2)[^\\]|\\.)*?)\2)\]|(?=(?:\.|\[\])(?:\.|\[\]|$))/g;
-  /** Used to match backslashes in property paths. */
-
-  var reEscapeChar = /\\(\\)?/g;
-  /**
-   * Converts `string` to a property path array.
-   *
-   * @private
-   * @param {string} string The string to convert.
-   * @returns {Array} Returns the property path array.
-   */
-
-  var stringToPath = memoizeCapped(function (string) {
-    var result = [];
-
-    if (string.charCodeAt(0) === 46
-    /* . */
-    ) {
-        result.push('');
-      }
-
-    string.replace(rePropName, function (match, number, quote, subString) {
-      result.push(quote ? subString.replace(reEscapeChar, '$1') : number || match);
-    });
-    return result;
-  });
-
-  /**
-   * A specialized version of `_.map` for arrays without support for iteratee
-   * shorthands.
-   *
-   * @private
-   * @param {Array} [array] The array to iterate over.
-   * @param {Function} iteratee The function invoked per iteration.
-   * @returns {Array} Returns the new mapped array.
-   */
-  function arrayMap(array, iteratee) {
-    var index = -1,
-        length = array == null ? 0 : array.length,
-        result = Array(length);
-
-    while (++index < length) {
-      result[index] = iteratee(array[index], index, array);
-    }
-
-    return result;
-  }
-
-  /** Used as references for various `Number` constants. */
-
-  var INFINITY$1 = 1 / 0;
-  /** Used to convert symbols to primitives and strings. */
-
-  var symbolProto$1 = _Symbol$1 ? _Symbol$1.prototype : undefined,
-      symbolToString = symbolProto$1 ? symbolProto$1.toString : undefined;
-  /**
-   * The base implementation of `_.toString` which doesn't convert nullish
-   * values to empty strings.
-   *
-   * @private
-   * @param {*} value The value to process.
-   * @returns {string} Returns the string.
-   */
-
-  function baseToString(value) {
-    // Exit early for strings to avoid a performance hit in some environments.
-    if (typeof value == 'string') {
-      return value;
-    }
-
-    if (isArray$1(value)) {
-      // Recursively convert values (susceptible to call stack limits).
-      return arrayMap(value, baseToString) + '';
-    }
-
-    if (isSymbol$1(value)) {
-      return symbolToString ? symbolToString.call(value) : '';
-    }
-
-    var result = value + '';
-    return result == '0' && 1 / value == -INFINITY$1 ? '-0' : result;
-  }
-
-  /**
-   * Converts `value` to a string. An empty string is returned for `null`
-   * and `undefined` values. The sign of `-0` is preserved.
-   *
-   * @static
-   * @memberOf _
-   * @since 4.0.0
-   * @category Lang
-   * @param {*} value The value to convert.
-   * @returns {string} Returns the converted string.
-   * @example
-   *
-   * _.toString(null);
-   * // => ''
-   *
-   * _.toString(-0);
-   * // => '-0'
-   *
-   * _.toString([1, 2, 3]);
-   * // => '1,2,3'
-   */
-
-  function toString(value) {
-    return value == null ? '' : baseToString(value);
-  }
-
-  /**
-   * Casts `value` to a path array if it's not one.
-   *
-   * @private
-   * @param {*} value The value to inspect.
-   * @param {Object} [object] The object to query keys on.
-   * @returns {Array} Returns the cast property path array.
-   */
-
-  function castPath(value, object) {
-    if (isArray$1(value)) {
-      return value;
-    }
-
-    return isKey(value, object) ? [value] : stringToPath(toString(value));
-  }
-
-  /** Used as references for various `Number` constants. */
-
-  var INFINITY$2 = 1 / 0;
-  /**
-   * Converts `value` to a string key if it's not a string or symbol.
-   *
-   * @private
-   * @param {*} value The value to inspect.
-   * @returns {string|symbol} Returns the key.
-   */
-
-  function toKey(value) {
-    if (typeof value == 'string' || isSymbol$1(value)) {
-      return value;
-    }
-
-    var result = value + '';
-    return result == '0' && 1 / value == -INFINITY$2 ? '-0' : result;
-  }
-
-  /**
-   * The base implementation of `_.get` without support for default values.
-   *
-   * @private
-   * @param {Object} object The object to query.
-   * @param {Array|string} path The path of the property to get.
-   * @returns {*} Returns the resolved value.
-   */
-
-  function baseGet(object, path) {
-    path = castPath(path, object);
-    var index = 0,
-        length = path.length;
-
-    while (object != null && index < length) {
-      object = object[toKey(path[index++])];
-    }
-
-    return index && index == length ? object : undefined;
-  }
-
-  /**
-   * Gets the value at `path` of `object`. If the resolved value is
-   * `undefined`, the `defaultValue` is returned in its place.
-   *
-   * @static
-   * @memberOf _
-   * @since 3.7.0
-   * @category Object
-   * @param {Object} object The object to query.
-   * @param {Array|string} path The path of the property to get.
-   * @param {*} [defaultValue] The value returned for `undefined` resolved values.
-   * @returns {*} Returns the resolved value.
-   * @example
-   *
-   * var object = { 'a': [{ 'b': { 'c': 3 } }] };
-   *
-   * _.get(object, 'a[0].b.c');
-   * // => 3
-   *
-   * _.get(object, ['a', '0', 'b', 'c']);
-   * // => 3
-   *
-   * _.get(object, 'a.b.c', 'default');
-   * // => 'default'
-   */
-
-  function get(object, path, defaultValue) {
-    var result = object == null ? undefined : baseGet(object, path);
-    return result === undefined ? defaultValue : result;
-  }
-
-  /**
-   * The base implementation of `_.hasIn` without support for deep paths.
-   *
-   * @private
-   * @param {Object} [object] The object to query.
-   * @param {Array|string} key The key to check.
-   * @returns {boolean} Returns `true` if `key` exists, else `false`.
-   */
-  function baseHasIn(object, key) {
-    return object != null && key in Object(object);
-  }
-
-  /**
-   * Checks if `path` exists on `object`.
-   *
-   * @private
-   * @param {Object} object The object to query.
-   * @param {Array|string} path The path to check.
-   * @param {Function} hasFunc The function to check properties.
-   * @returns {boolean} Returns `true` if `path` exists, else `false`.
-   */
-
-  function hasPath(object, path, hasFunc) {
-    path = castPath(path, object);
-    var index = -1,
-        length = path.length,
-        result = false;
-
-    while (++index < length) {
-      var key = toKey(path[index]);
-
-      if (!(result = object != null && hasFunc(object, key))) {
-        break;
-      }
-
-      object = object[key];
-    }
-
-    if (result || ++index != length) {
-      return result;
-    }
-
-    length = object == null ? 0 : object.length;
-    return !!length && isLength$1(length) && isIndex$1(key, length) && (isArray$1(object) || isArguments$1(object));
-  }
-
-  /**
-   * Checks if `path` is a direct or inherited property of `object`.
-   *
-   * @static
-   * @memberOf _
-   * @since 4.0.0
-   * @category Object
-   * @param {Object} object The object to query.
-   * @param {Array|string} path The path to check.
-   * @returns {boolean} Returns `true` if `path` exists, else `false`.
-   * @example
-   *
-   * var object = _.create({ 'a': _.create({ 'b': 2 }) });
-   *
-   * _.hasIn(object, 'a');
-   * // => true
-   *
-   * _.hasIn(object, 'a.b');
-   * // => true
-   *
-   * _.hasIn(object, ['a', 'b']);
-   * // => true
-   *
-   * _.hasIn(object, 'b');
-   * // => false
-   */
-
-  function hasIn(object, path) {
-    return object != null && hasPath(object, path, baseHasIn);
-  }
-
-  /** Used to compose bitmasks for value comparisons. */
-
-  var COMPARE_PARTIAL_FLAG$5 = 1,
-      COMPARE_UNORDERED_FLAG$3 = 2;
-  /**
-   * The base implementation of `_.matchesProperty` which doesn't clone `srcValue`.
-   *
-   * @private
-   * @param {string} path The path of the property to get.
-   * @param {*} srcValue The value to match.
-   * @returns {Function} Returns the new spec function.
-   */
-
-  function baseMatchesProperty(path, srcValue) {
-    if (isKey(path) && isStrictComparable(srcValue)) {
-      return matchesStrictComparable(toKey(path), srcValue);
-    }
-
-    return function (object) {
-      var objValue = get(object, path);
-      return objValue === undefined && objValue === srcValue ? hasIn(object, path) : baseIsEqual(srcValue, objValue, COMPARE_PARTIAL_FLAG$5 | COMPARE_UNORDERED_FLAG$3);
-    };
-  }
-
-  /**
-   * The base implementation of `_.property` without support for deep paths.
-   *
-   * @private
-   * @param {string} key The key of the property to get.
-   * @returns {Function} Returns the new accessor function.
-   */
-  function baseProperty(key) {
-    return function (object) {
-      return object == null ? undefined : object[key];
-    };
-  }
-
-  /**
-   * A specialized version of `baseProperty` which supports deep paths.
-   *
-   * @private
-   * @param {Array|string} path The path of the property to get.
-   * @returns {Function} Returns the new accessor function.
-   */
-
-  function basePropertyDeep(path) {
-    return function (object) {
-      return baseGet(object, path);
-    };
-  }
-
-  /**
-   * Creates a function that returns the value at `path` of a given object.
-   *
-   * @static
-   * @memberOf _
-   * @since 2.4.0
-   * @category Util
-   * @param {Array|string} path The path of the property to get.
-   * @returns {Function} Returns the new accessor function.
-   * @example
-   *
-   * var objects = [
-   *   { 'a': { 'b': 2 } },
-   *   { 'a': { 'b': 1 } }
-   * ];
-   *
-   * _.map(objects, _.property('a.b'));
-   * // => [2, 1]
-   *
-   * _.map(_.sortBy(objects, _.property(['a', 'b'])), 'a.b');
-   * // => [1, 2]
-   */
-
-  function property(path) {
-    return isKey(path) ? baseProperty(toKey(path)) : basePropertyDeep(path);
-  }
-
-  /**
-   * The base implementation of `_.iteratee`.
-   *
-   * @private
-   * @param {*} [value=_.identity] The value to convert to an iteratee.
-   * @returns {Function} Returns the iteratee.
-   */
-
-  function baseIteratee(value) {
-    // Don't store the `typeof` result in a variable to avoid a JIT bug in Safari 9.
-    // See https://bugs.webkit.org/show_bug.cgi?id=156034 for more details.
-    if (typeof value == 'function') {
-      return value;
-    }
-
-    if (value == null) {
-      return identity$1;
-    }
-
-    if (_typeof(value) == 'object') {
-      return isArray$1(value) ? baseMatchesProperty(value[0], value[1]) : baseMatches(value);
-    }
-
-    return property(value);
-  }
-
-  /** Used as references for various `Number` constants. */
-
-  var NAN$1 = 0 / 0;
-  /** Used to match leading and trailing whitespace. */
-
-  var reTrim$1 = /^\s+|\s+$/g;
-  /** Used to detect bad signed hexadecimal string values. */
-
-  var reIsBadHex$1 = /^[-+]0x[0-9a-f]+$/i;
-  /** Used to detect binary string values. */
-
-  var reIsBinary$1 = /^0b[01]+$/i;
-  /** Used to detect octal string values. */
-
-  var reIsOctal$1 = /^0o[0-7]+$/i;
-  /** Built-in method references without a dependency on `root`. */
-
-  var freeParseInt$1 = parseInt;
-  /**
-   * Converts `value` to a number.
-   *
-   * @static
-   * @memberOf _
-   * @since 4.0.0
-   * @category Lang
-   * @param {*} value The value to process.
-   * @returns {number} Returns the number.
-   * @example
-   *
-   * _.toNumber(3.2);
-   * // => 3.2
-   *
-   * _.toNumber(Number.MIN_VALUE);
-   * // => 5e-324
-   *
-   * _.toNumber(Infinity);
-   * // => Infinity
-   *
-   * _.toNumber('3.2');
-   * // => 3.2
-   */
-
-  function toNumber$1(value) {
-    if (typeof value == 'number') {
-      return value;
-    }
-
-    if (isSymbol$1(value)) {
-      return NAN$1;
-    }
-
-    if (isObject$1(value)) {
-      var other = typeof value.valueOf == 'function' ? value.valueOf() : value;
-      value = isObject$1(other) ? other + '' : other;
-    }
-
-    if (typeof value != 'string') {
-      return value === 0 ? value : +value;
-    }
-
-    value = value.replace(reTrim$1, '');
-    var isBinary = reIsBinary$1.test(value);
-    return isBinary || reIsOctal$1.test(value) ? freeParseInt$1(value.slice(2), isBinary ? 2 : 8) : reIsBadHex$1.test(value) ? NAN$1 : +value;
-  }
-
-  /** Used as references for various `Number` constants. */
-
-  var INFINITY$3 = 1 / 0,
-      MAX_INTEGER$1 = 1.7976931348623157e+308;
-  /**
-   * Converts `value` to a finite number.
-   *
-   * @static
-   * @memberOf _
-   * @since 4.12.0
-   * @category Lang
-   * @param {*} value The value to convert.
-   * @returns {number} Returns the converted number.
-   * @example
-   *
-   * _.toFinite(3.2);
-   * // => 3.2
-   *
-   * _.toFinite(Number.MIN_VALUE);
-   * // => 5e-324
-   *
-   * _.toFinite(Infinity);
-   * // => 1.7976931348623157e+308
-   *
-   * _.toFinite('3.2');
-   * // => 3.2
-   */
-
-  function toFinite$1(value) {
-    if (!value) {
-      return value === 0 ? value : 0;
-    }
-
-    value = toNumber$1(value);
-
-    if (value === INFINITY$3 || value === -INFINITY$3) {
-      var sign = value < 0 ? -1 : 1;
-      return sign * MAX_INTEGER$1;
-    }
-
-    return value === value ? value : 0;
-  }
-
-  /**
-   * Converts `value` to an integer.
-   *
-   * **Note:** This method is loosely based on
-   * [`ToInteger`](http://www.ecma-international.org/ecma-262/7.0/#sec-tointeger).
-   *
-   * @static
-   * @memberOf _
-   * @since 4.0.0
-   * @category Lang
-   * @param {*} value The value to convert.
-   * @returns {number} Returns the converted integer.
-   * @example
-   *
-   * _.toInteger(3.2);
-   * // => 3
-   *
-   * _.toInteger(Number.MIN_VALUE);
-   * // => 0
-   *
-   * _.toInteger(Infinity);
-   * // => 1.7976931348623157e+308
-   *
-   * _.toInteger('3.2');
-   * // => 3
-   */
-
-  function toInteger(value) {
-    var result = toFinite$1(value),
-        remainder = result % 1;
-    return result === result ? remainder ? result - remainder : result : 0;
-  }
-
-  /* Built-in method references for those with the same name as other `lodash` methods. */
-
-  var nativeMax$3 = Math.max;
-  /**
-   * This method is like `_.find` except that it returns the index of the first
-   * element `predicate` returns truthy for instead of the element itself.
-   *
-   * @static
-   * @memberOf _
-   * @since 1.1.0
-   * @category Array
-   * @param {Array} array The array to inspect.
-   * @param {Function} [predicate=_.identity] The function invoked per iteration.
-   * @param {number} [fromIndex=0] The index to search from.
-   * @returns {number} Returns the index of the found element, else `-1`.
-   * @example
-   *
-   * var users = [
-   *   { 'user': 'barney',  'active': false },
-   *   { 'user': 'fred',    'active': false },
-   *   { 'user': 'pebbles', 'active': true }
-   * ];
-   *
-   * _.findIndex(users, function(o) { return o.user == 'barney'; });
-   * // => 0
-   *
-   * // The `_.matches` iteratee shorthand.
-   * _.findIndex(users, { 'user': 'fred', 'active': false });
-   * // => 1
-   *
-   * // The `_.matchesProperty` iteratee shorthand.
-   * _.findIndex(users, ['active', false]);
-   * // => 0
-   *
-   * // The `_.property` iteratee shorthand.
-   * _.findIndex(users, 'active');
-   * // => 2
-   */
-
-  function findIndex(array, predicate, fromIndex) {
-    var length = array == null ? 0 : array.length;
-
-    if (!length) {
-      return -1;
-    }
-
-    var index = fromIndex == null ? 0 : toInteger(fromIndex);
-
-    if (index < 0) {
-      index = nativeMax$3(length + index, 0);
-    }
-
-    return baseFindIndex(array, baseIteratee(predicate), index);
-  }
-
-  var play = (function (gridPosition) {
-    return function (deck) {
-      return function (modifier) {
-        return function (device) {
-          return {
-            bindings: {
-              playIndicator: {
-                type: 'control',
-                target: deck.play_indicator,
-                update: function update(_ref, _ref2) {
-                  var value = _ref.value;
-                  var bindings = _ref2.bindings;
-
-                  if (value) {
-                    bindings.play.button.sendColor(device.colors.hi_red);
-                  } else if (!value) {
-                    bindings.play.button.sendColor(device.colors.black);
-                  }
-                }
-              },
-              play: {
-                type: 'button',
-                target: gridPosition,
-                attack: function attack() {
-                  modes(modifier.getState(), function () {
-                    return deck.play.setValue(Number(!deck.play.getValue()));
-                  }, function () {
-                    return deck.start_play.setValue(1);
-                  }, function () {
-                    return deck.start_stop.setValue(1);
-                  });
-                }
-              }
-            }
-          };
-        };
-      };
-    };
-  });
-
-  var sync = (function (gridPosition) {
-    return function (deck) {
-      return function (modifier) {
-        return function (device) {
-          return {
-            bindings: {
-              sync: {
-                type: 'button',
-                target: gridPosition,
-                attack: function attack(message, _ref) {
-                  var bindings = _ref.bindings;
-                  modes(modifier.getState(), function () {
-                    if (bindings.syncMode.getValue()) {
-                      deck.sync_enabled.setValue(0);
-                    } else {
-                      deck.sync_enabled.setValue(1);
-                    }
-                  }, function () {
-                    if (bindings.syncMode.getValue() === 2) {
-                      deck.sync_leader.setValue(0);
-                    } else {
-                      deck.sync_leader.setValue(1);
-                    }
-                  });
-                }
-              },
-              syncMode: {
-                type: 'control',
-                target: deck.sync_mode,
-                update: function update(_ref2, _ref3) {
-                  var value = _ref2.value;
-                  var bindings = _ref3.bindings;
-
-                  if (value === 0) {
-                    bindings.sync.button.sendColor(device.colors.black);
-                  } else if (value === 1) {
-                    bindings.sync.button.sendColor(device.colors.hi_orange);
-                  } else if (value === 2) {
-                    bindings.sync.button.sendColor(device.colors.hi_red);
-                  }
-                }
-              }
-            }
-          };
-        };
-      };
-    };
-  });
-
-  var nudge = (function (gridPosition) {
-    return function (deck) {
-      return function (modifier) {
-        return function (device) {
-          var rateEpsilon = 1e-3;
-
-          var getDirection = function getDirection(rate) {
-            if (rate < -rateEpsilon) {
-              return 'up';
-            } else if (rate > rateEpsilon) {
-              return 'down';
-            } else {
-              return '';
-            }
-          };
-
-          var onNudgeMidi = function onNudgeMidi(dir) {
-            return function (modifier) {
-              return retainAttackMode(modifier, function (mode, _ref, _ref2) {
-                var value = _ref.value;
-                var bindings = _ref2.bindings,
-                    state = _ref2.state;
-
-                if (value) {
-                  state[dir] = true;
-
-                  if (state.down && state.up) {
-                    deck.rate.setValue(0);
-                  } else {
-                    modes(mode, function () {
-                      bindings[dir].button.sendColor(device.colors.hi_yellow); // TODO: remove unsafe cast once flow supports https://github.com/facebook/flow/issues/3637
-
-                      deck["rate_temp_".concat(dir)].setValue(1);
-                    }, function () {
-                      bindings[dir].button.sendColor(device.colors.hi_red); // TODO: remove unsafe cast once flow supports https://github.com/facebook/flow/issues/3637
-
-                      deck["rate_perm_".concat(dir)].setValue(1);
-                    }, function () {
-                      bindings[dir].button.sendColor(device.colors.lo_yellow); // TODO: remove unsafe cast once flow supports https://github.com/facebook/flow/issues/3637
-
-                      deck["rate_temp_".concat(dir, "_small")].setValue(1);
-                    }, function () {
-                      bindings[dir].button.sendColor(device.colors.lo_red); // TODO: remove unsafe cast once flow supports https://github.com/facebook/flow/issues/3637
-
-                      deck["rate_perm_".concat(dir, "_small")].setValue(1);
-                    });
-                  }
-                } else {
-                  state[dir] = false;
-
-                  if (getDirection(bindings.rate.getValue()) === dir) {
-                    bindings[dir].button.sendColor(device.colors.lo_orange);
-                  } else {
-                    bindings[dir].button.sendColor(device.colors.black);
-                  }
-
-                  modes(mode, // TODO: remove unsafe cast once flow supports https://github.com/facebook/flow/issues/3637
-                  function () {
-                    return deck["rate_temp_".concat(dir)].setValue(0);
-                  }, undefined, // TODO: remove unsafe cast once flow supports https://github.com/facebook/flow/issues/3637
-                  function () {
-                    return deck["rate_temp_".concat(dir, "_small")].setValue(0);
-                  });
-                }
-              });
-            };
-          };
-
-          var onRate = function onRate(_ref3, _ref4) {
-            var value = _ref3.value;
-            var state = _ref4.state,
-                bindings = _ref4.bindings;
-            var up = device.colors.black;
-            var down = device.colors.black;
-            var rate = getDirection(value);
-
-            if (rate === 'down') {
-              down = device.colors.lo_orange;
-            } else if (rate === 'up') {
-              up = device.colors.lo_orange;
-            }
-
-            if (!state.down) {
-              bindings.down.button.sendColor(down);
-            }
-
-            if (!state.up) {
-              bindings.up.button.sendColor(up);
-            }
-          };
-
-          return {
-            bindings: {
-              down: {
-                type: 'button',
-                target: gridPosition,
-                midi: onNudgeMidi('down')(modifier)
-              },
-              up: {
-                type: 'button',
-                target: [gridPosition[0] + 1, gridPosition[1]],
-                midi: onNudgeMidi('up')(modifier)
-              },
-              rate: {
-                type: 'control',
-                target: deck.rate,
-                update: onRate
-              }
-            },
-            state: {
-              up: false,
-              down: false
-            }
-          };
-        };
-      };
-    };
-  });
-
-  var cue = (function (gridPosition) {
-    return function (deck) {
-      return function (modifier) {
-        return function (device) {
-          return {
-            bindings: {
-              cue: {
-                type: 'button',
-                target: gridPosition,
-                midi: retainAttackMode(modifier, function (mode, _ref) {
-                  var value = _ref.value;
-                  modes(mode, function () {
-                    if (value) {
-                      deck.cue_default.setValue(1);
-                    } else {
-                      deck.cue_default.setValue(0);
-                    }
-                  }, function () {
-                    return value && deck.cue_set.setValue(1);
-                  });
-                })
-              },
-              cueIndicator: {
-                type: 'control',
-                target: deck.cue_indicator,
-                update: function update(_ref2, _ref3) {
-                  var value = _ref2.value;
-                  var bindings = _ref3.bindings;
-
-                  if (value) {
-                    bindings.cue.button.sendColor(device.colors.hi_red);
-                  } else if (!value) {
-                    bindings.cue.button.sendColor(device.colors.black);
-                  }
-                }
-              }
-            }
-          };
-        };
-      };
-    };
-  });
-
-  function _createSuper$6(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct$6()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
-
-  function _isNativeReflectConstruct$6() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
-
-  var Bpm = /*#__PURE__*/function (_EventEmitter) {
-    _inherits(Bpm, _EventEmitter);
-
-    var _super = _createSuper$6(Bpm);
-
-    function Bpm(max) {
-      var _this;
-
-      _classCallCheck$1(this, Bpm);
-
-      _this = _super.call(this);
-
-      _defineProperty$1(_assertThisInitialized(_this), "tapTime", void 0);
-
-      _defineProperty$1(_assertThisInitialized(_this), "taps", void 0);
-
-      _defineProperty$1(_assertThisInitialized(_this), "max", void 0);
-
-      if (max == null) {
-        max = 8;
-      }
-
-      _this.tapTime = 0;
-      _this.taps = [];
-      _this.max = max;
-      return _this;
-    }
-
-    _createClass$1(Bpm, [{
-      key: "reset",
-      value: function reset() {
-        this.taps = [];
-      }
-    }, {
-      key: "tap",
-      value: function tap() {
-        var now = Date.now();
-        var tapDelta = now - this.tapTime;
-        this.tapTime = now;
-
-        if (tapDelta > 2000) {
-          // reset if longer than two seconds between taps
-          this.taps = [];
-        } else {
-          this.taps.push(60000 / tapDelta);
-          if (this.taps.length > this.max) this.taps.shift(); // Keep the last n samples for averaging
-
-          var sum = 0;
-          this.taps.forEach(function (v) {
-            sum += v;
-          });
-          var avg = sum / this.taps.length;
-          this.emit('tap', avg);
-        }
-      }
-    }]);
-
-    return Bpm;
-  }(eventemitter3);
-
-  var tap = (function (gridPosition) {
-    return function (deck) {
-      return function (modifier) {
-        return function (device) {
-          var tempoBpm = new Bpm();
-          tempoBpm.on('tap', function (avg) {
-            deck.bpm.setValue(avg);
-          });
-          return {
-            bindings: {
-              tap: {
-                type: 'button',
-                target: gridPosition,
-                attack: function attack() {
-                  modes(modifier.getState(), function () {
-                    tempoBpm.tap();
-                  }, function () {
-                    deck.bpm_tap.setValue(1);
-                  }, function () {
-                    deck.beats_translate_curpos.setValue(1);
-                  }, function () {
-                    deck.beats_translate_match_alignment.setValue(1);
-                  });
-                }
-              },
-              beat: {
-                type: 'control',
-                target: deck.beat_active,
-                update: function update(_ref, _ref2) {
-                  var value = _ref.value;
-                  var bindings = _ref2.bindings;
-
-                  if (value) {
-                    bindings.tap.button.sendColor(device.colors.hi_red);
-                  } else {
-                    bindings.tap.button.sendColor(device.colors.black);
-                  }
-                }
-              }
-            }
-          };
-        };
-      };
-    };
-  });
-
-  var grid = (function (gridPosition) {
-    return function (deck) {
-      return function (modifier) {
-        return function (device) {
-          var onGrid = function onGrid(dir) {
-            return function (_ref, _ref2) {
-              var value = _ref.value;
-              var bindings = _ref2.bindings,
-                  state = _ref2.state;
-
-              if (!value) {
-                bindings[dir].button.sendColor(device.colors.black);
-              } else {
-                modes(modifier.getState(), function () {
-                  bindings[dir].button.sendColor(device.colors.hi_yellow);
-                  state[dir].normal.setValue(1);
-                }, function () {
-                  bindings[dir].button.sendColor(device.colors.hi_amber);
-                  state[dir].ctrl.setValue(1);
-                });
-              }
-            };
-          };
-
-          return {
-            bindings: {
-              back: {
-                type: 'button',
-                target: gridPosition,
-                midi: onGrid('back')
-              },
-              forth: {
-                type: 'button',
-                target: [gridPosition[0] + 1, gridPosition[1]],
-                midi: onGrid('forth')
-              }
-            },
-            state: {
-              back: {
-                normal: deck.beats_translate_earlier,
-                ctrl: deck.beats_adjust_slower
-              },
-              forth: {
-                normal: deck.beats_translate_later,
-                ctrl: deck.beats_adjust_faster
-              }
-            }
-          };
-        };
-      };
-    };
-  });
-
-  var pfl = (function (gridPosition) {
-    return function (deck) {
-      return function (modifier) {
-        return function (device) {
-          return function (device) {
-            return {
-              bindings: {
-                pfl: {
-                  type: 'control',
-                  target: deck.pfl,
-                  update: function update(_ref, _ref2) {
-                    var value = _ref.value;
-                    var bindings = _ref2.bindings;
-                    return value ? bindings.button.button.sendColor(device.colors.hi_green) : bindings.button.button.sendColor(device.colors.black);
-                  }
-                },
-                button: {
-                  type: 'button',
-                  target: gridPosition,
-                  attack: function attack(message, _ref3) {
-                    var bindings = _ref3.bindings;
-                    return modes(modifier.getState(), function () {
-                      return bindings.pfl.setValue(Number(!bindings.pfl.getValue()));
-                    });
-                  }
-                }
-              }
-            };
-          };
-        };
-      };
-    };
-  });
-
-  var quantize = (function (gridPosition) {
-    return function (deck) {
-      return function (modifier) {
-        return function (device) {
-          return {
-            bindings: {
-              quantize: {
-                type: 'control',
-                target: deck.quantize,
-                update: function update(_ref, _ref2) {
-                  var value = _ref.value;
-                  var bindings = _ref2.bindings;
-                  return value ? bindings.button.button.sendColor(device.colors.hi_orange) : bindings.button.button.sendColor(device.colors.black);
-                }
-              },
-              button: {
-                type: 'button',
-                target: gridPosition,
-                attack: function attack(message, _ref3) {
-                  var bindings = _ref3.bindings;
-                  return modes(modifier.getState(), function () {
-                    return bindings.quantize.setValue(Number(!bindings.quantize.getValue()));
-                  });
-                }
-              }
-            }
-          };
-        };
-      };
-    };
-  });
-
-  var keyshift = (function (shifts, d) {
-    return function (gridPosition) {
-      return function (deck) {
-        return function (modifier) {
-          return function (device) {
-            var bindings = {};
-
-            var temporaryChange = function temporaryChange(i, value, bindings, state) {
-              if (value) {
-                var base = state.on === -1 ? deck.key.getValue() : state.base;
-
-                if (state.on !== -1) {
-                  bindings[state.on].button.sendColor(device.colors["lo_".concat(state.color[state.set])]);
-                }
-
-                bindings[i].button.sendColor(device.colors["hi_".concat(state.color[state.set])]);
-                deck.key.setValue((base + shifts[i][state.set]) % 12 + 12);
-                state.on = i;
-                state.base = base;
-              } else {
-                if (state.on === i) {
-                  bindings[i].button.sendColor(device.colors["lo_".concat(state.color[state.set])]);
-                  deck.key.setValue(state.base);
-                  state.on = -1;
-                }
-              }
-            };
-
-            var onMidi = function onMidi(i) {
-              return function (modifier) {
-                return retainAttackMode(modifier, function (mode, _ref, _ref2) {
-                  var value = _ref.value;
-                  var bindings = _ref2.bindings,
-                      state = _ref2.state;
-                  modes(mode, function () {
-                    return temporaryChange(i, value, bindings, state);
-                  }, function () {
-                    if (value) {
-                      if (state.set === 1) {
-                        state.set = 0;
-
-                        for (var _i = 0; _i < shifts.length; ++_i) {
-                          bindings[_i].button.sendColor(device.colors["lo_".concat(state.color[state.set])]);
-                        }
-                      }
-                    }
-                  }, function () {
-                    if (value) {
-                      if (state.set === 0) {
-                        state.set = 1;
-
-                        for (var _i2 = 0; _i2 < shifts.length; ++_i2) {
-                          bindings[_i2].button.sendColor(device.colors["lo_".concat(state.color[state.set])]);
-                        }
-                      }
-                    }
-                  });
-                });
-              };
-            };
-
-            shifts.forEach(function (s, i) {
-              var dx = i % d;
-              var dy = ~~(i / d);
-              var position = [gridPosition[0] + dx, gridPosition[1] + dy];
-              bindings[i] = {
-                type: 'button',
-                target: position,
-                midi: onMidi(i)(modifier),
-                mount: function mount(_, _ref3) {
-                  var bindings = _ref3.bindings,
-                      state = _ref3.state;
-                  bindings[i].button.sendColor(device.colors["lo_".concat(state.color[state.set])]);
-                }
-              };
-            });
-            return {
-              bindings: bindings,
-              state: {
-                on: -1,
-                base: null,
-                set: 0,
-                color: ['green', 'red']
-              }
-            };
-          };
-        };
-      };
-    };
-  });
-
-  /* Built-in method references for those with the same name as other `lodash` methods. */
-  var nativeCeil$1 = Math.ceil,
-      nativeMax$4 = Math.max;
-  /**
-   * The base implementation of `_.range` and `_.rangeRight` which doesn't
-   * coerce arguments.
-   *
-   * @private
-   * @param {number} start The start of the range.
-   * @param {number} end The end of the range.
-   * @param {number} step The value to increment or decrement by.
-   * @param {boolean} [fromRight] Specify iterating from right to left.
-   * @returns {Array} Returns the range of numbers.
-   */
-
-  function baseRange$1(start, end, step, fromRight) {
-    var index = -1,
-        length = nativeMax$4(nativeCeil$1((end - start) / (step || 1)), 0),
-        result = Array(length);
-
-    while (length--) {
-      result[fromRight ? length : ++index] = start;
-      start += step;
-    }
-
-    return result;
-  }
-
-  /**
-   * Creates a `_.range` or `_.rangeRight` function.
-   *
-   * @private
-   * @param {boolean} [fromRight] Specify iterating from right to left.
-   * @returns {Function} Returns the new range function.
-   */
-
-  function createRange$1(fromRight) {
-    return function (start, end, step) {
-      if (step && typeof step != 'number' && isIterateeCall$1(start, end, step)) {
-        end = step = undefined;
-      } // Ensure the sign of `-0` is preserved.
-
-
-      start = toFinite$1(start);
-
-      if (end === undefined) {
-        end = start;
-        start = 0;
-      } else {
-        end = toFinite$1(end);
-      }
-
-      step = step === undefined ? start < end ? 1 : -1 : toFinite$1(step);
-      return baseRange$1(start, end, step, fromRight);
-    };
-  }
-
-  /**
-   * Creates an array of numbers (positive and/or negative) progressing from
-   * `start` up to, but not including, `end`. A step of `-1` is used if a negative
-   * `start` is specified without an `end` or `step`. If `end` is not specified,
-   * it's set to `start` with `start` then set to `0`.
-   *
-   * **Note:** JavaScript follows the IEEE-754 standard for resolving
-   * floating-point values which can produce unexpected results.
-   *
-   * @static
-   * @since 0.1.0
-   * @memberOf _
-   * @category Util
-   * @param {number} [start=0] The start of the range.
-   * @param {number} end The end of the range.
-   * @param {number} [step=1] The value to increment or decrement by.
-   * @returns {Array} Returns the range of numbers.
-   * @see _.inRange, _.rangeRight
-   * @example
-   *
-   * _.range(4);
-   * // => [0, 1, 2, 3]
-   *
-   * _.range(-4);
-   * // => [0, -1, -2, -3]
-   *
-   * _.range(1, 5);
-   * // => [1, 2, 3, 4]
-   *
-   * _.range(0, 20, 5);
-   * // => [0, 5, 10, 15]
-   *
-   * _.range(0, -4, -1);
-   * // => [0, -1, -2, -3]
-   *
-   * _.range(1, 4, 0);
-   * // => [1, 1, 1]
-   *
-   * _.range(0);
-   * // => []
-   */
-
-  var range$1 = createRange$1();
-
-  var hotcue = (function (n, d) {
-    var s = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 0;
-    return function (gridPosition) {
-      return function (deck) {
-        return function (modifier) {
-          return function (device) {
-            var onHotcueMidi = function onHotcueMidi(i) {
-              return function (_ref, _ref2) {
-                var value = _ref.value;
-                var bindings = _ref2.bindings;
-                modes(modifier.getState(), function () {
-                  if (value) {
-                    deck.hotcues[1 + i + s].activate.setValue(1);
-                  } else {
-                    deck.hotcues[1 + i + s].activate.setValue(0);
-                  }
-                }, function () {
-                  if (value) {
-                    if (bindings["".concat(i, ".enabled")].getValue()) {
-                      deck.hotcues[1 + i + s].clear.setValue(1);
-                    } else {
-                      deck.hotcues[1 + i + s].set.setValue(1);
-                    }
-                  }
-                });
-              };
-            };
-
-            var onHotcueEnabled = function onHotcueEnabled(i) {
-              return function (_ref3, _ref4) {
-                var value = _ref3.value;
-                var bindings = _ref4.bindings;
-
-                if (value) {
-                  bindings["".concat(i, ".btn")].button.sendColor(device.colors.lo_yellow);
-                } else {
-                  bindings["".concat(i, ".btn")].button.sendColor(device.colors.black);
-                }
-              };
-            };
-
-            var bindings = {};
-            range$1(n).map(function (i) {
-              var dx = i % d;
-              var dy = ~~(i / d);
-              bindings["".concat(i, ".btn")] = {
-                type: 'button',
-                target: [gridPosition[0] + dx, gridPosition[1] + dy],
-                midi: onHotcueMidi(i)
-              };
-              bindings["".concat(i, ".enabled")] = {
-                type: 'control',
-                target: deck.hotcues[1 + i + s].enabled,
-                update: onHotcueEnabled(i)
-              };
-            });
-            return {
-              bindings: bindings
-            };
-          };
-        };
-      };
-    };
-  });
-
-  var load = (function (gridPosition) {
-    return function (deck) {
-      return function (modifier) {
-        return function (device) {
-          var onStateChanged = function onStateChanged(loaded, playing, bindings) {
-            if (loaded && playing) {
-              bindings.button.button.sendColor(device.colors.lo_red);
-            } else if (loaded) {
-              bindings.button.button.sendColor(device.colors.lo_yellow);
-            } else {
-              bindings.button.button.sendColor(device.colors.lo_green);
-            }
-          };
-
-          return {
-            bindings: {
-              samples: {
-                type: 'control',
-                target: deck.track_samples,
-                update: function update(_ref, _ref2) {
-                  var value = _ref.value;
-                  var bindings = _ref2.bindings;
-                  return onStateChanged(value, bindings.play.getValue(), bindings);
-                }
-              },
-              play: {
-                type: 'control',
-                target: deck.play,
-                update: function update(_ref3, _ref4) {
-                  var value = _ref3.value;
-                  var bindings = _ref4.bindings;
-                  return onStateChanged(bindings.samples.getValue(), value, bindings);
-                }
-              },
-              button: {
-                type: 'button',
-                target: gridPosition,
-                attack: function attack(message, _ref5) {
-                  var bindings = _ref5.bindings;
-                  modes(modifier.getState(), function () {
-                    if (!bindings.samples.getValue()) {
-                      deck.LoadSelectedTrack.setValue(1);
-                    }
-                  }, function () {
-                    return deck.LoadSelectedTrack.setValue(1);
-                  }, function () {
-                    return deck.eject.setValue(1);
-                  });
-                }
-              }
-            }
-          };
-        };
-      };
-    };
-  });
-
-  var key = (function (gridPosition) {
-    return function (deck) {
-      return function (modifier) {
-        return function (device) {
-          return {
-            bindings: {
-              button: {
-                type: 'button',
-                target: gridPosition,
-                attack: function attack(message, _ref) {
-                  var bindings = _ref.bindings;
-                  modes(modifier.getState(), function () {
-                    bindings.keylock.setValue(Number(!bindings.keylock.getValue()));
-                  }, function () {
-                    deck.key.setValue(deck.key.getValue() - 1);
-                  }, function () {
-                    deck.key.setValue(deck.key.getValue() + 1);
-                  }, function () {
-                    deck.reset_key.setValue(1);
-                  });
-                }
-              },
-              keylock: {
-                type: 'control',
-                target: deck.keylock,
-                update: function update(_ref2, _ref3) {
-                  var value = _ref2.value;
-                  var bindings = _ref3.bindings;
-
-                  if (value) {
-                    bindings.button.button.sendColor(device.colors.hi_red);
-                  } else {
-                    bindings.button.button.sendColor(device.colors.black);
-                  }
-                }
-              }
-            }
-          };
-        };
-      };
-    };
-  });
-
-  /** Built-in value references. */
-
-  var spreadableSymbol = _Symbol$1 ? _Symbol$1.isConcatSpreadable : undefined;
-  /**
-   * Checks if `value` is a flattenable `arguments` object or array.
-   *
-   * @private
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is flattenable, else `false`.
-   */
-
-  function isFlattenable(value) {
-    return isArray$1(value) || isArguments$1(value) || !!(spreadableSymbol && value && value[spreadableSymbol]);
-  }
-
-  /**
-   * The base implementation of `_.flatten` with support for restricting flattening.
-   *
-   * @private
-   * @param {Array} array The array to flatten.
-   * @param {number} depth The maximum recursion depth.
-   * @param {boolean} [predicate=isFlattenable] The function invoked per iteration.
-   * @param {boolean} [isStrict] Restrict to values that pass `predicate` checks.
-   * @param {Array} [result=[]] The initial result value.
-   * @returns {Array} Returns the new flattened array.
-   */
-
-  function baseFlatten(array, depth, predicate, isStrict, result) {
-    var index = -1,
-        length = array.length;
-    predicate || (predicate = isFlattenable);
-    result || (result = []);
-
-    while (++index < length) {
-      var value = array[index];
-
-      if (depth > 0 && predicate(value)) {
-        if (depth > 1) {
-          // Recursively flatten arrays (susceptible to call stack limits).
-          baseFlatten(value, depth - 1, predicate, isStrict, result);
-        } else {
-          arrayPush(result, value);
-        }
-      } else if (!isStrict) {
-        result[result.length] = value;
-      }
-    }
-
-    return result;
-  }
-
-  /**
-   * Creates a base function for methods like `_.forIn` and `_.forOwn`.
-   *
-   * @private
-   * @param {boolean} [fromRight] Specify iterating from right to left.
-   * @returns {Function} Returns the new base function.
-   */
-  function createBaseFor(fromRight) {
-    return function (object, iteratee, keysFunc) {
-      var index = -1,
-          iterable = Object(object),
-          props = keysFunc(object),
-          length = props.length;
-
-      while (length--) {
-        var key = props[fromRight ? length : ++index];
-
-        if (iteratee(iterable[key], key, iterable) === false) {
-          break;
-        }
-      }
-
-      return object;
-    };
-  }
-
-  /**
-   * The base implementation of `baseForOwn` which iterates over `object`
-   * properties returned by `keysFunc` and invokes `iteratee` for each property.
-   * Iteratee functions may exit iteration early by explicitly returning `false`.
-   *
-   * @private
-   * @param {Object} object The object to iterate over.
-   * @param {Function} iteratee The function invoked per iteration.
-   * @param {Function} keysFunc The function to get the keys of `object`.
-   * @returns {Object} Returns `object`.
-   */
-
-  var baseFor = createBaseFor();
-
-  /**
-   * The base implementation of `_.forOwn` without support for iteratee shorthands.
-   *
-   * @private
-   * @param {Object} object The object to iterate over.
-   * @param {Function} iteratee The function invoked per iteration.
-   * @returns {Object} Returns `object`.
-   */
-
-  function baseForOwn(object, iteratee) {
-    return object && baseFor(object, iteratee, keys$1);
-  }
-
-  /**
-   * Creates a `baseEach` or `baseEachRight` function.
-   *
-   * @private
-   * @param {Function} eachFunc The function to iterate over a collection.
-   * @param {boolean} [fromRight] Specify iterating from right to left.
-   * @returns {Function} Returns the new base function.
-   */
-
-  function createBaseEach(eachFunc, fromRight) {
-    return function (collection, iteratee) {
-      if (collection == null) {
-        return collection;
-      }
-
-      if (!isArrayLike$1(collection)) {
-        return eachFunc(collection, iteratee);
-      }
-
-      var length = collection.length,
-          index = fromRight ? length : -1,
-          iterable = Object(collection);
-
-      while (fromRight ? index-- : ++index < length) {
-        if (iteratee(iterable[index], index, iterable) === false) {
-          break;
-        }
-      }
-
-      return collection;
-    };
-  }
-
-  /**
-   * The base implementation of `_.forEach` without support for iteratee shorthands.
-   *
-   * @private
-   * @param {Array|Object} collection The collection to iterate over.
-   * @param {Function} iteratee The function invoked per iteration.
-   * @returns {Array|Object} Returns `collection`.
-   */
-
-  var baseEach = createBaseEach(baseForOwn);
-
-  /**
-   * The base implementation of `_.map` without support for iteratee shorthands.
-   *
-   * @private
-   * @param {Array|Object} collection The collection to iterate over.
-   * @param {Function} iteratee The function invoked per iteration.
-   * @returns {Array} Returns the new mapped array.
-   */
-
-  function baseMap(collection, iteratee) {
-    var index = -1,
-        result = isArrayLike$1(collection) ? Array(collection.length) : [];
-    baseEach(collection, function (value, key, collection) {
-      result[++index] = iteratee(value, key, collection);
-    });
-    return result;
-  }
-
-  /**
-   * Creates an array of values by running each element in `collection` thru
-   * `iteratee`. The iteratee is invoked with three arguments:
-   * (value, index|key, collection).
-   *
-   * Many lodash methods are guarded to work as iteratees for methods like
-   * `_.every`, `_.filter`, `_.map`, `_.mapValues`, `_.reject`, and `_.some`.
-   *
-   * The guarded methods are:
-   * `ary`, `chunk`, `curry`, `curryRight`, `drop`, `dropRight`, `every`,
-   * `fill`, `invert`, `parseInt`, `random`, `range`, `rangeRight`, `repeat`,
-   * `sampleSize`, `slice`, `some`, `sortBy`, `split`, `take`, `takeRight`,
-   * `template`, `trim`, `trimEnd`, `trimStart`, and `words`
-   *
-   * @static
-   * @memberOf _
-   * @since 0.1.0
-   * @category Collection
-   * @param {Array|Object} collection The collection to iterate over.
-   * @param {Function} [iteratee=_.identity] The function invoked per iteration.
-   * @returns {Array} Returns the new mapped array.
-   * @example
-   *
-   * function square(n) {
-   *   return n * n;
-   * }
-   *
-   * _.map([4, 8], square);
-   * // => [16, 64]
-   *
-   * _.map({ 'a': 4, 'b': 8 }, square);
-   * // => [16, 64] (iteration order is not guaranteed)
-   *
-   * var users = [
-   *   { 'user': 'barney' },
-   *   { 'user': 'fred' }
-   * ];
-   *
-   * // The `_.property` iteratee shorthand.
-   * _.map(users, 'user');
-   * // => ['barney', 'fred']
-   */
-
-  function map(collection, iteratee) {
-    var func = isArray$1(collection) ? arrayMap : baseMap;
-    return func(collection, baseIteratee(iteratee));
-  }
-
-  /**
-   * Creates a flattened array of values by running each element in `collection`
-   * thru `iteratee` and flattening the mapped results. The iteratee is invoked
-   * with three arguments: (value, index|key, collection).
-   *
-   * @static
-   * @memberOf _
-   * @since 4.0.0
-   * @category Collection
-   * @param {Array|Object} collection The collection to iterate over.
-   * @param {Function} [iteratee=_.identity] The function invoked per iteration.
-   * @returns {Array} Returns the new flattened array.
-   * @example
-   *
-   * function duplicate(n) {
-   *   return [n, n];
-   * }
-   *
-   * _.flatMap([1, 2], duplicate);
-   * // => [1, 1, 2, 2]
-   */
-
-  function flatMap(collection, iteratee) {
-    return baseFlatten(map(collection, iteratee), 1);
-  }
-
-  var beatjump = (function (jumps, vertical) {
-    return function (gridPosition) {
-      return function (deck) {
-        return function (modifier) {
-          return function (device) {
-            var bindings = {};
-
-            var onMidi = function onMidi(k, j, d) {
-              return function (modifier) {
-                return retainAttackMode(modifier, function (mode, _ref, _ref2) {
-                  var value = _ref.value;
-                  var bindings = _ref2.bindings,
-                      state = _ref2.state;
-                  modes(mode, function () {
-                    if (!state.mode) {
-                      if (value) {
-                        deck.beatjump.setValue(j[state.set] * d);
-                      }
-                    } else {
-                      if (value) {
-                        var currentJump = j[state.set] * d;
-                        deck.beatjump.setValue(currentJump);
-
-                        if (state.pressing != null) {
-                          bindings[state.pressing].button.sendColor(device.colors["lo_".concat(state.color[state.set])]);
-                        }
-
-                        bindings[k].button.sendColor(device.colors["hi_".concat(state.color[state.set])]);
-                        state.pressing = k;
-                        state.diff = state.diff + currentJump;
-                      } else {
-                        if (state.pressing === k) {
-                          bindings[k].button.sendColor(device.colors["lo_".concat(state.color[state.set])]);
-                          state.pressing = null;
-                          deck.beatjump.setValue(-state.diff);
-                          state.diff = 0;
-                        }
-                      }
-                    }
-                  }, function () {
-                    if (value) {
-                      if (state.set === 1) {
-                        state.set = 0;
-                        var prefix = state.mode ? 'lo' : 'hi';
-
-                        for (var b = 0; b < spec.length; ++b) {
-                          bindings[b].button.sendColor(device.colors["".concat(prefix, "_").concat(state.color[state.set])]);
-                        }
-                      }
-                    }
-                  }, function () {
-                    if (value) {
-                      if (state.set === 0) {
-                        state.set = 1;
-                        var prefix = state.mode ? 'lo' : 'hi';
-
-                        for (var b = 0; b < spec.length; ++b) {
-                          bindings[b].button.sendColor(device.colors["".concat(prefix, "_").concat(state.color[state.set])]);
-                        }
-                      }
-                    }
-                  }, function () {
-                    if (value) {
-                      state.mode = !state.mode;
-                      var prefix = state.mode ? 'lo' : 'hi';
-
-                      for (var b = 0; b < spec.length; ++b) {
-                        bindings[b].button.sendColor(device.colors["".concat(prefix, "_").concat(state.color[state.set])]);
-                      }
-                    }
-                  });
-                });
-              };
-            };
-
-            var onMount = function onMount(k) {
-              return function (_, _ref3) {
-                var bindings = _ref3.bindings,
-                    state = _ref3.state;
-                var prefix = state.mode ? 'lo' : 'hi';
-                bindings[k].button.sendColor(device.colors["".concat(prefix, "_").concat(state.color[state.set])]);
-              };
-            };
-
-            var spec = flatMap(jumps, function (j, i) {
-              return [[j, -1], [j, 1]];
-            });
-            spec.forEach(function (_ref4, i) {
-              var _ref5 = _slicedToArray(_ref4, 2),
-                  jump = _ref5[0],
-                  dir = _ref5[1];
-
-              bindings[i] = {
-                type: 'button',
-                target: vertical ? [gridPosition[0] + i % 2, gridPosition[1] + ~~(i / 2)] : [gridPosition[0] + ~~(i / 2), gridPosition[1] + i % 2],
-                midi: onMidi(i, jump, dir)(modifier),
-                mount: onMount(i)
-              };
-            });
-            return {
-              bindings: bindings,
-              state: {
-                mode: false,
-                pressing: 0,
-                diff: 0,
-                set: 0,
-                color: ['green', 'red']
-              }
-            };
-          };
-        };
-      };
-    };
-  });
-
-  var beatloop = (function (loops, d) {
-    return function (gridPosition) {
-      return function (deck) {
-        return function (modifier) {
-          return function (device) {
-            var bindings = {};
-
-            var onAttack = function onAttack(l) {
-              return function (modifier) {
-                return function () {
-                  modes(modifier.getState(), function () {
-                    return deck.beatloops[l].toggle.setValue(1);
-                  });
-                };
-              };
-            };
-
-            var onUpdate = function onUpdate(i) {
-              return function (_ref, _ref2) {
-                var value = _ref.value;
-                var bindings = _ref2.bindings;
-
-                if (value) {
-                  bindings[i].button.sendColor(device.colors.hi_red);
-                } else {
-                  bindings[i].button.sendColor(device.colors.lo_red);
-                }
-              };
-            };
-
-            loops.forEach(function (loop, i) {
-              var dx = i % d;
-              var dy = ~~(i / d);
-              bindings[i] = {
-                type: 'button',
-                target: [gridPosition[0] + dx, gridPosition[1] + dy],
-                attack: onAttack(loop)(modifier)
-              };
-              bindings["".concat(loop, ".enabled")] = {
-                type: 'control',
-                target: deck.beatloops[loop].enabled,
-                update: onUpdate(i)
-              };
-            });
-            return {
-              bindings: bindings
-            };
-          };
-        };
-      };
-    };
-  });
-
-  var loopjump = function loopjump(jumps) {
-    return function (gridPosition) {
-      return function (deck) {
-        return function (modifier) {
-          return function (device) {
-            var bindings = {};
-
-            var onMidi = function onMidi(k, j, d) {
-              return function (modifier) {
-                return retainAttackMode(modifier, function (mode, _ref, _ref2) {
-                  var value = _ref.value;
-                  var bindings = _ref2.bindings,
-                      state = _ref2.state;
-                  modes(mode, function () {
-                    if (!state.mode) {
-                      if (value) {
-                        deck.loop_move.setValue(j[state.set] * d);
-                      }
-                    } else {
-                      if (value) {
-                        var currentJump = j[state.set] * d;
-                        deck.loop_move.setValue(currentJump);
-
-                        if (state.pressing != null) {
-                          bindings[state.pressing].button.sendColor(device.colors["lo_".concat(state.color[state.set])]);
-                        }
-
-                        bindings[k].button.sendColor(device.colors["hi_".concat(state.color[state.set])]);
-                        state.pressing = k;
-                        state.diff = state.diff + currentJump;
-                      } else {
-                        if (state.pressing === k) {
-                          bindings[k].button.sendColor(device.colors["lo_".concat(state.color[state.set])]);
-                          state.pressing = null;
-                          deck.loop_move.setValue(-state.diff);
-                          state.diff = 0;
-                        }
-                      }
-                    }
-                  }, function () {
-                    if (value) {
-                      if (state.set === 1) {
-                        state.set = 0;
-                        var prefix = state.mode ? 'lo' : 'hi';
-
-                        for (var b = 0; b < spec.length; ++b) {
-                          bindings[b].button.sendColor(device.colors["".concat(prefix, "_").concat(state.color[state.set])]);
-                        }
-                      }
-                    }
-                  }, function () {
-                    if (value) {
-                      if (state.set === 0) {
-                        state.set = 1;
-                        var prefix = state.mode ? 'lo' : 'hi';
-
-                        for (var b = 0; b < spec.length; ++b) {
-                          bindings[b].button.sendColor(device.colors["".concat(prefix, "_").concat(state.color[state.set])]);
-                        }
-                      }
-                    }
-                  }, function () {
-                    if (value) {
-                      state.mode = !state.mode;
-                      var prefix = state.mode ? 'lo' : 'hi';
-
-                      for (var b = 0; b < spec.length; ++b) {
-                        bindings[b].button.sendColor(device.colors["".concat(prefix, "_").concat(state.color[state.set])]);
-                      }
-                    }
-                  });
-                });
-              };
-            };
-
-            var onMount = function onMount(k) {
-              return function (_, _ref3) {
-                var bindings = _ref3.bindings,
-                    state = _ref3.state;
-                var prefix = state.mode ? 'lo' : 'hi';
-                bindings[k].button.sendColor(device.colors["".concat(prefix, "_").concat(state.color[state.set])]);
-              };
-            };
-
-            var spec = flatMap(jumps, function (j, i) {
-              return [[j, 1], [j, -1]];
-            }); // FIXME: flatMap is incorrectly typed see https://github.com/flow-typed/flow-typed/issues/2463
-
-            spec.forEach(function (_ref4, i) {
-              var _ref5 = _slicedToArray(_ref4, 2),
-                  jump = _ref5[0],
-                  dir = _ref5[1];
-
-              bindings[i] = {
-                type: 'button',
-                target: [gridPosition[0] + i % 2, gridPosition[1] + ~~(i / 2)],
-                midi: onMidi(i, jump, dir)(modifier),
-                mount: onMount(i)
-              };
-            });
-            return {
-              bindings: bindings,
-              state: {
-                mode: false,
-                pressing: 0,
-                diff: 0,
-                set: 0,
-                color: ['green', 'red']
-              }
-            };
-          };
-        };
-      };
-    };
-  };
-  var loopjumpSmall = function loopjumpSmall(amount) {
-    return function (button) {
-      return function (deck) {
-        return function (modifier) {
-          return function (device) {
-            var onAttack = function onAttack(dir) {
-              return function () {
-                modes(modifier.getState(), function () {
-                  return deck.loop_move.setValue(dir * amount);
-                });
-              };
-            };
-
-            return {
-              bindings: {
-                back: {
-                  type: 'button',
-                  target: button,
-                  attack: onAttack(-1),
-                  mount: function mount(dk, _ref6) {
-                    var bindings = _ref6.bindings;
-                    bindings.back.button.sendColor(device.colors.hi_yellow);
-                  }
-                },
-                forth: {
-                  type: 'button',
-                  target: [button[0] + 1, button[1]],
-                  attack: onAttack(1),
-                  mount: function mount(dk, _ref7) {
-                    var bindings = _ref7.bindings;
-                    bindings.forth.button.sendColor(device.colors.hi_yellow);
-                  }
-                }
-              }
-            };
-          };
-        };
-      };
-    };
-  };
-
-  var loopMultiply = (function (gridPosition) {
-    return function (deck) {
-      return function (_) {
-        return function (device) {
-          var onMount = function onMount(k) {
-            return function (dk, _ref) {
-              var bindings = _ref.bindings;
-              bindings[k].button.sendColor(device.colors.lo_yellow);
-            };
-          };
-
-          var onAttack = function onAttack(k) {
-            return function () {
-              // TODO: remove unsafe cast once flow supports https://github.com/facebook/flow/issues/3637
-              deck["loop_".concat(k)].setValue(1);
-            };
-          };
-
-          return {
-            bindings: {
-              halve: {
-                type: 'button',
-                target: gridPosition,
-                mount: onMount('halve'),
-                attack: onAttack('halve')
-              },
-              "double": {
-                type: 'button',
-                target: [gridPosition[0] + 1, gridPosition[1]],
-                mount: onMount('double'),
-                attack: onAttack('double')
-              }
-            }
-          };
-        };
-      };
-    };
-  });
-
-  var reloop = (function (gridPosition) {
-    return function (deck) {
-      return function (modifier) {
-        return function (device) {
-          return {
-            bindings: {
-              button: {
-                type: 'button',
-                target: gridPosition,
-                attack: function attack() {
-                  modes(modifier.getState(), function () {
-                    return deck.reloop_exit.setValue(1);
-                  }, function () {
-                    return deck.reloop_andstop.setValue(1);
-                  });
-                }
-              },
-              control: {
-                type: 'control',
-                target: deck.loop_enabled,
-                update: function update(_ref, _ref2) {
-                  var value = _ref.value;
-                  var bindings = _ref2.bindings;
-
-                  if (value) {
-                    bindings.button.button.sendColor(device.colors.hi_green);
-                  } else {
-                    bindings.button.button.sendColor(device.colors.lo_green);
-                  }
-                }
-              }
-            }
-          };
-        };
-      };
-    };
-  });
-
-  var SMALL_SAMPLES = 125;
-  var loopIo = (function (gridPosition) {
-    return function (deck) {
-      return function (modifier) {
-        return function (device) {
-          var loopName = {
-            "in": 'loop_in',
-            out: 'loop_out'
-          };
-          var loopPosName = {
-            "in": 'loop_start_position',
-            out: 'loop_end_position'
-          };
-
-          var onMidi = function onMidi(dir) {
-            return function (_ref, _ref2) {
-              var value = _ref.value;
-              var bindings = _ref2.bindings;
-              modes(modifier.getState(), function () {
-                if (value) {
-                  var ctrl = loopName[dir];
-                  deck[ctrl].setValue(1);
-                  deck[ctrl].setValue(0);
-                }
-              }, function () {
-                if (value) {
-                  var ctrl = loopPosName[dir];
-                  deck[ctrl].setValue(deck[ctrl].getValue() - SMALL_SAMPLES);
-                }
-              }, function () {
-                if (value) {
-                  var ctrl = loopPosName[dir];
-                  deck[ctrl].setValue(deck[ctrl].getValue() + SMALL_SAMPLES);
-                }
-              });
-            };
-          };
-
-          return {
-            bindings: {
-              "in": {
-                type: 'button',
-                target: gridPosition,
-                midi: onMidi('in')
-              },
-              out: {
-                type: 'button',
-                target: [gridPosition[0] + 1, gridPosition[1]],
-                midi: onMidi('out')
-              }
-            }
-          };
-        };
-      };
-    };
-  });
-
-  var slip = (function (gridPosition) {
-    return function (deck) {
-      return function (modifier) {
-        return function (device) {
-          var onMidi = function onMidi(modifier) {
-            return retainAttackMode(modifier, function (mode, _ref, _ref2) {
-              var value = _ref.value;
-              var bindings = _ref2.bindings,
-                  state = _ref2.state;
-              modes(mode, function () {
-                if (value) {
-                  bindings.control.setValue(Number(!bindings.control.getValue()));
-                } else {
-                  if (state.mode) {
-                    bindings.control.setValue(Number(!bindings.control.getValue()));
-                  }
-                }
-              }, function () {
-                if (value) {
-                  state.mode = !state.mode;
-                  var color = state.mode ? 'orange' : 'red';
-                  bindings.button.button.sendColor(device.colors["lo_".concat(color)]);
-                }
-              });
-            });
-          };
-
-          return {
-            bindings: {
-              control: {
-                type: 'control',
-                target: deck.slip_enabled,
-                update: function update(_ref3, _ref4) {
-                  var value = _ref3.value;
-                  var bindings = _ref4.bindings,
-                      state = _ref4.state;
-                  var color = state.mode ? 'orange' : 'red';
-
-                  if (value) {
-                    bindings.button.button.sendColor(device.colors["hi_".concat(color)]);
-                  } else {
-                    bindings.button.button.sendColor(device.colors["lo_".concat(color)]);
-                  }
-                }
-              },
-              button: {
-                type: 'button',
-                target: gridPosition,
-                midi: onMidi(modifier),
-                mount: function mount(dk, _ref5) {
-                  var bindings = _ref5.bindings,
-                      state = _ref5.state;
-                  var color = state.mode ? 'orange' : 'red';
-                  bindings.button.button.sendColor(device.colors["lo_".concat(color)]);
-                }
-              }
-            },
-            state: {
-              mode: 1
-            }
-          };
-        };
-      };
-    };
-  });
-
-  var Grande = {
-    play: play([0, 0]),
-    sync: sync([1, 0]),
-    nudge: nudge([2, 0]),
-    cue: cue([0, 1]),
-    tap: tap([1, 1]),
-    grid: grid([2, 1]),
-    pfl: pfl([0, 2]),
-    quantize: quantize([1, 2]),
-    keyshift: keyshift([[1, 1], [2, 2], [3, 3], [5, 4], [7, 5], [8, 6], [10, 7], [12, 8]], 2)([2, 2]),
-    load: load([0, 3]),
-    key: key([1, 3]),
-    hotcue: hotcue(8, 2)([0, 4]),
-    beatjump: beatjump([[0.25, 1], [0.33, 2], [0.5, 4], [0.75, 8], [1, 16], [2, 32]])([2, 6]),
-    beatloop: beatloop([0.5, 1, 2, 4, 8, 16, 32, 64], 2)([4, 2]),
-    loopjump: loopjump([[0.5, 8], [1, 16], [2, 32], [4, 64]])([6, 2]),
-    loopjumpSmall: loopjumpSmall(0.03125)([6, 1]),
-    loopMultiply: loopMultiply([4, 1]),
-    reloop: reloop([4, 0]),
-    loopIo: loopIo([5, 0]),
-    slip: slip([7, 0])
-  };
-
-  var Juggler = {
-    play: play([0, 0]),
-    load: load([1, 0]),
-    beatjump: beatjump([[0.5, 4], [1, 16], [2, 32], [4, 64]], true)([2, 0]),
-    loopjump: loopjump([[1, 16], [4, 64]])([0, 1]),
-    reloop: reloop([0, 3]),
-    loopMultiply: loopMultiply([0, 4]),
-    hotcue: hotcue(8, 2)([2, 4]),
-    beatloop: beatloop([0.5, 1, 2, 4, 8, 16], 2)([0, 5])
-  };
-
-  var Sampler = {
-    hotcue: hotcue(16, 4)([0, 0])
-  };
-
-  var Short = {
-    play: play([0, 0]),
-    sync: sync([1, 0]),
-    nudge: nudge([2, 0]),
-    cue: cue([0, 1]),
-    tap: tap([1, 1]),
-    grid: grid([2, 1]),
-    pfl: pfl([0, 2]),
-    quantize: quantize([1, 2]),
-    loopIo: loopIo([2, 2]),
-    load: load([0, 3]),
-    key: key([1, 3]),
-    reloop: reloop([2, 3]),
-    slip: slip([3, 3])
-  };
-
-  var Tall = {
-    play: play([0, 0]),
-    sync: sync([1, 0]),
-    nudge: nudge([2, 0]),
-    cue: cue([0, 1]),
-    tap: tap([1, 1]),
-    grid: grid([2, 1]),
-    pfl: pfl([0, 2]),
-    quantize: quantize([1, 2]),
-    loopIo: loopIo([2, 2]),
-    load: load([0, 3]),
-    key: key([1, 3]),
-    reloop: reloop([2, 3]),
-    slip: slip([3, 3]),
-    hotcue: hotcue(4, 2)([0, 4]),
-    loopMultiply: loopMultiply([2, 4]),
-    beatloop: beatloop([0.5, 1, 2, 4, 8, 16], 2)([2, 5]),
-    beatjump: beatjump([[1, 16], [2, 32]])([0, 6])
-  };
-
-  function _createSuper$7(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct$7()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
-
-  function _isNativeReflectConstruct$7() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
-  var makePresetFromPartialTemplate = function makePresetFromPartialTemplate(id, partialTemplate, offset) {
-    return function (deck) {
-      return function (controlComponentBuilder) {
-        return function (midibus) {
-          return function (modifier) {
-            var template = {};
-            Object.keys(partialTemplate).forEach(function (k) {
-              assign$1(template, _defineProperty$1({}, k, partialTemplate[k](deck)(modifier)(midibus.device)));
-            });
-            return new Preset(midibus, controlComponentBuilder, modifier, id, template, offset);
-          };
-        };
-      };
-    };
-  };
-  var Preset = /*#__PURE__*/function (_MidiComponent) {
-    _inherits(Preset, _MidiComponent);
-
-    var _super = _createSuper$7(Preset);
-
-    function Preset(midibus, controlComponentBuilder, modifier, id, template, offset) {
-      var _this;
-
-      _classCallCheck$1(this, Preset);
-
-      _this = _super.call(this, midibus);
-
-      _defineProperty$1(_assertThisInitialized(_this), "preset", void 0);
-
-      var controlBindings = {};
-      var controlListeners = {};
-      var buttonBindings = {};
-      var buttonListeners = {};
-      Object.keys(template).forEach(function (tk) {
-        if (template[tk] && template[tk].bindings) {
-          var bindings = template[tk].bindings;
-          var instance = {
-            state: template[tk].state,
-            bindings: {}
-          };
-          Object.keys(bindings).forEach(function (bk) {
-            if (bindings[bk]) {
-              var binding = bindings[bk];
-
-              if (binding.type === 'control') {
-                var name = "".concat(binding.target.def.group).concat(binding.target.def.name);
-
-                if (!controlBindings[name]) {
-                  controlBindings[name] = controlComponentBuilder("".concat(id, ".").concat(tk, ".").concat(bk))(binding.target);
-                }
-
-                instance.bindings[bk] = controlBindings[name];
-                controlListeners[name] = controlListeners[name] || {};
-                ['update', 'mount', 'unmount'].forEach(function (action) {
-                  if (typeof binding[action] === 'function') {
-                    appendListener(action, controlListeners[name], function (data) {
-                      return binding[action](data, instance, modifier);
-                    });
-                  }
-                });
-              } else if (binding.type === 'button') {
-                var position = tr(binding.target, offset);
-
-                var _name = nameOf(position[0], position[1]);
-
-                if (!buttonBindings[_name]) {
-                  buttonBindings[_name] = new MidiButtonComponent(_this.midibus, _this.device.buttons[_name]);
-                }
-
-                instance.bindings[bk] = buttonBindings[_name];
-                buttonListeners[_name] = buttonListeners[_name] || {};
-                ['attack', 'release', 'midi', 'mount', 'unmount'].forEach(function (action) {
-                  if (typeof binding[action] === 'function') {
-                    appendListener(action, buttonListeners[_name], function (data) {
-                      return binding[action](data, instance);
-                    });
-                  }
-                });
-
-                if (typeof binding.unmount !== 'function') {
-                  appendListener('unmount', buttonListeners[_name], function (data) {
-                    instance.bindings[bk].button.sendColor(this.device.colors.black);
-                  });
-                }
-              }
-            }
-          });
-        }
-      });
-      _this.preset = {
-        controlBindings: controlBindings,
-        controlListeners: controlListeners,
-        buttonBindings: buttonBindings,
-        buttonListeners: buttonListeners
-      };
-      return _this;
-    }
-
-    _createClass$1(Preset, [{
-      key: "onMount",
-      value: function onMount() {
-        var _this$preset = this.preset,
-            controlBindings = _this$preset.controlBindings,
-            buttonBindings = _this$preset.buttonBindings,
-            controlListeners = _this$preset.controlListeners,
-            buttonListeners = _this$preset.buttonListeners;
-        addListeners(controlBindings, controlListeners);
-        addListeners(buttonBindings, buttonListeners);
-        Object.keys(controlBindings).forEach(function (k) {
-          return controlBindings[k].mount();
-        });
-        Object.keys(buttonBindings).forEach(function (k) {
-          return buttonBindings[k].mount();
-        });
-      }
-    }, {
-      key: "onUnmount",
-      value: function onUnmount() {
-        var _this$preset2 = this.preset,
-            controlBindings = _this$preset2.controlBindings,
-            buttonBindings = _this$preset2.buttonBindings,
-            controlListeners = _this$preset2.controlListeners,
-            buttonListeners = _this$preset2.buttonListeners;
-        Object.keys(controlBindings).forEach(function (k) {
-          return controlBindings[k].unmount();
-        });
-        Object.keys(buttonBindings).forEach(function (k) {
-          return buttonBindings[k].unmount();
-        });
-        removeListeners(controlBindings, controlListeners);
-        removeListeners(buttonBindings, buttonListeners);
-      }
-    }]);
-
-    return Preset;
-  }(MidiComponent);
-
-  var tr = function tr(a, b) {
-    return [a[0] + b[0], a[1] + b[1]];
-  };
-
-  var nameOf = function nameOf(x, y) {
-    return "".concat(7 - y, ",").concat(x);
-  };
-
-  var appendListener = function appendListener(type, bindings, binding) {
-    if (bindings[type] && Array.isArray(bindings[type])) {
-      bindings[type].push(binding);
-    } else if (bindings[type]) {
-      var first = bindings[type];
-      bindings[type] = [first, binding];
-    } else {
-      bindings[type] = binding;
-    }
-  };
-
-  var addListeners = function addListeners(tgt, bindings) {
-    Object.keys(bindings).forEach(function (binding) {
-      if (tgt[binding]) {
-        Object.keys(bindings[binding]).forEach(function (k) {
-          if (Array.isArray(bindings[binding][k])) {
-            bindings[binding][k].forEach(function (f) {
-              tgt[binding].on(k, f);
-            });
-          } else {
-            tgt[binding].on(k, bindings[binding][k]);
-          }
-        });
-      }
-    });
-  };
-
-  var removeListeners = function removeListeners(tgt, bindings) {
-    Object.keys(bindings).forEach(function (binding) {
-      if (tgt[binding]) {
-        Object.keys(bindings[binding]).forEach(function (k) {
-          if (Array.isArray(bindings[binding][k])) {
-            bindings[binding][k].forEach(function (f) {
-              tgt[binding].removeListener(k, f);
-            });
-          } else {
-            tgt[binding].removeListener(k, bindings[binding][k]);
-          }
-        });
-      }
-    });
-  };
-
-  function _createSuper$8(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct$8()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
-
-  function _isNativeReflectConstruct$8() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
-  var initialChannels = [0, 1];
-
-  var onMidi$1 = function onMidi(selectorBar, channel, modifier) {
-    return retainAttackMode(modifier, function (mode, _ref) {
-      var value = _ref.value;
-      var selected = selectorBar.getChord();
-      modes(mode, function () {
-        if (!value && selected.length) {
-          var diff = reorganize(selectorBar.getLayout(), selected);
-          selectorBar.updateLayout(diff);
-          selectorBar.removeChord();
-        } else if (value) {
-          selectorBar.addToChord(channel);
-        }
-      }, function () {
-        if (value) {
-          if (selected.length) selectorBar.removeChord();
-          var diff = cycle(channel, selectorBar.getLayout(), 1);
-          selectorBar.updateLayout(diff);
-        }
-      }, function () {
-        if (value) {
-          if (selected.length) selectorBar.removeChord();
-          var diff = cycle(channel, selectorBar.getLayout(), -1);
-          selectorBar.updateLayout(diff);
-        }
-      });
-    });
-  };
-
-  var SelectorBar = /*#__PURE__*/function (_MidiComponent) {
-    _inherits(SelectorBar, _MidiComponent);
-
-    var _super = _createSuper$8(SelectorBar);
-
-    function SelectorBar(midibus, controlComponentBuilder, modifier, id) {
-      var _this;
-
-      _classCallCheck$1(this, SelectorBar);
-
-      _this = _super.call(this, midibus);
-
-      _defineProperty$1(_assertThisInitialized(_this), "id", void 0);
-
-      _defineProperty$1(_assertThisInitialized(_this), "bindings", void 0);
-
-      _defineProperty$1(_assertThisInitialized(_this), "controlComponentBuilder", void 0);
-
-      _defineProperty$1(_assertThisInitialized(_this), "modifier", void 0);
-
-      _defineProperty$1(_assertThisInitialized(_this), "chord", void 0);
-
-      _defineProperty$1(_assertThisInitialized(_this), "layout", void 0);
-
-      _defineProperty$1(_assertThisInitialized(_this), "mountedPresets", void 0);
-
-      _this.id = id;
-      _this.bindings = SelectorBar.buttons.map(function (v, i) {
-        var binding = new MidiButtonComponent(_this.midibus, _this.device.buttons[v]);
-        return [binding, onMidi$1(_assertThisInitialized(_this), i, modifier)];
-      });
-      _this.controlComponentBuilder = controlComponentBuilder;
-      _this.modifier = modifier;
-      _this.chord = [];
-      _this.layout = {};
-      _this.mountedPresets = {};
-      return _this;
-    }
-
-    _createClass$1(SelectorBar, [{
-      key: "getLayout",
-      value: function getLayout() {
-        var res = [];
-
-        for (var k in this.layout) {
-          res.push(this.layout[k]);
-        }
-
-        return res;
-      }
-    }, {
-      key: "updateLayout",
-      value: function updateLayout(diff) {
-        var _this2 = this;
-
-        var removedChannels = diff[0].map(function (block) {
-          return block.channel;
-        });
-        removedChannels.forEach(function (ch) {
-          delete _this2.layout[String(ch)];
-
-          _this2.bindings[ch][0].button.sendColor(_this2.device.colors.black);
-
-          _this2.mountedPresets[ch].unmount();
-        });
-        var addedBlocks = diff[1];
-        addedBlocks.forEach(function (block) {
-          _this2.layout[String(block.channel)] = block;
-
-          if (block.index) {
-            _this2.bindings[block.channel][0].button.sendColor(_this2.device.colors.hi_orange);
-          } else {
-            _this2.bindings[block.channel][0].button.sendColor(_this2.device.colors.hi_green);
-          }
-
-          _this2.mountedPresets[block.channel] = makePresetFromPartialTemplate("".concat(_this2.id, ".deck.").concat(block.channel), cycled[block.size][block.index], block.offset)(channelControls[block.channel])(_this2.controlComponentBuilder)(_this2.midibus)(_this2.modifier);
-
-          _this2.mountedPresets[block.channel].mount();
-        });
-      }
-    }, {
-      key: "removeChord",
-      value: function removeChord() {
-        var _this3 = this;
-
-        var layout = this.getLayout();
-        this.chord.forEach(function (ch) {
-          var found = findIndex(layout, function (b) {
-            return b.channel === ch;
-          });
-
-          if (found === -1) {
-            _this3.bindings[ch][0].button.sendColor(_this3.device.colors.black);
-          } else {
-            var block = layout[found];
-
-            if (block.index) {
-              _this3.bindings[ch][0].button.sendColor(_this3.device.colors.hi_orange);
-            } else {
-              _this3.bindings[ch][0].button.sendColor(_this3.device.colors.hi_green);
-            }
-          }
-
-          _this3.chord = [];
-        });
-      }
-    }, {
-      key: "addToChord",
-      value: function addToChord(channel) {
-        if (this.chord.length === 4) {
-          var rem = this.chord.shift();
-          var found = findIndex(this.layout, function (b) {
-            return b.channel === rem;
-          }); // FIXME: badly typed
-
-          if (found === -1) {
-            this.bindings[rem][0].button.sendColor(this.device.colors.black);
-          } else {
-            var layout = this.layout[String(found)];
-
-            if (layout.index) {
-              this.bindings[rem][0].button.sendColor(this.device.colors.hi_orange);
-            } else {
-              this.bindings[rem][0].button.sendColor(this.device.colors.hi_green);
-            }
-          }
-        }
-
-        this.chord.push(channel);
-        this.bindings[channel][0].button.sendColor(this.device.colors.hi_red);
-      }
-    }, {
-      key: "getChord",
-      value: function getChord() {
-        return this.chord;
-      }
-    }, {
-      key: "onMount",
-      value: function onMount() {
-        this.bindings.forEach(function (_ref2) {
-          var _ref3 = _slicedToArray(_ref2, 2),
-              binding = _ref3[0],
-              midi = _ref3[1];
-
-          binding.mount();
-          binding.on('midi', midi);
-        });
-      }
-    }, {
-      key: "onUnmount",
-      value: function onUnmount() {
-        this.bindings.forEach(function (_ref4) {
-          var _ref5 = _slicedToArray(_ref4, 2),
-              binding = _ref5[0],
-              midi = _ref5[1];
-
-          binding.removeListener('midi', midi);
-          binding.unmount();
-        });
-      }
-    }]);
-
-    return SelectorBar;
-  }(MidiComponent);
-
-  _defineProperty$1(SelectorBar, "buttons", ['up', 'down', 'left', 'right', 'session', 'user1', 'user2', 'mixer']);
-
-  _defineProperty$1(SelectorBar, "channels", [0, 1, 2, 3, 4, 5, 6, 7]);
-
-  var Layout = /*#__PURE__*/function (_MidiComponent2) {
-    _inherits(Layout, _MidiComponent2);
-
-    var _super2 = _createSuper$8(Layout);
-
-    function Layout(midibus, controlComponentBuilder, modifier, id) {
-      var _this4;
-
-      _classCallCheck$1(this, Layout);
-
-      _this4 = _super2.call(this, midibus);
-
-      _defineProperty$1(_assertThisInitialized(_this4), "selectorBar", void 0);
-
-      _this4.selectorBar = new SelectorBar(midibus, controlComponentBuilder, modifier, "".concat(id, ".selectorBar"));
-      return _this4;
-    }
-
-    _createClass$1(Layout, [{
-      key: "onMount",
-      value: function onMount() {
-        this.selectorBar.mount();
-        var diff = reorganize([], initialChannels);
-        this.selectorBar.updateLayout(diff);
-      }
-    }, {
-      key: "onUnmount",
-      value: function onUnmount() {
-        var diff = reorganize(this.selectorBar.getLayout(), []);
-        this.selectorBar.updateLayout(diff);
-        this.selectorBar.unmount();
-      }
-    }]);
-
-    return Layout;
-  }(MidiComponent);
-  var offsets = [[0, 0], [4, 0], [0, 4], [4, 4]];
-  var presets = {
-    grande: [Grande],
-    tall: [Tall, Juggler],
-    "short": [Short, Sampler]
-  };
-  var cycled = {
-    grande: [].concat(_toConsumableArray(presets.grande), _toConsumableArray(presets.tall), _toConsumableArray(presets["short"])),
-    tall: [].concat(_toConsumableArray(presets.tall), _toConsumableArray(presets["short"])),
-    "short": presets["short"]
-  };
-
-  var blockEquals = function blockEquals(a, b) {
-    return a.offset === b.offset && a.size === b.size && a.channel === b.channel && a.index === b.index;
-  };
-
-  var reorganize = function reorganize(current, selectedChannels) {
-    var next = function (chs) {
-      switch (chs.length) {
-        case 0:
-          return [];
-
-        case 1:
-          return [{
-            offset: offsets[0],
-            size: 'grande',
-            channel: chs[0],
-            index: 0
-          }];
-
-        case 2:
-          return [{
-            offset: offsets[0],
-            size: 'tall',
-            channel: chs[0],
-            index: 0
-          }, {
-            offset: offsets[1],
-            size: 'tall',
-            channel: chs[1],
-            index: 0
-          }];
-
-        case 3:
-          return [{
-            offset: offsets[0],
-            size: 'tall',
-            channel: chs[0],
-            index: 0
-          }, {
-            offset: offsets[1],
-            size: 'short',
-            channel: chs[1],
-            index: 0
-          }, {
-            offset: offsets[3],
-            size: 'short',
-            channel: chs[2],
-            index: 0
-          }];
-
-        default:
-          return [{
-            offset: offsets[2],
-            size: 'short',
-            channel: chs[0],
-            index: 0
-          }, {
-            offset: offsets[3],
-            size: 'short',
-            channel: chs[1],
-            index: 0
-          }, {
-            offset: offsets[2],
-            size: 'short',
-            channel: chs[2],
-            index: 0
-          }, {
-            offset: offsets[3],
-            size: 'short',
-            channel: chs[3],
-            index: 0
-          }];
-      }
-    }(selectedChannels);
-
-    return current.reduce(function (diff, block) {
-      var _diff = _slicedToArray(diff, 2),
-          neg = _diff[0],
-          pos = _diff[1];
-
-      var matched = findIndex(pos, function (b) {
-        return blockEquals(block, b);
-      });
-      return matched === -1 ? [neg.concat([block]), pos] : [neg, pos.slice(0, matched).concat(pos.slice(matched + 1, pos.length))];
-    }, [[], next]);
-  };
-
-  var posMod = function posMod(x, n) {
-    return (x % n + n) % n;
-  };
-
-  var cycle = function cycle(channel, current, dir) {
-    var matched = findIndex(current, function (block) {
-      return block.channel === channel;
-    });
-
-    if (matched === -1) {
-      return [[], []];
-    }
-
-    var nextIndex = posMod(current[matched].index + dir, cycled[current[matched].size].length);
-
-    if (nextIndex === current[matched].index) {
-      return [[], []];
-    }
-
-    return [[current[matched]], [assign$1({}, current[matched], {
-      index: nextIndex
-    })]];
-  };
-
-  function _createSuper$9(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct$9()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
-
-  function _isNativeReflectConstruct$9() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
-
-  var Screen = /*#__PURE__*/function (_MidiComponent) {
-    _inherits(Screen, _MidiComponent);
-
-    var _super = _createSuper$9(Screen);
-
-    function Screen(midibus, timerBuilder, controlComponentBuilder, id) {
-      var _this;
-
-      _classCallCheck$1(this, Screen);
-
-      _this = _super.call(this, midibus);
-
-      _defineProperty$1(_assertThisInitialized(_this), "modifier", void 0);
-
-      _defineProperty$1(_assertThisInitialized(_this), "playListSidebar", void 0);
-
-      _defineProperty$1(_assertThisInitialized(_this), "layout", void 0);
-
-      _this.modifier = new ModifierSidebar(midibus);
-      _this.playListSidebar = new PlaylistSidebar(midibus, timerBuilder);
-      _this.layout = new Layout(midibus, controlComponentBuilder, _this.modifier, "".concat(id, ".layout"));
-      return _this;
-    }
-
-    _createClass$1(Screen, [{
-      key: "onMount",
-      value: function onMount() {
-        this.modifier.mount();
-        this.playListSidebar.mount();
-        this.layout.mount();
-      }
-    }, {
-      key: "onUnmount",
-      value: function onUnmount() {
-        this.layout.unmount();
-        this.playListSidebar.unmount();
-        this.modifier.unmount();
-      }
-    }]);
-
-    return Screen;
-  }(MidiComponent);
-
-  function _createSuper$a(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct$a()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
-
-  function _isNativeReflectConstruct$a() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
-  var makeControlComponent = function makeControlComponent(controlBus) {
-    return function (id) {
-      return function (control) {
-        return new ControlComponent(controlBus, id, control);
-      };
-    };
-  };
-
-  var ControlComponent = /*#__PURE__*/function (_Component) {
-    _inherits(ControlComponent, _Component);
-
-    var _super = _createSuper$a(ControlComponent);
-
-    function ControlComponent(controlBus, id, control) {
-      var _this;
-
-      _classCallCheck$1(this, ControlComponent);
-
-      _this = _super.call(this);
-
-      _defineProperty$1(_assertThisInitialized(_this), "value", void 0);
-
-      _defineProperty$1(_assertThisInitialized(_this), "id", void 0);
-
-      _defineProperty$1(_assertThisInitialized(_this), "controlBus", void 0);
-
-      _defineProperty$1(_assertThisInitialized(_this), "control", void 0);
-
-      _defineProperty$1(_assertThisInitialized(_this), "_handle", void 0);
-
-      _this.value = null;
-      _this.id = id;
-      _this.controlBus = controlBus;
-      _this.control = control;
-      _this._handle = null;
-      return _this;
-    }
-
-    _createClass$1(ControlComponent, [{
-      key: "onMount",
-      value: function onMount() {
-        var _this2 = this;
-
-        if (!this._handle) {
-          this._handle = this.controlBus.connect(this.id, this.control.def, function (data) {
-            _this2.value = data.value;
-
-            _this2.emit('update', data);
-          });
-          this.value = this.control.getValue();
-          this.emit('update', this);
-        }
-      }
-    }, {
-      key: "onUnmount",
-      value: function onUnmount() {
-        if (this._handle) {
-          this.controlBus.disconnect(this._handle);
-          this._handle = null;
-        }
-      }
-    }, {
-      key: "setValue",
-      value: function setValue(value) {
-        this.control.setValue(value);
-        this.value = this.control.getValue();
-      }
-    }, {
-      key: "toggleValue",
-      value: function toggleValue() {
-        this.setValue(Number(!this.getValue()));
-      }
-    }, {
-      key: "getValue",
-      value: function getValue() {
-        if (!this._handle) {
-          this.value = this.control.getValue();
-        }
-
-        return this.value;
-      }
-    }]);
-
-    return ControlComponent;
-  }(Component);
-
-  function _createSuper$b(Derived) { return function () { var Super = _getPrototypeOf(Derived), result; if (_isNativeReflectConstruct$b()) { var NewTarget = _getPrototypeOf(this).constructor; result = Reflect.construct(Super, arguments, NewTarget); } else { result = Super.apply(this, arguments); } return _possibleConstructorReturn(this, result); }; }
-
-  function _isNativeReflectConstruct$b() { if (typeof Reflect === "undefined" || !Reflect.construct) return false; if (Reflect.construct.sham) return false; if (typeof Proxy === "function") return true; try { Date.prototype.toString.call(Reflect.construct(Date, [], function () {})); return true; } catch (e) { return false; } }
-  var LaunchpadMidiButton = /*#__PURE__*/function () {
-    function LaunchpadMidiButton(def) {
-      _classCallCheck$1(this, LaunchpadMidiButton);
-
-      _defineProperty$1(this, "def", void 0);
-
-      this.def = def;
-    }
-
-    _createClass$1(LaunchpadMidiButton, [{
-      key: "sendColor",
-      value: function sendColor(value) {
-        midi_1.sendShortMsg(this.def.status, this.def.midino, value);
-      }
-    }]);
-
-    return LaunchpadMidiButton;
-  }();
-
-  var Global = /*#__PURE__*/function (_Component) {
-    _inherits(Global, _Component);
-
-    var _super = _createSuper$b(Global);
-
-    function Global(name, device) {
-      var _this;
-
-      _classCallCheck$1(this, Global);
-
-      _this = _super.call(this);
-
-      _defineProperty$1(_assertThisInitialized(_this), "screen", void 0);
-
-      _defineProperty$1(_assertThisInitialized(_this), "device", void 0);
-
-      _defineProperty$1(_assertThisInitialized(_this), "name", void 0);
-
-      _defineProperty$1(_assertThisInitialized(_this), "init", void 0);
-
-      _defineProperty$1(_assertThisInitialized(_this), "shutdown", void 0);
-
-      _this.name = name;
-      _this.device = device;
-      var timerBuilder = makeTimer(name, _assertThisInitialized(_this));
-      var controlComponentBuilder = makeControlComponent(ControlBus.create(name, _assertThisInitialized(_this)));
-      var midibus = MidiBus.create(_assertThisInitialized(_this), device);
-      _this.screen = new Screen(midibus, timerBuilder, controlComponentBuilder, 'main');
-
-      _this.init = function () {
-        _this.onMount();
-      };
-
-      _this.shutdown = function () {
-        _this.onUnmount();
-      };
-
-      return _this;
-    }
-
-    _createClass$1(Global, [{
-      key: "onMount",
-      value: function onMount() {
-        this.device.init();
-        this.screen.mount();
-      }
-    }, {
-      key: "onUnmount",
-      value: function onUnmount() {
-        this.screen.unmount();
-        this.device.shutdown();
-      }
-    }]);
-
-    return Global;
-  }(Component);
-
-  function create(name, device) {
-    return new Global(name, device);
-  }
-
-  function _typeof2(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof2 = function _typeof2(obj) { return typeof obj; }; } else { _typeof2 = function _typeof2(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof2(obj); }
-
-  function _typeof$1(obj) {
-    if (typeof Symbol === "function" && _typeof2(Symbol.iterator) === "symbol") {
-      _typeof$1 = function _typeof(obj) {
-        return _typeof2(obj);
-      };
-    } else {
-      _typeof$1 = function _typeof(obj) {
-        return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : _typeof2(obj);
-      };
-    }
-
-    return _typeof$1(obj);
-  }
-
-  /** Detect free variable `global` from Node.js. */
-  var freeGlobal$2 = (typeof global === "undefined" ? "undefined" : _typeof$1(global)) == 'object' && global && global.Object === Object && global;
-
-  /** Detect free variable `self`. */
-
-  var freeSelf$2 = (typeof self === "undefined" ? "undefined" : _typeof$1(self)) == 'object' && self && self.Object === Object && self;
-  /** Used as a reference to the global object. */
-
-  var root$2 = freeGlobal$2 || freeSelf$2 || Function('return this')();
-
-  /** Built-in value references. */
-
-  var _Symbol$2 = root$2.Symbol;
-
-  /** Used for built-in method references. */
-
-  var objectProto$n = Object.prototype;
-  /** Used to check objects for own properties. */
-
-  var hasOwnProperty$i = objectProto$n.hasOwnProperty;
-  /**
-   * Used to resolve the
-   * [`toStringTag`](http://ecma-international.org/ecma-262/7.0/#sec-object.prototype.tostring)
-   * of values.
-   */
-
-  var nativeObjectToString$4 = objectProto$n.toString;
-  /** Built-in value references. */
-
-  var symToStringTag$4 = _Symbol$2 ? _Symbol$2.toStringTag : undefined;
-  /**
-   * A specialized version of `baseGetTag` which ignores `Symbol.toStringTag` values.
-   *
-   * @private
-   * @param {*} value The value to query.
-   * @returns {string} Returns the raw `toStringTag`.
-   */
-
-  function getRawTag$2(value) {
-    var isOwn = hasOwnProperty$i.call(value, symToStringTag$4),
-        tag = value[symToStringTag$4];
-
-    try {
-      value[symToStringTag$4] = undefined;
-      var unmasked = true;
-    } catch (e) {}
-
-    var result = nativeObjectToString$4.call(value);
-
-    if (unmasked) {
-      if (isOwn) {
-        value[symToStringTag$4] = tag;
-      } else {
-        delete value[symToStringTag$4];
-      }
-    }
-
-    return result;
-  }
-
-  /** Used for built-in method references. */
-  var objectProto$o = Object.prototype;
-  /**
-   * Used to resolve the
-   * [`toStringTag`](http://ecma-international.org/ecma-262/7.0/#sec-object.prototype.tostring)
-   * of values.
-   */
-
-  var nativeObjectToString$5 = objectProto$o.toString;
-  /**
-   * Converts `value` to a string using `Object.prototype.toString`.
-   *
-   * @private
-   * @param {*} value The value to convert.
-   * @returns {string} Returns the converted string.
-   */
-
-  function objectToString$2(value) {
-    return nativeObjectToString$5.call(value);
-  }
-
-  /** `Object#toString` result references. */
-
-  var nullTag$2 = '[object Null]',
-      undefinedTag$2 = '[object Undefined]';
-  /** Built-in value references. */
-
-  var symToStringTag$5 = _Symbol$2 ? _Symbol$2.toStringTag : undefined;
-  /**
-   * The base implementation of `getTag` without fallbacks for buggy environments.
-   *
-   * @private
-   * @param {*} value The value to query.
-   * @returns {string} Returns the `toStringTag`.
-   */
-
-  function baseGetTag$2(value) {
-    if (value == null) {
-      return value === undefined ? undefinedTag$2 : nullTag$2;
-    }
-
-    return symToStringTag$5 && symToStringTag$5 in Object(value) ? getRawTag$2(value) : objectToString$2(value);
-  }
-
-  /**
-   * Checks if `value` is the
-   * [language type](http://www.ecma-international.org/ecma-262/7.0/#sec-ecmascript-language-types)
-   * of `Object`. (e.g. arrays, functions, objects, regexes, `new Number(0)`, and `new String('')`)
-   *
-   * @static
-   * @memberOf _
-   * @since 0.1.0
-   * @category Lang
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is an object, else `false`.
-   * @example
-   *
-   * _.isObject({});
-   * // => true
-   *
-   * _.isObject([1, 2, 3]);
-   * // => true
-   *
-   * _.isObject(_.noop);
-   * // => true
-   *
-   * _.isObject(null);
-   * // => false
-   */
-  function isObject$2(value) {
-    var type = _typeof$1(value);
-
-    return value != null && (type == 'object' || type == 'function');
-  }
-
-  /** `Object#toString` result references. */
-
-  var asyncTag$2 = '[object AsyncFunction]',
-      funcTag$4 = '[object Function]',
-      genTag$2 = '[object GeneratorFunction]',
-      proxyTag$2 = '[object Proxy]';
-  /**
-   * Checks if `value` is classified as a `Function` object.
-   *
-   * @static
-   * @memberOf _
-   * @since 0.1.0
-   * @category Lang
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is a function, else `false`.
-   * @example
-   *
-   * _.isFunction(_);
-   * // => true
-   *
-   * _.isFunction(/abc/);
-   * // => false
-   */
-
-  function isFunction$2(value) {
-    if (!isObject$2(value)) {
-      return false;
-    } // The use of `Object#toString` avoids issues with the `typeof` operator
-    // in Safari 9 which returns 'object' for typed arrays and other constructors.
-
-
-    var tag = baseGetTag$2(value);
-    return tag == funcTag$4 || tag == genTag$2 || tag == asyncTag$2 || tag == proxyTag$2;
-  }
-
-  /** Used to detect overreaching core-js shims. */
-
-  var coreJsData$2 = root$2['__core-js_shared__'];
-
-  /** Used to detect methods masquerading as native. */
-
-  var maskSrcKey$2 = function () {
-    var uid = /[^.]+$/.exec(coreJsData$2 && coreJsData$2.keys && coreJsData$2.keys.IE_PROTO || '');
-    return uid ? 'Symbol(src)_1.' + uid : '';
-  }();
-  /**
-   * Checks if `func` has its source masked.
-   *
-   * @private
-   * @param {Function} func The function to check.
-   * @returns {boolean} Returns `true` if `func` is masked, else `false`.
-   */
-
-
-  function isMasked$2(func) {
-    return !!maskSrcKey$2 && maskSrcKey$2 in func;
-  }
-
-  /** Used for built-in method references. */
-  var funcProto$4 = Function.prototype;
-  /** Used to resolve the decompiled source of functions. */
-
-  var funcToString$4 = funcProto$4.toString;
-  /**
-   * Converts `func` to its source code.
-   *
-   * @private
-   * @param {Function} func The function to convert.
-   * @returns {string} Returns the source code.
-   */
-
-  function toSource$2(func) {
-    if (func != null) {
-      try {
-        return funcToString$4.call(func);
-      } catch (e) {}
-
-      try {
-        return func + '';
-      } catch (e) {}
-    }
-
-    return '';
-  }
-
-  /**
-   * Used to match `RegExp`
-   * [syntax characters](http://ecma-international.org/ecma-262/7.0/#sec-patterns).
-   */
-
-  var reRegExpChar$2 = /[\\^$.*+?()[\]{}|]/g;
-  /** Used to detect host constructors (Safari). */
-
-  var reIsHostCtor$2 = /^\[object .+?Constructor\]$/;
-  /** Used for built-in method references. */
-
-  var funcProto$5 = Function.prototype,
-      objectProto$p = Object.prototype;
-  /** Used to resolve the decompiled source of functions. */
-
-  var funcToString$5 = funcProto$5.toString;
-  /** Used to check objects for own properties. */
-
-  var hasOwnProperty$j = objectProto$p.hasOwnProperty;
-  /** Used to detect if a method is native. */
-
-  var reIsNative$2 = RegExp('^' + funcToString$5.call(hasOwnProperty$j).replace(reRegExpChar$2, '\\$&').replace(/hasOwnProperty|(function).*?(?=\\\()| for .+?(?=\\\])/g, '$1.*?') + '$');
-  /**
-   * The base implementation of `_.isNative` without bad shim checks.
-   *
-   * @private
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is a native function,
-   *  else `false`.
-   */
-
-  function baseIsNative$2(value) {
-    if (!isObject$2(value) || isMasked$2(value)) {
-      return false;
-    }
-
-    var pattern = isFunction$2(value) ? reIsNative$2 : reIsHostCtor$2;
-    return pattern.test(toSource$2(value));
-  }
-
-  /**
-   * Gets the value at `key` of `object`.
-   *
-   * @private
-   * @param {Object} [object] The object to query.
-   * @param {string} key The key of the property to get.
-   * @returns {*} Returns the property value.
-   */
-  function getValue$2(object, key) {
-    return object == null ? undefined : object[key];
-  }
-
-  /**
-   * Gets the native function at `key` of `object`.
-   *
-   * @private
-   * @param {Object} object The object to query.
-   * @param {string} key The key of the method to get.
-   * @returns {*} Returns the function if it's native, else `undefined`.
-   */
-
-  function getNative$2(object, key) {
-    var value = getValue$2(object, key);
-    return baseIsNative$2(value) ? value : undefined;
-  }
-
-  var defineProperty$2 = function () {
-    try {
-      var func = getNative$2(Object, 'defineProperty');
-      func({}, '', {});
-      return func;
-    } catch (e) {}
-  }();
-
-  /**
-   * The base implementation of `assignValue` and `assignMergeValue` without
-   * value checks.
-   *
-   * @private
-   * @param {Object} object The object to modify.
-   * @param {string} key The key of the property to assign.
-   * @param {*} value The value to assign.
-   */
-
-  function baseAssignValue$2(object, key, value) {
-    if (key == '__proto__' && defineProperty$2) {
-      defineProperty$2(object, key, {
-        'configurable': true,
-        'enumerable': true,
-        'value': value,
-        'writable': true
-      });
-    } else {
-      object[key] = value;
-    }
-  }
-
-  /**
-   * Performs a
-   * [`SameValueZero`](http://ecma-international.org/ecma-262/7.0/#sec-samevaluezero)
-   * comparison between two values to determine if they are equivalent.
-   *
-   * @static
-   * @memberOf _
-   * @since 4.0.0
-   * @category Lang
-   * @param {*} value The value to compare.
-   * @param {*} other The other value to compare.
-   * @returns {boolean} Returns `true` if the values are equivalent, else `false`.
-   * @example
-   *
-   * var object = { 'a': 1 };
-   * var other = { 'a': 1 };
-   *
-   * _.eq(object, object);
-   * // => true
-   *
-   * _.eq(object, other);
-   * // => false
-   *
-   * _.eq('a', 'a');
-   * // => true
-   *
-   * _.eq('a', Object('a'));
-   * // => false
-   *
-   * _.eq(NaN, NaN);
-   * // => true
-   */
-  function eq$2(value, other) {
-    return value === other || value !== value && other !== other;
-  }
-
-  /** Used for built-in method references. */
-
-  var objectProto$q = Object.prototype;
-  /** Used to check objects for own properties. */
-
-  var hasOwnProperty$k = objectProto$q.hasOwnProperty;
-  /**
-   * Assigns `value` to `key` of `object` if the existing value is not equivalent
-   * using [`SameValueZero`](http://ecma-international.org/ecma-262/7.0/#sec-samevaluezero)
-   * for equality comparisons.
-   *
-   * @private
-   * @param {Object} object The object to modify.
-   * @param {string} key The key of the property to assign.
-   * @param {*} value The value to assign.
-   */
-
-  function assignValue$2(object, key, value) {
-    var objValue = object[key];
-
-    if (!(hasOwnProperty$k.call(object, key) && eq$2(objValue, value)) || value === undefined && !(key in object)) {
-      baseAssignValue$2(object, key, value);
-    }
-  }
-
-  /**
-   * Copies properties of `source` to `object`.
-   *
-   * @private
-   * @param {Object} source The object to copy properties from.
-   * @param {Array} props The property identifiers to copy.
-   * @param {Object} [object={}] The object to copy properties to.
-   * @param {Function} [customizer] The function to customize copied values.
-   * @returns {Object} Returns `object`.
-   */
-
-  function copyObject$2(source, props, object, customizer) {
-    var isNew = !object;
-    object || (object = {});
-    var index = -1,
-        length = props.length;
-
-    while (++index < length) {
-      var key = props[index];
-      var newValue = customizer ? customizer(object[key], source[key], key, object, source) : undefined;
-
-      if (newValue === undefined) {
-        newValue = source[key];
-      }
-
-      if (isNew) {
-        baseAssignValue$2(object, key, newValue);
-      } else {
-        assignValue$2(object, key, newValue);
-      }
-    }
-
-    return object;
-  }
-
-  /**
-   * This method returns the first argument it receives.
-   *
-   * @static
-   * @since 0.1.0
-   * @memberOf _
-   * @category Util
-   * @param {*} value Any value.
-   * @returns {*} Returns `value`.
-   * @example
-   *
-   * var object = { 'a': 1 };
-   *
-   * console.log(_.identity(object) === object);
-   * // => true
-   */
-  function identity$2(value) {
-    return value;
-  }
-
-  /**
-   * A faster alternative to `Function#apply`, this function invokes `func`
-   * with the `this` binding of `thisArg` and the arguments of `args`.
-   *
-   * @private
-   * @param {Function} func The function to invoke.
-   * @param {*} thisArg The `this` binding of `func`.
-   * @param {Array} args The arguments to invoke `func` with.
-   * @returns {*} Returns the result of `func`.
-   */
-  function apply$2(func, thisArg, args) {
-    switch (args.length) {
-      case 0:
-        return func.call(thisArg);
-
-      case 1:
-        return func.call(thisArg, args[0]);
-
-      case 2:
-        return func.call(thisArg, args[0], args[1]);
-
-      case 3:
-        return func.call(thisArg, args[0], args[1], args[2]);
-    }
-
-    return func.apply(thisArg, args);
-  }
-
-  /* Built-in method references for those with the same name as other `lodash` methods. */
-
-  var nativeMax$5 = Math.max;
-  /**
-   * A specialized version of `baseRest` which transforms the rest array.
-   *
-   * @private
-   * @param {Function} func The function to apply a rest parameter to.
-   * @param {number} [start=func.length-1] The start position of the rest parameter.
-   * @param {Function} transform The rest array transform.
-   * @returns {Function} Returns the new function.
-   */
-
-  function overRest$2(func, start, transform) {
-    start = nativeMax$5(start === undefined ? func.length - 1 : start, 0);
-    return function () {
-      var args = arguments,
-          index = -1,
-          length = nativeMax$5(args.length - start, 0),
-          array = Array(length);
-
-      while (++index < length) {
-        array[index] = args[start + index];
-      }
-
-      index = -1;
-      var otherArgs = Array(start + 1);
-
-      while (++index < start) {
-        otherArgs[index] = args[index];
-      }
-
-      otherArgs[start] = transform(array);
-      return apply$2(func, this, otherArgs);
-    };
-  }
-
-  /**
-   * Creates a function that returns `value`.
-   *
-   * @static
-   * @memberOf _
-   * @since 2.4.0
-   * @category Util
-   * @param {*} value The value to return from the new function.
-   * @returns {Function} Returns the new constant function.
-   * @example
-   *
-   * var objects = _.times(2, _.constant({ 'a': 1 }));
-   *
-   * console.log(objects);
-   * // => [{ 'a': 1 }, { 'a': 1 }]
-   *
-   * console.log(objects[0] === objects[1]);
-   * // => true
-   */
-  function constant$2(value) {
-    return function () {
-      return value;
-    };
-  }
-
-  /**
-   * The base implementation of `setToString` without support for hot loop shorting.
-   *
-   * @private
-   * @param {Function} func The function to modify.
-   * @param {Function} string The `toString` result.
-   * @returns {Function} Returns `func`.
-   */
-
-  var baseSetToString$2 = !defineProperty$2 ? identity$2 : function (func, string) {
-    return defineProperty$2(func, 'toString', {
-      'configurable': true,
-      'enumerable': false,
-      'value': constant$2(string),
-      'writable': true
-    });
-  };
-
-  /** Used to detect hot functions by number of calls within a span of milliseconds. */
-  var HOT_COUNT$2 = 800,
-      HOT_SPAN$2 = 16;
-  /* Built-in method references for those with the same name as other `lodash` methods. */
-
-  var nativeNow$2 = Date.now;
-  /**
-   * Creates a function that'll short out and invoke `identity` instead
-   * of `func` when it's called `HOT_COUNT` or more times in `HOT_SPAN`
-   * milliseconds.
-   *
-   * @private
-   * @param {Function} func The function to restrict.
-   * @returns {Function} Returns the new shortable function.
-   */
-
-  function shortOut$2(func) {
-    var count = 0,
-        lastCalled = 0;
-    return function () {
-      var stamp = nativeNow$2(),
-          remaining = HOT_SPAN$2 - (stamp - lastCalled);
-      lastCalled = stamp;
-
-      if (remaining > 0) {
-        if (++count >= HOT_COUNT$2) {
-          return arguments[0];
-        }
-      } else {
-        count = 0;
-      }
-
-      return func.apply(undefined, arguments);
-    };
-  }
-
-  /**
-   * Sets the `toString` method of `func` to return `string`.
-   *
-   * @private
-   * @param {Function} func The function to modify.
-   * @param {Function} string The `toString` result.
-   * @returns {Function} Returns `func`.
-   */
-
-  var setToString$2 = shortOut$2(baseSetToString$2);
-
-  /**
-   * The base implementation of `_.rest` which doesn't validate or coerce arguments.
-   *
-   * @private
-   * @param {Function} func The function to apply a rest parameter to.
-   * @param {number} [start=func.length-1] The start position of the rest parameter.
-   * @returns {Function} Returns the new function.
-   */
-
-  function baseRest$2(func, start) {
-    return setToString$2(overRest$2(func, start, identity$2), func + '');
-  }
-
-  /** Used as references for various `Number` constants. */
-  var MAX_SAFE_INTEGER$4 = 9007199254740991;
-  /**
-   * Checks if `value` is a valid array-like length.
-   *
-   * **Note:** This method is loosely based on
-   * [`ToLength`](http://ecma-international.org/ecma-262/7.0/#sec-tolength).
-   *
-   * @static
-   * @memberOf _
-   * @since 4.0.0
-   * @category Lang
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is a valid length, else `false`.
-   * @example
-   *
-   * _.isLength(3);
-   * // => true
-   *
-   * _.isLength(Number.MIN_VALUE);
-   * // => false
-   *
-   * _.isLength(Infinity);
-   * // => false
-   *
-   * _.isLength('3');
-   * // => false
-   */
-
-  function isLength$2(value) {
-    return typeof value == 'number' && value > -1 && value % 1 == 0 && value <= MAX_SAFE_INTEGER$4;
-  }
-
-  /**
-   * Checks if `value` is array-like. A value is considered array-like if it's
-   * not a function and has a `value.length` that's an integer greater than or
-   * equal to `0` and less than or equal to `Number.MAX_SAFE_INTEGER`.
-   *
-   * @static
-   * @memberOf _
-   * @since 4.0.0
-   * @category Lang
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is array-like, else `false`.
-   * @example
-   *
-   * _.isArrayLike([1, 2, 3]);
-   * // => true
-   *
-   * _.isArrayLike(document.body.children);
-   * // => true
-   *
-   * _.isArrayLike('abc');
-   * // => true
-   *
-   * _.isArrayLike(_.noop);
-   * // => false
-   */
-
-  function isArrayLike$2(value) {
-    return value != null && isLength$2(value.length) && !isFunction$2(value);
-  }
-
-  /** Used as references for various `Number` constants. */
-  var MAX_SAFE_INTEGER$5 = 9007199254740991;
-  /** Used to detect unsigned integer values. */
-
-  var reIsUint$2 = /^(?:0|[1-9]\d*)$/;
-  /**
-   * Checks if `value` is a valid array-like index.
-   *
-   * @private
-   * @param {*} value The value to check.
-   * @param {number} [length=MAX_SAFE_INTEGER] The upper bounds of a valid index.
-   * @returns {boolean} Returns `true` if `value` is a valid index, else `false`.
-   */
-
-  function isIndex$2(value, length) {
-    var type = _typeof$1(value);
-
-    length = length == null ? MAX_SAFE_INTEGER$5 : length;
-    return !!length && (type == 'number' || type != 'symbol' && reIsUint$2.test(value)) && value > -1 && value % 1 == 0 && value < length;
-  }
-
-  /**
-   * Checks if the given arguments are from an iteratee call.
-   *
-   * @private
-   * @param {*} value The potential iteratee value argument.
-   * @param {*} index The potential iteratee index or key argument.
-   * @param {*} object The potential iteratee object argument.
-   * @returns {boolean} Returns `true` if the arguments are from an iteratee call,
-   *  else `false`.
-   */
-
-  function isIterateeCall$2(value, index, object) {
-    if (!isObject$2(object)) {
-      return false;
-    }
-
-    var type = _typeof$1(index);
-
-    if (type == 'number' ? isArrayLike$2(object) && isIndex$2(index, object.length) : type == 'string' && index in object) {
-      return eq$2(object[index], value);
-    }
-
-    return false;
-  }
-
-  /**
-   * Creates a function like `_.assign`.
-   *
-   * @private
-   * @param {Function} assigner The function to assign values.
-   * @returns {Function} Returns the new assigner function.
-   */
-
-  function createAssigner$2(assigner) {
-    return baseRest$2(function (object, sources) {
-      var index = -1,
-          length = sources.length,
-          customizer = length > 1 ? sources[length - 1] : undefined,
-          guard = length > 2 ? sources[2] : undefined;
-      customizer = assigner.length > 3 && typeof customizer == 'function' ? (length--, customizer) : undefined;
-
-      if (guard && isIterateeCall$2(sources[0], sources[1], guard)) {
-        customizer = length < 3 ? undefined : customizer;
-        length = 1;
-      }
-
-      object = Object(object);
-
-      while (++index < length) {
-        var source = sources[index];
-
-        if (source) {
-          assigner(object, source, index, customizer);
-        }
-      }
-
-      return object;
-    });
-  }
-
-  /** Used for built-in method references. */
-  var objectProto$r = Object.prototype;
-  /**
-   * Checks if `value` is likely a prototype object.
-   *
-   * @private
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is a prototype, else `false`.
-   */
-
-  function isPrototype$2(value) {
-    var Ctor = value && value.constructor,
-        proto = typeof Ctor == 'function' && Ctor.prototype || objectProto$r;
-    return value === proto;
-  }
-
-  /**
-   * The base implementation of `_.times` without support for iteratee shorthands
-   * or max array length checks.
-   *
-   * @private
-   * @param {number} n The number of times to invoke `iteratee`.
-   * @param {Function} iteratee The function invoked per iteration.
-   * @returns {Array} Returns the array of results.
-   */
-  function baseTimes$2(n, iteratee) {
-    var index = -1,
-        result = Array(n);
-
-    while (++index < n) {
-      result[index] = iteratee(index);
-    }
-
-    return result;
-  }
-
-  /**
-   * Checks if `value` is object-like. A value is object-like if it's not `null`
-   * and has a `typeof` result of "object".
-   *
-   * @static
-   * @memberOf _
-   * @since 4.0.0
-   * @category Lang
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is object-like, else `false`.
-   * @example
-   *
-   * _.isObjectLike({});
-   * // => true
-   *
-   * _.isObjectLike([1, 2, 3]);
-   * // => true
-   *
-   * _.isObjectLike(_.noop);
-   * // => false
-   *
-   * _.isObjectLike(null);
-   * // => false
-   */
-  function isObjectLike$2(value) {
-    return value != null && _typeof$1(value) == 'object';
-  }
-
-  /** `Object#toString` result references. */
-
-  var argsTag$5 = '[object Arguments]';
-  /**
-   * The base implementation of `_.isArguments`.
-   *
-   * @private
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is an `arguments` object,
-   */
-
-  function baseIsArguments$2(value) {
-    return isObjectLike$2(value) && baseGetTag$2(value) == argsTag$5;
-  }
-
-  /** Used for built-in method references. */
-
-  var objectProto$s = Object.prototype;
-  /** Used to check objects for own properties. */
-
-  var hasOwnProperty$l = objectProto$s.hasOwnProperty;
-  /** Built-in value references. */
-
-  var propertyIsEnumerable$3 = objectProto$s.propertyIsEnumerable;
-  /**
-   * Checks if `value` is likely an `arguments` object.
-   *
-   * @static
-   * @memberOf _
-   * @since 0.1.0
-   * @category Lang
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is an `arguments` object,
-   *  else `false`.
-   * @example
-   *
-   * _.isArguments(function() { return arguments; }());
-   * // => true
-   *
-   * _.isArguments([1, 2, 3]);
-   * // => false
-   */
-
-  var isArguments$2 = baseIsArguments$2(function () {
-    return arguments;
-  }()) ? baseIsArguments$2 : function (value) {
-    return isObjectLike$2(value) && hasOwnProperty$l.call(value, 'callee') && !propertyIsEnumerable$3.call(value, 'callee');
-  };
-
-  /**
-   * Checks if `value` is classified as an `Array` object.
-   *
-   * @static
-   * @memberOf _
-   * @since 0.1.0
-   * @category Lang
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is an array, else `false`.
-   * @example
-   *
-   * _.isArray([1, 2, 3]);
-   * // => true
-   *
-   * _.isArray(document.body.children);
-   * // => false
-   *
-   * _.isArray('abc');
-   * // => false
-   *
-   * _.isArray(_.noop);
-   * // => false
-   */
-  var isArray$2 = Array.isArray;
-
-  /**
-   * This method returns `false`.
-   *
-   * @static
-   * @memberOf _
-   * @since 4.13.0
-   * @category Util
-   * @returns {boolean} Returns `false`.
-   * @example
-   *
-   * _.times(2, _.stubFalse);
-   * // => [false, false]
-   */
-  function stubFalse$2() {
-    return false;
-  }
-
-  /** Detect free variable `exports`. */
-
-  var freeExports$4 = (typeof exports === "undefined" ? "undefined" : _typeof$1(exports)) == 'object' && exports && !exports.nodeType && exports;
-  /** Detect free variable `module`. */
-
-  var freeModule$4 = freeExports$4 && (typeof module === "undefined" ? "undefined" : _typeof$1(module)) == 'object' && module && !module.nodeType && module;
-  /** Detect the popular CommonJS extension `module.exports`. */
-
-  var moduleExports$4 = freeModule$4 && freeModule$4.exports === freeExports$4;
-  /** Built-in value references. */
-
-  var Buffer$2 = moduleExports$4 ? root$2.Buffer : undefined;
-  /* Built-in method references for those with the same name as other `lodash` methods. */
-
-  var nativeIsBuffer$2 = Buffer$2 ? Buffer$2.isBuffer : undefined;
-  /**
-   * Checks if `value` is a buffer.
-   *
-   * @static
-   * @memberOf _
-   * @since 4.3.0
-   * @category Lang
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is a buffer, else `false`.
-   * @example
-   *
-   * _.isBuffer(new Buffer(2));
-   * // => true
-   *
-   * _.isBuffer(new Uint8Array(2));
-   * // => false
-   */
-
-  var isBuffer$2 = nativeIsBuffer$2 || stubFalse$2;
-
-  /** `Object#toString` result references. */
-
-  var argsTag$6 = '[object Arguments]',
-      arrayTag$3 = '[object Array]',
-      boolTag$3 = '[object Boolean]',
-      dateTag$3 = '[object Date]',
-      errorTag$3 = '[object Error]',
-      funcTag$5 = '[object Function]',
-      mapTag$4 = '[object Map]',
-      numberTag$3 = '[object Number]',
-      objectTag$4 = '[object Object]',
-      regexpTag$3 = '[object RegExp]',
-      setTag$4 = '[object Set]',
-      stringTag$3 = '[object String]',
-      weakMapTag$3 = '[object WeakMap]';
-  var arrayBufferTag$3 = '[object ArrayBuffer]',
-      dataViewTag$4 = '[object DataView]',
-      float32Tag$2 = '[object Float32Array]',
-      float64Tag$2 = '[object Float64Array]',
-      int8Tag$2 = '[object Int8Array]',
-      int16Tag$2 = '[object Int16Array]',
-      int32Tag$2 = '[object Int32Array]',
-      uint8Tag$2 = '[object Uint8Array]',
-      uint8ClampedTag$2 = '[object Uint8ClampedArray]',
-      uint16Tag$2 = '[object Uint16Array]',
-      uint32Tag$2 = '[object Uint32Array]';
-  /** Used to identify `toStringTag` values of typed arrays. */
-
-  var typedArrayTags$2 = {};
-  typedArrayTags$2[float32Tag$2] = typedArrayTags$2[float64Tag$2] = typedArrayTags$2[int8Tag$2] = typedArrayTags$2[int16Tag$2] = typedArrayTags$2[int32Tag$2] = typedArrayTags$2[uint8Tag$2] = typedArrayTags$2[uint8ClampedTag$2] = typedArrayTags$2[uint16Tag$2] = typedArrayTags$2[uint32Tag$2] = true;
-  typedArrayTags$2[argsTag$6] = typedArrayTags$2[arrayTag$3] = typedArrayTags$2[arrayBufferTag$3] = typedArrayTags$2[boolTag$3] = typedArrayTags$2[dataViewTag$4] = typedArrayTags$2[dateTag$3] = typedArrayTags$2[errorTag$3] = typedArrayTags$2[funcTag$5] = typedArrayTags$2[mapTag$4] = typedArrayTags$2[numberTag$3] = typedArrayTags$2[objectTag$4] = typedArrayTags$2[regexpTag$3] = typedArrayTags$2[setTag$4] = typedArrayTags$2[stringTag$3] = typedArrayTags$2[weakMapTag$3] = false;
-  /**
-   * The base implementation of `_.isTypedArray` without Node.js optimizations.
-   *
-   * @private
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is a typed array, else `false`.
-   */
-
-  function baseIsTypedArray$2(value) {
-    return isObjectLike$2(value) && isLength$2(value.length) && !!typedArrayTags$2[baseGetTag$2(value)];
-  }
-
-  /**
-   * The base implementation of `_.unary` without support for storing metadata.
-   *
-   * @private
-   * @param {Function} func The function to cap arguments for.
-   * @returns {Function} Returns the new capped function.
-   */
-  function baseUnary$2(func) {
-    return function (value) {
-      return func(value);
-    };
-  }
-
-  /** Detect free variable `exports`. */
-
-  var freeExports$5 = (typeof exports === "undefined" ? "undefined" : _typeof$1(exports)) == 'object' && exports && !exports.nodeType && exports;
-  /** Detect free variable `module`. */
-
-  var freeModule$5 = freeExports$5 && (typeof module === "undefined" ? "undefined" : _typeof$1(module)) == 'object' && module && !module.nodeType && module;
-  /** Detect the popular CommonJS extension `module.exports`. */
-
-  var moduleExports$5 = freeModule$5 && freeModule$5.exports === freeExports$5;
-  /** Detect free variable `process` from Node.js. */
-
-  var freeProcess$2 = moduleExports$5 && freeGlobal$2.process;
-  /** Used to access faster Node.js helpers. */
-
-  var nodeUtil$2 = function () {
-    try {
-      // Use `util.types` for Node.js 10+.
-      var types = freeModule$5 && freeModule$5.require && freeModule$5.require('util').types;
-
-      if (types) {
-        return types;
-      } // Legacy `process.binding('util')` for Node.js < 10.
-
-
-      return freeProcess$2 && freeProcess$2.binding && freeProcess$2.binding('util');
-    } catch (e) {}
-  }();
-
-  /* Node.js helper references. */
-
-  var nodeIsTypedArray$2 = nodeUtil$2 && nodeUtil$2.isTypedArray;
-  /**
-   * Checks if `value` is classified as a typed array.
-   *
-   * @static
-   * @memberOf _
-   * @since 3.0.0
-   * @category Lang
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is a typed array, else `false`.
-   * @example
-   *
-   * _.isTypedArray(new Uint8Array);
-   * // => true
-   *
-   * _.isTypedArray([]);
-   * // => false
-   */
-
-  var isTypedArray$2 = nodeIsTypedArray$2 ? baseUnary$2(nodeIsTypedArray$2) : baseIsTypedArray$2;
-
-  /** Used for built-in method references. */
-
-  var objectProto$t = Object.prototype;
-  /** Used to check objects for own properties. */
-
-  var hasOwnProperty$m = objectProto$t.hasOwnProperty;
-  /**
-   * Creates an array of the enumerable property names of the array-like `value`.
-   *
-   * @private
-   * @param {*} value The value to query.
-   * @param {boolean} inherited Specify returning inherited property names.
-   * @returns {Array} Returns the array of property names.
-   */
-
-  function arrayLikeKeys$2(value, inherited) {
-    var isArr = isArray$2(value),
-        isArg = !isArr && isArguments$2(value),
-        isBuff = !isArr && !isArg && isBuffer$2(value),
-        isType = !isArr && !isArg && !isBuff && isTypedArray$2(value),
-        skipIndexes = isArr || isArg || isBuff || isType,
-        result = skipIndexes ? baseTimes$2(value.length, String) : [],
-        length = result.length;
-
-    for (var key in value) {
-      if ((inherited || hasOwnProperty$m.call(value, key)) && !(skipIndexes && ( // Safari 9 has enumerable `arguments.length` in strict mode.
-      key == 'length' || // Node.js 0.10 has enumerable non-index properties on buffers.
-      isBuff && (key == 'offset' || key == 'parent') || // PhantomJS 2 has enumerable non-index properties on typed arrays.
-      isType && (key == 'buffer' || key == 'byteLength' || key == 'byteOffset') || // Skip index properties.
-      isIndex$2(key, length)))) {
-        result.push(key);
-      }
-    }
-
-    return result;
-  }
-
-  /**
-   * Creates a unary function that invokes `func` with its argument transformed.
-   *
-   * @private
-   * @param {Function} func The function to wrap.
-   * @param {Function} transform The argument transform.
-   * @returns {Function} Returns the new function.
-   */
-  function overArg$2(func, transform) {
-    return function (arg) {
-      return func(transform(arg));
-    };
-  }
-
-  /* Built-in method references for those with the same name as other `lodash` methods. */
-
-  var nativeKeys$2 = overArg$2(Object.keys, Object);
-
-  /** Used for built-in method references. */
-
-  var objectProto$u = Object.prototype;
-  /** Used to check objects for own properties. */
-
-  var hasOwnProperty$n = objectProto$u.hasOwnProperty;
-  /**
-   * The base implementation of `_.keys` which doesn't treat sparse arrays as dense.
-   *
-   * @private
-   * @param {Object} object The object to query.
-   * @returns {Array} Returns the array of property names.
-   */
-
-  function baseKeys$2(object) {
-    if (!isPrototype$2(object)) {
-      return nativeKeys$2(object);
-    }
-
-    var result = [];
-
-    for (var key in Object(object)) {
-      if (hasOwnProperty$n.call(object, key) && key != 'constructor') {
-        result.push(key);
-      }
-    }
-
-    return result;
-  }
-
-  /**
-   * Creates an array of the own enumerable property names of `object`.
-   *
-   * **Note:** Non-object values are coerced to objects. See the
-   * [ES spec](http://ecma-international.org/ecma-262/7.0/#sec-object.keys)
-   * for more details.
-   *
-   * @static
-   * @since 0.1.0
-   * @memberOf _
-   * @category Object
-   * @param {Object} object The object to query.
-   * @returns {Array} Returns the array of property names.
-   * @example
-   *
-   * function Foo() {
-   *   this.a = 1;
-   *   this.b = 2;
-   * }
-   *
-   * Foo.prototype.c = 3;
-   *
-   * _.keys(new Foo);
-   * // => ['a', 'b'] (iteration order is not guaranteed)
-   *
-   * _.keys('hi');
-   * // => ['0', '1']
-   */
-
-  function keys$2(object) {
-    return isArrayLike$2(object) ? arrayLikeKeys$2(object) : baseKeys$2(object);
-  }
-
-  /** Used for built-in method references. */
-
-  var objectProto$v = Object.prototype;
-  /** Used to check objects for own properties. */
-
-  var hasOwnProperty$o = objectProto$v.hasOwnProperty;
-  /**
-   * Assigns own enumerable string keyed properties of source objects to the
-   * destination object. Source objects are applied from left to right.
-   * Subsequent sources overwrite property assignments of previous sources.
-   *
-   * **Note:** This method mutates `object` and is loosely based on
-   * [`Object.assign`](https://mdn.io/Object/assign).
-   *
-   * @static
-   * @memberOf _
-   * @since 0.10.0
-   * @category Object
-   * @param {Object} object The destination object.
-   * @param {...Object} [sources] The source objects.
-   * @returns {Object} Returns `object`.
-   * @see _.assignIn
-   * @example
-   *
-   * function Foo() {
-   *   this.a = 1;
-   * }
-   *
-   * function Bar() {
-   *   this.c = 3;
-   * }
-   *
-   * Foo.prototype.b = 2;
-   * Bar.prototype.d = 4;
-   *
-   * _.assign({ 'a': 0 }, new Foo, new Bar);
-   * // => { 'a': 1, 'c': 3 }
-   */
-
-  var assign$2 = createAssigner$2(function (object, source) {
-    if (isPrototype$2(source) || isArrayLike$2(source)) {
-      copyObject$2(source, keys$2(source), object);
-      return;
-    }
-
-    for (var key in source) {
-      if (hasOwnProperty$o.call(source, key)) {
-        assignValue$2(object, key, source[key]);
-      }
-    }
-  });
-
-  var name = "@mixxx-launchpad/mk2";
-  var version = "1.0.0";
-  var main = "src/index.js";
-  var module$1 = "src/index.js";
-  var dependencies = {
-  	"@babel/runtime": "^7.3.1",
-  	"@mixxx-launchpad/app": "1.0.0",
-  	"lodash-es": "~4.17.14"
-  };
-  var controller = {
-  	device: "Launchpad MK2",
-  	manufacturer: "Novation",
-  	global: "NovationLaunchpadMK2",
-  	path: "src"
-  };
-  var pkg = {
-  	name: name,
-  	"private": true,
-  	version: version,
-  	main: main,
-  	module: module$1,
-  	dependencies: dependencies,
-  	controller: controller
-  };
-
-  var colors = {
-    black: 0,
-    lo_red: 7,
-    hi_red: 5,
-    lo_green: 19,
-    hi_green: 17,
-    lo_amber: 43,
-    hi_amber: 41,
-    hi_orange: 84,
-    lo_orange: 61,
-    hi_yellow: 13,
-    lo_yellow: 15
-  };
-
-  var buttons = {
-    /* eslint-disable key-spacing, no-multi-spaces */
-    up: {
-      status: 0xB0,
-      midino: 0x68,
-      name: 'up'
-    },
-    down: {
-      status: 0xB0,
-      midino: 0x69,
-      name: 'down'
-    },
-    left: {
-      status: 0xB0,
-      midino: 0x6A,
-      name: 'left'
-    },
-    right: {
-      status: 0xB0,
-      midino: 0x6B,
-      name: 'right'
-    },
-    session: {
-      status: 0xB0,
-      midino: 0x6C,
-      name: 'session'
-    },
-    user1: {
-      status: 0xB0,
-      midino: 0x6D,
-      name: 'user1'
-    },
-    user2: {
-      status: 0xB0,
-      midino: 0x6E,
-      name: 'user2'
-    },
-    mixer: {
-      status: 0xB0,
-      midino: 0x6F,
-      name: 'mixer'
-    },
-    vol: {
-      status: 0x90,
-      midino: 0x59,
-      name: 'vol'
-    },
-    pan: {
-      status: 0x90,
-      midino: 0x4F,
-      name: 'pan'
-    },
-    snda: {
-      status: 0x90,
-      midino: 0x45,
-      name: 'snda'
-    },
-    sndb: {
-      status: 0x90,
-      midino: 0x3B,
-      name: 'sndb'
-    },
-    stop: {
-      status: 0x90,
-      midino: 0x31,
-      name: 'stop'
-    },
-    trkon: {
-      status: 0x90,
-      midino: 0x27,
-      name: 'trkon'
-    },
-    solo: {
-      status: 0x90,
-      midino: 0x1D,
-      name: 'solo'
-    },
-    arm: {
-      status: 0x90,
-      midino: 0x13,
-      name: 'arm'
-    },
-    '0,0': {
-      status: 0x90,
-      midino: 0x51,
-      name: '0,0'
-    },
-    '0,1': {
-      status: 0x90,
-      midino: 0x52,
-      name: '0,1'
-    },
-    '0,2': {
-      status: 0x90,
-      midino: 0x53,
-      name: '0,2'
-    },
-    '0,3': {
-      status: 0x90,
-      midino: 0x54,
-      name: '0,3'
-    },
-    '0,4': {
-      status: 0x90,
-      midino: 0x55,
-      name: '0,4'
-    },
-    '0,5': {
-      status: 0x90,
-      midino: 0x56,
-      name: '0,5'
-    },
-    '0,6': {
-      status: 0x90,
-      midino: 0x57,
-      name: '0,6'
-    },
-    '0,7': {
-      status: 0x90,
-      midino: 0x58,
-      name: '0,7'
-    },
-    '1,0': {
-      status: 0x90,
-      midino: 0x47,
-      name: '1,0'
-    },
-    '1,1': {
-      status: 0x90,
-      midino: 0x48,
-      name: '1,1'
-    },
-    '1,2': {
-      status: 0x90,
-      midino: 0x49,
-      name: '1,2'
-    },
-    '1,3': {
-      status: 0x90,
-      midino: 0x4A,
-      name: '1,3'
-    },
-    '1,4': {
-      status: 0x90,
-      midino: 0x4B,
-      name: '1,4'
-    },
-    '1,5': {
-      status: 0x90,
-      midino: 0x4C,
-      name: '1,5'
-    },
-    '1,6': {
-      status: 0x90,
-      midino: 0x4D,
-      name: '1,6'
-    },
-    '1,7': {
-      status: 0x90,
-      midino: 0x4E,
-      name: '1,7'
-    },
-    '2,0': {
-      status: 0x90,
-      midino: 0x3D,
-      name: '2,0'
-    },
-    '2,1': {
-      status: 0x90,
-      midino: 0x3E,
-      name: '2,1'
-    },
-    '2,2': {
-      status: 0x90,
-      midino: 0x3F,
-      name: '2,2'
-    },
-    '2,3': {
-      status: 0x90,
-      midino: 0x40,
-      name: '2,3'
-    },
-    '2,4': {
-      status: 0x90,
-      midino: 0x41,
-      name: '2,4'
-    },
-    '2,5': {
-      status: 0x90,
-      midino: 0x42,
-      name: '2,5'
-    },
-    '2,6': {
-      status: 0x90,
-      midino: 0x43,
-      name: '2,6'
-    },
-    '2,7': {
-      status: 0x90,
-      midino: 0x44,
-      name: '2,7'
-    },
-    '3,0': {
-      status: 0x90,
-      midino: 0x33,
-      name: '3,0'
-    },
-    '3,1': {
-      status: 0x90,
-      midino: 0x34,
-      name: '3,1'
-    },
-    '3,2': {
-      status: 0x90,
-      midino: 0x35,
-      name: '3,2'
-    },
-    '3,3': {
-      status: 0x90,
-      midino: 0x36,
-      name: '3,3'
-    },
-    '3,4': {
-      status: 0x90,
-      midino: 0x37,
-      name: '3,4'
-    },
-    '3,5': {
-      status: 0x90,
-      midino: 0x38,
-      name: '3,5'
-    },
-    '3,6': {
-      status: 0x90,
-      midino: 0x39,
-      name: '3,6'
-    },
-    '3,7': {
-      status: 0x90,
-      midino: 0x3A,
-      name: '3,7'
-    },
-    '4,0': {
-      status: 0x90,
-      midino: 0x29,
-      name: '4,0'
-    },
-    '4,1': {
-      status: 0x90,
-      midino: 0x2A,
-      name: '4,1'
-    },
-    '4,2': {
-      status: 0x90,
-      midino: 0x2B,
-      name: '4,2'
-    },
-    '4,3': {
-      status: 0x90,
-      midino: 0x2C,
-      name: '4,3'
-    },
-    '4,4': {
-      status: 0x90,
-      midino: 0x2D,
-      name: '4,4'
-    },
-    '4,5': {
-      status: 0x90,
-      midino: 0x2E,
-      name: '4,5'
-    },
-    '4,6': {
-      status: 0x90,
-      midino: 0x2F,
-      name: '4,6'
-    },
-    '4,7': {
-      status: 0x90,
-      midino: 0x30,
-      name: '4,7'
-    },
-    '5,0': {
-      status: 0x90,
-      midino: 0x1F,
-      name: '5,0'
-    },
-    '5,1': {
-      status: 0x90,
-      midino: 0x20,
-      name: '5,1'
-    },
-    '5,2': {
-      status: 0x90,
-      midino: 0x21,
-      name: '5,2'
-    },
-    '5,3': {
-      status: 0x90,
-      midino: 0x22,
-      name: '5,3'
-    },
-    '5,4': {
-      status: 0x90,
-      midino: 0x23,
-      name: '5,4'
-    },
-    '5,5': {
-      status: 0x90,
-      midino: 0x24,
-      name: '5,5'
-    },
-    '5,6': {
-      status: 0x90,
-      midino: 0x25,
-      name: '5,6'
-    },
-    '5,7': {
-      status: 0x90,
-      midino: 0x26,
-      name: '5,7'
-    },
-    '6,0': {
-      status: 0x90,
-      midino: 0x15,
-      name: '6,0'
-    },
-    '6,1': {
-      status: 0x90,
-      midino: 0x16,
-      name: '6,1'
-    },
-    '6,2': {
-      status: 0x90,
-      midino: 0x17,
-      name: '6,2'
-    },
-    '6,3': {
-      status: 0x90,
-      midino: 0x18,
-      name: '6,3'
-    },
-    '6,4': {
-      status: 0x90,
-      midino: 0x19,
-      name: '6,4'
-    },
-    '6,5': {
-      status: 0x90,
-      midino: 0x1A,
-      name: '6,5'
-    },
-    '6,6': {
-      status: 0x90,
-      midino: 0x1B,
-      name: '6,6'
-    },
-    '6,7': {
-      status: 0x90,
-      midino: 0x1C,
-      name: '6,7'
-    },
-    '7,0': {
-      status: 0x90,
-      midino: 0x0B,
-      name: '7,0'
-    },
-    '7,1': {
-      status: 0x90,
-      midino: 0x0C,
-      name: '7,1'
-    },
-    '7,2': {
-      status: 0x90,
-      midino: 0x0D,
-      name: '7,2'
-    },
-    '7,3': {
-      status: 0x90,
-      midino: 0x0E,
-      name: '7,3'
-    },
-    '7,4': {
-      status: 0x90,
-      midino: 0x0F,
-      name: '7,4'
-    },
-    '7,5': {
-      status: 0x90,
-      midino: 0x10,
-      name: '7,5'
-    },
-    '7,6': {
-      status: 0x90,
-      midino: 0x11,
-      name: '7,6'
-    },
-    '7,7': {
-      status: 0x90,
-      midino: 0x12,
-      name: '7,7'
-    }
-    /* eslint-enable key-spacing, no-multi-spaces */
-
-  };
-
-  var LaunchpadMK2Device = /*#__PURE__*/function () {
-    function LaunchpadMK2Device() {
-      _classCallCheck(this, LaunchpadMK2Device);
-
-      _defineProperty(this, "buttons", void 0);
-
-      _defineProperty(this, "colors", void 0);
-
-      this.buttons = Object.keys(buttons).reduce(function (obj, name) {
-        return assign$2(obj, _defineProperty({}, name, new LaunchpadMidiButton(buttons[name])));
-      }, {});
-      this.colors = colors;
-    }
-
-    _createClass(LaunchpadMK2Device, [{
-      key: "init",
-      value: function init() {}
-    }, {
-      key: "shutdown",
-      value: function shutdown() {}
-    }]);
-
-    return LaunchpadMK2Device;
-  }();
-
-  var index = create(pkg.controller.global, new LaunchpadMK2Device());
-
-  return index;
-
-}());
+var NLMK2 = (function () {
+	'use strict';
+
+	var commonjsGlobal = typeof globalThis !== 'undefined' ? globalThis : typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {};
+
+	function getDefaultExportFromCjs (x) {
+		return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, 'default') ? x['default'] : x;
+	}
+
+	var definePropertyExports$3 = {};
+	var defineProperty$c = {
+	  get exports(){ return definePropertyExports$3; },
+	  set exports(v){ definePropertyExports$3 = v; },
+	};
+
+	var definePropertyExports$2 = {};
+	var defineProperty$b = {
+	  get exports(){ return definePropertyExports$2; },
+	  set exports(v){ definePropertyExports$2 = v; },
+	};
+
+	var definePropertyExports$1 = {};
+	var defineProperty$a = {
+	  get exports(){ return definePropertyExports$1; },
+	  set exports(v){ definePropertyExports$1 = v; },
+	};
+
+	var definePropertyExports = {};
+	var defineProperty$9 = {
+	  get exports(){ return definePropertyExports; },
+	  set exports(v){ definePropertyExports = v; },
+	};
+
+	var check = function (it) {
+	  return it && it.Math == Math && it;
+	};
+
+	// https://github.com/zloirock/core-js/issues/86#issuecomment-115759028
+	var global$e =
+	  // eslint-disable-next-line es/no-global-this -- safe
+	  check(typeof globalThis == 'object' && globalThis) ||
+	  check(typeof window == 'object' && window) ||
+	  // eslint-disable-next-line no-restricted-globals -- safe
+	  check(typeof self == 'object' && self) ||
+	  check(typeof commonjsGlobal == 'object' && commonjsGlobal) ||
+	  // eslint-disable-next-line no-new-func -- fallback
+	  (function () { return this; })() || Function('return this')();
+
+	var fails$f = function (exec) {
+	  try {
+	    return !!exec();
+	  } catch (error) {
+	    return true;
+	  }
+	};
+
+	var fails$e = fails$f;
+
+	var functionBindNative = !fails$e(function () {
+	  // eslint-disable-next-line es/no-function-prototype-bind -- safe
+	  var test = (function () { /* empty */ }).bind();
+	  // eslint-disable-next-line no-prototype-builtins -- safe
+	  return typeof test != 'function' || test.hasOwnProperty('prototype');
+	});
+
+	var NATIVE_BIND$3 = functionBindNative;
+
+	var FunctionPrototype$2 = Function.prototype;
+	var apply$2 = FunctionPrototype$2.apply;
+	var call$c = FunctionPrototype$2.call;
+
+	// eslint-disable-next-line es/no-reflect -- safe
+	var functionApply = typeof Reflect == 'object' && Reflect.apply || (NATIVE_BIND$3 ? call$c.bind(apply$2) : function () {
+	  return call$c.apply(apply$2, arguments);
+	});
+
+	var NATIVE_BIND$2 = functionBindNative;
+
+	var FunctionPrototype$1 = Function.prototype;
+	var call$b = FunctionPrototype$1.call;
+	var uncurryThisWithBind = NATIVE_BIND$2 && FunctionPrototype$1.bind.bind(call$b, call$b);
+
+	var functionUncurryThis = NATIVE_BIND$2 ? uncurryThisWithBind : function (fn) {
+	  return function () {
+	    return call$b.apply(fn, arguments);
+	  };
+	};
+
+	var uncurryThis$i = functionUncurryThis;
+
+	var toString$7 = uncurryThis$i({}.toString);
+	var stringSlice$1 = uncurryThis$i(''.slice);
+
+	var classofRaw$2 = function (it) {
+	  return stringSlice$1(toString$7(it), 8, -1);
+	};
+
+	var classofRaw$1 = classofRaw$2;
+	var uncurryThis$h = functionUncurryThis;
+
+	var functionUncurryThisClause = function (fn) {
+	  // Nashorn bug:
+	  //   https://github.com/zloirock/core-js/issues/1128
+	  //   https://github.com/zloirock/core-js/issues/1130
+	  if (classofRaw$1(fn) === 'Function') return uncurryThis$h(fn);
+	};
+
+	var documentAll$2 = typeof document == 'object' && document.all;
+
+	// https://tc39.es/ecma262/#sec-IsHTMLDDA-internal-slot
+	// eslint-disable-next-line unicorn/no-typeof-undefined -- required for testing
+	var IS_HTMLDDA = typeof documentAll$2 == 'undefined' && documentAll$2 !== undefined;
+
+	var documentAll_1 = {
+	  all: documentAll$2,
+	  IS_HTMLDDA: IS_HTMLDDA
+	};
+
+	var $documentAll$1 = documentAll_1;
+
+	var documentAll$1 = $documentAll$1.all;
+
+	// `IsCallable` abstract operation
+	// https://tc39.es/ecma262/#sec-iscallable
+	var isCallable$f = $documentAll$1.IS_HTMLDDA ? function (argument) {
+	  return typeof argument == 'function' || argument === documentAll$1;
+	} : function (argument) {
+	  return typeof argument == 'function';
+	};
+
+	var objectGetOwnPropertyDescriptor = {};
+
+	var fails$d = fails$f;
+
+	// Detect IE8's incomplete defineProperty implementation
+	var descriptors = !fails$d(function () {
+	  // eslint-disable-next-line es/no-object-defineproperty -- required for testing
+	  return Object.defineProperty({}, 1, { get: function () { return 7; } })[1] != 7;
+	});
+
+	var NATIVE_BIND$1 = functionBindNative;
+
+	var call$a = Function.prototype.call;
+
+	var functionCall = NATIVE_BIND$1 ? call$a.bind(call$a) : function () {
+	  return call$a.apply(call$a, arguments);
+	};
+
+	var objectPropertyIsEnumerable = {};
+
+	var $propertyIsEnumerable$1 = {}.propertyIsEnumerable;
+	// eslint-disable-next-line es/no-object-getownpropertydescriptor -- safe
+	var getOwnPropertyDescriptor$1 = Object.getOwnPropertyDescriptor;
+
+	// Nashorn ~ JDK8 bug
+	var NASHORN_BUG = getOwnPropertyDescriptor$1 && !$propertyIsEnumerable$1.call({ 1: 2 }, 1);
+
+	// `Object.prototype.propertyIsEnumerable` method implementation
+	// https://tc39.es/ecma262/#sec-object.prototype.propertyisenumerable
+	objectPropertyIsEnumerable.f = NASHORN_BUG ? function propertyIsEnumerable(V) {
+	  var descriptor = getOwnPropertyDescriptor$1(this, V);
+	  return !!descriptor && descriptor.enumerable;
+	} : $propertyIsEnumerable$1;
+
+	var createPropertyDescriptor$5 = function (bitmap, value) {
+	  return {
+	    enumerable: !(bitmap & 1),
+	    configurable: !(bitmap & 2),
+	    writable: !(bitmap & 4),
+	    value: value
+	  };
+	};
+
+	var uncurryThis$g = functionUncurryThis;
+	var fails$c = fails$f;
+	var classof$9 = classofRaw$2;
+
+	var $Object$4 = Object;
+	var split = uncurryThis$g(''.split);
+
+	// fallback for non-array-like ES3 and non-enumerable old V8 strings
+	var indexedObject = fails$c(function () {
+	  // throws an error in rhino, see https://github.com/mozilla/rhino/issues/346
+	  // eslint-disable-next-line no-prototype-builtins -- safe
+	  return !$Object$4('z').propertyIsEnumerable(0);
+	}) ? function (it) {
+	  return classof$9(it) == 'String' ? split(it, '') : $Object$4(it);
+	} : $Object$4;
+
+	// we can't use just `it == null` since of `document.all` special case
+	// https://tc39.es/ecma262/#sec-IsHTMLDDA-internal-slot-aec
+	var isNullOrUndefined$3 = function (it) {
+	  return it === null || it === undefined;
+	};
+
+	var isNullOrUndefined$2 = isNullOrUndefined$3;
+
+	var $TypeError$8 = TypeError;
+
+	// `RequireObjectCoercible` abstract operation
+	// https://tc39.es/ecma262/#sec-requireobjectcoercible
+	var requireObjectCoercible$3 = function (it) {
+	  if (isNullOrUndefined$2(it)) throw $TypeError$8("Can't call method on " + it);
+	  return it;
+	};
+
+	// toObject with fallback for non-array-like ES3 strings
+	var IndexedObject$1 = indexedObject;
+	var requireObjectCoercible$2 = requireObjectCoercible$3;
+
+	var toIndexedObject$7 = function (it) {
+	  return IndexedObject$1(requireObjectCoercible$2(it));
+	};
+
+	var isCallable$e = isCallable$f;
+	var $documentAll = documentAll_1;
+
+	var documentAll = $documentAll.all;
+
+	var isObject$8 = $documentAll.IS_HTMLDDA ? function (it) {
+	  return typeof it == 'object' ? it !== null : isCallable$e(it) || it === documentAll;
+	} : function (it) {
+	  return typeof it == 'object' ? it !== null : isCallable$e(it);
+	};
+
+	var path$7 = {};
+
+	var path$6 = path$7;
+	var global$d = global$e;
+	var isCallable$d = isCallable$f;
+
+	var aFunction = function (variable) {
+	  return isCallable$d(variable) ? variable : undefined;
+	};
+
+	var getBuiltIn$9 = function (namespace, method) {
+	  return arguments.length < 2 ? aFunction(path$6[namespace]) || aFunction(global$d[namespace])
+	    : path$6[namespace] && path$6[namespace][method] || global$d[namespace] && global$d[namespace][method];
+	};
+
+	var uncurryThis$f = functionUncurryThis;
+
+	var objectIsPrototypeOf = uncurryThis$f({}.isPrototypeOf);
+
+	var engineUserAgent = typeof navigator != 'undefined' && String(navigator.userAgent) || '';
+
+	var global$c = global$e;
+	var userAgent = engineUserAgent;
+
+	var process = global$c.process;
+	var Deno = global$c.Deno;
+	var versions = process && process.versions || Deno && Deno.version;
+	var v8 = versions && versions.v8;
+	var match, version;
+
+	if (v8) {
+	  match = v8.split('.');
+	  // in old Chrome, versions of V8 isn't V8 = Chrome / 10
+	  // but their correct versions are not interesting for us
+	  version = match[0] > 0 && match[0] < 4 ? 1 : +(match[0] + match[1]);
+	}
+
+	// BrowserFS NodeJS `process` polyfill incorrectly set `.v8` to `0.0`
+	// so check `userAgent` even if `.v8` exists, but 0
+	if (!version && userAgent) {
+	  match = userAgent.match(/Edge\/(\d+)/);
+	  if (!match || match[1] >= 74) {
+	    match = userAgent.match(/Chrome\/(\d+)/);
+	    if (match) version = +match[1];
+	  }
+	}
+
+	var engineV8Version = version;
+
+	/* eslint-disable es/no-symbol -- required for testing */
+
+	var V8_VERSION$2 = engineV8Version;
+	var fails$b = fails$f;
+
+	// eslint-disable-next-line es/no-object-getownpropertysymbols -- required for testing
+	var symbolConstructorDetection = !!Object.getOwnPropertySymbols && !fails$b(function () {
+	  var symbol = Symbol();
+	  // Chrome 38 Symbol has incorrect toString conversion
+	  // `get-own-property-symbols` polyfill symbols converted to object are not Symbol instances
+	  return !String(symbol) || !(Object(symbol) instanceof Symbol) ||
+	    // Chrome 38-40 symbols are not inherited from DOM collections prototypes to instances
+	    !Symbol.sham && V8_VERSION$2 && V8_VERSION$2 < 41;
+	});
+
+	/* eslint-disable es/no-symbol -- required for testing */
+
+	var NATIVE_SYMBOL$5 = symbolConstructorDetection;
+
+	var useSymbolAsUid = NATIVE_SYMBOL$5
+	  && !Symbol.sham
+	  && typeof Symbol.iterator == 'symbol';
+
+	var getBuiltIn$8 = getBuiltIn$9;
+	var isCallable$c = isCallable$f;
+	var isPrototypeOf$3 = objectIsPrototypeOf;
+	var USE_SYMBOL_AS_UID$1 = useSymbolAsUid;
+
+	var $Object$3 = Object;
+
+	var isSymbol$5 = USE_SYMBOL_AS_UID$1 ? function (it) {
+	  return typeof it == 'symbol';
+	} : function (it) {
+	  var $Symbol = getBuiltIn$8('Symbol');
+	  return isCallable$c($Symbol) && isPrototypeOf$3($Symbol.prototype, $Object$3(it));
+	};
+
+	var $String$3 = String;
+
+	var tryToString$4 = function (argument) {
+	  try {
+	    return $String$3(argument);
+	  } catch (error) {
+	    return 'Object';
+	  }
+	};
+
+	var isCallable$b = isCallable$f;
+	var tryToString$3 = tryToString$4;
+
+	var $TypeError$7 = TypeError;
+
+	// `Assert: IsCallable(argument) is true`
+	var aCallable$4 = function (argument) {
+	  if (isCallable$b(argument)) return argument;
+	  throw $TypeError$7(tryToString$3(argument) + ' is not a function');
+	};
+
+	var aCallable$3 = aCallable$4;
+	var isNullOrUndefined$1 = isNullOrUndefined$3;
+
+	// `GetMethod` abstract operation
+	// https://tc39.es/ecma262/#sec-getmethod
+	var getMethod$3 = function (V, P) {
+	  var func = V[P];
+	  return isNullOrUndefined$1(func) ? undefined : aCallable$3(func);
+	};
+
+	var call$9 = functionCall;
+	var isCallable$a = isCallable$f;
+	var isObject$7 = isObject$8;
+
+	var $TypeError$6 = TypeError;
+
+	// `OrdinaryToPrimitive` abstract operation
+	// https://tc39.es/ecma262/#sec-ordinarytoprimitive
+	var ordinaryToPrimitive$1 = function (input, pref) {
+	  var fn, val;
+	  if (pref === 'string' && isCallable$a(fn = input.toString) && !isObject$7(val = call$9(fn, input))) return val;
+	  if (isCallable$a(fn = input.valueOf) && !isObject$7(val = call$9(fn, input))) return val;
+	  if (pref !== 'string' && isCallable$a(fn = input.toString) && !isObject$7(val = call$9(fn, input))) return val;
+	  throw $TypeError$6("Can't convert object to primitive value");
+	};
+
+	var sharedExports = {};
+	var shared$7 = {
+	  get exports(){ return sharedExports; },
+	  set exports(v){ sharedExports = v; },
+	};
+
+	var global$b = global$e;
+
+	// eslint-disable-next-line es/no-object-defineproperty -- safe
+	var defineProperty$8 = Object.defineProperty;
+
+	var defineGlobalProperty$1 = function (key, value) {
+	  try {
+	    defineProperty$8(global$b, key, { value: value, configurable: true, writable: true });
+	  } catch (error) {
+	    global$b[key] = value;
+	  } return value;
+	};
+
+	var global$a = global$e;
+	var defineGlobalProperty = defineGlobalProperty$1;
+
+	var SHARED = '__core-js_shared__';
+	var store$3 = global$a[SHARED] || defineGlobalProperty(SHARED, {});
+
+	var sharedStore = store$3;
+
+	var store$2 = sharedStore;
+
+	(shared$7.exports = function (key, value) {
+	  return store$2[key] || (store$2[key] = value !== undefined ? value : {});
+	})('versions', []).push({
+	  version: '3.29.1',
+	  mode: 'pure' ,
+	  copyright: '© 2014-2023 Denis Pushkarev (zloirock.ru)',
+	  license: 'https://github.com/zloirock/core-js/blob/v3.29.1/LICENSE',
+	  source: 'https://github.com/zloirock/core-js'
+	});
+
+	var requireObjectCoercible$1 = requireObjectCoercible$3;
+
+	var $Object$2 = Object;
+
+	// `ToObject` abstract operation
+	// https://tc39.es/ecma262/#sec-toobject
+	var toObject$6 = function (argument) {
+	  return $Object$2(requireObjectCoercible$1(argument));
+	};
+
+	var uncurryThis$e = functionUncurryThis;
+	var toObject$5 = toObject$6;
+
+	var hasOwnProperty = uncurryThis$e({}.hasOwnProperty);
+
+	// `HasOwnProperty` abstract operation
+	// https://tc39.es/ecma262/#sec-hasownproperty
+	// eslint-disable-next-line es/no-object-hasown -- safe
+	var hasOwnProperty_1 = Object.hasOwn || function hasOwn(it, key) {
+	  return hasOwnProperty(toObject$5(it), key);
+	};
+
+	var uncurryThis$d = functionUncurryThis;
+
+	var id = 0;
+	var postfix = Math.random();
+	var toString$6 = uncurryThis$d(1.0.toString);
+
+	var uid$3 = function (key) {
+	  return 'Symbol(' + (key === undefined ? '' : key) + ')_' + toString$6(++id + postfix, 36);
+	};
+
+	var global$9 = global$e;
+	var shared$6 = sharedExports;
+	var hasOwn$b = hasOwnProperty_1;
+	var uid$2 = uid$3;
+	var NATIVE_SYMBOL$4 = symbolConstructorDetection;
+	var USE_SYMBOL_AS_UID = useSymbolAsUid;
+
+	var Symbol$3 = global$9.Symbol;
+	var WellKnownSymbolsStore$2 = shared$6('wks');
+	var createWellKnownSymbol = USE_SYMBOL_AS_UID ? Symbol$3['for'] || Symbol$3 : Symbol$3 && Symbol$3.withoutSetter || uid$2;
+
+	var wellKnownSymbol$g = function (name) {
+	  if (!hasOwn$b(WellKnownSymbolsStore$2, name)) {
+	    WellKnownSymbolsStore$2[name] = NATIVE_SYMBOL$4 && hasOwn$b(Symbol$3, name)
+	      ? Symbol$3[name]
+	      : createWellKnownSymbol('Symbol.' + name);
+	  } return WellKnownSymbolsStore$2[name];
+	};
+
+	var call$8 = functionCall;
+	var isObject$6 = isObject$8;
+	var isSymbol$4 = isSymbol$5;
+	var getMethod$2 = getMethod$3;
+	var ordinaryToPrimitive = ordinaryToPrimitive$1;
+	var wellKnownSymbol$f = wellKnownSymbol$g;
+
+	var $TypeError$5 = TypeError;
+	var TO_PRIMITIVE = wellKnownSymbol$f('toPrimitive');
+
+	// `ToPrimitive` abstract operation
+	// https://tc39.es/ecma262/#sec-toprimitive
+	var toPrimitive$8 = function (input, pref) {
+	  if (!isObject$6(input) || isSymbol$4(input)) return input;
+	  var exoticToPrim = getMethod$2(input, TO_PRIMITIVE);
+	  var result;
+	  if (exoticToPrim) {
+	    if (pref === undefined) pref = 'default';
+	    result = call$8(exoticToPrim, input, pref);
+	    if (!isObject$6(result) || isSymbol$4(result)) return result;
+	    throw $TypeError$5("Can't convert object to primitive value");
+	  }
+	  if (pref === undefined) pref = 'number';
+	  return ordinaryToPrimitive(input, pref);
+	};
+
+	var toPrimitive$7 = toPrimitive$8;
+	var isSymbol$3 = isSymbol$5;
+
+	// `ToPropertyKey` abstract operation
+	// https://tc39.es/ecma262/#sec-topropertykey
+	var toPropertyKey$5 = function (argument) {
+	  var key = toPrimitive$7(argument, 'string');
+	  return isSymbol$3(key) ? key : key + '';
+	};
+
+	var global$8 = global$e;
+	var isObject$5 = isObject$8;
+
+	var document$1 = global$8.document;
+	// typeof document.createElement is 'object' in old IE
+	var EXISTS$1 = isObject$5(document$1) && isObject$5(document$1.createElement);
+
+	var documentCreateElement$1 = function (it) {
+	  return EXISTS$1 ? document$1.createElement(it) : {};
+	};
+
+	var DESCRIPTORS$8 = descriptors;
+	var fails$a = fails$f;
+	var createElement = documentCreateElement$1;
+
+	// Thanks to IE8 for its funny defineProperty
+	var ie8DomDefine = !DESCRIPTORS$8 && !fails$a(function () {
+	  // eslint-disable-next-line es/no-object-defineproperty -- required for testing
+	  return Object.defineProperty(createElement('div'), 'a', {
+	    get: function () { return 7; }
+	  }).a != 7;
+	});
+
+	var DESCRIPTORS$7 = descriptors;
+	var call$7 = functionCall;
+	var propertyIsEnumerableModule$1 = objectPropertyIsEnumerable;
+	var createPropertyDescriptor$4 = createPropertyDescriptor$5;
+	var toIndexedObject$6 = toIndexedObject$7;
+	var toPropertyKey$4 = toPropertyKey$5;
+	var hasOwn$a = hasOwnProperty_1;
+	var IE8_DOM_DEFINE$1 = ie8DomDefine;
+
+	// eslint-disable-next-line es/no-object-getownpropertydescriptor -- safe
+	var $getOwnPropertyDescriptor$2 = Object.getOwnPropertyDescriptor;
+
+	// `Object.getOwnPropertyDescriptor` method
+	// https://tc39.es/ecma262/#sec-object.getownpropertydescriptor
+	objectGetOwnPropertyDescriptor.f = DESCRIPTORS$7 ? $getOwnPropertyDescriptor$2 : function getOwnPropertyDescriptor(O, P) {
+	  O = toIndexedObject$6(O);
+	  P = toPropertyKey$4(P);
+	  if (IE8_DOM_DEFINE$1) try {
+	    return $getOwnPropertyDescriptor$2(O, P);
+	  } catch (error) { /* empty */ }
+	  if (hasOwn$a(O, P)) return createPropertyDescriptor$4(!call$7(propertyIsEnumerableModule$1.f, O, P), O[P]);
+	};
+
+	var fails$9 = fails$f;
+	var isCallable$9 = isCallable$f;
+
+	var replacement = /#|\.prototype\./;
+
+	var isForced$1 = function (feature, detection) {
+	  var value = data[normalize(feature)];
+	  return value == POLYFILL ? true
+	    : value == NATIVE ? false
+	    : isCallable$9(detection) ? fails$9(detection)
+	    : !!detection;
+	};
+
+	var normalize = isForced$1.normalize = function (string) {
+	  return String(string).replace(replacement, '.').toLowerCase();
+	};
+
+	var data = isForced$1.data = {};
+	var NATIVE = isForced$1.NATIVE = 'N';
+	var POLYFILL = isForced$1.POLYFILL = 'P';
+
+	var isForced_1 = isForced$1;
+
+	var uncurryThis$c = functionUncurryThisClause;
+	var aCallable$2 = aCallable$4;
+	var NATIVE_BIND = functionBindNative;
+
+	var bind$4 = uncurryThis$c(uncurryThis$c.bind);
+
+	// optional / simple context binding
+	var functionBindContext = function (fn, that) {
+	  aCallable$2(fn);
+	  return that === undefined ? fn : NATIVE_BIND ? bind$4(fn, that) : function (/* ...args */) {
+	    return fn.apply(that, arguments);
+	  };
+	};
+
+	var objectDefineProperty = {};
+
+	var DESCRIPTORS$6 = descriptors;
+	var fails$8 = fails$f;
+
+	// V8 ~ Chrome 36-
+	// https://bugs.chromium.org/p/v8/issues/detail?id=3334
+	var v8PrototypeDefineBug = DESCRIPTORS$6 && fails$8(function () {
+	  // eslint-disable-next-line es/no-object-defineproperty -- required for testing
+	  return Object.defineProperty(function () { /* empty */ }, 'prototype', {
+	    value: 42,
+	    writable: false
+	  }).prototype != 42;
+	});
+
+	var isObject$4 = isObject$8;
+
+	var $String$2 = String;
+	var $TypeError$4 = TypeError;
+
+	// `Assert: Type(argument) is Object`
+	var anObject$7 = function (argument) {
+	  if (isObject$4(argument)) return argument;
+	  throw $TypeError$4($String$2(argument) + ' is not an object');
+	};
+
+	var DESCRIPTORS$5 = descriptors;
+	var IE8_DOM_DEFINE = ie8DomDefine;
+	var V8_PROTOTYPE_DEFINE_BUG$1 = v8PrototypeDefineBug;
+	var anObject$6 = anObject$7;
+	var toPropertyKey$3 = toPropertyKey$5;
+
+	var $TypeError$3 = TypeError;
+	// eslint-disable-next-line es/no-object-defineproperty -- safe
+	var $defineProperty$1 = Object.defineProperty;
+	// eslint-disable-next-line es/no-object-getownpropertydescriptor -- safe
+	var $getOwnPropertyDescriptor$1 = Object.getOwnPropertyDescriptor;
+	var ENUMERABLE = 'enumerable';
+	var CONFIGURABLE$1 = 'configurable';
+	var WRITABLE = 'writable';
+
+	// `Object.defineProperty` method
+	// https://tc39.es/ecma262/#sec-object.defineproperty
+	objectDefineProperty.f = DESCRIPTORS$5 ? V8_PROTOTYPE_DEFINE_BUG$1 ? function defineProperty(O, P, Attributes) {
+	  anObject$6(O);
+	  P = toPropertyKey$3(P);
+	  anObject$6(Attributes);
+	  if (typeof O === 'function' && P === 'prototype' && 'value' in Attributes && WRITABLE in Attributes && !Attributes[WRITABLE]) {
+	    var current = $getOwnPropertyDescriptor$1(O, P);
+	    if (current && current[WRITABLE]) {
+	      O[P] = Attributes.value;
+	      Attributes = {
+	        configurable: CONFIGURABLE$1 in Attributes ? Attributes[CONFIGURABLE$1] : current[CONFIGURABLE$1],
+	        enumerable: ENUMERABLE in Attributes ? Attributes[ENUMERABLE] : current[ENUMERABLE],
+	        writable: false
+	      };
+	    }
+	  } return $defineProperty$1(O, P, Attributes);
+	} : $defineProperty$1 : function defineProperty(O, P, Attributes) {
+	  anObject$6(O);
+	  P = toPropertyKey$3(P);
+	  anObject$6(Attributes);
+	  if (IE8_DOM_DEFINE) try {
+	    return $defineProperty$1(O, P, Attributes);
+	  } catch (error) { /* empty */ }
+	  if ('get' in Attributes || 'set' in Attributes) throw $TypeError$3('Accessors not supported');
+	  if ('value' in Attributes) O[P] = Attributes.value;
+	  return O;
+	};
+
+	var DESCRIPTORS$4 = descriptors;
+	var definePropertyModule$3 = objectDefineProperty;
+	var createPropertyDescriptor$3 = createPropertyDescriptor$5;
+
+	var createNonEnumerableProperty$5 = DESCRIPTORS$4 ? function (object, key, value) {
+	  return definePropertyModule$3.f(object, key, createPropertyDescriptor$3(1, value));
+	} : function (object, key, value) {
+	  object[key] = value;
+	  return object;
+	};
+
+	var global$7 = global$e;
+	var apply$1 = functionApply;
+	var uncurryThis$b = functionUncurryThisClause;
+	var isCallable$8 = isCallable$f;
+	var getOwnPropertyDescriptor = objectGetOwnPropertyDescriptor.f;
+	var isForced = isForced_1;
+	var path$5 = path$7;
+	var bind$3 = functionBindContext;
+	var createNonEnumerableProperty$4 = createNonEnumerableProperty$5;
+	var hasOwn$9 = hasOwnProperty_1;
+
+	var wrapConstructor = function (NativeConstructor) {
+	  var Wrapper = function (a, b, c) {
+	    if (this instanceof Wrapper) {
+	      switch (arguments.length) {
+	        case 0: return new NativeConstructor();
+	        case 1: return new NativeConstructor(a);
+	        case 2: return new NativeConstructor(a, b);
+	      } return new NativeConstructor(a, b, c);
+	    } return apply$1(NativeConstructor, this, arguments);
+	  };
+	  Wrapper.prototype = NativeConstructor.prototype;
+	  return Wrapper;
+	};
+
+	/*
+	  options.target         - name of the target object
+	  options.global         - target is the global object
+	  options.stat           - export as static methods of target
+	  options.proto          - export as prototype methods of target
+	  options.real           - real prototype method for the `pure` version
+	  options.forced         - export even if the native feature is available
+	  options.bind           - bind methods to the target, required for the `pure` version
+	  options.wrap           - wrap constructors to preventing global pollution, required for the `pure` version
+	  options.unsafe         - use the simple assignment of property instead of delete + defineProperty
+	  options.sham           - add a flag to not completely full polyfills
+	  options.enumerable     - export as enumerable property
+	  options.dontCallGetSet - prevent calling a getter on target
+	  options.name           - the .name of the function if it does not match the key
+	*/
+	var _export = function (options, source) {
+	  var TARGET = options.target;
+	  var GLOBAL = options.global;
+	  var STATIC = options.stat;
+	  var PROTO = options.proto;
+
+	  var nativeSource = GLOBAL ? global$7 : STATIC ? global$7[TARGET] : (global$7[TARGET] || {}).prototype;
+
+	  var target = GLOBAL ? path$5 : path$5[TARGET] || createNonEnumerableProperty$4(path$5, TARGET, {})[TARGET];
+	  var targetPrototype = target.prototype;
+
+	  var FORCED, USE_NATIVE, VIRTUAL_PROTOTYPE;
+	  var key, sourceProperty, targetProperty, nativeProperty, resultProperty, descriptor;
+
+	  for (key in source) {
+	    FORCED = isForced(GLOBAL ? key : TARGET + (STATIC ? '.' : '#') + key, options.forced);
+	    // contains in native
+	    USE_NATIVE = !FORCED && nativeSource && hasOwn$9(nativeSource, key);
+
+	    targetProperty = target[key];
+
+	    if (USE_NATIVE) if (options.dontCallGetSet) {
+	      descriptor = getOwnPropertyDescriptor(nativeSource, key);
+	      nativeProperty = descriptor && descriptor.value;
+	    } else nativeProperty = nativeSource[key];
+
+	    // export native or implementation
+	    sourceProperty = (USE_NATIVE && nativeProperty) ? nativeProperty : source[key];
+
+	    if (USE_NATIVE && typeof targetProperty == typeof sourceProperty) continue;
+
+	    // bind methods to global for calling from export context
+	    if (options.bind && USE_NATIVE) resultProperty = bind$3(sourceProperty, global$7);
+	    // wrap global constructors for prevent changes in this version
+	    else if (options.wrap && USE_NATIVE) resultProperty = wrapConstructor(sourceProperty);
+	    // make static versions for prototype methods
+	    else if (PROTO && isCallable$8(sourceProperty)) resultProperty = uncurryThis$b(sourceProperty);
+	    // default case
+	    else resultProperty = sourceProperty;
+
+	    // add a flag to not completely full polyfills
+	    if (options.sham || (sourceProperty && sourceProperty.sham) || (targetProperty && targetProperty.sham)) {
+	      createNonEnumerableProperty$4(resultProperty, 'sham', true);
+	    }
+
+	    createNonEnumerableProperty$4(target, key, resultProperty);
+
+	    if (PROTO) {
+	      VIRTUAL_PROTOTYPE = TARGET + 'Prototype';
+	      if (!hasOwn$9(path$5, VIRTUAL_PROTOTYPE)) {
+	        createNonEnumerableProperty$4(path$5, VIRTUAL_PROTOTYPE, {});
+	      }
+	      // export virtual prototype methods
+	      createNonEnumerableProperty$4(path$5[VIRTUAL_PROTOTYPE], key, sourceProperty);
+	      // export real prototype methods
+	      if (options.real && targetPrototype && (FORCED || !targetPrototype[key])) {
+	        createNonEnumerableProperty$4(targetPrototype, key, sourceProperty);
+	      }
+	    }
+	  }
+	};
+
+	var $$b = _export;
+	var DESCRIPTORS$3 = descriptors;
+	var defineProperty$7 = objectDefineProperty.f;
+
+	// `Object.defineProperty` method
+	// https://tc39.es/ecma262/#sec-object.defineproperty
+	// eslint-disable-next-line es/no-object-defineproperty -- safe
+	$$b({ target: 'Object', stat: true, forced: Object.defineProperty !== defineProperty$7, sham: !DESCRIPTORS$3 }, {
+	  defineProperty: defineProperty$7
+	});
+
+	var path$4 = path$7;
+
+	var Object$1 = path$4.Object;
+
+	var defineProperty$6 = defineProperty$9.exports = function defineProperty(it, key, desc) {
+	  return Object$1.defineProperty(it, key, desc);
+	};
+
+	if (Object$1.defineProperty.sham) defineProperty$6.sham = true;
+
+	var parent$d = definePropertyExports;
+
+	var defineProperty$5 = parent$d;
+
+	var parent$c = defineProperty$5;
+
+	var defineProperty$4 = parent$c;
+
+	var parent$b = defineProperty$4;
+
+	var defineProperty$3 = parent$b;
+
+	(function (module) {
+		module.exports = defineProperty$3;
+	} (defineProperty$a));
+
+	(function (module) {
+		module.exports = definePropertyExports$1;
+	} (defineProperty$b));
+
+	var toPropertyKeyExports = {};
+	var toPropertyKey$2 = {
+	  get exports(){ return toPropertyKeyExports; },
+	  set exports(v){ toPropertyKeyExports = v; },
+	};
+
+	var _typeofExports = {};
+	var _typeof = {
+	  get exports(){ return _typeofExports; },
+	  set exports(v){ _typeofExports = v; },
+	};
+
+	var symbolExports$1 = {};
+	var symbol$5 = {
+	  get exports(){ return symbolExports$1; },
+	  set exports(v){ symbolExports$1 = v; },
+	};
+
+	var symbolExports = {};
+	var symbol$4 = {
+	  get exports(){ return symbolExports; },
+	  set exports(v){ symbolExports = v; },
+	};
+
+	var classof$8 = classofRaw$2;
+
+	// `IsArray` abstract operation
+	// https://tc39.es/ecma262/#sec-isarray
+	// eslint-disable-next-line es/no-array-isarray -- safe
+	var isArray$4 = Array.isArray || function isArray(argument) {
+	  return classof$8(argument) == 'Array';
+	};
+
+	var ceil = Math.ceil;
+	var floor = Math.floor;
+
+	// `Math.trunc` method
+	// https://tc39.es/ecma262/#sec-math.trunc
+	// eslint-disable-next-line es/no-math-trunc -- safe
+	var mathTrunc = Math.trunc || function trunc(x) {
+	  var n = +x;
+	  return (n > 0 ? floor : ceil)(n);
+	};
+
+	var trunc = mathTrunc;
+
+	// `ToIntegerOrInfinity` abstract operation
+	// https://tc39.es/ecma262/#sec-tointegerorinfinity
+	var toIntegerOrInfinity$3 = function (argument) {
+	  var number = +argument;
+	  // eslint-disable-next-line no-self-compare -- NaN check
+	  return number !== number || number === 0 ? 0 : trunc(number);
+	};
+
+	var toIntegerOrInfinity$2 = toIntegerOrInfinity$3;
+
+	var min$1 = Math.min;
+
+	// `ToLength` abstract operation
+	// https://tc39.es/ecma262/#sec-tolength
+	var toLength$1 = function (argument) {
+	  return argument > 0 ? min$1(toIntegerOrInfinity$2(argument), 0x1FFFFFFFFFFFFF) : 0; // 2 ** 53 - 1 == 9007199254740991
+	};
+
+	var toLength = toLength$1;
+
+	// `LengthOfArrayLike` abstract operation
+	// https://tc39.es/ecma262/#sec-lengthofarraylike
+	var lengthOfArrayLike$7 = function (obj) {
+	  return toLength(obj.length);
+	};
+
+	var $TypeError$2 = TypeError;
+	var MAX_SAFE_INTEGER = 0x1FFFFFFFFFFFFF; // 2 ** 53 - 1 == 9007199254740991
+
+	var doesNotExceedSafeInteger$2 = function (it) {
+	  if (it > MAX_SAFE_INTEGER) throw $TypeError$2('Maximum allowed index exceeded');
+	  return it;
+	};
+
+	var toPropertyKey$1 = toPropertyKey$5;
+	var definePropertyModule$2 = objectDefineProperty;
+	var createPropertyDescriptor$2 = createPropertyDescriptor$5;
+
+	var createProperty$3 = function (object, key, value) {
+	  var propertyKey = toPropertyKey$1(key);
+	  if (propertyKey in object) definePropertyModule$2.f(object, propertyKey, createPropertyDescriptor$2(0, value));
+	  else object[propertyKey] = value;
+	};
+
+	var wellKnownSymbol$e = wellKnownSymbol$g;
+
+	var TO_STRING_TAG$3 = wellKnownSymbol$e('toStringTag');
+	var test = {};
+
+	test[TO_STRING_TAG$3] = 'z';
+
+	var toStringTagSupport = String(test) === '[object z]';
+
+	var TO_STRING_TAG_SUPPORT$2 = toStringTagSupport;
+	var isCallable$7 = isCallable$f;
+	var classofRaw = classofRaw$2;
+	var wellKnownSymbol$d = wellKnownSymbol$g;
+
+	var TO_STRING_TAG$2 = wellKnownSymbol$d('toStringTag');
+	var $Object$1 = Object;
+
+	// ES3 wrong here
+	var CORRECT_ARGUMENTS = classofRaw(function () { return arguments; }()) == 'Arguments';
+
+	// fallback for IE11 Script Access Denied error
+	var tryGet = function (it, key) {
+	  try {
+	    return it[key];
+	  } catch (error) { /* empty */ }
+	};
+
+	// getting tag from ES6+ `Object.prototype.toString`
+	var classof$7 = TO_STRING_TAG_SUPPORT$2 ? classofRaw : function (it) {
+	  var O, tag, result;
+	  return it === undefined ? 'Undefined' : it === null ? 'Null'
+	    // @@toStringTag case
+	    : typeof (tag = tryGet(O = $Object$1(it), TO_STRING_TAG$2)) == 'string' ? tag
+	    // builtinTag case
+	    : CORRECT_ARGUMENTS ? classofRaw(O)
+	    // ES3 arguments fallback
+	    : (result = classofRaw(O)) == 'Object' && isCallable$7(O.callee) ? 'Arguments' : result;
+	};
+
+	var uncurryThis$a = functionUncurryThis;
+	var isCallable$6 = isCallable$f;
+	var store$1 = sharedStore;
+
+	var functionToString = uncurryThis$a(Function.toString);
+
+	// this helper broken in `core-js@3.4.1-3.4.4`, so we can't use `shared` helper
+	if (!isCallable$6(store$1.inspectSource)) {
+	  store$1.inspectSource = function (it) {
+	    return functionToString(it);
+	  };
+	}
+
+	var inspectSource$1 = store$1.inspectSource;
+
+	var uncurryThis$9 = functionUncurryThis;
+	var fails$7 = fails$f;
+	var isCallable$5 = isCallable$f;
+	var classof$6 = classof$7;
+	var getBuiltIn$7 = getBuiltIn$9;
+	var inspectSource = inspectSource$1;
+
+	var noop = function () { /* empty */ };
+	var empty = [];
+	var construct = getBuiltIn$7('Reflect', 'construct');
+	var constructorRegExp = /^\s*(?:class|function)\b/;
+	var exec$1 = uncurryThis$9(constructorRegExp.exec);
+	var INCORRECT_TO_STRING = !constructorRegExp.exec(noop);
+
+	var isConstructorModern = function isConstructor(argument) {
+	  if (!isCallable$5(argument)) return false;
+	  try {
+	    construct(noop, empty, argument);
+	    return true;
+	  } catch (error) {
+	    return false;
+	  }
+	};
+
+	var isConstructorLegacy = function isConstructor(argument) {
+	  if (!isCallable$5(argument)) return false;
+	  switch (classof$6(argument)) {
+	    case 'AsyncFunction':
+	    case 'GeneratorFunction':
+	    case 'AsyncGeneratorFunction': return false;
+	  }
+	  try {
+	    // we can't check .prototype since constructors produced by .bind haven't it
+	    // `Function#toString` throws on some built-it function in some legacy engines
+	    // (for example, `DOMQuad` and similar in FF41-)
+	    return INCORRECT_TO_STRING || !!exec$1(constructorRegExp, inspectSource(argument));
+	  } catch (error) {
+	    return true;
+	  }
+	};
+
+	isConstructorLegacy.sham = true;
+
+	// `IsConstructor` abstract operation
+	// https://tc39.es/ecma262/#sec-isconstructor
+	var isConstructor$1 = !construct || fails$7(function () {
+	  var called;
+	  return isConstructorModern(isConstructorModern.call)
+	    || !isConstructorModern(Object)
+	    || !isConstructorModern(function () { called = true; })
+	    || called;
+	}) ? isConstructorLegacy : isConstructorModern;
+
+	var isArray$3 = isArray$4;
+	var isConstructor = isConstructor$1;
+	var isObject$3 = isObject$8;
+	var wellKnownSymbol$c = wellKnownSymbol$g;
+
+	var SPECIES$1 = wellKnownSymbol$c('species');
+	var $Array$1 = Array;
+
+	// a part of `ArraySpeciesCreate` abstract operation
+	// https://tc39.es/ecma262/#sec-arrayspeciescreate
+	var arraySpeciesConstructor$1 = function (originalArray) {
+	  var C;
+	  if (isArray$3(originalArray)) {
+	    C = originalArray.constructor;
+	    // cross-realm fallback
+	    if (isConstructor(C) && (C === $Array$1 || isArray$3(C.prototype))) C = undefined;
+	    else if (isObject$3(C)) {
+	      C = C[SPECIES$1];
+	      if (C === null) C = undefined;
+	    }
+	  } return C === undefined ? $Array$1 : C;
+	};
+
+	var arraySpeciesConstructor = arraySpeciesConstructor$1;
+
+	// `ArraySpeciesCreate` abstract operation
+	// https://tc39.es/ecma262/#sec-arrayspeciescreate
+	var arraySpeciesCreate$3 = function (originalArray, length) {
+	  return new (arraySpeciesConstructor(originalArray))(length === 0 ? 0 : length);
+	};
+
+	var fails$6 = fails$f;
+	var wellKnownSymbol$b = wellKnownSymbol$g;
+	var V8_VERSION$1 = engineV8Version;
+
+	var SPECIES = wellKnownSymbol$b('species');
+
+	var arrayMethodHasSpeciesSupport$1 = function (METHOD_NAME) {
+	  // We can't use this feature detection in V8 since it causes
+	  // deoptimization and serious performance degradation
+	  // https://github.com/zloirock/core-js/issues/677
+	  return V8_VERSION$1 >= 51 || !fails$6(function () {
+	    var array = [];
+	    var constructor = array.constructor = {};
+	    constructor[SPECIES] = function () {
+	      return { foo: 1 };
+	    };
+	    return array[METHOD_NAME](Boolean).foo !== 1;
+	  });
+	};
+
+	var $$a = _export;
+	var fails$5 = fails$f;
+	var isArray$2 = isArray$4;
+	var isObject$2 = isObject$8;
+	var toObject$4 = toObject$6;
+	var lengthOfArrayLike$6 = lengthOfArrayLike$7;
+	var doesNotExceedSafeInteger$1 = doesNotExceedSafeInteger$2;
+	var createProperty$2 = createProperty$3;
+	var arraySpeciesCreate$2 = arraySpeciesCreate$3;
+	var arrayMethodHasSpeciesSupport = arrayMethodHasSpeciesSupport$1;
+	var wellKnownSymbol$a = wellKnownSymbol$g;
+	var V8_VERSION = engineV8Version;
+
+	var IS_CONCAT_SPREADABLE = wellKnownSymbol$a('isConcatSpreadable');
+
+	// We can't use this feature detection in V8 since it causes
+	// deoptimization and serious performance degradation
+	// https://github.com/zloirock/core-js/issues/679
+	var IS_CONCAT_SPREADABLE_SUPPORT = V8_VERSION >= 51 || !fails$5(function () {
+	  var array = [];
+	  array[IS_CONCAT_SPREADABLE] = false;
+	  return array.concat()[0] !== array;
+	});
+
+	var isConcatSpreadable = function (O) {
+	  if (!isObject$2(O)) return false;
+	  var spreadable = O[IS_CONCAT_SPREADABLE];
+	  return spreadable !== undefined ? !!spreadable : isArray$2(O);
+	};
+
+	var FORCED$1 = !IS_CONCAT_SPREADABLE_SUPPORT || !arrayMethodHasSpeciesSupport('concat');
+
+	// `Array.prototype.concat` method
+	// https://tc39.es/ecma262/#sec-array.prototype.concat
+	// with adding support of @@isConcatSpreadable and @@species
+	$$a({ target: 'Array', proto: true, arity: 1, forced: FORCED$1 }, {
+	  // eslint-disable-next-line no-unused-vars -- required for `.length`
+	  concat: function concat(arg) {
+	    var O = toObject$4(this);
+	    var A = arraySpeciesCreate$2(O, 0);
+	    var n = 0;
+	    var i, k, length, len, E;
+	    for (i = -1, length = arguments.length; i < length; i++) {
+	      E = i === -1 ? O : arguments[i];
+	      if (isConcatSpreadable(E)) {
+	        len = lengthOfArrayLike$6(E);
+	        doesNotExceedSafeInteger$1(n + len);
+	        for (k = 0; k < len; k++, n++) if (k in E) createProperty$2(A, n, E[k]);
+	      } else {
+	        doesNotExceedSafeInteger$1(n + 1);
+	        createProperty$2(A, n++, E);
+	      }
+	    }
+	    A.length = n;
+	    return A;
+	  }
+	});
+
+	var classof$5 = classof$7;
+
+	var $String$1 = String;
+
+	var toString$5 = function (argument) {
+	  if (classof$5(argument) === 'Symbol') throw TypeError('Cannot convert a Symbol value to a string');
+	  return $String$1(argument);
+	};
+
+	var objectDefineProperties = {};
+
+	var toIntegerOrInfinity$1 = toIntegerOrInfinity$3;
+
+	var max$1 = Math.max;
+	var min = Math.min;
+
+	// Helper for a popular repeating case of the spec:
+	// Let integer be ? ToInteger(index).
+	// If integer < 0, let result be max((length + integer), 0); else let result be min(integer, length).
+	var toAbsoluteIndex$2 = function (index, length) {
+	  var integer = toIntegerOrInfinity$1(index);
+	  return integer < 0 ? max$1(integer + length, 0) : min(integer, length);
+	};
+
+	var toIndexedObject$5 = toIndexedObject$7;
+	var toAbsoluteIndex$1 = toAbsoluteIndex$2;
+	var lengthOfArrayLike$5 = lengthOfArrayLike$7;
+
+	// `Array.prototype.{ indexOf, includes }` methods implementation
+	var createMethod$2 = function (IS_INCLUDES) {
+	  return function ($this, el, fromIndex) {
+	    var O = toIndexedObject$5($this);
+	    var length = lengthOfArrayLike$5(O);
+	    var index = toAbsoluteIndex$1(fromIndex, length);
+	    var value;
+	    // Array#includes uses SameValueZero equality algorithm
+	    // eslint-disable-next-line no-self-compare -- NaN check
+	    if (IS_INCLUDES && el != el) while (length > index) {
+	      value = O[index++];
+	      // eslint-disable-next-line no-self-compare -- NaN check
+	      if (value != value) return true;
+	    // Array#indexOf ignores holes, Array#includes - not
+	    } else for (;length > index; index++) {
+	      if ((IS_INCLUDES || index in O) && O[index] === el) return IS_INCLUDES || index || 0;
+	    } return !IS_INCLUDES && -1;
+	  };
+	};
+
+	var arrayIncludes = {
+	  // `Array.prototype.includes` method
+	  // https://tc39.es/ecma262/#sec-array.prototype.includes
+	  includes: createMethod$2(true),
+	  // `Array.prototype.indexOf` method
+	  // https://tc39.es/ecma262/#sec-array.prototype.indexof
+	  indexOf: createMethod$2(false)
+	};
+
+	var hiddenKeys$5 = {};
+
+	var uncurryThis$8 = functionUncurryThis;
+	var hasOwn$8 = hasOwnProperty_1;
+	var toIndexedObject$4 = toIndexedObject$7;
+	var indexOf = arrayIncludes.indexOf;
+	var hiddenKeys$4 = hiddenKeys$5;
+
+	var push$3 = uncurryThis$8([].push);
+
+	var objectKeysInternal = function (object, names) {
+	  var O = toIndexedObject$4(object);
+	  var i = 0;
+	  var result = [];
+	  var key;
+	  for (key in O) !hasOwn$8(hiddenKeys$4, key) && hasOwn$8(O, key) && push$3(result, key);
+	  // Don't enum bug & hidden keys
+	  while (names.length > i) if (hasOwn$8(O, key = names[i++])) {
+	    ~indexOf(result, key) || push$3(result, key);
+	  }
+	  return result;
+	};
+
+	// IE8- don't enum bug keys
+	var enumBugKeys$3 = [
+	  'constructor',
+	  'hasOwnProperty',
+	  'isPrototypeOf',
+	  'propertyIsEnumerable',
+	  'toLocaleString',
+	  'toString',
+	  'valueOf'
+	];
+
+	var internalObjectKeys$1 = objectKeysInternal;
+	var enumBugKeys$2 = enumBugKeys$3;
+
+	// `Object.keys` method
+	// https://tc39.es/ecma262/#sec-object.keys
+	// eslint-disable-next-line es/no-object-keys -- safe
+	var objectKeys$2 = Object.keys || function keys(O) {
+	  return internalObjectKeys$1(O, enumBugKeys$2);
+	};
+
+	var DESCRIPTORS$2 = descriptors;
+	var V8_PROTOTYPE_DEFINE_BUG = v8PrototypeDefineBug;
+	var definePropertyModule$1 = objectDefineProperty;
+	var anObject$5 = anObject$7;
+	var toIndexedObject$3 = toIndexedObject$7;
+	var objectKeys$1 = objectKeys$2;
+
+	// `Object.defineProperties` method
+	// https://tc39.es/ecma262/#sec-object.defineproperties
+	// eslint-disable-next-line es/no-object-defineproperties -- safe
+	objectDefineProperties.f = DESCRIPTORS$2 && !V8_PROTOTYPE_DEFINE_BUG ? Object.defineProperties : function defineProperties(O, Properties) {
+	  anObject$5(O);
+	  var props = toIndexedObject$3(Properties);
+	  var keys = objectKeys$1(Properties);
+	  var length = keys.length;
+	  var index = 0;
+	  var key;
+	  while (length > index) definePropertyModule$1.f(O, key = keys[index++], props[key]);
+	  return O;
+	};
+
+	var getBuiltIn$6 = getBuiltIn$9;
+
+	var html$1 = getBuiltIn$6('document', 'documentElement');
+
+	var shared$5 = sharedExports;
+	var uid$1 = uid$3;
+
+	var keys = shared$5('keys');
+
+	var sharedKey$4 = function (key) {
+	  return keys[key] || (keys[key] = uid$1(key));
+	};
+
+	/* global ActiveXObject -- old IE, WSH */
+
+	var anObject$4 = anObject$7;
+	var definePropertiesModule$1 = objectDefineProperties;
+	var enumBugKeys$1 = enumBugKeys$3;
+	var hiddenKeys$3 = hiddenKeys$5;
+	var html = html$1;
+	var documentCreateElement = documentCreateElement$1;
+	var sharedKey$3 = sharedKey$4;
+
+	var GT = '>';
+	var LT = '<';
+	var PROTOTYPE$1 = 'prototype';
+	var SCRIPT = 'script';
+	var IE_PROTO$1 = sharedKey$3('IE_PROTO');
+
+	var EmptyConstructor = function () { /* empty */ };
+
+	var scriptTag = function (content) {
+	  return LT + SCRIPT + GT + content + LT + '/' + SCRIPT + GT;
+	};
+
+	// Create object with fake `null` prototype: use ActiveX Object with cleared prototype
+	var NullProtoObjectViaActiveX = function (activeXDocument) {
+	  activeXDocument.write(scriptTag(''));
+	  activeXDocument.close();
+	  var temp = activeXDocument.parentWindow.Object;
+	  activeXDocument = null; // avoid memory leak
+	  return temp;
+	};
+
+	// Create object with fake `null` prototype: use iframe Object with cleared prototype
+	var NullProtoObjectViaIFrame = function () {
+	  // Thrash, waste and sodomy: IE GC bug
+	  var iframe = documentCreateElement('iframe');
+	  var JS = 'java' + SCRIPT + ':';
+	  var iframeDocument;
+	  iframe.style.display = 'none';
+	  html.appendChild(iframe);
+	  // https://github.com/zloirock/core-js/issues/475
+	  iframe.src = String(JS);
+	  iframeDocument = iframe.contentWindow.document;
+	  iframeDocument.open();
+	  iframeDocument.write(scriptTag('document.F=Object'));
+	  iframeDocument.close();
+	  return iframeDocument.F;
+	};
+
+	// Check for document.domain and active x support
+	// No need to use active x approach when document.domain is not set
+	// see https://github.com/es-shims/es5-shim/issues/150
+	// variation of https://github.com/kitcambridge/es5-shim/commit/4f738ac066346
+	// avoid IE GC bug
+	var activeXDocument;
+	var NullProtoObject = function () {
+	  try {
+	    activeXDocument = new ActiveXObject('htmlfile');
+	  } catch (error) { /* ignore */ }
+	  NullProtoObject = typeof document != 'undefined'
+	    ? document.domain && activeXDocument
+	      ? NullProtoObjectViaActiveX(activeXDocument) // old IE
+	      : NullProtoObjectViaIFrame()
+	    : NullProtoObjectViaActiveX(activeXDocument); // WSH
+	  var length = enumBugKeys$1.length;
+	  while (length--) delete NullProtoObject[PROTOTYPE$1][enumBugKeys$1[length]];
+	  return NullProtoObject();
+	};
+
+	hiddenKeys$3[IE_PROTO$1] = true;
+
+	// `Object.create` method
+	// https://tc39.es/ecma262/#sec-object.create
+	// eslint-disable-next-line es/no-object-create -- safe
+	var objectCreate = Object.create || function create(O, Properties) {
+	  var result;
+	  if (O !== null) {
+	    EmptyConstructor[PROTOTYPE$1] = anObject$4(O);
+	    result = new EmptyConstructor();
+	    EmptyConstructor[PROTOTYPE$1] = null;
+	    // add "__proto__" for Object.getPrototypeOf polyfill
+	    result[IE_PROTO$1] = O;
+	  } else result = NullProtoObject();
+	  return Properties === undefined ? result : definePropertiesModule$1.f(result, Properties);
+	};
+
+	var objectGetOwnPropertyNames = {};
+
+	var internalObjectKeys = objectKeysInternal;
+	var enumBugKeys = enumBugKeys$3;
+
+	var hiddenKeys$2 = enumBugKeys.concat('length', 'prototype');
+
+	// `Object.getOwnPropertyNames` method
+	// https://tc39.es/ecma262/#sec-object.getownpropertynames
+	// eslint-disable-next-line es/no-object-getownpropertynames -- safe
+	objectGetOwnPropertyNames.f = Object.getOwnPropertyNames || function getOwnPropertyNames(O) {
+	  return internalObjectKeys(O, hiddenKeys$2);
+	};
+
+	var objectGetOwnPropertyNamesExternal = {};
+
+	var toAbsoluteIndex = toAbsoluteIndex$2;
+	var lengthOfArrayLike$4 = lengthOfArrayLike$7;
+	var createProperty$1 = createProperty$3;
+
+	var $Array = Array;
+	var max = Math.max;
+
+	var arraySliceSimple = function (O, start, end) {
+	  var length = lengthOfArrayLike$4(O);
+	  var k = toAbsoluteIndex(start, length);
+	  var fin = toAbsoluteIndex(end === undefined ? length : end, length);
+	  var result = $Array(max(fin - k, 0));
+	  for (var n = 0; k < fin; k++, n++) createProperty$1(result, n, O[k]);
+	  result.length = n;
+	  return result;
+	};
+
+	/* eslint-disable es/no-object-getownpropertynames -- safe */
+
+	var classof$4 = classofRaw$2;
+	var toIndexedObject$2 = toIndexedObject$7;
+	var $getOwnPropertyNames$1 = objectGetOwnPropertyNames.f;
+	var arraySlice$2 = arraySliceSimple;
+
+	var windowNames = typeof window == 'object' && window && Object.getOwnPropertyNames
+	  ? Object.getOwnPropertyNames(window) : [];
+
+	var getWindowNames = function (it) {
+	  try {
+	    return $getOwnPropertyNames$1(it);
+	  } catch (error) {
+	    return arraySlice$2(windowNames);
+	  }
+	};
+
+	// fallback for IE11 buggy Object.getOwnPropertyNames with iframe and window
+	objectGetOwnPropertyNamesExternal.f = function getOwnPropertyNames(it) {
+	  return windowNames && classof$4(it) == 'Window'
+	    ? getWindowNames(it)
+	    : $getOwnPropertyNames$1(toIndexedObject$2(it));
+	};
+
+	var objectGetOwnPropertySymbols = {};
+
+	// eslint-disable-next-line es/no-object-getownpropertysymbols -- safe
+	objectGetOwnPropertySymbols.f = Object.getOwnPropertySymbols;
+
+	var createNonEnumerableProperty$3 = createNonEnumerableProperty$5;
+
+	var defineBuiltIn$4 = function (target, key, value, options) {
+	  if (options && options.enumerable) target[key] = value;
+	  else createNonEnumerableProperty$3(target, key, value);
+	  return target;
+	};
+
+	var defineProperty$2 = objectDefineProperty;
+
+	var defineBuiltInAccessor$1 = function (target, name, descriptor) {
+	  return defineProperty$2.f(target, name, descriptor);
+	};
+
+	var wellKnownSymbolWrapped = {};
+
+	var wellKnownSymbol$9 = wellKnownSymbol$g;
+
+	wellKnownSymbolWrapped.f = wellKnownSymbol$9;
+
+	var path$3 = path$7;
+	var hasOwn$7 = hasOwnProperty_1;
+	var wrappedWellKnownSymbolModule$1 = wellKnownSymbolWrapped;
+	var defineProperty$1 = objectDefineProperty.f;
+
+	var wellKnownSymbolDefine = function (NAME) {
+	  var Symbol = path$3.Symbol || (path$3.Symbol = {});
+	  if (!hasOwn$7(Symbol, NAME)) defineProperty$1(Symbol, NAME, {
+	    value: wrappedWellKnownSymbolModule$1.f(NAME)
+	  });
+	};
+
+	var call$6 = functionCall;
+	var getBuiltIn$5 = getBuiltIn$9;
+	var wellKnownSymbol$8 = wellKnownSymbol$g;
+	var defineBuiltIn$3 = defineBuiltIn$4;
+
+	var symbolDefineToPrimitive = function () {
+	  var Symbol = getBuiltIn$5('Symbol');
+	  var SymbolPrototype = Symbol && Symbol.prototype;
+	  var valueOf = SymbolPrototype && SymbolPrototype.valueOf;
+	  var TO_PRIMITIVE = wellKnownSymbol$8('toPrimitive');
+
+	  if (SymbolPrototype && !SymbolPrototype[TO_PRIMITIVE]) {
+	    // `Symbol.prototype[@@toPrimitive]` method
+	    // https://tc39.es/ecma262/#sec-symbol.prototype-@@toprimitive
+	    // eslint-disable-next-line no-unused-vars -- required for .length
+	    defineBuiltIn$3(SymbolPrototype, TO_PRIMITIVE, function (hint) {
+	      return call$6(valueOf, this);
+	    }, { arity: 1 });
+	  }
+	};
+
+	var TO_STRING_TAG_SUPPORT$1 = toStringTagSupport;
+	var classof$3 = classof$7;
+
+	// `Object.prototype.toString` method implementation
+	// https://tc39.es/ecma262/#sec-object.prototype.tostring
+	var objectToString = TO_STRING_TAG_SUPPORT$1 ? {}.toString : function toString() {
+	  return '[object ' + classof$3(this) + ']';
+	};
+
+	var TO_STRING_TAG_SUPPORT = toStringTagSupport;
+	var defineProperty = objectDefineProperty.f;
+	var createNonEnumerableProperty$2 = createNonEnumerableProperty$5;
+	var hasOwn$6 = hasOwnProperty_1;
+	var toString$4 = objectToString;
+	var wellKnownSymbol$7 = wellKnownSymbol$g;
+
+	var TO_STRING_TAG$1 = wellKnownSymbol$7('toStringTag');
+
+	var setToStringTag$5 = function (it, TAG, STATIC, SET_METHOD) {
+	  if (it) {
+	    var target = STATIC ? it : it.prototype;
+	    if (!hasOwn$6(target, TO_STRING_TAG$1)) {
+	      defineProperty(target, TO_STRING_TAG$1, { configurable: true, value: TAG });
+	    }
+	    if (SET_METHOD && !TO_STRING_TAG_SUPPORT) {
+	      createNonEnumerableProperty$2(target, 'toString', toString$4);
+	    }
+	  }
+	};
+
+	var global$6 = global$e;
+	var isCallable$4 = isCallable$f;
+
+	var WeakMap$1 = global$6.WeakMap;
+
+	var weakMapBasicDetection = isCallable$4(WeakMap$1) && /native code/.test(String(WeakMap$1));
+
+	var NATIVE_WEAK_MAP = weakMapBasicDetection;
+	var global$5 = global$e;
+	var isObject$1 = isObject$8;
+	var createNonEnumerableProperty$1 = createNonEnumerableProperty$5;
+	var hasOwn$5 = hasOwnProperty_1;
+	var shared$4 = sharedStore;
+	var sharedKey$2 = sharedKey$4;
+	var hiddenKeys$1 = hiddenKeys$5;
+
+	var OBJECT_ALREADY_INITIALIZED = 'Object already initialized';
+	var TypeError$2 = global$5.TypeError;
+	var WeakMap = global$5.WeakMap;
+	var set, get, has;
+
+	var enforce = function (it) {
+	  return has(it) ? get(it) : set(it, {});
+	};
+
+	var getterFor = function (TYPE) {
+	  return function (it) {
+	    var state;
+	    if (!isObject$1(it) || (state = get(it)).type !== TYPE) {
+	      throw TypeError$2('Incompatible receiver, ' + TYPE + ' required');
+	    } return state;
+	  };
+	};
+
+	if (NATIVE_WEAK_MAP || shared$4.state) {
+	  var store = shared$4.state || (shared$4.state = new WeakMap());
+	  /* eslint-disable no-self-assign -- prototype methods protection */
+	  store.get = store.get;
+	  store.has = store.has;
+	  store.set = store.set;
+	  /* eslint-enable no-self-assign -- prototype methods protection */
+	  set = function (it, metadata) {
+	    if (store.has(it)) throw TypeError$2(OBJECT_ALREADY_INITIALIZED);
+	    metadata.facade = it;
+	    store.set(it, metadata);
+	    return metadata;
+	  };
+	  get = function (it) {
+	    return store.get(it) || {};
+	  };
+	  has = function (it) {
+	    return store.has(it);
+	  };
+	} else {
+	  var STATE = sharedKey$2('state');
+	  hiddenKeys$1[STATE] = true;
+	  set = function (it, metadata) {
+	    if (hasOwn$5(it, STATE)) throw TypeError$2(OBJECT_ALREADY_INITIALIZED);
+	    metadata.facade = it;
+	    createNonEnumerableProperty$1(it, STATE, metadata);
+	    return metadata;
+	  };
+	  get = function (it) {
+	    return hasOwn$5(it, STATE) ? it[STATE] : {};
+	  };
+	  has = function (it) {
+	    return hasOwn$5(it, STATE);
+	  };
+	}
+
+	var internalState = {
+	  set: set,
+	  get: get,
+	  has: has,
+	  enforce: enforce,
+	  getterFor: getterFor
+	};
+
+	var bind$2 = functionBindContext;
+	var uncurryThis$7 = functionUncurryThis;
+	var IndexedObject = indexedObject;
+	var toObject$3 = toObject$6;
+	var lengthOfArrayLike$3 = lengthOfArrayLike$7;
+	var arraySpeciesCreate$1 = arraySpeciesCreate$3;
+
+	var push$2 = uncurryThis$7([].push);
+
+	// `Array.prototype.{ forEach, map, filter, some, every, find, findIndex, filterReject }` methods implementation
+	var createMethod$1 = function (TYPE) {
+	  var IS_MAP = TYPE == 1;
+	  var IS_FILTER = TYPE == 2;
+	  var IS_SOME = TYPE == 3;
+	  var IS_EVERY = TYPE == 4;
+	  var IS_FIND_INDEX = TYPE == 6;
+	  var IS_FILTER_REJECT = TYPE == 7;
+	  var NO_HOLES = TYPE == 5 || IS_FIND_INDEX;
+	  return function ($this, callbackfn, that, specificCreate) {
+	    var O = toObject$3($this);
+	    var self = IndexedObject(O);
+	    var boundFunction = bind$2(callbackfn, that);
+	    var length = lengthOfArrayLike$3(self);
+	    var index = 0;
+	    var create = specificCreate || arraySpeciesCreate$1;
+	    var target = IS_MAP ? create($this, length) : IS_FILTER || IS_FILTER_REJECT ? create($this, 0) : undefined;
+	    var value, result;
+	    for (;length > index; index++) if (NO_HOLES || index in self) {
+	      value = self[index];
+	      result = boundFunction(value, index, O);
+	      if (TYPE) {
+	        if (IS_MAP) target[index] = result; // map
+	        else if (result) switch (TYPE) {
+	          case 3: return true;              // some
+	          case 5: return value;             // find
+	          case 6: return index;             // findIndex
+	          case 2: push$2(target, value);      // filter
+	        } else switch (TYPE) {
+	          case 4: return false;             // every
+	          case 7: push$2(target, value);      // filterReject
+	        }
+	      }
+	    }
+	    return IS_FIND_INDEX ? -1 : IS_SOME || IS_EVERY ? IS_EVERY : target;
+	  };
+	};
+
+	var arrayIteration = {
+	  // `Array.prototype.forEach` method
+	  // https://tc39.es/ecma262/#sec-array.prototype.foreach
+	  forEach: createMethod$1(0),
+	  // `Array.prototype.map` method
+	  // https://tc39.es/ecma262/#sec-array.prototype.map
+	  map: createMethod$1(1),
+	  // `Array.prototype.filter` method
+	  // https://tc39.es/ecma262/#sec-array.prototype.filter
+	  filter: createMethod$1(2),
+	  // `Array.prototype.some` method
+	  // https://tc39.es/ecma262/#sec-array.prototype.some
+	  some: createMethod$1(3),
+	  // `Array.prototype.every` method
+	  // https://tc39.es/ecma262/#sec-array.prototype.every
+	  every: createMethod$1(4),
+	  // `Array.prototype.find` method
+	  // https://tc39.es/ecma262/#sec-array.prototype.find
+	  find: createMethod$1(5),
+	  // `Array.prototype.findIndex` method
+	  // https://tc39.es/ecma262/#sec-array.prototype.findIndex
+	  findIndex: createMethod$1(6),
+	  // `Array.prototype.filterReject` method
+	  // https://github.com/tc39/proposal-array-filtering
+	  filterReject: createMethod$1(7)
+	};
+
+	var $$9 = _export;
+	var global$4 = global$e;
+	var call$5 = functionCall;
+	var uncurryThis$6 = functionUncurryThis;
+	var DESCRIPTORS$1 = descriptors;
+	var NATIVE_SYMBOL$3 = symbolConstructorDetection;
+	var fails$4 = fails$f;
+	var hasOwn$4 = hasOwnProperty_1;
+	var isPrototypeOf$2 = objectIsPrototypeOf;
+	var anObject$3 = anObject$7;
+	var toIndexedObject$1 = toIndexedObject$7;
+	var toPropertyKey = toPropertyKey$5;
+	var $toString = toString$5;
+	var createPropertyDescriptor$1 = createPropertyDescriptor$5;
+	var nativeObjectCreate = objectCreate;
+	var objectKeys = objectKeys$2;
+	var getOwnPropertyNamesModule = objectGetOwnPropertyNames;
+	var getOwnPropertyNamesExternal = objectGetOwnPropertyNamesExternal;
+	var getOwnPropertySymbolsModule$1 = objectGetOwnPropertySymbols;
+	var getOwnPropertyDescriptorModule = objectGetOwnPropertyDescriptor;
+	var definePropertyModule = objectDefineProperty;
+	var definePropertiesModule = objectDefineProperties;
+	var propertyIsEnumerableModule = objectPropertyIsEnumerable;
+	var defineBuiltIn$2 = defineBuiltIn$4;
+	var defineBuiltInAccessor = defineBuiltInAccessor$1;
+	var shared$3 = sharedExports;
+	var sharedKey$1 = sharedKey$4;
+	var hiddenKeys = hiddenKeys$5;
+	var uid = uid$3;
+	var wellKnownSymbol$6 = wellKnownSymbol$g;
+	var wrappedWellKnownSymbolModule = wellKnownSymbolWrapped;
+	var defineWellKnownSymbol$l = wellKnownSymbolDefine;
+	var defineSymbolToPrimitive$1 = symbolDefineToPrimitive;
+	var setToStringTag$4 = setToStringTag$5;
+	var InternalStateModule$2 = internalState;
+	var $forEach = arrayIteration.forEach;
+
+	var HIDDEN = sharedKey$1('hidden');
+	var SYMBOL = 'Symbol';
+	var PROTOTYPE = 'prototype';
+
+	var setInternalState$2 = InternalStateModule$2.set;
+	var getInternalState$2 = InternalStateModule$2.getterFor(SYMBOL);
+
+	var ObjectPrototype$1 = Object[PROTOTYPE];
+	var $Symbol = global$4.Symbol;
+	var SymbolPrototype = $Symbol && $Symbol[PROTOTYPE];
+	var TypeError$1 = global$4.TypeError;
+	var QObject = global$4.QObject;
+	var nativeGetOwnPropertyDescriptor = getOwnPropertyDescriptorModule.f;
+	var nativeDefineProperty = definePropertyModule.f;
+	var nativeGetOwnPropertyNames = getOwnPropertyNamesExternal.f;
+	var nativePropertyIsEnumerable = propertyIsEnumerableModule.f;
+	var push$1 = uncurryThis$6([].push);
+
+	var AllSymbols = shared$3('symbols');
+	var ObjectPrototypeSymbols = shared$3('op-symbols');
+	var WellKnownSymbolsStore$1 = shared$3('wks');
+
+	// Don't use setters in Qt Script, https://github.com/zloirock/core-js/issues/173
+	var USE_SETTER = !QObject || !QObject[PROTOTYPE] || !QObject[PROTOTYPE].findChild;
+
+	// fallback for old Android, https://code.google.com/p/v8/issues/detail?id=687
+	var setSymbolDescriptor = DESCRIPTORS$1 && fails$4(function () {
+	  return nativeObjectCreate(nativeDefineProperty({}, 'a', {
+	    get: function () { return nativeDefineProperty(this, 'a', { value: 7 }).a; }
+	  })).a != 7;
+	}) ? function (O, P, Attributes) {
+	  var ObjectPrototypeDescriptor = nativeGetOwnPropertyDescriptor(ObjectPrototype$1, P);
+	  if (ObjectPrototypeDescriptor) delete ObjectPrototype$1[P];
+	  nativeDefineProperty(O, P, Attributes);
+	  if (ObjectPrototypeDescriptor && O !== ObjectPrototype$1) {
+	    nativeDefineProperty(ObjectPrototype$1, P, ObjectPrototypeDescriptor);
+	  }
+	} : nativeDefineProperty;
+
+	var wrap = function (tag, description) {
+	  var symbol = AllSymbols[tag] = nativeObjectCreate(SymbolPrototype);
+	  setInternalState$2(symbol, {
+	    type: SYMBOL,
+	    tag: tag,
+	    description: description
+	  });
+	  if (!DESCRIPTORS$1) symbol.description = description;
+	  return symbol;
+	};
+
+	var $defineProperty = function defineProperty(O, P, Attributes) {
+	  if (O === ObjectPrototype$1) $defineProperty(ObjectPrototypeSymbols, P, Attributes);
+	  anObject$3(O);
+	  var key = toPropertyKey(P);
+	  anObject$3(Attributes);
+	  if (hasOwn$4(AllSymbols, key)) {
+	    if (!Attributes.enumerable) {
+	      if (!hasOwn$4(O, HIDDEN)) nativeDefineProperty(O, HIDDEN, createPropertyDescriptor$1(1, {}));
+	      O[HIDDEN][key] = true;
+	    } else {
+	      if (hasOwn$4(O, HIDDEN) && O[HIDDEN][key]) O[HIDDEN][key] = false;
+	      Attributes = nativeObjectCreate(Attributes, { enumerable: createPropertyDescriptor$1(0, false) });
+	    } return setSymbolDescriptor(O, key, Attributes);
+	  } return nativeDefineProperty(O, key, Attributes);
+	};
+
+	var $defineProperties = function defineProperties(O, Properties) {
+	  anObject$3(O);
+	  var properties = toIndexedObject$1(Properties);
+	  var keys = objectKeys(properties).concat($getOwnPropertySymbols(properties));
+	  $forEach(keys, function (key) {
+	    if (!DESCRIPTORS$1 || call$5($propertyIsEnumerable, properties, key)) $defineProperty(O, key, properties[key]);
+	  });
+	  return O;
+	};
+
+	var $create = function create(O, Properties) {
+	  return Properties === undefined ? nativeObjectCreate(O) : $defineProperties(nativeObjectCreate(O), Properties);
+	};
+
+	var $propertyIsEnumerable = function propertyIsEnumerable(V) {
+	  var P = toPropertyKey(V);
+	  var enumerable = call$5(nativePropertyIsEnumerable, this, P);
+	  if (this === ObjectPrototype$1 && hasOwn$4(AllSymbols, P) && !hasOwn$4(ObjectPrototypeSymbols, P)) return false;
+	  return enumerable || !hasOwn$4(this, P) || !hasOwn$4(AllSymbols, P) || hasOwn$4(this, HIDDEN) && this[HIDDEN][P]
+	    ? enumerable : true;
+	};
+
+	var $getOwnPropertyDescriptor = function getOwnPropertyDescriptor(O, P) {
+	  var it = toIndexedObject$1(O);
+	  var key = toPropertyKey(P);
+	  if (it === ObjectPrototype$1 && hasOwn$4(AllSymbols, key) && !hasOwn$4(ObjectPrototypeSymbols, key)) return;
+	  var descriptor = nativeGetOwnPropertyDescriptor(it, key);
+	  if (descriptor && hasOwn$4(AllSymbols, key) && !(hasOwn$4(it, HIDDEN) && it[HIDDEN][key])) {
+	    descriptor.enumerable = true;
+	  }
+	  return descriptor;
+	};
+
+	var $getOwnPropertyNames = function getOwnPropertyNames(O) {
+	  var names = nativeGetOwnPropertyNames(toIndexedObject$1(O));
+	  var result = [];
+	  $forEach(names, function (key) {
+	    if (!hasOwn$4(AllSymbols, key) && !hasOwn$4(hiddenKeys, key)) push$1(result, key);
+	  });
+	  return result;
+	};
+
+	var $getOwnPropertySymbols = function (O) {
+	  var IS_OBJECT_PROTOTYPE = O === ObjectPrototype$1;
+	  var names = nativeGetOwnPropertyNames(IS_OBJECT_PROTOTYPE ? ObjectPrototypeSymbols : toIndexedObject$1(O));
+	  var result = [];
+	  $forEach(names, function (key) {
+	    if (hasOwn$4(AllSymbols, key) && (!IS_OBJECT_PROTOTYPE || hasOwn$4(ObjectPrototype$1, key))) {
+	      push$1(result, AllSymbols[key]);
+	    }
+	  });
+	  return result;
+	};
+
+	// `Symbol` constructor
+	// https://tc39.es/ecma262/#sec-symbol-constructor
+	if (!NATIVE_SYMBOL$3) {
+	  $Symbol = function Symbol() {
+	    if (isPrototypeOf$2(SymbolPrototype, this)) throw TypeError$1('Symbol is not a constructor');
+	    var description = !arguments.length || arguments[0] === undefined ? undefined : $toString(arguments[0]);
+	    var tag = uid(description);
+	    var setter = function (value) {
+	      if (this === ObjectPrototype$1) call$5(setter, ObjectPrototypeSymbols, value);
+	      if (hasOwn$4(this, HIDDEN) && hasOwn$4(this[HIDDEN], tag)) this[HIDDEN][tag] = false;
+	      setSymbolDescriptor(this, tag, createPropertyDescriptor$1(1, value));
+	    };
+	    if (DESCRIPTORS$1 && USE_SETTER) setSymbolDescriptor(ObjectPrototype$1, tag, { configurable: true, set: setter });
+	    return wrap(tag, description);
+	  };
+
+	  SymbolPrototype = $Symbol[PROTOTYPE];
+
+	  defineBuiltIn$2(SymbolPrototype, 'toString', function toString() {
+	    return getInternalState$2(this).tag;
+	  });
+
+	  defineBuiltIn$2($Symbol, 'withoutSetter', function (description) {
+	    return wrap(uid(description), description);
+	  });
+
+	  propertyIsEnumerableModule.f = $propertyIsEnumerable;
+	  definePropertyModule.f = $defineProperty;
+	  definePropertiesModule.f = $defineProperties;
+	  getOwnPropertyDescriptorModule.f = $getOwnPropertyDescriptor;
+	  getOwnPropertyNamesModule.f = getOwnPropertyNamesExternal.f = $getOwnPropertyNames;
+	  getOwnPropertySymbolsModule$1.f = $getOwnPropertySymbols;
+
+	  wrappedWellKnownSymbolModule.f = function (name) {
+	    return wrap(wellKnownSymbol$6(name), name);
+	  };
+
+	  if (DESCRIPTORS$1) {
+	    // https://github.com/tc39/proposal-Symbol-description
+	    defineBuiltInAccessor(SymbolPrototype, 'description', {
+	      configurable: true,
+	      get: function description() {
+	        return getInternalState$2(this).description;
+	      }
+	    });
+	  }
+	}
+
+	$$9({ global: true, constructor: true, wrap: true, forced: !NATIVE_SYMBOL$3, sham: !NATIVE_SYMBOL$3 }, {
+	  Symbol: $Symbol
+	});
+
+	$forEach(objectKeys(WellKnownSymbolsStore$1), function (name) {
+	  defineWellKnownSymbol$l(name);
+	});
+
+	$$9({ target: SYMBOL, stat: true, forced: !NATIVE_SYMBOL$3 }, {
+	  useSetter: function () { USE_SETTER = true; },
+	  useSimple: function () { USE_SETTER = false; }
+	});
+
+	$$9({ target: 'Object', stat: true, forced: !NATIVE_SYMBOL$3, sham: !DESCRIPTORS$1 }, {
+	  // `Object.create` method
+	  // https://tc39.es/ecma262/#sec-object.create
+	  create: $create,
+	  // `Object.defineProperty` method
+	  // https://tc39.es/ecma262/#sec-object.defineproperty
+	  defineProperty: $defineProperty,
+	  // `Object.defineProperties` method
+	  // https://tc39.es/ecma262/#sec-object.defineproperties
+	  defineProperties: $defineProperties,
+	  // `Object.getOwnPropertyDescriptor` method
+	  // https://tc39.es/ecma262/#sec-object.getownpropertydescriptors
+	  getOwnPropertyDescriptor: $getOwnPropertyDescriptor
+	});
+
+	$$9({ target: 'Object', stat: true, forced: !NATIVE_SYMBOL$3 }, {
+	  // `Object.getOwnPropertyNames` method
+	  // https://tc39.es/ecma262/#sec-object.getownpropertynames
+	  getOwnPropertyNames: $getOwnPropertyNames
+	});
+
+	// `Symbol.prototype[@@toPrimitive]` method
+	// https://tc39.es/ecma262/#sec-symbol.prototype-@@toprimitive
+	defineSymbolToPrimitive$1();
+
+	// `Symbol.prototype[@@toStringTag]` property
+	// https://tc39.es/ecma262/#sec-symbol.prototype-@@tostringtag
+	setToStringTag$4($Symbol, SYMBOL);
+
+	hiddenKeys[HIDDEN] = true;
+
+	var NATIVE_SYMBOL$2 = symbolConstructorDetection;
+
+	/* eslint-disable es/no-symbol -- safe */
+	var symbolRegistryDetection = NATIVE_SYMBOL$2 && !!Symbol['for'] && !!Symbol.keyFor;
+
+	var $$8 = _export;
+	var getBuiltIn$4 = getBuiltIn$9;
+	var hasOwn$3 = hasOwnProperty_1;
+	var toString$3 = toString$5;
+	var shared$2 = sharedExports;
+	var NATIVE_SYMBOL_REGISTRY$1 = symbolRegistryDetection;
+
+	var StringToSymbolRegistry = shared$2('string-to-symbol-registry');
+	var SymbolToStringRegistry$1 = shared$2('symbol-to-string-registry');
+
+	// `Symbol.for` method
+	// https://tc39.es/ecma262/#sec-symbol.for
+	$$8({ target: 'Symbol', stat: true, forced: !NATIVE_SYMBOL_REGISTRY$1 }, {
+	  'for': function (key) {
+	    var string = toString$3(key);
+	    if (hasOwn$3(StringToSymbolRegistry, string)) return StringToSymbolRegistry[string];
+	    var symbol = getBuiltIn$4('Symbol')(string);
+	    StringToSymbolRegistry[string] = symbol;
+	    SymbolToStringRegistry$1[symbol] = string;
+	    return symbol;
+	  }
+	});
+
+	var $$7 = _export;
+	var hasOwn$2 = hasOwnProperty_1;
+	var isSymbol$2 = isSymbol$5;
+	var tryToString$2 = tryToString$4;
+	var shared$1 = sharedExports;
+	var NATIVE_SYMBOL_REGISTRY = symbolRegistryDetection;
+
+	var SymbolToStringRegistry = shared$1('symbol-to-string-registry');
+
+	// `Symbol.keyFor` method
+	// https://tc39.es/ecma262/#sec-symbol.keyfor
+	$$7({ target: 'Symbol', stat: true, forced: !NATIVE_SYMBOL_REGISTRY }, {
+	  keyFor: function keyFor(sym) {
+	    if (!isSymbol$2(sym)) throw TypeError(tryToString$2(sym) + ' is not a symbol');
+	    if (hasOwn$2(SymbolToStringRegistry, sym)) return SymbolToStringRegistry[sym];
+	  }
+	});
+
+	var uncurryThis$5 = functionUncurryThis;
+
+	var arraySlice$1 = uncurryThis$5([].slice);
+
+	var uncurryThis$4 = functionUncurryThis;
+	var isArray$1 = isArray$4;
+	var isCallable$3 = isCallable$f;
+	var classof$2 = classofRaw$2;
+	var toString$2 = toString$5;
+
+	var push = uncurryThis$4([].push);
+
+	var getJsonReplacerFunction = function (replacer) {
+	  if (isCallable$3(replacer)) return replacer;
+	  if (!isArray$1(replacer)) return;
+	  var rawLength = replacer.length;
+	  var keys = [];
+	  for (var i = 0; i < rawLength; i++) {
+	    var element = replacer[i];
+	    if (typeof element == 'string') push(keys, element);
+	    else if (typeof element == 'number' || classof$2(element) == 'Number' || classof$2(element) == 'String') push(keys, toString$2(element));
+	  }
+	  var keysLength = keys.length;
+	  var root = true;
+	  return function (key, value) {
+	    if (root) {
+	      root = false;
+	      return value;
+	    }
+	    if (isArray$1(this)) return value;
+	    for (var j = 0; j < keysLength; j++) if (keys[j] === key) return value;
+	  };
+	};
+
+	var $$6 = _export;
+	var getBuiltIn$3 = getBuiltIn$9;
+	var apply = functionApply;
+	var call$4 = functionCall;
+	var uncurryThis$3 = functionUncurryThis;
+	var fails$3 = fails$f;
+	var isCallable$2 = isCallable$f;
+	var isSymbol$1 = isSymbol$5;
+	var arraySlice = arraySlice$1;
+	var getReplacerFunction = getJsonReplacerFunction;
+	var NATIVE_SYMBOL$1 = symbolConstructorDetection;
+
+	var $String = String;
+	var $stringify = getBuiltIn$3('JSON', 'stringify');
+	var exec = uncurryThis$3(/./.exec);
+	var charAt$2 = uncurryThis$3(''.charAt);
+	var charCodeAt$1 = uncurryThis$3(''.charCodeAt);
+	var replace = uncurryThis$3(''.replace);
+	var numberToString = uncurryThis$3(1.0.toString);
+
+	var tester = /[\uD800-\uDFFF]/g;
+	var low = /^[\uD800-\uDBFF]$/;
+	var hi = /^[\uDC00-\uDFFF]$/;
+
+	var WRONG_SYMBOLS_CONVERSION = !NATIVE_SYMBOL$1 || fails$3(function () {
+	  var symbol = getBuiltIn$3('Symbol')();
+	  // MS Edge converts symbol values to JSON as {}
+	  return $stringify([symbol]) != '[null]'
+	    // WebKit converts symbol values to JSON as null
+	    || $stringify({ a: symbol }) != '{}'
+	    // V8 throws on boxed symbols
+	    || $stringify(Object(symbol)) != '{}';
+	});
+
+	// https://github.com/tc39/proposal-well-formed-stringify
+	var ILL_FORMED_UNICODE = fails$3(function () {
+	  return $stringify('\uDF06\uD834') !== '"\\udf06\\ud834"'
+	    || $stringify('\uDEAD') !== '"\\udead"';
+	});
+
+	var stringifyWithSymbolsFix = function (it, replacer) {
+	  var args = arraySlice(arguments);
+	  var $replacer = getReplacerFunction(replacer);
+	  if (!isCallable$2($replacer) && (it === undefined || isSymbol$1(it))) return; // IE8 returns string on undefined
+	  args[1] = function (key, value) {
+	    // some old implementations (like WebKit) could pass numbers as keys
+	    if (isCallable$2($replacer)) value = call$4($replacer, this, $String(key), value);
+	    if (!isSymbol$1(value)) return value;
+	  };
+	  return apply($stringify, null, args);
+	};
+
+	var fixIllFormed = function (match, offset, string) {
+	  var prev = charAt$2(string, offset - 1);
+	  var next = charAt$2(string, offset + 1);
+	  if ((exec(low, match) && !exec(hi, next)) || (exec(hi, match) && !exec(low, prev))) {
+	    return '\\u' + numberToString(charCodeAt$1(match, 0), 16);
+	  } return match;
+	};
+
+	if ($stringify) {
+	  // `JSON.stringify` method
+	  // https://tc39.es/ecma262/#sec-json.stringify
+	  $$6({ target: 'JSON', stat: true, arity: 3, forced: WRONG_SYMBOLS_CONVERSION || ILL_FORMED_UNICODE }, {
+	    // eslint-disable-next-line no-unused-vars -- required for `.length`
+	    stringify: function stringify(it, replacer, space) {
+	      var args = arraySlice(arguments);
+	      var result = apply(WRONG_SYMBOLS_CONVERSION ? stringifyWithSymbolsFix : $stringify, null, args);
+	      return ILL_FORMED_UNICODE && typeof result == 'string' ? replace(result, tester, fixIllFormed) : result;
+	    }
+	  });
+	}
+
+	var $$5 = _export;
+	var NATIVE_SYMBOL = symbolConstructorDetection;
+	var fails$2 = fails$f;
+	var getOwnPropertySymbolsModule = objectGetOwnPropertySymbols;
+	var toObject$2 = toObject$6;
+
+	// V8 ~ Chrome 38 and 39 `Object.getOwnPropertySymbols` fails on primitives
+	// https://bugs.chromium.org/p/v8/issues/detail?id=3443
+	var FORCED = !NATIVE_SYMBOL || fails$2(function () { getOwnPropertySymbolsModule.f(1); });
+
+	// `Object.getOwnPropertySymbols` method
+	// https://tc39.es/ecma262/#sec-object.getownpropertysymbols
+	$$5({ target: 'Object', stat: true, forced: FORCED }, {
+	  getOwnPropertySymbols: function getOwnPropertySymbols(it) {
+	    var $getOwnPropertySymbols = getOwnPropertySymbolsModule.f;
+	    return $getOwnPropertySymbols ? $getOwnPropertySymbols(toObject$2(it)) : [];
+	  }
+	});
+
+	var defineWellKnownSymbol$k = wellKnownSymbolDefine;
+
+	// `Symbol.asyncIterator` well-known symbol
+	// https://tc39.es/ecma262/#sec-symbol.asynciterator
+	defineWellKnownSymbol$k('asyncIterator');
+
+	var defineWellKnownSymbol$j = wellKnownSymbolDefine;
+
+	// `Symbol.hasInstance` well-known symbol
+	// https://tc39.es/ecma262/#sec-symbol.hasinstance
+	defineWellKnownSymbol$j('hasInstance');
+
+	var defineWellKnownSymbol$i = wellKnownSymbolDefine;
+
+	// `Symbol.isConcatSpreadable` well-known symbol
+	// https://tc39.es/ecma262/#sec-symbol.isconcatspreadable
+	defineWellKnownSymbol$i('isConcatSpreadable');
+
+	var defineWellKnownSymbol$h = wellKnownSymbolDefine;
+
+	// `Symbol.iterator` well-known symbol
+	// https://tc39.es/ecma262/#sec-symbol.iterator
+	defineWellKnownSymbol$h('iterator');
+
+	var defineWellKnownSymbol$g = wellKnownSymbolDefine;
+
+	// `Symbol.match` well-known symbol
+	// https://tc39.es/ecma262/#sec-symbol.match
+	defineWellKnownSymbol$g('match');
+
+	var defineWellKnownSymbol$f = wellKnownSymbolDefine;
+
+	// `Symbol.matchAll` well-known symbol
+	// https://tc39.es/ecma262/#sec-symbol.matchall
+	defineWellKnownSymbol$f('matchAll');
+
+	var defineWellKnownSymbol$e = wellKnownSymbolDefine;
+
+	// `Symbol.replace` well-known symbol
+	// https://tc39.es/ecma262/#sec-symbol.replace
+	defineWellKnownSymbol$e('replace');
+
+	var defineWellKnownSymbol$d = wellKnownSymbolDefine;
+
+	// `Symbol.search` well-known symbol
+	// https://tc39.es/ecma262/#sec-symbol.search
+	defineWellKnownSymbol$d('search');
+
+	var defineWellKnownSymbol$c = wellKnownSymbolDefine;
+
+	// `Symbol.species` well-known symbol
+	// https://tc39.es/ecma262/#sec-symbol.species
+	defineWellKnownSymbol$c('species');
+
+	var defineWellKnownSymbol$b = wellKnownSymbolDefine;
+
+	// `Symbol.split` well-known symbol
+	// https://tc39.es/ecma262/#sec-symbol.split
+	defineWellKnownSymbol$b('split');
+
+	var defineWellKnownSymbol$a = wellKnownSymbolDefine;
+	var defineSymbolToPrimitive = symbolDefineToPrimitive;
+
+	// `Symbol.toPrimitive` well-known symbol
+	// https://tc39.es/ecma262/#sec-symbol.toprimitive
+	defineWellKnownSymbol$a('toPrimitive');
+
+	// `Symbol.prototype[@@toPrimitive]` method
+	// https://tc39.es/ecma262/#sec-symbol.prototype-@@toprimitive
+	defineSymbolToPrimitive();
+
+	var getBuiltIn$2 = getBuiltIn$9;
+	var defineWellKnownSymbol$9 = wellKnownSymbolDefine;
+	var setToStringTag$3 = setToStringTag$5;
+
+	// `Symbol.toStringTag` well-known symbol
+	// https://tc39.es/ecma262/#sec-symbol.tostringtag
+	defineWellKnownSymbol$9('toStringTag');
+
+	// `Symbol.prototype[@@toStringTag]` property
+	// https://tc39.es/ecma262/#sec-symbol.prototype-@@tostringtag
+	setToStringTag$3(getBuiltIn$2('Symbol'), 'Symbol');
+
+	var defineWellKnownSymbol$8 = wellKnownSymbolDefine;
+
+	// `Symbol.unscopables` well-known symbol
+	// https://tc39.es/ecma262/#sec-symbol.unscopables
+	defineWellKnownSymbol$8('unscopables');
+
+	var global$3 = global$e;
+	var setToStringTag$2 = setToStringTag$5;
+
+	// JSON[@@toStringTag] property
+	// https://tc39.es/ecma262/#sec-json-@@tostringtag
+	setToStringTag$2(global$3.JSON, 'JSON', true);
+
+	var path$2 = path$7;
+
+	var symbol$3 = path$2.Symbol;
+
+	var iterators = {};
+
+	var DESCRIPTORS = descriptors;
+	var hasOwn$1 = hasOwnProperty_1;
+
+	var FunctionPrototype = Function.prototype;
+	// eslint-disable-next-line es/no-object-getownpropertydescriptor -- safe
+	var getDescriptor = DESCRIPTORS && Object.getOwnPropertyDescriptor;
+
+	var EXISTS = hasOwn$1(FunctionPrototype, 'name');
+	// additional protection from minified / mangled / dropped function names
+	var PROPER = EXISTS && (function something() { /* empty */ }).name === 'something';
+	var CONFIGURABLE = EXISTS && (!DESCRIPTORS || (DESCRIPTORS && getDescriptor(FunctionPrototype, 'name').configurable));
+
+	var functionName = {
+	  EXISTS: EXISTS,
+	  PROPER: PROPER,
+	  CONFIGURABLE: CONFIGURABLE
+	};
+
+	var fails$1 = fails$f;
+
+	var correctPrototypeGetter = !fails$1(function () {
+	  function F() { /* empty */ }
+	  F.prototype.constructor = null;
+	  // eslint-disable-next-line es/no-object-getprototypeof -- required for testing
+	  return Object.getPrototypeOf(new F()) !== F.prototype;
+	});
+
+	var hasOwn = hasOwnProperty_1;
+	var isCallable$1 = isCallable$f;
+	var toObject$1 = toObject$6;
+	var sharedKey = sharedKey$4;
+	var CORRECT_PROTOTYPE_GETTER = correctPrototypeGetter;
+
+	var IE_PROTO = sharedKey('IE_PROTO');
+	var $Object = Object;
+	var ObjectPrototype = $Object.prototype;
+
+	// `Object.getPrototypeOf` method
+	// https://tc39.es/ecma262/#sec-object.getprototypeof
+	// eslint-disable-next-line es/no-object-getprototypeof -- safe
+	var objectGetPrototypeOf = CORRECT_PROTOTYPE_GETTER ? $Object.getPrototypeOf : function (O) {
+	  var object = toObject$1(O);
+	  if (hasOwn(object, IE_PROTO)) return object[IE_PROTO];
+	  var constructor = object.constructor;
+	  if (isCallable$1(constructor) && object instanceof constructor) {
+	    return constructor.prototype;
+	  } return object instanceof $Object ? ObjectPrototype : null;
+	};
+
+	var fails = fails$f;
+	var isCallable = isCallable$f;
+	var isObject = isObject$8;
+	var create$1 = objectCreate;
+	var getPrototypeOf$1 = objectGetPrototypeOf;
+	var defineBuiltIn$1 = defineBuiltIn$4;
+	var wellKnownSymbol$5 = wellKnownSymbol$g;
+
+	var ITERATOR$3 = wellKnownSymbol$5('iterator');
+	var BUGGY_SAFARI_ITERATORS$1 = false;
+
+	// `%IteratorPrototype%` object
+	// https://tc39.es/ecma262/#sec-%iteratorprototype%-object
+	var IteratorPrototype$1, PrototypeOfArrayIteratorPrototype, arrayIterator;
+
+	/* eslint-disable es/no-array-prototype-keys -- safe */
+	if ([].keys) {
+	  arrayIterator = [].keys();
+	  // Safari 8 has buggy iterators w/o `next`
+	  if (!('next' in arrayIterator)) BUGGY_SAFARI_ITERATORS$1 = true;
+	  else {
+	    PrototypeOfArrayIteratorPrototype = getPrototypeOf$1(getPrototypeOf$1(arrayIterator));
+	    if (PrototypeOfArrayIteratorPrototype !== Object.prototype) IteratorPrototype$1 = PrototypeOfArrayIteratorPrototype;
+	  }
+	}
+
+	var NEW_ITERATOR_PROTOTYPE = !isObject(IteratorPrototype$1) || fails(function () {
+	  var test = {};
+	  // FF44- legacy iterators case
+	  return IteratorPrototype$1[ITERATOR$3].call(test) !== test;
+	});
+
+	if (NEW_ITERATOR_PROTOTYPE) IteratorPrototype$1 = {};
+	else IteratorPrototype$1 = create$1(IteratorPrototype$1);
+
+	// `%IteratorPrototype%[@@iterator]()` method
+	// https://tc39.es/ecma262/#sec-%iteratorprototype%-@@iterator
+	if (!isCallable(IteratorPrototype$1[ITERATOR$3])) {
+	  defineBuiltIn$1(IteratorPrototype$1, ITERATOR$3, function () {
+	    return this;
+	  });
+	}
+
+	var iteratorsCore = {
+	  IteratorPrototype: IteratorPrototype$1,
+	  BUGGY_SAFARI_ITERATORS: BUGGY_SAFARI_ITERATORS$1
+	};
+
+	var IteratorPrototype = iteratorsCore.IteratorPrototype;
+	var create = objectCreate;
+	var createPropertyDescriptor = createPropertyDescriptor$5;
+	var setToStringTag$1 = setToStringTag$5;
+	var Iterators$5 = iterators;
+
+	var returnThis$1 = function () { return this; };
+
+	var iteratorCreateConstructor = function (IteratorConstructor, NAME, next, ENUMERABLE_NEXT) {
+	  var TO_STRING_TAG = NAME + ' Iterator';
+	  IteratorConstructor.prototype = create(IteratorPrototype, { next: createPropertyDescriptor(+!ENUMERABLE_NEXT, next) });
+	  setToStringTag$1(IteratorConstructor, TO_STRING_TAG, false, true);
+	  Iterators$5[TO_STRING_TAG] = returnThis$1;
+	  return IteratorConstructor;
+	};
+
+	var $$4 = _export;
+	var call$3 = functionCall;
+	var FunctionName = functionName;
+	var createIteratorConstructor = iteratorCreateConstructor;
+	var getPrototypeOf = objectGetPrototypeOf;
+	var setToStringTag = setToStringTag$5;
+	var defineBuiltIn = defineBuiltIn$4;
+	var wellKnownSymbol$4 = wellKnownSymbol$g;
+	var Iterators$4 = iterators;
+	var IteratorsCore = iteratorsCore;
+
+	var PROPER_FUNCTION_NAME = FunctionName.PROPER;
+	var BUGGY_SAFARI_ITERATORS = IteratorsCore.BUGGY_SAFARI_ITERATORS;
+	var ITERATOR$2 = wellKnownSymbol$4('iterator');
+	var KEYS = 'keys';
+	var VALUES = 'values';
+	var ENTRIES = 'entries';
+
+	var returnThis = function () { return this; };
+
+	var iteratorDefine = function (Iterable, NAME, IteratorConstructor, next, DEFAULT, IS_SET, FORCED) {
+	  createIteratorConstructor(IteratorConstructor, NAME, next);
+
+	  var getIterationMethod = function (KIND) {
+	    if (KIND === DEFAULT && defaultIterator) return defaultIterator;
+	    if (!BUGGY_SAFARI_ITERATORS && KIND in IterablePrototype) return IterablePrototype[KIND];
+	    switch (KIND) {
+	      case KEYS: return function keys() { return new IteratorConstructor(this, KIND); };
+	      case VALUES: return function values() { return new IteratorConstructor(this, KIND); };
+	      case ENTRIES: return function entries() { return new IteratorConstructor(this, KIND); };
+	    } return function () { return new IteratorConstructor(this); };
+	  };
+
+	  var TO_STRING_TAG = NAME + ' Iterator';
+	  var INCORRECT_VALUES_NAME = false;
+	  var IterablePrototype = Iterable.prototype;
+	  var nativeIterator = IterablePrototype[ITERATOR$2]
+	    || IterablePrototype['@@iterator']
+	    || DEFAULT && IterablePrototype[DEFAULT];
+	  var defaultIterator = !BUGGY_SAFARI_ITERATORS && nativeIterator || getIterationMethod(DEFAULT);
+	  var anyNativeIterator = NAME == 'Array' ? IterablePrototype.entries || nativeIterator : nativeIterator;
+	  var CurrentIteratorPrototype, methods, KEY;
+
+	  // fix native
+	  if (anyNativeIterator) {
+	    CurrentIteratorPrototype = getPrototypeOf(anyNativeIterator.call(new Iterable()));
+	    if (CurrentIteratorPrototype !== Object.prototype && CurrentIteratorPrototype.next) {
+	      // Set @@toStringTag to native iterators
+	      setToStringTag(CurrentIteratorPrototype, TO_STRING_TAG, true, true);
+	      Iterators$4[TO_STRING_TAG] = returnThis;
+	    }
+	  }
+
+	  // fix Array.prototype.{ values, @@iterator }.name in V8 / FF
+	  if (PROPER_FUNCTION_NAME && DEFAULT == VALUES && nativeIterator && nativeIterator.name !== VALUES) {
+	    {
+	      INCORRECT_VALUES_NAME = true;
+	      defaultIterator = function values() { return call$3(nativeIterator, this); };
+	    }
+	  }
+
+	  // export additional methods
+	  if (DEFAULT) {
+	    methods = {
+	      values: getIterationMethod(VALUES),
+	      keys: IS_SET ? defaultIterator : getIterationMethod(KEYS),
+	      entries: getIterationMethod(ENTRIES)
+	    };
+	    if (FORCED) for (KEY in methods) {
+	      if (BUGGY_SAFARI_ITERATORS || INCORRECT_VALUES_NAME || !(KEY in IterablePrototype)) {
+	        defineBuiltIn(IterablePrototype, KEY, methods[KEY]);
+	      }
+	    } else $$4({ target: NAME, proto: true, forced: BUGGY_SAFARI_ITERATORS || INCORRECT_VALUES_NAME }, methods);
+	  }
+
+	  // define iterator
+	  if ((FORCED) && IterablePrototype[ITERATOR$2] !== defaultIterator) {
+	    defineBuiltIn(IterablePrototype, ITERATOR$2, defaultIterator, { name: DEFAULT });
+	  }
+	  Iterators$4[NAME] = defaultIterator;
+
+	  return methods;
+	};
+
+	// `CreateIterResultObject` abstract operation
+	// https://tc39.es/ecma262/#sec-createiterresultobject
+	var createIterResultObject$2 = function (value, done) {
+	  return { value: value, done: done };
+	};
+
+	var toIndexedObject = toIndexedObject$7;
+	var Iterators$3 = iterators;
+	var InternalStateModule$1 = internalState;
+	var defineIterator$1 = iteratorDefine;
+	var createIterResultObject$1 = createIterResultObject$2;
+
+	var ARRAY_ITERATOR = 'Array Iterator';
+	var setInternalState$1 = InternalStateModule$1.set;
+	var getInternalState$1 = InternalStateModule$1.getterFor(ARRAY_ITERATOR);
+
+	// `Array.prototype.entries` method
+	// https://tc39.es/ecma262/#sec-array.prototype.entries
+	// `Array.prototype.keys` method
+	// https://tc39.es/ecma262/#sec-array.prototype.keys
+	// `Array.prototype.values` method
+	// https://tc39.es/ecma262/#sec-array.prototype.values
+	// `Array.prototype[@@iterator]` method
+	// https://tc39.es/ecma262/#sec-array.prototype-@@iterator
+	// `CreateArrayIterator` internal method
+	// https://tc39.es/ecma262/#sec-createarrayiterator
+	defineIterator$1(Array, 'Array', function (iterated, kind) {
+	  setInternalState$1(this, {
+	    type: ARRAY_ITERATOR,
+	    target: toIndexedObject(iterated), // target
+	    index: 0,                          // next index
+	    kind: kind                         // kind
+	  });
+	// `%ArrayIteratorPrototype%.next` method
+	// https://tc39.es/ecma262/#sec-%arrayiteratorprototype%.next
+	}, function () {
+	  var state = getInternalState$1(this);
+	  var target = state.target;
+	  var kind = state.kind;
+	  var index = state.index++;
+	  if (!target || index >= target.length) {
+	    state.target = undefined;
+	    return createIterResultObject$1(undefined, true);
+	  }
+	  if (kind == 'keys') return createIterResultObject$1(index, false);
+	  if (kind == 'values') return createIterResultObject$1(target[index], false);
+	  return createIterResultObject$1([index, target[index]], false);
+	}, 'values');
+
+	// argumentsList[@@iterator] is %ArrayProto_values%
+	// https://tc39.es/ecma262/#sec-createunmappedargumentsobject
+	// https://tc39.es/ecma262/#sec-createmappedargumentsobject
+	Iterators$3.Arguments = Iterators$3.Array;
+
+	// iterable DOM collections
+	// flag - `iterable` interface - 'entries', 'keys', 'values', 'forEach' methods
+	var domIterables = {
+	  CSSRuleList: 0,
+	  CSSStyleDeclaration: 0,
+	  CSSValueList: 0,
+	  ClientRectList: 0,
+	  DOMRectList: 0,
+	  DOMStringList: 0,
+	  DOMTokenList: 1,
+	  DataTransferItemList: 0,
+	  FileList: 0,
+	  HTMLAllCollection: 0,
+	  HTMLCollection: 0,
+	  HTMLFormElement: 0,
+	  HTMLSelectElement: 0,
+	  MediaList: 0,
+	  MimeTypeArray: 0,
+	  NamedNodeMap: 0,
+	  NodeList: 1,
+	  PaintRequestList: 0,
+	  Plugin: 0,
+	  PluginArray: 0,
+	  SVGLengthList: 0,
+	  SVGNumberList: 0,
+	  SVGPathSegList: 0,
+	  SVGPointList: 0,
+	  SVGStringList: 0,
+	  SVGTransformList: 0,
+	  SourceBufferList: 0,
+	  StyleSheetList: 0,
+	  TextTrackCueList: 0,
+	  TextTrackList: 0,
+	  TouchList: 0
+	};
+
+	var DOMIterables = domIterables;
+	var global$2 = global$e;
+	var classof$1 = classof$7;
+	var createNonEnumerableProperty = createNonEnumerableProperty$5;
+	var Iterators$2 = iterators;
+	var wellKnownSymbol$3 = wellKnownSymbol$g;
+
+	var TO_STRING_TAG = wellKnownSymbol$3('toStringTag');
+
+	for (var COLLECTION_NAME in DOMIterables) {
+	  var Collection = global$2[COLLECTION_NAME];
+	  var CollectionPrototype = Collection && Collection.prototype;
+	  if (CollectionPrototype && classof$1(CollectionPrototype) !== TO_STRING_TAG) {
+	    createNonEnumerableProperty(CollectionPrototype, TO_STRING_TAG, COLLECTION_NAME);
+	  }
+	  Iterators$2[COLLECTION_NAME] = Iterators$2.Array;
+	}
+
+	var parent$a = symbol$3;
+
+
+	var symbol$2 = parent$a;
+
+	var defineWellKnownSymbol$7 = wellKnownSymbolDefine;
+
+	// `Symbol.dispose` well-known symbol
+	// https://github.com/tc39/proposal-explicit-resource-management
+	defineWellKnownSymbol$7('dispose');
+
+	var parent$9 = symbol$2;
+
+
+
+	var symbol$1 = parent$9;
+
+	var defineWellKnownSymbol$6 = wellKnownSymbolDefine;
+
+	// `Symbol.asyncDispose` well-known symbol
+	// https://github.com/tc39/proposal-async-explicit-resource-management
+	defineWellKnownSymbol$6('asyncDispose');
+
+	var $$3 = _export;
+	var getBuiltIn$1 = getBuiltIn$9;
+	var uncurryThis$2 = functionUncurryThis;
+
+	var Symbol$2 = getBuiltIn$1('Symbol');
+	var keyFor = Symbol$2.keyFor;
+	var thisSymbolValue$1 = uncurryThis$2(Symbol$2.prototype.valueOf);
+
+	// `Symbol.isRegistered` method
+	// https://tc39.es/proposal-symbol-predicates/#sec-symbol-isregistered
+	$$3({ target: 'Symbol', stat: true }, {
+	  isRegistered: function isRegistered(value) {
+	    try {
+	      return keyFor(thisSymbolValue$1(value)) !== undefined;
+	    } catch (error) {
+	      return false;
+	    }
+	  }
+	});
+
+	var $$2 = _export;
+	var shared = sharedExports;
+	var getBuiltIn = getBuiltIn$9;
+	var uncurryThis$1 = functionUncurryThis;
+	var isSymbol = isSymbol$5;
+	var wellKnownSymbol$2 = wellKnownSymbol$g;
+
+	var Symbol$1 = getBuiltIn('Symbol');
+	var $isWellKnown = Symbol$1.isWellKnown;
+	var getOwnPropertyNames = getBuiltIn('Object', 'getOwnPropertyNames');
+	var thisSymbolValue = uncurryThis$1(Symbol$1.prototype.valueOf);
+	var WellKnownSymbolsStore = shared('wks');
+
+	for (var i = 0, symbolKeys = getOwnPropertyNames(Symbol$1), symbolKeysLength = symbolKeys.length; i < symbolKeysLength; i++) {
+	  // some old engines throws on access to some keys like `arguments` or `caller`
+	  try {
+	    var symbolKey = symbolKeys[i];
+	    if (isSymbol(Symbol$1[symbolKey])) wellKnownSymbol$2(symbolKey);
+	  } catch (error) { /* empty */ }
+	}
+
+	// `Symbol.isWellKnown` method
+	// https://tc39.es/proposal-symbol-predicates/#sec-symbol-iswellknown
+	// We should patch it for newly added well-known symbols. If it's not required, this module just will not be injected
+	$$2({ target: 'Symbol', stat: true, forced: true }, {
+	  isWellKnown: function isWellKnown(value) {
+	    if ($isWellKnown && $isWellKnown(value)) return true;
+	    try {
+	      var symbol = thisSymbolValue(value);
+	      for (var j = 0, keys = getOwnPropertyNames(WellKnownSymbolsStore), keysLength = keys.length; j < keysLength; j++) {
+	        if (WellKnownSymbolsStore[keys[j]] == symbol) return true;
+	      }
+	    } catch (error) { /* empty */ }
+	    return false;
+	  }
+	});
+
+	var defineWellKnownSymbol$5 = wellKnownSymbolDefine;
+
+	// `Symbol.matcher` well-known symbol
+	// https://github.com/tc39/proposal-pattern-matching
+	defineWellKnownSymbol$5('matcher');
+
+	var defineWellKnownSymbol$4 = wellKnownSymbolDefine;
+
+	// `Symbol.metadataKey` well-known symbol
+	// https://github.com/tc39/proposal-decorator-metadata
+	defineWellKnownSymbol$4('metadataKey');
+
+	var defineWellKnownSymbol$3 = wellKnownSymbolDefine;
+
+	// `Symbol.observable` well-known symbol
+	// https://github.com/tc39/proposal-observable
+	defineWellKnownSymbol$3('observable');
+
+	// TODO: Remove from `core-js@4`
+	var defineWellKnownSymbol$2 = wellKnownSymbolDefine;
+
+	// `Symbol.metadata` well-known symbol
+	// https://github.com/tc39/proposal-decorators
+	defineWellKnownSymbol$2('metadata');
+
+	// TODO: remove from `core-js@4`
+	var defineWellKnownSymbol$1 = wellKnownSymbolDefine;
+
+	// `Symbol.patternMatch` well-known symbol
+	// https://github.com/tc39/proposal-pattern-matching
+	defineWellKnownSymbol$1('patternMatch');
+
+	// TODO: remove from `core-js@4`
+	var defineWellKnownSymbol = wellKnownSymbolDefine;
+
+	defineWellKnownSymbol('replaceAll');
+
+	var parent$8 = symbol$1;
+
+
+
+
+
+
+	// TODO: Remove from `core-js@4`
+
+
+
+
+	var symbol = parent$8;
+
+	(function (module) {
+		module.exports = symbol;
+	} (symbol$4));
+
+	(function (module) {
+		module.exports = symbolExports;
+	} (symbol$5));
+
+	var iteratorExports$1 = {};
+	var iterator$5 = {
+	  get exports(){ return iteratorExports$1; },
+	  set exports(v){ iteratorExports$1 = v; },
+	};
+
+	var iteratorExports = {};
+	var iterator$4 = {
+	  get exports(){ return iteratorExports; },
+	  set exports(v){ iteratorExports = v; },
+	};
+
+	var uncurryThis = functionUncurryThis;
+	var toIntegerOrInfinity = toIntegerOrInfinity$3;
+	var toString$1 = toString$5;
+	var requireObjectCoercible = requireObjectCoercible$3;
+
+	var charAt$1 = uncurryThis(''.charAt);
+	var charCodeAt = uncurryThis(''.charCodeAt);
+	var stringSlice = uncurryThis(''.slice);
+
+	var createMethod = function (CONVERT_TO_STRING) {
+	  return function ($this, pos) {
+	    var S = toString$1(requireObjectCoercible($this));
+	    var position = toIntegerOrInfinity(pos);
+	    var size = S.length;
+	    var first, second;
+	    if (position < 0 || position >= size) return CONVERT_TO_STRING ? '' : undefined;
+	    first = charCodeAt(S, position);
+	    return first < 0xD800 || first > 0xDBFF || position + 1 === size
+	      || (second = charCodeAt(S, position + 1)) < 0xDC00 || second > 0xDFFF
+	        ? CONVERT_TO_STRING
+	          ? charAt$1(S, position)
+	          : first
+	        : CONVERT_TO_STRING
+	          ? stringSlice(S, position, position + 2)
+	          : (first - 0xD800 << 10) + (second - 0xDC00) + 0x10000;
+	  };
+	};
+
+	var stringMultibyte = {
+	  // `String.prototype.codePointAt` method
+	  // https://tc39.es/ecma262/#sec-string.prototype.codepointat
+	  codeAt: createMethod(false),
+	  // `String.prototype.at` method
+	  // https://github.com/mathiasbynens/String.prototype.at
+	  charAt: createMethod(true)
+	};
+
+	var charAt = stringMultibyte.charAt;
+	var toString = toString$5;
+	var InternalStateModule = internalState;
+	var defineIterator = iteratorDefine;
+	var createIterResultObject = createIterResultObject$2;
+
+	var STRING_ITERATOR = 'String Iterator';
+	var setInternalState = InternalStateModule.set;
+	var getInternalState = InternalStateModule.getterFor(STRING_ITERATOR);
+
+	// `String.prototype[@@iterator]` method
+	// https://tc39.es/ecma262/#sec-string.prototype-@@iterator
+	defineIterator(String, 'String', function (iterated) {
+	  setInternalState(this, {
+	    type: STRING_ITERATOR,
+	    string: toString(iterated),
+	    index: 0
+	  });
+	// `%StringIteratorPrototype%.next` method
+	// https://tc39.es/ecma262/#sec-%stringiteratorprototype%.next
+	}, function next() {
+	  var state = getInternalState(this);
+	  var string = state.string;
+	  var index = state.index;
+	  var point;
+	  if (index >= string.length) return createIterResultObject(undefined, true);
+	  point = charAt(string, index);
+	  state.index += point.length;
+	  return createIterResultObject(point, false);
+	});
+
+	var WrappedWellKnownSymbolModule$1 = wellKnownSymbolWrapped;
+
+	var iterator$3 = WrappedWellKnownSymbolModule$1.f('iterator');
+
+	var parent$7 = iterator$3;
+
+
+	var iterator$2 = parent$7;
+
+	var parent$6 = iterator$2;
+
+	var iterator$1 = parent$6;
+
+	var parent$5 = iterator$1;
+
+	var iterator = parent$5;
+
+	(function (module) {
+		module.exports = iterator;
+	} (iterator$4));
+
+	(function (module) {
+		module.exports = iteratorExports;
+	} (iterator$5));
+
+	(function (module) {
+		var _Symbol = symbolExports$1;
+		var _Symbol$iterator = iteratorExports$1;
+		function _typeof(obj) {
+		  "@babel/helpers - typeof";
+
+		  return (module.exports = _typeof = "function" == typeof _Symbol && "symbol" == typeof _Symbol$iterator ? function (obj) {
+		    return typeof obj;
+		  } : function (obj) {
+		    return obj && "function" == typeof _Symbol && obj.constructor === _Symbol && obj !== _Symbol.prototype ? "symbol" : typeof obj;
+		  }, module.exports.__esModule = true, module.exports["default"] = module.exports), _typeof(obj);
+		}
+		module.exports = _typeof, module.exports.__esModule = true, module.exports["default"] = module.exports;
+	} (_typeof));
+
+	var toPrimitiveExports$2 = {};
+	var toPrimitive$6 = {
+	  get exports(){ return toPrimitiveExports$2; },
+	  set exports(v){ toPrimitiveExports$2 = v; },
+	};
+
+	var toPrimitiveExports$1 = {};
+	var toPrimitive$5 = {
+	  get exports(){ return toPrimitiveExports$1; },
+	  set exports(v){ toPrimitiveExports$1 = v; },
+	};
+
+	var toPrimitiveExports = {};
+	var toPrimitive$4 = {
+	  get exports(){ return toPrimitiveExports; },
+	  set exports(v){ toPrimitiveExports = v; },
+	};
+
+	var WrappedWellKnownSymbolModule = wellKnownSymbolWrapped;
+
+	var toPrimitive$3 = WrappedWellKnownSymbolModule.f('toPrimitive');
+
+	var parent$4 = toPrimitive$3;
+
+	var toPrimitive$2 = parent$4;
+
+	var parent$3 = toPrimitive$2;
+
+	var toPrimitive$1 = parent$3;
+
+	var parent$2 = toPrimitive$1;
+
+	var toPrimitive = parent$2;
+
+	(function (module) {
+		module.exports = toPrimitive;
+	} (toPrimitive$4));
+
+	(function (module) {
+		module.exports = toPrimitiveExports;
+	} (toPrimitive$5));
+
+	(function (module) {
+		var _Symbol$toPrimitive = toPrimitiveExports$1;
+		var _typeof = _typeofExports["default"];
+		function _toPrimitive(input, hint) {
+		  if (_typeof(input) !== "object" || input === null) return input;
+		  var prim = input[_Symbol$toPrimitive];
+		  if (prim !== undefined) {
+		    var res = prim.call(input, hint || "default");
+		    if (_typeof(res) !== "object") return res;
+		    throw new TypeError("@@toPrimitive must return a primitive value.");
+		  }
+		  return (hint === "string" ? String : Number)(input);
+		}
+		module.exports = _toPrimitive, module.exports.__esModule = true, module.exports["default"] = module.exports;
+	} (toPrimitive$6));
+
+	(function (module) {
+		var _typeof = _typeofExports["default"];
+		var toPrimitive = toPrimitiveExports$2;
+		function _toPropertyKey(arg) {
+		  var key = toPrimitive(arg, "string");
+		  return _typeof(key) === "symbol" ? key : String(key);
+		}
+		module.exports = _toPropertyKey, module.exports.__esModule = true, module.exports["default"] = module.exports;
+	} (toPropertyKey$2));
+
+	(function (module) {
+		var _Object$defineProperty = definePropertyExports$2;
+		var toPropertyKey = toPropertyKeyExports;
+		function _defineProperty(obj, key, value) {
+		  key = toPropertyKey(key);
+		  if (key in obj) {
+		    _Object$defineProperty(obj, key, {
+		      value: value,
+		      enumerable: true,
+		      configurable: true,
+		      writable: true
+		    });
+		  } else {
+		    obj[key] = value;
+		  }
+		  return obj;
+		}
+		module.exports = _defineProperty, module.exports.__esModule = true, module.exports["default"] = module.exports;
+	} (defineProperty$c));
+
+	var _defineProperty = /*@__PURE__*/getDefaultExportFromCjs(definePropertyExports$3);
+
+	var fromEntriesExports = {};
+	var fromEntries$2 = {
+	  get exports(){ return fromEntriesExports; },
+	  set exports(v){ fromEntriesExports = v; },
+	};
+
+	var wellKnownSymbol$1 = wellKnownSymbol$g;
+	var Iterators$1 = iterators;
+
+	var ITERATOR$1 = wellKnownSymbol$1('iterator');
+	var ArrayPrototype$1 = Array.prototype;
+
+	// check on default Array iterator
+	var isArrayIteratorMethod$1 = function (it) {
+	  return it !== undefined && (Iterators$1.Array === it || ArrayPrototype$1[ITERATOR$1] === it);
+	};
+
+	var classof = classof$7;
+	var getMethod$1 = getMethod$3;
+	var isNullOrUndefined = isNullOrUndefined$3;
+	var Iterators = iterators;
+	var wellKnownSymbol = wellKnownSymbol$g;
+
+	var ITERATOR = wellKnownSymbol('iterator');
+
+	var getIteratorMethod$2 = function (it) {
+	  if (!isNullOrUndefined(it)) return getMethod$1(it, ITERATOR)
+	    || getMethod$1(it, '@@iterator')
+	    || Iterators[classof(it)];
+	};
+
+	var call$2 = functionCall;
+	var aCallable$1 = aCallable$4;
+	var anObject$2 = anObject$7;
+	var tryToString$1 = tryToString$4;
+	var getIteratorMethod$1 = getIteratorMethod$2;
+
+	var $TypeError$1 = TypeError;
+
+	var getIterator$1 = function (argument, usingIterator) {
+	  var iteratorMethod = arguments.length < 2 ? getIteratorMethod$1(argument) : usingIterator;
+	  if (aCallable$1(iteratorMethod)) return anObject$2(call$2(iteratorMethod, argument));
+	  throw $TypeError$1(tryToString$1(argument) + ' is not iterable');
+	};
+
+	var call$1 = functionCall;
+	var anObject$1 = anObject$7;
+	var getMethod = getMethod$3;
+
+	var iteratorClose$1 = function (iterator, kind, value) {
+	  var innerResult, innerError;
+	  anObject$1(iterator);
+	  try {
+	    innerResult = getMethod(iterator, 'return');
+	    if (!innerResult) {
+	      if (kind === 'throw') throw value;
+	      return value;
+	    }
+	    innerResult = call$1(innerResult, iterator);
+	  } catch (error) {
+	    innerError = true;
+	    innerResult = error;
+	  }
+	  if (kind === 'throw') throw value;
+	  if (innerError) throw innerResult;
+	  anObject$1(innerResult);
+	  return value;
+	};
+
+	var bind$1 = functionBindContext;
+	var call = functionCall;
+	var anObject = anObject$7;
+	var tryToString = tryToString$4;
+	var isArrayIteratorMethod = isArrayIteratorMethod$1;
+	var lengthOfArrayLike$2 = lengthOfArrayLike$7;
+	var isPrototypeOf$1 = objectIsPrototypeOf;
+	var getIterator = getIterator$1;
+	var getIteratorMethod = getIteratorMethod$2;
+	var iteratorClose = iteratorClose$1;
+
+	var $TypeError = TypeError;
+
+	var Result = function (stopped, result) {
+	  this.stopped = stopped;
+	  this.result = result;
+	};
+
+	var ResultPrototype = Result.prototype;
+
+	var iterate$1 = function (iterable, unboundFunction, options) {
+	  var that = options && options.that;
+	  var AS_ENTRIES = !!(options && options.AS_ENTRIES);
+	  var IS_RECORD = !!(options && options.IS_RECORD);
+	  var IS_ITERATOR = !!(options && options.IS_ITERATOR);
+	  var INTERRUPTED = !!(options && options.INTERRUPTED);
+	  var fn = bind$1(unboundFunction, that);
+	  var iterator, iterFn, index, length, result, next, step;
+
+	  var stop = function (condition) {
+	    if (iterator) iteratorClose(iterator, 'normal', condition);
+	    return new Result(true, condition);
+	  };
+
+	  var callFn = function (value) {
+	    if (AS_ENTRIES) {
+	      anObject(value);
+	      return INTERRUPTED ? fn(value[0], value[1], stop) : fn(value[0], value[1]);
+	    } return INTERRUPTED ? fn(value, stop) : fn(value);
+	  };
+
+	  if (IS_RECORD) {
+	    iterator = iterable.iterator;
+	  } else if (IS_ITERATOR) {
+	    iterator = iterable;
+	  } else {
+	    iterFn = getIteratorMethod(iterable);
+	    if (!iterFn) throw $TypeError(tryToString(iterable) + ' is not iterable');
+	    // optimisation for array iterators
+	    if (isArrayIteratorMethod(iterFn)) {
+	      for (index = 0, length = lengthOfArrayLike$2(iterable); length > index; index++) {
+	        result = callFn(iterable[index]);
+	        if (result && isPrototypeOf$1(ResultPrototype, result)) return result;
+	      } return new Result(false);
+	    }
+	    iterator = getIterator(iterable, iterFn);
+	  }
+
+	  next = IS_RECORD ? iterable.next : iterator.next;
+	  while (!(step = call(next, iterator)).done) {
+	    try {
+	      result = callFn(step.value);
+	    } catch (error) {
+	      iteratorClose(iterator, 'throw', error);
+	    }
+	    if (typeof result == 'object' && result && isPrototypeOf$1(ResultPrototype, result)) return result;
+	  } return new Result(false);
+	};
+
+	var $$1 = _export;
+	var iterate = iterate$1;
+	var createProperty = createProperty$3;
+
+	// `Object.fromEntries` method
+	// https://github.com/tc39/proposal-object-from-entries
+	$$1({ target: 'Object', stat: true }, {
+	  fromEntries: function fromEntries(iterable) {
+	    var obj = {};
+	    iterate(iterable, function (k, v) {
+	      createProperty(obj, k, v);
+	    }, { AS_ENTRIES: true });
+	    return obj;
+	  }
+	});
+
+	var path$1 = path$7;
+
+	var fromEntries$1 = path$1.Object.fromEntries;
+
+	var parent$1 = fromEntries$1;
+
+
+	var fromEntries = parent$1;
+
+	(function (module) {
+		module.exports = fromEntries;
+	} (fromEntries$2));
+
+	var _Object$fromEntries = /*@__PURE__*/getDefaultExportFromCjs(fromEntriesExports);
+
+	const conf = {
+	  theme: {
+	    // color to use when mixxx doesn't report a color for the control
+	    // only used for RGB LEDs
+	    fallbackHotcueColor: [127, 127, 127],
+	    fallbackTrackColor: [127, 127, 127]
+	  },
+	  // what channels should be initially selected
+	  initialSelection: [0, 1],
+	  // mapping of sizes to presets
+	  // list of presets are cycled through in the specified order,
+	  // first element in the list serves as the default
+	  // possible sizes are: grande (8x8), tall (4x8) and short (4x4)
+	  // grid is indexed horizontally left-to-right then vertically bottom-to-top
+	  // check for available controls and their parameters in the controls directory
+	  presets: {
+	    grande: [{
+	      // 'Grande'
+	      deck: [{
+	        pos: [0, 0],
+	        control: {
+	          type: 'play'
+	        }
+	      }, {
+	        pos: [1, 0],
+	        control: {
+	          type: 'sync'
+	        }
+	      }, {
+	        pos: [2, 0],
+	        control: {
+	          type: 'nudge'
+	        }
+	      }, {
+	        pos: [0, 1],
+	        control: {
+	          type: 'cue'
+	        }
+	      }, {
+	        pos: [1, 1],
+	        control: {
+	          type: 'tap'
+	        }
+	      }, {
+	        pos: [2, 1],
+	        control: {
+	          type: 'grid'
+	        }
+	      }, {
+	        pos: [0, 2],
+	        control: {
+	          type: 'pfl'
+	        }
+	      }, {
+	        pos: [1, 2],
+	        control: {
+	          type: 'quantize'
+	        }
+	      }, {
+	        pos: [2, 2],
+	        control: {
+	          type: 'keyshift',
+	          params: {
+	            shifts: [[1, 1], [2, 2], [3, 3], [5, 4], [7, 5], [8, 6], [10, 7], [12, 8]],
+	            rows: 2
+	          }
+	        }
+	      }, {
+	        pos: [0, 3],
+	        control: {
+	          type: 'load'
+	        }
+	      }, {
+	        pos: [1, 3],
+	        control: {
+	          type: 'key'
+	        }
+	      }, {
+	        pos: [0, 4],
+	        control: {
+	          type: 'hotcue',
+	          params: {
+	            cues: 8,
+	            rows: 2
+	          }
+	        }
+	      }, {
+	        pos: [2, 6],
+	        control: {
+	          type: 'beatjump',
+	          params: {
+	            jumps: [[0.25, 1], [0.33, 2], [0.5, 4], [0.75, 8], [1, 16], [2, 32]]
+	          }
+	        }
+	      }, {
+	        pos: [4, 2],
+	        control: {
+	          type: 'beatloop',
+	          params: {
+	            loops: [0.5, 1, 2, 4, 8, 16, 32, 64],
+	            rows: 2
+	          }
+	        }
+	      }, {
+	        pos: [6, 2],
+	        control: {
+	          type: 'loopjump',
+	          params: {
+	            jumps: [[0.5, 8], [1, 16], [2, 32], [4, 64]],
+	            vertical: true
+	          }
+	        }
+	      }, {
+	        pos: [6, 1],
+	        control: {
+	          type: 'loopjumpSmall',
+	          params: {
+	            amount: 0.03125
+	          }
+	        }
+	      }, {
+	        pos: [4, 1],
+	        control: {
+	          type: 'loopMultiply'
+	        }
+	      }, {
+	        pos: [4, 0],
+	        control: {
+	          type: 'reloop'
+	        }
+	      }, {
+	        pos: [5, 0],
+	        control: {
+	          type: 'loopIo'
+	        }
+	      }, {
+	        pos: [7, 0],
+	        control: {
+	          type: 'slip'
+	        }
+	      }]
+	    }, {
+	      samplerPalette: {
+	        n: 64,
+	        offset: 4,
+	        rows: 8
+	      }
+	    }],
+	    tall: [{
+	      // 'Tall'
+	      deck: [{
+	        pos: [0, 0],
+	        control: {
+	          type: 'play'
+	        }
+	      }, {
+	        pos: [1, 0],
+	        control: {
+	          type: 'sync'
+	        }
+	      }, {
+	        pos: [2, 0],
+	        control: {
+	          type: 'nudge'
+	        }
+	      }, {
+	        pos: [0, 1],
+	        control: {
+	          type: 'cue'
+	        }
+	      }, {
+	        pos: [1, 1],
+	        control: {
+	          type: 'tap'
+	        }
+	      }, {
+	        pos: [2, 1],
+	        control: {
+	          type: 'grid'
+	        }
+	      }, {
+	        pos: [0, 2],
+	        control: {
+	          type: 'pfl'
+	        }
+	      }, {
+	        pos: [1, 2],
+	        control: {
+	          type: 'quantize'
+	        }
+	      }, {
+	        pos: [2, 2],
+	        control: {
+	          type: 'loopIo'
+	        }
+	      }, {
+	        pos: [0, 3],
+	        control: {
+	          type: 'load'
+	        }
+	      }, {
+	        pos: [1, 3],
+	        control: {
+	          type: 'key'
+	        }
+	      }, {
+	        pos: [2, 3],
+	        control: {
+	          type: 'reloop'
+	        }
+	      }, {
+	        pos: [3, 3],
+	        control: {
+	          type: 'slip'
+	        }
+	      }, {
+	        pos: [0, 4],
+	        control: {
+	          type: 'hotcue',
+	          params: {
+	            cues: 4,
+	            rows: 2
+	          }
+	        }
+	      }, {
+	        pos: [2, 4],
+	        control: {
+	          type: 'loopMultiply'
+	        }
+	      }, {
+	        pos: [2, 5],
+	        control: {
+	          type: 'beatloop',
+	          params: {
+	            loops: [0.5, 1, 2, 4, 8, 16],
+	            rows: 2
+	          }
+	        }
+	      }, {
+	        pos: [0, 6],
+	        control: {
+	          type: 'beatjump',
+	          params: {
+	            jumps: [[1, 16], [2, 32]]
+	          }
+	        }
+	      }]
+	    }, {
+	      // 'Juggler'
+	      deck: [{
+	        pos: [0, 0],
+	        control: {
+	          type: 'play'
+	        }
+	      }, {
+	        pos: [1, 0],
+	        control: {
+	          type: 'load'
+	        }
+	      }, {
+	        pos: [2, 0],
+	        control: {
+	          type: 'beatjump',
+	          params: {
+	            jumps: [[0.5, 4], [1, 16], [2, 32], [4, 64]],
+	            vertical: true
+	          }
+	        }
+	      }, {
+	        pos: [0, 1],
+	        control: {
+	          type: 'loopjump',
+	          params: {
+	            jumps: [[1, 16], [4, 64]]
+	          }
+	        }
+	      }, {
+	        pos: [0, 3],
+	        control: {
+	          type: 'reloop'
+	        }
+	      }, {
+	        pos: [0, 4],
+	        control: {
+	          type: 'loopMultiply'
+	        }
+	      }, {
+	        pos: [2, 4],
+	        control: {
+	          type: 'hotcue',
+	          params: {
+	            cues: 8,
+	            rows: 2
+	          }
+	        }
+	      }, {
+	        pos: [0, 5],
+	        control: {
+	          type: 'beatloop',
+	          params: {
+	            loops: [0.5, 1, 2, 4, 8, 16],
+	            rows: 2
+	          }
+	        }
+	      }]
+	    }],
+	    short: [{
+	      // 'Short'
+	      deck: [{
+	        pos: [0, 0],
+	        control: {
+	          type: 'play'
+	        }
+	      }, {
+	        pos: [1, 0],
+	        control: {
+	          type: 'sync'
+	        }
+	      }, {
+	        pos: [2, 0],
+	        control: {
+	          type: 'nudge'
+	        }
+	      }, {
+	        pos: [0, 1],
+	        control: {
+	          type: 'cue'
+	        }
+	      }, {
+	        pos: [1, 1],
+	        control: {
+	          type: 'tap'
+	        }
+	      }, {
+	        pos: [2, 1],
+	        control: {
+	          type: 'grid'
+	        }
+	      }, {
+	        pos: [0, 2],
+	        control: {
+	          type: 'pfl'
+	        }
+	      }, {
+	        pos: [1, 2],
+	        control: {
+	          type: 'quantize'
+	        }
+	      }, {
+	        pos: [2, 2],
+	        control: {
+	          type: 'loopIo'
+	        }
+	      }, {
+	        pos: [0, 3],
+	        control: {
+	          type: 'load'
+	        }
+	      }, {
+	        pos: [1, 3],
+	        control: {
+	          type: 'key'
+	        }
+	      }, {
+	        pos: [2, 3],
+	        control: {
+	          type: 'reloop'
+	        }
+	      }, {
+	        pos: [3, 3],
+	        control: {
+	          type: 'slip'
+	        }
+	      }]
+	    }, {
+	      // 'Sampler'
+	      deck: [{
+	        pos: [0, 0],
+	        control: {
+	          type: 'hotcue',
+	          params: {
+	            cues: 16,
+	            rows: 4
+	          }
+	        }
+	      }]
+	    }]
+	  }
+	};
+	var config = conf;
+
+	var eventemitter3Exports = {};
+	var eventemitter3 = {
+	  get exports(){ return eventemitter3Exports; },
+	  set exports(v){ eventemitter3Exports = v; },
+	};
+
+	(function (module) {
+
+		var has = Object.prototype.hasOwnProperty
+		  , prefix = '~';
+
+		/**
+		 * Constructor to create a storage for our `EE` objects.
+		 * An `Events` instance is a plain object whose properties are event names.
+		 *
+		 * @constructor
+		 * @private
+		 */
+		function Events() {}
+
+		//
+		// We try to not inherit from `Object.prototype`. In some engines creating an
+		// instance in this way is faster than calling `Object.create(null)` directly.
+		// If `Object.create(null)` is not supported we prefix the event names with a
+		// character to make sure that the built-in object properties are not
+		// overridden or used as an attack vector.
+		//
+		if (Object.create) {
+		  Events.prototype = Object.create(null);
+
+		  //
+		  // This hack is needed because the `__proto__` property is still inherited in
+		  // some old browsers like Android 4, iPhone 5.1, Opera 11 and Safari 5.
+		  //
+		  if (!new Events().__proto__) prefix = false;
+		}
+
+		/**
+		 * Representation of a single event listener.
+		 *
+		 * @param {Function} fn The listener function.
+		 * @param {*} context The context to invoke the listener with.
+		 * @param {Boolean} [once=false] Specify if the listener is a one-time listener.
+		 * @constructor
+		 * @private
+		 */
+		function EE(fn, context, once) {
+		  this.fn = fn;
+		  this.context = context;
+		  this.once = once || false;
+		}
+
+		/**
+		 * Add a listener for a given event.
+		 *
+		 * @param {EventEmitter} emitter Reference to the `EventEmitter` instance.
+		 * @param {(String|Symbol)} event The event name.
+		 * @param {Function} fn The listener function.
+		 * @param {*} context The context to invoke the listener with.
+		 * @param {Boolean} once Specify if the listener is a one-time listener.
+		 * @returns {EventEmitter}
+		 * @private
+		 */
+		function addListener(emitter, event, fn, context, once) {
+		  if (typeof fn !== 'function') {
+		    throw new TypeError('The listener must be a function');
+		  }
+
+		  var listener = new EE(fn, context || emitter, once)
+		    , evt = prefix ? prefix + event : event;
+
+		  if (!emitter._events[evt]) emitter._events[evt] = listener, emitter._eventsCount++;
+		  else if (!emitter._events[evt].fn) emitter._events[evt].push(listener);
+		  else emitter._events[evt] = [emitter._events[evt], listener];
+
+		  return emitter;
+		}
+
+		/**
+		 * Clear event by name.
+		 *
+		 * @param {EventEmitter} emitter Reference to the `EventEmitter` instance.
+		 * @param {(String|Symbol)} evt The Event name.
+		 * @private
+		 */
+		function clearEvent(emitter, evt) {
+		  if (--emitter._eventsCount === 0) emitter._events = new Events();
+		  else delete emitter._events[evt];
+		}
+
+		/**
+		 * Minimal `EventEmitter` interface that is molded against the Node.js
+		 * `EventEmitter` interface.
+		 *
+		 * @constructor
+		 * @public
+		 */
+		function EventEmitter() {
+		  this._events = new Events();
+		  this._eventsCount = 0;
+		}
+
+		/**
+		 * Return an array listing the events for which the emitter has registered
+		 * listeners.
+		 *
+		 * @returns {Array}
+		 * @public
+		 */
+		EventEmitter.prototype.eventNames = function eventNames() {
+		  var names = []
+		    , events
+		    , name;
+
+		  if (this._eventsCount === 0) return names;
+
+		  for (name in (events = this._events)) {
+		    if (has.call(events, name)) names.push(prefix ? name.slice(1) : name);
+		  }
+
+		  if (Object.getOwnPropertySymbols) {
+		    return names.concat(Object.getOwnPropertySymbols(events));
+		  }
+
+		  return names;
+		};
+
+		/**
+		 * Return the listeners registered for a given event.
+		 *
+		 * @param {(String|Symbol)} event The event name.
+		 * @returns {Array} The registered listeners.
+		 * @public
+		 */
+		EventEmitter.prototype.listeners = function listeners(event) {
+		  var evt = prefix ? prefix + event : event
+		    , handlers = this._events[evt];
+
+		  if (!handlers) return [];
+		  if (handlers.fn) return [handlers.fn];
+
+		  for (var i = 0, l = handlers.length, ee = new Array(l); i < l; i++) {
+		    ee[i] = handlers[i].fn;
+		  }
+
+		  return ee;
+		};
+
+		/**
+		 * Return the number of listeners listening to a given event.
+		 *
+		 * @param {(String|Symbol)} event The event name.
+		 * @returns {Number} The number of listeners.
+		 * @public
+		 */
+		EventEmitter.prototype.listenerCount = function listenerCount(event) {
+		  var evt = prefix ? prefix + event : event
+		    , listeners = this._events[evt];
+
+		  if (!listeners) return 0;
+		  if (listeners.fn) return 1;
+		  return listeners.length;
+		};
+
+		/**
+		 * Calls each of the listeners registered for a given event.
+		 *
+		 * @param {(String|Symbol)} event The event name.
+		 * @returns {Boolean} `true` if the event had listeners, else `false`.
+		 * @public
+		 */
+		EventEmitter.prototype.emit = function emit(event, a1, a2, a3, a4, a5) {
+		  var evt = prefix ? prefix + event : event;
+
+		  if (!this._events[evt]) return false;
+
+		  var listeners = this._events[evt]
+		    , len = arguments.length
+		    , args
+		    , i;
+
+		  if (listeners.fn) {
+		    if (listeners.once) this.removeListener(event, listeners.fn, undefined, true);
+
+		    switch (len) {
+		      case 1: return listeners.fn.call(listeners.context), true;
+		      case 2: return listeners.fn.call(listeners.context, a1), true;
+		      case 3: return listeners.fn.call(listeners.context, a1, a2), true;
+		      case 4: return listeners.fn.call(listeners.context, a1, a2, a3), true;
+		      case 5: return listeners.fn.call(listeners.context, a1, a2, a3, a4), true;
+		      case 6: return listeners.fn.call(listeners.context, a1, a2, a3, a4, a5), true;
+		    }
+
+		    for (i = 1, args = new Array(len -1); i < len; i++) {
+		      args[i - 1] = arguments[i];
+		    }
+
+		    listeners.fn.apply(listeners.context, args);
+		  } else {
+		    var length = listeners.length
+		      , j;
+
+		    for (i = 0; i < length; i++) {
+		      if (listeners[i].once) this.removeListener(event, listeners[i].fn, undefined, true);
+
+		      switch (len) {
+		        case 1: listeners[i].fn.call(listeners[i].context); break;
+		        case 2: listeners[i].fn.call(listeners[i].context, a1); break;
+		        case 3: listeners[i].fn.call(listeners[i].context, a1, a2); break;
+		        case 4: listeners[i].fn.call(listeners[i].context, a1, a2, a3); break;
+		        default:
+		          if (!args) for (j = 1, args = new Array(len -1); j < len; j++) {
+		            args[j - 1] = arguments[j];
+		          }
+
+		          listeners[i].fn.apply(listeners[i].context, args);
+		      }
+		    }
+		  }
+
+		  return true;
+		};
+
+		/**
+		 * Add a listener for a given event.
+		 *
+		 * @param {(String|Symbol)} event The event name.
+		 * @param {Function} fn The listener function.
+		 * @param {*} [context=this] The context to invoke the listener with.
+		 * @returns {EventEmitter} `this`.
+		 * @public
+		 */
+		EventEmitter.prototype.on = function on(event, fn, context) {
+		  return addListener(this, event, fn, context, false);
+		};
+
+		/**
+		 * Add a one-time listener for a given event.
+		 *
+		 * @param {(String|Symbol)} event The event name.
+		 * @param {Function} fn The listener function.
+		 * @param {*} [context=this] The context to invoke the listener with.
+		 * @returns {EventEmitter} `this`.
+		 * @public
+		 */
+		EventEmitter.prototype.once = function once(event, fn, context) {
+		  return addListener(this, event, fn, context, true);
+		};
+
+		/**
+		 * Remove the listeners of a given event.
+		 *
+		 * @param {(String|Symbol)} event The event name.
+		 * @param {Function} fn Only remove the listeners that match this function.
+		 * @param {*} context Only remove the listeners that have this context.
+		 * @param {Boolean} once Only remove one-time listeners.
+		 * @returns {EventEmitter} `this`.
+		 * @public
+		 */
+		EventEmitter.prototype.removeListener = function removeListener(event, fn, context, once) {
+		  var evt = prefix ? prefix + event : event;
+
+		  if (!this._events[evt]) return this;
+		  if (!fn) {
+		    clearEvent(this, evt);
+		    return this;
+		  }
+
+		  var listeners = this._events[evt];
+
+		  if (listeners.fn) {
+		    if (
+		      listeners.fn === fn &&
+		      (!once || listeners.once) &&
+		      (!context || listeners.context === context)
+		    ) {
+		      clearEvent(this, evt);
+		    }
+		  } else {
+		    for (var i = 0, events = [], length = listeners.length; i < length; i++) {
+		      if (
+		        listeners[i].fn !== fn ||
+		        (once && !listeners[i].once) ||
+		        (context && listeners[i].context !== context)
+		      ) {
+		        events.push(listeners[i]);
+		      }
+		    }
+
+		    //
+		    // Reset the array, or remove it completely if we have no more listeners.
+		    //
+		    if (events.length) this._events[evt] = events.length === 1 ? events[0] : events;
+		    else clearEvent(this, evt);
+		  }
+
+		  return this;
+		};
+
+		/**
+		 * Remove all listeners, or those of the specified event.
+		 *
+		 * @param {(String|Symbol)} [event] The event name.
+		 * @returns {EventEmitter} `this`.
+		 * @public
+		 */
+		EventEmitter.prototype.removeAllListeners = function removeAllListeners(event) {
+		  var evt;
+
+		  if (event) {
+		    evt = prefix ? prefix + event : event;
+		    if (this._events[evt]) clearEvent(this, evt);
+		  } else {
+		    this._events = new Events();
+		    this._eventsCount = 0;
+		  }
+
+		  return this;
+		};
+
+		//
+		// Alias methods names because people roll like that.
+		//
+		EventEmitter.prototype.off = EventEmitter.prototype.removeListener;
+		EventEmitter.prototype.addListener = EventEmitter.prototype.on;
+
+		//
+		// Expose the prefix.
+		//
+		EventEmitter.prefixed = prefix;
+
+		//
+		// Allow `EventEmitter` to be imported as module namespace.
+		//
+		EventEmitter.EventEmitter = EventEmitter;
+
+		//
+		// Expose the module.
+		//
+		{
+		  module.exports = EventEmitter;
+		}
+	} (eventemitter3));
+
+	var EventEmitter = eventemitter3Exports;
+
+	class Component extends eventemitter3Exports {
+	  constructor() {
+	    super();
+	    _defineProperty(this, "mounted", false);
+	  }
+	  mount() {
+	    this.onMount();
+	    this.emit('mount', this);
+	    this.mounted = true;
+	  }
+	  unmount() {
+	    this.onUnmount();
+	    this.emit('unmount', this);
+	    this.mounted = false;
+	  }
+
+	  // eslint-disable-next-line @typescript-eslint/no-empty-function
+	  onMount() {}
+
+	  // eslint-disable-next-line @typescript-eslint/no-empty-function
+	  onUnmount() {}
+	}
+
+	const posMod = function (x, n) {
+	  return (x % n + n) % n;
+	};
+	const hexFormat = function (n, d) {
+	  return '0x' + n.toString(16).toUpperCase().padStart(d, '0');
+	};
+	const range = function* (n) {
+	  for (let i = 0; i < n; i++) {
+	    yield i;
+	  }
+	};
+	const array = function (n) {
+	  return [...n];
+	};
+	const map = function* (f, n) {
+	  for (const x of n) {
+	    yield f(x);
+	  }
+	};
+	class Lazy {
+	  constructor(fn) {
+	    _defineProperty(this, "_fn", void 0);
+	    _defineProperty(this, "_cached", void 0);
+	    _defineProperty(this, "_value", void 0);
+	    this._fn = fn;
+	    this._cached = false;
+	    this._value = undefined;
+	  }
+	  get value() {
+	    if (!this._cached) {
+	      this._value = this._fn();
+	      this._cached = true;
+	    }
+	    return this._value;
+	  }
+	}
+	const lazy = function (fn) {
+	  return new Lazy(fn);
+	};
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const isLazy = function (x) {
+	  return x instanceof Lazy;
+	};
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
+	const lazyArray = function (lazies) {
+	  return new Proxy(lazies, {
+	    get: function (target, prop) {
+	      if (typeof prop === 'string' && Number.isInteger(Number(prop)) &&
+	      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	      // @ts-ignore
+	      isLazy(target[prop])) {
+	        // key is an index
+	        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	        // @ts-ignore
+	        return target[prop].value;
+	      } else {
+	        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	        // @ts-ignore
+	        return target[prop];
+	      }
+	    }
+	  });
+	};
+
+	const playListControlDef = {
+	  LoadSelectedIntoFirstStopped: {
+	    group: '[Playlist]',
+	    name: 'LoadSelectedIntoFirstStopped',
+	    type: 'binary'
+	  },
+	  SelectNextPlaylist: {
+	    group: '[Playlist]',
+	    name: 'SelectNextPlaylist',
+	    type: 'binary'
+	  },
+	  SelectPrevPlaylist: {
+	    group: '[Playlist]',
+	    name: 'SelectPrevPlaylist',
+	    type: 'binary'
+	  },
+	  ToggleSelectedSidebarItem: {
+	    group: '[Playlist]',
+	    name: 'ToggleSelectedSidebarItem',
+	    type: 'binary'
+	  },
+	  SelectNextTrack: {
+	    group: '[Playlist]',
+	    name: 'SelectNextTrack',
+	    type: 'binary'
+	  },
+	  SelectPrevTrack: {
+	    group: '[Playlist]',
+	    name: 'SelectPrevTrack',
+	    type: 'binary'
+	  },
+	  SelectTrackKnob: {
+	    group: '[Playlist]',
+	    name: 'SelectTrackKnob',
+	    type: 'relative value'
+	  },
+	  AutoDjAddBottom: {
+	    group: '[Playlist]',
+	    name: 'AutoDjAddBottom',
+	    type: 'binary'
+	  },
+	  AutoDjAddTop: {
+	    group: '[Playlist]',
+	    name: 'AutoDjAddTop',
+	    type: 'binary'
+	  }
+	};
+	const masterControlDef = {
+	  maximize_library: {
+	    group: '[Master]',
+	    name: 'maximize_library',
+	    type: 'binary'
+	  },
+	  num_samplers: {
+	    group: '[Master]',
+	    name: 'num_samplers',
+	    type: 'number'
+	  }
+	};
+	const createSamplerControlDef = function (i) {
+	  const [type, number] = getChannelNameForOrdinal(i);
+	  return {
+	    LoadSelectedTrack: {
+	      group: `[${type}${number}]`,
+	      name: 'LoadSelectedTrack',
+	      type: 'binary'
+	    },
+	    cue_gotoandplay: {
+	      group: `[${type}${number}]`,
+	      name: 'cue_gotoandplay',
+	      type: 'binary'
+	    },
+	    eject: {
+	      group: `[${type}${number}]`,
+	      name: 'eject',
+	      type: 'binary'
+	    },
+	    play: {
+	      group: `[${type}${number}]`,
+	      name: 'play',
+	      type: 'binary'
+	    },
+	    play_latched: {
+	      group: `[${type}${number}]`,
+	      name: 'play_latched',
+	      type: 'binary'
+	    },
+	    stop: {
+	      group: `[${type}${number}]`,
+	      name: 'stop',
+	      type: 'binary'
+	    },
+	    track_color: {
+	      group: `[${type}${number}]`,
+	      name: 'track_color',
+	      type: 'number'
+	    },
+	    track_loaded: {
+	      group: `[${type}${number}]`,
+	      name: 'track_loaded',
+	      type: 'binary'
+	    }
+	  };
+	};
+	const numDecks = 4;
+	const numSamplers = 64;
+	const getChannelNameForOrdinal = function (i) {
+	  return i < numDecks ? ['Channel', i + 1] : ['Sampler', i - 4 + 1];
+	};
+	array(map(createSamplerControlDef, range(numDecks + numSamplers)));
+
+	// the full control palette for decks, minus repeated controls (e.g hotcues)
+
+	const createSimpleChannelControlDef = function (type, i) {
+	  return {
+	    back: {
+	      group: `[${type}${i}]`,
+	      name: 'back',
+	      type: 'binary'
+	    },
+	    beat_active: {
+	      group: `[${type}${i}]`,
+	      name: 'beat_active',
+	      type: 'binary'
+	    },
+	    beatjump: {
+	      group: `[${type}${i}]`,
+	      name: 'beatjump',
+	      type: 'real number'
+	    },
+	    beatloop: {
+	      group: `[${type}${i}]`,
+	      name: 'beatloop',
+	      type: 'positive real number'
+	    },
+	    beats_adjust_faster: {
+	      group: `[${type}${i}]`,
+	      name: 'beats_adjust_faster',
+	      type: 'binary'
+	    },
+	    beats_adjust_slower: {
+	      group: `[${type}${i}]`,
+	      name: 'beats_adjust_slower',
+	      type: 'binary'
+	    },
+	    beats_translate_curpos: {
+	      group: `[${type}${i}]`,
+	      name: 'beats_translate_curpos',
+	      type: 'binary'
+	    },
+	    beats_translate_match_alignment: {
+	      group: `[${type}${i}]`,
+	      name: 'beats_translate_match_alignment',
+	      type: 'binary'
+	    },
+	    beats_translate_earlier: {
+	      group: `[${type}${i}]`,
+	      name: 'beats_translate_earlier',
+	      type: 'binary'
+	    },
+	    beats_translate_later: {
+	      group: `[${type}${i}]`,
+	      name: 'beats_translate_later',
+	      type: 'binary'
+	    },
+	    beatsync: {
+	      group: `[${type}${i}]`,
+	      name: 'beatsync',
+	      type: 'binary'
+	    },
+	    beatsync_phase: {
+	      group: `[${type}${i}]`,
+	      name: 'beatsync_phase',
+	      type: 'binary'
+	    },
+	    beatsync_tempo: {
+	      group: `[${type}${i}]`,
+	      name: 'beatsync_tempo',
+	      type: 'binary'
+	    },
+	    bpm: {
+	      group: `[${type}${i}]`,
+	      name: 'bpm',
+	      type: 'real-valued'
+	    },
+	    bpm_tap: {
+	      group: `[${type}${i}]`,
+	      name: 'bpm_tap',
+	      type: 'binary'
+	    },
+	    cue_default: {
+	      group: `[${type}${i}]`,
+	      name: 'cue_default',
+	      type: 'binary'
+	    },
+	    cue_gotoandplay: {
+	      group: `[${type}${i}]`,
+	      name: 'cue_gotoandplay',
+	      type: 'binary'
+	    },
+	    cue_gotoandstop: {
+	      group: `[${type}${i}]`,
+	      name: 'cue_gotoandstop',
+	      type: 'binary'
+	    },
+	    cue_indicator: {
+	      group: `[${type}${i}]`,
+	      name: 'cue_indicator',
+	      type: 'binary'
+	    },
+	    cue_cdj: {
+	      group: `[${type}${i}]`,
+	      name: 'cue_cdj',
+	      type: 'binary'
+	    },
+	    cue_play: {
+	      group: `[${type}${i}]`,
+	      name: 'cue_play',
+	      type: 'binary'
+	    },
+	    cue_point: {
+	      group: `[${type}${i}]`,
+	      name: 'cue_point',
+	      type: 'absolute value'
+	    },
+	    cue_preview: {
+	      group: `[${type}${i}]`,
+	      name: 'cue_preview',
+	      type: 'binary'
+	    },
+	    cue_set: {
+	      group: `[${type}${i}]`,
+	      name: 'cue_set',
+	      type: 'binary'
+	    },
+	    cue_simple: {
+	      group: `[${type}${i}]`,
+	      name: 'cue_simple',
+	      type: 'binary'
+	    },
+	    duration: {
+	      group: `[${type}${i}]`,
+	      name: 'duration',
+	      type: 'absolute value'
+	    },
+	    eject: {
+	      group: `[${type}${i}]`,
+	      name: 'eject',
+	      type: 'binary'
+	    },
+	    end: {
+	      group: `[${type}${i}]`,
+	      name: 'end',
+	      type: 'binary'
+	    },
+	    file_bpm: {
+	      group: `[${type}${i}]`,
+	      name: 'file_bpm',
+	      type: 'positive value'
+	    },
+	    file_key: {
+	      group: `[${type}${i}]`,
+	      name: 'file_key',
+	      type: '?'
+	    },
+	    fwd: {
+	      group: `[${type}${i}]`,
+	      name: 'fwd',
+	      type: 'binary'
+	    },
+	    key: {
+	      group: `[${type}${i}]`,
+	      name: 'key',
+	      type: 'real-valued'
+	    },
+	    keylock: {
+	      group: `[${type}${i}]`,
+	      name: 'keylock',
+	      type: 'binary'
+	    },
+	    LoadSelectedTrack: {
+	      group: `[${type}${i}]`,
+	      name: 'LoadSelectedTrack',
+	      type: 'binary'
+	    },
+	    LoadSelectedTrackAndPlay: {
+	      group: `[${type}${i}]`,
+	      name: 'LoadSelectedTrackAndPlay',
+	      type: 'binary'
+	    },
+	    loop_double: {
+	      group: `[${type}${i}]`,
+	      name: 'loop_double',
+	      type: 'binary'
+	    },
+	    loop_enabled: {
+	      group: `[${type}${i}]`,
+	      name: 'loop_enabled',
+	      type: 'read-only, binary'
+	    },
+	    loop_end_position: {
+	      group: `[${type}${i}]`,
+	      name: 'loop_end_position',
+	      type: 'positive integer'
+	    },
+	    loop_halve: {
+	      group: `[${type}${i}]`,
+	      name: 'loop_halve',
+	      type: 'binary'
+	    },
+	    loop_in: {
+	      group: `[${type}${i}]`,
+	      name: 'loop_in',
+	      type: 'binary'
+	    },
+	    loop_out: {
+	      group: `[${type}${i}]`,
+	      name: 'loop_out',
+	      type: 'binary'
+	    },
+	    loop_move: {
+	      group: `[${type}${i}]`,
+	      name: 'loop_move',
+	      type: 'real number'
+	    },
+	    loop_scale: {
+	      group: `[${type}${i}]`,
+	      name: 'loop_scale',
+	      type: '0.0 - infinity'
+	    },
+	    loop_start_position: {
+	      group: `[${type}${i}]`,
+	      name: 'loop_start_position',
+	      type: 'positive integer'
+	    },
+	    orientation: {
+	      group: `[${type}${i}]`,
+	      name: 'orientation',
+	      type: '0-2'
+	    },
+	    passthrough: {
+	      group: `[${type}${i}]`,
+	      name: 'passthrough',
+	      type: 'binary'
+	    },
+	    PeakIndicator: {
+	      group: `[${type}${i}]`,
+	      name: 'PeakIndicator',
+	      type: 'binary'
+	    },
+	    pfl: {
+	      group: `[${type}${i}]`,
+	      name: 'pfl',
+	      type: 'binary'
+	    },
+	    pitch: {
+	      group: `[${type}${i}]`,
+	      name: 'pitch',
+	      type: '-6.0..6.0'
+	    },
+	    pitch_adjust: {
+	      group: `[${type}${i}]`,
+	      name: 'pitch_adjust',
+	      type: '-3.0..3.0'
+	    },
+	    play: {
+	      group: `[${type}${i}]`,
+	      name: 'play',
+	      type: 'binary'
+	    },
+	    play_latched: {
+	      group: `[${type}${i}]`,
+	      name: 'play_latched',
+	      type: 'binary'
+	    },
+	    play_indicator: {
+	      group: `[${type}${i}]`,
+	      name: 'play_indicator',
+	      type: 'binary'
+	    },
+	    play_stutter: {
+	      group: `[${type}${i}]`,
+	      name: 'play_stutter',
+	      type: 'binary'
+	    },
+	    playposition: {
+	      group: `[${type}${i}]`,
+	      name: 'playposition',
+	      type: 'default'
+	    },
+	    pregain: {
+	      group: `[${type}${i}]`,
+	      name: 'pregain',
+	      type: '0.0..1.0..4.0'
+	    },
+	    quantize: {
+	      group: `[${type}${i}]`,
+	      name: 'quantize',
+	      type: 'binary'
+	    },
+	    rate: {
+	      group: `[${type}${i}]`,
+	      name: 'rate',
+	      type: '-1.0..1.0'
+	    },
+	    rate_dir: {
+	      group: `[${type}${i}]`,
+	      name: 'rate_dir',
+	      type: '-1 or 1'
+	    },
+	    rate_perm_down: {
+	      group: `[${type}${i}]`,
+	      name: 'rate_perm_down',
+	      type: 'binary'
+	    },
+	    rate_perm_down_small: {
+	      group: `[${type}${i}]`,
+	      name: 'rate_perm_down_small',
+	      type: 'binary'
+	    },
+	    rate_perm_up: {
+	      group: `[${type}${i}]`,
+	      name: 'rate_perm_up',
+	      type: 'binary'
+	    },
+	    rate_perm_up_small: {
+	      group: `[${type}${i}]`,
+	      name: 'rate_perm_up_small',
+	      type: 'binary'
+	    },
+	    rate_temp_down: {
+	      group: `[${type}${i}]`,
+	      name: 'rate_temp_down',
+	      type: 'binary'
+	    },
+	    rate_temp_down_small: {
+	      group: `[${type}${i}]`,
+	      name: 'rate_temp_down_small',
+	      type: 'binary'
+	    },
+	    rate_temp_up: {
+	      group: `[${type}${i}]`,
+	      name: 'rate_temp_up',
+	      type: 'binary'
+	    },
+	    rate_temp_up_small: {
+	      group: `[${type}${i}]`,
+	      name: 'rate_temp_up_small',
+	      type: 'binary'
+	    },
+	    rateRange: {
+	      group: `[${type}${i}]`,
+	      name: 'rateRange',
+	      type: '0.0..3.0'
+	    },
+	    reloop_andstop: {
+	      group: `[${type}${i}]`,
+	      name: 'reloop_andstop',
+	      type: 'binary'
+	    },
+	    reloop_exit: {
+	      group: `[${type}${i}]`,
+	      name: 'reloop_exit',
+	      type: 'binary'
+	    },
+	    repeat: {
+	      group: `[${type}${i}]`,
+	      name: 'repeat',
+	      type: 'binary'
+	    },
+	    reset_key: {
+	      group: `[${type}${i}]`,
+	      name: 'reset_key',
+	      type: 'binary'
+	    },
+	    reverse: {
+	      group: `[${type}${i}]`,
+	      name: 'reverse',
+	      type: 'binary'
+	    },
+	    reverseroll: {
+	      group: `[${type}${i}]`,
+	      name: 'reverseroll',
+	      type: 'binary'
+	    },
+	    slip_enabled: {
+	      group: `[${type}${i}]`,
+	      name: 'slip_enabled',
+	      type: 'binary'
+	    },
+	    start: {
+	      group: `[${type}${i}]`,
+	      name: 'start',
+	      type: 'binary'
+	    },
+	    start_play: {
+	      group: `[${type}${i}]`,
+	      name: 'start_play',
+	      type: 'binary'
+	    },
+	    start_stop: {
+	      group: `[${type}${i}]`,
+	      name: 'start_stop',
+	      type: 'binary'
+	    },
+	    stop: {
+	      group: `[${type}${i}]`,
+	      name: 'stop',
+	      type: 'binary'
+	    },
+	    sync_enabled: {
+	      group: `[${type}${i}]`,
+	      name: 'sync_enabled',
+	      type: 'binary'
+	    },
+	    sync_master: {
+	      group: `[${type}${i}]`,
+	      name: 'sync_master',
+	      type: 'binary'
+	    },
+	    sync_mode: {
+	      group: `[${type}${i}]`,
+	      name: 'sync_mode',
+	      type: 'binary'
+	    },
+	    sync_key: {
+	      group: `[${type}${i}]`,
+	      name: 'sync_key',
+	      type: '?'
+	    },
+	    track_color: {
+	      group: `[${type}${i}]`,
+	      name: 'track_color',
+	      type: 'number'
+	    },
+	    track_loaded: {
+	      group: `[${type}${i}]`,
+	      name: 'track_loaded',
+	      type: 'binary'
+	    },
+	    track_samplerate: {
+	      group: `[${type}${i}]`,
+	      name: 'track_samplerate',
+	      type: 'absolute value'
+	    },
+	    track_samples: {
+	      group: `[${type}${i}]`,
+	      name: 'track_samples',
+	      type: 'absolute value'
+	    },
+	    volume: {
+	      group: `[${type}${i}]`,
+	      name: 'volume',
+	      type: 'default'
+	    },
+	    mute: {
+	      group: `[${type}${i}]`,
+	      name: 'mute',
+	      type: 'binary'
+	    },
+	    vinylcontrol_enabled: {
+	      group: `[${type}${i}]`,
+	      name: 'vinylcontrol_enabled',
+	      type: 'binary'
+	    },
+	    vinylcontrol_cueing: {
+	      group: `[${type}${i}]`,
+	      name: 'vinylcontrol_cueing',
+	      type: '0.0-2.0'
+	    },
+	    vinylcontrol_mode: {
+	      group: `[${type}${i}]`,
+	      name: 'vinylcontrol_mode',
+	      type: '0.0-2.0'
+	    },
+	    vinylcontrol_status: {
+	      group: `[${type}${i}]`,
+	      name: 'vinylcontrol_status',
+	      type: '0.0-3.0 (read-only)'
+	    },
+	    visual_bpm: {
+	      group: `[${type}${i}]`,
+	      name: 'visual_bpm',
+	      type: '?'
+	    },
+	    visual_key: {
+	      group: `[${type}${i}]`,
+	      name: 'visual_key',
+	      type: '?'
+	    },
+	    visual_key_distance: {
+	      group: `[${type}${i}]`,
+	      name: 'visual_key_distance',
+	      type: '-0.5..0.5'
+	    },
+	    VuMeter: {
+	      group: `[${type}${i}]`,
+	      name: 'VuMeter',
+	      type: 'default'
+	    },
+	    VuMeterL: {
+	      group: `[${type}${i}]`,
+	      name: 'VuMeterL',
+	      type: 'default'
+	    },
+	    VuMeterR: {
+	      group: `[${type}${i}]`,
+	      name: 'VuMeterR',
+	      type: 'default'
+	    },
+	    waveform_zoom: {
+	      group: `[${type}${i}]`,
+	      name: 'waveform_zoom',
+	      type: '1.0 - 6.0'
+	    },
+	    waveform_zoom_up: {
+	      group: `[${type}${i}]`,
+	      name: 'waveform_zoom_up',
+	      type: '?'
+	    },
+	    waveform_zoom_down: {
+	      group: `[${type}${i}]`,
+	      name: 'waveform_zoom_down',
+	      type: '?'
+	    },
+	    waveform_zoom_set_default: {
+	      group: `[${type}${i}]`,
+	      name: 'waveform_zoom_set_default',
+	      type: '?'
+	    },
+	    wheel: {
+	      group: `[${type}${i}]`,
+	      name: 'wheel',
+	      type: '-3.0..3.0'
+	    }
+	  };
+	};
+	const createArrayChannelControlDefCreators = function (type, i) {
+	  return {
+	    hotcues: function (x) {
+	      return {
+	        activate: {
+	          group: `[${type}${i}]`,
+	          name: `hotcue_${x}_activate`,
+	          type: 'binary'
+	        },
+	        clear: {
+	          group: `[${type}${i}]`,
+	          name: `hotcue_${x}_clear`,
+	          type: 'binary'
+	        },
+	        color: {
+	          group: `[${type}${i}]`,
+	          name: `hotcue_${x}_color`,
+	          type: 'binary'
+	        },
+	        enabled: {
+	          group: `[${type}${i}]`,
+	          name: `hotcue_${x}_enabled`,
+	          type: 'read-only, binary'
+	        },
+	        goto: {
+	          group: `[${type}${i}]`,
+	          name: `hotcue_${x}_goto`,
+	          type: 'binary'
+	        },
+	        gotoandplay: {
+	          group: `[${type}${i}]`,
+	          name: `hotcue_${x}_gotoandplay`,
+	          type: 'binary'
+	        },
+	        gotoandstop: {
+	          group: `[${type}${i}]`,
+	          name: `hotcue_${x}_gotoandstop`,
+	          type: 'binary'
+	        },
+	        position: {
+	          group: `[${type}${i}]`,
+	          name: `hotcue_${x}_position`,
+	          type: 'positive integer'
+	        },
+	        set: {
+	          group: `[${type}${i}]`,
+	          name: `hotcue_${x}_set`,
+	          type: 'binary'
+	        }
+	      };
+	    },
+	    beatjumps: function (x) {
+	      return {
+	        forward: {
+	          group: `[${type}${i}]`,
+	          name: `beatjump_${x}_forward`,
+	          type: 'binary'
+	        },
+	        backward: {
+	          group: `[${type}${i}]`,
+	          name: `beatjump_${x}_backward`,
+	          type: 'binary'
+	        }
+	      };
+	    },
+	    beatloops: function (x) {
+	      return {
+	        activate: {
+	          group: `[${type}${i}]`,
+	          name: `beatloop_${x}_activate`,
+	          type: 'binary'
+	        },
+	        toggle: {
+	          group: `[${type}${i}]`,
+	          name: `beatloop_${x}_toggle`,
+	          type: 'binary'
+	        },
+	        enabled: {
+	          group: `[${type}${i}]`,
+	          name: `beatloop_${x}_enabled`,
+	          type: 'binary'
+	        }
+	      };
+	    }
+	  };
+	};
+	const beatjumps = [0.03125, 0.0625, 0.125, 0.25, 0.5, 1, 2, 4, 8, 16, 32, 64];
+	const beatloops = [0.03125, 0.0625, 0.125, 0.25, 0.5, 1, 2, 4, 8, 16, 32, 64];
+	const createArrayChannelControlDef = function (array, createOneDef) {
+	  return array.reduce(function (arr, i) {
+	    return Object.assign(arr, {
+	      [i]: createOneDef(i)
+	    });
+	  }, {});
+	};
+	const createChannelControlDef = function (i) {
+	  const [name, number] = getChannelNameForOrdinal(i);
+	  const simpleChannelControlDef = createSimpleChannelControlDef(name, number);
+	  const arrayChannelControlDefCreators = createArrayChannelControlDefCreators(name, number);
+	  return Object.assign(simpleChannelControlDef, {
+	    beatjumps: createArrayChannelControlDef(beatjumps, arrayChannelControlDefCreators.beatjumps),
+	    beatloops: createArrayChannelControlDef(beatloops, arrayChannelControlDefCreators.beatloops),
+	    hotcues: createArrayChannelControlDef(array(map(function (x) {
+	      return x + 1;
+	    }, range(16))), arrayChannelControlDefCreators.hotcues)
+	  });
+	};
+	array(map(function (i) {
+	  return createChannelControlDef(i);
+	}, range(8)));
+
+	// effect parameters
+	const numEffectParameters = 8;
+	const createEffectParameterDef = function (rack, unit, effect, parameter) {
+	  return {
+	    value: {
+	      group: `[${rack}_${unit}_${effect}]`,
+	      name: `parameter${parameter}`,
+	      type: 'number'
+	    },
+	    link_inverse: {
+	      group: `[${rack}_${unit}_${effect}]`,
+	      name: `parameter${parameter}_link_inverse`,
+	      type: 'binary'
+	    },
+	    link_type: {
+	      group: `[${rack}_${unit}_${effect}]`,
+	      name: `parameter${parameter}_link_type`,
+	      type: 'number'
+	    },
+	    loaded: {
+	      group: `[${rack}_${unit}_${effect}]`,
+	      name: `parameter${parameter}_loaded`,
+	      type: 'binary'
+	    },
+	    type: {
+	      group: `[${rack}_${unit}_${effect}]`,
+	      name: `parameter${parameter}_type`,
+	      type: 'number'
+	    },
+	    button_value: {
+	      group: `[${rack}_${unit}_${effect}]`,
+	      name: `button_parameter${parameter}`,
+	      type: 'number'
+	    },
+	    button_loaded: {
+	      group: `[${rack}_${unit}_${effect}]`,
+	      name: `button_parameter${parameter}_loaded`,
+	      type: 'binary'
+	    },
+	    button_type: {
+	      group: `[${rack}_${unit}_${effect}]`,
+	      name: `button_parameter${parameter}_type`,
+	      type: 'number'
+	    }
+	  };
+	};
+	const numEffects = 3;
+	const createEffectDef = function (rack, unit, effect) {
+	  return {
+	    clear: {
+	      group: `[${rack}_${unit}_${effect}]`,
+	      name: `clear`,
+	      type: 'binary'
+	    },
+	    effect_selector: {
+	      group: `[${rack}_${unit}_${effect}]`,
+	      name: `effect_selector`,
+	      type: 'number'
+	    },
+	    enabled: {
+	      group: `[${rack}_${unit}_${effect}]`,
+	      name: `enabled`,
+	      type: 'binary'
+	    },
+	    loaded: {
+	      group: `[${rack}_${unit}_${effect}]`,
+	      name: `loaded`,
+	      type: 'binary'
+	    },
+	    next_effect: {
+	      group: `[${rack}_${unit}_${effect}]`,
+	      name: `next_effect`,
+	      type: 'binary'
+	    },
+	    num_parameters: {
+	      group: `[${rack}_${unit}_${effect}]`,
+	      name: `num_parameters`,
+	      type: 'number'
+	    },
+	    num_parameterslots: {
+	      group: `[${rack}_${unit}_${effect}]`,
+	      name: `num_parameterslots`,
+	      type: 'number'
+	    },
+	    num_button_parameters: {
+	      group: `[${rack}_${unit}_${effect}]`,
+	      name: `num_button_parameters`,
+	      type: 'number'
+	    },
+	    num_button_parameterslots: {
+	      group: `[${rack}_${unit}_${effect}]`,
+	      name: `num_button_parameterslots`,
+	      type: 'number'
+	    },
+	    meta: {
+	      group: `[${rack}_${unit}_${effect}]`,
+	      name: `meta`,
+	      type: 'number'
+	    },
+	    prev_effect: {
+	      group: `[${rack}_${unit}_${effect}]`,
+	      name: `prev_effect`,
+	      type: 'binary'
+	    },
+	    parameters: lazyArray(array(map(function (i) {
+	      return lazy(function () {
+	        return createEffectParameterDef(rack, unit, effect, i + 1);
+	      });
+	    }, range(numEffectParameters))))
+	  };
+	};
+
+	// effect units
+	const numEffectUnits = 4;
+	const createEffectUnitDef = function (rack, unit) {
+	  return {
+	    chain_selector: {
+	      group: `[${rack}_${unit}]`,
+	      name: `chain_selector`,
+	      type: 'number'
+	    },
+	    clear: {
+	      group: `[${rack}_${unit}]`,
+	      name: `clear`,
+	      type: 'binary'
+	    },
+	    enabled: {
+	      group: `[${rack}_${unit}]`,
+	      name: `enabled`,
+	      type: 'binary'
+	    },
+	    focused_effect: {
+	      group: `[${rack}_${unit}]`,
+	      name: `focused_effect`,
+	      type: 'number'
+	    },
+	    mix: {
+	      group: `[${rack}_${unit}]`,
+	      name: `mix`,
+	      type: 'number'
+	    },
+	    super1: {
+	      group: `[${rack}_${unit}]`,
+	      name: `super1`,
+	      type: 'number'
+	    },
+	    num_effects: {
+	      group: `[${rack}_${unit}]`,
+	      name: `num_effects`,
+	      type: 'number'
+	    },
+	    num_effectslots: {
+	      group: `[${rack}_${unit}]`,
+	      name: `num_effectslots`,
+	      type: 'number'
+	    },
+	    effects: lazyArray(array(map(function (i) {
+	      return lazy(function () {
+	        return createEffectDef(rack, unit, `Effect${i + 1}`);
+	      });
+	    }, range(numEffects))))
+	  };
+	};
+
+	// effect racks
+
+	const createEffectRackDef = function (rack) {
+	  const units = rack.startsWith('EqualizerRack') || rack.startsWith('QuickEffectRack') ? map(function (i) {
+	    return `[Channel${i + 1}]`;
+	  }, range(numDecks)) : map(function (i) {
+	    return `EffectUnit${i + 1}`;
+	  }, range(numEffectUnits));
+	  return {
+	    num_effectunits: {
+	      group: `[${rack}]`,
+	      name: `num_effectunits`,
+	      type: 'number'
+	    },
+	    clear: {
+	      group: `[${rack}]`,
+	      name: `clear`,
+	      type: 'binary'
+	    },
+	    effect_units: lazyArray(array(map(function (unit) {
+	      return lazy(function () {
+	        return createEffectUnitDef(rack, unit);
+	      });
+	    }, units)))
+	  };
+	};
+	const numEqualizerRacks = 1;
+	const root = {
+	  master: masterControlDef,
+	  playList: playListControlDef,
+	  samplers: lazyArray(array(map(function (i) {
+	    return lazy(function () {
+	      return createSamplerControlDef(i);
+	    });
+	  }, range(numDecks + numSamplers)))),
+	  channels: lazyArray(array(map(function (i) {
+	    return lazy(function () {
+	      return createChannelControlDef(i);
+	    });
+	  }, range(numDecks + numSamplers)))),
+	  effectRacks: array(map(function (i) {
+	    return createEffectRackDef(`EffectRack${i + 1}`);
+	  }, range(numEqualizerRacks))),
+	  quickEffectRacks: array(map(function (i) {
+	    return createEffectRackDef(`QuickEffectRack${i + 1}`);
+	  }, range(numEqualizerRacks))),
+	  equalizerRacks: array(map(function (i) {
+	    return createEffectRackDef(`EqualizerRack${i + 1}`);
+	  }, range(numEqualizerRacks)))
+	};
+	const getValue = function (control) {
+	  return engine.getValue(control.group, control.name);
+	};
+	const setValue = function (control, value) {
+	  return engine.setValue(control.group, control.name, value);
+	};
+	const softTakeover = function (control, enable) {
+	  return engine.softTakeover(control.group, control.name, enable);
+	};
+	const softTakeOverIgnoreNextValue = function (control) {
+	  return engine.softTakeoverIgnoreNextValue(control.group, control.name);
+	};
+	const connect = function (control, cb) {
+	  const {
+	    group,
+	    name
+	  } = control;
+	  return engine.makeConnection(group, name, function (value) {
+	    cb({
+	      value,
+	      control
+	    });
+	  });
+	};
+	const disconnect = function (handle) {
+	  if (handle.isConnected) {
+	    handle.disconnect();
+	  }
+	};
+	class ControlComponent extends Component {
+	  constructor(control, softTakeover) {
+	    super();
+	    _defineProperty(this, "control", void 0);
+	    _defineProperty(this, "_handle", void 0);
+	    _defineProperty(this, "_softTakeover", void 0);
+	    this.control = control;
+	    this._handle = null;
+	    this._softTakeover = softTakeover;
+	  }
+	  onMount() {
+	    var _this = this;
+	    if (!this._handle) {
+	      this._handle = connect(this.control, function (data) {
+	        _this.emit('update', data);
+	      });
+	      if (this._softTakeover != null) {
+	        softTakeover(this.control, this._softTakeover);
+	      }
+	      const initialMessage = {
+	        control: this.control,
+	        value: getValue(this.control)
+	      };
+	      this.emit('update', initialMessage);
+	    }
+	  }
+	  onUnmount() {
+	    if (this._handle) {
+	      if (this._softTakeover != null) {
+	        softTakeOverIgnoreNextValue(this.control);
+	      }
+	      disconnect(this._handle);
+	      this._handle = null;
+	    }
+	  }
+	}
+
+	const midiCallbackPrefix = '__midi';
+	// mixxx currently doesn't support custom names for sysex callback handlers, see https://github.com/mixxxdj/mixxx/issues/11536
+	const sysexCallbackPrefix = 'incomingData';
+	class MidiDevice extends Component {
+	  constructor(...args) {
+	    super(...args);
+	    _defineProperty(this, "controls", void 0);
+	    // whether to listen for sysex messages
+	    _defineProperty(this, "sysex", false);
+	  }
+	  init() {
+	    this.mount();
+	  }
+	  shutdown() {
+	    this.unmount();
+	  }
+	  onMount() {
+	    var _this2 = this;
+	    super.onMount();
+	    const _this = this;
+	    Object.values(this.controls).forEach(function (control) {
+	      _this[`${midiCallbackPrefix}_${hexFormat(control.status, 2)}_${hexFormat(control.midino, 2)}`] = function (_channel, _control, value, _status) {
+	        const message = {
+	          value,
+	          control
+	        };
+	        _this2.emit(control.name, message);
+	      };
+	    });
+	    if (this.sysex) {
+	      _this[sysexCallbackPrefix] = function (data) {
+	        _this2.emit('sysex', data);
+	      };
+	    }
+	  }
+	  onUnmount() {
+	    super.onUnmount();
+	  }
+	}
+	let MidiComponent$1 = class MidiComponent extends Component {
+	  constructor(device, control) {
+	    var _this3;
+	    super();
+	    _this3 = this;
+	    _defineProperty(this, "control", void 0);
+	    _defineProperty(this, "_cb", void 0);
+	    _defineProperty(this, "_device", void 0);
+	    this.control = control;
+	    this._device = device;
+	    this._cb = function (data) {
+	      _this3.emit('midi', data);
+	    };
+	  }
+	  onMount() {
+	    super.onMount();
+	    this._device.on(this.control.name, this._cb);
+	  }
+	  onUnmount() {
+	    this._device.removeListener(this.control.name, this._cb);
+	    super.onUnmount();
+	  }
+	};
+	const sendShortMsg = function (control, value) {
+	  midi.sendShortMsg(control.status, control.midino, value);
+	};
+	const sendSysexMsg = midi.sendSysexMsg;
+
+	class Timer extends Component {
+	  constructor(task) {
+	    super();
+	    _defineProperty(this, "task", void 0);
+	    _defineProperty(this, "_state", void 0);
+	    this.task = task;
+	    this._state = null;
+	  }
+	  start(interval) {
+	    if (this._state == null) {
+	      const started = Date.now();
+	      const handle = engine.beginTimer(interval, this.task);
+	      this._state = {
+	        handle,
+	        started
+	      };
+	      return started;
+	    }
+	    return this._state.started;
+	  }
+	  end() {
+	    const state = this._state;
+	    if (state != null) {
+	      engine.stopTimer(state.handle);
+	      this._state = null;
+	    }
+	  }
+	  onUnmount() {
+	    this.end();
+	    super.onUnmount();
+	  }
+	  restart(interval) {
+	    if (this._state != null) {
+	      this.end();
+	    }
+	    return this.start(interval);
+	  }
+	}
+
+	const parseRGBColor = function (number) {
+	  if (number === -1) {
+	    return null;
+	  }
+	  const blue = number % 256;
+	  const green = (number >> 8) % 256;
+	  const red = (number >> 16) % 256;
+	  return [red, green, blue];
+	};
+	class LaunchpadDevice extends MidiDevice {
+	  sendColor(control, value) {
+	    sendShortMsg(control, value);
+	  }
+	  clearColor(control) {
+	    sendShortMsg(control, this.colors.black);
+	  }
+	  constructor() {
+	    super();
+	    _defineProperty(this, "colors", void 0);
+	    _defineProperty(this, "supportsRGBColors", void 0);
+	  }
+	  onMount() {
+	    super.onMount();
+	  }
+	  onUnmount() {
+	    super.onUnmount();
+	  }
+	}
+	class MidiComponent extends MidiComponent$1 {}
+
+	class ModifierSidebar extends Component {
+	  constructor(device) {
+	    var _this;
+	    super();
+	    _this = this;
+	    _defineProperty(this, "shift", void 0);
+	    _defineProperty(this, "ctrl", void 0);
+	    _defineProperty(this, "state", void 0);
+	    _defineProperty(this, "shiftListener", void 0);
+	    _defineProperty(this, "ctrlListener", void 0);
+	    this.shift = new MidiComponent(device, device.controls.solo);
+	    this.ctrl = new MidiComponent(device, device.controls.arm);
+	    this.state = {
+	      shift: false,
+	      ctrl: false
+	    };
+	    const makeListener = function (button) {
+	      return function (message) {
+	        const {
+	          value
+	        } = message;
+	        if (value) {
+	          device.sendColor(button.control, device.colors.hi_red);
+	        } else {
+	          device.clearColor(button.control);
+	        }
+	        if (button.control.name === device.controls.solo.name) {
+	          _this.state.shift = !!value;
+	          _this.emit('shift', value);
+	        } else {
+	          _this.state.ctrl = !!value;
+	          _this.emit('ctrl', value);
+	        }
+	      };
+	    };
+	    this.shiftListener = makeListener(this.shift);
+	    this.ctrlListener = makeListener(this.ctrl);
+	  }
+	  onMount() {
+	    this.shift.mount();
+	    this.ctrl.mount();
+	    this.shift.on('midi', this.shiftListener);
+	    this.ctrl.on('midi', this.ctrlListener);
+	  }
+	  onUnmount() {
+	    this.shift.removeListener('midi', this.shiftListener);
+	    this.ctrl.removeListener('midi', this.ctrlListener);
+	    this.shift.unmount();
+	    this.ctrl.unmount();
+	  }
+	  getState() {
+	    return this.state;
+	  }
+	}
+	const modes = function (ctx, n, c, s, cs) {
+	  if (ctx.shift && ctx.ctrl) {
+	    cs && cs();
+	  } else if (ctx.shift) {
+	    s && s();
+	  } else if (ctx.ctrl) {
+	    c && c();
+	  } else {
+	    n && n();
+	  }
+	};
+	const retainAttackMode = function (modifier, cb) {
+	  let state = {
+	    shift: false,
+	    ctrl: false
+	  };
+	  return function (data) {
+	    if (data.value) {
+	      state = Object.assign(state, modifier.getState());
+	    }
+	    return cb(state, data);
+	  };
+	};
+
+	var flatMapExports = {};
+	var flatMap$3 = {
+	  get exports(){ return flatMapExports; },
+	  set exports(v){ flatMapExports = v; },
+	};
+
+	var isArray = isArray$4;
+	var lengthOfArrayLike$1 = lengthOfArrayLike$7;
+	var doesNotExceedSafeInteger = doesNotExceedSafeInteger$2;
+	var bind = functionBindContext;
+
+	// `FlattenIntoArray` abstract operation
+	// https://tc39.github.io/proposal-flatMap/#sec-FlattenIntoArray
+	var flattenIntoArray$1 = function (target, original, source, sourceLen, start, depth, mapper, thisArg) {
+	  var targetIndex = start;
+	  var sourceIndex = 0;
+	  var mapFn = mapper ? bind(mapper, thisArg) : false;
+	  var element, elementLen;
+
+	  while (sourceIndex < sourceLen) {
+	    if (sourceIndex in source) {
+	      element = mapFn ? mapFn(source[sourceIndex], sourceIndex, original) : source[sourceIndex];
+
+	      if (depth > 0 && isArray(element)) {
+	        elementLen = lengthOfArrayLike$1(element);
+	        targetIndex = flattenIntoArray$1(target, original, element, elementLen, targetIndex, depth - 1) - 1;
+	      } else {
+	        doesNotExceedSafeInteger(targetIndex + 1);
+	        target[targetIndex] = element;
+	      }
+
+	      targetIndex++;
+	    }
+	    sourceIndex++;
+	  }
+	  return targetIndex;
+	};
+
+	var flattenIntoArray_1 = flattenIntoArray$1;
+
+	var $ = _export;
+	var flattenIntoArray = flattenIntoArray_1;
+	var aCallable = aCallable$4;
+	var toObject = toObject$6;
+	var lengthOfArrayLike = lengthOfArrayLike$7;
+	var arraySpeciesCreate = arraySpeciesCreate$3;
+
+	// `Array.prototype.flatMap` method
+	// https://tc39.es/ecma262/#sec-array.prototype.flatmap
+	$({ target: 'Array', proto: true }, {
+	  flatMap: function flatMap(callbackfn /* , thisArg */) {
+	    var O = toObject(this);
+	    var sourceLen = lengthOfArrayLike(O);
+	    var A;
+	    aCallable(callbackfn);
+	    A = arraySpeciesCreate(O, 0);
+	    A.length = flattenIntoArray(A, O, O, sourceLen, 0, 1, callbackfn, arguments.length > 1 ? arguments[1] : undefined);
+	    return A;
+	  }
+	});
+
+	var path = path$7;
+
+	var entryVirtual$1 = function (CONSTRUCTOR) {
+	  return path[CONSTRUCTOR + 'Prototype'];
+	};
+
+	var entryVirtual = entryVirtual$1;
+
+	var flatMap$2 = entryVirtual('Array').flatMap;
+
+	var isPrototypeOf = objectIsPrototypeOf;
+	var method = flatMap$2;
+
+	var ArrayPrototype = Array.prototype;
+
+	var flatMap$1 = function (it) {
+	  var own = it.flatMap;
+	  return it === ArrayPrototype || (isPrototypeOf(ArrayPrototype, it) && own === ArrayPrototype.flatMap) ? method : own;
+	};
+
+	var parent = flatMap$1;
+
+	var flatMap = parent;
+
+	(function (module) {
+		module.exports = flatMap;
+	} (flatMap$3));
+
+	var _flatMapInstanceProperty = /*@__PURE__*/getDefaultExportFromCjs(flatMapExports);
+
+	const colors$2 = ['green', 'red'];
+	const make$k = function ({
+	  jumps,
+	  vertical = false
+	}, gridPosition, deck) {
+	  const bindings = {};
+	  const spec = _flatMapInstanceProperty(jumps).call(jumps, function (j) {
+	    return [[j, -1], [j, 1]];
+	  });
+	  const onMidi = function (k, j, d) {
+	    return function ({
+	      bindings,
+	      state,
+	      context: {
+	        modifier,
+	        device
+	      }
+	    }) {
+	      return retainAttackMode(modifier, function (mode, {
+	        value
+	      }) {
+	        modes(mode, function () {
+	          if (!state.mode) {
+	            if (value) {
+	              setValue(deck.beatjump, j[state.set] * d);
+	            }
+	          } else {
+	            if (value) {
+	              const currentJump = j[state.set] * d;
+	              setValue(deck.beatjump, currentJump);
+	              if (state.pressing != null) {
+	                device.sendColor(bindings[state.pressing].control, device.colors[`lo_${colors$2[state.set]}`]);
+	              }
+	              device.sendColor(bindings[k].control, device.colors[`hi_${colors$2[state.set]}`]);
+	              state.pressing = k;
+	              state.diff = state.diff + currentJump;
+	            } else {
+	              if (state.pressing === k) {
+	                device.sendColor(bindings[k].control, device.colors[`lo_${colors$2[state.set]}`]);
+	                state.pressing = null;
+	                setValue(deck.beatjump, -state.diff);
+	                state.diff = 0;
+	              }
+	            }
+	          }
+	        }, function () {
+	          if (value) {
+	            state.set = posMod(state.set + 1, 2);
+	            const prefix = state.mode ? 'lo' : 'hi';
+	            for (let b = 0; b < spec.length; ++b) {
+	              device.sendColor(bindings[b].control, device.colors[`${prefix}_${colors$2[state.set]}`]);
+	            }
+	          }
+	        }, function () {
+	          if (value) {
+	            state.mode = !state.mode;
+	            const prefix = state.mode ? 'lo' : 'hi';
+	            for (let b = 0; b < spec.length; ++b) {
+	              device.sendColor(bindings[b].control, device.colors[`${prefix}_${colors$2[state.set]}`]);
+	            }
+	          }
+	        });
+	      });
+	    };
+	  };
+	  const onMount = function (k) {
+	    return function ({
+	      bindings,
+	      state,
+	      context: {
+	        device
+	      }
+	    }) {
+	      return function () {
+	        const prefix = state.mode ? 'lo' : 'hi';
+	        device.sendColor(bindings[k].control, device.colors[`${prefix}_${colors$2[state.set]}`]);
+	      };
+	    };
+	  };
+	  spec.forEach(function ([jump, dir], i) {
+	    bindings[i] = {
+	      type: 'button',
+	      target: vertical ? [gridPosition[0] + i % 2, gridPosition[1] + ~~(i / 2)] : [gridPosition[0] + ~~(i / 2), gridPosition[1] + i % 2],
+	      midi: onMidi(i, jump, dir),
+	      mount: onMount(i)
+	    };
+	  });
+	  return {
+	    bindings,
+	    state: {
+	      mode: false,
+	      pressing: null,
+	      diff: 0,
+	      set: 0
+	    }
+	  };
+	};
+	var makeBeatjump = make$k;
+
+	const onAttack = function (handler) {
+	  return function (m) {
+	    if (m.value) handler(m);
+	  };
+	};
+
+	const make$j = function (params, gridPosition, deck) {
+	  const {
+	    loops,
+	    rows
+	  } = params;
+	  const bindings = {};
+	  const onMidi = function (loop) {
+	    return function ({
+	      context
+	    }) {
+	      return onAttack(function () {
+	        const {
+	          modifier
+	        } = context;
+	        modes(modifier.getState(), function () {
+	          return setValue(deck.beatloops[loop].toggle, 1);
+	        });
+	      });
+	    };
+	  };
+	  const onUpdate = function (i) {
+	    return function ({
+	      context,
+	      bindings
+	    }) {
+	      return function ({
+	        value
+	      }) {
+	        const {
+	          device
+	        } = context;
+	        const color = value ? device.colors.hi_red : device.colors.lo_red;
+	        device.sendColor(bindings[`b.${i}`].control, color);
+	      };
+	    };
+	  };
+	  loops.forEach(function (loop, i) {
+	    const dx = i % rows;
+	    const dy = ~~(i / rows);
+	    bindings[`b.${i}`] = {
+	      type: 'button',
+	      target: [gridPosition[0] + dx, gridPosition[1] + dy],
+	      midi: onMidi(loop)
+	    };
+	    bindings[`c.${loop}`] = {
+	      type: 'control',
+	      target: deck.beatloops[loop].enabled,
+	      update: onUpdate(i)
+	    };
+	  });
+	  return {
+	    bindings,
+	    state: {}
+	  };
+	};
+	var makeBeatloop = make$j;
+
+	const make$i = function (_, gridPosition, deck) {
+	  return {
+	    state: {},
+	    bindings: {
+	      cue: {
+	        type: 'button',
+	        target: gridPosition,
+	        midi: function ({
+	          context: {
+	            modifier
+	          }
+	        }) {
+	          return retainAttackMode(modifier, function (mode, {
+	            value
+	          }) {
+	            modes(mode, function () {
+	              setValue(deck.cue_default, value ? 1 : 0);
+	            }, function () {
+	              return value && setValue(deck.cue_set, 1);
+	            });
+	          });
+	        }
+	      },
+	      cueIndicator: {
+	        type: 'control',
+	        target: deck.cue_indicator,
+	        update: function ({
+	          bindings: {
+	            cue: {
+	              control
+	            }
+	          },
+	          context: {
+	            device
+	          }
+	        }) {
+	          return function ({
+	            value
+	          }) {
+	            if (value) {
+	              device.sendColor(control, device.colors.hi_red);
+	            } else if (!value) {
+	              device.clearColor(control);
+	            }
+	          };
+	        }
+	      }
+	    }
+	  };
+	};
+	var makeCue = make$i;
+
+	const make$h = function (_, gridPosition, deck) {
+	  const steps = {
+	    back: {
+	      normal: deck.beats_translate_earlier,
+	      ctrl: deck.beats_adjust_slower
+	    },
+	    forth: {
+	      normal: deck.beats_translate_later,
+	      ctrl: deck.beats_adjust_faster
+	    }
+	  };
+	  const onGrid = function (dir) {
+	    return function ({
+	      context: {
+	        device,
+	        modifier
+	      },
+	      bindings
+	    }) {
+	      return function ({
+	        value
+	      }) {
+	        if (!value) {
+	          device.clearColor(bindings[dir].control);
+	        } else {
+	          modes(modifier.getState(), function () {
+	            device.sendColor(bindings[dir].control, device.colors.hi_yellow);
+	            setValue(steps[dir].normal, 1);
+	          }, function () {
+	            device.sendColor(bindings[dir].control, device.colors.hi_amber);
+	            setValue(steps[dir].ctrl, 1);
+	          });
+	        }
+	      };
+	    };
+	  };
+	  return {
+	    bindings: {
+	      back: {
+	        type: 'button',
+	        target: gridPosition,
+	        midi: onGrid('back')
+	      },
+	      forth: {
+	        type: 'button',
+	        target: [gridPosition[0] + 1, gridPosition[1]],
+	        midi: onGrid('forth')
+	      }
+	    },
+	    state: {}
+	  };
+	};
+	var makeGrid = make$h;
+
+	const make$g = function ({
+	  cues,
+	  rows,
+	  start = 0
+	}, gridPosition, deck, theme) {
+	  const onHotcueMidi = function (i) {
+	    return function ({
+	      context: {
+	        modifier
+	      },
+	      bindings
+	    }) {
+	      return function ({
+	        value
+	      }) {
+	        modes(modifier.getState(), function () {
+	          setValue(deck.hotcues[1 + i + start].activate, value ? 1 : 0);
+	        }, function () {
+	          if (value) {
+	            if (getValue(bindings[`cue.${i}`].control)) {
+	              setValue(deck.hotcues[1 + i + start].clear, 1);
+	            } else {
+	              setValue(deck.hotcues[1 + i + start].set, 1);
+	            }
+	          }
+	        });
+	      };
+	    };
+	  };
+	  const onHotcueColorChanged = function (i) {
+	    return function ({
+	      context: {
+	        device
+	      },
+	      bindings
+	    }) {
+	      return function ({
+	        value
+	      }) {
+	        const color = parseRGBColor(value);
+	        if (device.supportsRGBColors) {
+	          device.sendRGBColor(bindings[`midi.${i}`].control, color == null ? theme.fallbackHotcueColor : color);
+	        }
+	      };
+	    };
+	  };
+	  const onHotcueEnabled = function (i) {
+	    return function ({
+	      context: {
+	        device
+	      },
+	      bindings
+	    }) {
+	      return function ({
+	        value
+	      }) {
+	        if (value) {
+	          if (device.supportsRGBColors) {
+	            const color = parseRGBColor(getValue(deck.hotcues[1 + i + start].color));
+	            device.sendRGBColor(bindings[`midi.${i}`].control, color == null ? theme.fallbackHotcueColor : color);
+	          } else {
+	            device.sendColor(bindings[`midi.${i}`].control, device.colors.lo_yellow);
+	          }
+	        } else {
+	          device.clearColor(bindings[`midi.${i}`].control);
+	        }
+	      };
+	    };
+	  };
+	  const bindings = {};
+	  for (const i of range(cues)) {
+	    const dx = i % rows;
+	    const dy = ~~(i / rows);
+	    bindings[`midi.${i}`] = {
+	      type: 'button',
+	      target: [gridPosition[0] + dx, gridPosition[1] + dy],
+	      midi: onHotcueMidi(i)
+	    };
+	    bindings[`cue.${i}`] = {
+	      type: 'control',
+	      target: deck.hotcues[1 + i + start].enabled,
+	      update: onHotcueEnabled(i)
+	    };
+	    bindings[`color.${i}`] = {
+	      type: 'control',
+	      target: deck.hotcues[1 + i + start].color,
+	      update: onHotcueColorChanged(i)
+	    };
+	  }
+	  return {
+	    bindings,
+	    state: {}
+	  };
+	};
+	var makeHotcue = make$g;
+
+	const make$f = function (_, gridPosition, deck) {
+	  return {
+	    state: {},
+	    bindings: {
+	      button: {
+	        type: 'button',
+	        target: gridPosition,
+	        midi: function ({
+	          context: {
+	            modifier
+	          },
+	          bindings
+	        }) {
+	          return onAttack(function () {
+	            modes(modifier.getState(), function () {
+	              setValue(bindings.keylock.control, Number(!getValue(bindings.keylock.control)));
+	            }, function () {
+	              setValue(deck.key, getValue(deck.key) - 1);
+	            }, function () {
+	              setValue(deck.key, getValue(deck.key) + 1);
+	            }, function () {
+	              setValue(deck.reset_key, 1);
+	            });
+	          });
+	        }
+	      },
+	      keylock: {
+	        type: 'control',
+	        target: deck.keylock,
+	        update: function ({
+	          context: {
+	            device
+	          },
+	          bindings
+	        }) {
+	          return function ({
+	            value
+	          }) {
+	            if (value) {
+	              device.sendColor(bindings.button.control, device.colors.hi_red);
+	            } else {
+	              device.clearColor(bindings.button.control);
+	            }
+	          };
+	        }
+	      }
+	    }
+	  };
+	};
+	var makeKey = make$f;
+
+	const colors$1 = ['green', 'red'];
+	const make$e = function ({
+	  shifts,
+	  rows
+	}, gridPosition, deck) {
+	  const bindings = {};
+	  const temporaryChange = function (i, value, bindings, state, device) {
+	    if (value) {
+	      const base = state.on === -1 ? getValue(deck.key) : state.base;
+	      if (state.on !== -1) {
+	        device.sendColor(bindings[state.on].control, device.colors[`lo_${colors$1[state.set]}`]);
+	      }
+	      device.sendColor(bindings[i].control, device.colors[`hi_${colors$1[state.set]}`]);
+	      setValue(deck.key, (base + shifts[i][state.set]) % 12 + 12);
+	      state.on = i;
+	      state.base = base;
+	    } else {
+	      if (state.on === i) {
+	        device.sendColor(bindings[i].control, device.colors[`lo_${colors$1[state.set]}`]);
+	        setValue(deck.key, state.base);
+	        state.on = -1;
+	      }
+	    }
+	  };
+	  const onMidi = function (i) {
+	    return function ({
+	      context: {
+	        modifier,
+	        device
+	      },
+	      bindings,
+	      state
+	    }) {
+	      return retainAttackMode(modifier, function (mode, {
+	        value
+	      }) {
+	        modes(mode, function () {
+	          return temporaryChange(i, value, bindings, state, device);
+	        }, function () {
+	          if (value) {
+	            state.set = posMod(state.set + 1, 2);
+	            for (let i = 0; i < shifts.length; ++i) {
+	              device.sendColor(bindings[i].control, device.colors[`lo_${colors$1[state.set]}`]);
+	            }
+	          }
+	        });
+	      });
+	    };
+	  };
+	  shifts.forEach(function (_, i) {
+	    const dx = i % rows;
+	    const dy = ~~(i / rows);
+	    const position = [gridPosition[0] + dx, gridPosition[1] + dy];
+	    bindings[i] = {
+	      type: 'button',
+	      target: position,
+	      midi: onMidi(i),
+	      mount: function ({
+	        context: {
+	          device
+	        },
+	        bindings,
+	        state
+	      }) {
+	        return function () {
+	          device.sendColor(bindings[i].control, device.colors[`lo_${colors$1[state.set]}`]);
+	        };
+	      }
+	    };
+	  });
+	  return {
+	    bindings,
+	    state: {
+	      on: -1,
+	      base: -1,
+	      set: 0
+	    }
+	  };
+	};
+	var makeKeyshift = make$e;
+
+	const make$d = function (_, gridPosition, deck) {
+	  const onStateChanged = function (loaded, playing, bindings, device) {
+	    if (loaded && playing) {
+	      device.sendColor(bindings.button.control, device.colors.lo_red);
+	    } else if (loaded) {
+	      device.sendColor(bindings.button.control, device.colors.lo_yellow);
+	    } else {
+	      device.sendColor(bindings.button.control, device.colors.lo_green);
+	    }
+	  };
+	  return {
+	    state: {},
+	    bindings: {
+	      samples: {
+	        type: 'control',
+	        target: deck.track_samples,
+	        update: function ({
+	          bindings,
+	          context: {
+	            device
+	          }
+	        }) {
+	          return function ({
+	            value
+	          }) {
+	            return onStateChanged(value, getValue(bindings.play.control), bindings, device);
+	          };
+	        }
+	      },
+	      play: {
+	        type: 'control',
+	        target: deck.play,
+	        update: function ({
+	          bindings,
+	          context: {
+	            device
+	          }
+	        }) {
+	          return function ({
+	            value
+	          }) {
+	            return onStateChanged(getValue(bindings.samples.control), value, bindings, device);
+	          };
+	        }
+	      },
+	      button: {
+	        type: 'button',
+	        target: gridPosition,
+	        midi: function ({
+	          bindings,
+	          context: {
+	            modifier
+	          }
+	        }) {
+	          return onAttack(function () {
+	            modes(modifier.getState(), function () {
+	              if (!getValue(bindings.samples.control)) {
+	                setValue(deck.LoadSelectedTrack, 1);
+	              }
+	            }, function () {
+	              return setValue(deck.LoadSelectedTrack, 1);
+	            }, function () {
+	              return setValue(deck.eject, 1);
+	            });
+	          });
+	        }
+	      }
+	    }
+	  };
+	};
+	var makeLoad = make$d;
+
+	const SMALL_SAMPLES = 125;
+	const make$c = function (_, gridPosition, deck) {
+	  const map = {
+	    in: [deck.loop_in, deck.loop_start_position],
+	    out: [deck.loop_out, deck.loop_end_position]
+	  };
+	  const onMidi = function (dir) {
+	    return function ({
+	      context: {
+	        modifier
+	      }
+	    }) {
+	      return onAttack(function (_) {
+	        modes(modifier.getState(), function () {
+	          setValue(map[dir][0], 1);
+	          setValue(map[dir][0], 0);
+	        }, function () {
+	          const ctrl = map[dir][1];
+	          setValue(ctrl, getValue(ctrl) - SMALL_SAMPLES);
+	        }, function () {
+	          const ctrl = map[dir][1];
+	          setValue(ctrl, getValue(ctrl) + SMALL_SAMPLES);
+	        });
+	      });
+	    };
+	  };
+	  return {
+	    state: {},
+	    bindings: {
+	      in: {
+	        type: 'button',
+	        target: gridPosition,
+	        midi: onMidi('in')
+	      },
+	      out: {
+	        type: 'button',
+	        target: [gridPosition[0] + 1, gridPosition[1]],
+	        midi: onMidi('out')
+	      }
+	    }
+	  };
+	};
+	var makeLoopIo = make$c;
+
+	const make$b = function (_, gridPosition, deck) {
+	  const onMount = function (k) {
+	    return function ({
+	      context: {
+	        device
+	      },
+	      bindings
+	    }) {
+	      return function () {
+	        device.sendColor(bindings[k].control, device.colors.lo_yellow);
+	      };
+	    };
+	  };
+	  const onMidi = function (k) {
+	    return function (_) {
+	      return onAttack(function (_) {
+	        return setValue(deck[`loop_${k}`], 1);
+	      });
+	    };
+	  };
+	  return {
+	    state: {},
+	    bindings: {
+	      halve: {
+	        type: 'button',
+	        target: gridPosition,
+	        mount: onMount('halve'),
+	        midi: onMidi('halve')
+	      },
+	      double: {
+	        type: 'button',
+	        target: [gridPosition[0] + 1, gridPosition[1]],
+	        mount: onMount('double'),
+	        midi: onMidi('double')
+	      }
+	    }
+	  };
+	};
+	var makeLoopMultiply = make$b;
+
+	const make$a = function ({
+	  jumps,
+	  vertical = false
+	}, gridPosition, deck) {
+	  const bindings = {};
+	  const onMidi = function (k, j, d) {
+	    return function ({
+	      context: {
+	        modifier,
+	        device
+	      },
+	      bindings,
+	      state
+	    }) {
+	      return retainAttackMode(modifier, function (mode, {
+	        value
+	      }) {
+	        modes(mode, function () {
+	          if (!state.mode) {
+	            if (value) {
+	              setValue(deck.loop_move, j[state.set] * d);
+	            }
+	          } else {
+	            if (value) {
+	              const currentJump = j[state.set] * d;
+	              setValue(deck.loop_move, currentJump);
+	              if (state.pressing != null) {
+	                device.sendColor(bindings[state.pressing].control, device.colors[`lo_${state.color[state.set]}`]);
+	              }
+	              device.sendColor(bindings[k].control, device.colors[`hi_${state.color[state.set]}`]);
+	              state.pressing = k;
+	              state.diff = state.diff + currentJump;
+	            } else {
+	              if (state.pressing === k) {
+	                device.sendColor(bindings[k].control, device.colors[`lo_${state.color[state.set]}`]);
+	                state.pressing = null;
+	                setValue(deck.loop_move, -state.diff);
+	                state.diff = 0;
+	              }
+	            }
+	          }
+	        }, function () {
+	          if (value) {
+	            state.set = posMod(state.set + 1, 2);
+	            const prefix = state.mode ? 'lo' : 'hi';
+	            for (let b = 0; b < spec.length; ++b) {
+	              device.sendColor(bindings[b].control, device.colors[`${prefix}_${state.color[state.set]}`]);
+	            }
+	          }
+	        }, function () {
+	          if (value) {
+	            state.mode = !state.mode;
+	            const prefix = state.mode ? 'lo' : 'hi';
+	            for (let b = 0; b < spec.length; ++b) {
+	              device.sendColor(bindings[b].control, device.colors[`${prefix}_${state.color[state.set]}`]);
+	            }
+	          }
+	        });
+	      });
+	    };
+	  };
+	  const onMount = function (k) {
+	    return function ({
+	      context: {
+	        device
+	      },
+	      bindings,
+	      state
+	    }) {
+	      return function () {
+	        const prefix = state.mode ? 'lo' : 'hi';
+	        device.sendColor(bindings[k].control, device.colors[`${prefix}_${state.color[state.set]}`]);
+	      };
+	    };
+	  };
+	  const spec = _flatMapInstanceProperty(jumps).call(jumps, function (j) {
+	    return [[j, 1], [j, -1]];
+	  });
+	  spec.forEach(function ([jump, dir], i) {
+	    bindings[i] = {
+	      type: 'button',
+	      target: vertical ? [gridPosition[0] + i % 2, gridPosition[1] + ~~(i / 2)] : [gridPosition[0] + ~~(i / 2), gridPosition[1] + i % 2],
+	      midi: onMidi(i, jump, dir),
+	      mount: onMount(i)
+	    };
+	  });
+	  return {
+	    bindings,
+	    state: {
+	      mode: false,
+	      pressing: null,
+	      diff: 0,
+	      set: 0,
+	      color: ['green', 'red']
+	    }
+	  };
+	};
+	var makeLoopjump = make$a;
+
+	const make$9 = function ({
+	  amount
+	}, button, deck) {
+	  const onMidi = function (dir) {
+	    return function ({
+	      context: {
+	        modifier
+	      }
+	    }) {
+	      return onAttack(function (_) {
+	        return modes(modifier.getState(), function () {
+	          return setValue(deck.loop_move, dir * amount);
+	        });
+	      });
+	    };
+	  };
+	  return {
+	    state: {},
+	    bindings: {
+	      back: {
+	        type: 'button',
+	        target: button,
+	        midi: onMidi(-1),
+	        mount: function ({
+	          context: {
+	            device
+	          },
+	          bindings
+	        }) {
+	          return function () {
+	            device.sendColor(bindings.back.control, device.colors.hi_yellow);
+	          };
+	        }
+	      },
+	      forth: {
+	        type: 'button',
+	        target: [button[0] + 1, button[1]],
+	        midi: onMidi(1),
+	        mount: function ({
+	          context: {
+	            device
+	          },
+	          bindings
+	        }) {
+	          return function () {
+	            device.sendColor(bindings.forth.control, device.colors.hi_yellow);
+	          };
+	        }
+	      }
+	    }
+	  };
+	};
+	var makeLoopjumpSmall = make$9;
+
+	const make$8 = function (_, gridPosition, deck) {
+	  const rateEpsilon = 1e-3;
+	  const getDirection = function (rate) {
+	    if (rate < -rateEpsilon) {
+	      return 'up';
+	    } else if (rate > rateEpsilon) {
+	      return 'down';
+	    } else {
+	      return '';
+	    }
+	  };
+	  const onNudgeMidi = function (dir) {
+	    return function ({
+	      context: {
+	        modifier,
+	        device
+	      },
+	      bindings,
+	      state
+	    }) {
+	      return retainAttackMode(modifier, function (mode, {
+	        value
+	      }) {
+	        if (value) {
+	          state[dir] = true;
+	          if (state.down && state.up) {
+	            setValue(deck.rate, 0);
+	          } else {
+	            modes(mode, function () {
+	              device.sendColor(bindings[dir].control, device.colors.hi_yellow);
+	              setValue(deck[`rate_temp_${dir}`], 1);
+	            }, function () {
+	              device.sendColor(bindings[dir].control, device.colors.hi_red);
+	              setValue(deck[`rate_perm_${dir}`], 1);
+	            }, function () {
+	              device.sendColor(bindings[dir].control, device.colors.lo_yellow);
+	              setValue(deck[`rate_temp_${dir}_small`], 1);
+	            }, function () {
+	              device.sendColor(bindings[dir].control, device.colors.lo_red);
+	              setValue(deck[`rate_perm_${dir}_small`], 1);
+	            });
+	          }
+	        } else {
+	          state[dir] = false;
+	          if (getDirection(getValue(bindings.rate.control)) === dir) {
+	            device.sendColor(bindings[dir].control, device.colors.lo_orange);
+	          } else {
+	            device.clearColor(bindings[dir].control);
+	          }
+	          modes(mode, function () {
+	            return setValue(deck[`rate_temp_${dir}`], 0);
+	          }, undefined, function () {
+	            return setValue(deck[`rate_temp_${dir}_small`], 0);
+	          });
+	        }
+	      });
+	    };
+	  };
+	  const onRate = function ({
+	    context: {
+	      device
+	    },
+	    bindings,
+	    state
+	  }) {
+	    return function ({
+	      value
+	    }) {
+	      let up = device.colors.black;
+	      let down = device.colors.black;
+	      const rate = getDirection(value);
+	      if (rate === 'down') {
+	        down = device.colors.lo_orange;
+	      } else if (rate === 'up') {
+	        up = device.colors.lo_orange;
+	      }
+	      if (!state.down) {
+	        device.sendColor(bindings.down.control, down);
+	      }
+	      if (!state.up) {
+	        device.sendColor(bindings.up.control, up);
+	      }
+	    };
+	  };
+	  return {
+	    bindings: {
+	      down: {
+	        type: 'button',
+	        target: gridPosition,
+	        midi: onNudgeMidi('down')
+	      },
+	      up: {
+	        type: 'button',
+	        target: [gridPosition[0] + 1, gridPosition[1]],
+	        midi: onNudgeMidi('up')
+	      },
+	      rate: {
+	        type: 'control',
+	        target: deck.rate,
+	        update: onRate
+	      }
+	    },
+	    state: {
+	      up: false,
+	      down: false
+	    }
+	  };
+	};
+	var makeNudge = make$8;
+
+	const make$7 = function (_, gridPosition, deck) {
+	  return {
+	    state: {},
+	    bindings: {
+	      pfl: {
+	        type: 'control',
+	        target: deck.pfl,
+	        update: function ({
+	          context: {
+	            device
+	          },
+	          bindings
+	        }) {
+	          return function ({
+	            value
+	          }) {
+	            return value ? device.sendColor(bindings.button.control, device.colors.hi_green) : device.clearColor(bindings.button.control);
+	          };
+	        }
+	      },
+	      button: {
+	        type: 'button',
+	        target: gridPosition,
+	        midi: function ({
+	          context: {
+	            modifier
+	          },
+	          bindings
+	        }) {
+	          return onAttack(function (_) {
+	            return modes(modifier.getState(), function () {
+	              return setValue(bindings.pfl.control, Number(!getValue(bindings.pfl.control)));
+	            });
+	          });
+	        }
+	      }
+	    }
+	  };
+	};
+	var makePfl = make$7;
+
+	const make$6 = function (_, gridPosition, deck) {
+	  return {
+	    state: {},
+	    bindings: {
+	      playIndicator: {
+	        type: 'control',
+	        target: deck.play_indicator,
+	        update: function ({
+	          bindings,
+	          context: {
+	            device
+	          }
+	        }) {
+	          return function ({
+	            value
+	          }) {
+	            if (value) {
+	              device.sendColor(bindings.play.control, device.colors.hi_red);
+	            } else if (!value) {
+	              device.clearColor(bindings.play.control);
+	            }
+	          };
+	        }
+	      },
+	      play: {
+	        type: 'button',
+	        target: gridPosition,
+	        midi: function ({
+	          context: {
+	            modifier
+	          }
+	        }) {
+	          return onAttack(function () {
+	            modes(modifier.getState(), function () {
+	              return setValue(deck.play, Number(!getValue(deck.play)));
+	            }, function () {
+	              return setValue(deck.start_play, 1);
+	            }, function () {
+	              return setValue(deck.start_stop, 1);
+	            });
+	          });
+	        }
+	      }
+	    }
+	  };
+	};
+	var makePlay = make$6;
+
+	const make$5 = function (_, gridPosition, deck) {
+	  return {
+	    state: {},
+	    bindings: {
+	      quantize: {
+	        type: 'control',
+	        target: deck.quantize,
+	        update: function ({
+	          bindings,
+	          context: {
+	            device
+	          }
+	        }) {
+	          return function ({
+	            value
+	          }) {
+	            return value ? device.sendColor(bindings.button.control, device.colors.hi_orange) : device.clearColor(bindings.button.control);
+	          };
+	        }
+	      },
+	      button: {
+	        type: 'button',
+	        target: gridPosition,
+	        midi: function ({
+	          bindings,
+	          context: {
+	            modifier
+	          }
+	        }) {
+	          return onAttack(function () {
+	            return modes(modifier.getState(), function () {
+	              return setValue(bindings.quantize.control, Number(!getValue(bindings.quantize.control)));
+	            });
+	          });
+	        }
+	      }
+	    }
+	  };
+	};
+	var makeQuantize = make$5;
+
+	const make$4 = function (_, gridPosition, deck) {
+	  return {
+	    state: {},
+	    bindings: {
+	      button: {
+	        type: 'button',
+	        target: gridPosition,
+	        midi: function ({
+	          context: {
+	            modifier
+	          }
+	        }) {
+	          return onAttack(function () {
+	            modes(modifier.getState(), function () {
+	              return setValue(deck.reloop_exit, 1);
+	            }, function () {
+	              return setValue(deck.reloop_andstop, 1);
+	            });
+	          });
+	        }
+	      },
+	      control: {
+	        type: 'control',
+	        target: deck.loop_enabled,
+	        update: function ({
+	          context: {
+	            device
+	          },
+	          bindings
+	        }) {
+	          return function ({
+	            value
+	          }) {
+	            if (value) {
+	              device.sendColor(bindings.button.control, device.colors.hi_green);
+	            } else {
+	              device.sendColor(bindings.button.control, device.colors.lo_green);
+	            }
+	          };
+	        }
+	      }
+	    }
+	  };
+	};
+	var makeReloop = make$4;
+
+	const make$3 = function (_, gridPosition, deck) {
+	  const onMidi = function ({
+	    bindings,
+	    state,
+	    context: {
+	      modifier,
+	      device
+	    }
+	  }) {
+	    return retainAttackMode(modifier, function (mode, {
+	      value
+	    }) {
+	      modes(mode, function () {
+	        if (value) {
+	          setValue(bindings.control.control, Number(!getValue(bindings.control.control)));
+	        } else {
+	          if (state.mode) {
+	            setValue(bindings.control.control, Number(!getValue(bindings.control.control)));
+	          }
+	        }
+	      }, function () {
+	        if (value) {
+	          state.mode = !state.mode;
+	          const color = state.mode ? 'orange' : 'red';
+	          device.sendColor(bindings.button.control, device.colors[`lo_${color}`]);
+	        }
+	      });
+	    });
+	  };
+	  return {
+	    bindings: {
+	      control: {
+	        type: 'control',
+	        target: deck.slip_enabled,
+	        update: function ({
+	          bindings,
+	          state,
+	          context: {
+	            device
+	          }
+	        }) {
+	          return function ({
+	            value
+	          }) {
+	            const color = state.mode ? 'orange' : 'red';
+	            if (value) {
+	              device.sendColor(bindings.button.control, device.colors[`hi_${color}`]);
+	            } else {
+	              device.sendColor(bindings.button.control, device.colors[`lo_${color}`]);
+	            }
+	          };
+	        }
+	      },
+	      button: {
+	        type: 'button',
+	        target: gridPosition,
+	        midi: onMidi,
+	        mount: function ({
+	          bindings,
+	          state,
+	          context: {
+	            device
+	          }
+	        }) {
+	          return function () {
+	            const color = state.mode ? 'orange' : 'red';
+	            device.sendColor(bindings.button.control, device.colors[`lo_${color}`]);
+	          };
+	        }
+	      }
+	    },
+	    state: {
+	      mode: true
+	    }
+	  };
+	};
+	var makeSlip = make$3;
+
+	const make$2 = function (_, gridPosition, deck) {
+	  return {
+	    state: {},
+	    bindings: {
+	      sync: {
+	        type: 'button',
+	        target: gridPosition,
+	        midi: function ({
+	          bindings,
+	          context: {
+	            modifier
+	          }
+	        }) {
+	          return onAttack(function () {
+	            modes(modifier.getState(), function () {
+	              if (getValue(bindings.syncMode.control)) {
+	                setValue(deck.sync_enabled, 0);
+	              } else {
+	                setValue(deck.sync_enabled, 1);
+	              }
+	            }, function () {
+	              if (getValue(bindings.syncMode.control) === 2) {
+	                setValue(deck.sync_master, 0);
+	              } else {
+	                setValue(deck.sync_master, 1);
+	              }
+	            });
+	          });
+	        }
+	      },
+	      syncMode: {
+	        type: 'control',
+	        target: deck.sync_mode,
+	        update: function ({
+	          bindings,
+	          context: {
+	            device
+	          }
+	        }) {
+	          return function ({
+	            value
+	          }) {
+	            if (value === 0) {
+	              device.clearColor(bindings.sync.control);
+	            } else if (value === 1) {
+	              device.sendColor(bindings.sync.control, device.colors.hi_orange);
+	            } else if (value === 2) {
+	              device.sendColor(bindings.sync.control, device.colors.hi_red);
+	            }
+	          };
+	        }
+	      }
+	    }
+	  };
+	};
+	var makeSync = make$2;
+
+	class Bpm extends eventemitter3Exports {
+	  constructor(max) {
+	    super();
+	    _defineProperty(this, "tapTime", void 0);
+	    _defineProperty(this, "taps", void 0);
+	    _defineProperty(this, "max", void 0);
+	    if (max == null) {
+	      max = 8;
+	    }
+	    this.tapTime = 0;
+	    this.taps = [];
+	    this.max = max;
+	  }
+	  reset() {
+	    this.taps = [];
+	  }
+	  tap() {
+	    const now = Date.now();
+	    const tapDelta = now - this.tapTime;
+	    this.tapTime = now;
+	    if (tapDelta > 2000) {
+	      // reset if longer than two seconds between taps
+	      this.taps = [];
+	    } else {
+	      this.taps.push(60000 / tapDelta);
+	      if (this.taps.length > this.max) this.taps.shift(); // Keep the last n samples for averaging
+	      let sum = 0;
+	      this.taps.forEach(function (v) {
+	        sum += v;
+	      });
+	      const avg = sum / this.taps.length;
+	      this.emit('tap', avg);
+	    }
+	  }
+	}
+
+	const make$1 = function (_, gridPosition, deck) {
+	  const tempoBpm = new Bpm();
+	  tempoBpm.on('tap', function (avg) {
+	    setValue(deck.bpm, avg);
+	  });
+	  return {
+	    state: {},
+	    bindings: {
+	      tap: {
+	        type: 'button',
+	        target: gridPosition,
+	        midi: function ({
+	          context: {
+	            modifier
+	          }
+	        }) {
+	          return onAttack(function () {
+	            modes(modifier.getState(), function () {
+	              return tempoBpm.tap();
+	            }, function () {
+	              return setValue(deck.bpm_tap, 1);
+	            }, function () {
+	              return setValue(deck.beats_translate_curpos, 1);
+	            }, function () {
+	              return setValue(deck.beats_translate_match_alignment, 1);
+	            });
+	          });
+	        }
+	      },
+	      beat: {
+	        type: 'control',
+	        target: deck.beat_active,
+	        update: function ({
+	          context: {
+	            device
+	          },
+	          bindings
+	        }) {
+	          return function ({
+	            value
+	          }) {
+	            if (value) {
+	              device.sendColor(bindings.tap.control, device.colors.hi_red);
+	            } else {
+	              device.clearColor(bindings.tap.control);
+	            }
+	          };
+	        }
+	      }
+	    }
+	  };
+	};
+	var makeTap = make$1;
+
+	const index$1 = {
+	  beatjump: makeBeatjump,
+	  beatloop: makeBeatloop,
+	  cue: makeCue,
+	  grid: makeGrid,
+	  hotcue: makeHotcue,
+	  key: makeKey,
+	  keyshift: makeKeyshift,
+	  load: makeLoad,
+	  loopIo: makeLoopIo,
+	  loopMultiply: makeLoopMultiply,
+	  loopjump: makeLoopjump,
+	  loopjumpSmall: makeLoopjumpSmall,
+	  nudge: makeNudge,
+	  pfl: makePfl,
+	  play: makePlay,
+	  quantize: makeQuantize,
+	  reloop: makeReloop,
+	  slip: makeSlip,
+	  sync: makeSync,
+	  tap: makeTap
+	};
+	var makeControlTemplateIndex = index$1;
+
+	const make = function (_, gridPosition, sampler, theme) {
+	  const onStateChanged = function (state, device, bindings) {
+	    const color = state.color == null ? theme.fallbackTrackColor : state.color;
+	    if (!state.loaded) {
+	      device.clearColor(bindings.button.control);
+	    } else if (!state.playing) {
+	      if (device.supportsRGBColors) {
+	        device.sendRGBColor(bindings.button.control, color.map(function (x) {
+	          return ~~(x / 4);
+	        }));
+	      } else {
+	        device.sendColor(bindings.button.control, device.colors.lo_red);
+	      }
+	    } else {
+	      if (device.supportsRGBColors) {
+	        device.sendRGBColor(bindings.button.control, color);
+	      } else {
+	        device.sendColor(bindings.button.control, device.colors.hi_red);
+	      }
+	    }
+	  };
+	  return {
+	    state: {
+	      playing: false,
+	      loaded: false,
+	      color: null
+	    },
+	    bindings: {
+	      button: {
+	        type: 'button',
+	        target: gridPosition,
+	        midi: function ({
+	          context: {
+	            modifier
+	          },
+	          state
+	        }) {
+	          return function ({
+	            value
+	          }) {
+	            if (value) {
+	              modes(modifier.getState(), function () {
+	                if (!state.loaded) {
+	                  setValue(sampler.LoadSelectedTrack, 1);
+	                } else {
+	                  setValue(sampler.cue_gotoandplay, 1);
+	                }
+	              }, function () {
+	                if (state.playing) {
+	                  setValue(sampler.stop, 1);
+	                } else if (state.loaded) {
+	                  setValue(sampler.eject, 1);
+	                }
+	              });
+	            }
+	          };
+	        }
+	      },
+	      playing: {
+	        type: 'control',
+	        target: sampler.play_latched,
+	        update: function ({
+	          context: {
+	            device
+	          },
+	          bindings,
+	          state
+	        }) {
+	          return function ({
+	            value
+	          }) {
+	            state.playing = !!value;
+	            onStateChanged(state, device, bindings);
+	          };
+	        }
+	      },
+	      loaded: {
+	        type: 'control',
+	        target: sampler.track_loaded,
+	        update: function ({
+	          context: {
+	            device
+	          },
+	          bindings,
+	          state
+	        }) {
+	          return function ({
+	            value
+	          }) {
+	            state.loaded = !!value;
+	            onStateChanged(state, device, bindings);
+	          };
+	        }
+	      },
+	      colorChanged: {
+	        type: 'control',
+	        target: sampler.track_color,
+	        update: function ({
+	          context: {
+	            device
+	          },
+	          bindings,
+	          state
+	        }) {
+	          return function ({
+	            value
+	          }) {
+	            state.color = parseRGBColor(value);
+	            onStateChanged(state, device, bindings);
+	          };
+	        }
+	      }
+	    }
+	  };
+	};
+	var makeSamplerPad = make;
+
+	const controlListeners = ['update', 'mount', 'unmount'];
+	const midiListeners = ['midi', 'mount', 'unmount'];
+	const nameOf = function (x, y) {
+	  return `${7 - y},${x}`;
+	};
+	class Control extends Component {
+	  constructor(ctx, controlTemplate) {
+	    super();
+	    _defineProperty(this, "bindings", void 0);
+	    _defineProperty(this, "bindingTemplates", void 0);
+	    _defineProperty(this, "state", void 0);
+	    _defineProperty(this, "context", void 0);
+	    const bindings = {};
+	    for (const k in controlTemplate.bindings) {
+	      const bt = controlTemplate.bindings[k];
+	      bindings[k] = bt.type == 'control' ? new ControlComponent(bt.target) : new MidiComponent(ctx.device, ctx.device.controls[nameOf(...bt.target)]);
+	    }
+	    this.bindingTemplates = controlTemplate.bindings;
+	    this.bindings = bindings;
+	    this.state = controlTemplate.state;
+	    this.context = ctx;
+	  }
+	  onMount() {
+	    var _this = this;
+	    super.onMount();
+	    Object.keys(this.bindings).forEach(function (k) {
+	      const b = _this.bindings[k];
+	      if (b instanceof ControlComponent) {
+	        const bt = _this.bindingTemplates[k];
+	        controlListeners.forEach(function (event) {
+	          const listener = bt[event];
+	          if (listener != null) {
+	            b.addListener(event, listener(_this));
+	          }
+	        });
+	      } else {
+	        const bt = _this.bindingTemplates[k];
+	        midiListeners.forEach(function (event) {
+	          const listener = bt[event];
+	          if (listener) {
+	            b.addListener(event, listener(_this));
+	          }
+	        });
+	        // add a default handler to clear the button LED
+	        b.addListener('unmount', function () {
+	          _this.context.device.clearColor(b.control);
+	        });
+	      }
+	    });
+	    Object.values(this.bindings).forEach(function (b) {
+	      return b.mount();
+	    });
+	  }
+	  onUnmount() {
+	    const bs = Object.values(this.bindings);
+	    bs.forEach(function (b) {
+	      return b.unmount();
+	    });
+	    bs.forEach(function (b) {
+	      return b.removeAllListeners();
+	    });
+	    super.onUnmount();
+	  }
+	}
+	const isDeckPresetConf = function (p) {
+	  return 'deck' in p;
+	};
+	class Preset extends Component {
+	  constructor(ctx, presetTemplate) {
+	    super();
+	    _defineProperty(this, "controls", void 0);
+	    this.controls = presetTemplate.controls.map(function (c) {
+	      return new Control(ctx, c);
+	    });
+	  }
+	  onMount() {
+	    super.onMount();
+	    for (const control of this.controls) {
+	      control.mount();
+	    }
+	  }
+	  onUnmount() {
+	    for (const control of this.controls) {
+	      control.unmount();
+	    }
+	    super.onUnmount();
+	  }
+	}
+	const tr = function (a, b) {
+	  return [a[0] + b[0], a[1] + b[1]];
+	};
+	const makeDeckPresetTemplate = function (conf, gridPosition, deck, theme) {
+	  return {
+	    controls: conf.deck.map(function ({
+	      pos,
+	      control: {
+	        type,
+	        params
+	      }
+	    }) {
+	      return makeControlTemplateIndex[type](params, tr(gridPosition, pos), deck, theme);
+	    })
+	  };
+	};
+	const makeSamplerPalettePresetTemplate = function ({
+	  samplerPalette: {
+	    n,
+	    offset,
+	    rows
+	  }
+	}, gridPosition, _startingChannel, theme) {
+	  return {
+	    controls: array(map(function (i) {
+	      const dy = 7 - ~~(i / rows);
+	      const dx = i % rows;
+	      return makeSamplerPad({}, tr(gridPosition, [dx, dy]), root.samplers[i + offset], theme);
+	    }, range(Math.min(n, getValue(root.master.num_samplers)))))
+	  };
+	};
+	const makePresetTemplate = function (conf, gridPosition, channel, theme) {
+	  if (isDeckPresetConf(conf)) {
+	    return makeDeckPresetTemplate(conf, gridPosition, root.channels[channel], theme);
+	  } else {
+	    return makeSamplerPalettePresetTemplate(conf, gridPosition, channel, theme);
+	  }
+	};
+
+	const longInterval = 240;
+	const mediumInterval = 120;
+	const shortInterval = 60;
+	const minInterval = 30;
+	const autoscrolled = function (binding) {
+	  let started = null;
+	  let interval = null;
+	  let timer = null;
+	  binding.on('midi', function (data) {
+	    // unsafe cast: timer should be initialized at this point
+	    timer = timer;
+	    if (data.value) {
+	      interval = longInterval;
+	      started = timer.start(interval);
+	    } else {
+	      timer.end();
+	    }
+	  });
+	  binding.on('mount', function () {
+	    timer = new Timer(function () {
+	      binding.emit('scroll');
+	      // unsafe cast: interval should be initialized at this point
+	      interval = interval;
+	      // unsafe cast: timer should be initialized at this point
+	      timer = timer;
+	      // unsafe cast: started should be initialized at this point
+	      started = started;
+	      if (interval > minInterval) {
+	        const current = Date.now();
+	        if (interval === longInterval && current - started > 1500) {
+	          interval = mediumInterval;
+	          timer.restart(interval);
+	        } else if (interval === mediumInterval && current - started > 3000) {
+	          interval = shortInterval;
+	          timer.restart(interval);
+	        } else if (interval === shortInterval && current - started > 6000) {
+	          interval = minInterval;
+	          timer.restart(interval);
+	        }
+	      }
+	    });
+	  });
+	  binding.on('unmount', function () {
+	    return timer.unmount();
+	  });
+	  return binding;
+	};
+	class PlaylistSidebar extends Component {
+	  constructor(device) {
+	    super();
+	    _defineProperty(this, "buttons", void 0);
+	    _defineProperty(this, "controls", void 0);
+	    const onScroll = function (control) {
+	      return function () {
+	        setValue(control, 1);
+	      };
+	    };
+	    const onMidi = function (control, color = device.colors.hi_yellow) {
+	      return function (message) {
+	        if (message.value) {
+	          setValue(control, 1);
+	          device.sendColor(message.control, device.colors.hi_red);
+	        } else {
+	          device.sendColor(message.control, color);
+	        }
+	      };
+	    };
+	    const onMount = function (color = device.colors.hi_yellow) {
+	      return function (button) {
+	        device.sendColor(button.control, color);
+	      };
+	    };
+	    const onUnmount = function (button) {
+	      device.clearColor(button.control);
+	    };
+	    const btns = [new MidiComponent(device, device.controls.vol), new MidiComponent(device, device.controls.pan), new MidiComponent(device, device.controls.snda), new MidiComponent(device, device.controls.sndb), new MidiComponent(device, device.controls.stop), new MidiComponent(device, device.controls.trkon)];
+	    const controls = [new ControlComponent(masterControlDef.maximize_library)];
+	    const prevPlaylist = autoscrolled(btns[0]);
+	    const nextPlaylist = autoscrolled(btns[1]);
+	    const toggleItem = btns[2];
+	    const prevTrack = autoscrolled(btns[3]);
+	    const nextTrack = autoscrolled(btns[4]);
+	    const toggleLibrary = btns[5];
+	    const toggleLibraryControl = controls[0];
+	    prevPlaylist.on('scroll', onScroll(playListControlDef.SelectPrevPlaylist));
+	    prevPlaylist.on('midi', onMidi(playListControlDef.SelectPrevPlaylist));
+	    prevPlaylist.on('mount', onMount());
+	    prevPlaylist.on('unmount', onUnmount);
+	    nextPlaylist.on('scroll', onScroll(playListControlDef.SelectNextPlaylist));
+	    nextPlaylist.on('midi', onMidi(playListControlDef.SelectNextPlaylist));
+	    nextPlaylist.on('mount', onMount());
+	    nextPlaylist.on('unmount', onUnmount);
+	    prevTrack.on('scroll', onScroll(playListControlDef.SelectPrevTrack));
+	    prevTrack.on('midi', onMidi(playListControlDef.SelectPrevTrack));
+	    prevTrack.on('mount', onMount());
+	    prevTrack.on('unmount', onUnmount);
+	    nextTrack.on('scroll', onScroll(playListControlDef.SelectNextTrack));
+	    nextTrack.on('midi', onMidi(playListControlDef.SelectNextTrack));
+	    nextTrack.on('mount', onMount());
+	    nextTrack.on('unmount', onUnmount);
+	    toggleItem.on('midi', onMidi(playListControlDef.ToggleSelectedSidebarItem, device.colors.hi_green));
+	    toggleItem.on('mount', onMount(device.colors.hi_green));
+	    toggleItem.on('unmount', onUnmount);
+	    toggleLibraryControl.on('update', function (m) {
+	      if (m.value) {
+	        device.sendColor(toggleLibrary.control, device.colors.hi_red);
+	      } else {
+	        device.sendColor(toggleLibrary.control, device.colors.hi_green);
+	      }
+	    });
+	    toggleLibrary.on('midi', function (m) {
+	      if (m.value) {
+	        const t = getValue(masterControlDef.maximize_library);
+	        setValue(masterControlDef.maximize_library, 1 - t);
+	      }
+	    });
+	    toggleLibrary.on('unmount', onUnmount);
+	    this.buttons = btns;
+	    this.controls = controls;
+	  }
+	  onMount() {
+	    super.onMount();
+	    this.buttons.forEach(function (button) {
+	      return button.mount();
+	    });
+	    this.controls.forEach(function (control) {
+	      return control.mount();
+	    });
+	  }
+	  onUnmount() {
+	    this.controls.forEach(function (control) {
+	      return control.unmount();
+	    });
+	    this.buttons.forEach(function (button) {
+	      return button.unmount();
+	    });
+	    super.onUnmount();
+	  }
+	}
+
+	const onMidi = function (layout, channel, modifier) {
+	  return retainAttackMode(modifier, function (mode, {
+	    value
+	  }) {
+	    const selected = layout.chord;
+	    modes(mode, function () {
+	      if (!value && selected.length) {
+	        const diff = reorganize(layout.getLayout(), selected);
+	        layout.updateLayout(diff);
+	        layout.removeChord();
+	      } else if (value) {
+	        layout.addToChord(channel);
+	      }
+	    }, function () {
+	      if (value) {
+	        if (selected.length) layout.removeChord();
+	        const diff = cycle(channel, layout.getLayout(), 1, layout.presets);
+	        layout.updateLayout(diff);
+	      }
+	    }, function () {
+	      if (value) {
+	        if (selected.length) layout.removeChord();
+	        const diff = cycle(channel, layout.getLayout(), -1, layout.presets);
+	        layout.updateLayout(diff);
+	      }
+	    });
+	  });
+	};
+	const buttons = ['up', 'down', 'left', 'right', 'session', 'user1', 'user2', 'mixer'];
+	class App extends Component {
+	  // state variables
+
+	  constructor(device, conf) {
+	    var _this;
+	    super();
+	    _this = this;
+	    _defineProperty(this, "conf", void 0);
+	    _defineProperty(this, "bindings", void 0);
+	    _defineProperty(this, "modifier", void 0);
+	    _defineProperty(this, "presets", void 0);
+	    _defineProperty(this, "playlistSidebar", void 0);
+	    _defineProperty(this, "chord", void 0);
+	    _defineProperty(this, "layout", void 0);
+	    _defineProperty(this, "mountedPresets", void 0);
+	    _defineProperty(this, "device", void 0);
+	    this.conf = conf;
+	    this.device = device;
+	    this.modifier = new ModifierSidebar(device);
+	    this.playlistSidebar = new PlaylistSidebar(device);
+	    this.bindings = buttons.map(function (v, i) {
+	      const binding = new MidiComponent(_this.device, _this.device.controls[v]);
+	      return [binding, onMidi(_this, i, _this.modifier)];
+	    });
+	    this.presets = cycled(conf.presets);
+	    this.chord = [];
+	    this.layout = {};
+	    this.mountedPresets = {};
+	  }
+	  getLayout() {
+	    const res = [];
+	    for (const k in this.layout) {
+	      res.push(this.layout[k]);
+	    }
+	    return res;
+	  }
+	  updateLayout(diff) {
+	    var _this2 = this;
+	    const removedChannels = diff[0].map(function (block) {
+	      return block.channel;
+	    });
+	    removedChannels.forEach(function (ch) {
+	      delete _this2.layout[ch];
+	      _this2.device.clearColor(_this2.bindings[ch][0].control);
+	      _this2.mountedPresets[ch].unmount();
+	    });
+	    const addedBlocks = diff[1];
+	    addedBlocks.forEach(function (block) {
+	      _this2.layout[block.channel] = block;
+	      if (block.index) {
+	        _this2.device.sendColor(_this2.bindings[block.channel][0].control, _this2.device.colors.hi_orange);
+	      } else {
+	        _this2.device.sendColor(_this2.bindings[block.channel][0].control, _this2.device.colors.hi_green);
+	      }
+	      const ctx = {
+	        modifier: _this2.modifier,
+	        device: _this2.device
+	      };
+	      const presetTemplate = makePresetTemplate(_this2.presets[block.size][block.index], block.offset, block.channel, _this2.conf.theme);
+	      const preset = new Preset(ctx, presetTemplate);
+	      _this2.mountedPresets[block.channel] = preset;
+	      _this2.mountedPresets[block.channel].mount();
+	    });
+	  }
+	  removeChord() {
+	    var _this3 = this;
+	    const layout = this.getLayout();
+	    this.chord.forEach(function (ch) {
+	      const found = layout.findIndex(function (b) {
+	        return b.channel === ch;
+	      });
+	      if (found === -1) {
+	        _this3.device.clearColor(_this3.bindings[ch][0].control);
+	      } else {
+	        const block = layout[found];
+	        if (block.index) {
+	          _this3.device.sendColor(_this3.bindings[ch][0].control, _this3.device.colors.hi_orange);
+	        } else {
+	          _this3.device.sendColor(_this3.bindings[ch][0].control, _this3.device.colors.hi_green);
+	        }
+	      }
+	      _this3.chord = [];
+	    });
+	  }
+	  addToChord(channel) {
+	    if (this.chord.length === 4) {
+	      const rem = this.chord.shift();
+	      const found = this.getLayout().findIndex(function (b) {
+	        return b.channel === rem;
+	      });
+	      if (found === -1) {
+	        this.device.clearColor(this.bindings[rem][0].control);
+	      } else {
+	        const layout = this.layout[String(found)];
+	        if (layout.index) {
+	          this.device.sendColor(this.bindings[rem][0].control, this.device.colors.hi_orange);
+	        } else {
+	          this.device.sendColor(this.bindings[rem][0].control, this.device.colors.hi_green);
+	        }
+	      }
+	    }
+	    this.chord.push(channel);
+	    this.device.sendColor(this.bindings[channel][0].control, this.device.colors.hi_red);
+	  }
+	  onMount() {
+	    this.modifier.mount();
+	    this.playlistSidebar.mount();
+	    this.bindings.forEach(function ([binding, midi]) {
+	      binding.mount();
+	      binding.on('midi', midi);
+	    });
+	    const diff = reorganize([], this.conf.initialSelection);
+	    this.updateLayout(diff);
+	  }
+	  onUnmount() {
+	    const diff = reorganize(this.getLayout(), []);
+	    this.updateLayout(diff);
+	    this.bindings.forEach(function ([binding, midi]) {
+	      binding.removeListener('midi', midi);
+	      binding.unmount();
+	    });
+	    this.playlistSidebar.unmount();
+	    this.modifier.unmount();
+	  }
+	}
+	const offsets = [[0, 0], [4, 0], [0, 4], [4, 4]];
+	const cycled = function (presets) {
+	  return {
+	    grande: [...presets.grande, ...presets.tall, ...presets.short],
+	    tall: [...presets.tall, ...presets.short],
+	    short: presets.short
+	  };
+	};
+	const blockEquals = function (a, b) {
+	  return a.offset === b.offset && a.size === b.size && a.channel === b.channel && a.index === b.index;
+	};
+	const reorganize = function (current, selectedChannels) {
+	  const next = function (chs) {
+	    switch (chs.length) {
+	      case 0:
+	        return [];
+	      case 1:
+	        return [{
+	          offset: offsets[0],
+	          size: 'grande',
+	          channel: chs[0],
+	          index: 0
+	        }];
+	      case 2:
+	        return [{
+	          offset: offsets[0],
+	          size: 'tall',
+	          channel: chs[0],
+	          index: 0
+	        }, {
+	          offset: offsets[1],
+	          size: 'tall',
+	          channel: chs[1],
+	          index: 0
+	        }];
+	      case 3:
+	        return [{
+	          offset: offsets[0],
+	          size: 'tall',
+	          channel: chs[0],
+	          index: 0
+	        }, {
+	          offset: offsets[1],
+	          size: 'short',
+	          channel: chs[1],
+	          index: 0
+	        }, {
+	          offset: offsets[3],
+	          size: 'short',
+	          channel: chs[2],
+	          index: 0
+	        }];
+	      default:
+	        return [{
+	          offset: offsets[0],
+	          size: 'short',
+	          channel: chs[0],
+	          index: 0
+	        }, {
+	          offset: offsets[1],
+	          size: 'short',
+	          channel: chs[1],
+	          index: 0
+	        }, {
+	          offset: offsets[2],
+	          size: 'short',
+	          channel: chs[2],
+	          index: 0
+	        }, {
+	          offset: offsets[3],
+	          size: 'short',
+	          channel: chs[3],
+	          index: 0
+	        }];
+	    }
+	  }(selectedChannels);
+	  return current.reduce(function (diff, block) {
+	    const [neg, pos] = diff;
+	    const matched = pos.findIndex(function (b) {
+	      return blockEquals(block, b);
+	    });
+	    return matched === -1 ? [neg.concat([block]), pos] : [neg, pos.slice(0, matched).concat(pos.slice(matched + 1, pos.length))];
+	  }, [[], next]);
+	};
+	const cycle = function (channel, current, dir, lengths) {
+	  const matched = current.findIndex(function (block) {
+	    return block.channel === channel;
+	  });
+	  if (matched === -1) {
+	    return [[], []];
+	  }
+	  const nextIndex = posMod(current[matched].index + dir, lengths[current[matched].size].length);
+	  if (nextIndex === current[matched].index) {
+	    return [[], []];
+	  }
+	  return [[current[matched]], [Object.assign({}, current[matched], {
+	    index: nextIndex
+	  })]];
+	};
+
+	const useDevice = function (device) {
+	  const app = new App(device, config);
+	  device.addListener('mount', app.mount.bind(app));
+	  device.addListener('unmount', app.unmount.bind(app));
+	  return device;
+	};
+	const convertControlDef = function (name, [status, midino]) {
+	  return {
+	    name,
+	    status,
+	    midino
+	  };
+	};
+
+	var device = "Launchpad MK2";
+	var manufacturer = "Novation";
+	var global$1 = "NLMK2";
+	var controls = {
+		up: [
+			176,
+			104
+		],
+		down: [
+			176,
+			105
+		],
+		left: [
+			176,
+			106
+		],
+		right: [
+			176,
+			107
+		],
+		session: [
+			176,
+			108
+		],
+		user1: [
+			176,
+			109
+		],
+		user2: [
+			176,
+			110
+		],
+		mixer: [
+			176,
+			111
+		],
+		vol: [
+			144,
+			89
+		],
+		pan: [
+			144,
+			79
+		],
+		snda: [
+			144,
+			69
+		],
+		sndb: [
+			144,
+			59
+		],
+		stop: [
+			144,
+			49
+		],
+		trkon: [
+			144,
+			39
+		],
+		solo: [
+			144,
+			29
+		],
+		arm: [
+			144,
+			19
+		],
+		"0,0": [
+			144,
+			81
+		],
+		"0,1": [
+			144,
+			82
+		],
+		"0,2": [
+			144,
+			83
+		],
+		"0,3": [
+			144,
+			84
+		],
+		"0,4": [
+			144,
+			85
+		],
+		"0,5": [
+			144,
+			86
+		],
+		"0,6": [
+			144,
+			87
+		],
+		"0,7": [
+			144,
+			88
+		],
+		"1,0": [
+			144,
+			71
+		],
+		"1,1": [
+			144,
+			72
+		],
+		"1,2": [
+			144,
+			73
+		],
+		"1,3": [
+			144,
+			74
+		],
+		"1,4": [
+			144,
+			75
+		],
+		"1,5": [
+			144,
+			76
+		],
+		"1,6": [
+			144,
+			77
+		],
+		"1,7": [
+			144,
+			78
+		],
+		"2,0": [
+			144,
+			61
+		],
+		"2,1": [
+			144,
+			62
+		],
+		"2,2": [
+			144,
+			63
+		],
+		"2,3": [
+			144,
+			64
+		],
+		"2,4": [
+			144,
+			65
+		],
+		"2,5": [
+			144,
+			66
+		],
+		"2,6": [
+			144,
+			67
+		],
+		"2,7": [
+			144,
+			68
+		],
+		"3,0": [
+			144,
+			51
+		],
+		"3,1": [
+			144,
+			52
+		],
+		"3,2": [
+			144,
+			53
+		],
+		"3,3": [
+			144,
+			54
+		],
+		"3,4": [
+			144,
+			55
+		],
+		"3,5": [
+			144,
+			56
+		],
+		"3,6": [
+			144,
+			57
+		],
+		"3,7": [
+			144,
+			58
+		],
+		"4,0": [
+			144,
+			41
+		],
+		"4,1": [
+			144,
+			42
+		],
+		"4,2": [
+			144,
+			43
+		],
+		"4,3": [
+			144,
+			44
+		],
+		"4,4": [
+			144,
+			45
+		],
+		"4,5": [
+			144,
+			46
+		],
+		"4,6": [
+			144,
+			47
+		],
+		"4,7": [
+			144,
+			48
+		],
+		"5,0": [
+			144,
+			31
+		],
+		"5,1": [
+			144,
+			32
+		],
+		"5,2": [
+			144,
+			33
+		],
+		"5,3": [
+			144,
+			34
+		],
+		"5,4": [
+			144,
+			35
+		],
+		"5,5": [
+			144,
+			36
+		],
+		"5,6": [
+			144,
+			37
+		],
+		"5,7": [
+			144,
+			38
+		],
+		"6,0": [
+			144,
+			21
+		],
+		"6,1": [
+			144,
+			22
+		],
+		"6,2": [
+			144,
+			23
+		],
+		"6,3": [
+			144,
+			24
+		],
+		"6,4": [
+			144,
+			25
+		],
+		"6,5": [
+			144,
+			26
+		],
+		"6,6": [
+			144,
+			27
+		],
+		"6,7": [
+			144,
+			28
+		],
+		"7,0": [
+			144,
+			11
+		],
+		"7,1": [
+			144,
+			12
+		],
+		"7,2": [
+			144,
+			13
+		],
+		"7,3": [
+			144,
+			14
+		],
+		"7,4": [
+			144,
+			15
+		],
+		"7,5": [
+			144,
+			16
+		],
+		"7,6": [
+			144,
+			17
+		],
+		"7,7": [
+			144,
+			18
+		]
+	};
+	var def = {
+		device: device,
+		manufacturer: manufacturer,
+		global: global$1,
+		controls: controls
+	};
+
+	const colors = {
+	  black: 0,
+	  lo_red: 7,
+	  hi_red: 5,
+	  lo_green: 19,
+	  hi_green: 17,
+	  lo_amber: 43,
+	  hi_amber: 41,
+	  hi_orange: 84,
+	  lo_orange: 61,
+	  hi_yellow: 13,
+	  lo_yellow: 15,
+	  lo_white: 15,
+	  hi_white: 13
+	};
+	class LaunchpadMK2Device extends LaunchpadDevice {
+	  constructor() {
+	    super();
+	    _defineProperty(this, "supportsRGBColors", void 0);
+	    _defineProperty(this, "controls", void 0);
+	    _defineProperty(this, "colors", void 0);
+	    this.controls = _Object$fromEntries(Object.entries(def.controls).map(function ([k, v]) {
+	      return [k, convertControlDef(k, v)];
+	    }));
+	    this.colors = colors;
+	    this.supportsRGBColors = true;
+	  }
+	  onMount() {
+	    super.onMount();
+	  }
+	  sendRGBColor(control, color) {
+	    sendSysexMsg([240, 0, 32, 41, 2, 24, 11, control.midino, ...color.map(function (x) {
+	      return ~~(x / 4);
+	    }), 247]);
+	  }
+	}
+	var index = useDevice(new LaunchpadMK2Device());
+
+	return index;
+
+})();

--- a/res/controllers/Novation-Launchpad MK2-scripts.js
+++ b/res/controllers/Novation-Launchpad MK2-scripts.js
@@ -1,3 +1,14 @@
+/* eslint-disable */
+/*
+ * Novation-Launchpad MK2-scripts.js
+ *
+ * This file is generated. Do not edit directly.
+ * Instead, edit the source file and regenerate it.
+ * See https://github.com/dszakallas/mixxx-launchpad#building-from-source.
+ *
+ * Commit tag: v3.1.1-4-g4acd883-dirty
+ * Commit hash: 4acd8832e0e93fef400055f7938c9f919036b7d6
+ */
 var NLMK2 = (function () {
 	'use strict';
 

--- a/res/controllers/Novation-Launchpad Mini MK3-scripts.js
+++ b/res/controllers/Novation-Launchpad Mini MK3-scripts.js
@@ -1,4 +1,4 @@
-var NLMK1 = (function () {
+var NLMMK3 = (function () {
 	'use strict';
 
 	var commonjsGlobal = typeof globalThis !== 'undefined' ? globalThis : typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {};
@@ -4879,6 +4879,7 @@ var NLMK1 = (function () {
 	const sendShortMsg = function (control, value) {
 	  midi.sendShortMsg(control.status, control.midino, value);
 	};
+	const sendSysexMsg = midi.sendSysexMsg;
 
 	class Timer extends Component {
 	  constructor(task) {
@@ -7110,329 +7111,329 @@ var NLMK1 = (function () {
 	  };
 	};
 
-	var device = "Launchpad";
+	var device = "Launchpad Mini MK3";
 	var manufacturer = "Novation";
-	var global$1 = "NLMK1";
+	var global$1 = "NLMMK3";
 	var controls = {
 		up: [
 			176,
-			104
+			91
 		],
 		down: [
 			176,
-			105
+			92
 		],
 		left: [
 			176,
-			106
+			93
 		],
 		right: [
 			176,
-			107
+			94
 		],
 		session: [
 			176,
-			108
+			95
 		],
 		user1: [
 			176,
-			109
+			96
 		],
 		user2: [
 			176,
-			110
+			97
 		],
 		mixer: [
 			176,
-			111
+			98
 		],
 		vol: [
-			144,
-			8
+			176,
+			89
 		],
 		pan: [
-			144,
-			24
+			176,
+			79
 		],
 		snda: [
-			144,
-			40
+			176,
+			69
 		],
 		sndb: [
-			144,
-			56
+			176,
+			59
 		],
 		stop: [
-			144,
-			72
+			176,
+			49
 		],
 		trkon: [
-			144,
-			88
+			176,
+			39
 		],
 		solo: [
-			144,
-			104
+			176,
+			29
 		],
 		arm: [
-			144,
-			120
+			176,
+			19
 		],
 		"0,0": [
 			144,
-			0
+			81
 		],
 		"0,1": [
 			144,
-			1
+			82
 		],
 		"0,2": [
 			144,
-			2
+			83
 		],
 		"0,3": [
 			144,
-			3
+			84
 		],
 		"0,4": [
 			144,
-			4
+			85
 		],
 		"0,5": [
 			144,
-			5
+			86
 		],
 		"0,6": [
 			144,
-			6
+			87
 		],
 		"0,7": [
 			144,
-			7
+			88
 		],
 		"1,0": [
 			144,
-			16
+			71
 		],
 		"1,1": [
 			144,
-			17
+			72
 		],
 		"1,2": [
 			144,
-			18
+			73
 		],
 		"1,3": [
 			144,
-			19
+			74
 		],
 		"1,4": [
 			144,
-			20
+			75
 		],
 		"1,5": [
 			144,
-			21
+			76
 		],
 		"1,6": [
 			144,
-			22
+			77
 		],
 		"1,7": [
 			144,
-			23
+			78
 		],
 		"2,0": [
 			144,
-			32
+			61
 		],
 		"2,1": [
 			144,
-			33
+			62
 		],
 		"2,2": [
 			144,
-			34
+			63
 		],
 		"2,3": [
 			144,
-			35
+			64
 		],
 		"2,4": [
 			144,
-			36
+			65
 		],
 		"2,5": [
 			144,
-			37
+			66
 		],
 		"2,6": [
 			144,
-			38
+			67
 		],
 		"2,7": [
 			144,
-			39
+			68
 		],
 		"3,0": [
 			144,
-			48
+			51
 		],
 		"3,1": [
 			144,
-			49
+			52
 		],
 		"3,2": [
 			144,
-			50
+			53
 		],
 		"3,3": [
 			144,
-			51
+			54
 		],
 		"3,4": [
 			144,
-			52
+			55
 		],
 		"3,5": [
 			144,
-			53
+			56
 		],
 		"3,6": [
 			144,
-			54
+			57
 		],
 		"3,7": [
 			144,
-			55
+			58
 		],
 		"4,0": [
 			144,
-			64
+			41
 		],
 		"4,1": [
 			144,
-			65
+			42
 		],
 		"4,2": [
 			144,
-			66
+			43
 		],
 		"4,3": [
 			144,
-			67
+			44
 		],
 		"4,4": [
 			144,
-			68
+			45
 		],
 		"4,5": [
 			144,
-			69
+			46
 		],
 		"4,6": [
 			144,
-			70
+			47
 		],
 		"4,7": [
 			144,
-			71
+			48
 		],
 		"5,0": [
 			144,
-			80
+			31
 		],
 		"5,1": [
 			144,
-			81
+			32
 		],
 		"5,2": [
 			144,
-			82
+			33
 		],
 		"5,3": [
 			144,
-			83
+			34
 		],
 		"5,4": [
 			144,
-			84
+			35
 		],
 		"5,5": [
 			144,
-			85
+			36
 		],
 		"5,6": [
 			144,
-			86
+			37
 		],
 		"5,7": [
 			144,
-			87
+			38
 		],
 		"6,0": [
 			144,
-			96
+			21
 		],
 		"6,1": [
 			144,
-			97
+			22
 		],
 		"6,2": [
 			144,
-			98
+			23
 		],
 		"6,3": [
 			144,
-			99
+			24
 		],
 		"6,4": [
 			144,
-			100
+			25
 		],
 		"6,5": [
 			144,
-			101
+			26
 		],
 		"6,6": [
 			144,
-			102
+			27
 		],
 		"6,7": [
 			144,
-			103
+			28
 		],
 		"7,0": [
 			144,
-			112
+			11
 		],
 		"7,1": [
 			144,
-			113
+			12
 		],
 		"7,2": [
 			144,
-			114
+			13
 		],
 		"7,3": [
 			144,
-			115
+			14
 		],
 		"7,4": [
 			144,
-			116
+			15
 		],
 		"7,5": [
 			144,
-			117
+			16
 		],
 		"7,6": [
 			144,
-			118
+			17
 		],
 		"7,7": [
 			144,
-			119
+			18
 		]
 	};
 	var def = {
@@ -7443,19 +7444,34 @@ var NLMK1 = (function () {
 	};
 
 	const colors = {
-	  black: 4,
-	  lo_red: 1 + 4,
-	  hi_red: 3 + 4,
-	  lo_green: 16 + 4,
-	  hi_green: 48 + 4,
-	  lo_amber: 17 + 4,
-	  hi_amber: 51 + 4,
-	  hi_orange: 35 + 4,
-	  lo_orange: 18 + 4,
-	  hi_yellow: 50 + 4,
-	  lo_yellow: 33 + 4
+	  black: 0,
+	  lo_red: 7,
+	  hi_red: 5,
+	  lo_green: 19,
+	  hi_green: 17,
+	  lo_amber: 43,
+	  hi_amber: 41,
+	  hi_orange: 84,
+	  lo_orange: 61,
+	  hi_yellow: 13,
+	  lo_yellow: 15
 	};
-	class LaunchpadMK1Device extends LaunchpadDevice {
+	var DeviceMode;
+	(function (DeviceMode) {
+	  DeviceMode[DeviceMode["Live"] = 0] = "Live";
+	  DeviceMode[DeviceMode["Programmer"] = 1] = "Programmer";
+	})(DeviceMode || (DeviceMode = {}));
+	var LightingType;
+	(function (LightingType) {
+	  LightingType[LightingType["Static"] = 0] = "Static";
+	  LightingType[LightingType["Flash"] = 1] = "Flash";
+	  LightingType[LightingType["Pulse"] = 2] = "Pulse";
+	  LightingType[LightingType["RGB"] = 3] = "RGB";
+	})(LightingType || (LightingType = {}));
+	const selectMode = function (mode) {
+	  sendSysexMsg([240, 0, 32, 41, 2, 13, 14, mode, 247]);
+	};
+	class LaunchpadMiniMK3Device extends LaunchpadDevice {
 	  constructor() {
 	    super();
 	    _defineProperty(this, "supportsRGBColors", void 0);
@@ -7465,13 +7481,19 @@ var NLMK1 = (function () {
 	      return [k, convertControlDef(k, v)];
 	    }));
 	    this.colors = colors;
-	    this.supportsRGBColors = false;
+	    this.supportsRGBColors = true;
 	  }
-	  sendRGBColor(_control, _value) {
-	    throw new Error('Device does not support RGB Colors.');
+	  onMount() {
+	    selectMode(DeviceMode.Programmer);
+	    super.onMount();
+	  }
+	  sendRGBColor(control, color) {
+	    sendSysexMsg([240, 0, 32, 41, 2, 13, 3, LightingType.RGB, control.midino, ...color.map(function (x) {
+	      return ~~(x / 2);
+	    }), 247]);
 	  }
 	}
-	var index = useDevice(new LaunchpadMK1Device());
+	var index = useDevice(new LaunchpadMiniMK3Device());
 
 	return index;
 

--- a/res/controllers/Novation-Launchpad Mini MK3-scripts.js
+++ b/res/controllers/Novation-Launchpad Mini MK3-scripts.js
@@ -1,3 +1,14 @@
+/* eslint-disable */
+/*
+ * Novation-Launchpad Mini MK3-scripts.js
+ *
+ * This file is generated. Do not edit directly.
+ * Instead, edit the source file and regenerate it.
+ * See https://github.com/dszakallas/mixxx-launchpad#building-from-source.
+ *
+ * Commit tag: v3.1.1-4-g4acd883-dirty
+ * Commit hash: 4acd8832e0e93fef400055f7938c9f919036b7d6
+ */
 var NLMMK3 = (function () {
 	'use strict';
 

--- a/res/controllers/Novation-Launchpad-scripts.js
+++ b/res/controllers/Novation-Launchpad-scripts.js
@@ -1,3 +1,14 @@
+/* eslint-disable */
+/*
+ * Novation-Launchpad-scripts.js
+ *
+ * This file is generated. Do not edit directly.
+ * Instead, edit the source file and regenerate it.
+ * See https://github.com/dszakallas/mixxx-launchpad#building-from-source.
+ *
+ * Commit tag: v3.1.1-4-g4acd883-dirty
+ * Commit hash: 4acd8832e0e93fef400055f7938c9f919036b7d6
+ */
 var NLMK1 = (function () {
 	'use strict';
 


### PR DESCRIPTION
# Upgraded scripts

Controllers:
- Novation Launchpad MK1 (Novation-Launchpad-scripts.js)
- Novation Launchpad MK2 (Novation-Launchpad MK2-scripts.js)

Changes since v2.3.1:

## [3.1.1](https://github.com/dszakallas/mixxx-launchpad/compare/v3.1.0...v3.1.1) (2023-07-01)

### Bug Fixes

* remove circular dependencies ([746cc72](https://github.com/dszakallas/mixxx-launchpad/commit/746cc72e985f25f0100495173fb70351d262dc0d))

## [3.0.0](https://github.com/dszakallas/mixxx-launchpad/compare/v2.3.3...v3.0.0) (2022-04-30)

⚠️ Requires Mixxx 2.4 or newer ⚠️ 

#### New features & improvements:
- [x] Introduce a JSON compatible declarative configuration of layouts to make preset authoring easier
- [x] Sampler palette layout
- [x] Basic RGB LED support for HOTCUEs
- [x] RGB LED support for samplers
- [x] Library maximize / minimize button

#### Fixes:
- [x] Loopjump and beatjump modifiers work more consistently with the rest of the controls
- [x] Fixed retain attack mode bug causing incorrect behavior when shift/control changed between attack/release

#### Breaking changes:
- [x] Drop compatibility with Mixxx < 2.4 (old JS engine)
---------

## [2.3.3](https://github.com/dszakallas/mixxx-launchpad/compare/v2.3.2...v2.3.3) (2022-03-04)

### Bug Fixes

* short layout clash ([f6e0085](https://github.com/dszakallas/mixxx-launchpad/commit/f6e008533dc24f1ecf103f31cd0e716d5530b04d))

## [2.3.2](https://github.com/dszakallas/mixxx-launchpad/compare/v2.3.1...v2.3.2) (2021-12-29)

### Bug Fixes

* **app:** initialize pfl control properly ([ffe460f](https://github.com/dszakallas/mixxx-launchpad/commit/ffe460fb6cb530b828eb80daac14be7814e3c7b4))

# New scripts

- Novation Launchpad Mini MK3 (Novation-Launchpad Mini MK3-scripts.js)


# Notes

Uses ES6 features, I tested compatibility with Mixxx 2.4.0. **Not compatible with Mixxx 2.3**