### PR TITLE
add WEffectMetaKnob, draws arc from default meta position

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1201,6 +1201,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/widget/weffectchainpresetselector.cpp
   src/widget/weffectknobparametername.cpp
   src/widget/weffectname.cpp
+  src/widget/weffectmetaknob.cpp
   src/widget/weffectparameterknob.cpp
   src/widget/weffectparameterknobcomposed.cpp
   src/widget/weffectparameternamebase.cpp

--- a/res/skins/Deere/effect_meta_knob.xml
+++ b/res/skins/Deere/effect_meta_knob.xml
@@ -13,12 +13,20 @@
     <Layout>vertical</Layout>
     <Size>40f,34f</Size>
     <Children>
-      <Template src="skin:knob.xml">
-        <SetVariable name="TooltipId">EffectSlot_metaknob</SetVariable>
-        <SetVariable name="group">[EffectRack<Variable name="EffectRack"/>_EffectUnit<Variable name="EffectUnit"/>_Effect<Variable name="Effect"/>]</SetVariable>
-        <SetVariable name="control">meta</SetVariable>
-        <SetVariable name="color">blue_gapless</SetVariable>
-      </Template>
+      <EffectMetaKnob>
+        <TooltipId>EffectSlot_metaknob</TooltipId>
+        <Size>40f,34f</Size>
+        <Knob>knob.svg</Knob>
+        <BackPath>knob_bg_blue_gapless.svg</BackPath>
+        <MinAngle>-135</MinAngle>
+        <MaxAngle>135</MaxAngle>
+        <KnobCenterYOffset>1.602</KnobCenterYOffset>
+        <EffectUnit><Variable name="EffectUnit"/></EffectUnit>
+        <Effect><Variable name="Effect"/></Effect>
+        <Connection>
+          <ConfigKey>[EffectRack<Variable name="EffectRack"/>_EffectUnit<Variable name="EffectUnit"/>_Effect<Variable name="Effect"/>],meta</ConfigKey>
+        </Connection>
+      </EffectMetaKnob>
     </Children>
   </WidgetGroup>
 </Template>

--- a/res/skins/LateNight/fx/meta_knob.xml
+++ b/res/skins/LateNight/fx/meta_knob.xml
@@ -11,7 +11,7 @@
     <ObjectName>FxMetaKnob</ObjectName>
     <SizePolicy>f,max</SizePolicy>
     <Children>
-      <KnobComposed>
+      <EffectMetaKnob>
         <TooltipId>EffectSlot_metaknob</TooltipId>
         <Size>35f,30f</Size>
         <Knob>skins:LateNight/<Variable name="KnobScheme"/>/knobs/knob_indicator_small_<Variable name="KnobColor"/>.svg</Knob>
@@ -23,11 +23,12 @@
         <ArcThickness><Variable name="ArcThickness"/></ArcThickness>
         <ArcRoundCaps><Variable name="ArcRoundCaps"/></ArcRoundCaps>
         <ArcColor><Variable name="ArcColorSuper"/></ArcColor>
-        <ArcUnipolar>true</ArcUnipolar>
+        <EffectUnit><Variable name="FxUnit"/></EffectUnit>
+        <Effect><Variable name="FxNum"/></Effect>
         <Connection>
           <ConfigKey>[<Variable name="FxRack_FxUnit_FxNum"/>],meta</ConfigKey>
         </Connection>
-      </KnobComposed>
+      </EffectMetaKnob>
     </Children>
   </WidgetGroup>
 </Template>

--- a/res/skins/LateNight/fx/slot_controls.xml
+++ b/res/skins/LateNight/fx/slot_controls.xml
@@ -39,11 +39,7 @@
             <SetVariable name="ConfigKey">[<Variable name="FxRack_FxUnit_FxNum"/>],enabled</SetVariable>
           </Template>
 
-          <Template src="skins:LateNight/fx/meta_knob.xml">
-            <SetVariable name="Group">[<Variable name="FxRack_FxUnit_FxNum"/>]</SetVariable>
-            <SetVariable name="TooltipId">EffectUnit_mix</SetVariable>
-            <SetVariable name="Control">meta</SetVariable>
-          </Template>
+          <Template src="skins:LateNight/fx/meta_knob.xml"/>
 
           <EffectSelector>
             <MinimumSize>60,24</MinimumSize>

