### PR TITLE
Keyboard mapping fixes

### DIFF
--- a/res/keyboard/cs_CZ.kbd.cfg
+++ b/res/keyboard/cs_CZ.kbd.cfg
@@ -19,10 +19,10 @@ start_stop Shift+p
 back Alt+Left
 fwd Alt+Right
 
-[QuickEffectRack1_[Channel1]_Effect1]
+[QuickEffectRack1_[Channel1]]
 enabled ř
 
-[QuickEffectRack1_[Channel2]_Effect1]
+[QuickEffectRack1_[Channel2]]
 enabled ž
 
 [EqualizerRack1_[Channel1]_Effect1]
@@ -136,12 +136,6 @@ loop_double o
 passthrough Ctrl+k
 vinylcontrol_mode Ctrl+Shift+U
 vinylcontrol_cueing Ctrl+Alt+U
-
-[QuickEffectRack1_[Channel1]_Effect1]
-enabled ř
-
-[QuickEffectRack1_[Channel2]_Effect1]
-enabled 0
 
 [KeyboardShortcuts]
 FileMenu_LoadDeck1 Ctrl+o

--- a/res/keyboard/cs_CZ.kbd.cfg
+++ b/res/keyboard/cs_CZ.kbd.cfg
@@ -23,7 +23,7 @@ fwd Alt+Right
 enabled ř
 
 [QuickEffectRack1_[Channel2]]
-enabled ž
+enabled é
 
 [EqualizerRack1_[Channel1]_Effect1]
 button_parameter1 b

--- a/res/keyboard/da_DK.kbd.cfg
+++ b/res/keyboard/da_DK.kbd.cfg
@@ -19,10 +19,10 @@ start_stop Shift+p
 back Alt+Left
 fwd Alt+Right
 
-[QuickEffectRack1_[Channel1]_Effect1]
+[QuickEffectRack1_[Channel1]]
 enabled 5
 
-[QuickEffectRack1_[Channel2]_Effect1]
+[QuickEffectRack1_[Channel2]]
 enabled 0
 
 [EqualizerRack1_[Channel1]_Effect1]
@@ -136,12 +136,6 @@ loop_double o
 passthrough Ctrl+k
 vinylcontrol_mode Ctrl+Shift+U
 vinylcontrol_cueing Ctrl+Alt+U
-
-[QuickEffectRack1_[Channel1]_Effect1]
-enabled 5
-
-[QuickEffectRack1_[Channel2]_Effect1]
-enabled 0
 
 [KeyboardShortcuts]
 FileMenu_LoadDeck1 Ctrl+o

--- a/res/keyboard/de_CH.kbd.cfg
+++ b/res/keyboard/de_CH.kbd.cfg
@@ -19,10 +19,10 @@ start_stop Shift+p
 back Alt+Left
 fwd Alt+Right
 
-[QuickEffectRack1_[Channel1]_Effect1]
+[QuickEffectRack1_[Channel1]]
 enabled 5
 
-[QuickEffectRack1_[Channel2]_Effect1]
+[QuickEffectRack1_[Channel2]]
 enabled 0
 
 [EqualizerRack1_[Channel1]_Effect1]
@@ -136,12 +136,6 @@ loop_double o
 passthrough Ctrl+k
 vinylcontrol_mode Ctrl+Shift+U
 vinylcontrol_cueing Ctrl+Alt+U
-
-[QuickEffectRack1_[Channel1]_Effect1]
-enabled 5
-
-[QuickEffectRack1_[Channel2]_Effect1]
-enabled 0
 
 [KeyboardShortcuts]
 FileMenu_LoadDeck1 Ctrl+o

--- a/res/keyboard/de_DE.kbd.cfg
+++ b/res/keyboard/de_DE.kbd.cfg
@@ -19,10 +19,10 @@ start_stop Shift+p
 back Alt+Left
 fwd Alt+Right
 
-[QuickEffectRack1_[Channel1]_Effect1]
+[QuickEffectRack1_[Channel1]]
 enabled 5
 
-[QuickEffectRack1_[Channel2]_Effect1]
+[QuickEffectRack1_[Channel2]]
 enabled 0
 
 [EqualizerRack1_[Channel1]_Effect1]
@@ -136,12 +136,6 @@ loop_double o
 passthrough Ctrl+k
 vinylcontrol_mode Ctrl+Shift+U
 vinylcontrol_cueing Ctrl+Alt+U
