### PR TITLE
Revert "Samplers: don't create unneeded empty samplers during startup"

### DIFF
--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -450,12 +450,7 @@ void PlayerManager::addDeckInner() {
 }
 
 void PlayerManager::loadSamplers() {
-    // This is only called by CoreServices during startup to restore
-    // samplers from the previous session.
-    // We don't want it to create more players than necessary.
-    bool dontCreateEmptySamplers = true;
-    m_pSamplerBank->loadSamplerBankFromPath(getDefaultSamplerPath(m_pConfig),
-            dontCreateEmptySamplers);
+    m_pSamplerBank->loadSamplerBankFromPath(getDefaultSamplerPath(m_pConfig));
 }
 
 void PlayerManager::addSampler() {

--- a/src/mixer/samplerbank.h
+++ b/src/mixer/samplerbank.h
@@ -19,8 +19,7 @@ class SamplerBank : public QObject {
             PlayerManager* pPlayerManager);
 
     bool saveSamplerBankToPath(const QString& samplerBankPath);
-    bool loadSamplerBankFromPath(const QString& samplerBankPath,
-            bool dontCreateEmptySamplers = false);
+    bool loadSamplerBankFromPath(const QString& samplerBankPath);
 
   private slots:
     void slotSaveSamplerBank(double v);


### PR DESCRIPTION
This reverts the core commit of #12657 

Besides the Numark Mixtrack Pro3 #12808 other mappings slipped through in #12769.
I'm at it but I can't guarantuee to fix _all_ of them _in time_.
Also, user mappings may be broken, too.

Let's push #12657 to 2.4.1

To summarize: the mapping control error can still occur if
* _samplers.xml_ doesn't exist / is broken
* loading a mapping that needs N samplers
* before loading a skin that provides N samplers