### PR TITLE
fix preferred Color column width

### DIFF
--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -124,7 +124,8 @@ BaseTrackTableModel::BaseTrackTableModel(
           TrackModel(cloneDatabase(pTrackCollectionManager), settingsNamespace),
           m_pTrackCollectionManager(pTrackCollectionManager),
           m_previewDeckGroup(PlayerManager::groupForPreviewDeck(0)),
-          m_backgroundColorOpacity(WLibrary::kDefaultTrackTableBackgroundColorOpacity) {
+          m_backgroundColorOpacity(WLibrary::kDefaultTrackTableBackgroundColorOpacity),
+          m_defaultColumnWidth(static_cast<int>(WTrackTableView::kDefaultColumnWidth)) {
     connect(&pTrackCollectionManager->internalCollection()->getTrackDAO(),
             &TrackDAO::forceModelUpdate,
             this,
@@ -155,107 +156,108 @@ void BaseTrackTableModel::initHeaderProperties() {
     setHeaderProperties(
             ColumnCache::COLUMN_LIBRARYTABLE_ALBUM,
             tr("Album"),
-            defaultColumnWidth() * 4);
+            m_defaultColumnWidth * 4);
     setHeaderProperties(
             ColumnCache::COLUMN_LIBRARYTABLE_ALBUMARTIST,
             tr("Album Artist"),
-            defaultColumnWidth() * 4);
+            m_defaultColumnWidth * 4);
     setHeaderProperties(
             ColumnCache::COLUMN_LIBRARYTABLE_ARTIST,
             tr("Artist"),
-            defaultColumnWidth() * 4);
+            m_defaultColumnWidth * 4);
     setHeaderProperties(
             ColumnCache::COLUMN_LIBRARYTABLE_BITRATE,
             tr("Bitrate"),
-            defaultColumnWidth());
+            m_defaultColumnWidth);
     setHeaderProperties(
             ColumnCache::COLUMN_LIBRARYTABLE_BPM,
             tr("BPM"),
-            defaultColumnWidth() * 2);
+            m_defaultColumnWidth * 2);
     setHeaderProperties(
             ColumnCache::COLUMN_LIBRARYTABLE_CHANNELS,
             tr("Channels"),
-            defaultColumnWidth() / 2);
+            m_defaultColumnWidth / 2);
+    // Note that this is also set in ColorDelegate to be used for its sizeHint()
     setHeaderProperties(
             ColumnCache::COLUMN_LIBRARYTABLE_COLOR,
             tr("Color"),
-            defaultColumnWidth() / 2);
+            m_defaultColumnWidth / 2);
     setHeaderProperties(
             ColumnCache::COLUMN_LIBRARYTABLE_COMMENT,
             tr("Comment"),
-            defaultColumnWidth() * 6);
+            m_defaultColumnWidth * 6);
     setHeaderProperties(
             ColumnCache::COLUMN_LIBRARYTABLE_COMPOSER,
             tr("Composer"),
-            defaultColumnWidth() * 4);
+            m_defaultColumnWidth * 4);
     setHeaderProperties(
             ColumnCache::COLUMN_LIBRARYTABLE_COVERART,
             tr("Cover Art"),
-            defaultColumnWidth() / 2);
+            m_defaultColumnWidth / 2);
     setHeaderProperties(
             ColumnCache::COLUMN_LIBRARYTABLE_DATETIMEADDED,
             tr("Date Added"),
-            defaultColumnWidth() * 3);
+            m_defaultColumnWidth * 3);
     setHeaderProperties(
             ColumnCache::COLUMN_LIBRARYTABLE_LAST_PLAYED_AT,
             tr("Last Played"),
-            defaultColumnWidth() * 3);
+            m_defaultColumnWidth * 3);
     setHeaderProperties(
             ColumnCache::COLUMN_LIBRARYTABLE_DURATION,
             tr("Duration"),
-            defaultColumnWidth());
+            m_defaultColumnWidth);
     setHeaderProperties(
             ColumnCache::COLUMN_LIBRARYTABLE_FILETYPE,
             tr("Type"),
-            defaultColumnWidth());
+            m_defaultColumnWidth);
     setHeaderProperties(
             ColumnCache::COLUMN_LIBRARYTABLE_GENRE,
             tr("Genre"),
-            defaultColumnWidth() * 4);
+            m_defaultColumnWidth * 4);
     setHeaderProperties(
             ColumnCache::COLUMN_LIBRARYTABLE_GROUPING,
             tr("Grouping"),
-            defaultColumnWidth() * 4);
+            m_defaultColumnWidth * 4);
     setHeaderProperties(
             ColumnCache::COLUMN_LIBRARYTABLE_KEY,
             tr("Key"),
-            defaultColumnWidth());
+            m_defaultColumnWidth);
     setHeaderProperties(
             ColumnCache::COLUMN_TRACKLOCATIONSTABLE_LOCATION,
             tr("Location"),
-            defaultColumnWidth() * 6);
+            m_defaultColumnWidth * 6);
     setHeaderProperties(
             ColumnCache::COLUMN_LIBRARYTABLE_PREVIEW,
             tr("Preview"),
-            defaultColumnWidth() / 2);
+            m_defaultColumnWidth / 2);
     setHeaderProperties(
             ColumnCache::COLUMN_LIBRARYTABLE_RATING,
             tr("Rating"),
-            defaultColumnWidth() * 2);
+            m_defaultColumnWidth * 2);
     setHeaderProperties(
             ColumnCache::COLUMN_LIBRARYTABLE_REPLAYGAIN,
             tr("ReplayGain"),
-            defaultColumnWidth() * 2);
+            m_defaultColumnWidth * 2);
     setHeaderProperties(
             ColumnCache::COLUMN_LIBRARYTABLE_SAMPLERATE,
             tr("Samplerate"),
-            defaultColumnWidth());
+            m_defaultColumnWidth);
     setHeaderProperties(
             ColumnCache::COLUMN_LIBRARYTABLE_TIMESPLAYED,
             tr("Played"),
-            defaultColumnWidth() * 2);
+            m_defaultColumnWidth * 2);
     setHeaderProperties(
             ColumnCache::COLUMN_LIBRARYTABLE_TITLE,
             tr("Title"),
-            defaultColumnWidth() * 4);
+            m_defaultColumnWidth * 4);
     setHeaderProperties(
             ColumnCache::COLUMN_LIBRARYTABLE_TRACKNUMBER,
             tr("Track #"),
-            defaultColumnWidth());
+            m_defaultColumnWidth);
     setHeaderProperties(
             ColumnCache::COLUMN_LIBRARYTABLE_YEAR,
             tr("Year"),
-            defaultColumnWidth());
+            m_defaultColumnWidth);
 }
 
 void BaseTrackTableModel::setHeaderProperties(
@@ -332,7 +334,7 @@ QVariant BaseTrackTableModel::headerData(
             if (widthValue.isValid()) {
                 return widthValue;
             } else {
-                return defaultColumnWidth();
+                return m_defaultColumnWidth;
             }
         }
         case TrackModel::kHeaderNameRole: {

--- a/src/library/basetracktablemodel.h
+++ b/src/library/basetracktablemodel.h
@@ -102,9 +102,6 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
     static void setBpmColumnPrecision(int precision);
 
   protected:
-    static constexpr int defaultColumnWidth() {
-        return 50;
-    }
     static QStringList defaultTableColumns();
 
     // Build a map from the column names to their indices
@@ -284,4 +281,6 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
     mutable QModelIndex m_toolTipIndex;
 
     static int s_bpmColumnPrecision;
+
+    const int m_defaultColumnWidth;
 };

--- a/src/library/colordelegate.cpp
+++ b/src/library/colordelegate.cpp
@@ -6,9 +6,15 @@
 
 #include "moc_colordelegate.cpp"
 #include "util/color/rgbcolor.h"
+#include "widget/wtracktableview.h"
 
 ColorDelegate::ColorDelegate(QTableView* pTableView)
-        : TableItemDelegate(pTableView) {
+        : TableItemDelegate(pTableView),
+          m_preferredWidth(static_cast<int>(WTrackTableView::kDefaultColumnWidth / 2)) {
+}
+
+QSize ColorDelegate::sizeHint(const QStyleOptionViewItem&, const QModelIndex&) const {
+    return QSize(m_preferredWidth, 0);
 }
 
 void ColorDelegate::paintItem(

--- a/src/library/colordelegate.h
+++ b/src/library/colordelegate.h
@@ -15,4 +15,11 @@ class ColorDelegate : public TableItemDelegate {
             QPainter* painter,
             const QStyleOptionViewItem& option,
             const QModelIndex& index) const override;
+
+    // returns an item's preferred size
+    QSize sizeHint(const QStyleOptionViewItem&,
+            const QModelIndex&) const;
+
+  private:
+    int m_preferredWidth;
 };

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -56,6 +56,8 @@ class WTrackTableView : public WLibraryTableView {
         return m_pFocusBorderColor;
     }
 
+    static constexpr int kDefaultColumnWidth = 50;
+
   signals:
     void trackMenuVisible(bool visible);
 


### PR DESCRIPTION
Fixes #12850 

* I moved the default width (50px) from basetrackmodel.h to wtracktableview.h
could also be moved to a much smaller header, for example util/defs.h
* ColorDelegate and BaseTrackModel now fetch this during construction
* ColorDelegate has new `sizeHint`, returning the preferred width (25px)