### PR TITLE
Hercules Inpulse 200 - Configure shift-browser knob to scroll the library (quick)

### DIFF
--- a/res/controllers/Hercules_DJControl_Inpulse_200.midi.xml
+++ b/res/controllers/Hercules_DJControl_Inpulse_200.midi.xml
@@ -1107,6 +1107,18 @@
                     <script-binding />
                 </options>
             </control>
+            <!-- CC's MIDI Channel 4 (0xB3  SHIFT mode)-->
+            <!--Browser encoder-->
+	    <control>
+                <group>[Library]</group>
+                <key>ScrollVertical</key>
+                <description>Scroll Vertical (SHIFT + Browser Knob)</description>
+                <status>0xB3</status>
+                <midino>0x01</midino>
+                <options>
+                    <selectknob />
+                </options>
+            </control>
             <!-- CC's MIDI Channel 5 (0xB4  Deck B - SHIFT mode)-->
             <!--Jog wheel-->
             <control>


### PR DESCRIPTION
Shift-browser knob is currently unassigned. This assigns it to scroll the library  (page up/down) instead of just moving the cursor, so you can move more quickly in a large library.