### PR TITLE
CMakeLists: Support building for iOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,22 +158,31 @@ if(APPLE)
     message(FATAL_ERROR "'xcode-select -v' failed with '${XCODE_SELECT_RESULT}'. You may need to install Xcode and run 'sudo xcode-select --install'.")
   endif()
 
-  if(VCPKG_TARGET_TRIPLET MATCHES "^arm64-osx")
-    # Minimum macOS version for arm64 Support
-    set(CMAKE_OSX_DEPLOYMENT_TARGET 11.0 CACHE STRING "Minimum macOS version the build will be able to run on")
-    set(CMAKE_OSX_ARCHITECTURES arm64 CACHE STRING "The target architecture")
-    set(CMAKE_SYSTEM_PROCESSOR arm64 CACHE STRING "The target system processor")
-    set(CMAKE_SYSTEM_NAME Darwin CACHE STRING "Setting this enables CMAKE_CROSSCOMPILE")
-  else()
-    if(QT6)
-      # Minimum macOS version supported by Qt 6
-      set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15 CACHE STRING "Minimum macOS version the build will be able to run on")
+  if(VCPKG_TARGET_TRIPLET MATCHES "^[a-zA-Z0-9]+-osx")
+    message(STATUS "Targeting macOS (${VCPKG_TARGET_TRIPLET})")
+    set(CMAKE_SYSTEM_NAME Darwin CACHE STRING "Target macOS")
+    if(VCPKG_TARGET_TRIPLET MATCHES "^arm64-")
+      # Minimum macOS version for arm64 Support
+      set(CMAKE_OSX_DEPLOYMENT_TARGET 11.0 CACHE STRING "Minimum macOS version the build will be able to run on")
+      set(CMAKE_OSX_ARCHITECTURES arm64 CACHE STRING "The target architecture")
+      set(CMAKE_SYSTEM_PROCESSOR arm64 CACHE STRING "The target system processor")
     else()
-      # Minimum macOS version supported by Qt 5.12
-      set(CMAKE_OSX_DEPLOYMENT_TARGET 10.12 CACHE STRING "Minimum macOS version the build will be able to run on")
-      # Needed for deployment target < 10.14
-      add_compile_options(-fno-aligned-allocation)
+      if(QT6)
+        # Minimum macOS version supported by Qt 6
+        set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15 CACHE STRING "Minimum macOS version the build will be able to run on")
+      else()
+        # Minimum macOS version supported by Qt 5.12
+        set(CMAKE_OSX_DEPLOYMENT_TARGET 10.12 CACHE STRING "Minimum macOS version the build will be able to run on")
+        # Needed for deployment target < 10.14
+        add_compile_options(-fno-aligned-allocation)
+      endif()
     endif()
+  elseif(VCPKG_TARGET_TRIPLET MATCHES "^[a-zA-Z0-9]+-ios")
+    message(STATUS "Targeting iOS (${VCPKG_TARGET_TRIPLET})")
+    set(CMAKE_SYSTEM_NAME iOS CACHE STRING "Target iOS")
+    set(CMAKE_OSX_DEPLOYMENT_TARGET 14.0 CACHE STRING "Minimum iOS version to target")
+  else()
+    message(WARNING "Targeting an Apple platform, but VCPKG_TARGET_TRIPLET is not set. This is not a supported scenario!")
   endif()
 endif()
 
@@ -1531,22 +1540,25 @@ if(APPLE)
 
   target_sources(mixxx-lib PRIVATE
     src/util/appleosversion.mm
-    src/util/darkappearance.mm
   )
 
   if(IOS)
     target_sources(mixxx-lib PRIVATE
       src/util/screensaverios.mm
     )
-  endif()
-
-  option(MACOS_ITUNES_LIBRARY "Native macOS iTunes/Music.app library integration" ON)
-  if(MACOS_ITUNES_LIBRARY)
+  else()
     target_sources(mixxx-lib PRIVATE
-      src/library/itunes/itunesmacosimporter.mm
+      src/util/darkappearance.mm
     )
-    target_link_libraries(mixxx-lib PRIVATE "-weak_framework iTunesLibrary")
-    target_compile_definitions(mixxx-lib PUBLIC __MACOS_ITUNES_LIBRARY__)
+
+    option(MACOS_ITUNES_LIBRARY "Native macOS iTunes/Music.app library integration" ON)
+    if(MACOS_ITUNES_LIBRARY)
+      target_sources(mixxx-lib PRIVATE
+        src/library/itunes/itunesmacosimporter.mm
+      )
+      target_link_libraries(mixxx-lib PRIVATE "-weak_framework iTunesLibrary")
+      target_compile_definitions(mixxx-lib PUBLIC __MACOS_ITUNES_LIBRARY__)
+    endif()
   endif()
 endif()
 
