### PR TITLE
Developer Tools: initially sort controls by group name, ascending

### DIFF
--- a/src/dialog/dlgdevelopertools.cpp
+++ b/src/dialog/dlgdevelopertools.cpp
@@ -18,6 +18,7 @@ DlgDeveloperTools::DlgDeveloperTools(QWidget* pParent,
     controlsTable->hideColumn(ControlModel::CONTROL_COLUMN_TITLE);
     controlsTable->hideColumn(ControlModel::CONTROL_COLUMN_DESCRIPTION);
     controlsTable->hideColumn(ControlModel::CONTROL_COLUMN_FILTER);
+    m_controlProxyModel.sort(0, Qt::AscendingOrder);
 
     StatsManager* pManager = StatsManager::instance();
     if (pManager) {


### PR DESCRIPTION
When debugging I find myself always clicking on the group column to sort and have Channel1 shown at the top.