### PR TITLE
Skins: replace remaining 'skin:' occurences with 'skins:[skin name]'

### DIFF
--- a/res/skins/Deere/auxiliary.xml
+++ b/res/skins/Deere/auxiliary.xml
@@ -46,7 +46,7 @@
                     <SizePolicy>min,min</SizePolicy>
                     <Layout>vertical</Layout>
                     <Children>
-                      <Template src="skin:knob.xml">
+                      <Template src="skins:Deere/knob.xml">
                         <SetVariable name="TooltipId">microphone_pregain</SetVariable>
                         <SetVariable name="control">pregain</SetVariable>
                         <SetVariable name="color">green</SetVariable>
@@ -56,7 +56,7 @@
                         <SizePolicy>min,min</SizePolicy>
                         <Layout>vertical</Layout>
                         <Children>
-                          <Template src="skin:left_3state_button.xml">
+                          <Template src="skins:Deere/left_3state_button.xml">
                             <SetVariable name="TooltipId">orientation</SetVariable>
                             <SetVariable name="ObjectName">OrientationButtonAux</SetVariable>
                             <SetVariable name="MinimumSize">30,14</SetVariable>
@@ -75,7 +75,7 @@
                     </Children>
                   </WidgetGroup>
 
-                  <Template src="skin:vumeter.xml">
+                  <Template src="skins:Deere/vumeter.xml">
                     <SetVariable name="TooltipId">microphone_VuMeter</SetVariable>
                     <SetVariable name="Size">5f,42f</SetVariable>
                     <SetVariable name="control">vu_meter</SetVariable>
@@ -100,7 +100,7 @@
                 <Layout>horizontal</Layout>
                 <Children>
 
-                  <Template src="skin:left_2state_button.xml">
+                  <Template src="skins:Deere/left_2state_button.xml">
                     <SetVariable name="TooltipId">main_enable</SetVariable>
                     <SetVariable name="ObjectName">AuxPlayButton</SetVariable>
                     <SetVariable name="MinimumSize">32,22</SetVariable>
@@ -111,7 +111,7 @@
                     <SetVariable name="left_connection_control"><Variable name="group"/>,main_mix</SetVariable>
                   </Template>
 
-                  <Template src="skin:left_2state_button.xml">
+                  <Template src="skins:Deere/left_2state_button.xml">
                     <SetVariable name="TooltipId">pfl</SetVariable>
                     <SetVariable name="ObjectName">AuxPFLButton</SetVariable>
                     <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
@@ -134,12 +134,12 @@
                 <Layout>horizontal</Layout>
                 <SizePolicy>min,min</SizePolicy>
                 <Children>
-                  <Template src="skin:fx_unit_group_assignment_button.xml">
+                  <Template src="skins:Deere/fx_unit_group_assignment_button.xml">
                     <SetVariable name="EffectUnit">1</SetVariable>
                     <SetVariable name="SourceType">auxiliary</SetVariable>
                   </Template>
 
-                  <Template src="skin:fx_unit_group_assignment_button.xml">
+                  <Template src="skins:Deere/fx_unit_group_assignment_button.xml">
                     <SetVariable name="EffectUnit">2</SetVariable>
                     <SetVariable name="SourceType">auxiliary</SetVariable>
                   </Template>
@@ -151,7 +151,7 @@
                 <Layout>horizontal</Layout>
                 <SizePolicy>min,min</SizePolicy>
                 <Children>
-                  <Template src="skin:fx_unit_group_assignment_button.xml">
+                  <Template src="skins:Deere/fx_unit_group_assignment_button.xml">
                     <SetVariable name="EffectUnit">3</SetVariable>
                     <SetVariable name="SourceType">auxiliary</SetVariable>
                   </Template>
@@ -159,7 +159,7 @@
                   <!-- Workaround for layout spacing -->
                   <WidgetGroup><Size>2f,0min</Size></WidgetGroup>
 
-                  <Template src="skin:fx_unit_group_assignment_button.xml">
+                  <Template src="skins:Deere/fx_unit_group_assignment_button.xml">
                     <SetVariable name="EffectUnit">4</SetVariable>
                     <SetVariable name="SourceType">auxiliary</SetVariable>
                   </Template>

--- a/res/skins/Deere/auxiliary_unconfigured.xml
+++ b/res/skins/Deere/auxiliary_unconfigured.xml
@@ -38,7 +38,7 @@
             <Layout>horizontal</Layout>
             <SizePolicy>min,me</SizePolicy>
             <Children>
-              <Template src="skin:left_1state_button.xml">
+              <Template src="skins:Deere/left_1state_button.xml">
                 <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
                 <SetVariable name="MaximumSize"><Variable name="SquareButtonMaximumSize"/></SetVariable>
                 <SetVariable name="SizePolicy"><Variable name="SquareButtonSizePolicy"/></SetVariable>

--- a/res/skins/Deere/beatloop_button.xml
+++ b/res/skins/Deere/beatloop_button.xml
@@ -11,7 +11,7 @@
     SmallSquareButtonSize: The button size
 -->
 <Template>
-  <Template src="skin:left_right_display_2state_button.xml">
+  <Template src="skins:Deere/left_right_display_2state_button.xml">
     <SetVariable name="TooltipId">beatloop</SetVariable>
     <SetVariable name="ObjectName">BeatLoopButton</SetVariable>
     <SetVariable name="MinimumSize">40,46</SetVariable>

--- a/res/skins/Deere/crossfader_orientation_button.xml
+++ b/res/skins/Deere/crossfader_orientation_button.xml
@@ -1,5 +1,5 @@
 <Template>
-  <Template src="skin:left_3state_button.xml">
+  <Template src="skins:Deere/left_3state_button.xml">
     <SetVariable name="TooltipId">orientation</SetVariable>
     <SetVariable name="ObjectName">OrientationButton<Variable name="Unit"/></SetVariable>
     <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>

--- a/res/skins/Deere/deck.xml
+++ b/res/skins/Deere/deck.xml
@@ -18,7 +18,7 @@
         <Layout>vertical</Layout>
         <SizePolicy>me,me</SizePolicy>
         <Children>
-          <Template src="skin:deck_text_row.xml"/>
+          <Template src="skins:Deere/deck_text_row.xml"/>
 
           <!-- Hides if the 'Parallel Waveforms' option is activated in the skin settings -->
           <WidgetGroup>
@@ -69,8 +69,8 @@
             </Connection>
           </WidgetGroup>
 
-          <Template src="skin:deck_overview_row.xml"/>
-          <Template src="skin:deck_controls_row.xml"/>
+          <Template src="skins:Deere/deck_overview_row.xml"/>
+          <Template src="skins:Deere/deck_controls_row.xml"/>
         </Children>
       </WidgetGroup>
 
@@ -79,7 +79,7 @@
         <Layout>vertical</Layout>
         <SizePolicy>min,min</SizePolicy>
         <Children>
-          <Template src="skin:deck_tempo_column.xml"/>
+          <Template src="skins:Deere/deck_tempo_column.xml"/>
         </Children>
       </WidgetGroup>
     </Children>

--- a/res/skins/Deere/deck_beatjump_controls.xml
+++ b/res/skins/Deere/deck_beatjump_controls.xml
@@ -25,7 +25,7 @@
         <Layout>horizontal</Layout>
         <Children>
 
-          <Template src="skin:left_right_1state_button.xml">
+          <Template src="skins:Deere/left_right_1state_button.xml">
             <SetVariable name="TooltipId">beatjump_backward</SetVariable>
             <SetVariable name="ObjectName">BeatJumpButton</SetVariable>
             <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
@@ -41,7 +41,7 @@
           <!-- Workaround for layout spacing -->
           <WidgetGroup><Size>2f,0min</Size></WidgetGroup>
 
-          <Template src="skin:left_right_1state_button.xml">
+          <Template src="skins:Deere/left_right_1state_button.xml">
             <SetVariable name="TooltipId">beatjump_forward</SetVariable>
             <SetVariable name="ObjectName">BeatJumpButton</SetVariable>
             <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>

--- a/res/skins/Deere/deck_controls_row.xml
+++ b/res/skins/Deere/deck_controls_row.xml
@@ -20,7 +20,7 @@
         <MaximumSize>60, -1</MaximumSize>
         <SizePolicy>me,me</SizePolicy>
         <Children>
-          <Template src="skin:left_right_display_2state_button.xml">
+          <Template src="skins:Deere/left_right_display_2state_button.xml">
             <SetVariable name="TooltipId">cue_default_cue_gotoandstop</SetVariable>
             <SetVariable name="ObjectName">DeckCue</SetVariable>
             <SetVariable name="MinimumSize"><Variable name="HorizontalStretchButtonMinimumSize"/></SetVariable>
@@ -38,7 +38,7 @@
             <Layout>stacked</Layout>
             <SizePolicy>me,me</SizePolicy>
             <Children>
-              <Template src="skin:left_right_display_2state_button.xml">
+              <Template src="skins:Deere/left_right_display_2state_button.xml">
                 <SetVariable name="TooltipId">play_cue_set</SetVariable>
                 <SetVariable name="ObjectName">PlayToggle</SetVariable>
                 <SetVariable name="MinimumSize"><Variable name="HorizontalStretchButtonMinimumSize"/></SetVariable>
@@ -48,14 +48,14 @@
                 <SetVariable name="right_connection_control"><Variable name="group"/>,cue_set</SetVariable>
                 <SetVariable name="display_connection_control"><Variable name="group"/>,play_latched</SetVariable>
               </Template>
-              <Template src="skin:left_2state_button.xml">
+              <Template src="skins:Deere/left_2state_button.xml">
                 <SetVariable name="ObjectName">PreviewIndicator</SetVariable>
                 <SetVariable name="MinimumSize"><Variable name="HorizontalStretchButtonMinimumSize"/></SetVariable>
                 <SetVariable name="MaximumSize"><Variable name="HorizontalStretchButtonMaximumSize"/></SetVariable>
                 <SetVariable name="SizePolicy"><Variable name="HorizontalStretchButtonSizePolicy"/></SetVariable>
                 <SetVariable name="left_connection_control"><Variable name="group"/>,play</SetVariable>
               </Template>
-              <Template src="skin:left_2state_button.xml">
+              <Template src="skins:Deere/left_2state_button.xml">
                 <SetVariable name="MinimumSize"><Variable name="HorizontalStretchButtonMinimumSize"/></SetVariable>
                 <SetVariable name="MaximumSize"><Variable name="HorizontalStretchButtonMaximumSize"/></SetVariable>
                 <SetVariable name="SizePolicy"><Variable name="HorizontalStretchButtonSizePolicy"/></SetVariable>
@@ -71,23 +71,23 @@
         <MaximumSize>12,-1</MaximumSize>
       </WidgetGroup>
 
-      <Template src="skin:hotcues.xml"/>
+      <Template src="skins:Deere/hotcues.xml"/>
 
       <WidgetGroup>
         <Size>3min,1min</Size>
         <MaximumSize>12,-1</MaximumSize>
       </WidgetGroup>
 
-      <Template src="skin:special_cues.xml"/>
+      <Template src="skins:Deere/special_cues.xml"/>
 
       <!-- Expanding spacers in between control contexts -->
       <WidgetGroup><Size>3min,1min</Size></WidgetGroup>
 
-      <Template src="skin:deck_looping_controls.xml"/>
+      <Template src="skins:Deere/deck_looping_controls.xml"/>
 
       <WidgetGroup><Size>3min,1min</Size></WidgetGroup>
 
-      <Template src="skin:deck_beatjump_controls.xml"/>
+      <Template src="skins:Deere/deck_beatjump_controls.xml"/>
 
       <WidgetGroup><Size>0min,1min</Size></WidgetGroup>
 

--- a/res/skins/Deere/deck_looping_controls.xml
+++ b/res/skins/Deere/deck_looping_controls.xml
@@ -25,7 +25,7 @@
           <!-- Workaround for layout spacing -->
           <WidgetGroup><Size>1f,0min</Size></WidgetGroup>
 
-          <Template src="skin:left_right_display_2state_button.xml">
+          <Template src="skins:Deere/left_right_display_2state_button.xml">
             <SetVariable name="TooltipId">beatloop_activate</SetVariable>
             <SetVariable name="ObjectName">BeatloopActivate</SetVariable>
             <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
@@ -53,7 +53,7 @@
         <Children>
           <WidgetGroup><Size>4f,0min</Size></WidgetGroup>
 
-          <Template src="skin:left_right_1state_button.xml">
+          <Template src="skins:Deere/left_right_1state_button.xml">
             <SetVariable name="TooltipId">loop_in</SetVariable>
             <SetVariable name="ObjectName">LoopIn</SetVariable>
             <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
@@ -69,7 +69,7 @@
           <!-- Workaround for layout spacing -->
           <WidgetGroup><Size>2f,0min</Size></WidgetGroup>
 
-          <Template src="skin:left_right_1state_button.xml">
+          <Template src="skins:Deere/left_right_1state_button.xml">
             <SetVariable name="TooltipId">loop_out</SetVariable>
             <SetVariable name="ObjectName">LoopOut</SetVariable>
             <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
@@ -85,7 +85,7 @@
           <!-- Workaround for layout spacing -->
           <WidgetGroup><Size>5f,0min</Size></WidgetGroup>
 
-          <Template src="skin:left_right_2state_button.xml">
+          <Template src="skins:Deere/left_right_2state_button.xml">
             <SetVariable name="TooltipId">reloop_toggle</SetVariable>
             <SetVariable name="ObjectName">Reloop</SetVariable>
             <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>

--- a/res/skins/Deere/deck_overview_row.xml
+++ b/res/skins/Deere/deck_overview_row.xml
@@ -23,7 +23,7 @@
             <SizePolicy>min,min</SizePolicy>
             <Children>
 
-              <Template src="skin:left_2state_button.xml">
+              <Template src="skins:Deere/left_2state_button.xml">
                 <SetVariable name="TooltipId">slip_mode</SetVariable>
                 <SetVariable name="ObjectName">SlipModeButton</SetVariable>
                 <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
@@ -38,7 +38,7 @@
                 <SetVariable name="left_connection_control"><Variable name="group"/>,slip_enabled</SetVariable>
               </Template>
 
-              <Template src="skin:left_2state_button.xml">
+              <Template src="skins:Deere/left_2state_button.xml">
                 <SetVariable name="TooltipId">repeat</SetVariable>
                 <SetVariable name="ObjectName">RepeatButton</SetVariable>
                 <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
@@ -53,7 +53,7 @@
                 <SetVariable name="left_connection_control"><Variable name="group"/>,repeat</SetVariable>
               </Template>
 
-              <Template src="skin:left_right_1state_button.xml">
+              <Template src="skins:Deere/left_right_1state_button.xml">
                 <SetVariable name="TooltipId">beats_translate_curpos</SetVariable>
                 <SetVariable name="ObjectName">BeatsTranslateCurposButton</SetVariable>
                 <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
@@ -74,7 +74,7 @@
             <Layout>horizontal</Layout>
             <SizePolicy>min,min</SizePolicy>
             <Children>
-              <Template src="skin:left_2state_button.xml">
+              <Template src="skins:Deere/left_2state_button.xml">
                 <SetVariable name="TooltipId">eject</SetVariable>
                 <SetVariable name="ObjectName">EjectButton</SetVariable>
                 <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
@@ -89,7 +89,7 @@
                 <SetVariable name="left_connection_control"><Variable name="group"/>,eject</SetVariable>
               </Template>
 
-              <Template src="skin:left_2state_button.xml">
+              <Template src="skins:Deere/left_2state_button.xml">
                 <SetVariable name="TooltipId">quantize</SetVariable>
                 <SetVariable name="ObjectName">QuantizeButton</SetVariable>
                 <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
@@ -104,7 +104,7 @@
                 <SetVariable name="left_connection_control"><Variable name="group"/>,quantize</SetVariable>
               </Template>
 
-              <Template src="skin:left_2state_button.xml">
+              <Template src="skins:Deere/left_2state_button.xml">
                 <SetVariable name="TooltipId">keylock</SetVariable>
                 <SetVariable name="ObjectName">KeylockButton</SetVariable>
                 <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
@@ -147,12 +147,12 @@
             <Layout>vertical</Layout>
             <SizePolicy>min,min</SizePolicy>
             <Children>
-              <Template src="skin:fx_unit_group_assignment_button.xml">
+              <Template src="skins:Deere/fx_unit_group_assignment_button.xml">
                 <SetVariable name="EffectUnit">1</SetVariable>
                 <SetVariable name="SourceType">deck</SetVariable>
               </Template>
 
-              <Template src="skin:fx_unit_group_assignment_button.xml">
+              <Template src="skins:Deere/fx_unit_group_assignment_button.xml">
                 <SetVariable name="EffectUnit">2</SetVariable>
                 <SetVariable name="SourceType">deck</SetVariable>
               </Template>
@@ -170,12 +170,12 @@
                 <Layout>horizontal</Layout>
                 <SizePolicy>min,min</SizePolicy>
                 <Children>
-                  <Template src="skin:fx_unit_group_assignment_button.xml">
+                  <Template src="skins:Deere/fx_unit_group_assignment_button.xml">
                     <SetVariable name="EffectUnit">1</SetVariable>
                     <SetVariable name="SourceType">deck</SetVariable>
                   </Template>
 
-                  <Template src="skin:fx_unit_group_assignment_button.xml">
+                  <Template src="skins:Deere/fx_unit_group_assignment_button.xml">
                     <SetVariable name="EffectUnit">2</SetVariable>
                     <SetVariable name="SourceType">deck</SetVariable>
                   </Template>
@@ -187,12 +187,12 @@
                 <Layout>horizontal</Layout>
                 <SizePolicy>min,min</SizePolicy>
                 <Children>
-                  <Template src="skin:fx_unit_group_assignment_button.xml">
+                  <Template src="skins:Deere/fx_unit_group_assignment_button.xml">
                     <SetVariable name="EffectUnit">3</SetVariable>
                     <SetVariable name="SourceType">deck</SetVariable>
                   </Template>
 
-                  <Template src="skin:fx_unit_group_assignment_button.xml">
+                  <Template src="skins:Deere/fx_unit_group_assignment_button.xml">
                     <SetVariable name="EffectUnit">4</SetVariable>
                     <SetVariable name="SourceType">deck</SetVariable>
                   </Template>

--- a/res/skins/Deere/deck_small.xml
+++ b/res/skins/Deere/deck_small.xml
@@ -180,7 +180,7 @@
                 <Size>32min,46f</Size>
                 <Children>
 
-                  <Template src="skin:left_right_display_2state_button.xml">
+                  <Template src="skins:Deere/left_right_display_2state_button.xml">
                     <SetVariable name="TooltipId">cue_default_cue_gotoandstop</SetVariable>
                     <SetVariable name="ObjectName">DeckCue</SetVariable>
                     <SetVariable name="MinimumSize">30,21</SetVariable>
@@ -198,7 +198,7 @@
                     <Layout>stacked</Layout>
                     <SizePolicy>f,me</SizePolicy>
                     <Children>
-                      <Template src="skin:left_right_display_2state_button.xml">
+                      <Template src="skins:Deere/left_right_display_2state_button.xml">
                         <SetVariable name="TooltipId">play_cue_default</SetVariable>
                         <SetVariable name="ObjectName">PlayToggle</SetVariable>
                         <SetVariable name="MinimumSize">30,21</SetVariable>
@@ -208,14 +208,14 @@
                         <SetVariable name="right_connection_control"><Variable name="group"/>,cue_set</SetVariable>
                         <SetVariable name="display_connection_control"><Variable name="group"/>,play_latched</SetVariable>
                       </Template>
-                      <Template src="skin:left_2state_button.xml">
+                      <Template src="skins:Deere/left_2state_button.xml">
                         <SetVariable name="ObjectName">PreviewIndicator</SetVariable>
                         <SetVariable name="MinimumSize">30,21</SetVariable>
                         <SetVariable name="MaximumSize">30,21</SetVariable>
                         <SetVariable name="SizePolicy">f,f</SetVariable>
                         <SetVariable name="left_connection_control"><Variable name="group"/>,play</SetVariable>
                       </Template>
-                      <Template src="skin:left_2state_button.xml">
+                      <Template src="skins:Deere/left_2state_button.xml">
                         <SetVariable name="MinimumSize">30,21</SetVariable>
                         <SetVariable name="MaximumSize">30,21</SetVariable>
                         <SetVariable name="SizePolicy">f,f</SetVariable>

--- a/res/skins/Deere/deck_tempo_column.xml
+++ b/res/skins/Deere/deck_tempo_column.xml
@@ -19,7 +19,7 @@
             <Layout>horizontal</Layout>
             <ObjectName>RateTempButtons</ObjectName>
             <Children>
-              <Template src="skin:left_right_2state_button.xml">
+              <Template src="skins:Deere/left_right_2state_button.xml">
                 <SetVariable name="TooltipId">sync_enabled</SetVariable>
                 <SetVariable name="ObjectName">DeckSync</SetVariable>
                 <SetVariable name="MinimumSize">35,18</SetVariable>
@@ -30,7 +30,7 @@
                 <SetVariable name="left_connection_control"><Variable name="group"/>,sync_enabled</SetVariable>
                 <SetVariable name="right_connection_control"><Variable name="group"/>,beatsync_tempo</SetVariable>
               </Template>
-              <Template src="skin:left_3state_button.xml">
+              <Template src="skins:Deere/left_3state_button.xml">
                 <SetVariable name="TooltipId">sync_leader</SetVariable>
                 <SetVariable name="ObjectName">SyncLeader</SetVariable>
                 <SetVariable name="MinimumSize">15,18</SetVariable>
@@ -45,7 +45,7 @@
             <ObjectName>RateTempButtons</ObjectName>
             <Layout>horizontal</Layout>
             <Children>
-              <Template src="skin:left_right_1state_button.xml">
+              <Template src="skins:Deere/left_right_1state_button.xml">
                 <SetVariable name="ObjectName">TempRateDown</SetVariable>
                 <SetVariable name="TooltipId">rate_temp_down_rate_temp_down_small</SetVariable>
                 <SetVariable name="MinimumSize">20,20</SetVariable>
@@ -58,7 +58,7 @@
                 <SetVariable name="right_connection_control"><Variable name="group"/>,rate_temp_down_small</SetVariable>
               </Template>
 
-              <Template src="skin:left_right_1state_button.xml">
+              <Template src="skins:Deere/left_right_1state_button.xml">
                 <SetVariable name="TooltipId">rate_temp_up_rate_temp_up_small</SetVariable>
                 <SetVariable name="ObjectName">TempRateUp</SetVariable>
                 <SetVariable name="MinimumSize">20,20</SetVariable>

--- a/res/skins/Deere/deck_text_row.xml
+++ b/res/skins/Deere/deck_text_row.xml
@@ -164,7 +164,7 @@
                                 <Layout>horizontal</Layout>
                                 <SizePolicy>min,me</SizePolicy>
                                 <Children>
-                                  <Template src="skin:left_right_1state_button.xml">
+                                  <Template src="skins:Deere/left_right_1state_button.xml">
                                     <SetVariable name="TooltipId">shift_cues_earlier</SetVariable>
                                     <SetVariable name="ObjectName">HotcuesEarlierButton</SetVariable>
                                     <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
@@ -177,7 +177,7 @@
                                     <SetVariable name="right_connection_control"><Variable name="group"/>,shift_cues_earlier_small</SetVariable>
                                   </Template>
 
-                                  <Template src="skin:left_right_1state_button.xml">
+                                  <Template src="skins:Deere/left_right_1state_button.xml">
                                     <SetVariable name="TooltipId">shift_cues_later</SetVariable>
                                     <SetVariable name="ObjectName">HotcuesLaterButton</SetVariable>
                                     <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
@@ -196,7 +196,7 @@
                                 </Connection>
                               </WidgetGroup>
 
-                              <Template src="skin:left_right_1state_button.xml">
+                              <Template src="skins:Deere/left_right_1state_button.xml">
                                 <SetVariable name="TooltipId">beats_adjust_faster</SetVariable>
                                 <SetVariable name="ObjectName">BeatsAdjustFasterButton</SetVariable>
                                 <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
@@ -208,7 +208,7 @@
                                 <SetVariable name="left_connection_control"><Variable name="group"/>,beats_adjust_faster</SetVariable>
                               </Template>
 
-                              <Template src="skin:left_right_1state_button.xml">
+                              <Template src="skins:Deere/left_right_1state_button.xml">
                                 <SetVariable name="TooltipId">beats_adjust_slower</SetVariable>
                                 <SetVariable name="ObjectName">BeatsAdjustSlowerButton</SetVariable>
                                 <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
@@ -220,7 +220,7 @@
                                 <SetVariable name="left_connection_control"><Variable name="group"/>,beats_adjust_slower</SetVariable>
                               </Template>
 
-                              <Template src="skin:left_right_1state_button.xml">
+                              <Template src="skins:Deere/left_right_1state_button.xml">
                                 <SetVariable name="TooltipId">beats_translate_earlier</SetVariable>
                                 <SetVariable name="ObjectName">BeatsTranslateEarlierButton</SetVariable>
                                 <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
@@ -232,7 +232,7 @@
                                 <SetVariable name="left_connection_control"><Variable name="group"/>,beats_translate_earlier</SetVariable>
                               </Template>
 
-                              <Template src="skin:left_right_1state_button.xml">
+                              <Template src="skins:Deere/left_right_1state_button.xml">
                                 <SetVariable name="TooltipId">beats_translate_later</SetVariable>
                                 <SetVariable name="ObjectName">BeatsTranslateLaterButton</SetVariable>
                                 <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
@@ -244,7 +244,7 @@
                                 <SetVariable name="left_connection_control"><Variable name="group"/>,beats_translate_later</SetVariable>
                               </Template>
 
-                              <Template src="skin:left_right_1state_button.xml">
+                              <Template src="skins:Deere/left_right_1state_button.xml">
                                 <SetVariable name="TooltipId">beats_translate_curpos</SetVariable>
                                 <SetVariable name="ObjectName">BeatsTranslateCurposButton</SetVariable>
                                 <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
@@ -476,7 +476,7 @@
                             <MinimumSize>80,20</MinimumSize>
                             <MaximumSize>120,30</MaximumSize>
                             <Children>
-                              <Template src="skin:left_right_1state_button.xml">
+                              <Template src="skins:Deere/left_right_1state_button.xml">
                                 <SetVariable name="TooltipId">pitch_down</SetVariable>
                                 <SetVariable name="ObjectName">PitchDownButton</SetVariable>
                                 <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
@@ -489,7 +489,7 @@
                                 <SetVariable name="right_connection_control"><Variable name="group"/>,pitch_down_small</SetVariable>
                               </Template>
 
-                              <Template src="skin:left_right_1state_button.xml">
+                              <Template src="skins:Deere/left_right_1state_button.xml">
                                 <SetVariable name="TooltipId">pitch_up</SetVariable>
                                 <SetVariable name="ObjectName">PitchUpButton</SetVariable>
                                 <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
@@ -502,7 +502,7 @@
                                 <SetVariable name="right_connection_control"><Variable name="group"/>,pitch_up_small</SetVariable>
                               </Template>
 
-                              <Template src="skin:left_right_1state_button.xml">
+                              <Template src="skins:Deere/left_right_1state_button.xml">
                                 <SetVariable name="TooltipId">sync_reset_key</SetVariable>
                                 <SetVariable name="ObjectName">SyncKeyButton</SetVariable>
                                 <SetVariable name="MinimumSize">46,22</SetVariable>

--- a/res/skins/Deere/deck_waveform.xml
+++ b/res/skins/Deere/deck_waveform.xml
@@ -14,7 +14,7 @@
     <SizePolicy>me,me</SizePolicy>
     <Children>
 
-      <Template src="skin:vinylcontrol.xml"/>
+      <Template src="skins:Deere/vinylcontrol.xml"/>
 
       <Visual>
         <TooltipId>waveform_display</TooltipId>
@@ -132,7 +132,7 @@
         <Layout>vertical</Layout>
         <SizePolicy>min,min</SizePolicy>
         <Children>
-          <Template src="skin:left_1state_button.xml">
+          <Template src="skins:Deere/left_1state_button.xml">
             <SetVariable name="TooltipId">waveform_zoom_down</SetVariable>
             <SetVariable name="ObjectName">WaveformZoomDownButton</SetVariable>
             <SetVariable name="MinimumSize"><Variable name="SmallSquareButtonMinimumSize"/></SetVariable>
@@ -144,7 +144,7 @@
             <SetVariable name="left_connection_control"><Variable name="group"/>,waveform_zoom_down</SetVariable>
           </Template>
 
-          <Template src="skin:left_1state_button.xml">
+          <Template src="skins:Deere/left_1state_button.xml">
             <SetVariable name="TooltipId">waveform_zoom_set_default</SetVariable>
             <SetVariable name="ObjectName">WaveformZoomSetDefaultButton</SetVariable>
             <SetVariable name="MinimumSize"><Variable name="SmallSquareButtonMinimumSize"/></SetVariable>
@@ -156,7 +156,7 @@
             <SetVariable name="left_connection_control"><Variable name="group"/>,waveform_zoom_set_default</SetVariable>
           </Template>
 
-          <Template src="skin:left_1state_button.xml">
+          <Template src="skins:Deere/left_1state_button.xml">
             <SetVariable name="TooltipId">waveform_zoom_up</SetVariable>
             <SetVariable name="ObjectName">WaveformZoomUpButton</SetVariable>
             <SetVariable name="MinimumSize"><Variable name="SmallSquareButtonMinimumSize"/></SetVariable>

--- a/res/skins/Deere/decks_small.xml
+++ b/res/skins/Deere/decks_small.xml
@@ -8,11 +8,11 @@
         <Layout>horizontal</Layout>
         <Size>0me,51f</Size>
         <Children>
-          <Template src="skin:deck_small.xml">
+          <Template src="skins:Deere/deck_small.xml">
             <SetVariable name="i">1</SetVariable>
           </Template>
 
-          <Template src="skin:deck_small.xml">
+          <Template src="skins:Deere/deck_small.xml">
             <SetVariable name="i">2</SetVariable>
           </Template>
         </Children>
@@ -22,11 +22,11 @@
         <Layout>horizontal</Layout>
         <Size>0me,51f</Size>
         <Children>
-          <Template src="skin:deck_small.xml">
+          <Template src="skins:Deere/deck_small.xml">
             <SetVariable name="i">3</SetVariable>
           </Template>
 
-          <Template src="skin:deck_small.xml">
+          <Template src="skins:Deere/deck_small.xml">
             <SetVariable name="i">4</SetVariable>
           </Template>
         </Children>

--- a/res/skins/Deere/effect_buttons.xml
+++ b/res/skins/Deere/effect_buttons.xml
@@ -13,9 +13,9 @@ Variables:
     <SizePolicy><Variable name="SizePolicy"/></SizePolicy>
     <Layout>horizontal</Layout>
     <Children>
-      <Template src="skin:effect_focus_button.xml"/>
+      <Template src="skins:Deere/effect_focus_button.xml"/>
 
-      <Template src="skin:left_2state_button.xml">
+      <Template src="skins:Deere/left_2state_button.xml">
         <SetVariable name="TooltipId">EffectSlot_enabled</SetVariable>
         <SetVariable name="ObjectName">EffectEnableButton</SetVariable>
         <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>

--- a/res/skins/Deere/effect_meta_knob.xml
+++ b/res/skins/Deere/effect_meta_knob.xml
@@ -13,7 +13,7 @@
     <Layout>vertical</Layout>
     <Size>40f,34f</Size>
     <Children>
-      <Template src="skin:knob.xml">
+      <Template src="skins:Deere/knob.xml">
         <SetVariable name="TooltipId">EffectSlot_metaknob</SetVariable>
         <SetVariable name="group">[EffectRack<Variable name="EffectRack"/>_EffectUnit<Variable name="EffectUnit"/>_Effect<Variable name="Effect"/>]</SetVariable>
         <SetVariable name="control">meta</SetVariable>

--- a/res/skins/Deere/effect_parameter_knob.xml
+++ b/res/skins/Deere/effect_parameter_knob.xml
@@ -54,7 +54,7 @@
         <Layout>horizontal</Layout>
         <Size>-1,8f</Size>
         <Children>
-          <Template src="skin:left_2state_button.xml">
+          <Template src="skins:Deere/left_2state_button.xml">
             <!-- Button has no text/images, qss only -->
             <SetVariable name="TooltipId">EffectSlot_parameter_inversion</SetVariable>
             <SetVariable name="ObjectName">EffectSlotParameterLinkInversionButton</SetVariable>
@@ -64,7 +64,7 @@
             <SetVariable name="left_connection_control">[EffectRack<Variable name="EffectRack"/>_EffectUnit<Variable name="EffectUnit"/>_Effect<Variable name="Effect"/>],parameter<Variable name="EffectParameter"/>_link_inverse</SetVariable>
           </Template>
 
-          <Template src="skin:left_5state_button.xml">
+          <Template src="skins:Deere/left_5state_button.xml">
             <!-- Button has no text/images, qss only -->
             <SetVariable name="TooltipId">EffectSlot_parameter_link_type</SetVariable>
             <SetVariable name="ObjectName">EffectSlotParameterLinkTypeButton</SetVariable>

--- a/res/skins/Deere/effect_rack.xml
+++ b/res/skins/Deere/effect_rack.xml
@@ -24,17 +24,17 @@ Container for all the effect units
             <Layout>horizontal</Layout>
             <SizePolicy>me,me</SizePolicy>
             <Children>
-              <Template src="skin:effect_unit.xml">
+              <Template src="skins:Deere/effect_unit.xml">
                 <SetVariable name="EffectRack">1</SetVariable>
                 <SetVariable name="EffectUnit">1</SetVariable>
               </Template>
 
-              <Template src="skin:spacer_hx.xml">
+              <Template src="skins:Deere/spacer_hx.xml">
                 <SetVariable name="width">5</SetVariable>
                 <SetVariable name="color">22</SetVariable>
               </Template>
 
-              <Template src="skin:effect_unit.xml">
+              <Template src="skins:Deere/effect_unit.xml">
                 <SetVariable name="EffectRack">1</SetVariable>
                 <SetVariable name="EffectUnit">2</SetVariable>
               </Template>
@@ -50,17 +50,17 @@ Container for all the effect units
                 <Layout>horizontal</Layout>
                 <SizePolicy>me,me</SizePolicy>
                 <Children>
-                  <Template src="skin:effect_unit.xml">
+                  <Template src="skins:Deere/effect_unit.xml">
                     <SetVariable name="EffectRack">1</SetVariable>
                     <SetVariable name="EffectUnit">3</SetVariable>
                   </Template>
 
-                  <Template src="skin:spacer_hx.xml">
+                  <Template src="skins:Deere/spacer_hx.xml">
                     <SetVariable name="width">5</SetVariable>
                     <SetVariable name="color">22</SetVariable>
                   </Template>
 
-                  <Template src="skin:effect_unit.xml">
+                  <Template src="skins:Deere/effect_unit.xml">
                     <SetVariable name="EffectRack">1</SetVariable>
                     <SetVariable name="EffectUnit">4</SetVariable>
                   </Template>

--- a/res/skins/Deere/effect_single_no_parameters.xml
+++ b/res/skins/Deere/effect_single_no_parameters.xml
@@ -23,11 +23,11 @@ Variables:
           <WidgetGroup>
             <Layout>horizontal</Layout>
             <Children>
-              <Template src="skin:effect_buttons.xml">
+              <Template src="skins:Deere/effect_buttons.xml">
                 <SetVariable name="SizePolicy">min,max</SetVariable>
                 <SetVariable name="EnableButtonMaxSize">60,22</SetVariable>
               </Template>
-              <Template src="skin:effect_meta_knob.xml"/>
+              <Template src="skins:Deere/effect_meta_knob.xml"/>
             </Children>
           </WidgetGroup>
 
@@ -72,11 +72,11 @@ Variables:
           <WidgetGroup>
             <Layout>horizontal</Layout>
             <Children>
-              <Template src="skin:effect_buttons.xml">
+              <Template src="skins:Deere/effect_buttons.xml">
                 <SetVariable name="SizePolicy">min,max</SetVariable>
                 <SetVariable name="EnableButtonMaxSize">60,22</SetVariable>
               </Template>
-              <Template src="skin:effect_meta_knob.xml"/>
+              <Template src="skins:Deere/effect_meta_knob.xml"/>
             </Children>
           </WidgetGroup>
 

--- a/res/skins/Deere/effect_single_with_parameters.xml
+++ b/res/skins/Deere/effect_single_with_parameters.xml
@@ -18,7 +18,7 @@ Variables:
         <Layout>horizontal</Layout>
         <SizePolicy>me,min</SizePolicy>
         <Children>
-          <Template src="skin:effect_single_with_parameters_row.xml" />
+          <Template src="skins:Deere/effect_single_with_parameters_row.xml" />
         </Children>
         <Connection>
           <ConfigKey>[EffectRack<Variable name="EffectRack"/>_EffectUnit<Variable name="EffectUnit"/>],focused_effect</ConfigKey>
@@ -40,7 +40,7 @@ Variables:
     <ObjectName>EffectNotHighlightable</ObjectName>
     <Layout>horizontal</Layout>
     <Children>
-      <Template src="skin:effect_single_with_parameters_row.xml" />
+      <Template src="skins:Deere/effect_single_with_parameters_row.xml" />
     </Children>
     <Connection>
       <ConfigKey>[EffectRack<Variable name="EffectRack"/>_EffectUnit<Variable name="EffectUnit"/>],show_focus</ConfigKey>

--- a/res/skins/Deere/effect_single_with_parameters_row.xml
+++ b/res/skins/Deere/effect_single_with_parameters_row.xml
@@ -24,11 +24,11 @@ Variables:
             <SizePolicy>min,min</SizePolicy>
             <Layout>horizontal</Layout>
             <Children>
-              <Template src="skin:effect_buttons.xml">
+              <Template src="skins:Deere/effect_buttons.xml">
                 <SetVariable name="SizePolicy">max,min</SetVariable>
                 <SetVariable name="EnableButtonMaxSize">22,36</SetVariable>
               </Template>
-              <Template src="skin:effect_meta_knob.xml"/>
+              <Template src="skins:Deere/effect_meta_knob.xml"/>
             </Children>
           </WidgetGroup>
 
@@ -48,53 +48,53 @@ Variables:
             <SizePolicy>me,min</SizePolicy>
             <Layout>horizontal</Layout>
             <Children>
-              <Template src="skin:effect_parameter_knob.xml">
+              <Template src="skins:Deere/effect_parameter_knob.xml">
                 <SetVariable name="EffectParameter">1</SetVariable>
               </Template>
-              <Template src="skin:effect_parameter_knob.xml">
+              <Template src="skins:Deere/effect_parameter_knob.xml">
                 <SetVariable name="EffectParameter">2</SetVariable>
               </Template>
