### PR TITLE
GLWaveformRenderer: Move OpenGL 2.1 include into cond-compile

### DIFF
--- a/src/waveform/renderers/glwaveformrenderer.h
+++ b/src/waveform/renderers/glwaveformrenderer.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <QOpenGLFunctions_2_1>
-
 #if !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
+
+#include <QOpenGLFunctions_2_1>
 
 class GLWaveformRenderer : protected QOpenGLFunctions_2_1 {
   public:


### PR DESCRIPTION
A minor fix that surfaced while compiling for iOS.