### PR TITLE
Improved loging in case of  clamping visual position

### DIFF
--- a/src/waveform/visualplayposition.cpp
+++ b/src/waveform/visualplayposition.cpp
@@ -70,9 +70,9 @@ double VisualPlayPosition::calcOffsetAtNextVSync(
         const int maxOffset = static_cast<int>(
                 data.m_audioBufferMicroS + 2 * syncIntervalTimeMicros);
 
-        // The negative offset is limited to -data.m_callbackEntrytoDac to not
-        // More negative values indicated an outdated request, that is anyway no
-        // longer valid. Probably cause bay a vsync issue.
+        // The minimum offset is limited to -data.m_callbackEntrytoDac to avoid a more
+        // negative value indicating an outdated request that is no longer valid anyway.
+        // This is probably caused by a vsync problem.
         const int minOffset = -data.m_callbackEntrytoDac;
 
         // Calculate the offset in micros for the position of the sample that will be transferred

--- a/src/waveform/visualplayposition.cpp
+++ b/src/waveform/visualplayposition.cpp
@@ -76,7 +76,10 @@ double VisualPlayPosition::calcOffsetAtNextVSync(
             offset = -maxOffset;
             if (!m_noTransport) {
                 qWarning() << "VisualPlayPosition::calcOffsetAtNextVSync"
-                           << m_key << "no transport (offset < -maxOffset)";
+                           << m_key << "outdated position request (offset < minOffset)";
+                qDebug() << m_key << "refToVSync:" << refToVSync
+                         << "data.m_callbackEntrytoDac:"
+                         << data.m_callbackEntrytoDac;
                 m_noTransport = true;
             }
         } else if (offset > maxOffset) {
@@ -84,9 +87,17 @@ double VisualPlayPosition::calcOffsetAtNextVSync(
             if (!m_noTransport) {
                 qWarning() << "VisualPlayPosition::calcOffsetAtNextVSync"
                            << m_key << "no transport (offset > maxOffset)";
+                qDebug() << m_key << "refToVSync:" << refToVSync
+                         << "data.m_callbackEntrytoDac:"
+                         << data.m_callbackEntrytoDac;
                 m_noTransport = true;
             }
         } else {
+            if (m_noTransport) {
+                qDebug() << m_key << "refToVSync:" << refToVSync
+                         << "data.m_callbackEntrytoDac:"
+                         << data.m_callbackEntrytoDac;
+            }
             m_noTransport = false;
         }
         // Apply the offset proportional to m_positionStep


### PR DESCRIPTION
It turns out that the log spam discovered by @m0dB in https://github.com/mixxxdj/mixxx/pull/12470 is actually a bug. 

This PR improves the log output and the negative side that is not a transport issue but a vsync issue.

It happens if the rendere requests a position of an already missed vsync cycle. 

A solution is to detect that and advance to the next vsync cycle that has not yet passed. 