### PR TITLE
History: show track count and duration in sidebar

### DIFF
--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -802,6 +802,16 @@ void BasePlaylistFeature::markTreeItem(TreeItem* pTreeItem) {
     }
 }
 
+QString BasePlaylistFeature::createPlaylistLabel(const QString& name,
+        int count,
+        int duration) const {
+    return QStringLiteral("%1 (%2) %3")
+            .arg(name,
+                    QString::number(count),
+                    mixxx::Duration::formatTime(
+                            duration, mixxx::Duration::Precision::SECONDS));
+}
+
 void BasePlaylistFeature::slotResetSelectedTrack() {
     slotTrackSelected(TrackId{});
 }

--- a/src/library/trackset/baseplaylistfeature.h
+++ b/src/library/trackset/baseplaylistfeature.h
@@ -92,6 +92,8 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
     QModelIndex indexFromPlaylistId(int playlistId);
     bool isChildIndexSelectedInSidebar(const QModelIndex& index);
 
+    QString createPlaylistLabel(const QString& name, int count, int duration) const;
+
     PlaylistDAO& m_playlistDao;
     QModelIndex m_lastClickedIndex;
     QModelIndex m_lastRightClickedIndex;

--- a/src/library/trackset/playlistfeature.cpp
+++ b/src/library/trackset/playlistfeature.cpp
@@ -16,21 +16,6 @@
 #include "util/duration.h"
 #include "widget/wlibrarysidebar.h"
 
