### PR TITLE
Denon Prime GO - Mixxx Mapping

### DIFF
--- a/res/controllers/Denon-Prime-GO.midi.xml
+++ b/res/controllers/Denon-Prime-GO.midi.xml
@@ -967,7 +967,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>Prime4.leftDeck.padGrid.padModeButtonPressed</key>
                 <description>Deck 1 - Hot Cue Pad On</description>
                 <status>0x92</status>
                 <midino>0x0B</midino>
@@ -977,7 +977,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>Prime4.leftDeck.padGrid.padModeButtonPressed</key>
                 <description>Deck 1 - Hot Cue Pad Off</description>
                 <status>0x82</status>
                 <midino>0x0B</midino>
@@ -987,7 +987,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>Prime4.leftDeck.padGrid.padModeButtonPressed</key>
                 <description>Deck 1 - Loop Pad On</description>
                 <status>0x92</status>
                 <midino>0x0C</midino>
@@ -997,7 +997,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>Prime4.leftDeck.padGrid.padModeButtonPressed</key>
                 <description>Deck 1 - Loop Pad Off</description>
                 <status>0x82</status>
                 <midino>0x0C</midino>
@@ -1007,7 +1007,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>Prime4.leftDeck.padGrid.padModeButtonPressed</key>
                 <description>Deck 1 - Roll Pad On</description>
                 <status>0x92</status>
                 <midino>0x0D</midino>
@@ -1017,7 +1017,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>Prime4.leftDeck.padGrid.padModeButtonPressed</key>
                 <description>Deck 1 - Roll Pad Off</description>
                 <status>0x82</status>
                 <midino>0x0D</midino>
@@ -1025,9 +1025,9 @@
                     <Script-Binding/>
                 </options>
             </control>
+            <!-- Handled internally by controller, but MIDI value is logged here if needed
             <control>
                 <group></group>
-                <key></key>
                 <description>Deck 1 - Bank Pad On</description>
                 <status>0x92</status>
                 <midino>0x0E</midino>
@@ -1037,17 +1037,17 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
                 <description>Deck 1 - Bank Pad Off</description>
                 <status>0x82</status>
                 <midino>0x0E</midino>
                 <options>
                     <Script-Binding/>
                 </options>
-            </control>
+                </control>
+            -->
             <control>
                 <group></group>
-                <key></key>
+                <key>Prime4.rightDeck.padGrid.padModeButtonPressed</key>
                 <description>Deck 2 - Hot Cue Pad On</description>
                 <status>0x93</status>
                 <midino>0x0B</midino>
@@ -1057,7 +1057,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>Prime4.rightDeck.padGrid.padModeButtonPressed</key>
                 <description>Deck 2 - Hot Cue Pad Off</description>
                 <status>0x83</status>
                 <midino>0x0B</midino>
@@ -1067,7 +1067,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>Prime4.rightDeck.padGrid.padModeButtonPressed</key>
                 <description>Deck 2 - Loop Pad On</description>
                 <status>0x93</status>
                 <midino>0x0C</midino>
@@ -1077,7 +1077,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>Prime4.rightDeck.padGrid.padModeButtonPressed</key>
                 <description>Deck 2 - Loop Pad Off</description>
                 <status>0x83</status>
                 <midino>0x0C</midino>
@@ -1087,7 +1087,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>Prime4.rightDeck.padGrid.padModeButtonPressed</key>
                 <description>Deck 2 - Roll Pad On</description>
                 <status>0x93</status>
                 <midino>0x0D</midino>
@@ -1097,7 +1097,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>Prime4.rightDeck.padGrid.padModeButtonPressed</key>
                 <description>Deck 2 - Roll Pad Off</description>
                 <status>0x83</status>
                 <midino>0x0D</midino>
@@ -1105,9 +1105,9 @@
                     <Script-Binding/>
                 </options>
             </control>
+            <!-- Handled internally by controller, but MIDI value is logged here if needed
             <control>
                 <group></group>
-                <key></key>
                 <description>Deck 2 - Bank Pad On</description>
                 <status>0x93</status>
                 <midino>0x0E</midino>
@@ -1117,7 +1117,6 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
                 <description>Deck 2 - Bank Pad Off</description>
                 <status>0x83</status>
                 <midino>0x0E</midino>
@@ -1125,9 +1124,10 @@
                     <Script-Binding/>
                 </options>
             </control>
+            -->
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.padGrid.performancePad</key>
                 <description>Deck 1 - Pad 1 On</description>
                 <status>0x92</status>
                 <midino>0x0F</midino>
@@ -1137,7 +1137,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.padGrid.performancePad</key>
                 <description>Deck 1 - Pad 1 Off</description>
                 <status>0x82</status>
                 <midino>0x0F</midino>
@@ -1147,7 +1147,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.padGrid.performancePad</key>
                 <description>Deck 1 - Pad 2 On</description>
                 <status>0x92</status>
                 <midino>0x10</midino>
@@ -1157,7 +1157,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.padGrid.performancePad</key>
                 <description>Deck 1 - Pad 2 Off</description>
                 <status>0x82</status>
                 <midino>0x10</midino>
@@ -1167,7 +1167,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.padGrid.performancePad</key>
                 <description>Deck 1 - Pad 3 On</description>
                 <status>0x92</status>
                 <midino>0x11</midino>
@@ -1177,7 +1177,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.padGrid.performancePad</key>
                 <description>Deck 1 - Pad 3 Off</description>
                 <status>0x82</status>
                 <midino>0x11</midino>
@@ -1187,7 +1187,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.padGrid.performancePad</key>
                 <description>Deck 1 - Pad 4 On</description>
                 <status>0x92</status>
                 <midino>0x12</midino>
@@ -1197,7 +1197,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.padGrid.performancePad</key>
                 <description>Deck 1 - Pad 4 Off</description>
                 <status>0x82</status>
                 <midino>0x12</midino>
@@ -1207,7 +1207,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.padGrid.performancePad</key>
                 <description>Deck 1 - Pad 5 On</description>
                 <status>0x92</status>
                 <midino>0x13</midino>
@@ -1217,7 +1217,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.padGrid.performancePad</key>
                 <description>Deck 1 - Pad 5 Off</description>
                 <status>0x82</status>
                 <midino>0x13</midino>
@@ -1227,7 +1227,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.padGrid.performancePad</key>
                 <description>Deck 1 - Pad 6 On</description>
                 <status>0x92</status>
                 <midino>0x14</midino>
@@ -1237,7 +1237,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.padGrid.performancePad</key>
                 <description>Deck 1 - Pad 6 Off</description>
                 <status>0x82</status>
                 <midino>0x14</midino>
@@ -1247,7 +1247,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.padGrid.performancePad</key>
                 <description>Deck 1 - Pad 7 On</description>
                 <status>0x92</status>
                 <midino>0x15</midino>
@@ -1257,7 +1257,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.padGrid.performancePad</key>
                 <description>Deck 1 - Pad 7 Off</description>
                 <status>0x82</status>
                 <midino>0x15</midino>
@@ -1267,7 +1267,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.padGrid.performancePad</key>
                 <description>Deck 1 - Pad 8 On</description>
                 <status>0x92</status>
                 <midino>0x16</midino>
@@ -1277,7 +1277,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.padGrid.performancePad</key>
                 <description>Deck 1 - Pad 8 Off</description>
                 <status>0x82</status>
                 <midino>0x16</midino>
@@ -1287,7 +1287,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.padGrid.performancePad</key>
                 <description>Deck 2 - Pad 1 On</description>
                 <status>0x93</status>
                 <midino>0x0F</midino>
@@ -1297,7 +1297,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.padGrid.performancePad</key>
                 <description>Deck 2 - Pad 1 Off</description>
                 <status>0x83</status>
                 <midino>0x0F</midino>
@@ -1307,7 +1307,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.padGrid.performancePad</key>
                 <description>Deck 2 - Pad 2 On</description>
                 <status>0x93</status>
                 <midino>0x10</midino>
@@ -1317,7 +1317,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.padGrid.performancePad</key>
                 <description>Deck 2 - Pad 2 Off</description>
                 <status>0x83</status>
                 <midino>0x10</midino>
@@ -1327,7 +1327,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.padGrid.performancePad</key>
                 <description>Deck 2 - Pad 3 On</description>
                 <status>0x93</status>
                 <midino>0x11</midino>
@@ -1337,7 +1337,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.padGrid.performancePad</key>
                 <description>Deck 2 - Pad 3 Off</description>
                 <status>0x83</status>
                 <midino>0x11</midino>
@@ -1347,7 +1347,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.padGrid.performancePad</key>
                 <description>Deck 2 - Pad 4 On</description>
                 <status>0x93</status>
                 <midino>0x12</midino>
@@ -1357,7 +1357,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.padGrid.performancePad</key>
                 <description>Deck 2 - Pad 4 Off</description>
                 <status>0x83</status>
                 <midino>0x12</midino>
@@ -1367,7 +1367,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.padGrid.performancePad</key>
                 <description>Deck 2 - Pad 5 On</description>
                 <status>0x93</status>
                 <midino>0x13</midino>
@@ -1377,7 +1377,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.padGrid.performancePad</key>
                 <description>Deck 2 - Pad 5 Off</description>
                 <status>0x83</status>
                 <midino>0x13</midino>
