### PR TITLE
ci(packaging): Fail notarization if server returns "invalid" status

### DIFF
--- a/packaging/macos/sign_notarize_staple.sh
+++ b/packaging/macos/sign_notarize_staple.sh
@@ -44,6 +44,9 @@ while true; do
     elif [ "${NOTARIZATION_STATUS}" == "success" ]; then
         echo "Notarization succeeded"
         break
+    elif [ "${NOTARIZATION_STATUS}" == "invalid" ]; then
+        echo "Notarization failed with status: ${NOTARIZATION_STATUS}"
+        exit 1
     else
         echo "Notarization status: ${NOTARIZATION_STATUS}"
     fi


### PR DESCRIPTION
Otherwise it loops forever until the CI jobs runs into a timeout.