### PR TITLE
Tagfetcher: cache fetched covers

### DIFF
--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -85,8 +85,8 @@ void DlgCoverArtFullSize::init(TrackPointer pTrack) {
     slotLoadTrack(pTrack);
 }
 
-void DlgCoverArtFullSize::initFetchedCoverArt(const QPixmap& pixmap) {
-    m_pixmap = pixmap;
+void DlgCoverArtFullSize::initFetchedCoverArt(QPixmap pixmap) {
+    m_pixmap = std::move(pixmap);
 
     // The real size will be calculated later by adjustImageAndDialogSize().
     resize(100, 100);

--- a/src/library/dlgcoverartfullsize.cpp
+++ b/src/library/dlgcoverartfullsize.cpp
@@ -85,8 +85,8 @@ void DlgCoverArtFullSize::init(TrackPointer pTrack) {
     slotLoadTrack(pTrack);
 }
 
-void DlgCoverArtFullSize::initFetchedCoverArt(const QByteArray& fetchedCoverArtBytes) {
-    m_pixmap.loadFromData(fetchedCoverArtBytes);
+void DlgCoverArtFullSize::initFetchedCoverArt(const QPixmap& pixmap) {
+    m_pixmap = pixmap;
 
     // The real size will be calculated later by adjustImageAndDialogSize().
     resize(100, 100);

--- a/src/library/dlgcoverartfullsize.h
+++ b/src/library/dlgcoverartfullsize.h
@@ -24,7 +24,7 @@ class DlgCoverArtFullSize
     ~DlgCoverArtFullSize() override = default;
 
     void init(TrackPointer pTrack);
-    void initFetchedCoverArt(const QPixmap& fetchedCoverArtBytes);
+    void initFetchedCoverArt(QPixmap pixmap);
     void mousePressEvent(QMouseEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* ) override;
     void mouseMoveEvent(QMouseEvent* ) override;

--- a/src/library/dlgcoverartfullsize.h
+++ b/src/library/dlgcoverartfullsize.h
@@ -24,7 +24,7 @@ class DlgCoverArtFullSize
     ~DlgCoverArtFullSize() override = default;
 
     void init(TrackPointer pTrack);
-    void initFetchedCoverArt(const QByteArray& fetchedCoverArtBytes);
+    void initFetchedCoverArt(const QPixmap& fetchedCoverArtBytes);
     void mousePressEvent(QMouseEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* ) override;
     void mouseMoveEvent(QMouseEvent* ) override;

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -595,10 +595,9 @@ void DlgTagFetcher::slotCoverFound(
 }
 
 void DlgTagFetcher::slotStartFetchCoverArt(const QList<QString>& allUrls) {
-    DlgPrefLibrary::CoverArtFetcherQuality fetcherQuality =
-            static_cast<DlgPrefLibrary::CoverArtFetcherQuality>(
-                    m_pConfig->getValue(mixxx::library::prefs::kCoverArtFetcherQualityConfigKey,
-                            static_cast<int>(DlgPrefLibrary::CoverArtFetcherQuality::Medium)));
+    const int fetcherQuality = m_pConfig->getValue(
+            mixxx::library::prefs::kCoverArtFetcherQualityConfigKey,
+            static_cast<int>(DlgPrefLibrary::CoverArtFetcherQuality::Medium));
 
     // Cover art links task can retrieve us variable number of links with different cover art sizes
     // Every single successful response has 2 links.
@@ -618,8 +617,8 @@ void DlgTagFetcher::slotStartFetchCoverArt(const QList<QString>& allUrls) {
         return;
     }
 
-    if (allUrls.size() > static_cast<int>(fetcherQuality)) {
-        getCoverArt(allUrls.at(static_cast<int>(fetcherQuality)));
+    if (allUrls.size() > fetcherQuality) {
+        getCoverArt(allUrls.at(fetcherQuality));
     } else {
         getCoverArt(allUrls.last());
     }

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -213,7 +213,7 @@ void DlgTagFetcher::init() {
     connect(&m_tagFetcher,
             &TagFetcher::coverArtImageFetchAvailable,
             this,
-            &DlgTagFetcher::slotLoadBytesToLabel);
+            &DlgTagFetcher::slotLoadFetchedCoverArt);
 
     connect(&m_tagFetcher,
             &TagFetcher::coverArtLinkNotFound,
@@ -257,6 +257,8 @@ void DlgTagFetcher::loadTrack(const TrackPointer& pTrack) {
     tags->clear();
 
     m_pWFetchedCoverArtLabel->setCoverArt(CoverInfo{}, QPixmap{});
+
+    m_coverCache.clear();
 
     m_pTrack = pTrack;
     if (!m_pTrack) {
@@ -567,12 +569,21 @@ void DlgTagFetcher::tagSelected() {
     m_data.m_selectedTag = tagIndex;
 
     m_fetchedCoverArtByteArrays.clear();
-    m_pWFetchedCoverArtLabel->loadData(QByteArray());
     m_pWFetchedCoverArtLabel->setCoverArt(CoverInfo{},
             QPixmap(CoverArtUtils::defaultCoverLocation()));
 
     const mixxx::musicbrainz::TrackRelease& trackRelease = m_data.m_tags[tagIndex];
     QUuid selectedTagAlbumId = trackRelease.albumReleaseId;
+
+    // Check if we already fetched the cover for this release earlier
+    QString cacheKey = selectedTagAlbumId.toString();
+    auto it = m_coverCache.constFind(cacheKey);
+    if (it != m_coverCache.constEnd()) {
+        QPixmap pix = it.value();
+        loadPixmapToLabel(pix);
+        return;
+    }
+
     statusMessage->setVisible(false);
 
     loadingProgressBar->setFormat(tr("Looking for cover art"));
@@ -594,7 +605,8 @@ void DlgTagFetcher::slotCoverFound(
     }
 }
 
-void DlgTagFetcher::slotStartFetchCoverArt(const QList<QString>& allUrls) {
+void DlgTagFetcher::slotStartFetchCoverArt(const QUuid& albumReleaseId,
+        const QList<QString>& allUrls) {
     const int fetcherQuality = m_pConfig->getValue(
             mixxx::library::prefs::kCoverArtFetcherQualityConfigKey,
             static_cast<int>(DlgPrefLibrary::CoverArtFetcherQuality::Medium));
@@ -617,35 +629,48 @@ void DlgTagFetcher::slotStartFetchCoverArt(const QList<QString>& allUrls) {
         return;
     }
 
+    // TODO(ronso0) Check if we already fetched the cover for the preferred resolution
+
+    QString coverUrl;
     if (allUrls.size() > fetcherQuality) {
-        getCoverArt(allUrls.at(fetcherQuality));
+        coverUrl = allUrls.at(fetcherQuality);
     } else {
-        getCoverArt(allUrls.last());
+        coverUrl = allUrls.last();
     }
+    getCoverArt(albumReleaseId, coverUrl);
 }
 
-void DlgTagFetcher::slotLoadBytesToLabel(const QByteArray& data) {
+void DlgTagFetcher::slotLoadFetchedCoverArt(const QUuid& albumReleaseId,
+        const QByteArray& data) {
     QPixmap fetchedCoverArtPixmap;
     fetchedCoverArtPixmap.loadFromData(data);
+
+    // Bytes to be eventually applied as track cover art
+    m_fetchedCoverArtByteArrays = data;
+
+    // Cache the fetched cover image
+    m_coverCache.insert(albumReleaseId.toString(), fetchedCoverArtPixmap);
+    loadPixmapToLabel(fetchedCoverArtPixmap);
+}
+
+void DlgTagFetcher::loadPixmapToLabel(const QPixmap& pixmap) {
     CoverInfo coverInfo;
+    coverInfo.type = CoverInfo::NONE;
     coverInfo.source = CoverInfo::USER_SELECTED;
 
     loadingProgressBar->setVisible(false);
     statusMessage->clear();
     statusMessage->setVisible(true);
 
-    m_fetchedCoverArtByteArrays = data;
-    m_pWFetchedCoverArtLabel->loadData(
-            m_fetchedCoverArtByteArrays); // This data loaded because for full size.
-    m_pWFetchedCoverArtLabel->setCoverArt(coverInfo, fetchedCoverArtPixmap);
+    m_pWFetchedCoverArtLabel->setCoverArt(coverInfo, pixmap);
 
-    checkBoxCover->setEnabled(!data.isNull());
+    checkBoxCover->setEnabled(!pixmap.isNull());
 }
 
-void DlgTagFetcher::getCoverArt(const QString& url) {
+void DlgTagFetcher::getCoverArt(const QUuid& albumReleaseId, const QString& url) {
     loadingProgressBar->setFormat(tr("Cover art found, receiving image."));
     loadingProgressBar->setValue(kPercentForCoverArtImageTask);
-    m_tagFetcher.startFetchCoverArtImage(url);
+    m_tagFetcher.startFetchCoverArtImage(albumReleaseId, url);
 }
 
 void DlgTagFetcher::slotCoverArtLinkNotFound() {

--- a/src/library/dlgtagfetcher.h
+++ b/src/library/dlgtagfetcher.h
@@ -61,8 +61,10 @@ class DlgTagFetcher : public QDialog, public Ui::DlgTagFetcher {
             const QObject* pRequester,
             const CoverInfo& coverInfo,
             const QPixmap& pixmap);
-    void slotStartFetchCoverArt(const QList<QString>& allUrls);
-    void slotLoadBytesToLabel(const QByteArray& data);
+    void slotStartFetchCoverArt(const QUuid& albumReleaseId,
+            const QList<QString>& allUrls);
+    void slotLoadFetchedCoverArt(const QUuid& albumReleaseId,
+            const QByteArray& data);
     void slotCoverArtLinkNotFound();
     void slotWorkerStarted();
     void slotWorkerAskOverwrite(const QString& coverArtAbsolutePath,
@@ -74,10 +76,12 @@ class DlgTagFetcher : public QDialog, public Ui::DlgTagFetcher {
   private:
     // Called on population or changed via buttons Next&Prev.
     void loadTrackInternal(const TrackPointer& pTrack);
-    void getCoverArt(const QString& url);
+    void getCoverArt(const QUuid& albumReleaseId, const QString& url);
     void loadCurrentTrackCover();
 
     void saveCheckBoxState();
+
+    void loadPixmapToLabel(const QPixmap& pPixmap);
 
     UserSettingsPointer m_pConfig;
 
@@ -108,6 +112,8 @@ class DlgTagFetcher : public QDialog, public Ui::DlgTagFetcher {
     Data m_data;
 
     QByteArray m_fetchedCoverArtByteArrays;
+
+    QMap<QString, QPixmap> m_coverCache;
 
     QScopedPointer<CoverArtCopyWorker> m_pWorker;
 };

--- a/src/musicbrainz/tagfetcher.cpp
+++ b/src/musicbrainz/tagfetcher.cpp
@@ -382,7 +382,7 @@ void TagFetcher::slotCoverArtArchiveLinksTaskFailed(
             -1);
 }
 
-void TagFetcher::slotCoverArtArchiveLinksTaskSucceeded(
+void TagFetcher::slotCoverArtArchiveLinksTaskSucceeded(const QUuid& albumReleaseId,
         const QList<QString>& allUrls) {
     DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
     if (m_pCoverArtArchiveLinksTask.get() != sender()) {
@@ -393,14 +393,16 @@ void TagFetcher::slotCoverArtArchiveLinksTaskSucceeded(
     auto pTrack = std::move(m_pTrack);
     terminate();
 
-    emit coverArtArchiveLinksAvailable(std::move(allUrls));
+    emit coverArtArchiveLinksAvailable(std::move(albumReleaseId),
+            std::move(allUrls));
 }
 
-void TagFetcher::startFetchCoverArtImage(
+void TagFetcher::startFetchCoverArtImage(const QUuid& albumReleaseId,
         const QString& coverArtUrl) {
     m_pCoverArtArchiveImageTask = make_parented<mixxx::CoverArtArchiveImageTask>(
             &m_network,
             coverArtUrl,
+            albumReleaseId,
             this);
 
     connect(m_pCoverArtArchiveImageTask,
@@ -424,7 +426,8 @@ void TagFetcher::startFetchCoverArtImage(
             kCoverArtArchiveImageTimeoutMilis);
 }
 
-void TagFetcher::slotCoverArtArchiveImageTaskSucceeded(const QByteArray& coverArtBytes) {
+void TagFetcher::slotCoverArtArchiveImageTaskSucceeded(const QUuid& albumReleaseId,
+        const QByteArray& coverArtBytes) {
     if (m_pCoverArtArchiveImageTask.get() != sender()) {
         // stray call from an already aborted try
         return;
@@ -433,7 +436,8 @@ void TagFetcher::slotCoverArtArchiveImageTaskSucceeded(const QByteArray& coverAr
     auto pTrack = std::move(m_pTrack);
     terminate();
 
-    emit coverArtImageFetchAvailable(coverArtBytes);
+    emit coverArtImageFetchAvailable(std::move(albumReleaseId),
+            coverArtBytes);
 }
 
 void TagFetcher::slotCoverArtArchiveImageTaskAborted() {

--- a/src/musicbrainz/tagfetcher.h
+++ b/src/musicbrainz/tagfetcher.h
@@ -38,7 +38,7 @@ class TagFetcher : public QObject {
     // Link provided from preference option.
     // After a success task, related label updated with cover art.
     // If user presses apply, cover art downloaded and applied to the song.
-    void startFetchCoverArtImage(
+    void startFetchCoverArtImage(const QUuid& albumReleaseId,
             const QString& coverArtUrl);
 
   public slots:
@@ -58,8 +58,10 @@ class TagFetcher : public QObject {
             const QString& message,
             int code);
     void fetchedCoverUpdate(const QByteArray& coverInfo);
-    void coverArtImageFetchAvailable(const QByteArray& coverArtBytes);
-    void coverArtArchiveLinksAvailable(const QList<QString>& allUrls);
+    void coverArtImageFetchAvailable(const QUuid& albumReleaseId,
+            const QByteArray& coverArtBytes);
+    void coverArtArchiveLinksAvailable(const QUuid& albumReleaseId,
+            const QList<QString>& allUrls);
     void coverArtLinkNotFound();
 
   private slots:
@@ -87,7 +89,8 @@ class TagFetcher : public QObject {
             const QString& errorString,
             const mixxx::network::WebResponseWithContent& responseWithContent);
 
-    void slotCoverArtArchiveLinksTaskSucceeded(const QList<QString>& allUrls);
+    void slotCoverArtArchiveLinksTaskSucceeded(const QUuid& albumReleaseId,
+            const QList<QString>& allUrls);
     void slotCoverArtArchiveLinksTaskFailed(
             const mixxx::network::JsonWebResponse& response);
     void slotCoverArtArchiveLinksTaskAborted();
@@ -96,7 +99,8 @@ class TagFetcher : public QObject {
             const QString& errorString,
             const mixxx::network::WebResponseWithContent& responseWithContent);
 
-    void slotCoverArtArchiveImageTaskSucceeded(const QByteArray& coverArtBytes);
+    void slotCoverArtArchiveImageTaskSucceeded(const QUuid& albumReleaseId,
+            const QByteArray& coverArtBytes);
     void slotCoverArtArchiveImageTaskFailed(
             const mixxx::network::WebResponse& response,
             int errorCode,

--- a/src/musicbrainz/web/coverartarchiveimagetask.cpp
+++ b/src/musicbrainz/web/coverartarchiveimagetask.cpp
@@ -24,11 +24,13 @@ QNetworkRequest createNetworkRequest(const QString& coverArtUrl) {
 CoverArtArchiveImageTask::CoverArtArchiveImageTask(
         QNetworkAccessManager* pNetworkAccessManager,
         const QString& coverArtLink,
+        const QUuid& albumReleaseId,
         QObject* pParent)
         : network::WebTask(
                   pNetworkAccessManager,
                   pParent),
-          m_coverArtUrl(coverArtLink) {
+          m_coverArtUrl(coverArtLink),
+          m_albumReleaseId(albumReleaseId) {
 }
 
 QNetworkReply* CoverArtArchiveImageTask::doStartNetworkRequest(
@@ -83,7 +85,7 @@ void CoverArtArchiveImageTask::emitSucceeded(
         deleteLater();
         return;
     }
-    emit succeeded(coverArtImageBytes);
+    emit succeeded(m_albumReleaseId, coverArtImageBytes);
 }
 
 void CoverArtArchiveImageTask::emitFailed(

--- a/src/musicbrainz/web/coverartarchiveimagetask.h
+++ b/src/musicbrainz/web/coverartarchiveimagetask.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <QUuid>
+
 #include "network/webtask.h"
 
 namespace mixxx {
@@ -11,11 +13,12 @@ class CoverArtArchiveImageTask : public network::WebTask {
     CoverArtArchiveImageTask(
             QNetworkAccessManager* pNetworkAccessManager,
             const QString& coverArtLink,
+            const QUuid& albumReleaseId,
             QObject* pParent = nullptr);
     ~CoverArtArchiveImageTask() override = default;
 
   signals:
-    void succeeded(
+    void succeeded(const QUuid& albumReleaseId,
             const QByteArray& coverArtImageBytes);
 
     void failed(
@@ -39,7 +42,8 @@ class CoverArtArchiveImageTask : public network::WebTask {
             int errorCode,
             const QString& errorMessage);
 
-    QString m_coverArtUrl;
+    const QString m_coverArtUrl;
+    const QUuid m_albumReleaseId;
 
     QByteArray coverArtImageBytes;
 };

--- a/src/musicbrainz/web/coverartarchivelinkstask.cpp
+++ b/src/musicbrainz/web/coverartarchivelinkstask.cpp
@@ -161,7 +161,7 @@ void CoverArtArchiveLinksTask::emitSucceeded(
         deleteLater();
         return;
     }
-    emit succeeded(allUrls);
+    emit succeeded(m_albumReleaseId, allUrls);
 }
 
 } // namespace mixxx

--- a/src/musicbrainz/web/coverartarchivelinkstask.h
+++ b/src/musicbrainz/web/coverartarchivelinkstask.h
@@ -20,7 +20,7 @@ class CoverArtArchiveLinksTask : public network::JsonWebTask {
     ~CoverArtArchiveLinksTask() override = default;
 
   signals:
-    void succeeded(
+    void succeeded(const QUuid& albumReleaseId,
             const QList<QString>& allUrls);
 
   private:

--- a/src/widget/wcoverartlabel.cpp
+++ b/src/widget/wcoverartlabel.cpp
@@ -49,9 +49,11 @@ void WCoverArtLabel::setCoverArt(const CoverInfo& coverInfo,
     }
     if (px.isNull()) {
         m_loadedCover = px;
+        m_fullSizeCover = px;
         setPixmap(m_defaultCover);
     } else {
         m_loadedCover = scaleCoverLabel(this, px);
+        m_fullSizeCover = px;
         setPixmap(m_loadedCover);
     }
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
@@ -83,10 +85,6 @@ void WCoverArtLabel::loadTrack(TrackPointer pTrack) {
     m_pLoadedTrack = pTrack;
 }
 
-void WCoverArtLabel::loadData(const QByteArray& data) {
-    m_Data = data;
-}
-
 void WCoverArtLabel::mousePressEvent(QMouseEvent* event) {
     if (m_pCoverMenu != nullptr && m_pCoverMenu->isVisible()) {
         return;
@@ -98,8 +96,8 @@ void WCoverArtLabel::mousePressEvent(QMouseEvent* event) {
         } else {
             if (m_loadedCover.isNull()) {
                 return;
-            } else if (!m_pLoadedTrack && !m_Data.isNull()) {
-                m_pDlgFullSize->initFetchedCoverArt(m_Data);
+            } else if (!m_pLoadedTrack && !m_fullSizeCover.isNull()) {
+                m_pDlgFullSize->initFetchedCoverArt(m_fullSizeCover);
             } else {
                 m_pDlgFullSize->init(m_pLoadedTrack);
             }

--- a/src/widget/wcoverartlabel.h
+++ b/src/widget/wcoverartlabel.h
@@ -21,7 +21,6 @@ class WCoverArtLabel : public QLabel {
 
     void setCoverArt(const CoverInfo& coverInfo, const QPixmap& px);
     void loadTrack(TrackPointer pTrack);
-    void loadData(const QByteArray& data);
 
   protected:
     void mousePressEvent(QMouseEvent* event) override;
@@ -35,11 +34,9 @@ class WCoverArtLabel : public QLabel {
 
     const parented_ptr<DlgCoverArtFullSize> m_pDlgFullSize;
 
-    const QPixmap m_defaultCover;
-
-    QByteArray m_Data;
-
     TrackPointer m_pLoadedTrack;
 
+    const QPixmap m_defaultCover;
     QPixmap m_loadedCover;
+    QPixmap m_fullSizeCover;
 };


### PR DESCRIPTION
Closes #11084

A quick test to cache the fetched cover images with ~~the global `QPixmapCache`~~ a QMap.
Cache keys are ~~"DlgTagftecher" +~~ the MusicBrainz release id.
This greatly improves UX when comparing covers of MusicBrainz results.

~~Works good, though removing the covers from the cache is a bit dirty I think.~~
~~To discuss:~~
~~* really use global QPixmapCache which is also used by CoverArtCache?~~
~~* shall we increase the QPixmapCache cache limit when DlgTagFetcher is constructed to avoid clearing cached covers by adding large fetched covers?~~

I didn't check the sizes of fetched covers, yet, we need to estimate a reasonable limit.

### ToDo
- [x] clear cache when loading another track
- [ ] preferred image size vs. cached images:
currently the preference is read from config each time image urls are received. With the current implementation this may result in a mismatch of current size preference / cached images.
We could 
a) read from config **once** in the constructor to avoid the issue in the first place
b) read the preference each time urls are received and use the size preference (int) for the cache key
- [x] remove/disable debug output

based on #12300 