### PR TITLE
CMakeLists: Fix doubly escaped gitinfo paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2193,12 +2193,15 @@ if(GIT_COMMIT_DATE AND NOT GIT_COMMIT_DATE MATCHES "^[0-9]*-[0-9]*-[0-9]*T[0-9]*
 endif()
 
 add_custom_target(mixxx-gitinfo
+  # Note: We don't quote the paths in the command since CMake already inserts
+  # escapes (which, if quoted, lead to paths wrongly containing backslashes).
+  # See https://stackoverflow.com/questions/8925396/why-does-cmake-prefixes-spaces-with-backslashes-when-executing-a-command
   COMMAND ${CMAKE_COMMAND}
-    -DGIT_DESCRIBE="${GIT_DESCRIBE}"
-    -DGIT_COMMIT_DATE="${GIT_COMMIT_DATE}"
-    -DINPUT_FILE="${CMAKE_CURRENT_SOURCE_DIR}/src/gitinfo.h.in"
-    -DOUTPUT_FILE="${CMAKE_CURRENT_BINARY_DIR}/src/gitinfo.h"
-    -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/scripts/gitinfo.cmake"
+    -DGIT_DESCRIBE=${GIT_DESCRIBE}
+    -DGIT_COMMIT_DATE=${GIT_COMMIT_DATE}
+    -DINPUT_FILE=${CMAKE_CURRENT_SOURCE_DIR}/src/gitinfo.h.in
+    -DOUTPUT_FILE=${CMAKE_CURRENT_BINARY_DIR}/src/gitinfo.h
+    -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/scripts/gitinfo.cmake
   COMMENT "Update git version information in gitinfo.h"
   BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/src/gitinfo.h"
   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"


### PR DESCRIPTION
This is a bit of an odd issue with the way CMake deals with paths containing spaces.

When cloning Mixxx into a directory that contains spaces (e.g. `/Users/<user>/playground/mixxx repo`), perhaps surprisingly, CMake will automatically insert backslashes/escapes for spaces when substituted into a `COMMAND` argument. These backslashes turn into literal backslashes when quoted, which then turn into forward slashes due to some kind of path normalization, which finally results in an error that CMake is unable to find the `gitinfo.h.in`:

```
[40/893] Update git version information in gitinfo.h
FAILED: CMakeFiles/mixxx-gitinfo src/gitinfo.h /Users/<user>/playground/mixxx repo/build/CMakeFiles/mixxx-gitinfo /Users/<user>/playground/mixxx repo/build/src/gitinfo.h 
cd "/Users/<user>/playground/mixxx repo" && /Applications/CMake.app/Contents/bin/cmake -DGIT_DESCRIBE="" -DGIT_COMMIT_DATE="" -DINPUT_FILE="/Users/<user>/playground/mixxx\ repo/src/gitinfo.h.in" -DOUTPUT_FILE="/Users/<user>/playground/mixxx\ repo/build/src/gitinfo.h" -P /Users/<user>/playground/mixxx\ repo/cmake/scripts/gitinfo.cmake
Git describe: 3db98cc-modified
Git worktree modified: yes
Git branch: 2.4
Git commit count: unknown
Git commit date: 2023-11-24T20:02:05+01:00
CMake Error: File /Users/<user>/playground/mixxx/ repo/src/gitinfo.h.in does not exist.
CMake Error at cmake/scripts/gitinfo.cmake:3 (configure_file):
  configure_file Problem configuring file
```

Note the extra slash in `/Users/<user>/playground/mixxx/ repo/src/gitinfo.h.in`. The solution is, perhaps counterintuitively, to omit the double quotes and just let CMake deal with the escaping on its own.

For more info on this curiosity, see

- https://stackoverflow.com/questions/8925396/why-does-cmake-prefixes-spaces-with-backslashes-when-executing-a-command