### PR TITLE
Fix mapping for Behringer controllers DDM4000 & BCR2000

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The Mixxx team uses [Github Issues][issues] to manage Mixxx development.
 Have a bug or feature request? [File a bug on Github][fileabug].
 
 Want to get involved in Mixxx development? Assign yourself a bug from the [easy
-bug list][easybugs] and get started!   
+bug list][easybugs] and get started!
 Read [CONTRIBUTING](CONTRIBUTING.md) for more information.
 
 ## Building Mixxx

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The Mixxx team uses [Github Issues][issues] to manage Mixxx development.
 Have a bug or feature request? [File a bug on Github][fileabug].
 
 Want to get involved in Mixxx development? Assign yourself a bug from the [easy
-bug list][easybugs] and get started!
+bug list][easybugs] and get started!   
 Read [CONTRIBUTING](CONTRIBUTING.md) for more information.
 
 ## Building Mixxx

--- a/res/controllers/Behringer-Extension-scripts.js
+++ b/res/controllers/Behringer-Extension-scripts.js
@@ -239,7 +239,7 @@
         isEnabled: function() { return this.id !== 0; },
         start: function() {
             this.reset();
-            var timer = this;
+            const timer = this;
             this.id = engine.beginTimer(this.timeout, () => {
                 if (timer.oneShot) {
                     timer.disable();

--- a/res/controllers/Behringer-Extension-scripts.js
+++ b/res/controllers/Behringer-Extension-scripts.js
@@ -239,13 +239,12 @@
         isEnabled: function() { return this.id !== 0; },
         start: function() {
             this.reset();
-            const timer = this;
-            this.id = engine.beginTimer(this.timeout, () => {
-                if (timer.oneShot) {
-                    timer.disable();
+            this.id = engine.beginTimer(this.timeout, function() {
+                if (this.oneShot) {
+                    this.disable();
                 }
-                timer.action.call(timer.owner);
-            }, this.oneShot);
+                this.action.call(this.owner);
+            }.bind(this), this.oneShot); // .bind(this) is required instead of arrow function for Qt < 6.2.4 due to QTBUG-95677
         },
         reset: function() {
             if (this.isEnabled()) {

--- a/res/controllers/Behringer-Extension-scripts.js
+++ b/res/controllers/Behringer-Extension-scripts.js
@@ -239,11 +239,12 @@
         isEnabled: function() { return this.id !== 0; },
         start: function() {
             this.reset();
+            var timer = this;
             this.id = engine.beginTimer(this.timeout, () => {
-                if (this.oneShot) {
-                    this.disable();
+                if (timer.oneShot) {
+                    timer.disable();
                 }
-                this.action.call(this.owner);
+                timer.action.call(timer.owner);
             }, this.oneShot);
         },
         reset: function() {


### PR DESCRIPTION
This PR fixes a bug introduced by commit [306bbe4](https://github.com/mixxxdj/mixxx/commit/306bbe447ee96815d6a49ce93c58442fe23f883f#diff-e649c0e4db927d960f4ba867f7502dd90ad4e682fee19afb946f47f1094c4654) (PR https://github.com/mixxxdj/mixxx/pull/12401) that covers the switch to QJSEngine for v2.4.

When an affected controller (Behringer DDM4000 or BCR2000) is configured, the following message is shown on application start of v2.4.0:
```
Warning [Controller] ControllerScriptHandlerBase:
"Uncaught exception: file:///usr/share/mixxx/controllers/Behringer-Extension-scripts.js:244:
TypeError: Property 'disable' of object [object Object] is not a function
Backtrace: @file:///usr/share/mixxx/controllers/Behringer-Extension-scripts.js:244"
```

With the suggested patch applied, no error is shown and the controllers work as expected.

Probably related: https://github.com/mixxxdj/mixxx/issues/11473

/cc @Swiftb0y @JoergAtGithub 