### PR TITLE
add `hotcue_X_indicator` control, is 1.0 if playposition is at hotcue

### DIFF
--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -2200,8 +2200,10 @@ void CueControl::updateIndicators() {
             posInsideLoop(currPos, loopInfo)) {
         // Check if we wrapped around
         if (!reverse && prevPos > currPos) {
+            qWarning() << "       loop wrap-around";
             loopingWrapAround = true;
         } else if (reverse && prevPos < currPos) {
+            qWarning() << "       loop wrap-around reverse";
             loopingWrapAroundReverse = true;
         }
     }
@@ -2219,15 +2221,31 @@ void CueControl::updateIndicators() {
                 // Hotcue inside loop?
                 posInsideLoop(cuePos, loopInfo) &&
                 (cuePos > prevPos || cuePos <= currPos)) {
+            qWarning() << "    >> activate"
+                       << pControl->getHotcueIndex() + 1
+                       << "(loop wrap-around)";
             active = 1.0;
         } else if (loopingWrapAroundReverse &&
                 // Hotcue inside loop?
                 posInsideLoop(cuePos, loopInfo) &&
                 (cuePos < prevPos || cuePos >= currPos)) {
+            qWarning() << "    >> activate"
+                       << pControl->getHotcueIndex() + 1
+                       << "(loop wrap-around reverse)";
             active = 1.0;
         } else if (reverse && cuePos <= prevPos && cuePos >= currPos) {
+            // Fires constantly when stopped at hotcue,
+            // enable if needed.
+            // qWarning() << "    >> activate"
+            //            << pControl->getHotcueIndex() + 1
+            //            << "(regular, reverse)";
             active = 1.0;
         } else if (!reverse && cuePos >= prevPos && cuePos <= currPos) {
+            // Fires constantly when stopped at hotcue,
+            // enable if needed.
+            // qWarning() << "    >> activate"
+            //            << pControl->getHotcueIndex() + 1
+            //            << "(regular)";
             active = 1.0;
         }
 
