### PR TITLE
MSVC: Suppress possible loss of data warning 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1546,14 +1546,9 @@ if(GNU_GCC OR LLVM_CLANG)
   )
 elseif(MSVC)
   set_property(
-    SOURCE src/library/rekordbox/kaitaistructs/rekordbox_anlz.cpp
-    APPEND_STRING
-    PROPERTY COMPILE_OPTIONS /w
-  )
-  set_property(
     SOURCE src/library/rekordbox/kaitaistructs/rekordbox_pdb.cpp
     APPEND_STRING
-    PROPERTY COMPILE_OPTIONS /w
+    PROPERTY COMPILE_OPTIONS /wd4244
   )
 endif()
 


### PR DESCRIPTION
 a /w after /W3 seems to no longer work "overriding '/W3' with '/w'"

It puzzles me, why this happens only without PCH ...