### PR TITLE
fix/History: remove obsolete placeholder playlists

### DIFF
--- a/src/library/dao/playlistdao.cpp
+++ b/src/library/dao/playlistdao.cpp
@@ -520,6 +520,9 @@ int PlaylistDAO::getPlaylistId(const int index) const {
 PlaylistDAO::HiddenType PlaylistDAO::getHiddenType(const int playlistId) const {
     // qDebug() << "PlaylistDAO::getHiddenType"
     //          << QThread::currentThread() << m_database.connectionName();
+    if (playlistId != kInvalidPlaylistId) { // type is known, save a query
+        return PlaylistDAO::PLHT_UNKNOWN;
+    }
 
     QSqlQuery query(m_database);
     query.prepare(QStringLiteral(
@@ -533,8 +536,8 @@ PlaylistDAO::HiddenType PlaylistDAO::getHiddenType(const int playlistId) const {
     } else {
         LOG_FAILED_QUERY(query);
     }
-    qDebug() << "PlaylistDAO::getHiddenType returns PLHT_UNKNOWN for playlistId "
-             << playlistId;
+    // qDebug() << "PlaylistDAO::getHiddenType returns PLHT_UNKNOWN for playlist"
+    //          << playlistId << getPlaylistName(playlistId);
     return PLHT_UNKNOWN;
 }
 
@@ -1077,7 +1080,7 @@ void PlaylistDAO::shuffleTracks(const int playlistId,
     QList<int> newPositions = positions;
     const int searchDistance = math_max(static_cast<int>(trackPositionIds.count()) / 4, 1);
 
-    qDebug() << "Shuffling Tracks";
+    qDebug() << "Shuffling tracks of playlist" << playlistId << getPlaylistName(playlistId);
     qDebug() << "*** Search Distance: " << searchDistance;
     //for (int z = 0; z < positions.count(); z++) {
     //qDebug() << "*** Position: " << positions[z] << " | ID: " << allIds.value(positions[z]);

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -43,8 +43,18 @@ SetlogFeature::SetlogFeature(
     // remove unneeded entries
     deleteAllUnlockedPlaylistsWithFewerTracks();
 
-    // Create empty placeholder playlist for YEAR items
     QString placeholderName = "historyPlaceholder";
+    // remove previously created placeholder playlists
+    const QList<QPair<int, QString>> pls = m_playlistDao.getPlaylists(PlaylistDAO::PLHT_UNKNOWN);
+    QStringList plsToDelete;
+    for (const QPair<int, QString>& pl : pls) {
+        if (pl.second.startsWith(placeholderName)) {
+            plsToDelete.append(QString::number(pl.first));
+        }
+    }
+    m_playlistDao.deletePlaylists(plsToDelete);
+
+    // Create empty placeholder playlist for YEAR items
     m_yearNodeId = m_playlistDao.createUniquePlaylist(&placeholderName,
             PlaylistDAO::PLHT_UNKNOWN);
     DEBUG_ASSERT(m_yearNodeId != kInvalidPlaylistId);
@@ -97,8 +107,10 @@ SetlogFeature::SetlogFeature(
 
 SetlogFeature::~SetlogFeature() {
     // Clean up history when shutting down in case the track threshold changed,
-    // incl. the empty placeholder playlist and potentially empty current playlist
+    // incl. potentially empty current playlist
     deleteAllUnlockedPlaylistsWithFewerTracks();
+    // Delete the placeholder
+    m_playlistDao.deletePlaylist(m_yearNodeId);
 }
 
 QVariant SetlogFeature::title() {


### PR DESCRIPTION
I just noticed I made a mistake in 60198d5e376a87c0bcfcabffd2442c7e0f85b3e6  (I had ~300 `historyPlaceholder#` playlists in my database):
the YEAR placeholders are not removed in the destructor because 1) the type is `PlaylistDAO::PLHT_UNKNOWN` which is not covered by `deleteAllUnlockedPlaylistsWithFewerTracks()`, and 2) if it was, they'd be skipped because they are locked.

Note: this affects 2.4-beta users only, so we may remove this at some point (2.5?). Otoh the cleanup almost no time after the first execution.

