### PR TITLE
MixxxApplication: Use `QWasmIntegrationPlugin` when targeting WebAssembly

### DIFF
--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -23,7 +23,9 @@
 // https://doc.qt.io/qt-5/plugins-howto.html#details-of-linking-static-plugins
 #ifdef QT_STATIC
 #include <QtPlugin>
-#if defined(Q_OS_WIN)
+#if defined(Q_OS_WASM)
+Q_IMPORT_PLUGIN(QWasmIntegrationPlugin)
+#elif defined(Q_OS_WIN)
 Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin)
 Q_IMPORT_PLUGIN(QWindowsVistaStylePlugin)
 #elif defined(Q_OS_IOS)

--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -38,8 +38,10 @@ Q_IMPORT_PLUGIN(QXcbIntegrationPlugin)
 #else
 #error "Q_IMPORT_PLUGIN() for the current patform is missing"
 #endif
+#if !defined(Q_OS_WASM)
 Q_IMPORT_PLUGIN(QOffscreenIntegrationPlugin)
 Q_IMPORT_PLUGIN(QMinimalIntegrationPlugin)
+#endif
 
 Q_IMPORT_PLUGIN(QSQLiteDriverPlugin)
 Q_IMPORT_PLUGIN(QSvgPlugin)


### PR DESCRIPTION
This imports the WASM integration plugin when `Q_OS_WASM` is defined and compiles out the `QOffscreenIntegrationPlugin` and `QMinimalIntegrationPlugin`, which are unavailable when targeting WASM.