### PR TITLE
Build: Add `MUSICBRAINZ` flag for compiling with(out) MusicBrainz

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -929,8 +929,6 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/library/dao/trackschema.cpp
   src/library/dlgcoverartfullsize.cpp
   src/library/dlgcoverartfullsize.ui
-  src/library/dlgtagfetcher.cpp
-  src/library/dlgtagfetcher.ui
   src/library/dlgtrackinfo.cpp
   src/library/dlgtrackinfo.ui
   src/library/dlgtrackinfomulti.cpp
@@ -1022,16 +1020,6 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/mixer/samplerbank.cpp
   src/mixxxapplication.cpp
   src/mixxxmainwindow.cpp
-  src/musicbrainz/chromaprinter.cpp
-  src/musicbrainz/crc.cpp
-  src/musicbrainz/gzip.cpp
-  src/musicbrainz/musicbrainz.cpp
-  src/musicbrainz/musicbrainzxml.cpp
-  src/musicbrainz/tagfetcher.cpp
-  src/musicbrainz/web/acoustidlookuptask.cpp
-  src/musicbrainz/web/coverartarchiveimagetask.cpp
-  src/musicbrainz/web/coverartarchivelinkstask.cpp
-  src/musicbrainz/web/musicbrainzrecordingstask.cpp
   src/nativeeventhandlerwin.cpp
   src/network/jsonwebtask.cpp
   src/network/networktask.cpp
