### PR TITLE
Skins: polish fx chain controls

### DIFF
--- a/res/skins/Deere/effect_unit_controls.xml
+++ b/res/skins/Deere/effect_unit_controls.xml
@@ -113,7 +113,7 @@
             </Connection>
           </PushButton>
 
-          <WidgetGroup><Size>0min,2me</Size></WidgetGroup>
+          <WidgetGroup><Size>0min,2f</Size></WidgetGroup>
 
           <!-- Super/Mix knobs when parameters are visible -->
           <WidgetGroup>
@@ -123,7 +123,7 @@
 
               <WidgetGroup>
                 <Layout>horizontal</Layout>
-                <SizePolicy>min,min</SizePolicy>
+                <SizePolicy>min,max</SizePolicy>
                 <Children>
                   <Template src="skin:left_2state_button.xml">
                     <SetVariable name="ObjectName">EffectUnitMixModeButton</SetVariable>
@@ -145,10 +145,11 @@
                 </Children>
               </WidgetGroup>
 
+              <WidgetGroup><Size>0min,8me</Size></WidgetGroup>
 
               <WidgetGroup>
                 <Layout>horizontal</Layout>
-                <SizePolicy>me,me</SizePolicy>
+                <Size>0me,34f</Size>
                 <Children>
                   <WidgetGroup><Size>0me,0me</Size></WidgetGroup>
                   <EffectChainPresetButton>
@@ -178,6 +179,7 @@
 
                 </Children>
               </WidgetGroup>
+
             </Children>
             <Connection>
               <ConfigKey><Variable name="group"/>,show_parameters</ConfigKey>

--- a/res/skins/LateNight/fx/unit_parameters_visible.xml
+++ b/res/skins/LateNight/fx/unit_parameters_visible.xml
@@ -144,7 +144,7 @@
                 <ObjectName>FxUnit<Variable name="FxUnit"/>_MixmodePfl</ObjectName>
               </SingletonContainer>
 
-              <WidgetGroup><Size>,1f</Size></WidgetGroup>
+              <WidgetGroup><Size>,1me</Size></WidgetGroup>
 
               <SingletonContainer>
                 <ObjectName>FxUnit<Variable name="FxUnit"/>_PresetButton</ObjectName>

--- a/res/skins/Tango/buttons/btn_fx_mixmode_d+w.svg
+++ b/res/skins/Tango/buttons/btn_fx_mixmode_d+w.svg
@@ -1,1 +1,4 @@
-<svg id="svg1966" width="30" height="18" version="1.1" viewBox="0 0 30 18" xmlns="http://www.w3.org/2000/svg"><path id="path817" d="m5 5h20" fill="none" stroke="#b5b5b5" stroke-linecap="round" stroke-opacity=".99216" stroke-width="2"/><path id="path817-3" d="m25 5c-14 3-20 8-20 8" fill="none" stroke="#ec6300" stroke-linecap="round" stroke-width="2"/></svg>
+<svg width="24" height="18" version="1.1" viewBox="0 0 24 18" xmlns="http://www.w3.org/2000/svg">
+  <path d="m5 5h14" fill="none" stroke="#b5b5b5" stroke-linecap="round" stroke-opacity=".99216" stroke-width="2"/>
+  <path d="m19 5c-12 3-14 8-14 8" fill="none" stroke="#ec6300" stroke-linecap="round" stroke-width="2"/>
+</svg>

--- a/res/skins/Tango/buttons/btn_fx_mixmode_d-w.svg
+++ b/res/skins/Tango/buttons/btn_fx_mixmode_d-w.svg
@@ -1,1 +1,4 @@
-<svg id="svg8" width="30" height="18" version="1.1" viewBox="0 0 30 18" xmlns="http://www.w3.org/2000/svg"><path id="path817-3-9-3" d="m5.003 5c14 3 20 8 20 8" fill="none" stroke="#b5b5b5" stroke-linecap="round" stroke-opacity=".99216" stroke-width="2"/><path id="path817-3-9" d="m25 5c-14 3-20 8-20 8" fill="none" stroke="#ec6300" stroke-linecap="round" stroke-width="2"/></svg>
+<svg width="24" height="18" version="1.1" viewBox="0 0 24 18" xmlns="http://www.w3.org/2000/svg">
+  <path d="m5.003 5c12.109322 3.9864389 14.0005 8 14.0005 8" fill="none" stroke="#b5b5b5" stroke-linecap="round" stroke-opacity=".99216" stroke-width="2"/>
+  <path d="M 19.0005,5 C 7.2693137,9.0193218 5,13 5,13" fill="none" stroke="#ec6300" stroke-linecap="round" stroke-width="2"/>
+</svg>

