### PR TITLE
Synchronize AutoDJ next deck with top track in queue

### DIFF
--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -1671,7 +1671,22 @@ void AutoDJProcessor::playerRateChanged(DeckAttributes* pAttributes) {
 
 void AutoDJProcessor::playlistFirstTrackChanged() {
     qDebug() << this << "playlistFirstTrackChanged";
-    skipNext();
+    if (m_eState != ADJ_DISABLED) {
+        DeckAttributes* pLeftDeck = getLeftDeck();
+        DeckAttributes* pRightDeck = getRightDeck();
+        // if (!pLeftDeck || !pRightDeck) {
+        //     // User has changed the orientation, disable Auto DJ
+        //     toggleAutoDJ(false);
+        //     emit autoDJError(ADJ_NOT_TWO_DECKS);
+        //     return ADJ_NOT_TWO_DECKS;
+        // }
+
+        if (!pLeftDeck->isPlaying()) {
+            loadNextTrackFromQueue(*pLeftDeck);
+        } else if (!pRightDeck->isPlaying()) {
+            loadNextTrackFromQueue(*pRightDeck);
+        }
+    }
 }
 
 void AutoDJProcessor::setTransitionTime(int time) {

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -1670,7 +1670,9 @@ void AutoDJProcessor::playerRateChanged(DeckAttributes* pAttributes) {
 }
 
 void AutoDJProcessor::playlistFirstTrackChanged() {
-    qDebug() << this << "playlistFirstTrackChanged";
+    if constexpr (sDebug) {
+        qDebug() << this << "playlistFirstTrackChanged";
+    }
     if (m_eState != ADJ_DISABLED) {
         DeckAttributes* pLeftDeck = getLeftDeck();
         DeckAttributes* pRightDeck = getRightDeck();

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -534,6 +534,10 @@ AutoDJProcessor::AutoDJError AutoDJProcessor::toggleAutoDJ(bool enable) {
                 &DeckAttributes::rateChanged,
                 this,
                 &AutoDJProcessor::playerRateChanged);
+        connect(m_pAutoDJTableModel,
+                &PlaylistTableModel::firstTrackChanged,
+                this,
+                &AutoDJProcessor::playlistFirstTrackChanged);
 
         if (!leftDeckPlaying && !rightDeckPlaying) {
             // Both decks are stopped. Load a track into deck 1 and start it
@@ -1663,6 +1667,11 @@ void AutoDJProcessor::playerRateChanged(DeckAttributes* pAttributes) {
         return;
     }
     calculateTransition(fromDeck, getOtherDeck(fromDeck), false);
+}
+
+void AutoDJProcessor::playlistFirstTrackChanged() {
+    qDebug() << this << "playlistFirstTrackChanged";
+    skipNext();
 }
 
 void AutoDJProcessor::setTransitionTime(int time) {

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -1674,12 +1674,6 @@ void AutoDJProcessor::playlistFirstTrackChanged() {
     if (m_eState != ADJ_DISABLED) {
         DeckAttributes* pLeftDeck = getLeftDeck();
         DeckAttributes* pRightDeck = getRightDeck();
-        // if (!pLeftDeck || !pRightDeck) {
-        //     // User has changed the orientation, disable Auto DJ
-        //     toggleAutoDJ(false);
-        //     emit autoDJError(ADJ_NOT_TWO_DECKS);
-        //     return ADJ_NOT_TWO_DECKS;
-        // }
 
         if (!pLeftDeck->isPlaying()) {
             loadNextTrackFromQueue(*pLeftDeck);

--- a/src/library/autodj/autodjprocessor.h
+++ b/src/library/autodj/autodjprocessor.h
@@ -207,6 +207,9 @@ class AutoDJProcessor : public QObject {
     void transitionTimeChanged(int time);
     void randomTrackRequested(int tracksToAdd);
 
+  public slots:
+    void playlistFirstTrackChanged();
+
   private slots:
     void crossfaderChanged(double value);
     void playerPositionChanged(DeckAttributes* pDeck, double position);
@@ -219,7 +222,6 @@ class AutoDJProcessor : public QObject {
     void playerLoadingTrack(DeckAttributes* pDeck, TrackPointer pNewTrack, TrackPointer pOldTrack);
     void playerEmpty(DeckAttributes* pDeck);
     void playerRateChanged(DeckAttributes* pDeck);
-    void playlistFirstTrackChanged();
 
     void controlEnableChangeRequest(double value);
     void controlFadeNow(double value);

--- a/src/library/autodj/autodjprocessor.h
+++ b/src/library/autodj/autodjprocessor.h
@@ -207,9 +207,6 @@ class AutoDJProcessor : public QObject {
     void transitionTimeChanged(int time);
     void randomTrackRequested(int tracksToAdd);
 
-  public slots:
-    void playlistFirstTrackChanged();
-
   private slots:
     void crossfaderChanged(double value);
     void playerPositionChanged(DeckAttributes* pDeck, double position);
@@ -222,6 +219,7 @@ class AutoDJProcessor : public QObject {
     void playerLoadingTrack(DeckAttributes* pDeck, TrackPointer pNewTrack, TrackPointer pOldTrack);
     void playerEmpty(DeckAttributes* pDeck);
     void playerRateChanged(DeckAttributes* pDeck);
+    void playlistFirstTrackChanged();
 
     void controlEnableChangeRequest(double value);
     void controlFadeNow(double value);

--- a/src/library/autodj/autodjprocessor.h
+++ b/src/library/autodj/autodjprocessor.h
@@ -219,6 +219,7 @@ class AutoDJProcessor : public QObject {
     void playerLoadingTrack(DeckAttributes* pDeck, TrackPointer pNewTrack, TrackPointer pOldTrack);
     void playerEmpty(DeckAttributes* pDeck);
     void playerRateChanged(DeckAttributes* pDeck);
+    void playlistFirstTrackChanged();
 
     void controlEnableChangeRequest(double value);
     void controlFadeNow(double value);

--- a/src/library/dao/playlistdao.cpp
+++ b/src/library/dao/playlistdao.cpp
@@ -1278,21 +1278,18 @@ void PlaylistDAO::addTracksToAutoDJQueue(const QList<TrackId>& trackIds, AutoDJS
         return;
     }
 
-    // If the first track is already loaded to the player,
-    // alter the playlist only below the first track
-    int position =
-            (m_pAutoDJProcessor && m_pAutoDJProcessor->nextTrackLoaded()) ? 2 : 1;
-
     switch (loc) {
     case AutoDJSendLoc::TOP:
-        insertTracksIntoPlaylist(trackIds, iAutoDJPlaylistId, position);
+        insertTracksIntoPlaylist(trackIds, iAutoDJPlaylistId, 1);
+        m_pAutoDJProcessor->playlistFirstTrackChanged();
         break;
     case AutoDJSendLoc::BOTTOM:
         appendTracksToPlaylist(trackIds, iAutoDJPlaylistId);
         break;
     case AutoDJSendLoc::REPLACE:
-        if (removeTracksFromPlaylist(iAutoDJPlaylistId, position)) {
+        if (removeTracksFromPlaylist(iAutoDJPlaylistId, 1)) {
             appendTracksToPlaylist(trackIds, iAutoDJPlaylistId);
+            m_pAutoDJProcessor->playlistFirstTrackChanged();
         }
         break;
     }

--- a/src/library/dao/playlistdao.cpp
+++ b/src/library/dao/playlistdao.cpp
@@ -1278,18 +1278,21 @@ void PlaylistDAO::addTracksToAutoDJQueue(const QList<TrackId>& trackIds, AutoDJS
         return;
     }
 
+    // If the first track is already loaded to the player,
+    // alter the playlist only below the first track
+    int position =
+            (m_pAutoDJProcessor && m_pAutoDJProcessor->nextTrackLoaded()) ? 2 : 1;
+
     switch (loc) {
     case AutoDJSendLoc::TOP:
-        insertTracksIntoPlaylist(trackIds, iAutoDJPlaylistId, 1);
-        m_pAutoDJProcessor->playlistFirstTrackChanged();
+        insertTracksIntoPlaylist(trackIds, iAutoDJPlaylistId, position);
         break;
     case AutoDJSendLoc::BOTTOM:
         appendTracksToPlaylist(trackIds, iAutoDJPlaylistId);
         break;
     case AutoDJSendLoc::REPLACE:
-        if (removeTracksFromPlaylist(iAutoDJPlaylistId, 1)) {
+        if (removeTracksFromPlaylist(iAutoDJPlaylistId, position)) {
             appendTracksToPlaylist(trackIds, iAutoDJPlaylistId);
-            m_pAutoDJProcessor->playlistFirstTrackChanged();
         }
         break;
     }

--- a/src/library/playlisttablemodel.cpp
+++ b/src/library/playlisttablemodel.cpp
@@ -250,6 +250,10 @@ void PlaylistTableModel::removeTracks(const QModelIndexList& indices) {
     m_pTrackCollectionManager->internalCollection()->getPlaylistDAO().removeTracksFromPlaylist(
             m_iPlaylistId,
             std::move(trackPositions));
+
+    if (trackPositions.contains(1)) {
+        emit firstTrackChanged();
+    }
 }
 
 void PlaylistTableModel::moveTrack(const QModelIndex& sourceIndex,
@@ -275,6 +279,10 @@ void PlaylistTableModel::moveTrack(const QModelIndex& sourceIndex,
     }
 
     m_pTrackCollectionManager->internalCollection()->getPlaylistDAO().moveTrack(m_iPlaylistId, oldPosition, newPosition);
+
+    if (oldPosition == 1 || newPosition == 1) {
+        emit firstTrackChanged();
+    }
 }
 
 bool PlaylistTableModel::isLocked() {

--- a/src/library/playlisttablemodel.h
+++ b/src/library/playlisttablemodel.h
@@ -38,6 +38,9 @@ class PlaylistTableModel final : public TrackSetTableModel {
   private slots:
     void playlistsChanged(const QSet<int>& playlistIds);
 
+  signals:
+    void firstTrackChanged();
+
   private:
     void initSortColumnMapping() override;
 


### PR DESCRIPTION
This fixes bug #8956, adding a signal in playlisttablemodel which is emitted when a change in track order involves the first track. The signal is connected to a slot in autodjprocessor which skips the track in next deck, replacing it with the new top track in queue.