### PR TITLE
move ordering to waveformmarkset

### DIFF
--- a/src/waveform/renderers/allshader/waveformrendermark.cpp
+++ b/src/waveform/renderers/allshader/waveformrendermark.cpp
@@ -159,7 +159,7 @@ void allshader::WaveformRenderMark::drawMark(const QRectF& rect, QColor color) {
 
 void allshader::WaveformRenderMark::paintGL() {
     const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
-    QList<QPair<WaveformMarkPointer, int>> marksOnScreen;
+    QList<WaveformWidgetRenderer::WaveformMarkOnScreen> marksOnScreen;
 
     checkCuesUpdated();
 
@@ -221,7 +221,9 @@ void allshader::WaveformRenderMark::paintGL() {
             }
 
             if (visible) {
-                marksOnScreen.append(qMakePair(pMark, drawOffset));
+                marksOnScreen.append(
+                        WaveformWidgetRenderer::WaveformMarkOnScreen{
+                                pMark, static_cast<int>(drawOffset)});
             }
         }
     }

--- a/src/waveform/renderers/waveformmarkset.h
+++ b/src/waveform/renderers/waveformmarkset.h
@@ -9,7 +9,8 @@
 class WaveformWidgetRenderer;
 
 // This class helps share code between the WaveformRenderMark and WOverview
