### PR TITLE
(fix) library/qt6: workaround 'selected click' bug

### DIFF
--- a/src/library/library.h
+++ b/src/library/library.h
@@ -86,6 +86,10 @@ class Library: public QObject {
         return m_trackTableFont;
     }
 
+    bool selectedClickEnabled() const {
+        return m_editMetadataSelectedClick;
+    }
+
     //static Library* buildDefaultLibrary();
 
     static const int kDefaultRowHeightPx;

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -103,6 +103,19 @@ void WTrackTableView::selectionChanged(
         const QItemSelection& selected, const QItemSelection& deselected) {
     m_selectionChangedSinceLastGuiTick = true;
     enableCachedOnly();
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    // Workaround for Qt6 bug https://bugreports.qt.io/browse/QTBUG-108595:
+    // If 'selectedClick' is enabled Ctrl+click opens the editor instead of
+    // toggling the clicked item.
+    // TODO Remove or adjust version guard as soon as the bug is fixed.
+    if (m_pLibrary->selectedClickEnabled()) {
+        if (selectionModel()->selectedRows().size() > 1) {
+            setSelectedClick(false);
+        } else {
+            setSelectedClick(true);
+        }
+    }
+#endif
     QTableView::selectionChanged(selected, deselected);
 }
 


### PR DESCRIPTION
Workaround for Qt6 bug https://bugreports.qt.io/browse/QTBUG-108595
> Ctrl-clicking on a selected item opens the editor instead of clearing the selection, while the selection mode is ExtendedSelection, the edit trigger is SelectedClicked, and the item has the ItemIsDragEnabled flag.

This bug has been open for a year without any activity. Please vote so that it gets attention and maybe gets fixed at some point :+1: 

Ctrl+Space, in conjunction with Ctrl+Up/Down, still works but is not practical for keyboard+mouse workflow.
___

The workaround seems to have no side effects. Ctrl+click after switching between library views with multi-/single-selection works as expected.