### PR TITLE
Reuse from precompiled headers for mixxx-test 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1516,7 +1516,7 @@ endif()
 
 # QML Debugging
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-  target_compile_definitions(mixxx-lib PRIVATE QT_QML_DEBUG)
+  target_compile_definitions(mixxx-lib PUBLIC QT_QML_DEBUG)
   message(STATUS "Enabling QML Debugging! This poses a security risk as Mixxx will open a TCP port for debugging")
 endif()
 
@@ -2512,7 +2512,7 @@ target_link_libraries(mixxx-lib PRIVATE Vorbis::vorbis Vorbis::vorbisenc Vorbis:
 
 # PortAudio
 find_package(PortAudio REQUIRED)
-target_link_libraries(mixxx-lib PRIVATE PortAudio::PortAudio)
+target_link_libraries(mixxx-lib PUBLIC PortAudio::PortAudio)
 
 # PortAudio Ring Buffer
 add_library(PortAudioRingBuffer STATIC EXCLUDE_FROM_ALL
@@ -2711,14 +2711,14 @@ elseif(UNIX AND NOT APPLE)
   else()
     find_package(X11 REQUIRED)
     find_package(Qt5 COMPONENTS X11Extras REQUIRED)
-    target_link_libraries(mixxx-lib PRIVATE Qt5::X11Extras)
+    target_link_libraries(mixxx-lib PUBLIC Qt5::X11Extras)
   endif()
   if(${X11_FOUND})
     target_include_directories(mixxx-lib SYSTEM PUBLIC "${X11_INCLUDE_DIR}")
     target_link_libraries(mixxx-lib PRIVATE "${X11_LIBRARIES}")
   endif()
   find_package(Qt${QT_VERSION_MAJOR} COMPONENTS DBus REQUIRED)
-  target_link_libraries(mixxx-lib PRIVATE
+  target_link_libraries(mixxx-lib PUBLIC
     Qt${QT_VERSION_MAJOR}::DBus
   )
 elseif(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2097,6 +2097,7 @@ add_executable(mixxx-test
   src/test/wwidgetstack_test.cpp
   src/util/moc_included_test.cpp
 )
+target_precompile_headers(mixxx-test REUSE_FROM mixxx-lib)
 find_package(GTest CONFIG REQUIRED)
 set_target_properties(mixxx-test PROPERTIES AUTOMOC ON)
 target_link_libraries(mixxx-test PRIVATE mixxx-lib mixxx-gitinfostore GTest::gtest GTest::gmock)

--- a/lib/libshout-idjc/CMakeLists.txt
+++ b/lib/libshout-idjc/CMakeLists.txt
@@ -40,15 +40,15 @@ target_compile_definitions(${PROJECT_NAME}
 option(WARNINGS_PEDANTIC "Let the compiler show even more warnings" OFF)
 if(MSVC)
   if(WARNINGS_PEDANTIC)
-    target_compile_options(${PROJECT_NAME} PUBLIC /W4)
+    target_compile_options(${PROJECT_NAME} PRIVATE /W4)
   else()
-    target_compile_options(${PROJECT_NAME} PUBLIC /W3)
-    target_compile_definitions(${PROJECT_NAME} PUBLIC _SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING _CRT_SECURE_NO_WARNINGS _WINSOCK_DEPRECATED_NO_WARNINGS)
+    target_compile_options(${PROJECT_NAME} PRIVATE /W3)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE _SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING _CRT_SECURE_NO_WARNINGS _WINSOCK_DEPRECATED_NO_WARNINGS)
   endif()
 else()
-  target_compile_options(${PROJECT_NAME} PUBLIC -Wall -Wextra $<$<COMPILE_LANGUAGE:CXX>:-Woverloaded-virtual> -Wfloat-conversion -Werror=return-type -Wno-unused-parameter)
+  target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra $<$<COMPILE_LANGUAGE:CXX>:-Woverloaded-virtual> -Wfloat-conversion -Werror=return-type -Wno-unused-parameter)
   if(WARNINGS_PEDANTIC)
-    target_compile_options(${PROJECT_NAME} PUBLIC -pedantic)
+    target_compile_options(${PROJECT_NAME} PRIVATE -pedantic)
   endif()
 endif()
 
@@ -72,7 +72,7 @@ else()
     if (NOT CMAKE_USE_PTHREADS_INIT)
         message (FATAL_ERROR "Building ${PROJECT_NAME} requires the pthread library and its development heraders")
     endif ()
-    target_link_libraries(${PROJECT_NAME} PUBLIC Threads::Threads)
+    target_link_libraries(${PROJECT_NAME} PRIVATE Threads::Threads)
 endif()
 
 # Configure shout.h
@@ -83,10 +83,10 @@ configure_file(include/shoutidjc/shout.h.in "${CMAKE_CURRENT_BINARY_DIR}/include
 # Required system dependencies
 # Ogg Vorbis
 find_package(Ogg REQUIRED)
-target_link_libraries(${PROJECT_NAME} PUBLIC Ogg::ogg)
+target_link_libraries(${PROJECT_NAME} PRIVATE Ogg::ogg)
 
 find_package(Vorbis REQUIRED)
-target_link_libraries(${PROJECT_NAME} PUBLIC Vorbis::vorbis Vorbis::vorbisenc)
+target_link_libraries(${PROJECT_NAME} PRIVATE Vorbis::vorbis Vorbis::vorbisenc)
 
 # OpenSSL
 find_package(OpenSSL REQUIRED)
@@ -201,8 +201,7 @@ endif()
 
 check_include_file(unistd.h HAVE_UNISTD_H)
 if(HAVE_UNISTD_H)
-    # PUBLIC because it is also used in the header file
-    target_compile_definitions(${PROJECT_NAME} PUBLIC HAVE_UNISTD_H)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_UNISTD_H)
 endif()
 
 check_include_file(poll "poll.h" HAVE_POLL)
@@ -212,8 +211,7 @@ endif()
 
 check_include_file(winsock2.h HAVE_WINSOCK2_H)
 if(HAVE_WINSOCK2_H)
-    # PUBLIC because it is also used in the header file
-    target_compile_definitions(${PROJECT_NAME} PUBLIC HAVE_WINSOCK2_H)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_WINSOCK2_H)
 
     check_symbol_exists(endhostent "winsock2.h;ws2tcpip.h" HAVE_ENDHOSTENT)
     check_symbol_exists(getaddrinfo "winsock2.h;ws2tcpip.h" HAVE_GETADDRINFO)
@@ -237,12 +235,10 @@ if(HAVE_GETNAMEINFO)
     target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_GETNAMEINFO)
 endif()
 if(HAVE_INET_ATON)
-    # PUBLIC because it is also used in the header file
-    target_compile_definitions(${PROJECT_NAME} PUBLIC HAVE_INET_ATON)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_INET_ATON)
 endif()
 if(HAVE_INET_PTON)
