### PR TITLE
SearchQueryParser: Add "OR" search operator

### DIFF
--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -122,14 +122,6 @@ QString AndNode::toSql() const {
 }
 
 bool OrNode::match(const TrackPointer& pTrack) const {
-    // An empty OR node would always evaluate to false
-    // which is inconsistent with the generated SQL query!
-    VERIFY_OR_DEBUG_ASSERT(!m_nodes.empty()) {
-        // Evaluate to true even if the correct choice would
-        // be false to keep the evaluation consistent with
-        // the generated SQL query.
-        return true;
-    }
     for (const auto& pNode : m_nodes) {
         if (pNode->match(pTrack)) {
             return true;
@@ -139,6 +131,9 @@ bool OrNode::match(const TrackPointer& pTrack) const {
 }
 
 QString OrNode::toSql() const {
+    if (m_nodes.empty()) {
+        return "FALSE";
+    }
     QStringList queryFragments;
     queryFragments.reserve(static_cast<int>(m_nodes.size()));
     for (const auto& pNode : m_nodes) {

--- a/src/library/searchqueryparser.cpp
+++ b/src/library/searchqueryparser.cpp
@@ -266,7 +266,7 @@ void SearchQueryParser::parseTokens(QStringList tokens,
 }
 
 std::unique_ptr<AndNode> SearchQueryParser::parseAndNode(const QString& query) const {
-    auto pQuery(std::make_unique<AndNode>());
+    auto pQuery = std::make_unique<AndNode>();
 
     QStringList tokens = query.split(" ");
     parseTokens(std::move(tokens), pQuery.get());
@@ -275,7 +275,7 @@ std::unique_ptr<AndNode> SearchQueryParser::parseAndNode(const QString& query) c
 }
 
 std::unique_ptr<OrNode> SearchQueryParser::parseOrNode(const QString& query) const {
-    auto pQuery(std::make_unique<OrNode>());
+    auto pQuery = std::make_unique<OrNode>();
 
     QStringList rawAndNodes = query.split("|");
     for (const QString& rawAndNode : rawAndNodes) {

--- a/src/library/searchqueryparser.cpp
+++ b/src/library/searchqueryparser.cpp
@@ -8,6 +8,7 @@
 
 constexpr char kNegatePrefix[] = "-";
 constexpr char kFuzzyPrefix[] = "~";
+constexpr char kOrOperator[] = "|";
 // see https://stackoverflow.com/questions/1310473/regex-matching-spaces-but-not-in-strings
 const QRegularExpression kSplitIntoWordsRegexp = QRegularExpression(
         QStringLiteral(" (?=[^\"]*(\"[^\"]*\"[^\"]*)*$)"));
@@ -277,7 +278,7 @@ std::unique_ptr<AndNode> SearchQueryParser::parseAndNode(const QString& query) c
 std::unique_ptr<OrNode> SearchQueryParser::parseOrNode(const QString& query) const {
     auto pQuery = std::make_unique<OrNode>();
 
-    QStringList rawAndNodes = query.split("|");
+    QStringList rawAndNodes = query.split(kOrOperator);
     for (const QString& rawAndNode : rawAndNodes) {
         if (!rawAndNode.isEmpty()) {
             pQuery->addNode(parseAndNode(rawAndNode));

--- a/src/library/searchqueryparser.cpp
+++ b/src/library/searchqueryparser.cpp
@@ -10,13 +10,13 @@ constexpr char kNegatePrefix[] = "-";
 constexpr char kFuzzyPrefix[] = "~";
 
 // see https://stackoverflow.com/questions/1310473/regex-matching-spaces-but-not-in-strings
-#define STRING_QUOTE_SUFFIX "(?=[^\"]*(\"[^\"]*\"[^\"]*)*$)"
+#define QUOTED_STRING_LOOKAHEAD "(?=[^\"]*(\"[^\"]*\"[^\"]*)*$)"
 
 const QRegularExpression kSplitIntoWordsRegexp = QRegularExpression(
-        QStringLiteral(" " STRING_QUOTE_SUFFIX));
+        QStringLiteral(" " QUOTED_STRING_LOOKAHEAD));
 
 const QRegularExpression kSplitOnOrOperatorRegexp = QRegularExpression(
-        QStringLiteral("\\|" STRING_QUOTE_SUFFIX));
+        QStringLiteral("\\|" QUOTED_STRING_LOOKAHEAD));
 
 SearchQueryParser::SearchQueryParser(TrackCollection* pTrackCollection, QStringList searchColumns)
         : m_pTrackCollection(pTrackCollection),

--- a/src/library/searchqueryparser.cpp
+++ b/src/library/searchqueryparser.cpp
@@ -16,7 +16,7 @@ const QRegularExpression kSplitIntoWordsRegexp = QRegularExpression(
         QStringLiteral(" " QUOTED_STRING_LOOKAHEAD));
 
 const QRegularExpression kSplitOnOrOperatorRegexp = QRegularExpression(
-        QStringLiteral("\\|" QUOTED_STRING_LOOKAHEAD));
+        QStringLiteral("(?:\\||\\bOR\\b)" QUOTED_STRING_LOOKAHEAD));
 
 SearchQueryParser::SearchQueryParser(TrackCollection* pTrackCollection, QStringList searchColumns)
         : m_pTrackCollection(pTrackCollection),

--- a/src/library/searchqueryparser.cpp
+++ b/src/library/searchqueryparser.cpp
@@ -265,7 +265,7 @@ void SearchQueryParser::parseTokens(QStringList tokens,
     }
 }
 
-std::unique_ptr<AndNode> SearchQueryParser::parseAndNode(QString query) const {
+std::unique_ptr<AndNode> SearchQueryParser::parseAndNode(const QString& query) const {
     auto pQuery(std::make_unique<AndNode>());
 
     QStringList tokens = query.split(" ");
@@ -274,13 +274,13 @@ std::unique_ptr<AndNode> SearchQueryParser::parseAndNode(QString query) const {
     return pQuery;
 }
 
-std::unique_ptr<OrNode> SearchQueryParser::parseOrNode(QString query) const {
+std::unique_ptr<OrNode> SearchQueryParser::parseOrNode(const QString& query) const {
     auto pQuery(std::make_unique<OrNode>());
 
     QStringList rawAndNodes = query.split("|");
     for (const QString& rawAndNode : rawAndNodes) {
         if (!rawAndNode.isEmpty()) {
-            pQuery->addNode(parseAndNode(std::move(rawAndNode)));
+            pQuery->addNode(parseAndNode(rawAndNode));
         }
     }
 

--- a/src/library/searchqueryparser.h
+++ b/src/library/searchqueryparser.h
@@ -30,8 +30,8 @@ class SearchQueryParser {
     void parseTokens(QStringList tokens,
                      AndNode* pQuery) const;
 
-    std::unique_ptr<AndNode> parseAndNode(QString query) const;
-    std::unique_ptr<OrNode> parseOrNode(QString query) const;
+    std::unique_ptr<AndNode> parseAndNode(const QString& query) const;
+    std::unique_ptr<OrNode> parseOrNode(const QString& query) const;
 
     QString getTextArgument(QString argument,
                             QStringList* tokens) const;

--- a/src/library/searchqueryparser.h
+++ b/src/library/searchqueryparser.h
@@ -3,6 +3,7 @@
 #include <QRegularExpression>
 #include <QString>
 #include <QtSql>
+#include <memory>
 
 #include "library/searchquery.h"
 #include "library/trackcollection.h"
@@ -28,6 +29,9 @@ class SearchQueryParser {
   private:
     void parseTokens(QStringList tokens,
                      AndNode* pQuery) const;
+
+    std::unique_ptr<AndNode> parseAndNode(QString query) const;
+    std::unique_ptr<OrNode> parseOrNode(QString query) const;
 
     QString getTextArgument(QString argument,
                             QStringList* tokens) const;

--- a/src/test/searchqueryparsertest.cpp
+++ b/src/test/searchqueryparsertest.cpp
@@ -1054,6 +1054,36 @@ TEST_F(SearchQueryParserTest, EmptySpelledOutOrOperator) {
     EXPECT_FALSE(pQuery->match(pTrack));
 }
 
+TEST_F(SearchQueryParserTest, PrefixedSpelledOutOrOperator) {
+    m_parser.setSearchColumns({"title"});
+
+    // 'OR' needs to have a boundary on the left to be parsed as an operator
+    auto pQuery = m_parser.parseQuery("aOR", QString());
+
+    TrackPointer pTrackA = newTestTrack();
+    pTrackA->setTitle("aOR");
+    EXPECT_TRUE(pQuery->match(pTrackA));
+
+    TrackPointer pTrackB = newTestTrack();
+    pTrackB->setTitle("a");
+    EXPECT_FALSE(pQuery->match(pTrackB));
+}
+
+TEST_F(SearchQueryParserTest, SuffixedSpelledOutOrOperator) {
+    m_parser.setSearchColumns({"title"});
+
+    // 'OR' needs to have a boundary on the right to be parsed as an operator
+    auto pQuery = m_parser.parseQuery("ORa", QString());
+
+    TrackPointer pTrackA = newTestTrack();
+    pTrackA->setTitle("ORa");
+    EXPECT_TRUE(pQuery->match(pTrackA));
+
+    TrackPointer pTrackB = newTestTrack();
+    pTrackB->setTitle("a");
+    EXPECT_FALSE(pQuery->match(pTrackB));
+}
+
 TEST_F(SearchQueryParserTest, LowercaseOr) {
     m_parser.setSearchColumns({"title"});
 

--- a/src/test/searchqueryparsertest.cpp
+++ b/src/test/searchqueryparsertest.cpp
@@ -1046,6 +1046,52 @@ TEST_F(SearchQueryParserTest, EmptyOrOperator) {
     EXPECT_FALSE(pQuery->match(pTrack));
 }
 
+TEST_F(SearchQueryParserTest, EmptySpelledOutOrOperator) {
+    auto pQuery = m_parser.parseQuery("OR", QString());
+
+    // An empty OR query matches no tracks.
+    TrackPointer pTrack = Track::newTemporary();
+    EXPECT_FALSE(pQuery->match(pTrack));
+}
+
+TEST_F(SearchQueryParserTest, LowercaseOr) {
+    m_parser.setSearchColumns({"title"});
+
+    // Lowercase 'or' is not parsed as an operator and treated literally instead
+    auto pQuery = m_parser.parseQuery("or", QString());
+
+    TrackPointer pTrackA = newTestTrack();
+    pTrackA->setTitle("or");
+    EXPECT_TRUE(pQuery->match(pTrackA));
+
+    TrackPointer pTrackB = newTestTrack();
+    pTrackB->setTitle("and");
+    EXPECT_FALSE(pQuery->match(pTrackB));
+
+    TrackPointer pTrackC = newTestTrack();
+    pTrackC->setTitle("OR");
+    EXPECT_TRUE(pQuery->match(pTrackC));
+}
+
+TEST_F(SearchQueryParserTest, QuotedOr) {
+    m_parser.setSearchColumns({"title"});
+
+    // Quoted uppercase 'OR' is treated literally too.
+    auto pQuery = m_parser.parseQuery("\"OR\"", QString());
+
+    TrackPointer pTrackA = newTestTrack();
+    pTrackA->setTitle("or");
+    EXPECT_TRUE(pQuery->match(pTrackA));
+
+    TrackPointer pTrackB = newTestTrack();
+    pTrackB->setTitle("and");
+    EXPECT_FALSE(pQuery->match(pTrackB));
+
+    TrackPointer pTrackC = newTestTrack();
+    pTrackC->setTitle("OR");
+    EXPECT_TRUE(pQuery->match(pTrackC));
+}
+
 TEST_F(SearchQueryParserTest, DurationSearchWithOrOperator) {
     // Query is intentionally "misformatted" to ensure whitespace-invariance
     auto pQuery = m_parser.parseQuery("duration:<39|duration:>=2:00", QString());

--- a/src/test/searchqueryparsertest.cpp
+++ b/src/test/searchqueryparsertest.cpp
@@ -1041,9 +1041,9 @@ TEST_F(SearchQueryParserTest, QueryIsLessSpecific) {
 TEST_F(SearchQueryParserTest, EmptyOrOperator) {
     auto pQuery = m_parser.parseQuery("|", QString());
 
-    // An empty query matches all tracks.
+    // An empty OR query matches no tracks.
     TrackPointer pTrack = Track::newTemporary();
-    EXPECT_TRUE(pQuery->match(pTrack));
+    EXPECT_FALSE(pQuery->match(pTrack));
 }
 
 TEST_F(SearchQueryParserTest, DurationSearchWithOrOperator) {

--- a/src/test/searchqueryparsertest.cpp
+++ b/src/test/searchqueryparsertest.cpp
@@ -1109,3 +1109,49 @@ TEST_F(SearchQueryParserTest, MultiWayOrOperator) {
     pTrackI->setComment("Room");
     EXPECT_TRUE(pQuery->match(pTrackI));
 }
+
+TEST_F(SearchQueryParserTest, QuotedOrOperator) {
+    m_parser.setSearchColumns({"title", "comment"});
+
+    auto pQuery = m_parser.parseQuery("title:\"a | contrived|example\" house | techno", QString());
+
+    TrackPointer pTrackA = newTestTrack();
+    pTrackA->setTitle("a");
+    EXPECT_FALSE(pQuery->match(pTrackA));
+
+    TrackPointer pTrackB = newTestTrack();
+    pTrackB->setTitle("a  contrived example");
+    EXPECT_FALSE(pQuery->match(pTrackB));
+
+    TrackPointer pTrackC = newTestTrack();
+    pTrackC->setTitle("a | contrived|example");
+    EXPECT_FALSE(pQuery->match(pTrackC));
+
+    TrackPointer pTrackD = newTestTrack();
+    pTrackD->setTitle("a | contrived|example");
+    pTrackD->setComment("house");
+    EXPECT_TRUE(pQuery->match(pTrackD));
+
+    TrackPointer pTrackE = newTestTrack();
+    pTrackE->setTitle("house");
+    EXPECT_FALSE(pQuery->match(pTrackE));
+
+    TrackPointer pTrackF = newTestTrack();
+    pTrackF->setTitle("techno");
+    EXPECT_TRUE(pQuery->match(pTrackF));
+
+    TrackPointer pTrackG = newTestTrack();
+    pTrackG->setTitle("a contrived|example");
+    pTrackG->setComment("house");
+    EXPECT_FALSE(pQuery->match(pTrackG));
+
+    TrackPointer pTrackH = newTestTrack();
+    pTrackH->setTitle("a  | contrived|example");
+    pTrackH->setComment("house");
+    EXPECT_FALSE(pQuery->match(pTrackH));
+
+    TrackPointer pTrackI = newTestTrack();
+    pTrackI->setTitle("a | contrived|example and more");
+    pTrackI->setComment("house");
+    EXPECT_TRUE(pQuery->match(pTrackI));
+}


### PR DESCRIPTION
### Fixes #8881

This adds `|` and (uppercase) `OR` as syntax for the OR operator in search queries. Thus queries such as `house | disco` or equivalently `house OR disco` will now yield the combined results from querying `house` and `disco`.

Both `|` and `OR` have strong precedent, e.g. with Google using these operators[^1]. Especially `|` is terse, easy to read/write and familiar to technical users.

[^1]: https://ahrefs.com/blog/google-advanced-search-operators