### PR TITLE
Library: fix track relocation query

### DIFF
--- a/src/library/dao/directorydao.cpp
+++ b/src/library/dao/directorydao.cpp
@@ -201,8 +201,9 @@ QList<RelocatedTrack> DirectoryDAO::relocateDirectory(
     const QString replacement = "UPDATE track_locations SET location=:newloc WHERE id=:id";
     query.prepare(replacement);
     for (int i = 0; i < loc_ids.size(); ++i) {
-        query.bindValue("newloc", relocatedTracks.at(i).updatedTrackRef().getLocation());
-        query.bindValue("id", loc_ids.at(i).toVariant());
+        query.bindValue(QStringLiteral(":newloc"),
+                relocatedTracks.at(i).updatedTrackRef().getLocation());
+        query.bindValue(QStringLiteral(":id"), loc_ids.at(i).toVariant());
         if (!query.exec()) {
             LOG_FAILED_QUERY(query) << "could not relocate path of tracks";
             return {};

--- a/src/library/dao/directorydao.cpp
+++ b/src/library/dao/directorydao.cpp
@@ -198,14 +198,16 @@ QList<RelocatedTrack> DirectoryDAO::relocateDirectory(
 
     // Also update information in the track_locations table. This is where mixxx
     // gets the location information for a track.
-    const QString replacement = "UPDATE track_locations SET location=:newloc WHERE id=:id";
+    const QString replacement =
+            "UPDATE track_locations SET location=:newloc, directory=:newdir WHERE id=:id";
     query.prepare(replacement);
     for (int i = 0; i < loc_ids.size(); ++i) {
         query.bindValue(QStringLiteral(":newloc"),
                 relocatedTracks.at(i).updatedTrackRef().getLocation());
+        query.bindValue(QStringLiteral(":newdir"), newDirectory);
         query.bindValue(QStringLiteral(":id"), loc_ids.at(i).toVariant());
         if (!query.exec()) {
-            LOG_FAILED_QUERY(query) << "could not relocate path of tracks";
+            LOG_FAILED_QUERY(query) << "could not relocate path of track";
             return {};
         }
     }


### PR DESCRIPTION
After all it was missing `:` that made the entire relocation fail.
Seems this was broken for years.

I'm surprised there's no error raised for no-op `bindvalue()`.

mentioning **Relink** so I find this PR later on