### PR TITLE
new rate range controls: rateRange_next / _prev / _select

### DIFF
--- a/src/engine/controls/ratecontrol.cpp
+++ b/src/engine/controls/ratecontrol.cpp
@@ -34,108 +34,131 @@ RateControl::RateControl(const QString& group,
         UserSettingsPointer pConfig)
         : EngineControl(group, pConfig),
           m_pBpmControl(nullptr),
+          m_pSyncMode(group, "sync_mode"),
+          m_pSlipEnabled(group, "slip_enabled"),
           m_bTempStarted(false),
           m_tempRateRatio(0.0),
           m_dRateTempRampChange(0.0) {
-    m_pScratchController = new PositionScratchController(group);
+    m_pScratchController = std::make_unique<PositionScratchController>(group);
 
     // This is the resulting rate ratio that can be used for display or calculations.
     // The track original rate ratio is 1.
-    m_pRateRatio = new ControlObject(ConfigKey(group, "rate_ratio"),
-                  true, false, false, 1.0);
-    connect(m_pRateRatio, &ControlObject::valueChanged,
-            this, &RateControl::slotRateRatioChanged,
+    m_pRateRatio = std::make_unique<ControlObject>(ConfigKey(group, "rate_ratio"),
+            true,
+            false,
+            false,
+            1.0);
+    connect(m_pRateRatio.get(),
+            &ControlObject::valueChanged,
+            this,
+            &RateControl::slotRateRatioChanged,
             Qt::DirectConnection);
 
-    m_pRateDir = new ControlObject(ConfigKey(group, "rate_dir"));
-    connect(m_pRateDir, &ControlObject::valueChanged,
-            this, &RateControl::slotRateRangeChanged,
+    m_pRateDir = std::make_unique<ControlObject>(ConfigKey(group, "rate_dir"));
+    connect(m_pRateDir.get(),
+            &ControlObject::valueChanged,
+            this,
+            &RateControl::slotRateRangeChanged,
             Qt::DirectConnection);
-    m_pRateRange = new ControlPotmeter(
+    m_pRateRange = std::make_unique<ControlPotmeter>(
             ConfigKey(group, "rateRange"), 0.01, 4.00);
-    connect(m_pRateRange, &ControlObject::valueChanged,
+    connect(m_pRateRange.get(), &ControlObject::valueChanged,
             this, &RateControl::slotRateRangeChanged,
             Qt::DirectConnection);
 
     // Allow rate slider to go out of bounds so that sync lock rate
     // adjustments are not capped.
-    m_pRateSlider = new ControlPotmeter(
+    m_pRateSlider = std::make_unique<ControlPotmeter>(
             ConfigKey(group, "rate"), -1.0, 1.0, true);
-    connect(m_pRateSlider, &ControlObject::valueChanged,
-            this, &RateControl::slotRateSliderChanged,
+    connect(m_pRateSlider.get(),
+            &ControlObject::valueChanged,
+            this,
+            &RateControl::slotRateSliderChanged,
             Qt::DirectConnection);
 
     // Search rate. Rate used when searching in sound. This overrules the
     // playback rate
-    m_pRateSearch = new ControlPotmeter(ConfigKey(group, "rateSearch"), -300., 300.);
+    m_pRateSearch = std::make_unique<ControlPotmeter>(ConfigKey(group, "rateSearch"), -300., 300.);
 
     // Reverse button
-    m_pReverseButton = new ControlPushButton(ConfigKey(group, "reverse"));
+    m_pReverseButton = std::make_unique<ControlPushButton>(ConfigKey(group, "reverse"));
     m_pReverseButton->set(0);
 
     // Forward button
-    m_pForwardButton = new ControlPushButton(ConfigKey(group, "fwd"));
-    connect(m_pForwardButton, &ControlObject::valueChanged,
-            this, &RateControl::slotControlFastForward,
+    m_pForwardButton = std::make_unique<ControlPushButton>(ConfigKey(group, "fwd"));
+    connect(m_pForwardButton.get(),
+            &ControlObject::valueChanged,
+            this,
+            &RateControl::slotControlFastForward,
             Qt::DirectConnection);
     m_pForwardButton->set(0);
 
     // Back button
-    m_pBackButton = new ControlPushButton(ConfigKey(group, "back"));
-    connect(m_pBackButton, &ControlObject::valueChanged,
-            this, &RateControl::slotControlFastBack,
+    m_pBackButton = std::make_unique<ControlPushButton>(ConfigKey(group, "back"));
+    connect(m_pBackButton.get(),
+            &ControlObject::valueChanged,
+            this,
+            &RateControl::slotControlFastBack,
             Qt::DirectConnection);
     m_pBackButton->set(0);
 
-    m_pReverseRollButton = new ControlPushButton(ConfigKey(group, "reverseroll"));
-    connect(m_pReverseRollButton, &ControlObject::valueChanged,
-            this, &RateControl::slotReverseRollActivate,
+    m_pReverseRollButton = std::make_unique<ControlPushButton>(ConfigKey(group, "reverseroll"));
+    connect(m_pReverseRollButton.get(),
+            &ControlObject::valueChanged,
+            this,
+            &RateControl::slotReverseRollActivate,
             Qt::DirectConnection);
 
-    m_pSlipEnabled = new ControlProxy(group, "slip_enabled", this);
-
-    m_pVCEnabled = ControlObject::getControl(ConfigKey(getGroup(), "vinylcontrol_enabled"));
-    m_pVCScratching = ControlObject::getControl(ConfigKey(getGroup(), "vinylcontrol_scratching"));
-    m_pVCMode = ControlObject::getControl(ConfigKey(getGroup(), "vinylcontrol_mode"));
+    m_pVCEnabled = ControlObject::getControl(ConfigKey(group, "vinylcontrol_enabled"));
+    m_pVCScratching = ControlObject::getControl(ConfigKey(group, "vinylcontrol_scratching"));
+    m_pVCMode = ControlObject::getControl(ConfigKey(group, "vinylcontrol_mode"));
 
     // Permanent rate-change buttons
     m_pButtonRatePermDown =
-        new ControlPushButton(ConfigKey(group,"rate_perm_down"));
-    connect(m_pButtonRatePermDown, &ControlObject::valueChanged,
-            this, &RateControl::slotControlRatePermDown,
+            std::make_unique<ControlPushButton>(ConfigKey(group, "rate_perm_down"));
+    connect(m_pButtonRatePermDown.get(),
+            &ControlObject::valueChanged,
+            this,
+            &RateControl::slotControlRatePermDown,
             Qt::DirectConnection);
     m_pButtonRatePermDown->setKbdRepeatable(true);
 
     m_pButtonRatePermDownSmall =
-        new ControlPushButton(ConfigKey(group,"rate_perm_down_small"));
-    connect(m_pButtonRatePermDownSmall, &ControlObject::valueChanged,
-            this, &RateControl::slotControlRatePermDownSmall,
+            std::make_unique<ControlPushButton>(ConfigKey(group, "rate_perm_down_small"));
+    connect(m_pButtonRatePermDownSmall.get(),
+            &ControlObject::valueChanged,
+            this,
+            &RateControl::slotControlRatePermDownSmall,
             Qt::DirectConnection);
     m_pButtonRatePermDownSmall->setKbdRepeatable(true);
 
     m_pButtonRatePermUp =
-        new ControlPushButton(ConfigKey(group,"rate_perm_up"));
-    connect(m_pButtonRatePermUp, &ControlObject::valueChanged,
-            this, &RateControl::slotControlRatePermUp,
+            std::make_unique<ControlPushButton>(ConfigKey(group, "rate_perm_up"));
+    connect(m_pButtonRatePermUp.get(),
+            &ControlObject::valueChanged,
+            this,
+            &RateControl::slotControlRatePermUp,
             Qt::DirectConnection);
     m_pButtonRatePermUp->setKbdRepeatable(true);
 
     m_pButtonRatePermUpSmall =
-        new ControlPushButton(ConfigKey(group,"rate_perm_up_small"));
-    connect(m_pButtonRatePermUpSmall, &ControlObject::valueChanged,
-            this, &RateControl::slotControlRatePermUpSmall,
+            std::make_unique<ControlPushButton>(ConfigKey(group, "rate_perm_up_small"));
+    connect(m_pButtonRatePermUpSmall.get(),
+            &ControlObject::valueChanged,
+            this,
+            &RateControl::slotControlRatePermUpSmall,
             Qt::DirectConnection);
     m_pButtonRatePermUpSmall->setKbdRepeatable(true);
 
     // Temporary rate-change buttons
     m_pButtonRateTempDown =
-        new ControlPushButton(ConfigKey(group,"rate_temp_down"));
+            std::make_unique<ControlPushButton>(ConfigKey(group, "rate_temp_down"));
     m_pButtonRateTempDownSmall =
-        new ControlPushButton(ConfigKey(group,"rate_temp_down_small"));
+            std::make_unique<ControlPushButton>(ConfigKey(group, "rate_temp_down_small"));
     m_pButtonRateTempUp =
-        new ControlPushButton(ConfigKey(group,"rate_temp_up"));
+            std::make_unique<ControlPushButton>(ConfigKey(group, "rate_temp_up"));
     m_pButtonRateTempUpSmall =
-        new ControlPushButton(ConfigKey(group,"rate_temp_up_small"));
+            std::make_unique<ControlPushButton>(ConfigKey(group, "rate_temp_up_small"));
 
     // We need the sample rate so we can guesstimate something close
     // what latency is.
@@ -143,26 +166,25 @@ RateControl::RateControl(const QString& group,
             ConfigKey(QStringLiteral("[App]"), QStringLiteral("samplerate")));
 
     // Wheel to control playback position/speed
-    m_pWheel = new ControlTTRotary(ConfigKey(group, "wheel"));
+    m_pWheel = std::make_unique<ControlTTRotary>(ConfigKey(group, "wheel"));
 
     // Scratch controller, this is an accumulator which is useful for
     // controllers that return individual +1 or -1s, these get added up and
     // cleared when we read
-    m_pScratch2 = new ControlObject(ConfigKey(group, "scratch2"));
+    m_pScratch2 = std::make_unique<ControlObject>(ConfigKey(group, "scratch2"));
 
     // Scratch enable toggle
-    m_pScratch2Enable = new ControlPushButton(ConfigKey(group, "scratch2_enable"));
+    m_pScratch2Enable = std::make_unique<ControlPushButton>(ConfigKey(group, "scratch2_enable"));
     m_pScratch2Enable->set(0);
 
-    m_pScratch2Scratching = new ControlPushButton(ConfigKey(group,
-                                                            "scratch2_indicates_scratching"));
+    m_pScratch2Scratching = std::make_unique<ControlPushButton>(ConfigKey(group,
+            "scratch2_indicates_scratching"));
     // Enable by default, because it was always scratching before introducing
     // this control.
     m_pScratch2Scratching->set(1.0);
 
-
-    m_pJog = new ControlObject(ConfigKey(group, "jog"));
-    m_pJogFilter = new Rotary();
+    m_pJog = std::make_unique<ControlObject>(ConfigKey(group, "jog"));
+    m_pJogFilter = std::make_unique<Rotary>();
     // FIXME: This should be dependent on sample rate/block size or something
     m_pJogFilter->setFilterLength(25);
 
@@ -175,40 +197,6 @@ RateControl::RateControl(const QString& group,
 //     // Set the Sensitivity
 //     m_iRateRampSensitivity =
 //             getConfig()->getValueString(ConfigKey("[Controls]","RateRampSensitivity")).toInt();
-
-    m_pSyncMode = new ControlProxy(group, "sync_mode", this);
-}
-
-RateControl::~RateControl() {
-    delete m_pRateRatio;
-    delete m_pRateSlider;
-    delete m_pRateRange;
-    delete m_pRateDir;
-    delete m_pSyncMode;
-
-    delete m_pRateSearch;
-
-    delete m_pReverseButton;
-    delete m_pReverseRollButton;
-    delete m_pForwardButton;
-    delete m_pBackButton;
-
-    delete m_pButtonRateTempDown;
-    delete m_pButtonRateTempDownSmall;
-    delete m_pButtonRateTempUp;
-    delete m_pButtonRateTempUpSmall;
-    delete m_pButtonRatePermDown;
-    delete m_pButtonRatePermDownSmall;
-    delete m_pButtonRatePermUp;
-    delete m_pButtonRatePermUpSmall;
-
-    delete m_pWheel;
-    delete m_pScratch2;
-    delete m_pScratch2Scratching;
-    delete m_pScratch2Enable;
-    delete m_pJog;
-    delete m_pJogFilter;
-    delete m_pScratchController;
 }
 
 void RateControl::setBpmControl(BpmControl* bpmcontrol) {
@@ -301,11 +289,11 @@ void RateControl::slotRateRatioChanged(double v) {
 
 void RateControl::slotReverseRollActivate(double v) {
     if (v > 0.0) {
-        m_pSlipEnabled->set(1);
+        m_pSlipEnabled.set(1);
         m_pReverseButton->set(1);
     } else {
         m_pReverseButton->set(0);
-        m_pSlipEnabled->set(0);
+        m_pSlipEnabled.set(0);
     }
 }
 
@@ -388,7 +376,7 @@ double RateControl::getJogFactor() const {
 }
 
 SyncMode RateControl::getSyncMode() const {
-    return syncModeFromDouble(m_pSyncMode->get());
+    return syncModeFromDouble(m_pSyncMode.get());
 }
 
 double RateControl::calculateSpeed(double baserate, double speed, bool paused,

--- a/src/engine/controls/ratecontrol.h
+++ b/src/engine/controls/ratecontrol.h
@@ -23,6 +23,10 @@ class PositionScratchController;
 class RateControl : public EngineControl {
     Q_OBJECT
 public:
+  static constexpr double kDefaultRateRange = 0.08;
+  static constexpr double kMinRateRange = 0.01;
+  static constexpr double kMaxRateRange = 4.0;
+
   RateControl(const QString& group, UserSettingsPointer pConfig);
 
   // Enumerations which hold the state of the pitchbend buttons.
@@ -74,7 +78,9 @@ public:
   bool isReverseButtonPressed();
 
 public slots:
-  void slotRateRangeChanged(double);
+  void slotRateDirChanged(double);
+  // accepts any value in valid range
+  void slotRateRangeChangeRequest(double value);
   void slotRateSliderChanged(double);
   void slotRateRatioChanged(double);
   void slotReverseRollActivate(double);
@@ -120,7 +126,7 @@ private:
 
   std::unique_ptr<ControlObject> m_pRateRatio;
   std::unique_ptr<ControlObject> m_pRateDir;
-  std::unique_ptr<ControlPotmeter> m_pRateRange;
+  std::unique_ptr<ControlObject> m_pRateRange;
   std::unique_ptr<ControlPotmeter> m_pRateSlider;
   std::unique_ptr<ControlPotmeter> m_pRateSearch;
   std::unique_ptr<ControlPushButton> m_pReverseButton;

--- a/src/engine/controls/ratecontrol.h
+++ b/src/engine/controls/ratecontrol.h
@@ -2,9 +2,10 @@
 
 #include <QObject>
 
-#include "preferences/usersettings.h"
+#include "control/pollingcontrolproxy.h"
 #include "engine/controls/enginecontrol.h"
 #include "engine/sync/syncable.h"
+#include "preferences/usersettings.h"
 
 class BpmControl;
 class Rotary;
@@ -23,7 +24,6 @@ class RateControl : public EngineControl {
     Q_OBJECT
 public:
   RateControl(const QString& group, UserSettingsPointer pConfig);
-  ~RateControl() override;
 
   // Enumerations which hold the state of the pitchbend buttons.
   // These enumerations can be used like a bitmask.
@@ -108,45 +108,49 @@ private:
   static ControlValueAtomic<double> m_dPermanentRateChangeCoarse;
   static ControlValueAtomic<double> m_dPermanentRateChangeFine;
 
-  ControlPushButton* m_pButtonRateTempDown;
-  ControlPushButton* m_pButtonRateTempDownSmall;
-  ControlPushButton* m_pButtonRateTempUp;
-  ControlPushButton* m_pButtonRateTempUpSmall;
+  std::unique_ptr<ControlPushButton> m_pButtonRateTempDown;
+  std::unique_ptr<ControlPushButton> m_pButtonRateTempDownSmall;
+  std::unique_ptr<ControlPushButton> m_pButtonRateTempUp;
+  std::unique_ptr<ControlPushButton> m_pButtonRateTempUpSmall;
 
-  ControlPushButton* m_pButtonRatePermDown;
-  ControlPushButton* m_pButtonRatePermDownSmall;
-  ControlPushButton* m_pButtonRatePermUp;
-  ControlPushButton* m_pButtonRatePermUpSmall;
+  std::unique_ptr<ControlPushButton> m_pButtonRatePermDown;
+  std::unique_ptr<ControlPushButton> m_pButtonRatePermDownSmall;
+  std::unique_ptr<ControlPushButton> m_pButtonRatePermUp;
+  std::unique_ptr<ControlPushButton> m_pButtonRatePermUpSmall;
 
-  ControlObject* m_pRateRatio;
-  ControlObject* m_pRateDir;
-  ControlObject* m_pRateRange;
-  ControlPotmeter* m_pRateSlider;
-  ControlPotmeter* m_pRateSearch;
-  ControlPushButton* m_pReverseButton;
-  ControlPushButton* m_pReverseRollButton;
-  ControlObject* m_pBackButton;
-  ControlObject* m_pForwardButton;
+  std::unique_ptr<ControlObject> m_pRateRatio;
+  std::unique_ptr<ControlObject> m_pRateDir;
+  std::unique_ptr<ControlPotmeter> m_pRateRange;
+  std::unique_ptr<ControlPotmeter> m_pRateSlider;
+  std::unique_ptr<ControlPotmeter> m_pRateSearch;
+  std::unique_ptr<ControlPushButton> m_pReverseButton;
+  std::unique_ptr<ControlPushButton> m_pReverseRollButton;
+  std::unique_ptr<ControlObject> m_pBackButton;
+  std::unique_ptr<ControlObject> m_pForwardButton;
 
-  ControlTTRotary* m_pWheel;
-  ControlObject* m_pScratch2;
-  PositionScratchController* m_pScratchController;
+  std::unique_ptr<ControlTTRotary> m_pWheel;
+  std::unique_ptr<ControlObject> m_pScratch2;
+  std::unique_ptr<PositionScratchController> m_pScratchController;
 
-  ControlPushButton* m_pScratch2Enable;
-  ControlObject* m_pJog;
+  std::unique_ptr<ControlPushButton> m_pScratch2Enable;
+  std::unique_ptr<ControlObject> m_pJog;
+  //  std::unique_ptr<ControlObject> m_pVCEnabled;
+  //  std::unique_ptr<ControlObject> m_pVCScratching;
+  //  std::unique_ptr<ControlObject> m_pVCMode;
   ControlObject* m_pVCEnabled;
   ControlObject* m_pVCScratching;
   ControlObject* m_pVCMode;
-  ControlObject* m_pScratch2Scratching;
-  Rotary* m_pJogFilter;
+
+  std::unique_ptr<ControlObject> m_pScratch2Scratching;
+  std::unique_ptr<Rotary> m_pJogFilter;
 
   ControlObject* m_pSampleRate;
 
   // For Sync Lock
   BpmControl* m_pBpmControl;
 
-  ControlProxy* m_pSyncMode;
-  ControlProxy* m_pSlipEnabled;
+  PollingControlProxy m_pSyncMode;
+  PollingControlProxy m_pSlipEnabled;
 
   // This is true if we've already started to ramp the rate
   bool m_bTempStarted;

--- a/src/engine/controls/ratecontrol.h
+++ b/src/engine/controls/ratecontrol.h
@@ -24,8 +24,11 @@ class RateControl : public EngineControl {
     Q_OBJECT
 public:
   static constexpr double kDefaultRateRange = 0.08;
-  static constexpr double kMinRateRange = 0.01;
-  static constexpr double kMaxRateRange = 4.0;
+  static constexpr int kMinRateRangePercent = 1;
+  static constexpr int kMaxRateRangePercent = 400;
+
+  static QMap<int, QString> s_rateRangesPercentAndTrStrings;
+  static int verifyAndMaybeAddRateRange(int range);
 
   RateControl(const QString& group, UserSettingsPointer pConfig);
 
@@ -81,6 +84,9 @@ public slots:
   void slotRateDirChanged(double);
   // accepts any value in valid range
   void slotRateRangeChangeRequest(double value);
+  void slotRateRangeNext(double value);
+  void slotRateRangePrev(double value);
+  void rateRangeSelect(int direction);
   void slotRateSliderChanged(double);
   void slotRateRatioChanged(double);
   void slotReverseRollActivate(double);
@@ -127,6 +133,9 @@ private:
   std::unique_ptr<ControlObject> m_pRateRatio;
   std::unique_ptr<ControlObject> m_pRateDir;
   std::unique_ptr<ControlObject> m_pRateRange;
+  std::unique_ptr<ControlPushButton> m_pRateRangeSelectButton;
+  std::unique_ptr<ControlPushButton> m_pRateRangeNextButton;
+  std::unique_ptr<ControlPushButton> m_pRateRangePrevButton;
   std::unique_ptr<ControlPotmeter> m_pRateSlider;
   std::unique_ptr<ControlPotmeter> m_pRateSearch;
   std::unique_ptr<ControlPushButton> m_pReverseButton;

--- a/src/preferences/dialog/dlgprefdeck.cpp
+++ b/src/preferences/dialog/dlgprefdeck.cpp
@@ -267,9 +267,7 @@ DlgPrefDeck::DlgPrefDeck(QWidget* parent, UserSettingsPointer pConfig)
     }
     setRateRangeForAllDecks(m_iRateRangePercent);
 
-    //
     // Key lock mode
-    //
     connect(buttonGroupKeyLockMode,
             QOverload<QAbstractButton*>::of(&QButtonGroup::buttonClicked),
             this,
@@ -282,9 +280,7 @@ DlgPrefDeck::DlgPrefDeck(QWidget* parent, UserSettingsPointer pConfig)
         pControl->set(static_cast<double>(m_keylockMode));
     }
 
-    //
     // Key unlock mode
-    //
     connect(buttonGroupKeyUnlockMode,
             QOverload<QAbstractButton*>::of(&QButtonGroup::buttonClicked),
             this,
@@ -297,10 +293,7 @@ DlgPrefDeck::DlgPrefDeck(QWidget* parent, UserSettingsPointer pConfig)
         pControl->set(static_cast<int>(m_keyunlockMode));
     }
 
-    //
     // Cue Mode
-    //
-
     // Add "(?)" with a manual link to the label
     labelCueMode->setText(labelCueMode->text() + QStringLiteral(" ") +
             coloredLinkString(
@@ -308,10 +301,7 @@ DlgPrefDeck::DlgPrefDeck(QWidget* parent, UserSettingsPointer pConfig)
                     QStringLiteral("(?)"),
                     MIXXX_MANUAL_CUE_MODES_URL));
 
-    //
     // Speed / Pitch reset configuration
-    //
-
     // Update "reset speed" and "reset pitch" check boxes
     // TODO: All defaults should only be set in slotResetToDefaults.
     int configSPAutoReset = m_pConfig->getValue<int>(
@@ -329,10 +319,7 @@ DlgPrefDeck::DlgPrefDeck(QWidget* parent, UserSettingsPointer pConfig)
     connect(checkBoxResetSpeed, &QCheckBox::toggled, this, &DlgPrefDeck::slotUpdateSpeedAutoReset);
     connect(checkBoxResetPitch, &QCheckBox::toggled, this, &DlgPrefDeck::slotUpdatePitchAutoReset);
 
-    //
     // Ramping Temporary Rate Change configuration
-    //
-
     // Rate Ramp Sensitivity slider & spinbox
     connect(SliderRateRampSensitivity,
             QOverload<int>::of(&QAbstractSlider::valueChanged),

--- a/src/preferences/dialog/dlgprefdeck.cpp
+++ b/src/preferences/dialog/dlgprefdeck.cpp
@@ -4,6 +4,7 @@
 #include <QDoubleSpinBox>
 #include <QList>
 #include <QLocale>
+#include <QMap>
 #include <QToolTip>
 #include <QWidget>
 
@@ -22,6 +23,7 @@
 
 namespace {
 constexpr int kDefaultRateRangePercent = static_cast<int>(RateControl::kDefaultRateRange * 100);
+constexpr int kInvalidRateRangePercent = -1;
 constexpr double kRateDirectionInverted = -1;
 constexpr RateControl::RampMode kDefaultRampingMode = RateControl::RampMode::Stepping;
 constexpr double kDefaultTemporaryRateChangeCoarse = 4.00; // percent
@@ -233,42 +235,25 @@ DlgPrefDeck::DlgPrefDeck(QWidget* parent, UserSettingsPointer pConfig)
             this,
             &DlgPrefDeck::slotRateInversionCheckbox);
 
+    // Rate range
+    int rateRangePercent = m_pConfig->getValue(ConfigKey("[Controls]", "RateRangePercent"),
+            kDefaultRateRangePercent);
+    // Might be a custom range. Clamp to valid range.
+    rateRangePercent = RateControl::verifyAndMaybeAddRateRange(rateRangePercent);
+    // Apply it to all decks. This resets all previous individual (per deck) ranges
+    // and maybe adds a custom range to RateControl::s_rateRangesPercentAndTrStrings.
+    setRateRangeForAllDecks(rateRangePercent);
+    // Now populate the combobox with the potentially extended default list.
     ComboBoxRateRange->clear();
-    ComboBoxRateRange->addItem(tr("4%"), 4);
-    ComboBoxRateRange->addItem(tr("6% (semitone)"), 6);
-    ComboBoxRateRange->addItem(tr("8% (Technics SL-1210)"), 8);
-    ComboBoxRateRange->addItem(tr("10%"), 10);
-    ComboBoxRateRange->addItem(tr("16%"), 16);
-    ComboBoxRateRange->addItem(tr("24%"), 24);
-    ComboBoxRateRange->addItem(tr("50%"), 50);
-    ComboBoxRateRange->addItem(tr("90%"), 90);
+    for (auto rateRangeIt = RateControl::s_rateRangesPercentAndTrStrings.constBegin();
+            rateRangeIt != RateControl::s_rateRangesPercentAndTrStrings.constEnd();
+            rateRangeIt++) {
+        ComboBoxRateRange->addItem(rateRangeIt.value(), rateRangeIt.key());
+    }
     connect(ComboBoxRateRange,
             QOverload<int>::of(&QComboBox::currentIndexChanged),
             this,
             &DlgPrefDeck::slotRateRangeComboBox);
-
-    // RateRange is the legacy ConfigKey. RateRangePercent is used now.
-    if (m_pConfig->exists(ConfigKey("[Controls]", "RateRange")) &&
-        !m_pConfig->exists(ConfigKey("[Controls]", "RateRangePercent"))) {
-        int legacyIndex = m_pConfig->getValueString(ConfigKey("[Controls]", "RateRange")).toInt();
-        if (legacyIndex == 0) {
-            m_iRateRangePercent = 6;
-        } else if (legacyIndex == 1) {
-            m_iRateRangePercent = 8; // use kDefaultRateRangePercent?
-        } else {
-            m_iRateRangePercent = (legacyIndex-1) * 10;
-        }
-    } else {
-        // Custom range
-        m_iRateRangePercent = m_pConfig->getValue(ConfigKey("[Controls]", "RateRangePercent"),
-                                                  kDefaultRateRangePercent);
-    }
-    // Clamp to valid range. Custom range is added to combobox in slotUpdate().
-    if (!(m_iRateRangePercent >= RateControl::kMinRateRange * 100 &&
-                m_iRateRangePercent <= RateControl::kMaxRateRange * 100)) {
-        m_iRateRangePercent = kDefaultRateRangePercent;
-    }
-    setRateRangeForAllDecks(m_iRateRangePercent);
 
     // Key lock mode
     connect(buttonGroupKeyLockMode,
@@ -423,6 +408,8 @@ DlgPrefDeck::DlgPrefDeck(QWidget* parent, UserSettingsPointer pConfig)
 }
 
 DlgPrefDeck::~DlgPrefDeck() {
+    // TODO Store rate range of deck 1 in case we didn't store the common range
+    // in slotApply() earlier because decks used different ranges??
     qDeleteAll(m_rateControls);
     qDeleteAll(m_rateDirectionControls);
     qDeleteAll(m_cueControls);
@@ -440,20 +427,34 @@ void DlgPrefDeck::slotUpdate() {
     checkBoxCloneDeckOnLoadDoubleTap->setChecked(m_pConfig->getValue(
             ConfigKey("[Controls]", "CloneDeckOnLoadDoubleTap"), true));
 
-    int rateRangePercent = static_cast<int>(m_rateRangeControls[0]->get() * 100);
-    int index = ComboBoxRateRange->findData(rateRangePercent);
-    if (index == -1) { // not found
-        // Insert custom range at the correct pos (ascending order)
-        int insPos = 0;
-        for (int i = 0; i < ComboBoxRateRange->count(); i++) {
-            if (rateRangePercent < ComboBoxRateRange->itemData(i).toInt()) {
-                insPos = i;
-                break;
-            }
+    // Rate range
+    // Update the combobox in case one or more (custom) ranges were added
+    ComboBoxRateRange->clear();
+    for (auto rateRangeIt = RateControl::s_rateRangesPercentAndTrStrings.constBegin();
+            rateRangeIt != RateControl::s_rateRangesPercentAndTrStrings.constEnd();
+            rateRangeIt++) {
+        ComboBoxRateRange->addItem(rateRangeIt.value(), rateRangeIt.key());
+    }
+    // Check if all decks use the same range
+    QList<int> rangeValues;
+    for (auto rangeControl : m_rateRangeControls) {
+        int val = static_cast<int>(rangeControl->get() * 100);
+        if (!rangeValues.contains(val)) {
+            rangeValues << val;
         }
-        ComboBoxRateRange->insertItem(insPos,
-                QString::number(rateRangePercent).append("%"),
-                rateRangePercent);
+    }
+    // If there's only one range used, try to select the respective item.
+    // Else, show a hint that decks currently use different ranges.
+    int index = -1;
+    if (rangeValues.size() == 1) {
+        // Should always succeed since ranges in use should already been added to
+        // s_rateRangesPercentAndTrStrings by RateControl::slotRateRangeChangeRequest().
+        index = ComboBoxRateRange->findData(rangeValues.first());
+    } else {
+        index = 0;
+        ComboBoxRateRange->insertItem(index,
+                tr("(different ranges in use)"),
+                kInvalidRateRangePercent);
     }
     ComboBoxRateRange->setCurrentIndex(index);
 
@@ -557,8 +558,15 @@ void DlgPrefDeck::slotMoveIntroStartCheckbox(bool checked) {
     m_bSetIntroStartAtMainCue = checked;
 }
 
-void DlgPrefDeck::slotRateRangeComboBox(int index) {
-    m_iRateRangePercent = ComboBoxRateRange->itemData(index).toInt();
+void DlgPrefDeck::slotRateRangeComboBox(int) {
+    m_iRateRangePercent = kInvalidRateRangePercent;
+    if (ComboBoxRateRange->currentIndex() == -1) {
+        return;
+    }
+    int selectedRange = ComboBoxRateRange->currentData().toInt();
+    if (selectedRange != 0) {
+        m_iRateRangePercent = selectedRange;
+    }
 }
 
 void DlgPrefDeck::setRateRangeForAllDecks(int rangePercent) {
@@ -706,17 +714,19 @@ void DlgPrefDeck::slotApply() {
     m_pConfig->setValue(ConfigKey("[Controls]", "CloneDeckOnLoadDoubleTap"),
             m_bCloneDeckOnLoadDoubleTap);
 
-    // Set rate range
-    setRateRangeForAllDecks(m_iRateRangePercent);
-    m_pConfig->setValue(ConfigKey("[Controls]", "RateRangePercent"),
-                        m_iRateRangePercent);
+    // Set & store rate range
+    // Apply only if all decks use the same valid range (detected in slotUpdate()).
+    if (m_iRateRangePercent != kInvalidRateRangePercent) {
+        setRateRangeForAllDecks(m_iRateRangePercent);
+        m_pConfig->setValue(ConfigKey("[Controls]", "RateRangePercent"),
+                m_iRateRangePercent);
+    }
 
     setRateDirectionForAllDecks(m_bRateDownIncreasesSpeed);
     m_pConfig->setValue(ConfigKey("[Controls]", "RateDir"),
             m_bRateDownIncreasesSpeed);
 
     BaseTrackPlayer::TrackLoadReset configSPAutoReset = BaseTrackPlayer::RESET_NONE;
-
     if (m_speedAutoReset && m_pitchAutoReset) {
         configSPAutoReset = BaseTrackPlayer::RESET_PITCH_AND_SPEED;
     } else if (m_speedAutoReset) {
@@ -724,7 +734,6 @@ void DlgPrefDeck::slotApply() {
     } else if (m_pitchAutoReset) {
         configSPAutoReset = BaseTrackPlayer::RESET_PITCH;
     }
-
     m_pConfig->setValue(ConfigKey("[Controls]", "SpeedAutoReset"),
             configSPAutoReset);
 
@@ -770,8 +779,18 @@ void DlgPrefDeck::slotNumDecksChanged(double new_count, bool initializing) {
         QString group = PlayerManager::groupForDeck(i);
         m_rateControls.push_back(new ControlProxy(
                 group, "rate"));
-        m_rateRangeControls.push_back(new ControlProxy(
-                group, "rate_range"));
+        auto rateRangeControl = new ControlProxy(group, "rate_range");
+        m_rateRangeControls.push_back(rateRangeControl);
+        if (!initializing) {
+            // Set rate range for new deck
+            if (m_iRateRangePercent != kInvalidRateRangePercent) {
+                // Use the range used by all other decks.
+                rateRangeControl->set(m_iRateRangePercent);
+            } else {
+                // Use the default range.
+                rateRangeControl->set(kDefaultRateRangePercent);
+            }
+        }
         m_rateDirectionControls.push_back(new ControlProxy(
                 group, "rate_dir"));
         m_cueControls.push_back(new ControlProxy(
@@ -789,7 +808,6 @@ void DlgPrefDeck::slotNumDecksChanged(double new_count, bool initializing) {
     // The rate range hasn't been read from the config file when this is first called.
     if (!initializing) {
         setRateDirectionForAllDecks(m_rateDirectionControls[0]->get() == kRateDirectionInverted);
-        setRateRangeForAllDecks(static_cast<int>(m_rateRangeControls[0]->get() * 100.0));
     }
 }
 
@@ -803,8 +821,18 @@ void DlgPrefDeck::slotNumSamplersChanged(double new_count, bool initializing) {
         QString group = PlayerManager::groupForSampler(i);
         m_rateControls.push_back(new ControlProxy(
                 group, "rate"));
-        m_rateRangeControls.push_back(new ControlProxy(
-                group, "rate_range"));
+        auto rateRangeControl = new ControlProxy(group, "rate_range");
+        m_rateRangeControls.push_back(rateRangeControl);
+        if (!initializing) {
+            // Set rate range for new deck
+            if (m_iRateRangePercent != kInvalidRateRangePercent) {
+                // Use the range used by all other decks.
+                rateRangeControl->set(m_iRateRangePercent);
+            } else {
+                // Use the default range.
+                rateRangeControl->set(kDefaultRateRangePercent);
+            }
+        }
         m_rateDirectionControls.push_back(new ControlProxy(
                 group, "rate_dir"));
         m_cueControls.push_back(new ControlProxy(
@@ -822,7 +850,6 @@ void DlgPrefDeck::slotNumSamplersChanged(double new_count, bool initializing) {
     // The rate range hasn't been read from the config file when this is first called.
     if (!initializing) {
         setRateDirectionForAllDecks(m_rateDirectionControls[0]->get() == kRateDirectionInverted);
-        setRateRangeForAllDecks(static_cast<int>(m_rateRangeControls[0]->get() * 100.0));
     }
 }
 

--- a/src/test/signalpathtest.h
+++ b/src/test/signalpathtest.h
@@ -145,7 +145,7 @@ class BaseSignalPathTest : public MixxxTest, SoundSourceProviderRegistration {
     void addDeck(EngineDeck* pDeck) {
         ControlObject::set(ConfigKey(pDeck->getGroup(), "main_mix"), 1.0);
         ControlObject::set(ConfigKey(pDeck->getGroup(), "rate_dir"), kDefaultRateDir);
-        ControlObject::set(ConfigKey(pDeck->getGroup(), "rateRange"), kDefaultRateRange);
+        ControlObject::set(ConfigKey(pDeck->getGroup(), "rate_range"), kDefaultRateRange);
         m_pNumDecks->set(m_pNumDecks->get() + 1);
     }
 

--- a/src/widget/wraterange.cpp
+++ b/src/widget/wraterange.cpp
@@ -10,7 +10,7 @@ WRateRange::WRateRange(const QString& group, QWidget* parent)
           m_nodePosition(VerticalPosition::Top),
           m_nodeDisplay(DisplayType::Default) {
     m_pRateRangeControl = new ControlProxy(
-            group, "rateRange", this, ControlFlag::NoAssertIfMissing);
+            group, "rate_range", this, ControlFlag::NoAssertIfMissing);
     m_pRateRangeControl->connectValueChanged(this, &WRateRange::setValue);
     m_pRateDirControl = new ControlProxy(
             group, "rate_dir", this, ControlFlag::NoAssertIfMissing);


### PR DESCRIPTION
* make `rate_range` a pure **ControlObject**
(no ControlPotmeter with  _up & _down controls etc. which are useless for rate range)
* add `rate_range_next`, `_prev` and `_select` controls, allow to change the range **per deck** with with buttons (controller & GUI) 
* clear the combobox in Preferences -> Decks if users have set individual ranges

- [ ] update documentation

**Nice to have, but outof scope for this initial PR:**
* add per-deck comboboxes to the preferences
* control to set the range for all per-deck controls, see 'general wrapper' suggestion pitched by @Swiftb0y https://github.com/mixxxdj/mixxx/issues/12109#issuecomment-1765790312

Closes #11068 
Paves the way for fixing #12108 