### PR TITLE
Improve `rate_up/down` tooltips, pitch vs. speed

### DIFF
--- a/src/skin/legacy/tooltips.cpp
+++ b/src/skin/legacy/tooltips.cpp
@@ -325,27 +325,27 @@ void Tooltips::addStandardTooltips() {
 
     QString changeAmount = tr("Change the step-size in the Preferences -> Decks menu.");
     add("rate_perm_up_rate_perm_up_small")
-            << tr("Raise Pitch")
-            << QString("%1: %2").arg(leftClick, tr("Sets the pitch higher."))
-            << QString("%1: %2").arg(rightClick, tr("Sets the pitch higher in small steps."))
+            << tr("Speed Up")
+            << QString("%1: %2").arg(leftClick, tr("Raises the track playback speed (affects both the tempo and the pitch). If keylock is enabled, only the tempo is affected."))
+            << QString("%1: %2").arg(rightClick, tr("Raises playback speed in small steps."))
             << changeAmount;
 
     add("rate_perm_down_rate_perm_down_small")
-            << tr("Lower Pitch")
-            << QString("%1: %2").arg(leftClick, tr("Sets the pitch lower."))
-            << QString("%1: %2").arg(rightClick, tr("Sets the pitch lower in small steps."))
+            << tr("Slow Down")
+            << QString("%1: %2").arg(leftClick, tr("Lowers the track playback speed (affects both the tempo and the pitch). If keylock is enabled, only the tempo is affected."))
+            << QString("%1: %2").arg(rightClick, tr("Lowers playback speed in small steps."))
             << changeAmount;
 
     add("rate_temp_up_rate_temp_up_small")
-            << tr("Raise Pitch Temporary (Nudge)")
-            << QString("%1: %2").arg(leftClick, tr("Holds the pitch higher while active."))
-            << QString("%1: %2").arg(rightClick, tr("Holds the pitch higher (small amount) while active."))
+            << tr("Speed Up Temporarily (Nudge)")
+            << QString("%1: %2").arg(leftClick, tr("Holds playback speed higher while active (affects both the tempo and the pitch). If keylock is enabled, only the tempo is affected."))
+            << QString("%1: %2").arg(rightClick, tr("Holds playback speed higher (small amount) while active."))
             << changeAmount;
 
     add("rate_temp_down_rate_temp_down_small")
-            << tr("Lower Pitch Temporary (Nudge)")
-            << QString("%1: %2").arg(leftClick, tr("Holds the pitch lower while active."))
-            << QString("%1: %2").arg(rightClick, tr("Holds the pitch lower (small amount) while active."))
+            << tr("Slow Down Temporarily (Nudge)")
+            << QString("%1: %2").arg(leftClick, tr("Holds playback speed lower while active (affects both the tempo and the pitch). If keylock is enabled, only the tempo is affected."))
+            << QString("%1: %2").arg(rightClick, tr("Holds playback speed lower (small amount) while active."))
             << changeAmount;
 
     add("filterLow")

--- a/src/skin/legacy/tooltips.cpp
+++ b/src/skin/legacy/tooltips.cpp
@@ -326,26 +326,40 @@ void Tooltips::addStandardTooltips() {
     QString changeAmount = tr("Change the step-size in the Preferences -> Decks menu.");
     add("rate_perm_up_rate_perm_up_small")
             << tr("Speed Up")
-            << QString("%1: %2").arg(leftClick, tr("Raises the track playback speed (tempo). If keylock is disabled, pitch is also affected."))
-            << QString("%1: %2").arg(rightClick, tr("Raises playback speed in small steps."))
+            << QString("%1: %2").arg(leftClick,
+                       tr("Raises the track playback speed (tempo). If keylock "
+                          "is disabled, pitch is also affected."))
+            << QString("%1: %2").arg(
+                       rightClick, tr("Raises playback speed in small steps."))
             << changeAmount;
 
     add("rate_perm_down_rate_perm_down_small")
             << tr("Slow Down")
-            << QString("%1: %2").arg(leftClick, tr("Lowers the track playback speed (tempo). If keylock is disabled, pitch is also affected."))
-            << QString("%1: %2").arg(rightClick, tr("Lowers playback speed in small steps."))
+            << QString("%1: %2").arg(leftClick,
+                       tr("Lowers the track playback speed (tempo). If keylock "
+                          "is disabled, pitch is also affected."))
+            << QString("%1: %2").arg(
+                       rightClick, tr("Lowers playback speed in small steps."))
             << changeAmount;
 
     add("rate_temp_up_rate_temp_up_small")
             << tr("Speed Up Temporarily (Nudge)")
-            << QString("%1: %2").arg(leftClick, tr("Holds playback speed higher while active (tempo). If keylock is disabled, pitch is also affected."))
-            << QString("%1: %2").arg(rightClick, tr("Holds playback speed higher (small amount) while active."))
+            << QString("%1: %2").arg(leftClick,
+                       tr("Holds playback speed higher while active (tempo). "
+                          "If keylock is disabled, pitch is also affected."))
+            << QString("%1: %2").arg(rightClick,
+                       tr("Holds playback speed higher (small amount) while "
+                          "active."))
             << changeAmount;
 
     add("rate_temp_down_rate_temp_down_small")
             << tr("Slow Down Temporarily (Nudge)")
-            << QString("%1: %2").arg(leftClick, tr("Holds playback speed lower while active (tempo). If keylock is disabled, pitch is also affected."))
-            << QString("%1: %2").arg(rightClick, tr("Holds playback speed lower (small amount) while active."))
+            << QString("%1: %2").arg(leftClick,
+                       tr("Holds playback speed lower while active (tempo). "
+                          "If keylock is disabled, pitch is also affected."))
+            << QString("%1: %2").arg(rightClick,
+                       tr("Holds playback speed lower (small amount) while "
+                          "active."))
             << changeAmount;
 
     add("filterLow")

--- a/src/skin/legacy/tooltips.cpp
+++ b/src/skin/legacy/tooltips.cpp
@@ -324,11 +324,13 @@ void Tooltips::addStandardTooltips() {
             << tr("Manual: Sets how much to reduce the music volume, when talkover is activated regardless of volume of microphone inputs.");
 
     QString changeAmount = tr("Change the step-size in the Preferences -> Decks menu.");
+    QString pitchAffected = tr("If keylock is disabled, pitch is also affected.");
+
     add("rate_perm_up_rate_perm_up_small")
             << tr("Speed Up")
             << QString("%1: %2").arg(leftClick,
-                       tr("Raises the track playback speed (tempo). If keylock "
-                          "is disabled, pitch is also affected."))
+                       tr("Raises the track playback speed (tempo)."))
+            << pitchAffected
             << QString("%1: %2").arg(
                        rightClick, tr("Raises playback speed in small steps."))
             << changeAmount;
@@ -336,8 +338,8 @@ void Tooltips::addStandardTooltips() {
     add("rate_perm_down_rate_perm_down_small")
             << tr("Slow Down")
             << QString("%1: %2").arg(leftClick,
-                       tr("Lowers the track playback speed (tempo). If keylock "
-                          "is disabled, pitch is also affected."))
+                       tr("Lowers the track playback speed (tempo)."))
+            << pitchAffected
             << QString("%1: %2").arg(
                        rightClick, tr("Lowers playback speed in small steps."))
             << changeAmount;
@@ -345,8 +347,8 @@ void Tooltips::addStandardTooltips() {
     add("rate_temp_up_rate_temp_up_small")
             << tr("Speed Up Temporarily (Nudge)")
             << QString("%1: %2").arg(leftClick,
-                       tr("Holds playback speed higher while active (tempo). "
-                          "If keylock is disabled, pitch is also affected."))
+                       tr("Holds playback speed higher while active (tempo)."))
+            << pitchAffected
             << QString("%1: %2").arg(rightClick,
                        tr("Holds playback speed higher (small amount) while "
                           "active."))
@@ -355,8 +357,8 @@ void Tooltips::addStandardTooltips() {
     add("rate_temp_down_rate_temp_down_small")
             << tr("Slow Down Temporarily (Nudge)")
             << QString("%1: %2").arg(leftClick,
-                       tr("Holds playback speed lower while active (tempo). "
-                          "If keylock is disabled, pitch is also affected."))
+                       tr("Holds playback speed lower while active (tempo)."))
+            << pitchAffected
             << QString("%1: %2").arg(rightClick,
                        tr("Holds playback speed lower (small amount) while "
                           "active."))

--- a/src/skin/legacy/tooltips.cpp
+++ b/src/skin/legacy/tooltips.cpp
@@ -326,25 +326,25 @@ void Tooltips::addStandardTooltips() {
     QString changeAmount = tr("Change the step-size in the Preferences -> Decks menu.");
     add("rate_perm_up_rate_perm_up_small")
             << tr("Speed Up")
-            << QString("%1: %2").arg(leftClick, tr("Raises the track playback speed (affects both the tempo and the pitch). If keylock is enabled, only the tempo is affected."))
+            << QString("%1: %2").arg(leftClick, tr("Raises the track playback speed (tempo). If keylock is disabled, pitch is also affected."))
             << QString("%1: %2").arg(rightClick, tr("Raises playback speed in small steps."))
             << changeAmount;
 
     add("rate_perm_down_rate_perm_down_small")
             << tr("Slow Down")
-            << QString("%1: %2").arg(leftClick, tr("Lowers the track playback speed (affects both the tempo and the pitch). If keylock is enabled, only the tempo is affected."))
+            << QString("%1: %2").arg(leftClick, tr("Lowers the track playback speed (tempo). If keylock is disabled, pitch is also affected."))
             << QString("%1: %2").arg(rightClick, tr("Lowers playback speed in small steps."))
             << changeAmount;
 
     add("rate_temp_up_rate_temp_up_small")
             << tr("Speed Up Temporarily (Nudge)")
-            << QString("%1: %2").arg(leftClick, tr("Holds playback speed higher while active (affects both the tempo and the pitch). If keylock is enabled, only the tempo is affected."))
+            << QString("%1: %2").arg(leftClick, tr("Holds playback speed higher while active (tempo). If keylock is disabled, pitch is also affected."))
             << QString("%1: %2").arg(rightClick, tr("Holds playback speed higher (small amount) while active."))
             << changeAmount;
 
     add("rate_temp_down_rate_temp_down_small")
             << tr("Slow Down Temporarily (Nudge)")
-            << QString("%1: %2").arg(leftClick, tr("Holds playback speed lower while active (affects both the tempo and the pitch). If keylock is enabled, only the tempo is affected."))
+            << QString("%1: %2").arg(leftClick, tr("Holds playback speed lower while active (tempo). If keylock is disabled, pitch is also affected."))
             << QString("%1: %2").arg(rightClick, tr("Holds playback speed lower (small amount) while active."))
             << changeAmount;
 


### PR DESCRIPTION
The tooltip help regarding the playback rate change buttons stated that those raise/lower pitch.

If keylock is disabled, this is true, though incomplete, since the buttons also affect playback speed.
If keylock is enabled, this is false, since pitch is left unchanged, and only playback speed changes.

This change replaces the tooltip text about pitch change with text about playback speed. It also copies the clarification:
"(affects both the tempo and the pitch). If keylock is enabled, only the tempo is affected."
over from the Speed Control fader tooltip, to prevent further confusion.