### PR TITLE
macOS packaging: Enable app sandbox in ad-hoc-packaged (i.e. non-notarized) bundles too

### DIFF
--- a/cmake/modules/BundleInstall.cmake.in
+++ b/cmake/modules/BundleInstall.cmake.in
@@ -23,6 +23,7 @@ if(DEFINED APPLE_CODESIGN_IDENTITY AND DEFINED APPLE_CODESIGN_ENTITLEMENTS)
       message(STATUS "Ad-hoc signing bundle without hardened runtime")
       execute_process(COMMAND
           codesign --verbose=4 --deep --force
+          --entitlements "${APPLE_CODESIGN_ENTITLEMENTS}"
           --sign "${APPLE_CODESIGN_IDENTITY}"
           "${PATH_TO_SIGN}"
       )


### PR DESCRIPTION
In #4774 and specifically e9223294c5c5af9d633431b591ebad9b575ac54d we set up ad-hoc signing for (non-notarized) macOS builds in a way that neither uses the hardened runtime nor app sandbox.

Apparently, macOS Sonoma will prompt the user at every launch when a non-sandboxed app accesses a sandboxed path, even of the app itself (`~/Library/Containers/org.mixxx.mixxx/...`). See #12098 and [this blog post](https://lapcatsoftware.com/articles/2023/6/1.html) for details.

For this reason, this PR passes the entitlements, and thus enables app sandbox, in ad-hoc-signed builds too (note that we'll still leave the hardened runtime disabled for now), which should fix the issue.