### PR TITLE
Add FX Knob Script to "Korg Kaoss DJ" 

### DIFF
--- a/res/controllers/Korg-KAOSS-DJ-scripts.js
+++ b/res/controllers/Korg-KAOSS-DJ-scripts.js
@@ -184,7 +184,7 @@ KAOSSDJ.fxToggleButton = function(channel, _control, value, _status, _group) {
     KAOSSDJ.updateDeckByChannel(channel, "isFx", value === MIDI_ON);
 };
 
-KAOSSDJ.fxKnob = function(_channel, _control, value, _status, _group) { 
+KAOSSDJ.fxKnob = function(_channel, _control, value, _status, _group) {
     if (KAOSSDJ.shiftLeftPressed) {
         // If Left Shift is pressed, cycle the effects chains on EffectUnit1
         if (value === MIDI_UP) {

--- a/res/controllers/Korg-KAOSS-DJ-scripts.js
+++ b/res/controllers/Korg-KAOSS-DJ-scripts.js
@@ -184,32 +184,32 @@ KAOSSDJ.fxToggleButton = function(channel, _control, value, _status, _group) {
     KAOSSDJ.updateDeckByChannel(channel, "isFx", value === MIDI_ON);
 };
 
-KAOSSDJ.fxKnob = function (_channel, _control, value, _status, _group) {  
+KAOSSDJ.fxKnob = function(_channel, _control, value, _status, _group) {  
     if (KAOSSDJ.shiftLeftPressed) {
         // If Left Shift is pressed, cycle the effects chains on EffectUnit1
         if (value === MIDI_UP) {
-            engine.setValue(`[EffectRack1_EffectUnit1]`, 'next_chain', 1);
+            engine.setValue("[EffectRack1_EffectUnit1]", "next_chain", 1);
         } else if (value === MIDI_DOWN) {
-            engine.setValue(`[EffectRack1_EffectUnit1]`, 'prev_chain', 1);
+            engine.setValue("[EffectRack1_EffectUnit1]", "prev_chain", 1);
         }
     } else if (KAOSSDJ.shiftRightPressed) {
         // If Right Shift is not pressed, cycle the effects chains on EffectUnit2
         if (value === MIDI_UP) {
-            engine.setValue(`[EffectRack1_EffectUnit2]`, 'next_chain', 1);
+            engine.setValue(`[EffectRack1_EffectUnit2]`, "next_chain", 1);
         } else if (value === MIDI_DOWN) {
-            engine.setValue(`[EffectRack1_EffectUnit2]`, 'prev_chain', 1);
+            engine.setValue(`[EffectRack1_EffectUnit2]`, "prev_chain", 1);
         }
     } else {
         // If no shift is pressed, cycle through both QuickEffectRack filters
         if (value === MIDI_UP) {
-            engine.setValue(`[QuickEffectRack1_[Channel1]]`, 'next_chain', 1);
-            engine.setValue(`[QuickEffectRack1_[Channel2]]`, 'next_chain', 1);
+            engine.setValue("[QuickEffectRack1_[Channel1]]", "next_chain", 1);
+            engine.setValue("[QuickEffectRack1_[Channel2]]", "next_chain", 1);
         } else if (value === MIDI_DOWN) {
-            engine.setValue(`[QuickEffectRack1_[Channel1]]`, 'prev_chain', 1);
-            engine.setValue(`[QuickEffectRack1_[Channel2]]`, 'prev_chain', 1);
+            engine.setValue("[QuickEffectRack1_[Channel1]]", "prev_chain", 1);
+            engine.setValue("[QuickEffectRack1_[Channel2]]", "prev_chain", 1);
         }
     }
-}
+};
 
 KAOSSDJ.fxTouchMoveVertical = function(_channel, _control, value, _status, _group) {
     Object.values(KAOSSDJ.decks)

--- a/res/controllers/Korg-KAOSS-DJ-scripts.js
+++ b/res/controllers/Korg-KAOSS-DJ-scripts.js
@@ -181,7 +181,7 @@ KAOSSDJ.scratchMode = function(channel, _control, value, _status, _group) {
 };
 
 KAOSSDJ.fxToggleButton = function(channel, _control, value, _status, _group) {
-    KAOSSDJ.updateDeckByChannel(channel, "fx", value === MIDI_ON);
+    KAOSSDJ.updateDeckByChannel(channel, "isFx", value === MIDI_ON);
 };
 
 KAOSSDJ.fxKnob = function (_channel, _control, value, _status, _group) {  

--- a/res/controllers/Korg-KAOSS-DJ-scripts.js
+++ b/res/controllers/Korg-KAOSS-DJ-scripts.js
@@ -184,7 +184,7 @@ KAOSSDJ.fxToggleButton = function(channel, _control, value, _status, _group) {
     KAOSSDJ.updateDeckByChannel(channel, "isFx", value === MIDI_ON);
 };
 
-KAOSSDJ.fxKnob = function(_channel, _control, value, _status, _group) {  
+KAOSSDJ.fxKnob = function(_channel, _control, value, _status, _group) { 
     if (KAOSSDJ.shiftLeftPressed) {
         // If Left Shift is pressed, cycle the effects chains on EffectUnit1
         if (value === MIDI_UP) {
@@ -195,9 +195,9 @@ KAOSSDJ.fxKnob = function(_channel, _control, value, _status, _group) {
     } else if (KAOSSDJ.shiftRightPressed) {
         // If Right Shift is not pressed, cycle the effects chains on EffectUnit2
         if (value === MIDI_UP) {
-            engine.setValue(`[EffectRack1_EffectUnit2]`, "next_chain", 1);
+            engine.setValue("[EffectRack1_EffectUnit2]", "next_chain", 1);
         } else if (value === MIDI_DOWN) {
-            engine.setValue(`[EffectRack1_EffectUnit2]`, "prev_chain", 1);
+            engine.setValue("[EffectRack1_EffectUnit2]", "prev_chain", 1);
         }
     } else {
         // If no shift is pressed, cycle through both QuickEffectRack filters

--- a/res/controllers/Korg-KAOSS-DJ-scripts.js
+++ b/res/controllers/Korg-KAOSS-DJ-scripts.js
@@ -184,9 +184,32 @@ KAOSSDJ.fxToggleButton = function(channel, _control, value, _status, _group) {
     KAOSSDJ.updateDeckByChannel(channel, "fx", value === MIDI_ON);
 };
 
-KAOSSDJ.fxKnob = function(_channel, _control, _value, _status) {
-    // TODO
-};
+KAOSSDJ.fxKnob = function (_channel, _control, value, _status, _group) {  
+    if (KAOSSDJ.shiftLeftPressed) {
+        // If Left Shift is pressed, cycle the effects chains on EffectUnit1
+        if (value === MIDI_UP) {
+            engine.setValue(`[EffectRack1_EffectUnit1]`, 'next_chain', 1);
+        } else if (value === MIDI_DOWN) {
+            engine.setValue(`[EffectRack1_EffectUnit1]`, 'prev_chain', 1);
+        }
+    } else if (KAOSSDJ.shiftRightPressed) {
+        // If Right Shift is not pressed, cycle the effects chains on EffectUnit2
+        if (value === MIDI_UP) {
+            engine.setValue(`[EffectRack1_EffectUnit2]`, 'next_chain', 1);
+        } else if (value === MIDI_DOWN) {
+            engine.setValue(`[EffectRack1_EffectUnit2]`, 'prev_chain', 1);
+        }
+    } else {
+        // If no shift is pressed, cycle through both QuickEffectRack filters
+        if (value === MIDI_UP) {
+            engine.setValue(`[QuickEffectRack1_[Channel1]]`, 'next_chain', 1);
+            engine.setValue(`[QuickEffectRack1_[Channel2]]`, 'next_chain', 1);
+        } else if (value === MIDI_DOWN) {
+            engine.setValue(`[QuickEffectRack1_[Channel1]]`, 'prev_chain', 1);
+            engine.setValue(`[QuickEffectRack1_[Channel2]]`, 'prev_chain', 1);
+        }
+    }
+}
 
 KAOSSDJ.fxTouchMoveVertical = function(_channel, _control, value, _status, _group) {
     Object.values(KAOSSDJ.decks)

--- a/res/controllers/Korg-KAOSS-DJ.midi.xml
+++ b/res/controllers/Korg-KAOSS-DJ.midi.xml
@@ -625,7 +625,7 @@
                 <status>0xB6</status>
                 <midino>0x1F</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>


### PR DESCRIPTION
Based on #12683
The FX knob now functions as follows:
[no shift] Cycles QuickEffects of Channel 1  + 2
[left shift] Cycles chains on EffectUnit1
[right shift] Cycles chains on EffectUnit2

With this integrated I think the script is now in a state of merging.
I would still need to change the manual to reflect on this last change.

Some future improvements could be:
- [ ] Get the display to work
- [ ] add functions to Shift + Play/Sync/Cue
- [ ] Hold (Button 9) not mapped in ControllerFX mode