### PR TITLE
View menu: add 'Show Auto DJ' action

### DIFF
--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -23,12 +23,6 @@
 #include "widget/wlibrarysidebar.h"
 
 namespace {
-
-const QString kViewName = QStringLiteral("Auto DJ");
-
-} // namespace
-
-namespace {
 constexpr int kMaxRetrieveAttempts = 3;
 
     int findOrCrateAutoDjPlaylistId(PlaylistDAO& playlistDAO) {
@@ -55,6 +49,7 @@ AutoDJFeature::AutoDJFeature(Library* pLibrary,
           m_pAutoDJProcessor(nullptr),
           m_pSidebarModel(make_parented<TreeItemModel>(this)),
           m_pAutoDJView(nullptr),
+          m_viewName(Library::kAutoDJViewName),
           m_autoDjCratesDao(m_iAutoDJPlaylistId, pLibrary->trackCollectionManager(), m_pConfig) {
     qRegisterMetaType<AutoDJProcessor::AutoDJState>("AutoDJState");
     m_pAutoDJProcessor = new AutoDJProcessor(this,
@@ -152,7 +147,7 @@ void AutoDJFeature::bindLibraryWidget(
             m_pLibrary,
             m_pAutoDJProcessor,
             keyboard);
-    libraryWidget->registerView(kViewName, m_pAutoDJView);
+    libraryWidget->registerView(m_viewName, m_pAutoDJView);
     connect(m_pAutoDJView,
             &DlgAutoDJ::loadTrack,
             this,
@@ -196,7 +191,7 @@ TreeItemModel* AutoDJFeature::sidebarModel() const {
 
 void AutoDJFeature::activate() {
     //qDebug() << "AutoDJFeature::activate()";
-    emit switchToView(kViewName);
+    emit switchToView(m_viewName);
     emit disableSearch();
     emit enableCoverArtDisplay(true);
 }

--- a/src/library/autodj/autodjfeature.h
+++ b/src/library/autodj/autodjfeature.h
@@ -65,6 +65,7 @@ class AutoDJFeature : public LibraryFeature {
     AutoDJProcessor* m_pAutoDJProcessor;
     parented_ptr<TreeItemModel> m_pSidebarModel;
     DlgAutoDJ* m_pAutoDJView;
+    const QString m_viewName;
 
     // Initialize the list of crates loaded into the auto-DJ queue.
     void constructCrateChildModel();

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -51,7 +51,9 @@ using namespace mixxx::library::prefs;
 
 // This is the name which we use to register the WTrackTableView with the
 // WLibrary
-const QString Library::m_sTrackViewName = QString("WTrackTableView");
+const QString Library::m_sTrackViewName = QStringLiteral("WTrackTableView");
+
+const QString Library::kAutoDJViewName = QStringLiteral("Auto DJ");
 
 // The default row height of the library.
 const int Library::kDefaultRowHeightPx = 20;
@@ -71,6 +73,7 @@ Library::Library(
           m_pLibraryControl(make_parented<LibraryControl>(this)),
           m_pLibraryWidget(nullptr),
           m_pMixxxLibraryFeature(nullptr),
+          m_pAutoDJFeature(nullptr),
           m_pPlaylistFeature(nullptr),
           m_pCrateFeature(nullptr),
           m_pAnalysisFeature(nullptr) {
@@ -98,7 +101,8 @@ Library::Library(
             Qt::DirectConnection /* signal-to-signal */);
 #endif
 
-    addFeature(new AutoDJFeature(this, m_pConfig, pPlayerManager));
+    m_pAutoDJFeature = new AutoDJFeature(this, m_pConfig, pPlayerManager);
+    addFeature(m_pAutoDJFeature);
 
     m_pPlaylistFeature = new PlaylistFeature(this, UserSettingsPointer(m_pConfig));
     addFeature(m_pPlaylistFeature);
@@ -754,6 +758,12 @@ void Library::searchTracksInCollection(const QString& query) {
         return;
     }
     m_pMixxxLibraryFeature->searchAndActivate(query);
+}
+
+void Library::showAutoDJ() {
+    m_pAutoDJFeature->activate();
+    emit switchToView(kAutoDJViewName);
+    m_pSidebarModel->slotFeatureSelect(m_pAutoDJFeature);
 }
 
 #ifdef __ENGINEPRIME__

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -763,7 +763,8 @@ void Library::searchTracksInCollection(const QString& query) {
 void Library::showAutoDJ() {
     m_pAutoDJFeature->activate();
     emit switchToView(kAutoDJViewName);
-    m_pSidebarModel->slotFeatureSelect(m_pAutoDJFeature);
+    // Select it but don't scroll there
+    m_pSidebarModel->slotFeatureSelect(m_pAutoDJFeature, QModelIndex(), false);
 }
 
 #ifdef __ENGINEPRIME__

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -16,6 +16,7 @@
 #include "util/parented_ptr.h"
 
 class AnalysisFeature;
+class AutoDJFeature;
 class BrowseFeature;
 class ControlObject;
 class CrateFeature;
@@ -105,6 +106,9 @@ class Library: public QObject {
     /// Triggers a new search in the internal track collection
     /// and shows the results by switching the view.
     void searchTracksInCollection(const QString& query);
+    void showAutoDJ();
+
+    static const QString kAutoDJViewName;
 
     bool requestAddDir(const QString& directory);
     bool requestRemoveDir(const QString& directory, LibraryRemovalType removalType);
@@ -189,9 +193,9 @@ class Library: public QObject {
 
     QList<LibraryFeature*> m_features;
     const static QString m_sTrackViewName;
-    const static QString m_sAutoDJViewName;
     WLibrary* m_pLibraryWidget;
     MixxxLibraryFeature* m_pMixxxLibraryFeature;
+    AutoDJFeature* m_pAutoDJFeature;
     PlaylistFeature* m_pPlaylistFeature;
     CrateFeature* m_pCrateFeature;
     AnalysisFeature* m_pAnalysisFeature;

--- a/src/library/libraryfeature.h
+++ b/src/library/libraryfeature.h
@@ -165,7 +165,7 @@ class LibraryFeature : public QObject {
     // emit this signal if the foreign music collection has been imported/parsed.
     void featureLoadingFinished(LibraryFeature*s);
     // emit this signal to select pFeature
-    void featureSelect(LibraryFeature* pFeature, const QModelIndex& index);
+    void featureSelect(LibraryFeature* pFeature, const QModelIndex& index, bool scrollTo = true);
     // emit this signal to enable/disable the cover art widget
     void enableCoverArtDisplay(bool);
     void trackSelected(TrackPointer pTrack);

--- a/src/library/sidebarmodel.cpp
+++ b/src/library/sidebarmodel.cpp
@@ -96,7 +96,7 @@ void SidebarModel::setDefaultSelection(unsigned int index) {
 void SidebarModel::activateDefaultSelection() {
     if (m_iDefaultSelectedIndex <
             static_cast<unsigned int>(m_sFeatures.size())) {
-        emit selectIndex(getDefaultSelection());
+        emit selectIndex(getDefaultSelection(), true /* scrollTo */);
         // Selecting an index does not activate it.
         m_sFeatures[m_iDefaultSelectedIndex]->activate();
     }
@@ -593,7 +593,9 @@ void SidebarModel::featureRenamed(LibraryFeature* pFeature) {
     }
 }
 
-void SidebarModel::slotFeatureSelect(LibraryFeature* pFeature, const QModelIndex& featureIndex) {
+void SidebarModel::slotFeatureSelect(LibraryFeature* pFeature,
+        const QModelIndex& featureIndex,
+        bool scrollTo) {
     QModelIndex ind;
     if (featureIndex.isValid()) {
         TreeItem* pTreeItem = static_cast<TreeItem*>(featureIndex.internalPointer());
@@ -606,5 +608,5 @@ void SidebarModel::slotFeatureSelect(LibraryFeature* pFeature, const QModelIndex
             }
         }
     }
-    emit selectIndex(ind);
+    emit selectIndex(ind, scrollTo);
 }

--- a/src/library/sidebarmodel.h
+++ b/src/library/sidebarmodel.h
@@ -56,7 +56,9 @@ class SidebarModel : public QAbstractItemModel {
     void rightClicked(const QPoint& globalPos, const QModelIndex& index);
     void renameItem(const QModelIndex& index);
     void deleteItem(const QModelIndex& index);
-    void slotFeatureSelect(LibraryFeature* pFeature, const QModelIndex& index = QModelIndex());
+    void slotFeatureSelect(LibraryFeature* pFeature,
+            const QModelIndex& index = QModelIndex(),
+            bool scrollTo = true);
 
     // Slots for every single QAbstractItemModel signal
     // void slotColumnsAboutToBeInserted(const QModelIndex& parent, int start, int end);
@@ -79,7 +81,7 @@ class SidebarModel : public QAbstractItemModel {
     void slotFeatureLoadingFinished(LibraryFeature*);
 
   signals:
-    void selectIndex(const QModelIndex& index);
+    void selectIndex(const QModelIndex& index, bool scrollTo);
 
   private slots:
     void slotPressedUntilClickedTimeout();

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -450,6 +450,12 @@ void MixxxMainWindow::initialize() {
     if (CmdlineArgs::Instance().getStartAutoDJ()) {
         qDebug("Enabling Auto DJ from CLI flag.");
         ControlObject::set(ConfigKey("[AutoDJ]", "enabled"), 1.0);
+        // Switch to Auto DJ feature
+        auto* pLibrary = m_pCoreServices->getLibrary().get();
+        // Note: auto-scroll is disabled but that doesn't really matter here
+        // because the sidebar is still in its initial state (top feature visible,
+        // AutoDj is second from the top by default, all features collapsed).
+        pLibrary->showAutoDJ();
     }
 }
 

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -976,6 +976,11 @@ void MixxxMainWindow::connectMenuBar() {
                 m_pCoreServices->getLibrary().get(),
                 &Library::slotCreatePlaylist,
                 Qt::UniqueConnection);
+        connect(m_pMenuBar,
+                &WMainMenuBar::showAutoDJ,
+                m_pCoreServices->getLibrary().get(),
+                &Library::showAutoDJ,
+                Qt::UniqueConnection);
     }
 
 #ifdef __ENGINEPRIME__

--- a/src/widget/wlibrary.cpp
+++ b/src/widget/wlibrary.cpp
@@ -55,9 +55,6 @@ void WLibrary::switchToView(const QString& name) {
     const auto lock = lockMutex(&m_mutex);
     //qDebug() << "WLibrary::switchToView" << name;
 
-    LibraryView* pOldLibrartView = dynamic_cast<LibraryView*>(
-            currentWidget());
-
     QWidget* pWidget = m_viewMap.value(name, nullptr);
     if (pWidget != nullptr) {
         LibraryView* pLibraryView = dynamic_cast<LibraryView*>(pWidget);
@@ -68,8 +65,10 @@ void WLibrary::switchToView(const QString& name) {
             return;
         }
         if (currentWidget() != pWidget) {
-            if (pOldLibrartView) {
-                pOldLibrartView->saveCurrentViewState();
+            LibraryView* pOldLibraryView = dynamic_cast<LibraryView*>(
+                    currentWidget());
+            if (pOldLibraryView) {
+                pOldLibraryView->saveCurrentViewState();
             }
             //qDebug() << "WLibrary::setCurrentWidget" << name;
             setCurrentWidget(pWidget);

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -351,8 +351,8 @@ void WLibrarySidebar::focusInEvent(QFocusEvent* event) {
     QTreeView::focusInEvent(event);
 }
 
-void WLibrarySidebar::selectIndex(const QModelIndex& index) {
-    //qDebug() << "WLibrarySidebar::selectIndex" << index;
+void WLibrarySidebar::selectIndex(const QModelIndex& index, bool scrollToIndex) {
+    // qDebug() << "WLibrarySidebar::selectIndex" << index << scrollToIndex;
     if (!index.isValid()) {
         return;
     }
@@ -365,8 +365,18 @@ void WLibrarySidebar::selectIndex(const QModelIndex& index) {
         expand(index.parent());
     }
     setSelectionModel(pModel);
+    if (!scrollToIndex) {
+        // With auto-scroll enabled, setCurrentIndex() would scroll there.
+        // Disable (and re-enable if we don't want to scroll, e.g. when selecting
+        // AutoDJ from the menubar or during startup
+        setAutoScroll(false);
+    }
     setCurrentIndex(index);
-    scrollTo(index);
+    if (scrollToIndex) {
+        scrollTo(index);
+    } else {
+        setAutoScroll(true);
+    }
 }
 
 /// Selects a child index from a feature and ensures visibility

--- a/src/widget/wlibrarysidebar.h
+++ b/src/widget/wlibrarysidebar.h
@@ -30,7 +30,7 @@ class WLibrarySidebar : public QTreeView, public WBaseWidget {
     bool isFeatureRootIndexSelected(LibraryFeature* pFeature);
 
   public slots:
-    void selectIndex(const QModelIndex&);
+    void selectIndex(const QModelIndex& index, bool scrollToIndex = true);
     void selectChildIndex(const QModelIndex&, bool selectItem = true);
     void slotSetFont(const QFont& font);
 

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -377,6 +377,20 @@ void WMainMenuBar::initialize() {
 
     pViewMenu->addSeparator();
 
+    QString autoDJTitle = tr("Show Auto DJ");
+    QString autoDJText = tr("Switch to the Auto DJ view.");
+    auto* pViewAutoDJ = new QAction(autoDJTitle, this);
+    // pViewAutoDJ->setShortcut(QKeySequence(m_pKbdConfig->getValue(
+    //         ConfigKey("[KeyboardShortcuts]", "ViewMenu_ShowAutoDJ"),
+    //         tr("Ctrl+9", "Menubar|View|Show Auto DJ"))));
+    pViewAutoDJ->setStatusTip(autoDJText);
+    pViewAutoDJ->setWhatsThis(buildWhatsThis(autoDJTitle, autoDJText));
+    pViewAutoDJ->setCheckable(false);
+    connect(pViewAutoDJ, &QAction::triggered, this, &WMainMenuBar::showAutoDJ);
+    pViewMenu->addAction(pViewAutoDJ);
+
+    pViewMenu->addSeparator();
+
     QString fullScreenTitle = tr("&Full Screen");
     QString fullScreenText = tr("Display Mixxx using the full screen");
     auto* pViewFullScreen = new QAction(fullScreenTitle, this);

--- a/src/widget/wmainmenubar.h
+++ b/src/widget/wmainmenubar.h
@@ -69,6 +69,7 @@ class WMainMenuBar : public QMenuBar {
 #endif
     void searchInCurrentView();
     void searchInAllTracks();
+    void showAutoDJ();
     void showAbout();
     void showKeywheel(bool visible);
     void showPreferences();


### PR DESCRIPTION
requested here https://mixxx.zulipchat.com/#narrow/stream/109122-general/topic/AutoDJ.20as.20a.20View.20option

AutoDJ is a special feature that may need immediate attention, i.e. a way to activate it quickly, that's why I think a shortcut seems reasonable.
![Screenshot_2024-02-28_13-21-01](https://github.com/mixxxdj/mixxx/assets/5934199/caa8e7c8-9878-494b-9042-62a83fb937a2)

#### Which keyboard shortcut?
There are already Ctrl+1..6
Ctrl+7 would be next, but maybe we want to extend the skin controls, and then it would be better to have consecutive shortcuts for toggles ("Show AutoDJ is a _trigger_).
What about Ctrl+9?