### PR TITLE
Native Instruments Traktor Kontrol Z1: Add new HID mapping

### DIFF
--- a/res/controllers/Traktor Kontrol Z1.hid.xml
+++ b/res/controllers/Traktor Kontrol Z1.hid.xml
@@ -4,6 +4,7 @@
         <name>Native Instruments Traktor Kontrol Z1</name>
         <author>djantti</author>
         <description>HID mapping for Native Instruments Traktor Kontrol Z1</description>
+        <forums>https://mixxx.discourse.group/t/new-mapping-for-native-instruments-traktor-kontrol-z1/28436</forums>
         <manual>native_instruments_traktor_kontrol_z1</manual>
         <devices>
             <product protocol="hid" vendor_id="0x17cc" product_id="0x1210" />

--- a/res/controllers/Traktor Kontrol Z1.hid.xml
+++ b/res/controllers/Traktor Kontrol Z1.hid.xml
@@ -13,7 +13,7 @@
     <controller id="Traktor">
         <scriptfiles>
             <file filename="common-hid-packet-parser.js" functionprefix="" />
-            <file filename="Traktor-Kontrol-Z1-scripts.js" functionprefix="KontrolZ1" />
+            <file filename="Traktor-Kontrol-Z1-scripts.js" functionprefix="TraktorZ1" />
         </scriptfiles>
     </controller>
 </MixxxControllerPreset>

--- a/res/controllers/Traktor Kontrol Z1.hid.xml
+++ b/res/controllers/Traktor Kontrol Z1.hid.xml
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='utf-8'?>
+<MixxxControllerPreset mixxxVersion="2.4.0" schemaVersion="1">
+    <info>
+        <name>Native Instruments Traktor Kontrol Z1</name>
+        <author>djantti</author>
+        <description>HID mapping for Native Instruments Traktor Kontrol Z1</description>
+        <manual>native_instruments_traktor_kontrol_z1</manual>
+        <devices>
+            <product protocol="hid" vendor_id="0x17cc" product_id="0x1210" />
+        </devices>
+    </info>
+    <controller id="Traktor">
+        <scriptfiles>
+            <file filename="common-hid-packet-parser.js" functionprefix="" />
+            <file filename="Traktor-Kontrol-Z1-scripts.js" functionprefix="KontrolZ1" />
+        </scriptfiles>
+    </controller>
+</MixxxControllerPreset>

--- a/res/controllers/Traktor-Kontrol-Z1-scripts.js
+++ b/res/controllers/Traktor-Kontrol-Z1-scripts.js
@@ -6,7 +6,7 @@
 //
 // Extra functionality:
 // Mode + FX -> Playback start / stop