-// constructors.
+// constructors and allows to iterate over the orders marks that have to be
+// rendered.
 class WaveformMarkSet {
   public:
     WaveformMarkSet();
@@ -19,17 +20,63 @@ class WaveformMarkSet {
                const SkinContext& context,
                const WaveformSignalColors& signalColors);
 
-    inline QList<WaveformMarkPointer>::const_iterator begin() const { return m_marks.begin(); }
-    inline QList<WaveformMarkPointer>::const_iterator end() const { return m_marks.end(); }
+    template<typename Receiver, typename Slot>
+    void connectSamplePositionChanged(Receiver receiver, Slot slot) const {
+        for (const auto& pMark : std::as_const(m_marks)) {
+            if (pMark->isValid()) {
+                pMark->connectSamplePositionChanged(receiver, slot);
+            }
+        }
+    };
+
+    template<typename Receiver, typename Slot>
+    void connectSampleEndPositionChanged(Receiver receiver, Slot slot) const {
+        for (const auto& pMark : std::as_const(m_marks)) {
+            if (pMark->isValid()) {
+                pMark->connectSampleEndPositionChanged(receiver, slot);
+            }
+        }
+    };
+
+    template<typename Receiver, typename Slot>
+    void connectVisibleChanged(Receiver receiver, Slot slot) const {
+        for (const auto& pMark : std::as_const(m_marks)) {
+            if (pMark->hasVisible()) {
+                pMark->connectVisibleChanged(receiver, slot);
+            }
+        }
+    }
+
+    inline QList<WaveformMarkPointer>::const_iterator begin() const {
+        return m_marksToRender.begin();
+    }
+    inline QList<WaveformMarkPointer>::const_iterator end() const {
+        return m_marksToRender.end();
+    }
+    inline QList<WaveformMarkPointer>::const_iterator cbegin() const {
+        return m_marksToRender.cbegin();
+    }
+    inline QList<WaveformMarkPointer>::const_iterator cend() const {
+        return m_marksToRender.cend();
+    }
 
     // hotCue must be valid (>= 0 and < NUM_HOT_CUES)
     WaveformMarkPointer getHotCueMark(int hotCue) const;
     WaveformMarkPointer getDefaultMark() const;
+    WaveformMarkPointer findHoveredMark(QPoint point, Qt::Orientation orientation) const;
+
+    void update();
 
   private:
-    void clear() { m_marks.clear(); }
+    void clear() {
+        m_marks.clear();
+        m_marksToRender.clear();
+    }
     WaveformMarkPointer m_pDefaultMark;
     QList<WaveformMarkPointer> m_marks;
+    // List of visible WaveformMarks sorted by the order they appear in the track
+    QList<WaveformMarkPointer> m_marksToRender;
+
     QMap<int, WaveformMarkPointer> m_hotCueMarks;
 
     DISALLOW_COPY_AND_ASSIGN(WaveformMarkSet);

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -41,7 +41,7 @@ void WaveformRenderMark::setup(const QDomNode& node, const SkinContext& context)
 void WaveformRenderMark::draw(QPainter* painter, QPaintEvent* /*event*/) {
     PainterScope PainterScope(painter);
     // Associates mark objects with their positions in the widget.
-    QList<QPair<WaveformMarkPointer, int>> marksOnScreen;
+    QList<WaveformWidgetRenderer::WaveformMarkOnScreen> marksOnScreen;
 
     painter->setWorldMatrixEnabled(false);
 
@@ -102,7 +102,9 @@ void WaveformRenderMark::draw(QPainter* painter, QPaintEvent* /*event*/) {
                 }
 
                 if (visible) {
-                    marksOnScreen.append(qMakePair(pMark, drawOffset));
+                    marksOnScreen.append(
+                            WaveformWidgetRenderer::WaveformMarkOnScreen{
+                                    pMark, drawOffset});
                 }
             } else {
                 const int markHalfHeight =
@@ -146,7 +148,9 @@ void WaveformRenderMark::draw(QPainter* painter, QPaintEvent* /*event*/) {
                 }
 
                 if (visible) {
-                    marksOnScreen.append(qMakePair(pMark, drawOffset));
+                    marksOnScreen.append(
+                            WaveformWidgetRenderer::WaveformMarkOnScreen{
+                                    pMark, drawOffset});
                 }
             }
         }

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -422,12 +422,12 @@ WaveformMarkPointer WaveformWidgetRenderer::getCueMarkAtPoint(QPoint point) cons
     // drawoffset from the drawing and c) storing it in WaveformMark.
 
     for (auto it = m_markPositions.crbegin(); it != m_markPositions.crend(); ++it) {
-        const WaveformMarkPointer& pMark = it->first;
+        const WaveformMarkPointer& pMark = it->m_pMark;
         VERIFY_OR_DEBUG_ASSERT(pMark) {
             continue;
         }
 
-        int markImagePositionInWidgetSpace = it->second;
+        int markImagePositionInWidgetSpace = it->m_offsetOnScreen;
         QPoint pointInImageSpace;
         if (getOrientation() == Qt::Horizontal) {
             pointInImageSpace = QPoint(point.x() - markImagePositionInWidgetSpace, point.y());

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -413,13 +413,13 @@ ConstWaveformPointer WaveformWidgetRenderer::getWaveform() const {
 }
 
 WaveformMarkPointer WaveformWidgetRenderer::getCueMarkAtPoint(QPoint point) const {
-    // The m_markPositions list follows the order of drawing, so we search the list
-    // in reverse order to find the hovered mark.
+    // The m_markPositions list follows the order of drawing, so we search the
+    // list in reverse order to find the hovered mark.
     //
-    // TODO It would be preferable to use WaveformMarkSet::findHoveredMark here, as
-    // done by WOverview, but that requires a) making WaveformMarkSet m_marks a member
-    // of this class and b) decoupling the calculation of the drawoffset from the 
-    // drawing and c) storing it in WaveformMark. 
+    // TODO It would be preferable to use WaveformMarkSet::findHoveredMark here,
+    // as done by WOverview, but that requires a) making WaveformMarkSet m_marks
+    // a member of this class and b) decoupling the calculation of the
+    // drawoffset from the drawing and c) storing it in WaveformMark.
 
     for (auto it = m_markPositions.crbegin(); it != m_markPositions.crend(); ++it) {
         const WaveformMarkPointer& pMark = it->first;

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -413,13 +413,21 @@ ConstWaveformPointer WaveformWidgetRenderer::getWaveform() const {
 }
 
 WaveformMarkPointer WaveformWidgetRenderer::getCueMarkAtPoint(QPoint point) const {
-    for (auto it = m_markPositions.constBegin(); it != m_markPositions.constEnd(); ++it) {
-        WaveformMarkPointer pMark = it.key();
+    // The m_markPositions list follows the order of drawing, so we search the list
+    // in reverse order to find the hovered mark.
+    //
+    // TODO It would be preferable to use WaveformMarkSet::findHoveredMark here, as
+    // done by WOverview, but that requires a) making WaveformMarkSet m_marks a member
+    // of this class and b) decoupling the calculation of the drawoffset from the 
+    // drawing and c) storing it in WaveformMark. 
+
+    for (auto it = m_markPositions.crbegin(); it != m_markPositions.crend(); ++it) {
+        const WaveformMarkPointer& pMark = it->first;
         VERIFY_OR_DEBUG_ASSERT(pMark) {
             continue;
         }
 
-        int markImagePositionInWidgetSpace = it.value();
+        int markImagePositionInWidgetSpace = it->second;
         QPoint pointInImageSpace;
         if (getOrientation() == Qt::Horizontal) {
             pointInImageSpace = QPoint(point.x() - markImagePositionInWidgetSpace, point.y());

--- a/src/waveform/renderers/waveformwidgetrenderer.h
+++ b/src/waveform/renderers/waveformwidgetrenderer.h
@@ -149,7 +149,7 @@ class WaveformWidgetRenderer {
     }
 
     void setTrack(TrackPointer track);
-    void setMarkPositions(const QMap<WaveformMarkPointer, int>& markPositions) {
+    void setMarkPositions(const QList<QPair<WaveformMarkPointer, int>>& markPositions) {
         m_markPositions = markPositions;
     }
 
@@ -217,7 +217,7 @@ class WaveformWidgetRenderer {
 private:
     DISALLOW_COPY_AND_ASSIGN(WaveformWidgetRenderer);
     friend class WaveformWidgetFactory;
-    QMap<WaveformMarkPointer, int> m_markPositions;
+    QList<QPair<WaveformMarkPointer, int>> m_markPositions;
     // draw play position indicator triangles
     void drawPlayPosmarker(QPainter* painter);
     void drawTriangle(QPainter* painter,

--- a/src/waveform/renderers/waveformwidgetrenderer.h
+++ b/src/waveform/renderers/waveformwidgetrenderer.h
@@ -26,6 +26,11 @@ class WaveformWidgetRenderer {
     static const double s_waveformDefaultZoom;
     static const double s_defaultPlayMarkerPosition;
 
+    struct WaveformMarkOnScreen {
+        WaveformMarkPointer m_pMark;
+        int m_offsetOnScreen;
+    };
+
   public:
     explicit WaveformWidgetRenderer(const QString& group);
     virtual ~WaveformWidgetRenderer();
@@ -149,7 +154,7 @@ class WaveformWidgetRenderer {
     }
 
     void setTrack(TrackPointer track);
-    void setMarkPositions(const QList<QPair<WaveformMarkPointer, int>>& markPositions) {
+    void setMarkPositions(const QList<WaveformMarkOnScreen>& markPositions) {
         m_markPositions = markPositions;
     }
 
@@ -217,7 +222,7 @@ class WaveformWidgetRenderer {
 private:
     DISALLOW_COPY_AND_ASSIGN(WaveformWidgetRenderer);
     friend class WaveformWidgetFactory;
-    QList<QPair<WaveformMarkPointer, int>> m_markPositions;
+    QList<WaveformMarkOnScreen> m_markPositions;
     // draw play position indicator triangles
     void drawPlayPosmarker(QPainter* painter);
     void drawTriangle(QPainter* painter,

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -151,18 +151,9 @@ void WOverview::setup(const QDomNode& node, const SkinContext& context) {
     auto colorPalette = colorPaletteSettings.getHotcueColorPalette();
     m_pCueMenuPopup->setColorPalette(colorPalette);
 
-    for (const auto& pMark: m_marks) {
-        if (pMark->isValid()) {
-            pMark->connectSamplePositionChanged(this,
-                    &WOverview::onMarkChanged);
-            pMark->connectSampleEndPositionChanged(this,
-                    &WOverview::onMarkChanged);
-        }
-        if (pMark->hasVisible()) {
-            pMark->connectVisibleChanged(this,
-                    &WOverview::onMarkChanged);
-        }
-    }
+    m_marks.connectSamplePositionChanged(this, &WOverview::onMarkChanged);
+    m_marks.connectSampleEndPositionChanged(this, &WOverview::onMarkChanged);
+    m_marks.connectVisibleChanged(this, &WOverview::onMarkChanged);
 
     QDomNode child = node.firstChild();
     while (!child.isNull()) {
@@ -220,8 +211,8 @@ void WOverview::setup(const QDomNode& node, const SkinContext& context) {
 
     m_bShowCueTimes = context.selectBool(node, "ShowCueTimes", true);
 
-    //qDebug() << "WOverview : m_marks" << m_marks.size();
-    //qDebug() << "WOverview : m_markRanges" << m_markRanges.size();
+    // qDebug() << "WOverview : std::as_const(m_marks)" << m_marks.size();
+    // qDebug() << "WOverview : m_markRanges" << m_markRanges.size();
     if (!m_connections.isEmpty()) {
         ControlParameterWidgetConnection* defaultConnection = m_connections.at(0);
         if (defaultConnection) {
@@ -414,7 +405,6 @@ void WOverview::onPassthroughChange(double v) {
 }
 
 void WOverview::updateCues(const QList<CuePointer> &loadedCues) {
-    m_marksToRender.clear();
     for (const CuePointer& currentCue : loadedCues) {
         const WaveformMarkPointer pMark = m_marks.getHotCueMark(currentCue->getHotCue());
 
@@ -444,18 +434,7 @@ void WOverview::updateCues(const QList<CuePointer> &loadedCues) {
         }
     }
 
-    for (const auto& pMark : m_marks) {
-        if (pMark->isValid() && pMark->isVisible()) {
-            double samplePosition = pMark->getSamplePosition();
-            if (samplePosition != Cue::kNoPosition) {
-                // Create a stable key for sorting, because the WaveformMark's samplePosition is a
-                // ControlObject which can change at any time by other threads. Such a change causes
-                // another updateCues() call, rebuilding m_marksToRender.
-                auto key = WaveformMarkSortKey(samplePosition, pMark->getHotCue());
-                m_marksToRender.emplace(key, pMark);
-            }
-        }
-    }
+    m_marks.update();
 }
 
 // connecting the tracks cuesUpdated and onMarkChanged is not possible
@@ -492,21 +471,7 @@ void WOverview::mouseMoveEvent(QMouseEvent* e) {
         return;
     }
 
-    m_pHoveredMark.clear();
-
-    // Non-hotcue marks (intro/outro cues, main cue, loop in/out) are sorted
-    // before hotcues in m_marksToRender so if there is a hotcue in the same
-    // location, the hotcue gets rendered on top. When right clicking, the
-    // the hotcue rendered on top must be assigned to m_pHoveredMark to show
-    // the CueMenuPopup. To accomplish this, m_marksToRender is iterated in
-    // reverse and the loop breaks as soon as m_pHoveredMark is set.
-    for (auto i = m_marksToRender.crbegin(); i != m_marksToRender.crend(); ++i) {
-        const WaveformMarkPointer& pMark = i->second;
-        if (pMark->contains(e->pos(), m_orientation)) {
-            m_pHoveredMark = pMark;
-            break;
-        }
-    }
+    m_pHoveredMark = m_marks.findHoveredMark(e->pos(), m_orientation);
 
     //qDebug() << "WOverview::mouseMoveEvent" << e->pos() << m_iPos;
     update();
@@ -872,9 +837,9 @@ void WOverview::drawMarks(QPainter* pPainter, const float offset, const float ga
 
     bool markHovered = false;
 
-    for (auto i = m_marksToRender.cbegin(); i != m_marksToRender.cend(); ++i) {
+    for (auto it = m_marks.cbegin(); it != m_marks.cend(); ++it) {
         PainterScope painterScope(pPainter);
-        const WaveformMarkPointer& pMark = i->second;
+        const WaveformMarkPointer& pMark = *it;
         double samplePosition = pMark->getSamplePosition();
         const float markPosition = math_clamp(
                 offset + static_cast<float>(samplePosition) * gain,
@@ -932,8 +897,8 @@ void WOverview::drawMarks(QPainter* pPainter, const float offset, const float ga
 
             if (pMark != m_pHoveredMark) {
                 float nextMarkPosition = -1.0f;
-                for (auto m = std::next(i); m != m_marksToRender.cend(); ++m) {
-                    const WaveformMarkPointer& otherMark = m->second;
+                for (auto m = std::next(it); m != m_marks.cend(); ++m) {
+                    const WaveformMarkPointer& otherMark = *m;
                     bool otherAtSameHeight = valign == (otherMark->m_align & Qt::AlignVertical_Mask);
                     // Hotcues always show at least their number.
                     bool otherHasLabel = !otherMark->m_text.isEmpty() || otherMark->getHotCue() != Cue::kNoHotCue;
@@ -1184,8 +1149,7 @@ void WOverview::drawMarkLabels(QPainter* pPainter, const float offset, const flo
     QFontMetricsF fontMetrics(markerFont);
 
     // Draw WaveformMark labels
-    for (const auto& pair : m_marksToRender) {
-        const WaveformMarkPointer& pMark = pair.second;
+    for (const auto& pMark : std::as_const(m_marks)) {
         if (m_pHoveredMark != nullptr && pMark != m_pHoveredMark) {
             if (pMark->m_label.intersects(m_pHoveredMark->m_label)) {
                 continue;

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -192,10 +192,7 @@ class WOverview : public WWidget, public TrackDropTarget {
     int m_dimBrightThreshold;
     QLabel* m_pPassthroughLabel;
 
-    // All WaveformMarks
     WaveformMarkSet m_marks;
-    // List of visible WaveformMarks sorted by the order they appear in the track
-    std::map<WaveformMarkSortKey, WaveformMarkPointer> m_marksToRender;
     std::vector<WaveformMarkRange> m_markRanges;
     WaveformMarkLabel m_cuePositionLabel;
     WaveformMarkLabel m_cueTimeDistanceLabel;


### PR DESCRIPTION
This is a basically a code quality refactoring, but has the added bonus of fixing an inconsistency between the waveform overview and the waveform viewer.

WOverview had both a member `WaveformMarkSet m_marks` and a member `m_marksToRender` (a sorted map of the visible marks) , and code to update the second. This functionality makes more sense to live inside `WaveformMarkSet`.

With this refactoring, WOverview only has `WaveformMarkSet m_marks`, and when iteratoring over `m_marks`, this will be over the sorted marks to render, and WOverview doesn't need to know anything about this.

As a bonus, WaveformRenderMark, now uses the some ordering as WOverview (I believe there was a bug about this, or maybe a discussion in zulip, but I can't find it).
