### PR TITLE
add hotcue shift controls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1172,6 +1172,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/widget/findonwebmenuservices/findonwebmenusoundcloud.cpp
   src/widget/hexspinbox.cpp
   src/widget/paintable.cpp
+  src/widget/rightclickpushbutton.cpp
   src/widget/wanalysislibrarytableview.cpp
   src/widget/wbasewidget.cpp
   src/widget/wbattery.cpp

--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -2320,20 +2320,37 @@ WEffectChainPresetSelector::indicator:unchecked:selected,
   selection-background-color: #d2d2d2;
 }
 
-#CueDeleteButton {
-/* tall button, about the same height as cue number + label edit box */
-  width: 28px;
-  height: 46px;
-  /* make the icon slightly larger than default 16px */
-  qproperty-iconSize: 20px;
-  qproperty-icon: url(skin:/../Deere/icon/ic_delete.svg);
+WCueMenuPopup #CueDeleteButton,
+WCueMenuPopup #CueShiftEarlier,
+WCueMenuPopup #CueShiftLater {
   background-color: #3B3B3B;
   border-radius: 2px;
   outline: none;
 }
-
-#CueDeleteButton:hover {
+WCueMenuPopup #CueDeleteButton:hover,
+WCueMenuPopup #CueShiftEarlier:hover,
+WCueMenuPopup #CueShiftLater:hover {
   background-color: #4B4B4B;
+}
+
+WCueMenuPopup #CueDeleteButton {
+  width: 44px;
+  height: 28px;
+  /* make the icon slightly larger than default 16px */
+  qproperty-iconSize: 20px;
+  qproperty-icon: url(skin:/../Deere/icon/ic_delete.svg);
+}
+WCueMenuPopup #CueShiftEarlier,
+WCueMenuPopup #CueShiftLater {
+  width: 22px;
+  height: 22px;
+}
+WCueMenuPopup #CueShiftEarlier {
+  margin-right: 2px; /* is added to width */
+  qproperty-icon: url(skin:/../Deere/icon/ic_hotcues_earlier_48px.svg);
+}
+WCueMenuPopup #CueShiftLater {
+  qproperty-icon: url(skin:/../Deere/icon/ic_hotcues_later_48px.svg);
 }
 
 WRateRange {

--- a/res/skins/LateNight/palemoon/buttons/btn__beats_hotcues_earlier.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__beats_hotcues_earlier.svg
@@ -1,6 +1,6 @@
 <svg width="48" height="48" version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-  <path d="m14 3h-8v7h6v11h2z" fill="none" stroke="#000" stroke-linejoin="round" stroke-width="1.6"/>
-  <path d="m14 3h-8v7h6v11h2z" fill="#3f3d3d"/>
-  <path d="m11 20-7-4 7-4z" fill="none" stroke="#000" stroke-linejoin="round" stroke-width="1.6"/>
-  <path d="m11 20-7-4 7-4z" fill="#928476"/>
+  <path d="m16 3h-8v7h6v11h2z" fill="none" stroke="#000" stroke-linejoin="round" stroke-width="1.6"/>
+  <path d="m16 3h-8v7h6v11h2z" fill="#3f3d3d"/>
+  <path d="m13 20-7-4 7-4z" fill="none" stroke="#000" stroke-linejoin="round" stroke-width="1.6"/>
+  <path d="m13 20-7-4 7-4z" fill="#928476"/>
 </svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__beats_hotcues_earlier_active.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__beats_hotcues_earlier_active.svg
@@ -1,4 +1,4 @@
 <svg width="48" height="48" version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-  <path d="m14 3h-8v7h6v11h2z"/>
-  <path d="m11 20-7-4 7-4z"/>
+  <path d="m16 3h-8v7h6v11h2z"/>
+  <path d="m13 20-7-4 7-4z"/>
 </svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__beats_hotcues_later.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__beats_hotcues_later.svg
@@ -3,4 +3,8 @@
   <path d="m14 3h-8v7h6v11h2z" fill="#3f3d3d"/>
   <path d="m15 20 7-4-7-4z" fill="none" stroke="#000" stroke-linejoin="round" stroke-width="1.6"/>
   <path d="m15 20 7-4-7-4z" fill="#928476"/>
+  <path d="m13 3h-8v7h6v11h2z" fill="none" stroke="#000" stroke-linejoin="round" stroke-width="1.6"/>
+  <path d="m13 3h-8v7h6v11h2z" fill="#3f3d3d"/>
+  <path d="m14 20 7-4-7-4z" fill="none" stroke="#000" stroke-linejoin="round" stroke-width="1.6"/>
+  <path d="m14 20 7-4-7-4z" fill="#928476"/>
 </svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__beats_hotcues_later_active.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__beats_hotcues_later_active.svg
@@ -1,4 +1,4 @@
 <svg width="48" height="48" version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-  <path d="m14 3h-8v7h6v11h2z"/>
-  <path d="m15 20 7-4-7-4z"/>
+  <path d="m13 3h-8v7h6v11h2z"/>
+  <path d="m14 20 7-4-7-4z"/>
 </svg>

--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -1229,7 +1229,8 @@ QPushButton#pushButtonRecording:checked {
   color: #000;
 }
 
