### PR TITLE
Drop lodash dependency in ComponentJS

### DIFF
--- a/res/controllers/common-controller-scripts.js
+++ b/res/controllers/common-controller-scripts.js
@@ -48,19 +48,27 @@ var printObject = function(obj, maxdepth) {
 
 
 var stringifyObject = function(obj, maxdepth, checked, prefix) {
-    if (!maxdepth) { maxdepth = 2; }
+    if (!maxdepth) {
+        maxdepth = 2;
+    }
     try {
         return JSON.stringify(obj, null, maxdepth);
     } catch (e) {
-        if (!checked) { checked = []; }
-        if (!prefix) { prefix = ""; }
+        if (!checked) {
+            checked = [];
+        }
+        if (!prefix) {
+            prefix = "";
+        }
         if (maxdepth > 0 && typeof obj === "object" && obj !== null &&
             Object.getPrototypeOf(obj) !== "" && !arrayContains(checked, obj)) {
             checked.push(obj);
             let output = "{\n";
             for (const property in obj) {
                 const value = obj[property];
-                if (typeof value === "function") { continue; }
+                if (typeof value === "function") {
+                    continue;
+                }
                 output += prefix + property + ": "
                     + stringifyObject(value, maxdepth - 1, checked, prefix + "  ")
                     + "\n";
@@ -74,7 +82,9 @@ var stringifyObject = function(obj, maxdepth, checked, prefix) {
 
 var arrayContains = function(array, elem) {
     for (let i = 0; i < array.length; i++) {
-        if (array[i] === elem) { return true; }
+        if (array[i] === elem) {
+            return true;
+        }
     }
     return false;
 };
@@ -97,7 +107,9 @@ var msecondstominutes = function(msecs) {
     const secs = (msecs / 1000) | 0;
     msecs %= 1000;
     msecs = Math.round(msecs * 100 / 1000);
-    if (msecs === 100) { msecs = 99; }
+    if (msecs === 100) {
+        msecs = 99;
+    }
 
     return (m < 10 ? "0" + m : m)
         + ":"
@@ -127,6 +139,58 @@ var colorCodeToObject = function(colorCode) {
 /* eslint @typescript-eslint/no-empty-function: "off" */
 var script = function() {
 };
+
+/**
+ * Discriminates whether an object was created using the `{}` synthax.
+ *
+ * Returns true when was an object was created using the `{}` synthax.
+ * False if the object is an instance of a class like Date or Proxy or an Array.
+ *
+ * isSimpleObject({}) // true
+ * isSimpleObject(null) // false
+ * isSimpleObject(undefined) // false
+ * isSimpleObject(new Date) // false
+ * isSimpleObject(new (class {})()) // false
+ * @param {any} obj Object to test
+ * @returns {boolean} true if obj was created using the `{}` or `new Object()` synthax, false otherwise
+ */
+const isSimpleObject = function(obj) {
+    return obj !== null && typeof obj === "object" && obj.constructor.name === "Object";
+};
+
+script.isSimpleObject = isSimpleObject;
+
+/**
+ * Deeply merges 2 objects (Arrays and Objects only, not Map for instance).
+ * @param target {object | Array} Object to merge source into
+ * @param source {object | Array} Object to merge into source
+ */
+const deepMerge = function(target, source) {
+    if (target === source || target === undefined || target === null || source === undefined || source === null) {
+        return;
+    }
+
+    if (Array.isArray(target) && Array.isArray(source)) {
+        const objTarget = target.reduce((acc, val, idx) => Object.assign(acc, {[idx]: val}), {});
+        const objSource = source.reduce((acc, val, idx) => Object.assign(acc, {[idx]: val}), {});
+        deepMerge(objTarget, objSource);
+        target.length = 0;
+        target.push(...Object.values(objTarget));
+    } else if (isSimpleObject(target) && isSimpleObject(source)) {
+        Object.keys(source).forEach(key => {
+            if (
+                Array.isArray(target[key]) && Array.isArray(source[key]) ||
+              isSimpleObject(target[key]) && isSimpleObject(source[key])
+            ) {
+                deepMerge(target[key], source[key]);
+            } else if (source[key] !== undefined && source[key] !== null) {
+                Object.assign(target, {[key]: source[key]});
+            }
+        });
+    }
+};
+
+script.deepMerge = deepMerge;
 
 // ----------------- Mapping constants ---------------------
 
@@ -243,7 +307,7 @@ script.triggerControl = function(group, control, delay) {
         delay = 200;
     }
     engine.setValue(group, control, 1);
-    engine.beginTimer(delay, () => engine.setValue(group, control, 0) , true);
+    engine.beginTimer(delay, () => engine.setValue(group, control, 0), true);
 };
 
 /* -------- ------------------------------------------------------
@@ -399,7 +463,9 @@ script.posMod = function(a, m) {
    Output:  none
    -------- ------------------------------------------------------ */
 script.loopMove = function(group, direction, numberOfBeats) {
-    if (!numberOfBeats || numberOfBeats === 0) { numberOfBeats = 0.5; }
+    if (!numberOfBeats || numberOfBeats === 0) {
+        numberOfBeats = 0.5;
+    }
 
     if (direction < 0) {
         engine.setValue(group, "loop_move", -numberOfBeats);
@@ -527,15 +593,17 @@ bpm.tapButton = function(deck) {
     // a tap is considered missed when the delta of this press is 80% longer than the previous one
     // and a tap is considered double when the delta is shorter than 40% of the previous one.
     // these numbers are just guesses that produced good results in practice
-    if ((tapDelta > bpm.previousTapDelta * 1.8)||(tapDelta < bpm.previousTapDelta * 0.6)) {
+    if ((tapDelta > bpm.previousTapDelta * 1.8) || (tapDelta < bpm.previousTapDelta * 0.6)) {
         return;
     }
     bpm.previousTapDelta = tapDelta;
     bpm.tap.push(60 / tapDelta);
     // Keep the last 8 samples for averaging
-    if (bpm.tap.length > 8) { bpm.tap.shift(); }
+    if (bpm.tap.length > 8) {
+        bpm.tap.shift();
+    }
     let sum = 0;
-    for (let i=0; i<bpm.tap.length; i++) {
+    for (let i = 0; i < bpm.tap.length; i++) {
         sum += bpm.tap[i];
     }
     const average = sum / bpm.tap.length;
@@ -546,7 +614,7 @@ bpm.tapButton = function(deck) {
     // was supposed to return the tracks bpm (which it did before the change).
     // "file_bpm" is supposed to return the set BPM of the loaded track of the
     // channel.
-    let fRateScale = average/engine.getValue(group, "file_bpm");
+    let fRateScale = average / engine.getValue(group, "file_bpm");
 
     // Adjust the rate:
     fRateScale = (fRateScale - 1.) / engine.getValue(group, "rateRange");
@@ -565,7 +633,6 @@ script.effectUnitRegEx = /^\[EffectRack1_EffectUnit(\d+)\]$/;
 script.individualEffectRegEx = /^\[EffectRack1_EffectUnit(\d+)_Effect(\d+)\]$/;
 
 // ----------------- Object definitions --------------------------
-
 
 
 var ButtonState = {"released": 0x00, "pressed": 0x7F};
@@ -648,7 +715,7 @@ Control.prototype.setValue = function(group, inputValue) {
                 * (this.maxInput - this.midInput);
         }
         if (inputValue > currentRelative - this.maxJump
-                && inputValue < currentRelative + this.maxJump) {
+            && inputValue < currentRelative + this.maxJump) {
             engine.setValue(group, this.mappedFunction, outputValue);
         }
     } else {

--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -31,7 +31,7 @@
         if (Array.isArray(options) && typeof options[0] === "number") {
             this.midi = options;
         } else {
-            _.assign(this, options);
+            Object.assign(this, options);
         }
 
         if (typeof this.unshift === "function") {
@@ -661,7 +661,7 @@
                 });
             }
 
-            _.merge(this, newLayer);
+            script.deepMerge(this, newLayer);
 
             if (reconnectComponents === true) {
                 this.forEachComponent(function(component) {
@@ -735,9 +735,7 @@
     const JogWheelBasic = function(options) {
         Component.call(this, options);
 
-        // TODO 2.4: replace lodash polyfills with Number.isInteger/isFinite
-
-        if (!_.isInteger(this.deck)) {
+        if (!Number.isInteger(this.deck)) {
             console.warn("missing scratch deck");
             return;
         }
@@ -745,18 +743,18 @@
             console.warn("invalid deck number: " + this.deck);
             return;
         }
-        if (!_.isInteger(this.wheelResolution)) {
+        if (!Number.isInteger(this.wheelResolution)) {
             console.warn("missing jogwheel resolution");
             return;
         }
-        if (!_.isFinite(this.alpha)) {
+        if (!Number.isFinite(this.alpha)) {
             console.warn("missing alpha scratch parameter value");
             return;
         }
-        if (!_.isFinite(this.beta)) {
+        if (!Number.isFinite(this.beta)) {
             this.beta = this.alpha / 32;
         }
-        if (!_.isFinite(this.rpm)) {
+        if (!Number.isFinite(this.rpm)) {
             this.rpm = 33 + 1/3;
         }
         if (this.group === undefined) {


### PR DESCRIPTION
This removes the need to source `lodash.mixxx.js` when sourcing `midi-components-0.0.js`

`Object.deepMerge()` should work lik this:

```js
target = {
    a: "a",
    c: "c1",
    d: [{a: "a"}, 1],
    e: {},
    f: "f",
    g: {h: "", i: {j: "j"}}
}

source = {
    b: "b",
    c: "c2",
    d: [{b: "b"}, 2],
    e: new Date(),
    f: undefined,
    g: {i: {k: "k"}}
}

Object.deepMerge(target, source);
// Should produce
{
    a: "a",
    b: "b",
    c: "c2",
    d: [{a: "a", b: "b"}, 2],
    e: new Date(),
    f: "f",
    g: {h: "", i: {j: "j", k: "k"}}
}
```