### PR TITLE
ci: workaround runner-image issue

### DIFF
--- a/.github/workflows/build-checks.yml
+++ b/.github/workflows/build-checks.yml
@@ -115,6 +115,13 @@ jobs:
         working-directory: build
       - name: Set up problem matcher
         uses: ammaraskar/gcc-problem-matcher@0.2.0
+      # Work around https://github.com/actions/runner-images/issues/8659
+      - name: "Remove GCC 13 from runner image (workaround)"
+        shell: bash
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/ubuntu-toolchain-r-ubuntu-test-jammy.list
+          sudo apt-get update
+          sudo apt-get install -y --allow-downgrades libc6=2.35-0ubuntu3.4 libc6-dev=2.35-0ubuntu3.4 libstdc++6=12.3.0-1ubuntu1~22.04 libgcc-s1=12.3.0-1ubuntu1~22.04
       - name: Build
         # Do not abort on errors and build/check the whole project
         run: cmake --build . -j $(nproc) -- --keep-going


### PR DESCRIPTION
This workaround has been suggested on the issue https://github.com/actions/runner-images/issues/8659