### PR TITLE
fix `loop_remove`

### DIFF
--- a/res/skins/LateNight/decks/deck_settings.xml
+++ b/res/skins/LateNight/decks/deck_settings.xml
@@ -31,10 +31,10 @@
             <Layout>horizontal</Layout>
             <Children>
 
-              <Template src="skins:LateNight/controls/button_2state.xml">
+              <Template src="skins:LateNight/controls/button_1state.xml">
                 <SetVariable name="TooltipId">slip_mode</SetVariable>
                 <SetVariable name="ObjectName">SlipmodeButton<Variable name="DeckGroup"/></SetVariable>
-                <SetVariable name="ConfigKey"><Variable name="Group"/>,slip_enabled</SetVariable>
+                <SetVariable name="ConfigKey"><Variable name="Group"/>,loop_remove</SetVariable>
                 <SetVariable name="Size">21f,18f</SetVariable>
               </Template>
 

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -779,6 +779,21 @@ void LoopingControl::slotLoopRemove() {
     m_loopInfo.setValue(loopInfo);
     m_pCOLoopStartPosition->set(loopInfo.startPosition.toEngineSamplePosMaybeInvalid());
     m_pCOLoopEndPosition->set(loopInfo.endPosition.toEngineSamplePosMaybeInvalid());
+    // The loop cue is stored by BaseTrackPlayerImpl::unloadTrack()
+    // if the loop is valid, else it is removed.
+    // We remove it here right away so the loop is not restored
+    // when the track is loaded to another player in the meantime.
+    auto pLoadedTrack = getEngineBuffer()->getLoadedTrack();
+    if (!pLoadedTrack) {
+        return;
+    }
+    const QList<CuePointer> cuePoints = pLoadedTrack->getCuePoints();
+    for (const auto& pCue : cuePoints) {
+        if (pCue->getType() == mixxx::CueType::Loop && pCue->getHotCue() == Cue::kNoHotCue) {
+            pLoadedTrack->removeCue(pCue);
+            return;
+        }
+    }
 }
 
 void LoopingControl::slotLoopIn(double pressed) {

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -355,26 +355,26 @@ TrackPointer BaseTrackPlayerImpl::unloadTrack() {
         // nothing to do
         return TrackPointer();
     }
-
     PlayerInfo::instance().setTrackInfo(getGroup(), TrackPointer());
 
-    // Save the loops that are currently set in a loop cue. If no loop cue is
-    // currently on the track, then create a new one.
+    // Save the loop that is currently to the loop cue. If no loop cue is
+    // currently on the track, create a new one.
+    // If the loop is invalid and a loop cue exists, remove it.
     const auto loopStart =
             mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
                     m_pLoopInPoint->get());
     const auto loopEnd =
             mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
                     m_pLoopOutPoint->get());
-    if (loopStart.isValid() && loopEnd.isValid() && loopStart <= loopEnd) {
-        CuePointer pLoopCue;
-        const QList<CuePointer> cuePoints = m_pLoadedTrack->getCuePoints();
-        for (const auto& pCue : cuePoints) {
-            if (pCue->getType() == mixxx::CueType::Loop && pCue->getHotCue() == Cue::kNoHotCue) {
-                pLoopCue = pCue;
-                break;
-            }
+    CuePointer pLoopCue;
+    const QList<CuePointer> cuePoints = m_pLoadedTrack->getCuePoints();
+    for (const auto& pCue : cuePoints) {
+        if (pCue->getType() == mixxx::CueType::Loop && pCue->getHotCue() == Cue::kNoHotCue) {
+            pLoopCue = pCue;
+            break;
         }
+    }
+    if (loopStart.isValid() && loopEnd.isValid() && loopStart <= loopEnd) {
         if (pLoopCue) {
             pLoopCue->setStartAndEndPosition(loopStart, loopEnd);
         } else {
@@ -384,6 +384,8 @@ TrackPointer BaseTrackPlayerImpl::unloadTrack() {
                     loopStart,
                     loopEnd);
         }
+    } else if (pLoopCue) {
+        m_pLoadedTrack->removeCue(pLoopCue);
     }
 
     disconnectLoadedTrack();


### PR DESCRIPTION
This fixes two bugs with the loop cue (temp loop not attached to a hotcue):

**1)**
Appearantly `loop_remove` #4802 did only work for the first loop that was ever created for a track.
If a track already has a loop cue that was not cleared.
(and it seems Track menu > Reset > Loops only clears the temp. loop because Track emits cuesUpdated())

~~I fixed this in `BaseTrackPlayerImpl::unloadTrack()` rather than in `LoopingControl::slotLoopRemove()`, simply because that function already reads the loop positions and the loop cue.~~
Nope, that's not sufficient, clear it in `slotRemoveLoop` so it is not restored when the unsaved track is be loaded to another player.

**2)**
Currently, when an existing temp. loop is invalidated (set loop_in after loop_out) the loop cue is not cleared, i.e. the previous temp loop is restored next time the track is loaded.

___

The third commit changes LateNight so this can be tested easily. You may put that on top of 2.4 to confirm the bugs:
**1)**
* load a track that has a loop set (or load a track without loop, set a loop, eject, reload)
* click the Slip button (or trigger `loop_remove` otherwise)
= loop is removed
* eject
* reload
= loop is restored

**2)**
* load a track that has a loop set (or load a track without loop, set a loop, eject, reload)
* set loop_in after loop_out
= loop is removed
* eject
* reload
= previous loop is restored
Draft until that test commit is removed.