### PR TITLE
Tracks: custom color for missing tracks

### DIFF
--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -225,6 +225,11 @@ WLibrarySidebar {
   /* background of Color delegate in selected row */
   selection-background-color: #006596;
 }
+/* Override the 'missing' color in Tracks > Missing,
+   it's not useful there */
+#DlgMissing WTrackTableView {
+  qproperty-trackMissingColor: #d2d2d2;
+}
 
 /* Prevent OS-style checkbox from being rendered underneath the custom style. */
 #LibraryPlayedCheckbox::item,

--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -261,7 +261,7 @@ WTrackTableView {
   qproperty-focusBorderColor: #D6D6D6;
   /* This is the color used to paint the text of played tracks.
      BaseTrackTableModel::data() uses this to override Qt::ForegroundRole (QBrush). */
-  qproperty-playedInactiveColor: #555;
+  qproperty-trackPlayedColor: #555;
 }
 
 WTrackTableView:focus,

--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -1132,7 +1132,12 @@ WCueMenuPopup QLabel,
 #CueLabelEdit,
 #LatencyLabel, WTime {
   color: #f0bb2b;
-  }
+}
+/* Override the 'missing' color in Tracks > Missing,
+   it's not useful there */
+#DlgMissing WTrackTableView {
+  qproperty-trackMissingColor: #f0bb2b;
+}
   #SkinSettingsNumToggleHeader[displayValue="0"] {
     color: #b9901f;
   }

--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -2130,7 +2130,7 @@ WTrackTableView {
   qproperty-focusBorderColor: #fff;
   /* This is the color used to paint the text of played tracks.
      BaseTrackTableModel::data() uses this to override Qt::ForegroundRole (QBrush). */
-  qproperty-playedInactiveColor: #555;
+  qproperty-trackPlayedColor: #555;
 }
 
 WLibrarySidebar {

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -1231,7 +1231,13 @@ WCueMenuPopup QLabel,
 #CueLabelEdit,
 WCoverArtMenu {
   color: #c2b3a5;
-  }
+}
+/* Override the 'missing' color in Tracks > Missing,
+   it's not useful there */
+#DlgMissing WTrackTableView {
+  qproperty-trackMissingColor: #c2b3a5;
+}
+
   /* dim ivory / light brown */
   #Deck1 WStarRating, #DeckCompact1 WStarRating,
   #Deck2 WStarRating, #DeckCompact2 WStarRating,
@@ -2605,6 +2611,8 @@ WTrackTableView {
   /* This is the color used to paint the text of played tracks.
      BaseTrackTableModel::data() uses this to override Qt::ForegroundRole (QBrush). */
   qproperty-trackPlayedColor: #555;
+  /* This is the color used to paint the text of missing tracks. */
+  qproperty-trackMissingColor: #f856e7; /* pink */
 }
 
 /* Table cell in edit mode */

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -2604,7 +2604,7 @@ WTrackTableView {
   qproperty-focusBorderColor: #fff;
   /* This is the color used to paint the text of played tracks.
      BaseTrackTableModel::data() uses this to override Qt::ForegroundRole (QBrush). */
-  qproperty-playedInactiveColor: #555;
+  qproperty-trackPlayedColor: #555;
 }
 
 /* Table cell in edit mode */

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -532,7 +532,7 @@ WTrackTableView {
   qproperty-focusBorderColor: #c9c9c9;
   /* This is the color used to paint the text of played tracks.
      BaseTrackTableModel::data() uses this to override Qt::ForegroundRole (QBrush). */
-  qproperty-playedInactiveColor: #555;
+  qproperty-trackPlayedColor: #555;
 }
 
   /* Table cell in edit mode */

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -475,6 +475,11 @@ WLibrarySidebar,
 #LibraryPlayedCheckbox::item {
   color: #9e9e9e;
 }
