### PR TITLE
Introduce a previousTimerId parameter to ControllerScriptInterfaceLegacy::beginTimer()

### DIFF
--- a/res/controllers/engine-api.d.ts
+++ b/res/controllers/engine-api.d.ts
@@ -167,10 +167,14 @@ declare namespace engine {
      *                   function() { print("Executed Timer") }
      * @param oneShot If true the function is only once,
      *                if false the function is executed repeatedly  [default = false]
+     * @param previousTimerId The ID a previous timer to cancel prior to start this one.
+     *                        If this is parameter is defined and a timer exists with
+     *                        this ID, it will be canceled before scheduling the new
+     *                        script code. [default = undefined]
      * @returns timerId which is needed to stop a timer.
      *          In case of an error, 0 is returned.
      */
-    function beginTimer(interval: number, scriptCode: () => any, oneShot?: boolean): TimerID;
+    function beginTimer(interval: number, scriptCode: () => any, oneShot?: boolean, previousTimerId?: number): TimerID;
 
     /**
      * Stops the specified timer

--- a/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
+++ b/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
@@ -459,7 +459,11 @@ void ControllerScriptInterfaceLegacy::log(const QString& message) {
     qCDebug(m_logger) << message;
 }
 int ControllerScriptInterfaceLegacy::beginTimer(
-        int intervalMillis, QJSValue timerCallback, bool oneShot) {
+        int intervalMillis, QJSValue timerCallback, bool oneShot, const QJSValue& previousTimerId) {
+    if (previousTimerId.isNumber() && m_timers.contains(previousTimerId.toInt())) {
+        this->stopTimer(previousTimerId.toInt());
+    }
+
     if (timerCallback.isString()) {
         m_pScriptEngineLegacy->logOrThrowError(
                 QStringLiteral("passed a string to `engine.beginTimer`, please "

--- a/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.h
+++ b/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.h
@@ -46,7 +46,10 @@ class ControllerScriptInterfaceLegacy : public QObject {
     Q_INVOKABLE void trigger(const QString& group, const QString& name);
     // DEPRECATED: Use console.log instead.
     Q_INVOKABLE void log(const QString& message);
-    Q_INVOKABLE int beginTimer(int interval, QJSValue scriptCode, bool oneShot = false);
+    Q_INVOKABLE int beginTimer(int interval,
+            QJSValue scriptCode,
+            bool oneShot = false,
+            const QJSValue& previousTimerId = QJSValue::SpecialValue::UndefinedValue);
     Q_INVOKABLE void stopTimer(int timerId);
     Q_INVOKABLE void scratchEnable(int deck,
             int intervalsPerRev,


### PR DESCRIPTION
This parameter is used to specifiy a timer ID to cancel before starting a new one. This is especially useful for repeating timers that are not assured to end there execution before the next occurence is executed. 