--- a/res/skins/LateNight/skin.xml
+++ b/res/skins/LateNight/skin.xml
@@ -235,6 +235,7 @@
 
     <Scheme>
       <Name>Classic</Name>
+      <!-- Classic theme. Bulky containers, hatched backgrounds, no knob arcs -->
       <Style src="skins:LateNight/style_classic.qss"/>
       <SetVariable name="BtnScheme">classic</SetVariable>
       <SetVariable name="KnobScheme">classic</SetVariable>

--- a/res/skins/Tango/fx/metaknob.xml
+++ b/res/skins/Tango/fx/metaknob.xml
@@ -15,7 +15,7 @@ Variables:
     <Layout>vertical</Layout>
     <SizePolicy>min,min</SizePolicy>
     <Children>
-      <KnobComposed>
+      <EffectMetaKnob>
         <TooltipId>EffectSlot_metaknob</TooltipId>
         <Size>30f,26f</Size>
         <Knob>skins:Tango/knobs_sliders/knob_blue.svg</Knob>
@@ -23,10 +23,12 @@ Variables:
         <MinAngle><Variable name="PotiMinAngle"/></MinAngle>
         <MaxAngle><Variable name="PotiMaxAngle"/></MaxAngle>
         <KnobCenterYOffset>2.000</KnobCenterYOffset>
+        <EffectUnit><Variable name="FxUnit"/></EffectUnit>
+        <Effect><Variable name="FxNum"/></Effect>
         <Connection>
           <ConfigKey><Variable name="FxRack_FxUnit_FxNum"/>,meta</ConfigKey>
         </Connection>
-      </KnobComposed>
+      </EffectMetaKnob>
     </Children>
   </WidgetGroup>
 </Template>

--- a/src/effects/backends/builtin/graphiceqeffect.cpp
+++ b/src/effects/backends/builtin/graphiceqeffect.cpp
@@ -66,6 +66,7 @@ EffectManifestPointer GraphicEQEffect::getManifest() {
             "Gain for High Filter"));
     high->setValueScaler(EffectManifestParameter::ValueScaler::Linear);
     high->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
+    high->setNeutralPointOnScale(0.5);
     high->setRange(-12, 0, 12);
 
     return pManifest;

--- a/src/effects/backends/builtin/parametriceqeffect.cpp
+++ b/src/effects/backends/builtin/parametriceqeffect.cpp
@@ -60,7 +60,6 @@ EffectManifestPointer ParametricEQEffect::getManifest() {
             "Center frequency for Filter 1, from 100 Hz to 14 kHz"));
     center1->setValueScaler(EffectManifestParameter::ValueScaler::Logarithmic);
     center1->setUnitsHint(EffectManifestParameter::UnitsHint::Hertz);
-    center1->setNeutralPointOnScale(0.5);
     center1->setRange(100, kDefaultCenter1, 14000);
 
     EffectManifestParameterPointer gain2 = pManifest->addParameter();
@@ -95,7 +94,6 @@ EffectManifestPointer ParametricEQEffect::getManifest() {
             "Center frequency for Filter 2, from 100 Hz to 14 kHz"));
     center2->setValueScaler(EffectManifestParameter::ValueScaler::Logarithmic);
     center2->setUnitsHint(EffectManifestParameter::UnitsHint::Hertz);
-    center2->setNeutralPointOnScale(0.5);
     center2->setRange(100, kDefaultCenter2, 14000);
 
     return pManifest;

--- a/src/effects/backends/builtin/pitchshifteffect.cpp
+++ b/src/effects/backends/builtin/pitchshifteffect.cpp
@@ -80,7 +80,7 @@ EffectManifestPointer PitchShiftEffect::getManifest() {
             "The pitch shift applied to the sound."));
     pitch->setValueScaler(EffectManifestParameter::ValueScaler::Linear);
     pitch->setDefaultLinkType(EffectManifestParameter::LinkType::Linked);
-    pitch->setNeutralPointOnScale(0.0);
+    pitch->setNeutralPointOnScale(0.5);
     pitch->setRange(-1.0, 0.0, 1.0);
 
     EffectManifestParameterPointer range = pManifest->addParameter();
@@ -91,7 +91,7 @@ EffectManifestPointer PitchShiftEffect::getManifest() {
             "The range of the Pitch knob (0 - 2 octaves).\n"));
     range->setValueScaler(EffectManifestParameter::ValueScaler::Linear);
     range->setDefaultLinkType(EffectManifestParameter::LinkType::Linked);