@@ -1387,7 +1387,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.padGrid.performancePad</key>
                 <description>Deck 2 - Pad 6 On</description>
                 <status>0x93</status>
                 <midino>0x14</midino>
@@ -1397,7 +1397,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.padGrid.performancePad</key>
                 <description>Deck 2 - Pad 6 Off</description>
                 <status>0x83</status>
                 <midino>0x14</midino>
@@ -1407,7 +1407,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.padGrid.performancePad</key>
                 <description>Deck 2 - Pad 7 On</description>
                 <status>0x93</status>
                 <midino>0x15</midino>
@@ -1417,7 +1417,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.padGrid.performancePad</key>
                 <description>Deck 2 - Pad 7 Off</description>
                 <status>0x83</status>
                 <midino>0x15</midino>
@@ -1427,7 +1427,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.padGrid.performancePad</key>
                 <description>Deck 2 - Pad 8 On</description>
                 <status>0x93</status>
                 <midino>0x16</midino>
@@ -1437,7 +1437,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.padGrid.performancePad</key>
                 <description>Deck 2 - Pad 8 Off</description>
                 <status>0x83</status>
                 <midino>0x16</midino>

--- a/res/controllers/Denon-Prime-GO.midi.xml
+++ b/res/controllers/Denon-Prime-GO.midi.xml
@@ -116,13 +116,13 @@
                 </options>
             </control>
             <control>
-                <group>[QuickEffectRack1_[Channel1]]</group>
-                <key>super1</key>
+                <group></group>
+                <key>PrimeGo.leftDeck.sweepKnob.input</key>
                 <description>Deck 1 - Sweep FX Knob</description>
                 <status>0xB0</status>
                 <midino>0x0B</midino>
                 <options>
-                    <normal/>
+                    <Script-Binding/>
                 </options>
             </control>
             <control>
@@ -236,13 +236,13 @@
                 </options>
             </control>
             <control>
-                <group>[QuickEffectRack1_[Channel1]]</group>
-                <key>super1</key>
+                <group></group>
+                <key>PrimeGo.rightDeck.sweepKnob.input</key>
                 <description>Deck 2 - Sweep FX Knob</description>
                 <status>0xB1</status>
                 <midino>0x0B</midino>
                 <options>
-                    <normal/>
+                    <Script-Binding/>
                 </options>
             </control>
             <control>

--- a/res/controllers/Denon-Prime-GO.midi.xml
+++ b/res/controllers/Denon-Prime-GO.midi.xml
@@ -295,6 +295,106 @@
                     <Script-Binding/>
                 </options>
             </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>FX Select Encoder Touch ON</description>
+                <status>0x94</status>
+                <midino>0x09</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>FX Select Encoder Touch OFF</description>
+                <status>0x84</status>
+                <midino>0x09</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>FX Select Encoder</description>
+                <status>0xB4</status>
+                <midino>0x21</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>FX Select Encoder Button ON</description>
+                <status>0x94</status>
+                <midino>0x07</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>FX Select Encoder Button OFF</description>
+                <status>0x84</status>
+                <midino>0x07</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>FX Time/Parameter Encoder Touch ON</description>
+                <status>0x94</status>
+                <midino>0x0A</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>FX Time/Parameter Encoder Touch OFF</description>
+                <status>0x84</status>
+                <midino>0x0A</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>FX Time/Parameter Encoder</description>
+                <status>0xB4</status>
+                <midino>0x22</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>FX Time/Parameter Encoder Button ON</description>
+                <status>0x94</status>
+                <midino>0x08</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>FX Time/Parameter Encoder Button OFF</description>
+                <status>0x84</status>
+                <midino>0x08</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
         </controls>
 
         <outputs>

--- a/res/controllers/Denon-Prime-GO.midi.xml
+++ b/res/controllers/Denon-Prime-GO.midi.xml
@@ -116,13 +116,13 @@
                 </options>
             </control>
             <control>
-                <group></group>
-                <key></key>
+                <group>[QuickEffectRack1_[Channel1]]</group>
+                <key>super1</key>
                 <description>Deck 1 - Sweep FX Knob</description>
                 <status>0xB0</status>
                 <midino>0x0B</midino>
                 <options>
-                    <Script-Binding/>
+                    <normal/>
                 </options>
             </control>
             <control>
@@ -157,7 +157,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.sweepA.input</key>
                 <description>Deck 1 - Sweep FX A Button ON</description>
                 <status>0x90</status>
                 <midino>0x0E</midino>
@@ -167,7 +167,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.sweepA.input</key>
                 <description>Deck 1 - Sweep FX A Button OFF</description>
                 <status>0x80</status>
                 <midino>0x0E</midino>
@@ -177,7 +177,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.sweepA.input</key>
                 <description>Deck 2 - Sweep FX A Button ON</description>
                 <status>0x91</status>
                 <midino>0x0E</midino>
@@ -187,7 +187,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.sweepA.input</key>
                 <description>Deck 2 - Sweep FX A Button OFF</description>
                 <status>0x81</status>
                 <midino>0x0E</midino>
@@ -236,13 +236,13 @@
                 </options>
             </control>
             <control>
-                <group></group>
-                <key></key>
+                <group>[QuickEffectRack1_[Channel1]]</group>
+                <key>super1</key>
                 <description>Deck 2 - Sweep FX Knob</description>
                 <status>0xB1</status>
                 <midino>0x0B</midino>
                 <options>
-                    <Script-Binding/>
+                    <normal/>
                 </options>
             </control>
             <control>
@@ -787,7 +787,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.pitchBendDown.input</key>
                 <description>Deck 1 Pitch Bend (-) Button On</description>
                 <status>0x92</status>
                 <midino>0x1D</midino>
@@ -797,7 +797,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.pitchBendDown.input</key>
                 <description>Deck 1 Pitch Bend (-) Button Off</description>
                 <status>0x82</status>
                 <midino>0x1D</midino>
@@ -807,7 +807,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.pitchBendUp.input</key>
                 <description>Deck 1 Pitch Bend (+) Button On</description>
                 <status>0x92</status>
                 <midino>0x1E</midino>
@@ -817,7 +817,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.pitchBendUp.input</key>
                 <description>Deck 1 Pitch Bend (+) Button Off</description>
                 <status>0x82</status>
                 <midino>0x1E</midino>
@@ -827,7 +827,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.pitchBendDown.input</key>
                 <description>Deck 2 Pitch Bend (-) Button On</description>
                 <status>0x93</status>
                 <midino>0x1D</midino>
@@ -837,7 +837,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.pitchBendDown.input</key>
                 <description>Deck 2 Pitch Bend (-) Button Off</description>
                 <status>0x83</status>
                 <midino>0x1D</midino>
@@ -847,7 +847,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.pitchBendUp.input</key>
                 <description>Deck 2 Pitch Bend (+) Button On</description>
                 <status>0x93</status>
                 <midino>0x1E</midino>
@@ -857,7 +857,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.pitchBendUp.input</key>
                 <description>Deck 2 Pitch Bend (+) Button Off</description>
                 <status>0x83</status>
                 <midino>0x1E</midino>
@@ -1527,7 +1527,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.tempoFader.inputMSB</key>
                 <description>Deck 1 - Pitch Fader MSB</description>
                 <status>0xB2</status>
                 <midino>0x1F</midino>
@@ -1537,7 +1537,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.tempoFader.inputLSB</key>
                 <description>Deck 1 - Pitch Fader LSB</description>
                 <status>0xB2</status>
                 <midino>0x4B</midino>
@@ -1547,7 +1547,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.tempoFader.inputMSB</key>
                 <description>Deck 2 - Pitch Fader MSB</description>
                 <status>0xB3</status>
                 <midino>0x1F</midino>
@@ -1557,7 +1557,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.tempoFader.inputLSB</key>
                 <description>Deck 2 - Pitch Fader LSB</description>
                 <status>0xB3</status>
                 <midino>0x4B</midino>

--- a/res/controllers/Denon-Prime-GO.midi.xml
+++ b/res/controllers/Denon-Prime-GO.midi.xml
@@ -627,7 +627,7 @@
             </control>
             <control>
                 <group></group>
-                <key>PrimeGo.leftDeck.gain.input</key>
+                <key>PrimeGo.rightDeck.gain.input</key>
                 <description>Deck 2 Gain Knob</description>
                 <status>0xB1</status>
                 <midino>0x03</midino>

--- a/res/controllers/Denon-Prime-GO.midi.xml
+++ b/res/controllers/Denon-Prime-GO.midi.xml
@@ -597,7 +597,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.eqLow.input</key>
                 <description>Deck 1 Low Knob</description>
                 <status>0xB0</status>
                 <midino>0x08</midino>
@@ -607,7 +607,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.eqMid.input</key>
                 <description>Deck 1 Mid Knob</description>
                 <status>0xB0</status>
                 <midino>0x06</midino>
@@ -617,7 +617,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.eqHigh.input</key>
                 <description>Deck 1 High Knob</description>
                 <status>0xB0</status>
                 <midino>0x04</midino>
@@ -637,7 +637,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.eqLow.input</key>
                 <description>Deck 2 Low Knob</description>
                 <status>0xB1</status>
                 <midino>0x08</midino>
