### PR TITLE
change SKIN_WARNING to show the skin file:line first, then c++ context

### DIFF
--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -356,9 +356,10 @@ QWidget* LegacySkinParser::parseSkin(const QString& skinPath, QWidget* pParent) 
         bool ok = false;
         double value = QString::fromStdString(attribute.value()).toDouble(&ok);
         if (!ok) {
-            SKIN_WARNING(skinDocument, *m_pContext)
-                    << "Error reading double value from skin attribute: "
-                    << QString::fromStdString(attribute.value());
+            SKIN_WARNING(skinDocument,
+                    *m_pContext,
+                    QStringLiteral("Failed reading double value from skin attribute: %1")
+                            .arg(QString::fromStdString(attribute.value())));
             continue;
         }
 
@@ -411,10 +412,12 @@ QWidget* LegacySkinParser::parseSkin(const QString& skinPath, QWidget* pParent) 
     QList<QWidget*> widgets = parseNode(skinDocument);
 
     if (widgets.empty()) {
-        SKIN_WARNING(skinDocument, *m_pContext) << "Skin produced no widgets!";
+        SKIN_WARNING(skinDocument, *m_pContext, QStringLiteral("Skin produced no widgets!"));
         return nullptr;
     } else if (widgets.size() > 1) {
-        SKIN_WARNING(skinDocument, *m_pContext) << "Skin produced more than 1 widget!";
+        SKIN_WARNING(skinDocument,
+                *m_pContext,
+                QStringLiteral("Skin produced more than 1 widget!"));
     }
     return widgets[0];
 }
