### PR TITLE
shortkeys for track list management

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1141,6 +1141,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/track/trackref.cpp
   src/util/battery/battery.cpp
   src/util/cache.cpp
+  src/util/clipboard.cpp
   src/util/cmdlineargs.cpp
   src/util/color/color.cpp
   src/util/color/colorpalette.cpp

--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -30,6 +30,7 @@
 #include "skin/skincontrols.h"
 #include "soundio/soundmanager.h"
 #include "sources/soundsourceproxy.h"
+#include "util/clipboard.h"
 #include "util/db/dbconnectionpooled.h"
 #include "util/font.h"
 #include "util/logger.h"
@@ -335,6 +336,7 @@ void CoreServices::initialize(QApplication* pApp) {
 
     emit initializationProgressUpdate(50, tr("library"));
     CoverArtCache::createInstance();
+    Clipboard::createInstance();
 
     m_pTrackCollectionManager = std::make_shared<TrackCollectionManager>(
             this,
@@ -579,6 +581,8 @@ void CoreServices::finalize() {
 
     // CoverArtCache is fairly independent of everything else.
     CoverArtCache::destroy();
+
+    Clipboard::destroy();
 
     // PlayerManager depends on Engine, SoundManager, VinylControlManager, and Config
     // The player manager has to be deleted before the library to ensure

--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -14,6 +14,8 @@
 #include "moc_autodjfeature.cpp"
 #include "sources/soundsourceproxy.h"
 #include "track/track.h"
+#include "util/clipboard.h"
+#include "util/dnd.h"
 #include "widget/wlibrary.h"
 #include "widget/wlibrarysidebar.h"
 
@@ -159,6 +161,14 @@ void AutoDJFeature::activate() {
     emit switchToView(kViewName);
     emit disableSearch();
     emit enableCoverArtDisplay(true);
+}
+
+void AutoDJFeature::clear() {
+    m_playlistDao.clearAutoDJQueue();
+}
+
+void AutoDJFeature::paste() {
+    emit pasteFromSidebar();
 }
 
 bool AutoDJFeature::dropAccept(const QList<QUrl>& urls, QObject* pSource) {

--- a/src/library/autodj/autodjfeature.h
+++ b/src/library/autodj/autodjfeature.h
@@ -32,6 +32,9 @@ class AutoDJFeature : public LibraryFeature {
 
     QVariant title() override;
 
+    void clear() override;
+    void paste() override;
+
     bool dropAccept(const QList<QUrl>& urls, QObject* pSource) override;
     bool dragMoveAccept(const QUrl& url) override;
 

--- a/src/library/autodj/dlgautodj.cpp
+++ b/src/library/autodj/dlgautodj.cpp
@@ -390,6 +390,10 @@ void DlgAutoDJ::setFocus() {
     m_pTrackTableView->setFocus();
 }
 
+void DlgAutoDJ::pasteFromSidebar() {
+    m_pTrackTableView->pasteFromSidebar();
+}
+
 void DlgAutoDJ::keyPressEvent(QKeyEvent* pEvent) {
     // If we receive key events either the mode selector or the spinbox are focused.
     // Return, Enter and Escape move focus back to the previously focused

--- a/src/library/autodj/dlgautodj.h
+++ b/src/library/autodj/dlgautodj.h
@@ -28,6 +28,7 @@ class DlgAutoDJ : public QWidget, public Ui::DlgAutoDJ, public LibraryView {
     void onShow() override;
     bool hasFocus() const override;
     void setFocus() override;
+    void pasteFromSidebar() override;
     void onSearch(const QString& text) override;
     void activateSelectedTrack() override;
     void loadSelectedTrackToGroup(const QString& group, bool play) override;

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -404,7 +404,7 @@ QList<int> BaseTrackTableModel::pasteTracks(const QModelIndex& insertionIndex) {
 
     int insertionPos = 0;
     const QList<QUrl> urls = Clipboard::urls();
-    const QList<TrackId> trackIds = m_pTrackCollectionManager->resolveTrackIdsFromUrls(urls, false);
+    const QList<TrackId> trackIds = m_pTrackCollectionManager->resolveTrackIdsFromUrls(urls, true);
     if (!trackIds.isEmpty()) {
         addTracksWithTrackIds(insertionIndex, trackIds, &insertionPos);
     }

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -397,6 +397,11 @@ void BaseTrackTableModel::copyTracks(const QModelIndexList& indices) const {
 }
 
 QList<int> BaseTrackTableModel::pasteTracks(const QModelIndex& insertionIndex) {
+    // Don't paste into locked playlists and crates or into into History
+    if (isLocked() || !hasCapabilities(TrackModel::Capability::ReceiveDrops)) {
+        return QList<int>{};
+    }
+
     int insertionPos = 0;
     const QList<QUrl> urls = Clipboard::urls();
     const QList<TrackId> trackIds = m_pTrackCollectionManager->resolveTrackIdsFromUrls(urls, false);

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -21,6 +21,7 @@
 #include "moc_basetracktablemodel.cpp"
 #include "track/track.h"
 #include "util/assert.h"
+#include "util/clipboard.h"
 #include "util/datetime.h"
 #include "util/db/sqlite.h"
 #include "util/logger.h"
@@ -378,6 +379,54 @@ int BaseTrackTableModel::columnCount(const QModelIndex& parent) const {
         return 0;
     }
     return countValidColumnHeaders();
+}
+
+void BaseTrackTableModel::cutTracks(const QModelIndexList& indices) {
+    copyTracks(indices);
+    removeTracks(indices);
+}
+
+void BaseTrackTableModel::copyTracks(const QModelIndexList& indices) const {
+    Clipboard::start();
+    for (const QModelIndex& index : indices) {
+        if (index.isValid()) {
+            Clipboard::add(QUrl::fromLocalFile(getTrackLocation(index)));
+        }
+    }
+    Clipboard::finish();
+}
+
+QList<int> BaseTrackTableModel::pasteTracks(const QModelIndex& insertionIndex) {
+    int insertionPos = 0;
+    const QList<QUrl> urls = Clipboard::urls();
+    const QList<TrackId> trackIds = m_pTrackCollectionManager->resolveTrackIdsFromUrls(urls, false);
+    if (!trackIds.isEmpty()) {
+        addTracksWithTrackIds(insertionIndex, trackIds, &insertionPos);
+    }
+
+    QList<int> rows;
+    for (const auto& trackId : trackIds) {
+        const auto trackRows = getTrackRows(trackId);
+        for (int trackRow : trackRows) {
+            if (insertionPos == 0) {
+                rows.append(trackRow);
+            } else {
+                int pos =
+                        index(
+                                trackRow,
+                                fieldIndex(ColumnCache::
+                                                COLUMN_PLAYLISTTRACKSTABLE_POSITION))
+                                .data()
+                                .toInt();
+                // trackRows includes all instances in the table of the pasted
+                // tracks. We only want to select the ones we just inserted
+                if (pos >= insertionPos && pos < insertionPos + trackIds.size()) {
+                    rows.append(trackRow);
+                }
+            }
+        }
+    }
+    return rows;
 }
 
 bool BaseTrackTableModel::isColumnHiddenByDefault(

--- a/src/library/basetracktablemodel.h
+++ b/src/library/basetracktablemodel.h
@@ -81,6 +81,10 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
         return m_columnCache.fieldIndex(fieldName);
     }
 
+    void cutTracks(const QModelIndexList& indices) override;
+    void copyTracks(const QModelIndexList& indices) const override;
+    QList<int> pasteTracks(const QModelIndex& index) override;
+
     bool isColumnHiddenByDefault(
             int column) override;
 

--- a/src/library/browse/browsetablemodel.cpp
+++ b/src/library/browse/browsetablemodel.cpp
@@ -323,6 +323,10 @@ void BrowseTableModel::copyTracks(const QModelIndexList& indices) const {
         }
     }
     Clipboard::finish();
+
+    // TODO Investigate if we can also implement cut and paste (via QFile
+    // operations) so mixxx could manage files in the filesystem, rather than
+    // having to go switch between mixxx and the system file browser.
 }
 
 void BrowseTableModel::removeTracks(const QModelIndexList&) {

--- a/src/library/browse/browsetablemodel.cpp
+++ b/src/library/browse/browsetablemodel.cpp
@@ -14,6 +14,7 @@
 #include "moc_browsetablemodel.cpp"
 #include "recording/recordingmanager.h"
 #include "track/track.h"
+#include "util/clipboard.h"
 #include "widget/wlibrarytableview.h"
 
 namespace {
@@ -312,6 +313,16 @@ bool BrowseTableModel::isColumnHiddenByDefault(int column) {
 }
 
 void BrowseTableModel::moveTrack(const QModelIndex&, const QModelIndex&) {
+}
+
+void BrowseTableModel::copyTracks(const QModelIndexList& indices) const {
+    Clipboard::start();
+    for (const QModelIndex& index : indices) {
+        if (index.isValid()) {
+            Clipboard::add(QUrl::fromLocalFile(getTrackLocation(index)));
+        }
+    }
+    Clipboard::finish();
 }
 
 void BrowseTableModel::removeTracks(const QModelIndexList&) {

--- a/src/library/browse/browsetablemodel.h
+++ b/src/library/browse/browsetablemodel.h
@@ -71,6 +71,7 @@ class BrowseTableModel final : public QStandardItemModel, public virtual TrackMo
     const QString currentSearch() const override;
     bool isColumnInternal(int) override;
     void moveTrack(const QModelIndex&, const QModelIndex&) override;
+    void copyTracks(const QModelIndexList& indices) const override;
     bool isLocked() override { return false; }
     bool isColumnHiddenByDefault(int column) override;
     const QList<int>& searchColumns() const override;

--- a/src/library/dao/playlistdao.cpp
+++ b/src/library/dao/playlistdao.cpp
@@ -796,6 +796,16 @@ int PlaylistDAO::insertTracksIntoPlaylist(const QList<TrackId>& trackIds,
     return tracksAdded;
 }
 
+void PlaylistDAO::clearAutoDJQueue() {
+    const int iAutoDJPlaylistId = getPlaylistIdFromName(AUTODJ_TABLE);
+    // If the first track is already loaded to the player,
+    // alter the playlist only below the first track
+    const int position =
+            (m_pAutoDJProcessor && m_pAutoDJProcessor->nextTrackLoaded()) ? 2 : 1;
+
+    removeTracksFromPlaylist(iAutoDJPlaylistId, position);
+}
+
 void PlaylistDAO::addPlaylistToAutoDJQueue(const int playlistId, AutoDJSendLoc loc) {
     //qDebug() << "Adding tracks from playlist " << playlistId << " to the Auto-DJ Queue";
 

--- a/src/library/dao/playlistdao.h
+++ b/src/library/dao/playlistdao.h
@@ -107,6 +107,8 @@ class PlaylistDAO : public QObject, public virtual DAO {
     bool insertTrackIntoPlaylist(TrackId trackId, int playlistId, int position);
     // Inserts a list of tracks into playlist
     int insertTracksIntoPlaylist(const QList<TrackId>& trackIds, const int playlistId, int position);
+    // Remove all tracks from the Auto-DJ Queue
+    void clearAutoDJQueue();
     // Add a playlist to the Auto-DJ Queue
     void addPlaylistToAutoDJQueue(const int playlistId, AutoDJSendLoc loc);
     // Add a list of tracks to the Auto-DJ Queue

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -472,7 +472,7 @@ void Library::addFeature(LibraryFeature* feature) {
     connect(feature,
             &LibraryFeature::pasteFromSidebar,
             this,
-            &Library::slotPasteFromSidebar);
+            &Library::pasteFromSidebar);
     connect(feature,
             &LibraryFeature::showTrackModel,
             this,
@@ -526,10 +526,6 @@ void Library::onPlayerManagerTrackAnalyzerIdle() {
     if (m_pAnalysisFeature) {
         m_pAnalysisFeature->resumeAnalysis();
     }
-}
-
-void Library::slotPasteFromSidebar() {
-    emit pasteFromSidebar();
 }
 
 void Library::slotShowTrackModel(QAbstractItemModel* model) {

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -389,6 +389,10 @@ void Library::bindLibraryWidget(
             &Library::showTrackModel,
             pTrackTableView,
             &WTrackTableView::loadTrackModel);
+    connect(this,
+            &Library::pasteFromSidebar,
+            m_pLibraryWidget,
+            &WLibrary::pasteFromSidebar);
     connect(pTrackTableView,
             &WTrackTableView::loadTrack,
             this,
@@ -399,6 +403,10 @@ void Library::bindLibraryWidget(
             &Library::slotLoadTrackToPlayer);
     m_pLibraryWidget->registerView(m_sTrackViewName, pTrackTableView);
 
+    connect(m_pLibraryWidget,
+            &WLibrary::setLibraryFocus,
+            m_pLibraryControl,
+            &LibraryControl::setLibraryFocus);
     connect(this,
             &Library::switchToView,
             m_pLibraryWidget,
@@ -462,6 +470,10 @@ void Library::addFeature(LibraryFeature* feature) {
     m_features.push_back(feature);
     m_pSidebarModel->addLibraryFeature(feature);
     connect(feature,
+            &LibraryFeature::pasteFromSidebar,
+            this,
+            &Library::slotPasteFromSidebar);
+    connect(feature,
             &LibraryFeature::showTrackModel,
             this,
             &Library::slotShowTrackModel);
@@ -516,8 +528,12 @@ void Library::onPlayerManagerTrackAnalyzerIdle() {
     }
 }
 
+void Library::slotPasteFromSidebar() {
+    emit pasteFromSidebar();
+}
+
 void Library::slotShowTrackModel(QAbstractItemModel* model) {
-    //qDebug() << "Library::slotShowTrackModel" << model;
+    // qDebug() << "Library::slotShowTrackModel" << model;
     TrackModel* trackModel = dynamic_cast<TrackModel*>(model);
     VERIFY_OR_DEBUG_ASSERT(trackModel) {
         return;
@@ -528,7 +544,7 @@ void Library::slotShowTrackModel(QAbstractItemModel* model) {
 }
 
 void Library::slotSwitchToView(const QString& view) {
-    //qDebug() << "Library::slotSwitchToView" << view;
+    // qDebug() << "Library::slotSwitchToView" << view;
     emit switchToView(view);
 }
 

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -114,6 +114,7 @@ class Library: public QObject {
     void slotRequestAddDir(const QString& directory);
     void slotRequestRemoveDir(const QString& directory, LibraryRemovalType removalType);
     void slotRequestRelocateDir(const QString& previousDirectory, const QString& newDirectory);
+    void slotPasteFromSidebar();
     void onSkinLoadFinished();
 
   signals:
@@ -124,6 +125,7 @@ class Library: public QObject {
     void restoreSearch(const QString&);
     void search(const QString& text);
     void disableSearch();
+    void pasteFromSidebar();
     // emit this signal to enable/disable the cover art widget
     void enableCoverArtDisplay(bool);
     void selectTrack(const TrackId&);

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -114,7 +114,6 @@ class Library: public QObject {
     void slotRequestAddDir(const QString& directory);
     void slotRequestRemoveDir(const QString& directory, LibraryRemovalType removalType);
     void slotRequestRelocateDir(const QString& previousDirectory, const QString& newDirectory);
-    void slotPasteFromSidebar();
     void onSkinLoadFinished();
 
   signals:

--- a/src/library/libraryfeature.h
+++ b/src/library/libraryfeature.h
@@ -70,30 +70,11 @@ class LibraryFeature : public QObject {
 
     virtual void clear() {
     }
-    virtual void clearChild(const QModelIndex& index) {
-        Q_UNUSED(index);
-    }
-    virtual void cut() {
-    }
-    virtual void cutChild(const QModelIndex& index) {
-        Q_UNUSED(index);
-    }
-    virtual void copy() const {
-    }
-    virtual void copyChild(const QModelIndex& index) const {
-        Q_UNUSED(index);
-    }
     virtual void paste() {
     }
     virtual void pasteChild(const QModelIndex& index) {
         Q_UNUSED(index);
     }
-    virtual void selectAll() {
-    }
-    virtual void selectAllChild(const QModelIndex& index) {
-        Q_UNUSED(index);
-    }
-
     // Reimplement this to register custom views with the library widget.
     virtual void bindLibraryWidget(WLibrary* /* libraryWidget */,
                             KeyboardEventFilter* /* keyboard */) {}

--- a/src/library/libraryfeature.h
+++ b/src/library/libraryfeature.h
@@ -68,6 +68,32 @@ class LibraryFeature : public QObject {
         return false;
     }
 
+    virtual void clear() {
+    }
+    virtual void clearChild(const QModelIndex& index) {
+        Q_UNUSED(index);
+    }
+    virtual void cut() {
+    }
+    virtual void cutChild(const QModelIndex& index) {
+        Q_UNUSED(index);
+    }
+    virtual void copy() const {
+    }
+    virtual void copyChild(const QModelIndex& index) const {
+        Q_UNUSED(index);
+    }
+    virtual void paste() {
+    }
+    virtual void pasteChild(const QModelIndex& index) {
+        Q_UNUSED(index);
+    }
+    virtual void selectAll() {
+    }
+    virtual void selectAllChild(const QModelIndex& index) {
+        Q_UNUSED(index);
+    }
+
     // Reimplement this to register custom views with the library widget.
     virtual void bindLibraryWidget(WLibrary* /* libraryWidget */,
                             KeyboardEventFilter* /* keyboard */) {}
@@ -135,6 +161,7 @@ class LibraryFeature : public QObject {
     void restoreModelState();
     void restoreSearch(const QString&);
     void disableSearch();
+    void pasteFromSidebar();
     // emit this signal before you parse a large music collection, e.g., iTunes, Traktor.
     // The second arg indicates if the feature should be "selected" when loading starts
     void featureIsLoading(LibraryFeature*, bool selectFeature);

--- a/src/library/libraryview.h
+++ b/src/library/libraryview.h
@@ -22,6 +22,9 @@ class LibraryView {
     /// Reimplement if LibraryView should be able to search
     virtual void onSearch(const QString& text) {Q_UNUSED(text);}
 
+    virtual void pasteFromSidebar() {
+    }
+
     /// If applicable, requests that the LibraryView load the selected
     /// track. Does nothing otherwise.
     virtual void activateSelectedTrack() {

--- a/src/library/playlisttablemodel.cpp
+++ b/src/library/playlisttablemodel.cpp
@@ -189,29 +189,31 @@ void PlaylistTableModel::selectPlaylist(int playlistId) {
     setSort(defaultSortColumn(), defaultSortOrder());
 }
 
-int PlaylistTableModel::addTracks(const QModelIndex& index,
-        const QList<QString>& locations) {
-    if (locations.isEmpty()) {
+int PlaylistTableModel::addTracksWithTrackIds(const QModelIndex& insertionIndex,
+        const QList<TrackId>& trackIds,
+        int* pOutInsertionPos) {
+    if (trackIds.isEmpty()) {
         return 0;
     }
 
-    QList<TrackId> trackIds = m_pTrackCollectionManager->resolveTrackIdsFromLocations(
-            locations);
-
     const int positionColumn = fieldIndex(ColumnCache::COLUMN_PLAYLISTTRACKSTABLE_POSITION);
-    int position = index.sibling(index.row(), positionColumn).data().toInt();
+    int position = index(insertionIndex.row(), positionColumn).data().toInt();
 
     // Handle weird cases like a drag and drop to an invalid index
     if (position <= 0) {
         position = rowCount() + 1;
     }
 
+    if (pOutInsertionPos) {
+        *pOutInsertionPos = position;
+    }
+
     int tracksAdded = m_pTrackCollectionManager->internalCollection()->getPlaylistDAO().insertTracksIntoPlaylist(
             trackIds, m_iPlaylistId, position);
 
-    if (locations.size() - tracksAdded > 0) {
+    if (trackIds.size() - tracksAdded > 0) {
         qDebug() << "PlaylistTableModel::addTracks could not add"
-                 << locations.size() - tracksAdded
+                 << trackIds.size() - tracksAdded
                  << "to playlist" << m_iPlaylistId;
     }
     return tracksAdded;

--- a/src/library/playlisttablemodel.cpp
+++ b/src/library/playlisttablemodel.cpp
@@ -212,9 +212,12 @@ int PlaylistTableModel::addTracksWithTrackIds(const QModelIndex& insertionIndex,
             trackIds, m_iPlaylistId, position);
 
     if (trackIds.size() - tracksAdded > 0) {
+        QString playlistName = m_pTrackCollectionManager->internalCollection()
+                                       ->getPlaylistDAO()
+                                       .getPlaylistName(m_iPlaylistId);
         qDebug() << "PlaylistTableModel::addTracks could not add"
                  << trackIds.size() - tracksAdded
-                 << "to playlist" << m_iPlaylistId;
+                 << "to playlist id" << m_iPlaylistId << "name" << playlistName;
     }
     return tracksAdded;
 }

--- a/src/library/playlisttablemodel.h
+++ b/src/library/playlisttablemodel.h
@@ -25,7 +25,9 @@ class PlaylistTableModel final : public TrackSetTableModel {
     /// This function should only be used by AUTODJ
     void removeTracks(const QModelIndexList& indices) final;
     /// Returns the number of successful additions.
-    int addTracks(const QModelIndex& index, const QList<QString>& locations) final;
+    int addTracksWithTrackIds(const QModelIndex& index,
+            const QList<TrackId>& trackIds,
+            int* pOutInsertionPos) final;
     bool isLocked() final;
 
     /// Get the total duration of all tracks referenced by the given model indices

--- a/src/library/proxytrackmodel.cpp
+++ b/src/library/proxytrackmodel.cpp
@@ -113,6 +113,17 @@ void ProxyTrackModel::removeTracks(const QModelIndexList& indices) {
     }
 }
 
+void ProxyTrackModel::copyTracks(const QModelIndexList& indices) const {
+    QModelIndexList translatedList;
+    foreach (QModelIndex index, indices) {
+        QModelIndex indexSource = mapToSource(index);
+        translatedList.append(indexSource);
+    }
+    if (m_pTrackModel) {
+        m_pTrackModel->copyTracks(translatedList);
+    }
+}
+
 void ProxyTrackModel::moveTrack(const QModelIndex& sourceIndex,
         const QModelIndex& destIndex) {
     QModelIndex sourceIndexSource = mapToSource(sourceIndex);

--- a/src/library/proxytrackmodel.h
+++ b/src/library/proxytrackmodel.h
@@ -36,6 +36,7 @@ class ProxyTrackModel : public QSortFilterProxyModel, public TrackModel {
     bool isColumnInternal(int column) final;
     bool isColumnHiddenByDefault(int column) final;
     void removeTracks(const QModelIndexList& indices) final;
+    void copyTracks(const QModelIndexList& indices) const final;
     void moveTrack(const QModelIndex& sourceIndex, const QModelIndex& destIndex) final;
     QAbstractItemDelegate* delegateForColumn(const int i, QObject* pParent) final;
     QString getModelSetting(const QString& name) final;

--- a/src/library/sidebarmodel.cpp
+++ b/src/library/sidebarmodel.cpp
@@ -152,9 +152,9 @@ void SidebarModel::clear(const QModelIndex& index) {
     if (index.internalPointer() == this) {
         m_sFeatures[index.row()]->clear();
     } else {
-        TreeItem* tree_item = (TreeItem*)index.internalPointer();
-        if (tree_item) {
-            LibraryFeature* feature = tree_item->feature();
+        TreeItem* pTreeItem = (TreeItem*)index.internalPointer();
+        if (pTreeItem) {
+            LibraryFeature* feature = pTreeItem->feature();
             feature->clearChild(index);
         }
     }
@@ -164,9 +164,9 @@ void SidebarModel::cut(const QModelIndex& index) {
     if (index.internalPointer() == this) {
         m_sFeatures[index.row()]->cut();
     } else {
-        TreeItem* tree_item = (TreeItem*)index.internalPointer();
-        if (tree_item) {
-            LibraryFeature* feature = tree_item->feature();
+        TreeItem* pTreeItem = (TreeItem*)index.internalPointer();
+        if (pTreeItem) {
+            LibraryFeature* feature = pTreeItem->feature();
             feature->cutChild(index);
         }
     }
@@ -176,9 +176,9 @@ void SidebarModel::copy(const QModelIndex& index) const {
     if (index.internalPointer() == this) {
         m_sFeatures[index.row()]->copy();
     } else {
-        TreeItem* tree_item = (TreeItem*)index.internalPointer();
-        if (tree_item) {
-            LibraryFeature* feature = tree_item->feature();
+        TreeItem* pTreeItem = (TreeItem*)index.internalPointer();
+        if (pTreeItem) {
+            LibraryFeature* feature = pTreeItem->feature();
             feature->copyChild(index);
         }
     }
@@ -188,9 +188,9 @@ void SidebarModel::paste(const QModelIndex& index) {
     if (index.internalPointer() == this) {
         m_sFeatures[index.row()]->paste();
     } else {
-        TreeItem* tree_item = (TreeItem*)index.internalPointer();
-        if (tree_item) {
-            LibraryFeature* feature = tree_item->feature();
+        TreeItem* pTreeItem = (TreeItem*)index.internalPointer();
+        if (pTreeItem) {
+            LibraryFeature* feature = pTreeItem->feature();
             feature->pasteChild(index);
         }
     }
@@ -200,9 +200,9 @@ void SidebarModel::selectAll(const QModelIndex& index) {
     if (index.internalPointer() == this) {
         m_sFeatures[index.row()]->selectAll();
     } else {
-        TreeItem* tree_item = (TreeItem*)index.internalPointer();
-        if (tree_item) {
-            LibraryFeature* feature = tree_item->feature();
+        TreeItem* pTreeItem = (TreeItem*)index.internalPointer();
+        if (pTreeItem) {
+            LibraryFeature* feature = pTreeItem->feature();
             feature->selectAllChild(index);
         }
     }

--- a/src/library/sidebarmodel.cpp
+++ b/src/library/sidebarmodel.cpp
@@ -148,6 +148,66 @@ QModelIndex SidebarModel::getFeatureRootIndex(LibraryFeature* pFeature) {
     return ind;
 }
 
+void SidebarModel::clear(const QModelIndex& index) {
+    if (index.internalPointer() == this) {
+        m_sFeatures[index.row()]->clear();
+    } else {
+        TreeItem* tree_item = (TreeItem*)index.internalPointer();
+        if (tree_item) {
+            LibraryFeature* feature = tree_item->feature();
+            feature->clearChild(index);
+        }
+    }
+}
+
+void SidebarModel::cut(const QModelIndex& index) {
+    if (index.internalPointer() == this) {
+        m_sFeatures[index.row()]->cut();
+    } else {
+        TreeItem* tree_item = (TreeItem*)index.internalPointer();
+        if (tree_item) {
+            LibraryFeature* feature = tree_item->feature();
+            feature->cutChild(index);
+        }
+    }
+}
+
+void SidebarModel::copy(const QModelIndex& index) const {
+    if (index.internalPointer() == this) {
+        m_sFeatures[index.row()]->copy();
+    } else {
+        TreeItem* tree_item = (TreeItem*)index.internalPointer();
+        if (tree_item) {
+            LibraryFeature* feature = tree_item->feature();
+            feature->copyChild(index);
+        }
+    }
+}
+
+void SidebarModel::paste(const QModelIndex& index) {
+    if (index.internalPointer() == this) {
+        m_sFeatures[index.row()]->paste();
+    } else {
+        TreeItem* tree_item = (TreeItem*)index.internalPointer();
+        if (tree_item) {
+            LibraryFeature* feature = tree_item->feature();
+            feature->pasteChild(index);
+        }
+    }
+}
+
+void SidebarModel::selectAll(const QModelIndex& index) {
+    if (index.internalPointer() == this) {
+        m_sFeatures[index.row()]->selectAll();
+    } else {
+        TreeItem* tree_item = (TreeItem*)index.internalPointer();
+        if (tree_item) {
+            LibraryFeature* feature = tree_item->feature();
+            feature->selectAllChild(index);
+        }
+    }
+}
+
 QModelIndex SidebarModel::parent(const QModelIndex& index) const {
     //qDebug() << "SidebarModel::parent index=" << index.getData();
     if (index.isValid()) {
@@ -475,7 +535,7 @@ QModelIndex SidebarModel::translateIndex(
 }
 
 void SidebarModel::slotDataChanged(const QModelIndex& topLeft, const QModelIndex& bottomRight) {
-    //qDebug() << "slotDataChanged topLeft:" << topLeft << "bottomRight:" << bottomRight;
+    // qDebug() << "slotDataChanged topLeft:" << topLeft << "bottomRight:" << bottomRight;
     QModelIndex topLeftTranslated = translateSourceIndex(topLeft);
     QModelIndex bottomRightTranslated = translateSourceIndex(bottomRight);
     emit dataChanged(topLeftTranslated, bottomRightTranslated);
@@ -499,8 +559,8 @@ void SidebarModel::slotRowsInserted(const QModelIndex& parent, int start, int en
     Q_UNUSED(parent);
     Q_UNUSED(start);
     Q_UNUSED(end);
-    //qDebug() << "slotRowsInserted" << parent << start << end;
-    //QModelIndex newParent = translateSourceIndex(parent);
+    // qDebug() << "slotRowsInserted" << parent << start << end;
+    // QModelIndex newParent = translateSourceIndex(parent);
     endInsertRows();
 }
 

--- a/src/library/sidebarmodel.cpp
+++ b/src/library/sidebarmodel.cpp
@@ -151,36 +151,6 @@ QModelIndex SidebarModel::getFeatureRootIndex(LibraryFeature* pFeature) {
 void SidebarModel::clear(const QModelIndex& index) {
     if (index.internalPointer() == this) {
         m_sFeatures[index.row()]->clear();
-    } else {
-        TreeItem* pTreeItem = (TreeItem*)index.internalPointer();
-        if (pTreeItem) {
-            LibraryFeature* feature = pTreeItem->feature();
-            feature->clearChild(index);
-        }
-    }
-}
-
-void SidebarModel::cut(const QModelIndex& index) {
-    if (index.internalPointer() == this) {
-        m_sFeatures[index.row()]->cut();
-    } else {
-        TreeItem* pTreeItem = (TreeItem*)index.internalPointer();
-        if (pTreeItem) {
-            LibraryFeature* feature = pTreeItem->feature();
-            feature->cutChild(index);
-        }
-    }
-}
-
-void SidebarModel::copy(const QModelIndex& index) const {
-    if (index.internalPointer() == this) {
-        m_sFeatures[index.row()]->copy();
-    } else {
-        TreeItem* pTreeItem = (TreeItem*)index.internalPointer();
-        if (pTreeItem) {
-            LibraryFeature* feature = pTreeItem->feature();
-            feature->copyChild(index);
-        }
     }
 }
 
@@ -192,18 +162,6 @@ void SidebarModel::paste(const QModelIndex& index) {
         if (pTreeItem) {
             LibraryFeature* feature = pTreeItem->feature();
             feature->pasteChild(index);
-        }
-    }
-}
-
-void SidebarModel::selectAll(const QModelIndex& index) {
-    if (index.internalPointer() == this) {
-        m_sFeatures[index.row()]->selectAll();
-    } else {
-        TreeItem* pTreeItem = (TreeItem*)index.internalPointer();
-        if (pTreeItem) {
-            LibraryFeature* feature = pTreeItem->feature();
-            feature->selectAllChild(index);
         }
     }
 }

--- a/src/library/sidebarmodel.h
+++ b/src/library/sidebarmodel.h
@@ -47,6 +47,11 @@ class SidebarModel : public QAbstractItemModel {
     }
     QModelIndex getFeatureRootIndex(LibraryFeature* pFeature);
 
+    void clear(const QModelIndex& index);
+    void cut(const QModelIndex& index);
+    void copy(const QModelIndex& index) const;
+    void selectAll(const QModelIndex& index);
+    void paste(const QModelIndex& index);
   public slots:
     void pressed(const QModelIndex& index);
     void clicked(const QModelIndex& index);

--- a/src/library/sidebarmodel.h
+++ b/src/library/sidebarmodel.h
@@ -48,9 +48,6 @@ class SidebarModel : public QAbstractItemModel {
     QModelIndex getFeatureRootIndex(LibraryFeature* pFeature);
 
     void clear(const QModelIndex& index);
-    void cut(const QModelIndex& index);
-    void copy(const QModelIndex& index) const;
-    void selectAll(const QModelIndex& index);
     void paste(const QModelIndex& index);
   public slots:
     void pressed(const QModelIndex& index);

--- a/src/library/trackmodel.h
+++ b/src/library/trackmodel.h
@@ -154,6 +154,14 @@ class TrackModel {
         Q_UNUSED(locations);
         return 0;
     }
+    virtual int addTracksWithTrackIds(const QModelIndex& index,
+            const QList<TrackId>& tracks,
+            int* pOutInsertionPos) {
+        Q_UNUSED(index);
+        Q_UNUSED(tracks);
+        Q_UNUSED(pOutInsertionPos);
+        return 0;
+    }
     virtual void moveTrack(const QModelIndex& sourceIndex,
                            const QModelIndex& destIndex) {
         Q_UNUSED(sourceIndex);

--- a/src/library/trackmodel.h
+++ b/src/library/trackmodel.h
@@ -140,6 +140,16 @@ class TrackModel {
     virtual void removeTracks(const QModelIndexList& indices) {
         Q_UNUSED(indices);
     }
+    virtual void cutTracks(const QModelIndexList& indices) {
+        Q_UNUSED(indices);
+    }
+    virtual void copyTracks(const QModelIndexList& indices) const {
+        Q_UNUSED(indices);
+    }
+    virtual QList<int> pasteTracks(const QModelIndex& index) {
+        Q_UNUSED(index);
+        return QList<int>();
+    }
     virtual void hideTracks(const QModelIndexList& indices) {
         Q_UNUSED(indices);
     }

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -165,7 +165,7 @@ void BasePlaylistFeature::connectPlaylistDAO() {
             &BasePlaylistFeature::slotPlaylistTableRenamed);
 }
 
-int BasePlaylistFeature::playlistIdFromIndex(const QModelIndex& index) {
+int BasePlaylistFeature::playlistIdFromIndex(const QModelIndex& index) const {
     TreeItem* item = static_cast<TreeItem*>(index.internalPointer());
     if (item == nullptr) {
         return kInvalidPlaylistId;

--- a/src/library/trackset/baseplaylistfeature.h
+++ b/src/library/trackset/baseplaylistfeature.h
@@ -86,7 +86,7 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
     virtual void decorateChild(TreeItem* pChild, int playlistId) = 0;
     virtual void addToAutoDJ(PlaylistDAO::AutoDJSendLoc loc);
 
-    int playlistIdFromIndex(const QModelIndex& index);
+    int playlistIdFromIndex(const QModelIndex& index) const;
     // Get the QModelIndex of a playlist based on its id.  Returns QModelIndex()
     // on failure.
     QModelIndex indexFromPlaylistId(int playlistId);

--- a/src/library/trackset/basetracksetfeature.cpp
+++ b/src/library/trackset/basetracksetfeature.cpp
@@ -13,6 +13,11 @@ BaseTrackSetFeature::BaseTrackSetFeature(
           m_pSidebarModel(make_parented<TreeItemModel>(this)) {
 }
 
+void BaseTrackSetFeature::pasteChild(
+        const QModelIndex&) {
+    emit pasteFromSidebar();
+}
+
 void BaseTrackSetFeature::activate() {
     emit switchToView(m_rootViewName);
     emit disableSearch();

--- a/src/library/trackset/basetracksetfeature.cpp
+++ b/src/library/trackset/basetracksetfeature.cpp
@@ -13,8 +13,7 @@ BaseTrackSetFeature::BaseTrackSetFeature(
           m_pSidebarModel(make_parented<TreeItemModel>(this)) {
 }
 
-void BaseTrackSetFeature::pasteChild(
-        const QModelIndex&) {
+void BaseTrackSetFeature::pasteChild(const QModelIndex&) {
     emit pasteFromSidebar();
 }
 

--- a/src/library/trackset/basetracksetfeature.h
+++ b/src/library/trackset/basetracksetfeature.h
@@ -14,6 +14,7 @@ class BaseTrackSetFeature : public LibraryFeature {
             const QString& rootViewName,
             const QString& iconName);
 
+    void pasteChild(const QModelIndex& index) override;
   signals:
     void analyzeTracks(const QList<AnalyzerScheduledTrack>&);
 

--- a/src/library/trackset/crate/cratetablemodel.cpp
+++ b/src/library/trackset/crate/cratetablemodel.cpp
@@ -173,6 +173,17 @@ int CrateTableModel::addTracksWithTrackIds(
     return trackIds.size();
 }
 
+bool CrateTableModel::isLocked() {
+    Crate crate;
+    if (!m_pTrackCollectionManager->internalCollection()
+                    ->crates()
+                    .readCrateById(m_selectedCrate, &crate)) {
+        qWarning() << "Failed to read create" << m_selectedCrate;
+        return false;
+    }
+    return crate.isLocked();
+}
+
 void CrateTableModel::removeTracks(const QModelIndexList& indices) {
     VERIFY_OR_DEBUG_ASSERT(m_selectedCrate.isValid()) {
         return;

--- a/src/library/trackset/crate/cratetablemodel.cpp
+++ b/src/library/trackset/crate/cratetablemodel.cpp
@@ -150,17 +150,22 @@ TrackModel::Capabilities CrateTableModel::getCapabilities() const {
     return caps;
 }
 
-int CrateTableModel::addTracks(
-        const QModelIndex& index, const QList<QString>& locations) {
+int CrateTableModel::addTracksWithTrackIds(
+        const QModelIndex& index, const QList<TrackId>& trackIds, int* pOutInsertionPos) {
     Q_UNUSED(index);
+
+    if (!pOutInsertionPos) {
+        // crate insertion is not done by position, and no duplicates will be added,.
+        // 0 indicates this to the caller.
+        *pOutInsertionPos = 0;
+    }
+
     // If a track is dropped but it isn't in the library, then add it because
     // the user probably dropped a file from outside Mixxx into this crate.
-    QList<TrackId> trackIds =
-            m_pTrackCollectionManager->resolveTrackIdsFromLocations(locations);
     if (!m_pTrackCollectionManager->internalCollection()->addCrateTracks(
                 m_selectedCrate, trackIds)) {
         qWarning() << "CrateTableModel::addTracks could not add"
-                   << locations.size() << "tracks to crate" << m_selectedCrate;
+                   << trackIds.size() << "tracks to crate" << m_selectedCrate;
         return 0;
     }
 

--- a/src/library/trackset/crate/cratetablemodel.cpp
+++ b/src/library/trackset/crate/cratetablemodel.cpp
@@ -154,7 +154,7 @@ int CrateTableModel::addTracksWithTrackIds(
         const QModelIndex& index, const QList<TrackId>& trackIds, int* pOutInsertionPos) {
     Q_UNUSED(index);
 
-    if (!pOutInsertionPos) {
+    if (pOutInsertionPos != nullptr) {
         // crate insertion is not done by position, and no duplicates will be added,.
         // 0 indicates this to the caller.
         *pOutInsertionPos = 0;

--- a/src/library/trackset/crate/cratetablemodel.h
+++ b/src/library/trackset/crate/cratetablemodel.h
@@ -22,6 +22,7 @@ class CrateTableModel final : public TrackSetTableModel {
     int addTracksWithTrackIds(const QModelIndex& index,
             const QList<TrackId>& tracks,
             int* pOutInsertionPos) final;
+    bool isLocked() final;
 
     Capabilities getCapabilities() const final;
     QString modelKey(bool noSearch) const override;

--- a/src/library/trackset/crate/cratetablemodel.h
+++ b/src/library/trackset/crate/cratetablemodel.h
@@ -19,7 +19,9 @@ class CrateTableModel final : public TrackSetTableModel {
 
     void removeTracks(const QModelIndexList& indices) final;
     /// Returns the number of unsuccessful additions.
-    int addTracks(const QModelIndex& index, const QList<QString>& locations) final;
+    int addTracksWithTrackIds(const QModelIndex& index,
+            const QList<TrackId>& tracks,
+            int* pOutInsertionPos) final;
 
     Capabilities getCapabilities() const final;
     QString modelKey(bool noSearch) const override;

--- a/src/library/trackset/tracksettablemodel.cpp
+++ b/src/library/trackset/tracksettablemodel.cpp
@@ -26,3 +26,15 @@ bool TrackSetTableModel::isColumnInternal(int column) {
             column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COVERART_DIGEST) ||
             column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_COVERART_HASH);
 }
+
+int TrackSetTableModel::addTracks(const QModelIndex& index,
+        const QList<QString>& locations) {
+    if (locations.isEmpty()) {
+        return 0;
+    }
+
+    QList<TrackId> trackIds = m_pTrackCollectionManager->resolveTrackIdsFromLocations(
+            locations);
+
+    return addTracksWithTrackIds(index, trackIds, nullptr);
+}

--- a/src/library/trackset/tracksettablemodel.cpp
+++ b/src/library/trackset/tracksettablemodel.cpp
@@ -1,5 +1,6 @@
 #include "library/trackset/tracksettablemodel.h"
 
+#include "library/trackcollectionmanager.h"
 #include "mixer/playermanager.h"
 #include "moc_tracksettablemodel.cpp"
 

--- a/src/library/trackset/tracksettablemodel.h
+++ b/src/library/trackset/tracksettablemodel.h
@@ -11,4 +11,6 @@ class TrackSetTableModel : public BaseSqlTableModel {
             const char* settingsNamespace);
 
     bool isColumnInternal(int column) override;
+
+    int addTracks(const QModelIndex& index, const QList<QString>& locations) final;
 };

--- a/src/util/clipboard.cpp
+++ b/src/util/clipboard.cpp
@@ -9,7 +9,8 @@ namespace {
 QByteArray urlsToUtf8(const QList<QUrl>& urls) {
     QByteArray result;
     for (const QUrl& url : urls) {
-        result += url.toEncoded() + '\n';
+        result += url.toEncoded();
+        result += '\n';
     }
     if (!result.isEmpty()) {
         result.chop(1);
@@ -28,12 +29,13 @@ void Clipboard::add(const QUrl& url) {
 }
 
 void Clipboard::finish() {
-    QMimeData* data = new QMimeData;
-    data->setUrls(instance()->m_urls);
+    QMimeData* pData = new QMimeData;
+    pData->setUrls(instance()->m_urls);
     // "x-special/gnome-copied-files" is used for many file managers
     // https://indigo.re/posts/2021-12-21-clipboard-data.html
-    data->setData("x-special/gnome-copied-files", "copy\n" + urlsToUtf8(instance()->m_urls));
-    QApplication::clipboard()->setMimeData(data);
+    pData->setData(QStringLiteral("x-special/gnome-copied-files"),
+            "copy\n" + urlsToUtf8(instance()->m_urls));
+    QApplication::clipboard()->setMimeData(pData);
 }
 
 QList<QUrl> Clipboard::urls() {

--- a/src/util/clipboard.cpp
+++ b/src/util/clipboard.cpp
@@ -11,8 +11,9 @@ QByteArray urlsToUtf8(const QList<QUrl>& urls) {
     for (const QUrl& url : urls) {
         result += url.toEncoded() + '\n';
     }
-    if (!result.isEmpty())
+    if (!result.isEmpty()) {
         result.chop(1);
+    }
     return result;
 }
 

--- a/src/util/clipboard.cpp
+++ b/src/util/clipboard.cpp
@@ -1,0 +1,24 @@
+#include "clipboard.h"
+
+#include <QApplication>
+#include <QClipboard>
+#include <QMimeData>
+
+void Clipboard::start() {
+    instance()->m_urls.clear();
+}
+
+void Clipboard::add(const QUrl& url) {
+    instance()->m_urls.append(url);
+}
+
+void Clipboard::finish() {
+    QMimeData* data = new QMimeData;
+    data->setUrls(instance()->m_urls);
+    QApplication::clipboard()->setMimeData(data);
+}
+
+QList<QUrl> Clipboard::urls() {
+    const QMimeData* data = QApplication::clipboard()->mimeData();
+    return data ? data->urls() : QList<QUrl>();
+}

--- a/src/util/clipboard.cpp
+++ b/src/util/clipboard.cpp
@@ -4,6 +4,20 @@
 #include <QClipboard>
 #include <QMimeData>
 
+namespace {
+
+QByteArray urlsToUtf8(const QList<QUrl>& urls) {
+    QByteArray result;
+    for (const QUrl& url : urls) {
+        result += url.toEncoded() + '\n';
+    }
+    if (!result.isEmpty())
+        result.chop(1);
+    return result;
+}
+
+} // namespace
+
 void Clipboard::start() {
     instance()->m_urls.clear();
 }
@@ -15,6 +29,9 @@ void Clipboard::add(const QUrl& url) {
 void Clipboard::finish() {
     QMimeData* data = new QMimeData;
     data->setUrls(instance()->m_urls);
+    // "x-special/gnome-copied-files" is used for many file managers
+    // https://indigo.re/posts/2021-12-21-clipboard-data.html
+    data->setData("x-special/gnome-copied-files", "copy\n" + urlsToUtf8(instance()->m_urls));
     QApplication::clipboard()->setMimeData(data);
 }
 

--- a/src/util/clipboard.h
+++ b/src/util/clipboard.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <QList>
+#include <QUrl>
+
+#include "util/singleton.h"
+
+class Clipboard : public Singleton<Clipboard> {
+    QList<QUrl> m_urls;
+
+  public:
+    static QList<QUrl> urls();
+    static void start();
+    static void finish();
+    static void add(const QUrl& url);
+};

--- a/src/widget/wlibrary.cpp
+++ b/src/widget/wlibrary.cpp
@@ -76,6 +76,14 @@ void WLibrary::switchToView(const QString& name) {
     }
 }
 
+void WLibrary::pasteFromSidebar() {
+    QWidget* current = currentWidget();
+    LibraryView* view = dynamic_cast<LibraryView*>(current);
+    if (view) {
+        view->pasteFromSidebar();
+    }
+}
+
 void WLibrary::search(const QString& name) {
     auto lock = lockMutex(&m_mutex);
     QWidget* current = currentWidget();
@@ -141,4 +149,11 @@ bool WLibrary::event(QEvent* pEvent) {
         updateTooltip();
     }
     return QStackedWidget::event(pEvent);
+}
+
+void WLibrary::keyPressEvent(QKeyEvent* event) {
+    if (event->key() == Qt::Key_Left && event->modifiers() & Qt::ControlModifier) {
+        emit setLibraryFocus(FocusWidget::Sidebar);
+    }
+    QStackedWidget::keyPressEvent(event);
 }

--- a/src/widget/wlibrary.cpp
+++ b/src/widget/wlibrary.cpp
@@ -1,5 +1,6 @@
 #include "widget/wlibrary.h"
 
+#include <QKeyEvent>
 #include <QtDebug>
 
 #include "library/libraryview.h"
@@ -31,20 +32,20 @@ void WLibrary::setup(const QDomNode& node, const SkinContext& context) {
             kMaxTrackTableBackgroundColorOpacity);
 }
 
-bool WLibrary::registerView(const QString& name, QWidget* view) {
+bool WLibrary::registerView(const QString& name, QWidget* pView) {
     //qDebug() << "WLibrary::registerView" << name;
     const auto lock = lockMutex(&m_mutex);
     if (m_viewMap.contains(name)) {
         return false;
     }
-    if (dynamic_cast<LibraryView*>(view) == nullptr) {
+    if (dynamic_cast<LibraryView*>(pView) == nullptr) {
         qDebug() << "WARNING: Attempted to register view" << name << "with WLibrary "
                  << "which does not implement the LibraryView interface. "
                  << "Ignoring.";
         return false;
     }
-    addWidget(view);
-    m_viewMap[name] = view;
+    addWidget(pView);
+    m_viewMap[name] = pView;
     return true;
 }
 
@@ -52,49 +53,49 @@ void WLibrary::switchToView(const QString& name) {
     const auto lock = lockMutex(&m_mutex);
     //qDebug() << "WLibrary::switchToView" << name;
 
-    LibraryView* oldLibraryView = dynamic_cast<LibraryView*>(
+    LibraryView* pOldLibrartView = dynamic_cast<LibraryView*>(
             currentWidget());
 
-    QWidget* widget = m_viewMap.value(name, nullptr);
-    if (widget != nullptr) {
-        LibraryView * lview = dynamic_cast<LibraryView*>(widget);
-        if (lview == nullptr) {
+    QWidget* pWidget = m_viewMap.value(name, nullptr);
+    if (pWidget != nullptr) {
+        LibraryView* pLibraryView = dynamic_cast<LibraryView*>(pWidget);
+        if (pLibraryView == nullptr) {
             qDebug() << "WARNING: Attempted to switch to view" << name << "with WLibrary "
                      << "which does not implement the LibraryView interface. "
                      << "Ignoring.";
             return;
         }
-        if (currentWidget() != widget) {
-            if (oldLibraryView) {
-                oldLibraryView->saveCurrentViewState();
+        if (currentWidget() != pWidget) {
+            if (pOldLibrartView) {
+                pOldLibrartView->saveCurrentViewState();
             }
             //qDebug() << "WLibrary::setCurrentWidget" << name;
-            setCurrentWidget(widget);
-            lview->onShow();
-            lview->restoreCurrentViewState();
+            setCurrentWidget(pWidget);
+            pLibraryView->onShow();
+            pLibraryView->restoreCurrentViewState();
         }
     }
 }
 
 void WLibrary::pasteFromSidebar() {
-    QWidget* current = currentWidget();
-    LibraryView* view = dynamic_cast<LibraryView*>(current);
-    if (view) {
-        view->pasteFromSidebar();
+    QWidget* pCurrent = currentWidget();
+    LibraryView* pView = dynamic_cast<LibraryView*>(pCurrent);
+    if (pView) {
+        pView->pasteFromSidebar();
     }
 }
 
 void WLibrary::search(const QString& name) {
     auto lock = lockMutex(&m_mutex);
-    QWidget* current = currentWidget();
-    LibraryView* view = dynamic_cast<LibraryView*>(current);
-    if (view == nullptr) {
+    QWidget* pCurrent = currentWidget();
+    LibraryView* pView = dynamic_cast<LibraryView*>(pCurrent);
+    if (pView == nullptr) {
         qDebug() << "WARNING: Attempted to search in view" << name << "with WLibrary "
                  << "which does not implement the LibraryView interface. Ignoring.";
         return;
     }
     lock.unlock();
-    view->onSearch(name);
+    pView->onSearch(name);
 }
 
 LibraryView* WLibrary::getActiveView() const {
@@ -106,17 +107,17 @@ bool WLibrary::isTrackInCurrentView(const TrackId& trackId) {
     VERIFY_OR_DEBUG_ASSERT(trackId.isValid()) {
         return false;
     }
-    QWidget* current = currentWidget();
-    WTrackTableView* tracksView = qobject_cast<WTrackTableView*>(current);
-    if (!tracksView) {
+    QWidget* pCurrent = currentWidget();
+    WTrackTableView* pTracksView = qobject_cast<WTrackTableView*>(pCurrent);
+    if (!pTracksView) {
         // This view is no tracks view, but maybe a special tracks view with a
         // controls row (AutoDJ, Recording)?
         //qDebug() << "   view is no tracks view. look for tracks view child";
-        tracksView = current->findChild<WTrackTableView*>();
+        pTracksView = pCurrent->findChild<WTrackTableView*>();
     }
-    if (tracksView) {
+    if (pTracksView) {
         //qDebug() << "   tracks view found";
-        return tracksView->isTrackInCurrentView(trackId);
+        return pTracksView->isTrackInCurrentView(trackId);
     } else {
         // No tracks view, this is probably a root view WLibraryTextBrowser
         //qDebug() << "   no tracks view found";
@@ -130,15 +131,15 @@ void WLibrary::slotSelectTrackInActiveTrackView(const TrackId& trackId) {
         return;
     }
 
-    QWidget* current = currentWidget();
-    WTrackTableView* tracksView = qobject_cast<WTrackTableView*>(current);
-    if (!tracksView) {
+    QWidget* pCurrent = currentWidget();
+    WTrackTableView* pTracksView = qobject_cast<WTrackTableView*>(pCurrent);
+    if (!pTracksView) {
         //qDebug() << "   view is no tracks view. look for tracks view child";
-        tracksView = current->findChild<WTrackTableView*>();
+        pTracksView = pCurrent->findChild<WTrackTableView*>();
     }
-    if (tracksView) {
+    if (pTracksView) {
         //qDebug() << "   tracks view found";
-        tracksView->slotSelectTrack(trackId);
+        pTracksView->slotSelectTrack(trackId);
     } else {
         //qDebug() << "   no tracks view found";
     }
@@ -151,9 +152,9 @@ bool WLibrary::event(QEvent* pEvent) {
     return QStackedWidget::event(pEvent);
 }
 
-void WLibrary::keyPressEvent(QKeyEvent* event) {
-    if (event->key() == Qt::Key_Left && event->modifiers() & Qt::ControlModifier) {
+void WLibrary::keyPressEvent(QKeyEvent* pEvent) {
+    if (pEvent->key() == Qt::Key_Left && pEvent->modifiers() & Qt::ControlModifier) {
         emit setLibraryFocus(FocusWidget::Sidebar);
     }
-    QStackedWidget::keyPressEvent(event);
+    QStackedWidget::keyPressEvent(pEvent);
 }

--- a/src/widget/wlibrary.h
+++ b/src/widget/wlibrary.h
@@ -4,6 +4,9 @@
 #include <QStackedWidget>
 #include <QString>
 
+#include "library/library_decl.h"
+#include "library/libraryview.h"
+#include "skin/legacy/skincontext.h"
 #include "util/compatibility/qmutex.h"
 #include "widget/wbasewidget.h"
 
@@ -48,17 +51,22 @@ class WLibrary : public QStackedWidget, public WBaseWidget {
         return m_bShowButtonText;
     }
 
+  signals:
+    FocusWidget setLibraryFocus(FocusWidget newFocus);
+
   public slots:
     // Show the view registered with the given name. Does nothing if the current
     // view is the specified view, or if the name does not specify any
     // registered view.
     void switchToView(const QString& name);
     void slotSelectTrackInActiveTrackView(const TrackId& trackId);
+    void pasteFromSidebar();
 
     void search(const QString&);
 
   protected:
     bool event(QEvent* pEvent) override;
+    void keyPressEvent(QKeyEvent* event) override;
 
   private:
     QT_RECURSIVE_MUTEX m_mutex;

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -247,20 +247,8 @@ void WLibrarySidebar::keyPressEvent(QKeyEvent* event) {
             sidebarModel->clear(index);
             return;
         }
-        if (event->matches(QKeySequence::Cut)) {
-            sidebarModel->cut(index);
-            return;
-        }
-        if (event->matches(QKeySequence::Copy)) {
-            sidebarModel->copy(index);
-            return;
-        }
         if (event->matches(QKeySequence::Paste)) {
             sidebarModel->paste(index);
-            return;
-        }
-        if (event->matches(QKeySequence::SelectAll)) {
-            sidebarModel->selectAll(index);
             return;
         }
     }

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -239,12 +239,36 @@ void WLibrarySidebar::keyPressEvent(QKeyEvent* event) {
     // TODO(XXX) Should first keyEvent ensure previous item has focus? I.e. if the selected
     // item is not focused, require second press to perform the desired action.
 
-    // make the selected item the navigation starting point
+    SidebarModel* sidebarModel = qobject_cast<SidebarModel*>(model());
+    QModelIndexList selectedIndices = selectionModel()->selectedRows();
+    if (sidebarModel && !selectedIndices.isEmpty()) {
+        QModelIndex index = selectedIndices.at(0);
+        if (event->matches(QKeySequence::Delete) || event->key() == Qt::Key_Backspace) {
+            sidebarModel->clear(index);
+            return;
+        }
+        if (event->matches(QKeySequence::Cut)) {
+            sidebarModel->cut(index);
+            return;
+        }
+        if (event->matches(QKeySequence::Copy)) {
+            sidebarModel->copy(index);
+            return;
+        }
+        if (event->matches(QKeySequence::Paste)) {
+            sidebarModel->paste(index);
+            return;
+        }
+        if (event->matches(QKeySequence::SelectAll)) {
+            sidebarModel->selectAll(index);
+            return;
+        }
+    }
+
     focusSelectedIndex();
 
     switch (event->key()) {
     case Qt::Key_Return:
-        focusSelectedIndex();
         toggleSelectedItem();
         return;
     case Qt::Key_Down:
@@ -266,6 +290,14 @@ void WLibrarySidebar::keyPressEvent(QKeyEvent* event) {
         // we pressed Up, Home or PageUp.
         scrollTo(selIndex);
         emit pressed(selIndex);
+        return;
+    }
+    case Qt::Key_Right: {
+        if (event->modifiers() & Qt::ControlModifier) {
+            emit setLibraryFocus(FocusWidget::TracksTable);
+        } else {
+            QTreeView::keyPressEvent(event);
+        }
         return;
     }
     case Qt::Key_Left: {

--- a/src/widget/wlibrarytableview.cpp
+++ b/src/widget/wlibrarytableview.cpp
@@ -386,6 +386,14 @@ QModelIndex WLibraryTableView::moveCursor(CursorAction cursorAction,
                 return pModel->index(pModel->rowCount() - 1, column);
             }
         } break;
+        case QAbstractItemView::MoveLeft:
+        case QAbstractItemView::MoveRight:
+            if (modifiers & Qt::ControlModifier) {
+                // Ignore, so it can be handled by WLibrary::keyEvent
+                // to navigate to the sidebar
+                return currentIndex();
+            }
+            break;
         default:
             break;
         }

--- a/src/widget/wlibrarytableview.h
+++ b/src/widget/wlibrarytableview.h
@@ -4,6 +4,7 @@
 #include <QString>
 #include <QTableView>
 
+#include "library/library_decl.h"
 #include "library/libraryview.h"
 #include "preferences/usersettings.h"
 #include "track/track_decl.h"
@@ -61,6 +62,7 @@ class WLibraryTableView : public QTableView, public virtual LibraryView {
     void trackSelected(TrackPointer pTrack);
     void onlyCachedCoverArt(bool);
     void scrollValueChanged(int);
+    FocusWidget setLibraryFocus(FocusWidget newFocus);
 
   public slots:
     void setTrackTableFont(const QFont& font);

--- a/src/widget/wlibrarytextbrowser.cpp
+++ b/src/widget/wlibrarytextbrowser.cpp
@@ -1,5 +1,7 @@
 #include "widget/wlibrarytextbrowser.h"
 
+#include <QKeyEvent>
+
 #include "moc_wlibrarytextbrowser.cpp"
 
 WLibraryTextBrowser::WLibraryTextBrowser(QWidget* parent)
@@ -12,4 +14,12 @@ bool WLibraryTextBrowser::hasFocus() const {
 
 void WLibraryTextBrowser::setFocus() {
     QWidget::setFocus();
+}
+
+void WLibraryTextBrowser::keyPressEvent(QKeyEvent* event) {
+    if (event->key() == Qt::Key_Left && event->modifiers() & Qt::ControlModifier) {
+        event->ignore();
+        return;
+    }
+    QTextBrowser::keyPressEvent(event);
 }

--- a/src/widget/wlibrarytextbrowser.h
+++ b/src/widget/wlibrarytextbrowser.h
@@ -2,6 +2,7 @@
 
 #include <QTextBrowser>
 
+#include "library/library_decl.h"
 #include "library/libraryview.h"
 
 class WLibraryTextBrowser : public QTextBrowser, public LibraryView {
@@ -11,4 +12,7 @@ class WLibraryTextBrowser : public QTextBrowser, public LibraryView {
     void onShow() override {}
     bool hasFocus() const override;
     void setFocus() override;
+    void keyPressEvent(QKeyEvent* event) override;
+  signals:
+    FocusWidget setLibraryFocus(FocusWidget newFocus);
 };

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -861,7 +861,12 @@ void WTrackTableView::copySelectedTracks() {
 }
 
 void WTrackTableView::pasteTracks(const QModelIndex& index) {
-    const QList<int> rows = getTrackModel()->pasteTracks(index);
+    TrackModel* trackModel = getTrackModel();
+    if (!trackModel) {
+        return;
+    }
+
+    const QList<int> rows = trackModel->pasteTracks(index);
     if (rows.empty()) {
         return;
     }

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -996,9 +996,13 @@ void WTrackTableView::hideOrRemoveSelectedTracks() {
     }
 
     TrackModel::Capability cap;
+    // Hide is the primary action if allowed. Else we test for remove capability
     if (pTrackModel->hasCapabilities(TrackModel::Capability::Hide)) {
         cap = TrackModel::Capability::Hide;
-    } else if (pTrackModel->hasCapabilities(TrackModel::Capability::Remove)) {
+    } else if (pTrackModel->isLocked()) { // Locked playlists and crates
+        return;
+    }
+    if (pTrackModel->hasCapabilities(TrackModel::Capability::Remove)) {
         cap = TrackModel::Capability::Remove;
     } else if (pTrackModel->hasCapabilities(TrackModel::Capability::RemoveCrate)) {
         cap = TrackModel::Capability::RemoveCrate;

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -865,10 +865,6 @@ void WTrackTableView::pasteTracks(const QModelIndex& index) {
     if (rows.empty()) {
         return;
     }
-    for (const auto row : rows) {
-        selectionModel()->select(model()->index(row, 0),
-                QItemSelectionModel::Select | QItemSelectionModel::Rows);
-    }
 
     updateGeometries();
 
@@ -881,6 +877,12 @@ void WTrackTableView::pasteTracks(const QModelIndex& index) {
         selectRow(rows.back());
     } else {
         selectRow(rows.front());
+    }
+
+    // Select all the rows that we pasted
+    for (const auto row : rows) {
+        selectionModel()->select(model()->index(row, 0),
+                QItemSelectionModel::Select | QItemSelectionModel::Rows);
     }
 }
 

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -133,6 +133,9 @@ class WTrackTableView : public WLibraryTableView {
     // when dragging.
     void mouseMoveEvent(QMouseEvent *pEvent) override;
 
+    // Returns the list of selected rows, or an empty list if none are selected.
+    QModelIndexList getSelectedRows() const;
+
     // Returns the current TrackModel, or returns NULL if none is set.
     TrackModel* getTrackModel() const;
 

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -34,6 +34,7 @@ class WTrackTableView : public WLibraryTableView {
     void onShow() override;
     bool hasFocus() const override;
     void setFocus() override;
+    void pasteFromSidebar() override;
     void keyPressEvent(QKeyEvent* event) override;
     void resizeEvent(QResizeEvent* event) override;
     void activateSelectedTrack() override;
@@ -46,6 +47,12 @@ class WTrackTableView : public WLibraryTableView {
     void setSelectedTracks(const QList<TrackId>& tracks);
     TrackId getCurrentTrackId() const;
     bool setCurrentTrackId(const TrackId& trackId, int column = 0, bool scrollToTrack = false);
+
+    void removeSelectedTracks();
+    void cutSelectedTracks();
+    void copySelectedTracks();
+    void pasteTracks(const QModelIndex& index);
+    void selectTracksById(const QList<TrackId>& tracks, int prevColumn);
 
     double getBackgroundColorOpacity() const {
         return m_backgroundColorOpacity;


### PR DESCRIPTION
This PR implements shortkeys for track list management (between library, playlists, crates and autodj)

Ctrl-X
- with focus on tracklist: remove selected tracks from tracklist and place them on the clipboard

Ctrl-C
- with focus on tracklist: copy selected tracks from tracklist to the clipboard

Ctrl-V 
- paste tracks from the clipboard to the current tracklist
  - with focus on tracklist: 
    - in playlists and autodj cue: inserting them at the current index position (the last selected row) or appending at the bottom when no track is selected
    - in crates: inserting them according to the current sorting
  - with focus on the sidebar
    - appending at the bottom of the track list selected in the sidebar

Shift-Up/Down
- Select multiple tracks

Delete/Backspace
- with focus on tracklist: remove selected tracks from tracklist but without placing them on the clipboard

Ctrl+A
- with focus on tracklist: select all tracks

Escape
- with focus on tracklist: clear the selection

Ctrl-Left
- move focus to the sidebar (similar to using tab, but without going through the search bar)
 
Ctrl-Right
- move focus to the track list (similar to using tab, but without going through the search bar)

Please keep the discussion here focussed on implementation, and discuss the actual UI interaction at https://mixxx.zulipchat.com/#narrow/stream/247619-UI-.26-UX-design/topic/short-keys.20for.20tracklist.20management.20RFC 

(Note, this replaces an earlier PR)