@@ -647,7 +647,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.eqMid.input</key>
                 <description>Deck 2 Mid Knob</description>
                 <status>0xB1</status>
                 <midino>0x06</midino>
@@ -657,7 +657,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.eqHigh.input</key>
                 <description>Deck 2 High Knob</description>
                 <status>0xB1</status>
                 <midino>0x04</midino>

--- a/res/controllers/Denon-Prime-GO.midi.xml
+++ b/res/controllers/Denon-Prime-GO.midi.xml
@@ -1445,6 +1445,126 @@
                     <Script-Binding/>
                 </options>
             </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Jog Wheel Touch On</description>
+                <status>0x92</status>
+                <midino>0x21</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Jog Wheel Touch Off</description>
+                <status>0x82</status>
+                <midino>0x21</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Jog Wheel Touch On</description>
+                <status>0x93</status>
+                <midino>0x21</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Jog Wheel Touch Off</description>
+                <status>0x83</status>
+                <midino>0x21</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Jog Wheel MSB</description>
+                <status>0xB2</status>
+                <midino>0x37</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Jog Wheel LSB</description>
+                <status>0xB2</status>
+                <midino>0x4D</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Jog Wheel MSB</description>
+                <status>0xB3</status>
+                <midino>0x37</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Jog Wheel LSB</description>
+                <status>0xB3</status>
+                <midino>0x4D</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Pitch Fader MSB</description>
+                <status>0xB2</status>
+                <midino>0x1F</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Pitch Fader LSB</description>
+                <status>0xB2</status>
+                <midino>0x4B</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Pitch Fader MSB</description>
+                <status>0xB3</status>
+                <midino>0x1F</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Pitch Fader LSB</description>
+                <status>0xB3</status>
+                <midino>0x4B</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
         </controls>
 
         <outputs>

--- a/res/controllers/Denon-Prime-GO.midi.xml
+++ b/res/controllers/Denon-Prime-GO.midi.xml
@@ -37,7 +37,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.deckLoad.input</key>
                 <description>Deck 1 - Load Button ON</description>
                 <status>0x9F</status>
                 <midino>0x01</midino>
@@ -47,7 +47,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.deckLoad.input</key>
                 <description>Deck 1 - Load Button OFF</description>
                 <status>0x8F</status>
                 <midino>0x01</midino>
@@ -57,7 +57,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.deckLoad.input</key>
                 <description>Deck 2 - Load Button ON</description>
                 <status>0x9F</status>
                 <midino>0x02</midino>
@@ -67,7 +67,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.deckLoad.input</key>
                 <description>Deck 2 - Load Button OFF</description>
                 <status>0x8F</status>
                 <midino>0x02</midino>
@@ -77,7 +77,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.moveBack.input</key>
                 <description>Back Button ON</description>
                 <status>0x9F</status>
                 <midino>0x03</midino>
@@ -87,7 +87,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.moveBack.input</key>
                 <description>Back Button OFF</description>
                 <status>0x8F</status>
                 <midino>0x03</midino>
@@ -97,7 +97,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.moveForward.input</key>
                 <description>Fwd Button ON</description>
                 <status>0x9F</status>
                 <midino>0x04</midino>
@@ -107,7 +107,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.moveForward.input</key>
                 <description>Fwd Button OFF</description>
                 <status>0x8F</status>
                 <midino>0x04</midino>

--- a/res/controllers/Denon-Prime-GO.midi.xml
+++ b/res/controllers/Denon-Prime-GO.midi.xml
@@ -747,7 +747,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.vinylButton.input</key>
                 <description>Deck 1 Vinyl / Grid Edit Button On</description>
                 <status>0x92</status>
                 <midino>0x23</midino>
@@ -757,7 +757,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.vinylButton.input</key>
                 <description>Deck 1 Vinyl / Grid Edit Button Off</description>
                 <status>0x82</status>
                 <midino>0x23</midino>
@@ -767,7 +767,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.vinylButton.input</key>
                 <description>Deck 2 Vinyl / Grid Edit Button On</description>
                 <status>0x93</status>
                 <midino>0x23</midino>
@@ -777,7 +777,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.vinylButton.input</key>
                 <description>Deck 2 Vinyl / Grid Edit Button Off</description>
                 <status>0x83</status>
                 <midino>0x23</midino>

--- a/res/controllers/Denon-Prime-GO.midi.xml
+++ b/res/controllers/Denon-Prime-GO.midi.xml
@@ -395,6 +395,36 @@
                     <Script-Binding/>
                 </options>
             </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Wet/Dry Knob</description>
+                <status>0xB4</status>
+                <midino>0x04</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>FX On Button On</description>
+                <status>0x94</status>
+                <midino>0x06</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>FX On Button Off</description>
+                <status>0x84</status>
+                <midino>0x06</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
         </controls>
 
         <outputs>

--- a/res/controllers/Denon-Prime-GO.midi.xml
+++ b/res/controllers/Denon-Prime-GO.midi.xml
@@ -1,0 +1,303 @@
+<?xml version="1.0" encoding="utf-8"?>
+    <MixxxControllerPreset mixxxVersion="2.4.0+" schemaVersion="1">
+    <info>
+        <name>Denon Prime GO - Mixxx Mapping</name>
+        <author>Levi "Whanake" Williams</author>
+        <description>This is a Work-In-Progress mapping to allow the Denon Prime GO to be used with Mixxx, ideally with the same (if not more) functionality than the Prime GO provides as a standalone device.</description>
+        <wiki>Encoded URL to Mixxx wiki page documenting this controller mapping</wiki>
+        <forums>Encoded URL to Mixxx discussion forums page for this controller mapping</forums>
+    </info>
+    <controller id="primego"><!-- Many controllers in one file supported. A controller should only appear once -->
+        <scriptfiles>
+            <file filename="lodash.mixxx.js"/>
+            <file filename="midi-components-0.0.js"/>
+            <file filename="Denon-Prime-GO.scripts.js" functionprefix="PrimeGo"/>
+        </scriptfiles>
+
+        <controls>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Load Button ON</description>
+                <status>0x9F</status>
+                <midino>0x01</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Load Button OFF</description>
+                <status>0x8F</status>
+                <midino>0x01</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Load Button ON</description>
+                <status>0x9F</status>
+                <midino>0x02</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Load Button OFF</description>
+                <status>0x8F</status>
+                <midino>0x02</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Back Button ON</description>
+                <status>0x9F</status>
+                <midino>0x03</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Back Button OFF</description>
+                <status>0x8F</status>
+                <midino>0x03</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Fwd Button ON</description>
+                <status>0x9F</status>
+                <midino>0x04</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Fwd Button OFF</description>
+                <status>0x8F</status>
+                <midino>0x04</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Sweep FX Knob</description>
+                <status>0xB0</status>
+                <midino>0x0B</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Browse Encoder</description>
+                <status>0xBF</status>
+                <midino>0x05</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Browse Encoder Button ON</description>
+                <status>0x9F</status>
+                <midino>0x06</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Browse Encoder Button OFF</description>
+                <status>0x8F</status>
+                <midino>0x06</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Sweep FX A Button ON</description>
+                <status>0x90</status>
+                <midino>0x0E</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Sweep FX A Button OFF</description>
+                <status>0x80</status>
+                <midino>0x0E</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Sweep FX A Button ON</description>
+                <status>0x91</status>
+                <midino>0x0E</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Sweep FX A Button OFF</description>
+                <status>0x81</status>
+                <midino>0x0E</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Sweep FX B Button ON</description>
+                <status>0x90</status>
+                <midino>0x0F</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Sweep FX B Button OFF</description>
+                <status>0x80</status>
+                <midino>0x0F</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Sweep FX B Button ON</description>
+                <status>0x91</status>
+                <midino>0x0F</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Sweep FX B Button OFF</description>
+                <status>0x81</status>
+                <midino>0x0F</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Sweep FX Knob</description>
+                <status>0xB1</status>
+                <midino>0x0B</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Volume Fader</description>
+                <status>0xB0</status>
+                <midino>0x0E</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Volume Fader</description>
+                <status>0xB1</status>
+                <midino>0x0E</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Crossfader</description>
+                <status>0xBF</status>
+                <midino>0x0E</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>View Button ON</description>
+                <status>0x9F</status>
+                <midino>0x07</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>View Button OFF</description>
+                <status>0x8F</status>
+                <midino>0x07</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Shift Button ON</description>
+                <status>0x9F</status>
+                <midino>0x08</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Shift Button OFF</description>
+                <status>0x8F</status>
+                <midino>0x08</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+        </controls>
+
+        <outputs>
+        </outputs>
+    </controller>
+</MixxxControllerPreset>

--- a/res/controllers/Denon-Prime-GO.midi.xml
+++ b/res/controllers/Denon-Prime-GO.midi.xml
@@ -7,7 +7,7 @@
         <wiki>Encoded URL to Mixxx wiki page documenting this controller mapping</wiki>
         <forums>Encoded URL to Mixxx discussion forums page for this controller mapping</forums>
     </info>
-    <controller id="primego"><!-- Many controllers in one file supported. A controller should only appear once -->
+    <controller id="primego">
         <scriptfiles>
             <file filename="lodash.mixxx.js"/>
             <file filename="midi-components-0.0.js"/>
