### PR TITLE
GitHub Actions: Scope push trigger to main branches

### DIFF
--- a/.github/workflows/build-checks.yml
+++ b/.github/workflows/build-checks.yml
@@ -4,6 +4,9 @@ name: build-checks
 
 on:
   push:
+    branches:
+      - main
+      - "[0-9].[0-9]"
   pull_request:
 
 permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ name: Build
 
 on:
   push:
+    branches:
+      - main
+      - "[0-9].[0-9]"
   pull_request:
 
 permissions:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,6 +4,9 @@ name: pre-commit
 
 on:
   push:
+    branches:
+      - main
+      - "[0-9].[0-9]"
   pull_request:
 
 permissions:


### PR DESCRIPTION
This prevents CI from running the entire build matrix twice for PRs from upstream branches in `mixxxdj/mixxx` (triggering both `push` and `pull_request`), as per [this suggestion](https://github.com/orgs/community/discussions/26940#discussioncomment-5686753).

The side effect of this change would be that pushes no longer trigger CI on non-main, non-release branches in `mixxxdj/mixxx` outside of PRs. If that's not acceptable, we could [work around the issue using conditionals](https://github.com/orgs/community/discussions/26940#discussioncomment-6656489).

Thoughts?