### PR TITLE
(fix) relink directory / migrate Linux/macOS <--> Windows

### DIFF
--- a/src/library/dao/directorydao.h
+++ b/src/library/dao/directorydao.h
@@ -12,6 +12,9 @@ class DirectoryDAO : public DAO {
 
     QList<mixxx::FileInfo> loadAllDirectories(
             bool skipInvalidOrMissing = false) const;
+    /// Same as loadAllDirectories() just with paths as QString.
+    /// See DlgPrefLibrary::populateDirList() for info.
+    QStringList getRootDirStrings() const;
 
     enum class AddResult {
         Ok,

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -145,6 +145,10 @@ QList<mixxx::FileInfo> TrackCollection::loadRootDirs(bool skipInvalidOrMissing) 
     return m_directoryDao.loadAllDirectories(skipInvalidOrMissing);
 }
 
+QStringList TrackCollection::getRootDirStrings() const {
+    return m_directoryDao.getRootDirStrings();
+}
+
 bool TrackCollection::addDirectory(const mixxx::FileInfo& rootDir) {
     DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
 

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -45,6 +45,7 @@ class TrackCollection : public QObject,
 
     QList<mixxx::FileInfo> loadRootDirs(
             bool skipInvalidOrMissing = false) const;
+    QStringList getRootDirStrings() const;
 
     const CrateStorage& crates() const {
         DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -171,18 +171,26 @@ QUrl DlgPrefLibrary::helpUrl() const {
     return QUrl(MIXXX_MANUAL_LIBRARY_URL);
 }
 
-void DlgPrefLibrary::initializeDirList() {
+void DlgPrefLibrary::populateDirList() {
     // save which index was selected
     const QString selected = dirList->currentIndex().data().toString();
     // clear and fill model
     m_dirListModel.clear();
     const auto rootDirs = m_pLibrary->trackCollectionManager()
                                   ->internalCollection()
-                                  ->loadRootDirs();
-    for (const mixxx::FileInfo& rootDir : rootDirs) {
-        // mark missing/invalid dirs with a warning icon, add a tooltip
-        auto* pDirItem = new QStandardItem(rootDir.location());
-        if (!rootDir.exists() || !rootDir.isDir()) {
+                                  ->getRootDirStrings();
+    for (const QString& rootDir : rootDirs) {
+        auto* pDirItem = new QStandardItem(rootDir);
+        // Note: constructing a FileInfo from a path string added in another
+        // will create issues: on Windows, if that path doesn't start with
+        // '[drive letter]:' it'll get prefixed with 'C:'; if on Linux the path
+        // starts with '[drive letter]:' the working dir's path is prepended.
+        // In both cases this is obviously wrong and directory/track relocation
+        // will fail since the database has no tracks with constructed prefix.
+        // Let's use QStrings for the roundtrip. The FileInfo is just for
+        // validation and eventually adding the warning icon.
+        const mixxx::FileInfo fileInfo(rootDir);
+        if (!fileInfo.exists() || !fileInfo.isDir()) {
             pDirItem->setIcon(QIcon(kWarningIconPath));
             pDirItem->setToolTip(tr("Item is not a directory or directory is missing"));
         }
@@ -230,7 +238,7 @@ void DlgPrefLibrary::slotResetToDefaults() {
 }
 
 void DlgPrefLibrary::slotUpdate() {
-    initializeDirList();
+    populateDirList();
     checkBox_library_scan->setChecked(m_pConfig->getValue(
             kRescanOnStartupConfigKey, false));
 

--- a/src/preferences/dialog/dlgpreflibrary.h
+++ b/src/preferences/dialog/dlgpreflibrary.h
@@ -66,7 +66,7 @@ class DlgPrefLibrary : public DlgPreferencePage, public Ui::DlgPrefLibraryDlg  {
     void slotSeratoMetadataExportClicked(bool);
 
   private:
-    void initializeDirList();
+    void populateDirList();
     void setLibraryFont(const QFont& font);
     void updateSearchLineEditHistoryOptions();
     void setSeratoMetadataEnabled(bool shouldSyncTrackMetadata);


### PR DESCRIPTION
### The issue:
When trying to relink a music directory with a database created in another OS (actually only Windows <--> Linux/macOS),
directory relocation will fail. This is due to the fact that mixxx::FileInfo (QFileInfo), which is part of the roundtrip 
DirectoryDAO -> [Library preferences](https://github.com/mixxxdj/mixxx/blob/23e91ac0bf7c86c5b03dc2d7048396be6de2ad5c/src/preferences/dialog/dlgpreflibrary.cpp#L403-L425) -> ... -> DirectoryDAO, does unexpected things (no explicit documentation?) if the path string it's constructed from doesn't match the current OS' path schema:
* Windows -> Linux:
`C:\some\path` is considered relative and the the current working dir path is prepended
`/mixxx/build/dir/C:/some/path`
* Linux -> Windows
same issue, `/home/Music` is missing "[drive letter]:" prefix and becomes `C:/home/Music` (not found etc.)

For both directions it fails with this DEBUG_ASSERT in [DirectoryDAO::relocateDirectory](https://github.com/mixxxdj/mixxx/blob/474b82a282b50f0c7251e8ba223ae49119560b9f/src/library/dao/directorydao.cpp#L147) and relocation will fail silently.
See https://github.com/mixxxdj/mixxx/issues/12715

For both directions I also hit this [assertion in `mixxx::Fileinfo`](https://github.com/mixxxdj/mixxx/blob/23e91ac0bf7c86c5b03dc2d7048396be6de2ad5c/src/util/fileinfo.h#L108)), probably when trying to load cover arts.

(note #12436 which adds some feedback to directory operations)

___

### Simple fix:
avoid the string -> fileInfo -> string roundtrip and simply use QStrings for the entire display/relocation flow.
Just the 'oldDirectory' test needs to be fixed.
Or, does it? Actually it's now the same path returned by `DirectoryDAO::getRootDirStrings()`, so if it was changed on the roundtrip the query will fail :shrug: 

### Note for testing with a db from another OS:
You need to build with DEBUG_ASSERTIONS_FATAL=OFF, otherwise you'll hit them in fileinfo.h when the library tries to display cover art.
This also prevents building helpful migration tests.