### PR TITLE
Playlists: enforce update of playlist labels

### DIFF
--- a/src/library/dao/playlistdao.cpp
+++ b/src/library/dao/playlistdao.cpp
@@ -521,7 +521,7 @@ int PlaylistDAO::getPlaylistId(const int index) const {
 PlaylistDAO::HiddenType PlaylistDAO::getHiddenType(const int playlistId) const {
     // qDebug() << "PlaylistDAO::getHiddenType"
     //          << QThread::currentThread() << m_database.connectionName();
-    if (playlistId != kInvalidPlaylistId) { // type is known, save a query
+    if (playlistId == kInvalidPlaylistId) { // type is known, save a query
         return PlaylistDAO::PLHT_UNKNOWN;
     }
 

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -739,6 +739,7 @@ void BasePlaylistFeature::updateChildModel(const QSet<int>& playlistIds) {
             }
         }
     }
+    m_pSidebarModel->triggerRepaint();
 }
 
 /// Clears the child model dynamically, but the invisible root item remains


### PR DESCRIPTION
For some reason (I failed to find) the sidebar labels aren't updated anymore in main (with Qt6) when adding a track to a playlist.
* First commit fixes a stupid mistake (mine) made in #12494
* second commit adds explicit `m_pSidebarModel->triggerRepaint()` (like CrateFeature does) to enforce the label update

Closes #12761