### PR TITLE
gradually "compact" the markers if the waveform height is reduced

### DIFF
--- a/src/waveform/renderers/waveformmark.cpp
+++ b/src/waveform/renderers/waveformmark.cpp
@@ -254,7 +254,7 @@ struct MarkerGeometry {
         }
 
         const float increment = std::max<float>(0.f,
-                m_labelRect.height() + 2.f - std::max(0.f, 80.f - breadth));
+                static_cast<float>(m_labelRect.height()) + 2.f - std::max(0.f, 80.f - breadth));
 
         if (alignV == Qt::AlignVCenter) {
             m_labelRect.moveTop((m_imageSize.height() - m_labelRect.height()) / 2.f);

--- a/src/waveform/renderers/waveformmark.cpp
+++ b/src/waveform/renderers/waveformmark.cpp
@@ -253,13 +253,16 @@ struct MarkerGeometry {
             m_labelRect.moveLeft(0.5f);
         }
 
+        const float increment = std::max<float>(0.f,
+                m_labelRect.height() + 2.f - std::max(0.f, 80.f - breadth));
+
         if (alignV == Qt::AlignVCenter) {
             m_labelRect.moveTop((m_imageSize.height() - m_labelRect.height()) / 2.f);
         } else if (alignV == Qt::AlignBottom) {
             m_labelRect.moveBottom(m_imageSize.height() - 0.5f -
-                    level * (m_labelRect.height() + 2.f));
+                    level * increment);
         } else {
-            m_labelRect.moveTop(0.5f + level * (m_labelRect.height() + 2.f));
+            m_labelRect.moveTop(0.5f + level * increment);
         }
     }
     QSize getImageSize(float devicePixelRatio) const {

--- a/src/waveform/renderers/waveformmark.cpp
+++ b/src/waveform/renderers/waveformmark.cpp
@@ -56,6 +56,17 @@ Qt::Alignment decodeAlignmentFlags(const QString& alignString, Qt::Alignment def
 
     return hflags | vflags;
 }
+
+float overlappingMarkerIncrement(const float labelRectHeight, const float breadth) {
+    // gradually "compact" the markers if the waveform height is
+    // reduced, to avoid multiple markers obscuring the waveform.
+    const float threshold = 90.f; // above this, the full increment is used
+    const float fullIncrement = labelRectHeight + 2.f;
+    const float minIncrement = 2.f; // increment when most compacted
+
+    return std::max(minIncrement, fullIncrement - std::max(0.f, threshold - breadth));
+}
+
 } // anonymous namespace
 
 WaveformMark::WaveformMark(const QString& group,
@@ -253,8 +264,8 @@ struct MarkerGeometry {
             m_labelRect.moveLeft(0.5f);
         }
 
-        const float increment = std::max<float>(0.f,
-                static_cast<float>(m_labelRect.height()) + 2.f - std::max(0.f, 80.f - breadth));
+        const float increment = overlappingMarkerIncrement(
+                static_cast<float>(m_labelRect.height()), breadth);
 
         if (alignV == Qt::AlignVCenter) {
             m_labelRect.moveTop((m_imageSize.height() - m_labelRect.height()) / 2.f);


### PR DESCRIPTION
To address this issue: https://github.com/mixxxdj/mixxx/pull/12273#issuecomment-1874402179

<img width="218" alt="Screenshot 2024-01-03 at 00 11 34" src="https://github.com/mixxxdj/mixxx/assets/79429057/b1f47558-f288-4912-a0f3-3a5ce983427e">
<img width="168" alt="Screenshot 2024-01-03 at 00 11 56" src="https://github.com/mixxxdj/mixxx/assets/79429057/7615eb67-cf43-409b-bf52-27ae83c80533">
<img width="129" alt="Screenshot 2024-01-03 at 00 12 03" src="https://github.com/mixxxdj/mixxx/assets/79429057/434502de-5d3f-4b72-8256-3b1c74e2f32b">
<img width="154" alt="Screenshot 2024-01-03 at 00 12 09" src="https://github.com/mixxxdj/mixxx/assets/79429057/9c179884-f69b-4d96-9a65-94673b063f50">
