### PR TITLE
Use Taglib1 package on Linux if found 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2939,7 +2939,7 @@ target_link_libraries(mixxx-lib PRIVATE SoundTouch::SoundTouch)
 
 # TagLib
 find_package(TagLib 1.11 REQUIRED)
-target_link_libraries(mixxx-lib PRIVATE TagLib::TagLib)
+target_link_libraries(mixxx-lib PUBLIC TagLib::TagLib)
 if (NOT TagLib_VERSION VERSION_LESS 2.0.0)
     message(FATAL_ERROR "Installed Taglib ${TagLib_VERSION} is not supported. Use Version >= 1.11 and < 2.0 and its development headers.")
     # Dear package maintainer: Do not patch away this fatal error

--- a/cmake/modules/FindChromaprint.cmake
+++ b/cmake/modules/FindChromaprint.cmake
@@ -52,14 +52,14 @@ endif()
 
 find_path(Chromaprint_INCLUDE_DIR
   NAMES chromaprint.h
-  PATHS ${PC_Chromaprint_INCLUDE_DIRS}
+  HINTS ${PC_Chromaprint_INCLUDE_DIRS}
   PATH_SUFFIXES chromaprint
   DOC "Chromaprint include directory")
 mark_as_advanced(Chromaprint_INCLUDE_DIR)
 
 find_library(Chromaprint_LIBRARY
   NAMES chromaprint chromaprint_p
-  PATHS ${PC_Chromaprint_LIBRARY_DIRS}
+  HINTS ${PC_Chromaprint_LIBRARY_DIRS}
   DOC "Chromaprint library"
 )
 mark_as_advanced(Chromaprint_LIBRARY)

--- a/cmake/modules/FindDjInterop.cmake
+++ b/cmake/modules/FindDjInterop.cmake
@@ -50,13 +50,13 @@ endif()
 
 find_path(DjInterop_INCLUDE_DIR
   NAMES djinterop/djinterop.hpp
-  PATHS ${PC_DjInterop_INCLUDE_DIRS}
+  HINTS ${PC_DjInterop_INCLUDE_DIRS}
   DOC "DjInterop include directory")
 mark_as_advanced(DjInterop_INCLUDE_DIR)
 
 find_library(DjInterop_LIBRARY
   NAMES djinterop
-  PATHS ${PC_DjInterop_LIBRARY_DIRS}
+  HINTS ${PC_DjInterop_LIBRARY_DIRS}
   DOC "DjInterop library"
 )
 mark_as_advanced(DjInterop_LIBRARY)

--- a/cmake/modules/FindEbur128.cmake
+++ b/cmake/modules/FindEbur128.cmake
@@ -50,14 +50,14 @@ endif()
 
 find_path(Ebur128_INCLUDE_DIR
   NAMES ebur128.h
-  PATHS ${PC_Ebur128_INCLUDE_DIRS}
+  HINTS ${PC_Ebur128_INCLUDE_DIRS}
   PATH_SUFFIXES ebur128
   DOC "Ebur128 include directory")
 mark_as_advanced(Ebur128_INCLUDE_DIR)
 
 find_library(Ebur128_LIBRARY
   NAMES ebur128
-  PATHS ${PC_Ebur128_LIBRARY_DIRS}
+  HINTS ${PC_Ebur128_LIBRARY_DIRS}
   DOC "Ebur128 library"
 )
 mark_as_advanced(Ebur128_LIBRARY)

--- a/cmake/modules/FindFLAC.cmake
+++ b/cmake/modules/FindFLAC.cmake
@@ -52,13 +52,13 @@ endif()
 
 find_path(FLAC_INCLUDE_DIR
   NAMES FLAC/all.h
-  PATHS ${PC_FLAC_INCLUDE_DIRS}
+  HINTS ${PC_FLAC_INCLUDE_DIRS}
   DOC "FLAC include directory")
 mark_as_advanced(FLAC_INCLUDE_DIR)
 
 find_library(FLAC_LIBRARY
   NAMES FLAC
-  PATHS ${PC_FLAC_LIBRARY_DIRS}
+  HINTS ${PC_FLAC_LIBRARY_DIRS}
   DOC "FLAC library"
 )
 mark_as_advanced(FLAC_LIBRARY)

