### PR TITLE
multi-line delegate: fix bg color, Qt6 on Linux

### DIFF
--- a/src/library/multilineeditdelegate.cpp
+++ b/src/library/multilineeditdelegate.cpp
@@ -21,9 +21,13 @@ MultiLineEditor::MultiLineEditor(QWidget* pParent,
     document()->setDocumentMargin(0);
     setContentsMargins(0, 0, 0, 0);
     setCenterOnScroll(false);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     // Paint the entire rectangle, i.e. expand document background in order to
     // cover all underlying index text. Seems to be required for one-liners on macOS.
+    // Disabled for Qt6 since it does the exact opposite, i.e. the bottom margin
+    // is painted with the OS theme's background color
     setBackgroundVisible(true);
+#endif
     // Add event filter to catch right-clicks and key presses, see eventFilter()
     installEventFilter(this);
 


### PR DESCRIPTION
Curiously, with Qt6 on Linux this line causes what it avoided with Qt5: white bars at the bottom of the comment editor.

Would be nice if anyone on Windows and macOS can compare main/this.

before:
![Screenshot_2023-12-29_22-59-39](https://github.com/mixxxdj/mixxx/assets/5934199/02b70175-fe1f-4385-9874-e8ccaf0bde41)

this:
![Screenshot_2023-12-29_22-58-13](https://github.com/mixxxdj/mixxx/assets/5934199/fc4f5aba-d4e7-417f-b868-1ee83d8d34be)
