### PR TITLE
CMakeLists: Enable asyncify when targeting WASM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1585,6 +1585,13 @@ if(APPLE)
   endif()
 endif()
 
+if(EMSCRIPTEN)
+  # We need asyncify to support asynchronous calls (e.g. QDialog::exec)
+  # when targeting Emscripten/WebAssembly.
+  # See https://doc.qt.io/qt-6/wasm.html#asyncify
+  target_link_options(mixxx-lib PUBLIC -sASYNCIFY -Os)
+endif()
+
 # QML Debugging
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   target_compile_definitions(mixxx-lib PUBLIC QT_QML_DEBUG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -462,10 +462,17 @@ elseif(GNU_GCC OR LLVM_CLANG)
     # The following optimisation flags makes the engine code ~3 times
     # faster, measured on a Atom CPU.
     add_compile_options(
-      -O3
       -ffast-math
       -funroll-loops
     )
+    if(EMSCRIPTEN)
+      # Optimize for size + speed when targeting Emscripten/WebAssembly
+      # This is recommended as we use asyncify:
+      # See https://doc.qt.io/qt-6/wasm.html#asyncify
+      add_compile_options(-Os)
+    else()
+      add_compile_options(-O3)
+    endif()
     # set -fomit-frame-pointer when we don't profile and are not using
     # Clang sanitizers.
     # Note: It is only included in -O on machines where it does not
@@ -1589,7 +1596,7 @@ if(EMSCRIPTEN)
   # We need asyncify to support asynchronous calls (e.g. QDialog::exec)
   # when targeting Emscripten/WebAssembly.
   # See https://doc.qt.io/qt-6/wasm.html#asyncify
-  target_link_options(mixxx-lib PUBLIC -sASYNCIFY -Os)
+  target_link_options(mixxx-lib PUBLIC -sASYNCIFY)
 endif()
 
 # QML Debugging


### PR DESCRIPTION
This fixes calls that yield to the event loop when targeting WebAssembly (e.g. `QDialog::exec` would previously crash), as per https://doc.qt.io/qt-6/wasm.html#asyncify.

It does add some overhead unfortunately (the WASM binary went from 256M -> 304M and linking became considerably slower), even with the recommended optimizations (`-Os`), but better to have something that runs than crashes.