### PR TITLE
Delete all artifacts from obsolete feature branches from https://downloads.mixxx.org/snapshots/

### DIFF
--- a/.github/workflows/download_cleanup.yml
+++ b/.github/workflows/download_cleanup.yml
@@ -38,6 +38,28 @@ jobs:
           echo 2.2/* >> include_file.txt
           echo 2.2/*/* >> include_file.txt
           rsync --verbose --archive --times --recursive --delete --include-from=include_file.txt --exclude=* "empty_folder/" "${SSH_USER}@${SSH_HOST}:${DESTDIR}/snapshots/"
+          echo sccache/ > include_file.txt
+          echo sccache/* >> include_file.txt
+          echo sccache/*/* >> include_file.txt
+          echo qt_debug_fix/ >> include_file.txt
+          echo qt_debug_fix/* >> include_file.txt
+          echo qt_debug_fix/*/* >> include_file.txt
+          echo qt6/ >> include_file.txt
+          echo qt6/* >> include_file.txt
+          echo qt6/*/* >> include_file.txt
+          echo portaudio-jack/ >> include_file.txt
+          echo portaudio-jack/* >> include_file.txt
+          echo portaudio-jack/*/* >> include_file.txt
+          echo manifest_mode_ci/ >> include_file.txt
+          echo manifest_mode_ci/* >> include_file.txt
+          echo manifest_mode_ci/*/* >> include_file.txt
+          echo main/ >> include_file.txt
+          echo main/* >> include_file.txt
+          echo main/*/* >> include_file.txt
+          echo 2.3.macos/ >> include_file.txt
+          echo 2.3.macos/* >> include_file.txt
+          echo 2.3.macos/*/* >> include_file.txt
+          rsync --verbose --archive --times --recursive --delete --include-from=include_file.txt --exclude=* "empty_folder/" "${SSH_USER}@${SSH_HOST}:${DESTDIR}/dependencies/"
         env:
           DESTDIR: public_html/downloads
           SSH_HOST: downloads-hostgator.mixxx.org

--- a/.github/workflows/download_cleanup.yml
+++ b/.github/workflows/download_cleanup.yml
@@ -25,44 +25,20 @@ jobs:
         if: env.SSH_AUTH_SOCK != null
         run: |
           mkdir empty_folder
-          echo clang-tidy-ignore/ >> include_file.txt
-          echo clang-tidy-ignore/* >> include_file.txt
-          echo clang-tidy-warning/ >> include_file.txt
-          echo clang-tidy-warning/* >> include_file.txt
-          echo cmake-version-urls/ >> include_file.txt
-          echo cmake-version-urls/* >> include_file.txt
-          echo denormals_test_fix/ >> include_file.txt
-          echo denormals_test_fix/* >> include_file.txt
-          echo dependabot/ >> include_file.txt
-          echo dependabot/* >> include_file.txt
-          echo korg-kaoss-dj/ >> include_file.txt
-          echo korg-kaoss-dj/* >> include_file.txt
-          echo notarytool-2.4/ >> include_file.txt
-          echo notarytool-2.4/* >> include_file.txt
-          echo pr/ >> include_file.txt
-          echo pr/* >> include_file.txt
-          echo pr12370_winbuildenv_bat/ >> include_file.txt
-          echo pr12370_winbuildenv_bat/* >> include_file.txt
-          echo qt6/ >> include_file.txt
-          echo qt6/* >> include_file.txt
-          echo revert-12394-dependabot/ >> include_file.txt
-          echo revert-12394-dependabot/* >> include_file.txt
-          echo synclock-06-scratch-phase/ >> include_file.txt
-          echo synclock-06-scratch-phase/* >> include_file.txt
-          echo taglib_20_fail/ >> include_file.txt
-          echo taglib_20_fail/* >> include_file.txt
-          echo tracklists_shortkeys/ >> include_file.txt
-          echo tracklists_shortkeys/* >> include_file.txt
-          echo translate-spam-revert-2.4/ >> include_file.txt
-          echo translate-spam-revert-2.4/* >> include_file.txt
-          echo update-manifest/ >> include_file.txt
-          echo update-manifest/* >> include_file.txt
-          echo vcpkg_manifest/ >> include_file.txt
-          echo vcpkg_manifest/* >> include_file.txt
-          echo vcpkg_osx/ >> include_file.txt
-          echo vcpkg_osx/* >> include_file.txt
-          rsync --verbose --archive --times --recursive --delete --include-from=include_file.txt --exclude=* "empty_folder/" "${SSH_USER}@${SSH_HOST}:${DESTDIR}/"
+          echo 1.12/ > include_file.txt
+          echo 1.12/* >> include_file.txt
+          echo 1.12/*/* >> include_file.txt
+          echo 2.0/ >> include_file.txt
+          echo 2.0/* >> include_file.txt
+          echo 2.0/*/* >> include_file.txt
+          echo 2.1/ >> include_file.txt
+          echo 2.1/* >> include_file.txt
+          echo 2.1/*/* >> include_file.txt
+          echo 2.2/ >> include_file.txt
+          echo 2.2/* >> include_file.txt
+          echo 2.2/*/* >> include_file.txt
+          rsync --verbose --archive --times --recursive --delete --include-from=include_file.txt --exclude=* "empty_folder/" "${SSH_USER}@${SSH_HOST}:${DESTDIR}/snapshots/"
         env:
