### PR TITLE
DesktopHelper: Compile out process-spawning on WASM too

### DIFF
--- a/src/util/desktophelper.cpp
+++ b/src/util/desktophelper.cpp
@@ -90,8 +90,8 @@ bool selectInXfce(const QString& path) {
 #endif
 
 void selectViaCommand(const QString& path) {
-#ifdef Q_OS_IOS
-    qWarning() << "Starting process (" << path << ") is not supported on iOS!";
+#if defined(Q_OS_IOS) || defined(Q_OS_WASM)
+    qWarning() << "Starting process (" << path << ") is not supported on iOS or the web!";
 #else
     QStringList arguments = sSelectInFileBrowserCommand.split(" ");
     // No escaping required because QProcess bypasses the shell


### PR DESCRIPTION
Like on iOS, `QProcess` is unavailable when targeting WebAssembly.