### PR TITLE
add taglib path to includes

### DIFF
--- a/src/track/taglib/trackmetadata_file.h
+++ b/src/track/taglib/trackmetadata_file.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <aifffile.h>
-#include <flacfile.h>
-#include <mp4file.h>
-#include <mpegfile.h>
-#include <wavfile.h>
-#include <wavpackfile.h>
+#include <taglib/aifffile.h>
+#include <taglib/flacfile.h>
+#include <taglib/mp4file.h>
+#include <taglib/mpegfile.h>
+#include <taglib/wavfile.h>
+#include <taglib/wavpackfile.h>
 
 #include <QFile>
 


### PR DESCRIPTION
I needed to add taglib/ to some includes in order to be able to compile main.
