### PR TITLE
AutoDJ: reset of UI toggle if enable is rejected due to playing decks 3/4

### DIFF
--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -403,6 +403,7 @@ AutoDJProcessor::AutoDJError AutoDJProcessor::toggleAutoDJ(bool enable) {
         for (int i = 2; i < m_decks.length(); ++i) {
             if (m_decks[i] && m_decks[i]->isPlaying()) {
                 // Keep the current state.
+                emitAutoDJStateChanged(m_eState);
                 emit autoDJError(ADJ_DECKS_3_4_PLAYING);
                 return ADJ_DECKS_3_4_PLAYING;
             }


### PR DESCRIPTION
Fixes #12975 

Simply add the missing emission of the new (maybe unchanged) state in order to reset the clicked UI toggle.