### PR TITLE
Log warning if deprecated control is used

### DIFF
--- a/src/control/control.cpp
+++ b/src/control/control.cpp
@@ -150,6 +150,16 @@ QSharedPointer<ControlDoublePrivate> ControlDoublePrivate::getControl(
         if (it != s_qCOHash.end()) {
             auto pControl = it.value().lock();
             if (pControl) {
+                auto actualKey = pControl->getKey();
+                if (actualKey != key) {
+                    qWarning()
+                            << "ControlObject accessed via deprecated key"
+                            << key.group << key.item
+                            << "- use"
+                            << actualKey.group << actualKey.item
+                            << "instead";
+                }
+
                 // Control object already exists
                 if (pCreatorCO) {
                     qWarning()


### PR DESCRIPTION
This will make it easier to find uses of deprecated controls. Idea blatantly stolen from @Swiftb0y who suggested it here: https://github.com/mixxxdj/mixxx/pull/11960#discussion_r1321982436