### PR TITLE
Sandbox: Fix regression that caused `Sandbox::canAccess` to fail

### DIFF
--- a/src/util/sandbox.cpp
+++ b/src/util/sandbox.cpp
@@ -75,13 +75,17 @@ bool Sandbox::canAccess(mixxx::FileInfo* pFileInfo) {
     VERIFY_OR_DEBUG_ASSERT(pFileInfo) {
         return false;
     }
-    openSecurityToken(pFileInfo, true);
+    // NOTE: The token must be assigned to a variable, otherwise it will be
+    // invalidated immediately (causing `isReadable` to fail).
+    auto token = openSecurityToken(pFileInfo, true);
     return pFileInfo->isReadable();
 }
 
 //static
 bool Sandbox::canAccessDir(const QDir& dir) {
-    openSecurityTokenForDir(dir, true);
+    // NOTE: The token must be assigned to a variable, otherwise it will be
+    // invalidated immediately (causing `isReadable` to fail).
+    auto token = openSecurityTokenForDir(dir, true);
     return QFileInfo(dir.canonicalPath()).isReadable();
 }
 

--- a/src/util/sandbox.h
+++ b/src/util/sandbox.h
@@ -54,17 +54,17 @@ class Sandbox {
     }
 
 #if defined(__GNUC__) && __cplusplus < 201907L
-#define RATIONALE
+#define SECURITY_TOKEN_NODISCARD_RATIONALE
 #else
-#define RATIONALE                                                      \
+#define SECURITY_TOKEN_NODISCARD_RATIONALE                             \
     ("A new security token should be used, e.g. by assigning it to a " \
      "variable, otherwise it will be invalidated immediately.")
 #endif
 
-    [[nodiscard RATIONALE]] static SecurityTokenPointer openSecurityToken(
-            mixxx::FileInfo* pFileInfo, bool create);
-    [[nodiscard RATIONALE]] static SecurityTokenPointer openSecurityTokenForDir(
-            const QDir& dir, bool create);
+    [[nodiscard SECURITY_TOKEN_NODISCARD_RATIONALE]] static SecurityTokenPointer
+    openSecurityToken(mixxx::FileInfo* pFileInfo, bool create);
+    [[nodiscard SECURITY_TOKEN_NODISCARD_RATIONALE]] static SecurityTokenPointer
+    openSecurityTokenForDir(const QDir& dir, bool create);
 
   private:
     Sandbox() = delete;
@@ -72,7 +72,8 @@ class Sandbox {
     static ConfigKey keyForCanonicalPath(const QString& canonicalPath);
 
     // Must hold s_mutex to call this.
-    [[nodiscard RATIONALE]] static SecurityTokenPointer openTokenFromBookmark(
+    [[nodiscard SECURITY_TOKEN_NODISCARD_RATIONALE]] static SecurityTokenPointer
+    openTokenFromBookmark(
             const QString& canonicalPath, const QString& bookmarkBase64);
 
     // Creates a security token. s_mutex is not needed for this method.

--- a/src/util/sandbox.h
+++ b/src/util/sandbox.h
@@ -53,14 +53,18 @@ class Sandbox {
         return createSecurityToken(dir.canonicalPath(), true);
     }
 
-    [[nodiscard(
-            "A new security token should be assigned to a variable, otherwise "
-            "it will be invalidated immediately.")]] static SecurityTokenPointer
-    openSecurityToken(mixxx::FileInfo* pFileInfo, bool create);
-    [[nodiscard(
-            "A new security token should be assigned to a variable, otherwise "
-            "it will be invalidated immediately.")]] static SecurityTokenPointer
-    openSecurityTokenForDir(const QDir& dir, bool create);
+#if defined(__GNUC__) && __cplusplus < 201907L
+#define RATIONALE
+#else
+#define RATIONALE                                                           \
+    ("A new security token should be assigned to a variable, otherwise it " \
+     "will be invalidated immediately.")
+#endif
+
+    [[nodiscard RATIONALE]] static SecurityTokenPointer openSecurityToken(
+            mixxx::FileInfo* pFileInfo, bool create);
+    [[nodiscard RATIONALE]] static SecurityTokenPointer openSecurityTokenForDir(
+            const QDir& dir, bool create);
 
   private:
     Sandbox() = delete;

--- a/src/util/sandbox.h
+++ b/src/util/sandbox.h
@@ -56,9 +56,9 @@ class Sandbox {
 #if defined(__GNUC__) && __cplusplus < 201907L
 #define RATIONALE
 #else
-#define RATIONALE                                                           \
-    ("A new security token should be assigned to a variable, otherwise it " \
-     "will be invalidated immediately.")
+#define RATIONALE                                                      \
+    ("A new security token should be used, e.g. by assigning it to a " \
+     "variable, otherwise it will be invalidated immediately.")
 #endif
 
     [[nodiscard RATIONALE]] static SecurityTokenPointer openSecurityToken(

--- a/src/util/sandbox.h
+++ b/src/util/sandbox.h
@@ -53,8 +53,14 @@ class Sandbox {
         return createSecurityToken(dir.canonicalPath(), true);
     }
 
-    static SecurityTokenPointer openSecurityToken(mixxx::FileInfo* pFileInfo, bool create);
-    static SecurityTokenPointer openSecurityTokenForDir(const QDir& dir, bool create);
+    [[nodiscard(
+            "A new security token should be assigned to a variable, otherwise "
+            "it will be invalidated immediately.")]] static SecurityTokenPointer
+    openSecurityToken(mixxx::FileInfo* pFileInfo, bool create);
+    [[nodiscard(
+            "A new security token should be assigned to a variable, otherwise "
+            "it will be invalidated immediately.")]] static SecurityTokenPointer
+    openSecurityTokenForDir(const QDir& dir, bool create);
 
   private:
     Sandbox() = delete;

--- a/src/util/sandbox.h
+++ b/src/util/sandbox.h
@@ -72,8 +72,8 @@ class Sandbox {
     static ConfigKey keyForCanonicalPath(const QString& canonicalPath);
 
     // Must hold s_mutex to call this.
-    static SecurityTokenPointer openTokenFromBookmark(const QString& canonicalPath,
-                                                      const QString& bookmarkBase64);
+    [[nodiscard RATIONALE]] static SecurityTokenPointer openTokenFromBookmark(
+            const QString& canonicalPath, const QString& bookmarkBase64);
 
     // Creates a security token. s_mutex is not needed for this method.
     static bool createSecurityToken(const QString& canonicalPath, bool isDirectory);


### PR DESCRIPTION
### Fixes #12137 (and #11552)

This fixes a regression with macOS sandboxing introduced in #3761 that caused `Sandbox::canAccess` to always fail and to wrongly present this dialog on every launch:

![image](https://github.com/mixxxdj/mixxx/assets/30873659/22216957-803f-445b-aee4-91fab97a887c)

The issue was that the token is not assigned to a variable and thus immediately deinitialized (and invalidated):

```cpp
bool Sandbox::canAccess(mixxx::FileInfo* pFileInfo) {
    ...
    openSecurityToken(pFileInfo, true); // Token is invalidated immediately
    return pFileInfo->isReadable();     // therefore this may wrongly return false!
}
```

See https://github.com/mixxxdj/mixxx/pull/3761#issuecomment-1867131495 for details. To avoid regressing on this in the future, I have added a `[[nodiscard]]` to the `openSecurityToken` methods, which will generate a warning if used like this again.