### PR TITLE
Fix MSVC issues without PCH

### DIFF
--- a/lib/reverb/Reverb.h
+++ b/lib/reverb/Reverb.h
@@ -61,7 +61,7 @@ class Lattice
 : public DSP::Delay
 {
 	public:
-		sample_t process (sample_t x, double d)
+		sample_t process (sample_t x, sample_t d)
 			{
 				sample_t y = get();
 				x -= d*y;
@@ -126,8 +126,8 @@ class ModLattice
 
 		void init (int n, int w)
 			{
-				n0 = n;
-				width = w;
+				n0 = static_cast<float>(n);
+				width = static_cast<float>(w);
 				delay.init (n + w);
 			}
 
@@ -137,9 +137,9 @@ class ModLattice
 			}
 
 		inline sample_t
-		process (sample_t x, double d)
+		process (sample_t x, sample_t d)
 			{
-				sample_t y = delay.get_linear (n0 + width * lfo.get());
+				sample_t y = delay.get_linear (n0 + width * static_cast<float>(lfo.get()));
 				x += d * y;
 				delay.put (x);
 				return y - d * x; /* note sign */

--- a/lib/reverb/dsp/Delay.h
+++ b/lib/reverb/dsp/Delay.h
@@ -104,12 +104,9 @@ class Delay
 				sample_t x2 = (*this) [n + 2];
 
 				/* sample_t (32bit) quicker than double here */
-				sample_t a =
-						(3 * (x0 - x1) - x_1 + x2) * .5;
-				sample_t b =
-						2 * x1 + x_1 - (5 * x0 + x2) * .5;
-				sample_t c =
-						(x1 - x_1) * .5;
+				sample_t a = (3 * (x0 - x1) - x_1 + x2) * .5f;
+				sample_t b = 2 * x1 + x_1 - (5 * x0 + x2) * .5f;
+				sample_t c = (x1 - x_1) * .5f;
 
 				return x0 + (((a * f) + b) * f + c) * f;
 			}
@@ -124,7 +121,7 @@ class MovingAverage
 		void init (uint n)
 			{
 				this->Delay::init (n);
-				over_n = 1. / n;
+				over_n = 1.f / n;
 				/* adjust write pointer so we have a full history of zeros */
 				write = (write + size + 1) & size;
 				state = 0;

--- a/lib/reverb/dsp/IIR1.h
+++ b/lib/reverb/dsp/IIR1.h
@@ -36,7 +36,7 @@ class LP1
 	public:
 		T a0, b1, y1;
 
-		LP1 (double d = 1.)
+		LP1 (T d = 1.)
 			{
 				set (d);
 				y1 = 0.;

--- a/src/controllers/hid/hidioglobaloutputreportfifo.h
+++ b/src/controllers/hid/hidioglobaloutputreportfifo.h
@@ -1,12 +1,11 @@
 #pragma once
 
-#include <QtGlobal>
+#include <QByteArray>
 
 #include "rigtorp/SPSCQueue.h"
 
 struct RuntimeLoggingCategory;
 class QMutex;
-class QByteArray;
 
 typedef struct hid_device_ hid_device;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,7 +59,7 @@ int runMixxx(MixxxApplication* pApp, const CmdlineArgs& args) {
         pApp->installEventFilter(&mainWindow);
 
 #if defined(__WINDOWS__)
-        WindowsEventHandler winEventHandler(pApp);
+        WindowsEventHandler winEventHandler;
         pApp->installNativeEventFilter(&winEventHandler);
 #endif
 

--- a/src/nativeeventhandlerwin.cpp
+++ b/src/nativeeventhandlerwin.cpp
@@ -1,18 +1,19 @@
-#include "nativeeventhandlerwin.h"
 #if defined(__WINDOWS__)
-#include <commctrl.h>
-#include <windows.h>
-#include <winuser.h>
+
+#include "nativeeventhandlerwin.h"
+
+// clang-format off
+#include <windows.h>  // needs to be included first
+#include <commctrl.h> // for DefSubclassProc
+#include <winuser.h>  // for MSG, RedrawWindow PostMessageW
+// clang-format on
 
 #include "moc_nativeeventhandlerwin.cpp"
 
-WindowsEventHandler::WindowsEventHandler(MixxxApplication* pApp)
-        : m_pApp(pApp) {
-}
-
 bool WindowsEventHandler::nativeEventFilter(
         const QByteArray& eventType, void* message, long* result) {
-    MSG* msg = (MSG*)message;
+    Q_UNUSED(eventType);
+    MSG* msg = reinterpret_cast<MSG*>(message);
     if (msg && msg->message == WM_NCLBUTTONDOWN) {
         // Trigger the modal loop to prevent 500ms wait in Event Loop
         // when Windows setting "Show window contents while dragging" is enabled
@@ -38,4 +39,5 @@ bool WindowsEventHandler::nativeEventFilter(
     // so other recipients will also receive this message subsequently
     return false;
 }
+
 #endif

--- a/src/nativeeventhandlerwin.h
+++ b/src/nativeeventhandlerwin.h
@@ -1,15 +1,13 @@
-#include <QAbstractNativeEventFilter>
-
 #if defined(__WINDOWS__)
-#include "mixxxapplication.h"
+
+#include <QAbstractNativeEventFilter>
 
 class WindowsEventHandler : public QAbstractNativeEventFilter {
   public:
-    WindowsEventHandler(MixxxApplication* pApp);
+    WindowsEventHandler() = default;
+    ~WindowsEventHandler() override = default;
 
-    bool nativeEventFilter(const QByteArray& eventType, void* message, long* result);
-
-  private:
-    MixxxApplication* m_pApp;
+    bool nativeEventFilter(const QByteArray& eventType, void* message, long* result) override;
 };
+
 #endif

--- a/src/track/taglib/trackmetadata_file.cpp
+++ b/src/track/taglib/trackmetadata_file.cpp
@@ -1,3 +1,12 @@
+#if defined(_MSC_VER)
+#pragma warning(push)
+// https://github.com/taglib/taglib/issues/1185
+// warning C4251: 'TagLib::FileName::m_wname': class
+// 'std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t>>'
+// needs to have dll-interface to be used by clients of class 'TagLib::FileName'
+#pragma warning(disable : 4251)
+#endif
+
 #include "track/taglib/trackmetadata_file.h"
 
 #include <taglib/tfile.h>
@@ -151,3 +160,7 @@ bool readAudioPropertiesFromFile(
 } // namespace taglib
 
 } // namespace mixxx
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif

--- a/src/track/taglib/trackmetadata_mp4.cpp
+++ b/src/track/taglib/trackmetadata_mp4.cpp
@@ -1,3 +1,12 @@
+#if defined(_MSC_VER)
+#pragma warning(push)
+// https://github.com/taglib/taglib/issues/1185
+// warning C4251: 'TagLib::FileName::m_wname': class
+// 'std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t>>'
+// needs to have dll-interface to be used by clients of class 'TagLib::FileName'
+#pragma warning(disable : 4251)
+#endif
+
 #include "track/taglib/trackmetadata_mp4.h"
 
 #include "track/taglib/trackmetadata_common.h"
@@ -508,3 +517,7 @@ bool exportTrackMetadataIntoTag(
 } // namespace taglib
 
 } // namespace mixxx
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif

--- a/src/track/taglib/trackmetadata_xiph.cpp
+++ b/src/track/taglib/trackmetadata_xiph.cpp
@@ -1,3 +1,12 @@
+#if defined(_MSC_VER)
+#pragma warning(push)
+// https://github.com/taglib/taglib/issues/1185
+// warning C4251: 'TagLib::FileName::m_wname': class
+// 'std::basic_string<wchar_t,std::char_traits<wchar_t>,std::allocator<wchar_t>>'
+// needs to have dll-interface to be used by clients of class 'TagLib::FileName'
+#pragma warning(disable : 4251)
+#endif
+
 #include "track/taglib/trackmetadata_xiph.h"
 
 #include <taglib/flacpicture.h>
@@ -635,3 +644,7 @@ bool exportTrackMetadataIntoTag(
 } // namespace taglib
 
 } // namespace mixxx
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif

--- a/src/util/console.cpp
+++ b/src/util/console.cpp
@@ -6,6 +6,8 @@
 #include <string.h>
 #include <strsafe.h>
 
+#include <QDebug>
+
 #include "util/versionstore.h"
 
 typedef BOOL(WINAPI* pfGetCurrentConsoleFontEx)(HANDLE, BOOL, PCONSOLE_FONT_INFOEX);

--- a/src/util/safelywritablefile.cpp
+++ b/src/util/safelywritablefile.cpp
@@ -7,6 +7,8 @@
 
 #if defined(__WINDOWS__)
 #include <Windows.h>
+
+#include <QThread>
 #endif
 
 namespace mixxx {

--- a/src/waveform/renderers/allshader/waveformrendererpreroll.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererpreroll.cpp
@@ -3,6 +3,7 @@
 #include <QDomNode>
 #include <QOpenGLTexture>
 #include <QPainterPath>
+#include <array>
 
 #include "skin/legacy/skincontext.h"
 #include "util/texture.h"

--- a/src/widget/wspinnyglsl.cpp
+++ b/src/widget/wspinnyglsl.cpp
@@ -1,6 +1,7 @@
 #include "widget/wspinnyglsl.h"
 
 #include <QOpenGLTexture>
+#include <array>
 
 #include "moc_wspinnyglsl.cpp"
 #include "util/texture.h"

--- a/src/widget/wvumeterglsl.cpp
+++ b/src/widget/wvumeterglsl.cpp
@@ -1,6 +1,7 @@
 #include "widget/wvumeterglsl.h"
 
 #include <QOpenGLTexture>
+#include <array>
 
 #include "moc_wvumeterglsl.cpp"
 #include "util/duration.h"


### PR DESCRIPTION
This fixes some strange compiler errors and warnings (treated as errors) when we not use precompiled headers. 
You can find the CI run without PCH here: 
https://github.com/daschuer/mixxx/actions/runs/7134678783