-#LibraryFeatureControls QPushButton:pressed {
+#LibraryFeatureControls QPushButton:pressed,
+WCueMenuPopup QPushButton:pressed {
   color: #999;
 }
 
@@ -1298,7 +1299,10 @@ WPushButton#FxAssignButton1[displayValue="0"],
 #SkinSettingsToggle[displayValue="0"],
 #LibraryFeatureControls QPushButton,
 WEffectSelector:!editable,
-#fadeModeCombobox:!editable {
+#fadeModeCombobox:!editable,
+WCueMenuPopup #CueDeleteButton,
+WCueMenuPopup #CueShiftEarlier,
+WCueMenuPopup #CueShiftLater {
   border-width: 2px;
   border-image: url(skin:../LateNight/classic/buttons/btn_embedded_library.svg) 2 2 2 2;
   }
@@ -1320,7 +1324,10 @@ QPushButton#pushButtonRepeatPlaylist:checked,
 QPushButton#pushButtonAnalyze:checked,
 QPushButton#pushButtonRecording:checked,
 WEffectSelector:!editable:on,
-#fadeModeCombobox:!editable:on {
+#fadeModeCombobox:!editable:on,
+WCueMenuPopup #CueDeleteButton:pressed,
+WCueMenuPopup #CueShiftEarlier:pressed,
+WCueMenuPopup #CueShiftLater:pressed {
   border-width: 2px;
   border-image: url(skin:../LateNight/classic/buttons/btn_embedded_library_active.svg) 2 2 2 2;
   }
@@ -1414,7 +1421,10 @@ QPushButton#pushButtonAutoDJ:enabled:!checked,
 WPushButton#GuiToggleButton[displayValue="0"],
 #RecFeedback[displayValue="0"],
 WPushButton#BroadcastButton[displayValue="0"],
-WPushButton#SkinSettingsToggle[displayValue="0"] {
+WPushButton#SkinSettingsToggle[displayValue="0"],
+WCueMenuPopup #CueDeleteButton,
+WCueMenuPopup #CueShiftEarlier,
+WCueMenuPopup #CueShiftLater {
   background-color: #262626;
 }
 
@@ -1999,20 +2009,33 @@ QPushButton#pushButtonRepeatPlaylist:!checked {
   }
 
 /* widgets in cue popup menu */
-#CueDeleteButton {  /*
+WCueMenuPopup #CueDeleteButton {  /*
   padding: 3px 6px; */
   qproperty-icon: url(skin:../LateNight/classic/buttons/btn__delete.svg);
   /* color buttons are 42x24 px.
   To get the final size for the Delete button consider border width.
   It's a tall button, about the same height as cue number + label edit box */
-  width: 24px;
-  height: 42px;
-  border-width: 2px;
-  border-image: url(skin:../LateNight/classic/buttons/btn_embedded_library.svg) 2 2 2 2;
+  width: 44px;
+  height: 22px;
   /* make the icon slightly larger than default 16px */
   qproperty-iconSize: 20px;
   /* has no effect
   padding: 0px; */
+}
+
+WCueMenuPopup #CueShiftEarlier,
+WCueMenuPopup #CueShiftLater {
+  /* This gives us a final size of 26x26, exactly like other square
+     buttons (decks, mixer etc.) */
+  width: 22px;
+  height: 22px;
+}
+WCueMenuPopup #CueShiftEarlier {
+  /* same as #HotcuesShiftEarlier */
+  qproperty-icon: url(skin:../LateNight/classic/buttons/btn__beats_hotcues_earlier.svg);
+}
+WCueMenuPopup #CueShiftLater {
+  qproperty-icon: url(skin:../LateNight/classic/buttons/btn__beats_hotcues_later.svg);
 }
 
 #CueLabelEdit {

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -1443,7 +1443,7 @@ WPushButton#FxAssignButton1[displayValue="0"],
 WEffectSelector:!editable,
 #fadeModeCombobox:!editable,
 #LibraryFeatureControls QPushButton:enabled,
