### PR TITLE
Precompiled headers fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1477,6 +1477,8 @@ else()
   endif()
 endif()
 
+set_source_files_properties(src/util/moc_included_test.cpp PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
+
 set_target_properties(mixxx-lib PROPERTIES AUTOMOC ON AUTOUIC ON CXX_CLANG_TIDY "${CLANG_TIDY}")
 target_include_directories(mixxx-lib PUBLIC src "${CMAKE_CURRENT_BINARY_DIR}/src")
 if(UNIX AND NOT APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1094,6 +1094,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/util/logger.cpp
   src/util/logging.cpp
   src/util/mac.cpp
+  src/util/moc_included_test.cpp
   src/util/movinginterquartilemean.cpp
   src/util/performancetimer.cpp
   src/util/rangelist.cpp
@@ -2092,6 +2093,7 @@ add_executable(mixxx-test
   src/test/wbatterytest.cpp
   src/test/wpushbutton_test.cpp
   src/test/wwidgetstack_test.cpp
+  src/util/moc_included_test.cpp
 )
 find_package(GTest CONFIG REQUIRED)
 set_target_properties(mixxx-test PROPERTIES AUTOMOC ON)

--- a/src/test/ringdelaybuffer_test.cpp
+++ b/src/test/ringdelaybuffer_test.cpp
@@ -6,7 +6,6 @@
 #include <gtest/gtest.h>
 
 #include <QTest>
-#include <span>
 
 #include "test/mixxxtest.h"
 #include "util/samplebuffer.h"

--- a/src/util/moc_included_test.cpp
+++ b/src/util/moc_included_test.cpp
@@ -1,0 +1,8 @@
+#include "../mocs_compilation.cpp"
+
+// QT_VERSION will be defined by any moc_<header_base>.cpp file included from mocs_compilation.cpp
+// It is empty in case all moc files are included, a requirement to speed up incremental builds.
+// See https://cmake.org/cmake/help/latest/prop_tgt/AUTOMOC.html for details.
+#ifdef QT_VERSION
+#error mocs_compilation.cpp not empty. Move all #include "moc_<header_base>.cpp" lines from mocs_compilation.cpp to the cpp files of the related classes.
+#endif

--- a/src/util/ringdelaybuffer.cpp
+++ b/src/util/ringdelaybuffer.cpp
@@ -1,7 +1,5 @@
 #include "ringdelaybuffer.h"
 
-#include <span>
-
 #include "util/math.h"
 #include "util/sample.h"
 


### PR DESCRIPTION
This fixes building on Ubuntu Focal and reintroduces the moc_included_test.cpp