### PR TITLE
ffmpeg and Qt include impovements

### DIFF
--- a/src/qml/qmlapplication.cpp
+++ b/src/qml/qmlapplication.cpp
@@ -1,6 +1,6 @@
 #include "qmlapplication.h"
 
-#include <QtQml/qqmlextensionplugin.h>
+#include <QQmlEngineExtensionPlugin>
 
 #include "control/controlsortfiltermodel.h"
 #include "controllers/controllermanager.h"

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -1,8 +1,13 @@
 #include "sources/soundsourceffmpeg.h"
 
+extern "C" {
+
+#include <libavutil/avutil.h>
 #if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(57, 28, 100) // FFmpeg 5.1
 #include <libavutil/channel_layout.h>
 #endif
+
+} // extern "C"
 
 #include "util/logger.h"
 #include "util/sample.h"

--- a/src/util/desktophelper.cpp
+++ b/src/util/desktophelper.cpp
@@ -8,8 +8,8 @@
 #include <QProcess>
 
 #ifdef Q_OS_LINUX
-#include <QtDBus/QtDBus>
 #include <QFileInfo>
+#include <QtDBus>
 #endif
 
 namespace {

--- a/src/util/performancetimer.h
+++ b/src/util/performancetimer.h
@@ -48,7 +48,7 @@
 // Returns time in nanosecond resolution.
 //
 
-#include <QtCore/qglobal.h>
+#include <QtGlobal>
 
 #include "util/duration.h"
 


### PR DESCRIPTION
Another tidy up PR 
The ffmpeg headers are included elsewhere with  `extern "C"` so we should do it everywhere to not trick the linker. 