### PR TITLE
Tag Fetcher: fix apply status messages

### DIFF
--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -337,7 +337,7 @@ void DlgTagFetcher::applyTagsAndCover() {
             // to the current time.
             QDateTime::currentDateTimeUtc());
 
-    statusMessage->setText(tr("Selected metadata applied"));
+    statusMessage->setText(tr("Metadata & Cover Art applied"));
 }
 
 void DlgTagFetcher::applyCover() {
@@ -386,8 +386,6 @@ void DlgTagFetcher::applyCover() {
 
         m_pWorker->start();
     }
-
-    statusMessage->setText(tr("Selected cover art applied"));
 }
 
 void DlgTagFetcher::retry() {
@@ -625,7 +623,7 @@ void DlgTagFetcher::slotWorkerCoverArtUpdated(const CoverInfoRelative& coverInfo
     qDebug() << "DlgTagFetcher::slotWorkerCoverArtUpdated" << coverInfo;
     m_pTrack->setCoverInfo(coverInfo);
     loadCurrentTrackCover();
-    statusMessage->setText(tr("Metadata & Cover Art applied"));
+    statusMessage->setText(tr("Selected cover art applied"));
 }
 
 void DlgTagFetcher::slotWorkerAskOverwrite(const QString& coverArtAbsolutePath,


### PR DESCRIPTION
This removes the message added in #11938 and shifts the cover/cover+tags message to the correct spots.
I.e. no new translation strings except "Selected cover art applied" from #11938 