### PR TITLE
Tango: allow to toggle crossfader indepedently from mixer

### DIFF
--- a/res/skins/Tango/skin_settings.xml
+++ b/res/skins/Tango/skin_settings.xml
@@ -506,15 +506,15 @@ Description:
           <WidgetGroup><!-- EQ knobs, EQ Kill buttons, Crossfader -->
             <ObjectName>SkinSettingsSubMenu</ObjectName>
             <Layout>stacked</Layout>
-            <MinimumSize>182,39</MinimumSize>
-            <MaximumSize>182,60</MaximumSize>
+            <MinimumSize>182,26</MinimumSize>
+            <MaximumSize>182,40</MaximumSize>
             <SizePolicy>me,me</SizePolicy>
             <Children>
               <!-- translucent cover when Channel Mixer is hidden -->
               <WidgetGroup>
                 <ObjectName>SubmenuCover</ObjectName>
-                <MinimumSize>182,39</MinimumSize>
-                <MaximumSize>182,60</MaximumSize>
+                <MinimumSize>182,26</MinimumSize>
+                <MaximumSize>182,40</MaximumSize>
                 <SizePolicy>me,me</SizePolicy>
                 <Connection>
                   <ConfigKey persist="true">[Skin],show_mixer</ConfigKey>
@@ -558,11 +558,6 @@ Description:
                     </Children>
                   </WidgetGroup><!-- /EQ Kill buttons -->
 
-                  <Template src="skins:Tango/controls/skin_settings_button_2state.xml">
-                    <SetVariable name="text">Crossfader</SetVariable>
-                    <SetVariable name="Setting">[Skin],show_xfader</SetVariable>
-                  </Template>
-
                 </Children>
               </WidgetGroup>
 
@@ -593,6 +588,11 @@ Description:
               </Template>
             </Children>
           </WidgetGroup><!-- /Permanent Level Meters -->
+
+          <Template src="skins:Tango/controls/skin_settings_button_2state.xml">
+            <SetVariable name="text">Crossfader</SetVariable>
+            <SetVariable name="Setting">[Skin],show_xfader</SetVariable>
+          </Template>
           <!-- /Mixer -->
 
           <WidgetGroup>

--- a/res/skins/Tango/topbar.xml
+++ b/res/skins/Tango/topbar.xml
@@ -85,54 +85,27 @@ Description:
         </Children>
       </WidgetGroup><!-- /Logo + Main, Headphone & Booth Mixer -->
 
-      <WidgetGroup><!-- Crossfader, hidden with maximized library -->
-        <SizePolicy>min,min</SizePolicy>
-        <Layout>horizontal</Layout>
+      <WidgetGroup><!-- Crossfader -->
+        <ObjectName>CrossfaderContainer</ObjectName>
+        <SizePolicy>min,f</SizePolicy>
+        <Layout>vertical</Layout>
         <Children>
-		      <WidgetGroup>
-		        <SizePolicy>min,min</SizePolicy>
-		        <Layout>horizontal</Layout>
-		        <Children>
-		          <WidgetGroup>
-		            <SizePolicy>min,min</SizePolicy>
-		            <Layout>horizontal</Layout>
-		            <Children>
-		              <WidgetGroup>
-		                <ObjectName>CrossfaderContainer</ObjectName>
-		                <SizePolicy>min,f</SizePolicy>
-		                <Layout>vertical</Layout>
-		                <Children>
-		                  <SliderComposed>
-		                    <TooltipId>crossfader</TooltipId>
-		                    <Size>108f,32f</Size>
-		                    <Handle scalemode="STRETCH_ASPECT">skins:Tango/knobs_sliders/crossfader_handle.svg</Handle>
-		                    <Slider scalemode="STRETCH_ASPECT">skins:Tango/knobs_sliders/crossfader_scale.svg</Slider>
-		                    <Horizontal>true</Horizontal>
-		                    <Connection>
-		                      <ConfigKey>[Master],crossfader</ConfigKey>
-		                    </Connection>
-		                  </SliderComposed>
-		                </Children>
-		              </WidgetGroup>
-		            </Children>
-		            <Connection>
-		              <ConfigKey persist="true">[Skin],show_xfader</ConfigKey>
-		              <BindProperty>visible</BindProperty>
-		            </Connection>
-		          </WidgetGroup>
-            </Children>
+          <SliderComposed>
+            <TooltipId>crossfader</TooltipId>
+            <Size>108f,28f</Size>
+            <Handle scalemode="STRETCH_ASPECT">skins:Tango/knobs_sliders/crossfader_handle.svg</Handle>
+            <Slider scalemode="STRETCH_ASPECT">skins:Tango/knobs_sliders/crossfader_scale.svg</Slider>
+            <Horizontal>true</Horizontal>
             <Connection>
-              <ConfigKey persist="true">[Skin],show_mixer</ConfigKey>
-              <BindProperty>visible</BindProperty>
+              <ConfigKey>[Master],crossfader</ConfigKey>
             </Connection>
-          </WidgetGroup>
+          </SliderComposed>
         </Children>
         <Connection>
-          <ConfigKey>[Skin],show_maximized_library</ConfigKey>
-          <Transform><Not/></Transform>
+          <ConfigKey persist="true">[Skin],show_xfader</ConfigKey>
           <BindProperty>visible</BindProperty>
         </Connection>
-      </WidgetGroup><!-- /Crossfader, hidden with maximized library -->
+      </WidgetGroup><!-- /Crossfader -->
 
       <WidgetGroup><!-- Skin toggles, Rec, Broadcast, Clock, Skin menu toggle -->
         <Layout>horizontal</Layout>


### PR DESCRIPTION
As suggested in #12654 
This makes sense in Tango since the crossfader is separate from the mixer.