### PR TITLE
CMakeLists: Default `QT6` to `ON`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,7 @@ if(NOT CMAKE_CONFIGURATION_TYPES)
   endif()
 endif()
 
-option(QT6 "Build with Qt6" OFF)
+option(QT6 "Build with Qt6" ON)
 option(QML "Build with QML" OFF)
 option(QOPENGL "Use QOpenGLWindow based widget instead of QGLWidget" ON)
 


### PR DESCRIPTION
Given that

- #11892 

was recently merged and that the 2.5 vcpkg environments now ship Qt 6, we should set `-DQT6=ON` by default, both for consistency and to eliminate another configuration gotcha. This should also remove the need to set this explicitly in CI (though I didn't remove those here to keep the PR focused and since the workflows might be intentionally explicit).

Of course, developers can still set `-DQT6=OFF` to build with Qt 5.