### PR TITLE
Add support for "x-special/gnome-copied-files" on Linux

### DIFF
--- a/src/util/clipboard.cpp
+++ b/src/util/clipboard.cpp
@@ -4,6 +4,22 @@
 #include <QClipboard>
 #include <QMimeData>
 
+namespace {
+
+#ifdef __LINUX__
+QByteArray urlsToUtf8(const QList<QUrl>& urls) {
+    QByteArray result;
+    for (const QUrl& url : urls) {
+        result += url.toEncoded() + '\n';
+    }
+    if (!result.isEmpty())
+        result.chop(1);
+    return result;
+}
+#endif
+
+} // namespace
+
 void Clipboard::start() {
     instance()->m_urls.clear();
 }
@@ -15,6 +31,11 @@ void Clipboard::add(const QUrl& url) {
 void Clipboard::finish() {
     QMimeData* data = new QMimeData;
     data->setUrls(instance()->m_urls);
+#ifdef __LINUX__
+    // "x-special/gnome-copied-files" is used for many file managers
+    // https://indigo.re/posts/2021-12-21-clipboard-data.html
+    data->setData("x-special/gnome-copied-files", "copy\n" + urlsToUtf8(instance()->m_urls));
+#endif
     QApplication::clipboard()->setMimeData(data);
 }
 


### PR DESCRIPTION
This allows to use Crtl+C and Ctrl+V with various Linux file managers