### PR TITLE
OpenGLWindow: Fix sizing on Wasm by setting `Qt::FramelessWindowHint`

### DIFF
--- a/src/widget/openglwindow.cpp
+++ b/src/widget/openglwindow.cpp
@@ -12,10 +12,12 @@
 OpenGLWindow::OpenGLWindow(WGLWidget* pWidget)
         : m_pWidget(pWidget) {
     setFormat(WaveformWidgetFactory::getSurfaceFormat());
+#ifdef __EMSCRIPTEN__
     // This is required to ensure that QOpenGLWindows have no minimum size (When
     // targeting WebAssembly, the widgets will otherwise always have a minimum
     // width and minimum height of 100 pixels).
     setFlag(Qt::FramelessWindowHint);
+#endif
 }
 
 OpenGLWindow::~OpenGLWindow() {

--- a/src/widget/openglwindow.cpp
+++ b/src/widget/openglwindow.cpp
@@ -12,6 +12,10 @@
 OpenGLWindow::OpenGLWindow(WGLWidget* pWidget)
         : m_pWidget(pWidget) {
     setFormat(WaveformWidgetFactory::getSurfaceFormat());
+    // This is required to ensure that QOpenGLWindows have no minimum size (When
+    // targeting WebAssembly, the widgets will otherwise always have a minimum
+    // width and minimum height of 100 pixels).
+    setFlag(Qt::FramelessWindowHint);
 }
 
 OpenGLWindow::~OpenGLWindow() {


### PR DESCRIPTION
The Wasm implementation of windows [imposes a minimum size of 100x100](https://github.com/qt/qtbase/blob/0804109d686e0a99ab0de0f1c70e3422183c6e98/src/plugins/platforms/wasm/qwasmwindow.cpp#L214-L215) when this flag is not set. This patch fixes it.

| Before | After |
| - | - |
| <img src="https://github.com/mixxxdj/mixxx/assets/30873659/1ecad114-0dd4-4670-a51c-eeba3764c315" width="320"> | <img src="https://github.com/mixxxdj/mixxx/assets/30873659/33d34423-8567-4a6a-94fc-8f2ce8a6cc40" width="350"> |
