### PR TITLE
(fix) Deere: make sampler rows persist

### DIFF
--- a/res/skins/Deere (64 Samplers)/sample_decks.xml
+++ b/res/skins/Deere (64 Samplers)/sample_decks.xml
@@ -152,7 +152,7 @@
     <SizePolicy>me,f</SizePolicy>
     <Children>
 
-      <WidgetStack currentpage="[Skin],sampler_row_current" persist="true">
+      <WidgetStack currentpage="[Skin],sampler_rows" persist="true">
         <ObjectName>SampleDecksContainer</ObjectName>
         <NextControl>[Skin],sampler_row_next</NextControl>
         <PrevControl>[Skin],sampler_row_prev</PrevControl>

--- a/res/skins/Deere (64 Samplers)/skinsettings_sampler_buttons.xml
+++ b/res/skins/Deere (64 Samplers)/skinsettings_sampler_buttons.xml
@@ -4,7 +4,7 @@
     <SizePolicy>min,max</SizePolicy>
     <Children>
 
-      <WidgetStack currentpage="[Skin],sampler_row_current">
+      <WidgetStack currentpage="[Skin],sampler_rows">
         <NextControl>[Deere],sampler_bank_next</NextControl>
         <PrevControl>[Deere],sampler_bank_prev</PrevControl>
         <Children>

--- a/res/skins/Deere/sample_decks.xml
+++ b/res/skins/Deere/sample_decks.xml
@@ -50,7 +50,7 @@
     <SizePolicy>me,f</SizePolicy>
     <Children>
 
-      <WidgetStack currentpage="[Skin],sampler_row_current" persist="true">
+      <WidgetStack currentpage="[Skin],sampler_rows" persist="true">
         <ObjectName>SampleDecksContainer</ObjectName>
         <NextControl>[Skin],sampler_row_next</NextControl>
         <PrevControl>[Skin],sampler_row_prev</PrevControl>

--- a/res/skins/Deere/skinsettings_sampler_buttons.xml
+++ b/res/skins/Deere/skinsettings_sampler_buttons.xml
@@ -4,7 +4,7 @@
     <SizePolicy>min,max</SizePolicy>
     <Children>
 
-      <WidgetStack currentpage="[Skin],sampler_row_current">
+      <WidgetStack currentpage="[Skin],sampler_rows">
         <NextControl>[Deere],sampler_bank_next</NextControl>
         <PrevControl>[Deere],sampler_bank_prev</PrevControl>
         <Children>


### PR DESCRIPTION
Currently the selection is not stored, not sure when that broke.