### PR TITLE
Hdpi rounding for GLSL waveforms 

### DIFF
--- a/src/waveform/renderers/allshader/waveformrenderbeat.cpp
+++ b/src/waveform/renderers/allshader/waveformrenderbeat.cpp
@@ -41,6 +41,8 @@ void WaveformRenderBeat::paintGL() {
         return;
     }
 
+    const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
+
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
@@ -91,9 +93,7 @@ void WaveformRenderBeat::paintGL() {
         double xBeatPoint =
                 m_waveformRenderer->transformSamplePositionInRendererWorld(beatPosition);
 
-        xBeatPoint = std::floor(xBeatPoint);
-
-        xBeatPoint -= 0.5;
+        xBeatPoint = qRound(xBeatPoint * devicePixelRatio) / devicePixelRatio;
 
         const float x1 = static_cast<float>(xBeatPoint);
         const float x2 = x1 + 1.f;

--- a/src/waveform/renderers/allshader/waveformrendererfiltered.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererfiltered.cpp
@@ -68,7 +68,8 @@ void WaveformRendererFiltered::paintGL() {
     const float heightFactor = allGain * halfBreadth / m_maxValue;
 
     // Effective visual frame for x
-    double xVisualFrame = firstVisualFrame;
+    double xVisualFrame = qRound(firstVisualFrame / visualIncrementPerPixel) *
+            visualIncrementPerPixel;
 
     const int numVerticesPerLine = 6; // 2 triangles
 

--- a/src/waveform/renderers/allshader/waveformrendererhsv.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererhsv.cpp
@@ -71,7 +71,8 @@ void WaveformRendererHSV::paintGL() {
     const float heightFactor = allGain * halfBreadth / m_maxValue;
 
     // Effective visual frame for x
-    double xVisualFrame = firstVisualFrame;
+    double xVisualFrame = qRound(firstVisualFrame / visualIncrementPerPixel) *
+            visualIncrementPerPixel;
 
     const int numVerticesPerLine = 6; // 2 triangles
 

--- a/src/waveform/renderers/allshader/waveformrendererlrrgb.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererlrrgb.cpp
@@ -85,7 +85,8 @@ void WaveformRendererLRRGB::paintGL() {
     const float high_b = static_cast<float>(m_rgbHighColor_b);
 
     // Effective visual frame for x
-    double xVisualFrame = firstVisualFrame;
+    double xVisualFrame = qRound(firstVisualFrame / visualIncrementPerPixel) *
+            visualIncrementPerPixel;
 
     const int numVerticesPerLine = 6; // 2 triangles
 

--- a/src/waveform/renderers/allshader/waveformrendererrgb.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererrgb.cpp
@@ -84,7 +84,8 @@ void WaveformRendererRGB::paintGL() {
     const float high_b = static_cast<float>(m_rgbHighColor_b);
 
     // Effective visual frame for x
-    double xVisualFrame = firstVisualFrame;
+    double xVisualFrame = qRound(firstVisualFrame / visualIncrementPerPixel) *
+            visualIncrementPerPixel;
 
     const int numVerticesPerLine = 6; // 2 triangles
 

--- a/src/waveform/renderers/allshader/waveformrenderersimple.cpp
+++ b/src/waveform/renderers/allshader/waveformrenderersimple.cpp
@@ -73,7 +73,8 @@ void WaveformRendererSimple::paintGL() {
     const float heightFactor = allGain * halfBreadth / m_maxValue;
 
     // Effective visual frame for x, which we will increment for each pixel advanced
-    double xVisualFrame = firstVisualFrame;
+    double xVisualFrame = qRound(firstVisualFrame / visualIncrementPerPixel) *
+            visualIncrementPerPixel;
 
     const int numVerticesPerLine = 6; // 2 triangles
 

--- a/src/waveform/renderers/allshader/waveformrendermark.cpp
+++ b/src/waveform/renderers/allshader/waveformrendermark.cpp
@@ -169,9 +169,9 @@ void allshader::WaveformRenderMark::paintGL() {
 
         const double samplePosition = pMark->getSamplePosition();
         if (samplePosition != Cue::kNoPosition) {
-            const float currentMarkPoint = std::floor(static_cast<float>(
+            float currentMarkPoint = static_cast<float>(
                     m_waveformRenderer->transformSamplePositionInRendererWorld(
-                            samplePosition)));
+                            samplePosition));
             const double sampleEndPosition = pMark->getSampleEndPosition();
 
             // Pixmaps are expected to have the mark stroke at the center,
@@ -179,6 +179,7 @@ void allshader::WaveformRenderMark::paintGL() {
             // exactly at the sample position.
             const float markHalfWidth = pTexture->width() / devicePixelRatio / 2.f;
             const float drawOffset = currentMarkPoint - markHalfWidth;
+            currentMarkPoint = qRound(drawOffset * devicePixelRatio) / devicePixelRatio;
 
             bool visible = false;
             // Check if the current point needs to be displayed.
@@ -192,11 +193,11 @@ void allshader::WaveformRenderMark::paintGL() {
             // Check if the range needs to be displayed.
             if (samplePosition != sampleEndPosition && sampleEndPosition != Cue::kNoPosition) {
                 DEBUG_ASSERT(samplePosition < sampleEndPosition);
-                const float currentMarkEndPoint = std::floor(static_cast<
+                const float currentMarkEndPoint = static_cast<
                         float>(
                         m_waveformRenderer
                                 ->transformSamplePositionInRendererWorld(
-                                        sampleEndPosition)));
+                                        sampleEndPosition));
 
                 if (visible || currentMarkEndPoint > 0) {
                     QColor color = pMark->fillColor();

--- a/src/waveform/renderers/waveformwidgetrenderer.h
+++ b/src/waveform/renderers/waveformwidgetrenderer.h
@@ -71,11 +71,6 @@ class WaveformWidgetRenderer {
         return m_audioSamplePerPixel;
     }
 
-    // those function replace at its best sample position to an admissible
-    // sample position according to the current visual resampling
-    // this make mark and signal deterministic
-    void regulateVisualSample(int& sampleIndex) const;
-
     // this "regulate" against visual sampling to make the position in widget
     // stable and deterministic
     // Transform sample index to pixel in track.
@@ -87,12 +82,8 @@ class WaveformWidgetRenderer {
             // 1 pixel off.
             return m_playMarkerPosition * getLength();
         }
-        const double relativePosition = samplePosition / m_trackSamples;
-        return transformPositionInRendererWorld(relativePosition);
-    }
-    // Transform position (percentage of track) to pixel in track.
-    inline double transformPositionInRendererWorld(double position) const {
-        return m_trackPixelCount * (position - m_firstDisplayedPosition);
+        return (samplePosition - m_firstDisplayedPosition * m_trackSamples) /
+                2 / m_audioSamplePerPixel;
     }
 
     int getPlayPosVSample() const {


### PR DESCRIPTION
This fixes the rounding to device pixel to avoid visual interference at 125 % display scaling. 
Fixes one part of https://github.com/mixxxdj/mixxx/issues/12601