### PR TITLE
Feat: eslint plugin diff

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "extends": [ "eslint:recommended",
-               "plugin:jsdoc/recommended"],
+               "plugin:jsdoc/recommended",
+               "plugin:diff/diff"],
 
   "parser": "@typescript-eslint/parser",
   "parserOptions": {

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,6 +79,7 @@ repos:
           - eslint-plugin-jsdoc@^v46.5.1
           - "@typescript-eslint/eslint-plugin"
           - "@typescript-eslint/parser"
+          - eslint-plugin-diff@^2.0.3
   - repo: local
     hooks:
       - id: clang-format


### PR DESCRIPTION
This will make it less scaring to make changes to outdated mappings that are not style-conform.
The motivation is basically the same as for the diff-based clang-format tool we use.