### PR TITLE
Pioneer DDJ-FX4: Add waveform zoom

### DIFF
--- a/res/controllers/Pioneer-DDJ-FLX4-script.js
+++ b/res/controllers/Pioneer-DDJ-FLX4-script.js
@@ -277,6 +277,18 @@ PioneerDDJFLX4.init = function() {
 };
 
 //
+// Waveform zoom
+//
+
+PioneerDDJFLX4.waveformZoom = function(midichan, control, value, status, group) {
+    if (value === 0x7f) {
+        script.triggerControl(group, "waveform_zoom_up", 100);
+    } else {
+        script.triggerControl(group, "waveform_zoom_down", 100);
+    }
+};
+
+//
 // Channel level lights
 //
 

--- a/res/controllers/Pioneer-DDJ-FLX4.midi.xml
+++ b/res/controllers/Pioneer-DDJ-FLX4.midi.xml
@@ -25,6 +25,16 @@
                     <SelectKnob/>
                 </options>
             </control>
+	    <control>
+                <description>BROWSE +SHIFT - Zoom waveform</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.waveformZoom</key>
+                <status>0xB6</status>
+                <midino>0x64</midino>
+                <options>
+                  <Script-Binding/>
+                </options>
+            </control>
             <control>
                 <description>BROWSE - press - Move cursor between track list and tree view</description>
                 <group>[Library]</group>


### PR DESCRIPTION
According to the [Manual](https://docs.pioneerdj.com/Manuals/DDJ_FLX4_DRI1804A_manual/?page=12), turning the rotary selector while pressing a shift button should zoom the parallel waveform.