### PR TITLE
improve glsl pre-roll triangles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1428,6 +1428,7 @@ else()
   if(QOPENGL)
     target_sources(mixxx-lib PRIVATE
       src/shaders/endoftrackshader.cpp
+      src/shaders/patternshader.cpp
       src/shaders/rgbashader.cpp
       src/shaders/rgbshader.cpp
       src/shaders/shader.cpp

--- a/src/shaders/endoftrackshader.cpp
+++ b/src/shaders/endoftrackshader.cpp
@@ -4,7 +4,7 @@ using namespace mixxx;
 
 void EndOfTrackShader::init() {
     QString vertexShaderCode = QStringLiteral(R"--(
-attribute highp vec4 position;
+attribute highp vec4 position; // use vec4 here (will be padded) to assign directly to gl_Position
 attribute highp float gradient;
 varying highp float vgradient;
 void main()

--- a/src/shaders/endoftrackshader.cpp
+++ b/src/shaders/endoftrackshader.cpp
@@ -21,9 +21,13 @@ void main()
 {
     highp float minAlpha = 0.5 * color.w;
     highp float maxAlpha = 0.83 * color.w;
-    gl_FragColor = vec4(color.xyz, mix(minAlpha, maxAlpha, max(0.,vgradient)));
+    gl_FragColor = vec4(color.xyz, mix(minAlpha, maxAlpha, max(0.0, vgradient)));
 }
 )--");
 
     load(vertexShaderCode, fragmentShaderCode);
+
+    m_positionLocation = attributeLocation("position");
+    m_gradientLocation = attributeLocation("gradient");
+    m_colorLocation = uniformLocation("color");
 }

--- a/src/shaders/endoftrackshader.h
+++ b/src/shaders/endoftrackshader.h
@@ -12,6 +12,20 @@ class mixxx::EndOfTrackShader : public mixxx::Shader {
     ~EndOfTrackShader() = default;
     void init();
 
+    int positionLocation() const {
+        return m_positionLocation;
+    }
+    int gradientLocation() const {
+        return m_gradientLocation;
+    }
+    int colorLocation() const {
+        return m_colorLocation;
+    }
+
   private:
+    int m_positionLocation;
+    int m_gradientLocation;
+    int m_colorLocation;
+
     DISALLOW_COPY_AND_ASSIGN(EndOfTrackShader)
 };

--- a/src/shaders/patternshader.cpp
+++ b/src/shaders/patternshader.cpp
@@ -1,0 +1,35 @@
+#include "shaders/patternshader.h"
+
+using namespace mixxx;
+
+void PatternShader::init() {
+    QString vertexShaderCode = QStringLiteral(R"--(
+uniform highp mat4 matrix;
+attribute highp vec4 position;
+attribute highp vec2 texcoor;
+varying highp vec2 vTexcoor;
+void main()
+{
+    vTexcoor = texcoor;
+    gl_Position = matrix * position;
+}
+)--");
+
+    QString fragmentShaderCode = QStringLiteral(R"--(
+uniform sampler2D sampler;
+uniform vec2 repetitions;
+varying highp vec2 vTexcoor;
+void main()
+{
+    gl_FragColor = texture2D(sampler, fract(vTexcoor * repetitions));
+}
+)--");
+
+    load(vertexShaderCode, fragmentShaderCode);
+
+    m_matrixLocation = uniformLocation("matrix");
+    m_samplerLocation = uniformLocation("sampler");
+    m_repetitionsLocation = uniformLocation("repetitions");
+    m_positionLocation = attributeLocation("position");
+    m_texcoordLocation = attributeLocation("texcoor");
+}

--- a/src/shaders/patternshader.cpp
+++ b/src/shaders/patternshader.cpp
@@ -5,7 +5,7 @@ using namespace mixxx;
 void PatternShader::init() {
     QString vertexShaderCode = QStringLiteral(R"--(
 uniform highp mat4 matrix;
-attribute highp vec4 position;
+attribute highp vec4 position; // use vec4 here (will be padded) for matrix multiplication
 attribute highp vec2 texcoor;
 varying highp vec2 vTexcoor;
 void main()

--- a/src/shaders/patternshader.cpp
+++ b/src/shaders/patternshader.cpp
@@ -16,20 +16,20 @@ void main()
 )--");
 
     QString fragmentShaderCode = QStringLiteral(R"--(
-uniform sampler2D sampler;
+uniform sampler2D texture;
 uniform vec2 repetitions;
 varying highp vec2 vTexcoor;
 void main()
 {
-    gl_FragColor = texture2D(sampler, fract(vTexcoor * repetitions));
+    gl_FragColor = texture2D(texture, fract(vTexcoor * repetitions));
 }
 )--");
 
     load(vertexShaderCode, fragmentShaderCode);
 
     m_matrixLocation = uniformLocation("matrix");
-    m_samplerLocation = uniformLocation("sampler");
-    m_repetitionsLocation = uniformLocation("repetitions");
     m_positionLocation = attributeLocation("position");
     m_texcoordLocation = attributeLocation("texcoor");
+    m_textureLocation = uniformLocation("texture");
+    m_repetitionsLocation = uniformLocation("repetitions");
 }

--- a/src/shaders/patternshader.h
+++ b/src/shaders/patternshader.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "shaders/shader.h"
+
+namespace mixxx {
+class PatternShader;
+}
+
+class mixxx::PatternShader final : public mixxx::Shader {
+  public:
+    PatternShader() = default;
+    ~PatternShader() = default;
+    void init();
+
+    int matrixLocation() const {
+        return m_matrixLocation;
+    }
+    int samplerLocation() const {
+        return m_samplerLocation;
+    }
+    int repetitionsLocation() const {
+        return m_repetitionsLocation;
+    }
+    int positionLocation() const {
+        return m_positionLocation;
+    }
+    int texcoordLocation() const {
+        return m_texcoordLocation;
+    }
+
+  private:
+    int m_matrixLocation;
+    int m_samplerLocation;
+    int m_repetitionsLocation;
+    int m_texcoordLocation;
+    int m_positionLocation;
+
+    DISALLOW_COPY_AND_ASSIGN(PatternShader)
+};

--- a/src/shaders/patternshader.h
+++ b/src/shaders/patternshader.h
@@ -15,25 +15,25 @@ class mixxx::PatternShader final : public mixxx::Shader {
     int matrixLocation() const {
         return m_matrixLocation;
     }
-    int samplerLocation() const {
-        return m_samplerLocation;
-    }
-    int repetitionsLocation() const {
-        return m_repetitionsLocation;
-    }
     int positionLocation() const {
         return m_positionLocation;
     }
     int texcoordLocation() const {
         return m_texcoordLocation;
     }
+    int textureLocation() const {
+        return m_textureLocation;
+    }
+    int repetitionsLocation() const {
+        return m_repetitionsLocation;
+    }
 
   private:
     int m_matrixLocation;
-    int m_samplerLocation;
-    int m_repetitionsLocation;
-    int m_texcoordLocation;
     int m_positionLocation;
+    int m_texcoordLocation;
+    int m_textureLocation;
+    int m_repetitionsLocation;
 
     DISALLOW_COPY_AND_ASSIGN(PatternShader)
 };

--- a/src/shaders/rgbashader.cpp
+++ b/src/shaders/rgbashader.cpp
@@ -4,7 +4,7 @@ using namespace mixxx;
 
 void RGBAShader::init() {
     QString vertexShaderCode = QStringLiteral(R"--(
-uniform mat4 matrix;
+uniform highp mat4 matrix;
 attribute highp vec4 position; // use vec4 here (will be padded) for matrix multiplication
 attribute highp vec4 color;
 varying highp vec4 vColor;

--- a/src/shaders/rgbashader.cpp
+++ b/src/shaders/rgbashader.cpp
@@ -7,21 +7,25 @@ void RGBAShader::init() {
 uniform mat4 matrix;
 attribute highp vec4 position;
 attribute highp vec4 color;
-varying highp vec4 vcolor;
+varying highp vec4 vColor;
 void main()
 {
-    vcolor = color;
+    vColor = color;
     gl_Position = matrix * position;
 }
 )--");
 
     QString fragmentShaderCode = QStringLiteral(R"--(
-varying highp vec4 vcolor;
+varying highp vec4 vColor;
 void main()
 {
-    gl_FragColor = vcolor;
+    gl_FragColor = vColor;
 }
 )--");
 
     load(vertexShaderCode, fragmentShaderCode);
+
+    m_matrixLocation = uniformLocation("matrix");
+    m_positionLocation = attributeLocation("position");
+    m_colorLocation = attributeLocation("color");
 }

--- a/src/shaders/rgbashader.cpp
+++ b/src/shaders/rgbashader.cpp
@@ -5,7 +5,7 @@ using namespace mixxx;
 void RGBAShader::init() {
     QString vertexShaderCode = QStringLiteral(R"--(
 uniform mat4 matrix;
-attribute highp vec4 position;
+attribute highp vec4 position; // use vec4 here (will be padded) for matrix multiplication
 attribute highp vec4 color;
 varying highp vec4 vColor;
 void main()

--- a/src/shaders/rgbashader.h
+++ b/src/shaders/rgbashader.h
@@ -12,6 +12,20 @@ class mixxx::RGBAShader final : public mixxx::Shader {
     ~RGBAShader() = default;
     void init();
 
+    int matrixLocation() const {
+        return m_matrixLocation;
+    }
+    int positionLocation() const {
+        return m_positionLocation;
+    }
+    int colorLocation() const {
+        return m_colorLocation;
+    }
+
   private:
+    int m_matrixLocation;
+    int m_positionLocation;
+    int m_colorLocation;
+
     DISALLOW_COPY_AND_ASSIGN(RGBAShader)
 };

--- a/src/shaders/rgbshader.cpp
+++ b/src/shaders/rgbshader.cpp
@@ -7,21 +7,25 @@ void RGBShader::init() {
 uniform mat4 matrix;
 attribute highp vec4 position;
 attribute highp vec3 color;
-varying highp vec3 vcolor;
+varying highp vec3 vColor;
 void main()
 {
-    vcolor = color;
+    vColor = color;
     gl_Position = matrix * position;
 }
 )--");
 
     QString fragmentShaderCode = QStringLiteral(R"--(
-varying highp vec3 vcolor;
+varying highp vec3 vColor;
 void main()
 {
-    gl_FragColor = vec4(vcolor,1.0);
+    gl_FragColor = vec4(vColor, 1.0);
 }
 )--");
 
     load(vertexShaderCode, fragmentShaderCode);
+
+    m_matrixLocation = uniformLocation("matrix");
+    m_positionLocation = attributeLocation("position");
+    m_colorLocation = attributeLocation("color");
 }

--- a/src/shaders/rgbshader.cpp
+++ b/src/shaders/rgbshader.cpp
@@ -5,7 +5,7 @@ using namespace mixxx;
 void RGBShader::init() {
     QString vertexShaderCode = QStringLiteral(R"--(
 uniform mat4 matrix;
-attribute highp vec4 position;
+attribute highp vec4 position; // use vec4 here (will be padded) for matrix multiplication
 attribute highp vec3 color;
 varying highp vec3 vColor;
 void main()

--- a/src/shaders/rgbshader.cpp
+++ b/src/shaders/rgbshader.cpp
@@ -4,7 +4,7 @@ using namespace mixxx;
 
 void RGBShader::init() {
     QString vertexShaderCode = QStringLiteral(R"--(
-uniform mat4 matrix;
+uniform highp mat4 matrix;
 attribute highp vec4 position; // use vec4 here (will be padded) for matrix multiplication
 attribute highp vec3 color;
 varying highp vec3 vColor;

--- a/src/shaders/rgbshader.h
+++ b/src/shaders/rgbshader.h
@@ -12,6 +12,20 @@ class mixxx::RGBShader final : public mixxx::Shader {
     ~RGBShader() = default;
     void init();
 
+    int matrixLocation() const {
+        return m_matrixLocation;
+    }
+    int positionLocation() const {
+        return m_positionLocation;
+    }
+    int colorLocation() const {
+        return m_colorLocation;
+    }
+
   private:
+    int m_matrixLocation;
+    int m_positionLocation;
+    int m_colorLocation;
+
     DISALLOW_COPY_AND_ASSIGN(RGBShader)
 };

--- a/src/shaders/textureshader.cpp
+++ b/src/shaders/textureshader.cpp
@@ -6,28 +6,28 @@ void TextureShader::init() {
     QString vertexShaderCode = QStringLiteral(R"--(
 uniform highp mat4 matrix;
 attribute highp vec4 position;
-attribute highp vec2 texcoor;
-varying highp vec2 vTexcoor;
+attribute highp vec2 texcoord;
+varying highp vec2 vTexcoord;
 void main()
 {
-    vTexcoor = texcoor;
+    vTexcoord = texcoord;
     gl_Position = matrix * position;
 }
 )--");
 
     QString fragmentShaderCode = QStringLiteral(R"--(
-uniform sampler2D sampler;
-varying highp vec2 vTexcoor;
+uniform sampler2D texture;
+varying highp vec2 vTexcoord;
 void main()
 {
-    gl_FragColor = texture2D(sampler, vTexcoor);
+    gl_FragColor = texture2D(texture, vTexcoord);
 }
 )--");
 
     load(vertexShaderCode, fragmentShaderCode);
 
     m_matrixLocation = uniformLocation("matrix");
-    m_samplerLocation = uniformLocation("sampler");
     m_positionLocation = attributeLocation("position");
-    m_texcoordLocation = attributeLocation("texcoor");
+    m_texcoordLocation = attributeLocation("texcoord");
+    m_textureLocation = uniformLocation("texture");
 }

--- a/src/shaders/textureshader.cpp
+++ b/src/shaders/textureshader.cpp
@@ -4,10 +4,10 @@ using namespace mixxx;
 
 void TextureShader::init() {
     QString vertexShaderCode = QStringLiteral(R"--(
-uniform mat4 matrix;
+uniform highp mat4 matrix;
 attribute highp vec4 position;
-attribute highp vec3 texcoor;
-varying highp vec3 vTexcoor;
+attribute highp vec2 texcoor;
+varying highp vec2 vTexcoor;
 void main()
 {
     vTexcoor = texcoor;
@@ -17,10 +17,10 @@ void main()
 
     QString fragmentShaderCode = QStringLiteral(R"--(
 uniform sampler2D sampler;
-varying highp vec3 vTexcoor;
+varying highp vec2 vTexcoor;
 void main()
 {
-    gl_FragColor = texture2D(sampler, vTexcoor.xy);
+    gl_FragColor = texture2D(sampler, vTexcoor);
 }
 )--");
 

--- a/src/shaders/textureshader.cpp
+++ b/src/shaders/textureshader.cpp
@@ -5,7 +5,7 @@ using namespace mixxx;
 void TextureShader::init() {
     QString vertexShaderCode = QStringLiteral(R"--(
 uniform highp mat4 matrix;
-attribute highp vec4 position;
+attribute highp vec4 position; // use vec4 here (will be padded) for matrix multiplication
 attribute highp vec2 texcoord;
 varying highp vec2 vTexcoord;
 void main()

--- a/src/shaders/textureshader.h
+++ b/src/shaders/textureshader.h
@@ -15,21 +15,21 @@ class mixxx::TextureShader final : public mixxx::Shader {
     int matrixLocation() const {
         return m_matrixLocation;
     }
-    int samplerLocation() const {
-        return m_samplerLocation;
-    }
     int positionLocation() const {
         return m_positionLocation;
     }
     int texcoordLocation() const {
         return m_texcoordLocation;
     }
+    int textureLocation() const {
+        return m_textureLocation;
+    }
 
   private:
     int m_matrixLocation;
-    int m_samplerLocation;
     int m_positionLocation;
     int m_texcoordLocation;
+    int m_textureLocation;
 
     DISALLOW_COPY_AND_ASSIGN(TextureShader)
 };

--- a/src/shaders/unicolorshader.cpp
+++ b/src/shaders/unicolorshader.cpp
@@ -21,4 +21,8 @@ void main()
 )--");
 
     load(vertexShaderCode, fragmentShaderCode);
+
+    m_matrixLocation = uniformLocation("matrix");
+    m_positionLocation = attributeLocation("position");
+    m_colorLocation = uniformLocation("color");
 }

--- a/src/shaders/unicolorshader.cpp
+++ b/src/shaders/unicolorshader.cpp
@@ -4,7 +4,7 @@ using namespace mixxx;
 
 void UnicolorShader::init() {
     QString vertexShaderCode = QStringLiteral(R"--(
-uniform mat4 matrix;
+uniform highp mat4 matrix;
 attribute highp vec4 position; // use vec4 here (will be padded) for matrix multiplication
 void main()
 {

--- a/src/shaders/unicolorshader.cpp
+++ b/src/shaders/unicolorshader.cpp
@@ -5,7 +5,7 @@ using namespace mixxx;
 void UnicolorShader::init() {
     QString vertexShaderCode = QStringLiteral(R"--(
 uniform mat4 matrix;
-attribute highp vec4 position;
+attribute highp vec4 position; // use vec4 here (will be padded) for matrix multiplication
 void main()
 {
     gl_Position = matrix * position;

--- a/src/shaders/unicolorshader.h
+++ b/src/shaders/unicolorshader.h
@@ -12,6 +12,20 @@ class mixxx::UnicolorShader final : public mixxx::Shader {
     ~UnicolorShader() = default;
     void init();
 
+    int matrixLocation() const {
+        return m_matrixLocation;
+    }
+    int positionLocation() const {
+        return m_positionLocation;
+    }
+    int colorLocation() const {
+        return m_colorLocation;
+    }
+
   private:
+    int m_matrixLocation;
+    int m_positionLocation;
+    int m_colorLocation;
+
     DISALLOW_COPY_AND_ASSIGN(UnicolorShader)
 };

--- a/src/shaders/vinylqualityshader.cpp
+++ b/src/shaders/vinylqualityshader.cpp
@@ -6,30 +6,30 @@ void VinylQualityShader::init() {
     QString vertexShaderCode = QStringLiteral(R"--(
 uniform mat4 matrix;
 attribute highp vec4 position;
-attribute highp vec3 texcoor;
-varying highp vec3 vTexcoor;
+attribute highp vec2 texcoord;
+varying highp vec2 vTexcoord;
 void main()
 {
-    vTexcoor = texcoor;
+    vTexcoord = texcoord;
     gl_Position = matrix * position;
 }
 )--");
 
     QString fragmentShaderCode = QStringLiteral(R"--(
-uniform sampler2D sampler;
-uniform highp vec4 color;
-varying highp vec3 vTexcoor;
+uniform sampler2D texture;
+uniform highp vec3 color;
+varying highp vec2 vTexcoord;
 void main()
 {
-    gl_FragColor = vec4(color.xyz, texture2D(sampler, vTexcoor.xy) * 0.75);
+    gl_FragColor = vec4(color, texture2D(texture, vTexcoord) * 0.75);
 }
 )--");
 
     load(vertexShaderCode, fragmentShaderCode);
 
     m_matrixLocation = uniformLocation("matrix");
-    m_samplerLocation = uniformLocation("sampler");
-    m_colorLocation = uniformLocation("color");
     m_positionLocation = attributeLocation("position");
-    m_texcoordLocation = attributeLocation("texcoor");
+    m_texcoordLocation = attributeLocation("texcoord");
+    m_textureLocation = uniformLocation("texture");
+    m_colorLocation = uniformLocation("color");
 }

--- a/src/shaders/vinylqualityshader.cpp
+++ b/src/shaders/vinylqualityshader.cpp
@@ -4,7 +4,7 @@ using namespace mixxx;
 
 void VinylQualityShader::init() {
     QString vertexShaderCode = QStringLiteral(R"--(
-uniform mat4 matrix;
+uniform highp mat4 matrix;
 attribute highp vec4 position; // use vec4 here (will be padded) for matrix multiplication
 attribute highp vec2 texcoord;
 varying highp vec2 vTexcoord;
@@ -17,11 +17,11 @@ void main()
 
     QString fragmentShaderCode = QStringLiteral(R"--(
 uniform sampler2D texture;
-uniform highp vec3 color;
+uniform highp vec4 color;
 varying highp vec2 vTexcoord;
 void main()
 {
-    gl_FragColor = vec4(color, texture2D(texture, vTexcoord) * 0.75);
+    gl_FragColor = vec4(color.xyz, texture2D(texture, vTexcoord) * color.w);
 }
 )--");
 

--- a/src/shaders/vinylqualityshader.cpp
+++ b/src/shaders/vinylqualityshader.cpp
@@ -5,7 +5,7 @@ using namespace mixxx;
 void VinylQualityShader::init() {
     QString vertexShaderCode = QStringLiteral(R"--(
 uniform mat4 matrix;
-attribute highp vec4 position;
+attribute highp vec4 position; // use vec4 here (will be padded) for matrix multiplication
 attribute highp vec2 texcoord;
 varying highp vec2 vTexcoord;
 void main()

--- a/src/shaders/vinylqualityshader.h
+++ b/src/shaders/vinylqualityshader.h
@@ -15,12 +15,6 @@ class mixxx::VinylQualityShader final : public mixxx::Shader {
     int matrixLocation() const {
         return m_matrixLocation;
     }
-    int samplerLocation() const {
-        return m_samplerLocation;
-    }
-    int colorLocation() const {
-        return m_colorLocation;
-    }
     int positionLocation() const {
         return m_positionLocation;
     }
@@ -28,12 +22,19 @@ class mixxx::VinylQualityShader final : public mixxx::Shader {
         return m_texcoordLocation;
     }
 
+    int textureLocation() const {
+        return m_textureLocation;
+    }
+    int colorLocation() const {
+        return m_colorLocation;
+    }
+
   private:
     int m_matrixLocation;
-    int m_samplerLocation;
-    int m_colorLocation;
     int m_positionLocation;
     int m_texcoordLocation;
+    int m_textureLocation;
+    int m_colorLocation;
 
     DISALLOW_COPY_AND_ASSIGN(VinylQualityShader)
 };

--- a/src/util/texture.cpp
+++ b/src/util/texture.cpp
@@ -1,10 +1,10 @@
 #include "util/texture.h"
 
-QOpenGLTexture* createTexture(const QImage& image) {
+std::unique_ptr<QOpenGLTexture> createTexture(const QImage& image) {
     if (image.isNull()) {
-        return nullptr;
+        return std::unique_ptr<QOpenGLTexture>{};
     }
-    QOpenGLTexture* pTexture = new QOpenGLTexture(image);
+    std::unique_ptr<QOpenGLTexture> pTexture{new QOpenGLTexture(image)};
     pTexture->setMinificationFilter(QOpenGLTexture::Linear);
     pTexture->setMagnificationFilter(QOpenGLTexture::Linear);
     pTexture->setWrapMode(QOpenGLTexture::ClampToEdge);
@@ -12,20 +12,20 @@ QOpenGLTexture* createTexture(const QImage& image) {
     return pTexture;
 }
 
-QOpenGLTexture* createTexture(const QPixmap& pixmap) {
+std::unique_ptr<QOpenGLTexture> createTexture(const QPixmap& pixmap) {
     return createTexture(pixmap.toImage());
 }
 
-QOpenGLTexture* createTexture(const QSharedPointer<Paintable>& pPaintable) {
+std::unique_ptr<QOpenGLTexture> createTexture(const QSharedPointer<Paintable>& pPaintable) {
     if (pPaintable.isNull()) {
-        return nullptr;
+        return std::unique_ptr<QOpenGLTexture>{};
     }
     return createTexture(pPaintable->toImage());
 }
 
-QOpenGLTexture* createTexture(const std::shared_ptr<QImage>& pImage) {
+std::unique_ptr<QOpenGLTexture> createTexture(const std::shared_ptr<QImage>& pImage) {
     if (!pImage) {
-        return nullptr;
+        return std::unique_ptr<QOpenGLTexture>{};
     }
     return createTexture(*pImage);
 }

--- a/src/util/texture.cpp
+++ b/src/util/texture.cpp
@@ -4,7 +4,7 @@ std::unique_ptr<QOpenGLTexture> createTexture(const QImage& image) {
     if (image.isNull()) {
         return std::unique_ptr<QOpenGLTexture>{};
     }
-    std::unique_ptr<QOpenGLTexture> pTexture{new QOpenGLTexture(image)};
+    auto pTexture = std::make_unique<QOpenGLTexture>(image);
     pTexture->setMinificationFilter(QOpenGLTexture::Linear);
     pTexture->setMagnificationFilter(QOpenGLTexture::Linear);
     pTexture->setWrapMode(QOpenGLTexture::ClampToEdge);

--- a/src/util/texture.cpp
+++ b/src/util/texture.cpp
@@ -2,7 +2,7 @@
 
 std::unique_ptr<QOpenGLTexture> createTexture(const QImage& image) {
     if (image.isNull()) {
-        return std::unique_ptr<QOpenGLTexture>{};
+        return nullptr;
     }
     std::unique_ptr<QOpenGLTexture> pTexture{new QOpenGLTexture(image)};
     pTexture->setMinificationFilter(QOpenGLTexture::Linear);
@@ -18,14 +18,14 @@ std::unique_ptr<QOpenGLTexture> createTexture(const QPixmap& pixmap) {
 
 std::unique_ptr<QOpenGLTexture> createTexture(const QSharedPointer<Paintable>& pPaintable) {
     if (pPaintable.isNull()) {
-        return std::unique_ptr<QOpenGLTexture>{};
+        return nullptr;
     }
     return createTexture(pPaintable->toImage());
 }
 
 std::unique_ptr<QOpenGLTexture> createTexture(const std::shared_ptr<QImage>& pImage) {
     if (!pImage) {
-        return std::unique_ptr<QOpenGLTexture>{};
+        return nullptr;
     }
     return createTexture(*pImage);
 }

--- a/src/util/texture.h
+++ b/src/util/texture.h
@@ -6,7 +6,7 @@
 
 #include "widget/paintable.h"
 
-QOpenGLTexture* createTexture(const QImage& image);
-QOpenGLTexture* createTexture(const QPixmap& pixmap);
-QOpenGLTexture* createTexture(const QSharedPointer<Paintable>& pPaintable);
-QOpenGLTexture* createTexture(const std::shared_ptr<QImage>& pImage);
+std::unique_ptr<QOpenGLTexture> createTexture(const QImage& image);
+std::unique_ptr<QOpenGLTexture> createTexture(const QPixmap& pixmap);
+std::unique_ptr<QOpenGLTexture> createTexture(const QSharedPointer<Paintable>& pPaintable);
+std::unique_ptr<QOpenGLTexture> createTexture(const std::shared_ptr<QImage>& pImage);

--- a/src/waveform/renderers/allshader/waveformrenderbeat.cpp
+++ b/src/waveform/renderers/allshader/waveformrenderbeat.cpp
@@ -105,24 +105,24 @@ void WaveformRenderBeat::paintGL() {
 
     DEBUG_ASSERT(reserved == m_vertices.size());
 
-    const int vertexLocation = m_shader.attributeLocation("position");
-    const int matrixLocation = m_shader.uniformLocation("matrix");
-    const int colorLocation = m_shader.uniformLocation("color");
+    const int positionLocation = m_shader.positionLocation();
+    const int matrixLocation = m_shader.matrixLocation();
+    const int colorLocation = m_shader.colorLocation();
 
     m_shader.bind();
-    m_shader.enableAttributeArray(vertexLocation);
+    m_shader.enableAttributeArray(positionLocation);
 
     const QMatrix4x4 matrix = matrixForWidgetGeometry(m_waveformRenderer, false);
 
     m_shader.setAttributeArray(
-            vertexLocation, GL_FLOAT, m_vertices.constData(), 2);
+            positionLocation, GL_FLOAT, m_vertices.constData(), 2);
 
     m_shader.setUniformValue(matrixLocation, matrix);
     m_shader.setUniformValue(colorLocation, m_color);
 
     glDrawArrays(GL_TRIANGLES, 0, m_vertices.size());
 
-    m_shader.disableAttributeArray(vertexLocation);
+    m_shader.disableAttributeArray(positionLocation);
     m_shader.release();
 }
 

--- a/src/waveform/renderers/allshader/waveformrendererendoftrack.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererendoftrack.cpp
@@ -55,9 +55,9 @@ void WaveformRendererEndOfTrack::initializeGL() {
 }
 
 void WaveformRendererEndOfTrack::fillWithGradient(QColor color) {
-    const int colorLocation = m_shader.uniformLocation("color");
-    const int positionLocation = m_shader.attributeLocation("position");
-    const int gradientLocation = m_shader.attributeLocation("gradient");
+    const int colorLocation = m_shader.colorLocation();
+    const int positionLocation = m_shader.positionLocation();
+    const int gradientLocation = m_shader.gradientLocation();
 
     m_shader.bind();
     m_shader.enableAttributeArray(positionLocation);

--- a/src/waveform/renderers/allshader/waveformrendererfiltered.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererfiltered.cpp
@@ -158,9 +158,9 @@ void WaveformRendererFiltered::paintGL() {
 
     const QMatrix4x4 matrix = matrixForWidgetGeometry(m_waveformRenderer, true);
 
-    const int matrixLocation = m_shader.uniformLocation("matrix");
-    const int colorLocation = m_shader.uniformLocation("color");
-    const int positionLocation = m_shader.attributeLocation("position");
+    const int matrixLocation = m_shader.matrixLocation();
+    const int colorLocation = m_shader.colorLocation();
+    const int positionLocation = m_shader.positionLocation();
 
     m_shader.bind();
     m_shader.enableAttributeArray(positionLocation);

--- a/src/waveform/renderers/allshader/waveformrendererhsv.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererhsv.cpp
@@ -190,9 +190,9 @@ void WaveformRendererHSV::paintGL() {
 
     const QMatrix4x4 matrix = matrixForWidgetGeometry(m_waveformRenderer, true);
 
-    const int matrixLocation = m_shader.uniformLocation("matrix");
-    const int positionLocation = m_shader.attributeLocation("position");
-    const int colorLocation = m_shader.attributeLocation("color");
+    const int matrixLocation = m_shader.matrixLocation();
+    const int positionLocation = m_shader.positionLocation();
+    const int colorLocation = m_shader.colorLocation();
 
     m_shader.bind();
     m_shader.enableAttributeArray(positionLocation);

--- a/src/waveform/renderers/allshader/waveformrendererlrrgb.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererlrrgb.cpp
@@ -205,9 +205,9 @@ void WaveformRendererLRRGB::paintGL() {
 
     const QMatrix4x4 matrix = matrixForWidgetGeometry(m_waveformRenderer, true);
 
-    const int matrixLocation = m_shader.uniformLocation("matrix");
-    const int positionLocation = m_shader.attributeLocation("position");
-    const int colorLocation = m_shader.attributeLocation("color");
+    const int matrixLocation = m_shader.matrixLocation();
+    const int positionLocation = m_shader.positionLocation();
+    const int colorLocation = m_shader.colorLocation();
 
     m_shader.bind();
     m_shader.enableAttributeArray(positionLocation);

--- a/src/waveform/renderers/allshader/waveformrendererpreroll.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererpreroll.cpp
@@ -61,7 +61,7 @@ void WaveformRendererPreroll::paintGL() {
     const float halfBreadth = m_waveformRenderer->getBreadth() * 0.5f;
     const float halfMarkerBreadth = markerBreadth * 0.5f;
 
-    const double markerLength = 40.0 / vSamplesPerPixel;
+    const float markerLength = 40.f / static_cast<float>(vSamplesPerPixel);
 
     // A series of markers will be drawn (by repeating the texture in a pattern)
     // from the left of the screen up until start (preroll) and from the right
@@ -97,22 +97,22 @@ void WaveformRendererPreroll::paintGL() {
 
     m_pTexture->bind();
 
+    const float end = m_waveformRenderer->getLength();
+
     if (preRollVisible) {
         // VSample position of the right-most triangle's tip
         const double triangleTipVSamplePosition =
                 playMarkerPosition * numberOfVSamples -
                 currentVSamplePosition;
         // In pixels
-        double x = triangleTipVSamplePosition / vSamplesPerPixel;
-        const double limit =
-                static_cast<double>(m_waveformRenderer->getLength()) +
-                markerLength;
+        float x = static_cast<float>(triangleTipVSamplePosition / vSamplesPerPixel);
+        const float limit = end + markerLength;
         if (x >= limit) {
             // Don't draw invisible triangles beyond the right side of the display
             x -= std::ceil((x - limit) / markerLength) * markerLength;
         }
 
-        drawPattern(0,
+        drawPattern(0.f,
                 halfBreadth - halfMarkerBreadth,
                 x,
                 halfBreadth + halfMarkerBreadth,
@@ -127,14 +127,13 @@ void WaveformRendererPreroll::paintGL() {
                 playMarkerPosition * numberOfVSamples +
                 remainingVSamples;
         // In pixels
-        double x = triangleTipVSamplePosition / vSamplesPerPixel;
-        const double limit = -markerLength;
+        float x = static_cast<float>(triangleTipVSamplePosition / vSamplesPerPixel);
+        const float limit = -markerLength;
         if (x <= limit) {
             // Don't draw invisible triangles before the left side of the display
             x += std::ceil((limit - x) / markerLength) * markerLength;
         }
 
-        const double end = static_cast<double>(m_waveformRenderer->getLength());
         drawPattern(x,
                 halfBreadth - halfMarkerBreadth,
                 end,
@@ -151,7 +150,7 @@ void WaveformRendererPreroll::paintGL() {
 }
 
 void WaveformRendererPreroll::drawPattern(
-        float x1, float y1, float x2, float y2, double repetitions, bool flip) {
+        float x1, float y1, float x2, float y2, float repetitions, bool flip) {
     // Draw a large rectangle with a repeating pattern of the texture
     const int numVerticesPerTriangle = 3;
     const int reserved = 2 * numVerticesPerTriangle;
@@ -212,6 +211,10 @@ void WaveformRendererPreroll::generateTexture(float markerLength, float markerBr
     path.lineTo(p1);
     path.lineTo(p0);
     path.closeSubpath();
+    QColor fillColor = m_color;
+    fillColor.setAlphaF(0.25);
+    painter.fillPath(path, QBrush(fillColor));
+
     painter.drawPath(path);
     painter.end();
 

--- a/src/waveform/renderers/allshader/waveformrendererpreroll.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererpreroll.cpp
@@ -12,6 +12,53 @@
 #include "widget/wskincolor.h"
 #include "widget/wwidget.h"
 
+namespace {
+QOpenGLTexture* generateTexture(float markerLength,
+        float markerBreadth,
+        float devicePixelRatio,
+        QColor color) {
+    const int imagePixelW = static_cast<int>(markerLength * devicePixelRatio + 0.5f);
+    const int imagePixelH = static_cast<int>(markerBreadth * devicePixelRatio + 0.5f);
+    const float imageW = static_cast<float>(imagePixelW) / devicePixelRatio;
+    const float imageH = static_cast<float>(imagePixelH) / devicePixelRatio;
+
+    QImage image(imagePixelW, imagePixelH, QImage::Format_ARGB32_Premultiplied);
+    image.setDevicePixelRatio(devicePixelRatio);
+
+    const float penWidth = 1.5f;
+    const float offset = penWidth / 2.f;
+
+    image.fill(QColor(0, 0, 0, 0).rgba());
+    QPainter painter;
+    painter.begin(&image);
+
+    painter.setWorldMatrixEnabled(false);
+
+    QPen pen(color);
+    pen.setWidthF(penWidth);
+    pen.setCapStyle(Qt::RoundCap);
+    painter.setPen(pen);
+    painter.setRenderHints(QPainter::Antialiasing);
+    // Draw base the right, tip to the left
+    QPointF p0{imageW - offset, offset};
+    QPointF p1{imageW - offset, imageH - offset};
+    QPointF p2{offset, imageH / 2.f};
+    QPainterPath path;
+    path.moveTo(p2);
+    path.lineTo(p1);
+    path.lineTo(p0);
+    path.closeSubpath();
+    QColor fillColor = color;
+    fillColor.setAlphaF(0.5f);
+    painter.fillPath(path, QBrush(fillColor));
+
+    painter.drawPath(path);
+    painter.end();
+
+    return createTexture(image);
+}
+} // anonymous namespace
+
 namespace allshader {
 
 WaveformRendererPreroll::WaveformRendererPreroll(WaveformWidgetRenderer* waveformWidget)
@@ -72,7 +119,12 @@ void WaveformRendererPreroll::paintGL() {
             std::abs(m_markerBreadth - markerBreadth) > epsilon) {
         // Regenerate the texture with the preroll marker (a triangle) if the size
         // has changed size last time.
-        generateTexture(markerLength, markerBreadth);
+        m_markerLength = markerLength;
+        m_markerBreadth = markerBreadth;
+        m_pTexture.reset(generateTexture(m_markerLength,
+                m_markerBreadth,
+                m_waveformRenderer->getDevicePixelRatio(),
+                m_color));
     }
 
     if (!m_pTexture) {
@@ -80,20 +132,20 @@ void WaveformRendererPreroll::paintGL() {
     }
 
     const int matrixLocation = m_shader.matrixLocation();
-    const int samplerLocation = m_shader.samplerLocation();
-    const int vertexLocation = m_shader.positionLocation();
+    const int textureLocation = m_shader.textureLocation();
+    const int positionLocation = m_shader.positionLocation();
     const int texcoordLocation = m_shader.texcoordLocation();
 
     // Set up the shader
     m_shader.bind();
 
-    m_shader.enableAttributeArray(vertexLocation);
+    m_shader.enableAttributeArray(positionLocation);
     m_shader.enableAttributeArray(texcoordLocation);
 
     const QMatrix4x4 matrix = matrixForWidgetGeometry(m_waveformRenderer, false);
 
     m_shader.setUniformValue(matrixLocation, matrix);
-    m_shader.setUniformValue(samplerLocation, 0);
+    m_shader.setUniformValue(textureLocation, 0);
 
     m_pTexture->bind();
 
@@ -112,12 +164,11 @@ void WaveformRendererPreroll::paintGL() {
             x -= std::ceil((x - limit) / markerLength) * markerLength;
         }
 
-        drawPattern(0.f,
+        drawPattern(x,
                 halfBreadth - halfMarkerBreadth,
-                x,
+                0.f,
                 halfBreadth + halfMarkerBreadth,
-                x / markerLength,
-                true);
+                x / markerLength);
     }
 
     if (postRollVisible) {
@@ -138,87 +189,33 @@ void WaveformRendererPreroll::paintGL() {
                 halfBreadth - halfMarkerBreadth,
                 end,
                 halfBreadth + halfMarkerBreadth,
-                (end - x) / markerLength,
-                false);
+                (end - x) / markerLength);
     }
 
     m_pTexture->release();
 
-    m_shader.disableAttributeArray(vertexLocation);
+    m_shader.disableAttributeArray(positionLocation);
     m_shader.disableAttributeArray(texcoordLocation);
     m_shader.release();
 }
 
 void WaveformRendererPreroll::drawPattern(
-        float x1, float y1, float x2, float y2, float repetitions, bool flip) {
+        float x1, float y1, float x2, float y2, float repetitions) {
     // Draw a large rectangle with a repeating pattern of the texture
-    const int numVerticesPerTriangle = 3;
-    const int reserved = 2 * numVerticesPerTriangle;
     const int repetitionsLocation = m_shader.repetitionsLocation();
-    const int vertexLocation = m_shader.positionLocation();
+    const int positionLocation = m_shader.positionLocation();
     const int texcoordLocation = m_shader.texcoordLocation();
 
-    m_vertices.clear();
-    m_texcoords.clear();
-    m_vertices.reserve(reserved);
-    m_texcoords.reserve(reserved);
-    m_vertices.addRectangle(x1, y1, x2, y2);
-    m_texcoords.addRectangle(flip ? 1.f : 0.f, 0.f, flip ? 0.f : 1.f, 1.f);
-
+    const std::array<float, 8> positionArray = {x1, y1, x2, y1, x1, y2, x2, y2};
+    const std::array<float, 8> texcoordArray = {0.f, 0.f, 1.f, 0.f, 0.f, 1.f, 1.f, 1.f};
     m_shader.setUniformValue(repetitionsLocation, QVector2D(repetitions, 1.0));
 
     m_shader.setAttributeArray(
-            vertexLocation, GL_FLOAT, m_vertices.constData(), 2);
+            positionLocation, GL_FLOAT, positionArray.data(), 2);
     m_shader.setAttributeArray(
-            texcoordLocation, GL_FLOAT, m_texcoords.constData(), 2);
+            texcoordLocation, GL_FLOAT, texcoordArray.data(), 2);
 
-    glDrawArrays(GL_TRIANGLES, 0, m_vertices.size());
-}
-
-void WaveformRendererPreroll::generateTexture(float markerLength, float markerBreadth) {
-    const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
-    m_markerLength = markerLength;
-    m_markerBreadth = markerBreadth;
-
-    const int imagePixelW = static_cast<int>(m_markerLength * devicePixelRatio + 0.5f);
-    const int imagePixelH = static_cast<int>(m_markerBreadth * devicePixelRatio + 0.5f);
-    const float imageW = static_cast<float>(imagePixelW) / devicePixelRatio;
-    const float imageH = static_cast<float>(imagePixelH) / devicePixelRatio;
-
-    QImage image(imagePixelW, imagePixelH, QImage::Format_ARGB32_Premultiplied);
-    image.setDevicePixelRatio(devicePixelRatio);
-
-    const float penWidth = 1.5f;
-    const float offset = penWidth / 2.f;
-
-    image.fill(QColor(0, 0, 0, 0).rgba());
-    QPainter painter;
-    painter.begin(&image);
-
-    painter.setWorldMatrixEnabled(false);
-
-    QPen pen(m_color);
-    pen.setWidthF(penWidth);
-    pen.setCapStyle(Qt::RoundCap);
-    painter.setPen(pen);
-    painter.setRenderHints(QPainter::Antialiasing);
-    // Draw base the right, tip to the left
-    QPointF p0{imageW - offset, offset};
-    QPointF p1{imageW - offset, imageH - offset};
-    QPointF p2{offset, imageH / 2.f};
-    QPainterPath path;
-    path.moveTo(p2);
-    path.lineTo(p1);
-    path.lineTo(p0);
-    path.closeSubpath();
-    QColor fillColor = m_color;
-    fillColor.setAlphaF(0.5f);
-    painter.fillPath(path, QBrush(fillColor));
-
-    painter.drawPath(path);
-    painter.end();
-
-    m_pTexture.reset(createTexture(image));
+    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 }
 
 } // namespace allshader

--- a/src/waveform/renderers/allshader/waveformrendererpreroll.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererpreroll.cpp
@@ -28,7 +28,7 @@ QOpenGLTexture* generateTexture(float markerLength,
     const float penWidth = 1.5f;
     const float offset = penWidth / 2.f;
 
-    image.fill(QColor(0, 0, 0, 0).rgba());
+    image.fill(Qt::transparent);
     QPainter painter;
     painter.begin(&image);
 

--- a/src/waveform/renderers/allshader/waveformrendererpreroll.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererpreroll.cpp
@@ -212,7 +212,7 @@ void WaveformRendererPreroll::generateTexture(float markerLength, float markerBr
     path.lineTo(p0);
     path.closeSubpath();
     QColor fillColor = m_color;
-    fillColor.setAlphaF(0.25);
+    fillColor.setAlphaF(0.5f);
     painter.fillPath(path, QBrush(fillColor));
 
     painter.drawPath(path);

--- a/src/waveform/renderers/allshader/waveformrendererpreroll.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererpreroll.cpp
@@ -13,7 +13,7 @@
 #include "widget/wwidget.h"
 
 namespace {
-QOpenGLTexture* generateTexture(float markerLength,
+std::unique_ptr<QOpenGLTexture> generateTexture(float markerLength,
         float markerBreadth,
         float devicePixelRatio,
         QColor color) {
@@ -121,10 +121,10 @@ void WaveformRendererPreroll::paintGL() {
         // has changed size last time.
         m_markerLength = markerLength;
         m_markerBreadth = markerBreadth;
-        m_pTexture.reset(generateTexture(m_markerLength,
+        m_pTexture = generateTexture(m_markerLength,
                 m_markerBreadth,
                 m_waveformRenderer->getDevicePixelRatio(),
-                m_color));
+                m_color);
     }
 
     if (!m_pTexture) {

--- a/src/waveform/renderers/allshader/waveformrendererpreroll.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererpreroll.cpp
@@ -1,9 +1,12 @@
 #include "waveform/renderers/allshader/waveformrendererpreroll.h"
 
 #include <QDomNode>
+#include <QOpenGLTexture>
+#include <QPainterPath>
 
 #include "skin/legacy/skincontext.h"
 #include "track/track.h"
+#include "util/texture.h"
 #include "waveform/renderers/allshader/matrixforwidgetgeometry.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
 #include "widget/wskincolor.h"
@@ -14,6 +17,8 @@ namespace allshader {
 WaveformRendererPreroll::WaveformRendererPreroll(WaveformWidgetRenderer* waveformWidget)
         : WaveformRenderer(waveformWidget) {
 }
+
+WaveformRendererPreroll::~WaveformRendererPreroll() = default;
 
 void WaveformRendererPreroll::setup(
         const QDomNode& node, const SkinContext& context) {
@@ -31,8 +36,6 @@ void WaveformRendererPreroll::paintGL() {
     if (!track) {
         return;
     }
-
-    m_vertices.clear();
 
     const double firstDisplayedPosition = m_waveformRenderer->getFirstDisplayedPosition();
     const double lastDisplayedPosition = m_waveformRenderer->getLastDisplayedPosition();
@@ -53,45 +56,68 @@ void WaveformRendererPreroll::paintGL() {
     const int currentVSamplePosition = m_waveformRenderer->getPlayPosVSample();
     const int totalVSamples = m_waveformRenderer->getTotalVSample();
 
-    const float halfBreadth = m_waveformRenderer->getBreadth() / 2.0f;
-    const float halfPolyBreadth = m_waveformRenderer->getBreadth() / 5.0f;
+    const float markerBreadth = m_waveformRenderer->getBreadth() * 0.4f;
 
-    const double polyPixelWidth = 40.0 / vSamplesPerPixel;
+    const float halfBreadth = m_waveformRenderer->getBreadth() * 0.5f;
+    const float halfMarkerBreadth = markerBreadth * 0.5f;
 
-    const int maxNumTriangles =
-            static_cast<int>(
-                    static_cast<double>(m_waveformRenderer->getLength()) /
-                    polyPixelWidth) +
-            2;
-    const int numVerticesPerTriangle = 3;
-    const int reserved = maxNumTriangles * numVerticesPerTriangle;
-    // for most pessimistic case, where we fill the entire display with triangles
-    m_vertices.reserve(reserved);
+    const double markerLength = 40.0 / vSamplesPerPixel;
+
+    // A series of markers will be drawn (by repeating the texture in a pattern)
+    // from the left of the screen up until start (preroll) and from the right
+    // of the screen up until the end (postroll) of the track respectively.
+
+    const float epsilon = 0.5f;
+    if (std::abs(m_markerLength - markerLength) > epsilon ||
+            std::abs(m_markerBreadth - markerBreadth) > epsilon) {
+        // Regenerate the texture with the preroll marker (a triangle) if the size
+        // has changed size last time.
+        generateTexture(markerLength, markerBreadth);
+    }
+
+    if (!m_pTexture) {
+        return;
+    }
+
+    const int matrixLocation = m_shader.matrixLocation();
+    const int samplerLocation = m_shader.samplerLocation();
+    const int vertexLocation = m_shader.positionLocation();
+    const int texcoordLocation = m_shader.texcoordLocation();
+
+    // Set up the shader
+    m_shader.bind();
+
+    m_shader.enableAttributeArray(vertexLocation);
+    m_shader.enableAttributeArray(texcoordLocation);
+
+    const QMatrix4x4 matrix = matrixForWidgetGeometry(m_waveformRenderer, false);
+
+    m_shader.setUniformValue(matrixLocation, matrix);
+    m_shader.setUniformValue(samplerLocation, 0);
+
+    m_pTexture->bind();
 
     if (preRollVisible) {
         // VSample position of the right-most triangle's tip
         const double triangleTipVSamplePosition =
-                numberOfVSamples * playMarkerPosition -
+                playMarkerPosition * numberOfVSamples -
                 currentVSamplePosition;
         // In pixels
         double x = triangleTipVSamplePosition / vSamplesPerPixel;
         const double limit =
                 static_cast<double>(m_waveformRenderer->getLength()) +
-                polyPixelWidth;
+                markerLength;
         if (x >= limit) {
             // Don't draw invisible triangles beyond the right side of the display
-            x -= std::ceil((x - limit) / polyPixelWidth) * polyPixelWidth;
+            x -= std::ceil((x - limit) / markerLength) * markerLength;
         }
 
-        while (x >= 0) {
-            const float x1 = static_cast<float>(x);
-            const float x2 = static_cast<float>(x - polyPixelWidth);
-            m_vertices.addTriangle({x1, halfBreadth},
-                    {x2, halfBreadth - halfPolyBreadth},
-                    {x2, halfBreadth + halfPolyBreadth});
-
-            x -= polyPixelWidth;
-        }
+        drawPattern(0,
+                halfBreadth - halfMarkerBreadth,
+                x,
+                halfBreadth + halfMarkerBreadth,
+                x / markerLength,
+                true);
     }
 
     if (postRollVisible) {
@@ -102,44 +128,94 @@ void WaveformRendererPreroll::paintGL() {
                 remainingVSamples;
         // In pixels
         double x = triangleTipVSamplePosition / vSamplesPerPixel;
-        const double limit = -polyPixelWidth;
+        const double limit = -markerLength;
         if (x <= limit) {
             // Don't draw invisible triangles before the left side of the display
-            x += std::ceil((limit - x) / polyPixelWidth) * polyPixelWidth;
+            x += std::ceil((limit - x) / markerLength) * markerLength;
         }
 
         const double end = static_cast<double>(m_waveformRenderer->getLength());
-        while (x < end) {
-            const float x1 = static_cast<float>(x);
-            const float x2 = static_cast<float>(x + polyPixelWidth);
-            m_vertices.addTriangle({x1, halfBreadth},
-                    {x2, halfBreadth - halfPolyBreadth},
-                    {x2, halfBreadth + halfPolyBreadth});
-            x += polyPixelWidth;
-        }
+        drawPattern(x,
+                halfBreadth - halfMarkerBreadth,
+                end,
+                halfBreadth + halfMarkerBreadth,
+                (end - x) / markerLength,
+                false);
     }
 
-    DEBUG_ASSERT(m_vertices.size() <= reserved);
+    m_pTexture->release();
 
-    const int vertexLocation = m_shader.attributeLocation("position");
-    const int matrixLocation = m_shader.uniformLocation("matrix");
-    const int colorLocation = m_shader.uniformLocation("color");
+    m_shader.disableAttributeArray(vertexLocation);
+    m_shader.disableAttributeArray(texcoordLocation);
+    m_shader.release();
+}
 
-    m_shader.bind();
-    m_shader.enableAttributeArray(vertexLocation);
+void WaveformRendererPreroll::drawPattern(
+        float x1, float y1, float x2, float y2, double repetitions, bool flip) {
+    // Draw a large rectangle with a repeating pattern of the texture
+    const int numVerticesPerTriangle = 3;
+    const int reserved = 2 * numVerticesPerTriangle;
+    const int repetitionsLocation = m_shader.repetitionsLocation();
+    const int vertexLocation = m_shader.positionLocation();
+    const int texcoordLocation = m_shader.texcoordLocation();
 
-    const QMatrix4x4 matrix = matrixForWidgetGeometry(m_waveformRenderer, false);
+    m_vertices.clear();
+    m_texcoords.clear();
+    m_vertices.reserve(reserved);
+    m_texcoords.reserve(reserved);
+    m_vertices.addRectangle(x1, y1, x2, y2);
+    m_texcoords.addRectangle(flip ? 1.f : 0.f, 0.f, flip ? 0.f : 1.f, 1.f);
+
+    m_shader.setUniformValue(repetitionsLocation, QVector2D(repetitions, 1.0));
 
     m_shader.setAttributeArray(
             vertexLocation, GL_FLOAT, m_vertices.constData(), 2);
-
-    m_shader.setUniformValue(matrixLocation, matrix);
-    m_shader.setUniformValue(colorLocation, m_color);
+    m_shader.setAttributeArray(
+            texcoordLocation, GL_FLOAT, m_texcoords.constData(), 2);
 
     glDrawArrays(GL_TRIANGLES, 0, m_vertices.size());
+}
 
-    m_shader.disableAttributeArray(vertexLocation);
-    m_shader.release();
+void WaveformRendererPreroll::generateTexture(float markerLength, float markerBreadth) {
+    const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
+    m_markerLength = markerLength;
+    m_markerBreadth = markerBreadth;
+
+    const int imagePixelW = static_cast<int>(m_markerLength * devicePixelRatio + 0.5f);
+    const int imagePixelH = static_cast<int>(m_markerBreadth * devicePixelRatio + 0.5f);
+    const float imageW = static_cast<float>(imagePixelW) / devicePixelRatio;
+    const float imageH = static_cast<float>(imagePixelH) / devicePixelRatio;
+
+    QImage image(imagePixelW, imagePixelH, QImage::Format_ARGB32_Premultiplied);
+    image.setDevicePixelRatio(devicePixelRatio);
+
+    const float penWidth = 1.5f;
+    const float offset = penWidth / 2.f;
+
+    image.fill(QColor(0, 0, 0, 0).rgba());
+    QPainter painter;
+    painter.begin(&image);
+
+    painter.setWorldMatrixEnabled(false);
+
+    QPen pen(m_color);
+    pen.setWidthF(penWidth);
+    pen.setCapStyle(Qt::RoundCap);
+    painter.setPen(pen);
+    painter.setRenderHints(QPainter::Antialiasing);
+    // Draw base the right, tip to the left
+    QPointF p0{imageW - offset, offset};
+    QPointF p1{imageW - offset, imageH - offset};
+    QPointF p2{offset, imageH / 2.f};
+    QPainterPath path;
+    path.moveTo(p2);
+    path.lineTo(p1);
+    path.lineTo(p0);
+    path.closeSubpath();
+    painter.drawPath(path);
+    painter.end();
+
+    m_pTexture.reset(createTexture(image));
 }
 
 } // namespace allshader

--- a/src/waveform/renderers/allshader/waveformrendererpreroll.h
+++ b/src/waveform/renderers/allshader/waveformrendererpreroll.h
@@ -26,7 +26,7 @@ class allshader::WaveformRendererPreroll final : public allshader::WaveformRende
     void initializeGL() override;
 
   private:
-    void drawPattern(float x1, float y1, float x2, float y2, double repetitions, bool flip);
+    void drawPattern(float x1, float y1, float x2, float y2, float repetitions, bool flip);
     void generateTexture(float markerLength, float markerBreadth);
 
     mixxx::PatternShader m_shader;

--- a/src/waveform/renderers/allshader/waveformrendererpreroll.h
+++ b/src/waveform/renderers/allshader/waveformrendererpreroll.h
@@ -26,16 +26,13 @@ class allshader::WaveformRendererPreroll final : public allshader::WaveformRende
     void initializeGL() override;
 
   private:
-    void drawPattern(float x1, float y1, float x2, float y2, float repetitions, bool flip);
-    void generateTexture(float markerLength, float markerBreadth);
+    void drawPattern(float x1, float y1, float x2, float y2, float repetitions);
 
     mixxx::PatternShader m_shader;
     QColor m_color;
     float m_markerBreadth{};
     float m_markerLength{};
     std::unique_ptr<QOpenGLTexture> m_pTexture;
-    VertexData m_vertices;
-    VertexData m_texcoords;
 
     DISALLOW_COPY_AND_ASSIGN(WaveformRendererPreroll);
 };

--- a/src/waveform/renderers/allshader/waveformrendererpreroll.h
+++ b/src/waveform/renderers/allshader/waveformrendererpreroll.h
@@ -1,14 +1,16 @@
 #pragma once
 
 #include <QColor>
+#include <QImage>
 
-#include "shaders/unicolorshader.h"
+#include "shaders/patternshader.h"
 #include "util/class.h"
 #include "waveform/renderers/allshader/vertexdata.h"
 #include "waveform/renderers/allshader/waveformrenderer.h"
 
 class QDomNode;
 class SkinContext;
+class QOpenGLTexture;
 
 namespace allshader {
 class WaveformRendererPreroll;
@@ -17,15 +19,23 @@ class WaveformRendererPreroll;
 class allshader::WaveformRendererPreroll final : public allshader::WaveformRenderer {
   public:
     explicit WaveformRendererPreroll(WaveformWidgetRenderer* waveformWidgetRenderer);
+    ~WaveformRendererPreroll() override;
 
     void setup(const QDomNode& node, const SkinContext& context) override;
     void paintGL() override;
     void initializeGL() override;
 
   private:
-    mixxx::UnicolorShader m_shader;
+    void drawPattern(float x1, float y1, float x2, float y2, double repetitions, bool flip);
+    void generateTexture(float markerLength, float markerBreadth);
+
+    mixxx::PatternShader m_shader;
     QColor m_color;
+    float m_markerBreadth{};
+    float m_markerLength{};
+    std::unique_ptr<QOpenGLTexture> m_pTexture;
     VertexData m_vertices;
+    VertexData m_texcoords;
 
     DISALLOW_COPY_AND_ASSIGN(WaveformRendererPreroll);
 };

--- a/src/waveform/renderers/allshader/waveformrendererrgb.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererrgb.cpp
@@ -204,9 +204,9 @@ void WaveformRendererRGB::paintGL() {
 
     const QMatrix4x4 matrix = matrixForWidgetGeometry(m_waveformRenderer, true);
 
-    const int matrixLocation = m_shader.uniformLocation("matrix");
-    const int positionLocation = m_shader.attributeLocation("position");
-    const int colorLocation = m_shader.attributeLocation("color");
+    const int matrixLocation = m_shader.matrixLocation();
+    const int positionLocation = m_shader.positionLocation();
+    const int colorLocation = m_shader.colorLocation();
 
     m_shader.bind();
     m_shader.enableAttributeArray(positionLocation);

--- a/src/waveform/renderers/allshader/waveformrenderersimple.cpp
+++ b/src/waveform/renderers/allshader/waveformrenderersimple.cpp
@@ -147,9 +147,9 @@ void WaveformRendererSimple::paintGL() {
 
     const QMatrix4x4 matrix = matrixForWidgetGeometry(m_waveformRenderer, true);
 
-    const int matrixLocation = m_shader.uniformLocation("matrix");
-    const int colorLocation = m_shader.uniformLocation("color");
-    const int positionLocation = m_shader.attributeLocation("position");
+    const int matrixLocation = m_shader.matrixLocation();
+    const int colorLocation = m_shader.colorLocation();
+    const int positionLocation = m_shader.positionLocation();
 
     m_shader.bind();
     m_shader.enableAttributeArray(positionLocation);

--- a/src/waveform/renderers/allshader/waveformrendermark.cpp
+++ b/src/waveform/renderers/allshader/waveformrendermark.cpp
@@ -298,7 +298,7 @@ void allshader::WaveformRenderMark::generatePlayPosMarkTexture(float breadth) {
     }
     painter.end();
 
-    m_pPlayPosMarkTexture.reset(createTexture(image));
+    m_pPlayPosMarkTexture = createTexture(image);
 }
 
 void allshader::WaveformRenderMark::drawTriangle(QPainter* painter,
@@ -405,7 +405,7 @@ void allshader::WaveformRenderMark::generateMarkImage(WaveformMarkPointer pMark,
             //  Also, without this some Qt-internal issue results in an offset
             //  image when calculating the center line of pixmaps in draw().
             pMark->m_image.setDevicePixelRatio(devicePixelRatio);
-            pMark->m_pTexture.reset(createTexture(pMark->m_image));
+            pMark->m_pTexture = createTexture(pMark->m_image);
             return;
         }
     }
@@ -547,5 +547,5 @@ void allshader::WaveformRenderMark::generateMarkImage(WaveformMarkPointer pMark,
         painter.drawText(labelRect, Qt::AlignCenter, label);
     }
 
-    pMark->m_pTexture.reset(createTexture(pMark->m_image));
+    pMark->m_pTexture = createTexture(pMark->m_image);
 }

--- a/src/waveform/renderers/allshader/waveformrendermark.cpp
+++ b/src/waveform/renderers/allshader/waveformrendermark.cpp
@@ -80,9 +80,9 @@ void allshader::WaveformRenderMark::drawTexture(float x, float y, QOpenGLTexture
     m_textureShader.bind();
 
     const int matrixLocation = m_textureShader.uniformLocation("matrix");
-    const int samplerLocation = m_textureShader.uniformLocation("sampler");
+    const int textureLocation = m_textureShader.uniformLocation("texture");
     const int positionLocation = m_textureShader.attributeLocation("position");
-    const int texcoordLocation = m_textureShader.attributeLocation("texcoor");
+    const int texcoordLocation = m_textureShader.attributeLocation("texcoord");
 
     m_textureShader.setUniformValue(matrixLocation, matrix);
 
@@ -93,7 +93,7 @@ void allshader::WaveformRenderMark::drawTexture(float x, float y, QOpenGLTexture
     m_textureShader.setAttributeArray(
             texcoordLocation, GL_FLOAT, texarray, 2);
 
-    m_textureShader.setUniformValue(samplerLocation, 0);
+    m_textureShader.setUniformValue(textureLocation, 0);
 
     texture->bind();
 
@@ -135,9 +135,9 @@ void allshader::WaveformRenderMark::drawMark(const QRectF& rect, QColor color) {
 
     m_rgbaShader.bind();
 
-    int matrixLocation = m_rgbaShader.uniformLocation("matrix");
-    int positionLocation = m_rgbaShader.attributeLocation("position");
-    int colorLocation = m_rgbaShader.attributeLocation("color");
+    const int matrixLocation = m_rgbaShader.matrixLocation();
+    const int positionLocation = m_rgbaShader.positionLocation();
+    const int colorLocation = m_rgbaShader.colorLocation();
 
     m_rgbaShader.setUniformValue(matrixLocation, matrix);
 
@@ -359,7 +359,7 @@ void allshader::WaveformRenderMark::checkCuesUpdated() {
 
     QList<CuePointer> loadedCues = trackInfo->getCuePoints();
     for (const CuePointer& pCue : loadedCues) {
-        int hotCue = pCue->getHotCue();
+        const int hotCue = pCue->getHotCue();
         if (hotCue == Cue::kNoHotCue) {
             continue;
         }
@@ -377,7 +377,7 @@ void allshader::WaveformRenderMark::checkCuesUpdated() {
                 !pMark->fillColor().isValid() ||
                 newColor != pMark->fillColor()) {
             pMark->m_text = newLabel;
-            int dimBrightThreshold = m_waveformRenderer->getDimBrightThreshold();
+            const int dimBrightThreshold = m_waveformRenderer->getDimBrightThreshold();
             pMark->setBaseColor(newColor, dimBrightThreshold);
             generateMarkImage(pMark, m_waveformRenderer->getBreadth());
         }

--- a/src/waveform/renderers/allshader/waveformrendermark.cpp
+++ b/src/waveform/renderers/allshader/waveformrendermark.cpp
@@ -10,6 +10,7 @@
 #include "util/color/color.h"
 #include "util/colorcomponents.h"
 #include "util/painterscope.h"
+#include "util/texture.h"
 #include "waveform/renderers/allshader/matrixforwidgetgeometry.h"
 #include "waveform/renderers/allshader/moc_waveformrendermark.cpp"
 #include "waveform/renderers/allshader/rgbadata.h"
@@ -78,10 +79,10 @@ void allshader::WaveformRenderMark::drawTexture(float x, float y, QOpenGLTexture
 
     m_textureShader.bind();
 
-    int matrixLocation = m_textureShader.uniformLocation("matrix");
-    int samplerLocation = m_textureShader.uniformLocation("sampler");
-    int positionLocation = m_textureShader.attributeLocation("position");
-    int texcoordLocation = m_textureShader.attributeLocation("texcoor");
+    const int matrixLocation = m_textureShader.uniformLocation("matrix");
+    const int samplerLocation = m_textureShader.uniformLocation("sampler");
+    const int positionLocation = m_textureShader.attributeLocation("position");
+    const int texcoordLocation = m_textureShader.attributeLocation("texcoor");
 
     m_textureShader.setUniformValue(matrixLocation, matrix);
 
@@ -297,10 +298,7 @@ void allshader::WaveformRenderMark::generatePlayPosMarkTexture(float breadth) {
     }
     painter.end();
 
-    m_pPlayPosMarkTexture.reset(new QOpenGLTexture(image));
-    m_pPlayPosMarkTexture->setMinificationFilter(QOpenGLTexture::Linear);
-    m_pPlayPosMarkTexture->setMagnificationFilter(QOpenGLTexture::Linear);
-    m_pPlayPosMarkTexture->setWrapMode(QOpenGLTexture::ClampToBorder);
+    m_pPlayPosMarkTexture.reset(createTexture(image));
 }
 
 void allshader::WaveformRenderMark::drawTriangle(QPainter* painter,
@@ -407,10 +405,7 @@ void allshader::WaveformRenderMark::generateMarkImage(WaveformMarkPointer pMark,
             //  Also, without this some Qt-internal issue results in an offset
             //  image when calculating the center line of pixmaps in draw().
             pMark->m_image.setDevicePixelRatio(devicePixelRatio);
-            pMark->m_pTexture.reset(new QOpenGLTexture(pMark->m_image));
-            pMark->m_pTexture->setMinificationFilter(QOpenGLTexture::Linear);
-            pMark->m_pTexture->setMagnificationFilter(QOpenGLTexture::Linear);
-            pMark->m_pTexture->setWrapMode(QOpenGLTexture::ClampToBorder);
+            pMark->m_pTexture.reset(createTexture(pMark->m_image));
             return;
         }
     }
@@ -552,8 +547,5 @@ void allshader::WaveformRenderMark::generateMarkImage(WaveformMarkPointer pMark,
         painter.drawText(labelRect, Qt::AlignCenter, label);
     }
 
-    pMark->m_pTexture.reset(new QOpenGLTexture(pMark->m_image));
-    pMark->m_pTexture->setMinificationFilter(QOpenGLTexture::Linear);
-    pMark->m_pTexture->setMagnificationFilter(QOpenGLTexture::Linear);
-    pMark->m_pTexture->setWrapMode(QOpenGLTexture::ClampToBorder);
+    pMark->m_pTexture.reset(createTexture(pMark->m_image));
 }

--- a/src/waveform/renderers/allshader/waveformrendermarkrange.cpp
+++ b/src/waveform/renderers/allshader/waveformrendermarkrange.cpp
@@ -30,8 +30,8 @@ void allshader::WaveformRenderMarkRange::fillRect(
 
     const float posarray[] = {posx1, posy1, posx2, posy1, posx1, posy2, posx2, posy2};
 
-    int colorLocation = m_shader.uniformLocation("color");
-    int positionLocation = m_shader.attributeLocation("position");
+    const int colorLocation = m_shader.colorLocation();
+    const int positionLocation = m_shader.positionLocation();
 
     m_shader.setUniformValue(colorLocation, color);
 
@@ -65,12 +65,12 @@ void allshader::WaveformRenderMarkRange::paintGL() {
 
     const QMatrix4x4 matrix = matrixForWidgetGeometry(m_waveformRenderer, false);
 
-    int positionLocation = m_shader.attributeLocation("position");
+    const int positionLocation = m_shader.positionLocation();
+    const int matrixLocation = m_shader.matrixLocation();
 
     m_shader.bind();
     m_shader.enableAttributeArray(positionLocation);
 
-    int matrixLocation = m_shader.uniformLocation("matrix");
     m_shader.setUniformValue(matrixLocation, matrix);
 
     for (auto&& markRange : m_markRanges) {

--- a/src/widget/wspinnyglsl.cpp
+++ b/src/widget/wspinnyglsl.cpp
@@ -97,17 +97,17 @@ void WSpinnyGLSL::paintGL() {
     m_textureShader.bind();
 
     int matrixLocation = m_textureShader.matrixLocation();
-    int samplerLocation = m_textureShader.samplerLocation();
+    int textureLocation = m_textureShader.textureLocation();
     int positionLocation = m_textureShader.positionLocation();
     int texcoordLocation = m_textureShader.texcoordLocation();
 
-    QMatrix4x4 matrix;
+    QMatrix matrix;
     m_textureShader.setUniformValue(matrixLocation, matrix);
 
     m_textureShader.enableAttributeArray(positionLocation);
     m_textureShader.enableAttributeArray(texcoordLocation);
 
-    m_textureShader.setUniformValue(samplerLocation, 0);
+    m_textureShader.setUniformValue(textureLocation, 0);
 
     if (m_pBgTexture) {
         drawTexture(m_pBgTexture.get());
@@ -137,16 +137,16 @@ void WSpinnyGLSL::paintGL() {
     bool paintGhost = m_bGhostPlayback && m_pGhostTextureScaled;
 
     if (paintGhost) {
-        QMatrix4x4 rotate;
-        rotate.rotate(m_fGhostAngle, 0, 0, -1);
+        QMatrix rotate;
+        rotate.rotate(-m_fGhostAngle);
         m_textureShader.setUniformValue(matrixLocation, rotate);
 
         drawTexture(m_pGhostTextureScaled.get());
     }
 
     if (m_pFgTextureScaled) {
-        QMatrix4x4 rotate;
-        rotate.rotate(m_fAngle, 0, 0, -1);
+        QMatrix rotate;
+        rotate.rotate(-m_fAngle);
         m_textureShader.setUniformValue(matrixLocation, rotate);
 
         drawTexture(m_pFgTextureScaled.get());
@@ -185,16 +185,16 @@ void WSpinnyGLSL::drawTexture(QOpenGLTexture* texture) {
     const float posx1 = -posx2;
     const float posy1 = -posy2;
 
-    const float posarray[] = {posx1, posy1, posx2, posy1, posx1, posy2, posx2, posy2};
-    const float texarray[] = {texx1, texy1, texx2, texy1, texx1, texy2, texx2, texy2};
+    const std::array<float, 8> posarray = {posx1, posy1, posx2, posy1, posx1, posy2, posx2, posy2};
+    const std::array<float, 8> texarray = {texx1, texy1, texx2, texy1, texx1, texy2, texx2, texy2};
 
     int positionLocation = m_textureShader.positionLocation();
     int texcoordLocation = m_textureShader.texcoordLocation();
 
     m_textureShader.setAttributeArray(
-            positionLocation, GL_FLOAT, posarray, 2);
+            positionLocation, GL_FLOAT, posarray.data(), 2);
     m_textureShader.setAttributeArray(
-            texcoordLocation, GL_FLOAT, texarray, 2);
+            texcoordLocation, GL_FLOAT, texarray.data(), 2);
 
     texture->bind();
 
@@ -214,29 +214,29 @@ void WSpinnyGLSL::drawVinylQuality() {
     const float posx1 = -1.f;
     const float posy1 = -1.f;
 
-    const float posarray[] = {posx1, posy1, posx2, posy1, posx1, posy2, posx2, posy2};
-    const float texarray[] = {texx1, texy1, texx2, texy1, texx1, texy2, texx2, texy2};
+    const std::array<float, 8> posarray = {posx1, posy1, posx2, posy1, posx1, posy2, posx2, posy2};
+    const std::array<float, 8> texarray = {texx1, texy1, texx2, texy1, texx1, texy2, texx2, texy2};
 
     m_vinylQualityShader.bind();
     int matrixLocation = m_vinylQualityShader.matrixLocation();
     int colorLocation = m_vinylQualityShader.colorLocation();
-    int samplerLocation = m_vinylQualityShader.samplerLocation();
+    int textureLocation = m_vinylQualityShader.textureLocation();
     int positionLocation = m_vinylQualityShader.positionLocation();
     int texcoordLocation = m_vinylQualityShader.texcoordLocation();
 
-    QMatrix4x4 matrix;
+    QMatrix matrix;
     m_vinylQualityShader.setUniformValue(matrixLocation, matrix);
     m_vinylQualityShader.setUniformValue(colorLocation, m_vinylQualityColor);
 
     m_vinylQualityShader.enableAttributeArray(positionLocation);
     m_vinylQualityShader.enableAttributeArray(texcoordLocation);
 
-    m_vinylQualityShader.setUniformValue(samplerLocation, 0);
+    m_vinylQualityShader.setUniformValue(textureLocation, 0);
 
     m_vinylQualityShader.setAttributeArray(
-            positionLocation, GL_FLOAT, posarray, 2);
+            positionLocation, GL_FLOAT, posarray.data(), 2);
     m_vinylQualityShader.setAttributeArray(
-            texcoordLocation, GL_FLOAT, texarray, 2);
+            texcoordLocation, GL_FLOAT, texarray.data(), 2);
 
     m_pQTexture->bind();
 

--- a/src/widget/wspinnyglsl.cpp
+++ b/src/widget/wspinnyglsl.cpp
@@ -31,7 +31,7 @@ void WSpinnyGLSL::cleanupGL() {
 void WSpinnyGLSL::coverChanged() {
     if (isContextValid()) {
         makeCurrentIfNeeded();
-        m_pLoadedCoverTextureScaled.reset(createTexture(m_loadedCoverScaled));
+        m_pLoadedCoverTextureScaled = createTexture(m_loadedCoverScaled);
         doneCurrent();
     }
     // otherwise this will happen in initializeGL
@@ -53,11 +53,11 @@ void WSpinnyGLSL::resizeGL(int w, int h) {
 }
 
 void WSpinnyGLSL::updateTextures() {
-    m_pBgTexture.reset(createTexture(m_pBgImage));
-    m_pMaskTexture.reset(createTexture(m_pMaskImage));
-    m_pFgTextureScaled.reset(createTexture(m_fgImageScaled));
-    m_pGhostTextureScaled.reset(createTexture(m_ghostImageScaled));
-    m_pLoadedCoverTextureScaled.reset(createTexture(m_loadedCoverScaled));
+    m_pBgTexture = createTexture(m_pBgImage);
+    m_pMaskTexture = createTexture(m_pMaskImage);
+    m_pFgTextureScaled = createTexture(m_fgImageScaled);
+    m_pGhostTextureScaled = createTexture(m_ghostImageScaled);
+    m_pLoadedCoverTextureScaled = createTexture(m_loadedCoverScaled);
 }
 
 void WSpinnyGLSL::setupVinylSignalQuality() {

--- a/src/widget/wspinnyglsl.cpp
+++ b/src/widget/wspinnyglsl.cpp
@@ -101,7 +101,7 @@ void WSpinnyGLSL::paintGL() {
     int positionLocation = m_textureShader.positionLocation();
     int texcoordLocation = m_textureShader.texcoordLocation();
 
-    QMatrix matrix;
+    QMatrix4x4 matrix;
     m_textureShader.setUniformValue(matrixLocation, matrix);
 
     m_textureShader.enableAttributeArray(positionLocation);
@@ -137,16 +137,16 @@ void WSpinnyGLSL::paintGL() {
     bool paintGhost = m_bGhostPlayback && m_pGhostTextureScaled;
 
     if (paintGhost) {
-        QMatrix rotate;
-        rotate.rotate(-m_fGhostAngle);
+        QMatrix4x4 rotate;
+        rotate.rotate(-m_fGhostAngle, 0, 0);
         m_textureShader.setUniformValue(matrixLocation, rotate);
 
         drawTexture(m_pGhostTextureScaled.get());
     }
 
     if (m_pFgTextureScaled) {
-        QMatrix rotate;
-        rotate.rotate(-m_fAngle);
+        QMatrix4x4 rotate;
+        rotate.rotate(-m_fAngle, 0, 0);
         m_textureShader.setUniformValue(matrixLocation, rotate);
 
         drawTexture(m_pFgTextureScaled.get());
@@ -224,7 +224,7 @@ void WSpinnyGLSL::drawVinylQuality() {
     int positionLocation = m_vinylQualityShader.positionLocation();
     int texcoordLocation = m_vinylQualityShader.texcoordLocation();
 
-    QMatrix matrix;
+    QMatrix4x4 matrix;
     m_vinylQualityShader.setUniformValue(matrixLocation, matrix);
     m_vinylQualityShader.setUniformValue(colorLocation, m_vinylQualityColor);
 

--- a/src/widget/wspinnyglsl.cpp
+++ b/src/widget/wspinnyglsl.cpp
@@ -138,7 +138,7 @@ void WSpinnyGLSL::paintGL() {
 
     if (paintGhost) {
         QMatrix4x4 rotate;
-        rotate.rotate(-m_fGhostAngle, 0, 0);
+        rotate.rotate(m_fGhostAngle, 0, 0, -1);
         m_textureShader.setUniformValue(matrixLocation, rotate);
 
         drawTexture(m_pGhostTextureScaled.get());

--- a/src/widget/wspinnyglsl.cpp
+++ b/src/widget/wspinnyglsl.cpp
@@ -146,7 +146,7 @@ void WSpinnyGLSL::paintGL() {
 
     if (m_pFgTextureScaled) {
         QMatrix4x4 rotate;
-        rotate.rotate(-m_fAngle, 0, 0);
+        rotate.rotate(m_fAngle, 0, 0, -1);
         m_textureShader.setUniformValue(matrixLocation, rotate);
 
         drawTexture(m_pFgTextureScaled.get());

--- a/src/widget/wspinnyglsl.cpp
+++ b/src/widget/wspinnyglsl.cpp
@@ -66,6 +66,7 @@ void WSpinnyGLSL::setupVinylSignalQuality() {
 void WSpinnyGLSL::updateVinylSignalQualityImage(
         const QColor& qual_color, const unsigned char* data) {
     m_vinylQualityColor = qual_color;
+    m_vinylQualityColor.setAlphaF(0.75f);
     if (m_pQTexture) {
         makeCurrentIfNeeded();
         m_pQTexture->bind();

--- a/src/widget/wvumeterglsl.cpp
+++ b/src/widget/wvumeterglsl.cpp
@@ -24,8 +24,8 @@ void WVuMeterGLSL::draw() {
 void WVuMeterGLSL::initializeGL() {
     initializeOpenGLFunctions();
 
-    m_pTextureBack.reset(createTexture(m_pPixmapBack));
-    m_pTextureVu.reset(createTexture(m_pPixmapVu));
+    m_pTextureBack = createTexture(m_pPixmapBack);
+    m_pTextureVu = createTexture(m_pPixmapVu);
     m_textureShader.init();
 }
 

--- a/src/widget/wvumeterglsl.cpp
+++ b/src/widget/wvumeterglsl.cpp
@@ -46,7 +46,7 @@ void WVuMeterGLSL::paintGL() {
     m_textureShader.bind();
 
     int matrixLocation = m_textureShader.matrixLocation();
-    int samplerLocation = m_textureShader.samplerLocation();
+    int textureLocation = m_textureShader.textureLocation();
     int positionLocation = m_textureShader.positionLocation();
     int texcoordLocation = m_textureShader.texcoordLocation();
 
@@ -57,7 +57,7 @@ void WVuMeterGLSL::paintGL() {
     m_textureShader.enableAttributeArray(positionLocation);
     m_textureShader.enableAttributeArray(texcoordLocation);
 
-    m_textureShader.setUniformValue(samplerLocation, 0);
+    m_textureShader.setUniformValue(textureLocation, 0);
 
     if (m_pTextureBack) {
         QRectF sourceRect(0, 0, m_pPixmapBack->width(), m_pPixmapBack->height());
@@ -163,16 +163,16 @@ void WVuMeterGLSL::drawTexture(QOpenGLTexture* texture,
     const float posx2 = static_cast<float>(targetRect.x() + targetRect.width());
     const float posy2 = static_cast<float>(targetRect.y() + targetRect.height());
 
-    const float posarray[] = {posx1, posy1, posx2, posy1, posx1, posy2, posx2, posy2};
-    const float texarray[] = {texx1, texy1, texx2, texy1, texx1, texy2, texx2, texy2};
+    const std::array<float, 8> posarray = {posx1, posy1, posx2, posy1, posx1, posy2, posx2, posy2};
+    const std::array<float, 8> texarray = {texx1, texy1, texx2, texy1, texx1, texy2, texx2, texy2};
 
     int positionLocation = m_textureShader.positionLocation();
     int texcoordLocation = m_textureShader.texcoordLocation();
 
     m_textureShader.setAttributeArray(
-            positionLocation, GL_FLOAT, posarray, 2);
+            positionLocation, GL_FLOAT, posarray.data(), 2);
     m_textureShader.setAttributeArray(
-            texcoordLocation, GL_FLOAT, texarray, 2);
+            texcoordLocation, GL_FLOAT, texarray.data(), 2);
 
     texture->bind();
 


### PR DESCRIPTION
draw the glsl preroll and postroll markers with a patterned texture and some minor additional cleanups

fixes https://github.com/mixxxdj/mixxx/issues/12015 , initially bringing GLSL waveforms in line with the legacy waveforms, but after discussion going for a slightly different look (closer to the legacy waveform look but with a semi-transparent filling)

before:
<img width="479" alt="Screenshot 2023-10-13 at 19 49 49" src="https://github.com/mixxxdj/mixxx/assets/79429057/aeb62ea8-65c0-4b4a-ac44-e79a55b351d6">

initial after
<img width="518" alt="Screenshot 2023-10-13 at 19 48 36" src="https://github.com/mixxxdj/mixxx/assets/79429057/cea8e058-5f9c-4aee-8b7b-e29f81b7b7d9">

final after (with this PR)
<img width="497" alt="Screenshot 2023-10-15 at 17 27 56" src="https://github.com/mixxxdj/mixxx/assets/79429057/971b7828-9d12-4946-9940-454d01d77ffd">