@@ -619,8 +622,10 @@ QList<QWidget*> LegacySkinParser::parseNode(const QDomElement& node) {
     } else if (nodeName == "SingletonContainer") {
         result = wrapWidget(parseStandardWidget<WSingletonContainer>(node));
     } else {
-        SKIN_WARNING(node, *m_pContext) << "Invalid node name in skin:"
-                                       << nodeName;
+        SKIN_WARNING(node,
+                *m_pContext,
+                QStringLiteral("Invalid node name in skin: %1")
+                        .arg(nodeName));
     }
 
     if (sDebug) {
@@ -673,14 +678,19 @@ QWidget* LegacySkinParser::parseScrollable(const QDomElement& node) {
     if (!childrenNode.isNull()) {
         QDomNodeList childNodes = childrenNode.childNodes();
         if (childNodes.count() != 1) {
-            SKIN_WARNING(node, *m_pContext) << "Scrollables must have exactly one child";
+            SKIN_WARNING(node,
+                    *m_pContext,
+                    QStringLiteral("Scrollables must have exactly one child"));
         }
 
         QDomNode childnode = childNodes.at(0);
         if (childnode.isElement()) {
             QList<QWidget*> children = parseNode(childnode.toElement());
             if (children.count() != 1) {
-                SKIN_WARNING(node, *m_pContext) << "Scrollables must have exactly one child";
+                SKIN_WARNING(node,
+                        *m_pContext,
+                        QStringLiteral(
+                                "Scrollables must have exactly one child"));
             } else if (children.at(0) != nullptr) {
                 pScrollable->setWidget(children.at(0));
             }
@@ -781,15 +791,19 @@ QWidget* LegacySkinParser::parseWidgetStack(const QDomElement& node) {
             QList<QWidget*> child_widgets = parseNode(element);
 
             if (child_widgets.empty()) {
-                SKIN_WARNING(node, *m_pContext)
-                        << "WidgetStack child produced no widget.";
+                SKIN_WARNING(node,
+                        *m_pContext,
+                        QStringLiteral(
+                                "WidgetStack child produced no widget."));
                 continue;
             }
 
             if (child_widgets.size() > 1) {
-                SKIN_WARNING(node, *m_pContext)
-                        << "WidgetStack child produced multiple widgets."
-                        << "All but the first are ignored.";
+                SKIN_WARNING(node,
+                        *m_pContext,
+                        QStringLiteral(
+                                "WidgetStack child produced multiple widgets. "
+                                "All but the first are ignored."));
             }
             QWidget* pChild = child_widgets[0];
 
@@ -849,15 +863,19 @@ QWidget* LegacySkinParser::parseSizeAwareStack(const QDomElement& node) {
             QList<QWidget*> children = parseNode(element);
 
             if (children.empty()) {
-                SKIN_WARNING(node, *m_pContext)
-                        << "SizeAwareStack child produced no widget.";
+                SKIN_WARNING(node,
+                        *m_pContext,
+                        QStringLiteral(
+                                "SizeAwareStack child produced no widget."));
                 continue;
             }
 
             if (children.size() > 1) {
-                SKIN_WARNING(node, *m_pContext)
-                        << "SizeAwareStack child produced multiple widgets."
-                        << "All but the first are ignored.";
+                SKIN_WARNING(node,
+                        *m_pContext,
+                        QStringLiteral(
+                                "SizeAwareStack child produced multiple "
+                                "widgets. All but the first are ignored."));
             }
             QWidget* pChild = children[0];
 
@@ -958,7 +976,7 @@ QWidget* LegacySkinParser::parseOverview(const QDomElement& node) {
     QString group = lookupNodeGroup(node);
     BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(group);
     if (!pPlayer) {
-        SKIN_WARNING(node, *m_pContext) << "No player found for group:" << group;
+        SKIN_WARNING(node, *m_pContext, QStringLiteral("No player found for group: %1").arg(group));
         return nullptr;
     }
 
@@ -1004,7 +1022,7 @@ QWidget* LegacySkinParser::parseVisual(const QDomElement& node) {
     QString group = lookupNodeGroup(node);
     BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(group);
     if (!pPlayer) {
-        SKIN_WARNING(node, *m_pContext) << "No player found for group:" << group;
+        SKIN_WARNING(node, *m_pContext, QStringLiteral("No player found for group: %1").arg(group));
         return nullptr;
     }
 
@@ -1049,7 +1067,7 @@ QWidget* LegacySkinParser::parseText(const QDomElement& node) {
     QString group = lookupNodeGroup(node);
     BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(group);
     if (!pPlayer) {
-        SKIN_WARNING(node, *m_pContext) << "No player found for group:" << group;
+        SKIN_WARNING(node, *m_pContext, QStringLiteral("No player found for group:").arg(group));
         return nullptr;
     }
 
@@ -1079,7 +1097,7 @@ QWidget* LegacySkinParser::parseTrackProperty(const QDomElement& node) {
     QString group = lookupNodeGroup(node);
     BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(group);
     if (!pPlayer) {
-        SKIN_WARNING(node, *m_pContext) << "No player found for group:" << group;
+        SKIN_WARNING(node, *m_pContext, QStringLiteral("No player found for group: %1").arg(group));
         return nullptr;
     }
 
@@ -1119,7 +1137,7 @@ QWidget* LegacySkinParser::parseTrackWidgetGroup(const QDomElement& node) {
     QString group = lookupNodeGroup(node);
     BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(group);
     if (!pPlayer) {
-        SKIN_WARNING(node, *m_pContext) << "No player found for group:" << group;
+        SKIN_WARNING(node, *m_pContext, QStringLiteral("No player found for group: %1").arg(group));
         return nullptr;
     }
 
@@ -1161,7 +1179,7 @@ QWidget* LegacySkinParser::parseStarRating(const QDomElement& node) {
     QString group = lookupNodeGroup(node);
     BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(group);
     if (!pPlayer) {
-        SKIN_WARNING(node, *m_pContext) << "No player found for group:" << group;
+        SKIN_WARNING(node, *m_pContext, QStringLiteral("No player found for group: %1").arg(group));
         return nullptr;
     }
 
@@ -1298,7 +1316,7 @@ QWidget* LegacySkinParser::parseSpinny(const QDomElement& node) {
     QString group = lookupNodeGroup(node);
     BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(group);
     if (!pPlayer) {
-        SKIN_WARNING(node, *m_pContext) << "No player found for group:" << group;
+        SKIN_WARNING(node, *m_pContext, QStringLiteral("No player found for group: %1").arg(group));
         return nullptr;
     }
     // Note: For some reasons on X11 we need to create the widget without a parent to avoid to
@@ -1443,7 +1461,9 @@ QWidget* LegacySkinParser::parseCoverArt(const QDomElement& node) {
     if (!group.isEmpty()) {
         pPlayer = m_pPlayerManager->getPlayer(group);
         if (!pPlayer) {
-            SKIN_WARNING(node, *m_pContext) << "No player found for group:" << group;
+            SKIN_WARNING(node,
+                    *m_pContext,
+                    QStringLiteral("No player found for group: %1").arg(group));
             return nullptr;
         }
     }
@@ -1472,14 +1492,17 @@ QWidget* LegacySkinParser::parseCoverArt(const QDomElement& node) {
 void LegacySkinParser::parseSingletonDefinition(const QDomElement& node) {
     QString objectName = m_pContext->selectString(node, "ObjectName");
     if (objectName.isEmpty()) {
-        SKIN_WARNING(node, *m_pContext)
-                << "SingletonDefinition requires an ObjectName";
+        SKIN_WARNING(node,
+                *m_pContext,
+                QStringLiteral("SingletonDefinition requires an ObjectName"));
     }
 
     QDomNode childrenNode = m_pContext->selectNode(node, "Children");
     if (childrenNode.isNull()) {
-        SKIN_WARNING(node, *m_pContext)
-                << "SingletonDefinition requires a Children tag with one child";
+        SKIN_WARNING(node,
+                *m_pContext,
+                QStringLiteral("SingletonDefinition requires a Children tag "
+                               "with one child"));
     }
 
     // Descend children, taking the first valid element.
@@ -1493,27 +1516,30 @@ void LegacySkinParser::parseSingletonDefinition(const QDomElement& node) {
     }
 
     if (child_node.isNull()) {
-        SKIN_WARNING(node, *m_pContext)
-                << "SingletonDefinition Children node is empty";
+        SKIN_WARNING(node,
+                *m_pContext,
+                QStringLiteral("SingletonDefinition Children node is empty"));
         return;
     }
 
     QDomElement element = child_node.toElement();
     QList<QWidget*> child_widgets = parseNode(element);
     if (child_widgets.empty()) {
-        SKIN_WARNING(node, *m_pContext)
-                << "SingletonDefinition child produced no widget.";
+        SKIN_WARNING(node,
+                *m_pContext,
+                QStringLiteral(
+                        "SingletonDefinition child produced no widget."));
         return;
     } else if (child_widgets.size() > 1) {
-        SKIN_WARNING(node, *m_pContext)
-                << "SingletonDefinition child produced multiple widgets."
-                << "All but the first are ignored.";
+        SKIN_WARNING(node,
+                *m_pContext,
+                QStringLiteral("SingletonDefinition child produced multiple "
+                               "widgets. All but the first are ignored."));
     }
 
     QWidget* pChild = child_widgets[0];
     if (pChild == nullptr) {
-        SKIN_WARNING(node, *m_pContext)
-                << "SingletonDefinition child widget is NULL";
+        SKIN_WARNING(node, *m_pContext, QStringLiteral("SingletonDefinition child widget is NULL"));
         return;
     }
 
@@ -1712,9 +1738,11 @@ QDomElement LegacySkinParser::loadTemplate(const QString& path) {
 
 QList<QWidget*> LegacySkinParser::parseTemplate(const QDomElement& node) {
     if (!node.hasAttribute("src")) {
-        SKIN_WARNING(node, *m_pContext)
-                << "Template instantiation without src attribute:"
-                << node.text();
+        SKIN_WARNING(node,
+                *m_pContext,
+                QStringLiteral(
+                        "Template instantiation without src attribute: %1")
+                        .arg(node.text()));
         return QList<QWidget*>();
     }
 
@@ -1726,7 +1754,10 @@ QList<QWidget*> LegacySkinParser::parseTemplate(const QDomElement& node) {
     QDomElement templateNode = loadTemplate(path);
 
     if (templateNode.isNull()) {
-        SKIN_WARNING(node, *m_pContext) << "Template instantiation for template failed:" << path;
+        SKIN_WARNING(node,
+                *m_pContext,
+                QStringLiteral("Template instantiation for template failed: %1")
+                        .arg(path));
         m_pContext = std::move(pOldContext);
         return QList<QWidget*>();
     }
@@ -1943,9 +1974,11 @@ void LegacySkinParser::setupSize(const QDomNode& node, QWidget* pWidget) {
         } else if (y >= 0 && x == -1) {
             pWidget->setMinimumHeight(y);
         } else if (x != -1 || y != -1) {
-            SKIN_WARNING(node, *m_pContext)
-                    << "Could not parse widget MinimumSize:" << size;
-	}
+            SKIN_WARNING(node,
+                    *m_pContext,
+                    QStringLiteral("Could not parse widget MinimumSize: %1")
+                            .arg(size));
+        }
     }
 
 
@@ -1965,8 +1998,10 @@ void LegacySkinParser::setupSize(const QDomNode& node, QWidget* pWidget) {
         } else if (y >= 0 && x == -1) {
             pWidget->setMaximumHeight(y);
         } else if (x != -1 || y != -1) {
-            SKIN_WARNING(node, *m_pContext)
-                    << "Could not parse widget MaximumSize:" << size;
+            SKIN_WARNING(node,
+                    *m_pContext,
+                    QStringLiteral("Could not parse widget MaximumSize: %1")
+                            .arg(size));
         }
     }
 
@@ -1982,16 +2017,20 @@ void LegacySkinParser::setupSize(const QDomNode& node, QWidget* pWidget) {
         if (parseSizePolicy(&xs, &horizontalPolicy)) {
             sizePolicy.setHorizontalPolicy(horizontalPolicy);
         } else if (!xs.isEmpty()) {
-            SKIN_WARNING(node, *m_pContext)
-                    << "Could not parse horizontal size policy:" << xs;
+            SKIN_WARNING(node,
+                    *m_pContext,
+                    QStringLiteral("Could not parse horizontal size policy: %1")
+                            .arg(xs));
         }
 
         QSizePolicy::Policy verticalPolicy;
         if (parseSizePolicy(&ys, &verticalPolicy)) {
             sizePolicy.setVerticalPolicy(verticalPolicy);
         } else if (!ys.isEmpty()) {
-            SKIN_WARNING(node, *m_pContext)
-                    << "Could not parse vertical size policy:" << ys;
+            SKIN_WARNING(node,
+                    *m_pContext,
+                    QStringLiteral("Could not parse vertical size policy: %1")
+                            .arg(ys));
         }
 
         hasSizePolicyNode = true;
@@ -2164,8 +2203,10 @@ void LegacySkinParser::setupBaseWidget(const QDomNode& node,
         } else if (!toolTipId.isEmpty()) {
             // Only warn if there was a tooltip ID specified and no tooltip for
             // that ID.
-            SKIN_WARNING(node, *m_pContext)
-                    << "Invalid <TooltipId> in skin.xml:" << toolTipId;
+            SKIN_WARNING(node,
+                    *m_pContext,
+                    QStringLiteral("Invalid <TooltipId> in skin.xml: %1")
+                            .arg(toolTipId));
         }
     }
 }
@@ -2275,9 +2316,11 @@ void LegacySkinParser::setupConnections(const QDomNode& node, WBaseWidget* pWidg
                 if (nodeValue) {
                     emitOption = ControlParameterWidgetConnection::EMIT_ON_PRESS_AND_RELEASE;
                 } else {
-                    SKIN_WARNING(con, *m_pContext)
-                            << "LegacySkinParser::setupConnections():"
-                            << "Setting EmitOnPressAndRelease to false is not necessary.";
+                    SKIN_WARNING(con,
+                            *m_pContext,
+                            QStringLiteral("LegacySkinParser::setupConnections("
+                                           "): Setting EmitOnPressAndRelease "
+                                           "to false is not necessary."));
                 }
             } else {
                 // default:

--- a/src/skin/legacy/skincontext.cpp
+++ b/src/skin/legacy/skincontext.cpp
@@ -139,7 +139,7 @@ QDebug SkinContext::logWarning(const char* file,
         const int line,
         const QDomNode& node,
         const QString& message) const {
-    return qWarning() << QString("SKIN ERROR at %1:%2 <%3>: %4 | %5:%6")
+    return qWarning() << QString("Skin parsing failed at %1:%2 <%3>: %4 | %5:%6")
                                  .arg(m_xmlPath,
                                          QString::number(node.lineNumber()),
                                          node.nodeName(),

--- a/src/skin/legacy/skincontext.cpp
+++ b/src/skin/legacy/skincontext.cpp
@@ -135,14 +135,19 @@ PixmapSource SkinContext::getPixmapSourceInner(const QString& filename) const {
     return PixmapSource();
 }
 
-QDebug SkinContext::logWarning(const char* file, const int line,
-                               const QDomNode& node) const {
-    return qWarning() << QString("%1:%2 SKIN ERROR at %3:%4 <%5>:")
-                             .arg(file, QString::number(line), m_xmlPath,
-                                  QString::number(node.lineNumber()),
-                                  node.nodeName())
-                             .toUtf8()
-                             .constData();
+QDebug SkinContext::logWarning(const char* file,
+        const int line,
+        const QDomNode& node,
+        const QString& message) const {
+    return qWarning() << QString("SKIN ERROR at %1:%2 <%3>: %4 | %5:%6")
+                                 .arg(m_xmlPath,
+                                         QString::number(node.lineNumber()),
+                                         node.nodeName(),
+                                         message,
+                                         file,
+                                         QString::number(line))
+                                 .toUtf8()
+                                 .constData();
 }
 
 int SkinContext::scaleToWidgetSize(QString& size) const {

--- a/src/skin/legacy/skincontext.h
+++ b/src/skin/legacy/skincontext.h
@@ -15,7 +15,8 @@
 #include "widget/wpixmapstore.h"
 #include "widget/wsingletoncontainer.h"
 
-#define SKIN_WARNING(node, context) (context).logWarning(__FILE__, __LINE__, (node))
+#define SKIN_WARNING(node, context, message) \
+    (context).logWarning(__FILE__, __LINE__, (node), (message))
 
 // A class for managing the current context/environment when processing a
 // skin. Used hierarchically by LegacySkinParser to create new contexts and
@@ -225,7 +226,10 @@ class SkinContext {
         return defaultDrawMode;
     }
 
-    QDebug logWarning(const char* file, const int line, const QDomNode& node) const;
+    QDebug logWarning(const char* file,
+            const int line,
+            const QDomNode& node,
+            const QString& message) const;
 
     void defineSingleton(const QString& objectName, QWidget* widget) {
         m_pSharedState->singletons.insertSingleton(objectName, widget);

--- a/src/widget/wcombobox.cpp
+++ b/src/widget/wcombobox.cpp
@@ -25,8 +25,10 @@ void WComboBox::setup(const QDomNode& node, const SkinContext& context) {
                 QString icon = context.selectString(state, "Icon");
                 addItem(QIcon(icon), text, QVariant(iState));
             } else {
-                SKIN_WARNING(state, context)
-                        << "WComboBox ignoring <State> without <Number> node.";
+                SKIN_WARNING(state,
+                        context,
+                        QStringLiteral("WComboBox ignoring <State> without "
+                                       "<Number> node."));
             }
         }
         state = state.nextSibling();

--- a/src/widget/weffectbuttonparametername.cpp
+++ b/src/widget/weffectbuttonparametername.cpp
@@ -22,8 +22,10 @@ void WEffectButtonParameterName::setup(const QDomNode& node, const SkinContext& 
             EffectWidgetUtils::getButtonParameterSlotFromNode(
                     node, context, m_pEffectSlot);
     VERIFY_OR_DEBUG_ASSERT(m_pParameterSlot) {
-        SKIN_WARNING(node, context)
-                << "EffectButtonParameter node could not attach to effect parameter";
+        SKIN_WARNING(node,
+                context,
+                QStringLiteral("EffectButtonParameter node could not attach to "
+                               "effect parameter"));
     }
     setEffectParameterSlot(m_pParameterSlot);
 }

--- a/src/widget/weffectchain.cpp
+++ b/src/widget/weffectchain.cpp
@@ -19,8 +19,10 @@ void WEffectChain::setup(const QDomNode& node, const SkinContext& context) {
     if (pChainSlot) {
         setEffectChain(pChainSlot);
     } else {
-        SKIN_WARNING(node, context)
-                << "EffectChain node could not attach to effect chain slot.";
+        SKIN_WARNING(node,
+                context,
+                QStringLiteral("EffectChain node could not attach to effect "
+                               "chain slot."));
     }
 }
 

--- a/src/widget/weffectchainpresetbutton.cpp
+++ b/src/widget/weffectchainpresetbutton.cpp
@@ -26,8 +26,10 @@ void WEffectChainPresetButton::setup(const QDomNode& node, const SkinContext& co
     m_pChain = EffectWidgetUtils::getEffectChainFromNode(
             node, context, m_pEffectsManager);
     VERIFY_OR_DEBUG_ASSERT(m_pChain) {
-        SKIN_WARNING(node, context)
-                << "EffectChainPresetButton node could not attach to effect chain";
+        SKIN_WARNING(node,
+                context,
+                QStringLiteral("EffectChainPresetButton node could not attach "
+                               "to effect chain"));
         return;
     }
     connect(m_pChain.get(),

--- a/src/widget/weffectchainpresetselector.cpp
+++ b/src/widget/weffectchainpresetselector.cpp
@@ -31,8 +31,10 @@ void WEffectChainPresetSelector::setup(const QDomNode& node, const SkinContext& 
             node, context, m_pEffectsManager);
 
     VERIFY_OR_DEBUG_ASSERT(m_pChain != nullptr) {
-        SKIN_WARNING(node, context)
-                << "EffectChainPresetSelector node could not attach to EffectChain";
+        SKIN_WARNING(node,
+                context,
+                QStringLiteral("EffectChainPresetSelector node could not "
+                               "attach to EffectChain"));
         return;
     }
 

--- a/src/widget/weffectknobparametername.cpp
+++ b/src/widget/weffectknobparametername.cpp
@@ -22,8 +22,10 @@ void WEffectKnobParameterName::setup(const QDomNode& node, const SkinContext& co
             EffectWidgetUtils::getParameterSlotFromNode(
                     node, context, m_pEffectSlot);
     VERIFY_OR_DEBUG_ASSERT(m_pParameterSlot) {
-        SKIN_WARNING(node, context)
-                << "EffectParameter node could not attach to effect parameter";
+        SKIN_WARNING(node,
+                context,
+                QStringLiteral("EffectParameter node could not attach to "
+                               "effect parameter"));
     }
     setEffectParameterSlot(m_pParameterSlot);
 }

--- a/src/widget/weffectname.cpp
+++ b/src/widget/weffectname.cpp
@@ -22,8 +22,10 @@ void WEffectName::setup(const QDomNode& node, const SkinContext& context) {
     if (pEffectSlot) {
         setEffectSlot(pEffectSlot);
     } else {
-        SKIN_WARNING(node, context)
-                << "EffectName node could not attach to effect slot.";
+        SKIN_WARNING(node,
+                context,
+                QStringLiteral(
+                        "EffectName node could not attach to effect slot."));
     }
 }
 

--- a/src/widget/weffectparameterknob.cpp
+++ b/src/widget/weffectparameterknob.cpp
@@ -12,7 +12,7 @@ void WEffectParameterKnob::setup(const QDomNode& node, const SkinContext& contex
     m_pEffectParameterSlot = EffectWidgetUtils::getParameterSlotFromNode(
             node, context, pEffectSlot);
     VERIFY_OR_DEBUG_ASSERT(m_pEffectParameterSlot) {
-        SKIN_WARNING(node, context) << "Could not find effect parameter slot";
+        SKIN_WARNING(node, context, QStringLiteral("Could not find effect parameter slot"));
         return;
     }
     connect(m_pEffectParameterSlot.data(),

--- a/src/widget/weffectparameterknobcomposed.cpp
+++ b/src/widget/weffectparameterknobcomposed.cpp
@@ -12,7 +12,7 @@ void WEffectParameterKnobComposed::setup(const QDomNode& node, const SkinContext
     m_pEffectParameterSlot = EffectWidgetUtils::getParameterSlotFromNode(
             node, context, pEffectSlot);
     VERIFY_OR_DEBUG_ASSERT(m_pEffectParameterSlot) {
-        SKIN_WARNING(node, context) << "Could not find effect parameter slot";
+        SKIN_WARNING(node, context, QStringLiteral("Could not find effect parameter slot"));
         return;
     }
     connect(m_pEffectParameterSlot.data(),

--- a/src/widget/weffectpushbutton.cpp
+++ b/src/widget/weffectpushbutton.cpp
@@ -23,7 +23,7 @@ void WEffectPushButton::setup(const QDomNode& node, const SkinContext& context) 
     m_pEffectParameterSlot = EffectWidgetUtils::getButtonParameterSlotFromNode(
             node, context, pEffectSlot);
     if (!m_pEffectParameterSlot) {
-        SKIN_WARNING(node, context) << "Could not find effect parameter slot";
+        SKIN_WARNING(node, context, QStringLiteral("Could not find effect parameter slot"));
         DEBUG_ASSERT(false);
     }
     connect(m_pEffectParameterSlot.data(),

--- a/src/widget/weffectselector.cpp
+++ b/src/widget/weffectselector.cpp
@@ -42,8 +42,10 @@ void WEffectSelector::setup(const QDomNode& node, const SkinContext& context) {
                 this,
                 &WEffectSelector::slotEffectSelected);
     } else {
-        SKIN_WARNING(node, context)
-                << "EffectSelector node could not attach to effect slot.";
+        SKIN_WARNING(node,
+                context,
+                QStringLiteral("EffectSelector node could not attach to effect "
+                               "slot."));
     }
 
     populate();

--- a/src/widget/whotcuebutton.cpp
+++ b/src/widget/whotcuebutton.cpp
@@ -33,7 +33,10 @@ void WHotcueButton::setup(const QDomNode& node, const SkinContext& context) {
     if (ok && hotcue > 0) {
         m_hotcue = hotcue - 1;
     } else {
-        SKIN_WARNING(node, context) << "Hotcue value invalid";
+        SKIN_WARNING(node,
+                context,
+                QStringLiteral("Hotcue index '%1' invalid")
+                        .arg(context.selectString(node, QStringLiteral("Hotcue"))));
     }
 
     bool okay;
@@ -84,7 +87,7 @@ void WHotcueButton::setup(const QDomNode& node, const SkinContext& context) {
 
     QDomNode con = context.selectNode(node, QStringLiteral("Connection"));
     if (!con.isNull()) {
-        SKIN_WARNING(node, context) << "Additional Connections are not allowed";
+        SKIN_WARNING(node, context, QStringLiteral("Additional Connections are not allowed"));
     }
 }
 

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -195,9 +195,13 @@ void WPushButton::setup(const QDomNode& node, const SkinContext& context) {
                 if (m_rightButtonMode != ControlPushButton::PUSH &&
                         m_rightButtonMode != ControlPushButton::TOGGLE &&
                         m_rightButtonMode != ControlPushButton::TRIGGER) {
-                    SKIN_WARNING(node, context)
-                            << "WPushButton::setup: Connecting a Pushbutton not in PUSH, TRIGGER or TOGGLE mode is not implemented\n"
-                            << "Please consider to set <RightClickIsPushButton>true</RightClickIsPushButton>";
+                    SKIN_WARNING(node,
+                            context,
+                            "WPushButton::setup: Connecting a Pushbutton not "
+                            "in PUSH, TRIGGER or TOGGLE mode is not "
+                            "implemented\n Please consider to set "
+                            "<RightClickIsPushButton>true</"
+                            "RightClickIsPushButton>");
                 }
             }
         }

--- a/src/widget/wsingletoncontainer.cpp
+++ b/src/widget/wsingletoncontainer.cpp
@@ -20,19 +20,19 @@ void WSingletonContainer::setup(const QDomNode& node, const SkinContext& context
     QDomElement containerNode = node.toElement();
     QString objectName;
     if (!context.hasNodeSelectString(node, "ObjectName", &objectName)) {
-        SKIN_WARNING(node, context)
-                << "Need objectName attribute for Singleton tag";
+        SKIN_WARNING(node, context, QStringLiteral("Need ObjectName attribute for Singleton tag"));
         return;
     }
     if (objectName.isEmpty()) {
-        SKIN_WARNING(node, context)
-                << "Singleton tag's ObjectName is empty";
+        SKIN_WARNING(node, context, QStringLiteral("Singleton tag's ObjectName is empty"));
         return;
     }
     m_pWidget = context.getSingletonWidget(objectName);
     if (m_pWidget == nullptr) {
-        SKIN_WARNING(node, context)
-                << "Asked for an unknown singleton widget:" << objectName;
+        SKIN_WARNING(node,
+                context,
+                QStringLiteral("Asked for an unknown singleton widget: %1")
+                        .arg(objectName));
     }
 }
 

--- a/src/widget/wsplitter.cpp
+++ b/src/widget/wsplitter.cpp
@@ -35,22 +35,19 @@ void WSplitter::setup(const QDomNode& node, const SkinContext& context) {
 
         if (m_pConfig->exists(m_configKey)) {
             sizesJoined = m_pConfig->getValueString(m_configKey);
-            msg = "Reading .cfg file: '"
-                    + m_configKey.group + " "
-                    + m_configKey.item + " "
-                    + sizesJoined
-                    + "' does not match the number of children nodes:"
-                    + QString::number(this->count());
+            msg = "Reading .cfg file: '" + m_configKey.group + " " +
+                    m_configKey.item + " " + sizesJoined +
+                    "' does not match the number of children nodes:" +
+                    QString::number(count());
             ok = true;
         }
     }
 
     // nothing in mixxx.cfg? Load default values
     if (!ok && context.hasNodeSelectString(node, "SplitSizes", &sizesJoined)) {
-        msg = "<SplitSizes> for <Splitter> ("
-                + sizesJoined
-                + ") does not match the number of children nodes:"
-                + QString::number(this->count());
+        msg = "<SplitSizes> for <Splitter> (" + sizesJoined +
+                ") does not match the number of children nodes:" +
+                QString::number(count());
     }
 
     // found some value for splitsizes?
@@ -64,8 +61,8 @@ void WSplitter::setup(const QDomNode& node, const SkinContext& context) {
                 break;
             }
         }
-        if (sizesList.length() != this->count()) {
-            SKIN_WARNING(node, context) << msg;
+        if (sizesList.length() != count()) {
+            SKIN_WARNING(node, context, msg);
             ok = false;
         }
         if (ok) {
@@ -85,12 +82,11 @@ void WSplitter::setup(const QDomNode& node, const SkinContext& context) {
                 break;
             }
         }
-        if (collapsibleList.length() != this->count()) {
-            msg = "<Collapsible> for <Splitter> ("
-                            + collapsibleJoined
-                            + ") does not match the number of children nodes:"
-                            + QString::number(this->count());
-            SKIN_WARNING(node, context) << msg;
+        if (collapsibleList.length() != count()) {
+            msg = "<Collapsible> for <Splitter> (" + collapsibleJoined +
+                    ") does not match the number of children nodes:" +
+                    QString::number(count());
+            SKIN_WARNING(node, context, msg);
             ok = false;
         }
         if (ok) {

--- a/src/widget/wvumeterbase.cpp
+++ b/src/widget/wvumeterbase.cpp
@@ -80,8 +80,10 @@ void WVuMeterBase::setup(const QDomNode& node, const SkinContext& context) {
     if (height() < 2 || width() < 2) {
         // This triggers a QT bug and displays a white widget instead.
         // We warn here, because the skin designer may not use the affected mode.
-        SKIN_WARNING(node, context)
-                << "VuMeterBase needs to have 2 pixel in all extents to be visible on all targets.";
+        SKIN_WARNING(node,
+                context,
+                QStringLiteral("VuMeterBase needs to have 2 pixel in all "
+                               "extents to be visible on all targets."));
     }
 
     setFocusPolicy(Qt::NoFocus);


### PR DESCRIPTION
The failing skin xml line can now be spotted much easier, especially if your source directory path is rather long.

before:
```qml
warning [Main] /long/path/to/mixxx-source-directory/src/widget/whotcuebutton.cpp:36 SKIN ERROR at skin:../LateNight/controls/button_hotcue.xml:10 <HotcueButton>: Hotcue value invalid
```

now:
```qml
warning [Main] Skin parsing failed at skin:../LateNight/controls/button_hotcue.xml:10 <HotcueButton>: Hotcue value invalid at /long/path/to/mixxx-source-directory/src/widget/whotcuebutton.cpp:36
```

The xml path and the error message are meaningful already, so maybe we can omit  `/path/to/mixxx-source-file/:123` altogether. Just my impression, I didn't check all usages.