### PR TITLE
use frameSwapped - update for continuously repaint instead of swapBuffers from vsyncthread

### DIFF
--- a/src/waveform/useframeswapped.h
+++ b/src/waveform/useframeswapped.h
@@ -1,0 +1,1 @@
+constexpr bool USE_FRAME_SWAPPED = true;

--- a/src/waveform/vsyncthread.h
+++ b/src/waveform/vsyncthread.h
@@ -25,6 +25,8 @@ class VSyncThread : public QThread {
 
     void run();
 
+    void frameSwapped();
+
     bool waitForVideoSync(WGLWidget* glw);
     int elapsed();
     int toNextSyncMicros();

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -36,6 +36,7 @@
 #include "waveform/widgets/qtvsynctestwidget.h"
 #include "waveform/widgets/qtwaveformwidget.h"
 #endif
+#include "waveform/useframeswapped.h"
 #include "waveform/widgets/emptywaveformwidget.h"
 #include "waveform/widgets/glrgbwaveformwidget.h"
 #include "waveform/widgets/glsimplewaveformwidget.h"
@@ -439,6 +440,12 @@ void WaveformWidgetFactory::addVuMeter(WVuMeterBase* pVuMeter) {
             &WaveformWidgetFactory::swapVuMeters,
             pVuMeter,
             &WVuMeterBase::swap);
+}
+
+void WaveformWidgetFactory::frameSwapped() {
+    if (m_vsyncThread) {
+        m_vsyncThread->frameSwapped();
+    }
 }
 
 void WaveformWidgetFactory::slotSkinLoaded() {
@@ -1132,7 +1139,11 @@ void WaveformWidgetFactory::startVSync(GuiTick* pGuiTick, VisualsManager* pVisua
             this,
             &WaveformWidgetFactory::swap);
 
-    m_vsyncThread->start(QThread::NormalPriority);
+    // Don't start the thread when using the frameSwapped signal, in which case
+    // we do the timing based on the frameSwapped signal.
+    if (!USE_FRAME_SWAPPED) {
+        m_vsyncThread->start(QThread::NormalPriority);
+    }
 }
 
 void WaveformWidgetFactory::getAvailableVSyncTypes(QList<QPair<int, QString>>* pList) {

--- a/src/waveform/waveformwidgetfactory.h
+++ b/src/waveform/waveformwidgetfactory.h
@@ -150,6 +150,7 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
 
   public slots:
     void slotSkinLoaded();
+    void frameSwapped();
 
   protected:
     WaveformWidgetFactory();

--- a/src/widget/openglwindow.cpp
+++ b/src/widget/openglwindow.cpp
@@ -4,6 +4,7 @@
 #include <QResizeEvent>
 
 #include "moc_openglwindow.cpp"
+#include "waveform/useframeswapped.h"
 #include "waveform/waveformwidgetfactory.h"
 #include "widget/tooltipqopengl.h"
 #include "widget/trackdroptarget.h"
@@ -44,7 +45,11 @@ void OpenGLWindow::resizeGL(int w, int h) {
         // QGLWidget::resizeGL has devicePixelRatio applied, so we mimic the same behaviour
         m_pWidget->resizeGL(static_cast<int>(static_cast<float>(w) * devicePixelRatio()),
                 static_cast<int>(static_cast<float>(h) * devicePixelRatio()));
-        m_dirty = true;
+
+        if (!USE_FRAME_SWAPPED) {
+            // No need for this when using the frameSwapped/update mechanism
+            m_dirty = true;
+        }
         m_pWidget->doneCurrent();
     }
 }

--- a/src/widget/wglwidgetqopengl.h
+++ b/src/widget/wglwidgetqopengl.h
@@ -37,6 +37,9 @@ class WGLWidget : public QWidget {
     void setTrackDropTarget(TrackDropTarget* pTarget);
     TrackDropTarget* trackDropTarget() const;
 
+  private slots:
+    void slotFrameSwapped();
+
   protected:
     void showEvent(QShowEvent* event) override;
     void resizeEvent(QResizeEvent* event) override;


### PR DESCRIPTION
According to the Qt docs:

> Applications that wish to continuously repaint synchronized to the vertical refresh, should issue an [update](https://doc.qt.io/qt-6/qpaintdevicewindow.html#update-2)() upon the \[QOpenGLWindow::frameSwapped\] signal. This allows for a much smoother experience compared to the traditional usage of timers.
> This signal is emitted after the potentially blocking [buffer swap](https://doc.qt.io/qt-6/qopenglcontext.html#swapBuffers) has been done. 

This PR uses the mechanism, replacing the manual swapBuffers calls from the vsyncThread. The timing mechanism from the vsyncThread is still used, but now triggered by the frameSwapped signal.

Apart from being the recommended way, this also solves artifacts in the OpenGL widgets when resizing / moving the splitter.

I didn't want to fully replace the old code, so this is all conditional using the const bool USE_FRAME_SWAPPED. 