--- a/res/skins/Tango/fx/unit_left.xml
+++ b/res/skins/Tango/fx/unit_left.xml
@@ -212,7 +212,7 @@ Variables:
           <WidgetGroup>
             <ObjectName>FxUnitMixerLeft</ObjectName>
             <Layout>vertical</Layout>
-            <SizePolicy>min,me</SizePolicy>
+            <SizePolicy>max,me</SizePolicy>
             <Children>
               <WidgetGroup>
                 <Layout>horizontal</Layout>
@@ -221,7 +221,7 @@ Variables:
                   <Template src="skins:Tango/controls/button_2state_persist.xml">
                     <SetVariable name="ObjectName">MixModeButton</SetVariable>
                     <SetVariable name="TooltipId">EffectUnit_mix_mode</SetVariable>
-                    <SetVariable name="Size">30f,18f</SetVariable>
+                    <SetVariable name="Size">24f,18f</SetVariable>
                     <SetVariable name="state_0_icon">fx_mixmode_d-w.svg</SetVariable>
                     <SetVariable name="state_1_icon">fx_mixmode_d+w.svg</SetVariable>
                     <SetVariable name="ConfigKey">[EffectRack1_EffectUnit<Variable name="FxUnit"/>],mix_mode</SetVariable>
@@ -238,37 +238,43 @@ Variables:
                 </Children>
               </WidgetGroup>
 
+              <WidgetGroup><Size>1f,0me</Size></WidgetGroup>
+
               <WidgetGroup>
-                <Layout>horizontal</Layout>
                 <SizePolicy>min,min</SizePolicy>
+                <Layout>horizontal</Layout>
                 <Children>
                   <EffectChainPresetButton>
                     <EffectUnit><Variable name="FxUnit"/></EffectUnit>
                     <Size>24f,24f</Size>
                     <ObjectName>EffectChainSelector</ObjectName>
                   </EffectChainPresetButton>
-
-                  <WidgetGroup><!-- Super Knob, if enabled -->
-                    <SizePolicy>min,min</SizePolicy>
-                    <Layout>horizontal</Layout>
-                    <Children>
-                      <WidgetGroup><Size>1min,2min</Size></WidgetGroup>
-                      <Template src="skins:Tango/controls/knob_textless.xml">
-                        <SetVariable name="TooltipId">EffectUnit_super1</SetVariable>
-                        <SetVariable name="ObjectName">SuperWetDryKnob</SetVariable>
-                        <SetVariable name="Size">30f,26f</SetVariable>
-                        <SetVariable name="group">[<Variable name="FxRack_FxUnit"/>]</SetVariable>
-                        <SetVariable name="ConfigKey">super1</SetVariable>
-                        <SetVariable name="Color">blue</SetVariable>
-                      </Template>
-                    </Children>
-                    <Connection>
-                      <ConfigKey persist="true">[Skin],show_superknobs</ConfigKey>
-                      <BindProperty>visible</BindProperty>
-                    </Connection>
-                  </WidgetGroup>
                 </Children>
               </WidgetGroup>
+
+              <WidgetGroup><Size>1f,0me</Size></WidgetGroup>
+
+              <WidgetGroup><!-- Super Knob, if enabled -->
+                <SizePolicy>min,min</SizePolicy>
+                <Layout>horizontal</Layout>
+                <Children>
+                  <WidgetGroup><Size>1min,2min</Size></WidgetGroup>
+                  <Template src="skins:Tango/controls/knob_textless.xml">
+                    <SetVariable name="TooltipId">EffectUnit_super1</SetVariable>
+                    <SetVariable name="ObjectName">SuperWetDryKnob</SetVariable>
+                    <SetVariable name="Size">30f,26f</SetVariable>
+                    <SetVariable name="group">[<Variable name="FxRack_FxUnit"/>]</SetVariable>
+                    <SetVariable name="ConfigKey">super1</SetVariable>
+                    <SetVariable name="Color">blue</SetVariable>
+                  </Template>
+                </Children>
+                <Connection>
+                  <ConfigKey persist="true">[Skin],show_superknobs</ConfigKey>
+                  <BindProperty>visible</BindProperty>
+                </Connection>
+              </WidgetGroup>
+
+              <WidgetGroup><Size>1f,0me</Size></WidgetGroup>
 
               <WidgetGroup><!-- Pfl button -->
                 <ObjectName>AlignCenter</ObjectName>
