### PR TITLE
Preferences: apply changes from all pages when pressing Apply (like when pressing Okay)

### DIFF
--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -426,12 +426,10 @@ void DlgPreferences::slotButtonPressed(QAbstractButton* pButton) {
         }
         break;
     case QDialogButtonBox::ApplyRole:
-        // Only apply settings on the current page.
-        if (pCurrentPage) {
-            pCurrentPage->slotApply();
-        }
+        emit applyPreferences();
         break;
     case QDialogButtonBox::AcceptRole:
+        // Same as Apply but close the dialog
         emit applyPreferences();
         accept();
         break;


### PR DESCRIPTION
Currently it's very confusing that
* pressing **Apply** + **Cancel** (apply pending changes on the **current page**, close, discard other changes)
is not the same as
* pressing **Okay** (apply pending changes in **all** pages, close)

One step further to fixing #7440 