-namespace {
-
-QString createPlaylistLabel(
-        const QString& name,
-        int count,
-        int duration) {
-    return QStringLiteral("%1 (%2) %3")
-            .arg(name,
-                    QString::number(count),
-                    mixxx::Duration::formatTime(
-                            duration, mixxx::Duration::Precision::SECONDS));
-}
-
-} // anonymous namespace
-
 PlaylistFeature::PlaylistFeature(Library* pLibrary, UserSettingsPointer pConfig)
         : BasePlaylistFeature(pLibrary,
                   pConfig,
@@ -140,7 +125,7 @@ QList<BasePlaylistFeature::IdAndLabel> PlaylistFeature::createPlaylistLabels() {
             "  ON PlaylistTracks.playlist_id = Playlists.id "
             "LEFT JOIN library "
             "  ON PlaylistTracks.track_id = library.id "
-            "  WHERE Playlists.hidden = 0 "
+            "  WHERE Playlists.hidden = 0 " // PlaylistDAO::HiddenType::PLHT_NOT_HIDDEN
             "  GROUP BY Playlists.id");
     queryString.append(
             mixxx::DbConnection::collateLexicographically(

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -213,14 +213,42 @@ void SetlogFeature::onRightClickChild(const QPoint& globalPos, const QModelIndex
 /// Use a custom model in the history for grouping by year
 /// @param selectedId row which should be selected
 QModelIndex SetlogFeature::constructChildModel(int selectedId) {
-    // qDebug() << "SetlogFeature::constructChildModel() id:" << selectedId;
+    // qDebug() << "SetlogFeature::constructChildModel() selected:" << selectedId;
     // Setup the sidebar playlist model
-    QSqlTableModel playlistTableModel(this,
-            m_pLibrary->trackCollectionManager()->internalCollection()->database());
-    playlistTableModel.setTable("Playlists");
-    playlistTableModel.setFilter("hidden=" + QString::number(PlaylistDAO::PLHT_SET_LOG));
-    playlistTableModel.setSort(
-            playlistTableModel.fieldIndex("id"), Qt::DescendingOrder);
+    QSqlDatabase database =
+            m_pLibrary->trackCollectionManager()->internalCollection()->database();
+
+    QString queryString = QStringLiteral(
+            "CREATE TEMPORARY VIEW IF NOT EXISTS SetlogCountsDurations "
+            "AS SELECT "
+            "  Playlists.id AS id, "
+            "  Playlists.name AS name, "
+            "  Playlists.date_created AS date_created, "
+            "  LOWER(Playlists.name) AS sort_name, "
+            "  COUNT(case library.mixxx_deleted when 0 then 1 else null end) "
+            "    AS count, "
+            "  SUM(case library.mixxx_deleted "
+            "    when 0 then library.duration else 0 end) AS durationSeconds "
+            "FROM Playlists "
+            "LEFT JOIN PlaylistTracks "
+            "  ON PlaylistTracks.playlist_id = Playlists.id "
+            "LEFT JOIN library "
+            "  ON PlaylistTracks.track_id = library.id "
+            "  WHERE Playlists.hidden = %1 "
+            "  GROUP BY Playlists.id")
+                                  .arg(QString::number(PlaylistDAO::HiddenType::PLHT_SET_LOG));
+    queryString.append(
+            mixxx::DbConnection::collateLexicographically(
+                    " ORDER BY sort_name"));
+    QSqlQuery query(database);
+    if (!query.exec(queryString)) {
+        LOG_FAILED_QUERY(query);
+    }
+
+    // Setup the sidebar playlist model
+    QSqlTableModel playlistTableModel(this, database);
+    playlistTableModel.setTable("SetlogCountsDurations");
+    playlistTableModel.setSort(playlistTableModel.fieldIndex("id"), Qt::DescendingOrder);
     playlistTableModel.select();
     while (playlistTableModel.canFetchMore()) {
         playlistTableModel.fetchMore();
@@ -229,6 +257,8 @@ QModelIndex SetlogFeature::constructChildModel(int selectedId) {
     int nameColumn = record.indexOf("name");
     int idColumn = record.indexOf("id");
     int createdColumn = record.indexOf("date_created");
+    int countColumn = record.indexOf("count");
+    int durationColumn = record.indexOf("durationSeconds");
 
     // Nice to have: restore previous expanded/collapsed state of YEAR items
     clearChildModel();
@@ -250,8 +280,16 @@ QModelIndex SetlogFeature::constructChildModel(int selectedId) {
                 playlistTableModel
                         .data(playlistTableModel.index(row, createdColumn))
                         .toDateTime();
+        int count = playlistTableModel
+                            .data(playlistTableModel.index(row, countColumn))
+                            .toInt();
+        int duration =
+                playlistTableModel
+                        .data(playlistTableModel.index(row, durationColumn))
+                        .toInt();
+        QString label = createPlaylistLabel(name, count, duration);
 
-        // Create the TreeItem whose parent is the invisible root item
+        // Create the TreeItem whose parent is the invisible root item.
         // Show only [kNumToplevelHistoryEntries] recent playlists at the top level
         // before grouping them by year.
         if (row >= kNumToplevelHistoryEntries) {
@@ -273,12 +311,12 @@ QModelIndex SetlogFeature::constructChildModel(int selectedId) {
                 itemList.push_back(std::move(pNewGroupItem));
             }
 
-            TreeItem* pItem = pGroupItem->appendChild(name, id);
+            TreeItem* pItem = pGroupItem->appendChild(label, id);
             pItem->setBold(m_playlistIdsOfSelectedTrack.contains(id));
             decorateChild(pItem, id);
         } else {
             // add most recent top-level playlist
-            auto pItem = std::make_unique<TreeItem>(name, id);
+            auto pItem = std::make_unique<TreeItem>(label, id);
             pItem->setBold(m_playlistIdsOfSelectedTrack.contains(id));
             decorateChild(pItem.get(), id);
 


### PR DESCRIPTION
Exactly like in Playlists.

I thought it would be possible to avoid the code duplication ([PlaylistFeature::createPlaylistLabels()](https://github.com/mixxxdj/mixxx/blob/23e91ac0bf7c86c5b03dc2d7048396be6de2ad5c/src/library/trackset/playlistfeature.cpp#L135) and move this to a shared base method, but that wouldn't simplify the situation since History also needs the 'year created' in addition to an id/label pair.

Closes #12788 