-
-[QuickEffectRack1_[Channel1]_Effect1]
-enabled 5
-
-[QuickEffectRack1_[Channel2]_Effect1]
-enabled 0
 
 [KeyboardShortcuts]
 FileMenu_LoadDeck1 Ctrl+o

--- a/res/keyboard/el_GR.kbd.cfg
+++ b/res/keyboard/el_GR.kbd.cfg
@@ -19,10 +19,10 @@ start_stop Shift+Π
 back Alt+Left
 fwd Alt+Right
 
-[QuickEffectRack1_[Channel1]_Effect1]
+[QuickEffectRack1_[Channel1]]
 enabled 5
 
-[QuickEffectRack1_[Channel2]_Effect1]
+[QuickEffectRack1_[Channel2]]
 enabled 0
 
 [EqualizerRack1_[Channel1]_Effect1]
@@ -140,12 +140,6 @@ loop_double ο
 passthrough Ctrl+κ
 vinylcontrol_mode Ctrl+Shift+Θ
 vinylcontrol_cueing Ctrl+Alt+Θ
-
-[QuickEffectRack1_[Channel1]_Effect1]
-enabled 5
-
-[QuickEffectRack1_[Channel2]_Effect1]
-enabled 0
 
 [KeyboardShortcuts]
 FileMenu_LoadDeck1 Ctrl+o

--- a/res/keyboard/en_US.kbd.cfg
+++ b/res/keyboard/en_US.kbd.cfg
@@ -19,10 +19,10 @@ start_stop Shift+p
 back Alt+Left
 fwd Alt+Right
 
-[QuickEffectRack1_[Channel1]_Effect1]
+[QuickEffectRack1_[Channel1]]
 enabled 5
 
-[QuickEffectRack1_[Channel2]_Effect1]
+[QuickEffectRack1_[Channel2]]
 enabled 0
 
 [EqualizerRack1_[Channel1]_Effect1]
@@ -136,12 +136,6 @@ loop_double o
 passthrough Ctrl+k
 vinylcontrol_mode Ctrl+Shift+U
 vinylcontrol_cueing Ctrl+Alt+U
-
-[QuickEffectRack1_[Channel1]_Effect1]
-enabled 5
-
-[QuickEffectRack1_[Channel2]_Effect1]
-enabled 0
 
 [KeyboardShortcuts]
 FileMenu_LoadDeck1 Ctrl+o

--- a/res/keyboard/es_ES.kbd.cfg
+++ b/res/keyboard/es_ES.kbd.cfg
@@ -19,10 +19,10 @@ start_stop Shift+p
 back Alt+Left
 fwd Alt+Right
 
-[QuickEffectRack1_[Channel1]_Effect1]
+[QuickEffectRack1_[Channel1]]
 enabled 5
 
-[QuickEffectRack1_[Channel2]_Effect1]
+[QuickEffectRack1_[Channel2]]
 enabled 0
 
 [EqualizerRack1_[Channel1]_Effect1]
@@ -136,12 +136,6 @@ loop_double o
 passthrough Ctrl+k
 vinylcontrol_mode Ctrl+Shift+U
 vinylcontrol_cueing Ctrl+Alt+U
-
-[QuickEffectRack1_[Channel1]_Effect1]
-enabled 5
-
-[QuickEffectRack1_[Channel2]_Effect1]
-enabled 0
 
 [KeyboardShortcuts]
 FileMenu_LoadDeck1 Ctrl+o

--- a/res/keyboard/fi_FI.kbd.cfg
+++ b/res/keyboard/fi_FI.kbd.cfg
@@ -19,10 +19,10 @@ start_stop Shift+p
 back Alt+Left
 fwd Alt+Right
 
-[QuickEffectRack1_[Channel1]_Effect1]
+[QuickEffectRack1_[Channel1]]
 enabled 5
 
-[QuickEffectRack1_[Channel2]_Effect1]
+[QuickEffectRack1_[Channel2]]
 enabled 0
 
 [EqualizerRack1_[Channel1]_Effect1]
@@ -136,12 +136,6 @@ loop_double o
 passthrough Ctrl+k
 vinylcontrol_mode Ctrl+Shift+U
 vinylcontrol_cueing Ctrl+Alt+U
-
-[QuickEffectRack1_[Channel1]_Effect1]
-enabled 5
-
-[QuickEffectRack1_[Channel2]_Effect1]
-enabled 0
 
 [KeyboardShortcuts]
 FileMenu_LoadDeck1 Ctrl+o

