### PR TITLE
Notarization: Migrate script to `notarytool`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -372,7 +372,6 @@ jobs:
         run: packaging/macos/sign_notarize_staple.sh build/*.dmg
         env:
           APPLE_ID_USERNAME: rryan@mixxx.org
-          APPLE_BUNDLE_ID: org.mixxx.mixxx
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.MACOS_NOTARIZATION_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: FLYL4D545V
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -374,7 +374,7 @@ jobs:
           APPLE_ID_USERNAME: rryan@mixxx.org
           APPLE_BUNDLE_ID: org.mixxx.mixxx
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.MACOS_NOTARIZATION_APP_SPECIFIC_PASSWORD }}
-          ASC_PROVIDER: FLYL4D545V
+          APPLE_TEAM_ID: FLYL4D545V
 
       - name: "[Windows] Sign Package"
         if: runner.os == 'Windows' && env.WINDOWS_CODESIGN_CERTIFICATE_PATH != null && env.WINDOWS_CODESIGN_CERTIFICATE_PASSWORD != null

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 *.log
 *.log.*
 
+# Notarization
+notarize_status.plist
+
 # TOOLS
 
 # Might be created when running a Python script from the tools folder

--- a/packaging/macos/sign_notarize_staple.sh
+++ b/packaging/macos/sign_notarize_staple.sh
@@ -20,16 +20,17 @@ xcrun notarytool submit \
     --wait \
     "${DMG_FILE}" > notarize_status.plist
 
+trap 'rm notarize_status.plist' EXIT
+cat notarize_status.plist
+
 # shellcheck disable=SC2181
 if [ "$?" != "0" ]; then
     echo "Notarization failed:"
-    cat notarize_status.plist
     curl "$(/usr/libexec/PlistBuddy -c 'Print notarization-info:LogFileURL' notarize_status.plist)"
     exit 1
 fi
 
 NOTARIZATION_STATUS="$(/usr/libexec/PlistBuddy -c 'Print notarization-info:Status' notarize_status.plist)"
-rm notarize_status.plist
 
 case "${NOTARIZATION_STATUS}" in
     success)

--- a/packaging/macos/sign_notarize_staple.sh
+++ b/packaging/macos/sign_notarize_staple.sh
@@ -6,16 +6,20 @@ DMG_FILE="${1}"
 [ -z "${APPLE_BUNDLE_ID}" ] && echo 'Please set the APPLE_BUNDLE_ID env var.' >&2 && exit 1
 [ -z "${APPLE_ID_USERNAME}" ] && echo 'Please set the APPLE_ID_USERNAME env var.' >&2 && exit 1
 [ -z "${APPLE_APP_SPECIFIC_PASSWORD}" ] && echo 'Please set the APPLE_APP_SPECIFIC_PASSWORD env var.' >&2 && exit 1
-[ -z "${ASC_PROVIDER}" ] && echo 'Please set the ASC_PROVIDER env var.' >&2 && exit 1
+[ -z "${APPLE_TEAM_ID}" ] && echo 'Please set the APPLE_TEAM_ID env var.' >&2 && exit 1
 
 echo "Signing $DMG_FILE"
 codesign --verbose=4 --options runtime \
     --sign "${APPLE_CODESIGN_IDENTITY}" "$(dirname "$0")/Mixxx.entitlements" "${DMG_FILE}"
 
 echo "Notarizing $DMG_FILE"
-xcrun altool --notarize-app --primary-bundle-id "${APPLE_BUNDLE_ID}" --username "${APPLE_ID_USERNAME}" \
-    --password "${APPLE_APP_SPECIFIC_PASSWORD}" --asc-provider "${ASC_PROVIDER}" --file "${DMG_FILE}" \
-    --output-format xml > notarize_result.plist
+xcrun notarytool \
+    --primary-bundle-id "${APPLE_BUNDLE_ID}" \
+    --apple-id "${APPLE_ID_USERNAME}" \
+    --password "${APPLE_APP_SPECIFIC_PASSWORD}" \
+    --team-id "${APPLE_TEAM_ID}" \
+    --file "${DMG_FILE}" \
+    --output-format plist > notarize_result.plist
 UUID="$(/usr/libexec/PlistBuddy -c 'Print notarization-upload:RequestUUID' notarize_result.plist)"
 echo "Notarization UUID: $UUID"
 rm notarize_result.plist
@@ -25,9 +29,11 @@ sleep 5
 
 # wait for confirmation that notarization finished
 while true; do
-    xcrun altool --notarization-info "$UUID" \
-    --username "${APPLE_ID_USERNAME}" --password "${APPLE_APP_SPECIFIC_PASSWORD}" \
-    --output-format xml > notarize_status.plist
+    xcrun notarytool \
+        --notarization-info "$UUID" \
+        --apple-id "${APPLE_ID_USERNAME}" \
+        --password "${APPLE_APP_SPECIFIC_PASSWORD}" \
+        --output-format plist > notarize_status.plist
 
     # shellcheck disable=SC2181
     if [ "$?" != "0" ]; then

--- a/packaging/macos/sign_notarize_staple.sh
+++ b/packaging/macos/sign_notarize_staple.sh
@@ -2,11 +2,11 @@
 
 DMG_FILE="${1}"
 [ -z "${DMG_FILE}" ] && echo "Pass DMG file name as first argument." >&2 && exit 1
-[ -z "${APPLE_CODESIGN_IDENTITY}" ] && echo "Please set the $APPLE_CODESIGN_IDENTITY env var." >&2 && exit 1
-[ -z "${APPLE_BUNDLE_ID}" ] && echo "Please set the $APPLE_BUNDLE_ID env var." >&2 && exit 1
-[ -z "${APPLE_ID_USERNAME}" ] && echo "Please set the $APPLE_ID_USERNAME env var." >&2 && exit 1
-[ -z "${APPLE_APP_SPECIFIC_PASSWORD}" ] && echo "Please set the $APPLE_APP_SPECIFIC_PASSWORD env var." >&2 && exit 1
-[ -z "${ASC_PROVIDER}" ] && echo "Please set the $ASC_PROVIDER env var." >&2 && exit 1
+[ -z "${APPLE_CODESIGN_IDENTITY}" ] && echo 'Please set the APPLE_CODESIGN_IDENTITY env var.' >&2 && exit 1
+[ -z "${APPLE_BUNDLE_ID}" ] && echo 'Please set the APPLE_BUNDLE_ID env var.' >&2 && exit 1
+[ -z "${APPLE_ID_USERNAME}" ] && echo 'Please set the APPLE_ID_USERNAME env var.' >&2 && exit 1
+[ -z "${APPLE_APP_SPECIFIC_PASSWORD}" ] && echo 'Please set the APPLE_APP_SPECIFIC_PASSWORD env var.' >&2 && exit 1
+[ -z "${ASC_PROVIDER}" ] && echo 'Please set the ASC_PROVIDER env var.' >&2 && exit 1
 
 echo "Signing $DMG_FILE"
 codesign --verbose=4 --options runtime \

--- a/packaging/macos/sign_notarize_staple.sh
+++ b/packaging/macos/sign_notarize_staple.sh
@@ -25,14 +25,18 @@ xcrun notarytool submit \
 trap 'rm notarize_status.plist' EXIT
 cat notarize_status.plist
 
-NOTARIZATION_STATUS="$(/usr/libexec/PlistBuddy -c 'Print notarization-info:Status' notarize_status.plist)"
+NOTARIZATION_STATUS="$(/usr/libexec/PlistBuddy -c 'Print status' notarize_status.plist)"
 
 case "${NOTARIZATION_STATUS}" in
-    success)
+    Accepted)
         echo "Notarization succeeded"
         ;;
-    invalid)
-        echo "Notarization failed with status: ${NOTARIZATION_STATUS}"
+    Invalid)
+        echo "Notarization invalid"
+        exit 1
+        ;;
+    Rejected)
+        echo "Notarization rejected"
         exit 1
         ;;
     *)

--- a/packaging/macos/sign_notarize_staple.sh
+++ b/packaging/macos/sign_notarize_staple.sh
@@ -3,7 +3,6 @@
 DMG_FILE="${1}"
 [ -z "${DMG_FILE}" ] && echo "Pass DMG file name as first argument." >&2 && exit 1
 [ -z "${APPLE_CODESIGN_IDENTITY}" ] && echo 'Please set the APPLE_CODESIGN_IDENTITY env var.' >&2 && exit 1
-[ -z "${APPLE_BUNDLE_ID}" ] && echo 'Please set the APPLE_BUNDLE_ID env var.' >&2 && exit 1
 [ -z "${APPLE_ID_USERNAME}" ] && echo 'Please set the APPLE_ID_USERNAME env var.' >&2 && exit 1
 [ -z "${APPLE_APP_SPECIFIC_PASSWORD}" ] && echo 'Please set the APPLE_APP_SPECIFIC_PASSWORD env var.' >&2 && exit 1
 [ -z "${APPLE_TEAM_ID}" ] && echo 'Please set the APPLE_TEAM_ID env var.' >&2 && exit 1

--- a/packaging/macos/sign_notarize_staple.sh
+++ b/packaging/macos/sign_notarize_staple.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 DMG_FILE="${1}"
 [ -z "${DMG_FILE}" ] && echo "Pass DMG file name as first argument." >&2 && exit 1
 [ -z "${APPLE_CODESIGN_IDENTITY}" ] && echo 'Please set the APPLE_CODESIGN_IDENTITY env var.' >&2 && exit 1
@@ -22,13 +24,6 @@ xcrun notarytool submit \
 
 trap 'rm notarize_status.plist' EXIT
 cat notarize_status.plist
-
-# shellcheck disable=SC2181
-if [ "$?" != "0" ]; then
-    echo "Notarization failed:"
-    curl "$(/usr/libexec/PlistBuddy -c 'Print notarization-info:LogFileURL' notarize_status.plist)"
-    exit 1
-fi
 
 NOTARIZATION_STATUS="$(/usr/libexec/PlistBuddy -c 'Print notarization-info:Status' notarize_status.plist)"
 

--- a/packaging/macos/sign_notarize_staple.sh
+++ b/packaging/macos/sign_notarize_staple.sh
@@ -13,13 +13,12 @@ codesign --verbose=4 --options runtime \
     --sign "${APPLE_CODESIGN_IDENTITY}" "$(dirname "$0")/Mixxx.entitlements" "${DMG_FILE}"
 
 echo "Notarizing $DMG_FILE"
-xcrun notarytool \
-    --primary-bundle-id "${APPLE_BUNDLE_ID}" \
+xcrun notarytool submit \
     --apple-id "${APPLE_ID_USERNAME}" \
     --password "${APPLE_APP_SPECIFIC_PASSWORD}" \
     --team-id "${APPLE_TEAM_ID}" \
-    --file "${DMG_FILE}" \
-    --output-format plist > notarize_result.plist
+    --output-format plist \
+    "${DMG_FILE}" > notarize_result.plist
 UUID="$(/usr/libexec/PlistBuddy -c 'Print notarization-upload:RequestUUID' notarize_result.plist)"
 echo "Notarization UUID: $UUID"
 rm notarize_result.plist
@@ -29,11 +28,11 @@ sleep 5
 
 # wait for confirmation that notarization finished
 while true; do
-    xcrun notarytool \
-        --notarization-info "$UUID" \
+    xcrun notarytool info \
         --apple-id "${APPLE_ID_USERNAME}" \
         --password "${APPLE_APP_SPECIFIC_PASSWORD}" \
-        --output-format plist > notarize_status.plist
+        --output-format plist > notarize_status.plist \
+        "$UUID"
 
     # shellcheck disable=SC2181
     if [ "$?" != "0" ]; then


### PR DESCRIPTION
### Fixes #12089 

As per [the official migration guide](https://developer.apple.com/documentation/technotes/tn3147-migrating-to-the-latest-notarization-tool). In principle everything should work as-is, but I'll mark this as a draft for now for some more testing. Since notarization fails on 2.4 and `main`, we might have to generate new passwords anyway.

### To do

- [x] Migrate to the new credential flags
- [x] Migrate the polling mechanism to the `--wait` flag
- [x] Fix the plist parsing
- [ ] Print `notarytool log ...` if a submission fails