### PR TITLE
fixes around cratetablemodel, remove tracks + don't allow pasting tracks into locked playlists/crates or History

### DIFF
--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -397,6 +397,11 @@ void BaseTrackTableModel::copyTracks(const QModelIndexList& indices) const {
 }
 
 QList<int> BaseTrackTableModel::pasteTracks(const QModelIndex& insertionIndex) {
+    // Don't paste into locked playlists and crates or into into History
+    if (isLocked() || !hasCapabilities(TrackModel::Capability::ReceiveDrops)) {
+        return QList<int>{};
+    }
+
     int insertionPos = 0;
     const QList<QUrl> urls = Clipboard::urls();
     const QList<TrackId> trackIds = m_pTrackCollectionManager->resolveTrackIdsFromUrls(urls, false);

--- a/src/library/trackset/crate/cratetablemodel.cpp
+++ b/src/library/trackset/crate/cratetablemodel.cpp
@@ -173,6 +173,17 @@ int CrateTableModel::addTracksWithTrackIds(
     return trackIds.size();
 }
 
+bool CrateTableModel::isLocked() {
+    Crate crate;
+    if (!m_pTrackCollectionManager->internalCollection()
+                    ->crates()
+                    .readCrateById(m_selectedCrate, &crate)) {
+        qWarning() << "Failed to read create" << m_selectedCrate;
+        return false;
+    }
+    return crate.isLocked();
+}
+
 void CrateTableModel::removeTracks(const QModelIndexList& indices) {
     VERIFY_OR_DEBUG_ASSERT(m_selectedCrate.isValid()) {
         return;

--- a/src/library/trackset/crate/cratetablemodel.h
+++ b/src/library/trackset/crate/cratetablemodel.h
@@ -22,6 +22,7 @@ class CrateTableModel final : public TrackSetTableModel {
     int addTracksWithTrackIds(const QModelIndex& index,
             const QList<TrackId>& tracks,
             int* pOutInsertionPos) final;
+    bool isLocked() final;
 
     Capabilities getCapabilities() const final;
     QString modelKey(bool noSearch) const override;

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -861,7 +861,12 @@ void WTrackTableView::copySelectedTracks() {
 }
 
 void WTrackTableView::pasteTracks(const QModelIndex& index) {
-    const QList<int> rows = getTrackModel()->pasteTracks(index);
+    TrackModel* trackModel = getTrackModel();
+    if (!trackModel) {
+        return;
+    }
+
+    const QList<int> rows = trackModel->pasteTracks(index);
     if (rows.empty()) {
         return;
     }

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -996,9 +996,13 @@ void WTrackTableView::hideOrRemoveSelectedTracks() {
     }
 
     TrackModel::Capability cap;
+    // Hide is the primary action if allowed. Else we test for remove capability
     if (pTrackModel->hasCapabilities(TrackModel::Capability::Hide)) {
         cap = TrackModel::Capability::Hide;
-    } else if (pTrackModel->hasCapabilities(TrackModel::Capability::Remove)) {
+    } else if (pTrackModel->isLocked()) { // Locked playlists and crates
+        return;
+    }
+    if (pTrackModel->hasCapabilities(TrackModel::Capability::Remove)) {
         cap = TrackModel::Capability::Remove;
     } else if (pTrackModel->hasCapabilities(TrackModel::Capability::RemoveCrate)) {
         cap = TrackModel::Capability::RemoveCrate;


### PR DESCRIPTION
Based on #12927 
= the first two commits are fixes for 2.4
the third commit prevents pasting into locked tracksets

