### PR TITLE
Show hint if resource path in CMakeCache.txt does not exist

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,9 +53,9 @@ const QString kScaleFactorKey = QStringLiteral("ScaleFactor");
 constexpr int kPixmapCacheLimitAt100PercentZoom = 32 * 1024; // 32 MByte
 
 int runMixxx(MixxxApplication* pApp, const CmdlineArgs& args) {
-    const auto pCoreServices = std::make_shared<mixxx::CoreServices>(args, pApp);
-
     CmdlineArgs::Instance().parseForUserFeedback();
+
+    const auto pCoreServices = std::make_shared<mixxx::CoreServices>(args, pApp);
 
     int exitCode;
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)

--- a/src/preferences/configobject.cpp
+++ b/src/preferences/configobject.cpp
@@ -51,7 +51,13 @@ QString computeResourcePathImpl() {
                 }
                 line = in.readLine();
             }
-            DEBUG_ASSERT(QDir(qResourcePath).exists());
+            if (!QDir(qResourcePath).exists()) {
+                reportCriticalErrorAndQuit(
+                        "Resource path listed in " + kCMakeCacheFile +
+                        " does not exist. Did you move the build directory? "
+                        "Hint: Set an alternative resource path with "
+                        "'--resource-path <path>'.");
+            }
         }
 #if defined(__UNIX__)
         else if (mixxxDir.cd(QStringLiteral("../share/mixxx"))) {


### PR DESCRIPTION
If a `CMakeCache.txt` was located in the same directory as the `mixxx` binary, `mixxx` tried to read the resource path from the `CMakeCache.txt` file. However, if the resource path is not available, is simply prints an error and exits the application. Now a hint is displayed stating to use the command line option `--resource-path <path>`. 

Additionally, this error is suppressed when a user requests help on command line options with `--help`. 