### PR TITLE
Fix 500ms blocking of the whole event loop, when holding mouse down on title bar on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -617,16 +617,8 @@ endif()
 
 set(CLANG_TIDY "" CACHE STRING "CMAKE_CXX_CLANG_TIDY equivalent that only applies to mixxx sources, not bundled dependencies")
 
-if(WIN32)
-  set(NATIVE_SOURCE_FILES src/nativeeventhandlerwin.cpp)
-else()
-  set(NATIVE_SOURCE_FILES "")
-endif()
-
-
 # Mixxx itself
 add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
-  ${NATIVE_SOURCE_FILES}
   src/analyzer/analyzerbeats.cpp
   src/analyzer/analyzerebur128.cpp
   src/analyzer/analyzergain.cpp
@@ -966,6 +958,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/musicbrainz/web/coverartarchiveimagetask.cpp
   src/musicbrainz/web/coverartarchivelinkstask.cpp
   src/musicbrainz/web/musicbrainzrecordingstask.cpp
+  src/nativeeventhandlerwin.cpp
   src/network/jsonwebtask.cpp
   src/network/networktask.cpp
   src/network/webtask.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -617,8 +617,16 @@ endif()
 
 set(CLANG_TIDY "" CACHE STRING "CMAKE_CXX_CLANG_TIDY equivalent that only applies to mixxx sources, not bundled dependencies")
 
+if(WIN32)
+  set(NATIVE_SOURCE_FILES src/nativeeventhandlerwin.cpp)
+else()
+  set(NATIVE_SOURCE_FILES "")
+endif()
+
+
 # Mixxx itself
 add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
+  ${NATIVE_SOURCE_FILES}
   src/analyzer/analyzerbeats.cpp
   src/analyzer/analyzerebur128.cpp
   src/analyzer/analyzergain.cpp
@@ -2738,6 +2746,9 @@ elseif(UNIX AND NOT APPLE)
     Qt${QT_VERSION_MAJOR}::DBus
   )
 elseif(WIN32)
+    target_link_libraries(mixxx-lib PRIVATE
+    Comctl32
+    )
   if(Qt_IS_STATIC)
     target_link_libraries(mixxx-lib PRIVATE
       # Pulled from qt-4.8.2-source\mkspecs\win32-msvc2010\qmake.conf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1672,7 +1672,7 @@ if(WIN32)
     target_compile_definitions(mixxx-lib PUBLIC WIN64)
   endif()
 
-  target_link_libraries(mixxx-lib PRIVATE shell32)
+  target_link_libraries(mixxx-lib PRIVATE comctl32 shell32)
 
   if(MSVC)
     target_link_options(mixxx-lib PUBLIC /entry:mainCRTStartup)
@@ -2739,9 +2739,6 @@ elseif(UNIX AND NOT APPLE)
     Qt${QT_VERSION_MAJOR}::DBus
   )
 elseif(WIN32)
