### PR TITLE
(fix) DlgTrackInfo: prevent wiping metadata when applying twice quickly

### DIFF
--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -614,8 +614,13 @@ void DlgTrackInfo::saveTrack() {
     static_cast<void>(updateKeyText()); // discard result
 
     // Update the cached track
-    // The dialog is updated and repopulated by the Track::changed() signal.
-    m_pLoadedTrack->replaceRecord(std::move(m_trackRecord), std::move(m_pBeatsClone));
+    //
+    // If replaceRecord() returns true then both m_trackRecord and m_pBeatsClone
+    // will be updated by the subsequent Track::changed() signal to keep them
+    // synchronized with the track. Otherwise the track has not been modified and
+    // both members must remain valid. Do not use std::move() for passing arguments!
+    // Else triggering apply twice in quick succession might clear the metadata.
+    m_pLoadedTrack->replaceRecord(m_trackRecord, m_pBeatsClone);
 }
 
 void DlgTrackInfo::clear() {

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -306,7 +306,7 @@ bool Track::replaceRecord(
 
     bool bpmUpdatedFlag;
     if (pOptionalBeats) {
-        bpmUpdatedFlag = trySetBeatsWhileLocked(std::move(pOptionalBeats));
+        bpmUpdatedFlag = trySetBeatsWhileLocked(pOptionalBeats);
         if (recordUnchanged && !bpmUpdatedFlag) {
             return false;
         }
@@ -390,7 +390,7 @@ bool Track::trySetBpmWhileLocked(mixxx::Bpm bpm) {
         auto pBeats = mixxx::Beats::fromConstTempo(getSampleRate(),
                 cuePosition,
                 bpm);
-        return trySetBeatsWhileLocked(std::move(pBeats));
+        return trySetBeatsWhileLocked(pBeats);
     } else if (getBeatsPointerBpm(m_pBeats, getDuration()) != bpm) {
         // Continue with the regular cases
         const auto newBeats = m_pBeats->trySetBpm(bpm);

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -288,7 +288,6 @@ mixxx::TrackRecord Track::getRecord(
 bool Track::replaceRecord(
         mixxx::TrackRecord newRecord,
         mixxx::BeatsPointer pOptionalBeats) {
-    const auto newKey = newRecord.getGlobalKey();
     const auto newReplayGain = newRecord.getMetadata().getTrackInfo().getReplayGain();
     const auto newColor = newRecord.getColor();
     const auto newRating = newRecord.getRating();
@@ -299,7 +298,6 @@ bool Track::replaceRecord(
         return false;
     }
 
-    const auto oldKey = m_record.getGlobalKey();
     const auto oldReplayGain = m_record.getMetadata().getTrackInfo().getReplayGain();
     const auto oldColor = m_record.getColor();
     const auto oldRating = m_record.getRating();
@@ -327,10 +325,7 @@ bool Track::replaceRecord(
     markDirtyAndUnlock(&locked);
 
     if (bpmUpdatedFlag) {
-        emitBeatsAndBpmUpdated();
-    }
-    if (oldKey != newKey) {
-        emit keyChanged();
+        emit beatsUpdated();
     }
     if (oldReplayGain != newReplayGain) {
         emit replayGainUpdated(newReplayGain);


### PR DESCRIPTION
Not sure what exactly is the root cause, but preventing what should be a [no-op in `Track`](https://github.com/mixxxdj/mixxx/blob/24b415c4ff7e3bfd5e418ad31e03c4c627367c3e/src/track/track.cpp#L298) already  in `DlgTrackInfo` seems to suffice. Can't reproduce anymore.

With my sparse basic c++ knowledge, I suspected the cause is that the track record has been moved to Track (is null in DlgTrackRecord?) when applying again before the `Track::changed` signal triggered DlgTrackInfo to fetch the new track record.
But tracing that turned out this is not it since now the changed signal is received _before_ trying to save again (maybe it's just delays caused by the new m_pLoadedTrack->getRecord(), idk :man_shrugging: )

With symptoms fixed this good enough for 2.4.1 I guess.

#### Update:
As [clarified by @uklotzde](90cdb1fa3fd7b89e39beb69e364d8b5ae9e10f4c) the issue was indeed passing the record and the beats to track via `std::move`.

Fixes #12963 