### PR TITLE
Refactor(parented_ptr): make trivially destructible in release mode, delete move operations

### DIFF
--- a/src/util/parented_ptr.h
+++ b/src/util/parented_ptr.h
@@ -36,8 +36,11 @@ class parented_ptr final {
     // explicitly generate trivial destructor (since decltype(m_ptr) is not a class type)
     ~parented_ptr() noexcept = default;
 #endif
+    // Rule of 5
     parented_ptr(const parented_ptr<T>&) = delete;
     parented_ptr& operator=(const parented_ptr<T>&) = delete;
+    parented_ptr(const parented_ptr<T>&& other) = delete;
+    parented_ptr& operator=(const parented_ptr<T>&& other) = delete;
 
     // If U* is convertible to T* then parented_ptr<U> is convertible to parented_ptr<T>
     template<

--- a/src/util/parented_ptr.h
+++ b/src/util/parented_ptr.h
@@ -26,12 +26,16 @@ class parented_ptr final {
     explicit parented_ptr(T* t) noexcept
             : m_ptr{t} {
     }
-
+// Only generate destructor if not empty, otherwise its empty but will
+// cause the parented_ptr to be not trivially destructible even though it could be.
+#ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
     ~parented_ptr() noexcept {
         DEBUG_ASSERT(!m_ptr || static_cast<const QObject*>(m_ptr)->parent());
     }
-
-    // Delete copy constructor and copy assignment operator
+#else
+    // explicitly generate trivial destructor (since decltype(m_ptr) is not a class type)
+    ~parented_ptr() noexcept = default;
+#endif
     parented_ptr(const parented_ptr<T>&) = delete;
     parented_ptr& operator=(const parented_ptr<T>&) = delete;
 

--- a/src/widget/findonwebmenufactory.cpp
+++ b/src/widget/findonwebmenufactory.cpp
@@ -11,14 +11,9 @@ namespace mixxx {
 namespace library {
 
 void createFindOnWebSubmenus(QMenu* pFindOnWebMenu, const Track& track) {
-    auto pFindOnWebMenuSoundcloud = make_parented<QMenu>(
-            new FindOnWebMenuSoundcloud(pFindOnWebMenu, track));
-
-    auto pFindOnWebMenuDiscogs = make_parented<QMenu>(
-            new FindOnWebMenuDiscogs(pFindOnWebMenu, track));
-
-    auto pFindOnWebMenuLastfm = make_parented<QMenu>(
-            new FindOnWebMenuLastfm(pFindOnWebMenu, track));
+    make_parented<QMenu>(new FindOnWebMenuSoundcloud(pFindOnWebMenu, track));
+    make_parented<QMenu>(new FindOnWebMenuDiscogs(pFindOnWebMenu, track));
+    make_parented<QMenu>(new FindOnWebMenuLastfm(pFindOnWebMenu, track));
 }
 
 } // namespace library


### PR DESCRIPTION
not ready yet, just did this for fun and an experiment. wdyt about this? It's obviously not super necessary but it may take of even more burden of a reviewer when they see a `make_parented`, knowing that it will only work if the object is actually capable of participating in the Object Tree memory management and not just taking a `QObject` by chance. 
Thoughts and reviews welcome even though this is just a draft. 