-#CueDeleteButton {
+WCueMenuPopup QPushButton {
   outline: none;
   border-width: 2px;
   border-image: url(skin:../LateNight/palemoon/buttons/btn_embedded_library.svg) 2 2 2 2;
@@ -1463,14 +1463,14 @@ WEffectSelector:!editable,
   #BroadcastButton[displayValue="3"],
   #BroadcastButton[displayValue="4"],
   #SkinSettingsToggle[displayValue="1"],
-  #LibraryFeatureControls QPushButton:pressed
+  #LibraryFeatureControls QPushButton:pressed,
   QPushButton#pushButtonAutoDJ:checked,
   QPushButton#pushButtonRepeatPlaylist:checked,
   QPushButton#pushButtonAnalyze:checked,
   QPushButton#pushButtonRecording:checked,
   WEffectSelector:!editable:on,
   #fadeModeCombobox:!editable:on,
-  #CueDeleteButton[pressed="true"] {
+  WCueMenuPopup QPushButton:pressed {
     border-width: 2px;
     border-image: url(skin:../LateNight/palemoon/buttons/btn_embedded_library_active.svg) 2 2 2 2;
   }
@@ -1617,7 +1617,9 @@ WBeatSpinBox::down-button {
   }
   /* bright buttons in dimmed containers
   #BeatgridControls WPushButton[displayValue="0"], */
-  #CueDeleteButton,
+  WCueMenuPopup #CueDeleteButton,
+  WCueMenuPopup #CueShiftEarlier,
+  WCueMenuPopup #CueShiftLater,
   #SplitCue[displayValue="0"],
   #PlayPreview[displayValue="0"],
   /* library controls */
@@ -2475,19 +2477,34 @@ QPushButton#pushButtonRepeatPlaylist:!checked {
 
 /* widgets in cue popup menu */
 WCueMenuPopup #CueDeleteButton {
+  /* For QPushButtons, the border is added (here: 2px in each direction).
+     This sets the minimum size, the button may expand depending on the
+     layout and stretch options set in src/widget/wcuemenupopup.cpp */
+  width: 44px;
+  height: 22px;
+}
+WCueMenuPopup #CueDeleteButton {
   qproperty-icon: url(skin:../LateNight/palemoon/buttons/btn__delete.svg);
-  width: 24px;
-  height: 42px;
   /* make the icon slightly larger than default 16px */
   qproperty-iconSize: 20px;
 }
 
-WCueMenuPopup #CueDeleteButton:pressed {
-  background-color: #b24c12;
-  outline: none;
-  /* not applied: */
-  qproperty-icon: url(skin:../LateNight/palemoon/buttons/btn__delete_active.svg);
+WCueMenuPopup #CueShiftEarlier,
+WCueMenuPopup #CueShiftLater {
+  /* This gives us a final size of 26x26, exactly like other square
+     buttons (decks, mixer etc.) */
+  width: 22px;
+  height: 22px;
+  qproperty-iconSize: 24px;
 }
+WCueMenuPopup #CueShiftEarlier {
+  /* same as #HotcuesShiftEarlier */
+  qproperty-icon: url(skin:../LateNight/palemoon/buttons/btn__beats_hotcues_earlier.svg);
+}
+WCueMenuPopup #CueShiftLater {
+  qproperty-icon: url(skin:../LateNight/palemoon/buttons/btn__beats_hotcues_later.svg);
+}
+
 WCueMenuPopup #CueLabelEdit {
   /*border: 1px solid #c2b3a5;*/
   border-radius: 0px;

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -426,19 +426,27 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
     // Hotcues
     QMenu* hotcueMainMenu = addSubmenu(tr("Hotcues"));
     QString hotcueActivateTitle = tr("Hotcue %1");
-    QString hotcueClearTitle = tr("Clear Hotcue %1");
-    QString hotcueSetTitle = tr("Set Hotcue %1");
-    QString hotcueGotoTitle = tr("Jump To Hotcue %1");
-    QString hotcueGotoAndStopTitle = tr("Jump To Hotcue %1 And Stop");
-    QString hotcueGotoAndPlayTitle = tr("Jump To Hotcue %1 And Play");
-    QString hotcuePreviewTitle = tr("Preview Hotcue %1");
     QString hotcueActivateDescription = tr("Set, preview from or jump to hotcue %1");
+    QString hotcueClearTitle = tr("Clear Hotcue %1");
     QString hotcueClearDescription = tr("Clear hotcue %1");
