### PR TITLE
History: show track count and duration in sidebar

### DIFF
--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -803,6 +803,16 @@ void BasePlaylistFeature::markTreeItem(TreeItem* pTreeItem) {
     }
 }
 
+QString BasePlaylistFeature::createPlaylistLabel(const QString& name,
+        int count,
+        int duration) const {
+    return QStringLiteral("%1 (%2) %3")
+            .arg(name,
+                    QString::number(count),
+                    mixxx::Duration::formatTime(
+                            duration, mixxx::Duration::Precision::SECONDS));
+}
+
 void BasePlaylistFeature::slotResetSelectedTrack() {
     slotTrackSelected(TrackId{});
 }

--- a/src/library/trackset/baseplaylistfeature.h
+++ b/src/library/trackset/baseplaylistfeature.h
@@ -92,6 +92,8 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
     QModelIndex indexFromPlaylistId(int playlistId);
     bool isChildIndexSelectedInSidebar(const QModelIndex& index);
 
+    QString createPlaylistLabel(const QString& name, int count, int duration) const;
+
     PlaylistDAO& m_playlistDao;
     QModelIndex m_lastClickedIndex;
     QModelIndex m_lastRightClickedIndex;

--- a/src/library/trackset/playlistfeature.cpp
+++ b/src/library/trackset/playlistfeature.cpp
@@ -18,21 +18,6 @@
 #include "widget/wlibrarysidebar.h"
 #include "widget/wtracktableview.h"
 
-namespace {
-
-QString createPlaylistLabel(
-        const QString& name,
-        int count,
-        int duration) {
-    return QStringLiteral("%1 (%2) %3")
-            .arg(name,
-                    QString::number(count),
-                    mixxx::Duration::formatTime(
-                            duration, mixxx::Duration::Precision::SECONDS));
-}
-
-} // anonymous namespace
-
 PlaylistFeature::PlaylistFeature(Library* pLibrary, UserSettingsPointer pConfig)
         : BasePlaylistFeature(pLibrary,
                   pConfig,
@@ -152,7 +137,7 @@ QList<BasePlaylistFeature::IdAndLabel> PlaylistFeature::createPlaylistLabels() {
             "  ON PlaylistTracks.playlist_id = Playlists.id "
             "LEFT JOIN library "
             "  ON PlaylistTracks.track_id = library.id "
-            "  WHERE Playlists.hidden = 0 "
+            "  WHERE Playlists.hidden = 0 " // PlaylistDAO::HiddenType::PLHT_NOT_HIDDEN
             "  GROUP BY Playlists.id");
     queryString.append(
             mixxx::DbConnection::collateLexicographically(


### PR DESCRIPTION
Exactly like in Playlists.

I thought it would be possible to avoid the code duplication ([PlaylistFeature::createPlaylistLabels()](https://github.com/mixxxdj/mixxx/blob/23e91ac0bf7c86c5b03dc2d7048396be6de2ad5c/src/library/trackset/playlistfeature.cpp#L135) and move this to a shared base method, but that wouldn't simplify the situation since History also needs the 'year created' in addition to an id/label pair.