### PR TITLE
fix glitch in Star rating

### DIFF
--- a/res/skins/LateNight/decks/deck_settings.xml
+++ b/res/skins/LateNight/decks/deck_settings.xml
@@ -18,7 +18,7 @@
             <Children>
               <StarRating>
                 <TooltipId>starrating</TooltipId>
-                <Size>75f,15f</Size>
+                <Size>105f,15f</Size>
                 <Channel><Variable name="ChanNum"/></Channel>
               </StarRating>
             </Children>

--- a/src/library/colordelegate.cpp
+++ b/src/library/colordelegate.cpp
@@ -28,21 +28,6 @@ void ColorDelegate::paintItem(
 
     // Draw a border if the color cell has focus
     if (option.state & QStyle::State_HasFocus) {
-        // This uses a color from the stylesheet:
-        // WTrackTableView {
-        //   qproperty-focusBorderColor: red;
-        // }
-        QPen borderPen(
-                m_pFocusBorderColor,
-                1,
-                Qt::SolidLine,
-                Qt::SquareCap);
-        painter->setPen(borderPen);
-        painter->setBrush(QBrush(Qt::transparent));
-        painter->drawRect(
-                option.rect.left(),
-                option.rect.top(),
-                option.rect.width() - 1,
-                option.rect.height() - 1);
+        drawBorder(painter, m_pFocusBorderColor, option.rect);
     }
 }

--- a/src/library/coverartdelegate.cpp
+++ b/src/library/coverartdelegate.cpp
@@ -163,21 +163,6 @@ void CoverArtDelegate::paintItem(
 
     // Draw a border if the cover art cell has focus
     if (option.state & QStyle::State_HasFocus) {
-        // This uses a color from the stylesheet:
-        // WTrackTableView {
-        //   qproperty-focusBorderColor: red;
-        // }
-        QPen borderPen(
-                m_pFocusBorderColor,
-                1,
-                Qt::SolidLine,
-                Qt::SquareCap);
-        painter->setPen(borderPen);
-        painter->setBrush(QBrush(Qt::transparent));
-        painter->drawRect(
-                option.rect.left(),
-                option.rect.top(),
-                option.rect.width() - 1,
-                option.rect.height() - 1);
+        drawBorder(painter, m_pFocusBorderColor, option.rect);
     }
 }

