### PR TITLE
(WIP) Axka changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,7 @@ endif()
 #######################################################################
 # Compilers and toolchains
 
+#set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   # GNU is GNU GCC
   set(GNU_GCC true)
@@ -1197,6 +1198,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/widget/wwidget.cpp
   src/widget/wwidgetgroup.cpp
   src/widget/wwidgetstack.cpp
+  src/axkaremote/axkaremote.cpp
 )
 target_precompile_headers(mixxx-lib PUBLIC
   src/audio/frame.h
@@ -2562,6 +2564,7 @@ find_package(Qt${QT_VERSION_MAJOR}
     Test
     Widgets
     Xml
+    HttpServer
     ${QT_EXTRA_COMPONENTS}
   REQUIRED
 )
@@ -2579,7 +2582,8 @@ target_link_libraries(mixxx-lib PUBLIC
   Qt${QT_VERSION_MAJOR}::Svg
   Qt${QT_VERSION_MAJOR}::Test
   Qt${QT_VERSION_MAJOR}::Widgets
-  Qt${QT_VERSION_MAJOR}::Xml)
+  Qt${QT_VERSION_MAJOR}::Xml
+  Qt${QT_VERSION_MAJOR}::HttpServer)
 if(QT_EXTRA_COMPONENTS)
   foreach(COMPONENT ${QT_EXTRA_COMPONENTS})
     target_link_libraries(mixxx-lib PUBLIC Qt6::${COMPONENT})
@@ -3535,3 +3539,4 @@ if(APPLE AND MACOS_BUNDLE)
     configure_file(cmake/modules/BundleInstall.cmake.in "${CMAKE_CURRENT_BINARY_DIR}/BundleInstall.cmake" @ONLY)
     install(SCRIPT "${CMAKE_CURRENT_BINARY_DIR}/BundleInstall.cmake")
 endif()
+

