### PR TITLE
Addes the test SoftTakeoverTest.CatchOutOfBounds

### DIFF
--- a/src/test/softtakeover_test.cpp
+++ b/src/test/softtakeover_test.cpp
@@ -562,6 +562,32 @@ TEST_F(SoftTakeoverTest, PrevFarMore_NewFarMore_Late) {
     EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(100)));
 }
 
+TEST_F(SoftTakeoverTest, CatchOutOfBounds) {
+    auto co = std::make_unique<ControlPotmeter>(
+            ConfigKey("[Channel1]", "test_pot"), -250, 250, true);
+
+    co->set(50);
+    SoftTakeoverCtrl st_control;
+    st_control.enable(co.get());
+
+    // First is always ignored.
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(45)));
+    // Cross the original value to take over
+    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(55)));
+
+    // Set value to an out of bounds value
+    co->set(300);
+    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
+    // Actions in the same direction shall be ignored
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(60)));
+    // actions in the other edirection shall be ignored
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(40)));
+    // reaching the lower border should be ignored
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(-250)));
+    // reaching the upper border near the out of bounds value should not be ignored.
+    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(250)));
+}
+
 // For the ignore cases, check that they work correctly with various signed values
 // TODO
 


### PR DESCRIPTION
This proves that the slider is able to snap an out of bounds position. 
https://github.com/mixxxdj/mixxx/issues/12011 