### PR TITLE
Changlog update for 2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [2.4.1](https://github.com/mixxxdj/mixxx/milestone/41?closed=1) (unreleased)
 
+### Controller Mappings
+
+* Pioneer DDJ-FLX4 mapping improvements [#12842](https://github.com/mixxxdj/mixxx/pull/12842)
+* Traktor S3: Fix mapping crash on macOS [#12840](https://github.com/mixxxdj/mixxx/pull/12840)
+
+### Target Support
+
+* Fix various minor build issues
+  [#12853](https://github.com/mixxxdj/mixxx/pull/12853)
+  [#12847](https://github.com/mixxxdj/mixxx/pull/12847)
+  [#12822](https://github.com/mixxxdj/mixxx/pull/12822)
+
 ## [2.4.0](https://github.com/mixxxdj/mixxx/milestone/15?closed=1) (2024-02-16)
 
 ### Music Library: Tracks Table & Track Menu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [2.4.1](https://github.com/mixxxdj/mixxx/milestone/41?closed=1) (unreleased)
+
 ## [2.4.0](https://github.com/mixxxdj/mixxx/milestone/15?closed=1) (2024-02-16)
 
 ### Music Library: Tracks Table & Track Menu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [2.4.0](https://launchpad.net/mixxx/+milestone/2.4.0) (2024-02-16)
+## [2.4.0](https://github.com/mixxxdj/mixxx/milestone/15?closed=1) (2024-02-16)
 
 ### Music Library: Tracks Table & Track Menu
 

--- a/res/linux/org.mixxx.Mixxx.metainfo.xml
+++ b/res/linux/org.mixxx.Mixxx.metainfo.xml
@@ -96,8 +96,32 @@
   Do not edit it manually.
   -->
   <releases>
-    <release version="2.4.1" type="development" date="2024-02-22" timestamp="1708584177">
+    <release version="2.4.1" type="development" date="2024-02-22" timestamp="1708584325">
       <description>
+ <p>
+  Controller Mappings
+ </p>
+ <ul>
+  <li>
+   Pioneer DDJ-FLX4 mapping improvements
+   #12842
+  </li>
+  <li>
+   Traktor S3: Fix mapping crash on macOS
+   #12840
+  </li>
+ </ul>
+ <p>
+  Target Support
+ </p>
+ <ul>
+  <li>
+   Fix various minor build issues
+   #12853
+   #12847
+   #12822
+  </li>
+ </ul>
 </description>
     </release>
     <release version="2.4.0" type="stable" date="2024-02-16" timestamp="1708041600">

--- a/res/linux/org.mixxx.Mixxx.metainfo.xml
+++ b/res/linux/org.mixxx.Mixxx.metainfo.xml
@@ -96,6 +96,10 @@
   Do not edit it manually.
   -->
   <releases>
+    <release version="2.4.1" type="development" date="2024-02-22" timestamp="1708584177">
+      <description>
+</description>
+    </release>
     <release version="2.4.0" type="stable" date="2024-02-16" timestamp="1708041600">
       <description>
  <p>


### PR DESCRIPTION
This also fixes a link to our Launchpad milestone. 