### PR TITLE
chore: fix flake8 E226's

### DIFF
--- a/tools/json2github.py
+++ b/tools/json2github.py
@@ -630,7 +630,7 @@ class LaunchpadImporter:
             lp_issues[issuedata["id"]]["gh_status_comment_imported"] = True
             self.logger.info(
                 f"Imported {i}/{num_issues} "
-                f"({'{:.2f}'.format((i/num_issues)*100)}%)"
+                f"({'{:.2f}'.format((i / num_issues) * 100)}%)"
             )
 
         for issuedata in sorted(


### PR DESCRIPTION
randomly encountered during a force push. I don't know why nor how to reproduce, but probably a good idea to fix anyways. 
```quote
tools/json2github.py:633:39: E226 missing whitespace around arithmetic operator
tools/json2github.py:633:51: E226 missing whitespace around arithmetic operator
```