### PR TITLE
CMakeLists: Fix deduplication trap with `--preload-file`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1830,7 +1830,7 @@ if(EMSCRIPTEN)
   # This will generate a mixxx.data file containing all the resources.
   # See https://emscripten.org/docs/porting/files/packaging_files.html
   # TODO: Strip this down by only including what we need (i.e. no macOS/Linux packaging, ...)
-  target_link_options(mixxx-lib PUBLIC --preload-file "${CMAKE_CURRENT_SOURCE_DIR}/res@/res")
+  target_link_options(mixxx-lib PUBLIC "--preload-file=${CMAKE_CURRENT_SOURCE_DIR}/res@/res")
 endif()
 
 if(WIN32)


### PR DESCRIPTION
CMake applies a form of deduplication that, when specifying

```cmake
target_link_options(mixxx-lib PUBLIC --preload-file a)
target_link_options(mixxx-lib PUBLIC --preload-file b)
```

would only result in

```
--preload-file a b
```

because it considers `--preload-file` to be a flag that was already set. This leads to very confusing error messages, because the Emscripten compiler would consider `b` to be a positional argument (i.e. a source file) rather than a value to `--preload-file`.

While this currently isn't an issue, because we only set this flag once, the current syntax is misleading and could easily lead to issues if we e.g. split up the resources as proposed in the adjacent TODO comment. For this reason, this PR migrates to the `--preload-file=...` syntax to avoid this.

> Side note: Another way to do this would be to use `"SHELL:--preload-file ..."`, but then we would likely have to deal with escaping/quoting the path ourselves to make it robust against spaces. For details, see [this upstream CMake issue](https://gitlab.kitware.com/cmake/cmake/-/issues/15826) and [this CMake PR](https://gitlab.kitware.com/cmake/cmake/-/merge_requests/1841).