### PR TITLE
Increased pixmapCache size limit and made it dependent on devicePixelRatio (for HiDPI/Retina displays)

### DIFF
--- a/src/library/coverartcache.cpp
+++ b/src/library/coverartcache.cpp
@@ -14,15 +14,6 @@ namespace {
 
 mixxx::Logger kLogger("CoverArtCache");
 
-// The initial QPixmapCache limit is 10MB.
-// But it is not used just by the coverArt stuff,
-// it is also used by Qt to handle other things behind the scenes.
-// Consequently coverArt cache will always have less than those
-// 10MB available to store the pixmaps.
-// So, we must increase this size a bit more,
-// in order to allow CoverCache handle more covers (performance gain).
-constexpr int kPixmapCacheLimit = 20480;
-
 QString pixmapCacheKey(mixxx::cache_key_t hash, int width) {
     return QString("CoverArtCache_%1_%2")
             .arg(QString::number(hash), QString::number(width));
@@ -39,7 +30,6 @@ inline QImage resizeImageWidth(const QImage& image, int width) {
 } // anonymous namespace
 
 CoverArtCache::CoverArtCache() {
-    QPixmapCache::setCacheLimit(kPixmapCacheLimit);
 }
 
 //static


### PR DESCRIPTION
I noticed during profiling on Windows, that Mixxx sometimes renders SVG icons and the waveforms stuck slightly. I could fix this by increasing the pixmapCache limit for rendered SVGs and scaled CoverArt from 20MByte to 32MByte.
But these images increase all in size when HiDPI displays with higher zoom levels are used, therefore I consider this as well.
Furthermore I moved this general setting out off coverartcache.cpp.