### PR TITLE
fix(library): remove typo in user-facing string

### DIFF
--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -61,7 +61,7 @@ SetlogFeature::SetlogFeature(
             this,
             &SetlogFeature::slotJoinWithPrevious);
 
-    m_pMarkTracksPlayedAction = new QAction(tr("Mark all tracks played)"), this);
+    m_pMarkTracksPlayedAction = new QAction(tr("Mark all tracks played"), this);
     connect(m_pMarkTracksPlayedAction,
             &QAction::triggered,
             this,


### PR DESCRIPTION
spotted while practicing just now. 
does this violate string freeze or can we just merge?