### PR TITLE
Traktor S3: Fix mapping crash on macOS

### DIFF
--- a/res/controllers/Traktor-Kontrol-S3-hid-scripts.js
+++ b/res/controllers/Traktor-Kontrol-S3-hid-scripts.js
@@ -286,21 +286,16 @@ TraktorS3.Controller = class {
             engine.makeConnection(ch, "end_of_track",
                 TraktorS3.Channel.prototype.endOfTrackHandler.bind(chanob));
         }
+        // Set each InputReport to the bitwise inverted state first,
+        // and than apply the non-inverted initial state.
+        // This is done, because the common-hid-packet-parser only triggers
+        // the callback functions in case of a delta to the previous data.
+        for (let inputReportIdx = 0x01; inputReportIdx <= 0x02; ++inputReportIdx) {
+            const reportData = new Uint8Array(controller.getInputReport(inputReportIdx));
 
-        // Query the current values from the controller and set them. The packet
-        // parser ignores the first time a value is set, so we'll need to set it
-        // with different values once. Report 2 contains the state of the mixer
-        // controls.
-        const report2Values = new Uint8Array(controller.getInputReport(2));
-        TraktorS3.incomingData(new Uint8Array([2, ...Uint8Array.from(report2Values.map(x => ~x))]));
-        TraktorS3.incomingData(new Uint8Array([2, ...Uint8Array.from(report2Values)]));
-
-        // Report 1 is the state of the deck controls. These shouldn't have any
-        // initial effect, and most of these values will be 0 anyways. We'll
-        // just tell the packet parser the current values so it won't ignore the
-        // next input.
-        const report1Values = new Uint8Array(controller.getInputReport(1));
-        TraktorS3.incomingData(new Uint8Array([1, ...Uint8Array.from(report1Values)]));
+            TraktorS3.incomingData([inputReportIdx, ...reportData.map(x => ~x)]);
+            TraktorS3.incomingData([inputReportIdx, ...reportData]);
+        }
 
         // NOTE: Soft takeovers must only be enabled after setting the initial
         //       value, or the above line won't have any effect


### PR DESCRIPTION
Closes: #12834

Replaced the initialization code by a snipped already used in other mappings, to fix a crash reported on macOS only (maybe due to the very old Qt version for macOS? )

Fix is confirmend to work in #12834