### PR TITLE
Allow switching between legacy and new QML UI with command arg

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
             os: ubuntu-22.04
             cmake_args: >-
               -DQT6=ON
+              -DQML=OFF
               -DBULK=ON
               -DFFMPEG=ON
               -DLOCALECOMPARE=ON

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,28 +19,6 @@ jobs:
             os: ubuntu-22.04
             cmake_args: >-
               -DQT6=ON
-              -DQML=OFF
-              -DBULK=ON
-              -DFFMPEG=ON
-              -DLOCALECOMPARE=ON
-              -DMAD=ON
-              -DMODPLUG=ON
-              -DWAVPACK=ON
-              -DINSTALL_USER_UDEV_RULES=OFF
-            ctest_args: []
-            compiler_cache: ccache
-            compiler_cache_path: ~/.ccache
-            cpack_generator: DEB
-            buildenv_basepath: /home/runner/buildenv.sh
-            buildenv_script: tools/debian_buildenv.sh
-            artifacts_name: Ubuntu 22.04 DEB
-            artifacts_path: build/*.deb
-            artifacts_slug: ubuntu-jammy
-            qt_qpa_platform: offscreen
-          - name: Ubuntu 22.04 (QML)
-            os: ubuntu-22.04
-            cmake_args: >-
-              -DQT6=ON
               -DQML=ON
               -DBULK=ON
               -DFFMPEG=ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -625,9 +625,9 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/analyzer/plugins/buffering_utils.cpp
   src/analyzer/trackanalysisscheduler.cpp
   src/audio/frame.cpp
-  src/audio/types.cpp
   src/audio/signalinfo.cpp
   src/audio/streaminfo.cpp
+  src/audio/types.cpp
   src/control/control.cpp
   src/control/controlaudiotaperpot.cpp
   src/control/controlbehavior.cpp
@@ -649,12 +649,11 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/controllers/controllerinputmappingtablemodel.cpp
   src/controllers/controllerlearningeventfilter.cpp
   src/controllers/controllermanager.cpp
-  src/controllers/controllermappingtablemodel.cpp
   src/controllers/controllermappinginfo.cpp
   src/controllers/controllermappinginfoenumerator.cpp
+  src/controllers/controllermappingtablemodel.cpp
   src/controllers/controlleroutputmappingtablemodel.cpp
   src/controllers/controlpickermenu.cpp
-  src/controllers/legacycontrollermappingfilehandler.cpp
   src/controllers/delegates/controldelegate.cpp
   src/controllers/delegates/midibytedelegate.cpp
   src/controllers/delegates/midichanneldelegate.cpp
@@ -666,16 +665,9 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/controllers/dlgprefcontrollerdlg.ui
   src/controllers/dlgprefcontrollers.cpp
   src/controllers/dlgprefcontrollersdlg.ui
-  src/controllers/scripting/controllerscriptenginebase.cpp
-  src/controllers/scripting/controllerscriptmoduleengine.cpp
-  src/controllers/scripting/colormapper.cpp
-  src/controllers/scripting/colormapperjsproxy.cpp
-  src/controllers/scripting/legacy/controllerscriptenginelegacy.cpp
-  src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
-  src/controllers/scripting/legacy/scriptconnection.cpp
-  src/controllers/scripting/legacy/scriptconnectionjsproxy.cpp
   src/controllers/keyboard/keyboardeventfilter.cpp
   src/controllers/learningutils.cpp
+  src/controllers/legacycontrollermappingfilehandler.cpp
   src/controllers/midi/legacymidicontrollermapping.cpp
   src/controllers/midi/legacymidicontrollermappingfilehandler.cpp
   src/controllers/midi/midicontroller.cpp
@@ -685,7 +677,16 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/controllers/midi/midiutils.cpp
   src/controllers/midi/portmidicontroller.cpp
   src/controllers/midi/portmidienumerator.cpp
+  src/controllers/scripting/colormapper.cpp
+  src/controllers/scripting/colormapperjsproxy.cpp
+  src/controllers/scripting/controllerscriptenginebase.cpp
+  src/controllers/scripting/controllerscriptmoduleengine.cpp
+  src/controllers/scripting/legacy/controllerscriptenginelegacy.cpp
+  src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
+  src/controllers/scripting/legacy/scriptconnection.cpp
+  src/controllers/scripting/legacy/scriptconnectionjsproxy.cpp
   src/controllers/softtakeover.cpp
+  src/coreservices.cpp
   src/database/mixxxdb.cpp
   src/database/schemamanager.cpp
   src/dialog/dlgabout.cpp
@@ -696,19 +697,6 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/dialog/dlgkeywheel.ui
   src/dialog/dlgreplacecuecolor.cpp
   src/dialog/dlgreplacecuecolordlg.ui
-  src/effects/effectbuttonparameterslot.cpp
-  src/effects/effectchain.cpp
-  src/effects/effectchainmixmode.cpp
-  src/effects/effectparameter.cpp
-  src/effects/effectknobparameterslot.cpp
-  src/effects/effectparameterslotbase.cpp
-  src/effects/effectslot.cpp
-  src/effects/effectsmanager.cpp
-  src/effects/effectsmessenger.cpp
-  src/effects/visibleeffectslist.cpp
-  src/effects/backends/effectsbackend.cpp
-  src/effects/backends/effectmanifest.cpp
-  src/effects/backends/effectmanifestparameter.cpp
   src/effects/backends/builtin/autopaneffect.cpp
   src/effects/backends/builtin/balanceeffect.cpp
   src/effects/backends/builtin/bessel4lvmixeqeffect.cpp
@@ -716,15 +704,16 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/effects/backends/builtin/biquadfullkilleqeffect.cpp
   src/effects/backends/builtin/bitcrushereffect.cpp
   src/effects/backends/builtin/builtinbackend.cpp
+  src/effects/backends/builtin/distortioneffect.cpp
   src/effects/backends/builtin/echoeffect.cpp
   src/effects/backends/builtin/filtereffect.cpp
   src/effects/backends/builtin/flangereffect.cpp
+  src/effects/backends/builtin/glitcheffect.cpp
   src/effects/backends/builtin/graphiceqeffect.cpp
   src/effects/backends/builtin/linkwitzriley8eqeffect.cpp
   src/effects/backends/builtin/loudnesscontoureffect.cpp
   src/effects/backends/builtin/metronomeeffect.cpp
   src/effects/backends/builtin/moogladder4filtereffect.cpp
-  src/effects/backends/builtin/distortioneffect.cpp
   src/effects/backends/builtin/parametriceqeffect.cpp
   src/effects/backends/builtin/phasereffect.cpp
   src/effects/backends/builtin/pitchshifteffect.cpp
@@ -732,18 +721,30 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/effects/backends/builtin/threebandbiquadeqeffect.cpp
   src/effects/backends/builtin/tremoloeffect.cpp
   src/effects/backends/builtin/whitenoiseeffect.cpp
-  src/effects/backends/builtin/glitcheffect.cpp
+  src/effects/backends/effectmanifest.cpp
+  src/effects/backends/effectmanifestparameter.cpp
+  src/effects/backends/effectsbackend.cpp
   src/effects/backends/effectsbackendmanager.cpp
   src/effects/chains/equalizereffectchain.cpp
   src/effects/chains/outputeffectchain.cpp
   src/effects/chains/pergroupeffectchain.cpp
   src/effects/chains/quickeffectchain.cpp
   src/effects/chains/standardeffectchain.cpp
+  src/effects/effectbuttonparameterslot.cpp
+  src/effects/effectchain.cpp
+  src/effects/effectchainmixmode.cpp
+  src/effects/effectknobparameterslot.cpp
+  src/effects/effectparameter.cpp
+  src/effects/effectparameterslotbase.cpp
+  src/effects/effectslot.cpp
+  src/effects/effectsmanager.cpp
+  src/effects/effectsmessenger.cpp
   src/effects/presets/effectchainpreset.cpp
   src/effects/presets/effectchainpresetmanager.cpp
   src/effects/presets/effectparameterpreset.cpp
   src/effects/presets/effectpreset.cpp
   src/effects/presets/effectpresetmanager.cpp
+  src/effects/visibleeffectslist.cpp
   src/encoder/encoder.cpp
   src/encoder/encoderfdkaac.cpp
   src/encoder/encoderfdkaacsettings.cpp
@@ -935,8 +936,8 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/mixer/previewdeck.cpp
   src/mixer/sampler.cpp
   src/mixer/samplerbank.cpp
-  src/coreservices.cpp
   src/mixxxapplication.cpp
+  src/mixxxmainwindow.cpp
   src/musicbrainz/chromaprinter.cpp
   src/musicbrainz/crc.cpp
   src/musicbrainz/gzip.cpp
@@ -951,7 +952,10 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/network/networktask.cpp
   src/network/webtask.cpp
   src/preferences/colorpaletteeditor.cpp
+  src/preferences/colorpaletteeditor.cpp
   src/preferences/colorpaletteeditormodel.cpp
+  src/preferences/colorpaletteeditormodel.cpp
+  src/preferences/colorpalettesettings.cpp
   src/preferences/colorpalettesettings.cpp
   src/preferences/configobject.cpp
   src/preferences/dialog/dlgprefautodj.cpp
@@ -960,8 +964,6 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/preferences/dialog/dlgprefbeatsdlg.ui
   src/preferences/dialog/dlgprefcolors.cpp
   src/preferences/dialog/dlgprefcolorsdlg.ui
-  src/preferences/dialog/dlgprefmixer.cpp
-  src/preferences/dialog/dlgprefmixerdlg.ui
   src/preferences/dialog/dlgprefdeck.cpp
   src/preferences/dialog/dlgprefdeckdlg.ui
   src/preferences/dialog/dlgprefeffects.cpp
@@ -975,6 +977,8 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/preferences/dialog/dlgprefkeydlg.ui
   src/preferences/dialog/dlgpreflibrary.cpp
   src/preferences/dialog/dlgpreflibrarydlg.ui
+  src/preferences/dialog/dlgprefmixer.cpp
+  src/preferences/dialog/dlgprefmixerdlg.ui
   src/preferences/dialog/dlgprefrecord.cpp
   src/preferences/dialog/dlgprefrecorddlg.ui
   src/preferences/dialog/dlgprefreplaygain.cpp
@@ -988,9 +992,6 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/preferences/dialog/dlgprefwaveformdlg.ui
   src/preferences/effectchainpresetlistmodel.cpp
   src/preferences/effectmanifesttablemodel.cpp
-  src/preferences/colorpaletteeditor.cpp
-  src/preferences/colorpaletteeditormodel.cpp
-  src/preferences/colorpalettesettings.cpp
   src/preferences/replaygainsettings.cpp
   src/preferences/settingsmanager.cpp
   src/preferences/upgrade.cpp
@@ -1046,12 +1047,6 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/track/serato/markers.cpp
   src/track/serato/markers2.cpp
   src/track/serato/tags.cpp
-  src/track/track.cpp
-  src/track/trackinfo.cpp
-  src/track/trackmetadata.cpp
-  src/track/tracknumbers.cpp
-  src/track/trackrecord.cpp
-  src/track/trackref.cpp
   src/track/taglib/trackmetadata_ape.cpp
   src/track/taglib/trackmetadata_common.cpp
   src/track/taglib/trackmetadata_file.cpp
@@ -1059,15 +1054,20 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/track/taglib/trackmetadata_mp4.cpp
   src/track/taglib/trackmetadata_riff.cpp
   src/track/taglib/trackmetadata_xiph.cpp
+  src/track/track.cpp
+  src/track/trackinfo.cpp
+  src/track/trackmetadata.cpp
+  src/track/tracknumbers.cpp
+  src/track/trackrecord.cpp
+  src/track/trackref.cpp
   src/util/battery/battery.cpp
   src/util/cache.cpp
   src/util/cmdlineargs.cpp
-  src/util/colorcomponents.cpp
   src/util/color/color.cpp
   src/util/color/colorpalette.cpp
   src/util/color/predefinedcolorpalettes.cpp
+  src/util/colorcomponents.cpp
   src/util/console.cpp
-  src/util/safelywritablefile.cpp
   src/util/db/dbconnection.cpp
   src/util/db/dbconnectionpool.cpp
   src/util/db/dbconnectionpooled.cpp
@@ -1084,10 +1084,10 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/util/duration.cpp
   src/util/experiment.cpp
   src/util/file.cpp
-  src/util/imagefiledata.cpp
   src/util/fileaccess.cpp
   src/util/fileinfo.cpp
   src/util/filename.cpp
+  src/util/imagefiledata.cpp
   src/util/imagefiledata.cpp
   src/util/imageutils.cpp
   src/util/indexrange.cpp
@@ -1101,11 +1101,12 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/util/ringdelaybuffer.cpp
   src/util/rotary.cpp
   src/util/runtimeloggingcategory.cpp
+  src/util/safelywritablefile.cpp
   src/util/sample.cpp
   src/util/sandbox.cpp
-  src/util/semanticversion.cpp
   src/util/screensaver.cpp
   src/util/screensavermanager.cpp
+  src/util/semanticversion.cpp
   src/util/stat.cpp
   src/util/statmodel.cpp
   src/util/statsmanager.cpp
@@ -1121,9 +1122,48 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/util/workerthread.cpp
   src/util/workerthreadscheduler.cpp
   src/util/xml.cpp
+  src/waveform/guitick.cpp
+  src/waveform/renderers/glslwaveformrenderersignal.cpp
+  src/waveform/renderers/glvsynctestrenderer.cpp
+  src/waveform/renderers/glwaveformrenderbackground.cpp
+  src/waveform/renderers/glwaveformrendererfilteredsignal.cpp
+  src/waveform/renderers/glwaveformrendererrgb.cpp
+  src/waveform/renderers/glwaveformrenderersimplesignal.cpp
+  src/waveform/renderers/waveformmark.cpp
+  src/waveform/renderers/waveformmarkrange.cpp
+  src/waveform/renderers/waveformmarkset.cpp
+  src/waveform/renderers/waveformrenderbackground.cpp
+  src/waveform/renderers/waveformrenderbeat.cpp
+  src/waveform/renderers/waveformrendererabstract.cpp
+  src/waveform/renderers/waveformrendererendoftrack.cpp
+  src/waveform/renderers/waveformrendererfilteredsignal.cpp
+  src/waveform/renderers/waveformrendererhsv.cpp
+  src/waveform/renderers/waveformrendererpreroll.cpp
+  src/waveform/renderers/waveformrendererrgb.cpp
+  src/waveform/renderers/waveformrenderersignalbase.cpp
+  src/waveform/renderers/waveformrendermark.cpp
+  src/waveform/renderers/waveformrendermarkrange.cpp
+  src/waveform/renderers/waveformsignalcolors.cpp
+  src/waveform/renderers/waveformwidgetrenderer.cpp
+  src/waveform/sharedglcontext.cpp
   src/waveform/visualplayposition.cpp
+  src/waveform/visualsmanager.cpp
+  src/waveform/vsyncthread.cpp
   src/waveform/waveform.cpp
   src/waveform/waveformfactory.cpp
+  src/waveform/waveformmarklabel.cpp
+  src/waveform/waveformwidgetfactory.cpp
+  src/waveform/widgets/emptywaveformwidget.cpp
+  src/waveform/widgets/glrgbwaveformwidget.cpp
+  src/waveform/widgets/glsimplewaveformwidget.cpp
+  src/waveform/widgets/glslwaveformwidget.cpp
+  src/waveform/widgets/glvsynctestwidget.cpp
+  src/waveform/widgets/glwaveformwidget.cpp
+  src/waveform/widgets/glwaveformwidgetabstract.cpp
+  src/waveform/widgets/hsvwaveformwidget.cpp
+  src/waveform/widgets/rgbwaveformwidget.cpp
+  src/waveform/widgets/softwarewaveformwidget.cpp
+  src/waveform/widgets/waveformwidgetabstract.cpp
   src/widget/controlwidgetconnection.cpp
   src/widget/findonwebmenufactory.cpp
   src/widget/findonwebmenuservices/findonwebmenudiscogs.cpp
@@ -1170,6 +1210,10 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/widget/wnumberdb.cpp
   src/widget/wnumberpos.cpp
   src/widget/wnumberrate.cpp
+  src/widget/woverview.cpp
+  src/widget/woverviewhsv.cpp
+  src/widget/woverviewlmh.cpp
+  src/widget/woverviewrgb.cpp
   src/widget/wpixmapstore.cpp
   src/widget/wpushbutton.cpp
   src/widget/wraterange.cpp
@@ -1181,6 +1225,8 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/widget/wsizeawarestack.cpp
   src/widget/wskincolor.cpp
   src/widget/wslidercomposed.cpp
+  src/widget/wspinny.cpp
+  src/widget/wspinnybase.cpp
   src/widget/wsplitter.cpp
   src/widget/wstarrating.cpp
   src/widget/wstatuslight.cpp
@@ -1191,6 +1237,10 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/widget/wtracktableviewheader.cpp
   src/widget/wtracktext.cpp
   src/widget/wtrackwidgetgroup.cpp
+  src/widget/wvumeter.cpp
+  src/widget/wvumeterbase.cpp
+  src/widget/wvumeterlegacy.cpp
+  src/widget/wwaveformviewer.cpp
   src/widget/wwidget.cpp
   src/widget/wwidgetgroup.cpp
   src/widget/wwidgetstack.cpp
@@ -1356,60 +1406,11 @@ target_precompile_headers(mixxx-lib PUBLIC
   src/util/xml.h
   ${MIXXX_COMMON_PRECOMPILED_HEADER}
 )
-target_sources(mixxx-lib PRIVATE
-  src/mixxxmainwindow.cpp
-  src/waveform/guitick.cpp
-  src/waveform/renderers/glslwaveformrenderersignal.cpp
-  src/waveform/renderers/glvsynctestrenderer.cpp
-  src/waveform/renderers/glwaveformrenderbackground.cpp
-  src/waveform/renderers/glwaveformrendererfilteredsignal.cpp
-  src/waveform/renderers/glwaveformrendererrgb.cpp
-  src/waveform/renderers/glwaveformrenderersimplesignal.cpp
-  src/waveform/renderers/waveformmark.cpp
-  src/waveform/renderers/waveformmarkrange.cpp
-  src/waveform/renderers/waveformmarkset.cpp
-  src/waveform/renderers/waveformrenderbackground.cpp
-  src/waveform/renderers/waveformrenderbeat.cpp
-  src/waveform/renderers/waveformrendererabstract.cpp
-  src/waveform/renderers/waveformrendererendoftrack.cpp
-  src/waveform/renderers/waveformrendererfilteredsignal.cpp
-  src/waveform/renderers/waveformrendererhsv.cpp
-  src/waveform/renderers/waveformrendererpreroll.cpp
-  src/waveform/renderers/waveformrendererrgb.cpp
-  src/waveform/renderers/waveformrenderersignalbase.cpp
-  src/waveform/renderers/waveformrendermark.cpp
-  src/waveform/renderers/waveformrendermarkrange.cpp
-  src/waveform/renderers/waveformsignalcolors.cpp
-  src/waveform/renderers/waveformwidgetrenderer.cpp
-  src/waveform/sharedglcontext.cpp
-  src/waveform/visualsmanager.cpp
-  src/waveform/vsyncthread.cpp
-  src/waveform/waveformmarklabel.cpp
-  src/waveform/waveformwidgetfactory.cpp
-  src/waveform/widgets/emptywaveformwidget.cpp
-  src/waveform/widgets/glrgbwaveformwidget.cpp
-  src/waveform/widgets/glsimplewaveformwidget.cpp
-  src/waveform/widgets/glslwaveformwidget.cpp
-  src/waveform/widgets/glvsynctestwidget.cpp
-  src/waveform/widgets/glwaveformwidget.cpp
-  src/waveform/widgets/glwaveformwidgetabstract.cpp
-  src/waveform/widgets/hsvwaveformwidget.cpp
-  src/waveform/widgets/rgbwaveformwidget.cpp
-  src/waveform/widgets/softwarewaveformwidget.cpp
-  src/waveform/widgets/waveformwidgetabstract.cpp
-  src/widget/woverview.cpp
-  src/widget/woverviewhsv.cpp
-  src/widget/woverviewlmh.cpp
-  src/widget/woverviewrgb.cpp
-  src/widget/wspinny.cpp
-  src/widget/wspinnybase.cpp
-  src/widget/wvumeter.cpp
-  src/widget/wvumeterbase.cpp
-  src/widget/wvumeterlegacy.cpp
-  src/widget/wwaveformviewer.cpp
-)
 if (NOT QML)
   target_sources(mixxx-lib PRIVATE
+    # The following sources need to be in the QML target in order to get QML_ELEMENT properly interpreted.
+    # However, if we build Mixxx without QML support, these are still required, so it gets appended to the
+    # main target
     src/control/controlmodel.cpp
     src/control/controlsortfiltermodel.cpp
   )
@@ -2640,7 +2641,7 @@ if(QML)
     src/qml/qmlplayerproxy.cpp
     src/qml/qmlvisibleeffectsmodel.cpp
     src/qml/qmlwaveformoverview.cpp
-    # The following source needs to be in this target to get QML_ELEMENT properly interpreted
+    # The following sources need to be in this target to get QML_ELEMENT properly interpreted
     src/control/controlmodel.cpp
     src/control/controlsortfiltermodel.cpp
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,13 +129,11 @@ if(NOT CMAKE_CONFIGURATION_TYPES)
   endif()
 endif()
 
-option(QT6 "Build with Qt6" ON)
-option(QML "Build with QML" OFF)
-option(QOPENGL "Use QOpenGLWindow based widget instead of QGLWidget" ON)
+include(CMakeDependentOption)
 
-if(QML AND NOT QT6)
-  message(FATAL_ERROR "Building with option QML=ON requires QT6=ON")
-endif()
+option(QT6 "Build with Qt6" ON)
+cmake_dependent_option(QML "Build with QML" ON "QT6" OFF)
+option(QOPENGL "Use QOpenGLWindow based widget instead of QGLWidget" ON)
 
 if(QOPENGL)
   add_compile_definitions(MIXXX_USE_QOPENGL)
@@ -187,7 +185,6 @@ set(CMAKE_PROJECT_DESCRIPTION "Mixxx is Free DJ software that gives you everythi
 set(BUILD_COLORS "auto" CACHE STRING "Try to use colors auto/always/no")
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
-include(CMakeDependentOption)
 include(CheckSymbolExists)
 include(CheckIncludeFileCXX)
 include(ExternalProject)
@@ -641,8 +638,6 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/control/controlindicatortimer.cpp
   src/control/controllinpotmeter.cpp
   src/control/controllogpotmeter.cpp
-  src/control/controlmodel.cpp
-  src/control/controlsortfiltermodel.cpp
   src/control/controlobject.cpp
   src/control/controlobjectscript.cpp
   src/control/controlpotmeter.cpp
@@ -1200,6 +1195,9 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/widget/wwidgetgroup.cpp
   src/widget/wwidgetstack.cpp
 )
+set(MIXXX_COMMON_PRECOMPILED_HEADER
+  src/util/assert.h
+)
 target_precompile_headers(mixxx-lib PUBLIC
   src/audio/frame.h
   src/audio/signalinfo.h
@@ -1242,7 +1240,6 @@ target_precompile_headers(mixxx-lib PUBLIC
   src/track/trackrecord.h
   src/track/trackref.h
   src/util/alphabetafilter.h
-  src/util/assert.h
   src/util/battery/battery.h
   src/util/cache.h
   src/util/circularbuffer.h
@@ -1357,128 +1354,116 @@ target_precompile_headers(mixxx-lib PUBLIC
   src/util/workerthread.h
   src/util/workerthreadscheduler.h
   src/util/xml.h
+  ${MIXXX_COMMON_PRECOMPILED_HEADER}
 )
-if(QML)
+target_sources(mixxx-lib PRIVATE
+  src/mixxxmainwindow.cpp
+  src/waveform/guitick.cpp
+  src/waveform/renderers/glslwaveformrenderersignal.cpp
+  src/waveform/renderers/glvsynctestrenderer.cpp
+  src/waveform/renderers/glwaveformrenderbackground.cpp
+  src/waveform/renderers/glwaveformrendererfilteredsignal.cpp
+  src/waveform/renderers/glwaveformrendererrgb.cpp
+  src/waveform/renderers/glwaveformrenderersimplesignal.cpp
+  src/waveform/renderers/waveformmark.cpp
+  src/waveform/renderers/waveformmarkrange.cpp
+  src/waveform/renderers/waveformmarkset.cpp
+  src/waveform/renderers/waveformrenderbackground.cpp
+  src/waveform/renderers/waveformrenderbeat.cpp
+  src/waveform/renderers/waveformrendererabstract.cpp
+  src/waveform/renderers/waveformrendererendoftrack.cpp
+  src/waveform/renderers/waveformrendererfilteredsignal.cpp
+  src/waveform/renderers/waveformrendererhsv.cpp
+  src/waveform/renderers/waveformrendererpreroll.cpp
+  src/waveform/renderers/waveformrendererrgb.cpp
+  src/waveform/renderers/waveformrenderersignalbase.cpp
+  src/waveform/renderers/waveformrendermark.cpp
+  src/waveform/renderers/waveformrendermarkrange.cpp
+  src/waveform/renderers/waveformsignalcolors.cpp
+  src/waveform/renderers/waveformwidgetrenderer.cpp
+  src/waveform/sharedglcontext.cpp
+  src/waveform/visualsmanager.cpp
+  src/waveform/vsyncthread.cpp
+  src/waveform/waveformmarklabel.cpp
+  src/waveform/waveformwidgetfactory.cpp
+  src/waveform/widgets/emptywaveformwidget.cpp
+  src/waveform/widgets/glrgbwaveformwidget.cpp
+  src/waveform/widgets/glsimplewaveformwidget.cpp
+  src/waveform/widgets/glslwaveformwidget.cpp
+  src/waveform/widgets/glvsynctestwidget.cpp
+  src/waveform/widgets/glwaveformwidget.cpp
+  src/waveform/widgets/glwaveformwidgetabstract.cpp
+  src/waveform/widgets/hsvwaveformwidget.cpp
+  src/waveform/widgets/rgbwaveformwidget.cpp
+  src/waveform/widgets/softwarewaveformwidget.cpp
+  src/waveform/widgets/waveformwidgetabstract.cpp
+  src/widget/woverview.cpp
+  src/widget/woverviewhsv.cpp
+  src/widget/woverviewlmh.cpp
+  src/widget/woverviewrgb.cpp
+  src/widget/wspinny.cpp
+  src/widget/wspinnybase.cpp
+  src/widget/wvumeter.cpp
+  src/widget/wvumeterbase.cpp
+  src/widget/wvumeterlegacy.cpp
+  src/widget/wwaveformviewer.cpp
+)
+if (NOT QML)
   target_sources(mixxx-lib PRIVATE
-    src/qml/asyncimageprovider.cpp
-    src/qml/qmlapplication.cpp
-    src/qml/qmlcontrolproxy.cpp
-    src/qml/qmlconfigproxy.cpp
-    src/qml/qmldlgpreferencesproxy.cpp
-    src/qml/qmleffectmanifestparametersmodel.cpp
-    src/qml/qmleffectsmanagerproxy.cpp
-    src/qml/qmleffectslotproxy.cpp
-    src/qml/qmllibraryproxy.cpp
-    src/qml/qmllibrarytracklistmodel.cpp
-    src/qml/qmlplayermanagerproxy.cpp
-    src/qml/qmlplayerproxy.cpp
-    src/qml/qmlvisibleeffectsmodel.cpp
-    src/qml/qmlwaveformoverview.cpp
+    src/control/controlmodel.cpp
+    src/control/controlsortfiltermodel.cpp
+  )
+endif()
+if(QOPENGL)
+  target_sources(mixxx-lib PRIVATE
+    src/shaders/endoftrackshader.cpp
+    src/shaders/patternshader.cpp
+    src/shaders/rgbashader.cpp
+    src/shaders/rgbshader.cpp
+    src/shaders/shader.cpp
+    src/shaders/textureshader.cpp
+    src/shaders/unicolorshader.cpp
+    src/shaders/vinylqualityshader.cpp
+    src/util/texture.cpp
+    src/waveform/renderers/allshader/matrixforwidgetgeometry.cpp
+    src/waveform/renderers/allshader/waveformrenderbackground.cpp
+    src/waveform/renderers/allshader/waveformrenderbeat.cpp
+    src/waveform/renderers/allshader/waveformrenderer.cpp
+    src/waveform/renderers/allshader/waveformrendererendoftrack.cpp
+    src/waveform/renderers/allshader/waveformrendererfiltered.cpp
+    src/waveform/renderers/allshader/waveformrendererhsv.cpp
+    src/waveform/renderers/allshader/waveformrendererlrrgb.cpp
+    src/waveform/renderers/allshader/waveformrendererpreroll.cpp
+    src/waveform/renderers/allshader/waveformrendererrgb.cpp
+    src/waveform/renderers/allshader/waveformrenderersignalbase.cpp
+    src/waveform/renderers/allshader/waveformrenderersimple.cpp
+    src/waveform/renderers/allshader/waveformrendermark.cpp
+    src/waveform/renderers/allshader/waveformrendermarkrange.cpp
+    src/waveform/widgets/allshader/filteredwaveformwidget.cpp
+    src/waveform/widgets/allshader/hsvwaveformwidget.cpp
+    src/waveform/widgets/allshader/lrrgbwaveformwidget.cpp
+    src/waveform/widgets/allshader/rgbwaveformwidget.cpp
+    src/waveform/widgets/allshader/simplewaveformwidget.cpp
+    src/waveform/widgets/allshader/waveformwidget.cpp
+    src/widget/openglwindow.cpp
+    src/widget/tooltipqopengl.cpp
+    src/widget/wglwidgetqopengl.cpp
+    src/widget/winitialglwidget.cpp
+    src/widget/wspinnyglsl.cpp
+    src/widget/wvumeterglsl.cpp
   )
 else()
   target_sources(mixxx-lib PRIVATE
-    src/mixxxmainwindow.cpp
-    src/waveform/guitick.cpp
-    src/waveform/renderers/glslwaveformrenderersignal.cpp
-    src/waveform/renderers/glvsynctestrenderer.cpp
-    src/waveform/renderers/glwaveformrenderbackground.cpp
-    src/waveform/renderers/glwaveformrendererfilteredsignal.cpp
-    src/waveform/renderers/glwaveformrendererrgb.cpp
-    src/waveform/renderers/glwaveformrenderersimplesignal.cpp
-    src/waveform/renderers/waveformmark.cpp
-    src/waveform/renderers/waveformmarkrange.cpp
-    src/waveform/renderers/waveformmarkset.cpp
-    src/waveform/renderers/waveformrenderbackground.cpp
-    src/waveform/renderers/waveformrenderbeat.cpp
-    src/waveform/renderers/waveformrendererabstract.cpp
-    src/waveform/renderers/waveformrendererendoftrack.cpp
-    src/waveform/renderers/waveformrendererfilteredsignal.cpp
-    src/waveform/renderers/waveformrendererhsv.cpp
-    src/waveform/renderers/waveformrendererpreroll.cpp
-    src/waveform/renderers/waveformrendererrgb.cpp
-    src/waveform/renderers/waveformrenderersignalbase.cpp
-    src/waveform/renderers/waveformrendermark.cpp
-    src/waveform/renderers/waveformrendermarkrange.cpp
-    src/waveform/renderers/waveformsignalcolors.cpp
-    src/waveform/renderers/waveformwidgetrenderer.cpp
-    src/waveform/sharedglcontext.cpp
-    src/waveform/visualsmanager.cpp
-    src/waveform/vsyncthread.cpp
-    src/waveform/waveformmarklabel.cpp
-    src/waveform/waveformwidgetfactory.cpp
-    src/waveform/widgets/emptywaveformwidget.cpp
-    src/waveform/widgets/glrgbwaveformwidget.cpp
-    src/waveform/widgets/glsimplewaveformwidget.cpp
-    src/waveform/widgets/glslwaveformwidget.cpp
-    src/waveform/widgets/glvsynctestwidget.cpp
-    src/waveform/widgets/glwaveformwidget.cpp
-    src/waveform/widgets/glwaveformwidgetabstract.cpp
-    src/waveform/widgets/hsvwaveformwidget.cpp
-    src/waveform/widgets/rgbwaveformwidget.cpp
-    src/waveform/widgets/softwarewaveformwidget.cpp
-    src/waveform/widgets/waveformwidgetabstract.cpp
-    src/widget/woverview.cpp
-    src/widget/woverviewhsv.cpp
-    src/widget/woverviewlmh.cpp
-    src/widget/woverviewrgb.cpp
-    src/widget/wspinny.cpp
-    src/widget/wspinnybase.cpp
-    src/widget/wvumeter.cpp
-    src/widget/wvumeterbase.cpp
-    src/widget/wvumeterlegacy.cpp
-    src/widget/wwaveformviewer.cpp
+    src/waveform/renderers/qtvsynctestrenderer.cpp
+    src/waveform/renderers/qtwaveformrendererfilteredsignal.cpp
+    src/waveform/renderers/qtwaveformrenderersimplesignal.cpp
+    src/waveform/widgets/qthsvwaveformwidget.cpp
+    src/waveform/widgets/qtrgbwaveformwidget.cpp
+    src/waveform/widgets/qtsimplewaveformwidget.cpp
+    src/waveform/widgets/qtvsynctestwidget.cpp
+    src/waveform/widgets/qtwaveformwidget.cpp
+    src/widget/wglwidgetqglwidget.cpp
   )
-  if(QOPENGL)
-    target_sources(mixxx-lib PRIVATE
-      src/shaders/endoftrackshader.cpp
-      src/shaders/patternshader.cpp
-      src/shaders/rgbashader.cpp
-      src/shaders/rgbshader.cpp
-      src/shaders/shader.cpp
-      src/shaders/textureshader.cpp
-      src/shaders/unicolorshader.cpp
-      src/shaders/vinylqualityshader.cpp
-      src/util/texture.cpp
-      src/waveform/renderers/allshader/matrixforwidgetgeometry.cpp
-      src/waveform/renderers/allshader/waveformrenderbackground.cpp
-      src/waveform/renderers/allshader/waveformrenderbeat.cpp
-      src/waveform/renderers/allshader/waveformrenderer.cpp
-      src/waveform/renderers/allshader/waveformrendererendoftrack.cpp
-      src/waveform/renderers/allshader/waveformrendererfiltered.cpp
-      src/waveform/renderers/allshader/waveformrendererhsv.cpp
-      src/waveform/renderers/allshader/waveformrendererlrrgb.cpp
-      src/waveform/renderers/allshader/waveformrendererpreroll.cpp
-      src/waveform/renderers/allshader/waveformrendererrgb.cpp
-      src/waveform/renderers/allshader/waveformrenderersignalbase.cpp
-      src/waveform/renderers/allshader/waveformrenderersimple.cpp
-      src/waveform/renderers/allshader/waveformrendermark.cpp
-      src/waveform/renderers/allshader/waveformrendermarkrange.cpp
-      src/waveform/widgets/allshader/filteredwaveformwidget.cpp
-      src/waveform/widgets/allshader/hsvwaveformwidget.cpp
-      src/waveform/widgets/allshader/lrrgbwaveformwidget.cpp
-      src/waveform/widgets/allshader/rgbwaveformwidget.cpp
-      src/waveform/widgets/allshader/simplewaveformwidget.cpp
-      src/waveform/widgets/allshader/waveformwidget.cpp
-      src/widget/openglwindow.cpp
-      src/widget/tooltipqopengl.cpp
-      src/widget/wglwidgetqopengl.cpp
-      src/widget/winitialglwidget.cpp
-      src/widget/wspinnyglsl.cpp
-      src/widget/wvumeterglsl.cpp
-    )
-  else()
-    target_sources(mixxx-lib PRIVATE
-      src/waveform/renderers/qtvsynctestrenderer.cpp
-      src/waveform/renderers/qtwaveformrendererfilteredsignal.cpp
-      src/waveform/renderers/qtwaveformrenderersimplesignal.cpp
-      src/waveform/widgets/qthsvwaveformwidget.cpp
-      src/waveform/widgets/qtrgbwaveformwidget.cpp
-      src/waveform/widgets/qtsimplewaveformwidget.cpp
-      src/waveform/widgets/qtvsynctestwidget.cpp
-      src/waveform/widgets/qtwaveformwidget.cpp
-      src/widget/wglwidgetqglwidget.cpp
-    )
-  endif()
 endif()
 
 set_source_files_properties(src/util/moc_included_test.cpp PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
@@ -2540,6 +2525,22 @@ target_link_libraries(mixxx-lib PUBLIC mixxx-proto)
 target_include_directories(mixxx-lib SYSTEM PUBLIC lib/rigtorp/SPSCQueue/include)
 
 # Qt
+set(
+  QT_COMPONENTS
+    Concurrent
+    Core
+    Gui
+    Network
+    OpenGL
+    PrintSupport
+    Qml
+    QuickWidgets
+    Sql
+    Svg
+    Test
+    Widgets
+    Xml
+)
 set(QT_EXTRA_COMPONENTS "")
 if(QT6)
   find_package(QT 6.2 NAMES Qt6 COMPONENTS Core REQUIRED)
@@ -2554,47 +2555,33 @@ if(QML)
 endif()
 find_package(Qt${QT_VERSION_MAJOR}
   COMPONENTS
-    Concurrent
-    Core
-    Gui
-    Network
-    OpenGL
-    PrintSupport
-    Qml
-    QuickWidgets
-    Sql
-    Svg
-    Test
-    Widgets
-    Xml
+    ${QT_COMPONENTS}
     ${QT_EXTRA_COMPONENTS}
   REQUIRED
 )
 # PUBLIC is required below to find included headers
-target_link_libraries(mixxx-lib PUBLIC
-  Qt${QT_VERSION_MAJOR}::Concurrent
-  Qt${QT_VERSION_MAJOR}::Core
-  Qt${QT_VERSION_MAJOR}::Gui
-  Qt${QT_VERSION_MAJOR}::Network
-  Qt${QT_VERSION_MAJOR}::OpenGL
-  Qt${QT_VERSION_MAJOR}::PrintSupport
-  Qt${QT_VERSION_MAJOR}::Qml
-  Qt${QT_VERSION_MAJOR}::QuickWidgets
-  Qt${QT_VERSION_MAJOR}::Sql
-  Qt${QT_VERSION_MAJOR}::Svg
-  Qt${QT_VERSION_MAJOR}::Test
-  Qt${QT_VERSION_MAJOR}::Widgets
-  Qt${QT_VERSION_MAJOR}::Xml)
+foreach(COMPONENT ${QT_COMPONENTS})
+  target_link_libraries(mixxx-lib PUBLIC Qt${QT_VERSION_MAJOR}::${COMPONENT})
+endforeach()
 if(QT_EXTRA_COMPONENTS)
   foreach(COMPONENT ${QT_EXTRA_COMPONENTS})
-    target_link_libraries(mixxx-lib PUBLIC Qt6::${COMPONENT})
+    target_link_libraries(mixxx-lib PUBLIC Qt${QT_VERSION_MAJOR}::${COMPONENT})
   endforeach()
 endif()
 
 if(QML)
   set(QT_QML_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/qml)
-  set_target_properties(mixxx-lib PROPERTIES AUTOMOC ON)
-  qt_add_qml_module(mixxx-lib
+  qt_add_library(mixxx-qml-lib STATIC)
+  foreach(COMPONENT ${QT_COMPONENTS})
+    target_link_libraries(mixxx-qml-lib PUBLIC Qt${QT_VERSION_MAJOR}::${COMPONENT})
+  endforeach()
+  if(QT_EXTRA_COMPONENTS)
+    foreach(COMPONENT ${QT_EXTRA_COMPONENTS})
+      target_link_libraries(mixxx-qml-lib PUBLIC Qt${QT_VERSION_MAJOR}::${COMPONENT})
+    endforeach()
+  endif()
+  set_target_properties(mixxx-qml-lib PROPERTIES AUTOMOC ON)
+  qt_add_qml_module(mixxx-qml-lib
     URI Mixxx
     VERSION 1.0
     RESOURCE_PREFIX /mixxx.org/imports
@@ -2602,27 +2589,24 @@ if(QML)
     QML_FILES
       res/qml/Mixxx/MathUtils.mjs
       res/qml/Mixxx/PlayerDropArea.qml
-    NO_GENERATE_QMLDIR
   )
-
-  # Generation of the `qmldir` file has been disabled (via `NO_GENERATE_QMLDIR`
-  # above) due to QTBUG-100326, which breaks JavaScript module imports:
-  # https://bugreports.qt.io/browse/QTBUG-100326
-  # Instead, a handwritten `qmldir` file that works around the issue needs to
-  # be added to the resources here.
-  set_source_files_properties("res/qml/Mixxx/qmldir" PROPERTIES QT_RESOURCE_ALIAS "qmldir")
-  qt_add_resources(mixxx-libplugin qmldir
-    FILES "res/qml/Mixxx/qmldir"
-    PREFIX "/mixxx.org/imports/Mixxx"
-  )
-  # to make also qmllint happy
-  configure_file(res/qml/Mixxx/qmldir qml/Mixxx/qmldir COPYONLY)
+  target_link_libraries(mixxx-lib PRIVATE mixxx-qml-lib)
 
   # FIXME: Currently we need to add these include directories due to
   # QTBUG-87221. We should figure out a better way to fix this.
   # See: https://bugreports.qt.io/browse/QTBUG-87221
-  target_include_directories(mixxx-lib PRIVATE src/control src/qml)
-  target_link_libraries(mixxx-lib PRIVATE mixxx-libplugin)
+  target_include_directories(mixxx-qml-lib PRIVATE src/control src/qml)
+  target_include_directories(mixxx-qml-lib PUBLIC src/ ${CMAKE_BINARY_DIR}/src)
+  target_include_directories(mixxx-qml-lib SYSTEM PUBLIC lib/rigtorp/SPSCQueue/include lib/portaudio)
+
+  target_link_libraries(mixxx-qml-lib PUBLIC mixxx-proto)
+  target_link_libraries(mixxx-qml-libplugin PUBLIC mixxx-proto)
+
+  target_precompile_headers(mixxx-qml-lib PUBLIC
+    ${MIXXX_COMMON_PRECOMPILED_HEADER}
+  )
+
+  target_link_libraries(mixxx-qml-lib PRIVATE mixxx-qml-libplugin)
 
   qt_add_library(mixxx-qml-mixxxcontrols STATIC)
   set_target_properties(mixxx-qml-mixxxcontrols PROPERTIES AUTOMOC ON)
@@ -2639,7 +2623,27 @@ if(QML)
       res/qml/Mixxx/Controls/WaveformOverviewMarker.qml
       res/qml/Mixxx/Controls/WaveformOverview.qml
   )
-  target_link_libraries(mixxx-lib PRIVATE mixxx-qml-mixxxcontrolsplugin)
+  target_link_libraries(mixxx-qml-lib PRIVATE mixxx-qml-mixxxcontrolsplugin)
+
+  target_sources(mixxx-qml-lib PRIVATE
+    src/qml/asyncimageprovider.cpp
+    src/qml/qmlapplication.cpp
+    src/qml/qmlcontrolproxy.cpp
+    src/qml/qmlconfigproxy.cpp
+    src/qml/qmldlgpreferencesproxy.cpp
+    src/qml/qmleffectmanifestparametersmodel.cpp
+    src/qml/qmleffectsmanagerproxy.cpp
+    src/qml/qmleffectslotproxy.cpp
+    src/qml/qmllibraryproxy.cpp
+    src/qml/qmllibrarytracklistmodel.cpp
+    src/qml/qmlplayermanagerproxy.cpp
+    src/qml/qmlplayerproxy.cpp
+    src/qml/qmlvisibleeffectsmodel.cpp
+    src/qml/qmlwaveformoverview.cpp
+    # The following source needs to be in this target to get QML_ELEMENT properly interpreted
+    src/control/controlmodel.cpp
+    src/control/controlsortfiltermodel.cpp
+  )
 
   # qt_finalize_target takes care that the resources :/mixxx.org/imports/Mixxx/
   # and :/mixxx.org/imports/Mixxx/Controls are placed into beginning of the binary
@@ -3227,6 +3231,9 @@ if(BROADCAST)
     src/encoder/encoderbroadcastsettings.cpp
   )
   target_compile_definitions(mixxx-lib PUBLIC __BROADCAST__)
+  if (QML)
+    target_compile_definitions(mixxx-qml-lib PUBLIC __BROADCAST__)
+  endif()
 endif()
 
 # Opus (RFC 6716)
@@ -3302,6 +3309,10 @@ endif()
 find_package(Microsoft.GSL CONFIG)
 if(Microsoft.GSL_FOUND)
   target_link_libraries(mixxx-lib PRIVATE Microsoft.GSL::GSL)
+  if (QML)
+    target_link_libraries(mixxx-qml-lib PRIVATE Microsoft.GSL::GSL)
+    target_link_libraries(mixxx-qml-libplugin PRIVATE Microsoft.GSL::GSL)
+  endif()
 else()
   # check if the headers have been installed without cmake config (< 3.1.0)
   check_include_file_cxx(gsl/gsl HAVE_GSL_GSL)

--- a/src/control/controlmodel.cpp
+++ b/src/control/controlmodel.cpp
@@ -1,5 +1,7 @@
 #include "control/controlmodel.h"
 
+#include <QStringBuilder>
+
 #include "moc_controlmodel.cpp"
 
 ControlModel::ControlModel(QObject* pParent)

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -36,9 +36,7 @@
 #include "util/sample.h"
 #include "util/timer.h"
 #include "waveform/visualplayposition.h"
-#ifndef MIXXX_USE_QML
 #include "waveform/waveformwidgetfactory.h"
-#endif
 
 #ifdef __VINYLCONTROL__
 #include "engine/controls/vinylcontrolcontrol.h"

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -82,100 +82,115 @@ LibraryControl::LibraryControl(Library* pLibrary)
     m_pMoveUp = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "MoveUp"));
     m_pMoveDown = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "MoveDown"));
     m_pMoveVertical = std::make_unique<ControlEncoder>(ConfigKey("[Library]", "MoveVertical"), false);
-#ifndef MIXXX_USE_QML
-    connect(m_pMoveUp.get(),
-            &ControlPushButton::valueChanged,
-            this,
-            &LibraryControl::slotMoveUp);
-    connect(m_pMoveDown.get(),
-            &ControlPushButton::valueChanged,
-            this,
-            &LibraryControl::slotMoveDown);
-    connect(m_pMoveVertical.get(),
-            &ControlEncoder::valueChanged,
-            this,
-            &LibraryControl::slotMoveVertical);
+#ifdef MIXXX_USE_QML
+    if (!CmdlineArgs::Instance().isQml())
 #endif
+    {
+        connect(m_pMoveUp.get(),
+                &ControlPushButton::valueChanged,
+                this,
+                &LibraryControl::slotMoveUp);
+        connect(m_pMoveDown.get(),
+                &ControlPushButton::valueChanged,
+                this,
+                &LibraryControl::slotMoveDown);
+        connect(m_pMoveVertical.get(),
+                &ControlEncoder::valueChanged,
+                this,
+                &LibraryControl::slotMoveVertical);
+    }
 
     // Controls to navigate vertically within currently focused widget (up/down buttons)
     m_pScrollUp = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "ScrollUp"));
     m_pScrollDown = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "ScrollDown"));
     m_pScrollVertical = std::make_unique<ControlEncoder>(ConfigKey("[Library]", "ScrollVertical"), false);
-#ifndef MIXXX_USE_QML
-    connect(m_pScrollUp.get(),
-            &ControlPushButton::valueChanged,
-            this,
-            &LibraryControl::slotScrollUp);
-    connect(m_pScrollDown.get(),
-            &ControlPushButton::valueChanged,
-            this,
-            &LibraryControl::slotScrollDown);
-    connect(m_pScrollVertical.get(),
-            &ControlEncoder::valueChanged,
-            this,
-            &LibraryControl::slotScrollVertical);
+#ifdef MIXXX_USE_QML
+    if (!CmdlineArgs::Instance().isQml())
 #endif
+    {
+        connect(m_pScrollUp.get(),
+                &ControlPushButton::valueChanged,
+                this,
+                &LibraryControl::slotScrollUp);
+        connect(m_pScrollDown.get(),
+                &ControlPushButton::valueChanged,
+                this,
+                &LibraryControl::slotScrollDown);
+        connect(m_pScrollVertical.get(),
+                &ControlEncoder::valueChanged,
+                this,
+                &LibraryControl::slotScrollVertical);
+    }
 
     // Controls to navigate horizontally within currently selected item (left/right buttons)
     m_pMoveLeft = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "MoveLeft"));
     m_pMoveRight = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "MoveRight"));
     m_pMoveHorizontal = std::make_unique<ControlEncoder>(ConfigKey("[Library]", "MoveHorizontal"), false);
-#ifndef MIXXX_USE_QML
-    connect(m_pMoveLeft.get(),
-            &ControlPushButton::valueChanged,
-            this,
-            &LibraryControl::slotMoveLeft);
-    connect(m_pMoveRight.get(),
-            &ControlPushButton::valueChanged,
-            this,
-            &LibraryControl::slotMoveRight);
-    connect(m_pMoveHorizontal.get(),
-            &ControlEncoder::valueChanged,
-            this,
-            &LibraryControl::slotMoveHorizontal);
+#ifdef MIXXX_USE_QML
+    if (!CmdlineArgs::Instance().isQml())
 #endif
+    {
+        connect(m_pMoveLeft.get(),
+                &ControlPushButton::valueChanged,
+                this,
+                &LibraryControl::slotMoveLeft);
+        connect(m_pMoveRight.get(),
+                &ControlPushButton::valueChanged,
+                this,
+                &LibraryControl::slotMoveRight);
+        connect(m_pMoveHorizontal.get(),
+                &ControlEncoder::valueChanged,
+                this,
+                &LibraryControl::slotMoveHorizontal);
+    }
 
     // Controls to navigate between widgets
     // Relative focus controls (emulate Tab/Shift+Tab button press)
     m_pMoveFocusForward = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "MoveFocusForward"));
     m_pMoveFocusBackward = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "MoveFocusBackward"));
     m_pMoveFocus = std::make_unique<ControlEncoder>(ConfigKey("[Library]", "MoveFocus"), false);
-#ifndef MIXXX_USE_QML
-    connect(m_pMoveFocusForward.get(),
-            &ControlPushButton::valueChanged,
-            this,
-            &LibraryControl::slotMoveFocusForward);
-    connect(m_pMoveFocusBackward.get(),
-            &ControlPushButton::valueChanged,
-            this,
-            &LibraryControl::slotMoveFocusBackward);
-    connect(m_pMoveFocus.get(),
-            &ControlEncoder::valueChanged,
-            this,
-            &LibraryControl::slotMoveFocus);
+#ifdef MIXXX_USE_QML
+    if (!CmdlineArgs::Instance().isQml())
 #endif
+    {
+        connect(m_pMoveFocusForward.get(),
+                &ControlPushButton::valueChanged,
+                this,
+                &LibraryControl::slotMoveFocusForward);
+        connect(m_pMoveFocusBackward.get(),
+                &ControlPushButton::valueChanged,
+                this,
+                &LibraryControl::slotMoveFocusBackward);
+        connect(m_pMoveFocus.get(),
+                &ControlEncoder::valueChanged,
+                this,
+                &LibraryControl::slotMoveFocus);
+    }
 
     // Direct focus control, read/write
     m_pFocusedWidgetCO = std::make_unique<ControlPushButton>(
             ConfigKey("[Library]", "focused_widget"));
     m_pFocusedWidgetCO->setStates(static_cast<int>(FocusWidget::Count));
-#ifndef MIXXX_USE_QML
-    m_pFocusedWidgetCO->connectValueChangeRequest(
-            this,
-            [this](double value) {
-                // Focus can not be removed from a widget just moved to another one.
-                // Thus, to keep the CO and QApplication::focusWidget() in sync we
-                // have to prevent scripts or GUI buttons setting the CO to 'None'.
-                // It's only set to 'None' internally when one of the library widgets
-                // receives a FocusOutEvent(), e.g. when the focus is moved to another
-                // widget, or when the main window loses focus.
-                const int valueInt = static_cast<int>(value);
-                if (valueInt != static_cast<int>(FocusWidget::None) &&
-                        valueInt < static_cast<int>(FocusWidget::Count)) {
-                    setLibraryFocus(static_cast<FocusWidget>(valueInt));
-                }
-            });
+#ifdef MIXXX_USE_QML
+    if (!CmdlineArgs::Instance().isQml())
 #endif
+    {
+        m_pFocusedWidgetCO->connectValueChangeRequest(
+                this,
+                [this](double value) {
+                    // Focus can not be removed from a widget just moved to another one.
+                    // Thus, to keep the CO and QApplication::focusWidget() in sync we
+                    // have to prevent scripts or GUI buttons setting the CO to 'None'.
+                    // It's only set to 'None' internally when one of the library widgets
+                    // receives a FocusOutEvent(), e.g. when the focus is moved to another
+                    // widget, or when the main window loses focus.
+                    const int valueInt = static_cast<int>(value);
+                    if (valueInt != static_cast<int>(FocusWidget::None) &&
+                            valueInt < static_cast<int>(FocusWidget::Count)) {
+                        setLibraryFocus(static_cast<FocusWidget>(valueInt));
+                    }
+                });
+    }
 
     // Pure trigger control. Alternative for signal/slot since widgets that want
     // to call refocusPrevLibraryWidget() are cumbersome to connect to.
@@ -183,49 +198,64 @@ LibraryControl::LibraryControl(Library* pLibrary)
     m_pRefocusPrevWidgetCO = std::make_unique<ControlPushButton>(
             ConfigKey("[Library]", "refocus_prev_widget"));
     m_pRefocusPrevWidgetCO->setButtonMode(ControlPushButton::TRIGGER);
-#ifndef MIXXX_USE_QML
-    m_pRefocusPrevWidgetCO->connectValueChangeRequest(this,
-            &LibraryControl::refocusPrevLibraryWidget);
+#ifdef MIXXX_USE_QML
+    if (!CmdlineArgs::Instance().isQml())
 #endif
+    {
+        m_pRefocusPrevWidgetCO->connectValueChangeRequest(this,
+                &LibraryControl::refocusPrevLibraryWidget);
+    }
 
     // Control to "goto" the currently selected item in focused widget (context dependent)
     m_pGoToItem = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "GoToItem"));
-#ifndef MIXXX_USE_QML
-    connect(m_pGoToItem.get(),
-            &ControlPushButton::valueChanged,
-            this,
-            &LibraryControl::slotGoToItem);
+#ifdef MIXXX_USE_QML
+    if (!CmdlineArgs::Instance().isQml())
 #endif
+    {
+        connect(m_pGoToItem.get(),
+                &ControlPushButton::valueChanged,
+                this,
+                &LibraryControl::slotGoToItem);
+    }
 
     // Auto DJ controls
     m_pAutoDjAddTop = std::make_unique<ControlPushButton>(ConfigKey("[Library]","AutoDjAddTop"));
     m_pAutoDjAddTop->addAlias(ConfigKey(
             QStringLiteral("[Playlist]"), QStringLiteral("AutoDjAddTop")));
-#ifndef MIXXX_USE_QML
-    connect(m_pAutoDjAddTop.get(),
-            &ControlPushButton::valueChanged,
-            this,
-            &LibraryControl::slotAutoDjAddTop);
+#ifdef MIXXX_USE_QML
+    if (!CmdlineArgs::Instance().isQml())
 #endif
+    {
+        connect(m_pAutoDjAddTop.get(),
+                &ControlPushButton::valueChanged,
+                this,
+                &LibraryControl::slotAutoDjAddTop);
+    }
 
     m_pAutoDjAddBottom = std::make_unique<ControlPushButton>(ConfigKey("[Library]","AutoDjAddBottom"));
     m_pAutoDjAddBottom->addAlias(ConfigKey(
             QStringLiteral("[Playlist]"), QStringLiteral("AutoDjAddBottom")));
-#ifndef MIXXX_USE_QML
-    connect(m_pAutoDjAddBottom.get(),
-            &ControlPushButton::valueChanged,
-            this,
-            &LibraryControl::slotAutoDjAddBottom);
+#ifdef MIXXX_USE_QML
+    if (!CmdlineArgs::Instance().isQml())
 #endif
+    {
+        connect(m_pAutoDjAddBottom.get(),
+                &ControlPushButton::valueChanged,
+                this,
+                &LibraryControl::slotAutoDjAddBottom);
+    }
 
     m_pAutoDjAddReplace = std::make_unique<ControlPushButton>(
             ConfigKey("[Library]", "AutoDjAddReplace"));
-#ifndef MIXXX_USE_QML
-    connect(m_pAutoDjAddReplace.get(),
-            &ControlPushButton::valueChanged,
-            this,
-            &LibraryControl::slotAutoDjAddReplace);
+#ifdef MIXXX_USE_QML
+    if (!CmdlineArgs::Instance().isQml())
 #endif
+    {
+        connect(m_pAutoDjAddReplace.get(),
+                &ControlPushButton::valueChanged,
+                this,
+                &LibraryControl::slotAutoDjAddReplace);
+    }
 
     // Sort controls
     m_pSortColumn = std::make_unique<ControlEncoder>(ConfigKey("[Library]", "sort_column"));
@@ -234,46 +264,50 @@ LibraryControl::LibraryControl(Library* pLibrary)
     m_pSortColumnToggle = std::make_unique<ControlEncoder>(ConfigKey("[Library]", "sort_column_toggle"), false);
     m_pSortFocusedColumn = std::make_unique<ControlPushButton>(
             ConfigKey("[Library]", "sort_focused_column"));
-#ifndef MIXXX_USE_QML
-    connect(m_pSortColumn.get(),
-            &ControlEncoder::valueChanged,
-            this,
-            &LibraryControl::slotSortColumn);
-    connect(m_pSortColumnToggle.get(),
-            &ControlEncoder::valueChanged,
-            this,
-            &LibraryControl::slotSortColumnToggle);
-    connect(m_pSortFocusedColumn.get(),
-            &ControlObject::valueChanged,
-            this,
-            [this](double value) {
-                if (value > 0.0) {
-                    slotSortColumnToggle(static_cast<int>(TrackModel::SortColumnId::CurrentIndex));
-                }
-            });
-
-    // Font sizes
-    m_pFontSizeKnob = std::make_unique<ControlObject>(
-            ConfigKey("[Library]", "font_size_knob"), false);
-    connect(m_pFontSizeKnob.get(),
-            &ControlObject::valueChanged,
-            this,
-            &LibraryControl::slotFontSize);
-
-    m_pFontSizeDecrement = std::make_unique<ControlPushButton>(
-            ConfigKey("[Library]", "font_size_decrement"));
-    connect(m_pFontSizeDecrement.get(),
-            &ControlPushButton::valueChanged,
-            this,
-            &LibraryControl::slotDecrementFontSize);
-
-    m_pFontSizeIncrement = std::make_unique<ControlPushButton>(
-            ConfigKey("[Library]", "font_size_increment"));
-    connect(m_pFontSizeIncrement.get(),
-            &ControlPushButton::valueChanged,
-            this,
-            &LibraryControl::slotIncrementFontSize);
+#ifdef MIXXX_USE_QML
+    if (!CmdlineArgs::Instance().isQml())
 #endif
+    {
+        connect(m_pSortColumn.get(),
+                &ControlEncoder::valueChanged,
+                this,
+                &LibraryControl::slotSortColumn);
+        connect(m_pSortColumnToggle.get(),
+                &ControlEncoder::valueChanged,
+                this,
+                &LibraryControl::slotSortColumnToggle);
+        connect(m_pSortFocusedColumn.get(),
+                &ControlObject::valueChanged,
+                this,
+                [this](double value) {
+                    if (value > 0.0) {
+                        slotSortColumnToggle(static_cast<int>(
+                                TrackModel::SortColumnId::CurrentIndex));
+                    }
+                });
+
+        // Font sizes
+        m_pFontSizeKnob = std::make_unique<ControlObject>(
+                ConfigKey("[Library]", "font_size_knob"), false);
+        connect(m_pFontSizeKnob.get(),
+                &ControlObject::valueChanged,
+                this,
+                &LibraryControl::slotFontSize);
+
+        m_pFontSizeDecrement = std::make_unique<ControlPushButton>(
+                ConfigKey("[Library]", "font_size_decrement"));
+        connect(m_pFontSizeDecrement.get(),
+                &ControlPushButton::valueChanged,
+                this,
+                &LibraryControl::slotDecrementFontSize);
+
+        m_pFontSizeIncrement = std::make_unique<ControlPushButton>(
+                ConfigKey("[Library]", "font_size_increment"));
+        connect(m_pFontSizeIncrement.get(),
+                &ControlPushButton::valueChanged,
+                this,
+                &LibraryControl::slotIncrementFontSize);
+    }
 
     // Track Color controls
     m_pTrackColorPrev = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "track_color_prev"));
@@ -422,24 +456,27 @@ LibraryControl::LibraryControl(Library* pLibrary)
             this,
             &LibraryControl::slotLoadSelectedIntoFirstStopped);
 
-#ifndef MIXXX_USE_QML
-    QApplication* app = qApp;
-    // Update controls if any widget in any Mixxx window gets or loses focus
-    connect(app,
-            &QApplication::focusChanged,
-            this,
-            &LibraryControl::slotFocusedWidgetChanged);
-    // Also update controls if the window focus changed.
-    // Even though any new menu window has focus and will receive keypress events
-    // it does NOT have a focused widget before the first click or keypress.
-    // Thus a QMenu popping up is not reported by focusChanged(oldWidget, newWidget).
-    // QApplication::focusWidget() is still that in the previously focused
-    // window (MixxxMainWindow for example).
-    connect(app,
-            &QGuiApplication::focusWindowChanged,
-            this,
-            &LibraryControl::updateFocusedWidgetControls);
+#ifdef MIXXX_USE_QML
+    if (!CmdlineArgs::Instance().isQml())
 #endif
+    {
+        QApplication* app = qApp;
+        // Update controls if any widget in any Mixxx window gets or loses focus
+        connect(app,
+                &QApplication::focusChanged,
+                this,
+                &LibraryControl::slotFocusedWidgetChanged);
+        // Also update controls if the window focus changed.
+        // Even though any new menu window has focus and will receive keypress events
+        // it does NOT have a focused widget before the first click or keypress.
+        // Thus a QMenu popping up is not reported by focusChanged(oldWidget, newWidget).
+        // QApplication::focusWidget() is still that in the previously focused
+        // window (MixxxMainWindow for example).
+        connect(app,
+                &QGuiApplication::focusWindowChanged,
+                this,
+                &LibraryControl::updateFocusedWidgetControls);
+    }
 }
 
 LibraryControl::~LibraryControl() = default;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,9 +15,8 @@
 #include "mixxxapplication.h"
 #ifdef MIXXX_USE_QML
 #include "qml/qmlapplication.h"
-#else
-#include "mixxxmainwindow.h"
 #endif
+#include "mixxxmainwindow.h"
 #include "sources/soundsourceproxy.h"
 #include "util/cmdlineargs.h"
 #include "util/console.h"
@@ -27,9 +26,7 @@
 namespace {
 
 // Exit codes
-#ifndef MIXXX_USE_QML
 constexpr int kFatalErrorOnStartupExitCode = 1;
-#endif
 constexpr int kParseCmdlineArgsErrorExitCode = 2;
 
 constexpr char kScaleFactorEnvVar[] = "QT_SCALE_FACTOR";
@@ -43,9 +40,11 @@ int runMixxx(MixxxApplication* pApp, const CmdlineArgs& args) {
 
     int exitCode;
 #ifdef MIXXX_USE_QML
-    mixxx::qml::QmlApplication qmlApplication(pApp, pCoreServices);
-    exitCode = pApp->exec();
-#else
+    if (args.isQml()) {
+        mixxx::qml::QmlApplication qmlApplication(pApp, pCoreServices);
+        exitCode = pApp->exec();
+    } else
+#endif
     {
         // This scope ensures that `MixxxMainWindow` is destroyed *before*
         // CoreServices is shut down. Otherwise a debug assertion complaining about
@@ -82,7 +81,6 @@ int runMixxx(MixxxApplication* pApp, const CmdlineArgs& args) {
             exitCode = pApp->exec();
         }
     }
-#endif
     return exitCode;
 }
 

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -17,10 +17,8 @@
 #include "track/track.h"
 #include "util/sandbox.h"
 #include "vinylcontrol/defs_vinylcontrol.h"
-#ifndef MIXXX_USE_QML
 #include "waveform/renderers/waveformwidgetrenderer.h"
 #include "waveform/visualsmanager.h"
-#endif
 
 namespace {
 

--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -25,9 +25,7 @@
 #include "preferences/dialog/dlgprefeffects.h"
 #include "preferences/dialog/dlgprefinterface.h"
 #include "preferences/dialog/dlgprefmixer.h"
-#ifndef MIXXX_USE_QML
 #include "preferences/dialog/dlgprefwaveform.h"
-#endif
 
 #ifdef __BROADCAST__
 #include "preferences/dialog/dlgprefbroadcast.h"
@@ -158,7 +156,6 @@ DlgPreferences::DlgPreferences(
             tr("Interface"),
             "ic_preferences_interface.svg");
 
-#ifndef MIXXX_USE_QML
     // ugly proxy for determining whether this is being instantiated for QML or legacy QWidgets GUI
     if (pSkinLoader) {
         DlgPrefWaveform* pWaveformPage = new DlgPrefWaveform(this, m_pConfig, pLibrary);
@@ -173,7 +170,6 @@ DlgPreferences::DlgPreferences(
                 &DlgPreferences::reloadUserInterface,
                 Qt::DirectConnection);
     }
-#endif
 
     addPageWidget(PreferencesPage(
                           new DlgPrefColors(this, m_pConfig, pLibrary),

--- a/src/qml/qmlapplication.cpp
+++ b/src/qml/qmlapplication.cpp
@@ -62,6 +62,10 @@ QmlApplication::QmlApplication(
     // the QQmlApplicationEngine.
     pDlgPreferences->setAttribute(Qt::WA_QuitOnClose, false);
 
+    // Since DlgPreferences is only meant to be used in the main QML engine, it
+    // follows a strict singleton pattern design
+    QmlDlgPreferencesProxy::s_pInstance = new QmlDlgPreferencesProxy(pDlgPreferences, this);
+
     // Any uncreateable non-singleton types registered here require arguments
     // that we don't want to expose to QML directly. Instead, they can be
     // retrieved by member properties or methods from the singleton types.
@@ -70,13 +74,10 @@ QmlApplication::QmlApplication(
     // system, which would improve nothing, or we had to expose them as
     // singletons to that they can be accessed by components instantiated by
     // QML, which would also be suboptimal.
-    QmlDlgPreferencesProxy::s_pInstance = new QmlDlgPreferencesProxy(pDlgPreferences, this);
-    QmlEffectsManagerProxy::s_pInstance = new QmlEffectsManagerProxy(
-            pCoreServices->getEffectsManager(), this);
-    QmlPlayerManagerProxy::s_pInstance =
-            new QmlPlayerManagerProxy(pCoreServices->getPlayerManager(), this);
-    QmlConfigProxy::s_pInstance = new QmlConfigProxy(pCoreServices->getSettings(), this);
-    QmlLibraryProxy::s_pInstance = new QmlLibraryProxy(pCoreServices->getLibrary(), this);
+    QmlEffectsManagerProxy::registerEffectsManager(pCoreServices->getEffectsManager());
+    QmlPlayerManagerProxy::registerPlayerManager(pCoreServices->getPlayerManager());
+    QmlConfigProxy::registerUserSettings(pCoreServices->getSettings());
+    QmlLibraryProxy::registerLibrary(pCoreServices->getLibrary());
 
     loadQml(m_mainFilePath);
 
@@ -88,12 +89,20 @@ QmlApplication::QmlApplication(
             &QmlApplication::loadQml);
 }
 
+QmlApplication::~QmlApplication() {
+    // Delete all the QML singletons in order to prevent leak detection in CoreService
+    QmlEffectsManagerProxy::registerEffectsManager(nullptr);
+    QmlPlayerManagerProxy::registerPlayerManager(nullptr);
+    QmlConfigProxy::registerUserSettings(nullptr);
+    QmlLibraryProxy::registerLibrary(nullptr);
+    QmlDlgPreferencesProxy::s_pInstance->deleteLater();
+}
+
 void QmlApplication::loadQml(const QString& path) {
     // QQmlApplicationEngine::load creates a new window but also leaves the old one,
     // so it is necessary to destroy the old QQmlApplicationEngine and create a new one.
     m_pAppEngine = std::make_unique<QQmlApplicationEngine>();
 
-    const QFileInfo fileInfo(path);
     m_pAppEngine->addImportPath(QStringLiteral(":/mixxx.org/imports"));
 
     // No memory leak here, the QQmlEngine takes ownership of the provider

--- a/src/qml/qmlapplication.h
+++ b/src/qml/qmlapplication.h
@@ -15,7 +15,7 @@ class QmlApplication : public QObject {
     QmlApplication(
             QApplication* app,
             std::shared_ptr<CoreServices> pCoreServices);
-    ~QmlApplication() override = default;
+    ~QmlApplication() override;
 
   public slots:
     void loadQml(const QString& path);

--- a/src/qml/qmlconfigproxy.cpp
+++ b/src/qml/qmlconfigproxy.cpp
@@ -33,30 +33,17 @@ QVariantList QmlConfigProxy::getTrackColorPalette() {
 
 // static
 QmlConfigProxy* QmlConfigProxy::create(QQmlEngine* pQmlEngine, QJSEngine* pJsEngine) {
-    Q_UNUSED(pQmlEngine);
-
     // The implementation of this method is mostly taken from the code example
     // that shows the replacement for `qmlRegisterSingletonInstance()` when
     // using `QML_SINGLETON`.
     // https://doc.qt.io/qt-6/qqmlengine.html#QML_SINGLETON
 
     // The instance has to exist before it is used. We cannot replace it.
-    DEBUG_ASSERT(s_pInstance);
-
-    // The engine has to have the same thread affinity as the singleton.
-    DEBUG_ASSERT(pJsEngine->thread() == s_pInstance->thread());
-
-    // There can only be one engine accessing the singleton.
-    if (s_pJsEngine) {
-        DEBUG_ASSERT(pJsEngine == s_pJsEngine);
-    } else {
-        s_pJsEngine = pJsEngine;
+    VERIFY_OR_DEBUG_ASSERT(s_pUserSettings) {
+        qWarning() << "UserSettings hasn't been registered yet";
+        return nullptr;
     }
-
-    // Explicitly specify C++ ownership so that the engine doesn't delete
-    // the instance.
-    QJSEngine::setObjectOwnership(s_pInstance, QJSEngine::CppOwnership);
-    return s_pInstance;
+    return new QmlConfigProxy(s_pUserSettings, pQmlEngine);
 }
 
 } // namespace qml

--- a/src/qml/qmlconfigproxy.h
+++ b/src/qml/qmlconfigproxy.h
@@ -22,10 +22,13 @@ class QmlConfigProxy : public QObject {
     Q_INVOKABLE QVariantList getTrackColorPalette();
 
     static QmlConfigProxy* create(QQmlEngine* pQmlEngine, QJSEngine* pJsEngine);
-    static inline QmlConfigProxy* s_pInstance = nullptr;
+    static inline void registerUserSettings(UserSettingsPointer pConfig) {
+        s_pUserSettings = std::move(pConfig);
+    }
 
   private:
-    static inline QJSEngine* s_pJsEngine = nullptr;
+    static inline UserSettingsPointer s_pUserSettings = nullptr;
+
     const UserSettingsPointer m_pConfig;
 };
 

--- a/src/qml/qmleffectsmanagerproxy.cpp
+++ b/src/qml/qmleffectsmanagerproxy.cpp
@@ -47,30 +47,17 @@ QmlEffectSlotProxy* QmlEffectsManagerProxy::getEffectSlot(int unitNumber, int ef
 // static
 QmlEffectsManagerProxy* QmlEffectsManagerProxy::create(
         QQmlEngine* pQmlEngine, QJSEngine* pJsEngine) {
-    Q_UNUSED(pQmlEngine);
-
     // The implementation of this method is mostly taken from the code example
     // that shows the replacement for `qmlRegisterSingletonInstance()` when
     // using `QML_SINGLETON`.
     // https://doc.qt.io/qt-6/qqmlengine.html#QML_SINGLETON
 
     // The instance has to exist before it is used. We cannot replace it.
-    DEBUG_ASSERT(s_pInstance);
-
-    // The engine has to have the same thread affinity as the singleton.
-    DEBUG_ASSERT(pJsEngine->thread() == s_pInstance->thread());
-
-    // There can only be one engine accessing the singleton.
-    if (s_pJsEngine) {
-        DEBUG_ASSERT(pJsEngine == s_pJsEngine);
-    } else {
-        s_pJsEngine = pJsEngine;
+    VERIFY_OR_DEBUG_ASSERT(s_pEffectManager) {
+        qWarning() << "EffectManager hasn't been registered yet";
+        return nullptr;
     }
-
-    // Explicitly specify C++ ownership so that the engine doesn't delete
-    // the instance.
-    QJSEngine::setObjectOwnership(s_pInstance, QJSEngine::CppOwnership);
-    return s_pInstance;
+    return new QmlEffectsManagerProxy(s_pEffectManager, pQmlEngine);
 }
 
 } // namespace qml

--- a/src/qml/qmleffectsmanagerproxy.h
+++ b/src/qml/qmleffectsmanagerproxy.h
@@ -25,10 +25,13 @@ class QmlEffectsManagerProxy : public QObject {
             int unitNumber, int effectNumber) const;
 
     static QmlEffectsManagerProxy* create(QQmlEngine* pQmlEngine, QJSEngine* pJsEngine);
-    static inline QmlEffectsManagerProxy* s_pInstance = nullptr;
+    static void registerEffectsManager(std::shared_ptr<EffectsManager> pEffectsManager) {
+        s_pEffectManager = std::move(pEffectsManager);
+    }
 
   private:
-    static inline QJSEngine* s_pJsEngine = nullptr;
+    static inline std::shared_ptr<EffectsManager> s_pEffectManager;
+
     const std::shared_ptr<EffectsManager> m_pEffectsManager;
     QmlVisibleEffectsModel* m_pVisibleEffectsModel;
 };

--- a/src/qml/qmllibraryproxy.cpp
+++ b/src/qml/qmllibraryproxy.cpp
@@ -16,30 +16,17 @@ QmlLibraryProxy::QmlLibraryProxy(std::shared_ptr<Library> pLibrary, QObject* par
 
 // static
 QmlLibraryProxy* QmlLibraryProxy::create(QQmlEngine* pQmlEngine, QJSEngine* pJsEngine) {
-    Q_UNUSED(pQmlEngine);
-
     // The implementation of this method is mostly taken from the code example
     // that shows the replacement for `qmlRegisterSingletonInstance()` when
     // using `QML_SINGLETON`.
     // https://doc.qt.io/qt-6/qqmlengine.html#QML_SINGLETON
 
     // The instance has to exist before it is used. We cannot replace it.
-    DEBUG_ASSERT(s_pInstance);
-
-    // The engine has to have the same thread affinity as the singleton.
-    DEBUG_ASSERT(pJsEngine->thread() == s_pInstance->thread());
-
-    // There can only be one engine accessing the singleton.
-    if (s_pJsEngine) {
-        DEBUG_ASSERT(pJsEngine == s_pJsEngine);
-    } else {
-        s_pJsEngine = pJsEngine;
+    VERIFY_OR_DEBUG_ASSERT(s_pLibrary) {
+        qWarning() << "Library hasn't been registered yet";
+        return nullptr;
     }
-
-    // Explicitly specify C++ ownership so that the engine doesn't delete
-    // the instance.
-    QJSEngine::setObjectOwnership(s_pInstance, QJSEngine::CppOwnership);
-    return s_pInstance;
+    return new QmlLibraryProxy(s_pLibrary, pQmlEngine);
 }
 
 } // namespace qml

--- a/src/qml/qmllibraryproxy.h
+++ b/src/qml/qmllibraryproxy.h
@@ -23,10 +23,13 @@ class QmlLibraryProxy : public QObject {
     explicit QmlLibraryProxy(std::shared_ptr<Library> pLibrary, QObject* parent = nullptr);
 
     static QmlLibraryProxy* create(QQmlEngine* pQmlEngine, QJSEngine* pJsEngine);
-    static inline QmlLibraryProxy* s_pInstance = nullptr;
+    static void registerLibrary(std::shared_ptr<Library> pLibrary) {
+        s_pLibrary = std::move(pLibrary);
+    }
 
   private:
-    static inline QJSEngine* s_pJsEngine = nullptr;
+    static inline std::shared_ptr<Library> s_pLibrary;
+
     std::shared_ptr<Library> m_pLibrary;
 
     /// This needs to be a plain pointer because it's used as a `Q_PROPERTY` member variable.

--- a/src/qml/qmlplayermanagerproxy.cpp
+++ b/src/qml/qmlplayermanagerproxy.cpp
@@ -61,30 +61,17 @@ void QmlPlayerManagerProxy::loadLocationToPlayer(
 
 // static
 QmlPlayerManagerProxy* QmlPlayerManagerProxy::create(QQmlEngine* pQmlEngine, QJSEngine* pJsEngine) {
-    Q_UNUSED(pQmlEngine);
-
     // The implementation of this method is mostly taken from the code example
     // that shows the replacement for `qmlRegisterSingletonInstance()` when
     // using `QML_SINGLETON`.
     // https://doc.qt.io/qt-6/qqmlengine.html#QML_SINGLETON
 
     // The instance has to exist before it is used. We cannot replace it.
-    DEBUG_ASSERT(s_pInstance);
-
-    // The engine has to have the same thread affinity as the singleton.
-    DEBUG_ASSERT(pJsEngine->thread() == s_pInstance->thread());
-
-    // There can only be one engine accessing the singleton.
-    if (s_pJsEngine) {
-        DEBUG_ASSERT(pJsEngine == s_pJsEngine);
-    } else {
-        s_pJsEngine = pJsEngine;
+    VERIFY_OR_DEBUG_ASSERT(s_pPlayerManager) {
+        qWarning() << "PlayerManager hasn't been registered yet";
+        return nullptr;
     }
-
-    // Explicitly specify C++ ownership so that the engine doesn't delete
-    // the instance.
-    QJSEngine::setObjectOwnership(s_pInstance, QJSEngine::CppOwnership);
-    return s_pInstance;
+    return new QmlPlayerManagerProxy(s_pPlayerManager, pQmlEngine);
 }
 
 } // namespace qml

--- a/src/qml/qmlplayermanagerproxy.h
+++ b/src/qml/qmlplayermanagerproxy.h
@@ -4,6 +4,7 @@
 #include <QtQml>
 
 #include "mixer/playermanager.h"
+#include "qml/qmlplayerproxy.h"
 
 namespace mixxx {
 namespace qml {
@@ -25,10 +26,13 @@ class QmlPlayerManagerProxy : public QObject {
             const QString& location, const QString& group, bool play = false);
 
     static QmlPlayerManagerProxy* create(QQmlEngine* pQmlEngine, QJSEngine* pJsEngine);
-    static inline QmlPlayerManagerProxy* s_pInstance = nullptr;
+    static void registerPlayerManager(std::shared_ptr<PlayerManager> pPlayerManager) {
+        s_pPlayerManager = std::move(pPlayerManager);
+    }
 
   private:
-    static inline QJSEngine* s_pJsEngine = nullptr;
+    static inline std::shared_ptr<PlayerManager> s_pPlayerManager;
+
     const std::shared_ptr<PlayerManager> m_pPlayerManager;
 };
 

--- a/src/qml/qmlwaveformoverview.h
+++ b/src/qml/qmlwaveformoverview.h
@@ -42,7 +42,7 @@ class QmlWaveformOverview : public QQuickPaintedItem {
     QmlWaveformOverview(QQuickItem* parent = nullptr);
     ~QmlWaveformOverview() override = default;
 
-    void paint(QPainter* painter);
+    void paint(QPainter* painter) override;
 
     void setPlayer(QmlPlayerProxy* player);
     QmlPlayerProxy* getPlayer() const;

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -30,9 +30,7 @@
 #include "util/timer.h"
 #include "util/valuetransformer.h"
 #include "util/xml.h"
-#ifndef MIXXX_USE_QML
 #include "waveform/vsyncthread.h"
-#endif
 #include "waveform/waveformwidgetfactory.h"
 #include "widget/controlwidgetconnection.h"
 #include "widget/wbasewidget.h"
@@ -75,10 +73,8 @@
 #include "widget/wsizeawarestack.h"
 #include "widget/wskincolor.h"
 #include "widget/wslidercomposed.h"
-#ifndef MIXXX_USE_QML
 #include "widget/wspinny.h"
 #include "widget/wspinnyglsl.h"
-#endif
 #include "widget/wsplitter.h"
 #include "widget/wstarrating.h"
 #include "widget/wstatuslight.h"
@@ -86,11 +82,9 @@
 #include "widget/wtrackproperty.h"
 #include "widget/wtracktext.h"
 #include "widget/wtrackwidgetgroup.h"
-#ifndef MIXXX_USE_QML
 #include "widget/wvumeter.h"
 #include "widget/wvumeterglsl.h"
 #include "widget/wvumeterlegacy.h"
-#endif
 #include "widget/wwaveformviewer.h"
 #include "widget/wwidget.h"
 #include "widget/wwidgetgroup.h"
@@ -951,10 +945,10 @@ void LegacySkinParser::setupLabelWidget(const QDomElement& element, WLabel* pLab
 
 QWidget* LegacySkinParser::parseOverview(const QDomElement& node) {
 #ifdef MIXXX_USE_QML
-    Q_UNUSED(node);
-
-    return nullptr;
-#else
+    if (CmdlineArgs::Instance().isQml()) {
+        return nullptr;
+    }
+#endif
     QString group = lookupNodeGroup(node);
     BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(group);
     if (!pPlayer) {
@@ -992,15 +986,14 @@ QWidget* LegacySkinParser::parseOverview(const QDomElement& node) {
     connect(pPlayer, &BaseTrackPlayer::loadingTrack, overviewWidget, &WOverview::slotLoadingTrack);
 
     return overviewWidget;
-#endif
 }
 
 QWidget* LegacySkinParser::parseVisual(const QDomElement& node) {
 #ifdef MIXXX_USE_QML
-    Q_UNUSED(node);
-
-    return nullptr;
-#else
+    if (CmdlineArgs::Instance().isQml()) {
+        return nullptr;
+    }
+#endif
     QString group = lookupNodeGroup(node);
     BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(group);
     if (!pPlayer) {
@@ -1042,7 +1035,6 @@ QWidget* LegacySkinParser::parseVisual(const QDomElement& node) {
     viewer->slotTrackLoaded(pPlayer->getLoadedTrack());
 
     return viewer;
-#endif
 }
 
 QWidget* LegacySkinParser::parseText(const QDomElement& node) {
@@ -1274,10 +1266,10 @@ QWidget* LegacySkinParser::parseRecordingDuration(const QDomElement& node) {
 
 QWidget* LegacySkinParser::parseSpinny(const QDomElement& node) {
 #ifdef MIXXX_USE_QML
-    Q_UNUSED(node);
-
-    return nullptr;
-#else
+    if (CmdlineArgs::Instance().isQml()) {
+        return nullptr;
+    }
+#endif
     if (CmdlineArgs::Instance().getSafeMode()) {
         WLabel* dummy = new WLabel(m_pParent);
         //: Shown when Mixxx is running in safe mode.
@@ -1348,15 +1340,14 @@ QWidget* LegacySkinParser::parseSpinny(const QDomElement& node) {
     pSpinny->installEventFilter(m_pControllerManager->getControllerLearningEventFilter());
     pSpinny->Init();
     return pSpinny;
-#endif
 }
 
 QWidget* LegacySkinParser::parseVuMeter(const QDomElement& node) {
 #ifdef MIXXX_USE_QML
-    Q_UNUSED(node);
-
-    return nullptr;
-#else
+    if (CmdlineArgs::Instance().isQml()) {
+        return nullptr;
+    }
+#endif
     auto* pWaveformWidgetFactory = WaveformWidgetFactory::instance();
     if (CmdlineArgs::Instance().getUseLegacyVuMeter() ||
             (!pWaveformWidgetFactory->isOpenGlAvailable() &&
@@ -1414,7 +1405,6 @@ QWidget* LegacySkinParser::parseVuMeter(const QDomElement& node) {
     pVuMeterWidget->Init();
 
     return pVuMeterWidget;
-#endif
 }
 
 QWidget* LegacySkinParser::parseSearchBox(const QDomElement& node) {

--- a/src/test/controlobjectaliastest.cpp
+++ b/src/test/controlobjectaliastest.cpp
@@ -24,7 +24,6 @@ const QString kSkinGroup = QStringLiteral("[Skin]");
 class ControlObjectAliasTest : public MixxxTest {
 };
 
-#ifndef MIXXX_USE_QML
 TEST_F(ControlObjectAliasTest, GuiTick) {
     auto guiTick = GuiTick();
 
@@ -36,7 +35,6 @@ TEST_F(ControlObjectAliasTest, GuiTick) {
     auto period50msLegacy = ControlProxy(ConfigKey(kLegacyGroup, QStringLiteral("guiTick50ms")));
     EXPECT_DOUBLE_EQ(period50ms.get(), period50msLegacy.get());
 }
-#endif
 
 TEST_F(ControlObjectAliasTest, ControlIndicatorTimer) {
     auto controlIndicatorTimer = mixxx::ControlIndicatorTimer();

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -215,6 +215,13 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
                             : QString());
     parser.addOption(developer);
 
+#ifdef MIXXX_USE_QML
+    const QCommandLineOption qml(QStringLiteral("qml"),
+            forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
+                                      "Loads experimental QML GUI instead of legacy QWidget skin")
+                            : QString());
+    parser.addOption(qml);
+#endif
     const QCommandLineOption safeMode(QStringLiteral("safe-mode"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
                                       "Enables safe-mode. Disables OpenGL waveforms, and "
@@ -350,6 +357,9 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
     m_controllerDebug = parser.isSet(controllerDebug) || parser.isSet(controllerDebugDeprecated);
     m_controllerAbortOnWarning = parser.isSet(controllerAbortOnWarning);
     m_developer = parser.isSet(developer);
+#ifdef MIXXX_USE_QML
+    m_qml = parser.isSet(qml);
+#endif
     m_safeMode = parser.isSet(safeMode) || parser.isSet(safeModeDeprecated);
     m_debugAssertBreak = parser.isSet(debugAssertBreak) || parser.isSet(debugAssertBreakDeprecated);
 

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -38,6 +38,11 @@ class CmdlineArgs final {
         return m_controllerAbortOnWarning;
     }
     bool getDeveloper() const { return m_developer; }
+#ifdef MIXXX_USE_QML
+    bool isQml() const {
+        return m_qml;
+    }
+#endif
     bool getSafeMode() const { return m_safeMode; }
     bool useColors() const {
         return m_useColors;
@@ -81,6 +86,9 @@ class CmdlineArgs final {
     bool m_controllerDebug;
     bool m_controllerAbortOnWarning; // Controller Engine will be stricter
     bool m_developer; // Developer Mode
+#ifdef MIXXX_USE_QML
+    bool m_qml;
+#endif
     bool m_safeMode;
     bool m_useLegacyVuMeter;
     bool m_useLegacySpinny;

--- a/src/waveform/visualplayposition.h
+++ b/src/waveform/visualplayposition.h
@@ -9,11 +9,7 @@
 #include "util/performancetimer.h"
 
 class ControlProxy;
-#ifdef MIXXX_USE_QML
-typedef void VSyncThread;
-#else
 class VSyncThread;
-#endif
 
 // This class is for synchronizing the sound device DAC time with the waveforms, displayed on the
 // graphic device, using the CPU time


### PR DESCRIPTION
This change reintroduce the `--qml` argument to allow switch to QML dynamically. It also refactor slightly QML singletons to allow Qt to create a singleton per QML engines