### PR TITLE
controllers: ensure required samplers are created

### DIFF
--- a/res/controllers/Behringer-CMD-MM1-scripts.js
+++ b/res/controllers/Behringer-CMD-MM1-scripts.js
@@ -536,10 +536,10 @@ CMDMM.init = function () {
       this.speed=navEncoderScale;
     },
   });
-  CMDMM.VuMeterL = engine.makeUnbufferedConnection("[Master]","vu_meter_left",function (value) {
+  CMDMM.VuMeterL = engine.makeUnbufferedConnection("[Main]", "vu_meter_left", function(value) {
     midi.sendShortMsg(MIDI.CC, 0x50, (value * 15) + 48);
   });
-  CMDMM.VuMeterR = engine.makeUnbufferedConnection("[Master]","vu_meter_right",function (value) {
+  CMDMM.VuMeterR = engine.makeUnbufferedConnection("[Main]", "vu_meter_right", function(value) {
     midi.sendShortMsg(MIDI.CC, 0x51, (value * 15) + 48);
   });
   CMDMM.layer(1);
@@ -549,8 +549,8 @@ CMDMM.init = function () {
 };
 
 CMDMM.shutdown = function () {
-  engine.setParameter("[Master]","vu_meter_left",0);
-  engine.setParameter("[Master]","vu_meter_right",0);
+  engine.setParameter("[Main]", "vu_meter_left", 0);
+  engine.setParameter("[Main]", "vu_meter_right", 0);
   for (var i = 0; i<127; i++) {
     midi.sendShortMsg(MIDI.noteOn, i, 0);
     // sets the controller to orange (to match the left/right buttons which only light up in orange);

--- a/res/controllers/Behringer-CMDStudio4a-scripts.js
+++ b/res/controllers/Behringer-CMDStudio4a-scripts.js
@@ -65,8 +65,8 @@ BehringerCMDStudio4a.init = function () {
     // Initialise anything that might not be in the correct state.
     BehringerCMDStudio4a.initLEDs();
     // Connect the VUMeters
-    engine.connectControl("[Master]","vu_meter_left","BehringerCMDStudio4a.vuMeterUpdate");
-    engine.connectControl("[Master]","vu_meter_right","BehringerCMDStudio4a.vuMeterUpdate");
+    engine.connectControl("[Main]", "vu_meter_left", "BehringerCMDStudio4a.vuMeterUpdate");
+    engine.connectControl("[Main]", "vu_meter_right", "BehringerCMDStudio4a.vuMeterUpdate");
 }
 
 BehringerCMDStudio4a.shutdown = function() {
@@ -76,8 +76,8 @@ BehringerCMDStudio4a.shutdown = function() {
     // Disconnect the VUMeters.
 // Maybe not! It seems you don't have to do this even though the connection
 // in done in init(), in fact if you try it throws an error.
-//  engine.connectControl("[Master]","vu_meter_left","BehringerCMDStudio4a.vuMeterUpdate",true);
-//  engine.connectControl("[Master]","vu_meter_right","BehringerCMDStudio4a.vuMeterUpdate",true);
+//  engine.connectControl("[Main]","vu_meter_left","BehringerCMDStudio4a.vuMeterUpdate",true);
+//  engine.connectControl("[Main]","vu_meter_right","BehringerCMDStudio4a.vuMeterUpdate",true);
 }
 
 

--- a/res/controllers/DJ-Tech-Mixer-One-scripts.js
+++ b/res/controllers/DJ-Tech-Mixer-One-scripts.js
@@ -23,8 +23,8 @@ MIXER1.shutdown = function shutdown() {
 MIXER1.volumeLEDs = function volumeLEDs(value, group, control){
 
     value=(value*127);
-    if (group=="[Master]" && control=="vu_meter_left"){ch=0xB5;midino=0x1f;midi.sendShortMsg(ch, midino, value);ch=0xB7;midino=0x1f;midi.sendShortMsg(ch, midino, value);}
-    if (group=="[Master]" && control=="vu_meter_right"){ch=0xB5;midino=0x20;midi.sendShortMsg(ch, midino, value);ch=0xB7;midino=0x20;midi.sendShortMsg(ch, midino, value);}
+    if (group=="[Main]" && control=="vu_meter_left") { ch=0xB5; midino=0x1f; midi.sendShortMsg(ch, midino, value); ch=0xB7; midino=0x1f; midi.sendShortMsg(ch, midino, value); }
+    if (group=="[Main]" && control=="vu_meter_right") { ch=0xB5; midino=0x20; midi.sendShortMsg(ch, midino, value); ch=0xB7; midino=0x20; midi.sendShortMsg(ch, midino, value); }
     if (group=="[Channel1]" && control=="vu_meter"){ch=0xB5;midino=0x22;midi.sendShortMsg(ch, midino, value);}
     if (group=="[Channel2]" && control=="vu_meter"){ch=0xB6;midino=0x23;midi.sendShortMsg(ch, midino, value);}
     if (group=="[Channel3]" && control=="vu_meter"){ch=0xB7;midino=0x22;midi.sendShortMsg(ch, midino, value);}

--- a/res/controllers/Denon-MC6000MK2-scripts.js
+++ b/res/controllers/Denon-MC6000MK2-scripts.js
@@ -1343,7 +1343,7 @@ DenonMC6000MK2.initValues = function() {
         engine.setValue("[App]", "samplerate", DenonMC6000MK2.SAMPLE_RATE);
     }
     DenonMC6000MK2.backupNumDecks = engine.getValue("[App]", "num_decks");
-    if (DenonMC6000MK2.backupNumDecks !== DenonMC6000MK2.DECK_COUNT) {
+    if (DenonMC6000MK2.backupNumDecks < DenonMC6000MK2.DECK_COUNT) {
         DenonMC6000MK2.logInfo(
             "Adjusting number of decks: " +
             DenonMC6000MK2.backupNumDecks +
@@ -1353,7 +1353,7 @@ DenonMC6000MK2.initValues = function() {
     }
     DenonMC6000MK2.backupNumSamplers = engine.getValue("[App]", "num_samplers");
     var numSamplers = DenonMC6000MK2.SIDE_COUNT * DenonMC6000MK2.SAMPLER_COUNT_PER_SIDE;
-    if (DenonMC6000MK2.backupNumSamplers !== numSamplers) {
+    if (DenonMC6000MK2.backupNumSamplers < numSamplers) {
         DenonMC6000MK2.logInfo(
             "Adjusting number of samplers: " +
             DenonMC6000MK2.backupNumSamplers +

--- a/res/controllers/Denon-MC7000-scripts.js
+++ b/res/controllers/Denon-MC7000-scripts.js
@@ -242,6 +242,9 @@ MC7000.init = function() {
         }
     }
     // Sampler Mode LEDs and Velocity Sampler Mode LEDs
+    if (engine.getValue("[App]", "num_samplers") < MC7000.SamplerQty) {
+        engine.setValue("[App]", "num_samplers", MC7000.SamplerQty);
+    }
     for (let samplerIdx = 1; samplerIdx <= MC7000.SamplerQty; samplerIdx++) {
         engine.makeConnection("[Sampler"+samplerIdx+"]", "track_loaded", MC7000.SamplerLED);
         engine.makeConnection("[Sampler"+samplerIdx+"]", "play", MC7000.SamplerLED);

--- a/res/controllers/Hercules-DJControl-Inpulse-200-script.js
+++ b/res/controllers/Hercules-DJControl-Inpulse-200-script.js
@@ -46,6 +46,9 @@ DJCi200.kScratchActionSeek = 2;
 DJCi200.kScratchActionBend = 3;
 
 DJCi200.init = function() {
+    if (engine.getValue("[App]", "num_samplers") < 8) {
+        engine.setValue("[App]", "num_samplers", 8);
+    }
     // Scratch button state
     DJCi200.scratchButtonState = true;
     // Scratch Action

--- a/res/controllers/Hercules-DJControl-Inpulse-300-script.js
+++ b/res/controllers/Hercules-DJControl-Inpulse-300-script.js
@@ -62,6 +62,10 @@ DJCi300.vuMeterUpdateDeck = function(value, group, _control, _status) {
 };
 
 DJCi300.init = function() {
+    if (engine.getValue("[App]", "num_samplers") < 16) {
+        engine.setValue("[App]", "num_samplers", 16);
+    }
+
     // Scratch button state
     DJCi300.scratchButtonState = true;
     // Scratch Action

--- a/res/controllers/Hercules-DJControl-MIX-scripts.js
+++ b/res/controllers/Hercules-DJControl-MIX-scripts.js
@@ -32,6 +32,10 @@ class DJCMixClass {
     }
 
     init() {
+        if (engine.getValue("[App]", "num_samplers") < 8) {
+            engine.setValue("[App]", "num_samplers", 8);
+        }
+
         this.scratchButtonState = true;
         this.scratchAction = {
             1: this.kScratchActionNone,

--- a/res/controllers/Hercules_DJControl_Jogvision-scripts.js
+++ b/res/controllers/Hercules_DJControl_Jogvision-scripts.js
@@ -126,6 +126,10 @@ var DJCJV = {
     "init": function(id) {
         print(id+": initializing...");
 
+        if (engine.getValue("[App]", "num_samplers") < 8) {
+            engine.setValue("[App]", "num_samplers", 8);
+        }
+
         // Prepare some musical constants
         if (CFG.fine.beatHelpSensitivity >= 1) {
             print(id+": WARNING: variable 'CFG.fine.beatHelpSensitivity' is set to a value equal or bigger than 1 ("+CFG.fine.beatHelpSensitivity+"). Setting it exactly to 0.9");

--- a/res/controllers/KANE_QuNeo_scripts.js
+++ b/res/controllers/KANE_QuNeo_scripts.js
@@ -348,7 +348,7 @@ KANE_QuNeo.init = function (id) { // called when the device is opened & set up
   engine.connectControl("[Channel2]","visual_playposition","KANE_QuNeo.time2Keeper");
 
   // led controls for the master / flanger channels
-  engine.connectControl("[Master]","vu_meter","KANE_QuNeo.masterVuMeter");
+  engine.connectControl("[Main]", "vu_meter", "KANE_QuNeo.masterVuMeter");
   //engine.softTakeover("[Master]","volume",true);
   engine.connectControl("[Master]","headVolume","KANE_QuNeo.headVol");
   engine.connectControl("[Flanger]","lfoPeriod","KANE_QuNeo.flangerPeriod");

--- a/res/controllers/Numark_DJ2GO2_Touch_scripts.js
+++ b/res/controllers/Numark_DJ2GO2_Touch_scripts.js
@@ -1,8 +1,12 @@
 var DJ2GO2Touch = {};
 DJ2GO2Touch.ControllerStatusSysex = [0xF0, 0x00, 0x01, 0x3F, 0x3C, 0x48, 0xF7];
 DJ2GO2Touch.padsPerDeck = 4;
+DJ2GO2Touch.samplerCount = 2 * DJ2GO2Touch.padsPerDeck;
 
 DJ2GO2Touch.init = function() {
+    if (engine.getValue("[App]", "num_samplers") < DJ2GO2Touch.samplerCount) {
+        engine.setValue("[App]", "num_samplers", DJ2GO2Touch.samplerCount);
+    }
     DJ2GO2Touch.leftDeck = new DJ2GO2Touch.Deck([1], 0);
     DJ2GO2Touch.rightDeck = new DJ2GO2Touch.Deck([2], 1);
     midi.sendSysexMsg(DJ2GO2Touch.ControllerStatusSysex, DJ2GO2Touch.ControllerStatusSysex.length);

--- a/res/controllers/Pioneer-DDJ-400-script.js
+++ b/res/controllers/Pioneer-DDJ-400-script.js
@@ -172,7 +172,11 @@ PioneerDDJ400.init = function() {
     engine.softTakeover("[EffectRack1_EffectUnit1_Effect3]", "meta", true);
     engine.softTakeover("[EffectRack1_EffectUnit1]", "mix", true);
 
-    for (let i = 1; i <= 16; ++i) {
+    const samplerCount = 16;
+    if (engine.getValue("[App]", "num_samplers") < samplerCount) {
+        engine.setValue("[App]", "num_samplers", samplerCount);
+    }
+    for (let i = 1; i <= samplerCount; ++i) {
         engine.makeConnection("[Sampler" + i + "]", "play", PioneerDDJ400.samplerPlayOutputCallbackFunction);
     }
 

--- a/res/controllers/Pioneer-DDJ-FLX4-script.js
+++ b/res/controllers/Pioneer-DDJ-FLX4-script.js
@@ -239,7 +239,11 @@ PioneerDDJFLX4.init = function() {
     engine.softTakeover("[EffectRack1_EffectUnit1_Effect3]", "meta", true);
     engine.softTakeover("[EffectRack1_EffectUnit1]", "mix", true);
 
-    for (var i = 1; i <= 16; ++i) {
+    const samplerCount = 16;
+    if (engine.getValue("[App]", "num_samplers") < samplerCount) {
+        engine.setValue("[App]", "num_samplers", samplerCount);
+    }
+    for (let i = 1; i <= samplerCount; ++i) {
         engine.makeConnection("[Sampler" + i + "]", "play", PioneerDDJFLX4.samplerPlayOutputCallbackFunction);
     }
 

--- a/res/controllers/Pioneer-DDJ-SB3-scripts.js
+++ b/res/controllers/Pioneer-DDJ-SB3-scripts.js
@@ -254,6 +254,10 @@ PioneerDDJSB3.init = function() {
         "[Channel4]_enabled": 1,
     };
 
+    if (engine.getValue("[App]", "num_samplers") < 8) {
+        engine.setValue("[App]", "num_samplers", 8);
+    }
+
     PioneerDDJSB3.deck = [];
     PioneerDDJSB3.deck[1] = new PioneerDDJSB3.Deck(1);
     PioneerDDJSB3.deck[2] = new PioneerDDJSB3.Deck(2);

--- a/res/controllers/Reloop Terminal Mix 2-4.js
+++ b/res/controllers/Reloop Terminal Mix 2-4.js
@@ -84,18 +84,22 @@ TerminalMix.init = function (id,debug) {
 
     // Enable four decks in v1.11.x
     engine.setValue("[App]", "num_decks", 4);
+    const samplerCount = 8;
+    if (engine.getValue("[App]", "num_samplers") < samplerCount) {
+        engine.setValue("[App]", "num_samplers", samplerCount);
+    }
 
     // Set soft-takeover for all Sampler volumes
-    for (var i=engine.getValue("[App]", "num_samplers"); i>=1; i--) {
+    for (let i=samplerCount; i>=1; i--) {
         engine.softTakeover("[Sampler"+i+"]","pregain",true);
     }
     // Set soft-takeover for all applicable Deck controls
-    for (var i=engine.getValue("[App]", "num_decks"); i>=1; i--) {
-        engine.softTakeover("[Channel"+i+"]","volume",true);
-        engine.softTakeover("[Channel"+i+"]","filterHigh",true);
-        engine.softTakeover("[Channel"+i+"]","filterMid",true);
-        engine.softTakeover("[Channel"+i+"]","filterLow",true);
-        engine.softTakeover("[Channel"+i+"]","rate",true);
+    for (let j=engine.getValue("[App]", "num_decks"); j>=1; j--) {
+        engine.softTakeover("[Channel"+j+"]", "volume", true);
+        engine.softTakeover("[Channel"+j+"]", "filterHigh", true);
+        engine.softTakeover("[Channel"+j+"]", "filterMid", true);
+        engine.softTakeover("[Channel"+j+"]", "filterLow", true);
+        engine.softTakeover("[Channel"+j+"]", "rate", true);
     }
 
     engine.softTakeover("[Master]","crossfader",true);

--- a/res/controllers/Reloop-Beatmix-2-4-scripts.js
+++ b/res/controllers/Reloop-Beatmix-2-4-scripts.js
@@ -192,6 +192,9 @@ ReloopBeatmix24.connectControls = function() {
 ReloopBeatmix24.init = function(id, _debug) {
     ReloopBeatmix24.id = id;
     ReloopBeatmix24.TurnLEDsOff(); // Turn off all LEDs
+    if (engine.getValue("[App]", "num_samplers") < 8) {
+        engine.setValue("[App]", "num_samplers", 8);
+    }
     ReloopBeatmix24.connectControls(false);
 
     for (let i = 1; i <= 4; i++) {

--- a/res/controllers/Reloop-Beatpad-scripts.js
+++ b/res/controllers/Reloop-Beatpad-scripts.js
@@ -1634,6 +1634,10 @@ ReloopBeatpad.init = function(id, debug) {
     print("============================");
     TurnLEDsOff();
 
+    if (engine.getValue("[App]", "num_samplers") < 16) {
+        engine.setValue("[App]", "num_samplers", 16);
+    }
+
     ReloopBeatpad.initButtonsObjects();
     ReloopBeatpad.initobjects();
 

--- a/res/controllers/Stanton-SCS1m-scripts.js
+++ b/res/controllers/Stanton-SCS1m-scripts.js
@@ -74,8 +74,8 @@ StantonSCS1m.init = function (id) {    // called when the MIDI device is opened 
 
     // Connect signals
         // Vu Meters
-    engine.connectControl("[Master]","vu_meter_left","StantonSCS1m.MasterLVu");
-    engine.connectControl("[Master]","vu_meter_right","StantonSCS1m.MasterRVu");
+    engine.connectControl("[Main]", "vu_meter_left", "StantonSCS1m.MasterLVu");
+    engine.connectControl("[Main]", "vu_meter_right", "StantonSCS1m.MasterRVu");
     engine.connectControl("[Channel1]","vu_meter","StantonSCS1m.Channel1Vu");
     engine.connectControl("[Channel2]","vu_meter","StantonSCS1m.Channel2Vu");
 

--- a/res/controllers/Traktor-Kontrol-S2-MK1-hid-scripts.js
+++ b/res/controllers/Traktor-Kontrol-S2-MK1-hid-scripts.js
@@ -1012,6 +1012,9 @@ class EffectParameter {
 class TraktorS2MK1Class {
     constructor() {
         this.controller = new HIDController();
+        if (engine.getValue("[App]", "num_samplers") < 8) {
+            engine.setValue("[App]", "num_samplers", 8);
+        }
 
         // When true, packets will not be sent to the controller.
         // Used when updating multiple LEDs simultaneously.

--- a/res/controllers/Traktor-Kontrol-S2-MK2-hid-scripts.js
+++ b/res/controllers/Traktor-Kontrol-S2-MK2-hid-scripts.js
@@ -457,6 +457,9 @@ TraktorS2MK2.lightDeck = function(group) {
 };
 
 TraktorS2MK2.init = function() {
+    if (engine.getValue("[App]", "num_samplers") < 8) {
+        engine.setValue("[App]", "num_samplers", 8);
+    }
     if (!(ShiftCueButtonAction === "REWIND" || ShiftCueButtonAction === "REVERSEROLL")) {
         throw new Error("ShiftCueButtonAction must be either \"REWIND\" or \"REVERSEROLL\"\n" +
             "ShiftCueButtonAction is: " + ShiftCueButtonAction);

--- a/res/controllers/Traktor-Kontrol-S2-MK3-hid-scripts.js
+++ b/res/controllers/Traktor-Kontrol-S2-MK3-hid-scripts.js
@@ -42,6 +42,7 @@ var TraktorS2MK3 = new function() {
     this.vuMeterThresholds = {"vu-18": (1 / 6), "vu-12": (2 / 6), "vu-6": (3 / 6), "vu0": (4 / 6), "vu6": (5 / 6)};
 
     // Sampler callbacks
+    this.samplerCount = 16;
     this.samplerCallbacks = [];
     this.samplerHotcuesRelation = {
         "[Channel1]": {
@@ -53,6 +54,9 @@ var TraktorS2MK3 = new function() {
 };
 
 TraktorS2MK3.init = function(_id) {
+    if (engine.getValue("[App]", "num_samplers") < TraktorS2MK3.samplerCount) {
+        engine.setValue("[App]", "num_samplers", TraktorS2MK3.samplerCount);
+    }
     TraktorS2MK3.registerInputPackets();
     TraktorS2MK3.registerOutputPackets();
     HIDDebug("TraktorS2MK3: Init done!");
@@ -219,8 +223,7 @@ TraktorS2MK3.registerInputPackets = function() {
     //engine.softTakeover("[Master]", "gain", true);
     engine.softTakeover("[Master]", "headMix", true);
     engine.softTakeover("[Master]", "headGain", true);
-
-    for (let i = 1; i <= 16; ++i) {
+    for (let i = 1; i <= TraktorS2MK3.samplerCount; ++i) {
         engine.softTakeover("[Sampler" + i + "]", "pregain", true);
     }
 
@@ -605,7 +608,7 @@ TraktorS2MK3.parameterHandler = function(field) {
 TraktorS2MK3.samplerPregainHandler = function(field) {
     // Map sampler gain knob of all sampler together.
     // Dirty hack, but the best we can do for now.
-    for (let i = 1; i <= 16; ++i) {
+    for (let i = 1; i <= TraktorS2MK3.samplerCount; ++i) {
         engine.setParameter("[Sampler" + i + "]", field.name, field.value / 4095);
     }
 };
@@ -904,7 +907,7 @@ TraktorS2MK3.registerOutputPackets = function() {
     this.clipRightConnection = engine.makeConnection("[Channel2]", "peak_indicator", this.peakOutputHandler.bind(this));
 
     // Sampler callbacks
-    for (let i = 1; i <= 16; ++i) {
+    for (let i = 1; i <= TraktorS2MK3.samplerCount; ++i) {
         this.samplerCallbacks.push(engine.makeConnection("[Sampler" + i + "]", "track_loaded", this.samplesOutputHandler.bind(this)));
         this.samplerCallbacks.push(engine.makeConnection("[Sampler" + i + "]", "play", this.samplesOutputHandler.bind(this)));
     }

--- a/res/controllers/Traktor-Kontrol-S4-MK2-hid-scripts.js
+++ b/res/controllers/Traktor-Kontrol-S4-MK2-hid-scripts.js
@@ -708,6 +708,9 @@ TraktorS4MK2.pointlessLightShow = function() {
 };
 
 TraktorS4MK2.init = function(id) {
+    if (engine.getValue("[App]", "num_samplers") < 16) {
+        engine.setValue("[App]", "num_samplers", 16);
+    }
     TraktorS4MK2.pointlessLightShow();
     TraktorS4MK2.registerInputPackets();
     TraktorS4MK2.registerOutputPackets();

--- a/res/controllers/Vestax-VCI-400-scripts.js
+++ b/res/controllers/Vestax-VCI-400-scripts.js
@@ -49,8 +49,8 @@ VestaxVCI400.init = function (id) {
 
     //Connect vu meters
     // No need if using the sound card
-    engine.connectControl("[Master]","vu_meter_left", "VestaxVCI400.onMasterVuMeterLChanged");
-    engine.connectControl("[Master]","vu_meter_right", "VestaxVCI400.onMasterVuMeterRChanged");
+    engine.connectControl("[Main]", "vu_meter_left", "VestaxVCI400.onMasterVuMeterLChanged");
+    engine.connectControl("[Main]", "vu_meter_right", "VestaxVCI400.onMasterVuMeterRChanged");
 
     //Reset VU meters
     if (VestaxVCI400.enableMasterVu) {

--- a/res/controllers/Vestax-VCI-400-scripts.js
+++ b/res/controllers/Vestax-VCI-400-scripts.js
@@ -37,23 +37,26 @@ VestaxVCI400.ModeEnum = {
  * Called when the MIDI device is opened for set up
  */
 VestaxVCI400.init = function (id) {
-   engine.setValue("[App]", "num_decks", 4);
-   //Initialize controls and their default values here
-   VestaxVCI400.Decks.A.init();
-   VestaxVCI400.Decks.B.init();
-   VestaxVCI400.Decks.C.init();
-   VestaxVCI400.Decks.D.init();
+    engine.setValue("[App]", "num_decks", 4);
+    if (engine.getValue("[App]", "num_samplers") < 8) {
+        engine.setValue("[App]", "num_samplers", 8);
+    }
+    //Initialize controls and their default values here
+    VestaxVCI400.Decks.A.init();
+    VestaxVCI400.Decks.B.init();
+    VestaxVCI400.Decks.C.init();
+    VestaxVCI400.Decks.D.init();
 
-   //Connect vu meters
-   // No need if using the sound card
-   engine.connectControl("[Master]","vu_meter_left", "VestaxVCI400.onMasterVuMeterLChanged");
-   engine.connectControl("[Master]","vu_meter_right", "VestaxVCI400.onMasterVuMeterRChanged");
+    //Connect vu meters
+    // No need if using the sound card
+    engine.connectControl("[Master]","vu_meter_left", "VestaxVCI400.onMasterVuMeterLChanged");
+    engine.connectControl("[Master]","vu_meter_right", "VestaxVCI400.onMasterVuMeterRChanged");
 
-   //Reset VU meters
-   if (VestaxVCI400.enableMasterVu) {
-       midi.sendShortMsg("0xbe", 43, 0);
-       midi.sendShortMsg("0xbe", 44, 0);
-   }
+    //Reset VU meters
+    if (VestaxVCI400.enableMasterVu) {
+        midi.sendShortMsg("0xbe", 43, 0);
+        midi.sendShortMsg("0xbe", 44, 0);
+    }
 };
 
 /*

--- a/res/controllers/Yaeltex-MiniMixxx-scripts.js
+++ b/res/controllers/Yaeltex-MiniMixxx-scripts.js
@@ -1494,6 +1494,10 @@ MiniMixxx.Controller = class {
 };
 
 MiniMixxx.init = function(_id) {
+    if (engine.getValue("[App]", "num_samplers") < 8) {
+        engine.setValue("[App]", "num_samplers", 8);
+    }
+
     this.kontrol = new MiniMixxx.Controller();
 
     console.log("MiniMixxx: Init done!");


### PR DESCRIPTION
This PR simply ensures mappings request all required samplers being created, exactly like they set `[App],num_decks` if they need more than 2 decks.

With #12657 some mapping flaws produce mapping warnings, and users may not be able to resolve the issues.
This will occur with a fresh profile or when users don't have any tracks loaded in samplers with numbers higher than the deafult (4) or skin minimum (8, Shade skin).
After having merged #12657 this is just much more likely to happen.

To reproduce:
* ~~load Shade skin~~ doesn't matter, mappings are loaded before skins are created https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/2.2E4.20samplers.20regression
* close Mixxx, remove samplers.xml to ensure not more than the samplers required by the skin are created (Shade needs 8)
* start Mixxx (8 sample players are created)
* load Denon MC7000 or DDJ-FLX4 mapping (see #12747) or any of the mappings fixed in this PR
* mapping warning will popup

There may be more mappings that affected in a different way, I just did a quick check where `[Sampler` is used with
https://github.com/search?q=repo%3Amixxxdj%2Fmixxx+%22%5BSampler+path%3A%2F%5Eres%5C%2Fcontrollers%5C%2F%2F&type=code&p=2