### PR TITLE
CO Renaming (Pt. 3): Add `ControlPotMeter` aliasing and move `audio_latency_*` COs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1845,6 +1845,7 @@ add_executable(mixxx-test
   src/test/controlobjecttest.cpp
   src/test/controlobjectaliastest.cpp
   src/test/controlobjectscripttest.cpp
+  src/test/controlpotmetertest.cpp
   src/test/coreservicestest.cpp
   src/test/coverartcache_test.cpp
   src/test/coverartutils_test.cpp

--- a/res/controllers/Stanton-SCS3m-scripts.js
+++ b/res/controllers/Stanton-SCS3m-scripts.js
@@ -869,7 +869,7 @@ SCS3M.Agent = function(device) {
         }
 
         // Light the logo and let it go out to signal an overload
-        watch("[Master]", 'audio_latency_overload', binarylight(
+        watch("[App]", 'audio_latency_overload', binarylight(
             device.logo.on,
             device.logo.off
         ));

--- a/res/skins/LateNight/toolbar.xml
+++ b/res/skins/LateNight/toolbar.xml
@@ -178,12 +178,12 @@
                     <PeakFallTime>100</PeakFallTime>
                     <PeakFallStep>1</PeakFallStep>
                     <Connection>
-                      <ConfigKey>[Master],audio_latency_usage</ConfigKey>
+                      <ConfigKey>[App],audio_latency_usage</ConfigKey>
                     </Connection>
                   </VuMeter>
                 </Children>
                 <Connection>
-                  <ConfigKey>[Master],audio_latency_overload</ConfigKey>
+                  <ConfigKey>[App],audio_latency_overload</ConfigKey>
                   <BindProperty>highlight</BindProperty>
                 </Connection>
               </WidgetGroup><!-- LatencyMeterBox -->

--- a/res/skins/Shade/mixer_panel.xml
+++ b/res/skins/Shade/mixer_panel.xml
@@ -518,7 +518,7 @@
                 <PathStatusLight>audio_latency/audio_latency_overload.png</PathStatusLight>
                 <PathBack>audio_latency/audio_latency_overload_back.png</PathBack>
                 <Connection>
-                  <ConfigKey>[Master],audio_latency_overload</ConfigKey>
+                  <ConfigKey>[App],audio_latency_overload</ConfigKey>
                 </Connection>
               </StatusLight>
 
@@ -537,7 +537,7 @@
                     <PeakFallStep>1</PeakFallStep>
                     <Horizontal>true</Horizontal>
                     <Connection>
-                      <ConfigKey>[Master],audio_latency_usage</ConfigKey>
+                      <ConfigKey>[App],audio_latency_usage</ConfigKey>
                     </Connection>
                   </VuMeter>
                 </Children>

--- a/res/skins/Tango/topbar.xml
+++ b/res/skins/Tango/topbar.xml
@@ -343,7 +343,7 @@ Description:
                     <PeakFallTime>100</PeakFallTime>
                     <PeakFallStep>1</PeakFallStep>
                     <Connection>
-                      <ConfigKey>[Master],audio_latency_usage</ConfigKey>
+                      <ConfigKey>[App],audio_latency_usage</ConfigKey>
                     </Connection>
                   </VuMeter><!-- /latency usage -->
                 </Children>

--- a/src/control/controlpotmeter.cpp
+++ b/src/control/controlpotmeter.cpp
@@ -5,6 +5,14 @@
 #include "control/controlpushbutton.h"
 #include "moc_controlpotmeter.cpp"
 
+namespace {
+
+ConfigKey configKeyFromBaseKey(const ConfigKey& key, const QString& suffix) {
+    return ConfigKey(key.group, QString(key.item) + suffix);
+}
+
+} // namespace
+
 ControlPotmeter::ControlPotmeter(const ConfigKey& key,
         double dMinValue,
         double dMaxValue,
@@ -59,26 +67,16 @@ void ControlPotmeter::privateValueChanged(double dValue, QObject* pSender) {
 
 PotmeterControls::PotmeterControls(const ConfigKey& key)
         : m_control(key, this),
-          m_controlUp(ConfigKey(
-                  key.group, QString(key.item) + QStringLiteral("_up"))),
-          m_controlDown(ConfigKey(
-                  key.group, QString(key.item) + QStringLiteral("_down"))),
-          m_controlUpSmall(ConfigKey(
-                  key.group, QString(key.item) + QStringLiteral("_up_small"))),
-          m_controlDownSmall(ConfigKey(key.group,
-                  QString(key.item) + QStringLiteral("_down_small"))),
-          m_controlSetDefault(ConfigKey(key.group,
-                  QString(key.item) + QStringLiteral("_set_default"))),
-          m_controlSetZero(ConfigKey(
-                  key.group, QString(key.item) + QStringLiteral("_set_zero"))),
-          m_controlSetOne(ConfigKey(
-                  key.group, QString(key.item) + QStringLiteral("_set_one"))),
-          m_controlSetMinusOne(ConfigKey(key.group,
-                  QString(key.item) + QStringLiteral("_set_minus_one"))),
-          m_controlToggle(ConfigKey(
-                  key.group, QString(key.item) + QStringLiteral("_toggle"))),
-          m_controlMinusToggle(ConfigKey(key.group,
-                  QString(key.item) + QStringLiteral("_minus_toggle"))),
+          m_controlUp(configKeyFromBaseKey(key, QStringLiteral("_up"))),
+          m_controlDown(configKeyFromBaseKey(key, QStringLiteral("_down"))),
+          m_controlUpSmall(configKeyFromBaseKey(key, QStringLiteral("_up_small"))),
+          m_controlDownSmall(configKeyFromBaseKey(key, QStringLiteral("_down_small"))),
+          m_controlSetDefault(configKeyFromBaseKey(key, QStringLiteral("_set_default"))),
+          m_controlSetZero(configKeyFromBaseKey(key, QStringLiteral("_set_zero"))),
+          m_controlSetOne(configKeyFromBaseKey(key, QStringLiteral("_set_one"))),
+          m_controlSetMinusOne(configKeyFromBaseKey(key, QStringLiteral("_set_minus_one"))),
+          m_controlToggle(configKeyFromBaseKey(key, QStringLiteral("_toggle"))),
+          m_controlMinusToggle(configKeyFromBaseKey(key, QStringLiteral("_minus_toggle"))),
           m_stepCount(10),
           m_smallStepCount(100) {
     connect(&m_controlUp, &ControlPushButton::valueChanged, this, &PotmeterControls::incValue);
@@ -118,22 +116,16 @@ PotmeterControls::~PotmeterControls() {
 }
 
 void PotmeterControls::addAlias(const ConfigKey& key) {
-    m_controlUp.addAlias(ConfigKey(key.group, QString(key.item) + QStringLiteral("_up")));
-    m_controlDown.addAlias(ConfigKey(key.group, QString(key.item) + QStringLiteral("_down")));
-    m_controlUpSmall.addAlias(ConfigKey(
-            key.group, QString(key.item) + QStringLiteral("_up_small")));
-    m_controlDownSmall.addAlias(ConfigKey(
-            key.group, QString(key.item) + QStringLiteral("_down_small")));
-    m_controlSetDefault.addAlias(ConfigKey(
-            key.group, QString(key.item) + QStringLiteral("_set_default")));
-    m_controlSetZero.addAlias(ConfigKey(
-            key.group, QString(key.item) + QStringLiteral("_set_zero")));
-    m_controlSetOne.addAlias(ConfigKey(key.group, QString(key.item) + QStringLiteral("_set_one")));
-    m_controlSetMinusOne.addAlias(ConfigKey(
-            key.group, QString(key.item) + QStringLiteral("_set_minus_one")));
-    m_controlToggle.addAlias(ConfigKey(key.group, QString(key.item) + QStringLiteral("_toggle")));
-    m_controlMinusToggle.addAlias(ConfigKey(
-            key.group, QString(key.item) + QStringLiteral("_minus_toggle")));
+    m_controlUp.addAlias(configKeyFromBaseKey(key, QStringLiteral("_up")));
+    m_controlDown.addAlias(configKeyFromBaseKey(key, QStringLiteral("_down")));
+    m_controlUpSmall.addAlias(configKeyFromBaseKey(key, QStringLiteral("_up_small")));
+    m_controlDownSmall.addAlias(configKeyFromBaseKey(key, QStringLiteral("_down_small")));
+    m_controlSetDefault.addAlias(configKeyFromBaseKey(key, QStringLiteral("_set_default")));
+    m_controlSetZero.addAlias(configKeyFromBaseKey(key, QStringLiteral("_set_zero")));
+    m_controlSetOne.addAlias(configKeyFromBaseKey(key, QStringLiteral("_set_one")));
+    m_controlSetMinusOne.addAlias(configKeyFromBaseKey(key, QStringLiteral("_set_minus_one")));
+    m_controlToggle.addAlias(configKeyFromBaseKey(key, QStringLiteral("_toggle")));
+    m_controlMinusToggle.addAlias(configKeyFromBaseKey(key, QStringLiteral("_minus_toggle")));
 }
 
 void PotmeterControls::incValue(double v) {

--- a/src/control/controlpotmeter.cpp
+++ b/src/control/controlpotmeter.cpp
@@ -67,6 +67,8 @@ void ControlPotmeter::privateValueChanged(double dValue, QObject* pSender) {
 
 PotmeterControls::PotmeterControls(const ConfigKey& key)
         : m_control(key, this),
+          // When adding an additional control here, do not forget to also add
+          // it to the `PotmeterControls::addAlias()` method, too.
           m_controlUp(configKeyFromBaseKey(key, QStringLiteral("_up"))),
           m_controlDown(configKeyFromBaseKey(key, QStringLiteral("_down"))),
           m_controlUpSmall(configKeyFromBaseKey(key, QStringLiteral("_up_small"))),

--- a/src/control/controlpotmeter.cpp
+++ b/src/control/controlpotmeter.cpp
@@ -58,86 +58,57 @@ void ControlPotmeter::privateValueChanged(double dValue, QObject* pSender) {
 }
 
 PotmeterControls::PotmeterControls(const ConfigKey& key)
-        : m_pControl(new ControlProxy(key, this)),
+        : m_control(key, this),
+          m_controlUp(ConfigKey(
+                  key.group, QString(key.item) + QStringLiteral("_up"))),
+          m_controlDown(ConfigKey(
+                  key.group, QString(key.item) + QStringLiteral("_down"))),
+          m_controlUpSmall(ConfigKey(
+                  key.group, QString(key.item) + QStringLiteral("_up_small"))),
+          m_controlDownSmall(ConfigKey(key.group,
+                  QString(key.item) + QStringLiteral("_down_small"))),
+          m_controlSetDefault(ConfigKey(key.group,
+                  QString(key.item) + QStringLiteral("_set_default"))),
+          m_controlSetZero(ConfigKey(
+                  key.group, QString(key.item) + QStringLiteral("_set_zero"))),
+          m_controlSetOne(ConfigKey(
+                  key.group, QString(key.item) + QStringLiteral("_set_one"))),
+          m_controlSetMinusOne(ConfigKey(key.group,
+                  QString(key.item) + QStringLiteral("_set_minus_one"))),
+          m_controlToggle(ConfigKey(
+                  key.group, QString(key.item) + QStringLiteral("_toggle"))),
+          m_controlMinusToggle(ConfigKey(key.group,
+                  QString(key.item) + QStringLiteral("_minus_toggle"))),
           m_stepCount(10),
           m_smallStepCount(100) {
-    // These controls are deleted when the ControlPotmeter is since
-    // PotmeterControls is a member variable of the associated ControlPotmeter
-    // and the push-button controls are parented to the PotmeterControls.
-
-    ControlPushButton* controlUp = new ControlPushButton(
-        ConfigKey(key.group, QString(key.item) + "_up"));
-    controlUp->setParent(this);
-    connect(controlUp,
-            &ControlPushButton::valueChanged,
-            this,
-            &PotmeterControls::incValue);
-
-    ControlPushButton* controlDown = new ControlPushButton(
-        ConfigKey(key.group, QString(key.item) + "_down"));
-    controlDown->setParent(this);
-    connect(controlDown,
-            &ControlPushButton::valueChanged,
-            this,
-            &PotmeterControls::decValue);
-
-    ControlPushButton* controlUpSmall = new ControlPushButton(
-        ConfigKey(key.group, QString(key.item) + "_up_small"));
-    controlUpSmall->setParent(this);
-    connect(controlUpSmall,
+    connect(&m_controlUp, &ControlPushButton::valueChanged, this, &PotmeterControls::incValue);
+    connect(&m_controlDown, &ControlPushButton::valueChanged, this, &PotmeterControls::decValue);
+    connect(&m_controlUpSmall,
             &ControlPushButton::valueChanged,
             this,
             &PotmeterControls::incSmallValue);
-
-    ControlPushButton* controlDownSmall = new ControlPushButton(
-        ConfigKey(key.group, QString(key.item) + "_down_small"));
-    controlDownSmall->setParent(this);
-    connect(controlDownSmall,
+    connect(&m_controlDownSmall,
             &ControlPushButton::valueChanged,
             this,
             &PotmeterControls::decSmallValue);
-
-    m_pControlDefault = new ControlPushButton(
-            ConfigKey(key.group, QString(key.item) + "_set_default"));
-    m_pControlDefault->setParent(this);
-    connect(m_pControlDefault,
+    connect(&m_controlSetDefault,
             &ControlPushButton::valueChanged,
             this,
             &PotmeterControls::setToDefault);
-
-    ControlPushButton* controlZero = new ControlPushButton(
-        ConfigKey(key.group, QString(key.item) + "_set_zero"));
-    controlZero->setParent(this);
-    connect(controlZero,
+    connect(&m_controlSetZero,
             &ControlPushButton::valueChanged,
             this,
             &PotmeterControls::setToZero);
-
-    ControlPushButton* controlOne = new ControlPushButton(
-        ConfigKey(key.group, QString(key.item) + "_set_one"));
-    controlOne->setParent(this);
-    connect(controlOne,
+    connect(&m_controlSetOne, &ControlPushButton::valueChanged, this, &PotmeterControls::setToOne);
+    connect(&m_controlSetMinusOne,
             &ControlPushButton::valueChanged,
             this,
-            &PotmeterControls::setToOne);
-
-    ControlPushButton* controlMinusOne = new ControlPushButton(
-        ConfigKey(key.group, QString(key.item) + "_set_minus_one"));
-    controlMinusOne->setParent(this);
-    connect(controlMinusOne, &ControlPushButton::valueChanged, this, &PotmeterControls::setToMinusOne);
-
-    ControlPushButton* controlToggle = new ControlPushButton(
-        ConfigKey(key.group, QString(key.item) + "_toggle"));
-    controlToggle->setParent(this);
-    connect(controlToggle,
+            &PotmeterControls::setToMinusOne);
+    connect(&m_controlToggle,
             &ControlPushButton::valueChanged,
             this,
             &PotmeterControls::toggleValue);
-
-    ControlPushButton* controlMinusToggle = new ControlPushButton(
-        ConfigKey(key.group, QString(key.item) + "_minus_toggle"));
-    controlMinusToggle->setParent(this);
-    connect(controlMinusToggle,
+    connect(&m_controlMinusToggle,
             &ControlPushButton::valueChanged,
             this,
             &PotmeterControls::toggleMinusValue);
@@ -146,76 +117,95 @@ PotmeterControls::PotmeterControls(const ConfigKey& key)
 PotmeterControls::~PotmeterControls() {
 }
 
+void PotmeterControls::addAlias(const ConfigKey& key) {
+    m_controlUp.addAlias(ConfigKey(key.group, QString(key.item) + QStringLiteral("_up")));
+    m_controlDown.addAlias(ConfigKey(key.group, QString(key.item) + QStringLiteral("_down")));
+    m_controlUpSmall.addAlias(ConfigKey(
+            key.group, QString(key.item) + QStringLiteral("_up_small")));
+    m_controlDownSmall.addAlias(ConfigKey(
+            key.group, QString(key.item) + QStringLiteral("_down_small")));
+    m_controlSetDefault.addAlias(ConfigKey(
+            key.group, QString(key.item) + QStringLiteral("_set_default")));
+    m_controlSetZero.addAlias(ConfigKey(
+            key.group, QString(key.item) + QStringLiteral("_set_zero")));
+    m_controlSetOne.addAlias(ConfigKey(key.group, QString(key.item) + QStringLiteral("_set_one")));
+    m_controlSetMinusOne.addAlias(ConfigKey(
+            key.group, QString(key.item) + QStringLiteral("_set_minus_one")));
+    m_controlToggle.addAlias(ConfigKey(key.group, QString(key.item) + QStringLiteral("_toggle")));
+    m_controlMinusToggle.addAlias(ConfigKey(
+            key.group, QString(key.item) + QStringLiteral("_minus_toggle")));
+}
+
 void PotmeterControls::incValue(double v) {
     if (v > 0) {
-        double parameter = m_pControl->getParameter();
+        double parameter = m_control.getParameter();
         parameter += 1.0 / m_stepCount;
-        m_pControl->setParameter(parameter);
+        m_control.setParameter(parameter);
     }
 }
 
 void PotmeterControls::decValue(double v) {
     if (v > 0) {
-        double parameter = m_pControl->getParameter();
+        double parameter = m_control.getParameter();
         parameter -= 1.0 / m_stepCount;
-        m_pControl->setParameter(parameter);
+        m_control.setParameter(parameter);
     }
 }
 
 void PotmeterControls::incSmallValue(double v) {
     if (v > 0) {
-        double parameter = m_pControl->getParameter();
+        double parameter = m_control.getParameter();
         parameter += 1.0 / m_smallStepCount;
-        m_pControl->setParameter(parameter);
+        m_control.setParameter(parameter);
     }
 }
 
 void PotmeterControls::decSmallValue(double v) {
     if (v > 0) {
-        double parameter = m_pControl->getParameter();
+        double parameter = m_control.getParameter();
         parameter -= 1.0 / m_smallStepCount;
-        m_pControl->setParameter(parameter);
+        m_control.setParameter(parameter);
     }
 }
 
 void PotmeterControls::setToZero(double v) {
     if (v > 0) {
-        m_pControl->set(0.0);
+        m_control.set(0.0);
     }
 }
 
 void PotmeterControls::setToOne(double v) {
     if (v > 0) {
-        m_pControl->set(1.0);
+        m_control.set(1.0);
     }
 }
 
 void PotmeterControls::setToMinusOne(double v) {
     if (v > 0) {
-        m_pControl->set(-1.0);
+        m_control.set(-1.0);
     }
 }
 
 void PotmeterControls::setToDefault(double v) {
     if (v > 0) {
-        m_pControl->reset();
+        m_control.reset();
     }
 }
 
 void PotmeterControls::toggleValue(double v) {
     if (v > 0) {
-        double value = m_pControl->get();
-        m_pControl->set(value > 0.0 ? 0.0 : 1.0);
+        double value = m_control.get();
+        m_control.set(value > 0.0 ? 0.0 : 1.0);
     }
 }
 
 void PotmeterControls::toggleMinusValue(double v) {
     if (v > 0) {
-        double value = m_pControl->get();
-        m_pControl->set(value > 0.0 ? -1.0 : 1.0);
+        double value = m_control.get();
+        m_control.set(value > 0.0 ? -1.0 : 1.0);
     }
 }
 
 void PotmeterControls::setIsDefault(bool isDefault) {
-    m_pControlDefault->forceSet(isDefault ? 1.0 : 0.0);
+    m_controlSetDefault.forceSet(isDefault ? 1.0 : 0.0);
 }

--- a/src/control/controlpotmeter.h
+++ b/src/control/controlpotmeter.h
@@ -1,7 +1,9 @@
 #pragma once
 
-#include "preferences/usersettings.h"
 #include "control/controlobject.h"
+#include "control/controlproxy.h"
+#include "control/controlpushbutton.h"
+#include "preferences/usersettings.h"
 
 class ControlPushButton;
 class ControlProxy;
@@ -19,6 +21,8 @@ class PotmeterControls : public QObject {
     void setSmallStepCount(int count) {
         m_smallStepCount = count;
     }
+
+    void addAlias(const ConfigKey& key);
 
   public slots:
     // Increases the value.
@@ -44,8 +48,17 @@ class PotmeterControls : public QObject {
     void setIsDefault(bool isDefault);
 
   private:
-    ControlProxy* m_pControl;
-    ControlPushButton* m_pControlDefault;
+    ControlProxy m_control;
+    ControlPushButton m_controlUp;
+    ControlPushButton m_controlDown;
+    ControlPushButton m_controlUpSmall;
+    ControlPushButton m_controlDownSmall;
+    ControlPushButton m_controlSetDefault;
+    ControlPushButton m_controlSetZero;
+    ControlPushButton m_controlSetOne;
+    ControlPushButton m_controlSetMinusOne;
+    ControlPushButton m_controlToggle;
+    ControlPushButton m_controlMinusToggle;
     int m_stepCount;
     double m_smallStepCount;
 };
@@ -72,6 +85,11 @@ class ControlPotmeter : public ControlObject {
     // Sets the minimum and maximum allowed value. The control value is reset
     // when calling this method
     void setRange(double dMinValue, double dMaxValue, bool allowOutOfBounds);
+
+    void addAlias(const ConfigKey& key) {
+        ControlObject::addAlias(key);
+        m_controls.addAlias(key);
+    };
 
   private slots:
     // Used to check if the current control value matches the default value.

--- a/src/engine/enginemixer.cpp
+++ b/src/engine/enginemixer.cpp
@@ -30,6 +30,7 @@
 
 namespace {
 const QString kAppGroup = QStringLiteral("[App]");
+const QString kLegacyGroup = QStringLiteral("[Master]");
 }
 
 EngineMixer::EngineMixer(
@@ -81,9 +82,24 @@ EngineMixer::EngineMixer(
     m_pMainLatency = new ControlObject(ConfigKey(group, "latency"),
             true,
             true); // reported latency (sometimes correct)
-    m_pAudioLatencyOverloadCount = new ControlObject(ConfigKey(group, "audio_latency_overload_count"), true, true);
-    m_pAudioLatencyUsage = new ControlPotmeter(ConfigKey(group, "audio_latency_usage"), 0.0, 0.25);
-    m_pAudioLatencyOverload  = new ControlPotmeter(ConfigKey(group, "audio_latency_overload"), 0.0, 1.0);
+    m_pAudioLatencyOverloadCount = new ControlObject(
+            ConfigKey(
+                    kAppGroup, QStringLiteral("audio_latency_overload_count")),
+            true,
+            true);
+    m_pAudioLatencyOverloadCount->addAlias(ConfigKey(
+            kLegacyGroup, QStringLiteral("audio_latency_overload_count")));
+    m_pAudioLatencyUsage = new ControlPotmeter(
+            ConfigKey(kAppGroup, QStringLiteral("audio_latency_usage")),
+            0.0,
+            0.25);
+    m_pAudioLatencyUsage->addAlias(ConfigKey(kLegacyGroup, QStringLiteral("audio_latency_usage")));
+    m_pAudioLatencyOverload = new ControlPotmeter(
+            ConfigKey(kAppGroup, QStringLiteral("audio_latency_overload")),
+            0.0,
+            1.0);
+    m_pAudioLatencyOverload->addAlias(
+            ConfigKey(kLegacyGroup, QStringLiteral("audio_latency_overload")));
 
     // Sync controller
     m_pEngineSync = new EngineSync(pConfig);

--- a/src/engine/enginemixer.cpp
+++ b/src/engine/enginemixer.cpp
@@ -83,18 +83,13 @@ EngineMixer::EngineMixer(
             true,
             true); // reported latency (sometimes correct)
     m_pAudioLatencyOverloadCount = new ControlObject(
-            ConfigKey(
-                    kAppGroup, QStringLiteral("audio_latency_overload_count")),
-            true,
-            true);
+            ConfigKey(kAppGroup, QStringLiteral("audio_latency_overload_count")));
     m_pAudioLatencyOverloadCount->addAlias(ConfigKey(
             kLegacyGroup, QStringLiteral("audio_latency_overload_count")));
-    m_pAudioLatencyUsage = new ControlPotmeter(
-            ConfigKey(kAppGroup, QStringLiteral("audio_latency_usage")),
-            0.0,
-            0.25);
+    m_pAudioLatencyUsage = new ControlObject(
+            ConfigKey(kAppGroup, QStringLiteral("audio_latency_usage")));
     m_pAudioLatencyUsage->addAlias(ConfigKey(kLegacyGroup, QStringLiteral("audio_latency_usage")));
-    m_pAudioLatencyOverload = new ControlPotmeter(
+    m_pAudioLatencyOverload = new ControlObject(
             ConfigKey(kAppGroup, QStringLiteral("audio_latency_overload")),
             0.0,
             1.0);

--- a/src/engine/enginemixer.cpp
+++ b/src/engine/enginemixer.cpp
@@ -90,9 +90,7 @@ EngineMixer::EngineMixer(
             ConfigKey(kAppGroup, QStringLiteral("audio_latency_usage")));
     m_pAudioLatencyUsage->addAlias(ConfigKey(kLegacyGroup, QStringLiteral("audio_latency_usage")));
     m_pAudioLatencyOverload = new ControlObject(
-            ConfigKey(kAppGroup, QStringLiteral("audio_latency_overload")),
-            0.0,
-            1.0);
+            ConfigKey(kAppGroup, QStringLiteral("audio_latency_overload")));
     m_pAudioLatencyOverload->addAlias(
             ConfigKey(kLegacyGroup, QStringLiteral("audio_latency_overload")));
 

--- a/src/engine/enginemixer.h
+++ b/src/engine/enginemixer.h
@@ -306,8 +306,8 @@ class EngineMixer : public QObject, public AudioSource {
     ControlObject* m_pMainSampleRate;
     ControlObject* m_pMainLatency;
     ControlObject* m_pAudioLatencyOverloadCount;
-    ControlPotmeter* m_pAudioLatencyUsage;
-    ControlPotmeter* m_pAudioLatencyOverload;
+    ControlObject* m_pAudioLatencyUsage;
+    ControlObject* m_pAudioLatencyOverload;
     EngineTalkoverDucking* m_pTalkoverDucking;
     EngineDelay* m_pMainDelay;
     EngineDelay* m_pHeadDelay;

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -203,9 +203,9 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
                 loadSettings();
             });
 
-    m_pMainAudioLatencyOverloadCount =
-            new ControlProxy("[Master]", "audio_latency_overload_count", this);
-    m_pMainAudioLatencyOverloadCount->connectValueChanged(this, &DlgPrefSound::bufferUnderflow);
+    m_pAudioLatencyOverloadCount =
+            new ControlProxy(kAppGroup, QStringLiteral("audio_latency_overload_count"), this);
+    m_pAudioLatencyOverloadCount->connectValueChanged(this, &DlgPrefSound::bufferUnderflow);
 
     m_pMainLatency = new ControlProxy("[Master]", "latency", this);
     m_pMainLatency->connectValueChanged(this, &DlgPrefSound::mainLatencyChanged);

--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -85,7 +85,7 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     std::shared_ptr<SoundManager> m_pSoundManager;
     UserSettingsPointer m_pSettings;
     SoundManagerConfig m_config;
-    ControlProxy* m_pMainAudioLatencyOverloadCount;
+    ControlProxy* m_pAudioLatencyOverloadCount;
     ControlProxy* m_pMainLatency;
     ControlProxy* m_pHeadDelay;
     ControlProxy* m_pMainDelay;

--- a/src/soundio/sounddevicenetwork.cpp
+++ b/src/soundio/sounddevicenetwork.cpp
@@ -39,7 +39,7 @@ SoundDeviceNetwork::SoundDeviceNetwork(
         : SoundDevice(config, sm),
           m_pNetworkStream(pNetworkStream),
           m_inputDrift(false),
-          m_mainAudioLatencyUsage("[Master]", "audio_latency_usage"),
+          m_audioLatencyUsage(kAppGroup, QStringLiteral("audio_latency_usage")),
           m_framesSinceAudioLatencyUsageUpdate(0),
           m_denormals(false),
           m_targetTime(0) {
@@ -515,11 +515,11 @@ void SoundDeviceNetwork::updateAudioLatencyUsage(SINT framesPerBuffer) {
     if (m_framesSinceAudioLatencyUsageUpdate
             > (m_dSampleRate / CPU_USAGE_UPDATE_RATE)) {
         double secInAudioCb = m_timeInAudioCallback.toDoubleSeconds();
-        m_mainAudioLatencyUsage.set(secInAudioCb /
+        m_audioLatencyUsage.set(secInAudioCb /
                 (m_framesSinceAudioLatencyUsageUpdate / m_dSampleRate));
         m_timeInAudioCallback = mixxx::Duration::empty();
         m_framesSinceAudioLatencyUsageUpdate = 0;
-        // qDebug() << m_mainAudioLatencyUsage->get();
+        // qDebug() << m_audioLatencyUsage->get();
     }
 
     qint64 currentTime = m_pNetworkStream->getInputStreamTimeUs();

--- a/src/soundio/sounddevicenetwork.h
+++ b/src/soundio/sounddevicenetwork.h
@@ -62,7 +62,7 @@ class SoundDeviceNetwork : public SoundDevice {
     std::unique_ptr<FIFO<CSAMPLE>> m_inputFifo;
     bool m_inputDrift;
 
-    PollingControlProxy m_mainAudioLatencyUsage;
+    PollingControlProxy m_audioLatencyUsage;
     mixxx::Duration m_timeInAudioCallback;
     int m_framesSinceAudioLatencyUsageUpdate;
     std::unique_ptr<SoundDeviceNetworkThread> m_pThread;

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -91,7 +91,7 @@ SoundDevicePortAudio::SoundDevicePortAudio(UserSettingsPointer config,
           m_outputDrift(false),
           m_inputDrift(false),
           m_bSetThreadPriority(false),
-          m_mainAudioLatencyUsage("[Master]", "audio_latency_usage"),
+          m_audioLatencyUsage(kAppGroup, QStringLiteral("audio_latency_usage")),
           m_framesSinceAudioLatencyUsageUpdate(0),
           m_syncBuffers(2),
           m_invalidTimeInfoCount(0),
@@ -1088,12 +1088,12 @@ void SoundDevicePortAudio::updateAudioLatencyUsage(
     m_framesSinceAudioLatencyUsageUpdate += framesPerBuffer;
     if (m_framesSinceAudioLatencyUsageUpdate > (m_dSampleRate / kCpuUsageUpdateRate)) {
         double secInAudioCb = m_timeInAudioCallback.toDoubleSeconds();
-        m_mainAudioLatencyUsage.set(
+        m_audioLatencyUsage.set(
                 secInAudioCb / (m_framesSinceAudioLatencyUsageUpdate / m_dSampleRate));
         m_timeInAudioCallback = mixxx::Duration::fromSeconds(0);
         m_framesSinceAudioLatencyUsageUpdate = 0;
-        // qDebug() << m_mainAudioLatencyUsage
-        //          << m_mainAudioLatencyUsage->get();
+        // qDebug() << m_audioLatencyUsage
+        //          << m_audioLatencyUsage->get();
     }
     // measure time in Audio callback at the very last
     m_timeInAudioCallback += m_clkRefTimer.elapsed();

--- a/src/soundio/sounddeviceportaudio.h
+++ b/src/soundio/sounddeviceportaudio.h
@@ -75,7 +75,7 @@ class SoundDevicePortAudio : public SoundDevice {
     QString m_lastError;
     // Whether we have set the thread priority to realtime or not.
     bool m_bSetThreadPriority;
-    PollingControlProxy m_mainAudioLatencyUsage;
+    PollingControlProxy m_audioLatencyUsage;
     mixxx::Duration m_timeInAudioCallback;
     int m_framesSinceAudioLatencyUsageUpdate;
     int m_syncBuffers;

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -30,6 +30,8 @@ typedef PaError (*SetJackClientName)(const char *name);
 
 namespace {
 
+const QString kAppGroup = QStringLiteral("[App]");
+
 #define CPU_OVERLOAD_DURATION 500 // in ms
 
 struct DeviceMode {
@@ -52,9 +54,8 @@ SoundManager::SoundManager(UserSettingsPointer pConfig,
           m_pErrorDevice(nullptr),
           m_underflowHappened(0),
           m_underflowUpdateCount(0),
-          m_mainAudioLatencyOverloadCount("[Master]",
-                  "audio_latency_overload_count"),
-          m_mainAudioLatencyOverload("[Master]", "audio_latency_overload") {
+          m_audioLatencyOverloadCount(kAppGroup, QStringLiteral("audio_latency_overload_count")),
+          m_audioLatencyOverload(kAppGroup, QStringLiteral("audio_latency_overload")) {
     // TODO(xxx) some of these ControlObject are not needed by soundmanager, or are unused here.
     // It is possible to take them out?
     m_pControlObjectSoundStatusCO = new ControlObject(
@@ -350,7 +351,7 @@ SoundDeviceStatus SoundManager::setupDevices() {
     // compute the new one then atomically hand off below.
     SoundDevicePointer pNewMainClockRef;
 
-    m_mainAudioLatencyOverloadCount.set(0);
+    m_audioLatencyOverloadCount.set(0);
 
     // load with all configured devices.
     // all found devices are removed below
@@ -687,9 +688,9 @@ int SoundManager::getConfiguredDeckCount() const {
 void SoundManager::processUnderflowHappened(SINT framesPerBuffer) {
     if (m_underflowUpdateCount == 0) {
         if (atomicLoadRelaxed(m_underflowHappened)) {
-            m_mainAudioLatencyOverload.set(1.0);
-            m_mainAudioLatencyOverloadCount.set(
-                    m_mainAudioLatencyOverloadCount.get() + 1);
+            m_audioLatencyOverload.set(1.0);
+            m_audioLatencyOverloadCount.set(
+                    m_audioLatencyOverloadCount.get() + 1);
             m_underflowUpdateCount = CPU_OVERLOAD_DURATION *
                     m_config.getSampleRate() / framesPerBuffer / 1000;
 
@@ -697,7 +698,7 @@ void SoundManager::processUnderflowHappened(SINT framesPerBuffer) {
                                      // but that is OK, because we count only
                                      // 1 underflow each 500 ms
         } else {
-            m_mainAudioLatencyOverload.set(0.0);
+            m_audioLatencyOverload.set(0.0);
         }
     } else {
         --m_underflowUpdateCount;

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -149,6 +149,6 @@ class SoundManager : public QObject {
 
     QAtomicInt m_underflowHappened;
     int m_underflowUpdateCount;
-    PollingControlProxy m_mainAudioLatencyOverloadCount;
-    PollingControlProxy m_mainAudioLatencyOverload;
+    PollingControlProxy m_audioLatencyOverloadCount;
+    PollingControlProxy m_audioLatencyOverload;
 };

--- a/src/test/co_dumps/co_dump_inital.csv
+++ b/src/test/co_dumps/co_dump_inital.csv
@@ -74,7 +74,7 @@
 [QuickEffectRack1_[Channel2]_Effect1],parameter5_toggle,0
 [Channel3],hotcue_6_set,0
 [Channel4],beatloop_16_enabled,0
-[Master],audio_latency_overload_set_minus_one,0
+[App],audio_latency_overload_set_minus_one,0
 [QuickEffectRack1_[Channel3]_Effect1],parameter1_set_zero,0
 [QuickEffectRack1_[Channel3]_Effect1],parameter7_toggle,0
 [EffectRack1_EffectUnit3_Effect2],parameter4_minus_toggle,0
@@ -1088,7 +1088,7 @@
 [Sampler4],hotcue_8_gotoandplay,0
 [EffectRack1_EffectUnit4_Effect1],parameter14_link_type,0
 [Channel4],pitch_set_default,0
-[Master],audio_latency_overload_up_small,0
+[App],audio_latency_overload_up_small,0
 [EffectRack1_EffectUnit1_Effect4],parameter10_loaded,0
 [Channel4],hotcue_37_goto,0
 [Sampler3],hotcue_21_position,-1
@@ -1423,7 +1423,7 @@
 [QuickEffectRack1_[Channel2]_Effect1],parameter9_up,0
 [Sampler2],beatlooproll_64_activate,0
 [EffectRack1_EffectUnit4_Effect3],parameter2_type,0
-[Master],audio_latency_usage_down_small,0
+[App],audio_latency_usage_down_small,0
 [Auxiliary2],VuMeterL_set_default,0
 [Channel1],hotcue_18_goto,0
 [Sampler1],hotcue_36_clear,0
@@ -2330,7 +2330,7 @@
 [EffectRack1_EffectUnit1_Effect1],parameter1_link_inverse,0
 [Channel4],loop_move_8_forward,0
 [Sampler1],hotcue_21_goto,0
-[Master],audio_latency_usage_set_default,0
+[App],audio_latency_usage_set_default,0
 [Sampler3],waveform_zoom_minus_toggle,0
 [EffectRack1_EffectUnit2_Effect4],parameter8_down_small,0
 [Channel2],loop_move_64_backward,0
@@ -4125,7 +4125,7 @@
 [EffectRack1_EffectUnit3_Effect1],parameter2_set_default,0
 [EffectRack1_EffectUnit4_Effect1],parameter11_up_small,0
 [Auxiliary3],pregain_set_zero,0
-[Master],audio_latency_usage,0.013661
+[App],audio_latency_usage,0.013661
 [Channel4],hotcue_23_set,0
 [Channel2],loop_move_4_forward,0
 [EffectRack1_EffectUnit4_Effect2],parameter2_set_minus_one,0
@@ -4506,7 +4506,7 @@
 [EqualizerRack1_[Channel3]_Effect1],parameter4_down,0
 [Sampler2],rateSearch_up_small,0
 [EffectRack1_EffectUnit3_Effect2],parameter12_minus_toggle,0
-[Master],audio_latency_usage_up,0
+[App],audio_latency_usage_up,0
 [Channel1],beatjump_0.25_forward,0
 [Channel4],hotcue_36_activate_preview,0
 [Sampler1],hotcue_35_clear,0
@@ -4740,7 +4740,7 @@
 [QuickEffectRack1_[Channel4]_Effect1],parameter5_link_type,0
 [Sampler1],beatloop_0.0625_toggle,0
 [EqualizerRack1_[Channel2]_Effect1],parameter1_down_small,0
-[Master],audio_latency_overload_set_default,0
+[App],audio_latency_overload_set_default,0
 [Sampler2],hotcue_28_activate_preview,0
 [EffectRack1_EffectUnit4_Effect3],button_parameter12_type,0
 [EqualizerRack1_[Channel3]_Effect1],parameter1_set_minus_one,0
@@ -5067,7 +5067,7 @@
 [EqualizerRack1_[Channel2]_Effect1],parameter13_down,0
 [EqualizerRack1_[Channel4]_Effect1],parameter1_down_small,0
 [Sampler1],hotcue_7_goto,0
-[Master],audio_latency_overload_up,0
+[App],audio_latency_overload_up,0
 [EqualizerRack1_[Channel3]_Effect1],effect_selector,0
 [EffectRack1_EffectUnit3_Effect1],button_parameter12_loaded,0
 [Channel4],beatloop_1_activate,0
@@ -5841,7 +5841,7 @@
 [EffectRack1_EffectUnit1_Effect2],parameter16_down,0
 [Channel2],hotcue_24_activate,0
 [Channel1],hotcue_14_set,0
-[Master],audio_latency_overload_count,1
+[App],audio_latency_overload_count,1
 [EqualizerRack1_[Master]_Effect1],parameter10_set_zero,0
 [Auxiliary4],volume_up,0
 [Master],VuMeterL_minus_toggle,0
@@ -5868,7 +5868,7 @@
 [EqualizerRack1_[Channel4]_Effect1],parameter4_up,0
 [Channel1],hotcue_26_enabled,0
 [EffectRack1_EffectUnit3_Effect1],button_parameter14_type,0
-[Master],audio_latency_usage_minus_toggle,0
+[App],audio_latency_usage_minus_toggle,0
 [Channel2],reloop_exit,0
 [EffectRack1_EffectUnit1_Effect3],button_parameter14_type,0
 [EffectRack1_EffectUnit1_Effect4],parameter16_set_minus_one,0
@@ -7013,7 +7013,7 @@
 [EffectRack1_EffectUnit3_Effect4],parameter7_set_minus_one,0
 [Sampler1],rate_up_small,0
 [App],num_auxiliaries,4
-[Master],audio_latency_overload_down_small,0
+[App],audio_latency_overload_down_small,0
 [EffectRack1_EffectUnit3_Effect3],parameter15_set_minus_one,0
 [EqualizerRack1_[Channel1]_Effect1],parameter7_down,0
 [EffectRack1_EffectUnit3_Effect4],parameter1_set_one,0
@@ -7141,7 +7141,7 @@
 [EffectRack1_EffectUnit2_Effect4],parameter14_set_zero,0
 [Channel2],beatloop_0.0625_enabled,0
 [QuickEffectRack1_[Channel2]_Effect1],button_parameter14_type,0
-[Master],audio_latency_overload_down,0
+[App],audio_latency_overload_down,0
 [Sampler2],beatloop_0.03125_enabled,0
 [Sampler2],loop_move_0.03125_forward,0
 [QuickEffectRack1_[Channel1]_Effect1],parameter3_link_type,3
@@ -7585,7 +7585,7 @@
 [Sampler1],loop_move_16_forward,0
 [Sampler1],VuMeterR_up,0
 [EffectRack1_EffectUnit4_Effect3],parameter5_minus_toggle,0
-[Master],audio_latency_usage_set_zero,0
+[App],audio_latency_usage_set_zero,0
 [Channel3],hotcue_25_enabled,0
 [Channel3],hotcue_36_gotoandplay,0
 [EffectRack1_EffectUnit2_Effect3],parameter3_minus_toggle,0
@@ -8427,7 +8427,7 @@
 [EffectRack1_EffectUnit2_Effect2],parameter9_up_small,0
 [EffectRack1_EffectUnit4_Effect1],parameter10_loaded,0
 [QuickEffectRack1_[Channel2]_Effect1],button_parameter6_loaded,0
-[Master],audio_latency_overload_set_zero,0
+[App],audio_latency_overload_set_zero,0
 [Sampler2],beatloop_0.5_activate,0
 [Channel2],hotcue_1_clear,0
 [QuickEffectRack1_[Channel1]_Effect1],parameter7_up,0
@@ -9775,7 +9775,7 @@
 [EqualizerRack1_[Channel4]_Effect1],parameter7_up,0
 [Microphone],pregain_set_zero,0
 [EffectRack1_EffectUnit4_Effect3],parameter11_down_small,0
-[Master],audio_latency_usage_set_minus_one,0
+[App],audio_latency_usage_set_minus_one,0
 [Sampler4],hotcue_15_gotoandstop,0
 [QuickEffectRack1_[Channel4]],next_chain,0
 [Sampler2],hotcue_8_clear,0
@@ -10042,7 +10042,7 @@
 [Microphone2],VuMeterR_set_default,0
 [Channel3],hotcue_4_gotoandplay,0
 [Sampler3],hotcue_28_set,0
-[Master],audio_latency_usage_down,0
+[App],audio_latency_usage_down,0
 [EffectRack1_EffectUnit2],super1_set_default,0
 [EqualizerRack1_[Channel2]_Effect1],parameter3_up,0
 [QuickEffectRack1_[Channel3]_Effect1],parameter11_up,0
@@ -10869,7 +10869,7 @@
 [Sampler1],beatloop_8,0
 [Sampler3],hotcue_1_clear,0
 [EffectRack1_EffectUnit4_Effect1],parameter11_set_minus_one,0
-[Master],audio_latency_overload_toggle,0
+[App],audio_latency_overload_toggle,0
 [Sampler1],beatloop_4,0
 [Sampler1],hotcue_22_activate,0
 [Sampler3],hotcue_10_activate,0
@@ -11073,7 +11073,7 @@
 [QuickEffectRack1_[Channel2]_Effect1],parameter11_set_zero,0
 [EffectRack1_EffectUnit2_Effect1],parameter6_set_one,0
 [Channel1],pregain,1
-[Master],audio_latency_overload,0
+[App],audio_latency_overload,0
 [Sampler1],hotcue_31_gotoandplay,0
 [Sampler3],hotcue_29_gotoandplay,0
 [Channel1],volume_toggle,0
@@ -12291,7 +12291,7 @@
 [EffectRack1_EffectUnit2_Effect4],parameter13_down,0
 [QuickEffectRack1_[Channel2]_Effect1],parameter13_down_small,0
 [EffectRack1_EffectUnit2_Effect1],parameter10_minus_toggle,0
-[Master],audio_latency_usage_set_one,0
+[App],audio_latency_usage_set_one,0
 [Sampler4],playposition_set_minus_one,0
 [EffectRack1_EffectUnit4_Effect2],parameter8_set_one,0
 [EqualizerRack1_[Master]_Effect1],button_parameter15_type,0
@@ -12733,7 +12733,7 @@
 [Channel1],beats_adjust_slower,0
 [Sampler4],playposition_set_one,0
 [Auxiliary3],PeakIndicator_down_small,0
-[Master],audio_latency_overload_minus_toggle,0
+[App],audio_latency_overload_minus_toggle,0
 [Sampler1],waveform_zoom_set_one,0
 [Auxiliary4],VuMeterR_toggle,0
 [Sampler3],hotcue_4_enabled,0
@@ -12857,7 +12857,7 @@
 [Sampler2],beatloop_2_toggle,0
 [EffectRack1_EffectUnit2_Effect4],button_parameter11_loaded,0
 [QuickEffectRack1_[Channel2]_Effect1],parameter8_up,0
-[Master],audio_latency_usage_up_small,0
+[App],audio_latency_usage_up_small,0
 [PreviewDeck1],PeakIndicator_up,0
 [QuickEffectRack1_[Channel4]],mix_up,0
 [EqualizerRack1_[Master]_Effect1],parameter2_toggle,0
@@ -14303,7 +14303,7 @@
 [Sampler3],hotcue_10_activate_preview,0
 [EffectRack1_EffectUnit4_Effect1],parameter15_type,0
 [EffectRack1_EffectUnit3_Effect1],button_parameter3_type,0
-[Master],audio_latency_overload_set_one,0
+[App],audio_latency_overload_set_one,0
 [Channel3],VuMeter_set_default,0
 [Playlist],AutoDjAddBottom,0
 [Microphone3],VuMeterL_set_minus_one,0
@@ -14879,7 +14879,7 @@
 [Channel3],hotcue_32_gotoandplay,0
 [EffectRack1_EffectUnit3_Effect1],parameter13_set_default,0
 [EffectRack1_EffectUnit4_Effect4],parameter15_minus_toggle,0
-[Master],audio_latency_usage_toggle,0
+[App],audio_latency_usage_toggle,0
 [QuickEffectRack1_[Channel2]_Effect1],parameter4_loaded,0
 [Sampler4],hotcue_10_clear,0
 [PreviewDeck1],hotcue_29_gotoandstop,0

--- a/src/test/co_dumps/co_dump_inital.csv
+++ b/src/test/co_dumps/co_dump_inital.csv
@@ -74,7 +74,6 @@
 [QuickEffectRack1_[Channel2]_Effect1],parameter5_toggle,0
 [Channel3],hotcue_6_set,0
 [Channel4],beatloop_16_enabled,0
-[App],audio_latency_overload_set_minus_one,0
 [QuickEffectRack1_[Channel3]_Effect1],parameter1_set_zero,0
 [QuickEffectRack1_[Channel3]_Effect1],parameter7_toggle,0
 [EffectRack1_EffectUnit3_Effect2],parameter4_minus_toggle,0
@@ -1088,7 +1087,6 @@
 [Sampler4],hotcue_8_gotoandplay,0
 [EffectRack1_EffectUnit4_Effect1],parameter14_link_type,0
 [Channel4],pitch_set_default,0
-[App],audio_latency_overload_up_small,0
 [EffectRack1_EffectUnit1_Effect4],parameter10_loaded,0
 [Channel4],hotcue_37_goto,0
 [Sampler3],hotcue_21_position,-1
@@ -1423,7 +1421,6 @@
 [QuickEffectRack1_[Channel2]_Effect1],parameter9_up,0
 [Sampler2],beatlooproll_64_activate,0
 [EffectRack1_EffectUnit4_Effect3],parameter2_type,0
-[App],audio_latency_usage_down_small,0
 [Auxiliary2],VuMeterL_set_default,0
 [Channel1],hotcue_18_goto,0
 [Sampler1],hotcue_36_clear,0
@@ -2330,7 +2327,6 @@
 [EffectRack1_EffectUnit1_Effect1],parameter1_link_inverse,0
 [Channel4],loop_move_8_forward,0
 [Sampler1],hotcue_21_goto,0
-[App],audio_latency_usage_set_default,0
 [Sampler3],waveform_zoom_minus_toggle,0
 [EffectRack1_EffectUnit2_Effect4],parameter8_down_small,0
 [Channel2],loop_move_64_backward,0
@@ -4506,7 +4502,6 @@
 [EqualizerRack1_[Channel3]_Effect1],parameter4_down,0
 [Sampler2],rateSearch_up_small,0
 [EffectRack1_EffectUnit3_Effect2],parameter12_minus_toggle,0
-[App],audio_latency_usage_up,0
 [Channel1],beatjump_0.25_forward,0
 [Channel4],hotcue_36_activate_preview,0
 [Sampler1],hotcue_35_clear,0
@@ -4740,7 +4735,6 @@
 [QuickEffectRack1_[Channel4]_Effect1],parameter5_link_type,0
 [Sampler1],beatloop_0.0625_toggle,0
 [EqualizerRack1_[Channel2]_Effect1],parameter1_down_small,0
-[App],audio_latency_overload_set_default,0
 [Sampler2],hotcue_28_activate_preview,0
 [EffectRack1_EffectUnit4_Effect3],button_parameter12_type,0
 [EqualizerRack1_[Channel3]_Effect1],parameter1_set_minus_one,0
@@ -5067,7 +5061,6 @@
 [EqualizerRack1_[Channel2]_Effect1],parameter13_down,0
 [EqualizerRack1_[Channel4]_Effect1],parameter1_down_small,0
 [Sampler1],hotcue_7_goto,0
-[App],audio_latency_overload_up,0
 [EqualizerRack1_[Channel3]_Effect1],effect_selector,0
 [EffectRack1_EffectUnit3_Effect1],button_parameter12_loaded,0
 [Channel4],beatloop_1_activate,0
@@ -5868,7 +5861,6 @@
 [EqualizerRack1_[Channel4]_Effect1],parameter4_up,0
 [Channel1],hotcue_26_enabled,0
 [EffectRack1_EffectUnit3_Effect1],button_parameter14_type,0
-[App],audio_latency_usage_minus_toggle,0
 [Channel2],reloop_exit,0
 [EffectRack1_EffectUnit1_Effect3],button_parameter14_type,0
 [EffectRack1_EffectUnit1_Effect4],parameter16_set_minus_one,0
@@ -7013,7 +7005,6 @@
 [EffectRack1_EffectUnit3_Effect4],parameter7_set_minus_one,0
 [Sampler1],rate_up_small,0
 [App],num_auxiliaries,4
-[App],audio_latency_overload_down_small,0
 [EffectRack1_EffectUnit3_Effect3],parameter15_set_minus_one,0
 [EqualizerRack1_[Channel1]_Effect1],parameter7_down,0
 [EffectRack1_EffectUnit3_Effect4],parameter1_set_one,0
@@ -7141,7 +7132,6 @@
 [EffectRack1_EffectUnit2_Effect4],parameter14_set_zero,0
 [Channel2],beatloop_0.0625_enabled,0
 [QuickEffectRack1_[Channel2]_Effect1],button_parameter14_type,0
-[App],audio_latency_overload_down,0
 [Sampler2],beatloop_0.03125_enabled,0
 [Sampler2],loop_move_0.03125_forward,0
 [QuickEffectRack1_[Channel1]_Effect1],parameter3_link_type,3
@@ -7585,7 +7575,6 @@
 [Sampler1],loop_move_16_forward,0
 [Sampler1],VuMeterR_up,0
 [EffectRack1_EffectUnit4_Effect3],parameter5_minus_toggle,0
-[App],audio_latency_usage_set_zero,0
 [Channel3],hotcue_25_enabled,0
 [Channel3],hotcue_36_gotoandplay,0
 [EffectRack1_EffectUnit2_Effect3],parameter3_minus_toggle,0
@@ -8427,7 +8416,6 @@
 [EffectRack1_EffectUnit2_Effect2],parameter9_up_small,0
 [EffectRack1_EffectUnit4_Effect1],parameter10_loaded,0
 [QuickEffectRack1_[Channel2]_Effect1],button_parameter6_loaded,0
-[App],audio_latency_overload_set_zero,0
 [Sampler2],beatloop_0.5_activate,0
 [Channel2],hotcue_1_clear,0
 [QuickEffectRack1_[Channel1]_Effect1],parameter7_up,0
@@ -9775,7 +9763,6 @@
 [EqualizerRack1_[Channel4]_Effect1],parameter7_up,0
 [Microphone],pregain_set_zero,0
 [EffectRack1_EffectUnit4_Effect3],parameter11_down_small,0
-[App],audio_latency_usage_set_minus_one,0
 [Sampler4],hotcue_15_gotoandstop,0
 [QuickEffectRack1_[Channel4]],next_chain,0
 [Sampler2],hotcue_8_clear,0
@@ -10042,7 +10029,6 @@
 [Microphone2],VuMeterR_set_default,0
 [Channel3],hotcue_4_gotoandplay,0
 [Sampler3],hotcue_28_set,0
-[App],audio_latency_usage_down,0
 [EffectRack1_EffectUnit2],super1_set_default,0
 [EqualizerRack1_[Channel2]_Effect1],parameter3_up,0
 [QuickEffectRack1_[Channel3]_Effect1],parameter11_up,0
@@ -10869,7 +10855,6 @@
 [Sampler1],beatloop_8,0
 [Sampler3],hotcue_1_clear,0
 [EffectRack1_EffectUnit4_Effect1],parameter11_set_minus_one,0
-[App],audio_latency_overload_toggle,0
 [Sampler1],beatloop_4,0
 [Sampler1],hotcue_22_activate,0
 [Sampler3],hotcue_10_activate,0
@@ -12291,7 +12276,6 @@
 [EffectRack1_EffectUnit2_Effect4],parameter13_down,0
 [QuickEffectRack1_[Channel2]_Effect1],parameter13_down_small,0
 [EffectRack1_EffectUnit2_Effect1],parameter10_minus_toggle,0
-[App],audio_latency_usage_set_one,0
 [Sampler4],playposition_set_minus_one,0
 [EffectRack1_EffectUnit4_Effect2],parameter8_set_one,0
 [EqualizerRack1_[Master]_Effect1],button_parameter15_type,0
@@ -12733,7 +12717,6 @@
 [Channel1],beats_adjust_slower,0
 [Sampler4],playposition_set_one,0
 [Auxiliary3],PeakIndicator_down_small,0
-[App],audio_latency_overload_minus_toggle,0
 [Sampler1],waveform_zoom_set_one,0
 [Auxiliary4],VuMeterR_toggle,0
 [Sampler3],hotcue_4_enabled,0
@@ -12857,7 +12840,6 @@
 [Sampler2],beatloop_2_toggle,0
 [EffectRack1_EffectUnit2_Effect4],button_parameter11_loaded,0
 [QuickEffectRack1_[Channel2]_Effect1],parameter8_up,0
-[App],audio_latency_usage_up_small,0
 [PreviewDeck1],PeakIndicator_up,0
 [QuickEffectRack1_[Channel4]],mix_up,0
 [EqualizerRack1_[Master]_Effect1],parameter2_toggle,0
@@ -14303,7 +14285,6 @@
 [Sampler3],hotcue_10_activate_preview,0
 [EffectRack1_EffectUnit4_Effect1],parameter15_type,0
 [EffectRack1_EffectUnit3_Effect1],button_parameter3_type,0
-[App],audio_latency_overload_set_one,0
 [Channel3],VuMeter_set_default,0
 [Playlist],AutoDjAddBottom,0
 [Microphone3],VuMeterL_set_minus_one,0
@@ -14879,7 +14860,6 @@
 [Channel3],hotcue_32_gotoandplay,0
 [EffectRack1_EffectUnit3_Effect1],parameter13_set_default,0
 [EffectRack1_EffectUnit4_Effect4],parameter15_minus_toggle,0
-[App],audio_latency_usage_toggle,0
 [QuickEffectRack1_[Channel2]_Effect1],parameter4_loaded,0
 [Sampler4],hotcue_10_clear,0
 [PreviewDeck1],hotcue_29_gotoandstop,0

--- a/src/test/controlobjectaliastest.cpp
+++ b/src/test/controlobjectaliastest.cpp
@@ -62,6 +62,40 @@ TEST_F(ControlObjectAliasTest, EngineMixer) {
     auto sampleRate = ControlProxy(ConfigKey(kAppGroup, QStringLiteral("samplerate")));
     auto sampleRateLegacy = ControlProxy(ConfigKey(kLegacyGroup, QStringLiteral("samplerate")));
     EXPECT_DOUBLE_EQ(sampleRate.get(), sampleRateLegacy.get());
+
+    auto audioLatencyUsage = ControlProxy(
+            ConfigKey(kAppGroup, QStringLiteral("audio_latency_usage")));
+    auto audioLatencyUsageLegacy = ControlProxy(
+            ConfigKey(kLegacyGroup, QStringLiteral("audio_latency_usage")));
+    EXPECT_DOUBLE_EQ(audioLatencyUsage.get(), audioLatencyUsageLegacy.get());
+
+    // `audio_latency_usage` is a ControlPotMeter control. Check if its
+    // additional COs are also aliased correctly.
+    auto audioLatencyUsageSetOne = ControlProxy(
+            ConfigKey(kAppGroup, QStringLiteral("audio_latency_usage_set_one")));
+    auto audioLatencyUsageSetOneLegacy = ControlProxy(
+            ConfigKey(kLegacyGroup, QStringLiteral("audio_latency_usage_set_one")));
+    EXPECT_DOUBLE_EQ(audioLatencyUsageSetOne.get(), audioLatencyUsageSetOneLegacy.get());
+
+    auto audioLatencyOverload = ControlProxy(
+            ConfigKey(kAppGroup, QStringLiteral("audio_latency_overload")));
+    auto audioLatencyOverloadLegacy = ControlProxy(
+            ConfigKey(kLegacyGroup, QStringLiteral("audio_latency_overload")));
+    EXPECT_DOUBLE_EQ(audioLatencyOverload.get(), audioLatencyOverloadLegacy.get());
+
+    // `audio_latency_overload` is a ControlPotMeter control. Check if its
+    // additional COs are also aliased correctly.
+    auto audioLatencyOverloadSetOne = ControlProxy(
+            ConfigKey(kAppGroup, QStringLiteral("audio_latency_overload_set_one")));
+    auto audioLatencyOverloadSetOneLegacy = ControlProxy(
+            ConfigKey(kLegacyGroup, QStringLiteral("audio_latency_overload_set_one")));
+    EXPECT_DOUBLE_EQ(audioLatencyOverloadSetOne.get(), audioLatencyOverloadSetOneLegacy.get());
+
+    auto audioLatencyOverloadCount = ControlProxy(ConfigKey(
+            kAppGroup, QStringLiteral("audio_latency_overload_count")));
+    auto audioLatencyOverloadCountLegacy = ControlProxy(ConfigKey(
+            kLegacyGroup, QStringLiteral("audio_latency_overload_count")));
+    EXPECT_DOUBLE_EQ(audioLatencyOverloadCount.get(), audioLatencyOverloadCountLegacy.get());
 }
 
 TEST_F(ControlObjectAliasTest, PlayerManager) {

--- a/src/test/controlobjectaliastest.cpp
+++ b/src/test/controlobjectaliastest.cpp
@@ -69,27 +69,11 @@ TEST_F(ControlObjectAliasTest, EngineMixer) {
             ConfigKey(kLegacyGroup, QStringLiteral("audio_latency_usage")));
     EXPECT_DOUBLE_EQ(audioLatencyUsage.get(), audioLatencyUsageLegacy.get());
 
-    // `audio_latency_usage` is a ControlPotMeter control. Check if its
-    // additional COs are also aliased correctly.
-    auto audioLatencyUsageSetOne = ControlProxy(
-            ConfigKey(kAppGroup, QStringLiteral("audio_latency_usage_set_one")));
-    auto audioLatencyUsageSetOneLegacy = ControlProxy(
-            ConfigKey(kLegacyGroup, QStringLiteral("audio_latency_usage_set_one")));
-    EXPECT_DOUBLE_EQ(audioLatencyUsageSetOne.get(), audioLatencyUsageSetOneLegacy.get());
-
     auto audioLatencyOverload = ControlProxy(
             ConfigKey(kAppGroup, QStringLiteral("audio_latency_overload")));
     auto audioLatencyOverloadLegacy = ControlProxy(
             ConfigKey(kLegacyGroup, QStringLiteral("audio_latency_overload")));
     EXPECT_DOUBLE_EQ(audioLatencyOverload.get(), audioLatencyOverloadLegacy.get());
-
-    // `audio_latency_overload` is a ControlPotMeter control. Check if its
-    // additional COs are also aliased correctly.
-    auto audioLatencyOverloadSetOne = ControlProxy(
-            ConfigKey(kAppGroup, QStringLiteral("audio_latency_overload_set_one")));
-    auto audioLatencyOverloadSetOneLegacy = ControlProxy(
-            ConfigKey(kLegacyGroup, QStringLiteral("audio_latency_overload_set_one")));
-    EXPECT_DOUBLE_EQ(audioLatencyOverloadSetOne.get(), audioLatencyOverloadSetOneLegacy.get());
 
     auto audioLatencyOverloadCount = ControlProxy(ConfigKey(
             kAppGroup, QStringLiteral("audio_latency_overload_count")));

--- a/src/test/controlpotmetertest.cpp
+++ b/src/test/controlpotmetertest.cpp
@@ -1,0 +1,202 @@
+#include <gtest/gtest.h>
+
+#include <QtDebug>
+
+#include "control/controlpotmeter.h"
+#include "control/controlproxy.h"
+#include "test/mixxxtest.h"
+
+namespace {
+
+class ControlPotmeterTest : public MixxxTest {
+  protected:
+    void SetUp() override {
+        ck = ConfigKey("[SomeGroup]", "some_controlpotmeter");
+        co = std::make_unique<ControlPotmeter>(ck, -1.0, 1.0);
+    }
+
+    ConfigKey ck;
+    std::unique_ptr<ControlPotmeter> co;
+};
+
+TEST_F(ControlPotmeterTest, Up) {
+    auto coUp = ControlProxy(ConfigKey(ck.group, ck.item + QStringLiteral("_up")));
+    co->set(0.0);
+    ASSERT_DOUBLE_EQ(0.0, co->get());
+
+    coUp.set(1.0);
+    coUp.set(0.0);
+    EXPECT_GT(co->get(), 0.0);
+
+    double previousValue = co->get();
+    coUp.set(1.0);
+    coUp.set(0.0);
+    EXPECT_GT(co->get(), previousValue);
+}
+
+TEST_F(ControlPotmeterTest, UpSmall) {
+    auto coUpSmall = ControlProxy(ConfigKey(ck.group, ck.item + QStringLiteral("_up_small")));
+    co->set(0.0);
+    ASSERT_DOUBLE_EQ(0.0, co->get());
+
+    coUpSmall.set(1.0);
+    coUpSmall.set(0.0);
+    EXPECT_GT(co->get(), 0.0);
+
+    double previousValue = co->get();
+    coUpSmall.set(1.0);
+    coUpSmall.set(0.0);
+    EXPECT_GT(co->get(), previousValue);
+}
+
+TEST_F(ControlPotmeterTest, Down) {
+    auto coDown = ControlProxy(ConfigKey(ck.group, ck.item + QStringLiteral("_down")));
+    co->set(1.0);
+    ASSERT_DOUBLE_EQ(1.0, co->get());
+
+    coDown.set(1.0);
+    coDown.set(0.0);
+    EXPECT_LT(co->get(), 1.0);
+
+    double previousValue = co->get();
+    coDown.set(1.0);
+    coDown.set(0.0);
+    EXPECT_LT(co->get(), previousValue);
+}
+
+TEST_F(ControlPotmeterTest, DownSmall) {
+    auto coDownSmall = ControlProxy(ConfigKey(ck.group, ck.item + QStringLiteral("_down_small")));
+    co->set(1.0);
+    ASSERT_DOUBLE_EQ(1.0, co->get());
+
+    coDownSmall.set(1.0);
+    coDownSmall.set(0.0);
+    EXPECT_LT(co->get(), 1.0);
+
+    double previousValue = co->get();
+    coDownSmall.set(1.0);
+    coDownSmall.set(0.0);
+    EXPECT_LT(co->get(), previousValue);
+}
+
+TEST_F(ControlPotmeterTest, SetDefault) {
+    auto coSetDefault = ControlProxy(ConfigKey(ck.group, ck.item + QStringLiteral("_set_default")));
+    co->setDefaultValue(0.25);
+    co->set(0.0);
+    EXPECT_DOUBLE_EQ(0.0, co->get());
+
+    coSetDefault.set(1.0);
+    coSetDefault.set(0.0);
+    EXPECT_DOUBLE_EQ(0.25, co->get());
+
+    co->setDefaultValue(0.75);
+    co->set(1.0);
+    EXPECT_DOUBLE_EQ(1.0, co->get());
+
+    coSetDefault.set(1.0);
+    coSetDefault.set(0.0);
+    EXPECT_DOUBLE_EQ(0.75, co->get());
+
+    co->setDefaultValue(0.0);
+}
+
+TEST_F(ControlPotmeterTest, SetZero) {
+    auto coSetZero = ControlProxy(ConfigKey(ck.group, ck.item + QStringLiteral("_set_zero")));
+    co->set(0.5);
+    EXPECT_DOUBLE_EQ(0.5, co->get());
+
+    coSetZero.set(1.0);
+    coSetZero.set(0.0);
+    EXPECT_DOUBLE_EQ(0.0, co->get());
+
+    co->set(1.0);
+    EXPECT_DOUBLE_EQ(1.0, co->get());
+
+    coSetZero.set(1.0);
+    coSetZero.set(0.0);
+    EXPECT_DOUBLE_EQ(0.0, co->get());
+}
+
+TEST_F(ControlPotmeterTest, SetOne) {
+    auto coSetOne = ControlProxy(ConfigKey(ck.group, ck.item + QStringLiteral("_set_one")));
+    co->set(0.5);
+    EXPECT_DOUBLE_EQ(0.5, co->get());
+
+    coSetOne.set(1.0);
+    coSetOne.set(0.0);
+    EXPECT_DOUBLE_EQ(1.0, co->get());
+
+    co->set(0.0);
+    EXPECT_DOUBLE_EQ(0.0, co->get());
+
+    coSetOne.set(1.0);
+    coSetOne.set(0.0);
+    EXPECT_DOUBLE_EQ(1.0, co->get());
+}
+
+TEST_F(ControlPotmeterTest, SetMinusOne) {
+    auto coSetMinusOne = ControlProxy(
+            ConfigKey(ck.group, ck.item + QStringLiteral("_set_minus_one")));
+    co->set(0.5);
+    ASSERT_DOUBLE_EQ(0.5, co->get());
+
+    coSetMinusOne.set(1.0);
+    coSetMinusOne.set(0.0);
+    EXPECT_DOUBLE_EQ(-1.0, co->get());
+
+    co->set(0.0);
+    EXPECT_DOUBLE_EQ(0.0, co->get());
+
+    coSetMinusOne.set(1.0);
+    coSetMinusOne.set(0.0);
+    EXPECT_DOUBLE_EQ(-1.0, co->get());
+}
+
+TEST_F(ControlPotmeterTest, Toggle) {
+    auto coToggle = ControlProxy(ConfigKey(ck.group, ck.item + QStringLiteral("_toggle")));
+    co->set(0.0);
+    ASSERT_DOUBLE_EQ(0.0, co->get());
+
+    coToggle.set(1.0);
+    coToggle.set(0.0);
+    EXPECT_DOUBLE_EQ(1.0, co->get());
+
+    coToggle.set(1.0);
+    coToggle.set(0.0);
+    EXPECT_DOUBLE_EQ(0.0, co->get());
+
+    co->set(-0.5);
+    coToggle.set(1.0);
+    coToggle.set(0.0);
+    EXPECT_DOUBLE_EQ(1.0, co->get());
+
+    coToggle.set(1.0);
+    coToggle.set(0.0);
+    EXPECT_DOUBLE_EQ(0.0, co->get());
+}
+
+TEST_F(ControlPotmeterTest, MinusToggle) {
+    auto coMinusToggle = ControlProxy(
+            ConfigKey(ck.group, ck.item + QStringLiteral("_minus_toggle")));
+    co->set(0.0);
+    ASSERT_DOUBLE_EQ(0.0, co->get());
+
+    coMinusToggle.set(1.0);
+    coMinusToggle.set(0.0);
+    EXPECT_DOUBLE_EQ(1.0, co->get());
+
+    coMinusToggle.set(1.0);
+    coMinusToggle.set(0.0);
+    EXPECT_DOUBLE_EQ(-1.0, co->get());
+
+    co->set(-0.5);
+    coMinusToggle.set(1.0);
+    coMinusToggle.set(0.0);
+    EXPECT_DOUBLE_EQ(1.0, co->get());
+
+    coMinusToggle.set(1.0);
+    coMinusToggle.set(0.0);
+    EXPECT_DOUBLE_EQ(-1.0, co->get());
+}
+
+} // namespace

--- a/src/test/controlpotmetertest.cpp
+++ b/src/test/controlpotmetertest.cpp
@@ -199,4 +199,36 @@ TEST_F(ControlPotmeterTest, MinusToggle) {
     EXPECT_DOUBLE_EQ(-1.0, co->get());
 }
 
+TEST_F(ControlPotmeterTest, AddAlias) {
+    co->addAlias(ConfigKey("[AliasGroup]", "alias_controlpotmeter"));
+
+    auto alias = ControlProxy(ConfigKey("[AliasGroup]", "alias_controlpotmeter"));
+    EXPECT_DOUBLE_EQ(co->get(), alias.get());
+
+    co->set(1.0);
+    EXPECT_DOUBLE_EQ(1.0, co->get());
+    EXPECT_DOUBLE_EQ(1.0, alias.get());
+
+    co->set(0.5);
+    EXPECT_DOUBLE_EQ(0.5, co->get());
+    EXPECT_DOUBLE_EQ(0.5, alias.get());
+
+    alias.set(0.25);
+    EXPECT_DOUBLE_EQ(0.25, co->get());
+    EXPECT_DOUBLE_EQ(0.25, alias.get());
+
+    auto aliasSetMinusOne = ControlProxy(
+            ConfigKey("[AliasGroup]", "alias_controlpotmeter_set_one"));
+    aliasSetMinusOne.set(1.0);
+    aliasSetMinusOne.set(0.0);
+    EXPECT_DOUBLE_EQ(1.0, co->get());
+    EXPECT_DOUBLE_EQ(1.0, alias.get());
+
+    auto coSetZero = ControlProxy(ConfigKey(ck.group, ck.item + QStringLiteral("_set_zero")));
+    coSetZero.set(1.0);
+    coSetZero.set(0.0);
+    EXPECT_DOUBLE_EQ(0.0, co->get());
+    EXPECT_DOUBLE_EQ(0.0, alias.get());
+}
+
 } // namespace


### PR DESCRIPTION
*This PR is part of the ongoing effort to remove offensive language from the Mixxx codebase (#11931).*

I had to add proper support for adding aliases to `ControlPotMeter` due to `audio_latency_usage` and `audio_latency_overload`. However, I'm wondering why these controls are `ControlPotMeter` objects in the first place. These should be read-only IIRC, so there is no need for all these setter-COs.

| Old Name                                                | New Name                                              | Alias?
| ------------------------------------------------------- | ----------------------------------------------------- | ----------
| `[Master],audio_latency_usage`                          | `[App],audio_latency_usage`                           | :heavy_check_mark:
| `[Master],audio_latency_overload`                       | `[App],audio_latency_overload`                        | :heavy_check_mark:
| `[Master],audio_latency_overload_count`                 | `[App],audio_latency_overload_count`                  | :heavy_check_mark:
