### PR TITLE
Search: add special BPM filters

### DIFF
--- a/src/defs_urls.h
+++ b/src/defs_urls.h
@@ -55,6 +55,8 @@
     MIXXX_MANUAL_URL "/chapters/user_interface.html#using-cue-modes"
 #define MIXXX_MANUAL_SYNC_MODES_URL \
     MIXXX_MANUAL_URL "/chapters/djing_with_mixxx#sync-lock-with-dynamic-tempo"
+#define MIXXX_MANUAL_TRACK_SEARCH_URL \
+    MIXXX_MANUAL_URL "/chapters/library.html#finding-tracks-search"
 #define MIXXX_MANUAL_BEATS_URL \
     MIXXX_MANUAL_URL "/chapters/preferences.html#beat-detection"
 #define MIXXX_MANUAL_KEY_URL \

--- a/src/library/library_prefs.cpp
+++ b/src/library/library_prefs.cpp
@@ -48,6 +48,11 @@ const ConfigKey mixxx::library::prefs::kSearchDebouncingTimeoutMillisConfigKey =
                 mixxx::library::prefs::kConfigGroup,
                 QStringLiteral("SearchDebouncingTimeoutMillis")};
 
+const ConfigKey mixxx::library::prefs::kSearchBpmFuzzyRangeConfigKey =
+        ConfigKey{
+                mixxx::library::prefs::kConfigGroup,
+                QStringLiteral("search_bpm_fuzzy_range")};
+
 const ConfigKey mixxx::library::prefs::kEnableSearchCompletionsConfigKey =
         ConfigKey{
                 mixxx::library::prefs::kConfigGroup,

--- a/src/library/library_prefs.h
+++ b/src/library/library_prefs.h
@@ -20,6 +20,8 @@ extern const ConfigKey kTrackDoubleClickActionConfigKey;
 
 extern const ConfigKey kSearchDebouncingTimeoutMillisConfigKey;
 
+extern const ConfigKey kSearchBpmFuzzyRangeConfigKey;
+
 extern const ConfigKey kEnableSearchCompletionsConfigKey;
 
 extern const ConfigKey kEnableSearchHistoryShortcutsConfigKey;

--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -24,6 +24,8 @@ const QRegularExpression kDurationRegex(QStringLiteral("^(\\d+)(m|:)?([0-5]?\\d)
 // > are not necessarily greedy.
 const QRegularExpression kNumericOperatorRegex(QStringLiteral("^(<=|>=|=|<|>)(.*)$"));
 
+const QRegularExpression kNullRegex(QStringLiteral("^([0.,]+)$"));
+
 QVariant getTrackValueForColumn(const TrackPointer& pTrack, const QString& column) {
     if (column == LIBRARYTABLE_ARTIST) {
         return pTrack->getArtist();
@@ -530,7 +532,10 @@ BpmFilterNode::BpmFilterNode(QString& argument, bool fuzzy, bool negate)
           m_bpmHalfUpper(0.0),
           m_bpmDoubleLower(0.0),
           m_bpmDoubleUpper(0.0) {
-    if (argument == kMissingFieldSearchTerm) {
+    QRegularExpressionMatch nullMatch = kNullRegex.match(argument);
+    if (argument == kMissingFieldSearchTerm || // explicit empty
+            argument == "-" ||                 // displayed in the BPM column
+            nullMatch.hasMatch()) {            // displayed in the BPM widgets
         m_matchMode = MatchMode::Null;
         return;
     }

--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -645,10 +645,19 @@ BpmFilterNode::BpmFilterNode(QString& argument, bool fuzzy, bool negate)
         // We find everything that is displayed as 127.** in the library
         m_rangeLower = bpm - kLibraryRoundRange; // [126.95
         m_rangeUpper = bpm + 1;                  // ]128
-        // In case bpm / 2 is a fractional, we include the *.0 value neighbours
-        // since fractional bpm values are less common in some genres.
-        m_bpmHalfLower = floor(bpm / 2); // [63
-        m_bpmHalfUpper = ceil(bpm / 2);  // 64]
+
+        double halfBpm = bpm / 2;
+        if (floor(halfBpm) != halfBpm) {
+            // In case bpm / 2 is a fractional, we include the *.0 value neighbours
+            // since fractional bpm values are less common in some genres.
+            m_bpmHalfLower = floor(halfBpm) - kLibraryRoundRange; // [62.95
+        } else {
+            // Here we are for instance with 126
+            // We find everything that is displayed as 63.** in the library
+            m_bpmHalfLower = halfBpm - kLibraryRoundRange; //        [62.95
+        }
+        m_bpmHalfUpper = halfBpm + 1; //                                ]64
+
         // We find everything which would be found when editing the beat grid via / 2
         m_bpmDoubleLower = (bpm * 2) - kLibraryRoundRange; // [253.95
         m_bpmDoubleUpper = m_rangeUpper * 2;               // ]256
@@ -729,7 +738,7 @@ QString BpmFilterNode::toSql() const {
     case MatchMode::HalveDouble: {
         QStringList searchClauses;
         searchClauses << rangeUpperExclusiveSqlString(m_rangeLower, m_rangeUpper);
-        searchClauses << rangeSqlString(m_bpmHalfLower, m_bpmHalfUpper);
+        searchClauses << rangeUpperExclusiveSqlString(m_bpmHalfLower, m_bpmHalfUpper);
         searchClauses << rangeUpperExclusiveSqlString(m_bpmDoubleLower, m_bpmDoubleUpper);
         return concatSqlClauses(searchClauses, "OR");
     }

--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -558,7 +558,7 @@ BpmFilterNode::BpmFilterNode(QString& argument, bool fuzzy, bool negate)
     double bpm = argument.toDouble(&isDouble);
     if (isDouble) {
         // Check if the arg has a decimal separator (even if no digits after that)
-        bool strictMatch = argument.contains('.');
+        bool strictMatch = argument.split('.', Qt::SkipEmptyParts).length() > 1;
         if (fuzzy) {
             // fuzzy search +- n%
             m_matchMode = MatchMode::Fuzzy;

--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -516,6 +516,9 @@ BpmFilterNode::BpmFilterNode(QString& argument, bool fuzzy, bool negate)
         argument = opMatch.captured(2);
     }
 
+    // Replace the locale's decimal separator with .
+    // This is handy if numbers are typed with the numpad.
+    argument.replace(',', '.');
     bool isDouble = false;
     const double bpm = argument.toDouble(&isDouble);
     if (isDouble) {

--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -508,8 +508,8 @@ BpmFilterNode::BpmFilterNode(QString& argument, bool fuzzy, bool negate)
     if (isDouble) {
         if (m_fuzzy) {
             // fuzzy search
-            m_rangeLower = std::floor((1 - kRelativeBpmRange) * bpm);
-            m_rangeUpper = std::ceil((1 + kRelativeBpmRange) * bpm);
+            m_rangeLower = floor((1 - kRelativeBpmRange) * bpm);
+            m_rangeUpper = ceil((1 + kRelativeBpmRange) * bpm);
             m_isRangeQuery = true;
         } else if (!opMatch.hasMatch() && !m_negate) {
             // Simple 'bpm:NNN' search.

--- a/src/library/searchquery.h
+++ b/src/library/searchquery.h
@@ -195,29 +195,28 @@ class BpmFilterNode : public QueryNode {
 
     BpmFilterNode(QString& argument, bool fuzzy, bool negate = false);
 
+    enum class MatchMode {
+        Invalid,
+        Null,
+        Exact,
+        Fuzzy,
+        Range,
+        HalveDouble,
+        Operator,
+    };
+
     // Allows WSearchRelatedTracksMenu to construct the QAction title
-    bool isRangeQuery(double* low, double* high) const {
-        if (m_isRangeQuery) {
-            *low = m_rangeLower;
-            *high = m_rangeUpper;
-            return true;
-        }
-        return false;
+    std::pair<double, double> getBpmRange() const {
+        return std::pair<double, double>(m_rangeLower, m_rangeUpper);
     }
 
     QString toSql() const override;
 
   private:
-    void ifDecimalsSetRange(const QString& argument, double bpm);
     bool match(const TrackPointer& pTrack) const override;
 
-    bool m_fuzzy;
-    bool m_negate;
+    MatchMode m_matchMode;
 
-    bool m_isNullQuery;
-    bool m_isOperatorQuery;
-    bool m_isRangeQuery;
-    bool m_isHalfDoubleQuery;
     QString m_operator;
 
     double m_bpm;

--- a/src/library/searchquery.h
+++ b/src/library/searchquery.h
@@ -199,9 +199,11 @@ class BpmFilterNode : public QueryNode {
         Invalid,
         Null,
         Exact,
+        ExactStrict,
         Fuzzy,
         Range,
         HalveDouble,
+        HalveDoubleStrict,
         Operator,
     };
 

--- a/src/library/searchquery.h
+++ b/src/library/searchquery.h
@@ -184,21 +184,34 @@ class DurationFilterNode : public NumericFilterNode {
     double parse(const QString& arg, bool* ok) override;
 };
 
+// BPM filter that supports fuzzy matching via ~ prefix.
+// If no operator is provided (bpm:123) it also finds half & double BPM matches.
+// Half/double values aren't integers, int ranges are used. E.g. bpm:123.1 finds
+// 61-61, 123.1 and 246-247 BPM
 class BpmFilterNode : public QueryNode {
   public:
-    BpmFilterNode(QString& argument);
+    BpmFilterNode(QString& argument, bool fuzzy, bool negate);
 
   private:
     bool match(const TrackPointer& pTrack) const override;
     QString toSql() const override;
 
+    bool m_fuzzy;
+    bool m_negate;
+
     bool m_isNullQuery;
     bool m_isOperatorQuery;
     bool m_isRangeQuery;
+    bool m_isHalfDoubleQuery;
     QString m_operator;
+
     double m_bpm;
     double m_rangeLower;
     double m_rangeUpper;
+    double m_bpmHalfLower;
+    double m_bpmHalfUpper;
+    double m_bpmDoubleLower;
+    double m_bpmDoubleUpper;
 };
 
 class KeyFilterNode : public QueryNode {

--- a/src/library/searchquery.h
+++ b/src/library/searchquery.h
@@ -193,11 +193,22 @@ class BpmFilterNode : public QueryNode {
     static constexpr double kRelativeRangeDefault = 0.06;
     static void setBpmRelativeRange(double range);
 
-    BpmFilterNode(QString& argument, bool fuzzy, bool negate);
+    BpmFilterNode(QString& argument, bool fuzzy, bool negate = false);
+
+    // Allows WSearchRelatedTracksMenu to construct the QAction title
+    bool isRangeQuery(double* low, double* high) const {
+        if (m_isRangeQuery) {
+            *low = m_rangeLower;
+            *high = m_rangeUpper;
+            return true;
+        }
+        return false;
+    }
+
+    QString toSql() const override;
 
   private:
     bool match(const TrackPointer& pTrack) const override;
-    QString toSql() const override;
 
     bool m_fuzzy;
     bool m_negate;

--- a/src/library/searchquery.h
+++ b/src/library/searchquery.h
@@ -197,14 +197,14 @@ class BpmFilterNode : public QueryNode {
 
     enum class MatchMode {
         Invalid,
-        Null,
-        Exact,
-        ExactStrict,
-        Fuzzy,
-        Range,
-        HalveDouble,
-        HalveDoubleStrict,
-        Operator,
+        Null,              // bpm:- | bpm:000.0 | bpm:0,0 | bpm:""
+        Explicit,          // bpm:=120
+        ExplicitStrict,    // bpm:=120.0
+        Fuzzy,             // ~bpm:120
+        Range,             // bpm:120-130
+        HalveDouble,       // bpm:120
+        HalveDoubleStrict, // bpm:120.0
+        Operator,          // bpm:<=120
     };
 
     // Allows WSearchRelatedTracksMenu to construct the QAction title

--- a/src/library/searchquery.h
+++ b/src/library/searchquery.h
@@ -184,6 +184,23 @@ class DurationFilterNode : public NumericFilterNode {
     double parse(const QString& arg, bool* ok) override;
 };
 
+class BpmFilterNode : public QueryNode {
+  public:
+    BpmFilterNode(QString& argument);
+
+  private:
+    bool match(const TrackPointer& pTrack) const override;
+    QString toSql() const override;
+
+    bool m_isNullQuery;
+    bool m_isOperatorQuery;
+    bool m_isRangeQuery;
+    QString m_operator;
+    double m_bpm;
+    double m_rangeLower;
+    double m_rangeUpper;
+};
+
 class KeyFilterNode : public QueryNode {
   public:
     KeyFilterNode(mixxx::track::io::key::ChromaticKey key, bool fuzzy);

--- a/src/library/searchquery.h
+++ b/src/library/searchquery.h
@@ -190,6 +190,9 @@ class DurationFilterNode : public NumericFilterNode {
 // 61-61, 123.1 and 246-247 BPM
 class BpmFilterNode : public QueryNode {
   public:
+    static constexpr double kRelativeRangeDefault = 0.06;
+    static void setBpmRelativeRange(double range);
+
     BpmFilterNode(QString& argument, bool fuzzy, bool negate);
 
   private:
@@ -212,6 +215,8 @@ class BpmFilterNode : public QueryNode {
     double m_bpmHalfUpper;
     double m_bpmDoubleLower;
     double m_bpmDoubleUpper;
+
+    static double s_relativeRange;
 };
 
 class KeyFilterNode : public QueryNode {

--- a/src/library/searchquery.h
+++ b/src/library/searchquery.h
@@ -208,6 +208,7 @@ class BpmFilterNode : public QueryNode {
     QString toSql() const override;
 
   private:
+    void ifDecimalsSetRange(const QString& argument, double bpm);
     bool match(const TrackPointer& pTrack) const override;
 
     bool m_fuzzy;

--- a/src/library/searchqueryparser.h
+++ b/src/library/searchqueryparser.h
@@ -47,10 +47,8 @@ class SearchQueryParser {
     QStringList m_textFilters;
     QStringList m_numericFilters;
     QStringList m_specialFilters;
-    QStringList m_allFilters;
     QHash<QString, QStringList> m_fieldToSqlColumns;
 
-    QRegularExpression m_fuzzyMatcher;
     QRegularExpression m_textFilterMatcher;
     QRegularExpression m_crateFilterMatcher;
     QRegularExpression m_numericFilterMatcher;

--- a/src/library/searchqueryparser.h
+++ b/src/library/searchqueryparser.h
@@ -39,7 +39,8 @@ class SearchQueryParser {
     };
 
     TextArgumentResult getTextArgument(QString argument,
-            QStringList* tokens) const;
+            QStringList* tokens,
+            bool removeLeadingEqualsSign = true) const;
 
     TrackCollection* m_pTrackCollection;
     QStringList m_queryColumns;

--- a/src/preferences/dialog/dlgprefdeck.cpp
+++ b/src/preferences/dialog/dlgprefdeck.cpp
@@ -702,13 +702,16 @@ void DlgPrefDeck::slotApply() {
             m_bCloneDeckOnLoadDoubleTap);
 
     // Set rate range
-    setRateRangeForAllDecks(m_iRateRangePercent);
+    // Set the config value before setting the CO values in setRateRangeForAllDecks()
+    // because a proxy in DlgPrefLibrary listens to [Channe1],rate_range changes
+    // in order to update the fuzzy BPM range with the new value of "RateRangePercent".
     m_pConfig->setValue(ConfigKey("[Controls]", "RateRangePercent"),
                         m_iRateRangePercent);
+    setRateRangeForAllDecks(m_iRateRangePercent);
 
-    setRateDirectionForAllDecks(m_bRateDownIncreasesSpeed);
     m_pConfig->setValue(ConfigKey("[Controls]", "RateDir"),
             m_bRateDownIncreasesSpeed);
+    setRateDirectionForAllDecks(m_bRateDownIncreasesSpeed);
 
     BaseTrackPlayer::TrackLoadReset configSPAutoReset = BaseTrackPlayer::RESET_NONE;
 

--- a/src/preferences/dialog/dlgprefdeck.cpp
+++ b/src/preferences/dialog/dlgprefdeck.cpp
@@ -259,6 +259,10 @@ DlgPrefDeck::DlgPrefDeck(QWidget* parent, UserSettingsPointer pConfig)
         m_iRateRangePercent = kDefaultRateRangePercent;
     }
     setRateRangeForAllDecks(m_iRateRangePercent);
+    // Write verified value back to config so DlgPrefLibrary can use it to
+    // calculate the 'fuzzy' BPM search range
+    m_pConfig->set(ConfigKey("[Controls]", "RateRangePercent"),
+            ConfigValue{m_iRateRangePercent});
 
     // Key lock mode
     connect(buttonGroupKeyLockMode,

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -9,6 +9,7 @@
 #include <QStandardPaths>
 #include <QUrl>
 
+#include "control/controlproxy.h"
 #include "defs_urls.h"
 #include "library/basetracktablemodel.h"
 #include "library/dlgtrackmetadataexport.h"
@@ -36,7 +37,9 @@ DlgPrefLibrary::DlgPrefLibrary(
           m_pConfig(pConfig),
           m_pLibrary(pLibrary),
           m_bAddedDirectory(false),
-          m_iOriginalTrackTableRowHeight(Library::kDefaultRowHeightPx) {
+          m_iOriginalTrackTableRowHeight(Library::kDefaultRowHeightPx),
+          m_pRateRangeDeck1(make_parented<ControlProxy>(
+                  QStringLiteral("[Channel1]"), QStringLiteral("rateRange"), this)) {
     setupUi(this);
 
     connect(this,
@@ -105,6 +108,13 @@ DlgPrefLibrary::DlgPrefLibrary(
             QOverload<int>::of(&QComboBox::currentIndexChanged),
             this,
             &DlgPrefLibrary::slotBpmRangeSelected);
+    // Also listen to rate range changes (e.g. made in DlgPrefDecks) and
+    // adjust the fuzzy range accordingly
+    m_pRateRangeDeck1->connectValueChanged(
+            this,
+            [this]() {
+                slotBpmRangeSelected(comboBox_search_bpm_fuzzy_range->currentIndex());
+            });
 
     updateSearchLineEditHistoryOptions();
 

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -612,13 +612,6 @@ void DlgPrefLibrary::slotBpmRangeSelected(int index) {
     m_pConfig->set(kSearchBpmFuzzyRangeConfigKey, ConfigValue{bpmRange});
     const int rateRangePercent =
             m_pConfig->getValue(ConfigKey("[Controls]", "RateRangePercent"), 8);
-    qWarning() << "     .";
-    qWarning() << "     Pref fuzzy range selected:";
-    qWarning().nospace() << "       " << bpmRange << "%";
-    qWarning().nospace() << "       of " << rateRangePercent << "%";
-    qWarning() << "       =" << bpmRange * rateRangePercent / 10000.0;
-    qWarning() << "     .";
-    // 75% / 100 * 8% / 100
     BpmFilterNode::setBpmRelativeRange(bpmRange * rateRangePercent / 10000.0);
 }
 

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -46,24 +46,24 @@ DlgPrefLibrary::DlgPrefLibrary(
             &DlgPrefLibrary::requestRelocateDir,
             m_pLibrary.get(),
             &Library::slotRequestRelocateDir);
-    connect(PushButtonAddDir,
+    connect(pushButton_add_dir,
             &QPushButton::clicked,
             this,
             &DlgPrefLibrary::slotAddDir);
-    connect(PushButtonRemoveDir,
+    connect(pushButton_remove_dir,
             &QPushButton::clicked,
             this,
             &DlgPrefLibrary::slotRemoveDir);
-    connect(PushButtonRelocateDir,
+    connect(pushButton_relocate_dir,
             &QPushButton::clicked,
             this,
             &DlgPrefLibrary::slotRelocateDir);
-    connect(checkBox_SeratoMetadataExport,
+    connect(checkBox_serato_metadata_export,
             &QAbstractButton::clicked,
             this,
             &DlgPrefLibrary::slotSeratoMetadataExportClicked);
     const QString& settingsDir = m_pConfig->getSettingsPath();
-    connect(PushButtonOpenSettingsDir,
+    connect(pushButton_open_settings_dir,
             &QPushButton::clicked,
             [settingsDir] {
                 mixxx::DesktopHelper::openUrl(QUrl::fromLocalFile(settingsDir));
@@ -71,8 +71,8 @@ DlgPrefLibrary::DlgPrefLibrary(
 
     // Set default direction as stored in config file
     int rowHeight = m_pLibrary->getTrackTableRowHeight();
-    spinBoxRowHeight->setValue(rowHeight);
-    connect(spinBoxRowHeight,
+    spinBox_row_height->setValue(rowHeight);
+    connect(spinBox_row_height,
             QOverload<int>::of(&QSpinBox::valueChanged),
             this,
             &DlgPrefLibrary::slotRowHeightValueChanged);
@@ -84,16 +84,16 @@ DlgPrefLibrary::DlgPrefLibrary(
             this,
             &DlgPrefLibrary::slotBpmColumnPrecisionChanged);
 
-    searchDebouncingTimeoutSpinBox->setMinimum(WSearchLineEdit::kMinDebouncingTimeoutMillis);
-    searchDebouncingTimeoutSpinBox->setMaximum(WSearchLineEdit::kMaxDebouncingTimeoutMillis);
-    connect(searchDebouncingTimeoutSpinBox,
+    spinBox_search_debouncing_timeout->setMinimum(WSearchLineEdit::kMinDebouncingTimeoutMillis);
+    spinBox_search_debouncing_timeout->setMaximum(WSearchLineEdit::kMaxDebouncingTimeoutMillis);
+    connect(spinBox_search_debouncing_timeout,
             QOverload<int>::of(&QSpinBox::valueChanged),
             this,
             &DlgPrefLibrary::slotSearchDebouncingTimeoutMillisChanged);
 
     updateSearchLineEditHistoryOptions();
 
-    connect(libraryFontButton, &QAbstractButton::clicked, this, &DlgPrefLibrary::slotSelectFont);
+    connect(btn_library_font, &QAbstractButton::clicked, this, &DlgPrefLibrary::slotSelectFont);
 
     // TODO(XXX) this string should be extracted from the soundsources
     QString builtInFormatsStr = "Ogg Vorbis, FLAC, WAVE, AIFF";
@@ -127,7 +127,7 @@ DlgPrefLibrary::DlgPrefLibrary(
                 mixxx::DesktopHelper::openUrl(url);
             });
 
-    connect(checkBox_SyncTrackMetadata,
+    connect(checkBox_sync_track_metadata,
             &QCheckBox::toggled,
             this,
             &DlgPrefLibrary::slotSyncTrackMetadataToggled);
@@ -205,21 +205,22 @@ void DlgPrefLibrary::slotResetToDefaults() {
     spinbox_history_track_duplicate_distance->setValue(
             kHistoryTrackDuplicateDistanceDefault);
     spinbox_history_min_tracks_to_keep->setValue(1);
-    checkBox_SyncTrackMetadata->setChecked(false);
-    checkBox_SeratoMetadataExport->setChecked(false);
+    checkBox_sync_track_metadata->setChecked(false);
+    checkBox_serato_metadata_export->setChecked(false);
     checkBox_use_relative_path->setChecked(false);
-    checkBoxEditMetadataSelectedClicked->setChecked(kEditMetadataSelectedClickDefault);
+    checkBox_edit_metadata_selected_clicked->setChecked(kEditMetadataSelectedClickDefault);
     radioButton_dbclick_deck->setChecked(true);
     spinbox_bpm_precision->setValue(BaseTrackTableModel::kBpmColumnPrecisionDefault);
 
     radioButton_cover_art_fetcher_medium->setChecked(true);
 
-    spinBoxRowHeight->setValue(Library::kDefaultRowHeightPx);
+    spinBox_row_height->setValue(Library::kDefaultRowHeightPx);
     setLibraryFont(QApplication::font());
-    searchDebouncingTimeoutSpinBox->setValue(
+    spinBox_search_debouncing_timeout->setValue(
             WSearchLineEdit::kDefaultDebouncingTimeoutMillis);
-    checkBoxEnableSearchCompletions->setChecked(WSearchLineEdit::kCompletionsEnabledDefault);
-    checkBoxEnableSearchHistoryShortcuts->setChecked(
+    checkBox_enable_search_history_shortcuts->setChecked(
+            WSearchLineEdit::kCompletionsEnabledDefault);
+    checkBox_enable_search_history_shortcuts->setChecked(
             WSearchLineEdit::kHistoryShortcutsEnabledDefault);
 
     checkBox_show_rhythmbox->setChecked(true);
@@ -241,11 +242,11 @@ void DlgPrefLibrary::slotUpdate() {
             kHistoryMinTracksToKeepConfigKey,
             kHistoryMinTracksToKeepDefault));
 
-    checkBox_SyncTrackMetadata->setChecked(
+    checkBox_sync_track_metadata->setChecked(
             m_pConfig->getValue(kSyncTrackMetadataConfigKey, false));
-    checkBox_SeratoMetadataExport->setChecked(
+    checkBox_serato_metadata_export->setChecked(
             m_pConfig->getValue(kSyncSeratoMetadataConfigKey, false));
-    setSeratoMetadataEnabled(checkBox_SyncTrackMetadata->isChecked());
+    setSeratoMetadataEnabled(checkBox_sync_track_metadata->isChecked());
     checkBox_use_relative_path->setChecked(m_pConfig->getValue(
             kUseRelativePathOnExportConfigKey, false));
 
@@ -299,26 +300,26 @@ void DlgPrefLibrary::slotUpdate() {
     bool editMetadataSelectedClick = m_pConfig->getValue(
             kEditMetadataSelectedClickConfigKey,
             kEditMetadataSelectedClickDefault);
-    checkBoxEditMetadataSelectedClicked->setChecked(editMetadataSelectedClick);
+    checkBox_edit_metadata_selected_clicked->setChecked(editMetadataSelectedClick);
     m_pLibrary->setEditMetadataSelectedClick(editMetadataSelectedClick);
 
-    checkBoxEnableSearchCompletions->setChecked(m_pConfig->getValue(
+    checkBox_enable_search_history_shortcuts->setChecked(m_pConfig->getValue(
             kEnableSearchCompletionsConfigKey,
             WSearchLineEdit::kCompletionsEnabledDefault));
-    checkBoxEnableSearchHistoryShortcuts->setChecked(m_pConfig->getValue(
+    checkBox_enable_search_history_shortcuts->setChecked(m_pConfig->getValue(
             kEnableSearchHistoryShortcutsConfigKey,
             WSearchLineEdit::kHistoryShortcutsEnabledDefault));
 
     m_originalTrackTableFont = m_pLibrary->getTrackTableFont();
     m_iOriginalTrackTableRowHeight = m_pLibrary->getTrackTableRowHeight();
-    spinBoxRowHeight->setValue(m_iOriginalTrackTableRowHeight);
+    spinBox_row_height->setValue(m_iOriginalTrackTableRowHeight);
     setLibraryFont(m_originalTrackTableFont);
 
     const auto searchDebouncingTimeoutMillis =
             m_pConfig->getValue(
                     kSearchDebouncingTimeoutMillisConfigKey,
                     WSearchLineEdit::kDefaultDebouncingTimeoutMillis);
-    searchDebouncingTimeoutSpinBox->setValue(searchDebouncingTimeoutMillis);
+    spinBox_search_debouncing_timeout->setValue(searchDebouncingTimeoutMillis);
 
     const auto bpmColumnPrecision =
             m_pConfig->getValue(
@@ -438,7 +439,7 @@ void DlgPrefLibrary::slotSeratoMetadataExportClicked(bool checked) {
                             "recommended. Are you sure you want to enable this "
                             "option?"),
                     QMessageBox::Yes | QMessageBox::No) == QMessageBox::No) {
-            checkBox_SeratoMetadataExport->setChecked(false);
+            checkBox_serato_metadata_export->setChecked(false);
         }
     }
 }
@@ -454,18 +455,18 @@ void DlgPrefLibrary::slotApply() {
 
     m_pConfig->set(
             kSyncTrackMetadataConfigKey,
-            ConfigValue{checkBox_SyncTrackMetadata->isChecked()});
+            ConfigValue{checkBox_sync_track_metadata->isChecked()});
     m_pConfig->set(
             kSyncSeratoMetadataConfigKey,
-            ConfigValue{checkBox_SeratoMetadataExport->isChecked()});
+            ConfigValue{checkBox_serato_metadata_export->isChecked()});
 
     m_pConfig->set(kUseRelativePathOnExportConfigKey,
             ConfigValue((int)checkBox_use_relative_path->isChecked()));
 
     m_pConfig->set(kEnableSearchCompletionsConfigKey,
-            ConfigValue(checkBoxEnableSearchCompletions->isChecked()));
+            ConfigValue(checkBox_enable_search_history_shortcuts->isChecked()));
     m_pConfig->set(kEnableSearchHistoryShortcutsConfigKey,
-            ConfigValue(checkBoxEnableSearchHistoryShortcuts->isChecked()));
+            ConfigValue(checkBox_enable_search_history_shortcuts->isChecked()));
     updateSearchLineEditHistoryOptions();
 
     m_pConfig->set(ConfigKey("[Library]","ShowRhythmboxLibrary"),
@@ -507,9 +508,9 @@ void DlgPrefLibrary::slotApply() {
             ConfigValue(dbclick_status));
 
     m_pConfig->set(kEditMetadataSelectedClickConfigKey,
-            ConfigValue(checkBoxEditMetadataSelectedClicked->checkState()));
+            ConfigValue(checkBox_edit_metadata_selected_clicked->checkState()));
     m_pLibrary->setEditMetadataSelectedClick(
-            checkBoxEditMetadataSelectedClicked->checkState());
+            checkBox_edit_metadata_selected_clicked->checkState());
 
     QFont font = m_pLibrary->getTrackTableFont();
     if (m_originalTrackTableFont != font) {
@@ -517,7 +518,7 @@ void DlgPrefLibrary::slotApply() {
                        ConfigValue(font.toString()));
     }
 
-    int rowHeight = spinBoxRowHeight->value();
+    int rowHeight = spinBox_row_height->value();
     if (m_iOriginalTrackTableRowHeight != rowHeight) {
         m_pConfig->set(ConfigKey("[Library]","RowHeight"),
                        ConfigValue(rowHeight));
@@ -532,17 +533,20 @@ void DlgPrefLibrary::slotRowHeightValueChanged(int height) {
 }
 
 void DlgPrefLibrary::setLibraryFont(const QFont& font) {
-    libraryFont->setText(QString("%1 %2 %3pt").arg(
-        font.family(), font.styleName(), QString::number(font.pointSizeF())));
+    lineEdit_library_font->setText(
+            QString("%1 %2 %3pt")
+                    .arg(font.family(),
+                            font.styleName(),
+                            QString::number(font.pointSizeF())));
     m_pLibrary->setFont(font);
 
     // Don't let the font height exceed the row height.
     QFontMetrics metrics(font);
     int fontHeight = metrics.height();
-    spinBoxRowHeight->setMinimum(fontHeight);
+    spinBox_row_height->setMinimum(fontHeight);
     // library.cpp takes care of setting the new row height according to the
     // previous font height/ row height ratio
-    spinBoxRowHeight->setValue(m_pLibrary->getTrackTableRowHeight());
+    spinBox_row_height->setValue(m_pLibrary->getTrackTableRowHeight());
 }
 
 void DlgPrefLibrary::slotSelectFont() {
@@ -579,7 +583,7 @@ void DlgPrefLibrary::slotBpmColumnPrecisionChanged(int bpmPrecision) {
 }
 
 void DlgPrefLibrary::slotSyncTrackMetadataToggled() {
-    bool shouldSyncTrackMetadata = checkBox_SyncTrackMetadata->isChecked();
+    bool shouldSyncTrackMetadata = checkBox_sync_track_metadata->isChecked();
     if (isVisible() && shouldSyncTrackMetadata) {
         mixxx::DlgTrackMetadataExport::showMessageBoxOncePerSession();
     }
@@ -587,8 +591,8 @@ void DlgPrefLibrary::slotSyncTrackMetadataToggled() {
 }
 
 void DlgPrefLibrary::setSeratoMetadataEnabled(bool shouldSyncTrackMetadata) {
-    checkBox_SeratoMetadataExport->setEnabled(shouldSyncTrackMetadata);
+    checkBox_serato_metadata_export->setEnabled(shouldSyncTrackMetadata);
     if (!shouldSyncTrackMetadata) {
-        checkBox_SeratoMetadataExport->setChecked(false);
+        checkBox_serato_metadata_export->setChecked(false);
     }
 }

--- a/src/preferences/dialog/dlgpreflibrary.h
+++ b/src/preferences/dialog/dlgpreflibrary.h
@@ -62,6 +62,7 @@ class DlgPrefLibrary : public DlgPreferencePage, public Ui::DlgPrefLibraryDlg  {
     void slotSelectFont();
     void slotSyncTrackMetadataToggled();
     void slotSearchDebouncingTimeoutMillisChanged(int);
+    void slotBpmRangeSelected(int index);
     void slotBpmColumnPrecisionChanged(int bpmPrecision);
     void slotSeratoMetadataExportClicked(bool);
 

--- a/src/preferences/dialog/dlgpreflibrary.h
+++ b/src/preferences/dialog/dlgpreflibrary.h
@@ -8,8 +8,10 @@
 #include "preferences/dialog/dlgpreferencepage.h"
 #include "preferences/dialog/ui_dlgpreflibrarydlg.h"
 #include "preferences/usersettings.h"
+#include "util/parented_ptr.h"
 
 class QWidget;
+class ControlProxy;
 
 class DlgPrefLibrary : public DlgPreferencePage, public Ui::DlgPrefLibraryDlg  {
     Q_OBJECT
@@ -78,4 +80,6 @@ class DlgPrefLibrary : public DlgPreferencePage, public Ui::DlgPrefLibraryDlg  {
     bool m_bAddedDirectory;
     QFont m_originalTrackTableFont;
     int m_iOriginalTrackTableRowHeight;
+    // Listen to rate range changes in order to update the fuzzy BPM range
+    parented_ptr<ControlProxy> m_pRateRangeDeck1;
 };

--- a/src/preferences/dialog/dlgpreflibrarydlg.ui
+++ b/src/preferences/dialog/dlgpreflibrarydlg.ui
@@ -325,10 +325,30 @@
        </widget>
       </item>
 
-      <item row="3" column="0" colspan="3">
-       <widget class="QCheckBox" name="checkBox_BpmHalfDoubleSearch">
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_searchBpmFuzzyRange">
         <property name="text">
-         <string>Search also for half and double BPM with 'bpm:123'</string>
+         <string>Percentage of pitch slider range for 'fuzzy' BPM search:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+        <property name="buddy">
+         <cstring>comboBox_search_bpm_fuzzy_range</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1" colspan="2">
+       <widget class="QComboBox" name="comboBox_search_bpm_fuzzy_range">
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="3">
+       <widget class="QLabel" name="label_searchBpmFuzzyRangeInfo">
+        <property name="text">
+         <string>This range will be used for the 'fuzzy' BPM search (~bpm:) via the search box, as well as for BPM search in Track context menu > Search related Tracks</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
         </property>
        </widget>
       </item>
@@ -657,6 +677,7 @@
   <tabstop>spinBox_search_debouncing_timeout</tabstop>
   <tabstop>checkBox_enable_search_completions</tabstop>
   <tabstop>checkBox_enable_search_history_shortcuts</tabstop>
+  <tabstop>comboBox_search_bpm_fuzzy_range</tabstop>
   <tabstop>checkBox_show_rhythmbox</tabstop>
   <tabstop>checkBox_show_banshee</tabstop>
   <tabstop>checkBox_show_itunes</tabstop>

--- a/src/preferences/dialog/dlgpreflibrarydlg.ui
+++ b/src/preferences/dialog/dlgpreflibrarydlg.ui
@@ -40,7 +40,7 @@
       </item>
 
       <item row="0" column="1">
-       <widget class="QPushButton" name="PushButtonAddDir">
+       <widget class="QPushButton" name="pushButton_add_dir">
         <property name="font">
          <font/>
         </property>
@@ -54,7 +54,7 @@
       </item>
 
       <item row="1" column="1">
-       <widget class="QPushButton" name="PushButtonRelocateDir">
+       <widget class="QPushButton" name="pushButton_relocate_dir">
         <property name="toolTip">
          <string>If an existing music directory is moved, Mixxx doesn't know where to find the audio files in it. Choose Relink to select the music directory in its new location. &lt;br/&gt; This will re-establish the links to the audio files in the Mixxx library.</string>
         </property>
@@ -65,7 +65,7 @@
       </item>
 
       <item row="2" column="1">
-       <widget class="QPushButton" name="PushButtonRemoveDir">
+       <widget class="QPushButton" name="pushButton_remove_dir">
         <property name="font">
          <font/>
         </property>
@@ -119,11 +119,11 @@
    <item>
     <widget class="QGroupBox" name="groupBox_AudioFileTags">
      <property name="title">
-      <string>Track Metadata Synchronization</string>
+      <string>Track Metadata Synchronization / Playlists</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_metadata">
       <item row="0" column="0" colspan="2">
-       <widget class="QCheckBox" name="checkBox_SyncTrackMetadata">
+       <widget class="QCheckBox" name="checkBox_sync_track_metadata">
         <property name="text">
          <string>Synchronize library track metadata from/to file tags</string>
         </property>
@@ -132,13 +132,22 @@
         </property>
        </widget>
       </item>
+
       <item row="1" column="0">
-       <widget class="QCheckBox" name="checkBox_SeratoMetadataExport">
+       <widget class="QCheckBox" name="checkBox_serato_metadata_export">
         <property name="text">
          <string>Synchronize Serato track metadata from/to file tags (experimental)</string>
         </property>
         <property name="toolTip">
          <string>Keeps track color, beat grid, bpm lock, cue points, and loops synchronized with SERATO_MARKERS/MARKERS2 file tags.&lt;br/&gt;&lt;br/&gt;WARNING: Enabling this option also enables the reimport of Serato metadata after files have been modified outside of Mixxx. On reimport existing metadata in Mixxx is replaced with the metadata found in file tags. Custom metadata not included in file tags like loop colors is lost.</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="2" column="0" colspan="2">
+       <widget class="QCheckBox" name="checkBox_use_relative_path">
+        <property name="text">
+         <string>Use relative paths for playlist export if possible</string>
         </property>
        </widget>
       </item>
@@ -154,7 +163,7 @@
      <layout class="QGridLayout" name="gridLayout_track_table_view">
 
       <item row="1" column="0" colspan="3">
-       <widget class="QCheckBox" name="checkBoxEditMetadataSelectedClicked">
+       <widget class="QCheckBox" name="checkBox_edit_metadata_selected_clicked">
         <property name="text">
          <string>Edit metadata after clicking selected track</string>
         </property>
@@ -162,7 +171,7 @@
       </item>
 
       <item row="2" column="0" colspan="3">
-       <widget class="QLabel" name="doubeClickActionLabel">
+       <widget class="QLabel" name="label_doubeClickAction">
         <property name="text">
          <string>Track Double-Click Action:</string>
         </property>
@@ -205,6 +214,58 @@
       </item>
 
       <item row="7" column="0">
+       <widget class="QLabel" name="label_rowHeight">
+        <property name="text">
+         <string>Library Row Height:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1" colspan="2">
+       <widget class="QSpinBox" name="spinBox_row_height">
+        <property name="suffix">
+         <string> px</string>
+        </property>
+        <property name="minimum">
+         <number>5</number>
+        </property>
+        <property name="maximum">
+         <number>100</number>
+        </property>
+        <property name="value">
+         <number>20</number>
+        </property>
+       </widget>
+      </item>
+
+      <item row="8" column="0">
+       <widget class="QLabel" name="label_libraryFont">
+        <property name="text">
+         <string>Library Font:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="1">
+       <widget class="QLineEdit" name="lineEdit_library_font">
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="8" column="2">
+       <widget class="QToolButton" name="btn_library_font">
+        <property name="text">
+         <string>...</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="9" column="0">
        <widget class="QLabel" name="label_bpm_precision">
         <property name="text">
          <string>BPM display precision:</string>
@@ -214,7 +275,7 @@
         </property>
        </widget>
       </item>
-      <item row="7" column="1" colspan="2">
+      <item row="9" column="1" colspan="2">
        <widget class="QSpinBox" name="spinbox_bpm_precision">
        </widget>
       </item>
@@ -222,6 +283,59 @@
      </layout>
     </widget>
    </item><!-- Track Table View -->
+
+   <item>
+    <widget class="QGroupBox" name="groupBox_Search">
+     <property name="title">
+      <string>Track Search</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_search">
+
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_searchDebouncingTimeout">
+        <property name="text">
+         <string>Search-as-you-type timeout:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1" colspan="2">
+       <widget class="QSpinBox" name="spinBox_search_debouncing_timeout">
+        <property name="suffix">
+         <string> ms</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="1" column="0" colspan="3">
+       <widget class="QCheckBox" name="checkBox_enable_search_completions">
+        <property name="text">
+         <string>Enable search completions</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="2" column="0" colspan="3">
+       <widget class="QCheckBox" name="checkBox_enable_search_history_shortcuts">
+        <property name="text">
+         <string>Enable search history keyboard shortcuts</string>
+        </property>
+       </widget>
+      </item>
+
+      <item row="3" column="0" colspan="3">
+       <widget class="QCheckBox" name="checkBox_BpmHalfDoubleSearch">
+        <property name="text">
+         <string>Search also for half and double BPM with 'bpm:123'</string>
+        </property>
+       </widget>
+      </item>
+
+     </layout>
+    </widget>
+   </item><!-- Search box -->
 
    <item>
     <widget class="QGroupBox" name="groupBox_History">
@@ -290,110 +404,6 @@
      </layout>
     </widget>
    </item><!-- History -->
-
-   <item>
-    <widget class="QGroupBox" name="groupBox_Miscellaneous">
-     <property name="title">
-      <string>Miscellaneous</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_misc">
-
-      <item row="0" column="0" colspan="2">
-       <widget class="QCheckBox" name="checkBox_use_relative_path">
-        <property name="text">
-         <string>Use relative paths for playlist export if possible</string>
-        </property>
-       </widget>
-      </item>
-
-      <item row="1" column="0">
-       <widget class="QLabel" name="rowHeightLabel">
-        <property name="text">
-         <string>Library Row Height:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignLeft|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1" colspan="2">
-       <widget class="QSpinBox" name="spinBoxRowHeight">
-        <property name="suffix">
-         <string> px</string>
-        </property>
-        <property name="minimum">
-         <number>5</number>
-        </property>
-        <property name="maximum">
-         <number>100</number>
-        </property>
-        <property name="value">
-         <number>20</number>
-        </property>
-       </widget>
-      </item>
-
-      <item row="2" column="0">
-       <widget class="QLabel" name="libraryFontLabel">
-        <property name="text">
-         <string>Library Font:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignLeft|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QLineEdit" name="libraryFont">
-        <property name="readOnly">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="2">
-       <widget class="QToolButton" name="libraryFontButton">
-        <property name="text">
-         <string>...</string>
-        </property>
-       </widget>
-      </item>
-
-      <item row="3" column="0">
-       <widget class="QLabel" name="searchDebouncingTimeoutLabel">
-        <property name="text">
-         <string>Search-as-you-type timeout:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignLeft|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1" colspan="2">
-       <widget class="QSpinBox" name="searchDebouncingTimeoutSpinBox">
-        <property name="suffix">
-         <string> ms</string>
-        </property>
-       </widget>
-      </item>
-
-      <item row="4" column="0" colspan="3">
-       <widget class="QCheckBox" name="checkBoxEnableSearchCompletions">
-        <property name="text">
-         <string>Enable search completions</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0" colspan="3">
-       <widget class="QCheckBox" name="checkBoxEnableSearchHistoryShortcuts">
-        <property name="text">
-         <string>Enable search history keyboard shortcuts</string>
-        </property>
-       </widget>
-      </item>
-
-     </layout>
-    </widget>
-   </item>
 
    <item>
     <widget class="QGroupBox" name="groupBox_external_libraries">
@@ -578,6 +588,9 @@
         <property name="wordWrap">
          <bool>true</bool>
         </property>
+        <property name="openExternalLinks">
+         <bool>true</bool>
+        </property>
        </widget>
       </item>
       <item>
@@ -591,7 +604,7 @@
        </widget>
       </item>
       <item>
-       <widget class="QPushButton" name="PushButtonOpenSettingsDir">
+       <widget class="QPushButton" name="pushButton_open_settings_dir">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
           <horstretch>0</horstretch>
@@ -624,13 +637,13 @@
  <layoutdefault spacing="6" margin="11"/>
  <tabstops>
   <tabstop>dirList</tabstop>
-  <tabstop>PushButtonAddDir</tabstop>
-  <tabstop>PushButtonRelocateDir</tabstop>
-  <tabstop>PushButtonRemoveDir</tabstop>
+  <tabstop>pushButton_add_dir</tabstop>
+  <tabstop>pushButton_relocate_dir</tabstop>
+  <tabstop>pushButton_remove_dir</tabstop>
   <tabstop>checkBox_library_scan</tabstop>
-  <tabstop>checkBox_SyncTrackMetadata</tabstop>
-  <tabstop>checkBox_SeratoMetadataExport</tabstop>
-  <tabstop>checkBoxEditMetadataSelectedClicked</tabstop>
+  <tabstop>checkBox_sync_track_metadata</tabstop>
+  <tabstop>checkBox_serato_metadata_export</tabstop>
+  <tabstop>checkBox_edit_metadata_selected_clicked</tabstop>
   <tabstop>radioButton_dbclick_deck</tabstop>
   <tabstop>radioButton_dbclick_bottom</tabstop>
   <tabstop>radioButton_dbclick_top</tabstop>
@@ -639,12 +652,11 @@
   <tabstop>spinbox_history_track_duplicate_distance</tabstop>
   <tabstop>spinbox_history_min_tracks_to_keep</tabstop>
   <tabstop>checkBox_use_relative_path</tabstop>
-  <tabstop>spinBoxRowHeight</tabstop>
-  <tabstop>libraryFont</tabstop>
-  <tabstop>libraryFontButton</tabstop>
-  <tabstop>searchDebouncingTimeoutSpinBox</tabstop>
-  <tabstop>checkBoxEnableSearchCompletions</tabstop>
-  <tabstop>checkBoxEnableSearchHistoryShortcuts</tabstop>
+  <tabstop>spinBox_row_height</tabstop>
+  <tabstop>btn_library_font</tabstop>
+  <tabstop>spinBox_search_debouncing_timeout</tabstop>
+  <tabstop>checkBox_enable_search_completions</tabstop>
+  <tabstop>checkBox_enable_search_history_shortcuts</tabstop>
   <tabstop>checkBox_show_rhythmbox</tabstop>
   <tabstop>checkBox_show_banshee</tabstop>
   <tabstop>checkBox_show_itunes</tabstop>
@@ -655,7 +667,7 @@
   <tabstop>radioButton_cover_art_fetcher_high</tabstop>
   <tabstop>radioButton_cover_art_fetcher_medium</tabstop>
   <tabstop>radioButton_cover_art_fetcher_lowest</tabstop>
-  <tabstop>PushButtonOpenSettingsDir</tabstop>
+  <tabstop>pushButton_open_settings_dir</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/test/searchqueryparsertest.cpp
+++ b/src/test/searchqueryparsertest.cpp
@@ -533,7 +533,9 @@ TEST_F(SearchQueryParserTest, BpmFilter) {
             qPrintable(QString("bpm BETWEEN 127.12 AND 129")),
             qPrintable(pQuery->toSql()));
 
-    // Test fuzzy BPM match (hardcoded range is +- 6%)
+    // Test fuzzy BPM match
+    // Should be enabled by default and default range is 6% (= 75% 0f default
+    // pitch slider range)
     pQuery = m_parser.parseQuery("~bpm:100", QString());
     EXPECT_FALSE(pQuery->match(pTrack));
     pTrack->trySetBpm(106);

--- a/src/test/searchqueryparsertest.cpp
+++ b/src/test/searchqueryparsertest.cpp
@@ -506,7 +506,8 @@ TEST_F(SearchQueryParserTest, BpmFilter) {
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-            qPrintable(QString("(bpm = 127.12) OR (bpm BETWEEN 63 AND 64) OR "
+            qPrintable(QString("(bpm BETWEEN 127.115 AND 127.125) OR "
+                               "(bpm BETWEEN 63 AND 64) OR "
                                "(bpm BETWEEN 254 AND 255)")),
             qPrintable(pQuery->toSql()));
 
@@ -517,7 +518,7 @@ TEST_F(SearchQueryParserTest, BpmFilter) {
     EXPECT_FALSE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-            qPrintable(QString("bpm = 127.12")),
+            qPrintable(QString("bpm BETWEEN 127.115 AND 127.125")),
             qPrintable(pQuery->toSql()));
 
     // Test BPM range
@@ -534,7 +535,7 @@ TEST_F(SearchQueryParserTest, BpmFilter) {
             qPrintable(pQuery->toSql()));
 
     // Test fuzzy BPM match
-    // Should be enabled by default and default range is 6% (= 75% 0f default
+    // Should be enabled by default and default range is 6% (= 75% of default
     // pitch slider range)
     pQuery = m_parser.parseQuery("~bpm:100", QString());
     EXPECT_FALSE(pQuery->match(pTrack));

--- a/src/test/searchqueryparsertest.cpp
+++ b/src/test/searchqueryparsertest.cpp
@@ -498,16 +498,29 @@ TEST_F(SearchQueryParserTest, BpmFilter) {
     m_parser.setSearchColumns({"artist", "album"});
 
     // Test BpmFilter's MatchModes:
-    // HalveDouble
-    auto pQuery(m_parser.parseQuery("bpm:127", QString()));
+
+    // HalveDouble even
+    auto pQuery = m_parser.parseQuery("bpm:126", QString());
     TrackPointer pTrack = newTestTrack();
+    EXPECT_FALSE(pQuery->match(pTrack));
+    pTrack->trySetBpm(126.13);
+    EXPECT_TRUE(pQuery->match(pTrack));
+
+    EXPECT_STREQ(
+            qPrintable(QString("(bpm >= 125.95 AND bpm < 127) OR "
+                               "(bpm >= 62.95 AND bpm < 64) OR "
+                               "(bpm >= 251.95 AND bpm < 254)")),
+            qPrintable(pQuery->toSql()));
+
+    // HalveDouble uneven
+    pQuery = m_parser.parseQuery("bpm:127", QString());
     EXPECT_FALSE(pQuery->match(pTrack));
     pTrack->trySetBpm(127.13);
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
             qPrintable(QString("(bpm >= 126.95 AND bpm < 128) OR "
-                               "(bpm BETWEEN 63 AND 64) OR "
+                               "(bpm >= 62.95 AND bpm < 64.5) OR "
                                "(bpm >= 253.95 AND bpm < 256)")),
             qPrintable(pQuery->toSql()));
 

--- a/src/test/searchqueryparsertest.cpp
+++ b/src/test/searchqueryparsertest.cpp
@@ -351,18 +351,17 @@ TEST_F(SearchQueryParserTest, TextFilterNegation) {
 
 TEST_F(SearchQueryParserTest, NumericFilter) {
     m_parser.setSearchColumns({"artist", "album"});
-    auto pQuery(
-            m_parser.parseQuery("bpm:127.12", QString()));
+    auto pQuery(m_parser.parseQuery("bitrate:127", QString()));
 
     TrackPointer pTrack = newTestTrack();
-    pTrack->trySetBpm(127);
+    pTrack->setBitrate(128);
     EXPECT_FALSE(pQuery->match(pTrack));
-    pTrack->trySetBpm(127.12);
+    pTrack->setBitrate(127);
     EXPECT_TRUE(pQuery->match(pTrack));
 
-    EXPECT_STREQ(
-        qPrintable(QString("bpm = 127.12")),
-        qPrintable(pQuery->toSql()));
+    EXPECT_STREQ( // half/double BPM, half
+            qPrintable(QString("bitrate = 127")),
+            qPrintable(pQuery->toSql()));
 }
 
 TEST_F(SearchQueryParserTest, NumericFilterYear) {
@@ -388,11 +387,10 @@ TEST_F(SearchQueryParserTest, NumericFilterYear) {
 
 TEST_F(SearchQueryParserTest, NumericFilterEmpty) {
     m_parser.setSearchColumns({"artist", "album"});
-    auto pQuery(
-            m_parser.parseQuery("bpm:", QString()));
+    auto pQuery(m_parser.parseQuery("bitrate:", QString()));
 
     TrackPointer pTrack = newTestTrack();
-    pTrack->trySetBpm(127);
+    pTrack->setBitrate(127);
     EXPECT_TRUE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
@@ -402,84 +400,128 @@ TEST_F(SearchQueryParserTest, NumericFilterEmpty) {
 
 TEST_F(SearchQueryParserTest, NumericFilterNegation) {
     m_parser.setSearchColumns({"artist", "album"});
-    auto pQuery(
-            m_parser.parseQuery("-bpm:127.12", QString()));
+    auto pQuery(m_parser.parseQuery("-bitrate:127", QString()));
 
     TrackPointer pTrack = newTestTrack();
-    pTrack->trySetBpm(127);
+    pTrack->setBitrate(129);
     EXPECT_TRUE(pQuery->match(pTrack));
-    pTrack->trySetBpm(127.12);
+    pTrack->setBitrate(127);
     EXPECT_FALSE(pQuery->match(pTrack));
 
     EXPECT_STREQ(
-        qPrintable(QString("NOT (bpm = 127.12)")),
-        qPrintable(pQuery->toSql()));
+            qPrintable(QString("NOT (bitrate = 127)")),
+            qPrintable(pQuery->toSql()));
 }
 
 TEST_F(SearchQueryParserTest, NumericFilterAllowsSpace) {
     m_parser.setSearchColumns({"artist", "album"});
-    auto pQuery(
-            m_parser.parseQuery("bpm: 127.12", QString()));
+    auto pQuery(m_parser.parseQuery("bitrate: 127", QString()));
 
     TrackPointer pTrack = newTestTrack();
-    pTrack->trySetBpm(127);
+    pTrack->setBitrate(128);
     EXPECT_FALSE(pQuery->match(pTrack));
-    pTrack->trySetBpm(127.12);
+    pTrack->setBitrate(127);
     EXPECT_TRUE(pQuery->match(pTrack));
 
-    EXPECT_STREQ(
-        qPrintable(QString("bpm = 127.12")),
-        qPrintable(pQuery->toSql()));
+    EXPECT_STREQ(qPrintable(QString("bitrate = 127")),
+            qPrintable(pQuery->toSql()));
 }
 
 TEST_F(SearchQueryParserTest, NumericFilterOperators) {
     m_parser.setSearchColumns({"artist", "album"});
-    auto pQuery(
-            m_parser.parseQuery("bpm:>127.12", QString()));
+    auto pQuery(m_parser.parseQuery("bitrate:>127", QString()));
 
     TrackPointer pTrack = newTestTrack();
-    pTrack->trySetBpm(127.12);
+    pTrack->setBitrate(127);
     EXPECT_FALSE(pQuery->match(pTrack));
-    pTrack->trySetBpm(127.13);
+    pTrack->setBitrate(128);
     EXPECT_TRUE(pQuery->match(pTrack));
     EXPECT_STREQ(
-        qPrintable(QString("bpm > 127.12")),
-        qPrintable(pQuery->toSql()));
+            qPrintable(QString("bitrate > 127")),
+            qPrintable(pQuery->toSql()));
 
-    pQuery = m_parser.parseQuery("bpm:>=127.12", QString());
-    pTrack->trySetBpm(127.11);
+    pQuery = m_parser.parseQuery("bitrate:>=127", QString());
+    pTrack->setBitrate(126);
     EXPECT_FALSE(pQuery->match(pTrack));
-    pTrack->trySetBpm(127.12);
+    pTrack->setBitrate(127);
     EXPECT_TRUE(pQuery->match(pTrack));
     EXPECT_STREQ(
-        qPrintable(QString("bpm >= 127.12")),
-        qPrintable(pQuery->toSql()));
+            qPrintable(QString("bitrate >= 127")),
+            qPrintable(pQuery->toSql()));
 
-    pQuery = m_parser.parseQuery("bpm:<127.12", QString());
-    pTrack->trySetBpm(127.12);
+    pQuery = m_parser.parseQuery("bitrate:<127", QString());
+    pTrack->setBitrate(127);
     EXPECT_FALSE(pQuery->match(pTrack));
-    pTrack->trySetBpm(127.11);
+    pTrack->setBitrate(126);
     EXPECT_TRUE(pQuery->match(pTrack));
     EXPECT_STREQ(
-        qPrintable(QString("bpm < 127.12")),
-        qPrintable(pQuery->toSql()));
+            qPrintable(QString("bitrate < 127")),
+            qPrintable(pQuery->toSql()));
 
-    pQuery = m_parser.parseQuery("bpm:<=127.12", QString());
-    pTrack->trySetBpm(127.13);
+    pQuery = m_parser.parseQuery("bitrate:<=127", QString());
+    pTrack->setBitrate(129);
     EXPECT_FALSE(pQuery->match(pTrack));
-    pTrack->trySetBpm(127.12);
+    pTrack->setBitrate(127);
     EXPECT_TRUE(pQuery->match(pTrack));
     EXPECT_STREQ(
-        qPrintable(QString("bpm <= 127.12")),
-        qPrintable(pQuery->toSql()));
+            qPrintable(QString("bitrate <= 127")),
+            qPrintable(pQuery->toSql()));
+
+    pQuery = m_parser.parseQuery("bitrate:=127", QString());
+    pTrack->setBitrate(129);
+    EXPECT_FALSE(pQuery->match(pTrack));
+    pTrack->setBitrate(127);
+    EXPECT_TRUE(pQuery->match(pTrack));
+    EXPECT_STREQ(
+            qPrintable(QString("bitrate = 127")),
+            qPrintable(pQuery->toSql()));
 }
 
 TEST_F(SearchQueryParserTest, NumericRangeFilter) {
     m_parser.setSearchColumns({"artist", "album"});
-    auto pQuery(
-            m_parser.parseQuery("bpm:127.12-129", QString()));
+    auto pQuery(m_parser.parseQuery("bitrate:127-129", QString()));
 
     TrackPointer pTrack = newTestTrack();
+    pTrack->setBitrate(125);
+    EXPECT_FALSE(pQuery->match(pTrack));
+    pTrack->setBitrate(127);
+    EXPECT_TRUE(pQuery->match(pTrack));
+    pTrack->setBitrate(129);
+    EXPECT_TRUE(pQuery->match(pTrack));
+
+    EXPECT_STREQ(
+            qPrintable(QString("bitrate BETWEEN 127 AND 129")),
+            qPrintable(pQuery->toSql()));
+}
+
+TEST_F(SearchQueryParserTest, BpmFilter) {
+    m_parser.setSearchColumns({"artist", "album"});
+
+    // Test (implicit) half/double BPM match
+    auto pQuery(m_parser.parseQuery("bpm:127.12", QString()));
+
+    TrackPointer pTrack = newTestTrack();
+    EXPECT_FALSE(pQuery->match(pTrack));
+    pTrack->trySetBpm(127.12);
+    EXPECT_TRUE(pQuery->match(pTrack));
+
+    EXPECT_STREQ(
+            qPrintable(QString("(bpm = 127.12) OR (bpm BETWEEN 63 AND 64) OR "
+                               "(bpm BETWEEN 254 AND 255)")),
+            qPrintable(pQuery->toSql()));
+
+    // Test (explicit) exact match
+    pQuery = m_parser.parseQuery("bpm:=127.12", QString());
+    EXPECT_TRUE(pQuery->match(pTrack));
+    pTrack->trySetBpm(127.13);
+    EXPECT_FALSE(pQuery->match(pTrack));
+
+    EXPECT_STREQ(
+            qPrintable(QString("bpm = 127.12")),
+            qPrintable(pQuery->toSql()));
+
+    // Test BPM range
+    pQuery = m_parser.parseQuery("bpm:127.12-129", QString());
     pTrack->trySetBpm(125);
     EXPECT_FALSE(pQuery->match(pTrack));
     pTrack->trySetBpm(127.12);
@@ -489,6 +531,26 @@ TEST_F(SearchQueryParserTest, NumericRangeFilter) {
 
     EXPECT_STREQ(
             qPrintable(QString("bpm BETWEEN 127.12 AND 129")),
+            qPrintable(pQuery->toSql()));
+
+    // Test fuzzy BPM match (hardcoded range is +- 6%)
+    pQuery = m_parser.parseQuery("~bpm:100", QString());
+    EXPECT_FALSE(pQuery->match(pTrack));
+    pTrack->trySetBpm(106);
+    EXPECT_TRUE(pQuery->match(pTrack));
+    pTrack->trySetBpm(94);
+    EXPECT_TRUE(pQuery->match(pTrack));
+
+    EXPECT_STREQ(
+            qPrintable(QString("bpm BETWEEN 94 AND 106")),
+            qPrintable(pQuery->toSql()));
+
+    // Test empty BPM
+    pQuery = m_parser.parseQuery("bpm:", QString());
+    EXPECT_TRUE(pQuery->match(pTrack));
+
+    EXPECT_STREQ(
+            qPrintable(QString("")),
             qPrintable(pQuery->toSql()));
 }
 

--- a/src/test/searchqueryparsertest.cpp
+++ b/src/test/searchqueryparsertest.cpp
@@ -508,7 +508,7 @@ TEST_F(SearchQueryParserTest, BpmFilter) {
     EXPECT_STREQ(
             qPrintable(QString("(bpm >= 126.95 AND bpm < 128) OR "
                                "(bpm BETWEEN 63 AND 64) OR "
-                               "(bpm BETWEEN 253 AND 255)")),
+                               "(bpm >= 253.95 AND bpm < 256)")),
             qPrintable(pQuery->toSql()));
 
     // HalveDoubleStrict

--- a/src/widget/wsearchrelatedtracksmenu.cpp
+++ b/src/widget/wsearchrelatedtracksmenu.cpp
@@ -137,7 +137,7 @@ void WSearchRelatedTracksMenu::addActionsForTrack(
             BpmFilterNode* pBpmNode = new BpmFilterNode(bpmStr, true /* fuzzy search */);
             double bpmLowerBound = 0.0;
             double bpmUpperBound = 0.0;
-            DEBUG_ASSERT(pBpmNode->isRangeQuery(&bpmLowerBound, &bpmUpperBound));
+            std::tie(bpmLowerBound, bpmUpperBound) = pBpmNode->getBpmRange();
             const QString searchQuery =
                     QStringLiteral("bpm:>=") +
                     QString::number(bpmLowerBound) +


### PR DESCRIPTION
rework of #12070
Closes #8191 

This adds `BpmFilterNode` which allows the following special filtering:
* `~bpm:N` finds `N` +- n%
n is % of the current rate slider range, can be configured in Pref > Library, default is 75%
* `bpm:N` finds N¹ as well as N/2 and N*2 (in case N is odd N/2 is replaced with a range of prev - next integer, considering electronic music with mostly integer BPM)
can be toggled in Pref > Library, default ON

¹N is turned into a range to cover the rounded values (in the tracks table or BPM widgets).
For example 102.5 becomes [102.45 - 102.55]

Btw, this works beautifully with the new `OR` operator: `~bpm:80 | ~bpm:160` : )

**Results:**
* `~bpm:100`: 94-106 **NEW**
* `bpm:125.2`: [125.15 - 125.25] and [250 - 251] and [52 - 53] **NEW**
* `-bpm:100`: anything except exactly 100.0
* `bpm:=100`: 125.15 - 125.25

**Preferences > Library**
I re-grouped the options a bit, though we may discuss details like Metadata /Playlist title and the search note label
- moved Misc options to Metadata & Track Table groups
- added the Search group
  - fuzzy range selector (percentage of pitch slider)

![library-search-options_](https://github.com/mixxxdj/mixxx/assets/5934199/cc10ca0e-91fe-4d84-b0fa-7fd05ba49c7e)

**TODO**
- [x] adjust NumericFilterTests to use something else than `bpm`
- [x] add BpmFilterNode tests
- [x] adjust 'fuzzy range' in Preferences > Library > Search
- [x] use fuzzy range also for 'Search related tracks' > BPM?
- [x] half/double search can be overriden with `=` operator (we just need to document it)

**Manual**
- [x] documentation PR: https://github.com/mixxxdj/manual/pull/693