-              <Template src="skin:effect_parameter_knob.xml">
+              <Template src="skins:Deere/effect_parameter_knob.xml">
                 <SetVariable name="EffectParameter">3</SetVariable>
               </Template>
-              <Template src="skin:effect_parameter_knob.xml">
+              <Template src="skins:Deere/effect_parameter_knob.xml">
                 <SetVariable name="EffectParameter">4</SetVariable>
               </Template>
-              <Template src="skin:effect_parameter_knob.xml">
+              <Template src="skins:Deere/effect_parameter_knob.xml">
                 <SetVariable name="EffectParameter">5</SetVariable>
               </Template>
-              <Template src="skin:effect_parameter_knob.xml">
+              <Template src="skins:Deere/effect_parameter_knob.xml">
                 <SetVariable name="EffectParameter">6</SetVariable>
               </Template>
-              <Template src="skin:effect_parameter_knob.xml">
+              <Template src="skins:Deere/effect_parameter_knob.xml">
                 <SetVariable name="EffectParameter">7</SetVariable>
               </Template>
-              <Template src="skin:effect_parameter_knob.xml">
+              <Template src="skins:Deere/effect_parameter_knob.xml">
                 <SetVariable name="EffectParameter">8</SetVariable>
               </Template>
 
-              <Template src="skin:effect_parameter_button.xml">
+              <Template src="skins:Deere/effect_parameter_button.xml">
                 <SetVariable name="EffectButtonParameter">1</SetVariable>
               </Template>
-              <Template src="skin:effect_parameter_button.xml">
+              <Template src="skins:Deere/effect_parameter_button.xml">
                 <SetVariable name="EffectButtonParameter">2</SetVariable>
               </Template>
-              <Template src="skin:effect_parameter_button.xml">
+              <Template src="skins:Deere/effect_parameter_button.xml">
                 <SetVariable name="EffectButtonParameter">3</SetVariable>
               </Template>
-              <Template src="skin:effect_parameter_button.xml">
+              <Template src="skins:Deere/effect_parameter_button.xml">
                 <SetVariable name="EffectButtonParameter">4</SetVariable>
               </Template>
-              <Template src="skin:effect_parameter_button.xml">
+              <Template src="skins:Deere/effect_parameter_button.xml">
                 <SetVariable name="EffectButtonParameter">5</SetVariable>
               </Template>
-              <Template src="skin:effect_parameter_button.xml">
+              <Template src="skins:Deere/effect_parameter_button.xml">
                 <SetVariable name="EffectButtonParameter">6</SetVariable>
               </Template>
-              <Template src="skin:effect_parameter_button.xml">
+              <Template src="skins:Deere/effect_parameter_button.xml">
                 <SetVariable name="EffectButtonParameter">7</SetVariable>
               </Template>
-              <Template src="skin:effect_parameter_button.xml">
+              <Template src="skins:Deere/effect_parameter_button.xml">
                 <SetVariable name="EffectButtonParameter">8</SetVariable>
               </Template>
             </Children>

--- a/res/skins/Deere/effect_unit.xml
+++ b/res/skins/Deere/effect_unit.xml
@@ -17,8 +17,8 @@
         <Layout>horizontal</Layout>
         <SizePolicy>min,max</SizePolicy>
         <Children>
-          <Template src="skin:effect_unit_no_parameters.xml"/>
-          <Template src="skin:effect_unit_controls.xml"/>
+          <Template src="skins:Deere/effect_unit_no_parameters.xml"/>
+          <Template src="skins:Deere/effect_unit_controls.xml"/>
         </Children>
         <Connection>
           <ConfigKey><Variable name="group"/>,show_parameters</ConfigKey>
@@ -31,8 +31,8 @@
         <Layout>horizontal</Layout>
         <SizePolicy>min,min</SizePolicy>
         <Children>
-          <Template src="skin:effect_unit_with_parameters.xml"/>
-          <Template src="skin:effect_unit_controls.xml"/>
+          <Template src="skins:Deere/effect_unit_with_parameters.xml"/>
+          <Template src="skins:Deere/effect_unit_controls.xml"/>
         </Children>
         <Connection>
           <ConfigKey><Variable name="group"/>,show_parameters</ConfigKey>

--- a/res/skins/Deere/effect_unit_controls.xml
+++ b/res/skins/Deere/effect_unit_controls.xml
@@ -29,7 +29,7 @@
               <BindProperty>visible</BindProperty>
             </Connection>
             <Children>
-              <Template src="skin:knob.xml">
+              <Template src="skins:Deere/knob.xml">
                 <SetVariable name="TooltipId">EffectUnit_super1</SetVariable>
                 <SetVariable name="control">super1</SetVariable>
                 <SetVariable name="color">blue_gapless</SetVariable>
@@ -44,13 +44,13 @@
           <WidgetGroup>
             <Layout>vertical</Layout>
             <Children>
-              <Template src="skin:knob.xml">
+              <Template src="skins:Deere/knob.xml">
                 <SetVariable name="TooltipId">EffectUnit_mix</SetVariable>
                 <SetVariable name="control">mix</SetVariable>
                 <SetVariable name="color">purple_gapless</SetVariable>
               </Template>
 
-              <Template src="skin:left_2state_button.xml">
+              <Template src="skins:Deere/left_2state_button.xml">
                 <SetVariable name="ObjectName">EffectUnitMixModeButton</SetVariable>
                 <SetVariable name="TooltipId">EffectUnit_mix_mode</SetVariable>
                 <SetVariable name="MinimumSize">40,20</SetVariable>
@@ -110,13 +110,13 @@
                 <Layout>vertical</Layout>
                 <SizePolicy>min,min</SizePolicy>
                 <Children>
-                  <Template src="skin:knob.xml">
+                  <Template src="skins:Deere/knob.xml">
                     <SetVariable name="TooltipId">EffectUnit_mix</SetVariable>
                     <SetVariable name="control">mix</SetVariable>
                     <SetVariable name="color">purple_gapless</SetVariable>
                   </Template>
 
-                  <Template src="skin:left_2state_button.xml">
+                  <Template src="skins:Deere/left_2state_button.xml">
                     <SetVariable name="ObjectName">EffectUnitMixModeButton</SetVariable>
                     <SetVariable name="TooltipId">EffectUnit_mix_mode</SetVariable>
                     <SetVariable name="MinimumSize">40,20</SetVariable>
@@ -139,7 +139,7 @@
                 </Connection>
                 <Children>
                   <WidgetGroup><Size>0min,2f</Size></WidgetGroup>
-                  <Template src="skin:knob.xml">
+                  <Template src="skins:Deere/knob.xml">
                     <SetVariable name="TooltipId">EffectUnit_super1</SetVariable>
                     <SetVariable name="control">super1</SetVariable>
                     <SetVariable name="color">blue_gapless</SetVariable>
@@ -161,7 +161,7 @@
             <Layout>horizontal</Layout>
             <SizePolicy>min,max</SizePolicy>
             <Children>
-              <Template src="skin:left_2state_button.xml">
+              <Template src="skins:Deere/left_2state_button.xml">
                 <SetVariable name="TooltipId">EffectUnit_headphones_enabled</SetVariable>
                 <SetVariable name="ObjectName">FxAssignmentButton</SetVariable>
                 <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>

--- a/res/skins/Deere/effect_unit_no_parameters.xml
+++ b/res/skins/Deere/effect_unit_no_parameters.xml
@@ -27,15 +27,15 @@ Variables:
             <Layout>horizontal</Layout>
             <SizePolicy>min,min</SizePolicy>
             <Children>
-              <Template src="skin:effect_single_no_parameters.xml">
+              <Template src="skins:Deere/effect_single_no_parameters.xml">
                 <SetVariable name="Effect">1</SetVariable>
               </Template>
 
-              <Template src="skin:effect_single_no_parameters.xml">
+              <Template src="skins:Deere/effect_single_no_parameters.xml">
                 <SetVariable name="Effect">2</SetVariable>
               </Template>
 
-              <Template src="skin:effect_single_no_parameters.xml">
+              <Template src="skins:Deere/effect_single_no_parameters.xml">
                 <SetVariable name="Effect">3</SetVariable>
               </Template>
             </Children>

--- a/res/skins/Deere/effect_unit_with_parameters.xml
+++ b/res/skins/Deere/effect_unit_with_parameters.xml
@@ -23,15 +23,15 @@ Variables:
         <Layout>vertical</Layout>
         <Children>
 
-          <Template src="skin:effect_single_with_parameters.xml">
+          <Template src="skins:Deere/effect_single_with_parameters.xml">
             <SetVariable name="Effect">1</SetVariable>
           </Template>
 
-          <Template src="skin:effect_single_with_parameters.xml">
+          <Template src="skins:Deere/effect_single_with_parameters.xml">
             <SetVariable name="Effect">2</SetVariable>
           </Template>
 
-          <Template src="skin:effect_single_with_parameters.xml">
+          <Template src="skins:Deere/effect_single_with_parameters.xml">
             <SetVariable name="Effect">3</SetVariable>
           </Template>
 

--- a/res/skins/Deere/fx_unit_group_assignment_button.xml
+++ b/res/skins/Deere/fx_unit_group_assignment_button.xml
@@ -1,5 +1,5 @@
 <Template>
-  <Template src="skin:left_2state_button.xml">
+  <Template src="skins:Deere/left_2state_button.xml">
     <SetVariable name="TooltipId">EffectUnit_<Variable name="SourceType"/>_enabled</SetVariable>
     <SetVariable name="ObjectName">FxAssignmentButton</SetVariable>
     <SetVariable name="MinimumSize"><Variable name="FXAssignmentButtonMinimumSize"/></SetVariable>

--- a/res/skins/Deere/hotcues.xml
+++ b/res/skins/Deere/hotcues.xml
@@ -18,10 +18,10 @@
         <Layout>horizontal</Layout>
         <SizePolicy>me,min</SizePolicy>
         <Children>
-          <Template src="skin:hotcue_button.xml">
+          <Template src="skins:Deere/hotcue_button.xml">
             <SetVariable name="hotcue">1</SetVariable>
           </Template>
-          <Template src="skin:hotcue_button.xml">
+          <Template src="skins:Deere/hotcue_button.xml">
             <SetVariable name="hotcue">2</SetVariable>
           </Template>
         </Children>
@@ -32,10 +32,10 @@
         <Layout>horizontal</Layout>
         <SizePolicy>me,min</SizePolicy>
         <Children>
-          <Template src="skin:hotcue_button.xml">
+          <Template src="skins:Deere/hotcue_button.xml">
             <SetVariable name="hotcue">3</SetVariable>
           </Template>
-          <Template src="skin:hotcue_button.xml">
+          <Template src="skins:Deere/hotcue_button.xml">
             <SetVariable name="hotcue">4</SetVariable>
           </Template>
         </Children>
@@ -62,16 +62,16 @@
         <Layout>horizontal</Layout>
         <SizePolicy>me,min</SizePolicy>
         <Children>
-          <Template src="skin:hotcue_button.xml">
+          <Template src="skins:Deere/hotcue_button.xml">
             <SetVariable name="hotcue">1</SetVariable>
           </Template>
-          <Template src="skin:hotcue_button.xml">
+          <Template src="skins:Deere/hotcue_button.xml">
             <SetVariable name="hotcue">2</SetVariable>
           </Template>
-          <Template src="skin:hotcue_button.xml">
+          <Template src="skins:Deere/hotcue_button.xml">
             <SetVariable name="hotcue">3</SetVariable>
           </Template>
-          <Template src="skin:hotcue_button.xml">
+          <Template src="skins:Deere/hotcue_button.xml">
             <SetVariable name="hotcue">4</SetVariable>
           </Template>
         </Children>
@@ -82,16 +82,16 @@
         <Layout>horizontal</Layout>
         <SizePolicy>me,min</SizePolicy>
         <Children>
-          <Template src="skin:hotcue_button.xml">
+          <Template src="skins:Deere/hotcue_button.xml">
             <SetVariable name="hotcue">5</SetVariable>
           </Template>
-          <Template src="skin:hotcue_button.xml">
+          <Template src="skins:Deere/hotcue_button.xml">
             <SetVariable name="hotcue">6</SetVariable>
           </Template>
-          <Template src="skin:hotcue_button.xml">
+          <Template src="skins:Deere/hotcue_button.xml">
             <SetVariable name="hotcue">7</SetVariable>
           </Template>
-          <Template src="skin:hotcue_button.xml">
+          <Template src="skins:Deere/hotcue_button.xml">
             <SetVariable name="hotcue">8</SetVariable>
           </Template>
         </Children>

--- a/res/skins/Deere/knob_with_button.xml
+++ b/res/skins/Deere/knob_with_button.xml
@@ -11,7 +11,7 @@
   <WidgetGroup>
     <Layout>vertical</Layout>
     <Children>
-      <Template src="skin:knob.xml"/>
+      <Template src="skins:Deere/knob.xml"/>
       <WidgetGroup>
         <Layout>horizontal</Layout>
         <Children>

--- a/res/skins/Deere/knob_with_button_left.xml
+++ b/res/skins/Deere/knob_with_button_left.xml
@@ -34,7 +34,7 @@
         </Connection>
       </PushButton>
 
-      <Template src="skin:knob.xml"/>
+      <Template src="skins:Deere/knob.xml"/>
 
     </Children>
   </WidgetGroup>

--- a/res/skins/Deere/knob_with_button_right.xml
+++ b/res/skins/Deere/knob_with_button_right.xml
@@ -13,7 +13,7 @@
     <Layout>horizontal</Layout>
     <Children>
 
-      <Template src="skin:knob.xml"/>
+      <Template src="skins:Deere/knob.xml"/>
 
       <PushButton>
         <TooltipId><Variable name="button_TooltipId"/></TooltipId>

--- a/res/skins/Deere/knob_with_label.xml
+++ b/res/skins/Deere/knob_with_label.xml
@@ -9,7 +9,7 @@
   <WidgetGroup>
     <Layout>vertical</Layout>
     <Children>
-      <Template src="skin:knob.xml"/>
+      <Template src="skins:Deere/knob.xml"/>
       <Label>
         <Size>40f,11f</Size>
         <ObjectName>KnobLabel</ObjectName>

--- a/res/skins/Deere/left_gutter.xml
+++ b/res/skins/Deere/left_gutter.xml
@@ -9,14 +9,14 @@
     <Layout>vertical</Layout>
     <SizePolicy>me,me</SizePolicy>
     <Children>
-      <Template src="skin:deck.xml">
+      <Template src="skins:Deere/deck.xml">
         <SetVariable name="i">1</SetVariable>
       </Template>
 
       <WidgetGroup>
         <Layout>horizontal</Layout>
         <Children>
-          <Template src="skin:deck.xml">
+          <Template src="skins:Deere/deck.xml">
             <SetVariable name="i">3</SetVariable>
           </Template>
         </Children>

--- a/res/skins/Deere/library.xml
+++ b/res/skins/Deere/library.xml
@@ -29,12 +29,12 @@
               <WidgetGroup>
                 <Layout>vertical</Layout>
                 <Children>
-                  <Template src="skin:preview_deck.xml"/>
+                  <Template src="skins:Deere/preview_deck.xml"/>
                   <WidgetGroup>
                     <Layout>horizontal</Layout>
                     <Children>
                       <SearchBox></SearchBox>
-                      <Template src="skin:hide_show_button.xml">
+                      <Template src="skins:Deere/hide_show_button.xml">
                         <SetVariable name="TooltipId">maximize_library</SetVariable>
                         <SetVariable name="object_name">LibraryToggle</SetVariable>
                         <SetVariable name="control">[Skin],show_maximized_library</SetVariable>

--- a/res/skins/Deere/main_decks.xml
+++ b/res/skins/Deere/main_decks.xml
@@ -8,9 +8,9 @@
     <Layout>horizontal</Layout>
     <SizePolicy>me,max</SizePolicy>
     <Children>
-      <Template src="skin:left_gutter.xml"/>
-      <Template src="skin:mixer.xml"/>
-      <Template src="skin:right_gutter.xml"/>
+      <Template src="skins:Deere/left_gutter.xml"/>
+      <Template src="skins:Deere/mixer.xml"/>
+      <Template src="skins:Deere/right_gutter.xml"/>
     </Children>
   </WidgetGroup>
 </Template>

--- a/res/skins/Deere/microphone.xml
+++ b/res/skins/Deere/microphone.xml
@@ -40,12 +40,12 @@
                 <Layout>horizontal</Layout>
                 <Children>
 
-                  <Template src="skin:knob.xml">
+                  <Template src="skins:Deere/knob.xml">
                     <SetVariable name="TooltipId">microphone_pregain</SetVariable>
                     <SetVariable name="control">pregain</SetVariable>
                     <SetVariable name="color">green</SetVariable>
                   </Template>
-                  <Template src="skin:vumeter.xml">
+                  <Template src="skins:Deere/vumeter.xml">
                     <SetVariable name="TooltipId">microphone_VuMeter</SetVariable>
                     <SetVariable name="Size">5f,42f</SetVariable>
                     <SetVariable name="control">vu_meter</SetVariable>
@@ -69,7 +69,7 @@
                 <Layout>horizontal</Layout>
                 <Children>
 
-                  <Template src="skin:left_2state_button.xml">
+                  <Template src="skins:Deere/left_2state_button.xml">
                     <SetVariable name="TooltipId">microphone_talkover</SetVariable>
                     <SetVariable name="ObjectName">MicTalkButton</SetVariable>
                     <SetVariable name="MinimumSize">32,22</SetVariable>
@@ -80,7 +80,7 @@
                     <SetVariable name="left_connection_control"><Variable name="group"/>,talkover</SetVariable>
                   </Template>
 
-                  <Template src="skin:left_2state_button.xml">
+                  <Template src="skins:Deere/left_2state_button.xml">
                     <SetVariable name="TooltipId">pfl</SetVariable>
                     <SetVariable name="ObjectName">MicPFLButton</SetVariable>
                     <SetVariable name="MinimumSize">18,22</SetVariable>
@@ -102,12 +102,12 @@
                 <ObjectName>ButtonGrid</ObjectName>
                 <Layout>horizontal</Layout>
                 <Children>
-                  <Template src="skin:fx_unit_group_assignment_button.xml">
+                  <Template src="skins:Deere/fx_unit_group_assignment_button.xml">
                     <SetVariable name="EffectUnit">1</SetVariable>
                     <SetVariable name="SourceType">microphone</SetVariable>
                   </Template>
 
-                  <Template src="skin:fx_unit_group_assignment_button.xml">
+                  <Template src="skins:Deere/fx_unit_group_assignment_button.xml">
                     <SetVariable name="EffectUnit">2</SetVariable>
                     <SetVariable name="SourceType">microphone</SetVariable>
                   </Template>
@@ -118,7 +118,7 @@
               <WidgetGroup>
                 <Layout>horizontal</Layout>
                 <Children>
-                  <Template src="skin:fx_unit_group_assignment_button.xml">
+                  <Template src="skins:Deere/fx_unit_group_assignment_button.xml">
                     <SetVariable name="EffectUnit">3</SetVariable>
                     <SetVariable name="SourceType">microphone</SetVariable>
                   </Template>
@@ -126,7 +126,7 @@
                   <!-- Workaround for layout spacing -->
                   <WidgetGroup><Size>2f,0min</Size></WidgetGroup>
 
-                  <Template src="skin:fx_unit_group_assignment_button.xml">
+                  <Template src="skins:Deere/fx_unit_group_assignment_button.xml">
                     <SetVariable name="EffectUnit">4</SetVariable>
                     <SetVariable name="SourceType">microphone</SetVariable>
                   </Template>

--- a/res/skins/Deere/microphone_rack.xml
+++ b/res/skins/Deere/microphone_rack.xml
@@ -21,27 +21,27 @@
             to the preferences pane for easy set up. Once Mic 1 is
             set up, this widget hides itself. -->
 
-          <Template src="skin:microphone.xml"/>
-          <Template src="skin:microphone_unconfigured.xml"/>
+          <Template src="skins:Deere/microphone.xml"/>
+          <Template src="skins:Deere/microphone_unconfigured.xml"/>
 
-          <Template src="skin:microphone.xml">
+          <Template src="skins:Deere/microphone.xml">
             <SetVariable name="i">2</SetVariable>
           </Template>
-          <Template src="skin:microphone_unconfigured.xml">
+          <Template src="skins:Deere/microphone_unconfigured.xml">
             <SetVariable name="i">2</SetVariable>
           </Template>
 
-          <Template src="skin:microphone.xml">
+          <Template src="skins:Deere/microphone.xml">
             <SetVariable name="i">3</SetVariable>
           </Template>
-          <Template src="skin:microphone_unconfigured.xml">
+          <Template src="skins:Deere/microphone_unconfigured.xml">
             <SetVariable name="i">3</SetVariable>
           </Template>
 
-          <Template src="skin:microphone.xml">
+          <Template src="skins:Deere/microphone.xml">
             <SetVariable name="i">4</SetVariable>
           </Template>
-          <Template src="skin:microphone_unconfigured.xml">
+          <Template src="skins:Deere/microphone_unconfigured.xml">
             <SetVariable name="i">4</SetVariable>
           </Template>
 
@@ -90,7 +90,7 @@
 
                   <!-- knob_with_label.xml template will not work here because
                   "Strength" label exceeds width of knob. -->
-                  <Template src="skin:knob.xml">
+                  <Template src="skins:Deere/knob.xml">
                     <SetVariable name="group">[Master]</SetVariable>
                     <SetVariable name="control">duckStrength</SetVariable>
                     <SetVariable name="TooltipId">talkover_duck_strength</SetVariable>
@@ -122,31 +122,31 @@
 
           <!-- Auxiliary input controls -->
 
-          <Template src="skin:auxiliary.xml">
+          <Template src="skins:Deere/auxiliary.xml">
             <SetVariable name="i">1</SetVariable>
           </Template>
-          <Template src="skin:auxiliary_unconfigured.xml">
+          <Template src="skins:Deere/auxiliary_unconfigured.xml">
             <SetVariable name="i">1</SetVariable>
           </Template>
 
-          <Template src="skin:auxiliary.xml">
+          <Template src="skins:Deere/auxiliary.xml">
             <SetVariable name="i">2</SetVariable>
           </Template>
-          <Template src="skin:auxiliary_unconfigured.xml">
+          <Template src="skins:Deere/auxiliary_unconfigured.xml">
             <SetVariable name="i">2</SetVariable>
           </Template>
 
-          <Template src="skin:auxiliary.xml">
+          <Template src="skins:Deere/auxiliary.xml">
             <SetVariable name="i">3</SetVariable>
           </Template>
-          <Template src="skin:auxiliary_unconfigured.xml">
+          <Template src="skins:Deere/auxiliary_unconfigured.xml">
             <SetVariable name="i">3</SetVariable>
           </Template>
 
-          <Template src="skin:auxiliary.xml">
+          <Template src="skins:Deere/auxiliary.xml">
             <SetVariable name="i">4</SetVariable>
           </Template>
-          <Template src="skin:auxiliary_unconfigured.xml">
+          <Template src="skins:Deere/auxiliary_unconfigured.xml">
             <SetVariable name="i">4</SetVariable>
           </Template>
 

--- a/res/skins/Deere/microphone_unconfigured.xml
+++ b/res/skins/Deere/microphone_unconfigured.xml
@@ -38,7 +38,7 @@
             <Layout>horizontal</Layout>
             <SizePolicy>min,me</SizePolicy>
             <Children>
-              <Template src="skin:left_1state_button.xml">
+              <Template src="skins:Deere/left_1state_button.xml">
                 <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
                 <SetVariable name="MaximumSize"><Variable name="SquareButtonMaximumSize"/></SetVariable>
                 <SetVariable name="SizePolicy"><Variable name="SquareButtonSizePolicy"/></SetVariable>

--- a/res/skins/Deere/mixer.xml
+++ b/res/skins/Deere/mixer.xml
@@ -27,11 +27,11 @@
                   <WidgetGroup>
                     <Layout>horizontal</Layout>
                     <Children>
-                      <Template src="skin:mixer_controls_2decks_left.xml">
+                      <Template src="skins:Deere/mixer_controls_2decks_left.xml">
                         <SetVariable name="i">1</SetVariable>
                       </Template>
-                      <Template src="skin:mixer_column_main_vu_2decks.xml"/>
-                      <Template src="skin:mixer_controls_2decks_right.xml">
+                      <Template src="skins:Deere/mixer_column_main_vu_2decks.xml"/>
+                      <Template src="skins:Deere/mixer_controls_2decks_right.xml">
                         <SetVariable name="i">2</SetVariable>
                       </Template>
                     </Children>
@@ -92,21 +92,21 @@
                 <Layout>horizontal</Layout>
                 <Children>
                   <!-- See comments in the templates for explanation of the modes -->
-                  <Template src="skin:mixer_controls_4decks_left.xml">
+                  <Template src="skins:Deere/mixer_controls_4decks_left.xml">
                     <SetVariable name="i">3</SetVariable>
                   </Template>
-                  <Template src="skin:mixer_controls_4decks_left.xml">
+                  <Template src="skins:Deere/mixer_controls_4decks_left.xml">
                     <SetVariable name="i">1</SetVariable>
                   </Template>
                   <!-- The 4-deck main VU meter column contains the same
                       structure and mechanisms as the left/right channel controls.
                       When altering those remember to change i.e. <MaximumSize>
                       and fixed spacers there as well -->
-                  <Template src="skin:mixer_column_main_vu_4decks.xml"/>
-                  <Template src="skin:mixer_controls_4decks_right.xml">
+                  <Template src="skins:Deere/mixer_column_main_vu_4decks.xml"/>
+                  <Template src="skins:Deere/mixer_controls_4decks_right.xml">
                     <SetVariable name="i">2</SetVariable>
                   </Template>
-                  <Template src="skin:mixer_controls_4decks_right.xml">
+                  <Template src="skins:Deere/mixer_controls_4decks_right.xml">
                     <SetVariable name="i">4</SetVariable>
                   </Template>
                 </Children>
@@ -140,7 +140,7 @@
                     <Layout>vertical</Layout>
                     <Size>28f,22f</Size>
                     <Children>
-                      <Template src="skin:crossfader_orientation_button.xml">
+                      <Template src="skins:Deere/crossfader_orientation_button.xml">
                         <SetVariable name="group">[Channel1]</SetVariable>
                         <SetVariable name="Unit">Deck1</SetVariable>
                       </Template>
@@ -204,7 +204,7 @@
                     <Layout>vertical</Layout>
                     <Size>28f,22f</Size>
                     <Children>
-                      <Template src="skin:crossfader_orientation_button.xml">
+                      <Template src="skins:Deere/crossfader_orientation_button.xml">
                         <SetVariable name="group">[Channel2]</SetVariable>
                         <SetVariable name="Unit">Deck2</SetVariable>
                       </Template>

--- a/res/skins/Deere/mixer_column_eq_left.xml
+++ b/res/skins/Deere/mixer_column_eq_left.xml
@@ -9,19 +9,19 @@
     <Layout>vertical</Layout>
     <SizePolicy>min,p</SizePolicy>
     <Children>
-      <Template src="skin:equalizer_rack_parameter_left.xml">
+      <Template src="skins:Deere/equalizer_rack_parameter_left.xml">
         <SetVariable name="parameter">3</SetVariable>
       </Template>
 
-      <Template src="skin:equalizer_rack_parameter_left.xml">
+      <Template src="skins:Deere/equalizer_rack_parameter_left.xml">
         <SetVariable name="parameter">2</SetVariable>
       </Template>
 
-      <Template src="skin:equalizer_rack_parameter_left.xml">
+      <Template src="skins:Deere/equalizer_rack_parameter_left.xml">
         <SetVariable name="parameter">1</SetVariable>
       </Template>
 
-      <Template src="skin:quick_effect_superknob_left.xml">
+      <Template src="skins:Deere/quick_effect_superknob_left.xml">
         <SetVariable name="TooltipId">QuickEffectRack_super1</SetVariable>
         <SetVariable name="button_TooltipId">QuickEffectRack_enabled</SetVariable>
         <SetVariable name="color">blue</SetVariable>

--- a/res/skins/Deere/mixer_column_eq_right.xml
+++ b/res/skins/Deere/mixer_column_eq_right.xml
@@ -9,19 +9,19 @@
     <Layout>vertical</Layout>
     <SizePolicy>min,min</SizePolicy>
     <Children>
-      <Template src="skin:equalizer_rack_parameter_right.xml">
+      <Template src="skins:Deere/equalizer_rack_parameter_right.xml">
         <SetVariable name="parameter">3</SetVariable>
       </Template>
 
-      <Template src="skin:equalizer_rack_parameter_right.xml">
+      <Template src="skins:Deere/equalizer_rack_parameter_right.xml">
         <SetVariable name="parameter">2</SetVariable>
       </Template>
 
-      <Template src="skin:equalizer_rack_parameter_right.xml">
+      <Template src="skins:Deere/equalizer_rack_parameter_right.xml">
         <SetVariable name="parameter">1</SetVariable>
       </Template>
 
-      <Template src="skin:quick_effect_superknob_right.xml">
+      <Template src="skins:Deere/quick_effect_superknob_right.xml">
         <SetVariable name="TooltipId">QuickEffectRack_super1</SetVariable>
         <SetVariable name="button_TooltipId">QuickEffectRack_enabled</SetVariable>
         <SetVariable name="color">blue</SetVariable>

--- a/res/skins/Deere/mixer_column_main_vu_2decks.xml
+++ b/res/skins/Deere/mixer_column_main_vu_2decks.xml
@@ -20,7 +20,7 @@
         <Layout>horizontal</Layout>
         <SizePolicy>me,me</SizePolicy>
         <Children>
-          <Template src="skin:vumeter_main.xml"/>
+          <Template src="skins:Deere/vumeter_main.xml"/>
         </Children>
       </WidgetGroup>
 

--- a/res/skins/Deere/mixer_column_main_vu_4decks.xml
+++ b/res/skins/Deere/mixer_column_main_vu_4decks.xml
@@ -5,7 +5,7 @@
   <SingletonDefinition>
     <ObjectName>StereoVUMeterMain</ObjectName>
     <Children>
-      <Template src="skin:vumeter_main.xml"/>
+      <Template src="skins:Deere/vumeter_main.xml"/>
     </Children>
   </SingletonDefinition>
 
@@ -48,7 +48,7 @@
         </Connection>
         <Children>
 
-          <Template src="skin:mixer_spacer_topbottom.xml" />
+          <Template src="skins:Deere/mixer_spacer_topbottom.xml" />
 
           <!-- Gain knob spacer -->
           <WidgetGroup><Size>0me,34f</Size></WidgetGroup>
@@ -161,7 +161,7 @@
             </Children>
           </WidgetGroup>
 
-          <Template src="skin:mixer_spacer_topbottom.xml" />
+          <Template src="skins:Deere/mixer_spacer_topbottom.xml" />
 
         </Children>
       </WidgetGroup>

--- a/res/skins/Deere/mixer_column_pfl_levels.xml
+++ b/res/skins/Deere/mixer_column_pfl_levels.xml
@@ -14,7 +14,7 @@
         <ObjectName>ButtonContainer</ObjectName>
         <Layout>horizontal</Layout>
         <Children>
-          <Template src="skin:left_2state_button.xml">
+          <Template src="skins:Deere/left_2state_button.xml">
             <SetVariable name="TooltipId">pfl</SetVariable>
             <SetVariable name="ObjectName">DeckPFLButton</SetVariable>
             <SetVariable name="MinimumSize">22,22</SetVariable>
@@ -41,13 +41,13 @@
             <Layout>horizontal</Layout>
             <MaximumSize>22,150</MaximumSize>
             <Children>
-              <Template src="skin:vumeter_v.xml">
+              <Template src="skins:Deere/vumeter_v.xml">
                 <SetVariable name="group"><Variable name="group"/></SetVariable>
                 <SetVariable name="side">_left</SetVariable>
                 <SetVariable name="tooltip_meter">channel_VuMeterL</SetVariable>
                 <SetVariable name="tooltip_clip">channel_peak_indicator_left</SetVariable>
               </Template>
-              <Template src="skin:vumeter_v.xml">
+              <Template src="skins:Deere/vumeter_v.xml">
                 <SetVariable name="group"><Variable name="group"/></SetVariable>
                 <SetVariable name="side">_right</SetVariable>
                 <SetVariable name="tooltip_meter">channel_VuMeterR</SetVariable>
@@ -65,7 +65,7 @@
             <Layout>vertical</Layout>
             <Size>28f,28min</Size>
             <Children>
-              <Template src="skin:crossfader_orientation_button.xml">
+              <Template src="skins:Deere/crossfader_orientation_button.xml">
                 <SetVariable name="Unit">Deck<Variable name="i"/></SetVariable>
               </Template>
             </Children>

--- a/res/skins/Deere/mixer_column_volume_gain.xml
+++ b/res/skins/Deere/mixer_column_volume_gain.xml
@@ -16,7 +16,7 @@
         <MinimumSize>40,34</MinimumSize>
         <MaximumSize>40,46</MaximumSize>
         <Children>
-          <Template src="skin:knob.xml">
+          <Template src="skins:Deere/knob.xml">
             <SetVariable name="TooltipId">pregain</SetVariable>
             <SetVariable name="control">pregain</SetVariable>
             <SetVariable name="color">green</SetVariable>

--- a/res/skins/Deere/mixer_controls_2decks_left.xml
+++ b/res/skins/Deere/mixer_controls_2decks_left.xml
@@ -10,9 +10,9 @@
     <Layout>horizontal</Layout>
     <SizePolicy>min,min</SizePolicy>
     <Children>
-      <Template src="skin:mixer_column_eq_left.xml"/>
-      <Template src="skin:mixer_column_volume_gain.xml"/>
-      <Template src="skin:mixer_column_pfl_levels.xml"/>
+      <Template src="skins:Deere/mixer_column_eq_left.xml"/>
+      <Template src="skins:Deere/mixer_column_volume_gain.xml"/>
+      <Template src="skins:Deere/mixer_column_pfl_levels.xml"/>
     </Children>
   </WidgetGroup>
 </Template>

--- a/res/skins/Deere/mixer_controls_2decks_right.xml
+++ b/res/skins/Deere/mixer_controls_2decks_right.xml
@@ -10,9 +10,9 @@
     <Layout>horizontal</Layout>
     <SizePolicy>min,min</SizePolicy>
     <Children>
-      <Template src="skin:mixer_column_pfl_levels.xml"/>
-      <Template src="skin:mixer_column_volume_gain.xml"/>
-      <Template src="skin:mixer_column_eq_right.xml"/>
+      <Template src="skins:Deere/mixer_column_pfl_levels.xml"/>
+      <Template src="skins:Deere/mixer_column_volume_gain.xml"/>
+      <Template src="skins:Deere/mixer_column_eq_right.xml"/>
     </Children>
   </WidgetGroup>
 </Template>

--- a/res/skins/Deere/mixer_controls_4decks_left.xml
+++ b/res/skins/Deere/mixer_controls_4decks_left.xml
@@ -49,20 +49,20 @@
         <SizePolicy>me,min</SizePolicy>
         <MaximumSize>-1,210</MaximumSize>
         <Children>
-          <Template src="skin:spacer_h.xml"/>
+          <Template src="skins:Deere/spacer_h.xml"/>
           <WidgetGroup>
             <ObjectName>channel_VuMeter_Group</ObjectName>
             <Layout>horizontal</Layout>
             <SizePolicy>min,me</SizePolicy>
             <MaximumSize>22,210</MaximumSize>
             <Children>
-              <Template src="skin:vumeter_v.xml">
+              <Template src="skins:Deere/vumeter_v.xml">
                 <SetVariable name="group"><Variable name="group"/></SetVariable>
                 <SetVariable name="side">_left</SetVariable>
                 <SetVariable name="tooltip_meter">channel_VuMeterL</SetVariable>
                 <SetVariable name="tooltip_clip">channel_peak_indicator_left</SetVariable>
               </Template>
-              <Template src="skin:vumeter_v.xml">
+              <Template src="skins:Deere/vumeter_v.xml">
                 <SetVariable name="group"><Variable name="group"/></SetVariable>
                 <SetVariable name="side">_right</SetVariable>
                 <SetVariable name="tooltip_meter">channel_VuMeterR</SetVariable>
@@ -81,7 +81,7 @@
     <Layout>vertical</Layout>
     <Children>
 
-      <Template src="skin:mixer_spacer_topbottom.xml" />
+      <Template src="skins:Deere/mixer_spacer_topbottom.xml" />
 
       <WidgetGroup>
         <Layout>horizontal</Layout>
@@ -89,7 +89,7 @@
         <Children>
           <!-- Expanding spacer to push EQ knob to right side -->
           <WidgetGroup><Size>0me,1min</Size></WidgetGroup>
-          <Template src="skin:knob.xml">
+          <Template src="skins:Deere/knob.xml">
             <SetVariable name="TooltipId">pregain</SetVariable>
             <SetVariable name="control">pregain</SetVariable>
             <SetVariable name="color">green</SetVariable>
@@ -101,7 +101,7 @@
         <Layout>horizontal</Layout>
         <SizePolicy>me,max</SizePolicy>
         <Children>
-          <Template src="skin:mixer_column_eq_left.xml"/>
+          <Template src="skins:Deere/mixer_column_eq_left.xml"/>
         </Children>
       </WidgetGroup>
 
@@ -132,7 +132,7 @@
             <Layout>horizontal</Layout>
             <SizePolicy>min,min</SizePolicy>
             <Children>
-              <Template src="skin:left_2state_button.xml">
+              <Template src="skins:Deere/left_2state_button.xml">
                 <SetVariable name="TooltipId">pfl</SetVariable>
                 <SetVariable name="ObjectName">DeckPFLButton</SetVariable>
                 <SetVariable name="MinimumSize">22,22</SetVariable>
@@ -170,7 +170,7 @@
                     <Layout>horizontal</Layout>
                     <ObjectName>4DecksMixerMonoMeterLeft</ObjectName>
                     <Children>
-                      <Template src="skin:vumeter_v.xml">
+                      <Template src="skins:Deere/vumeter_v.xml">
                         <SetVariable name="group"><Variable name="group"/></SetVariable>
                         <SetVariable name="tooltip_meter">channel_VuMeter</SetVariable>
                         <SetVariable name="tooltip_clip">channel_peak_indicator</SetVariable>
@@ -278,7 +278,7 @@
             <Layout>horizontal</Layout>
             <SizePolicy>min,min</SizePolicy>
             <Children>
-              <Template src="skin:crossfader_orientation_button.xml">
+              <Template src="skins:Deere/crossfader_orientation_button.xml">
                 <SetVariable name="Unit">Deck<Variable name="i"/></SetVariable>
               </Template>
             </Children>
@@ -287,7 +287,7 @@
         </Children>
       </WidgetGroup>
 
