### PR TITLE
FindLibudev: Link hidapi and libusb with libudev in static builds on Linux

### DIFF
--- a/cmake/modules/FindLibUSB.cmake
+++ b/cmake/modules/FindLibUSB.cmake
@@ -43,6 +43,8 @@ The following cache variables may also be set:
 
 #]=======================================================================]
 
+include(IsStaticLibrary)
+
 find_package(PkgConfig QUIET)
 if(PkgConfig_FOUND)
   pkg_check_modules(PC_LibUSB QUIET libusb-1.0)
@@ -87,5 +89,15 @@ if(LibUSB_FOUND)
         INTERFACE_COMPILE_OPTIONS "${PC_LibUSB_CFLAGS_OTHER}"
         INTERFACE_INCLUDE_DIRECTORIES "${LibUSB_INCLUDE_DIR}"
     )
+
+    is_static_library(LibUSB_IS_STATIC LibUSB::LibUSB)
+    if(LibUSB_IS_STATIC)
+      find_package(Libudev)
+      if(Libudev_FOUND)
+        set_property(TARGET LibUSB::LibUSB APPEND PROPERTY INTERFACE_LINK_LIBRARIES
+          Libudev::Libudev
+        )
+      endif()
+    endif()
   endif()
 endif()

--- a/cmake/modules/FindLibudev.cmake
+++ b/cmake/modules/FindLibudev.cmake
@@ -1,0 +1,61 @@
+# This file is part of Mixxx, Digital DJ'ing software.
+# Copyright (C) 2001-2023 Mixxx Development Team
+# Distributed under the GNU General Public Licence (GPL) version 2 or any later
+# later version. See the LICENSE file for details.
+
+#[=======================================================================[.rst:
+FindLibudev
+--------
+
+Finds the libudev (userspace device manager) library.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module provides the following imported targets, if found:
+
+``Libudev::Libudev``
+  The libudev library
+
+#]=======================================================================]
+
+find_package(PkgConfig QUIET)
+if(PkgConfig_FOUND)
+  pkg_check_modules(PC_Libudev QUIET libudev)
+endif()
+
+find_path(Libudev_INCLUDE_DIR
+  NAMES libudev.h
+  PATHS ${PC_Libudev_INCLUDE_DIRS}
+  DOC "The libudev include directory")
+mark_as_advanced(Libudev_INCLUDE_DIR)
+
+find_library(Libudev_LIBRARY
+  NAMES udev
+  PATH ${PC_Libudev_LIBRARY_DIRS}
+  DOC "The libudev library"
+)
+mark_as_advanced(Libudev_LIBRARY)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  Libudev
+  REQUIRED_VARS Libudev_LIBRARY Libudev_INCLUDE_DIR
+  VERSION_VAR Libudev_VERSION
+)
+
+if(Libudev_FOUND)
+  set(Libudev_LIBRARIES "${Libudev_LIBRARY}")
+  set(Libudev_INCLUDE_DIRS "${Libudev_INCLUDE_DIR}")
+  set(Libudev_DEFINITIONS ${PC_Libudev_CFLAGS_OTHER})
+
+  if(NOT TARGET Libudev::Libudev)
+    add_library(Libudev::Libudev UNKNOWN IMPORTED)
+    set_target_properties(Libudev::Libudev
+      PROPERTIES
+        IMPORTED_LOCATION "${Libudev_LIBRARY}"
+        INTERFACE_COMPILE_OPTIONS "${PC_Libudev_CFLAGS_OTHER}"
+        INTERFACE_INCLUDE_DIRECTORIES "${Libudev_INCLUDE_DIR}"
+    )
+  endif()
+endif()

--- a/cmake/modules/Findhidapi.cmake
+++ b/cmake/modules/Findhidapi.cmake
@@ -43,6 +43,8 @@ The following cache variables may also be set:
 
 #]=======================================================================]
 
+include(IsStaticLibrary)
+
 find_package(PkgConfig QUIET)
 if(PkgConfig_FOUND)
   pkg_search_module(PC_hidapi QUIET hidapi-libusb hidapi)