@@ -901,6 +901,546 @@
                 <description>Deck 2 Sync / Key Sync Button Off</description>
                 <status>0x83</status>
                 <midino>0x08</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Loop Encoder Button On</description>
+                <status>0x92</status>
+                <midino>0x27</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Loop Encoder Button Off</description>
+                <status>0x82</status>
+                <midino>0x27</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Loop Encoder</description>
+                <status>0xB2</status>
+                <midino>0x20</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Loop Encoder Button On</description>
+                <status>0x93</status>
+                <midino>0x27</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Loop Encoder Button Off</description>
+                <status>0x83</status>
+                <midino>0x27</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Loop Encoder</description>
+                <status>0xB3</status>
+                <midino>0x20</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Hot Cue Pad On</description>
+                <status>0x92</status>
+                <midino>0x0B</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Hot Cue Pad Off</description>
+                <status>0x82</status>
+                <midino>0x0B</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Loop Pad On</description>
+                <status>0x92</status>
+                <midino>0x0C</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Loop Pad Off</description>
+                <status>0x82</status>
+                <midino>0x0C</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Roll Pad On</description>
+                <status>0x92</status>
+                <midino>0x0D</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Roll Pad Off</description>
+                <status>0x82</status>
+                <midino>0x0D</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Bank Pad On</description>
+                <status>0x92</status>
+                <midino>0x0E</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Bank Pad Off</description>
+                <status>0x82</status>
+                <midino>0x0E</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Hot Cue Pad On</description>
+                <status>0x93</status>
+                <midino>0x0B</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Hot Cue Pad Off</description>
+                <status>0x83</status>
+                <midino>0x0B</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Loop Pad On</description>
+                <status>0x93</status>
+                <midino>0x0C</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Loop Pad Off</description>
+                <status>0x83</status>
+                <midino>0x0C</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Roll Pad On</description>
+                <status>0x93</status>
+                <midino>0x0D</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Roll Pad Off</description>
+                <status>0x83</status>
+                <midino>0x0D</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Bank Pad On</description>
+                <status>0x93</status>
+                <midino>0x0E</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Bank Pad Off</description>
+                <status>0x83</status>
+                <midino>0x0E</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Pad 1 On</description>
+                <status>0x92</status>
+                <midino>0x0F</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Pad 1 Off</description>
+                <status>0x82</status>
+                <midino>0x0F</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Pad 2 On</description>
+                <status>0x92</status>
+                <midino>0x10</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Pad 2 Off</description>
+                <status>0x82</status>
+                <midino>0x10</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Pad 3 On</description>
+                <status>0x92</status>
+                <midino>0x11</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Pad 3 Off</description>
+                <status>0x82</status>
+                <midino>0x11</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Pad 4 On</description>
+                <status>0x92</status>
+                <midino>0x12</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Pad 4 Off</description>
+                <status>0x82</status>
+                <midino>0x12</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Pad 5 On</description>
+                <status>0x92</status>
+                <midino>0x13</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Pad 5 Off</description>
+                <status>0x82</status>
+                <midino>0x13</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Pad 6 On</description>
+                <status>0x92</status>
+                <midino>0x14</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Pad 6 Off</description>
+                <status>0x82</status>
+                <midino>0x14</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Pad 7 On</description>
+                <status>0x92</status>
+                <midino>0x15</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Pad 7 Off</description>
+                <status>0x82</status>
+                <midino>0x15</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Pad 8 On</description>
+                <status>0x92</status>
+                <midino>0x16</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - Pad 8 Off</description>
+                <status>0x82</status>
+                <midino>0x16</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Pad 1 On</description>
+                <status>0x93</status>
+                <midino>0x0F</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Pad 1 Off</description>
+                <status>0x83</status>
+                <midino>0x0F</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Pad 2 On</description>
+                <status>0x93</status>
+                <midino>0x10</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Pad 2 Off</description>
+                <status>0x83</status>
+                <midino>0x10</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Pad 3 On</description>
+                <status>0x93</status>
+                <midino>0x11</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Pad 3 Off</description>
+                <status>0x83</status>
+                <midino>0x11</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Pad 4 On</description>
+                <status>0x93</status>
+                <midino>0x12</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Pad 4 Off</description>
+                <status>0x83</status>
+                <midino>0x12</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Pad 5 On</description>
+                <status>0x93</status>
+                <midino>0x13</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Pad 5 Off</description>
+                <status>0x83</status>
+                <midino>0x13</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Pad 6 On</description>
+                <status>0x93</status>
+                <midino>0x14</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Pad 6 Off</description>
+                <status>0x83</status>
+                <midino>0x14</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Pad 7 On</description>
+                <status>0x93</status>
+                <midino>0x15</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Pad 7 Off</description>
+                <status>0x83</status>
+                <midino>0x15</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Pad 8 On</description>
+                <status>0x93</status>
+                <midino>0x16</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - Pad 8 Off</description>
+                <status>0x83</status>
+                <midino>0x16</midino>
                 <options>
                     <Script-Binding/>
                 </options>

--- a/res/controllers/Denon-Prime-GO.midi.xml
+++ b/res/controllers/Denon-Prime-GO.midi.xml
@@ -137,7 +137,7 @@
             </control>
             <control>
                 <group></group>
-                <key>Prime4.encoderLoad.input</key>
+                <key>PrimeGo.encoderLoad.input</key>
                 <description>Browse Encoder Button ON</description>
                 <status>0x9F</status>
                 <midino>0x06</midino>
@@ -147,7 +147,7 @@
             </control>
             <control>
                 <group></group>
-                <key>Prime4.encoderLoad.input</key>
+                <key>PrimeGo.encoderLoad.input</key>
                 <description>Browse Encoder Button OFF</description>
                 <status>0x8F</status>
                 <midino>0x06</midino>
@@ -267,7 +267,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.headphoneCue.input</key>
                 <description>Deck 1 - PFL Button On</description>
                 <status>0x90</status>
                 <midino>0x0D</midino>
@@ -277,7 +277,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.headphoneCue.input</key>
                 <description>Deck 1 - PFL Button Off</description>
                 <status>0x80</status>
                 <midino>0x0D</midino>
@@ -287,7 +287,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.headphoneCue.input</key>
                 <description>Deck 2 - PFL Button On</description>
                 <status>0x91</status>
                 <midino>0x0D</midino>
@@ -297,7 +297,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.headphoneCue.input</key>
                 <description>Deck 2 - PFL Button Off</description>
                 <status>0x81</status>
                 <midino>0x0D</midino>
@@ -306,18 +306,18 @@
                 </options>
             </control>
             <control>
-                <group></group>
-                <key></key>
+                <group>[Master]</group>
+                <key>crossfader</key>
                 <description>Crossfader</description>
                 <status>0xBF</status>
                 <midino>0x0E</midino>
                 <options>
-                    <Script-Binding/>
+                    <normal/>
                 </options>
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.maxView.input</key>
                 <description>View Button ON</description>
                 <status>0x9F</status>
                 <midino>0x07</midino>
@@ -327,7 +327,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.maxView.input</key>
                 <description>View Button OFF</description>
                 <status>0x8F</status>
                 <midino>0x07</midino>

--- a/res/controllers/Denon-Prime-GO.midi.xml
+++ b/res/controllers/Denon-Prime-GO.midi.xml
@@ -587,7 +587,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.gain.input</key>
                 <description>Deck 1 Gain Knob</description>
                 <status>0xB0</status>
                 <midino>0x03</midino>
@@ -627,7 +627,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.gain.input</key>
                 <description>Deck 2 Gain Knob</description>
                 <status>0xB1</status>
                 <midino>0x03</midino>

--- a/res/controllers/Denon-Prime-GO.midi.xml
+++ b/res/controllers/Denon-Prime-GO.midi.xml
@@ -425,6 +425,186 @@
                     <Script-Binding/>
                 </options>
             </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Assign 1 Button On</description>
+                <status>0x94</status>
+                <midino>0x0B</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Assign 1 Button Off</description>
+                <status>0x84</status>
+                <midino>0x0B</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Assign 2 Button On</description>
+                <status>0x94</status>
+                <midino>0x0C</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Assign 2 Button Off</description>
+                <status>0x84</status>
+                <midino>0x0C</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Mic 1 Button On</description>
+                <status>0x94</status>
+                <midino>0x24</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Mic 1 Button Off</description>
+                <status>0x84</status>
+                <midino>0x24</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Mic 2 Button On</description>
+                <status>0x94</status>
+                <midino>0x25</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Mic 2 Button Off</description>
+                <status>0x84</status>
+                <midino>0x25</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Eject Button On</description>
+                <status>0x94</status>
+                <midino>0x14</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Eject Button Off</description>
+                <status>0x84</status>
+                <midino>0x14</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 Gain Knob</description>
+                <status>0xB0</status>
+                <midino>0x03</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 Low Knob</description>
+                <status>0xB0</status>
+                <midino>0x08</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 Mid Knob</description>
+                <status>0xB0</status>
+                <midino>0x06</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 High Knob</description>
+                <status>0xB0</status>
+                <midino>0x04</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 Gain Knob</description>
+                <status>0xB1</status>
+                <midino>0x03</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 Low Knob</description>
+                <status>0xB1</status>
+                <midino>0x08</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 Mid Knob</description>
+                <status>0xB1</status>
+                <midino>0x06</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 High Knob</description>
+                <status>0xB1</status>
+                <midino>0x04</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
         </controls>
 
         <outputs>

