### PR TITLE
Handle new " / " from taglib 2.0 

### DIFF
--- a/src/track/taglib/trackmetadata_common.cpp
+++ b/src/track/taglib/trackmetadata_common.cpp
@@ -274,20 +274,25 @@ void exportTrackMetadataIntoTag(
         WriteTagMask writeMask) {
     DEBUG_ASSERT(pTag); // already validated before
 
-    pTag->setTitle(toTString(trackMetadata.getTrackInfo().getTitle()));
-    pTag->setAlbum(toTString(trackMetadata.getAlbumInfo().getTitle()));
-
     // The mapping of multi-valued fields in TagLib is not bijective.
     // We don't want to overwrite existing values if the corresponding
-    // field has not been modified in Mixxx. This workaround only covers
-    // the most common multi-valued fields.
+    // field has not been modified in Mixxx.
     //
     // See also: <https://github.com/mixxxdj/mixxx/issues/12587>
-    const auto artist = toTString(trackMetadata.getTrackInfo().getArtist());
+
+    const TagLib::String title = toTString(trackMetadata.getTrackInfo().getTitle());
+    if (title != pTag->title()) {
+        pTag->setTitle(title);
+    }
+    const TagLib::String album = toTString(trackMetadata.getAlbumInfo().getTitle());
+    if (album != pTag->album()) {
+        pTag->setAlbum(album);
+    }
+    const TagLib::String artist = toTString(trackMetadata.getTrackInfo().getArtist());
     if (artist != pTag->artist()) {
         pTag->setArtist(artist);
     }
-    const auto genre = toTString(trackMetadata.getTrackInfo().getGenre());
+    const TagLib::String genre = toTString(trackMetadata.getTrackInfo().getGenre());
     if (genre != pTag->genre()) {
         pTag->setGenre(genre);
     }
@@ -297,7 +302,10 @@ void exportTrackMetadataIntoTag(
     // different purposes, e.g. ID3v2. In this case setting the
     // comment here should be omitted.
     if (0 == (writeMask & WriteTagFlag::OmitComment)) {
-        pTag->setComment(toTString(trackMetadata.getTrackInfo().getComment()));
+        const TagLib::String comment = toTString(trackMetadata.getTrackInfo().getComment());
+        if (comment != pTag->comment()) {
+            pTag->setComment(comment);
+        }
     }
 
     // Specialized write functions for tags derived from Taglib::Tag might

--- a/src/track/taglib/trackmetadata_common.cpp
+++ b/src/track/taglib/trackmetadata_common.cpp
@@ -268,6 +268,10 @@ void importTrackMetadataFromTag(
     }
 }
 
+bool isMultiValueTagEqual(const TagLib::String& taglibVal, const QString& mixxxVal) {
+    return toQString(taglibVal) == mixxxVal;
+}
+
 void exportTrackMetadataIntoTag(
         TagLib::Tag* pTag,
         const TrackMetadata& trackMetadata,
@@ -279,22 +283,17 @@ void exportTrackMetadataIntoTag(
     // field has not been modified in Mixxx.
     //
     // See also: <https://github.com/mixxxdj/mixxx/issues/12587>
-
-    const TagLib::String title = toTString(trackMetadata.getTrackInfo().getTitle());
-    if (title != pTag->title()) {
-        pTag->setTitle(title);
+    if (!isMultiValueTagEqual(pTag->title(), trackMetadata.getTrackInfo().getTitle())) {
+        pTag->setTitle(toTString(trackMetadata.getTrackInfo().getTitle()));
     }
-    const TagLib::String album = toTString(trackMetadata.getAlbumInfo().getTitle());
-    if (album != pTag->album()) {
-        pTag->setAlbum(album);
+    if (!isMultiValueTagEqual(pTag->album(), trackMetadata.getAlbumInfo().getTitle())) {
+        pTag->setAlbum(toTString(trackMetadata.getAlbumInfo().getTitle()));
     }
-    const TagLib::String artist = toTString(trackMetadata.getTrackInfo().getArtist());
-    if (artist != pTag->artist()) {
-        pTag->setArtist(artist);
+    if (!isMultiValueTagEqual(pTag->artist(), trackMetadata.getTrackInfo().getArtist())) {
+        pTag->setArtist(toTString(trackMetadata.getTrackInfo().getArtist()));
     }
-    const TagLib::String genre = toTString(trackMetadata.getTrackInfo().getGenre());
-    if (genre != pTag->genre()) {
-        pTag->setGenre(genre);
+    if (!isMultiValueTagEqual(pTag->genre(), trackMetadata.getTrackInfo().getGenre())) {
+        pTag->setGenre(toTString(trackMetadata.getTrackInfo().getGenre()));
     }
 
     // Using setComment() from TagLib::Tag might have undesirable
@@ -302,9 +301,8 @@ void exportTrackMetadataIntoTag(
     // different purposes, e.g. ID3v2. In this case setting the
     // comment here should be omitted.
     if (0 == (writeMask & WriteTagFlag::OmitComment)) {
-        const TagLib::String comment = toTString(trackMetadata.getTrackInfo().getComment());
-        if (comment != pTag->comment()) {
-            pTag->setComment(comment);
+        if (!isMultiValueTagEqual(pTag->comment(), trackMetadata.getTrackInfo().getComment())) {
+            pTag->setComment(toTString(trackMetadata.getTrackInfo().getComment()));
         }
     }
 

--- a/src/track/taglib/trackmetadata_common.cpp
+++ b/src/track/taglib/trackmetadata_common.cpp
@@ -268,8 +268,12 @@ void importTrackMetadataFromTag(
     }
 }
 
-bool isMultiValueTagEqual(const TagLib::String& taglibVal, const QString& mixxxVal) {
-    return toQString(taglibVal) == mixxxVal;
+bool isMultiValueTagEqual(const TagLib::String& taglibVal, QString mixxxVal) {
+    // Taglib 2 uses " / " instead of " " as a multi value separator.
+    // We may have read or write with either TagLib 1 or 2.
+    QString taglibValStripped = toQString(taglibVal).remove(" /");
+    QString mixxxValStripped = mixxxVal.remove(" /");
+    return taglibValStripped == mixxxValStripped;
 }
 
 void exportTrackMetadataIntoTag(


### PR DESCRIPTION
This fixes #12790 by ignoring the new multi value separator when comparing tags. 
After installing taglib 2.0 this separator will populate the Mixxx database when reading a multi value tag.

After editing such tag, the multi values are deleted and the new value is stored a singe Tag containing the " / " separator. 

This is a workaround to allow to use Taglib 2. Writing full multi value tags is more work.  
 