### PR TITLE
privat generated ui headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1692,9 +1692,7 @@ if(QT6)
 else()
   add_executable(mixxx WIN32 src/main.cpp)
 endif()
-# ugly hack to get #include "preferences/dialog/ui_dlgpreferencesdlg.h" to work in
-# src/qmldlgpreferencesproxy.h, which is #included from src/qmlapplication.h.
-target_include_directories(mixxx PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/mixxx-lib_autogen/include")
+
 set_target_properties(mixxx-lib PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY}")
 target_link_libraries(mixxx PRIVATE mixxx-lib mixxx-gitinfostore)
 

--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -22,6 +22,7 @@
 #include "mixer/playerinfo.h"
 #include "mixer/playermanager.h"
 #include "moc_coreservices.cpp"
+#include "preferences/dialog/dlgpreferences.h"
 #include "preferences/settingsmanager.h"
 #ifdef __MODPLUG__
 #include "preferences/dialog/dlgprefmodplug.h"
@@ -525,6 +526,19 @@ bool CoreServices::initializeDatabase() {
 
     kLogger.info() << "Initializing or upgrading database schema";
     return MixxxDb::initDatabaseSchema(dbConnection);
+}
+
+std::shared_ptr<QDialog> CoreServices::makeDlgPreferences() const {
+    std::shared_ptr<DlgPreferences> pDlgPreferences = std::make_shared<DlgPreferences>(
+            getScreensaverManager(),
+            nullptr,
+            getSoundManager(),
+            getControllerManager(),
+            getVinylControlManager(),
+            getEffectsManager(),
+            getSettingsManager(),
+            getLibrary());
+    return pDlgPreferences;
 }
 
 void CoreServices::finalize() {

--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -529,6 +529,8 @@ bool CoreServices::initializeDatabase() {
 }
 
 std::shared_ptr<QDialog> CoreServices::makeDlgPreferences() const {
+    // Note: We return here the base class pointer to make the coreservices.h usable
+    // in test classes where header included from dlgpreferences.h are not accessible.
     std::shared_ptr<DlgPreferences> pDlgPreferences = std::make_shared<DlgPreferences>(
             getScreensaverManager(),
             nullptr,

--- a/src/coreservices.h
+++ b/src/coreservices.h
@@ -105,6 +105,8 @@ class CoreServices : public QObject {
         return m_pScreensaverManager;
     }
 
+    std::shared_ptr<QDialog> makeDlgPreferences() const;
+
   signals:
     void initializationProgressUpdate(int progress, const QString& serviceName);
 

--- a/src/qml/qmlapplication.cpp
+++ b/src/qml/qmlapplication.cpp
@@ -57,15 +57,7 @@ QmlApplication::QmlApplication(
 
     // FIXME: DlgPreferences has some initialization logic that must be executed
     // before the GUI is shown, at least for the effects system.
-    std::shared_ptr<DlgPreferences> pDlgPreferences = std::make_shared<DlgPreferences>(
-            m_pCoreServices->getScreensaverManager(),
-            nullptr,
-            m_pCoreServices->getSoundManager(),
-            m_pCoreServices->getControllerManager(),
-            m_pCoreServices->getVinylControlManager(),
-            m_pCoreServices->getEffectsManager(),
-            m_pCoreServices->getSettingsManager(),
-            m_pCoreServices->getLibrary());
+    std::shared_ptr<QDialog> pDlgPreferences = m_pCoreServices->makeDlgPreferences();
     // Without this, QApplication will quit when the last QWidget QWindow is
     // closed because it does not take into account the window created by
     // the QQmlApplicationEngine.

--- a/src/qml/qmlapplication.cpp
+++ b/src/qml/qmlapplication.cpp
@@ -5,7 +5,6 @@
 #include "control/controlsortfiltermodel.h"
 #include "controllers/controllermanager.h"
 #include "moc_qmlapplication.cpp"
-#include "preferences/dialog/dlgpreferences.h"
 #include "qml/asyncimageprovider.h"
 #include "qml/qmlconfigproxy.h"
 #include "qml/qmlcontrolproxy.h"

--- a/src/qml/qmlapplication.cpp
+++ b/src/qml/qmlapplication.cpp
@@ -5,6 +5,7 @@
 #include "control/controlsortfiltermodel.h"
 #include "controllers/controllermanager.h"
 #include "moc_qmlapplication.cpp"
+#include "preferences/dialog/dlgpreferences.h"
 #include "qml/asyncimageprovider.h"
 #include "qml/qmlconfigproxy.h"
 #include "qml/qmlcontrolproxy.h"
@@ -56,7 +57,7 @@ QmlApplication::QmlApplication(
 
     // FIXME: DlgPreferences has some initialization logic that must be executed
     // before the GUI is shown, at least for the effects system.
-    m_pDlgPreferences = std::make_shared<DlgPreferences>(
+    std::shared_ptr<DlgPreferences> pDlgPreferences = std::make_shared<DlgPreferences>(
             m_pCoreServices->getScreensaverManager(),
             nullptr,
             m_pCoreServices->getSoundManager(),
@@ -68,7 +69,7 @@ QmlApplication::QmlApplication(
     // Without this, QApplication will quit when the last QWidget QWindow is
     // closed because it does not take into account the window created by
     // the QQmlApplicationEngine.
-    m_pDlgPreferences->setAttribute(Qt::WA_QuitOnClose, false);
+    pDlgPreferences->setAttribute(Qt::WA_QuitOnClose, false);
 
     // Any uncreateable non-singleton types registered here require arguments
     // that we don't want to expose to QML directly. Instead, they can be
@@ -78,7 +79,7 @@ QmlApplication::QmlApplication(
     // system, which would improve nothing, or we had to expose them as
     // singletons to that they can be accessed by components instantiated by
     // QML, which would also be suboptimal.
-    QmlDlgPreferencesProxy::s_pInstance = new QmlDlgPreferencesProxy(m_pDlgPreferences, this);
+    QmlDlgPreferencesProxy::s_pInstance = new QmlDlgPreferencesProxy(pDlgPreferences, this);
     QmlEffectsManagerProxy::s_pInstance = new QmlEffectsManagerProxy(
             pCoreServices->getEffectsManager(), this);
     QmlPlayerManagerProxy::s_pInstance =

--- a/src/qml/qmlapplication.h
+++ b/src/qml/qmlapplication.h
@@ -5,7 +5,6 @@
 #include <QQmlApplicationEngine>
 
 #include "coreservices.h"
-#include "preferences/dialog/dlgpreferences.h"
 
 namespace mixxx {
 namespace qml {
@@ -28,7 +27,6 @@ class QmlApplication : public QObject {
 
     std::unique_ptr<QQmlApplicationEngine> m_pAppEngine;
     QFileSystemWatcher m_fileWatcher;
-    std::shared_ptr<DlgPreferences> m_pDlgPreferences;
 };
 
 } // namespace qml

--- a/src/qml/qmldlgpreferencesproxy.cpp
+++ b/src/qml/qmldlgpreferencesproxy.cpp
@@ -6,7 +6,8 @@ namespace mixxx {
 namespace qml {
 
 QmlDlgPreferencesProxy::QmlDlgPreferencesProxy(
-        std::shared_ptr<DlgPreferences> pDlgPreferences, QObject* parent)
+        std::shared_ptr<QDialog> pDlgPreferences,
+        QObject* parent)
         : QObject(parent),
           m_pDlgPreferences(pDlgPreferences) {
 }
@@ -17,7 +18,8 @@ void QmlDlgPreferencesProxy::show() {
 
 // static
 QmlDlgPreferencesProxy* QmlDlgPreferencesProxy::create(
-        QQmlEngine* pQmlEngine, QJSEngine* pJsEngine) {
+        QQmlEngine* pQmlEngine,
+        QJSEngine* pJsEngine) {
     Q_UNUSED(pQmlEngine);
 
     // The implementation of this method is mostly taken from the code example

--- a/src/qml/qmldlgpreferencesproxy.h
+++ b/src/qml/qmldlgpreferencesproxy.h
@@ -1,9 +1,9 @@
 #pragma once
+
+#include <QDialog>
 #include <QObject>
 #include <QtQml>
 #include <memory>
-
-#include "preferences/dialog/dlgpreferences.h"
 
 namespace mixxx {
 namespace qml {
@@ -14,7 +14,7 @@ class QmlDlgPreferencesProxy : public QObject {
     QML_SINGLETON
   public:
     explicit QmlDlgPreferencesProxy(
-            std::shared_ptr<DlgPreferences> pDlgPreferences,
+            std::shared_ptr<QDialog> pDlgPreferences,
             QObject* parent = nullptr);
 
     Q_INVOKABLE void show();
@@ -24,7 +24,7 @@ class QmlDlgPreferencesProxy : public QObject {
 
   private:
     static inline QJSEngine* s_pJsEngine = nullptr;
-    std::shared_ptr<DlgPreferences> m_pDlgPreferences;
+    std::shared_ptr<QDialog> m_pDlgPreferences;
 };
 
 } // namespace qml


### PR DESCRIPTION
This makes the ui_dlgpreferencesdlg.h private by moving the instantiation of the DlgPreferences to CoreServices.

This fixes one issue from https://github.com/mixxxdj/mixxx/pull/11407