### PR TITLE
Shifting cue points also shift beats

### DIFF
--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -212,16 +212,7 @@ void BpmControl::slotTranslateBeatsMove(double v) {
     if (!pTrack) {
         return;
     }
-    const mixxx::BeatsPointer pBeats = pTrack->getBeats();
-    if (pBeats) {
-        // TODO(rryan): Track::frameInfo is possibly inaccurate!
-        const double sampleOffset = frameInfo().sampleRate * v * 0.01;
-        const mixxx::audio::FrameDiff_t frameOffset = sampleOffset / mixxx::kEngineChannelCount;
-        const auto translatedBeats = pBeats->tryTranslate(frameOffset);
-        if (translatedBeats) {
-            pTrack->trySetBeats(*translatedBeats);
-        }
-    }
+    pTrack->shiftBeatsMillis(5 * v); // 5ms * v
 }
 
 void BpmControl::slotBpmTap(double v) {

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -837,6 +837,7 @@ void BaseTrackPlayerImpl::slotShiftCuesMillis(double milliseconds) {
         return;
     }
     m_pLoadedTrack->shiftCuePositionsMillis(milliseconds);
+    m_pLoadedTrack->shiftBeatsMillis(milliseconds);
 }
 
 void BaseTrackPlayerImpl::slotShiftCuesMillisButton(double value, double milliseconds) {

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -950,12 +950,27 @@ void Track::shiftCuePositionsMillis(double milliseconds) {
     VERIFY_OR_DEBUG_ASSERT(m_record.getStreamInfoFromSource()) {
         return;
     }
-    double frames = m_record.getStreamInfoFromSource()->getSignalInfo().millis2frames(milliseconds);
+    const double frames =
+            m_record.getStreamInfoFromSource()->getSignalInfo().millis2frames(
+                    milliseconds);
     for (const CuePointer& pCue : std::as_const(m_cuePoints)) {
         pCue->shiftPositionFrames(frames);
     }
 
     markDirtyAndUnlock(&locked);
+}
+
+void Track::shiftBeatsMillis(double milliseconds) {
+    if (milliseconds == 0 || !m_pBeats) {
+        return;
+    }
+    const double frames =
+            m_record.getStreamInfoFromSource()->getSignalInfo().millis2frames(
+                    milliseconds);
+    const auto translatedBeats = m_pBeats->tryTranslate(frames);
+    if (translatedBeats) {
+        trySetBeats(*translatedBeats);
+    }
 }
 
 void Track::analysisFinished() {

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -290,6 +290,9 @@ class Track : public QObject {
     void setMainCuePosition(mixxx::audio::FramePos position);
     /// Shift all cues by a constant offset
     void shiftCuePositionsMillis(mixxx::audio::FrameDiff_t milliseconds);
+    /// Shift beatgrid by a constant offset
+    void shiftBeatsMillis(double milliseconds);
+
     // Call when analysis is done.
     void analysisFinished();
 


### PR DESCRIPTION
Recently I went through my old mp3 library and came across many tracks were I had to shift the cues and beats, pretty much what was requested in the PR introducing these controls https://github.com/mixxxdj/mixxx/pull/2737#issuecomment-630276761

For now, this PR simply makes the cue shift controls `shift_cues_earlier/_later`also shift the beats accordingly.
Based on dde5302b164d8b8281bfbc0cb6fbfeca7eed5dd1 from #12423.

Let's discuss whether this should be the default (CO name doesn't fit anymore), or if we need to make it optional:
**a)** dedicated buttons for cues and cues+beats?
**b)** a preferences option (Decks? Waveforms?) that sets a static bool in `BaseTrackPlayer`?