-      <Template src="skin:mixer_spacer_topbottom.xml" />
+      <Template src="skins:Deere/mixer_spacer_topbottom.xml" />
 
     </Children>
   </WidgetGroup>

--- a/res/skins/Deere/mixer_controls_4decks_right.xml
+++ b/res/skins/Deere/mixer_controls_4decks_right.xml
@@ -56,13 +56,13 @@
             <SizePolicy>min,me</SizePolicy>
             <MaximumSize>22,210</MaximumSize>
             <Children>
-              <Template src="skin:vumeter_v.xml">
+              <Template src="skins:Deere/vumeter_v.xml">
                 <SetVariable name="group"><Variable name="group"/></SetVariable>
                 <SetVariable name="side">_left</SetVariable>
                 <SetVariable name="tooltip_meter">channel_VuMeterL</SetVariable>
                 <SetVariable name="tooltip_clip">channel_peak_indicator_left</SetVariable>
               </Template>
-              <Template src="skin:vumeter_v.xml">
+              <Template src="skins:Deere/vumeter_v.xml">
                 <SetVariable name="group"><Variable name="group"/></SetVariable>
                 <SetVariable name="side">_right</SetVariable>
                 <SetVariable name="tooltip_meter">channel_VuMeterR</SetVariable>
@@ -70,7 +70,7 @@
               </Template>
             </Children>
           </WidgetGroup>
-          <Template src="skin:spacer_h.xml"/>
+          <Template src="skins:Deere/spacer_h.xml"/>
         </Children>
       </WidgetGroup>
     </Children>
@@ -81,13 +81,13 @@
     <Layout>vertical</Layout>
     <Children>
 
-      <Template src="skin:mixer_spacer_topbottom.xml" />
+      <Template src="skins:Deere/mixer_spacer_topbottom.xml" />
 
       <WidgetGroup>
         <Layout>horizontal</Layout>
         <SizePolicy>me,min</SizePolicy>
         <Children>
-          <Template src="skin:knob.xml">
+          <Template src="skins:Deere/knob.xml">
             <SetVariable name="TooltipId">pregain</SetVariable>
             <SetVariable name="control">pregain</SetVariable>
             <SetVariable name="color">green</SetVariable>
@@ -101,7 +101,7 @@
         <Layout>horizontal</Layout>
         <SizePolicy>me,max</SizePolicy>
         <Children>
-          <Template src="skin:mixer_column_eq_right.xml"/>
+          <Template src="skins:Deere/mixer_column_eq_right.xml"/>
         </Children>
       </WidgetGroup>
 
@@ -132,7 +132,7 @@
             <Layout>horizontal</Layout>
             <SizePolicy>min,min</SizePolicy>
             <Children>
-              <Template src="skin:left_2state_button.xml">
+              <Template src="skins:Deere/left_2state_button.xml">
                 <SetVariable name="TooltipId">pfl</SetVariable>
                 <SetVariable name="ObjectName">DeckPFLButton</SetVariable>
                 <SetVariable name="MinimumSize">22,22</SetVariable>
@@ -182,7 +182,7 @@
                     <Layout>horizontal</Layout>
                     <ObjectName>4DecksMixerMonoMeterRight</ObjectName>
                     <Children>
-                      <Template src="skin:vumeter_v.xml">
+                      <Template src="skins:Deere/vumeter_v.xml">
                         <SetVariable name="group"><Variable name="group"/></SetVariable>
                         <SetVariable name="tooltip_meter">channel_VuMeter</SetVariable>
                         <SetVariable name="tooltip_clip">channel_peak_indicator</SetVariable>
@@ -277,7 +277,7 @@
             <Layout>horizontal</Layout>
             <SizePolicy>min,min</SizePolicy>
             <Children>
-              <Template src="skin:crossfader_orientation_button.xml">
+              <Template src="skins:Deere/crossfader_orientation_button.xml">
                 <SetVariable name="Unit">Deck<Variable name="i"/></SetVariable>
               </Template>
             </Children>
@@ -286,7 +286,7 @@
         </Children>
       </WidgetGroup>
 
-      <Template src="skin:mixer_spacer_topbottom.xml" />
+      <Template src="skins:Deere/mixer_spacer_topbottom.xml" />
 
     </Children>
   </WidgetGroup>

--- a/res/skins/Deere/preview_deck.xml
+++ b/res/skins/Deere/preview_deck.xml
@@ -36,7 +36,7 @@
                     <Elide>right</Elide>
                   </TrackProperty>
 
-                  <Template src="skin:left_1state_button.xml">
+                  <Template src="skins:Deere/left_1state_button.xml">
                     <SetVariable name="TooltipId">eject</SetVariable>
                     <SetVariable name="ObjectName">PreviewDeckEjectButton</SetVariable>
                     <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
@@ -70,7 +70,7 @@
                 <ObjectName>PreviewDeckVisualRow</ObjectName>
                 <Layout>horizontal</Layout>
                 <Children>
-                  <Template src="skin:left_right_2state_button.xml">
+                  <Template src="skins:Deere/left_right_2state_button.xml">
                     <SetVariable name="TooltipId">play_start</SetVariable>
                     <SetVariable name="ObjectName">PreviewDeckPlayButton</SetVariable>
                     <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
@@ -129,7 +129,7 @@
             <SizePolicy>min,me</SizePolicy>
             <Layout>vertical</Layout>
             <Children>
-              <Template src="skin:vumeter.xml">
+              <Template src="skins:Deere/vumeter.xml">
                 <SetVariable name="TooltipId">channel_VuMeter</SetVariable>
                 <SetVariable name="control">vu_meter</SetVariable>
               </Template>

--- a/res/skins/Deere/quick_effect_superknob_left.xml
+++ b/res/skins/Deere/quick_effect_superknob_left.xml
@@ -45,7 +45,7 @@
         </Connection>
       </WidgetGroup>
 
-      <Template src="skin:knob.xml">
+      <Template src="skins:Deere/knob.xml">
         <SetVariable name="group"><Variable name="QuickEffectUnitGroup"/></SetVariable>
         <SetVariable name="control">super1</SetVariable>
         <SetVariable name="color"><Variable name="color"/></SetVariable>

--- a/res/skins/Deere/quick_effect_superknob_right.xml
+++ b/res/skins/Deere/quick_effect_superknob_right.xml
@@ -14,7 +14,7 @@
     <SizePolicy>me,me</SizePolicy>
     <Children>
 
-      <Template src="skin:knob.xml">
+      <Template src="skins:Deere/knob.xml">
         <SetVariable name="group"><Variable name="QuickEffectUnitGroup"/></SetVariable>
         <SetVariable name="control">super1</SetVariable>
         <SetVariable name="color"><Variable name="color"/></SetVariable>

--- a/res/skins/Deere/right_gutter.xml
+++ b/res/skins/Deere/right_gutter.xml
@@ -9,14 +9,14 @@
     <Layout>vertical</Layout>
     <SizePolicy>me,min</SizePolicy>
     <Children>
-      <Template src="skin:deck.xml">
+      <Template src="skins:Deere/deck.xml">
         <SetVariable name="i">2</SetVariable>
       </Template>
 
       <WidgetGroup>
         <Layout>horizontal</Layout>
         <Children>
-          <Template src="skin:deck.xml">
+          <Template src="skins:Deere/deck.xml">
             <SetVariable name="i">4</SetVariable>
           </Template>
         </Children>

--- a/res/skins/Deere/sample_decks.xml
+++ b/res/skins/Deere/sample_decks.xml
@@ -7,7 +7,7 @@
   <SingletonDefinition>
     <ObjectName>SamplerRow1</ObjectName>
     <Children>
-      <Template src="skin:sampler_row.xml">
+      <Template src="skins:Deere/sampler_row.xml">
         <SetVariable name="row">1</SetVariable>
         <SetVariable name="1">1</SetVariable>
         <SetVariable name="2">2</SetVariable>
@@ -24,7 +24,7 @@
   <SingletonDefinition>
     <ObjectName>SamplerRow2</ObjectName>
     <Children>
-      <Template src="skin:sampler_row.xml">
+      <Template src="skins:Deere/sampler_row.xml">
         <SetVariable name="row">2</SetVariable>
         <SetVariable name="1">9</SetVariable>
         <SetVariable name="2">10</SetVariable>

--- a/res/skins/Deere/sampler.xml
+++ b/res/skins/Deere/sampler.xml
@@ -13,7 +13,7 @@
     <Layout>vertical</Layout>
     <SizePolicy>me,f</SizePolicy>
     <Children>
-      <Template src="skin:sampler_text_row.xml"/>
+      <Template src="skins:Deere/sampler_text_row.xml"/>
       <WidgetGroup>
         <Connection>
           <ConfigKey>[Skin],sampler_row_<Variable name="row"/>_expanded</ConfigKey>
@@ -21,7 +21,7 @@
         </Connection>
         <Layout>horizontal</Layout>
         <Children>
-          <Template src="skin:sampler_controls_row.xml"/>
+          <Template src="skins:Deere/sampler_controls_row.xml"/>
         </Children>
       </WidgetGroup>
     </Children>

--- a/res/skins/Deere/sampler_controls_row.xml
+++ b/res/skins/Deere/sampler_controls_row.xml
@@ -15,7 +15,7 @@
       <WidgetGroup>
         <Layout>horizontal</Layout>
         <Children>
-          <Template src="skin:left_2state_button.xml">
+          <Template src="skins:Deere/left_2state_button.xml">
             <SetVariable name="TooltipId">repeat</SetVariable>
             <SetVariable name="ObjectName">RepeatButton</SetVariable>
             <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
@@ -78,13 +78,13 @@
         <Layout>horizontal</Layout>
         <ObjectName>ButtonGrid</ObjectName>
         <Children>
-          <Template src="skin:knob.xml">
+          <Template src="skins:Deere/knob.xml">
             <SetVariable name="TooltipId">pregain</SetVariable>
             <SetVariable name="control">pregain</SetVariable>
             <SetVariable name="color">green</SetVariable>
           </Template>
 
-          <Template src="skin:left_right_1state_button.xml">
+          <Template src="skins:Deere/left_right_1state_button.xml">
             <SetVariable name="TooltipId">beatsync_beatsync_tempo</SetVariable>
             <SetVariable name="ObjectName">BeatsyncButton</SetVariable>
             <SetVariable name="MinimumSize">32,22</SetVariable>
@@ -97,11 +97,11 @@
             <SetVariable name="right_connection_control"><Variable name="group"/>,beatsync_tempo</SetVariable>
           </Template>
 
-          <Template src="skin:crossfader_orientation_button.xml">
+          <Template src="skins:Deere/crossfader_orientation_button.xml">
             <SetVariable name="Unit">Sampler</SetVariable>
           </Template>
 
-          <Template src="skin:left_1state_button.xml">
+          <Template src="skins:Deere/left_1state_button.xml">
             <SetVariable name="TooltipId">eject</SetVariable>
             <SetVariable name="ObjectName">EjectButton</SetVariable>
             <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>

--- a/res/skins/Deere/sampler_row.xml
+++ b/res/skins/Deere/sampler_row.xml
@@ -5,34 +5,34 @@
     <Layout>horizontal</Layout>
     <Children>
 
-      <Template src="skin:sampler.xml">
+      <Template src="skins:Deere/sampler.xml">
         <SetVariable name="i"><Variable name="1"/></SetVariable>
       </Template>
-      <Template src="skin:sampler.xml">
+      <Template src="skins:Deere/sampler.xml">
         <SetVariable name="i"><Variable name="2"/></SetVariable>
       </Template>
-      <Template src="skin:sampler.xml">
+      <Template src="skins:Deere/sampler.xml">
         <SetVariable name="i"><Variable name="3"/></SetVariable>
       </Template>
-      <Template src="skin:sampler.xml">
+      <Template src="skins:Deere/sampler.xml">
         <SetVariable name="i"><Variable name="4"/></SetVariable>
       </Template>
 
-      <Template src="skin:spacer_hx.xml">
+      <Template src="skins:Deere/spacer_hx.xml">
         <SetVariable name="width">3</SetVariable>
         <SetVariable name="color">22</SetVariable>
       </Template>
 
-      <Template src="skin:sampler.xml">
+      <Template src="skins:Deere/sampler.xml">
         <SetVariable name="i"><Variable name="5"/></SetVariable>
       </Template>
-      <Template src="skin:sampler.xml">
+      <Template src="skins:Deere/sampler.xml">
         <SetVariable name="i"><Variable name="6"/></SetVariable>
       </Template>
-      <Template src="skin:sampler.xml">
+      <Template src="skins:Deere/sampler.xml">
         <SetVariable name="i"><Variable name="7"/></SetVariable>
       </Template>
-      <Template src="skin:sampler.xml">
+      <Template src="skins:Deere/sampler.xml">
         <SetVariable name="i"><Variable name="8"/></SetVariable>
       </Template>
 
@@ -43,13 +43,13 @@
         <Children>
           <WidgetGroup><Size>0min,3f</Size></WidgetGroup>
 
-          <Template src="skin:hide_show_button.xml">
+          <Template src="skins:Deere/hide_show_button.xml">
             <SetVariable name="object_name">SamplerRowExpandButton</SetVariable>
             <SetVariable name="control">[Skin],sampler_row_<Variable name="row"/>_expanded</SetVariable>
           </Template>
 
           <!-- Push the button up to the top. -->
-          <Template src="skin:spacer_v.xml"/>
+          <Template src="skins:Deere/spacer_v.xml"/>
         </Children>
       </WidgetGroup>
 

--- a/res/skins/Deere/sampler_text_row.xml
+++ b/res/skins/Deere/sampler_text_row.xml
@@ -23,7 +23,7 @@
           <WidgetGroup>
             <Layout>horizontal</Layout>
             <Children>
-              <Template src="skin:left_right_display_2state_button.xml">
+              <Template src="skins:Deere/left_right_display_2state_button.xml">
                 <SetVariable name="TooltipId">cue_gotoandplay_cue_default</SetVariable>
                 <SetVariable name="ObjectName">SamplerPlayButton</SetVariable>
                 <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
@@ -55,7 +55,7 @@
             <Layout>horizontal</Layout>
             <Children>
 
-              <Template src="skin:left_right_display_2state_button.xml">
+              <Template src="skins:Deere/left_right_display_2state_button.xml">
                 <SetVariable name="TooltipId">cue_gotoandplay_cue_default</SetVariable>
                 <SetVariable name="ObjectName">SamplerPlayButtonRepeating</SetVariable>
                 <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>

--- a/res/skins/Deere/skin_settings.xml
+++ b/res/skins/Deere/skin_settings.xml
@@ -125,7 +125,7 @@
             <SetVariable name="skinsetting">[Skin],show_vinylcontrol</SetVariable>
           </Template>
 
-          <Template src="skin:../Deere/skinsettings_button.xml">
+          <Template src="skins:Deere/skinsettings_button.xml">
             <SetVariable name="TooltipId">show_coverart</SetVariable>
             <SetVariable name="text">Hotcue Shift Buttons</SetVariable>
             <SetVariable name="skinsetting">[Skin],timing_shift_buttons</SetVariable>

--- a/res/skins/Deere/special_cue_button.xml
+++ b/res/skins/Deere/special_cue_button.xml
@@ -19,15 +19,15 @@ Variables:
       <Number>0</Number>
       <Text><Variable name="label"/></Text>
       <Alignment><Variable name="Align"/></Alignment>
-      <Pressed scalemode="STRETCH_ASPECT">skin:/buttons/btn_<Variable name="state_0_pressed"/></Pressed>
-      <Unpressed scalemode="STRETCH_ASPECT">skin:/buttons/btn_<Variable name="state_0_unpressed"/></Unpressed>
+      <Pressed scalemode="STRETCH_ASPECT">skins:Deere/buttons/btn_<Variable name="state_0_pressed"/></Pressed>
+      <Unpressed scalemode="STRETCH_ASPECT">skins:Deere/buttons/btn_<Variable name="state_0_unpressed"/></Unpressed>
     </State>
     <State>
       <Number>1</Number>
       <Text><Variable name="label"/></Text>
       <Alignment><Variable name="Align"/></Alignment>
-      <Pressed scalemode="STRETCH_ASPECT">skin:/buttons/btn_<Variable name="state_1_pressed"/></Pressed>
-      <Unpressed scalemode="STRETCH_ASPECT">skin:/buttons/btn_<Variable name="state_1_unpressed"/></Unpressed>
+      <Pressed scalemode="STRETCH_ASPECT">skins:Deere/buttons/btn_<Variable name="state_1_pressed"/></Pressed>
+      <Unpressed scalemode="STRETCH_ASPECT">skins:Deere/buttons/btn_<Variable name="state_1_unpressed"/></Unpressed>
     </State>
     <Connection>
       <ConfigKey><Variable name="group"/>,<Variable name="cue_type"/>_activate</ConfigKey>

--- a/res/skins/Deere/special_cues.xml
+++ b/res/skins/Deere/special_cues.xml
@@ -18,11 +18,11 @@
         <Layout>horizontal</Layout>
         <SizePolicy>min,min</SizePolicy>
         <Children>
-          <Template src="skin:special_cue_button.xml">
+          <Template src="skins:Deere/special_cue_button.xml">
             <SetVariable name="cue_type">intro_start</SetVariable>
             <SetVariable name="label">|&#9698;</SetVariable>
           </Template>
-          <Template src="skin:special_cue_button.xml">
+          <Template src="skins:Deere/special_cue_button.xml">
             <SetVariable name="cue_type">intro_end</SetVariable>
             <SetVariable name="label">&#9698;|</SetVariable>
           </Template>
@@ -33,11 +33,11 @@
         <Layout>horizontal</Layout>
         <SizePolicy>min,min</SizePolicy>
         <Children>
-          <Template src="skin:special_cue_button.xml">
+          <Template src="skins:Deere/special_cue_button.xml">
             <SetVariable name="cue_type">outro_start</SetVariable>
             <SetVariable name="label">|&#9699;</SetVariable>
           </Template>
-          <Template src="skin:special_cue_button.xml">
+          <Template src="skins:Deere/special_cue_button.xml">
             <SetVariable name="cue_type">outro_end</SetVariable>
             <SetVariable name="label">&#9699;|</SetVariable>
           </Template>

--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -274,10 +274,10 @@ WBeatSpinBox,
 
 /* checkbox in library "Played" column */
 WTrackTableView::indicator:unchecked {
-  image: url(skin:/../Deere/icon/ic_library_checkbox.svg);
+  image: url(skins:Deere/icon/ic_library_checkbox.svg);
 }
 WTrackTableView::indicator:checked {
-  image: url(skin:/../Deere/icon/ic_library_checkbox_checked.svg);
+  image: url(skins:Deere/icon/ic_library_checkbox_checked.svg);
 }
 
 /* focused BPM cell in the library "BPM" column */
@@ -287,11 +287,11 @@ WTrackTableView::indicator:checked {
 }
 /* BPM lock icon */
 #LibraryBPMButton::indicator:checked {
-  image: url(skin:/../Deere/icon/ic_library_bpm_locked.svg);
+  image: url(skins:Deere/icon/ic_library_bpm_locked.svg);
 }
 
 #LibraryBPMButton::indicator:unchecked {
-  image: url(skin:/../Deere/icon/ic_library_bpm_unlocked.svg);
+  image: url(skins:Deere/icon/ic_library_bpm_unlocked.svg);
 }
 
 #LibraryBPMSpinBox {
@@ -304,10 +304,10 @@ WTrackTableView::indicator:checked {
     background-color: #006596;
     }
     #LibraryBPMSpinBox::up-button {
-      image: url(skin:/../Deere/icon/ic_lib_spinbox_up_white.svg) no-repeat;
+      image: url(skins:Deere/icon/ic_lib_spinbox_up_white.svg) no-repeat;
       }
     #LibraryBPMSpinBox::down-button {
-      image: url(skin:/../Deere/icon/ic_lib_spinbox_down_white.svg) no-repeat;
+      image: url(skins:Deere/icon/ic_lib_spinbox_down_white.svg) no-repeat;
       }
 
 /* button in library "Preview" column */
@@ -320,7 +320,7 @@ QPushButton#LibraryPreviewButton {
 }
 
 QPushButton#LibraryPreviewButton:!checked {
-  image: url(skin:/../Deere/icon/ic_library_preview_play.svg);
+  image: url(skins:Deere/icon/ic_library_preview_play.svg);
 }
 
 QPushButton#LibraryPreviewButton:!checked:hover {
@@ -329,7 +329,7 @@ QPushButton#LibraryPreviewButton:!checked:hover {
 }
 
 QPushButton#LibraryPreviewButton:checked {
-  image: url(skin:/../Deere/icon/ic_library_preview_pause.svg);
+  image: url(skins:Deere/icon/ic_library_preview_pause.svg);
   background-color: #0f0f0f;
   border: 1px solid #006596;
 }
@@ -363,11 +363,11 @@ WTrackTableViewHeader::down-arrow {
   padding: 0px;
 }
 WTrackTableViewHeader::up-arrow {
-  image: url(skin:/../Deere/image/style_sort_up.svg);
+  image: url(skins:Deere/image/style_sort_up.svg);
 }
 
 WTrackTableViewHeader::down-arrow {
-  image: url(skin:/../Deere/image/style_sort_down.svg);
+  image: url(skins:Deere/image/style_sort_down.svg);
 }
 
 /* library search bar */
@@ -430,12 +430,12 @@ WLibrarySidebar {
 /* triangle for closed/opened branches in treeview */
 WLibrarySidebar::branch:has-children:!has-siblings:closed,
 WLibrarySidebar::branch:closed:has-children:has-siblings {
-  border-image: none; image: url(skin:/../Deere/image/style_branch_closed.svg);
+  border-image: none; image: url(skins:Deere/image/style_branch_closed.svg);
 }
 
 WLibrarySidebar::branch:open:has-children:!has-siblings,
 WLibrarySidebar::branch:open:has-children:has-siblings {
-  border-image: none; image: url(skin:/../Deere/image/style_branch_open.svg);
+  border-image: none; image: url(skins:Deere/image/style_branch_open.svg);
 }
 
 /* space left of selected child item */
@@ -449,12 +449,12 @@ WLibrarySidebar::branch:open:!has-children:has-siblings:selected {
 
 /* QSplitter between WLibrarySidebar and WTrackTableView */
 #LibrarySplitter::handle {
-  image: url(skin:/../Deere/image/style_handle_horizontal_unchecked.svg);
+  image: url(skins:Deere/image/style_handle_horizontal_unchecked.svg);
   background: none;
 }
 
 #LibrarySplitter::handle:pressed {
-  image: url(skin:/../Deere/image/style_handle_horizontal_checked.svg);
+  image: url(skins:Deere/image/style_handle_horizontal_checked.svg);
   background: none;
 }
 
@@ -470,14 +470,14 @@ WLibrarySidebar::branch:open:!has-children:has-siblings:selected {
 #LibraryCoverArtSplitter::handle,
 #LibraryVerticalSplitter::handle,
 #WaveformSplitter::handle {
-  image: url(skin:/../Deere/image/style_handle_vertical_unchecked.svg);
+  image: url(skins:Deere/image/style_handle_vertical_unchecked.svg);
   background-color: #222;
 }
 
 #LibraryCoverArtSplitter::handle:pressed,
 #LibraryVerticalSplitter::handle:pressed,
 #WaveformSplitter::handle:pressed {
-  image: url(skin:/../Deere/image/style_handle_vertical_checked.svg);
+  image: url(skins:Deere/image/style_handle_vertical_checked.svg);
   background-color: #222;
 }
 
@@ -515,11 +515,11 @@ WLibrarySidebar::branch:open:!has-children:has-siblings:selected {
 }
 
 #LibraryFeatureControls QRadioButton::indicator:checked {
-  image: url(skin:/../Deere/icon/ic_radio_button_on_18px.svg);
+  image: url(skins:Deere/icon/ic_radio_button_on_18px.svg);
 }
 
 #LibraryFeatureControls QRadioButton::indicator:unchecked {
-  image: url(skin:/../Deere/icon/ic_radio_button_off_18px.svg);
+  image: url(skins:Deere/icon/ic_radio_button_off_18px.svg);
 }
 /* buttons in library (in hierarchical order of appearance)
    Style them just as the other regular buttons */
@@ -602,28 +602,28 @@ QPushButton#pushButtonRecording:checked:hover {
 
 /* AutoDJ button icons */
 QPushButton#pushButtonAutoDJ {
-  image: url(skin:/../Deere/icon/ic_autodj_enable.svg) no-repeat center center;
+  image: url(skins:Deere/icon/ic_autodj_enable.svg) no-repeat center center;
 }
 QPushButton#pushButtonFadeNow:!enabled {
-  image: url(skin:/../Deere/icon/ic_autodj_fade_disabled.svg) no-repeat center center;
+  image: url(skins:Deere/icon/ic_autodj_fade_disabled.svg) no-repeat center center;
   }
   QPushButton#pushButtonFadeNow:enabled {
-    image: url(skin:/../Deere/icon/ic_autodj_fade.svg) no-repeat center center;
+    image: url(skins:Deere/icon/ic_autodj_fade.svg) no-repeat center center;
   }
 QPushButton#pushButtonSkipNext:!enabled {
-  image: url(skin:/../Deere/icon/ic_autodj_skip_disabled.svg) no-repeat center center;
+  image: url(skins:Deere/icon/ic_autodj_skip_disabled.svg) no-repeat center center;
   }
   QPushButton#pushButtonSkipNext:enabled {
-    image: url(skin:/../Deere/icon/ic_autodj_skip.svg) no-repeat center center;
+    image: url(skins:Deere/icon/ic_autodj_skip.svg) no-repeat center center;
   }
 QPushButton#pushButtonShuffle {
-  image: url(skin:/../Deere/icon/ic_autodj_shuffle.svg) no-repeat center center;
+  image: url(skins:Deere/icon/ic_autodj_shuffle.svg) no-repeat center center;
 }
 QPushButton#pushButtonAddRandomTrack {
-  image: url(skin:/../Deere/icon/ic_autodj_addrandom.svg) no-repeat center center;
+  image: url(skins:Deere/icon/ic_autodj_addrandom.svg) no-repeat center center;
 }
 QPushButton#pushButtonRepeatPlaylist {
-  image: url(skin:/../Deere/icon/ic_autodj_repeat_playlist.svg) no-repeat center center;
+  image: url(skins:Deere/icon/ic_autodj_repeat_playlist.svg) no-repeat center center;
 }
 /* AutoDJ button icons */
 
@@ -980,11 +980,11 @@ WBeatSpinBox,
   #spinBoxTransition::down-arrow {
     width: 9px;
     height: 7px;
-    image: url(skin:/../Deere/icon/ic_chevron_down_selector.svg);
+    image: url(skins:Deere/icon/ic_chevron_down_selector.svg);
   }
   WBeatSpinBox::down-arrow:hover,
   #spinBoxTransition::down-arrow:hover {
-    image: url(skin:/../Deere/icon/ic_chevron_down_selector_hover.svg);
+    image: url(skins:Deere/icon/ic_chevron_down_selector_hover.svg);
   }
   WBeatSpinBox::up-button,
   #spinBoxTransition::up-button {
@@ -998,11 +998,11 @@ WBeatSpinBox,
   #spinBoxTransition::up-arrow {
     width: 9px;
     height: 7px;
-    image: url(skin:/../Deere/icon/ic_chevron_up_selector.svg);
+    image: url(skins:Deere/icon/ic_chevron_up_selector.svg);
   }
   WBeatSpinBox::up-arrow:hover,
   #spinBoxTransition::up-arrow:hover {
-    image: url(skin:/../Deere/icon/ic_chevron_up_selector_hover.svg);
+    image: url(skins:Deere/icon/ic_chevron_up_selector_hover.svg);
   }
 
 /* End spacing for Deck controls row */
@@ -1130,11 +1130,11 @@ WBeatSpinBox,
 }
 
 #BpmKeyInfoShow {
-  image: url(skin:/../Deere/icon/ic_chevron_left_24x48px.svg) center center;
+  image: url(skins:Deere/icon/ic_chevron_left_24x48px.svg) center center;
 }
 
 #BpmKeyInfoHide {
-  image: url(skin:/../Deere/icon/ic_chevron_right_24x48px.svg) center center;
+  image: url(skins:Deere/icon/ic_chevron_right_24x48px.svg) center center;
 }
 /* End editable widgets in decks */
 
@@ -1211,11 +1211,11 @@ WBeatSpinBox,
 }
 
 #EffectUnitToggle[value="0"] {
-  image: url(skin:icon/ic_unfold_more_48px.svg) no-repeat top right;
+  image: url(skins:Deere/icon/ic_unfold_more_48px.svg) no-repeat top right;
 }
 
 #EffectUnitToggle[value="1"] {
-  image: url(skin:icon/ic_unfold_less_48px.svg) no-repeat top right;
+  image: url(skins:Deere/icon/ic_unfold_less_48px.svg) no-repeat top right;
 }
 
 #EffectUnitFiller {
@@ -1275,7 +1275,7 @@ WBeatSpinBox,
 }
 
 #EffectEnableButton {
-  image: url(skin:/../Deere/icon/ic_power_48px.svg) no-repeat center center;
+  image: url(skins:Deere/icon/ic_power_48px.svg) no-repeat center center;
 }
 
 #EffectKnob {
@@ -1329,7 +1329,7 @@ WBeatSpinBox,
 }
 
 #Crossfader[highlight="1"] {
-  border-image: url(skin:slider-crossfader-AutoDJ.svg) 0 0 0 0 stretch stretch;
+  border-image: url(skins:Deere/slider-crossfader-AutoDJ.svg) 0 0 0 0 stretch stretch;
 }
 
 #MainControls {
@@ -1629,11 +1629,11 @@ WPushButton#SyncLeader[value="1"] {
     border: 1px solid #0092d9;
 }
 WPushButton#SyncLeader[value="0"] {
-  image: url(skin:/../Deere/icon/ic_sync_leader_off.svg) no-repeat center center;
+  image: url(skins:Deere/icon/ic_sync_leader_off.svg) no-repeat center center;
 }
 WPushButton#SyncLeader[value="1"],
 WPushButton#SyncLeader[value="2"] {
-  image: url(skin:/../Deere/icon/ic_sync_leader_on.svg) no-repeat center center;
+  image: url(skins:Deere/icon/ic_sync_leader_on.svg) no-repeat center center;
 }
 
 WPushButton[value="1"]:hover,
@@ -1658,12 +1658,12 @@ WPushButton[value="2"]:hover,
 }
 
 WPushButton#PlayToggle[value="0"] {
-  image: url(skin:/../Deere/icon/ic_play_48px.svg) no-repeat center center;
+  image: url(skins:Deere/icon/ic_play_48px.svg) no-repeat center center;
   background-color: transparent;
 }
 
 WPushButton#PlayToggle[value="1"] {
-  image: url(skin:/../Deere/icon/ic_pause_48px.svg) no-repeat center center;
+  image: url(skins:Deere/icon/ic_pause_48px.svg) no-repeat center center;
 }
 WPushButton#PreviewIndicator {
   background-color: transparent;
@@ -2071,11 +2071,11 @@ WSearchLineEdit QAbstractScrollArea,
 }
   #MainMenu QMenu::indicator:checked,
   #MainMenu QMenu::indicator:checked:selected {
-    image: url(skin:/../Deere/icon/ic_mainmenu_checkbox_checked.svg);
+    image: url(skins:Deere/icon/ic_mainmenu_checkbox_checked.svg);
   }
   #MainMenu QMenu::indicator:unchecked,
   #MainMenu QMenu::indicator:unchecked:selected {
-    image: url(skin:/../Deere/icon/ic_mainmenu_checkbox.svg);
+    image: url(skins:Deere/icon/ic_mainmenu_checkbox.svg);
   }
 
 #MainMenu QMenu {
@@ -2088,7 +2088,7 @@ WSearchLineEdit QAbstractScrollArea,
   WTrackMenu QMenu::right-arrow {
     width: 0.7em;
     height: 0.7em;
-    image: url(skin:/../Deere/icon/ic_chevron_right_48px.svg);
+    image: url(skins:Deere/icon/ic_chevron_right_48px.svg);
   }
 
 
@@ -2151,7 +2151,7 @@ WEffectChainPresetSelector:!editable:on {
   WSearchLineEdit::down-arrow,
   WEffectChainPresetSelector::down-arrow,
   #fadeModeCombobox::down-arrow {
-    image: url(skin:/../Deere/icon/ic_chevron_down_48px.svg);
+    image: url(skins:Deere/icon/ic_chevron_down_48px.svg);
   }
   /* currently loaded effect */
   WEffectSelector::checked,
@@ -2257,13 +2257,13 @@ WTrackMenu QMenu QCheckBox::indicator:disabled {
 }
 WLibrarySidebar QMenu::indicator:checked,
 WTrackMenu QMenu QCheckBox::indicator:checked {
-  image: url(skin:/../Deere/icon/ic_library_checkmark_orange.svg);
+  image: url(skins:Deere/icon/ic_library_checkmark_orange.svg);
 }
 WTrackTableViewHeader QMenu::indicator:checked,
 WEffectSelector::indicator:checked,
 WEffectChainPresetSelector::indicator:checked,
 #fadeModeCombobox::indicator:checked {
-  image: url(skin:/../Deere/icon/ic_library_checkmark_blue.svg);
+  image: url(skins:Deere/icon/ic_library_checkmark_blue.svg);
 }
 
 /* disabled menu item and checkbox */
