### PR TITLE
Engine: Add feature for building with/without Rubberband

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -779,7 +779,6 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/effects/backends/builtin/distortioneffect.cpp
   src/effects/backends/builtin/parametriceqeffect.cpp
   src/effects/backends/builtin/phasereffect.cpp
-  src/effects/backends/builtin/pitchshifteffect.cpp
   src/effects/backends/builtin/reverbeffect.cpp
   src/effects/backends/builtin/threebandbiquadeqeffect.cpp
   src/effects/backends/builtin/tremoloeffect.cpp
@@ -808,7 +807,6 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/encoder/encoderwavesettings.cpp
   src/engine/bufferscalers/enginebufferscale.cpp
   src/engine/bufferscalers/enginebufferscalelinear.cpp
-  src/engine/bufferscalers/enginebufferscalerubberband.cpp
   src/engine/bufferscalers/enginebufferscalest.cpp
   src/engine/cachingreader/cachingreader.cpp
   src/engine/cachingreader/cachingreaderchunk.cpp
@@ -2909,8 +2907,16 @@ target_include_directories(mixxx-lib SYSTEM PRIVATE lib/reverb)
 target_link_libraries(mixxx-lib PRIVATE Reverb)
 
 # Rubberband
-find_package(rubberband REQUIRED)
-target_link_libraries(mixxx-lib PRIVATE rubberband::rubberband)
+option(RUBBERBAND "Enable the rubberband engine for pitch-bending" ON)
+if(RUBBERBAND)
+  find_package(rubberband REQUIRED)
+  target_link_libraries(mixxx-lib PRIVATE rubberband::rubberband)
+  target_compile_definitions(mixxx-lib PUBLIC __RUBBERBAND__)
+  target_sources(mixxx-lib PRIVATE
+    src/effects/backends/builtin/pitchshifteffect.cpp
+    src/engine/bufferscalers/enginebufferscalerubberband.cpp
+  )
+endif()
 
 # SndFile
 find_package(SndFile REQUIRED)

--- a/src/effects/backends/builtin/builtinbackend.cpp
+++ b/src/effects/backends/builtin/builtinbackend.cpp
@@ -22,7 +22,9 @@
 #include "effects/backends/builtin/loudnesscontoureffect.h"
 #include "effects/backends/builtin/metronomeeffect.h"
 #include "effects/backends/builtin/phasereffect.h"
+#ifdef __RUBBERBAND__
 #include "effects/backends/builtin/pitchshifteffect.h"
+#endif
 #include "effects/backends/builtin/tremoloeffect.h"
 #include "effects/backends/builtin/whitenoiseeffect.h"
 
@@ -54,7 +56,9 @@ BuiltInBackend::BuiltInBackend() {
     registerEffect<PhaserEffect>();
     registerEffect<MetronomeEffect>();
     registerEffect<TremoloEffect>();
+#ifdef __RUBBERBAND__
     registerEffect<PitchShiftEffect>();
+#endif
     registerEffect<DistortionEffect>();
 }
 

--- a/src/test/enginebuffertest.cpp
+++ b/src/test/enginebuffertest.cpp
@@ -119,6 +119,7 @@ TEST_F(EngineBufferTest, PitchRoundtrip) {
     ASSERT_NEAR(0.0, ControlObject::get(ConfigKey(m_sGroup1, "pitch")), 1e-10);
 }
 
+#ifdef __RUBBERBAND__
 TEST_F(EngineBufferTest, SlowRubberBand) {
     // At very slow speeds, RubberBand needs to reallocate buffers and since
     // this
@@ -152,6 +153,7 @@ TEST_F(EngineBufferTest, SlowRubberBand) {
     ProcessBuffer();
     EXPECT_EQ(m_pMockScaleVinyl1, m_pChannel1->getEngineBuffer()->m_pScale);
 }
+#endif
 
 TEST_F(EngineBufferTest, ScalerNoTransport) {
     // normally use the Vinyl scaler
@@ -338,6 +340,7 @@ TEST_F(EngineBufferE2ETest, DISABLED_SoundTouchToggleTest) {
             "SoundTouchTestRegular");
 }
 
+#ifdef __RUBBERBAND__
 // DISABLED: This test is too dependent on the rubber band library version.
 TEST_F(EngineBufferE2ETest, DISABLED_RubberbandToggleTest) {
    // Test various cases where Rubberband toggles on and off.
@@ -366,6 +369,7 @@ TEST_F(EngineBufferE2ETest, DISABLED_RubberbandToggleTest) {
             kProcessBufferSize,
             "RubberbandTestRegular");
 }
+#endif
 
 // DISABLED: This test is too dependent on the sound touch library version.
 // NOTE(uklotzde, 2018-01-10): We have also seen spurious failures on the
@@ -417,6 +421,7 @@ TEST_F(EngineBufferE2ETest, SoundTouchReverseTest) {
     // on the uses library version
 }
 
+#ifdef __RUBBERBAND__
 TEST_F(EngineBufferE2ETest, RubberbandReverseTest) {
     // This test must not crash when changing to reverse while pitch is tweaked
     // Testing issue #8061
@@ -430,6 +435,7 @@ TEST_F(EngineBufferE2ETest, RubberbandReverseTest) {
     // Note: we cannot compare a golden buffer here, because the result depends
     // on the uses library version
 }
+#endif
 
 TEST_F(EngineBufferE2ETest, CueGotoAndStopTest) {
     // Be sure, that the Crossfade buffer is processed only once

--- a/src/util/versionstore.cpp
+++ b/src/util/versionstore.cpp
@@ -16,11 +16,14 @@
 #undef WIN32
 #endif
 
+#ifdef __RUBBERBAND__
+#include <rubberband/RubberBandStretcher.h>
+#endif
+
 #include <FLAC/format.h>
 #include <chromaprint.h>
 #include <lame/lame.h>
 #include <portaudio.h>
-#include <rubberband/RubberBandStretcher.h>
 #include <sndfile.h>
 #include <soundtouch/SoundTouch.h>
 #include <taglib/taglib.h>
@@ -160,8 +163,10 @@ QStringList VersionStore::dependencyVersions() {
             << QString("PortAudio: %1 %2")
                        .arg(Pa_GetVersion())
                        .arg(Pa_GetVersionText())
+#ifdef __RUBBERBAND__
             // The version of the RubberBand headers Mixxx was compiled with.
             << QString("RubberBand: %1").arg(RUBBERBAND_VERSION)
+#endif
             // The version of the SoundTouch headers Mixxx was compiled with.
             << QString("SoundTouch: %1").arg(SOUNDTOUCH_VERSION)
             // The version of the TagLib headers Mixxx was compiled with.


### PR DESCRIPTION
This makes it possible to build Mixxx without Rubberband, using SoundTouch as the default keylock engine instead. This has proven pretty useful in building Mixxx for iOS, both for technical reasons (cross-compiling the library seems to be non-trivial) and potential licensing reasons (non-App-Store-clause-GPL).