### PR TITLE
SettingsManager: remove unused initializeDefaults()

### DIFF
--- a/src/preferences/settingsmanager.cpp
+++ b/src/preferences/settingsmanager.cpp
@@ -23,8 +23,6 @@ SettingsManager::SettingsManager(const QString& settingsPath)
     }
     m_bShouldRescanLibrary = upgrader.rescanLibrary();
 
-    initializeDefaults();
-
     ControlDoublePrivate::setUserConfig(m_pSettings);
 
 #ifdef __BROADCAST__
@@ -35,12 +33,4 @@ SettingsManager::SettingsManager(const QString& settingsPath)
 
 SettingsManager::~SettingsManager() {
     ControlDoublePrivate::setUserConfig(UserSettingsPointer());
-}
-
-void SettingsManager::initializeDefaults() {
-    QString resourcePath = m_pSettings->getResourcePath();
-
-    // Store the last resource path in the config database.
-    // TODO(rryan): this looks unused.
-    m_pSettings->set(ConfigKey("[Config]", "Path"), ConfigValue(resourcePath));
 }

--- a/src/preferences/settingsmanager.h
+++ b/src/preferences/settingsmanager.h
@@ -29,8 +29,6 @@ class SettingsManager {
     }
 
   private:
-    void initializeDefaults();
-
     UserSettingsPointer m_pSettings;
     bool m_bShouldRescanLibrary;
 #ifdef __BROADCAST__


### PR DESCRIPTION
noticed when I stumbled upon `[Config] Path` in mixxx.cfg which is supposed to store the last used resource path, though it's never read.