### PR TITLE
update beatloop size for loops set manually with IN/OUT

### DIFF
--- a/src/audio/frame.h
+++ b/src/audio/frame.h
@@ -121,6 +121,16 @@ class FramePos final {
         return util_isfinite(m_framePosition);
     }
 
+    // returns true if a is valid and is fairly close to target (within +/- 1 frame).
+    bool isNear(mixxx::audio::FramePos target) const {
+        VERIFY_OR_DEBUG_ASSERT(isValid()) {
+            return false;
+        }
+        return target.isValid() &&
+                value() > target.value() - 1.0 &&
+                value() < target.value() + 1.0;
+    };
+
     void setValue(value_t framePosition) {
         m_framePosition = framePosition;
     }

--- a/src/audio/frame.h
+++ b/src/audio/frame.h
@@ -120,6 +120,16 @@ class FramePos final {
         return util_isfinite(m_framePosition);
     }
 
+    // returns true if a is valid and is fairly close to target (within +/- 1 frame).
+    bool isNear(mixxx::audio::FramePos target) const {
+        VERIFY_OR_DEBUG_ASSERT(isValid()) {
+            return false;
+        }
+        return target.isValid() &&
+                value() > target.value() - 1.0 &&
+                value() < target.value() + 1.0;
+    };
+
     void setValue(value_t framePosition) {
         m_framePosition = framePosition;
     }

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -641,64 +641,6 @@ double BpmControl::getBeatDistance(mixxx::audio::FramePos thisPosition) const {
     return beatPercentage;
 }
 