@@ -1659,12 +1671,16 @@ set(MIXXX_INSTALL_DOCDIR "./doc")
 set(MIXXX_INSTALL_LICENSEDIR "./doc")
 if (APPLE AND MACOS_BUNDLE)
   set(MIXXX_INSTALL_BINDIR "${CMAKE_INSTALL_BINDIR}")
-  set(MACOS_BUNDLE_NAME Mixxx)
-  set(MACOS_BUNDLE_IDENTIFIER org.mixxx.mixxx)
+  set(MACOS_BUNDLE_NAME Mixxx CACHE STRING "The macOS app bundle and executable name")
+  set(MACOS_BUNDLE_IDENTIFIER org.mixxx.mixxx CACHE STRING "The macOS app bundle identifier")
   set(MIXXX_INSTALL_PREFIX "${MACOS_BUNDLE_NAME}.app")
   set(MIXXX_INSTALL_DATADIR "${MIXXX_INSTALL_PREFIX}/Contents/Resources")
   set(MIXXX_INSTALL_DOCDIR "${MIXXX_INSTALL_DATADIR}")
   set(MIXXX_INSTALL_LICENSEDIR "${MIXXX_INSTALL_DATADIR}/licenses")
+elseif (APPLE AND IOS)
+  set(MIXXX_INSTALL_BINDIR "${CMAKE_INSTALL_BINDIR}")
+  set(IOS_BUNDLE_NAME Mixxx CACHE STRING "The iOS app bundle and executable name")
+  set(IOS_BUNDLE_IDENTIFIER org.mixxx.mixxx CACHE STRING "The iOS app bundle identifier")
 elseif (UNIX)
   set(MIXXX_INSTALL_BINDIR "${CMAKE_INSTALL_BINDIR}")
   set(MIXXX_INSTALL_DATADIR "${CMAKE_INSTALL_DATADIR}/${CMAKE_PROJECT_NAME}")
@@ -1736,7 +1752,29 @@ target_link_libraries(mixxx PRIVATE mixxx-lib mixxx-gitinfostore)
 # Installation and Packaging
 #
 if (APPLE)
