### PR TITLE
Effects: center Super knob when loading empty (QuickEffect) chain preset

### DIFF
--- a/src/effects/presets/effectchainpresetmanager.cpp
+++ b/src/effects/presets/effectchainpresetmanager.cpp
@@ -41,6 +41,8 @@ EffectChainPresetPointer loadPresetFromFile(const QString& filePath) {
 EffectChainPresetPointer createEmptyChainPreset() {
     EffectManifestPointer pEmptyManifest(new EffectManifest());
     pEmptyManifest->setName(kNoEffectString);
+    // Center the Super knob, eliminates the colored (bipolar) knob ring
+    pEmptyManifest->setMetaknobDefault(0.5);
     // Required for the QuickEffect selector in DlgPrefEQ
     pEmptyManifest->setShortName(kNoEffectString);
     auto pEmptyChainPreset =


### PR DESCRIPTION
picked from #11695 

Center Super knob in order to eliminate the colored ring when not at 12 o'clock. It's simply less visual noise this way.