### PR TITLE
inherit unversioned QOpenGLFunctions instead of QOpenGLFunctions_2_1

### DIFF
--- a/src/waveform/renderers/glwaveformrenderer.h
+++ b/src/waveform/renderers/glwaveformrenderer.h
@@ -2,15 +2,15 @@
 
 #include <QtGui/qtgui-config.h> // for QT_NO_OPENGL and QT_OPENGL_ES_2
 
-#if !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
+#if !defined(QT_NO_OPENGL)
 
-#include <QOpenGLFunctions_2_1>
+#include <QOpenGLFunctions>
 
-class GLWaveformRenderer : protected QOpenGLFunctions_2_1 {
+class GLWaveformRenderer : protected QOpenGLFunctions {
   public:
     virtual void initializeGL() {
         initializeOpenGLFunctions();
     }
 };
 
-#endif // !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
+#endif // !defined(QT_NO_OPENGL)


### PR DESCRIPTION
Currently the aarch64 KDE Flatpak runtime is built with `-opengl es` passed to Qt's configure script. It's questionable whether that's necessary, but regardless, Mixxx can support Qt built with that option.
https://invent.kde.org/packaging/flatpak-kde-runtime/-/issues/19
    
Fixes https://github.com/mixxxdj/mixxx/issues/12802