### PR TITLE
Display the samplerate in the track info dialog.

### DIFF
--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -425,6 +425,13 @@ void DlgTrackInfo::updateTrackMetadataFields() {
     txtReplayGain->setText(
             mixxx::ReplayGain::ratioToString(
                     m_trackRecord.getMetadata().getTrackInfo().getReplayGain().getRatio()));
+
+    auto samplerate = m_trackRecord.getMetadata().getStreamInfo().getSignalInfo().getSampleRate();
+    if (samplerate.isValid()) {
+        txtSamplerate->setText(QString::number(samplerate.value()) + " Hz");
+    } else {
+        txtSamplerate->clear();
+    }
 }
 
 void DlgTrackInfo::updateSpinBpmFromBeats() {

--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>575</width>
-    <height>595</height>
+    <height>642</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -43,7 +43,6 @@
      <property name="currentIndex">
       <number>0</number>
      </property>
-
      <widget class="QWidget" name="tabSummary">
       <attribute name="title">
        <string>Summary</string>
@@ -54,7 +53,6 @@
          <layout class="QGridLayout" name="gridLayout_2">
           <item row="0" column="0">
            <layout class="QGridLayout" name="gridLayout_5" columnstretch="0,10,0,2">
-
             <item row="0" column="0">
              <widget class="QLabel" name="lblTrackName">
               <property name="sizePolicy">
@@ -76,7 +74,6 @@
               </property>
              </widget>
             </item>
-
             <item row="0" column="1">
              <widget class="QLineEdit" name="txtTrackName">
               <property name="sizePolicy">
@@ -111,7 +108,6 @@
               </layout>
              </widget>
             </item>
-
             <item row="1" column="0">
              <widget class="QLabel" name="lblArtist">
               <property name="sizePolicy">
@@ -128,7 +124,6 @@
               </property>
              </widget>
             </item>
-
             <item row="1" column="1">
              <widget class="QLineEdit" name="txtArtist">
               <property name="sizePolicy">
@@ -145,7 +140,6 @@
               </property>
              </widget>
             </item>
-
             <item row="2" column="0">
              <widget class="QLabel" name="lblAlbum">
               <property name="sizePolicy">
@@ -162,7 +156,6 @@
               </property>
              </widget>
             </item>
-
             <item row="2" column="1">
              <widget class="QLineEdit" name="txtAlbum">
               <property name="sizePolicy">
@@ -179,7 +172,6 @@
               </property>
              </widget>
             </item>
-
             <item row="3" column="0">
              <widget class="QLabel" name="lblAlbumArtist">
               <property name="sizePolicy">
@@ -196,7 +188,6 @@
               </property>
              </widget>
             </item>
-
             <item row="3" column="1">
              <widget class="QLineEdit" name="txtAlbumArtist">
               <property name="sizePolicy">
@@ -213,7 +204,6 @@
               </property>
              </widget>
             </item>
-
             <item row="3" column="2" colspan="2">
              <widget class="QWidget" name="verticalWidgetStars" native="true">
               <property name="sizePolicy">
@@ -232,7 +222,6 @@
               </layout>
              </widget>
             </item>
-
             <item row="4" column="0">
              <widget class="QLabel" name="lblComposer">
               <property name="text">
@@ -243,7 +232,6 @@
               </property>
              </widget>
             </item>
-
             <item row="4" column="1">
              <widget class="QLineEdit" name="txtComposer">
               <property name="sizePolicy">
@@ -260,7 +248,6 @@
               </property>
              </widget>
             </item>
-
             <item row="4" column="2">
              <widget class="QLabel" name="lblYear">
               <property name="text">
@@ -268,7 +255,6 @@
               </property>
              </widget>
             </item>
-
             <item row="4" column="3">
              <widget class="QLineEdit" name="txtYear">
               <property name="sizePolicy">
@@ -279,7 +265,6 @@
               </property>
              </widget>
             </item>
-
             <item row="5" column="0">
              <widget class="QLabel" name="lblGenre">
               <property name="text">
@@ -290,7 +275,6 @@
               </property>
              </widget>
             </item>
-
             <item row="5" column="1">
              <widget class="QLineEdit" name="txtGenre">
               <property name="sizePolicy">
@@ -307,7 +291,6 @@
               </property>
              </widget>
             </item>
-
             <item row="5" column="2">
              <widget class="QLabel" name="lblKey">
               <property name="text">
@@ -315,7 +298,6 @@
               </property>
              </widget>
             </item>
-
             <item row="5" column="3">
              <widget class="QLineEdit" name="txtKey">
               <property name="sizePolicy">
@@ -332,7 +314,6 @@
               </property>
              </widget>
             </item>
-
             <item row="6" column="0">
              <widget class="QLabel" name="lblGrouping">
               <property name="text">
@@ -343,7 +324,6 @@
               </property>
              </widget>
             </item>
-
             <item row="6" column="1">
              <widget class="QLineEdit" name="txtGrouping">
               <property name="sizePolicy">
@@ -360,7 +340,6 @@
               </property>
              </widget>
             </item>
-
             <item row="6" column="2">
              <widget class="QLabel" name="lblTrackNumber">
               <property name="text">
@@ -368,7 +347,6 @@
               </property>
              </widget>
             </item>
-
             <item row="6" column="3">
              <widget class="QLineEdit" name="txtTrackNumber">
               <property name="sizePolicy">
@@ -385,7 +363,6 @@
               </property>
              </widget>
             </item>
-
             <item row="7" column="0">
              <widget class="QLabel" name="lblTrackComment">
               <property name="text">
@@ -396,7 +373,6 @@
               </property>
              </widget>
             </item>
-
             <item row="7" column="1" colspan="3">
              <widget class="QPlainTextEdit" name="txtComment">
               <property name="tabChangesFocus">
@@ -404,7 +380,6 @@
               </property>
              </widget>
             </item>
-
             <item row="8" column="1" colspan="3">
              <layout class="QHBoxLayout" name="horizontalLayout_3">
               <item>
@@ -436,7 +411,6 @@
               </item>
              </layout>
             </item>
-
             <item row="9" column="0">
              <widget class="QLabel" name="lblTrackColor">
               <property name="text">
@@ -447,7 +421,6 @@
               </property>
              </widget>
             </item>
-
             <item row="9" column="1" colspan="3">
              <widget class="QPushButton" name="btnColorPicker">
               <property name="sizePolicy">
@@ -458,8 +431,7 @@
               </property>
              </widget>
             </item>
-
-            <item>
+            <item row="0" column="0">
              <spacer name="horizontalSpacer_5">
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
@@ -474,8 +446,6 @@
             </item>
            </layout>
           </item>
-
-
          </layout>
         </widget>
        </item>
@@ -489,73 +459,11 @@
          </property>
          <layout class="QGridLayout" name="gridLayout_3">
           <item row="0" column="0">
-           <layout class="QGridLayout" name="gridLayout_4" rowstretch="0,0,0,0,0" columnstretch="0,1,0,1">
-            <item row="0" column="0">
-             <widget class="QLabel" name="lblDuration">
-              <property name="text">
-               <string>Duration:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QLabel" name="txtDuration">
-              <property name="font">
-               <font>
-                <weight>75</weight>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="text">
-               <string/>
-              </property>
-              <property name="textInteractionFlags">
-               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-              </property>
-             </widget>
-            </item>
+           <layout class="QGridLayout" name="gridLayout_4" rowstretch="0,0,0,0,0,0" columnstretch="0,1,0,1">
             <item row="1" column="0">
              <widget class="QLabel" name="lblBpm">
               <property name="text">
                <string>BPM:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <widget class="QLabel" name="txtBpm">
-              <property name="font">
-               <font>
-                <weight>75</weight>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="text">
-               <string/>
-              </property>
-              <property name="textInteractionFlags">
-               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="lblReplayGain">
-              <property name="text">
-               <string>ReplayGain:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1">
-             <widget class="QLabel" name="txtReplayGain">
-              <property name="font">
-               <font>
-                <weight>75</weight>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="text">
-               <string/>
-              </property>
-              <property name="textInteractionFlags">
-               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
               </property>
              </widget>
             </item>
@@ -582,53 +490,7 @@
               </property>
              </widget>
             </item>
-            <item row="1" column="2">
-             <widget class="QLabel" name="lblBitrate">
-              <property name="text">
-               <string>Bitrate:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="3">
-             <widget class="QLabel" name="txtBitrate">
-              <property name="font">
-               <font>
-                <weight>75</weight>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="text">
-               <string/>
-              </property>
-              <property name="textInteractionFlags">
-               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="2">
-             <widget class="QLabel" name="lblDateAdded">
-              <property name="text">
-               <string>Date added:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="3">
-             <widget class="QLabel" name="txtDateAdded">
-              <property name="font">
-               <font>
-                <weight>75</weight>
-                <bold>true</bold>
-               </font>
-              </property>
-              <property name="text">
-               <string/>
-              </property>
-              <property name="textInteractionFlags">
-               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="0">
+            <item row="4" column="0">
              <widget class="QLabel" name="lblLocation">
               <property name="text">
                <string>Location:</string>
@@ -638,7 +500,7 @@
               </property>
              </widget>
             </item>
-            <item row="3" column="1" colspan="3">
+            <item row="4" column="1" colspan="3">
              <widget class="QLabel" name="txtLocation">
               <property name="text">
                <string/>
@@ -651,7 +513,21 @@
               </property>
              </widget>
             </item>
-            <item row="4" column="1" colspan="3">
+            <item row="1" column="2">
+             <widget class="QLabel" name="lblBitrate">
+              <property name="text">
+               <string>Bitrate:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QLabel" name="lblDuration">
+              <property name="text">
+               <string>Duration:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="1" colspan="3">
              <layout class="QHBoxLayout" name="horizontalLayout_5">
               <item>
                <widget class="QPushButton" name="btnOpenFileBrowser">
@@ -674,6 +550,120 @@
                </spacer>
               </item>
              </layout>
+            </item>
+            <item row="1" column="1">
+             <widget class="QLabel" name="txtBpm">
+              <property name="font">
+               <font>
+                <weight>75</weight>
+                <bold>true</bold>
+               </font>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="textInteractionFlags">
+               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="3">
+             <widget class="QLabel" name="txtBitrate">
+              <property name="font">
+               <font>
+                <weight>75</weight>
+                <bold>true</bold>
+               </font>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="textInteractionFlags">
+               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QLabel" name="txtDuration">
+              <property name="font">
+               <font>
+                <weight>75</weight>
+                <bold>true</bold>
+               </font>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="textInteractionFlags">
+               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="QLabel" name="lblReplayGain">
+              <property name="text">
+               <string>ReplayGain:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="lblDateAdded">
+              <property name="text">
+               <string>Date added:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <widget class="QLabel" name="txtReplayGain">
+              <property name="font">
+               <font>
+                <weight>75</weight>
+                <bold>true</bold>
+               </font>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="textInteractionFlags">
+               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QLabel" name="txtDateAdded">
+              <property name="font">
+               <font>
+                <weight>75</weight>
+                <bold>true</bold>
+               </font>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="textInteractionFlags">
+               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="2">
+             <widget class="QLabel" name="lblSamplerate">
+              <property name="text">
+               <string>Samplerate:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="3">
+             <widget class="QLabel" name="txtSamplerate">
+              <property name="font">
+               <font>
+                <weight>75</weight>
+                <bold>true</bold>
+               </font>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+             </widget>
             </item>
            </layout>
           </item>
@@ -698,7 +688,6 @@
        </item>
       </layout>
      </widget>
-
      <widget class="QWidget" name="tabBPM">
       <attribute name="title">
        <string>BPM</string>


### PR DESCRIPTION
During debug, I had no quick way to look up the sample rate. Here it is: 

![grafik](https://github.com/mixxxdj/mixxx/assets/1777442/d47ff02c-4209-45a8-8957-9ee6e8568092)

I think it is also useful for the user to pick the soundcard sample-rate. 

This is on top of 2.4 and can IMHO slip in 2.4. But I don't mind to merge it to 2.5 otherwise. 