--- a/src/library/stardelegate.cpp
+++ b/src/library/stardelegate.cpp
@@ -43,7 +43,8 @@ QWidget* StarDelegate::createEditor(QWidget* parent,
     QStyleOptionViewItem newOption = option;
     initStyleOption(&newOption, index);
 
-    StarEditor* editor = new StarEditor(parent, m_pTableView, index, newOption);
+    StarEditor* editor =
+            new StarEditor(parent, m_pTableView, index, newOption, m_pFocusBorderColor);
     connect(editor,
             &StarEditor::editingFinished,
             this,

--- a/src/library/stardelegate.cpp
+++ b/src/library/stardelegate.cpp
@@ -76,6 +76,7 @@ void StarDelegate::cellEntered(const QModelIndex& index) {
     // StarRating.
     if (index.data().canConvert<StarRating>()) {
         if (m_isOneCellInEditMode) {
+            // Don't close other editors when hovering the stars cell!
             m_pTableView->closePersistentEditor(m_currentEditedCellIndex);
         }
         m_pTableView->openPersistentEditor(index);

--- a/src/library/stareditor.cpp
+++ b/src/library/stareditor.cpp
@@ -2,11 +2,12 @@
 
 #include <QItemSelectionModel>
 #include <QMouseEvent>
+#include <QPainter>
 #include <QTableView>
 
 #include "library/starrating.h"
+#include "library/tableitemdelegate.h"
 #include "moc_stareditor.cpp"
-#include "util/painterscope.h"
 
 // We enable mouse tracking on the widget so we can follow the cursor even
 // when the user doesn't hold down any mouse button. We also turn on
@@ -21,11 +22,13 @@
 StarEditor::StarEditor(QWidget* parent,
         QTableView* pTableView,
         const QModelIndex& index,
-        const QStyleOptionViewItem& option)
+        const QStyleOptionViewItem& option,
+        const QColor& focusBorderColor)
         : QWidget(parent),
           m_pTableView(pTableView),
           m_index(index),
           m_styleOption(option),
+          m_pFocusBorderColor(focusBorderColor),
           m_starCount(StarRating::kMinStarCount) {
     DEBUG_ASSERT(m_pTableView);
     setMouseTracking(true);
@@ -50,7 +53,6 @@ void StarEditor::paintEvent(QPaintEvent*) {
     }
 
     QPainter painter(this);
-    PainterScope painterScope(&painter);
 
     painter.setClipRect(m_styleOption.rect);
 
@@ -58,6 +60,12 @@ void StarEditor::paintEvent(QPaintEvent*) {
     QStyle* style = m_pTableView->style();
     if (style) {
         style->drawControl(QStyle::CE_ItemViewItem, &m_styleOption, &painter, m_pTableView);
+    }
+
+    // Draw a border if the color cell has focus
+    if (m_styleOption.state & QStyle::State_Selected) {
+        // QPainterScope in drawBorder() and shift down?
+        TableItemDelegate::drawBorder(&painter, m_pFocusBorderColor, m_styleOption.rect);
     }
 
     // Starrating scales the painter so do this after painting the border.

--- a/src/library/stareditor.cpp
+++ b/src/library/stareditor.cpp
@@ -8,12 +8,6 @@
 #include "moc_stareditor.cpp"
 #include "util/painterscope.h"
 
-namespace {
-
-constexpr int kInvalidStarCount = StarRating::kMinStarCount - 1;
-
-}
-
 // We enable mouse tracking on the widget so we can follow the cursor even
 // when the user doesn't hold down any mouse button. We also turn on
 // QWidget's auto-fill background feature to obtain an opaque background.
@@ -97,9 +91,9 @@ void StarEditor::mouseMoveEvent(QMouseEvent *event) {
 #else
     const int eventPosition = event->x();
 #endif
-    int star = starAtPosition(eventPosition);
+    int star = m_starRating.starAtPosition(eventPosition, m_styleOption.rect);
 
-    if (star <= kInvalidStarCount) {
+    if (star == StarRating::kInvalidStarCount) {
         resetRating();
     } else if (star != m_starRating.starCount()) {
         // Apply star rating if it changed
@@ -115,31 +109,4 @@ void StarEditor::leaveEvent(QEvent*) {
 
 void StarEditor::mouseReleaseEvent(QMouseEvent* /* event */) {
     emit editingFinished();
-}
-
-int StarEditor::starAtPosition(int x) {
-    int starsWidth = m_starRating.sizeHint().width();
-    // The star rating is drawn centered in the table cell, so we need
-    // to shift the x input as well.
-    int xOffset = std::max((m_styleOption.rect.width() - starsWidth) / 2, 0);
-    // Only shift if the editor is wider than the star rating
-    x -= std::max(xOffset, 0);
-
-    // Return invalid if the pointer left the star rectangle at either side.
-    // If the the cell is wider than the star rating, add a half star margin
-    // at the left to simplify setting 0.
-    double leftVoid = xOffset > starsWidth * 0.05 ? starsWidth * -0.05 : 0;
-    if (x < leftVoid || x >= starsWidth) {
-        return kInvalidStarCount;
-    } else if (x < starsWidth * 0.05) {
-        // If the pointer is very close to the left edge, set 0 stars.
-        return 0;
-    }
-
-    int star = (x / (starsWidth / m_starRating.maxStarCount())) + 1;
-
-    if (star <= 0 || star > m_starRating.maxStarCount()) {
-        return 0;
-    }
-    return star;
 }

--- a/src/library/stareditor.cpp
+++ b/src/library/stareditor.cpp
@@ -119,8 +119,17 @@ void StarEditor::mouseReleaseEvent(QMouseEvent* /* event */) {
 
 int StarEditor::starAtPosition(int x) {
     int starsWidth = m_starRating.sizeHint().width();
+    // The star rating is drawn centered in the table cell, so we need
+    // to shift the x input as well.
+    int xOffset = std::max((m_styleOption.rect.width() - starsWidth) / 2, 0);
+    // Only shift if the editor is wider than the star rating
+    x -= std::max(xOffset, 0);
+
     // Return invalid if the pointer left the star rectangle at either side.
-    if (x < 0 || x >= starsWidth) {
+    // If the the cell is wider than the star rating, add a half star margin
+    // at the left to simplify setting 0.
+    double leftVoid = xOffset > starsWidth * 0.05 ? starsWidth * -0.05 : 0;
+    if (x < leftVoid || x >= starsWidth) {
         return kInvalidStarCount;
     } else if (x < starsWidth * 0.05) {
         // If the pointer is very close to the left edge, set 0 stars.

--- a/src/library/stareditor.h
+++ b/src/library/stareditor.h
@@ -19,6 +19,12 @@ class StarEditor : public QWidget {
     QSize sizeHint() const override;
     void setStarRating(const StarRating& starRating) {
         m_starRating = starRating;
+        int stars = m_starRating.starCount();
+        VERIFY_OR_DEBUG_ASSERT(stars >= m_starRating.kMinStarCount &&
+                stars <= m_starRating.maxStarCount()) {
+            return;
+        }
+        m_starCount = stars;
     }
     StarRating starRating() { return m_starRating; }
 
@@ -33,14 +39,18 @@ class StarEditor : public QWidget {
     void paintEvent(QPaintEvent* event) override;
     void mouseMoveEvent(QMouseEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* event) override;
-    //if the mouse leaves the editing index set starCount to 0
     void leaveEvent(QEvent*) override;
 
   private:
     int starAtPosition(int x);
+    void resetRating() {
+        m_starRating.setStarCount(m_starCount);
+        update();
+    }
 
     QTableView* m_pTableView;
     QModelIndex m_index;
     QStyleOptionViewItem m_styleOption;
     StarRating m_starRating;
+    int m_starCount;
 };

--- a/src/library/stareditor.h
+++ b/src/library/stareditor.h
@@ -22,8 +22,7 @@ class StarEditor : public QWidget {
     void setStarRating(const StarRating& starRating) {
         m_starRating = starRating;
         int stars = m_starRating.starCount();
-        VERIFY_OR_DEBUG_ASSERT(stars >= m_starRating.kMinStarCount &&
-                stars <= m_starRating.maxStarCount()) {
+        VERIFY_OR_DEBUG_ASSERT(m_starRating.verifyStarCount(stars)) {
             return;
         }
         m_starCount = stars;

--- a/src/library/stareditor.h
+++ b/src/library/stareditor.h
@@ -37,9 +37,8 @@ class StarEditor : public QWidget {
 
   protected:
     void paintEvent(QPaintEvent* event) override;
-    void mouseMoveEvent(QMouseEvent* event) override;
-    void mouseReleaseEvent(QMouseEvent* event) override;
-    void leaveEvent(QEvent*) override;
+
+    bool eventFilter(QObject* obj, QEvent* event) override;
 
   private:
     void resetRating() {

--- a/src/library/stareditor.h
+++ b/src/library/stareditor.h
@@ -42,13 +42,12 @@ class StarEditor : public QWidget {
     void leaveEvent(QEvent*) override;
 
   private:
-    int starAtPosition(int x);
     void resetRating() {
         m_starRating.setStarCount(m_starCount);
         update();
     }
 
-    QTableView* m_pTableView;
+QTableView* m_pTableView;
     QModelIndex m_index;
     QStyleOptionViewItem m_styleOption;
     StarRating m_starRating;

--- a/src/library/stareditor.h
+++ b/src/library/stareditor.h
@@ -12,9 +12,11 @@ class QTableView;
 class StarEditor : public QWidget {
     Q_OBJECT
   public:
-    StarEditor(QWidget* parent, QTableView* pTableView,
-               const QModelIndex& index,
-               const QStyleOptionViewItem& option);
+    StarEditor(QWidget* parent,
+            QTableView* pTableView,
+            const QModelIndex& index,
+            const QStyleOptionViewItem& option,
+            const QColor& focusBorderColor);
 
     QSize sizeHint() const override;
     void setStarRating(const StarRating& starRating) {
@@ -42,9 +44,10 @@ class StarEditor : public QWidget {
         update();
     }
 
-QTableView* m_pTableView;
+    QTableView* m_pTableView;
     QModelIndex m_index;
     QStyleOptionViewItem m_styleOption;
+    QColor m_pFocusBorderColor;
     StarRating m_starRating;
     int m_starCount;
 };

--- a/src/library/stareditor.h
+++ b/src/library/stareditor.h
@@ -28,10 +28,6 @@ class StarEditor : public QWidget {
     }
     StarRating starRating() { return m_starRating; }
 
-    static void renderHelper(QPainter* painter, QTableView* pTableView,
-                             const QStyleOptionViewItem& option,
-                             StarRating* pStarRating);
-
   signals:
     void editingFinished();
 

--- a/src/library/starrating.cpp
+++ b/src/library/starrating.cpp
@@ -4,6 +4,7 @@
 #include <QRect>
 
 #include "util/math.h"
+#include "util/painterscope.h"
 
 // Magic number? Explain what this factor affects and how
 constexpr int PaintingScaleFactor = 15;
@@ -34,6 +35,7 @@ QSize StarRating::sizeHint() const {
 }
 
 void StarRating::paint(QPainter* painter, const QRect& rect) const {
+    PainterScope painterScope(painter);
     // Assume the painter is configured with the right brush.
     painter->setRenderHint(QPainter::Antialiasing, true);
     painter->setPen(Qt::NoPen);

--- a/src/library/starrating.cpp
+++ b/src/library/starrating.cpp
@@ -14,8 +14,7 @@ StarRating::StarRating(
         int maxStarCount)
         : m_starCount(starCount),
           m_maxStarCount(maxStarCount) {
-    DEBUG_ASSERT(m_starCount >= kMinStarCount);
-    DEBUG_ASSERT(m_starCount <= m_maxStarCount);
+    DEBUG_ASSERT(verifyStarCount(m_starCount));
     // 1st star cusp at 0° of the unit circle whose center is shifted to adapt the 0,0-based paint area
     m_starPolygon << QPointF(1.0, 0.5);
     for (int i = 1; i < 5; ++i) {

--- a/src/library/starrating.cpp
+++ b/src/library/starrating.cpp
@@ -38,8 +38,11 @@ void StarRating::paint(QPainter *painter, const QRect &rect) const {
     painter->setRenderHint(QPainter::Antialiasing, true);
     painter->setPen(Qt::NoPen);
 
+    // Center vertically inside the table cell, and also center horizontally
+    // if the cell is wider than the minimum stars width.
+    int xOffset = std::max((rect.width() - sizeHint().width()) / 2, 0);
     int yOffset = (rect.height() - PaintingScaleFactor) / 2;
-    painter->translate(rect.x(), rect.y() + yOffset);
+    painter->translate(rect.x() + xOffset, rect.y() + yOffset);
     painter->scale(PaintingScaleFactor, PaintingScaleFactor);
 
     //determine number of stars that are possible to paint

--- a/src/library/starrating.cpp
+++ b/src/library/starrating.cpp
@@ -33,7 +33,7 @@ QSize StarRating::sizeHint() const {
     return PaintingScaleFactor * QSize(m_maxStarCount, 1);
 }
 
-void StarRating::paint(QPainter *painter, const QRect &rect) const {
+void StarRating::paint(QPainter* painter, const QRect& rect) const {
     // Assume the painter is configured with the right brush.
     painter->setRenderHint(QPainter::Antialiasing, true);
     painter->setPen(Qt::NoPen);
@@ -45,7 +45,7 @@ void StarRating::paint(QPainter *painter, const QRect &rect) const {
     painter->translate(rect.x() + xOffset, rect.y() + yOffset);
     painter->scale(PaintingScaleFactor, PaintingScaleFactor);
 
-    //determine number of stars that are possible to paint
+    // Determine number of stars that are possible to paint
     int n = rect.width() / PaintingScaleFactor;
 
     for (int i = 0; i < m_maxStarCount && i < n; ++i) {
@@ -56,4 +56,31 @@ void StarRating::paint(QPainter *painter, const QRect &rect) const {
         }
         painter->translate(1.0, 0.0);
     }
+}
+
+int StarRating::starAtPosition(int x, const QRect& rect) const {
+    // The star rating is drawn centered in the parent (WStarrating or
+    // cell of StarDelegate, so we need to shift the x input as well.
+    int starsWidth = sizeHint().width();
+    int xOffset = std::max((rect.width() - starsWidth) / 2, 0);
+    // Only shift if the parent is wider than the star rating
+    x -= std::max(xOffset, 0);
+
+    // Return invalid if the pointer left the star rectangle at either side.
+    // If the the parent is wider than the star rating, add a half star margin
+    // at the left to simplify setting 0.
+    double leftVoid = xOffset > starsWidth * 0.05 ? starsWidth * -0.05 : 0;
+    if (x < leftVoid || x >= starsWidth) {
+        return StarRating::kInvalidStarCount;
+    } else if (x < starsWidth * 0.05) {
+        // If the pointer is very close to the left edge, set 0 stars.
+        return 0;
+    }
+
+    int star = (x / (starsWidth / maxStarCount())) + 1;
+
+    if (star <= 0 || star > maxStarCount()) {
+        return 0;
+    }
+    return star;
 }

--- a/src/library/starrating.h
+++ b/src/library/starrating.h
@@ -37,9 +37,14 @@ class StarRating {
     /// x is the x-position inside the parent rectangle rect
     int starAtPosition(int x, const QRect& rect) const;
 
+    bool verifyStarCount(int starCount) {
+        return starCount >= kMinStarCount && starCount <= m_maxStarCount;
+    }
+
     void setStarCount(int starCount) {
-        DEBUG_ASSERT(starCount >= kMinStarCount);
-        DEBUG_ASSERT(starCount <= m_maxStarCount);
+        VERIFY_OR_DEBUG_ASSERT(verifyStarCount(starCount)) {
+            return;
+        }
         m_starCount = starCount;
     }
 

--- a/src/library/starrating.h
+++ b/src/library/starrating.h
@@ -8,18 +8,17 @@
 QT_FORWARD_DECLARE_CLASS(QPainter);
 QT_FORWARD_DECLARE_CLASS(QRect);
 
-/*
- * The StarRating class represents a rating as a number of stars.
- * In addition to holding the data, it is also capable of painting the stars on a QPaintDevice,
- * which in this example is either a view or an editor.
- * The m_starCount member variable stores the current rating, and m_maxStarCount stores
- * the highest possible rating (typically 5).
- */
+/// The StarRating class represents a rating as a number of stars.
+/// In addition to holding the data, it is also capable of painting the stars
+/// on a QPaintDevice, which in this example is either a view or an editor.
+/// The m_starCount member variable stores the current rating, and
+/// m_maxStarCount stores the highest possible rating (typically 5).
 class StarRating {
   public:
     enum EditMode { Editable, ReadOnly };
 
     static constexpr int kMinStarCount = 0;
+    static constexpr int kInvalidStarCount = -1;
 
     explicit StarRating(
             int starCount = kMinStarCount,
@@ -34,6 +33,10 @@ class StarRating {
     int maxStarCount() const {
         return m_maxStarCount;
     }
+
+    /// x is the x-position inside the parent rectangle rect
+    int starAtPosition(int x, const QRect& rect) const;
+
     void setStarCount(int starCount) {
         DEBUG_ASSERT(starCount >= kMinStarCount);
         DEBUG_ASSERT(starCount <= m_maxStarCount);

--- a/src/library/tableitemdelegate.cpp
+++ b/src/library/tableitemdelegate.cpp
@@ -13,6 +13,10 @@ TableItemDelegate::TableItemDelegate(QTableView* pTableView)
     DEBUG_ASSERT(m_pTableView);
     auto* pTrackTableView = qobject_cast<WTrackTableView*>(m_pTableView);
     if (pTrackTableView) {
+        // This gets a color from the stylesheet:
+        // WTrackTableView {
+        //   qproperty-focusBorderColor: red;
+        // }
         m_pFocusBorderColor = pTrackTableView->getFocusBorderColor();
     }
 }
@@ -72,6 +76,26 @@ void TableItemDelegate::paintItemBackground(
     DEBUG_ASSERT(bgValue.canConvert<QBrush>());
     const auto bgBrush = qvariant_cast<QBrush>(bgValue);
     painter->fillRect(option.rect, bgBrush);
+}
+
+// static
+void TableItemDelegate::drawBorder(
+        QPainter* painter,
+        const QColor borderColor,
+        const QRect& rect) {
+    // Draws a border around the cell with official skin's default focus border width
+    QPen borderPen(
+            borderColor,
+            1,
+            Qt::SolidLine,
+            Qt::SquareCap);
+    painter->setPen(borderPen);
+    painter->setBrush(QBrush(Qt::transparent));
+    painter->drawRect(
+            rect.left(),
+            rect.top(),
+            rect.width() - 1,
+            rect.height() - 1);
 }
 
 void TableItemDelegate::paintItem(

--- a/src/library/tableitemdelegate.h
+++ b/src/library/tableitemdelegate.h
@@ -21,6 +21,11 @@ class TableItemDelegate : public QStyledItemDelegate {
             const QStyleOptionViewItem& option,
             const QModelIndex& index) const;
 
+    static void drawBorder(
+            QPainter* painter,
+            const QColor borderColor,
+            const QRect& rect);
+
   protected:
     static void paintItemBackground(
             QPainter* painter,

--- a/src/widget/wstarrating.cpp
+++ b/src/widget/wstarrating.cpp
@@ -37,18 +37,15 @@ void WStarRating::setup(const QDomNode& node, const SkinContext& context) {
 QSize WStarRating::sizeHint() const {
     QStyleOption option;
     option.initFrom(this);
-    QSize widgetSize = style()->sizeFromContents(QStyle::CT_PushButton,
-            &option,
-            m_visualStarRating.sizeHint(),
-            this);
 
+    // Center rating horizontally
     m_contentRect.setRect(
-            (widgetSize.width() - m_visualStarRating.sizeHint().width()) / 2,
-            (widgetSize.height() - m_visualStarRating.sizeHint().height()) / 2,
+            (size().width() - m_visualStarRating.sizeHint().width()) / 2,
+            (size().height() - m_visualStarRating.sizeHint().height()) / 2,
             m_visualStarRating.sizeHint().width(),
             m_visualStarRating.sizeHint().height());
 
-    return widgetSize;
+    return size();
 }
 
 void WStarRating::slotSetRating(int starCount) {
@@ -74,12 +71,15 @@ void WStarRating::paintEvent(QPaintEvent * /*unused*/) {
 
 void WStarRating::mouseMoveEvent(QMouseEvent *event) {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    int star = starAtPosition(event->position().toPoint().x());
+    const int pos = event->position().toPoint().x();
 #else
-    int star = starAtPosition(event->x());
+    const int pos = event->x();
 #endif
+    int star = m_visualStarRating.starAtPosition(pos, rect());
 
-    if (star != -1) {
+    if (star == StarRating::kInvalidStarCount) {
+        resetVisualRating();
+    } else {
         updateVisualRating(star);
     }
 }
@@ -106,24 +106,6 @@ void WStarRating::updateVisualRating(int starCount) {
     }
     m_visualStarRating.setStarCount(starCount);
     update();
-}
-
-// The method uses basic linear algebra to find out which star is under the cursor.
-int WStarRating::starAtPosition(int x) const {
-    // If the mouse is very close to the left edge, set 0 stars.
-    if (x < m_visualStarRating.sizeHint().width() * 0.05) {
-        return 0;
-    }
-    int star = (x /
-                       (m_visualStarRating.sizeHint().width() /
-                               m_visualStarRating.maxStarCount())) +
-            1;
-
-    if (star <= 0 || star > m_visualStarRating.maxStarCount()) {
-        return 0;
-    }
-
-    return star;
 }
 
 void WStarRating::mouseReleaseEvent(QMouseEvent* /*unused*/) {

--- a/src/widget/wstarrating.cpp
+++ b/src/widget/wstarrating.cpp
@@ -49,8 +49,7 @@ QSize WStarRating::sizeHint() const {
 }
 
 void WStarRating::slotSetRating(int starCount) {
-    if (starCount == m_starCount) {
-        // Unchanged
+    if (starCount == m_starCount || !m_visualStarRating.verifyStarCount(starCount)) {
         return;
     }
     m_starCount = starCount;

--- a/src/widget/wstarrating.h
+++ b/src/widget/wstarrating.h
@@ -40,7 +40,6 @@ class WStarRating : public WWidget {
     StarRating m_visualStarRating;
     mutable QRect m_contentRect;
 
-    int starAtPosition(int x) const;
     void updateVisualRating(int starCount);
     void resetVisualRating() {
         updateVisualRating(m_starCount);


### PR DESCRIPTION
* Reset last confirmed value
  * on leave event and when the track menu is opened
  (even though it works for other editors, the latter requires a hack if the editor is also selected)
  * when pointer position leaves the rating area
  (if parent is wider than the rating, e.g. stretched library column)
* draw focus border on first click

**Bonus:**
* center rating horizontally
(if parent is wider, else still left-aligned and can be truncated)

Fixes apply to both WStarRating (decks, Track Info) and the library's StarDelegate/StarEditor.
I moved redundant code to StarRating, and some more small improvements along the way.

[star-rating-fix.webm](https://github.com/mixxxdj/mixxx/assets/5934199/cfe751dc-7c51-428e-80b1-6a2359f56886)



Fixes #12576 #7304