### PR TITLE
Fix gain issue with cloned tracks

### DIFF
--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -171,6 +171,8 @@ EngineBuffer::EngineBuffer(const QString& group,
     m_pKeylock = new ControlPushButton(ConfigKey(m_group, "keylock"), true);
     m_pKeylock->setButtonMode(ControlPushButton::TOGGLE);
 
+    m_pReplayGain = new ControlProxy(m_group, QStringLiteral("replaygain"), this);
+
     m_pTrackLoaded = new ControlObject(ConfigKey(m_group, "track_loaded"), false);
     m_pTrackLoaded->setReadOnly();
 
@@ -308,6 +310,7 @@ EngineBuffer::~EngineBuffer() {
     delete m_pScaleRB;
 
     delete m_pKeylock;
+    delete m_pReplayGain;
 
     SampleUtil::free(m_pCrossfadeBuffer);
 
@@ -539,6 +542,8 @@ void EngineBuffer::slotTrackLoaded(TrackPointer pTrack,
     m_dSlipRate = 0;
     m_slipModeState = SlipModeState::Disabled;
 
+    m_pReplayGain->set(pTrack->getReplayGain().getRatio());
+
     m_queuedSeek.setValue(kNoQueuedSeek);
 
     // Reset the pitch value for the new track.
@@ -602,6 +607,8 @@ void EngineBuffer::ejectTrack() {
     m_playButton->set(0.0);
     m_playposSlider->set(0);
     m_pCueControl->resetIndicators();
+
+    m_pReplayGain->set(0.0);
 
     m_queuedSeek.setValue(kNoQueuedSeek);
 

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -374,6 +374,7 @@ class EngineBuffer : public EngineObject {
     ControlProxy* m_pSampleRate;
     ControlProxy* m_pKeylockEngine;
     ControlPushButton* m_pKeylock;
+    ControlProxy* m_pReplayGain;
 
     // This ControlProxys is created as parent to this and deleted by
     // the Qt object tree. This helps that they are deleted by the creating

--- a/src/engine/enginepregain.cpp
+++ b/src/engine/enginepregain.cpp
@@ -11,11 +11,11 @@
 namespace {
 
 // Bends the speed to gain curve for a natural vinyl sound
-constexpr float kSpeedGainMultiplier = 4.0f;
+constexpr CSAMPLE_GAIN kSpeedGainMultiplier = 4.0f;
 // -1 dB to not risk any clipping even for lossy track that may have samples above 1.0
-constexpr float kMaxTotalGainBySpeed = 0.9f;
+constexpr CSAMPLE_GAIN kMaxTotalGainBySpeed = 0.9f;
 // value to normalize gain to 1 at speed one
-const float kSpeedOneDiv = std::log10((1 * kSpeedGainMultiplier) + 1);
+const CSAMPLE_GAIN kSpeedOneDiv = std::log10((1 * kSpeedGainMultiplier) + 1);
 } // anonymous namespace
 
 ControlPotmeter* EnginePregain::s_pReplayGainBoost = nullptr;
@@ -75,7 +75,7 @@ void EnginePregain::process(CSAMPLE* pInOut, const int iBufferSize) {
         fReplayGainCorrection = 1; // We expect a replaygain leveled input
     } else if (fReplayGain == 0) {
         // use predicted replaygain
-        fReplayGainCorrection = (float)s_pDefaultBoost->get();
+        fReplayGainCorrection = static_cast<CSAMPLE_GAIN>(s_pDefaultBoost->get());
         // We prepare for smoothfading to ReplayGain suggested gain
         // if ReplayGain value changes or ReplayGain is enabled
         m_bSmoothFade = true;
@@ -88,12 +88,12 @@ void EnginePregain::process(CSAMPLE* pInOut, const int iBufferSize) {
         // full process for one second.
         // So we need to alter gain each time ::process is called.
 
-        const float fullReplayGainBoost =
-                fReplayGain * static_cast<float>(s_pReplayGainBoost->get());
+        const CSAMPLE_GAIN fullReplayGainBoost =
+                fReplayGain * static_cast<CSAMPLE_GAIN>(s_pReplayGainBoost->get());
 
         // This means that a ReplayGain value has been calculated after the
         // track has been loaded
-        constexpr float kFadeSeconds = 1.0;
+        constexpr float kFadeSeconds = 1.0f;
 
         if (m_bSmoothFade) {
             float seconds = static_cast<float>(m_timer.elapsed().toDoubleSeconds());
@@ -115,7 +115,7 @@ void EnginePregain::process(CSAMPLE* pInOut, const int iBufferSize) {
     // Clamp gain to within [0, 10.0] to prevent insane gains. This can happen
     // (some corrupt files get really high replay gain values).
     // 10 allows a maximum replay Gain Boost * calculated replay gain of ~2
-    CSAMPLE_GAIN totalGain = (CSAMPLE_GAIN)m_pPotmeterPregain->get() *
+    auto totalGain = static_cast<CSAMPLE_GAIN>(m_pPotmeterPregain->get()) *
             math_clamp(fReplayGainCorrection, 0.0f, 10.0f);
 
     m_pTotalGain->set(totalGain);

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -527,7 +527,6 @@ void BaseTrackPlayerImpl::slotTrackLoaded(TrackPointer pNewTrack,
         m_pDuration->set(0);
         m_pFileBPM->set(0);
         m_pKey->set(0);
-        setReplayGain(0);
         slotSetTrackColor(std::nullopt);
         m_pLoopInPoint->set(kNoTrigger);
         m_pLoopOutPoint->set(kNoTrigger);
@@ -547,7 +546,6 @@ void BaseTrackPlayerImpl::slotTrackLoaded(TrackPointer pNewTrack,
         m_pDuration->set(m_pLoadedTrack->getDuration());
         m_pFileBPM->set(m_pLoadedTrack->getBpm());
         m_pKey->set(m_pLoadedTrack->getKey());
-        setReplayGain(m_pLoadedTrack->getReplayGain().getRatio());
         slotSetTrackColor(m_pLoadedTrack->getColor());
 
         if(m_pConfig->getValue(


### PR DESCRIPTION
This PR fixes #10550 Via a couple of single fixes regarding using the right data at the right time. 

This finally allows to play two cloned tracks with changing tempo without that the leader applies future or outdated tempo changes to the follower. 