### PR TITLE
(fix) Track widgets: set `show_track_menu` only for main decks

### DIFF
--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -1081,17 +1081,20 @@ QWidget* LegacySkinParser::parseTrackProperty(const QDomElement& node) {
         return nullptr;
     }
 
+    bool isMainDeck = PlayerManager::isDeckGroup(group);
     WTrackProperty* pTrackProperty = new WTrackProperty(
             m_pParent,
             m_pConfig,
             m_pLibrary,
-            group);
+            group,
+            isMainDeck);
     setupLabelWidget(node, pTrackProperty);
 
     // Ensure 'show_track_menu' control is created for each main deck and
     // valueChangeRequest hook is set up.
-    // Only the first WTrackProperty that is created connects the signals.
-    if (PlayerManager::isDeckGroup(group)) {
+    if (isMainDeck) {
+        // Only the first WTrackProperty that is created connects the signals,
+        // for later attempts this returns false.
         if (pPlayer->isTrackMenuControlAvailable()) {
             connect(pPlayer,
                     &BaseTrackPlayer::trackMenuChangeRequest,
@@ -1143,7 +1146,8 @@ QWidget* LegacySkinParser::parseTrackWidgetGroup(const QDomElement& node) {
             m_pParent,
             m_pConfig,
             m_pLibrary,
-            group);
+            group,
+            PlayerManager::isDeckGroup(group));
     commonWidgetSetup(node, pGroup);
     pGroup->setup(node, *m_pContext);
     pGroup->Init();

--- a/src/widget/wtrackproperty.h
+++ b/src/widget/wtrackproperty.h
@@ -18,7 +18,8 @@ class WTrackProperty : public WLabel, public TrackDropTarget {
             QWidget* pParent,
             UserSettingsPointer pConfig,
             Library* pLibrary,
-            const QString& group);
+            const QString& group,
+            bool isMainDeck);
     ~WTrackProperty() override;
 
     void setup(const QDomNode& node, const SkinContext& context) override;
@@ -48,6 +49,7 @@ class WTrackProperty : public WLabel, public TrackDropTarget {
     const QString m_group;
     const UserSettingsPointer m_pConfig;
     Library* m_pLibrary;
+    const bool m_isMainDeck;
     TrackPointer m_pCurrentTrack;
     QString m_property;
 

--- a/src/widget/wtrackwidgetgroup.h
+++ b/src/widget/wtrackwidgetgroup.h
@@ -15,7 +15,8 @@ class WTrackWidgetGroup : public WWidgetGroup, public TrackDropTarget {
     WTrackWidgetGroup(QWidget* pParent,
             UserSettingsPointer pConfig,
             Library* pLibrary,
-            const QString& group);
+            const QString& group,
+            bool isMainDeck);
     ~WTrackWidgetGroup() override;
     void setup(const QDomNode& node, const SkinContext& context) override;
 
@@ -49,6 +50,7 @@ class WTrackWidgetGroup : public WWidgetGroup, public TrackDropTarget {
     TrackPointer m_pCurrentTrack;
     QColor m_trackColor;
     int m_trackColorAlpha;
+    const bool m_isMainDeck;
 
     parented_ptr<WTrackMenu> m_pTrackMenu;
 };


### PR DESCRIPTION
only for those BaseTrackPlayer created the ControlPushButtons.

Currently a DEBUG_ASSERT is hit if e.g. a sampler's track label receives a contextMenuEvent.
(apparently no one uses that track menu... I just discovered this by accident X)

I'd actually have pushed this minimal fix directly but a second pair of eyes would be good.