### PR TITLE
Tracks table: Ctrl+Space toggles BPM & Played checkboxes

### DIFF
--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -840,6 +840,20 @@ void WTrackTableView::keyPressEvent(QKeyEvent* event) {
             return;
         }
     } break;
+    case Qt::Key_Space: {
+        // Ctrl + Space toggles the BPM lock and the Played checkbox
+        if ((event->modifiers() & kPropertiesShortcutModifier) &&
+                state() != QTableView::EditingState) {
+            QModelIndex index = currentIndex();
+            auto* pModel = model();
+            if (!index.isValid() || pModel == nullptr) {
+                return;
+            }
+            bool checked = pModel->data(index, Qt::CheckStateRole).toBool();
+            pModel->setData(index, !checked, Qt::CheckStateRole);
+            return;
+        }
+    } break;
     default:
         QTableView::keyPressEvent(event);
     }


### PR DESCRIPTION
I tried `Space` intuitively a few times but  that maxmizes the library, of course.

Usually `Space` toggles checkboxes in dialogs, and `Ctrl`+`Space` toggles combobox views, so IMO it make sense to use `Ctrl`+`Space` for checkboxes in the table view, somehow fits the `Ctrl` cursor move keys.

