### PR TITLE
pll initial delta

### DIFF
--- a/src/waveform/vsyncthread.cpp
+++ b/src/waveform/vsyncthread.cpp
@@ -16,8 +16,10 @@ VSyncThread::VSyncThread(QObject* pParent)
           m_swapWait(0),
           m_displayFrameRate(60.0),
           m_vSyncPerRendering(1),
+          m_pllInitCnt(0),
+          m_pllInitSum(0.0),
           m_pllPhaseOut(0.0),
-          m_pllDeltaOut(16666.6), // 60 FPS initial delta
+          m_pllDeltaOut(16666.6),
           m_pllLogging(0.0) {
     m_pllTimer.start();
 }
@@ -73,14 +75,17 @@ void VSyncThread::runFree() {
 
 void VSyncThread::runPLL() {
     assert(m_vSyncMode == ST_PLL);
+    qint64 offsetAdjustedAt = 0;
     qint64 offset = 0;
     qint64 nextSwapMicros = 0;
+    qint64 multiplierAdjustedPllPhaseOut = 0;
     while (m_bDoRendering) {
         // Use a phase-locked-loop on the QOpenGLWindow::frameSwapped signal
         // to determine when the vsync occurs
 
         qint64 pllPhaseOut;
         qint64 pllDeltaOut;
+        qint64 multiplierAdjustedPllDeltaOut;
         qint64 now;
 
         {
@@ -90,37 +95,73 @@ void VSyncThread::runPLL() {
             // estimated frame interval
             pllDeltaOut = std::llround(m_pllDeltaOut);
             now = m_pllTimer.elapsed().toIntegerMicros();
-        }
-        if (pllPhaseOut > nextSwapMicros) {
-            nextSwapMicros = pllPhaseOut;
-        }
-        if (nextSwapMicros == pllPhaseOut) {
-            nextSwapMicros += pllDeltaOut;
+
+            // Calculate the nearest integer number of PLL intervals that
+            // correspond with the interval based on the frame rate from the
+            // user settings. E.g. if the PLL is running at 60 fps, and the user
+            // settings is between 25 and 40 fps, we do run effectively at 30
+            // fps (multiplier is 2)
+            //
+            // Note this also is applied when running at 120 fps (ProMotion)
+            const auto multiplier = std::max<qint64>(1,
+                    (m_syncIntervalTimeMicros + pllDeltaOut / 2) / pllDeltaOut);
+
+            // Update the multiplierAdjustedPllPhaseOut to pllPhaseOut, if pllPhaseOut has increased
+            // multiplier * pllDeltaOut intervals.
+            if (multiplierAdjustedPllPhaseOut == 0 ||
+                    ((pllPhaseOut - multiplierAdjustedPllPhaseOut +
+                             pllDeltaOut / 2) /
+                            pllDeltaOut) %
+                                    multiplier ==
+                            0) {
+                multiplierAdjustedPllPhaseOut = pllPhaseOut;
+            }
+
+            multiplierAdjustedPllDeltaOut = pllDeltaOut * multiplier;
         }
 
-        // sleep an integer number of frames extra to approximate the
-        // selected framerate (eg 10,15,20,30)
-        const auto skippedFrames = (m_syncIntervalTimeMicros - pllDeltaOut / 2) / pllDeltaOut;
-        qint64 sleepForSkippedFrames = skippedFrames * pllDeltaOut;
+        if (multiplierAdjustedPllPhaseOut > nextSwapMicros) {
+            // We received a new pll phase
+            nextSwapMicros = multiplierAdjustedPllPhaseOut;
+        } else {
+            // We didn't receive a new pll phase out, so freewheel to estimated
+            // next with the current delta.
+            nextSwapMicros += multiplierAdjustedPllDeltaOut;
+        }
 
-        qint64 sleepUntilSwap = (nextSwapMicros + offset - now) % pllDeltaOut;
+        qint64 sleepUntilSwap = (nextSwapMicros + offset - now) % multiplierAdjustedPllDeltaOut;
         if (sleepUntilSwap < 0) {
-            sleepUntilSwap += pllDeltaOut;
+            sleepUntilSwap += multiplierAdjustedPllDeltaOut;
         }
-        usleep(sleepUntilSwap + sleepForSkippedFrames);
+        usleep(sleepUntilSwap);
 
         m_sinceLastSwap = m_timer.restart();
-        m_waitToSwapMicros = pllDeltaOut + sleepForSkippedFrames;
+        m_waitToSwapMicros = multiplierAdjustedPllDeltaOut;
 
         // Signal to swap the gl widgets (waveforms, spinnies, vumeters)
         // and render them for the next swap
-        emit vsyncSwapAndRender();
-        m_semaVsyncSlot.acquire();
-        if (m_sinceLastSwap.toIntegerMicros() > sleepForSkippedFrames + pllDeltaOut * 3 / 2) {
+        if (!pllInitializing() || m_pllPendingUpdate) {
+            emit vsyncSwapAndRender();
+            m_semaVsyncSlot.acquire();
+            m_pllPendingUpdate = false;
+        }
+
+        if (m_sinceLastSwap.toIntegerMicros() > multiplierAdjustedPllDeltaOut * 3 / 2) {
+            // Too much time passed since last swap: consider frame dropped.
+            // Automatically adjust the time offset between the PLL and our signal,
+            // ideally settling on an offset with no or little frame drops.
+            const auto sinceLastOffsetAdjust = now - offsetAdjustedAt;
+            // Don't adjust too often (max once every 100 ms)
+            if (sinceLastOffsetAdjust > 100000) {
+                // And don't adjust (immediately) if we have been running
+                // without drops for over 1 second
+                if (sinceLastOffsetAdjust < 1000000) {
+                    offset = (offset + pllDeltaOut / 8) % multiplierAdjustedPllDeltaOut;
+                }
+                offsetAdjustedAt = now;
+            }
             m_droppedFrames++;
-            // Adjusting the offset on each frame drop ends up at
-            // an offset with no frame drops
-            offset = (offset + 2000) % pllDeltaOut;
+            qDebug() << "DROP";
         }
     }
 }
@@ -246,26 +287,57 @@ mixxx::Duration VSyncThread::sinceLastSwap() const {
     return m_sinceLastSwap;
 }
 
+namespace {
+const int numStableDeltasRequired = 20;
+}
+
+bool VSyncThread::pllInitializing() const {
+    return m_pllInitCnt < numStableDeltasRequired;
+}
+
 void VSyncThread::updatePLL() {
     std::scoped_lock lock(m_pllMutex);
 
+    m_pllPendingUpdate = false;
+
     // Phase-lock-looped to estimate the vsync based on the
     // QOpenGLWindow::frameSwapped signal
+
+    const double pllPhaseIn = m_pllTimer.elapsed().toDoubleMicros();
+
+    if (m_pllInitCnt < numStableDeltasRequired) {
+        // Before activating the phase-lock-looped, we need an initial
+        // delta and phase, which we calculate by taking the average
+        // delta over a number of stable deltas.
+        const double delta = pllPhaseIn - m_pllPhaseOut;
+        m_pllPhaseOut = pllPhaseIn;
+        m_pllInitSum += delta;
+        m_pllInitCnt++;
+        m_pllInitAvg = m_pllInitSum / static_cast<double>(m_pllInitCnt);
+        if (std::abs(delta - m_pllInitAvg) > 2000.0) {
+            // The current delta is too different from the current
+            // average so we reset the init process.
+            m_pllInitSum = 0.0;
+            m_pllInitCnt = 0;
+        }
+        if (m_pllInitCnt == numStableDeltasRequired) {
+            m_pllDeltaOut = m_pllInitAvg;
+        }
+        return;
+    }
 
     // inspired by https://liquidsdr.org/blog/pll-simple-howto/
     const double alpha = 0.01;               // the page above uses 0.05, but a more narrow
                                              // filter seems to work better here
     const double beta = 0.5 * alpha * alpha; // increment adjustment factor
 
-    const double pllPhaseIn = m_pllTimer.elapsed().toDoubleMicros();
-
     m_pllPhaseOut += m_pllDeltaOut;
 
     double pllPhaseError = pllPhaseIn - m_pllPhaseOut;
 
     if (pllPhaseError > 0) {
-        // when advanced more than a frame, jump to the current frame
-        m_pllPhaseOut += std::floor(pllPhaseError / m_pllDeltaOut) * m_pllDeltaOut;
+        // when advanced more than a frame, jump to the nearest frame
+        m_pllPhaseOut += std::round(pllPhaseError / m_pllDeltaOut) * m_pllDeltaOut;
         pllPhaseError = pllPhaseIn - m_pllPhaseOut;
     }
 
@@ -277,9 +349,12 @@ void VSyncThread::updatePLL() {
         if (m_pllLogging == 0) {
             m_pllLogging = pllPhaseIn;
         } else {
-            qDebug() << "phase-locked-loop:" << m_pllPhaseOut << m_pllDeltaOut;
+            qDebug() << "phase-locked-loop:" << std::llround(m_pllPhaseOut)
+                     << m_pllDeltaOut << pllPhaseError;
         }
         // log every 10 seconds
         m_pllLogging += 10000000.0;
     }
+
+    m_pllPendingUpdate = true;
 }

--- a/src/waveform/vsyncthread.h
+++ b/src/waveform/vsyncthread.h
@@ -43,11 +43,11 @@ class VSyncThread : public QThread {
         return m_syncIntervalTimeMicros;
     }
     void updatePLL();
+    bool pllInitializing() const;
   signals:
     void vsyncSwapAndRender();
     void vsyncRender();
     void vsyncSwap();
-
   private:
     void runFree();
     void runPLL();
@@ -69,6 +69,10 @@ class VSyncThread : public QThread {
     // phase locked loop
     std::mutex m_pllMutex;
     PerformanceTimer m_pllTimer;
+    int m_pllInitCnt;
+    bool m_pllPendingUpdate;
+    double m_pllInitSum;
+    double m_pllInitAvg;
     double m_pllPhaseOut;
     double m_pllDeltaOut;
     double m_pllLogging;

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -807,16 +807,23 @@ void WaveformWidgetFactory::swap() {
 }
 
 void WaveformWidgetFactory::swapAndRender() {
+    // used for PLL
+    WGLWidget* widget = SharedGLContext::getWidget();
+    widget->getOpenGLWindow()->update();
+
     swapSelf();
     renderSelf();
+
     m_vsyncThread->vsyncSlotFinished();
 }
 
 void WaveformWidgetFactory::slotFrameSwapped() {
 #ifdef MIXXX_USE_QOPENGL
-    WGLWidget* widget = SharedGLContext::getWidget();
-    // continuously trigger redraws
-    widget->getOpenGLWindow()->update();
+    if (m_vsyncThread->pllInitializing()) {
+        // continuously trigger redraws during PLL init
+        WGLWidget* widget = SharedGLContext::getWidget();
+        widget->getOpenGLWindow()->update();
+    }
     // update the phase-locked-loop
     m_vsyncThread->updatePLL();
 #endif


### PR DESCRIPTION
Calculate the initial delta for the phase-locked-loop by calculating the average during an init stage in which only the continuous redraw is running.

Added lots of comments to the code.

With this, the PLL will work correctly with different refresh rates, including ProMotion. Note that after change the refresh rate in the system settings, Mixxx needs to be restarted.