-  if (MACOS_BUNDLE)
+  if (IOS)
+    set(IOS_BUNDLE_VERSION "${CMAKE_PROJECT_VERSION}")
+    set(IOS_BUNDLE_SHORTVERSION "${CMAKE_PROJECT_VERSION}")
+
+    # https://stackoverflow.com/questions/54830302/how-to-add-the-copy-bundle-resources-phase-with-cmake-in-xcode
+    # https://discourse.cmake.org/t/ios-resource-management/758/7
+    file(GLOB IOS_RESOURCES res/**)
+    list(APPEND IOS_RESOURCES packaging/ios/Assets.xcassets)
+    target_sources(mixxx PUBLIC ${IOS_RESOURCES})
+    set_source_files_properties(${IOS_RESOURCES} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
+    source_group(Resources FILES ${IOS_RESOURCES})
+
+    set(QT_IOS_LAUNCH_SCREEN "${CMAKE_CURRENT_SOURCE_DIR}/packaging/ios/LaunchScreen.storyboard")
+
+    set_target_properties(mixxx PROPERTIES
+      MACOSX_BUNDLE true
+      OUTPUT_NAME "${IOS_BUNDLE_NAME}"
+      MACOSX_BUNDLE_BUNDLE_NAME "${IOS_BUNDLE_NAME}"
+      MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/packaging/ios/Info.plist.in"
+      MACOSX_BUNDLE_GUI_IDENTIFIER "${IOS_BUNDLE_IDENTIFIER}"
+      XCODE_ATTRIBUTE_ASSETCATALOG_COMPILER_APPICON_NAME "AppIcon"
+    )
+  elseif (MACOS_BUNDLE)
     install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/res/osx/application.icns" DESTINATION ${MIXXX_INSTALL_DATADIR})
 
     set(MACOS_BUNDLE_VERSION "${CMAKE_PROJECT_VERSION}")
@@ -2506,9 +2544,14 @@ target_include_directories(MP3GuessEnc SYSTEM PUBLIC lib/mp3guessenc-0.27.4)
 target_link_libraries(mixxx-lib PRIVATE MP3GuessEnc)
 
 # OpenGL
-set(OpenGL_GL_PREFERENCE "GLVND")
-find_package(OpenGL REQUIRED)
-target_link_libraries(mixxx-lib PRIVATE OpenGL::GL)
+if(IOS)
+  target_link_libraries(mixxx-lib PRIVATE "-framework OpenGLES")
+  target_compile_definitions(mixxx-lib PUBLIC QT_OPENGL_ES_2)
+else()
+  set(OpenGL_GL_PREFERENCE "GLVND")
+  find_package(OpenGL REQUIRED)
+  target_link_libraries(mixxx-lib PRIVATE OpenGL::GL)
+endif()
 
 # Ogg
 find_package(Ogg REQUIRED)
@@ -2710,10 +2753,16 @@ if(Qt_IS_STATIC)
   endif()
 
   if(APPLE)
-    target_link_libraries(mixxx-lib PRIVATE
-      Qt${QT_VERSION_MAJOR}::QCocoaIntegrationPlugin
-      Qt${QT_VERSION_MAJOR}::QMacStylePlugin
-    )
+    if(IOS)
+      target_link_libraries(mixxx-lib PRIVATE
+        Qt${QT_VERSION_MAJOR}::QIOSIntegrationPlugin
+      )
+    else()
+      target_link_libraries(mixxx-lib PRIVATE
+        Qt${QT_VERSION_MAJOR}::QCocoaIntegrationPlugin
+        Qt${QT_VERSION_MAJOR}::QMacStylePlugin
+      )
+    endif()
   endif()
 else()
   if(QT6 AND (WIN32 OR APPLE))
@@ -2773,9 +2822,7 @@ if(APPLE)
   if(Qt_IS_STATIC OR QT6)
     target_link_libraries(mixxx-lib PRIVATE
         "-weak_framework Accelerate"
-        "-weak_framework AppKit"
         "-weak_framework AudioToolbox"
-        "-weak_framework AudioUnit"
         "-weak_framework AVFoundation"
         "-weak_framework CoreAudio"
         "-weak_framework CoreFoundation"
@@ -2787,6 +2834,16 @@ if(APPLE)
         "-weak_framework IOSurface"
         "-weak_framework VideoToolbox"
     )
+    if(IOS)
+      target_link_libraries(mixxx-lib PRIVATE
+        "-weak_framework UIKit"
+      )
+    elseif()
+      target_link_libraries(mixxx-lib PRIVATE
+        "-weak_framework AppKit"
+        "-weak_framework AudioUnit"
+      )
+    endif()
   else()
     # Used for battery measurements and controlling the screensaver on macOS.
     target_link_libraries(mixxx-lib PRIVATE
@@ -3008,7 +3065,11 @@ if(BATTERY)
   if(WIN32)
     target_sources(mixxx-lib PRIVATE src/util/battery/batterywindows.cpp)
   elseif(APPLE)
-    target_sources(mixxx-lib PRIVATE src/util/battery/batterymac.cpp)
+    if(IOS)
+      message(FATAL_ERROR "Battery support is not implemented for iOS")
+    else()
+      target_sources(mixxx-lib PRIVATE src/util/battery/batterymac.cpp)
+    endif()
   elseif(UNIX)
     find_package(Upower REQUIRED)
     find_package(GLIB COMPONENTS gobject REQUIRED)
@@ -3223,7 +3284,7 @@ if(LILV)
 endif()
 
 # Live Broadcasting (Shoutcast)
-option(BROADCAST "Live Broadcasting (Shoutcast) support" ON)
+cmake_dependent_option(BROADCAST "Live Broadcasting (Shoutcast) support" ON "NOT IOS" OFF)
 if(BROADCAST)
   find_package(Shoutidjc)
   # Check if system lib is at least 2.4.6 and not suffering bugs
@@ -3377,6 +3438,9 @@ if(HID)
         find_library(Setupapi_LIBRARY Setupapi REQUIRED)
         target_link_libraries(mixxx-hidapi PUBLIC ${Setupapi_LIBRARY})
     elseif(APPLE)
+        if(IOS)
+          message(FATAL_ERROR "USB HID controllers are not supported on iOS")
+        endif()
         target_sources(mixxx-hidapi PRIVATE lib/hidapi/mac/hid.c)
         find_library(AppKit_LIBRARY AppKit REQUIRED)
         target_link_libraries(mixxx-hidapi PUBLIC ${AppKit_LIBRARY})


### PR DESCRIPTION
This PR implements the necessary changes to instruct CMake to build for iOS. This mainly boils down to:

- Setting `CMAKE_SYSTEM_NAME` to iOS
- Scoping macOS-specific stuff under a `NOT IOS` condition
- Linking iOS-specific frameworks (UIKit, OpenGLES)
- Linking the iOS Qt integration plugin
- Packaging (sold separately in #12676)

The rationale for targeting 2.4 is that, even if we don't build 2.4 for iOS, we avoid painful merge conflicts in the future by already having the relevant conditionals in place.