### PR TITLE
feat: add QML interceptor to auto reload on file change

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2688,6 +2688,7 @@ if(QML)
   target_sources(mixxx-qml-lib PRIVATE
     src/qml/asyncimageprovider.cpp
     src/qml/qmlapplication.cpp
+    src/qml/qmlautoreload.cpp
     src/qml/qmlcontrolproxy.cpp
     src/qml/qmlconfigproxy.cpp
     src/qml/qmldlgpreferencesproxy.cpp

--- a/src/qml/qmlapplication.cpp
+++ b/src/qml/qmlapplication.cpp
@@ -45,7 +45,7 @@ QmlApplication::QmlApplication(
         : m_pCoreServices(pCoreServices),
           m_mainFilePath(pCoreServices->getSettings()->getResourcePath() + kMainQmlFileName),
           m_pAppEngine(nullptr),
-          m_fileWatcher({m_mainFilePath}) {
+          m_autoReload() {
     m_pCoreServices->initialize(app);
     SoundDeviceStatus result = m_pCoreServices->getSoundManager()->setupDevices();
     if (result != SoundDeviceStatus::Ok) {
@@ -83,10 +83,12 @@ QmlApplication::QmlApplication(
 
     pCoreServices->getControllerManager()->setUpDevices();
 
-    connect(&m_fileWatcher,
-            &QFileSystemWatcher::fileChanged,
+    connect(&m_autoReload,
+            &QmlAutoReload::triggered,
             this,
-            &QmlApplication::loadQml);
+            [this]() {
+                loadQml(m_mainFilePath);
+            });
 }
 
 QmlApplication::~QmlApplication() {
@@ -103,6 +105,8 @@ void QmlApplication::loadQml(const QString& path) {
     // so it is necessary to destroy the old QQmlApplicationEngine and create a new one.
     m_pAppEngine = std::make_unique<QQmlApplicationEngine>();
 
+    m_autoReload.clear();
+    m_pAppEngine->addUrlInterceptor(&m_autoReload);
     m_pAppEngine->addImportPath(QStringLiteral(":/mixxx.org/imports"));
 
     // No memory leak here, the QQmlEngine takes ownership of the provider

--- a/src/qml/qmlapplication.h
+++ b/src/qml/qmlapplication.h
@@ -5,6 +5,7 @@
 #include <QQmlApplicationEngine>
 
 #include "coreservices.h"
+#include "qmlautoreload.h"
 
 namespace mixxx {
 namespace qml {
@@ -26,7 +27,7 @@ class QmlApplication : public QObject {
     QString m_mainFilePath;
 
     std::unique_ptr<QQmlApplicationEngine> m_pAppEngine;
-    QFileSystemWatcher m_fileWatcher;
+    QmlAutoReload m_autoReload;
 };
 
 } // namespace qml

--- a/src/qml/qmlautoreload.cpp
+++ b/src/qml/qmlautoreload.cpp
@@ -1,0 +1,43 @@
+#include "qml/qmlautoreload.h"
+
+#include <QDebug>
+#include <QFileInfo>
+#include <QUrl>
+
+#include "moc_qmlautoreload.cpp"
+
+namespace mixxx {
+
+namespace qml {
+
+QmlAutoReload::QmlAutoReload() {
+    connect(&m_fileWatcher,
+            &QFileSystemWatcher::fileChanged,
+            this,
+            &QmlAutoReload::slotFileChanged);
+}
+
+QUrl QmlAutoReload::intercept(const QUrl& url, QQmlAbstractUrlInterceptor::DataType type) {
+    if (!url.isLocalFile() || !QFileInfo(url.toLocalFile()).isFile()) {
+        return url;
+    }
+    m_fileWatcher.addPath(url.toLocalFile());
+    return url;
+}
+
+void QmlAutoReload::slotFileChanged(const QString& changedFile) {
+    qDebug() << "File" << changedFile << "used in QML interface has been changed.";
+    // This is to prevent double-reload when a file is updated twice
+    // in a row as part of the normal saving process. See note in
+    // QFileSystemWatcher::fileChanged documentation.
+    if (m_fileWatcher.removePath(changedFile)) {
+        emit triggered();
+    }
+}
+
+void QmlAutoReload::clear() {
+    m_fileWatcher.removePaths(m_fileWatcher.files());
+}
+
+} // namespace qml
+} // namespace mixxx

--- a/src/qml/qmlautoreload.h
+++ b/src/qml/qmlautoreload.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <QFileSystemWatcher>
+#include <QObject>
+#include <QQmlAbstractUrlInterceptor>
+#include <QSet>
+
+namespace mixxx {
+namespace qml {
+
+class QmlAutoReload : public QObject, public QQmlAbstractUrlInterceptor {
+    Q_OBJECT
+  public:
+    explicit QmlAutoReload();
+
+    QUrl intercept(const QUrl& url, QQmlAbstractUrlInterceptor::DataType type) override;
+
+  signals:
+    void triggered();
+
+  private slots:
+    void slotFileChanged(const QString& changedFile);
+
+  public slots:
+    void clear();
+
+  private:
+    QFileSystemWatcher m_fileWatcher;
+};
+
+} // namespace qml
+} // namespace mixxx


### PR DESCRIPTION
Currently, when working on the QML interface, if you want to hot reload that last one, you need to trigger a file change on `res/qml/main.qml` as it is the only file watched (e.g `touch res/qml/main.qml`). This makes the dev experience on the QML interface not very friendly. 
This small change extends the QML app file watcher to dynamically "learn" file that are actively used in the interface such as QML component or SVG assets and watches them for hot-reload on change