### PR TITLE
fix: add multi-sampling settings for QML

### DIFF
--- a/res/qml/Mixxx/Controls/Knob.qml
+++ b/res/qml/Mixxx/Controls/Knob.qml
@@ -67,8 +67,9 @@ Item {
         // by enabling multisampling, so we use 4xMSAA here.
         //
         // See https://www.qt.io/blog/2017/07/07/let-there-be-shapes for details.
-        layer.enabled: true
-        layer.samples: 4
+        property int multiSamplingLevel: Mixxx.Config.getMultiSamplingLevel()
+        layer.enabled: multiSamplingLevel > 1
+        layer.samples: multiSamplingLevel
 
         ShapePath {
             id: arcPath

--- a/src/preferences/dialog/dlgprefinterface.cpp
+++ b/src/preferences/dialog/dlgprefinterface.cpp
@@ -194,7 +194,7 @@ DlgPrefInterface::DlgPrefInterface(
         mulitSamplingComboBox->addItem(tr("8x MSAA"), 8);
         mulitSamplingComboBox->addItem(tr("16x MSAA"), 16);
 
-        m_multiSampling = m_pConfig->getValue(ConfigKey(kPreferencesGroup, kMultiSamplingKey), 0);
+        m_multiSampling = m_pConfig->getValue(ConfigKey(kPreferencesGroup, kMultiSamplingKey), 4);
         int mulitSamplingIndex = mulitSamplingComboBox->findData(m_multiSampling);
         if (mulitSamplingIndex != -1) {
             mulitSamplingComboBox->setCurrentIndex(mulitSamplingIndex);

--- a/src/preferences/dialog/dlgprefinterface.h
+++ b/src/preferences/dialog/dlgprefinterface.h
@@ -68,6 +68,7 @@ class DlgPrefInterface : public DlgPreferencePage, public Ui::DlgPrefControlsDlg
     QString m_colorScheme;
     QString m_colorSchemeOnUpdate;
     QString m_localeOnUpdate;
+    int m_multiSampling;
     mixxx::TooltipsPreference m_tooltipMode;
     double m_dScaleFactor;
     double m_minScaleFactor;

--- a/src/preferences/dialog/dlgprefinterfacedlg.ui
+++ b/src/preferences/dialog/dlgprefinterfacedlg.ui
@@ -269,7 +269,16 @@
       <item row="4" column="1" colspan="2">
        <widget class="QComboBox" name="comboBoxScreensaver"/>
       </item>
-
+      <item row="5" column="0">
+       <widget class="QLabel" name="mulitSamplingLabel">
+        <property name="text">
+         <string>Multi-Sampling</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1" colspan="2">
+       <widget class="QComboBox" name="mulitSamplingComboBox"/>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/qml/qmlconfigproxy.cpp
+++ b/src/qml/qmlconfigproxy.cpp
@@ -11,6 +11,10 @@ QVariantList paletteToQColorList(const ColorPalette& palette) {
     }
     return colors;
 }
+
+const QString kPreferencesGroup = QStringLiteral("[Preferences]");
+const QString kMultiSamplingKey = QStringLiteral("multi_sampling");
+
 } // namespace
 
 namespace mixxx {
@@ -29,6 +33,10 @@ QVariantList QmlConfigProxy::getHotcueColorPalette() {
 QVariantList QmlConfigProxy::getTrackColorPalette() {
     ColorPaletteSettings colorPaletteSettings(m_pConfig);
     return paletteToQColorList(colorPaletteSettings.getTrackColorPalette());
+}
+
+int QmlConfigProxy::getMultiSamplingLevel() {
+    return m_pConfig->getValue(ConfigKey(kPreferencesGroup, kMultiSamplingKey), 0);
 }
 
 // static

--- a/src/qml/qmlconfigproxy.h
+++ b/src/qml/qmlconfigproxy.h
@@ -18,8 +18,11 @@ class QmlConfigProxy : public QObject {
             UserSettingsPointer pConfig,
             QObject* parent = nullptr);
 
+    // We use method here instead of properties as there is no way to achieve property binding
+    // with UserSettings, since there is no synchronisation upon mutations.
     Q_INVOKABLE QVariantList getHotcueColorPalette();
     Q_INVOKABLE QVariantList getTrackColorPalette();
+    Q_INVOKABLE int getMultiSamplingLevel();
 
     static QmlConfigProxy* create(QQmlEngine* pQmlEngine, QJSEngine* pJsEngine);
     static inline void registerUserSettings(UserSettingsPointer pConfig) {


### PR DESCRIPTION
This extends the work made on #12541 to address #12536 with a customizable multi-sampling level.