### PR TITLE
Tracks: custom text color for played tracks (qss)

### DIFF
--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -247,11 +247,14 @@ WTrackTableView,
 WTrackTableView QCheckBox:focus {
   outline: 1px solid #D6D6D6;
 }
-/* This uses a custom qproperty to set the focus border
-  for Color and Cover Art cells, 1px solid, sharp corners.
-  See src/library/tableitemdelegate.cpp */
 WTrackTableView {
+  /* This uses a custom qproperty to set the focus border
+     for Color and Cover Art cells, 1px solid, sharp corners.
+     See src/library/tableitemdelegate.cpp */
   qproperty-focusBorderColor: #D6D6D6;
+  /* This is the color used to paint the text of played tracks.
+     BaseTrackTableModel::data() uses this to override Qt::ForegroundRole (QBrush). */
+  qproperty-playedInactiveColor: #555;
 }
 
 WTrackTableView:focus,

--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -2119,7 +2119,13 @@ WTrackTableView QCheckBox:focus {
   for Color and Cover Art cells, 1px solid, sharp corners.
   See src/library/tableitemdelegate.cpp */
 WTrackTableView {
+  /* This uses a custom qproperty to set the focus border
+     for Color and Cover Art cells, 1px solid, sharp corners.
+     See src/library/tableitemdelegate.cpp */
   qproperty-focusBorderColor: #fff;
+  /* This is the color used to paint the text of played tracks.
+     BaseTrackTableModel::data() uses this to override Qt::ForegroundRole (QBrush). */
+  qproperty-playedInactiveColor: #555;
 }
 
 WLibrarySidebar {

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -2586,11 +2586,14 @@ WTrackTableView,
 WTrackTableView QCheckBox:focus {
   outline: 1px solid #fff;
 }
-/* This uses a custom qproperty to set the focus border
-  for Color and Cover Art cells, 1px solid, sharp corners.
-  See src/library/tableitemdelegate.cpp */
 WTrackTableView {
+  /* This uses a custom qproperty to set the focus border
+     for Color and Cover Art cells, 1px solid, sharp corners.
+     See src/library/tableitemdelegate.cpp */
   qproperty-focusBorderColor: #fff;
+  /* This is the color used to paint the text of played tracks.
+     BaseTrackTableModel::data() uses this to override Qt::ForegroundRole (QBrush). */
+  qproperty-playedInactiveColor: #555;
 }
 
 /* Table cell in edit mode */

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -508,7 +508,13 @@ WTrackTableView QCheckBox:focus {
   for Color and Cover Art cells, 1px solid, sharp corners.
   See src/library/tableitemdelegate.cpp */
 WTrackTableView {
+  /* This uses a custom qproperty to set the focus border
+     for Color and Cover Art cells, 1px solid, sharp corners.
+     See src/library/tableitemdelegate.cpp */
   qproperty-focusBorderColor: #c9c9c9;
+  /* This is the color used to paint the text of played tracks.
+     BaseTrackTableModel::data() uses this to override Qt::ForegroundRole (QBrush). */
+  qproperty-playedInactiveColor: #555;
 }
 
   /* Table cell in edit mode */

--- a/res/skins/Shade/style_dark.qss
+++ b/res/skins/Shade/style_dark.qss
@@ -195,7 +195,13 @@ WTrackTableView QCheckBox:focus {
   for Color and Cover Art cells, 1px solid, sharp corners.
   See src/library/tableitemdelegate.cpp */
 WTrackTableView {
+  /* This uses a custom qproperty to set the focus border
+     for Color and Cover Art cells, 1px solid, sharp corners.
+     See src/library/tableitemdelegate.cpp */
   qproperty-focusBorderColor: #ccc;
+  /* This is the color used to paint the text of played tracks.
+     BaseTrackTableModel::data() uses this to override Qt::ForegroundRole (QBrush). */
+  qproperty-playedInactiveColor: #555;
 }
 
   /* Table cell in edit mode */

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -2598,7 +2598,13 @@ WTrackTableView QCheckBox:focus {
   for Color and Cover Art cells, 1px solid, sharp corners.
   See src/library/tableitemdelegate.cpp */
 WTrackTableView {
+  /* This uses a custom qproperty to set the focus border
+     for Color and Cover Art cells, 1px solid, sharp corners.
+     See src/library/tableitemdelegate.cpp */
   qproperty-focusBorderColor: #fff;
+  /* This is the color used to paint the text of played tracks.
+     BaseTrackTableModel::data() uses this to override Qt::ForegroundRole (QBrush). */
+  qproperty-playedInactiveColor: #555;
 }
 
   /* Table cell in edit mode */

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -124,7 +124,8 @@ BaseTrackTableModel::BaseTrackTableModel(
           TrackModel(cloneDatabase(pTrackCollectionManager), settingsNamespace),
           m_pTrackCollectionManager(pTrackCollectionManager),
           m_previewDeckGroup(PlayerManager::groupForPreviewDeck(0)),
-          m_backgroundColorOpacity(WLibrary::kDefaultTrackTableBackgroundColorOpacity) {
+          m_backgroundColorOpacity(WLibrary::kDefaultTrackTableBackgroundColorOpacity),
+          m_playedInactiveColor(QColor::fromRgb(WTrackTableView::kDefaultPlayedInactiveColorHex)) {
     connect(&pTrackCollectionManager->internalCollection()->getTrackDAO(),
             &TrackDAO::forceModelUpdate,
             this,
@@ -395,6 +396,15 @@ QAbstractItemDelegate* BaseTrackTableModel::delegateForColumn(
         return nullptr;
     }
     m_backgroundColorOpacity = pTableView->getBackgroundColorOpacity();
+    // This is the color used for the text of played tracks.
+    // data() uses this to compose the ForegroundRole QBrush if 'played' is checked.
+    m_playedInactiveColor = pTableView->getPlayedInactiveColor();
+    connect(pTableView,
+            &WTrackTableView::playedInactiveColorChanged,
+            this,
+            [this](QColor col) {
+                m_playedInactiveColor = col;
+            });
     if (index == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_RATING)) {
         return new StarDelegate(pTableView);
     } else if (index == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_BPM)) {
@@ -447,6 +457,16 @@ QVariant BaseTrackTableModel::data(
         DEBUG_ASSERT(m_backgroundColorOpacity <= 1.0);
         bgColor.setAlphaF(static_cast<float>(m_backgroundColorOpacity));
         return QBrush(bgColor);
+    } else if (role == Qt::ForegroundRole) {
+        // Custom text color for played tracks
+        auto playedRaw = rawSiblingValue(
+                index,
+                ColumnCache::COLUMN_LIBRARYTABLE_PLAYED);
+        if (!playedRaw.isNull() &&
+                playedRaw.canConvert<bool>() &&
+                playedRaw.toBool()) {
+            return QVariant::fromValue(m_playedInactiveColor);
+        }
     }
 
     // Only retrieve a value for supported roles

--- a/src/library/basetracktablemodel.h
+++ b/src/library/basetracktablemodel.h
@@ -268,6 +268,7 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
     const QString m_previewDeckGroup;
 
     double m_backgroundColorOpacity;
+    QColor m_playedInactiveColor;
 
     ColumnCache m_columnCache;
 

--- a/src/library/bpmdelegate.cpp
+++ b/src/library/bpmdelegate.cpp
@@ -81,6 +81,28 @@ void BPMDelegate::paintItem(QPainter* painter,const QStyleOptionViewItem &option
     QStyleOptionViewItem opt = option;
     initStyleOption(&opt, index);
 
+    // The checkbox uses the QTableView's qss style, therefore it's not picking
+    //  up the 'played' text color via ForegroundRole from BaseTrackTableModel::data().
+    // Enforce it with an explicit stylesheet. Note: the stylesheet persists so
+    // we need to reset it to normal/highlighted.
+    QColor textColor;
+    auto dat = index.data(Qt::ForegroundRole);
+    if (dat.canConvert<QColor>()) {
+        textColor = dat.value<QColor>();
+    } else {
+        if (option.state & QStyle::State_Selected) {
+            textColor = option.palette.color(QPalette::Normal, QPalette::HighlightedText);
+        } else {
+            textColor = option.palette.color(QPalette::Normal, QPalette::Text);
+            // qWarning() << "     !! BPM col:" << textColor.name(QColor::HexRgb);
+        }
+    }
+    if (textColor.isValid()) {
+        m_pCheckBox->setStyleSheet(QStringLiteral(
+                "#LibraryBPMButton::item { color: %1; }")
+                                           .arg(textColor.name(QColor::HexRgb)));
+    }
+
     QStyle* style = m_pTableView->style();
     if (style != nullptr) {
         style->drawControl(QStyle::CE_ItemViewItem, &opt, painter, m_pCheckBox);

--- a/src/library/colordelegate.cpp
+++ b/src/library/colordelegate.cpp
@@ -28,6 +28,6 @@ void ColorDelegate::paintItem(
 
     // Draw a border if the color cell has focus
     if (option.state & QStyle::State_HasFocus) {
-        drawBorder(painter, m_pFocusBorderColor, option.rect);
+        drawBorder(painter, m_focusBorderColor, option.rect);
     }
 }

--- a/src/library/coverartdelegate.cpp
+++ b/src/library/coverartdelegate.cpp
@@ -163,6 +163,6 @@ void CoverArtDelegate::paintItem(
 
     // Draw a border if the cover art cell has focus
     if (option.state & QStyle::State_HasFocus) {
-        drawBorder(painter, m_pFocusBorderColor, option.rect);
+        drawBorder(painter, m_focusBorderColor, option.rect);
     }
 }

--- a/src/library/stardelegate.cpp
+++ b/src/library/stardelegate.cpp
@@ -44,7 +44,7 @@ QWidget* StarDelegate::createEditor(QWidget* parent,
     initStyleOption(&newOption, index);
 
     StarEditor* editor =
-            new StarEditor(parent, m_pTableView, index, newOption, m_pFocusBorderColor);
+            new StarEditor(parent, m_pTableView, index, newOption, m_focusBorderColor);
     connect(editor,
             &StarEditor::editingFinished,
             this,

--- a/src/library/stareditor.cpp
+++ b/src/library/stareditor.cpp
@@ -28,7 +28,7 @@ StarEditor::StarEditor(QWidget* parent,
           m_pTableView(pTableView),
           m_index(index),
           m_styleOption(option),
-          m_pFocusBorderColor(focusBorderColor),
+          m_focusBorderColor(focusBorderColor),
           m_starCount(StarRating::kMinStarCount) {
     DEBUG_ASSERT(m_pTableView);
     setMouseTracking(true);
@@ -93,7 +93,7 @@ void StarEditor::paintEvent(QPaintEvent*) {
 
     // Draw a border if the color cell is selected
     if (m_styleOption.state & QStyle::State_HasFocus) {
-        TableItemDelegate::drawBorder(&painter, m_pFocusBorderColor, m_styleOption.rect);
+        TableItemDelegate::drawBorder(&painter, m_focusBorderColor, m_styleOption.rect);
     }
 }
 

--- a/src/library/stareditor.h
+++ b/src/library/stareditor.h
@@ -46,7 +46,7 @@ class StarEditor : public QWidget {
     QTableView* m_pTableView;
     QModelIndex m_index;
     QStyleOptionViewItem m_styleOption;
-    QColor m_pFocusBorderColor;
+    QColor m_focusBorderColor;
     StarRating m_starRating;
     int m_starCount;
 };

--- a/src/library/tableitemdelegate.cpp
+++ b/src/library/tableitemdelegate.cpp
@@ -48,7 +48,20 @@ void TableItemDelegate::paint(
     if (option.state & QStyle::State_Selected) {
         painter->setBrush(option.palette.color(cg, QPalette::HighlightedText));
     } else {
-        painter->setBrush(option.palette.color(cg, QPalette::Text));
+        // This gets the custom 'played' text color from BaseTrackTableModel
+        // depending on check state of the 'played' column.
+        // Note that we need to do this again in BPMDelegate which uses the
+        // style of the TableView.
+        auto playedColorData = index.data(Qt::ForegroundRole);
+        if (playedColorData.canConvert<QColor>()) {
+            QColor playedColor = playedColorData.value<QColor>();
+            // for the star rating polygons
+            painter->setBrush(playedColor);
+            // for the 'location' text
+            painter->setPen(playedColor);
+        } else {
+            painter->setBrush(option.palette.color(cg, QPalette::Text));
+        }
     }
 
     QStyle* style = m_pTableView->style();

--- a/src/library/tableitemdelegate.cpp
+++ b/src/library/tableitemdelegate.cpp
@@ -17,6 +17,15 @@ TableItemDelegate::TableItemDelegate(QTableView* pTableView)
         //   qproperty-focusBorderColor: red;
         // }
         m_focusBorderColor = pTrackTableView->getFocusBorderColor();
+        // For some reason the color is not initialized from the stylesheet for
+        // some WTrackTableViews (in DlgAutoDJ, DlgAnalysis, ...)
+        // Listen to the property changed signal.
+        connect(pTrackTableView,
+                &WTrackTableView::focusBorderColorChanged,
+                this,
+                [this](QColor col) {
+                    m_focusBorderColor = col;
+                });
     }
 }
 

--- a/src/library/tableitemdelegate.cpp
+++ b/src/library/tableitemdelegate.cpp
@@ -16,7 +16,7 @@ TableItemDelegate::TableItemDelegate(QTableView* pTableView)
         // WTrackTableView {
         //   qproperty-focusBorderColor: red;
         // }
-        m_pFocusBorderColor = pTrackTableView->getFocusBorderColor();
+        m_focusBorderColor = pTrackTableView->getFocusBorderColor();
     }
 }
 

--- a/src/library/tableitemdelegate.h
+++ b/src/library/tableitemdelegate.h
@@ -36,6 +36,6 @@ class TableItemDelegate : public QStyledItemDelegate {
     // Having this here avoids including QTableView there.
     int columnWidth(const QModelIndex &index) const;
 
-    QColor m_pFocusBorderColor;
+    QColor m_focusBorderColor;
     QTableView* m_pTableView;
 };

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -38,9 +38,6 @@ const ConfigKey kVScrollBarPosConfigKey{
         QStringLiteral("[Library]"),
         QStringLiteral("VScrollBarPos")};
 
-// Default color for the focus border of TableItemDelegates
-const QColor kDefaultFocusBorderColor = Qt::white;
-
 } // anonymous namespace
 
 WTrackTableView::WTrackTableView(QWidget* parent,
@@ -52,7 +49,8 @@ WTrackTableView::WTrackTableView(QWidget* parent,
           m_pConfig(pConfig),
           m_pLibrary(pLibrary),
           m_backgroundColorOpacity(backgroundColorOpacity),
-          m_focusBorderColor(kDefaultFocusBorderColor),
+          // Default color for the focus border of TableItemDelegates
+          m_focusBorderColor(Qt::white),
           m_sorting(sorting),
           m_selectionChangedSinceLastGuiTick(true),
           m_loadCachedOnly(false) {

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -52,7 +52,7 @@ WTrackTableView::WTrackTableView(QWidget* parent,
           m_pConfig(pConfig),
           m_pLibrary(pLibrary),
           m_backgroundColorOpacity(backgroundColorOpacity),
-          m_pFocusBorderColor(kDefaultFocusBorderColor),
+          m_focusBorderColor(kDefaultFocusBorderColor),
           m_sorting(sorting),
           m_selectionChangedSinceLastGuiTick(true),
           m_loadCachedOnly(false) {

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -51,6 +51,7 @@ WTrackTableView::WTrackTableView(QWidget* parent,
           m_backgroundColorOpacity(backgroundColorOpacity),
           // Default color for the focus border of TableItemDelegates
           m_focusBorderColor(Qt::white),
+          m_playedInactiveColor(QColor::fromRgb(kDefaultPlayedInactiveColorHex)),
           m_sorting(sorting),
           m_selectionChangedSinceLastGuiTick(true),
           m_loadCachedOnly(false) {

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -51,9 +51,9 @@ class WTrackTableView : public WLibraryTableView {
         return m_backgroundColorOpacity;
     }
 
-    Q_PROPERTY(QColor focusBorderColor MEMBER m_pFocusBorderColor DESIGNABLE true);
+    Q_PROPERTY(QColor focusBorderColor MEMBER m_focusBorderColor DESIGNABLE true);
     QColor getFocusBorderColor() const {
-        return m_pFocusBorderColor;
+        return m_focusBorderColor;
     }
 
   signals:
@@ -124,7 +124,7 @@ class WTrackTableView : public WLibraryTableView {
     parented_ptr<WTrackMenu> m_pTrackMenu;
 
     const double m_backgroundColorOpacity;
-    QColor m_pFocusBorderColor;
+    QColor m_focusBorderColor;
     bool m_sorting;
 
     // Control the delay to load a cover art.

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -59,9 +59,21 @@ class WTrackTableView : public WLibraryTableView {
         return m_focusBorderColor;
     }
 
+    // Default color for played tracks' text color. #555555, bit darker than Qt::darkgray.
+    // BaseTrackTableModel uses this for the ForegroundRole of played tracks.
+    static constexpr uint kDefaultPlayedInactiveColorHex = 555555;
+    Q_PROPERTY(QColor playedInactiveColor
+                    MEMBER m_playedInactiveColor
+                            NOTIFY playedInactiveColorChanged
+                                    DESIGNABLE true);
+    QColor getPlayedInactiveColor() const {
+        return m_playedInactiveColor;
+    }
+
   signals:
     void trackMenuVisible(bool visible);
     void focusBorderColorChanged(QColor col);
+    void playedInactiveColorChanged(QColor col);
 
   public slots:
     void loadTrackModel(QAbstractItemModel* model, bool restoreState = false);
@@ -129,6 +141,7 @@ class WTrackTableView : public WLibraryTableView {
 
     const double m_backgroundColorOpacity;
     QColor m_focusBorderColor;
+    QColor m_playedInactiveColor;
     bool m_sorting;
 
     // Control the delay to load a cover art.

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -51,13 +51,17 @@ class WTrackTableView : public WLibraryTableView {
         return m_backgroundColorOpacity;
     }
 
-    Q_PROPERTY(QColor focusBorderColor MEMBER m_focusBorderColor DESIGNABLE true);
+    Q_PROPERTY(QColor focusBorderColor
+                    MEMBER m_focusBorderColor
+                            NOTIFY focusBorderColorChanged
+                                    DESIGNABLE true);
     QColor getFocusBorderColor() const {
         return m_focusBorderColor;
     }
 
   signals:
     void trackMenuVisible(bool visible);
+    void focusBorderColorChanged(QColor col);
 
   public slots:
     void loadTrackModel(QAbstractItemModel* model, bool restoreState = false);


### PR DESCRIPTION
Quick POC, fixing #5911 

Set the custom property `qproperty-playedInactiveColor` in qss for painting the text of played tracks.
```
WTrackTableView {
  qproperty-playedInactiveColor: #555;
}
```
`BaseTrackTableModel::data()` uses this to override Qt::ForegroundRole (QBrush).
Works as desired, only the BPM delegate doesn't want to play along. **edit:** fix with explicit stylesheet.
![image](https://github.com/mixxxdj/mixxx/assets/5934199/b55b1d99-541f-4f67-83a6-b8fee7725eb6)

Can be tested, but is still WIP (PaleMoon only) and I'm cleaning it up a bit. Will rebase onto main.

Alternatively, this could be an opacity factor (like that for the track colors), but I don't see a way to get that in the SQL model. I think with this we could also modify the 'selected' color.
I did a quick test by returning a TableItemDelegate for _every column_ and do the painting there, but it's not as straight forward as the current implementation.
___
While testing it I noticed that the focus border added in #3172 was only working for Tracks and other top-level features -- in AutoDJ, Analysis etc. it was the default color (WTrackTableView nested in LibraryView :shrug: ).
Fixed by connecting the property changed signal and listening to that where required. 
