### PR TITLE
Default vsyncmode

### DIFF
--- a/src/preferences/upgrade.cpp
+++ b/src/preferences/upgrade.cpp
@@ -19,6 +19,7 @@
 #include "util/db/dbconnectionpooler.h"
 #include "util/math.h"
 #include "util/versionstore.h"
+#include "waveform/vsyncthread.h"
 #include "waveform/widgets/waveformwidgettype.h"
 
 Upgrade::Upgrade()
@@ -65,6 +66,32 @@ WaveformWidgetType::Type upgradeToAllShaders(WaveformWidgetType::Type waveformTy
         return WWT::AllShaderHSVWaveform;
     }
     return WWT::AllShaderRGBWaveform;
+}
+
+VSyncThread::VSyncMode upgradeDeprecatedVSyncModes(int configVSyncMode) {
+    using VT = VSyncThread;
+    if (configVSyncMode >= 0 || configVSyncMode <= static_cast<int>(VT::ST_COUNT)) {
+        switch (static_cast<VSyncThread::VSyncMode>(configVSyncMode)) {
+        case VT::ST_DEFAULT:
+            return VT::ST_DEFAULT;
+        case VT::ST_MESA_VBLANK_MODE_1_DEPRECATED:
+            return VT::ST_DEFAULT;
+        case VT::ST_SGI_VIDEO_SYNC_DEPRECATED:
+            return VT::ST_DEFAULT;
+        case VT::ST_OML_SYNC_CONTROL_DEPRECATED:
+            return VT::ST_DEFAULT;
+        case VT::ST_FREE:
+            return VT::ST_FREE;
+        case VT::ST_TIMER:
+            return VT::ST_TIMER;
+        case VT::ST_PLL:
+            return VT::ST_PLL;
+        case VT::ST_COUNT:
+            return VT::ST_DEFAULT;
+        }
+    }
+
+    return VT::ST_DEFAULT;
 }
 } // namespace
 
@@ -272,6 +299,10 @@ UserSettingsPointer Upgrade::versionUpgrade(const QString& settingsPath) {
         }
 #endif
     }
+
+    config->set(ConfigKey("[Waveform]", "VSync"),
+            ConfigValue(upgradeDeprecatedVSyncModes(
+                    config->getValue(ConfigKey("[Waveform]", "VSync"), 0))));
 
     // If it's already current, stop here
     if (configVersion == VersionStore::version()) {

--- a/src/waveform/vsyncthread.h
+++ b/src/waveform/vsyncthread.h
@@ -13,16 +13,17 @@ class VSyncThread : public QThread {
     Q_OBJECT
   public:
     enum VSyncMode {
-        ST_TIMER = 0,
-        ST_MESA_VBLANK_MODE_1,
-        ST_SGI_VIDEO_SYNC,
-        ST_OML_SYNC_CONTROL,
-        ST_FREE,
-        ST_PLL,
-        ST_COUNT // Dummy Type at last, counting possible types
+        ST_DEFAULT = 0,
+        ST_MESA_VBLANK_MODE_1_DEPRECATED, // 1
+        ST_SGI_VIDEO_SYNC_DEPRECATED,     // 2
+        ST_OML_SYNC_CONTROL_DEPRECATED,   // 3
+        ST_FREE,                          // 4
+        ST_PLL,                           // 5
+        ST_TIMER,                         // 6
+        ST_COUNT                          // Dummy Type at last, counting possible types
     };
 
-    VSyncThread(QObject* pParent);
+    VSyncThread(QObject* pParent, VSyncMode vSyncMode);
     ~VSyncThread();
 
     void run();
@@ -30,7 +31,6 @@ class VSyncThread : public QThread {
     bool waitForVideoSync(WGLWidget* glw);
     int elapsed();
     void setSyncIntervalTimeMicros(int usSyncTimer);
-    void setVSyncType(int mode);
     int droppedFrames();
     void setSwapWait(int sw);
     int fromTimerToNextSyncMicros(const PerformanceTimer& timer);
@@ -44,6 +44,9 @@ class VSyncThread : public QThread {
     }
     void updatePLL();
     bool pllInitializing() const;
+    VSyncMode vsyncMode() const {
+        return m_vSyncMode;
+    }
   signals:
     void vsyncSwapAndRender();
     void vsyncRender();
@@ -54,7 +57,6 @@ class VSyncThread : public QThread {
     void runTimer();
 
     bool m_bDoRendering;
-    bool m_vSyncTypeChanged;
     int m_syncIntervalTimeMicros;
     int m_waitToSwapMicros;
     enum VSyncMode m_vSyncMode;


### PR DESCRIPTION
- Make VSync mode 0 refer to the default mode; make ST_PLL the default on macOS, ST_TIMER otherwise

- Write the mode to the config
```
[Waveform]
VSync 0
```

- Users can overwrite the default in the config
```
[Waveform]
VSync <value>
```

where valid <values> are 0 (DEFAULT), 4 (ST_FREE), 5 (ST_PLL), 6 (ST_TIMER)
 