### PR TITLE
make decks' xfader assignment persistent

### DIFF
--- a/src/engine/channels/enginechannel.cpp
+++ b/src/engine/channels/enginechannel.cpp
@@ -23,10 +23,11 @@ EngineChannel::EngineChannel(const ChannelHandleAndGroup& handleGroup,
     m_pMainMix = new ControlPushButton(ConfigKey(getGroup(), "main_mix"));
     m_pMainMix->setButtonMode(ControlPushButton::POWERWINDOW);
     m_pMainMix->addAlias(ConfigKey(getGroup(), QStringLiteral("master")));
-    m_pOrientation = new ControlPushButton(ConfigKey(getGroup(), "orientation"));
+    // crossfader assignment is persistent
+    m_pOrientation = new ControlPushButton(
+            ConfigKey(getGroup(), "orientation"), true, defaultOrientation);
     m_pOrientation->setButtonMode(ControlPushButton::TOGGLE);
     m_pOrientation->setStates(3);
-    m_pOrientation->set(defaultOrientation);
     m_pOrientationLeft = new ControlPushButton(ConfigKey(getGroup(), "orientation_left"));
     connect(m_pOrientationLeft, &ControlObject::valueChanged,
             this, &EngineChannel::slotOrientationLeft, Qt::DirectConnection);


### PR DESCRIPTION
Closes #10122

I agree with Be's [comment](https://github.com/mixxxdj/mixxx/issues/10122#issuecomment-1225430189):
> I am leaning towards simply making the crossfader orientation switches persistent in all cases. This is how every 4 deck mixer and controller with crossfader assignment switches works. I think if a user wants to change these, they probably want that change to persist.