--- a/cmake/modules/FindGPerfTools.cmake
+++ b/cmake/modules/FindGPerfTools.cmake
@@ -57,26 +57,26 @@ endif()
 
 find_path(GPerfTools_TCMALLOC_INCLUDE_DIR
   NAMES gperftools/tcmalloc.h
-  PATHS ${PC_GPerfTools_TCMALLOC_INCLUDE_DIRS}
+  HINTS ${PC_GPerfTools_TCMALLOC_INCLUDE_DIRS}
   DOC "tcmalloc include directory")
 mark_as_advanced(GPerfTools_TCMALLOC_INCLUDE_DIR)
 
 find_library(GPerfTools_TCMALLOC_LIBRARY
   NAMES tcmalloc
-  PATHS ${PC_GPerfTools_TCMALLOC_LIBRARY_DIRS}
+  HINTS ${PC_GPerfTools_TCMALLOC_LIBRARY_DIRS}
   DOC "tcmalloc library"
 )
 mark_as_advanced(GPerfTools_TCMALLOC_LIBRARY)
 
 find_path(GPerfTools_PROFILER_INCLUDE_DIR
   NAMES gperftools/profiler.h
-  PATHS ${PC_GPerfTools_PROFILER_INCLUDE_DIRS}
+  HINTS ${PC_GPerfTools_PROFILER_INCLUDE_DIRS}
   DOC "profiler include directory")
 mark_as_advanced(GPerfTools_PROFILER_INCLUDE_DIR)
 
 find_library(GPerfTools_PROFILER_LIBRARY
   NAMES profiler
-  PATHS ${PC_GPerfTools_PROFILER_LIBRARY_DIRS}
+  HINTS ${PC_GPerfTools_PROFILER_LIBRARY_DIRS}
   DOC "profiler library"
 )
 mark_as_advanced(GPerfTools_PROFILER_LIBRARY)

--- a/cmake/modules/FindID3Tag.cmake
+++ b/cmake/modules/FindID3Tag.cmake
@@ -50,14 +50,14 @@ endif()
 
 find_path(ID3Tag_INCLUDE_DIR
   NAMES id3tag.h
-  PATHS ${PC_ID3Tag_INCLUDE_DIRS}
+  HINTS ${PC_ID3Tag_INCLUDE_DIRS}
   PATH_SUFFIXES id3tag
   DOC "ID3Tag include directory")
 mark_as_advanced(ID3Tag_INCLUDE_DIR)
 
 find_library(ID3Tag_LIBRARY
   NAMES id3tag
-  PATHS ${PC_ID3Tag_LIBRARY_DIRS}
+  HINTS ${PC_ID3Tag_LIBRARY_DIRS}
   DOC "ID3Tag library"
 )
 mark_as_advanced(ID3Tag_LIBRARY)

--- a/cmake/modules/FindJACK.cmake
+++ b/cmake/modules/FindJACK.cmake
@@ -28,13 +28,13 @@ endif()
 
 find_path(JACK_INCLUDE_DIR
   NAMES jack/jack.h
-  PATHS ${PC_JACK_INCLUDE_DIRS}
+  HINTS ${PC_JACK_INCLUDE_DIRS}
   DOC "JACK include directory")
 mark_as_advanced(JACK_INCLUDE_DIR)
 
 find_library(JACK_LIBRARY
   NAMES jack
-  PATHS ${PC_JACK_LIBRARY_DIRS}
+  HINTS ${PC_JACK_LIBRARY_DIRS}
   DOC "JACK library"
 )
 mark_as_advanced(JACK_LIBRARY)