@@ -121,6 +123,23 @@ if(hidapi_FOUND)
          INTERFACE_COMPILE_OPTIONS "${PC_hidapi_CFLAGS_OTHER}"
          INTERFACE_INCLUDE_DIRECTORIES "${hidapi_INCLUDE_DIR}"
       )
+
+      find_package(Libudev)
+      if(Libudev_FOUND)
+        is_static_library(hidapi_IS_STATIC hidapi::hidapi)
+        if(hidapi_IS_STATIC)
+          set_property(TARGET hidapi::hidapi APPEND PROPERTY INTERFACE_LINK_LIBRARIES
+            Libudev::Libudev
+          )
+        endif()
+
+        is_static_library(hidapi-hidraw_IS_STATIC hidapi::hidraw)
+        if(hidapi-hidraw_IS_STATIC)
+          set_property(TARGET hidapi::hidraw APPEND PROPERTY INTERFACE_LINK_LIBRARIES
+            Libudev::Libudev
+          )
+        endif()
+      endif()
     endif()
   endif()
 endif()


### PR DESCRIPTION
Follow-up to the other static linking PRs (#12291, #12292), some of the hidapi-related dependencies have a dependency on `libudev` that we'll have to link in explicitly in static builds (see e.g. [this build](https://github.com/fwcd/m1xxx/actions/runs/6841211208/job/18601330776)):

<details>

<summary>Click to see full linker error</summary>

```
/usr/bin/ld: /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libhidapi-hidraw.a(hid.c.o): in function `create_device_info_for_device':
hid.c:(.text+0x449): undefined reference to `udev_device_get_syspath'
/usr/bin/ld: hid.c:(.text+0x456): undefined reference to `udev_device_get_devnode'
/usr/bin/ld: hid.c:(.text+0x46c): undefined reference to `udev_device_get_parent_with_subsystem_devtype'
/usr/bin/ld: hid.c:(.text+0x48e): undefined reference to `udev_device_get_sysattr_value'
/usr/bin/ld: hid.c:(.text+0x9bf): undefined reference to `udev_device_get_parent_with_subsystem_devtype'
/usr/bin/ld: hid.c:(.text+0x9da): undefined reference to `udev_device_get_sysattr_value'
/usr/bin/ld: hid.c:(.text+0x9f5): undefined reference to `udev_device_get_sysattr_value'
/usr/bin/ld: hid.c:(.text+0xa18): undefined reference to `udev_device_get_sysattr_value'
/usr/bin/ld: hid.c:(.text+0xa47): undefined reference to `udev_device_get_parent_with_subsystem_devtype'
/usr/bin/ld: hid.c:(.text+0xa5f): undefined reference to `udev_device_get_sysattr_value'
/usr/bin/ld: /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libhidapi-hidraw.a(hid.c.o): in function `hid_enumerate':
hid.c:(.text+0xeb6): undefined reference to `udev_new'
/usr/bin/ld: hid.c:(.text+0xecc): undefined reference to `udev_enumerate_new'
/usr/bin/ld: hid.c:(.text+0xee3): undefined reference to `udev_enumerate_add_match_subsystem'
/usr/bin/ld: hid.c:(.text+0xeeb): undefined reference to `udev_enumerate_scan_devices'
/usr/bin/ld: hid.c:(.text+0xef3): undefined reference to `udev_enumerate_get_list_entry'
/usr/bin/ld: hid.c:(.text+0xf3a): undefined reference to `udev_list_entry_get_name'
/usr/bin/ld: hid.c:(.text+0xfe7): undefined reference to `udev_device_new_from_syspath'
/usr/bin/ld: hid.c:(.text+0x1004): undefined reference to `udev_device_unref'
/usr/bin/ld: hid.c:(.text+0x100c): undefined reference to `udev_list_entry_get_next'
/usr/bin/ld: hid.c:(.text+0x1022): undefined reference to `udev_enumerate_unref'
/usr/bin/ld: hid.c:(.text+0x102a): undefined reference to `udev_unref'
/usr/bin/ld: hid.c:(.text+0x10bd): undefined reference to `udev_enumerate_unref'
/usr/bin/ld: hid.c:(.text+0x10c5): undefined reference to `udev_unref'
/usr/bin/ld: /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libhidapi-hidraw.a(hid.c.o): in function `hid_get_device_info':
hid.c:(.text+0x183c): undefined reference to `udev_new'
/usr/bin/ld: hid.c:(.text+0x185a): undefined reference to `udev_device_new_from_devnum'
/usr/bin/ld: hid.c:(.text+0x187a): undefined reference to `udev_device_unref'
/usr/bin/ld: hid.c:(.text+0x1882): undefined reference to `udev_unref'
/usr/bin/ld: /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libusb-1.0.a(linux_udev.o): in function `udev_hotplug_event':
linux_udev.c:(.text+0x2c): undefined reference to `udev_device_get_action'
/usr/bin/ld: linux_udev.c:(.text+0x5c): undefined reference to `udev_device_get_devnode'
/usr/bin/ld: linux_udev.c:(.text+0x6c): undefined reference to `udev_device_get_sysname'
/usr/bin/ld: linux_udev.c:(.text+0xa2): undefined reference to `udev_device_unref'
/usr/bin/ld: /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libusb-1.0.a(linux_udev.o): in function `linux_udev_event_thread_main':
linux_udev.c:(.text+0x247): undefined reference to `udev_monitor_receive_device'
/usr/bin/ld: /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libusb-1.0.a(linux_udev.o): in function `linux_udev_start_event_monitor':
linux_udev.c:(.text+0x2f6): undefined reference to `udev_new'
/usr/bin/ld: linux_udev.c:(.text+0x315): undefined reference to `udev_monitor_new_from_netlink'
/usr/bin/ld: linux_udev.c:(.text+0x33b): undefined reference to `udev_monitor_filter_add_match_subsystem_devtype'
/usr/bin/ld: linux_udev.c:(.text+0x34f): undefined reference to `udev_monitor_enable_receiving'
/usr/bin/ld: linux_udev.c:(.text+0x363): undefined reference to `udev_monitor_get_fd'
/usr/bin/ld: linux_udev.c:(.text+0x480): undefined reference to `udev_monitor_unref'
/usr/bin/ld: linux_udev.c:(.text+0x4a1): undefined reference to `udev_unref'
/usr/bin/ld: /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libusb-1.0.a(linux_udev.o): in function `linux_udev_stop_event_monitor':
linux_udev.c:(.text+0x5b0): undefined reference to `udev_monitor_unref'
/usr/bin/ld: linux_udev.c:(.text+0x5d1): undefined reference to `udev_unref'
/usr/bin/ld: /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libusb-1.0.a(linux_udev.o): in function `linux_udev_scan_devices':
linux_udev.c:(.text+0x63d): undefined reference to `udev_enumerate_new'
/usr/bin/ld: linux_udev.c:(.text+0x65d): undefined reference to `udev_enumerate_add_match_subsystem'
/usr/bin/ld: linux_udev.c:(.text+0x673): undefined reference to `udev_enumerate_add_match_property'
/usr/bin/ld: linux_udev.c:(.text+0x67b): undefined reference to `udev_enumerate_scan_devices'
/usr/bin/ld: linux_udev.c:(.text+0x683): undefined reference to `udev_enumerate_get_list_entry'
/usr/bin/ld: linux_udev.c:(.text+0x6a4): undefined reference to `udev_list_entry_get_name'
/usr/bin/ld: linux_udev.c:(.text+0x6bd): undefined reference to `udev_device_new_from_syspath'
/usr/bin/ld: linux_udev.c:(.text+0x6c8): undefined reference to `udev_device_get_devnode'
/usr/bin/ld: linux_udev.c:(.text+0x6d8): undefined reference to `udev_device_get_sysname'
/usr/bin/ld: linux_udev.c:(.text+0x721): undefined reference to `udev_device_unref'
/usr/bin/ld: linux_udev.c:(.text+0x729): undefined reference to `udev_list_entry_get_next'
/usr/bin/ld: linux_udev.c:(.text+0x73f): undefined reference to `udev_enumerate_unref'
/usr/bin/ld: /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libusb-1.0.a(linux_udev.o): in function `linux_udev_hotplug_poll':
linux_udev.c:(.text+0x7c8): undefined reference to `udev_monitor_receive_device'
```

</details>

Note that `libudev` itself will likely still have to be linked dynamically, since it is part of the systemd libraries.