@@ -281,7 +287,6 @@ Variables:
                     <Children>
                       <!-- Greyed out if no headphone device is configured -->
                       <Template src="skins:Tango/helpers/pfl_cover.xml"/>
-
                       <Template src="skins:Tango/controls/button_2state.xml">
                         <SetVariable name="ObjectName">PflButton</SetVariable>
                         <SetVariable name="TooltipId">EffectUnit_headphones_enabled</SetVariable>

--- a/res/skins/Tango/fx/unit_left_mini.xml
+++ b/res/skins/Tango/fx/unit_left_mini.xml
@@ -233,7 +233,7 @@ Variables:
               <EffectChainPresetButton>
                 <ObjectName>EffectChainPresetButtonLeft</ObjectName>
                 <EffectUnit><Variable name="FxUnit"/></EffectUnit>
-                <Size>18f,18f</Size>
+                <Size>20f,20f</Size>
               </EffectChainPresetButton>
             </Children>
           </WidgetGroup>
@@ -241,7 +241,7 @@ Variables:
           <Template src="skins:Tango/controls/button_2state_persist.xml">
             <SetVariable name="ObjectName">MixModeButton</SetVariable>
             <SetVariable name="TooltipId">EffectUnit_mix_mode</SetVariable>
-            <SetVariable name="Size">30f,18f</SetVariable>
+            <SetVariable name="Size">24f,18f</SetVariable>
             <SetVariable name="state_0_icon">fx_mixmode_d-w.svg</SetVariable>
             <SetVariable name="state_1_icon">fx_mixmode_d+w.svg</SetVariable>
             <SetVariable name="ConfigKey">[EffectRack1_EffectUnit<Variable name="FxUnit"/>],mix_mode</SetVariable>

--- a/res/skins/Tango/fx/unit_right.xml
+++ b/res/skins/Tango/fx/unit_right.xml
@@ -64,7 +64,7 @@ Variables:
                   <Template src="skins:Tango/controls/button_2state_persist.xml">
                     <SetVariable name="ObjectName">MixModeButton</SetVariable>
                     <SetVariable name="TooltipId">EffectUnit_mix_mode</SetVariable>
-                    <SetVariable name="Size">30f,18f</SetVariable>
+                    <SetVariable name="Size">24f,18f</SetVariable>
                     <SetVariable name="state_0_icon">fx_mixmode_d-w.svg</SetVariable>
                     <SetVariable name="state_1_icon">fx_mixmode_d+w.svg</SetVariable>
                     <SetVariable name="ConfigKey">[EffectRack1_EffectUnit<Variable name="FxUnit"/>],mix_mode</SetVariable>
@@ -72,30 +72,12 @@ Variables:
                 </Children>
               </WidgetGroup>
 
-              <WidgetGroup>
-                <Layout>horizontal</Layout>
-                <SizePolicy>min,min</SizePolicy>
-                <Children>
-                  <WidgetGroup><!-- Super Knob, if enabled -->
-                    <SizePolicy>min,min</SizePolicy>
-                    <Layout>horizontal</Layout>
-                    <Children>
-                      <WidgetGroup><Size>1min,2min</Size></WidgetGroup>
-                      <Template src="skins:Tango/controls/knob_textless.xml">
-                        <SetVariable name="TooltipId">EffectUnit_super1</SetVariable>
-                        <SetVariable name="ObjectName">SuperWetDryKnob</SetVariable>
-                        <SetVariable name="Size">30f,26f</SetVariable>
-                        <SetVariable name="group">[<Variable name="FxRack_FxUnit"/>]</SetVariable>
-                        <SetVariable name="ConfigKey">super1</SetVariable>
-                        <SetVariable name="Color">blue</SetVariable>
-                      </Template>
-                    </Children>
-                    <Connection>
-                      <ConfigKey persist="true">[Skin],show_superknobs</ConfigKey>
-                      <BindProperty>visible</BindProperty>
-                    </Connection>
-                  </WidgetGroup>
+              <WidgetGroup><Size>1f,1me</Size></WidgetGroup>
 
+              <WidgetGroup>
+                <SizePolicy>min,min</SizePolicy>
+                <Layout>horizontal</Layout>
+                <Children>
                   <EffectChainPresetButton>
                     <EffectUnit><Variable name="FxUnit"/></EffectUnit>
                     <Size>24f,24f</Size>
