### PR TITLE
Set app_id to fix Mixxx window icon on Wayland

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -173,6 +173,11 @@ int main(int argc, char * argv[]) {
             Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
 #endif
 
+#ifdef __LINUX__
+    // Needed by Wayland compositors to set proper app_id and window icon
+    QGuiApplication::setDesktopFileName(QStringLiteral("org.mixxx.Mixxx"));
+#endif
+
     // Setting the organization name results in a QDesktopStorage::DataLocation
     // of "$HOME/Library/Application Support/Mixxx/Mixxx" on OS X. Leave the
     // organization name blank.


### PR DESCRIPTION
![mixxx_wayland_w](https://github.com/mixxxdj/mixxx/assets/151883861/43eb73f0-dd4e-41e0-ab46-f851961ae8fb)

I was testing Mixxx on Wayland KDE and noticed the default yellow 'W' window icon was displayed instead of the proper Mixxx icon. Apparently this is caused by a missing QGuiApplication::setDesktopFileName() that sets Wayland app_id for the application.

[https://community.kde.org/Guidelines_and_HOWTOs/Wayland_Porting_Notes#Application_Icon](https://community.kde.org/Guidelines_and_HOWTOs/Wayland_Porting_Notes#Application_Icon)

I'm not entirely sure if main.cpp is the correct location or if VersionStore should be used, but it's a set and forget thing so this seemed like the logical place. Adding this should not affect Windows or macOS builds, but I did find one report of something unexpected happening, hence the #ifdef.