--- a/res/controllers/Denon-Prime-GO.midi.xml
+++ b/res/controllers/Denon-Prime-GO.midi.xml
@@ -247,7 +247,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.volumeFader.input</key>
                 <description>Deck 1 - Volume Fader</description>
                 <status>0xB0</status>
                 <midino>0x0E</midino>
@@ -257,7 +257,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.volumeFader.input</key>
                 <description>Deck 2 - Volume Fader</description>
                 <status>0xB1</status>
                 <midino>0x0E</midino>
@@ -337,7 +337,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.shiftState</key>
                 <description>Shift Button ON</description>
                 <status>0x9F</status>
                 <midino>0x08</midino>
@@ -347,7 +347,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.shiftState</key>
                 <description>Shift Button OFF</description>
                 <status>0x8F</status>
                 <midino>0x08</midino>

--- a/res/controllers/Denon-Prime-GO.midi.xml
+++ b/res/controllers/Denon-Prime-GO.midi.xml
@@ -18,6 +18,26 @@
             <control>
                 <group></group>
                 <key></key>
+                <description>Cue Mix Knob</description>
+                <status>0xBF</status>
+                <midino>0x0C</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Cue Level Knob</description>
+                <status>0xBF</status>
+                <midino>0x0D</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
                 <description>Deck 1 - Load Button ON</description>
                 <status>0x9F</status>
                 <midino>0x01</midino>
@@ -241,6 +261,46 @@
                 <description>Deck 2 - Volume Fader</description>
                 <status>0xB1</status>
                 <midino>0x0E</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - PFL Button On</description>
+                <status>0x90</status>
+                <midino>0x0D</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 - PFL Button Off</description>
+                <status>0x80</status>
+                <midino>0x0D</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - PFL Button On</description>
+                <status>0x91</status>
+                <midino>0x0D</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 - PFL Button Off</description>
+                <status>0x81</status>
+                <midino>0x0D</midino>
                 <options>
                     <Script-Binding/>
                 </options>
@@ -601,6 +661,246 @@
                 <description>Deck 2 High Knob</description>
                 <status>0xB1</status>
                 <midino>0x04</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 Cue Button On</description>
+                <status>0x92</status>
+                <midino>0x09</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 Cue Button Off</description>
+                <status>0x82</status>
+                <midino>0x09</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 Play/Stop Button On</description>
+                <status>0x92</status>
+                <midino>0x0A</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 Play/Stop Button Off</description>
+                <status>0x82</status>
+                <midino>0x0A</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 Cue Button On</description>
+                <status>0x93</status>
+                <midino>0x09</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 Cue Button Off</description>
+                <status>0x83</status>
+                <midino>0x09</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 Play/Stop Button On</description>
+                <status>0x93</status>
+                <midino>0x0A</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 Play/Stop Button Off</description>
+                <status>0x83</status>
+                <midino>0x0A</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 Vinyl / Grid Edit Button On</description>
+                <status>0x92</status>
+                <midino>0x23</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 Vinyl / Grid Edit Button Off</description>
+                <status>0x82</status>
+                <midino>0x23</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 Vinyl / Grid Edit Button On</description>
+                <status>0x93</status>
+                <midino>0x23</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 Vinyl / Grid Edit Button Off</description>
+                <status>0x83</status>
+                <midino>0x23</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 Pitch Bend (-) Button On</description>
+                <status>0x92</status>
+                <midino>0x1D</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 Pitch Bend (-) Button Off</description>
+                <status>0x82</status>
+                <midino>0x1D</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 Pitch Bend (+) Button On</description>
+                <status>0x92</status>
+                <midino>0x1E</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 Pitch Bend (+) Button Off</description>
+                <status>0x82</status>
+                <midino>0x1E</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 Pitch Bend (-) Button On</description>
+                <status>0x93</status>
+                <midino>0x1D</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 Pitch Bend (-) Button Off</description>
+                <status>0x83</status>
+                <midino>0x1D</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 Pitch Bend (+) Button On</description>
+                <status>0x93</status>
+                <midino>0x1E</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 Pitch Bend (+) Button Off</description>
+                <status>0x83</status>
+                <midino>0x1E</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 Sync / Key Sync Button On</description>
+                <status>0x92</status>
+                <midino>0x08</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 1 Sync / Key Sync Button Off</description>
+                <status>0x82</status>
+                <midino>0x08</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 Sync / Key Sync Button On</description>
+                <status>0x93</status>
+                <midino>0x08</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <group></group>
+                <key></key>
+                <description>Deck 2 Sync / Key Sync Button Off</description>
+                <status>0x83</status>
+                <midino>0x08</midino>
                 <options>
                     <Script-Binding/>
                 </options>

--- a/res/controllers/Denon-Prime-GO.midi.xml
+++ b/res/controllers/Denon-Prime-GO.midi.xml
@@ -667,7 +667,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.cueButton.input</key>
                 <description>Deck 1 Cue Button On</description>
                 <status>0x92</status>
                 <midino>0x09</midino>
@@ -677,7 +677,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.cueButton.input</key>
                 <description>Deck 1 Cue Button Off</description>
                 <status>0x82</status>
                 <midino>0x09</midino>
@@ -687,7 +687,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.playButton.input</key>
                 <description>Deck 1 Play/Stop Button On</description>
                 <status>0x92</status>
                 <midino>0x0A</midino>
@@ -697,7 +697,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.playButton.input</key>
                 <description>Deck 1 Play/Stop Button Off</description>
                 <status>0x82</status>
                 <midino>0x0A</midino>
@@ -707,7 +707,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.cueButton.input</key>
                 <description>Deck 2 Cue Button On</description>
                 <status>0x93</status>
                 <midino>0x09</midino>
@@ -717,7 +717,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.cueButton.input</key>
                 <description>Deck 2 Cue Button Off</description>
                 <status>0x83</status>
                 <midino>0x09</midino>
@@ -727,7 +727,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.playButton.input</key>
                 <description>Deck 2 Play/Stop Button On</description>
                 <status>0x93</status>
                 <midino>0x0A</midino>
@@ -737,7 +737,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.playButton.input</key>
                 <description>Deck 2 Play/Stop Button Off</description>
                 <status>0x83</status>
                 <midino>0x0A</midino>
@@ -867,7 +867,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.syncButton.input</key>
                 <description>Deck 1 Sync / Key Sync Button On</description>
                 <status>0x92</status>
                 <midino>0x08</midino>
@@ -877,7 +877,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.syncButton.input</key>
                 <description>Deck 1 Sync / Key Sync Button Off</description>
                 <status>0x82</status>
                 <midino>0x08</midino>
@@ -887,7 +887,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.syncButton.input</key>
                 <description>Deck 2 Sync / Key Sync Button On</description>
                 <status>0x93</status>
                 <midino>0x08</midino>
@@ -897,7 +897,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.syncButton.input</key>
                 <description>Deck 2 Sync / Key Sync Button Off</description>
                 <status>0x83</status>
                 <midino>0x08</midino>

--- a/res/controllers/Denon-Prime-GO.midi.xml
+++ b/res/controllers/Denon-Prime-GO.midi.xml
@@ -126,18 +126,18 @@
                 </options>
             </control>
             <control>
-                <group></group>
-                <key></key>
+                <group>[Library]</group>
+                <key>MoveVertical</key>
                 <description>Browse Encoder</description>
                 <status>0xBF</status>
                 <midino>0x05</midino>
                 <options>
-                    <Script-Binding/>
+                    <selectknob/>
                 </options>
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>Prime4.encoderLoad.input</key>
                 <description>Browse Encoder Button ON</description>
                 <status>0x9F</status>
                 <midino>0x06</midino>
@@ -147,7 +147,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>Prime4.encoderLoad.input</key>
                 <description>Browse Encoder Button OFF</description>
                 <status>0x8F</status>
                 <midino>0x06</midino>

--- a/res/controllers/Denon-Prime-GO.midi.xml
+++ b/res/controllers/Denon-Prime-GO.midi.xml
@@ -967,7 +967,7 @@
             </control>
             <control>
                 <group></group>
-                <key>Prime4.leftDeck.padGrid.padModeButtonPressed</key>
+                <key>PrimeGo.leftDeck.padGrid.padModeButtonPressed</key>
                 <description>Deck 1 - Hot Cue Pad On</description>
                 <status>0x92</status>
                 <midino>0x0B</midino>
@@ -977,7 +977,7 @@
             </control>
             <control>
                 <group></group>
-                <key>Prime4.leftDeck.padGrid.padModeButtonPressed</key>
+                <key>PrimeGo.leftDeck.padGrid.padModeButtonPressed</key>
                 <description>Deck 1 - Hot Cue Pad Off</description>
                 <status>0x82</status>
                 <midino>0x0B</midino>
@@ -987,7 +987,7 @@
             </control>
             <control>
                 <group></group>
