### PR TITLE
Effects: read effect data for decks added after initial setup

### DIFF
--- a/src/effects/effectsmanager.h
+++ b/src/effects/effectsmanager.h
@@ -85,6 +85,7 @@ class EffectsManager {
     void addQuickEffectChain(const ChannelHandleAndGroup& deckHandleGroup);
 
     void readEffectsXml();
+    void readEffectsXmlSingleDeck(const QString& deckGroup);
     void saveEffectsXml();
 
     QSet<ChannelHandleAndGroup> m_registeredInputChannels;
@@ -111,6 +112,11 @@ class EffectsManager {
     // TODO: replace these with effect parameters that are hidden by default
     ControlPotmeter m_loEqFreq;
     ControlPotmeter m_hiEqFreq;
+
+    // This is set true when setup() is run. Then, the initial decks (their EQ
+    // and QuickEffect chains) have been initialized, either with defaults or the
+    // previous state read from effects.xml
+    bool m_initializedFromEffectsXml;
 
     DISALLOW_COPY_AND_ASSIGN(EffectsManager);
 };

--- a/src/effects/presets/effectchainpresetmanager.cpp
+++ b/src/effects/presets/effectchainpresetmanager.cpp
@@ -658,14 +658,19 @@ bool EffectChainPresetManager::savePresetXml(EffectChainPresetPointer pPreset) {
     return success;
 }
 
-EffectsXmlData EffectChainPresetManager::readEffectsXml(
-        const QDomDocument& doc, const QStringList& deckStrings) {
+EffectChainPresetPointer EffectChainPresetManager::getDefaultQuickEffectPreset() {
     EffectManifestPointer pDefaultQuickEffectManifest = m_pBackendManager->getManifest(
             FilterEffect::getId(), EffectBackendType::BuiltIn);
     auto defaultQuickEffectChainPreset =
             EffectChainPresetPointer(pDefaultQuickEffectManifest
                             ? new EffectChainPreset(pDefaultQuickEffectManifest)
                             : new EffectChainPreset());
+    return defaultQuickEffectChainPreset;
+}
+
+EffectsXmlData EffectChainPresetManager::readEffectsXml(
+        const QDomDocument& doc, const QStringList& deckStrings) {
+    auto defaultQuickEffectChainPreset = getDefaultQuickEffectPreset();
 
     QList<EffectChainPresetPointer> standardEffectChainPresets;
     QHash<QString, EffectChainPresetPointer> quickEffectPresets;
@@ -782,6 +787,36 @@ EffectsXmlData EffectChainPresetManager::readEffectsXml(
     }
 
     return EffectsXmlData{quickEffectPresets, standardEffectChainPresets};
+}
+
+EffectChainPresetPointer EffectChainPresetManager::readEffectsXmlSingleDeck(
+        const QDomDocument& doc, const QString& deckString) {
+    QDomElement root = doc.documentElement();
+
+    auto pQuickEffectChainPreset = getDefaultQuickEffectPreset();
+
+    // Read name of last loaded QuickEffect preset
+    QDomElement quickEffectPresetsElement =
+            XmlParse::selectElement(root, EffectXml::kQuickEffectChainPresets);
+    QDomNodeList quickEffectNodeList =
+            quickEffectPresetsElement.elementsByTagName(
+                    EffectXml::kChainPresetName);
+    for (int i = 0; i < quickEffectNodeList.count(); ++i) {
+        QDomElement presetNameElement = quickEffectNodeList.at(i).toElement();
+        if (presetNameElement.isNull()) {
+            continue;
+        }
+        if (presetNameElement.attribute(QStringLiteral("group")) == deckString) {
+            auto pPreset = m_effectChainPresets.value(presetNameElement.text());
+            if (pPreset != nullptr || presetNameElement.text() == kNoEffectString) {
+                // Replace the default preset.
+                // Load empty preset if the chain was cleared explicitly ('---' preset)
+                pQuickEffectChainPreset = pPreset;
+            }
+        }
+    }
+
+    return pQuickEffectChainPreset;
 }
 
 void EffectChainPresetManager::saveEffectsXml(QDomDocument* pDoc, const EffectsXmlData& data) {

--- a/src/effects/presets/effectchainpresetmanager.h
+++ b/src/effects/presets/effectchainpresetmanager.h
@@ -69,7 +69,11 @@ class EffectChainPresetManager : public QObject {
     bool savePreset(EffectChainPresetPointer pPreset);
     void updatePreset(EffectChainPointer pChainSlot);
 
+    EffectChainPresetPointer getDefaultQuickEffectPreset();
+
     EffectsXmlData readEffectsXml(const QDomDocument& doc, const QStringList& deckStrings);
+    EffectChainPresetPointer readEffectsXmlSingleDeck(
+            const QDomDocument& doc, const QString& deckString);
     void saveEffectsXml(QDomDocument* pDoc, const EffectsXmlData& data);
 
   signals:


### PR DESCRIPTION
Closes #12277 

> `EffectsManager::readEffectsXml` is responsible for initialising/restoring Quick Effects, though it only cares about existing decks when it's called (once) via `CoreServices::initialize` -> `EffectsManager::setup`. The deck count is still the initial 2 then, the default count `PlayerManager`  is initialized with.
> If any decks are added later on, e.g. when the default (4-deck) skin LateNight is loaded, effects.xml is not read again and the Quick Effect slots remain empty.
> On next start it uses the `deck_count` attribute from `soundconfig.xml`.
> 
> IMO only `EffectsManager` should be responsible for effect defaults, not the Preferences.

Fixed by creating a separate, stripped down version of `readEffectsXml` that extracts only the Quick Effect for one deck, and call that each time a deck is added after the initial `setup()` call.
