### PR TITLE
Fix deprecated hotcue status control in midi-components.js

### DIFF
--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -298,7 +298,7 @@
             this.colorKey = "hotcue_" + options.number + "_color";
         }
         this.number = options.number;
-        this.outKey = "hotcue_" + this.number + "_enabled";
+        this.outKey = "hotcue_" + this.number + "_status";
         Button.call(this, options);
     };
     HotcueButton.prototype = new Button({


### PR DESCRIPTION
This fixes the `ControlObject accessed via deprecated key "[Channel1]" "hotcue_x_enabled" - use "[Channel1]" "hotcue_x_status" instead` warning.