### PR TITLE
improve rendering of waveform marks

### DIFF
--- a/res/skins/LateNight/classic/style/mark_intro.svg
+++ b/res/skins/LateNight/classic/style/mark_intro.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="64"
+   height="64"
+   viewBox="0 0 16.933333 16.933334"
+   version="1.1"
+   id="svg7299"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs7296" />
+  <path
+     style="fill:#ffffff;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 16.933334,0 V 16.933334 H 0 Z"
+     id="path1109" />
+</svg>

--- a/res/skins/LateNight/classic/style/mark_loop.svg
+++ b/res/skins/LateNight/classic/style/mark_loop.svg
@@ -7,30 +7,8 @@
    viewBox="0 0 16.933333 16.933334"
    version="1.1"
    id="svg7299"
-   sodipodi:docname="mark_loop.svg"
-   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg">
-  <sodipodi:namedview
-     id="namedview829"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     showgrid="false"
-     inkscape:zoom="8.734375"
-     inkscape:cx="32.457961"
-     inkscape:cy="35.663685"
-     inkscape:window-width="1312"
-     inkscape:window-height="781"
-     inkscape:window-x="0"
-     inkscape:window-y="25"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="svg7299" />
   <defs
      id="defs7296" />
   <g

--- a/res/skins/LateNight/classic/style/mark_loop.svg
+++ b/res/skins/LateNight/classic/style/mark_loop.svg
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="64"
+   height="64"
+   viewBox="0 0 16.933333 16.933334"
+   version="1.1"
+   id="svg7299"
+   sodipodi:docname="mark_loop.svg"
+   inkscape:version="1.1.1 (c3084ef, 2021-09-22)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview829"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="8.734375"
+     inkscape:cx="32.457961"
+     inkscape:cy="35.663685"
+     inkscape:window-width="1312"
+     inkscape:window-height="781"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg7299" />
+  <defs
+     id="defs7296" />
+  <g
+     id="g940"
+     transform="matrix(0.97898566,0,0,0.97883358,0.1884315,0.18864367)"
+     style="stroke-width:3.175;stroke-miterlimit:4;stroke-dasharray:none">
+    <g
+       id="layer1"
+       transform="matrix(1.0692589,0,0,1.0692589,-0.58545593,-0.58545597)"
+       style="stroke-width:2.96935;stroke-miterlimit:4;stroke-dasharray:none">
+      <path
+         style="fill:none;stroke:#000000;stroke-width:2.96935;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="M 1.852085,1.852085 H 7.1437516 V 7.1437516"
+         id="path8821" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:2.96935;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none"
+         id="path9136"
+         d="M 13.580891,4.6619169 A 6.3307567,6.3307567 0 0 1 14.070556,12.132762 6.3307567,6.3307567 0 0 1 7.0927295,14.84629 6.3307567,6.3307567 0 0 1 2.4065186,9.0073927 6.3307567,6.3307567 0 0 1 6.5660033,2.7822836" />
+    </g>
+  </g>
+</svg>

--- a/res/skins/LateNight/classic/style/mark_outro.svg
+++ b/res/skins/LateNight/classic/style/mark_outro.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="64"
+   height="64"
+   viewBox="0 0 16.933333 16.933334"
+   version="1.1"
+   id="svg7299"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs7296" />
+  <path
+     style="fill:#ffffff;stroke:none;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 0,0 V 16.933334 H 16.933334 Z"
+     id="path1109" />
+</svg>

--- a/res/skins/LateNight/waveform.xml
+++ b/res/skins/LateNight/waveform.xml
@@ -62,6 +62,7 @@
             </MarkRange>
             <Mark>
               <Control>loop_start_position</Control>
+              <!--Text>&#8635;</Text-->
               <Icon>skin:../LateNight/classic/style/mark_loop.svg</Icon>
               <Align>top|left</Align>
               <Color><Variable name="LoopColor"/></Color>
@@ -86,7 +87,8 @@
             </MarkRange>
             <Mark>
               <Control>intro_start_position</Control>
-              <Text>&#9698;</Text>
+              <!--Text>&#9698;</Text-->
+              <Icon>skin:../LateNight/classic/style/mark_intro.svg</Icon>
               <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
               <Align>top|right</Align>
               <Color><Variable name="IntroOutroColor"/></Color>
@@ -95,7 +97,8 @@
             <Mark>
               <Control>intro_end_position</Control>
               <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-              <Text>&#9698;</Text>
+              <!--Text>&#9698;</Text-->
+              <Icon>skin:../LateNight/classic/style/mark_intro.svg</Icon>
               <Align>top|left</Align>
               <Color><Variable name="IntroOutroColor"/></Color>
               <TextColor>#FFFFFF</TextColor>
@@ -113,14 +116,16 @@
             <Mark>
               <Control>outro_start_position</Control>
               <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-              <Text>&#9699;</Text>
+              <!--Text>&#9699;</Text-->
+              <Icon>skin:../LateNight/classic/style/mark_outro.svg</Icon>
               <Align>top|right</Align>
               <Color><Variable name="IntroOutroColor"/></Color>
               <TextColor>#FFFFFF</TextColor>
             </Mark>
             <Mark>
               <Control>outro_end_position</Control>
-              <Text>&#9699;</Text>
+              <!--Text>&#9699;</Text-->
+              <Icon>skin:../LateNight/classic/style/mark_outro.svg</Icon>
               <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
               <Align>top|left</Align>
               <Color><Variable name="IntroOutroColor"/></Color>

--- a/res/skins/LateNight/waveform.xml
+++ b/res/skins/LateNight/waveform.xml
@@ -62,7 +62,7 @@
             </MarkRange>
             <Mark>
               <Control>loop_start_position</Control>
-              <Text>&#8635;</Text>
+              <Icon>skin:../LateNight/classic/style/mark_loop.svg</Icon>
               <Align>top|left</Align>
               <Color><Variable name="LoopColor"/></Color>
               <TextColor>#FFFFFF</TextColor>

--- a/res/skins/LateNight/waveform.xml
+++ b/res/skins/LateNight/waveform.xml
@@ -62,7 +62,7 @@
             </MarkRange>
             <Mark>
               <Control>loop_start_position</Control>
