### PR TITLE
ConfigObject: Find resource path on iOS

### DIFF
--- a/src/preferences/configobject.cpp
+++ b/src/preferences/configobject.cpp
@@ -63,6 +63,11 @@ QString computeResourcePathImpl() {
         else {
             qResourcePath = QCoreApplication::applicationDirPath();
         }
+#elif defined(Q_OS_IOS)
+        // On iOS the bundle contains the resources directly.
+        else {
+            qResourcePath = QCoreApplication::applicationDirPath();
+        }
 #elif defined(__APPLE__)
         else if (mixxxDir.cd("../Resources")) {
             // Release configuration

--- a/src/preferences/configobject.cpp
+++ b/src/preferences/configobject.cpp
@@ -68,7 +68,7 @@ QString computeResourcePathImpl() {
         else {
             qResourcePath = QCoreApplication::applicationDirPath();
         }
-#elif defined(__APPLE__)
+#elif defined(Q_OS_MACOS)
         else if (mixxxDir.cd("../Resources")) {
             // Release configuration
             qResourcePath = mixxxDir.absolutePath();


### PR DESCRIPTION
This updates the `qResourcePath` logic to handle iOS app bundles (which use a flat directory layout with resources at the top level, see [the Apple docs](https://developer.apple.com/go/?id=bundle-structure)).