-                <key>Prime4.leftDeck.padGrid.padModeButtonPressed</key>
+                <key>PrimeGo.leftDeck.padGrid.padModeButtonPressed</key>
                 <description>Deck 1 - Loop Pad On</description>
                 <status>0x92</status>
                 <midino>0x0C</midino>
@@ -997,7 +997,7 @@
             </control>
             <control>
                 <group></group>
-                <key>Prime4.leftDeck.padGrid.padModeButtonPressed</key>
+                <key>PrimeGo.leftDeck.padGrid.padModeButtonPressed</key>
                 <description>Deck 1 - Loop Pad Off</description>
                 <status>0x82</status>
                 <midino>0x0C</midino>
@@ -1007,7 +1007,7 @@
             </control>
             <control>
                 <group></group>
-                <key>Prime4.leftDeck.padGrid.padModeButtonPressed</key>
+                <key>PrimeGo.leftDeck.padGrid.padModeButtonPressed</key>
                 <description>Deck 1 - Roll Pad On</description>
                 <status>0x92</status>
                 <midino>0x0D</midino>
@@ -1017,7 +1017,7 @@
             </control>
             <control>
                 <group></group>
-                <key>Prime4.leftDeck.padGrid.padModeButtonPressed</key>
+                <key>PrimeGo.leftDeck.padGrid.padModeButtonPressed</key>
                 <description>Deck 1 - Roll Pad Off</description>
                 <status>0x82</status>
                 <midino>0x0D</midino>
@@ -1047,7 +1047,7 @@
             -->
             <control>
                 <group></group>
-                <key>Prime4.rightDeck.padGrid.padModeButtonPressed</key>
+                <key>PrimeGo.rightDeck.padGrid.padModeButtonPressed</key>
                 <description>Deck 2 - Hot Cue Pad On</description>
                 <status>0x93</status>
                 <midino>0x0B</midino>
@@ -1057,7 +1057,7 @@
             </control>
             <control>
                 <group></group>
-                <key>Prime4.rightDeck.padGrid.padModeButtonPressed</key>
+                <key>PrimeGo.rightDeck.padGrid.padModeButtonPressed</key>
                 <description>Deck 2 - Hot Cue Pad Off</description>
                 <status>0x83</status>
                 <midino>0x0B</midino>
@@ -1067,7 +1067,7 @@
             </control>
             <control>
                 <group></group>
-                <key>Prime4.rightDeck.padGrid.padModeButtonPressed</key>
+                <key>PrimeGo.rightDeck.padGrid.padModeButtonPressed</key>
                 <description>Deck 2 - Loop Pad On</description>
                 <status>0x93</status>
                 <midino>0x0C</midino>
@@ -1077,7 +1077,7 @@
             </control>
             <control>
                 <group></group>
-                <key>Prime4.rightDeck.padGrid.padModeButtonPressed</key>
+                <key>PrimeGo.rightDeck.padGrid.padModeButtonPressed</key>
                 <description>Deck 2 - Loop Pad Off</description>
                 <status>0x83</status>
                 <midino>0x0C</midino>
@@ -1087,7 +1087,7 @@
             </control>
             <control>
                 <group></group>
-                <key>Prime4.rightDeck.padGrid.padModeButtonPressed</key>
+                <key>PrimeGo.rightDeck.padGrid.padModeButtonPressed</key>
                 <description>Deck 2 - Roll Pad On</description>
                 <status>0x93</status>
                 <midino>0x0D</midino>
@@ -1097,7 +1097,7 @@
             </control>
             <control>
                 <group></group>
-                <key>Prime4.rightDeck.padGrid.padModeButtonPressed</key>
+                <key>PrimeGo.rightDeck.padGrid.padModeButtonPressed</key>
                 <description>Deck 2 - Roll Pad Off</description>
                 <status>0x83</status>
                 <midino>0x0D</midino>
@@ -1447,7 +1447,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.jogWheel.inputTouch</key>
                 <description>Deck 1 - Jog Wheel Touch On</description>
                 <status>0x92</status>
                 <midino>0x21</midino>
@@ -1457,7 +1457,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.jogWheel.inputTouch</key>
                 <description>Deck 1 - Jog Wheel Touch Off</description>
                 <status>0x82</status>
                 <midino>0x21</midino>
@@ -1467,7 +1467,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.jogWheel.inputTouch</key>
                 <description>Deck 2 - Jog Wheel Touch On</description>
                 <status>0x93</status>
                 <midino>0x21</midino>
@@ -1477,7 +1477,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.jogWheel.inputTouch</key>
                 <description>Deck 2 - Jog Wheel Touch Off</description>
                 <status>0x83</status>
                 <midino>0x21</midino>
@@ -1487,7 +1487,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.jogWheel.inputWheelMSB</key>
                 <description>Deck 1 - Jog Wheel MSB</description>
                 <status>0xB2</status>
                 <midino>0x37</midino>
@@ -1497,7 +1497,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.leftDeck.jogWheel.inputWheelLSB</key>
                 <description>Deck 1 - Jog Wheel LSB</description>
                 <status>0xB2</status>
                 <midino>0x4D</midino>
@@ -1507,7 +1507,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.jogWheel.inputWheelMSB</key>
                 <description>Deck 2 - Jog Wheel MSB</description>
                 <status>0xB3</status>
                 <midino>0x37</midino>
@@ -1517,7 +1517,7 @@
             </control>
             <control>
                 <group></group>
-                <key></key>
+                <key>PrimeGo.rightDeck.jogWheel.inputWheelLSB</key>
                 <description>Deck 2 - Jog Wheel LSB</description>
                 <status>0xB3</status>
                 <midino>0x4D</midino>

--- a/res/controllers/Denon-Prime-GO.scripts.js
+++ b/res/controllers/Denon-Prime-GO.scripts.js
@@ -224,6 +224,8 @@ PrimeGo.Deck = function(deckNumber, midiChannel) {
         inKey: "volume",
     });
 
