### PR TITLE
WTrackMenu: create only on demand for deck widgets

### DIFF
--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -35,8 +35,7 @@ WTrackProperty::WTrackProperty(
         : WLabel(pParent),
           m_group(group),
           m_pConfig(pConfig),
-          m_pTrackMenu(make_parented<WTrackMenu>(
-                  this, pConfig, pLibrary, kTrackMenuFeatures)) {
+          m_pLibrary(pLibrary) {
     setAcceptDrops(true);
 }
 
@@ -102,6 +101,7 @@ void WTrackProperty::mouseMoveEvent(QMouseEvent* event) {
 void WTrackProperty::mouseDoubleClickEvent(QMouseEvent* event) {
     Q_UNUSED(event);
     if (m_pCurrentTrack) {
+        ensureTrackMenuIsCreated();
         m_pTrackMenu->loadTrack(m_pCurrentTrack, m_group);
         m_pTrackMenu->showDlgTrackInfo(m_property);
     }
@@ -118,8 +118,16 @@ void WTrackProperty::dropEvent(QDropEvent* event) {
 void WTrackProperty::contextMenuEvent(QContextMenuEvent* event) {
     event->accept();
     if (m_pCurrentTrack) {
+        ensureTrackMenuIsCreated();
         m_pTrackMenu->loadTrack(m_pCurrentTrack, m_group);
         // Create the right-click menu
         m_pTrackMenu->popup(event->globalPos());
+    }
+}
+
+void WTrackProperty::ensureTrackMenuIsCreated() {
+    if (m_pTrackMenu.get() == nullptr) {
+        m_pTrackMenu = make_parented<WTrackMenu>(
+                this, m_pConfig, m_pLibrary, kTrackMenuFeatures);
     }
 }

--- a/src/widget/wtrackproperty.h
+++ b/src/widget/wtrackproperty.h
@@ -49,10 +49,13 @@ private:
 
   void updateLabel();
 
+  void ensureTrackMenuIsCreated();
+
   const QString m_group;
   const UserSettingsPointer m_pConfig;
+  Library* m_pLibrary;
   TrackPointer m_pCurrentTrack;
   QString m_property;
 
-  const parented_ptr<WTrackMenu> m_pTrackMenu;
+  parented_ptr<WTrackMenu> m_pTrackMenu;
 };

--- a/src/widget/wtracktext.cpp
+++ b/src/widget/wtracktext.cpp
@@ -33,8 +33,7 @@ WTrackText::WTrackText(QWidget* pParent,
         : WLabel(pParent),
           m_group(group),
           m_pConfig(pConfig),
-          m_pTrackMenu(make_parented<WTrackMenu>(
-                  this, pConfig, pLibrary, kTrackMenuFeatures)) {
+          m_pLibrary(pLibrary) {
     setAcceptDrops(true);
 }
 
@@ -86,6 +85,7 @@ void WTrackText::mouseMoveEvent(QMouseEvent *event) {
 void WTrackText::mouseDoubleClickEvent(QMouseEvent* event) {
     Q_UNUSED(event);
     if (m_pCurrentTrack) {
+        ensureTrackMenuIsCreated();
         m_pTrackMenu->loadTrack(m_pCurrentTrack, m_group);
         m_pTrackMenu->slotShowDlgTrackInfo();
     }
@@ -102,8 +102,15 @@ void WTrackText::dropEvent(QDropEvent *event) {
 void WTrackText::contextMenuEvent(QContextMenuEvent* event) {
     event->accept();
     if (m_pCurrentTrack) {
+        ensureTrackMenuIsCreated();
         m_pTrackMenu->loadTrack(m_pCurrentTrack, m_group);
-        // Create the right-click menu
         m_pTrackMenu->popup(event->globalPos());
+    }
+}
+
+void WTrackText::ensureTrackMenuIsCreated() {
+    if (m_pTrackMenu.get() == nullptr) {
+        m_pTrackMenu = make_parented<WTrackMenu>(
+                this, m_pConfig, m_pLibrary, kTrackMenuFeatures);
     }
 }

--- a/src/widget/wtracktext.h
+++ b/src/widget/wtracktext.h
@@ -46,8 +46,11 @@ class WTrackText : public WLabel, public TrackDropTarget {
 
     void updateLabel();
 
+    void ensureTrackMenuIsCreated();
+
     const QString m_group;
     UserSettingsPointer m_pConfig;
+    Library* m_pLibrary;
     TrackPointer m_pCurrentTrack;
-    const parented_ptr<WTrackMenu> m_pTrackMenu;
+    parented_ptr<WTrackMenu> m_pTrackMenu;
 };

--- a/src/widget/wtrackwidgetgroup.cpp
+++ b/src/widget/wtrackwidgetgroup.cpp
@@ -38,9 +38,8 @@ WTrackWidgetGroup::WTrackWidgetGroup(QWidget* pParent,
         : WWidgetGroup(pParent),
           m_group(group),
           m_pConfig(pConfig),
-          m_trackColorAlpha(kDefaultTrackColorAlpha),
-          m_pTrackMenu(make_parented<WTrackMenu>(
-                  this, pConfig, pLibrary, kTrackMenuFeatures)) {
+          m_pLibrary(pLibrary),
+          m_trackColorAlpha(kDefaultTrackColorAlpha) {
     setAcceptDrops(true);
 }
 
@@ -125,8 +124,16 @@ void WTrackWidgetGroup::dropEvent(QDropEvent* event) {
 void WTrackWidgetGroup::contextMenuEvent(QContextMenuEvent* event) {
     event->accept();
     if (m_pCurrentTrack) {
+        ensureTrackMenuIsCreated();
         m_pTrackMenu->loadTrack(m_pCurrentTrack, m_group);
         // Create the right-click menu
         m_pTrackMenu->popup(event->globalPos());
+    }
+}
+
+void WTrackWidgetGroup::ensureTrackMenuIsCreated() {
+    if (m_pTrackMenu.get() == nullptr) {
+        m_pTrackMenu = make_parented<WTrackMenu>(
+                this, m_pConfig, m_pLibrary, kTrackMenuFeatures);
     }
 }

--- a/src/widget/wtrackwidgetgroup.h
+++ b/src/widget/wtrackwidgetgroup.h
@@ -42,11 +42,14 @@ class WTrackWidgetGroup : public WWidgetGroup, public TrackDropTarget {
 
     void updateColor();
 
+    void ensureTrackMenuIsCreated();
+
     const QString m_group;
     const UserSettingsPointer m_pConfig;
+    Library* m_pLibrary;
     TrackPointer m_pCurrentTrack;
     QColor m_trackColor;
     int m_trackColorAlpha;
 
-    const parented_ptr<WTrackMenu> m_pTrackMenu;
+    parented_ptr<WTrackMenu> m_pTrackMenu;
 };


### PR DESCRIPTION
There is no need to create a track menu for each WTrackProperty, WTrackText and WTrackWidgetGroup in 4 decks and 16 or more samplers.

For me this results in 10% shorter startup time, so I think the acceleration will be noticable on slower machines.
* before: 5.1 -> now: 4.5 seconds, core i7 gen8, ondemand scheduler, 4 decks, 8 samplers

The first call to open a track menu in the decks will take a bit longer, though I'm not sure if that is noticable/will be noticed.