### PR TITLE
common HID: always return the passed-in group in case of error

### DIFF
--- a/res/controllers/common-hid-packet-parser.js
+++ b/res/controllers/common-hid-packet-parser.js
@@ -1344,7 +1344,6 @@ class HIDController {
             if (this.activeDeck === 3 || this.activeDeck === 4) {
                 return "[Channel3]";
             }
-            return undefined;
         } else if (group === "deck2") {
             if (this.activeDeck === 1 || this.activeDeck === 2) {
                 return "[Channel2]";
@@ -1352,7 +1351,6 @@ class HIDController {
             if (this.activeDeck === 3 || this.activeDeck === 4) {
                 return "[Channel4]";
             }
-            return undefined;
         }
         return group;
     }


### PR DESCRIPTION
The previous controller fix would return undefined if activedeck was not set, but that was not consistent with previous behavior.

As an aside the activedeck logic appears to be broken, because it is per-controller instead of per-deck. Many controllers have two decks, each with their own activedeck selector, and that currently is not supported by the library. A future fix should address this issue but is out of scope to unbreak controller configs for 2.4