### PR TITLE
VersionStore: Recognize Emscripten/WebAssembly

### DIFF
--- a/src/util/versionstore.cpp
+++ b/src/util/versionstore.cpp
@@ -78,6 +78,8 @@ QString VersionStore::platform() {
     QString base = QStringLiteral("FreeBSD");
 #elif defined(__BSD__)
     QString base = QStringLiteral("BSD");
+#elif defined(__EMSCRIPTEN__)
+    QString base = QStringLiteral("Emscripten");
 #else
     QString base = QStringLiteral("Unknown OS");
 #endif
@@ -104,6 +106,10 @@ QString VersionStore::platform() {
         defined(__PPC64__) || defined(_ARCH_PPC) || defined(_ARCH_PPC64) ||   \
         defined(_M_PPC)
     base.append(" PowerPC");
+#elif defined(__wasm32__)
+    base.append(" Wasm32");
+#elif defined(__wasm__)
+    base.append(" Wasm");
 #endif
 
     return base;


### PR DESCRIPTION
With this patch, the Wasm build should now be recognized properly:

![Screenshot 2024-03-08 at 18 42 19](https://github.com/mixxxdj/mixxx/assets/30873659/94f9888f-3c56-47d9-b89e-29b15ecd1d8f)
