### PR TITLE
CMakeLists: Relativize `__FILE__` paths by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1586,6 +1586,13 @@ if (INFO_VECTORIZE)
     endif()
 endif()
 
+option(RELATIVE_MACRO_PATHS "Relativize __FILE__ paths" ON)
+if(RELATIVE_MACRO_PATHS)
+  if(NOT MSVC)
+    target_compile_options(mixxx-lib PUBLIC "-fmacro-prefix-map=${CMAKE_SOURCE_DIR}=.")
+  endif()
+endif()
+
 option(WARNINGS_FATAL "Fail if compiler generates a warning" OFF)
 if(WARNINGS_FATAL)
   if(MSVC)


### PR DESCRIPTION
This uses the [`-fmacro-prefix-map`](https://gcc.gnu.org/onlinedocs/gcc/Preprocessor-Options.html#index-fmacro-prefix-map) flag to automatically relativize all `__FILE__` paths to the `CMAKE_SOURCE_DIREC`, i.e. the root of the cloned repository. This means that debug asserts, for example, will now no longer include the build prefix:

```
DEBUG ASSERT: "m_value < origValue" in function Beats::ConstIterator mixxx::Beats::ConstIterator::operator-=(Beats::ConstIterator::difference_type) at src/track/beats.cpp:133
```

instead of

```
DEBUG ASSERT: "m_value < origValue" in function Beats::ConstIterator mixxx::Beats::ConstIterator::operator-=(Beats::ConstIterator::difference_type) at /Users/runner/work/m1xxx/m1xxx/mixxx/src/track/beats.cpp:133
```

Other cases where `__FILE__` is used benefit from this too, e.g. #12344.

### Compiler Support

[GCC](https://gcc.gnu.org/onlinedocs/gcc/Preprocessor-Options.html#index-fmacro-prefix-map) and [Clang](https://reviews.llvm.org/D49466) currently support this flag, MSVC [does not](https://developercommunity.visualstudio.com/t/Map-__FILE__-to-a-relative-path/1393881?q=relative+paths+modules).

Compiler Exporer Demo:

- [x86-64 clang 17.0.1](https://godbolt.org/#g:!((g:!((g:!((h:codeEditor,i:(filename:'1',fontScale:14,fontUsePx:'0',j:1,lang:c%2B%2B,selection:(endColumn:1,endLineNumber:2,positionColumn:1,positionLineNumber:2,selectionStartColumn:1,selectionStartLineNumber:2,startColumn:1,startLineNumber:2),source:'%23include+%3Ciostream%3E%0A%0Avoid+test()+%7B%0A++++std::cout+%3C%3C+__FILE__%3B%0A%7D'),l:'5',n:'0',o:'C%2B%2B+source+%231',t:'0')),k:33.333333333333336,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((h:compiler,i:(compiler:clang1701,filters:(b:'0',binary:'1',binaryObject:'1',commentOnly:'0',debugCalls:'1',demangle:'0',directives:'0',execute:'1',intel:'0',libraryCode:'0',trim:'1'),flagsViewOpen:'1',fontScale:14,fontUsePx:'0',j:1,lang:c%2B%2B,libs:!(),options:'-fmacro-prefix-map%3D/app%3D.',overrides:!(),selection:(endColumn:1,endLineNumber:1,positionColumn:1,positionLineNumber:1,selectionStartColumn:1,selectionStartLineNumber:1,startColumn:1,startLineNumber:1),source:1),l:'5',n:'0',o:'+x86-64+clang+17.0.1+(Editor+%231)',t:'0')),k:41.15884115884115,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((h:output,i:(compilerName:'BPF+clang+17.0.1',editorid:1,fontScale:14,fontUsePx:'0',j:1,wrap:'1'),l:'5',n:'0',o:'Output+of+x86-64+clang+17.0.1+(Compiler+%231)',t:'0')),k:25.507825507825505,l:'4',n:'0',o:'',s:0,t:'0')),l:'2',n:'0',o:'',t:'0')),version:4)
- [x86-64 gcc 13.2](https://godbolt.org/#g:!((g:!((g:!((h:codeEditor,i:(filename:'1',fontScale:14,fontUsePx:'0',j:1,lang:c%2B%2B,selection:(endColumn:1,endLineNumber:2,positionColumn:1,positionLineNumber:2,selectionStartColumn:1,selectionStartLineNumber:2,startColumn:1,startLineNumber:2),source:'%23include+%3Ciostream%3E%0A%0Avoid+test()+%7B%0A++++std::cout+%3C%3C+__FILE__%3B%0A%7D'),l:'5',n:'0',o:'C%2B%2B+source+%231',t:'0')),k:33.333333333333336,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((h:compiler,i:(compiler:g132,filters:(b:'0',binary:'1',binaryObject:'1',commentOnly:'0',debugCalls:'1',demangle:'0',directives:'0',execute:'1',intel:'0',libraryCode:'0',trim:'1'),flagsViewOpen:'1',fontScale:14,fontUsePx:'0',j:1,lang:c%2B%2B,libs:!(),options:'-fmacro-prefix-map%3D/app%3D.',overrides:!(),selection:(endColumn:1,endLineNumber:1,positionColumn:1,positionLineNumber:1,selectionStartColumn:1,selectionStartLineNumber:1,startColumn:1,startLineNumber:1),source:1),l:'5',n:'0',o:'+x86-64+gcc+13.2+(Editor+%231)',t:'0')),k:41.15884115884115,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((h:output,i:(compilerName:'BPF+clang+17.0.1',editorid:1,fontScale:14,fontUsePx:'0',j:1,wrap:'1'),l:'5',n:'0',o:'Output+of+x86-64+gcc+13.2+(Compiler+%231)',t:'0')),k:25.507825507825505,l:'4',n:'0',o:'',s:0,t:'0')),l:'2',n:'0',o:'',t:'0')),version:4)
- [x86-64 msvc 19.latest](https://godbolt.org/#g:!((g:!((g:!((h:codeEditor,i:(filename:'1',fontScale:14,fontUsePx:'0',j:1,lang:c%2B%2B,selection:(endColumn:1,endLineNumber:2,positionColumn:1,positionLineNumber:2,selectionStartColumn:1,selectionStartLineNumber:2,startColumn:1,startLineNumber:2),source:'%23include+%3Ciostream%3E%0A%0Avoid+test()+%7B%0A++++std::cout+%3C%3C+__FILE__%3B%0A%7D'),l:'5',n:'0',o:'C%2B%2B+source+%231',t:'0')),k:33.333333333333336,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((h:compiler,i:(compiler:vcpp_v19_latest_x64,filters:(b:'0',binary:'1',binaryObject:'1',commentOnly:'0',debugCalls:'1',demangle:'0',directives:'0',execute:'1',intel:'0',libraryCode:'0',trim:'1'),flagsViewOpen:'1',fontScale:14,fontUsePx:'0',j:1,lang:c%2B%2B,libs:!(),options:'-fmacro-prefix-map%3D/app%3D.',overrides:!(),selection:(endColumn:1,endLineNumber:1,positionColumn:1,positionLineNumber:1,selectionStartColumn:1,selectionStartLineNumber:1,startColumn:1,startLineNumber:1),source:1),l:'5',n:'0',o:'+x64+msvc+v19.latest+(Editor+%231)',t:'0')),k:41.15884115884115,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((h:output,i:(compilerName:'BPF+clang+17.0.1',editorid:1,fontScale:14,fontUsePx:'0',j:1,wrap:'1'),l:'5',n:'0',o:'Output+of+x64+msvc+v19.latest+(Compiler+%231)',t:'0')),k:25.507825507825505,l:'4',n:'0',o:'',s:0,t:'0')),l:'2',n:'0',o:'',t:'0')),version:4) (not working)