### PR TITLE
(fix) Computer feature: update removable devices on Linux

### DIFF
--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -277,10 +277,6 @@ void BrowseFeature::activateChild(const QModelIndex& index) {
 
 void BrowseFeature::onRightClickChild(const QPoint& globalPos, const QModelIndex& index) {
     TreeItem *item = static_cast<TreeItem*>(index.internalPointer());
-
-    // Make sure that this is reset when the related TreeItem is deleted.
-    m_pLastRightClickedItem = item;
-
     if (!item) {
         return;
     }
@@ -290,6 +286,9 @@ void BrowseFeature::onRightClickChild(const QPoint& globalPos, const QModelIndex
     if (path == QUICK_LINK_NODE || path == DEVICE_NODE) {
         return;
     }
+
+    // Make sure that this is reset when TreeItems are deleted in onLazyChildExpandation()
+    m_pLastRightClickedItem = item;
 
     QMenu menu(m_pSidebarWidget);
 

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -414,6 +414,13 @@ void BrowseFeature::onLazyChildExpandation(const QModelIndex& index) {
 
     // If we are on the special device node
     if (path == DEVICE_NODE) {
+#if defined(__LINUX__)
+        // Tell the model to remove the cached 'hasChildren' states of all sub-
+        // directories when we expand the Device node.
+        // This ensures we show the real dir tree. This is relevant when devices
+        // were unmounted, changed and mounted again.
+        m_pSidebarModel->removeChildDirsFromCache(removableDriveRootPaths());
+#endif
         folders = createRemovableDevices();
     } else {
         // we assume that the path refers to a folder in the file system

--- a/src/library/browse/foldertreemodel.cpp
+++ b/src/library/browse/foldertreemodel.cpp
@@ -111,3 +111,38 @@ bool FolderTreeModel::directoryHasChildren(const QString& path) const {
     m_directoryCache[path] = has_children;
     return has_children;
 }
+
+void FolderTreeModel::removeChildDirsFromCache(const QStringList& rootPaths) {
+    // PerformanceTimer time;
+    // const auto start = time.elapsed();
+    if (rootPaths.isEmpty()) {
+        return;
+    }
+
+    // Just a quick check that prevents iterating the cache pointlessly
+    for (const auto& rootPath : rootPaths) {
+        VERIFY_OR_DEBUG_ASSERT(!rootPath.isEmpty()) {
+            // List contains at least one non-empty path
+            break;
+        }
+    }
+
+    // int checked = 0;
+    // int removed = 0;
+    QHashIterator<QString, bool> it(m_directoryCache);
+    while (it.hasNext()) {
+        it.next();
+        // checked++;
+        const QString cachedPath = it.key();
+        for (const auto& rootPath : rootPaths) {
+            if (!rootPath.isEmpty() && cachedPath.startsWith(rootPath)) {
+                m_directoryCache.remove(cachedPath);
+                // removed++;
+            }
+        }
+    }
+
+    // qWarning() << "     checked:" << checked << "| removed:" << removed;
+    // qWarning() << "     elapsed:" << mixxx::Duration(time.elapsed() -
+    // start).debugMicrosWithUnit();
+}

--- a/src/library/browse/foldertreemodel.cpp
+++ b/src/library/browse/foldertreemodel.cpp
@@ -20,20 +20,18 @@ FolderTreeModel::FolderTreeModel(QObject *parent)
 FolderTreeModel::~FolderTreeModel() {
 }
 
-/* A tree model of the filesystem should be initialized lazy.
- * It will take the universe to iterate over all files over filesystem
- * hasChildren() returns true if a folder has subfolders although
- * we do not know the precise number of subfolders.
- *
- * Note that BrowseFeature inserts folder trees dynamically and rowCount()
- * is only called if necessary.
- */
+// A tree model of the filesystem should be initialized lazy.
+// It will take the universe to iterate over all files over filesystem
+// hasChildren() returns true if a folder has subfolders although
+// we do not know the precise number of subfolders.
+//
+// Note that BrowseFeature inserts folder trees dynamically and rowCount()
+// is only called if necessary.
 bool FolderTreeModel::hasChildren(const QModelIndex& parent) const {
     TreeItem *item = static_cast<TreeItem*>(parent.internalPointer());
-    /* Usually the child count is 0 because we do lazy initialization
-     * However, for, buid-in items such as 'Quick Links' there exist
-     * child items at init time
-     */
+    // Usually the child count is 0 because we do lazy initialization
+    // However, for, buid-in items such as 'Quick Links' there exist
+    // child items at init time
     if (item->getData().toString() == QUICK_LINK_NODE) {
         return true;
     }
@@ -56,18 +54,15 @@ bool FolderTreeModel::directoryHasChildren(const QString& path) const {
     // Acquire a security token for the path.
     const auto dirAccess = mixxx::FileAccess(mixxx::FileInfo(path));
 
-    /*
-     *  The following code is too expensive, general and SLOW since
-     *  QDIR::EntryInfoList returns a full QFileInfolist
-     *
-     *
-     *  QDir dir(item->getData().toString());
-     *  QFileInfoList all = dir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
-     *  return (all.count() > 0);
-     *
-     *  We can benefit from low-level filesystem APIs, i.e.,
-     *  Windows API or SystemCalls
-     */
+    // The following code is too expensive, general and SLOW since
+    // QDIR::EntryInfoList returns a full QFileInfolist
+    //
+    // QDir dir(item->getData().toString());
+    // QFileInfoList all = dir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
+    // return (all.count() > 0);
+    //
+    // We can benefit from low-level filesystem APIs, i.e.,
+    // Windows API or SystemCalls
 
     bool has_children = false;
 

--- a/src/library/browse/foldertreemodel.h
+++ b/src/library/browse/foldertreemodel.h
@@ -16,8 +16,12 @@ class FolderTreeModel : public TreeItemModel {
     virtual ~FolderTreeModel();
     virtual bool hasChildren(const QModelIndex& parent = QModelIndex()) const;
     bool directoryHasChildren(const QString& path) const;
+    void removeChildDirsFromCache(const QStringList& rootPaths);
 
   private:
-    // Used for memoizing the results of directoryHasChildren
+    // Used for memorizing the results of directoryHasChildren.
+    // Note: this means we won't see directory tree changes after the initial
+    // tree population after first expansion. I.e. newly added directories won't
+    // be displayed and removed dirs will remain in the sidebar tree.
     mutable QHash<QString, bool> m_directoryCache;
 };

--- a/src/library/browse/foldertreemodel.h
+++ b/src/library/browse/foldertreemodel.h
@@ -23,5 +23,6 @@ class FolderTreeModel : public TreeItemModel {
     // Note: this means we won't see directory tree changes after the initial
     // tree population after first expansion. I.e. newly added directories won't
     // be displayed and removed dirs will remain in the sidebar tree.
+    // removeChildDirsFromCache() can be used to reset selected directories.
     mutable QHash<QString, bool> m_directoryCache;
 };

--- a/src/library/treeitemmodel.cpp
+++ b/src/library/treeitemmodel.cpp
@@ -3,30 +3,29 @@
 #include "library/treeitem.h"
 #include "moc_treeitemmodel.cpp"
 
-/*
- * Just a word about how the TreeItem objects and TreeItemModels are used in general:
- * TreeItems are used by the TreeItemModel class to display tree
- * structures in the sidebar.
- *
- * The constructor has 4 arguments:
- * 1. argument represents a name shown in the sidebar view later on
- * 2. argument represents the absolute path of this tree item
- * 3. argument is a library feature object.
- *    This is necessary because in sidebar.cpp we handle 'activateChid' events
- * 4. the parent TreeItem object
- *    The constructor does not add this TreeItem object to the parent's child list
- *
- * In case of no arguments, the standard constructor creates a
- * root item that is not visible in the sidebar.
- *
- * Once the TreeItem objects are inserted to models, the models take care of their
- * deletion.
- *
- * Examples on how to use TreeItem and TreeItemModels can be found in
- * - playlistfeature.cpp
- * - cratefeature.cpp
- * - *feature.cpp
- */
+// Just a word about how the TreeItem objects and TreeItemModels are used in general:
+// TreeItems are used by the TreeItemModel class to display tree
+// structures in the sidebar.
+//
+// The constructor has 4 arguments:
+// 1. argument represents a name shown in the sidebar view later on
+// 2. argument represents the absolute path of this tree item
+// 3. argument is a library feature object.
+//    This is necessary because in sidebar.cpp we handle 'activateChid' events
+// 4. the parent TreeItem object
+//    The constructor does not add this TreeItem object to the parent's child list
+//
+// In case of no arguments, the standard constructor creates a
+// root item that is not visible in the sidebar.
+//
+// Once the TreeItem objects are inserted to models, the models take care of their
+// deletion.
+//
+// Examples on how to use TreeItem and TreeItemModels can be found in
+// - playlistfeature.cpp
+// - cratefeature.cpp
+// - *feature.cpp
+
 TreeItemModel::TreeItemModel(QObject *parent)
         : QAbstractItemModel(parent),
           m_pRootItem(std::make_unique<TreeItem>()) {
@@ -35,7 +34,7 @@ TreeItemModel::TreeItemModel(QObject *parent)
 TreeItemModel::~TreeItemModel() {
 }
 
-//Our Treeview Model supports exactly a single column
+// Our Treeview Model supports exactly a single column
 int TreeItemModel::columnCount(const QModelIndex &parent) const {
     Q_UNUSED(parent);
     return 1;
@@ -153,10 +152,8 @@ int TreeItemModel::rowCount(const QModelIndex& parent) const {
     return parentItem->childRows();
 }
 
-/**
- * Populates the model and notifies the view.
- * Call this method first, before you do call any other methods.
- */
+// Populates the model and notifies the view.
+// Call this method first, before you do call any other methods.
 TreeItem* TreeItemModel::setRootItem(std::unique_ptr<TreeItem> pRootItem) {
     beginResetModel();
     m_pRootItem = std::move(pRootItem);
@@ -168,10 +165,8 @@ const QModelIndex TreeItemModel::getRootIndex() {
     return createIndex(0, 0, getRootItem());
 }
 
-/**
- * Before you can resize the data model dynamically by using 'insertRows' and 'removeRows'
- * make sure you have initialized.
- */
+// Before you can resize the data model dynamically by using 'insertRows' and 'removeRows'
+// make sure you have initialized.
 void TreeItemModel::insertTreeItemRows(
         std::vector<std::unique_ptr<TreeItem>>&& rows,
         int position,


### PR DESCRIPTION
Re #12891 

### Issue 1
I didn't see my SD card in /media/user after I re-mounted it.
I have been focused only on `/media/[user]` because this is where my USB/SD drives are mounted. Devices changes (or removed and re-mounted devices) where not reflected in the tree view because these are **subdirs** of the device lookup path /media for which the respective **'hasChildren()` state has been cached**.

This is not the case for 1st-level children of the lookup paths, e.g. /run/media/[user]. In those we show devices correctly (newly added or removed) when (re-)expanding the 'Removable Devices' node.

**Fix:**
add /media/[user] to lookup paths, but don't show it when adding children of /media :heavy_check_mark: 
= all devices are now leaves of the Devices branch

### Issue 2
We won't see changes in the dir tree after initial expand due to `hasChildren()` caching.
While for static mounts this may be an okayish tradeoff for (assumed) faster repaint for static mounts, it is much more likely that the dir tree of a removable device has changed.

**Ideas and simple benchmarking:**
**a)** when expanding Devices, tell the FolderTreeitemModel to remove all child paths from the cache:
with 10.000 cached paths this takes about 2.5ms, and is only done once when [devices] is expanded
**b)** in `directoryHasChildren`, check if `path` starts with one of the device root paths, if yes: don't cache `hasChildren`
with 10.000 cached paths this takes about 7ms **per dir**, and causes some notable delay under some circumstances

**Fix:**
So the winner is a) :heavy_check_mark: 
To refresh, just collapse & expand 'Removable Devices' (click on branch icon or hit Return twice).

### Addon / Proposal
We could add a new Browse  item action 'Refresh directory tree', mapped to the new method `FolderTreeModel::removeChildDirsFromCache(QStringList)`.
This would allow to force-refresh the dir tree of that item, e.g. when you copied dirs to a previously empty QuickLink dir.
#12908 

**TODO**
make Refresh more discoverable (tooltip), mention it in the manual
___
Related meta discussion: https://mixxx.zulipchat.com/#narrow/stream/109122-general/topic/linux.3A.20mounting.20drive.20after.20starting.20mixxx