@@ -2273,13 +2273,13 @@ WTrackMenu QMenu QCheckBox::indicator:indeterminate {
   background-color: #222;
 }
 WTrackMenu QMenu QCheckBox::indicator:disabled:checked {
-  image: url(skin:/../Deere/icon/ic_library_checkmark_grey.svg);
+  image: url(skins:Deere/icon/ic_library_checkmark_grey.svg);
 }
 WTrackMenu QMenu QCheckBox::indicator:indeterminate {
-  image: url(skin:/../Deere/icon/ic_library_checkmark_indeterminate_orange.svg);
+  image: url(skins:Deere/icon/ic_library_checkmark_indeterminate_orange.svg);
 }
 WTrackMenu QMenu QCheckBox::indicator:disabled:indeterminate {
-  image: url(skin:/../Deere/icon/ic_library_checkmark_indeterminate_grey.svg);
+  image: url(skins:Deere/icon/ic_library_checkmark_indeterminate_grey.svg);
 }
 WTrackMenu QMenu QCheckBox::indicator:disabled:checked,
 WTrackMenu QMenu QCheckBox::indicator:disabled:unchecked {
@@ -2318,7 +2318,7 @@ WEffectChainPresetSelector::indicator:unchecked:selected,
   height: 46px;
   /* make the icon slightly larger than default 16px */
   qproperty-iconSize: 20px;
-  qproperty-icon: url(skin:/../Deere/icon/ic_delete.svg);
+  qproperty-icon: url(skins:Deere/icon/ic_delete.svg);
   background-color: #3B3B3B;
   border-radius: 2px;
   outline: none;

--- a/res/skins/Deere/tool_bar.xml
+++ b/res/skins/Deere/tool_bar.xml
@@ -38,7 +38,7 @@
                 <CustomFormat>hh:mm</CustomFormat>
               </Time>
 
-              <Template src="skin:vumeter_latency.xml">
+              <Template src="skins:Deere/vumeter_latency.xml">
                 <SetVariable name="TooltipId">audio_latency_usage</SetVariable>
                 <SetVariable name="group">[App]</SetVariable>
                 <SetVariable name="control">audio_latency_usage</SetVariable>
@@ -51,7 +51,7 @@
             <SizePolicy>min,min</SizePolicy>
             <Layout>horizontal</Layout>
             <Children>
-              <Template src="skin:knob_toolbar.xml">
+              <Template src="skins:Deere/knob_toolbar.xml">
                 <SetVariable name="TooltipId">main_gain</SetVariable>
                 <SetVariable name="group">[Master]</SetVariable>
                 <SetVariable name="control">gain</SetVariable>
@@ -59,7 +59,7 @@
                 <SetVariable name="label">Main</SetVariable>
               </Template>
 
-              <Template src="skin:left_2state_button.xml">
+              <Template src="skins:Deere/left_2state_button.xml">
                 <SetVariable name="TooltipId">EffectUnit_main_enabled</SetVariable>
                 <SetVariable name="ObjectName">FxAssignmentButton</SetVariable>
                 <SetVariable name="MinimumSize">26,22</SetVariable>
@@ -70,7 +70,7 @@
                 <SetVariable name="left_connection_control">[EffectRack1_EffectUnit1],group_[Master]_enable</SetVariable>
               </Template>
 
-              <Template src="skin:left_2state_button.xml">
+              <Template src="skins:Deere/left_2state_button.xml">
                 <SetVariable name="TooltipId">EffectUnit_main_enabled</SetVariable>
                 <SetVariable name="ObjectName">FxAssignmentButton</SetVariable>
                 <SetVariable name="MinimumSize">18,22</SetVariable>
@@ -81,7 +81,7 @@
                 <SetVariable name="left_connection_control">[EffectRack1_EffectUnit2],group_[Master]_enable</SetVariable>
               </Template>
 
-              <Template src="skin:left_2state_button.xml">
+              <Template src="skins:Deere/left_2state_button.xml">
                 <SetVariable name="TooltipId">EffectUnit_main_enabled</SetVariable>
                 <SetVariable name="ObjectName">FxAssignmentButton</SetVariable>
                 <SetVariable name="MinimumSize">18,22</SetVariable>
@@ -92,7 +92,7 @@
                 <SetVariable name="left_connection_control">[EffectRack1_EffectUnit3],group_[Master]_enable</SetVariable>
               </Template>
 
-              <Template src="skin:left_2state_button.xml">
+              <Template src="skins:Deere/left_2state_button.xml">
                 <SetVariable name="TooltipId">EffectUnit_main_enabled</SetVariable>
                 <SetVariable name="ObjectName">FxAssignmentButton</SetVariable>
                 <SetVariable name="MinimumSize">18,22</SetVariable>
@@ -103,7 +103,7 @@
                 <SetVariable name="left_connection_control">[EffectRack1_EffectUnit4],group_[Master]_enable</SetVariable>
               </Template>
 
-              <Template src="skin:knob_toolbar.xml">
+              <Template src="skins:Deere/knob_toolbar.xml">
                 <SetVariable name="TooltipId">balance</SetVariable>
                 <SetVariable name="group">[Master]</SetVariable>
                 <SetVariable name="control">balance</SetVariable>
@@ -122,7 +122,7 @@
               <BindProperty>visible</BindProperty>
             </Connection>
             <Children>
-              <Template src="skin:knob_toolbar.xml">
+              <Template src="skins:Deere/knob_toolbar.xml">
                 <SetVariable name="TooltipId">booth_gain</SetVariable>
                 <SetVariable name="group">[Master]</SetVariable>
                 <SetVariable name="control">booth_gain</SetVariable>
@@ -144,7 +144,7 @@
             </Connection>
             <Children>
 
-              <Template src="skin:knob_toolbar.xml">
+              <Template src="skins:Deere/knob_toolbar.xml">
                 <SetVariable name="TooltipId">headphone_gain</SetVariable>
                 <SetVariable name="group">[Master]</SetVariable>
                 <SetVariable name="control">headGain</SetVariable>
@@ -189,7 +189,7 @@
 
               <WidgetGroup><Size>5f,0min</Size></WidgetGroup>
 
-              <Template src="skin:left_2state_button.xml">
+              <Template src="skins:Deere/left_2state_button.xml">
                 <SetVariable name="TooltipId">headSplit</SetVariable>
                 <SetVariable name="ObjectName">ToolbarButton</SetVariable>
                 <SetVariable name="MinimumSize">38,22</SetVariable>
@@ -222,7 +222,7 @@
             <Layout>horizontal</Layout>
             <Children>
 
-              <Template src="skin:statuslight_3state.xml">
+              <Template src="skins:Deere/statuslight_3state.xml">
                 <SetVariable name="TooltipId">vinylcontrol_status</SetVariable>
                 <SetVariable name="Tooltip">Vinyl Control 1 active</SetVariable>
                 <SetVariable name="ObjectName">VinylControlNotification</SetVariable>
@@ -235,7 +235,7 @@
                 <SetVariable name="left_connection_control">[Channel1],vinylcontrol_status</SetVariable>
               </Template>
 
-              <Template src="skin:statuslight_3state.xml">
+              <Template src="skins:Deere/statuslight_3state.xml">
                 <SetVariable name="TooltipId">vinylcontrol_status</SetVariable>
                 <SetVariable name="Tooltip">Vinyl Control 2 active</SetVariable>
                 <SetVariable name="ObjectName">VinylControlNotification</SetVariable>
@@ -248,7 +248,7 @@
                 <SetVariable name="left_connection_control">[Channel2],vinylcontrol_status</SetVariable>
               </Template>
 
-              <Template src="skin:statuslight_3state.xml">
+              <Template src="skins:Deere/statuslight_3state.xml">
                 <SetVariable name="TooltipId">vinylcontrol_status</SetVariable>
                 <SetVariable name="Tooltip">Vinyl Control 3 active</SetVariable>
                 <SetVariable name="ObjectName">VinylControlNotification</SetVariable>
@@ -261,7 +261,7 @@
                 <SetVariable name="left_connection_control">[Channel3],vinylcontrol_status</SetVariable>
               </Template>
 
-              <Template src="skin:statuslight_3state.xml">
+              <Template src="skins:Deere/statuslight_3state.xml">
                 <SetVariable name="TooltipId">vinylcontrol_status</SetVariable>
                 <SetVariable name="Tooltip">Vinyl Control 4 active</SetVariable>
                 <SetVariable name="ObjectName">VinylControlNotification</SetVariable>
@@ -280,7 +280,7 @@
                 against enabling AutoDj with an empty queue. You would throw off button states easily. So we stick with
                 just displaying the AutoDJ status here.
               -->
-              <Template src="skin:statuslight_3state.xml">
+              <Template src="skins:Deere/statuslight_3state.xml">
                 <SetVariable name="TooltipId">autodj_status</SetVariable>
                 <SetVariable name="ObjectName">AutoDjNotification</SetVariable>
                 <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
@@ -316,7 +316,7 @@
                 </Children>
               </WidgetGroup>
 
-              <Template src="skin:left_display_4state_button.xml">
+              <Template src="skins:Deere/left_display_4state_button.xml">
                 <SetVariable name="TooltipId">toggle_recording</SetVariable>
                 <SetVariable name="ObjectName">RecordingNotification</SetVariable>
                 <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
@@ -332,7 +332,7 @@
             </Children>
           </WidgetGroup>
 
-          <Template src="skin:left_display_4state_button.xml">
+          <Template src="skins:Deere/left_display_4state_button.xml">
             <SetVariable name="TooltipId">broadcast_enabled</SetVariable>
             <SetVariable name="ObjectName">LiveBroadcastingNotification</SetVariable>
             <SetVariable name="MinimumSize"><Variable name="SquareButtonMinimumSize"/></SetVariable>
@@ -352,7 +352,7 @@
             <SizePolicy>me,min</SizePolicy>
             <Children>
 
-              <Template src="skin:left_2state_button.xml">
+              <Template src="skins:Deere/left_2state_button.xml">
                 <SetVariable name="TooltipId">show_mixer</SetVariable>
                 <SetVariable name="ObjectName">ToolbarButton</SetVariable>
                 <SetVariable name="MinimumSize">55,22</SetVariable>
@@ -365,7 +365,7 @@
 
               <WidgetGroup><Size>6f,1min</Size></WidgetGroup>
 
-              <Template src="skin:left_2state_button.xml">
+              <Template src="skins:Deere/left_2state_button.xml">
                 <SetVariable name="TooltipId">show_effects</SetVariable>
                 <SetVariable name="ObjectName">ToolbarButton</SetVariable>
                 <SetVariable name="MinimumSize">55,22</SetVariable>
@@ -378,7 +378,7 @@
 
               <WidgetGroup><Size>6f,1min</Size></WidgetGroup>
 
-              <Template src="skin:left_2state_button.xml">
+              <Template src="skins:Deere/left_2state_button.xml">
                 <SetVariable name="TooltipId">show_samplers</SetVariable>
                 <SetVariable name="ObjectName">ToolbarButton</SetVariable>
                 <SetVariable name="MinimumSize"><Variable name="ToolbarButtonMinimumSize"/></SetVariable>
@@ -391,7 +391,7 @@
 
               <WidgetGroup><Size>6f,1min</Size></WidgetGroup>
 
-              <Template src="skin:left_2state_button.xml">
+              <Template src="skins:Deere/left_2state_button.xml">
                 <SetVariable name="TooltipId">show_microphone</SetVariable>
                 <SetVariable name="ObjectName">ToolbarButton</SetVariable>
                 <SetVariable name="MinimumSize"><Variable name="ToolbarButtonMinimumSize"/></SetVariable>

--- a/res/skins/Deere/vinylcontrol.xml
+++ b/res/skins/Deere/vinylcontrol.xml
@@ -10,7 +10,7 @@
         <Layout>vertical</Layout>
         <SizePolicy>min,min</SizePolicy>
         <Children>
-          <Template src="skin:left_2state_button.xml">
+          <Template src="skins:Deere/left_2state_button.xml">
             <SetVariable name="TooltipId">vinylcontrol_enabled</SetVariable>
             <SetVariable name="ObjectName">VinylToggleButtonUL</SetVariable>
             <SetVariable name="MinimumSize">40,10</SetVariable>
@@ -21,7 +21,7 @@
             <SetVariable name="left_connection_control"><Variable name="group"/>,vinylcontrol_enabled</SetVariable>
           </Template>
 
-          <Template src="skin:left_3state_button.xml">
+          <Template src="skins:Deere/left_3state_button.xml">
             <SetVariable name="ObjectName">TristateButton</SetVariable>
             <SetVariable name="MinimumSize">40,10</SetVariable>
             <SetVariable name="MaximumSize">40,22</SetVariable>
@@ -39,7 +39,7 @@
         <Layout>vertical</Layout>
         <SizePolicy>min,min</SizePolicy>
         <Children>
-          <Template src="skin:left_2state_button.xml">
+          <Template src="skins:Deere/left_2state_button.xml">
             <SetVariable name="TooltipId">passthrough_enabled</SetVariable>
             <SetVariable name="ObjectName">VinylToggleButtonLL</SetVariable>
             <SetVariable name="MinimumSize">40,10</SetVariable>
@@ -50,7 +50,7 @@
             <SetVariable name="left_connection_control"><Variable name="group"/>,passthrough</SetVariable>
           </Template>
 
-          <Template src="skin:left_3state_button.xml">
+          <Template src="skins:Deere/left_3state_button.xml">
             <SetVariable name="ObjectName">VinylCueButton</SetVariable>
             <SetVariable name="TooltipId">vinylcontrol_cueing</SetVariable>
             <SetVariable name="MinimumSize">40,10</SetVariable>

--- a/res/skins/Deere/vumeter_main.xml
+++ b/res/skins/Deere/vumeter_main.xml
@@ -14,13 +14,13 @@
         <SizePolicy>f,me</SizePolicy>
         <Layout>horizontal</Layout>
         <Children>
-          <Template src="skin:vumeter_v.xml">
+          <Template src="skins:Deere/vumeter_v.xml">
             <SetVariable name="group">[Main]</SetVariable>
             <SetVariable name="side">_left</SetVariable>
             <SetVariable name="tooltip_meter">main_VuMeterL</SetVariable>
             <SetVariable name="tooltip_clip">main_peak_indicator_left</SetVariable>
           </Template>
-          <Template src="skin:vumeter_v.xml">
+          <Template src="skins:Deere/vumeter_v.xml">
             <SetVariable name="group">[Main]</SetVariable>
             <SetVariable name="side">_right</SetVariable>
             <SetVariable name="tooltip_meter">main_VuMeterR</SetVariable>

--- a/res/skins/LateNight/waveforms_container.xml
+++ b/res/skins/LateNight/waveforms_container.xml
@@ -20,7 +20,7 @@
                 <Layout>horizontal</Layout>
                 <SizePolicy>me,me</SizePolicy>
                 <Children>
-                  <Template src="skin:waveform.xml">
+                  <Template src="skins:LateNight/waveform.xml">
                     <SetVariable name="ChanNum">3</SetVariable>
                     <SetVariable name="SignalColor"><Variable name="SignalColor_34"/></SetVariable>
                     <SetVariable name="BgColorWaveform"><Variable name="BgColorWaveform_34"/></SetVariable>
@@ -37,7 +37,7 @@
                 <Layout>horizontal</Layout>
                 <SizePolicy>me,me</SizePolicy>
                 <Children>
-                  <Template src="skin:waveform.xml">
+                  <Template src="skins:LateNight/waveform.xml">
                     <SetVariable name="ChanNum">1</SetVariable>
                     <SetVariable name="SignalColor"><Variable name="SignalColor_12"/></SetVariable>
                     <SetVariable name="BgColorWaveform"><Variable name="BgColorWaveform_12"/></SetVariable>
@@ -50,7 +50,7 @@
                 <Layout>horizontal</Layout>
                 <SizePolicy>me,me</SizePolicy>
                 <Children>
-                  <Template src="skin:waveform.xml">
+                  <Template src="skins:LateNight/waveform.xml">
                     <SetVariable name="ChanNum">2</SetVariable>
                     <SetVariable name="SignalColor"><Variable name="SignalColor_12"/></SetVariable>
                     <SetVariable name="BgColorWaveform"><Variable name="BgColorWaveform_12"/></SetVariable>
@@ -63,7 +63,7 @@
                 <Layout>horizontal</Layout>
                 <SizePolicy>me,me</SizePolicy>
                 <Children>
-                  <Template src="skin:waveform.xml">
+                  <Template src="skins:LateNight/waveform.xml">
                     <SetVariable name="ChanNum">4</SetVariable>
                     <SetVariable name="SignalColor"><Variable name="SignalColor_34"/></SetVariable>
                     <SetVariable name="BgColorWaveform"><Variable name="BgColorWaveform_34"/></SetVariable>

--- a/res/skins/Shade/auxiliary.xml
+++ b/res/skins/Shade/auxiliary.xml
@@ -11,8 +11,8 @@
       -->
       <StatusLight>
         <TooltipId>auxiliary_peak_indicator</TooltipId>
-        <PathStatusLight>skin:/style/volume_clipping_microphone_over.png</PathStatusLight>
-        <PathBack>skin:/style/volume_clipping_microphone.png</PathBack>
+        <PathStatusLight>skins:Shade/style/volume_clipping_microphone_over.png</PathStatusLight>
+        <PathBack>skins:Shade/style/volume_clipping_microphone.png</PathBack>
         <Pos>99,6</Pos>
         <Connection>
           <ConfigKey>[Auxiliary<Variable name="auxnum"/>],peak_indicator</ConfigKey>
@@ -31,8 +31,8 @@
         <Children>
           <VuMeter>
             <TooltipId>auxiliary_VuMeter</TooltipId>
-            <PathVu>skin:/style/volume_display_microphone_over.png</PathVu>
-            <PathBack>skin:/style/volume_display_microphone.png</PathBack>
+            <PathVu>skins:Shade/style/volume_display_microphone_over.png</PathVu>
+            <PathBack>skins:Shade/style/volume_display_microphone.png</PathBack>
             <PeakHoldSize>5</PeakHoldSize>
             <PeakHoldTime>500</PeakHoldTime>
             <PeakFallTime>50</PeakFallTime>
@@ -59,18 +59,18 @@
         <NumberStates>3</NumberStates>
         <State>
           <Number>0</Number>
-          <Pressed>skin:/btn/btn_orientation_sampler_left_over.png</Pressed>
-          <Unpressed>skin:/btn/btn_orientation_sampler_left_over.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_orientation_sampler_left_over.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_orientation_sampler_left_over.png</Unpressed>
         </State>
         <State>
           <Number>1</Number>
-          <Pressed>skin:/btn/btn_orientation_sampler_main.png</Pressed>
-          <Unpressed>skin:/btn/btn_orientation_sampler_main.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_orientation_sampler_main.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_orientation_sampler_main.png</Unpressed>
         </State>
         <State>
           <Number>2</Number>
-          <Pressed>skin:/btn/btn_orientation_sampler_right_over.png</Pressed>
-          <Unpressed>skin:/btn/btn_orientation_sampler_right_over.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_orientation_sampler_right_over.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_orientation_sampler_right_over.png</Unpressed>
         </State>
         <Pos>0,28</Pos>
         <Connection>
@@ -85,13 +85,13 @@
         <NumberStates>2</NumberStates>
         <State>
           <Number>0</Number>
-          <Pressed>skin:/btn/btn_pfl_fx_down.png</Pressed>
-          <Unpressed>skin:/btn/btn_pfl_fx.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_pfl_fx_down.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_pfl_fx.png</Unpressed>
         </State>
         <State>
           <Number>1</Number>
-          <Pressed>skin:/btn/btn_pfl_fx_overdown.png</Pressed>
-          <Unpressed>skin:/btn/btn_pfl_fx_over.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_pfl_fx_overdown.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_pfl_fx_over.png</Unpressed>
         </State>
         <Pos>21,30</Pos>
         <Connection>

--- a/res/skins/Shade/deck.xml
+++ b/res/skins/Shade/deck.xml
@@ -84,8 +84,8 @@
                                 <NumberStates>1</NumberStates>
                                 <State>
                                   <Number>0</Number>
-                                  <Pressed>skin:/btn/btn_eject_over.png</Pressed>
-                                  <Unpressed>skin:/btn/btn_eject.png</Unpressed>
+                                  <Pressed>skins:Shade/btn/btn_eject_over.png</Pressed>
+                                  <Unpressed>skins:Shade/btn/btn_eject.png</Unpressed>
                                 </State>
                                 <Connection>
                                   <ConfigKey><Variable name="group"/>,eject</ConfigKey>
@@ -180,7 +180,7 @@
                                 <Layout>horizontal</Layout>
                                 <Size>0e,81f</Size>
                                 <Children>
-                                  <Template src="skin:waveform.xml"/>
+                                  <Template src="skins:Shade/waveform.xml"/>
                                 </Children>
                               </WidgetGroup>
 
@@ -212,7 +212,7 @@
                                       <BindProperty>visible</BindProperty>
                                     </Connection>
                                   </WidgetGroup>
-                                  <Template src="skin:vinylcontrol.xml"/>
+                                  <Template src="skins:Shade/vinylcontrol.xml"/>
                                 </Children>
                               </WidgetGroup>
 
@@ -248,13 +248,13 @@
                             <NumberStates>2</NumberStates>
                             <State>
                               <Number>0</Number>
-                              <Pressed>skin:/btn/btn_spinny.png</Pressed>
-                              <Unpressed>skin:/btn/btn_spinny.png</Unpressed>
+                              <Pressed>skins:Shade/btn/btn_spinny.png</Pressed>
+                              <Unpressed>skins:Shade/btn/btn_spinny.png</Unpressed>
                             </State>
                             <State>
                               <Number>1</Number>
-                              <Pressed>skin:/btn/btn_spinny_over.png</Pressed>
-                              <Unpressed>skin:/btn/btn_spinny_over.png</Unpressed>
+                              <Pressed>skins:Shade/btn/btn_spinny_over.png</Pressed>
+                              <Unpressed>skins:Shade/btn/btn_spinny_over.png</Unpressed>
                             </State>
                             <Pos>1,1</Pos>
                             <Connection>
@@ -268,13 +268,13 @@
                             <NumberStates>2</NumberStates>
                             <State>
                               <Number>0</Number>
-                              <Pressed>skin:/btn/btn_repeat.png</Pressed>
-                              <Unpressed>skin:/btn/btn_repeat.png</Unpressed>
+                              <Pressed>skins:Shade/btn/btn_repeat.png</Pressed>
+                              <Unpressed>skins:Shade/btn/btn_repeat.png</Unpressed>
                             </State>
                             <State>
                               <Number>1</Number>
-                              <Pressed>skin:/btn/btn_repeat_over.png</Pressed>
-                              <Unpressed>skin:/btn/btn_repeat_over.png</Unpressed>
+                              <Pressed>skins:Shade/btn/btn_repeat_over.png</Pressed>
+                              <Unpressed>skins:Shade/btn/btn_repeat_over.png</Unpressed>
                             </State>
                             <Pos>22,1</Pos>
                             <Connection>
@@ -286,13 +286,13 @@
                             <NumberStates>2</NumberStates>
                             <State>
                               <Number>0</Number>
-                              <Pressed>skin:/btn/btn_slip.png</Pressed>
-                              <Unpressed>skin:/btn/btn_slip.png</Unpressed>
+                              <Pressed>skins:Shade/btn/btn_slip.png</Pressed>
+                              <Unpressed>skins:Shade/btn/btn_slip.png</Unpressed>
                             </State>
                             <State>
                               <Number>1</Number>
-                              <Pressed>skin:/btn/btn_slip_over.png</Pressed>
-                              <Unpressed>skin:/btn/btn_slip_over.png</Unpressed>
+                              <Pressed>skins:Shade/btn/btn_slip_over.png</Pressed>
+                              <Unpressed>skins:Shade/btn/btn_slip_over.png</Unpressed>
                             </State>
                             <Pos>43,1</Pos>
                             <Connection>
@@ -306,8 +306,8 @@
                             <NumberStates>1</NumberStates>
                             <State>
                               <Number>0</Number>
-                              <Pressed>skin:/btn/btn_beatgrid_over.png</Pressed>
-                              <Unpressed>skin:/btn/btn_beatgrid.png</Unpressed>
+                              <Pressed>skins:Shade/btn/btn_beatgrid_over.png</Pressed>
+                              <Unpressed>skins:Shade/btn/btn_beatgrid.png</Unpressed>
                             </State>
                             <Pos>1,20</Pos>
                             <Connection>
@@ -327,13 +327,13 @@
                             <NumberStates>2</NumberStates>
                             <State>
                               <Number>0</Number>
-                              <Pressed>skin:/btn/btn_quantize.png</Pressed>
-                              <Unpressed>skin:/btn/btn_quantize.png</Unpressed>
+                              <Pressed>skins:Shade/btn/btn_quantize.png</Pressed>
+                              <Unpressed>skins:Shade/btn/btn_quantize.png</Unpressed>
                             </State>
                             <State>
                               <Number>1</Number>
-                              <Pressed>skin:/btn/btn_quantize_over.png</Pressed>
-                              <Unpressed>skin:/btn/btn_quantize_over.png</Unpressed>
+                              <Pressed>skins:Shade/btn/btn_quantize_over.png</Pressed>
+                              <Unpressed>skins:Shade/btn/btn_quantize_over.png</Unpressed>
                             </State>
                             <Pos>22,20</Pos>
                             <Connection>
@@ -347,13 +347,13 @@
                             <NumberStates>2</NumberStates>
                             <State>
                               <Number>0</Number>
-                              <Pressed>skin:/btn/btn_keylock.png</Pressed>
-                              <Unpressed>skin:/btn/btn_keylock.png</Unpressed>
+                              <Pressed>skins:Shade/btn/btn_keylock.png</Pressed>
+                              <Unpressed>skins:Shade/btn/btn_keylock.png</Unpressed>
                             </State>
                             <State>
                               <Number>1</Number>
-                              <Pressed>skin:/btn/btn_keylock_over.png</Pressed>
-                              <Unpressed>skin:/btn/btn_keylock_over.png</Unpressed>
+                              <Pressed>skins:Shade/btn/btn_keylock_over.png</Pressed>
+                              <Unpressed>skins:Shade/btn/btn_keylock_over.png</Unpressed>
                             </State>
                             <Pos>43,20</Pos>
                             <Connection>
@@ -377,13 +377,13 @@
                     <NumberStates>2</NumberStates>
                     <State>
                       <Number>0</Number>
-                      <Pressed>skin:/btn/btn_sync_bpm_down.png</Pressed>
-                      <Unpressed>skin:/btn/btn_sync_bpm.png</Unpressed>
+                      <Pressed>skins:Shade/btn/btn_sync_bpm_down.png</Pressed>
+                      <Unpressed>skins:Shade/btn/btn_sync_bpm.png</Unpressed>
                     </State>
                     <State>
                       <Number>1</Number>
-                      <Pressed>skin:/btn/btn_sync_bpm_overdown.png</Pressed>
-                      <Unpressed>skin:/btn/btn_sync_bpm_over.png</Unpressed>
+                      <Pressed>skins:Shade/btn/btn_sync_bpm_overdown.png</Pressed>
+                      <Unpressed>skins:Shade/btn/btn_sync_bpm_over.png</Unpressed>
                     </State>
                     <Pos>3,15</Pos>
                     <Connection>
@@ -401,13 +401,13 @@
                     <NumberStates>2</NumberStates>
                     <State>
                       <Number>0</Number>
-                      <Pressed>skin:/btn/btn_sync_key_down.png</Pressed>
-                      <Unpressed>skin:/btn/btn_sync_key.png</Unpressed>
+                      <Pressed>skins:Shade/btn/btn_sync_key_down.png</Pressed>
+                      <Unpressed>skins:Shade/btn/btn_sync_key.png</Unpressed>
                     </State>
                     <State>
                       <Number>1</Number>
-                      <Pressed>skin:/btn/btn_sync_key_overdown.png</Pressed>
-                      <Unpressed>skin:/btn/btn_sync_key_over.png</Unpressed>
+                      <Pressed>skins:Shade/btn/btn_sync_key_overdown.png</Pressed>
+                      <Unpressed>skins:Shade/btn/btn_sync_key_over.png</Unpressed>
                     </State>
                     <Pos>27,15</Pos>
                     <Connection>
@@ -619,11 +619,11 @@
             <Layout>horizontal</Layout>
             <BackPath>style/style_bg_deck_pane.png</BackPath>
             <Children>
-              <Template src="skin:deck_effect.xml"/>
+              <Template src="skins:Shade/deck_effect.xml"/>
               <WidgetGroup>
                 <Size>0e,59f</Size>
               </WidgetGroup>
-              <Template src="skin:deck_transport.xml"/>
+              <Template src="skins:Shade/deck_transport.xml"/>
             </Children>
           </WidgetGroup>
 
@@ -632,7 +632,7 @@
             <Size>0e,24f</Size>
             <Layout>horizontal</Layout>
             <Children>
-              <Template src="skin:deck_cues.xml">
+              <Template src="skins:Shade/deck_cues.xml">
               </Template>
             </Children>
             <Connection>

--- a/res/skins/Shade/deck_cues.xml
+++ b/res/skins/Shade/deck_cues.xml
@@ -7,35 +7,35 @@
         <Layout>horizontal</Layout>
         <Children>
             <WidgetGroup><Size>0e,0e</Size></WidgetGroup>
-          <Template src="skin:hotcue_button.xml">
+          <Template src="skins:Shade/hotcue_button.xml">
             <SetVariable name="hotcue">1</SetVariable>
           </Template>
             <WidgetGroup><Size>1f,0e</Size></WidgetGroup>
-          <Template src="skin:hotcue_button.xml">
+          <Template src="skins:Shade/hotcue_button.xml">
             <SetVariable name="hotcue">2</SetVariable>
           </Template>
             <WidgetGroup><Size>1f,0e</Size></WidgetGroup>
-          <Template src="skin:hotcue_button.xml">
+          <Template src="skins:Shade/hotcue_button.xml">
             <SetVariable name="hotcue">3</SetVariable>
           </Template>
             <WidgetGroup><Size>1f,0e</Size></WidgetGroup>
-          <Template src="skin:hotcue_button.xml">
+          <Template src="skins:Shade/hotcue_button.xml">
             <SetVariable name="hotcue">4</SetVariable>
           </Template>
             <WidgetGroup><Size>1f,0e</Size></WidgetGroup>
-          <Template src="skin:hotcue_button.xml">
+          <Template src="skins:Shade/hotcue_button.xml">
             <SetVariable name="hotcue">5</SetVariable>
           </Template>
             <WidgetGroup><Size>1f,0e</Size></WidgetGroup>
-          <Template src="skin:hotcue_button.xml">
+          <Template src="skins:Shade/hotcue_button.xml">
             <SetVariable name="hotcue">6</SetVariable>
           </Template>
             <WidgetGroup><Size>1f,0e</Size></WidgetGroup>
-          <Template src="skin:hotcue_button.xml">
+          <Template src="skins:Shade/hotcue_button.xml">
             <SetVariable name="hotcue">7</SetVariable>
           </Template>
             <WidgetGroup><Size>1f,0e</Size></WidgetGroup>
-          <Template src="skin:hotcue_button.xml">
+          <Template src="skins:Shade/hotcue_button.xml">
             <SetVariable name="hotcue">8</SetVariable>
           </Template>
             <WidgetGroup><Size>5f,0e</Size></WidgetGroup>

--- a/res/skins/Shade/deck_effect.xml
+++ b/res/skins/Shade/deck_effect.xml
@@ -12,13 +12,13 @@
         <NumberStates>2</NumberStates>
         <State>
           <Number>0</Number>
-          <Pressed>skin:/btn/btn_fx_plus.png</Pressed>
-          <Unpressed>skin:/btn/btn_fx_plus.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_fx_plus.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_fx_plus.png</Unpressed>
         </State>
         <State>
           <Number>1</Number>
-          <Pressed>skin:/btn/btn_fx_minus.png</Pressed>
-          <Unpressed>skin:/btn/btn_fx_minus.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_fx_minus.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_fx_minus.png</Unpressed>
         </State>
         <Pos>2,0</Pos>
         <Connection>
@@ -31,13 +31,13 @@
         <NumberStates>2</NumberStates>
         <State>
           <Number>0</Number>
-          <Pressed>skin:/btn/btn_beatloop_<Variable name="effectunitnum"/>_down.png</Pressed>
-          <Unpressed>skin:/btn/btn_beatloop_<Variable name="effectunitnum"/>.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_beatloop_<Variable name="effectunitnum"/>_down.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_beatloop_<Variable name="effectunitnum"/>.png</Unpressed>
         </State>
         <State>
           <Number>1</Number>
-          <Pressed>skin:/btn/btn_beatloop_<Variable name="effectunitnum"/>_overdown.png</Pressed>
-          <Unpressed>skin:/btn/btn_beatloop_<Variable name="effectunitnum"/>_over.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_beatloop_<Variable name="effectunitnum"/>_overdown.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_beatloop_<Variable name="effectunitnum"/>_over.png</Unpressed>
         </State>
         <Pos>4,14</Pos>
         <Connection>
@@ -51,13 +51,13 @@
         <NumberStates>2</NumberStates>
         <State>
           <Number>0</Number>
-          <Pressed>skin:/btn/btn_pfl_fx_down.png</Pressed>
-          <Unpressed>skin:/btn/btn_pfl_fx.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_pfl_fx_down.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_pfl_fx.png</Unpressed>
         </State>
         <State>
           <Number>1</Number>
-          <Pressed>skin:/btn/btn_pfl_fx_overdown.png</Pressed>
-          <Unpressed>skin:/btn/btn_pfl_fx_over.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_pfl_fx_overdown.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_pfl_fx_over.png</Unpressed>
         </State>
           <Pos>25,14</Pos>
         <Connection>
@@ -71,13 +71,13 @@
         <NumberStates>2</NumberStates>
         <State>
           <Number>0</Number>
-          <Pressed>skin:/btn/btn_fx<Variable name="effectunitnum"/>_down.png</Pressed>
-          <Unpressed>skin:/btn/btn_fx<Variable name="effectunitnum"/>.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_fx<Variable name="effectunitnum"/>_down.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_fx<Variable name="effectunitnum"/>.png</Unpressed>
         </State>
         <State>
           <Number>1</Number>
-          <Pressed>skin:/btn/btn_fx<Variable name="effectunitnum"/>_overdown.png</Pressed>
-          <Unpressed>skin:/btn/btn_fx<Variable name="effectunitnum"/>_over.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_fx<Variable name="effectunitnum"/>_overdown.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_fx<Variable name="effectunitnum"/>_over.png</Unpressed>
         </State>
           <Pos>4,35</Pos>
         <Connection>
@@ -89,7 +89,7 @@
       <WidgetGroup>
         <Size>17f,5f</Size>
         <Pos>53,14</Pos>
-        <BackPath>skin:/btn/btn_mix.png</BackPath>
+        <BackPath>skins:Shade/btn/btn_mix.png</BackPath>
       </WidgetGroup>
 
       <Knob>
@@ -107,13 +107,13 @@
         <NumberStates>2</NumberStates>
         <State>
           <Number>0</Number>
-          <Pressed>skin:/btn/btn_fxmix_d-w.svg</Pressed>
-          <Unpressed>skin:/btn/btn_fxmix_d-w.svg</Unpressed>
+          <Pressed>skins:Shade/btn/btn_fxmix_d-w.svg</Pressed>
+          <Unpressed>skins:Shade/btn/btn_fxmix_d-w.svg</Unpressed>
         </State>
         <State>
           <Number>1</Number>
-          <Pressed>skin:/btn/btn_fxmix_d+w.svg</Pressed>
-          <Unpressed>skin:/btn/btn_fxmix_d+w.svg</Unpressed>
+          <Pressed>skins:Shade/btn/btn_fxmix_d+w.svg</Pressed>
+          <Unpressed>skins:Shade/btn/btn_fxmix_d+w.svg</Unpressed>
         </State>
         <Size>20f,9f</Size>
         <Pos>52,46</Pos>
@@ -125,7 +125,7 @@
       <WidgetGroup>
         <Size>29f,5f</Size>
         <Pos>76,14</Pos>
-        <BackPath>skin:/btn/btn_super.png</BackPath>
+        <BackPath>skins:Shade/btn/btn_super.png</BackPath>
       </WidgetGroup>
 
       <Knob>

--- a/res/skins/Shade/deck_small.xml
+++ b/res/skins/Shade/deck_small.xml
@@ -185,13 +185,13 @@
                     <NumberStates>2</NumberStates>
                     <State>
                       <Number>0</Number>
-                      <Pressed>skin:/btn/btn_play_deck_small.png</Pressed>
-                      <Unpressed>skin:/btn/btn_play_deck_small.png</Unpressed>
+                      <Pressed>skins:Shade/btn/btn_play_deck_small.png</Pressed>
+                      <Unpressed>skins:Shade/btn/btn_play_deck_small.png</Unpressed>
                     </State>
                     <State>
                       <Number>1</Number>
-                      <Pressed>skin:/btn/btn_play_deck_small_over.png</Pressed>
-                      <Unpressed>skin:/btn/btn_play_deck_small_over.png</Unpressed>
+                      <Pressed>skins:Shade/btn/btn_play_deck_small_over.png</Pressed>
+                      <Unpressed>skins:Shade/btn/btn_play_deck_small_over.png</Unpressed>
                     </State>
                     <Connection>
                       <ConfigKey><Variable name="group"/>,play_indicator</ConfigKey>
@@ -206,8 +206,8 @@
                     </State>
                     <State>
                       <Number>1</Number>
-                      <Pressed>skin:/btn/btn_play_deck_small_preview.png</Pressed>
-                      <Unpressed>skin:/btn/btn_play_deck_small_preview.png</Unpressed>
+                      <Pressed>skins:Shade/btn/btn_play_deck_small_preview.png</Pressed>
+                      <Unpressed>skins:Shade/btn/btn_play_deck_small_preview.png</Unpressed>
                     </State>
                     <Connection>
                       <ConfigKey><Variable name="group"/>,play</ConfigKey>
@@ -220,13 +220,13 @@
                     <NumberStates>2</NumberStates>
                     <State>
                       <Number>0</Number>
-                      <Pressed>skin:/btn/btn_play_deck_small_down.png</Pressed>
+                      <Pressed>skins:Shade/btn/btn_play_deck_small_down.png</Pressed>
                       <Unpressed></Unpressed>
                     </State>
                     <State>
                       <Number>1</Number>
-                      <Pressed>skin:/btn/btn_play_deck_small_overdown.png</Pressed>
-                      <Unpressed>skin:/btn/btn_play_deck_small_over.png</Unpressed>
+                      <Pressed>skins:Shade/btn/btn_play_deck_small_overdown.png</Pressed>
+                      <Unpressed>skins:Shade/btn/btn_play_deck_small_over.png</Unpressed>
                     </State>
                     <Connection>
                       <ConfigKey><Variable name="group"/>,play</ConfigKey>

--- a/res/skins/Shade/deck_transport.xml
+++ b/res/skins/Shade/deck_transport.xml
@@ -12,13 +12,13 @@
         <NumberStates>2</NumberStates>
         <State>
           <Number>0</Number>
-          <Pressed>skin:/btn/btn_src_plus.png</Pressed>
-          <Unpressed>skin:/btn/btn_src_plus.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_src_plus.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_src_plus.png</Unpressed>
         </State>
         <State>
           <Number>1</Number>
-          <Pressed>skin:/btn/btn_src_minus.png</Pressed>
-          <Unpressed>skin:/btn/btn_src_minus.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_src_minus.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_src_minus.png</Unpressed>
         </State>
         <Pos>5,0</Pos>
         <Connection>
@@ -31,13 +31,13 @@
         <NumberStates>2</NumberStates>
         <State>
           <Number>0</Number>
-          <Pressed>skin:/btn/btn_microphone_talkover_overdown.png</Pressed>
-          <Unpressed>skin:/btn/btn_microphone_talkover.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_microphone_talkover_overdown.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_microphone_talkover.png</Unpressed>
         </State>
         <State>
           <Number>1</Number>
-          <Pressed>skin:/btn/btn_microphone_talkover_overdown.png</Pressed>
-          <Unpressed>skin:/btn/btn_microphone_talkover_over.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_microphone_talkover_overdown.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_microphone_talkover_over.png</Unpressed>
         </State>
         <Pos>5,14</Pos>
         <Connection>
@@ -52,13 +52,13 @@
         <NumberStates>2</NumberStates>
         <State>
           <Number>0</Number>
-          <Pressed>skin:/btn/btn_aux_mute_overdown.png</Pressed>
-          <Unpressed>skin:/btn/btn_aux_mute.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_aux_mute_overdown.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_aux_mute.png</Unpressed>
         </State>
         <State>
           <Number>1</Number>
-          <Pressed>skin:/btn/btn_aux_mute_overdown.png</Pressed>
-          <Unpressed>skin:/btn/btn_aux_mute_over.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_aux_mute_overdown.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_aux_mute_over.png</Unpressed>
         </State>
         <Pos>5,35</Pos>
         <Connection>
@@ -77,13 +77,13 @@
         <NumberStates>2</NumberStates>
         <State>
           <Number>0</Number>
-          <Pressed>skin:/btn/btn_sampler_plus.png</Pressed>
-          <Unpressed>skin:/btn/btn_sampler_plus.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_sampler_plus.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_sampler_plus.png</Unpressed>
         </State>
         <State>
           <Number>1</Number>
-          <Pressed>skin:/btn/btn_sampler_minus.png</Pressed>
-          <Unpressed>skin:/btn/btn_sampler_minus.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_sampler_minus.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_sampler_minus.png</Unpressed>
         </State>
         <Pos>53,0</Pos>
         <Connection>
@@ -96,13 +96,13 @@
         <NumberStates>2</NumberStates>
         <State>
           <Number>0</Number>
-          <Pressed>skin:/btn/btn_play_sampler_down.png</Pressed>
-          <Unpressed>skin:/btn/btn_play_sampler.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_play_sampler_down.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_play_sampler.png</Unpressed>
         </State>
         <State>
           <Number>1</Number>
-          <Pressed>skin:/btn/btn_pause_sampler_overdown.png</Pressed>
-          <Unpressed>skin:/btn/btn_pause_sampler_over.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_pause_sampler_overdown.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_pause_sampler_over.png</Unpressed>
         </State>
         <Pos>53,14</Pos>
         <Connection>
@@ -123,13 +123,13 @@
         <NumberStates>2</NumberStates>
         <State>
           <Number>0</Number>
-          <Pressed>skin:/btn/btn_play_sampler_down.png</Pressed>
-          <Unpressed>skin:/btn/btn_play_sampler.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_play_sampler_down.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_play_sampler.png</Unpressed>
         </State>
         <State>
           <Number>1</Number>
-          <Pressed>skin:/btn/btn_pause_sampler_overdown.png</Pressed>
-          <Unpressed>skin:/btn/btn_pause_sampler_over.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_pause_sampler_overdown.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_pause_sampler_over.png</Unpressed>
         </State>
         <Pos>74,14</Pos>
         <Connection>
@@ -150,13 +150,13 @@
         <NumberStates>2</NumberStates>
         <State>
           <Number>0</Number>
-          <Pressed>skin:/btn/btn_play_sampler_down.png</Pressed>
-          <Unpressed>skin:/btn/btn_play_sampler.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_play_sampler_down.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_play_sampler.png</Unpressed>
         </State>
         <State>
           <Number>1</Number>
-          <Pressed>skin:/btn/btn_pause_sampler_overdown.png</Pressed>
-          <Unpressed>skin:/btn/btn_pause_sampler_over.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_pause_sampler_overdown.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_pause_sampler_over.png</Unpressed>
         </State>
         <Pos>53,35</Pos>
         <Connection>
@@ -177,13 +177,13 @@
         <NumberStates>2</NumberStates>
         <State>
           <Number>0</Number>
-          <Pressed>skin:/btn/btn_play_sampler_down.png</Pressed>
-          <Unpressed>skin:/btn/btn_play_sampler.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_play_sampler_down.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_play_sampler.png</Unpressed>
         </State>
         <State>
           <Number>1</Number>
-          <Pressed>skin:/btn/btn_pause_sampler_overdown.png</Pressed>
-          <Unpressed>skin:/btn/btn_pause_sampler_over.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_pause_sampler_overdown.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_pause_sampler_over.png</Unpressed>
         </State>
         <Pos>74,35</Pos>
         <Connection>
@@ -210,13 +210,13 @@
         <NumberStates>2</NumberStates>
         <State>
           <Number>0</Number>
-          <Pressed>skin:/btn/btn_seek_plus.png</Pressed>
-          <Unpressed>skin:/btn/btn_seek_plus.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_seek_plus.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_seek_plus.png</Unpressed>
         </State>
         <State>
           <Number>1</Number>
-          <Pressed>skin:/btn/btn_seek_minus.png</Pressed>
-          <Unpressed>skin:/btn/btn_seek_minus.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_seek_minus.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_seek_minus.png</Unpressed>
         </State>
         <Connection>
           <ConfigKey>[Skin],show_loop_beatjump_controls</ConfigKey>
@@ -228,8 +228,8 @@
         <NumberStates>1</NumberStates>
         <State>
           <Number>0</Number>
-          <Pressed>skin:/btn/btn_beatjump_forward_overdown.png</Pressed>
-          <Unpressed>skin:/btn/btn_beatjump_forward.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_beatjump_forward_overdown.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_beatjump_forward.png</Unpressed>
         </State>
         <Pos>122,14</Pos>
         <Connection>
@@ -246,8 +246,8 @@
         <NumberStates>1</NumberStates>
         <State>
           <Number>0</Number>
-          <Pressed>skin:/btn/btn_beatjump_backward_overdown.png</Pressed>
-          <Unpressed>skin:/btn/btn_beatjump_backward.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_beatjump_backward_overdown.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_beatjump_backward.png</Unpressed>
         </State>
         <Pos>101,14</Pos>
         <Connection>
@@ -271,13 +271,13 @@
         <LeftClickIsPushButton>true</LeftClickIsPushButton>
         <State>
           <Number>0</Number>
-          <Pressed>skin:/btn/btn_reverse_overdown.png</Pressed>
-          <Unpressed>skin:/btn/btn_reverse.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_reverse_overdown.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_reverse.png</Unpressed>
         </State>
         <State>
           <Number>1</Number>
-          <Pressed>skin:/btn/btn_reverse_overdown.png</Pressed>
-          <Unpressed>skin:/btn/btn_reverse_over.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_reverse_overdown.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_reverse_over.png</Unpressed>
         </State>
         <Pos>101,35</Pos>
         <Connection>
@@ -302,13 +302,13 @@
         <NumberStates>2</NumberStates>
         <State>
           <Number>0</Number>
-          <Pressed>skin:/btn/btn_loop_plus.png</Pressed>
-          <Unpressed>skin:/btn/btn_loop_plus.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_loop_plus.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_loop_plus.png</Unpressed>
         </State>
         <State>
           <Number>1</Number>
-          <Pressed>skin:/btn/btn_loop_minus.png</Pressed>
-          <Unpressed>skin:/btn/btn_loop_minus.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_loop_minus.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_loop_minus.png</Unpressed>
         </State>
         <Pos>149,0</Pos>
         <Connection>
@@ -328,13 +328,13 @@
         <RightClickIsPushButton>true</RightClickIsPushButton>
         <State>
           <Number>0</Number>
-          <Pressed>skin:/btn/btn_beatloop_4_down.png</Pressed>
-          <Unpressed>skin:/btn/btn_beatloop_4.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_beatloop_4_down.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_beatloop_4.png</Unpressed>
         </State>
         <State>
           <Number>1</Number>
-          <Pressed>skin:/btn/btn_beatloop_4_overdown.png</Pressed>
-          <Unpressed>skin:/btn/btn_beatloop_4_over.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_beatloop_4_overdown.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_beatloop_4_over.png</Unpressed>
         </State>
         <Pos>149,14</Pos>
         <Connection>
@@ -363,13 +363,13 @@
         <LeftClickIsPushButton>true</LeftClickIsPushButton>
         <State>
           <Number>0</Number>
-          <Pressed>skin:/btn/btn_reloop_down.png</Pressed>
-          <Unpressed>skin:/btn/btn_reloop.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_reloop_down.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_reloop.png</Unpressed>
         </State>
         <State>
           <Number>1</Number>
-          <Pressed>skin:/btn/btn_reloop_overdown.png</Pressed>
-          <Unpressed>skin:/btn/btn_reloop_over.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_reloop_overdown.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_reloop_over.png</Unpressed>
         </State>
         <Connection>
           <ConfigKey>[Channel<Variable name="channum"/>],reloop_toggle</ConfigKey>
@@ -390,8 +390,8 @@
         <NumberStates>1</NumberStates>
         <State>
           <Number>0</Number>
-          <Pressed>skin:/btn/btn_beatloop_halve_overdown.png</Pressed>
-          <Unpressed>skin:/btn/btn_beatloop_halve.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_beatloop_halve_overdown.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_beatloop_halve.png</Unpressed>
         </State>
         <Pos>149,35</Pos>
         <Connection>
@@ -405,8 +405,8 @@
         <NumberStates>1</NumberStates>
         <State>
           <Number>0</Number>
-          <Pressed>skin:/btn/btn_beatloop_double_overdown.png</Pressed>
-          <Unpressed>skin:/btn/btn_beatloop_double.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_beatloop_double_overdown.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_beatloop_double.png</Unpressed>
         </State>
         <Pos>170,35</Pos>
         <Connection>
@@ -428,13 +428,13 @@
         <NumberStates>2</NumberStates>
         <State>
           <Number>0</Number>
-          <Pressed>skin:/btn/btn_hotcues.png</Pressed>
-          <Unpressed>skin:/btn/btn_hotcues.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_hotcues.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_hotcues.png</Unpressed>
         </State>
         <State>
           <Number>1</Number>
-          <Pressed>skin:/btn/btn_intro_cues.png</Pressed>
-          <Unpressed>skin:/btn/btn_intro_cues.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_intro_cues.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_intro_cues.png</Unpressed>
         </State>
         <Pos>196,0</Pos>
         <Connection>
@@ -445,19 +445,19 @@
         <Pos>197,14</Pos>
         <Size>43f,43f</Size>
         <Children>
-          <Template src="skin:hotcue_button.xml">
+          <Template src="skins:Shade/hotcue_button.xml">
             <SetVariable name="hotcue">1</SetVariable>
             <SetVariable name="pos">0,0</SetVariable>
           </Template>
-          <Template src="skin:hotcue_button.xml">
+          <Template src="skins:Shade/hotcue_button.xml">
             <SetVariable name="hotcue">2</SetVariable>
             <SetVariable name="pos">21,0</SetVariable>
           </Template>
-          <Template src="skin:hotcue_button.xml">
+          <Template src="skins:Shade/hotcue_button.xml">
             <SetVariable name="hotcue">3</SetVariable>
             <SetVariable name="pos">0,21</SetVariable>
           </Template>
-          <Template src="skin:hotcue_button.xml">
+          <Template src="skins:Shade/hotcue_button.xml">
             <SetVariable name="hotcue">4</SetVariable>
             <SetVariable name="pos">21,21</SetVariable>
           </Template>
@@ -480,13 +480,13 @@
             <RightClickIsPushButton>true</RightClickIsPushButton>
             <State>
               <Number>0</Number>
-              <Pressed>skin:/btn/btn_intro_start_down.png</Pressed>
-              <Unpressed>skin:/btn/btn_intro_start.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_intro_start_down.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_intro_start.png</Unpressed>
             </State>
             <State>
               <Number>1</Number>
-              <Pressed>skin:/btn/btn_intro_start_overdown.png</Pressed>
-              <Unpressed>skin:/btn/btn_intro_start_over.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_intro_start_overdown.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_intro_start_over.png</Unpressed>
             </State>
             <Connection>
               <ConfigKey>[Channel<Variable name="channum"/>],intro_start_activate</ConfigKey>
@@ -513,13 +513,13 @@
             <RightClickIsPushButton>true</RightClickIsPushButton>
             <State>
               <Number>0</Number>
-              <Pressed>skin:/btn/btn_intro_end_down.png</Pressed>
-              <Unpressed>skin:/btn/btn_intro_end.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_intro_end_down.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_intro_end.png</Unpressed>
             </State>
             <State>
               <Number>1</Number>
-              <Pressed>skin:/btn/btn_intro_end_overdown.png</Pressed>
-              <Unpressed>skin:/btn/btn_intro_end_over.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_intro_end_overdown.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_intro_end_over.png</Unpressed>
             </State>
             <Connection>
               <ConfigKey>[Channel<Variable name="channum"/>],intro_end_activate</ConfigKey>
@@ -546,13 +546,13 @@
             <RightClickIsPushButton>true</RightClickIsPushButton>
             <State>
               <Number>0</Number>
-              <Pressed>skin:/btn/btn_outro_start_down.png</Pressed>
-              <Unpressed>skin:/btn/btn_outro_start.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_outro_start_down.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_outro_start.png</Unpressed>
             </State>
             <State>
               <Number>1</Number>
-              <Pressed>skin:/btn/btn_outro_start_overdown.png</Pressed>
-              <Unpressed>skin:/btn/btn_outro_start_over.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_outro_start_overdown.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_outro_start_over.png</Unpressed>
             </State>
             <Connection>
               <ConfigKey>[Channel<Variable name="channum"/>],outro_start_activate</ConfigKey>
@@ -579,13 +579,13 @@
             <RightClickIsPushButton>true</RightClickIsPushButton>
             <State>
               <Number>0</Number>
-              <Pressed>skin:/btn/btn_outro_end_down.png</Pressed>
-              <Unpressed>skin:/btn/btn_outro_end.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_outro_end_down.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_outro_end.png</Unpressed>
             </State>
             <State>
               <Number>1</Number>
-              <Pressed>skin:/btn/btn_outro_end_overdown.png</Pressed>
-              <Unpressed>skin:/btn/btn_outro_end_over.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_outro_end_overdown.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_outro_end_over.png</Unpressed>
             </State>
             <Connection>
               <ConfigKey>[Channel<Variable name="channum"/>],outro_end_activate</ConfigKey>

--- a/res/skins/Shade/decks_row_small.xml
+++ b/res/skins/Shade/decks_row_small.xml
@@ -9,13 +9,13 @@
         <Layout>horizontal</Layout>
         <Children>
 
-          <Template src="skin:deck_small.xml">
+          <Template src="skins:Shade/deck_small.xml">
             <SetVariable name="channum">1</SetVariable>
           </Template>
 
           <WidgetGroup><Size>4f,40f</Size></WidgetGroup>
 
-          <Template src="skin:deck_small.xml">
+          <Template src="skins:Shade/deck_small.xml">
             <SetVariable name="channum">2</SetVariable>
           </Template>
 

--- a/res/skins/Shade/ducking.xml
+++ b/res/skins/Shade/ducking.xml
@@ -8,18 +8,18 @@
         <NumberStates>3</NumberStates>
         <State>
           <Number>0</Number>
-          <Pressed>skin:/btn/btn_kill_down.png</Pressed>
-          <Unpressed>skin:/btn/btn_kill.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_kill_down.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_kill.png</Unpressed>
         </State>
         <State>
           <Number>1</Number>
-          <Pressed>skin:/btn/btn_ducking_auto_overdown.png</Pressed>
-          <Unpressed>skin:/btn/btn_ducking_auto_over.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_ducking_auto_overdown.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_ducking_auto_over.png</Unpressed>
         </State>
         <State>
           <Number>2</Number>
-          <Pressed>skin:/btn/btn_ducking_man_overdown.png</Pressed>
-          <Unpressed>skin:/btn/btn_ducking_man_over.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_ducking_man_overdown.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_ducking_man_over.png</Unpressed>
         </State>
         <Pos>6,30</Pos>
         <Connection>

--- a/res/skins/Shade/effect_parameter_button.xml
+++ b/res/skins/Shade/effect_parameter_button.xml
@@ -49,13 +49,13 @@
           <NumberStates>2</NumberStates>
           <State>
             <Number>0</Number>
-            <Pressed>skin:/btn/btn_kill_down.png</Pressed>
-            <Unpressed>skin:/btn/btn_kill.png</Unpressed>
+            <Pressed>skins:Shade/btn/btn_kill_down.png</Pressed>
+            <Unpressed>skins:Shade/btn/btn_kill.png</Unpressed>
           </State>
           <State>
             <Number>1</Number>
-            <Pressed>skin:/btn/btn_kill_overdown.png</Pressed>
-            <Unpressed>skin:/btn/btn_kill_over.png</Unpressed>
+            <Pressed>skins:Shade/btn/btn_kill_overdown.png</Pressed>
+            <Unpressed>skins:Shade/btn/btn_kill_over.png</Unpressed>
           </State>
           <Pos>11,57</Pos>
           <Connection>

--- a/res/skins/Shade/effect_parameter_knob.xml
+++ b/res/skins/Shade/effect_parameter_knob.xml
@@ -67,13 +67,13 @@
                 <NumberStates>2</NumberStates>
                 <State>
                   <Number>0</Number>
-                  <Pressed>skin:/btn_link_type/btn_link_inversion_off.png</Pressed>
-                  <Unpressed>skin:/btn_link_type/btn_link_inversion_off.png</Unpressed>
+                  <Pressed>skins:Shade/btn_link_type/btn_link_inversion_off.png</Pressed>
+                  <Unpressed>skins:Shade/btn_link_type/btn_link_inversion_off.png</Unpressed>
                 </State>
                 <State>
                   <Number>1</Number>
-                  <Pressed>skin:/btn_link_type/btn_link_inversion_on.png</Pressed>
-                  <Unpressed>skin:/btn_link_type/btn_link_inversion_on.png</Unpressed>
+                  <Pressed>skins:Shade/btn_link_type/btn_link_inversion_on.png</Pressed>
+                  <Unpressed>skins:Shade/btn_link_type/btn_link_inversion_on.png</Unpressed>
                 </State>
                 <Connection>
                   <ConfigKey>[EffectRack1_EffectUnit<Variable name="effectunitnum"/>_Effect<Variable name="effectnum"/>],parameter<Variable name="effectparameternum"/>_link_inverse</ConfigKey>
@@ -85,28 +85,28 @@
                 <NumberStates>5</NumberStates>
                 <State>
                   <Number>0</Number>
-                  <Pressed>skin:/btn_link_type/btn_link_type_none.png</Pressed>
-                  <Unpressed>skin:/btn_link_type/btn_link_type_none.png</Unpressed>
+                  <Pressed>skins:Shade/btn_link_type/btn_link_type_none.png</Pressed>
+                  <Unpressed>skins:Shade/btn_link_type/btn_link_type_none.png</Unpressed>
                 </State>
                 <State>
                   <Number>1</Number>
-                  <Pressed>skin:/btn_link_type/btn_link_type_linked.png</Pressed>
-                  <Unpressed>skin:/btn_link_type/btn_link_type_linked.png</Unpressed>
+                  <Pressed>skins:Shade/btn_link_type/btn_link_type_linked.png</Pressed>
+                  <Unpressed>skins:Shade/btn_link_type/btn_link_type_linked.png</Unpressed>
                 </State>
                    <State>
                   <Number>2</Number>
-                  <Pressed>skin:/btn_link_type/btn_link_type_left.png</Pressed>
-                  <Unpressed>skin:/btn_link_type/btn_link_type_left.png</Unpressed>
+                  <Pressed>skins:Shade/btn_link_type/btn_link_type_left.png</Pressed>
+                  <Unpressed>skins:Shade/btn_link_type/btn_link_type_left.png</Unpressed>
                 </State>
                 <State>
                     <Number>3</Number>
-                    <Pressed>skin:/btn_link_type/btn_link_type_right.png</Pressed>
-                  <Unpressed>skin:/btn_link_type/btn_link_type_right.png</Unpressed>
+                    <Pressed>skins:Shade/btn_link_type/btn_link_type_right.png</Pressed>
+                  <Unpressed>skins:Shade/btn_link_type/btn_link_type_right.png</Unpressed>
                 </State>
                    <State>
                     <Number>4</Number>
-                    <Pressed>skin:/btn_link_type/btn_link_type_left_right.png</Pressed>
-                  <Unpressed>skin:/btn_link_type/btn_link_type_left_right.png</Unpressed>
+                    <Pressed>skins:Shade/btn_link_type/btn_link_type_left_right.png</Pressed>
+                  <Unpressed>skins:Shade/btn_link_type/btn_link_type_left_right.png</Unpressed>
                 </State>
                 <Connection>
                   <ConfigKey>[EffectRack1_EffectUnit<Variable name="effectunitnum"/>_Effect<Variable name="effectnum"/>],parameter<Variable name="effectparameternum"/>_link_type</ConfigKey>

--- a/res/skins/Shade/effect_parameters.xml
+++ b/res/skins/Shade/effect_parameters.xml
@@ -13,52 +13,52 @@
     }
     </Style>
     <Children>
