### PR TITLE
Pref multi sampling enum

### DIFF
--- a/src/preferences/constants.h
+++ b/src/preferences/constants.h
@@ -2,6 +2,8 @@
 
 namespace mixxx {
 
+Q_NAMESPACE
+
 // Don't change these constants since they are stored in user configuration
 // files.
 enum class TooltipsPreference {
@@ -16,5 +18,15 @@ enum class ScreenSaverPreference {
     PREVENT_ON = 1,
     PREVENT_ON_PLAY = 2
 };
+
+enum class MultiSamplingMode {
+    Disabled = 0,
+    Two = 2,
+    Four = 4,
+    Eight = 8,
+    Sixteen = 16
+};
+
+Q_ENUM_NS(MultiSamplingMode);
 
 }  // namespace mixxx

--- a/src/preferences/dialog/dlgprefinterface.cpp
+++ b/src/preferences/dialog/dlgprefinterface.cpp
@@ -325,6 +325,10 @@ void DlgPrefInterface::slotResetToDefaults() {
     comboBoxScreensaver->setCurrentIndex(comboBoxScreensaver->findData(
         static_cast<int>(mixxx::ScreenSaverPreference::PREVENT_ON)));
 
+#ifdef MIXXX_USE_QML
+    mulitSamplingComboBox->setCurrentIndex(4); // 4x MSAA
+#endif
+
 #ifdef Q_OS_IOS
     // Tooltips off everywhere.
     radioButtonTooltipsOff->setChecked(true);
@@ -446,18 +450,25 @@ void DlgPrefInterface::slotApply() {
                 static_cast<mixxx::ScreenSaverPreference>(screensaverComboBoxState));
     }
 
+#ifdef MIXXX_USE_QML
     int multiSampling = mulitSamplingComboBox->itemData(
                                                      mulitSamplingComboBox->currentIndex())
                                 .toInt();
     m_pConfig->set(ConfigKey(kPreferencesGroup, kMultiSamplingKey), ConfigValue(multiSampling));
+#endif
 
-    if (locale != m_localeOnUpdate || scaleFactor != m_dScaleFactor ||
-            multiSampling != m_multiSampling) {
+    if (locale != m_localeOnUpdate || scaleFactor != m_dScaleFactor
+#ifdef MIXXX_USE_QML
+            || multiSampling != m_multiSampling
+#endif
+    ) {
         notifyRebootNecessary();
         // hack to prevent showing the notification when pressing "Okay" after "Apply"
         m_localeOnUpdate = locale;
         m_dScaleFactor = scaleFactor;
+#ifdef MIXXX_USE_QML
         m_multiSampling = multiSampling;
+#endif
     }
 
     // load skin/scheme if necessary

--- a/src/preferences/dialog/dlgprefinterface.cpp
+++ b/src/preferences/dialog/dlgprefinterface.cpp
@@ -182,26 +182,26 @@ DlgPrefInterface::DlgPrefInterface(
     // Multi-Sampling
 #ifdef MIXXX_USE_QML
     if (CmdlineArgs::Instance().isQml()) {
-        mulitSamplingComboBox->clear();
-        mulitSamplingComboBox->addItem(tr("Disabled"), 0);
-        mulitSamplingComboBox->addItem(tr("2x MSAA"), 2);
-        mulitSamplingComboBox->addItem(tr("4x MSAA"), 4);
-        mulitSamplingComboBox->addItem(tr("8x MSAA"), 8);
-        mulitSamplingComboBox->addItem(tr("16x MSAA"), 16);
+        multiSamplingComboBox->clear();
+        multiSamplingComboBox->addItem(tr("Disabled"), 0);
+        multiSamplingComboBox->addItem(tr("2x MSAA"), 2);
+        multiSamplingComboBox->addItem(tr("4x MSAA"), 4);
+        multiSamplingComboBox->addItem(tr("8x MSAA"), 8);
+        multiSamplingComboBox->addItem(tr("16x MSAA"), 16);
 
         m_multiSampling = m_pConfig->getValue(ConfigKey(kPreferencesGroup, kMultiSamplingKey), 4);
-        int mulitSamplingIndex = mulitSamplingComboBox->findData(m_multiSampling);
-        if (mulitSamplingIndex != -1) {
-            mulitSamplingComboBox->setCurrentIndex(mulitSamplingIndex);
+        int multiSamplingIndex = multiSamplingComboBox->findData(m_multiSampling);
+        if (multiSamplingIndex != -1) {
+            multiSamplingComboBox->setCurrentIndex(multiSamplingIndex);
         } else {
-            mulitSamplingComboBox->setCurrentIndex(0);
+            multiSamplingComboBox->setCurrentIndex(0);
             m_pConfig->set(ConfigKey(kPreferencesGroup, kMultiSamplingKey), ConfigValue(0));
         }
     } else
 #endif
     {
-        mulitSamplingLabel->hide();
-        mulitSamplingComboBox->hide();
+        multiSamplingLabel->hide();
+        multiSamplingComboBox->hide();
     }
 
     // Tooltip configuration
@@ -326,7 +326,7 @@ void DlgPrefInterface::slotResetToDefaults() {
         static_cast<int>(mixxx::ScreenSaverPreference::PREVENT_ON)));
 
 #ifdef MIXXX_USE_QML
-    mulitSamplingComboBox->setCurrentIndex(4); // 4x MSAA
+    multiSamplingComboBox->setCurrentIndex(4); // 4x MSAA
 #endif
 
 #ifdef Q_OS_IOS
@@ -451,8 +451,8 @@ void DlgPrefInterface::slotApply() {
     }
 
 #ifdef MIXXX_USE_QML
-    int multiSampling = mulitSamplingComboBox->itemData(
-                                                     mulitSamplingComboBox->currentIndex())
+    int multiSampling = multiSamplingComboBox->itemData(
+                                                     multiSamplingComboBox->currentIndex())
                                 .toInt();
     m_pConfig->set(ConfigKey(kPreferencesGroup, kMultiSamplingKey), ConfigValue(multiSampling));
 #endif

--- a/src/preferences/dialog/dlgprefinterface.h
+++ b/src/preferences/dialog/dlgprefinterface.h
@@ -68,7 +68,7 @@ class DlgPrefInterface : public DlgPreferencePage, public Ui::DlgPrefControlsDlg
     QString m_colorScheme;
     QString m_colorSchemeOnUpdate;
     QString m_localeOnUpdate;
-    int m_multiSampling;
+    mixxx::MultiSamplingMode m_multiSampling;
     mixxx::TooltipsPreference m_tooltipMode;
     double m_dScaleFactor;
     double m_minScaleFactor;

--- a/src/preferences/dialog/dlgprefinterfacedlg.ui
+++ b/src/preferences/dialog/dlgprefinterfacedlg.ui
@@ -270,14 +270,14 @@
        <widget class="QComboBox" name="comboBoxScreensaver"/>
       </item>
       <item row="5" column="0">
-       <widget class="QLabel" name="mulitSamplingLabel">
+       <widget class="QLabel" name="multiSamplingLabel">
         <property name="text">
          <string>Multi-Sampling</string>
         </property>
        </widget>
       </item>
       <item row="5" column="1" colspan="2">
-       <widget class="QComboBox" name="mulitSamplingComboBox"/>
+       <widget class="QComboBox" name="multiSamplingComboBox"/>
       </item>
      </layout>
     </widget>
@@ -294,6 +294,7 @@
   <tabstop>radioButtonTooltipsOff</tabstop>
   <tabstop>radioButtonTooltipsLibrary</tabstop>
   <tabstop>radioButtonTooltipsLibraryAndSkin</tabstop>
+  <tabstop>multiSamplingComboBox</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/qml/qmlconfigproxy.cpp
+++ b/src/qml/qmlconfigproxy.cpp
@@ -2,6 +2,7 @@
 
 #include "moc_qmlconfigproxy.cpp"
 #include "preferences/colorpalettesettings.h"
+#include "preferences/constants.h"
 
 namespace {
 QVariantList paletteToQColorList(const ColorPalette& palette) {
@@ -36,7 +37,9 @@ QVariantList QmlConfigProxy::getTrackColorPalette() {
 }
 
 int QmlConfigProxy::getMultiSamplingLevel() {
-    return m_pConfig->getValue(ConfigKey(kPreferencesGroup, kMultiSamplingKey), 0);
+    return m_pConfig->getValue(
+            ConfigKey(kPreferencesGroup, kMultiSamplingKey),
+            static_cast<int>(mixxx::MultiSamplingMode::Disabled));
 }
 
 // static


### PR DESCRIPTION
based on #12794

Currently this is a mess.
Got it working to a state where it builds but the linker complains, but I'm not motivated to continue this polishing atm.
```
[ 98%] Linking CXX executable mixxx
mold: error: undefined symbol: mixxx::staticMetaObject
>>> referenced by dlgprefinterface.cpp
>>>               libmixxx-lib.a(dlgprefinterface.cpp.o):(QtPrivate::MetaObjectForType<mixxx::MultiSamplingMode, void>::metaObjectFunction(QtPrivate::QMetaTypeInterface const*))>>> referenced by dlgprefinterface.cpp
>>>               libmixxx-lib.a(dlgprefinterface.cpp.o):(QtPrivate::QDebugStreamOperatorForType<mixxx::MultiSamplingMode, true>::debugStream(QtPrivate::QMetaTypeInterface const*, QDebug&, void const*))>>> referenced by dlgprefinterface.cpp
>>>               libmixxx-lib.a(dlgprefinterface.cpp.o):(QtPrivate::QMetaTypeForType<mixxx::MultiSamplingMode>::getLegacyRegister()::{lambda()#1}::_FUN())

```