### PR TITLE
Lenient taglib 2.0 guard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2941,11 +2941,7 @@ target_link_libraries(mixxx-lib PRIVATE SoundTouch::SoundTouch)
 find_package(TagLib 1.11 REQUIRED)
 target_link_libraries(mixxx-lib PRIVATE TagLib::TagLib)
 if (NOT TagLib_VERSION VERSION_LESS 2.0.0)
-    message(FATAL_ERROR "Installed Taglib ${TagLib_VERSION} is not supported. Use Version >= 1.11 and < 2.0 and its development headers.")
-    # Dear package maintainer: Do not patch away this fatal error
-    # using taglib 2.0.0 will put user data at risk!!
-    # Mixxx is a complex application that needs to be adapted and tested thoroughly
-    # https://github.com/mixxxdj/mixxx/issues/12708
+  message(WARNING "Installed Taglib ${TagLib_VERSION} is not supported and might lead to data loss (https://github.com/mixxxdj/mixxx/issues/12708). Use version >= 1.11 and < 2.0 instead.")
 endif()
 
 # Threads


### PR DESCRIPTION
Follow up to #12775.

This downgrades the include guard to a warning to allow Mixxx being built with TagLib 2.0 is desired. Due to the warning, the user is still made aware of the possible implications.