--- a/cmake/modules/FindKeyFinder.cmake
+++ b/cmake/modules/FindKeyFinder.cmake
@@ -52,13 +52,13 @@ endif()
 
 find_path(KeyFinder_INCLUDE_DIR
   NAMES keyfinder/keyfinder.h
-  PATHS ${PC_KeyFinder_INCLUDE_DIRS}
+  HINTS ${PC_KeyFinder_INCLUDE_DIRS}
   DOC "KeyFinder include directory")
 mark_as_advanced(KeyFinder_INCLUDE_DIR)
 
 find_library(KeyFinder_LIBRARY
   NAMES keyfinder
-  PATHS ${PC_KeyFinder_LIBRARY_DIRS}
+  HINTS ${PC_KeyFinder_LIBRARY_DIRS}
   DOC "KeyFinder library"
 )
 mark_as_advanced(KeyFinder_LIBRARY)

--- a/cmake/modules/FindLibUSB.cmake
+++ b/cmake/modules/FindLibUSB.cmake
@@ -51,14 +51,14 @@ endif()
 find_path(LibUSB_INCLUDE_DIR
   NAMES libusb.h
   PATH_SUFFIXES libusb libusb-1.0
-  PATHS ${PC_LibUSB_INCLUDE_DIRS}
+  HINTS ${PC_LibUSB_INCLUDE_DIRS}
   DOC "LibUSB include directory"
 )
 mark_as_advanced(LibUSB_INCLUDE_DIR)
 
 find_library(LibUSB_LIBRARY
   NAMES usb-1.0 usb
-  PATHS ${PC_LibUSB_LIBRARY_DIRS}
+  HINTS ${PC_LibUSB_LIBRARY_DIRS}
   DOC "LibUSB library"
 )
 mark_as_advanced(LibUSB_LIBRARY)

--- a/cmake/modules/FindMAD.cmake
+++ b/cmake/modules/FindMAD.cmake
@@ -50,14 +50,14 @@ endif()
 
 find_path(MAD_INCLUDE_DIR
   NAMES mad.h
-  PATHS ${PC_MAD_INCLUDE_DIRS}
+  HINTS ${PC_MAD_INCLUDE_DIRS}
   PATH_SUFFIXES mad
   DOC "MAD include directory")
 mark_as_advanced(MAD_INCLUDE_DIR)
 
 find_library(MAD_LIBRARY
   NAMES mad
-  PATHS ${PC_MAD_LIBRARY_DIRS}
+  HINTS ${PC_MAD_LIBRARY_DIRS}
   DOC "MAD library"
 )
 mark_as_advanced(MAD_LIBRARY)

--- a/cmake/modules/FindMP4.cmake
+++ b/cmake/modules/FindMP4.cmake
@@ -50,13 +50,13 @@ endif()
 
 find_path(MP4_INCLUDE_DIR
   NAMES mp4/mp4.h
-  PATHS ${PC_MP4_INCLUDE_DIRS}
+  HINTS ${PC_MP4_INCLUDE_DIRS}
   DOC "MP4 include directory")
 mark_as_advanced(MP4_INCLUDE_DIR)
 
 find_library(MP4_LIBRARY
   NAMES mp4
-  PATHS ${PC_MP4_LIBRARY_DIRS}
+  HINTS ${PC_MP4_LIBRARY_DIRS}
   DOC "MP4 library"
 )
 mark_as_advanced(MP4_LIBRARY)

--- a/cmake/modules/FindMP4v2.cmake
+++ b/cmake/modules/FindMP4v2.cmake
@@ -50,13 +50,13 @@ endif()
 
 find_path(MP4v2_INCLUDE_DIR
   NAMES mp4v2/mp4v2.h
-  PATHS ${PC_MP4v2_INCLUDE_DIRS}
+  HINTS ${PC_MP4v2_INCLUDE_DIRS}
   DOC "MP4v2 include directory")
 mark_as_advanced(MP4v2_INCLUDE_DIR)
 
 find_library(MP4v2_LIBRARY
   NAMES mp4v2
-  PATHS ${PC_MP4v2_LIBRARY_DIRS}
+  HINTS ${PC_MP4v2_LIBRARY_DIRS}
   DOC "MP4v2 library"
 )
 mark_as_advanced(MP4v2_LIBRARY)

