### PR TITLE
LegacyControllerMappingFileHandler: Add missing cond-compile for building without HID

### DIFF
--- a/src/controllers/legacycontrollermappingfilehandler.cpp
+++ b/src/controllers/legacycontrollermappingfilehandler.cpp
@@ -1,9 +1,12 @@
 #include "controllers/legacycontrollermappingfilehandler.h"
 
 #include "controllers/defs_controllers.h"
-#include "controllers/hid/legacyhidcontrollermappingfilehandler.h"
 #include "controllers/midi/legacymidicontrollermappingfilehandler.h"
 #include "util/xml.h"
+
+#ifdef __HID__
+#include "controllers/hid/legacyhidcontrollermappingfilehandler.h"
+#endif
 
 namespace {
 
@@ -50,7 +53,9 @@ std::shared_ptr<LegacyControllerMapping> LegacyControllerMappingFileHandler::loa
                        HID_MAPPING_EXTENSION, Qt::CaseInsensitive) ||
             mappingFile.fileName().endsWith(
                     BULK_MAPPING_EXTENSION, Qt::CaseInsensitive)) {
+#ifdef __HID__
         pHandler = new LegacyHidControllerMappingFileHandler();
+#endif
     }
 
     if (pHandler == nullptr) {


### PR DESCRIPTION
This is something I stumbled upon while building Mixxx without HID support. Everything in `controllers/hid` is only available when `-DHID=ON`, including `legacyhidcontrollermappingfilehandler.h`:

https://github.com/mixxxdj/mixxx/blob/59ca3a25b768c44ac0934ed4cb4504cac52bde54/CMakeLists.txt#L3354-L3408

LegacyControllerMappingFileHandler was missing a cond-compile around the HID handler, therefore this patch.