### PR TITLE
MixxxMainWindow: Set window file path to the playing track

### DIFF
--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -694,11 +694,11 @@ void MixxxMainWindow::slotUpdateWindowTitle(TrackPointer pTrack) {
         }
         filePath = pTrack->getLocation();
     }
-    this->setWindowTitle(appTitle);
+    setWindowTitle(appTitle);
 
     // Display a draggable proxy icon for the track in the title bar on
     // platforms that support it, e.g. macOS
-    this->setWindowFilePath(filePath);
+    setWindowFilePath(filePath);
 }
 
 void MixxxMainWindow::createMenuBar() {

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -682,6 +682,7 @@ QDialog::DialogCode MixxxMainWindow::noOutputDlg(bool* continueClicked) {
 
 void MixxxMainWindow::slotUpdateWindowTitle(TrackPointer pTrack) {
     QString appTitle = VersionStore::applicationName();
+    QString filePath;
 
     // If we have a track, use getInfo() to format a summary string and prepend
     // it to the title.
@@ -691,8 +692,13 @@ void MixxxMainWindow::slotUpdateWindowTitle(TrackPointer pTrack) {
         if (!trackInfo.isEmpty()) {
             appTitle = QString("%1 | %2").arg(trackInfo, appTitle);
         }
+        filePath = pTrack->getLocation();
     }
     this->setWindowTitle(appTitle);
+
+    // Display a draggable proxy icon for the track in the title bar on
+    // platforms that support it, e.g. macOS
+    this->setWindowFilePath(filePath);
 }
 
 void MixxxMainWindow::createMenuBar() {


### PR DESCRIPTION
This adds a small proxy icon for the currently playing track to the title bar on platforms that support it, e.g. macOS:

![Screenshot-2023-10-15-at-15 28 46](https://github.com/mixxxdj/mixxx/assets/30873659/b027eb4a-f715-47e6-9391-b7fe2715bd1d)

This icon can be drag-n-dropped (like a regular file) and also right-clicked to quickly access the track's parent folders:

![Screenshot-2023-10-15-at-15 29 05](https://github.com/mixxxdj/mixxx/assets/30873659/4b24bc6f-629c-4fdb-b706-e2c04380b4fb)
