### PR TITLE
Computer feature: add sidebar action "Refresh directory tree"

### DIFF
--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -327,29 +327,29 @@ void BrowseFeature::onRightClickChild(const QPoint& globalPos, const QModelIndex
 
     QMenu menu(m_pSidebarWidget);
 
-    // If this a QuickLink show only the Remove action
     if (item->parent()->getData().toString() == QUICK_LINK_NODE) {
+        // This is a QuickLink
         menu.addAction(m_pRemoveQuickLinkAction);
+        menu.addAction(m_pRefreshDirTreeAction);
         menu.exec(globalPos);
         onLazyChildExpandation(index);
         return;
     }
 
-    // If path is in the QuickLinks list show only the Remove action
-    foreach (const QString& str, m_quickLinkList) {
-        if (str == path) {
-            menu.addAction(m_pRemoveQuickLinkAction);
-            menu.exec(globalPos);
-            onLazyChildExpandation(index);
-            return;
-        }
-     }
+    if (m_quickLinkList.contains(path)) {
+        // Path is in the Quick Link list
+        menu.addAction(m_pRemoveQuickLinkAction);
+        menu.addAction(m_pRefreshDirTreeAction);
+        menu.exec(globalPos);
+        onLazyChildExpandation(index);
+        return;
+    }
 
-     menu.addAction(m_pAddQuickLinkAction);
-     menu.addAction(m_pAddtoLibraryAction);
-     menu.addAction(m_pRefreshDirTreeAction);
-     menu.exec(globalPos);
-     onLazyChildExpandation(index);
+    menu.addAction(m_pAddQuickLinkAction);
+    menu.addAction(m_pAddtoLibraryAction);
+    menu.addAction(m_pRefreshDirTreeAction);
+    menu.exec(globalPos);
+    onLazyChildExpandation(index);
 }
 
 namespace {

--- a/src/library/browse/browsefeature.h
+++ b/src/library/browse/browsefeature.h
@@ -42,6 +42,7 @@ class BrowseFeature : public LibraryFeature {
     void slotAddQuickLink();
     void slotRemoveQuickLink();
     void slotAddToLibrary();
+    void slotRefreshDirectoryTree();
     void activate() override;
     void activateChild(const QModelIndex& index) override;
     void onRightClickChild(const QPoint& globalPos, const QModelIndex& index) override;
@@ -58,6 +59,7 @@ class BrowseFeature : public LibraryFeature {
     QString getRootViewHtml() const;
     QString extractNameFromPath(const QString& spath);
     QStringList getDefaultQuickLinks() const;
+    std::vector<std::unique_ptr<TreeItem>> getChildDirectoryItems(const QString& path) const;
     void saveQuickLinks();
     void loadQuickLinks();
 
@@ -69,6 +71,7 @@ class BrowseFeature : public LibraryFeature {
     QAction* m_pAddQuickLinkAction;
     QAction* m_pRemoveQuickLinkAction;
     QAction* m_pAddtoLibraryAction;
+    QAction* m_pRefreshDirTreeAction;
 
     // Caution: Make sure this is reset whenever the library tree is updated,
     // so that the internalPointer() does not become dangling


### PR DESCRIPTION
This allows to show newly added directories when the parent had no directories when it was first added to the tree.

This works around the caching of the 'hasChildren' state of each tree item.

based on #12893 