### PR TITLE
Import playlist when opening file with Mixxx

### DIFF
--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -17,6 +17,7 @@
 #include "library/coverartcache.h"
 #include "library/library.h"
 #include "library/library_prefs.h"
+#include "library/parser.h"
 #include "library/trackcollection.h"
 #include "library/trackcollectionmanager.h"
 #include "mixer/playerinfo.h"
@@ -439,7 +440,8 @@ void CoreServices::initialize(QApplication* pApp) {
     // 1 and 2:
     const QList<QString>& musicFiles = m_cmdlineArgs.getMusicFiles();
     for (int i = 0; i < (int)m_pPlayerManager->numDecks() && i < musicFiles.count(); ++i) {
-        if (SoundSourceProxy::isFileNameSupported(musicFiles.at(i))) {
+        if (SoundSourceProxy::isFileNameSupported(musicFiles.at(i)) &&
+                !Parser::isPlaylistFilenameSupported(musicFiles.at(i))) {
             m_pPlayerManager->slotLoadToDeck(musicFiles.at(i), i + 1);
         }
     }

--- a/src/library/dao/playlistdao.cpp
+++ b/src/library/dao/playlistdao.cpp
@@ -1276,8 +1276,12 @@ void PlaylistDAO::setAutoDJProcessor(AutoDJProcessor* pAutoDJProcessor) {
     m_pAutoDJProcessor = pAutoDJProcessor;
 }
 
+int PlaylistDAO::getAutoDJPlaylistID() {
+    return getPlaylistIdFromName(AUTODJ_TABLE);
+}
+
 void PlaylistDAO::addTracksToAutoDJQueue(const QList<TrackId>& trackIds, AutoDJSendLoc loc) {
-    int iAutoDJPlaylistId = getPlaylistIdFromName(AUTODJ_TABLE);
+    int iAutoDJPlaylistId = getAutoDJPlaylistID();
     if (iAutoDJPlaylistId == kInvalidPlaylistId) {
         return;
     }
@@ -1300,4 +1304,10 @@ void PlaylistDAO::addTracksToAutoDJQueue(const QList<TrackId>& trackIds, AutoDJS
         }
         break;
     }
+}
+
+void PlaylistDAO::toggleAutoDJ(bool enabled) {
+    if (!m_pAutoDJProcessor)
+        return;
+    m_pAutoDJProcessor->toggleAutoDJ(enabled);
 }

--- a/src/library/dao/playlistdao.h
+++ b/src/library/dao/playlistdao.h
@@ -109,8 +109,13 @@ class PlaylistDAO : public QObject, public virtual DAO {
     int insertTracksIntoPlaylist(const QList<TrackId>& trackIds, const int playlistId, int position);
     // Add a playlist to the Auto-DJ Queue
     void addPlaylistToAutoDJQueue(const int playlistId, AutoDJSendLoc loc);
+    // Get AutoDJ Table Playlist ID
+    int getAutoDJPlaylistID();
     // Add a list of tracks to the Auto-DJ Queue
     void addTracksToAutoDJQueue(const QList<TrackId>& trackIds, AutoDJSendLoc loc);
+    // Toggle AutoDJ using AutoDJProcessor, for calling it from outside without
+    // connecting the module
+    void toggleAutoDJ(bool enabled);
     // Get the preceding playlist of currentPlaylistId with the HiddenType
     // hidden. Returns -1 if no such playlist exists.
     int getPreviousPlaylist(const int currentPlaylistId, HiddenType hidden) const;

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -706,3 +706,12 @@ LibraryTableModel* Library::trackTableModel() const {
 
     return m_pMixxxLibraryFeature->trackTableModel();
 }
+
+void Library::importPlaylistFromFile(QString playlistFile) {
+    if (!playlistFile.isEmpty()) {
+        int playlistId = m_pPlaylistFeature->createImportPlaylist(playlistFile);
+        if (playlistId == kInvalidPlaylistId)
+            return;
+        m_pPlaylistFeature->activatePlaylist(playlistId);
+    }
+}

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -707,7 +707,7 @@ LibraryTableModel* Library::trackTableModel() const {
     return m_pMixxxLibraryFeature->trackTableModel();
 }
 
-void Library::importPlaylistFromFile(QString playlistFile) {
+void Library::importPlaylistFromFile(const QString& playlistFile) {
     if (!playlistFile.isEmpty()) {
         int playlistId = m_pPlaylistFeature->createImportPlaylist(playlistFile);
         if (playlistId == kInvalidPlaylistId)

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -707,11 +707,27 @@ LibraryTableModel* Library::trackTableModel() const {
     return m_pMixxxLibraryFeature->trackTableModel();
 }
 
-void Library::importPlaylistFromFile(const QString& playlistFile) {
+void Library::importPlaylistFromFile(const QString& playlistFile,
+        bool activatePlaylist,
+        bool sendToAutoDJ,
+        PlaylistDAO::AutoDJSendLoc loc) {
     if (!playlistFile.isEmpty()) {
         int playlistId = m_pPlaylistFeature->createImportPlaylist(playlistFile);
         if (playlistId == kInvalidPlaylistId)
             return;
-        m_pPlaylistFeature->activatePlaylist(playlistId);
+
+        if (activatePlaylist && !sendToAutoDJ)
+            m_pPlaylistFeature->activatePlaylist(playlistId);
+
+        if (sendToAutoDJ)
+            m_pPlaylistFeature->addPlaylistToAutoDJQueue(playlistId, loc);
     }
+}
+
+void Library::toggleAutoDJ(bool enabled) {
+    m_pPlaylistFeature->toggleAutoDJ(enabled);
+}
+
+void Library::activateAutoDJPlaylist() {
+    m_pPlaylistFeature->activateAutoDJPlaylist();
 }

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -8,6 +8,7 @@
 
 #include "analyzer/analyzerscheduledtrack.h"
 #include "analyzer/trackanalysisscheduler.h"
+#include "library/dao/playlistdao.h"
 #include "library/library_decl.h"
 #ifdef __ENGINEPRIME__
 #include "library/trackset/crate/crateid.h"
@@ -103,7 +104,12 @@ class Library: public QObject {
     /// and shows the results by switching the view.
     void searchTracksInCollection(const QString& query);
 
-    void importPlaylistFromFile(const QString& playlistFile);
+    void importPlaylistFromFile(const QString& playlistFile,
+            bool activatePlaylist = true,
+            bool sendToAutoDJ = false,
+            PlaylistDAO::AutoDJSendLoc loc = PlaylistDAO::AutoDJSendLoc::TOP);
+    void toggleAutoDJ(bool enabled);
+    void activateAutoDJPlaylist();
 
 #ifdef __ENGINEPRIME__
     std::unique_ptr<mixxx::LibraryExporter> makeLibraryExporter(QWidget* parent);

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -103,6 +103,8 @@ class Library: public QObject {
     /// and shows the results by switching the view.
     void searchTracksInCollection(const QString& query);
 
+    void importPlaylistFromFile(QString playlistFile);
+
 #ifdef __ENGINEPRIME__
     std::unique_ptr<mixxx::LibraryExporter> makeLibraryExporter(QWidget* parent);
 #endif

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -103,7 +103,7 @@ class Library: public QObject {
     /// and shows the results by switching the view.
     void searchTracksInCollection(const QString& query);
 
-    void importPlaylistFromFile(QString playlistFile);
+    void importPlaylistFromFile(const QString& playlistFile);
 
 #ifdef __ENGINEPRIME__
     std::unique_ptr<mixxx::LibraryExporter> makeLibraryExporter(QWidget* parent);

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -231,6 +231,14 @@ void BasePlaylistFeature::activatePlaylist(int playlistId) {
     emit featureSelect(this, m_lastClickedIndex);
 }
 
+void BasePlaylistFeature::activateAutoDJPlaylist() {
+    int iAutoDJPlaylistId = m_playlistDao.getAutoDJPlaylistID();
+    if (iAutoDJPlaylistId == kInvalidPlaylistId) {
+        return;
+    }
+    activatePlaylist(iAutoDJPlaylistId);
+}
+
 void BasePlaylistFeature::renameItem(const QModelIndex& index) {
     m_lastRightClickedIndex = index;
     slotRenamePlaylist();
@@ -660,13 +668,22 @@ void BasePlaylistFeature::slotAddToAutoDJReplace() {
     addToAutoDJ(PlaylistDAO::AutoDJSendLoc::REPLACE);
 }
 
+void BasePlaylistFeature::addPlaylistToAutoDJQueue(
+        const int playlistId, PlaylistDAO::AutoDJSendLoc loc) {
+    m_playlistDao.addPlaylistToAutoDJQueue(playlistId, loc);
+}
+
+void BasePlaylistFeature::toggleAutoDJ(bool enabled) {
+    m_playlistDao.toggleAutoDJ(enabled);
+}
+
 void BasePlaylistFeature::addToAutoDJ(PlaylistDAO::AutoDJSendLoc loc) {
     //qDebug() << "slotAddToAutoDJ() row:" << m_lastRightClickedIndex.data();
     if (m_lastRightClickedIndex.isValid()) {
         int playlistId = playlistIdFromIndex(m_lastRightClickedIndex);
         if (playlistId >= 0) {
             // Insert this playlist
-            m_playlistDao.addPlaylistToAutoDJQueue(playlistId, loc);
+            addPlaylistToAutoDJQueue(playlistId, loc);
         }
     }
 }

--- a/src/library/trackset/baseplaylistfeature.h
+++ b/src/library/trackset/baseplaylistfeature.h
@@ -40,6 +40,9 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
     void selectPlaylistInSidebar(int playlistId, bool select = true);
     int getSiblingPlaylistIdOf(QModelIndex& start);
 
+    void activateAutoDJPlaylist();
+    void addPlaylistToAutoDJQueue(const int playlistId, PlaylistDAO::AutoDJSendLoc loc);
+    void toggleAutoDJ(bool enabled);
     int createImportPlaylist(const QString& playlistFile);
 
   public slots:

--- a/src/library/trackset/baseplaylistfeature.h
+++ b/src/library/trackset/baseplaylistfeature.h
@@ -40,6 +40,8 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
     void selectPlaylistInSidebar(int playlistId, bool select = true);
     int getSiblingPlaylistIdOf(QModelIndex& start);
 
+    int createImportPlaylist(const QString& playlistFile);
+
   public slots:
     void activateChild(const QModelIndex& index) override;
     virtual void activatePlaylist(int playlistId);
@@ -57,6 +59,7 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
     virtual void slotPlaylistContentOrLockChanged(const QSet<int>& playlistIds) = 0;
     virtual void slotPlaylistTableRenamed(int playlistId, const QString& newName) = 0;
     void slotCreatePlaylist();
+    void slotImportPlaylistFile(const QString& playlistFile, int playlistId);
     void renameItem(const QModelIndex& index) override;
     void deleteItem(const QModelIndex& index) override;
 
@@ -69,7 +72,6 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
     void slotRenamePlaylist();
     void slotTogglePlaylistLock();
     void slotImportPlaylist();
-    void slotImportPlaylistFile(const QString& playlistFile, int playlistId);
     void slotCreateImportPlaylist();
     void slotExportPlaylist();
     // Copy all of the tracks in a playlist to a new directory.

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -414,6 +414,10 @@ void MixxxMainWindow::initialize() {
             &PlayerInfo::currentPlayingTrackChanged,
             this,
             &MixxxMainWindow::slotUpdateWindowTitle);
+
+    // Import playlist if passed to cmd line args
+    const QString playlistFile = CmdlineArgs::Instance().getPlaylistFilePath();
+    m_pCoreServices->getLibrary()->importPlaylistFromFile(playlistFile);
 }
 
 MixxxMainWindow::~MixxxMainWindow() {

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -37,6 +37,7 @@
 #include "database/mixxxdb.h"
 #include "library/library.h"
 #include "library/library_prefs.h"
+#include "library/parser.h"
 #ifdef __ENGINEPRIME__
 #include "library/export/libraryexporter.h"
 #endif
@@ -415,9 +416,12 @@ void MixxxMainWindow::initialize() {
             this,
             &MixxxMainWindow::slotUpdateWindowTitle);
 
-    // Import playlist if passed to cmd line args
-    const QString playlistFile = CmdlineArgs::Instance().getPlaylistFilePath();
-    m_pCoreServices->getLibrary()->importPlaylistFromFile(playlistFile);
+    // Import playlist if passed in args.qlMusicFiles (command line arguments)
+    const QList<QString>& musicFiles = CmdlineArgs::Instance().getMusicFiles();
+    for (int i = 0; i < musicFiles.count(); ++i) {
+        if (Parser::isPlaylistFilenameSupported(musicFiles.at(i)))
+            m_pCoreServices->getLibrary()->importPlaylistFromFile(musicFiles.at(i));
+    }
 }
 
 MixxxMainWindow::~MixxxMainWindow() {

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -418,9 +418,23 @@ void MixxxMainWindow::initialize() {
 
     // Import playlist if passed in args.qlMusicFiles (command line arguments)
     const QList<QString>& musicFiles = CmdlineArgs::Instance().getMusicFiles();
+    bool autodjEnabledForImportedPlaylists = CmdlineArgs::Instance().getAutodjEnabled();
+    PlaylistDAO::AutoDJSendLoc autodjSendLocation = CmdlineArgs::Instance().getAutodjLocation();
     for (int i = 0; i < musicFiles.count(); ++i) {
+        if (i > 0 && autodjSendLocation == PlaylistDAO::AutoDJSendLoc::REPLACE)
+            autodjSendLocation = PlaylistDAO::AutoDJSendLoc::TOP;
+
         if (Parser::isPlaylistFilenameSupported(musicFiles.at(i)))
-            m_pCoreServices->getLibrary()->importPlaylistFromFile(musicFiles.at(i));
+            m_pCoreServices->getLibrary()->importPlaylistFromFile(
+                    musicFiles.at(i),
+                    true,
+                    autodjEnabledForImportedPlaylists,
+                    autodjSendLocation);
+    }
+
+    if (musicFiles.count() > 0 && autodjEnabledForImportedPlaylists) {
+        m_pCoreServices->getLibrary()->toggleAutoDJ(true);
+        m_pCoreServices->getLibrary()->activateAutoDJPlaylist();
     }
 }
 

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -14,6 +14,7 @@
 
 #include "config.h"
 #include "defs_urls.h"
+#include "library/parser.h"
 #include "sources/soundsourceproxy.h"
 #include "util/assert.h"
 
@@ -82,6 +83,17 @@ bool CmdlineArgs::parse(int argc, char** argv) {
     for (int a = 0; a < argc; ++a) {
         arguments << QString::fromLocal8Bit(argv[a]);
     }
+
+    // Process the playlist file path argument if provided
+    if (argc > 1) {
+        QString firstArgument = QString::fromLocal8Bit(argv[1]);
+        mixxx::FileInfo fileInfo(firstArgument);
+        if (fileInfo.exists() && fileInfo.isFile() &&
+                Parser::isPlaylistFilenameSupported(fileInfo.fileName())) {
+            m_playlistFilePath = fileInfo.location();
+        }
+    }
+
     return parse(arguments, ParseMode::Initial);
 }
 

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -14,7 +14,6 @@
 
 #include "config.h"
 #include "defs_urls.h"
-#include "library/parser.h"
 #include "sources/soundsourceproxy.h"
 #include "util/assert.h"
 
@@ -82,16 +81,6 @@ bool CmdlineArgs::parse(int argc, char** argv) {
     arguments.reserve(argc);
     for (int a = 0; a < argc; ++a) {
         arguments << QString::fromLocal8Bit(argv[a]);
-    }
-
-    // Process the playlist file path argument if provided
-    if (argc > 1) {
-        QString firstArgument = QString::fromLocal8Bit(argv[1]);
-        mixxx::FileInfo fileInfo(firstArgument);
-        if (fileInfo.exists() && fileInfo.isFile() &&
-                Parser::isPlaylistFilenameSupported(fileInfo.fileName())) {
-            m_playlistFilePath = fileInfo.location();
-        }
     }
 
     return parse(arguments, ParseMode::Initial);

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -23,6 +23,9 @@ CmdlineArgs::CmdlineArgs()
           m_controllerAbortOnWarning(false),
           m_developer(false),
           m_safeMode(false),
+          m_autodjReplace(false),
+          m_autodjAddTop(false),
+          m_autodjAddBottom(false),
           m_useLegacyVuMeter(false),
           m_useLegacySpinny(false),
           m_debugAssertBreak(false),
@@ -173,6 +176,24 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
     timelinePathDeprecated.setValueName(timelinePath.valueName());
     parser.addOption(timelinePath);
     parser.addOption(timelinePathDeprecated);
+
+    const QCommandLineOption autodjReplace(QStringLiteral("autodj-replace"),
+            forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
+                                      "If playlist passed, insert in AutoDJ after importing")
+                            : QString());
+    parser.addOption(autodjReplace);
+
+    const QCommandLineOption autodjAddTop(QStringLiteral("autodj-add-top"),
+            forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
+                                      "If playlist passed, add to AutoDJ at top after importing")
+                            : QString());
+    parser.addOption(autodjAddTop);
+
+    const QCommandLineOption autodjAddBottom(QStringLiteral("autodj-add-bottom"),
+            forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
+                                      "If playlist passed, add to AutoDJ at bottom after importing")
+                            : QString());
+    parser.addOption(autodjAddBottom);
 
     const QCommandLineOption enableLegacyVuMeter(QStringLiteral("enable-legacy-vumeter"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
@@ -353,6 +374,9 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
         m_timelinePath = parser.value(timelinePathDeprecated);
     }
 
+    m_autodjReplace = parser.isSet(autodjReplace);
+    m_autodjAddTop = parser.isSet(autodjAddTop);
+    m_autodjAddBottom = parser.isSet(autodjAddBottom);
     m_useLegacyVuMeter = parser.isSet(enableLegacyVuMeter);
     m_useLegacySpinny = parser.isSet(enableLegacySpinny);
     m_controllerDebug = parser.isSet(controllerDebug) || parser.isSet(controllerDebugDeprecated);

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -6,6 +6,7 @@
 #include <QList>
 #include <QString>
 
+#include "library/dao/playlistdao.h"
 #include "util/logging.h"
 
 /// A structure to store the parsed command-line arguments
@@ -44,6 +45,18 @@ class CmdlineArgs final {
     }
 #endif
     bool getSafeMode() const { return m_safeMode; }
+    bool getAutodjEnabled() const {
+        return m_autodjReplace || m_autodjAddTop || m_autodjAddBottom;
+    }
+    PlaylistDAO::AutoDJSendLoc getAutodjLocation() const {
+        if (m_autodjReplace) {
+            return PlaylistDAO::AutoDJSendLoc::REPLACE;
+        } else if (m_autodjAddTop) {
+            return PlaylistDAO::AutoDJSendLoc::TOP;
+        } else {
+            return PlaylistDAO::AutoDJSendLoc::BOTTOM;
+        }
+    }
     bool useColors() const {
         return m_useColors;
     }
@@ -90,6 +103,9 @@ class CmdlineArgs final {
     bool m_qml;
 #endif
     bool m_safeMode;
+    bool m_autodjReplace;
+    bool m_autodjAddTop;
+    bool m_autodjAddBottom;
     bool m_useLegacyVuMeter;
     bool m_useLegacySpinny;
     bool m_debugAssertBreak;

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -73,6 +73,10 @@ class CmdlineArgs final {
         return m_scaleFactor;
     }
 
+    const QString& getPlaylistFilePath() const {
+        return m_playlistFilePath;
+    }
+
   private:
     enum class ParseMode {
         Initial,
@@ -103,4 +107,5 @@ class CmdlineArgs final {
     QString m_settingsPath;
     QString m_resourcePath;
     QString m_timelinePath;
+    QString m_playlistFilePath;
 };

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -73,10 +73,6 @@ class CmdlineArgs final {
         return m_scaleFactor;
     }
 
-    const QString& getPlaylistFilePath() const {
-        return m_playlistFilePath;
-    }
-
   private:
     enum class ParseMode {
         Initial,
@@ -107,5 +103,4 @@ class CmdlineArgs final {
     QString m_settingsPath;
     QString m_resourcePath;
     QString m_timelinePath;
-    QString m_playlistFilePath;
 };


### PR DESCRIPTION
Yet another attempt to close #11178
I decided to open a new PR with a very simple approach because other ones are stale or not finished.
I got inspiration from #11618 for the variable names (so I added @QtKaii as co-author).

### Progress:
- [x] Save passed playlist file into a variable and validate is file exists and if it's an importable file
- [x] Create playlist and import tracks into it
- [x] Activate that playlist OR show an msg box (to give a feedback to the user)
- [x] Move `addPlaylistIfCmdArg()` away from `trackset/setlogfeature.cpp`
- [ ] Support more cmd arguments related to importing playlists or adding to AutoDJ

Let me know what do you think and what can I do for re-implementing the last part of this feature. I'm still a beginner, and I haven't programmed a lot in QT/C++, but I really like this FOSS and I use it a lot daily.