### PR TITLE
move COs from DeckVisuals/VisualsManager to BaseTrackPlayerImpl

### DIFF
--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -205,9 +205,15 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(
             this,
             &BaseTrackPlayerImpl::slotShiftCuesMillis);
 
-    // BPM of the current song
+    // BPM and key of the current song
     m_pFileBPM = std::make_unique<ControlObject>(ConfigKey(getGroup(), "file_bpm"));
+    m_pVisualBpm = std::make_unique<ControlObject>(ConfigKey(getGroup(), "visual_bpm"));
     m_pKey = make_parented<ControlProxy>(getGroup(), "file_key", this);
+    m_pVisualKey = std::make_unique<ControlObject>(ConfigKey(getGroup(), "visual_key"));
+
+    m_pTimeElapsed = std::make_unique<ControlObject>(ConfigKey(getGroup(), "time_elapsed"));
+    m_pTimeRemaining = std::make_unique<ControlObject>(ConfigKey(getGroup(), "time_remaining"));
+    m_pEndOfTrack = std::make_unique<ControlObject>(ConfigKey(getGroup(), "end_of_track"));
 
     m_pReplayGain = make_parented<ControlProxy>(getGroup(), "replaygain", this);
     m_pPlay = make_parented<ControlProxy>(getGroup(), "play", this);

--- a/src/mixer/basetrackplayer.h
+++ b/src/mixer/basetrackplayer.h
@@ -156,7 +156,13 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
     // TODO() these COs are reconnected during runtime
     // This may lock the engine
     std::unique_ptr<ControlObject> m_pFileBPM;
+    std::unique_ptr<ControlObject> m_pVisualBpm;
     parented_ptr<ControlProxy> m_pKey;
+    std::unique_ptr<ControlObject> m_pVisualKey;
+
+    std::unique_ptr<ControlObject> m_pTimeElapsed;
+    std::unique_ptr<ControlObject> m_pTimeRemaining;
+    std::unique_ptr<ControlObject> m_pEndOfTrack;
 
     std::unique_ptr<ControlPushButton> m_pShiftCuesEarlier;
     std::unique_ptr<ControlPushButton> m_pShiftCuesEarlierSmall;

--- a/src/waveform/visualsmanager.cpp
+++ b/src/waveform/visualsmanager.cpp
@@ -7,16 +7,15 @@ DeckVisuals::DeckVisuals(const QString& group)
         : m_group(group),
           m_SlowTickCnt(0),
           m_trackLoaded(false),
