### PR TITLE
DesktopHelper: Add openUrl abstraction to support iOS

### DIFF
--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -1,6 +1,5 @@
 #include "controllers/dlgprefcontroller.h"
 
-#include <QDesktopServices>
 #include <QDir>
 #include <QFileDialog>
 #include <QFileInfo>
@@ -21,6 +20,7 @@
 #include "defs_urls.h"
 #include "moc_dlgprefcontroller.cpp"
 #include "preferences/usersettings.h"
+#include "util/desktophelper.h"
 #include "util/string.h"
 
 namespace {
@@ -113,7 +113,7 @@ DlgPrefController::DlgPrefController(
     connect(m_ui.labelLoadedMappingScriptFileLinks,
             &QLabel::linkActivated,
             [](const QString& path) {
-                QDesktopServices::openUrl(QUrl::fromLocalFile(path));
+                mixxx::DesktopHelper::openUrl(QUrl::fromLocalFile(path));
             });
 
     // Input mappings

--- a/src/controllers/dlgprefcontrollers.cpp
+++ b/src/controllers/dlgprefcontrollers.cpp
@@ -1,7 +1,5 @@
 #include "controllers/dlgprefcontrollers.h"
 
-#include <QDesktopServices>
-
 #include "controllers/controller.h"
 #include "controllers/controllermanager.h"
 #include "controllers/defs_controllers.h"
@@ -9,6 +7,7 @@
 #include "defs_urls.h"
 #include "moc_dlgprefcontrollers.cpp"
 #include "preferences/dialog/dlgpreferences.h"
+#include "util/desktophelper.h"
 #include "util/string.h"
 
 DlgPrefControllers::DlgPrefControllers(DlgPreferences* pPreferences,
@@ -78,7 +77,7 @@ DlgPrefControllers::~DlgPrefControllers() {
 }
 
 void DlgPrefControllers::openLocalFile(const QString& file) {
-    QDesktopServices::openUrl(QUrl::fromLocalFile(file));
+    mixxx::DesktopHelper::openUrl(QUrl::fromLocalFile(file));
 }
 
 void DlgPrefControllers::slotUpdate() {

--- a/src/dialog/dlgabout.cpp
+++ b/src/dialog/dlgabout.cpp
@@ -1,13 +1,13 @@
 #include "dialog/dlgabout.h"
 
 #include <QDebug>
-#include <QDesktopServices>
 #include <QFile>
 #include <QLocale>
 
 #include "defs_urls.h"
 #include "moc_dlgabout.cpp"
 #include "util/color/color.h"
+#include "util/desktophelper.h"
 #include "util/versionstore.h"
 
 DlgAbout::DlgAbout()
@@ -411,7 +411,7 @@ DlgAbout::DlgAbout()
     }
     btnDonate->setText(tr("Donate"));
     connect(btnDonate, &QPushButton::clicked, this, [] {
-        QDesktopServices::openUrl(QUrl(MIXXX_DONATE_URL));
+        mixxx::DesktopHelper::openUrl(QUrl(MIXXX_DONATE_URL));
     });
 
     connect(buttonBox, &QDialogButtonBox::accepted, this, &DlgAbout::accept);

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -2,7 +2,6 @@
 
 #include <QCloseEvent>
 #include <QDebug>
-#include <QDesktopServices>
 #include <QFileDialog>
 #include <QOpenGLContext>
 #include <QUrl>
@@ -48,6 +47,7 @@
 #include "sources/soundsourceproxy.h"
 #include "track/track.h"
 #include "util/debug.h"
+#include "util/desktophelper.h"
 #include "util/sandbox.h"
 #include "util/timer.h"
 #include "util/versionstore.h"
@@ -554,7 +554,7 @@ QDialog::DialogCode MixxxMainWindow::soundDeviceErrorDlg(
             *retryClicked = true;
             return QDialog::Accepted;
         } else if (msgBox.clickedButton() == wikiButton) {
-            QDesktopServices::openUrl(QUrl(MIXXX_WIKI_TROUBLESHOOTING_SOUND_URL));
+            mixxx::DesktopHelper::openUrl(QUrl(MIXXX_WIKI_TROUBLESHOOTING_SOUND_URL));
             wikiButton->setEnabled(false);
         } else if (msgBox.clickedButton() == reconfigureButton) {
             msgBox.hide();

--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -1,6 +1,5 @@
 #include "preferences/dialog/dlgpreferences.h"
 
-#include <QDesktopServices>
 #include <QDialog>
 #include <QEvent>
 #include <QMoveEvent>
@@ -15,6 +14,7 @@
 #include "preferences/dialog/dlgpreflibrary.h"
 #include "preferences/dialog/dlgprefsound.h"
 #include "util/color/color.h"
+#include "util/desktophelper.h"
 #include "util/widgethelper.h"
 
 #ifdef __VINYLCONTROL__
@@ -435,7 +435,7 @@ void DlgPreferences::slotButtonPressed(QAbstractButton* pButton) {
         if (pCurrentPage) {
             QUrl helpUrl = pCurrentPage->helpUrl();
             DEBUG_ASSERT(helpUrl.isValid());
-            QDesktopServices::openUrl(helpUrl);
+            mixxx::DesktopHelper::openUrl(helpUrl);
         }
         break;
     default:

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -1,7 +1,6 @@
 #include "preferences/dialog/dlgpreflibrary.h"
 
 #include <QApplication>
-#include <QDesktopServices>
 #include <QDir>
 #include <QFileDialog>
 #include <QFontDialog>
@@ -18,6 +17,7 @@
 #include "library/trackcollection.h"
 #include "library/trackcollectionmanager.h"
 #include "moc_dlgpreflibrary.cpp"
+#include "util/desktophelper.h"
 #include "widget/wsearchlineedit.h"
 
 using namespace mixxx::library::prefs;
@@ -66,7 +66,7 @@ DlgPrefLibrary::DlgPrefLibrary(
     connect(PushButtonOpenSettingsDir,
             &QPushButton::clicked,
             [settingsDir] {
-                QDesktopServices::openUrl(QUrl::fromLocalFile(settingsDir));
+                mixxx::DesktopHelper::openUrl(QUrl::fromLocalFile(settingsDir));
             });
 
     // Set default direction as stored in config file
@@ -124,7 +124,7 @@ DlgPrefLibrary::DlgPrefLibrary(
     connect(label_settingsManualLink,
             &QLabel::linkActivated,
             [](const QString& url) {
-                QDesktopServices::openUrl(url);
+                mixxx::DesktopHelper::openUrl(url);
             });
 
     connect(checkBox_SyncTrackMetadata,

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <QCoreApplication>
-#include <QDesktopServices>
 #include <QDir>
 #include <QList>
 #include <QString>

--- a/src/util/desktophelper.cpp
+++ b/src/util/desktophelper.cpp
@@ -19,7 +19,7 @@ const QString kSelectInXfce = "xf";
 QString sSelectInFileBrowserCommand;
 
 QString getSelectInFileBrowserCommand() {
-#if defined(Q_OS_MAC)
+#if defined(Q_OS_MACOS)
     return "open -R";
 #elif defined(Q_OS_WIN)
     return "explorer.exe /select,";

--- a/src/util/desktophelper.cpp
+++ b/src/util/desktophelper.cpp
@@ -165,10 +165,23 @@ void DesktopHelper::openInFileBrowser(const QStringList& paths) {
         dirPath = dir.absolutePath();
         qDebug() << "opening:" << dirPath;
         if (!openedDirs.contains(dirPath)) {
-            QDesktopServices::openUrl(QUrl::fromLocalFile(dirPath));
+            openUrl(QUrl::fromLocalFile(dirPath));
             openedDirs.insert(dirPath);
         }
     }
+}
+
+bool DesktopHelper::openUrl(const QUrl& url) {
+#ifdef Q_OS_IOS
+    QUrl urlToOpen = url;
+    // Open files and folders in the iOS Files app
+    if (urlToOpen.scheme() == "file") {
+        urlToOpen.setScheme("shareddocuments");
+    }
+    return QDesktopServices::openUrl(urlToOpen);
+#else
+    return QDesktopServices::openUrl(url);
+#endif
 }
 
 } // namespace mixxx

--- a/src/util/desktophelper.cpp
+++ b/src/util/desktophelper.cpp
@@ -175,6 +175,7 @@ bool DesktopHelper::openUrl(const QUrl& url) {
 #ifdef Q_OS_IOS
     QUrl urlToOpen = url;
     // Open files and folders in the iOS Files app
+    // See https://stackoverflow.com/q/46499842
     if (urlToOpen.scheme() == "file") {
         urlToOpen.setScheme("shareddocuments");
     }

--- a/src/util/desktophelper.h
+++ b/src/util/desktophelper.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QUrl>
 #include <QtGlobal>
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
@@ -11,6 +12,8 @@ namespace mixxx {
 class DesktopHelper {
 public:
    static void openInFileBrowser(const QStringList& paths);
+
+   static bool openUrl(const QUrl& url);
 };
 
 } // namespace mixxx

--- a/src/widget/wfindonwebmenu.cpp
+++ b/src/widget/wfindonwebmenu.cpp
@@ -1,11 +1,11 @@
 #include "wfindonwebmenu.h"
 
-#include <QDesktopServices>
 #include <QMenu>
 #include <QtDebug>
 
 #include "moc_wfindonwebmenu.cpp"
 #include "track/track.h"
+#include "util/desktophelper.h"
 
 WFindOnWebMenu::WFindOnWebMenu(QWidget* parent)
         : QMenu(tr("Find on Web"), parent) {
@@ -36,8 +36,8 @@ QString WFindOnWebMenu::composeSearchQuery(
 }
 
 void WFindOnWebMenu::openInBrowser(const QUrl& url) {
-    if (!QDesktopServices::openUrl(url)) {
-        qWarning() << "QDesktopServices::openUrl() failed for " << url;
+    if (!mixxx::DesktopHelper::openUrl(url)) {
+        qWarning() << "DesktopHelper::openUrl() failed for " << url;
         DEBUG_ASSERT(false);
     }
 }

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -7,6 +7,7 @@
 #include "defs_urls.h"
 #include "moc_wmainmenubar.cpp"
 #include "util/cmdlineargs.h"
+#include "util/desktophelper.h"
 #include "util/experiment.h"
 #include "vinylcontrol/defs_vinylcontrol.h"
 
@@ -733,7 +734,7 @@ void WMainMenuBar::slotDeveloperDebugger(bool toggle) {
 }
 
 void WMainMenuBar::slotVisitUrl(const QUrl& url) {
-    QDesktopServices::openUrl(url);
+    mixxx::DesktopHelper::openUrl(url);
 }
 
 void WMainMenuBar::createVisibilityControl(QAction* pAction,


### PR DESCRIPTION
As mentioned in https://github.com/mixxxdj/mixxx/pull/12674#issuecomment-1913793086, iOS supports opening files in the native Files app by replacing `file://` URLs with `shareddocuments://` URLs. To avoid duplication, this PR introduces a new abstraction, `DesktopHelper::openUrl` which serves as a drop-in replacement for `QDesktopServices::openUrl` that handles this schema mapping on iOS.

Since #12688 makes the config directory (including controller mappings etc.) user-accessible, links to the settings directory or user mappings "just work", even on iOS:

https://github.com/mixxxdj/mixxx/assets/30873659/3509eb2a-0df5-466c-b3e5-16a104255fb7