+    this.padGrid = new PrimeGo.PadSection(this, midiChannel - 2);
+
     this.reconnectComponents(function(c) {
         if (c.group === undefined) {
             c.group = this.currentDeck;
@@ -252,7 +254,6 @@ PrimeGo.shiftState = function(channel, control, value) {
 };
 
 
-/*
 //========== PERFORMANCE PADS ==========//
 
 // mode-select pad index list to avoid remembering MIDI values
@@ -264,5 +265,139 @@ PrimeGo.padMode = {
 };
 
 PrimeGo.PadSection = function(deck, offset) {
+    components.ComponentContainer.call(this);
+    const theContainer = this;
+
+    // Create component containers for each pad mode
+    const modes = new components.ComponentContainer({
+        "hotcue": new PrimeGo.WrappingArrayView([new PrimeGo.hotcueMode(deck, offset)], 0),
+    });
+
+    modes.forEachComponent(c => c.disconnect());
+
+    const controlToPadMode = control => {
+        // If a pad selector button has multiple modes, go to the first mode
+        // by default. Otherwise, go to the next mode in that button's list.
+        const nextPadMode = (a) => {
+            if (a.indexable.includes(this.currentMode)) {
+                return a.next();
+            } else {
+                a.index = 0;
+                return a.current();
+            }
+        };
+
+        let mode;
+
+        switch (control) {
+        case PrimeGo.padMode.HOTCUE:
+            mode = nextPadMode(modes.hotcue);
+            break;
+        case PrimeGo.padMode.LOOP:
+            mode = nextPadMode(modes.loop);
+            break;
+        case PrimeGo.padMode.ROLL:
+            mode = nextPadMode(modes.roll);
+            break;
+        }
+
+        return mode;
+    };
+
+    this.offset = offset;
+
+    this.padModeSelectLeds = new components.Component({
+        trigger: function() {
+            // NOTE: There need to be two `for` blocks here to ensure that
+            //       the active mode's LED gets lit last. Otherwise, selecting
+            //       a mode when pressing shift will result in that pad mode's
+            //       LED being unlit.
+            for (const modeLayers of Object.values(modes)) {
+                const mode = modeLayers.current();
+                if (theContainer.currentMode !== mode) {
+                    // Make this LED inactive
+                }
+            }
+            for (const modeLayers of Object.values(modes)) {
+                const mode = modeLayers.current();
+                if (theContainer.currentMode === mode) {
+                    // Make this LED active
+                }
+            }
+        },
+    }, false);
+
+    // Function for switching between pad modes
+    this.setPadMode = function(control) {
+        const newMode = controlToPadMode(control);
+
+        // Exit early if requested mode is already active or unavailable
+        if (newMode === this.currentMode || newMode === undefined) {
+            return;
+        }
+
+        // Disable LED of current mode button
+        if (this.currentMode) {
+            // Disconnect pads from current mode
+            this.currentMode.forEachComponent(function(component) {
+                component.disconnect();
+                component.outConnect = false;
+            });
+        }
+
+        // Connect pads to new mode
+        newMode.forEachComponent(function(component) {
+            component.outConnect = true;
+            component.connect();
+            component.trigger();
+        });
+
+        // Assign mode select buttons in XML file
+        this.padModeButtonPressed = function(channel, control, value, _status, _group) {
+            if (value) {
+                this.setPadMode(control);
+            }
+        };
+
+        this.currentMode = newMode;
+
+        theContainer.padModeSelectLeds.trigger();
+    };
+
+    // Start in hotcue mode
+    this.setPadMode(PrimeGo.padMode.HOTCUE);
 };
-*/
+
+PrimeGo.PadSection.prototype = Object.create(components.ComponentContainer.prototype);
+
+// Assign performance pads mapped in XML file
+PrimeGo.PadSection.prototype.performancePad = function(channel, control, value, status, group) {
+    // Convert pad `control` to index value (1 to 8)
+    const i = (control - 0x0E);
+
+    this.currentMode.pads[i].input(channel, control, value, status, group);
+};
+
+PrimeGo.hotcueMode = function(deck, offset) {
+    components.ComponentContainer.call(this);
+    this.ledControl = PrimeGo.padMode.HOTCUE;
+    // this.colourOn = ________
+    // this.colourOff = ________
+    this.pads = new components.ComponentContainer();
+    for (let i = 1; i <= 8; i++) {
+        this.pads[i] = new components.HotcueButton({
+            number: i,
+            group: deck.currentDeck,
+            midi: [0x92 + offset, 0x0E + i],
+            sendRGB: function(color_obj) {
+                const msg = [0xf0, 0x00, 0x02, 0x0b, 0x7f, 0x0c, 0x03, 0x00, 0x05, 0x02 + offset, 0x0e + i, color_obj.red>>1, color_obj.green>>1, color_obj.blue>>1, 0xf7];
+                // F0 00 02 0B 7F 0C 03 00 05 status midino red green blue F7
+                midi.sendSysexMsg(msg, msg.length);
+            },
+            //on: this.colourOn,
+            //off: this.colourOff,
+            outConnect: false,
+        });
+    }
+};
+PrimeGo.hotcueMode.prototype = Object.create(components.ComponentContainer.prototype);

--- a/res/controllers/Denon-Prime-GO.scripts.js
+++ b/res/controllers/Denon-Prime-GO.scripts.js
@@ -9,12 +9,20 @@ components.Button.prototype.isPress = function(channel, control, value, status) 
 // 'Off' value sets basic LEDs to dim instead of fully off
 components.Button.prototype.off = 0x01;
 
+const initMsg = [0xF0, 0x00, 0x02, 0x0B, 0x7F, 0x0C, 0x04, 0x00, 0x00, 0xF7];
+
+// Send colors to RGB pads via SysEx
+// F0 00 02 0B 7F 0C 03 00 05 status midino red green blue F7
+
 PrimeGo.init = function(_id, _debugging) {
     // Turn off all LEDs
     midi.sendShortMsg(0x90, 0x75, 0x00);
 
     // Initialize Shift LED
     midi.sendShortMsg(0x9F, 0x08, 0x01);
+
+    // Get position of all components
+    midi.sendSysexMsg(initMsg, initMsg.length);
 
     PrimeGo.leftDeck = new PrimeGo.Deck(1, 2);
     PrimeGo.rightDeck = new PrimeGo.Deck(2, 3);
@@ -39,16 +47,15 @@ PrimeGo.init = function(_id, _debugging) {
 
     PrimeGo.maxView = new components.Button({
         midi: [0x9F, 0x07],
-        group: "[Master]",
-        key: "maximize_library",
+        group: "[Skin]",
+        key: "show_maximized_library",
         type: components.Button.prototype.types.toggle,
     });
 };
 
 PrimeGo.shutdown = function() {
     // Dim all LEDs
-    midi.sendShortMsg(0x90, 0x75, 0x00);
-    // Final functions go here
+    midi.sendShortMsg(0x90, 0x75, 0x01);
 };
 
 PrimeGo.Deck = function(deckNumber, midiChannel) {

--- a/res/controllers/Denon-Prime-GO.scripts.js
+++ b/res/controllers/Denon-Prime-GO.scripts.js
@@ -30,43 +30,67 @@ PrimeGo.Deck = function(deckNumber, midiChannel) {
         midi: [0x90 + midiChannel, 0x0A],
         //TODO: play_stutter
     });
+
     this.cueButton = new components.CueButton({
         midi: [0x90 + midiChannel, 0x09]
     });
+
     //pitchbend -
+
     //pitchbend +
+
     //pitchfader
+
     this.syncButton = new components.SyncButton({
         midi: [0x90 + midiChannel, 0x08],
     });
+
     //vinyl
+
     //jogwheel
+
     //loopencoder
+
     this.gain = new components.Pot({
         midi: [0xB0 + midiChannel - 2, 0x03],
         group: "[Channel" + deckNumber + "]",
         inKey: "pregain",
     });
+
     this.eqLow = new components.Pot({
         midi: [0xB0 + midiChannel - 2, 0x08],
         group: "[EqualizerRack1_[Channel" + deckNumber + "]_Effect1]",
         inKey: "parameter1",
     });
+
     this.eqMid = new components.Pot({
         midi: [0xB0 + midiChannel - 2, 0x06],
         group: "[EqualizerRack1_[Channel" + deckNumber + "]_Effect1]",
         inKey: "parameter2",
     });
+
     this.eqHigh = new components.Pot({
         midi: [0xB0 + midiChannel - 2, 0x04],
         group: "[EqualizerRack1_[Channel" + deckNumber + "]_Effect1]",
         inKey: "parameter3",
     });
+
     //sweepfxknob
+
     //sweepA
+
     //sweepB
-    //pfl
-    //volume
+
+    this.headphoneCue = new components.Button({
+        midi: [0x90 + midiChannel - 2, 0x0D],
+        key: "pfl",
+        type: components.Button.prototype.types.toggle,
+    });
+
+    this.volumeFader = new components.Pot({
+        midi: [0xB0 + midiChannel - 2, 0x0E],
+        inKey: "volume",
+    });
 
     this.reconnectComponents(function(c) {
         if (c.group === undefined) {
@@ -76,3 +100,20 @@ PrimeGo.Deck = function(deckNumber, midiChannel) {
 };
 
 PrimeGo.Deck.prototype = new components.Deck();
+
+PrimeGo.shift = false;
+PrimeGo.shiftState = function(channel, control, value) {
+    PrimeGo.shift = value === 0x7F;
+    if (PrimeGo.shift) {
+        midi.sendShortMsg(0x9F, 0x08, 0x7F);
+        PrimeGo.leftDeck.shift();
+        PrimeGo.rightDeck.shift();
+        PrimeGo.leftDeck.reconnectComponents();
+        PrimeGo.rightDeck.reconnectComponents();
+    } else {
+        PrimeGo.leftDeck.unshift();
+        PrimeGo.rightDeck.unshift();
+        PrimeGo.leftDeck.reconnectComponents();
+        PrimeGo.rightDeck.reconnectComponents();
+    }
+};

--- a/res/controllers/Denon-Prime-GO.scripts.js
+++ b/res/controllers/Denon-Prime-GO.scripts.js
@@ -25,8 +25,20 @@ PrimeGo.init = function(_id, _debugging) {
         key: "GoToItem",
     });
 
+    PrimeGo.moveBack = new components.Button({
+        midi: [0x9F, 0x03],
+        group: "[Library]",
+        key: "MoveFocusBackward",
+    });
+
+    PrimeGo.moveForward = new components.Button({
+        midi: [0x9F, 0x04],
+        group: "[Library]",
+        key: "MoveFocusForward",
+    });
+
     PrimeGo.maxView = new components.Button({
-        midi: [],
+        midi: [0x9F, 0x07],
         group: "[Master]",
         key: "maximize_library",
         type: components.Button.prototype.types.toggle,
@@ -41,6 +53,19 @@ PrimeGo.shutdown = function() {
 
 PrimeGo.Deck = function(deckNumber, midiChannel) {
     components.Deck.call(this, deckNumber);
+
+    this.deckLoad = new components.Button({
+        midi: [0x9F, midiChannel - 1],
+        key: "LoadSelectedTrack",
+        shift: function() {
+            this.inKey = "eject";
+            this.outKey = this.inKey;
+        },
+        unshift: function() {
+            this.inKey = "LoadSelectedTrack",
+            this.outKey = this.inKey;
+        },
+    });
 
     this.playButton = new components.PlayButton({
         midi: [0x90 + midiChannel, 0x0A],

--- a/res/controllers/Denon-Prime-GO.scripts.js
+++ b/res/controllers/Denon-Prime-GO.scripts.js
@@ -137,6 +137,7 @@ PrimeGo.shutdown = function() {
 
 PrimeGo.Deck = function(deckNumber, midiChannel) {
     components.Deck.call(this, deckNumber);
+    const theDeck = this;
 
     this.deckLoad = new components.Button({
         midi: [0x9F, midiChannel - 1],
@@ -191,6 +192,20 @@ PrimeGo.Deck = function(deckNumber, midiChannel) {
     });
 
     //vinylButton
+    this.vinylButton = new components.Button({
+        midi: [0x90 + midiChannel, 0x23],
+        type: components.Button.prototype.types.toggle,
+        input: function(channel, control, value, status, _group) {
+            if (!this.isPress(channel, control, value, status)) {
+                return;
+            }
+            theDeck.jogWheel.vinylMode = !theDeck.jogWheel.vinylMode;
+            this.trigger();
+        },
+        trigger: function() {
+            this.output(theDeck.jogWheel.vinylMode);
+        },
+    });
 
     //jogwheel
     this.jogWheel = new components.JogWheelBasic({

--- a/res/controllers/Denon-Prime-GO.scripts.js
+++ b/res/controllers/Denon-Prime-GO.scripts.js
@@ -1,2 +1,61 @@
 // eslint-disable-next-line-no-var
-//var PrimeGo = {};
+var PrimeGo = {};
+
+// Register '0x9n' as a button press and '0x8n' as a button release
+components.Button.prototype.isPress = function(channel, control, value, status) {
+    return (status & 0xF0) === 0x90;
+};
+
+// 'Off' value sets basic LEDs to dim instead of fully off
+components.Button.prototype.off = 0x01;
+
+PrimeGo.init = function(_id, _debugging) {
+    // Turn off all LEDs
+    midi.sendShortMsg(0x90, 0x75, 0x00);
+    PrimeGo.leftDeck = new PrimeGo.Deck(1, 2);
+    PrimeGo.rightDeck = new PrimeGo.Deck(2, 3);
+    // Initial functions go here
+};
+
+PrimeGo.shutdown = function() {
+    // Dim all LEDs
+    midi.sendShortMsg(0x90, 0x75, 0x01);
+    // Final functions go here
+};
+
+PrimeGo.Deck = function(deckNumber, midiChannel) {
+    components.Deck.call(this, deckNumber);
+    this.playButton = new components.PlayButton({
+        midi: [0x90 + midiChannel, 0x0A],
+        //TODO: play_stutter
+    });
+    this.cueButton = new components.CueButton({
+        midi: [0x90 + midiChannel, 0x09]
+    });
+    //pitchbend -
+    //pitchbend +
+    //pitchfader
+    this.syncButton = new components.SyncButton({
+        midi: [0x90 + midiChannel, 0x08],
+    });
+    //vinyl
+    //jogwheel
+    //loopencoder
+    //gain
+    //low
+    //mid
+    //high
+    //sweepfxknob
+    //sweepA
+    //sweepB
+    //pfl
+    //volume
+
+    this.reconnectComponents(function(c) {
+        if (c.group === undefined) {
+            c.group = this.currentDeck;
+        }
+    });
+};
+
+PrimeGo.Deck.prototype = new components.Deck();

--- a/res/controllers/Denon-Prime-GO.scripts.js
+++ b/res/controllers/Denon-Prime-GO.scripts.js
@@ -47,9 +47,21 @@ PrimeGo.Deck = function(deckNumber, midiChannel) {
         group: "[Channel" + deckNumber + "]",
         inKey: "pregain",
     });
-    //low
-    //mid
-    //high
+    this.eqLow = new components.Pot({
+        midi: [0xB0 + midiChannel - 2, 0x08],
+        group: "[EqualizerRack1_[Channel" + deckNumber + "]_Effect1]",
+        inKey: "parameter1",
+    });
+    this.eqMid = new components.Pot({
+        midi: [0xB0 + midiChannel - 2, 0x06],
+        group: "[EqualizerRack1_[Channel" + deckNumber + "]_Effect1]",
+        inKey: "parameter2",
+    });
+    this.eqHigh = new components.Pot({
+        midi: [0xB0 + midiChannel - 2, 0x04],
+        group: "[EqualizerRack1_[Channel" + deckNumber + "]_Effect1]",
+        inKey: "parameter3",
+    });
     //sweepfxknob
     //sweepA
     //sweepB

--- a/res/controllers/Denon-Prime-GO.scripts.js
+++ b/res/controllers/Denon-Prime-GO.scripts.js
@@ -14,7 +14,12 @@ PrimeGo.init = function(_id, _debugging) {
     midi.sendShortMsg(0x90, 0x75, 0x00);
     PrimeGo.leftDeck = new PrimeGo.Deck(1, 2);
     PrimeGo.rightDeck = new PrimeGo.Deck(2, 3);
-    // Initial functions go here
+
+    PrimeGo.encoderLoad = new components.Button({
+        midi: [0x9F, 0x06],
+        group: "[Library]",
+        key: "GoToItem",
+    });
 };
 
 PrimeGo.shutdown = function() {
@@ -28,7 +33,14 @@ PrimeGo.Deck = function(deckNumber, midiChannel) {
 
     this.playButton = new components.PlayButton({
         midi: [0x90 + midiChannel, 0x0A],
-        //TODO: play_stutter
+        unshift: function() {
+            components.PlayButton.prototype.unshift.call(this);
+            this.type = components.Button.prototype.types.toggle;
+        },
+        shift: function() {
+            this.inKey = "play_stutter";
+            this.type = components.Button.prototype.types.push;
+        },
     });
 
     this.cueButton = new components.CueButton({
@@ -45,7 +57,7 @@ PrimeGo.Deck = function(deckNumber, midiChannel) {
         midi: [0x90 + midiChannel, 0x08],
     });
 
-    //vinyl
+    //vinylButton
 
     //jogwheel
 

--- a/res/controllers/Denon-Prime-GO.scripts.js
+++ b/res/controllers/Denon-Prime-GO.scripts.js
@@ -25,6 +25,7 @@ PrimeGo.shutdown = function() {
 
 PrimeGo.Deck = function(deckNumber, midiChannel) {
     components.Deck.call(this, deckNumber);
+
     this.playButton = new components.PlayButton({
         midi: [0x90 + midiChannel, 0x0A],
         //TODO: play_stutter
@@ -41,7 +42,11 @@ PrimeGo.Deck = function(deckNumber, midiChannel) {
     //vinyl
     //jogwheel
     //loopencoder
-    //gain
+    this.gain = new components.Pot({
+        midi: [0xB0 + midiChannel - 2, 0x03],
+        group: "[Channel" + deckNumber + "]",
+        inKey: "pregain",
+    });
     //low
     //mid
     //high

--- a/res/controllers/Denon-Prime-GO.scripts.js
+++ b/res/controllers/Denon-Prime-GO.scripts.js
@@ -12,6 +12,10 @@ components.Button.prototype.off = 0x01;
 PrimeGo.init = function(_id, _debugging) {
     // Turn off all LEDs
     midi.sendShortMsg(0x90, 0x75, 0x00);
+
+    // Initialize Shift LED
+    midi.sendShortMsg(0x9F, 0x08, 0x01);
+
     PrimeGo.leftDeck = new PrimeGo.Deck(1, 2);
     PrimeGo.rightDeck = new PrimeGo.Deck(2, 3);
 
@@ -20,11 +24,18 @@ PrimeGo.init = function(_id, _debugging) {
         group: "[Library]",
         key: "GoToItem",
     });
+
+    PrimeGo.maxView = new components.Button({
+        midi: [],
+        group: "[Master]",
+        key: "maximize_library",
+        type: components.Button.prototype.types.toggle,
+    });
 };
 
 PrimeGo.shutdown = function() {
     // Dim all LEDs
-    midi.sendShortMsg(0x90, 0x75, 0x01);
+    midi.sendShortMsg(0x90, 0x75, 0x00);
     // Final functions go here
 };
 
@@ -123,6 +134,7 @@ PrimeGo.shiftState = function(channel, control, value) {
         PrimeGo.leftDeck.reconnectComponents();
         PrimeGo.rightDeck.reconnectComponents();
     } else {
+        midi.sendShortMsg(0x9F, 0x08, 0x01);
         PrimeGo.leftDeck.unshift();
         PrimeGo.rightDeck.unshift();
         PrimeGo.leftDeck.reconnectComponents();

--- a/res/controllers/Denon-Prime-GO.scripts.js
+++ b/res/controllers/Denon-Prime-GO.scripts.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line-no-var
+//var PrimeGo = {};

--- a/res/controllers/Denon-Prime-GO.scripts.js
+++ b/res/controllers/Denon-Prime-GO.scripts.js
@@ -90,11 +90,24 @@ PrimeGo.Deck = function(deckNumber, midiChannel) {
         midi: [0x90 + midiChannel, 0x09]
     });
 
-    //pitchbend -
+    this.pitchBendUp = new components.Button({
+        midi: [],
+        type: components.Button.prototype.types.push,
+        key: "rate_temp_up",
+        //TODO: tempo fader range
+    });
 
-    //pitchbend +
+    this.pitchBendDown = new components.Button({
+        midi: [],
+        type: components.Button.prototype.types.push,
+        key: "rate_temp_down",
+        //TODO: tempo fader range
+    });
 
-    //pitchfader
+    this.tempoFader = new components.Pot({
+        midi: [0xB0 + midiChannel, 0x1F],
+        inKey: "rate",
+    });
 
     this.syncButton = new components.SyncButton({
         midi: [0x90 + midiChannel, 0x08],
@@ -130,9 +143,14 @@ PrimeGo.Deck = function(deckNumber, midiChannel) {
         inKey: "parameter3",
     });
 
-    //sweepfxknob
+    //sweepfxknob (mapped in XML)
 
     //sweepA
+    this.sweepA = new components.Button({
+        midi: [0x90 + midiChannel - 2, 0x0E],
+        group: "QuickEffectRack1_[Channel1]]",
+        key: "enabled",
+    });
 
     //sweepB
 


### PR DESCRIPTION
This PR is being made to allow the Denon Prime GO to be used as a controller for Mixxx when in Computer Mode.