### PR TITLE
LateNight: fix xfader icons in samplers and aux units

### DIFF
--- a/res/skins/LateNight/classic/buttons/btn__xfader_sampler_left.svg
+++ b/res/skins/LateNight/classic/buttons/btn__xfader_sampler_left.svg
@@ -1,5 +1,5 @@
-<svg width="42" height="36" version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 21 18">
-	<g transform="translate(-2,-1034.4)">
-		<path d="m8 1039.4v9h8v-2h-6v-7h-2" fill="#f856e7"/>
-	</g>
+<svg width="21" height="18" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <g transform="translate(-2,-1034.4)">
+    <path d="m8 1039.4v9h8v-2h-6v-7h-2" fill="#f856e7"/>
+  </g>
 </svg>

--- a/res/skins/LateNight/classic/buttons/btn__xfader_sampler_main.svg
+++ b/res/skins/LateNight/classic/buttons/btn__xfader_sampler_main.svg
@@ -1,3 +1,3 @@
-<svg width="42" height="36" version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 21 18">
-	<path d="m6 14v-9h2l3 3 3-3h2v9h-2v-6l-3 3-3-3v6z" fill="#585858"/>
+<svg width="21" height="18" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <path d="m6 14v-9h2l3 3 3-3h2v9h-2v-6l-3 3-3-3v6z" fill="#585858"/>
 </svg>

--- a/res/skins/LateNight/classic/buttons/btn__xfader_sampler_right.svg
+++ b/res/skins/LateNight/classic/buttons/btn__xfader_sampler_right.svg
@@ -1,3 +1,3 @@
-<svg width="42" height="36" version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 21 18">
-	<path d="m6.0252 5v9h2v-3h2.4998l3 3h1.5v-1.5l-2-2 1-1v-3l-1.5-1.5zm2 2h3.9998v2h-3.9998z" fill="#f856e7"/>
+<svg width="21" height="18" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <path d="m6.0252 5v9h2v-3h2.4998l3 3h1.5v-1.5l-2-2 1-1v-3l-1.5-1.5zm2 2h3.9998v2h-3.9998z" fill="#f856e7"/>
 </svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__xfader_aux_left.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__xfader_aux_left.svg
@@ -1,60 +1,11 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   width="22"
-   height="26"
-   version="1.1"
-   id="svg2"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-  <defs
-     id="defs2">
-    <linearGradient
-       id="a"
-       x1="-11.2589"
-       x2="-1.077"
-       y1="8"
-       y2="8"
-       gradientTransform="matrix(1.7508715,0,0,1.7508908,-4.7624891,-14.935315)"
-       gradientUnits="userSpaceOnUse">
-      <stop
-         offset="0"
-         id="stop1" />
-      <stop
-         stop-color="#fff"
-         stop-opacity="0"
-         offset="1"
-         id="stop2" />
+<svg width="22" height="26" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="a" x1="-11.2589" x2="-1.077" y1="8" y2="8" gradientTransform="matrix(1.7508715,0,0,1.7508908,-4.7624891,-14.935315)" gradientUnits="userSpaceOnUse">
+      <stop offset="0"/>
+      <stop stop-color="#fff" stop-opacity="0" offset="1"/>
     </linearGradient>
   </defs>
-  <rect
-     y="4.0000052"
-     width="29.5294"
-     height="16"
-     rx="8"
-     ry="8"
-     fill="#0f0f0f"
-     id="rect2"
-     x="1.1740101e-05"
-     style="stroke-width:2" />
-  <circle
-     transform="scale(-1,1)"
-     cx="-8.0000114"
-     cy="12.000006"
-     r="8"
-     fill="#787878"
-     id="circle2"
-     style="stroke-width:2" />
-  <ellipse
-     transform="matrix(-0.50000716,-0.86602127,-0.86602958,0.49999276,0,0)"
-     cx="-14.392266"
-     cy="-0.92819202"
-     rx="7.0034776"
-     ry="7.0035634"
-     fill="none"
-     stroke="url(#a)"
-     stroke-linecap="round"
-     stroke-linejoin="round"
-     stroke-width="2.00002"
-     id="ellipse2"
-     style="stroke:url(#a)" />
+  <rect x="1.1740101e-5" y="4.0000052" width="29.5294" height="16" rx="8" ry="8" fill="#0f0f0f" stroke-width="2"/>
+  <circle transform="scale(-1,1)" cx="-8.0000114" cy="12.000006" r="8" fill="#787878" stroke-width="2"/>
+  <ellipse transform="matrix(-.50000716 -.86602127 -.86602958 .49999276 0 0)" cx="-14.392266" cy="-.92819202" rx="7.0034776" ry="7.0035634" fill="none" stroke="url(#a)" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.00002"/>
 </svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__xfader_aux_left_off.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__xfader_aux_left_off.svg
