### PR TITLE
ITunesDAO: Add missing `<ostream>` include

### DIFF
--- a/src/library/itunes/itunesdao.h
+++ b/src/library/itunes/itunesdao.h
@@ -6,6 +6,7 @@
 #include <QString>
 #include <gsl/pointers>
 #include <map>
+#include <ostream>
 
 #include "library/dao/dao.h"
 


### PR DESCRIPTION
Another missing header in 2.4.