### PR TITLE
Keyboard event filter tweaks

### DIFF
--- a/src/controllers/keyboard/keyboardeventfilter.cpp
+++ b/src/controllers/keyboard/keyboardeventfilter.cpp
@@ -120,40 +120,40 @@ bool KeyboardEventFilter::eventFilter(QObject*, QEvent* e) {
 
 // static
 QKeySequence KeyboardEventFilter::getKeySeq(QKeyEvent* e) {
-    QString modseq;
-    QKeySequence k;
-
-    // TODO(XXX) check if we may simply return QKeySequence(e->modifiers()+e->key())
-
-    if (e->modifiers() & Qt::ShiftModifier) {
-        modseq += "Shift+";
-    }
-
-    if (e->modifiers() & Qt::ControlModifier) {
-        modseq += "Ctrl+";
-    }
-
-    if (e->modifiers() & Qt::AltModifier) {
-        modseq += "Alt+";
-    }
-
-    if (e->modifiers() & Qt::MetaModifier) {
-        modseq += "Meta+";
-    }
-
     if (e->key() >= 0x01000020 && e->key() <= 0x01000023) {
-        // Do not act on Modifier only
-        // avoid returning "khmer vowel sign ie (U+17C0)"
-        return k;
+        // Do not act on Modifier only, avoid returning "khmer vowel sign ie (U+17C0)"
+        return {};
     }
-
-    QString keyseq = QKeySequence(e->key()).toString();
-    k = QKeySequence(modseq + keyseq);
 
     if (CmdlineArgs::Instance().getDeveloper()) {
-        qDebug() << "keyboard press: " << k.toString();
+        QString modseq;
+        QKeySequence k;
+        if (e->modifiers() & Qt::ShiftModifier) {
+            modseq += "Shift+";
+        }
+        if (e->modifiers() & Qt::ControlModifier) {
+            modseq += "Ctrl+";
+        }
+        if (e->modifiers() & Qt::AltModifier) {
+            modseq += "Alt+";
+        }
+        if (e->modifiers() & Qt::MetaModifier) {
+            modseq += "Meta+";
+        }
+        QString keyseq = QKeySequence(e->key()).toString();
+        k = QKeySequence(modseq + keyseq);
+        if (e->type() == QEvent::KeyPress) {
+            qDebug() << "keyboard press: " << k.toString();
+        } else if (e->type() == QEvent::KeyRelease) {
+            qDebug() << "keyboard release: " << k.toString();
+        }
     }
-    return k;
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    return QKeySequence(e->modifiers() | e->key());
+#else
+    return QKeySequence(e->modifiers() + e->key());
+#endif
 }
 
 void KeyboardEventFilter::setKeyboardConfig(ConfigObject<ConfigValueKbd>* pKbdConfigObject) {

--- a/src/controllers/keyboard/keyboardeventfilter.cpp
+++ b/src/controllers/keyboard/keyboardeventfilter.cpp
@@ -118,6 +118,7 @@ bool KeyboardEventFilter::eventFilter(QObject*, QEvent* e) {
     return false;
 }
 
+// static
 QKeySequence KeyboardEventFilter::getKeySeq(QKeyEvent* e) {
     QString modseq;
     QKeySequence k;

--- a/src/controllers/keyboard/keyboardeventfilter.h
+++ b/src/controllers/keyboard/keyboardeventfilter.h
@@ -25,6 +25,9 @@ class KeyboardEventFilter : public QObject {
     void setKeyboardConfig(ConfigObject<ConfigValueKbd> *pKbdConfigObject);
     ConfigObject<ConfigValueKbd>* getKeyboardConfig();
 
+    // Returns a valid QString with modifier keys from a QKeyEvent
+    static QKeySequence getKeySeq(QKeyEvent* e);
+
   private:
     struct KeyDownInformation {
         KeyDownInformation(int keyId, int modifiers, ControlObject* pControl)
@@ -38,9 +41,6 @@ class KeyboardEventFilter : public QObject {
         ControlObject* pControl;
     };
 
-    // Returns a valid QString with modifier keys from a QKeyEvent
-    QKeySequence getKeySeq(QKeyEvent *e);
-
     // Run through list of active keys to see if the pressed key is already active
     // and is not a control that repeats when held.
     bool shouldSkipHeldKey(int keyId) {
@@ -51,7 +51,6 @@ class KeyboardEventFilter : public QObject {
                     return keyDownInfo.keyId == keyId && !keyDownInfo.pControl->getKbdRepeatable();
                 });
     }
-
     // List containing keys which is currently pressed
     QList<KeyDownInformation> m_qActiveKeyList;
     // Pointer to keyboard config object


### PR DESCRIPTION
* make `KeyboardEventFilter::getKeySeq()` static so it can be used anywhere for debugging key events
* implement an old TODO, simplify creating the `QKeySequence`
* pick 275a5ab16fed45987ed1788c5973065c8221509a from #11526 to have distinct log messages for press and release