-              <!--Text>&#8635;</Text-->
+              <Text>&#8635;</Text>
               <Icon>skin:../LateNight/classic/style/mark_loop.svg</Icon>
               <Align>top|left</Align>
               <Color><Variable name="LoopColor"/></Color>
@@ -87,7 +87,7 @@
             </MarkRange>
             <Mark>
               <Control>intro_start_position</Control>
-              <!--Text>&#9698;</Text-->
+              <Text>&#9698;</Text>
               <Icon>skin:../LateNight/classic/style/mark_intro.svg</Icon>
               <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
               <Align>top|right</Align>
@@ -97,7 +97,7 @@
             <Mark>
               <Control>intro_end_position</Control>
               <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-              <!--Text>&#9698;</Text-->
+              <Text>&#9698;</Text>
               <Icon>skin:../LateNight/classic/style/mark_intro.svg</Icon>
               <Align>top|left</Align>
               <Color><Variable name="IntroOutroColor"/></Color>
@@ -116,7 +116,7 @@
             <Mark>
               <Control>outro_start_position</Control>
               <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
-              <!--Text>&#9699;</Text-->
+              <Text>&#9699;</Text>
               <Icon>skin:../LateNight/classic/style/mark_outro.svg</Icon>
               <Align>top|right</Align>
               <Color><Variable name="IntroOutroColor"/></Color>
@@ -124,7 +124,7 @@
             </Mark>
             <Mark>
               <Control>outro_end_position</Control>
-              <!--Text>&#9699;</Text-->
+              <Text>&#9699;</Text>
               <Icon>skin:../LateNight/classic/style/mark_outro.svg</Icon>
               <VisibilityControl>[Skin],show_intro_outro_cues</VisibilityControl>
               <Align>top|left</Align>

--- a/src/waveform/renderers/allshader/waveformrendermark.h
+++ b/src/waveform/renderers/allshader/waveformrendermark.h
@@ -21,7 +21,6 @@ class allshader::WaveformRenderMark final : public QObject, public allshader::Wa
     Q_OBJECT
   public:
     explicit WaveformRenderMark(WaveformWidgetRenderer* waveformWidget);
-    ~WaveformRenderMark() override;
 
     void setup(const QDomNode& node, const SkinContext& context) override;
 

--- a/src/waveform/renderers/allshader/waveformrendermark.h
+++ b/src/waveform/renderers/allshader/waveformrendermark.h
@@ -42,8 +42,8 @@ class allshader::WaveformRenderMark final : public QObject, public allshader::Wa
   private:
     void checkCuesUpdated();
 
