### PR TITLE
Always render SVG to Pixmap, to prevent main thread stucking due to File IO

### DIFF
--- a/src/widget/paintable.cpp
+++ b/src/widget/paintable.cpp
@@ -74,10 +74,11 @@ Paintable::Paintable(const PixmapSource& source, DrawMode mode, double scaleFact
         // Retina display. This can be fixed when switching to QT5
         if (mode == TILE || WPixmapStore::willCorrectColors()) {
 #else
-        if (mode == TILE || mode == Paintable::FIXED || WPixmapStore::willCorrectColors()) {
+        {
 #endif
             // The SVG renderer doesn't directly support tiling, so we render
             // it to a pixmap which will then get tiled.
+
             QImage copy_buffer(m_pSvg->defaultSize() * scaleFactor, QImage::Format_ARGB32);
             copy_buffer.fill(0x00000000);  // Transparent black.
             QPainter painter(&copy_buffer);


### PR DESCRIPTION
I noticed some stucking of the Main Thread, due to File IO. This happens from time to time during normal operation. The reason is re-rendering of many SVG files used in the skins at once. If the Main Thread stucks, of cause the waveform rendering and the Qt event queue stuck as well:
![grafik](https://github.com/mixxxdj/mixxx/assets/64457745/267231e2-98f9-44d3-a51a-e9a88f481bbe)

I could prevent this stucking by the experimental code of this PR, which always create a Pixmap for these images. 

I don't know if this is a Windows specific issue, or also affect other platforms.
