### PR TITLE
macOS: Add more `Q_OS_MACOS` cond-compiles where appropriate

### DIFF
--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -3,6 +3,7 @@
 #include <QApplication>
 #include <QFileDialog>
 #include <QStandardPaths>
+#include <QtGlobal>
 
 #ifdef __BROADCAST__
 #include "broadcast/broadcastmanager.h"
@@ -178,7 +179,7 @@ CoreServices::~CoreServices() {
 }
 
 void CoreServices::initializeSettings() {
-#ifdef __APPLE__
+#ifdef Q_OS_MACOS
     // TODO: At this point it is too late to provide the same settings path to all components
     // and too early to log errors and give users advises in their system language.
     // Calling this from main.cpp before the QApplication is initialized may cause a crash

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 #include <QTextCodec>
 #include <QThread>
 #include <QtDebug>
+#include <QtGlobal>
 #include <cstdio>
 #include <stdexcept>
 
@@ -209,7 +210,7 @@ int main(int argc, char * argv[]) {
 
     MixxxApplication app(argc, argv);
 
-#ifdef __APPLE__
+#ifdef Q_OS_MACOS
     // TODO: At this point it is too late to provide the same settings path to all components
     // and too early to log errors and give users advises in their system language.
     // Calling this from main.cpp before the QApplication is initialized may cause a crash

--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -3,6 +3,7 @@
 #include <QThreadPool>
 #include <QTouchEvent>
 #include <QtDebug>
+#include <QtGlobal>
 
 #include "audio/frame.h"
 #include "audio/types.h"

--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -7,6 +7,7 @@
 #include <QResizeEvent>
 #include <QScreen>
 #include <QScrollArea>
+#include <QtGlobal>
 
 #include "controllers/dlgprefcontrollers.h"
 #include "library/library.h"
@@ -44,7 +45,7 @@
 #include "preferences/dialog/dlgprefmodplug.h"
 #endif // __MODPLUG__
 
-#ifdef __APPLE__
+#ifdef Q_OS_MACOS
 #include "util/darkappearance.h"
 #endif
 
@@ -576,7 +577,7 @@ QRect DlgPreferences::getDefaultGeometry() {
 }
 
 void DlgPreferences::fixSliderStyle() {
-#ifdef __APPLE__
+#ifdef Q_OS_MACOS
     // Only used on macOS where the default slider style has several issues:
     // - the handle is semi-transparent
     // - the slider is higher than the space we give it, which causes that:

--- a/src/util/sandbox.h
+++ b/src/util/sandbox.h
@@ -5,6 +5,7 @@
 #include <QFileInfo>
 #include <QHash>
 #include <QSharedPointer>
+#include <QtGlobal>
 
 #include "preferences/configobject.h"
 #include "util/compatibility/qmutex.h"
@@ -33,7 +34,7 @@ class Sandbox {
     static void setPermissionsFilePath(const QString& permissionsFile);
     static void shutdown();
 
-#ifdef __APPLE__
+#ifdef Q_OS_MACOS
     static QString migrateOldSettings();
 #endif
 

--- a/src/util/screensaver.cpp
+++ b/src/util/screensaver.cpp
@@ -18,6 +18,7 @@ https://github.com/awjackson/bsnes-classic/blob/038e2e051ffc8abe7c56a3bf27e3016c
 #include "util/screensaver.h"
 
 #include <QDebug>
+#include <QtGlobal>
 
 #include "util/assert.h"
 


### PR DESCRIPTION
In preparation of iOS support, this turns a bunch of `__APPLE__` cond-compiles into `Q_OS_MACOS`, since e.g. dark title bars or the migration from `~/Library/Application Support/...` to `~/Library/Containers/...` only affects macOS.