### PR TITLE
WTrackMenu: Add missing wcoverartlabel.h include

### DIFF
--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -41,6 +41,7 @@
 #include "util/widgethelper.h"
 #include "widget/findonwebmenufactory.h"
 #include "widget/wcolorpickeraction.h"
+#include "widget/wcoverartlabel.h"
 #include "widget/wcoverartmenu.h"
 #include "widget/wfindonwebmenu.h"
 #include "widget/wsearchrelatedtracksmenu.h"


### PR DESCRIPTION
Ran into this issue with a debug Wasm build today:

```
In file included from mixxx/src/widget/wtrackmenu.cpp:1:
In file included from mixxx/src/widget/wtrackmenu.h:17:
mixxx/src/util/parented_ptr.h:37:32: error: static_cast from 'WCoverArtLabel *' to 'const QObject *', which are not related by inheritance, is not allowed
   37 |         DEBUG_ASSERT(!m_ptr || static_cast<const QObject*>(m_ptr)->parent());
      |                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
mixxx/src/util/assert.h:59:32: note: expanded from macro 'DEBUG_ASSERT'
   59 |         if (!static_cast<bool>(cond)) [[unlikely]] {                        \
      |                                ^~~~
mixxx/src/library/dlgtrackinfo.h:37:5: note: in instantiation of member function 'parented_ptr<WCoverArtLabel>::~parented_ptr' requested here
   37 |     ~DlgTrackInfo() override = default;
      |     ^
/opt/emsdk/upstream/emscripten/cache/sysroot/include/c++/v1/__memory/unique_ptr.h:300:7: note: in instantiation of member function 'std::default_delete<DlgTrackInfo>::operator()' requested here
  300 |       __ptr_.second()(__tmp);
      |       ^
/opt/emsdk/upstream/emscripten/cache/sysroot/include/c++/v1/__memory/unique_ptr.h:266:75: note: in instantiation of member function 'std::unique_ptr<DlgTrackInfo>::reset' requested here
  266 |   _LIBCPP_INLINE_VISIBILITY _LIBCPP_CONSTEXPR_SINCE_CXX23 ~unique_ptr() { reset(); }
      |                                                                           ^
mixxx/src/widget/wtrackmenu.cpp:94:13: note: in instantiation of member function 'std::unique_ptr<DlgTrackInfo>::~unique_ptr' requested here
   94 | WTrackMenu::WTrackMenu(
      |             ^
mixxx/src/library/dlgtrackinfo.h:21:7: note: 'WCoverArtLabel' is incomplete
   21 | class WCoverArtLabel;
      |       ^
1 error generated.
```

Somehow `DlgTrackInfo`'s `parented_ptr<WCoverArtLabel>` only ended up having the forward declaration in scope, resulting in the compiler complaining about `WCoverArtLabel` and `QObject` being seemingly unrelated types.

Including `wcoverartlabel.h` in `wtrackmenu.cpp` fixes it.