-      <Template src="skin:effect_parameter_knob.xml">
+      <Template src="skins:Shade/effect_parameter_knob.xml">
         <SetVariable name="effectparameternum">1</SetVariable>
       </Template>
-      <Template src="skin:effect_parameter_button.xml">
+      <Template src="skins:Shade/effect_parameter_button.xml">
         <SetVariable name="effectparameternum">1</SetVariable>
       </Template>
-      <Template src="skin:effect_parameter_knob.xml">
+      <Template src="skins:Shade/effect_parameter_knob.xml">
         <SetVariable name="effectparameternum">2</SetVariable>
       </Template>
-      <Template src="skin:effect_parameter_button.xml">
+      <Template src="skins:Shade/effect_parameter_button.xml">
         <SetVariable name="effectparameternum">2</SetVariable>
       </Template>
-      <Template src="skin:effect_parameter_knob.xml">
+      <Template src="skins:Shade/effect_parameter_knob.xml">
         <SetVariable name="effectparameternum">3</SetVariable>
       </Template>
-      <Template src="skin:effect_parameter_button.xml">
+      <Template src="skins:Shade/effect_parameter_button.xml">
         <SetVariable name="effectparameternum">3</SetVariable>
       </Template>
-      <Template src="skin:effect_parameter_knob.xml">
+      <Template src="skins:Shade/effect_parameter_knob.xml">
         <SetVariable name="effectparameternum">4</SetVariable>
       </Template>
-      <Template src="skin:effect_parameter_button.xml">
+      <Template src="skins:Shade/effect_parameter_button.xml">
         <SetVariable name="effectparameternum">4</SetVariable>
       </Template>
-      <Template src="skin:effect_parameter_knob.xml">
+      <Template src="skins:Shade/effect_parameter_knob.xml">
         <SetVariable name="effectparameternum">5</SetVariable>
       </Template>
-      <Template src="skin:effect_parameter_button.xml">
+      <Template src="skins:Shade/effect_parameter_button.xml">
         <SetVariable name="effectparameternum">5</SetVariable>
       </Template>
-      <Template src="skin:effect_parameter_knob.xml">
+      <Template src="skins:Shade/effect_parameter_knob.xml">
         <SetVariable name="effectparameternum">6</SetVariable>
       </Template>
-      <Template src="skin:effect_parameter_button.xml">
+      <Template src="skins:Shade/effect_parameter_button.xml">
         <SetVariable name="effectparameternum">6</SetVariable>
       </Template>
-      <Template src="skin:effect_parameter_knob.xml">
+      <Template src="skins:Shade/effect_parameter_knob.xml">
         <SetVariable name="effectparameternum">7</SetVariable>
       </Template>
-      <Template src="skin:effect_parameter_button.xml">
+      <Template src="skins:Shade/effect_parameter_button.xml">
         <SetVariable name="effectparameternum">7</SetVariable>
       </Template>
-      <Template src="skin:effect_parameter_knob.xml">
+      <Template src="skins:Shade/effect_parameter_knob.xml">
         <SetVariable name="effectparameternum">8</SetVariable>
       </Template>
-      <Template src="skin:effect_parameter_button.xml">
+      <Template src="skins:Shade/effect_parameter_button.xml">
         <SetVariable name="effectparameternum">8</SetVariable>
       </Template>
     </Children>

--- a/res/skins/Shade/effectrow.xml
+++ b/res/skins/Shade/effectrow.xml
@@ -23,13 +23,13 @@
                   <WidgetGroup>
                     <Size>0e,1f</Size>
                   </WidgetGroup>
-                  <Template src="skin:effectunitsmall.xml">
+                  <Template src="skins:Shade/effectunitsmall.xml">
                     <SetVariable name="effectunitnum">1</SetVariable>
                   </Template>
-                  <Template src="skin:effectunit_parameters.xml">
+                  <Template src="skins:Shade/effectunit_parameters.xml">
                     <SetVariable name="effectunitnum">1</SetVariable>
                   </Template>
-                  <Template src="skin:effectunit_border.xml"/>
+                  <Template src="skins:Shade/effectunit_border.xml"/>
                   <WidgetGroup>
                     <Size>0e,2f</Size>
                   </WidgetGroup>
@@ -43,13 +43,13 @@
                   <WidgetGroup>
                     <Size>0e,1f</Size>
                   </WidgetGroup>
-                  <Template src="skin:effectunitsmall.xml">
+                  <Template src="skins:Shade/effectunitsmall.xml">
                     <SetVariable name="effectunitnum">2</SetVariable>
                   </Template>
-                  <Template src="skin:effectunit_parameters.xml">
+                  <Template src="skins:Shade/effectunit_parameters.xml">
                     <SetVariable name="effectunitnum">2</SetVariable>
                   </Template>
-                  <Template src="skin:effectunit_border.xml"/>
+                  <Template src="skins:Shade/effectunit_border.xml"/>
                   <WidgetGroup>
                     <Size>0e,2f</Size>
                   </WidgetGroup>

--- a/res/skins/Shade/effectslotsmall.xml
+++ b/res/skins/Shade/effectslotsmall.xml
@@ -8,13 +8,13 @@
         <NumberStates>2</NumberStates>
         <State>
           <Number>0</Number>
-          <Pressed>skin:/btn/btn_plus.png</Pressed>
-          <Unpressed>skin:/btn/btn_plus.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_plus.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_plus.png</Unpressed>
         </State>
         <State>
           <Number>1</Number>
-          <Pressed>skin:/btn/btn_minus.png</Pressed>
-          <Unpressed>skin:/btn/btn_minus.png</Unpressed>
+          <Pressed>skins:Shade/btn/btn_minus.png</Pressed>
+          <Unpressed>skins:Shade/btn/btn_minus.png</Unpressed>
         </State>
         <Connection>
           <ConfigKey>[EffectRack1_EffectUnit<Variable name="effectunitnum"/>],focused_effect</ConfigKey>
@@ -34,13 +34,13 @@
             <NumberStates>2</NumberStates>
             <State>
               <Number>0</Number>
-              <Pressed>skin:/btn/btn_beatloop_<Variable name="effectnum"/>_down.png</Pressed>
-              <Unpressed>skin:/btn/btn_beatloop_<Variable name="effectnum"/>.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_beatloop_<Variable name="effectnum"/>_down.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_beatloop_<Variable name="effectnum"/>.png</Unpressed>
             </State>
             <State>
               <Number>1</Number>
-              <Pressed>skin:/btn/btn_beatloop_<Variable name="effectnum"/>_overdown.png</Pressed>
-              <Unpressed>skin:/btn/btn_beatloop_<Variable name="effectnum"/>_over.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_beatloop_<Variable name="effectnum"/>_overdown.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_beatloop_<Variable name="effectnum"/>_over.png</Unpressed>
             </State>
             <Connection>
               <ConfigKey>[EffectRack1_EffectUnit<Variable name="effectunitnum"/>_Effect<Variable name="effectnum"/>],enabled</ConfigKey>
@@ -70,7 +70,7 @@
         <Pos>65,3</Pos>
         <Size>94f,22f</Size>
         <Children>
-          <Template src="skin:effect_selector_button.xml">
+          <Template src="skins:Shade/effect_selector_button.xml">
             <SetVariable name="effectunitnum"><Variable name="effectunitnum"/></SetVariable>
             <SetVariable name="effectnum"><Variable name="effectnum"/></SetVariable>
           </Template>

--- a/res/skins/Shade/effectunit_parameters.xml
+++ b/res/skins/Shade/effectunit_parameters.xml
@@ -22,15 +22,15 @@
               <BindProperty>visible</BindProperty>
             </Connection>
           </WidgetGroup>
-          <Template src="skin:effect_parameters.xml">
+          <Template src="skins:Shade/effect_parameters.xml">
             <SetVariable name="effectunitnum"><Variable name="effectunitnum"/></SetVariable>
             <SetVariable name="effectnum">1</SetVariable>
           </Template>
-          <Template src="skin:effect_parameters.xml">
+          <Template src="skins:Shade/effect_parameters.xml">
             <SetVariable name="effectunitnum"><Variable name="effectunitnum"/></SetVariable>
             <SetVariable name="effectnum">2</SetVariable>
           </Template>
-          <Template src="skin:effect_parameters.xml">
+          <Template src="skins:Shade/effect_parameters.xml">
             <SetVariable name="effectunitnum"><Variable name="effectunitnum"/></SetVariable>
             <SetVariable name="effectnum">3</SetVariable>
           </Template>

--- a/res/skins/Shade/effectunitsmall.xml
+++ b/res/skins/Shade/effectunitsmall.xml
@@ -15,15 +15,15 @@
         <BackPath>style/style_bg_looping.png</BackPath>
         <Layout>horizontal</Layout>
         <Children>
-          <Template src="skin:effectslotsmall.xml">
+          <Template src="skins:Shade/effectslotsmall.xml">
             <SetVariable name="effectunitnum"><Variable name="effectunitnum"/></SetVariable>
             <SetVariable name="effectnum">1</SetVariable>
           </Template>
-          <Template src="skin:effectslotsmall.xml">
+          <Template src="skins:Shade/effectslotsmall.xml">
             <SetVariable name="effectunitnum"><Variable name="effectunitnum"/></SetVariable>
             <SetVariable name="effectnum">2</SetVariable>
           </Template>
-          <Template src="skin:effectslotsmall.xml">
+          <Template src="skins:Shade/effectslotsmall.xml">
             <SetVariable name="effectunitnum"><Variable name="effectunitnum"/></SetVariable>
             <SetVariable name="effectnum">3</SetVariable>
           </Template>

--- a/res/skins/Shade/hotcue_button.xml
+++ b/res/skins/Shade/hotcue_button.xml
@@ -8,13 +8,13 @@
     <NumberStates>2</NumberStates>
     <State>
       <Number>0</Number>
-      <Pressed>skin:/btn/btn_hotcue_<Variable name="hotcue"/>.png</Pressed>
-      <Unpressed>skin:/btn/btn_hotcue_<Variable name="hotcue"/>.png</Unpressed>
+      <Pressed>skins:Shade/btn/btn_hotcue_<Variable name="hotcue"/>.png</Pressed>
+      <Unpressed>skins:Shade/btn/btn_hotcue_<Variable name="hotcue"/>.png</Unpressed>
     </State>
     <State>
       <Number>1</Number>
-      <Pressed>skin:/btn/btn_hotcue_<Variable name="hotcue"/>_overdown.png</Pressed>
-      <Unpressed>skin:/btn/btn_hotcue_<Variable name="hotcue"/>_over.png</Unpressed>
+      <Pressed>skins:Shade/btn/btn_hotcue_<Variable name="hotcue"/>_overdown.png</Pressed>
+      <Unpressed>skins:Shade/btn/btn_hotcue_<Variable name="hotcue"/>_over.png</Unpressed>
     </State>
   </HotcueButton>
 </Template>

--- a/res/skins/Shade/library.xml
+++ b/res/skins/Shade/library.xml
@@ -23,7 +23,7 @@
                 <SizePolicy>i,min</SizePolicy>
                 <Layout>vertical</Layout>
                 <Children>
-                  <Template src="skin:preview_deck.xml"/>
+                  <Template src="skins:Shade/preview_deck.xml"/>
 
                   <SearchBox></SearchBox>
 

--- a/res/skins/Shade/looping.xml
+++ b/res/skins/Shade/looping.xml
@@ -19,8 +19,8 @@
             <NumberStates>1</NumberStates>
             <State>
               <Number>0</Number>
-              <Pressed>skin:/btn/btn_beatjump_backward_overdown.png</Pressed>
-              <Unpressed>skin:/btn/btn_beatjump_backward.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_beatjump_backward_overdown.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_beatjump_backward.png</Unpressed>
             </State>
             <Pos>5,10</Pos>
             <Connection>
@@ -53,8 +53,8 @@
             <NumberStates>1</NumberStates>
             <State>
               <Number>0</Number>
-              <Pressed>skin:/btn/btn_beatjump_forward_overdown.png</Pressed>
-              <Unpressed>skin:/btn/btn_beatjump_forward.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_beatjump_forward_overdown.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_beatjump_forward.png</Unpressed>
             </State>
             <Pos>77,10</Pos>
             <Connection>
@@ -72,8 +72,8 @@
             <NumberStates>1</NumberStates>
             <State>
               <Number>0</Number>
-              <Pressed>skin:/btn/btn_rewind_overdown.png</Pressed>
-              <Unpressed>skin:/btn/btn_rewind.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_rewind_overdown.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_rewind.png</Unpressed>
             </State>
             <Pos>102,10</Pos>
             <Connection>
@@ -93,8 +93,8 @@
             <NumberStates>1</NumberStates>
             <State>
               <Number>0</Number>
-              <Pressed>skin:/btn/btn_forward_overdown.png</Pressed>
-              <Unpressed>skin:/btn/btn_forward.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_forward_overdown.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_forward.png</Unpressed>
             </State>
             <Pos>124,10</Pos>
             <Connection>
@@ -140,13 +140,13 @@
             <LeftClickIsPushButton>true</LeftClickIsPushButton>
             <State>
               <Number>0</Number>
-              <Pressed>skin:/btn/btn_reloop_down.png</Pressed>
-              <Unpressed>skin:/btn/btn_reloop.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_reloop_down.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_reloop.png</Unpressed>
             </State>
             <State>
               <Number>1</Number>
-              <Pressed>skin:/btn/btn_reloop_overdown.png</Pressed>
-              <Unpressed>skin:/btn/btn_reloop_over.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_reloop_overdown.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_reloop_over.png</Unpressed>
             </State>
             <Connection>
               <ConfigKey>[Channel<Variable name="channum"/>],reloop_toggle</ConfigKey>
@@ -168,8 +168,8 @@
             <NumberStates>1</NumberStates>
             <State>
               <Number>0</Number>
-              <Pressed>skin:/btn/btn_loop_in_overdown.png</Pressed>
-              <Unpressed>skin:/btn/btn_loop_in.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_loop_in_overdown.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_loop_in.png</Unpressed>
             </State>
             <Connection>
               <ConfigKey>[Channel<Variable name="channum"/>],loop_in</ConfigKey>
@@ -184,8 +184,8 @@
             <NumberStates>1</NumberStates>
             <State>
               <Number>0</Number>
-              <Pressed>skin:/btn/btn_loop_out_overdown.png</Pressed>
-              <Unpressed>skin:/btn/btn_loop_out.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_loop_out_overdown.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_loop_out.png</Unpressed>
             </State>
             <Connection>
               <ConfigKey>[Channel<Variable name="channum"/>],loop_out</ConfigKey>
@@ -200,8 +200,8 @@
             <NumberStates>1</NumberStates>
             <State>
               <Number>0</Number>
-              <Pressed>skin:/btn/btn_beatloop_enable_overdown.png</Pressed>
-              <Unpressed>skin:/btn/btn_beatloop_enable.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_beatloop_enable_overdown.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_beatloop_enable.png</Unpressed>
             </State>
             <Connection>
               <ConfigKey>[Channel<Variable name="channum"/>],beatloop_activate</ConfigKey>
@@ -242,13 +242,13 @@
             <RightClickIsPushButton>true</RightClickIsPushButton>
             <State>
               <Number>0</Number>
-              <Pressed>skin:/btn/btn_beatloop_0125_down.png</Pressed>
-              <Unpressed>skin:/btn/btn_beatloop_0125.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_beatloop_0125_down.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_beatloop_0125.png</Unpressed>
             </State>
             <State>
               <Number>1</Number>
-              <Pressed>skin:/btn/btn_beatloop_0125_overdown.png</Pressed>
-              <Unpressed>skin:/btn/btn_beatloop_0125_over.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_beatloop_0125_overdown.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_beatloop_0125_over.png</Unpressed>
             </State>
             <Connection>
               <ConfigKey>[Channel<Variable name="channum"/>],beatloop_0.125_toggle</ConfigKey>
@@ -274,13 +274,13 @@
             <RightClickIsPushButton>true</RightClickIsPushButton>
             <State>
               <Number>0</Number>
-              <Pressed>skin:/btn/btn_beatloop_0250_down.png</Pressed>
-              <Unpressed>skin:/btn/btn_beatloop_0250.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_beatloop_0250_down.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_beatloop_0250.png</Unpressed>
             </State>
             <State>
               <Number>1</Number>
-              <Pressed>skin:/btn/btn_beatloop_0250_overdown.png</Pressed>
-              <Unpressed>skin:/btn/btn_beatloop_0250_over.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_beatloop_0250_overdown.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_beatloop_0250_over.png</Unpressed>
             </State>
             <Connection>
               <ConfigKey>[Channel<Variable name="channum"/>],beatloop_0.25_toggle</ConfigKey>
@@ -306,13 +306,13 @@
             <RightClickIsPushButton>true</RightClickIsPushButton>
             <State>
               <Number>0</Number>
-              <Pressed>skin:/btn/btn_beatloop_0500_down.png</Pressed>
-              <Unpressed>skin:/btn/btn_beatloop_0500.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_beatloop_0500_down.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_beatloop_0500.png</Unpressed>
             </State>
             <State>
               <Number>1</Number>
-              <Pressed>skin:/btn/btn_beatloop_0500_overdown.png</Pressed>
-              <Unpressed>skin:/btn/btn_beatloop_0500_over.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_beatloop_0500_overdown.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_beatloop_0500_over.png</Unpressed>
             </State>
             <Connection>
               <ConfigKey>[Channel<Variable name="channum"/>],beatloop_0.5_toggle</ConfigKey>
@@ -336,13 +336,13 @@
             <RightClickIsPushButton>true</RightClickIsPushButton>
             <State>
               <Number>0</Number>
-              <Pressed>skin:/btn/btn_beatloop_1_down.png</Pressed>
-              <Unpressed>skin:/btn/btn_beatloop_1.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_beatloop_1_down.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_beatloop_1.png</Unpressed>
             </State>
             <State>
               <Number>1</Number>
-              <Pressed>skin:/btn/btn_beatloop_1_overdown.png</Pressed>
-              <Unpressed>skin:/btn/btn_beatloop_1_over.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_beatloop_1_overdown.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_beatloop_1_over.png</Unpressed>
             </State>
             <Pos>223,10</Pos>
             <Connection>
@@ -367,13 +367,13 @@
             <RightClickIsPushButton>true</RightClickIsPushButton>
             <State>
               <Number>0</Number>
-              <Pressed>skin:/btn/btn_beatloop_2_down.png</Pressed>
-              <Unpressed>skin:/btn/btn_beatloop_2.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_beatloop_2_down.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_beatloop_2.png</Unpressed>
             </State>
             <State>
               <Number>1</Number>
-              <Pressed>skin:/btn/btn_beatloop_2_overdown.png</Pressed>
-              <Unpressed>skin:/btn/btn_beatloop_2_over.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_beatloop_2_overdown.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_beatloop_2_over.png</Unpressed>
             </State>
             <Pos>244,10</Pos>
             <Connection>
@@ -398,13 +398,13 @@
             <RightClickIsPushButton>true</RightClickIsPushButton>
             <State>
               <Number>0</Number>
-              <Pressed>skin:/btn/btn_beatloop_4_down.png</Pressed>
-              <Unpressed>skin:/btn/btn_beatloop_4.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_beatloop_4_down.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_beatloop_4.png</Unpressed>
             </State>
             <State>
               <Number>1</Number>
-              <Pressed>skin:/btn/btn_beatloop_4_overdown.png</Pressed>
-              <Unpressed>skin:/btn/btn_beatloop_4_over.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_beatloop_4_overdown.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_beatloop_4_over.png</Unpressed>
             </State>
             <Pos>265,10</Pos>
             <Connection>
@@ -429,13 +429,13 @@
             <RightClickIsPushButton>true</RightClickIsPushButton>
             <State>
               <Number>0</Number>
-              <Pressed>skin:/btn/btn_beatloop_8_down.png</Pressed>
-              <Unpressed>skin:/btn/btn_beatloop_8.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_beatloop_8_down.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_beatloop_8.png</Unpressed>
             </State>
             <State>
               <Number>1</Number>
-              <Pressed>skin:/btn/btn_beatloop_8_overdown.png</Pressed>
-              <Unpressed>skin:/btn/btn_beatloop_8_over.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_beatloop_8_overdown.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_beatloop_8_over.png</Unpressed>
             </State>
             <Pos>286,10</Pos>
             <Connection>
@@ -460,13 +460,13 @@
             <RightClickIsPushButton>true</RightClickIsPushButton>
             <State>
               <Number>0</Number>
-              <Pressed>skin:/btn/btn_beatloop_16_down.png</Pressed>
-              <Unpressed>skin:/btn/btn_beatloop_16.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_beatloop_16_down.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_beatloop_16.png</Unpressed>
             </State>
             <State>
               <Number>1</Number>
-              <Pressed>skin:/btn/btn_beatloop_16_overdown.png</Pressed>
-              <Unpressed>skin:/btn/btn_beatloop_16_over.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_beatloop_16_overdown.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_beatloop_16_over.png</Unpressed>
             </State>
             <Pos>307,10</Pos>
             <Connection>

--- a/res/skins/Shade/microphone.xml
+++ b/res/skins/Shade/microphone.xml
@@ -12,8 +12,8 @@
       -->
       <StatusLight>
         <TooltipId>microphone_peak_indicator</TooltipId>
-        <PathStatusLight>skin:/style/volume_clipping_microphone_over.png</PathStatusLight>
-        <PathBack>skin:/style/volume_clipping_microphone.png</PathBack>
+        <PathStatusLight>skins:Shade/style/volume_clipping_microphone_over.png</PathStatusLight>
+        <PathBack>skins:Shade/style/volume_clipping_microphone.png</PathBack>
         <Pos>82,6</Pos>
         <Connection>
           <ConfigKey>[Microphone<Variable name="micnum"/>],peak_indicator</ConfigKey>
@@ -32,8 +32,8 @@
         <Children>
           <VuMeter>
             <TooltipId>microphone_VuMeter</TooltipId>
