### PR TITLE
turn `waveform_zoom` into ControlPotmeter

### DIFF
--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -1791,6 +1791,14 @@ WPushButton[value="2"]:hover,
   border: 1px solid transparent;
 }
 
+/* If zoom level is set to default value (with Zoom sync enabled), the Reset button
+   of other deck waveforms would be lit. This is a bit distracting, disable it.
+   Unfortunately it doesn't turn blue if pressed but that's acceptable. */
+WPushButton#WaveformZoomSetDefaultButton[value="1"] {
+  background-color: transparent;
+  border: 1px solid transparent;
+}
+
 WPushButton#PlayToggle[value="0"] {
   image: url(skin:/../Deere/icon/ic_play_48px.svg) no-repeat center center;
   background-color: transparent;

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -6,6 +6,7 @@
 
 #include "control/controlencoder.h"
 #include "control/controlobject.h"
+#include "control/controlpotmeter.h"
 #include "engine/channels/enginedeck.h"
 #include "engine/controls/enginecontrol.h"
 #include "engine/defs_keylock.h"
@@ -249,32 +250,25 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(
             &BaseTrackPlayerImpl::slotLoadTrackFromPreviewDeck);
 
     // Waveform controls
-    // This acts somewhat like a ControlPotmeter, but the normal _up/_down methods
-    // do not work properly with this CO.
-    m_pWaveformZoom =
-            std::make_unique<ControlObject>(ConfigKey(getGroup(), "waveform_zoom"));
-    m_pWaveformZoom->connectValueChangeRequest(this,
-            &BaseTrackPlayerImpl::slotWaveformZoomValueChangeRequest,
-            Qt::DirectConnection);
-    m_pWaveformZoom->set(1.0);
-    m_pWaveformZoomUp = std::make_unique<ControlPushButton>(
-            ConfigKey(getGroup(), "waveform_zoom_up"));
-    connect(m_pWaveformZoomUp.get(),
-            &ControlPushButton::valueChanged,
-            this,
-            &BaseTrackPlayerImpl::slotWaveformZoomUp);
-    m_pWaveformZoomDown = std::make_unique<ControlPushButton>(
-            ConfigKey(getGroup(), "waveform_zoom_down"));
-    connect(m_pWaveformZoomDown.get(),
-            &ControlPushButton::valueChanged,
-            this,
-            &BaseTrackPlayerImpl::slotWaveformZoomDown);
-    m_pWaveformZoomSetDefault = std::make_unique<ControlPushButton>(
-            ConfigKey(getGroup(), "waveform_zoom_set_default"));
-    connect(m_pWaveformZoomSetDefault.get(),
-            &ControlPushButton::valueChanged,
-            this,
-            &BaseTrackPlayerImpl::slotWaveformZoomSetDefault);
+    // Unfortunately there's no WaveformWidgetFactory instance, yet, so we can't
+    // use WaveformWidgetFactory::instance()->getDefaultZoom()
+    // Read from config ourselves instead.
+    double defaultZoom = m_pConfig->getValue(
+            ConfigKey(QStringLiteral("[Waveform]"), QStringLiteral("DefaultZoom")),
+            WaveformWidgetRenderer::s_waveformDefaultZoom);
+    m_pWaveformZoom = std::make_unique<ControlPotmeter>(
+            ConfigKey(getGroup(), QStringLiteral("waveform_zoom")),
+            WaveformWidgetRenderer::s_waveformMinZoom,
+            WaveformWidgetRenderer::s_waveformMaxZoom,
+            false, // allow out of bounds
+            false, // ignore no-ops
+            false, // track
+            false, // persist
+            defaultZoom);
+    const int stepCount = static_cast<int>(WaveformWidgetRenderer::s_waveformMaxZoom -
+            WaveformWidgetRenderer::s_waveformMinZoom);
+    m_pWaveformZoom->setStepCount(stepCount);
+    m_pWaveformZoom->setSmallStepCount(stepCount * 10);
 
     m_pPreGain = make_parented<ControlProxy>(getGroup(), "pregain", this);
 
@@ -1061,39 +1055,6 @@ void BaseTrackPlayerImpl::setupEqControls() {
             group, QStringLiteral("button_parameter2"), this);
     m_pHighFilterKill = make_parented<ControlProxy>(
             group, QStringLiteral("button_parameter3"), this);
