### PR TITLE
SSE: Check `!defined(__EMSCRIPTEN__)` where intrinsics are unavailable on WASM

### DIFF
--- a/src/soundio/sounddevicenetwork.cpp
+++ b/src/soundio/sounddevicenetwork.cpp
@@ -442,9 +442,15 @@ void SoundDeviceNetwork::callbackProcessClkRef() {
 
     if (!m_denormals) {
         m_denormals = true;
+
         // This disables the denormals calculations, to avoid a
         // performance penalty of ~20
         // https://github.com/mixxxdj/mixxx/issues/7747
+
+        // On Emscripten (WebAssembly) denormals-as-zero/flush-as-zero is not
+        // configurable, for discussion and links see
+        // https://github.com/mixxxdj/mixxx/pull/12917
+
 #if defined(__SSE__) && !defined(__EMSCRIPTEN__)
         if (!_MM_GET_DENORMALS_ZERO_MODE()) {
             qDebug() << "SSE: Enabling denormals to zero mode";

--- a/src/soundio/sounddevicenetwork.cpp
+++ b/src/soundio/sounddevicenetwork.cpp
@@ -445,7 +445,7 @@ void SoundDeviceNetwork::callbackProcessClkRef() {
         // This disables the denormals calculations, to avoid a
         // performance penalty of ~20
         // https://github.com/mixxxdj/mixxx/issues/7747
-#ifdef __SSE__
+#if defined(__SSE__) && !defined(__EMSCRIPTEN__)
         if (!_MM_GET_DENORMALS_ZERO_MODE()) {
             qDebug() << "SSE: Enabling denormals to zero mode";
             _MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_ON);

--- a/src/soundio/sounddevicenetwork.cpp
+++ b/src/soundio/sounddevicenetwork.cpp
@@ -447,9 +447,11 @@ void SoundDeviceNetwork::callbackProcessClkRef() {
         // performance penalty of ~20
         // https://github.com/mixxxdj/mixxx/issues/7747
 
-        // On Emscripten (WebAssembly) denormals-as-zero/flush-as-zero is not
-        // configurable, for discussion and links see
-        // https://github.com/mixxxdj/mixxx/pull/12917
+        // On Emscripten (WebAssembly) denormals-as-zero/flush-as-zero are
+        // neither supported nor configurable. This may lead to degraded
+        // performance compared to other platforms and may be addressed in the
+        // future if/when WebAssembly adds support for DAZ/FTZ. For further
+        // discussion and links see https://github.com/mixxxdj/mixxx/pull/12917
 
 #if defined(__SSE__) && !defined(__EMSCRIPTEN__)
         if (!_MM_GET_DENORMALS_ZERO_MODE()) {

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -906,10 +906,15 @@ int SoundDevicePortAudio::callbackProcessClkRef(
 #endif
         m_bSetThreadPriority = true;
 
-#if defined(__SSE__) && !defined(__EMSCRIPTEN__)
         // This disables the denormals calculations, to avoid a
         // performance penalty of ~20
         // https://github.com/mixxxdj/mixxx/issues/7747
+
+        // On Emscripten (WebAssembly) denormals-as-zero/flush-as-zero is not
+        // configurable, for discussion and links see
+        // https://github.com/mixxxdj/mixxx/pull/12917
+
+#if defined(__SSE__) && !defined(__EMSCRIPTEN__)
         if (!_MM_GET_DENORMALS_ZERO_MODE()) {
             qDebug() << "SSE: Enabling denormals to zero mode";
             _MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_ON);

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -910,9 +910,11 @@ int SoundDevicePortAudio::callbackProcessClkRef(
         // performance penalty of ~20
         // https://github.com/mixxxdj/mixxx/issues/7747
 
-        // On Emscripten (WebAssembly) denormals-as-zero/flush-as-zero is not
-        // configurable, for discussion and links see
-        // https://github.com/mixxxdj/mixxx/pull/12917
+        // On Emscripten (WebAssembly) denormals-as-zero/flush-as-zero are
+        // neither supported nor configurable. This may lead to degraded
+        // performance compared to other platforms and may be addressed in the
+        // future if/when WebAssembly adds support for DAZ/FTZ. For further
+        // discussion and links see https://github.com/mixxxdj/mixxx/pull/12917
 
 #if defined(__SSE__) && !defined(__EMSCRIPTEN__)
         if (!_MM_GET_DENORMALS_ZERO_MODE()) {

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -906,7 +906,7 @@ int SoundDevicePortAudio::callbackProcessClkRef(
 #endif
         m_bSetThreadPriority = true;
 
-#ifdef __SSE__
+#if defined(__SSE__) && !defined(__EMSCRIPTEN__)
         // This disables the denormals calculations, to avoid a
         // performance penalty of ~20
         // https://github.com/mixxxdj/mixxx/issues/7747

--- a/src/util/denormalsarezero.h
+++ b/src/util/denormalsarezero.h
@@ -20,7 +20,7 @@
 #define _MM_DENORMALS_ZERO_OFF      0x0000
 #endif
 
-#ifdef __SSE__
+#if defined(__SSE__) && !defined(__EMSCRIPTEN__)
 
 #include <xmmintrin.h>
 


### PR DESCRIPTION
Some SSE intrinsics are unavailable in Emscripten, in particular `_MM_SET_DENORMALS_ZERO_MODE`[^1], therefore we have to disable them when targeting Emscripten/WASM.

[^1]: As per https://emscripten.org/docs/porting/simd.html#id8, 