### PR TITLE
AutoDJ: fix GUI freeze when updating duration for many selected tracks

### DIFF
--- a/src/library/autodj/dlgautodj.cpp
+++ b/src/library/autodj/dlgautodj.cpp
@@ -367,12 +367,9 @@ void DlgAutoDJ::updateSelectionInfo() {
 
     QModelIndexList indices = m_pTrackTableView->selectionModel()->selectedRows();
 
-    for (int i = 0; i < indices.size(); ++i) {
-        TrackPointer pTrack = m_pAutoDJTableModel->getTrack(indices.at(i));
-        if (pTrack) {
-            duration += pTrack->getDuration();
-        }
-    }
+    // Derive total duration from the table model. This is much faster than
+    // getting the duration from individual track objects.
+    duration = m_pAutoDJTableModel->getDurationOfRows(indices);
 
     QString label;
 

--- a/src/library/playlisttablemodel.cpp
+++ b/src/library/playlisttablemodel.cpp
@@ -319,6 +319,22 @@ void PlaylistTableModel::shuffleTracks(const QModelIndexList& shuffle, const QMo
     m_pTrackCollectionManager->internalCollection()->getPlaylistDAO().shuffleTracks(m_iPlaylistId, positions, allIds);
 }
 
+double PlaylistTableModel::getDurationOfRows(const QModelIndexList& indices) {
+    double durationTotal = 0.0;
+    if (indices.isEmpty()) {
+        return durationTotal;
+    }
+
+    const int durationColumnIndex = fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_DURATION);
+    for (const auto& index : indices) {
+        durationTotal += index.sibling(index.row(), durationColumnIndex)
+                                 .data(Qt::EditRole)
+                                 .toDouble();
+    }
+
+    return durationTotal;
+}
+
 bool PlaylistTableModel::isColumnInternal(int column) {
     return column == fieldIndex(ColumnCache::COLUMN_PLAYLISTTRACKSTABLE_TRACKID) ||
             TrackSetTableModel::isColumnInternal(column);

--- a/src/library/playlisttablemodel.h
+++ b/src/library/playlisttablemodel.h
@@ -27,6 +27,8 @@ class PlaylistTableModel final : public TrackSetTableModel {
     int addTracks(const QModelIndex& index, const QList<QString>& locations) final;
     bool isLocked() final;
 
+    double getDurationOfRows(const QModelIndexList& indices);
+
     Capabilities getCapabilities() const final;
 
     QString modelKey(bool noSearch) const override;


### PR DESCRIPTION
fixes #12520 

* ~~move the duration collection to TrackDAO~~
* ~~query the database duration column instead of inspecting each Track object~~
____
* move the duration collection to PlaylistTableModel
(could also be in any of the classes that is derived from but... YAGNI?)
* query the duration column of each row instead of inspecting each Track object

Now updating the info for ~16k tracks takes ~5ms here.
With the 2.4 code, updating the info for 3 tracks already takes ~40ms :grimacing: 