-}
-
-void BaseTrackPlayerImpl::slotWaveformZoomValueChangeRequest(double v) {
-    if (v <= WaveformWidgetRenderer::s_waveformMaxZoom
-            && v >= WaveformWidgetRenderer::s_waveformMinZoom) {
-        m_pWaveformZoom->setAndConfirm(v);
-    }
-}
-
-void BaseTrackPlayerImpl::slotWaveformZoomUp(double pressed) {
-    if (pressed <= 0.0) {
-        return;
-    }
-
-    m_pWaveformZoom->set(m_pWaveformZoom->get() + 1.0);
-}
-
-void BaseTrackPlayerImpl::slotWaveformZoomDown(double pressed) {
-    if (pressed <= 0.0) {
-        return;
-    }
-
-    m_pWaveformZoom->set(m_pWaveformZoom->get() - 1.0);
-}
-
-void BaseTrackPlayerImpl::slotWaveformZoomSetDefault(double pressed) {
-    if (pressed <= 0.0) {
-        return;
-    }
-
-    double defaultZoom = m_pConfig->getValue(ConfigKey("[Waveform]", "DefaultZoom"),
-            WaveformWidgetRenderer::s_waveformDefaultZoom);
-    m_pWaveformZoom->set(defaultZoom);
 }
 
 void BaseTrackPlayerImpl::slotShiftCuesMillis(double milliseconds) {

--- a/src/mixer/basetrackplayer.h
+++ b/src/mixer/basetrackplayer.h
@@ -21,6 +21,7 @@
 
 class EngineMixer;
 class ControlObject;
+class ControlPotmeter;
 class ControlProxy;
 class ControlEncoder;
 class EffectsManager;
@@ -147,10 +148,6 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
     void slotTrackColorChangeRequest(double value);
     /// Slot for change signals from up/down controls (relative values)
     void slotTrackRatingChangeRequestRelative(int change);
-    void slotWaveformZoomValueChangeRequest(double pressed);
-    void slotWaveformZoomUp(double pressed);
-    void slotWaveformZoomDown(double pressed);
-    void slotWaveformZoomSetDefault(double pressed);
     void slotShiftCuesMillis(double milliseconds);
     void slotShiftCuesMillisButton(double value, double milliseconds);
     void slotUpdateReplayGainFromPregain(double pressed);
@@ -198,10 +195,7 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
 #endif
 
     // Waveform display related controls
-    std::unique_ptr<ControlObject> m_pWaveformZoom;
-    std::unique_ptr<ControlPushButton> m_pWaveformZoomUp;
-    std::unique_ptr<ControlPushButton> m_pWaveformZoomDown;
-    std::unique_ptr<ControlPushButton> m_pWaveformZoomSetDefault;
+    std::unique_ptr<ControlPotmeter> m_pWaveformZoom;
 
     parented_ptr<ControlProxy> m_pLoopInPoint;
     parented_ptr<ControlProxy> m_pLoopOutPoint;

--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -3,9 +3,11 @@
 #include <QLocale>
 #include <QMetaEnum>
 
+#include "control/controlobject.h"
 #include "control/controlpushbutton.h"
 #include "library/dao/analysisdao.h"
 #include "library/library.h"
+#include "mixer/playerinfo.h"
 #include "moc_dlgprefwaveform.cpp"
 #include "preferences/waveformsettings.h"
 #include "util/db/dbconnectionpooled.h"
@@ -426,8 +428,8 @@ void DlgPrefWaveform::slotResetToDefaults() {
     midVisualGain->setValue(WaveformWidgetFactory::getVisualGainDefault(BandIndex::Mid));
     highVisualGain->setValue(WaveformWidgetFactory::getVisualGainDefault(BandIndex::High));
 
-    // Default zoom level is 3 in WaveformWidgetFactory.
-    defaultZoomComboBox->setCurrentIndex(3 + 1);
+    defaultZoomComboBox->setCurrentIndex(
+            static_cast<int>(WaveformWidgetRenderer::s_waveformDefaultZoom) - 1);
 
     synchronizeZoomCheckBox->setChecked(true);
 
@@ -689,6 +691,22 @@ void DlgPrefWaveform::slotSetWaveformOverviewType() {
 
 void DlgPrefWaveform::slotSetDefaultZoom(int index) {
     WaveformWidgetFactory::instance()->setDefaultZoom(index + 1);
+    QStringList groups;
+    for (int i = 1; i <= PlayerInfo::instance().numDecks(); i++) {
+        groups.append(QStringLiteral("[Channel%1]").arg(i));
+    }
+    for (int i = 1; i <= PlayerInfo::instance().numSamplers(); i++) {
+        groups.append(QStringLiteral("[Sampler%1]").arg(i));
+    }
+    for (int i = 1; i <= PlayerInfo::instance().numPreviewDecks(); i++) {
+        groups.append(QStringLiteral("[PreviewDeck%1]").arg(i));
+    }
+    for (const QString& group : std::as_const(groups)) {
+        ControlObject* pControl = ControlObject::getControl(
+                group, QStringLiteral("waveform_zoom"));
+        DEBUG_ASSERT(pControl);
+        pControl->setDefaultValue(index + 1);
+    }
 }
 
 void DlgPrefWaveform::slotSetZoomSynchronization(bool checked) {


### PR DESCRIPTION
c++ alternative to  #12373 

* `waveform_zoom` is now a ControlPotmeter incl. `_up`, `_down`, `_set_default` and some rather useless controls
step size is 1, i.e. `_up`/`_down` act exactly as before
* ~~added `waveform_zoom_selector`, triggers `_up`/`_down` and thereby simplifies mapping rotary encoders with the `SelectKnob` MIDI option~~ already possible with the e.g. the `Rot64` MIDI option
* ~~fixed some hard-coded ranges in mappings~~ #12393 

**TODO**
- [x] update the manual https://github.com/mixxxdj/manual/pull/722


Note to myself:
pick https://github.com/mixxxdj/mixxx/pull/12373/commits/55418d00da24e01077e2bd8d7cedad561a672979 from #12373


