### PR TITLE
TagLib: Log import of metadata and cover art from file

### DIFF
--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -151,6 +151,7 @@ void DlgCoverArtFullSize::slotLoadTrack(TrackPointer pTrack) {
 
 void DlgCoverArtFullSize::slotTrackCoverArtUpdated() {
     if (m_pLoadedTrack) {
+        qDebug() << "DlgCoverArtFullSize: requestTrackCover" << m_pLoadedTrack->getLocation();
         CoverArtCache::requestTrackCover(this, m_pLoadedTrack);
     } else {
         coverArt->setPixmap(QPixmap());

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -407,6 +407,7 @@ void DlgTagFetcher::showProgressOfConstantTask(const QString& text) {
 void DlgTagFetcher::loadCurrentTrackCover() {
     m_pWCurrentCoverArtLabel->loadTrack(m_pTrack);
     CoverArtCache* pCache = CoverArtCache::instance();
+    qDebug() << "DlgTagFetcher: requestTrackCover" << m_pTrack->getLocation();
     pCache->requestTrackCover(this, m_pTrack);
 }
 

--- a/src/sources/metadatasourcetaglib.cpp
+++ b/src/sources/metadatasourcetaglib.cpp
@@ -92,15 +92,16 @@ MetadataSourceTagLib::importTrackMetadataAndCoverImage(
         kLogger.warning()
                 << "Nothing to import"
                 << "from file" << m_fileName
-                << "with type" << m_fileType;
+                << "of type" << m_fileType;
         return afterImport(ImportResult::Unavailable);
     }
-    if (kLogger.traceEnabled()) {
-        kLogger.trace() << "Importing"
-                        << ((pTrackMetadata && pCoverImage) ? "track metadata and cover art" : (pTrackMetadata ? "track metadata" : "cover art"))
-                        << "from file" << m_fileName
-                        << "with type" << m_fileType;
-    }
+    kLogger.info() << "Importing"
+                   << ((pTrackMetadata && pCoverImage)
+                                      ? "track metadata and cover art"
+                                      : (pTrackMetadata ? "track metadata"
+                                                        : "cover art"))
+                   << "from file" << m_fileName
+                   << "of type" << m_fileType;
 
     // Rationale: If a file contains different types of tags only
     // a single type of tag will be read. Tag types are read in a

--- a/src/widget/wcoverart.cpp
+++ b/src/widget/wcoverart.cpp
@@ -144,6 +144,7 @@ void WCoverArt::slotReset() {
 
 void WCoverArt::slotTrackCoverArtUpdated() {
     if (m_loadedTrack) {
+        qDebug() << "WCoverArt: requestTrackCover" << m_loadedTrack->getLocation();
         CoverArtCache::requestTrackCover(this, m_loadedTrack);
     }
 }

--- a/src/widget/wspinnybase.cpp
+++ b/src/widget/wspinnybase.cpp
@@ -285,6 +285,7 @@ void WSpinnyBase::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrac
 
 void WSpinnyBase::slotTrackCoverArtUpdated() {
     if (m_pLoadedTrack) {
+        qDebug() << "WSpinnyBase: requestTrackCover" << m_pLoadedTrack->getLocation();
         CoverArtCache::requestTrackCover(this, m_pLoadedTrack);
     }
 }


### PR DESCRIPTION
This is valuable information. Especially before an unexpected crash caused by malformed data. It also helps to identify subsequent, repeated imports that are probably not intended.

Log level INFO is expected to be verbose and a valid choice for tracking I/O operations. A single log message per file is still coarse grained.