### PR TITLE
FindVorbis: Link ogg in static builds

### DIFF
--- a/cmake/modules/FindVorbis.cmake
+++ b/cmake/modules/FindVorbis.cmake
@@ -43,6 +43,8 @@ The following cache variables may also be set:
 
 #]=======================================================================]
 
+include(IsStaticLibrary)
+
 find_path(Vorbis_vorbis_INCLUDE_DIR
   NAMES vorbis/codec.h
   DOC "Vorbis include directory"
@@ -101,3 +103,15 @@ find_package_handle_standard_args(Vorbis
     REQUIRED_VARS Vorbis_vorbis_INCLUDE_DIR Vorbis_vorbis_LIBRARY
     HANDLE_COMPONENTS
 )
+
+if(Vorbis_vorbis_FOUND)
+  is_static_library(Vorbis_vorbis_IS_STATIC Vorbis::vorbis)
+  if(Vorbis_vorbis_IS_STATIC)
+    find_package(Ogg)
+    if(Ogg_FOUND)
+      set_property(TARGET Vorbis::vorbis APPEND PROPERTY INTERFACE_LINK_LIBRARIES
+        Ogg::ogg
+      )
+    endif()
+  endif()
+endif()


### PR DESCRIPTION
We have to link libogg into libvorbis when building static binaries on Linux, see e.g. [this build](https://github.com/fwcd/m1xxx/actions/runs/6842881677/job/18604858454):

```
/usr/bin/ld: /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libvorbis.a(block.c.o): in function `vorbis_block_init':
block.c:(.text+0x3f8): undefined reference to `oggpack_writeinit'
/usr/bin/ld: block.c:(.text+0x415): undefined reference to `oggpack_writeinit'
/usr/bin/ld: /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libvorbis.a(block.c.o): in function `vorbis_block_clear':
block.c:(.text+0x58a): undefined reference to `oggpack_writeclear'
/usr/bin/ld: /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux/lib/libvorbis.a(analysis.c.o): in function `vorbis_analysis':
analysis.c:(.text+0x48): undefined reference to `oggpack_reset'
...
```