--- a/cmake/modules/FindModplug.cmake
+++ b/cmake/modules/FindModplug.cmake
@@ -50,13 +50,13 @@ endif()
 
 find_path(Modplug_INCLUDE_DIR
   NAMES libmodplug/modplug.h
-  PATHS ${PC_Modplug_INCLUDE_DIRS}
+  HINTS ${PC_Modplug_INCLUDE_DIRS}
   DOC "Modplug include directory")
 mark_as_advanced(Modplug_INCLUDE_DIR)
 
 find_library(Modplug_LIBRARY
   NAMES modplug
-  PATHS ${PC_Modplug_LIBRARY_DIRS}
+  HINTS ${PC_Modplug_LIBRARY_DIRS}
   DOC "Modplug library"
 )
 mark_as_advanced(Modplug_LIBRARY)

--- a/cmake/modules/FindOgg.cmake
+++ b/cmake/modules/FindOgg.cmake
@@ -41,14 +41,14 @@ endif()
 
 find_path(Ogg_INCLUDE_DIR
   NAMES ogg/ogg.h
-  PATHS ${PC_Ogg_INCLUDE_DIRS}
+  HINTS ${PC_Ogg_INCLUDE_DIRS}
   DOC "Ogg include directory"
 )
 mark_as_advanced(Ogg_INCLUDE_DIR)
 
 find_library(Ogg_LIBRARY
   NAMES ogg
-  PATHS ${PC_Ogg_LIBRARY_DIRS}
+  HINTS ${PC_Ogg_LIBRARY_DIRS}
   DOC "Ogg library"
 )
 mark_as_advanced(Ogg_LIBRARY)

--- a/cmake/modules/FindOpus.cmake
+++ b/cmake/modules/FindOpus.cmake
@@ -42,13 +42,13 @@ endif()
 
 find_path(Opus_INCLUDE_DIR
   NAMES opus/opus.h
-  PATHS ${PC_Opus_INCLUDE_DIRS}
+  HINTS ${PC_Opus_INCLUDE_DIRS}
   DOC "Opus include directory")
 mark_as_advanced(Opus_INCLUDE_DIR)
 
 find_library(Opus_LIBRARY
   NAMES opus
-  PATHS ${PC_Opus_LIBRARY_DIRS}
+  HINTS ${PC_Opus_LIBRARY_DIRS}
   DOC "Opus library"
 )
 mark_as_advanced(Opus_LIBRARY)

--- a/cmake/modules/FindOpusFile.cmake
+++ b/cmake/modules/FindOpusFile.cmake
@@ -49,13 +49,13 @@ endif()
 find_path(OpusFile_INCLUDE_DIR
   NAMES opusfile.h
   PATH_SUFFIXES opus
-  PATHS ${PC_OpusFile_INCLUDE_DIRS}
+  HINTS ${PC_OpusFile_INCLUDE_DIRS}
   DOC "Opusfile include directory")
 mark_as_advanced(OpusFile_INCLUDE_DIR)
 
 find_library(OpusFile_LIBRARY
   NAMES opusfile
-  PATHS ${PC_OpusFile_LIBRARY_DIRS}
+  HINTS ${PC_OpusFile_LIBRARY_DIRS}
   DOC "Opusfile library"
 )
 mark_as_advanced(OpusFile_LIBRARY)

--- a/cmake/modules/FindPortAudio.cmake
+++ b/cmake/modules/FindPortAudio.cmake
@@ -50,19 +50,19 @@ endif()
 
 find_path(PortAudio_INCLUDE_DIR
   NAMES portaudio.h
-  PATHS ${PC_PortAudio_INCLUDE_DIRS}
+  HINTS ${PC_PortAudio_INCLUDE_DIRS}
   DOC "PortAudio include directory")
 mark_as_advanced(PortAudio_INCLUDE_DIR)
 
 # Temporary hack until https://github.com/PortAudio/portaudio/pull/635 is released.
 find_path(PortAudio_ALSA_H
   NAMES pa_linux_alsa.h
-  PATHS ${PC_PortAudio_INCLUDE_DIRS})
+  HINTS ${PC_PortAudio_INCLUDE_DIRS})
 mark_as_advanced(PortAudio_ALSA_H)
 
 find_library(PortAudio_LIBRARY
   NAMES portaudio
-  PATHS ${PC_PortAudio_LIBRARY_DIRS}
+  HINTS ${PC_PortAudio_LIBRARY_DIRS}
   DOC "PortAudio library"
 )
 mark_as_advanced(PortAudio_LIBRARY)

