### PR TITLE
Feat/cmake presets

### DIFF
--- a/.github/workflows/build-checks.yml
+++ b/.github/workflows/build-checks.yml
@@ -35,23 +35,9 @@ jobs:
         # Disable optimizations as workaround for Clang 9 bug: https://bugs.llvm.org/show_bug.cgi?id=45034
         run: |
           cmake \
-            -DCMAKE_BUILD_TYPE=Debug \
+            --preset=build-checks \
             -DWARNINGS_FATAL=ON \
-            -DOPTIMIZE=off \
-            -DBATTERY=ON \
-            -DBROADCAST=ON \
-            -DBULK=ON \
-            -DHID=ON \
-            -DLILV=ON \
-            -DOPUS=ON \
-            -DQTKEYCHAIN=ON \
-            -DVINYLCONTROL=ON \
-            -DFFMPEG=ON \
-            -DKEYFINDER=ON \
-            -DLOCALECOMPARE=ON \
-            -DMAD=ON \
-            -DMODPLUG=ON \
-            -DWAVPACK=ON \
+            -DOPTIMIZE=OFF \
             ..
         working-directory: build
         env:
@@ -62,23 +48,9 @@ jobs:
         if: matrix.name == 'clang-tidy'
         run: |
           cmake \
-            -DCMAKE_BUILD_TYPE=Debug \
+            --preset=build-checks \
             -DCLANG_TIDY=clang-tidy \
             -DWARNINGS_FATAL=ON \
-            -DBATTERY=ON \
-            -DBROADCAST=ON \
-            -DBULK=ON \
-            -DHID=ON \
-            -DLILV=ON \
-            -DOPUS=ON \
-            -DQTKEYCHAIN=ON \
-            -DVINYLCONTROL=ON \
-            -DFFMPEG=ON \
-            -DKEYFINDER=ON \
-            -DLOCALECOMPARE=ON \
-            -DMAD=ON \
-            -DMODPLUG=ON \
-            -DWAVPACK=ON \
             ..
         working-directory: build
         env:
@@ -89,25 +61,11 @@ jobs:
         if: matrix.name == 'coverage'
         run: |
           cmake \
-            -DCMAKE_BUILD_TYPE=Debug \
-            -DOPTIMIZE=off \
+            --preset=build-checks \
+            -DOPTIMIZE=OFF \
             -DCOVERAGE=ON \
             -DWARNINGS_FATAL=OFF \
             -DDEBUG_ASSERTIONS_FATAL=OFF \
-            -DBATTERY=ON \
-            -DBROADCAST=ON \
-            -DBULK=ON \
-            -DHID=ON \
-            -DLILV=ON \
-            -DOPUS=ON \
-            -DQTKEYCHAIN=ON \
-            -DVINYLCONTROL=ON \
-            -DFFMPEG=ON \
-            -DKEYFINDER=ON \
-            -DLOCALECOMPARE=ON \
-            -DMAD=ON \
-            -DMODPLUG=ON \
-            -DWAVPACK=ON \
             ..
         working-directory: build
       - name: Set up problem matcher

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,7 +176,7 @@ jobs:
         with:
           # This should always match the minimum required version in
           # our CMakeLists.txt
-          cmake-version: "3.19.x"
+          cmake-version: "3.21.x"
 
       - name: "[Windows] Set up cmake"
         uses: jwlawson/actions-setup-cmake@v1.13

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,6 @@ jobs:
               -DFFMPEG=ON
               -DLOCALECOMPARE=ON
               -DMAD=ON
-              -DMODPLUG=ON
-              -DWAVPACK=ON
               -DINSTALL_USER_UDEV_RULES=OFF
             ctest_args: []
             compiler_cache: ccache
@@ -45,8 +43,6 @@ jobs:
               -DFFMPEG=ON
               -DLOCALECOMPARE=ON
               -DMAD=ON
-              -DMODPLUG=ON
-              -DWAVPACK=ON
               -DINSTALL_USER_UDEV_RULES=OFF
             ctest_args: []
             compiler_cache: ccache
