### PR TITLE
EGL

### DIFF
--- a/src/shaders/endoftrackshader.cpp
+++ b/src/shaders/endoftrackshader.cpp
@@ -4,9 +4,9 @@ using namespace mixxx;
 
 void EndOfTrackShader::init() {
     QString vertexShaderCode = QStringLiteral(R"--(
-attribute vec4 position;
-attribute float gradient;
-varying float vgradient;
+attribute highp vec4 position;
+attribute highp float gradient;
+varying highp float vgradient;
 void main()
 {
     vgradient = gradient;
@@ -15,12 +15,12 @@ void main()
 )--");
 
     QString fragmentShaderCode = QStringLiteral(R"--(
-uniform vec4 color;
-varying float vgradient;
+uniform highp vec4 color;
+varying highp float vgradient;
 void main()
 {
-    float minAlpha = 0.5 * color.w;
-    float maxAlpha = 0.83 * color.w;
+    float minAlpha = 0.5f * color.w;
+    float maxAlpha = 0.83f * color.w;
     gl_FragColor = vec4(color.xyz, mix(minAlpha, maxAlpha, max(0.,vgradient)));
 }
 )--");

--- a/src/shaders/rgbashader.cpp
+++ b/src/shaders/rgbashader.cpp
@@ -5,9 +5,9 @@ using namespace mixxx;
 void RGBAShader::init() {
     QString vertexShaderCode = QStringLiteral(R"--(
 uniform mat4 matrix;
-attribute vec4 position;
-attribute vec4 color;
-varying vec4 vcolor;
+attribute highp vec4 position;
+attribute highp vec4 color;
+varying highp vec4 vcolor;
 void main()
 {
     vcolor = color;
@@ -16,7 +16,7 @@ void main()
 )--");
 
     QString fragmentShaderCode = QStringLiteral(R"--(
-varying vec4 vcolor;
+varying highp vec4 vcolor;
 void main()
 {
     gl_FragColor = vcolor;

--- a/src/shaders/rgbshader.cpp
+++ b/src/shaders/rgbshader.cpp
@@ -5,9 +5,9 @@ using namespace mixxx;
 void RGBShader::init() {
     QString vertexShaderCode = QStringLiteral(R"--(
 uniform mat4 matrix;
-attribute vec4 position;
-attribute vec3 color;
-varying vec3 vcolor;
+attribute highp vec4 position;
+attribute highp vec3 color;
+varying highp vec3 vcolor;
 void main()
 {
     vcolor = color;
@@ -16,7 +16,7 @@ void main()
 )--");
 
     QString fragmentShaderCode = QStringLiteral(R"--(
-varying vec3 vcolor;
+varying highp vec3 vcolor;
 void main()
 {
     gl_FragColor = vec4(vcolor,1.0);

--- a/src/shaders/textureshader.cpp
+++ b/src/shaders/textureshader.cpp
@@ -5,9 +5,9 @@ using namespace mixxx;
 void TextureShader::init() {
     QString vertexShaderCode = QStringLiteral(R"--(
 uniform mat4 matrix;
-attribute vec4 position;
-attribute vec3 texcoor;
-varying vec3 vTexcoor;
+attribute highp vec4 position;
+attribute highp vec3 texcoor;
+varying highp vec3 vTexcoor;
 void main()
 {
     vTexcoor = texcoor;
@@ -17,7 +17,7 @@ void main()
 
     QString fragmentShaderCode = QStringLiteral(R"--(
 uniform sampler2D sampler;
-varying vec3 vTexcoor;
+varying highp vec3 vTexcoor;
 void main()
 {
     gl_FragColor = texture2D(sampler, vTexcoor.xy);

--- a/src/shaders/unicolorshader.cpp
+++ b/src/shaders/unicolorshader.cpp
@@ -5,7 +5,7 @@ using namespace mixxx;
 void UnicolorShader::init() {
     QString vertexShaderCode = QStringLiteral(R"--(
 uniform mat4 matrix;
-attribute vec4 position;
+attribute highp vec4 position;
 void main()
 {
     gl_Position = matrix * position;
@@ -13,7 +13,7 @@ void main()
 )--");
 
     QString fragmentShaderCode = QStringLiteral(R"--(
-uniform vec4 color;
+uniform highp vec4 color;
 void main()
 {
     gl_FragColor = color;

--- a/src/shaders/vinylqualityshader.cpp
+++ b/src/shaders/vinylqualityshader.cpp
@@ -5,9 +5,9 @@ using namespace mixxx;
 void VinylQualityShader::init() {
     QString vertexShaderCode = QStringLiteral(R"--(
 uniform mat4 matrix;
-attribute vec4 position;
-attribute vec3 texcoor;
-varying vec3 vTexcoor;
+attribute highp vec4 position;
+attribute highp vec3 texcoor;
+varying highp vec3 vTexcoor;
 void main()
 {
     vTexcoor = texcoor;
@@ -17,11 +17,11 @@ void main()
 
     QString fragmentShaderCode = QStringLiteral(R"--(
 uniform sampler2D sampler;
-uniform vec4 color;
-varying vec3 vTexcoor;
+uniform highp vec4 color;
+varying highp vec3 vTexcoor;
 void main()
 {
-    gl_FragColor = vec4(color.xyz, texture2D(sampler, vTexcoor.xy) * 0.75);
+    gl_FragColor = vec4(color.xyz, texture2D(sampler, vTexcoor.xy) * 0.75f);
 }
 )--");
 

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -173,10 +173,13 @@ WaveformWidgetFactory::WaveformWidgetFactory()
             m_openGLVersion = pContext->isOpenGLES() ? "ES " : "";
             m_openGLVersion += majorVersion == 0 ? QString("None") : versionString;
 
-            if (majorVersion * 100 + minorVersion >= 201) {
-                if (pContext->isOpenGLES()) {
+            // Qt5 requires at least OpenGL 2.1 or OpenGL ES 2.0
+            if (pContext->isOpenGLES()) {
+                if (majorVersion * 100 + minorVersion >= 200) {
                     m_openGlesAvailable = true;
-                } else {
+                }
+            } else {
+                if (majorVersion * 100 + minorVersion >= 201) {
                     m_openGlAvailable = true;
                 }
             }
@@ -1188,11 +1191,11 @@ QString WaveformWidgetFactory::buildWidgetDisplayName() const {
 QSurfaceFormat WaveformWidgetFactory::getSurfaceFormat() {
     QSurfaceFormat format;
     // Qt5 requires at least OpenGL 2.1 or OpenGL ES 2.0, default is 2.0
-    format.setVersion(2, 1);
+    // format.setVersion(2, 1);
     // Core and Compatibility contexts have been introduced in openGL 3.2
     // From 3.0 to 3.1 we have implicit the Core profile and Before 3.0 we have the
     // Compatibility profile
-    format.setProfile(QSurfaceFormat::CoreProfile);
+    // format.setProfile(QSurfaceFormat::CoreProfile);
 
     // setSwapInterval sets the application preferred swap interval
     // in minimum number of video frames that are displayed before a buffer swap occurs

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -1170,14 +1170,14 @@ QString WaveformWidgetFactory::buildWidgetDisplayName() const {
     if (isLegacy) {
         extras.push_back(tr("legacy"));
     }
-    if (isOpenGlAvailable() || isOpenGlesAvailable()) {
-        if (WaveformT::useOpenGles()) {
-            if (WaveformT::useOpenGLShaders()) {
-                extras.push_back(QStringLiteral("GLSL ES"));
-            } else {
-                extras.push_back(QStringLiteral("GLES"));
-            }
-        } else if (WaveformT::useOpenGLShaders()) {
+    if (isOpenGlesAvailable()) {
+        if (WaveformT::useOpenGLShaders()) {
+            extras.push_back(QStringLiteral("GLSL ES"));
+        } else if (WaveformT::useOpenGles()) {
+            extras.push_back(QStringLiteral("GLES"));
+        }
+    } else if (isOpenGlAvailable()) {
+        if (WaveformT::useOpenGLShaders()) {
             extras.push_back(QStringLiteral("GLSL"));
         } else if (WaveformT::useOpenGl()) {
             extras.push_back(QStringLiteral("GL"));

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -1187,7 +1187,11 @@ QString WaveformWidgetFactory::buildWidgetDisplayName() const {
 // static
 QSurfaceFormat WaveformWidgetFactory::getSurfaceFormat() {
     QSurfaceFormat format;
+    // Qt5 requires at least OpenGL 2.1 or OpenGL ES 2.0, default is 2.0
     format.setVersion(2, 1);
+    // Core and Compatibility contexts have been introduced in openGL 3.2
+    // From 3.0 to 3.1 we have implicit the Core profile and Before 3.0 we have the
+    // Compatibility profile
     format.setProfile(QSurfaceFormat::CoreProfile);
 
     // setSwapInterval sets the application preferred swap interval

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -1171,13 +1171,16 @@ QString WaveformWidgetFactory::buildWidgetDisplayName() const {
         extras.push_back(tr("legacy"));
     }
     if (isOpenGlAvailable() || isOpenGlesAvailable()) {
-        if (WaveformT::useOpenGLShaders()) {
+        if (WaveformT::useOpenGles()) {
+            if (WaveformT::useOpenGLShaders()) {
+                extras.push_back(QStringLiteral("GLSL ES"));
+            } else {
+                extras.push_back(QStringLiteral("GLES"));
+            }
+        } else if (WaveformT::useOpenGLShaders()) {
             extras.push_back(QStringLiteral("GLSL"));
         } else if (WaveformT::useOpenGl()) {
             extras.push_back(QStringLiteral("GL"));
-        }
-        if (WaveformT::useOpenGles()) {
-            extras.push_back(QStringLiteral("ES"));
         }
     }
     QString name = WaveformT::getWaveformWidgetName();

--- a/src/waveform/widgets/allshader/filteredwaveformwidget.h
+++ b/src/waveform/widgets/allshader/filteredwaveformwidget.h
@@ -23,7 +23,7 @@ class allshader::FilteredWaveformWidget final : public allshader::WaveformWidget
         return true;
     }
     static constexpr bool useOpenGles() {
-        return false;
+        return true;
     }
     static constexpr bool useOpenGLShaders() {
         return true;

--- a/src/waveform/widgets/allshader/hsvwaveformwidget.h
+++ b/src/waveform/widgets/allshader/hsvwaveformwidget.h
@@ -23,7 +23,7 @@ class allshader::HSVWaveformWidget final : public allshader::WaveformWidget {
         return true;
     }
     static constexpr bool useOpenGles() {
-        return false;
+        return true;
     }
     static constexpr bool useOpenGLShaders() {
         return true;

--- a/src/waveform/widgets/allshader/lrrgbwaveformwidget.h
+++ b/src/waveform/widgets/allshader/lrrgbwaveformwidget.h
@@ -23,7 +23,7 @@ class allshader::LRRGBWaveformWidget final : public allshader::WaveformWidget {
         return true;
     }
     static constexpr bool useOpenGles() {
-        return false;
+        return true;
     }
     static constexpr bool useOpenGLShaders() {
         return true;

--- a/src/waveform/widgets/allshader/rgbwaveformwidget.h
+++ b/src/waveform/widgets/allshader/rgbwaveformwidget.h
@@ -23,7 +23,7 @@ class allshader::RGBWaveformWidget final : public allshader::WaveformWidget {
         return true;
     }
     static constexpr bool useOpenGles() {
-        return false;
+        return true;
     }
     static constexpr bool useOpenGLShaders() {
         return true;

--- a/src/waveform/widgets/allshader/simplewaveformwidget.h
+++ b/src/waveform/widgets/allshader/simplewaveformwidget.h
@@ -23,7 +23,7 @@ class allshader::SimpleWaveformWidget final : public allshader::WaveformWidget {
         return true;
     }
     static constexpr bool useOpenGles() {
-        return false;
+        return true;
     }
     static constexpr bool useOpenGLShaders() {
         return true;


### PR DESCRIPTION
This brings back the GLES support required for Windows drivers that are ignored by QT and on Single PCB devices like Raspberry PI. 

The spinnies are still black. https://github.com/mixxxdj/mixxx/issues/11930

Fixes https://github.com/mixxxdj/mixxx/issues/11641