### PR TITLE
MIDI Input editor: allow selecting multiple Options

### DIFF
--- a/src/controllers/delegates/midioptionsdelegate.cpp
+++ b/src/controllers/delegates/midioptionsdelegate.cpp
@@ -161,6 +161,10 @@ void MidiOptionsDelegate::commitAndCloseEditor(int index) {
     DEBUG_ASSERT(pItem);
     if (pItem->isCheckable()) {
         pItem->setCheckState(pItem->checkState() == Qt::Checked ? Qt::Unchecked : Qt::Checked);
+        // TODO Concurrent option scan be selected. Implement a compatibility
+        // matrix and uncheck all options that are incompatible with the last
+        // checked option. Store initial check state for/in each item and
+        // hook up to QStandardItemModel::itemChanged()
     } else {
         // Clear was selected. Uncheck all other items
         for (int row = 0; row < pModel->rowCount() - 1; row++) {

--- a/src/controllers/delegates/midioptionsdelegate.cpp
+++ b/src/controllers/delegates/midioptionsdelegate.cpp
@@ -12,7 +12,13 @@
 namespace {
 
 const QList<MidiOption> kMidiOptions = {
-        MidiOption::None,
+        // Don't add 'Normal' to the list because it's useless: it's exclusive,
+        // meaning it's the implicit result of unchecking all other options, but
+        // clicking it does not uncheck all other options. Also, showing it
+        // checked is pointless (and it's not updated if others are checked).
+        // Furthermore, the mapping list is cleaner without it, mappings that
+        // have options set are much easier to spot.
+        // MidiOption::None,
         MidiOption::Invert,
         MidiOption::Rot64,
         MidiOption::Rot64Invert,
@@ -49,13 +55,6 @@ QWidget* MidiOptionsDelegate::createEditor(QWidget* parent,
     auto* pModel = static_cast<QStandardItemModel*>(pComboBox->model());
     DEBUG_ASSERT(pModel);
     for (const MidiOption opt : kMidiOptions) {
-        // Don't add 'Normal' to the list because it's useless: it's exclusive,
-        // meaning it's the implicit result of unchecking all other options, so
-        // showing it checked is pointless (and it's not updated if others are
-        // checked). Also, clicking it does not uncheck all other options.
-        if (opt == MidiOption::None) {
-            continue;
-        }
         QStandardItem* pItem =
                 new QStandardItem(MidiUtils::midiOptionToTranslatedString(opt));
         pItem->setData(static_cast<uint16_t>(opt));

--- a/src/controllers/delegates/midioptionsdelegate.h
+++ b/src/controllers/delegates/midioptionsdelegate.h
@@ -17,4 +17,7 @@ class MidiOptionsDelegate : public QStyledItemDelegate {
 
     void setModelData(QWidget* editor, QAbstractItemModel* model,
                       const QModelIndex& index) const;
+
+  private slots:
+    void commitAndCloseEditor(int index);
 };


### PR DESCRIPTION
Multiple options can be set in the learning dialog (not all available options are shown there https://github.com/mixxxdj/mixxx/issues/12336#issuecomment-1825007161) and by editing the mapping XML, of course. Though, editing multi-select in the mapping table was not possible since selecting an option would deselect all others.

This PR allows to set multiple options in the list view of the Options combobox.
Either click / press Enter on a selected option to toggle it and close the list, or press Space on an option to toggle it and keep the list open.
![image](https://github.com/mixxxdj/mixxx/assets/5934199/3662dd9f-bd94-4067-9873-6fb29e2db38f)



It took me a while to figure that the 'Normal' option should not be in options list now that it allows multiple options. Due to how the options flags work here 'Normal' is exclusive, meaning it's the implicit result of unchecking all other options, so showing it checked is pointless (and since it's a dumb combobox it's not unchecked immediately if others are checked). Also, clicking it does not uncheck all other options.

The second commit removes 'Normal' entirely. IMO the mapping table is much clearer without it, individual mappings that have options set are now much easier to spot.

The third commit (experimental) adds an 'Unset all' action. Please test if you think if that is helpful in real life. I didn't manipulate mappings on that level for very long.

____

I'm targeting `main` since this doesn't work with Qt5 as is unfortunately. Checkboxes are not shown and the check state can't be changed. I tried with setting QAction icons in c++ but handling the checkstate was a mess.
An alternative approach with a QMenu is to complex for this small improvement.



Closes #7416 