### PR TITLE
(fix) use track `info` for preview deck labels = artist+title / file info

### DIFF
--- a/res/skins/Deere/preview_deck.xml
+++ b/res/skins/Deere/preview_deck.xml
@@ -33,7 +33,7 @@
                     <TooltipId>text</TooltipId>
                     <SizePolicy>me,min</SizePolicy>
                     <Group><Variable name="group"/></Group>
-                    <Property>titleInfo</Property>
+                    <Property>info</Property>
                     <Elide>right</Elide>
                   </TrackProperty>
 

--- a/res/skins/LateNight/decks/preview_deck.xml
+++ b/res/skins/LateNight/decks/preview_deck.xml
@@ -42,7 +42,7 @@
                             <Size>0me,20f</Size>
                             <Elide>right</Elide>
                             <Group><Variable name="Group"/></Group>
-                            <Property>titleInfo</Property>
+                            <Property>info</Property>
                           </TrackProperty>
                           <Number>
                             <ObjectName>PreviewBPM</ObjectName>

--- a/res/skins/Shade/preview_deck.xml
+++ b/res/skins/Shade/preview_deck.xml
@@ -53,7 +53,7 @@
                               padding-top: 2px;}
                             </Style>
                             <Group>[PreviewDeck1]</Group>
-                            <Property>titleInfo</Property>
+                            <Property>info</Property>
                             <SizePolicy>me,min</SizePolicy>
                             <Elide>right</Elide>
                           </TrackProperty>

--- a/res/skins/Tango/decks/preview_deck.xml
+++ b/res/skins/Tango/decks/preview_deck.xml
@@ -61,7 +61,7 @@ Variables:
                     <TooltipId>text</TooltipId>
                     <Size>1me,17f</Size>
                     <Group><Variable name="group"/></Group>
-                    <Property>titleInfo</Property>
+                    <Property>info</Property>
                     <Elide>right</Elide>
                   </TrackProperty>
                 </Children>


### PR DESCRIPTION
Regression from direct "fix" c1ad273cf3b81511415d8cc4acaa95481c63595a :grimacing: 

Now it matches the tooltip again.