### PR TITLE
Revert "Bump actions/labeler from 4.3.0 to 5.0.0"

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/labeler@v5.0.0
+      - uses: actions/labeler@v4.3.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: false


### PR DESCRIPTION
Reverts mixxxdj/mixxx#12394

I didn't pay attention, It broke due to format changes.
https://github.com/actions/labeler/releases/tag/v5.0.0-beta.1

If anyone is motivated to fix it now (I'm not) please do so, otherwise merge this to revert to 4.3