### PR TITLE
macOS buildenv: Improve error messages for CI-only wrappers

### DIFF
--- a/tools/macos_arm64-cross-release_buildenv.sh
+++ b/tools/macos_arm64-cross-release_buildenv.sh
@@ -1,3 +1,9 @@
 #!/bin/bash
+
+if [ -z "${GITHUB_ENV}" ]; then
+  echo "This script is currently intended for CI use only (source tools/macos_buildenv.sh instead)"
+  exit 1
+fi
+
 tools_path=$(dirname "$0")
 BUILDENV_ARM64=TRUE BUILDENV_RELEASE=TRUE "${tools_path}/macos_buildenv.sh" "$@"

--- a/tools/macos_arm64-cross_buildenv.sh
+++ b/tools/macos_arm64-cross_buildenv.sh
@@ -1,3 +1,9 @@
 #!/bin/bash
+
+if [ -z "${GITHUB_ENV}" ]; then
+  echo "This script is currently intended for CI use only (source tools/macos_buildenv.sh instead)"
+  exit 1
+fi
+
 tools_path=$(dirname "$0")
 BUILDENV_ARM64=TRUE "${tools_path}/macos_buildenv.sh" "$@"

--- a/tools/macos_release_buildenv.sh
+++ b/tools/macos_release_buildenv.sh
@@ -1,3 +1,9 @@
 #!/bin/bash
+
+if [ -z "${GITHUB_ENV}" ]; then
+  echo "This script is currently intended for CI use only (source tools/macos_buildenv.sh instead)"
+  exit 1
+fi
+
 tools_path=$(dirname "$0")
 BUILDENV_RELEASE=TRUE "${tools_path}/macos_buildenv.sh" "$@"


### PR DESCRIPTION
Since these scripts currently rely on being invoked and cannot be sourced (due to writing to `GITHUB_ENV`, see https://github.com/mixxxdj/mixxx/pull/12370#issuecomment-1834435406), this PR improves the error message by clarifying that the scripts are intended for CI use only. The message further directs developers interesting in setting up a local environment to `tools/macos_buildenv.sh`.

Previously, executing the wrappers in a non-CI-environment would result in an error message in `macos_buildenv` that the latter script has to be sourced, which may be a bit confusing to newcomers.

In the future we may investigate making these scripts "sourcable" too (though there are some subtleties involved, e.g. accidentally "leaking" `BUILDENV_RELEASE` and similar variables into the parent shell).