### PR TITLE
Debug: Add Rust-inspired `DBG` macro for quick print-debugging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1595,14 +1595,6 @@ if(WARNINGS_FATAL)
   endif()
 endif()
 
-option(DEBUG_ASSERTIONS_FATAL "Fail if debug become true assertions" OFF)
-if(DEBUG_ASSERTIONS_FATAL)
-  target_compile_definitions(mixxx-lib PUBLIC MIXXX_DEBUG_ASSERTIONS_FATAL MIXXX_DEBUG_ASSERTIONS_ENABLED)
-  if (NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
-    message(STATUS "DEBUG_ASSERT statements have been enabled because DEBUG_ASSERTIONS_FATAL is ON.")
-  endif()
-endif()
-
 target_compile_definitions(mixxx-lib PUBLIC
   "${CMAKE_SYSTEM_PROCESSOR}"
   $<$<CONFIG:Debug>:MIXXX_BUILD_DEBUG>
@@ -2653,6 +2645,17 @@ if(QT_EXTRA_COMPONENTS)
   # qt_finalize_target takes care that the resources :/mixxx.org/imports/Mixxx/
   # and :/mixxx.org/imports/Mixxx/Controls are placed into beginning of the binary
   qt_finalize_target(mixxx)
+endif()
+
+option(DEBUG_ASSERTIONS_FATAL "Fail if debug become true assertions" OFF)
+if(DEBUG_ASSERTIONS_FATAL)
+  target_compile_definitions(mixxx-lib PUBLIC MIXXX_DEBUG_ASSERTIONS_FATAL MIXXX_DEBUG_ASSERTIONS_ENABLED)
+  if(QML)
+    target_compile_definitions(mixxx-qml-lib PUBLIC MIXXX_DEBUG_ASSERTIONS_FATAL MIXXX_DEBUG_ASSERTIONS_ENABLED)
+  endif()
+  if (NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+    message(STATUS "DEBUG_ASSERT statements have been enabled because DEBUG_ASSERTIONS_FATAL is ON.")
+  endif()
 endif()
 
 target_compile_definitions(mixxx-lib PUBLIC QT_TABLET_SUPPORT QT_USE_QSTRINGBUILDER)

--- a/src/util/debug.h
+++ b/src/util/debug.h
@@ -9,12 +9,10 @@
 #define DBG(value) \
     (qDebug().nospace() << #value << " = " << (value) << " [" << __FILE__ << ":" << __LINE__ << "]")
 #else
-// We have to stop clang-format from breaking up the string literal since that
-// breaks the pragma (at least when using Clang).
-// clang-format off
-#define DBG(value)                                                            \
-    _Pragma("message \"DBG(...) should not be used in a build without debug assertions, please remove it! This will be a no-op.\"")
-// clang-format on
+#define DBG(value)                                                             \
+    static_assert(false,                                                       \
+            "DBG() is not allowed in builds without debug assertions, please " \
+            "remove it!")
 #endif
 
 template <typename T>

--- a/src/util/debug.h
+++ b/src/util/debug.h
@@ -7,7 +7,7 @@
 
 #ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
 #define DBG(value) \
-    (qDebug().nospace() << #value << " = " << value << " [" << __FILE__ << ":" << __LINE__ << "]")
+    (qDebug().nospace() << #value << " = " << (value) << " [" << __FILE__ << ":" << __LINE__ << "]")
 #else
 // We have to stop clang-format from breaking up the string literal since that
 // breaks the pragma (at least when using Clang).

--- a/src/util/debug.h
+++ b/src/util/debug.h
@@ -6,9 +6,8 @@
 #include "errordialoghandler.h"
 
 #ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
-#define DBG(value)                                                       \
-    (qDebug().nospace() << __FILE__ << ":" << __LINE__ << ": " << #value \
-                        << " = " << value)
+#define DBG(value) \
+    (qDebug().nospace() << #value << " = " << value << " [" << __FILE__ << ":" << __LINE__ << "]")
 #else
 // We have to stop clang-format from breaking up the string literal since that
 // breaks the pragma (at least when using Clang).

--- a/src/util/debug.h
+++ b/src/util/debug.h
@@ -5,6 +5,19 @@
 
 #include "errordialoghandler.h"
 
+#ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
+#define DBG(value)                                                       \
+    (qDebug().nospace() << __FILE__ << ":" << __LINE__ << ": " << #value \
+                        << " = " << value)
+#else
+// We have to stop clang-format from breaking up the string literal since that
+// breaks the pragma (at least when using Clang).
+// clang-format off
+#define DBG(value)                                                            \
+    _Pragma("message \"DBG(...) should not be used in a build without debug assertions, please remove it! This will be a no-op.\"")
+// clang-format on
+#endif
+
 template <typename T>
 QString toDebugString(const T& object) {
     QString output;


### PR DESCRIPTION
During debugging, I often find myself logging a bunch of variables to retrace/understand some part of the codebase. While this is essentially a very crude, quick-and-dirty form of print debugging, it seems to be so common that the Rust standard library has a macro for this, [`dbg!`](https://doc.rust-lang.org/std/macro.dbg.html).

Therefore, to make it easier to quickly debug Mixxx, this PR adds a heavily Rust-inspired and quick-to-type `DBG` macro that writes an expression in both its quoted and evaluated form to `qDebug`, along with the file and line to make it easy to quickly locatable in the source code.

To avoid accidentally including `DBG` invocations in release builds, the macro is redefined to emit a message if debug assertions are disabled. Ideally this should be promoted to an error, but I couldn't figure out a way to do so (from within the macro definition where we can't just use `#error`), also the QML library which includes this header currently seems to be built without debug assertions even if `DEBUG_ASSERTIONS_FATAL` is set.

Thoughts?

### To do

- [x] Target 2.4
- [ ] Figure out how to shorten the file path format