### PR TITLE
Waveform tweaks

### DIFF
--- a/src/analyzer/analyzerwaveform.h
+++ b/src/analyzer/analyzerwaveform.h
@@ -26,6 +26,10 @@ inline CSAMPLE scaleSignal(CSAMPLE invalue, FilterIndex index = FilterCount) {
     } else {
         return std::pow(invalue, 2.0f * 0.316f);
     }
+
+    // TODO this function needs an explanation of why this scaling is applied.
+    // Note that in the allshader waveform-renderers, this scaling is undone for
+    // the filtered.all band.
 }
 
 struct WaveformStride {

--- a/src/analyzer/analyzerwaveform.h
+++ b/src/analyzer/analyzerwaveform.h
@@ -27,9 +27,15 @@ inline CSAMPLE scaleSignal(CSAMPLE invalue, FilterIndex index = FilterCount) {
         return std::pow(invalue, 2.0f * 0.316f);
     }
 
-    // TODO this function needs an explanation of why this scaling is applied.
-    // Note that in the allshader waveform-renderers, this scaling is undone for
-    // the filtered.all band.
+    // According to this discussion
+    // https://github.com/mixxxdj/mixxx/issues/6352
+    // it looks like this scaling is done to accentuate
+    // low level information.
+
+    // This scaling can be undone with a function in
+    //  waveform/renderers/waveformrenderersignalbase.h
+    // but arguable it would be better not to do this scaling here at all
+    // and do it (or not) at the waveform renderer side.
 }
 
 struct WaveformStride {

--- a/src/waveform/renderers/allshader/waveformrendererfiltered.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererfiltered.cpp
@@ -60,7 +60,7 @@ void WaveformRendererFiltered::paintGL() {
     // Per-band gain from the EQ knobs.
     float allGain{1.0};
     float bandGain[3] = {1.0, 1.0, 1.0};
-    getGains(&allGain, &bandGain[0], &bandGain[1], &bandGain[2]);
+    getGains(&allGain, true, &bandGain[0], &bandGain[1], &bandGain[2]);
 
     const float breadth = static_cast<float>(m_waveformRenderer->getBreadth()) * devicePixelRatio;
     const float halfBreadth = breadth / 2.0f;

--- a/src/waveform/renderers/allshader/waveformrendererhsv.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererhsv.cpp
@@ -59,7 +59,7 @@ void WaveformRendererHSV::paintGL() {
             (lastVisualFrame - firstVisualFrame) / static_cast<double>(length);
 
     float allGain(1.0);
-    getGains(&allGain, nullptr, nullptr, nullptr);
+    getGains(&allGain, false, nullptr, nullptr, nullptr);
 
     // Get base color of waveform in the HSV format (s and v isn't use)
     float h, s, v;

--- a/src/waveform/renderers/allshader/waveformrendererhsv.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererhsv.cpp
@@ -129,7 +129,8 @@ void WaveformRendererHSV::paintGL() {
             maxLow[chn] = static_cast<float>(u8maxLow);
             maxMid[chn] = static_cast<float>(u8maxMid);
             maxHigh[chn] = static_cast<float>(u8maxHigh);
-            maxAll[chn] = static_cast<float>(u8maxAll);
+            // Undo scaling with pow(value, 2.0f * 0.316f) done in analyzerwaveform.h
+            maxAll[chn] = unscale(u8maxAll);
         }
 
         float total{};

--- a/src/waveform/renderers/allshader/waveformrendererhsv.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererhsv.cpp
@@ -129,8 +129,9 @@ void WaveformRendererHSV::paintGL() {
             maxLow[chn] = static_cast<float>(u8maxLow);
             maxMid[chn] = static_cast<float>(u8maxMid);
             maxHigh[chn] = static_cast<float>(u8maxHigh);
-            // Undo scaling with pow(value, 2.0f * 0.316f) done in analyzerwaveform.h
-            maxAll[chn] = unscale(u8maxAll);
+            maxAll[chn] = static_cast<float>(u8maxAll);
+            // Uncomment to undo scaling with pow(value, 2.0f * 0.316f) done in analyzerwaveform.h
+            // maxAll[chn] = unscale(u8maxAll);
         }
 
         float total{};

--- a/src/waveform/renderers/allshader/waveformrendererlrrgb.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererlrrgb.cpp
@@ -65,7 +65,8 @@ void WaveformRendererLRRGB::paintGL() {
 
     // Per-band gain from the EQ knobs.
     float allGain(1.0), lowGain(1.0), midGain(1.0), highGain(1.0);
-    getGains(&allGain, &lowGain, &midGain, &highGain);
+    // applyCompensation = false, as we scale to match filtered.all
+    getGains(&allGain, false, &lowGain, &midGain, &highGain);
 
     const float breadth = static_cast<float>(m_waveformRenderer->getBreadth()) * devicePixelRatio;
     const float halfBreadth = breadth / 2.0f;

--- a/src/waveform/renderers/allshader/waveformrendererlrrgb.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererlrrgb.cpp
@@ -136,7 +136,8 @@ void WaveformRendererLRRGB::paintGL() {
             float maxLow = static_cast<float>(u8maxLow);
             float maxMid = static_cast<float>(u8maxMid);
             float maxHigh = static_cast<float>(u8maxHigh);
-            float maxAll = static_cast<float>(u8maxAll);
+            // Undo scaling with pow(value, 2.0f * 0.316f) done in analyzerwaveform.h
+            float maxAll = unscale(u8maxAll);
 
             // Calculate the squared magnitude of the maxLow, maxMid and maxHigh values.
             // We take the square root to get the magnitude below.

--- a/src/waveform/renderers/allshader/waveformrendererlrrgb.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererlrrgb.cpp
@@ -136,8 +136,9 @@ void WaveformRendererLRRGB::paintGL() {
             float maxLow = static_cast<float>(u8maxLow);
             float maxMid = static_cast<float>(u8maxMid);
             float maxHigh = static_cast<float>(u8maxHigh);
-            // Undo scaling with pow(value, 2.0f * 0.316f) done in analyzerwaveform.h
-            float maxAll = unscale(u8maxAll);
+            float maxAll = static_cast<float>(u8maxAll);
+            // Uncomment to undo scaling with pow(value, 2.0f * 0.316f) done in analyzerwaveform.h
+            // float maxAll = unscale(u8maxAll);
 
             // Calculate the squared magnitude of the maxLow, maxMid and maxHigh values.
             // We take the square root to get the magnitude below.

--- a/src/waveform/renderers/allshader/waveformrendererrgb.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererrgb.cpp
@@ -138,7 +138,8 @@ void WaveformRendererRGB::paintGL() {
         float maxLow = static_cast<float>(u8maxLow);
         float maxMid = static_cast<float>(u8maxMid);
         float maxHigh = static_cast<float>(u8maxHigh);
-        float maxAllChn[2]{static_cast<float>(u8maxAllChn[0]), static_cast<float>(u8maxAllChn[1])};
+        // Undo scaling with pow(value, 2.0f * 0.316f) done in analyzerwaveform.h
+        float maxAllChn[2]{unscale(u8maxAllChn[0]), unscale(u8maxAllChn[1])};
 
         // Calculate the squared magnitude of the maxLow, maxMid and maxHigh values.
         // We take the square root to get the magnitude below.

--- a/src/waveform/renderers/allshader/waveformrendererrgb.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererrgb.cpp
@@ -65,7 +65,8 @@ void WaveformRendererRGB::paintGL() {
 
     // Per-band gain from the EQ knobs.
     float allGain(1.0), lowGain(1.0), midGain(1.0), highGain(1.0);
-    getGains(&allGain, &lowGain, &midGain, &highGain);
+    // applyCompensation = false, as we scale to match filtered.all
+    getGains(&allGain, false, &lowGain, &midGain, &highGain);
 
     const float breadth = static_cast<float>(m_waveformRenderer->getBreadth()) * devicePixelRatio;
     const float halfBreadth = breadth / 2.0f;

--- a/src/waveform/renderers/allshader/waveformrendererrgb.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererrgb.cpp
@@ -138,8 +138,9 @@ void WaveformRendererRGB::paintGL() {
         float maxLow = static_cast<float>(u8maxLow);
         float maxMid = static_cast<float>(u8maxMid);
         float maxHigh = static_cast<float>(u8maxHigh);
-        // Undo scaling with pow(value, 2.0f * 0.316f) done in analyzerwaveform.h
-        float maxAllChn[2]{unscale(u8maxAllChn[0]), unscale(u8maxAllChn[1])};
+        float maxAllChn[2]{static_cast<float>(u8maxAllChn[0]), static_cast<float>(u8maxAllChn[1])};
+        // Uncomment to undo scaling with pow(value, 2.0f * 0.316f) done in analyzerwaveform.h
+        // float maxAllChn[2]{unscale(u8maxAllChn[0]), unscale(u8maxAllChn[1])};
 
         // Calculate the squared magnitude of the maxLow, maxMid and maxHigh values.
         // We take the square root to get the magnitude below.

--- a/src/waveform/renderers/allshader/waveformrenderersimple.cpp
+++ b/src/waveform/renderers/allshader/waveformrenderersimple.cpp
@@ -119,7 +119,8 @@ void WaveformRendererSimple::paintGL() {
             // data is interleaved left / right
             for (int i = visualIndexStart + chn; i < visualIndexStop + chn; i += 2) {
                 const WaveformData& waveformData = data[i];
-                const float filteredAll = static_cast<float>(waveformData.filtered.all);
+                // Undo scaling with pow(value, 2.0f * 0.316f) done in analyzerwaveform.h
+                const float filteredAll = unscale(waveformData.filtered.all);
 
                 max[chn] = math_max(max[chn], filteredAll);
             }

--- a/src/waveform/renderers/allshader/waveformrenderersimple.cpp
+++ b/src/waveform/renderers/allshader/waveformrenderersimple.cpp
@@ -65,7 +65,7 @@ void WaveformRendererSimple::paintGL() {
     // Per-band gain from the EQ knobs.
     float allGain{1.0};
     float bandGain[3] = {1.0, 1.0, 1.0};
-    getGains(&allGain, &bandGain[0], &bandGain[1], &bandGain[2]);
+    getGains(&allGain, false, &bandGain[0], &bandGain[1], &bandGain[2]);
 
     const float breadth = static_cast<float>(m_waveformRenderer->getBreadth()) * devicePixelRatio;
     const float halfBreadth = breadth / 2.0f;

--- a/src/waveform/renderers/allshader/waveformrenderersimple.cpp
+++ b/src/waveform/renderers/allshader/waveformrenderersimple.cpp
@@ -119,8 +119,10 @@ void WaveformRendererSimple::paintGL() {
             // data is interleaved left / right
             for (int i = visualIndexStart + chn; i < visualIndexStop + chn; i += 2) {
                 const WaveformData& waveformData = data[i];
-                // Undo scaling with pow(value, 2.0f * 0.316f) done in analyzerwaveform.h
-                const float filteredAll = unscale(waveformData.filtered.all);
+                const float filteredAll = static_cast<float>(waveformData.filtered.all);
+                // Uncomment to undo scaling with pow(value, 2.0f * 0.316f) done
+                // in analyzerwaveform.h const float filteredAll =
+                // unscale(waveformData.filtered.all);
 
                 max[chn] = math_max(max[chn], filteredAll);
             }

--- a/src/waveform/renderers/glslwaveformrenderersignal.cpp
+++ b/src/waveform/renderers/glslwaveformrenderersignal.cpp
@@ -297,7 +297,7 @@ void GLSLWaveformRendererSignal::draw(QPainter* painter, QPaintEvent* /*event*/)
 
     // Per-band gain from the EQ knobs.
     float lowGain(1.0), midGain(1.0), highGain(1.0), allGain(1.0);
-    getGains(&allGain, &lowGain, &midGain, &highGain);
+    getGains(&allGain, true, &lowGain, &midGain, &highGain);
 
     const auto firstVisualIndex = static_cast<GLfloat>(
             m_waveformRenderer->getFirstDisplayedPosition() * trackSamples /

--- a/src/waveform/renderers/glwaveformrendererfilteredsignal.cpp
+++ b/src/waveform/renderers/glwaveformrendererfilteredsignal.cpp
@@ -67,7 +67,7 @@ void GLWaveformRendererFilteredSignal::draw(QPainter* painter, QPaintEvent* /*ev
 
     // Per-band gain from the EQ knobs.
     float allGain(1.0), lowGain(1.0), midGain(1.0), highGain(1.0);
-    getGains(&allGain, &lowGain, &midGain, &highGain);
+    getGains(&allGain, true, &lowGain, &midGain, &highGain);
 
     if (m_alignment == Qt::AlignCenter) {
         glMatrixMode(GL_PROJECTION);

--- a/src/waveform/renderers/glwaveformrendererrgb.cpp
+++ b/src/waveform/renderers/glwaveformrendererrgb.cpp
@@ -67,7 +67,7 @@ void GLWaveformRendererRGB::draw(QPainter* painter, QPaintEvent* /*event*/) {
 
     // Per-band gain from the EQ knobs.
     float allGain(1.0), lowGain(1.0), midGain(1.0), highGain(1.0);
-    getGains(&allGain, &lowGain, &midGain, &highGain);
+    getGains(&allGain, true, &lowGain, &midGain, &highGain);
 
     if (m_alignment == Qt::AlignCenter) {
         glMatrixMode(GL_PROJECTION);

--- a/src/waveform/renderers/glwaveformrenderersimplesignal.cpp
+++ b/src/waveform/renderers/glwaveformrenderersimplesignal.cpp
@@ -68,7 +68,7 @@ void GLWaveformRendererSimpleSignal::draw(QPainter* painter, QPaintEvent* /*even
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
     float allGain(1.0);
-    getGains(&allGain, nullptr, nullptr, nullptr);
+    getGains(&allGain, false, nullptr, nullptr, nullptr);
 
     if (m_alignment == Qt::AlignCenter) {
         glMatrixMode(GL_PROJECTION);

--- a/src/waveform/renderers/waveformrendererfilteredsignal.cpp
+++ b/src/waveform/renderers/waveformrendererfilteredsignal.cpp
@@ -76,7 +76,7 @@ void WaveformRendererFilteredSignal::draw(QPainter* painter,
 
     // Per-band gain from the EQ knobs.
     float allGain(1.0), lowGain(1.0), midGain(1.0), highGain(1.0);
-    getGains(&allGain, &lowGain, &midGain, &highGain);
+    getGains(&allGain, true, &lowGain, &midGain, &highGain);
 
     const float breadth = m_waveformRenderer->getBreadth();
     const float halfBreadth = breadth / 2.0f;

--- a/src/waveform/renderers/waveformrendererhsv.cpp
+++ b/src/waveform/renderers/waveformrendererhsv.cpp
@@ -73,7 +73,7 @@ void WaveformRendererHSV::draw(
             (double)m_waveformRenderer->getLength();
 
     float allGain(1.0);
-    getGains(&allGain, nullptr, nullptr, nullptr);
+    getGains(&allGain, false, nullptr, nullptr, nullptr);
 
     // Get base color of waveform in the HSV format (s and v isn't use)
     float h, s, v;

--- a/src/waveform/renderers/waveformrendererrgb.cpp
+++ b/src/waveform/renderers/waveformrendererrgb.cpp
@@ -71,7 +71,7 @@ void WaveformRendererRGB::draw(
 
     // Per-band gain from the EQ knobs.
     float allGain(1.0), lowGain(1.0), midGain(1.0), highGain(1.0);
-    getGains(&allGain, &lowGain, &midGain, &highGain);
+    getGains(&allGain, true, &lowGain, &midGain, &highGain);
 
     QColor color;
 

--- a/src/waveform/renderers/waveformrenderersignalbase.cpp
+++ b/src/waveform/renderers/waveformrenderersignalbase.cpp
@@ -169,11 +169,14 @@ void WaveformRendererSignalBase::setup(const QDomNode& node,
     onSetup(node);
 }
 
-void WaveformRendererSignalBase::getGains(float* pAllGain, float* pLowGain,
-                                          float* pMidGain, float* pHighGain) {
+void WaveformRendererSignalBase::getGains(float* pAllGain,
+        bool applyCompensation,
+        float* pLowGain,
+        float* pMidGain,
+        float* pHighGain) {
     WaveformWidgetFactory* factory = WaveformWidgetFactory::instance();
     if (pAllGain) {
-        *pAllGain = static_cast<CSAMPLE_GAIN>(m_waveformRenderer->getGain()) *
+        *pAllGain = static_cast<CSAMPLE_GAIN>(m_waveformRenderer->getGain(applyCompensation)) *
                 static_cast<CSAMPLE_GAIN>(factory->getVisualGain(WaveformWidgetFactory::All));
         ;
     }

--- a/src/waveform/renderers/waveformrenderersignalbase.cpp
+++ b/src/waveform/renderers/waveformrenderersignalbase.cpp
@@ -223,3 +223,13 @@ void WaveformRendererSignalBase::getGains(float* pAllGain, float* pLowGain,
         }
     }
 }
+
+float* WaveformRendererSignalBase::unscaleTable() {
+    // Table to undo the scaling std::pow(invalue, 2.0f * 0.316f);
+    // done in scaleSignal in analyzerwaveform.h
+    static float result[256];
+    for (int i = 0; i < 256; i++) {
+        result[i] = 255.f * std::pow(static_cast<float>(i) / 255.f, 1.f / 0.632f);
+    }
+    return result;
+}

--- a/src/waveform/renderers/waveformrenderersignalbase.cpp
+++ b/src/waveform/renderers/waveformrenderersignalbase.cpp
@@ -227,10 +227,10 @@ void WaveformRendererSignalBase::getGains(float* pAllGain,
     }
 }
 
-float* WaveformRendererSignalBase::unscaleTable() {
+std::span<float, 256> WaveformRendererSignalBase::unscaleTable() {
     // Table to undo the scaling std::pow(invalue, 2.0f * 0.316f);
     // done in scaleSignal in analyzerwaveform.h
-    static float result[256];
+    static std::array<float, 256> result;
     for (int i = 0; i < 256; i++) {
         result[i] = 255.f * std::pow(static_cast<float>(i) / 255.f, 1.f / 0.632f);
     }

--- a/src/waveform/renderers/waveformrenderersignalbase.h
+++ b/src/waveform/renderers/waveformrenderersignalbase.h
@@ -1,7 +1,9 @@
 #pragma once
 
-#include "waveformrendererabstract.h"
+#include <span>
+
 #include "skin/legacy/skincontext.h"
+#include "waveformrendererabstract.h"
 
 class ControlProxy;
 class WaveformSignalColors;
@@ -26,12 +28,12 @@ public:
             float* pMidGain,
             float* highGain);
 
-    static float* unscaleTable();
+    static std::span<float, 256> unscaleTable();
     inline float unscale(unsigned char value) {
         // The all and hi components of the waveform data are scaled with pow(value, 2.0f * 0.316f)
         // (see analyzerwaveform.h). This function can be used to undo that scaling,
         // but apparently it is intentional.
-        static const float* table = unscaleTable();
+        static const auto table = unscaleTable();
         return table[value];
     }
 

--- a/src/waveform/renderers/waveformrenderersignalbase.h
+++ b/src/waveform/renderers/waveformrenderersignalbase.h
@@ -23,6 +23,13 @@ public:
     void getGains(float* pAllGain, float* pLowGain, float* pMidGain,
                   float* highGain);
 
+    // To undo scaling with pow(value, 2.0f * 0.316f) done in analyzerwaveform.h
+    static float* unscaleTable();
+    inline float unscale(unsigned char value) {
+        static const float* table = unscaleTable();
+        return table[value];
+    }
+
   protected:
     ControlProxy* m_pEQEnabled;
     ControlProxy* m_pLowFilterControlObject;

--- a/src/waveform/renderers/waveformrenderersignalbase.h
+++ b/src/waveform/renderers/waveformrenderersignalbase.h
@@ -20,8 +20,11 @@ public:
   protected:
     void deleteControls();
 
-    void getGains(float* pAllGain, float* pLowGain, float* pMidGain,
-                  float* highGain);
+    void getGains(float* pAllGain,
+            bool applyCompensation,
+            float* pLowGain,
+            float* pMidGain,
+            float* highGain);
 
     static float* unscaleTable();
     inline float unscale(unsigned char value) {

--- a/src/waveform/renderers/waveformrenderersignalbase.h
+++ b/src/waveform/renderers/waveformrenderersignalbase.h
@@ -23,9 +23,11 @@ public:
     void getGains(float* pAllGain, float* pLowGain, float* pMidGain,
                   float* highGain);
 
-    // To undo scaling with pow(value, 2.0f * 0.316f) done in analyzerwaveform.h
     static float* unscaleTable();
     inline float unscale(unsigned char value) {
+        // The all and hi components of the waveform data are scaled with pow(value, 2.0f * 0.316f)
+        // (see analyzerwaveform.h). This function can be used to undo that scaling,
+        // but apparently it is intentional.
         static const float* table = unscaleTable();
         return table[value];
     }

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -116,9 +116,7 @@ void WaveformWidgetRenderer::onPreRender(VSyncThread* vsyncThread) {
     //Fetch parameters before rendering in order the display all sub-renderers with the same values
     double rateRatio = m_pRateRatioCO->get();
 
-    // This gain adjustment compensates for an arbitrary /2 gain chop in
-    // EnginePregain. See the comment there.
-    m_gain = m_pGainControlObject->get() * 2;
+    m_gain = m_pGainControlObject->get();
 
     // Compute visual sample to pixel ratio
     // Allow waveform to spread one visual sample across a hundred pixels

--- a/src/waveform/renderers/waveformwidgetrenderer.h
+++ b/src/waveform/renderers/waveformwidgetrenderer.h
@@ -104,8 +104,21 @@ class WaveformWidgetRenderer {
     double getZoomFactor() const {
         return m_zoomFactor;
     }
-    double getGain() const {
-        return m_gain;
+    double getGain(bool applyCompensation) const {
+        // m_gain was always multiplied by 2.0, according to a comment:
+        //
+        //   "This gain adjustment compensates for an arbitrary /2 gain chop in
+        //   EnginePregain. See the comment there."
+        //
+        // However, no comment there seems to explain this, and it resulted
+        // in renderers that use the filtered.all data for the amplitude, to
+        // be twice the expected value.
+        // But without this compensation, renderers that use the combined
+        // lo, mid, hi values became much lower than expected. By making this
+        // optional we move the decision to each renderer whether to apply the
+        // compensation or not, in order to have a more similar amplitude across
+        // waveform renderers
+        return applyCompensation ? m_gain * 2.f : m_gain;
     }
     double getTrackSamples() const {
         return m_trackSamples;


### PR DESCRIPTION
Adjust the scaling of the waveform data: removing a * 2 factor which doesn't seem justified and undo a scaling curve applied to the waveform.filtered.all data which also lacks an explanation.

See my analysis here https://github.com/mixxxdj/mixxx/issues/12448
