### PR TITLE
Remove redundant by-copy capture default

### DIFF
--- a/src/controllers/dlgprefcontrollers.cpp
+++ b/src/controllers/dlgprefcontrollers.cpp
@@ -23,7 +23,7 @@ DlgPrefControllers::DlgPrefControllers(DlgPreferences* pPreferences,
     createLinkColor();
     setupControllerWidgets();
 
-    connect(btnOpenUserMappings, &QPushButton::clicked, this, [=, this]() {
+    connect(btnOpenUserMappings, &QPushButton::clicked, this, [this]() {
         QString mappingsPath = userMappingsPath(m_pConfig);
         openLocalFile(mappingsPath);
     });

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -133,7 +133,7 @@ LoopingControl::LoopingControl(const QString& group,
             m_pCOBeatLoop,
             &ControlObject::valueChanged,
             this,
-            [=, this](double value) { slotBeatLoop(value); },
+            [this](double value) { slotBeatLoop(value); },
             Qt::DirectConnection);
 
     m_pCOBeatLoopSize = new ControlObject(ConfigKey(group, "beatloop_size"),


### PR DESCRIPTION
This fixes the warning:
warning: explicit by-copy capture of ‘this’ redundant with by-copy capture default 