### PR TITLE
BundleInstall: Enable hardened runtime in ad-hoc-signed macOS builds too

### DIFF
--- a/cmake/modules/BundleInstall.cmake.in
+++ b/cmake/modules/BundleInstall.cmake.in
@@ -19,25 +19,14 @@ fixup_bundle("${BUNDLE_PATH}" "${BUNDLE_LIBS}" "${BUNDLE_DIRS}")
 
 if(DEFINED APPLE_CODESIGN_IDENTITY AND DEFINED APPLE_CODESIGN_ENTITLEMENTS)
   foreach(PATH_TO_SIGN IN LISTS BUNDLE_LIBS BUNDLE_PATH)
-    if(APPLE_CODESIGN_IDENTITY STREQUAL "-")
-      message(STATUS "Ad-hoc signing bundle without hardened runtime")
-      execute_process(COMMAND
-          codesign --verbose=4 --deep --force
-          --entitlements "${APPLE_CODESIGN_ENTITLEMENTS}"
-          --sign "${APPLE_CODESIGN_IDENTITY}"
-          "${PATH_TO_SIGN}"
-          RESULT_VARIABLE CODESIGN_EXIT_CODE
-      )
-    else()
-      message(STATUS "Signing bundle with hardened runtime and identity ${APPLE_CODESIGN_IDENTITY}")
-      execute_process(COMMAND
-          codesign --verbose=4 --deep --force --options runtime
-          --entitlements "${APPLE_CODESIGN_ENTITLEMENTS}"
-          --sign "${APPLE_CODESIGN_IDENTITY}"
-          "${PATH_TO_SIGN}"
-          RESULT_VARIABLE CODESIGN_EXIT_CODE
-      )
-    endif()
+    message(STATUS "Signing bundle with hardened runtime and identity ${APPLE_CODESIGN_IDENTITY}")
+    execute_process(COMMAND
+      codesign --verbose=4 --deep --force --options runtime
+      --entitlements "${APPLE_CODESIGN_ENTITLEMENTS}"
+      --sign "${APPLE_CODESIGN_IDENTITY}"
+      "${PATH_TO_SIGN}"
+      RESULT_VARIABLE CODESIGN_EXIT_CODE
+    )
     if(NOT CODESIGN_EXIT_CODE EQUAL 0)
       message(FATAL_ERROR "Signing ${PATH_TO_SIGN} failed")
     endif()


### PR DESCRIPTION
A small follow-up to #12101 and #12138.

Currently we have App Sandbox + Hardened Runtime in notarized builds, but only App Sandbox in unnotarized builds (e.g. in PR builds). In an effort to both streamline the signing logic and to have fewer different configurations floating around, this patch enables the hardened runtime in ad-hoc-signed macOS builds too.

This means any potential issues that arise in production builds due to the hardened runtime should now be reproducible in development/PR builds too.