### PR TITLE
scale library star rating with the library font

### DIFF
--- a/src/library/stardelegate.cpp
+++ b/src/library/stardelegate.cpp
@@ -27,6 +27,8 @@ void StarDelegate::paintItem(
     paintItemBackground(painter, option, index);
 
     StarRating starRating = index.data().value<StarRating>();
+    // Scale star size with the library's current font height.
+    starRating.setStarBreadth(StarEditor::starBreadthFromFont(option));
     starRating.paint(painter, option.rect);
 }
 
@@ -34,6 +36,7 @@ QSize StarDelegate::sizeHint(const QStyleOptionViewItem& option,
                              const QModelIndex& index) const {
     Q_UNUSED(option);
     StarRating starRating = index.data().value<StarRating>();
+    starRating.setStarBreadth(static_cast<int>(option.fontMetrics.height() / 2));
     return starRating.sizeHint();
 }
 

--- a/src/library/stareditor.cpp
+++ b/src/library/stareditor.cpp
@@ -9,11 +9,6 @@
 #include "library/tableitemdelegate.h"
 #include "moc_stareditor.cpp"
 
-// We enable mouse tracking on the widget so we can follow the cursor even
-// when the user doesn't hold down any mouse button. We also turn on
-// QWidget's auto-fill background feature to obtain an opaque background.
-// (Without the call, the view's background would shine through the editor.)
-
 /// StarEditor inherits QWidget and is used by StarDelegate to let the user
 /// edit a star rating in the library using the mouse.
 ///
@@ -31,6 +26,8 @@ StarEditor::StarEditor(QWidget* parent,
           m_pFocusBorderColor(focusBorderColor),
           m_starCount(StarRating::kMinStarCount) {
     DEBUG_ASSERT(m_pTableView);
+    // We enable mouse tracking on the widget so we can follow the cursor even
+    // when the user doesn't hold down any mouse button.
     setMouseTracking(true);
     installEventFilter(this);
 }

--- a/src/library/stareditor.h
+++ b/src/library/stareditor.h
@@ -19,14 +19,26 @@ class StarEditor : public QWidget {
             const QColor& focusBorderColor);
 
     QSize sizeHint() const override;
+
+    // Calculate the width/height of a single star rectangle from the
+    // used library font..
+    // Half the font height is roughly equal to the default size (15px) with
+    // Open Sans regular 11pt.
+    static int starBreadthFromFont(const QStyleOption& option) {
+        auto mf = option.fontMetrics;
+        return static_cast<int>((mf.capHeight() + mf.ascent()) / 2);
+    }
+
     void setStarRating(const StarRating& starRating) {
         m_starRating = starRating;
+        m_starRating.setStarBreadth(starBreadthFromFont(m_styleOption));
         int stars = m_starRating.starCount();
         VERIFY_OR_DEBUG_ASSERT(m_starRating.verifyStarCount(stars)) {
             return;
         }
         m_starCount = stars;
     }
+
     StarRating starRating() { return m_starRating; }
 
   signals:

--- a/src/library/starrating.h
+++ b/src/library/starrating.h
@@ -24,8 +24,15 @@ class StarRating {
             int starCount = kMinStarCount,
             int maxStarCount = mixxx::TrackRecord::kMaxRating - mixxx::TrackRecord::kMinRating);
 
-    void paint(QPainter* painter, const QRect& rect) const;
+    void paint(QPainter* painter, const QRect& rect);
+
+    /// This is the preferred size, used for example for auto-adjusting
+    /// StarDelegate's column width.
     QSize sizeHint() const;
+
+    void setStarBreadth(int breadth) {
+        m_starBreadth = breadth;
+    }
 
     int starCount() const {
         return m_starCount;
@@ -53,6 +60,7 @@ class StarRating {
     QPolygonF m_diamondPolygon;
     int m_starCount;
     int m_maxStarCount;
+    int m_starBreadth;
 };
 
 Q_DECLARE_METATYPE(StarRating)

--- a/src/widget/wstarrating.cpp
+++ b/src/widget/wstarrating.cpp
@@ -32,6 +32,10 @@ void WStarRating::setup(const QDomNode& node, const SkinContext& context) {
     Q_UNUSED(context);
     setMouseTracking(true);
     setFocusPolicy(Qt::NoFocus);
+    // NOTE Here we may read <StarBreadth> from the widget,
+    // then m_visualStarRating.setStarBreadth().
+    // Must be <= size().height().
+    // For now: YAGNI
 }
 
 QSize WStarRating::sizeHint() const {


### PR DESCRIPTION
Supersedes #11772. Rebased, simplified, I think I addressed all of @daschuer's review comments.

Works nicely!
For me stars are slightly larger now (16px instead of 15px) with my default font Open Sans Regular 11pt.

__
~~The thing is: most users will see a different size than before since star size now depends on the library font.
This may be the system's default font or the user-set font (Library preferences).
One idea to lint this would be:~~
* ~~get the font/stars ratio the user has seen before (get height() of default app font)~~
* ~~multiply that with the current font's capital height or some other font metric~~

Too much magic.
**edit** maybe not. has to be done only once

I'd say stars size should be something in between **ooooo** and **OOOOO** (compared to the library text) to be visible and accessible.
What do you think? Does the current state fullfill this requirement?