### PR TITLE
test(coreservices): Fix and re-enable `CoreServicesTest`

### DIFF
--- a/.github/workflows/build-checks.yml
+++ b/.github/workflows/build-checks.yml
@@ -121,7 +121,7 @@ jobs:
           CLAZY_IGNORE_DIRS: lib/.*
       - name: "Test"
         if: matrix.name == 'coverage'
-        run: ctest --timeout 45
+        run: ctest --timeout 45 --exclude-regex '^CoreServicesTest\.'
         working-directory: build
         env:
           # Render analyzer waveform tests to an offscreen buffer

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
               -DMODPLUG=ON
               -DWAVPACK=ON
               -DINSTALL_USER_UDEV_RULES=OFF
-            ctest_args: []
+            ctest_args: --exclude-regex '^CoreServicesTest\.'
             compiler_cache: ccache
             compiler_cache_path: ~/.ccache
             cpack_generator: DEB
@@ -48,7 +48,7 @@ jobs:
               -DMODPLUG=ON
               -DWAVPACK=ON
               -DINSTALL_USER_UDEV_RULES=OFF
-            ctest_args: []
+            ctest_args: --exclude-regex '^CoreServicesTest\.'
             compiler_cache: ccache
             compiler_cache_path: ~/.ccache
             cpack_generator: DEB
@@ -70,7 +70,7 @@ jobs:
               -DVCPKG_TARGET_TRIPLET=x64-osx-min1012
               -DVCPKG_DEFAULT_HOST_TRIPLET=x64-osx-min1012
             # TODO: Fix this broken test on macOS
-            ctest_args: --exclude-regex DirectoryDAOTest.relocateDirectory
+            ctest_args: --exclude-regex '^(DirectoryDAOTest\.relocateDirectory|CoreServicesTest\.)'
             cpack_generator: DragNDrop
             compiler_cache: ccache
             compiler_cache_path: /Users/runner/Library/Caches/ccache
@@ -121,7 +121,7 @@ jobs:
             cc: cl
             cxx: cl
             # TODO: Fix these broken tests on Windows
-            ctest_args: --exclude-regex '^AutoDJProcessorTest.*$'
+            ctest_args: --exclude-regex '^(AutoDJProcessorTest|CoreServicesTest)\..*$'
             cpack_generator: WIX
             compiler_cache: sccache
             compiler_cache_path: C:\Users\runneradmin\AppData\Local\Mozilla\sccache\cache

--- a/src/coreservices.h
+++ b/src/coreservices.h
@@ -25,7 +25,6 @@ class ControllerManager;
 class VinylControlManager;
 class TrackCollectionManager;
 class Library;
