### PR TITLE
Add missing includes

### DIFF
--- a/src/controllers/midi/hss1394enumerator.h
+++ b/src/controllers/midi/hss1394enumerator.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "controllers/midi/midienumerator.h"
+#include "preferences/usersettings.h"
 
 // Handles discovery and enumeration of DJ controllers that appear under the
 // HSS1394 cross-platform API.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,7 @@
 #include "util/cmdlineargs.h"
 #include "util/console.h"
 #include "util/logging.h"
+#include "util/sandbox.h"
 #include "util/versionstore.h"
 
 namespace {

--- a/src/preferences/upgrade.cpp
+++ b/src/preferences/upgrade.cpp
@@ -14,6 +14,7 @@
 #include "library/trackcollection.h"
 #include "preferences/beatdetectionsettings.h"
 #include "preferences/usersettings.h"
+#include "util/cmdlineargs.h"
 #include "util/db/dbconnectionpooled.h"
 #include "util/db/dbconnectionpooler.h"
 #include "util/math.h"


### PR DESCRIPTION
For some reason, the `main` build randomly started failing for me due to some missing includes.

Now I wonder why this even worked in the first place (`hss1394enumerator.h` doesn't even include `usersettings.h` transitively, so it probably relied on having downstream source files include that somewhere above `hss1394enumerator.h`?) Not sure if there was some update to Xcode that made the compiler stricter, but even that seems strange, since C++ compilers usually go to great lengths to ensure backwards compatibility.

Anyway, here's the patch.