### PR TITLE
Add PlayerProxy missing current track when created after loading

### DIFF
--- a/src/qml/qmlwaveformoverview.cpp
+++ b/src/qml/qmlwaveformoverview.cpp
@@ -35,7 +35,8 @@ void QmlWaveformOverview::setPlayer(QmlPlayerProxy* pPlayer) {
 
     m_pPlayer = pPlayer;
 
-    if (pPlayer != nullptr) {
+    if (m_pPlayer != nullptr) {
+        setCurrentTrack(m_pPlayer->internalTrackPlayer()->getLoadedTrack());
         connect(m_pPlayer->internalTrackPlayer(),
                 &BaseTrackPlayer::newTrackLoaded,
                 this,


### PR DESCRIPTION
This PR fixes the issue where a `QMLPlayerProxy` is missing the currently loaded track. Currently, if you create a `QMLPlayerProxy` (or `PlayerProxy` in QML) while a track is already loaded on a player, the PlayerProxy will appears as if no track was loaded. 

This can can be reproduced by
- Opening the QML interface
- Load a track on a deck
- Triggering a reload (e.g `touch res/qml/main.qml`)

Without this fix, the deck will appears as if empty. With it, and will display correctly, with the loaded track.