### PR TITLE
DlgPrefSound: Fix fetching of sample rate

### DIFF
--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -608,7 +608,11 @@ void DlgPrefSound::updateAudioBufferSizes(int sampleRateIndex) {
                 static_cast<unsigned int>(SoundManagerConfig::
                                 JackAudioBufferSizeIndex::Size4096fpp));
     } else {
-        double sampleRate = sampleRateComboBox->itemData(sampleRateIndex).toDouble();
+        DEBUG_ASSERT(sampleRateComboBox->itemData(sampleRateIndex)
+                             .canConvert<mixxx::audio::SampleRate>());
+        double sampleRate = sampleRateComboBox->itemData(sampleRateIndex)
+                                    .value<mixxx::audio::SampleRate>()
+                                    .toDouble();
         unsigned int framesPerBuffer = 1; // start this at 0 and inf loop happens
         // we don't want to display any sub-1ms buffer sizes (well maybe we do but I
         // don't right now!), so we iterate over all the buffer sizes until we


### PR DESCRIPTION
Fixes #11949, i.e. causes audio buffer sizes to be displayed correctly again:

![image](https://github.com/mixxxdj/mixxx/assets/30873659/58b47c45-41cf-45c8-85b0-4607dad89f66)

The issue was that the sample rate combo box was still queried for a double, while underlying data already used the `SampleRate` type, causing it to presumably default to 0 and thus result in divisions by zero. This was likely an oversight in #11904.