### PR TITLE
Adjust position for FATAL_ERROR_MISSING_ENV()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1680,13 +1680,22 @@ endif()
 
 # The mixxx executable
 if(QT6)
-  find_package(Qt6 REQUIRED COMPONENTS Core) # For Qt Core cmake functions
+  find_package(Qt6 COMPONENTS Core) # For Qt Core cmake functions
+  # This is the first package form the environment, if this fails give hints how to install the environment
+  if(NOT Qt6_FOUND)
+     FATAL_ERROR_MISSING_ENV()
+  endif()
   # qt_add_executable() is the recommended initial call for qt_finalize_target()
   # below that takes care of the correct object order in the resulting binary
   # According to https://doc.qt.io/qt-6/qt-finalize-target.html it is importand for
   # builds with Qt < 3.21
   qt_add_executable(mixxx WIN32 src/main.cpp MANUAL_FINALIZATION)
 else()
+  find_package(Qt5 COMPONENTS Core) # For Qt Core cmake functions
+  # This is the first package form the environment, if this fails give hints how to install the environment
+  if(NOT Qt5_FOUND)
+     FATAL_ERROR_MISSING_ENV()
+  endif()
   add_executable(mixxx WIN32 src/main.cpp)
 endif()
 # ugly hack to get #include "preferences/dialog/ui_dlgpreferencesdlg.h" to work in
@@ -2231,13 +2240,8 @@ if(WIN32)
 endif()
 
 # Chromaprint
-find_package(Chromaprint)
-# This is the first package form the environment, if this fails give hints how to install the environment
-if(NOT Chromaprint_FOUND)
-  FATAL_ERROR_MISSING_ENV()
-else()
-  target_link_libraries(mixxx-lib PRIVATE Chromaprint::Chromaprint)
-endif()
+find_package(Chromaprint REQUIRED)
+target_link_libraries(mixxx-lib PRIVATE Chromaprint::Chromaprint)
 
 # Locale Aware Compare for SQLite
 find_package(SQLite3)


### PR DESCRIPTION
It turns out that the warning is issued to later after the adjustments for QT6. 
Here is the fix. 
https://mixxx.zulipchat.com/#narrow/stream/247620-development-help/topic/help.20compiling.20mixxx