### PR TITLE
SearchQuery: Add ability to filter tracks in Mixxx library by iTunes playlist

### DIFF
--- a/src/library/itunes/itunesdao.cpp
+++ b/src/library/itunes/itunesdao.cpp
@@ -64,12 +64,12 @@ void ITunesDAO::initialize(const QSqlDatabase& database) {
     m_insertPlaylistTrackQuery.prepare(QStringLiteral(
             "INSERT INTO %1 (playlist_id, track_id, "
             "position) VALUES (:playlist_id, :track_id, :position)")
-                                               .arg(ITUNES_PLAYLIST_TRACKS_TABLE));
+                    .arg(ITUNES_PLAYLIST_TRACKS_TABLE));
 
     m_applyPathMappingQuery.prepare(QStringLiteral(
             "UPDATE %1 SET location = replace( location, "
             ":itunes_path, :mixxx_path )")
-                                            .arg(ITUNES_LIBRARY_TABLE));
+                    .arg(ITUNES_LIBRARY_TABLE));
 
     m_isDatabaseInitialized = true;
 }

--- a/src/library/itunes/itunesdao.cpp
+++ b/src/library/itunes/itunesdao.cpp
@@ -2,10 +2,12 @@
 
 #include <QObject>
 #include <QSqlQuery>
+#include <QStringLiteral>
 #include <gsl/pointers>
 
 #include "library/itunes/ituneslocalhosttoken.h"
 #include "library/itunes/itunespathmapping.h"
+#include "library/itunes/itunesschema.h"
 #include "library/queryutil.h"
 #include "library/treeitem.h"
 
@@ -47,22 +49,27 @@ void ITunesDAO::initialize(const QSqlDatabase& database) {
     m_applyPathMappingQuery = QSqlQuery(database);
 
     m_insertTrackQuery.prepare(
-            "INSERT INTO itunes_library (id, artist, title, album, "
-            "album_artist, genre, grouping, year, duration, "
-            "location, rating, comment, tracknumber, bpm, bitrate) "
-            "VALUES (:id, :artist, :title, :album, :album_artist, "
-            ":genre, :grouping, :year, :duration, :location, "
-            ":rating, :comment, :tracknumber, :bpm, :bitrate)");
+            QStringLiteral("INSERT INTO %1 (id, artist, title, album, "
+                           "album_artist, genre, grouping, year, duration, "
+                           "location, rating, comment, tracknumber, bpm, bitrate) "
+                           "VALUES (:id, :artist, :title, :album, :album_artist, "
+                           ":genre, :grouping, :year, :duration, :location, "
+                           ":rating, :comment, :tracknumber, :bpm, :bitrate)")
+                    .arg(ITUNES_LIBRARY_TABLE));
 
-    m_insertPlaylistQuery.prepare("INSERT INTO itunes_playlists (id, name) VALUES (:id, :name)");
+    m_insertPlaylistQuery.prepare(
+            QStringLiteral("INSERT INTO %1 (id, name) VALUES (:id, :name)")
+                    .arg(ITUNES_PLAYLISTS_TABLE));
 
-    m_insertPlaylistTrackQuery.prepare(
-            "INSERT INTO itunes_playlist_tracks (playlist_id, track_id, "
-            "position) VALUES (:playlist_id, :track_id, :position)");
+    m_insertPlaylistTrackQuery.prepare(QStringLiteral(
+            "INSERT INTO %1 (playlist_id, track_id, "
+            "position) VALUES (:playlist_id, :track_id, :position)")
+                                               .arg(ITUNES_PLAYLIST_TRACKS_TABLE));
 
-    m_applyPathMappingQuery.prepare(
-            "UPDATE itunes_library SET location = replace( location, "
-            ":itunes_path, :mixxx_path )");
+    m_applyPathMappingQuery.prepare(QStringLiteral(
+            "UPDATE %1 SET location = replace( location, "
+            ":itunes_path, :mixxx_path )")
+                                            .arg(ITUNES_LIBRARY_TABLE));
 
     m_isDatabaseInitialized = true;
 }

--- a/src/library/itunes/itunesfeature.cpp
+++ b/src/library/itunes/itunesfeature.cpp
@@ -17,6 +17,7 @@
 #include "library/itunes/itunesdao.h"
 #include "library/itunes/itunesimporter.h"
 #include "library/itunes/itunesplaylistmodel.h"
