### PR TITLE
MixxxApplication: Support linking Qt statically on Linux

### DIFF
--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -28,6 +28,8 @@ Q_IMPORT_PLUGIN(QWindowsVistaStylePlugin)
 #elif defined(Q_OS_MACOS)
 Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin)
 Q_IMPORT_PLUGIN(QMacStylePlugin)
+#elif defined(Q_OS_LINUX)
+Q_IMPORT_PLUGIN(QXcbIntegrationPlugin)
 #else
 #error "Q_IMPORT_PLUGIN() for the current patform is missing"
 #endif


### PR DESCRIPTION
Currently, Mixxx cannot be built at all using static Qt on Linux, since it will always error at compile time with a message indicating the a plugin for the current platform is missing (see e.g. [this build](https://github.com/fwcd/m1xxx/actions/runs/6825053309/job/18562147900)).

While using the system-packaged (and dynamically linked) Qt is generally the preferred way, there are use cases for statically linking Qt (e.g. portable or embedded builds), therefore it would be nice if we could at least support building Mixxx this way.

Unfortunately Linux does not have a single display API, instead there are several choices for platform plugins on Linux, as described in the Qt documentation:

- https://doc.qt.io/qt-6/qpa.html

This patch chooses to hardcode the X11/XCB plugin for static Qt builds, which is certainly not ideal, especially since Wayland seems to increasingly be the preferred backend, but seems to be the only plugin supported by vcpkg's `qtbase`:

- https://github.com/mixxxdj/vcpkg/blob/2.5-rel/ports/qtbase/portfile.cmake

In the spirit of having at least something that works, I would consider this an acceptable tradeoff for now. In the future we could e.g. add a configuration flag for selecting a plugin at build-time (including e.g. the Wayland plugin). Any thoughts?