-    # PUBLIC because it is also used in the header file
-    target_compile_definitions(${PROJECT_NAME} PUBLIC HAVE_INET_PTON)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_INET_PTON)
 endif()
 if(HAVE_SETHOSTENT)
     target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_SETHOSTENT)

--- a/src/track/cueinfo.cpp
+++ b/src/track/cueinfo.cpp
@@ -9,6 +9,7 @@ namespace {
 void assertEndPosition(
         CueType type,
         std::optional<double> endPositionMillis) {
+    Q_UNUSED(endPositionMillis);
     switch (type) {
     case CueType::HotCue:
     case CueType::MainCue:

--- a/src/widget/wkey.cpp
+++ b/src/widget/wkey.cpp
@@ -63,6 +63,7 @@ void WKey::setCents() {
 }
 
 void WKey::keyNotationChanged(double dKeyNotationValue) {
+    Q_UNUSED(dKeyNotationValue);
     // NOTE: dKeyNotationValue is the index of the key notation type, NOT the
     // key itself, so we intentionally set the old value again to update the UI.
     setValue(m_dOldValue);


### PR DESCRIPTION
Now it is working. We need to change some definition to PRIVATE or PUBLIC. 
In case of libshout-idjc the dependent headers are no longer part of the public interface. I guess that must have changed in a version. 

To use the same headers in mixxx-test like in mixxx-lib all libraries of mixxx-lib needs to become public that all definition are inherited by mixxx-test and it uses that way the same definitions. This has the benefit that we are sure the mixxx-test is compiled with the same flags as the mixxx-lib. 

An alternative solution would be to maintain public and private headers in mixxx-lib. A maintenance burden I would like to avoid. 


