### PR TITLE
Track menu: enable Lock BPM action if any selected track BPM is unlocked

### DIFF
--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -201,7 +201,7 @@ class WTrackMenu : public QMenu {
     void loadSelectionToGroup(const QString& group, bool play = false);
     void clearTrackSelection();
 
-    bool isAnyTrackBpmLocked() const;
+    std::pair<bool, bool> getTrackBpmLockStates() const;
 
     /// Get the common track color of all tracks this menu is shown for, or
     /// return `nullopt` if there is no common color. Tracks may have no color


### PR DESCRIPTION
**BPM** > **Lock** was not enabled if any of the selected track is locked.