### PR TITLE
Fail early in case Taglib 2.0 is found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2942,6 +2942,10 @@ find_package(TagLib 1.11 REQUIRED)
 target_link_libraries(mixxx-lib PRIVATE TagLib::TagLib)
 if (NOT TagLib_VERSION VERSION_LESS 2.0.0)
     message(FATAL_ERROR "Installed Taglib ${TagLib_VERSION} is not supported. Use Version >= 1.11 and < 2.0 and its development headers.")
+    # Dear package maintainer: Do not patch away this fatal error
+    # using taglib 2.0.0 will put user data at risk!!
+    # Mixxx is a complex application that needs to be adapted and tested thoroughly
+    # https://github.com/mixxxdj/mixxx/issues/12708
 endif()
 
 # Threads

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2940,6 +2940,9 @@ target_link_libraries(mixxx-lib PRIVATE SoundTouch::SoundTouch)
 # TagLib
 find_package(TagLib 1.11 REQUIRED)
 target_link_libraries(mixxx-lib PRIVATE TagLib::TagLib)
+if (NOT TagLib_VERSION VERSION_LESS 2.0.0)
+    message(FATAL_ERROR "Installed Taglib ${TagLib_VERSION} is not supported. Use Version >= 1.11 and < 2.0 and its development headers.")
+endif()
 
 # Threads
 set(THREADS_PREFER_PTHREAD_FLAG ON)


### PR DESCRIPTION
This makes the build error because of Taglib 2.0 explicit. 

https://github.com/mixxxdj/mixxx/issues/12708

I am strictly against hacking a support in to 2.4-beta, because it requires a good amount of testing. 
Any issue will put user data on a risk 

See also the discussion about the new " / " separator in multi-valued fields
https://github.com/mixxxdj/mixxx/pull/12613


