### PR TITLE
Remove offensive language (Pt. 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1072,7 +1072,7 @@
 * Library preferences: Uncheck Serato metadata export when file metadata export is unchecked
   [#11782](https://github.com/mixxxdj/mixxx/pull/11782)
   [#11226](https://github.com/mixxxdj/mixxx/issues/11226)
-* Denon MC6000MK2: Delete mapping for master gain
+* Denon MC6000MK2: Delete mapping for main gain
   [#11792](https://github.com/mixxxdj/mixxx/pull/11792)
 * Improve output in case of some failed file system operations
   [#11783](https://github.com/mixxxdj/mixxx/pull/11783)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -779,7 +779,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/engine/effects/engineeffectsmanager.cpp
   src/engine/enginebuffer.cpp
   src/engine/enginedelay.cpp
-  src/engine/enginemaster.cpp
+  src/engine/enginemixer.cpp
   src/engine/engineobject.cpp
   src/engine/enginepregain.cpp
   src/engine/enginesidechaincompressor.cpp
@@ -1856,7 +1856,7 @@ add_executable(mixxx-test
   src/test/enginebuffertest.cpp
   src/test/engineeffectsdelay_test.cpp
   src/test/enginefilterbiquadtest.cpp
-  src/test/enginemastertest.cpp
+  src/test/enginemixertest.cpp
   src/test/enginemicrophonetest.cpp
   src/test/enginesynctest.cpp
   src/test/fileinfo_test.cpp

--- a/res/linux/org.mixxx.Mixxx.metainfo.xml
+++ b/res/linux/org.mixxx.Mixxx.metainfo.xml
@@ -96,7 +96,7 @@
   Do not edit it manually.
   -->
   <releases>
-    <release version="2.4.0" type="development" date="2023-08-12" timestamp="1691865042">
+    <release version="2.4.0" type="development" date="2023-09-10" timestamp="1694376244">
       <description>
  <p>
   Cover Art
@@ -2005,7 +2005,7 @@
    #11226
   </li>
   <li>
-   Denon MC6000MK2: Delete mapping for master gain
+   Denon MC6000MK2: Delete mapping for main gain
    #11792
   </li>
   <li>

--- a/src/broadcast/broadcastmanager.cpp
+++ b/src/broadcast/broadcastmanager.cpp
@@ -9,7 +9,7 @@
 
 #include "broadcast/broadcastmanager.h"
 #include "broadcast/defs_broadcast.h"
-#include "engine/enginemaster.h"
+#include "engine/enginemixer.h"
 #include "engine/sidechain/enginenetworkstream.h"
 #include "engine/sidechain/enginesidechain.h"
 #include "moc_broadcastmanager.cpp"

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -13,7 +13,7 @@
 
 ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
         : QMenu(pParent) {
-    m_effectMasterOutputStr = tr("Main Output");
+    m_effectMainOutputStr = tr("Main Output");
     m_effectHeadphoneOutputStr = tr("Headphone Output");
     m_deckStr = tr("Deck %1");
     m_samplerStr = tr("Sampler %1");
@@ -894,8 +894,8 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                 m_effectUnitStr.arg(iEffectUnitNumber));
 
         addControl(effectUnitGroup, "group_[Master]_enable",
-                assignString + m_effectMasterOutputStr, // in ComboBox
-                assignString + m_effectMasterOutputStr, // description below
+                assignString + m_effectMainOutputStr, // in ComboBox
+                assignString + m_effectMainOutputStr, // description below
                 effectUnitGroups,
                 false,
                 groupDescriptionPrefix);

--- a/src/controllers/controlpickermenu.h
+++ b/src/controllers/controlpickermenu.h
@@ -103,7 +103,7 @@ class ControlPickerMenu : public QMenu {
 
     int addAvailableControl(const ConfigKey& key, const QString& title, const QString& description);
 
-    QString m_effectMasterOutputStr;
+    QString m_effectMainOutputStr;
     QString m_effectHeadphoneOutputStr;
     QString m_deckStr;
     QString m_previewdeckStr;

--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -13,7 +13,7 @@
 #include "controllers/keyboard/keyboardeventfilter.h"
 #include "database/mixxxdb.h"
 #include "effects/effectsmanager.h"
-#include "engine/enginemaster.h"
+#include "engine/enginemixer.h"
 #include "library/coverartcache.h"
 #include "library/library.h"
 #include "library/library_prefs.h"
@@ -258,7 +258,7 @@ void CoreServices::initialize(QApplication* pApp) {
     emit initializationProgressUpdate(20, tr("effects"));
     m_pEffectsManager = std::make_shared<EffectsManager>(pConfig, pChannelHandleFactory);
 
-    m_pEngine = std::make_shared<EngineMaster>(
+    m_pEngine = std::make_shared<EngineMixer>(
             pConfig,
             "[Master]",
             m_pEffectsManager.get(),
@@ -615,8 +615,8 @@ void CoreServices::finalize() {
     CLEAR_AND_CHECK_DELETED(m_pBroadcastManager);
 #endif
 
-    // EngineMaster depends on Config and m_pEffectsManager.
-    qDebug() << t.elapsed(false).debugMillisWithUnit() << "deleting EngineMaster";
+    // EngineMixer depends on Config and m_pEffectsManager.
+    qDebug() << t.elapsed(false).debugMillisWithUnit() << "deleting EngineMixer";
     CLEAR_AND_CHECK_DELETED(m_pEngine);
 
     qDebug() << t.elapsed(false).debugMillisWithUnit() << "deleting EffectsManager";

--- a/src/coreservices.h
+++ b/src/coreservices.h
@@ -14,7 +14,7 @@ class QApplication;
 class CmdlineArgs;
 class KeyboardEventFilter;
 class EffectsManager;
-class EngineMaster;
+class EngineMixer;
 class SoundManager;
 class PlayerManager;
 class RecordingManager;
@@ -130,7 +130,7 @@ class CoreServices : public QObject {
     std::shared_ptr<EffectsManager> m_pEffectsManager;
     // owned by EffectsManager
     LV2Backend* m_pLV2Backend;
-    std::shared_ptr<EngineMaster> m_pEngine;
+    std::shared_ptr<EngineMixer> m_pEngine;
     std::shared_ptr<SoundManager> m_pSoundManager;
     std::shared_ptr<PlayerManager> m_pPlayerManager;
     std::shared_ptr<RecordingManager> m_pRecordingManager;

--- a/src/effects/backends/builtin/autopaneffect.cpp
+++ b/src/effects/backends/builtin/autopaneffect.cpp
@@ -50,7 +50,7 @@ EffectManifestPointer AutoPanEffect::getManifest() {
     smoothing->setDefaultLinkType(EffectManifestParameter::LinkType::Linked);
     smoothing->setRange(0.25, 0.50, 0.50); // There are two steps per period so max is half
 
-    // TODO(Ferran Pujol): when KnobComposedMaskedRing branch is merged to master,
+    // TODO(Ferran Pujol): when KnobComposedMaskedRing branch is merged to main,
     //                     make the scaleStartParameter for this be 1.
 
     // Width : applied on the channel with gain reducing.

--- a/src/effects/backends/builtin/graphiceqeffect.cpp
+++ b/src/effects/backends/builtin/graphiceqeffect.cpp
@@ -20,7 +20,7 @@ EffectManifestPointer GraphicEQEffect::getManifest() {
     pManifest->setDescription(QObject::tr(
             "An 8-band graphic equalizer based on biquad filters"));
     pManifest->setEffectRampsFromDry(true);
-    pManifest->setIsMasterEQ(true);
+    pManifest->setIsMainEQ(true);
 
     // Display rounded center frequencies for each filter
     float centerFrequencies[8] = {45, 100, 220, 500, 1100, 2500, 5500, 12000};

--- a/src/effects/backends/builtin/loudnesscontoureffect.cpp
+++ b/src/effects/backends/builtin/loudnesscontoureffect.cpp
@@ -125,7 +125,7 @@ void LoudnessContourEffect::processChannel(
                 gainKnob = math_clamp(gainKnob, 0.03, 1.0); // Limit at 0 .. -30 dB
                 double gainKnobDb = ratio2db(gainKnob);
                 filterGainDb = loudness * gainKnobDb / kMaxLoGain;
-                gain = 1; // No need for adjust gain because master gain follows
+                gain = 1; // No need for adjust gain because main gain follows
             } else {
                 filterGainDb = -loudness;
                 // compensate filter boost to avoid clipping

--- a/src/effects/backends/builtin/parametriceqeffect.cpp
+++ b/src/effects/backends/builtin/parametriceqeffect.cpp
@@ -25,7 +25,7 @@ EffectManifestPointer ParametricEQEffect::getManifest() {
             "An gentle 2-band parametric equalizer based on biquad filters.\n"
             "It is designed as a complement to the steep mixing equalizers."));
     pManifest->setEffectRampsFromDry(true);
-    pManifest->setIsMasterEQ(true);
+    pManifest->setIsMainEQ(true);
 
     EffectManifestParameterPointer gain1 = pManifest->addParameter();
     gain1->setId("gain1");

--- a/src/effects/backends/effectmanifest.h
+++ b/src/effects/backends/effectmanifest.h
@@ -27,7 +27,7 @@ class EffectManifest {
     EffectManifest()
             : m_backendType(EffectBackendType::Unknown),
               m_isMixingEQ(false),
-              m_isMasterEQ(false),
+              m_isMainEQ(false),
               m_effectRampsFromDry(false),
               m_bAddDryToWet(false),
               m_metaknobDefault(0.0) {
@@ -104,12 +104,12 @@ class EffectManifest {
         m_isMixingEQ = value;
     }
 
-    const bool& isMasterEQ() const {
-        return m_isMasterEQ;
+    const bool& isMainEQ() const {
+        return m_isMainEQ;
     }
 
-    void setIsMasterEQ(const bool value) {
-        m_isMasterEQ = value;
+    void setIsMainEQ(const bool value) {
+        m_isMainEQ = value;
     }
 
     bool hasMetaKnobLinking() const;
@@ -183,7 +183,7 @@ class EffectManifest {
     QString m_description;
     /// This helps us at DlgPrefEQ's basic selection of Equalizers
     bool m_isMixingEQ;
-    bool m_isMasterEQ;
+    bool m_isMainEQ;
     QList<EffectManifestParameterPointer> m_parameters;
     bool m_effectRampsFromDry;
     bool m_bAddDryToWet;

--- a/src/effects/backends/effectprocessor.h
+++ b/src/effects/backends/effectprocessor.h
@@ -114,7 +114,7 @@ class EffectProcessor {
 
 /// EffectProcessorImpl manages a separate EffectState for every combination of
 /// input channel to output channel. This allows for processing effects in
-/// parallel for PFL and post-fader for the master output.
+/// parallel for PFL and post-fader for the main output.
 /// EffectSpecificState must be a subclass of EffectState.
 template<typename EffectSpecificState>
 class EffectProcessorImpl : public EffectProcessor {

--- a/src/effects/backends/effectprocessor.h
+++ b/src/effects/backends/effectprocessor.h
@@ -34,7 +34,7 @@
 ///
 /// Each EffectState instance tracks the state for one combination of input signal
 /// and output signal. Input signals can be any EngineChannel, but output channels
-/// are hardcoded in EngineMaster as the postfader processing for the main mix
+/// are hardcoded in EngineMixer as the postfader processing for the main mix
 /// and prefader processing for headphones. There can be many EffectStates for one
 /// EffectProcessorImpl, allowing a single EffectProcessorImpl to maintain
 /// independent state for each combination of input and output signal. This allows

--- a/src/effects/chains/outputeffectchain.cpp
+++ b/src/effects/chains/outputeffectchain.cpp
@@ -12,22 +12,22 @@ OutputEffectChain::OutputEffectChain(EffectsManager* pEffectsManager,
     addEffectSlot("[OutputEffectRack_[Master]_Effect1]");
     m_effectSlots[0]->setEnabled(true);
 
-    // Register the master channel
-    const ChannelHandleAndGroup* masterHandleAndGroup = nullptr;
+    // Register the main channel
+    const ChannelHandleAndGroup* mainHandleAndGroup = nullptr;
 
     // TODO(Be): Remove this hideous hack to get the ChannelHandleAndGroup
     const QSet<ChannelHandleAndGroup>& registeredChannels =
             m_pEffectsManager->registeredInputChannels();
     for (const ChannelHandleAndGroup& handle_group : registeredChannels) {
         if (handle_group.name() == "[MasterOutput]") {
-            masterHandleAndGroup = &handle_group;
+            mainHandleAndGroup = &handle_group;
             break;
         }
     }
-    DEBUG_ASSERT(masterHandleAndGroup != nullptr);
+    DEBUG_ASSERT(mainHandleAndGroup != nullptr);
 
-    registerInputChannel(*masterHandleAndGroup);
-    enableForInputChannel(*masterHandleAndGroup);
+    registerInputChannel(*mainHandleAndGroup);
+    enableForInputChannel(*mainHandleAndGroup);
     m_pControlChainMix->set(1.0);
     sendParameterUpdate();
 }

--- a/src/effects/effectchain.h
+++ b/src/effects/effectchain.h
@@ -24,7 +24,7 @@ class EngineEffectChain;
 /// EffectChain is the main thread representation of an effect chain.
 /// EffectChain owns the ControlObjects for the routing switches that assign
 /// chains to process audio inputs (decks, microphones, auxiliary inputs,
-/// master mix). EffectChain also owns the ControlObject for the superknob
+/// main mix). EffectChain also owns the ControlObject for the superknob
 /// which manipulates the metaknob of each EffectSlot in the chain.
 ///
 /// EffectChains are created and destroyed by EffectsManager during Mixxx

--- a/src/effects/effectsmanager.h
+++ b/src/effects/effectsmanager.h
@@ -42,7 +42,7 @@ class EffectsManager {
         return m_pEngineEffectsManager.get();
     }
 
-    const ChannelHandle getMasterHandle() const {
+    const ChannelHandle getMainHandle() const {
         return m_pChannelHandleFactory->getOrCreateHandle("[Master]");
     }
 

--- a/src/encoder/encoderopus.cpp
+++ b/src/encoder/encoderopus.cpp
@@ -21,7 +21,7 @@ constexpr int kMaxOpusBufferSize = 1+1275;
 constexpr int kOpusFrameMs = 60;
 constexpr int kOpusChannelCount = 2;
 // Opus only supports 48 and 96 kHz samplerates
-constexpr mixxx::audio::SampleRate kMasterSamplerate = mixxx::audio::SampleRate(48000);
+constexpr mixxx::audio::SampleRate kMainSampleRate = mixxx::audio::SampleRate(48000);
 
 const mixxx::Logger kLogger("EncoderOpus");
 
@@ -73,8 +73,8 @@ int getSerial() {
 } // namespace
 
 //static
-mixxx::audio::SampleRate EncoderOpus::getMasterSamplerate() {
-    return kMasterSamplerate;
+mixxx::audio::SampleRate EncoderOpus::getMainSampleRate() {
+    return kMainSampleRate;
 }
 
 //static
@@ -140,18 +140,18 @@ void EncoderOpus::setEncoderSettings(const EncoderSettings& settings) {
 int EncoderOpus::initEncoder(mixxx::audio::SampleRate sampleRate, QString* pUserErrorMessage) {
     Q_UNUSED(pUserErrorMessage);
 
-    if (sampleRate != kMasterSamplerate) {
-        kLogger.warning() << "initEncoder failed: samplerate not supported by Opus";
+    if (sampleRate != kMainSampleRate) {
+            kLogger.warning() << "initEncoder failed: samplerate not supported by Opus";
 
-        const QString invalidSamplerateMessage = getInvalidSamplerateMessage();
+            const QString invalidSamplerateMessage = getInvalidSamplerateMessage();
 
-        ErrorDialogProperties* props = ErrorDialogHandler::instance()->newDialogProperties();
-        props->setType(DLG_WARNING);
-        props->setTitle(QObject::tr("Encoder"));
-        props->setText(invalidSamplerateMessage);
-        props->setKey(invalidSamplerateMessage);
-        ErrorDialogHandler::instance()->requestErrorDialog(props);
-        return -1;
+            ErrorDialogProperties* props = ErrorDialogHandler::instance()->newDialogProperties();
+            props->setType(DLG_WARNING);
+            props->setTitle(QObject::tr("Encoder"));
+            props->setText(invalidSamplerateMessage);
+            props->setKey(invalidSamplerateMessage);
+            ErrorDialogHandler::instance()->requestErrorDialog(props);
+            return -1;
     }
     m_sampleRate = sampleRate;
     DEBUG_ASSERT(m_sampleRate == 8000 || m_sampleRate == 12000 ||

--- a/src/encoder/encoderopus.h
+++ b/src/encoder/encoderopus.h
@@ -17,7 +17,7 @@
 
 class EncoderOpus: public Encoder {
   public:
-    static mixxx::audio::SampleRate getMasterSamplerate();
+    static mixxx::audio::SampleRate getMainSampleRate();
     static QString getInvalidSamplerateMessage();
 
     explicit EncoderOpus(EncoderCallback* pCallback = nullptr);

--- a/src/engine/channelhandle.h
+++ b/src/engine/channelhandle.h
@@ -10,7 +10,7 @@
 #include "util/compatibility/qhash.h"
 
 // ChannelHandle defines a unique identifier for channels of audio in the engine
-// (e.g. headphone output, master output, deck 1, microphone 3). Previously we
+// (e.g. headphone output, main output, deck 1, microphone 3). Previously we
 // used the group string of the channel in the engine to uniquely identify it
 // and key associative containers (e.g. QMap, QHash) but the downside to this is
 // that we waste a lot of callback time hashing and re-hashing the strings.
@@ -23,7 +23,7 @@
 // (since the keys are numbered [0, num_channels]).
 
 /// A wrapper around an integer handle. Used to uniquely identify and refer to
-/// channels (headphone output, master output, deck 1, microphone 4, etc.) while
+/// channels (headphone output, main output, deck 1, microphone 4, etc.) while
 /// avoiding slow QString comparisons incurred when using the group.
 ///
 /// A helper class, ChannelHandleFactory, keeps a running count of handles that

--- a/src/engine/channelhandle.h
+++ b/src/engine/channelhandle.h
@@ -130,11 +130,11 @@ inline qhash_seed_t qHash(
     return qHash(handleGroup.handle(), seed);
 }
 
-// A helper class used by EngineMaster to assign ChannelHandles to channel group
+// A helper class used by EngineMixer to assign ChannelHandles to channel group
 // strings. Warning: ChannelHandles produced by different ChannelHandleFactory
 // objects are not compatible and will produce incorrect results when compared,
 // stored in the same container, etc. In practice we only use one instance in
-// EngineMaster.
+// EngineMixer.
 class ChannelHandleFactory {
   public:
     ChannelHandleFactory() : m_iNextHandle(0) {

--- a/src/engine/channelmixer.cpp
+++ b/src/engine/channelmixer.cpp
@@ -4,9 +4,9 @@
 #include "util/timer.h"
 
 // static
-void ChannelMixer::applyEffectsAndMixChannels(const EngineMaster::GainCalculator& gainCalculator,
-        const QVarLengthArray<EngineMaster::ChannelInfo*, kPreallocatedChannels>& activeChannels,
-        QVarLengthArray<EngineMaster::GainCache, kPreallocatedChannels>* channelGainCache,
+void ChannelMixer::applyEffectsAndMixChannels(const EngineMixer::GainCalculator& gainCalculator,
+        const QVarLengthArray<EngineMixer::ChannelInfo*, kPreallocatedChannels>& activeChannels,
+        QVarLengthArray<EngineMixer::GainCache, kPreallocatedChannels>* channelGainCache,
         CSAMPLE* pOutput,
         const ChannelHandle& outputHandle,
         unsigned int iBufferSize,
@@ -22,9 +22,9 @@ void ChannelMixer::applyEffectsAndMixChannels(const EngineMaster::GainCalculator
     //     D) Mixes the temporary buffer into pOutput
     // The original channel input buffers are not modified.
     SampleUtil::clear(pOutput, iBufferSize);
-    ScopedTimer t("EngineMaster::applyEffectsAndMixChannels");
+    ScopedTimer t("EngineMixer::applyEffectsAndMixChannels");
     for (auto* pChannelInfo : activeChannels) {
-        EngineMaster::GainCache& gainCache = (*channelGainCache)[pChannelInfo->m_index];
+        EngineMixer::GainCache& gainCache = (*channelGainCache)[pChannelInfo->m_index];
         CSAMPLE_GAIN oldGain = gainCache.m_gain;
         CSAMPLE_GAIN newGain;
         bool fadeout = gainCache.m_fadeout ||
@@ -51,10 +51,10 @@ void ChannelMixer::applyEffectsAndMixChannels(const EngineMaster::GainCalculator
 }
 
 void ChannelMixer::applyEffectsInPlaceAndMixChannels(
-        const EngineMaster::GainCalculator& gainCalculator,
-        const QVarLengthArray<EngineMaster::ChannelInfo*, kPreallocatedChannels>&
+        const EngineMixer::GainCalculator& gainCalculator,
+        const QVarLengthArray<EngineMixer::ChannelInfo*, kPreallocatedChannels>&
                 activeChannels,
-        QVarLengthArray<EngineMaster::GainCache, kPreallocatedChannels>*
+        QVarLengthArray<EngineMixer::GainCache, kPreallocatedChannels>*
                 channelGainCache,
         CSAMPLE* pOutput,
         const ChannelHandle& outputHandle,
@@ -67,10 +67,10 @@ void ChannelMixer::applyEffectsInPlaceAndMixChannels(
     //    A) Applies the calculated gain to the channel buffer, modifying the original input buffer
     //    B) Applies effects to the buffer, modifying the original input buffer
     // 4. Mix the channel buffers together to make pOutput, overwriting the pOutput buffer from the last engine callback
-    ScopedTimer t("EngineMaster::applyEffectsInPlaceAndMixChannels");
+    ScopedTimer t("EngineMixer::applyEffectsInPlaceAndMixChannels");
     SampleUtil::clear(pOutput, iBufferSize);
     for (auto* pChannelInfo : activeChannels) {
-        EngineMaster::GainCache& gainCache = (*channelGainCache)[pChannelInfo->m_index];
+        EngineMixer::GainCache& gainCache = (*channelGainCache)[pChannelInfo->m_index];
         CSAMPLE_GAIN oldGain = gainCache.m_gain;
         CSAMPLE_GAIN newGain;
         bool fadeout = gainCache.m_fadeout ||

--- a/src/engine/channelmixer.h
+++ b/src/engine/channelmixer.h
@@ -2,9 +2,9 @@
 
 #include <QVarLengthArray>
 
-#include "util/types.h"
-#include "engine/enginemaster.h"
 #include "effects/engineeffectsmanager.h"
+#include "engine/enginemixer.h"
+#include "util/types.h"
 
 class ChannelMixer {
   public:
@@ -12,10 +12,10 @@ class ChannelMixer {
     // channel buffers is done after copying to a temporary buffer, then they are mixed
     // to make the output buffer.
     static void applyEffectsAndMixChannels(
-            const EngineMaster::GainCalculator& gainCalculator,
-            const QVarLengthArray<EngineMaster::ChannelInfo*,
+            const EngineMixer::GainCalculator& gainCalculator,
+            const QVarLengthArray<EngineMixer::ChannelInfo*,
                     kPreallocatedChannels>& activeChannels,
-            QVarLengthArray<EngineMaster::GainCache, kPreallocatedChannels>*
+            QVarLengthArray<EngineMixer::GainCache, kPreallocatedChannels>*
                     channelGainCache,
             CSAMPLE* pOutput,
             const ChannelHandle& outputHandle,
@@ -24,10 +24,10 @@ class ChannelMixer {
             EngineEffectsManager* pEngineEffectsManager);
     // This does modify the input channel buffers, then mixes them to make the output buffer.
     static void applyEffectsInPlaceAndMixChannels(
-            const EngineMaster::GainCalculator& gainCalculator,
-            const QVarLengthArray<EngineMaster::ChannelInfo*,
+            const EngineMixer::GainCalculator& gainCalculator,
+            const QVarLengthArray<EngineMixer::ChannelInfo*,
                     kPreallocatedChannels>& activeChannels,
-            QVarLengthArray<EngineMaster::GainCache, kPreallocatedChannels>*
+            QVarLengthArray<EngineMixer::GainCache, kPreallocatedChannels>*
                     channelGainCache,
             CSAMPLE* pOutput,
             const ChannelHandle& outputHandle,

--- a/src/engine/channels/engineaux.cpp
+++ b/src/engine/channels/engineaux.cpp
@@ -80,7 +80,7 @@ void EngineAux::process(CSAMPLE* pOut, const int iBufferSize) {
         EngineEffectsManager* pEngineEffectsManager = m_pEffectsManager->getEngineEffectsManager();
         if (pEngineEffectsManager != nullptr) {
             pEngineEffectsManager->processPreFaderInPlace(
-                    m_group.handle(), m_pEffectsManager->getMasterHandle(), pOut, iBufferSize,
+                    m_group.handle(), m_pEffectsManager->getMainHandle(), pOut, iBufferSize,
                     // TODO(jholthuis): Use mixxx::audio::SampleRate instead
                     static_cast<unsigned int>(m_sampleRate.get()));
         }

--- a/src/engine/channels/engineaux.cpp
+++ b/src/engine/channels/engineaux.cpp
@@ -21,9 +21,9 @@ EngineAux::EngineAux(const ChannelHandleAndGroup& handleGroup, EffectsManager* p
     ControlDoublePrivate::insertAlias(ConfigKey(getGroup(), "enabled"),
                                       ConfigKey(getGroup(), "input_configured"));
 
-    // by default Aux is disabled on the master and disabled on PFL. User
+    // by default Aux is disabled on the main and disabled on PFL. User
     // can over-ride by setting the "pfl" or "main_mix" controls.
-    // Skins can change that during initialisation, if the master control is not provided.
+    // Skins can change that during initialisation, if the main control is not provided.
     setMainMix(false);
 }
 

--- a/src/engine/channels/engineaux.h
+++ b/src/engine/channels/engineaux.h
@@ -20,7 +20,7 @@ class EngineAux : public EngineChannel, public AudioDestination {
 
     ActiveState updateActiveState() override;
 
-    /// Called by EngineMaster whenever is requesting a new buffer of audio.
+    /// Called by EngineMixer whenever is requesting a new buffer of audio.
     void process(CSAMPLE* pOutput, const int iBufferSize) override;
     void collectFeatures(GroupFeatureState* pGroupFeatures) const override;
     void postProcess(const int iBufferSize) override {
@@ -31,7 +31,7 @@ class EngineAux : public EngineChannel, public AudioDestination {
     /// configured input to be processed. This is run in the callback thread of
     /// the soundcard this AudioDestination was registered for! Beware, in the
     /// case of multiple soundcards, this method is not re-entrant but it may be
-    /// concurrent with EngineMaster processing.
+    /// concurrent with EngineMixer processing.
     void receiveBuffer(const AudioInput& input,
             const CSAMPLE* pBuffer,
             unsigned int nFrames) override;

--- a/src/engine/channels/enginedeck.cpp
+++ b/src/engine/channels/enginedeck.cpp
@@ -73,7 +73,7 @@ void EngineDeck::process(CSAMPLE* pOut, const int iBufferSize) {
     EngineEffectsManager* pEngineEffectsManager = m_pEffectsManager->getEngineEffectsManager();
     if (pEngineEffectsManager != nullptr) {
         pEngineEffectsManager->processPreFaderInPlace(m_group.handle(),
-                m_pEffectsManager->getMasterHandle(),
+                m_pEffectsManager->getMainHandle(),
                 pOut,
                 iBufferSize,
                 // TODO(jholthuis): Use mixxx::audio::SampleRate instead

--- a/src/engine/channels/enginedeck.cpp
+++ b/src/engine/channels/enginedeck.cpp
@@ -13,7 +13,7 @@
 EngineDeck::EngineDeck(
         const ChannelHandleAndGroup& handleGroup,
         UserSettingsPointer pConfig,
-        EngineMaster* pMixingEngine,
+        EngineMixer* pMixingEngine,
         EffectsManager* pEffectsManager,
         EngineChannel::ChannelOrientation defaultOrientation,
         bool primaryDeck)

--- a/src/engine/channels/enginedeck.h
+++ b/src/engine/channels/enginedeck.h
@@ -13,7 +13,7 @@
 class EngineBuffer;
 class EnginePregain;
 class EngineBuffer;
-class EngineMaster;
+class EngineMixer;
 class EngineVuMeter;
 class EngineEffectsManager;
 class ControlPushButton;
@@ -24,7 +24,7 @@ class EngineDeck : public EngineChannel, public AudioDestination {
     EngineDeck(
             const ChannelHandleAndGroup& handleGroup,
             UserSettingsPointer pConfig,
-            EngineMaster* pMixingEngine,
+            EngineMixer* pMixingEngine,
             EffectsManager* pEffectsManager,
             EngineChannel::ChannelOrientation defaultOrientation,
             bool primaryDeck);
@@ -43,7 +43,7 @@ class EngineDeck : public EngineChannel, public AudioDestination {
     // configured input to be processed. This is run in the callback thread of
     // the soundcard this AudioDestination was registered for! Beware, in the
     // case of multiple soundcards, this method is not re-entrant but it may be
-    // concurrent with EngineMaster processing.
+    // concurrent with EngineMixer processing.
     void receiveBuffer(const AudioInput& input,
             const CSAMPLE* pBuffer,
             unsigned int nFrames) override;

--- a/src/engine/channels/enginemicrophone.cpp
+++ b/src/engine/channels/enginemicrophone.cpp
@@ -80,7 +80,7 @@ void EngineMicrophone::process(CSAMPLE* pOut, const int iBufferSize) {
         EngineEffectsManager* pEngineEffectsManager = m_pEffectsManager->getEngineEffectsManager();
         if (pEngineEffectsManager != nullptr) {
             pEngineEffectsManager->processPreFaderInPlace(
-                    m_group.handle(), m_pEffectsManager->getMasterHandle(), pOut, iBufferSize,
+                    m_group.handle(), m_pEffectsManager->getMainHandle(), pOut, iBufferSize,
                     // TODO(jholthuis): Use mixxx::audio::SampleRate instead
                     static_cast<unsigned int>(m_sampleRate.get()));
         }

--- a/src/engine/channels/enginemicrophone.h
+++ b/src/engine/channels/enginemicrophone.h
@@ -23,7 +23,7 @@ class EngineMicrophone : public EngineChannel, public AudioDestination {
 
     ActiveState updateActiveState() override;
 
-    // Called by EngineMaster whenever is requesting a new buffer of audio.
+    // Called by EngineMixer whenever is requesting a new buffer of audio.
     void process(CSAMPLE* pOutput, const int iBufferSize) override;
     void collectFeatures(GroupFeatureState* pGroupFeatures) const override;
     void postProcess(const int iBufferSize) override {
@@ -34,7 +34,7 @@ class EngineMicrophone : public EngineChannel, public AudioDestination {
     // configured input to be processed. This is run in the callback thread of
     // the soundcard this AudioDestination was registered for! Beware, in the
     // case of multiple soundcards, this method is not re-entrant but it may be
-    // concurrent with EngineMaster processing.
+    // concurrent with EngineMixer processing.
     void receiveBuffer(const AudioInput& input,
             const CSAMPLE* pBuffer,
             unsigned int iNumSamples) override;

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -8,7 +8,7 @@
 #include "control/controlpushbutton.h"
 #include "engine/channels/enginechannel.h"
 #include "engine/enginebuffer.h"
-#include "engine/enginemaster.h"
+#include "engine/enginemixer.h"
 #include "moc_bpmcontrol.cpp"
 #include "track/beatutils.h"
 #include "track/track.h"

--- a/src/engine/controls/enginecontrol.cpp
+++ b/src/engine/controls/enginecontrol.cpp
@@ -1,7 +1,7 @@
 #include "engine/controls/enginecontrol.h"
 
 #include "engine/enginebuffer.h"
-#include "engine/enginemaster.h"
+#include "engine/enginemixer.h"
 #include "engine/sync/enginesync.h"
 #include "mixer/playermanager.h"
 #include "moc_enginecontrol.cpp"
@@ -10,7 +10,7 @@ EngineControl::EngineControl(const QString& group,
         UserSettingsPointer pConfig)
         : m_group(group),
           m_pConfig(pConfig),
-          m_pEngineMaster(nullptr),
+          m_pEngineMixer(nullptr),
           m_pEngineBuffer(nullptr) {
     setFrameInfo(mixxx::audio::kStartFramePos,
             mixxx::audio::kInvalidFramePos,
@@ -39,8 +39,8 @@ void EngineControl::trackBeatsUpdated(mixxx::BeatsPointer pBeats) {
 void EngineControl::hintReader(gsl::not_null<HintVector*>) {
 }
 
-void EngineControl::setEngineMaster(EngineMaster* pEngineMaster) {
-    m_pEngineMaster = pEngineMaster;
+void EngineControl::setEngineMixer(EngineMixer* pEngineMixer) {
+    m_pEngineMixer = pEngineMixer;
 }
 
 void EngineControl::setEngineBuffer(EngineBuffer* pEngineBuffer) {
@@ -61,8 +61,8 @@ UserSettingsPointer EngineControl::getConfig() {
     return m_pConfig;
 }
 
-EngineMaster* EngineControl::getEngineMaster() {
-    return m_pEngineMaster;
+EngineMixer* EngineControl::getEngineMixer() {
+    return m_pEngineMixer;
 }
 
 EngineBuffer* EngineControl::getEngineBuffer() {
@@ -102,17 +102,17 @@ void EngineControl::seek(double fractionalPosition) {
 }
 
 EngineBuffer* EngineControl::pickSyncTarget() {
-    EngineMaster* pMaster = getEngineMaster();
-    if (!pMaster) {
+    EngineMixer* pEngineMixer = getEngineMixer();
+    if (!pEngineMixer) {
         return nullptr;
     }
 
-    EngineSync* pEngineSync = pMaster->getEngineSync();
+    EngineSync* pEngineSync = pEngineMixer->getEngineSync();
     if (!pEngineSync) {
         return nullptr;
     }
 
-    EngineChannel* pThisChannel = pMaster->getChannel(getGroup());
+    EngineChannel* pThisChannel = pEngineMixer->getChannel(getGroup());
     Syncable* pSyncable = pEngineSync->pickNonSyncSyncTarget(pThisChannel);
     // pickNonSyncSyncTarget can return nullptr, but if it doesn't the Syncable
     // definitely has an EngineChannel.

--- a/src/engine/controls/enginecontrol.h
+++ b/src/engine/controls/enginecontrol.h
@@ -15,7 +15,7 @@
 #include "track/beats.h"
 #include "track/track_decl.h"
 
-class EngineMaster;
+class EngineMixer;
 class EngineBuffer;
 
 constexpr int kNoTrigger = -1;
@@ -56,7 +56,7 @@ class EngineControl : public QObject {
     // target.
     virtual void hintReader(gsl::not_null<HintVector*> pHintList);
 
-    virtual void setEngineMaster(EngineMaster* pEngineMaster);
+    virtual void setEngineMixer(EngineMixer* pEngineMixer);
     void setEngineBuffer(EngineBuffer* pEngineBuffer);
     virtual void setFrameInfo(mixxx::audio::FramePos currentPosition,
             mixxx::audio::FramePos trackEndPosition,
@@ -104,7 +104,7 @@ class EngineControl : public QObject {
     EngineBuffer* pickSyncTarget();
 
     UserSettingsPointer getConfig();
-    EngineMaster* getEngineMaster();
+    EngineMixer* getEngineMixer();
     EngineBuffer* getEngineBuffer();
 
     const QString m_group;
@@ -112,7 +112,7 @@ class EngineControl : public QObject {
 
   private:
     ControlValueAtomic<FrameInfo> m_frameInfo;
-    EngineMaster* m_pEngineMaster;
+    EngineMixer* m_pEngineMixer;
     EngineBuffer* m_pEngineBuffer;
 
     friend class CueControlTest;

--- a/src/engine/effects/engineeffectsmanager.cpp
+++ b/src/engine/effects/engineeffectsmanager.cpp
@@ -46,7 +46,7 @@ void EngineEffectsManager::onCallbackStart() {
                     *request, m_pResponsePipe.get());
             if (processed) {
                 // When an effect becomes active (part of a chain), keep
-                // it in our master list so that we can respond to
+                // it in our main list so that we can respond to
                 // requests about it.
                 if (request->type == EffectsRequest::ADD_EFFECT_TO_CHAIN) {
                     m_effects.append(request->AddEffectToChain.pEffect);

--- a/src/engine/effects/message.h
+++ b/src/engine/effects/message.h
@@ -22,7 +22,7 @@ struct EffectsRequest {
         ADD_EFFECT_TO_CHAIN,
         REMOVE_EFFECT_FROM_CHAIN,
         // Effects cannot currently be toggled for output channels;
-        // the outputs that effects are applied to are hardwired in EngineMaster
+        // the outputs that effects are applied to are hardwired in EngineMixer
         ENABLE_EFFECT_CHAIN_FOR_INPUT_CHANNEL,
         DISABLE_EFFECT_CHAIN_FOR_INPUT_CHANNEL,
 

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1000,9 +1000,9 @@ void EngineBuffer::processTrackLocked(
         m_tempo_ratio_old = tempoRatio;
         m_reverse_old = is_reverse;
 
-        // Now we need to update the scaler with the master sample rate, the
+        // Now we need to update the scaler with the main sample rate, the
         // base rate (ratio between sample rate of the source audio and the
-        // master samplerate), the deck speed, the pitch shift, and whether
+        // main samplerate), the deck speed, the pitch shift, and whether
         // the deck speed should affect the pitch.
 
         m_pScale->setScaleParameters(baserate,
@@ -1168,7 +1168,7 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
         // we can't predict when they will be in place.
         // If one does this, a click from breaking the last track is somehow
         // natural and he should know that such sound should not be played to
-        // the master (audience).
+        // the main (audience).
         // Workaround: Simply pause the track before.
 
         // TODO(XXX):

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -20,7 +20,7 @@
 #include "engine/controls/loopingcontrol.h"
 #include "engine/controls/quantizecontrol.h"
 #include "engine/controls/ratecontrol.h"
-#include "engine/enginemaster.h"
+#include "engine/enginemixer.h"
 #include "engine/engineworkerscheduler.h"
 #include "engine/readaheadmanager.h"
 #include "engine/sync/enginesync.h"
@@ -67,7 +67,7 @@ constexpr int kPlaypositionUpdateRate = 15; // updates per second
 EngineBuffer::EngineBuffer(const QString& group,
         UserSettingsPointer pConfig,
         EngineChannel* pChannel,
-        EngineMaster* pMixingEngine)
+        EngineMixer* pMixingEngine)
         : m_group(group),
           m_pConfig(pConfig),
           m_pLoopingControl(nullptr),
@@ -282,11 +282,11 @@ EngineBuffer::EngineBuffer(const QString& group,
     writer.setDevice(&df);
 #endif
 
-    // Now that all EngineControls have been created call setEngineMaster.
-    // TODO(XXX): Get rid of EngineControl::setEngineMaster and
+    // Now that all EngineControls have been created call setEngineMixer.
+    // TODO(XXX): Get rid of EngineControl::setEngineMixer and
     // EngineControl::setEngineBuffer entirely and pass them through the
     // constructor.
-    setEngineMaster(pMixingEngine);
+    setEngineMixer(pMixingEngine);
 }
 
 EngineBuffer::~EngineBuffer() {
@@ -382,9 +382,9 @@ void EngineBuffer::setLoop(mixxx::audio::FramePos startPosition,
     return m_pLoopingControl->setLoop(startPosition, endPositon, enabled);
 }
 
-void EngineBuffer::setEngineMaster(EngineMaster* pEngineMaster) {
+void EngineBuffer::setEngineMixer(EngineMixer* pEngineMixer) {
     for (const auto& pControl: qAsConst(m_engineControls)) {
-        pControl->setEngineMaster(pEngineMaster);
+        pControl->setEngineMixer(pEngineMixer);
     }
 }
 

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -48,7 +48,7 @@ class EngineBufferScaleRubberBand;
 class EngineSync;
 class EngineWorkerScheduler;
 class VisualPlayPosition;
-class EngineMaster;
+class EngineMixer;
 
 class EngineBuffer : public EngineObject {
      Q_OBJECT
@@ -91,8 +91,10 @@ class EngineBuffer : public EngineObject {
             KeylockEngine::RubberBandFaster,
             KeylockEngine::RubberBandFiner};
 
-    EngineBuffer(const QString& group, UserSettingsPointer pConfig,
-                 EngineChannel* pChannel, EngineMaster* pMixingEngine);
+    EngineBuffer(const QString& group,
+            UserSettingsPointer pConfig,
+            EngineChannel* pChannel,
+            EngineMixer* pMixingEngine);
     virtual ~EngineBuffer();
 
     void bindWorkers(EngineWorkerScheduler* pWorkerScheduler);
@@ -113,7 +115,7 @@ class EngineBuffer : public EngineObject {
             mixxx::audio::FramePos endPositon,
             bool enabled);
     // Sets pointer to other engine buffer/channel
-    void setEngineMaster(EngineMaster*);
+    void setEngineMixer(EngineMixer*);
 
     // Queues a new seek position. Use SEEK_EXACT or SEEK_STANDARD as seekType
     void queueNewPlaypos(mixxx::audio::FramePos newpos, enum SeekRequest seekType);

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -374,7 +374,6 @@ class EngineBuffer : public EngineObject {
     ControlPushButton* m_pSlipButton;
 
     ControlObject* m_pQuantize;
-    ControlObject* m_pMasterRate;
     ControlPotmeter* m_playposSlider;
     ControlProxy* m_pSampleRate;
     ControlProxy* m_pKeylockEngine;

--- a/src/engine/enginemixer.cpp
+++ b/src/engine/enginemixer.cpp
@@ -42,19 +42,19 @@ EngineMixer::EngineMixer(
           m_headphoneGainOld(1.0),
           m_balleftOld(1.0),
           m_balrightOld(1.0),
-          m_masterHandle(registerChannelGroup(group)),
+          m_mainHandle(registerChannelGroup(group)),
           m_headphoneHandle(registerChannelGroup("[Headphone]")),
-          m_masterOutputHandle(registerChannelGroup("[MasterOutput]")),
+          m_mainOutputHandle(registerChannelGroup("[MasterOutput]")),
           m_busTalkoverHandle(registerChannelGroup("[BusTalkover]")),
           m_busCrossfaderLeftHandle(registerChannelGroup("[BusLeft]")),
           m_busCrossfaderCenterHandle(registerChannelGroup("[BusCenter]")),
           m_busCrossfaderRightHandle(registerChannelGroup("[BusRight]")) {
-    pEffectsManager->registerInputChannel(m_masterHandle);
+    pEffectsManager->registerInputChannel(m_mainHandle);
     pEffectsManager->registerInputChannel(m_headphoneHandle);
-    pEffectsManager->registerOutputChannel(m_masterHandle);
+    pEffectsManager->registerOutputChannel(m_mainHandle);
     pEffectsManager->registerOutputChannel(m_headphoneHandle);
 
-    pEffectsManager->registerInputChannel(m_masterOutputHandle);
+    pEffectsManager->registerInputChannel(m_mainOutputHandle);
     pEffectsManager->registerInputChannel(m_busTalkoverHandle);
     pEffectsManager->registerInputChannel(m_busCrossfaderLeftHandle);
     pEffectsManager->registerInputChannel(m_busCrossfaderCenterHandle);
@@ -474,7 +474,7 @@ void EngineMixer::process(const int iBufferSize) {
             m_activeTalkoverChannels,
             &m_channelTalkoverGainCache,
             m_pTalkover,
-            m_masterHandle.handle(),
+            m_mainHandle.handle(),
             iBufferSize,
             static_cast<int>(m_sampleRate.value()),
             m_pEngineEffectsManager);
@@ -485,7 +485,7 @@ void EngineMixer::process(const int iBufferSize) {
     if (m_pEngineEffectsManager) {
         m_pEngineEffectsManager->processPostFaderInPlace(
                 m_busTalkoverHandle.handle(),
-                m_masterHandle.handle(),
+                m_mainHandle.handle(),
                 m_pTalkover,
                 iBufferSize,
                 static_cast<int>(m_sampleRate.value()),
@@ -534,7 +534,7 @@ void EngineMixer::process(const int iBufferSize) {
                 &m_channelMainGainCache, // no [o] because the old gain
                                          // follows an orientation switch
                 m_pOutputBusBuffers[o],
-                m_masterHandle.handle(),
+                m_mainHandle.handle(),
                 iBufferSize,
                 static_cast<int>(m_sampleRate.value()),
                 m_pEngineEffectsManager);
@@ -544,7 +544,7 @@ void EngineMixer::process(const int iBufferSize) {
     if (m_pEngineEffectsManager) {
         m_pEngineEffectsManager->processPostFaderInPlace(
                 m_busCrossfaderLeftHandle.handle(),
-                m_masterHandle.handle(),
+                m_mainHandle.handle(),
                 m_pOutputBusBuffers[EngineChannel::LEFT],
                 iBufferSize,
                 static_cast<int>(m_sampleRate.value()),
@@ -554,7 +554,7 @@ void EngineMixer::process(const int iBufferSize) {
                 false);
         m_pEngineEffectsManager->processPostFaderInPlace(
                 m_busCrossfaderCenterHandle.handle(),
-                m_masterHandle.handle(),
+                m_mainHandle.handle(),
                 m_pOutputBusBuffers[EngineChannel::CENTER],
                 iBufferSize,
                 static_cast<int>(m_sampleRate.value()),
@@ -564,7 +564,7 @@ void EngineMixer::process(const int iBufferSize) {
                 false);
         m_pEngineEffectsManager->processPostFaderInPlace(
                 m_busCrossfaderRightHandle.handle(),
-                m_masterHandle.handle(),
+                m_mainHandle.handle(),
                 m_pOutputBusBuffers[EngineChannel::RIGHT],
                 iBufferSize,
                 static_cast<int>(m_sampleRate.value()),
@@ -751,16 +751,16 @@ void EngineMixer::process(const int iBufferSize) {
         // Process effects that apply to main hardware output only but not
         // record/broadcast signal
         if (m_pEngineEffectsManager) {
-            GroupFeatureState masterFeatures;
-            masterFeatures.has_gain = true;
-            masterFeatures.gain = m_pMainGain->get();
+            GroupFeatureState mainFeatures;
+            mainFeatures.has_gain = true;
+            mainFeatures.gain = m_pMainGain->get();
             m_pEngineEffectsManager->processPostFaderInPlace(
-                    m_masterOutputHandle.handle(),
-                    m_masterHandle.handle(),
+                    m_mainOutputHandle.handle(),
+                    m_mainHandle.handle(),
                     m_pMain,
                     iBufferSize,
                     static_cast<int>(m_sampleRate.value()),
-                    masterFeatures);
+                    mainFeatures);
         }
 
         // Balance values
@@ -815,15 +815,15 @@ void EngineMixer::process(const int iBufferSize) {
 void EngineMixer::applyMainEffects(int bufferSize) {
     // Apply main effects
     if (m_pEngineEffectsManager) {
-        GroupFeatureState masterFeatures;
-        masterFeatures.has_gain = true;
-        masterFeatures.gain = m_pMainGain->get();
-        m_pEngineEffectsManager->processPostFaderInPlace(m_masterHandle.handle(),
-                m_masterHandle.handle(),
+        GroupFeatureState mainFeatures;
+        mainFeatures.has_gain = true;
+        mainFeatures.gain = m_pMainGain->get();
+        m_pEngineEffectsManager->processPostFaderInPlace(m_mainHandle.handle(),
+                m_mainHandle.handle(),
                 m_pMain,
                 bufferSize,
                 static_cast<int>(m_sampleRate.value()),
-                masterFeatures,
+                mainFeatures,
                 CSAMPLE_GAIN_ONE,
                 CSAMPLE_GAIN_ONE,
                 false);

--- a/src/engine/enginemixer.cpp
+++ b/src/engine/enginemixer.cpp
@@ -1,4 +1,4 @@
-#include "engine/enginemaster.h"
+#include "engine/enginemixer.h"
 
 #include <QList>
 #include <QPair>
@@ -21,14 +21,14 @@
 #include "engine/sidechain/enginesidechain.h"
 #include "engine/sync/enginesync.h"
 #include "mixer/playermanager.h"
-#include "moc_enginemaster.cpp"
+#include "moc_enginemixer.cpp"
 #include "preferences/usersettings.h"
 #include "util/defs.h"
 #include "util/sample.h"
 #include "util/timer.h"
 #include "util/trace.h"
 
-EngineMaster::EngineMaster(
+EngineMixer::EngineMixer(
         UserSettingsPointer pConfig,
         const QString& group,
         EffectsManager* pEffectsManager,
@@ -177,7 +177,7 @@ EngineMaster::EngineMaster(
     m_pKeylockEngine->set(pConfig->getValue(ConfigKey(group, "keylock_engine"),
             static_cast<double>(EngineBuffer::defaultKeylockEngine())));
 
-    // TODO: Make this read only and make EngineMaster decide whether
+    // TODO: Make this read only and make EngineMixer decide whether
     // processing the main mix is necessary.
     m_pMainEnabled = new ControlObject(ConfigKey(group, "enabled"),
             true,
@@ -197,8 +197,8 @@ EngineMaster::EngineMaster(
     // Note: the EQ Rack is set in EffectsManager::setupDefaults();
 }
 
-EngineMaster::~EngineMaster() {
-    //qDebug() << "in ~EngineMaster()";
+EngineMixer::~EngineMixer() {
+    // qDebug() << "in ~EngineMixer()";
     delete m_pKeylockEngine;
     delete m_pCrossfader;
     delete m_pBalance;
@@ -256,23 +256,23 @@ EngineMaster::~EngineMaster() {
     }
 }
 
-const CSAMPLE* EngineMaster::getMainBuffer() const {
+const CSAMPLE* EngineMixer::getMainBuffer() const {
     return m_pMain;
 }
 
-const CSAMPLE* EngineMaster::getBoothBuffer() const {
+const CSAMPLE* EngineMixer::getBoothBuffer() const {
     return m_pBooth;
 }
 
-const CSAMPLE* EngineMaster::getHeadphoneBuffer() const {
+const CSAMPLE* EngineMixer::getHeadphoneBuffer() const {
     return m_pHead;
 }
 
-const CSAMPLE* EngineMaster::getSidechainBuffer() const {
+const CSAMPLE* EngineMixer::getSidechainBuffer() const {
     return m_pSidechainMix;
 }
 
-void EngineMaster::processChannels(int iBufferSize) {
+void EngineMixer::processChannels(int iBufferSize) {
     // Update internal sync lock rate.
     m_pEngineSync->onCallbackStart(m_sampleRate, iBufferSize);
 
@@ -283,7 +283,7 @@ void EngineMaster::processChannels(int iBufferSize) {
     m_activeTalkoverChannels.clear();
     m_activeChannels.clear();
 
-    //ScopedTimer timer("EngineMaster::processChannels");
+    // ScopedTimer timer("EngineMixer::processChannels");
     EngineChannel* pLeaderChannel = m_pEngineSync->getLeaderChannel();
     // Reserve the first place for the main channel which
     // should be processed first
@@ -392,13 +392,13 @@ void EngineMaster::processChannels(int iBufferSize) {
     }
 }
 
-void EngineMaster::process(const int iBufferSize) {
+void EngineMixer::process(const int iBufferSize) {
     static bool haveSetName = false;
     if (!haveSetName) {
         QThread::currentThread()->setObjectName("Engine");
         haveSetName = true;
     }
-    //Trace t("EngineMaster::process");
+    // Trace t("EngineMixer::process");
 
     bool mainEnabled = m_pMainEnabled->toBool();
     bool boothEnabled = m_pBoothEnabled->toBool();
@@ -812,7 +812,7 @@ void EngineMaster::process(const int iBufferSize) {
     m_pWorkerScheduler->runWorkers();
 }
 
-void EngineMaster::applyMainEffects(int bufferSize) {
+void EngineMixer::applyMainEffects(int bufferSize) {
     // Apply main effects
     if (m_pEngineEffectsManager) {
         GroupFeatureState masterFeatures;
@@ -830,7 +830,7 @@ void EngineMaster::applyMainEffects(int bufferSize) {
     }
 }
 
-void EngineMaster::processHeadphones(
+void EngineMixer::processHeadphones(
         const CSAMPLE_GAIN mainMixGainInHeadphones,
         int iBufferSize) {
     // Add main mix to headphones
@@ -864,7 +864,7 @@ void EngineMaster::processHeadphones(
     m_headphoneGainOld = headphoneGain;
 }
 
-void EngineMaster::addChannel(EngineChannel* pChannel) {
+void EngineMixer::addChannel(EngineChannel* pChannel) {
     ChannelInfo* pChannelInfo = new ChannelInfo(m_channels.size());
     pChannel->setChannelIndex(pChannelInfo->m_index);
     pChannelInfo->m_pChannel = pChannel;
@@ -901,7 +901,7 @@ void EngineMaster::addChannel(EngineChannel* pChannel) {
     }
 }
 
-EngineChannel* EngineMaster::getChannel(const QString& group) {
+EngineChannel* EngineMixer::getChannel(const QString& group) {
     for (int i = 0; i < m_channels.size(); ++i) {
         ChannelInfo* pChannelInfo = m_channels[i];
         if (pChannelInfo->m_pChannel->getGroup() == group) {
@@ -911,25 +911,25 @@ EngineChannel* EngineMaster::getChannel(const QString& group) {
     return nullptr;
 }
 
-CSAMPLE_GAIN EngineMaster::getMainGain(int channelIndex) const {
+CSAMPLE_GAIN EngineMixer::getMainGain(int channelIndex) const {
     if (channelIndex >= 0 && channelIndex < m_channelMainGainCache.size()) {
         return m_channelMainGainCache[channelIndex].m_gain;
     }
     return CSAMPLE_GAIN_ZERO;
 }
 
-const CSAMPLE* EngineMaster::getDeckBuffer(unsigned int i) const {
+const CSAMPLE* EngineMixer::getDeckBuffer(unsigned int i) const {
     return getChannelBuffer(PlayerManager::groupForDeck(i));
 }
 
-const CSAMPLE* EngineMaster::getOutputBusBuffer(unsigned int i) const {
+const CSAMPLE* EngineMixer::getOutputBusBuffer(unsigned int i) const {
     if (i <= EngineChannel::RIGHT) {
         return m_pOutputBusBuffers[i];
     }
     return nullptr;
 }
 
-const CSAMPLE* EngineMaster::getChannelBuffer(const QString& group) const {
+const CSAMPLE* EngineMixer::getChannelBuffer(const QString& group) const {
     for (int i = 0; i < m_channels.size(); ++i) {
         const ChannelInfo* pChannelInfo = m_channels[i];
         if (pChannelInfo->m_pChannel->getGroup() == group) {
@@ -939,7 +939,7 @@ const CSAMPLE* EngineMaster::getChannelBuffer(const QString& group) const {
     return nullptr;
 }
 
-const CSAMPLE* EngineMaster::buffer(const AudioOutput& output) const {
+const CSAMPLE* EngineMixer::buffer(const AudioOutput& output) const {
     switch (output.getType()) {
     case AudioPathType::Main:
         return getMainBuffer();
@@ -964,7 +964,7 @@ const CSAMPLE* EngineMaster::buffer(const AudioOutput& output) const {
     }
 }
 
-void EngineMaster::onOutputConnected(const AudioOutput& output) {
+void EngineMixer::onOutputConnected(const AudioOutput& output) {
     switch (output.getType()) {
     case AudioPathType::Main:
         // overwrite config option if a main output is configured
@@ -992,7 +992,7 @@ void EngineMaster::onOutputConnected(const AudioOutput& output) {
     }
 }
 
-void EngineMaster::onOutputDisconnected(const AudioOutput& output) {
+void EngineMixer::onOutputDisconnected(const AudioOutput& output) {
     switch (output.getType()) {
     case AudioPathType::Main:
         // not used, because we need the main buffer for headphone mix
@@ -1018,7 +1018,7 @@ void EngineMaster::onOutputDisconnected(const AudioOutput& output) {
     }
 }
 
-void EngineMaster::onInputConnected(const AudioInput& input) {
+void EngineMixer::onInputConnected(const AudioInput& input) {
     switch (input.getType()) {
     case AudioPathType::Microphone:
         m_pNumMicsConfigured->set(m_pNumMicsConfigured->get() + 1);
@@ -1037,7 +1037,7 @@ void EngineMaster::onInputConnected(const AudioInput& input) {
     }
 }
 
-void EngineMaster::onInputDisconnected(const AudioInput& input) {
+void EngineMixer::onInputDisconnected(const AudioInput& input) {
     switch (input.getType()) {
     case AudioPathType::Microphone:
         m_pNumMicsConfigured->set(m_pNumMicsConfigured->get() - 1);
@@ -1056,7 +1056,7 @@ void EngineMaster::onInputDisconnected(const AudioInput& input) {
     }
 }
 
-void EngineMaster::registerNonEngineChannelSoundIO(SoundManager* pSoundManager) {
+void EngineMixer::registerNonEngineChannelSoundIO(SoundManager* pSoundManager) {
     pSoundManager->registerInput(AudioInput(AudioPathType::RecordBroadcast, 0, 2),
             m_pEngineSideChain);
 
@@ -1069,6 +1069,6 @@ void EngineMaster::registerNonEngineChannelSoundIO(SoundManager* pSoundManager) 
     pSoundManager->registerOutput(AudioOutput(AudioPathType::RecordBroadcast, 0, 2), this);
 }
 
-bool EngineMaster::sidechainMixRequired() const {
+bool EngineMixer::sidechainMixRequired() const {
     return m_pEngineSideChain && !m_bExternalRecordBroadcastInputConnected;
 }

--- a/src/engine/enginemixer.cpp
+++ b/src/engine/enginemixer.cpp
@@ -632,7 +632,7 @@ void EngineMixer::process(const int iBufferSize) {
             }
         } else if (configuredMicMonitorMode == MicMonitorMode::MainAndBooth) {
             // Process main channel effects
-            // TODO(Be): Move this after mixing in talkover. For the MASTER only
+            // TODO(Be): Move this after mixing in talkover. For the main output only
             // MicMonitorMode above, that will require refactoring the effects system
             // to be able to process the same effects on different buffers
             // within the same callback. For consistency between the MicMonitorModes,

--- a/src/engine/enginemixer.h
+++ b/src/engine/enginemixer.h
@@ -336,9 +336,9 @@ class EngineMixer : public QObject, public AudioSource {
     CSAMPLE_GAIN m_headphoneGainOld;
     CSAMPLE_GAIN m_balleftOld;
     CSAMPLE_GAIN m_balrightOld;
-    const ChannelHandleAndGroup m_masterHandle;
+    const ChannelHandleAndGroup m_mainHandle;
     const ChannelHandleAndGroup m_headphoneHandle;
-    const ChannelHandleAndGroup m_masterOutputHandle;
+    const ChannelHandleAndGroup m_mainOutputHandle;
     const ChannelHandleAndGroup m_busTalkoverHandle;
     const ChannelHandleAndGroup m_busCrossfaderLeftHandle;
     const ChannelHandleAndGroup m_busCrossfaderCenterHandle;

--- a/src/engine/enginemixer.h
+++ b/src/engine/enginemixer.h
@@ -245,7 +245,7 @@ class EngineMixer : public QObject, public AudioSource {
     };
 
   protected:
-    // The master buffer is protected so it can be accessed by test subclasses.
+    // The main buffer is protected so it can be accessed by test subclasses.
     CSAMPLE* m_pMain;
 
     // ControlObjects for switching off unnecessary processing
@@ -274,7 +274,7 @@ class EngineMixer : public QObject, public AudioSource {
     // List of channels added to the engine.
     QVarLengthArray<ChannelInfo*, kPreallocatedChannels> m_channels;
 
-    // The previous gain of each channel for each mixing output (master,
+    // The previous gain of each channel for each mixing output (main,
     // headphone, talkover).
     QVarLengthArray<GainCache, kPreallocatedChannels> m_channelMainGainCache;
     QVarLengthArray<GainCache, kPreallocatedChannels> m_channelHeadphoneGainCache;

--- a/src/engine/enginemixer.h
+++ b/src/engine/enginemixer.h
@@ -265,7 +265,7 @@ class EngineMixer : public QObject, public AudioSource {
     ChannelHandleFactoryPointer m_pChannelHandleFactory;
     void applyMainEffects(int bufferSize);
     void processHeadphones(
-            const CSAMPLE_GAIN masterMixGainInHeadphones,
+            const CSAMPLE_GAIN mainMixGainInHeadphones,
             int iBufferSize);
     bool sidechainMixRequired() const;
 

--- a/src/engine/enginemixer.h
+++ b/src/engine/enginemixer.h
@@ -32,18 +32,18 @@ class EngineTalkoverDucking;
 class EngineDelay;
 
 // The number of channels to pre-allocate in various structures in the
-// engine. Prevents memory allocation in EngineMaster::addChannel.
+// engine. Prevents memory allocation in EngineMixer::addChannel.
 static constexpr int kPreallocatedChannels = 64;
 
-class EngineMaster : public QObject, public AudioSource {
+class EngineMixer : public QObject, public AudioSource {
     Q_OBJECT
   public:
-    EngineMaster(UserSettingsPointer pConfig,
+    EngineMixer(UserSettingsPointer pConfig,
             const QString& group,
             EffectsManager* pEffectsManager,
             ChannelHandleFactoryPointer pChannelHandleFactory,
             bool bEnableSidechain);
-    virtual ~EngineMaster();
+    virtual ~EngineMixer();
 
     // Get access to the sample buffers. None of these are thread safe. Only to
     // be called by SoundManager.
@@ -166,7 +166,7 @@ class EngineMaster : public QObject, public AudioSource {
         inline CSAMPLE_GAIN getGain(ChannelInfo* pChannelInfo) const {
             const CSAMPLE_GAIN channelVolume = static_cast<CSAMPLE_GAIN>(
                     pChannelInfo->m_pVolumeControl->get());
-            const CSAMPLE_GAIN orientationGain = EngineMaster::gainForOrientation(
+            const CSAMPLE_GAIN orientationGain = EngineMixer::gainForOrientation(
                     pChannelInfo->m_pChannel->getOrientation(),
                     m_dLeftGain,
                     m_dCenterGain,

--- a/src/engine/enginetalkoverducking.cpp
+++ b/src/engine/enginetalkoverducking.cpp
@@ -14,9 +14,10 @@ EngineTalkoverDucking::EngineTalkoverDucking(
         : EngineSideChainCompressor(group),
           m_pConfig(pConfig),
           m_group(group) {
-    m_pMasterSampleRate = new ControlProxy(m_group, "samplerate", this);
-    m_pMasterSampleRate->connectValueChanged(this, &EngineTalkoverDucking::slotSampleRateChanged,
-                                             Qt::DirectConnection);
+    m_pSampleRate = new ControlProxy(m_group, "samplerate", this);
+    m_pSampleRate->connectValueChanged(this,
+            &EngineTalkoverDucking::slotSampleRateChanged,
+            Qt::DirectConnection);
 
     m_pDuckStrength = new ControlPotmeter(ConfigKey(m_group, "duckStrength"), 0.0, 1.0);
     m_pDuckStrength->set(
@@ -31,8 +32,8 @@ EngineTalkoverDucking::EngineTalkoverDucking(
     setParameters(
             kDuckThreshold,
             static_cast<CSAMPLE>(m_pDuckStrength->get()),
-            static_cast<unsigned int>(m_pMasterSampleRate->get() / 2 * .1),
-            static_cast<unsigned int>(m_pMasterSampleRate->get() / 2));
+            static_cast<unsigned int>(m_pSampleRate->get() / 2 * .1),
+            static_cast<unsigned int>(m_pSampleRate->get() / 2));
 
     m_pTalkoverDucking = new ControlPushButton(ConfigKey(m_group, "talkoverDucking"));
     m_pTalkoverDucking->setButtonMode(ControlPushButton::TOGGLE);
@@ -64,8 +65,8 @@ void EngineTalkoverDucking::slotSampleRateChanged(double samplerate) {
 void EngineTalkoverDucking::slotDuckStrengthChanged(double strength) {
     setParameters(kDuckThreshold,
             static_cast<CSAMPLE>(strength),
-            static_cast<unsigned int>(m_pMasterSampleRate->get() / 2 * .1),
-            static_cast<unsigned int>(m_pMasterSampleRate->get() / 2));
+            static_cast<unsigned int>(m_pSampleRate->get() / 2 * .1),
+            static_cast<unsigned int>(m_pSampleRate->get() / 2));
     m_pConfig->set(ConfigKey(m_group, "duckStrength"), ConfigValue(strength * 100));
 }
 

--- a/src/engine/enginetalkoverducking.h
+++ b/src/engine/enginetalkoverducking.h
@@ -35,7 +35,7 @@ class EngineTalkoverDucking : public QObject, public EngineSideChainCompressor {
     UserSettingsPointer m_pConfig;
     const QString m_group;
 
-    ControlProxy* m_pMasterSampleRate;
+    ControlProxy* m_pSampleRate;
     ControlPotmeter* m_pDuckStrength;
     ControlPushButton* m_pTalkoverDucking;
 };

--- a/src/engine/positionscratchcontroller.cpp
+++ b/src/engine/positionscratchcontroller.cpp
@@ -77,7 +77,7 @@ PositionScratchController::PositionScratchController(const QString& group)
           m_dMouseSampeTime(0) {
     m_pScratchEnable = new ControlObject(ConfigKey(group, "scratch_position_enable"));
     m_pScratchPosition = new ControlObject(ConfigKey(group, "scratch_position"));
-    m_pMasterSampleRate = ControlObject::getControl(ConfigKey("[Master]", "samplerate"));
+    m_pMainSampleRate = ControlObject::getControl(ConfigKey("[Master]", "samplerate"));
     m_pVelocityController = new VelocityController();
     m_pRateIIFilter = new RateIIFilter;
 }
@@ -104,8 +104,7 @@ void PositionScratchController::process(double currentSample, double releaseRate
     }
 
     // The latency or time difference between process calls.
-    const double dt = static_cast<double>(iBufferSize)
-            / m_pMasterSampleRate->get() / 2;
+    const double dt = static_cast<double>(iBufferSize) / m_pMainSampleRate->get() / 2;
 
     // Sample Mouse with fixed timing intervals to iron out significant jitters
     // that are added on the way from mouse to engine thread

--- a/src/engine/positionscratchcontroller.h
+++ b/src/engine/positionscratchcontroller.h
@@ -25,7 +25,7 @@ class PositionScratchController : public QObject {
     const QString m_group;
     ControlObject* m_pScratchEnable;
     ControlObject* m_pScratchPosition;
-    ControlObject* m_pMasterSampleRate;
+    ControlObject* m_pMainSampleRate;
     VelocityController* m_pVelocityController;
     RateIIFilter* m_pRateIIFilter;
     bool m_bScratching;

--- a/src/engine/sidechain/shoutconnection.cpp
+++ b/src/engine/sidechain/shoutconnection.cpp
@@ -412,7 +412,7 @@ void ShoutConnection::updateFromPreferences() {
     }
 
 #ifdef __OPUS__
-    if (m_format_is_opus && mainSamplerate != EncoderOpus::getMasterSamplerate()) {
+    if (m_format_is_opus && mainSamplerate != EncoderOpus::getMainSampleRate()) {
         errorDialog(
             EncoderOpus::getInvalidSamplerateMessage(),
             tr("Unsupported sample rate")

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -7,7 +7,7 @@
 #include "engine/controls/bpmcontrol.h"
 #include "engine/controls/ratecontrol.h"
 #include "engine/enginebuffer.h"
-#include "engine/enginemaster.h"
+#include "engine/enginemixer.h"
 #include "moc_synccontrol.cpp"
 #include "track/track.h"
 #include "util/assert.h"
@@ -575,7 +575,7 @@ void SyncControl::setLocalBpm(mixxx::Bpm localBpm) {
 void SyncControl::updateAudible() {
     int channelIndex = m_pChannel->getChannelIndex();
     if (channelIndex >= 0) {
-        CSAMPLE_GAIN gain = getEngineMaster()->getMainGain(channelIndex);
+        CSAMPLE_GAIN gain = getEngineMixer()->getMainGain(channelIndex);
         bool newAudible = gain > CSAMPLE_GAIN_ZERO;
         if (static_cast<bool>(m_audible) != newAudible) {
             m_audible = newAudible;

--- a/src/engine/sync/synccontrol.h
+++ b/src/engine/sync/synccontrol.h
@@ -114,7 +114,7 @@ class SyncControl : public EngineControl, public Syncable {
 
     QString m_sGroup;
     // The only reason we have this pointer is an optimization so that the
-    // EngineSync can ask us what our EngineChannel is. EngineMaster in turn
+    // EngineSync can ask us what our EngineChannel is. EngineMixer in turn
     // asks EngineSync what EngineChannel is the "leader" channel.
     EngineChannel* m_pChannel;
     EngineSync* m_pEngineSync;

--- a/src/library/banshee/bansheedbconnection.cpp
+++ b/src/library/banshee/bansheedbconnection.cpp
@@ -87,7 +87,7 @@ QList<BansheeDbConnection::PlaylistEntry> BansheeDbConnection::getPlaylistEntrie
     QString queryString;
 
     if (playlistId == 0) {
-        // Create Master Playlist
+        // Create Main Playlist
         queryString = QString(
             "SELECT "
             "CoreTracks.TrackID, "        // 0

--- a/src/library/banshee/bansheefeature.cpp
+++ b/src/library/banshee/bansheefeature.cpp
@@ -110,7 +110,7 @@ void BansheeFeature::activate() {
         emit featureLoadingFinished(this);
     }
 
-    m_pBansheePlaylistModel->selectPlaylist(0); // Loads the master playlist
+    m_pBansheePlaylistModel->selectPlaylist(0); // Loads the main playlist
     emit showTrackModel(m_pBansheePlaylistModel);
     emit enableCoverArtDisplay(false);
 }

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -330,7 +330,7 @@ void BaseSqlTableModel::select() {
     // number of total rows returned by the query
     DEBUG_ASSERT(trackIdToRows.size() <= rowInfos.size());
 
-    // We're done! Issue the update signals and replace the master maps.
+    // We're done! Issue the update signals and replace the main maps.
     replaceRows(
             std::move(rowInfos),
             std::move(trackIdToRows));

--- a/src/mixer/auxiliary.cpp
+++ b/src/mixer/auxiliary.cpp
@@ -32,7 +32,7 @@ void Auxiliary::slotAuxMainMixEnabled(double v) {
     bool configured = m_pInputConfigured->toBool();
     bool auxMainMixEnable = v > 0.0;
 
-    // Warn the user if they try to enable master on a auxiliary with no
+    // Warn the user if they try to enable main on a auxiliary with no
     // configured input.
     if (!configured && auxMainMixEnable) {
         m_pAuxMainMixEnabled->set(0.0);

--- a/src/mixer/auxiliary.cpp
+++ b/src/mixer/auxiliary.cpp
@@ -2,7 +2,7 @@
 
 #include "control/controlproxy.h"
 #include "engine/channels/engineaux.h"
-#include "engine/enginemaster.h"
+#include "engine/enginemixer.h"
 #include "moc_auxiliary.cpp"
 #include "soundio/soundmanager.h"
 #include "soundio/soundmanagerutil.h"
@@ -11,7 +11,7 @@ Auxiliary::Auxiliary(PlayerManager* pParent,
         const QString& group,
         int index,
         SoundManager* pSoundManager,
-        EngineMaster* pEngine,
+        EngineMixer* pEngine,
         EffectsManager* pEffectsManager)
         : BasePlayer(pParent, group) {
     ChannelHandleAndGroup channelGroup = pEngine->registerChannelGroup(group);

--- a/src/mixer/auxiliary.h
+++ b/src/mixer/auxiliary.h
@@ -8,7 +8,7 @@
 
 class ControlProxy;
 class EffectsManager;
-class EngineMaster;
+class EngineMixer;
 class SoundManager;
 
 class Auxiliary : public BasePlayer {
@@ -18,7 +18,7 @@ class Auxiliary : public BasePlayer {
             const QString& group,
             int index,
             SoundManager* pSoundManager,
-            EngineMaster* pMixingEngine,
+            EngineMixer* pMixingEngine,
             EffectsManager* pEffectsManager);
     ~Auxiliary() override;
 

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -44,7 +44,7 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(
         EffectsManager* pEffectsManager,
         EngineChannel::ChannelOrientation defaultOrientation,
         const ChannelHandleAndGroup& handleGroup,
-        bool defaultMainMixMix,
+        bool defaultMainMix,
         bool defaultHeadphones,
         bool primaryDeck)
         : BaseTrackPlayer(pParent, handleGroup.name()),
@@ -72,7 +72,7 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(
     pMixingEngine->addChannel(m_pChannel);
 
     // Set the routing option defaults for the main and headphone mixes.
-    m_pChannel->setMainMix(defaultMainMixMix);
+    m_pChannel->setMainMix(defaultMainMix);
     m_pChannel->setPfl(defaultHeadphones);
 
     // Connect our signals and slots with the EngineBuffer's signals and

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -44,7 +44,7 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(
         EffectsManager* pEffectsManager,
         EngineChannel::ChannelOrientation defaultOrientation,
         const ChannelHandleAndGroup& handleGroup,
-        bool defaultMainMix,
+        bool defaultMainMixMix,
         bool defaultHeadphones,
         bool primaryDeck)
         : BaseTrackPlayer(pParent, handleGroup.name()),
@@ -72,7 +72,7 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(
     pMixingEngine->addChannel(m_pChannel);
 
     // Set the routing option defaults for the main and headphone mixes.
-    m_pChannel->setMainMix(defaultMainMix);
+    m_pChannel->setMainMix(defaultMainMixMix);
     m_pChannel->setPfl(defaultHeadphones);
 
     // Connect our signals and slots with the EngineBuffer's signals and

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -8,7 +8,7 @@
 #include "engine/controls/enginecontrol.h"
 #include "engine/engine.h"
 #include "engine/enginebuffer.h"
-#include "engine/enginemaster.h"
+#include "engine/enginemixer.h"
 #include "engine/sync/enginesync.h"
 #include "mixer/playerinfo.h"
 #include "mixer/playermanager.h"
@@ -40,7 +40,7 @@ BaseTrackPlayer::BaseTrackPlayer(PlayerManager* pParent, const QString& group)
 BaseTrackPlayerImpl::BaseTrackPlayerImpl(
         PlayerManager* pParent,
         UserSettingsPointer pConfig,
-        EngineMaster* pMixingEngine,
+        EngineMixer* pMixingEngine,
         EffectsManager* pEffectsManager,
         EngineChannel::ChannelOrientation defaultOrientation,
         const ChannelHandleAndGroup& handleGroup,
@@ -49,7 +49,7 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(
         bool primaryDeck)
         : BaseTrackPlayer(pParent, handleGroup.name()),
           m_pConfig(pConfig),
-          m_pEngineMaster(pMixingEngine),
+          m_pEngineMixer(pMixingEngine),
           m_pLoadedTrack(),
           m_pPrevFailedTrackId(),
           m_replaygainPending(false),
@@ -582,7 +582,7 @@ void BaseTrackPlayerImpl::slotTrackLoaded(TrackPointer pNewTrack,
             if (reset == RESET_SPEED || reset == RESET_PITCH_AND_SPEED) {
                 // Avoid resetting speed if sync lock is enabled and other decks with sync enabled
                 // are playing, as this would change the speed of already playing decks.
-                if (!m_pEngineMaster->getEngineSync()->otherSyncedPlaying(getGroup())) {
+                if (!m_pEngineMixer->getEngineSync()->otherSyncedPlaying(getGroup())) {
                     m_pRateRatio->set(1.0);
                 }
             }
@@ -634,14 +634,14 @@ TrackPointer BaseTrackPlayerImpl::getLoadedTrack() const {
 }
 
 void BaseTrackPlayerImpl::slotCloneDeck() {
-    Syncable* syncable = m_pEngineMaster->getEngineSync()->pickNonSyncSyncTarget(m_pChannel);
+    Syncable* syncable = m_pEngineMixer->getEngineSync()->pickNonSyncSyncTarget(m_pChannel);
     if (syncable) {
         slotCloneChannel(syncable->getChannel());
     }
 }
 
 void BaseTrackPlayerImpl::slotCloneFromGroup(const QString& group) {
-    EngineChannel* pChannel = m_pEngineMaster->getChannel(group);
+    EngineChannel* pChannel = m_pEngineMixer->getChannel(group);
     if (!pChannel) {
         return;
     }
@@ -696,7 +696,7 @@ void BaseTrackPlayerImpl::slotLoadTrackFromSampler(double d) {
 }
 
 void BaseTrackPlayerImpl::loadTrackFromGroup(const QString& group) {
-    EngineChannel* pChannel = m_pEngineMaster->getChannel(group);
+    EngineChannel* pChannel = m_pEngineMixer->getChannel(group);
     if (!pChannel) {
         return;
     }

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -71,7 +71,7 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(
     EngineBuffer* pEngineBuffer = m_pChannel->getEngineBuffer();
     pMixingEngine->addChannel(m_pChannel);
 
-    // Set the routing option defaults for the master and headphone mixes.
+    // Set the routing option defaults for the main and headphone mixes.
     m_pChannel->setMainMix(defaultMainMix);
     m_pChannel->setPfl(defaultHeadphones);
 

--- a/src/mixer/basetrackplayer.h
+++ b/src/mixer/basetrackplayer.h
@@ -15,7 +15,7 @@
 #include "util/memory.h"
 #include "util/parented_ptr.h"
 
-class EngineMaster;
+class EngineMixer;
 class ControlObject;
 class ControlPotmeter;
 class ControlProxy;
@@ -62,7 +62,7 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
   public:
     BaseTrackPlayerImpl(PlayerManager* pParent,
             UserSettingsPointer pConfig,
-            EngineMaster* pMixingEngine,
+            EngineMixer* pMixingEngine,
             EffectsManager* pEffectsManager,
             EngineChannel::ChannelOrientation defaultOrientation,
             const ChannelHandleAndGroup& handleGroup,
@@ -74,7 +74,7 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
     TrackPointer getLoadedTrack() const final;
 
     // TODO(XXX): Only exposed to let the passthrough AudioInput get
-    // connected. Delete me when EngineMaster supports AudioInput assigning.
+    // connected. Delete me when EngineMixer supports AudioInput assigning.
     EngineDeck* getEngineDeck() const;
 
     void setupEqControls() final;
@@ -124,7 +124,7 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
     void disconnectLoadedTrack();
 
     UserSettingsPointer m_pConfig;
-    EngineMaster* m_pEngineMaster;
+    EngineMixer* m_pEngineMixer;
     TrackPointer m_pLoadedTrack;
     TrackId m_pPrevFailedTrackId;
     EngineDeck* m_pChannel;

--- a/src/mixer/basetrackplayer.h
+++ b/src/mixer/basetrackplayer.h
@@ -66,7 +66,7 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
             EffectsManager* pEffectsManager,
             EngineChannel::ChannelOrientation defaultOrientation,
             const ChannelHandleAndGroup& handleGroup,
-            bool defaultMaster,
+            bool defaultMainMix,
             bool defaultHeadphones,
             bool primaryDeck);
     ~BaseTrackPlayerImpl() override;

--- a/src/mixer/deck.cpp
+++ b/src/mixer/deck.cpp
@@ -14,7 +14,7 @@ Deck::Deck(PlayerManager* pParent,
                   pEffectsManager,
                   defaultOrientation,
                   handleGroup,
-                  /*defaultMaster*/ true,
+                  /*defaultMainMix*/ true,
                   /*defaultHeadphones*/ false,
                   /*primaryDeck*/ true) {
 }

--- a/src/mixer/deck.cpp
+++ b/src/mixer/deck.cpp
@@ -4,7 +4,7 @@
 
 Deck::Deck(PlayerManager* pParent,
         UserSettingsPointer pConfig,
-        EngineMaster* pMixingEngine,
+        EngineMixer* pMixingEngine,
         EffectsManager* pEffectsManager,
         EngineChannel::ChannelOrientation defaultOrientation,
         const ChannelHandleAndGroup& handleGroup)

--- a/src/mixer/deck.h
+++ b/src/mixer/deck.h
@@ -9,7 +9,7 @@ class Deck : public BaseTrackPlayerImpl {
   public:
     Deck(PlayerManager* pParent,
             UserSettingsPointer pConfig,
-            EngineMaster* pMixingEngine,
+            EngineMixer* pMixingEngine,
             EffectsManager* pEffectsManager,
             EngineChannel::ChannelOrientation defaultOrientation,
             const ChannelHandleAndGroup& handleGroup);

--- a/src/mixer/microphone.cpp
+++ b/src/mixer/microphone.cpp
@@ -2,7 +2,7 @@
 
 #include "control/controlproxy.h"
 #include "engine/channels/enginemicrophone.h"
-#include "engine/enginemaster.h"
+#include "engine/enginemixer.h"
 #include "moc_microphone.cpp"
 #include "soundio/soundmanager.h"
 #include "soundio/soundmanagerutil.h"
@@ -11,7 +11,7 @@ Microphone::Microphone(PlayerManager* pParent,
         const QString& group,
         int index,
         SoundManager* pSoundManager,
-        EngineMaster* pEngine,
+        EngineMixer* pEngine,
         EffectsManager* pEffectsManager)
         : BasePlayer(pParent, group) {
     ChannelHandleAndGroup channelGroup = pEngine->registerChannelGroup(group);

--- a/src/mixer/microphone.h
+++ b/src/mixer/microphone.h
@@ -8,7 +8,7 @@
 
 class ControlProxy;
 class EffectsManager;
-class EngineMaster;
+class EngineMixer;
 class SoundManager;
 
 class Microphone : public BasePlayer {
@@ -18,7 +18,7 @@ class Microphone : public BasePlayer {
             const QString& group,
             int index,
             SoundManager* pSoundManager,
-            EngineMaster* pMixingEngine,
+            EngineMixer* pMixingEngine,
             EffectsManager* pEffectsManager);
     ~Microphone() override;
 

--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -5,7 +5,7 @@
 #include "control/controlobject.h"
 #include "effects/effectsmanager.h"
 #include "engine/channels/enginedeck.h"
-#include "engine/enginemaster.h"
+#include "engine/enginemixer.h"
 #include "mixer/auxiliary.h"
 #include "mixer/deck.h"
 #include "mixer/microphone.h"
@@ -94,7 +94,7 @@ QAtomicPointer<ControlProxy> PlayerManager::m_pCOPNumPreviewDecks;
 PlayerManager::PlayerManager(UserSettingsPointer pConfig,
         SoundManager* pSoundManager,
         EffectsManager* pEffectsManager,
-        EngineMaster* pEngine)
+        EngineMixer* pEngine)
         : m_mutex(QT_RECURSIVE_MUTEX_INIT),
           m_pConfig(pConfig),
           m_pSoundManager(pSoundManager),

--- a/src/mixer/playermanager.h
+++ b/src/mixer/playermanager.h
@@ -229,8 +229,8 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
     // there is no input configured.
     void noMicrophoneInputConfigured();
 
-    // Emitted when the user tries to enable an auxiliary master control when
-    // there is no input configured.
+    // Emitted when the user tries to enable an auxiliary `main_mix` control
+    // when there is no input configured.
     void noAuxiliaryInputConfigured();
 
     // Emitted when the user tries to enable deck passthrough when there is no

--- a/src/mixer/playermanager.h
+++ b/src/mixer/playermanager.h
@@ -21,7 +21,7 @@ class BaseTrackPlayer;
 class ControlObject;
 class Deck;
 class EffectsManager;
-class EngineMaster;
+class EngineMixer;
 class Library;
 class Microphone;
 class PreviewDeck;
@@ -61,7 +61,7 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
     PlayerManager(UserSettingsPointer pConfig,
             SoundManager* pSoundManager,
             EffectsManager* pEffectsManager,
-            EngineMaster* pEngine);
+            EngineMixer* pEngine);
     ~PlayerManager() override;
 
     // Add a deck to the PlayerManager
@@ -275,7 +275,7 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
     Library* m_pLibrary;
     SoundManager* m_pSoundManager;
     EffectsManager* m_pEffectsManager;
-    EngineMaster* m_pEngine;
+    EngineMixer* m_pEngine;
     SamplerBank* m_pSamplerBank;
     ControlObject* m_pCONumDecks;
     ControlObject* m_pCONumSamplers;

--- a/src/mixer/previewdeck.cpp
+++ b/src/mixer/previewdeck.cpp
@@ -14,7 +14,7 @@ PreviewDeck::PreviewDeck(PlayerManager* pParent,
                   pEffectsManager,
                   defaultOrientation,
                   handleGroup,
-                  /*defaultMaster*/ false,
+                  /*defaultMainMix*/ false,
                   /*defaultHeadphones*/ true,
                   /*primaryDeck*/ false) {
 }

--- a/src/mixer/previewdeck.cpp
+++ b/src/mixer/previewdeck.cpp
@@ -4,7 +4,7 @@
 
 PreviewDeck::PreviewDeck(PlayerManager* pParent,
         UserSettingsPointer pConfig,
-        EngineMaster* pMixingEngine,
+        EngineMixer* pMixingEngine,
         EffectsManager* pEffectsManager,
         EngineChannel::ChannelOrientation defaultOrientation,
         const ChannelHandleAndGroup& handleGroup)

--- a/src/mixer/previewdeck.h
+++ b/src/mixer/previewdeck.h
@@ -7,7 +7,7 @@ class PreviewDeck : public BaseTrackPlayerImpl {
   public:
     PreviewDeck(PlayerManager* pParent,
             UserSettingsPointer pConfig,
-            EngineMaster* pMixingEngine,
+            EngineMixer* pMixingEngine,
             EffectsManager* pEffectsManager,
             EngineChannel::ChannelOrientation defaultOrientation,
             const ChannelHandleAndGroup& handleGroup);

--- a/src/mixer/sampler.cpp
+++ b/src/mixer/sampler.cpp
@@ -5,7 +5,7 @@
 
 Sampler::Sampler(PlayerManager* pParent,
         UserSettingsPointer pConfig,
-        EngineMaster* pMixingEngine,
+        EngineMixer* pMixingEngine,
         EffectsManager* pEffectsManager,
         EngineChannel::ChannelOrientation defaultOrientation,
         const ChannelHandleAndGroup& handleGroup)

--- a/src/mixer/sampler.cpp
+++ b/src/mixer/sampler.cpp
@@ -15,7 +15,7 @@ Sampler::Sampler(PlayerManager* pParent,
                   pEffectsManager,
                   defaultOrientation,
                   handleGroup,
-                  /*defaultMaster*/ true,
+                  /*defaultMainMix*/ true,
                   /*defaultHeadphones*/ false,
                   /*primaryDeck*/ false) {
 }

--- a/src/mixer/sampler.h
+++ b/src/mixer/sampler.h
@@ -7,7 +7,7 @@ class Sampler : public BaseTrackPlayerImpl {
   public:
     Sampler(PlayerManager* pParent,
             UserSettingsPointer pConfig,
-            EngineMaster* pMixingEngine,
+            EngineMixer* pMixingEngine,
             EffectsManager* pEffectsManager,
             EngineChannel::ChannelOrientation defaultOrientation,
             const ChannelHandleAndGroup& handleGroup);

--- a/src/preferences/dialog/dlgprefmixer.cpp
+++ b/src/preferences/dialog/dlgprefmixer.cpp
@@ -38,7 +38,7 @@ bool isMixingEQ(EffectManifest* pManifest) {
 }
 
 bool isMainEQ(EffectManifest* pManifest) {
-    return pManifest->isMasterEQ();
+    return pManifest->isMainEQ();
 }
 } // anonymous namespace
 

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -7,7 +7,7 @@
 
 #include "control/controlproxy.h"
 #include "engine/enginebuffer.h"
-#include "engine/enginemaster.h"
+#include "engine/enginemixer.h"
 #include "mixer/playermanager.h"
 #include "moc_dlgprefsound.cpp"
 #include "preferences/dialog/dlgprefsounditem.h"
@@ -139,11 +139,11 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
 
     m_pMicMonitorMode = new ControlProxy("[Master]", "talkover_mix", this);
     micMonitorModeComboBox->addItem(tr("Main output only"),
-            QVariant(static_cast<int>(EngineMaster::MicMonitorMode::Main)));
+            QVariant(static_cast<int>(EngineMixer::MicMonitorMode::Main)));
     micMonitorModeComboBox->addItem(tr("Main and booth outputs"),
-            QVariant(static_cast<int>(EngineMaster::MicMonitorMode::MainAndBooth)));
+            QVariant(static_cast<int>(EngineMixer::MicMonitorMode::MainAndBooth)));
     micMonitorModeComboBox->addItem(tr("Direct monitor (recording and broadcasting only)"),
-            QVariant(static_cast<int>(EngineMaster::MicMonitorMode::DirectMonitor)));
+            QVariant(static_cast<int>(EngineMixer::MicMonitorMode::DirectMonitor)));
     int modeIndex = micMonitorModeComboBox->findData(
         static_cast<int>(m_pMicMonitorMode->get()));
     micMonitorModeComboBox->setCurrentIndex(modeIndex);
@@ -715,10 +715,10 @@ void DlgPrefSound::slotResetToDefaults() {
     // Enable talkover main output
     m_pMicMonitorMode->set(
             static_cast<double>(
-                    static_cast<int>(EngineMaster::MicMonitorMode::Main)));
+                    static_cast<int>(EngineMixer::MicMonitorMode::Main)));
     micMonitorModeComboBox->setCurrentIndex(
             micMonitorModeComboBox->findData(
-                    static_cast<int>(EngineMaster::MicMonitorMode::Main)));
+                    static_cast<int>(EngineMixer::MicMonitorMode::Main)));
 
     latencyCompensationSpinBox->setValue(latencyCompensationSpinBox->minimum());
 
@@ -771,9 +771,9 @@ void DlgPrefSound::mainMonoMixdownChanged(double value) {
 }
 
 void DlgPrefSound::micMonitorModeComboBoxChanged(int value) {
-    EngineMaster::MicMonitorMode newMode =
-        static_cast<EngineMaster::MicMonitorMode>(
-            micMonitorModeComboBox->itemData(value).toInt());
+    EngineMixer::MicMonitorMode newMode =
+            static_cast<EngineMixer::MicMonitorMode>(
+                    micMonitorModeComboBox->itemData(value).toInt());
 
     m_pMicMonitorMode->set(static_cast<double>(newMode));
 
@@ -781,9 +781,9 @@ void DlgPrefSound::micMonitorModeComboBoxChanged(int value) {
 }
 
 void DlgPrefSound::checkLatencyCompensation() {
-    EngineMaster::MicMonitorMode configuredMicMonitorMode =
-        static_cast<EngineMaster::MicMonitorMode>(
-            static_cast<int>(m_pMicMonitorMode->get()));
+    EngineMixer::MicMonitorMode configuredMicMonitorMode =
+            static_cast<EngineMixer::MicMonitorMode>(
+                    static_cast<int>(m_pMicMonitorMode->get()));
 
     // Do not clear the SoundManagerConfig on startup, from slotApply, or from slotUpdate
     if (!m_bSkipConfigClear) {
@@ -795,7 +795,7 @@ void DlgPrefSound::checkLatencyCompensation() {
 
     if (m_config.hasMicInputs() && !m_config.hasExternalRecordBroadcast()) {
         micMonitorModeComboBox->setEnabled(true);
-        if (configuredMicMonitorMode == EngineMaster::MicMonitorMode::DirectMonitor) {
+        if (configuredMicMonitorMode == EngineMixer::MicMonitorMode::DirectMonitor) {
             latencyCompensationSpinBox->setEnabled(true);
             QString warningIcon(
                     "<html>"

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -323,7 +323,7 @@ QUrl DlgPrefSound::helpUrl() const {
  * Initializes (and creates) all the path items. Each path item widget allows
  * the user to input a sound device name and channel number given a description
  * of what will be done with that info. Inputs and outputs are grouped by tab,
- * and each path item has an identifier (Master, Headphones, ...) and an index,
+ * and each path item has an identifier (Main, Headphones, ...) and an index,
  * if necessary.
  */
 void DlgPrefSound::initializePaths() {

--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -19,7 +19,7 @@ class ControlProxy;
 
 /*
  * TODO(bkgood) (n-decks) establish a signal/slot connection with a signal
- * on EngineMaster that emits every time a channel is added, and a slot here
+ * on EngineMixer that emits every time a channel is added, and a slot here
  * that updates the dialog accordingly.
  */
 

--- a/src/recording/recordingmanager.cpp
+++ b/src/recording/recordingmanager.cpp
@@ -8,7 +8,7 @@
 
 #include "control/controlproxy.h"
 #include "control/controlpushbutton.h"
-#include "engine/enginemaster.h"
+#include "engine/enginemixer.h"
 #include "engine/sidechain/enginerecord.h"
 #include "engine/sidechain/enginesidechain.h"
 #include "errordialoghandler.h"
@@ -17,7 +17,7 @@
 
 #define MIN_DISK_FREE 1024 * 1024 * 1024ll // one gibibyte
 
-RecordingManager::RecordingManager(UserSettingsPointer pConfig, EngineMaster* pEngine)
+RecordingManager::RecordingManager(UserSettingsPointer pConfig, EngineMixer* pEngine)
         : m_pConfig(pConfig),
           m_recordingDir(""),
           m_recording_base_file(""),

--- a/src/recording/recordingmanager.h
+++ b/src/recording/recordingmanager.h
@@ -10,7 +10,7 @@
 #include "preferences/usersettings.h"
 #include "recording/defs_recording.h"
 
-class EngineMaster;
+class EngineMixer;
 class ControlPushButton;
 class ControlProxy;
 
@@ -25,7 +25,7 @@ class ControlProxy;
 class RecordingManager : public QObject {
     Q_OBJECT
   public:
-    RecordingManager(UserSettingsPointer pConfig, EngineMaster* pEngine);
+    RecordingManager(UserSettingsPointer pConfig, EngineMixer* pEngine);
     ~RecordingManager() override = default;
 
     // This will try to start recording. If successful, slotIsRecording will be

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -16,7 +16,7 @@
 #include "util/cmdlineargs.h"
 #include "util/types.h"
 
-class EngineMaster;
+class EngineMixer;
 class AudioOutput;
 class AudioInput;
 class AudioSource;
@@ -40,7 +40,7 @@ class SoundDeviceNotFound;
 class SoundManager : public QObject {
     Q_OBJECT
   public:
-    SoundManager(UserSettingsPointer pConfig, EngineMaster *_master);
+    SoundManager(UserSettingsPointer pConfig, EngineMixer* pEngineMixer);
     ~SoundManager() override;
 
     // Returns a list of all devices we've enumerated that match the provided
@@ -130,7 +130,7 @@ class SoundManager : public QObject {
         return m_config.getAPI() == MIXXX_PORTAUDIO_JACK_STRING;
     }
 
-    EngineMaster *m_pMaster;
+    EngineMixer* m_pEngineMixer;
     UserSettingsPointer m_pConfig;
     bool m_paInitialized;
     mixxx::audio::SampleRate m_jackSampleRate;

--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -472,11 +472,11 @@ bool SoundManagerConfig::hasExternalRecordBroadcast() {
 }
 
 /**
- * Loads default values for API, master output, sample rate and/or latency.
+ * Loads default values for API, main output, sample rate and/or latency.
  * @param soundManager pointer to SoundManager instance to load data from
  * @param flags Bitfield to determine which defaults to load, use something
  *              like SoundManagerConfig::API | SoundManagerConfig::DEVICES to
- *              load default API and master device.
+ *              load default API and main device.
  */
 void SoundManagerConfig::loadDefaults(SoundManager* soundManager, unsigned int flags) {
     if (flags & SoundManagerConfig::API) {
@@ -519,8 +519,8 @@ void SoundManagerConfig::loadDefaults(SoundManager* soundManager, unsigned int f
                 if (pDevice->getNumOutputChannels() < 2) {
                     continue;
                 }
-                AudioOutput masterOut(AudioPathType::Main, 0, 2, 0);
-                addOutput(pDevice->getDeviceId(), masterOut);
+                auto mainOut = AudioOutput(AudioPathType::Main, 0, 2, 0);
+                addOutput(pDevice->getDeviceId(), mainOut);
                 defaultSampleRate = pDevice->getDefaultSampleRate();
                 break;
             }

--- a/src/test/autodjprocessor_test.cpp
+++ b/src/test/autodjprocessor_test.cpp
@@ -24,9 +24,9 @@ static int kDefaultTransitionTime = 10;
 const mixxx::audio::ChannelCount kChannelCount = mixxx::kEngineChannelCount;
 const QString kTrackLocationTest = QStringLiteral("id3-test-data/cover-test-png.mp3");
 
-class FakeMaster {
+class FakeMixer {
   public:
-    FakeMaster()
+    FakeMixer()
             : crossfader(ConfigKey("[Master]", "crossfader"), -1.0, 1.0),
               crossfaderReverse(ConfigKey("[Mixer Profile]", "xFaderReverse")) {
         crossfaderReverse.setButtonMode(ControlPushButton::TOGGLE);
@@ -242,7 +242,7 @@ class AutoDJProcessorTest : public LibraryTest {
         return pTrack ? pTrack->getId() : TrackId();
     }
 
-    FakeMaster master;
+    FakeMixer mixer;
     FakeDeck deck1;
     FakeDeck deck2;
     FakeDeck deck3;
@@ -259,7 +259,7 @@ TEST_F(AutoDJProcessorTest, FullIntroOutro_LongerIntro) {
     ASSERT_TRUE(testId.isValid());
 
     // Crossfader starts on the left.
-    master.crossfader.set(-1.0);
+    mixer.crossfader.set(-1.0);
     // Pretend a track is playing on deck 1.
     TrackPointer pTrack(newTestTrack(nextTrackId(testId)));
     // Pretend that track is 1 minute and 40 seconds long.
@@ -299,7 +299,7 @@ TEST_F(AutoDJProcessorTest, FullIntroOutro_LongerIntro) {
 
     // No change to the mode, crossfader or play states.
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(-1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(-1.0, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(1.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(0.0, deck2.play.get());
 
@@ -323,7 +323,7 @@ TEST_F(AutoDJProcessorTest, FullIntroOutro_LongerIntro) {
     // Advance track to the point where crossfading should be over (intro end)
     deck2.playposition.set(0.4);
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(1.0, mixer.crossfader.get());
 }
 
 TEST_F(AutoDJProcessorTest, FullIntroOutro_LongerOutro) {
@@ -333,7 +333,7 @@ TEST_F(AutoDJProcessorTest, FullIntroOutro_LongerOutro) {
     ASSERT_TRUE(testId.isValid());
 
     // Crossfader starts on the left.
-    master.crossfader.set(-1.0);
+    mixer.crossfader.set(-1.0);
     // Pretend a track is playing on deck 1.
     TrackPointer pTrack(newTestTrack(nextTrackId(testId)));
     // Pretend that track is 1 minute and 40 seconds long.
@@ -374,7 +374,7 @@ TEST_F(AutoDJProcessorTest, FullIntroOutro_LongerOutro) {
 
     // No change to the mode, crossfader or play states.
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(-1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(-1.0, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(1.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(0.0, deck2.play.get());
 
@@ -403,7 +403,7 @@ TEST_F(AutoDJProcessorTest, FullIntroOutro_LongerOutro) {
     // Advance track to the point where crossfading should be over.
     deck2.playposition.set(0.2);
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(1.0, mixer.crossfader.get());
 }
 
 TEST_F(AutoDJProcessorTest, FadeAtOutroStart_LongerIntro) {
@@ -413,7 +413,7 @@ TEST_F(AutoDJProcessorTest, FadeAtOutroStart_LongerIntro) {
     ASSERT_TRUE(testId.isValid());
 
     // Crossfader starts on the left.
-    master.crossfader.set(-1.0);
+    mixer.crossfader.set(-1.0);
     // Pretend a track is playing on deck 1.
     TrackPointer pTrack(newTestTrack(nextTrackId(testId)));
     // Pretend that track is 1 minute and 40 seconds long.
@@ -454,7 +454,7 @@ TEST_F(AutoDJProcessorTest, FadeAtOutroStart_LongerIntro) {
 
     // No change to the mode, crossfader or play states.
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(-1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(-1.0, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(1.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(0.0, deck2.play.get());
 
@@ -479,7 +479,7 @@ TEST_F(AutoDJProcessorTest, FadeAtOutroStart_LongerIntro) {
     // Advance track to the point where crossfading should be over.
     deck2.playposition.set(0.3);
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(1.0, mixer.crossfader.get());
 }
 
 TEST_F(AutoDJProcessorTest, FadeAtOutroStart_LongerOutro) {
@@ -489,7 +489,7 @@ TEST_F(AutoDJProcessorTest, FadeAtOutroStart_LongerOutro) {
     ASSERT_TRUE(testId.isValid());
 
     // Crossfader starts on the left.
-    master.crossfader.set(-1.0);
+    mixer.crossfader.set(-1.0);
     // Pretend a track is playing on deck 1.
     TrackPointer pTrack(newTestTrack(nextTrackId(testId)));
     // Pretend that track is 1 minute and 40 seconds long.
@@ -530,7 +530,7 @@ TEST_F(AutoDJProcessorTest, FadeAtOutroStart_LongerOutro) {
 
     // No change to the mode, crossfader or play states.
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(-1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(-1.0, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(1.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(0.0, deck2.play.get());
 
@@ -555,7 +555,7 @@ TEST_F(AutoDJProcessorTest, FadeAtOutroStart_LongerOutro) {
     deck2.playposition.set(0.2);
 
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(1.0, mixer.crossfader.get());
 }
 
 TEST_F(AutoDJProcessorTest, TransitionTimeLoadedFromConfig) {
@@ -622,7 +622,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_DecksStopped) {
     EXPECT_EQ(AutoDJProcessor::ADJ_OK, err);
     EXPECT_EQ(AutoDJProcessor::ADJ_ENABLE_P1LOADED, pProcessor->getState());
     // Sets crossfader left and deck 1 playing.
-    EXPECT_DOUBLE_EQ(-1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(-1.0, mixer.crossfader.get());
     // ADJ_ENABLE_P1LOADED logic does not set play directly. It waits for the
     // engine to load the track and set the deck playing.
     EXPECT_DOUBLE_EQ(0.0, deck1.play.get());
@@ -675,7 +675,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_DecksStopped_TrackLoadFails) {
     EXPECT_EQ(AutoDJProcessor::ADJ_OK, err);
     EXPECT_EQ(AutoDJProcessor::ADJ_ENABLE_P1LOADED, pProcessor->getState());
     // Sets crossfader left.
-    EXPECT_DOUBLE_EQ(-1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(-1.0, mixer.crossfader.get());
     // ADJ_ENABLE_P1LOADED logic does not set play directly. It waits for the
     // engine to load the track and set the deck playing.
     EXPECT_DOUBLE_EQ(0.0, deck1.play.get());
@@ -698,7 +698,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_DecksStopped_TrackLoadFails) {
     EXPECT_EQ(AutoDJProcessor::ADJ_ENABLE_P1LOADED, pProcessor->getState());
 
     // Check the crossfader is the same.
-    EXPECT_DOUBLE_EQ(-1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(-1.0, mixer.crossfader.get());
 
     // The deck1 play state was cleared by the engine after the failure to
     // load. Check that the AutoDJProcessor didn't set either deck to playing.
@@ -745,7 +745,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_DecksStopped_TrackLoadFailsRightDeck)
     EXPECT_EQ(AutoDJProcessor::ADJ_OK, err);
     EXPECT_EQ(AutoDJProcessor::ADJ_ENABLE_P1LOADED, pProcessor->getState());
     // Sets crossfader left.
-    EXPECT_DOUBLE_EQ(-1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(-1.0, mixer.crossfader.get());
     // ADJ_ENABLE_P1LOADED logic does not set play directly. It waits for the
     // engine to load the track and set the deck playing.
     EXPECT_DOUBLE_EQ(0.0, deck1.play.get());
@@ -790,7 +790,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_DecksStopped_TrackLoadFailsRightDeck)
 
     // Check that we are still in ADJ_IDLE mode and the left deck is playing.
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(-1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(-1.0, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(1.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(0.0, deck2.play.get());
 }
@@ -807,7 +807,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck1) {
     deck1.fakeTrackLoadedEvent(pTrack);
 
     // Arbitrary to check that it was unchanged.
-    master.crossfader.set(0.2447);
+    mixer.crossfader.set(0.2447);
 
     PlaylistTableModel* pAutoDJTableModel = pProcessor->getTableModel();
     pAutoDJTableModel->appendTrack(testId);
@@ -819,7 +819,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck1) {
     EXPECT_EQ(AutoDJProcessor::ADJ_OK, err);
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
 
-    EXPECT_DOUBLE_EQ(-1, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(-1, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(1.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(0.0, deck2.play.get());
 
@@ -829,7 +829,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck1) {
 
     // No change to the mode, crossfader or play states.
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(-1, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(-1, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(1.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(0.0, deck2.play.get());
 }
@@ -846,7 +846,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck1_TrackLoadFailed) {
     deck1.fakeTrackLoadedEvent(pTrack);
 
     // Arbitrary to check that it was unchanged.
-    master.crossfader.set(0.2447);
+    mixer.crossfader.set(0.2447);
 
     PlaylistTableModel* pAutoDJTableModel = pProcessor->getTableModel();
     // The first track will fail to load and the second will succeed.
@@ -861,7 +861,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck1_TrackLoadFailed) {
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
 
     // No change to the crossfader or play states.
-    EXPECT_DOUBLE_EQ(-1, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(-1, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(1.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(0.0, deck2.play.get());
 
@@ -875,7 +875,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck1_TrackLoadFailed) {
 
     // No change to the mode, crossfader, or play states.
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(-1, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(-1, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(1.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(0.0, deck2.play.get());
 
@@ -885,7 +885,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck1_TrackLoadFailed) {
 
     // No change to the mode, crossfader, or play states.
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(-1, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(-1, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(1.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(0.0, deck2.play.get());
 }
@@ -902,7 +902,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck2) {
     deck2.fakeTrackLoadedEvent(pTrack);
 
     // Arbitrary to check that it was unchanged.
-    master.crossfader.set(0.2447);
+    mixer.crossfader.set(0.2447);
 
     PlaylistTableModel* pAutoDJTableModel = pProcessor->getTableModel();
     pAutoDJTableModel->appendTrack(testId);
@@ -915,7 +915,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck2) {
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
 
     // No change to the crossfader or play states.
-    EXPECT_DOUBLE_EQ(1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(1.0, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(0.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(1.0, deck2.play.get());
 
@@ -925,7 +925,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck2) {
 
     // No change to the mode, crossfader or play states.
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(1.0, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(0.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(1.0, deck2.play.get());
 }
@@ -942,7 +942,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck2_TrackLoadFailed) {
     deck2.fakeTrackLoadedEvent(pTrack);
 
     // Arbitrary to check that it was unchanged.
-    master.crossfader.set(0.2447);
+    mixer.crossfader.set(0.2447);
 
     PlaylistTableModel* pAutoDJTableModel = pProcessor->getTableModel();
     // The first track will fail to load and the second will succeed.
@@ -957,7 +957,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck2_TrackLoadFailed) {
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
 
     // No change to the crossfader or play states.
-    EXPECT_DOUBLE_EQ(1, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(1, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(0.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(1.0, deck2.play.get());
 
@@ -971,7 +971,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck2_TrackLoadFailed) {
 
     // No change to the mode, crossfader, or play states.
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(1, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(1, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(0.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(1.0, deck2.play.get());
 
@@ -981,7 +981,7 @@ TEST_F(AutoDJProcessorTest, EnabledSuccess_PlayingDeck2_TrackLoadFailed) {
 
     // No change to the mode, crossfader, or play states.
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(1.0, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(0.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(1.0, deck2.play.get());
 }
@@ -1007,7 +1007,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck1_LoadOnDeck2_TrackLoadSuccess) {
     ASSERT_TRUE(testId.isValid());
 
     // Crossfader starts on the right.
-    master.crossfader.set(1.0);
+    mixer.crossfader.set(1.0);
     // Pretend a track is playing on deck 2.
     TrackPointer pTrack(newTestTrack(nextTrackId(testId)));
     // Load track and mark it playing.
@@ -1031,7 +1031,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck1_LoadOnDeck2_TrackLoadSuccess) {
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
 
     // No change to the crossfader or play states.
-    EXPECT_DOUBLE_EQ(1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(1.0, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(0.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(1.0, deck2.play.get());
 
@@ -1041,7 +1041,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck1_LoadOnDeck2_TrackLoadSuccess) {
 
     // No change to the mode, crossfader or play states.
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(1.0, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(0.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(1.0, deck2.play.get());
 
@@ -1052,7 +1052,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck1_LoadOnDeck2_TrackLoadSuccess) {
     deck2.playposition.set(1.0);
 
     EXPECT_EQ(AutoDJProcessor::ADJ_RIGHT_FADING, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(-1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(-1.0, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(1.0, deck1.play.get());
     // Deck is still playing, because the crossfader is processed in the next audio
     // callback.
@@ -1074,7 +1074,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck1_LoadOnDeck2_TrackLoadSuccess) {
     // Check we are in IDLE mode, the crossfader is fully left, and deck 1 is
     // playing.
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(-1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(-1.0, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(1.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(0.0, deck2.play.get());
 
@@ -1084,7 +1084,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck1_LoadOnDeck2_TrackLoadSuccess) {
 
     // No change to the mode, crossfader, or play states.
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(-1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(-1.0, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(1.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(0.0, deck2.play.get());
 }
@@ -1094,7 +1094,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck1_LoadOnDeck2_TrackLoadFailed) {
     ASSERT_TRUE(testId.isValid());
 
     // Crossfader starts on the right.
-    master.crossfader.set(1.0);
+    mixer.crossfader.set(1.0);
     // Pretend a track is playing on deck 2.
     TrackPointer pTrack(newTestTrack(nextTrackId(testId)));
     // Load track and mark it playing.
@@ -1120,7 +1120,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck1_LoadOnDeck2_TrackLoadFailed) {
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
 
     // No change to the crossfader or play states.
-    EXPECT_DOUBLE_EQ(1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(1.0, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(0.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(1.0, deck2.play.get());
 
@@ -1130,7 +1130,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck1_LoadOnDeck2_TrackLoadFailed) {
 
     // No change to the mode, crossfader or play states.
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(1.0, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(0.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(1.0, deck2.play.get());
 
@@ -1141,7 +1141,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck1_LoadOnDeck2_TrackLoadFailed) {
     deck2.playposition.set(1.0);
 
     EXPECT_EQ(AutoDJProcessor::ADJ_RIGHT_FADING, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(-1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(-1.0, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(1.0, deck1.play.get());
     // Deck is still playing, because the crossfader is processed in the next audio
     // callback.
@@ -1163,7 +1163,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck1_LoadOnDeck2_TrackLoadFailed) {
     // Check we are in IDLE mode, the crossfader is fully left, and deck 1 is
     // playing.
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(-1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(-1.0, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(1.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(0.0, deck2.play.get());
 
@@ -1177,7 +1177,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck1_LoadOnDeck2_TrackLoadFailed) {
 
     // No change to the mode, crossfader, or play states.
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(-1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(-1.0, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(1.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(0.0, deck2.play.get());
 
@@ -1187,7 +1187,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck1_LoadOnDeck2_TrackLoadFailed) {
 
     // No change to the mode, crossfader, or play states.
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(-1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(-1.0, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(1.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(0.0, deck2.play.get());
 }
@@ -1197,7 +1197,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_LoadOnDeck1_TrackLoadSuccess) {
     ASSERT_TRUE(testId.isValid());
 
     // Crossfader starts on the left.
-    master.crossfader.set(-1.0);
+    mixer.crossfader.set(-1.0);
     // Pretend a track is playing on deck 1.
     TrackPointer pTrack(newTestTrack(nextTrackId(testId)));
     // Load track and mark it playing.
@@ -1221,7 +1221,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_LoadOnDeck1_TrackLoadSuccess) {
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
 
     // No change to the crossfader or play states.
-    EXPECT_DOUBLE_EQ(-1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(-1.0, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(1.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(0.0, deck2.play.get());
 
@@ -1231,7 +1231,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_LoadOnDeck1_TrackLoadSuccess) {
 
     // No change to the mode, crossfader or play states.
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(-1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(-1.0, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(1.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(0.0, deck2.play.get());
 
@@ -1242,7 +1242,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_LoadOnDeck1_TrackLoadSuccess) {
     deck1.playposition.set(1.0);
 
     EXPECT_EQ(AutoDJProcessor::ADJ_LEFT_FADING, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(1.0, mixer.crossfader.get());
     // Deck is still playing, because the crossfader is processed in the next audio
     // callback.
     EXPECT_DOUBLE_EQ(1.0, deck1.play.get());
@@ -1264,7 +1264,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_LoadOnDeck1_TrackLoadSuccess) {
     // Check we are in IDLE mode, the crossfader is fully right, and deck 2 is
     // playing.
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(1.0, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(0.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(1.0, deck2.play.get());
 
@@ -1274,7 +1274,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_LoadOnDeck1_TrackLoadSuccess) {
 
     // No change to the mode, crossfader, or play states.
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(1.0, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(0.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(1.0, deck2.play.get());
 }
@@ -1284,7 +1284,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_LoadOnDeck1_TrackLoadFailed) {
     ASSERT_TRUE(testId.isValid());
 
     // Crossfader starts on the left.
-    master.crossfader.set(-1.0);
+    mixer.crossfader.set(-1.0);
     // Pretend a track is playing on deck 1.
     TrackPointer pTrack(newTestTrack(nextTrackId(testId)));
     // Load track and mark it playing.
@@ -1310,7 +1310,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_LoadOnDeck1_TrackLoadFailed) {
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
 
     // No change to the crossfader or play states.
-    EXPECT_DOUBLE_EQ(-1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(-1.0, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(1.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(0.0, deck2.play.get());
 
@@ -1320,7 +1320,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_LoadOnDeck1_TrackLoadFailed) {
 
     // No change to the mode, crossfader or play states.
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(-1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(-1.0, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(1.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(0.0, deck2.play.get());
 
@@ -1331,7 +1331,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_LoadOnDeck1_TrackLoadFailed) {
     deck1.playposition.set(1.0);
 
     EXPECT_EQ(AutoDJProcessor::ADJ_LEFT_FADING, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(1.0, mixer.crossfader.get());
     // Deck is still playing, because the crossfader is processed in the next audio
     // callback.
     EXPECT_DOUBLE_EQ(1.0, deck1.play.get());
@@ -1353,7 +1353,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_LoadOnDeck1_TrackLoadFailed) {
     // Check we are in IDLE mode, the crossfader is fully right, and deck 2 is
     // playing.
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(1.0, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(0.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(1.0, deck2.play.get());
 
@@ -1367,7 +1367,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_LoadOnDeck1_TrackLoadFailed) {
 
     // No change to the mode, crossfader, or play states.
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(1.0, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(0.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(1.0, deck2.play.get());
 
@@ -1377,7 +1377,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_LoadOnDeck1_TrackLoadFailed) {
 
     // No change to the mode, crossfader, or play states.
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(1.0, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(0.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(1.0, deck2.play.get());
 }
@@ -1390,7 +1390,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_Long_Transition) {
     ASSERT_TRUE(testId.isValid());
 
     // Crossfader starts on the left.
-    master.crossfader.set(-1.0);
+    mixer.crossfader.set(-1.0);
     // Pretend a track is playing on deck 1.
     TrackPointer pTrack(newTestTrack(nextTrackId(testId)));
     // Load track and mark it playing.
@@ -1423,14 +1423,14 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_Long_Transition) {
 
     // No change to the mode, crossfader or play states.
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(-1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(-1.0, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(1.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(0.0, deck2.play.get());
 
     // Seek track to 45 % it should not fade
     deck1.playposition.set(0.45);
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(-1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(-1.0, mixer.crossfader.get());
 
     // Expect that we will transition into LEFT_FADING mode.
     EXPECT_CALL(*pProcessor, emitAutoDJStateChanged(AutoDJProcessor::ADJ_LEFT_FADING));
@@ -1439,7 +1439,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_Long_Transition) {
     deck1.playposition.set(0.55);
     EXPECT_EQ(AutoDJProcessor::ADJ_LEFT_FADING, pProcessor->getState());
 
-    EXPECT_LT(-1.0, master.crossfader.get());
+    EXPECT_LT(-1.0, mixer.crossfader.get());
 
     EXPECT_DOUBLE_EQ(1.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(1.0, deck2.play.get());
@@ -1451,7 +1451,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_Long_Transition) {
     deck1.playposition.set(1.0);
     EXPECT_EQ(AutoDJProcessor::ADJ_LEFT_FADING, pProcessor->getState());
 
-    EXPECT_DOUBLE_EQ(1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(1.0, mixer.crossfader.get());
     // Deck is still playing, because the crossfader is processed in the next audio
     // callback.
     EXPECT_DOUBLE_EQ(1.0, deck1.play.get());
@@ -1477,7 +1477,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_Pause_Transition) {
     ASSERT_TRUE(testId.isValid());
 
     // Crossfader starts on the left.
-    master.crossfader.set(-1.0);
+    mixer.crossfader.set(-1.0);
     // Pretend a track is playing on deck 1.
     TrackPointer pTrack(newTestTrack(nextTrackId(testId)));
     // Pretend that track is 2 minutes long.
@@ -1521,7 +1521,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_Pause_Transition) {
 
     // No change to the mode, crossfader or play states.
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(-1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(-1.0, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(1.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(0.0, deck2.play.get());
 
@@ -1551,7 +1551,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_Pause_Transition) {
     // Advance track to the point where crossfading should be over.
     deck2.playposition.set(0.0);
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(1.0, mixer.crossfader.get());
 }
 
 TEST_F(AutoDJProcessorTest, FadeToDeck2_SeekEnd) {
@@ -1559,7 +1559,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_SeekEnd) {
     ASSERT_TRUE(testId.isValid());
 
     // Crossfader starts on the left.
-    master.crossfader.set(-1.0);
+    mixer.crossfader.set(-1.0);
     // Pretend a track is playing on deck 1.
     TrackPointer pTrack(newTestTrack(nextTrackId(testId)));
     // Load track and mark it playing.
@@ -1585,7 +1585,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_SeekEnd) {
 
     // No change to the mode, crossfader or play states.
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(-1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(-1.0, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(1.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(0.0, deck2.play.get());
 
@@ -1600,7 +1600,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_SeekEnd) {
     deck1.playposition.set(0.999);
     EXPECT_EQ(AutoDJProcessor::ADJ_LEFT_FADING, pProcessor->getState());
 
-    EXPECT_LT(-1.0, master.crossfader.get());
+    EXPECT_LT(-1.0, mixer.crossfader.get());
 
     EXPECT_DOUBLE_EQ(1.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(1.0, deck2.play.get());
@@ -1611,7 +1611,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_SeekBeforeTransition) {
     ASSERT_TRUE(testId.isValid());
 
     // Crossfader starts on the left.
-    master.crossfader.set(-1.0);
+    mixer.crossfader.set(-1.0);
     // Pretend a track is playing on deck 1.
     TrackPointer pTrack(newTestTrack(nextTrackId(testId)));
     // Load track and mark it playing.
@@ -1637,7 +1637,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_SeekBeforeTransition) {
 
     // No change to the mode, crossfader or play states.
     EXPECT_EQ(AutoDJProcessor::ADJ_IDLE, pProcessor->getState());
-    EXPECT_DOUBLE_EQ(-1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(-1.0, mixer.crossfader.get());
     EXPECT_DOUBLE_EQ(1.0, deck1.play.get());
     EXPECT_DOUBLE_EQ(0.0, deck2.play.get());
 
@@ -1653,7 +1653,7 @@ TEST_F(AutoDJProcessorTest, FadeToDeck2_SeekBeforeTransition) {
     deck1.playposition.set(0.999);
     EXPECT_EQ(AutoDJProcessor::ADJ_LEFT_FADING, pProcessor->getState());
 
-    EXPECT_LT(-1.0, master.crossfader.get());
+    EXPECT_LT(-1.0, mixer.crossfader.get());
 
     EXPECT_DOUBLE_EQ(0.999, deck1.playposition.get());
     // We expect that the "to Deck" has been seeked to the beginning"
@@ -1679,7 +1679,7 @@ TEST_F(AutoDJProcessorTest, TrackZeroLength) {
     EXPECT_EQ(AutoDJProcessor::ADJ_OK, err);
     EXPECT_EQ(AutoDJProcessor::ADJ_ENABLE_P1LOADED, pProcessor->getState());
     // Sets crossfader left and deck 1 playing.
-    EXPECT_DOUBLE_EQ(-1.0, master.crossfader.get());
+    EXPECT_DOUBLE_EQ(-1.0, mixer.crossfader.get());
     // ADJ_ENABLE_P1LOADED logic does not set play directly. It waits for the
     // engine to load the track and set the deck playing.
     EXPECT_DOUBLE_EQ(0.0, deck1.play.get());

--- a/src/test/enginebuffertest.cpp
+++ b/src/test/enginebuffertest.cpp
@@ -225,16 +225,16 @@ TEST_F(EngineBufferE2ETest, BasicProcessingTest) {
     ControlObject::set(ConfigKey(m_sGroup1, "rate"), 0.05);
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 1.0);
     ProcessBuffer();
-    assertBufferMatchesReference(m_pEngineMaster->getMainBuffer(),
+    assertBufferMatchesReference(m_pEngineMixer->getMainBuffer(),
             kProcessBufferSize,
             "BasicProcessingTestPlay");
     ProcessBuffer();
-    assertBufferMatchesReference(m_pEngineMaster->getMainBuffer(),
+    assertBufferMatchesReference(m_pEngineMixer->getMainBuffer(),
             kProcessBufferSize,
             "BasicProcessingTestPlaying");
     ControlObject::set(ConfigKey(m_sGroup1, "play"), 0.0);
     ProcessBuffer();
-    assertBufferMatchesReference(m_pEngineMaster->getMainBuffer(),
+    assertBufferMatchesReference(m_pEngineMixer->getMainBuffer(),
             kProcessBufferSize,
             "BasicProcessingTestPause");
 }
@@ -249,7 +249,7 @@ TEST_F(EngineBufferE2ETest, ScratchTest) {
     ProcessBuffer();
     ControlObject::set(ConfigKey(m_sGroup1, "scratch2"), -1.1);
     ProcessBuffer();
-    assertBufferMatchesReference(m_pEngineMaster->getMainBuffer(),
+    assertBufferMatchesReference(m_pEngineMixer->getMainBuffer(),
             kProcessBufferSize,
             "ScratchTestMaster");
 }
@@ -264,7 +264,7 @@ TEST_F(EngineBufferE2ETest, ScratchTestStart) {
     ProcessBuffer();
     ControlObject::set(ConfigKey(m_sGroup1, "scratch2"), 0.5);
     ProcessBuffer();
-    assertBufferMatchesReference(m_pEngineMaster->getMainBuffer(),
+    assertBufferMatchesReference(m_pEngineMixer->getMainBuffer(),
             kProcessBufferSize,
             "ScratchTestStart");
 }
@@ -276,7 +276,7 @@ TEST_F(EngineBufferE2ETest, ReverseTest) {
     ProcessBuffer();
     ControlObject::set(ConfigKey(m_sGroup1, "reverse"), 1.0);
     ProcessBuffer();
-    assertBufferMatchesReference(m_pEngineMaster->getMainBuffer(),
+    assertBufferMatchesReference(m_pEngineMixer->getMainBuffer(),
             kProcessBufferSize,
             "ReverseTest");
 }
@@ -292,20 +292,20 @@ TEST_F(EngineBufferE2ETest, DISABLED_SoundTouchToggleTest) {
    // Test transition from vinyl to keylock
    ControlObject::set(ConfigKey(m_sGroup1, "keylock"), 1.0);
    ProcessBuffer();
-   assertBufferMatchesReference(m_pEngineMaster->getMainBuffer(),
+   assertBufferMatchesReference(m_pEngineMixer->getMainBuffer(),
            kProcessBufferSize,
            "SoundTouchTest");
    // Test transition from keylock to vinyl due to slow speed.
    ControlObject::set(ConfigKey(m_sGroup1, "play"), 0.0);
    ControlObject::set(ConfigKey(m_sGroup1, "rateSearch"), 0.0072);
    ProcessBuffer();
-   assertBufferMatchesReference(m_pEngineMaster->getMainBuffer(),
+   assertBufferMatchesReference(m_pEngineMixer->getMainBuffer(),
            kProcessBufferSize,
            "SoundTouchTestSlow");
    // Test transition back to keylock due to regular speed.
    ControlObject::set(ConfigKey(m_sGroup1, "rateSearch"), 1.0);
    ProcessBuffer();
-   assertBufferMatchesReference(m_pEngineMaster->getMainBuffer(),
+   assertBufferMatchesReference(m_pEngineMixer->getMainBuffer(),
            kProcessBufferSize,
            "SoundTouchTestRegular");
 }
@@ -321,20 +321,20 @@ TEST_F(EngineBufferE2ETest, DISABLED_RubberbandToggleTest) {
    // Test transition from vinyl to keylock
    ControlObject::set(ConfigKey(m_sGroup1, "keylock"), 1.0);
    ProcessBuffer();
-   assertBufferMatchesReference(m_pEngineMaster->getMainBuffer(),
+   assertBufferMatchesReference(m_pEngineMixer->getMainBuffer(),
            kProcessBufferSize,
            "RubberbandTest");
    // Test transition from keylock to vinyl due to slow speed.
    ControlObject::set(ConfigKey(m_sGroup1, "play"), 0.0);
    ControlObject::set(ConfigKey(m_sGroup1, "rateSearch"), 0.0072);
    ProcessBuffer();
-   assertBufferMatchesReference(m_pEngineMaster->getMainBuffer(),
+   assertBufferMatchesReference(m_pEngineMixer->getMainBuffer(),
            kProcessBufferSize,
            "RubberbandTestSlow");
    // Test transition back to keylock due to regular speed.
    ControlObject::set(ConfigKey(m_sGroup1, "rateSearch"), 1.0);
    ProcessBuffer();
-   assertBufferMatchesReference(m_pEngineMaster->getMainBuffer(),
+   assertBufferMatchesReference(m_pEngineMixer->getMainBuffer(),
            kProcessBufferSize,
            "RubberbandTestRegular");
 }
@@ -357,7 +357,7 @@ TEST_F(EngineBufferE2ETest, DISABLED_KeylockReverseTest) {
     ProcessBuffer();
     ControlObject::set(ConfigKey(m_sGroup1, "reverse"), 1.0);
     ProcessBuffer();
-    assertBufferMatchesReference(m_pEngineMaster->getMainBuffer(),
+    assertBufferMatchesReference(m_pEngineMixer->getMainBuffer(),
             kProcessBufferSize,
             "KeylockReverseTest");
 }
@@ -370,7 +370,7 @@ TEST_F(EngineBufferE2ETest, SeekTest) {
     m_pChannel1->getEngineBuffer()->queueNewPlaypos(
             mixxx::audio::FramePos(500), EngineBuffer::SEEK_EXACT);
     ProcessBuffer();
-    assertBufferMatchesReference(m_pEngineMaster->getMainBuffer(),
+    assertBufferMatchesReference(m_pEngineMixer->getMainBuffer(),
             kProcessBufferSize,
             "SeekTest");
 }
@@ -410,7 +410,7 @@ TEST_F(EngineBufferE2ETest, CueGotoAndStopTest) {
     ProcessBuffer();
     ControlObject::set(ConfigKey(m_sGroup1, "cue_gotoandstop"), 1.0);
     ProcessBuffer();
-    assertBufferMatchesReference(m_pEngineMaster->getMainBuffer(),
+    assertBufferMatchesReference(m_pEngineMixer->getMainBuffer(),
             kProcessBufferSize,
             "CueGotoAndStopTest");
 }
@@ -425,7 +425,7 @@ TEST_F(EngineBufferE2ETest, CueGotoAndPlayTest) {
     ProcessBuffer();
     ControlObject::set(ConfigKey(m_sGroup1, "cue_gotoandplay"), 1.0);
     ProcessBuffer();
-    assertBufferMatchesReference(m_pEngineMaster->getMainBuffer(),
+    assertBufferMatchesReference(m_pEngineMixer->getMainBuffer(),
             kProcessBufferSize,
             "CueGotoAndPlayTest");
 }
@@ -437,7 +437,7 @@ TEST_F(EngineBufferE2ETest, CueStartPlayTest) {
     ProcessBuffer();
     ControlObject::set(ConfigKey(m_sGroup1, "start_play"), 1.0);
     ProcessBuffer();
-    assertBufferMatchesReference(m_pEngineMaster->getMainBuffer(),
+    assertBufferMatchesReference(m_pEngineMixer->getMainBuffer(),
             kProcessBufferSize,
             "StartPlayTest");
 }

--- a/src/test/mockedenginebackendtest.h
+++ b/src/test/mockedenginebackendtest.h
@@ -1,24 +1,23 @@
 #pragma once
 
-#include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
 #include <QtDebug>
 
-#include "preferences/usersettings.h"
 #include "control/controlobject.h"
-#include "mixer/deck.h"
 #include "effects/effectsmanager.h"
-#include "engine/enginebuffer.h"
 #include "engine/bufferscalers/enginebufferscale.h"
 #include "engine/channels/enginechannel.h"
 #include "engine/channels/enginedeck.h"
-#include "engine/enginemaster.h"
 #include "engine/controls/ratecontrol.h"
+#include "engine/enginebuffer.h"
+#include "engine/enginemixer.h"
 #include "engine/sync/enginesync.h"
 #include "mixer/deck.h"
 #include "mixer/previewdeck.h"
 #include "mixer/sampler.h"
+#include "preferences/usersettings.h"
 #include "test/signalpathtest.h"
 #include "util/defs.h"
 #include "util/memory.h"

--- a/src/test/playermanagertest.cpp
+++ b/src/test/playermanagertest.cpp
@@ -5,7 +5,7 @@
 #include "control/controlindicatortimer.h"
 #include "database/mixxxdb.h"
 #include "engine/enginebuffer.h"
-#include "engine/enginemaster.h"
+#include "engine/enginemixer.h"
 #include "mixer/basetrackplayer.h"
 #include "mixer/deck.h"
 #include "mixer/playerinfo.h"
@@ -48,7 +48,7 @@ class PlayerManagerTest : public MixxxDbTest, SoundSourceProviderRegistration {
         // but it does a lot of local disk / settings setup.
         auto pChannelHandleFactory = std::make_shared<ChannelHandleFactory>();
         m_pEffectsManager = std::make_shared<EffectsManager>(m_pConfig, pChannelHandleFactory);
-        m_pEngine = std::make_shared<EngineMaster>(
+        m_pEngine = std::make_shared<EngineMixer>(
                 m_pConfig,
                 "[Master]",
                 m_pEffectsManager.get(),
@@ -110,7 +110,7 @@ class PlayerManagerTest : public MixxxDbTest, SoundSourceProviderRegistration {
 
     std::shared_ptr<EffectsManager> m_pEffectsManager;
     std::shared_ptr<mixxx::ControlIndicatorTimer> m_pControlIndicatorTimer;
-    std::shared_ptr<EngineMaster> m_pEngine;
+    std::shared_ptr<EngineMixer> m_pEngine;
     std::shared_ptr<SoundManager> m_pSoundManager;
     std::shared_ptr<PlayerManager> m_pPlayerManager;
     std::unique_ptr<TrackCollectionManager> m_pTrackCollectionManager;

--- a/src/test/signalpathtest.cpp
+++ b/src/test/signalpathtest.cpp
@@ -1,6 +1,6 @@
 #include "test/signalpathtest.h"
 
-const QString BaseSignalPathTest::m_sMasterGroup = QStringLiteral("[Master]");
+const QString BaseSignalPathTest::m_sMainGroup = QStringLiteral("[Master]");
 const QString BaseSignalPathTest::m_sInternalClockGroup = QStringLiteral("[InternalClock]");
 // these names need to match PlayerManager::groupForDeck and friends
 const QString BaseSignalPathTest::m_sGroup1 = QStringLiteral("[Channel1]");

--- a/src/test/signalpathtest.h
+++ b/src/test/signalpathtest.h
@@ -14,7 +14,7 @@
 #include "engine/channels/enginedeck.h"
 #include "engine/controls/ratecontrol.h"
 #include "engine/enginebuffer.h"
-#include "engine/enginemaster.h"
+#include "engine/enginemixer.h"
 #include "engine/sync/enginesync.h"
 #include "mixer/deck.h"
 #include "mixer/playerinfo.h"
@@ -46,14 +46,14 @@ using ::testing::_;
         EXPECT_FRAMEPOS_EQ(position, controlPos);                        \
     }
 
-class TestEngineMaster : public EngineMaster {
+class TestEngineMixer : public EngineMixer {
   public:
-    TestEngineMaster(UserSettingsPointer _config,
+    TestEngineMixer(UserSettingsPointer _config,
             const QString& group,
             EffectsManager* pEffectsManager,
             ChannelHandleFactoryPointer pChannelHandleFactory,
             bool bEnableSidechain)
-            : EngineMaster(_config,
+            : EngineMixer(_config,
                       group,
                       pEffectsManager,
                       pChannelHandleFactory,
@@ -71,7 +71,7 @@ class BaseSignalPathTest : public MixxxTest, SoundSourceProviderRegistration {
         m_pChannelHandleFactory = std::make_shared<ChannelHandleFactory>();
         m_pNumDecks = new ControlObject(ConfigKey(m_sMasterGroup, "num_decks"));
         m_pEffectsManager = new EffectsManager(config(), m_pChannelHandleFactory);
-        m_pEngineMaster = new TestEngineMaster(m_pConfig,
+        m_pEngineMixer = new TestEngineMixer(m_pConfig,
                 m_sMasterGroup,
                 m_pEffectsManager,
                 m_pChannelHandleFactory,
@@ -79,38 +79,38 @@ class BaseSignalPathTest : public MixxxTest, SoundSourceProviderRegistration {
 
         m_pMixerDeck1 = new Deck(nullptr,
                 m_pConfig,
-                m_pEngineMaster,
+                m_pEngineMixer,
                 m_pEffectsManager,
                 EngineChannel::CENTER,
-                m_pEngineMaster->registerChannelGroup(m_sGroup1));
+                m_pEngineMixer->registerChannelGroup(m_sGroup1));
         m_pMixerDeck2 = new Deck(nullptr,
                 m_pConfig,
-                m_pEngineMaster,
+                m_pEngineMixer,
                 m_pEffectsManager,
                 EngineChannel::CENTER,
-                m_pEngineMaster->registerChannelGroup(m_sGroup2));
+                m_pEngineMixer->registerChannelGroup(m_sGroup2));
         m_pMixerDeck3 = new Deck(nullptr,
                 m_pConfig,
-                m_pEngineMaster,
+                m_pEngineMixer,
                 m_pEffectsManager,
                 EngineChannel::CENTER,
-                m_pEngineMaster->registerChannelGroup(m_sGroup3));
+                m_pEngineMixer->registerChannelGroup(m_sGroup3));
 
         m_pChannel1 = m_pMixerDeck1->getEngineDeck();
         m_pChannel2 = m_pMixerDeck2->getEngineDeck();
         m_pChannel3 = m_pMixerDeck3->getEngineDeck();
         m_pPreview1 = new PreviewDeck(nullptr,
                 m_pConfig,
-                m_pEngineMaster,
+                m_pEngineMixer,
                 m_pEffectsManager,
                 EngineChannel::CENTER,
-                m_pEngineMaster->registerChannelGroup(m_sPreviewGroup));
+                m_pEngineMixer->registerChannelGroup(m_sPreviewGroup));
         ControlObject::set(ConfigKey(m_sPreviewGroup, "file_bpm"), 2.0);
 
         // TODO(owilliams) Tests fail with this turned on because EngineSync is syncing
         // to this sampler.  FIX IT!
         // m_pSampler1 = new Sampler(NULL, m_pConfig,
-        //                           m_pEngineMaster, m_pEffectsManager,
+        //                           m_pEngineMixer, m_pEffectsManager,
         //                           EngineChannel::CENTER, m_sSamplerGroup);
         // ControlObject::getControl(ConfigKey(m_sSamplerGroup, "file_bpm"))->set(2.0);
 
@@ -118,7 +118,7 @@ class BaseSignalPathTest : public MixxxTest, SoundSourceProviderRegistration {
         addDeck(m_pChannel2);
         addDeck(m_pChannel3);
 
-        m_pEngineSync = m_pEngineMaster->getEngineSync();
+        m_pEngineSync = m_pEngineMixer->getEngineSync();
         ControlObject::set(ConfigKey(m_sMasterGroup, "enabled"), 1.0);
 
         PlayerInfo::create();
@@ -135,7 +135,7 @@ class BaseSignalPathTest : public MixxxTest, SoundSourceProviderRegistration {
         delete m_pPreview1;
 
         // Deletes all EngineChannels added to it.
-        delete m_pEngineMaster;
+        delete m_pEngineMixer;
         delete m_pEffectsManager;
         delete m_pNumDecks;
         PlayerInfo::destroy();
@@ -236,7 +236,7 @@ class BaseSignalPathTest : public MixxxTest, SoundSourceProviderRegistration {
 
     void ProcessBuffer() {
         qDebug() << "------- Process Buffer -------";
-        m_pEngineMaster->process(kProcessBufferSize);
+        m_pEngineMixer->process(kProcessBufferSize);
     }
 
     ChannelHandleFactoryPointer m_pChannelHandleFactory;
@@ -244,7 +244,7 @@ class BaseSignalPathTest : public MixxxTest, SoundSourceProviderRegistration {
     std::unique_ptr<mixxx::ControlIndicatorTimer> m_pControlIndicatorTimer;
     EffectsManager* m_pEffectsManager;
     EngineSync* m_pEngineSync;
-    TestEngineMaster* m_pEngineMaster;
+    TestEngineMixer* m_pEngineMixer;
     Deck *m_pMixerDeck1, *m_pMixerDeck2, *m_pMixerDeck3;
     EngineDeck *m_pChannel1, *m_pChannel2, *m_pChannel3;
     PreviewDeck* m_pPreview1;

--- a/src/test/signalpathtest.h
+++ b/src/test/signalpathtest.h
@@ -69,10 +69,10 @@ class BaseSignalPathTest : public MixxxTest, SoundSourceProviderRegistration {
     BaseSignalPathTest() {
         m_pControlIndicatorTimer = std::make_unique<mixxx::ControlIndicatorTimer>();
         m_pChannelHandleFactory = std::make_shared<ChannelHandleFactory>();
-        m_pNumDecks = new ControlObject(ConfigKey(m_sMasterGroup, "num_decks"));
+        m_pNumDecks = new ControlObject(ConfigKey(m_sMainGroup, "num_decks"));
         m_pEffectsManager = new EffectsManager(config(), m_pChannelHandleFactory);
         m_pEngineMixer = new TestEngineMixer(m_pConfig,
-                m_sMasterGroup,
+                m_sMainGroup,
                 m_pEffectsManager,
                 m_pChannelHandleFactory,
                 false);
@@ -119,7 +119,7 @@ class BaseSignalPathTest : public MixxxTest, SoundSourceProviderRegistration {
         addDeck(m_pChannel3);
 
         m_pEngineSync = m_pEngineMixer->getEngineSync();
-        ControlObject::set(ConfigKey(m_sMasterGroup, "enabled"), 1.0);
+        ControlObject::set(ConfigKey(m_sMainGroup, "enabled"), 1.0);
 
         PlayerInfo::create();
     }
@@ -249,7 +249,7 @@ class BaseSignalPathTest : public MixxxTest, SoundSourceProviderRegistration {
     EngineDeck *m_pChannel1, *m_pChannel2, *m_pChannel3;
     PreviewDeck* m_pPreview1;
 
-    static const QString m_sMasterGroup;
+    static const QString m_sMainGroup;
     static const QString m_sInternalClockGroup;
     static const QString m_sGroup1;
     static const QString m_sGroup2;

--- a/tools/make_xone.py
+++ b/tools/make_xone.py
@@ -20,25 +20,25 @@ def help():
     print("optional args: ")
     print("          --4decks     ", end="")
     print("to generate a layout for 4 deck-enabled versions of mixxx")
-    print("          --mastersync ", end="")
-    print("to generate alternative layout for master_sync testing")
+    print("          --sync-lock ", end="")
+    print("to generate alternative layout for sync_lock testing")
 
 
 if len(sys.argv) < 2:
     help()
     sys.exit(1)
 
-MASTER_SYNC_LAYOUT = False
+SYNC_LOCK_LAYOUT = False
 MAX_DECKS = 2
 fname = ""
 DECK_ORDER = range(0, 2)
 
 try:
-    opts, args = getopt.getopt(sys.argv[1:], "", ["mastersync", "4decks"])
+    opts, args = getopt.getopt(sys.argv[1:], "", ["sync-lock", "4decks"])
     for o, a in opts:
-        if o == "--mastersync":
-            # This is an alternative layout for my work on master sync
-            MASTER_SYNC_LAYOUT = True
+        if o == "--sync-lock":
+            # This is an alternative layout for my work on sync lock
+            SYNC_LOCK_LAYOUT = True
         elif o == "--4decks":
             MAX_DECKS = 4
             DECK_ORDER = (2, 0, 1, 3)
@@ -200,7 +200,7 @@ button_mapping = {
     },
 }
 
-if MASTER_SYNC_LAYOUT:
+if SYNC_LOCK_LAYOUT:
     button_mapping = {
         "spinknob": ["XoneK2.encoderButton", "<Script-Binding/>"],
         "knoblight1": ["keylock", "<button/>"],
@@ -255,7 +255,7 @@ light_mapping = {  # 'spinknob':'jog',
     },
 }
 
-if MASTER_SYNC_LAYOUT:
+if SYNC_LOCK_LAYOUT:
     light_mapping = {  # 'spinknob':'jog',
         "knoblight1": "keylock",
         "knoblight2": "quantize",
@@ -284,7 +284,7 @@ if MASTER_SYNC_LAYOUT:
 
 
 # these aren't worth automating
-master_knobs = """            <control>
+main_knobs = """            <control>
                 <group>[Playlist]</group>
                 <key>XoneK2.rightBottomKnob</key>
                 <status>0xBF</status>
@@ -330,8 +330,8 @@ master_knobs = """            <control>
                 </options>
             </control>"""
 
-if MASTER_SYNC_LAYOUT:
-    master_knobs = """            <control>
+if SYNC_LOCK_LAYOUT:
+    main_knobs = """            <control>
                 <group>[Playlist]</group>
                 <key>XoneK2.rightBottomKnob</key>
                 <status>0xBF</status>
@@ -587,7 +587,7 @@ for j, channel in enumerate(DECK_ORDER):
 
 xml.append("<!-- Special Case Knobs / buttons -->")
 # a couple custom entries:
-xml.append(master_knobs)
+xml.append(main_knobs)
 
 
 # done with controls


### PR DESCRIPTION
Continuation of #11942 which is part of #11931. This removes further ocurrences of offensive terms from the C++ codebase and most notably does the `EngineMixer` rename. CO changes will be done in a Follow-Up PR to keep the diff reviewable.

Please ensure that `2.4` has been merged into `main` before merging this PR.