### PR TITLE
FindSleef: Use OpenMP in static builds

### DIFF
--- a/cmake/modules/FindSleef.cmake
+++ b/cmake/modules/FindSleef.cmake
@@ -118,6 +118,10 @@ if(Sleef_FOUND)
 
     is_static_library(SleefDFT_IS_STATIC Sleef::sleefdft)
     if(SleefDFT_IS_STATIC)
+      set_property(TARGET Sleef::sleefdft APPEND PROPERTY INTERFACE_LINK_LIBRARIES
+        Sleef::sleef
+      )
+
       find_package(OpenMP)
       if(OpenMP_CXX_FOUND)
         set_property(TARGET Sleef::sleefdft APPEND PROPERTY INTERFACE_LINK_LIBRARIES

--- a/cmake/modules/Findrubberband.cmake
+++ b/cmake/modules/Findrubberband.cmake
@@ -99,10 +99,9 @@ if(rubberband_FOUND)
       endif()
       find_package(Sleef)
       if (Sleef_FOUND)
-        find_library(sleefdft_path sleefdft REQUIRED)
         set_property(TARGET rubberband::rubberband APPEND PROPERTY INTERFACE_LINK_LIBRARIES
           Sleef::sleef
-          ${sleefdft_path}
+          Sleef::sleefdft
         )
       endif()
     endif()


### PR DESCRIPTION
Linking the vcpkg-built sleef statically on Linux seems to require OpenMP (see e.g. [this build](https://github.com/fwcd/m1xxx/actions/runs/6841211208/job/18601330776)):

```
/usr/bin/ld: /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libsleefdft.a(dftcommon.c.o): in function `SleefDFT_setPlanFilePath':
dftcommon.c:(.text+0x566): undefined reference to `GOMP_critical_start'
/usr/bin/ld: dftcommon.c:(.text+0x57c): undefined reference to `GOMP_critical_end'
/usr/bin/ld: dftcommon.c:(.text+0x68e): undefined reference to `omp_init_lock'
/usr/bin/ld: /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libsleefdft.a(dftcommon.c.o): in function `PlanManager_loadMeasurementResultsP':
dftcommon.c:(.text+0x7d8): undefined reference to `GOMP_critical_start'
/usr/bin/ld: dftcommon.c:(.text+0x7fa): undefined reference to `GOMP_critical_end'
/usr/bin/ld: dftcommon.c:(.text+0x804): undefined reference to `omp_set_lock'
/usr/bin/ld: dftcommon.c:(.text+0xa03): undefined reference to `omp_unset_lock'
/usr/bin/ld: dftcommon.c:(.text+0xa39): undefined reference to `omp_unset_lock'
/usr/bin/ld: dftcommon.c:(.text+0xa66): undefined reference to `omp_init_lock'
/usr/bin/ld: /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libsleefdft.a(dftcommon.c.o): in function `PlanManager_saveMeasurementResultsP':
dftcommon.c:(.text+0xab8): undefined reference to `GOMP_critical_start'
/usr/bin/ld: dftcommon.c:(.text+0xada): undefined reference to `GOMP_critical_end'
/usr/bin/ld: dftcommon.c:(.text+0xae4): undefined reference to `omp_set_lock'
/usr/bin/ld: dftcommon.c:(.text+0xdb6): undefined reference to `omp_init_lock'
...
```