### PR TITLE
Allow controller mapping to discard polling

### DIFF
--- a/src/controllers/bulk/bulkcontroller.cpp
+++ b/src/controllers/bulk/bulkcontroller.cpp
@@ -172,6 +172,12 @@ int BulkController::open() {
 
     if (m_pReader != nullptr) {
         qCWarning(m_logBase) << "BulkReader already present for" << getName();
+    } else if (m_pMapping &&
+            !(m_pMapping->getDeviceDirection() &
+                    LegacyControllerMapping::DeviceDirection::Incoming)) {
+        qDebug() << "The mapping for the bulk device" << getName()
+                 << "doesn't require reading the data. Ignoring BulkReader "
+                    "setup.";
     } else {
         m_pReader = new BulkReader(m_phandle, in_epaddr);
         m_pReader->setObjectName(QString("BulkReader %1").arg(getName()));
@@ -195,10 +201,12 @@ int BulkController::close() {
     qCInfo(m_logBase) << "Shutting down USB Bulk device" << getName();
 
     // Stop the reading thread
-    if (m_pReader == nullptr) {
+    if (m_pReader == nullptr &&
+            m_pMapping->getDeviceDirection() &
+                    LegacyControllerMapping::DeviceDirection::Incoming) {
         qCWarning(m_logBase) << "BulkReader not present for" << getName()
                              << "yet the device is open!";
-    } else {
+    } else if (m_pReader) {
         disconnect(m_pReader, &BulkReader::incomingData, this, &BulkController::receive);
         m_pReader->stop();
         qCInfo(m_logBase) << "  Waiting on reader to finish";
@@ -230,6 +238,14 @@ void BulkController::send(const QList<int>& data, unsigned int length) {
 }
 
 void BulkController::sendBytes(const QByteArray& data) {
+    VERIFY_OR_DEBUG_ASSERT(!m_pMapping ||
+            m_pMapping->getDeviceDirection() &
+                    LegacyControllerMapping::DeviceDirection::Outgoing) {
+        qDebug() << "The mapping for the bulk device" << getName()
+                 << "doesn't require sending data. Ignoring sending request.";
+        return;
+    }
+
     int ret;
     int transferred;
 

--- a/src/controllers/legacycontrollermapping.h
+++ b/src/controllers/legacycontrollermapping.h
@@ -15,7 +15,8 @@
 class LegacyControllerMapping {
   public:
     LegacyControllerMapping()
-            : m_bDirty(false) {
+            : m_bDirty(false),
+              m_deviceDirection(DeviceDirection::Bidirectionnal) {
     }
     virtual ~LegacyControllerMapping() = default;
 
@@ -31,6 +32,19 @@ class LegacyControllerMapping {
         QFileInfo file;
         bool builtin;
     };
+
+    // TODO (xxx): this is a temporary solution to address devices that don't
+    // support and need bidirectional communication and lead to
+    // polling/performance issues. The proper solution would involve refactoring
+    // the bulk integration to perform a better endpoint capability discovery
+    // and let Mixxx decide communication direction depending of the hardware
+    // capabilities
+    enum class DeviceDirection : uint8_t {
+        Outgoing = 0x1,
+        Incoming = 0x2,
+        Bidirectionnal = 0x3
+    };
+    Q_DECLARE_FLAGS(DeviceDirections, DeviceDirection)
 
     /// Adds a script file to the list of controller scripts for this mapping.
     /// @param filename Name of the script file to add
@@ -52,6 +66,14 @@ class LegacyControllerMapping {
 
     const QList<ScriptFileInfo>& getScriptFiles() const {
         return m_scripts;
+    }
+
+    inline void setDeviceDirection(DeviceDirections aDeviceDirection) {
+        m_deviceDirection = aDeviceDirection;
+    }
+
+    inline DeviceDirections getDeviceDirection() const {
+        return m_deviceDirection;
     }
 
     inline void setDirty(bool bDirty) {
@@ -192,4 +214,5 @@ class LegacyControllerMapping {
     QString m_mixxxVersion;
 
     QList<ScriptFileInfo> m_scripts;
+    DeviceDirections m_deviceDirection;
 };

--- a/src/controllers/legacycontrollermappingfilehandler.cpp
+++ b/src/controllers/legacycontrollermappingfilehandler.cpp
@@ -131,6 +131,17 @@ void LegacyControllerMappingFileHandler::addScriptFilesToMapping(
     QString deviceId = controller.attribute("id", "");
     mapping->setDeviceId(deviceId);
 
+    // See TODO in LegacyControllerMapping::DeviceDirection - `direction` should
+    // only be used as a workaround till the bulk integration gets refactored
+    QString deviceDirection = controller.attribute("direction", "").toLower();
+    if (deviceDirection == "in") {
+        mapping->setDeviceDirection(LegacyControllerMapping::DeviceDirection::Incoming);
+    } else if (deviceDirection == "out") {
+        mapping->setDeviceDirection(LegacyControllerMapping::DeviceDirection::Outgoing);
+    } else {
+        mapping->setDeviceDirection(LegacyControllerMapping::DeviceDirection::Bidirectionnal);
+    }
+
     // Build a list of script files to load
     QDomElement scriptFile = controller.firstChildElement("scriptfiles")
                                      .firstChildElement("file");


### PR DESCRIPTION
As I'm working on the screen support for S4 MK3, I realized that the `BulkReader` was keeping its thread under a 100% CPU usage. After some `libusb` debugging, it looks like the `BulkReader` was constantly initiating a bulk transfer, despite the device returning an empty buffer (the bulk endpoint on S4 Mk3 is write-only).

This PR allows mapping to provide information on whether or not a device should be polled or not. It also set the foundations to inhibit writing to a device.