### PR TITLE
add missing include /util/time.h

### DIFF
--- a/src/util/timer.cpp
+++ b/src/util/timer.cpp
@@ -2,6 +2,7 @@
 
 #include "moc_timer.cpp"
 #include "util/experiment.h"
+#include "util/time.h"
 
 Timer::Timer(const QString& key, Stat::ComputeFlags compute)
         : m_key(key),


### PR DESCRIPTION
noticed locally with pre-built headers OFF

I'm a bit worried that such things seem to slip through CI