### PR TITLE
feat(control): Do not show CO aliases in developer tools window

### DIFF
--- a/src/control/controlmodel.cpp
+++ b/src/control/controlmodel.cpp
@@ -15,8 +15,6 @@ ControlModel::ControlModel(QObject* pParent)
     // Add all controls to Model
     const QList<QSharedPointer<ControlDoublePrivate>> controlsList =
             ControlDoublePrivate::getAllInstances();
-    const QHash<ConfigKey, ConfigKey> controlAliases =
-            ControlDoublePrivate::getControlAliases();
 
     for (const QSharedPointer<ControlDoublePrivate>& pControl : controlsList) {
         if (!pControl) {
@@ -26,14 +24,6 @@ ControlModel::ControlModel(QObject* pParent)
         addControl(pControl->getKey(),
                 pControl->name(),
                 pControl->description());
-
-        ConfigKey aliasKey = controlAliases[pControl->getKey()];
-        if (aliasKey.isValid()) {
-            addControl(aliasKey,
-                    pControl->name(),
-                    QStringLiteral("Alias for ") + pControl->getKey().group +
-                            pControl->getKey().item);
-        }
     }
 }
 


### PR DESCRIPTION
This hides aliases in the control model. Aliases are only for backwards compatibility, so this reduces the risk that mapping developers use these COs for new mappings.

This also removes a bunch of CO deprecation warnings when opening the developer tools window or starting the QML interface.