### PR TITLE
Labeler: Cherry-pick v5 updates to 2.4

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,29 +1,136 @@
 build:
-  - default.nix
-  - CMakeLists.txt
-  - build/**
-  - cmake/**
+  - changed-files:
+      - any-glob-to-any-file:
+          - default.nix
+          - CMakeLists.txt
+          - build/**
+          - cmake/**
+
+cmake:
+  - changed-files:
+      - any-glob-to-any-file:
+          - cmake/**
 
 code quality:
-  - src/test/**
-  - .clang-format
-  - .codespell
-  - .eslint*
-  - .flake8
-  - .pre-commit-config.yaml
-  - pyproject.toml
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/test/**
+          - .clang-format
+          - .codespell
+          - .eslint*
+          - .flake8
+          - .pre-commit-config.yaml
+          - pyproject.toml
 
 controllers:
-  - res/controllers/**
+  - changed-files:
+      - any-glob-to-any-file:
+          - res/controllers/**
+
+analyzer:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/analyzer/**
+
+broadcast:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/broadcast/**
+
+effects:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/effects/**
+
+engine:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/engine/**
+
+sync:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/engine/sync/**
 
 library:
-  - src/library/**
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/library/**
+
+autodj:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/library/autodj/**
+
+browse:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/library/browse/**
+
+itunes:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/library/itunes/**
+
+rekordbox:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/library/rekordbox/**
+
+scanner:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/library/scanner/**
+
+search:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/library/searchquery*
+
+serato:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/library/serato/**
+
+packaging:
+  - changed-files:
+      - any-glob-to-any-file:
+          - packaging/**
+
+preferences:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/preferences/**
 
 skins:
-  - res/skins/**
+  - changed-files:
+      - any-glob-to-any-file:
+          - res/skins/**
+
+soundio:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/soundio/**
+
+soundsource:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/sources/soundsource*
 
 ui:
-  - src/**.ui
-  - src/dialog/**
-  - src/preferences/**
-  - src/widget/**
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/**.ui
+          - src/dialog/**
+          - src/preferences/**
+          - src/widget/**
+
+vinylcontrol:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/vinylcontrol/**
+
+waveform:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/waveform/**

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -22,9 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # version between v4.0.3 and the one after which has not yet been tagged
-      # at the time of writing
-      - uses: actions/labeler@7012d51fe062f0b1e26e224a3c9fb52598ee3302
+      - uses: actions/labeler@v5.0.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: false


### PR DESCRIPTION
I've noticed that 2.4 PRs weren't labeled by feature, which is presumably due to the outdated labeler workflow. This PR therefore cherry-picks the updated labeling workflow and configuration from `main` (including #12421 and #12106).