### PR TITLE
NI Traktor Kontrol Z1: Synchronize control positions on startup

### DIFF
--- a/res/controllers/Traktor-Kontrol-Z1-scripts.js
+++ b/res/controllers/Traktor-Kontrol-Z1-scripts.js
@@ -12,7 +12,7 @@ class TraktorZ1Class {
         // Modifier state
         this.modePressed = false;
 
-        // VuMeter
+        // VU meters
         this.vuLeftConnection = {};
         this.vuRightConnection = {};
         this.vuMeterThresholds = {"vu-30": (1 / 7), "vu-15": (2 / 7), "vu-6": (3 / 7), "vu-3": (4 / 7), "vu0": (5 / 7), "vu3": (6 / 7), "vu6": (7 / 7)};
@@ -186,7 +186,7 @@ class TraktorZ1Class {
             if (this.vuMeterThresholds[vuKeys[i]] > value) {
                 this.controller.setOutput(group, vuKeys[i], 0x00, last);
             } else {
-                this.controller.setOutput(group, vuKeys[i], 0x7E, last);
+                this.controller.setOutput(group, vuKeys[i], 0x7F, last);
             }
         }
     }


### PR DESCRIPTION
Greetings,

This PR implements the really useful startup controls sync code from the official Traktor S2 MK1 script. This made it necessary to move takeovers to a separate function, but that likely only improved the overall structure. I also fixed a small typo and a LED brightness discrepancy.

Let me know if changes are needed. Thanks!