### PR TITLE
[DRAFT] use QOpenGLBuffer for vertex attributes

### DIFF
--- a/src/waveform/renderers/allshader/vectordata.h
+++ b/src/waveform/renderers/allshader/vectordata.h
@@ -4,10 +4,10 @@
 #include <QVector>
 
 namespace allshader {
-class VertexData;
+class VectorData;
 }
 
-class allshader::VertexData {
+class allshader::VectorData {
     QVector<QVector2D> mData;
 
   public:

--- a/src/waveform/renderers/allshader/vertexbuffer.h
+++ b/src/waveform/renderers/allshader/vertexbuffer.h
@@ -1,0 +1,186 @@
+#pragma once
+
+#include <QOpenGLBuffer>
+#include <cassert>
+
+namespace allshader {
+class VertexBuffer;
+class Vector2DVertexBuffer;
+class Vector2DRGBVertexBuffer;
+class Vector2DRGBAVertexBuffer;
+}
+
+class allshader::VertexBuffer : public QOpenGLBuffer {
+  public:
+    VertexBuffer(int tupleSize)
+            : QOpenGLBuffer(QOpenGLBuffer::VertexBuffer), m_tupleSize(tupleSize) {
+    }
+
+    void reserve(int count) {
+        int nBytes = count * stride() * sizeof(float);
+        if (nBytes > m_allocatedBytes) {
+            allocate(nBytes);
+            m_allocatedBytes = nBytes;
+        }
+    }
+
+    void mapForWrite() {
+        void* ptr = QOpenGLBuffer::map(QOpenGLBuffer::WriteOnly);
+        assert(ptr);
+        m_pMapped = static_cast<float*>(ptr);
+        m_valueIndex = 0;
+    }
+
+    void setIndex(int index) { // in amount of tuples
+        m_valueIndex = index * m_tupleSize;
+    }
+
+    int tupleSize() const { // in amount of floats
+        return m_tupleSize;
+    }
+
+    int size() const { // in tuples
+        return m_valueIndex / m_tupleSize;
+    }
+
+    int stride() const { // in bytes
+        return m_tupleSize * sizeof(float);
+    }
+
+  protected:
+    const int m_tupleSize;
+    int m_allocatedBytes{};
+    float* m_pMapped{};
+    int m_valueIndex{}; // index into m_pMapped, in amount of floats
+};
+
+class allshader::Vector2DVertexBuffer : public allshader::VertexBuffer {
+  public:
+    Vector2DVertexBuffer()
+            : VertexBuffer{2} {
+    }
+
+    constexpr int offset() const {
+        return 0;
+    }
+
+    void add(float x, float y) {
+        m_pMapped[m_valueIndex++] = x;
+        m_pMapped[m_valueIndex++] = y;
+    }
+
+    void addRectangle(float x1, float y1, float x2, float y2) {
+        add(x1, y1);
+        add(x2, y1);
+        add(x1, y2);
+
+        add(x1, y2);
+        add(x2, y2);
+        add(x2, y1);
+    }
+};
+
+class allshader::Vector2DRGBVertexBuffer : public VertexBuffer {
+  public:
+    Vector2DRGBVertexBuffer()
+            : VertexBuffer{positionTupleSize() + colorTupleSize()} {
+    }
+
+    constexpr int positionOffset() const {
+        return 0;
+    }
+
+    constexpr int positionTupleSize() const {
+        return 2;
+    }
+
+    constexpr int colorOffset() const {
+        return positionTupleSize() * sizeof(float);
+    }
+
+    constexpr int colorTupleSize() const {
+        return 3;
+    }
+
+    void add(float x, float y, float r, float g, float b) {
+        m_pMapped[m_valueIndex++] = x;
+        m_pMapped[m_valueIndex++] = y;
+
+        m_pMapped[m_valueIndex++] = r;
+        m_pMapped[m_valueIndex++] = g;
+        m_pMapped[m_valueIndex++] = b;
+    }
+
+    void addRectangle(float x1, float y1, float x2, float y2, float r, float g, float b) {
+        add(x1, y1, r, g, b);
+        add(x2, y1, r, g, b);
+        add(x1, y2, r, g, b);
+
+        add(x1, y2, r, g, b);
+        add(x2, y2, r, g, b);
+        add(x2, y1, r, g, b);
+    }
+};
+
+class allshader::Vector2DRGBAVertexBuffer : public VertexBuffer {
+  public:
+    Vector2DRGBAVertexBuffer()
+            : VertexBuffer{positionTupleSize() + colorTupleSize()} {
+    }
+
+    constexpr int positionOffset() const {
+        return 0;
+    }
+
+    constexpr int positionTupleSize() const {
+        return 2;
+    }
+
+    constexpr int colorOffset() const {
+        return positionTupleSize() * sizeof(float);
+    }
+
+    constexpr int colorTupleSize() const {
+        return 4;
+    }
+
+    void add(float x, float y, float r, float g, float b, float a) {
+        m_pMapped[m_valueIndex++] = x;
+        m_pMapped[m_valueIndex++] = y;
+
+        m_pMapped[m_valueIndex++] = r;
+        m_pMapped[m_valueIndex++] = g;
+        m_pMapped[m_valueIndex++] = b;
+        m_pMapped[m_valueIndex++] = a;
+    }
+
+    void addRectangle(float x1, float y1, float x2, float y2, float r, float g, float b, float a) {
+        add(x1, y1, r, g, b, a);
+        add(x2, y1, r, g, b, a);
+        add(x1, y2, r, g, b, a);
+
+        add(x1, y2, r, g, b, a);
+        add(x2, y2, r, g, b, a);
+        add(x2, y1, r, g, b, a);
+    }
+
+    void addRectangleGradient(float x1,
+            float y1,
+            float x2,
+            float y2,
+            float rA,
+            float gA,
+            float bA,
+            float aA,
+            float rB,
+            float gB,
+            float bB,
+            float aB) {
+        add(x1, y1, rA, gA, bA, aA);
+        add(x2, y1, rA, gA, bA, aA);
+        add(x1, y2, rB, gB, bB, aB);
+        add(x1, y2, rB, gB, bB, aB);
+        add(x2, y2, rB, gB, bB, aB);
+        add(x2, y1, rA, gA, bA, aA);
+    }
+};

--- a/src/waveform/renderers/allshader/vertexbuffer.h
+++ b/src/waveform/renderers/allshader/vertexbuffer.h
@@ -8,7 +8,7 @@ class VertexBuffer;
 class Vector2DVertexBuffer;
 class Vector2DRGBVertexBuffer;
 class Vector2DRGBAVertexBuffer;
-}
+} // namespace allshader
 
 class allshader::VertexBuffer : public QOpenGLBuffer {
   public:

--- a/src/waveform/renderers/allshader/waveformrenderbeat.h
+++ b/src/waveform/renderers/allshader/waveformrenderbeat.h
@@ -4,7 +4,7 @@
 
 #include "shaders/unicolorshader.h"
 #include "util/class.h"
-#include "waveform/renderers/allshader/vertexdata.h"
+#include "waveform/renderers/allshader/vertexbuffer.h"
 #include "waveform/renderers/allshader/waveformrenderer.h"
 
 class QDomNode;
@@ -25,7 +25,7 @@ class allshader::WaveformRenderBeat final : public allshader::WaveformRenderer {
   private:
     mixxx::UnicolorShader m_shader;
     QColor m_color;
-    VertexData m_vertices;
+    Vector2DVertexBuffer m_vertices;
 
     DISALLOW_COPY_AND_ASSIGN(WaveformRenderBeat);
 };

--- a/src/waveform/renderers/allshader/waveformrendererfiltered.h
+++ b/src/waveform/renderers/allshader/waveformrendererfiltered.h
@@ -2,7 +2,7 @@
 
 #include "shaders/unicolorshader.h"
 #include "util/class.h"
-#include "waveform/renderers/allshader/vertexdata.h"
+#include "waveform/renderers/allshader/vertexbuffer.h"
 #include "waveform/renderers/allshader/waveformrenderersignalbase.h"
 
 namespace allshader {
@@ -21,7 +21,7 @@ class allshader::WaveformRendererFiltered final : public allshader::WaveformRend
 
   private:
     mixxx::UnicolorShader m_shader;
-    VertexData m_vertices[4];
+    Vector2DVertexBuffer m_vertices;
 
     DISALLOW_COPY_AND_ASSIGN(WaveformRendererFiltered);
 };

--- a/src/waveform/renderers/allshader/waveformrendererhsv.h
+++ b/src/waveform/renderers/allshader/waveformrendererhsv.h
@@ -2,8 +2,7 @@
 
 #include "shaders/rgbshader.h"
 #include "util/class.h"
-#include "waveform/renderers/allshader/rgbdata.h"
-#include "waveform/renderers/allshader/vertexdata.h"
+#include "waveform/renderers/allshader/vertexbuffer.h"
 #include "waveform/renderers/allshader/waveformrenderersignalbase.h"
 
 namespace allshader {
@@ -22,8 +21,7 @@ class allshader::WaveformRendererHSV final : public allshader::WaveformRendererS
 
   private:
     mixxx::RGBShader m_shader;
-    VertexData m_vertices;
-    RGBData m_colors;
+    Vector2DRGBVertexBuffer m_vertices;
 
     DISALLOW_COPY_AND_ASSIGN(WaveformRendererHSV);
 };

--- a/src/waveform/renderers/allshader/waveformrendererlrrgb.h
+++ b/src/waveform/renderers/allshader/waveformrendererlrrgb.h
@@ -2,8 +2,7 @@
 
 #include "shaders/rgbshader.h"
 #include "util/class.h"
-#include "waveform/renderers/allshader/rgbdata.h"
-#include "waveform/renderers/allshader/vertexdata.h"
+#include "waveform/renderers/allshader/vertexbuffer.h"
 #include "waveform/renderers/allshader/waveformrenderersignalbase.h"
 
 namespace allshader {
@@ -22,8 +21,7 @@ class allshader::WaveformRendererLRRGB final : public allshader::WaveformRendere
 
   private:
     mixxx::RGBShader m_shader;
-    VertexData m_vertices;
-    RGBData m_colors;
+    Vector2DRGBVertexBuffer m_vertices;
 
     DISALLOW_COPY_AND_ASSIGN(WaveformRendererLRRGB);
 };

--- a/src/waveform/renderers/allshader/waveformrendererpreroll.h
+++ b/src/waveform/renderers/allshader/waveformrendererpreroll.h
@@ -6,7 +6,6 @@
 
 #include "shaders/patternshader.h"
 #include "util/class.h"
-#include "waveform/renderers/allshader/vertexdata.h"
 #include "waveform/renderers/allshader/waveformrenderer.h"
 
 class QDomNode;

--- a/src/waveform/renderers/allshader/waveformrendererrgb.h
+++ b/src/waveform/renderers/allshader/waveformrendererrgb.h
@@ -3,7 +3,7 @@
 #include "shaders/rgbshader.h"
 #include "util/class.h"
 #include "waveform/renderers/allshader/rgbdata.h"
-#include "waveform/renderers/allshader/vertexdata.h"
+#include "waveform/renderers/allshader/vertexbuffer.h"
 #include "waveform/renderers/allshader/waveformrenderersignalbase.h"
 
 namespace allshader {
@@ -22,8 +22,7 @@ class allshader::WaveformRendererRGB final : public allshader::WaveformRendererS
 
   private:
     mixxx::RGBShader m_shader;
-    VertexData m_vertices;
-    RGBData m_colors;
+    Vector2DRGBVertexBuffer m_vertices;
 
     DISALLOW_COPY_AND_ASSIGN(WaveformRendererRGB);
 };

--- a/src/waveform/renderers/allshader/waveformrenderersimple.h
+++ b/src/waveform/renderers/allshader/waveformrenderersimple.h
@@ -2,7 +2,7 @@
 
 #include "shaders/unicolorshader.h"
 #include "util/class.h"
-#include "waveform/renderers/allshader/vertexdata.h"
+#include "waveform/renderers/allshader/vertexbuffer.h"
 #include "waveform/renderers/allshader/waveformrenderersignalbase.h"
 
 namespace allshader {
@@ -21,7 +21,7 @@ class allshader::WaveformRendererSimple final : public allshader::WaveformRender
 
   private:
     mixxx::UnicolorShader m_shader;
-    VertexData m_vertices[2];
+    Vector2DVertexBuffer m_vertices;
 
     DISALLOW_COPY_AND_ASSIGN(WaveformRendererSimple);
 };

--- a/src/waveform/renderers/allshader/waveformrendermark.cpp
+++ b/src/waveform/renderers/allshader/waveformrendermark.cpp
@@ -7,7 +7,7 @@
 #include "util/texture.h"
 #include "waveform/renderers/allshader/matrixforwidgetgeometry.h"
 #include "waveform/renderers/allshader/rgbadata.h"
-#include "waveform/renderers/allshader/vertexdata.h"
+#include "waveform/renderers/allshader/vectordata.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
 
 // On the use of QPainter:
@@ -118,7 +118,7 @@ void allshader::WaveformRenderMark::drawMark(const QRectF& rect, QColor color) {
 
     getRgbF(color, &r, &g, &b, &a);
 
-    VertexData vertices;
+    VectorData vertices;
     vertices.reserve(12); // 4 triangles
     vertices.addRectangle(posx1, posy1, posx2, posy2);
     vertices.addRectangle(posx1, posy4, posx2, posy3);


### PR DESCRIPTION
Use QOpenGLBuffer and QOpenGLShaderProgram::setAttributeBuffer instead of setAttributeArray to pass vertex data to the shader. So far only used in allshader::WaveformRendererRGB but it should be simple to apply everywhere.

From the OpenGL docs:
"Buffer objects are general purpose memory storage blocks allocated by OpenGL. They are intended to be used in a great many ways. To give the implementation great flexibility in exactly what a particular buffer object's data store will be, so as to better optimize performance, the user is required to give usage hints. These provide a general description as to how exactly the user will be using the buffer object."

