### PR TITLE
(fix)Tag Fetcher: enable Apply button regardless the cover art

### DIFF
--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -511,13 +511,18 @@ void DlgTagFetcher::addDivider(const QString& text, QTreeWidget* pParent) const 
 
 void DlgTagFetcher::tagSelected() {
     if (!tags->currentItem()) {
+        btnApply->setDisabled(true);
         return;
     }
 
     if (tags->currentItem()->data(0, Qt::UserRole).toInt() == kOriginalTrackIndex) {
         tags->currentItem()->setFlags(Qt::ItemIsEnabled);
+        btnApply->setDisabled(true);
         return;
     }
+    // Allow applying the tags, regardless the cover art
+    btnApply->setEnabled(true);
+
     const int tagIndex = tags->currentItem()->data(0, Qt::UserRole).toInt();
     m_data.m_selectedTag = tagIndex;
 


### PR DESCRIPTION
fixes a regression from #12041 or a later commit:
Tags couldn't be applied because the button remained diasbled.