--- a/cmake/modules/FindShoutidjc.cmake
+++ b/cmake/modules/FindShoutidjc.cmake
@@ -52,13 +52,13 @@ endif()
 
 find_path(Shoutidjc_INCLUDE_DIR
   NAMES shoutidjc/shout.h
-  PATHS ${PC_Shout_INCLUDE_DIRS}
+  HINTS ${PC_Shout_INCLUDE_DIRS}
   DOC "Shout include directory")
 mark_as_advanced(Shoutidjc_INCLUDE_DIR)
 
 find_library(Shoutidjc_LIBRARY
   NAMES shout-idjc
-  PATHS ${PC_Shoutidjc_LIBRARY_DIRS}
+  HINTS ${PC_Shoutidjc_LIBRARY_DIRS}
   DOC "Shoutidjc library"
 )
 mark_as_advanced(Shoutidjc_LIBRARY)

--- a/cmake/modules/FindSndFile.cmake
+++ b/cmake/modules/FindSndFile.cmake
@@ -50,14 +50,14 @@ endif()
 
 find_path(SndFile_INCLUDE_DIR
   NAMES sndfile.h
-  PATHS ${PC_SndFile_INCLUDE_DIRS}
+  HINTS ${PC_SndFile_INCLUDE_DIRS}
   PATH_SUFFIXES sndfile
   DOC "SndFile include directory")
 mark_as_advanced(SndFile_INCLUDE_DIR)
 
 find_library(SndFile_LIBRARY
   NAMES sndfile sndfile-1
-  PATHS ${PC_SndFile_LIBRARY_DIRS}
+  HINTS ${PC_SndFile_LIBRARY_DIRS}
   DOC "SndFile library"
 )
 mark_as_advanced(SndFile_LIBRARY)

--- a/cmake/modules/FindSoundTouch.cmake
+++ b/cmake/modules/FindSoundTouch.cmake
@@ -50,13 +50,13 @@ endif()
 
 find_path(SoundTouch_INCLUDE_DIR
   NAMES soundtouch/SoundTouch.h
-  PATHS ${PC_SoundTouch_INCLUDE_DIRS}
+  HINTS ${PC_SoundTouch_INCLUDE_DIRS}
   DOC "SoundTouch include directory")
 mark_as_advanced(SoundTouch_INCLUDE_DIR)
 
 find_library(SoundTouch_LIBRARY
   NAMES SoundTouch
-  PATHS ${PC_SoundTouch_LIBRARY_DIRS}
+  HINTS ${PC_SoundTouch_LIBRARY_DIRS}
   DOC "SoundTouch library"
 )
 mark_as_advanced(SoundTouch_LIBRARY)

--- a/cmake/modules/FindTagLib.cmake
+++ b/cmake/modules/FindTagLib.cmake
@@ -47,6 +47,8 @@ include(IsStaticLibrary)
 
 find_package(PkgConfig QUIET)
 if(PkgConfig_FOUND)
+  # priorize the taglib1 package introduced in https://aur.archlinux.org/packages/taglib1
+  set(ENV{PKG_CONFIG_PATH} "/usr/lib/taglib1/lib/pkgconfig/")
   pkg_check_modules(PC_TagLib QUIET taglib)
 endif()
 

