### PR TITLE
Loop: `beatloop_activate` adopts rolling loop and quits slip mode

### DIFF
--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -1309,6 +1309,15 @@ void LoopingControl::slotBeatLoopDeactivate(BeatLoopingControl* pBeatLoopControl
 
 void LoopingControl::slotBeatLoopDeactivateRoll(BeatLoopingControl* pBeatLoopControl) {
     pBeatLoopControl->deactivate();
+
+    if (!m_bLoopRollActive) {
+        // beatloop_activate was pressed while rolling and slotBeatLoopToggle()
+        // did already reset roll status (m_activeLoopRolls, m_bLoopRollActive)
+        // and EngineBuffer quit slip mode (but didn't seek).
+        // So nothing to do here, just leave the adopted loop active.
+        return;
+    }
+
     const double size = pBeatLoopControl->getSize();
     // clang-tidy wants auto to be auto* because QStack inherits from QVector
     // and QVector::iterator is a pointer type in Qt5, but QStack inherits
@@ -1325,18 +1334,15 @@ void LoopingControl::slotBeatLoopDeactivateRoll(BeatLoopingControl* pBeatLoopCon
 
     // Make sure slip mode is not turned off if it was turned on
     // by something that was not a rolling beatloop.
-    if (m_bLoopRollActive && m_activeLoopRolls.empty()) {
+    if (m_activeLoopRolls.empty()) {
         setLoopingEnabled(false);
         m_pSlipEnabled->set(0);
         m_bLoopRollActive = false;
-    }
-
-    // Return to the previous beatlooproll if necessary.
-    // Else previous regular beatloop if no rolling loops are active.
-    if (!m_activeLoopRolls.empty()) {
-        slotBeatLoop(m_activeLoopRolls.top(), m_bLoopRollActive, true);
-    } else {
         restoreLoopInfo();
+    } else {
+        // Return to the previous beatlooproll if necessary.
+        // Else previous regular beatloop if no rolling loops are active.
+        slotBeatLoop(m_activeLoopRolls.top(), m_bLoopRollActive, true);
     }
 }
 
@@ -1694,14 +1700,25 @@ void LoopingControl::slotBeatLoopSizeChangeRequest(double beats) {
 }
 
 void LoopingControl::slotBeatLoopToggle(double pressed) {
-    if (pressed > 0) {
-        if (m_bLoopingEnabled) {
+    if (pressed <= 0) {
+        return;
+    }
+
+    if (m_bLoopingEnabled) {
+        // If we're in a rolling loop, quit slip mode and adopt it as regular loop.
+        // Use case is to have a looproll button pressed, then press loop_activate
+        // and nothing should happen when releasing the looproll button.
+        if (m_bLoopRollActive) {
+            m_bLoopRollActive = false;
+            m_activeLoopRolls.clear();
+            getEngineBuffer()->slipQuitAndAdopt();
+        } else {
             // Deactivate the loop if we're already looping
             setLoopingEnabled(false);
-        } else {
-            // Create a loop at current position
-            slotBeatLoop(m_pCOBeatLoopSize->get());
         }
+    } else {
+        // Create a loop at current position
+        slotBeatLoop(m_pCOBeatLoopSize->get());
     }
 }
 
@@ -1723,6 +1740,14 @@ void LoopingControl::slotBeatLoopRollActivate(double pressed) {
             m_bLoopRollActive = true;
         }
     } else {
+        if (!m_bLoopRollActive) {
+            // beatloop_activate was pressed while rolling and slotBeatLoopToggle()
+            // did already reset roll status (m_activeLoopRolls, m_bLoopRollActive)
+            // and EngineBuffer quit slip mode (but didn't seek).
+            // So nothing to do here, just leave the adopted loop active.
+            return;
+        }
+
         setLoopingEnabled(false);
         // Make sure slip mode is not turned off if it was turned on
         // by something that was not a rolling beatloop.

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -236,6 +236,8 @@ class EngineBuffer : public EngineObject {
 
     void verifyPlay();
 
+    void slipQuitAndAdopt();
+
   public slots:
     void slotControlPlayRequest(double);
     void slotControlPlayFromStart(double);
@@ -466,6 +468,7 @@ class EngineBuffer : public EngineObject {
     ControlValueAtomic<QueuedSeek> m_queuedSeek;
     bool m_previousBufferSeek = false;
 
+    QAtomicInt m_slipQuitAndAdopt;
     /// Indicates that no seek is queued
     static constexpr QueuedSeek kNoQueuedSeek = {mixxx::audio::kInvalidFramePos, SEEK_NONE};
     /// indicates a clone seek on a bosition from another deck


### PR DESCRIPTION
While a rolling beatloop is active, press `beatloop_activate` to adopt this loop and quit slip mode.

This fixes #9445 for me.

* press and hold a looproll button for a transition, or just as filler
* notice I want to play with that loop, or simply need my looproll finger for other stuff, instead of holding the looproll button for the entire transition
* press `beatloop_activate`
=> loop becomes a regular loop, slip mode is deactivated (no seek!)
* release looproll button (nothin happens)
* do whatever I like with the loop