### PR TITLE
Tracks: select track row when clicking the preview button (only when starting preview)

### DIFF
--- a/src/library/previewbuttondelegate.cpp
+++ b/src/library/previewbuttondelegate.cpp
@@ -49,8 +49,7 @@ PreviewButtonDelegate::PreviewButtonDelegate(
           m_column(column),
           m_pPreviewDeckPlay(make_parented<ControlProxy>(
                   kPreviewDeckGroup, QStringLiteral("play"), this)),
-          m_pCueGotoAndPlay(make_parented<ControlProxy>(
-                  kPreviewDeckGroup, QStringLiteral("cue_gotoandplay"), this)),
+          m_pCueGotoAndPlay(kPreviewDeckGroup, QStringLiteral("cue_gotoandplay")),
           m_pButton(make_parented<LibraryPreviewButton>(parent)) {
     DEBUG_ASSERT(m_column >= 0);
 
@@ -226,7 +225,7 @@ void PreviewButtonDelegate::buttonClicked() {
     } else if (pTrack == pOldTrack && !isPreviewDeckPlaying()) {
         // Since the Preview deck might be hidden, starting at the main cue
         // is a predictable behavior.
-        m_pCueGotoAndPlay->set(1.0);
+        m_pCueGotoAndPlay.set(1.0);
         startedPlaying = true;
     } else {
         m_pPreviewDeckPlay->set(0.0);

--- a/src/library/previewbuttondelegate.cpp
+++ b/src/library/previewbuttondelegate.cpp
@@ -217,15 +217,23 @@ void PreviewButtonDelegate::buttonClicked() {
 
     TrackPointer pOldTrack = PlayerInfo::instance().getTrackInfo(kPreviewDeckGroup);
 
+    bool startedPlaying = false;
     TrackPointer pTrack = pTrackModel->getTrack(m_currentEditedCellIndex);
     if (pTrack && pTrack != pOldTrack) {
+        // Load to preview deck and start playing
         emit loadTrackToPlayer(pTrack, kPreviewDeckGroup, true);
+        startedPlaying = true;
     } else if (pTrack == pOldTrack && !isPreviewDeckPlaying()) {
-        // Since the Preview deck might be hidden
-        // Starting at cue is a predictable behavior
+        // Since the Preview deck might be hidden, starting at the main cue
+        // is a predictable behavior.
         m_pCueGotoAndPlay->set(1.0);
+        startedPlaying = true;
     } else {
         m_pPreviewDeckPlay->set(0.0);
+    }
+    // If we start previewing also select the track (the table view didn't receive the click)
+    if (startedPlaying) {
+        m_pTableView->selectRow(m_currentEditedCellIndex.row());
     }
 }
 

--- a/src/library/previewbuttondelegate.h
+++ b/src/library/previewbuttondelegate.h
@@ -2,6 +2,7 @@
 
 #include <QPushButton>
 
+#include "control/pollingcontrolproxy.h"
 #include "library/tableitemdelegate.h"
 #include "track/track_decl.h"
 #include "util/parented_ptr.h"
@@ -31,9 +32,12 @@ class PreviewButtonDelegate : public TableItemDelegate {
             const QStyleOptionViewItem& option,
             const QModelIndex& index) const override;
 
+    // Apparently this no-op override is required to trigger a paint
+    // event after row has been painted with the 'selected' style. (Qt 5)
     void setEditorData(
             QWidget* editor,
             const QModelIndex& index) const override;
+    // Seems this is not required
     void setModelData(
             QWidget* editor,
             QAbstractItemModel* model,
@@ -74,7 +78,7 @@ class PreviewButtonDelegate : public TableItemDelegate {
     const int m_column;
 
     const parented_ptr<ControlProxy> m_pPreviewDeckPlay;
-    const parented_ptr<ControlProxy> m_pCueGotoAndPlay;
+    PollingControlProxy m_pCueGotoAndPlay;
 
     const parented_ptr<LibraryPreviewButton> m_pButton;
 


### PR DESCRIPTION
Low prio, draft until we discussed if that is desired or conflicts with library use cases.

Selects the Preview row if Preview button is clicked to **start previewing**, no seletion change if preview is stopped.

The use case mentioned in #12789 is
* click Preview
* scroll right to read metadata in offscreen columns
* have some highlight to keep track of the row


Quoting myself:
> I can't imagine why one would like to keep the current selection when clicking the preview button. On the contrary, that would simplify loading that track to a deck (with Return key if double-click is configured accordingly in the Library preferences, Mixxx 2.4)

I think simply selecting the row is predictable (consistency with other columns).
Some other highlight is certainly feasible  but overkill IMHO.