+/* Override the 'missing' color in Tracks > Missing,
+   it's not useful there */
+#DlgMissing WTrackTableView {
+  qproperty-trackMissingColor: #9e9e9e;
+}
 
 
 /* Prevent OS-style checkbox from being rendered underneath the custom style. */

--- a/res/skins/Shade/style_dark.qss
+++ b/res/skins/Shade/style_dark.qss
@@ -204,7 +204,7 @@ WTrackTableView {
   qproperty-focusBorderColor: #ccc;
   /* This is the color used to paint the text of played tracks.
      BaseTrackTableModel::data() uses this to override Qt::ForegroundRole (QBrush). */
-  qproperty-playedInactiveColor: #555;
+  qproperty-trackPlayedColor: #555;
 }
 
   /* Table cell in edit mode */

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -2594,6 +2594,11 @@ WLibrarySidebar,
 #LibraryPlayedCheckbox::item {
   color: #9e9e9e;
 }
+/* Override the 'missing' color in Tracks > Missing,
+   it's not useful there */
+#DlgMissing WTrackTableView {
+  qproperty-trackMissingColor: #9e9e9e;
+}
 
 /* Prevent OS-style checkbox from being rendered underneath the custom style. */
 #LibraryPlayedCheckbox::item,

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -2630,7 +2630,7 @@ WTrackTableView {
   qproperty-focusBorderColor: #fff;
   /* This is the color used to paint the text of played tracks.
      BaseTrackTableModel::data() uses this to override Qt::ForegroundRole (QBrush). */
-  qproperty-playedInactiveColor: #555;
+  qproperty-trackPlayedColor: #555;
 }
 
   /* Table cell in edit mode */

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -135,7 +135,8 @@ BaseTrackTableModel::BaseTrackTableModel(
           m_pTrackCollectionManager(pTrackCollectionManager),
           m_previewDeckGroup(PlayerManager::groupForPreviewDeck(0)),
           m_backgroundColorOpacity(WLibrary::kDefaultTrackTableBackgroundColorOpacity),
-          m_trackPlayedColor(QColor(WTrackTableView::kDefaultTrackPlayedColor)) {
+          m_trackPlayedColor(QColor(WTrackTableView::kDefaultTrackPlayedColor)),
+          m_trackMissingColor(QColor(WTrackTableView::kDefaultTrackMissingColor)) {
     connect(&pTrackCollectionManager->internalCollection()->getTrackDAO(),
             &TrackDAO::forceModelUpdate,
             this,
@@ -468,6 +469,14 @@ QAbstractItemDelegate* BaseTrackTableModel::delegateForColumn(
             [this](QColor col) {
                 m_trackPlayedColor = col;
             });
+    // Same for the 'missing' color
+    m_trackMissingColor = pTableView->getTrackMissingColor();
+    connect(pTableView,
+            &WTrackTableView::trackMissingColorChanged,
+            this,
+            [this](QColor col) {
+                m_trackMissingColor = col;
+            });
     if (index == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_RATING)) {
         return new StarDelegate(pTableView);
     } else if (index == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_BPM)) {
@@ -522,15 +531,32 @@ QVariant BaseTrackTableModel::data(
         DEBUG_ASSERT(m_backgroundColorOpacity <= 1.0);
         bgColor.setAlphaF(static_cast<float>(m_backgroundColorOpacity));
         return QBrush(bgColor);
-    } else if (role == Qt::ForegroundRole && s_bApplyPlayedTrackColor) {
-        // Custom text color for played tracks
-        auto playedRaw = rawSiblingValue(
+    } else if (role == Qt::ForegroundRole) {
+        // Custom text color for missing tracks
+        // Visible in playlists, crates and Missing feature.
+        // Check this first so played, missing tracks (unlikely case, but possible)
+        // get the 'missing' color.
+        // Note: this is not helpful in Tracks -> Missing, so override it with
+        // the regular track color (WTrackTableView { color: #xxx; }) like this:
+        // #DlgMissing WTrackTableView { qproperty-trackMissingColor: #xxx; }
+        auto missingRaw = rawSiblingValue(
                 index,
-                ColumnCache::COLUMN_LIBRARYTABLE_PLAYED);
-        if (!playedRaw.isNull() &&
-                playedRaw.canConvert<bool>() &&
-                playedRaw.toBool()) {
-            return QVariant::fromValue(m_trackPlayedColor);
+                ColumnCache::COLUMN_TRACKLOCATIONSTABLE_FSDELETED);
+        if (!missingRaw.isNull() &&
+                missingRaw.canConvert<bool>() &&
+                missingRaw.toBool()) {
+            return QVariant::fromValue(m_trackMissingColor);
+        }
+        if (s_bApplyPlayedTrackColor) {
+            // Custom text color for played tracks
+            auto playedRaw = rawSiblingValue(
+                    index,
+                    ColumnCache::COLUMN_LIBRARYTABLE_PLAYED);
+            if (!playedRaw.isNull() &&
+                    playedRaw.canConvert<bool>() &&
+                    playedRaw.toBool()) {
+                return QVariant::fromValue(m_trackPlayedColor);
+            }
         }
     }
 

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -135,7 +135,7 @@ BaseTrackTableModel::BaseTrackTableModel(
           m_pTrackCollectionManager(pTrackCollectionManager),
           m_previewDeckGroup(PlayerManager::groupForPreviewDeck(0)),
           m_backgroundColorOpacity(WLibrary::kDefaultTrackTableBackgroundColorOpacity),
-          m_playedInactiveColor(QColor::fromRgb(WTrackTableView::kDefaultPlayedInactiveColorHex)) {
+          m_trackPlayedColor(QColor(WTrackTableView::kDefaultTrackPlayedColor)) {
     connect(&pTrackCollectionManager->internalCollection()->getTrackDAO(),
             &TrackDAO::forceModelUpdate,
             this,
@@ -461,12 +461,12 @@ QAbstractItemDelegate* BaseTrackTableModel::delegateForColumn(
     m_backgroundColorOpacity = pTableView->getBackgroundColorOpacity();
     // This is the color used for the text of played tracks.
     // data() uses this to compose the ForegroundRole QBrush if 'played' is checked.
-    m_playedInactiveColor = pTableView->getPlayedInactiveColor();
+    m_trackPlayedColor = pTableView->getTrackPlayedColor();
     connect(pTableView,
-            &WTrackTableView::playedInactiveColorChanged,
+            &WTrackTableView::trackPlayedColorChanged,
             this,
             [this](QColor col) {
-                m_playedInactiveColor = col;
+                m_trackPlayedColor = col;
             });
     if (index == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_RATING)) {
         return new StarDelegate(pTableView);
@@ -530,7 +530,7 @@ QVariant BaseTrackTableModel::data(
         if (!playedRaw.isNull() &&
                 playedRaw.canConvert<bool>() &&
                 playedRaw.toBool()) {
-            return QVariant::fromValue(m_playedInactiveColor);
+            return QVariant::fromValue(m_trackPlayedColor);
         }
     }
 

--- a/src/library/basetracktablemodel.h
+++ b/src/library/basetracktablemodel.h
@@ -275,7 +275,7 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
     const QString m_previewDeckGroup;
 
     double m_backgroundColorOpacity;
-    QColor m_playedInactiveColor;
+    QColor m_trackPlayedColor;
 
     ColumnCache m_columnCache;
 

--- a/src/library/basetracktablemodel.h
+++ b/src/library/basetracktablemodel.h
@@ -276,6 +276,7 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
 
     double m_backgroundColorOpacity;
     QColor m_trackPlayedColor;
+    QColor m_trackMissingColor;
 
     ColumnCache m_columnCache;
 

--- a/src/library/tabledelegates/bpmdelegate.cpp
+++ b/src/library/tabledelegates/bpmdelegate.cpp
@@ -93,7 +93,8 @@ void BPMDelegate::paintItem(QPainter* painter,const QStyleOptionViewItem &option
     initStyleOption(&opt, index);
 
     // The checkbox uses the QTableView's qss style, therefore it's not picking
-    //  up the 'played' text color via ForegroundRole from BaseTrackTableModel::data().
+    // up the 'missing' or 'played' text color via ForegroundRole from
+    // BaseTrackTableModel::data().
     // Enforce it with an explicit stylesheet. Note: the stylesheet persists so
     // we need to reset it to normal/highlighted.
     QColor textColor;

--- a/src/library/tabledelegates/bpmdelegate.cpp
+++ b/src/library/tabledelegates/bpmdelegate.cpp
@@ -97,15 +97,14 @@ void BPMDelegate::paintItem(QPainter* painter,const QStyleOptionViewItem &option
     // Enforce it with an explicit stylesheet. Note: the stylesheet persists so
     // we need to reset it to normal/highlighted.
     QColor textColor;
-    auto dat = index.data(Qt::ForegroundRole);
-    if (dat.canConvert<QColor>()) {
-        textColor = dat.value<QColor>();
+    if (option.state & QStyle::State_Selected) {
+        textColor = option.palette.color(QPalette::Normal, QPalette::HighlightedText);
     } else {
-        if (option.state & QStyle::State_Selected) {
-            textColor = option.palette.color(QPalette::Normal, QPalette::HighlightedText);
+        auto colorData = index.data(Qt::ForegroundRole);
+        if (colorData.canConvert<QColor>()) {
+            textColor = colorData.value<QColor>();
         } else {
             textColor = option.palette.color(QPalette::Normal, QPalette::Text);
-            // qWarning() << "     !! BPM col:" << textColor.name(QColor::HexRgb);
         }
     }
     if (textColor.isValid()) {

--- a/src/library/tabledelegates/tableitemdelegate.cpp
+++ b/src/library/tabledelegates/tableitemdelegate.cpp
@@ -48,17 +48,18 @@ void TableItemDelegate::paint(
     if (option.state & QStyle::State_Selected) {
         painter->setBrush(option.palette.color(cg, QPalette::HighlightedText));
     } else {
-        // This gets the custom 'played' text color from BaseTrackTableModel
-        // depending on check state of the 'played' column.
+        // This gets the custom 'missing' or played text color from BaseTrackTableModel
+        // depending on check state of the (hidden) 'missing' (fs_deleted)
+        // or 'played' columns.
         // Note that we need to do this again in BPMDelegate which uses the
         // style of the TableView.
-        auto playedColorData = index.data(Qt::ForegroundRole);
-        if (playedColorData.canConvert<QColor>()) {
-            QColor playedColor = playedColorData.value<QColor>();
+        auto customColorData = index.data(Qt::ForegroundRole);
+        if (customColorData.canConvert<QColor>()) {
+            QColor customColor = customColorData.value<QColor>();
             // for the star rating polygons
-            painter->setBrush(playedColor);
+            painter->setBrush(customColor);
             // for the 'location' text
-            painter->setPen(playedColor);
+            painter->setPen(customColor);
         } else {
             painter->setBrush(option.palette.color(cg, QPalette::Text));
         }

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -52,6 +52,7 @@ WTrackTableView::WTrackTableView(QWidget* parent,
           // Default color for the focus border of TableItemDelegates
           m_focusBorderColor(Qt::white),
           m_trackPlayedColor(QColor(kDefaultTrackPlayedColor)),
+          m_trackMissingColor(QColor(kDefaultTrackMissingColor)),
           m_sorting(sorting),
           m_selectionChangedSinceLastGuiTick(true),
           m_loadCachedOnly(false) {

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -51,7 +51,7 @@ WTrackTableView::WTrackTableView(QWidget* parent,
           m_backgroundColorOpacity(backgroundColorOpacity),
           // Default color for the focus border of TableItemDelegates
           m_focusBorderColor(Qt::white),
-          m_playedInactiveColor(QColor::fromRgb(kDefaultPlayedInactiveColorHex)),
+          m_trackPlayedColor(QColor(kDefaultTrackPlayedColor)),
           m_sorting(sorting),
           m_selectionChangedSinceLastGuiTick(true),
           m_loadCachedOnly(false) {

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -76,11 +76,22 @@ class WTrackTableView : public WLibraryTableView {
     QColor getTrackPlayedColor() const {
         return m_trackPlayedColor;
     }
+    // Default color for missing tracks' text color. #ee0000, bit darker than Qt::red.
+    // BaseTrackTableModel uses this for the ForegroundRole of missing tracks.
+    static constexpr const char* kDefaultTrackMissingColor = "#ff0000";
+    Q_PROPERTY(QColor trackMissingColor
+                    MEMBER m_trackMissingColor
+                            NOTIFY trackMissingColorChanged
+                                    DESIGNABLE true);
+    QColor getTrackMissingColor() const {
+        return m_trackMissingColor;
+    }
 
   signals:
     void trackMenuVisible(bool visible);
     void focusBorderColorChanged(QColor col);
     void trackPlayedColorChanged(QColor col);
+    void trackMissingColorChanged(QColor col);
 
   public slots:
     void loadTrackModel(QAbstractItemModel* model, bool restoreState = false);
@@ -153,6 +164,7 @@ class WTrackTableView : public WLibraryTableView {
     const double m_backgroundColorOpacity;
     QColor m_focusBorderColor;
     QColor m_trackPlayedColor;
+    QColor m_trackMissingColor;
     bool m_sorting;
 
     // Control the delay to load a cover art.

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -68,19 +68,19 @@ class WTrackTableView : public WLibraryTableView {
 
     // Default color for played tracks' text color. #555555, bit darker than Qt::darkgray.
     // BaseTrackTableModel uses this for the ForegroundRole of played tracks.
-    static constexpr uint kDefaultPlayedInactiveColorHex = 555555;
-    Q_PROPERTY(QColor playedInactiveColor
-                    MEMBER m_playedInactiveColor
-                            NOTIFY playedInactiveColorChanged
+    static constexpr const char* kDefaultTrackPlayedColor = "#555555";
+    Q_PROPERTY(QColor trackPlayedColor
+                    MEMBER m_trackPlayedColor
+                            NOTIFY trackPlayedColorChanged
                                     DESIGNABLE true);
-    QColor getPlayedInactiveColor() const {
-        return m_playedInactiveColor;
+    QColor getTrackPlayedColor() const {
+        return m_trackPlayedColor;
     }
 
   signals:
     void trackMenuVisible(bool visible);
     void focusBorderColorChanged(QColor col);
-    void playedInactiveColorChanged(QColor col);
+    void trackPlayedColorChanged(QColor col);
 
   public slots:
     void loadTrackModel(QAbstractItemModel* model, bool restoreState = false);
@@ -152,7 +152,7 @@ class WTrackTableView : public WLibraryTableView {
 
     const double m_backgroundColorOpacity;
     QColor m_focusBorderColor;
-    QColor m_playedInactiveColor;
+    QColor m_trackPlayedColor;
     bool m_sorting;
 
     // Control the delay to load a cover art.


### PR DESCRIPTION
Fix (first commit) and follow-up for #12744 
Lints #9365 

Default color is red.
Pink in LateNight PaleMoon.

The text color might conflict with track colors. If both are similiar tracks would look like if they had empty tags.
The QBrush returned for the Qt::ForeGroundRole may as well be a QLinearGradient. Maybe too much magic?

### TODO
- [ ] set colors in all skins (or keep default `red`?)
- [x] set override for **Missing** feature in all skins