@@ -1,21 +1,3 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   width="22"
-   height="26"
-   version="1.1"
-   id="svg1"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-  <defs
-     id="defs1" />
-  <rect
-     y="4"
-     width="29.5294"
-     height="16"
-     rx="8"
-     ry="8"
-     fill="#0f0f0f"
-     id="rect1"
-     x="0"
-     style="stroke-width:2" />
+<svg width="22" height="26" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <rect y="4" width="29.5294" height="16" rx="8" ry="8" fill="#0f0f0f" stroke-width="2"/>
 </svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__xfader_aux_mid.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__xfader_aux_mid.svg
@@ -1,60 +1,11 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   width="22"
-   height="26"
-   version="1.1"
-   id="svg2"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-  <defs
-     id="defs2">
-    <linearGradient
-       id="a"
-       x1="-11.2589"
-       x2="-1.077"
-       y1="8"
-       y2="8"
-       gradientTransform="matrix(1.7508715,0,0,1.7508908,-7.1285084,-17.033268)"
-       gradientUnits="userSpaceOnUse">
-      <stop
-         offset="0"
-         id="stop1" />
-      <stop
-         stop-color="#fff"
-         stop-opacity="0"
-         offset="1"
-         id="stop2" />
+<svg width="22" height="26" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="a" x1="-11.2589" x2="-1.077" y1="8" y2="8" gradientTransform="matrix(1.7508715,0,0,1.7508908,-6.2624788,-17.533275)" gradientUnits="userSpaceOnUse">
+      <stop offset="0"/>
+      <stop stop-color="#fff" stop-opacity="0" offset="1"/>
     </linearGradient>
   </defs>
-  <rect
-     x="-12.2068"
-     y="5"
-     width="46.413601"
-     height="16"
-     rx="8"
-     ry="8"
-     fill="#0f0f0f"
-     id="rect2"
-     style="stroke-width:2" />
-  <circle
-     transform="scale(-1,1)"
-     cx="-11"
-     cy="13"
-     r="8"
-     fill="#787878"
-     id="circle2"
-     style="stroke-width:2" />
-  <ellipse
-     transform="matrix(-0.50000716,-0.86602127,-0.86602958,0.49999276,0,0)"
-     cx="-16.758305"
-     cy="-3.0261407"
-     rx="7.0034776"
-     ry="7.0035634"
-     fill="none"
-     stroke="url(#a)"
-     stroke-linecap="round"
-     stroke-linejoin="round"
-     stroke-width="2.00002"
-     id="ellipse2"
-     style="stroke:url(#a)" />
+  <rect y="4" width="22" height="16" rx="0" ry="0" fill="#0f0f0f" stroke-width="1.37695"/>
+  <circle cx="11" cy="12" r="8" fill="#787878" stroke-width="2"/>
+  <ellipse transform="matrix(-.50000716 -.86602127 -.86602958 .49999276 0 0)" cx="-15.892275" cy="-3.5261478" rx="7.0034776" ry="7.0035634" fill="none" stroke="url(#a)" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.00002"/>
 </svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__xfader_aux_mid_off.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__xfader_aux_mid_off.svg
@@ -1,21 +1,3 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   width="22"
-   height="26"
-   version="1.1"
-   id="svg1"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-  <defs
-     id="defs1" />
-  <rect
-     x="-12.2068"
-     y="5"
-     width="46.413601"
-     height="16"
-     rx="8"
-     ry="8"
-     fill="#0f0f0f"
-     id="rect1"
-     style="stroke-width:2" />
+<svg width="22" height="26" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <rect x="-12.2068" y="4" width="46.413601" height="16" rx="8" ry="8" fill="#0f0f0f" stroke-width="2"/>
 </svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__xfader_aux_right.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__xfader_aux_right.svg
@@ -1,60 +1,11 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   width="22"
-   height="26"
-   version="1.1"
-   id="svg2"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-  <defs
-     id="defs2">
-    <linearGradient
-       id="a"
-       x1="-11.2589"
-       x2="-1.077"
-       y1="8"
-       y2="8"
-       gradientTransform="matrix(1.7508715,0,0,1.7508908,-7.7624252,-20.131405)"
-       gradientUnits="userSpaceOnUse">
-      <stop
-         offset="0"
-         id="stop1" />
-      <stop
-         stop-color="#fff"
-         stop-opacity="0"
-         offset="1"
-         id="stop2" />
+<svg width="22" height="26" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="a" x1="-11.2589" x2="-1.077" y1="8" y2="8" gradientTransform="matrix(1.7508715,0,0,1.7508908,-7.7624252,-20.131405)" gradientUnits="userSpaceOnUse">
+      <stop offset="0"/>
+      <stop stop-color="#fff" stop-opacity="0" offset="1"/>
     </linearGradient>
   </defs>
