### PR TITLE
animate long press latching

### DIFF
--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -434,8 +434,8 @@ void WPushButton::mousePressEvent(QMouseEvent * e) {
                 m_clickTimer.start(ControlPushButtonBehavior::kLongPressLatchingTimeMillis);
                 if (oldValue == 0.0) {
                     // Capture pixmap with the off state ...
-                    m_preLongPressPixmap = QPixmap(width() * devicePixelRatio(),
-                            height() * devicePixelRatio());
+                    m_preLongPressPixmap = QPixmap(static_cast<int>(width() * devicePixelRatio()),
+                            static_cast<int>(height() * devicePixelRatio()));
                     m_preLongPressPixmap.setDevicePixelRatio(devicePixelRatio());
                     paintOnDevice(&m_preLongPressPixmap);
                     // ... and start the long press latching animation

--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -414,7 +414,7 @@ void WPushButton::mousePressEvent(QMouseEvent * e) {
             if (m_leftButtonMode == ControlPushButton::LONGPRESSLATCHING) {
                 m_clickTimer.setSingleShot(true);
                 m_clickTimer.start(ControlPushButtonBehavior::kLongPressLatchingTimeMillis);
-                if (oldValue == 0.0) {
+                if (oldValue == 0.0 && m_pLongPressLatching) {
                     m_pLongPressLatching->start();
                 }
             }

--- a/src/widget/wpushbutton.h
+++ b/src/widget/wpushbutton.h
@@ -61,6 +61,9 @@ class WPushButton : public WWidget {
   public slots:
     void onConnectedControlChanged(double dParameter, double dValue) override;
 
+  private slots:
+    void onAnimTimer();
+
   protected:
     bool event(QEvent* e) override;
     void paintEvent(QPaintEvent* e) override;
@@ -86,6 +89,8 @@ class WPushButton : public WWidget {
             Paintable::DrawMode mode,
             double scaleFactor);
 
+    void paintOnDevice(QPaintDevice* pd);
+
     // True, if the button is currently pressed
     bool m_bPressed;
     // True, if the button is pointer is above button
@@ -101,9 +106,12 @@ class WPushButton : public WWidget {
     // Associated background pixmap
     PaintablePointer m_pPixmapBack;
 
+    QPixmap m_preLongPressPixmap;
+
     // short click toggle button long click push button
     ControlPushButton::ButtonMode m_leftButtonMode;
     ControlPushButton::ButtonMode m_rightButtonMode;
     QTimer m_clickTimer;
+    QTimer m_animTimer; // To animate long press latching
     QVector<int> m_align;
 };

--- a/src/widget/wpushbutton.h
+++ b/src/widget/wpushbutton.h
@@ -3,6 +3,7 @@
 #include <QString>
 #include <QTimer>
 #include <QVector>
+#include <memory>
 
 #include "control/controlpushbutton.h"
 #include "util/fpclassify.h"

--- a/src/widget/wpushbutton.h
+++ b/src/widget/wpushbutton.h
@@ -62,7 +62,7 @@ class WPushButton : public WWidget {
     void onConnectedControlChanged(double dParameter, double dValue) override;
 
   private slots:
-    void onAnimTimer();
+    void updateSlot();
 
   protected:
     bool event(QEvent* e) override;
@@ -106,12 +106,24 @@ class WPushButton : public WWidget {
     // Associated background pixmap
     PaintablePointer m_pPixmapBack;
 
-    QPixmap m_preLongPressPixmap;
-
     // short click toggle button long click push button
     ControlPushButton::ButtonMode m_leftButtonMode;
     ControlPushButton::ButtonMode m_rightButtonMode;
     QTimer m_clickTimer;
-    QTimer m_animTimer; // To animate long press latching
     QVector<int> m_align;
+
+    class LongPressLatching {
+      public:
+        LongPressLatching(WPushButton* pButton);
+        void paint(QPainter* p, int remainingTime);
+        void start();
+        void stop();
+
+      private:
+        WPushButton* m_pButton;
+        QPixmap m_preLongPressPixmap;
+        QTimer m_animTimer;
+    };
+
+    std::unique_ptr<LongPressLatching> m_pLongPressLatching;
 };

--- a/src/widget/wpushbutton.h
+++ b/src/widget/wpushbutton.h
@@ -112,6 +112,11 @@ class WPushButton : public WWidget {
     QTimer m_clickTimer;
     QVector<int> m_align;
 
+    // Animates long press latching by storing the off state of the
+    // WPushButton in a pixmap and gradually (from left to right)
+    // drawing less of the off state on top of the on state, to
+    // give a visual indication that the long press latching is in
+    // progress.
     class LongPressLatching {
       public:
         LongPressLatching(WPushButton* pButton);
@@ -125,5 +130,6 @@ class WPushButton : public WWidget {
         QTimer m_animTimer;
     };
 
+    // Only assigned for WPushButtons that use long press latching
     std::unique_ptr<LongPressLatching> m_pLongPressLatching;
 };


### PR DESCRIPTION
Animate long press latching (e.g. sync button) by capture the off-state in a pixmap and during the long press latch time, gradually draw less of it.


https://github.com/mixxxdj/mixxx/assets/79429057/788ee1f5-bb5c-4e2a-9ba1-884d1610accc

