### PR TITLE
vsyncthread mode for qopenglwindow frameswapped driven phase locked loop

### DIFF
--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -138,7 +138,7 @@ void MixxxMainWindow::initializeQOpenGL() {
     if (!CmdlineArgs::Instance().getSafeMode()) {
 #endif
         QOpenGLContext context;
-        context.setFormat(WaveformWidgetFactory::getSurfaceFormat());
+        context.setFormat(WaveformWidgetFactory::getSurfaceFormat(m_pCoreServices->getSettings()));
         if (context.create()) {
             // This widget and its QOpenGLWindow will be used to query QOpenGL
             // information (version, driver, etc) in WaveformWidgetFactory.

--- a/src/waveform/vsyncthread.cpp
+++ b/src/waveform/vsyncthread.cpp
@@ -24,7 +24,7 @@ VSyncThread::VSyncThread(QObject* pParent)
 
 VSyncThread::~VSyncThread() {
     m_bDoRendering = false;
-    m_semaVsyncSlot.release(2); // Two slots
+    m_semaVsyncSlot.release(m_vSyncMode == ST_PLL ? 1 : 2); // Two slots, one for PLL
     wait();
     //delete m_glw;
 }
@@ -94,7 +94,6 @@ void VSyncThread::run() {
             // Signal to swap the gl widgets (waveforms, spinnies, vumeters)
             // and render them for the next swap
             emit vsyncSwapAndRender();
-            m_semaVsyncSlot.acquire();
             m_semaVsyncSlot.acquire();
             if (m_sinceLastSwap.toIntegerMicros() > sleepForSkippedFrames + pllDeltaOut * 3 / 2) {
                 m_droppedFrames++;

--- a/src/waveform/vsyncthread.cpp
+++ b/src/waveform/vsyncthread.cpp
@@ -17,7 +17,8 @@ VSyncThread::VSyncThread(QObject* pParent)
           m_displayFrameRate(60.0),
           m_vSyncPerRendering(1),
           m_pllPhaseOut(0.0),
-          m_pllDeltaOut(16666.6) { // 60 FPS
+          m_pllDeltaOut(16666.6), // 60 FPS initial delta
+          m_pllLogging(0.0) {
     m_pllTimer.start();
 }
 
@@ -241,5 +242,13 @@ void VSyncThread::updatePLL() {
     m_pllPhaseOut += alpha * pllPhaseError; // adjust phase
     m_pllDeltaOut += beta * pllPhaseError;  // adjust delta
 
-    // qDebug() << "PLL delta" << m_pllDeltaOut;
+    if (pllPhaseIn > m_pllLogging) {
+        if (m_pllLogging == 0) {
+            m_pllLogging = pllPhaseIn;
+        } else {
+            qDebug() << "phase-locked-loop:" << m_pllPhaseOut << m_pllDeltaOut;
+        }
+        // log every 10 seconds
+        m_pllLogging += 10000000.0;
+    }
 }

--- a/src/waveform/vsyncthread.h
+++ b/src/waveform/vsyncthread.h
@@ -49,6 +49,10 @@ class VSyncThread : public QThread {
     void vsyncSwap();
 
   private:
+    void runFree();
+    void runPLL();
+    void runTimer();
+
     bool m_bDoRendering;
     bool m_vSyncTypeChanged;
     int m_syncIntervalTimeMicros;

--- a/src/waveform/vsyncthread.h
+++ b/src/waveform/vsyncthread.h
@@ -67,4 +67,5 @@ class VSyncThread : public QThread {
     PerformanceTimer m_pllTimer;
     double m_pllPhaseOut;
     double m_pllDeltaOut;
+    double m_pllLogging;
 };

--- a/src/waveform/vsyncthread.h
+++ b/src/waveform/vsyncthread.h
@@ -3,6 +3,7 @@
 #include <QPair>
 #include <QSemaphore>
 #include <QThread>
+#include <mutex>
 
 #include "util/performancetimer.h"
 
@@ -17,6 +18,7 @@ class VSyncThread : public QThread {
         ST_SGI_VIDEO_SYNC,
         ST_OML_SYNC_CONTROL,
         ST_FREE,
+        ST_PLL,
         ST_COUNT // Dummy Type at last, counting possible types
     };
 
@@ -27,7 +29,6 @@ class VSyncThread : public QThread {
 
     bool waitForVideoSync(WGLWidget* glw);
     int elapsed();
-    int toNextSyncMicros();
     void setSyncIntervalTimeMicros(int usSyncTimer);
     void setVSyncType(int mode);
     int droppedFrames();
@@ -41,7 +42,9 @@ class VSyncThread : public QThread {
     int getSyncIntervalTimeMicros() const {
         return m_syncIntervalTimeMicros;
     }
+    void updatePLL();
   signals:
+    void vsyncSwapAndRender();
     void vsyncRender();
     void vsyncSwap();
 
@@ -59,4 +62,9 @@ class VSyncThread : public QThread {
     double m_displayFrameRate;
     int m_vSyncPerRendering;
     mixxx::Duration m_sinceLastSwap;
+    // phase locked loop
+    std::mutex m_pllMutex;
+    PerformanceTimer m_pllTimer;
+    double m_pllPhaseOut;
+    double m_pllDeltaOut;
 };

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -687,7 +687,7 @@ void WaveformWidgetFactory::notifyZoomChange(WWaveformViewer* viewer) {
     }
 }
 
-void WaveformWidgetFactory::render() {
+void WaveformWidgetFactory::renderSelf() {
     ScopedTimer t("WaveformWidgetFactory::render() %1waveforms",
             static_cast<int>(m_waveformWidgetHolders.size()));
 
@@ -759,10 +759,14 @@ void WaveformWidgetFactory::render() {
     m_pGuiTick->process();
 
     //qDebug() << "refresh end" << m_vsyncThread->elapsed();
+}
+
+void WaveformWidgetFactory::render() {
+    renderSelf();
     m_vsyncThread->vsyncSlotFinished();
 }
 
-void WaveformWidgetFactory::swap() {
+void WaveformWidgetFactory::swapSelf() {
     ScopedTimer t("WaveformWidgetFactory::swap() %1waveforms",
             static_cast<int>(m_waveformWidgetHolders.size()));
 
@@ -797,13 +801,17 @@ void WaveformWidgetFactory::swap() {
         // If we are using WVuMeter, this does nothing
         emit swapVuMeters();
     }
-    //qDebug() << "swap end" << m_vsyncThread->elapsed();
+}
+
+void WaveformWidgetFactory::swap() {
+    swapSelf();
     m_vsyncThread->vsyncSlotFinished();
 }
 
 void WaveformWidgetFactory::swapAndRender() {
-    swap();
-    render();
+    swapSelf();
+    renderSelf();
+    m_vsyncThread->vsyncSlotFinished();
 }
 
 void WaveformWidgetFactory::slotFrameSwapped() {

--- a/src/waveform/waveformwidgetfactory.h
+++ b/src/waveform/waveformwidgetfactory.h
@@ -160,6 +160,8 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
   private slots:
     void render();
     void swap();
+    void swapAndRender();
+    void slotFrameSwapped();
 
   private:
     void evaluateWidgets();

--- a/src/waveform/waveformwidgetfactory.h
+++ b/src/waveform/waveformwidgetfactory.h
@@ -99,7 +99,7 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
     int findHandleIndexFromType(WaveformWidgetType::Type type);
 
     /// Returns the desired surface format for the OpenGLWindow
-    static QSurfaceFormat getSurfaceFormat();
+    static QSurfaceFormat getSurfaceFormat(UserSettingsPointer config = nullptr);
 
   protected:
     bool setWidgetType(
@@ -130,8 +130,6 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
     void addVuMeter(WVuMeterBase* pWidget);
 
     void startVSync(GuiTick* pGuiTick, VisualsManager* pVisualsManager);
-    void setVSyncType(int vsType);
-    int getVSyncType();
 
     void setPlayMarkerPosition(double position);
     double getPlayMarkerPosition() const { return m_playMarkerPosition; }

--- a/src/waveform/waveformwidgetfactory.h
+++ b/src/waveform/waveformwidgetfactory.h
@@ -162,6 +162,9 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
     void slotFrameSwapped();
 
   private:
+    void renderSelf();
+    void swapSelf();
+
     void evaluateWidgets();
     template<typename WaveformT>
     QString buildWidgetDisplayName() const;

--- a/src/widget/wglwidgetqopengl.cpp
+++ b/src/widget/wglwidgetqopengl.cpp
@@ -93,3 +93,7 @@ void WGLWidget::swapBuffers() {
 bool WGLWidget::shouldRender() const {
     return m_pOpenGLWindow && m_pOpenGLWindow->isExposed();
 }
+
+QOpenGLWindow* WGLWidget::getOpenGLWindow() const {
+    return m_pOpenGLWindow;
+}

--- a/src/widget/wglwidgetqopengl.h
+++ b/src/widget/wglwidgetqopengl.h
@@ -11,6 +11,7 @@
 ////////////////////////////////
 
 class QPaintDevice;
+class QOpenGLWindow;
 class OpenGLWindow;
 class TrackDropTarget;
 
@@ -36,6 +37,8 @@ class WGLWidget : public QWidget {
 
     void setTrackDropTarget(TrackDropTarget* pTarget);
     TrackDropTarget* trackDropTarget() const;
+
+    QOpenGLWindow* getOpenGLWindow() const;
 
   protected:
     void showEvent(QShowEvent* event) override;


### PR DESCRIPTION
This PR adds a VSyncMode ST_PLL to the VSyncThread. 

With this mode, a phase locked loop is used to determine the vsync time and -interval based on the frameSwapped signal, that is coming from an invisible QOpenGLWindow (that of the WInitialGLWidget, which is used to query OpenGL).

This solves the problem that the phase offset between the vsync and the VSyncThread timer could effect the animation very badly and that timer could drift from the actual vsync.

In the Qt documentation we can read that using the frameSwapped signal is the preferred mechanism for animation:

> Applications that wish to continuously repaint synchronized to the vertical refresh, should issue an update() upon this signal. This allows for a much smoother experience compared to the traditional usage of timers.

Unfortunately, this doesn't play nice with our multiple QOpenGLWindow-based widgets, for which we still need to use the manual and coordinated call to swapBuffers().

Notes:
- I have tested this on macOS only. 
- This mode is enabled by adding
```
VSync 5
```
to `[Waveform]` in `mixxx.cfg`

Question:
- If we decide to take this, how do we proceed
