### PR TITLE
chore(clang-tidy): fix renamed readability-namespace-comment rule

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,13 @@
 ---
-Checks: "-*,modernize-use-bool-literals,modernize-use-nullptr,modernize-use-override,readability-braces-around-statements,google-readability-namespace-comments,readability-non-const-parameter,readability-qualified-auto"
+Checks: >-
+  -*,
+  modernize-use-bool-literals,
+  modernize-use-nullptr,
+  modernize-use-override,
+  readability-braces-around-statements,
+  google-readability-namespace-comments,
+  readability-non-const-parameter,
+  readability-qualified-auto
 WarningsAsErrors: ""
 HeaderFilterRegex: ""
 AnalyzeTemporaryDtors: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,11 +1,11 @@
 ---
 Checks: >-
   -*,
+  google-readability-namespace-comments,
   modernize-use-bool-literals,
   modernize-use-nullptr,
   modernize-use-override,
   readability-braces-around-statements,
-  google-readability-namespace-comments,
   readability-non-const-parameter,
   readability-qualified-auto
 WarningsAsErrors: ""

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks: "-*,modernize-use-bool-literals,modernize-use-nullptr,modernize-use-override,readability-braces-around-statements,readability-namespace-comment,readability-non-const-parameter,readability-qualified-auto"
+Checks: "-*,modernize-use-bool-literals,modernize-use-nullptr,modernize-use-override,readability-braces-around-statements,google-readability-namespace-comments,readability-non-const-parameter,readability-qualified-auto"
 WarningsAsErrors: ""
 HeaderFilterRegex: ""
 AnalyzeTemporaryDtors: false
@@ -8,9 +8,9 @@ User: user
 CheckOptions:
   - key: readability-braces-around-statements.ShortStatementLines
     value: 0
-  - key: readability-namespace-comments.ShortNamespaceLines
+  - key: google-readability-namespace-comments.ShortNamespaceLines
     value: 0
-  - key: readability-namespace-comments.SpacesBeforeComments
+  - key: google-readability-namespace-comments.SpacesBeforeComments
     value: 1
   - key: readability-qualified-auto.AddConstToQualified
     value: true


### PR DESCRIPTION
found on clang-tidy 16. fixes:
```
/home/swiftb0y/Sourcerepositories/mixxx/.clang-tidy: warning: unknown check 'readability-namespace-comment' [-verify-config]
/home/swiftb0y/Sourcerepositories/mixxx/.clang-tidy: warning: unknown check option 'readability-namespace-comments.ShortNamespaceLines' [-verify-config]
/home/swiftb0y/Sourcerepositories/mixxx/.clang-tidy: warning: unknown check option 'readability-namespace-comments.SpacesBeforeComments' [-verify-config]
```