@@ -2282,9 +2270,28 @@ if(WIN32)
   target_include_directories(mixxx PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
 endif()
 
-# Chromaprint
-find_package(Chromaprint REQUIRED)
-target_link_libraries(mixxx-lib PRIVATE Chromaprint::Chromaprint)
+option(MUSICBRAINZ "Enable MusicBrainz-based tag lookup" ON)
+if(MUSICBRAINZ)
+  # Chromaprint
+  find_package(Chromaprint REQUIRED)
+  target_link_libraries(mixxx-lib PRIVATE Chromaprint::Chromaprint)
+
+  target_compile_definitions(mixxx-lib PUBLIC __MUSICBRAINZ__)
+  target_sources(mixxx-lib PRIVATE
+    src/library/dlgtagfetcher.cpp
+    src/library/dlgtagfetcher.ui
+    src/musicbrainz/chromaprinter.cpp
+    src/musicbrainz/crc.cpp
+    src/musicbrainz/gzip.cpp
+    src/musicbrainz/musicbrainz.cpp
+    src/musicbrainz/musicbrainzxml.cpp
+    src/musicbrainz/tagfetcher.cpp
+    src/musicbrainz/web/acoustidlookuptask.cpp
+    src/musicbrainz/web/coverartarchiveimagetask.cpp
+    src/musicbrainz/web/coverartarchivelinkstask.cpp
+    src/musicbrainz/web/musicbrainzrecordingstask.cpp
+  )
+endif()
 
 # Locale Aware Compare for SQLite
 find_package(SQLite3)

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -7,7 +7,9 @@
 #include "defs_urls.h"
 #include "library/coverartcache.h"
 #include "library/coverartutils.h"
+#ifdef __MUSICBRAINZ__
 #include "library/dlgtagfetcher.h"
+#endif
 #include "library/library_prefs.h"
 #include "library/trackmodel.h"
 #include "moc_dlgtrackinfo.cpp"
@@ -237,10 +239,12 @@ void DlgTrackInfo::init() {
             this,
             &DlgTrackInfo::slotImportMetadataFromFile);
 
+#ifdef __MUSICBRAINZ__
     connect(btnImportMetadataFromMusicBrainz,
             &QPushButton::clicked,
             this,
             &DlgTrackInfo::slotImportMetadataFromMusicBrainz);
+#endif
 
     connect(btnOpenFileBrowser,
             &QPushButton::clicked,
@@ -310,6 +314,7 @@ void DlgTrackInfo::slotPrevButton() {
     loadPrevTrack();
 }
 
+#ifdef __MUSICBRAINZ__
 void DlgTrackInfo::slotNextDlgTagFetcher() {
     loadNextTrack();
     // Do not load track back into DlgTagFetcher since
@@ -319,6 +324,7 @@ void DlgTrackInfo::slotNextDlgTagFetcher() {
 void DlgTrackInfo::slotPrevDlgTagFetcher() {
     loadPrevTrack();
 }
+#endif
 
 void DlgTrackInfo::loadNextTrack() {
     auto nextRow = m_currentTrackIndex.sibling(
@@ -483,9 +489,11 @@ void DlgTrackInfo::loadTrack(TrackPointer pTrack) {
         return;
     }
     loadTrackInternal(pTrack);
+#ifdef __MUSICBRAINZ__
     if (m_pDlgTagFetcher && m_pDlgTagFetcher->isVisible()) {
         m_pDlgTagFetcher->loadTrack(m_pLoadedTrack);
     }
+#endif
 }
 
 void DlgTrackInfo::loadTrack(const QModelIndex& index) {
@@ -495,9 +503,11 @@ void DlgTrackInfo::loadTrack(const QModelIndex& index) {
     TrackPointer pTrack = m_pTrackModel->getTrack(index);
     m_currentTrackIndex = index;
     loadTrackInternal(pTrack);
+#ifdef __MUSICBRAINZ__
     if (m_pDlgTagFetcher && m_pDlgTagFetcher->isVisible()) {
         m_pDlgTagFetcher->loadTrack(m_currentTrackIndex);
     }
+#endif
 }
 
 void DlgTrackInfo::focusField(const QString& property) {
@@ -800,6 +810,7 @@ void DlgTrackInfo::slotTrackChanged(TrackId trackId) {
     }
 }
 
+#ifdef __MUSICBRAINZ__
 void DlgTrackInfo::slotImportMetadataFromMusicBrainz() {
     if (!m_pDlgTagFetcher) {
         m_pDlgTagFetcher = std::make_unique<DlgTagFetcher>(
@@ -833,3 +844,4 @@ void DlgTrackInfo::slotImportMetadataFromMusicBrainz() {
     }
     m_pDlgTagFetcher->show();
 }
+#endif

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -19,7 +19,9 @@ class WColorPickerAction;
 class WStarRating;
 class WCoverArtMenu;
 class WCoverArtLabel;
+#ifdef __MUSICBRAINZ__
 class DlgTagFetcher;
+#endif
 
 /// A dialog box to display and edit track properties.
 /// Use TrackPointer to load a track into the dialog or
@@ -48,8 +50,10 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
   private slots:
     void slotNextButton();
     void slotPrevButton();
+#ifdef __MUSICBRAINZ__
     void slotNextDlgTagFetcher();
     void slotPrevDlgTagFetcher();
+#endif
     void slotOk();
     void slotApply();
     void slotCancel();
@@ -63,7 +67,9 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     void slotKeyTextChanged();
     void slotRatingChanged(int rating);
     void slotImportMetadataFromFile();
+#ifdef __MUSICBRAINZ__
     void slotImportMetadataFromMusicBrainz();
+#endif
 
     void slotTrackChanged(TrackId trackId);
     void slotOpenInFileBrowser();
@@ -126,5 +132,7 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     parented_ptr<WStarRating> m_pWStarRating;
     parented_ptr<WColorPickerAction> m_pColorPicker;
 
+#ifdef __MUSICBRAINZ__
     std::unique_ptr<DlgTagFetcher> m_pDlgTagFetcher;
+#endif
 };

--- a/src/util/versionstore.cpp
+++ b/src/util/versionstore.cpp
@@ -13,8 +13,11 @@
 #include <rubberband/RubberBandStretcher.h>
 #endif
 
-#include <FLAC/format.h>
+#ifdef __MUSICBRAINZ__
 #include <chromaprint.h>
+#endif
+
+#include <FLAC/format.h>
 #include <lame/lame.h>
 #include <portaudio.h>
 #include <sndfile.h>
@@ -180,11 +183,13 @@ QStringList VersionStore::dependencyVersions() {
                        .arg(QString::number(TAGLIB_MAJOR_VERSION),
                                QString::number(TAGLIB_MINOR_VERSION),
                                QString::number(TAGLIB_PATCH_VERSION))
+#ifdef __MUSICBRAINZ__
             // The version of the ChromaPrint headers Mixxx was compiled with.
             << QString("ChromaPrint: %1.%2.%3")
                        .arg(QString::number(CHROMAPRINT_VERSION_MAJOR),
                                QString::number(CHROMAPRINT_VERSION_MINOR),
                                QString::number(CHROMAPRINT_VERSION_PATCH))
+#endif
             // Should be accurate.
             << QString("Vorbis: %1").arg(vorbis_version_string())
             // Should be accurate.

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -14,7 +14,9 @@
 #include "control/controlobject.h"
 #include "library/coverartutils.h"
 #include "library/dao/trackschema.h"
+#ifdef __MUSICBRAINZ__
 #include "library/dlgtagfetcher.h"
+#endif
 #include "library/dlgtrackinfo.h"
 #include "library/dlgtrackinfomulti.h"
 #include "library/dlgtrackmetadataexport.h"
@@ -387,12 +389,14 @@ void WTrackMenu::createActions() {
                 this,
                 &WTrackMenu::slotImportMetadataFromFileTags);
 
+#ifdef __MUSICBRAINZ__
         m_pImportMetadataFromMusicBrainzAct =
                 new QAction(tr("Import From MusicBrainz"), m_pMetadataMenu);
         connect(m_pImportMetadataFromMusicBrainzAct,
                 &QAction::triggered,
                 this,
                 &WTrackMenu::slotShowDlgTagFetcher);
+#endif
 
         m_pExportMetadataAct =
                 new QAction(tr("Export To File Tags"), m_pMetadataMenu);
@@ -644,7 +648,9 @@ void WTrackMenu::setupActions() {
 
     if (featureIsEnabled(Feature::Metadata)) {
         m_pMetadataMenu->addAction(m_pImportMetadataFromFileAct);
+#ifdef __MUSICBRAINZ__
         m_pMetadataMenu->addAction(m_pImportMetadataFromMusicBrainzAct);
+#endif
         m_pMetadataMenu->addAction(m_pExportMetadataAct);
 
         for (const auto& updateInExternalTrackCollection :
@@ -993,7 +999,9 @@ void WTrackMenu::updateMenus() {
     }
 
     if (featureIsEnabled(Feature::Metadata)) {
+#ifdef __MUSICBRAINZ__
         m_pImportMetadataFromMusicBrainzAct->setEnabled(singleTrackSelected);
+#endif
 
         // We use the last selected track for the cover art context to be
         // consistent with selectionChanged above.
@@ -2557,6 +2565,7 @@ void WTrackMenu::showDlgTrackInfo(const QString& property) {
     }
 }
 
+#ifdef __MUSICBRAINZ__
 void WTrackMenu::slotShowDlgTagFetcher() {
     if (isEmpty()) {
         return;
@@ -2580,6 +2589,7 @@ void WTrackMenu::slotShowDlgTagFetcher() {
     }
     m_pDlgTagFetcher->show();
 }
+#endif
 
 void WTrackMenu::slotAddToAutoDJBottom() {
     // append to auto DJ

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -16,7 +16,9 @@
 #include "util/color/rgbcolor.h"
 #include "util/parented_ptr.h"
 
+#ifdef __MUSICBRAINZ__
 class DlgTagFetcher;
+#endif
 class DlgTrackInfo;
 class DlgTrackInfoMulti;
 //class DlgDeleteFilesConfirmation;
@@ -155,7 +157,9 @@ class WTrackMenu : public QMenu {
 
     // Info and metadata
     void slotUpdateReplayGainFromPregain();
+#ifdef __MUSICBRAINZ__
     void slotShowDlgTagFetcher();
+#endif
     void slotImportMetadataFromFileTags();
     void slotExportMetadataIntoFileTags();
     void slotUpdateExternalTrackCollection(ExternalTrackCollection* externalTrackCollection);
@@ -274,7 +278,9 @@ class WTrackMenu : public QMenu {
 
     // Reload Track Metadata Action:
     QAction* m_pImportMetadataFromFileAct{};
+#ifdef __MUSICBRAINZ__
     QAction* m_pImportMetadataFromMusicBrainzAct{};
+#endif
 
     // Save Track Metadata Action:
     QAction* m_pExportMetadataAct{};
@@ -351,7 +357,9 @@ class WTrackMenu : public QMenu {
 
     std::unique_ptr<DlgTrackInfo> m_pDlgTrackInfo;
     std::unique_ptr<DlgTrackInfoMulti> m_pDlgTrackInfoMulti;
+#ifdef __MUSICBRAINZ__
     std::unique_ptr<DlgTagFetcher> m_pDlgTagFetcher;
+#endif
 
     struct UpdateExternalTrackCollection {
         QPointer<ExternalTrackCollection> externalTrackCollection;

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -13,7 +13,9 @@
 #include "widget/wlibrarytableview.h"
 
 class ControlProxy;
+#ifdef __MUSICBRAINZ__
 class DlgTagFetcher;
+#endif
 class DlgTrackInfo;
 class ExternalTrackCollection;
 class Library;


### PR DESCRIPTION
This adds the flag `MUSICBRAINZ` which controls whether the tag fetcher dialog and the rest of the MusicBrainz integration, including acoustic fingerprinting, is built.

This is useful, because it makes it possible to build Mixxx without Chromaprint and thus ffmpeg, which is pretty tricky to get to build for WebAssembly (the port doesn't build as-is and integrating `ffmpeg.wasm` seems to be nontrivial).