-    void generateMarkImage(WaveformMarkPointer pMark, float breadth);
-    void generatePlayPosMarkTexture(float breadth);
+    void generateMarkImage(WaveformMarkPointer pMark);
+    void generatePlayPosMarkTexture();
 
     void drawTriangle(QPainter* painter,
             const QBrush& fillColor,

--- a/src/waveform/renderers/waveformmark.cpp
+++ b/src/waveform/renderers/waveformmark.cpp
@@ -261,13 +261,10 @@ QImage WaveformMark::generateImage(float breadth, float devicePixelRatio) {
         QString path = m_pixmapPath;
         // Use devicePixelRatio to properly scale the image
         QImage image = *WImageStore::getImage(path, devicePixelRatio);
-        // QImage image = QImage(path);
         //  If loading the image didn't fail, then we're done. Otherwise fall
         //  through and render a label.
         if (!image.isNull()) {
-            image =
-                    image.convertToFormat(QImage::Format_ARGB32_Premultiplied);
-            // WImageStore::correctImageColors(&m_image);
+            image = image.convertToFormat(QImage::Format_ARGB32_Premultiplied);
             //  Set the pixel/device ratio AFTER loading the image in order to get
             //  a truly scaled source image.
             //  See https://doc.qt.io/qt-5/qimage.html#setDevicePixelRatio

--- a/src/waveform/renderers/waveformmark.cpp
+++ b/src/waveform/renderers/waveformmark.cpp
@@ -178,43 +178,40 @@ struct MarkerGeometry {
 
         const qreal margin{3.f};
 
-        qreal capHeight;
-        {
-            QFontMetricsF metrics{m_font};
-            capHeight = metrics.capHeight();
+        QFontMetricsF metrics{m_font};
+        const qreal capHeight = metrics.capHeight();
 
-            if (m_isSymbol) {
-                // Symbols can be aligned and sized in an way that is not ideal.
-                // We auto-scale the font size so the symbol fits in capHeight
-                // (the height of a flat capital letter such as H) but without
-                // exceeded a width of capHeight * 1.1
-                const auto targetHeight = std::ceil(capHeight);
-                const auto targetWidth = std::ceil(capHeight * 1.1f);
+        if (m_isSymbol) {
+            // Symbols can be aligned and sized in an way that is not ideal.
+            // We auto-scale the font size so the symbol fits in capHeight
+            // (the height of a flat capital letter such as H) but without
+            // exceeded a width of capHeight * 1.1
+            const auto targetHeight = std::ceil(capHeight);
+            const auto targetWidth = std::ceil(capHeight * 1.1f);
 
-                // As a starting point we look at the tight bounding rect at a
-                // large font size
-                m_font.setPointSize(50.0);
-                metrics = QFontMetricsF(m_font);
-                m_contentRect = metrics.tightBoundingRect(label);
+            // As a starting point we look at the tight bounding rect at a
+            // large font size
+            m_font.setPointSize(50.0);
+            metrics = QFontMetricsF(m_font);
+            m_contentRect = metrics.tightBoundingRect(label);
 
-                // Now we calculate how much bigger this is than our target
-                // size.
-                const auto ratioH = targetHeight / m_contentRect.height();
-                const auto ratioW = targetWidth / m_contentRect.width();
-                const auto ratio = std::min(ratioH, ratioW);
+            // Now we calculate how much bigger this is than our target
+            // size.
+            const auto ratioH = targetHeight / m_contentRect.height();
+            const auto ratioW = targetWidth / m_contentRect.width();
+            const auto ratio = std::min(ratioH, ratioW);
 
-                // And we scale the font size accordingly.
-                m_font.setPointSizeF(50.0 * ratio);
-                metrics = QFontMetricsF(m_font);
-                m_contentRect = metrics.tightBoundingRect(label);
-            } else if (useIcon) {
-                m_contentRect = QRectF(0.f, 0.f, std::ceil(capHeight), std::ceil(capHeight));
-            } else {
-                m_contentRect = QRectF{0.f,
-                        -capHeight,
-                        metrics.boundingRect(label).width(),
-                        capHeight};
-            }
+            // And we scale the font size accordingly.
+            m_font.setPointSizeF(50.0 * ratio);
+            metrics = QFontMetricsF(m_font);
+            m_contentRect = metrics.tightBoundingRect(label);
+        } else if (useIcon) {
+            m_contentRect = QRectF(0.f, 0.f, std::ceil(capHeight), std::ceil(capHeight));
+        } else {
+            m_contentRect = QRectF{0.f,
+                    -capHeight,
+                    metrics.boundingRect(label).width(),
+                    capHeight};
         }
 
         const Qt::Alignment alignH = align & Qt::AlignHorizontal_Mask;

--- a/src/waveform/renderers/waveformmark.cpp
+++ b/src/waveform/renderers/waveformmark.cpp
@@ -121,7 +121,9 @@ WaveformMark::WaveformMark(const QString& group,
 WaveformMark::~WaveformMark() = default;
 
 void WaveformMark::setBaseColor(QColor baseColor, int dimBrightThreshold) {
-    m_needsUpdate = true;
+    if (m_pGraphics) {
+        m_pGraphics->m_obsolete = true;
+    }
     m_fillColor = baseColor;
     m_borderColor = Color::chooseContrastColor(baseColor, dimBrightThreshold);
     m_labelColor = Color::chooseColorByBrightness(baseColor,

--- a/src/waveform/renderers/waveformmark.cpp
+++ b/src/waveform/renderers/waveformmark.cpp
@@ -157,7 +157,7 @@ struct MarkerGeometry {
     MarkerGeometry(const QString& label, bool useIcon, Qt::Alignment align, float breadth) {
         // If the label is 1 character long, and this character isn't a letter or a number,
         // we can assume it's a special symbol
-        m_isSymbol = label.length() == 1 && !label[0].isLetterOrNumber();
+        m_isSymbol = !useIcon && label.length() == 1 && !label[0].isLetterOrNumber();
 
         // This alone would pick the OS default font, or that set by Qt5 Settings (qt5ct)
         // respectively. This would mostly not be notable since contemporary OS and distros

--- a/src/waveform/renderers/waveformmark.cpp
+++ b/src/waveform/renderers/waveformmark.cpp
@@ -145,7 +145,7 @@ bool WaveformMark::contains(QPoint point, Qt::Orientation orientation) const {
     return m_label.area().contains(point) || lineHovered;
 }
 
-// Helper class to calculate the geometry and fontsize needed by generateImage
+// Helper struct to calculate the geometry and fontsize needed by generateImage
 // to draw the label and text
 struct MarkerGeometry {
     bool m_isSymbol; // it the label normal text or a single symbol (e.g. open circle arrow)

--- a/src/waveform/renderers/waveformmark.cpp
+++ b/src/waveform/renderers/waveformmark.cpp
@@ -125,21 +125,14 @@ void WaveformMark::setBaseColor(QColor baseColor, int dimBrightThreshold) {
 };
 
 bool WaveformMark::contains(QPoint point, Qt::Orientation orientation) const {
-    qDebug() << "contains" << point << m_label.area();
-
     // Without some padding, the user would only have a single pixel width that
     // would count as hovering over the WaveformMark.
     float lineHoverPadding = 5.0;
-    int position;
-    if (orientation == Qt::Horizontal) {
-        position = point.x();
-    } else {
-        position = point.y();
+    if (orientation == Qt::Vertical) {
+        point = QPoint(point.y(), m_breadth - point.x());
     }
-    bool lineHovered = m_linePosition >= position - lineHoverPadding &&
-            m_linePosition <= position + lineHoverPadding;
-
-    qDebug() << "---contains " << point << m_label.area() << m_linePosition;
+    bool lineHovered = m_linePosition >= point.x() - lineHoverPadding &&
+            m_linePosition <= point.x() + lineHoverPadding;
 
     return m_label.area().contains(point) || lineHovered;
 }
@@ -253,6 +246,8 @@ struct MarkerGeometry {
 QImage WaveformMark::generateImage(float breadth, float devicePixelRatio) {
     // Load the pixmap from file.
     // If that succeeds loading the text and stroke is skipped.
+
+    m_breadth = static_cast<int>(breadth);
 
     if (!m_pixmapPath.isEmpty()) {
         QString path = m_pixmapPath;

--- a/src/waveform/renderers/waveformmark.cpp
+++ b/src/waveform/renderers/waveformmark.cpp
@@ -5,6 +5,7 @@
 
 #include "skin/legacy/skincontext.h"
 #include "waveform/renderers/waveformsignalcolors.h"
+#include "widget/wimagestore.h"
 #include "widget/wskincolor.h"
 
 namespace {
@@ -52,10 +53,10 @@ Qt::Alignment decodeAlignmentFlags(const QString& alignString, Qt::Alignment def
 } // anonymous namespace
 
 WaveformMark::WaveformMark(const QString& group,
-                           const QDomNode& node,
-                           const SkinContext& context,
-                           const WaveformSignalColors& signalColors,
-                           int hotCue)
+        const QDomNode& node,
+        const SkinContext& context,
+        const WaveformSignalColors& signalColors,
+        int hotCue)
         : m_iHotCue(hotCue) {
     QString positionControl;
     QString endPositionControl;
@@ -114,7 +115,7 @@ WaveformMark::WaveformMark(const QString& group,
 WaveformMark::~WaveformMark() = default;
 
 void WaveformMark::setBaseColor(QColor baseColor, int dimBrightThreshold) {
-    m_image = QImage();
+    m_needsUpdate = true;
     m_fillColor = baseColor;
     m_borderColor = Color::chooseContrastColor(baseColor, dimBrightThreshold);
     m_labelColor = Color::chooseColorByBrightness(baseColor,
@@ -124,6 +125,8 @@ void WaveformMark::setBaseColor(QColor baseColor, int dimBrightThreshold) {
 };
 
 bool WaveformMark::contains(QPoint point, Qt::Orientation orientation) const {
+    qDebug() << "contains" << point << m_label.area();
+
     // Without some padding, the user would only have a single pixel width that
     // would count as hovering over the WaveformMark.
     float lineHoverPadding = 5.0;
@@ -136,5 +139,219 @@ bool WaveformMark::contains(QPoint point, Qt::Orientation orientation) const {
     bool lineHovered = m_linePosition >= position - lineHoverPadding &&
             m_linePosition <= position + lineHoverPadding;
 
+    qDebug() << "---contains " << point << m_label.area() << m_linePosition;
+
     return m_label.area().contains(point) || lineHovered;
+}
+
+// Helper class to calculate the geometry and fontsize needed by generateImage
+// to draw the label and text
+struct MarkerGeometry {
+    bool m_isSymbol; // it the label normal text or a single symbol (e.g. open circle arrow)
+    QFont m_font;
+    QRectF m_textRect;
+    QRectF m_labelRect;
+    QSizeF m_imageSize;
+
+    MarkerGeometry(const QString& label, Qt::Alignment align, float breadth) {
+        // If the label is 1 character long, and this character isn't a letter or a number,
+        // we can assume it's a special symbol
+        m_isSymbol = label.length() == 1 && !label[0].isLetterOrNumber();
+
+        // This alone would pick the OS default font, or that set by Qt5 Settings (qt5ct)
+        // respectively. This would mostly not be notable since contemporary OS and distros
+        // use a proven sans-serif anyway. Though, some user fonts may be lacking glyphs
+        // we use for the intro/outro markers for example.
+        // So, let's just use Open Sans which is used by all official skins to achieve
+        // a consistent skin design.
+        m_font.setFamily("Open Sans");
+        // For text, use a pixel size like everywhere else in Mixxx, which can be scaled
+        // well in general.
+        // Point sizes would work if only explicit Qt scaling QT_SCALE_FACTORS is used,
+        // though as soon as other OS-based font and app scaling mechanics join the
+        // party the resulting font size is hard to predict (affects all supported OS).
+
+        m_font.setPixelSize(13);
+        m_font.setWeight(75); // bold
+        m_font.setItalic(false);
+
+        qreal capHeight;
+        {
+            QFontMetricsF metrics{m_font};
+            capHeight = metrics.capHeight();
+
+            if (m_isSymbol) {
+                // Symbols can be aligned and sized in an way that is not ideal.
+                // We auto-scale the font size so the symbol fits in capHeight
+                // (the height of a flat capital letter such as H) but without
+                // exceeded a width of capHeight * 1.1
+                const auto targetHeight = std::ceil(capHeight);
+                const auto targetWidth = std::ceil(capHeight * 1.1f);
+
+                // As a starting point we look at the tight bounding rect at a
+                // large font size
+                m_font.setPointSize(50.0);
+                metrics = QFontMetricsF(m_font);
+                m_textRect = metrics.tightBoundingRect(label);
+
+                // Now we calculate how much bigger this is than our target
+                // size.
+                const auto ratioH = targetHeight / m_textRect.height();
+                const auto ratioW = targetWidth / m_textRect.width();
+                const auto ratio = std::min(ratioH, ratioW);
+
+                // And we scale the font size accordingly.
+                m_font.setPointSizeF(50.0 * ratio);
+                metrics = QFontMetricsF(m_font);
+                m_textRect = metrics.tightBoundingRect(label);
+            } else {
+                m_textRect = QRectF{0.f,
+                        -metrics.capHeight(),
+                        metrics.boundingRect(label).width(),
+                        metrics.capHeight()};
+            }
+        }
+
+        const qreal margin{3.f};
+        const Qt::Alignment alignH = align & Qt::AlignHorizontal_Mask;
+        const Qt::Alignment alignV = align & Qt::AlignVertical_Mask;
+        const bool alignHCenter{alignH == Qt::AlignHCenter};
+        const qreal widthRounding{alignHCenter ? 2.f : 1.f};
+
+        m_labelRect = QRectF{0.f,
+                0.f,
+                std::ceil((m_textRect.width() + 2.f * margin) / widthRounding) *
+                        widthRounding,
+                std::ceil(capHeight + 2.f * margin)};
+
+        m_imageSize = QSizeF{alignHCenter ? m_labelRect.width() + 1.f
+                                          : 2.f * m_labelRect.width() + 1.f,
+                breadth};
+
+        if (alignH == Qt::AlignHCenter) {
+            m_labelRect.moveLeft((m_imageSize.width() - m_labelRect.width()) / 2.f);
+        } else if (alignH == Qt::AlignRight) {
+            m_labelRect.moveRight(m_imageSize.width() - 0.5f);
+        } else {
+            m_labelRect.moveLeft(0.5f);
+        }
+
+        if (alignV == Qt::AlignVCenter) {
+            m_labelRect.moveTop((m_imageSize.height() - m_labelRect.height()) / 2.f);
+        } else if (alignV == Qt::AlignBottom) {
+            m_labelRect.moveBottom(m_imageSize.height() - 0.5f);
+        } else {
+            m_labelRect.moveTop(0.5f);
+        }
+    }
+    QSize getImageSize(float devicePixelRatio) const {
+        return QSize{static_cast<int>(m_imageSize.width() * devicePixelRatio),
+                static_cast<int>(m_imageSize.height() * devicePixelRatio)};
+    }
+};
+
+QImage WaveformMark::generateImage(float breadth, float devicePixelRatio) {
+    // Load the pixmap from file.
+    // If that succeeds loading the text and stroke is skipped.
+
+    if (!m_pixmapPath.isEmpty()) {
+        QString path = m_pixmapPath;
+        // Use devicePixelRatio to properly scale the image
+        QImage image = *WImageStore::getImage(path, devicePixelRatio);
+        // QImage image = QImage(path);
+        //  If loading the image didn't fail, then we're done. Otherwise fall
+        //  through and render a label.
+        if (!image.isNull()) {
+            image =
+                    image.convertToFormat(QImage::Format_ARGB32_Premultiplied);
+            // WImageStore::correctImageColors(&m_image);
+            //  Set the pixel/device ratio AFTER loading the image in order to get
+            //  a truly scaled source image.
+            //  See https://doc.qt.io/qt-5/qimage.html#setDevicePixelRatio
+            //  Also, without this some Qt-internal issue results in an offset
+            //  image when calculating the center line of pixmaps in draw().
+            image.setDevicePixelRatio(devicePixelRatio);
+            return image;
+        }
+    }
+
+    QString label = m_text;
+
+    // Determine mark text.
+    if (getHotCue() >= 0) {
+        constexpr int kMaxCueLabelLength = 23;
+        if (!label.isEmpty()) {
+            label.prepend(": ");
+        }
+        label.prepend(QString::number(getHotCue() + 1));
+        if (label.size() > kMaxCueLabelLength) {
+            label = label.left(kMaxCueLabelLength - 3) + "...";
+        }
+    }
+
+    // Determine drawing geometries
+    const MarkerGeometry markerGeometry(label, m_align, breadth);
+
+    m_label.setAreaRect(markerGeometry.m_labelRect);
+
+    // Create the image
+    QImage image{markerGeometry.getImageSize(devicePixelRatio),
+            QImage::Format_ARGB32_Premultiplied};
+    image.setDevicePixelRatio(devicePixelRatio);
+
+    // Fill with transparent pixels
+    image.fill(Qt::transparent);
+
+    QPainter painter;
+
+    painter.begin(&image);
+    painter.setRenderHint(QPainter::TextAntialiasing);
+    painter.setRenderHint(QPainter::Antialiasing);
+
+    painter.setWorldMatrixEnabled(false);
+
+    // Draw marker lines
+    const float hcenter = markerGeometry.m_imageSize.width() / 2.f;
+    m_linePosition = hcenter;
+
+    // Draw the center line
+    painter.setPen(fillColor());
+    painter.drawLine(QLineF(hcenter, 0.f, hcenter, markerGeometry.m_imageSize.height()));
+
+    painter.setPen(borderColor());
+    painter.drawLine(QLineF(hcenter - 1.f, 0, hcenter - 1.f, markerGeometry.m_imageSize.height()));
+    painter.drawLine(QLineF(hcenter + 1.f, 0, hcenter + 1.f, markerGeometry.m_imageSize.height()));
+
+    if (label.length() != 0) {
+        painter.setPen(borderColor());
+
+        // Draw the label rounded rect with border
+        QPainterPath path;
+        path.addRoundedRect(markerGeometry.m_labelRect, 2.f, 2.f);
+        painter.fillPath(path, fillColor());
+        painter.drawPath(path);
+
+        // Draw the text
+        painter.setBrush(Qt::transparent);
+        painter.setPen(labelColor());
+        painter.setFont(markerGeometry.m_font);
+
+        // Center m_textRect.width() and m_textRect.height() inside m_labelRect
+        // and apply the offset x,y so the text ends up in the centered width,height.
+        QPointF pos(markerGeometry.m_labelRect.x() +
+                        (markerGeometry.m_labelRect.width() -
+                                markerGeometry.m_textRect.width()) /
+                                2.f -
+                        markerGeometry.m_textRect.x(),
+                markerGeometry.m_labelRect.y() +
+                        (markerGeometry.m_labelRect.height() -
+                                markerGeometry.m_textRect.height()) /
+                                2.f -
+                        markerGeometry.m_textRect.y());
+        painter.drawText(pos, label);
+    }
+
+    painter.end();
+
+    return image;
 }

--- a/src/waveform/renderers/waveformmark.cpp
+++ b/src/waveform/renderers/waveformmark.cpp
@@ -1,6 +1,7 @@
 #include "waveformmark.h"
 
 #include <QOpenGLTexture>
+#include <QPainterPath>
 #include <QtDebug>
 
 #include "skin/legacy/skincontext.h"
@@ -306,16 +307,22 @@ QImage WaveformMark::generateImage(float breadth, float devicePixelRatio) {
     painter.setWorldMatrixEnabled(false);
 
     // Draw marker lines
-    const float hcenter = markerGeometry.m_imageSize.width() / 2.f;
-    m_linePosition = hcenter;
+    const auto hcenter = markerGeometry.m_imageSize.width() / 2.f;
+    m_linePosition = static_cast<float>(hcenter);
 
     // Draw the center line
     painter.setPen(fillColor());
     painter.drawLine(QLineF(hcenter, 0.f, hcenter, markerGeometry.m_imageSize.height()));
 
     painter.setPen(borderColor());
-    painter.drawLine(QLineF(hcenter - 1.f, 0, hcenter - 1.f, markerGeometry.m_imageSize.height()));
-    painter.drawLine(QLineF(hcenter + 1.f, 0, hcenter + 1.f, markerGeometry.m_imageSize.height()));
+    painter.drawLine(QLineF(hcenter - 1.f,
+            0.f,
+            hcenter - 1.f,
+            markerGeometry.m_imageSize.height()));
+    painter.drawLine(QLineF(hcenter + 1.f,
+            0.f,
+            hcenter + 1.f,
+            markerGeometry.m_imageSize.height()));
 
     if (label.length() != 0) {
         painter.setPen(borderColor());

--- a/src/waveform/renderers/waveformmark.cpp
+++ b/src/waveform/renderers/waveformmark.cpp
@@ -58,7 +58,7 @@ WaveformMark::WaveformMark(const QString& group,
         const SkinContext& context,
         const WaveformSignalColors& signalColors,
         int hotCue)
-        : m_iHotCue(hotCue) {
+        : m_linePosition{}, m_breadth{}, m_iHotCue{hotCue} {
     QString positionControl;
     QString endPositionControl;
     if (hotCue != Cue::kNoHotCue) {

--- a/src/waveform/renderers/waveformmark.h
+++ b/src/waveform/renderers/waveformmark.h
@@ -103,7 +103,8 @@ class WaveformMark {
     Qt::Alignment m_align;
     QString m_pixmapPath;
 
-    float m_linePosition;
+    float m_linePosition{};
+    int m_breadth{};
 
     WaveformMarkLabel m_label;
 

--- a/src/waveform/renderers/waveformmark.h
+++ b/src/waveform/renderers/waveformmark.h
@@ -102,6 +102,7 @@ class WaveformMark {
     QString m_text;
     Qt::Alignment m_align;
     QString m_pixmapPath;
+    QString m_iconPath;
 
     float m_linePosition{};
     int m_breadth{};

--- a/src/waveform/renderers/waveformmark.h
+++ b/src/waveform/renderers/waveformmark.h
@@ -21,6 +21,14 @@ class WaveformRenderMark;
 
 class WaveformMark {
   public:
+    class Graphics {
+      public:
+        Graphics()
+                : m_obsolete{false} {
+        }
+        bool m_obsolete;
+    };
+
     WaveformMark(
             const QString& group,
             const QDomNode& node,
@@ -116,10 +124,7 @@ class WaveformMark {
 
     friend class allshader::WaveformRenderMark;
 
-    std::unique_ptr<QOpenGLTexture> m_pTexture; // Used by allshader::WaveformRenderMark
-    QImage m_image;                             // Used by WaveformRenderMark
-    bool m_needsUpdate{true};                   // To indicate either the texture or the image has
-                                                // to be updated
+    std::unique_ptr<Graphics> m_pGraphics;
 
     int m_iHotCue;
 

--- a/src/waveform/renderers/waveformmark.h
+++ b/src/waveform/renderers/waveformmark.h
@@ -112,8 +112,8 @@ class WaveformMark {
     QString m_pixmapPath;
     QString m_iconPath;
 
-    float m_linePosition{};
-    int m_breadth{};
+    float m_linePosition;
+    int m_breadth;
 
     WaveformMarkLabel m_label;
 

--- a/src/waveform/renderers/waveformmark.h
+++ b/src/waveform/renderers/waveformmark.h
@@ -33,14 +33,16 @@ class WaveformMark {
     WaveformMark(const WaveformMark&) = delete;
     WaveformMark& operator=(const WaveformMark&) = delete;
 
-    int getHotCue() const { return m_iHotCue; };
+    int getHotCue() const {
+        return m_iHotCue;
+    };
 
-    //The m_pPositionCO related function
+    // The m_pPositionCO related function
     bool isValid() const {
         return m_pPositionCO && m_pPositionCO->valid();
     }
 
-    template <typename Receiver, typename Slot>
+    template<typename Receiver, typename Slot>
     void connectSamplePositionChanged(Receiver receiver, Slot slot) const {
         m_pPositionCO->connectValueChanged(receiver, slot, Qt::AutoConnection);
     };
@@ -74,7 +76,7 @@ class WaveformMark {
         return m_pVisibleCO->toBool();
     }
 
-    template <typename Receiver, typename Slot>
+    template<typename Receiver, typename Slot>
     void connectVisibleChanged(Receiver receiver, Slot slot) const {
         m_pVisibleCO->connectValueChanged(receiver, slot, Qt::AutoConnection);
     }
@@ -94,6 +96,8 @@ class WaveformMark {
     // Check if a point (in image coordinates) lies on drawn image.
     bool contains(QPoint point, Qt::Orientation orientation) const;
 
+    QImage generateImage(float breath, float devicePixelRatio);
+
     QColor m_textColor;
     QString m_text;
     Qt::Alignment m_align;
@@ -107,10 +111,15 @@ class WaveformMark {
     std::unique_ptr<ControlProxy> m_pPositionCO;
     std::unique_ptr<ControlProxy> m_pEndPositionCO;
     std::unique_ptr<ControlProxy> m_pVisibleCO;
-    std::unique_ptr<QOpenGLTexture> m_pTexture; // used by allshader::WaveformRenderMark
+
     friend class allshader::WaveformRenderMark;
+
+    std::unique_ptr<QOpenGLTexture> m_pTexture; // Used by allshader::WaveformRenderMark
+    QImage m_image;                             // Used by WaveformRenderMark
+    bool m_needsUpdate{true};                   // To indicate either the texture or the image has
+                                                // to be updated
+
     int m_iHotCue;
-    QImage m_image;
 
     QColor m_fillColor;
     QColor m_borderColor;

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -12,13 +12,8 @@
 #include "util/painterscope.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
 #include "waveform/waveform.h"
-#include "widget/wimagestore.h"
 #include "widget/wskincolor.h"
 #include "widget/wwidget.h"
-
-namespace {
-constexpr int kMaxCueLabelLength = 23;
-} // namespace
 
 WaveformRenderMark::WaveformRenderMark(
         WaveformWidgetRenderer* waveformWidgetRenderer) :
@@ -55,7 +50,7 @@ void WaveformRenderMark::draw(QPainter* painter, QPaintEvent* /*event*/) {
 
         // Generate image on first paint can't be done in setup since we need to
         // wait for the render widget to be resized yet.
-        if (pMark->m_image.isNull()) {
+        if (pMark->m_needsUpdate || pMark->m_image.isNull()) {
             generateMarkImage(pMark);
         }
 
@@ -158,9 +153,9 @@ void WaveformRenderMark::draw(QPainter* painter, QPaintEvent* /*event*/) {
 }
 
 void WaveformRenderMark::onResize() {
-    // Delete all marks' images. New images will be created on next paint.
+    // Flag that the mark image has to be updated. New images will be created on next paint.
     for (const auto& pMark : m_marks) {
-        pMark->m_image = QImage();
+        pMark->m_needsUpdate = true;
     }
 }
 
@@ -211,189 +206,7 @@ void WaveformRenderMark::slotCuesUpdated() {
 }
 
 void WaveformRenderMark::generateMarkImage(WaveformMarkPointer pMark) {
-    // Load the pixmap from file.
-    // If that succeeds loading the text and stroke is skipped.
-    float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
-    if (!pMark->m_pixmapPath.isEmpty()) {
-        QString path = pMark->m_pixmapPath;
-        // Use devicePixelRatio to properly scale the image
-        QImage image = *WImageStore::getImage(path, devicePixelRatio);
-        //QImage image = QImage(path);
-        // If loading the image didn't fail, then we're done. Otherwise fall
-        // through and render a label.
-        if (!image.isNull()) {
-            pMark->m_image =
-                    image.convertToFormat(QImage::Format_ARGB32_Premultiplied);
-            //WImageStore::correctImageColors(&pMark->m_image);
-            // Set the pixel/device ratio AFTER loading the image in order to get
-            // a truly scaled source image.
-            // See https://doc.qt.io/qt-5/qimage.html#setDevicePixelRatio
-            // Also, without this some Qt-internal issue results in an offset
-            // image when calculating the center line of pixmaps in draw().
-            pMark->m_image.setDevicePixelRatio(devicePixelRatio);
-            return;
-        }
-    }
-
-    QPainter painter;
-
-    // Determine mark text.
-    QString label = pMark->m_text;
-    if (pMark->getHotCue() >= 0) {
-        if (!label.isEmpty()) {
-            label.prepend(": ");
-        }
-        label.prepend(QString::number(pMark->getHotCue() + 1));
-        if (label.size() > kMaxCueLabelLength) {
-            label = label.left(kMaxCueLabelLength - 3) + "...";
-        }
-    }
-
-    // This alone would pick the OS default font, or that set by Qt5 Settings (qt5ct)
-    // respectively. This would mostly not be notable since contemporary OS and distros
-    // use a proven sans-serif anyway. Though, some user fonts may be lacking glyphs
-    // we use for the intro/outro markers for example.
-    QFont font;
-    // So, let's just use Open Sans which is used by all official skins to achieve
-    // a consistent skin design.
-    font.setFamily("Open Sans");
-    // Use a pixel size like everywhere else in Mixxx, which can be scaled well
-    // in general.
-    // Point sizes would work if only explicit Qt scaling QT_SCALE_FACTORS is used,
-    // though as soon as other OS-based font and app scaling mechanics join the
-    // party the resulting font size is hard to predict (affects all supported OS).
-    font.setPixelSize(13);
-    font.setWeight(75); // bold
-    font.setItalic(false);
-
-    QFontMetrics metrics(font);
-
-    //fixed margin ...
-    QRect wordRect = metrics.tightBoundingRect(label);
-    constexpr int marginX = 1;
-    constexpr int marginY = 1;
-    wordRect.moveTop(marginX + 1);
-    wordRect.moveLeft(marginY + 1);
-    wordRect.setHeight(wordRect.height() + (wordRect.height() % 2));
-    wordRect.setWidth(wordRect.width() + (wordRect.width()) % 2);
-    //even wordrect to have an even Image >> draw the line in the middle !
-
-    int labelRectWidth = wordRect.width() + 2 * marginX + 4;
-    int labelRectHeight = wordRect.height() + 2 * marginY + 4;
-
-    QRectF labelRect(0, 0, (float)labelRectWidth, (float)labelRectHeight);
-
-    int width;
-    int height;
-
-    if (m_waveformRenderer->getOrientation() == Qt::Horizontal) {
-        width = 2 * labelRectWidth + 1;
-        height = m_waveformRenderer->getHeight();
-    } else {
-        width = m_waveformRenderer->getWidth();
-        height = 2 * labelRectHeight + 1;
-    }
-
-    pMark->m_image = QImage(
-            static_cast<int>(width * devicePixelRatio),
-            static_cast<int>(height * devicePixelRatio),
-            QImage::Format_ARGB32_Premultiplied);
-    pMark->m_image.setDevicePixelRatio(devicePixelRatio);
-
-    Qt::Alignment markAlignH = pMark->m_align & Qt::AlignHorizontal_Mask;
-    Qt::Alignment markAlignV = pMark->m_align & Qt::AlignVertical_Mask;
-
-    if (markAlignH == Qt::AlignHCenter) {
-        labelRect.moveLeft((width - labelRectWidth) / 2);
-    } else if (markAlignH == Qt::AlignRight) {
-        labelRect.moveRight(width - 1);
-    }
-
-    if (markAlignV == Qt::AlignVCenter) {
-        labelRect.moveTop((height - labelRectHeight) / 2);
-    } else if (markAlignV == Qt::AlignBottom) {
-        labelRect.moveBottom(height - 1);
-    }
-
-    pMark->m_label.setAreaRect(labelRect);
-
-    // Fill with transparent pixels
-    pMark->m_image.fill(QColor(0, 0, 0, 0).rgba());
-
-    painter.begin(&pMark->m_image);
-    painter.setRenderHint(QPainter::TextAntialiasing);
-
-    painter.setWorldMatrixEnabled(false);
-
-    // Draw marker lines
-    if (m_waveformRenderer->getOrientation() == Qt::Horizontal) {
-        int middle = width / 2;
-        pMark->m_linePosition = middle;
-        if (markAlignH == Qt::AlignHCenter) {
-            if (labelRect.top() > 0) {
-                painter.setPen(pMark->fillColor());
-                painter.drawLine(QLineF(middle, 0, middle, labelRect.top()));
-
-                painter.setPen(pMark->borderColor());
-                painter.drawLine(QLineF(middle - 1, 0, middle - 1, labelRect.top()));
-                painter.drawLine(QLineF(middle + 1, 0, middle + 1, labelRect.top()));
-            }
-
-            if (labelRect.bottom() < height) {
-                painter.setPen(pMark->fillColor());
-                painter.drawLine(QLineF(middle, labelRect.bottom(), middle, height));
-
-                painter.setPen(pMark->borderColor());
-                painter.drawLine(QLineF(middle - 1, labelRect.bottom(), middle - 1, height));
-                painter.drawLine(QLineF(middle + 1, labelRect.bottom(), middle + 1, height));
-            }
-        } else { // AlignLeft || AlignRight
-            painter.setPen(pMark->fillColor());
-            painter.drawLine(middle, 0, middle, height);
-
-            painter.setPen(pMark->borderColor());
-            painter.drawLine(middle - 1, 0, middle - 1, height);
-            painter.drawLine(middle + 1, 0, middle + 1, height);
-        }
-    } else { // Vertical
-        int middle = height / 2;
-        pMark->m_linePosition = middle;
-        if (markAlignV == Qt::AlignVCenter) {
-            if (labelRect.left() > 0) {
-                painter.setPen(pMark->fillColor());
-                painter.drawLine(QLineF(0, middle, labelRect.left(), middle));
-
-                painter.setPen(pMark->borderColor());
-                painter.drawLine(QLineF(0, middle - 1, labelRect.left(), middle - 1));
-                painter.drawLine(QLineF(0, middle + 1, labelRect.left(), middle + 1));
-            }
-
-            if (labelRect.right() < width) {
-                painter.setPen(pMark->fillColor());
-                painter.drawLine(QLineF(labelRect.right(), middle, width, middle));
-
-                painter.setPen(pMark->borderColor());
-                painter.drawLine(QLineF(labelRect.right(), middle - 1, width, middle - 1));
-                painter.drawLine(QLineF(labelRect.right(), middle + 1, width, middle + 1));
-            }
-        } else { // AlignTop || AlignBottom
-            painter.setPen(pMark->fillColor());
-            painter.drawLine(0, middle, width, middle);
-
-            painter.setPen(pMark->borderColor());
-            painter.drawLine(0, middle - 1, width, middle - 1);
-            painter.drawLine(0, middle + 1, width, middle + 1);
-        }
-    }
-
-    // Draw the label rect
-    painter.setPen(pMark->borderColor());
-    painter.setBrush(QBrush(pMark->fillColor()));
-    painter.drawRoundedRect(labelRect, 2.0, 2.0);
-
-    // Draw text
-    painter.setBrush(QBrush(QColor(0, 0, 0, 0)));
-    painter.setFont(font);
-    painter.setPen(pMark->labelColor());
-    painter.drawText(labelRect, Qt::AlignCenter, label);
+    pMark->m_image = pMark->generateImage(m_waveformRenderer->getBreadth(),
+            m_waveformRenderer->getDevicePixelRatio());
+    pMark->m_needsUpdate = false;
 }

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -105,7 +105,9 @@ void WaveformRenderMark::draw(QPainter* painter, QPaintEvent* /*event*/) {
                     marksOnScreen[pMark] = drawOffset;
                 }
             } else {
-                const int markHalfHeight = static_cast<int>(pMark->m_image.height() / 2.0);
+                const int markHalfHeight =
+                        static_cast<int>(pMark->m_image.height() / 2.0 /
+                                m_waveformRenderer->getDevicePixelRatio());
                 const int drawOffset = static_cast<int>(currentMarkPoint) - markHalfHeight;
 
                 bool visible = false;
@@ -113,7 +115,7 @@ void WaveformRenderMark::draw(QPainter* painter, QPaintEvent* /*event*/) {
                 if (currentMarkPoint > -markHalfHeight &&
                         currentMarkPoint < m_waveformRenderer->getHeight() +
                                         markHalfHeight) {
-                    painter->drawImage(drawOffset, 0, pMark->m_image);
+                    painter->drawImage(0, drawOffset, pMark->m_image);
                     visible = true;
                 }
 
@@ -206,7 +208,13 @@ void WaveformRenderMark::slotCuesUpdated() {
 }
 
 void WaveformRenderMark::generateMarkImage(WaveformMarkPointer pMark) {
-    pMark->m_image = pMark->generateImage(m_waveformRenderer->getBreadth(),
-            m_waveformRenderer->getDevicePixelRatio());
+    if (m_waveformRenderer->getOrientation() == Qt::Horizontal) {
+        pMark->m_image = pMark->generateImage(m_waveformRenderer->getBreadth(),
+                m_waveformRenderer->getDevicePixelRatio());
+    } else {
+        pMark->m_image = pMark->generateImage(m_waveformRenderer->getBreadth(),
+                                      m_waveformRenderer->getDevicePixelRatio())
+                                 .transformed(QTransform().rotate(90));
+    }
     pMark->m_needsUpdate = false;
 }

--- a/src/waveform/widgets/allshader/waveformwidget.cpp
+++ b/src/waveform/widgets/allshader/waveformwidget.cpp
@@ -60,4 +60,9 @@ void WaveformWidget::wheelEvent(QWheelEvent* pEvent) {
     pEvent->accept();
 }
 
+void WaveformWidget::leaveEvent(QEvent* pEvent) {
+    QApplication::sendEvent(parentWidget(), pEvent);
+    pEvent->accept();
+}
+
 } // namespace allshader

--- a/src/waveform/widgets/allshader/waveformwidget.h
+++ b/src/waveform/widgets/allshader/waveformwidget.h
@@ -27,4 +27,5 @@ class allshader::WaveformWidget : public ::WGLWidget,
 
   private:
     void wheelEvent(QWheelEvent* event) override;
+    void leaveEvent(QEvent* event) override;
 };


### PR DESCRIPTION
This PR improves the rendering of the waveform marks, by auto-scaling and better aligning the symbolic marks (such as the intro/outro triangles and the loop open circle arrow), as discussed here: https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/look.20of.20loop.20out.20marker

Additionally it:
- removes code duplication between `waveformrendermark.cpp` and `allshaders/waveformrendermark.cpp` by moving the mark image rendering to `waveformmark.cpp` and doing a general cleanup of that code
- doesn't draw a small empty rectangle for marks without a label
- fixes drawing of marks in vertical orientation in legacy waveforms
- fixes a small bug with hovering over marks (propagate leave event)
- uses antialiasing to render the marks and the glsl play position mark image

<img width="786" alt="Screenshot 2023-10-21 at 03 34 09" src="https://github.com/mixxxdj/mixxx/assets/79429057/5727b3d4-008d-4dc1-9ebf-ceb4e738e193">
