### PR TITLE
Link library DJINTEROP as PUBLIC, to make it visible in mixxx-test too

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2314,7 +2314,7 @@ if(ENGINEPRIME)
   if(DjInterop_FOUND)
     # An existing installation of djinterop is available.
     message(STATUS "STATIC link existing system installation of libdjinterop")
-    target_link_libraries(mixxx-lib PRIVATE DjInterop::DjInterop)
+    target_link_libraries(mixxx-lib PUBLIC DjInterop::DjInterop)
   else()
     # On MacOS, Mixxx does not use system SQLite, so we will use libdjinterop's
     # embedded SQLite in such a case.


### PR DESCRIPTION
This fixes a build issue, when libdjinterop is used from the VCPKG buildenv. Currently we use the VCPKG version of libdjnterop only in the Main branch. Therefore the build of 2.4 did not fail, but the bug in the CMakelist is also in here.
That it works can be seen in this Main based branch:
https://github.com/JoergAtGithub/mixxx/actions/runs/7267409626/job/19801163505
