### PR TITLE
avoid confusion between visual waveform samples and frames

### DIFF
--- a/src/waveform/renderers/allshader/waveformrendererfiltered.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererfiltered.cpp
@@ -46,17 +46,15 @@ void WaveformRendererFiltered::paintGL() {
     const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
     const int length = static_cast<int>(m_waveformRenderer->getLength() * devicePixelRatio);
 
-    // Not multiplying with devicePixelRatio will also work. In that case, on
-    // High-DPI-Display the lines will be devicePixelRatio pixels wide (which is
-    // also what is used for the beat grid and the markers), or in other words
-    // each block of samples is represented by devicePixelRatio pixels (width).
+    const int visualFramesSize = dataSize / 2;
+    const double firstVisualFrame =
+            m_waveformRenderer->getFirstDisplayedPosition() * visualFramesSize;
+    const double lastVisualFrame =
+            m_waveformRenderer->getLastDisplayedPosition() * visualFramesSize;
 
-    const double firstVisualIndex = m_waveformRenderer->getFirstDisplayedPosition() * dataSize;
-    const double lastVisualIndex = m_waveformRenderer->getLastDisplayedPosition() * dataSize;
-
-    // Represents the # of waveform data points per horizontal pixel.
+    // Represents the # of visual frames per horizontal pixel.
     const double visualIncrementPerPixel =
-            (lastVisualIndex - firstVisualIndex) / static_cast<double>(length);
+            (lastVisualFrame - firstVisualFrame) / static_cast<double>(length);
 
     // Per-band gain from the EQ knobs.
     float allGain{1.0};
@@ -68,8 +66,8 @@ void WaveformRendererFiltered::paintGL() {
 
     const float heightFactor = allGain * halfBreadth / 255.f;
 
-    // Effective visual index of x
-    double xVisualSampleIndex = firstVisualIndex;
+    // Effective visual frame for x
+    double xVisualFrame = firstVisualFrame;
 
     const int numVerticesPerLine = 6; // 2 triangles
 
@@ -92,33 +90,19 @@ void WaveformRendererFiltered::paintGL() {
             static_cast<float>(length),
             halfBreadth + 0.5f * devicePixelRatio);
 
+    const double maxSamplingRange = visualIncrementPerPixel / 2.0;
+
     for (int pos = 0; pos < length; ++pos) {
-        // Our current pixel (x) corresponds to a number of visual samples
-        // (visualSamplerPerPixel) in our waveform object. We take the max of
-        // all the data points on either side of xVisualSampleIndex within a
-        // window of 'maxSamplingRange' visual samples to measure the maximum
-        // data point contained by this pixel.
-        double maxSamplingRange = visualIncrementPerPixel / 2.0;
+        const int visualFrameStart = int(xVisualFrame - maxSamplingRange + 0.5);
+        const int visualFrameStop = int(xVisualFrame + maxSamplingRange + 0.5);
 
-        // Since xVisualSampleIndex is in visual-samples (e.g. R,L,R,L) we want
-        // to check +/- maxSamplingRange frames, not samples. To do this, divide
-        // xVisualSampleIndex by 2. Since frames indices are integers, we round
-        // to the nearest integer by adding 0.5 before casting to int.
-        int visualFrameStart = int(xVisualSampleIndex / 2.0 - maxSamplingRange + 0.5);
-        int visualFrameStop = int(xVisualSampleIndex / 2.0 + maxSamplingRange + 0.5);
-        const int lastVisualFrame = dataSize / 2 - 1;
+        const int visualIndexStart = math_clamp(visualFrameStart * 2, 0, dataSize - 1);
+        const int visualIndexStop =
+                math_clamp(std::max(visualFrameStart + 1, visualFrameStop) * 2,
+                        0,
+                        dataSize - 1);
 
-        // We now know that some subset of [visualFrameStart, visualFrameStop]
-        // lies within the valid range of visual frames. Clamp
-        // visualFrameStart/Stop to within [0, lastVisualFrame].
-        visualFrameStart = math_clamp(visualFrameStart, 0, lastVisualFrame);
-        visualFrameStop = math_clamp(visualFrameStop, 0, lastVisualFrame);
-
-        int visualIndexStart = visualFrameStart * 2;
-        int visualIndexStop = visualFrameStop * 2;
-
-        visualIndexStart = std::max(visualIndexStart, 0);
-        visualIndexStop = std::min(visualIndexStop, dataSize);
+        const float fpos = static_cast<float>(pos);
 
         // 3 bands, 2 channels
         float max[3][2]{};
@@ -136,8 +120,6 @@ void WaveformRendererFiltered::paintGL() {
             }
         }
 
-        const float fpos = static_cast<float>(pos);
-
         for (int bandIndex = 0; bandIndex < 3; bandIndex++) {
             max[bandIndex][0] *= bandGain[bandIndex];
             max[bandIndex][1] *= bandGain[bandIndex];
@@ -150,7 +132,7 @@ void WaveformRendererFiltered::paintGL() {
                     halfBreadth + heightFactor * max[bandIndex][1]);
         }
 
-        xVisualSampleIndex += visualIncrementPerPixel;
+        xVisualFrame += visualIncrementPerPixel;
     }
 
     const QMatrix4x4 matrix = matrixForWidgetGeometry(m_waveformRenderer, true);

--- a/src/waveform/renderers/allshader/waveformrendererfiltered.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererfiltered.cpp
@@ -46,6 +46,7 @@ void WaveformRendererFiltered::paintGL() {
     const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
     const int length = static_cast<int>(m_waveformRenderer->getLength() * devicePixelRatio);
 
+    // See waveformrenderersimple.cpp for a detailed explanation of the frame and index calculation
     const int visualFramesSize = dataSize / 2;
     const double firstVisualFrame =
             m_waveformRenderer->getFirstDisplayedPosition() * visualFramesSize;
@@ -64,7 +65,7 @@ void WaveformRendererFiltered::paintGL() {
     const float breadth = static_cast<float>(m_waveformRenderer->getBreadth()) * devicePixelRatio;
     const float halfBreadth = breadth / 2.0f;
 
-    const float heightFactor = allGain * halfBreadth / 255.f;
+    const float heightFactor = allGain * halfBreadth / m_maxValue;
 
     // Effective visual frame for x
     double xVisualFrame = firstVisualFrame;
@@ -93,13 +94,12 @@ void WaveformRendererFiltered::paintGL() {
     const double maxSamplingRange = visualIncrementPerPixel / 2.0;
 
     for (int pos = 0; pos < length; ++pos) {
-        const int visualFrameStart = int(xVisualFrame - maxSamplingRange + 0.5);
-        const int visualFrameStop = int(xVisualFrame + maxSamplingRange + 0.5);
+        const int visualFrameStart = std::lround(xVisualFrame - maxSamplingRange);
+        const int visualFrameStop = std::lround(xVisualFrame + maxSamplingRange);
 
-        const int visualIndexStart = math_clamp(visualFrameStart * 2, 0, dataSize - 1);
+        const int visualIndexStart = std::max(visualFrameStart * 2, 0);
         const int visualIndexStop =
-                math_clamp(std::max(visualFrameStart + 1, visualFrameStop) * 2,
-                        0,
+                std::min(std::max(visualFrameStop * 2, visualIndexStart + 1),
                         dataSize - 1);
 
         const float fpos = static_cast<float>(pos);

--- a/src/waveform/renderers/allshader/waveformrendererhsv.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererhsv.cpp
@@ -47,6 +47,7 @@ void WaveformRendererHSV::paintGL() {
     const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
     const int length = static_cast<int>(m_waveformRenderer->getLength() * devicePixelRatio);
 
+    // See waveformrenderersimple.cpp for a detailed explanation of the frame and index calculation
     const int visualFramesSize = dataSize / 2;
     const double firstVisualFrame =
             m_waveformRenderer->getFirstDisplayedPosition() * visualFramesSize;
@@ -67,7 +68,7 @@ void WaveformRendererHSV::paintGL() {
     const float breadth = static_cast<float>(m_waveformRenderer->getBreadth()) * devicePixelRatio;
     const float halfBreadth = breadth / 2.0f;
 
-    const float heightFactor = allGain * halfBreadth / 255.f;
+    const float heightFactor = allGain * halfBreadth / m_maxValue;
 
     // Effective visual frame for x
     double xVisualFrame = firstVisualFrame;
@@ -93,13 +94,12 @@ void WaveformRendererHSV::paintGL() {
     const double maxSamplingRange = visualIncrementPerPixel / 2.0;
 
     for (int pos = 0; pos < length; ++pos) {
-        const int visualFrameStart = int(xVisualFrame - maxSamplingRange + 0.5);
-        const int visualFrameStop = int(xVisualFrame + maxSamplingRange + 0.5);
+        const int visualFrameStart = std::lround(xVisualFrame - maxSamplingRange);
+        const int visualFrameStop = std::lround(xVisualFrame + maxSamplingRange);
 
-        const int visualIndexStart = math_clamp(visualFrameStart * 2, 0, dataSize - 1);
+        const int visualIndexStart = std::max(visualFrameStart * 2, 0);
         const int visualIndexStop =
-                math_clamp(std::max(visualFrameStart + 1, visualFrameStop) * 2,
-                        0,
+                std::min(std::max(visualFrameStop * 2, visualIndexStart + 1),
                         dataSize - 1);
 
         const float fpos = static_cast<float>(pos);

--- a/src/waveform/renderers/allshader/waveformrendererlrrgb.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererlrrgb.cpp
@@ -52,6 +52,7 @@ void WaveformRendererLRRGB::paintGL() {
     const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
     const int length = static_cast<int>(m_waveformRenderer->getLength() * devicePixelRatio);
 
+    // See waveformrenderersimple.cpp for a detailed explanation of the frame and index calculation
     const int visualFramesSize = dataSize / 2;
     const double firstVisualFrame =
             m_waveformRenderer->getFirstDisplayedPosition() * visualFramesSize;
@@ -69,7 +70,7 @@ void WaveformRendererLRRGB::paintGL() {
     const float breadth = static_cast<float>(m_waveformRenderer->getBreadth()) * devicePixelRatio;
     const float halfBreadth = breadth / 2.0f;
 
-    const float heightFactorAbs = allGain * halfBreadth / 255.f;
+    const float heightFactorAbs = allGain * halfBreadth / m_maxValue;
     const float heightFactor[2] = {-heightFactorAbs, heightFactorAbs};
 
     const float low_r = static_cast<float>(m_rgbLowColor_r);
@@ -106,13 +107,12 @@ void WaveformRendererLRRGB::paintGL() {
     const double maxSamplingRange = visualIncrementPerPixel / 2.0;
 
     for (int pos = 0; pos < length; ++pos) {
-        const int visualFrameStart = int(xVisualFrame - maxSamplingRange + 0.5);
-        const int visualFrameStop = int(xVisualFrame + maxSamplingRange + 0.5);
+        const int visualFrameStart = std::lround(xVisualFrame - maxSamplingRange);
+        const int visualFrameStop = std::lround(xVisualFrame + maxSamplingRange);
 
-        const int visualIndexStart = math_clamp(visualFrameStart * 2, 0, dataSize - 1);
+        const int visualIndexStart = std::max(visualFrameStart * 2, 0);
         const int visualIndexStop =
-                math_clamp(std::max(visualFrameStart + 1, visualFrameStop) * 2,
-                        0,
+                std::min(std::max(visualFrameStop * 2, visualIndexStart + 1),
                         dataSize - 1);
 
         const float fpos = static_cast<float>(pos);

--- a/src/waveform/renderers/allshader/waveformrendererlrrgb.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererlrrgb.cpp
@@ -103,7 +103,7 @@ void WaveformRendererLRRGB::paintGL() {
             static_cast<float>(m_axesColor_g),
             static_cast<float>(m_axesColor_b));
 
-    double maxSamplingRange = visualIncrementPerPixel / 2.0;
+    const double maxSamplingRange = visualIncrementPerPixel / 2.0;
 
     for (int pos = 0; pos < length; ++pos) {
         const int visualFrameStart = int(xVisualFrame - maxSamplingRange + 0.5);

--- a/src/waveform/renderers/allshader/waveformrendererrgb.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererrgb.cpp
@@ -52,6 +52,7 @@ void WaveformRendererRGB::paintGL() {
     const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
     const int length = static_cast<int>(m_waveformRenderer->getLength() * devicePixelRatio);
 
+    // See waveformrenderersimple.cpp for a detailed explanation of the frame and index calculation
     const int visualFramesSize = dataSize / 2;
     const double firstVisualFrame =
             m_waveformRenderer->getFirstDisplayedPosition() * visualFramesSize;
@@ -69,7 +70,7 @@ void WaveformRendererRGB::paintGL() {
     const float breadth = static_cast<float>(m_waveformRenderer->getBreadth()) * devicePixelRatio;
     const float halfBreadth = breadth / 2.0f;
 
-    const float heightFactor = allGain * halfBreadth / 255.f;
+    const float heightFactor = allGain * halfBreadth / m_maxValue;
 
     const float low_r = static_cast<float>(m_rgbLowColor_r);
     const float mid_r = static_cast<float>(m_rgbMidColor_r);
@@ -105,13 +106,12 @@ void WaveformRendererRGB::paintGL() {
     const double maxSamplingRange = visualIncrementPerPixel / 2.0;
 
     for (int pos = 0; pos < length; ++pos) {
-        const int visualFrameStart = int(xVisualFrame - maxSamplingRange + 0.5);
-        const int visualFrameStop = int(xVisualFrame + maxSamplingRange + 0.5);
+        const int visualFrameStart = std::lround(xVisualFrame - maxSamplingRange);
+        const int visualFrameStop = std::lround(xVisualFrame + maxSamplingRange);
 
-        const int visualIndexStart = math_clamp(visualFrameStart * 2, 0, dataSize - 1);
+        const int visualIndexStart = std::max(visualFrameStart * 2, 0);
         const int visualIndexStop =
-                math_clamp(std::max(visualFrameStart + 1, visualFrameStop) * 2,
-                        0,
+                std::min(std::max(visualFrameStop * 2, visualIndexStart + 1),
                         dataSize - 1);
 
         const float fpos = static_cast<float>(pos);

--- a/src/waveform/renderers/allshader/waveformrendererrgb.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererrgb.cpp
@@ -102,7 +102,7 @@ void WaveformRendererRGB::paintGL() {
             static_cast<float>(m_axesColor_g),
             static_cast<float>(m_axesColor_b));
 
-    double maxSamplingRange = visualIncrementPerPixel / 2.0;
+    const double maxSamplingRange = visualIncrementPerPixel / 2.0;
 
     for (int pos = 0; pos < length; ++pos) {
         const int visualFrameStart = int(xVisualFrame - maxSamplingRange + 0.5);

--- a/src/waveform/renderers/allshader/waveformrenderersignalbase.h
+++ b/src/waveform/renderers/allshader/waveformrenderersignalbase.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <limits>
+
 #include "util/class.h"
 #include "waveform/renderers/allshader/waveformrendererabstract.h"
 #include "waveform/renderers/waveformrenderersignalbase.h"
@@ -13,6 +15,8 @@ class WaveformRendererSignalBase;
 class allshader::WaveformRendererSignalBase : public ::WaveformRendererSignalBase,
                                               public allshader::WaveformRendererAbstract {
   public:
+    static constexpr float m_maxValue{static_cast<float>(std::numeric_limits<uint8_t>::max())};
+
     explicit WaveformRendererSignalBase(WaveformWidgetRenderer* waveformWidget);
 
     void draw(QPainter* painter, QPaintEvent* event) override {

--- a/src/waveform/renderers/allshader/waveformrenderersimple.cpp
+++ b/src/waveform/renderers/allshader/waveformrenderersimple.cpp
@@ -46,17 +46,15 @@ void WaveformRendererSimple::paintGL() {
     const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
     const int length = static_cast<int>(m_waveformRenderer->getLength() * devicePixelRatio);
 
-    // Not multiplying with devicePixelRatio will also work. In that case, on
-    // High-DPI-Display the lines will be devicePixelRatio pixels wide (which is
-    // also what is used for the beat grid and the markers), or in other words
-    // each block of samples is represented by devicePixelRatio pixels (width).
+    const int visualFramesSize = dataSize / 2;
+    const double firstVisualFrame =
+            m_waveformRenderer->getFirstDisplayedPosition() * visualFramesSize;
+    const double lastVisualFrame =
+            m_waveformRenderer->getLastDisplayedPosition() * visualFramesSize;
 
-    const double firstVisualIndex = m_waveformRenderer->getFirstDisplayedPosition() * dataSize;
-    const double lastVisualIndex = m_waveformRenderer->getLastDisplayedPosition() * dataSize;
-
-    // Represents the # of waveform data points per horizontal pixel.
+    // Represents the # of visual frames per horizontal pixel.
     const double visualIncrementPerPixel =
-            (lastVisualIndex - firstVisualIndex) / static_cast<double>(length);
+            (lastVisualFrame - firstVisualFrame) / static_cast<double>(length);
 
     // Per-band gain from the EQ knobs.
     float allGain{1.0};
@@ -68,8 +66,8 @@ void WaveformRendererSimple::paintGL() {
 
     const float heightFactor = allGain * halfBreadth / 255.f;
 
-    // Effective visual index of x
-    double xVisualSampleIndex = firstVisualIndex;
+    // Effective visual frame for x
+    double xVisualFrame = firstVisualFrame;
 
     const int numVerticesPerLine = 6; // 2 triangles
 
@@ -90,40 +88,25 @@ void WaveformRendererSimple::paintGL() {
             static_cast<float>(length),
             halfBreadth + 0.5f * devicePixelRatio);
 
+    const double maxSamplingRange = visualIncrementPerPixel / 2.0;
+
     for (int pos = 0; pos < length; ++pos) {
-        // Our current pixel (x) corresponds to a number of visual samples
-        // (visualSamplerPerPixel) in our waveform object. We take the max of
-        // all the data points on either side of xVisualSampleIndex within a
-        // window of 'maxSamplingRange' visual samples to measure the maximum
-        // data point contained by this pixel.
-        double maxSamplingRange = visualIncrementPerPixel / 2.0;
+        const int visualFrameStart = int(xVisualFrame - maxSamplingRange + 0.5);
+        const int visualFrameStop = int(xVisualFrame + maxSamplingRange + 0.5);
 
-        // Since xVisualSampleIndex is in visual-samples (e.g. R,L,R,L) we want
-        // to check +/- maxSamplingRange frames, not samples. To do this, divide
-        // xVisualSampleIndex by 2. Since frames indices are integers, we round
-        // to the nearest integer by adding 0.5 before casting to int.
-        int visualFrameStart = int(xVisualSampleIndex / 2.0 - maxSamplingRange + 0.5);
-        int visualFrameStop = int(xVisualSampleIndex / 2.0 + maxSamplingRange + 0.5);
-        const int lastVisualFrame = dataSize / 2 - 1;
-
-        // We now know that some subset of [visualFrameStart, visualFrameStop]
-        // lies within the valid range of visual frames. Clamp
-        // visualFrameStart/Stop to within [0, lastVisualFrame].
-        visualFrameStart = math_clamp(visualFrameStart, 0, lastVisualFrame);
-        visualFrameStop = math_clamp(visualFrameStop, 0, lastVisualFrame);
-
-        int visualIndexStart = visualFrameStart * 2;
-        int visualIndexStop = visualFrameStop * 2;
-
-        visualIndexStart = std::max(visualIndexStart, 0);
-        visualIndexStop = std::min(visualIndexStop, dataSize);
+        const int visualIndexStart = math_clamp(visualFrameStart * 2, 0, dataSize - 1);
+        const int visualIndexStop =
+                math_clamp(std::max(visualFrameStart + 1, visualFrameStop) * 2,
+                        0,
+                        dataSize - 1);
 
         // 2 channels
         float max[2]{};
 
-        for (int i = visualIndexStart; i < visualIndexStop; i += 2) {
-            for (int chn = 0; chn < 2; chn++) {
-                const WaveformData& waveformData = data[i + chn];
+        for (int chn = 0; chn < 2; chn++) {
+            // data is interleaved left / right
+            for (int i = visualIndexStart + chn; i < visualIndexStop + chn; i += 2) {
+                const WaveformData& waveformData = data[i];
                 const float filteredAll = static_cast<float>(waveformData.filtered.all);
 
                 max[chn] = math_max(max[chn], filteredAll);
@@ -139,7 +122,7 @@ void WaveformRendererSimple::paintGL() {
                 fpos + 0.5f,
                 halfBreadth + heightFactor * max[1]);
 
-        xVisualSampleIndex += visualIncrementPerPixel;
+        xVisualFrame += visualIncrementPerPixel;
     }
 
     const QMatrix4x4 matrix = matrixForWidgetGeometry(m_waveformRenderer, true);


### PR DESCRIPTION
Avoid confusion between visual waveform samples and frames by better naming and use correct range (was double!)

Continuation of https://github.com/mixxxdj/mixxx/pull/12205 for simple, filtered and hsv allshader waveform renderers