### PR TITLE
iTunes: Add composer, play count, dates and display name to schema (bumping it to v40)

### DIFF
--- a/res/schema.xml
+++ b/res/schema.xml
@@ -584,4 +584,22 @@ reapplying those migrations.
       UPDATE library SET filetype='aiff' WHERE filetype='aif';
     </sql>
   </revision>
+  <revision version="40" min_compatible="3">
+    <description>
+      Add composer, played, last_played_at and datetime_added to iTunes tracks
+      and a (non-unique) display_name to iTunes playlists.
+    </description>
+    <sql>
+      ALTER TABLE itunes_library ADD COLUMN composer TEXT DEFAULT "";
+      ALTER TABLE itunes_library ADD COLUMN timesplayed INTEGER DEFAULT 0;
+      ALTER TABLE itunes_library ADD COLUMN last_played_at DATETIME DEFAULT NULL;
+      ALTER TABLE itunes_library ADD COLUMN datetime_added DATETIME DEFAULT NULL;
+
+      ALTER TABLE itunes_playlists ADD COLUMN display_name TEXT DEFAULT "";
+
+      -- Default to the unique name for now, this will be overridden on the next
+      -- iTunes import anyway.
+      UPDATE itunes_playlists SET display_name=name;
+    </sql>
+  </revision>
 </schema>

--- a/src/database/mixxxdb.cpp
+++ b/src/database/mixxxdb.cpp
@@ -12,7 +12,7 @@
 const QString MixxxDb::kDefaultSchemaFile(":/schema.xml");
 
 //static
-const int MixxxDb::kRequiredSchemaVersion = 39;
+const int MixxxDb::kRequiredSchemaVersion = 40;
 
 namespace {
 

--- a/src/library/itunes/itunesdao.cpp
+++ b/src/library/itunes/itunesdao.cpp
@@ -48,12 +48,16 @@ void ITunesDAO::initialize(const QSqlDatabase& database) {
     m_insertTrackQuery.prepare(
             "INSERT INTO itunes_library (id, artist, title, album, "
             "album_artist, genre, grouping, year, duration, "
-            "location, rating, comment, tracknumber, bpm, bitrate) "
+            "location, rating, comment, tracknumber, bpm, bitrate, composer, "
+            "timesplayed, last_played_at, datetime_added) "
             "VALUES (:id, :artist, :title, :album, :album_artist, "
             ":genre, :grouping, :year, :duration, :location, "
-            ":rating, :comment, :tracknumber, :bpm, :bitrate)");
+            ":rating, :comment, :tracknumber, :bpm, :bitrate, :composer, "
+            ":timesplayed, :last_played_at, :datetime_added)");
 
-    m_insertPlaylistQuery.prepare("INSERT INTO itunes_playlists (id, name) VALUES (:id, :name)");
+    m_insertPlaylistQuery.prepare(
+            "INSERT INTO itunes_playlists (id, name, display_name) VALUES "
+            "(:id, :name, :display_name)");
 
     m_insertPlaylistTrackQuery.prepare(
             "INSERT INTO itunes_playlist_tracks (playlist_id, track_id, "
@@ -86,6 +90,10 @@ bool ITunesDAO::importTrack(const ITunesTrack& track) {
                 track.trackNumber > 0 ? QVariant(track.trackNumber) : QVariant());
         query.bindValue(":bpm", track.bpm);
         query.bindValue(":bitrate", track.bitrate);
+        query.bindValue(":composer", track.composer);
+        query.bindValue(":timesplayed", track.playCount);
+        query.bindValue(":last_played_at", track.lastPlayedAt);
+        query.bindValue(":datetime_added", track.dateAdded);
 
         if (!query.exec()) {
             LOG_FAILED_QUERY(query);
@@ -104,6 +112,7 @@ bool ITunesDAO::importPlaylist(const ITunesPlaylist& playlist) {
 
         query.bindValue(":id", playlist.id);
         query.bindValue(":name", uniqueName);
+        query.bindValue(":display_name", playlist.name);
 
         if (!query.exec()) {
             LOG_FAILED_QUERY(query);

--- a/src/library/itunes/itunesfeature.cpp
+++ b/src/library/itunes/itunesfeature.cpp
@@ -366,7 +366,7 @@ void ITunesFeature::onTrackCollectionLoaded() {
     if (root) {
         m_pSidebarModel->setRootItem(std::move(root));
 
-        // Tell the rhythmbox track source that it should re-build its index.
+        // Tell the iTunes track source that it should re-build its index.
         m_trackSource->buildIndex();
 
         //m_pITunesTrackModel->select();

--- a/src/library/itunes/itunesfeature.cpp
+++ b/src/library/itunes/itunesfeature.cpp
@@ -61,12 +61,15 @@ ITunesFeature::ITunesFeature(Library* pLibrary, UserSettingsPointer pConfig)
     QString idColumn = "id";
     QStringList columns = {
             "id",
+            "timesplayed",
+            "last_played_at",
             "artist",
             "title",
             "album",
             "album_artist",
             "year",
             "genre",
+            "composer",
             "grouping",
             "tracknumber",
             "location",
@@ -74,13 +77,15 @@ ITunesFeature::ITunesFeature(Library* pLibrary, UserSettingsPointer pConfig)
             "duration",
             "bitrate",
             "bpm",
-            "rating"};
+            "rating",
+            "datetime_added"};
     QStringList searchColumns = {
             "artist",
             "album",
             "album_artist",
             "location",
             "grouping",
+            "composer",
             "comment",
             "title",
             "genre"};


### PR DESCRIPTION
This is the follow-up to #11948 that adds the new iTunes track columns (composer, play count, last played, date added) to the database. Targeting `main` since it bumps the schema.

Additionally it adds a new display name column to the playlists table which stores the non-unique name, to prepare for better search queries (see the future directions in #11955 for details).

To do:

- [x] Update schema
- [x] Populate new columns in `ITunesDAO`
- [ ] Figure out why the `Last Played` column is still empty (even where the date is set in the db, the date added column seems to work fine for some reason?)