### PR TITLE
SoundManager: Use correct PortAudio backend on iOS

### DIFF
--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -23,6 +23,10 @@ class ControlObject;
 #define MIXXX_PORTAUDIO_OSS_STRING "OSS"
 #define MIXXX_PORTAUDIO_ASIO_STRING "ASIO"
 #define MIXXX_PORTAUDIO_DIRECTSOUND_STRING "Windows DirectSound"
+// NOTE: This is what our patched version of PortAudio uses for the Core Audio
+// backend on iOS. If/when upstream supports iOS officially
+// (https://github.com/PortAudio/portaudio/pull/881), we may have to update this
+#define MIXXX_PORTAUDIO_IOSAUDIO_STRING "iOS Audio"
 #define MIXXX_PORTAUDIO_COREAUDIO_STRING "Core Audio"
 
 #define SOUNDMANAGER_DISCONNECTED 0

--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -1,6 +1,7 @@
 #include "soundio/soundmanagerconfig.h"
 
 #include <QRegularExpression>
+#include <QtGlobal>
 
 #include "audio/types.h"
 #include "soundio/sounddevice.h"
@@ -495,7 +496,9 @@ void SoundManagerConfig::loadDefaults(SoundManager* soundManager, unsigned int f
                 m_api = MIXXX_PORTAUDIO_DIRECTSOUND_STRING;
             }
 #endif
-#ifdef __APPLE__
+#ifdef Q_OS_IOS
+            m_api = MIXXX_PORTAUDIO_IOSAUDIO_STRING;
+#elif defined(Q_OS_MACOS)
             m_api = MIXXX_PORTAUDIO_COREAUDIO_STRING;
 #endif
         }


### PR DESCRIPTION
The iOS backend (https://github.com/PortAudio/portaudio/pull/881) is called `iOS Audio`, therefore we should pick the correct default here.