### PR TITLE
CO Renaming (Pt. 5): Latency Control

### DIFF
--- a/res/controllers/Akai-LPD8-RK-scripts.js
+++ b/res/controllers/Akai-LPD8-RK-scripts.js
@@ -493,7 +493,7 @@ LPD8RK.beatjump = function (channel, control, value, status, group) {
     var numbeats = LPD8RK.beatjumpstep;
     var backseconds = numbeats*(1/(engine.getValue(group, "bpm")/60));
     var backsamples = backseconds*engine.getValue(group, "track_samples")/engine.getValue(group, "duration");
-    var newpos = curpos-(backsamples+engine.getValue("Master", "latency"));
+    var newpos = curpos-(backsamples+engine.getValue("[App]", "output_latency_ms"));
 
     if (LPD8RK.debug){print("backseconds: "+backseconds);}
     if (LPD8RK.debug){print("backsamples: "+backsamples);}

--- a/src/engine/enginemixer.cpp
+++ b/src/engine/enginemixer.cpp
@@ -80,9 +80,10 @@ EngineMixer::EngineMixer(
     m_pMainSampleRate->set(44100.);
 
     // Latency control
-    m_pMainLatency = new ControlObject(ConfigKey(group, "latency"),
+    m_pMainLatency = new ControlObject(ConfigKey(kAppGroup, QStringLiteral("output_latency_ms")),
             true,
             true); // reported latency (sometimes correct)
+    m_pMainLatency->addAlias(ConfigKey(kLegacyGroup, QStringLiteral("latency")));
     m_pAudioLatencyOverloadCount = new ControlObject(
             ConfigKey(kAppGroup, QStringLiteral("audio_latency_overload_count")));
     m_pAudioLatencyOverloadCount->addAlias(ConfigKey(

--- a/src/engine/enginemixer.cpp
+++ b/src/engine/enginemixer.cpp
@@ -74,16 +74,17 @@ EngineMixer::EngineMixer(
     m_pWorkerScheduler->start(QThread::HighPriority);
 
     // Main sample rate
-    m_pMainSampleRate = new ControlObject(
+    m_pSampleRate = new ControlObject(
             ConfigKey(kAppGroup, QStringLiteral("samplerate")), true, true);
-    m_pMainSampleRate->addAlias(ConfigKey(group, QStringLiteral("samplerate")));
-    m_pMainSampleRate->set(44100.);
+    m_pSampleRate->addAlias(ConfigKey(group, QStringLiteral("samplerate")));
+    m_pSampleRate->set(44100.);
 
     // Latency control
-    m_pMainLatency = new ControlObject(ConfigKey(kAppGroup, QStringLiteral("output_latency_ms")),
+    m_pOutputLatencyMs = new ControlObject(
+            ConfigKey(kAppGroup, QStringLiteral("output_latency_ms")),
             true,
             true); // reported latency (sometimes correct)
-    m_pMainLatency->addAlias(ConfigKey(kLegacyGroup, QStringLiteral("latency")));
+    m_pOutputLatencyMs->addAlias(ConfigKey(kLegacyGroup, QStringLiteral("latency")));
     m_pAudioLatencyOverloadCount = new ControlObject(
             ConfigKey(kAppGroup, QStringLiteral("audio_latency_overload_count")));
     m_pAudioLatencyOverloadCount->addAlias(ConfigKey(
@@ -236,8 +237,8 @@ EngineMixer::~EngineMixer() {
     delete m_pXFaderMode;
 
     delete m_pEngineSync;
-    delete m_pMainSampleRate;
-    delete m_pMainLatency;
+    delete m_pSampleRate;
+    delete m_pOutputLatencyMs;
     delete m_pAudioLatencyOverloadCount;
     delete m_pAudioLatencyUsage;
     delete m_pAudioLatencyOverload;
@@ -418,7 +419,7 @@ void EngineMixer::process(const int iBufferSize) {
     bool boothEnabled = m_pBoothEnabled->toBool();
     bool headphoneEnabled = m_pHeadphoneEnabled->toBool();
 
-    m_sampleRate = mixxx::audio::SampleRate::fromDouble(m_pMainSampleRate->get());
+    m_sampleRate = mixxx::audio::SampleRate::fromDouble(m_pSampleRate->get());
     // TODO: remove assumption of stereo buffer
     constexpr unsigned int kChannels = 2;
     const unsigned int iFrames = iBufferSize / kChannels;

--- a/src/engine/enginemixer.h
+++ b/src/engine/enginemixer.h
@@ -303,8 +303,8 @@ class EngineMixer : public QObject, public AudioSource {
     ControlObject* m_pMainGain;
     ControlObject* m_pBoothGain;
     ControlObject* m_pHeadGain;
-    ControlObject* m_pMainSampleRate;
-    ControlObject* m_pMainLatency;
+    ControlObject* m_pSampleRate;
+    ControlObject* m_pOutputLatencyMs;
     ControlObject* m_pAudioLatencyOverloadCount;
     ControlObject* m_pAudioLatencyUsage;
     ControlObject* m_pAudioLatencyOverload;

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -207,7 +207,7 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
             new ControlProxy(kAppGroup, QStringLiteral("audio_latency_overload_count"), this);
     m_pAudioLatencyOverloadCount->connectValueChanged(this, &DlgPrefSound::bufferUnderflow);
 
-    m_pMainLatency = new ControlProxy("[Master]", "latency", this);
+    m_pMainLatency = new ControlProxy(kAppGroup, QStringLiteral("output_latency_ms"), this);
     m_pMainLatency->connectValueChanged(this, &DlgPrefSound::mainLatencyChanged);
 
     // TODO: remove this option by automatically disabling/enabling the main mix

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -207,8 +207,8 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
             new ControlProxy(kAppGroup, QStringLiteral("audio_latency_overload_count"), this);
     m_pAudioLatencyOverloadCount->connectValueChanged(this, &DlgPrefSound::bufferUnderflow);
 
-    m_pMainLatency = new ControlProxy(kAppGroup, QStringLiteral("output_latency_ms"), this);
-    m_pMainLatency->connectValueChanged(this, &DlgPrefSound::mainLatencyChanged);
+    m_pOutputLatencyMs = new ControlProxy(kAppGroup, QStringLiteral("output_latency_ms"), this);
+    m_pOutputLatencyMs->connectValueChanged(this, &DlgPrefSound::outputLatencyChanged);
 
     // TODO: remove this option by automatically disabling/enabling the main mix
     // when recording, broadcasting, headphone, and main outputs are enabled/disabled
@@ -732,7 +732,7 @@ void DlgPrefSound::bufferUnderflow(double count) {
     update();
 }
 
-void DlgPrefSound::mainLatencyChanged(double latency) {
+void DlgPrefSound::outputLatencyChanged(double latency) {
     currentLatency->setText(QString("%1 ms").arg(latency));
     update();
 }

--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -48,7 +48,7 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     void slotApply() override;  // called on ok button
     void slotResetToDefaults() override;
     void bufferUnderflow(double count);
-    void mainLatencyChanged(double latency);
+    void outputLatencyChanged(double latency);
     void latencyCompensationSpinboxChanged(double value);
     void mainDelaySpinboxChanged(double value);
     void headDelaySpinboxChanged(double value);
@@ -86,7 +86,7 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     UserSettingsPointer m_pSettings;
     SoundManagerConfig m_config;
     ControlProxy* m_pAudioLatencyOverloadCount;
-    ControlProxy* m_pMainLatency;
+    ControlProxy* m_pOutputLatencyMs;
     ControlProxy* m_pHeadDelay;
     ControlProxy* m_pMainDelay;
     ControlProxy* m_pBoothDelay;

--- a/src/soundio/sounddevicenetwork.cpp
+++ b/src/soundio/sounddevicenetwork.cpp
@@ -89,7 +89,7 @@ SoundDeviceStatus SoundDeviceNetwork::open(bool isClkRefDevice, int syncBuffers)
 
         // Update the samplerate and latency ControlObjects, which allow the
         // waveform view to properly correct for the latency.
-        ControlObject::set(ConfigKey("[Master]", "latency"),
+        ControlObject::set(ConfigKey(kAppGroup, QStringLiteral("output_latency_ms")),
                 requestedBufferTime.toDoubleMillis());
         ControlObject::set(ConfigKey(kAppGroup, QStringLiteral("samplerate")), m_dSampleRate);
 

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -385,7 +385,9 @@ SoundDeviceStatus SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffer
     if (isClkRefDevice) {
         // Update the samplerate and latency ControlObjects, which allow the
         // waveform view to properly correct for the latency.
-        ControlObject::set(ConfigKey("[Master]", "latency"), currentLatencyMSec);
+        ControlObject::set(
+                ConfigKey(kAppGroup, QStringLiteral("output_latency_ms")),
+                currentLatencyMSec);
         ControlObject::set(ConfigKey(kAppGroup, QStringLiteral("samplerate")), m_dSampleRate);
         m_invalidTimeInfoCount = 0;
         m_clkRefTimer.start();

--- a/src/test/co_dumps/co_dump_inital.csv
+++ b/src/test/co_dumps/co_dump_inital.csv
@@ -29,7 +29,7 @@
 [EffectRack1_EffectUnit4_Effect4],parameter4_set_default,0
 [EffectRack1_EffectUnit2_Effect2],parameter2_link_type,0
 [QuickEffectRack1_[Channel3]_Effect1],parameter5_set_zero,0
-[Master],latency,5.80499
+[App],output_latency_ms,5.80499
 [Channel4],hotcue_15_enabled,0
 [Channel4],hotcue_2_activate,0
 [EffectRack1_EffectUnit3_Effect3],parameter4_minus_toggle,0

--- a/src/test/controlobjectaliastest.cpp
+++ b/src/test/controlobjectaliastest.cpp
@@ -66,6 +66,10 @@ TEST_F(ControlObjectAliasTest, EngineMixer) {
     auto sampleRateLegacy = ControlProxy(ConfigKey(kLegacyGroup, QStringLiteral("samplerate")));
     EXPECT_DOUBLE_EQ(sampleRate.get(), sampleRateLegacy.get());
 
+    auto latency = ControlProxy(ConfigKey(kAppGroup, QStringLiteral("output_latency_ms")));
+    auto latencyLegacy = ControlProxy(ConfigKey(kLegacyGroup, QStringLiteral("latency")));
+    EXPECT_DOUBLE_EQ(latency.get(), latencyLegacy.get());
+
     auto audioLatencyUsage = ControlProxy(
             ConfigKey(kAppGroup, QStringLiteral("audio_latency_usage")));
     auto audioLatencyUsageLegacy = ControlProxy(

--- a/src/vinylcontrol/vinylcontrolxwax.cpp
+++ b/src/vinylcontrol/vinylcontrolxwax.cpp
@@ -128,7 +128,7 @@ VinylControlXwax::VinylControlXwax(UserSettingsPointer pConfig, const QString& g
     }
 
     double latency = ControlObject::get(
-            ConfigKey("[Master]", "latency"));
+            ConfigKey(QStringLiteral("[App]"), QStringLiteral("output_latency_ms")));
     if (latency <= 0 || latency > 200) {
         qDebug() << "Failed to get sane latency, assuming 20 as a reasonable value";
         latency = 20;


### PR DESCRIPTION
*Part of https://github.com/mixxxdj/mixxx/issues/11931.*

Moves the `latency` control into the `[App]` group.