### PR TITLE
fix(wspinnyglsl): fix drawing of non-square textures

### DIFF
--- a/src/widget/wspinnyglsl.cpp
+++ b/src/widget/wspinnyglsl.cpp
@@ -174,8 +174,8 @@ void WSpinnyGLSL::drawTexture(QOpenGLTexture* texture) {
     const float th = texture->height();
 
     // fill centered
-    const float posx2 = tw >= th ? 1.f : (th - tw) / th;
-    const float posy2 = th >= tw ? 1.f : (tw - th) / tw;
+    const float posx2 = tw >= th ? 1.f : tw / th;
+    const float posy2 = th >= tw ? 1.f : th / tw;
     const float posx1 = -posx2;
     const float posy1 = -posy2;
 


### PR DESCRIPTION
Fixes #11967 
Thank you @m0dB for the fix. 
@ronso0 this looks correct to you too, right?

![Screenshot from 2023-09-12 17-48-34](https://github.com/mixxxdj/mixxx/assets/12380386/a866fe08-a206-4f77-9496-84f93342bfbb)