+    QString hotcueSetTitle = tr("Set Hotcue %1");
     QString hotcueSetDescription = tr("Set hotcue %1");
+    QString hotcueGotoTitle = tr("Jump To Hotcue %1");
     QString hotcueGotoDescription = tr("Jump to hotcue %1");
+    QString hotcueGotoAndStopTitle = tr("Jump To Hotcue %1 And Stop");
     QString hotcueGotoAndStopDescription = tr("Jump to hotcue %1 and stop");
     QString hotcueGotoAndPlayDescription = tr("Jump to hotcue %1 and play");
+    QString hotcueGotoAndPlayTitle = tr("Jump To Hotcue %1 And Play");
+    QString hotcuePreviewTitle = tr("Preview Hotcue %1");
     QString hotcuePreviewDescription = tr("Preview from hotcue %1");
+    QString hotcueShiftEarlierTitle = tr("Shift hotcue %1 earlier");
+    QString hotcueShiftEarlierDescription = tr(
+            "Shift hotcue %1 10 milliseconds earlier, "
+            "or to the previous beat if quatize is enabled");
+    QString hotcueShiftLaterTitle = tr("Shift hotcue %1 later");
+    QString hotcueShiftLaterDescription = tr(
+            "Shift hotcue %1 10 milliseconds later, "
+            "or to the next beat if quatize is enabled");
     addDeckControl("shift_cues_earlier",
             tr("Shift cue points earlier"),
             tr("Shift cue points 10 milliseconds earlier"),
@@ -501,6 +509,14 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
         addDeckAndSamplerControl(QString("hotcue_%1_activate_preview").arg(i),
                 hotcuePreviewTitle.arg(QString::number(i)),
                 hotcuePreviewDescription.arg(QString::number(i)),
+                hotcueSubMenu);
+        addDeckAndSamplerControl(QString("hotcue_%1_shift_earlier").arg(i),
+                hotcueShiftEarlierTitle.arg(QString::number(i)),
+                hotcueShiftEarlierDescription.arg(QString::number(i)),
+                hotcueSubMenu);
+        addDeckAndSamplerControl(QString("hotcue_%1_shift_later").arg(i),
+                hotcueShiftLaterTitle.arg(QString::number(i)),
+                hotcueShiftLaterDescription.arg(QString::number(i)),
                 hotcueSubMenu);
     }
     if (moreHotcues) {

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -1,5 +1,6 @@
 #include "engine/controls/cuecontrol.h"
 
+#include "control/controlencoder.h"
 #include "control/controlindicator.h"
 #include "control/controlobject.h"
 #include "control/controlpushbutton.h"
@@ -2589,6 +2590,13 @@ HotcueControl::HotcueControl(const QString& group, int hotcueIndex)
             &HotcueControl::slotHotcueClear,
             Qt::DirectConnection);
 
