### PR TITLE
avoid overlapping marks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1405,6 +1405,7 @@ else()
     src/waveform/renderers/waveformrendererrgb.cpp
     src/waveform/renderers/waveformrenderersignalbase.cpp
     src/waveform/renderers/waveformrendermark.cpp
+    src/waveform/renderers/waveformrendermarkbase.cpp
     src/waveform/renderers/waveformrendermarkrange.cpp
     src/waveform/renderers/waveformsignalcolors.cpp
     src/waveform/renderers/waveformwidgetrenderer.cpp

--- a/src/waveform/renderers/allshader/waveformrendermark.cpp
+++ b/src/waveform/renderers/allshader/waveformrendermark.cpp
@@ -3,6 +3,7 @@
 #include <QOpenGLTexture>
 #include <QPainterPath>
 
+#include "util/colorcomponents.h"
 #include "util/texture.h"
 #include "waveform/renderers/allshader/matrixforwidgetgeometry.h"
 #include "waveform/renderers/allshader/rgbadata.h"

--- a/src/waveform/renderers/allshader/waveformrendermark.h
+++ b/src/waveform/renderers/allshader/waveformrendermark.h
@@ -1,13 +1,11 @@
 #pragma once
 
 #include <QColor>
-#include <QObject>
 
 #include "shaders/rgbashader.h"
 #include "shaders/textureshader.h"
-#include "util/class.h"
-#include "waveform/renderers/allshader/waveformrenderer.h"
-#include "waveform/renderers/waveformmarkset.h"
+#include "waveform/renderers/allshader/waveformrendererabstract.h"
+#include "waveform/renderers/waveformrendermarkbase.h"
 
 class QDomNode;
 class SkinContext;
@@ -17,32 +15,28 @@ namespace allshader {
 class WaveformRenderMark;
 }
 