-          playButton(ConfigKey(group, "play")),
-          loopEnabled(ConfigKey(group, "loop_enabled")),
-          engineBpm(ConfigKey(group, "bpm")),
-          engineKey(ConfigKey(group, "key")) {
-    m_pTimeElapsed = std::make_unique<ControlObject>(ConfigKey(m_group, "time_elapsed"));
-    m_pTimeRemaining = std::make_unique<ControlObject>(ConfigKey(m_group, "time_remaining"));
-    m_pEndOfTrack = std::make_unique<ControlObject>(ConfigKey(m_group, "end_of_track"));
-    m_pVisualBpm = std::make_unique<ControlObject>(ConfigKey(m_group, "visual_bpm"));
-    m_pVisualKey = std::make_unique<ControlObject>(ConfigKey(m_group, "visual_key"));
-
+          m_pPlayButton(std::make_unique<ControlProxy>(ConfigKey(group, "play"))),
+          m_pLoopEnabled(std::make_unique<ControlProxy>(ConfigKey(group, "loop_enabled"))),
+          m_pEngineBpm(std::make_unique<ControlProxy>(ConfigKey(group, "bpm"))),
+          m_pVisualBpm(std::make_unique<ControlProxy>(ConfigKey(m_group, "visual_bpm"))),
+          m_pEngineKey(std::make_unique<ControlProxy>(ConfigKey(group, "key"))),
+          m_pVisualKey(std::make_unique<ControlProxy>(ConfigKey(m_group, "visual_key"))),
+          m_pTimeElapsed(std::make_unique<ControlProxy>(ConfigKey(m_group, "time_elapsed"))),
+          m_pTimeRemaining(std::make_unique<ControlProxy>(ConfigKey(m_group, "time_remaining"))),
+          m_pEndOfTrack(std::make_unique<ControlProxy>(ConfigKey(m_group, "end_of_track"))) {
     // Control used to communicate ratio playpos to GUI thread
     m_pVisualPlayPos = VisualPlayPosition::getVisualPlayPosition(m_group);
 }
@@ -36,11 +35,10 @@ void DeckVisuals::process(double remainingTimeTriggerSeconds) {
     m_pTimeRemaining->set(timeRemaining);
     m_pTimeElapsed->set(tempoTrackSeconds - timeRemaining);
 
-    if (!playButton.toBool() || // not playing
-            loopEnabled.toBool() || // in loop
+    if (!m_pPlayButton->toBool() ||                             // not playing
+            m_pLoopEnabled->toBool() ||                         // in loop
             tempoTrackSeconds <= remainingTimeTriggerSeconds || // track too short
-            timeRemaining > remainingTimeTriggerSeconds // before the trigger
-            ) {
+            timeRemaining > remainingTimeTriggerSeconds) {      // before the trigger
         m_pEndOfTrack->set(0.0);
     } else {
         m_pEndOfTrack->set(1.0);
@@ -49,9 +47,9 @@ void DeckVisuals::process(double remainingTimeTriggerSeconds) {
     // Update the BPM even more slowly
     m_SlowTickCnt = (m_SlowTickCnt + 1) % kSlowUpdateDivider;
     if (m_SlowTickCnt == 0 || !trackLoaded) {
-        m_pVisualBpm->set(engineBpm.get());
+        m_pVisualBpm->set(m_pEngineBpm->get());
     }
-    m_pVisualKey->set(engineKey.get());
+    m_pVisualKey->set(m_pEngineKey->get());
 
     m_trackLoaded = trackLoaded;
 }

--- a/src/waveform/visualsmanager.h
+++ b/src/waveform/visualsmanager.h
@@ -35,16 +35,18 @@ class DeckVisuals {
     int m_SlowTickCnt;
     bool m_trackLoaded;
 
-    std::unique_ptr<ControlObject> m_pTimeElapsed;
-    std::unique_ptr<ControlObject> m_pTimeRemaining;
-    std::unique_ptr<ControlObject> m_pEndOfTrack;
-    std::unique_ptr<ControlObject> m_pVisualBpm;
-    std::unique_ptr<ControlObject> m_pVisualKey;
+    std::unique_ptr<ControlProxy> m_pPlayButton;
+    std::unique_ptr<ControlProxy> m_pLoopEnabled;
 
-    ControlProxy playButton;
-    ControlProxy loopEnabled;
-    ControlProxy engineBpm;
-    ControlProxy engineKey;
+    std::unique_ptr<ControlProxy> m_pEngineBpm;
+    std::unique_ptr<ControlProxy> m_pVisualBpm;
+
+    std::unique_ptr<ControlProxy> m_pEngineKey;
+    std::unique_ptr<ControlProxy> m_pVisualKey;
+
+    std::unique_ptr<ControlProxy> m_pTimeElapsed;
+    std::unique_ptr<ControlProxy> m_pTimeRemaining;
+    std::unique_ptr<ControlProxy> m_pEndOfTrack;
 
     QSharedPointer<VisualPlayPosition> m_pVisualPlayPos;
 };


### PR DESCRIPTION
This is an attempt to fix a warning I encountered a few times, which was something like
```
[warning] Control 'end_of_track' does not exist
```
Probably triggered when WOverview tried to create the `end_of_track` ControlProxy with ControlFlag::NoAssertIfMissing flag, while the ControlObject has not been created, yet.
IIRC I noticed this only with my personal branch with #3534 merged (which I like very much btw).

### The root cause (probably)
* `LegacySkinParser::parseSkin` sets `[App],num_decks` from 2 (default) to 4 after reading the skin attributes
* change request for `[App],num_decks` by `LegacySkinParser::parseSkin` signals `PlayerManager` to create a new `BasetrackPlayer`
* after the player has been created, [`PlayerManager` signals `VisualsManager`](https://github.com/mixxxdj/mixxx/blob/dc22fd5f963a7efc54cb2cd64c7251c180368295/src/mixxxmainwindow.cpp#L206-L229) to create new `DeckVisual` 
* so, could this be caused by `PlayerManager` living in a different thread than `VisualsManager` (with [#3534](https://github.com/mixxxdj/mixxx/pull/3534)), and the connection being implicitely a `Qt::AutoConnection` ([Qt::QueuedConnection](https://doc.qt.io/qt-6/qt.html#ConnectionType-enum) in this case), and `WOverview` trying to create the proxy _before_ `end_of_track` has been created by DeckVisual?

### Fix
* first, create `end_of_track` and other controls in BaseTrackPlayer
* then the proxies in WOverview and DeckVisual
* use `Qt::DirectConnection` for `PlayerManager::numberOfDecksChanged` -> `VisualsManager` (is this helpful??)

