### PR TITLE
WTrackMenu: provide the same features in all deck track widgets

### DIFF
--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -47,6 +47,8 @@
 #include "widget/wsearchrelatedtracksmenu.h"
 #include "widget/wstarrating.h"
 
+constexpr WTrackMenu::Features WTrackMenu::kDeckTrackMenuFeatures;
+
 namespace {
 const QString kAppGroup = QStringLiteral("[App]");
 } // namespace

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -63,6 +63,24 @@ class WTrackMenu : public QMenu {
     };
     Q_DECLARE_FLAGS(Features, Feature)
 
+    // Make all deck track widgets provide the same features.
+    // Used by WTrackProperty, WTrackText & WTrackWidgetGroup.
+    static constexpr WTrackMenu::Features kDeckTrackMenuFeatures{
+            WTrackMenu::Feature::SearchRelated |
+            WTrackMenu::Feature::Playlist |
+            WTrackMenu::Feature::Crate |
+            WTrackMenu::Feature::Metadata |
+            WTrackMenu::Feature::Reset |
+            WTrackMenu::Feature::Analyze |
+            WTrackMenu::Feature::BPM |
+            WTrackMenu::Feature::Color |
+            WTrackMenu::Feature::RemoveFromDisk |
+            WTrackMenu::Feature::FileBrowser |
+            WTrackMenu::Feature::Properties |
+            WTrackMenu::Feature::UpdateReplayGainFromPregain |
+            WTrackMenu::Feature::FindOnWeb |
+            WTrackMenu::Feature::SelectInLibrary};
+
     WTrackMenu(QWidget* parent,
             UserSettingsPointer pConfig,
             Library* pLibrary,

--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -8,24 +8,6 @@
 #include "util/dnd.h"
 #include "widget/wtrackmenu.h"
 
-namespace {
-constexpr WTrackMenu::Features kTrackMenuFeatures =
-        WTrackMenu::Feature::SearchRelated |
-        WTrackMenu::Feature::Playlist |
-        WTrackMenu::Feature::Crate |
-        WTrackMenu::Feature::Metadata |
-        WTrackMenu::Feature::Reset |
-        WTrackMenu::Feature::Analyze |
-        WTrackMenu::Feature::BPM |
-        WTrackMenu::Feature::Color |
-        WTrackMenu::Feature::RemoveFromDisk |
-        WTrackMenu::Feature::FileBrowser |
-        WTrackMenu::Feature::Properties |
-        WTrackMenu::Feature::UpdateReplayGainFromPregain |
-        WTrackMenu::Feature::FindOnWeb |
-        WTrackMenu::Feature::SelectInLibrary;
-} // namespace
-
 WTrackProperty::WTrackProperty(
         QWidget* pParent,
         UserSettingsPointer pConfig,
@@ -137,6 +119,6 @@ void WTrackProperty::contextMenuEvent(QContextMenuEvent* event) {
 void WTrackProperty::ensureTrackMenuIsCreated() {
     if (m_pTrackMenu.get() == nullptr) {
         m_pTrackMenu = make_parented<WTrackMenu>(
-                this, m_pConfig, m_pLibrary, kTrackMenuFeatures);
+                this, m_pConfig, m_pLibrary, WTrackMenu::kDeckTrackMenuFeatures);
     }
 }

--- a/src/widget/wtrackwidgetgroup.cpp
+++ b/src/widget/wtrackwidgetgroup.cpp
@@ -12,21 +12,6 @@ namespace {
 
 constexpr int kDefaultTrackColorAlpha = 255;
 
-constexpr WTrackMenu::Features kTrackMenuFeatures =
-        WTrackMenu::Feature::SearchRelated |
-        WTrackMenu::Feature::Playlist |
-        WTrackMenu::Feature::Crate |
-        WTrackMenu::Feature::Metadata |
-        WTrackMenu::Feature::Reset |
-        WTrackMenu::Feature::Analyze |
-        WTrackMenu::Feature::BPM |
-        WTrackMenu::Feature::Color |
-        WTrackMenu::Feature::FileBrowser |
-        WTrackMenu::Feature::Properties |
-        WTrackMenu::Feature::UpdateReplayGainFromPregain |
-        WTrackMenu::Feature::FindOnWeb |
-        WTrackMenu::Feature::SelectInLibrary;
-
 } // anonymous namespace
 
 WTrackWidgetGroup::WTrackWidgetGroup(QWidget* pParent,
@@ -132,6 +117,6 @@ void WTrackWidgetGroup::contextMenuEvent(QContextMenuEvent* event) {
 void WTrackWidgetGroup::ensureTrackMenuIsCreated() {
     if (m_pTrackMenu.get() == nullptr) {
         m_pTrackMenu = make_parented<WTrackMenu>(
-                this, m_pConfig, m_pLibrary, kTrackMenuFeatures);
+                this, m_pConfig, m_pLibrary, WTrackMenu::kDeckTrackMenuFeatures);
     }
 }


### PR DESCRIPTION
Same features for WTrackProperty, WTrackText & WTrackWidgetGroup.

Btw I'm missing 'Hide' in decks (+ Unhide, for completeness), but that requires quite some changes since it's currently done via the track model.