--- a/shell.nix
+++ b/shell.nix
@@ -88,7 +88,9 @@ in pkgs.qt6Packages.callPackage ({
     libGLU, libid3tag, libkeyfinder, libmad, libmodplug, libopus, libsecret, libshout,
     libsndfile, libusb1, libvorbis, libxcb, lilv, lv2, mp4v2, opusfile, pcre, portaudio,
     portmidi, protobuf, qtbase, qtkeychain, qtsvg, rubberband,
-    serd, sord, soundtouch, sratom, sqlite, taglib, upower, vamp-plugin-sdk, wavpack, gtest, gbenchmark, qtdeclarative, qt5compat, microsoft_gsl
+    serd, sord, soundtouch, sratom, sqlite, taglib, upower, vamp-plugin-sdk, wavpack, gtest, gbenchmark, qtdeclarative, qt5compat, microsoft_gsl,
+
+    qthttpserver
 }: stdenv.mkDerivation rec {
   name = "mixxx-${version}";
   # Reading the version from git output is very hard to do without wasting lots of diskspace and
@@ -142,6 +144,7 @@ in pkgs.qt6Packages.callPackage ({
 
     pkgs.microsoft_gsl
     pkgs.gbenchmark
+    qthttpserver
   ] ++ allLv2Plugins;
 
   postInstall = (if releaseMode then ''

--- a/src/axkaremote/axkaremote.cpp
+++ b/src/axkaremote/axkaremote.cpp
@@ -1,0 +1,228 @@
+// axkaremote.cpp
+// Remote control and monitoring system using local sockets
+// Created 2023-10-05 by Axel Karjalainen <axel@axka.fi>
+// vim:set et sw=4 ts=4 sts=4:
+
+#include "axkaremote/axkaremote.h"
+#include <qjsonarray.h>
+#include <qjsondocument.h>
+#include <qjsonobject.h>
+
+#include "control/controlobject.h"
+#include "control/controlproxy.h"
+#include "library/coverart.h"
+#include "preferences/usersettings.h"
+
+#include "errordialoghandler.h"
+#include "mixer/playerinfo.h"
+#include "util/event.h"
+
+#include "mixer/playermanager.h"
+#include <QDebug>
+
+#include "moc_axkaremote.cpp"
+
+namespace mixxx {
+
+AxkaRemote::AxkaRemote(UserSettingsPointer &pConfig)
+    : m_pConfig(pConfig) {
+    m_time.start();
+    qInfo() << "[AxkaRemote] initializing AxkaRemote...";
+
+    createServer();
+
+    broadcastConnectValue("xfader", "[Master]", "crossfader");
+
+    // connect play buttons
+    for (int deckNr = 0; deckNr < (int)PlayerManager::numDecks(); deckNr++) {
+        QString group = PlayerManager::groupForDeck(deckNr);
+
+        broadcastConnectValue(QStringLiteral("deck/%1/volume"), group, "volume");
+
+        connectValue(group, "play", std::bind(&AxkaRemote::broadcastRate, this, deckNr));
+        connectValue(group, "reverse", std::bind(&AxkaRemote::broadcastRate, this, deckNr));
+        connectValue(group, "rate", std::bind(&AxkaRemote::broadcastRate, this, deckNr));
+        connectValue(group, "rateRange", std::bind(&AxkaRemote::broadcastRate, this, deckNr));
+
+        // TODO(axka): cast to bool
+        broadcastConnectValue(QStringLiteral("deck/%1/is_playing"), group, "play");
+
+        connectValue(group, "track_samples", std::bind(&AxkaRemote::broadcastPosition, this, deckNr));
+        connectValue(group, "track_samplerate", std::bind(&AxkaRemote::broadcastPosition, this, deckNr));
+        connectValue(group, "playposition", std::bind(&AxkaRemote::broadcastPosition, this, deckNr));
+
+        // TODO: broadcast on deck (un)loaded and on metadata change
+        connectValue(group, "play", std::bind(&AxkaRemote::broadcastMetadata, this, deckNr));
+        // FIXME: this combined with getMetadata locking a mutex segfaults Mixxx
+        // connectValue(group, "track_loaded", std::bind(&AxkaRemote::broadcastMetadata, this, deckNr));
+    }
+    qInfo() << "[AxkaRemote] initialized AxkaRemote!";
+}
+
+void AxkaRemote::broadcastValue(QString name, QString group, QString item) {
+    ControlProxy control(ConfigKey(group, item));
+    wsBroadcast(name, control.get());
+}
+void AxkaRemote::broadcastConnectValue(QString name, QString group, QString item) {
+    qInfo() << "[AxkaRemote] broadcastConnectValue";
+    auto control = ControlDoublePrivate::getControl(ConfigKey(group, item));
+    DEBUG_ASSERT(control);
+    control->setParent(this);
+    connect(control.data(), &ControlDoublePrivate::valueChanged, [group, item, name, this] (double value, QObject * sender) {
+        qInfo() << "[AxkaRemote] broadcastConnectValue changed for input" << group << item;
+        wsBroadcast(name, value);
+    });
+    /*ControlProxy control(ConfigKey(group, item), this);
+    control.connectValueChanged(this, [name, &control, this] () {
+        qInfo() << "[AxkaRemote] broadcastConnectValue changed";
+        wsBroadcast(name, control.get());
+    });
+    m_connectedControls.append(&control);*/
+}
+void AxkaRemote::connectValue(QString group, QString item, std::function<void (double value)> callback) {
+    qInfo() << "[AxkaRemote] connectValue";
+    auto control = ControlDoublePrivate::getControl(ConfigKey(group, item));
+    DEBUG_ASSERT(control);
+    control->setParent(this);
+    connect(control.data(), &ControlDoublePrivate::valueChanged, [group, item, callback] (double value, QObject * sender) {
+        qInfo() << "[AxkaRemote] connectValue changed for input" << group << item;
+        callback(value);
+    });
+    /*ControlProxy control(ConfigKey(group, item), this);
+    control.connectValueChanged(this, callback);
+    m_connectedControls.append(&control);*/
+}
+
+AxkaRemote::~AxkaRemote() {
+    // FIXME: doesn't do anything .. update: causes a coredump segfault
+    /*for (ControlProxy *pControl : std::as_const(m_connectedControls)) {
+        delete pControl;
+    }*/
+}
+
+void AxkaRemote::broadcastRate(int deckNr) {
+    qInfo() << "[AxkaRemote] broadcastRate";
+    QString group = PlayerManager::groupForDeck(deckNr);
+
+    bool is_reversing = ControlProxy(group, "reverse").toBool();
+    double rate_multiplier = ControlProxy(group, "rate").get() * (is_reversing ? -1 : 1);
+    double rate_max = ControlProxy(group, "rateRange").get();
+
+    // Default:
+    // rate_multiplier: 1
+    // rate_max: 0.08
+    wsBroadcast(QStringLiteral("deck/%1/rate").arg(deckNr), QJsonObject({
+            {"rate_multiplier", rate_multiplier},
+            {"rate_max", rate_max},
+    }));
+}
+
+void AxkaRemote::broadcastPosition(int deckNr) {
+    qInfo() << "[AxkaRemote] broadcastPosition";
+    QString group = PlayerManager::groupForDeck(deckNr);
+
+    // TODO: replace with Track::getDuration() ?
+    double track_samples = ControlProxy(group, "track_samples").get();
+    double track_samplerate = ControlProxy(group, "track_samplerate").get();
+    double duration = track_samples / track_samplerate / 2;
+
+    double playposition_mul = ControlProxy(group, "playposition").get();
+    double playposition_sec = playposition_mul * duration;
+
+    // Default:
+    // duration: -1
+    // playposition_mul: 0
+    // playposition_sec: 0
+    wsBroadcast(QStringLiteral("deck/%1/playposition").arg(deckNr), QJsonObject({
+            {"duration", duration},
+            {"playposition_mul", playposition_mul},
+            {"playposition_sec", playposition_sec},
+    }));
+}
+
+void AxkaRemote::broadcastMetadata(int deckNr) {
+    qInfo() << "[AxkaRemote] broadcastMetadata";
+    QString group = PlayerManager::groupForDeck(deckNr);
+
+    PlayerInfo &playerInfo = PlayerInfo::instance();
+    TrackPointer pTrack =
+        playerInfo.getTrackInfo(PlayerManager::groupForDeck(deckNr));
+    TrackMetadata meta = pTrack->getMetadata();
+
+    CoverInfo::LoadedImage img = pTrack->getCoverInfoWithLocation().loadImage(pTrack);
+    // TODO: use cache and don't send the image over websockets
+    // TODO: check img.result (CoverInfo::LoadedImage::Result)
+    // TODO: check img.image null
+
+    // Default:
+    // title: ""
+    // duration: -1
+    // lyrics: ""
+    wsBroadcast(QStringLiteral("deck/%1/metadata").arg(deckNr), QJsonObject({
+            {"title", pTrack->getTitleInfo()}, // getTitle doesn't fallback to the filename
+            {"duration", pTrack->getDuration()},
+            {"lyrics", meta.getTrackInfo().getLyrics()},
+    }));
+}
+
+void AxkaRemote::createServer() {
+    m_server.route("/", [] () {
+        return "Mixxx AxkaRemote API server";
+    });
+
+    m_server.route("/ws", [](QHttpServerResponder&&) {});
+    connect(&m_server, &QHttpServer::newWebSocketConnection, this, &AxkaRemote::handleWebSocketConnection);
+
+    const auto port = m_server.listen(QHostAddress::Any, 8001);
+    if (!port) {
+        qWarning() << "Server failed to listen on a port.";
+        return;
+    }
+    // TODO: if (CmdlineArgs::Instance().getDeveloper()) {
+    qInfo().noquote() << QStringLiteral("[AxkaRemote]   listening on http://127.0.0.1:%1 (Press CTRL+C to quit)").arg(port);
+}
+
+static QString getIdentifier(QWebSocket *peer)
+{
+    return QStringLiteral("%1:%2").arg(peer->peerAddress().toString(),
+                                       QString::number(peer->peerPort()));
+}
+void AxkaRemote::wsBroadcast(QString kind, QJsonValue value) {
+    auto doc = QJsonDocument(QJsonObject {
+        {
+            {"kind", kind},
+            {"data", value}
+        }
+    });
+    auto message = QString(doc.toJson());
+    for (QWebSocket *pClient : std::as_const(m_clients)) {
+        pClient->sendTextMessage(message);
+    }
+}
+
+void AxkaRemote::handleWebSocketConnection() {
+    auto *pSocket= m_server.nextPendingWebSocketConnection().release();
+    if (pSocket == nullptr) {
+        // This should never happen when using the connection signal
+        return;
+    }
+    qInfo() << "[AxkaRemote]" << getIdentifier(pSocket) << "connected!";
+    pSocket->setParent(this);
+    connect(pSocket, &QWebSocket::textMessageReceived, [this] (QString message) {
+            QWebSocket *pSender = qobject_cast<QWebSocket *>(sender());
+            qInfo() << "[AxkaRemote]" << getIdentifier(pSender) << "sent message:" << message;
+    });
+    connect(pSocket, &QWebSocket::disconnected, [this] () {
+            qInfo() << "[AxkaRemote] disconnecting...";
+            QWebSocket *pClient = qobject_cast<QWebSocket *>(sender());
+            if (pClient) {
+                qInfo() << "[AxkaRemote]" << getIdentifier(pClient) << "disconnected!";
+                m_clients.removeAll(pClient);
+                pClient->deleteLater();
+            }
+    });
+    m_clients << pSocket;
+    wsBroadcast("clientJoined", getIdentifier(pSocket));
+}
+
+} // namespace mixxx

--- a/src/axkaremote/axkaremote.h
+++ b/src/axkaremote/axkaremote.h
@@ -1,0 +1,46 @@
+// axkaremote.h
+// Remote control and monitoring system using local sockets
+// Created 2023-10-05 by Axel Karjalainen <axel@axka.fi>
+// vim:set et sw=4 ts=4 sts=4:
+
+#pragma once
+
+#include <qelapsedtimer.h>
+#include "control/controlobject.h"
+#include "control/controlproxy.h"
+#include "preferences/usersettings.h"
+#include "track/track.h"
+#include <QList>
+#include <QHttpServer>
+
+namespace mixxx {
+
+class AxkaRemote : public QObject {
+    Q_OBJECT
+    public:
+        AxkaRemote(UserSettingsPointer &pConfig);
+        virtual ~AxkaRemote();
+
+    public slots:
+        void createServer();
+        void handleWebSocketConnection();
+
+    private:
+        QElapsedTimer m_time;
+        //QLocalServer m_server;
+        QHttpServer m_server;
+        UserSettingsPointer m_pConfig;
+        QList<ControlProxy *> m_connectedControls;
+        QList<QWebSocket *> m_clients;
+
+        void wsBroadcast(QString key, QJsonValue json);
+        void broadcastPosition(int deckNr);
+        void broadcastRate(int deckNr);
+        void broadcastMetadata(int deckNr);
+        void broadcastValue(QString name, QString group, QString item);
+        void broadcastConnectValue(QString name, QString group, QString item);
+        void connectValue(QString group, QString item, std::function<void (double value)> callback);
+
+};
+
+} // namespace mixxx

--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -38,6 +38,7 @@
 #include "util/translations.h"
 #include "util/versionstore.h"
 #include "vinylcontrol/vinylcontrolmanager.h"
+#include "axkaremote/axkaremote.h"
 
 #ifdef __APPLE__
 #include "util/sandbox.h"
@@ -311,6 +312,8 @@ void CoreServices::initialize(QApplication* pApp) {
     m_pPlayerManager->addPreviewDeck();
 
     m_pEffectsManager->setup();
+
+    m_pAxkaRemote = std::make_unique<mixxx::AxkaRemote>(pConfig);
 
 #ifdef __VINYLCONTROL__
     m_pVCManager->init();

--- a/src/coreservices.h
+++ b/src/coreservices.h
@@ -32,6 +32,7 @@ namespace mixxx {
 class ControlIndicatorTimer;
 class DbConnectionPool;
 class ScreensaverManager;
+class AxkaRemote;
 
 class CoreServices : public QObject {
     Q_OBJECT
@@ -147,6 +148,8 @@ class CoreServices : public QObject {
 
     std::unique_ptr<SkinControls> m_pSkinControls;
     std::unique_ptr<ControlPushButton> m_pTouchShift;
+
+    std::unique_ptr<mixxx::AxkaRemote> m_pAxkaRemote;
 
     Timer m_runtime_timer;
     const CmdlineArgs& m_cmdlineArgs;

--- a/src/track/taglib/trackmetadata_common.cpp
+++ b/src/track/taglib/trackmetadata_common.cpp
@@ -1,6 +1,7 @@
 #include "track/taglib/trackmetadata_common.h"
 
 #include <taglib/tmap.h>
+#include <taglib/tpropertymap.h>
 
 #include "track/tracknumbers.h"
 #include "util/assert.h"
@@ -255,6 +256,7 @@ void importTrackMetadataFromTag(
     pTrackMetadata->refTrackInfo().setArtist(toQString(tag.artist()));
     pTrackMetadata->refTrackInfo().setGenre(toQString(tag.genre()));
     pTrackMetadata->refAlbumInfo().setTitle(toQString(tag.album()));
+    pTrackMetadata->refTrackInfo().setLyrics(toQString(tag.properties().value("LYRICS").toString()));
 
     if ((readMask & ReadTagFlag::OmitComment) == 0) {
         pTrackMetadata->refTrackInfo().setComment(toQString(tag.comment()));
@@ -281,6 +283,13 @@ void exportTrackMetadataIntoTag(
     pTag->setTitle(toTString(trackMetadata.getTrackInfo().getTitle()));
     pTag->setAlbum(toTString(trackMetadata.getAlbumInfo().getTitle()));
     pTag->setGenre(toTString(trackMetadata.getTrackInfo().getGenre()));
+    pTag->setProperties(({
+        auto properties = TagLib::PropertyMap();
+        properties["LYRICS"] = TagLib::StringList(
+            toTString(trackMetadata.getTrackInfo().getLyrics())
+        );
+        properties;
+    }));
 
     // Using setComment() from TagLib::Tag might have undesirable
     // effects if the tag type supports multiple comment fields for

--- a/src/track/trackinfo.h
+++ b/src/track/trackinfo.h
@@ -34,6 +34,9 @@ class TrackInfo final {
 #if defined(__EXTRA_METADATA__)
     MIXXX_DECL_PROPERTY(QString, language, Language)
     MIXXX_DECL_PROPERTY(QString, lyricist, Lyricist)
+#endif // __EXTRA_METADATA__
+    MIXXX_DECL_PROPERTY(QString, lyrics, Lyrics)
+#if defined(__EXTRA_METADATA__)
     MIXXX_DECL_PROPERTY(QString, mood, Mood)
     MIXXX_DECL_PROPERTY(QString, movement, Movement)
     MIXXX_DECL_PROPERTY(QUuid, musicBrainzArtistId, MusicBrainzArtistId)


### PR DESCRIPTION
FYI: _AMEND THIS_ means that I'll force push an amended commit

also FYI: I tried to get Rust in the codebase using [corrosion](https://github.com/corrosion-rs/corrosion), [autocxx](https://github.com/google/autocxx) and [cxx-qt](https://github.com/KDAB/cxx-qt) but couldn't get it working

Should I rebase (fast-forward and add my commits on top or how does it work?) the new commits from main now or compare to an older commit?

I am implementing a REST+WebSockets+JSON remote API with QHttpServer. This is mostly for my personal usage as I hear official Mixxx devs have make an API in the future but I'm open to feedback and for this to be included in Mixxx.

## Copied and modified from [Zulip](https://mixxx.zulipchat.com/#narrow/stream/247620-development-help/topic/Mixxx.20AxkaRemote/near/397976320):

https://github.com/axelkar/mixxx/blob/9e9ef374228dbff4d1ed1e3069d9ef0d2556c935/src/axkaremote/axkaremote.cpp#L150
My code combined with `Track::getMetadata` locking a mutex segfaults Mixxx. Could somebody point me to the problem or a fix?

Oh and somehow `broadcastMetadata` gets executed on track load, even on commit `9e9ef37` which only uses `play` and not `track_loaded`. - SOLVED: I think Mixxx (re)sets play to zero and broadcasts it even if it hasn't changed.

Could it be related to using raw `ControlDoublePrivate::getControl` instead of `ControlProxy` to get the lambda functions working?
Everyone is also free to generally comment on my code as I've never used C++ other than for small microcontroller projects.

When I drag a track to deck 1 it takes a few seconds for Mixxx to crash. Here is a part of the backtrace:
```
(gdb) bt
#0  0x00007f82f96c24d2 in QRecursiveMutex::tryLock(int) () from /nix/store/1q7fbgdb0nsrf0wxw72jxf35lfwj3r99-qtbase-6.5.2/lib/libQt6Core.so.6
#1  0x000000000070e5eb in QRecursiveMutex::lock (this=0x10) at /nix/store/1q7fbgdb0nsrf0wxw72jxf35lfwj3r99-qtbase-6.5.2/include/QtCore/qmutex.h:201
#2  QMutexLocker<QRecursiveMutex>::QMutexLocker (mutex=0x10, this=<synthetic pointer>) at /nix/store/1q7fbgdb0nsrf0wxw72jxf35lfwj3r99-qtbase-6.5.2/include/QtCore/qmutex.h:235
#3  lockMutex (pMutex=0x10) at /home/axel/dev/mixxx/src/util/compatibility/qmutex.h:38
#4  Track::getMetadata (this=0x0, pSourceSyncStatus=pSourceSyncStatus@entry=0x0) at /home/axel/dev/mixxx/src/track/track.cpp:275
#5  0x0000000000752219 in mixxx::AxkaRemote::broadcastMetadata (this=0x50c2e70, deckNr=0) at /nix/store/n8dryz4xf7ln028j37zapgzg4j47p743-gcc-12.3.0/include/c++/12.3.0/bits/shared_ptr_base.h:1665
```
Oh and icons don't show up when launching a Mixxx debug release with `--developer --resourcePath ~/dev/mixxx/res` but I guess it isn't related

Crossfader and deck rate reporting seem to be working. Now I just found out that the crossfader goes from -1 to 1. How is that possible? I though values were only from 0 to 1 in contrast to parameters. - Explained on Zulip

Logs between track drop and coredump:
```
info [CachingReaderWorker 1] [AxkaRemote] connectValue changed for input "[Channel1]" "play"
info [CachingReaderWorker 1] [AxkaRemote] broadcastRate
warning [CachingReaderWorker 1] QSocketNotifier: Socket notifiers cannot be enabled or disabled from another thread
info [CachingReaderWorker 1] [AxkaRemote] broadcastConnectValue changed for input "[Channel1]" "play"
info [CachingReaderWorker 1] [AxkaRemote] connectValue changed for input "[Channel1]" "play"
info [CachingReaderWorker 1] [AxkaRemote] broadcastMetadata
zsh: segmentation fault (core dumped)  ./mixxx-wrapper
```