### PR TITLE
multi-line delegate: v-center one-line text

### DIFF
--- a/src/library/multilineeditdelegate.h
+++ b/src/library/multilineeditdelegate.h
@@ -27,6 +27,7 @@ class MultiLineEditor : public QPlainTextEdit {
   private:
     QTableView* m_pTableView;
     const QModelIndex m_index;
+    int m_fontHeight;
 };
 
 /// A delegate for text value columns that allows editing content


### PR DESCRIPTION
I'm not sure when this broke, but applying padding via stylesheet works.