### PR TITLE
CMakeLists: Require WebGL 2.0 when building for Wasm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2599,6 +2599,10 @@ else()
     # Emscripten's FindOpenGL.cmake does not create OpenGL::GL
     target_link_libraries(mixxx-lib PRIVATE ${OPENGL_gl_LIBRARY})
     target_compile_definitions(mixxx-lib PUBLIC QT_OPENGL_ES_2)
+    # Require WebGL 2.0 (for a WebGL-friendly subset of OpenGL ES 3.0) and
+    # enable full OpenGL ES 2.0 emulation as per
+    # https://emscripten.org/docs/porting/multimedia_and_graphics/OpenGL-support.html
+    target_link_options(mixxx-lib PUBLIC -sMIN_WEBGL_VERSION=2 -sMAX_WEBGL_VERSION=2 -sFULL_ES2=1)
   else()
     target_link_libraries(mixxx-lib PRIVATE OpenGL::GL)
   endif()


### PR DESCRIPTION
We need OpenGL ES 3.0 and by requiring a WebGL 2 browser, we can reduce the size of the binary.

We also need `-sFULL_ES2=1` to avoid warnings like

```
WebGL: INVALID_OPERATION: vertexAttribPointer: no ARRAY_BUFFER is bound and offset is non-zero
```

...and the link options have to be public to apply to the final binary.