-          DESTDIR: public_html/downloads/snapshots
+          DESTDIR: public_html/downloads
           SSH_HOST: downloads-hostgator.mixxx.org
           SSH_USER: mixxx

--- a/.github/workflows/download_cleanup.yml
+++ b/.github/workflows/download_cleanup.yml
@@ -25,8 +25,42 @@ jobs:
         if: env.SSH_AUTH_SOCK != null
         run: |
           mkdir empty_folder
-          echo build-checks-fix/ >> include_file.txt
-          echo build-checks-fix/* >> include_file.txt
+          echo clang-tidy-ignore/ >> include_file.txt
+          echo clang-tidy-ignore/* >> include_file.txt
+          echo clang-tidy-warning/ >> include_file.txt
+          echo clang-tidy-warning/* >> include_file.txt
+          echo cmake-version-urls/ >> include_file.txt
+          echo cmake-version-urls/* >> include_file.txt
+          echo denormals_test_fix/ >> include_file.txt
+          echo denormals_test_fix/* >> include_file.txt
+          echo dependabot/ >> include_file.txt
+          echo dependabot/* >> include_file.txt
+          echo korg-kaoss-dj/ >> include_file.txt
+          echo korg-kaoss-dj/* >> include_file.txt
+          echo notarytool-2.4/ >> include_file.txt
+          echo notarytool-2.4/* >> include_file.txt
+          echo pr/ >> include_file.txt
+          echo pr/* >> include_file.txt
+          echo pr12370_winbuildenv_bat/ >> include_file.txt
+          echo pr12370_winbuildenv_bat/* >> include_file.txt
+          echo qt6/ >> include_file.txt
+          echo qt6/* >> include_file.txt
+          echo revert-12394-dependabot/ >> include_file.txt
+          echo revert-12394-dependabot/* >> include_file.txt
+          echo synclock-06-scratch-phase/ >> include_file.txt
+          echo synclock-06-scratch-phase/* >> include_file.txt
+          echo taglib_20_fail/ >> include_file.txt
+          echo taglib_20_fail/* >> include_file.txt
+          echo tracklists_shortkeys/ >> include_file.txt
+          echo tracklists_shortkeys/* >> include_file.txt
+          echo translate-spam-revert-2.4/ >> include_file.txt
+          echo translate-spam-revert-2.4/* >> include_file.txt
+          echo update-manifest/ >> include_file.txt
+          echo update-manifest/* >> include_file.txt
+          echo vcpkg_manifest/ >> include_file.txt
+          echo vcpkg_manifest/* >> include_file.txt
+          echo vcpkg_osx/ >> include_file.txt
+          echo vcpkg_osx/* >> include_file.txt
           rsync --verbose --archive --times --recursive --delete --include-from=include_file.txt --exclude=* "empty_folder/" "${SSH_USER}@${SSH_HOST}:${DESTDIR}/"
         env:
           DESTDIR: public_html/downloads/snapshots


### PR DESCRIPTION
I don't think we need them anymore.

http://downloads.mixxx.org/snapshots/
clang-tidy-ignore/
clang-tidy-warning/
cmake-version-urls/
denormals_test_fix/
dependabot/
korg-kaoss-dj/
notarytool-2.4/
pr/
pr12370_winbuildenv_bat/
qt6/
revert-12394-dependabot/
synclock-06-scratch-phase/
taglib_20_fail/
tracklists_shortkeys/
translate-spam-revert-2.4/
update-manifest/
vcpkg_manifest/
vcpkg_osx/