### PR TITLE
add Rate Tap button

### DIFF
--- a/res/skins/Deere/deck_text_row.xml
+++ b/res/skins/Deere/deck_text_row.xml
@@ -258,7 +258,7 @@
                               </Template>
 
                               <PushButton>
-                                <TooltipId>bpm_tap</TooltipId>
+                                <TooltipId>tempo_tap_bpm_tap</TooltipId>
                                 <MinimumSize>30,20</MinimumSize>
                                 <MaximumSize>60,30</MaximumSize>
                                 <SizePolicy>me,me</SizePolicy>
@@ -268,9 +268,11 @@
                                   <Text>TAP</Text>
                                 </State>
                                 <Connection>
+                                  <ConfigKey><Variable name="group"/>,tempo_tap</ConfigKey>
+                                </Connection>
+                                <Connection>
                                   <ConfigKey><Variable name="group"/>,bpm_tap</ConfigKey>
-                                  <EmitOnPressAndRelease>true</EmitOnPressAndRelease>
-                                  <ButtonState>LeftButton</ButtonState>
+                                  <ButtonState>RightButton</ButtonState>
                                 </Connection>
                               </PushButton>
                             </Children>

--- a/res/skins/LateNight/decks/rate_controls.xml
+++ b/res/skins/LateNight/decks/rate_controls.xml
@@ -31,15 +31,18 @@
                 <Layout>stacked</Layout>
                 <Size>57f,-1me</Size>
                 <Children>
-                  <!-- In order to make the bpm display tappable, we use an old-style
-                  widget group and put the bpm pushbutton on top of the display. -->
+                  <!-- invisible Tempo/BPM tap button on top of BPM display -->
                   <PushButton>
-                    <TooltipId>bpm_tap_visual_bpm</TooltipId>
+                    <TooltipId>tempo_tap_bpm_tap_visual_bpm</TooltipId>
                     <ObjectName>BpmTap</ObjectName>
                     <Size>57f,-1me</Size>
                     <NumberStates>1</NumberStates>
                     <Connection>
+                      <ConfigKey><Variable name="Group"/>,tempo_tap</ConfigKey>
+                    </Connection>
+                    <Connection>
                       <ConfigKey><Variable name="Group"/>,bpm_tap</ConfigKey>
+                      <ButtonState>RightButton</ButtonState>
                     </Connection>
                   </PushButton>
                   <WidgetGroup><!-- BPM + rate -->

--- a/res/skins/LateNight/decks/rate_controls_compact.xml
+++ b/res/skins/LateNight/decks/rate_controls_compact.xml
@@ -25,17 +25,19 @@
             <Layout>stacked</Layout>
             <Size>60f,40f</Size>
             <Children>
-              <!-- In order to make the bpm display tappable, we use an old-style
-              widget group and put the bpm pushbutton on top of the display. -->
+              <!-- invisible Tempo/BPM tap button on top of BPM display -->
               <PushButton>
-                <TooltipId>bpm_tap_visual_bpm</TooltipId>
+                <TooltipId>tempo_tap_bpm_tap_visual_bpm</TooltipId>
                 <ObjectName>BpmTap</ObjectName>
                 <SizePolicy>me,me</SizePolicy>
                 <NumberStates>1</NumberStates>
-                <Connection>
-                  <ConfigKey><Variable name="Group"/>,bpm_tap</ConfigKey>
-                  <EmitOnPressAndRelease>true</EmitOnPressAndRelease>
-                </Connection>
+                  <Connection>
+                    <ConfigKey><Variable name="Group"/>,tempo_tap</ConfigKey>
+                  </Connection>
+                  <Connection>
+                    <ConfigKey><Variable name="Group"/>,bpm_tap</ConfigKey>
+                    <ButtonState>RightButton</ButtonState>
+                  </Connection>
               </PushButton>
               <WidgetGroup><!-- BPM + rate -->
                 <ObjectName>AlignCenter</ObjectName>

--- a/res/skins/Shade/sampler.xml
+++ b/res/skins/Shade/sampler.xml
@@ -58,6 +58,7 @@
               <WidgetGroup>
                 <Size>35f,24f</Size>
                 <Children>
