### PR TITLE
Registering MIDI Input Handlers From Javascript

### DIFF
--- a/res/controllers/midi-controller-api.d.ts
+++ b/res/controllers/midi-controller-api.d.ts
@@ -1,5 +1,6 @@
-
-/** MidiControllerJSProxy */
+declare interface MidiInputHandlerController {
+    disconnect(): boolean;
+}
 
 declare namespace midi {
 
@@ -29,4 +30,16 @@ declare namespace midi {
      */
     function sendSysexMsg(dataList: number[], length?: number): void;
 
+    type InputCallback = (channel: string, control: string, value: number, status: number) => void
+
+    /**
+     * Calls the provided callback whenever Mixxx receives a MIDI signal with the first two bytes matching the
+     * provided status and midino argument.
+     * @param status
+     * @param midino
+     * @param callback
+     * @see https://github.com/mixxxdj/mixxx/wiki/midi%20scripting
+     * @see https://github.com/mixxxdj/mixxx/wiki/Midi-Crash-Course
+     */
+    function makeInputHandler(status: number, midino: number, callback: InputCallback): MidiInputHandlerController
 }

--- a/res/controllers/midi-controller-api.d.ts
+++ b/res/controllers/midi-controller-api.d.ts
@@ -30,7 +30,7 @@ declare namespace midi {
      */
     function sendSysexMsg(dataList: number[], length?: number): void;
 
-    type InputCallback = (channel: string, control: string, value: number, status: number) => void
+    type InputCallback = (channel: string, control: string, value: number, status: number, group: string) => void
 
     /**
      * Calls the provided callback whenever Mixxx receives a MIDI signal with the first two bytes matching the

--- a/res/controllers/midi-controller-api.d.ts
+++ b/res/controllers/midi-controller-api.d.ts
@@ -30,7 +30,7 @@ declare namespace midi {
      */
     function sendSysexMsg(dataList: number[], length?: number): void;
 
-    type InputCallback = (channel: string, control: string, value: number, status: number, group: string) => void
+    type InputCallback = (channel: string, control: string, value: number, status: number) => void
 
     /**
      * Calls the provided callback whenever Mixxx receives a MIDI signal with the first two bytes matching the

--- a/src/controllers/controller.cpp
+++ b/src/controllers/controller.cpp
@@ -47,7 +47,7 @@ void Controller::startEngine()
     QObject::connect(m_pScriptEngineLegacy,
             &ControllerScriptEngineBase::beforeShutdown,
             this,
-            &Controller::onBeforeEngineShutdown);
+            &Controller::slotBeforeEngineShutdown);
 }
 
 void Controller::stopEngine() {
@@ -56,11 +56,6 @@ void Controller::stopEngine() {
         qCWarning(m_logBase) << "Controller::stopEngine(): No engine exists!";
         return;
     }
-
-    QObject::disconnect(m_pScriptEngineLegacy,
-            &ControllerScriptEngineBase::beforeShutdown,
-            this,
-            &Controller::onBeforeEngineShutdown);
 
     delete m_pScriptEngineLegacy;
     m_pScriptEngineLegacy = nullptr;
@@ -157,7 +152,7 @@ void Controller::receive(const QByteArray& data, mixxx::Duration timestamp) {
 
     m_pScriptEngineLegacy->handleIncomingData(data);
 }
-void Controller::onBeforeEngineShutdown() {
+void Controller::slotBeforeEngineShutdown() {
     /* Override this to get called before the JS engine shuts down */
     qCDebug(m_logInput) << "Engine shutdown";
 }

--- a/src/controllers/controller.cpp
+++ b/src/controllers/controller.cpp
@@ -44,6 +44,10 @@ void Controller::startEngine()
         stopEngine();
     }
     m_pScriptEngineLegacy = new ControllerScriptEngineLegacy(this, m_logBase);