-            <PathVu>skin:/style/volume_display_microphone_over.png</PathVu>
-            <PathBack>skin:/style/volume_display_microphone.png</PathBack>
+            <PathVu>skins:Shade/style/volume_display_microphone_over.png</PathVu>
+            <PathBack>skins:Shade/style/volume_display_microphone.png</PathBack>
             <PeakHoldSize>5</PeakHoldSize>
             <PeakHoldTime>500</PeakHoldTime>
             <PeakFallTime>50</PeakFallTime>

--- a/res/skins/Shade/mixer_panel.xml
+++ b/res/skins/Shade/mixer_panel.xml
@@ -92,13 +92,13 @@
                 <NumberStates>2</NumberStates>
                 <State>
                   <Number>0</Number>
-                  <Pressed>skin:/btn/btn_play_deck.png</Pressed>
-                  <Unpressed>skin:/btn/btn_play_deck.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_play_deck.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_play_deck.png</Unpressed>
                 </State>
                 <State>
                   <Number>1</Number>
-                  <Pressed>skin:/btn/btn_play_deck_over.png</Pressed>
-                  <Unpressed>skin:/btn/btn_play_deck_over.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_play_deck_over.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_play_deck_over.png</Unpressed>
                 </State>
                 <Connection>
                   <ConfigKey>[Channel1],play_indicator</ConfigKey>
@@ -113,8 +113,8 @@
                 </State>
                 <State>
                   <Number>1</Number>
-                  <Pressed>skin:/btn/btn_play_deck_preview.png</Pressed>
-                  <Unpressed>skin:/btn/btn_play_deck_preview.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_play_deck_preview.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_play_deck_preview.png</Unpressed>
                 </State>
                 <Connection>
                   <ConfigKey>[Channel1],play</ConfigKey>
@@ -127,13 +127,13 @@
                 <NumberStates>2</NumberStates>
                 <State>
                   <Number>0</Number>
-                  <Pressed>skin:/btn/btn_play_deck_down.png</Pressed>
+                  <Pressed>skins:Shade/btn/btn_play_deck_down.png</Pressed>
                   <Unpressed></Unpressed>
                 </State>
                 <State>
                   <Number>1</Number>
-                  <Pressed>skin:/btn/btn_play_deck_overdown.png</Pressed>
-                  <Unpressed>skin:/btn/btn_play_deck_over.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_play_deck_overdown.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_play_deck_over.png</Unpressed>
                 </State>
                 <Connection>
                   <ConfigKey>[Channel1],play</ConfigKey>
@@ -156,13 +156,13 @@
                 <NumberStates>2</NumberStates>
                 <State>
                   <Number>0</Number>
-                  <Pressed>skin:/btn/btn_play_deck.png</Pressed>
-                  <Unpressed>skin:/btn/btn_play_deck.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_play_deck.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_play_deck.png</Unpressed>
                 </State>
                 <State>
                   <Number>1</Number>
-                  <Pressed>skin:/btn/btn_play_deck_over.png</Pressed>
-                  <Unpressed>skin:/btn/btn_play_deck_over.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_play_deck_over.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_play_deck_over.png</Unpressed>
                 </State>
                 <Connection>
                   <ConfigKey>[Channel2],play_indicator</ConfigKey>
@@ -177,8 +177,8 @@
                 </State>
                 <State>
                   <Number>1</Number>
-                  <Pressed>skin:/btn/btn_deck_preview.png</Pressed>
-                  <Unpressed>skin:/btn/btn_deck_preview.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_deck_preview.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_deck_preview.png</Unpressed>
                 </State>
                 <Connection>
                   <ConfigKey>[Channel2],play</ConfigKey>
@@ -191,13 +191,13 @@
                 <NumberStates>2</NumberStates>
                 <State>
                   <Number>0</Number>
-                  <Pressed>skin:/btn/btn_play_deck_down.png</Pressed>
+                  <Pressed>skins:Shade/btn/btn_play_deck_down.png</Pressed>
                   <Unpressed></Unpressed>
                 </State>
                 <State>
                   <Number>1</Number>
-                  <Pressed>skin:/btn/btn_play_deck_overdown.png</Pressed>
-                  <Unpressed>skin:/btn/btn_play_deck_over.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_play_deck_overdown.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_play_deck_over.png</Unpressed>
                 </State>
                 <Connection>
                   <ConfigKey>[Channel2],play</ConfigKey>
@@ -223,13 +223,13 @@
                 <NumberStates>2</NumberStates>
                 <State>
                   <Number>0</Number>
-                  <Pressed>skin:/btn/btn_cue_down.png</Pressed>
-                  <Unpressed>skin:/btn/btn_cue.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_cue_down.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_cue.png</Unpressed>
                 </State>
                 <State>
                   <Number>1</Number>
-                  <Pressed>skin:/btn/btn_cue_overdown.png</Pressed>
-                  <Unpressed>skin:/btn/btn_cue_over.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_cue_overdown.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_cue_over.png</Unpressed>
                 </State>
                 <Pos>11,179</Pos>
                 <Connection>
@@ -251,13 +251,13 @@
                 <NumberStates>2</NumberStates>
                 <State>
                   <Number>0</Number>
-                  <Pressed>skin:/btn/btn_cue_down.png</Pressed>
-                  <Unpressed>skin:/btn/btn_cue.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_cue_down.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_cue.png</Unpressed>
                 </State>
                 <State>
                   <Number>1</Number>
-                  <Pressed>skin:/btn/btn_cue_overdown.png</Pressed>
-                  <Unpressed>skin:/btn/btn_cue_over.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_cue_overdown.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_cue_over.png</Unpressed>
                 </State>
                 <Pos>203,179</Pos>
                 <Connection>
@@ -285,13 +285,13 @@
                 <NumberStates>2</NumberStates>
                 <State>
                   <Number>0</Number>
-                  <Pressed>skin:/btn/btn_pfl_down.png</Pressed>
-                  <Unpressed>skin:/btn/btn_pfl.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_pfl_down.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_pfl.png</Unpressed>
                 </State>
                 <State>
                   <Number>1</Number>
-                  <Pressed>skin:/btn/btn_pfl_overdown.png</Pressed>
-                  <Unpressed>skin:/btn/btn_pfl_over.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_pfl_overdown.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_pfl_over.png</Unpressed>
                 </State>
                 <Pos>65,161</Pos>
                 <Connection>
@@ -303,13 +303,13 @@
                 <NumberStates>2</NumberStates>
                 <State>
                   <Number>0</Number>
-                  <Pressed>skin:/btn/btn_pfl_down.png</Pressed>
-                  <Unpressed>skin:/btn/btn_pfl.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_pfl_down.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_pfl.png</Unpressed>
                 </State>
                 <State>
                   <Number>1</Number>
-                  <Pressed>skin:/btn/btn_pfl_overdown.png</Pressed>
-                  <Unpressed>skin:/btn/btn_pfl_over.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_pfl_overdown.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_pfl_over.png</Unpressed>
                 </State>
                 <Pos>160,161</Pos>
                 <Connection>
@@ -329,13 +329,13 @@
                 <NumberStates>2</NumberStates>
                 <State>
                   <Number>0</Number>
-                  <Pressed>skin:/btn/btn_kill_down.png</Pressed>
-                  <Unpressed>skin:/btn/btn_kill.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_kill_down.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_kill.png</Unpressed>
                 </State>
                 <State>
                   <Number>1</Number>
-                  <Pressed>skin:/btn/btn_kill_overdown.png</Pressed>
-                  <Unpressed>skin:/btn/btn_kill_over.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_kill_overdown.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_kill_over.png</Unpressed>
                 </State>
                 <Pos>11,84</Pos>
                 <Connection>
@@ -355,13 +355,13 @@
                 <NumberStates>2</NumberStates>
                 <State>
                   <Number>0</Number>
-                  <Pressed>skin:/btn/btn_kill_down.png</Pressed>
-                  <Unpressed>skin:/btn/btn_kill.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_kill_down.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_kill.png</Unpressed>
                 </State>
                 <State>
                   <Number>1</Number>
-                  <Pressed>skin:/btn/btn_kill_overdown.png</Pressed>
-                  <Unpressed>skin:/btn/btn_kill_over.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_kill_overdown.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_kill_over.png</Unpressed>
                 </State>
                 <Pos>11,113</Pos>
                 <Connection>
@@ -381,13 +381,13 @@
                 <NumberStates>2</NumberStates>
                 <State>
                   <Number>0</Number>
-                  <Pressed>skin:/btn/btn_kill_down.png</Pressed>
-                  <Unpressed>skin:/btn/btn_kill.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_kill_down.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_kill.png</Unpressed>
                 </State>
                 <State>
                   <Number>1</Number>
-                  <Pressed>skin:/btn/btn_kill_overdown.png</Pressed>
-                  <Unpressed>skin:/btn/btn_kill_over.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_kill_overdown.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_kill_over.png</Unpressed>
                 </State>
                 <Pos>11,142</Pos>
                 <Connection>
@@ -408,13 +408,13 @@
                 <NumberStates>2</NumberStates>
                 <State>
                   <Number>0</Number>
-                  <Pressed>skin:/btn/btn_kill_down.png</Pressed>
-                  <Unpressed>skin:/btn/btn_kill.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_kill_down.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_kill.png</Unpressed>
                 </State>
                 <State>
                   <Number>1</Number>
-                  <Pressed>skin:/btn/btn_kill_overdown.png</Pressed>
-                  <Unpressed>skin:/btn/btn_kill_over.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_kill_overdown.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_kill_over.png</Unpressed>
                 </State>
                 <Pos>229,84</Pos>
                 <Connection>
@@ -434,13 +434,13 @@
                 <NumberStates>2</NumberStates>
                 <State>
                   <Number>0</Number>
-                  <Pressed>skin:/btn/btn_kill_down.png</Pressed>
-                  <Unpressed>skin:/btn/btn_kill.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_kill_down.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_kill.png</Unpressed>
                 </State>
                 <State>
                   <Number>1</Number>
-                  <Pressed>skin:/btn/btn_kill_overdown.png</Pressed>
-                  <Unpressed>skin:/btn/btn_kill_over.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_kill_overdown.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_kill_over.png</Unpressed>
                 </State>
                 <Pos>229,113</Pos>
                 <Connection>
@@ -460,13 +460,13 @@
                 <NumberStates>2</NumberStates>
                 <State>
                   <Number>0</Number>
-                  <Pressed>skin:/btn/btn_kill_down.png</Pressed>
-                  <Unpressed>skin:/btn/btn_kill.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_kill_down.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_kill.png</Unpressed>
                 </State>
                 <State>
                   <Number>1</Number>
-                  <Pressed>skin:/btn/btn_kill_overdown.png</Pressed>
-                  <Unpressed>skin:/btn/btn_kill_over.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_kill_overdown.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_kill_over.png</Unpressed>
                 </State>
                 <Pos>229,142</Pos>
                 <Connection>
@@ -529,8 +529,8 @@
                 <Children>
                   <VuMeter>
                     <TooltipId>audio_latency_usage</TooltipId>
-                    <PathVu>skin:/audio_latency/audio_latency_usage.png</PathVu>
-                    <PathBack>skin:/audio_latency/audio_latency_usage_back.png</PathBack>
+                    <PathVu>skins:Shade/audio_latency/audio_latency_usage.png</PathVu>
+                    <PathBack>skins:Shade/audio_latency/audio_latency_usage_back.png</PathBack>
                     <PeakHoldSize>5</PeakHoldSize>
                     <PeakHoldTime>1000</PeakHoldTime>
                     <PeakFallTime>100</PeakFallTime>
@@ -547,28 +547,28 @@
                 <NumberStates>5</NumberStates>
                 <State>
                   <Number>0</Number>
-                  <Pressed>skin:/btn/btn_broadcast_unconnected.png</Pressed>
-                  <Unpressed>skin:/btn/btn_broadcast_unconnected.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_broadcast_unconnected.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_broadcast_unconnected.png</Unpressed>
                 </State>
                 <State>
                   <Number>1</Number>
-                  <Pressed>skin:/btn/btn_broadcast_connecting.png</Pressed>
-                  <Unpressed>skin:/btn/btn_broadcast_connecting.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_broadcast_connecting.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_broadcast_connecting.png</Unpressed>
                 </State>
                 <State>
                   <Number>2</Number>
-                  <Pressed>skin:/btn/btn_broadcast_connected.png</Pressed>
-                  <Unpressed>skin:/btn/btn_broadcast_connected.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_broadcast_connected.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_broadcast_connected.png</Unpressed>
                 </State>
                 <State>
                   <Number>3</Number>
-                  <Pressed>skin:/btn/btn_broadcast_failure.png</Pressed>
-                  <Unpressed>skin:/btn/btn_broadcast_failure.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_broadcast_failure.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_broadcast_failure.png</Unpressed>
                 </State>
                 <State>
                   <Number>4</Number>
-                  <Pressed>skin:/btn/btn_broadcast_warning.png</Pressed>
-                  <Unpressed>skin:/btn/btn_broadcast_warning.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_broadcast_warning.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_broadcast_warning.png</Unpressed>
                 </State>
                 <Pos>111,29</Pos>
                 <Connection>
@@ -591,18 +591,18 @@
                 <NumberStates>3</NumberStates>
                 <State>
                   <Number>0</Number>
-                  <Pressed>skin:/btn/btn_record_off.png</Pressed>
-                  <Unpressed>skin:/btn/btn_record_off.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_record_off.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_record_off.png</Unpressed>
                 </State>
                   <State>
                   <Number>1</Number>
-                  <Pressed>skin:/btn/btn_record_ready.png</Pressed>
-                  <Unpressed>skin:/btn/btn_record_ready.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_record_ready.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_record_ready.png</Unpressed>
                 </State>
                 <State>
                   <Number>2</Number>
-                  <Pressed>skin:/btn/btn_record_on.png</Pressed>
-                  <Unpressed>skin:/btn/btn_record_on.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_record_on.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_record_on.png</Unpressed>
                 </State>
                 <Pos>214,18</Pos>
                 <Connection>
@@ -696,13 +696,13 @@
                 <NumberStates>2</NumberStates>
                 <State>
                   <Number>0</Number>
-                  <Pressed>skin:/btn/btn_headsplit_down.png</Pressed>
-                  <Unpressed>skin:/btn/btn_headsplit.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_headsplit_down.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_headsplit.png</Unpressed>
                 </State>
                 <State>
                   <Number>1</Number>
-                  <Pressed>skin:/btn/btn_headsplit_overdown.png</Pressed>
-                  <Unpressed>skin:/btn/btn_headsplit_over.png</Unpressed>
+                  <Pressed>skins:Shade/btn/btn_headsplit_overdown.png</Pressed>
+                  <Unpressed>skins:Shade/btn/btn_headsplit_over.png</Unpressed>
                 </State>
                 <Pos>11,18</Pos>
                 <Connection>
@@ -839,8 +839,8 @@
                 <Children>
                   <VuMeter>
                     <TooltipId>channel_VuMeter</TooltipId>
-                    <PathVu>skin:/style/volume_display_over.png</PathVu>
-                    <PathBack>skin:/style/volume_display.png</PathBack>
+                    <PathVu>skins:Shade/style/volume_display_over.png</PathVu>
+                    <PathBack>skins:Shade/style/volume_display.png</PathBack>
                     <Horizontal>false</Horizontal>
                     <PeakHoldSize>5</PeakHoldSize>
                     <PeakHoldTime>500</PeakHoldTime>
@@ -860,8 +860,8 @@
                 <Children>
                   <VuMeter>
                     <TooltipId>channel_VuMeter</TooltipId>
-                    <PathVu>skin:/style/volume_display_over.png</PathVu>
-                    <PathBack>skin:/style/volume_display.png</PathBack>
+                    <PathVu>skins:Shade/style/volume_display_over.png</PathVu>
+                    <PathBack>skins:Shade/style/volume_display.png</PathBack>
                     <Horizontal>false</Horizontal>
                     <PeakHoldSize>5</PeakHoldSize>
                     <PeakHoldTime>500</PeakHoldTime>
@@ -880,8 +880,8 @@
                 <Children>
                   <VuMeter>
                     <TooltipId>main_VuMeterL</TooltipId>
-                    <PathVu>skin:/style/volume_display_main_over.png</PathVu>
-                    <PathBack>skin:/style/volume_display_main.png</PathBack>
+                    <PathVu>skins:Shade/style/volume_display_main_over.png</PathVu>
+                    <PathBack>skins:Shade/style/volume_display_main.png</PathBack>
                     <PeakHoldSize>5</PeakHoldSize>
                     <PeakHoldTime>500</PeakHoldTime>
                     <PeakFallTime>50</PeakFallTime>
@@ -899,8 +899,8 @@
                 <Children>
                   <VuMeter>
                     <TooltipId>main_VuMeterR</TooltipId>
-                    <PathVu>skin:/style/volume_display_main_over.png</PathVu>
-                    <PathBack>skin:/style/volume_display_main.png</PathBack>
+                    <PathVu>skins:Shade/style/volume_display_main_over.png</PathVu>
+                    <PathBack>skins:Shade/style/volume_display_main.png</PathBack>
                     <PeakHoldSize>5</PeakHoldSize>
                     <PeakHoldTime>500</PeakHoldTime>
                     <PeakFallTime>50</PeakFallTime>
@@ -918,8 +918,8 @@
               -->
               <StatusLight>
                 <TooltipId>channel_peak_indicator</TooltipId>
-                <PathStatusLight>skin:/style/volume_clipping_over.png</PathStatusLight>
-                <PathBack>skin:/style/volume_clipping.png</PathBack>
+                <PathStatusLight>skins:Shade/style/volume_clipping_over.png</PathStatusLight>
+                <PathBack>skins:Shade/style/volume_clipping.png</PathBack>
                 <Pos>107,57</Pos>
                 <Connection>
                   <ConfigKey>[Channel1],peak_indicator</ConfigKey>
@@ -927,8 +927,8 @@
               </StatusLight>
               <StatusLight>
                 <TooltipId>channel_peak_indicator</TooltipId>
-                <PathStatusLight>skin:/style/volume_clipping_over.png</PathStatusLight>
-                <PathBack>skin:/style/volume_clipping.png</PathBack>
+                <PathStatusLight>skins:Shade/style/volume_clipping_over.png</PathStatusLight>
+                <PathBack>skins:Shade/style/volume_clipping.png</PathBack>
                 <Pos>143,57</Pos>
                 <Connection>
                   <ConfigKey>[Channel2],peak_indicator</ConfigKey>
@@ -936,8 +936,8 @@
               </StatusLight>
               <StatusLight>
                 <TooltipId>main_peak_indicator_left</TooltipId>
-                <PathStatusLight>skin:/style/volume_clipping_main_over.png</PathStatusLight>
-                <PathBack>skin:/style/volume_clipping_main.png</PathBack>
+                <PathStatusLight>skins:Shade/style/volume_clipping_main_over.png</PathStatusLight>
+                <PathBack>skins:Shade/style/volume_clipping_main.png</PathBack>
                 <Pos>122,57</Pos>
                 <Connection>
                   <ConfigKey>[Main],peak_indicator_left</ConfigKey>
@@ -945,8 +945,8 @@
               </StatusLight>
               <StatusLight>
                 <TooltipId>main_peak_indicator_right</TooltipId>
-                <PathStatusLight>skin:/style/volume_clipping_main_over.png</PathStatusLight>
-                <PathBack>skin:/style/volume_clipping_main.png</PathBack>
+                <PathStatusLight>skins:Shade/style/volume_clipping_main_over.png</PathStatusLight>
+                <PathBack>skins:Shade/style/volume_clipping_main.png</PathBack>
                 <Pos>128,57</Pos>
                 <Connection>
                   <ConfigKey>[Main],peak_indicator_right</ConfigKey>

--- a/res/skins/Shade/preview_deck.xml
+++ b/res/skins/Shade/preview_deck.xml
@@ -96,8 +96,8 @@
                             <NumberStates>1</NumberStates>
                             <State>
                               <Number>0</Number>
-                              <Pressed>skin:/btn/btn_eject_over.png</Pressed>
-                              <Unpressed>skin:/btn/btn_eject.png</Unpressed>
+                              <Pressed>skins:Shade/btn/btn_eject_over.png</Pressed>
+                              <Unpressed>skins:Shade/btn/btn_eject.png</Unpressed>
                             </State>
                             <Connection>
                               <ConfigKey>[PreviewDeck1],eject</ConfigKey>
@@ -131,13 +131,13 @@
                             <NumberStates>2</NumberStates>
                             <State>
                               <Number>0</Number>
-                              <Pressed>skin:/btn/btn_play_sampler_down.png</Pressed>
-                              <Unpressed>skin:/btn/btn_play_sampler.png</Unpressed>
+                              <Pressed>skins:Shade/btn/btn_play_sampler_down.png</Pressed>
+                              <Unpressed>skins:Shade/btn/btn_play_sampler.png</Unpressed>
                             </State>
                             <State>
                               <Number>1</Number>
-                              <Pressed>skin:/btn/btn_play_previewdeck_overdown.png</Pressed>
-                              <Unpressed>skin:/btn/btn_play_previewdeck_over.png</Unpressed>
+                              <Pressed>skins:Shade/btn/btn_play_previewdeck_overdown.png</Pressed>
+                              <Unpressed>skins:Shade/btn/btn_play_previewdeck_over.png</Unpressed>
                             </State>
                             <Pos>3,7</Pos>
                             <Connection>
@@ -209,8 +209,8 @@
                     <Children>
                       <StatusLight>
                         <TooltipId>preview_peak_indicator</TooltipId>
-                        <PathStatusLight>skin:/style/volume_clipping_previewdeck_over.png</PathStatusLight>
-                        <PathBack>skin:/style/volume_clipping_previewdeck.png</PathBack>
+                        <PathStatusLight>skins:Shade/style/volume_clipping_previewdeck_over.png</PathStatusLight>
+                        <PathBack>skins:Shade/style/volume_clipping_previewdeck.png</PathBack>
                         <Connection>
                           <ConfigKey>[PreviewDeck1],peak_indicator</ConfigKey>
                         </Connection>
@@ -224,8 +224,8 @@
                     <Children>
                       <VuMeter>
                         <TooltipId>preview_VuMeter</TooltipId>
-                        <PathVu>skin:/style/volume_display_previewdeck_over.png</PathVu>
-                        <PathBack>skin:/style/volume_display_previewdeck.png</PathBack>
+                        <PathVu>skins:Shade/style/volume_display_previewdeck_over.png</PathVu>
+                        <PathBack>skins:Shade/style/volume_display_previewdeck.png</PathBack>
                         <Horizontal>false</Horizontal>
                         <PeakHoldSize>5</PeakHoldSize>
                         <PeakHoldTime>500</PeakHoldTime>

--- a/res/skins/Shade/sampler.xml
+++ b/res/skins/Shade/sampler.xml
@@ -89,8 +89,8 @@
                     <NumberStates>1</NumberStates>
                     <State>
                       <Number>0</Number>
-                      <Pressed>skin:/btn/btn_tap_sampler_over.png</Pressed>
-                      <Unpressed>skin:/btn/btn_tap_sampler.png</Unpressed>
+                      <Pressed>skins:Shade/btn/btn_tap_sampler_over.png</Pressed>
+                      <Unpressed>skins:Shade/btn/btn_tap_sampler.png</Unpressed>
                     </State>
                     <Connection>
                       <ConfigKey><Variable name="group"/>,bpm_tap</ConfigKey>
@@ -119,13 +119,13 @@
                     <RightClickIsPushButton>true</RightClickIsPushButton>
                     <State>
                       <Number>0</Number>
-                      <Pressed>skin:/btn/btn_play_sampler.png</Pressed>
-                      <Unpressed>skin:/btn/btn_play_sampler.png</Unpressed>
+                      <Pressed>skins:Shade/btn/btn_play_sampler.png</Pressed>
+                      <Unpressed>skins:Shade/btn/btn_play_sampler.png</Unpressed>
                     </State>
                     <State>
                       <Number>1</Number>
-                      <Pressed>skin:/btn/btn_play_sampler_preview.png</Pressed>
-                      <Unpressed>skin:/btn/btn_play_sampler_preview.png</Unpressed>
+                      <Pressed>skins:Shade/btn/btn_play_sampler_preview.png</Pressed>
+                      <Unpressed>skins:Shade/btn/btn_play_sampler_preview.png</Unpressed>
                     </State>
                     <Connection>
                       <ConfigKey><Variable name="group"/>,play</ConfigKey>
@@ -140,12 +140,12 @@
                     <RightClickIsPushButton>true</RightClickIsPushButton>
                     <State>
                       <Number>0</Number>
-                      <Pressed>skin:/btn/btn_play_sampler_down.png</Pressed>
+                      <Pressed>skins:Shade/btn/btn_play_sampler_down.png</Pressed>
                     </State>
                     <State>
                       <Number>1</Number>
-                      <Pressed>skin:/btn/btn_pause_sampler_overdown.png</Pressed>
-                      <Unpressed>skin:/btn/btn_pause_sampler_over.png</Unpressed>
+                      <Pressed>skins:Shade/btn/btn_pause_sampler_overdown.png</Pressed>
+                      <Unpressed>skins:Shade/btn/btn_pause_sampler_over.png</Unpressed>
                     </State>
                     <Connection>
                       <ConfigKey><Variable name="group"/>,cue_gotoandplay</ConfigKey>
@@ -212,13 +212,13 @@
                     <NumberStates>2</NumberStates>
                     <State>
                       <Number>0</Number>
-                      <Pressed>skin:/btn/btn_repeat_sampler.png</Pressed>
-                      <Unpressed>skin:/btn/btn_repeat_sampler.png</Unpressed>
+                      <Pressed>skins:Shade/btn/btn_repeat_sampler.png</Pressed>
+                      <Unpressed>skins:Shade/btn/btn_repeat_sampler.png</Unpressed>
                     </State>
                     <State>
                       <Number>1</Number>
-                      <Pressed>skin:/btn/btn_repeat_sampler_over.png</Pressed>
-                      <Unpressed>skin:/btn/btn_repeat_sampler_over.png</Unpressed>
+                      <Pressed>skins:Shade/btn/btn_repeat_sampler_over.png</Pressed>
+                      <Unpressed>skins:Shade/btn/btn_repeat_sampler_over.png</Unpressed>
                     </State>
                     <Pos>1,0</Pos>
                     <Connection>
@@ -230,8 +230,8 @@
                     <NumberStates>1</NumberStates>
                     <State>
                       <Number>0</Number>
-                      <Pressed>skin:/btn/btn_eject_sampler_over.png</Pressed>
-                      <Unpressed>skin:/btn/btn_eject_sampler.png</Unpressed>
+                      <Pressed>skins:Shade/btn/btn_eject_sampler_over.png</Pressed>
+                      <Unpressed>skins:Shade/btn/btn_eject_sampler.png</Unpressed>
                     </State>
                     <Pos>22,0</Pos>
                     <Connection>
@@ -246,18 +246,18 @@
                     <NumberStates>3</NumberStates>
                     <State>
                       <Number>0</Number>
-                      <Pressed>skin:/btn/btn_orientation_sampler_left_over.png</Pressed>
-                      <Unpressed>skin:/btn/btn_orientation_sampler_left_over.png</Unpressed>
+                      <Pressed>skins:Shade/btn/btn_orientation_sampler_left_over.png</Pressed>
+                      <Unpressed>skins:Shade/btn/btn_orientation_sampler_left_over.png</Unpressed>
                     </State>
                     <State>
                       <Number>1</Number>
-                      <Pressed>skin:/btn/btn_orientation_sampler_main.png</Pressed>
-                      <Unpressed>skin:/btn/btn_orientation_sampler_main.png</Unpressed>
+                      <Pressed>skins:Shade/btn/btn_orientation_sampler_main.png</Pressed>
+                      <Unpressed>skins:Shade/btn/btn_orientation_sampler_main.png</Unpressed>
                     </State>
                     <State>
                       <Number>2</Number>
-                      <Pressed>skin:/btn/btn_orientation_sampler_right_over.png</Pressed>
-                      <Unpressed>skin:/btn/btn_orientation_sampler_right_over.png</Unpressed>
+                      <Pressed>skins:Shade/btn/btn_orientation_sampler_right_over.png</Pressed>
+                      <Unpressed>skins:Shade/btn/btn_orientation_sampler_right_over.png</Unpressed>
                     </State>
                     <Pos>1,17</Pos>
                     <Connection>
@@ -271,13 +271,13 @@
                     <NumberStates>2</NumberStates>
                     <State>
                       <Number>0</Number>
-                      <Pressed>skin:/btn/btn_keylock_sampler.png</Pressed>
-                      <Unpressed>skin:/btn/btn_keylock_sampler.png</Unpressed>
+                      <Pressed>skins:Shade/btn/btn_keylock_sampler.png</Pressed>
+                      <Unpressed>skins:Shade/btn/btn_keylock_sampler.png</Unpressed>
                     </State>
                     <State>
                       <Number>1</Number>
-                      <Pressed>skin:/btn/btn_keylock_sampler_over.png</Pressed>
-                      <Unpressed>skin:/btn/btn_keylock_sampler_over.png</Unpressed>
+                      <Pressed>skins:Shade/btn/btn_keylock_sampler_over.png</Pressed>
+                      <Unpressed>skins:Shade/btn/btn_keylock_sampler_over.png</Unpressed>
                     </State>
                     <Pos>21,17</Pos>
                     <Connection>
@@ -304,8 +304,8 @@
                     <NumberStates>1</NumberStates>
                     <State>
                       <Number>0</Number>
-                      <Pressed>skin:/btn/btn_sync_sampler_overdown.png</Pressed>
-                      <Unpressed>skin:/btn/btn_sync_sampler.png</Unpressed>
+                      <Pressed>skins:Shade/btn/btn_sync_sampler_overdown.png</Pressed>
+                      <Unpressed>skins:Shade/btn/btn_sync_sampler.png</Unpressed>
                     </State>
                     <Pos>3,4</Pos>
                     <Connection>
@@ -320,19 +320,19 @@
                     </Connection>
                   </PushButton>
 
-                  <Template src="skin:hotcue_button.xml">
+                  <Template src="skins:Shade/hotcue_button.xml">
                     <SetVariable name="hotcue">1</SetVariable>
                     <SetVariable name="pos">47,4</SetVariable>
                   </Template>
-                  <Template src="skin:hotcue_button.xml">
+                  <Template src="skins:Shade/hotcue_button.xml">
                     <SetVariable name="hotcue">2</SetVariable>
                     <SetVariable name="pos">68,4</SetVariable>
                   </Template>
-                  <Template src="skin:hotcue_button.xml">
+                  <Template src="skins:Shade/hotcue_button.xml">
                     <SetVariable name="hotcue">3</SetVariable>
                     <SetVariable name="pos">89,4</SetVariable>
                   </Template>
-                  <Template src="skin:hotcue_button.xml">
+                  <Template src="skins:Shade/hotcue_button.xml">
                     <SetVariable name="hotcue">4</SetVariable>
                     <SetVariable name="pos">110,4</SetVariable>
                   </Template>
@@ -342,13 +342,13 @@
                     <NumberStates>2</NumberStates>
                     <State>
                       <Number>0</Number>
-                      <Pressed>skin:/btn/btn_pfl_sampler_down.png</Pressed>
-                      <Unpressed>skin:/btn/btn_pfl_sampler.png</Unpressed>
+                      <Pressed>skins:Shade/btn/btn_pfl_sampler_down.png</Pressed>
+                      <Unpressed>skins:Shade/btn/btn_pfl_sampler.png</Unpressed>
                     </State>
                     <State>
                       <Number>1</Number>
-                      <Pressed>skin:/btn/btn_pfl_sampler_overdown.png</Pressed>
-                      <Unpressed>skin:/btn/btn_pfl_sampler_over.png</Unpressed>
+                      <Pressed>skins:Shade/btn/btn_pfl_sampler_overdown.png</Pressed>
+                      <Unpressed>skins:Shade/btn/btn_pfl_sampler_over.png</Unpressed>
                     </State>
                     <Pos>134,4</Pos>
                     <Connection>
@@ -380,8 +380,8 @@
             <Children>
               <StatusLight>
                 <TooltipId>sampler_peak_indicator</TooltipId>
-                <PathStatusLight>skin:/style/volume_clipping_sampler_over.png</PathStatusLight>
-                <PathBack>skin:/style/volume_clipping_sampler.png</PathBack>
+                <PathStatusLight>skins:Shade/style/volume_clipping_sampler_over.png</PathStatusLight>
+                <PathBack>skins:Shade/style/volume_clipping_sampler.png</PathBack>
                 <Connection>
                   <ConfigKey><Variable name="group"/>,peak_indicator</ConfigKey>
                 </Connection>
@@ -394,8 +394,8 @@
             <Children>
               <VuMeter>
                 <TooltipId>sampler_VuMeter</TooltipId>
-                <PathVu>skin:/style/volume_display_sampler_over.png</PathVu>
-                <PathBack>skin:/style/volume_display_sampler.png</PathBack>
+                <PathVu>skins:Shade/style/volume_display_sampler_over.png</PathVu>
+                <PathBack>skins:Shade/style/volume_display_sampler.png</PathBack>
                 <Horizontal>false</Horizontal>
                 <PeakHoldSize>5</PeakHoldSize>
                 <PeakHoldTime>500</PeakHoldTime>

--- a/res/skins/Shade/samplerrow.xml
+++ b/res/skins/Shade/samplerrow.xml
@@ -35,13 +35,13 @@
 								<NumberStates>2</NumberStates>
 								<State>
 									<Number>0</Number>
-									<Pressed>skin:/btn/btn_big_plus.png</Pressed>
-									<Unpressed>skin:/btn/btn_big_plus.png</Unpressed>
+									<Pressed>skins:Shade/btn/btn_big_plus.png</Pressed>
+									<Unpressed>skins:Shade/btn/btn_big_plus.png</Unpressed>
 								</State>
 								<State>
 									<Number>1</Number>
-									<Pressed>skin:/btn/btn_big_minus.png</Pressed>
-									<Unpressed>skin:/btn/btn_big_minus.png</Unpressed>
+									<Pressed>skins:Shade/btn/btn_big_minus.png</Pressed>
+									<Unpressed>skins:Shade/btn/btn_big_minus.png</Unpressed>
 								</State>
 								<Pos>0,0</Pos>
 								<Connection>
@@ -61,16 +61,16 @@
 					</WidgetGroup>
 				</Children>
 			</WidgetGroup>
-		    <Template src="skin:samplersmall.xml">
+		    <Template src="skins:Shade/samplersmall.xml">
 		      <SetVariable name="samplernum"><Variable name="samplernum1"/></SetVariable>
 		    </Template>
-		    <Template src="skin:samplersmall.xml">
+		    <Template src="skins:Shade/samplersmall.xml">
 		      <SetVariable name="samplernum"><Variable name="samplernum2"/></SetVariable>
 		    </Template>
-		    <Template src="skin:samplersmall.xml">
+		    <Template src="skins:Shade/samplersmall.xml">
 		      <SetVariable name="samplernum"><Variable name="samplernum3"/></SetVariable>
 		    </Template>
-		    <Template src="skin:samplersmall.xml">
+		    <Template src="skins:Shade/samplersmall.xml">
 		      <SetVariable name="samplernum"><Variable name="samplernum4"/></SetVariable>
 		    </Template>
 			<WidgetGroup>
@@ -91,8 +91,8 @@
 								<NumberStates>1</NumberStates>
 								<State>
 									<Number>0</Number>
-									<Pressed>skin:/btn/btn_load.png</Pressed>
-									<Unpressed>skin:/btn/btn_load.png</Unpressed>
+									<Pressed>skins:Shade/btn/btn_load.png</Pressed>
+									<Unpressed>skins:Shade/btn/btn_load.png</Unpressed>
 								</State>
 								<Pos>0,6</Pos>
 								<Connection>
@@ -104,8 +104,8 @@
 								<NumberStates>1</NumberStates>
 								<State>
 									<Number>0</Number>
-									<Pressed>skin:/btn/btn_save.png</Pressed>
-									<Unpressed>skin:/btn/btn_save.png</Unpressed>
+									<Pressed>skins:Shade/btn/btn_save.png</Pressed>
+									<Unpressed>skins:Shade/btn/btn_save.png</Unpressed>
 								</State>
 								<Pos>0,20</Pos>
 								<Connection>
@@ -162,13 +162,13 @@
 								<NumberStates>2</NumberStates>
 								<State>
 									<Number>0</Number>
-									<Pressed>skin:/btn/btn_big_plus.png</Pressed>
-									<Unpressed>skin:/btn/btn_big_plus.png</Unpressed>
+									<Pressed>skins:Shade/btn/btn_big_plus.png</Pressed>
+									<Unpressed>skins:Shade/btn/btn_big_plus.png</Unpressed>
 								</State>
 								<State>
 									<Number>1</Number>
-									<Pressed>skin:/btn/btn_big_minus.png</Pressed>
-									<Unpressed>skin:/btn/btn_big_minus.png</Unpressed>
+									<Pressed>skins:Shade/btn/btn_big_minus.png</Pressed>
+									<Unpressed>skins:Shade/btn/btn_big_minus.png</Unpressed>
 								</State>
 								<Pos>0,6</Pos>
 								<Connection>
@@ -188,16 +188,16 @@
 					</WidgetGroup>
 				</Children>
 			</WidgetGroup>
-		    <Template src="skin:sampler.xml">
+		    <Template src="skins:Shade/sampler.xml">
 		      <SetVariable name="samplernum"><Variable name="samplernum1"/></SetVariable>
 		    </Template>
-		    <Template src="skin:sampler.xml">
+		    <Template src="skins:Shade/sampler.xml">
 		      <SetVariable name="samplernum"><Variable name="samplernum2"/></SetVariable>
 		    </Template>
-		    <Template src="skin:sampler.xml">
+		    <Template src="skins:Shade/sampler.xml">
 		      <SetVariable name="samplernum"><Variable name="samplernum3"/></SetVariable>
 		    </Template>
-		    <Template src="skin:sampler.xml">
+		    <Template src="skins:Shade/sampler.xml">
 		      <SetVariable name="samplernum"><Variable name="samplernum4"/></SetVariable>
 		    </Template>
 			<WidgetGroup>
@@ -220,8 +220,8 @@
 								<NumberStates>1</NumberStates>
 								<State>
 									<Number>0</Number>
-									<Pressed>skin:/btn/btn_load.png</Pressed>
-									<Unpressed>skin:/btn/btn_load.png</Unpressed>
+									<Pressed>skins:Shade/btn/btn_load.png</Pressed>
+									<Unpressed>skins:Shade/btn/btn_load.png</Unpressed>
 								</State>
 								<Pos>0,6</Pos>
 								<Connection>
@@ -233,8 +233,8 @@
 								<NumberStates>1</NumberStates>
 								<State>
 									<Number>0</Number>
