### PR TITLE
iTunes: Add iOS importer using the Media Player framework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -946,6 +946,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/library/itunes/itunesfeature.cpp
   src/library/itunes/itunesimporter.cpp
   src/library/itunes/itunesplaylistmodel.cpp
+  src/library/itunes/itunestrackmodel.cpp
   src/library/itunes/itunesxmlimporter.cpp
   src/library/library_prefs.cpp
   src/library/library.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1575,6 +1575,15 @@ if(APPLE)
       src/soundio/soundmanagerios.mm
       src/util/screensaverios.mm
     )
+
+    option(IOS_ITUNES_LIBRARY "Native iOS music library integration" ON)
+    if(IOS_ITUNES_LIBRARY)
+      target_sources(mixxx-lib PRIVATE
+        src/library/itunes/itunesiosimporter.mm
+      )
+      target_link_libraries(mixxx-lib PRIVATE "-weak_framework MediaPlayer")
+      target_compile_definitions(mixxx-lib PUBLIC __IOS_ITUNES_LIBRARY__)
+    endif()
   else()
     target_sources(mixxx-lib PRIVATE
       src/util/darkappearance.mm

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1580,6 +1580,7 @@ if(APPLE)
     option(IOS_ITUNES_LIBRARY "Native iOS music library integration" ON)
     if(IOS_ITUNES_LIBRARY)
       target_sources(mixxx-lib PRIVATE
+        src/library/itunes/itunesiosassetexporter.mm
         src/library/itunes/itunesiosimporter.mm
       )
       target_link_libraries(mixxx-lib PRIVATE "-weak_framework MediaPlayer")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1582,6 +1582,7 @@ if(APPLE)
       target_sources(mixxx-lib PRIVATE
         src/library/itunes/itunesiosassetexporter.mm
         src/library/itunes/itunesiosimporter.mm
+        src/library/itunes/itunesiostrackresolver.cpp
       )
       target_link_libraries(mixxx-lib PRIVATE "-weak_framework MediaPlayer")
       target_compile_definitions(mixxx-lib PUBLIC __IOS_ITUNES_LIBRARY__)

--- a/src/library/baseexternalplaylistmodel.cpp
+++ b/src/library/baseexternalplaylistmodel.cpp
@@ -32,8 +32,7 @@ BaseExternalPlaylistModel::~BaseExternalPlaylistModel() {
 }
 
 TrackPointer BaseExternalPlaylistModel::getTrack(const QModelIndex& index) const {
-    QString nativeLocation = index.sibling(index.row(), fieldIndex("location")).data().toString();
-    QString location = QDir::fromNativeSeparators(nativeLocation);
+    QString location = getTrackLocation(index);
 
     if (location.isEmpty()) {
         // Track is lost
@@ -69,6 +68,15 @@ TrackPointer BaseExternalPlaylistModel::getTrack(const QModelIndex& index) const
         pTrack->trySetBpm(bpm);
     }
     return pTrack;
+}
+
+QString BaseExternalPlaylistModel::resolveLocation(const QString& nativeLocation) const {
+    return QDir::fromNativeSeparators(nativeLocation);
+}
+
+QString BaseExternalPlaylistModel::getTrackLocation(const QModelIndex& index) const {
+    QString nativeLocation = index.sibling(index.row(), fieldIndex("location")).data().toString();
+    return resolveLocation(nativeLocation);
 }
 
 TrackId BaseExternalPlaylistModel::getTrackId(const QModelIndex& index) const {

--- a/src/library/baseexternalplaylistmodel.h
+++ b/src/library/baseexternalplaylistmodel.h
@@ -22,10 +22,14 @@ class BaseExternalPlaylistModel : public BaseSqlTableModel {
 
     TrackPointer getTrack(const QModelIndex& index) const override;
     TrackId getTrackId(const QModelIndex& index) const override;
+    QString getTrackLocation(const QModelIndex& index) const override;
     bool isColumnInternal(int column) override;
     Qt::ItemFlags flags(const QModelIndex& index) const override;
     Capabilities getCapabilities() const override;
     QString modelKey(bool noSearch) const override;
+
+  protected:
+    virtual QString resolveLocation(const QString& nativeLocation) const;
 
   private:
     TrackId doGetTrackId(const TrackPointer& pTrack) const override;

--- a/src/library/baseexternaltrackmodel.cpp
+++ b/src/library/baseexternaltrackmodel.cpp
@@ -50,7 +50,7 @@ TrackPointer BaseExternalTrackModel::getTrack(const QModelIndex& index) const {
     float bpm = index.sibling(index.row(), fieldIndex("bpm")).data().toString().toFloat();
 
     QString nativeLocation = index.sibling(index.row(), fieldIndex("location")).data().toString();
-    QString location = QDir::fromNativeSeparators(nativeLocation);
+    QString location = resolveLocation(nativeLocation);
 
     if (location.isEmpty()) {
         // Track is lost
@@ -79,6 +79,10 @@ TrackPointer BaseExternalTrackModel::getTrack(const QModelIndex& index) const {
         qWarning() << "Failed to load external track" << location;
     }
     return pTrack;
+}
+
+QString BaseExternalTrackModel::resolveLocation(const QString& nativeLocation) const {
+    return QDir::fromNativeSeparators(nativeLocation);
 }
 
 TrackId BaseExternalTrackModel::getTrackId(const QModelIndex& index) const {

--- a/src/library/baseexternaltrackmodel.cpp
+++ b/src/library/baseexternaltrackmodel.cpp
@@ -49,8 +49,7 @@ TrackPointer BaseExternalTrackModel::getTrack(const QModelIndex& index) const {
     QString genre = index.sibling(index.row(), fieldIndex("genre")).data().toString();
     float bpm = index.sibling(index.row(), fieldIndex("bpm")).data().toString().toFloat();
 
-    QString nativeLocation = index.sibling(index.row(), fieldIndex("location")).data().toString();
-    QString location = resolveLocation(nativeLocation);
+    QString location = getTrackLocation(index);
 
     if (location.isEmpty()) {
         // Track is lost
@@ -94,13 +93,18 @@ TrackId BaseExternalTrackModel::getTrackId(const QModelIndex& index) const {
     }
 }
 
+QString BaseExternalTrackModel::getTrackLocation(const QModelIndex& index) const {
+    QString nativeLocation = index.sibling(index.row(), fieldIndex("location")).data().toString();
+    return resolveLocation(nativeLocation);
+}
+
 TrackId BaseExternalTrackModel::doGetTrackId(const TrackPointer& pTrack) const {
     if (pTrack) {
         // The external table has foreign Track IDs, so we need to compare
         // by location
         for (int row = 0; row < rowCount(); ++row) {
             QString nativeLocation = index(row, fieldIndex("location")).data().toString();
-            QString location = QDir::fromNativeSeparators(nativeLocation);
+            QString location = resolveLocation(nativeLocation);
             if (location == pTrack->getLocation()) {
                 return TrackId(index(row, 0).data());
             }

--- a/src/library/baseexternaltrackmodel.h
+++ b/src/library/baseexternaltrackmodel.h
@@ -25,6 +25,8 @@ class BaseExternalTrackModel : public BaseSqlTableModel {
     bool isColumnInternal(int column) override;
     Qt::ItemFlags flags(const QModelIndex& index) const override;
 
+    QString getTrackLocation(const QModelIndex& index) const override;
+
   protected:
     virtual QString resolveLocation(const QString& nativeLocation) const;
 

--- a/src/library/baseexternaltrackmodel.h
+++ b/src/library/baseexternaltrackmodel.h
@@ -25,6 +25,9 @@ class BaseExternalTrackModel : public BaseSqlTableModel {
     bool isColumnInternal(int column) override;
     Qt::ItemFlags flags(const QModelIndex& index) const override;
 
+  protected:
+    virtual QString resolveLocation(const QString& nativeLocation) const;
+
   private:
     TrackId doGetTrackId(const TrackPointer& pTrack) const override;
 };

--- a/src/library/baseexternaltrackmodel.h
+++ b/src/library/baseexternaltrackmodel.h
@@ -22,10 +22,9 @@ class BaseExternalTrackModel : public BaseSqlTableModel {
     Capabilities getCapabilities() const override;
     TrackId getTrackId(const QModelIndex& index) const override;
     TrackPointer getTrack(const QModelIndex& index) const override;
+    QString getTrackLocation(const QModelIndex& index) const override;
     bool isColumnInternal(int column) override;
     Qt::ItemFlags flags(const QModelIndex& index) const override;
-
-    QString getTrackLocation(const QModelIndex& index) const override;
 
   protected:
     virtual QString resolveLocation(const QString& nativeLocation) const;

--- a/src/library/itunes/itunesfeature.cpp
+++ b/src/library/itunes/itunesfeature.cpp
@@ -31,11 +31,15 @@
 #include "library/itunes/itunesmacosimporter.h"
 #endif
 
+#ifdef __IOS_ITUNES_LIBRARY__
+#include "library/itunes/itunesiosimporter.h"
+#endif
+
 namespace {
 
 const QString kItdbPathKey = "mixxx.itunesfeature.itdbpath";
 
-bool isMacOSImporterAvailable() {
+bool isNativeImporterAvailable() {
 #ifdef __MACOS_ITUNES_LIBRARY__
     // The iTunesLibrary framework is only available on macOS 10.13+
     // Note that this uses a Clang directive to check the macOS version at
@@ -45,6 +49,8 @@ bool isMacOSImporterAvailable() {
     if (__builtin_available(macOS 10.13, *)) {
         return true;
     }
+#elif defined(__IOS_ITUNES_LIBRARY__)
+    return true;
 #endif
     return false;
 }
@@ -186,7 +192,7 @@ void ITunesFeature::activate(bool forceReload) {
             m_dbfile = getiTunesMusicPath();
         }
 
-        if (!isMacOSImporterUsed()) {
+        if (!isNativeImporterUsed()) {
             mixxx::FileInfo fileInfo(m_dbfile);
             if (fileInfo.checkFileExists()) {
                 // Users of Mixxx <1.12.0 didn't support sandboxing. If we are sandboxed
@@ -250,8 +256,8 @@ QString ITunesFeature::showOpenDialog() {
             "iTunes XML (*.xml)");
 }
 
-bool ITunesFeature::isMacOSImporterUsed() {
-    return isMacOSImporterAvailable() && m_dbfile.isEmpty();
+bool ITunesFeature::isNativeImporterUsed() {
+    return isNativeImporterAvailable() && m_dbfile.isEmpty();
 }
 
 void ITunesFeature::onRightClick(const QPoint& globalPos) {
@@ -288,9 +294,9 @@ void ITunesFeature::onRightClick(const QPoint& globalPos) {
 
 QString ITunesFeature::getiTunesMusicPath() {
     QString musicFolder;
-    if (isMacOSImporterAvailable()) {
+    if (isNativeImporterAvailable()) {
         qDebug() << "Using empty iTunes music path (which we interpret as "
-                    "using ITunesMacOSImporter)";
+                    "using ITunesMacOSImporter/ITunesIOSImporter)";
         return "";
     }
 #if defined(__APPLE__)
@@ -310,9 +316,14 @@ std::unique_ptr<ITunesImporter> ITunesFeature::makeImporter() {
     std::unique_ptr<ITunesDAO> dao = std::make_unique<ITunesDAO>();
     dao->initialize(m_database);
 #ifdef __MACOS_ITUNES_LIBRARY__
-    if (isMacOSImporterUsed()) {
+    if (isNativeImporterUsed()) {
         qDebug() << "Using ITunesMacOSImporter to read default iTunes library";
         return std::make_unique<ITunesMacOSImporter>(this, std::move(dao));
+    }
+#elif defined(__IOS_ITUNES_LIBRARY__)
+    if (isNativeImporterUsed()) {
+        qDebug() << "Using ITunesIOSImporter to read default iTunes library";
+        return std::make_unique<ITunesIOSImporter>(this, std::move(dao));
     }
 #endif
     qDebug() << "Using ITunesXMLImporter to read iTunes library from " << m_dbfile;

--- a/src/library/itunes/itunesfeature.cpp
+++ b/src/library/itunes/itunesfeature.cpp
@@ -16,6 +16,7 @@
 #include "library/itunes/itunesdao.h"
 #include "library/itunes/itunesimporter.h"
 #include "library/itunes/itunesplaylistmodel.h"
+#include "library/itunes/itunestrackmodel.h"
 #include "library/itunes/itunesxmlimporter.h"
 #include "library/library.h"
 #include "library/queryutil.h"
@@ -96,10 +97,8 @@ ITunesFeature::ITunesFeature(Library* pLibrary, UserSettingsPointer pConfig)
             std::move(columns),
             std::move(searchColumns),
             false);
-    m_pITunesTrackModel = new BaseExternalTrackModel(this,
+    m_pITunesTrackModel = new ITunesTrackModel(this,
             m_pLibrary->trackCollectionManager(),
-            "mixxx.db.model.itunes",
-            "itunes_library",
             m_trackSource);
     m_pITunesPlaylistModel = new ITunesPlaylistModel(this,
             m_pLibrary->trackCollectionManager(),

--- a/src/library/itunes/itunesfeature.h
+++ b/src/library/itunes/itunesfeature.h
@@ -51,7 +51,7 @@ class ITunesFeature : public BaseExternalLibraryFeature {
     /// returns the file path.
     QString showOpenDialog();
 
-    bool isMacOSImporterUsed();
+    bool isNativeImporterUsed();
 
     BaseExternalTrackModel* m_pITunesTrackModel;
     BaseExternalPlaylistModel* m_pITunesPlaylistModel;

--- a/src/library/itunes/itunesiosassetexporter.h
+++ b/src/library/itunes/itunesiosassetexporter.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <QDir>
+#include <QString>
+#include <QUrl>
+
+/// A facility for exporting assets (e.g. audio files) on Apple platforms. This
+/// is needed to copy audio files from the user's local music library into a
+/// writable location in the sandbox.
+class ITunesIOSAssetExporter {
+  public:
+    ITunesIOSAssetExporter(const QDir& outputDir);
+
+    /// Exports the asset with the given URL to the output directory. URLs using
+    /// the `ipod-library://` scheme are supported. Returns the output path.
+    QString exportAsync(const QUrl& url);
+
+  private:
+    QDir outputDir;
+};

--- a/src/library/itunes/itunesiosassetexporter.h
+++ b/src/library/itunes/itunesiosassetexporter.h
@@ -11,9 +11,10 @@ class ITunesIOSAssetExporter {
   public:
     ITunesIOSAssetExporter(const QDir& outputDir);
 
-    /// Exports the asset with the given URL to the output directory. URLs using
-    /// the `ipod-library://` scheme are supported. Returns the output path.
-    QString exportAsync(const QUrl& url);
+    /// Synchronously exports the asset with the given URL to the output
+    /// directory. URLs using the `ipod-library://` scheme are supported.
+    /// Returns the output path.
+    QString exportAsset(const QUrl& url);
 
   private:
     QDir outputDir;

--- a/src/library/itunes/itunesiosassetexporter.mm
+++ b/src/library/itunes/itunesiosassetexporter.mm
@@ -47,6 +47,9 @@ QString ITunesIOSAssetExporter::exportAsset(const QUrl& url) {
         }
 
         asset = [[AVURLAsset alloc] initWithURL:item.assetURL options:nil];
+        baseName = persistentID;
+
+        // Add metadata tags for the exported audio file
 
         AVMutableMetadataItem* titleItem = [[AVMutableMetadataItem alloc] init];
         titleItem.keySpace = AVMetadataKeySpaceCommon;
@@ -79,8 +82,6 @@ QString ITunesIOSAssetExporter::exportAsset(const QUrl& url) {
         releaseDateItem.key = AVMetadataiTunesMetadataKeyReleaseDate;
         releaseDateItem.value = item.releaseDate;
         [metadata addObject:releaseDateItem];
-
-        baseName = persistentID;
     } else {
         asset = [[AVURLAsset alloc] initWithURL:url.toNSURL() options:nil];
         baseName = QFileInfo(url.path()).baseName();

--- a/src/library/itunes/itunesiosassetexporter.mm
+++ b/src/library/itunes/itunesiosassetexporter.mm
@@ -11,6 +11,11 @@
 
 ITunesIOSAssetExporter::ITunesIOSAssetExporter(const QDir& outputDir)
         : outputDir(outputDir) {
+    if (!outputDir.exists()) {
+        qInfo() << "Creating output directory for exported iTunes assets at"
+                << outputDir;
+        outputDir.mkpath(".");
+    }
 }
 
 QString ITunesIOSAssetExporter::exportAsync(const QUrl& url) {

--- a/src/library/itunes/itunesiosassetexporter.mm
+++ b/src/library/itunes/itunesiosassetexporter.mm
@@ -20,7 +20,8 @@ ITunesIOSAssetExporter::ITunesIOSAssetExporter(const QDir& outputDir)
 }
 
 QString ITunesIOSAssetExporter::exportAsset(const QUrl& url) {
-    AVURLAsset* asset;
+    AVURLAsset* asset = nil;
+    NSMutableArray<AVMetadataItem*>* metadata = [[NSMutableArray alloc] init];
     QString baseName;
 
     if (url.scheme() == "ipod-library") {
@@ -47,10 +48,25 @@ QString ITunesIOSAssetExporter::exportAsset(const QUrl& url) {
 
         asset = [[AVURLAsset alloc] initWithURL:item.assetURL options:nil];
 
-        // TODO: Use a more descriptive name than the ID, e.g. including
-        // title/artist? Note that the file path should identify the asset
-        // uniquely, otherwise our existence check may wrongly identify
-        // some other track with the one we are looking to export here.
+        AVMutableMetadataItem* titleItem = [[AVMutableMetadataItem alloc] init];
+        titleItem.keySpace = AVMetadataKeySpaceCommon;
+        titleItem.key = AVMetadataCommonKeyTitle;
+        titleItem.value = item.title;
+        [metadata addObject:titleItem];
+
+        AVMutableMetadataItem* artistItem =
+                [[AVMutableMetadataItem alloc] init];
+        artistItem.keySpace = AVMetadataKeySpaceCommon;
+        artistItem.key = AVMetadataCommonKeyArtist;
+        artistItem.value = item.artist;
+        [metadata addObject:artistItem];
+
+        AVMutableMetadataItem* albumItem = [[AVMutableMetadataItem alloc] init];
+        albumItem.keySpace = AVMetadataKeySpaceCommon;
+        albumItem.key = AVMetadataCommonKeyAlbumName;
+        albumItem.value = item.albumTitle;
+        [metadata addObject:albumItem];
+
         baseName = persistentID;
     } else {
         asset = [[AVURLAsset alloc] initWithURL:url.toNSURL() options:nil];
@@ -64,6 +80,7 @@ QString ITunesIOSAssetExporter::exportAsset(const QUrl& url) {
                 initWithAsset:asset
                    presetName:AVAssetExportPresetAppleM4A];
 
+        session.metadata = metadata;
         session.outputFileType = AVFileTypeAppleM4A;
         session.outputURL = [NSURL fileURLWithPath:outputPath.toNSString()];
 

--- a/src/library/itunes/itunesiosassetexporter.mm
+++ b/src/library/itunes/itunesiosassetexporter.mm
@@ -67,6 +67,19 @@ QString ITunesIOSAssetExporter::exportAsset(const QUrl& url) {
         albumItem.value = item.albumTitle;
         [metadata addObject:albumItem];
 
+        AVMutableMetadataItem* genreItem = [[AVMutableMetadataItem alloc] init];
+        genreItem.keySpace = AVMetadataKeySpaceiTunes;
+        genreItem.key = AVMetadataiTunesMetadataKeyUserGenre;
+        genreItem.value = item.genre;
+        [metadata addObject:genreItem];
+
+        AVMutableMetadataItem* releaseDateItem =
+                [[AVMutableMetadataItem alloc] init];
+        releaseDateItem.keySpace = AVMetadataKeySpaceiTunes;
+        releaseDateItem.key = AVMetadataiTunesMetadataKeyReleaseDate;
+        releaseDateItem.value = item.releaseDate;
+        [metadata addObject:releaseDateItem];
+
         baseName = persistentID;
     } else {
         asset = [[AVURLAsset alloc] initWithURL:url.toNSURL() options:nil];

--- a/src/library/itunes/itunesiosassetexporter.mm
+++ b/src/library/itunes/itunesiosassetexporter.mm
@@ -1,0 +1,54 @@
+#include "library/itunes/itunesiosassetexporter.h"
+
+#import <AVFoundation/AVFoundation.h>
+
+#include <QDir>
+#include <QString>
+#include <QUrl>
+#include <QUrlQuery>
+#include <QtGlobal>
+
+ITunesIOSAssetExporter::ITunesIOSAssetExporter(const QDir& outputDir)
+        : outputDir(outputDir) {
+}
+
+QString ITunesIOSAssetExporter::exportAsync(const QUrl& url) {
+    AVURLAsset* asset = [[AVURLAsset alloc] initWithURL:url.toNSURL()
+                                                options:nil];
+    AVAssetExportSession* session = [[AVAssetExportSession alloc]
+            initWithAsset:asset
+               presetName:AVAssetExportPresetAppleM4A];
+
+    QString name;
+    if (url.scheme() == "ipod-library") {
+        // TODO: Use a more descriptive name than the ID, e.g. including
+        // title/artist?
+        QUrlQuery query(url);
+        name = query.queryItemValue("id");
+    } else {
+        name = QFileInfo(url.path()).baseName();
+    }
+
+    QString outputPath(outputDir.absolutePath() + "/" + name + ".m4a");
+
+    session.outputFileType = AVFileTypeAppleM4A;
+    session.outputURL = [NSURL fileURLWithPath:outputPath.toNSString()];
+
+    [session exportAsynchronouslyWithCompletionHandler:^{
+        switch (session.status) {
+        case AVAssetExportSessionStatusCompleted:
+            qInfo() << "Successfully exported asset to" << outputPath;
+            break;
+        case AVAssetExportSessionStatusFailed:
+            qWarning() << "Exporting asset to" << outputPath
+                       << "failed:" << [session.error localizedDescription];
+            break;
+        default:
+            qWarning() << "Exporting asset to" << outputPath
+                       << "completed with unknown status:" << session.status;
+            break;
+        }
+    }];
+
+    return outputPath;
+}

--- a/src/library/itunes/itunesiosimporter.h
+++ b/src/library/itunes/itunesiosimporter.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <QSqlDatabase>
+#include <QString>
+#include <atomic>
+#include <memory>
+
+#include "library/itunes/itunesimporter.h"
+
+class ITunesDAO;
+class ITunesFeature;
+
+/// An importer that reads the user's default Music library
+/// using the native `MediaPlayer` framework on iOS.
+class ITunesIOSImporter : public ITunesImporter {
+  public:
+    ITunesIOSImporter(
+            ITunesFeature* pParentFeature,
+            std::unique_ptr<ITunesDAO> dao);
+
+    ITunesImport importLibrary() override;
+
+  private:
+    std::unique_ptr<ITunesDAO> m_dao;
+};

--- a/src/library/itunes/itunesiosimporter.h
+++ b/src/library/itunes/itunesiosimporter.h
@@ -22,4 +22,6 @@ class ITunesIOSImporter : public ITunesImporter {
 
   private:
     std::unique_ptr<ITunesDAO> m_dao;
+    
+    void requestAuthorization();
 };

--- a/src/library/itunes/itunesiosimporter.h
+++ b/src/library/itunes/itunesiosimporter.h
@@ -22,6 +22,6 @@ class ITunesIOSImporter : public ITunesImporter {
 
   private:
     std::unique_ptr<ITunesDAO> m_dao;
-    
+
     void requestAuthorization();
 };

--- a/src/library/itunes/itunesiosimporter.mm
+++ b/src/library/itunes/itunesiosimporter.mm
@@ -84,9 +84,15 @@ class ImporterImpl {
 
     void importPlaylist(MPMediaPlaylist* mpPlaylist) {
         int playlistId = dbIdFromPersistentId(mpPlaylist.persistentID);
-        // TODO: Figure out if we can infer a hierarchy or if the API even
-        // provides folders
-        int parentId = kRootITunesPlaylistId;
+
+        // We use an undocumented API to get the parent ID here:
+        // https://stackoverflow.com/a/12369132
+        NSNumber* parentPersistentId =
+                [mpPlaylist valueForProperty:@"parentPersistentID"];
+        int parentId = (parentPersistentId &&
+                               parentPersistentId.unsignedLongLongValue != 0)
+                ? dbIdFromPersistentId(parentPersistentId.unsignedLongLongValue)
+                : kRootITunesPlaylistId;
 
         ITunesPlaylist playlist = {
                 .id = playlistId,

--- a/src/library/itunes/itunesiosimporter.mm
+++ b/src/library/itunes/itunesiosimporter.mm
@@ -138,7 +138,11 @@ class ImporterImpl {
                 .grouping = QString::fromNSString(item.userGrouping),
                 .year = 0, // TODO: Infer from releaseDate?
                 .duration = static_cast<int>(item.playbackDuration / 1000),
-                .location = QString::fromNSString(item.assetURL.path),
+                // NOTE: These URLs are of the form
+                // `ipod-library://item/item.m4a?id=...` and do not represent
+                // actual file system paths, so we have to treat them specially
+                // in `ITunesTrackModel`.
+                .location = QString::fromNSString(item.assetURL.absoluteString),
                 .rating = static_cast<int>(item.rating / 20),
                 .comment = QString::fromNSString(item.comments),
                 .trackNumber = static_cast<int>(item.albumTrackNumber),

--- a/src/library/itunes/itunesiosimporter.mm
+++ b/src/library/itunes/itunesiosimporter.mm
@@ -1,0 +1,178 @@
+#include "library/itunes/itunesiosimporter.h"
+
+#import <MediaPlayer/MediaPlayer.h>
+#include <gsl/pointers>
+
+#include <QDateTime>
+#include <QHash>
+#include <QSqlDatabase>
+#include <QSqlQuery>
+#include <QString>
+#include <QVariant>
+#include <algorithm>
+#include <atomic>
+#include <map>
+#include <memory>
+#include <optional>
+#include <utility>
+
+#include "library/itunes/itunesdao.h"
+#include "library/itunes/itunesfeature.h"
+#include "library/queryutil.h"
+#include "library/treeitem.h"
+#include "library/treeitemmodel.h"
+
+namespace {
+
+class ImporterImpl {
+  public:
+    ImporterImpl(ITunesIOSImporter* pImporter, ITunesDAO& dao)
+            : m_pImporter(pImporter), m_dao(dao) {
+    }
+
+    void importCollections(NSArray<MPMediaItemCollection*>* collections) {
+        qDebug() << "Importing collections via native Media Player framework";
+
+        // We prefer Objective-C-style for-in loops over C++ loops when dealing
+        // with Objective-C types (both here and in the methods below) since
+        // they use Objective-C's enumeration protocols and are guaranteed to
+        // interact well with Objective-C collections.
+
+        for (MPMediaItemCollection* collection in collections) {
+            if (m_pImporter->canceled()) {
+                break;
+            }
+
+            if ([collection isKindOfClass:[MPMediaPlaylist class]]) {
+                importPlaylist((MPMediaPlaylist*)collection);
+            }
+        }
+    }
+
+    void importMediaItems(NSArray<MPMediaItem*>* items) {
+        qDebug() << "Importing media items via native Media Player framework";
+
+        for (MPMediaItem* item in items) {
+            if (m_pImporter->canceled()) {
+                break;
+            }
+
+            importMediaItem(item);
+        }
+    }
+
+    void appendPlaylistTree(gsl::not_null<TreeItem*> item) {
+        m_dao.appendPlaylistTree(item);
+    }
+
+  private:
+    ITunesIOSImporter* m_pImporter;
+
+    QHash<MPMediaEntityPersistentID, int> m_dbIdByPersistentId;
+    ITunesDAO& m_dao;
+
+    int dbIdFromPersistentId(MPMediaEntityPersistentID persistentId) {
+        // Map a persistent ID as used by iTunes to an (incrementing) database
+        // ID The persistent IDs used by iTunes occasionally exceed signed
+        // 64-bit ints, so we cannot use them directly, unfortunately (also we
+        // currently use the fact that our deterministic indexing scheme starts
+        // at 0 to represent the root of the playlist tree with -1 in
+        // appendPlaylistTree).
+        auto existing = m_dbIdByPersistentId.find(persistentId);
+        if (existing != m_dbIdByPersistentId.end()) {
+            return existing.value();
+        } else {
+            int dbId = m_dbIdByPersistentId.size();
+            m_dbIdByPersistentId[persistentId] = dbId;
+            return dbId;
+        }
+    }
+
+    void importPlaylist(MPMediaPlaylist* mpPlaylist) {
+        int playlistId = dbIdFromPersistentId(mpPlaylist.persistentID);
+        // TODO: Figure out if we can infer a hierarchy or if the API even
+        // provides folders
+        int parentId = kRootITunesPlaylistId;
+
+        ITunesPlaylist playlist = {
+                .id = playlistId,
+                .name = QString::fromNSString(mpPlaylist.name),
+        };
+        if (!m_dao.importPlaylist(playlist)) {
+            return;
+        }
+
+        if (!m_dao.importPlaylistRelation(parentId, playlistId)) {
+            return;
+        }
+
+        int i = 0;
+        for (MPMediaItem* item in mpPlaylist.items) {
+            if (m_pImporter->canceled()) {
+                return;
+            }
+
+            int trackId = dbIdFromPersistentId(item.persistentID);
+            if (!m_dao.importPlaylistTrack(playlistId, trackId, i)) {
+                return;
+            }
+
+            i++;
+        }
+    }
+
+    void importMediaItem(MPMediaItem* item) {
+        // Skip DRM-protected and non-downloaded tracks
+        if (item.hasProtectedAsset || item.isCloudItem) {
+            return;
+        }
+
+        ITunesTrack track = {
+                .id = dbIdFromPersistentId(item.persistentID),
+                .artist = QString::fromNSString(item.artist),
+                .title = QString::fromNSString(item.title),
+                .album = QString::fromNSString(item.albumTitle),
+                .albumArtist = QString::fromNSString(item.albumArtist),
+                .composer = QString::fromNSString(item.composer),
+                .genre = QString::fromNSString(item.genre),
+                .grouping = QString::fromNSString(item.userGrouping),
+                .year = 0, // TODO: Infer from releaseDate?
+                .duration = static_cast<int>(item.playbackDuration / 1000),
+                .location = QString::fromNSString(item.assetURL.path),
+                .rating = static_cast<int>(item.rating / 20),
+                .comment = QString::fromNSString(item.comments),
+                .trackNumber = static_cast<int>(item.albumTrackNumber),
+                .bpm = static_cast<int>(item.beatsPerMinute),
+                .bitrate = 0,
+                .playCount = static_cast<int>(item.playCount),
+                .lastPlayedAt = QDateTime::fromNSDate(item.lastPlayedDate),
+                .dateAdded = QDateTime::fromNSDate(item.dateAdded),
+        };
+
+        if (!m_dao.importTrack(track)) {
+            return;
+        }
+    }
+};
+
+} // anonymous namespace
+
+ITunesIOSImporter::ITunesIOSImporter(
+        ITunesFeature* pParentFeature, std::unique_ptr<ITunesDAO> dao)
+        : ITunesImporter(pParentFeature), m_dao(std::move(dao)) {
+}
+
+ITunesImport ITunesIOSImporter::importLibrary() {
+    ITunesImport iTunesImport;
+
+    std::unique_ptr<TreeItem> rootItem = TreeItem::newRoot(m_pParentFeature);
+    ImporterImpl impl(this, *m_dao);
+
+    impl.importCollections([MPMediaQuery playlistsQuery].collections);
+    impl.importMediaItems([MPMediaQuery songsQuery].items);
+    impl.appendPlaylistTree(rootItem.get());
+
+    iTunesImport.playlistRoot = std::move(rootItem);
+
+    return iTunesImport;
+}

--- a/src/library/itunes/itunesiosimporter.mm
+++ b/src/library/itunes/itunesiosimporter.mm
@@ -141,7 +141,7 @@ class ImporterImpl {
                 // NOTE: These URLs are of the form
                 // `ipod-library://item/item.m4a?id=...` and do not represent
                 // actual file system paths, so we have to treat them specially
-                // in `ITunesTrackModel`.
+                // in `ITunesTrackModel` and `ITunesPlaylistModel`.
                 .location = QString::fromNSString(item.assetURL.absoluteString),
                 .rating = static_cast<int>(item.rating / 20),
                 .comment = QString::fromNSString(item.comments),

--- a/src/library/itunes/itunesiosimporter.mm
+++ b/src/library/itunes/itunesiosimporter.mm
@@ -180,22 +180,27 @@ ITunesIOSImporter::ITunesIOSImporter(
 void ITunesIOSImporter::requestAuthorization() {
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
-    [MPMediaLibrary requestAuthorization:^(MPMediaLibraryAuthorizationStatus status){
+    [MPMediaLibrary requestAuthorization:^(
+            MPMediaLibraryAuthorizationStatus status) {
         switch (status) {
         case MPMediaLibraryAuthorizationStatusAuthorized:
             qInfo() << "Successfully authorized iOS media library access";
             break;
         case MPMediaLibraryAuthorizationStatusRestricted:
-            qWarning() << "iOS media library access is restricted, Mixxx may not be able to access all tracks";
+            qWarning() << "iOS media library access is restricted, Mixxx may "
+                          "not be able to access all tracks";
             break;
         case MPMediaLibraryAuthorizationStatusDenied:
-            qWarning() << "iOS media library access is denied, Mixxx will not be able to access any tracks";
+            qWarning() << "iOS media library access is denied, Mixxx will not "
+                          "be able to access any tracks";
             break;
         case MPMediaLibraryAuthorizationStatusNotDetermined:
-            qWarning() << "iOS media library access is not determined, Mixxx may not be able to access any tracks";
+            qWarning() << "iOS media library access is not determined, Mixxx "
+                          "may not be able to access any tracks";
             break;
         default:
-            qWarning() << "Unknown iOS media library authorization status:" << status;
+            qWarning() << "Unknown iOS media library authorization status:"
+                       << status;
             break;
         }
         dispatch_semaphore_signal(semaphore);
@@ -207,7 +212,7 @@ void ITunesIOSImporter::requestAuthorization() {
 
 ITunesImport ITunesIOSImporter::importLibrary() {
     requestAuthorization();
-    
+
     ITunesImport iTunesImport;
 
     std::unique_ptr<TreeItem> rootItem = TreeItem::newRoot(m_pParentFeature);

--- a/src/library/itunes/itunesiostrackresolver.cpp
+++ b/src/library/itunes/itunesiostrackresolver.cpp
@@ -1,0 +1,22 @@
+#include "library/itunes/itunesiostrackresolver.h"
+
+#include <QStandardPaths>
+#include <QString>
+#include <QUrl>
+#include <QtGlobal>
+
+#include "library/itunes/itunesiosassetexporter.h"
+#include "util/assert.h"
+
+namespace mixxx {
+
+QString resolveiPodLibraryTrack(const QUrl& url) {
+    DEBUG_ASSERT(url.scheme() == "ipod-library");
+
+    qInfo() << "Exporting" << url << "to file (if needed)";
+    QString musicDir = QStandardPaths::writableLocation(QStandardPaths::MusicLocation);
+    ITunesIOSAssetExporter exporter(QDir(musicDir + "/Mixxx/iTunes Tracks"));
+    return exporter.exportAsset(url);
+}
+
+}; // namespace mixxx

--- a/src/library/itunes/itunesiostrackresolver.h
+++ b/src/library/itunes/itunesiostrackresolver.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <QString>
+#include <QUrl>
+
+namespace mixxx {
+
+/// Resolves a track from the local iOS music library, identified by a URL of
+/// the form `ipod-library://...`, to an on-disk file path. This may require
+/// copying the underlying file to the Mixxx sandbox.
+QString resolveiPodLibraryTrack(const QUrl& url);
+
+}; // namespace mixxx

--- a/src/library/itunes/itunesplaylistmodel.cpp
+++ b/src/library/itunes/itunesplaylistmodel.cpp
@@ -1,6 +1,9 @@
 #include "library/itunes/itunesplaylistmodel.h"
 
 #include "library/baseexternalplaylistmodel.h"
+#ifdef __IOS_ITUNES_LIBRARY__
+#include "library/itunes/itunesiostrackresolver.h"
+#endif
 #include "moc_itunesplaylistmodel.cpp"
 
 ITunesPlaylistModel::ITunesPlaylistModel(QObject* parent,
@@ -78,4 +81,13 @@ void ITunesPlaylistModel::initSortColumnMapping() {
                 m_columnIndexBySortColumnId[static_cast<int>(sortColumn)],
                 sortColumn);
     }
+}
+
+QString ITunesPlaylistModel::resolveLocation(const QString& nativeLocation) const {
+#ifdef __IOS_ITUNES_LIBRARY__
+    if (nativeLocation.startsWith("ipod-library:")) {
+        return mixxx::resolveiPodLibraryTrack(QUrl(nativeLocation));
+    }
+#endif
+    return BaseExternalPlaylistModel::resolveLocation(nativeLocation);
 }

--- a/src/library/itunes/itunesplaylistmodel.h
+++ b/src/library/itunes/itunesplaylistmodel.h
@@ -13,4 +13,5 @@ class ITunesPlaylistModel : public BaseExternalPlaylistModel {
 
   protected:
     void initSortColumnMapping() override;
+    QString resolveLocation(const QString& nativeLocation) const override;
 };

--- a/src/library/itunes/itunestrackmodel.cpp
+++ b/src/library/itunes/itunestrackmodel.cpp
@@ -3,11 +3,10 @@
 #include "library/baseexternaltrackmodel.h"
 #include "library/basetrackcache.h"
 #ifdef __IOS_ITUNES_LIBRARY__
-#include "library/itunes/itunesiosassetexporter.h"
+#include "library/itunes/itunesiostrackresolver.h"
 #endif
 #include <QObject>
 #include <QSharedPointer>
-#include <QStandardPaths>
 #include <QString>
 
 #include "library/trackcollectionmanager.h"
@@ -26,9 +25,7 @@ ITunesTrackModel::ITunesTrackModel(QObject* parent,
 QString ITunesTrackModel::resolveLocation(const QString& nativeLocation) const {
 #ifdef __IOS_ITUNES_LIBRARY__
     if (nativeLocation.startsWith("ipod-library:")) {
-        QString musicDir = QStandardPaths::writableLocation(QStandardPaths::MusicLocation);
-        ITunesIOSAssetExporter exporter(QDir(musicDir + "/Mixxx/iTunes Tracks"));
-        return exporter.exportAsset(QUrl(nativeLocation));
+        return mixxx::resolveiPodLibraryTrack(QUrl(nativeLocation));
     }
 #endif
     return BaseExternalTrackModel::resolveLocation(nativeLocation);

--- a/src/library/itunes/itunestrackmodel.cpp
+++ b/src/library/itunes/itunestrackmodel.cpp
@@ -1,5 +1,16 @@
 #include "library/itunes/itunestrackmodel.h"
 
+#include "library/baseexternaltrackmodel.h"
+#include "library/basetrackcache.h"
+#ifdef __IOS_ITUNES_LIBRARY__
+#include "library/itunes/itunesiosassetexporter.h"
+#endif
+#include <QObject>
+#include <QSharedPointer>
+#include <QStandardPaths>
+#include <QString>
+
+#include "library/trackcollectionmanager.h"
 #include "moc_itunestrackmodel.cpp"
 
 ITunesTrackModel::ITunesTrackModel(QObject* parent,
@@ -10,4 +21,15 @@ ITunesTrackModel::ITunesTrackModel(QObject* parent,
                   "mixxx.db.model.itunes",
                   "itunes_library",
                   trackSource) {
+}
+
+QString ITunesTrackModel::resolveLocation(const QString& nativeLocation) const {
+#ifdef __IOS_ITUNES_LIBRARY__
+    if (nativeLocation.startsWith("ipod-library:")) {
+        QString musicDir = QStandardPaths::writableLocation(QStandardPaths::MusicLocation);
+        ITunesIOSAssetExporter exporter(QDir(musicDir + "/Mixxx/iTunes Tracks"));
+        return exporter.exportAsync(QUrl(nativeLocation));
+    }
+#endif
+    return BaseExternalTrackModel::resolveLocation(nativeLocation);
 }

--- a/src/library/itunes/itunestrackmodel.cpp
+++ b/src/library/itunes/itunestrackmodel.cpp
@@ -28,7 +28,7 @@ QString ITunesTrackModel::resolveLocation(const QString& nativeLocation) const {
     if (nativeLocation.startsWith("ipod-library:")) {
         QString musicDir = QStandardPaths::writableLocation(QStandardPaths::MusicLocation);
         ITunesIOSAssetExporter exporter(QDir(musicDir + "/Mixxx/iTunes Tracks"));
-        return exporter.exportAsync(QUrl(nativeLocation));
+        return exporter.exportAsset(QUrl(nativeLocation));
     }
 #endif
     return BaseExternalTrackModel::resolveLocation(nativeLocation);

--- a/src/library/itunes/itunestrackmodel.cpp
+++ b/src/library/itunes/itunestrackmodel.cpp
@@ -1,0 +1,13 @@
+#include "library/itunes/itunestrackmodel.h"
+
+#include "moc_itunestrackmodel.cpp"
+
+ITunesTrackModel::ITunesTrackModel(QObject* parent,
+        TrackCollectionManager* pTrackCollectionManager,
+        QSharedPointer<BaseTrackCache> trackSource)
+        : BaseExternalTrackModel(parent,
+                  pTrackCollectionManager,
+                  "mixxx.db.model.itunes",
+                  "itunes_library",
+                  trackSource) {
+}

--- a/src/library/itunes/itunestrackmodel.h
+++ b/src/library/itunes/itunestrackmodel.h
@@ -1,8 +1,12 @@
 #pragma once
 
 #include <QObject>
+#include <QSharedPointer>
+#include <QString>
 
 #include "library/baseexternaltrackmodel.h"
+#include "library/basetrackcache.h"
+#include "library/trackcollectionmanager.h"
 
 class ITunesTrackModel : public BaseExternalTrackModel {
     Q_OBJECT
@@ -10,4 +14,7 @@ class ITunesTrackModel : public BaseExternalTrackModel {
     ITunesTrackModel(QObject* parent,
             TrackCollectionManager* pTrackCollectionManager,
             QSharedPointer<BaseTrackCache> trackSource);
+
+  protected:
+    QString resolveLocation(const QString& nativeLocation) const override;
 };

--- a/src/library/itunes/itunestrackmodel.h
+++ b/src/library/itunes/itunestrackmodel.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <QObject>
+
+#include "library/baseexternaltrackmodel.h"
+
+class ITunesTrackModel : public BaseExternalTrackModel {
+    Q_OBJECT
+  public:
+    ITunesTrackModel(QObject* parent,
+            TrackCollectionManager* pTrackCollectionManager,
+            QSharedPointer<BaseTrackCache> trackSource);
+};


### PR DESCRIPTION
### Based on #12672 

This adds a new iTunes importer for iOS, using the Media Player framework as the iTunes Library framework is macOS-only. Since the APIs are pretty similar, the implementation is largely similar to the existing macOS importer.

One major difference to macOS is that iOS does not expose the track locations directly, but instead gives us a special URL[^1]:

```
ipod-library://item/item.m4a?id=...
```

Since the assumption that every track has an on-disk location is present in many parts of the codebase, we use an [`AVAssetExportSession`](https://developer.apple.com/documentation/avfoundation/avassetexportsession) to export the audio files into the Mixxx sandbox whenever a track from iTunes is added to the Mixxx library[^2]. These tracks are saved to

```
<path to sandbox>/Documents/Music/Mixxx/iTunes Tracks
```

### Future Improvements

- We currently use a `DispatchSemaphore` to synchronously export the track, even though the underlying API is asynchronous. This is non-ideal, since Xcode rightfully warns about potentially hanging the UI thread and thus causing a priority inversion. In practice this does not seem to be so bad, since we only exports single tracks at a time as the user selects them/load them to a deck, but ideally we should make this asynchronous. Retrofitting asynchrony into the synchronous track loading seems to be a larger task, however. One option would be to simply accept the (potentially still non-existent) output path as the export happens asynchronously, but that would require being more liberal with non-existent paths (e.g. in `BaseExternalTrackModel` and `BaseExternalPlaylistModel`).
- If Mixxx eventually moves to storing track locations as URLs, we could revisit simply storing the `ipod-library` URLs in the db and loading the track files without having to copy them into the sandbox first, where they are stored redundantly+

[^1]: Sandboxing on iOS is a bit more restrictive than on macOS, see #12675
[^2]: This happens whenever the user selects a track or drags it to the deck