### PR TITLE
Small fixes for common-hid-packet-parser.js

### DIFF
--- a/res/controllers/common-hid-packet-parser.js
+++ b/res/controllers/common-hid-packet-parser.js
@@ -2,7 +2,6 @@
 
 /**
  * Common HID script debugging function. Just to get logging with 'HID' prefix.
- *
  * @deprecated Use console.log instead
  * @param {any} message Message to be printed on controller debug console output
  */
@@ -12,8 +11,7 @@ this.HIDDebug = function(message) {
 /**
  * creates a `DataView` from any ArrayBuffer, TypedArray
  * or plain Array (clamped to 8-bit width).
- *
- * @param {number[] | ArrayBuffer | TypedArray} bufferLike Object that can be represented as a sequence of bytes
+ * @param {number[] | ArrayBuffer | Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array } bufferLike Object that can be represented as a sequence of bytes
  * @returns {DataView} dataview over the bufferLike object
  */
 const createDataView = function(bufferLike) {
@@ -33,20 +31,17 @@ const createDataView = function(bufferLike) {
  * InputReport are received. If a packet callback is defined and the data for the InputReport are
  * received, the complete report data are sent to the callback function after field values are
  * parsed, without calling any packet field parsing functions.
- *
  * @callback packetCallback
  * @param {HIDPacket} packet The packet that represents the InputReport
  * @param {Object.<string, packetField | bitObject>} changed_data The data received from the device
  */
 /**
  * Callback function to call when, the value of a modifier control changed
- *
  * @callback modifierCallback
  * @param {boolean} Value of the modifier control
  */
 /**
  * Callback function to call when, data for specified filed in the packet is updated.
- *
  * @callback fieldChangeCallback
  * @param {packetField|bitObject} Object that describes a field/bit inside of a packet, which can often
  *     mapped to a Mixxx control.
@@ -54,7 +49,6 @@ const createDataView = function(bufferLike) {
 
 /**
  * Callback function, which will be called every time, the value of the connected control changes.
- *
  * @callback controlCallback
  * @param {number} value New value of the control
  * @param {string} group Mixxx control group name e.g. "[Channel1]"
@@ -71,7 +65,6 @@ const createDataView = function(bufferLike) {
  * The ScallingCallback function can also have a boolean property .useSetParameter, if:
  * - 'false' or 'undefined', engine.setValue is used
  * - 'true' engine.setParameter is used
- *
  * @callback scalingCallback
  * @param {string} group Control group name e.g. "[Channel1]"
  * @param {string} name Control name "pregain"
@@ -82,7 +75,6 @@ const createDataView = function(bufferLike) {
 /**
  * Callback function to call when, jog wheel scratching got enabled or disabled by
  * the button with the special name 'jog_touch'
- *
  * @callback scratchingCallback
  * @param {boolean} isScratchEnabled True, when button 'jog_touch' is active
  */
@@ -153,20 +145,17 @@ class HIDBitVector {
     constructor() {
         /**
          * Number of bitObjects in bits array
-         *
          * @type {number}
          */
         this.size = 0;
         /**
          * Object of bitObjects, referred by a string of group and control name separated by a dot
-         *
          * @type {Object.<string, bitObject>}
          */
         this.bits = {};
     }
     /**
      * Get the index of the least significant bit that is 1 in `bitmask`
-     *
      * @param {number} bitmask A bitwise mask of up to 32 bit. All bits set to'1' in this mask are
      *     considered.
      * @returns {number} Index of the least significant bit that is 1 in `bitmask`
@@ -183,7 +172,6 @@ class HIDBitVector {
     }
     /**
      * Add a control bitmask to the HIDBitVector
-     *
      * @param {string} group Control group name e.g. "[Channel1]"
      * @param {string} name Control name e.g. "play"
      * @param {number} bitmask A bitwise mask of up to 32 bit. All bits set to'1' in this mask are
@@ -209,7 +197,6 @@ class HIDBitVector {
     }
     /**
      * Add an output control bitmask to the HIDBitVector
-     *
      * @param {string} group Control group name e.g. "[Channel1]"
      * @param {string} name Control name e.g. "play"
      * @param {number} bitmask A bitwise mask of up to 32 bit. All bits set to'1' in this mask are
@@ -251,21 +238,18 @@ class HIDModifierList {
     constructor() {
         /**
          * Actual value of the modifier
-         *
          * @type {Object.<string, boolean>}
          */
         this.modifiers = Object();
 
         /**
          * Function to be called after modifier value changes
-         *
          * @type {Object.<string, modifierCallback>}
          */
         this.callbacks = Object();
     }
     /**
      * Add a new modifier to controller.
-     *
      * @param {string} name Name of modifier
      */
     add(name) {
@@ -277,7 +261,6 @@ class HIDModifierList {
     }
     /**
      * Set modifier value
-     *
      * @param {string} name Name of modifier
      * @param {boolean} value Value to be set
      */
@@ -294,7 +277,6 @@ class HIDModifierList {
     }
     /**
      * Get modifier value
-     *
      * @param {string} name Name of modifier
      * @returns {boolean} Value of modifier
      */
@@ -307,7 +289,6 @@ class HIDModifierList {
     }
     /**
      * Set modifier callback function
-     *
      * @param {string} name Name of reference in HIDModifierList
      * @param {modifierCallback} callback Function to be called after modifier value changes
      */
@@ -348,49 +329,42 @@ class HIDPacket {
     constructor(name, reportId = 0, callback = undefined, header = []) {
         /**
          * Name of packet
-         *
          * @type {string}
          */
         this.name = name;
 
         /**
          * ReportID of the packet. If the device does not use ReportIDs this must be 0.
-         *
          * @type {number}
          */
         this.reportId = reportId;
 
         /**
          * Function to call when the packet type represents an InputReport, and a new report is received.
-         *
          * @type {packetCallback}
          */
         this.callback = callback;
 
         /**
          * List of bytes to match from beginning of packet
-         *
          * @type {number[]}
          */
         this.header = header;
 
         /**
          * Object of groups, referred by the group string
-         *
          * @type {Object.<string, Object.<string, any>>}
          */
         this.groups = {};
 
         /**
          * Length of packet in bytes
-         *
          * @type {number}
          */
         this.length = this.header.length;
 
         /**
          * Size of the 'pack' types in bytes
-         *
          * @type {Object.<string, number>}
          */
         this.packSizes = {b: 1, B: 1, h: 2, H: 2, i: 4, I: 4};
@@ -400,7 +374,6 @@ class HIDPacket {
     /**
      * Pack a field value to the packet.
      * Can only pack bits and byte values, patches welcome.
-     *
      * @todo Implement multi byte bit vector outputs
      * @param {Uint8Array} data Data to be send as OutputReport to the device
      * @param {packetField} field Object that describes a field inside of a packet, which can often
@@ -458,14 +431,13 @@ class HIDPacket {
     /**
      * Parse and return field value matching the 'pack' field from field attributes.
      * Valid field packing types are:
-     *  - b       signed byte
-     *  - B       unsigned byte
-     *  - h       signed short
-     *  - H       unsigned short
-     *  - i       signed integer
-     *  - I       unsigned integer
-     *
-     * @param {Uint8Array} data Data received as InputReport from the device
+     * - b       signed byte
+     * - B       unsigned byte
+     * - h       signed short
+     * - H       unsigned short
+     * - i       signed integer
+     * - I       unsigned integer
+     * @param {number[] | ArrayBuffer | Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array} data Data received as InputReport from the device
      * @param {packetField} field Object that describes a field inside of a packet, which can often
      *     mapped to a Mixxx control.
      * @returns {number} Value for the field in data, represented according the fields packing type
@@ -493,9 +465,8 @@ class HIDPacket {
     /**
      * Find HID packet group matching name.
      * Create group if create is true
-     *
      * @param {string} name Name of the group
-     * @param {boolean} [create=false] If true, group will be created
+     * @param {boolean} [create] If true, group will be created
        @returns {any} Group Returns group or undefined, when group is not existing and create is set
          to false
      */
@@ -514,7 +485,6 @@ class HIDPacket {
     }
     /**
      * Lookup HID packet field matching given offset and pack type
-     *
      * @param {number} offset The field's offset from the start of the packet in bytes:
      *                        - For HID devices which don't use ReportIDs, the data bytes starts at
      * position 0
@@ -565,7 +535,6 @@ class HIDPacket {
     /**
      * Return a field by group and name from the packet,
      * Returns undefined if field could not be found
-     *
      * @param {string} group Control group name e.g. "[Channel1]"
      * @param {string} name Control name e.g. "play"
      * @returns {packetField} Field
@@ -603,7 +572,6 @@ class HIDPacket {
     }
     /**
      * Return reference to a bit in a bitvector field
-     *
      * @param {string} group Control group name e.g. "[Channel1]"
      * @param {string} name Control name e.g. "play"
      * @returns {bitObject} Reference to a bit in a bitvector field
@@ -635,7 +603,6 @@ class HIDPacket {
     }
     /**
      * Remove a control registered. Normally not needed
-     *
      * @param {string} group Control group name e.g. "[Channel1]"
      * @param {string} name Control name e.g. "play"
      */
@@ -652,7 +619,6 @@ class HIDPacket {
      *
      * 'group' and 'name' form the ID of the field, if it matches a valid Mixxx control name,
      * the system attempts to attach it directly to the correct field.
-     *
      * @param {string} group Control group name e.g. "[Channel1]"
      * @param {string} name Control name e.g. "play"
      * @param {number} offset The field's offset from the start of the packet in bytes:
@@ -667,13 +633,13 @@ class HIDPacket {
      *              - H       unsigned short    (Uint16 Little-Endian)
      *              - i       signed integer    (Int32  Little-Endian)
      *              - I       unsigned integer  (Uint32 Little-Endian)
-     * @param {number} bitmask  A bitwise mask of up to 32 bit. All bits set to'1' in this mask are
+     * @param {number} [bitmask]  A bitwise mask of up to 32 bit. All bits set to'1' in this mask are
      *     considered.
      *           Note: For controls that use full bytes (8bit, 16bit, ...), you can set this to
      * undefined NOTE: Parsing bitmask with multiple bits is not supported yet.
-     * @param {boolean} isEncoder indicates if this is an encoder which should be wrapped and delta
+     * @param {boolean} [isEncoder] indicates if this is an encoder which should be wrapped and delta
      *     reported
-     * @param {fieldChangeCallback} callback Callback function for the control
+     * @param {fieldChangeCallback} [callback] Callback function for the control
      */
     addControl(group, name, offset, pack, bitmask, isEncoder, callback) {
         const control_group = this.getGroup(group, true);
@@ -786,13 +752,12 @@ class HIDPacket {
     /**
      * Register a Output control field or Output control bit to output packet
      * Output control field:
-     *    Output field with no bitmask, controls Output with multiple values
+     * Output field with no bitmask, controls Output with multiple values
      * Output control bit:
-     *    Output with with bitmask, controls Output with a single bit
+     * Output with with bitmask, controls Output with a single bit
      *
      * It is recommended to define callbacks after packet creation with
      * setCallback instead of adding it directly here. But you can do it.
-     *
      * @param {string} group Control group name e.g. "[Channel1]"
      * @param {string} name Control name "VuMeter"
      * @param {number} offset The field's offset from the start of the packet in bytes:
@@ -807,9 +772,9 @@ class HIDPacket {
      *              - H       unsigned short    (Uint16 Little-Endian)
      *              - i       signed integer    (Int32  Little-Endian)
      *              - I       unsigned integer  (Uint32 Little-Endian)
-     * @param {number} [bitmask=undefined] A bitwise mask of up to 32 bit. All bits set to'1' in this mask are
+     * @param {number} [bitmask] A bitwise mask of up to 32 bit. All bits set to'1' in this mask are
      *     considered.
-     * @param {fieldChangeCallback} [callback=undefined] Callback function for the control
+     * @param {fieldChangeCallback} [callback] Callback function for the control
      */
     addOutput(group, name, offset, pack, bitmask, callback) {
         const control_group = this.getGroup(group, true);
@@ -894,7 +859,6 @@ class HIDPacket {
     /**
      * Register a callback to field or a bit vector bit.
      * Does not make sense for Output fields but you can do that.
-     *
      * @param {string} group Control group name e.g. "[Channel1]"
      * @param {string} name Control name e.g. "play"
      * @param {fieldChangeCallback} callback Callback function for the control
@@ -929,7 +893,6 @@ class HIDPacket {
      * This function can be set in script code to ignore a field you don't want to be processed but
      * still wanted to define, to make packet format complete from specifications. If field is
      * ignored, it is not reported in 'delta' objects.
-     *
      * @param {string} group Control group name e.g. "[Channel1]"
      * @param {string} name Control name "pregain"
      * @param {boolean} ignored 'ignored' flag for field to given value (true or false)
@@ -945,7 +908,6 @@ class HIDPacket {
     /**
      * Adjust field's minimum delta value.
      * Input value changes smaller than this are not reported in delta
-     *
      * @param {string} group Control group name e.g. "[Channel1]"
      * @param {string} name Control name "pregain"
      * @param {number} mindelta Minimum delta value.
@@ -964,7 +926,6 @@ class HIDPacket {
     }
     /**
      * Parse bitvector field values, returning object with the named bits set.
-     *
      * @param {packetField} field Object that describes a field inside of a packet, which can often
      *     mapped to a Mixxx control.
      * @param {number} value Value must be a valid unsigned byte to parse, with enough bits.
@@ -974,7 +935,6 @@ class HIDPacket {
     parseBitVector(field, value) {
         /**
          * Object of bitObjects, referred by a string of group and control name separated by a dot
-         *
          * @type {Object.<string, bitObject>}
          */
         const bits = {};
@@ -1000,14 +960,12 @@ class HIDPacket {
      * Parse input packet fields from data.
      * Data is expected to be a Packet() received from HID device.
      * BitVectors are returned as bits you can iterate separately.
-     *
-     * @param {Uint8Array} data Data received as InputReport from the device
+     * @param {number[] | ArrayBuffer | Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array} data Data received as InputReport from the device
      * @returns {Object.<string, packetField | bitObject>} List of changed fields with new value.
      */
     parse(data) {
         /**
          * Object of packetField or bitObjects, referred by a string of group and control name separated by a dot
-         *
          * @type {Object.<string, packetField | bitObject>}
          */
         const field_changes = {};
@@ -1083,8 +1041,7 @@ class HIDPacket {
      * First the header bytes are copied to beginning of packet, then
      * field object values are packed to the HID packet according to the
      * field type.
-     *
-     * @param {boolean} [debug=false] Enables debug output to console
+     * @param {boolean} [debug] Enables debug output to console
      */
     send(debug) {
         const data = new Uint8Array(this.length);
@@ -1136,7 +1093,6 @@ class HIDController {
         /**
          * - By default 'false'
          * - Should be set 'true', when controller is found and everything is OK
-         *
          * @type {boolean}
          */
         this.initialized = false;
@@ -1148,14 +1104,12 @@ class HIDController {
 
         /**
          * HIDPackets representing HID InputReports, by packet name
-         *
          * @type {Object.<string, HIDPacket>}
          */
         this.InputPackets = {};
 
         /**
          * HIDPackets representing HID OutputReports, by packet name
-         *
          * @type {Object.<string, HIDPacket>}
          */
         this.OutputPackets = {};
@@ -1163,7 +1117,6 @@ class HIDController {
         /**
          * A map to determine the output Bit or bytewise field by group and name,
          * across all OutputPackets
-         *
          * @type {Map<string,bitObject|packetField>}
          */
         this.OutputFieldLookup = new Map();
@@ -1171,7 +1124,6 @@ class HIDController {
         /**
          * Default input packet name: can be modified for controllers
          * which can swap modes (wiimote for example)
-         *
          * @type {string}
          */
         this.defaultPacket = "control";
@@ -1184,7 +1136,6 @@ class HIDController {
         // override for custom control
         /**
          * Set to true, when button 'jog_touch' is active
-         *
          * @type {boolean}
          */
         this.isScratchEnabled = false;
@@ -1192,7 +1143,6 @@ class HIDController {
         /**
          * The resolution of the jogwheel HID control (in intervals per revolution)
          * - Default is 128
-         *
          * @type {number}
          */
         this.scratchintervalsPerRev = 128;
@@ -1200,7 +1150,6 @@ class HIDController {
         /**
          * The speed of the imaginary record at 0% pitch - in revolutions per minute (RPM)
          * - Default 33+1/3 - adjust for comfort
-         *
          * @type {number}
          */
         this.scratchRPM = 33 + 1 / 3;
@@ -1208,7 +1157,6 @@ class HIDController {
         /**
          * The alpha coefficient of the filter
          * - Default is 1/8 (0.125) - start tune from there
-         *
          * @type {number}
          */
         this.scratchAlpha = 1.0 / 8;
@@ -1216,7 +1164,6 @@ class HIDController {
         /**
          * The beta coefficient of the filter
          * - Default is scratchAlpha/32 - start tune from there
-         *
          * @type {number}
          */
         this.scratchBeta = this.scratchAlpha / 32;
@@ -1224,7 +1171,6 @@ class HIDController {
         /**
          * - Set 'true' to ramp the deck speed down.
          * - Set 'false' to stop instantly (default)
-         *
          * @type {boolean}
          */
         this.scratchRampOnEnable = false;
@@ -1232,14 +1178,12 @@ class HIDController {
         /**
          * - Set 'true' to ramp the deck speed up.
          * - Set 'false' to jump to normal play speed instantly (default)
-         *
          * @type {boolean}
          */
         this.scratchRampOnDisable = false;
 
         /**
          * Callback function to call when, jog wheel scratching got enabled or disabled
-         *
          * @type {scratchingCallback}
          */
         this.enableScratchCallback = undefined;
@@ -1280,7 +1224,6 @@ class HIDController {
         //
         /**
          * Used to map the virtual deck names 'deck', 'deck1' or 'deck2' to actual [ChannelX]
-         *
          * @type {string[]}
          */
         this.virtualDecks = ["deck", "deck1", "deck2", "deck3", "deck4"];
@@ -1294,7 +1237,6 @@ class HIDController {
          * Standard target groups available in mixxx.
          *
          * This is used by HID packet parser to recognize group parameters we should try sending to mixxx.
-         *
          * @type {string[]}
          */
         this.valid_groups = [
@@ -1328,7 +1270,6 @@ class HIDController {
          * Set to value in ms to update Outputs periodically
          * - By default undefined.
          * - If set, it's a value for timer executed every n ms to update Outputs with updateOutputs()
-         *
          * @deprecated This is unused and updateOutputs() doesn't exist - Remove?
          * @type {number}
          */
@@ -1336,14 +1277,12 @@ class HIDController {
 
         /**
          * Reference to HIDModifierList object
-         *
          * @type {HIDModifierList}
          */
         this.modifiers = new HIDModifierList();
 
         /**
          * Object of scaling function callbacks by name
-         *
          * @type {Object.<string, scalingCallback>}
          */
         this.scalers = {};
@@ -1352,14 +1291,12 @@ class HIDController {
          * Object of engine timer IDs of running auto repeat timers
          * Key is a user specified timer_id.
          * Used only in the controller.startAutoRepeatTimer code stubs of Sony-SixxAxis.js and Nintendo-Wiimote.js.
-         *
          * @type {Object.<number, number>}
          */
         this.timers = {};
 
         /**
          * Auto repeat interval default for fields, where not specified individual (in milliseconds)
-         *
          * @default 100
          * @type {number}
          */
@@ -1375,7 +1312,6 @@ class HIDController {
         /**
          * Callback that is executed after parsing incoming packet
          * (see Traktor-Kontrol-F1-scripts.js for an example)
-         *
          * @type {packetCallback}
          */
         this.postProcessDelta = undefined;
@@ -1395,7 +1331,6 @@ class HIDController {
     /**
      * Return deck number from deck name. Deck name can't be virtual deck name
      * in this function call.
-     *
      * @param {string} group Control group name e.g. "[Channel1]"
      * @returns {number} Number of deck
      */
@@ -1412,7 +1347,6 @@ class HIDController {
     }
     /**
      * Return the group name from given deck number.
-     *
      * @param {number} deck Number of deck
      * @returns {string} Group name of the deck (e.g. Channel2 for deck number 2)
      */
@@ -1425,7 +1359,6 @@ class HIDController {
     /**
      * Map virtual deck names to real deck group. If group is already
      * a real mixxx group value, just return it as it without mapping.
-     *
      * @param {string} group Control group name e.g. "[Channel1]"
      * @returns {string} Channel
      */
@@ -1455,7 +1388,6 @@ class HIDController {
     }
     /**
      * Find Output control matching give group and name
-     *
      * @param {string} m_group Mapped group, must be a valid Mixxx control group name e.g. "[Channel1]"
      * @param {string} m_name Name of mapped control, must be a valid Mixxx control name "VuMeter"
      * @returns {bitObject|packetField} Bit or bytewise field - Returns undefined if output field
@@ -1467,7 +1399,6 @@ class HIDController {
     /**
      * Find input packet matching given name.
      * Returns undefined if input packet name is not registered.
-     *
      * @param {string} name Name of packet (it makes sense to refer the HID report type and HID
      *     Report-ID here e.g. 'InputReport_0x02')
      * @returns {HIDPacket} The input packet
@@ -1481,7 +1412,6 @@ class HIDController {
     /**
      * Find output packet matching given name
      * Returns undefined if output packet name is not registered.
-     *
      * @param {string} name Name of packet (it makes sense to refer the HID report type and HID
      *     Report-ID here e.g. 'OutputReport_0x81')
      * @returns {HIDPacket} The output packet
@@ -1494,7 +1424,6 @@ class HIDController {
     }
     /**
      * Set input packet callback afterwards
-     *
      * @param {string} packet The name of the input packet e.g. 'InputReport_0x02'
      * @param {packetCallback} callback Callback function for the control
      */
@@ -1506,7 +1435,6 @@ class HIDController {
      * Register packet field's callback.
      * If packet has callback, it is still parsed but no field processing is done,
      * callback is called directly after unpacking fields from packet.
-     *
      * @param {string} packet The name of the input packet e.g. 'InputReport_0x02'
      * @param {string} group Control group name e.g. "[Channel1]"
      * @param {string} name Control name "pregain"
@@ -1523,7 +1451,6 @@ class HIDController {
     /**
      * Register scaling function for a control name
      * This does not check if given control name is valid
-     *
      * @param {string} name Reference of the scaling function in scalers list of HIDController
      * @param {scalingCallback} callback Scaling function
      */
@@ -1535,7 +1462,6 @@ class HIDController {
     }
     /**
      * Lookup scaling function for control
-     *
      * @param {string} name Reference of the scaling function in scalers list of HIDController
      * @param {any} _callback Unused
      * @returns {scalingCallback} Scaling function. Returns undefined if function is not
@@ -1549,7 +1475,6 @@ class HIDController {
     }
     /**
      * Change type of a previously defined field to modifier and register it
-     *
      * @param {string} group Control group name e.g. "[Channel1]"
      * @param {string} name Control name
      * @param {string} modifier Name of the modifier e.g. 'shiftbutton'
@@ -1583,7 +1508,6 @@ class HIDController {
 
     /**
      * Link a previously declared HID control to actual mixxx control
-     *
      * @param {string} group Control group name
      * @param {string} name Control name
      * @param {string} m_group Mapped group, must be a valid Mixxx control group name e.g. "[Channel1]"
@@ -1631,7 +1555,6 @@ class HIDController {
      * Input packets can be responses from device to queries, or control
      * data details. The default control data packet must be named in
      * variable this.defaultPacket to allow automatic processing.
-     *
      * @param {HIDPacket} packet The input packet to register
      */
     registerInputPacket(packet) {
@@ -1665,7 +1588,6 @@ class HIDController {
      * This module only supports sending bitvector values and byte fields to device.
      * If you need other data structures, patches are welcome, or you can just do it
      * manually in your script without registering the packet.
-     *
      * @param {HIDPacket} packet The output packet to register
      */
     registerOutputPacket(packet) {
@@ -1701,14 +1623,13 @@ class HIDController {
     }
     /**
      * Parse a packet representing an HID InputReport, and processes each field with "unpack":
-     *  - Calls packet callback and returns, if packet callback was defined
-     *  - Calls processIncomingPacket and processes automated events there.
-     *  - If defined, calls postProcessDelta for results after processing automated fields
-     *
-     * @param {Uint8Array} data The data received from an HID InputReport.
+     * - Calls packet callback and returns, if packet callback was defined
+     * - Calls processIncomingPacket and processes automated events there.
+     * - If defined, calls postProcessDelta for results after processing automated fields
+     * @param {number[] | ArrayBuffer | Int8Array | Uint8Array | Uint8ClampedArray | Int16Array | Uint16Array | Int32Array | Uint32Array} data The data received from an HID InputReport.
      *                        In case of HID devices, which use ReportIDs to enumerate the reports,
      * the ReportID is stored in the first byte and the data start at the second byte
-     * @param {number} length Length of the data array in bytes
+     * @param {number} [length] Length of the data array in bytes
      */
     parsePacket(data, length) {
         if (this.InputPackets === undefined) {
@@ -1773,17 +1694,16 @@ class HIDController {
      * - Sets modifiers from buttons
      * - Calls button callbacks, if defined
      * - Finally tries to run matching engine.setValue() function for buttons
-     *   in default mixxx groups, honoring toggleButtons and other button
-     *   details. Not done if a callback was defined for button.
+     * in default mixxx groups, honoring toggleButtons and other button
+     * details. Not done if a callback was defined for button.
      *
      * Control (Numeric value) field processing
      * - Calls scaling functions for control fields, if defined for field.
-     *   Scaling function for encoders (isEncoder attribute is true) scales
-     *   field delta instead of raw value.
+     * Scaling function for encoders (isEncoder attribute is true) scales
+     * field delta instead of raw value.
      * - Calls callback functions for control fields, if defined for field
      * - Finally tries run matching engine.setValue() function for control
-     *   fields in default mixxx groups. Not done if a callback was defined.
-     *
+     * fields in default mixxx groups. Not done if a callback was defined.
      * @param {any} packet Unused
      * @param {Object.<string, packetField | bitObject>} delta
      */
@@ -1812,7 +1732,6 @@ class HIDController {
     }
     /**
      * Get active group for this field
-     *
      * @param {packetField|bitObject} field Object that describes a field inside of a packet, which can often
      *     mapped to a Mixxx control.
      * @returns {string} Group
@@ -1835,7 +1754,6 @@ class HIDController {
     }
     /**
      * Get active control name from field
-     *
      * @param {packetField|bitObject} field Object that describes a field inside of a packet, which can often
      *     mapped to a Mixxx control.
      * @returns {string} Name of field
@@ -1849,7 +1767,6 @@ class HIDController {
     }
     /**
      * Process given button field, triggering events
-     *
      * @param {bitObject} field Object that describes a field inside of a packet, which can often
      *     mapped to a Mixxx control.
      */
@@ -1920,7 +1837,6 @@ class HIDController {
     }
     /**
      * Process given control field, triggering events
-     *
      * @param {packetField} field Object that describes a field inside of a packet, which can often
      *     mapped to a Mixxx control.
      */
@@ -1976,7 +1892,6 @@ class HIDController {
     }
     /**
      * Toggle control state from toggle button
-     *
      * @param {string} group Control group name e.g. "[Channel1]"
      * @param {string} control Name of the control (button)
      * @param {number} value Value defined in this.buttonStates
@@ -1990,7 +1905,6 @@ class HIDController {
     }
     /**
      * Toggle play/pause state
-     *
      * @param {string} group Control group name e.g. "[Channel1]"
      * @param {packetField} field Object that describes a field inside of a packet, which can often
      *     mapped to a Mixxx control.
@@ -2010,7 +1924,6 @@ class HIDController {
      * Processing of the 'jog_touch' special button name, which is used to detect
      * when scratching should be enabled.
      * Deck is resolved from group with 'resolveDeck'
-     *
      * @param {string} group Control group name e.g. "[Channel1]"
      * @param {boolean} status Enable or Disable scratching:
      * - true enables scratching (press 'jog_touch' button)
@@ -2052,14 +1965,13 @@ class HIDController {
      * you are warned if following scaling function names are not registered:
      *
      * jog
-     *      Scaling function from 'jog_wheel' for rate bend events with mixxx 'jog'
-     *      function. Should return value range suitable for 'jog', whatever you
-     *      wish it to do.
+     * Scaling function from 'jog_wheel' for rate bend events with mixxx 'jog'
+     * function. Should return value range suitable for 'jog', whatever you
+     * wish it to do.
      * jog_scratch
-     *      Scaling function from 'jog_wheel' for scratch movements with mixxx
-     *      'scratchTick' function. Should return -1,0,1 or small ranges of integers
-     *      both negative and positive values.
-     *
+     * Scaling function from 'jog_wheel' for scratch movements with mixxx
+     * 'scratchTick' function. Should return -1,0,1 or small ranges of integers
+     * both negative and positive values.
      * @param {packetField} field Object that describes a field inside of a packet, which can often
      *     mapped to a Mixxx control.
      */
@@ -2102,7 +2014,6 @@ class HIDController {
     }
     /**
      * Stops the specified auto repeat timer
-     *
      * @param {string} timer_id Reference of the timer to stop
      */
     stopAutoRepeatTimer(timer_id) {
@@ -2115,7 +2026,6 @@ class HIDController {
     }
     /**
      * Toggle field autorepeat on or off
-     *
      * @param {string} group
      * @param {string} name
      * @param {fieldChangeCallback} callback Callback function for the control
@@ -2167,7 +2077,6 @@ class HIDController {
     }
     /**
      * Toggle active deck and update virtual output field control mappings
-     *
      * @param {number} deck Number of deck
      */
     switchDeck(deck) {
@@ -2250,7 +2159,6 @@ class HIDController {
     }
     /**
      * Link a virtual HID Output to mixxx control
-     *
      * @param {string} group Control group name
      * @param {string} name  Control name
      * @param {string} m_group Mapped group, must be a valid Mixxx control group name e.g. "[Channel1]"
@@ -2280,7 +2188,6 @@ class HIDController {
     }
     /**
      * Unlink a virtual HID Output from mixxx control
-     *
      * @param {string} group Mixxx control group name e.g. "[Channel1]"
      * @param {string} name Mixxx control name "VuMeter"
      * @param {controlCallback} callback Callback function for the control
@@ -2303,11 +2210,10 @@ class HIDController {
     }
     /**
      * Set output state to given value
-     *
      * @param {string} group Control group name e.g. "[Channel1]"
      * @param {string} name Control name "cue_indicator"
      * @param {number|boolean} value Value to set as new output state of the control
-     * @param {boolean} [send_packet=false] If true, the packet (an HID OutputReport) is send
+     * @param {boolean} [send_packet] If true, the packet (an HID OutputReport) is send
      *     immediately
      */
     setOutput(group, name, value, send_packet) {
@@ -2324,7 +2230,6 @@ class HIDController {
     }
     /**
      * Set Output to toggle between two values. Reset with setOutput(name,'off')
-     *
      * @param {string} group Control group name e.g. "[Channel1]"
      * @param {string} name Control name "cue_indicator"
      * @param toggle_value
@@ -2345,7 +2250,6 @@ class HIDController {
      * Don't use 'continue' and 'break' don't work as in normal loops,
      * because body is a function
      * 'return' statements in the body function behaves as 'continue' in normal loops
-     *
      * @param {Object.<string, any>} object
      * @param {function (string):void } body
      */


### PR DESCRIPTION
-TypedArray is no public JS keyword, we need to list them all, not only for createDataView, but also for it's callers
-Last 3 arguments of addControl are optional (but were not defined this way in JSDoc)
-length argument of parsePacket is only needed for a warning message -> make it optional

The other changes are automatic reformatting by pre-commit(including the removal of default values for optional arguments)