-									<Pressed>skin:/btn/btn_save.png</Pressed>
-									<Unpressed>skin:/btn/btn_save.png</Unpressed>
+									<Pressed>skins:Shade/btn/btn_save.png</Pressed>
+									<Unpressed>skins:Shade/btn/btn_save.png</Unpressed>
 								</State>
 								<Pos>0,20</Pos>
 								<Connection>

--- a/res/skins/Shade/samplersmall.xml
+++ b/res/skins/Shade/samplersmall.xml
@@ -21,13 +21,13 @@
             <NumberStates>2</NumberStates>
             <State>
               <Number>0</Number>
-              <Pressed>skin:/btn/btn_play_sampler_down.png</Pressed>
-              <Unpressed>skin:/btn/btn_play_sampler.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_play_sampler_down.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_play_sampler.png</Unpressed>
             </State>
             <State>
               <Number>1</Number>
-              <Pressed>skin:/btn/btn_pause_sampler_overdown.png</Pressed>
-              <Unpressed>skin:/btn/btn_pause_sampler_over.png</Unpressed>
+              <Pressed>skins:Shade/btn/btn_pause_sampler_overdown.png</Pressed>
+              <Unpressed>skins:Shade/btn/btn_pause_sampler_over.png</Unpressed>
             </State>
             <Connection>
               <ConfigKey>[Sampler<Variable name="samplernum"/>],cue_gotoandplay</ConfigKey>
@@ -121,8 +121,8 @@
                     <NumberStates>1</NumberStates>
                     <State>
                       <Number>0</Number>
-                      <Pressed>skin:/btn/btn_eject_sampler_over.png</Pressed>
-                      <Unpressed>skin:/btn/btn_eject_sampler.png</Unpressed>
+                      <Pressed>skins:Shade/btn/btn_eject_sampler_over.png</Pressed>
+                      <Unpressed>skins:Shade/btn/btn_eject_sampler.png</Unpressed>
                     </State>
                     <Pos>0,0</Pos>
                     <Connection>
@@ -137,18 +137,18 @@
                     <NumberStates>3</NumberStates>
                     <State>
                       <Number>0</Number>
-                      <Pressed>skin:/btn/btn_orientation_sampler_left_over.png</Pressed>
-                      <Unpressed>skin:/btn/btn_orientation_sampler_left_over.png</Unpressed>
+                      <Pressed>skins:Shade/btn/btn_orientation_sampler_left_over.png</Pressed>
+                      <Unpressed>skins:Shade/btn/btn_orientation_sampler_left_over.png</Unpressed>
                     </State>
                     <State>
                       <Number>1</Number>
-                      <Pressed>skin:/btn/btn_orientation_sampler_main.png</Pressed>
-                      <Unpressed>skin:/btn/btn_orientation_sampler_main.png</Unpressed>
+                      <Pressed>skins:Shade/btn/btn_orientation_sampler_main.png</Pressed>
+                      <Unpressed>skins:Shade/btn/btn_orientation_sampler_main.png</Unpressed>
                     </State>
                     <State>
                       <Number>2</Number>
-                      <Pressed>skin:/btn/btn_orientation_sampler_right_over.png</Pressed>
-                      <Unpressed>skin:/btn/btn_orientation_sampler_right_over.png</Unpressed>
+                      <Pressed>skins:Shade/btn/btn_orientation_sampler_right_over.png</Pressed>
+                      <Unpressed>skins:Shade/btn/btn_orientation_sampler_right_over.png</Unpressed>
                     </State>
                     <Pos>0,13</Pos>
                     <Connection>

--- a/res/skins/Shade/skin.xml
+++ b/res/skins/Shade/skin.xml
@@ -168,7 +168,7 @@
           <Amount>-40</Amount>
         </Add>
       </Filters>
-      <Style src="skin:style_dark.qss"/>
+      <Style src="skins:Shade/style_dark.qss"/>
     </Scheme>
     <Scheme>
       <Name>Summer Sunset</Name>
@@ -187,7 +187,7 @@
           <VConst>-10</VConst>
         </HSVTweak>
       </Filters>
-      <Style src="skin:style_summer_sunset.qss"/>
+      <Style src="skins:Shade/style_summer_sunset.qss"/>
     </Scheme>
   </Schemes>
 
@@ -200,7 +200,7 @@
   ############################################################################################
   -->
   <ObjectName>Mixxx</ObjectName>
-  <Style src="skin:style.qss"
+  <Style src="skins:Shade/style.qss"
          src-linux="skins:default-menu-styles-linux.qss"
          src-windows="skins:default-menu-styles-windows.qss"/>
   <Size>1008e,500e</Size>
@@ -208,7 +208,7 @@
     <LaunchImageStyle>
       LaunchImage { background-color: #202020; }
         QLabel {
-          image: url(skin:/style/mixxx-icon-logo-symbolic.png);
+          image: url(skins:Shade/style/mixxx-icon-logo-symbolic.png);
           padding:0;
           margin:0;
           border:none;
@@ -252,7 +252,7 @@
     <SingletonDefinition>
       <ObjectName>Overview1</ObjectName>
       <Children>
-        <Template src="skin:deck_overview.xml">
+        <Template src="skins:Shade/deck_overview.xml">
           <SetVariable name="channum">1</SetVariable>
         </Template>
       </Children>
@@ -261,7 +261,7 @@
     <SingletonDefinition>
       <ObjectName>Overview2</ObjectName>
       <Children>
-        <Template src="skin:deck_overview.xml">
+        <Template src="skins:Shade/deck_overview.xml">
           <SetVariable name="channum">2</SetVariable>
         </Template>
       </Children>
@@ -270,7 +270,7 @@
     <SingletonDefinition>
       <ObjectName>Library</ObjectName>
       <Children>
-        <Template src="skin:library.xml"/>
+        <Template src="skins:Shade/library.xml"/>
       </Children>
     </SingletonDefinition>
 
@@ -313,7 +313,7 @@
               <Children>
                 <WidgetGroup><Size>3f,0min</Size></WidgetGroup>
 
-                <Template src="skin:deck.xml">
+                <Template src="skins:Shade/deck.xml">
                   <SetVariable name="channum">1</SetVariable>
                   <SetVariable name="effectunitnum">1</SetVariable>
                   <SetVariable name="effectgroup">BusLeft</SetVariable>
@@ -327,11 +327,11 @@
 
                 <WidgetGroup><Size>3f,0min</Size></WidgetGroup>
 
-                <Template src="skin:mixer_panel.xml"/>
+                <Template src="skins:Shade/mixer_panel.xml"/>
 
                 <WidgetGroup><Size>3f,0min</Size></WidgetGroup>
 
-                <Template src="skin:deck.xml">
+                <Template src="skins:Shade/deck.xml">
                   <SetVariable name="channum">2</SetVariable>
                   <SetVariable name="effectunitnum">2</SetVariable>
                   <SetVariable name="effectgroup">BusRight</SetVariable>
@@ -357,10 +357,10 @@
                   <ObjectName>EffectLeftBorder</ObjectName>
                   <Size>3f,43f</Size>
                 </WidgetGroup>
-                <Template src="skin:looping.xml">
+                <Template src="skins:Shade/looping.xml">
                   <SetVariable name="channum">1</SetVariable>
                 </Template>
-                <Template src="skin:looping.xml">
+                <Template src="skins:Shade/looping.xml">
                   <SetVariable name="channum">2</SetVariable>
                 </Template>
               </Children>
@@ -369,16 +369,16 @@
                 <BindProperty>visible</BindProperty>
               </Connection>
             </WidgetGroup>
-            <Template src="skin:effectrow.xml"/>
-            <Template src="skin:srcrow.xml"/>
-            <Template src="skin:samplerrow.xml">
+            <Template src="skins:Shade/effectrow.xml"/>
+            <Template src="skins:Shade/srcrow.xml"/>
+            <Template src="skins:Shade/samplerrow.xml">
               <SetVariable name="row">1</SetVariable>
               <SetVariable name="samplernum1">1</SetVariable>
               <SetVariable name="samplernum2">2</SetVariable>
               <SetVariable name="samplernum3">5</SetVariable>
               <SetVariable name="samplernum4">6</SetVariable>
             </Template>
-            <Template src="skin:samplerrow.xml">
+            <Template src="skins:Shade/samplerrow.xml">
               <SetVariable name="row">2</SetVariable>
               <SetVariable name="samplernum1">3</SetVariable>
               <SetVariable name="samplernum2">4</SetVariable>
@@ -395,7 +395,7 @@
         </WidgetGroup>
 
         <!-- minimal decks, visible with maximized library -->
-        <Template src="skin:decks_row_small.xml"/>
+        <Template src="skins:Shade/decks_row_small.xml"/>
 
         <SingletonContainer>
           <ObjectName>Library</ObjectName>

--- a/res/skins/Shade/srcfx.xml
+++ b/res/skins/Shade/srcfx.xml
@@ -16,7 +16,7 @@
           <WidgetGroup>
             <Size>0e,54f</Size>
           </WidgetGroup>
-          <Template src="skin:ducking.xml"/>
+          <Template src="skins:Shade/ducking.xml"/>
           <WidgetGroup>
             <Size>0e,54f</Size>
           </WidgetGroup>

--- a/res/skins/Shade/srcmicrophoneaux.xml
+++ b/res/skins/Shade/srcmicrophoneaux.xml
@@ -16,7 +16,7 @@
           <WidgetGroup>
             <Size>93f,54f</Size>
             <Children>
-              <Template src="skin:microphone.xml">
+              <Template src="skins:Shade/microphone.xml">
               </Template>
             </Children>
             <Connection>
@@ -30,7 +30,7 @@
           <WidgetGroup>
             <Size>108f,54f</Size>
             <Children>
-              <Template src="skin:auxiliary.xml">
+              <Template src="skins:Shade/auxiliary.xml">
               </Template>
             </Children>
             <Connection>

--- a/res/skins/Shade/srcrow.xml
+++ b/res/skins/Shade/srcrow.xml
@@ -19,7 +19,7 @@
 				<WidgetGroup>
           <Layout>vertical</Layout>
           <Children>
-            <Template src="skin:srcmicrophoneaux.xml">
+            <Template src="skins:Shade/srcmicrophoneaux.xml">
               <SetVariable name="micnum"></SetVariable>
               <SetVariable name="miclabel">1</SetVariable>
               <SetVariable name="auxnum">1</SetVariable>
@@ -29,13 +29,13 @@
 				<WidgetGroup>
           <Layout>vertical</Layout>
           <Children>
-            <Template src="skin:srcfx.xml"/>
+            <Template src="skins:Shade/srcfx.xml"/>
           </Children>
 				</WidgetGroup>
 				<WidgetGroup>
           <Layout>vertical</Layout>
           <Children>
-          <Template src="skin:srcmicrophoneaux.xml">
+          <Template src="skins:Shade/srcmicrophoneaux.xml">
             <SetVariable name="micnum">2</SetVariable>
             <SetVariable name="miclabel">2</SetVariable>
             <SetVariable name="auxnum">2</SetVariable>

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -72,13 +72,13 @@ that's why we do it in another way here */
 WBeatSpinBox::up-button,
 #spinBoxTransition::up-button {
   border-left: 1px solid #060613;
-  image: url(skin:/btn/btn_spin_up.png) no-repeat;
+  image: url(skins:Shade/btn/btn_spin_up.png) no-repeat;
 }
 
 WBeatSpinBox::down-button,
 #spinBoxTransition::down-button {
   border-left: 1px solid #060613;
-  image: url(skin:/btn/btn_spin_down.png) no-repeat;
+  image: url(skins:Shade/btn/btn_spin_down.png) no-repeat;
 }
 WBeatSpinBox::up-button,
 WBeatSpinBox::down-button {
@@ -208,11 +208,11 @@ WEffectSelector::indicator:unchecked:selected,
   }
   #MainMenu QMenu::indicator:checked,
   #MainMenu QMenu::indicator:checked:selected {
-    image: url(skin:/btn/btn_mainmenu_checkbox_checked.svg);
+    image: url(skins:Shade/btn/btn_mainmenu_checkbox_checked.svg);
   }
   #MainMenu QMenu::indicator:unchecked,
   #MainMenu QMenu::indicator:unchecked:selected {
-    image: url(skin:/btn/btn_mainmenu_checkbox.svg);
+    image: url(skins:Shade/btn/btn_mainmenu_checkbox.svg);
   }
 
 #MainMenu QMenu {
@@ -226,7 +226,7 @@ WEffectSelector::indicator:unchecked:selected,
     width: 0.5em;
     height: 0.5em;
     margin-right: 0.2em;
-    image: url(skin:/style/menu_arrow.svg);
+    image: url(skins:Shade/style/menu_arrow.svg);
   }
 
 WEffectSelector,
@@ -291,10 +291,10 @@ WEffectSelector QAbstractScrollArea,
     #fadeModeCombobox::down-arrow {
       border-width: 0px 0px 0px 1px;
       margin: 0px;
-      image: url(skin:/btn/btn_spin_down.png) no-repeat;
+      image: url(skins:Shade/btn/btn_spin_down.png) no-repeat;
     }
     WSearchLineEdit::down-arrow {
-      image: url(skin:/btn/btn_search_down_grey.svg) no-repeat;
+      image: url(skins:Shade/btn/btn_search_down_grey.svg) no-repeat;
     }
 
 
@@ -342,16 +342,16 @@ WEffectSelector QAbstractScrollArea,
   #fadeModeCombobox::indicator:checked {
     border-color: #1a2025;
     background-color: #f90562;
-    image: url(skin:/btn/btn_lib_checkmark_black.svg);
+    image: url(skins:Shade/btn/btn_lib_checkmark_black.svg);
   }
   WTrackMenu QMenu QCheckBox::indicator:indeterminate {
     border-color: #1a2025;
     background-color: #aa5f78;
-    image: url(skin:/btn/btn_lib_checkmark_dark_grey.svg);
+    image: url(skins:Shade/btn/btn_lib_checkmark_dark_grey.svg);
   }
   /* disabled checked box */
   WTrackMenu QMenu QCheckBox::indicator:disabled:checked {
-    image: url(skin:/btn/btn_lib_checkmark_grey.svg);
+    image: url(skins:Shade/btn/btn_lib_checkmark_grey.svg);
   }
   /* unchecked menu checkbox */
   WLibrarySidebar QMenu::indicator:unchecked,
@@ -421,7 +421,7 @@ WCueMenuPopup QLabel {
   height: 43px;
   padding: 0px;
   background-color: #aab2b7;
-  qproperty-icon: url(skin:/btn/btn_delete.svg);
+  qproperty-icon: url(skins:Shade/btn/btn_delete.svg);
   /* make the icon slightly larger than default 16px */
   qproperty-iconSize: 20px;
   outline: none;
@@ -524,10 +524,10 @@ WTrackTableView {
 
   /* BPM lock icon in the library "BPM" column. */
   #LibraryBPMButton::indicator:checked {
-    image: url(skin:/btn/btn_lib_bpm_locked.svg);
+    image: url(skins:Shade/btn/btn_lib_bpm_locked.svg);
     }
     #LibraryBPMButton::indicator:unchecked {
-      image: url(skin:/btn/btn_lib_bpm_unlocked.svg);
+      image: url(skins:Shade/btn/btn_lib_bpm_unlocked.svg);
       }
   #LibraryBPMButton::item {
     color: #cfcfcf;
@@ -548,10 +548,10 @@ WTrackTableView {
       background-color: #656d75;
       }
       #LibraryBPMSpinBox::up-button {
-        image: url(skin:/btn/btn_lib_spinbox_up_white.svg) no-repeat;
+        image: url(skins:Shade/btn/btn_lib_spinbox_up_white.svg) no-repeat;
         }
       #LibraryBPMSpinBox::down-button {
-        image: url(skin:/btn/btn_lib_spinbox_down_white.svg) no-repeat;
+        image: url(skins:Shade/btn/btn_lib_spinbox_down_white.svg) no-repeat;
         }
 
   /* Button in library "Preview" column */
@@ -562,14 +562,14 @@ WTrackTableView {
     border: 1px solid transparent;
   }
   #LibraryPreviewButton:!checked{
-    image: url(skin:/btn/btn_lib_preview_play.svg);
+    image: url(skins:Shade/btn/btn_lib_preview_play.svg);
   }
   #LibraryPreviewButton:!checked:hover {
     border: 1px solid #666;
     background: #0f0f0f;
   }
   #LibraryPreviewButton:checked {
-    image: url(skin:/btn/btn_lib_preview_pause.svg);
+    image: url(skins:Shade/btn/btn_lib_preview_pause.svg);
     background-color: #0f0f0f;
     border: 1px solid #444;
   }
@@ -585,10 +585,10 @@ WTrackTableView {
     border: 0px;
     }
   WTrackTableView::indicator:unchecked {
-    image: url(skin:/btn/btn_lib_checkbox.svg);
+    image: url(skins:Shade/btn/btn_lib_checkbox.svg);
     }
   WTrackTableView::indicator:checked {
-    image: url(skin:/btn/btn_lib_checkbox_checked.svg);
+    image: url(skins:Shade/btn/btn_lib_checkbox_checked.svg);
     }
 
 /* explicitly remove icons from unchecked items otherwise
@@ -650,22 +650,22 @@ WLibrarySidebar {
 /*  Closed branch of tree 	*/
 WLibrarySidebar::branch:has-children:!has-siblings:closed,
 WLibrarySidebar::branch:closed:has-children:has-siblings {
-  image: url(skin:/style/style_branch_closed.svg);
+  image: url(skins:Shade/style/style_branch_closed.svg);
   }
   WLibrarySidebar::branch:has-children:!has-siblings:closed:selected,
   WLibrarySidebar::branch:closed:has-children:has-siblings:selected {
-    image: url(skin:/style/style_branch_closed_selected.svg);
+    image: url(skins:Shade/style/style_branch_closed_selected.svg);
   }
 
 /*  Open branch of tree 	*/
 WLibrarySidebar::branch:open:has-children:!has-siblings,
 WLibrarySidebar::branch:open:has-children:has-siblings {
-  image: url(skin:/style/style_branch_open.svg);
+  image: url(skins:Shade/style/style_branch_open.svg);
   }
   WLibrarySidebar::branch:open:has-children:!has-siblings:selected,
   WLibrarySidebar::branch:open:has-children:has-siblings:selected {
     border-image: none;
-    image: url(skin:/style/style_branch_open_selected.svg);
+    image: url(skins:Shade/style/style_branch_open_selected.svg);
   }
   /* space left of selected child item */
   WLibrarySidebar::branch:!has-children:!has-siblings:closed:selected,
@@ -715,10 +715,10 @@ WTrackTableViewHeader::down-arrow {
   background-color: rgba(98,111,135,255);
   }
   WTrackTableViewHeader::up-arrow {
-    image: url(skin:/btn/btn_lib_sort_up_black.png)
+    image: url(skins:Shade/btn/btn_lib_sort_up_black.png)
   }
   WTrackTableViewHeader::down-arrow {
-    image: url(skin:/btn/btn_lib_sort_down_black.png)
+    image: url(skins:Shade/btn/btn_lib_sort_down_black.png)
   }
 
 /* Scroll bars */
@@ -825,11 +825,11 @@ WCoverArt {
 
 /* splitter between treeview and library*/
 QSplitter::handle {
-  image: url(skin:/style/style_handle_unchecked.png);
+  image: url(skins:Shade/style/style_handle_unchecked.png);
   background: none;
 }
 QSplitter::handle:pressed {
-  image: url(skin:/style/style_handle_checked.png);
+  image: url(skins:Shade/style/style_handle_checked.png);
   background: none;
 }
 QSplitter::handle:horizontal {
@@ -859,11 +859,11 @@ WLibrary { margin: 2px 3px 0px 0px; }
 }
 
 #LibraryFeatureControls QRadioButton::indicator:checked {
-  image: url(skin:/btn/btn_lib_radio_button_on_pink.svg) center center;
+  image: url(skins:Shade/btn/btn_lib_radio_button_on_pink.svg) center center;
 }
 
 #LibraryFeatureControls QRadioButton::indicator:unchecked {
-  image: url(skin:/btn/btn_lib_radio_button_off.svg) center center;
+  image: url(skins:Shade/btn/btn_lib_radio_button_off.svg) center center;
 }
 
 #LibraryFeatureControls QPushButton {
@@ -937,28 +937,28 @@ WLibrary { margin: 2px 3px 0px 0px; }
   }
 /* AutoDJ button icons */
 QPushButton#pushButtonAutoDJ {
-  image: url(skin:/btn/btn_autodj_enable.svg) no-repeat center center;
+  image: url(skins:Shade/btn/btn_autodj_enable.svg) no-repeat center center;
 }
 QPushButton#pushButtonFadeNow:!enabled {
-  image: url(skin:/btn/btn_autodj_fade_disabled.svg) no-repeat center center;
+  image: url(skins:Shade/btn/btn_autodj_fade_disabled.svg) no-repeat center center;
   }
   QPushButton#pushButtonFadeNow:enabled {
-    image: url(skin:/btn/btn_autodj_fade.svg) no-repeat center center;
+    image: url(skins:Shade/btn/btn_autodj_fade.svg) no-repeat center center;
   }
 QPushButton#pushButtonSkipNext:!enabled {
-  image: url(skin:/btn/btn_autodj_skip_disabled.svg) no-repeat center center;
+  image: url(skins:Shade/btn/btn_autodj_skip_disabled.svg) no-repeat center center;
   }
   QPushButton#pushButtonSkipNext:enabled {
-    image: url(skin:/btn/btn_autodj_skip.svg) no-repeat center center;
+    image: url(skins:Shade/btn/btn_autodj_skip.svg) no-repeat center center;
   }
 QPushButton#pushButtonShuffle {
-  image: url(skin:/btn/btn_autodj_shuffle.svg) no-repeat center center;
+  image: url(skins:Shade/btn/btn_autodj_shuffle.svg) no-repeat center center;
 }
 QPushButton#pushButtonAddRandomTrack {
-  image: url(skin:/btn/btn_autodj_addrandom.svg) no-repeat center center;
+  image: url(skins:Shade/btn/btn_autodj_addrandom.svg) no-repeat center center;
 }
 QPushButton#pushButtonRepeatPlaylist {
-  image: url(skin:/btn/btn_autodj_repeat_playlist.svg) no-repeat center center;
+  image: url(skins:Shade/btn/btn_autodj_repeat_playlist.svg) no-repeat center center;
 }
 /* AutoDJ button icons */
 

--- a/res/skins/Shade/style_dark.qss
+++ b/res/skins/Shade/style_dark.qss
@@ -131,11 +131,11 @@ WEffectSelector::indicator:unchecked:selected,
 
 #MainMenu QMenu::indicator:checked,
 #MainMenu QMenu::indicator:checked:selected {
-  image: url(skin:/btn/btn_mainmenu_dark_checkbox_checked.svg);
+  image: url(skins:Shade/btn/btn_mainmenu_dark_checkbox_checked.svg);
 }
 #MainMenu QMenu::indicator:unchecked,
 #MainMenu QMenu::indicator:unchecked:selected {
-  image: url(skin:/btn/btn_mainmenu_dark_checkbox.svg);
+  image: url(skins:Shade/btn/btn_mainmenu_dark_checkbox.svg);
 }
 
 #EffectSelectorGroup[highlight="1"]{
@@ -169,7 +169,7 @@ WSearchLineEdit:focus {
   border: 2px solid #78C70B;
 }
 WSearchLineEdit QToolButton:focus {
-  image: url(skin:/btn/btn_lib_clear_search_focus_green.svg);
+  image: url(skins:Shade/btn/btn_lib_clear_search_focus_green.svg);
 }
 
 WLibrarySidebar::item:selected,
@@ -246,10 +246,10 @@ WTrackTableViewHeader::down-arrow {
   background-color: rgba(63,48,65,200);
   }
   WTrackTableViewHeader::up-arrow {
-    image: url(skin:/btn/btn_lib_sort_up_green.png)
+    image: url(skins:Shade/btn/btn_lib_sort_up_green.png)
   }
   WTrackTableViewHeader::down-arrow {
-    image: url(skin:/btn/btn_lib_sort_down_green.png)
+    image: url(skins:Shade/btn/btn_lib_sort_down_green.png)
   }
 #LibraryFeatureControls QPushButton:enabled {
   background-color: #5C5B5D;
@@ -266,7 +266,7 @@ WTrackTableViewHeader::down-arrow {
   }
 
 #LibraryFeatureControls QRadioButton::indicator:checked {
-  image: url(skin:/btn/btn_lib_radio_button_on_mustard.svg) center center;
+  image: url(skins:Shade/btn/btn_lib_radio_button_on_mustard.svg) center center;
 }
 
 WRateRange {

--- a/res/skins/Shade/style_summer_sunset.qss
+++ b/res/skins/Shade/style_summer_sunset.qss
@@ -126,11 +126,11 @@ WEffectSelector::indicator:unchecked:selected,
 
 #MainMenu QMenu::indicator:checked,
 #MainMenu QMenu::indicator:checked:selected {
-  image: url(skin:/btn/btn_mainmenu_summer_checkbox_checked.svg);
+  image: url(skins:Shade/btn/btn_mainmenu_summer_checkbox_checked.svg);
 }
 #MainMenu QMenu::indicator:unchecked,
 #MainMenu QMenu::indicator:unchecked:selected {
-  image: url(skin:/btn/btn_mainmenu_summer_checkbox.svg);
+  image: url(skins:Shade/btn/btn_mainmenu_summer_checkbox.svg);
 }
 
 #EffectSelectorGroup[highlight="1"]{
@@ -173,7 +173,7 @@ WSearchLineEdit:focus {
     }
 
 #LibraryFeatureControls QRadioButton::indicator:checked {
-  image: url(skin:/btn/btn_lib_radio_button_on_neongreen.svg) center center;
+  image: url(skins:Shade/btn/btn_lib_radio_button_on_neongreen.svg) center center;
 }
 
 /* 'Enable AutoDJ' button	*/

--- a/res/skins/Shade/vinylcontrol.xml
+++ b/res/skins/Shade/vinylcontrol.xml
@@ -9,13 +9,13 @@
 				<NumberStates>2</NumberStates>
 				<State>
 					<Number>0</Number>
-					<Pressed>skin:/btn/btn_vinylcontrol.png</Pressed>
-					<Unpressed>skin:/btn/btn_vinylcontrol.png</Unpressed>
+					<Pressed>skins:Shade/btn/btn_vinylcontrol.png</Pressed>
+					<Unpressed>skins:Shade/btn/btn_vinylcontrol.png</Unpressed>
 				</State>
 				<State>
 					<Number>1</Number>
-					<Pressed>skin:/btn/btn_vinylcontrol_over.png</Pressed>
-					<Unpressed>skin:/btn/btn_vinylcontrol_over.png</Unpressed>
+					<Pressed>skins:Shade/btn/btn_vinylcontrol_over.png</Pressed>
+					<Unpressed>skins:Shade/btn/btn_vinylcontrol_over.png</Unpressed>
 				</State>
 				<Pos>1,21</Pos>
 				<Connection>
@@ -28,13 +28,13 @@
 				<NumberStates>2</NumberStates>
 				<State>
 					<Number>0</Number>
-					<Pressed>skin:/btn/btn_vinylcontrol_passthrough.png</Pressed>
-					<Unpressed>skin:/btn/btn_vinylcontrol_passthrough.png</Unpressed>
+					<Pressed>skins:Shade/btn/btn_vinylcontrol_passthrough.png</Pressed>
+					<Unpressed>skins:Shade/btn/btn_vinylcontrol_passthrough.png</Unpressed>
 				</State>
 				<State>
 					<Number>1</Number>
-					<Pressed>skin:/btn/btn_vinylcontrol_passthrough_over.png</Pressed>
-					<Unpressed>skin:/btn/btn_vinylcontrol_passthrough_over.png</Unpressed>
+					<Pressed>skins:Shade/btn/btn_vinylcontrol_passthrough_over.png</Pressed>
+					<Unpressed>skins:Shade/btn/btn_vinylcontrol_passthrough_over.png</Unpressed>
 				</State>
 				<Pos>1,1</Pos>
 				<Connection>
@@ -58,18 +58,18 @@
 				<NumberStates>3</NumberStates>
 				<State>
 					<Number>0</Number>
-					<Pressed>skin:/btn/btn_vinylcontrol_abs.png</Pressed>
-					<Unpressed>skin:/btn/btn_vinylcontrol_abs.png</Unpressed>
+					<Pressed>skins:Shade/btn/btn_vinylcontrol_abs.png</Pressed>
+					<Unpressed>skins:Shade/btn/btn_vinylcontrol_abs.png</Unpressed>
 				</State>
 				<State>
 					<Number>1</Number>
-					<Pressed>skin:/btn/btn_vinylcontrol_rel.png</Pressed>
-					<Unpressed>skin:/btn/btn_vinylcontrol_rel.png</Unpressed>
+					<Pressed>skins:Shade/btn/btn_vinylcontrol_rel.png</Pressed>
+					<Unpressed>skins:Shade/btn/btn_vinylcontrol_rel.png</Unpressed>
 				</State>
 				<State>
 					<Number>2</Number>
-					<Pressed>skin:/btn/btn_vinylcontrol_const.png</Pressed>
-					<Unpressed>skin:/btn/btn_vinylcontrol_const.png</Unpressed>
+					<Pressed>skins:Shade/btn/btn_vinylcontrol_const.png</Pressed>
+					<Unpressed>skins:Shade/btn/btn_vinylcontrol_const.png</Unpressed>
 				</State>
 				<Pos>1,41</Pos>
 				<Connection>
@@ -88,18 +88,18 @@
 				<NumberStates>3</NumberStates>
 				<State>
 					<Number>0</Number>
-					<Pressed>skin:/btn/btn_vinylcontrol_cue_off.png</Pressed>
-					<Unpressed>skin:/btn/btn_vinylcontrol_cue_off.png</Unpressed>
+					<Pressed>skins:Shade/btn/btn_vinylcontrol_cue_off.png</Pressed>
+					<Unpressed>skins:Shade/btn/btn_vinylcontrol_cue_off.png</Unpressed>
 				</State>
 				<State>
 					<Number>1</Number>
-					<Pressed>skin:/btn/btn_vinylcontrol_cue_on.png</Pressed>
-					<Unpressed>skin:/btn/btn_vinylcontrol_cue_on.png</Unpressed>
+					<Pressed>skins:Shade/btn/btn_vinylcontrol_cue_on.png</Pressed>
+					<Unpressed>skins:Shade/btn/btn_vinylcontrol_cue_on.png</Unpressed>
 				</State>
 				<State>
 					<Number>2</Number>
-					<Pressed>skin:/btn/btn_vinylcontrol_cue_hot.png</Pressed>
-					<Unpressed>skin:/btn/btn_vinylcontrol_cue_hot.png</Unpressed>
+					<Pressed>skins:Shade/btn/btn_vinylcontrol_cue_hot.png</Pressed>
+					<Unpressed>skins:Shade/btn/btn_vinylcontrol_cue_hot.png</Unpressed>
 				</State>
 				<Pos>1,62</Pos>
 				<Connection>

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -122,22 +122,22 @@ WWidgetGroup {
     - waveforms & lower skin part
     - treeview & library table */
 #LibrarySplitter::handle:horizontal {
-  image: url(skin:/../Tango/graphics/splitterHori_handle.svg);
+  image: url(>skins:Tango/graphics/splitterHori_handle.svg);
   }
   #LibrarySplitter::handle:horizontal:hover,
   #LibrarySplitter::handle:horizontal:pressed {
-    image: url(skin:/../Tango/graphics/splitterHori_handle_pressed.svg);
+    image: url(>skins:Tango/graphics/splitterHori_handle_pressed.svg);
   }
   /* splitter between coverArt and tree view */
   #LibrarySplitter::handle:vertical,
   #WaveformSplitter::handle:vertical {
-    image: url(skin:/../Tango/graphics/splitterVert_handle.svg);
+    image: url(>skins:Tango/graphics/splitterVert_handle.svg);
     }
     #LibrarySplitter::handle:vertical:hover,
     #LibrarySplitter::handle:vertical:pressed,
     #WaveformSplitter::handle:vertical:hover,
     #WaveformSplitter::handle:vertical:pressed {
-      image: url(skin:/../Tango/graphics/splitterVert_handle_pressed.svg);
+      image: url(>skins:Tango/graphics/splitterVert_handle_pressed.svg);
     }
 
 
@@ -154,12 +154,12 @@ WWidgetGroup {
   #SkinSettingsClose {
     border-radius:2px;
     background-color: transparent;
-    image: url(skin:/../Tango/buttons/btn_skinsettings_close.svg) no-repeat center top;
+    image: url(>skins:Tango/buttons/btn_skinsettings_close.svg) no-repeat center top;
     }
     #SkinSettingsClose:hover {
       border-radius:2px;
       background-color: #0f0f0f;
-      image: url(skin:/../Tango/buttons/btn_skinsettings_close_hover.svg) no-repeat center top;
+      image: url(>skins:Tango/buttons/btn_skinsettings_close_hover.svg) no-repeat center top;
     }
 
 #SkinSettingsSeparator {
@@ -286,16 +286,16 @@ WWidgetGroup {
   }
 
 #MainHeadMixerLabel {
-  image: url(skin:/../Tango/buttons/btn_main_head_mixer.svg) no-repeat center center;
+  image: url(>skins:Tango/buttons/btn_main_head_mixer.svg) no-repeat center center;
   }
   #MainMixerLabel {
-    image: url(skin:/../Tango/buttons/btn_main.svg) no-repeat center center;
+    image: url(>skins:Tango/buttons/btn_main.svg) no-repeat center center;
   }
   #HeadphoneMixerLabel {
-    image: url(skin:/../Tango/buttons/btn_head.svg) no-repeat center center;
+    image: url(>skins:Tango/buttons/btn_head.svg) no-repeat center center;
   }
 #BoothMixerLabel {
-  image: url(skin:/../Tango/buttons/btn_booth.svg) no-repeat center center;
+  image: url(>skins:Tango/buttons/btn_booth.svg) no-repeat center center;
 }
 #MixerbarKnob {
   qproperty-layoutAlignment: 'AlignCenter';
@@ -368,7 +368,7 @@ WWidgetGroup {
     }
   #RecDot {
     background-color: transparent;  /*
-    image: url(skin:/../Tango/graphics/rec_dot.svg) no-repeat center center; */
+    image: url(>skins:Tango/graphics/rec_dot.svg) no-repeat center center; */
     font-size: 12px/12px;
     margin: 2px 0px 0px 0px;
     }
@@ -405,22 +405,22 @@ WWidgetGroup {
   margin: 0px;
   }
   #BroadcastButton[displayValue="0"] {
-    image: url(skin:/../Tango/buttons/btn_broadcast_off.svg) no-repeat center center;
+    image: url(>skins:Tango/buttons/btn_broadcast_off.svg) no-repeat center center;
     }
     #BroadcastButton[displayValue="0"]:hover {
-      image: url(skin:/../Tango/buttons/btn_broadcast_off_hover.svg) no-repeat center center;
+      image: url(>skins:Tango/buttons/btn_broadcast_off_hover.svg) no-repeat center center;
       }
   #BroadcastButton[displayValue="1"] {
-    image: url(skin:/../Tango/buttons/btn_broadcast_connecting.svg) no-repeat center center;
+    image: url(>skins:Tango/buttons/btn_broadcast_connecting.svg) no-repeat center center;
     }
   #BroadcastButton[displayValue="2"] {
-    image: url(skin:/../Tango/buttons/btn_broadcast_connected.svg) no-repeat center center;
+    image: url(>skins:Tango/buttons/btn_broadcast_connected.svg) no-repeat center center;
     }
   #BroadcastButton[displayValue="3"] {
-    image: url(skin:/../Tango/buttons/btn_broadcast_failure.svg) no-repeat center center;
+    image: url(>skins:Tango/buttons/btn_broadcast_failure.svg) no-repeat center center;
     }
   #BroadcastButton[displayValue="4"] {
-    image: url(skin:/../Tango/buttons/btn_broadcast_warning.svg) no-repeat center center;
+    image: url(>skins:Tango/buttons/btn_broadcast_warning.svg) no-repeat center center;
     }
     #BroadcastButton:hover {
       background-color: #0f0f0f;
@@ -428,11 +428,11 @@ WWidgetGroup {
 
 #SkinSettingsToggler[displayValue="0"] {
   background-color: transparent;
-  image: url(skin:/../Tango/buttons/btn_skinsettings_off.svg) no-repeat center center;
+  image: url(>skins:Tango/buttons/btn_skinsettings_off.svg) no-repeat center center;
   }
   #SkinSettingsToggler[displayValue="0"]:hover {
     background-color: #0f0f0f;
-    image: url(skin:/../Tango/buttons/btn_skinsettings_on.svg) no-repeat center center;
+    image: url(>skins:Tango/buttons/btn_skinsettings_on.svg) no-repeat center center;
   }
 
 
@@ -471,16 +471,16 @@ WWidgetGroup {
   background-color: #333;
   }
   #BeatgridButtonToggler[displayValue="0"] {
-    image: url(skin:/../Tango/buttons/btn_arrow_left.svg) no-repeat center center;
+    image: url(>skins:Tango/buttons/btn_arrow_left.svg) no-repeat center center;
   }
   #BeatgridButtonToggler[displayValue="0"]:hover {
-    image: url(skin:/../Tango/buttons/btn_arrow_left_hover.svg) no-repeat center center;
+    image: url(>skins:Tango/buttons/btn_arrow_left_hover.svg) no-repeat center center;
   }
 #BeatgridButtonToggler[displayValue="1"] {
-  image: url(skin:/../Tango/buttons/btn_arrow_right.svg) no-repeat center center;
+  image: url(>skins:Tango/buttons/btn_arrow_right.svg) no-repeat center center;
 }
   #BeatgridButtonToggler[displayValue="1"]:hover {
-    image: url(skin:/../Tango/buttons/btn_arrow_right_hover.svg) no-repeat center center;
+    image: url(>skins:Tango/buttons/btn_arrow_right_hover.svg) no-repeat center center;
   }
 
 #BeatgridCurpos,
@@ -502,25 +502,25 @@ WWidgetGroup {
     background-color: #0f0f0f;
   }
   #BeatgridCurpos {
-    image: url(skin:/../Tango/buttons/btn_beats_curpos.svg) no-repeat center center;
+    image: url(>skins:Tango/buttons/btn_beats_curpos.svg) no-repeat center center;
   }
   #BeatgridSlower {
-    image: url(skin:/../Tango/buttons/btn_beats_slower.svg) no-repeat center center;
+    image: url(>skins:Tango/buttons/btn_beats_slower.svg) no-repeat center center;
   }
   #BeatgridFaster {
-    image: url(skin:/../Tango/buttons/btn_beats_faster.svg) no-repeat center center;
+    image: url(>skins:Tango/buttons/btn_beats_faster.svg) no-repeat center center;
   }
   #BeatgridEarlier {
