### PR TITLE
Tag fetcher: allow to apply cover and tags separately // var.2

### DIFF
--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -112,6 +112,18 @@ void addTagRow(
     }
 }
 
+void addDivider(const QString& text, QTreeWidget* pParent) {
+    QTreeWidgetItem* pItem = new QTreeWidgetItem(pParent);
+    pItem->setFirstColumnSpanned(true);
+    pItem->setText(0, text);
+    pItem->setFlags(Qt::NoItemFlags);
+    pItem->setForeground(0, pParent->palette().color(QPalette::Disabled, QPalette::Text));
+
+    QFont bold_font(pParent->font());
+    bold_font.setBold(true);
+    pItem->setFont(0, bold_font);
+}
+
 void updateOriginalTag(const Track& track, QTreeWidget* pParent) {
     const mixxx::TrackMetadata trackMetadata = track.getMetadata();
     const QString trackNumberAndTotal = TrackNumbers::joinAsString(
@@ -507,18 +519,6 @@ void DlgTagFetcher::slotNetworkResult(
     btnRetry->setEnabled(true);
     loadingProgressBar->setValue(kMaximumValueOfQProgressBar);
     return;
-}
-
-void DlgTagFetcher::addDivider(const QString& text, QTreeWidget* pParent) const {
-    QTreeWidgetItem* pItem = new QTreeWidgetItem(pParent);
-    pItem->setFirstColumnSpanned(true);
-    pItem->setText(0, text);
-    pItem->setFlags(Qt::NoItemFlags);
-    pItem->setForeground(0, palette().color(QPalette::Disabled, QPalette::Text));
-
-    QFont bold_font(font());
-    bold_font.setBold(true);
-    pItem->setFont(0, bold_font);
 }
 
 void DlgTagFetcher::tagSelected() {

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -361,7 +361,7 @@ void DlgTagFetcher::applyTags() {
             // to the current time.
             QDateTime::currentDateTimeUtc());
 
-    // statusMessage->setText(tr("Metadata & Cover Art applied"));
+    statusMessage->setText(tr("Metadata applied"));
 }
 
 void DlgTagFetcher::applyCover() {

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -168,7 +168,7 @@ void DlgTagFetcher::init() {
         btnPrev->hide();
     }
 
-    connect(btnApply, &QPushButton::clicked, this, &DlgTagFetcher::applyTagsAndCover);
+    connect(btnApplyTags, &QPushButton::clicked, this, &DlgTagFetcher::applyTags);
     connect(btnApplyCover, &QPushButton::clicked, this, &DlgTagFetcher::applyCover);
     connect(btnQuit, &QPushButton::clicked, this, &DlgTagFetcher::quit);
     connect(btnRetry, &QPushButton::clicked, this, &DlgTagFetcher::retry);
@@ -261,7 +261,7 @@ void DlgTagFetcher::loadTrack(const TrackPointer& pTrack) {
     }
 
     btnRetry->setDisabled(true);
-    btnApply->setDisabled(true);
+    btnApplyTags->setDisabled(true);
     btnApplyCover->setDisabled(true);
     statusMessage->setVisible(false);
     loadingProgressBar->setVisible(true);
@@ -290,7 +290,7 @@ void DlgTagFetcher::slotTrackChanged(TrackId trackId) {
     }
 }
 
-void DlgTagFetcher::applyTagsAndCover() {
+void DlgTagFetcher::applyTags() {
     int tagIndex = m_data.m_selectedTag;
     if (tagIndex < 0) {
         return;
@@ -354,8 +354,6 @@ void DlgTagFetcher::applyTagsAndCover() {
     }
 #endif // __EXTRA_METADATA__
 
-    applyCover();
-
     m_pTrack->replaceMetadataFromSource(
             std::move(trackMetadata),
             // Prevent re-import of outdated metadata from file tags
@@ -363,7 +361,7 @@ void DlgTagFetcher::applyTagsAndCover() {
             // to the current time.
             QDateTime::currentDateTimeUtc());
 
-    statusMessage->setText(tr("Metadata & Cover Art applied"));
+    // statusMessage->setText(tr("Metadata & Cover Art applied"));
 }
 
 void DlgTagFetcher::applyCover() {
@@ -416,7 +414,7 @@ void DlgTagFetcher::applyCover() {
 
 void DlgTagFetcher::retry() {
     btnRetry->setDisabled(true);
-    btnApply->setDisabled(true);
+    btnApplyTags->setDisabled(true);
     btnApplyCover->setDisabled(true);
     loadingProgressBar->setValue(kMinimumValueOfQProgressBar);
     m_tagFetcher.startFetch(m_pTrack);
@@ -467,7 +465,7 @@ void DlgTagFetcher::fetchTagFinished(
         loadingProgressBar->setFormat(emptyMessage);
         return;
     } else {
-        btnApply->setDisabled(true);
+        btnApplyTags->setDisabled(true);
         btnApplyCover->setDisabled(true);
         btnRetry->setDisabled(true);
         loadingProgressBar->setVisible(false);
@@ -523,17 +521,17 @@ void DlgTagFetcher::slotNetworkResult(
 
 void DlgTagFetcher::tagSelected() {
     if (!tags->currentItem()) {
-        btnApply->setDisabled(true);
+        btnApplyTags->setDisabled(true);
         return;
     }
 
     if (tags->currentItem()->data(0, Qt::UserRole).toInt() == kOriginalTrackIndex) {
         tags->currentItem()->setFlags(Qt::ItemIsEnabled);
-        btnApply->setDisabled(true);
+        btnApplyTags->setDisabled(true);
         return;
     }
     // Allow applying the tags, regardless the cover art
-    btnApply->setEnabled(true);
+    btnApplyTags->setEnabled(true);
 
     const int tagIndex = tags->currentItem()->data(0, Qt::UserRole).toInt();
     m_data.m_selectedTag = tagIndex;

--- a/src/library/dlgtagfetcher.h
+++ b/src/library/dlgtagfetcher.h
@@ -73,7 +73,6 @@ class DlgTagFetcher : public QDialog, public Ui::DlgTagFetcher {
   private:
     // Called on population or changed via buttons Next&Prev.
     void loadTrackInternal(const TrackPointer& pTrack);
-    void addDivider(const QString& text, QTreeWidget* pParent) const;
     void getCoverArt(const QString& url);
     void loadCurrentTrackCover();
 

--- a/src/library/dlgtagfetcher.h
+++ b/src/library/dlgtagfetcher.h
@@ -49,7 +49,7 @@ class DlgTagFetcher : public QDialog, public Ui::DlgTagFetcher {
     void slotNetworkResult(int httpStatus, const QString& app, const QString& message, int code);
     // Called when apply is pressed.
     void slotTrackChanged(TrackId trackId);
-    void applyTagsAndCover();
+    void applyTags();
     void applyCover();
     void retry();
     void quit();

--- a/src/library/dlgtagfetcher.ui
+++ b/src/library/dlgtagfetcher.ui
@@ -412,7 +412,7 @@
      <item>
       <widget class="QPushButton" name="btnApplyTags">
        <property name="text">
-        <string>&amp;Apply</string>
+        <string>&amp;Apply Tags</string>
        </property>
       </widget>
      </item>

--- a/src/library/dlgtagfetcher.ui
+++ b/src/library/dlgtagfetcher.ui
@@ -410,7 +410,7 @@
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="btnApply">
+      <widget class="QPushButton" name="btnApplyTags">
        <property name="text">
         <string>&amp;Apply</string>
        </property>
@@ -436,7 +436,7 @@
   <tabstop>btnPrev</tabstop>
   <tabstop>btnNext</tabstop>
   <tabstop>btnApplyCover</tabstop>
-  <tabstop>btnApply</tabstop>
+  <tabstop>btnApplyTags</tabstop>
   <tabstop>btnQuit</tabstop>
   <tabstop>btnRetry</tabstop>
  </tabstops>


### PR DESCRIPTION
Fixes #12532 

Now Apply only applies the tags.
(now-wrong status message is disabled)

The last commit renames the Apply button and adjusts the status message.
'Apply' does not necessarily need to be renamed (translations will be abandoned), so if we don  **not** want to change tr strings that late I'll revert that commit.

![image](https://github.com/mixxxdj/mixxx/assets/5934199/798bd63d-d7f4-4113-954f-6635efa6ae26)