--- a/res/keyboard/fr_CH.kbd.cfg
+++ b/res/keyboard/fr_CH.kbd.cfg
@@ -19,10 +19,10 @@ start_stop Shift+p
 back Alt+Left
 fwd Alt+Right
 
-[QuickEffectRack1_[Channel1]_Effect1]
+[QuickEffectRack1_[Channel1]]
 enabled 5
 
-[QuickEffectRack1_[Channel2]_Effect1]
+[QuickEffectRack1_[Channel2]]
 enabled 0
 
 [EqualizerRack1_[Channel1]_Effect1]
@@ -136,12 +136,6 @@ loop_double o
 passthrough Ctrl+k
 vinylcontrol_mode Ctrl+Shift+U
 vinylcontrol_cueing Ctrl+Alt+U
-
-[QuickEffectRack1_[Channel1]_Effect1]
-enabled 5
-
-[QuickEffectRack1_[Channel2]_Effect1]
-enabled 0
 
 [KeyboardShortcuts]
 FileMenu_LoadDeck1 Ctrl+o

--- a/res/keyboard/fr_FR.kbd.cfg
+++ b/res/keyboard/fr_FR.kbd.cfg
@@ -19,10 +19,10 @@ start_stop Shift+p
 back Alt+Left
 fwd Alt+Right
 
-[QuickEffectRack1_[Channel1]_Effect1]
+[QuickEffectRack1_[Channel1]]
 enabled (
 
-[QuickEffectRack1_[Channel2]_Effect1]
+[QuickEffectRack1_[Channel2]]
 enabled à
 
 [EqualizerRack1_[Channel1]_Effect1]
@@ -136,12 +136,6 @@ loop_double o
 passthrough Ctrl+k
 vinylcontrol_mode Ctrl+Shift+U
 vinylcontrol_cueing Ctrl+Alt+U
-
-[QuickEffectRack1_[Channel1]_Effect1]
-enabled (
-
-[QuickEffectRack1_[Channel2]_Effect1]
-enabled à
 
 [KeyboardShortcuts]
 FileMenu_LoadDeck1 Ctrl+o

--- a/res/keyboard/it_IT.kbd.cfg
+++ b/res/keyboard/it_IT.kbd.cfg
@@ -19,10 +19,10 @@ start_stop Shift+p
 back Alt+Left
 fwd Alt+Right
 
-[QuickEffectRack1_[Channel1]_Effect1]
+[QuickEffectRack1_[Channel1]]
 enabled 5
 
-[QuickEffectRack1_[Channel2]_Effect1]
+[QuickEffectRack1_[Channel2]]
 enabled 0
 
 [EqualizerRack1_[Channel1]_Effect1]
@@ -136,12 +136,6 @@ loop_double o
 passthrough Ctrl+k
 vinylcontrol_mode Ctrl+Shift+U
 vinylcontrol_cueing Ctrl+Alt+U
-
-[QuickEffectRack1_[Channel1]_Effect1]
-enabled 5
-
-[QuickEffectRack1_[Channel2]_Effect1]
-enabled 0
 
 [KeyboardShortcuts]
 FileMenu_LoadDeck1 Ctrl+o

--- a/res/keyboard/ru_RU.kbd.cfg
+++ b/res/keyboard/ru_RU.kbd.cfg
@@ -19,10 +19,10 @@ start_stop З
 back Alt+Left
 fwd Alt+Right
 
-[QuickEffectRack1_[Channel1]_Effect1]
+[QuickEffectRack1_[Channel1]]
 enabled 5
 
-[QuickEffectRack1_[Channel2]_Effect1]
+[QuickEffectRack1_[Channel2]]
 enabled 0
 
 [EqualizerRack1_[Channel1]_Effect1]
@@ -136,12 +136,6 @@ loop_double щ
 passthrough Ctrl+л
 vinylcontrol_mode Ctrl+Shift+Г
 vinylcontrol_cueing Ctrl+Alt+Г
-
-[QuickEffectRack1_[Channel1]_Effect1]
-enabled 5
-
-[QuickEffectRack1_[Channel2]_Effect1]
-enabled 0
 
 [KeyboardShortcuts]
 FileMenu_LoadDeck1 Ctrl+o


### PR DESCRIPTION
* update to use **chain** toggle, not Effect1 toggle (Effects refactoring)
* remove redundant mappings
* fix Czech Quick Effect mapping:  is `é` (`0`in _en_ and many others) not `ž` (= `6`)