### PR TITLE
macOS packaging: Fix running macOS bundle from development build directory

### DIFF
--- a/src/preferences/configobject.cpp
+++ b/src/preferences/configobject.cpp
@@ -23,12 +23,24 @@ QString computeResourcePathImpl() {
 
     if (qResourcePath.isEmpty()) {
         QDir mixxxDir = QCoreApplication::applicationDirPath();
+
         // We used to support using the mixxx.cfg's [Config],Path setting but
         // this causes issues if you try and use two different versions of Mixxx
         // on the same computer.
-        auto cmakecache = QFile(mixxxDir.filePath(kCMakeCacheFile));
+
+        QDir potentialBuildDir = mixxxDir;
+#ifdef __APPLE__
+        if (potentialBuildDir.absolutePath().endsWith(".app/Contents/MacOS")) {
+            // We are in an app bundle (built with `-DMACOS_BUNDLE=ON`).
+            // If we are in a development build directory, we need to search three directories up.
+            potentialBuildDir.cd("../../..");
+        }
+#endif
+
+        // Check if there's a `CMakeCache.txt`, if so we are in a development build directory.
+        auto cmakecache = QFile(potentialBuildDir.filePath(kCMakeCacheFile));
         if (cmakecache.open(QFile::ReadOnly | QFile::Text)) {
-            // We are running form a build dir (CMAKE_CURRENT_BINARY_DIR),
+            // We are running from a build dir (CMAKE_CURRENT_BINARY_DIR),
             // Look up the source path from CMakeCache.txt (mixxx_SOURCE_DIR)
             QTextStream in(&cmakecache);
             QString line = in.readLine();

--- a/src/preferences/configobject.cpp
+++ b/src/preferences/configobject.cpp
@@ -42,7 +42,7 @@ QString computeResourcePathImpl() {
             DEBUG_ASSERT(QDir(qResourcePath).exists());
         }
 #if defined(__UNIX__)
-        else if (mixxxDir.cdUp() && mixxxDir.cd(QStringLiteral("share/mixxx"))) {
+        else if (mixxxDir.cd(QStringLiteral("../share/mixxx"))) {
             qResourcePath = mixxxDir.absolutePath();
         }
 #elif defined(__WINDOWS__)
@@ -52,7 +52,7 @@ QString computeResourcePathImpl() {
             qResourcePath = QCoreApplication::applicationDirPath();
         }
 #elif defined(__APPLE__)
-        else if (mixxxDir.cdUp() && mixxxDir.cd("Resources")) {
+        else if (mixxxDir.cd("../Resources")) {
             // Release configuration
             qResourcePath = mixxxDir.absolutePath();
         } else {


### PR DESCRIPTION
There are several configurations in which a developer could run a Mixxx build on macOS:

- `-DMACOS_BUNDLE=OFF`, running `<path to repo>/build/mixxx`
  - This works, since `ConfigObject::computeResourcePathImpl` will find the `CMakeCache.txt` and assume it's a dev build
- `-DMACOS_BUNDLE=ON` and running the App from a packaged DMG
  - This also works, since the `ConfigObject::computeResourcePathImpl` will find the packaged up `Resources` directory
- `-DMACOS_BUNDLE=ON` and running `<path to repo>/build/mixxx.app` (i.e. without packaging it up with `cpack`)
  - This currently **does not work**, since neither of the above assumptions are valid, the executable path does not contain a `CMakeCache.txt` and the `Resources` folder is not packaged up. The user thus sees this alert:
    <img width="372" alt="image" src="https://github.com/mixxxdj/mixxx/assets/30873659/f74d3253-386c-4c24-b73a-39c4543f8b10">


This PR fixes the third use case by searching for the `CMakeLists.txt` in the `mixxx.app` bundle's parent directory if it identifies that it is running from within an app bundle. Currently it searches `mixxx.app/Contents/MacOS`, where obviously it won't find anything.