@@ -103,6 +85,30 @@ Variables:
                   </EffectChainPresetButton>
                 </Children>
               </WidgetGroup>
+
+              <WidgetGroup><Size>1f,1me</Size></WidgetGroup>
+
+              <WidgetGroup><!-- Super Knob, if enabled -->
+                <SizePolicy>min,min</SizePolicy>
+                <Layout>horizontal</Layout>
+                <Children>
+                  <WidgetGroup><Size>1min,2min</Size></WidgetGroup>
+                  <Template src="skins:Tango/controls/knob_textless.xml">
+                    <SetVariable name="TooltipId">EffectUnit_super1</SetVariable>
+                    <SetVariable name="ObjectName">SuperWetDryKnob</SetVariable>
+                    <SetVariable name="Size">30f,26f</SetVariable>
+                    <SetVariable name="group">[<Variable name="FxRack_FxUnit"/>]</SetVariable>
+                    <SetVariable name="ConfigKey">super1</SetVariable>
+                    <SetVariable name="Color">blue</SetVariable>
+                  </Template>
+                </Children>
+                <Connection>
+                  <ConfigKey persist="true">[Skin],show_superknobs</ConfigKey>
+                  <BindProperty>visible</BindProperty>
+                </Connection>
+              </WidgetGroup>
+
+              <WidgetGroup><Size>1f,1me</Size></WidgetGroup>
 
               <WidgetGroup><!-- Pfl button -->
                 <ObjectName>AlignCenter</ObjectName>

--- a/res/skins/Tango/fx/unit_right_mini.xml
+++ b/res/skins/Tango/fx/unit_right_mini.xml
@@ -53,7 +53,7 @@ Variables:
           <Template src="skins:Tango/controls/button_2state_persist.xml">
             <SetVariable name="ObjectName">MixModeButton</SetVariable>
             <SetVariable name="TooltipId">EffectUnit_mix_mode</SetVariable>
-            <SetVariable name="Size">30f,18f</SetVariable>
+            <SetVariable name="Size">24f,18f</SetVariable>
             <SetVariable name="state_0_icon">fx_mixmode_d-w.svg</SetVariable>
             <SetVariable name="state_1_icon">fx_mixmode_d+w.svg</SetVariable>
             <SetVariable name="ConfigKey">[EffectRack1_EffectUnit<Variable name="FxUnit"/>],mix_mode</SetVariable>
@@ -67,7 +67,7 @@ Variables:
               <EffectChainPresetButton>
                 <ObjectName>EffectChainPresetButtonRight</ObjectName>
                 <EffectUnit><Variable name="FxUnit"/></EffectUnit>
-                <Size>18f,18f</Size>
+                <Size>20f,20f</Size>
               </EffectChainPresetButton>
             </Children>
           </WidgetGroup>

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -433,7 +433,6 @@ WWidgetGroup {
   image: url(skin:/../Tango/buttons/btn_skinsettings_off.svg) no-repeat center center;
   }
   #SkinSettingsToggler[displayValue="0"]:hover {
-    background-color: #0f0f0f;
     image: url(skin:/../Tango/buttons/btn_skinsettings_on.svg) no-repeat center center;
   }
 
@@ -1596,7 +1595,8 @@ decks, samplers, mic, aux, fx */
 #FxUnitMixerRight,
 #FxUnitMixerLeft_mini,
 #FxUnitMixerRight_mini {
-  qproperty-layoutAlignment: 'AlignHCenter';
+  qproperty-layoutAlignment: 'AlignHCenter | AlignTop';
+/*  qproperty-layoutAlignment: 'AlignHCenter';*/
   background-color: #333;
   }
 #FxUnitMixerLeft,
@@ -1809,7 +1809,6 @@ decks, samplers, mic, aux, fx */
     image: url(skin:/../Tango/buttons/btn_skinsettings_off.svg) no-repeat center center;
     }
     WEffectChainPresetButton:hover {
-      background-color: #151515;
       image: url(skin:/../Tango/buttons/btn_skinsettings_on.svg) no-repeat center center;
     }
     WEffectChainPresetButton::menu-indicator {


### PR DESCRIPTION
follow-up for #12735 

* layout effect chain controls evenly, with/without Super knobs
* static Mix + Mix Mode controls when toggling Super knobs
* slightly larger chain preset button in Tango, slightly smaller Mix Mode button