### PR TITLE
CMakeLists: Always default `CMAKE_BUILD_TYPE` to `RelWithDebInfo`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,11 +110,6 @@ set(X_VCPKG_APPLOCAL_DEPS_INSTALL ON CACHE BOOL "Automatically copy dependencies
 # Set a default build type if none was specified
 # See https://blog.kitware.com/cmake-and-the-default-build-type/ for details.
 set(default_build_type "RelWithDebInfo")
-if(EXISTS "${CMAKE_SOURCE_DIR}/.git" AND NOT WIN32)
-  # On Windows, Debug builds are linked to unoptimized libs
-  # generating unusable slow Mixxx builds.
-  set(default_build_type "Debug")
-endif()
 
 if(NOT CMAKE_CONFIGURATION_TYPES)
   if(NOT CMAKE_BUILD_TYPE)


### PR DESCRIPTION
As discussed in https://github.com/mixxxdj/mixxx/pull/11871#issuecomment-1694760590, we should default to release builds on all platforms since debug builds of Qt (especially Qt 6) are too slow even for development. Currently this is only done on Windows.

cc @daschuer 