### PR TITLE
[DRAFT] fix for tableview drawing performance

### DIFF
--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -416,7 +416,9 @@ QAbstractItemDelegate* BaseTrackTableModel::delegateForColumn(
                 &BaseTrackTableModel::slotRefreshCoverRows);
         return pCoverArtDelegate;
     }
-    return nullptr;
+    // Explicitly return a TableItemDelegate, otherwise
+    // the default QStyleItemDelegate will be used.
+    return new TableItemDelegate(pTableView);
 }
 
 QVariant BaseTrackTableModel::data(

--- a/src/library/bpmdelegate.cpp
+++ b/src/library/bpmdelegate.cpp
@@ -81,14 +81,21 @@ void BPMDelegate::paintItem(QPainter* painter,const QStyleOptionViewItem &option
     // #LibraryBPMButton::indicator:unchecked {
     //  image: url(:/images/library/ic_library_unlocked.svg);
     // }
-    QStyleOptionViewItem opt = option;
-    initStyleOption(&opt, index);
 
-    if (m_pTableView != nullptr) {
-        QStyle* style = m_pTableView->style();
-        if (style != nullptr) {
-            style->drawControl(QStyle::CE_ItemViewItem, &opt, painter,
-                               m_pCheckBox);
-        }
-    }
+    // TODO: Draw the checkbox. Considering using the approach used with
+    // PreviewButtonDelegate and LibraryPreviewButton
+    //
+    // QStyleOptionViewItem opt = option;
+    // initStyleOption(&opt, index);
+    // if (m_pTableView != nullptr) {
+    //     QStyle* style = m_pTableView->style();
+    //     if (style != nullptr) {
+    //         style->drawControl(QStyle::CE_ItemViewItem, &opt, painter,
+    //                         m_pCheckBox);
+    //     }
+    // }
+
+    painter->drawText(addMargins(option.rect),
+            Qt::AlignVCenter | Qt::AlignRight,
+            index.data().toString());
 }

--- a/src/library/stardelegate.cpp
+++ b/src/library/stardelegate.cpp
@@ -42,7 +42,6 @@ QWidget* StarDelegate::createEditor(QWidget* parent,
                                     const QModelIndex& index) const {
     // Populate the correct colors based on the styling
     QStyleOptionViewItem newOption = option;
-    initStyleOption(&newOption, index);
 
     StarEditor* editor = new StarEditor(parent, m_pTableView, index, newOption);
     connect(editor,

--- a/src/library/tableitemdelegate.cpp
+++ b/src/library/tableitemdelegate.cpp
@@ -8,7 +8,7 @@
 #include "widget/wtracktableview.h"
 
 TableItemDelegate::TableItemDelegate(QTableView* pTableView)
-        : QStyledItemDelegate(pTableView),
+        : QItemDelegate(pTableView),
           m_pTableView(pTableView) {
     DEBUG_ASSERT(m_pTableView);
     auto* pTrackTableView = qobject_cast<WTrackTableView*>(m_pTableView);
@@ -22,7 +22,7 @@ void TableItemDelegate::paint(
         const QStyleOptionViewItem& option,
         const QModelIndex& index) const {
     PainterScope painterScope(painter);
-    painter->setClipRect(option.rect);
+    painter->setClipRect(addMargins(option.rect));
 
     // Set the palette appropriately based on whether the row is selected or
     // not. We also have to check if it is inactive or not and use the
@@ -78,5 +78,9 @@ void TableItemDelegate::paintItem(
         QPainter* painter,
         const QStyleOptionViewItem& option,
         const QModelIndex& index) const {
-    QStyledItemDelegate::paint(painter, option, index);
+    painter->drawText(addMargins(option.rect), Qt::AlignVCenter, index.data().toString());
+}
+
+QRect TableItemDelegate::addMargins(const QRect& rect) const {
+    return QRect(rect.x() + 4, rect.y(), rect.width() - 8, rect.height());
 }

--- a/src/library/tableitemdelegate.h
+++ b/src/library/tableitemdelegate.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <QStyledItemDelegate>
+#include <QItemDelegate>
 #include <QTableView>
 
-class TableItemDelegate : public QStyledItemDelegate {
+class TableItemDelegate : public QItemDelegate {
     Q_OBJECT
   public:
     explicit TableItemDelegate(
@@ -27,6 +27,7 @@ class TableItemDelegate : public QStyledItemDelegate {
             const QModelIndex& index);
 
     int columnWidth(const QModelIndex &index) const;
+    QRect addMargins(const QRect& rect) const;
 
     QColor m_pFocusBorderColor;
     QTableView* m_pTableView;


### PR DESCRIPTION
Fixes library tableview drawing performance issues which holds up the Qt event loop, causing frame drops in the waveforms. (https://github.com/mixxxdj/mixxx/issues/11603)

Profiling (on macOS) pointed to QStyledItemDelegate.

This PR derives TableItemDelegate from QItemDelegate instead of from QStyledItemDelegate. The text is manually with painter->drawText(..) (and without eliding, which makes a big difference). 

BPMDelegate is still TODO (not drawing checkbox)

To discuss: how important is styling for the tableview?