-    image: url(skin:/../Tango/buttons/btn_beats_earlier.svg) no-repeat center center;
+    image: url(>skins:Tango/buttons/btn_beats_earlier.svg) no-repeat center center;
   }
   #BeatgridLater {
-    image: url(skin:/../Tango/buttons/btn_beats_later.svg) no-repeat center center;
+    image: url(>skins:Tango/buttons/btn_beats_later.svg) no-repeat center center;
   }
   #HotcuesEarlier {
-    image: url(skin:/../Tango/buttons/btn_hotcues_earlier.svg) no-repeat center center;
+    image: url(>skins:Tango/buttons/btn_hotcues_earlier.svg) no-repeat center center;
   }
   #HotcuesLater {
-    image: url(skin:/../Tango/buttons/btn_hotcues_later.svg) no-repeat center center;
+    image: url(>skins:Tango/buttons/btn_hotcues_later.svg) no-repeat center center;
   }
 
 /*################################################################
@@ -537,10 +537,10 @@ WWidgetGroup {
   qproperty-layoutAlignment: 'AlignLeft | AlignTop';
   }
   #MicSectionIcon {
-    image: url(skin:/../Tango/buttons/btn_mic_section.svg) no-repeat center center;
+    image: url(>skins:Tango/buttons/btn_mic_section.svg) no-repeat center center;
   }
   #AuxSectionLabel {
-    image: url(skin:/../Tango/buttons/btn_aux_section.svg) no-repeat center center;
+    image: url(>skins:Tango/buttons/btn_aux_section.svg) no-repeat center center;
   }
 
 #MicUnit, #AuxUnit {
@@ -550,10 +550,10 @@ WWidgetGroup {
   padding-left: 2px;
   }
   #MicUnitIcon {
-    image: url(skin:/../Tango/buttons/btn_mic_unit.svg) no-repeat center left;
+    image: url(>skins:Tango/buttons/btn_mic_unit.svg) no-repeat center left;
   }
   #AuxUnitIcon {
-    image: url(skin:/../Tango/buttons/btn_aux_unit.svg) no-repeat center left;
+    image: url(>skins:Tango/buttons/btn_aux_unit.svg) no-repeat center left;
   }
   #MicUnitLabel, #AuxUnitLabel {
     padding-bottom: 8px;
@@ -654,42 +654,42 @@ WLabel#TrackComment {
   #VinylTogglerRightPassthrough[displayValue="1"],
   #VinylTogglerRight[displayValue="1"] {
     background-color: transparent;
-    image: url(skin:/../Tango/buttons/btn_vinyl_left.svg) no-repeat top center;
+    image: url(>skins:Tango/buttons/btn_vinyl_left.svg) no-repeat top center;
     }
     #VinylTogglerLeft[displayValue="0"]:hover,
     #VinylTogglerRightPassthrough[displayValue="1"]:hover,
     #VinylTogglerRight[displayValue="1"]:hover {
       background-color: transparent;
-      image: url(skin:/../Tango/buttons/btn_vinyl_left_hover.svg) no-repeat top center;
+      image: url(>skins:Tango/buttons/btn_vinyl_left_hover.svg) no-repeat top center;
     }
   #VinylTogglerLeft[displayValue="1"],
   #VinylTogglerLeftPassthrough[displayValue="1"],
   #VinylTogglerRight[displayValue="0"] {
     background-color: transparent;
-    image: url(skin:/../Tango/buttons/btn_vinyl_right.svg) no-repeat top center;
+    image: url(>skins:Tango/buttons/btn_vinyl_right.svg) no-repeat top center;
     }
     #VinylTogglerLeft[displayValue="1"]:hover,
     #VinylTogglerLeftPassthrough[displayValue="1"]:hover,
     #VinylTogglerRight[displayValue="0"]:hover {
       background-color: transparent;
-      image: url(skin:/../Tango/buttons/btn_vinyl_right_hover.svg) no-repeat top center;
+      image: url(>skins:Tango/buttons/btn_vinyl_right_hover.svg) no-repeat top center;
     }
   /* When passthrough is active but Vinyl Controls are hidden,
     yellow background indicates passthrough, similar to how
     the FX expand toggle does */
   #VinylTogglerLeftPassthrough[displayValue="0"] {
     background: #00ffff;
-    image: url(skin:/../Tango/buttons/btn_vinyl_pass_left.svg) no-repeat top center;
+    image: url(>skins:Tango/buttons/btn_vinyl_pass_left.svg) no-repeat top center;
     }
     #VinylTogglerLeftPassthrough[displayValue="0"]:hover {
-      image: url(skin:/../Tango/buttons/btn_vinyl_pass_left_hover.svg) no-repeat top center;
+      image: url(>skins:Tango/buttons/btn_vinyl_pass_left_hover.svg) no-repeat top center;
     }
   #VinylTogglerRightPassthrough[displayValue="0"] {
     background: #00ffff;
-    image: url(skin:/../Tango/buttons/btn_vinyl_pass_right.svg) no-repeat top center;
+    image: url(>skins:Tango/buttons/btn_vinyl_pass_right.svg) no-repeat top center;
     }
     #VinylTogglerRightPassthrough[displayValue="0"]:hover {
-      image: url(skin:/../Tango/buttons/btn_vinyl_pass_right_hover.svg) no-repeat top center;
+      image: url(>skins:Tango/buttons/btn_vinyl_pass_right_hover.svg) no-repeat top center;
     }
 
   #VinylControlButton,
@@ -807,7 +807,7 @@ WLabel#TrackComment {
     border: 1px solid #fff;
     }
     #LoopIndicator[displayValue="1"] {
-      image: url(skin:/../Tango/buttons/btn_reloop_on.svg) no-repeat center center;
+      image: url(>skins:Tango/buttons/btn_reloop_on.svg) no-repeat center center;
     }
 
 #DeckRowTransport {
@@ -856,32 +856,32 @@ WLabel#TrackComment {
 
   #DeckControlsToggle_Left[displayValue="0"],
   #MainHeadMixerToggle[displayValue="0"] {
-    image: url(skin:/../Tango/buttons/btn_arrow_right.svg) no-repeat center center;
+    image: url(>skins:Tango/buttons/btn_arrow_right.svg) no-repeat center center;
     }
     #DeckControlsToggle_Left[displayValue="0"]:hover,
     #MainHeadMixerToggle[displayValue="0"]:hover {
-      image: url(skin:/../Tango/buttons/btn_arrow_right_hover.svg) no-repeat center center;
+      image: url(>skins:Tango/buttons/btn_arrow_right_hover.svg) no-repeat center center;
     }
     #DeckControlsToggle_Left[displayValue="1"],
     #MainHeadMixerToggle[displayValue="1"] {
-      image: url(skin:/../Tango/buttons/btn_arrow_left.svg) no-repeat center center;
+      image: url(>skins:Tango/buttons/btn_arrow_left.svg) no-repeat center center;
     }
     #DeckControlsToggle_Left[displayValue="1"]:hover,
     #MainHeadMixerToggle[displayValue="1"]:hover {
-      image: url(skin:/../Tango/buttons/btn_arrow_left_hover.svg) no-repeat center center;
+      image: url(>skins:Tango/buttons/btn_arrow_left_hover.svg) no-repeat center center;
     }
 
   #DeckControlsToggle_Right[displayValue="0"] {
-    image: url(skin:/../Tango/buttons/btn_arrow_left.svg) no-repeat center center;
+    image: url(>skins:Tango/buttons/btn_arrow_left.svg) no-repeat center center;
     }
     #DeckControlsToggle_Right[displayValue="0"]:hover {
-      image: url(skin:/../Tango/buttons/btn_arrow_left_hover.svg) no-repeat center center;
+      image: url(>skins:Tango/buttons/btn_arrow_left_hover.svg) no-repeat center center;
     }
     #DeckControlsToggle_Right[displayValue="1"] {
-      image: url(skin:/../Tango/buttons/btn_arrow_right.svg) no-repeat center center;
+      image: url(>skins:Tango/buttons/btn_arrow_right.svg) no-repeat center center;
     }
     #DeckControlsToggle_Right[displayValue="1"]:hover {
-      image: url(skin:/../Tango/buttons/btn_arrow_right_hover.svg) no-repeat center center;
+      image: url(>skins:Tango/buttons/btn_arrow_right_hover.svg) no-repeat center center;
     }
 
   #Keylock[displayValue="1"]:hover {
@@ -915,13 +915,13 @@ WLabel#TrackComment {
 
 #PassthroughPlayCover {
   background-color: transparent;
-  image: url(skin:/../Tango/buttons/btn_mic_aux_mute.svg) no-repeat center center;
+  image: url(>skins:Tango/buttons/btn_mic_aux_mute.svg) no-repeat center center;
 }
 
 #MicTalkover,
 #AuxEnable {
   background-color: transparent;
-  image: url(skin:/../Tango/buttons/btn_mic_aux_mute.svg) no-repeat center center;
+  image: url(>skins:Tango/buttons/btn_mic_aux_mute.svg) no-repeat center center;
 }
 
 #PlayCue[displayValue="0"]:hover,
@@ -1153,22 +1153,22 @@ WBeatSpinBox,
     This would make them overlap so we need to move one of those two
     buttons out of the way: */
     right: -16px;
-    image: url(skin:/../Tango/buttons/btn_beatbox_up.svg) no-repeat;
+    image: url(>skins:Tango/buttons/btn_beatbox_up.svg) no-repeat;
     }
     WBeatSpinBox::up-button:hover,
     #spinBoxTransition::up-button:hover {
-      image: url(skin:/../Tango/buttons/btn_beatbox_up_hover.svg) no-repeat;
+      image: url(>skins:Tango/buttons/btn_beatbox_up_hover.svg) no-repeat;
     }
   WBeatSpinBox::down-button,
   #spinBoxTransition::down-button {
     subcontrol-position: center right;
     border-top-left-radius: 3px;
     border-bottom-left-radius: 3px;
-    image: url(skin:/../Tango/buttons/btn_beatbox_down.svg) no-repeat;
+    image: url(>skins:Tango/buttons/btn_beatbox_down.svg) no-repeat;
     }
     WBeatSpinBox::down-button:hover,
     #spinBoxTransition::down-button:hover {
-      image: url(skin:/../Tango/buttons/btn_beatbox_down_hover.svg) no-repeat;
+      image: url(>skins:Tango/buttons/btn_beatbox_down_hover.svg) no-repeat;
     }
 
 /*################################################################
@@ -1217,7 +1217,7 @@ WBeatSpinBox,
   }
   #SyncButtonOverlay[displayValue="0"]:hover,
   #SyncButtonOverlayMini[displayValue="0"]:hover {
-    image: url(skin:/../Tango/buttons/btn_key_match_hover.svg) no-repeat center center;
+    image: url(>skins:Tango/buttons/btn_key_match_hover.svg) no-repeat center center;
   }
   #SyncButtonOverlay[displayValue="0"] {
     border: 1px solid #444;
@@ -1252,16 +1252,16 @@ WBeatSpinBox,
       background-color: #333;
     }
   #RateUp {
-    image: url(skin:/../Tango/buttons/btn_rate_up.svg) no-repeat center center;
+    image: url(>skins:Tango/buttons/btn_rate_up.svg) no-repeat center center;
     }
     #RateUp:hover {
-      image: url(skin:/../Tango/buttons/btn_rate_up_hover.svg) no-repeat center center;
+      image: url(>skins:Tango/buttons/btn_rate_up_hover.svg) no-repeat center center;
     }
   #RateDown {
-    image: url(skin:/../Tango/buttons/btn_rate_down.svg) no-repeat center center;
+    image: url(>skins:Tango/buttons/btn_rate_down.svg) no-repeat center center;
     }
     #RateDown:hover {
-      image: url(skin:/../Tango/buttons/btn_rate_down_hover.svg) no-repeat center center;
+      image: url(>skins:Tango/buttons/btn_rate_down_hover.svg) no-repeat center center;
     }
 
   #KeyDisplay, #KeyDisplayMini {
@@ -1278,19 +1278,19 @@ WBeatSpinBox,
   }
     #KeyMatch:hover,
     #KeyMatchMini:hover {
-      image: url(skin:/../Tango/buttons/btn_key_match_hover.svg) no-repeat center center;
+      image: url(>skins:Tango/buttons/btn_key_match_hover.svg) no-repeat center center;
     }
     #KeyUp {
-      image: url(skin:/../Tango/buttons/btn_key_up.svg) no-repeat center center;
+      image: url(>skins:Tango/buttons/btn_key_up.svg) no-repeat center center;
       }
       #KeyUp:hover {
-        image: url(skin:/../Tango/buttons/btn_key_up_hover.svg) no-repeat center center;
+        image: url(>skins:Tango/buttons/btn_key_up_hover.svg) no-repeat center center;
       }
     #KeyDown {
-      image: url(skin:/../Tango/buttons/btn_key_down.svg) no-repeat center center;
+      image: url(>skins:Tango/buttons/btn_key_down.svg) no-repeat center center;
       }
       #KeyDown:hover {
-        image: url(skin:/../Tango/buttons/btn_key_down_hover.svg) no-repeat center center;
+        image: url(>skins:Tango/buttons/btn_key_down_hover.svg) no-repeat center center;
       }
 
 
@@ -1387,10 +1387,10 @@ WLabel#TrackComment {
 
 /* Kill indicators underneath EQ knobs */
 #EQKilledUnderlay[displayValue="1"] {
-  image: url(skin:/../Tango/knobs_sliders/knob_eq_killed.svg) no-repeat center center;
+  image: url(>skins:Tango/knobs_sliders/knob_eq_killed.svg) no-repeat center center;
 }
 #QuickFxDisabledUnderlay[displayValue="0"] {
-  image: url(skin:/../Tango/knobs_sliders/knob_quickFX_disabled.svg) no-repeat center center;
+  image: url(>skins:Tango/knobs_sliders/knob_quickFX_disabled.svg) no-repeat center center;
 }
 
 #QuickFXSide {
@@ -1416,13 +1416,13 @@ WLabel#TrackComment {
 
 /*  This wouldn't scale the image:
 #PflButton[displayValue="0"] {
-  background: transparent url(skin:/../Tango/buttons/btn_pfl_off.svg) no-repeat center center;
+  background: transparent url(>skins:Tango/buttons/btn_pfl_off.svg) no-repeat center center;
   background-origin: padding;
   }
   This is a workaround to scale and center the image, but image would appear blurred
   if it is scaled up too much (>120). Source:
   https://forum.qt.io/topic/40151/solved-scaled-background-image-using-stylesheet/6
-  border-image: url(skin:/../Tango/buttons/btn_pfl_off.svg) 0 0 0 0 stretch stretch; */
+  border-image: url(>skins:Tango/buttons/btn_pfl_off.svg) 0 0 0 0 stretch stretch; */
 #PflBoxLeft,
 #PflBoxRight {
   background-color: #0f0f0f;
@@ -1500,19 +1500,19 @@ decks, samplers, mic, aux, fx */
   }
 
 #VUMeterLabelMain {
-  image: url(skin:/../Tango/buttons/btn_main_vu_label.svg) no-repeat center center;
+  image: url(>skins:Tango/buttons/btn_main_vu_label.svg) no-repeat center center;
 }
 #VUMeterLabelDeck1 {
-  image: url(skin:/../Tango/buttons/btn_deck1_vu_label.svg) no-repeat center center;
+  image: url(>skins:Tango/buttons/btn_deck1_vu_label.svg) no-repeat center center;
 }
 #VUMeterLabelDeck2 {
-  image: url(skin:/../Tango/buttons/btn_deck2_vu_label.svg) no-repeat center center;
+  image: url(>skins:Tango/buttons/btn_deck2_vu_label.svg) no-repeat center center;
 }
 #VUMeterLabelDeck3 {
-  image: url(skin:/../Tango/buttons/btn_deck3_vu_label.svg) no-repeat center center;
+  image: url(>skins:Tango/buttons/btn_deck3_vu_label.svg) no-repeat center center;
 }
 #VUMeterLabelDeck4 {
-  image: url(skin:/../Tango/buttons/btn_deck4_vu_label.svg) no-repeat center center;
+  image: url(>skins:Tango/buttons/btn_deck4_vu_label.svg) no-repeat center center;
 }
 
 
@@ -1547,22 +1547,22 @@ decks, samplers, mic, aux, fx */
 #FixedLoopSizesMiniMaxi[displayValue="0"],
 #FxMiniMaxi[displayValue="0"],
 #SamplersMiniMaxi[displayValue="0"] {
-  background-image: url(skin:/../Tango/buttons/btn_arrow_down.svg)
+  background-image: url(>skins:Tango/buttons/btn_arrow_down.svg)
   }
   #FixedLoopSizesMiniMaxi[displayValue="0"]:hover,
   #FxMiniMaxi[displayValue="0"]:hover,
   #SamplersMiniMaxi[displayValue="0"]:hover {
-    background-image: url(skin:/../Tango/buttons/btn_arrow_down_hover.svg);
+    background-image: url(>skins:Tango/buttons/btn_arrow_down_hover.svg);
   }
 #FixedLoopSizesMiniMaxi[displayValue="1"],
 #FxMiniMaxi[displayValue="1"],
 #SamplersMiniMaxi[displayValue="1"] {
-  background-image: url(skin:/../Tango/buttons/btn_arrow_up.svg);
+  background-image: url(>skins:Tango/buttons/btn_arrow_up.svg);
   }
   #FixedLoopSizesMiniMaxi[displayValue="1"]:hover,
   #FxMiniMaxi[displayValue="1"]:hover,
   #SamplersMiniMaxi[displayValue="1"]:hover {
-    background-image: url(skin:/../Tango/buttons/btn_arrow_up_hover.svg);
+    background-image: url(>skins:Tango/buttons/btn_arrow_up_hover.svg);
   }
 
 #FxUnitControls {
@@ -1601,12 +1601,12 @@ decks, samplers, mic, aux, fx */
 /* no focus */
 #FxFlow_mini_separator {
   background-color: transparent;
-  image: url(skin:/../Tango/graphics/fxFlow_mini_noFocus_Fx1-2-3.svg) no-repeat center center;
+  image: url(>skins:Tango/graphics/fxFlow_mini_noFocus_Fx1-2-3.svg) no-repeat center center;
 }
 #FxFlow_maxi_separator {
   background-color: transparent;
   border-radius: 0px;
-  image: url(skin:/../Tango/graphics/fxFlow_maxi_noFocus_Fx1-2-3.svg) no-repeat right center;
+  image: url(>skins:Tango/graphics/fxFlow_maxi_noFocus_Fx1-2-3.svg) no-repeat right center;
 }
 
 #FxFlow_focus_background,
@@ -1625,17 +1625,17 @@ decks, samplers, mic, aux, fx */
 #FxFlow_mini_focus_separator2-3[highlight="0"],
 #FxFlow_mini_focus_separator2-3[highlight="1"] {
   background-color: transparent;
-  image: url(skin:/../Tango/graphics/fxFlow_mini_noFocus_Fx1-2-3.svg) no-repeat center center;
+  image: url(>skins:Tango/graphics/fxFlow_mini_noFocus_Fx1-2-3.svg) no-repeat center center;
   }
   #FxFlow_mini_focus_separator1-2[highlight="1"],
   #FxFlow_mini_focus_separator2-3[highlight="2"] {
     background-color: transparent;
-    image: url(skin:/../Tango/graphics/fxFlow_mini_focus_left.svg) no-repeat center center;
+    image: url(>skins:Tango/graphics/fxFlow_mini_focus_left.svg) no-repeat center center;
   }
   #FxFlow_mini_focus_separator1-2[highlight="2"],
   #FxFlow_mini_focus_separator2-3[highlight="3"] {
     background-color: transparent;
-    image: url(skin:/../Tango/graphics/fxFlow_mini_focus_right.svg) no-repeat center center;
+    image: url(>skins:Tango/graphics/fxFlow_mini_focus_right.svg) no-repeat center center;
   }
 
 /* expanded effect slots, vertical layout */
@@ -1644,17 +1644,17 @@ decks, samplers, mic, aux, fx */
 #FxFlow_maxi_focus_separator2-3[highlight="0"],
 #FxFlow_maxi_focus_separator2-3[highlight="1"] {
   background-color: transparent;
-  image: url(skin:/../Tango/graphics/fxFlow_maxi_noFocus_Fx1-2-3.svg) no-repeat center center;
+  image: url(>skins:Tango/graphics/fxFlow_maxi_noFocus_Fx1-2-3.svg) no-repeat center center;
   }
   #FxFlow_maxi_focus_separator1-2[highlight="1"],
   #FxFlow_maxi_focus_separator2-3[highlight="2"] {
     background-color: transparent;
-    image: url(skin:/../Tango/graphics/fxFlow_maxi_focus_top.svg) no-repeat center center;
+    image: url(>skins:Tango/graphics/fxFlow_maxi_focus_top.svg) no-repeat center center;
   }
   #FxFlow_maxi_focus_separator1-2[highlight="2"],
   #FxFlow_maxi_focus_separator2-3[highlight="3"] {
     background-color: transparent;
-    image: url(skin:/../Tango/graphics/fxFlow_maxi_focus_bottom.svg) no-repeat center center;
+    image: url(>skins:Tango/graphics/fxFlow_maxi_focus_bottom.svg) no-repeat center center;
   }
 /* /effect slot focus indicators */
 
@@ -1662,16 +1662,16 @@ decks, samplers, mic, aux, fx */
   background-color: transparent;
 }
   #FxFocusButton[displayValue="0"] {
-    image: url(skin:/../Tango/buttons/btn_fx_focus_off.svg) no-repeat center center;
+    image: url(>skins:Tango/buttons/btn_fx_focus_off.svg) no-repeat center center;
     }
     #FxFocusButton[displayValue="0"]:hover {
-      image: url(skin:/../Tango/buttons/btn_fx_focus_off_hover.svg) no-repeat center center;
+      image: url(>skins:Tango/buttons/btn_fx_focus_off_hover.svg) no-repeat center center;
     }
   #FxFocusButton[displayValue="1"] {
-    image: url(skin:/../Tango/buttons/btn_fx_focus_on.svg) no-repeat center center;
+    image: url(>skins:Tango/buttons/btn_fx_focus_on.svg) no-repeat center center;
     }
     #FxFocusButton[displayValue="1"]:hover {
-      image: url(skin:/../Tango/buttons/btn_fx_focus_on_hover.svg) no-repeat center center;
+      image: url(>skins:Tango/buttons/btn_fx_focus_on_hover.svg) no-repeat center center;
     }
 
 #FxMetaknob {
@@ -1817,19 +1817,19 @@ decks, samplers, mic, aux, fx */
     background-color: #101010;
     width: 11px;
     height: 20px; */
-    image: url(skin:/../Tango/buttons/btn_arrow_down_fx.svg) no-repeat center center;
+    image: url(>skins:Tango/buttons/btn_arrow_down_fx.svg) no-repeat center center;
     }
     WEffectSelector::down-arrow:hover,
     WEffectChainPresetButton::menu-indicator:hover,
     WSearchLineEdit::down-arrow:hover,
     #fadeModeCombobox::down-arrow:hover {
-      image: url(skin:/../Tango/buttons/btn_arrow_down_fx_hover.svg) no-repeat center center;
+      image: url(>skins:Tango/buttons/btn_arrow_down_fx_hover.svg) no-repeat center center;
     }
   WEffectChainPresetSelector::down-arrow {
-    image: url(skin:/../Tango/buttons/btn_arrow_down_fxquick.svg) no-repeat center center;
+    image: url(>skins:Tango/buttons/btn_arrow_down_fxquick.svg) no-repeat center center;
     }
     WEffectChainPresetSelector::down-arrow:hover {
-      image: url(skin:/../Tango/buttons/btn_arrow_down_fxquick_hover.svg) no-repeat center center;
+      image: url(>skins:Tango/buttons/btn_arrow_down_fxquick_hover.svg) no-repeat center center;
     }
 
   WEffectSelector QAbstractScrollArea,
@@ -1875,7 +1875,7 @@ decks, samplers, mic, aux, fx */
     above will be applied... it's qt magic
     background: #0081B7; */
     margin: 3px 3px 3px 6px;
-    image: url(skin:/../Tango/buttons/btn_lib_checkmark_white.svg) no-repeat center center;
+    image: url(>skins:Tango/buttons/btn_lib_checkmark_white.svg) no-repeat center center;
   }
   /* Wtf?
   This removes 3D border from unchecked effects checkmark space.
@@ -2243,11 +2243,11 @@ WSearchLineEdit::drop-down,
   }
   #MainMenu QMenu::indicator:checked,
   #MainMenu QMenu::indicator:checked:selected {
-    image: url(skin:/../Tango/buttons/btn_mainmenu_checkbox_checked.svg);
+    image: url(>skins:Tango/buttons/btn_mainmenu_checkbox_checked.svg);
   }
   #MainMenu QMenu::indicator:unchecked,
   #MainMenu QMenu::indicator:unchecked:selected {
-    image: url(skin:/../Tango/buttons/btn_mainmenu_checkbox.svg);
+    image: url(>skins:Tango/buttons/btn_mainmenu_checkbox.svg);
   }
 
 #MainMenu QMenu {
@@ -2262,13 +2262,13 @@ WSearchLineEdit::drop-down,
     width: 0.35em;
     height: 0.7em;
     margin-right: 0.2em;
-    image: url(skin:/../Tango/buttons/btn_arrow_right.svg);
+    image: url(>skins:Tango/buttons/btn_arrow_right.svg);
   }
   #MainMenu QMenu::right-arrow:selected,
   WEffectChainPresetButton QMenu::right-arrow,
   WTrackMenu::right-arrow:selected,
   WTrackMenu QMenu::right-arrow:selected {
-    image: url(skin:/../Tango/buttons/btn_arrow_right_hover.svg);
+    image: url(>skins:Tango/buttons/btn_arrow_right_hover.svg);
   }
 
 /* Passthrough label on overview waveform */
@@ -2424,11 +2424,11 @@ WTrackMenu QMenu QCheckBox::indicator {
   WTrackTableViewHeader QMenu::indicator:checked,
   WEffectChainPresetButton QMenu QCheckBox::indicator:checked,
   WTrackMenu QMenu QCheckBox::indicator:checked {
-    image: url(skin:/../Tango/buttons/btn_lib_checkmark.svg);
+    image: url(>skins:Tango/buttons/btn_lib_checkmark.svg);
     border: 1px solid #111;
   }
   WTrackMenu QMenu QCheckBox::indicator:indeterminate {
-    image: url(skin:/../Tango/buttons/btn_lib_checkmark_indeterminate.svg);
+    image: url(>skins:Tango/buttons/btn_lib_checkmark_indeterminate.svg);
     background-color: #1e1e1e;
   }
   /* disabled menu checkbox */
@@ -2436,10 +2436,10 @@ WTrackMenu QMenu QCheckBox::indicator {
     background-color: #222;
   }
   WTrackMenu QMenu QCheckBox::indicator:disabled:checked {
-    image: url(skin:/../Tango/buttons/btn_lib_checkmark_grey.svg);
+    image: url(>skins:Tango/buttons/btn_lib_checkmark_grey.svg);
   }
   WTrackMenu QMenu QCheckBox::indicator:disabled:indeterminate {
-    image: url(skin:/../Tango/buttons/btn_lib_checkmark_indeterminate_grey.svg);
+    image: url(>skins:Tango/buttons/btn_lib_checkmark_indeterminate_grey.svg);
   }
 
 /* widgets in cue popup menu */
@@ -2452,7 +2452,7 @@ WTrackMenu QMenu QCheckBox::indicator {
   border: 1px solid #666;
   background-color: #333;
   border-radius: 2px;
-  qproperty-icon: url(skin:/../Tango/buttons/btn_delete.svg);
+  qproperty-icon: url(>skins:Tango/buttons/btn_delete.svg);
   /* make the icon slightly larger than default 16px */
   qproperty-iconSize: 20px;
 }
@@ -2538,16 +2538,16 @@ WTrackMenu QMenu QCheckBox::indicator {
 #LibMiniMaxiButton {
   }
   #LibMiniMaxiButton[displayValue="0"] {
-    image: url(skin:/../Tango/buttons/btn_lib_maxi.svg) no-repeat center top;
+    image: url(>skins:Tango/buttons/btn_lib_maxi.svg) no-repeat center top;
     }
     #LibMiniMaxiButton[displayValue="0"]:hover {
-      image: url(skin:/../Tango/buttons/btn_lib_maxi_hover.svg) no-repeat center top;
+      image: url(>skins:Tango/buttons/btn_lib_maxi_hover.svg) no-repeat center top;
     }
   #LibMiniMaxiButton[displayValue="1"] {
-    image: url(skin:/../Tango/buttons/btn_lib_mini.svg) no-repeat center top;
+    image: url(>skins:Tango/buttons/btn_lib_mini.svg) no-repeat center top;
     }
     #LibMiniMaxiButton[displayValue="1"]:hover {
-      image: url(skin:/../Tango/buttons/btn_lib_mini_hover.svg) no-repeat center top;
+      image: url(>skins:Tango/buttons/btn_lib_mini_hover.svg) no-repeat center top;
     }
 
 WTrackTableView,
@@ -2628,7 +2628,7 @@ WLibrarySidebar {
 /*  Closed branch icon in tree */
 WLibrarySidebar::branch:has-children:!has-siblings:closed,
 WLibrarySidebar::branch:closed:has-children:has-siblings {
-  image: url(skin:/../Tango/graphics/branch_closed.svg);
+  image: url(>skins:Tango/graphics/branch_closed.svg);
   }
   WLibrarySidebar::branch:has-children:!has-siblings:closed:selected,
   WLibrarySidebar::branch:closed:has-children:has-siblings:selected {
@@ -2638,7 +2638,7 @@ WLibrarySidebar::branch:closed:has-children:has-siblings {
 /*  Open branch icon in tree */
 WLibrarySidebar::branch:open:has-children:!has-siblings,
 WLibrarySidebar::branch:open:has-children:has-siblings {
-  image: url(skin:/../Tango/graphics/branch_open.svg);
+  image: url(>skins:Tango/graphics/branch_open.svg);
   }
   WLibrarySidebar::branch:open:has-children:!has-siblings:selected,
   WLibrarySidebar::branch:open:has-children:has-siblings:selected {
@@ -2708,16 +2708,16 @@ WTrackTableViewHeader {
       background-color: rgba(88,88,88,200);
     }
     WTrackTableViewHeader::up-arrow {
-      image: url(skin:/../Tango/graphics/library_sort_up.svg);
+      image: url(>skins:Tango/graphics/library_sort_up.svg);
       }
       WTrackTableViewHeader::up-arrow:hover {
-        image: url(skin:/../Tango/graphics/library_sort_down.svg);
+        image: url(>skins:Tango/graphics/library_sort_down.svg);
       }
     WTrackTableViewHeader::down-arrow {
-      image: url(skin:/../Tango/graphics/library_sort_down.svg);
+      image: url(>skins:Tango/graphics/library_sort_down.svg);
       }
       WTrackTableViewHeader::down-arrow:hover {
-        image: url(skin:/../Tango/graphics/library_sort_up.svg);
+        image: url(>skins:Tango/graphics/library_sort_up.svg);
       }
 
 WLibraryTextBrowser {
@@ -2955,34 +2955,34 @@ Library features and their buttons:
 
 /* AutoDJ button icons */
 QPushButton#pushButtonAutoDJ:!checked {
-  image: url(skin:/../Tango/buttons/btn_autodj_enable_off.svg) no-repeat center center;
+  image: url(>skins:Tango/buttons/btn_autodj_enable_off.svg) no-repeat center center;
   }
   QPushButton#pushButtonAutoDJ:checked {
-    image: url(skin:/../Tango/buttons/btn_autodj_enable_on.svg) no-repeat center center;
+    image: url(>skins:Tango/buttons/btn_autodj_enable_on.svg) no-repeat center center;
   }
 QPushButton#pushButtonFadeNow:!enabled {
-  image: url(skin:/../Tango/buttons/btn_autodj_fade_disabled.svg) no-repeat center center;
+  image: url(>skins:Tango/buttons/btn_autodj_fade_disabled.svg) no-repeat center center;
   }
   QPushButton#pushButtonFadeNow:enabled {
-    image: url(skin:/../Tango/buttons/btn_autodj_fade.svg) no-repeat center center;
+    image: url(>skins:Tango/buttons/btn_autodj_fade.svg) no-repeat center center;
   }
 QPushButton#pushButtonSkipNext:!enabled {
-  image: url(skin:/../Tango/buttons/btn_autodj_skip_disabled.svg) no-repeat center center;
+  image: url(>skins:Tango/buttons/btn_autodj_skip_disabled.svg) no-repeat center center;
   }
   QPushButton#pushButtonSkipNext:enabled {
-    image: url(skin:/../Tango/buttons/btn_autodj_skip.svg) no-repeat center center;
+    image: url(>skins:Tango/buttons/btn_autodj_skip.svg) no-repeat center center;
   }
 QPushButton#pushButtonShuffle {
-  image: url(skin:/../Tango/buttons/btn_autodj_shuffle.svg) no-repeat center center;
+  image: url(>skins:Tango/buttons/btn_autodj_shuffle.svg) no-repeat center center;
 }
 QPushButton#pushButtonAddRandomTrack {
-  image: url(skin:/../Tango/buttons/btn_autodj_addrandom.svg) no-repeat center center;
+  image: url(>skins:Tango/buttons/btn_autodj_addrandom.svg) no-repeat center center;
 }
 QPushButton#pushButtonRepeatPlaylist:!checked {
-  image: url(skin:/../Tango/buttons/btn_autodj_repeat_playlist_off.svg) no-repeat center center;
+  image: url(>skins:Tango/buttons/btn_autodj_repeat_playlist_off.svg) no-repeat center center;
   }
   QPushButton#pushButtonRepeatPlaylist:checked {
-    image: url(skin:/../Tango/buttons/btn_autodj_repeat_playlist_on.svg) no-repeat center center;
+    image: url(>skins:Tango/buttons/btn_autodj_repeat_playlist_on.svg) no-repeat center center;
   }
 /* AutoDJ button icons */
 
@@ -3011,10 +3011,10 @@ QPushButton#pushButtonRepeatPlaylist:!checked {
   /* Entire BPM cell */
   /* Lock icon at the left */
   #LibraryBPMButton::indicator:checked {
-    image: url(skin:/../Tango/buttons/btn_lib_bpm_locked.svg);
+    image: url(>skins:Tango/buttons/btn_lib_bpm_locked.svg);
     }
   #LibraryBPMButton::indicator:unchecked {
-    image: url(skin:/../Tango/buttons/btn_lib_bpm_unlocked.svg);
+    image: url(>skins:Tango/buttons/btn_lib_bpm_unlocked.svg);
     }
   /* BPM value */
   #LibraryBPMButton::item {
@@ -3031,10 +3031,10 @@ QPushButton#pushButtonRepeatPlaylist:!checked {
     background-color: #0f0f0f;
     }
     #LibraryBPMSpinBox::up-button {
-      image: url(skin:/../Tango/buttons/btn_lib_spinbox_up_white.svg) no-repeat;
+      image: url(>skins:Tango/buttons/btn_lib_spinbox_up_white.svg) no-repeat;
       }
     #LibraryBPMSpinBox::down-button {
-      image: url(skin:/../Tango/buttons/btn_lib_spinbox_down_white.svg) no-repeat;
+      image: url(>skins:Tango/buttons/btn_lib_spinbox_down_white.svg) no-repeat;
     }
 
   /* Button in library "Preview" column */
@@ -3045,14 +3045,14 @@ QPushButton#pushButtonRepeatPlaylist:!checked {
     border: 1px solid transparent;
     }
     #LibraryPreviewButton:!checked {
-      image: url(skin:/../Tango/buttons/btn_lib_preview_play.svg);
+      image: url(>skins:Tango/buttons/btn_lib_preview_play.svg);
       }
       #LibraryPreviewButton:!checked:hover {
         border: 1px solid #888;
         background: #0f0f0f;
       }
     #LibraryPreviewButton:checked {
-      image: url(skin:/../Tango/buttons/btn_lib_preview_pause.svg);
+      image: url(>skins:Tango/buttons/btn_lib_preview_pause.svg);
       background-color: #000;
       border: 1px solid #555;
       }
@@ -3073,10 +3073,10 @@ QPushButton#pushButtonRepeatPlaylist:!checked {
 
   /* checkbox in library "Played" column */
   WTrackTableView::indicator:checked {
-    image: url(skin:/../Tango/buttons/btn_lib_checkbox_checked.svg);
+    image: url(>skins:Tango/buttons/btn_lib_checkbox_checked.svg);
     }
   WTrackTableView::indicator:unchecked {
-    image: url(skin:/../Tango/buttons/btn_lib_checkbox.svg);
+    image: url(>skins:Tango/buttons/btn_lib_checkbox.svg);
     }
 
 #LibraryFeatureControls QSpinBox {
@@ -3123,11 +3123,11 @@ QRadioButton#radioButtonRecentlyAdded {
 }
 
 #LibraryFeatureControls QRadioButton::indicator:checked {
-  image: url(skin:/../Tango/buttons/btn_lib_radio_button_on.svg) center center;
+  image: url(>skins:Tango/buttons/btn_lib_radio_button_on.svg) center center;
 }
 
 #LibraryFeatureControls QRadioButton::indicator:unchecked {
-  image: url(skin:/../Tango/buttons/btn_lib_radio_button_off.svg) center center;
+  image: url(>skins:Tango/buttons/btn_lib_radio_button_off.svg) center center;
 }
 
 /* explicitly remove icons from unchecked items otherwise


### PR DESCRIPTION
@mxmilkiib discovered a flaw/regression I introduced with #12463, #12614.
The intent of #12463 was to simplify skin modding by requiring only a skin dir with only the modded sub-level template.
However, this fails if that template itself requires templates from the base skin.

This PR replaces all remaining 'skin:' occurences with 'skins:[skin name]'.

The procedure to mod a single template is now not that simple anymore, unfortnately.
But it still is rather inexpensive considering you'd benefit from future updates to the base skin. Use `<Template src="skin:path/to/template.xml">`, or explicitly `<Template src="skins:[name of modded skin]/path/to/template.xml`

**Example:** modifiy `Deere/deck_controls_row.xml`
The include tree looks like this:
```
+ Deere
∟ skin.xml
  ∟ left_/right_gutter.xml
    ∟ deck.xml
       ∟ deck_controls_row.xml
```
 * skin.xml: use `skin:left_gutter.xml` and  `skin:right_gutter.xml`
 * left_/right_gutter.xml: use `skin:deck.xml`
 * deck.xml: use `skin:path/to/deck_controls_row.xml`

Thanks @mxmilkiib for battle testing Mixxx beta and alpha!