-// static
-bool BpmControl::getBeatContext(
-        const mixxx::BeatsPointer& pBeats,
-        mixxx::audio::FramePos position,
-        mixxx::audio::FramePos* pPrevBeatPosition,
-        mixxx::audio::FramePos* pNextBeatPosition,
-        mixxx::audio::FrameDiff_t* pBeatLengthFrames,
-        double* pBeatPercentage) {
-    if (!pBeats) {
-        return false;
-    }
-
-    mixxx::audio::FramePos prevBeatPosition;
-    mixxx::audio::FramePos nextBeatPosition;
-    if (!pBeats->findPrevNextBeats(position, &prevBeatPosition, &nextBeatPosition, false)) {
-        return false;
-    }
-
-    if (pPrevBeatPosition != nullptr) {
-        *pPrevBeatPosition = prevBeatPosition;
-    }
-
-    if (pNextBeatPosition != nullptr) {
-        *pNextBeatPosition = nextBeatPosition;
-    }
-
-    return getBeatContextNoLookup(position,
-            prevBeatPosition,
-            nextBeatPosition,
-            pBeatLengthFrames,
-            pBeatPercentage);
-}
-
-// static
-bool BpmControl::getBeatContextNoLookup(
-        mixxx::audio::FramePos position,
-        mixxx::audio::FramePos prevBeatPosition,
-        mixxx::audio::FramePos nextBeatPosition,
-        mixxx::audio::FrameDiff_t* pBeatLengthFrames,
-        double* pBeatPercentage) {
-    if (!prevBeatPosition.isValid() || !nextBeatPosition.isValid()) {
-        return false;
-    }
-
-    const mixxx::audio::FrameDiff_t beatLengthFrames = nextBeatPosition - prevBeatPosition;
-    if (pBeatLengthFrames != nullptr) {
-        *pBeatLengthFrames = beatLengthFrames;
-    }
-
-    if (pBeatPercentage != nullptr) {
-        *pBeatPercentage = (beatLengthFrames == 0.0)
-                ? 0.0
-                : (position - prevBeatPosition) / beatLengthFrames;
-    }
-
-    return true;
-}
-
 mixxx::audio::FramePos BpmControl::getNearestPositionInPhase(
         mixxx::audio::FramePos thisPosition, bool respectLoops, bool playing) {
     // Without a beatgrid, we don't know the phase offset.
@@ -726,7 +668,7 @@ mixxx::audio::FramePos BpmControl::getNearestPositionInPhase(
         }
         // This happens if dThisPosition is the target position of a requested
         // seek command
-        if (!getBeatContext(pBeats,
+        if (!pBeats->getContext(
                     thisPosition,
                     &thisPrevBeatPosition,
                     &thisNextBeatPosition,
@@ -735,7 +677,8 @@ mixxx::audio::FramePos BpmControl::getNearestPositionInPhase(
             return thisPosition;
         }
     } else {
-        if (!getBeatContextNoLookup(thisPosition,
+        if (!mixxx::Beats::getContextNoLookup(
+                    thisPosition,
                     thisPrevBeatPosition,
                     thisNextBeatPosition,
                     &thisBeatLengthFrames,
@@ -775,7 +718,7 @@ mixxx::audio::FramePos BpmControl::getNearestPositionInPhase(
         }
 
         const auto otherPosition = pOtherEngineBuffer->getExactPlayPos();
-        if (!BpmControl::getBeatContext(otherBeats,
+        if (!otherBeats->getContext(
                     otherPosition,
                     nullptr,
                     nullptr,
@@ -923,8 +866,7 @@ mixxx::audio::FramePos BpmControl::getBeatMatchPosition(
         }
         // This happens if thisPosition is the target position of a requested
         // seek command.  Get new prev and next beats for the calculation.
-        getBeatContext(
-                m_pBeats,
+        m_pBeats->getContext(
                 thisPosition,
                 &thisPrevBeatPosition,
                 &thisNextBeatPosition,
@@ -942,7 +884,7 @@ mixxx::audio::FramePos BpmControl::getBeatMatchPosition(
         }
         // We are between the previous and next beats so we can try a standard
         // lookup of the beat length.
-        getBeatContextNoLookup(
+        mixxx::Beats::getContextNoLookup(
                 thisPosition,
                 thisPrevBeatPosition,
                 thisNextBeatPosition,
@@ -979,8 +921,7 @@ mixxx::audio::FramePos BpmControl::getBeatMatchPosition(
     mixxx::audio::FramePos otherNextBeatPosition;
     mixxx::audio::FrameDiff_t otherBeatLengthFrames = -1;
     double otherBeatFraction = -1;
-    if (!BpmControl::getBeatContext(
-                otherBeats,
+    if (!otherBeats->getContext(
                 otherPositionOfThisNextBeat,
                 &otherPrevBeatPosition,
                 &otherNextBeatPosition,
@@ -1277,7 +1218,8 @@ void BpmControl::collectFeatures(GroupFeatureState* pGroupFeatures) const {
                     m_pNextBeat.get());
     mixxx::audio::FrameDiff_t beatLengthFrames;
     double beatFraction;
-    if (getBeatContextNoLookup(info.currentPosition,
+    if (mixxx::Beats::getContextNoLookup(
+                info.currentPosition,
                 prevBeatPosition,
                 nextBeatPosition,
                 &beatLengthFrames,

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -695,64 +695,6 @@ double BpmControl::getBeatDistance(mixxx::audio::FramePos thisPosition) const {
     return beatPercentage;
 }
 
-// static
-bool BpmControl::getBeatContext(
-        const mixxx::BeatsPointer& pBeats,
-        mixxx::audio::FramePos position,
-        mixxx::audio::FramePos* pPrevBeatPosition,
-        mixxx::audio::FramePos* pNextBeatPosition,
-        mixxx::audio::FrameDiff_t* pBeatLengthFrames,
-        double* pBeatPercentage) {
-    if (!pBeats) {
-        return false;
-    }
-
-    mixxx::audio::FramePos prevBeatPosition;
-    mixxx::audio::FramePos nextBeatPosition;
-    if (!pBeats->findPrevNextBeats(position, &prevBeatPosition, &nextBeatPosition, false)) {
-        return false;
-    }
-
-    if (pPrevBeatPosition != nullptr) {
-        *pPrevBeatPosition = prevBeatPosition;
-    }
-
-    if (pNextBeatPosition != nullptr) {
-        *pNextBeatPosition = nextBeatPosition;
-    }
-
-    return getBeatContextNoLookup(position,
-            prevBeatPosition,
-            nextBeatPosition,
-            pBeatLengthFrames,
-            pBeatPercentage);
-}
-
-// static
-bool BpmControl::getBeatContextNoLookup(
-        mixxx::audio::FramePos position,
-        mixxx::audio::FramePos prevBeatPosition,
-        mixxx::audio::FramePos nextBeatPosition,
-        mixxx::audio::FrameDiff_t* pBeatLengthFrames,
-        double* pBeatPercentage) {
-    if (!prevBeatPosition.isValid() || !nextBeatPosition.isValid()) {
-        return false;
-    }
-
-    const mixxx::audio::FrameDiff_t beatLengthFrames = nextBeatPosition - prevBeatPosition;
-    if (pBeatLengthFrames != nullptr) {
-        *pBeatLengthFrames = beatLengthFrames;
-    }
-
-    if (pBeatPercentage != nullptr) {
-        *pBeatPercentage = (beatLengthFrames == 0.0)
-                ? 0.0
-                : (position - prevBeatPosition) / beatLengthFrames;
-    }
-
-    return true;
-}
-
 mixxx::audio::FramePos BpmControl::getNearestPositionInPhase(
         mixxx::audio::FramePos thisPosition, bool respectLoops, bool playing) {
     // Without a beatgrid, we don't know the phase offset.
@@ -780,7 +722,7 @@ mixxx::audio::FramePos BpmControl::getNearestPositionInPhase(
         }
         // This happens if dThisPosition is the target position of a requested
         // seek command
-        if (!getBeatContext(pBeats,
+        if (!pBeats->getContext(
                     thisPosition,
                     &thisPrevBeatPosition,
                     &thisNextBeatPosition,
@@ -789,7 +731,8 @@ mixxx::audio::FramePos BpmControl::getNearestPositionInPhase(
             return thisPosition;
         }
     } else {
-        if (!getBeatContextNoLookup(thisPosition,
+        if (!mixxx::Beats::getContextNoLookup(
+                    thisPosition,
                     thisPrevBeatPosition,
                     thisNextBeatPosition,
                     &thisBeatLengthFrames,
@@ -829,7 +772,7 @@ mixxx::audio::FramePos BpmControl::getNearestPositionInPhase(
         }
 
         const auto otherPosition = pOtherEngineBuffer->getExactPlayPos();
-        if (!BpmControl::getBeatContext(otherBeats,
+        if (!otherBeats->getContext(
                     otherPosition,
                     nullptr,
                     nullptr,
@@ -977,8 +920,7 @@ mixxx::audio::FramePos BpmControl::getBeatMatchPosition(
         }
         // This happens if thisPosition is the target position of a requested
         // seek command.  Get new prev and next beats for the calculation.
-        getBeatContext(
-                m_pBeats,
+        m_pBeats->getContext(
                 thisPosition,
                 &thisPrevBeatPosition,
                 &thisNextBeatPosition,
@@ -996,7 +938,7 @@ mixxx::audio::FramePos BpmControl::getBeatMatchPosition(
         }
         // We are between the previous and next beats so we can try a standard
         // lookup of the beat length.
-        getBeatContextNoLookup(
+        mixxx::Beats::getContextNoLookup(
                 thisPosition,
                 thisPrevBeatPosition,
                 thisNextBeatPosition,
@@ -1033,8 +975,7 @@ mixxx::audio::FramePos BpmControl::getBeatMatchPosition(
     mixxx::audio::FramePos otherNextBeatPosition;
     mixxx::audio::FrameDiff_t otherBeatLengthFrames = -1;
     double otherBeatFraction = -1;
-    if (!BpmControl::getBeatContext(
-                otherBeats,
+    if (!otherBeats->getContext(
                 otherPositionOfThisNextBeat,
                 &otherPrevBeatPosition,
                 &otherNextBeatPosition,
@@ -1342,7 +1283,8 @@ void BpmControl::collectFeatures(GroupFeatureState* pGroupFeatures, double speed
                     m_nextBeat.get());
     mixxx::audio::FrameDiff_t beatLengthFrames;
     double beatFraction;
-    if (getBeatContextNoLookup(info.currentPosition,
+    if (mixxx::Beats::getContextNoLookup(
+                info.currentPosition,
                 prevBeatPosition,
                 nextBeatPosition,
                 &beatLengthFrames,

--- a/src/engine/controls/bpmcontrol.h
+++ b/src/engine/controls/bpmcontrol.h
@@ -67,25 +67,6 @@ class BpmControl : public EngineControl {
 
     void collectFeatures(GroupFeatureState* pGroupFeatures, double speed) const;
 
-    // Calculates contextual information about beats: the previous beat, the
-    // next beat, the current beat length, and the beat ratio (how far dPosition
-    // lies within the current beat). Returns false if a previous or next beat
-    // does not exist. NULL arguments are safe and ignored.
-    static bool getBeatContext(const mixxx::BeatsPointer& pBeats,
-            mixxx::audio::FramePos position,
-            mixxx::audio::FramePos* pPrevBeatPosition,
-            mixxx::audio::FramePos* pNextBeatPosition,
-            mixxx::audio::FrameDiff_t* pBeatLengthFrames,
-            double* pBeatPercentage);
-
-    // Alternative version that works if the next and previous beat positions
-    // are already known.
-    static bool getBeatContextNoLookup(mixxx::audio::FramePos position,
-            mixxx::audio::FramePos prevBeatPosition,
-            mixxx::audio::FramePos nextBeatPosition,
-            mixxx::audio::FrameDiff_t* pBeatLengthFrames,
-            double* pBeatPercentage);
-
     // Returns the shortest change in percentage needed to achieve
     // target_percentage.
     // Example: shortestPercentageChange(0.99, 0.01) == 0.02

--- a/src/engine/controls/bpmcontrol.h
+++ b/src/engine/controls/bpmcontrol.h
@@ -67,25 +67,6 @@ class BpmControl : public EngineControl {
 
     void collectFeatures(GroupFeatureState* pGroupFeatures) const;
 
-    // Calculates contextual information about beats: the previous beat, the
-    // next beat, the current beat length, and the beat ratio (how far dPosition
-    // lies within the current beat). Returns false if a previous or next beat
-    // does not exist. NULL arguments are safe and ignored.
-    static bool getBeatContext(const mixxx::BeatsPointer& pBeats,
-            mixxx::audio::FramePos position,
-            mixxx::audio::FramePos* pPrevBeatPosition,
-            mixxx::audio::FramePos* pNextBeatPosition,
-            mixxx::audio::FrameDiff_t* pBeatLengthFrames,
-            double* pBeatPercentage);
-
-    // Alternative version that works if the next and previous beat positions
-    // are already known.
-    static bool getBeatContextNoLookup(mixxx::audio::FramePos position,
-            mixxx::audio::FramePos prevBeatPosition,
-            mixxx::audio::FramePos nextBeatPosition,
-            mixxx::audio::FrameDiff_t* pBeatLengthFrames,
-            double* pBeatPercentage);
-
     // Returns the shortest change in percentage needed to achieve
     // target_percentage.
     // Example: shortestPercentageChange(0.99, 0.01) == 0.02

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -2380,14 +2380,15 @@ void CueControl::slotLoopEnabledChanged(bool enabled) {
     }
 
     DEBUG_ASSERT(pSavedLoopControl->getStatus() != HotcueControl::Status::Empty);
-    DEBUG_ASSERT(pSavedLoopControl->getCue() &&
-            pSavedLoopControl->getCue()->getPosition() ==
-                    mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-                            m_pLoopStartPosition->get()));
-    DEBUG_ASSERT(pSavedLoopControl->getCue() &&
-            pSavedLoopControl->getCue()->getEndPosition() ==
-                    mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-                            m_pLoopEndPosition->get()));
+    DEBUG_ASSERT(pSavedLoopControl->getCue());
+    // Don't compare with == because there might be a tiny round-trip offset
+    // because LoopingControl::slotBeatLoop() uses beats to set the loop_in/_out COs
+    DEBUG_ASSERT(pSavedLoopControl->getCue()->getPosition().isNear(
+            mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
+                    m_pLoopStartPosition->get())));
+    DEBUG_ASSERT(pSavedLoopControl->getCue()->getEndPosition().isNear(
+            mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
+                    m_pLoopEndPosition->get())));
 
     if (enabled) {
         pSavedLoopControl->setStatus(HotcueControl::Status::Active);

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -2356,10 +2356,13 @@ void CueControl::setCurrentSavedLoopControlAndActivate(HotcueControl* pControl) 
     mixxx::CueType type = pCue->getType();
     Cue::StartAndEndPositions pos = pCue->getStartAndEndPosition();
 
-    VERIFY_OR_DEBUG_ASSERT(
-            type == mixxx::CueType::Loop &&
-            pos.startPosition.isValid() &&
-            pos.endPosition.isValid()) {
+    VERIFY_OR_DEBUG_ASSERT(type == mixxx::CueType::Loop) {
+        return;
+    }
+    VERIFY_OR_DEBUG_ASSERT(pos.startPosition.isValid()) {
+        return;
+    }
+    VERIFY_OR_DEBUG_ASSERT(pos.endPosition.isValid()) {
         return;
     }
 

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -2558,14 +2558,15 @@ void CueControl::slotLoopEnabledChanged(bool enabled) {
     }
 
     DEBUG_ASSERT(pSavedLoopControl->getStatus() != HotcueControl::Status::Empty);
-    DEBUG_ASSERT(pSavedLoopControl->getCue() &&
-            pSavedLoopControl->getCue()->getPosition() ==
-                    mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-                            m_pLoopStartPosition->get()));
-    DEBUG_ASSERT(pSavedLoopControl->getCue() &&
-            pSavedLoopControl->getCue()->getEndPosition() ==
-                    mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-                            m_pLoopEndPosition->get()));
+    DEBUG_ASSERT(pSavedLoopControl->getCue());
+    // Don't compare with == because there might be a tiny round-trip offset
+    // because LoopingControl::slotBeatLoop() uses beats to set the loop_in/_out COs
+    DEBUG_ASSERT(pSavedLoopControl->getCue()->getPosition().isNear(
+            mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
+                    m_pLoopStartPosition->get())));
+    DEBUG_ASSERT(pSavedLoopControl->getCue()->getEndPosition().isNear(
+            mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
+                    m_pLoopEndPosition->get())));
 
     if (enabled) {
         pSavedLoopControl->setStatus(HotcueControl::Status::Active);

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -2529,10 +2529,13 @@ void CueControl::setCurrentSavedLoopControlAndActivate(HotcueControl* pControl) 
     mixxx::CueType type = pCue->getType();
     Cue::StartAndEndPositions pos = pCue->getStartAndEndPosition();
 
-    VERIFY_OR_DEBUG_ASSERT(
-            type == mixxx::CueType::Loop &&
-            pos.startPosition.isValid() &&
-            pos.endPosition.isValid()) {
+    VERIFY_OR_DEBUG_ASSERT(type == mixxx::CueType::Loop) {
+        return;
+    }
+    VERIFY_OR_DEBUG_ASSERT(pos.startPosition.isValid()) {
+        return;
+    }
+    VERIFY_OR_DEBUG_ASSERT(pos.endPosition.isValid()) {
         return;
     }
 

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -1417,7 +1417,9 @@ double LoopingControl::findBeatloopSizeForLoop(
             }
         }
     }
-    return -1;
+
+    // No hit. Calculate the fractional beat length
+    return pBeats->numFractionalBeatsInRange(startPosition, endPosition);
 }
 
 void LoopingControl::updateBeatLoopingControls() {

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -17,11 +17,6 @@
 
 namespace {
 constexpr mixxx::audio::FrameDiff_t kMinimumAudibleLoopSizeFrames = 150;
-
-// returns true if a is valid and is fairly close to target (within +/- 1 frame).
-bool positionNear(mixxx::audio::FramePos a, mixxx::audio::FramePos target) {
-    return a.isValid() && a > target - 1 && a < target + 1;
-}
 } // namespace
 
 double LoopingControl::s_dBeatSizes[] = { 0.03125, 0.0625, 0.125, 0.25, 0.5,
@@ -1400,7 +1395,7 @@ bool LoopingControl::currentLoopMatchesBeatloopSize(const LoopInfo& loopInfo) co
     const auto loopEndPosition = pBeats->findNBeatsFromPosition(
             loopInfo.startPosition, m_pCOBeatLoopSize->get());
 
-    return positionNear(loopInfo.endPosition, loopEndPosition);
+    return loopEndPosition.isNear(loopInfo.endPosition);
 }
 
 bool LoopingControl::quantizeEnabledAndHasTrueTrackBeats() const {
@@ -1646,8 +1641,8 @@ void LoopingControl::slotBeatLoop(double beats,
         // or if the endpoints are nearly the same, do not seek forward into the adjusted loop.
         if (!keepSetPoint ||
                 !(enable || m_bLoopingEnabled) ||
-                (positionNear(newloopInfo.startPosition, loopInfo.startPosition) &&
-                        positionNear(newloopInfo.endPosition, loopInfo.endPosition))) {
+                (newloopInfo.startPosition.isNear(loopInfo.startPosition) &&
+                        newloopInfo.endPosition.isNear(loopInfo.endPosition))) {
             newloopInfo.seekMode = LoopSeekMode::MovedOut;
         } else {
             newloopInfo.seekMode = LoopSeekMode::Changed;

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -998,6 +998,9 @@ void LoopingControl::slotLoopOut(double pressed) {
         if (pressed > 0.0) {
             setLoopOutToCurrentPosition();
             m_bLoopOutPressedWhileLoopDisabled = true;
+            // This updates m_pCOBeatLoopSize
+            LoopInfo loopInfo = m_loopInfo.getValue();
+            setLoop(loopInfo.startPosition, loopInfo.endPosition, m_bLoopingEnabled);
         }
         m_bAdjustingLoopOut = false;
     }

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -1270,8 +1270,8 @@ void LoopingControl::trackBeatsUpdated(mixxx::BeatsPointer pBeats) {
         m_trueTrackBeats = false;
     }
     double loaded_loop_size = -1;
-    LoopInfo loopInfo = m_loopInfo.getValue();
-    if (loopInfo.startPosition.isValid() && loopInfo.endPosition.isValid()) {
+    if (playposInsideLoop()) {
+        LoopInfo loopInfo = getLoopInfo();
         loaded_loop_size = findBeatloopSizeForLoop(
                 loopInfo.startPosition, loopInfo.endPosition);
         if (loaded_loop_size != -1) {
@@ -1704,7 +1704,15 @@ void LoopingControl::slotBeatLoopSizeChangeRequest(double beats) {
         return;
     }
 
-    slotBeatLoop(beats, true, false);
+    // Change the current loop only if it's active or the playpos is inside it.
+    // Else, set the new value.
+    if (playposAfterLoop() || m_bLoopingEnabled) {
+        qWarning() << "     size change" << beats << "active loop / inside";
+        slotBeatLoop(beats, true, false);
+    } else {
+        qWarning() << "     size change" << beats << "just CO";
+        m_pCOBeatLoopSize->setAndConfirm(beats);
+    }
 }
 
 void LoopingControl::slotBeatLoopToggle(double pressed) {

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -4,7 +4,6 @@
 
 #include "control/controlobject.h"
 #include "control/controlpushbutton.h"
-#include "engine/controls/bpmcontrol.h"
 #include "engine/controls/enginecontrol.h"
 #include "engine/controls/ratecontrol.h"
 #include "engine/enginebuffer.h"
@@ -1801,7 +1800,7 @@ void LoopingControl::slotLoopMove(double beats) {
     }
 
     FrameInfo info = frameInfo();
-    if (BpmControl::getBeatContext(pBeats,
+    if (pBeats->getContext(
                 info.currentPosition,
                 nullptr,
                 nullptr,

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -1269,9 +1269,11 @@ void LoopingControl::trackBeatsUpdated(mixxx::BeatsPointer pBeats) {
         }
     }
 
-    // Reset to default value if track has no loop
-    // TODO Also reset if current loop size is odd or has decimals?
-    if (loaded_loop_size == -1) {
+    // Optinonally reset to default value if track has no loop
+    bool reset = m_pConfig->getValue(
+            ConfigKey(QStringLiteral("[Controls]"), QStringLiteral("LoopAutoReset")),
+            false);
+    if (loaded_loop_size == -1 && reset) {
         m_pCOBeatLoopSize->setAndConfirm(kDefaultBeatloopSize);
     }
 }

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -1258,8 +1258,8 @@ void LoopingControl::trackBeatsUpdated(mixxx::BeatsPointer pBeats) {
         m_trueTrackBeats = false;
     }
     double loaded_loop_size = -1;
-    LoopInfo loopInfo = m_loopInfo.getValue();
-    if (loopInfo.startPosition.isValid() && loopInfo.endPosition.isValid()) {
+    if (playposInsideLoop()) {
+        LoopInfo loopInfo = getLoopInfo();
         loaded_loop_size = findBeatloopSizeForLoop(
                 loopInfo.startPosition, loopInfo.endPosition);
         if (loaded_loop_size != -1) {
@@ -1700,7 +1700,15 @@ void LoopingControl::slotBeatLoopSizeChangeRequest(double beats) {
         return;
     }
 
-    slotBeatLoop(beats, true, false);
+    // Change the current loop only if it's active or the playpos is inside it.
+    // Else, set the new value.
+    if (playposAfterLoop() || m_bLoopingEnabled) {
+        qWarning() << "     size change" << beats << "active loop / inside";
+        slotBeatLoop(beats, true, false);
+    } else {
+        qWarning() << "     size change" << beats << "just CO";
+        m_pCOBeatLoopSize->setAndConfirm(beats);
+    }
 }
 
 void LoopingControl::slotBeatLoopToggle(double pressed) {

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -16,6 +16,8 @@
 
 namespace {
 constexpr mixxx::audio::FrameDiff_t kMinimumAudibleLoopSizeFrames = 150;
+
+const double kDefaultBeatloopSize = 4.0;
 } // namespace
 
 double LoopingControl::s_dBeatSizes[] = { 0.03125, 0.0625, 0.125, 0.25, 0.5,
@@ -134,7 +136,10 @@ LoopingControl::LoopingControl(const QString& group,
     m_pCOLoopAnchor->setButtonMode(mixxx::control::ButtonMode::Toggle);
 
     m_pCOBeatLoopSize = new ControlObject(ConfigKey(group, "beatloop_size"),
-                                          true, false, false, 4.0);
+            true,
+            false,
+            false,
+            kDefaultBeatloopSize);
     m_pCOBeatLoopSize->connectValueChangeRequest(this,
             &LoopingControl::slotBeatLoopSizeChangeRequest, Qt::DirectConnection);
     m_pCOBeatLoopActivate = new ControlPushButton(ConfigKey(group, "beatloop_activate"));
@@ -167,7 +172,10 @@ LoopingControl::LoopingControl(const QString& group,
     connect(m_pCOBeatJump, &ControlObject::valueChanged,
             this, &LoopingControl::slotBeatJump, Qt::DirectConnection);
     m_pCOBeatJumpSize = new ControlObject(ConfigKey(group, "beatjump_size"),
-                                          true, false, false, 4.0);
+            true,
+            false,
+            false,
+            kDefaultBeatloopSize);
     m_pCOBeatJumpSize->connectValueChangeRequest(this,
             &LoopingControl::slotBeatJumpSizeChangeRequest,
             Qt::DirectConnection);
@@ -1249,15 +1257,22 @@ void LoopingControl::trackBeatsUpdated(mixxx::BeatsPointer pBeats) {
         m_pBeats = pBeats;
         m_trueTrackBeats = false;
     }
+    double loaded_loop_size = -1;
     LoopInfo loopInfo = m_loopInfo.getValue();
     if (loopInfo.startPosition.isValid() && loopInfo.endPosition.isValid()) {
-        double loaded_loop_size = findBeatloopSizeForLoop(
+        loaded_loop_size = findBeatloopSizeForLoop(
                 loopInfo.startPosition, loopInfo.endPosition);
         if (loaded_loop_size != -1) {
             // If the loop size matches any of the 2^n sizes we adopt
             // the value for the spinbox
             m_pCOBeatLoopSize->setAndConfirm(loaded_loop_size);
         }
+    }
+
+    // Reset to default value if track has no loop
+    // TODO Also reset if current loop size is odd or has decimals?
+    if (loaded_loop_size == -1) {
+        m_pCOBeatLoopSize->setAndConfirm(kDefaultBeatloopSize);
     }
 }
 
@@ -1471,7 +1486,7 @@ mixxx::audio::FramePos LoopingControl::findQuantizedBeatloopStart(
     // ...|...................^........|...
     //
     // If we press 1/2 beatloop we want loop from 50% to 100%,
-    // If I press 1/4 beatloop, we want loop from 50% to 75% etc
+    // if we press 1/4 beatloop we want loop from 50% to 75% etc
     const mixxx::audio::FrameDiff_t framesSinceLastBeat =
             currentPosition - prevBeatPosition;
     // find the previous beat fraction and check if the current position is closer to this or the next one

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -1408,7 +1408,9 @@ double LoopingControl::findBeatloopSizeForLoop(
             }
         }
     }
-    return -1;
+
+    // No hit. Calculate the fractional beat length
+    return pBeats->numFractionalBeatsInRange(startPosition, endPosition);
 }
 
 void LoopingControl::updateBeatLoopingControls() {

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -4,7 +4,6 @@
 
 #include "control/controlobject.h"
 #include "control/controlpushbutton.h"
-#include "engine/controls/bpmcontrol.h"
 #include "engine/controls/enginecontrol.h"
 #include "engine/controls/ratecontrol.h"
 #include "engine/enginebuffer.h"
@@ -1811,7 +1810,7 @@ void LoopingControl::slotLoopMove(double beats) {
     }
 
     FrameInfo info = frameInfo();
-    if (BpmControl::getBeatContext(pBeats,
+    if (pBeats->getContext(
                 info.currentPosition,
                 nullptr,
                 nullptr,

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -17,11 +17,6 @@
 
 namespace {
 constexpr mixxx::audio::FrameDiff_t kMinimumAudibleLoopSizeFrames = 150;
-
-// returns true if a is valid and is fairly close to target (within +/- 1 frame).
-bool positionNear(mixxx::audio::FramePos a, mixxx::audio::FramePos target) {
-    return a.isValid() && a > target - 1 && a < target + 1;
-}
 } // namespace
 
 double LoopingControl::s_dBeatSizes[] = { 0.03125, 0.0625, 0.125, 0.25, 0.5,
@@ -1391,7 +1386,7 @@ bool LoopingControl::currentLoopMatchesBeatloopSize(const LoopInfo& loopInfo) co
     const auto loopEndPosition = pBeats->findNBeatsFromPosition(
             loopInfo.startPosition, m_pCOBeatLoopSize->get());
 
-    return positionNear(loopInfo.endPosition, loopEndPosition);
+    return loopEndPosition.isNear(loopInfo.endPosition);
 }
 
 bool LoopingControl::quantizeEnabledAndHasTrueTrackBeats() const {
@@ -1637,8 +1632,8 @@ void LoopingControl::slotBeatLoop(double beats,
         // or if the endpoints are nearly the same, do not seek forward into the adjusted loop.
         if (!keepSetPoint ||
                 !(enable || m_bLoopingEnabled) ||
-                (positionNear(newloopInfo.startPosition, loopInfo.startPosition) &&
-                        positionNear(newloopInfo.endPosition, loopInfo.endPosition))) {
+                (newloopInfo.startPosition.isNear(loopInfo.startPosition) &&
+                        newloopInfo.endPosition.isNear(loopInfo.endPosition))) {
             newloopInfo.seekMode = LoopSeekMode::MovedOut;
         } else {
             newloopInfo.seekMode = LoopSeekMode::Changed;

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -843,6 +843,11 @@ void LoopingControl::slotLoopIn(double pressed) {
         emit loopReset();
         if (pressed > 0.0) {
             setLoopInToCurrentPosition();
+            // This updates m_pCOBeatLoopSize
+            LoopInfo loopInfo = m_loopInfo.getValue();
+            if (loopInfo.endPosition.isValid()) {
+                setLoop(loopInfo.startPosition, loopInfo.endPosition, m_bLoopingEnabled);
+            }
         }
         m_bAdjustingLoopIn = false;
     }
@@ -981,6 +986,9 @@ void LoopingControl::slotLoopOut(double pressed) {
         if (pressed > 0.0) {
             setLoopOutToCurrentPosition();
             m_bLoopOutPressedWhileLoopDisabled = true;
+            // This updates m_pCOBeatLoopSize
+            LoopInfo loopInfo = m_loopInfo.getValue();
+            setLoop(loopInfo.startPosition, loopInfo.endPosition, m_bLoopingEnabled);
         }
         m_bAdjustingLoopOut = false;
     }

--- a/src/engine/controls/loopingcontrol.h
+++ b/src/engine/controls/loopingcontrol.h
@@ -182,6 +182,24 @@ class LoopingControl : public EngineControl {
                 mixxx::Bpm(60.0));
         return fakeBeats;
     }
+    bool loopIsValid() {
+        LoopInfo loopInfo = getLoopInfo();
+        return loopInfo.startPosition.isValid() && loopInfo.endPosition.isValid();
+    }
+    bool playposInsideLoop() {
+        LoopInfo loopInfo = getLoopInfo();
+        FrameInfo info = frameInfo();
+        mixxx::audio::FramePos currentPosition = info.currentPosition;
+        return loopIsValid() &&
+                currentPosition >= loopInfo.startPosition &&
+                currentPosition <= loopInfo.endPosition;
+    }
+    bool playposAfterLoop() {
+        LoopInfo loopInfo = getLoopInfo();
+        FrameInfo info = frameInfo();
+        mixxx::audio::FramePos currentPosition = info.currentPosition;
+        return loopIsValid() && currentPosition >= loopInfo.startPosition;
+    }
 
     // Given loop in and out points, determine if this is a beatloop of a particular
     // size.

--- a/src/preferences/dialog/dlgprefdeck.cpp
+++ b/src/preferences/dialog/dlgprefdeck.cpp
@@ -338,6 +338,14 @@ DlgPrefDeck::DlgPrefDeck(QWidget* parent, UserSettingsPointer pConfig)
     connect(checkBoxResetSpeed, &QCheckBox::toggled, this, &DlgPrefDeck::slotUpdateSpeedAutoReset);
     connect(checkBoxResetPitch, &QCheckBox::toggled, this, &DlgPrefDeck::slotUpdatePitchAutoReset);
 
+    checkboxLoopsizeReset->setChecked(m_pConfig->getValue(
+            ConfigKey(QStringLiteral("[Controls]"), QStringLiteral("LoopAutoReset")),
+            false));
+    connect(checkboxLoopsizeReset,
+            &QCheckBox::toggled,
+            this,
+            &DlgPrefDeck::slotUpdateLoopsizeAutoReset);
+
     //
     // Ramping Temporary Rate Change configuration
     //
@@ -507,6 +515,10 @@ void DlgPrefDeck::slotUpdate() {
         checkBoxResetSpeed->setChecked(false);
     }
 
+    checkboxLoopsizeReset->setChecked(m_pConfig->getValue(
+            ConfigKey(QStringLiteral("[Controls]"), QStringLiteral("LoopAutoReset")),
+            false));
+
     if (m_bRateRamping == RateControl::RampMode::Linear) {
         radioButtonRateRampModeLinear->setChecked(true);
     } else {
@@ -559,6 +571,8 @@ void DlgPrefDeck::slotResetToDefaults() {
 
     checkBoxResetSpeed->setChecked(false);
     checkBoxResetPitch->setChecked(true);
+
+    checkboxLoopsizeReset->setChecked(false);
 
     radioButtonSoftLeader->setChecked(true);
 
@@ -867,6 +881,10 @@ void DlgPrefDeck::slotUpdateSpeedAutoReset(bool b) {
 
 void DlgPrefDeck::slotUpdatePitchAutoReset(bool b) {
     m_pitchAutoReset = b;
+}
+
+void DlgPrefDeck::slotUpdateLoopsizeAutoReset(bool checked) {
+    m_loopsizeAutoReset = checked;
 }
 
 int DlgPrefDeck::cueDefaultIndexByData(int userData) const {

--- a/src/preferences/dialog/dlgprefdeck.h
+++ b/src/preferences/dialog/dlgprefdeck.h
@@ -63,6 +63,7 @@ class DlgPrefDeck : public DlgPreferencePage, public Ui::DlgPrefDeckDlg  {
 
     void slotUpdateSpeedAutoReset(bool);
     void slotUpdatePitchAutoReset(bool);
+    void slotUpdateLoopsizeAutoReset(bool);
 
   private:
     // Because the CueDefault list is out of order, we have to set the combo
@@ -104,6 +105,7 @@ class DlgPrefDeck : public DlgPreferencePage, public Ui::DlgPrefDeckDlg  {
 
     bool m_speedAutoReset;
     bool m_pitchAutoReset;
+    bool m_loopsizeAutoReset;
     KeylockMode m_keylockMode;
     KeyunlockMode m_keyunlockMode;
     SeekOnLoadMode m_seekOnLoadMode;

--- a/src/preferences/dialog/dlgprefdeckdlg.ui
+++ b/src/preferences/dialog/dlgprefdeckdlg.ui
@@ -203,7 +203,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
      <layout class="QGridLayout" name="gridLayout_7">
       <item row="0" column="0">
        <layout class="QGridLayout" name="GridLayoutSpeedOptions">
-        <item row="11" column="2">
+        <item row="12" column="2">
          <widget class="QDoubleSpinBox" name="spinBoxPermanentRateCoarse">
           <property name="toolTip">
            <string>Permanent rate change when left-clicking</string>
@@ -231,7 +231,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </property>
          </widget>
         </item>
-        <item row="11" column="1">
+        <item row="12" column="1">
          <widget class="QDoubleSpinBox" name="spinBoxPermanentRateFine">
           <property name="toolTip">
            <string>Permanent rate change when right-clicking</string>
@@ -269,7 +269,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </property>
          </widget>
         </item>
-        <item row="3" column="2">
+        <item row="4" column="2">
          <widget class="QRadioButton" name="radioButtonCurrentKey">
           <property name="text">
            <string>Current key</string>
@@ -279,7 +279,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </attribute>
          </widget>
         </item>
-        <item row="10" column="1">
+        <item row="11" column="1">
          <widget class="QDoubleSpinBox" name="spinBoxTemporaryRateFine">
           <property name="enabled">
            <bool>false</bool>
@@ -310,7 +310,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </property>
          </widget>
         </item>
-        <item row="11" column="0">
+        <item row="12" column="0">
          <widget class="QLabel" name="labelSpeedPermanent">
           <property name="text">
            <string>Permanent</string>
@@ -320,7 +320,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </property>
          </widget>
         </item>
-        <item row="7" column="1" colspan="2">
+        <item row="8" column="1" colspan="2">
          <widget class="QSlider" name="SliderRateRampSensitivity">
           <property name="enabled">
            <bool>false</bool>
@@ -342,7 +342,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </property>
          </widget>
         </item>
-        <item row="10" column="0">
+        <item row="11" column="0">
          <widget class="QLabel" name="labelSpeedTemporary">
           <property name="enabled">
            <bool>false</bool>
@@ -355,7 +355,14 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </property>
          </widget>
         </item>
-        <item row="2" column="0">
+        <item row="2" column="1">
+         <widget class="QCheckBox" name="checkboxLoopsizeReset">
+          <property name="text">
+           <string>Loop size</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
          <widget class="QLabel" name="labelSyncMode">
           <property name="text">
            <string>Sync mode (Dynamic tempo tracks)</string>
@@ -365,7 +372,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </property>
          </widget>
         </item>
-        <item row="3" column="0">
+        <item row="4" column="0">
          <widget class="QLabel" name="labelKeylockMode">
           <property name="text">
            <string>Keylock mode</string>
@@ -375,7 +382,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </property>
          </widget>
         </item>
-        <item row="7" column="0">
+        <item row="8" column="0">
          <widget class="QLabel" name="labelSpeedRampSensitivity">
           <property name="enabled">
            <bool>false</bool>
@@ -388,7 +395,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </property>
          </widget>
         </item>
-        <item row="6" column="0">
+        <item row="7" column="0">
          <widget class="QLabel" name="labelSpeedBendBehavior">
           <property name="text">
            <string>Pitch bend behavior</string>
@@ -398,7 +405,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </property>
          </widget>
         </item>
-        <item row="3" column="1">
+        <item row="4" column="1">
          <widget class="QRadioButton" name="radioButtonOriginalKey">
           <property name="text">
            <string>Original key</string>
@@ -408,7 +415,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </attribute>
          </widget>
         </item>
-        <item row="10" column="2">
+        <item row="11" column="2">
          <widget class="QDoubleSpinBox" name="spinBoxTemporaryRateCoarse">
           <property name="enabled">
            <bool>false</bool>
@@ -453,14 +460,14 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </property>
          </widget>
         </item>
-        <item row="9" column="0">
+        <item row="10" column="0">
          <widget class="QLabel" name="labelSpeedAdjustment">
           <property name="text">
            <string>Adjustment buttons:</string>
           </property>
          </widget>
         </item>
-        <item row="2" column="1">
+        <item row="3" column="1">
          <widget class="QRadioButton" name="radioButtonSoftLeader">
           <property name="toolTip">
            <string>Apply tempo changes from a soft-leading track (usually the leaving track in a transition) to the follower tracks. After the transition, the follower track will continue with the previous leader's very last tempo. Changes from explicit selected leaders are always applied.</string>
@@ -473,7 +480,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </attribute>
          </widget>
         </item>
-        <item row="9" column="2">
+        <item row="10" column="2">
          <widget class="QLabel" name="labelSpeedCoarse">
           <property name="enabled">
            <bool>true</bool>
@@ -498,7 +505,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </property>
          </widget>
         </item>
-        <item row="9" column="1">
+        <item row="10" column="1">
          <widget class="QLabel" name="labelSpeedFine">
           <property name="enabled">
            <bool>true</bool>
@@ -562,7 +569,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </property>
          </widget>
         </item>
-        <item row="6" column="2">
+        <item row="7" column="2">
          <widget class="QRadioButton" name="radioButtonRateRampModeStepping">
           <property name="text">
            <string>Abrupt jump</string>
@@ -572,7 +579,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </attribute>
          </widget>
         </item>
-        <item row="6" column="1">
+        <item row="7" column="1">
          <widget class="QRadioButton" name="radioButtonRateRampModeLinear">
           <property name="toolTip">
            <string>Smoothly adjusts deck speed when temporary change buttons are held down</string>
@@ -585,14 +592,14 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </attribute>
          </widget>
         </item>
-        <item row="4" column="0">
+        <item row="5" column="0">
          <widget class="QLabel" name="labelKeyunlockMode">
           <property name="text">
            <string>Keyunlock mode</string>
           </property>
          </widget>
         </item>
-        <item row="4" column="1">
+        <item row="5" column="1">
          <widget class="QRadioButton" name="radioButtonResetUnlockedKey">
           <property name="text">
            <string>Reset key</string>
@@ -602,7 +609,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </attribute>
          </widget>
         </item>
-        <item row="4" column="2">
+        <item row="5" column="2">
          <widget class="QRadioButton" name="radioButtonKeepUnlockedKey">
           <property name="text">
            <string>Keep key</string>
@@ -612,7 +619,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </attribute>
          </widget>
         </item>
-        <item row="2" column="2">
+        <item row="3" column="2">
          <widget class="QRadioButton" name="radioButtonLockBpm">
           <property name="toolTip">
            <string>The tempo of a previous soft leader track at the beginning of the transition is kept steady. After the transition, the follower track will maintain this original tempo. This technique serves as a workaround to avoid dynamic tempo changes, as seen during the outro of rubato-style tracks. For instance, it prevents the follower track from continuing with a slowed-down tempo of the soft leader. This corresponds to the behavior before Mixxx 2.4. Changes from explicit selected leaders are always applied.</string>
@@ -625,7 +632,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </attribute>
          </widget>
         </item>
-        <item row="5" column="0">
+        <item row="6" column="0">
          <spacer name="verticalSpacer1">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
@@ -673,6 +680,7 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
   <tabstop>checkBoxInvertSpeedSlider</tabstop>
   <tabstop>checkBoxResetPitch</tabstop>
   <tabstop>checkBoxResetSpeed</tabstop>
+  <tabstop>checkboxLoopsizeReset</tabstop>
   <tabstop>radioButtonSoftLeader</tabstop>
   <tabstop>radioButtonOriginalKey</tabstop>
   <tabstop>radioButtonCurrentKey</tabstop>

--- a/src/test/bpmcontrol_test.cpp
+++ b/src/test/bpmcontrol_test.cpp
@@ -44,7 +44,7 @@ TEST_F(BpmControlTest, BeatContext_BeatGrid) {
     mixxx::audio::FramePos nextBeatPosition;
     mixxx::audio::FrameDiff_t beatLengthFrames;
     double beatPercentage;
-    EXPECT_TRUE(BpmControl::getBeatContext(pBeats,
+    EXPECT_TRUE(pBeats->getContext(
             mixxx::audio::kStartFramePos,
             &prevBeatPosition,
             &nextBeatPosition,

--- a/src/test/looping_control_test.cpp
+++ b/src/test/looping_control_test.cpp
@@ -493,7 +493,7 @@ TEST_F(LoopingControlTest, LoopDoubleButton_DoublesBeatloopSize) {
     EXPECT_EQ(32.0, m_pBeatLoopSize->get());
 }
 
-TEST_F(LoopingControlTest, LoopDoubleButton_DoesNotResizeManualLoop) {
+TEST_F(LoopingControlTest, DISABLED_LoopDoubleButton_DoesNotResizeManualLoop) {
     m_pQuantizeEnabled->set(0);
     setCurrentPosition(mixxx::audio::FramePos{500});
     m_pButtonLoopIn->set(1.0);
@@ -545,7 +545,7 @@ TEST_F(LoopingControlTest, LoopHalveButton_HalvesBeatloopSize) {
     EXPECT_EQ(32.0, m_pBeatLoopSize->get());
 }
 
-TEST_F(LoopingControlTest, LoopHalveButton_DoesNotResizeManualLoop) {
+TEST_F(LoopingControlTest, DISABLED_LoopHalveButton_DoesNotResizeManualLoop) {
     m_pQuantizeEnabled->set(0);
     setCurrentPosition(mixxx::audio::FramePos{500});
     m_pButtonLoopIn->set(1.0);
@@ -887,7 +887,7 @@ TEST_F(LoopingControlTest, BeatLoopSize_ValueChangeResizesBeatLoop) {
     EXPECT_EQ(oldLoopLength * 2, newLoopLength);
 }
 
-TEST_F(LoopingControlTest, BeatLoopSize_ValueChangeDoesNotResizeManualLoop) {
+TEST_F(LoopingControlTest, DISABLED_BeatLoopSize_ValueChangeDoesNotResizeManualLoop) {
     setCurrentPosition(mixxx::audio::FramePos{50});
     m_pTrack1->trySetBpm(160.0);
     m_pQuantizeEnabled->set(0);

--- a/src/test/looping_control_test.cpp
+++ b/src/test/looping_control_test.cpp
@@ -496,7 +496,7 @@ TEST_F(LoopingControlTest, LoopDoubleButton_DoublesBeatloopSize) {
     EXPECT_EQ(32.0, m_pBeatLoopSize->get());
 }
 
-TEST_F(LoopingControlTest, LoopDoubleButton_DoesNotResizeManualLoop) {
+TEST_F(LoopingControlTest, DISABLED_LoopDoubleButton_DoesNotResizeManualLoop) {
     m_pQuantizeEnabled->set(0);
     setCurrentPosition(mixxx::audio::FramePos{500});
     m_pButtonLoopIn->set(1.0);
@@ -548,7 +548,7 @@ TEST_F(LoopingControlTest, LoopHalveButton_HalvesBeatloopSize) {
     EXPECT_EQ(32.0, m_pBeatLoopSize->get());
 }
 
-TEST_F(LoopingControlTest, LoopHalveButton_DoesNotResizeManualLoop) {
+TEST_F(LoopingControlTest, DISABLED_LoopHalveButton_DoesNotResizeManualLoop) {
     m_pQuantizeEnabled->set(0);
     setCurrentPosition(mixxx::audio::FramePos{500});
     m_pButtonLoopIn->set(1.0);
@@ -890,7 +890,7 @@ TEST_F(LoopingControlTest, BeatLoopSize_ValueChangeResizesBeatLoop) {
     EXPECT_EQ(oldLoopLength * 2, newLoopLength);
 }
 
-TEST_F(LoopingControlTest, BeatLoopSize_ValueChangeDoesNotResizeManualLoop) {
+TEST_F(LoopingControlTest, DISABLED_BeatLoopSize_ValueChangeDoesNotResizeManualLoop) {
     setCurrentPosition(mixxx::audio::FramePos{50});
     m_pTrack1->trySetBpm(160.0);
     m_pQuantizeEnabled->set(0);

--- a/src/track/beats.cpp
+++ b/src/track/beats.cpp
@@ -793,6 +793,29 @@ int Beats::numBeatsInRange(audio::FramePos startPosition, audio::FramePos endPos
     return i - 2;
 };
 
+double Beats::numFractionalBeatsInRange(audio::FramePos startPos, audio::FramePos endPos) const {
+    double pBeatPercentage;
+    // get the ratio of first beat / position:
+    // 1 - ((startPos - beat before range) / first beat length)
+    if (!getContext(startPos, nullptr, nullptr, nullptr, &pBeatPercentage)) {
+        return -1;
+    }
+    double numBeats = 1 - pBeatPercentage;
+
+    // get the last beat ratio:
+    // (endPos - last beat in range) / last beat length
+    if (!getContext(endPos, nullptr, nullptr, nullptr, &pBeatPercentage)) {
+        return -1;
+    }
+    numBeats += pBeatPercentage;
+
+    // get the beats inside the range
+    // subtract 1 because we already counted the first beat
+    numBeats += numBeatsInRange(findNextBeat(startPos), endPos) - 1;
+
+    return numBeats;
+}
+
 audio::FramePos Beats::findNextBeat(audio::FramePos position) const {
     return findNthBeat(position, 1);
 }

--- a/src/track/beats.cpp
+++ b/src/track/beats.cpp
@@ -620,6 +620,59 @@ mixxx::Bpm Beats::getBpmAroundPosition(audio::FramePos position, int n) const {
     return BeatUtils::calculateAverageBpm(2 * n, m_sampleRate, startPosition, endPosition);
 }
 
+bool Beats::getContext(
+        mixxx::audio::FramePos position,
+        mixxx::audio::FramePos* pPrevBeatPosition,
+        mixxx::audio::FramePos* pNextBeatPosition,
+        mixxx::audio::FrameDiff_t* pBeatLengthFrames,
+        double* pBeatPercentage) const {
+    mixxx::audio::FramePos prevBeatPosition;
+    mixxx::audio::FramePos nextBeatPosition;
+    if (!findPrevNextBeats(position, &prevBeatPosition, &nextBeatPosition, false)) {
+        return false;
+    }
+
+    if (pPrevBeatPosition != nullptr) {
+        *pPrevBeatPosition = prevBeatPosition;
+    }
+
+    if (pNextBeatPosition != nullptr) {
+        *pNextBeatPosition = nextBeatPosition;
+    }
+
+    return getContextNoLookup(
+            position,
+            prevBeatPosition,
+            nextBeatPosition,
+            pBeatLengthFrames,
+            pBeatPercentage);
+}
+
+// static
+bool Beats::getContextNoLookup(
+        mixxx::audio::FramePos position,
+        mixxx::audio::FramePos prevBeatPosition,
+        mixxx::audio::FramePos nextBeatPosition,
+        mixxx::audio::FrameDiff_t* pBeatLengthFrames,
+        double* pBeatPercentage) {
+    if (!prevBeatPosition.isValid() || !nextBeatPosition.isValid()) {
+        return false;
+    }
+
+    const mixxx::audio::FrameDiff_t beatLengthFrames = nextBeatPosition - prevBeatPosition;
+    if (pBeatLengthFrames != nullptr) {
+        *pBeatLengthFrames = beatLengthFrames;
+    }
+
+    if (pBeatPercentage != nullptr) {
+        *pBeatPercentage = (beatLengthFrames == 0.0)
+                ? 0.0
+                : (position - prevBeatPosition) / beatLengthFrames;
+    }
+
+    return true;
+}
+
 std::optional<BeatsPointer> Beats::tryTranslate(audio::FrameDiff_t offsetFrames) const {
     std::vector<BeatMarker> markers;
     std::transform(m_markers.cbegin(),

--- a/src/track/beats.cpp
+++ b/src/track/beats.cpp
@@ -818,6 +818,29 @@ int Beats::numBeatsInRange(audio::FramePos startPosition, audio::FramePos endPos
     return i - 2;
 };
 
+double Beats::numFractionalBeatsInRange(audio::FramePos startPos, audio::FramePos endPos) const {
+    double pBeatPercentage;
+    // get the ratio of first beat / position:
+    // 1 - ((startPos - beat before range) / first beat length)
+    if (!getContext(startPos, nullptr, nullptr, nullptr, &pBeatPercentage)) {
+        return -1;
+    }
+    double numBeats = 1 - pBeatPercentage;
+
+    // get the last beat ratio:
+    // (endPos - last beat in range) / last beat length
+    if (!getContext(endPos, nullptr, nullptr, nullptr, &pBeatPercentage)) {
+        return -1;
+    }
+    numBeats += pBeatPercentage;
+
+    // get the beats inside the range
+    // subtract 1 because we already counted the first beat
+    numBeats += numBeatsInRange(findNextBeat(startPos), endPos) - 1;
+
+    return numBeats;
+}
+
 audio::FramePos Beats::findNextBeat(audio::FramePos position) const {
     return findNthBeat(position, 1);
 }

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -349,6 +349,8 @@ class Beats : private std::enable_shared_from_this<Beats> {
     audio::FramePos snapPosToNearBeat(audio::FramePos position) const;
 
     int numBeatsInRange(audio::FramePos startPosition, audio::FramePos endPosition) const;
+    double numFractionalBeatsInRange(audio::FramePos startPosition,
+            audio::FramePos endPosition) const;
 
     /// Find the frame position N beats away from `position`. The number of beats may be
     /// negative and does not need to be an integer. In this case the returned position will

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -370,6 +370,26 @@ class Beats : private std::enable_shared_from_this<Beats> {
     /// The returned Bpm value may be invalid.
     mixxx::Bpm getBpmAroundPosition(audio::FramePos position, int n) const;
 
+    // Calculates contextual information about beats: the previous beat, the
+    // next beat, the current beat length, and the beat ratio (how far position
+    // lies within the current beat). Returns false if a previous or next beat
+    // does not exist. NULL arguments are safe and ignored.
+    bool getContext(
+            mixxx::audio::FramePos position,
+            mixxx::audio::FramePos* pPrevBeatPosition,
+            mixxx::audio::FramePos* pNextBeatPosition,
+            mixxx::audio::FrameDiff_t* pBeatLengthFrames,
+            double* pBeatPercentage) const;
+
+    // Alternative version that works if the next and previous beat positions
+    // are already known.
+    static bool getContextNoLookup(
+            mixxx::audio::FramePos position,
+            mixxx::audio::FramePos prevBeatPosition,
+            mixxx::audio::FramePos nextBeatPosition,
+            mixxx::audio::FrameDiff_t* pBeatLengthFrames,
+            double* pBeatPercentage);
+
     audio::SampleRate getSampleRate() const {
         return m_sampleRate;
     }

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -372,6 +372,26 @@ class Beats : private std::enable_shared_from_this<Beats> {
     /// The returned Bpm value may be invalid.
     mixxx::Bpm getBpmAroundPosition(audio::FramePos position, int n) const;
 
+    // Calculates contextual information about beats: the previous beat, the
+    // next beat, the current beat length, and the beat ratio (how far position
+    // lies within the current beat). Returns false if a previous or next beat
+    // does not exist. NULL arguments are safe and ignored.
+    bool getContext(
+            mixxx::audio::FramePos position,
+            mixxx::audio::FramePos* pPrevBeatPosition,
+            mixxx::audio::FramePos* pNextBeatPosition,
+            mixxx::audio::FrameDiff_t* pBeatLengthFrames,
+            double* pBeatPercentage) const;
+
+    // Alternative version that works if the next and previous beat positions
+    // are already known.
+    static bool getContextNoLookup(
+            mixxx::audio::FramePos position,
+            mixxx::audio::FramePos prevBeatPosition,
+            mixxx::audio::FramePos nextBeatPosition,
+            mixxx::audio::FrameDiff_t* pBeatLengthFrames,
+            double* pBeatPercentage);
+
     audio::SampleRate getSampleRate() const {
         return m_sampleRate;
     }

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -351,6 +351,8 @@ class Beats : private std::enable_shared_from_this<Beats> {
     audio::FramePos snapPosToNearBeat(audio::FramePos position) const;
 
     int numBeatsInRange(audio::FramePos startPosition, audio::FramePos endPosition) const;
+    double numFractionalBeatsInRange(audio::FramePos startPosition,
+            audio::FramePos endPosition) const;
 
     /// Find the frame position N beats away from `position`. The number of beats may be
     /// negative and does not need to be an integer. In this case the returned position will


### PR DESCRIPTION
This updates the `beatloop_size` for loops set manually with IN/OUT, which also enables `loop_halve`/`_double`.
**This is on top of #12509, so check only the last two commits.**

That was discussed in #1187 and rejected for some reasons (or rather concerns and assumptions IMO).
I disabled the respective tests.

Fixing #10511 in #12509 made the previous inconsistency obvious (https://github.com/mixxxdj/mixxx/pull/12509#issuecomment-1879126230).

The second commit tries to address the concerns raised in #1187:
When a track with an unusual loop size is ejected, that loop size is kept (now not only for saved loops but also for temp. loops).
If a track with no loop is loaded, beatloop_size is reset to default (4 beats), or, if there's a saved loop, its size is adopted.

What do you think?
(I know it's a bit late for such a change)