+                  <!-- invisible Tempo/BPM tap button on top of BPM display -->
                   <Number>
                     <TooltipId>visual_bpm</TooltipId>
                     <Style>QLabel {
@@ -77,15 +78,8 @@
                       <ConfigKey><Variable name="group"/>,visual_bpm</ConfigKey>
                     </Connection>
                   </Number>
-                  <!-- Little trickery here:
-                    BPM tap is transparent png directly over BPM display, so it became BPM and TAP at once,
-                    changed tooltip accordingly
-                  -->
                   <PushButton>
-                  <!-- Original:
-                    <TooltipId>bpm_tap</TooltipId>
-                  -->
-                    <TooltipId>bpm_tap_visual_bpm</TooltipId>
+                    <TooltipId>tempo_tap_bpm_tap_visual_bpm</TooltipId>
                     <Pos>0,5</Pos>
                     <NumberStates>1</NumberStates>
                     <State>
@@ -94,8 +88,11 @@
                       <Unpressed>skin:/btn/btn_tap_sampler.png</Unpressed>
                     </State>
                     <Connection>
+                      <ConfigKey><Variable name="group"/>,tempo_tap</ConfigKey>
+                    </Connection>
+                    <Connection>
                       <ConfigKey><Variable name="group"/>,bpm_tap</ConfigKey>
-                      <EmitOnPressAndRelease>true</EmitOnPressAndRelease>
+                      <ButtonState>RightButton</ButtonState>
                     </Connection>
                   </PushButton>
                 </Children>

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -243,6 +243,7 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
     addDeckAndSamplerControl("bpm_up_small", tr("BPM +0.1"), tr("Increase BPM by 0.1"), pBpmMenu);
     addDeckAndSamplerControl("bpm_down_small", tr("BPM -0.1"), tr("Decrease BPM by 0.1"), pBpmMenu);
     addDeckAndSamplerControl("bpm_tap", tr("BPM Tap"), tr("BPM tap button"), pBpmMenu);
+    addDeckAndSamplerControl("tempo_tap", tr("Tempo Tap"), tr("Tempo tap button"), pBpmMenu);
     pBpmMenu->addSeparator();
     addDeckAndSamplerControl("beats_adjust_faster",
             tr("Adjust Beatgrid Faster +.01"),

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -319,6 +319,7 @@ void BpmControl::slotBpmTapFilter(double averageLength, int numSamples) {
     }
     pTrack->trySetBeats(*newBeats);
 }
+
 void BpmControl::slotTempoTap(double v) {
     if (v > 0) {
         m_tempoTapFilter.tap();
@@ -1005,16 +1006,17 @@ mixxx::audio::FrameDiff_t BpmControl::getPhaseOffset(mixxx::audio::FramePos this
     return position - thisPosition;
 }
 
-void BpmControl::slotUpdateEngineBpm(double value) {
+void BpmControl::slotUpdateEngineBpm(double rateRatio) {
     // Adjust playback bpm in response to a rate_ratio update
-
     if (kLogger.traceEnabled()) {
-        kLogger.trace() << getGroup() << "BpmControl::slotUpdateEngineBpm"
-                        << m_pLocalBpm->get() << value;
+        kLogger.trace() << getGroup() << "BpmControl::slotUpdateEngineBpm: local BPM:"
+                        << m_pLocalBpm->get()
+                        << "rate ratio:"
+                        << rateRatio;
         // This can be used to detect pitch shift issues with cloned decks
         // DEBUG_ASSERT(getGroup() != "[Channel1]" || m_pRateRatio->get(); == 1);
     }
-    m_pEngineBpm->set(m_pLocalBpm->get() * value);
+    m_pEngineBpm->set(m_pLocalBpm->get() * rateRatio);
 }
 
 void BpmControl::slotUpdateRateSlider(double value) {

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -51,9 +51,9 @@ BpmControl::BpmControl(const QString& group,
     m_dSyncTargetBeatDistance.setValue(0.0);
     m_dUserOffset.setValue(0.0);
 
-    m_pPlayButton = new ControlProxy(group, "play", this);
-    m_pReverseButton = new ControlProxy(group, "reverse", this);
-    m_pRateRatio = new ControlProxy(group, "rate_ratio", this);
+    m_pPlayButton = std::make_unique<ControlProxy>(group, "play", this);
+    m_pReverseButton = std::make_unique<ControlProxy>(group, "reverse", this);
+    m_pRateRatio = std::make_unique<ControlProxy>(group, "rate_ratio", this);
     m_pRateRatio->connectValueChanged(this, &BpmControl::slotUpdateEngineBpm,
                                       Qt::DirectConnection);
 
@@ -62,33 +62,46 @@ BpmControl::BpmControl(const QString& group,
     m_pPrevBeat.reset(new ControlProxy(group, "beat_prev"));
     m_pNextBeat.reset(new ControlProxy(group, "beat_next"));
 
-    m_pLoopEnabled = new ControlProxy(group, "loop_enabled", this);
-    m_pLoopStartPosition = new ControlProxy(group, "loop_start_position", this);
-    m_pLoopEndPosition = new ControlProxy(group, "loop_end_position", this);
+    m_pLoopEnabled = std::make_unique<ControlProxy>(group, "loop_enabled", this);
+    m_pLoopStartPosition = std::make_unique<ControlProxy>(group, "loop_start_position", this);
+    m_pLoopEndPosition = std::make_unique<ControlProxy>(group, "loop_end_position", this);
 
-    m_pLocalBpm = new ControlObject(ConfigKey(group, "local_bpm"));
-    m_pAdjustBeatsFaster = new ControlPushButton(ConfigKey(group, "beats_adjust_faster"), false);
+    m_pLocalBpm = std::make_unique<ControlObject>(ConfigKey(group, "local_bpm"));
+    m_pAdjustBeatsFaster = std::make_unique<ControlPushButton>(
+            ConfigKey(group, "beats_adjust_faster"), false);
     m_pAdjustBeatsFaster->setKbdRepeatable(true);
-    connect(m_pAdjustBeatsFaster, &ControlObject::valueChanged,
-            this, &BpmControl::slotAdjustBeatsFaster,
+    connect(m_pAdjustBeatsFaster.get(),
+            &ControlObject::valueChanged,
+            this,
+            &BpmControl::slotAdjustBeatsFaster,
             Qt::DirectConnection);
-    m_pAdjustBeatsSlower = new ControlPushButton(ConfigKey(group, "beats_adjust_slower"), false);
+    m_pAdjustBeatsSlower = std::make_unique<ControlPushButton>(
+            ConfigKey(group, "beats_adjust_slower"), false);
     m_pAdjustBeatsSlower->setKbdRepeatable(true);
-    connect(m_pAdjustBeatsSlower, &ControlObject::valueChanged,
-            this, &BpmControl::slotAdjustBeatsSlower,
+    connect(m_pAdjustBeatsSlower.get(),
+            &ControlObject::valueChanged,
+            this,
+            &BpmControl::slotAdjustBeatsSlower,
             Qt::DirectConnection);
-    m_pTranslateBeatsEarlier = new ControlPushButton(ConfigKey(group, "beats_translate_earlier"), false);
+    m_pTranslateBeatsEarlier = std::make_unique<ControlPushButton>(
+            ConfigKey(group, "beats_translate_earlier"), false);
     m_pTranslateBeatsEarlier->setKbdRepeatable(true);
-    connect(m_pTranslateBeatsEarlier, &ControlObject::valueChanged,
-            this, &BpmControl::slotTranslateBeatsEarlier,
+    connect(m_pTranslateBeatsEarlier.get(),
+            &ControlObject::valueChanged,
+            this,
+            &BpmControl::slotTranslateBeatsEarlier,
             Qt::DirectConnection);
-    m_pTranslateBeatsLater = new ControlPushButton(ConfigKey(group, "beats_translate_later"), false);
+    m_pTranslateBeatsLater = std::make_unique<ControlPushButton>(
+            ConfigKey(group, "beats_translate_later"), false);
     m_pTranslateBeatsLater->setKbdRepeatable(true);
-    connect(m_pTranslateBeatsLater, &ControlObject::valueChanged,
-            this, &BpmControl::slotTranslateBeatsLater,
+    connect(m_pTranslateBeatsLater.get(),
+            &ControlObject::valueChanged,
+            this,
+            &BpmControl::slotTranslateBeatsLater,
             Qt::DirectConnection);
-    m_pTranslateBeatsMove = new ControlEncoder(ConfigKey(group, "beats_translate_move"), false);
-    connect(m_pTranslateBeatsMove,
+    m_pTranslateBeatsMove = std::make_unique<ControlEncoder>(
+            ConfigKey(group, "beats_translate_move"), false);
+    connect(m_pTranslateBeatsMove.get(),
             &ControlObject::valueChanged,
             this,
             &BpmControl::slotTranslateBeatsMove,
@@ -99,7 +112,7 @@ BpmControl::BpmControl(const QString& group,
     // bpm_down controls.
     // bpm_up / bpm_down steps by kBpmRangeStep
     // bpm_up_small / bpm_down_small steps by kBpmRangeSmallStep
-    m_pEngineBpm = new ControlLinPotmeter(
+    m_pEngineBpm = std::make_unique<ControlLinPotmeter>(
             ConfigKey(group, "bpm"),
             kBpmRangeMin,
             kBpmRangeMax,
@@ -107,27 +120,33 @@ BpmControl::BpmControl(const QString& group,
             kBpmRangeSmallStep,
             true);
     m_pEngineBpm->set(0.0);
-    connect(m_pEngineBpm, &ControlObject::valueChanged,
-            this, &BpmControl::slotUpdateRateSlider,
+    connect(m_pEngineBpm.get(),
+            &ControlObject::valueChanged,
+            this,
+            &BpmControl::slotUpdateRateSlider,
             Qt::DirectConnection);
 
-    m_pButtonTap = new ControlPushButton(ConfigKey(group, "bpm_tap"));
-    connect(m_pButtonTap, &ControlObject::valueChanged,
-            this, &BpmControl::slotBpmTap,
+    m_pBpmTap = std::make_unique<ControlPushButton>(ConfigKey(group, "bpm_tap"));
+    connect(m_pBpmTap.get(),
+            &ControlObject::valueChanged,
+            this,
+            &BpmControl::slotBpmTap,
             Qt::DirectConnection);
 
-    m_pTranslateBeats = new ControlPushButton(ConfigKey(group, "beats_translate_curpos"));
-    connect(m_pTranslateBeats, &ControlObject::valueChanged,
-            this, &BpmControl::slotBeatsTranslate,
+    m_pTranslateBeats = std::make_unique<ControlPushButton>(
+            ConfigKey(group, "beats_translate_curpos"));
+    connect(m_pTranslateBeats.get(),
+            &ControlObject::valueChanged,
+            this,
+            &BpmControl::slotBeatsTranslate,
             Qt::DirectConnection);
 
-    m_pBeatsTranslateMatchAlignment = new ControlPushButton(ConfigKey(group, "beats_translate_match_alignment"));
-    connect(m_pBeatsTranslateMatchAlignment, &ControlObject::valueChanged,
-            this, &BpmControl::slotBeatsTranslateMatchAlignment,
-            Qt::DirectConnection);
-
-    connect(&m_tapFilter, &TapFilter::tapped,
-            this, &BpmControl::slotTapFilter,
+    m_pBeatsTranslateMatchAlignment = std::make_unique<ControlPushButton>(
+            ConfigKey(group, "beats_translate_match_alignment"));
+    connect(m_pBeatsTranslateMatchAlignment.get(),
+            &ControlObject::valueChanged,
+            this,
+            &BpmControl::slotBeatsTranslateMatchAlignment,
             Qt::DirectConnection);
 
     m_pBpmLock = std::make_unique<ControlPushButton>(
@@ -138,30 +157,17 @@ BpmControl::BpmControl(const QString& group,
             &BpmControl::slotToggleBpmLock,
             Qt::DirectConnection);
 
-    m_pBeatsUndo = new ControlPushButton(ConfigKey(group, "beats_undo_adjustment"));
-    connect(m_pBeatsUndo,
+    m_pBeatsUndo = std::make_unique<ControlPushButton>(
+            ConfigKey(group, "beats_undo_adjustment"));
+    connect(m_pBeatsUndo.get(),
             &ControlObject::valueChanged,
             this,
             &BpmControl::slotBeatsUndoAdjustment,
             Qt::DirectConnection);
 
     // Measures distance from last beat in percentage: 0.5 = half-beat away.
-    m_pThisBeatDistance = new ControlProxy(group, "beat_distance", this);
-    m_pSyncMode = new ControlProxy(group, "sync_mode", this);
-}
-
-BpmControl::~BpmControl() {
-    delete m_pLocalBpm;
-    delete m_pEngineBpm;
-    delete m_pButtonTap;
-    delete m_pTranslateBeats;
-    delete m_pBeatsTranslateMatchAlignment;
-    delete m_pTranslateBeatsEarlier;
-    delete m_pTranslateBeatsLater;
-    delete m_pTranslateBeatsMove;
-    delete m_pAdjustBeatsFaster;
-    delete m_pAdjustBeatsSlower;
-    delete m_pBeatsUndo;
+    m_pThisBeatDistance = std::make_unique<ControlProxy>(group, "beat_distance", this);
+    m_pSyncMode = std::make_unique<ControlProxy>(group, "sync_mode", this);
 }
 
 mixxx::Bpm BpmControl::getBpm() const {

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -1007,15 +1007,14 @@ mixxx::audio::FrameDiff_t BpmControl::getPhaseOffset(mixxx::audio::FramePos this
 
 void BpmControl::slotUpdateEngineBpm(double value) {
     // Adjust playback bpm in response to a rate_ratio update
-    double dRate = m_pRateRatio->get();
 
     if (kLogger.traceEnabled()) {
         kLogger.trace() << getGroup() << "BpmControl::slotUpdateEngineBpm"
-                        << value << m_pLocalBpm->get() << dRate << frameInfo().currentPosition;
+                        << m_pLocalBpm->get() << value;
         // This can be used to detect pitch shift issues with cloned decks
-        // DEBUG_ASSERT(getGroup() != "[Channel1]" || dRate == 1);
+        // DEBUG_ASSERT(getGroup() != "[Channel1]" || m_pRateRatio->get(); == 1);
     }
-    m_pEngineBpm->set(m_pLocalBpm->get() * dRate);
+    m_pEngineBpm->set(m_pLocalBpm->get() * value);
 }
 
 void BpmControl::slotUpdateRateSlider(double value) {
@@ -1140,7 +1139,7 @@ mixxx::Bpm BpmControl::updateLocalBpm() {
             localBpmValue = localBpm.value();
         }
         m_pLocalBpm->set(localBpmValue);
-        slotUpdateEngineBpm();
+        slotUpdateEngineBpm(m_pRateRatio->get());
     }
     return localBpm;
 }

--- a/src/engine/controls/bpmcontrol.h
+++ b/src/engine/controls/bpmcontrol.h
@@ -21,7 +21,6 @@ class BpmControl : public EngineControl {
 
   public:
     BpmControl(const QString& group, UserSettingsPointer pConfig);
-    ~BpmControl() override;
 
     mixxx::Bpm getBpm() const;
     mixxx::Bpm getLocalBpm() const {
@@ -125,10 +124,10 @@ class BpmControl : public EngineControl {
     friend class SyncControl;
 
     // ControlObjects that come from EngineBuffer
-    ControlProxy* m_pPlayButton;
+    std::unique_ptr<ControlProxy> m_pPlayButton;
     QAtomicInt m_oldPlayButton;
-    ControlProxy* m_pReverseButton;
-    ControlProxy* m_pRateRatio;
+    std::unique_ptr<ControlProxy> m_pReverseButton;
+    std::unique_ptr<ControlProxy> m_pRateRatio;
     ControlObject* m_pQuantize;
 
     // ControlObjects that come from QuantizeControl
@@ -136,41 +135,42 @@ class BpmControl : public EngineControl {
     QScopedPointer<ControlProxy> m_pPrevBeat;
 
     // ControlObjects that come from LoopingControl
-    ControlProxy* m_pLoopEnabled;
-    ControlProxy* m_pLoopStartPosition;
-    ControlProxy* m_pLoopEndPosition;
+    std::unique_ptr<ControlProxy> m_pLoopEnabled;
+    std::unique_ptr<ControlProxy> m_pLoopStartPosition;
+    std::unique_ptr<ControlProxy> m_pLoopEndPosition;
 
     // The average bpm around the current playposition;
-    ControlObject* m_pLocalBpm;
-    ControlPushButton* m_pAdjustBeatsFaster;
-    ControlPushButton* m_pAdjustBeatsSlower;
-    ControlPushButton* m_pTranslateBeatsEarlier;
-    ControlPushButton* m_pTranslateBeatsLater;
-    ControlEncoder* m_pTranslateBeatsMove;
-    ControlPushButton* m_pBeatsUndo;
+    std::unique_ptr<ControlObject> m_pLocalBpm;
+    std::unique_ptr<ControlPushButton> m_pAdjustBeatsFaster;
+    std::unique_ptr<ControlPushButton> m_pAdjustBeatsSlower;
+    std::unique_ptr<ControlPushButton> m_pTranslateBeatsEarlier;
+    std::unique_ptr<ControlPushButton> m_pTranslateBeatsLater;
+    std::unique_ptr<ControlEncoder> m_pTranslateBeatsMove;
+    std::unique_ptr<ControlPushButton> m_pBeatsUndo;
 
     std::unique_ptr<ControlPushButton> m_pBpmLock;
 
     // The current effective BPM of the engine
-    ControlLinPotmeter* m_pEngineBpm;
+    std::unique_ptr<ControlLinPotmeter> m_pEngineBpm;
 
     // Used for bpm tapping from GUI and MIDI
-    ControlPushButton* m_pButtonTap;
+    std::unique_ptr<ControlPushButton> m_pBpmTap;  // File BPM
+    std::unique_ptr<ControlPushButton> m_pRateTap; // Enigne BPM (playback rate)
 
     // Button that translates the beats so the nearest beat is on the current
     // playposition.
-    ControlPushButton* m_pTranslateBeats;
+    std::unique_ptr<ControlPushButton> m_pTranslateBeats;
     // Button that translates beats to match another playing deck
-    ControlPushButton* m_pBeatsTranslateMatchAlignment;
+    std::unique_ptr<ControlPushButton> m_pBeatsTranslateMatchAlignment;
 
-    ControlProxy* m_pThisBeatDistance;
+    std::unique_ptr<ControlProxy> m_pThisBeatDistance;
     ControlValueAtomic<double> m_dSyncTargetBeatDistance;
     // The user offset is a beat distance percentage value that the user has tweaked a deck
     // to bring it in sync with the other decks. This value is added to the reported beat
     // distance to get the virtual beat distance used for sync.
     ControlValueAtomic<double> m_dUserOffset;
     QAtomicInt m_resetSyncAdjustment;
-    ControlProxy* m_pSyncMode;
+    std::unique_ptr<ControlProxy> m_pSyncMode;
 
     TapFilter m_tapFilter; // threadsafe
 

--- a/src/engine/controls/bpmcontrol.h
+++ b/src/engine/controls/bpmcontrol.h
@@ -4,6 +4,7 @@
 
 #include "control/controlobject.h"
 #include "control/controlproxy.h"
+#include "control/pollingcontrolproxy.h"
 #include "engine/controls/enginecontrol.h"
 #include "engine/sync/syncable.h"
 #include "track/beats.h"
@@ -117,7 +118,7 @@ class BpmControl : public EngineControl {
 
   private:
     SyncMode getSyncMode() const {
-        return syncModeFromDouble(m_pSyncMode->get());
+        return syncModeFromDouble(m_pSyncMode.get());
     }
     inline bool isSynchronized() const {
         return toSynchronized(getSyncMode());
@@ -128,20 +129,18 @@ class BpmControl : public EngineControl {
     friend class SyncControl;
 
     // ControlObjects that come from EngineBuffer
-    std::unique_ptr<ControlProxy> m_pPlayButton;
-    QAtomicInt m_oldPlayButton;
-    std::unique_ptr<ControlProxy> m_pReverseButton;
+    PollingControlProxy m_pReverseButton;
     std::unique_ptr<ControlProxy> m_pRateRatio;
-    ControlObject* m_pQuantize;
+    PollingControlProxy m_pQuantize;
 
     // ControlObjects that come from QuantizeControl
-    QScopedPointer<ControlProxy> m_pNextBeat;
-    QScopedPointer<ControlProxy> m_pPrevBeat;
+    PollingControlProxy m_pNextBeat;
+    PollingControlProxy m_pPrevBeat;
 
     // ControlObjects that come from LoopingControl
-    std::unique_ptr<ControlProxy> m_pLoopEnabled;
-    std::unique_ptr<ControlProxy> m_pLoopStartPosition;
-    std::unique_ptr<ControlProxy> m_pLoopEndPosition;
+    PollingControlProxy m_pLoopEnabled;
+    PollingControlProxy m_pLoopStartPosition;
+    PollingControlProxy m_pLoopEndPosition;
 
     // The average bpm around the current playposition;
     std::unique_ptr<ControlObject> m_pLocalBpm;
@@ -167,14 +166,14 @@ class BpmControl : public EngineControl {
     // Button that translates beats to match another playing deck
     std::unique_ptr<ControlPushButton> m_pBeatsTranslateMatchAlignment;
 
-    std::unique_ptr<ControlProxy> m_pThisBeatDistance;
+    PollingControlProxy m_pThisBeatDistance;
     ControlValueAtomic<double> m_dSyncTargetBeatDistance;
     // The user offset is a beat distance percentage value that the user has tweaked a deck
     // to bring it in sync with the other decks. This value is added to the reported beat
     // distance to get the virtual beat distance used for sync.
     ControlValueAtomic<double> m_dUserOffset;
     QAtomicInt m_resetSyncAdjustment;
-    std::unique_ptr<ControlProxy> m_pSyncMode;
+    PollingControlProxy m_pSyncMode;
 
     TapFilter m_bpmTapFilter;   // threadsafe
     TapFilter m_tempoTapFilter; // threadsafe

--- a/src/engine/controls/bpmcontrol.h
+++ b/src/engine/controls/bpmcontrol.h
@@ -102,8 +102,12 @@ class BpmControl : public EngineControl {
     void slotTranslateBeatsEarlier(double);
     void slotTranslateBeatsLater(double);
     void slotTranslateBeatsMove(double);
-    void slotTapFilter(double,int);
-    void slotBpmTap(double);
+
+    void slotBpmTap(double value);
+    void slotBpmTapFilter(double averageLength, int numSamples);
+    void slotTempoTap(double value);
+    void slotTempoTapFilter(double averageLength, int numSamples);
+
     void slotUpdateRateSlider(double v = 0.0);
     void slotUpdateEngineBpm(double v = 0.0);
     void slotBeatsTranslate(double);
@@ -154,8 +158,8 @@ class BpmControl : public EngineControl {
     std::unique_ptr<ControlLinPotmeter> m_pEngineBpm;
 
     // Used for bpm tapping from GUI and MIDI
-    std::unique_ptr<ControlPushButton> m_pBpmTap;  // File BPM
-    std::unique_ptr<ControlPushButton> m_pRateTap; // Enigne BPM (playback rate)
+    std::unique_ptr<ControlPushButton> m_pBpmTap;   // File BPM
+    std::unique_ptr<ControlPushButton> m_pTempoTap; // Enigne BPM (playback rate)
 
     // Button that translates the beats so the nearest beat is on the current
     // playposition.
@@ -172,7 +176,8 @@ class BpmControl : public EngineControl {
     QAtomicInt m_resetSyncAdjustment;
     std::unique_ptr<ControlProxy> m_pSyncMode;
 
-    TapFilter m_tapFilter; // threadsafe
+    TapFilter m_bpmTapFilter;   // threadsafe
+    TapFilter m_tempoTapFilter; // threadsafe
 
     // used in the engine thread only
     double m_dSyncInstantaneousBpm;

--- a/src/skin/legacy/tooltips.cpp
+++ b/src/skin/legacy/tooltips.cpp
@@ -397,6 +397,11 @@ void Tooltips::addStandardTooltips() {
             << eqKillLatch;
 
     QString tempoDisplay = tr("Displays the tempo of the loaded track in BPM (beats per minute).");
+    // TODO Clarify this refers to 'file BPM', not playback rate?
+    QString bpmTapButton = tr("When tapped repeatedly, adjusts the BPM to match the tapped BPM.");
+    QString tempoTapButton =
+            tr("When tapped repeatedly, adjusts the tempo to match the tapped "
+               "BPM.");
     add("visual_bpm")
             << tr("Tempo")
             << tempoDisplay;
@@ -408,7 +413,14 @@ void Tooltips::addStandardTooltips() {
 
     add("bpm_tap")
             << tr("BPM Tap")
-            << tr("When tapped repeatedly, adjusts the BPM to match the tapped BPM.");
+            << bpmTapButton;
+    add("tempo_tap")
+            << tr("Tempo Tap")
+            << tempoTapButton;
+    add("tempo_tap_bpm_tap")
+            << tr("Rate Tap and BPM Tap")
+            << QString("%1: %2").arg(leftClick, tempoTapButton)
+            << QString("%1: %2").arg(rightClick, bpmTapButton);
 
     add("beats_adjust_slower")
             << tr("Adjust BPM Down")
@@ -439,11 +451,22 @@ void Tooltips::addStandardTooltips() {
             << tr("Revert last BPM/Beatgrid Change")
             << tr("Revert last BPM/Beatgrid Change of the loaded track.");
 
-    //this is a special case, in some skins we might display a transparent png for bpm_tap on top of visual_bpm
+    // These are special cases:
+    // in some skins we display a transparent button for tempo_tap and/or bpm_tap
+    // on top of the visual_bpm display.
     add("bpm_tap_visual_bpm")
             << tr("Tempo and BPM Tap")
             << tempoDisplay
-            << tr("When tapped repeatedly, adjusts the BPM to match the tapped BPM.");
+            << bpmTapButton;
+    add("tempo_tap_visual_bpm")
+            << tr("Tempo and Rate Tap")
+            << tempoDisplay
+            << tempoTapButton;
+    add("tempo_tap_bpm_tap_visual_bpm")
+            << tr("Tempo, Rate Tap and BPM Tap")
+            << tempoDisplay
+            << QString("%1: %2").arg(leftClick, tempoTapButton)
+            << QString("%1: %2").arg(rightClick, bpmTapButton);
 
     add("shift_cues_earlier")
             << tr("Shift cues earlier")


### PR DESCRIPTION
* add `tempo_tap` which works exactly like BPM tap, just it sets the tempo
* change BPM display overlay and buttons in skins to do
  * **tempo** tap on left click
  * BPM tap on right-click.

quoting myself from #12086
> Admittedly, I never understood why this a track edit tool [BPM tap button] was placed in the rate control section in the first place.

> double-clicking any track (text) label opens the Track Properties editor where the (track) BPM can be set (type or tap)
Use case

### Reasoning
BPM tap edits a track property (permanently) while the rate section is solely about controlling the playback speed (+, -, sync). Hence, IMO BPM tap doesn't belong there.
IIUC the intention for putting it there was to allow _setting_ the track BPM, i.e. set initial value or correct BPM analysis. I assume it was helpful in the early days of Mixxx but with the improved beats analyzer nowadays I suppose it's not needed (that much) anymore. Manual correction can be done in Track Properties > BPM tab.

### My use case
Infrequently I need to "Sync" to external players (vinyl via Aux, other DJ in b2b sessions), i.e. at least estimate the target BPM. Until now I was using a Python BPM counter [1], activated with a global hotkey, which gives very accurate results. However, it'd be much more convenient to do this within Mixxx.
Either I apply the guessed target BPM (e.g. 128) to loaded tracks, or I do a bpm search `bpm:125-130`.
Rate Tap is a good step forward.

Thinking this further, a BPM tap utility might be helpful, see #12105 

- 1 https://github.com/m13253/bpm-counter/blob/master/trunk/bpm-counter.py 