### PR TITLE
Tracks table: avoid wrong pre-selection with no tracks selected previously

### DIFF
--- a/src/widget/wlibrarytableview.cpp
+++ b/src/widget/wlibrarytableview.cpp
@@ -21,8 +21,8 @@ constexpr int kModelCacheSize = 1000;
 WLibraryTableView::WLibraryTableView(QWidget* parent,
         UserSettingsPointer pConfig)
         : QTableView(parent),
-          m_prevRow(0),
-          m_prevColumn(0),
+          m_prevRow(-1),
+          m_prevColumn(-1),
           m_pConfig(pConfig),
           m_modelStateCache(kModelCacheSize) {
     // Setup properties for table
@@ -212,8 +212,8 @@ void WLibraryTableView::restoreCurrentIndex(const QModelIndex& index) {
         pSelectionModel->setCurrentIndex(idx, QItemSelectionModel::NoUpdate);
         scrollTo(idx);
     }
-    m_prevRow = 0;
-    m_prevColumn = 0;
+    m_prevRow = -1;
+    m_prevColumn = -1;
 }
 
 void WLibraryTableView::setTrackTableFont(const QFont& font) {

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -215,7 +215,7 @@ void WTrackTableView::loadTrackModel(QAbstractItemModel* model, bool restoreStat
     // tableview is focused -- and would not restore the previous style when
     // it's unfocused. This can not be overwritten with qss, so it can screw up
     // the skin design. Also, due to selectionModel()->selectedRows() it is not
-    // even useful to highlight the focused column because all colmsn are highlighted.
+    // even useful to indicate the focused column because all columns are highlighted.
     header->setHighlightSections(false);
     header->setSortIndicatorShown(m_sorting);
     header->setDefaultAlignment(Qt::AlignLeft);


### PR DESCRIPTION
by initializing with invalid row/column -1

Closes #12064