### PR TITLE
Add support for TagLib 2.0

### DIFF
--- a/src/track/taglib/trackmetadata_ape.cpp
+++ b/src/track/taglib/trackmetadata_ape.cpp
@@ -59,7 +59,7 @@ bool importCoverImageFromTag(QImage* pCoverArt, const TagLib::APE::Tag& tag) {
     if (tag.itemListMap().contains("COVER ART (FRONT)")) {
         const TagLib::ByteVector nullStringTerminator(1, 0);
         TagLib::ByteVector item =
-                tag.itemListMap()["COVER ART (FRONT)"].value();
+                tag.itemListMap()["COVER ART (FRONT)"].binaryData();
         int pos = item.find(nullStringTerminator); // skip the filename
         if (++pos > 0) {
             const TagLib::ByteVector data(item.mid(pos));


### PR DESCRIPTION
This fixes a build error with TagLib 2.0 while still being backwards compatible with legacy TagLib 1.x versions. The `binaryData()` method exists since TagLib 1.8 which was released almost 12 years ago (September 6, 2012).

Also see https://taglib.org/#taglib-20-release---jan-24-2024:
> New major version, binary incompatible, but source-compatible with the latest 1.x release if no deprecated features are used.

This seems to be the only deprecated API we use, at least it builds fine on Arch.

Obsoletes #12709 and #12760.