@@ -2249,6 +2267,9 @@ void CueControl::resetIndicators() {
 /// hotcue indicators. Otherwise m_prevPosition would be the position from before
 /// the seek and we'd falsely activate indicators.
 void CueControl::notifySeek(mixxx::audio::FramePos position) {
+    qWarning() << "     .";
+    qWarning() << "     notifySeek";
+    qWarning() << "     .";
     m_prevPosition.setValue(position);
 }
 
@@ -2815,6 +2836,11 @@ void HotcueControl::setStatus(HotcueControl::Status status) {
 void HotcueControl::setIndicator(double on) {
     if (on == m_pHotcueIndicator->get()) {
         return;
+    }
+    if (on > 0.0) {
+        qWarning() << "  >> set indicator"
+                   << getHotcueIndex() + 1
+                   << "ON";
     }
     m_pHotcueIndicator->forceSet(on);
     // TODO: check if we can squeez this into hotcue_N_status without too much effort.

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -116,6 +116,9 @@ CueControl::CueControl(const QString& group,
     m_pLoopStartPosition = make_parented<ControlProxy>(group, "loop_start_position", this);
     m_pLoopEndPosition = make_parented<ControlProxy>(group, "loop_end_position", this);
     m_pLoopEnabled = make_parented<ControlProxy>(group, "loop_enabled", this);
+    m_pLoopEnabled->connectValueChanged(this,
+            &CueControl::slotLoopEnabledChanged,
+            Qt::DirectConnection);
     m_pBeatLoopActivate = make_parented<ControlProxy>(group, "beatloop_activate", this);
     m_pBeatLoopSize = make_parented<ControlProxy>(group, "beatloop_size", this);
 
@@ -2397,7 +2400,8 @@ void CueControl::slotLoopReset() {
     setCurrentSavedLoopControlAndActivate(nullptr);
 }
 
-void CueControl::slotLoopEnabledChanged(bool enabled) {
+/// Check if we just toggled current saved loop and change its status accordingly
+void CueControl::slotLoopEnabledChanged(double value) {
     HotcueControl* pSavedLoopControl = m_pCurrentSavedLoopControl;
     if (!pSavedLoopControl) {
         return;
@@ -2413,7 +2417,7 @@ void CueControl::slotLoopEnabledChanged(bool enabled) {
                     mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
                             m_pLoopEndPosition->get()));
 
-    if (enabled) {
+    if (value > 0.0) {
         pSavedLoopControl->setStatus(HotcueControl::Status::Active);
     } else {
         pSavedLoopControl->setStatus(HotcueControl::Status::Set);

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -2428,9 +2428,13 @@ void CueControl::slotLoopUpdated(const LoopInfo& loopInfo) {
     const auto endPosition = loopInfo.endPosition;
     const auto startPosition = loopInfo.startPosition;
     bool validLoop = false;
+    // Store LoopInfo, used for updating hotcue indicators in updateindicators().
     if (startPosition.isValid() && endPosition.isValid() &&
             startPosition < endPosition) {
         validLoop = true;
+        m_loopInfo = loopInfo;
+    } else {
+        m_loopInfo = LoopInfo();
     }
 
     HotcueControl* pSavedLoopControl = m_pCurrentSavedLoopControl;

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -2420,8 +2420,15 @@ void CueControl::slotLoopEnabledChanged(bool enabled) {
     }
 }
 
-void CueControl::slotLoopUpdated(mixxx::audio::FramePos startPosition,
-        mixxx::audio::FramePos endPosition) {
+void CueControl::slotLoopUpdated(const LoopInfo& loopInfo) {
+    const auto endPosition = loopInfo.endPosition;
+    const auto startPosition = loopInfo.startPosition;
+    bool validLoop = false;
+    if (startPosition.isValid() && endPosition.isValid() &&
+            startPosition < endPosition) {
+        validLoop = true;
+    }
+
     HotcueControl* pSavedLoopControl = m_pCurrentSavedLoopControl;
     if (!pSavedLoopControl) {
         return;
@@ -2443,8 +2450,7 @@ void CueControl::slotLoopUpdated(mixxx::audio::FramePos startPosition,
         return;
     }
 
-    VERIFY_OR_DEBUG_ASSERT(startPosition.isValid() && endPosition.isValid() &&
-            startPosition < endPosition) {
+    if (!validLoop) {
         return;
     }
 

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -212,7 +212,7 @@ class CueControl : public EngineControl {
 
   public slots:
     void slotLoopReset();
-    void slotLoopEnabledChanged(bool enabled);
+    void slotLoopEnabledChanged(double value);
     void slotLoopUpdated(const LoopInfo& loopInfo); // clazy:exclude=fully-qualified-moc-types
 
   private slots:

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -95,6 +95,8 @@ class HotcueControl : public QObject {
     void setStatus(HotcueControl::Status status);
     HotcueControl::Status getStatus() const;
 
+    void setIndicator(double on);
+
     void setColor(mixxx::RgbColor::optional_t newColor);
     mixxx::RgbColor::optional_t getColor() const;
 
@@ -164,6 +166,7 @@ class HotcueControl : public QObject {
     std::unique_ptr<ControlObject> m_hotcuePosition;
     std::unique_ptr<ControlObject> m_hotcueEndPosition;
     std::unique_ptr<ControlObject> m_pHotcueStatus;
+    std::unique_ptr<ControlObject> m_pHotcueIndicator;
     std::unique_ptr<ControlObject> m_hotcueType;
     std::unique_ptr<ControlObject> m_hotcueColor;
     // Hotcue button controls
@@ -193,6 +196,7 @@ class CueControl : public EngineControl {
     ~CueControl() override;
 
     void hintReader(gsl::not_null<HintVector*> pHintList) override;
+    void notifySeek(mixxx::audio::FramePos position) override;
     bool updateIndicatorsAndModifyPlay(bool newPlay, bool oldPlay, bool playPossible);
     void updateIndicators();
     bool isTrackAtIntroCue();
@@ -361,6 +365,9 @@ class CueControl : public EngineControl {
 
     // Tells us which controls map to which hotcue
     QMap<QObject*, int> m_controlMap;
+
+    // Position used to update hotcue indicators in updateIndicators()
+    ControlValueAtomic<mixxx::audio::FramePos> m_prevPosition;
 
     // Must be locked when using the m_pLoadedTrack and it's properties
     QT_RECURSIVE_MUTEX m_trackMutex;

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -213,7 +213,7 @@ class CueControl : public EngineControl {
   public slots:
     void slotLoopReset();
     void slotLoopEnabledChanged(bool enabled);
-    void slotLoopUpdated(mixxx::audio::FramePos startPosition, mixxx::audio::FramePos endPosition);
+    void slotLoopUpdated(const LoopInfo& loopInfo); // clazy:exclude=fully-qualified-moc-types
 
   private slots:
     void quantizeChanged(double v);

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -368,6 +368,7 @@ class CueControl : public EngineControl {
 
     // Position used to update hotcue indicators in updateIndicators()
     ControlValueAtomic<mixxx::audio::FramePos> m_prevPosition;
+    LoopInfo m_loopInfo; // clazy:exclude=fully-qualified-moc-types
 
     // Must be locked when using the m_pLoadedTrack and it's properties
     QT_RECURSIVE_MUTEX m_trackMutex;

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -286,6 +286,9 @@ class CueControl : public EngineControl {
     mixxx::audio::FramePos quantizeCuePoint(mixxx::audio::FramePos position);
     mixxx::audio::FramePos getQuantizedCurrentPosition();
     TrackAt getTrackAt() const;
+    bool posInsideLoop(mixxx::audio::FramePos position, const LoopInfo& info) const {
+        return position >= info.startPosition && position < info.endPosition;
+    }
     void seekOnLoad(mixxx::audio::FramePos seekOnLoadPosition);
     void setHotcueFocusIndex(int hotcueIndex);
     int getHotcueFocusIndex() const;
@@ -354,6 +357,7 @@ class CueControl : public EngineControl {
 
     std::unique_ptr<ControlProxy> m_pVinylControlEnabled;
     std::unique_ptr<ControlProxy> m_pVinylControlMode;
+    std::unique_ptr<ControlProxy> m_pReverse;
 
     std::unique_ptr<ControlObject> m_pHotcueFocus;
     std::unique_ptr<ControlObject> m_pHotcueFocusColorNext;

--- a/src/engine/controls/enginecontrol.h
+++ b/src/engine/controls/enginecontrol.h
@@ -101,6 +101,20 @@ class EngineControl : public QObject {
     FrameInfo frameInfo() const {
         return m_frameInfo.getValue();
     }
+
+    // Both Loopingcontrol and Cuecontrol need LoopInfo
+    enum class LoopSeekMode {
+        Changed, // force the playposition to be inside the loop after adjusting it.
+        MovedOut,
+        None,
+    };
+
+    struct LoopInfo {
+        mixxx::audio::FramePos startPosition;
+        mixxx::audio::FramePos endPosition;
+        LoopSeekMode seekMode;
+    };
+
     void seek(double fractionalPosition);
     void seekAbs(mixxx::audio::FramePos position);
     // Seek to an exact sample and don't allow quantizing adjustment.

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -1214,8 +1214,6 @@ void LoopingControl::setLoopingEnabled(bool enabled) {
             pActiveBeatLoop->deactivate();
         }
     }
-
-    emit loopEnabledChanged(enabled);
 }
 
 void LoopingControl::trackLoaded(TrackPointer pNewTrack) {

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -336,7 +336,7 @@ void LoopingControl::slotLoopScale(double scaleFactor) {
             : LoopSeekMode::MovedOut;
 
     m_loopInfo.setValue(loopInfo);
-    emit loopUpdated(loopInfo.startPosition, loopInfo.endPosition);
+    emit loopUpdated(loopInfo);
 
     // Update CO for loop end marker
     m_pCOLoopEndPosition->set(loopInfo.endPosition.toEngineSamplePos());
@@ -821,7 +821,7 @@ void LoopingControl::slotLoopIn(double pressed) {
             m_bAdjustingLoopIn = false;
             LoopInfo loopInfo = m_loopInfo.getValue();
             if (loopInfo.startPosition < loopInfo.endPosition) {
-                emit loopUpdated(loopInfo.startPosition, loopInfo.endPosition);
+                emit loopUpdated(loopInfo);
             } else {
                 emit loopReset();
             }
@@ -967,7 +967,7 @@ void LoopingControl::slotLoopOut(double pressed) {
                 setLoopOutToCurrentPosition();
                 LoopInfo loopInfo = m_loopInfo.getValue();
                 if (loopInfo.startPosition < loopInfo.endPosition) {
-                    emit loopUpdated(loopInfo.startPosition, loopInfo.endPosition);
+                    emit loopUpdated(loopInfo);
                 } else {
                     emit loopReset();
                 }
@@ -1534,7 +1534,7 @@ void LoopingControl::slotBeatLoop(double beats, bool keepStartPoint, bool enable
         newloopInfo.seekMode = LoopSeekMode::Changed;
     }
     m_loopInfo.setValue(newloopInfo);
-    emit loopUpdated(newloopInfo.startPosition, newloopInfo.endPosition);
+    emit loopUpdated(newloopInfo);
     m_pCOLoopStartPosition->set(newloopInfo.startPosition.toEngineSamplePos());
     m_pCOLoopEndPosition->set(newloopInfo.endPosition.toEngineSamplePos());
 
@@ -1695,7 +1695,7 @@ void LoopingControl::slotLoopMove(double beats) {
         loopInfo.startPosition = newLoopStartPosition;
         loopInfo.endPosition = newLoopEndPosition;
         m_loopInfo.setValue(loopInfo);
-        emit loopUpdated(loopInfo.startPosition, loopInfo.endPosition);
+        emit loopUpdated(loopInfo);
         m_pCOLoopStartPosition->set(loopInfo.startPosition.toEngineSamplePosMaybeInvalid());
         m_pCOLoopEndPosition->set(loopInfo.endPosition.toEngineSamplePosMaybeInvalid());
     }

--- a/src/engine/controls/loopingcontrol.h
+++ b/src/engine/controls/loopingcontrol.h
@@ -57,19 +57,7 @@ class LoopingControl : public EngineControl {
             mixxx::audio::FramePos endPosition,
             bool enabled);
 
-    enum class LoopSeekMode {
-        Changed, // force the playposition to be inside the loop after adjusting it.
-        MovedOut,
-        None,
-    };
-
-    struct LoopInfo {
-        mixxx::audio::FramePos startPosition;
-        mixxx::audio::FramePos endPosition;
-        LoopSeekMode seekMode;
-    };
-
-    LoopInfo getLoopInfo() {
+    LoopInfo getLoopInfo() { // clazy:exclude=fully-qualified-moc-types
         return m_loopInfo.getValue();
     }
 
@@ -99,7 +87,7 @@ class LoopingControl : public EngineControl {
   signals:
     void loopReset();
     void loopEnabledChanged(bool enabled);
-    void loopUpdated(mixxx::audio::FramePos startPosition, mixxx::audio::FramePos endPosition);
+    void loopUpdated(LoopInfo loopInfo); // clazy:exclude=fully-qualified-moc-types
 
   public slots:
     void slotLoopIn(double pressed);
@@ -148,7 +136,8 @@ class LoopingControl : public EngineControl {
     void setLoopOutToCurrentPosition();
     void clearActiveBeatLoop();
     void updateBeatLoopingControls();
-    bool currentLoopMatchesBeatloopSize(const LoopInfo& loopInfo) const;
+    bool currentLoopMatchesBeatloopSize(const LoopInfo& loopInfo)
+            const; // clazy:exclude=fully-qualified-moc-types
 
     // Given loop in and out points, determine if this is a beatloop of a particular
     // size.
@@ -199,8 +188,8 @@ class LoopingControl : public EngineControl {
     bool m_bAdjustingLoopOutOld;
     bool m_bLoopOutPressedWhileLoopDisabled;
     QStack<double> m_activeLoopRolls;
-    ControlValueAtomic<LoopInfo> m_loopInfo;
-    LoopInfo m_oldLoopInfo;
+    ControlValueAtomic<LoopInfo> m_loopInfo; // clazy:exclude=fully-qualified-moc-types
+    LoopInfo m_oldLoopInfo;                  // clazy:exclude=fully-qualified-moc-types
     ControlValueAtomic<mixxx::audio::FramePos> m_currentPosition;
     ControlObject* m_pQuantizeEnabled;
     QAtomicPointer<BeatLoopingControl> m_pActiveBeatLoop;

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -237,11 +237,6 @@ EngineBuffer::EngineBuffer(const QString& group,
             m_pCueControl,
             &CueControl::slotLoopUpdated,
             Qt::DirectConnection);
-    connect(m_pLoopingControl,
-            &LoopingControl::loopEnabledChanged,
-            m_pCueControl,
-            &CueControl::slotLoopEnabledChanged,
-            Qt::DirectConnection);
     connect(m_pCueControl,
             &CueControl::loopRemove,
             m_pLoopingControl,


### PR DESCRIPTION
Just a little helper that allows having callbacks for when the playposition crosses a hotcue / loopcue.
For example:
* always trigger the fog machine on hotcue5 via MIDI_4_Lights
* auto-censor certain spots in _all_ tracks by making hotcue17 trigger a certain sample / engage revere-roll for 1 sec
* flash controller hotcue buttons if deck is stopped at a hotcue
* ...

### Description
Basically, it's something like `beat_active` and `cue_indicator`: it is activated (1.0) if
* the play position is on the hotcue
(when stopped or when the buffer's new position is coincidentally at the hotcue position)
* the play position crossed the hotcue since the last update
(while playing forward or backward and while scratching, **not** when seeking over a hotcue)

_`beat_active` is 1.0 if the playposition is in a certain **range** around a beat marker_
_`cue_indicator`_ is 1.0 (maybe flashing) if the play position is **exactly** at the Cue (unlikely when playing)_



### Improvement?
Integrating it into `hotcue_X_status` would allow GUI feedback via WHotcueButton, it'd be just two more states that could be styled rather easily. #9760 
For now this is separate because integration/extension seems a bit cumbersome.

### Nice to have
- [ ] tests that covers looping (hotcue slight before and at loop_out, slightly after loop_in)

### Proposal for testing
* load this mapping to the MIDI Through controller https://gist.github.com/ronso0/2dd322622ddac2590020ce9b2af5d695
* load a track to deck1, set hotcues 1-2-3 with a distance of ~10s
* load a track to deck2
* both decks stoped
* Test1:
   * play from start
   * jump to hotcue 1
   * jump to hotcue 3
   * == deck2 should **not** start
* Test2:
   * play from start
   * jump to hotcue 1
   * jump to hotcue 2
   * == deck2 should start
* Test1:
   * stopped
   * jump to hotcue 3
   * scratch backwards over hotcue 2
   * == deck2 should start