### PR TITLE
Fixup: Removed unsupported floating-point suffix prior to GLSL ES 3.00

### DIFF
--- a/src/shaders/endoftrackshader.cpp
+++ b/src/shaders/endoftrackshader.cpp
@@ -19,8 +19,8 @@ uniform highp vec4 color;
 varying highp float vgradient;
 void main()
 {
-    float minAlpha = 0.5f * color.w;
-    float maxAlpha = 0.83f * color.w;
+    float minAlpha = 0.5 * color.w;
+    float maxAlpha = 0.83 * color.w;
     gl_FragColor = vec4(color.xyz, mix(minAlpha, maxAlpha, max(0.,vgradient)));
 }
 )--");

--- a/src/shaders/vinylqualityshader.cpp
+++ b/src/shaders/vinylqualityshader.cpp
@@ -21,7 +21,7 @@ uniform highp vec4 color;
 varying highp vec3 vTexcoor;
 void main()
 {
-    gl_FragColor = vec4(color.xyz, texture2D(sampler, vTexcoor.xy) * 0.75f);
+    gl_FragColor = vec4(color.xyz, texture2D(sampler, vTexcoor.xy) * 0.75);
 }
 )--");
 


### PR DESCRIPTION
This fixes the issue reported here: 
https://github.com/mixxxdj/mixxx/pull/11982

```
warning [Main] QOpenGLShader::compile(Fragment): ERROR: 0:7: '0.75f' : Floating-point suffix unsupported prior to GLSL ES 3.00
ERROR: 0:7: '0.75f' : syntax error
```
