### PR TITLE
LateNight: use default RGB waveform colors

### DIFF
--- a/res/skins/LateNight/decks/overview.xml
+++ b/res/skins/LateNight/decks/overview.xml
@@ -8,12 +8,13 @@
     </Connection>
     <BgColor><Variable name="BgColor"/></BgColor>
     <SignalColor><Variable name="SignalColor"/></SignalColor>
-    <SignalHighColor><Variable name="SignalHighColor"/></SignalHighColor>
-    <SignalMidColor><Variable name="SignalMidColor"/></SignalMidColor>
-    <SignalLowColor><Variable name="SignalLowColor"/></SignalLowColor>
-    <SignalRGBHighColor><Variable name="SignalHighColor"/></SignalRGBHighColor>
-    <SignalRGBMidColor><Variable name="SignalMidColor"/></SignalRGBMidColor>
-    <SignalRGBLowColor><Variable name="SignalLowColor"/></SignalRGBLowColor>
+    <!-- Default colors are used for high/mid/low: blue/green/red -->
+    <SignalHighColor></SignalHighColor>
+    <SignalMidColor></SignalMidColor>
+    <SignalLowColor></SignalLowColor>
+    <SignalRGBHighColor></SignalRGBHighColor>
+    <SignalRGBMidColor></SignalRGBMidColor>
+    <SignalRGBLowColor></SignalRGBLowColor>
     <PlayedOverlayColor><Variable name="PlayedOverlayColor"/></PlayedOverlayColor>
     <PlayPosColor><Variable name="PlayPosColor"/></PlayPosColor>
     <EndOfTrackColor><Variable name="EndOfTrackColor"/></EndOfTrackColor>

--- a/res/skins/LateNight/waveform.xml
+++ b/res/skins/LateNight/waveform.xml
@@ -18,12 +18,13 @@
             <Channel><Variable name="ChanNum"/></Channel>
             <BgColor><Variable name="BgColorWaveform"/></BgColor>
             <SignalColor><Variable name="SignalColor"/></SignalColor>
-            <SignalHighColor><Variable name="SignalHighColor"/></SignalHighColor>
-            <SignalMidColor><Variable name="SignalMidColor"/></SignalMidColor>
-            <SignalLowColor><Variable name="SignalLowColor"/></SignalLowColor>
-            <SignalRGBHighColor><Variable name="SignalHighColor"/></SignalRGBHighColor>
-            <SignalRGBMidColor><Variable name="SignalMidColor"/></SignalRGBMidColor>
-            <SignalRGBLowColor><Variable name="SignalLowColor"/></SignalRGBLowColor>
+            <!-- Default colors are used for high/mid/low: blue/green/red -->
+            <SignalHighColor></SignalHighColor>
+            <SignalMidColor></SignalMidColor>
+            <SignalLowColor></SignalLowColor>
+            <SignalRGBHighColor></SignalRGBHighColor>
+            <SignalRGBMidColor></SignalRGBMidColor>
+            <SignalRGBLowColor></SignalRGBLowColor>
             <BeatColor><Variable name="BeatColor"/></BeatColor>
             <AxesColor><Variable name="AxesColor"/></AxesColor>
             <BeatHighlightColor></BeatHighlightColor>


### PR DESCRIPTION
The recent waveform discussions and especially [Uwe's demo](https://github.com/mixxxdj/mixxx/issues/11833#issuecomment-1905165836) of an alternative signal drawing implementation made me realize how 'muddy' PaleMoon's waveforms look like in comparison to the default colors.

I suggest to remove the custom colors.

current:
![wave_current](https://github.com/mixxxdj/mixxx/assets/5934199/00a7965a-80cf-4118-9463-bf142085898e)

defaults / this PR:
![wave_default](https://github.com/mixxxdj/mixxx/assets/5934199/be937d8d-1b03-47fc-a68b-e6cfa2a53628)

I did not yet look at the other skins.