### PR TITLE
fix(ci): update eslint jsdoc plugin to avoid crash on jsdoc'd files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,8 +75,8 @@ repos:
           - commit
           - manual
         additional_dependencies:
-          - eslint@^v8.6.0
-          - eslint-plugin-jsdoc@^v37.5.0
+          - eslint@^8.48.0
+          - eslint-plugin-jsdoc@^v46.5.1
           - "@typescript-eslint/eslint-plugin"
           - "@typescript-eslint/parser"
   - repo: local


### PR DESCRIPTION
fixes the failing pre-commit runs on PRs such as https://github.com/mixxxdj/mixxx/pull/11913 #11910 (example failing job: https://github.com/mixxxdj/mixxx/actions/runs/6065922549/job/16456428918?pr=11913)