### PR TITLE
fix(waveforms): add missing precision specifier to repetions uniform of patternshader

### DIFF
--- a/src/shaders/patternshader.cpp
+++ b/src/shaders/patternshader.cpp
@@ -17,7 +17,7 @@ void main()
 
     QString fragmentShaderCode = QStringLiteral(R"--(
 uniform sampler2D texture;
-uniform vec2 repetitions;
+uniform highp vec2 repetitions;
 varying highp vec2 vTexcoor;
 void main()
 {


### PR DESCRIPTION
fixes #12600 

don't have a windows env so I can't confirm the original bug nor confirm this fixes it, but I'm fairly certain it should. please test @JoergAtGithub ty.