-class allshader::WaveformRenderMark final : public QObject, public allshader::WaveformRenderer {
-    Q_OBJECT
+class allshader::WaveformRenderMark : public ::WaveformRenderMarkBase,
+                                      public allshader::WaveformRendererAbstract {
   public:
     explicit WaveformRenderMark(WaveformWidgetRenderer* waveformWidget);
 
-    void setup(const QDomNode& node, const SkinContext& context) override;
+    void draw(QPainter* painter, QPaintEvent* event) override {
+        Q_UNUSED(painter);
+        Q_UNUSED(event);
+    }
+
+    allshader::WaveformRendererAbstract* allshaderWaveformRenderer() override {
+        return this;
+    }
 
     void initializeGL() override;
     void paintGL() override;
     void resizeGL(int w, int h) override;
 
-    // Called when a new track is loaded.
-    void onSetTrack() override;
-
-  public slots:
-    // Called when the loaded track's cues are added, deleted or modified and
-    // when a new track is loaded.
-    // It updates the marks' names and regenerates their image if needed.
-    // This method is used for hotcues.
-    void slotCuesUpdated();
-
   private:
-    void checkCuesUpdated();
+    void updateMarkImage(WaveformMarkPointer pMark) override;
 
-    void generateMarkImage(WaveformMarkPointer pMark);
-    void generatePlayPosMarkTexture();
+    void updatePlayPosMarkTexture();
 
     void drawTriangle(QPainter* painter,
             const QBrush& fillColor,
@@ -50,11 +44,9 @@ class allshader::WaveformRenderMark final : public QObject, public allshader::Wa
             QPointF p2,
             QPointF p3);
 
-    WaveformMarkSet m_marks;
     mixxx::RGBAShader m_rgbaShader;
     mixxx::TextureShader m_textureShader;
     std::unique_ptr<QOpenGLTexture> m_pPlayPosMarkTexture;
-    bool m_bCuesUpdates;
 
     void drawMark(const QRectF& rect, QColor color);
     void drawTexture(float x, float y, QOpenGLTexture* texture);

--- a/src/waveform/renderers/waveformmark.cpp
+++ b/src/waveform/renderers/waveformmark.cpp
@@ -10,6 +10,11 @@
 #include "widget/wskincolor.h"
 
 namespace {
+
+// Without some padding, the user would only have a single pixel width that
+// would count as hovering over the WaveformMark.
+constexpr float lineHoverPadding = 5.0;
+
 Qt::Alignment decodeAlignmentFlags(const QString& alignString, Qt::Alignment defaultFlags) {
     QStringList stringFlags = alignString.toLower()
                                       .split('|',
@@ -137,10 +142,8 @@ void WaveformMark::setBaseColor(QColor baseColor, int dimBrightThreshold) {
 }
 
 bool WaveformMark::lineHovered(QPoint point, Qt::Orientation orientation) const {
-    // Without some padding, the user would only have a single pixel width that
-    // would count as hovering over the WaveformMark.
-    float lineHoverPadding = 5.0;
     if (orientation == Qt::Vertical) {
+        // Note that for vertical orientation, breadth is set to the width.
         point = QPoint(point.y(), static_cast<int>(m_breadth) - point.x());
     }
     return m_linePosition >= point.x() - lineHoverPadding &&
@@ -306,7 +309,7 @@ QImage WaveformMark::generateImage(float devicePixelRatio) {
     const bool useIcon = m_iconPath != "";
 
     // Determine drawing geometries
-    const MarkerGeometry markerGeometry(label, useIcon, m_align, m_breadth, m_level);
+    const MarkerGeometry markerGeometry{label, useIcon, m_align, m_breadth, m_level};
 
     m_label.setAreaRect(markerGeometry.m_labelRect);
 

--- a/src/waveform/renderers/waveformmark.cpp
+++ b/src/waveform/renderers/waveformmark.cpp
@@ -136,17 +136,22 @@ void WaveformMark::setBaseColor(QColor baseColor, int dimBrightThreshold) {
     setNeedsImageUpdate();
 }
 
-bool WaveformMark::contains(QPoint point, Qt::Orientation orientation) const {
+bool WaveformMark::lineHovered(QPoint point, Qt::Orientation orientation) const {
     // Without some padding, the user would only have a single pixel width that
     // would count as hovering over the WaveformMark.
     float lineHoverPadding = 5.0;
     if (orientation == Qt::Vertical) {
         point = QPoint(point.y(), static_cast<int>(m_breadth) - point.x());
     }
-    bool lineHovered = m_linePosition >= point.x() - lineHoverPadding &&
+    return m_linePosition >= point.x() - lineHoverPadding &&
             m_linePosition <= point.x() + lineHoverPadding;
+}
 
-    return m_label.area().contains(point) || lineHovered;
+bool WaveformMark::contains(QPoint point, Qt::Orientation orientation) const {
+    if (orientation == Qt::Vertical) {
+        point = QPoint(point.y(), static_cast<int>(m_breadth) - point.x());
+    }
+    return m_label.area().contains(point);
 }
 
 // Helper struct to calculate the geometry and fontsize needed by generateImage

--- a/src/waveform/renderers/waveformmark.h
+++ b/src/waveform/renderers/waveformmark.h
@@ -19,8 +19,8 @@ class WaveformMark {
   public:
     class Graphics {
       public:
-        Graphics() {
-        }
+        // To indicate that the image for the mark needs to be regenerated,
+        // when the text, color, breadth or level are changed.
         bool m_obsolete{};
     };
 
@@ -149,6 +149,10 @@ class WaveformMark {
 
     float m_linePosition;
     float m_breadth;
+
+    // When there are overlapping marks, level is increased for each overlapping mark,
+    // so that we can draw them at different positions: The marks at the top go lower
+    // when the level increased, the marks at the bottom higher.
     int m_level;
 
     WaveformMarkLabel m_label;

--- a/src/waveform/renderers/waveformmark.h
+++ b/src/waveform/renderers/waveformmark.h
@@ -134,6 +134,8 @@ class WaveformMark {
         }
     }
 
+    // Check if a point (in image coordinates) lies on the line
+    bool lineHovered(QPoint point, Qt::Orientation orientation) const;
     // Check if a point (in image coordinates) lies on drawn image.
     bool contains(QPoint point, Qt::Orientation orientation) const;
 

--- a/src/waveform/renderers/waveformmark.h
+++ b/src/waveform/renderers/waveformmark.h
@@ -19,16 +19,16 @@ class WaveformMark {
   public:
     class Graphics {
       public:
-        Graphics()
-                : m_obsolete{false} {
+        Graphics() {
         }
-        bool m_obsolete;
+        bool m_obsolete{};
     };
 
     WaveformMark(
             const QString& group,
             const QDomNode& node,
             const SkinContext& context,
+            int priority,
             const WaveformSignalColors& signalColors,
             int hotCue = Cue::kNoHotCue);
     ~WaveformMark();
@@ -39,6 +39,9 @@ class WaveformMark {
 
     int getHotCue() const {
         return m_iHotCue;
+    };
+    int getPriority() const {
+        return m_iPriority;
     };
 
     // The m_pPositionCO related function
@@ -85,22 +88,56 @@ class WaveformMark {
         m_pVisibleCO->connectValueChanged(receiver, slot, Qt::AutoConnection);
     }
 
+    void setText(const QString& text) {
+        if (m_text != text) {
+            m_text = text;
+            setNeedsImageUpdate();
+        }
+    }
+
     // Sets the appropriate mark colors based on the base color
     void setBaseColor(QColor baseColor, int dimBrightThreshold);
+
     QColor fillColor() const {
         return m_fillColor;
     }
+
     QColor borderColor() const {
         return m_borderColor;
     }
+
     QColor labelColor() const {
         return m_labelColor;
+    }
+
+    void setNeedsImageUpdate() {
+        if (m_pGraphics) {
+            m_pGraphics->m_obsolete = true;
+        }
+    }
+
+    bool needsImageUpdate() const {
+        return !m_pGraphics || m_pGraphics->m_obsolete;
+    }
+
+    void setBreadth(float breadth) {
+        if (m_breadth != breadth) {
+            m_breadth = breadth;
+            setNeedsImageUpdate();
+        }
+    }
+
+    void setLevel(int level) {
+        if (m_level != level) {
+            m_level = level;
+            setNeedsImageUpdate();
+        }
     }
 
     // Check if a point (in image coordinates) lies on drawn image.
     bool contains(QPoint point, Qt::Orientation orientation) const;
 
-    QImage generateImage(float breath, float devicePixelRatio);
+    QImage generateImage(float devicePixelRatio);
 
     QColor m_textColor;
     QString m_text;
@@ -109,7 +146,8 @@ class WaveformMark {
     QString m_iconPath;
 
     float m_linePosition;
-    int m_breadth;
+    float m_breadth;
+    int m_level;
 
     WaveformMarkLabel m_label;
 
@@ -118,10 +156,9 @@ class WaveformMark {
     std::unique_ptr<ControlProxy> m_pEndPositionCO;
     std::unique_ptr<ControlProxy> m_pVisibleCO;
 
-    friend class allshader::WaveformRenderMark;
-
     std::unique_ptr<Graphics> m_pGraphics;
 
+    int m_iPriority;
     int m_iHotCue;
 
     QColor m_fillColor;
@@ -129,6 +166,8 @@ class WaveformMark {
     QColor m_labelColor;
 
     friend class WaveformRenderMark;
+    friend class WaveformRenderMarkBase;
+    friend class allshader::WaveformRenderMark;
 };
 
 typedef QSharedPointer<WaveformMark> WaveformMarkPointer;
@@ -140,27 +179,18 @@ typedef QSharedPointer<WaveformMark> WaveformMarkPointer;
 // temporarily incorrect sort order is acceptable.
 class WaveformMarkSortKey {
   public:
-    WaveformMarkSortKey(double samplePosition, int hotcue)
+    WaveformMarkSortKey(double samplePosition, int priority)
             : m_samplePosition(samplePosition),
-              m_hotcue(hotcue) {
+              m_priority(priority) {
     }
 
     bool operator<(const WaveformMarkSortKey& other) const {
-        if (m_samplePosition == other.m_samplePosition) {
-            // Sort WaveformMarks without hotcues before those with hotcues;
-            // if both have hotcues, sort numerically by hotcue number.
-            if (m_hotcue == Cue::kNoHotCue && other.m_hotcue != Cue::kNoHotCue) {
-                return true;
-            } else if (m_hotcue != Cue::kNoHotCue && other.m_hotcue == Cue::kNoHotCue) {
-                return false;
-            } else {
-                return m_hotcue < other.m_hotcue;
-            }
-        }
-        return m_samplePosition < other.m_samplePosition;
+        return m_samplePosition == other.m_samplePosition
+                ? m_priority < other.m_priority
+                : m_samplePosition < other.m_samplePosition;
     }
 
   private:
     double m_samplePosition;
-    int m_hotcue;
+    int m_priority;
 };

--- a/src/waveform/renderers/waveformmarkset.cpp
+++ b/src/waveform/renderers/waveformmarkset.cpp
@@ -101,6 +101,10 @@ void WaveformMarkSet::update() {
             [](auto const& pair) { return pair.second; });
 
     double prevSamplePosition = Cue::kNoPosition;
+
+    // Avoid overlapping marks by increasing the level per alignment.
+    // We take this into account when drawing the marks aligned at:
+    // left top, right top, left bottom, right bottom.
     std::map<Qt::Alignment, int> levels;
     for (auto& pMark : m_marksToRender) {
         if (pMark->getSamplePosition() != prevSamplePosition) {

--- a/src/waveform/renderers/waveformmarkset.cpp
+++ b/src/waveform/renderers/waveformmarkset.cpp
@@ -23,13 +23,16 @@ void WaveformMarkSet::setup(const QString& group, const QDomNode& node,
 
     QDomNode child = node.firstChild();
     QDomNode defaultChild;
+    int priority = 0;
     while (!child.isNull()) {
         if (child.nodeName() == "DefaultMark") {
-            m_pDefaultMark = WaveformMarkPointer(new WaveformMark(group, child, context, signalColors));
+            m_pDefaultMark = WaveformMarkPointer(new WaveformMark(
+                    group, child, context, --priority, signalColors));
             hasDefaultMark = true;
             defaultChild = child;
         } else if (child.nodeName() == "Mark") {
-            WaveformMarkPointer pMark(new WaveformMark(group, child, context, signalColors));
+            WaveformMarkPointer pMark(new WaveformMark(
+                    group, child, context, --priority, signalColors));
             if (pMark->isValid()) {
                 // guarantee uniqueness even if there is a misdesigned skin
                 QString item = pMark->getItem();
@@ -52,7 +55,8 @@ void WaveformMarkSet::setup(const QString& group, const QDomNode& node,
         for (int i = 0; i < NUM_HOT_CUES; ++i) {
             if (m_hotCueMarks.value(i).isNull()) {
                 //qDebug() << "WaveformRenderMark::setup - Automatic mark" << hotCueControlItem;
-                WaveformMarkPointer pMark(new WaveformMark(group, defaultChild, context, signalColors, i));
+                WaveformMarkPointer pMark(new WaveformMark(
+                        group, defaultChild, context, i, signalColors, i));
                 m_marks.push_front(pMark);
                 m_hotCueMarks.insert(pMark->getHotCue(), pMark);
             }
@@ -68,6 +72,12 @@ WaveformMarkPointer WaveformMarkSet::getDefaultMark() const {
     return m_pDefaultMark;
 }
 
+void WaveformMarkSet::setBreadth(float breadth) {
+    for (auto& pMark : m_marks) {
+        pMark->setBreadth(breadth);
+    }
+}
+
 void WaveformMarkSet::update() {
     std::map<WaveformMarkSortKey, WaveformMarkPointer> map;
     for (const auto& pMark : std::as_const(m_marks)) {
@@ -77,7 +87,7 @@ void WaveformMarkSet::update() {
                 // Create a stable key for sorting, because the WaveformMark's samplePosition is a
                 // ControlObject which can change at any time by other threads. Such a change causes
                 // another updateCues() call, rebuilding map.
-                auto key = WaveformMarkSortKey(samplePosition, pMark->getHotCue());
+                auto key = WaveformMarkSortKey(samplePosition, pMark->getPriority());
                 map.emplace(key, pMark);
             }
         }
@@ -89,6 +99,16 @@ void WaveformMarkSet::update() {
             map.end(),
             std::back_inserter(m_marksToRender),
             [](auto const& pair) { return pair.second; });
+
+    double prevSamplePosition = Cue::kNoPosition;
+    std::map<Qt::Alignment, int> levels;
+    for (auto& pMark : m_marksToRender) {
+        if (pMark->getSamplePosition() != prevSamplePosition) {
+            prevSamplePosition = pMark->getSamplePosition();
+            levels.clear();
+        }
+        pMark->setLevel(levels[pMark->m_align]++);
+    }
 }
 
 WaveformMarkPointer WaveformMarkSet::findHoveredMark(

--- a/src/waveform/renderers/waveformmarkset.cpp
+++ b/src/waveform/renderers/waveformmarkset.cpp
@@ -125,5 +125,11 @@ WaveformMarkPointer WaveformMarkSet::findHoveredMark(
             return pMark;
         }
     }
+    for (auto it = m_marksToRender.crbegin(); it != m_marksToRender.crend(); ++it) {
+        const WaveformMarkPointer& pMark = *it;
+        if (pMark->lineHovered(pos, orientation)) {
+            return pMark;
+        }
+    }
     return nullptr;
 }

--- a/src/waveform/renderers/waveformmarkset.h
+++ b/src/waveform/renderers/waveformmarkset.h
@@ -65,6 +65,8 @@ class WaveformMarkSet {
 
     void update();
 
+    void setBreadth(float breadth);
+
   private:
     void clear() {
         m_marks.clear();

--- a/src/waveform/renderers/waveformrendermark.h
+++ b/src/waveform/renderers/waveformrendermark.h
@@ -1,36 +1,15 @@
 #pragma once
 
-#include <QObject>
+#include "waveform/renderers/waveformrendermarkbase.h"
 
-#include "skin/legacy/skincontext.h"
-#include "util/class.h"
-#include "waveform/renderers/waveformmarkset.h"
-#include "waveform/renderers/waveformrendererabstract.h"
-
-class WaveformRenderMark : public QObject, public WaveformRendererAbstract {
-    Q_OBJECT
-
+class WaveformRenderMark : public WaveformRenderMarkBase {
   public:
     explicit WaveformRenderMark(WaveformWidgetRenderer* waveformWidgetRenderer);
 
-    void setup(const QDomNode& node, const SkinContext& context) override;
     void draw(QPainter* painter, QPaintEvent* event) override;
 
-    void onResize() override;
-
-    // Called when a new track is loaded.
-    void onSetTrack() override;
-
-  public slots:
-    // Called when the loaded track's cues are added, deleted or modified and
-    // when a new track is loaded.
-    // It updates the marks' names and regenerates their image if needed.
-    // This method is used for hotcues.
-    void slotCuesUpdated();
-
   private:
-    void generateMarkImage(WaveformMarkPointer pMark);
+    void updateMarkImage(WaveformMarkPointer pMark) override;
 
-    WaveformMarkSet m_marks;
     DISALLOW_COPY_AND_ASSIGN(WaveformRenderMark);
 };

--- a/src/waveform/renderers/waveformrendermarkbase.cpp
+++ b/src/waveform/renderers/waveformrendermarkbase.cpp
@@ -5,9 +5,9 @@
 #include "waveform/renderers/waveformwidgetrenderer.h"
 
 WaveformRenderMarkBase::WaveformRenderMarkBase(
-        WaveformWidgetRenderer* waveformWidgetRenderer,
+        WaveformWidgetRenderer* pWaveformWidgetRenderer,
         bool updateImagesImmediately)
-        : WaveformRendererAbstract(waveformWidgetRenderer),
+        : WaveformRendererAbstract(pWaveformWidgetRenderer),
           m_updateImagesImmediately(updateImagesImmediately) {
 }
 
@@ -88,7 +88,7 @@ void WaveformRenderMarkBase::updateMarks() {
 }
 
 void WaveformRenderMarkBase::updateMarkImages() {
-    for (auto& pMark : m_marks) {
+    for (const auto& pMark : m_marks) {
         if (pMark->needsImageUpdate()) {
             updateMarkImage(pMark);
         }

--- a/src/waveform/renderers/waveformrendermarkbase.cpp
+++ b/src/waveform/renderers/waveformrendermarkbase.cpp
@@ -1,4 +1,5 @@
 #include "waveform/renderers/waveformrendermarkbase.h"
+
 #include "moc_waveformrendermarkbase.cpp"
 #include "track/track.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"

--- a/src/waveform/renderers/waveformrendermarkbase.cpp
+++ b/src/waveform/renderers/waveformrendermarkbase.cpp
@@ -1,0 +1,95 @@
+#include "waveform/renderers/waveformrendermarkbase.h"
+#include "moc_waveformrendermarkbase.cpp"
+#include "track/track.h"
+#include "waveform/renderers/waveformwidgetrenderer.h"
+
+WaveformRenderMarkBase::WaveformRenderMarkBase(
+        WaveformWidgetRenderer* waveformWidgetRenderer,
+        bool updateImagesImmediately)
+        : WaveformRendererAbstract(waveformWidgetRenderer),
+          m_updateImagesImmediately(updateImagesImmediately) {
+}
+
+void WaveformRenderMarkBase::setup(const QDomNode& node, const SkinContext& context) {
+    WaveformSignalColors signalColors = *m_waveformRenderer->getWaveformSignalColors();
+    m_marks.setup(m_waveformRenderer->getGroup(), node, context, signalColors);
+    m_marks.connectSamplePositionChanged(this, &WaveformRenderMarkBase::onMarkChanged);
+    m_marks.connectSampleEndPositionChanged(this, &WaveformRenderMarkBase::onMarkChanged);
+    m_marks.connectVisibleChanged(this, &WaveformRenderMarkBase::onMarkChanged);
+}
+
+void WaveformRenderMarkBase::onSetTrack() {
+    updateMarksFromCues();
+
+    const TrackPointer pTrackInfo = m_waveformRenderer->getTrackInfo();
+    if (!pTrackInfo) {
+        return;
+    }
+
+    connect(pTrackInfo.get(),
+            &Track::cuesUpdated,
+            this,
+            &WaveformRenderMarkBase::slotCuesUpdated);
+}
+
+void WaveformRenderMarkBase::onResize() {
+    m_marks.setBreadth(m_waveformRenderer->getBreadth());
+    if (m_updateImagesImmediately) {
+        updateMarkImages();
+    }
+}
+
+void WaveformRenderMarkBase::onMarkChanged(double v) {
+    Q_UNUSED(v);
+
+    updateMarks();
+}
+
+void WaveformRenderMarkBase::slotCuesUpdated() {
+    updateMarksFromCues();
+}
+
+void WaveformRenderMarkBase::updateMarksFromCues() {
+    const TrackPointer pTrackInfo = m_waveformRenderer->getTrackInfo();
+    if (!pTrackInfo) {
+        return;
+    }
+
+    const int dimBrightThreshold = m_waveformRenderer->getDimBrightThreshold();
+    QList<CuePointer> loadedCues = pTrackInfo->getCuePoints();
+    for (const CuePointer& pCue : loadedCues) {
+        const int hotCue = pCue->getHotCue();
+        if (hotCue == Cue::kNoHotCue) {
+            continue;
+        }
+
+        // Here we assume no two cues can have the same hotcue assigned,
+        // because WaveformMarkSet stores one mark for each hotcue.
+        WaveformMarkPointer pMark = m_marks.getHotCueMark(hotCue);
+        if (pMark.isNull()) {
+            continue;
+        }
+
+        QString newLabel = pCue->getLabel();
+        QColor newColor = mixxx::RgbColor::toQColor(pCue->getColor());
+        pMark->setText(newLabel);
+        pMark->setBaseColor(newColor, dimBrightThreshold);
+    }
+
+    updateMarks();
+}
+
+void WaveformRenderMarkBase::updateMarks() {
+    m_marks.update();
+    if (m_updateImagesImmediately) {
+        updateMarkImages();
+    }
+}
+
+void WaveformRenderMarkBase::updateMarkImages() {
+    for (auto& pMark : m_marks) {
+        if (pMark->needsImageUpdate()) {
+            updateMarkImage(pMark);
+        }
+    }
+}

--- a/src/waveform/renderers/waveformrendermarkbase.h
+++ b/src/waveform/renderers/waveformrendermarkbase.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <QObject>
+
+#include "skin/legacy/skincontext.h"
+#include "util/class.h"
+#include "waveform/renderers/waveformmarkset.h"
+#include "waveform/renderers/waveformrendererabstract.h"
+
+class WaveformRenderMarkBase : public QObject, public WaveformRendererAbstract {
+    Q_OBJECT
+
+  public:
+    explicit WaveformRenderMarkBase(
+            WaveformWidgetRenderer* waveformWidgetRenderer,
+            bool updateImagesImmediately);
+
+    void setup(const QDomNode& node, const SkinContext& context) override;
+
+    // Called when a new track is loaded.
+    void onSetTrack() override;
+
+    void onResize() override;
+
+  public slots:
+    // Called when the loaded track's cues are added, deleted or modified and
+    // when a new track is loaded.
+    // It updates the marks' names and flags the need for an image update.
+    // This method is used for hotcues.
+    void slotCuesUpdated();
+
+  private slots:
+    // Called when a mark position or visibility changes
+    void onMarkChanged(double v);
+
+  protected:
+    WaveformMarkSet m_marks;
+
+    void updateMarkImages();
+
+  private:
+    const bool m_updateImagesImmediately;
+
+    void updateMarksFromCues();
+    void updateMarks();
+
+  private:
+    virtual void updateMarkImage(WaveformMarkPointer pMark) = 0;
+
+    DISALLOW_COPY_AND_ASSIGN(WaveformRenderMarkBase);
+};

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -437,6 +437,24 @@ WaveformMarkPointer WaveformWidgetRenderer::getCueMarkAtPoint(QPoint point) cons
             return pMark;
         }
     }
+    for (auto it = m_markPositions.crbegin(); it != m_markPositions.crend(); ++it) {
+        const WaveformMarkPointer& pMark = it->m_pMark;
+        VERIFY_OR_DEBUG_ASSERT(pMark) {
+            continue;
+        }
+
+        int markImagePositionInWidgetSpace = it->m_offsetOnScreen;
+        QPoint pointInImageSpace;
+        if (getOrientation() == Qt::Horizontal) {
+            pointInImageSpace = QPoint(point.x() - markImagePositionInWidgetSpace, point.y());
+        } else {
+            DEBUG_ASSERT(getOrientation() == Qt::Vertical);
+            pointInImageSpace = QPoint(point.x(), point.y() - markImagePositionInWidgetSpace);
+        }
+        if (pMark->lineHovered(pointInImageSpace, getOrientation())) {
+            return pMark;
+        }
+    }
     return nullptr;
 }
 

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -350,7 +350,7 @@ void WaveformWidgetRenderer::setPassThroughEnabled(bool enabled) {
     }
 }
 
-void WaveformWidgetRenderer::resize(int width, int height, float devicePixelRatio) {
+void WaveformWidgetRenderer::resizeRenderer(int width, int height, float devicePixelRatio) {
     m_width = width;
     m_height = height;
     m_devicePixelRatio = devicePixelRatio;

--- a/src/waveform/renderers/waveformwidgetrenderer.h
+++ b/src/waveform/renderers/waveformwidgetrenderer.h
@@ -115,7 +115,8 @@ class WaveformWidgetRenderer {
         return m_alphaBeatGrid;
     }
 
-    void resize(int width, int height, float devicePixelRatio);
+    virtual void resizeRenderer(int width, int height, float devicePixelRatio);
+
     int getHeight() const {
         return m_height;
     }

--- a/src/waveform/widgets/glslwaveformwidget.cpp
+++ b/src/waveform/widgets/glslwaveformwidget.cpp
@@ -84,10 +84,10 @@ mixxx::Duration GLSLWaveformWidget::render() {
     return t1; // return timer for painter setup
 }
 
-void GLSLWaveformWidget::resize(int width, int height) {
+void GLSLWaveformWidget::resizeRenderer(int width, int height, float devicePixelRatio) {
     // NOTE: (vrince) this is needed since we allocation buffer on resize
     // and the Gl Context should be properly set
     makeCurrentIfNeeded();
-    WaveformWidgetAbstract::resize(width, height);
+    WaveformWidgetRenderer::resizeRenderer(width, height, devicePixelRatio);
     doneCurrent();
 }

--- a/src/waveform/widgets/glslwaveformwidget.h
+++ b/src/waveform/widgets/glslwaveformwidget.h
@@ -17,7 +17,7 @@ class GLSLWaveformWidget : public GLWaveformWidgetAbstract {
             GlslType type);
     ~GLSLWaveformWidget() override = default;
 
-    void resize(int width, int height) override;
+    void resizeRenderer(int width, int height, float devicePixelRatio) override;
 
   protected:
     void castToQWidget() override;

--- a/src/waveform/widgets/waveformwidgetabstract.cpp
+++ b/src/waveform/widgets/waveformwidgetabstract.cpp
@@ -43,5 +43,5 @@ void WaveformWidgetAbstract::resize(int width, int height) {
         m_widget->resize(width, height);
         devicePixelRatio = m_widget->devicePixelRatioF();
     }
-    WaveformWidgetRenderer::resize(width, height, static_cast<float>(devicePixelRatio));
+    resizeRenderer(width, height, static_cast<float>(devicePixelRatio));
 }

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -52,14 +52,27 @@ WWaveformViewer::~WWaveformViewer() {
 void WWaveformViewer::setup(const QDomNode& node, const SkinContext& context) {
     if (m_waveformWidget) {
         m_waveformWidget->setup(node, context);
+        m_dimBrightThreshold = m_waveformWidget->getDimBrightThreshold();
     }
-    m_dimBrightThreshold = m_waveformWidget->getDimBrightThreshold();
 }
 
 void WWaveformViewer::resizeEvent(QResizeEvent* event) {
     Q_UNUSED(event);
     if (m_waveformWidget) {
+        // Note m_waveformWidget is a WaveformWidgetAbstract,
+        // so this calls the method of WaveformWidgetAbstract,
+        // note of the derived waveform widgets which are also
+        // a QWidget, though that will be called directly.
         m_waveformWidget->resize(width(), height());
+    }
+}
+
+void WWaveformViewer::showEvent(QShowEvent* event) {
+    if (m_waveformWidget) {
+        // We leave it up to Qt to set the size of the derived
+        // waveform widget, but we still need to set the size
+        // of the renderer.
+        m_waveformWidget->resizeRenderer(width(), height(), devicePixelRatioF());
     }
 }
 

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -68,11 +68,13 @@ void WWaveformViewer::resizeEvent(QResizeEvent* event) {
 }
 
 void WWaveformViewer::showEvent(QShowEvent* event) {
+    Q_UNUSED(event);
     if (m_waveformWidget) {
         // We leave it up to Qt to set the size of the derived
         // waveform widget, but we still need to set the size
         // of the renderer.
-        m_waveformWidget->resizeRenderer(width(), height(), devicePixelRatioF());
+        m_waveformWidget->resizeRenderer(
+                width(), height(), static_cast<float>(devicePixelRatioF()));
     }
 }
 

--- a/src/widget/wwaveformviewer.h
+++ b/src/widget/wwaveformviewer.h
@@ -46,6 +46,7 @@ class WWaveformViewer : public WWidget, public TrackDropTarget {
     void slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack);
 
   protected:
+    void showEvent(QShowEvent* event) override;
     void resizeEvent(QResizeEvent *event) override;
     void wheelEvent(QWheelEvent *event) override;
 


### PR DESCRIPTION
draw overlapping marks at increasing/decreasing y position in the waveform viewer

<img width="359" alt="Screenshot 2023-11-08 at 10 41 49" src="https://github.com/mixxxdj/mixxx/assets/79429057/fd910893-e5bb-4370-bea3-6616177806e3">
