### PR TITLE
Sampler DeckVisuals fix

### DIFF
--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -59,6 +59,7 @@ namespace {
 const mixxx::Logger kLogger("CoreServices");
 constexpr int kMicrophoneCount = 4;
 constexpr int kAuxiliaryCount = 4;
+constexpr int kSamplerCount = 4;
 
 #define CLEAR_AND_CHECK_DELETED(x) clearHelper(x, #x);
 
@@ -303,10 +304,11 @@ void CoreServices::initialize(QApplication* pApp) {
     }
 
     m_pPlayerManager->addConfiguredDecks();
-    m_pPlayerManager->addSampler();
-    m_pPlayerManager->addSampler();
-    m_pPlayerManager->addSampler();
-    m_pPlayerManager->addSampler();
+
+    for (int i = 0; i < kSamplerCount; ++i) {
+        m_pPlayerManager->addSampler();
+    }
+
     m_pPlayerManager->addPreviewDeck();
 
     m_pEffectsManager->setup();

--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -86,6 +86,10 @@ T* findFirstStoppedPlayerInList(const QList<T*>& players) {
     return nullptr;
 }
 
+inline QString getDefaultSamplerPath(UserSettingsPointer pConfig) {
+    return pConfig->getSettingsPath() + QStringLiteral("/samplers.xml");
+}
+
 } // anonymous namespace
 
 //static
