### PR TITLE
Labeler: Add `qml` to labeler config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -102,6 +102,12 @@ preferences:
       - any-glob-to-any-file:
           - src/preferences/**
 
+qml:
+  - changed-files:
+      - any-glob-to-any-file:
+          - res/qml/**
+          - src/qml/**
+
 skins:
   - changed-files:
       - any-glob-to-any-file:


### PR DESCRIPTION
This adds the `qml` to the PR labeler, which might be useful to filter PRs working on QML.