### PR TITLE
Clamp offset in VisualPlayPosition with extra time of two vsync interval

### DIFF
--- a/src/waveform/visualplayposition.cpp
+++ b/src/waveform/visualplayposition.cpp
@@ -63,10 +63,11 @@ double VisualPlayPosition::calcOffsetAtNextVSync(
         const int refToVSync = pVSyncThread->fromTimerToNextSyncMicros(data.m_referenceTime);
         const int syncIntervalTimeMicros = pVSyncThread->getSyncIntervalTimeMicros();
 #endif
-        // The offset is limited to the audio buffer + waveform sync interval
+        // The offset is limited to the audio buffer + 2 x waveform sync interval
         // This should be sufficient to compensate jitter, but does not continue
         // in case of underflows.
-        const int maxOffset = static_cast<int>(data.m_audioBufferMicroS + syncIntervalTimeMicros);
+        const int maxOffset = static_cast<int>(
+                data.m_audioBufferMicroS + 2 * syncIntervalTimeMicros);
         // Calculate the offset in micros for the position of the sample that will be transferred
         // to the DAC when the next display frame is displayed
         const int offset = math_clamp(

--- a/src/waveform/visualplayposition.h
+++ b/src/waveform/visualplayposition.h
@@ -93,6 +93,7 @@ class VisualPlayPosition : public QObject {
     ControlValueAtomic<VisualPlayPositionData> m_data;
     bool m_valid;
     QString m_key;
+    bool m_noTransport;
 
     static QMap<QString, QWeakPointer<VisualPlayPosition>> m_listVisualPlayPosition;
     // Time info from the Sound device, updated just after audio callback is called


### PR DESCRIPTION
It turns out that this is required to not clamp in all good conditions. Clamping causes a jittery waveform and must not happen under normal conditions. 

This removes one cause of jittery waveforms, during my tests. All other tests where successful with reasonable values. So I guess that the remaining jitters are real vsync misses. 

The clamping has been introduced to not move the waveform with a stalled audio engine. This still works, but is done one vsync cycle later. 

  