### PR TITLE
(fix) hotcue_X_color control: color not stored in cue

### DIFF
--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -2477,11 +2477,6 @@ HotcueControl::HotcueControl(const QString& group, int hotcueIndex)
             this,
             &HotcueControl::slotHotcueColorChangeRequest,
             Qt::DirectConnection);
-    connect(m_hotcueColor.get(),
-            &ControlObject::valueChanged,
-            this,
-            &HotcueControl::slotHotcueColorChanged,
-            Qt::DirectConnection);
 
     m_hotcueSet = std::make_unique<ControlPushButton>(keyForControl(QStringLiteral("set")));
     connect(m_hotcueSet.get(),
@@ -2649,16 +2644,12 @@ void HotcueControl::slotHotcueEndPositionChanged(double newEndPosition) {
     emit hotcueEndPositionChanged(this, newEndPosition);
 }
 
-void HotcueControl::slotHotcueColorChangeRequest(double color) {
-    if (color < 0 || color > 0xFFFFFF) {
-        qWarning() << "slotHotcueColorChanged got invalid value:" << color;
+void HotcueControl::slotHotcueColorChangeRequest(double newColor) {
+    if (newColor < 0 || newColor > 0xFFFFFF) {
+        qWarning() << "slotHotcueColorChangeRequest got invalid value:" << newColor;
         return;
     }
-    // qDebug() << "HotcueControl::slotHotcueColorChangeRequest" << color;
-    m_hotcueColor->setAndConfirm(color);
-}
-
-void HotcueControl::slotHotcueColorChanged(double newColor) {
+    // qDebug() << "HotcueControl::slotHotcueColorChangeRequest" << newColor;
     if (!m_pCue) {
         return;
     }
@@ -2669,7 +2660,7 @@ void HotcueControl::slotHotcueColorChanged(double newColor) {
     }
 
     m_pCue->setColor(*color);
-    emit hotcueColorChanged(this, newColor);
+    m_hotcueColor->setAndConfirm(newColor);
 }
 
 mixxx::audio::FramePos HotcueControl::getPosition() const {

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -138,7 +138,6 @@ class HotcueControl : public QObject {
     void slotHotcueEndPositionChanged(double newPosition);
     void slotHotcuePositionChanged(double newPosition);
     void slotHotcueColorChangeRequest(double newColor);
-    void slotHotcueColorChanged(double newColor);
 
   signals:
     void hotcueSet(HotcueControl* pHotcue, double v, HotcueSetMode mode);
@@ -152,7 +151,6 @@ class HotcueControl : public QObject {
     void hotcueClear(HotcueControl* pHotcue, double v);
     void hotcuePositionChanged(HotcueControl* pHotcue, double newPosition);
     void hotcueEndPositionChanged(HotcueControl* pHotcue, double newEndPosition);
-    void hotcueColorChanged(HotcueControl* pHotcue, double newColor);
     void hotcuePlay(double v);
 
   private:


### PR DESCRIPTION
Fixes the hotcue color issue reported in https://mixxx.zulipchat.com/#narrow/stream/113295-controller-mapping/topic/Hotcue.20setting.20script

For some reason the valueChanged() signal is not emitted, therefore slotHotcueColorChanged() not being called and the new color not stored in the cue. The color control is reset as soon as anothe cue is set (track emits cuesUpdated() adn cues are reloaded from track, default color).
Reproducible with Qt5 and Qt6.
without this fix:
https://github.com/mixxxdj/mixxx/assets/5934199/aad6ae0f-2ea3-4825-ae77-7da8ba95b22b


For testing, use this mapping with virtual MIDI device:
load a track to deck1, click Eject on deck2
https://gist.github.com/ronso0/471efe54370a32fa9eb26a571a818dd5