### PR TITLE
Preferences > Sound: ensure sound item tab order matches visual order

### DIFF
--- a/src/soundio/soundmanagerutil.cpp
+++ b/src/soundio/soundmanagerutil.cpp
@@ -312,7 +312,7 @@ QList<AudioPathType> AudioOutput::getSupportedTypes() {
     return types;
 }
 
-bool AudioOutput::isHidden() {
+bool AudioOutput::isHidden() const {
     return m_type == RECORD_BROADCAST;
 }
 

--- a/src/soundio/soundmanagerutil.h
+++ b/src/soundio/soundmanagerutil.h
@@ -56,6 +56,7 @@ public:
     /// methods including getStringFromType, isIndexed, getTypeFromInt,
     /// channelsNeededForType (if necessary), the subclasses' getSupportedTypes
     /// (if necessary), etc.
+    /// Note: the enum order defines the order of items in DlgPrefSound
     enum AudioPathType {
         MASTER,
         HEADPHONES,

--- a/src/soundio/soundmanagerutil.h
+++ b/src/soundio/soundmanagerutil.h
@@ -137,7 +137,8 @@ class AudioOutput : public AudioPath {
     QDomElement toXML(QDomElement *element) const;
     static AudioOutput fromXML(const QDomElement &xml);
     static QList<AudioPathType> getSupportedTypes();
-    bool isHidden();
+    bool isHidden() const;
+
   protected:
     void setType(AudioPathType type) override;
 };


### PR DESCRIPTION
Another UX helper like #11859:
Currently the sound items¹ are inserted into the I/O layouts in random order (though being sorted by type and index on insertion) which results in a random Tab order.

This PR sorts them the same way, just _before_ insertion.
Does apply only to the audio paths added during initialization, hence sound items added later on may theoretically be inserted in between existing items.  (in which situation? I didn't investigate)

¹Audio path label ('Main' etc.) + device combobox + channel combobox