-// Mode + Headphone -> Stop and rewind track
+// Mode + Headphone -> Go to cue and stop
 //
 
 var KontrolZ1 = new function() {
@@ -156,9 +156,9 @@ KontrolZ1.headphoneHandler = function(field) {
     if (field.value === 0) {
         return;
     }
-    // Seek to start and stop when modifier is active
+    // Go to cue and stop when modifier is active
     if (KontrolZ1.modePressed) {
-        engine.setValue(field.group, "start_stop", field.value);
+        engine.setValue(field.group, "cue_gotoandstop", field.value);
     } else {
         script.toggleControl(field.group, "pfl");
     }

--- a/res/controllers/Traktor-Kontrol-Z1-scripts.js
+++ b/res/controllers/Traktor-Kontrol-Z1-scripts.js
@@ -26,46 +26,46 @@ class TraktorZ1Class {
     }
 
     registerInputPackets() {
-        const message = new HIDPacket("message", 0x01, this.messageCallback.bind(this));
+        const InputReport0x01 = new HIDPacket("InputReport0x01", 0x01, this.inputReportCallback.bind(this));
 
         // Mode button
-        this.registerInputButton(message, "[ControlX]", "!mode", 0x1D, 0x02, this.modeHandler.bind(this));
+        this.registerInputButton(InputReport0x01, "[ControlX]", "!mode", 0x1D, 0x02, this.modeHandler.bind(this));
 
         // Headphone buttons
-        this.registerInputButton(message, "[Channel1]", "!pfl", 0x1D, 0x10, this.headphoneHandler.bind(this));
-        this.registerInputButton(message, "[Channel2]", "!pfl", 0x1D, 0x01, this.headphoneHandler.bind(this));
+        this.registerInputButton(InputReport0x01, "[Channel1]", "!pfl", 0x1D, 0x10, this.headphoneHandler.bind(this));
+        this.registerInputButton(InputReport0x01, "[Channel2]", "!pfl", 0x1D, 0x01, this.headphoneHandler.bind(this));
 
         // FX buttons
-        this.registerInputButton(message, "[Channel1]", "!fx", 0x1D, 0x04, this.fxHandler.bind(this));
-        this.registerInputButton(message, "[Channel2]", "!fx", 0x1D, 0x08, this.fxHandler.bind(this));
+        this.registerInputButton(InputReport0x01, "[Channel1]", "!fx", 0x1D, 0x04, this.fxHandler.bind(this));
+        this.registerInputButton(InputReport0x01, "[Channel2]", "!fx", 0x1D, 0x08, this.fxHandler.bind(this));
 
         // EQ knobs
-        this.registerInputScaler(message, "[EqualizerRack1_[Channel1]_Effect1]", "parameter3", 0x03, 0xFFFF, this.parameterHandler.bind(this));
-        this.registerInputScaler(message, "[EqualizerRack1_[Channel1]_Effect1]", "parameter2", 0x05, 0xFFFF, this.parameterHandler.bind(this));
-        this.registerInputScaler(message, "[EqualizerRack1_[Channel1]_Effect1]", "parameter1", 0x07, 0xFFFF, this.parameterHandler.bind(this));
-        this.registerInputScaler(message, "[EqualizerRack1_[Channel2]_Effect1]", "parameter3", 0x0D, 0xFFFF, this.parameterHandler.bind(this));
-        this.registerInputScaler(message, "[EqualizerRack1_[Channel2]_Effect1]", "parameter2", 0x0F, 0xFFFF, this.parameterHandler.bind(this));
-        this.registerInputScaler(message, "[EqualizerRack1_[Channel2]_Effect1]", "parameter1", 0x11, 0xFFFF, this.parameterHandler.bind(this));
+        this.registerInputScaler(InputReport0x01, "[EqualizerRack1_[Channel1]_Effect1]", "parameter3", 0x03, 0xFFFF, this.parameterHandler.bind(this));
+        this.registerInputScaler(InputReport0x01, "[EqualizerRack1_[Channel1]_Effect1]", "parameter2", 0x05, 0xFFFF, this.parameterHandler.bind(this));
+        this.registerInputScaler(InputReport0x01, "[EqualizerRack1_[Channel1]_Effect1]", "parameter1", 0x07, 0xFFFF, this.parameterHandler.bind(this));
+        this.registerInputScaler(InputReport0x01, "[EqualizerRack1_[Channel2]_Effect1]", "parameter3", 0x0D, 0xFFFF, this.parameterHandler.bind(this));
+        this.registerInputScaler(InputReport0x01, "[EqualizerRack1_[Channel2]_Effect1]", "parameter2", 0x0F, 0xFFFF, this.parameterHandler.bind(this));
+        this.registerInputScaler(InputReport0x01, "[EqualizerRack1_[Channel2]_Effect1]", "parameter1", 0x11, 0xFFFF, this.parameterHandler.bind(this));
 
         // FX knobs
-        this.registerInputScaler(message, "[QuickEffectRack1_[Channel1]]", "super1", 0x09, 0xFFFF, this.parameterHandler.bind(this));
-        this.registerInputScaler(message, "[QuickEffectRack1_[Channel2]]", "super1", 0x13, 0xFFFF, this.parameterHandler.bind(this));
+        this.registerInputScaler(InputReport0x01, "[QuickEffectRack1_[Channel1]]", "super1", 0x09, 0xFFFF, this.parameterHandler.bind(this));
+        this.registerInputScaler(InputReport0x01, "[QuickEffectRack1_[Channel2]]", "super1", 0x13, 0xFFFF, this.parameterHandler.bind(this));
 
         // Gain knobs
-        this.registerInputScaler(message, "[Channel1]", "pregain", 0x01, 0xFFFF, this.parameterHandler.bind(this));
-        this.registerInputScaler(message, "[Channel2]", "pregain", 0x0B, 0xFFFF, this.parameterHandler.bind(this));
+        this.registerInputScaler(InputReport0x01, "[Channel1]", "pregain", 0x01, 0xFFFF, this.parameterHandler.bind(this));
+        this.registerInputScaler(InputReport0x01, "[Channel2]", "pregain", 0x0B, 0xFFFF, this.parameterHandler.bind(this));
 
         // Headphone mix
-        this.registerInputScaler(message, "[Master]", "headMix", 0x15, 0xFFFF, this.parameterHandler.bind(this));
+        this.registerInputScaler(InputReport0x01, "[Master]", "headMix", 0x15, 0xFFFF, this.parameterHandler.bind(this));
 
         // Volume faders
-        this.registerInputScaler(message, "[Channel1]", "volume", 0x17, 0xFFFF, this.parameterHandler.bind(this));
-        this.registerInputScaler(message, "[Channel2]", "volume", 0x19, 0xFFFF, this.parameterHandler.bind(this));
+        this.registerInputScaler(InputReport0x01, "[Channel1]", "volume", 0x17, 0xFFFF, this.parameterHandler.bind(this));
+        this.registerInputScaler(InputReport0x01, "[Channel2]", "volume", 0x19, 0xFFFF, this.parameterHandler.bind(this));
 
         // Crossfader
-        this.registerInputScaler(message, "[Master]", "crossfader", 0x1B, 0xFFFF, this.parameterHandler.bind(this));
+        this.registerInputScaler(InputReport0x01, "[Master]", "crossfader", 0x1B, 0xFFFF, this.parameterHandler.bind(this));
 
-        this.controller.registerInputPacket(message);
+        this.controller.registerInputPacket(InputReport0x01);
 
         // Soft takeover for all knobs and faders
         engine.softTakeover("[EqualizerRack1_[Channel1]_Effect1]", "parameter3", true);
@@ -90,47 +90,47 @@ class TraktorZ1Class {
         engine.softTakeover("[Master]", "crossfader", true);
     }
 
-    registerInputButton(message, group, name, offset, bitmask, callback) {
-        message.addControl(group, name, offset, "B", bitmask);
-        message.setCallback(group, name, callback);
+    registerInputButton(inputReport, group, name, offset, bitmask, callback) {
+        inputReport.addControl(group, name, offset, "B", bitmask);
+        inputReport.setCallback(group, name, callback);
     }
 
-    registerInputScaler(message, group, name, offset, bitmask, callback) {
-        message.addControl(group, name, offset, "H", bitmask);
-        message.setCallback(group, name, callback);
+    registerInputScaler(inputReport, group, name, offset, bitmask, callback) {
+        inputReport.addControl(group, name, offset, "H", bitmask);
+        inputReport.setCallback(group, name, callback);
     }
 
     registerOutputPackets() {
-        const output = new HIDPacket("output", 0x80);
+        const OutputReport0x80 = new HIDPacket("OutputReport0x80", 0x80);
 
-        output.addOutput("[ControlX]", "mode", 0x13, "B");
+        OutputReport0x80.addOutput("[ControlX]", "mode", 0x13, "B");
 
-        output.addOutput("[Channel1]", "pfl", 0x0F, "B");
-        output.addOutput("[Channel2]", "pfl", 0x10, "B");
+        OutputReport0x80.addOutput("[Channel1]", "pfl", 0x0F, "B");
+        OutputReport0x80.addOutput("[Channel2]", "pfl", 0x10, "B");
 
-        output.addOutput("[Channel1]", "play_indicator", 0x11, "B");
-        output.addOutput("[Channel2]", "play_indicator", 0x14, "B");
+        OutputReport0x80.addOutput("[Channel1]", "play_indicator", 0x11, "B");
+        OutputReport0x80.addOutput("[Channel2]", "play_indicator", 0x14, "B");
 
-        output.addOutput("[QuickEffectRack1_[Channel1]]", "enabled", 0x12, "B");
-        output.addOutput("[QuickEffectRack1_[Channel2]]", "enabled", 0x15, "B");
+        OutputReport0x80.addOutput("[QuickEffectRack1_[Channel1]]", "enabled", 0x12, "B");
+        OutputReport0x80.addOutput("[QuickEffectRack1_[Channel2]]", "enabled", 0x15, "B");
 
-        output.addOutput("[Channel1]", "vu-30", 0x01, "B");
-        output.addOutput("[Channel1]", "vu-15", 0x02, "B");
-        output.addOutput("[Channel1]", "vu-6", 0x03, "B");
-        output.addOutput("[Channel1]", "vu-3", 0x04, "B");
-        output.addOutput("[Channel1]", "vu0", 0x05, "B");
-        output.addOutput("[Channel1]", "vu3", 0x06, "B");
-        output.addOutput("[Channel1]", "vu6", 0x07, "B");
+        OutputReport0x80.addOutput("[Channel1]", "vu-30", 0x01, "B");
+        OutputReport0x80.addOutput("[Channel1]", "vu-15", 0x02, "B");
+        OutputReport0x80.addOutput("[Channel1]", "vu-6", 0x03, "B");
+        OutputReport0x80.addOutput("[Channel1]", "vu-3", 0x04, "B");
+        OutputReport0x80.addOutput("[Channel1]", "vu0", 0x05, "B");
+        OutputReport0x80.addOutput("[Channel1]", "vu3", 0x06, "B");
+        OutputReport0x80.addOutput("[Channel1]", "vu6", 0x07, "B");
 
-        output.addOutput("[Channel2]", "vu-30", 0x08, "B");
-        output.addOutput("[Channel2]", "vu-15", 0x09, "B");
-        output.addOutput("[Channel2]", "vu-6", 0x0A, "B");
-        output.addOutput("[Channel2]", "vu-3", 0x0B, "B");
-        output.addOutput("[Channel2]", "vu0", 0x0C, "B");
-        output.addOutput("[Channel2]", "vu3", 0x0D, "B");
-        output.addOutput("[Channel2]", "vu6", 0x0E, "B");
+        OutputReport0x80.addOutput("[Channel2]", "vu-30", 0x08, "B");
+        OutputReport0x80.addOutput("[Channel2]", "vu-15", 0x09, "B");
+        OutputReport0x80.addOutput("[Channel2]", "vu-6", 0x0A, "B");
+        OutputReport0x80.addOutput("[Channel2]", "vu-3", 0x0B, "B");
+        OutputReport0x80.addOutput("[Channel2]", "vu0", 0x0C, "B");
+        OutputReport0x80.addOutput("[Channel2]", "vu3", 0x0D, "B");
+        OutputReport0x80.addOutput("[Channel2]", "vu6", 0x0E, "B");
 
-        this.controller.registerOutputPacket(output);
+        this.controller.registerOutputPacket(OutputReport0x80);
 
         engine.makeConnection("[QuickEffectRack1_[Channel1]]", "enabled", this.outputHandler.bind(this));
         engine.makeConnection("[QuickEffectRack1_[Channel2]]", "enabled", this.outputHandler.bind(this));
@@ -170,8 +170,8 @@ class TraktorZ1Class {
         // Control playback when modifier is active
         if (this.modePressed) {
             // Match play indicator (red led) brightness to fx indicator (blue led)
-            const current = engine.getValue("[QuickEffectRack1_" + field.group + "]", "enabled") ? 0x7F : 0x0A;
-            this.controller.setOutput(field.group, "play_indicator", current, true);
+            const ledBrightness = engine.getValue("[QuickEffectRack1_" + field.group + "]", "enabled") ? 0x7F : 0x0A;
+            this.controller.setOutput(field.group, "play_indicator", ledBrightness, true);
             script.toggleControl(field.group, "play");
         } else {
             script.toggleControl("[QuickEffectRack1_" + field.group + "]", "enabled");
@@ -210,7 +210,7 @@ class TraktorZ1Class {
     lightDeck(switchOff) {
         let softLight = 0x0A;
         let fullLight = 0x7F;
-        let current;
+        let ledBrightness;
 
         if (switchOff) {
             softLight = 0x00;
@@ -219,18 +219,18 @@ class TraktorZ1Class {
 
         this.controller.setOutput("[ControlX]", "mode", softLight, true);
 
-        current = engine.getValue("[QuickEffectRack1_[Channel1]]", "enabled") ? fullLight : softLight;
-        this.controller.setOutput("[QuickEffectRack1_[Channel1]]", "enabled", current, true);
-        current = engine.getValue("[QuickEffectRack1_[Channel2]]", "enabled") ? fullLight : softLight;
-        this.controller.setOutput("[QuickEffectRack1_[Channel2]]", "enabled", current, true);
+        ledBrightness = engine.getValue("[QuickEffectRack1_[Channel1]]", "enabled") ? fullLight : softLight;
+        this.controller.setOutput("[QuickEffectRack1_[Channel1]]", "enabled", ledBrightness, true);
+        ledBrightness = engine.getValue("[QuickEffectRack1_[Channel2]]", "enabled") ? fullLight : softLight;
+        this.controller.setOutput("[QuickEffectRack1_[Channel2]]", "enabled", ledBrightness, true);
 
-        current = engine.getValue("[Channel1]", "pfl") ? fullLight : softLight;
-        this.controller.setOutput("[Channel1]", "pfl", current, true);
-        current = engine.getValue("[Channel2]", "pfl") ? fullLight : softLight;
-        this.controller.setOutput("[Channel2]", "pfl", current, true);
+        ledBrightness = engine.getValue("[Channel1]", "pfl") ? fullLight : softLight;
+        this.controller.setOutput("[Channel1]", "pfl", ledBrightness, true);
+        ledBrightness = engine.getValue("[Channel2]", "pfl") ? fullLight : softLight;
+        this.controller.setOutput("[Channel2]", "pfl", ledBrightness, true);
     }
 
-    messageCallback(packet, data) {
+    inputReportCallback(packet, data) {
         for (const name in data) {
             if (Object.hasOwnProperty.call(data, name)) {
                 this.controller.processButton(data[name]);

--- a/res/controllers/Traktor-Kontrol-Z1-scripts.js
+++ b/res/controllers/Traktor-Kontrol-Z1-scripts.js
@@ -21,7 +21,7 @@ KontrolZ1.init = function(_id) {
     KontrolZ1.id = _id;
     KontrolZ1.registerInputPackets();
     KontrolZ1.registerOutputPackets();
-    print(KontrolZ1.id + " initialized");
+    console.log(KontrolZ1.id + " initialized");
 };
 
 KontrolZ1.registerInputPackets = function() {
@@ -240,7 +240,7 @@ KontrolZ1.messageCallback = function(packet, data) {
 KontrolZ1.shutdown = function() {
     // Deactivate all LEDs
     KontrolZ1.lightDeck(true);
-    print(KontrolZ1.id + " shut down");
+    console.log(KontrolZ1.id + " shut down");
 };
 
 KontrolZ1.incomingData = function(data, length) {

--- a/res/controllers/Traktor-Kontrol-Z1-scripts.js
+++ b/res/controllers/Traktor-Kontrol-Z1-scripts.js
@@ -191,7 +191,6 @@ class TraktorZ1Class {
         }
     }
 
-
     parameterHandler(field) {
         engine.setParameter(field.group, field.name, field.value / 4095);
     }

--- a/res/controllers/Traktor-Kontrol-Z1-scripts.js
+++ b/res/controllers/Traktor-Kontrol-Z1-scripts.js
@@ -173,7 +173,7 @@ KontrolZ1.fxHandler = function(field) {
     // Control playback when modifier is active
     if (KontrolZ1.modePressed) {
         // Match play indicator (red led) brightness to fx indicator (blue led)
-        current = (engine.getValue("[QuickEffectRack1_" + field.group + "]", "enabled")) ? 0x7F : 0xA;
+        current = engine.getValue("[QuickEffectRack1_" + field.group + "]", "enabled") ? 0x7F : 0xA;
         KontrolZ1.controller.setOutput(field.group, "play_indicator", current, true);
         script.toggleControl(field.group, "play");
     } else {
@@ -185,7 +185,7 @@ KontrolZ1.vuMeterHandler = function(value, group, _key) {
     const vuKeys = Object.keys(KontrolZ1.vuMeterThresholds);
     for (let i = 0; i < vuKeys.length; ++i) {
         // Avoid spamming HID by only sending last LED update
-        const last = (i === (vuKeys.length - 1));
+        const last = i === (vuKeys.length - 1);
         if (KontrolZ1.vuMeterThresholds[vuKeys[i]] > value) {
             KontrolZ1.controller.setOutput(group, vuKeys[i], 0x00, last);
         } else {
@@ -220,14 +220,14 @@ KontrolZ1.lightDeck = function(switchOff) {
 
     KontrolZ1.controller.setOutput("[Controls]", "mode", softLight, true);
 
-    current = (engine.getValue("[QuickEffectRack1_[Channel1]]", "enabled")) ? fullLight : softLight;
+    current = engine.getValue("[QuickEffectRack1_[Channel1]]", "enabled") ? fullLight : softLight;
     KontrolZ1.controller.setOutput("[QuickEffectRack1_[Channel1]]", "enabled", current, true);
-    current = (engine.getValue("[QuickEffectRack1_[Channel2]]", "enabled")) ? fullLight : softLight;
+    current = engine.getValue("[QuickEffectRack1_[Channel2]]", "enabled") ? fullLight : softLight;
     KontrolZ1.controller.setOutput("[QuickEffectRack1_[Channel2]]", "enabled", current, true);
 
-    current = (engine.getValue("[Channel1]", "pfl")) ? fullLight : softLight;
+    current = engine.getValue("[Channel1]", "pfl") ? fullLight : softLight;
     KontrolZ1.controller.setOutput("[Channel1]", "pfl", current, true);
-    current = (engine.getValue("[Channel2]", "pfl")) ? fullLight : softLight;
+    current = engine.getValue("[Channel2]", "pfl") ? fullLight : softLight;
     KontrolZ1.controller.setOutput("[Channel2]", "pfl", current, true);
 }
 

--- a/res/controllers/Traktor-Kontrol-Z1-scripts.js
+++ b/res/controllers/Traktor-Kontrol-Z1-scripts.js
@@ -28,7 +28,7 @@ KontrolZ1.registerInputPackets = function() {
     const message = new HIDPacket("message", 0x1, this.messageCallback);
 
     // Mode button
-    this.registerInputButton(message, "[Controls]", "!mode", 0x1D, 0x2, this.modeHandler);
+    this.registerInputButton(message, "[ControlX]", "!mode", 0x1D, 0x2, this.modeHandler);
 
     // Headphone buttons
     this.registerInputButton(message, "[Channel1]", "!pfl", 0x1D, 0x10, this.headphoneHandler);
@@ -102,7 +102,7 @@ KontrolZ1.registerInputScaler = function(message, group, name, offset, bitmask, 
 KontrolZ1.registerOutputPackets = function() {
     const output = new HIDPacket("output", 0x80);
 
-    output.addOutput("[Controls]", "mode", 0x13, "B");
+    output.addOutput("[ControlX]", "mode", 0x13, "B");
 
     output.addOutput("[Channel1]", "pfl", 0xF, "B");
     output.addOutput("[Channel2]", "pfl", 0x10, "B");
@@ -214,7 +214,7 @@ KontrolZ1.lightDeck = function(switchOff) {
         fullLight = 0x00;
     }
 
-    KontrolZ1.controller.setOutput("[Controls]", "mode", softLight, true);
+    KontrolZ1.controller.setOutput("[ControlX]", "mode", softLight, true);
 
     current = engine.getValue("[QuickEffectRack1_[Channel1]]", "enabled") ? fullLight : softLight;
     KontrolZ1.controller.setOutput("[QuickEffectRack1_[Channel1]]", "enabled", current, true);

--- a/res/controllers/Traktor-Kontrol-Z1-scripts.js
+++ b/res/controllers/Traktor-Kontrol-Z1-scripts.js
@@ -169,7 +169,7 @@ KontrolZ1.fxHandler = function(field) {
     // Control playback when modifier is active
     if (KontrolZ1.modePressed) {
         // Match play indicator (red led) brightness to fx indicator (blue led)
-        current = engine.getValue("[QuickEffectRack1_" + field.group + "]", "enabled") ? 0x7F : 0xA;
+        const current = engine.getValue("[QuickEffectRack1_" + field.group + "]", "enabled") ? 0x7F : 0xA;
         KontrolZ1.controller.setOutput(field.group, "play_indicator", current, true);
         script.toggleControl(field.group, "play");
     } else {
@@ -195,6 +195,7 @@ KontrolZ1.parameterHandler = function(field) {
 };
 
 KontrolZ1.outputHandler = function(value, group, key) {
+    let ledValue;
     if (value === 0 || value === false) {
         // Off value (dimmed)
         ledValue = 0xA;
@@ -208,6 +209,7 @@ KontrolZ1.outputHandler = function(value, group, key) {
 KontrolZ1.lightDeck = function(switchOff) {
     let softLight = 0xA;
     let fullLight = 0x7F;
+    let current;
 
     if (switchOff) {
         softLight = 0x00;

--- a/res/controllers/Traktor-Kontrol-Z1-scripts.js
+++ b/res/controllers/Traktor-Kontrol-Z1-scripts.js
@@ -5,244 +5,249 @@
 // Author: djantti
 //
 
-var KontrolZ1 = new function() {
-    this.controller = new HIDController();
+class TraktorZ1Class {
+    constructor() {
+        this.controller = new HIDController();
 
-    // Modifier state
-    this.modePressed = false;
+        // Modifier state
+        this.modePressed = false;
 
-    // VuMeter
-    this.vuLeftConnection = {};
-    this.vuRightConnection = {};
-    this.vuMeterThresholds = {"vu-30": (1 / 7), "vu-15": (2 / 7), "vu-6": (3 / 7), "vu-3": (4 / 7), "vu0": (5 / 7), "vu3": (6 / 7), "vu6": (7 / 7)};
-};
-
-KontrolZ1.init = function(_id) {
-    KontrolZ1.id = _id;
-    KontrolZ1.registerInputPackets();
-    KontrolZ1.registerOutputPackets();
-    console.log(KontrolZ1.id + " initialized");
-};
-
-KontrolZ1.registerInputPackets = function() {
-    const message = new HIDPacket("message", 0x1, this.messageCallback);
-
-    // Mode button
-    this.registerInputButton(message, "[ControlX]", "!mode", 0x1D, 0x2, this.modeHandler);
-
-    // Headphone buttons
-    this.registerInputButton(message, "[Channel1]", "!pfl", 0x1D, 0x10, this.headphoneHandler);
-    this.registerInputButton(message, "[Channel2]", "!pfl", 0x1D, 0x1, this.headphoneHandler);
-
-    // FX buttons
-    this.registerInputButton(message, "[Channel1]", "!fx", 0x1D, 0x4, this.fxHandler);
-    this.registerInputButton(message, "[Channel2]", "!fx", 0x1D, 0x8, this.fxHandler);
-
-    // EQ knobs
-    this.registerInputScaler(message, "[EqualizerRack1_[Channel1]_Effect1]", "parameter3", 0x3, 0xFFFF, this.parameterHandler);
-    this.registerInputScaler(message, "[EqualizerRack1_[Channel1]_Effect1]", "parameter2", 0x5, 0xFFFF, this.parameterHandler);
-    this.registerInputScaler(message, "[EqualizerRack1_[Channel1]_Effect1]", "parameter1", 0x7, 0xFFFF, this.parameterHandler);
-    this.registerInputScaler(message, "[EqualizerRack1_[Channel2]_Effect1]", "parameter3", 0xD, 0xFFFF, this.parameterHandler);
-    this.registerInputScaler(message, "[EqualizerRack1_[Channel2]_Effect1]", "parameter2", 0xF, 0xFFFF, this.parameterHandler);
-    this.registerInputScaler(message, "[EqualizerRack1_[Channel2]_Effect1]", "parameter1", 0x11, 0xFFFF, this.parameterHandler);
-
-    // FX knobs
-    this.registerInputScaler(message, "[QuickEffectRack1_[Channel1]]", "super1", 0x9, 0xFFFF, this.parameterHandler);
-    this.registerInputScaler(message, "[QuickEffectRack1_[Channel2]]", "super1", 0x13, 0xFFFF, this.parameterHandler);
-
-    // Gain knobs
-    this.registerInputScaler(message, "[Channel1]", "pregain", 0x1, 0xFFFF, this.parameterHandler);
-    this.registerInputScaler(message, "[Channel2]", "pregain", 0xB, 0xFFFF, this.parameterHandler);
-
-    // Headphone mix
-    this.registerInputScaler(message, "[Master]", "headMix", 0x15, 0xFFFF, this.parameterHandler);
-
-    // Volume faders
-    this.registerInputScaler(message, "[Channel1]", "volume", 0x17, 0xFFFF, this.parameterHandler);
-    this.registerInputScaler(message, "[Channel2]", "volume", 0x19, 0xFFFF, this.parameterHandler);
-
-    // Crossfader
-    this.registerInputScaler(message, "[Master]", "crossfader", 0x1B, 0xFFFF, this.parameterHandler);
-
-    this.controller.registerInputPacket(message);
-
-    // Soft takeover for all knobs and faders
-    engine.softTakeover("[EqualizerRack1_[Channel1]_Effect1]", "parameter3", true);
-    engine.softTakeover("[EqualizerRack1_[Channel1]_Effect1]", "parameter2", true);
-    engine.softTakeover("[EqualizerRack1_[Channel1]_Effect1]", "parameter1", true);
-
-    engine.softTakeover("[EqualizerRack1_[Channel2]_Effect1]", "parameter3", true);
-    engine.softTakeover("[EqualizerRack1_[Channel2]_Effect1]", "parameter2", true);
-    engine.softTakeover("[EqualizerRack1_[Channel2]_Effect1]", "parameter1", true);
-
-    engine.softTakeover("[QuickEffectRack1_[Channel1]]", "super1", true);
-    engine.softTakeover("[QuickEffectRack1_[Channel2]]", "super1", true);
-
-    engine.softTakeover("[Channel1]", "pregain", true);
-    engine.softTakeover("[Channel2]", "pregain", true);
-
-    engine.softTakeover("[Master]", "headMix", true);
-
-    engine.softTakeover("[Channel1]", "volume", true);
-    engine.softTakeover("[Channel2]", "volume", true);
-
-    engine.softTakeover("[Master]", "crossfader", true);
-};
-
-KontrolZ1.registerInputButton = function(message, group, name, offset, bitmask, callback) {
-    message.addControl(group, name, offset, "B", bitmask);
-    message.setCallback(group, name, callback);
-};
-
-KontrolZ1.registerInputScaler = function(message, group, name, offset, bitmask, callback) {
-    message.addControl(group, name, offset, "H", bitmask);
-    message.setCallback(group, name, callback);
-};
-
-KontrolZ1.registerOutputPackets = function() {
-    const output = new HIDPacket("output", 0x80);
-
-    output.addOutput("[ControlX]", "mode", 0x13, "B");
-
-    output.addOutput("[Channel1]", "pfl", 0xF, "B");
-    output.addOutput("[Channel2]", "pfl", 0x10, "B");
-
-    output.addOutput("[Channel1]", "play_indicator", 0x11, "B");
-    output.addOutput("[Channel2]", "play_indicator", 0x14, "B");
-
-    output.addOutput("[QuickEffectRack1_[Channel1]]", "enabled", 0x12, "B");
-    output.addOutput("[QuickEffectRack1_[Channel2]]", "enabled", 0x15, "B");
-
-    output.addOutput("[Channel1]", "vu-30", 0x1, "B");
-    output.addOutput("[Channel1]", "vu-15", 0x2, "B");
-    output.addOutput("[Channel1]", "vu-6", 0x3, "B");
-    output.addOutput("[Channel1]", "vu-3", 0x4, "B");
-    output.addOutput("[Channel1]", "vu0", 0x5, "B");
-    output.addOutput("[Channel1]", "vu3", 0x6, "B");
-    output.addOutput("[Channel1]", "vu6", 0x7, "B");
-
-    output.addOutput("[Channel2]", "vu-30", 0x8, "B");
-    output.addOutput("[Channel2]", "vu-15", 0x9, "B");
-    output.addOutput("[Channel2]", "vu-6", 0xA, "B");
-    output.addOutput("[Channel2]", "vu-3", 0xB, "B");
-    output.addOutput("[Channel2]", "vu0", 0xC, "B");
-    output.addOutput("[Channel2]", "vu3", 0xD, "B");
-    output.addOutput("[Channel2]", "vu6", 0xE, "B");
-
-    this.controller.registerOutputPacket(output);
-
-    engine.makeConnection("[QuickEffectRack1_[Channel1]]", "enabled", this.outputHandler);
-    engine.makeConnection("[QuickEffectRack1_[Channel2]]", "enabled", this.outputHandler);
-
-    engine.makeConnection("[Channel1]", "pfl", this.outputHandler);
-    engine.makeConnection("[Channel2]", "pfl", this.outputHandler);
-
-    this.vuLeftConnection = engine.makeUnbufferedConnection("[Channel1]", "vu_meter", this.vuMeterHandler);
-    this.vuRightConnection = engine.makeUnbufferedConnection("[Channel2]", "vu_meter", this.vuMeterHandler);
-
-    KontrolZ1.lightDeck(false);
-};
-
-KontrolZ1.modeHandler = function(field) {
-    KontrolZ1.modePressed = field.value;
-    KontrolZ1.outputHandler(field.value, field.group, "mode");
-};
-
-KontrolZ1.headphoneHandler = function(field) {
-    if (field.value === 0) {
-        return;
+        // VuMeter
+        this.vuLeftConnection = {};
+        this.vuRightConnection = {};
+        this.vuMeterThresholds = {"vu-30": (1 / 7), "vu-15": (2 / 7), "vu-6": (3 / 7), "vu-3": (4 / 7), "vu0": (5 / 7), "vu3": (6 / 7), "vu6": (7 / 7)};
     }
-    // Go to cue and stop when modifier is active
-    if (KontrolZ1.modePressed) {
-        engine.setValue(field.group, "cue_gotoandstop", field.value);
-    } else {
-        script.toggleControl(field.group, "pfl");
-    }
-};
 
-KontrolZ1.fxHandler = function(field) {
-    if (field.value === 0) {
-        // Always clear play indicator on button release
-        KontrolZ1.controller.setOutput(field.group, "play_indicator", 0x0, true);
-        return;
+    init(_id) {
+        this.id = _id;
+        this.registerInputPackets();
+        this.registerOutputPackets();
+        console.log(this.id + " initialized");
     }
-    // Control playback when modifier is active
-    if (KontrolZ1.modePressed) {
-        // Match play indicator (red led) brightness to fx indicator (blue led)
-        const current = engine.getValue("[QuickEffectRack1_" + field.group + "]", "enabled") ? 0x7F : 0xA;
-        KontrolZ1.controller.setOutput(field.group, "play_indicator", current, true);
-        script.toggleControl(field.group, "play");
-    } else {
-        script.toggleControl("[QuickEffectRack1_" + field.group + "]", "enabled");
-    }
-};
 
-KontrolZ1.vuMeterHandler = function(value, group, _key) {
-    const vuKeys = Object.keys(KontrolZ1.vuMeterThresholds);
-    for (let i = 0; i < vuKeys.length; ++i) {
-        // Avoid spamming HID by only sending last LED update
-        const last = i === (vuKeys.length - 1);
-        if (KontrolZ1.vuMeterThresholds[vuKeys[i]] > value) {
-            KontrolZ1.controller.setOutput(group, vuKeys[i], 0x00, last);
+    registerInputPackets() {
+        const message = new HIDPacket("message", 0x1, this.messageCallback);
+
+        // Mode button
+        this.registerInputButton(message, "[ControlX]", "!mode", 0x1D, 0x2, this.modeHandler);
+
+        // Headphone buttons
+        this.registerInputButton(message, "[Channel1]", "!pfl", 0x1D, 0x10, this.headphoneHandler);
+        this.registerInputButton(message, "[Channel2]", "!pfl", 0x1D, 0x1, this.headphoneHandler);
+
+        // FX buttons
+        this.registerInputButton(message, "[Channel1]", "!fx", 0x1D, 0x4, this.fxHandler);
+        this.registerInputButton(message, "[Channel2]", "!fx", 0x1D, 0x8, this.fxHandler);
+
+        // EQ knobs
+        this.registerInputScaler(message, "[EqualizerRack1_[Channel1]_Effect1]", "parameter3", 0x3, 0xFFFF, this.parameterHandler);
+        this.registerInputScaler(message, "[EqualizerRack1_[Channel1]_Effect1]", "parameter2", 0x5, 0xFFFF, this.parameterHandler);
+        this.registerInputScaler(message, "[EqualizerRack1_[Channel1]_Effect1]", "parameter1", 0x7, 0xFFFF, this.parameterHandler);
+        this.registerInputScaler(message, "[EqualizerRack1_[Channel2]_Effect1]", "parameter3", 0xD, 0xFFFF, this.parameterHandler);
+        this.registerInputScaler(message, "[EqualizerRack1_[Channel2]_Effect1]", "parameter2", 0xF, 0xFFFF, this.parameterHandler);
+        this.registerInputScaler(message, "[EqualizerRack1_[Channel2]_Effect1]", "parameter1", 0x11, 0xFFFF, this.parameterHandler);
+
+        // FX knobs
+        this.registerInputScaler(message, "[QuickEffectRack1_[Channel1]]", "super1", 0x9, 0xFFFF, this.parameterHandler);
+        this.registerInputScaler(message, "[QuickEffectRack1_[Channel2]]", "super1", 0x13, 0xFFFF, this.parameterHandler);
+
+        // Gain knobs
+        this.registerInputScaler(message, "[Channel1]", "pregain", 0x1, 0xFFFF, this.parameterHandler);
+        this.registerInputScaler(message, "[Channel2]", "pregain", 0xB, 0xFFFF, this.parameterHandler);
+
+        // Headphone mix
+        this.registerInputScaler(message, "[Master]", "headMix", 0x15, 0xFFFF, this.parameterHandler);
+
+        // Volume faders
+        this.registerInputScaler(message, "[Channel1]", "volume", 0x17, 0xFFFF, this.parameterHandler);
+        this.registerInputScaler(message, "[Channel2]", "volume", 0x19, 0xFFFF, this.parameterHandler);
+
+        // Crossfader
+        this.registerInputScaler(message, "[Master]", "crossfader", 0x1B, 0xFFFF, this.parameterHandler);
+
+        this.controller.registerInputPacket(message);
+
+        // Soft takeover for all knobs and faders
+        engine.softTakeover("[EqualizerRack1_[Channel1]_Effect1]", "parameter3", true);
+        engine.softTakeover("[EqualizerRack1_[Channel1]_Effect1]", "parameter2", true);
+        engine.softTakeover("[EqualizerRack1_[Channel1]_Effect1]", "parameter1", true);
+
+        engine.softTakeover("[EqualizerRack1_[Channel2]_Effect1]", "parameter3", true);
+        engine.softTakeover("[EqualizerRack1_[Channel2]_Effect1]", "parameter2", true);
+        engine.softTakeover("[EqualizerRack1_[Channel2]_Effect1]", "parameter1", true);
+
+        engine.softTakeover("[QuickEffectRack1_[Channel1]]", "super1", true);
+        engine.softTakeover("[QuickEffectRack1_[Channel2]]", "super1", true);
+
+        engine.softTakeover("[Channel1]", "pregain", true);
+        engine.softTakeover("[Channel2]", "pregain", true);
+
+        engine.softTakeover("[Master]", "headMix", true);
+
+        engine.softTakeover("[Channel1]", "volume", true);
+        engine.softTakeover("[Channel2]", "volume", true);
+
+        engine.softTakeover("[Master]", "crossfader", true);
+    }
+
+    registerInputButton(message, group, name, offset, bitmask, callback) {
+        message.addControl(group, name, offset, "B", bitmask);
+        message.setCallback(group, name, callback);
+    }
+
+    registerInputScaler(message, group, name, offset, bitmask, callback) {
+        message.addControl(group, name, offset, "H", bitmask);
+        message.setCallback(group, name, callback);
+    }
+
+    registerOutputPackets() {
+        const output = new HIDPacket("output", 0x80);
+
+        output.addOutput("[ControlX]", "mode", 0x13, "B");
+
+        output.addOutput("[Channel1]", "pfl", 0xF, "B");
+        output.addOutput("[Channel2]", "pfl", 0x10, "B");
+
+        output.addOutput("[Channel1]", "play_indicator", 0x11, "B");
+        output.addOutput("[Channel2]", "play_indicator", 0x14, "B");
+
+        output.addOutput("[QuickEffectRack1_[Channel1]]", "enabled", 0x12, "B");
+        output.addOutput("[QuickEffectRack1_[Channel2]]", "enabled", 0x15, "B");
+
+        output.addOutput("[Channel1]", "vu-30", 0x1, "B");
+        output.addOutput("[Channel1]", "vu-15", 0x2, "B");
+        output.addOutput("[Channel1]", "vu-6", 0x3, "B");
+        output.addOutput("[Channel1]", "vu-3", 0x4, "B");
+        output.addOutput("[Channel1]", "vu0", 0x5, "B");
+        output.addOutput("[Channel1]", "vu3", 0x6, "B");
+        output.addOutput("[Channel1]", "vu6", 0x7, "B");
+
+        output.addOutput("[Channel2]", "vu-30", 0x8, "B");
+        output.addOutput("[Channel2]", "vu-15", 0x9, "B");
+        output.addOutput("[Channel2]", "vu-6", 0xA, "B");
+        output.addOutput("[Channel2]", "vu-3", 0xB, "B");
+        output.addOutput("[Channel2]", "vu0", 0xC, "B");
+        output.addOutput("[Channel2]", "vu3", 0xD, "B");
+        output.addOutput("[Channel2]", "vu6", 0xE, "B");
+
+        this.controller.registerOutputPacket(output);
+
+        engine.makeConnection("[QuickEffectRack1_[Channel1]]", "enabled", this.outputHandler);
+        engine.makeConnection("[QuickEffectRack1_[Channel2]]", "enabled", this.outputHandler);
+
+        engine.makeConnection("[Channel1]", "pfl", this.outputHandler);
+        engine.makeConnection("[Channel2]", "pfl", this.outputHandler);
+
+        this.vuLeftConnection = engine.makeUnbufferedConnection("[Channel1]", "vu_meter", this.vuMeterHandler);
+        this.vuRightConnection = engine.makeUnbufferedConnection("[Channel2]", "vu_meter", this.vuMeterHandler);
+
+        this.lightDeck(false);
+    }
+
+    modeHandler(field) {
+        this.modePressed = field.value;
+        this.outputHandler(field.value, field.group, "mode");
+    }
+
+    headphoneHandler(field) {
+        if (field.value === 0) {
+            return;
+        }
+        // Go to cue and stop when modifier is active
+        if (this.modePressed) {
+            engine.setValue(field.group, "cue_gotoandstop", field.value);
         } else {
-            KontrolZ1.controller.setOutput(group, vuKeys[i], 0x7E, last);
+            script.toggleControl(field.group, "pfl");
         }
     }
-};
 
-KontrolZ1.parameterHandler = function(field) {
-    engine.setParameter(field.group, field.name, field.value / 4095);
-};
-
-KontrolZ1.outputHandler = function(value, group, key) {
-    let ledValue;
-    if (value === 0 || value === false) {
-        // Off value (dimmed)
-        ledValue = 0xA;
-    } else if (value === 1 || value === true) {
-        // On value
-        ledValue = 0x7F;
-    }
-    KontrolZ1.controller.setOutput(group, key, ledValue, true);
-};
-
-KontrolZ1.lightDeck = function(switchOff) {
-    let softLight = 0xA;
-    let fullLight = 0x7F;
-    let current;
-
-    if (switchOff) {
-        softLight = 0x00;
-        fullLight = 0x00;
-    }
-
-    KontrolZ1.controller.setOutput("[ControlX]", "mode", softLight, true);
-
-    current = engine.getValue("[QuickEffectRack1_[Channel1]]", "enabled") ? fullLight : softLight;
-    KontrolZ1.controller.setOutput("[QuickEffectRack1_[Channel1]]", "enabled", current, true);
-    current = engine.getValue("[QuickEffectRack1_[Channel2]]", "enabled") ? fullLight : softLight;
-    KontrolZ1.controller.setOutput("[QuickEffectRack1_[Channel2]]", "enabled", current, true);
-
-    current = engine.getValue("[Channel1]", "pfl") ? fullLight : softLight;
-    KontrolZ1.controller.setOutput("[Channel1]", "pfl", current, true);
-    current = engine.getValue("[Channel2]", "pfl") ? fullLight : softLight;
-    KontrolZ1.controller.setOutput("[Channel2]", "pfl", current, true);
-};
-
-KontrolZ1.messageCallback = function(packet, data) {
-    for (const name in data) {
-        if (Object.hasOwnProperty.call(data, name)) {
-            KontrolZ1.controller.processButton(data[name]);
+    fxHandler(field) {
+        if (field.value === 0) {
+            // Always clear play indicator on button release
+            this.controller.setOutput(field.group, "play_indicator", 0x0, true);
+            return;
+        }
+        // Control playback when modifier is active
+        if (this.modePressed) {
+            // Match play indicator (red led) brightness to fx indicator (blue led)
+            const current = engine.getValue("[QuickEffectRack1_" + field.group + "]", "enabled") ? 0x7F : 0xA;
+            this.controller.setOutput(field.group, "play_indicator", current, true);
+            script.toggleControl(field.group, "play");
+        } else {
+            script.toggleControl("[QuickEffectRack1_" + field.group + "]", "enabled");
         }
     }
-};
 
-KontrolZ1.shutdown = function() {
-    // Deactivate all LEDs
-    KontrolZ1.lightDeck(true);
-    console.log(KontrolZ1.id + " shut down");
-};
+    vuMeterHandler(value, group, _key) {
+        const vuKeys = Object.keys(this.vuMeterThresholds);
+        for (let i = 0; i < vuKeys.length; ++i) {
+            // Avoid spamming HID by only sending last LED update
+            const last = i === (vuKeys.length - 1);
+            if (this.vuMeterThresholds[vuKeys[i]] > value) {
+                this.controller.setOutput(group, vuKeys[i], 0x00, last);
+            } else {
+                this.controller.setOutput(group, vuKeys[i], 0x7E, last);
+            }
+        }
+    }
 
-KontrolZ1.incomingData = function(data, length) {
-    KontrolZ1.controller.parsePacket(data, length);
-};
+
+    parameterHandler(field) {
+        engine.setParameter(field.group, field.name, field.value / 4095);
+    }
+
+    outputHandler(value, group, key) {
+        let ledValue;
+        if (value === 0 || value === false) {
+            // Off value (dimmed)
+            ledValue = 0xA;
+        } else if (value === 1 || value === true) {
+            // On value
+            ledValue = 0x7F;
+        }
+        this.controller.setOutput(group, key, ledValue, true);
+    }
+
+    lightDeck(switchOff) {
+        let softLight = 0xA;
+        let fullLight = 0x7F;
+        let current;
+
+        if (switchOff) {
+            softLight = 0x00;
+            fullLight = 0x00;
+        }
+
+        this.controller.setOutput("[ControlX]", "mode", softLight, true);
+
+        current = engine.getValue("[QuickEffectRack1_[Channel1]]", "enabled") ? fullLight : softLight;
+        this.controller.setOutput("[QuickEffectRack1_[Channel1]]", "enabled", current, true);
+        current = engine.getValue("[QuickEffectRack1_[Channel2]]", "enabled") ? fullLight : softLight;
+        this.controller.setOutput("[QuickEffectRack1_[Channel2]]", "enabled", current, true);
+
+        current = engine.getValue("[Channel1]", "pfl") ? fullLight : softLight;
+        this.controller.setOutput("[Channel1]", "pfl", current, true);
+        current = engine.getValue("[Channel2]", "pfl") ? fullLight : softLight;
+        this.controller.setOutput("[Channel2]", "pfl", current, true);
+    }
+
+    messageCallback(packet, data) {
+        for (const name in data) {
+            if (Object.hasOwnProperty.call(data, name)) {
+                this.controller.processButton(data[name]);
+            }
+        }
+    }
+
+    shutdown() {
+        // Deactivate all LEDs
+        this.lightDeck(true);
+        console.log(this.id + " shut down");
+    }
+
+    incomingData(data, length) {
+        this.controller.parsePacket(data, length);
+    }
+}
+
+var TraktorZ1 = new TraktorZ1Class;  // eslint-disable-line no-var, no-unused-vars

--- a/res/controllers/Traktor-Kontrol-Z1-scripts.js
+++ b/res/controllers/Traktor-Kontrol-Z1-scripts.js
@@ -26,44 +26,44 @@ class TraktorZ1Class {
     }
 
     registerInputPackets() {
-        const message = new HIDPacket("message", 0x1, this.messageCallback);
+        const message = new HIDPacket("message", 0x1, this.messageCallback.bind(this));
 
         // Mode button
-        this.registerInputButton(message, "[ControlX]", "!mode", 0x1D, 0x2, this.modeHandler);
+        this.registerInputButton(message, "[ControlX]", "!mode", 0x1D, 0x2, this.modeHandler.bind(this));
 
         // Headphone buttons
-        this.registerInputButton(message, "[Channel1]", "!pfl", 0x1D, 0x10, this.headphoneHandler);
-        this.registerInputButton(message, "[Channel2]", "!pfl", 0x1D, 0x1, this.headphoneHandler);
+        this.registerInputButton(message, "[Channel1]", "!pfl", 0x1D, 0x10, this.headphoneHandler.bind(this));
+        this.registerInputButton(message, "[Channel2]", "!pfl", 0x1D, 0x1, this.headphoneHandler.bind(this));
 
         // FX buttons
-        this.registerInputButton(message, "[Channel1]", "!fx", 0x1D, 0x4, this.fxHandler);
-        this.registerInputButton(message, "[Channel2]", "!fx", 0x1D, 0x8, this.fxHandler);
+        this.registerInputButton(message, "[Channel1]", "!fx", 0x1D, 0x4, this.fxHandler.bind(this));
+        this.registerInputButton(message, "[Channel2]", "!fx", 0x1D, 0x8, this.fxHandler.bind(this));
 
         // EQ knobs
-        this.registerInputScaler(message, "[EqualizerRack1_[Channel1]_Effect1]", "parameter3", 0x3, 0xFFFF, this.parameterHandler);
-        this.registerInputScaler(message, "[EqualizerRack1_[Channel1]_Effect1]", "parameter2", 0x5, 0xFFFF, this.parameterHandler);
-        this.registerInputScaler(message, "[EqualizerRack1_[Channel1]_Effect1]", "parameter1", 0x7, 0xFFFF, this.parameterHandler);
-        this.registerInputScaler(message, "[EqualizerRack1_[Channel2]_Effect1]", "parameter3", 0xD, 0xFFFF, this.parameterHandler);
-        this.registerInputScaler(message, "[EqualizerRack1_[Channel2]_Effect1]", "parameter2", 0xF, 0xFFFF, this.parameterHandler);
-        this.registerInputScaler(message, "[EqualizerRack1_[Channel2]_Effect1]", "parameter1", 0x11, 0xFFFF, this.parameterHandler);
+        this.registerInputScaler(message, "[EqualizerRack1_[Channel1]_Effect1]", "parameter3", 0x3, 0xFFFF, this.parameterHandler.bind(this));
+        this.registerInputScaler(message, "[EqualizerRack1_[Channel1]_Effect1]", "parameter2", 0x5, 0xFFFF, this.parameterHandler.bind(this));
+        this.registerInputScaler(message, "[EqualizerRack1_[Channel1]_Effect1]", "parameter1", 0x7, 0xFFFF, this.parameterHandler.bind(this));
+        this.registerInputScaler(message, "[EqualizerRack1_[Channel2]_Effect1]", "parameter3", 0xD, 0xFFFF, this.parameterHandler.bind(this));
+        this.registerInputScaler(message, "[EqualizerRack1_[Channel2]_Effect1]", "parameter2", 0xF, 0xFFFF, this.parameterHandler.bind(this));
+        this.registerInputScaler(message, "[EqualizerRack1_[Channel2]_Effect1]", "parameter1", 0x11, 0xFFFF, this.parameterHandler.bind(this));
 
         // FX knobs
-        this.registerInputScaler(message, "[QuickEffectRack1_[Channel1]]", "super1", 0x9, 0xFFFF, this.parameterHandler);
-        this.registerInputScaler(message, "[QuickEffectRack1_[Channel2]]", "super1", 0x13, 0xFFFF, this.parameterHandler);
+        this.registerInputScaler(message, "[QuickEffectRack1_[Channel1]]", "super1", 0x9, 0xFFFF, this.parameterHandler.bind(this));
+        this.registerInputScaler(message, "[QuickEffectRack1_[Channel2]]", "super1", 0x13, 0xFFFF, this.parameterHandler.bind(this));
 
         // Gain knobs
-        this.registerInputScaler(message, "[Channel1]", "pregain", 0x1, 0xFFFF, this.parameterHandler);
-        this.registerInputScaler(message, "[Channel2]", "pregain", 0xB, 0xFFFF, this.parameterHandler);
+        this.registerInputScaler(message, "[Channel1]", "pregain", 0x1, 0xFFFF, this.parameterHandler.bind(this));
+        this.registerInputScaler(message, "[Channel2]", "pregain", 0xB, 0xFFFF, this.parameterHandler.bind(this));
 
         // Headphone mix
-        this.registerInputScaler(message, "[Master]", "headMix", 0x15, 0xFFFF, this.parameterHandler);
+        this.registerInputScaler(message, "[Master]", "headMix", 0x15, 0xFFFF, this.parameterHandler.bind(this));
 
         // Volume faders
-        this.registerInputScaler(message, "[Channel1]", "volume", 0x17, 0xFFFF, this.parameterHandler);
-        this.registerInputScaler(message, "[Channel2]", "volume", 0x19, 0xFFFF, this.parameterHandler);
+        this.registerInputScaler(message, "[Channel1]", "volume", 0x17, 0xFFFF, this.parameterHandler.bind(this));
+        this.registerInputScaler(message, "[Channel2]", "volume", 0x19, 0xFFFF, this.parameterHandler.bind(this));
 
         // Crossfader
-        this.registerInputScaler(message, "[Master]", "crossfader", 0x1B, 0xFFFF, this.parameterHandler);
+        this.registerInputScaler(message, "[Master]", "crossfader", 0x1B, 0xFFFF, this.parameterHandler.bind(this));
 
         this.controller.registerInputPacket(message);
 
@@ -132,14 +132,14 @@ class TraktorZ1Class {
 
         this.controller.registerOutputPacket(output);
 
-        engine.makeConnection("[QuickEffectRack1_[Channel1]]", "enabled", this.outputHandler);
-        engine.makeConnection("[QuickEffectRack1_[Channel2]]", "enabled", this.outputHandler);
+        engine.makeConnection("[QuickEffectRack1_[Channel1]]", "enabled", this.outputHandler.bind(this));
+        engine.makeConnection("[QuickEffectRack1_[Channel2]]", "enabled", this.outputHandler.bind(this));
 
-        engine.makeConnection("[Channel1]", "pfl", this.outputHandler);
-        engine.makeConnection("[Channel2]", "pfl", this.outputHandler);
+        engine.makeConnection("[Channel1]", "pfl", this.outputHandler.bind(this));
+        engine.makeConnection("[Channel2]", "pfl", this.outputHandler.bind(this));
 
-        this.vuLeftConnection = engine.makeUnbufferedConnection("[Channel1]", "vu_meter", this.vuMeterHandler);
-        this.vuRightConnection = engine.makeUnbufferedConnection("[Channel2]", "vu_meter", this.vuMeterHandler);
+        this.vuLeftConnection = engine.makeUnbufferedConnection("[Channel1]", "vu_meter", this.vuMeterHandler.bind(this));
+        this.vuRightConnection = engine.makeUnbufferedConnection("[Channel2]", "vu_meter", this.vuMeterHandler.bind(this));
 
         this.lightDeck(false);
     }

--- a/res/controllers/Traktor-Kontrol-Z1-scripts.js
+++ b/res/controllers/Traktor-Kontrol-Z1-scripts.js
@@ -1,6 +1,7 @@
 //
 // Native Instruments Traktor Kontrol Z1 HID controller script for Mixxx 2.4
-// Based on Traktor Kontrol S2 MK3 script by Michael Schmidt
+// -------------------------------------------------------------------------
+// Based on: Kontrol S2 MK3 script by mi01 and Kontrol Z1 script by xeruf
 // Author: djantti
 //
 

--- a/res/controllers/Traktor-Kontrol-Z1-scripts.js
+++ b/res/controllers/Traktor-Kontrol-Z1-scripts.js
@@ -26,34 +26,34 @@ class TraktorZ1Class {
     }
 
     registerInputPackets() {
-        const message = new HIDPacket("message", 0x1, this.messageCallback.bind(this));
+        const message = new HIDPacket("message", 0x01, this.messageCallback.bind(this));
 
         // Mode button
-        this.registerInputButton(message, "[ControlX]", "!mode", 0x1D, 0x2, this.modeHandler.bind(this));
+        this.registerInputButton(message, "[ControlX]", "!mode", 0x1D, 0x02, this.modeHandler.bind(this));
 
         // Headphone buttons
         this.registerInputButton(message, "[Channel1]", "!pfl", 0x1D, 0x10, this.headphoneHandler.bind(this));
-        this.registerInputButton(message, "[Channel2]", "!pfl", 0x1D, 0x1, this.headphoneHandler.bind(this));
+        this.registerInputButton(message, "[Channel2]", "!pfl", 0x1D, 0x01, this.headphoneHandler.bind(this));
 
         // FX buttons
-        this.registerInputButton(message, "[Channel1]", "!fx", 0x1D, 0x4, this.fxHandler.bind(this));
-        this.registerInputButton(message, "[Channel2]", "!fx", 0x1D, 0x8, this.fxHandler.bind(this));
+        this.registerInputButton(message, "[Channel1]", "!fx", 0x1D, 0x04, this.fxHandler.bind(this));
+        this.registerInputButton(message, "[Channel2]", "!fx", 0x1D, 0x08, this.fxHandler.bind(this));
 
         // EQ knobs
-        this.registerInputScaler(message, "[EqualizerRack1_[Channel1]_Effect1]", "parameter3", 0x3, 0xFFFF, this.parameterHandler.bind(this));
-        this.registerInputScaler(message, "[EqualizerRack1_[Channel1]_Effect1]", "parameter2", 0x5, 0xFFFF, this.parameterHandler.bind(this));
-        this.registerInputScaler(message, "[EqualizerRack1_[Channel1]_Effect1]", "parameter1", 0x7, 0xFFFF, this.parameterHandler.bind(this));
-        this.registerInputScaler(message, "[EqualizerRack1_[Channel2]_Effect1]", "parameter3", 0xD, 0xFFFF, this.parameterHandler.bind(this));
-        this.registerInputScaler(message, "[EqualizerRack1_[Channel2]_Effect1]", "parameter2", 0xF, 0xFFFF, this.parameterHandler.bind(this));
+        this.registerInputScaler(message, "[EqualizerRack1_[Channel1]_Effect1]", "parameter3", 0x03, 0xFFFF, this.parameterHandler.bind(this));
+        this.registerInputScaler(message, "[EqualizerRack1_[Channel1]_Effect1]", "parameter2", 0x05, 0xFFFF, this.parameterHandler.bind(this));
+        this.registerInputScaler(message, "[EqualizerRack1_[Channel1]_Effect1]", "parameter1", 0x07, 0xFFFF, this.parameterHandler.bind(this));
+        this.registerInputScaler(message, "[EqualizerRack1_[Channel2]_Effect1]", "parameter3", 0x0D, 0xFFFF, this.parameterHandler.bind(this));
+        this.registerInputScaler(message, "[EqualizerRack1_[Channel2]_Effect1]", "parameter2", 0x0F, 0xFFFF, this.parameterHandler.bind(this));
         this.registerInputScaler(message, "[EqualizerRack1_[Channel2]_Effect1]", "parameter1", 0x11, 0xFFFF, this.parameterHandler.bind(this));
 
         // FX knobs
-        this.registerInputScaler(message, "[QuickEffectRack1_[Channel1]]", "super1", 0x9, 0xFFFF, this.parameterHandler.bind(this));
+        this.registerInputScaler(message, "[QuickEffectRack1_[Channel1]]", "super1", 0x09, 0xFFFF, this.parameterHandler.bind(this));
         this.registerInputScaler(message, "[QuickEffectRack1_[Channel2]]", "super1", 0x13, 0xFFFF, this.parameterHandler.bind(this));
 
         // Gain knobs
-        this.registerInputScaler(message, "[Channel1]", "pregain", 0x1, 0xFFFF, this.parameterHandler.bind(this));
-        this.registerInputScaler(message, "[Channel2]", "pregain", 0xB, 0xFFFF, this.parameterHandler.bind(this));
+        this.registerInputScaler(message, "[Channel1]", "pregain", 0x01, 0xFFFF, this.parameterHandler.bind(this));
+        this.registerInputScaler(message, "[Channel2]", "pregain", 0x0B, 0xFFFF, this.parameterHandler.bind(this));
 
         // Headphone mix
         this.registerInputScaler(message, "[Master]", "headMix", 0x15, 0xFFFF, this.parameterHandler.bind(this));
@@ -105,7 +105,7 @@ class TraktorZ1Class {
 
         output.addOutput("[ControlX]", "mode", 0x13, "B");
 
-        output.addOutput("[Channel1]", "pfl", 0xF, "B");
+        output.addOutput("[Channel1]", "pfl", 0x0F, "B");
         output.addOutput("[Channel2]", "pfl", 0x10, "B");
 
         output.addOutput("[Channel1]", "play_indicator", 0x11, "B");
@@ -114,21 +114,21 @@ class TraktorZ1Class {
         output.addOutput("[QuickEffectRack1_[Channel1]]", "enabled", 0x12, "B");
         output.addOutput("[QuickEffectRack1_[Channel2]]", "enabled", 0x15, "B");
 
-        output.addOutput("[Channel1]", "vu-30", 0x1, "B");
-        output.addOutput("[Channel1]", "vu-15", 0x2, "B");
-        output.addOutput("[Channel1]", "vu-6", 0x3, "B");
-        output.addOutput("[Channel1]", "vu-3", 0x4, "B");
-        output.addOutput("[Channel1]", "vu0", 0x5, "B");
-        output.addOutput("[Channel1]", "vu3", 0x6, "B");
-        output.addOutput("[Channel1]", "vu6", 0x7, "B");
+        output.addOutput("[Channel1]", "vu-30", 0x01, "B");
+        output.addOutput("[Channel1]", "vu-15", 0x02, "B");
+        output.addOutput("[Channel1]", "vu-6", 0x03, "B");
+        output.addOutput("[Channel1]", "vu-3", 0x04, "B");
+        output.addOutput("[Channel1]", "vu0", 0x05, "B");
+        output.addOutput("[Channel1]", "vu3", 0x06, "B");
+        output.addOutput("[Channel1]", "vu6", 0x07, "B");
 
-        output.addOutput("[Channel2]", "vu-30", 0x8, "B");
-        output.addOutput("[Channel2]", "vu-15", 0x9, "B");
-        output.addOutput("[Channel2]", "vu-6", 0xA, "B");
-        output.addOutput("[Channel2]", "vu-3", 0xB, "B");
-        output.addOutput("[Channel2]", "vu0", 0xC, "B");
-        output.addOutput("[Channel2]", "vu3", 0xD, "B");
-        output.addOutput("[Channel2]", "vu6", 0xE, "B");
+        output.addOutput("[Channel2]", "vu-30", 0x08, "B");
+        output.addOutput("[Channel2]", "vu-15", 0x09, "B");
+        output.addOutput("[Channel2]", "vu-6", 0x0A, "B");
+        output.addOutput("[Channel2]", "vu-3", 0x0B, "B");
+        output.addOutput("[Channel2]", "vu0", 0x0C, "B");
+        output.addOutput("[Channel2]", "vu3", 0x0D, "B");
+        output.addOutput("[Channel2]", "vu6", 0x0E, "B");
 
         this.controller.registerOutputPacket(output);
 
@@ -164,13 +164,13 @@ class TraktorZ1Class {
     fxHandler(field) {
         if (field.value === 0) {
             // Always clear play indicator on button release
-            this.controller.setOutput(field.group, "play_indicator", 0x0, true);
+            this.controller.setOutput(field.group, "play_indicator", 0x00, true);
             return;
         }
         // Control playback when modifier is active
         if (this.modePressed) {
             // Match play indicator (red led) brightness to fx indicator (blue led)
-            const current = engine.getValue("[QuickEffectRack1_" + field.group + "]", "enabled") ? 0x7F : 0xA;
+            const current = engine.getValue("[QuickEffectRack1_" + field.group + "]", "enabled") ? 0x7F : 0x0A;
             this.controller.setOutput(field.group, "play_indicator", current, true);
             script.toggleControl(field.group, "play");
         } else {
@@ -199,7 +199,7 @@ class TraktorZ1Class {
         let ledValue;
         if (value === 0 || value === false) {
             // Off value (dimmed)
-            ledValue = 0xA;
+            ledValue = 0x0A;
         } else if (value === 1 || value === true) {
             // On value
             ledValue = 0x7F;
@@ -208,7 +208,7 @@ class TraktorZ1Class {
     }
 
     lightDeck(switchOff) {
-        let softLight = 0xA;
+        let softLight = 0x0A;
         let fullLight = 0x7F;
         let current;
 

--- a/res/controllers/Traktor-Kontrol-Z1-scripts.js
+++ b/res/controllers/Traktor-Kontrol-Z1-scripts.js
@@ -1,0 +1,250 @@
+//
+// Native Instruments Traktor Kontrol Z1 HID controller script for Mixxx 2.4
+// Based on Traktor Kontrol S2 MK3 script by Michael Schmidt
+// Author: djantti
+// Last modified: 20231123
+//
+// Extra functionality:
+// Mode + FX -> Playback start / stop
+// Mode + Headphone -> Stop and rewind track
+//
+
+var KontrolZ1 = new function() {
+    this.controller = new HIDController();
+
+    // Modifier state
+    this.modePressed = false;
+
+    // VuMeter
+    this.vuLeftConnection = {};
+    this.vuRightConnection = {};
+    this.vuMeterThresholds = {"vu-30": (1 / 7), "vu-15": (2 / 7), "vu-6": (3 / 7), "vu-3": (4 / 7), "vu0": (5 / 7), "vu3": (6 / 7), "vu6": (7 / 7)};
+};
+
+KontrolZ1.init = function(_id) {
+    KontrolZ1.id = _id;
+    KontrolZ1.registerInputPackets();
+    KontrolZ1.registerOutputPackets();
+    print(KontrolZ1.id + " initialized");
+};
+
+KontrolZ1.registerInputPackets = function() {
+    const message = new HIDPacket("message", 0x1, this.messageCallback);
+
+    // Mode button
+    this.registerInputButton(message, "[Controls]", "!mode", 0x1D, 0x2, this.modeHandler);
+
+    // Headphone buttons
+    this.registerInputButton(message, "[Channel1]", "!pfl", 0x1D, 0x10, this.headphoneHandler);
+    this.registerInputButton(message, "[Channel2]", "!pfl", 0x1D, 0x1, this.headphoneHandler);
+
+    // FX buttons
+    this.registerInputButton(message, "[Channel1]", "!fx", 0x1D, 0x4, this.fxHandler);
+    this.registerInputButton(message, "[Channel2]", "!fx", 0x1D, 0x8, this.fxHandler);
+
+    // EQ knobs
+    this.registerInputScaler(message, "[EqualizerRack1_[Channel1]_Effect1]", "parameter3", 0x3, 0xFFFF, this.parameterHandler);
+    this.registerInputScaler(message, "[EqualizerRack1_[Channel1]_Effect1]", "parameter2", 0x5, 0xFFFF, this.parameterHandler);
+    this.registerInputScaler(message, "[EqualizerRack1_[Channel1]_Effect1]", "parameter1", 0x7, 0xFFFF, this.parameterHandler);
+    this.registerInputScaler(message, "[EqualizerRack1_[Channel2]_Effect1]", "parameter3", 0xD, 0xFFFF, this.parameterHandler);
+    this.registerInputScaler(message, "[EqualizerRack1_[Channel2]_Effect1]", "parameter2", 0xF, 0xFFFF, this.parameterHandler);
+    this.registerInputScaler(message, "[EqualizerRack1_[Channel2]_Effect1]", "parameter1", 0x11, 0xFFFF, this.parameterHandler);
+
+    // FX knobs
+    this.registerInputScaler(message, "[QuickEffectRack1_[Channel1]]", "super1", 0x9, 0xFFFF, this.parameterHandler);
+    this.registerInputScaler(message, "[QuickEffectRack1_[Channel2]]", "super1", 0x13, 0xFFFF, this.parameterHandler);
+
+    // Gain knobs
+    this.registerInputScaler(message, "[Channel1]", "pregain", 0x1, 0xFFFF, this.parameterHandler);
+    this.registerInputScaler(message, "[Channel2]", "pregain", 0xB, 0xFFFF, this.parameterHandler);
+
+    // Headphone mix
+    this.registerInputScaler(message, "[Master]", "headMix", 0x15, 0xFFFF, this.parameterHandler);
+
+    // Volume faders
+    this.registerInputScaler(message, "[Channel1]", "volume", 0x17, 0xFFFF, this.parameterHandler);
+    this.registerInputScaler(message, "[Channel2]", "volume", 0x19, 0xFFFF, this.parameterHandler);
+
+    // Crossfader
+    this.registerInputScaler(message, "[Master]", "crossfader", 0x1B, 0xFFFF, this.parameterHandler);
+
+    this.controller.registerInputPacket(message);
+
+    // Soft takeover for all knobs and faders
+    engine.softTakeover("[EqualizerRack1_[Channel1]_Effect1]", "parameter3", true);
+    engine.softTakeover("[EqualizerRack1_[Channel1]_Effect1]", "parameter2", true);
+    engine.softTakeover("[EqualizerRack1_[Channel1]_Effect1]", "parameter1", true);
+
+    engine.softTakeover("[EqualizerRack1_[Channel2]_Effect1]", "parameter3", true);
+    engine.softTakeover("[EqualizerRack1_[Channel2]_Effect1]", "parameter2", true);
+    engine.softTakeover("[EqualizerRack1_[Channel2]_Effect1]", "parameter1", true);
+
+    engine.softTakeover("[QuickEffectRack1_[Channel1]]", "super1", true);
+    engine.softTakeover("[QuickEffectRack1_[Channel2]]", "super1", true);
+
+    engine.softTakeover("[Channel1]", "pregain", true);
+    engine.softTakeover("[Channel2]", "pregain", true);
+
+    engine.softTakeover("[Master]", "headMix", true);
+
+    engine.softTakeover("[Channel1]", "volume", true);
+    engine.softTakeover("[Channel2]", "volume", true);
+
+    engine.softTakeover("[Master]", "crossfader", true);
+};
+
+KontrolZ1.registerInputButton = function(message, group, name, offset, bitmask, callback) {
+    message.addControl(group, name, offset, "B", bitmask);
+    message.setCallback(group, name, callback);
+};
+
+KontrolZ1.registerInputScaler = function(message, group, name, offset, bitmask, callback) {
+    message.addControl(group, name, offset, "H", bitmask);
+    message.setCallback(group, name, callback);
+};
+
+KontrolZ1.registerOutputPackets = function() {
+    const output = new HIDPacket("output", 0x80);
+
+    output.addOutput("[Controls]", "mode", 0x13, "B");
+
+    output.addOutput("[Channel1]", "pfl", 0xF, "B");
+    output.addOutput("[Channel2]", "pfl", 0x10, "B");
+
+    output.addOutput("[Channel1]", "play_indicator", 0x11, "B");
+    output.addOutput("[Channel2]", "play_indicator", 0x14, "B");
+
+    output.addOutput("[QuickEffectRack1_[Channel1]]", "enabled", 0x12, "B");
+    output.addOutput("[QuickEffectRack1_[Channel2]]", "enabled", 0x15, "B");
+
+    output.addOutput("[Channel1]", "vu-30", 0x1, "B");
+    output.addOutput("[Channel1]", "vu-15", 0x2, "B");
+    output.addOutput("[Channel1]", "vu-6", 0x3, "B");
+    output.addOutput("[Channel1]", "vu-3", 0x4, "B");
+    output.addOutput("[Channel1]", "vu0", 0x5, "B");
+    output.addOutput("[Channel1]", "vu3", 0x6, "B");
+    output.addOutput("[Channel1]", "vu6", 0x7, "B");
+
+    output.addOutput("[Channel2]", "vu-30", 0x8, "B");
+    output.addOutput("[Channel2]", "vu-15", 0x9, "B");
+    output.addOutput("[Channel2]", "vu-6", 0xA, "B");
+    output.addOutput("[Channel2]", "vu-3", 0xB, "B");
+    output.addOutput("[Channel2]", "vu0", 0xC, "B");
+    output.addOutput("[Channel2]", "vu3", 0xD, "B");
+    output.addOutput("[Channel2]", "vu6", 0xE, "B");
+
+    this.controller.registerOutputPacket(output);
+
+    engine.makeConnection("[QuickEffectRack1_[Channel1]]", "enabled", this.outputHandler);
+    engine.makeConnection("[QuickEffectRack1_[Channel2]]", "enabled", this.outputHandler);
+
+    engine.makeConnection("[Channel1]", "pfl", this.outputHandler);
+    engine.makeConnection("[Channel2]", "pfl", this.outputHandler);
+
+    this.vuLeftConnection = engine.makeUnbufferedConnection("[Channel1]", "vu_meter", this.vuMeterHandler);
+    this.vuRightConnection = engine.makeUnbufferedConnection("[Channel2]", "vu_meter", this.vuMeterHandler);
+
+    KontrolZ1.lightDeck(false);
+}
+
+KontrolZ1.modeHandler = function(field) {
+    KontrolZ1.modePressed = field.value;
+    KontrolZ1.outputHandler(field.value, field.group, "mode");
+};
+
+KontrolZ1.headphoneHandler = function(field) {
+    if (field.value === 0) {
+        return;
+    }
+    // Seek to start and stop when modifier is active
+    if (KontrolZ1.modePressed) {
+        engine.setValue(field.group, "start_stop", field.value);
+    } else {
+        script.toggleControl(field.group, "pfl");
+    }
+};
+
+KontrolZ1.fxHandler = function(field) {
+    if (field.value === 0) {
+        // Always clear play indicator on button release
+        KontrolZ1.controller.setOutput(field.group, "play_indicator", 0x0, true);
+        return;
+    }
+    // Control playback when modifier is active
+    if (KontrolZ1.modePressed) {
+        // Match play indicator (red led) brightness to fx indicator (blue led)
+        current = (engine.getValue("[QuickEffectRack1_" + field.group + "]", "enabled")) ? 0x7F : 0xA;
+        KontrolZ1.controller.setOutput(field.group, "play_indicator", current, true);
+        script.toggleControl(field.group, "play");
+    } else {
+        script.toggleControl("[QuickEffectRack1_" + field.group + "]", "enabled");
+    }
+};
+
+KontrolZ1.vuMeterHandler = function(value, group, _key) {
+    const vuKeys = Object.keys(KontrolZ1.vuMeterThresholds);
+    for (let i = 0; i < vuKeys.length; ++i) {
+        // Avoid spamming HID by only sending last LED update
+        const last = (i === (vuKeys.length - 1));
+        if (KontrolZ1.vuMeterThresholds[vuKeys[i]] > value) {
+            KontrolZ1.controller.setOutput(group, vuKeys[i], 0x00, last);
+        } else {
+            KontrolZ1.controller.setOutput(group, vuKeys[i], 0x7E, last);
+        }
+    }
+};
+
+KontrolZ1.parameterHandler = function(field) {
+    engine.setParameter(field.group, field.name, field.value / 4095);
+}
+
+KontrolZ1.outputHandler = function(value, group, key) {
+    if (value === 0 || value === false) {
+        // Off value (dimmed)
+        ledValue = 0xA;
+    } else if (value === 1 || value === true) {
+        // On value
+        ledValue = 0x7F;
+    }
+    KontrolZ1.controller.setOutput(group, key, ledValue, true);
+};
+
+KontrolZ1.lightDeck = function(switchOff) {
+    let softLight = 0xA;
+    let fullLight = 0x7F;
+
+    if (switchOff) {
+        softLight = 0x00;
+        fullLight = 0x00;
+    }
+
+    KontrolZ1.controller.setOutput("[Controls]", "mode", softLight, true);
+
+    current = (engine.getValue("[QuickEffectRack1_[Channel1]]", "enabled")) ? fullLight : softLight;
+    KontrolZ1.controller.setOutput("[QuickEffectRack1_[Channel1]]", "enabled", current, true);
+    current = (engine.getValue("[QuickEffectRack1_[Channel2]]", "enabled")) ? fullLight : softLight;
+    KontrolZ1.controller.setOutput("[QuickEffectRack1_[Channel2]]", "enabled", current, true);
+
+    current = (engine.getValue("[Channel1]", "pfl")) ? fullLight : softLight;
+    KontrolZ1.controller.setOutput("[Channel1]", "pfl", current, true);
+    current = (engine.getValue("[Channel2]", "pfl")) ? fullLight : softLight;
+    KontrolZ1.controller.setOutput("[Channel2]", "pfl", current, true);
+}
+
+KontrolZ1.messageCallback = function(packet, data) {
+    for (const name in data) {
+        if (Object.hasOwnProperty.call(data, name)) {
+            KontrolZ1.controller.processButton(data[name]);
+        }
+    }
+}
+
+KontrolZ1.shutdown = function() {
+    // Deactivate all LEDs
+    KontrolZ1.lightDeck(true);
+    print(KontrolZ1.id + " shut down");
+};
+
+KontrolZ1.incomingData = function(data, length) {
+    KontrolZ1.controller.parsePacket(data, length);
+};

--- a/res/controllers/Traktor-Kontrol-Z1-scripts.js
+++ b/res/controllers/Traktor-Kontrol-Z1-scripts.js
@@ -2,11 +2,6 @@
 // Native Instruments Traktor Kontrol Z1 HID controller script for Mixxx 2.4
 // Based on Traktor Kontrol S2 MK3 script by Michael Schmidt
 // Author: djantti
-// Last modified: 20231123
-//
-// Extra functionality:
-// Mode + FX -> Playback start / stop
-// Mode + Headphone -> Go to cue and stop
 //
 
 var KontrolZ1 = new function() {

--- a/res/controllers/Traktor-Kontrol-Z1-scripts.js
+++ b/res/controllers/Traktor-Kontrol-Z1-scripts.js
@@ -141,7 +141,7 @@ KontrolZ1.registerOutputPackets = function() {
     this.vuRightConnection = engine.makeUnbufferedConnection("[Channel2]", "vu_meter", this.vuMeterHandler);
 
     KontrolZ1.lightDeck(false);
-}
+};
 
 KontrolZ1.modeHandler = function(field) {
     KontrolZ1.modePressed = field.value;
@@ -192,7 +192,7 @@ KontrolZ1.vuMeterHandler = function(value, group, _key) {
 
 KontrolZ1.parameterHandler = function(field) {
     engine.setParameter(field.group, field.name, field.value / 4095);
-}
+};
 
 KontrolZ1.outputHandler = function(value, group, key) {
     if (value === 0 || value === false) {
@@ -225,7 +225,7 @@ KontrolZ1.lightDeck = function(switchOff) {
     KontrolZ1.controller.setOutput("[Channel1]", "pfl", current, true);
     current = engine.getValue("[Channel2]", "pfl") ? fullLight : softLight;
     KontrolZ1.controller.setOutput("[Channel2]", "pfl", current, true);
-}
+};
 
 KontrolZ1.messageCallback = function(packet, data) {
     for (const name in data) {
@@ -233,7 +233,7 @@ KontrolZ1.messageCallback = function(packet, data) {
             KontrolZ1.controller.processButton(data[name]);
         }
     }
-}
+};
 
 KontrolZ1.shutdown = function() {
     // Deactivate all LEDs


### PR DESCRIPTION
Hi Mixxx developers!

I created a new Native Instruments Traktor Kontrol Z1 HID mapping based on the official Traktor Kontrol S2 MK3 code. I've been testing it with Mixxx 2.4 branch and everything seems to work properly. It has extended features using the Mode button as a modifier (same as in Kontrol Z1 wiki page) and better support for the device LEDs. I also have a finished Mixxx manual page ready for the controller.

Features:

- All knobs, faders and VU meters functional
- Mode + FX -> Playback start / stop
- Mode + Headphone -> Go to cue and stop
- Dim standby lights for all buttons
- FX button red LEDs as momentary playback start / stop indicators

Let me know if there's something missing or if changes are needed. Thanks!