### PR TITLE
(fix) TrackModel remove tracks

### DIFF
--- a/src/library/trackset/crate/cratetablemodel.cpp
+++ b/src/library/trackset/crate/cratetablemodel.cpp
@@ -168,6 +168,17 @@ int CrateTableModel::addTracks(
     return trackIds.size();
 }
 
+bool CrateTableModel::isLocked() {
+    Crate crate;
+    if (!m_pTrackCollectionManager->internalCollection()
+                    ->crates()
+                    .readCrateById(m_selectedCrate, &crate)) {
+        qWarning() << "Failed to read create" << m_selectedCrate;
+        return false;
+    }
+    return crate.isLocked();
+}
+
 void CrateTableModel::removeTracks(const QModelIndexList& indices) {
     VERIFY_OR_DEBUG_ASSERT(m_selectedCrate.isValid()) {
         return;

--- a/src/library/trackset/crate/cratetablemodel.h
+++ b/src/library/trackset/crate/cratetablemodel.h
@@ -20,6 +20,7 @@ class CrateTableModel final : public TrackSetTableModel {
     void removeTracks(const QModelIndexList& indices) final;
     /// Returns the number of unsuccessful additions.
     int addTracks(const QModelIndex& index, const QList<QString>& locations) final;
+    bool isLocked() final;
 
     Capabilities getCapabilities() const final;
     QString modelKey(bool noSearch) const override;

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -905,9 +905,13 @@ void WTrackTableView::hideOrRemoveSelectedTracks() {
     }
 
     TrackModel::Capability cap;
+    // Hide is the primary action if allowed. Else we test for remove capability
     if (pTrackModel->hasCapabilities(TrackModel::Capability::Hide)) {
         cap = TrackModel::Capability::Hide;
-    } else if (pTrackModel->hasCapabilities(TrackModel::Capability::Remove)) {
+    } else if (pTrackModel->isLocked()) { // Locked playlists and crates
+        return;
+    }
+    if (pTrackModel->hasCapabilities(TrackModel::Capability::Remove)) {
         cap = TrackModel::Capability::Remove;
     } else if (pTrackModel->hasCapabilities(TrackModel::Capability::RemoveCrate)) {
         cap = TrackModel::Capability::RemoveCrate;


### PR DESCRIPTION
The corresponding track menu action is disabled but it was still possible via hotkey.
Added a `isLocked()` to the crate model to avoid running into a [debug assert](https://github.com/mixxxdj/mixxx/blob/77b466e745dc9cf8bdf57286426cdca4b12f485f/src/library/trackset/crate/cratetablemodel.cpp#L187).

When merging this please also merge 2.4 to main so we can rebase https://github.com/mixxxdj/mixxx/tree/tracklists_shortkeys asap.