### PR TITLE
MacOsVersion: Import Foundation instead of Cocoa

### DIFF
--- a/src/util/macosversion.mm
+++ b/src/util/macosversion.mm
@@ -1,6 +1,6 @@
 #include "util/macosversion.h"
 
-#import <Cocoa/Cocoa.h>
+#import <Foundation/Foundation.h>
 
 QString getMacOsVersion() {
     NSProcessInfo* processInfo = [NSProcessInfo processInfo];


### PR DESCRIPTION
Cocoa/AppKit is unavailable on iOS and since we only use Foundation APIs here anyway, we can just import it directly.