### PR TITLE
Device pixel non GL waveforms

### DIFF
--- a/src/waveform/renderers/waveformrenderbeat.cpp
+++ b/src/waveform/renderers/waveformrenderbeat.cpp
@@ -52,6 +52,8 @@ void WaveformRenderBeat::draw(QPainter* painter, QPaintEvent* /*event*/) {
         return;
     }
 
+    const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
+
     const double firstDisplayedPosition =
             m_waveformRenderer->getFirstDisplayedPosition();
     const double lastDisplayedPosition =
@@ -91,7 +93,7 @@ void WaveformRenderBeat::draw(QPainter* painter, QPaintEvent* /*event*/) {
         double xBeatPoint =
                 m_waveformRenderer->transformSamplePositionInRendererWorld(beatPosition);
 
-        xBeatPoint = qRound(xBeatPoint);
+        xBeatPoint = qRound(xBeatPoint * devicePixelRatio) / devicePixelRatio;
 
         // If we don't have enough space, double the size.
         if (beatCount >= m_beats.size()) {

--- a/src/waveform/renderers/waveformrendererfilteredsignal.cpp
+++ b/src/waveform/renderers/waveformrendererfilteredsignal.cpp
@@ -15,9 +15,12 @@ WaveformRendererFilteredSignal::~WaveformRendererFilteredSignal() {
 }
 
 void WaveformRendererFilteredSignal::onResize() {
-    m_lowLines.resize(m_waveformRenderer->getLength());
-    m_midLines.resize(m_waveformRenderer->getLength());
-    m_highLines.resize(m_waveformRenderer->getLength());
+    const int devicePixelLength =
+            static_cast<int>(m_waveformRenderer->getLength() *
+                    m_waveformRenderer->getDevicePixelRatio());
+    m_lowLines.resize(devicePixelLength);
+    m_midLines.resize(devicePixelLength);
+    m_highLines.resize(devicePixelLength);
 }
 
 void WaveformRendererFilteredSignal::onSetup(const QDomNode& node) {
@@ -35,6 +38,8 @@ void WaveformRendererFilteredSignal::draw(QPainter* painter,
     if (audioVisualRatio <= 0) {
         return;
     }
+
+    const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
 
     const int dataSize = pWaveform->getDataSize();
     if (dataSize <= 1) {
@@ -59,8 +64,11 @@ void WaveformRendererFilteredSignal::draw(QPainter* painter,
     painter->resetTransform();
 
     // Rotate if drawing vertical waveforms
+    // and revert devicePixelRatio scaling in x direction.
     if (m_waveformRenderer->getOrientation() == Qt::Vertical) {
-        painter->setTransform(QTransform(0, 1, 1, 0, 0, 0));
+        painter->setTransform(QTransform(0, 1 / devicePixelRatio, 1, 0, 0, 0));
+    } else {
+        painter->setTransform(QTransform(1 / devicePixelRatio, 0, 0, 1, 0, 0));
     }
 
     const double firstVisualIndex =
@@ -70,9 +78,10 @@ void WaveformRendererFilteredSignal::draw(QPainter* painter,
             m_waveformRenderer->getLastDisplayedPosition() * trackSamples /
             audioVisualRatio;
 
+    const float length = m_waveformRenderer->getLength() * devicePixelRatio;
+
     // Represents the # of waveform data points per horizontal pixel.
-    const double gain = (lastVisualIndex - firstVisualIndex) /
-            (double)m_waveformRenderer->getLength();
+    const double gain = (lastVisualIndex - firstVisualIndex) / length;
 
     // Per-band gain from the EQ knobs.
     float allGain(1.0), lowGain(1.0), midGain(1.0), highGain(1.0);
@@ -88,14 +97,14 @@ void WaveformRendererFilteredSignal::draw(QPainter* painter,
     //draw reference line
     if (m_alignment == Qt::AlignCenter) {
         painter->setPen(m_pColors->getAxesColor());
-        painter->drawLine(QLineF(0, halfBreadth, m_waveformRenderer->getLength(), halfBreadth));
+        painter->drawLine(QLineF(0, halfBreadth, length, halfBreadth));
     }
 
     int actualLowLineNumber = 0;
     int actualMidLineNumber = 0;
     int actualHighLineNumber = 0;
 
-    for (int x = 0; x < m_waveformRenderer->getLength(); ++x) {
+    for (int x = 0; x < static_cast<int>(length); ++x) {
         // Width of the x position in visual indices.
         const double xSampleWidth = gain * x;
 
@@ -132,7 +141,7 @@ void WaveformRendererFilteredSignal::draw(QPainter* painter,
         int visualIndexStart = visualFrameStart * 2;
         int visualIndexStop = visualFrameStop * 2;
 
-        // if (x == m_waveformRenderer->getLength() / 2) {
+        // if (x == static_cast<int>(length) / 2) {
         //     qDebug() << "audioVisualRatio" << waveform->getAudioVisualRatio();
         //     qDebug() << "visualSampleRate" << waveform->getVisualSampleRate();
         //     qDebug() << "audioSamplesPerVisualPixel" << waveform->getAudioSamplesPerVisualSample();

--- a/src/waveform/renderers/waveformrendererhsv.cpp
+++ b/src/waveform/renderers/waveformrendererhsv.cpp
@@ -32,6 +32,8 @@ void WaveformRendererHSV::draw(
         return;
     }
 
+    const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
+
     const int dataSize = pWaveform->getDataSize();
     if (dataSize <= 1) {
         return;
@@ -55,8 +57,11 @@ void WaveformRendererHSV::draw(
     painter->resetTransform();
 
     // Rotate if drawing vertical waveforms
+    // and revert devicePixelRatio scaling in x direction.
     if (m_waveformRenderer->getOrientation() == Qt::Vertical) {
-        painter->setTransform(QTransform(0, 1, 1, 0, 0, 0));
+        painter->setTransform(QTransform(0, 1 / devicePixelRatio, 1, 0, 0, 0));
+    } else {
+        painter->setTransform(QTransform(1 / devicePixelRatio, 0, 0, 1, 0, 0));
     }
 
     const double firstVisualIndex =
@@ -67,10 +72,10 @@ void WaveformRendererHSV::draw(
             audioVisualRatio;
 
     const double offset = firstVisualIndex;
+    const float length = m_waveformRenderer->getLength() * devicePixelRatio;
 
     // Represents the # of waveform data points per horizontal pixel.
-    const double gain = (lastVisualIndex - firstVisualIndex) /
-            (double)m_waveformRenderer->getLength();
+    const double gain = (lastVisualIndex - firstVisualIndex) / length;
 
     float allGain(1.0);
     getGains(&allGain, false, nullptr, nullptr, nullptr);
@@ -93,9 +98,9 @@ void WaveformRendererHSV::draw(
 
     //draw reference line
     painter->setPen(m_pColors->getAxesColor());
-    painter->drawLine(QLineF(0, halfBreadth, m_waveformRenderer->getLength(), halfBreadth));
+    painter->drawLine(QLineF(0, halfBreadth, length, halfBreadth));
 
-    for (int x = 0; x < m_waveformRenderer->getLength(); ++x) {
+    for (int x = 0; x < static_cast<int>(length); ++x) {
         // Width of the x position in visual indices.
         const double xSampleWidth = gain * x;
 
@@ -132,7 +137,8 @@ void WaveformRendererHSV::draw(
         int maxAll[2] = {0, 0};
 
         for (int i = visualIndexStart;
-             i >= 0 && i + 1 < dataSize && i + 1 <= visualIndexStop; i += 2) {
+                i >= 0 && i + 1 < dataSize && i + 1 <= visualIndexStop;
+                i += 2) {
             const WaveformData& waveformData = *(data + i);
             const WaveformData& waveformDataNext = *(data + i + 1);
             maxLow[0] = math_max(maxLow[0], (int)waveformData.filtered.low);
@@ -153,8 +159,7 @@ void WaveformRendererHSV::draw(
                     1.2f;
 
             // prevent division by zero
-            if (total > 0)
-            {
+            if (total > 0) {
                 // Normalize low and high (mid not need, because it not change the color)
                 lo = (maxLow[0] + maxLow[1]) / total;
                 hi = (maxHigh[0] + maxHigh[1]) / total;

--- a/src/waveform/renderers/waveformrendererrgb.cpp
+++ b/src/waveform/renderers/waveformrendererrgb.cpp
@@ -29,6 +29,8 @@ void WaveformRendererRGB::draw(
         return;
     }
 
+    const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
+
     const int dataSize = pWaveform->getDataSize();
     if (dataSize <= 1) {
         return;
@@ -52,8 +54,11 @@ void WaveformRendererRGB::draw(
     painter->resetTransform();
 
     // Rotate if drawing vertical waveforms
+    // and revert devicePixelRatio scaling in x direction.
     if (m_waveformRenderer->getOrientation() == Qt::Vertical) {
-        painter->setTransform(QTransform(0, 1, 1, 0, 0, 0));
+        painter->setTransform(QTransform(0, 1 / devicePixelRatio, 1, 0, 0, 0));
+    } else {
+        painter->setTransform(QTransform(1 / devicePixelRatio, 0, 0, 1, 0, 0));
     }
 
     const double firstVisualIndex =
@@ -65,9 +70,10 @@ void WaveformRendererRGB::draw(
 
     const double offset = firstVisualIndex;
 
+    const float length = m_waveformRenderer->getLength() * devicePixelRatio;
+
     // Represents the # of waveform data points per horizontal pixel.
-    const double gain = (lastVisualIndex - firstVisualIndex) /
-            (double)m_waveformRenderer->getLength();
+    const double gain = (lastVisualIndex - firstVisualIndex) / length;
 
     // Per-band gain from the EQ knobs.
     float allGain(1.0), lowGain(1.0), midGain(1.0), highGain(1.0);
@@ -88,7 +94,7 @@ void WaveformRendererRGB::draw(
     painter->setPen(m_pColors->getAxesColor());
     painter->drawLine(QLineF(0, halfBreadth, m_waveformRenderer->getLength(), halfBreadth));
 
-    for (int x = 0; x < m_waveformRenderer->getLength(); ++x) {
+    for (int x = 0; x < static_cast<int>(length); ++x) {
         // Width of the x position in visual indices.
         const double xSampleWidth = gain * x;
 


### PR DESCRIPTION
This daws the waveforms directly in device resolution instead of paint them fist and then upscale them. 

Before:
![grafik](https://github.com/mixxxdj/mixxx/assets/1777442/115d37fc-32aa-47bd-8db3-111b83e7871a)

After: 
![grafik](https://github.com/mixxxdj/mixxx/assets/1777442/2db3ebb4-21b3-4dcf-a045-dde1b0fde535)

