### PR TITLE
chore(skincontrols): Rename `show_previewdecks` to `show_preview_decks`

### DIFF
--- a/res/skins/Deere (64 Samplers)/skin.xml
+++ b/res/skins/Deere (64 Samplers)/skin.xml
@@ -52,7 +52,7 @@
       <!-- Library -->
       <attribute config_key="[Skin],show_library">1</attribute>
       <attribute config_key="[Skin],show_maximized_library">0</attribute>
-      <attribute persist="true" config_key="[Skin],show_previewdecks">0</attribute>
+      <attribute persist="true" config_key="[Skin],show_preview_decks">0</attribute>
       <attribute persist="true" config_key="[Skin],show_library_coverart">1</attribute>
       <!--Disable hidden effect routing Buttons-->
       <attribute persist="false" config_key="[EffectRack1_EffectUnit1],group_[MasterOutput]_enable">0</attribute>

--- a/res/skins/Deere (64 Samplers)/skin_settings.xml
+++ b/res/skins/Deere (64 Samplers)/skin_settings.xml
@@ -359,7 +359,7 @@
           <Template src="skin:../Deere/skinsettings_button.xml">
             <SetVariable name="TooltipId">show_previewdeck</SetVariable>
             <SetVariable name="text">Preview Deck</SetVariable>
-            <SetVariable name="skinsetting">[Skin],show_previewdecks</SetVariable>
+            <SetVariable name="skinsetting">[Skin],show_preview_decks</SetVariable>
           </Template>
 
           <Template src="skin:../Deere/skinsettings_button.xml">

--- a/res/skins/Deere/preview_deck.xml
+++ b/res/skins/Deere/preview_deck.xml
@@ -139,7 +139,7 @@
       </WidgetGroup><!-- /PreviewDeck -->
     </Children>
     <Connection>
-      <ConfigKey>[Skin],show_previewdecks</ConfigKey>
+      <ConfigKey>[Skin],show_preview_decks</ConfigKey>
       <BindProperty>visible</BindProperty>
     </Connection>
   </WidgetGroup>

--- a/res/skins/Deere/skin.xml
+++ b/res/skins/Deere/skin.xml
@@ -51,7 +51,7 @@
       <!-- Library -->
       <attribute config_key="[Skin],show_library">1</attribute>
       <attribute config_key="[Skin],show_maximized_library">0</attribute>
-      <attribute persist="true" config_key="[Skin],show_previewdecks">0</attribute>
+      <attribute persist="true" config_key="[Skin],show_preview_decks">0</attribute>
       <attribute persist="true" config_key="[Skin],show_library_coverart">1</attribute>
       <!--Disable hidden effect routing Buttons-->
       <attribute persist="false" config_key="[EffectRack1_EffectUnit1],group_[MasterOutput]_enable">0</attribute>

--- a/res/skins/Deere/skin_settings.xml
+++ b/res/skins/Deere/skin_settings.xml
@@ -293,7 +293,7 @@
           <Template src="skin:../Deere/skinsettings_button.xml">
             <SetVariable name="TooltipId">show_previewdeck</SetVariable>
             <SetVariable name="text">Preview Deck</SetVariable>
-            <SetVariable name="skinsetting">[Skin],show_previewdecks</SetVariable>
+            <SetVariable name="skinsetting">[Skin],show_preview_decks</SetVariable>
           </Template>
 
           <Template src="skin:../Deere/skinsettings_button.xml">

--- a/res/skins/LateNight (64 Samplers)/skin.xml
+++ b/res/skins/LateNight (64 Samplers)/skin.xml
@@ -94,7 +94,7 @@
     <!-- Library -->
       <attribute config_key="[Skin],show_maximized_library">0</attribute>
       <attribute persist="true" config_key="[LateNight],max_lib_show_decks">1</attribute>
-      <attribute persist="true" config_key="[Skin],show_previewdecks">0</attribute>
+      <attribute persist="true" config_key="[Skin],show_preview_decks">0</attribute>
       <attribute persist="true" config_key="[Skin],show_library_coverart">1</attribute>
 
     <!-- Disable hidden effect routing Buttons -->

--- a/res/skins/LateNight/decks/preview_deck.xml
+++ b/res/skins/LateNight/decks/preview_deck.xml
@@ -173,7 +173,7 @@
 
     </Children>
     <Connection>
-      <ConfigKey>[Skin],show_previewdecks</ConfigKey>
+      <ConfigKey>[Skin],show_preview_decks</ConfigKey>
       <BindProperty>visible</BindProperty>
     </Connection>
   </WidgetGroup>

