### PR TITLE
WKey: Fix regression in key notation change

### DIFF
--- a/src/widget/wkey.cpp
+++ b/src/widget/wkey.cpp
@@ -62,6 +62,8 @@ void WKey::setCents() {
     setValue(m_dOldValue);
 }
 
-void WKey::keyNotationChanged(double dValue) {
+void WKey::keyNotationChanged(double dKeyNotationValue) {
+    // NOTE: dKeyNotationValue is the index of the key notation type, NOT the
+    // key itself, so we intentionally set the old value again to update the UI.
     setValue(m_dOldValue);
 }

--- a/src/widget/wkey.cpp
+++ b/src/widget/wkey.cpp
@@ -63,5 +63,5 @@ void WKey::setCents() {
 }
 
 void WKey::keyNotationChanged(double dValue) {
-    setValue(dValue);
+    setValue(m_dOldValue);
 }


### PR DESCRIPTION
### Fixes #12044 

This fixes an issue where the _key notation index_ would incorrectly be interpreted as the _value_ of the key itself. This would often result in an incorrect key being displayed after switching the key notation:

https://github.com/mixxxdj/mixxx/assets/30873659/60bab9f1-0174-4435-8de1-73c6c9a0817b

See the issue for more details. The fix was to simply revert bb6db98fcff0293e927f7338f0d9324c7909bd04. I've also added a short explanatory comment to avoid confusion in the future.

cc @daschuer 