### PR TITLE
Fix incomplete type ‘EffectManifest’ used in nested name

### DIFF
--- a/src/effects/backends/effectsbackendmanager.cpp
+++ b/src/effects/backends/effectsbackendmanager.cpp
@@ -2,6 +2,7 @@
 
 #include "control/controlobject.h"
 #include "effects/backends/builtin/builtinbackend.h"
+#include "effects/backends/effectmanifest.h"
 #include "effects/backends/effectprocessor.h"
 #ifdef __LILV__
 #include "effects/backends/lv2/lv2backend.h"


### PR DESCRIPTION
Building Mixxx on Gentoo fail with the following error:

/var/tmp/portage/media-sound/mixxx-2.4.0/work/mixxx-2.4.0/src/effects/backends/effectsbackendmanager.cpp: In member function ‘void EffectsBackendManager::addBackend(EffectsBackendPointer)’: /var/tmp/portage/media-sound/mixxx-2.4.0/work/mixxx-2.4.0/src/effects/backends/effectsbackendmanager.cpp:37:29: error: incomplete type ‘EffectManifest’ used in nested name specifier 37 | EffectManifest::sortLexigraphically);
| ^~~~~~~~~~~~~~~~~~~

GCC: 13.2.1_p20240210
This commit make it works fine.