### PR TITLE
Pitch Shift effect: set Meta default to 0.5 (center)

### DIFF
--- a/src/effects/backends/builtin/pitchshifteffect.cpp
+++ b/src/effects/backends/builtin/pitchshifteffect.cpp
@@ -70,6 +70,7 @@ EffectManifestPointer PitchShiftEffect::getManifest() {
     pManifest->setVersion("2.0");
     pManifest->setDescription(QObject::tr(
             "Raises or lowers the original pitch of a sound."));
+    pManifest->setMetaknobDefault(0.5);
 
     EffectManifestParameterPointer pitch = pManifest->addParameter();
     pitch->setId(kPitchParameterId);


### PR DESCRIPTION
matches the defaults of both linked knob parameters