### PR TITLE
Labeler: Migrate configuration to v5

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,86 +1,136 @@
 build:
-  - default.nix
-  - CMakeLists.txt
-  - build/**
-  - cmake/**
+  - changed-files:
+      - any-glob-to-any-file:
+          - default.nix
+          - CMakeLists.txt
+          - build/**
+          - cmake/**
 
 cmake:
-  - cmake/**
+  - changed-files:
+      - any-glob-to-any-file:
+          - cmake/**
 
 code quality:
-  - src/test/**
-  - .clang-format
-  - .codespell
-  - .eslint*
-  - .flake8
-  - .pre-commit-config.yaml
-  - pyproject.toml
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/test/**
+          - .clang-format
+          - .codespell
+          - .eslint*
+          - .flake8
+          - .pre-commit-config.yaml
+          - pyproject.toml
 
 controllers:
-  - res/controllers/**
+  - changed-files:
+      - any-glob-to-any-file:
+          - res/controllers/**
 
 analyzer:
-  - src/analyzer/**
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/analyzer/**
 
 broadcast:
-  - src/broadcast/**
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/broadcast/**
 
 effects:
-  - src/effects/**
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/effects/**
 
 engine:
-  - src/engine/**
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/engine/**
 
 sync:
-  - src/engine/sync/**
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/engine/sync/**
 
 library:
-  - src/library/**
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/library/**
 
 autodj:
-  - src/library/autodj/**
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/library/autodj/**
 
 browse:
-  - src/library/browse/**
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/library/browse/**
 
 itunes:
-  - src/library/itunes/**
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/library/itunes/**
 
 rekordbox:
-  - src/library/rekordbox/**
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/library/rekordbox/**
 
 scanner:
-  - src/library/scanner/**
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/library/scanner/**
 
 search:
-  - src/library/searchquery*
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/library/searchquery*
 
 serato:
-  - src/library/serato/**
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/library/serato/**
 
 packaging:
-  - packaging/**
+  - changed-files:
+      - any-glob-to-any-file:
+          - packaging/**
 
 preferences:
-  - src/preferences/**
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/preferences/**
 
 skins:
-  - res/skins/**
+  - changed-files:
+      - any-glob-to-any-file:
+          - res/skins/**
 
 soundio:
-  - src/soundio/**
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/soundio/**
 
 soundsource:
-  - src/sources/soundsource*
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/sources/soundsource*
 
 ui:
-  - src/**.ui
-  - src/dialog/**
-  - src/preferences/**
-  - src/widget/**
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/**.ui
+          - src/dialog/**
+          - src/preferences/**
+          - src/widget/**
 
 vinylcontrol:
-  - src/vinylcontrol/**
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/vinylcontrol/**
 
 waveform:
-  - src/waveform/**
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/waveform/**


### PR DESCRIPTION
This adapts our PR labeler configuration to the v5 syntax (which is broken as of #12394).

Note that we have to merge the PR for the updated configuration to take effect, even for this PR itself.