### PR TITLE
Install Angle DLLs via CMake config mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1803,14 +1803,18 @@ if(MSVC)
   )
 endif()
 
-if(WIN32 AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+if(WIN32)
   # Qt 5 loads these ANGLE DLLs at runtime if the graphics driver is on the ignore list.
   # It does not work with Debug, because the debug version is compiled without the a d suffix
   find_package(unofficial-angle CONFIG REQUIRED)
   install(IMPORTED_RUNTIME_ARTIFACTS
     unofficial::angle::libEGL
     unofficial::angle::libGLESv2
-    DESTINATION "${MIXXX_INSTALL_BINDIR}")
+    CONFIGURATIONS RelWithDebInfo Release
+    DESTINATION "${MIXXX_INSTALL_BINDIR}"
+    RUNTIME_DEPENDENCY_SET mixxx
+    COMPONENT applocal)
+  set(APPLOCAL_COMPONENT_DEFINED true)
 endif()
 
 #
@@ -3188,6 +3192,14 @@ if(WAVPACK)
   target_sources(mixxx-lib PRIVATE src/sources/soundsourcewv.cpp)
   target_compile_definitions(mixxx-lib PUBLIC __WV__)
   target_link_libraries(mixxx-lib PRIVATE WavPack::wavpack)
+endif()
+
+if (APPLOCAL_COMPONENT_DEFINED)
+    set(CPACK_COMPONENT_applocal_HIDDEN TRUE)
+    # In order to run Mixx from the build directory install applocal components
+    add_custom_command(
+        TARGET mixxx POST_BUILD
+        COMMAND "${CMAKE_COMMAND}" -DCOMPONENT=applocal -DCMAKE_INSTALL_PREFIX="${CMAKE_CURRENT_BINARY_DIR}" -P cmake_install.cmake)
 endif()
 
 # Configure file with build options

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1803,13 +1803,14 @@ if(MSVC)
   )
 endif()
 
-if(WIN32)
-  # Qt 5 loads these ANGLE DLLs at runtime if the graphics driver is blocklisted.
-  # Qt does not link these and vcpkg does not build them as a dependency of Qt,
-  # so copy them manually.
-  find_file(EGL_DLL libEGL.dll PATH_SUFFIXES ${CMAKE_INSTALL_BINDIR})
-  find_file(GLESv2_DLL libGLESv2.dll PATH_SUFFIXES ${CMAKE_INSTALL_BINDIR})
-  install(FILES ${EGL_DLL} ${GLESv2_DLL} DESTINATION "${MIXXX_INSTALL_BINDIR}")
+if(WIN32 AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+  # Qt 5 loads these ANGLE DLLs at runtime if the graphics driver is on the ignore list.
+  # It does not work with Debug, because the debug version is compiled without the a d suffix
+  find_package(unofficial-angle CONFIG REQUIRED)
+  install(IMPORTED_RUNTIME_ARTIFACTS
+    unofficial::angle::libEGL
+    unofficial::angle::libGLESv2
+    DESTINATION "${MIXXX_INSTALL_BINDIR}")
 endif()
 
 #


### PR DESCRIPTION
This fixes parts from https://github.com/mixxxdj/mixxx/issues/11641
installing the debug libraries when the a debug build has been performed. 
