### PR TITLE
fix clamping of the index for drawing the waveform left of zero position

### DIFF
--- a/src/waveform/renderers/allshader/waveformrendererfiltered.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererfiltered.cpp
@@ -99,8 +99,7 @@ void WaveformRendererFiltered::paintGL() {
 
         const int visualIndexStart = std::max(visualFrameStart * 2, 0);
         const int visualIndexStop =
-                std::min(std::max(visualFrameStop * 2, visualIndexStart + 1),
-                        dataSize - 1);
+                std::min(std::max(visualFrameStop, visualFrameStart + 1) * 2, dataSize - 1);
 
         const float fpos = static_cast<float>(pos);
 

--- a/src/waveform/renderers/allshader/waveformrendererhsv.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererhsv.cpp
@@ -99,8 +99,7 @@ void WaveformRendererHSV::paintGL() {
 
         const int visualIndexStart = std::max(visualFrameStart * 2, 0);
         const int visualIndexStop =
-                std::min(std::max(visualFrameStop * 2, visualIndexStart + 1),
-                        dataSize - 1);
+                std::min(std::max(visualFrameStop, visualFrameStart + 1) * 2, dataSize - 1);
 
         const float fpos = static_cast<float>(pos);
 

--- a/src/waveform/renderers/allshader/waveformrendererlrrgb.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererlrrgb.cpp
@@ -112,8 +112,7 @@ void WaveformRendererLRRGB::paintGL() {
 
         const int visualIndexStart = std::max(visualFrameStart * 2, 0);
         const int visualIndexStop =
-                std::min(std::max(visualFrameStop * 2, visualIndexStart + 1),
-                        dataSize - 1);
+                std::min(std::max(visualFrameStop, visualFrameStart + 1) * 2, dataSize - 1);
 
         const float fpos = static_cast<float>(pos);
 

--- a/src/waveform/renderers/allshader/waveformrendererrgb.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererrgb.cpp
@@ -111,8 +111,7 @@ void WaveformRendererRGB::paintGL() {
 
         const int visualIndexStart = std::max(visualFrameStart * 2, 0);
         const int visualIndexStop =
-                std::min(std::max(visualFrameStop * 2, visualIndexStart + 1),
-                        dataSize - 1);
+                std::min(std::max(visualFrameStop, visualFrameStart + 1) * 2, dataSize - 1);
 
         const float fpos = static_cast<float>(pos);
 

--- a/src/waveform/renderers/allshader/waveformrenderersimple.cpp
+++ b/src/waveform/renderers/allshader/waveformrenderersimple.cpp
@@ -108,10 +108,9 @@ void WaveformRendererSimple::paintGL() {
         const int visualIndexStart = std::max(visualFrameStart * 2, 0);
         // and at the upper boundary.
         // Note: * dataSize - 1, because below we add chn = 1
-        //       * visualIndexStart + 1, because we want to have at least 1 value
+        //       * visualFrameStart + 1, because we want to have at least 1 value
         const int visualIndexStop =
-                std::min(std::max(visualFrameStop * 2, visualIndexStart + 1),
-                        dataSize - 1);
+                std::min(std::max(visualFrameStop, visualFrameStart + 1) * 2, dataSize - 1);
 
         // 2 channels
         float max[2]{};


### PR DESCRIPTION
Left of the zero position was drawn was the value of the first position. I guess nobody noticed because the start of tracks tend to be low amplitude.

Before:
<img width="358" alt="Screenshot 2023-12-08 at 11 15 32" src="https://github.com/mixxxdj/mixxx/assets/79429057/aa835cdf-d1b6-419e-bfb5-5df8454a2b1d">

After:
<img width="285" alt="Screenshot 2023-12-08 at 11 49 00" src="https://github.com/mixxxdj/mixxx/assets/79429057/fe0d55d0-8eef-4486-8148-eb95994235c0">
