### PR TITLE
Tag fetcher: allow to apply cover and tags separately // var.1 checkboxes

### DIFF
--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -112,6 +112,18 @@ void addTagRow(
     }
 }
 
+void addDivider(const QString& text, QTreeWidget* pParent) {
+    QTreeWidgetItem* pItem = new QTreeWidgetItem(pParent);
+    pItem->setFirstColumnSpanned(true);
+    pItem->setText(0, text);
+    pItem->setFlags(Qt::NoItemFlags);
+    pItem->setForeground(0, pParent->palette().color(QPalette::Disabled, QPalette::Text));
+
+    QFont bold_font(pParent->font());
+    bold_font.setBold(true);
+    pItem->setFont(0, bold_font);
+}
+
 void updateOriginalTag(const Track& track, QTreeWidget* pParent) {
     const mixxx::TrackMetadata trackMetadata = track.getMetadata();
     const QString trackNumberAndTotal = TrackNumbers::joinAsString(
@@ -507,18 +519,6 @@ void DlgTagFetcher::slotNetworkResult(
     btnRetry->setEnabled(true);
     loadingProgressBar->setValue(kMaximumValueOfQProgressBar);
     return;
-}
-
-void DlgTagFetcher::addDivider(const QString& text, QTreeWidget* pParent) const {
-    QTreeWidgetItem* pItem = new QTreeWidgetItem(pParent);
-    pItem->setFirstColumnSpanned(true);
-    pItem->setText(0, text);
-    pItem->setFlags(Qt::NoItemFlags);
-    pItem->setForeground(0, palette().color(QPalette::Disabled, QPalette::Text));
-
-    QFont bold_font(font());
-    bold_font.setBold(true);
-    pItem->setFont(0, bold_font);
 }
 
 void DlgTagFetcher::tagSelected() {

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -265,6 +265,8 @@ void DlgTagFetcher::loadTrack(const TrackPointer& pTrack) {
 
     btnRetry->setDisabled(true);
     btnApply->setDisabled(true);
+    checkBoxTags->setDisabled(true);
+    checkBoxCover->setDisabled(true);
     statusMessage->setVisible(false);
     loadingProgressBar->setVisible(true);
     loadingProgressBar->setValue(kMinimumValueOfQProgressBar);
@@ -428,6 +430,8 @@ void DlgTagFetcher::applyCover() {
 void DlgTagFetcher::retry() {
     btnRetry->setDisabled(true);
     btnApply->setDisabled(true);
+    checkBoxTags->setDisabled(true);
+    checkBoxCover->setDisabled(true);
     loadingProgressBar->setValue(kMinimumValueOfQProgressBar);
     m_tagFetcher.startFetch(m_pTrack);
 }
@@ -488,6 +492,8 @@ void DlgTagFetcher::fetchTagFinished(
     } else {
         btnApply->setDisabled(true);
         btnRetry->setDisabled(true);
+        checkBoxTags->setDisabled(true);
+        checkBoxCover->setDisabled(true);
         loadingProgressBar->setVisible(false);
         statusMessage->setVisible(true);
 
@@ -542,16 +548,20 @@ void DlgTagFetcher::slotNetworkResult(
 void DlgTagFetcher::tagSelected() {
     if (!tags->currentItem()) {
         btnApply->setDisabled(true);
+        checkBoxTags->setDisabled(true);
+        checkBoxCover->setDisabled(true);
         return;
     }
 
     if (tags->currentItem()->data(0, Qt::UserRole).toInt() == kOriginalTrackIndex) {
         tags->currentItem()->setFlags(Qt::ItemIsEnabled);
         btnApply->setDisabled(true);
+        checkBoxTags->setDisabled(true);
         return;
     }
     // Allow applying the tags, regardless the cover art
     btnApply->setEnabled(true);
+    checkBoxTags->setEnabled(true);
 
     const int tagIndex = tags->currentItem()->data(0, Qt::UserRole).toInt();
     m_data.m_selectedTag = tagIndex;
@@ -629,6 +639,8 @@ void DlgTagFetcher::slotLoadBytesToLabel(const QByteArray& data) {
     m_pWFetchedCoverArtLabel->loadData(
             m_fetchedCoverArtByteArrays); // This data loaded because for full size.
     m_pWFetchedCoverArtLabel->setCoverArt(coverInfo, fetchedCoverArtPixmap);
+
+    checkBoxCover->setEnabled(!data.isNull());
 }
 
 void DlgTagFetcher::getCoverArt(const QString& url) {
@@ -641,6 +653,7 @@ void DlgTagFetcher::slotCoverArtLinkNotFound() {
     loadingProgressBar->setVisible(false);
     statusMessage->setText(tr("Cover Art is not available for selected metadata"));
     statusMessage->setVisible(true);
+    checkBoxCover->setDisabled(true);
 }
 
 void DlgTagFetcher::slotWorkerStarted() {

--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -192,8 +192,10 @@ void DlgTagFetcher::init() {
 
     btnRetry->setDisabled(true);
 
-    checkBoxTags->setChecked(true);
-    checkBoxCover->setChecked(true);
+    int iApplyTags = m_pConfig->getValue(mixxx::library::prefs::kTagFetcherApplyTagsConfigKey, 1);
+    int iApplyCover = m_pConfig->getValue(mixxx::library::prefs::kTagFetcherApplyCoverConfigKey, 1);
+    checkBoxTags->setChecked(iApplyTags == 1);
+    checkBoxCover->setChecked(iApplyCover == 1);
 
     CoverArtCache* pCache = CoverArtCache::instance();
     if (pCache) {
@@ -432,12 +434,21 @@ void DlgTagFetcher::retry() {
 
 void DlgTagFetcher::quit() {
     m_tagFetcher.cancel();
+    saveCheckBoxState();
     accept();
 }
 
 void DlgTagFetcher::reject() {
     m_tagFetcher.cancel();
+    saveCheckBoxState();
     accept();
+}
+
+void DlgTagFetcher::saveCheckBoxState() {
+    m_pConfig->set(mixxx::library::prefs::kTagFetcherApplyTagsConfigKey,
+            ConfigValue(checkBoxTags->isChecked()));
+    m_pConfig->set(mixxx::library::prefs::kTagFetcherApplyCoverConfigKey,
+            ConfigValue(checkBoxCover->isChecked()));
 }
 
 void DlgTagFetcher::showProgressOfConstantTask(const QString& text) {

--- a/src/library/dlgtagfetcher.h
+++ b/src/library/dlgtagfetcher.h
@@ -73,7 +73,6 @@ class DlgTagFetcher : public QDialog, public Ui::DlgTagFetcher {
   private:
     // Called on population or changed via buttons Next&Prev.
     void loadTrackInternal(const TrackPointer& pTrack);
-    void addDivider(const QString& text, QTreeWidget* pParent) const;
     void getCoverArt(const QString& url);
     void loadCurrentTrackCover();
 

--- a/src/library/dlgtagfetcher.h
+++ b/src/library/dlgtagfetcher.h
@@ -49,7 +49,8 @@ class DlgTagFetcher : public QDialog, public Ui::DlgTagFetcher {
     void slotNetworkResult(int httpStatus, const QString& app, const QString& message, int code);
     // Called when apply is pressed.
     void slotTrackChanged(TrackId trackId);
-    void applyTagsAndCover();
+    void apply();
+    void applyTags();
     void applyCover();
     void retry();
     void quit();

--- a/src/library/dlgtagfetcher.h
+++ b/src/library/dlgtagfetcher.h
@@ -77,6 +77,8 @@ class DlgTagFetcher : public QDialog, public Ui::DlgTagFetcher {
     void getCoverArt(const QString& url);
     void loadCurrentTrackCover();
 
+    void saveCheckBoxState();
+
     UserSettingsPointer m_pConfig;
 
     const TrackModel* const m_pTrackModel;

--- a/src/library/dlgtagfetcher.ui
+++ b/src/library/dlgtagfetcher.ui
@@ -297,13 +297,6 @@
           </widget>
          </item>
          <item>
-          <widget class="QPushButton" name="btnApplyCover">
-           <property name="text">
-            <string>Apply Cover</string>
-           </property>
-          </widget>
-         </item>
-         <item>
           <spacer name="verticalSpacer">
            <property name="orientation">
             <enum>Qt::Vertical</enum>
@@ -410,6 +403,20 @@
       </spacer>
      </item>
      <item>
+      <widget class="QCheckBox" name="checkBoxTags">
+       <property name="text">
+        <string>Tags</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="checkBoxCover">
+       <property name="text">
+        <string>Cover</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="btnApply">
        <property name="text">
         <string>&amp;Apply</string>
@@ -435,7 +442,8 @@
   <tabstop>submit_tree</tabstop>
   <tabstop>btnPrev</tabstop>
   <tabstop>btnNext</tabstop>
-  <tabstop>btnApplyCover</tabstop>
+  <tabstop>checkBoxTags</tabstop>
+  <tabstop>checkBoxCover</tabstop>
   <tabstop>btnApply</tabstop>
   <tabstop>btnQuit</tabstop>
   <tabstop>btnRetry</tabstop>

--- a/src/library/library_prefs.cpp
+++ b/src/library/library_prefs.cpp
@@ -89,3 +89,13 @@ const ConfigKey mixxx::library::prefs::kCoverArtFetcherQualityConfigKey =
         ConfigKey{
                 mixxx::library::prefs::kConfigGroup,
                 QStringLiteral("CoverArtFetcherQuality")};
+
+const ConfigKey mixxx::library::prefs::kTagFetcherApplyTagsConfigKey =
+        ConfigKey{
+                mixxx::library::prefs::kConfigGroup,
+                QStringLiteral("TagFetcherApplyTags")};
+
+const ConfigKey mixxx::library::prefs::kTagFetcherApplyCoverConfigKey =
+        ConfigKey{
+                mixxx::library::prefs::kConfigGroup,
+                QStringLiteral("TagFetcherApplyCover")};

--- a/src/library/library_prefs.h
+++ b/src/library/library_prefs.h
@@ -48,6 +48,10 @@ extern const ConfigKey kUseRelativePathOnExportConfigKey;
 
 extern const ConfigKey kCoverArtFetcherQualityConfigKey;
 
+extern const ConfigKey kTagFetcherApplyTagsConfigKey;
+
+extern const ConfigKey kTagFetcherApplyCoverConfigKey;
+
 } // namespace prefs
 
 } // namespace library


### PR DESCRIPTION
Fixes #12532 

Solution with two checkboxes = two new tr strings
Check states are forgotten when the dialog is closed.
![image](https://github.com/mixxxdj/mixxx/assets/5934199/0b053e02-263a-452a-af40-e936bbf1b0a4)

With this new tr strings are inevitable. With #12542 not necessarily.

Both solutions probably fit different use cases:
* this: more suitable for batch tagging with cover art if users prefer to stick to the cover art referenced by the MusicBrainz release
   * check the boxes as desired
   * go through tracks, apply
* #12542: better for individual tagging
   * select tags
   * apply tags
   * (optional: select another cover)
   * apply cover
   * = no need to adjust checkboxes if the found covers is not desired

I have no preference since I rarely use this feature, though I think separate buttons are easier to understand (even if we stick to 'Apply') than checkboxes.