### PR TITLE
Beats: Fix unsafe overflow checks and debug asserts

### DIFF
--- a/src/track/beats.cpp
+++ b/src/track/beats.cpp
@@ -72,7 +72,7 @@ Beats::ConstIterator Beats::ConstIterator::operator+=(Beats::ConstIterator::diff
         m_it = m_beats->m_markers.cend();
         m_beatOffset = maxBeatOffset;
         updateValue();
-        DEBUG_ASSERT(m_value > origValue);
+        DEBUG_ASSERT(m_value >= origValue);
         return *this;
     }
 
@@ -120,7 +120,7 @@ Beats::ConstIterator Beats::ConstIterator::operator-=(Beats::ConstIterator::diff
         m_it = m_beats->m_markers.cbegin();
         m_beatOffset = minBeatOffset;
         updateValue();
-        DEBUG_ASSERT(m_value < origValue);
+        DEBUG_ASSERT(m_value <= origValue);
         return *this;
     }
 

--- a/src/track/beats.cpp
+++ b/src/track/beats.cpp
@@ -60,23 +60,23 @@ Beats::ConstIterator Beats::ConstIterator::operator+=(Beats::ConstIterator::diff
     }
 
     DEBUG_ASSERT(n > 0);
-    const int beatOffset = m_beatOffset + n;
 #ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
     const auto origValue = m_value;
 #endif
 
-    // Detect integer overflow
-    if (beatOffset < m_beatOffset) {
+    // Detect integer overflow in `m_beatOffset + n`
+    const int maxBeatOffset = std::numeric_limits<Beats::ConstIterator::difference_type>::max();
+    if (m_beatOffset > maxBeatOffset - n) {
         qWarning() << "Beats: Iterator would go out of possible range, capping "
                       "at latest possible position.";
         m_it = m_beats->m_markers.cend();
-        m_beatOffset = std::numeric_limits<Beats::ConstIterator::difference_type>::max();
+        m_beatOffset = maxBeatOffset;
         updateValue();
         DEBUG_ASSERT(m_value > origValue);
         return *this;
     }
 
-    m_beatOffset = beatOffset;
+    m_beatOffset += n;
     while (m_it != m_beats->m_markers.cend() && m_beatOffset >= m_it->beatsTillNextMarker()) {
         m_beatOffset -= m_it->beatsTillNextMarker();
         m_it++;
@@ -108,23 +108,23 @@ Beats::ConstIterator Beats::ConstIterator::operator-=(Beats::ConstIterator::diff
     }
 
     DEBUG_ASSERT(n > 0);
-    const int beatOffset = m_beatOffset - n;
 #ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
     const auto origValue = m_value;
 #endif
 
     // Detect integer overflow
-    if (beatOffset > m_beatOffset) {
+    const int minBeatOffset = std::numeric_limits<Beats::ConstIterator::difference_type>::lowest();
+    if (m_beatOffset < minBeatOffset + n) {
         qWarning() << "Beats: Iterator would go out of possible range, capping "
                       "at earliest possible position.";
         m_it = m_beats->m_markers.cbegin();
-        m_beatOffset = std::numeric_limits<Beats::ConstIterator::difference_type>::lowest();
+        m_beatOffset = minBeatOffset;
         updateValue();
         DEBUG_ASSERT(m_value < origValue);
         return *this;
     }
 
-    m_beatOffset = beatOffset;
+    m_beatOffset -= n;
     while (m_it != m_beats->m_markers.cbegin() && m_beatOffset < 0) {
         m_it--;
         m_beatOffset += m_it->beatsTillNextMarker();


### PR DESCRIPTION
### Fixes #12071 (for me, testing would be appreciated!)

With this patch Mixxx no longer crashes after loading variable BPM tracks with debug assertions enabled.

As noted in https://github.com/mixxxdj/mixxx/issues/12071#issuecomment-1825743901, the overflow checks in `Beats::ConstIterator` were rather unsafe and probably even undefined behavior, therefore this patch replaces them with a safe check.

Additionally, I have updated the `DEBUG_ASSERT`s to accept equality too. This should make sense, since we can't move the iterator further once we're at the limit, as the warning should indicate:

```
warning [CachingReaderWorker 1] Beats: Iterator would go out of possible range, capping at earliest possible position.
```

It should be noted, however, that I still think there's an issue somewhere in the (de)serialization machinery of `BeatMap-1.0`, since this feels like an edge case we shouldn't be hitting, even for variable BPM maps. Some more debugging would probably be helpful, but for now this should hopefully at least fix the assertion.