### PR TITLE
CMakeLists: Match arbitrary `arm64-osx` triplets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,7 +154,7 @@ if(APPLE)
     message(FATAL_ERROR "'xcode-select -v' failed with '${XCODE_SELECT_RESULT}'. You may need to install Xcode and run 'sudo xcode-select --install'.")
   endif()
 
-  if(VCPKG_TARGET_TRIPLET STREQUAL "arm64-osx-min1100")
+  if(VCPKG_TARGET_TRIPLET MATCHES "^arm64-osx")
     # Minimum macOS version for arm64 Support
     set(CMAKE_OSX_DEPLOYMENT_TARGET 11.0 CACHE STRING "Minimum macOS version the build will be able to run on")
     set(CMAKE_OSX_ARCHITECTURES arm64 CACHE STRING "The target architecture")


### PR DESCRIPTION
Compiling natively on an arm64 macOS machine will, by default, use `arm64-osx` as a vcpkg host triplet, which currently isn't recognized by the CMake configuration. Since macOS 11 is the first version that supports arm64, we'd want to use a deployment target of 11.0 on _all_ Apple Silicon machines instead of defaulting to 10.15. This branch fixes this by matching all triplets beginning with `arm64-osx`.