+    QObject::connect(m_pScriptEngineLegacy,
+            &ControllerScriptEngineBase::beforeShutdown,
+            this,
+            &Controller::onBeforeEngineShutdown);
 }
 
 void Controller::stopEngine() {
@@ -52,6 +56,12 @@ void Controller::stopEngine() {
         qCWarning(m_logBase) << "Controller::stopEngine(): No engine exists!";
         return;
     }
+
+    QObject::disconnect(m_pScriptEngineLegacy,
+            &ControllerScriptEngineBase::beforeShutdown,
+            this,
+            &Controller::onBeforeEngineShutdown);
+
     delete m_pScriptEngineLegacy;
     m_pScriptEngineLegacy = nullptr;
 }
@@ -146,4 +156,8 @@ void Controller::receive(const QByteArray& data, mixxx::Duration timestamp) {
     }
 
     m_pScriptEngineLegacy->handleIncomingData(data);
+}
+void Controller::onBeforeEngineShutdown() {
+    /* Override this to get called before the JS engine shuts down */
+    qCDebug(m_logInput) << "Engine shutdown";
 }

--- a/src/controllers/controller.h
+++ b/src/controllers/controller.h
@@ -71,6 +71,7 @@ class Controller : public QObject {
     virtual void receive(const QByteArray& data, mixxx::Duration timestamp);
 
     virtual bool applyMapping();
+    virtual void onBeforeEngineShutdown();
 
     // Puts the controller in and out of learning mode.
     void startLearning();
@@ -169,6 +170,7 @@ class Controller : public QObject {
     friend class ControllerManager;
     // For testing
     friend class LegacyControllerMappingValidationTest;
+    friend class MidiControllerTest;
 };
 
 // An object of this class gets exposed to the JS engine, so the methods of this class

--- a/src/controllers/controller.h
+++ b/src/controllers/controller.h
@@ -71,7 +71,7 @@ class Controller : public QObject {
     virtual void receive(const QByteArray& data, mixxx::Duration timestamp);
 
     virtual bool applyMapping();
-    virtual void onBeforeEngineShutdown();
+    virtual void slotBeforeEngineShutdown();
 
     // Puts the controller in and out of learning mode.
     void startLearning();

--- a/src/controllers/controllerinputmappingtablemodel.cpp
+++ b/src/controllers/controllerinputmappingtablemodel.cpp
@@ -197,6 +197,11 @@ QVariant ControllerInputMappingTableModel::data(const QModelIndex& index,
         }
 
         const MidiInputMapping& mapping = m_midiInputMappings.at(row);
+
+        if (std::holds_alternative<QJSValue>(mapping.control)) {
+            return QVariant();
+        }
+
         switch (column) {
             case MIDI_COLUMN_CHANNEL:
                 return MidiUtils::channelFromStatus(mapping.key.status);
@@ -213,9 +218,12 @@ QVariant ControllerInputMappingTableModel::data(const QModelIndex& index,
             case MIDI_COLUMN_ACTION:
                 if (role == Qt::UserRole) {
                     // TODO(rryan): somehow get the delegate display text?
-                    return QVariant(mapping.control.group + QStringLiteral(",") + mapping.control.item);
+                    return QVariant(
+                            std::get<ConfigKey>(mapping.control).group +
+                            QStringLiteral(",") +
+                            std::get<ConfigKey>(mapping.control).item);
                 }
-                return QVariant::fromValue(mapping.control);
+                return QVariant::fromStdVariant(mapping.control);
             case MIDI_COLUMN_COMMENT:
                 return mapping.description;
             default:
@@ -233,6 +241,10 @@ QString ControllerInputMappingTableModel::getDisplayString(const QModelIndex& in
     int row = index.row();
     int column = index.column();
     const MidiInputMapping& mapping = m_midiInputMappings.at(row);
+
+    if (!std::holds_alternative<ConfigKey>(mapping.control)) {
+        return QString();
+    }
 
     switch (column) {
     case MIDI_COLUMN_COMMENT: {
@@ -259,7 +271,7 @@ QString ControllerInputMappingTableModel::getDisplayString(const QModelIndex& in
         // untranslated script control
         return data(index, Qt::UserRole).toString() + QStringLiteral(" ") +
                 del->displayText(
-                        QVariant::fromValue(mapping.control), QLocale());
+                        QVariant::fromStdVariant(mapping.control), QLocale());
     }
     default:
         return QString();

--- a/src/controllers/controllerinputmappingtablemodel.cpp
+++ b/src/controllers/controllerinputmappingtablemodel.cpp
@@ -202,6 +202,12 @@ QVariant ControllerInputMappingTableModel::data(const QModelIndex& index,
             return QVariant();
         }
 
+        const auto* const control = std::get_if<ConfigKey>(&mapping.control);
+
+        VERIFY_OR_DEBUG_ASSERT(control != nullptr) {
+            return QVariant();
+        }
+
         switch (column) {
             case MIDI_COLUMN_CHANNEL:
                 return MidiUtils::channelFromStatus(mapping.key.status);
@@ -218,12 +224,9 @@ QVariant ControllerInputMappingTableModel::data(const QModelIndex& index,
             case MIDI_COLUMN_ACTION:
                 if (role == Qt::UserRole) {
                     // TODO(rryan): somehow get the delegate display text?
-                    return QVariant(
-                            std::get<ConfigKey>(mapping.control).group +
-                            QStringLiteral(",") +
-                            std::get<ConfigKey>(mapping.control).item);
+                    return QVariant(control->group + QStringLiteral(",") + control->item);
                 }
-                return QVariant::fromValue(&std::get<ConfigKey>(mapping.control));
+                return QVariant::fromValue(control);
             case MIDI_COLUMN_COMMENT:
                 return mapping.description;
             default:

--- a/src/controllers/controllerinputmappingtablemodel.cpp
+++ b/src/controllers/controllerinputmappingtablemodel.cpp
@@ -198,7 +198,7 @@ QVariant ControllerInputMappingTableModel::data(const QModelIndex& index,
 
         const MidiInputMapping& mapping = m_midiInputMappings.at(row);
 
-        if (std::holds_alternative<QJSValue>(mapping.control)) {
+        if (std::holds_alternative<std::shared_ptr<QJSValue>>(mapping.control)) {
             return QVariant();
         }
 
@@ -223,7 +223,7 @@ QVariant ControllerInputMappingTableModel::data(const QModelIndex& index,
                             QStringLiteral(",") +
                             std::get<ConfigKey>(mapping.control).item);
                 }
-                return QVariant::fromStdVariant(mapping.control);
+                return QVariant::fromValue(&std::get<ConfigKey>(mapping.control));
             case MIDI_COLUMN_COMMENT:
                 return mapping.description;
             default:

--- a/src/controllers/midi/legacymidicontrollermapping.cpp
+++ b/src/controllers/midi/legacymidicontrollermapping.cpp
@@ -21,6 +21,13 @@ void LegacyMidiControllerMapping::removeInputMapping(uint16_t key) {
     setDirty(true);
 }
 
+bool LegacyMidiControllerMapping::removeInputMapping(
+        uint16_t key, const MidiInputMapping& mapping) {
+    auto result = m_inputMappings.remove(key, mapping);
+    setDirty(true);
+    return result > 0;
+}
+
 const QMultiHash<uint16_t, MidiInputMapping>&
 LegacyMidiControllerMapping::getInputMappings() const {
     return m_inputMappings;
@@ -58,4 +65,9 @@ void LegacyMidiControllerMapping::setOutputMappings(
         m_outputMappings.unite(mappings);
         setDirty(true);
     }
+}
+void LegacyMidiControllerMapping::removeInputHandlerMappings() {
+    m_inputMappings.removeIf([](std::pair<const uint16_t&, MidiInputMapping&> it) {
+        return !std::holds_alternative<ConfigKey>(it.second.control);
+    });
 }

--- a/src/controllers/midi/legacymidicontrollermapping.h
+++ b/src/controllers/midi/legacymidicontrollermapping.h
@@ -23,6 +23,8 @@ class LegacyMidiControllerMapping : public LegacyControllerMapping {
     // Input mappings
     void addInputMapping(uint16_t key, const MidiInputMapping& mapping);
     void removeInputMapping(uint16_t key);
+    bool removeInputMapping(uint16_t key, const MidiInputMapping& mapping);
+    void removeInputHandlerMappings();
     const QMultiHash<uint16_t, MidiInputMapping>& getInputMappings() const;
     void setInputMappings(const QMultiHash<uint16_t, MidiInputMapping>& mappings);
 

--- a/src/controllers/midi/legacymidicontrollermappingfilehandler.cpp
+++ b/src/controllers/midi/legacymidicontrollermappingfilehandler.cpp
@@ -271,10 +271,15 @@ QDomElement LegacyMidiControllerMappingFileHandler::makeTextElement(QDomDocument
 
 QDomElement LegacyMidiControllerMappingFileHandler::inputMappingToXML(
         QDomDocument* doc, const MidiInputMapping& mapping) const {
+    if (std::holds_alternative<QJSValue>(mapping.control)) {
+        return QDomElement();
+    }
+
     QDomElement controlNode = doc->createElement("control");
 
-    controlNode.appendChild(makeTextElement(doc, "group", mapping.control.group));
-    controlNode.appendChild(makeTextElement(doc, "key", mapping.control.item));
+    controlNode.appendChild(makeTextElement(
+            doc, "group", std::get<ConfigKey>(mapping.control).group));
+    controlNode.appendChild(makeTextElement(doc, "key", std::get<ConfigKey>(mapping.control).item));
     if (!mapping.description.isEmpty()) {
         controlNode.appendChild(
                 makeTextElement(doc, "description", mapping.description));

--- a/src/controllers/midi/legacymidicontrollermappingfilehandler.cpp
+++ b/src/controllers/midi/legacymidicontrollermappingfilehandler.cpp
@@ -271,7 +271,7 @@ QDomElement LegacyMidiControllerMappingFileHandler::makeTextElement(QDomDocument
 
 QDomElement LegacyMidiControllerMappingFileHandler::inputMappingToXML(
         QDomDocument* doc, const MidiInputMapping& mapping) const {
-    if (std::holds_alternative<QJSValue>(mapping.control)) {
+    if (std::holds_alternative<std::shared_ptr<QJSValue>>(mapping.control)) {
         return QDomElement();
     }
 

--- a/src/controllers/midi/midicontroller.cpp
+++ b/src/controllers/midi/midicontroller.cpp
@@ -208,7 +208,7 @@ void MidiController::learnTemporaryInputMappings(const MidiInputMappings& mappin
                             qDebug() << "Set mapping for" << message << "to"
                                      << control.group << control.item;
                         },
-                        [message](const QJSValue& control) {
+                        [message](const std::shared_ptr<QJSValue>& control) {
                             Q_UNUSED(control);
                             qDebug() << "Set mapping for" << message << "to lambda";
                         }},
@@ -328,14 +328,14 @@ void MidiController::processInputMapping(const MidiInputMapping& mapping,
                             return;
                         },
                         [this, pEngine, channel, control, value, status](
-                                QJSValue function) {
+                                const std::shared_ptr<QJSValue>& function) {
                             const auto args = QJSValueList{
                                     channel,
                                     control,
                                     value,
                                     status,
                             };
-                            if (!pEngine->executeFunction(&function, args)) {
+                            if (!pEngine->executeFunction(function.get(), args)) {
                                 qCWarning(m_logBase)
                                         << "MidiController: Invalid "
                                            "anonymous script function";
@@ -633,7 +633,7 @@ QJSValue MidiController::makeInputHandler(int status, int midino, const QJSValue
     MidiInputMapping inputMapping(
             MidiKey(status, midino),
             MidiOption::Script,
-            scriptCode);
+            std::make_shared<QJSValue>(scriptCode));
 
     m_pMapping->addInputMapping(inputMapping.key.key, inputMapping);
     return pJsEngine->newQObject(new MidiInputHandleJSProxy(m_pMapping, inputMapping));

--- a/src/controllers/midi/midicontroller.h
+++ b/src/controllers/midi/midicontroller.h
@@ -1,11 +1,27 @@
 #pragma once
 
+#include <QJSValue>
+#include <utility>
+
 #include "controllers/controller.h"
 #include "controllers/midi/legacymidicontrollermappingfilehandler.h"
 #include "controllers/midi/midimessage.h"
 #include "controllers/softtakeover.h"
 
 class MidiOutputHandler;
+
+class MidiInputHandleJSProxy final : public QObject {
+    Q_OBJECT
+  public:
+    MidiInputHandleJSProxy(
+            const std::shared_ptr<LegacyMidiControllerMapping> mapping,
+            const MidiInputMapping& inputMapping);
+    Q_INVOKABLE bool disconnect();
+
+  protected:
+    std::shared_ptr<LegacyMidiControllerMapping> m_mapping;
+    MidiInputMapping m_inputMapping;
+};
 
 /// MIDI Controller base class
 ///
@@ -51,6 +67,8 @@ class MidiController : public Controller {
         send(data);
     }
 
+    QJSValue makeInputHandler(int status, int midino, const QJSValue& scriptCode);
+
   protected slots:
     virtual void receivedShortMessage(
             unsigned char status,
@@ -60,6 +78,7 @@ class MidiController : public Controller {
     // For receiving System Exclusive messages
     void receive(const QByteArray& data, mixxx::Duration timestamp) override;
     int close() override;
+    void onBeforeEngineShutdown() override;
 
   private slots:
     bool applyMapping() override;
@@ -116,6 +135,10 @@ class MidiControllerJSProxy : public ControllerJSProxy {
 
     Q_INVOKABLE void sendSysexMsg(const QList<int>& data, unsigned int length = 0) {
         m_pMidiController->sendSysexMsg(data, length);
+    }
+
+    Q_INVOKABLE QJSValue makeInputHandler(int status, int midino, const QJSValue& scriptCode) {
+        return m_pMidiController->makeInputHandler(status, midino, scriptCode);
     }
 
   private:

--- a/src/controllers/midi/midicontroller.h
+++ b/src/controllers/midi/midicontroller.h
@@ -89,7 +89,7 @@ class MidiController : public Controller {
 
   private:
     void processInputMapping(
-            MidiInputMapping& mapping,
+            const MidiInputMapping& mapping,
             unsigned char status,
             unsigned char control,
             unsigned char value,

--- a/src/controllers/midi/midicontroller.h
+++ b/src/controllers/midi/midicontroller.h
@@ -78,7 +78,7 @@ class MidiController : public Controller {
     // For receiving System Exclusive messages
     void receive(const QByteArray& data, mixxx::Duration timestamp) override;
     int close() override;
-    void onBeforeEngineShutdown() override;
+    void slotBeforeEngineShutdown() override;
 
   private slots:
     bool applyMapping() override;
@@ -89,7 +89,7 @@ class MidiController : public Controller {
 
   private:
     void processInputMapping(
-            const MidiInputMapping& mapping,
+            MidiInputMapping& mapping,
             unsigned char status,
             unsigned char control,
             unsigned char value,

--- a/src/controllers/midi/midimessage.h
+++ b/src/controllers/midi/midimessage.h
@@ -222,12 +222,10 @@ struct MidiInputMapping {
                         std::get<ConfigKey>(control) == std::get<ConfigKey>(other.control) &&
                         description == other.description;
             } else if constexpr (std::is_same_v<T, std::shared_ptr<QJSValue>>) {
-                const std::shared_ptr<QJSValue> otherControl =
-                        std::get<std::shared_ptr<QJSValue>>(other.control);
-                const std::shared_ptr<QJSValue> thisControl =
-                        std::get<std::shared_ptr<QJSValue>>(control);
+                const auto& otherControl = std::get<std::shared_ptr<QJSValue>>(other.control);
+                const auto& thisControl = std::get<std::shared_ptr<QJSValue>>(control);
                 return key == other.key && options == other.options &&
-                        otherControl->strictlyEquals(*thisControl) &&
+                        thisControl->strictlyEquals(*otherControl) &&
                         description == other.description;
             } else
                 static_assert(always_false_v<T>, "non-exhaustive visitor");

--- a/src/controllers/midi/midimessage.h
+++ b/src/controllers/midi/midimessage.h
@@ -236,6 +236,7 @@ struct MidiInputMapping {
 
     MidiKey key;
     MidiOptions options;
+    // TODO: find a new name to represent both an XML's control entry and an anonymous JS function
     std::variant<ConfigKey, std::shared_ptr<QJSValue>> control;
     QString description;
 };

--- a/src/controllers/midi/midiutils.h
+++ b/src/controllers/midi/midiutils.h
@@ -66,4 +66,14 @@ class MidiUtils {
     static QString formatSysexMessage(const QString& controllerName,
                               const QByteArray& data,
                               mixxx::Duration timestamp = mixxx::Duration::fromMillis(0));
+
+    template<class... Ts>
+    struct overloaded : Ts... {
+        using Ts::operator()...;
+    };
+#if __cplusplus < 202002L || defined(__clang__)
+    // explicit deduction guide (not needed as of C++20)
+    template<class... Ts>
+    overloaded(Ts...) -> overloaded<Ts...>;
+#endif
 };

--- a/src/controllers/scripting/controllerscriptenginebase.cpp
+++ b/src/controllers/scripting/controllerscriptenginebase.cpp
@@ -58,6 +58,7 @@ bool ControllerScriptEngineBase::initialize() {
 
 void ControllerScriptEngineBase::shutdown() {
     DEBUG_ASSERT(m_pJSEngine.use_count() == 1);
+    emit beforeShutdown();
     m_pJSEngine.reset();
 }
 

--- a/src/controllers/scripting/controllerscriptenginebase.h
+++ b/src/controllers/scripting/controllerscriptenginebase.h
@@ -40,6 +40,9 @@ class ControllerScriptEngineBase : public QObject {
         return m_bTesting;
     }
 
+  signals:
+    void beforeShutdown();
+
   protected:
     virtual void shutdown();
 
@@ -63,4 +66,5 @@ class ControllerScriptEngineBase : public QObject {
     void errorDialogButton(const QString& key, QMessageBox::StandardButton button);
 
     friend class ColorMapperJSProxy;
+    friend class MidiControllerTest;
 };

--- a/src/controllers/scripting/legacy/controllerscriptenginelegacy.h
+++ b/src/controllers/scripting/legacy/controllerscriptenginelegacy.h
@@ -26,6 +26,10 @@ class ControllerScriptEngineLegacy : public ControllerScriptEngineBase {
     /// and ensures the function is executed with the correct 'this' object.
     QJSValue wrapFunctionCode(const QString& codeSnippet, int numberOfArgs);
 
+    std::shared_ptr<QJSEngine> jsEngine() const {
+        return m_pJSEngine;
+    }
+
   public slots:
     void setScriptFiles(const QList<LegacyControllerMapping::ScriptFileInfo>& scripts);
 
@@ -50,9 +54,7 @@ class ControllerScriptEngineLegacy : public ControllerScriptEngineBase {
     // There is lots of tight coupling between ControllerScriptEngineLegacy
     // and ControllerScriptInterface. This is probably not worth improving in legacy code.
     friend class ControllerScriptInterfaceLegacy;
-    std::shared_ptr<QJSEngine> jsEngine() const {
-        return m_pJSEngine;
-    }
 
     friend class ControllerScriptEngineLegacyTest;
+    friend class MidiControllerTest;
 };

--- a/src/test/learningutilstest.cpp
+++ b/src/test/learningutilstest.cpp
@@ -29,7 +29,7 @@ class LearningUtilsTest : public MixxxTest {
         for (const MidiInputMapping& mapping : haystack) {
             if (mapping.key == needle.key &&
                     mapping.options == needle.options &&
-                    mapping.control == needle.control) {
+                    std::get<ConfigKey>(mapping.control) == std::get<ConfigKey>(needle.control)) {
                 return true;
             }
         }


### PR DESCRIPTION
This is a try at implementing the [*Registering MIDI Input Handlers From Javascript*](https://github.com/mixxxdj/mixxx/wiki/registering-midi-input-handlers-from-javascript).

My C++ knowledge is close to zero so beware of the memory managment problems ahead.

The implementation is still very rough as I am discovering the code. Nothing has been tested yet. I'm opening this PR to get review as early as possible. I still have to connect the `MidiInputHandlerController` to the QJSEngine.

I will appreciate any hint on this feature.