### PR TITLE
(fix) Looping: reset loop_end_pos on eject

### DIFF
--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -1107,8 +1107,8 @@ void LoopingControl::slotLoopEndPos(double positionSamples) {
 
     // Reject if the loop-in is not set, or if the new position is before the
     // start point (but not -1).
-    if (!loopInfo.startPosition.isValid() ||
-            (position.isValid() && position <= loopInfo.startPosition)) {
+    if (position.isValid() &&
+            (!loopInfo.startPosition.isValid() || position <= loopInfo.startPosition)) {
         m_pCOLoopEndPosition->set(loopInfo.endPosition.toEngineSamplePosMaybeInvalid());
         return;
     }

--- a/src/test/looping_control_test.cpp
+++ b/src/test/looping_control_test.cpp
@@ -678,6 +678,14 @@ TEST_F(LoopingControlTest, LoopResizeSeek) {
     EXPECT_FRAMEPOS_EQ(mixxx::audio::FramePos{250}, currentFramePos());
 }
 
+TEST_F(LoopingControlTest, EjectResetsLoopInOutPositions) {
+    m_pLoopStartPoint->set(mixxx::audio::kStartFramePos.toEngineSamplePos());
+    m_pLoopEndPoint->set(mixxx::audio::FramePos{300}.toEngineSamplePos());
+    m_pChannel1->getEngineBuffer()->ejectTrack();
+    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kInvalidFramePos, m_pLoopStartPoint);
+    EXPECT_FRAMEPOS_EQ_CONTROL(mixxx::audio::kInvalidFramePos, m_pLoopEndPoint);
+}
+
 TEST_F(LoopingControlTest, BeatLoopSize_SetAndToggle) {
     m_pTrack1->trySetBpm(120.0);
     // Setting beatloop_size should not activate a loop


### PR DESCRIPTION
Just a quick test if this fixes #12223
It works as expected, but let's run the tests.

In theory:
On eject, `loop_in_pos` was just reset (before `slotLoopEndPos` is called) so this eval would always be true, regardless the invalid requested `loop_end_pos`.
Fall through here and set `loop_end_pos` to -1 a few lines below.
This code hasn't changed for very long, but maybe the callers?