### PR TITLE
FindPortAudio: Link ALSA in static builds on Linux

### DIFF
--- a/cmake/modules/FindPortAudio.cmake
+++ b/cmake/modules/FindPortAudio.cmake
@@ -89,6 +89,14 @@ if(PortAudio_FOUND)
     )
     is_static_library(PortAudio_IS_STATIC PortAudio::PortAudio)
     if(PortAudio_IS_STATIC)
+      if(PortAudio_ALSA_H)
+        find_package(ALSA)
+        if(ALSA_FOUND)
+          set_property(TARGET PortAudio::PortAudio APPEND PROPERTY INTERFACE_LINK_LIBRARIES
+            ALSA::ALSA
+          )
+        endif()
+      endif()
       find_package(JACK)
       if(JACK_FOUND)
         set_property(TARGET PortAudio::PortAudio APPEND PROPERTY INTERFACE_LINK_LIBRARIES

--- a/cmake/modules/FindPortAudio.cmake
+++ b/cmake/modules/FindPortAudio.cmake
@@ -43,6 +43,8 @@ The following cache variables may also be set:
 
 #]=======================================================================]
 
+include(IsStaticLibrary)
+
 find_package(PkgConfig QUIET)
 if(PkgConfig_FOUND)
   pkg_check_modules(PC_PortAudio QUIET portaudio-2.0)


### PR DESCRIPTION
As a follow-up to #12284, this is another step towards making it possible to build Mixxx statically on Linux. In particular, we we missing a link dependency on ALSA, that resulted in these errors (see e.g. [this build](https://github.com/fwcd/m1xxx/actions/runs/6840738557/job/18600331817)):

```
: && /usr/bin/c++ -fdiagnostics-color=auto -O2 -g -DNDEBUG -Wl,--gc-sections /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/qmltooling/objects-Release/QDebugMessageServiceFactoryPlugin_init/QDebugMessageServiceFactoryPlugin_init.cpp.o /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/qmltooling/objects-Release/QLocalClientConnectionFactoryPlugin_init/QLocalClientConnectionFactoryPlugin_init.cpp.o /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/qmltooling/objects-Release/QQmlDebugServerFactoryPlugin_init/QQmlDebugServerFactoryPlugin_init.cpp.o /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/qmltooling/objects-Release/QQmlDebuggerServiceFactoryPlugin_init/QQmlDebuggerServiceFactoryPlugin_init.cpp.o /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/qmltooling/objects-Release/QQmlInspectorServiceFactoryPlugin_init/QQmlInspectorServiceFactoryPlugin_init.cpp.o /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/qmltooling/objects-Release/QQmlNativeDebugConnectorFactoryPlugin_init/QQmlNativeDebugConnectorFactoryPlugin_init.cpp.o /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/qmltooling/objects-Release/QQmlNativeDebugServiceFactoryPlugin_init/QQmlNativeDebugServiceFactoryPlugin_init.cpp.o /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/qmltooling/objects-Release/QQmlPreviewServiceFactoryPlugin_init/QQmlPreviewServiceFactoryPlugin_init.cpp.o /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/qmltooling/objects-Release/QQmlProfilerServiceFactoryPlugin_init/QQmlProfilerServiceFactoryPlugin_init.cpp.o /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/qmltooling/objects-Release/QQuickProfilerAdapterFactoryPlugin_init/QQuickProfilerAdapterFactoryPlugin_init.cpp.o /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/qmltooling/objects-Release/QTcpServerConnectionFactoryPlugin_init/QTcpServerConnectionFactoryPlugin_init.cpp.o /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/networkinformation/objects-Release/QNetworkManagerNetworkInformationPlugin_init/QNetworkManagerNetworkInformationPlugin_init.cpp.o /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/tls/objects-Release/QTlsBackendOpenSSLPlugin_init/QTlsBackendOpenSSLPlugin_init.cpp.o /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/egldeviceintegrations/objects-Release/QEglFSEmulatorIntegrationPlugin_init/QEglFSEmulatorIntegrationPlugin_init.cpp.o /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/egldeviceintegrations/objects-Release/QEglFSX11IntegrationPlugin_init/QEglFSX11IntegrationPlugin_init.cpp.o /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/imageformats/objects-Release/QGifPlugin_init/QGifPlugin_init.cpp.o /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/imageformats/objects-Release/QICOPlugin_init/QICOPlugin_init.cpp.o /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/imageformats/objects-Release/QJpegPlugin_init/QJpegPlugin_init.cpp.o /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/iconengines/objects-Release/QSvgIconPlugin_init/QSvgIconPlugin_init.cpp.o /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/imageformats/objects-Release/QSvgPlugin_init/QSvgPlugin_init.cpp.o /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/xcbglintegrations/objects-Release/QXcbEglIntegrationPlugin_init/QXcbEglIntegrationPlugin_init.cpp.o /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/xcbglintegrations/objects-Release/QXcbGlxIntegrationPlugin_init/QXcbGlxIntegrationPlugin_init.cpp.o /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/platforms/objects-Release/QXcbIntegrationPlugin_init/QXcbIntegrationPlugin_init.cpp.o /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/sqldrivers/objects-Release/QPSQLDriverPlugin_init/QPSQLDriverPlugin_init.cpp.o /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/sqldrivers/objects-Release/QSQLiteDriverPlugin_init/QSQLiteDriverPlugin_init.cpp.o CMakeFiles/mixxx.dir/src/main.cpp.o CMakeFiles/mixxx.dir/mixxx_autogen/PNK5WDWK6L/qrc_mixxx.cpp.o -o mixxx  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/objects-Release/qtquick2plugin_init/qtquick2plugin_init.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQml/objects-Release/QmlMeta_resources_1/.rcc/qrc_qmake_QtQml.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQml/objects-Release/QmlMeta_init/QmlMeta_init.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQml/Base/objects-Release/qmlplugin_init/qmlplugin_init.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQml/Models/objects-Release/modelsplugin_init/modelsplugin_init.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQml/WorkerScript/objects-Release/workerscriptplugin_init/workerscriptplugin_init.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/Qt5Compat/GraphicalEffects/objects-Release/qtgraphicaleffectsplugin_resources_1/.rcc/qrc_qmake_Qt5Compat_GraphicalEffects.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/Qt5Compat/GraphicalEffects/objects-Release/qtgraphicaleffectsplugin_qmlcache/.rcc/qmlcache/qtgraphicaleffectsplugin_qmlcache_loader.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/Qt5Compat/GraphicalEffects/objects-Release/qtgraphicaleffectsplugin_resources_2/.rcc/qrc_qtgraphicaleffectsplugin_raw_qml_0.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/Qt5Compat/GraphicalEffects/objects-Release/qtgraphicaleffectsplugin_init/qtgraphicaleffectsplugin_init.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/objects-Release/qtgraphicaleffectsplugin_resources_3/.rcc/qrc_qtgraphicaleffectsshaders.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/Qt5Compat/GraphicalEffects/private/objects-Release/qtgraphicaleffectsprivate_resources_1/.rcc/qrc_qmake_Qt5Compat_GraphicalEffects_private.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/Qt5Compat/GraphicalEffects/private/objects-Release/qtgraphicaleffectsprivate_qmlcache/.rcc/qmlcache/qtgraphicaleffectsprivate_qmlcache_loader.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/Qt5Compat/GraphicalEffects/private/objects-Release/qtgraphicaleffectsprivate_resources_2/.rcc/qrc_qtgraphicaleffectsprivate_raw_qml_0.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/Qt5Compat/GraphicalEffects/private/objects-Release/qtgraphicaleffectsprivate_init/qtgraphicaleffectsprivate_init.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Window/objects-Release/quickwindow_resources_1/.rcc/qrc_qmake_QtQuick_Window.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Window/objects-Release/quickwindow_init/quickwindow_init.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/objects-Release/qtquickcontrols2plugin_init/qtquickcontrols2plugin_init.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/objects-Release/qtquickcontrols2plugin_resources_1/.rcc/qrc_indirectBasic.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Fusion/objects-Release/qtquickcontrols2fusionstyleplugin_resources_1/.rcc/qrc_qmake_QtQuick_Controls_Fusion.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Fusion/objects-Release/qtquickcontrols2fusionstyleplugin_qmlcache/.rcc/qmlcache/qtquickcontrols2fusionstyleplugin_qmlcache_loader.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Fusion/objects-Release/qtquickcontrols2fusionstyleplugin_resources_2/.rcc/qrc_qtquickcontrols2fusionstyleplugin_raw_qml_0.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Fusion/objects-Release/qtquickcontrols2fusionstyleplugin_init/qtquickcontrols2fusionstyleplugin_init.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/objects-Release/qtquickcontrols2fusionstyleplugin_resources_3/.rcc/qrc_qtquickcontrols2fusionstyle.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Material/objects-Release/qtquickcontrols2materialstyleplugin_resources_1/.rcc/qrc_qmake_QtQuick_Controls_Material.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Material/objects-Release/qtquickcontrols2materialstyleplugin_qmlcache/.rcc/qmlcache/qtquickcontrols2materialstyleplugin_qmlcache_loader.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Material/objects-Release/qtquickcontrols2materialstyleplugin_resources_2/.rcc/qrc_qtquickcontrols2materialstyleplugin_raw_qml_0.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Material/objects-Release/qtquickcontrols2materialstyleplugin_init/qtquickcontrols2materialstyleplugin_init.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/objects-Release/qtquickcontrols2materialstyleplugin_resources_3/.rcc/qrc_qtquickcontrols2materialstyleplugin.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/objects-Release/qtquickcontrols2materialstyleplugin_resources_4/.rcc/qrc_qtquickcontrols2materialstyleplugin_shaders.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Imagine/objects-Release/qtquickcontrols2imaginestyleplugin_resources_1/.rcc/qrc_qmake_QtQuick_Controls_Imagine.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Imagine/objects-Release/qtquickcontrols2imaginestyleplugin_qmlcache/.rcc/qmlcache/qtquickcontrols2imaginestyleplugin_qmlcache_loader.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Imagine/objects-Release/qtquickcontrols2imaginestyleplugin_resources_2/.rcc/qrc_qtquickcontrols2imaginestyleplugin_raw_qml_0.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Imagine/objects-Release/qtquickcontrols2imaginestyleplugin_init/qtquickcontrols2imaginestyleplugin_init.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/objects-Release/qtquickcontrols2imaginestyleplugin_resources_3/.rcc/qrc_qmake_qtquickcontrols2imaginestyleplugin.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Universal/objects-Release/qtquickcontrols2universalstyleplugin_resources_1/.rcc/qrc_qmake_QtQuick_Controls_Universal.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Universal/objects-Release/qtquickcontrols2universalstyleplugin_qmlcache/.rcc/qmlcache/qtquickcontrols2universalstyleplugin_qmlcache_loader.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Universal/objects-Release/qtquickcontrols2universalstyleplugin_resources_2/.rcc/qrc_qtquickcontrols2universalstyleplugin_raw_qml_0.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Universal/objects-Release/qtquickcontrols2universalstyleplugin_init/qtquickcontrols2universalstyleplugin_init.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/objects-Release/qtquickcontrols2universalstyleplugin_resources_3/.rcc/qrc_qtquickcontrols2universalstyleplugin.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Basic/objects-Release/qtquickcontrols2basicstyleplugin_resources_1/.rcc/qrc_qmake_QtQuick_Controls_Basic.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Basic/objects-Release/qtquickcontrols2basicstyleplugin_qmlcache/.rcc/qmlcache/qtquickcontrols2basicstyleplugin_qmlcache_loader.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Basic/objects-Release/qtquickcontrols2basicstyleplugin_resources_2/.rcc/qrc_qtquickcontrols2basicstyleplugin_raw_qml_0.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Basic/objects-Release/qtquickcontrols2basicstyleplugin_init/qtquickcontrols2basicstyleplugin_init.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/objects-Release/qtquickcontrols2basicstyleplugin_resources_3/.rcc/qrc_qtquickcontrols2basicstyleplugin.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Templates/objects-Release/qtquicktemplates2plugin_init/qtquicktemplates2plugin_init.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/impl/objects-Release/qtquickcontrols2implplugin_init/qtquickcontrols2implplugin_init.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Fusion/impl/objects-Release/qtquickcontrols2fusionstyleimplplugin_resources_1/.rcc/qrc_qmake_QtQuick_Controls_Fusion_impl.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Fusion/impl/objects-Release/qtquickcontrols2fusionstyleimplplugin_qmlcache/.rcc/qmlcache/qtquickcontrols2fusionstyleimplplugin_qmlcache_loader.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Fusion/impl/objects-Release/qtquickcontrols2fusionstyleimplplugin_resources_2/.rcc/qrc_qtquickcontrols2fusionstyleimplplugin_raw_qml_0.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Fusion/impl/objects-Release/qtquickcontrols2fusionstyleimplplugin_init/qtquickcontrols2fusionstyleimplplugin_init.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Material/impl/objects-Release/qtquickcontrols2materialstyleimplplugin_resources_1/.rcc/qrc_qmake_QtQuick_Controls_Material_impl.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Material/impl/objects-Release/qtquickcontrols2materialstyleimplplugin_qmlcache/.rcc/qmlcache/qtquickcontrols2materialstyleimplplugin_qmlcache_loader.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Material/impl/objects-Release/qtquickcontrols2materialstyleimplplugin_resources_2/.rcc/qrc_qtquickcontrols2materialstyleimplplugin_raw_qml_0.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Material/impl/objects-Release/qtquickcontrols2materialstyleimplplugin_init/qtquickcontrols2materialstyleimplplugin_init.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Imagine/impl/objects-Release/qtquickcontrols2imaginestyleimplplugin_resources_1/.rcc/qrc_qmake_QtQuick_Controls_Imagine_impl.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Imagine/impl/objects-Release/qtquickcontrols2imaginestyleimplplugin_qmlcache/.rcc/qmlcache/qtquickcontrols2imaginestyleimplplugin_qmlcache_loader.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Imagine/impl/objects-Release/qtquickcontrols2imaginestyleimplplugin_resources_2/.rcc/qrc_qtquickcontrols2imaginestyleimplplugin_raw_qml_0.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Imagine/impl/objects-Release/qtquickcontrols2imaginestyleimplplugin_init/qtquickcontrols2imaginestyleimplplugin_init.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/objects-Release/qtquickcontrols2imaginestyleimplplugin_resources_3/.rcc/qrc_qtquickcontrols2imaginestyleimplplugin_shaders.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Universal/impl/objects-Release/qtquickcontrols2universalstyleimplplugin_resources_1/.rcc/qrc_qmake_QtQuick_Controls_Universal_impl.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Universal/impl/objects-Release/qtquickcontrols2universalstyleimplplugin_qmlcache/.rcc/qmlcache/qtquickcontrols2universalstyleimplplugin_qmlcache_loader.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Universal/impl/objects-Release/qtquickcontrols2universalstyleimplplugin_resources_2/.rcc/qrc_qtquickcontrols2universalstyleimplplugin_raw_qml_0.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Universal/impl/objects-Release/qtquickcontrols2universalstyleimplplugin_init/qtquickcontrols2universalstyleimplplugin_init.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Basic/impl/objects-Release/qtquickcontrols2basicstyleimplplugin_resources_1/.rcc/qrc_qmake_QtQuick_Controls_Basic_impl.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Basic/impl/objects-Release/qtquickcontrols2basicstyleimplplugin_init/qtquickcontrols2basicstyleimplplugin_init.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Shapes/objects-Release/qmlshapesplugin_init/qmlshapesplugin_init.cpp.o  CMakeFiles/mixxx-qml-libplugin_init.dir/./mixxx_qml_libplugin_init.cpp.o  CMakeFiles/mixxx-qml-mixxxcontrolsplugin_init.dir/./mixxx_qml_mixxxcontrolsplugin_init.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/Qt/labs/qmlmodels/objects-Release/labsmodelsplugin_init/labsmodelsplugin_init.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Layouts/objects-Release/qquicklayoutsplugin_init/qquicklayoutsplugin_init.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/objects-Release/Gui_resources_1/.rcc/qrc_qpdf.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/objects-Release/Gui_resources_2/.rcc/qrc_gui_shaders.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/objects-Release/PrintSupport_resources_1/.rcc/qrc_qprintdialog.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/objects-Release/PrintSupport_resources_2/.rcc/qrc_qprintdialog1.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQml/Base/objects-Release/Qml_resources_1/.rcc/qrc_qmake_QtQml_Base.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/objects-Release/Qml_resources_2/.rcc/qrc_qmlMetaQmldir.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/objects-Release/Widgets_resources_1/.rcc/qrc_qstyle.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/objects-Release/Widgets_resources_2/.rcc/qrc_qstyle1.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/objects-Release/Widgets_resources_3/.rcc/qrc_qmessagebox.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/objects-Release/Quick_resources_1/.rcc/qrc_qmake_QtQuick.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/objects-Release/Quick_resources_2/.rcc/qrc_scenegraph_shaders.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/objects-Release/QuickControls2_resources_1/.rcc/qrc_qmake_QtQuick_Controls.cpp.o  CMakeFiles/mixxx-qml-lib_resources_1.dir/./build/.rcc/qrc_qmake_Mixxx.cpp.o  CMakeFiles/mixxx-qml-lib_qmlcache.dir/./build/.rcc/qmlcache/mixxx-qml-lib_qmlcache_loader.cpp.o  CMakeFiles/mixxx-qml-lib_resources_2.dir/./build/.rcc/qrc_mixxx-qml-lib_raw_qml_0.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQml/Models/objects-Release/QmlModels_resources_1/.rcc/qrc_qmake_QtQml_Models.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQml/WorkerScript/objects-Release/QmlWorkerScript_resources_1/.rcc/qrc_qmake_QtQml_WorkerScript.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Templates/objects-Release/QuickTemplates2_resources_1/.rcc/qrc_qmake_QtQuick_Templates.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/impl/objects-Release/QuickControls2Impl_resources_1/.rcc/qrc_qmake_QtQuick_Controls_impl.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Shapes/objects-Release/QuickShapesPrivate_resources_1/.rcc/qrc_qmake_QtQuick_Shapes.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/objects-Release/QuickShapesPrivate_resources_2/.rcc/qrc_qtquickshapes_shaders.cpp.o  CMakeFiles/mixxx-qml-mixxxcontrols_resources_1.dir/./build/.rcc/qrc_qmake_Mixxx_Controls.cpp.o  CMakeFiles/mixxx-qml-mixxxcontrols_qmlcache.dir/./build/.rcc/qmlcache/mixxx-qml-mixxxcontrols_qmlcache_loader.cpp.o  CMakeFiles/mixxx-qml-mixxxcontrols_resources_2.dir/./build/.rcc/qrc_mixxx-qml-mixxxcontrols_raw_qml_0.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/Qt/labs/qmlmodels/objects-Release/LabsQmlModels_resources_1/.rcc/qrc_qmake_Qt_labs_qmlmodels.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Layouts/objects-Release/QuickLayouts_resources_1/.rcc/qrc_qmake_QtQuick_Layouts.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/objects-Release/EglFSDeviceIntegrationPrivate_resources_1/.rcc/qrc_cursor.cpp.o  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6Core.a  libmixxx-lib.a  libmixxx-gitinfostore.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/libqtquick2plugin.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQml/libqmlmetaplugin.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQml/Base/libqmlplugin.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQml/Models/libmodelsplugin.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQml/WorkerScript/libworkerscriptplugin.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/Qt5Compat/GraphicalEffects/libqtgraphicaleffectsplugin.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/Qt5Compat/GraphicalEffects/private/libqtgraphicaleffectsprivateplugin.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Window/libquickwindowplugin.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/libqtquickcontrols2plugin.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Fusion/libqtquickcontrols2fusionstyleplugin.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Material/libqtquickcontrols2materialstyleplugin.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Imagine/libqtquickcontrols2imaginestyleplugin.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Universal/libqtquickcontrols2universalstyleplugin.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Basic/libqtquickcontrols2basicstyleplugin.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Templates/libqtquicktemplates2plugin.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/impl/libqtquickcontrols2implplugin.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Fusion/impl/libqtquickcontrols2fusionstyleimplplugin.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Material/impl/libqtquickcontrols2materialstyleimplplugin.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Imagine/impl/libqtquickcontrols2imaginestyleimplplugin.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Universal/impl/libqtquickcontrols2universalstyleimplplugin.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/Basic/impl/libqtquickcontrols2basicstyleimplplugin.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Shapes/libqmlshapesplugin.a  qml/Mixxx/libmixxx-qml-libplugin.a  qml/Mixxx/Controls/libmixxx-qml-mixxxcontrolsplugin.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/Qt/labs/qmlmodels/liblabsmodelsplugin.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Layouts/libqquicklayoutsplugin.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/qmltooling/libqmldbg_messages.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/qmltooling/libqmldbg_local.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/qmltooling/libqmldbg_server.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/qmltooling/libqmldbg_debugger.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/qmltooling/libqmldbg_inspector.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/qmltooling/libqmldbg_native.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/qmltooling/libqmldbg_nativedebugger.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/qmltooling/libqmldbg_preview.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/qmltooling/libqmldbg_profiler.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/qmltooling/libqmldbg_quickprofiler.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/qmltooling/libqmldbg_tcp.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/networkinformation/libqnetworkmanager.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/tls/libqopensslbackend.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/egldeviceintegrations/libqeglfs-emu-integration.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/egldeviceintegrations/libqeglfs-x11-integration.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/imageformats/libqgif.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/imageformats/libqico.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/imageformats/libqjpeg.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/iconengines/libqsvgicon.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/imageformats/libqsvg.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/xcbglintegrations/libqxcb-egl-integration.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/xcbglintegrations/libqxcb-glx-integration.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/platforms/libqxcb.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/sqldrivers/libqsqlpsql.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/sqldrivers/libqsqlite.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libjpeg.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libchromaprint.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libsqlite3.a  lib/libdjinterop-install/lib/libdjinterop.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libebur128.a  libfidlib.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libkeyfinder.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libFLAC.a  libFpClassify.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libmp3lame.a  libKaitai.a  libMP3GuessEnc.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libvorbisfile.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libportaudio.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libjack.a  libPortAudioRingBuffer.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libportmidi.a  libmixxx-qml-lib.a  qml/Mixxx/libmixxx-qml-libplugin.a  libmixxx-qml-lib.a  qml/Mixxx/Controls/libmixxx-qml-mixxxcontrolsplugin.a  libmixxx-qml-mixxxcontrols.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libprotobuf-lite.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6Concurrent.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6PrintSupport.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6QuickWidgets.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6Test.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6Xml.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6SvgWidgets.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6Widgets.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6Core5Compat.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/platforms/libqoffscreen.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/plugins/platforms/libqminimal.a  /usr/lib/x86_64-linux-gnu/libSM.so  /usr/lib/x86_64-linux-gnu/libICE.so  /usr/lib/x86_64-linux-gnu/libXext.so  libQueenMaryDsp.a  libReplayGain.a  libReverb.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/librubberband.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libfftw3.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libsamplerate.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libsleef.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libsleefdft.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libsndfile.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libSoundTouch.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libtag.a  /usr/lib/x86_64-linux-gnu/libupower-glib.so  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libglib-2.0.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libgobject-2.0.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libavcodec.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libavformat.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libavutil.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libswresample.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/liblilv.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libsord.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libserd.a  lib/libshout-idjc/libshout_mixxx.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libogg.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libvorbis.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libvorbisenc.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libopusfile.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libopus.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libmodplug.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libqt6keychain.a  -lsecret-1  -lgio-2.0  -lgobject-2.0  -lffi  -lgmodule-2.0  -lglib-2.0  -lpcre2-8  -lz  -lgcrypt  -lgpg-error  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libhidapi-hidraw.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libusb-1.0.a  libmixxx-xwax.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libwavpack.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6ShaderTools.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6BundledSpirv_Cross.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6BundledGlslang_Glslang.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6BundledGlslang_Spirv.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6BundledGlslang_Osdependent.a  -lpthread  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6BundledGlslang_Oglcompiler.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Window/libquickwindowplugin.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/libqtquickcontrols2plugin.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Controls/impl/libqtquickcontrols2implplugin.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/Templates/libqtquicktemplates2plugin.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6QuickControls2Impl.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6QuickControls2.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6QuickTemplates2.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6QuickShapes.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6LabsQmlModels.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQuick/libqtquick2plugin.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQml/Models/libmodelsplugin.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQml/libqmlmetaplugin.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQml/Base/libqmlplugin.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQml/WorkerScript/libworkerscriptplugin.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQml/libqmlmetaplugin.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQml/Base/libqmlplugin.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/Qt6/qml/QtQml/WorkerScript/libworkerscriptplugin.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6QmlWorkerScript.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6QuickLayouts.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6Quick.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6QmlModels.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6PacketProtocol.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6Qml.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6Network.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libbrotlidec.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libbrotlicommon.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6EglFSDeviceIntegration.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6FbSupport.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6InputSupport.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6DeviceDiscoverySupport.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6Svg.a  /usr/lib/x86_64-linux-gnu/libxcb-glx.so  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6XcbQpa.a  /usr/lib/x86_64-linux-gnu/libX11-xcb.so  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6OpenGL.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6Gui.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6DBus.a  /usr/lib/x86_64-linux-gnu/libX11.so  /usr/lib/x86_64-linux-gnu/libEGL.so  /usr/lib/x86_64-linux-gnu/libGLX.so  /usr/lib/x86_64-linux-gnu/libOpenGL.so  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libharfbuzz.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libfreetype.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libbz2.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libpng16.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libz.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libfontconfig.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libfreetype.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libpng16.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libbz2.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libbrotlidec.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libbrotlicommon.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libexpat.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libuuid.a  /usr/lib/x86_64-linux-gnu/libxkbcommon.so  /usr/lib/x86_64-linux-gnu/libxkbcommon-x11.so  /usr/lib/x86_64-linux-gnu/libxkbcommon.so  /usr/lib/x86_64-linux-gnu/libxcb-cursor.so  /usr/lib/x86_64-linux-gnu/libxcb-icccm.so  /usr/lib/x86_64-linux-gnu/libxcb-image.so  /usr/lib/x86_64-linux-gnu/libxcb-keysyms.so  /usr/lib/x86_64-linux-gnu/libxcb-randr.so  /usr/lib/x86_64-linux-gnu/libxcb-render-util.so  /usr/lib/x86_64-linux-gnu/libxcb-shm.so  /usr/lib/x86_64-linux-gnu/libxcb-sync.so  /usr/lib/x86_64-linux-gnu/libxcb-xfixes.so  /usr/lib/x86_64-linux-gnu/libxcb-render.so  /usr/lib/x86_64-linux-gnu/libxcb-shape.so  /usr/lib/x86_64-linux-gnu/libxcb-xkb.so  /usr/lib/x86_64-linux-gnu/libSM.so  /usr/lib/x86_64-linux-gnu/libICE.so  /usr/lib/x86_64-linux-gnu/libXrender.so  /usr/lib/x86_64-linux-gnu/libX11.so  /usr/lib/x86_64-linux-gnu/libxcb-xinput.so  /usr/lib/x86_64-linux-gnu/libxcb.so  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libpq.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libpgport.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libpgcommon.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6Sql.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libQt6Core.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libz.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libdouble-conversion.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libb2.a  -lm  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libicui18n.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libicuuc.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libicudata.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libpcre2-16.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libssl.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libcrypto.a  /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libzstd.a  -ldl  /usr/lib/x86_64-linux-gnu/librt.a && :
/usr/bin/ld: /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libportaudio.a(pa_linux_alsa.c.o): in function `PaAlsa_Initialize':
pa_linux_alsa.c:(.text+0x8b9f): undefined reference to `snd_pcm_open'
/usr/bin/ld: pa_linux_alsa.c:(.text+0x8bad): undefined reference to `snd_pcm_close'
/usr/bin/ld: pa_linux_alsa.c:(.text+0x8bbb): undefined reference to `snd_pcm_nonblock'
/usr/bin/ld: pa_linux_alsa.c:(.text+0x8bc9): undefined reference to `snd_pcm_prepare'
/usr/bin/ld: pa_linux_alsa.c:(.text+0x8bd7): undefined reference to `snd_pcm_start'
/usr/bin/ld: pa_linux_alsa.c:(.text+0x8be5): undefined reference to `snd_pcm_state'
/usr/bin/ld: pa_linux_alsa.c:(.text+0x8bf3): undefined reference to `snd_pcm_avail_update'
/usr/bin/ld: pa_linux_alsa.c:(.text+0x8c01): undefined reference to `snd_pcm_areas_silence'
/usr/bin/ld: pa_linux_alsa.c:(.text+0x8c0f): undefined reference to `snd_pcm_mmap_begin'
/usr/bin/ld: pa_linux_alsa.c:(.text+0x8c1d): undefined reference to `snd_pcm_mmap_commit'
...
```

This is likely not the end of the story, there are some other libraries such as `libudev` that we'll have to take care of, but that's for another PR.