### PR TITLE
Skins: fix style of selected QComboBox items on Windows

### DIFF
--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -2039,6 +2039,16 @@ WSearchLineEdit QAbstractScrollArea,
     /* remove OS focus indicator */
     outline: none;
     }
+    /* required on Windows since the QAbstractItemViews don't inherit styles from
+       the respective QComboBoxes */
+    WEffectSelector QAbstractItemView,
+    WEffectChainPresetSelector QAbstractItemView,
+    WSearchLineEdit QAbstractItemView {
+      selection-color: #fff;
+      selection-background-color: #565353;
+      border: 0px;
+      outline: none;
+    }
     /* Remove 3D border from unchecked effects checkmark space */
     WEffectSelector::item:selected,
     WEffectChainPresetSelector::item:selected,

--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -2504,9 +2504,20 @@ WSearchLineEdit::item:selected,
 #SkinSettingsMixerToggle[hover="true"],
 #SkinSettingsLabelButton[hover="true"] {
   background-color: #5E4507;
-  color: white;
+  color: #fff;
   /* remove OS focus indicator */
   outline: none;
+  }
+  /* required on Windows since the QAbstractItemViews don't inherit styles from
+     the respective QComboBoxes */
+  WEffectSelector QAbstractItemView,
+  WEffectChainPresetSelector QAbstractItemView,
+  WSearchLineEdit QAbstractItemView {
+    selection-color: #fff;
+    selection-background-color: #5E4507;
+    border-radius: 1px;
+    border: 0px;
+    outline: none;
   }
   /* checked item */
   WEffectSelector::item:checked,

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -1327,6 +1327,7 @@ WEffectChainPresetSelector:!editable:on,
 #RateText, #RateRangePrefix, #RateRangeText,
 #MixerMainHeadphone #FxAssignButtons WPushButton[displayValue="0"],
 #PreviewLabel,
+WSearchLineEdit QAbstractScrollArea,
 WEffectSelector QAbstractScrollArea,
 WEffectChainPresetSelector QAbstractScrollArea,
 #fadeModeCombobox QAbstractScrollArea,
@@ -2997,6 +2998,15 @@ WSearchLineEdit::item:selected,
   color: #fff;
   /* remove OS focus indicator */
   outline: none;
+  }
+  WEffectSelector QAbstractItemView,
+  WEffectChainPresetSelector QAbstractItemView,
+  WSearchLineEdit QAbstractItemView {
+    selection-color: #fff;
+    selection-background-color: #2c454f;
+    border-radius: 1px;
+    border: 0px;
+    outline: none;
   }
   /* checked item */
   WEffectSelector::item:checked,

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -173,6 +173,16 @@ WEffectSelector::indicator:unchecked:selected,
   /* remove OS focus indicator */
   outline: none;
   }
+  /* required on Windows since the QAbstractItemViews don't inherit styles from
+     the respective QComboBoxes */
+  WEffectSelector QAbstractItemView,
+  WEffectChainPresetSelector QAbstractItemView,
+  WSearchLineEdit QAbstractItemView {
+    selection-color: #000;
+    selection-background-color: lightgray;
+    border: 0px;
+    outline: none;
+  }
   /* Remove 3D border from unchecked effects checkmark space */
   WEffectSelector::item:selected,
   WSearchLineEdit::item:selected,

--- a/res/skins/Shade/style_dark.qss
+++ b/res/skins/Shade/style_dark.qss
@@ -71,6 +71,13 @@ WEffectSelector::indicator:unchecked:selected,
 #fadeModeCombobox::indicator:unchecked:selected {
   background-color: #999;
   }
+  /* required on Windows since the QAbstractItemViews don't inherit styles from
+     the respective QComboBoxes */
+  WEffectSelector QAbstractItemView,
+  WEffectChainPresetSelector QAbstractItemView,
+  WSearchLineEdit QAbstractItemView {
+    selection-background-color: #999;
+  }
   WEffectSelector::indicator:unchecked:selected,
   #fadeModeCombobox::indicator:unchecked:selected {
     border-color: #999;

--- a/res/skins/Shade/style_summer_sunset.qss
+++ b/res/skins/Shade/style_summer_sunset.qss
@@ -81,6 +81,13 @@ WEffectSelector::indicator:unchecked:selected,
 #fadeModeCombobox::indicator:unchecked:selected {
   background-color: #d9c663;
   }
+  /* required on Windows since the QAbstractItemViews don't inherit styles from
+     the respective QComboBoxes */
+  WEffectSelector QAbstractItemView,
+  WEffectChainPresetSelector QAbstractItemView,
+  WSearchLineEdit QAbstractItemView {
+    selection-background-color: #d9c663;
+  }
   WEffectSelector::indicator:unchecked:selected,
   #fadeModeCombobox::indicator:unchecked:selected {
     border-color: #d9c663;

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -2377,7 +2377,17 @@ WSearchLineEdit::item:selected,
   color: #fff;
   /* remove OS focus indicator */
   outline: none;
-}
+  }
+  /* required on Windows since the QAbstractItemViews don't inherit styles from
+     the respective QComboBoxes */
+  WEffectSelector QAbstractItemView,
+  WEffectChainPresetSelector QAbstractItemView,
+  WSearchLineEdit QAbstractItemView {
+    selection-color: #fff;
+    selection-background-color: #555;
+    border: 0px;
+    outline: none;
+  }
 
 /* disabled menu items and checkboxes */
 #MainMenu::item:disabled,


### PR DESCRIPTION
add explict selectors for the QComboBoxes' QList items since appearantly they don't inherit styles from the respective QComboBoxes on Windows and the system theme is used.

Closes #12323 