### PR TITLE
ScreenSaver: Check `Q_OS_MACOS` instead of `Q_OS_MAC`

### DIFF
--- a/src/util/screensaver.cpp
+++ b/src/util/screensaver.cpp
@@ -19,7 +19,7 @@ https://github.com/awjackson/bsnes-classic/blob/038e2e051ffc8abe7c56a3bf27e3016c
 
 #include <QDebug>
 
-#if defined(__APPLE__)
+#if defined(Q_OS_MACOS)
 #  include "util/mac.h"
 #elif defined(_WIN32)
 #  include <windows.h>
@@ -56,8 +56,7 @@ void ScreenSaverHelper::uninhibit()
     }
 }
 
-
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
 IOPMAssertionID ScreenSaverHelper::s_systemSleepAssertionID=0;
 IOPMAssertionID ScreenSaverHelper::s_userActivityAssertionID=0;
 
@@ -334,7 +333,6 @@ void ScreenSaverHelper::uninhibitInternal()
 {
     DEBUG_ASSERT(!"Screensaver suspending not implemented");
 }
-#endif // Q_OS_MAC
-
+#endif // Q_OS_MACOS
 
 } // namespace mixxx

--- a/src/util/screensaver.cpp
+++ b/src/util/screensaver.cpp
@@ -19,6 +19,8 @@ https://github.com/awjackson/bsnes-classic/blob/038e2e051ffc8abe7c56a3bf27e3016c
 
 #include <QDebug>
 
+#include "util/assert.h"
+
 #if defined(Q_OS_MACOS)
 #  include "util/mac.h"
 #elif defined(_WIN32)

--- a/src/util/screensaver.h
+++ b/src/util/screensaver.h
@@ -2,9 +2,9 @@
 
 #include <QtGlobal>
 
-#ifdef Q_OS_MAC
+#ifdef Q_OS_MACOS
 #include <IOKit/pwr_mgt/IOPMLib.h>
-#endif // Q_OS_MAC
+#endif // Q_OS_MACOS
 
 namespace mixxx {
 
@@ -25,14 +25,14 @@ private:
 
    static bool s_enabled;
    static bool s_sendActivity;
-#if defined(Q_OS_MAC)
-    /* sleep management */
-    static IOPMAssertionID s_systemSleepAssertionID;
-    static IOPMAssertionID s_userActivityAssertionID;
+#if defined(Q_OS_MACOS)
+   /* sleep management */
+   static IOPMAssertionID s_systemSleepAssertionID;
+   static IOPMAssertionID s_userActivityAssertionID;
 #elif defined(Q_OS_LINUX)
     static uint32_t s_cookie;
     static int s_saverindex;
-#endif // Q_OS_MAC
+#endif // Q_OS_MACOS
 };
 
 }


### PR DESCRIPTION
`Q_OS_MAC` is a deprecated synonym for `Q_OS_DARWIN`, referring to both macOS and iOS. Since screensavers aren't available on iOS, this replaces the cond-compile with `Q_OS_MACOS`.