### PR TITLE
fix(qml): Improve knobs by applying selective 4xMSAA on the Arc shape

### DIFF
--- a/res/qml/Mixxx/Controls/Knob.qml
+++ b/res/qml/Mixxx/Controls/Knob.qml
@@ -63,6 +63,12 @@ Item {
         anchors.fill: parent
         antialiasing: true
         visible: root.arc
+        // Enable smooth curves. For QtQuick Shapes, this currently only works
+        // by enabling multisampling, so we use 4xMSAA here.
+        //
+        // See https://www.qt.io/blog/2017/07/07/let-there-be-shapes for details.
+        layer.enabled: true
+        layer.samples: 4
 
         ShapePath {
             id: arcPath


### PR DESCRIPTION
This is way less resource-consuming than doing MSAA on the entire GUI.

Fixes #12536.