-class LV2Backend;
 
 namespace mixxx {
 
@@ -81,10 +80,6 @@ class CoreServices : public QObject {
         return m_pVCManager;
     }
 
-    LV2Backend* getLV2Backend() const {
-        return m_pLV2Backend;
-    }
-
     std::shared_ptr<EffectsManager> getEffectsManager() const {
         return m_pEffectsManager;
     }
@@ -128,8 +123,6 @@ class CoreServices : public QObject {
     std::shared_ptr<SettingsManager> m_pSettingsManager;
     std::shared_ptr<mixxx::ControlIndicatorTimer> m_pControlIndicatorTimer;
     std::shared_ptr<EffectsManager> m_pEffectsManager;
-    // owned by EffectsManager
-    LV2Backend* m_pLV2Backend;
     std::shared_ptr<EngineMixer> m_pEngine;
     std::shared_ptr<SoundManager> m_pSoundManager;
     std::shared_ptr<PlayerManager> m_pPlayerManager;

--- a/src/test/coreservicestest.cpp
+++ b/src/test/coreservicestest.cpp
@@ -22,7 +22,6 @@ TEST_F(CoreServicesTest, DISABLED_TestInitialization) {
 
     EXPECT_NE(pCoreServices->getControllerManager(), nullptr);
     EXPECT_NE(pCoreServices->getEffectsManager(), nullptr);
-    EXPECT_NE(pCoreServices->getLV2Backend(), nullptr);
     EXPECT_NE(pCoreServices->getLibrary(), nullptr);
     EXPECT_NE(pCoreServices->getPlayerManager(), nullptr);
     EXPECT_NE(pCoreServices->getScreensaverManager(), nullptr);

--- a/src/test/coreservicestest.cpp
+++ b/src/test/coreservicestest.cpp
@@ -2,22 +2,13 @@
 
 #include "coreservices.h"
 #include "test/mixxxtest.h"
-#include "util/cmdlineargs.h"
 
 class CoreServicesTest : public MixxxTest {
 };
 
 // This test is disabled because it fails on CI for some unknown reason.
-TEST_F(CoreServicesTest, DISABLED_TestInitialization) {
-    // Initialize the app
-    constexpr int argc = 1;
-    CmdlineArgs cmdlineArgs;
-    char progName[] = "mixxxtest";
-    char safeMode[] = "--safe-mode";
-    char* argv[] = {progName, safeMode};
-    cmdlineArgs.parse(argc, argv);
-
-    const auto pCoreServices = std::make_unique<mixxx::CoreServices>(cmdlineArgs, application());
+TEST_F(CoreServicesTest, TestInitialization) {
+    const auto pCoreServices = std::make_unique<mixxx::CoreServices>(cmdLineArgs(), application());
     pCoreServices->initialize(application());
 
     EXPECT_NE(pCoreServices->getControllerManager(), nullptr);

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -24,8 +24,13 @@ int main(int argc, char **argv) {
         testing::InitGoogleTest(&argc, argv);
     }
 
+    int testArgc = 1;
+    char testProgName[] = "mixxxtest";
+    char testSafeMode[] = "--safe-mode";
+    char* testArgv[] = {testProgName, testSafeMode};
+
     // Otherwise, run the test suite:
-    MixxxTest::ApplicationScope applicationScope(argc, argv);
+    MixxxTest::ApplicationScope applicationScope(testArgc, testArgv);
 
     if (run_benchmarks) {
         benchmark::RunSpecifiedBenchmarks();

--- a/src/test/mixxxtest.cpp
+++ b/src/test/mixxxtest.cpp
@@ -20,15 +20,15 @@ QString makeTestConfigFile(const QString& path) {
 
 // Static initialization
 QScopedPointer<MixxxApplication> MixxxTest::s_pApplication;
+CmdlineArgs MixxxTest::s_cmdLineArgs;
 QDir MixxxTest::s_TestDir;
 
 MixxxTest::ApplicationScope::ApplicationScope(int& argc, char** argv) {
-    CmdlineArgs args;
-    const bool argsParsed = args.parse(argc, argv);
+    const bool argsParsed = s_cmdLineArgs.parse(argc, argv);
     Q_UNUSED(argsParsed);
     DEBUG_ASSERT(argsParsed);
 
-    mixxx::LogLevel logLevel = args.getLogLevel();
+    mixxx::LogLevel logLevel = s_cmdLineArgs.getLogLevel();
 
     // Log level Debug would produce too many log messages that
     // might abort and fail the CI builds.

--- a/src/test/mixxxtest.h
+++ b/src/test/mixxxtest.h
@@ -8,6 +8,7 @@
 
 #include "mixxxapplication.h"
 #include "preferences/usersettings.h"
+#include "util/cmdlineargs.h"
 
 #define EXPECT_QSTRING_EQ(expected, test) EXPECT_STREQ(qPrintable(expected), qPrintable(test))
 #define ASSERT_QSTRING_EQ(expected, test) ASSERT_STREQ(qPrintable(expected), qPrintable(test))
@@ -48,6 +49,10 @@ class MixxxTest : public testing::Test {
         return s_pApplication.data();
     }
 
+    const CmdlineArgs& cmdLineArgs() {
+        return s_cmdLineArgs;
+    }
+
     UserSettingsPointer config() const {
         return m_pConfig;
     }
@@ -64,6 +69,7 @@ class MixxxTest : public testing::Test {
     }
 
   private:
+    static CmdlineArgs s_cmdLineArgs;
     static QScopedPointer<MixxxApplication> s_pApplication;
     static QDir s_TestDir;
     const QTemporaryDir m_testDataDir;


### PR DESCRIPTION
It still does not work on CI (timeout) but at least we should keep it enabled locally.