--- a/cmake/modules/FindTagLib.cmake
+++ b/cmake/modules/FindTagLib.cmake
@@ -52,14 +52,14 @@ endif()
 
 find_path(TagLib_INCLUDE_DIR
   NAMES tag.h
-  PATHS ${PC_TagLib_INCLUDE_DIRS}
+  HINTS ${PC_TagLib_INCLUDE_DIRS}
   PATH_SUFFIXES taglib
   DOC "TagLib include directory")
 mark_as_advanced(TagLib_INCLUDE_DIR)
 
 find_library(TagLib_LIBRARY
   NAMES tag
-  PATHS ${PC_TagLib_LIBRARY_DIRS}
+  HINTS ${PC_TagLib_LIBRARY_DIRS}
   DOC "TagLib library"
 )
 mark_as_advanced(TagLib_LIBRARY)

--- a/cmake/modules/FindTagLib.cmake
+++ b/cmake/modules/FindTagLib.cmake
@@ -47,8 +47,10 @@ include(IsStaticLibrary)
 
 find_package(PkgConfig QUIET)
 if(PkgConfig_FOUND)
-  # priorize the taglib1 package introduced in https://aur.archlinux.org/packages/taglib1
-  set(ENV{PKG_CONFIG_PATH} "/usr/lib/taglib1/lib/pkgconfig/")
+  if(UNIX AND NOT APPLE)
+    # priorize the taglib1 package introduced in https://aur.archlinux.org/packages/taglib1
+    set(ENV{PKG_CONFIG_PATH} "/usr/lib/taglib1/lib/pkgconfig/:$ENV{PKG_CONFIG_PATH}")
+  endif()
   pkg_check_modules(PC_TagLib QUIET taglib)
 endif()
 

--- a/cmake/modules/FindUpower.cmake
+++ b/cmake/modules/FindUpower.cmake
@@ -51,13 +51,13 @@ endif()
 find_path(Upower_INCLUDE_DIR
   NAMES upower.h
   PATH_SUFFIXES upower-glib libupower-glib
-  PATHS ${PC_Upower_INCLUDE_DIRS}
+  HINTS ${PC_Upower_INCLUDE_DIRS}
   DOC "Upower include directory")
 mark_as_advanced(Upower_INCLUDE_DIR)
 
 find_library(Upower_LIBRARY
   NAMES upower-glib
-  PATHS ${PC_Upower_LIBRARY_DIRS}
+  HINTS ${PC_Upower_LIBRARY_DIRS}
   DOC "Upower library"
 )
 mark_as_advanced(Upower_LIBRARY)

--- a/cmake/modules/Findhidapi.cmake
+++ b/cmake/modules/Findhidapi.cmake
@@ -50,14 +50,14 @@ endif()
 
 find_path(hidapi_INCLUDE_DIR
   NAMES hidapi.h
-  PATHS ${PC_hidapi_INCLUDE_DIRS}
+  HINTS ${PC_hidapi_INCLUDE_DIRS}
   PATH_SUFFIXES hidapi
   DOC "hidapi include directory")
 mark_as_advanced(hidapi_INCLUDE_DIR)
 
 find_library(hidapi_LIBRARY
   NAMES hidapi-libusb hidapi
-  PATHS ${PC_hidapi_LIBRARY_DIRS}
+  HINTS ${PC_hidapi_LIBRARY_DIRS}
   DOC "hidapi library"
 )
 mark_as_advanced(hidapi_LIBRARY)
@@ -65,7 +65,7 @@ mark_as_advanced(hidapi_LIBRARY)
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
   find_library(hidapi-hidraw_LIBRARY
     NAMES hidapi-hidraw
-    PATHS ${PC_hidapi_LIBRARY_DIRS}
+    HINTS ${PC_hidapi_LIBRARY_DIRS}
     DOC "hidap-hidraw library"
   )
   mark_as_advanced(hidapi-hidraw_LIBRARY)

--- a/cmake/modules/Findlilv.cmake
+++ b/cmake/modules/Findlilv.cmake
@@ -53,14 +53,14 @@ endif()
 find_path(lilv_INCLUDE_DIR
   NAMES lilv/lilv.h
   PATH_SUFFIXES lilv-0
-  PATHS ${PC_lilv_INCLUDE_DIRS}
+  HINTS ${PC_lilv_INCLUDE_DIRS}
   DOC "lilv include directory"
 )
 mark_as_advanced(lilv_INCLUDE_DIR)
 
 find_library(lilv_LIBRARY
   NAMES lilv-0 lilv
-  PATHS ${PC_lilv_LIBRARY_DIRS}
+  HINTS ${PC_lilv_LIBRARY_DIRS}
   DOC "lilv library"
 )
 mark_as_advanced(lilv_LIBRARY)

