### PR TITLE
macOS packaging: Enable app sandbox in unsigned 2.4 builds too

### DIFF
--- a/cmake/modules/BundleInstall.cmake.in
+++ b/cmake/modules/BundleInstall.cmake.in
@@ -23,6 +23,7 @@ if(DEFINED APPLE_CODESIGN_IDENTITY AND DEFINED APPLE_CODESIGN_ENTITLEMENTS)
       message(STATUS "Ad-hoc signing bundle without hardened runtime")
       execute_process(COMMAND
           codesign --verbose=4 --deep --force
+          --entitlements "${APPLE_CODESIGN_ENTITLEMENTS}"
           --sign "${APPLE_CODESIGN_IDENTITY}"
           "${PATH_TO_SIGN}"
       )


### PR DESCRIPTION
Cherry-pick of #12101 onto 2.4.

This would be great to have to move our test builds closer to the release builds and would really help in diagnosing issues such as #12137.