### PR TITLE
make scaling of GLSL RGB and RGB L/R waveform amplitudes consistent with simple waveform

### DIFF
--- a/src/waveform/renderers/allshader/waveformrendererlrrgb.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererlrrgb.cpp
@@ -160,23 +160,25 @@ void WaveformRendererLRRGB::paintGL() {
             float maxHigh = static_cast<float>(u8maxHigh);
             float maxAll = static_cast<float>(u8maxAll);
 
-            // Calculate the magnitude of the maxLow, maxMid and maxHigh values
-            const float magnitude = std::sqrt(
-                    math_pow2(maxLow) + math_pow2(maxMid) + math_pow2(maxHigh));
+            // Calculate the squared magnitude of the maxLow, maxMid and maxHigh values.
+            // We take the square root to get the magnitude below.
+            const float sum = math_pow2(maxLow) + math_pow2(maxMid) + math_pow2(maxHigh);
 
             // Apply the gains
             maxLow *= lowGain;
             maxMid *= midGain;
             maxHigh *= highGain;
 
-            // Calculate the magnitude of the gained maxLow, maxMid and maxHigh values
-            const float magnitudeGained = std::sqrt(
-                    math_pow2(maxLow) + math_pow2(maxMid) + math_pow2(maxHigh));
+            // Calculate the squared magnitude of the gained maxLow, maxMid and maxHigh values
+            // We take the square root to get the magnitude below.
+            const float sumGained = math_pow2(maxLow) + math_pow2(maxMid) + math_pow2(maxHigh);
 
             // The maxAll value will be used to draw the amplitude. We scale them according to
             // magnitude of the gained maxLow, maxMid and maxHigh values
-            if (magnitude != 0.f) {
-                const float factor = magnitudeGained / magnitude;
+            if (sum != 0.f) {
+                // magnitude = sqrt(sum) and magnitudeGained = sqrt(sumGained), and
+                // factor = magnitudeGained / magnitude, but we can do with a single sqrt:
+                const float factor = std::sqrt(sumGained / sum);
                 maxAll *= factor;
             }
 

--- a/src/waveform/renderers/allshader/waveformrendererlrrgb.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererlrrgb.cpp
@@ -55,17 +55,15 @@ void WaveformRendererLRRGB::paintGL() {
     const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
     const int length = static_cast<int>(m_waveformRenderer->getLength() * devicePixelRatio);
 
-    // Not multiplying with devicePixelRatio will also work. In that case, on
-    // High-DPI-Display the lines will be devicePixelRatio pixels wide (which is
-    // also what is used for the beat grid and the markers), or in other words
-    // each block of samples is represented by devicePixelRatio pixels (width).
+    const int visualFramesSize = dataSize / 2;
+    const double firstVisualFrame =
+            m_waveformRenderer->getFirstDisplayedPosition() * visualFramesSize;
+    const double lastVisualFrame =
+            m_waveformRenderer->getLastDisplayedPosition() * visualFramesSize;
 
-    const double firstVisualIndex = m_waveformRenderer->getFirstDisplayedPosition() * dataSize;
-    const double lastVisualIndex = m_waveformRenderer->getLastDisplayedPosition() * dataSize;
-
-    // Represents the # of waveform data points per horizontal pixel.
+    // Represents the # of visual frames per horizontal pixel.
     const double visualIncrementPerPixel =
-            (lastVisualIndex - firstVisualIndex) / static_cast<double>(length);
+            (lastVisualFrame - firstVisualFrame) / static_cast<double>(length);
 
     // Per-band gain from the EQ knobs.
     float allGain(1.0), lowGain(1.0), midGain(1.0), highGain(1.0);
@@ -87,8 +85,8 @@ void WaveformRendererLRRGB::paintGL() {
     const float mid_b = static_cast<float>(m_rgbMidColor_b);
     const float high_b = static_cast<float>(m_rgbHighColor_b);
 
-    // Effective visual index of x
-    double xVisualSampleIndex = firstVisualIndex;
+    // Effective visual frame for x
+    double xVisualFrame = firstVisualFrame;
 
     const int numVerticesPerLine = 6; // 2 triangles
 
@@ -108,33 +106,17 @@ void WaveformRendererLRRGB::paintGL() {
             static_cast<float>(m_axesColor_g),
             static_cast<float>(m_axesColor_b));
 
+    double maxSamplingRange = visualIncrementPerPixel / 2.0;
+
     for (int pos = 0; pos < length; ++pos) {
-        // Our current pixel (x) corresponds to a number of visual samples
-        // (visualSamplerPerPixel) in our waveform object. We take the max of
-        // all the data points on either side of xVisualSampleIndex within a
-        // window of 'maxSamplingRange' visual samples to measure the maximum
-        // data point contained by this pixel.
-        double maxSamplingRange = visualIncrementPerPixel / 2.0;
+        const int visualFrameStart = int(xVisualFrame - maxSamplingRange + 0.5);
+        const int visualFrameStop = int(xVisualFrame + maxSamplingRange + 0.5);
 
-        // Since xVisualSampleIndex is in visual-samples (e.g. R,L,R,L) we want
-        // to check +/- maxSamplingRange frames, not samples. To do this, divide
-        // xVisualSampleIndex by 2. Since frames indices are integers, we round
-        // to the nearest integer by adding 0.5 before casting to int.
-        int visualFrameStart = int(xVisualSampleIndex / 2.0 - maxSamplingRange + 0.5);
-        int visualFrameStop = int(xVisualSampleIndex / 2.0 + maxSamplingRange + 0.5);
-        const int lastVisualFrame = dataSize / 2 - 1;
-
-        // We now know that some subset of [visualFrameStart, visualFrameStop]
-        // lies within the valid range of visual frames. Clamp
-        // visualFrameStart/Stop to within [0, lastVisualFrame].
-        visualFrameStart = math_clamp(visualFrameStart, 0, lastVisualFrame);
-        visualFrameStop = math_clamp(visualFrameStop, 0, lastVisualFrame);
-
-        int visualIndexStart = visualFrameStart * 2;
-        int visualIndexStop = visualFrameStop * 2;
-
-        visualIndexStart = std::max(visualIndexStart, 0);
-        visualIndexStop = std::min(visualIndexStop, dataSize);
+        const int visualIndexStart = math_clamp(visualFrameStart * 2, 0, dataSize - 1);
+        const int visualIndexStop =
+                math_clamp(std::max(visualFrameStart + 1, visualFrameStop) * 2,
+                        0,
+                        dataSize - 1);
 
         const float fpos = static_cast<float>(pos);
 
@@ -211,7 +193,7 @@ void WaveformRendererLRRGB::paintGL() {
             m_colors.addForRectangle(red, green, blue);
         }
 
-        xVisualSampleIndex += visualIncrementPerPixel;
+        xVisualFrame += visualIncrementPerPixel;
     }
 
     DEBUG_ASSERT(reserved == m_vertices.size());

--- a/src/waveform/renderers/allshader/waveformrendererrgb.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererrgb.cpp
@@ -156,19 +156,11 @@ void WaveformRendererRGB::paintGL() {
             }
         }
 
-        float maxLow;
-        float maxMid;
-        float maxHigh;
-        float maxAllChn[2];
-
         // Cast to float
-        maxLow = static_cast<float>(u8maxLow);
-        maxMid = static_cast<float>(u8maxMid);
-        maxHigh = static_cast<float>(u8maxHigh);
-        maxAllChn[0] = static_cast<float>(u8maxAllChn[0]);
-        maxAllChn[1] = static_cast<float>(u8maxAllChn[1]);
-
-        float maxAll = math_max(maxAllChn[0], maxAllChn[1]);
+        float maxLow = static_cast<float>(u8maxLow);
+        float maxMid = static_cast<float>(u8maxMid);
+        float maxHigh = static_cast<float>(u8maxHigh);
+        float maxAllChn[2]{static_cast<float>(u8maxAllChn[0]), static_cast<float>(u8maxAllChn[1])};
 
         // Calculate the magnitude of the maxLow, maxMid and maxHigh values
         const float magnitude = std::sqrt(

--- a/src/waveform/renderers/allshader/waveformrendererrgb.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererrgb.cpp
@@ -162,23 +162,25 @@ void WaveformRendererRGB::paintGL() {
         float maxHigh = static_cast<float>(u8maxHigh);
         float maxAllChn[2]{static_cast<float>(u8maxAllChn[0]), static_cast<float>(u8maxAllChn[1])};
 
-        // Calculate the magnitude of the maxLow, maxMid and maxHigh values
-        const float magnitude = std::sqrt(
-                math_pow2(maxLow) + math_pow2(maxMid) + math_pow2(maxHigh));
+        // Calculate the squared magnitude of the maxLow, maxMid and maxHigh values.
+        // We take the square root to get the magnitude below.
+        const float sum = math_pow2(maxLow) + math_pow2(maxMid) + math_pow2(maxHigh);
 
         // Apply the gains
         maxLow *= lowGain;
         maxMid *= midGain;
         maxHigh *= highGain;
 
-        // Calculate the magnitude of the gained maxLow, maxMid and maxHigh values
-        const float magnitudeGained = std::sqrt(
-                math_pow2(maxLow) + math_pow2(maxMid) + math_pow2(maxHigh));
+        // Calculate the squared magnitude of the gained maxLow, maxMid and maxHigh values
+        // We take the square root to get the magnitude below.
+        const float sumGained = math_pow2(maxLow) + math_pow2(maxMid) + math_pow2(maxHigh);
 
         // The maxAll values will be used to draw the amplitude. We scale them according to
         // magnitude of the gained maxLow, maxMid and maxHigh values
-        if (magnitude != 0.f) {
-            const float factor = magnitudeGained / magnitude;
+        if (sum != 0.f) {
+            // magnitude = sqrt(sum) and magnitudeGained = sqrt(sumGained), and
+            // factor = magnitudeGained / magnitude, but we can do with a single sqrt:
+            const float factor = std::sqrt(sumGained / sum);
             maxAllChn[0] *= factor;
             maxAllChn[1] *= factor;
         }


### PR DESCRIPTION
As pointed out by @ronso0 in https://github.com/mixxxdj/mixxx/issues/12115 , the amplitudes of the waveform rendering is inconsistent between waveform types. I discuss the cause there.

This PR fixes the scaling, so the waveform amplitudes are the same as the simple waveform (when gains are 0), while still maintaining the adaptation of the waveform amplitude to the low/mid/high gains, by scaling the amplitude as drawn with the ratio between the low+mid+high magnitude with gains applies and without gains applied.

(Note that the wrong scaling is still present in the legacy waveforms. I will not fix those)

See https://github.com/mixxxdj/mixxx/issues/12115 for some screenshots that show the issue before this fix. With this fix, compare Simple with RGB and RGB L/R.
<img width="800" alt="simple" src="https://github.com/mixxxdj/mixxx/assets/79429057/1bda409e-b256-4344-a140-8cb900fc03d7">
<img width="800" alt="RGB" src="https://github.com/mixxxdj/mixxx/assets/79429057/b1cd088c-8bc5-47f7-8128-5be19ea9d8bb">
<img width="800" alt="RGBLR" src="https://github.com/mixxxdj/mixxx/assets/79429057/ce2878f6-e8b3-4d46-9ff1-28db2d69e51a">

This is RGB and RGB L/R with some gain applied (high and low bands turned down)

<img width="800" alt="RGBgained" src="https://github.com/mixxxdj/mixxx/assets/79429057/c4dbd408-cb41-4db3-be22-faa9acb2b958">
<img width="800" alt="RGBLRgained" src="https://github.com/mixxxdj/mixxx/assets/79429057/e0cfbe5b-08b3-48a6-9328-e41e70e8753d">


