### PR TITLE
CI test: type declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The Mixxx team uses [Github Issues][issues] to manage Mixxx development.
 Have a bug or feature request? [File a bug on Github][fileabug].
 
 Want to get involved in Mixxx development? Assign yourself a bug from the [easy
-bug list][easybugs] and get started!   
+bug list][easybugs] and get started!
 Read [CONTRIBUTING](CONTRIBUTING.md) for more information.
 
 ## Building Mixxx

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -1,5 +1,6 @@
 #include "engine/controls/bpmcontrol.h"
 
+// #include "control/controlencoder.h"
 #include "control/controllinpotmeter.h"
 #include "control/controlobject.h"
 #include "control/controlproxy.h"
@@ -87,6 +88,13 @@ BpmControl::BpmControl(const QString& group,
     connect(m_pTranslateBeatsLater, &ControlObject::valueChanged,
             this, &BpmControl::slotTranslateBeatsLater,
             Qt::DirectConnection);
+    m_pTranslateBeatsMove = new ControlEncoder(ConfigKey(group, "beats_translate_move"), false);
+    // m_pTranslateBeatsMove->setKbdRepeatable(true);
+    connect(m_pTranslateBeatsMove,
+            &ControlObject::valueChanged,
+            this,
+            &BpmControl::slotTranslateBeatsMove,
+            Qt::DirectConnection);
 
     // Pick a wide range (kBpmRangeMin to kBpmRangeMax) and allow out of bounds sets. This lets you
     // map a soft-takeover MIDI knob to the BPM. This also creates bpm_up and
@@ -138,6 +146,7 @@ BpmControl::~BpmControl() {
     delete m_pBeatsTranslateMatchAlignment;
     delete m_pTranslateBeatsEarlier;
     delete m_pTranslateBeatsLater;
+    delete m_pTranslateBeatsMove;
     delete m_pAdjustBeatsFaster;
     delete m_pAdjustBeatsSlower;
 }
@@ -187,23 +196,19 @@ void BpmControl::slotTranslateBeatsEarlier(double v) {
     if (v <= 0) {
         return;
     }
-    const TrackPointer pTrack = getEngineBuffer()->getLoadedTrack();
-    if (!pTrack) {
-        return;
-    }
-    const mixxx::BeatsPointer pBeats = pTrack->getBeats();
-    if (pBeats) {
-        const double sampleOffset = frameInfo().sampleRate * -0.01;
-        const mixxx::audio::FrameDiff_t frameOffset = sampleOffset / mixxx::kEngineChannelCount;
-        const auto translatedBeats = pBeats->tryTranslate(frameOffset);
-        if (translatedBeats) {
-            pTrack->trySetBeats(*translatedBeats);
-        }
-    }
+    slotTranslateBeatsMove(-1);
 }
 
 void BpmControl::slotTranslateBeatsLater(double v) {
     if (v <= 0) {
+        return;
+    }
+    slotTranslateBeatsMove(1);
+}
+
+void BpmControl::slotTranslateBeatsMove(double v) {
+    v = std::round(v);
+    if (v == 0) {
         return;
     }
     const TrackPointer pTrack = getEngineBuffer()->getLoadedTrack();
@@ -213,7 +218,7 @@ void BpmControl::slotTranslateBeatsLater(double v) {
     const mixxx::BeatsPointer pBeats = pTrack->getBeats();
     if (pBeats) {
         // TODO(rryan): Track::frameInfo is possibly inaccurate!
-        const double sampleOffset = frameInfo().sampleRate * 0.01;
+        const double sampleOffset = frameInfo().sampleRate * v * 0.01;
         const mixxx::audio::FrameDiff_t frameOffset = sampleOffset / mixxx::kEngineChannelCount;
         const auto translatedBeats = pBeats->tryTranslate(frameOffset);
         if (translatedBeats) {

--- a/src/engine/controls/bpmcontrol.h
+++ b/src/engine/controls/bpmcontrol.h
@@ -9,6 +9,7 @@
 #include "track/beats.h"
 #include "util/tapfilter.h"
 
+// class ControlEncoder;
 class ControlLinPotmeter;
 class ControlPushButton;
 
@@ -100,6 +101,7 @@ class BpmControl : public EngineControl {
     void slotAdjustBeatsSlower(double);
     void slotTranslateBeatsEarlier(double);
     void slotTranslateBeatsLater(double);
+    void slotTranslateBeatsMove(double);
     void slotTapFilter(double,int);
     void slotBpmTap(double);
     void slotUpdateRateSlider(double v = 0.0);
@@ -141,6 +143,7 @@ class BpmControl : public EngineControl {
     ControlPushButton* m_pAdjustBeatsSlower;
     ControlPushButton* m_pTranslateBeatsEarlier;
     ControlPushButton* m_pTranslateBeatsLater;
+    ControlEncoder* m_pTranslateBeatsMove;
 
     // The current effective BPM of the engine
     ControlLinPotmeter* m_pEngineBpm;


### PR DESCRIPTION
This is just a test.

One of the initial commit in #12376 made via Github web UI was missing the `ControlEncoder` type delaration (no header, no forward-declaration), yet CI didn't complain (it could be built on all targets). Locally it failed with gc 13 / mold.

Let's see if this is reproducible.