-    range->setNeutralPointOnScale(1.0);
+    range->setNeutralPointOnScale(0.5);
     range->setRange(0.0, 1.0, 2.0);
 
     EffectManifestParameterPointer semitonesMode = pManifest->addParameter();

--- a/src/effects/effectknobparameterslot.cpp
+++ b/src/effects/effectknobparameterslot.cpp
@@ -239,10 +239,3 @@ void EffectKnobParameterSlot::syncSofttakeover() {
 double EffectKnobParameterSlot::getValueParameter() const {
     return m_pControlValue->getParameter();
 }
-
-std::optional<double> EffectKnobParameterSlot::neutralPointOnScale() const {
-    if (m_pManifestParameter) {
-        return m_pManifestParameter->neutralPointOnScale();
-    }
-    return std::nullopt;
-}

--- a/src/effects/effectknobparameterslot.cpp
+++ b/src/effects/effectknobparameterslot.cpp
@@ -239,3 +239,10 @@ void EffectKnobParameterSlot::syncSofttakeover() {
 double EffectKnobParameterSlot::getValueParameter() const {
     return m_pControlValue->getParameter();
 }
+
+double EffectKnobParameterSlot::neutralPointOnScale() const {
+    if (m_pManifestParameter) {
+        return m_pManifestParameter->neutralPointOnScale();
+    }
+    return 0.0;
+}

--- a/src/effects/effectknobparameterslot.cpp
+++ b/src/effects/effectknobparameterslot.cpp
@@ -240,9 +240,9 @@ double EffectKnobParameterSlot::getValueParameter() const {
     return m_pControlValue->getParameter();
 }
 
-double EffectKnobParameterSlot::neutralPointOnScale() const {
+std::optional<double> EffectKnobParameterSlot::neutralPointOnScale() const {
     if (m_pManifestParameter) {
         return m_pManifestParameter->neutralPointOnScale();
     }
-    return 0.0;
+    return std::nullopt;
 }

--- a/src/effects/effectknobparameterslot.h
+++ b/src/effects/effectknobparameterslot.h
@@ -3,6 +3,7 @@
 #include <QObject>
 #include <QString>
 #include <QVariant>
+#include <optional>
 
 #include "effects/effectparameterslotbase.h"
 #include "util/class.h"
@@ -38,7 +39,7 @@ class EffectKnobParameterSlot : public EffectParameterSlotBase {
 
     void setParameter(double value) override;
 
-    double neutralPointOnScale() const override;
+    std::optional<double> neutralPointOnScale() const override;
 
   private slots:
     // Solely for handling control changes

--- a/src/effects/effectknobparameterslot.h
+++ b/src/effects/effectknobparameterslot.h
@@ -39,8 +39,6 @@ class EffectKnobParameterSlot : public EffectParameterSlotBase {
 
     void setParameter(double value) override;
 
-    std::optional<double> neutralPointOnScale() const override;
-
   private slots:
     // Solely for handling control changes
     void slotLinkTypeChanging(double v);

--- a/src/effects/effectknobparameterslot.h
+++ b/src/effects/effectknobparameterslot.h
@@ -38,6 +38,8 @@ class EffectKnobParameterSlot : public EffectParameterSlotBase {
 
     void setParameter(double value) override;
 
+    double neutralPointOnScale() const override;
+
   private slots:
     // Solely for handling control changes
     void slotLinkTypeChanging(double v);

--- a/src/effects/effectparameterslotbase.h
+++ b/src/effects/effectparameterslotbase.h
@@ -50,6 +50,10 @@ class EffectParameterSlotBase : public QObject {
 
     virtual void setParameter(double value) = 0;
 
+    virtual double neutralPointOnScale() const {
+        return 0.0;
+    }
+
   signals:
     // Signal that indicates that the EffectParameterSlotBase has been updated.
     void updated();

--- a/src/effects/effectparameterslotbase.h
+++ b/src/effects/effectparameterslotbase.h
@@ -51,8 +51,11 @@ class EffectParameterSlotBase : public QObject {
 
     virtual void setParameter(double value) = 0;
 
-    virtual std::optional<double> neutralPointOnScale() const {
-        return std::nullopt;
+    std::optional<double> neutralPointOnScale() const {
+        if (m_pManifestParameter == nullptr) {
+            return std::nullopt;
+        }
+        return m_pManifestParameter->neutralPointOnScale();
     }
 
   signals:

--- a/src/effects/effectparameterslotbase.h
+++ b/src/effects/effectparameterslotbase.h
@@ -2,6 +2,7 @@
 
 #include <QObject>
 #include <QString>
+#include <optional>
 
 #include "effects/backends/effectmanifestparameter.h"
 #include "util/class.h"
@@ -50,8 +51,8 @@ class EffectParameterSlotBase : public QObject {
 
     virtual void setParameter(double value) = 0;
 
-    virtual double neutralPointOnScale() const {
-        return 0.0;
+    virtual std::optional<double> neutralPointOnScale() const {
+        return std::nullopt;
     }
 
   signals:

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -43,6 +43,7 @@
 #include "widget/weffectchainpresetbutton.h"
 #include "widget/weffectchainpresetselector.h"
 #include "widget/weffectknobparametername.h"
+#include "widget/weffectmetaknob.h"
 #include "widget/weffectname.h"
 #include "widget/weffectparameterknob.h"
 #include "widget/weffectparameterknobcomposed.h"
@@ -592,6 +593,8 @@ QList<QWidget*> LegacySkinParser::parseNode(const QDomElement& node) {
         result = wrapWidget(parseEffectChainPresetSelector(node));
     } else if (nodeName == "EffectName") {
         result = wrapWidget(parseEffectName(node));
+    } else if (nodeName == "EffectMetaKnob") {
+        result = wrapWidget(parseEffectMetaKnob(node));
     } else if (nodeName == "EffectSelector") {
         result = wrapWidget(parseEffectSelector(node));
     } else if (nodeName == "EffectParameterKnob") {
@@ -1882,6 +1885,18 @@ QWidget* LegacySkinParser::parseEffectSelector(const QDomElement& node) {
         m_pControllerManager->getControllerLearningEventFilter());
     pSelector->Init();
     return pSelector;
+}
+
+QWidget* LegacySkinParser::parseEffectMetaKnob(const QDomElement& node) {
+    WEffectMetaKnob* pMetaKnob =
+            new WEffectMetaKnob(m_pParent, m_pEffectsManager);
+    commonWidgetSetup(node, pMetaKnob);
+    pMetaKnob->setup(node, *m_pContext);
+    pMetaKnob->installEventFilter(m_pKeyboard);
+    pMetaKnob->installEventFilter(
+            m_pControllerManager->getControllerLearningEventFilter());
+    pMetaKnob->Init();
+    return pMetaKnob;
 }
 
 QWidget* LegacySkinParser::parseEffectParameterKnob(const QDomElement& node) {

--- a/src/skin/legacy/legacyskinparser.h
+++ b/src/skin/legacy/legacyskinparser.h
@@ -87,6 +87,7 @@ class LegacySkinParser : public QObject, public SkinParser {
     QWidget* parseEffectChainPresetButton(const QDomElement& node);
     QWidget* parseEffectChainPresetSelector(const QDomElement& node);
     QWidget* parseEffectName(const QDomElement& node);
+    QWidget* parseEffectMetaKnob(const QDomElement& node);
     QWidget* parseEffectParameterName(const QDomElement& node);
     QWidget* parseEffectParameterKnob(const QDomElement& node);
     QWidget* parseEffectParameterKnobComposed(const QDomElement& node);

--- a/src/widget/weffectmetaknob.cpp
+++ b/src/widget/weffectmetaknob.cpp
@@ -1,0 +1,46 @@
+#include "widget/weffectmetaknob.h"
+
+#include "effects/effectslot.h"
+#include "moc_weffectmetaknob.cpp"
+#include "widget/effectwidgetutils.h"
+
+WEffectMetaKnob::WEffectMetaKnob(QWidget* pParent, EffectsManager* pEffectsManager)
+        : WKnobComposed(pParent),
+          m_pEffectsManager(pEffectsManager) {
+}
+
+void WEffectMetaKnob::setup(const QDomNode& node, const SkinContext& context) {
+    WKnobComposed::setup(node, context);
+    auto pChainSlot = EffectWidgetUtils::getEffectChainFromNode(
+            node, context, m_pEffectsManager);
+    m_pEffectSlot =
+            EffectWidgetUtils::getEffectSlotFromNode(node, context, pChainSlot);
+    VERIFY_OR_DEBUG_ASSERT(m_pEffectSlot) {
+        SKIN_WARNING(node, context, QStringLiteral("Could not find effect slot"));
+        return;
+    }
+    connect(m_pEffectSlot.data(),
+            &EffectSlot::effectChanged,
+            this,
+            &WEffectMetaKnob::effectChanged);
+    effectChanged();
+}
+
+void WEffectMetaKnob::effectChanged() {
+    EffectManifestPointer pManifest = nullptr;
+    if (m_pEffectSlot->isLoaded()) {
+        pManifest = m_pEffectSlot->getManifest();
+    }
+
+    if (pManifest) {
+        setDefaultAngleFromParameterOrReset(pManifest->metaknobDefault());
+        setBaseTooltip(QString("%1\n%2").arg(
+                pManifest->name(),
+                pManifest->description()));
+    } else {
+        // This makes drawArc() fall back to drawing from center (if Reverse is not set)
+        setDefaultAngleFromParameterOrReset(-1);
+        setBaseTooltip("");
+    }
+    update();
+}

--- a/src/widget/weffectmetaknob.cpp
+++ b/src/widget/weffectmetaknob.cpp
@@ -34,7 +34,7 @@ void WEffectMetaKnob::effectChanged() {
 
     if (pManifest) {
         setDefaultAngleFromParameterOrReset(pManifest->metaknobDefault());
-        setBaseTooltip(QString("%1\n%2").arg(
+        setBaseTooltip(QStringLiteral("%1\n%2").arg(
                 pManifest->name(),
                 pManifest->description()));
     } else {

--- a/src/widget/weffectmetaknob.cpp
+++ b/src/widget/weffectmetaknob.cpp
@@ -38,8 +38,7 @@ void WEffectMetaKnob::effectChanged() {
                 pManifest->name(),
                 pManifest->description()));
     } else {
-        // This makes drawArc() fall back to drawing from center (if Reverse is not set)
-        setDefaultAngleFromParameterOrReset(-1);
+        setDefaultAngleFromParameterOrReset(std::nullopt);
         setBaseTooltip("");
     }
     update();

--- a/src/widget/weffectmetaknob.h
+++ b/src/widget/weffectmetaknob.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "effects/defs.h"
+#include "widget/wknobcomposed.h"
+
+class EffectsManager;
+
+// This is used for effect parameter knobs with dynamic
+// tooltips, if the knob value is displayed by rotating a single SVG..
+class WEffectMetaKnob : public WKnobComposed {
+    Q_OBJECT
+  public:
+    WEffectMetaKnob(QWidget* pParent, EffectsManager* pEffectsManager);
+
+    void setup(const QDomNode& node, const SkinContext& context) override;
+
+  private slots:
+    void effectChanged();
+
+  private:
+    EffectsManager* m_pEffectsManager;
+    EffectSlotPointer m_pEffectSlot;
+};

--- a/src/widget/weffectparameterbase.cpp
+++ b/src/widget/weffectparameterbase.cpp
@@ -30,7 +30,7 @@ void WEffectParameterBase::parameterUpdated() {
         } else {
             setText(m_pEffectParameterSlot->name());
         }
-        setBaseTooltip(QString("%1\n%2").arg(
+        setBaseTooltip(QStringLiteral("%1\n%2").arg(
                 m_pEffectParameterSlot->name(),
                 m_pEffectParameterSlot->description()));
     } else {

--- a/src/widget/weffectparameterknob.cpp
+++ b/src/widget/weffectparameterknob.cpp
@@ -25,7 +25,7 @@ void WEffectParameterKnob::setup(const QDomNode& node, const SkinContext& contex
 
 void WEffectParameterKnob::parameterUpdated() {
     if (m_pEffectParameterSlot->isLoaded()) {
-        setBaseTooltip(QString("%1\n%2").arg(
+        setBaseTooltip(QStringLiteral("%1\n%2").arg(
                 m_pEffectParameterSlot->name(),
                 m_pEffectParameterSlot->description()));
     } else {

--- a/src/widget/weffectparameterknobcomposed.cpp
+++ b/src/widget/weffectparameterknobcomposed.cpp
@@ -29,6 +29,7 @@ void WEffectParameterKnobComposed::parameterUpdated() {
         setBaseTooltip(QString("%1\n%2").arg(
                 m_pEffectParameterSlot->name(),
                 m_pEffectParameterSlot->description()));
+        setDefaultAngleFromParameterOrReset(m_pEffectParameterSlot->neutralPointOnScale());
     } else {
         // The knob should be hidden by the skin when the parameterX_loaded ControlObject
         // indicates no parameter is loaded, so this tooltip should never be shown.

--- a/src/widget/weffectparameterknobcomposed.cpp
+++ b/src/widget/weffectparameterknobcomposed.cpp
@@ -26,7 +26,7 @@ void WEffectParameterKnobComposed::setup(const QDomNode& node, const SkinContext
 
 void WEffectParameterKnobComposed::parameterUpdated() {
     if (m_pEffectParameterSlot->isLoaded()) {
-        setBaseTooltip(QString("%1\n%2").arg(
+        setBaseTooltip(QStringLiteral("%1\n%2").arg(
                 m_pEffectParameterSlot->name(),
                 m_pEffectParameterSlot->description()));
         setDefaultAngleFromParameterOrReset(m_pEffectParameterSlot->neutralPointOnScale());

--- a/src/widget/weffectparameternamebase.cpp
+++ b/src/widget/weffectparameternamebase.cpp
@@ -60,7 +60,7 @@ void WEffectParameterNameBase::parameterUpdated() {
         } else {
             m_text = m_pParameterSlot->name();
         }
-        setBaseTooltip(QString("%1\n%2").arg(
+        setBaseTooltip(QStringLiteral("%1\n%2").arg(
                 m_pParameterSlot->name(),
                 m_pParameterSlot->description()));
         EffectManifestParameterPointer pManifest = m_pParameterSlot->getManifest();

--- a/src/widget/weffectpushbutton.cpp
+++ b/src/widget/weffectpushbutton.cpp
@@ -102,7 +102,7 @@ void WEffectPushButton::parameterUpdated() {
 
     // Set tooltip
     if (m_pEffectParameterSlot->isLoaded()) {
-        setBaseTooltip(QString("%1\n%2").arg(
+        setBaseTooltip(QStringLiteral("%1\n%2").arg(
                 m_pEffectParameterSlot->name(),
                 m_pEffectParameterSlot->description()));
     } else {

--- a/src/widget/wknobcomposed.cpp
+++ b/src/widget/wknobcomposed.cpp
@@ -9,7 +9,7 @@
 
 WKnobComposed::WKnobComposed(QWidget* pParent)
         : WWidget(pParent),
-          m_defaultAngleIsValid(false),
+          m_defaultAngle(std::nullopt),
           m_dCurrentAngle(140.0),
           m_dMinAngle(-230.0),
           m_dMaxAngle(50.0),
@@ -114,12 +114,13 @@ void WKnobComposed::onConnectedControlChanged(double dParameter, double dValue) 
     }
 }
 
-void WKnobComposed::setDefaultAngleFromParameterOrReset(double parameter) {
-    if (parameter < 0 || parameter > 1) {
-        m_defaultAngleIsValid = false;
+void WKnobComposed::setDefaultAngleFromParameterOrReset(std::optional<double> parameter) {
+    // TODO(xxx) Use m_defaultAngle->value() as soon as
+    // AppleClang 10.13+ is used.
+    if (!parameter.has_value() || *parameter < 0 || *parameter > 1) {
+        m_defaultAngle = std::nullopt;
     } else {
-        m_defaultAngle = std::lerp(m_dMinAngle, m_dMaxAngle, parameter);
-        m_defaultAngleIsValid = true;
+        m_defaultAngle = std::lerp(m_dMinAngle, m_dMaxAngle, *parameter);
     }
 }
 
@@ -189,11 +190,13 @@ void WKnobComposed::drawArc(QPainter* pPainter) {
     arcPen.setCapStyle(m_arcPenCap);
 
     pPainter->setPen(arcPen);
-    if (m_defaultAngleIsValid) {
+    if (m_defaultAngle.has_value()) {
         // draw arc from default angle to current angle
         pPainter->drawArc(rect,
-                static_cast<int>((90 - m_defaultAngle) * 16),
-                static_cast<int>((m_dCurrentAngle - m_defaultAngle) * -16));
+                // TODO(xxx) Use m_defaultAngle->value() as soon as
+                // AppleClang 10.13+ is used.
+                static_cast<int>((90 - *m_defaultAngle) * 16),
+                static_cast<int>((m_dCurrentAngle - *m_defaultAngle) * -16));
     } else if (m_arcUnipolar) {
         if (m_arcReversed) {
            // draw arc from maxAngle to current position

--- a/src/widget/wknobcomposed.cpp
+++ b/src/widget/wknobcomposed.cpp
@@ -104,7 +104,7 @@ void WKnobComposed::setPixmapKnob(const PixmapSource& source,
 void WKnobComposed::onConnectedControlChanged(double dParameter, double dValue) {
     Q_UNUSED(dValue);
     // dParameter is in the range [0, 1].
-    double angle = m_dMinAngle + (m_dMaxAngle - m_dMinAngle) * dParameter;
+    double angle = std::lerp(m_dMinAngle, m_dMaxAngle, dParameter);
 
     // TODO(rryan): What's a good epsilon? Should it be dependent on the min/max
     // angle range? Right now it's just 1/100th of a degree.
@@ -152,7 +152,7 @@ void WKnobComposed::paintEvent(QPaintEvent* e) {
     if ((!m_pKnob.isNull() && !m_pKnob->isNull()) || m_dArcRadius > 0.1) {
         // We update m_dCurrentAngle since onConnectedControlChanged uses it for
         // no-op detection.
-        m_dCurrentAngle = m_dMinAngle + (m_dMaxAngle - m_dMinAngle) * getControlParameterDisplay();
+        m_dCurrentAngle = std::lerp(m_dMinAngle, m_dMaxAngle, getControlParameterDisplay());
     }
 
     if (m_dArcRadius > 0.1) {

--- a/src/widget/wknobcomposed.h
+++ b/src/widget/wknobcomposed.h
@@ -28,6 +28,10 @@ class WKnobComposed : public WWidget {
     void mouseReleaseEvent(QMouseEvent *e) override;
     void paintEvent(QPaintEvent* /*unused*/) override;
 
+    bool m_defaultAngleIsValid;
+    double m_defaultAngle;
+    void setDefaultAngleFromParameterOrReset(double parameter);
+
   private:
     void inputActivity();
     void clear();
@@ -41,10 +45,10 @@ class WKnobComposed : public WWidget {
             double scaleFactor);
     void drawArc(QPainter* pPainter);
 
-    double m_dCurrentAngle;
     PaintablePointer m_pKnob;
     PaintablePointer m_pPixmapBack;
     KnobEventHandler<WKnobComposed> m_handler;
+    double m_dCurrentAngle;
     double m_dMinAngle;
     double m_dMaxAngle;
     double m_dKnobCenterXOffset;

--- a/src/widget/wknobcomposed.h
+++ b/src/widget/wknobcomposed.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include "skin/legacy/skincontext.h"
 #include "widget/knobeventhandler.h"
 #include "widget/wpixmapstore.h"
@@ -28,9 +30,8 @@ class WKnobComposed : public WWidget {
     void mouseReleaseEvent(QMouseEvent *e) override;
     void paintEvent(QPaintEvent* /*unused*/) override;
 
-    bool m_defaultAngleIsValid;
-    double m_defaultAngle;
-    void setDefaultAngleFromParameterOrReset(double parameter);
+    std::optional<double> m_defaultAngle;
+    void setDefaultAngleFromParameterOrReset(std::optional<double> parameter);
 
   private:
     void inputActivity();

--- a/src/widget/wknobcomposed.h
+++ b/src/widget/wknobcomposed.h
@@ -28,6 +28,7 @@ class WKnobComposed : public WWidget {
     void mousePressEvent(QMouseEvent *e) override;
     void mouseDoubleClickEvent(QMouseEvent* e) override;
     void mouseReleaseEvent(QMouseEvent *e) override;
+    void resizeEvent(QResizeEvent* /*unused*/) override;
     void paintEvent(QPaintEvent* /*unused*/) override;
 
     std::optional<double> m_defaultAngle;
@@ -62,6 +63,7 @@ class WKnobComposed : public WWidget {
     bool m_arcUnipolar;
     bool m_arcReversed;
     Qt::PenCapStyle m_arcPenCap;
+    QRectF m_rect;
 
     friend class KnobEventHandler<WKnobComposed>;
 };


### PR DESCRIPTION
When an effect is loaded, the knob gets the default meta parameter from the effect manifest and draws the knob arc from there to current angle.

Closes #12634

Don't let this distract you from the 2.4 release, this can very well wait for 2.4.1 or later.

I added this widget only where arcs are or may be used, i.e. all skins except Shade.