### PR TITLE
File Access fix

### DIFF
--- a/src/library/coverart.cpp
+++ b/src/library/coverart.cpp
@@ -106,8 +106,7 @@ QDebug operator<<(QDebug dbg, const CoverInfoRelative& info) {
             << '}';
 }
 
-CoverInfo::LoadedImage CoverInfo::loadImage(
-        const SecurityTokenPointer& pTrackLocationToken) const {
+CoverInfo::LoadedImage CoverInfo::loadImage(TrackPointer pTrack) const {
     LoadedImage loadedImage(LoadedImage::Result::ErrorUnknown);
     if (type == CoverInfo::METADATA) {
         VERIFY_OR_DEBUG_ASSERT(!trackLocation.isEmpty()) {
@@ -115,10 +114,12 @@ CoverInfo::LoadedImage CoverInfo::loadImage(
             return loadedImage;
         }
         loadedImage.location = trackLocation;
-        loadedImage.image = CoverArtUtils::extractEmbeddedCover(
-                mixxx::FileAccess(
-                        mixxx::FileInfo(trackLocation),
-                        pTrackLocationToken));
+        if (pTrack) {
+            loadedImage.image = CoverArtUtils::extractEmbeddedCover(pTrack);
+        } else {
+            loadedImage.image = CoverArtUtils::extractEmbeddedCover(
+                    mixxx::FileAccess(mixxx::FileInfo(trackLocation)));
+        }
         if (loadedImage.image.isNull()) {
             // TODO: extractEmbeddedCover() should indicate if no image
             // is available or if loading the embedded image failed.
@@ -171,8 +172,7 @@ CoverInfo::LoadedImage CoverInfo::loadImage(
 }
 
 bool CoverInfo::refreshImageDigest(
-        const QImage& loadedImage,
-        const SecurityTokenPointer& pTrackLocationToken) {
+        const QImage& loadedImage) {
     if (!imageDigest().isEmpty()) {
         // Assume that a non-empty digest has been calculated from
         // the corresponding image. Otherwise we would refresh all
@@ -183,7 +183,7 @@ bool CoverInfo::refreshImageDigest(
     }
     QImage image = loadedImage;
     if (image.isNull()) {
-        image = loadImage(pTrackLocationToken).image;
+        image = loadImage(TrackPointer()).image;
     }
     if (image.isNull() && type != CoverInfo::NONE) {
         kLogger.warning()

--- a/src/library/coverart.cpp
+++ b/src/library/coverart.cpp
@@ -115,6 +115,7 @@ CoverInfo::LoadedImage CoverInfo::loadImage(TrackPointer pTrack) const {
         }
         loadedImage.location = trackLocation;
         if (pTrack) {
+            DEBUG_ASSERT(trackLocation == pTrack->getLocation());
             loadedImage.image = CoverArtUtils::extractEmbeddedCover(pTrack);
         } else {
             loadedImage.image = CoverArtUtils::extractEmbeddedCover(

--- a/src/library/coverart.h
+++ b/src/library/coverart.h
@@ -4,6 +4,7 @@
 #include <QString>
 #include <QtDebug>
 
+#include "track/track_decl.h"
 #include "util/cache.h"
 #include "util/color/rgbcolor.h"
 #include "util/imageutils.h"
@@ -175,16 +176,14 @@ class CoverInfo : public CoverInfoRelative {
                 : result(result) {
         }
     };
-    LoadedImage loadImage(
-            const SecurityTokenPointer& pTrackLocationToken = SecurityTokenPointer()) const;
+    LoadedImage loadImage(TrackPointer pTrack = {}) const;
 
     /// Verify the image digest and update it if necessary.
     /// If the corresponding image has already been loaded it
     /// could be provided as a parameter to avoid reloading
     /// if actually needed.
     bool refreshImageDigest(
-            const QImage& loadedImage = QImage(),
-            const SecurityTokenPointer& pTrackLocationToken = SecurityTokenPointer());
+            const QImage& loadedImage = QImage());
 
     QString trackLocation;
 };

--- a/src/library/coverartcache.cpp
+++ b/src/library/coverartcache.cpp
@@ -181,7 +181,7 @@ CoverArtCache::FutureResult CoverArtCache::loadCover(
     DEBUG_ASSERT(!res.coverInfoUpdated);
 
     auto loadedImage = coverInfo.loadImage(
-            pTrack ? pTrack->getFileAccess().token() : SecurityTokenPointer());
+            pTrack ? pTrack->getFileAccessToken() : SecurityTokenPointer());
     if (!loadedImage.image.isNull()) {
         // Refresh hash before resizing the original image!
         res.coverInfoUpdated = coverInfo.refreshImageDigest(loadedImage.image);

--- a/src/library/coverartcache.cpp
+++ b/src/library/coverartcache.cpp
@@ -180,8 +180,7 @@ CoverArtCache::FutureResult CoverArtCache::loadCover(
             signalWhenDone);
     DEBUG_ASSERT(!res.coverInfoUpdated);
 
-    auto loadedImage = coverInfo.loadImage(
-            pTrack ? pTrack->getFileAccessToken() : SecurityTokenPointer());
+    auto loadedImage = coverInfo.loadImage(pTrack);
     if (!loadedImage.image.isNull()) {
         // Refresh hash before resizing the original image!
         res.coverInfoUpdated = coverInfo.refreshImageDigest(loadedImage.image);

--- a/src/library/coverartutils.cpp
+++ b/src/library/coverartutils.cpp
@@ -209,17 +209,17 @@ CoverInfoRelative CoverInfoGuesser::guessCoverInfo(
 
 CoverInfoRelative CoverInfoGuesser::guessCoverInfoForTrack(
         TrackPointer pTrack) {
-    const auto fileAccess = pTrack->getFileAccess();
+    const auto fileInfo = pTrack->getFileInfo();
     if (kLogger.debugEnabled()) {
         kLogger.debug()
                 << "Guessing cover art for track"
-                << fileAccess.info();
+                << fileInfo;
     }
 
     QImage embeddedCover = CoverArtUtils::extractEmbeddedCover(pTrack);
 
     return guessCoverInfo(
-            fileAccess.info(),
+            fileInfo,
             pTrack->getAlbum(),
             embeddedCover);
 }

--- a/src/library/coverartutils.cpp
+++ b/src/library/coverartutils.cpp
@@ -56,6 +56,18 @@ QImage CoverArtUtils::extractEmbeddedCover(
     return image;
 }
 
+QImage CoverArtUtils::extractEmbeddedCover(
+        TrackPointer pTrack) {
+    QImage image;
+    // Both resetMissingTagMetadata = false/true have the same effect
+    constexpr auto resetMissingTagMetadata = false;
+    SoundSourceProxy(pTrack).importTrackMetadataAndCoverImage(
+            nullptr,
+            &image,
+            resetMissingTagMetadata);
+    return image;
+}
+
 //static
 QList<QFileInfo> CoverArtUtils::findPossibleCoversInFolder(const QString& folder) {
     // Search for image files in the track directory.
@@ -204,7 +216,7 @@ CoverInfoRelative CoverInfoGuesser::guessCoverInfoForTrack(
                 << fileAccess.info();
     }
 
-    QImage embeddedCover = CoverArtUtils::extractEmbeddedCover(fileAccess);
+    QImage embeddedCover = CoverArtUtils::extractEmbeddedCover(pTrack);
 
     return guessCoverInfo(
             fileAccess.info(),

--- a/src/library/coverartutils.cpp
+++ b/src/library/coverartutils.cpp
@@ -46,8 +46,9 @@ QString CoverArtUtils::supportedCoverArtExtensionsRegex() {
 QImage CoverArtUtils::extractEmbeddedCover(
         mixxx::FileAccess trackFileAccess) {
     QImage image;
-    // Both resetMissingTagMetadata = false/true have the same effect
-    constexpr auto resetMissingTagMetadata = false;
+    // Since pTrackMetadataBoth is null, resetMissingTagMetadata
+    // has no effect
+    const auto resetMissingTagMetadata = false;
     SoundSourceProxy::importTrackMetadataAndCoverImageFromFile(
             std::move(trackFileAccess),
             nullptr,
@@ -59,8 +60,9 @@ QImage CoverArtUtils::extractEmbeddedCover(
 QImage CoverArtUtils::extractEmbeddedCover(
         TrackPointer pTrack) {
     QImage image;
-    // Both resetMissingTagMetadata = false/true have the same effect
-    constexpr auto resetMissingTagMetadata = false;
+    // Since pTrackMetadataBoth is null, resetMissingTagMetadata
+    // has no effect
+    const auto resetMissingTagMetadata = false;
     SoundSourceProxy(pTrack).importTrackMetadataAndCoverImage(
             nullptr,
             &image,

--- a/src/library/coverartutils.h
+++ b/src/library/coverartutils.h
@@ -30,6 +30,8 @@ class CoverArtUtils {
     // Extracts the first cover art image embedded within the file.
     static QImage extractEmbeddedCover(
             mixxx::FileAccess trackFileAccess);
+    static QImage extractEmbeddedCover(
+            TrackPointer pTrack);
 
     static QStringList supportedCoverArtExtensions();
     static QString supportedCoverArtExtensionsRegex();

--- a/src/library/coverartutils.h
+++ b/src/library/coverartutils.h
@@ -78,11 +78,10 @@ class CoverInfoGuesser {
 
     // Extracts an embedded cover image if available and guesses
     // the cover art for the provided track.
-    CoverInfoRelative guessCoverInfoForTrack(
-            const Track& track);
+    CoverInfoRelative guessCoverInfoForTrack(TrackPointer pTrack);
 
     void guessAndSetCoverInfoForTrack(
-            Track& track);
+            TrackPointer pTrack);
     void guessAndSetCoverInfoForTracks(
             const TrackPointerList& tracks);
 

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -2232,13 +2232,11 @@ TrackPointer TrackDAO::getOrAddTrack(
     return pTrack;
 }
 
-mixxx::FileAccess TrackDAO::relocateCachedTrack(
-        TrackId trackId,
-        mixxx::FileAccess fileAccess) {
+mixxx::FileAccess TrackDAO::relocateCachedTrack(TrackId trackId) {
     QString trackLocation = getTrackLocation(trackId);
     if (trackLocation.isEmpty()) {
         // not found
-        return fileAccess;
+        return mixxx::FileAccess();
     } else {
         return mixxx::FileAccess(mixxx::FileInfo(trackLocation));
     }

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -683,30 +683,30 @@ bool insertTrackLibrary(
 
 TrackId TrackDAO::addTracksAddTrack(const TrackPointer& pTrack, bool unremove) {
     DEBUG_ASSERT(pTrack);
-    const auto fileAccess = pTrack->getFileAccess();
+    const mixxx::FileInfo fileInfo = pTrack->getFileInfo();
 
     if (!(m_pQueryLibraryInsert || m_pQueryTrackLocationInsert ||
                 m_pQueryLibrarySelect || m_pQueryTrackLocationSelect)) {
         qDebug() << "TrackDAO::addTracksAddTrack: needed SqlQuerys have not "
                     "been prepared. Skipping track"
-                 << fileAccess.info().location();
+                 << fileInfo.location();
         DEBUG_ASSERT("Failed query");
         return TrackId();
     }
 
     qDebug() << "TrackDAO: Adding track"
-             << fileAccess.info().location();
+             << fileInfo.location();
 
     TrackId trackId;
 
     // Insert the track location into the corresponding table. This will fail
     // silently if the location is already in the table because it has a UNIQUE
     // constraint.
-    if (!insertTrackLocation(m_pQueryTrackLocationInsert.get(), fileAccess.info())) {
+    if (!insertTrackLocation(m_pQueryTrackLocationInsert.get(), fileInfo)) {
         DEBUG_ASSERT(pTrack->getDateAdded().isValid());
         // Inserting into track_locations failed, so the file already
         // exists. Query for its trackLocationId.
-        m_pQueryTrackLocationSelect->bindValue(":location", fileAccess.info().location());
+        m_pQueryTrackLocationSelect->bindValue(":location", fileInfo.location());
         if (!m_pQueryTrackLocationSelect->exec()) {
             // We can't even select this, something is wrong.
             LOG_FAILED_QUERY(*m_pQueryTrackLocationSelect)
@@ -729,7 +729,7 @@ TrackId TrackDAO::addTracksAddTrack(const TrackPointer& pTrack, bool unremove) {
         if (!m_pQueryLibrarySelect->exec()) {
             LOG_FAILED_QUERY(*m_pQueryLibrarySelect)
                     << "Failed to query existing track: "
-                    << fileAccess.info().location();
+                    << fileInfo.location();
             return TrackId();
         }
         if (m_queryLibraryIdColumn == UndefinedRecordIndex) {
@@ -756,7 +756,7 @@ TrackId TrackDAO::addTracksAddTrack(const TrackPointer& pTrack, bool unremove) {
             if (!m_pQueryLibraryUpdate->exec()) {
                 LOG_FAILED_QUERY(*m_pQueryLibraryUpdate)
                         << "Failed to unremove existing track: "
-                        << fileAccess.info().location();
+                        << fileInfo.location();
                 return TrackId();
             }
         }
@@ -792,7 +792,7 @@ TrackId TrackDAO::addTracksAddTrack(const TrackPointer& pTrack, bool unremove) {
                     trackRecord,
                     pTrack->getBeats(),
                     trackLocationId,
-                    fileAccess.info(),
+                    fileInfo,
                     trackDateAdded)) {
             return TrackId();
         }

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -196,9 +196,7 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
                                         QSet<TrackId>* pTracksChanged);
 
     // Callback for GlobalTrackCache
-    mixxx::FileAccess relocateCachedTrack(
-            TrackId trackId,
-            mixxx::FileAccess fileAccess) override;
+    mixxx::FileAccess relocateCachedTrack(TrackId trackId) override;
 
     CueDAO& m_cueDao;
     PlaylistDAO& m_playlistDao;

--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -229,8 +229,7 @@ void DlgCoverArtFullSize::slotReloadCoverArt() {
         return;
     }
     slotCoverInfoSelected(
-            CoverInfoGuesser().guessCoverInfoForTrack(
-                    *m_pLoadedTrack));
+            CoverInfoGuesser().guessCoverInfoForTrack(m_pLoadedTrack));
 }
 
 void DlgCoverArtFullSize::slotCoverInfoSelected(

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -533,7 +533,7 @@ void DlgTrackInfo::slotReloadCoverArt() {
     }
     slotCoverInfoSelected(
             CoverInfoGuesser().guessCoverInfoForTrack(
-                    *m_pLoadedTrack));
+                    m_pLoadedTrack));
 }
 
 void DlgTrackInfo::slotCoverInfoSelected(const CoverInfoRelative& coverInfo) {

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -771,9 +771,9 @@ void DlgTrackInfo::slotImportMetadataFromFile() {
     if (importResult != mixxx::MetadataSource::ImportResult::Succeeded) {
         return;
     }
-    auto fileAccess = m_pLoadedTrack->getFileAccess();
+    const mixxx::FileInfo fileInfo = m_pLoadedTrack->getFileInfo();
     auto guessedCoverInfo = CoverInfoGuesser().guessCoverInfo(
-            fileAccess.info(),
+            fileInfo,
             trackMetadata.getAlbumInfo().getTitle(),
             coverImage);
     trackRecord.replaceMetadataFromSource(
@@ -783,7 +783,7 @@ void DlgTrackInfo::slotImportMetadataFromFile() {
             std::move(guessedCoverInfo));
     replaceTrackRecord(
             std::move(trackRecord),
-            fileAccess.info().location());
+            fileInfo.location());
 }
 
 void DlgTrackInfo::slotTrackChanged(TrackId trackId) {

--- a/src/track/globaltrackcache.cpp
+++ b/src/track/globaltrackcache.cpp
@@ -341,15 +341,13 @@ void GlobalTrackCache::relocateTracks(
                 fileAccess.info(),
                 plainPtr->getId());
         if (!trackRef.hasCanonicalLocation() && trackRef.hasId() && pRelocator) {
-            auto relocatedFileAccess = pRelocator->relocateCachedTrack(
-                    trackRef.getId(),
-                    fileAccess);
-            if (fileAccess.info() != relocatedFileAccess.info()) {
+            auto relocatedFileAccess = pRelocator->relocateCachedTrack(trackRef.getId());
+            if (relocatedFileAccess.info().hasLocation() &&
+                    fileAccess.info() != relocatedFileAccess.info()) {
                 plainPtr->relocate(relocatedFileAccess);
                 trackRef = TrackRef::fromFileInfo(
                         relocatedFileAccess.info(),
                         trackRef.getId());
-                fileAccess = std::move(relocatedFileAccess);
             }
         }
         if (!trackRef.hasCanonicalLocation()) {

--- a/src/track/globaltrackcache.cpp
+++ b/src/track/globaltrackcache.cpp
@@ -336,14 +336,12 @@ void GlobalTrackCache::relocateTracks(
             ++i) {
         const QString oldCanonicalLocation = i->first;
         Track* plainPtr = i->second->getPlainPtr();
-        auto fileAccess = plainPtr->getFileAccess();
-        TrackRef trackRef = TrackRef::fromFileInfo(
-                fileAccess.info(),
-                plainPtr->getId());
+        const mixxx::FileInfo fileInfo = plainPtr->getFileInfo();
+        TrackRef trackRef = TrackRef::fromFileInfo(fileInfo, plainPtr->getId());
         if (!trackRef.hasCanonicalLocation() && trackRef.hasId() && pRelocator) {
             auto relocatedFileAccess = pRelocator->relocateCachedTrack(trackRef.getId());
             if (relocatedFileAccess.info().hasLocation() &&
-                    fileAccess.info() != relocatedFileAccess.info()) {
+                    fileInfo != relocatedFileAccess.info()) {
                 plainPtr->relocate(relocatedFileAccess);
                 trackRef = TrackRef::fromFileInfo(
                         relocatedFileAccess.info(),

--- a/src/track/globaltrackcache.h
+++ b/src/track/globaltrackcache.h
@@ -26,9 +26,7 @@ private:
     friend class GlobalTrackCache;
     // Try to determine and return the relocated file info
     // or otherwise return just the provided file info.
-    virtual mixxx::FileAccess relocateCachedTrack(
-            TrackId trackId,
-            mixxx::FileAccess fileAccess) = 0;
+    virtual mixxx::FileAccess relocateCachedTrack(TrackId trackId) = 0;
 
   protected:
     virtual ~GlobalTrackCacheRelocator() = default;

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -81,7 +81,7 @@ class Track : public QObject {
     mixxx::FileInfo getFileInfo() const {
         // Copying mixxx::FileInfo based on QFileInfo is thread-safe due to implicit sharing,
         // i.e. no locking needed.
-        static_assert(sizeof(QSharedDataPointer<int>) == sizeof(mixxx::FileInfo));
+        static_assert(mixxx::FileInfo::isQFileInfo());
         return m_fileAccess.info();
     }
 

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -78,12 +78,6 @@ class Track : public QObject {
     Q_PROPERTY(QString titleInfo READ getTitleInfo STORED false NOTIFY infoChanged)
     Q_PROPERTY(QDateTime sourceSynchronizedAt READ getSourceSynchronizedAt STORED false)
 
-    SecurityTokenPointer getFileAccessToken() const {
-        // Copying a QSharedPointer is thread-safe
-        // i.e. no locking needed.
-        return m_fileAccess.token();
-    }
-
     mixxx::FileInfo getFileInfo() const {
         // Copying mixxx::FileInfo based on QFileInfo is thread-safe due to implicit sharing,
         // i.e. no locking needed.

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -78,14 +78,16 @@ class Track : public QObject {
     Q_PROPERTY(QString titleInfo READ getTitleInfo STORED false NOTIFY infoChanged)
     Q_PROPERTY(QDateTime sourceSynchronizedAt READ getSourceSynchronizedAt STORED false)
 
-    mixxx::FileAccess getFileAccess() const {
-        // Copying QFileInfo is thread-safe due to implicit sharing,
+    SecurityTokenPointer getFileAccessToken() const {
+        // Copying a QSharedPointer is thread-safe
         // i.e. no locking needed.
-        return m_fileAccess;
+        return m_fileAccess.token();
     }
+
     mixxx::FileInfo getFileInfo() const {
-        // Copying QFileInfo is thread-safe due to implicit sharing,
+        // Copying mixxx::FileInfo based on QFileInfo is thread-safe due to implicit sharing,
         // i.e. no locking needed.
+        static_assert(sizeof(QSharedDataPointer<int>) == sizeof(mixxx::FileInfo));
         return m_fileAccess.info();
     }
 

--- a/src/util/fileinfo.h
+++ b/src/util/fileinfo.h
@@ -258,6 +258,8 @@ class FileInfo final {
 
     // This can be used to assert that the object is thread-safe copyable like QFileInfo
     static constexpr bool isQFileInfo() {
+        // This only works because Qt's implicit sharing allows copies to be
+        // threadsafe and this class only consists of a single QFileInfo member.
         // Additional member variables will violate this assumption
         return (sizeof(QFileInfo) == sizeof(mixxx::FileInfo) &&
                 std::is_same_v<decltype(m_fileInfo), QFileInfo>);

--- a/src/util/fileinfo.h
+++ b/src/util/fileinfo.h
@@ -8,6 +8,7 @@
 #include <QFileInfo>
 #include <QUrl>
 #include <QtDebug>
+#include <type_traits>
 
 #include "util/assert.h"
 
@@ -253,6 +254,13 @@ class FileInfo final {
     /// has been chosen deliberately.
     qint64 sizeInBytes() const {
         return m_fileInfo.size();
+    }
+
+    // This can be used to assert that the object is thread-safe copyable like QFileInfo
+    static constexpr bool isQFileInfo() {
+        // Additional member variables will violate this assumption
+        return (sizeof(QFileInfo) == sizeof(mixxx::FileInfo) &&
+                std::is_same_v<decltype(m_fileInfo), QFileInfo>);
     }
 
     friend bool operator==(const FileInfo& lhs, const FileInfo& rhs) {

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -2344,7 +2344,7 @@ class ReloadCoverInfoTrackPointerOperation : public mixxx::TrackPointerOperation
   private:
     void doApply(
             const TrackPointer& pTrack) const override {
-        m_coverInfoGuesser.guessAndSetCoverInfoForTrack(*pTrack);
+        m_coverInfoGuesser.guessAndSetCoverInfoForTrack(pTrack);
     }
 
     mutable CoverInfoGuesser m_coverInfoGuesser;


### PR DESCRIPTION
Due to refactoring the thread safe access of the Tracks File access object is no longer thread safe. 
https://github.com/mixxxdj/mixxx/blob/2.4/src/track/track.h#L82

I have removed this function and pass the thread safe TrackPointer instead. 
This has the big advantage, that we can use it directly with the sound source for extracting the cover and don't need to use the location of the track outside the track locking it up again from the Track cache later. 

In https://github.com/mixxxdj/mixxx/issues/11131 we have seen that the independent track location was empty in the concurrent case. 

I don't think that getFileAccess() was the cause or even a real Problem, because it is almost all the time read only, but hopefully the additional ASSERTS and the streamlined control flow helps to find the real root cause.

(I am still not able to produce the issue) 

@JoergAtGithub can you check this out with debug asserts fatal? 