### PR TITLE
ComponentJS: make JogWheelBasic correctly switch which deck it controls

### DIFF
--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -790,6 +790,9 @@
             throw "Called wrong input handler for " + status + ": " + control + ".\n" +
                 "Please bind jogwheel-related messages to inputWheel and inputTouch!\n";
         },
+        // this is needed for features such as "deck switching" that work
+        // by changing the component group. It is assumed they call `connect`
+        // afterwards.
         connect: function() {
             Component.prototype.connect.call(this);
             this.deck = parseInt(script.channelRegEx.exec(this.group)[1]);

--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -789,6 +789,10 @@
         input: function(_channel, control, _value, status, _group) {
             throw "Called wrong input handler for " + status + ": " + control + ".\n" +
                 "Please bind jogwheel-related messages to inputWheel and inputTouch!\n";
+        },
+        connect: function() {
+            Component.prototype.connect.call(this);
+            this.deck = parseInt(script.channelRegEx.exec(this.group)[1]);
         }
     });
 


### PR DESCRIPTION
by getting the deck from the `group` in `connect`. Fixes #11867. Please let me know if any changes are needed @Swiftb0y.