+    m_hotcueShift = std::make_unique<ControlEncoder>(
+            keyForControl(QStringLiteral("shift")), false);
+    connect(m_hotcueShift.get(),
+            &ControlEncoder::valueChanged,
+            this,
+            &HotcueControl::slotHotcueShift,
+            Qt::DirectConnection);
     m_hotcueShiftEarlier = std::make_unique<ControlPushButton>(
             keyForControl(QStringLiteral("shift_earlier")));
     connect(m_hotcueShiftEarlier.get(),
@@ -2660,6 +2668,13 @@ void HotcueControl::slotHotcueActivatePreview(double v) {
 
 void HotcueControl::slotHotcueClear(double v) {
     emit hotcueClear(this, v);
+}
+
+void HotcueControl::slotHotcueShift(double v) {
+    if (v == 0) {
+        return;
+    }
+    emit hotcueShift(this, static_cast<int>(v));
 }
 
 void HotcueControl::slotHotcueShiftEarlier(double v) {

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -2790,6 +2790,7 @@ void HotcueControl::setColor(mixxx::RgbColor::optional_t newColor) {
         m_hotcueColor->set(*newColor);
     }
 }
+
 void HotcueControl::resetCue() {
     // clear pCue first because we have a null check for valid data else where
     // in the code

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -245,6 +245,8 @@ class CueControl : public EngineControl {
     void hotcueFocusColorNext(double v);
     void hotcueFocusColorPrev(double v);
 
+    void slotShiftFocusedHotcue(double v);
+
     void passthroughChanged(double v);
 
     void cueSet(double v);
@@ -366,6 +368,8 @@ class CueControl : public EngineControl {
     std::unique_ptr<ControlObject> m_pHotcueFocus;
     std::unique_ptr<ControlObject> m_pHotcueFocusColorNext;
     std::unique_ptr<ControlObject> m_pHotcueFocusColorPrev;
+
+    std::unique_ptr<ControlEncoder> m_pShiftFocusedHotcue;
 
     parented_ptr<ControlProxy> m_pPassthrough;
 

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -135,6 +135,8 @@ class HotcueControl : public QObject {
     void slotHotcueActivateLoop(double v);
     void slotHotcueActivatePreview(double v);
     void slotHotcueClear(double v);
+    void slotHotcueShiftEarlier(double v);
+    void slotHotcueShiftLater(double v);
     void slotHotcueEndPositionChanged(double newPosition);
     void slotHotcuePositionChanged(double newPosition);
     void slotHotcueColorChangeRequest(double newColor);
@@ -150,6 +152,7 @@ class HotcueControl : public QObject {
     void hotcueActivate(HotcueControl* pHotcue, double v, HotcueSetMode mode);
     void hotcueActivatePreview(HotcueControl* pHotcue, double v);
     void hotcueClear(HotcueControl* pHotcue, double v);
+    void hotcueShift(HotcueControl* pHotcue, int direction);
     void hotcuePositionChanged(HotcueControl* pHotcue, double newPosition);
     void hotcueEndPositionChanged(HotcueControl* pHotcue, double newEndPosition);
     void hotcueColorChanged(HotcueControl* pHotcue, double newColor);
@@ -182,6 +185,8 @@ class HotcueControl : public QObject {
     std::unique_ptr<ControlPushButton> m_hotcueActivateLoop;
     std::unique_ptr<ControlPushButton> m_hotcueActivatePreview;
     std::unique_ptr<ControlPushButton> m_hotcueClear;
+    std::unique_ptr<ControlPushButton> m_hotcueShiftEarlier;
+    std::unique_ptr<ControlPushButton> m_hotcueShiftLater;
 
     ControlValueAtomic<mixxx::CueType> m_previewingType;
     ControlValueAtomic<mixxx::audio::FramePos> m_previewingPosition;
@@ -229,6 +234,7 @@ class CueControl : public EngineControl {
     void hotcueActivatePreview(HotcueControl* pControl, double v);
     void updateCurrentlyPreviewingIndex(int hotcueIndex);
     void hotcueClear(HotcueControl* pControl, double v);
+    void hotcueShift(HotcueControl* pHotcue, int direction);
     void hotcuePositionChanged(HotcueControl* pControl, double newPosition);
     void hotcueEndPositionChanged(HotcueControl* pControl, double newEndPosition);
 

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -375,9 +375,6 @@ class CueControl : public EngineControl {
 
     QAtomicPointer<HotcueControl> m_pCurrentSavedLoopControl;
 
-    // Tells us which controls map to which hotcue
-    QMap<QObject*, int> m_controlMap;
-
     // Must be locked when using the m_pLoadedTrack and it's properties
     QT_RECURSIVE_MUTEX m_trackMutex;
     TrackPointer m_pLoadedTrack; // is written from an engine worker thread

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -18,6 +18,7 @@
 
 class ControlObject;
 class ControlPushButton;
+class ControlEncoder;
 class ControlIndicator;
 class ControlProxy;
 
@@ -135,6 +136,7 @@ class HotcueControl : public QObject {
     void slotHotcueActivateLoop(double v);
     void slotHotcueActivatePreview(double v);
     void slotHotcueClear(double v);
+    void slotHotcueShift(double v);
     void slotHotcueShiftEarlier(double v);
     void slotHotcueShiftLater(double v);
     void slotHotcueEndPositionChanged(double newPosition);
@@ -185,6 +187,8 @@ class HotcueControl : public QObject {
     std::unique_ptr<ControlPushButton> m_hotcueActivateLoop;
     std::unique_ptr<ControlPushButton> m_hotcueActivatePreview;
     std::unique_ptr<ControlPushButton> m_hotcueClear;
+
+    std::unique_ptr<ControlEncoder> m_hotcueShift;
     std::unique_ptr<ControlPushButton> m_hotcueShiftEarlier;
     std::unique_ptr<ControlPushButton> m_hotcueShiftLater;
 

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -20,8 +20,6 @@
 namespace {
 
 constexpr double kNoTrackColor = -1;
-constexpr double kShiftCuesOffsetMillis = 10;
-constexpr double kShiftCuesOffsetSmallMillis = 1;
 const QString kEffectGroupFormat = QStringLiteral("[EqualizerRack1_%1_Effect1]");
 
 inline double trackColorToDouble(mixxx::RgbColor::optional_t color) {
@@ -173,20 +171,24 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(
     connect(m_pShiftCuesEarlier.get(),
             &ControlObject::valueChanged,
             this,
-            [this](double value) { slotShiftCuesMillisButton(value, -kShiftCuesOffsetMillis); });
+            [this](double value) {
+                slotShiftCuesMillisButton(value, -Cue::kShiftCuesOffsetMillis);
+            });
     m_pShiftCuesLater = std::make_unique<ControlPushButton>(
             ConfigKey(getGroup(), "shift_cues_later"));
     connect(m_pShiftCuesLater.get(),
             &ControlObject::valueChanged,
             this,
-            [this](double value) { slotShiftCuesMillisButton(value, kShiftCuesOffsetMillis); });
+            [this](double value) {
+                slotShiftCuesMillisButton(value, Cue::kShiftCuesOffsetMillis);
+            });
     m_pShiftCuesEarlierSmall = std::make_unique<ControlPushButton>(
             ConfigKey(getGroup(), "shift_cues_earlier_small"));
     connect(m_pShiftCuesEarlierSmall.get(),
             &ControlObject::valueChanged,
             this,
             [this](double value) {
-                slotShiftCuesMillisButton(value, -kShiftCuesOffsetSmallMillis);
+                slotShiftCuesMillisButton(value, -Cue::kShiftCuesOffsetSmallMillis);
             });
     m_pShiftCuesLaterSmall = std::make_unique<ControlPushButton>(
             ConfigKey(getGroup(), "shift_cues_later_small"));
@@ -194,7 +196,7 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(
             &ControlObject::valueChanged,
             this,
             [this](double value) {
-                slotShiftCuesMillisButton(value, kShiftCuesOffsetSmallMillis);
+                slotShiftCuesMillisButton(value, Cue::kShiftCuesOffsetSmallMillis);
             });
     m_pShiftCues = std::make_unique<ControlObject>(
             ConfigKey(getGroup(), "shift_cues"));

--- a/src/track/cue.h
+++ b/src/track/cue.h
@@ -22,6 +22,9 @@ class Cue : public QObject {
     /// Invalid hot cue index
     static constexpr int kNoHotCue = -1;
 
+    static constexpr double kShiftCuesOffsetMillis = 10;
+    static constexpr double kShiftCuesOffsetSmallMillis = 1;
+
     static_assert(kNoHotCue != mixxx::kFirstHotCueIndex,
             "Conflicting definitions of invalid and first hot cue index");
 

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -290,6 +290,9 @@ class Track : public QObject {
     void setMainCuePosition(mixxx::audio::FramePos position);
     /// Shift all cues by a constant offset
     void shiftCuePositionsMillis(mixxx::audio::FrameDiff_t milliseconds);
+    /// Shift a single cue point
+    void shiftCuePositionMillis(const CuePointer& pCue, mixxx::audio::FrameDiff_t milliseconds);
+    void shiftCuePositionBeats(const CuePointer& pCue, int direction);
     // Call when analysis is done.
     void analysisFinished();
 

--- a/src/widget/rightclickpushbutton.cpp
+++ b/src/widget/rightclickpushbutton.cpp
@@ -1,0 +1,16 @@
+#include "widget/rightclickpushbutton.h"
+
+#include <QMouseEvent>
+
+#include "moc_rightclickpushbutton.cpp"
+
+RightClickPushButton::RightClickPushButton(const QString& text,
+        QWidget* parent)
+        : QPushButton(text, parent) {
+}
+
+void RightClickPushButton::mousePressEvent(QMouseEvent* event) {
+    if (event->button() == Qt::RightButton) {
+        emit rightClicked();
+    }
+}

--- a/src/widget/rightclickpushbutton.h
+++ b/src/widget/rightclickpushbutton.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <QPushButton>
+
+class RightClickPushButton : public QPushButton {
+    Q_OBJECT
+  public:
+    explicit RightClickPushButton(const QString& text, QWidget* parent = nullptr);
+
+  private slots:
+    void mousePressEvent(QMouseEvent* event) override;
+
+  signals:
+    void rightClicked();
+};

--- a/src/widget/wcuemenupopup.cpp
+++ b/src/widget/wcuemenupopup.cpp
@@ -14,6 +14,14 @@ WCueMenuPopup::WCueMenuPopup(UserSettingsPointer pConfig, QWidget* parent)
     setAttribute(Qt::WA_StyledBackground);
     setObjectName("WCueMenuPopup");
 
+    // TODO Improve / polish Tab key navigation:
+    // Order of widget creation apearantly determines the Tab key navigation order.
+    // We may create the Delete and Shift buttons before the color picker so they're
+    // first after the edit label. That way, if we want to delete or shift a cue
+    // via keyboard we don't need to skip through the entire color button grid first.
+    // Proper styles need to be added (per skin), e.g. remove 'outline: none' or
+    // add a custom border to WCueMenuPopup QPushButton:focus.
+
     m_pCueNumber = new QLabel(this);
     m_pCueNumber->setToolTip(tr("Cue number"));
     m_pCueNumber->setObjectName("CueNumberLabel");

--- a/src/widget/wcuemenupopup.cpp
+++ b/src/widget/wcuemenupopup.cpp
@@ -49,7 +49,7 @@ WCueMenuPopup::WCueMenuPopup(UserSettingsPointer pConfig, const QString& group, 
     m_pDeleteCue->setObjectName("CueDeleteButton");
     connect(m_pDeleteCue, &QPushButton::clicked, this, &WCueMenuPopup::slotDeleteCue);
 
-    m_pShiftCueEarlier = new QPushButton("", this);
+    m_pShiftCueEarlier = new RightClickPushButton("", this);
     m_pShiftCueEarlier->setToolTip(tr(
             "Shift this cue backwards by %1 milliseconds.\n"
             "If quantize is enabled shift this cue to the previous beat.")
@@ -61,7 +61,13 @@ WCueMenuPopup::WCueMenuPopup(UserSettingsPointer pConfig, const QString& group, 
             [this]() {
                 slotShiftCue(-1);
             });
-    m_pShiftCueLater = new QPushButton("", this);
+    connect(m_pShiftCueEarlier,
+            &RightClickPushButton::rightClicked,
+            this,
+            [this]() {
+                slotShiftCueSmall(-1);
+            });
+    m_pShiftCueLater = new RightClickPushButton("", this);
     m_pShiftCueLater->setToolTip(tr(
             "Shift this cue forwards by %1 milliseconds.\n"
             "If quantize is enabled shift this cue to the next beat.")
@@ -72,6 +78,12 @@ WCueMenuPopup::WCueMenuPopup(UserSettingsPointer pConfig, const QString& group, 
             this,
             [this]() {
                 slotShiftCue(1);
+            });
+    connect(m_pShiftCueLater,
+            &RightClickPushButton::rightClicked,
+            this,
+            [this]() {
+                slotShiftCueSmall(1);
             });
 
     QHBoxLayout* pLabelLayout = new QHBoxLayout();
@@ -193,6 +205,20 @@ void WCueMenuPopup::slotShiftCue(int direction) {
     } else {
         m_pTrack->shiftCuePositionMillis(m_pCue, Cue::kShiftCuesOffsetMillis * direction);
     }
+}
+
+void WCueMenuPopup::slotShiftCueSmall(int direction) {
+    VERIFY_OR_DEBUG_ASSERT(m_pCue != nullptr) {
+        return;
+    }
+    VERIFY_OR_DEBUG_ASSERT(m_pTrack != nullptr) {
+        return;
+    }
+    if (direction == 0) {
+        return;
+    }
+
+    m_pTrack->shiftCuePositionMillis(m_pCue, Cue::kShiftCuesOffsetSmallMillis * direction);
 }
 
 void WCueMenuPopup::closeEvent(QCloseEvent* event) {

--- a/src/widget/wcuemenupopup.h
+++ b/src/widget/wcuemenupopup.h
@@ -9,6 +9,7 @@
 #include "track/cue.h"
 #include "track/track_decl.h"
 #include "util/widgethelper.h"
+#include "widget/rightclickpushbutton.h"
 #include "widget/wcolorpicker.h"
 
 class WCueMenuPopup : public QWidget {
@@ -54,6 +55,7 @@ class WCueMenuPopup : public QWidget {
     void slotEditLabel();
     void slotDeleteCue();
     void slotShiftCue(int direction);
+    void slotShiftCueSmall(int direction);
     void slotChangeCueColor(mixxx::RgbColor::optional_t color);
 
   private:
@@ -66,8 +68,8 @@ class WCueMenuPopup : public QWidget {
     QLineEdit* m_pEditLabel;
     WColorPicker* m_pColorPicker;
     QPushButton* m_pDeleteCue;
-    QPushButton* m_pShiftCueEarlier;
-    QPushButton* m_pShiftCueLater;
+    RightClickPushButton* m_pShiftCueEarlier;
+    RightClickPushButton* m_pShiftCueLater;
 
     PollingControlProxy m_pQuantize;
 

--- a/src/widget/wcuemenupopup.h
+++ b/src/widget/wcuemenupopup.h
@@ -4,6 +4,7 @@
 #include <QLineEdit>
 #include <QPushButton>
 
+#include "control/pollingcontrolproxy.h"
 #include "preferences/colorpalettesettings.h"
 #include "track/cue.h"
 #include "track/track_decl.h"
@@ -13,7 +14,7 @@
 class WCueMenuPopup : public QWidget {
     Q_OBJECT
   public:
-    WCueMenuPopup(UserSettingsPointer pConfig, QWidget* parent = nullptr);
+    WCueMenuPopup(UserSettingsPointer pConfig, const QString& group, QWidget* parent = nullptr);
 
     ~WCueMenuPopup() {
         delete m_pCueNumber;
@@ -52,6 +53,7 @@ class WCueMenuPopup : public QWidget {
   private slots:
     void slotEditLabel();
     void slotDeleteCue();
+    void slotShiftCue(int direction);
     void slotChangeCueColor(mixxx::RgbColor::optional_t color);
 
   private:
@@ -64,6 +66,10 @@ class WCueMenuPopup : public QWidget {
     QLineEdit* m_pEditLabel;
     WColorPicker* m_pColorPicker;
     QPushButton* m_pDeleteCue;
+    QPushButton* m_pShiftCueEarlier;
+    QPushButton* m_pShiftCueLater;
+
+    PollingControlProxy m_pQuantize;
 
   protected:
     void closeEvent(QCloseEvent* event) override;

--- a/src/widget/whotcuebutton.cpp
+++ b/src/widget/whotcuebutton.cpp
@@ -46,7 +46,7 @@ void WHotcueButton::setup(const QDomNode& node, const SkinContext& context) {
 
     m_hoverCueColor = context.selectBool(node, QStringLiteral("Hover"), false);
 
-    m_pCueMenuPopup = make_parented<WCueMenuPopup>(context.getConfig(), this);
+    m_pCueMenuPopup = make_parented<WCueMenuPopup>(context.getConfig(), m_group, this);
     ColorPaletteSettings colorPaletteSettings(context.getConfig());
     auto colorPalette = colorPaletteSettings.getHotcueColorPalette();
     m_pCueMenuPopup->setColorPalette(colorPalette);

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -38,7 +38,7 @@ WOverview::WOverview(
           m_pConfig(pConfig),
           m_endOfTrack(false),
           m_bPassthroughEnabled(false),
-          m_pCueMenuPopup(make_parented<WCueMenuPopup>(pConfig, this)),
+          m_pCueMenuPopup(make_parented<WCueMenuPopup>(pConfig, group, this)),
           m_bShowCueTimes(true),
           m_iPosSeconds(0),
           m_bLeftClickDragging(false),

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -22,7 +22,7 @@ WWaveformViewer::WWaveformViewer(
           m_zoomZoneWidth(20),
           m_bScratching(false),
           m_bBending(false),
-          m_pCueMenuPopup(make_parented<WCueMenuPopup>(pConfig, this)),
+          m_pCueMenuPopup(make_parented<WCueMenuPopup>(pConfig, group, this)),
           m_waveformWidget(nullptr) {
     setMouseTracking(true);
     setAcceptDrops(true);


### PR DESCRIPTION
This PR adds
* `hotcue_N_shift_earlier` and `hotcue_N_shift_later`, incl. entry in the control picker menu
(not supposed to be used in skins, hence no tooltip)
* respective buttons to the hotcue menu popup
* ControlEncoder `hotcue_N_shift` for easy encoder mapping
* ControlEncoder `group,shift_focused_hotcue` to allow cramming it into dense mappings¹

The controls shift the cue by 10ms or, if `quantize` is enabled, to the previous / next beat. It is not checked whether the cue is already quantized.

![image](https://github.com/mixxxdj/mixxx/assets/5934199/870b33ea-f8a8-43cf-904d-af93caead812)


**ToDo**
- [ ] style WCueMenuPopup controls in all skins

¹I considered creating a control that can address ANY cue (main cue, hotcues, intro, outro) by looking up the cue closest to the play position, but it requires more complex (debatable) code, and even though it may be useful I think it's not required since
1. the clear/set controls for the main cue, intro and outro are a bit more accessible than those for the hotcues (in the GUI)
2. I think there's more demand during performance being able to re-set hotcues than the intro/outro.

Fixes both #10812 (nudge) and #12367 (shift by one beat)