### PR TITLE
fix wspinnyglsl and wvumeterglsl with QOpenGLFunctions

### DIFF
--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -1307,26 +1307,20 @@ QWidget* LegacySkinParser::parseSpinny(const QDomElement& node) {
     // with platform windows q_createNativeChildrenAndSetParent() while another window is already
     // under construction. The ID for the first window is not cleared and leads to a segfault
     // during on shutdown. This has been tested with Qt 5.12.8 and 5.15.3
+    QWidget* pParent = (qApp->platformName() == QLatin1String("xcb")) ? nullptr : m_pParent;
     WSpinnyBase* pSpinny;
-    if (qApp->platformName() == QLatin1String("xcb")) {
 #ifdef MIXXX_USE_QOPENGL
-        if (pWaveformWidgetFactory->isOpenGlShaderAvailable()) {
-            pSpinny = new WSpinnyGLSL(nullptr, group, m_pConfig, m_pVCManager, pPlayer);
-        } else
+    if (pWaveformWidgetFactory->isOpenGlShaderAvailable() &&
+            !CmdlineArgs::Instance().getUseLegacySpinny()) {
+        pSpinny = new WSpinnyGLSL(pParent, group, m_pConfig, m_pVCManager, pPlayer);
+    } else
 #endif
-        {
-            pSpinny = new WSpinny(nullptr, group, m_pConfig, m_pVCManager, pPlayer);
-        }
+    {
+        pSpinny = new WSpinny(pParent, group, m_pConfig, m_pVCManager, pPlayer);
+    }
+    if (!pParent) {
+        // Widget was created without parent (see comment above), set it now
         pSpinny->setParent(m_pParent);
-    } else {
-#ifdef MIXXX_USE_QOPENGL
-        if (pWaveformWidgetFactory->isOpenGlShaderAvailable()) {
-            pSpinny = new WSpinnyGLSL(m_pParent, group, m_pConfig, m_pVCManager, pPlayer);
-        } else
-#endif
-        {
-            pSpinny = new WSpinny(m_pParent, group, m_pConfig, m_pVCManager, pPlayer);
-        }
     }
     commonWidgetSetup(node, pSpinny);
 
@@ -1364,7 +1358,7 @@ QWidget* LegacySkinParser::parseVuMeter(const QDomElement& node) {
     return nullptr;
 #else
     auto* pWaveformWidgetFactory = WaveformWidgetFactory::instance();
-    if (!CmdlineArgs::Instance().getUseVuMeterGL() ||
+    if (CmdlineArgs::Instance().getUseLegacyVuMeter() ||
             (!pWaveformWidgetFactory->isOpenGlAvailable() &&
                     !pWaveformWidgetFactory->isOpenGlesAvailable())) {
         // Legacy WVuMeter
@@ -1395,26 +1389,19 @@ QWidget* LegacySkinParser::parseVuMeter(const QDomElement& node) {
     // with platform windows q_createNativeChildrenAndSetParent() while another window is already
     // under construction. The ID for the first window is not cleared and leads to a segfault
     // during on shutdown. This has been tested with Qt 5.12.8 and 5.15.3
+    QWidget* pParent = (qApp->platformName() == QLatin1String("xcb")) ? nullptr : m_pParent;
     WVuMeterBase* pVuMeterWidget;
-    if (qApp->platformName() == QLatin1String("xcb")) {
 #ifdef MIXXX_USE_QOPENGL
-        if (pWaveformWidgetFactory->isOpenGlShaderAvailable()) {
-            pVuMeterWidget = new WVuMeterGLSL();
-        } else
+    if (pWaveformWidgetFactory->isOpenGlShaderAvailable()) {
+        pVuMeterWidget = new WVuMeterGLSL(pParent);
+    } else
 #endif
-        {
-            pVuMeterWidget = new WVuMeter();
-        }
+    {
+        pVuMeterWidget = new WVuMeter(pParent);
+    }
+    if (!pParent) {
+        // Widget was created without parent (see comment above), set it now
         pVuMeterWidget->setParent(m_pParent);
-    } else {
-#ifdef MIXXX_USE_QOPENGL
-        if (pWaveformWidgetFactory->isOpenGlShaderAvailable()) {
-            pVuMeterWidget = new WVuMeterGLSL(m_pParent);
-        } else
-#endif
-        {
-            pVuMeterWidget = new WVuMeter(m_pParent);
-        }
     }
     commonWidgetSetup(node, pVuMeterWidget);
 

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -23,7 +23,8 @@ CmdlineArgs::CmdlineArgs()
           m_controllerAbortOnWarning(false),
           m_developer(false),
           m_safeMode(false),
-          m_useVuMeterGL(false),
+          m_useLegacyVuMeter(false),
+          m_useLegacySpinny(false),
           m_debugAssertBreak(false),
           m_settingsPathSet(false),
           m_scaleFactor(1.0),
@@ -172,11 +173,17 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
     parser.addOption(timelinePath);
     parser.addOption(timelinePathDeprecated);
 
-    const QCommandLineOption enableVuMeterGL(QStringLiteral("enable-vumetergl"),
+    const QCommandLineOption enableLegacyVuMeter(QStringLiteral("enable-legacy-vumeter"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
-                                      "Use OpenGL vu meter")
+                                      "Use legacy vu meter")
                             : QString());
-    parser.addOption(enableVuMeterGL);
+    parser.addOption(enableLegacyVuMeter);
+
+    const QCommandLineOption enableLegacySpinny(QStringLiteral("enable-legacy-spinny"),
+            forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
+                                      "Use legacy spinny")
+                            : QString());
+    parser.addOption(enableLegacySpinny);
 
     const QCommandLineOption controllerDebug(QStringLiteral("controller-debug"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
@@ -338,7 +345,8 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
         m_timelinePath = parser.value(timelinePathDeprecated);
     }
 
-    m_useVuMeterGL = parser.isSet(enableVuMeterGL);
+    m_useLegacyVuMeter = parser.isSet(enableLegacyVuMeter);
+    m_useLegacySpinny = parser.isSet(enableLegacySpinny);
     m_controllerDebug = parser.isSet(controllerDebug) || parser.isSet(controllerDebugDeprecated);
     m_controllerAbortOnWarning = parser.isSet(controllerAbortOnWarning);
     m_developer = parser.isSet(developer);

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -42,8 +42,11 @@ class CmdlineArgs final {
     bool useColors() const {
         return m_useColors;
     }
-    bool getUseVuMeterGL() const {
-        return m_useVuMeterGL;
+    bool getUseLegacyVuMeter() const {
+        return m_useLegacyVuMeter;
+    }
+    bool getUseLegacySpinny() const {
+        return m_useLegacySpinny;
     }
     bool getDebugAssertBreak() const { return m_debugAssertBreak; }
     bool getSettingsPathSet() const { return m_settingsPathSet; }
@@ -79,7 +82,8 @@ class CmdlineArgs final {
     bool m_controllerAbortOnWarning; // Controller Engine will be stricter
     bool m_developer; // Developer Mode
     bool m_safeMode;
-    bool m_useVuMeterGL;
+    bool m_useLegacyVuMeter;
+    bool m_useLegacySpinny;
     bool m_debugAssertBreak;
     bool m_settingsPathSet; // has --settingsPath been set on command line ?
     double m_scaleFactor;

--- a/src/widget/wspinnyglsl.cpp
+++ b/src/widget/wspinnyglsl.cpp
@@ -90,6 +90,9 @@ void WSpinnyGLSL::paintGL() {
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
+    glClearColor(0.f, 0.f, 0.f, 1.f);
+    glClear(GL_COLOR_BUFFER_BIT);
+
     m_textureShader.bind();
 
     int matrixLocation = m_textureShader.matrixLocation();
@@ -152,6 +155,8 @@ void WSpinnyGLSL::paintGL() {
 }
 
 void WSpinnyGLSL::initializeGL() {
+    initializeOpenGLFunctions();
+
     updateTextures();
 
     m_pQTexture.reset(new QOpenGLTexture(QOpenGLTexture::Target2D));
@@ -227,9 +232,9 @@ void WSpinnyGLSL::drawVinylQuality() {
 
     m_vinylQualityShader.setUniformValue(samplerLocation, 0);
 
-    m_textureShader.setAttributeArray(
+    m_vinylQualityShader.setAttributeArray(
             positionLocation, GL_FLOAT, posarray, 2);
-    m_textureShader.setAttributeArray(
+    m_vinylQualityShader.setAttributeArray(
             texcoordLocation, GL_FLOAT, texarray, 2);
 
     m_pQTexture->bind();

--- a/src/widget/wspinnyglsl.h
+++ b/src/widget/wspinnyglsl.h
@@ -1,12 +1,13 @@
 #pragma once
 
+#include <QOpenGLFunctions>
 #include <QOpenGLTexture>
 
 #include "shaders/textureshader.h"
 #include "shaders/vinylqualityshader.h"
 #include "widget/wspinnybase.h"
 
-class WSpinnyGLSL : public WSpinnyBase {
+class WSpinnyGLSL : public WSpinnyBase, private QOpenGLFunctions {
   public:
     WSpinnyGLSL(QWidget* parent,
             const QString& group,

--- a/src/widget/wvumeterglsl.cpp
+++ b/src/widget/wvumeterglsl.cpp
@@ -22,6 +22,8 @@ void WVuMeterGLSL::draw() {
 }
 
 void WVuMeterGLSL::initializeGL() {
+    initializeOpenGLFunctions();
+
     m_pTextureBack.reset(createTexture(m_pPixmapBack));
     m_pTextureVu.reset(createTexture(m_pPixmapVu));
     m_textureShader.init();

--- a/src/widget/wvumeterglsl.h
+++ b/src/widget/wvumeterglsl.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QOpenGLFunctions>
 #include <QOpenGLTexture>
 #include <memory>
 
@@ -8,7 +9,7 @@
 #include "widget/wvumeterbase.h"
 #include "widget/wwidget.h"
 
-class WVuMeterGLSL : public WVuMeterBase {
+class WVuMeterGLSL : public WVuMeterBase, private QOpenGLFunctions {
     Q_OBJECT
   public:
     explicit WVuMeterGLSL(QWidget* pParent = nullptr);


### PR DESCRIPTION
derive wspinnyglsl wvumeterglsl from QOpenGLFunctions and call initOpenGLFunctions, add --enable-legacy-spinny and changed to --enable-legacy-vumeter (default glsl), some minor cleanup

fixes https://github.com/mixxxdj/mixxx/issues/11930