+#include "library/itunes/itunesschema.h"
 #include "library/itunes/itunestrackmodel.h"
 #include "library/itunes/itunesxmlimporter.h"
 #include "library/library.h"
@@ -63,7 +64,7 @@ ITunesFeature::ITunesFeature(Library* pLibrary, UserSettingsPointer pConfig)
         : BaseExternalLibraryFeature(pLibrary, pConfig, QStringLiteral("itunes")),
           m_pSidebarModel(make_parented<TreeItemModel>(this)),
           m_cancelImport(false) {
-    QString tableName = "itunes_library";
+    QString tableName = ITUNES_LIBRARY_TABLE;
     QString idColumn = "id";
     QStringList columns = {
             "id",
@@ -100,6 +101,8 @@ ITunesFeature::ITunesFeature(Library* pLibrary, UserSettingsPointer pConfig)
             false);
     m_pITunesTrackModel = new ITunesTrackModel(this,
             m_pLibrary->trackCollectionManager(),
+            "mixxx.db.model.itunes",
+            ITUNES_LIBRARY_TABLE,
             m_trackSource);
     m_pITunesPlaylistModel = new ITunesPlaylistModel(this,
             m_pLibrary->trackCollectionManager(),
@@ -138,8 +141,8 @@ ITunesFeature::createPlaylistModelForPlaylist(const QString& playlist) {
     auto pModel = std::make_unique<BaseExternalPlaylistModel>(this,
             m_pLibrary->trackCollectionManager(),
             "mixxx.db.model.itunes_playlist",
-            "itunes_playlists",
-            "itunes_playlist_tracks",
+            ITUNES_PLAYLISTS_TABLE,
+            ITUNES_PLAYLIST_TRACKS_TABLE,
             m_trackSource);
     pModel->setPlaylist(playlist);
     return pModel;
@@ -175,9 +178,9 @@ void ITunesFeature::activate(bool forceReload) {
 
         //Delete all table entries of iTunes feature
         ScopedTransaction transaction(m_database);
-        clearTable("itunes_playlist_tracks");
-        clearTable("itunes_library");
-        clearTable("itunes_playlists");
+        clearTable(ITUNES_PLAYLIST_TRACKS_TABLE);
+        clearTable(ITUNES_LIBRARY_TABLE);
+        clearTable(ITUNES_PLAYLISTS_TABLE);
         transaction.commit();
 
         emit showTrackModel(m_pITunesTrackModel);

--- a/src/library/itunes/itunesfeature.cpp
+++ b/src/library/itunes/itunesfeature.cpp
@@ -101,8 +101,6 @@ ITunesFeature::ITunesFeature(Library* pLibrary, UserSettingsPointer pConfig)
             false);
     m_pITunesTrackModel = new ITunesTrackModel(this,
             m_pLibrary->trackCollectionManager(),
-            "mixxx.db.model.itunes",
-            ITUNES_LIBRARY_TABLE,
             m_trackSource);
     m_pITunesPlaylistModel = new ITunesPlaylistModel(this,
             m_pLibrary->trackCollectionManager(),

--- a/src/library/itunes/itunesplaylistmodel.cpp
+++ b/src/library/itunes/itunesplaylistmodel.cpp
@@ -4,6 +4,7 @@
 #ifdef __IOS_ITUNES_LIBRARY__
 #include "library/itunes/itunesiostrackresolver.h"
 #endif
+#include "library/itunes/itunesschema.h"
 #include "moc_itunesplaylistmodel.cpp"
 
 ITunesPlaylistModel::ITunesPlaylistModel(QObject* parent,
@@ -12,8 +13,8 @@ ITunesPlaylistModel::ITunesPlaylistModel(QObject* parent,
         : BaseExternalPlaylistModel(parent,
                   pTrackCollectionManager,
                   "mixxx.db.model.itunes_playlist",
-                  "itunes_playlists",
-                  "itunes_playlist_tracks",
+                  ITUNES_PLAYLISTS_TABLE,
+                  ITUNES_PLAYLIST_TRACKS_TABLE,
                   trackSource) {
 }
 

--- a/src/library/itunes/itunesschema.h
+++ b/src/library/itunes/itunesschema.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <QString>
+
+#define ITUNES_LIBRARY_TABLE "itunes_library"
+#define ITUNES_PLAYLISTS_TABLE "itunes_playlists"
+#define ITUNES_PLAYLIST_TRACKS_TABLE "itunes_playlist_tracks"

--- a/src/library/itunes/itunesschema.h
+++ b/src/library/itunes/itunesschema.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <QString>
-
-#define ITUNES_LIBRARY_TABLE "itunes_library"
-#define ITUNES_PLAYLISTS_TABLE "itunes_playlists"
-#define ITUNES_PLAYLIST_TRACKS_TABLE "itunes_playlist_tracks"
+constexpr static auto ITUNES_LIBRARY_TABLE = "itunes_library";
+constexpr static auto ITUNES_PLAYLISTS_TABLE = "itunes_playlists";
+constexpr static auto ITUNES_PLAYLIST_TRACKS_TABLE = "itunes_playlist_tracks";

--- a/src/library/itunes/itunestrackmodel.cpp
+++ b/src/library/itunes/itunestrackmodel.cpp
@@ -2,6 +2,7 @@
 
 #include "library/baseexternaltrackmodel.h"
 #include "library/basetrackcache.h"
+#include "library/itunes/itunesschema.h"
 #ifdef __IOS_ITUNES_LIBRARY__
 #include "library/itunes/itunesiostrackresolver.h"
 #endif
@@ -18,7 +19,7 @@ ITunesTrackModel::ITunesTrackModel(QObject* parent,
         : BaseExternalTrackModel(parent,
                   pTrackCollectionManager,
                   "mixxx.db.model.itunes",
-                  "itunes_library",
+                  ITUNES_LIBRARY_TABLE,
                   trackSource) {
 }
 

--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -337,7 +337,8 @@ bool ExternalPlaylistFilterNode::match(const TrackPointer& pTrack) const {
             return false;
         }
 
-        DbFieldIndex trackIdColumn = query.record().indexOf("track_id");
+        DbFieldIndex trackIdColumn = query.record().indexOf(
+                QStringLiteral("%1.id").arg(LIBRARY_TABLE));
 
         while (query.next()) {
             m_matchingTrackIds.push_back(TrackId(query.fieldValue(trackIdColumn)));

--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -359,7 +359,8 @@ QString ExternalPlaylistFilterNode::toSql() const {
 
 QString ExternalPlaylistFilterNode::formatQuerySuffixForTrackIds() const {
     FieldEscaper escaper(m_database);
-    QString escapedPlaylistNameLike = escaper.escapeString(m_playlistNameLike);
+    QString escapedPlaylistNameLike = escaper.escapeString(
+            kSqlLikeMatchAll + m_playlistNameLike + kSqlLikeMatchAll);
     return QStringLiteral(
             "FROM %1 "
             "JOIN %2 ON %2.id = %1.playlist_id "

--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -311,15 +311,15 @@ QString NoCrateFilterNode::toSql() const {
 }
 
 ExternalPlaylistFilterNode::ExternalPlaylistFilterNode(const QSqlDatabase& database,
-        const QString& playlistNameLike,
-        const QString& externalPlaylistsTable,
-        const QString& externalPlaylistTracksTable,
-        const QString& externalLibraryTable)
+        QString playlistNameLike,
+        QString externalPlaylistsTable,
+        QString externalPlaylistTracksTable,
+        QString externalLibraryTable)
         : m_database(database),
-          m_playlistNameLike(playlistNameLike),
-          m_externalPlaylistsTable(externalPlaylistsTable),
-          m_externalPlaylistTracksTable(externalPlaylistTracksTable),
-          m_externalLibraryTable(externalLibraryTable) {
+          m_playlistNameLike(std::move(playlistNameLike)),
+          m_externalPlaylistsTable(std::move(externalPlaylistsTable)),
+          m_externalPlaylistTracksTable(std::move(externalPlaylistTracksTable)),
+          m_externalLibraryTable(std::move(externalLibraryTable)) {
 }
 
 bool ExternalPlaylistFilterNode::match(const TrackPointer& pTrack) const {

--- a/src/library/searchquery.h
+++ b/src/library/searchquery.h
@@ -140,10 +140,10 @@ class NoCrateFilterNode : public QueryNode {
 class ExternalPlaylistFilterNode : public QueryNode {
   public:
     ExternalPlaylistFilterNode(const QSqlDatabase& database,
-            const QString& playlistNameLike,
-            const QString& externalPlaylistsTable,
-            const QString& externalPlaylistTracksTable,
-            const QString& externalLibraryTable);
+            QString playlistNameLike,
+            QString externalPlaylistsTable,
+            QString externalPlaylistTracksTable,
+            QString externalLibraryTable);
 
     bool match(const TrackPointer& pTrack) const override;
     QString toSql() const override;

--- a/src/library/searchquery.h
+++ b/src/library/searchquery.h
@@ -137,6 +137,22 @@ class NoCrateFilterNode : public QueryNode {
     mutable std::vector<TrackId> m_matchingTrackIds;
 };
 
+class ITunesFilterNode : public QueryNode {
+  public:
+    ITunesFilterNode(const QSqlDatabase& database, const QString& playlistNameLike);
+
+    bool match(const TrackPointer& pTrack) const override;
+    QString toSql() const override;
+
+  private:
+    QSqlDatabase m_database;
+    QString m_playlistNameLike;
+    mutable bool m_matchInitialized;
+    mutable std::vector<TrackId> m_matchingTrackIds;
+
+    QString formatQuerySuffixForTrackIds() const;
+};
+
 class NumericFilterNode : public QueryNode {
   public:
     NumericFilterNode(const QStringList& sqlColumns, const QString& argument);

--- a/src/library/searchquery.h
+++ b/src/library/searchquery.h
@@ -137,9 +137,13 @@ class NoCrateFilterNode : public QueryNode {
     mutable std::vector<TrackId> m_matchingTrackIds;
 };
 
-class ITunesFilterNode : public QueryNode {
+class ExternalPlaylistFilterNode : public QueryNode {
   public:
-    ITunesFilterNode(const QSqlDatabase& database, const QString& playlistNameLike);
+    ExternalPlaylistFilterNode(const QSqlDatabase& database,
+            const QString& playlistNameLike,
+            const QString& externalPlaylistsTable,
+            const QString& externalPlaylistTracksTable,
+            const QString& externalLibraryTable);
 
     bool match(const TrackPointer& pTrack) const override;
     QString toSql() const override;
@@ -147,10 +151,18 @@ class ITunesFilterNode : public QueryNode {
   private:
     QSqlDatabase m_database;
     QString m_playlistNameLike;
+    QString m_externalPlaylistsTable;
+    QString m_externalPlaylistTracksTable;
+    QString m_externalLibraryTable;
     mutable bool m_matchInitialized;
     mutable std::vector<TrackId> m_matchingTrackIds;
 
     QString formatQuerySuffixForTrackIds() const;
+};
+
+class ITunesFilterNode : public ExternalPlaylistFilterNode {
+  public:
+    ITunesFilterNode(const QSqlDatabase& database, const QString& playlistNameLike);
 };
 
 class NumericFilterNode : public QueryNode {

--- a/src/library/searchqueryparser.cpp
+++ b/src/library/searchqueryparser.cpp
@@ -69,7 +69,7 @@ const QRegularExpression kSplitOnOrOperatorRegexp = QRegularExpression(
 
 SearchQueryParser::SearchQueryParser(TrackCollection* pTrackCollection, QStringList searchColumns)
         : m_pTrackCollection(pTrackCollection),
-          m_searchCratesAndExternal(false) {
+          m_searchCrates(false) {
     setSearchColumns(std::move(searchColumns));
 
     m_textFilters << "artist"
@@ -133,8 +133,8 @@ void SearchQueryParser::setSearchColumns(QStringList searchColumns) {
 
     // we need to create a filtered columns list that are handled differently
     for (int i = 0; i < m_queryColumns.size(); ++i) {
-        if (m_queryColumns[i] == "crate" || m_queryColumns[i] == "itunes") {
-            m_searchCratesAndExternal = true;
+        if (m_queryColumns[i] == "crate") {
+            m_searchCrates = true;
             m_queryColumns.removeAt(i);
             break;
         }
@@ -280,12 +280,10 @@ void SearchQueryParser::parseTokens(QStringList tokens,
                 // For untagged strings we search the track fields as well
                 // as the crate names the track is in. This allows the user
                 // to use crates like tags
-                if (m_searchCratesAndExternal) {
+                if (m_searchCrates) {
                     auto gNode = std::make_unique<OrNode>();
                     gNode->addNode(std::make_unique<CrateFilterNode>(
                                     &m_pTrackCollection->crates(), argument));
-                    gNode->addNode(std::make_unique<ITunesFilterNode>(
-                            m_pTrackCollection->database(), argument));
                     gNode->addNode(std::make_unique<TextFilterNode>(
                             m_pTrackCollection->database(), m_queryColumns, argument));
                     pNode = std::move(gNode);

--- a/src/library/searchqueryparser.h
+++ b/src/library/searchqueryparser.h
@@ -44,7 +44,7 @@ class SearchQueryParser {
 
     TrackCollection* m_pTrackCollection;
     QStringList m_queryColumns;
-    bool m_searchCrates;
+    bool m_searchCratesAndExternal;
     QStringList m_textFilters;
     QStringList m_numericFilters;
     QStringList m_specialFilters;

--- a/src/library/searchqueryparser.h
+++ b/src/library/searchqueryparser.h
@@ -44,7 +44,7 @@ class SearchQueryParser {
 
     TrackCollection* m_pTrackCollection;
     QStringList m_queryColumns;
-    bool m_searchCratesAndExternal;
+    bool m_searchCrates;
     QStringList m_textFilters;
     QStringList m_numericFilters;
     QStringList m_specialFilters;

--- a/src/test/searchqueryparsertest.cpp
+++ b/src/test/searchqueryparsertest.cpp
@@ -843,6 +843,25 @@ TEST_F(SearchQueryParserTest, HumanReadableDurationSearchwithRangeFilter) {
             qPrintable(pQuery->toSql()));
 }
 
+TEST_F(SearchQueryParserTest, ITunesFilter) {
+    auto pQuery(
+            m_parser.parseQuery("itunes:house", QString()));
+    EXPECT_STREQ(
+            qPrintable(QStringLiteral(
+                    "id IN (SELECT library.id "
+                    "FROM itunes_playlist_tracks "
+                    "JOIN itunes_playlists ON itunes_playlists.id = "
+                    "itunes_playlist_tracks.playlist_id "
+                    "JOIN itunes_library ON itunes_library.id = "
+                    "itunes_playlist_tracks.track_id "
+                    "JOIN track_locations ON track_locations.location = "
+                    "itunes_library.location "
+                    "JOIN library ON library.location = track_locations.id "
+                    "WHERE itunes_playlists.name LIKE '%house%' ORDER BY "
+                    "itunes_playlist_tracks.track_id)")),
+            qPrintable(pQuery->toSql()));
+}
+
 TEST_F(SearchQueryParserTest, CrateFilter) {
     // User's search term
     QString searchTerm = "test";


### PR DESCRIPTION
This adds a new filter node to the search query machinery, namely `ExternalPlaylistFilterNode` that matches the name of an external playlist, along with a 'reference implementation' `ITunesFilterNode` that uses the iTunes tables (though the mechanism is explicitly intended to be generic, so support for Serato, Traktor etc. could easily be added in the future).

Thus, if the user has an iTunes playlist named "House", queries like `itunes:house` or `itunes:house daft punk` will now explicitly search for tracks in that playlist in a similar way to the `crate` operator.

External tracks are matched with library tracks via their location (since external libraries generally use a different track indexing scheme). Consequentially, this only affects the case where the external tracks are in the user's Mixxx library too (not necessarily the case, but probably common enough to make this a worthwhile use case).

### To do

- [x] Perform fuzzy matching on the playlist name (instead of requiring the exact name)
- [x] Investigate whether this is performant enough to warrant the inclusion of the untagged `ITunesFilterNode` (if not, we might want to consider gating this behind the explicit `itunes` operator)
  - We'll require the `itunes:` operator for now to avoid any potential performance regressions in regular searches, but leave this open for revisiting it in the future (See 1a2fca195df0d7b085bcfdec293ea7c4b06a4196)
- [x] Add unit test

### Future Directions

- Add Serato, Traktor etc. support as mentioned above (likely pretty easy, would only require subclassing `ExternalPlaylistFilterNode` and adding the corresponding operator to `SearchQueryParser`)
- Filter by non-uniquified iTunes playlist name (see `ITunesDAO::uniquifyPlaylistName`, we might want to store the non-unique playlist name in a separate column, that would require a schema change though and also require us to abstract over the playlist name column in `ExternalPlaylistFilterNode` since other external playlist integrations may not necessarily have this machinery).