### PR TITLE
Trackmenu: shift cues and beats

### DIFF
--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -212,16 +212,7 @@ void BpmControl::slotTranslateBeatsMove(double v) {
     if (!pTrack) {
         return;
     }
-    const mixxx::BeatsPointer pBeats = pTrack->getBeats();
-    if (pBeats) {
-        // TODO(rryan): Track::frameInfo is possibly inaccurate!
-        const double sampleOffset = frameInfo().sampleRate * v * 0.01;
-        const mixxx::audio::FrameDiff_t frameOffset = sampleOffset / mixxx::kEngineChannelCount;
-        const auto translatedBeats = pBeats->tryTranslate(frameOffset);
-        if (translatedBeats) {
-            pTrack->trySetBeats(*translatedBeats);
-        }
-    }
+    pTrack->shiftBeatsMillis(5 * v); // 5ms * v
 }
 
 void BpmControl::slotBpmTap(double v) {

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -950,12 +950,27 @@ void Track::shiftCuePositionsMillis(double milliseconds) {
     VERIFY_OR_DEBUG_ASSERT(m_record.getStreamInfoFromSource()) {
         return;
     }
-    double frames = m_record.getStreamInfoFromSource()->getSignalInfo().millis2frames(milliseconds);
+    const double frames =
+            m_record.getStreamInfoFromSource()->getSignalInfo().millis2frames(
+                    milliseconds);
     for (const CuePointer& pCue : std::as_const(m_cuePoints)) {
         pCue->shiftPositionFrames(frames);
     }
 
     markDirtyAndUnlock(&locked);
+}
+
+void Track::shiftBeatsMillis(double milliseconds) {
+    if (milliseconds == 0 || !m_pBeats) {
+        return;
+    }
+    const double frames =
+            m_record.getStreamInfoFromSource()->getSignalInfo().millis2frames(
+                    milliseconds);
+    const auto translatedBeats = m_pBeats->tryTranslate(frames);
+    if (translatedBeats) {
+        trySetBeats(*translatedBeats);
+    }
 }
 
 void Track::analysisFinished() {

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -953,6 +953,7 @@ void Track::shiftCuePositionsMillis(double milliseconds) {
     const double frames =
             m_record.getStreamInfoFromSource()->getSignalInfo().millis2frames(
                     milliseconds);
+    qWarning() << "     cue shift by" << frames << "frames";
     for (const CuePointer& pCue : std::as_const(m_cuePoints)) {
         pCue->shiftPositionFrames(frames);
     }
@@ -967,6 +968,7 @@ void Track::shiftBeatsMillis(double milliseconds) {
     const double frames =
             m_record.getStreamInfoFromSource()->getSignalInfo().millis2frames(
                     milliseconds);
+    qWarning() << "     beat shift by" << frames << "frames";
     const auto translatedBeats = m_pBeats->tryTranslate(frames);
     if (translatedBeats) {
         trySetBeats(*translatedBeats);

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -290,6 +290,9 @@ class Track : public QObject {
     void setMainCuePosition(mixxx::audio::FramePos position);
     /// Shift all cues by a constant offset
     void shiftCuePositionsMillis(mixxx::audio::FrameDiff_t milliseconds);
+    /// Shift beatgrid by a constant offset
+    void shiftBeatsMillis(double milliseconds);
+
     // Call when analysis is done.
     void analysisFinished();
 

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -126,6 +126,7 @@ class WTrackMenu : public QMenu {
     void slotLockBpm();
     void slotUnlockBpm();
     void slotScaleBpm(mixxx::Beats::BpmScale scale);
+    void slotShiftCuesAndBeats();
 
     // Info and metadata
     void slotUpdateReplayGainFromPregain();
@@ -287,6 +288,7 @@ class WTrackMenu : public QMenu {
     QAction* m_pBpmFourThirdsAction{};
     QAction* m_pBpmThreeHalvesAction{};
     QAction* m_pBpmResetAction{};
+    QAction* m_pBpmShiftCuesAndBeatsAction{};
 
     // Track color
     WColorPickerAction* m_pColorPickerAction{};


### PR DESCRIPTION
I was wondering why fixing track offsets after migration or decoder changes requires shifting beats and cues individually per track.

Since no automatic detection / solution is in sight...
Adds an action to the track menu that allows shifting both beats and cues by an abitrary amount.
The last used offset is remembered.

The idea is that users can collect affected tracks that appear being shifted by the same amount, check with one track how much the cues are off, and mass-fix them easily.
Can't tell which relevance this has (never had such issues lately), but #2737 has been implememented for a reason.

**Notes**
* the tooltips for `shift_cues_..` mention the offset (10ms) while `beats_translate_...` just says "a small amount"