### PR TITLE
Library delegates: reduce includes, remove unneeded functions and debug asserts

### DIFF
--- a/src/library/bpmdelegate.cpp
+++ b/src/library/bpmdelegate.cpp
@@ -35,7 +35,6 @@ class BpmEditorCreator : public QItemEditorCreatorBase {
 
 BPMDelegate::BPMDelegate(QTableView* pTableView)
         : TableItemDelegate(pTableView),
-          m_pTableView(pTableView),
           m_pCheckBox(new QCheckBox(m_pTableView)) {
     m_pCheckBox->setObjectName("LibraryBPMButton");
     // NOTE(rryan): Without ensurePolished the first render of the QTableView
@@ -82,11 +81,8 @@ void BPMDelegate::paintItem(QPainter* painter,const QStyleOptionViewItem &option
     QStyleOptionViewItem opt = option;
     initStyleOption(&opt, index);
 
-    if (m_pTableView != nullptr) {
-        QStyle* style = m_pTableView->style();
-        if (style != nullptr) {
-            style->drawControl(QStyle::CE_ItemViewItem, &opt, painter,
-                               m_pCheckBox);
-        }
+    QStyle* style = m_pTableView->style();
+    if (style != nullptr) {
+        style->drawControl(QStyle::CE_ItemViewItem, &opt, painter, m_pCheckBox);
     }
 }

--- a/src/library/bpmdelegate.h
+++ b/src/library/bpmdelegate.h
@@ -15,7 +15,6 @@ class BPMDelegate : public TableItemDelegate {
             const QModelIndex& index) const override;
 
   private:
-    QTableView* m_pTableView;
     QCheckBox* m_pCheckBox;
     QItemEditorFactory* m_pFactory;
 };

--- a/src/library/previewbuttondelegate.h
+++ b/src/library/previewbuttondelegate.h
@@ -1,8 +1,6 @@
 #pragma once
 
 #include <QPushButton>
-#include <QStyleOptionButton>
-#include <QTableView>
 
 #include "library/tableitemdelegate.h"
 #include "track/track_decl.h"
@@ -16,22 +14,9 @@ class WLibraryTableView;
 class LibraryPreviewButton : public QPushButton {
     Q_OBJECT
   public:
-    explicit LibraryPreviewButton(QWidget* parent)
-            : QPushButton(parent) {
-        setObjectName("LibraryPreviewButton");
-    }
+    explicit LibraryPreviewButton(QWidget* parent);
 
-    void paint(QPainter* painter) {
-        // This matches the implementation of QPushButton::paintEvent, except it
-        // does not create a new QStylePainter, and it is simpler and more
-        // direct than QWidget::render(QPainter*, ...).
-        QStyleOptionButton option;
-        initStyleOption(&option);
-        auto pStyle = style();
-        if (pStyle) {
-            pStyle->drawControl(QStyle::CE_PushButton, &option, painter, this);
-        }
-    }
+    void paint(QPainter* painter);
 };
 
 class PreviewButtonDelegate : public TableItemDelegate {
@@ -74,9 +59,6 @@ class PreviewButtonDelegate : public TableItemDelegate {
     void previewDeckPlayChanged(double v);
 
   private:
-    QTableView* parentTableView() const {
-        return qobject_cast<QTableView*>(parent());
-    }
     bool isPreviewDeckPlaying() const;
     bool isTrackLoadedInPreviewDeck(
             const QModelIndex& index) const;

--- a/src/library/stardelegate.cpp
+++ b/src/library/stardelegate.cpp
@@ -9,7 +9,6 @@
 
 StarDelegate::StarDelegate(QTableView* pTableView)
         : TableItemDelegate(pTableView),
-          m_pTableView(pTableView),
           m_isOneCellInEditMode(false) {
     connect(pTableView, &QTableView::entered, this, &StarDelegate::cellEntered);
 }

--- a/src/library/stardelegate.h
+++ b/src/library/stardelegate.h
@@ -34,7 +34,6 @@ class StarDelegate : public TableItemDelegate {
     void cellEntered(const QModelIndex& index);
 
   private:
-    QTableView* m_pTableView;
     QPersistentModelIndex m_currentEditedCellIndex;
     bool m_isOneCellInEditMode;
 };

--- a/src/library/tableitemdelegate.cpp
+++ b/src/library/tableitemdelegate.cpp
@@ -1,7 +1,6 @@
 #include "library/tableitemdelegate.h"
 
 #include <QPainter>
-#include <QTableView>
 
 #include "moc_tableitemdelegate.cpp"
 #include "util/painterscope.h"

--- a/src/library/tableitemdelegate.h
+++ b/src/library/tableitemdelegate.h
@@ -27,6 +27,8 @@ class TableItemDelegate : public QStyledItemDelegate {
             const QStyleOptionViewItem& option,
             const QModelIndex& index);
 
+    // Only used by LocationDelegate's text elide.
+    // Having this here avoids including QTableView there.
     int columnWidth(const QModelIndex &index) const;
 
     QColor m_pFocusBorderColor;

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -338,7 +338,7 @@ void WTrackTableView::initTrackMenu() {
     connect(m_pTrackMenu.get(),
             &WTrackMenu::loadTrackToPlayer,
             this,
-            &WTrackTableView::loadTrackToPlayer);
+            &WLibraryTableView::loadTrackToPlayer);
 
     connect(m_pTrackMenu,
             &WTrackMenu::trackMenuVisible,


### PR DESCRIPTION
Just a few bycatches from #12582