### PR TITLE
unify `[effect chain],loaded_chain_preset` control (all 0-indexed now)

### DIFF
--- a/src/effects/effectchain.cpp
+++ b/src/effects/effectchain.cpp
@@ -337,8 +337,7 @@ void EffectChain::slotControlChainPresetSelector(double value) {
 }
 
 void EffectChain::slotControlLoadedChainPresetRequest(double value) {
-    // subtract 1 to make the ControlObject 1-indexed like other ControlObjects
-    int index = static_cast<int>(value) - 1;
+    int index = static_cast<int>(value);
     if (index < 0 || index >= numPresets()) {
         return;
     }
@@ -346,9 +345,8 @@ void EffectChain::slotControlLoadedChainPresetRequest(double value) {
     loadChainPreset(presetAtIndex(index));
 }
 
-void EffectChain::setControlLoadedPresetIndex(uint index) {
-    // add 1 to make the ControlObject 1-indexed like other ControlObjects
-    m_pControlLoadedChainPreset->setAndConfirm(index + 1);
+void EffectChain::setControlLoadedPresetIndex(int index) {
+    m_pControlLoadedChainPreset->setAndConfirm(index);
 }
 
 void EffectChain::slotControlNextChainPreset(double value) {

--- a/src/effects/effectchain.cpp
+++ b/src/effects/effectchain.cpp
@@ -219,6 +219,23 @@ void EffectChain::loadChainPreset(EffectChainPresetPointer pChainPreset) {
     setControlLoadedPresetIndex(presetIndex());
 }
 
+bool EffectChain::isEmpty() {
+    for (const auto& pEffectSlot : std::as_const(m_effectSlots)) {
+        if (pEffectSlot->isLoaded()) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool EffectChain::isEmptyPlaceholderPresetLoaded() {
+    return isEmpty() && presetName() == kNoEffectString;
+}
+
+void EffectChain::loadEmptyNamelessPreset() {
+    loadChainPreset(m_pChainPresetManager->createEmptyNamelessChainPreset());
+}
+
 void EffectChain::sendParameterUpdate() {
     EffectsRequest* pRequest = new EffectsRequest();
     pRequest->type = EffectsRequest::SET_EFFECT_CHAIN_PARAMETERS;
@@ -309,7 +326,7 @@ EffectSlotPointer EffectChain::getEffectSlot(unsigned int slotNumber) {
 }
 
 void EffectChain::slotControlClear(double v) {
-    for (EffectSlotPointer pEffectSlot : std::as_const(m_effectSlots)) {
+    for (const auto& pEffectSlot : std::as_const(m_effectSlots)) {
         pEffectSlot->slotClear(v);
     }
 }

--- a/src/effects/effectchain.cpp
+++ b/src/effects/effectchain.cpp
@@ -433,6 +433,9 @@ void EffectChain::disableForInputChannel(const ChannelHandleAndGroup& handleGrou
 }
 
 int EffectChain::presetIndex() const {
+    // 0-indexed, 0 is the empty '---' preset.
+    // This can be -1 if the name is not found in the presets list,
+    // which is default state of standard effect chains.
     return m_pChainPresetManager->presetIndex(m_presetName);
 }
 

--- a/src/effects/effectchain.h
+++ b/src/effects/effectchain.h
@@ -72,6 +72,12 @@ class EffectChain : public QObject {
 
     virtual void loadChainPreset(EffectChainPresetPointer pPreset);
 
+    bool isEmpty();
+
+    bool isEmptyPlaceholderPresetLoaded();
+
+    void loadEmptyNamelessPreset();
+
   public slots:
     void slotControlClear(double value);
 

--- a/src/effects/effectchain.h
+++ b/src/effects/effectchain.h
@@ -135,7 +135,7 @@ class EffectChain : public QObject {
     std::unique_ptr<ControlPushButton> m_pControlNextChainPreset;
     std::unique_ptr<ControlPushButton> m_pControlPrevChainPreset;
 
-    void setControlLoadedPresetIndex(uint index);
+    void setControlLoadedPresetIndex(int index);
 
     // These COs do not affect how the effects are processed;
     // they are defined here for skins and controller mappings to communicate

--- a/src/effects/effectslot.cpp
+++ b/src/effects/effectslot.cpp
@@ -282,6 +282,14 @@ void EffectSlot::loadEffectInner(const EffectManifestPointer pManifest,
         return;
     }
 
+    // Don't load an effect into the '---' preset. The preset would remain
+    // selected in WEffectChainPresetSelector and WEffectChainPresetButton and
+    // therefore couldn't be used to clear the chain.
+    // Instead, load an empty, nameless preset, then load the desired effect.
+    if (m_pChain->isEmptyPlaceholderPresetLoaded()) {
+        m_pChain->loadEmptyNamelessPreset();
+    }
+
     m_pManifest = pManifest;
     addToEngine();
 

--- a/src/effects/presets/effectchainpresetmanager.cpp
+++ b/src/effects/presets/effectchainpresetmanager.cpp
@@ -38,7 +38,7 @@ EffectChainPresetPointer loadPresetFromFile(const QString& filePath) {
     return pEffectChainPreset;
 }
 
-EffectChainPresetPointer createEmptyChainPreset() {
+EffectChainPresetPointer createEmptyReadOnlyChainPreset() {
     EffectManifestPointer pEmptyManifest(new EffectManifest());
     pEmptyManifest->setName(kNoEffectString);
     // Center the Super knob, eliminates the colored (bipolar) knob ring
@@ -628,7 +628,7 @@ void EffectChainPresetManager::resetToDefaults() {
     prependRemainingPresetsToLists();
 
     // Re-add the empty chain preset
-    EffectChainPresetPointer pEmptyChainPreset = createEmptyChainPreset();
+    EffectChainPresetPointer pEmptyChainPreset = createEmptyReadOnlyChainPreset();
     m_effectChainPresets.insert(pEmptyChainPreset->name(), pEmptyChainPreset);
     m_effectChainPresetsSorted.prepend(pEmptyChainPreset);
     m_quickEffectChainPresetsSorted.prepend(pEmptyChainPreset);
@@ -807,7 +807,7 @@ EffectsXmlData EffectChainPresetManager::readEffectsXml(
     // It will not be visible in the effects preferences.
     // Note: we also need to take care of this preset in resetToDefaults() and
     // setQuickEffectPresetOrder(), both called from DlgPrefEffects
-    EffectChainPresetPointer pEmptyChainPreset = createEmptyChainPreset();
+    EffectChainPresetPointer pEmptyChainPreset = createEmptyReadOnlyChainPreset();
     m_effectChainPresets.insert(pEmptyChainPreset->name(), pEmptyChainPreset);
     m_effectChainPresetsSorted.prepend(pEmptyChainPreset);
     m_quickEffectChainPresetsSorted.prepend(pEmptyChainPreset);

--- a/src/effects/presets/effectchainpresetmanager.cpp
+++ b/src/effects/presets/effectchainpresetmanager.cpp
@@ -677,6 +677,13 @@ bool EffectChainPresetManager::savePresetXml(EffectChainPresetPointer pPreset) {
     return success;
 }
 
+// static
+EffectChainPresetPointer EffectChainPresetManager::createEmptyNamelessChainPreset() {
+    auto pPreset = EffectChainPresetPointer::create(EffectChainPreset());
+    pPreset->setName("");
+    return pPreset;
+}
+
 EffectManifestPointer EffectChainPresetManager::getDefaultEqEffect() {
     EffectManifestPointer pDefaultEqEffect = m_pBackendManager->getManifest(
             BiquadFullKillEQEffect::getId(), EffectBackendType::BuiltIn);
@@ -722,12 +729,8 @@ EffectsXmlData EffectChainPresetManager::readEffectsXml(
             QDomElement chainElement = chainNode.toElement();
             EffectChainPresetPointer pPreset =
                     EffectChainPresetPointer::create(chainElement);
-            // Don't restore the name '---', or this preset will be selected
-            // in WEffectChainPreselector and WEffectChainPresetButton (and
-            // represented by `loaded_chain_preset` CO).
-            // Then, this item can't be used to clear a chain, via the GUI or
-            // by setting `loaded_chain_preset` to 0.
-            if (pPreset->name() == kNoEffectString) {
+            // Shouldn't happen, see EffectSlot::loadEffectInner
+            VERIFY_OR_DEBUG_ASSERT(pPreset->name() != kNoEffectString) {
                 pPreset->setName("");
             }
             standardEffectChainPresets.append(pPreset);

--- a/src/effects/presets/effectchainpresetmanager.cpp
+++ b/src/effects/presets/effectchainpresetmanager.cpp
@@ -925,9 +925,16 @@ void EffectChainPresetManager::saveEffectsXml(QDomDocument* pDoc, const EffectsX
     QDomElement chainsElement = pDoc->createElement(EffectXml::kChainsRoot);
     rackElement.appendChild(chainsElement);
     for (const auto& pPreset : std::as_const(data.standardEffectChainPresets)) {
-        // Don't store the name '---', see readEffectsXml() for explanation.
+        // Don't store the empty '---' preset.
         if (pPreset->name() == kNoEffectString) {
-            pPreset->setName("");
+            // It must not have any effects loaded. If it has, clear the name.
+            // See readEffectsXml() for explanation.
+            VERIFY_OR_DEBUG_ASSERT(pPreset->isEmpty()) {
+                pPreset->setName("");
+            }
+            else {
+                continue;
+            }
         }
         chainsElement.appendChild(pPreset->toXml(pDoc));
     }

--- a/src/effects/presets/effectchainpresetmanager.h
+++ b/src/effects/presets/effectchainpresetmanager.h
@@ -76,6 +76,8 @@ class EffectChainPresetManager : public QObject {
     EffectManifestPointer getDefaultEqEffect();
     EffectChainPresetPointer getDefaultQuickEffectPreset();
 
+    static EffectChainPresetPointer createEmptyNamelessChainPreset();
+
     EffectsXmlData readEffectsXml(const QDomDocument& doc, const QStringList& deckStrings);
     EffectXmlDataSingleDeck readEffectsXmlSingleDeck(
             const QDomDocument& doc, const QString& deckString);

--- a/src/preferences/dialog/dlgprefeffects.cpp
+++ b/src/preferences/dialog/dlgprefeffects.cpp
@@ -167,6 +167,12 @@ void DlgPrefEffects::clearChainInfoDisableButtons() {
 void DlgPrefEffects::loadChainPresetLists() {
     QStringList chainPresetNames;
     for (const auto& pChainPreset : m_pChainPresetManager->getPresetsSorted()) {
+        // Don't show the empty '---' preset.
+        // After pushing the changed preferences list back to the preset manager
+        // it is re-added to the base list.
+        if (pChainPreset->name() == kNoEffectString) {
+            continue;
+        }
         chainPresetNames << pChainPreset->name();
     }
     auto* pModel = dynamic_cast<EffectChainPresetListModel*>(chainListView->model());
@@ -174,9 +180,7 @@ void DlgPrefEffects::loadChainPresetLists() {
 
     QStringList quickEffectChainPresetNames;
     for (const auto& pChainPreset : m_pChainPresetManager->getQuickEffectPresetsSorted()) {
-        // Don't show the empty '---' preset.
-        // After pushing the changed preferences list back to the preset manager
-        // it is re-added to the root list.
+        // Same here, don't show the empty '---' preset.
         if (pChainPreset->name() == kNoEffectString) {
             continue;
         }


### PR DESCRIPTION
In #10859 I introduced an inconsistency, `[QuickEffectRack1_[ChannelN]]` loaded_chain_preset is offset by one compared to `[EffectRack1_EffectUnitN]` because of the prepended empty preset.

**Fix1**
The '---' preset is now also available for standard chains, e.g. via the effect chain preset button (⚙️ icon in effect units), which removes the offset. As before, selecting this preset clears the effect chain and `loaded_chain_preset` is set to `0` (works with **all** effect chains).
_(and `-1` for nameless items, the default state of standard effect units and the main output effect unit)_
_(fixes the issue discovered by @Swiftb0y in https://github.com/mixxxdj/mixxx/pull/11378#issue-1626390581)_
I didn't do this before to avoid the UX issue I tried to describe here https://github.com/mixxxdj/mixxx/pull/11378#issuecomment-1889794345
which is now fixed by

**Fix2**
When an effect is about to be loaded while the '---' preset is loaded (and slots are empty)
* an empty, nameless preset is loaded (`loaded_chain_preset` is set to `-1`)
* the effect is loaded
* '---' is again available for clearing the effect chain

### Tests
#### Don't store/reload '---' preset
* clear an effect unit by selecting the '---' preset in the chain preset menu
* `loaded_chain_preset` is `0`
* restart Mixxx
* check
   * _no preset_ is selected in the chain preset menu
   * `loaded_chain_preset` is `-1`

#### Don't allow loading an effect into the '---' preset
* clear an effect unit by selecting the '---' preset in the chain preset menu
* trigger loading an effect (via effect selector or `[(unit)_Effect1],next_/prev_effect`/`effect_selector`
* check
   * desired effect is loaded
   * _no preset_ is selected in the chain preset menu
   * `loaded_chain_preset` is `-1`