### PR TITLE
Skins: Fix checkbox styling on Qt 6

### DIFF
--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -222,6 +222,12 @@ WLibrarySidebar {
   selection-background-color: #006596;
 }
 
+/* Prevent OS-style checkbox from being rendered underneath the custom style. */
+WTrackTableView::item,
+#LibraryBPMButton::item {
+  border: 0px;
+}
+
 /* Selected rows in Tree and Tracks table */
 WTrackTableView::item:selected,
 WLibrarySidebar::item:selected,

--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -2065,6 +2065,11 @@ WLibraryTextBrowser:focus {
   border: 1px solid #d09300;
 }
 
+/* Prevent OS-style checkbox from being rendered underneath the custom style. */
+WTrackTableView::item,
+#LibraryBPMButton::item {
+  border: 0px;
+}
 /* Selected rows in Tree and Tracks table */
 WLibrarySidebar::item:selected,
 WTrackTableView::item:selected,

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -2549,6 +2549,11 @@ WLibrarySidebar {
 WLibrarySidebar {
   outline: none;
 }
+/* Prevent OS-style checkbox from being rendered underneath the custom style. */
+WTrackTableView::item,
+#LibraryBPMButton::item {
+  border: 0px;
+}
 /* Selected rows in Tree and Tracks table */
 WLibrarySidebar::item:selected,
 WTrackTableView::item:selected,

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -457,6 +457,12 @@ WLibraryTextBrowser {
   padding-left: 10px;
 }
 
+/* Prevent OS-style checkbox from being rendered underneath the custom style. */
+WTrackTableView::item,
+#LibraryBPMButton::item {
+  border: 0px;
+}
+
 WTrackTableView::item:selected,
 WSearchLineEdit::item:selected,
 WSearchLineEdit::item:checked,

--- a/res/skins/Shade/style_dark.qss
+++ b/res/skins/Shade/style_dark.qss
@@ -165,6 +165,12 @@ WSearchLineEdit QToolButton:focus {
   image: url(skin:/btn/btn_lib_clear_search_focus_green.svg);
 }
 
+/* Prevent OS-style checkbox from being rendered underneath the custom style. */
+WTrackTableView::item,
+#LibraryBPMButton::item {
+  border: 0px;
+}
+
 WLibrarySidebar::item:selected,
 WTrackTableView::item:selected,
 WLibrarySidebar::branch:selected,

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -2558,6 +2558,12 @@ WLibrarySidebar {
   selection-background-color: #555;
 }
 
+/* Prevent OS-style checkbox from being rendered underneath the custom style. */
+WTrackTableView::item,
+#LibraryBPMButton::item {
+  border: 0px;
+}
+
 /* selected table row */
 WTrackTableView::item:selected,
 #LibraryBPMButton::item:selected {


### PR DESCRIPTION
### Fixes #11630, fixes #11908

This fixes the UI regression that the BPM lock and play count checkboxes are rendered twice when building with Qt 6:

| Before | After |
| - | - |
| <img width="227" alt="Screenshot 2023-10-01 at 16 28 15" src="https://github.com/mixxxdj/mixxx/assets/30873659/9a119f2b-bc04-4346-a34f-3e84b14a38ae"> | <img width="229" alt="Screenshot 2023-10-01 at 16 28 04" src="https://github.com/mixxxdj/mixxx/assets/30873659/9be7ce4c-1218-4c91-8cec-4a79f90d71fe"> |

Seems to solve the issue under all skins and I couldn't notice any other UI regressions. Perhaps someone could test the Qt 5 build too, just to make sure that this doesn't break anything there?

cc @ronso0 