### PR TITLE
FindPortMidi: Link ALSA in static builds on Linux

### DIFF
--- a/cmake/modules/FindPortMidi.cmake
+++ b/cmake/modules/FindPortMidi.cmake
@@ -37,6 +37,8 @@ The following cache variables may also be set:
 
 #]=======================================================================]
 
+include(IsStaticLibrary)
+
 find_path(PortMidi_INCLUDE_DIR
   NAMES portmidi.h
   PATH_SUFFIXES portmidi
@@ -80,4 +82,14 @@ if(PortMidi_FOUND)
     list(APPEND PortMidi_LIBRARIES ${PortTime_LIBRARY})
   endif()
   set(PortMidi_INCLUDE_DIRS ${PortMidi_INCLUDE_DIR} ${PortTime_INCLUDE_DIR})
+
+  is_static_library(PortMidi_IS_STATIC ${PortMidi_LIBRARY})
+  if(PortMidi_IS_STATIC)
+    find_package(ALSA)
+    if(ALSA_FOUND)
+      set_property(TARGET ${PortMidi_LIBRARY} APPEND PROPERTY INTERFACE_LINK_LIBRARIES
+        ALSA::ALSA
+      )
+    endif()
+  endif()
 endif()


### PR DESCRIPTION
Another follow-up to #12291, the never ending story of linker errors in getting Mixxx to compile statically on Linux. PortMidi was apparently missing an ALSA link dependency too, which resulted in similar errors (see [this build](https://github.com/fwcd/m1xxx/actions/runs/6841211208/job/18601330776)):

```
/usr/bin/ld: /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libportmidi.a(pmlinuxalsa.c.o): in function `alsa_poll':
pmlinuxalsa.c:(.text+0x9d): undefined reference to `snd_seq_event_input_pending'
/usr/bin/ld: pmlinuxalsa.c:(.text+0xba): undefined reference to `snd_seq_event_input_pending'
/usr/bin/ld: pmlinuxalsa.c:(.text+0xcd): undefined reference to `snd_seq_event_input'
/usr/bin/ld: /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libportmidi.a(pmlinuxalsa.c.o): in function `alsa_write_byte':
pmlinuxalsa.c:(.text+0x510): undefined reference to `snd_midi_event_encode_byte'
/usr/bin/ld: pmlinuxalsa.c:(.text+0x5c5): undefined reference to `snd_seq_event_output'
/usr/bin/ld: /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libportmidi.a(pmlinuxalsa.c.o): in function `alsa_create_virtual':
pmlinuxalsa.c:(.text+0x6c5): undefined reference to `snd_seq_port_info_sizeof'
/usr/bin/ld: pmlinuxalsa.c:(.text+0x70d): undefined reference to `snd_seq_port_info_sizeof'
/usr/bin/ld: pmlinuxalsa.c:(.text+0x730): undefined reference to `snd_seq_port_info_set_capability'
/usr/bin/ld: pmlinuxalsa.c:(.text+0x73d): undefined reference to `snd_seq_port_info_set_type'
...
```