### PR TITLE
ScreenSaverHelper: Add no-op implementation for WASM

### DIFF
--- a/src/util/screensaver.cpp
+++ b/src/util/screensaver.cpp
@@ -336,6 +336,14 @@ void ScreenSaverHelper::uninhibitInternal() {
     setIdleTimerDisabled(false);
     s_enabled = false;
 }
+#elif defined(Q_OS_WASM)
+// Screensavers are not supported
+void ScreenSaverHelper::triggerUserActivity() {
+}
+void ScreenSaverHelper::inhibitInternal() {
+}
+void ScreenSaverHelper::uninhibitInternal() {
+}
 #else
 void ScreenSaverHelper::triggerUserActivity()
 {


### PR DESCRIPTION
Previously Mixxx would crash when debug asserts were enabled. There may be some workarounds to prevent sleep in a browser (I've seen people use `<video>` tags for that), but for now having an empty implementation seems like the best option.