### PR TITLE
feat(debug): make DBG macro usable within expressions

### DIFF
--- a/src/util/debug.h
+++ b/src/util/debug.h
@@ -6,8 +6,11 @@
 #include "errordialoghandler.h"
 
 #ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
-#define DBG(value) \
-    (qDebug().nospace() << #value << " = " << (value) << " [" << __FILE__ << ":" << __LINE__ << "]")
+#define DBG(value)                                                                         \
+    (([](auto&& val) {                                                                     \
+        qDebug().nospace() << #value " = " << val << " [" __FILE__ ":" << __LINE__ << "]"; \
+        return val;                                                                        \
+    })(value))
 #else
 #define DBG(value)                                                             \
     static_assert(false,                                                       \
@@ -15,7 +18,7 @@
             "remove it!")
 #endif
 
-template <typename T>
+template<typename T>
 QString toDebugString(const T& object) {
     QString output;
 #ifndef QT_NO_DEBUG_OUTPUT


### PR DESCRIPTION
The DBG macro now accuraletely models the rust dbg! macro by returning the argument its been given verbatim, making it possible to embed in the middle of expressions.

Here's a godbolt if you want to play around with it outside of mixxx
https://compiler-explorer.com/z/Pjf3z3bEx

I also removed some unnecessary `<<` for strings that can be concatenated automatically at compile time. 