### PR TITLE
Labeler: Add more labels to the auto-labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,6 +4,9 @@ build:
   - build/**
   - cmake/**
 
+cmake:
+  - cmake/**
+
 code quality:
   - src/test/**
   - .clang-format
@@ -16,14 +19,68 @@ code quality:
 controllers:
   - res/controllers/**
 
+analyzer:
+  - src/analyzer/**
+
+broadcast:
+  - src/broadcast/**
+
+effects:
+  - src/effects/**
+
+engine:
+  - src/engine/**
+
+sync:
+  - src/engine/sync/**
+
 library:
   - src/library/**
 
+autodj:
+  - src/library/autodj/**
+
+browse:
+  - src/library/browse/**
+
+itunes:
+  - src/library/itunes/**
+
+rekordbox:
+  - src/library/rekordbox/**
+
+scanner:
+  - src/library/scanner/**
+
+search:
+  - src/library/searchquery*
+
+serato:
+  - src/library/serato/**
+
+packaging:
+  - packaging/**
+
+preferences:
+  - src/preferences/**
+
 skins:
   - res/skins/**
+
+soundio:
+  - src/soundio/**
+
+soundsource:
+  - src/sources/soundsource*
 
 ui:
   - src/**.ui
   - src/dialog/**
   - src/preferences/**
   - src/widget/**
+
+vinylcontrol:
+  - src/vinylcontrol/**
+
+waveform:
+  - src/waveform/**


### PR DESCRIPTION
There are still [a lot of labels](https://github.com/mixxxdj/mixxx/labels) from the Launchpad import that aren't used by the auto-labeling workflows. This PR fixes that and maps labels with a "dedicated" source tree to that.