### PR TITLE
refactor(controllers): send sysex to all handlers

### DIFF
--- a/src/controllers/midi/midicontroller.cpp
+++ b/src/controllers/midi/midicontroller.cpp
@@ -516,9 +516,9 @@ void MidiController::receive(const QByteArray& data, mixxx::Duration timestamp) 
         }
     }
 
-    auto it = m_pMapping->getInputMappings().constFind(mappingKey.key);
-    for (; it != m_pMapping->getInputMappings().constEnd() && it.key() == mappingKey.key; ++it) {
-        processInputMapping(it.value(), data, timestamp);
+    const auto inputMappings = m_pMapping->getInputMappings().values(mappingKey.key);
+    for (const auto& inputMapping : inputMappings) {
+        processInputMapping(inputMapping, data, timestamp);
     }
 }
 


### PR DESCRIPTION
Something I noticed while digging through #12824, probably a bug, but its masked by the unintuitive behavior described in #12824 anyways. Potentially proper fixes for #12824 to come.