### PR TITLE
fix(coreservices): Remove obsolete `getLV2Backend()` method

### DIFF
--- a/src/coreservices.h
+++ b/src/coreservices.h
@@ -26,7 +26,6 @@ class ControllerManager;
 class VinylControlManager;
 class TrackCollectionManager;
 class Library;
-class LV2Backend;
 
 namespace mixxx {
 
@@ -82,10 +81,6 @@ class CoreServices : public QObject {
         return m_pVCManager;
     }
 
-    LV2Backend* getLV2Backend() const {
-        return m_pLV2Backend;
-    }
-
     std::shared_ptr<EffectsManager> getEffectsManager() const {
         return m_pEffectsManager;
     }
@@ -129,8 +124,6 @@ class CoreServices : public QObject {
     std::shared_ptr<SettingsManager> m_pSettingsManager;
     std::shared_ptr<mixxx::ControlIndicatorTimer> m_pControlIndicatorTimer;
     std::shared_ptr<EffectsManager> m_pEffectsManager;
-    // owned by EffectsManager
-    LV2Backend* m_pLV2Backend;
     std::shared_ptr<EngineMixer> m_pEngine;
     std::shared_ptr<SoundManager> m_pSoundManager;
     std::shared_ptr<PlayerManager> m_pPlayerManager;

--- a/src/test/coreservicestest.cpp
+++ b/src/test/coreservicestest.cpp
@@ -22,7 +22,6 @@ TEST_F(CoreServicesTest, DISABLED_TestInitialization) {
 
     EXPECT_NE(pCoreServices->getControllerManager(), nullptr);
     EXPECT_NE(pCoreServices->getEffectsManager(), nullptr);
-    EXPECT_NE(pCoreServices->getLV2Backend(), nullptr);
     EXPECT_NE(pCoreServices->getLibrary(), nullptr);
     EXPECT_NE(pCoreServices->getPlayerManager(), nullptr);
     EXPECT_NE(pCoreServices->getScreensaverManager(), nullptr);


### PR DESCRIPTION
This method is obsolete. It's never used in production code and always returns `nullptr` because the `m_pLV2Backend` member of `CoreServices` is never set.