### PR TITLE
Fix beat iterator clamping 

### DIFF
--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -1017,7 +1017,9 @@ mixxx::Bpm BpmControl::updateLocalBpm() {
     const mixxx::BeatsPointer pBeats = m_pBeats;
     const FrameInfo info = frameInfo();
     if (pBeats) {
-        localBpm = pBeats->getBpmAroundPosition(info.currentPosition, kLocalBpmSpan);
+        if (info.currentPosition.isValid() && info.currentPosition != kInitialPlayPosition) {
+            localBpm = pBeats->getBpmAroundPosition(info.currentPosition, kLocalBpmSpan);
+        }
         if (!localBpm.isValid()) {
             localBpm = pBeats->getBpmInRange(mixxx::audio::kStartFramePos, info.trackEndPosition);
         }

--- a/src/engine/controls/enginecontrol.h
+++ b/src/engine/controls/enginecontrol.h
@@ -21,6 +21,13 @@ static_assert(
         mixxx::audio::FramePos::kLegacyInvalidEnginePosition == kNoTrigger,
         "Invalid engine position value mismatch");
 
+// This value is used to make sure the initial seek after loading a track is
+// not omitted. Therefore this value must be different for 0.0 or any likely
+// value for the main cue
+constexpr auto kInitialPlayPosition =
+        mixxx::audio::FramePos::fromEngineSamplePos(
+                std::numeric_limits<double>::lowest());
+
 /**
  * EngineControl is an abstract base class for objects which implement
  * functionality pertaining to EngineBuffer. An EngineControl is meant to be a

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -41,13 +41,6 @@
 namespace {
 const mixxx::Logger kLogger("EngineBuffer");
 
-// This value is used to make sure the initial seek after loading a track is
-// not omitted. Therefore this value must be different for 0.0 or any likely
-// value for the main cue
-constexpr auto kInitialPlayPosition =
-        mixxx::audio::FramePos::fromEngineSamplePos(
-                std::numeric_limits<double>::lowest());
-
 constexpr double kLinearScalerElipsis =
         1.00058; // 2^(0.01/12): changes < 1 cent allows a linear scaler
 

--- a/src/track/beats.cpp
+++ b/src/track/beats.cpp
@@ -67,8 +67,8 @@ Beats::ConstIterator Beats::ConstIterator::operator+=(Beats::ConstIterator::diff
     // Detect integer overflow in `m_beatOffset + n`
     const int maxBeatOffset = std::numeric_limits<Beats::ConstIterator::difference_type>::max();
     if (m_beatOffset > maxBeatOffset - n) {
-        qWarning() << "Beats: Iterator" << m_beatOffset << "+" << n
-                   << "would go out of possible range, capping at latest possible position.";
+        qDebug() << "Beats: Iterator" << m_beatOffset << "+" << n
+                 << "would go out of possible range, capping at latest possible position.";
         m_it = m_beats->m_markers.cend();
         m_beatOffset = maxBeatOffset;
         updateValue();
@@ -115,8 +115,8 @@ Beats::ConstIterator Beats::ConstIterator::operator-=(Beats::ConstIterator::diff
     // Detect integer overflow
     const int minBeatOffset = std::numeric_limits<Beats::ConstIterator::difference_type>::lowest();
     if (m_beatOffset < minBeatOffset + n) {
-        qWarning() << "Beats Iterator" << m_beatOffset << "-" << n
-                   << "would go out of possible range, capping at earliest possible position.";
+        qDebug() << "Beats Iterator" << m_beatOffset << "-" << n
+                 << "would go out of possible range, capping at earliest possible position.";
         m_it = m_beats->m_markers.cbegin();
         m_beatOffset = minBeatOffset;
         updateValue();

--- a/src/track/beats.cpp
+++ b/src/track/beats.cpp
@@ -67,8 +67,8 @@ Beats::ConstIterator Beats::ConstIterator::operator+=(Beats::ConstIterator::diff
     // Detect integer overflow in `m_beatOffset + n`
     const int maxBeatOffset = std::numeric_limits<Beats::ConstIterator::difference_type>::max();
     if (m_beatOffset > maxBeatOffset - n) {
-        qWarning() << "Beats: Iterator would go out of possible range, capping "
-                      "at latest possible position.";
+        qWarning() << "Beats: Iterator" << m_beatOffset << "+" << n
+                   << "would go out of possible range, capping at latest possible position.";
         m_it = m_beats->m_markers.cend();
         m_beatOffset = maxBeatOffset;
         updateValue();
@@ -115,8 +115,8 @@ Beats::ConstIterator Beats::ConstIterator::operator-=(Beats::ConstIterator::diff
     // Detect integer overflow
     const int minBeatOffset = std::numeric_limits<Beats::ConstIterator::difference_type>::lowest();
     if (m_beatOffset < minBeatOffset + n) {
-        qWarning() << "Beats: Iterator would go out of possible range, capping "
-                      "at earliest possible position.";
+        qWarning() << "Beats Iterator" << m_beatOffset << "-" << n
+                   << "would go out of possible range, capping at earliest possible position.";
         m_it = m_beats->m_markers.cbegin();
         m_beatOffset = minBeatOffset;
         updateValue();

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -77,7 +77,9 @@ class Beats : private std::enable_shared_from_this<Beats> {
         ConstIterator(const Beats* beats,
                 std::vector<BeatMarker>::const_iterator it,
                 int beatOffset)
-                : m_beats(beats), m_it(it), m_beatOffset(beatOffset) {
+                : m_beats(beats),
+                  m_it(it),
+                  m_beatOffset(beatOffset) {
             updateValue();
         }
 
@@ -133,7 +135,8 @@ class Beats : private std::enable_shared_from_this<Beats> {
         difference_type operator-(const ConstIterator& other) const;
 
         friend bool operator==(const ConstIterator& lhs, const ConstIterator& rhs) {
-            return lhs.m_beats == rhs.m_beats && lhs.m_it == rhs.m_it &&
+            return lhs.m_beats == rhs.m_beats &&
+                    lhs.m_it == rhs.m_it &&
                     lhs.m_beatOffset == rhs.m_beatOffset;
         }
 


### PR DESCRIPTION
This is the second part of the fix for https://github.com/mixxxdj/mixxx/issues/12071
It continues https://github.com/mixxxdj/mixxx/pull/12349

This PR avoids the warning about the iterator clamping and introduces a DEBUG assert for cases that must not have slipped through. 