### PR TITLE
refactor(util/timer): cleanup includes

### DIFF
--- a/src/util/battery/battery.h
+++ b/src/util/battery/battery.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "util/timer.h"
+#include <QObject>
+#include <QTimer>
 
 class Battery : public QObject {
     Q_OBJECT

--- a/src/util/battery/batterylinux.cpp
+++ b/src/util/battery/batterylinux.cpp
@@ -7,6 +7,7 @@
 #include <QtDebug>
 
 #include "moc_batterylinux.cpp"
+#include "util/assert.h"
 
 BatteryLinux::BatteryLinux(QObject* pParent)
     : Battery(pParent),

--- a/src/util/timer.cpp
+++ b/src/util/timer.cpp
@@ -1,9 +1,6 @@
 #include "util/timer.h"
 
-#include "moc_timer.cpp"
 #include "util/experiment.h"
-#include "util/time.h"
-#include "waveform/guitick.h"
 
 Timer::Timer(QString key, Stat::ComputeFlags compute)
         : m_key(std::move(key)),

--- a/src/util/timer.h
+++ b/src/util/timer.h
@@ -1,13 +1,11 @@
 #pragma once
 
-#include <QObject>
+#include <QString>
 #include <QStringView>
 #include <optional>
 
-#include "control/controlproxy.h"
 #include "util/cmdlineargs.h"
 #include "util/duration.h"
-#include "util/parented_ptr.h"
 #include "util/performancetimer.h"
 #include "util/stat.h"
 


### PR DESCRIPTION
I noticed an AutoMoc warning during the build and got annoyed by it. Turns out there was an unnecessary `#include "moc_timer.cpp"`. While I was at it, I also cleaned up the rest of the headers. 