### PR TITLE
Skins: Fix sidebar item styling on 2.4 too

### DIFF
--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -231,7 +231,6 @@ WLibrarySidebar::item:selected,
 }
 WLibrarySidebar::item:selected:focus {
   outline: none;
-  border: 0px;
 }
 WLibrarySidebar::item:!selected:focus {
   outline: none;

--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -2074,7 +2074,6 @@ WTrackTableView::item:selected,
 }
 WLibrarySidebar::item:selected:focus {
   outline: none;
-  border: 0px;
 }
 WLibrarySidebar::item:!selected:focus {
   outline: none;

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -2558,7 +2558,6 @@ WTrackTableView::item:selected,
 }
 WLibrarySidebar::item:selected:focus {
   outline: none;
-  border: 0px;
 }
 WLibrarySidebar::item:!selected:focus {
   outline: none;

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -482,7 +482,6 @@ WLibrarySidebar {
 }
 WLibrarySidebar::item:selected:focus {
   outline: none;
-  border: 0px;
 }
 WLibrarySidebar::item:!selected:focus {
   outline: none;

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -2660,7 +2660,6 @@ WLibrarySidebar::item:!selected {
   }
 WLibrarySidebar::item:selected:focus {
   outline: none;
-  border: 0px;
 }
 WLibrarySidebar::item:!selected:focus {
   outline: none;


### PR DESCRIPTION
Forgot this affected 2.4 too, so here's a cherry-pick of #11970 onto 2.4

cc @ronso0 