### PR TITLE
A small fix to .desktop file that improves Gnome dock integration on

### DIFF
--- a/res/linux/org.mixxx.Mixxx.desktop
+++ b/res/linux/org.mixxx.Mixxx.desktop
@@ -13,4 +13,5 @@ Terminal=false
 Icon=mixxx
 Type=Application
 StartupNotify=true
+StartupWMClass=org.mixxx.mixxx
 Categories=Qt;AudioVideo;Audio;Midi;Mixer;Player;Recorder;Sequencer;


### PR DESCRIPTION
linux.
The issue was that without that line gnome dock couldn't pick right icon for Mixxx window and it wasn't possible to pin Mixxx to the dock. Both fixed.