--- a/res/skins/LateNight/skin.xml
+++ b/res/skins/LateNight/skin.xml
@@ -94,7 +94,7 @@
     <!-- Library -->
       <attribute config_key="[Skin],show_maximized_library">0</attribute>
       <attribute persist="true" config_key="[LateNight],max_lib_show_decks">1</attribute>
-      <attribute persist="true" config_key="[Skin],show_previewdecks">0</attribute>
+      <attribute persist="true" config_key="[Skin],show_preview_decks">0</attribute>
       <attribute persist="true" config_key="[Skin],show_library_coverart">1</attribute>
 
     <!-- Disable hidden effect routing Buttons -->

--- a/res/skins/LateNight/skin_settings.xml
+++ b/res/skins/LateNight/skin_settings.xml
@@ -470,7 +470,7 @@ Description:
               <Template src="skin:../LateNight/helpers/skin_settings_button_2state.xml">
                 <SetVariable name="TooltipId">show_previewdeck</SetVariable>
                 <SetVariable name="Text">Preview Deck</SetVariable>
-                <SetVariable name="Setting">[Skin],show_previewdecks</SetVariable>
+                <SetVariable name="Setting">[Skin],show_preview_decks</SetVariable>
               </Template>
 
               <!-- Cover Art -->

--- a/res/skins/Shade/preview_deck.xml
+++ b/res/skins/Shade/preview_deck.xml
@@ -276,7 +276,7 @@
       </WidgetGroup>
     </Children>
     <Connection>
-      <ConfigKey>[Skin],show_previewdecks</ConfigKey>
+      <ConfigKey>[Skin],show_preview_decks</ConfigKey>
       <BindProperty>visible</BindProperty>
     </Connection>
   </WidgetGroup>

--- a/res/skins/Shade/skin.xml
+++ b/res/skins/Shade/skin.xml
@@ -69,7 +69,7 @@
       <attribute persist="true" config_key="[Skin],sampler_row_2_expanded">0</attribute>
       <attribute persist="false" config_key="[Skin],show_effectrack">0</attribute>
       <attribute persist="false" config_key="[Skin],show_microphones">0</attribute>
-      <attribute persist="true" config_key="[Skin],show_previewdecks">0</attribute>
+      <attribute persist="true" config_key="[Skin],show_preview_decks">0</attribute>
       <attribute persist="true" config_key="[Skin],show_library_coverart">0</attribute>
       <attribute persist="true" config_key="[Skin],show_vinylcontrol">0</attribute>
       <attribute persist="true" config_key="[Skin],show_loop_beatjump_controls">0</attribute>

--- a/res/skins/Tango (64 Samplers)/skin.xml
+++ b/res/skins/Tango (64 Samplers)/skin.xml
@@ -99,7 +99,7 @@
 
       <!-- Library -->
       <attribute config_key="[Skin],show_maximized_library">0</attribute>
-      <attribute persist="true" config_key="[Skin],show_previewdecks">0</attribute>
+      <attribute persist="true" config_key="[Skin],show_preview_decks">0</attribute>
       <attribute persist="true" config_key="[Skin],show_library_coverart">1</attribute>
       <!--Disable hidden effect routing Buttons-->
       <attribute persist="false" config_key="[EffectRack1_EffectUnit1],group_[MasterOutput]_enable">0</attribute>

--- a/res/skins/Tango (64 Samplers)/skin_settings.xml
+++ b/res/skins/Tango (64 Samplers)/skin_settings.xml
@@ -710,7 +710,7 @@ Description:
 
           <Template src="skin:../Tango/controls/skin_settings_button_2state.xml">
             <SetVariable name="text">Preview Deck</SetVariable>
-            <SetVariable name="Setting">[Skin],show_previewdecks</SetVariable>
+            <SetVariable name="Setting">[Skin],show_preview_decks</SetVariable>
           </Template>
 
           <Template src="skin:../Tango/controls/skin_settings_button_2state.xml">

--- a/res/skins/Tango/decks/preview_deck.xml
+++ b/res/skins/Tango/decks/preview_deck.xml
@@ -170,7 +170,7 @@ Variables:
       </WidgetGroup>
     </Children>
     <Connection>
-      <ConfigKey persist="true">[Skin],show_previewdecks</ConfigKey>
+      <ConfigKey persist="true">[Skin],show_preview_decks</ConfigKey>
       <BindProperty>visible</BindProperty>
     </Connection>
   </WidgetGroup>

