### PR TITLE
Resources: Bundle resources for preloading when targeting Emscripten/WASM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1811,6 +1811,14 @@ if (APPLE)
   endif()
 endif()
 
+if(EMSCRIPTEN)
+  # Package resources for the web using preloading.
+  # This will generate a mixxx.data file containing all the resources.
+  # See https://emscripten.org/docs/porting/files/packaging_files.html
+  # TODO: Strip this down by only including what we need (i.e. no macOS/Linux packaging, ...)
+  target_link_options(mixxx-lib PUBLIC --preload-file "${CMAKE_CURRENT_SOURCE_DIR}/res@/res")
+endif()
+
 if(WIN32)
   set(CMAKE_INSTALL_SYSTEM_RUNTIME_DESTINATION "${MIXXX_INSTALL_BINDIR}")
   if(MSVC AND CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/src/preferences/configobject.cpp
+++ b/src/preferences/configobject.cpp
@@ -22,6 +22,12 @@ QString computeResourcePathImpl() {
     QString qResourcePath = CmdlineArgs::Instance().getResourcePath();
 
     if (qResourcePath.isEmpty()) {
+#ifdef __EMSCRIPTEN__
+        // When targeting Emscripten/WebAssembly, we have a virtual file system
+        // that is populated by our preloaded resources located at /res. See
+        // also https://emscripten.org/docs/porting/files/packaging_files.html
+        qResourcePath = "/res";
+#else
         QDir mixxxDir = QCoreApplication::applicationDirPath();
 
         // We used to support using the mixxx.cfg's [Config],Path setting but
@@ -76,6 +82,7 @@ QString computeResourcePathImpl() {
             // TODO(rryan): What should we do here?
         }
 #endif
+#endif // !defined(__EMSCRIPTEN__)
     } else {
         //qDebug() << "Setting qResourcePath from location in resourcePath commandline arg:" << qResourcePath;
     }


### PR DESCRIPTION
This is the final piece in the puzzle to getting Mixxx to successfully launch in the browser[^1].

Emscripten provides a virtual file system as described in https://emscripten.org/docs/porting/files/packaging_files.html. Since our WASM binary is already pretty heavy (304M) I went with the preloading option for now, which bundles our `res` directory in a single `mixxx.data` (96M), located at `/res` within the virtual file system. `qResourcePath` is also updated to use this path when targeting Emscripten.

[^1]: Of course there is still a lot of work ahead to make this run well