@@ -144,8 +148,7 @@ PlayerManager::~PlayerManager() {
 
     const auto locker = lockMutex(&m_mutex);
 
-    m_pSamplerBank->saveSamplerBankToPath(
-        m_pConfig->getSettingsPath() + "/samplers.xml");
+    m_pSamplerBank->saveSamplerBankToPath(getDefaultSamplerPath(m_pConfig));
     // No need to delete anything because they are all parented to us and will
     // be destroyed when we are destroyed.
     m_players.clear();
@@ -453,8 +456,7 @@ void PlayerManager::addDeckInner() {
 }
 
 void PlayerManager::loadSamplers() {
-    m_pSamplerBank->loadSamplerBankFromPath(
-            m_pConfig->getSettingsPath() + "/samplers.xml");
+    m_pSamplerBank->loadSamplerBankFromPath(getDefaultSamplerPath(m_pConfig));
 }
 
 void PlayerManager::addSampler() {

--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -110,15 +110,15 @@ PlayerManager::PlayerManager(UserSettingsPointer pConfig,
           m_pEngine(pEngine),
           // NOTE(XXX) LegacySkinParser relies on these controls being Controls
           // and not ControlProxies.
-          m_pCONumDecks(new ControlObject(
+          m_pCONumDecks(std::make_unique<ControlObject>(
                   ConfigKey(kAppGroup, QStringLiteral("num_decks")), true, true)),
-          m_pCONumSamplers(new ControlObject(
+          m_pCONumSamplers(std::make_unique<ControlObject>(
                   ConfigKey(kAppGroup, QStringLiteral("num_samplers")), true, true)),
-          m_pCONumPreviewDecks(new ControlObject(
+          m_pCONumPreviewDecks(std::make_unique<ControlObject>(
                   ConfigKey(kAppGroup, QStringLiteral("num_preview_decks")), true, true)),
-          m_pCONumMicrophones(new ControlObject(
+          m_pCONumMicrophones(std::make_unique<ControlObject>(
                   ConfigKey(kAppGroup, QStringLiteral("num_microphones")), true, true)),
-          m_pCONumAuxiliaries(new ControlObject(
+          m_pCONumAuxiliaries(std::make_unique<ControlObject>(
                   ConfigKey(kAppGroup, QStringLiteral("num_auxiliaries")), true, true)),
           m_pTrackAnalysisScheduler(TrackAnalysisScheduler::NullPointer()) {
     m_pCONumDecks->addAlias(ConfigKey(kLegacyGroup, QStringLiteral("num_decks")));
@@ -160,12 +160,6 @@ PlayerManager::~PlayerManager() {
     delete m_pCOPNumDecks.fetchAndStoreAcquire(nullptr);
     delete m_pCOPNumSamplers.fetchAndStoreAcquire(nullptr);
     delete m_pCOPNumPreviewDecks.fetchAndStoreAcquire(nullptr);
-
-    delete m_pCONumSamplers;
-    delete m_pCONumDecks;
-    delete m_pCONumPreviewDecks;
-    delete m_pCONumMicrophones;
-    delete m_pCONumAuxiliaries;
 
     if (m_pTrackAnalysisScheduler) {
         m_pTrackAnalysisScheduler->stop();

--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -342,6 +342,7 @@ void PlayerManager::slotChangeNumSamplers(double v) {
         addSamplerInner();
     }
     m_pCONumSamplers->setAndConfirm(m_samplers.size());
+    emit numberOfSamplersChanged(m_samplers.count());
 }
 
 void PlayerManager::slotChangeNumPreviewDecks(double v) {

--- a/src/mixer/playermanager.h
+++ b/src/mixer/playermanager.h
@@ -276,11 +276,11 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
     EffectsManager* m_pEffectsManager;
     EngineMixer* m_pEngine;
     SamplerBank* m_pSamplerBank;
-    ControlObject* m_pCONumDecks;
-    ControlObject* m_pCONumSamplers;
-    ControlObject* m_pCONumPreviewDecks;
-    ControlObject* m_pCONumMicrophones;
-    ControlObject* m_pCONumAuxiliaries;
+    std::unique_ptr<ControlObject> m_pCONumDecks;
+    std::unique_ptr<ControlObject> m_pCONumSamplers;
+    std::unique_ptr<ControlObject> m_pCONumPreviewDecks;
+    std::unique_ptr<ControlObject> m_pCONumMicrophones;
+    std::unique_ptr<ControlObject> m_pCONumAuxiliaries;
     parented_ptr<ControlProxy> m_pAutoDjEnabled;
 
     TrackAnalysisScheduler::Pointer m_pTrackAnalysisScheduler;

--- a/src/mixer/playermanager.h
+++ b/src/mixer/playermanager.h
@@ -241,6 +241,7 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
 
     // Emitted when the number of decks changes.
     void numberOfDecksChanged(int decks);
+    void numberOfSamplersChanged(int samplers);
 
     void trackAnalyzerProgress(TrackId trackId, AnalyzerProgress analyzerProgress);
     void trackAnalyzerIdle();

--- a/src/mixer/samplerbank.cpp
+++ b/src/mixer/samplerbank.cpp
@@ -46,9 +46,6 @@ SamplerBank::SamplerBank(UserSettingsPointer pConfig,
             this);
 }
 
-SamplerBank::~SamplerBank() {
-}
-
 void SamplerBank::slotSaveSamplerBank(double v) {
     if (v <= 0.0) {
         return;

--- a/src/mixer/samplerbank.h
+++ b/src/mixer/samplerbank.h
@@ -17,7 +17,6 @@ class SamplerBank : public QObject {
   public:
     SamplerBank(UserSettingsPointer pConfig,
             PlayerManager* pPlayerManager);
-    ~SamplerBank() override;
 
     bool saveSamplerBankToPath(const QString& samplerBankPath);
     bool loadSamplerBankFromPath(const QString& samplerBankPath);

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -218,6 +218,15 @@ void MixxxMainWindow::initialize() {
                     m_pVisualsManager->addDeckIfNotExist(group);
                 }
             });
+    connect(pPlayerManager.get(),
+            &PlayerManager::numberOfSamplersChanged,
+            this,
+            [this](int decks) {
+                for (int i = 0; i < decks; ++i) {
+                    QString group = PlayerManager::groupForSampler(i);
+                    m_pVisualsManager->addDeckIfNotExist(group);
+                }
+            });
 
 #ifndef MIXXX_USE_QOPENGL
     // Before creating the first skin we need to create a QGLWidget so that all

--- a/src/waveform/visualsmanager.cpp
+++ b/src/waveform/visualsmanager.cpp
@@ -13,7 +13,7 @@ DeckVisuals::DeckVisuals(const QString& group)
           engineKey(ConfigKey(group, "key")) {
     m_pTimeElapsed = std::make_unique<ControlObject>(ConfigKey(m_group, "time_elapsed"));
     m_pTimeRemaining = std::make_unique<ControlObject>(ConfigKey(m_group, "time_remaining"));
-    m_pEndOfTrack = std::make_unique<ControlObject>(ConfigKey(group, "end_of_track"));
+    m_pEndOfTrack = std::make_unique<ControlObject>(ConfigKey(m_group, "end_of_track"));
     m_pVisualBpm = std::make_unique<ControlObject>(ConfigKey(m_group, "visual_bpm"));
     m_pVisualKey = std::make_unique<ControlObject>(ConfigKey(m_group, "visual_key"));
 


### PR DESCRIPTION
Closes #12304 
```
info [Main] Creating skin control object: "[Sampler16],visual_bpm"
warning [Main] ControlDoublePrivate::getControl returning NULL for ( "[Sampler9]" , "end_of_track" )
```

Symptons were
* no end-of-track highlight
* no BPM display
* no key display

for samplers requested by a skin that exceed the initial sampler count (4) or the number of samplers requested by `samplers.xml`

And some cleanup/tweaking en passant.