### PR TITLE
SoundManager: Set up `AVAudioSession` on iOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1544,6 +1544,7 @@ if(APPLE)
 
   if(IOS)
     target_sources(mixxx-lib PRIVATE
+      src/soundio/soundmanagerios.mm
       src/util/screensaverios.mm
     )
   else()

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -4,6 +4,7 @@
 
 #include <QLibrary>
 #include <QThread>
+#include <QtGlobal>
 #include <cstring> // for memcpy and strcmp
 
 #include "control/controlobject.h"
@@ -21,6 +22,10 @@
 #include "util/sample.h"
 #include "util/versionstore.h"
 #include "vinylcontrol/defs_vinylcontrol.h"
+
+#ifdef Q_OS_IOS
+#include "soundio/soundmanagerios.h"
+#endif
 
 typedef PaError (*SetJackClientName)(const char *name);
 
@@ -249,6 +254,9 @@ void SoundManager::queryDevicesPortaudio() {
     if (!m_paInitialized) {
 #ifdef Q_OS_LINUX
         setJACKName();
+#endif
+#ifdef Q_OS_IOS
+        mixxx::initializeAVAudioSession();
 #endif
         err = Pa_Initialize();
         m_paInitialized = true;

--- a/src/soundio/soundmanagerios.h
+++ b/src/soundio/soundmanagerios.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace mixxx {
+
+void initializeAVAudioSession();
+
+}; // namespace mixxx

--- a/src/soundio/soundmanagerios.mm
+++ b/src/soundio/soundmanagerios.mm
@@ -1,0 +1,31 @@
+#include <QDebug>
+#include <QtGlobal>
+
+#import <AVFAudio/AVFAudio.h>
+
+namespace mixxx {
+
+void initializeAVAudioSession() {
+    AVAudioSession* session = AVAudioSession.sharedInstance;
+    AVAudioSessionCategory category = AVAudioSessionCategoryPlayback;
+    AVAudioSessionMode mode = AVAudioSessionModeDefault;
+    AVAudioSessionCategoryOptions options =
+            AVAudioSessionCategoryOptionMixWithOthers |
+            AVAudioSessionCategoryOptionAllowAirPlay |
+            AVAudioSessionCategoryOptionAllowBluetoothA2DP;
+
+    NSError* error = nil;
+    [session setCategory:category mode:mode options:options error:&error];
+    if (error != nil) {
+        qWarning() << "Could not initialize AVAudioSession:"
+                   << error.localizedDescription;
+    }
+
+    [session setActive:true error:&error];
+    if (error != nil) {
+        qWarning() << "Could not activate AVAudioSession:"
+                   << error.localizedDescription;
+    }
+}
+
+}; // namespace mixxx


### PR DESCRIPTION
### Based on #12672 

On iOS, audio apps should set up an [`AVAudioSession`](https://developer.apple.com/documentation/avfaudio/avaudiosession) to tailor the OS behavior towards their use case (e.g. whether the app should interrupt other audio etc.) As explained in https://github.com/PortAudio/portaudio/pull/881, this is currently not handled by PortAudio and likely doesn't fit into its API, since different apps will have different requirements that can't be handled by a "one-size-fits-all" initialization.

For Mixxx, I've set up the session in a way that it mixes with other apps[^1] and uses the standard playback mode.

[^1]: Not strictly necessary, but since we're mixing our own decks anyway, I see no downside in mixing with other apps too? Also, we wouldn't interrupt audio when launching Mixxx that way (an alternative would be to activate the audio session first upon playing a track, but that would likely require the `AVAudioSession` logic to be more deeply intertwined with other playback logic, which might not be desirable in order to keep platform-specific stuff isolated).