--- a/cmake/modules/Findrubberband.cmake
+++ b/cmake/modules/Findrubberband.cmake
@@ -50,13 +50,13 @@ endif()
 
 find_path(rubberband_INCLUDE_DIR
   NAMES rubberband/RubberBandStretcher.h
-  PATHS ${PC_rubberband_INCLUDE_DIRS}
+  HINTS ${PC_rubberband_INCLUDE_DIRS}
   DOC "rubberband include directory")
 mark_as_advanced(rubberband_INCLUDE_DIR)
 
 find_library(rubberband_LIBRARY
   NAMES rubberband rubberband-library rubberband-dll
-  PATHS ${PC_rubberband_LIBRARY_DIRS}
+  HINTS ${PC_rubberband_LIBRARY_DIRS}
   DOC "rubberband library"
 )
 mark_as_advanced(rubberband_LIBRARY)

--- a/cmake/modules/Findwavpack.cmake
+++ b/cmake/modules/Findwavpack.cmake
@@ -51,12 +51,12 @@ endif()
 find_path(wavpack_INCLUDE_DIR
   NAMES wavpack.h
   PATH_SUFFIXES wavpack
-  PATHS ${PC_wavpack_INCLUDE_DIRS}
+  HINTS ${PC_wavpack_INCLUDE_DIRS}
   DOC "wavpack include directory")
 mark_as_advanced(wavpack_INCLUDE_DIR)
 
 find_library(wavpack_LIBRARY NAMES wavpack wv wavpackdll
-  PATHS ${PC_wavpack_LIBRARY_DIRS}
+  HINTS ${PC_wavpack_LIBRARY_DIRS}
   DOC "wavpack library"
 )
 mark_as_advanced(wavpack_LIBRARY)

--- a/src/sources/metadatasourcetaglib.cpp
+++ b/src/sources/metadatasourcetaglib.cpp
@@ -1,7 +1,7 @@
 #include "sources/metadatasourcetaglib.h"
 
-#include <taglib/opusfile.h>
-#include <taglib/vorbisfile.h>
+#include <opusfile.h>
+#include <vorbisfile.h>
 
 #include <QFile>
 #include <memory>

--- a/src/test/metadatatest.cpp
+++ b/src/test/metadatatest.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
-#include <taglib/textidentificationframe.h>
-#include <taglib/tstring.h>
+#include <textidentificationframe.h>
+#include <tstring.h>
 
 #include <QtDebug>
 

--- a/src/test/seratobeatgridtest.cpp
+++ b/src/test/seratobeatgridtest.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
-#include <taglib/textidentificationframe.h>
-#include <taglib/tstring.h>
+#include <textidentificationframe.h>
+#include <tstring.h>
 
 #include <QDir>
 #include <QtDebug>

--- a/src/test/seratomarkers2test.cpp
+++ b/src/test/seratomarkers2test.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
-#include <taglib/textidentificationframe.h>
-#include <taglib/tstring.h>
+#include <textidentificationframe.h>
+#include <tstring.h>
 
 #include <QDir>
 #include <QtDebug>

--- a/src/test/seratomarkerstest.cpp
+++ b/src/test/seratomarkerstest.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
-#include <taglib/textidentificationframe.h>
-#include <taglib/tstring.h>
+#include <textidentificationframe.h>
+#include <tstring.h>
 
 #include <QDir>
 #include <QtDebug>

--- a/src/track/taglib/trackmetadata_ape.h
+++ b/src/track/taglib/trackmetadata_ape.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <taglib/apetag.h>
+#include <apetag.h>
 
 class QImage;
 