-    target_link_libraries(mixxx-lib PRIVATE
-    Comctl32
-    )
   if(Qt_IS_STATIC)
     target_link_libraries(mixxx-lib PRIVATE
       # Pulled from qt-4.8.2-source\mkspecs\win32-msvc2010\qmake.conf

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,9 @@
 #else
 #include "mixxxmainwindow.h"
 #endif
+#if defined(__WINDOWS__)
+#include "nativeeventhandlerwin.h"
+#endif
 #include "sources/soundsourceproxy.h"
 #include "util/cmdlineargs.h"
 #include "util/console.h"
@@ -54,6 +57,11 @@ int runMixxx(MixxxApplication* pApp, const CmdlineArgs& args) {
         MixxxMainWindow mainWindow(pCoreServices);
         pApp->processEvents();
         pApp->installEventFilter(&mainWindow);
+
+#if defined(__WINDOWS__)
+        WindowsEventHandler winEventHandler(pApp);
+        pApp->installNativeEventFilter(&winEventHandler);
+#endif
 
         QObject::connect(pCoreServices.get(),
                 &mixxx::CoreServices::initializationProgressUpdate,

--- a/src/nativeeventhandlerwin.cpp
+++ b/src/nativeeventhandlerwin.cpp
@@ -1,0 +1,35 @@
+#include "nativeeventhandlerwin.h"
+
+#include <commctrl.h>
+#include <windows.h>
+#include <winuser.h>
+
+#include "moc_nativeeventhandlerwin.cpp"
+
+WindowsEventHandler::WindowsEventHandler(MixxxApplication* pApp)
+        : m_pApp(pApp) {
+}
+
+bool WindowsEventHandler::nativeEventFilter(
+        const QByteArray& eventType, void* message, long* result) {
+    MSG* msg = (MSG*)message;
+    if (msg && msg->message == WM_NCLBUTTONDOWN) {
+        // Trigger the modal loop to prevent 500ms wait in Event Loop
+        // when Windows setting "Show window contents while dragging" is enabled
+        // and the user left-clicks and holds with the mouse on the titlebar of
+        // a window
+        RedrawWindow(
+                msg->hwnd,
+                nullptr,
+                0,
+                RDW_INTERNALPAINT);
+
+        if (msg->wParam == HTCAPTION) {
+            PostMessageW(msg->hwnd, WM_MOUSEMOVE, 0, 0);
+        }
+
+        DefSubclassProc(msg->hwnd, msg->message, msg->wParam, msg->lParam);
+    }
+
+    return false;
+}

--- a/src/nativeeventhandlerwin.cpp
+++ b/src/nativeeventhandlerwin.cpp
@@ -1,5 +1,5 @@
 #include "nativeeventhandlerwin.h"
-
+#if defined(__WINDOWS__)
 #include <commctrl.h>
 #include <windows.h>
 #include <winuser.h>
@@ -33,3 +33,4 @@ bool WindowsEventHandler::nativeEventFilter(
 
     return false;
 }
+#endif

--- a/src/nativeeventhandlerwin.cpp
+++ b/src/nativeeventhandlerwin.cpp
@@ -18,6 +18,9 @@ bool WindowsEventHandler::nativeEventFilter(
         // when Windows setting "Show window contents while dragging" is enabled
         // and the user left-clicks and holds with the mouse on the titlebar of
         // a window
+        // For reference, have a look at:
+        // https://www.gamedev.net/forums/topic/520860-sizemove-loop-and-delay-in-defwindowproc/4382282/
+        // https://github.com/rust-windowing/winit/pull/839
         RedrawWindow(
                 msg->hwnd,
                 nullptr,
@@ -31,6 +34,8 @@ bool WindowsEventHandler::nativeEventFilter(
         DefSubclassProc(msg->hwnd, msg->message, msg->wParam, msg->lParam);
     }
 
+    // Returning false indicates that the event itself has not been finally processed here,
+    // so other recipients will also receive this message subsequently
     return false;
 }
 #endif

--- a/src/nativeeventhandlerwin.h
+++ b/src/nativeeventhandlerwin.h
@@ -1,5 +1,6 @@
 #include <QAbstractNativeEventFilter>
 
+#if defined(__WINDOWS__)
 #include "mixxxapplication.h"
 
 class WindowsEventHandler : public QAbstractNativeEventFilter {
@@ -11,3 +12,4 @@ class WindowsEventHandler : public QAbstractNativeEventFilter {
   private:
     MixxxApplication* m_pApp;
 };
+#endif

--- a/src/nativeeventhandlerwin.h
+++ b/src/nativeeventhandlerwin.h
@@ -1,0 +1,13 @@
+#include <QAbstractNativeEventFilter>
+
+#include "mixxxapplication.h"
+
+class WindowsEventHandler : public QAbstractNativeEventFilter {
+  public:
+    WindowsEventHandler(MixxxApplication* pApp);
+
+    bool nativeEventFilter(const QByteArray& eventType, void* message, long* result);
+
+  private:
+    MixxxApplication* m_pApp;
+};


### PR DESCRIPTION
Closes: #12358

This adapts a solution for this problem from https://github.com/rust-windowing/winit/pull/839 

Before:
https://github.com/mixxxdj/mixxx/assets/64457745/2886ab96-2dfa-4b5b-ad22-35b23a978a02

After:
https://github.com/mixxxdj/mixxx/assets/64457745/956f2a83-866c-46f6-9b62-74f44a36c5ec

