### PR TITLE
Fix reading the Spinny cover on Windows 

### DIFF
--- a/src/library/coverartcache.h
+++ b/src/library/coverartcache.h
@@ -40,25 +40,18 @@ class CoverArtCache : public QObject, public Singleton<CoverArtCache> {
     // Only public for testing
     struct FutureResult {
         FutureResult()
-                : pRequester(nullptr),
-                  requestedCacheKey(CoverImageUtils::defaultCacheKey()) {
+                : requestedCacheKey(CoverImageUtils::defaultCacheKey()) {
         }
         FutureResult(
-                const QObject* pRequestorArg,
                 mixxx::cache_key_t requestedCacheKeyArg)
-                : pRequester(pRequestorArg),
-                  requestedCacheKey(requestedCacheKeyArg) {
+                : requestedCacheKey(requestedCacheKeyArg) {
         }
-
-        const QObject* pRequester;
         mixxx::cache_key_t requestedCacheKey;
-
         CoverArt coverArt;
     };
     // Load cover from path indicated in coverInfo. WARNING: This is run in a
     // worker thread.
     static FutureResult loadCover(
-            const QObject* pRequester,
             TrackPointer pTrack,
             CoverInfo coverInfo,
             int desiredWidth);
@@ -91,5 +84,5 @@ class CoverArtCache : public QObject, public Singleton<CoverArtCache> {
             const CoverInfo& info,
             int desiredWidth);
 
-    QSet<QPair<const QObject*, mixxx::cache_key_t>> m_runningRequests;
+    QMultiHash<QString, const QObject*> m_runningRequests;
 };

--- a/src/library/coverartcache.h
+++ b/src/library/coverartcache.h
@@ -84,5 +84,9 @@ class CoverArtCache : public QObject, public Singleton<CoverArtCache> {
             const CoverInfo& info,
             int desiredWidth);
 
-    QMultiHash<QString, const QObject*> m_runningRequests;
+    struct RequestData {
+        const QObject* pRequester;
+        int desiredWidth;
+    };
+    QMultiHash<mixxx::cache_key_t, RequestData> m_runningRequests;
 };

--- a/src/test/coverartcache_test.cpp
+++ b/src/test/coverartcache_test.cpp
@@ -29,7 +29,7 @@ class CoverArtCacheTest : public LibraryTest, public CoverArtCache {
         info.trackLocation = trackLocation;
 
         CoverArtCache::FutureResult res;
-        res = CoverArtCache::loadCover(nullptr, TrackPointer(), info, 0);
+        res = CoverArtCache::loadCover(TrackPointer(), info, 0);
         EXPECT_EQ(img, res.coverArt.loadedImage.image);
         EXPECT_TRUE(res.coverArt.coverLocation.isNull());
     }
@@ -47,7 +47,7 @@ class CoverArtCacheTest : public LibraryTest, public CoverArtCache {
         info.trackLocation = trackLocation;
 
         CoverArtCache::FutureResult res;
-        res = CoverArtCache::loadCover(nullptr, TrackPointer(), info, 0);
+        res = CoverArtCache::loadCover(TrackPointer(), info, 0);
         EXPECT_EQ(img, res.coverArt.loadedImage.image);
         EXPECT_QSTRING_EQ(info.coverLocation, res.coverArt.coverLocation);
     }


### PR DESCRIPTION
This finally fixes https://github.com/mixxxdj/mixxx/issues/11131

This patch awoid to access the same file simultaneously form two threads. 
Instead it used the same thread to redponds to both requests. 

@JoergAtGithub Please confirm if this fixes your issue. 

This PR is on top of #12087 which is on top of #12009