### PR TITLE
fix(controllers): ensure callbacks have appropriate `this`

### DIFF
--- a/res/controllers/Numark-Mixtrack-3-scripts.js
+++ b/res/controllers/Numark-Mixtrack-3-scripts.js
@@ -422,7 +422,7 @@ SingleDoubleBtn.prototype.buttonDown = function(channel, control, value, status,
     this.group = group;
 
     if (this.buttonTimer === 0) { // first press
-        this.buttonTimer = engine.beginTimer(this.doublePressTimeOut, this.buttonDecide, true);
+        this.buttonTimer = engine.beginTimer(this.doublePressTimeOut, this.buttonDecide.bind(this), true);
         this.buttonCount = 1;
     } else { // 2nd press (before timer's out)
         engine.stopTimer(this.buttonTimer);
@@ -486,7 +486,7 @@ LongShortBtn.prototype.buttonDown = function(channel, control, value, status, gr
     this.status = status;
     this.group = group;
     this.buttonLongPress = false;
-    this.buttonLongPressTimer = engine.beginTimer(this.longPressThreshold, this.buttonAssertLongPress, true);
+    this.buttonLongPressTimer = engine.beginTimer(this.longPressThreshold, this.buttonAssertLongPress.bind(this), true);
 };
 
 LongShortBtn.prototype.buttonUp = function() {
@@ -576,11 +576,11 @@ LongShortDoubleBtn.prototype.buttonDown = function(channel, control, value, stat
         this.buttonLongPress = false;
 
         this.buttonLongPressTimer = engine.beginTimer(
-            this.longPressThreshold, this.buttonAssertLongPress, true
+            this.longPressThreshold, this.buttonAssertLongPress.bind(this), true
         );
 
         this.buttonTimer = engine.beginTimer(
-            this.doublePressTimeOut, this.buttonAssert1Press, true
+            this.doublePressTimeOut, this.buttonAssert1Press.bind(this), true
         );
 
     } else if (this.buttonCount === 1) { // 2nd press (before short timer's out)

--- a/res/controllers/Numark-N4-scripts.js
+++ b/res/controllers/Numark-N4-scripts.js
@@ -586,7 +586,7 @@ NumarkN4.Deck = function(channel) {
         // spawned which conflicted with the old (still running) timers.
         if (!this.previouslyLoaded) {
             //timer is more efficient is this case than a callback because it would be called too often.
-            theDeck.blinkTimer=engine.beginTimer(NumarkN4.blinkInterval, theDeck.manageChannelIndicator);
+            theDeck.blinkTimer=engine.beginTimer(NumarkN4.blinkInterval, theDeck.manageChannelIndicator.bind(this), true);
         }
         this.previouslyLoaded=value;
     }.bind(this));

--- a/res/controllers/Reloop-Beatpad-scripts.js
+++ b/res/controllers/Reloop-Beatpad-scripts.js
@@ -527,7 +527,7 @@ SingleDoubleBtn.prototype.ButtonDown = function(channel, control, value, status,
     if (this.ButtonTimer === 0) { // first press
 
         this.ButtonTimer =
-            engine.beginTimer(this.DoublePressTimeOut, this.ButtonDecide, true);
+            engine.beginTimer(this.DoublePressTimeOut, this.ButtonDecide.bind(this), true);
         this.ButtonCount = 1;
     } else { // 2nd press (before timer's out)
         engine.stopTimer(this.ButtonTimer);
@@ -599,7 +599,7 @@ LongShortBtn.prototype.ButtonDown = function(channel, control, value, status, gr
     this.status = status;
     this.group = group;
     this.ButtonLongPress = false;
-    this.ButtonLongPressTimer = engine.beginTimer(this.LongPressThreshold, this.ButtonAssertLongPress, true);
+    this.ButtonLongPressTimer = engine.beginTimer(this.LongPressThreshold, this.ButtonAssertLongPress.bind(this), true);
 };
 
 LongShortBtn.prototype.ButtonUp = function() {
@@ -696,10 +696,10 @@ LongShortDoubleBtn.prototype.ButtonDown = function(channel, control, value, stat
         // and short press
         this.ButtonLongPress = false;
         this.ButtonLongPressTimer =
-            engine.beginTimer(this.LongPressThreshold, this.ButtonAssertLongPress,
+            engine.beginTimer(this.LongPressThreshold, this.ButtonAssertLongPress.bind(this),
                               true);
         this.ButtonTimer =
-            engine.beginTimer(this.DoublePressTimeOut, this.ButtonAssert1Press, true);
+            engine.beginTimer(this.DoublePressTimeOut, this.ButtonAssert1Press.bind(this), true);
     } else if (this.ButtonCount == 1) { // 2nd press (before short timer's out)
         // stop timers...
         if (this.ButtonLongPressTimer !== 0) {
@@ -862,7 +862,7 @@ Jogger.prototype.finishWheelTouch = function() {
         } else {
             // Check again soon.
             this.wheelTouchInertiaTimer =
-                engine.beginTimer(100, this.finishWheelTouch, true);
+                engine.beginTimer(100, this.finishWheelTouch.bind(this), true);
         }
     }
 };
@@ -893,7 +893,7 @@ Jogger.prototype.onWheelTouch = function(value,Do_iCut) {
             this.finishWheelTouch();
         } else { // If button up
             this.wheelTouchInertiaTimer =
-                engine.beginTimer(inertiaTime, this.finishWheelTouch, true);
+                engine.beginTimer(inertiaTime, this.finishWheelTouch.bind(this), true);
         }
     }
 };
@@ -1102,7 +1102,7 @@ ReloopBeatpad.rgbLEDs.prototype.flashOn = function(num_ms_on, RGBColor, num_ms_o
         // so we don't need this part  if flashcount=1
         // temporary timer. The end of this timer stops the permanent flashing
 
-        this.flashTimer2 = engine.beginTimer(flashCount * (num_ms_on + num_ms_off) - num_ms_off, this.Stopflash, true);
+        this.flashTimer2 = engine.beginTimer(flashCount * (num_ms_on + num_ms_off) - num_ms_off, this.Stopflash.bind(this), true);
     }
 };
 

--- a/res/controllers/Traktor-Kontrol-S2-MK1-hid-scripts.js
+++ b/res/controllers/Traktor-Kontrol-S2-MK1-hid-scripts.js
@@ -416,7 +416,7 @@ class DeckClass {
             } else {
                 this.wheelTouchInertiaTimer = engine.beginTimer(
                     inertiaTime,
-                    this.finishJogPress, 
+                    this.finishJogPress.bind(this),
                     true);
             }
         }
@@ -530,7 +530,7 @@ class DeckClass {
                 engine.scratchDisable(this.number, true);
             } else {
             // Check again soon.
-                this.wheelPressInertiaTimer = engine.beginTimer(20, finishJogPress, true);
+                this.wheelPressInertiaTimer = engine.beginTimer(20, this.finishJogPress.bind(this), true);
             }
         }
     }

--- a/res/controllers/Traktor-Kontrol-S2-MK3-hid-scripts.js
+++ b/res/controllers/Traktor-Kontrol-S2-MK3-hid-scripts.js
@@ -827,13 +827,13 @@ TraktorS2MK3.registerOutputPackets = function() {
     // VuMeter
     this.vuLeftConnection = engine.makeUnbufferedConnection("[Channel1]", "vu_meter", this.vuMeterHandler);
     this.vuRightConnection = engine.makeUnbufferedConnection("[Channel2]", "vu_meter", this.vuMeterHandler);
-    this.clipLeftConnection = engine.makeConnection("[Channel1]", "peak_indicator", this.peakOutputHandler);
-    this.clipRightConnection = engine.makeConnection("[Channel2]", "peak_indicator", this.peakOutputHandler);
+    this.clipLeftConnection = engine.makeConnection("[Channel1]", "peak_indicator", this.peakOutputHandler.bind(this));
+    this.clipRightConnection = engine.makeConnection("[Channel2]", "peak_indicator", this.peakOutputHandler.bind(this));
 
     // Sampler callbacks
     for (let i = 1; i <= 16; ++i) {
-        this.samplerCallbacks.push(engine.makeConnection("[Sampler" + i + "]", "track_loaded", this.samplesOutputHandler));
-        this.samplerCallbacks.push(engine.makeConnection("[Sampler" + i + "]", "play", this.samplesOutputHandler));
+        this.samplerCallbacks.push(engine.makeConnection("[Sampler" + i + "]", "track_loaded", this.samplesOutputHandler.bind(this)));
+        this.samplerCallbacks.push(engine.makeConnection("[Sampler" + i + "]", "play", this.samplesOutputHandler.bind(this)));
     }
 
     TraktorS2MK3.lightDeck(false);

--- a/res/controllers/Traktor-Kontrol-S3-hid-scripts.js
+++ b/res/controllers/Traktor-Kontrol-S3-hid-scripts.js
@@ -527,7 +527,7 @@ TraktorS3.Controller = class {
             this.Channels[idx].linkOutputs();
         }
 
-        engine.makeConnection("[Microphone]", "pfl", this.pflOutput);
+        engine.makeConnection("[Microphone]", "pfl", this.pflOutput.bind(this));
 
         engine.makeConnection("[Skin]", "show_maximized_library", TraktorS3.Controller.prototype.maximizeLibraryOutput.bind(this));
 

--- a/res/controllers/Traktor-Kontrol-S4-MK3.js
+++ b/res/controllers/Traktor-Kontrol-S4-MK3.js
@@ -537,7 +537,7 @@ class Button extends Component {
     indicator(on) {
         if (on && this.indicatorTimer === 0) {
             this.outDisconnect();
-            this.indicatorTimer = engine.beginTimer(this.indicatorIntervalMillis, this.indicatorCallback);
+            this.indicatorTimer = engine.beginTimer(this.indicatorIntervalMillis, this.indicatorCallback.bind(this));
         } else if (!on && this.indicatorTimer !== 0) {
             engine.stopTimer(this.indicatorTimer);
             this.indicatorTimer = 0;
@@ -2380,7 +2380,7 @@ class S4Mk3Deck extends Deck {
                 } else if (engine.getValue(this.group, "scratch2") === 0) {
                     engine.setValue(this.group, "scratch2_enable", false);
                 } else {
-                    engine.beginTimer(100, this.stopScratchWhenOver, true);
+                    engine.beginTimer(100, this.stopScratchWhenOver.bind(this), true);
                 }
             }
         });
@@ -2922,7 +2922,7 @@ class S4MK3 {
             controller.sendOutputReport(129, deckMeters.buffer);
         });
         if (UseMotors) {
-            engine.beginTimer(20, this.motorCallback);
+            engine.beginTimer(20, this.motorCallback.bind(this));
             this.leftVelocityFactor = wheelAbsoluteMax * baseRevolutionsPerSecond * 2;
             this.rightVelocityFactor = wheelAbsoluteMax * baseRevolutionsPerSecond * 2;
 


### PR DESCRIPTION
This should fix most mappings that were previously broken, because they assumed when a function was passed as a callback to `engine.makeConnection` or `engine.beginTimer` that the `this` argument referred to the same `this` as when the function was defined (eg when defined as a "method" on a class). In reality, any function executed via [`QJSValue::call`](https://doc.qt.io/qt-5/qjsvalue.html#call) (which is the case with callbacks executed via
`ControllerScriptEngineBase::executeFunction`), will have its `this` argument set to the globalObject!

This commit fixes some of these issues in known cases (https://github.com/mixxxdj/mixxx/issues/12460), potential places introduced as part of (https://github.com/mixxxdj/mixxx/pull/12401) as well as some other potential spots that were easy to grep for.