@@ -65,8 +61,6 @@ jobs:
               -DCOREAUDIO=ON
               -DHSS1394=ON
               -DMACOS_BUNDLE=ON
-              -DMODPLUG=ON
-              -DWAVPACK=ON
               -DVCPKG_TARGET_TRIPLET=x64-osx-min1012
               -DVCPKG_DEFAULT_HOST_TRIPLET=x64-osx-min1012
             # TODO: Fix this broken test on macOS
@@ -87,8 +81,6 @@ jobs:
               -DCOREAUDIO=ON
               -DHSS1394=ON
               -DMACOS_BUNDLE=ON
-              -DMODPLUG=ON
-              -DWAVPACK=ON
               -DVCPKG_TARGET_TRIPLET=arm64-osx-min1100
               -DVCPKG_DEFAULT_HOST_TRIPLET=x64-osx-min1012
             # TODO: Fix this broken test on macOS
@@ -116,8 +108,6 @@ jobs:
               -DLOCALECOMPARE=ON
               -DMAD=ON
               -DMEDIAFOUNDATION=ON
-              -DMODPLUG=ON
-              -DWAVPACK=ON
             cc: cl
             cxx: cl
             # TODO: Fix these broken tests on Windows
@@ -285,19 +275,11 @@ jobs:
 
       - name: "Configure"
         run: >-
-          cmake ${{ matrix.cmake_args }} ${{ env.CMAKE_ARGS_EXTRA }}
+          cmake --preset=common
+          ${{ matrix.cmake_args }} ${{ env.CMAKE_ARGS_EXTRA }}
           -DCMAKE_BUILD_TYPE=RelWithDebInfo
           -DCMAKE_PREFIX_PATH="${{ env.CMAKE_PREFIX_PATH }}"
           -DDEBUG_ASSERTIONS_FATAL=OFF
-          -DBATTERY=ON
-          -DBROADCAST=ON
-          -DDOWNLOAD_MANUAL=ON
-          -DHID=ON
-          -DKEYFINDER=ON
-          -DLILV=ON
-          -DOPUS=ON
-          -DQTKEYCHAIN=ON
-          -DVINYLCONTROL=ON
           -DCMAKE_VERBOSE_MAKEFILE=OFF
           -L
           ..

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ __pycache__
 # Clang/cmake
 *_build
 compile_commands.json
+CMakeUserPresets.json
 
 # Doxygen documentation
 /doxygen

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,35 @@
+{
+    "version": 3,
+    "configurePresets": [
+        {
+            "name": "common",
+            "displayName": "Common",
+            "description": "Common configuration regardless of environment or platform",
+            "cacheVariables": {
+                "BATTERY": "ON",
+                "BROADCAST": "ON",
+                "DOWNLOAD_MANUAL": "ON",
+                "HID": "ON",
+                "KEYFINDER": "ON",
+                "LILV": "ON",
+                "OPUS": "ON",
+                "QTKEYCHAIN": "ON",
+                "VINYLCONTROL": "ON",
+                "MODPLUG": "ON",
+                "WAVPACK": "ON"
+            }
+        },
+        {
+            "name": "build-checks",
+            "displayName": "Build Checks",
+            "description": "Common configuration specific to the CI build environment",
+            "inherits": "common",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "FFMPEG": "ON",
+                "LOCALECOMPARE": "ON",
+                "MAD": "ON"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
This reduces the copy-pasted build configs across CI by unifying them in a CMakePreset.
That way the same options can be used in local builds more easily. Moreover, this reduces the size of our github workflow config files, easing a transition to a different service.

### Open Questions:
1. Should we also move the OS-specific "cacheVariables" into presets?
2. Do also want to use the other CMakePreset features (configs for tests, workflows, etc)?
3. Now that this reduced the noise, it highlighted some more config options that seemed inconsistent across related jobs (see `-DOPTIMIZE=OFF` missing for the clang-tidy, `-DLOCALECOMPARE=ON` everywhere except macos, etc). Which of those are intentional and which have been missing by error?
4. the `cacheVariables` objects supports js booleans as values as well which would get converted into `"TRUE"`/`"FALSE"` while we use ON/OFF. Should we change that?