### PR TITLE
controllers: add helper to control "waveform_zoom" with potmeters

### DIFF
--- a/res/controllers/KANE_QuNeo_scripts.js
+++ b/res/controllers/KANE_QuNeo_scripts.js
@@ -888,9 +888,8 @@ KANE_QuNeo.closeSliderMode = function () {
 KANE_QuNeo.deckZoom = function (deck, value) {
     var channel = deck - 1; // track channels start at 0 to properly reference arrays
     var channelName = KANE_QuNeo.getChannelName(deck)
-    var normalized = Math.ceil(6 * ((127 - value) / 127))
     // adjust zoom
-    engine.setValue(channelName, "waveform_zoom", normalized)
+    script.waveformZoom(group, value, true);
 }
 
 KANE_QuNeo.deckCursor = function (deck, value) {
@@ -2347,8 +2346,10 @@ KANE_QuNeo.masterVuMeter = function (value) {
 // Sliders
 KANE_QuNeo.deckZoomLEDs = function (deck, value) {
     var LEDGroup = KANE_QuNeo.getLEDGroup(deck);
+    // TODO Add script.zoomToMidiValue() ?
     // normalize zoom LED value to be 0-127
-    var zoom = ((value - 1) / 5) * 127
+    // get range from src/waveform/renderers/waveformwidgetrenderer.cpp
+    var zoom = ((value - 1) / 9) * 127
     // determine which control we are manipulating
     var control = KANE_QuNeo.getSliderControl(deck, 0)
     // emit message

--- a/res/controllers/Korg-nanoKONTROL-2-scripts.js
+++ b/res/controllers/Korg-nanoKONTROL-2-scripts.js
@@ -506,13 +506,9 @@ NK2.toggleBinaryControlAll = function toggleBinaryControlAll(control){
 NK2.wavezoomAll = function wavezoomAll(value){
     if (NK2.debug>2){print("##function: "+NK2.getFunctionName())};
 
-    var range=6-1;
-    var newValue=Math.round(1+((value/127)*range));
-    if (newValue>6)newValue=6;
-    if (newValue<1)newValue=1;
     if (NK2.lastwavevalue!=value){
-        for (var i=1; i<9; i++){
-            engine.setValue(NK2.Deck[i], "waveform_zoom", newValue);
+        for (var i=1; i<=NK2.numDecks; i++){
+            script.waveformZoom(NK2.Deck[i], value, true);
         };
     }
     NK2.lastwavevalue=value;
@@ -522,12 +518,8 @@ NK2.wavezoomDeck = function wavezoomDeck(value, group){
     if (NK2.debug>2){print("##function: "+NK2.getFunctionName())};
     if (group=="default"){group=NK2.Deck[NK2.curDeck];};
 
-    var range=6-1;
-    var newValue=Math.round(1+((value/127)*range));
-    if (newValue>6)newValue=6;
-    if (newValue<1)newValue=1;
     if (NK2.lastwavevalue!=value){
-        engine.setValue(group, "waveform_zoom", newValue);
+        script.waveformZoom(group, value, true);
     }
     NK2.lastwavevalue=value;
     }

--- a/res/controllers/Novation-Launchpad MK2-scripts.js
+++ b/res/controllers/Novation-Launchpad MK2-scripts.js
@@ -4410,7 +4410,8 @@ var NLMK2 = (function () {
 	    waveform_zoom: {
 	      group: `[${type}${i}]`,
 	      name: 'waveform_zoom',
-	      type: '1.0 - 6.0'
+             // get range from src/waveform/renderers/waveformwidgetrenderer.cpp
+	      type: '1.0 - 10.0'
 	    },
 	    waveform_zoom_up: {
 	      group: `[${type}${i}]`,

--- a/res/controllers/Novation-Launchpad Mini MK3-scripts.js
+++ b/res/controllers/Novation-Launchpad Mini MK3-scripts.js
@@ -4410,7 +4410,8 @@ var NLMMK3 = (function () {
 	    waveform_zoom: {
 	      group: `[${type}${i}]`,
 	      name: 'waveform_zoom',
-	      type: '1.0 - 6.0'
+             // get range from src/waveform/renderers/waveformwidgetrenderer.cpp
+	      type: '1.0 - 10.0'
 	    },
 	    waveform_zoom_up: {
 	      group: `[${type}${i}]`,

--- a/res/controllers/Novation-Launchpad-Mini-scripts.js
+++ b/res/controllers/Novation-Launchpad-Mini-scripts.js
@@ -337,7 +337,8 @@ function ZoomKey(dir) {
     that.onPushOrig = that.onPush;
     that.onPush = function()
     {
-        if ( ZoomKey.zoom < 6 && this.dir == "+" ) {
+        // get range from src/waveform/renderers/waveformwidgetrenderer.cpp
+        if ( ZoomKey.zoom < 10 && this.dir == "+" ) {
             ZoomKey.zoom++;
         }
         if ( ZoomKey.zoom > 1 && this.dir == "-") {

--- a/res/controllers/Novation-Launchpad-scripts.js
+++ b/res/controllers/Novation-Launchpad-scripts.js
@@ -4410,7 +4410,8 @@ var NLMK1 = (function () {
 	    waveform_zoom: {
 	      group: `[${type}${i}]`,
 	      name: 'waveform_zoom',
-	      type: '1.0 - 6.0'
+             // get range from src/waveform/renderers/waveformwidgetrenderer.cpp
+	      type: '1.0 - 10.0'
 	    },
 	    waveform_zoom_up: {
 	      group: `[${type}${i}]`,

--- a/res/controllers/common-controller-scripts.js
+++ b/res/controllers/common-controller-scripts.js
@@ -32,7 +32,6 @@ String.prototype.toInt = function() {
 
 /**
  * Prints a message to the terminal and the log file.
- *
  * @param {string} message - The log message.
  * @deprecated Use console.log()/console.warn()/console.debug() instead.
  */
@@ -378,6 +377,27 @@ script.crossfaderCurve = function(value, min, max) {
         engine.setValue("[Mixer Profile]", "xFaderCurve",
             script.absoluteLin(value, 1, 2, min, max));
     }
+};
+
+/* -------- ------------------------------------------------------
+     script.waveformZoom
+   Purpose: Adjusts the wavform zoom level with a pot (0 <= value <= 127)
+            "waveform_zoom" behaves like a ControlPotmeter but is actually
+            a ControlObject (no min, max or default), so we need to calculate
+            the scaled with script.absoluteLin().
+            Range is set in waveform/renderers/waveformwidgetrenderer.cpp
+   Input:   Deck group,
+            current value of the hardware control,
+            round: false (default if missing) for linear/smooth scaling or
+            true for stepped scaling (like _up/_down controls)
+   Output:  none
+   -------- ------------------------------------------------------ */
+script.waveformZoom = function(group, value, round) {
+    let scaledValue = script.absoluteLin(value, 1, 10, 0, 127);
+    if (round) {
+        scaledValue = Math.round(scaledValue);
+    }
+    engine.setValue(group, "waveform_zoom", scaledValue);
 };
 
 /* -------- ------------------------------------------------------

--- a/src/control/controleffectknob.cpp
+++ b/src/control/controleffectknob.cpp
@@ -8,7 +8,7 @@ ControlEffectKnob::ControlEffectKnob(const ConfigKey& key, double dMinValue, dou
         : ControlPotmeter(key, dMinValue, dMaxValue) {
 }
 
-void ControlEffectKnob::setBehaviour(EffectManifestParameter::ValueScaler type,
+void ControlEffectKnob::setBehavior(EffectManifestParameter::ValueScaler type,
         double dMinValue,
         double dMaxValue) {
     if (m_pControl == nullptr) {

--- a/src/control/controleffectknob.h
+++ b/src/control/controleffectknob.h
@@ -8,7 +8,7 @@ class ControlEffectKnob : public ControlPotmeter {
   public:
     ControlEffectKnob(const ConfigKey& key, double dMinValue = 0.0, double dMaxValue = 1.0);
 
-    void setBehaviour(EffectManifestParameter::ValueScaler type,
+    void setBehavior(EffectManifestParameter::ValueScaler type,
             double dMinValue,
             double dMaxValue);
 };

--- a/src/effects/effectknobparameterslot.cpp
+++ b/src/effects/effectknobparameterslot.cpp
@@ -71,7 +71,7 @@ void EffectKnobParameterSlot::loadParameter(EffectParameterPointer pEffectParame
         m_pManifestParameter = m_pEffectParameter->manifest();
 
         EffectManifestParameter::ValueScaler type = m_pManifestParameter->valueScaler();
-        m_pControlValue->setBehaviour(type,
+        m_pControlValue->setBehavior(type,
                 m_pManifestParameter->getMinimum(),
                 m_pManifestParameter->getMaximum());
         m_pControlValue->setDefaultValue(m_pManifestParameter->getDefault());

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -666,7 +666,7 @@ void LoopingControl::setLoop(mixxx::audio::FramePos startPosition,
     // Seek back to loop in position if we're already behind the loop end.
     //
     // TODO(Holzhaus): This needs to be reverted as soon as GUI controls for
-    // controlling saved loop behaviour are in place, because this change makes
+    // controlling saved loop behavior are in place, because this change makes
     // saved loops very risky to use and might potentially mess up your mix.
     // See https://github.com/mixxxdj/mixxx/pull/2194#issuecomment-721847833
     // for details.

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1101,7 +1101,7 @@ void EngineBuffer::processTrackLocked(
     // If we're repeating and crossed the track boundary, ReadAheadManager already
     // wrapped around the playposition.
     // To ensure quantize is respected we request a phase sync.
-    // TODO(ronso) This just restores previous repeat+quantize behaviour. I'm not
+    // TODO(ronso) This just restores previous repeat+quantize behavior. I'm not
     // sure whether that was actually desired or just a side effect of seeking.
     // Ife it's really desired, should this be moved to looping control in order
     // to set the sync'ed playposition right away and fill the wrap-around buffer

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -679,7 +679,7 @@ void LibraryControl::slotMoveVertical(double v) {
     }
     case FocusWidget::Searchbar:
         // There's also m_pSearchbox->slotMoveSelectedHistory but that wraps around
-        // at top/bottom. Doesn't match Up/Down key behaviour and may not be desired.
+        // at top/bottom. Doesn't match Up/Down key behavior and may not be desired.
         // Proceed and let emitkeyEvent deal with it.
         break;
     case FocusWidget::None:

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -140,9 +140,12 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(
             this,
             &BaseTrackPlayerImpl::slotLoadTrackFromSampler);
 
-    // Waveform controls
-    // This acts somewhat like a ControlPotmeter, but the normal _up/_down methods
-    // do not work properly with this CO.
+    // Waveform zoom controls
+    // This acts somewhat like a ControlPotmeter, but the normal ControlPotmeter's
+    // _up/_down methods would not work properly with this CO. Instead, _up/_down,
+    // scroll wheel ticks sent to the waveform widget and the default zoom level
+    // combobox in the waveform preferences page set discrete zoom levels
+    // (integer values of "waveform_zoom").
     m_pWaveformZoom =
             std::make_unique<ControlObject>(ConfigKey(getGroup(), "waveform_zoom"));
     m_pWaveformZoom->connectValueChangeRequest(this,

--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -45,7 +45,7 @@ Q_IMPORT_PLUGIN(QGifPlugin)
 namespace {
 
 /// This class allows to change the button of a mouse event on the fly.
-/// This is required because we want to change the behaviour of Qts mouse
+/// This is required because we want to change the behavior of Qts mouse
 /// buttony synthesizer without duplicate all the code.
 class QMouseEventEditable : public QMouseEvent {
   public:

--- a/src/track/serato/beatgrid.cpp
+++ b/src/track/serato/beatgrid.cpp
@@ -18,7 +18,7 @@ QByteArray base64encode(const QByteArray& data, bool chopPadding) {
     QByteArray dataBase64;
 
     // Serato inserts a newline char after every 72 bytes of base64-encoded
-    // content.  To mirror that behaviour, we can split the data into blocks of
+    // content. To mirror that behavior, we can split the data into blocks of
     // 72 bytes * 3/4 = 54 bytes and base64-encode them one at a time.
     int offset = 0;
     while (offset < data.size()) {

--- a/src/track/serato/tags.cpp
+++ b/src/track/serato/tags.cpp
@@ -227,7 +227,7 @@ QList<CueInfo> SeratoTags::getCueInfos() const {
         // cues. If a cue is not set, that entry is present but empty.
         // If a cue is set in "Serato Markers2" but not in "Serato Markers_",
         // Serato DJ Pro considers it as "not set" and ignores it.
-        // To mirror the behaviour of Serato, we need to remove from the output of
+        // To mirror the behavior of Serato, we need to remove from the output of
         // this function.
         QSet<int> unsetCuesInMarkersTag;
         unsetCuesInMarkersTag.reserve(kNumCuesInMarkersTag);

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -10,6 +10,8 @@
 #include "waveform/visualplayposition.h"
 #include "waveform/waveform.h"
 
+// When changing these zoom values remember to also adjust the range in
+// script.waveformZoom in /res/controllers/common-controller-scripts.js
 const double WaveformWidgetRenderer::s_waveformMinZoom = 1.0;
 const double WaveformWidgetRenderer::s_waveformMaxZoom = 10.0;
 const double WaveformWidgetRenderer::s_waveformDefaultZoom = 3.0;

--- a/src/widget/openglwindow.cpp
+++ b/src/widget/openglwindow.cpp
@@ -39,9 +39,9 @@ void OpenGLWindow::paintGL() {
 void OpenGLWindow::resizeGL(int w, int h) {
     if (m_pWidget) {
         // QGLWidget::resizeGL has a valid context (QOpenGLWindow::resizeGL does not), so we
-        // mimic the same behaviour
+        // mimic the same behavior
         m_pWidget->makeCurrentIfNeeded();
-        // QGLWidget::resizeGL has devicePixelRatio applied, so we mimic the same behaviour
+        // QGLWidget::resizeGL has devicePixelRatio applied, so we mimic the same behavior
         m_pWidget->resizeGL(static_cast<int>(static_cast<float>(w) * devicePixelRatio()),
                 static_cast<int>(static_cast<float>(h) * devicePixelRatio()));
         m_dirty = true;

--- a/src/widget/tooltipqopengl.h
+++ b/src/widget/tooltipqopengl.h
@@ -6,7 +6,7 @@
 class WGLWidget;
 
 // Tooltips don't work for the qopengl-based WGLWidget. This
-// singleton mimics the standard tooltip behaviour for them.
+// singleton mimics the standard tooltip behavior for them.
 class ToolTipQOpenGL : public QObject {
     Q_OBJECT
   public:

--- a/src/widget/wlibrary.h
+++ b/src/widget/wlibrary.h
@@ -32,7 +32,7 @@ class WLibrary : public QStackedWidget, public WBaseWidget {
     // This returns true if the current view is or has a WTracksTableView and
     // contains trackId, otherwise false.
     // This is primarily used to disable the "Select track in library" track menu action
-    // to avoid unintended behaviour if the current view has no tracks table.
+    // to avoid unintended behavior if the current view has no tracks table.
     bool isTrackInCurrentView(const TrackId& trackId);
 
     // Alpha value for row color background


### PR DESCRIPTION
This came up in the forums https://mixxx.discourse.group/t/waveform-zoom-midi-control-on-a-cc-dial/28293

* first comit is just a cleanup after I failed to find "behaviour"
* second commit is the script helper: default is a continuous range, set 'round' to `true` to get discrete integer steps
* third commit fixes some mappings using the `waveform_zoom` with the ancient range 0..6

**TODO**
- [ ] add note to [[ChannelN],waveform_zoom](https://manual.mixxx.org/2.4/en/chapters/appendix/mixxx_controls.html#control-[ChannelN]-waveform_zoom), improve Feedback note
- [ ] remove 'zoom' from ControlPotmeter controls examples
