### PR TITLE
Don't use a refrence into an rvalue object

### DIFF
--- a/src/track/taglib/trackmetadata_file.cpp
+++ b/src/track/taglib/trackmetadata_file.cpp
@@ -120,7 +120,8 @@ bool readAudioPropertiesFromFile(
     // we must pick one explicit,
     // to prevent "use of overloaded operator '<<' is ambiguous" error
     // on clang-cl builds.
-    const std::wstring& filename = file.name().wstr();
+    TagLib::FileName filename_owning = file.name();
+    const std::wstring& filename = filename_owning.wstr();
 #else
     const char* filename = file.name();
 #endif

--- a/src/track/taglib/trackmetadata_file.cpp
+++ b/src/track/taglib/trackmetadata_file.cpp
@@ -120,8 +120,8 @@ bool readAudioPropertiesFromFile(
     // we must pick one explicit,
     // to prevent "use of overloaded operator '<<' is ambiguous" error
     // on clang-cl builds.
-    // We need to save the filename here because if it was chained 
-    // (`file.name().wstr()`) the wstr() result would be dangling. 
+    // We need to save the filename here because if it was chained
+    // (`file.name().wstr()`) the wstr() result would be dangling.
     TagLib::FileName filename_owning = file.name();
     const std::wstring& filename = filename_owning.wstr();
 #else

--- a/src/track/taglib/trackmetadata_file.cpp
+++ b/src/track/taglib/trackmetadata_file.cpp
@@ -120,6 +120,8 @@ bool readAudioPropertiesFromFile(
     // we must pick one explicit,
     // to prevent "use of overloaded operator '<<' is ambiguous" error
     // on clang-cl builds.
+    // We need to save the filename here because if it was chained 
+    // (`file.name().wstr()`) the wstr() result would be dangling. 
     TagLib::FileName filename_owning = file.name();
     const std::wstring& filename = filename_owning.wstr();
 #else


### PR DESCRIPTION
This should fix the empty filename in the taglib error message
https://github.com/mixxxdj/mixxx/issues/11964

Maybe one can share some C++ knowledge, was 
```
const std::wstring& filename = file.name().wstr();
```
not allowed or is it a compiler bug? 
 
with `const std::wstring &wstr() const;`
and file name() returns by value. 