--- a/res/skins/Tango/library.xml
+++ b/res/skins/Tango/library.xml
@@ -49,7 +49,7 @@ Description:
                   <WidgetGroup>
                     <Size>1me,5f</Size>
                     <Connection>
-                      <ConfigKey persist="true">[Skin],show_previewdecks</ConfigKey>
+                      <ConfigKey persist="true">[Skin],show_preview_decks</ConfigKey>
                       <BindProperty>visible</BindProperty>
                     </Connection>
                   </WidgetGroup>

--- a/res/skins/Tango/skin.xml
+++ b/res/skins/Tango/skin.xml
@@ -93,7 +93,7 @@
 
       <!-- Library -->
       <attribute config_key="[Skin],show_maximized_library">0</attribute>
-      <attribute persist="true" config_key="[Skin],show_previewdecks">0</attribute>
+      <attribute persist="true" config_key="[Skin],show_preview_decks">0</attribute>
       <attribute persist="true" config_key="[Skin],show_library_coverart">1</attribute>
       <!--Disable hidden effect routing Buttons-->
       <attribute persist="false" config_key="[EffectRack1_EffectUnit1],group_[MasterOutput]_enable">0</attribute>

--- a/res/skins/Tango/skin_settings.xml
+++ b/res/skins/Tango/skin_settings.xml
@@ -697,7 +697,7 @@ Description:
 
           <Template src="skin:../Tango/controls/skin_settings_button_2state.xml">
             <SetVariable name="text">Preview Deck</SetVariable>
-            <SetVariable name="Setting">[Skin],show_previewdecks</SetVariable>
+            <SetVariable name="Setting">[Skin],show_preview_decks</SetVariable>
           </Template>
 
           <Template src="skin:../Tango/controls/skin_settings_button_2state.xml">

--- a/src/skin/skincontrols.cpp
+++ b/src/skin/skincontrols.cpp
@@ -16,7 +16,7 @@ SkinControls::SkinControls()
           m_showMicrophones(ConfigKey(kSkinGroup, QStringLiteral("show_microphones")),
                   true,
                   true),
-          m_showPreviewDecks(ConfigKey(kSkinGroup, QStringLiteral("show_previewdecks")),
+          m_showPreviewDecks(ConfigKey(kSkinGroup, QStringLiteral("show_preview_decks")),
                   true,
                   true),
           m_showSamplers(ConfigKey(kSkinGroup, QStringLiteral("show_samplers")),

--- a/src/test/co_dumps/co_dump_inital.csv
+++ b/src/test/co_dumps/co_dump_inital.csv
@@ -2095,7 +2095,7 @@
 [Channel3],hotcue_1_goto,0
 [Channel1],beatjump_0.03125_backward,0
 [Sampler4],loop_move_2_forward,0
-[Skin],show_previewdecks,0
+[Skin],show_preview_decks,0
 [EffectRack1_EffectUnit1_Effect2],parameter8_set_minus_one,0
 [QuickEffectRack1_[Channel2]_Effect1],parameter14_toggle,0
 [Channel3],volume_set_default,0

--- a/src/test/controlobjectaliastest.cpp
+++ b/src/test/controlobjectaliastest.cpp
@@ -137,7 +137,7 @@ TEST_F(ControlObjectAliasTest, SkinControls) {
     EXPECT_DOUBLE_EQ(showMicrophones.get(), showMicrophonesLegacy.get());
 
     auto showPreviewDecks = ControlProxy(
-            ConfigKey(kSkinGroup, QStringLiteral("show_previewdecks")));
+            ConfigKey(kSkinGroup, QStringLiteral("show_preview_decks")));
     auto showPreviewDecksLegacy = ControlProxy(
             ConfigKey(QStringLiteral("[PreviewDeck]"), QStringLiteral("show_previewdeck")));
     EXPECT_DOUBLE_EQ(showPreviewDecks.get(), showPreviewDecksLegacy.get());

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -259,7 +259,7 @@ void WMainMenuBar::initialize() {
     pViewShowPreviewDeck->setStatusTip(showPreviewDeckText);
     pViewShowPreviewDeck->setWhatsThis(buildWhatsThis(showPreviewDeckTitle, showPreviewDeckText));
     createVisibilityControl(pViewShowPreviewDeck,
-            ConfigKey(kSkinGroup, QStringLiteral("show_previewdecks")));
+            ConfigKey(kSkinGroup, QStringLiteral("show_preview_decks")));
     pViewMenu->addAction(pViewShowPreviewDeck);
 
 


### PR DESCRIPTION
This more consistent with the `[App],num_preview_decks` CO. Sorry, I should have checked this beforehand and done this as part of #11996.