### PR TITLE
DesktopHelper: Cond-compile out process creation on iOS

### DIFF
--- a/src/util/desktophelper.cpp
+++ b/src/util/desktophelper.cpp
@@ -90,12 +90,16 @@ bool selectInXfce(const QString& path) {
 #endif
 
 void selectViaCommand(const QString& path) {
+#ifdef Q_OS_IOS
+    qWarning() << "Starting process (" << path << ") is not supported on iOS!";
+#else
     QStringList arguments = sSelectInFileBrowserCommand.split(" ");
     // No escaping required because QProcess bypasses the shell
     arguments.append(QDir::toNativeSeparators(path));
     QString program = arguments.takeFirst();
     qDebug() << "Calling:" << program << arguments;
     QProcess::startDetached(program, arguments);
+#endif
 }
 
 } // anonymous namespace


### PR DESCRIPTION
Forking is not supported on iOS, so we'll emit a warning instead.