### PR TITLE
feat(ci): add eslint rule prefer-template

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -84,6 +84,7 @@
     "object-curly-spacing": "warn",
     "prefer-const": "warn",
     "prefer-regex-literals": "warn",
+    "prefer-template": "warn",
     "quotes": [ "warn", "double" ],
     "require-atomic-updates": "error",
     "semi": "warn",


### PR DESCRIPTION
Due to the fact that our CO's are stringly typed, a lot of accesses to CO's from javascript need to assemble the CO's key or group from other components. In Mixxx 2.4, the QJSEngine- based controler engine allows us to use ES6 string-template-literals (eg \`[EffectRack1_EffectUnit${n}_Effect${m}]\` which make these assembled strings a lot easier to read than compared to the same string assembled using string-concatination
("[EffectRack1_EffectUnit" + n + "_Effect" + m + "]").