--- a/src/track/taglib/trackmetadata_common.h
+++ b/src/track/taglib/trackmetadata_common.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <taglib/tag.h>
-#include <taglib/tstringlist.h>
+#include <tag.h>
+#include <tstringlist.h>
 
 #include <QByteArray>
 #include <QFlags>

--- a/src/track/taglib/trackmetadata_file.cpp
+++ b/src/track/taglib/trackmetadata_file.cpp
@@ -9,7 +9,7 @@
 
 #include "track/taglib/trackmetadata_file.h"
 
-#include <taglib/tfile.h>
+#include <tfile.h>
 
 #include "track/taglib/trackmetadata_common.h"
 #include "util/logger.h"

--- a/src/track/taglib/trackmetadata_file.h
+++ b/src/track/taglib/trackmetadata_file.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <taglib/aifffile.h>
-#include <taglib/flacfile.h>
-#include <taglib/mp4file.h>
-#include <taglib/mpegfile.h>
-#include <taglib/wavfile.h>
-#include <taglib/wavpackfile.h>
+#include <aifffile.h>
+#include <flacfile.h>
+#include <mp4file.h>
+#include <mpegfile.h>
+#include <wavfile.h>
+#include <wavpackfile.h>
 
 #include <QFile>
 

--- a/src/track/taglib/trackmetadata_id3v2.cpp
+++ b/src/track/taglib/trackmetadata_id3v2.cpp
@@ -1,14 +1,14 @@
 #include "track/taglib/trackmetadata_id3v2.h"
 
-#include <taglib/attachedpictureframe.h>
-#include <taglib/commentsframe.h>
-#include <taglib/generalencapsulatedobjectframe.h>
-#include <taglib/textidentificationframe.h>
-#include <taglib/unknownframe.h>
+#include <attachedpictureframe.h>
+#include <commentsframe.h>
+#include <generalencapsulatedobjectframe.h>
+#include <textidentificationframe.h>
+#include <unknownframe.h>
 
 #include <array>
 #if defined(__EXTRA_METADATA__)
-#include <taglib/uniquefileidentifierframe.h>
+#include <uniquefileidentifierframe.h>
 #endif // __EXTRA_METADATA__
 
 #include "track/taglib/trackmetadata_common.h"

--- a/src/track/taglib/trackmetadata_id3v2.h
+++ b/src/track/taglib/trackmetadata_id3v2.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <taglib/id3v2tag.h>
+#include <id3v2tag.h>
 
 class QImage;
 

--- a/src/track/taglib/trackmetadata_mp4.h
+++ b/src/track/taglib/trackmetadata_mp4.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <taglib/mp4tag.h>
+#include <mp4tag.h>
 
 class QImage;
 

--- a/src/track/taglib/trackmetadata_riff.h
+++ b/src/track/taglib/trackmetadata_riff.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <taglib/infotag.h>
+#include <infotag.h>
 
 class TrackMetadata;
 

--- a/src/track/taglib/trackmetadata_xiph.cpp
+++ b/src/track/taglib/trackmetadata_xiph.cpp
@@ -9,7 +9,7 @@
 
 #include "track/taglib/trackmetadata_xiph.h"
 
-#include <taglib/flacpicture.h>
+#include <flacpicture.h>
 
 #include <array>
 

--- a/src/track/taglib/trackmetadata_xiph.h
+++ b/src/track/taglib/trackmetadata_xiph.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <taglib/xiphcomment.h>
+#include <xiphcomment.h>
 
 #include "track/taglib/trackmetadata_file.h"
 

--- a/src/util/versionstore.cpp
+++ b/src/util/versionstore.cpp
@@ -26,7 +26,7 @@
 #include <portaudio.h>
 #include <sndfile.h>
 #include <soundtouch/SoundTouch.h>
-#include <taglib/taglib.h>
+#include <taglib.h>
 #include <vorbis/codec.h>
 
 #include "util/gitinfostore.h"


### PR DESCRIPTION
This allows to use the https://aur.archlinux.org/packages/taglib1 package on Linux Arch. 
This is a workaround for https://github.com/mixxxdj/mixxx/issues/12790