-  <rect
-     transform="scale(-1,1)"
-     x="-22"
-     y="4.0000091"
-     width="30"
-     height="16"
-     rx="8"
-     ry="8"
-     fill="#0f0f0f"
-     id="rect2"
-     style="stroke-width:2" />
-  <circle
-     cx="14"
-     cy="12.00001"
-     r="8"
-     fill="#787878"
-     id="circle2"
-     style="stroke-width:2" />
-  <ellipse
-     transform="matrix(-0.50000716,-0.86602127,-0.86602958,0.49999276,0,0)"
-     cx="-17.392221"
-     cy="-6.1243186"
-     rx="7.0034776"
-     ry="7.0035634"
-     fill="none"
-     stroke="url(#a)"
-     stroke-linecap="round"
-     stroke-linejoin="round"
-     stroke-width="2.00002"
-     id="ellipse2"
-     style="stroke:url(#a)" />
+  <rect x="-8" y="4" width="30" height="16" rx="8" ry="8" fill="#0f0f0f" stroke-width="2"/>
+  <circle cx="14" cy="12.00001" r="8" fill="#787878" stroke-width="2"/>
+  <ellipse transform="matrix(-.50000716 -.86602127 -.86602958 .49999276 0 0)" cx="-17.392221" cy="-6.1243186" rx="7.0034776" ry="7.0035634" fill="none" stroke="url(#a)" stroke-linecap="round" stroke-linejoin="round" stroke-width="2.00002"/>
 </svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__xfader_aux_right_off.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__xfader_aux_right_off.svg
@@ -1,22 +1,3 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   width="22"
-   height="26"
-   version="1.1"
-   id="svg1"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-  <defs
-     id="defs1" />
-  <rect
-     transform="scale(-1,1)"
-     x="-22"
-     y="4"
-     width="30"
-     height="16"
-     rx="8"
-     ry="8"
-     fill="#0f0f0f"
-     id="rect1"
-     style="stroke-width:2" />
+<svg width="22" height="26" version="1.1" xmlns="http://www.w3.org/2000/svg">
+  <rect transform="scale(-1,1)" x="-22" y="4" width="30" height="16" rx="8" ry="8" fill="#0f0f0f" stroke-width="2"/>
 </svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__xfader_sampler_left.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__xfader_sampler_left.svg
@@ -1,4 +1,4 @@
-<svg width="42" height="36" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 21 18">
+<svg width="21" height="18" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <defs>
     <linearGradient id="a" x1="-11.2589" x2="-1.077" y1="8" y2="8" gradientTransform="matrix(.875436 0 0 .875445 -6.09535 -5.90063)" gradientUnits="userSpaceOnUse">
       <stop offset="0"/>

--- a/res/skins/LateNight/palemoon/buttons/btn__xfader_sampler_main.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__xfader_sampler_main.svg
@@ -1,4 +1,4 @@
-<svg width="42" height="36" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 21 18">
+<svg width="21" height="18" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <rect x=".5" y="6" width="20" height="8" rx="4" ry="4" fill="#0f0f0f"/>
   <circle transform="scale(-1,1)" cx="-10.5" cy="10" r="4" fill="#3d3d3c"/>
   <ellipse transform="matrix(-.500007 -.866021 -.86603 .499993 0 0)" cx="-13.9102" cy="-4.0932" rx="3.50174" ry="3.50178" fill="none"/>

--- a/res/skins/LateNight/palemoon/buttons/btn__xfader_sampler_right.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__xfader_sampler_right.svg
@@ -1,4 +1,4 @@
-<svg width="42" height="36" version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 21 18">
+<svg width="21" height="18" version="1.1" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <linearGradient id="a" x1="-11.2589" x2="-1.077" y1="8" y2="8" gradientTransform="matrix(.875436 0 0 .875445 -12.0953 -16.2929)" gradientUnits="userSpaceOnUse">
       <stop offset="0"/>


### PR DESCRIPTION
The samplers xfader icns were only half the size, so doubling the size and setting the 1:1 viewbox attribute does not work for icons set in xml templates via 
```xml
<State>
  <Number>2</Number>
  <Pressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_sampler_right.svg</Pressed>
  <Unpressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_sampler_right.svg</Unpressed>
</State>
```
it has the contrary effect, exactly what **daschuer** noticed here https://github.com/mixxxdj/mixxx/pull/12364#issuecomment-1828761228
![grafik](https://github.com/mixxxdj/mixxx/assets/1777442/28264f4f-3aca-443c-82b7-254fb4c00b70)

@m0dB please check if that looks okay on your machine.

Addionally, I fixed blurred edges caused by a pixel offset in double-size icons (Aux xfader icons).