### PR TITLE
Keyfinder workaround for 'CMakeFiles/mixxx-lib_autogen_timestamp_deps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2453,6 +2453,17 @@ if(KEYFINDER)
     # an error if not.
     file(MAKE_DIRECTORY "${KeyFinder_INSTALL_DIR}/include")
 
+    if(NOT CMAKE_GENERATOR STREQUAL "Ninja")
+      # Required for 'CMakeFiles/mixxx-lib_autogen_timestamp_deps'
+      # This tells 'make" that the libkeyfinder is required for the mixxx-keyfinder library
+      # BUILD_BYPRODUCTS work for Ninja only, while this workaround does not work for Ninja on macOS
+      add_custom_command(
+        OUTPUT "${KeyFinder_INSTALL_DIR}/${KeyFinder_LIBRARY}"
+        DEPENDS libkeyfinder
+        COMMAND echo libkeyfinder installed
+      )
+    endif()
+
     add_library(mixxx-keyfinder STATIC IMPORTED)
     add_dependencies(mixxx-keyfinder libkeyfinder)
     set_target_properties(mixxx-keyfinder PROPERTIES IMPORTED_LOCATION "${KeyFinder_INSTALL_DIR}/${KeyFinder_LIBRARY}")


### PR DESCRIPTION
Copied from libdjinteropt https://github.com/mixxxdj/mixxx/pull/12434/commits/79dcbbb1efd158dfe479f1069838646b05da132f

This fails from time to time depending on threading like here: 
https://github.com/daschuer/mixxx/actions/runs/7419134610/job/20188140634

Fixes https://github.com/mixxxdj/mixxx/issues/12505