### PR TITLE
Remove redundant #include "moc_nativeeventhandlerwin.cpp"

### DIFF
--- a/src/nativeeventhandlerwin.cpp
+++ b/src/nativeeventhandlerwin.cpp
@@ -8,8 +8,6 @@
 #include <winuser.h>  // for MSG, RedrawWindow PostMessageW
 // clang-format on
 
-#include "moc_nativeeventhandlerwin.cpp"
-
 bool WindowsEventHandler::nativeEventFilter(
         const QByteArray& eventType,
         void* message,


### PR DESCRIPTION
This was the root cause for the moc warning discussed here: https://github.com/mixxxdj/mixxx/pull/12450
