### PR TITLE
Create files: Nowplaying + DeckStatus + AutoDJCenterXfader

### DIFF
--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -577,6 +577,7 @@ AutoDJProcessor::AutoDJError AutoDJProcessor::toggleAutoDJ(bool enable) {
         for (const auto& pDeck : std::as_const(m_decks)) {
             pDeck->disconnect(this);
         }
+        m_pCOCrossfader->set(0);
         emitAutoDJStateChanged(m_eState);
     }
     return ADJ_OK;

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -629,7 +629,6 @@ void BaseTrackPlayerImpl::slotTrackLoaded(TrackPointer pNewTrack,
     PlayerInfo::instance().setTrackInfo(getGroup(), m_pLoadedTrack);
     QString trackInfoArtist = " ";
     QString trackInfoTitle = " ";
-//    QString DeckStatusTime = " ";
     QString DeckStatusTxtLine2 = " ";
     QString DeckStatusTxtLine3 = " ";
     QString DeckStatusTxtLine4 = " ";
@@ -649,18 +648,14 @@ void BaseTrackPlayerImpl::slotTrackLoaded(TrackPointer pNewTrack,
     } else {
         DeckStatusTxtLine2 = "Artist : \" \",";
         DeckStatusTxtLine3 = "Title : \" \",";
-        //DeckStatusTxtLine4 = "Time : \" \",";
         DeckStatusTxtLine4 = "Time : \"" + DeckStatusTime + "\",";
     }
     QString trackInfoDeck = getGroup();
     trackInfoDeck.replace("[Channel", "");
     trackInfoDeck.replace("]", "");
-        // how to call m_settingsPath;
-    //QString DeckStatusFilePath = getenv("appdata");
     QString DeckStatusFilePath = m_pConfig->getSettingsPath();
     DeckStatusFilePath.replace("Roaming", "Local");
     DeckStatusFilePath.replace("\\", "/");
-    //QString DeckStatusFileLocation = DeckStatusFilePath + "/Mixxx/controllers/Status" + getGroup() + ".js";
     QString DeckStatusFileLocation = DeckStatusFilePath + "/controllers/Status" + getGroup() + ".js";
     //  Different file for each Deck / Sampler
     QString DeckStatusTxtLine1 = "var TrackDeck" + trackInfoDeck + " = { ";

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -622,11 +622,60 @@ void BaseTrackPlayerImpl::slotTrackLoaded(TrackPointer pNewTrack,
         qDebug() << "stray BaseTrackPlayerImpl::slotTrackLoaded()";
     }
 
-    m_pChannelToCloneFrom = nullptr;
+        m_pChannelToCloneFrom = nullptr;
 
     // Update the PlayerInfo class that is used in EngineBroadcast to replace
     // the metadata of a stream
     PlayerInfo::instance().setTrackInfo(getGroup(), m_pLoadedTrack);
+    QString trackInfoArtist = " ";
+    QString trackInfoTitle = " ";
+//    QString DeckStatusTime = " ";
+    QString DeckStatusTxtLine2 = " ";
+    QString DeckStatusTxtLine3 = " ";
+    QString DeckStatusTxtLine4 = " ";
+    QTime tempStatusTime = QTime::currentTime();
+    QString DeckStatusTime = tempStatusTime.toString("hh:mm:ss");
+     
+
+    if (pNewTrack) {
+        //    QString trackInfo = pNewTrack->getInfo();
+        trackInfoArtist = pNewTrack->getArtist();
+        trackInfoTitle = pNewTrack->getTitle();
+        trackInfoArtist.replace("\"", "''");
+        trackInfoTitle.replace("\"", "''");
+        DeckStatusTxtLine2 = "Artist : \"" + trackInfoArtist + "\",";
+        DeckStatusTxtLine3 = "Title : \"" + trackInfoTitle + "\",";
+        DeckStatusTxtLine4 = "Time : \"" + DeckStatusTime  + "\",";
+    } else {
+        DeckStatusTxtLine2 = "Artist : \" \",";
+        DeckStatusTxtLine3 = "Title : \" \",";
+        //DeckStatusTxtLine4 = "Time : \" \",";
+        DeckStatusTxtLine4 = "Time : \"" + DeckStatusTime + "\",";
+    }
+    QString trackInfoDeck = getGroup();
+    trackInfoDeck.replace("[Channel", "");
+    trackInfoDeck.replace("]", "");
+        // how to call m_settingsPath;
+    //QString DeckStatusFilePath = getenv("appdata");
+    QString DeckStatusFilePath = m_pConfig->getSettingsPath();
+    DeckStatusFilePath.replace("Roaming", "Local");
+    DeckStatusFilePath.replace("\\", "/");
+    //QString DeckStatusFileLocation = DeckStatusFilePath + "/Mixxx/controllers/Status" + getGroup() + ".js";
+    QString DeckStatusFileLocation = DeckStatusFilePath + "/controllers/Status" + getGroup() + ".js";
+    //  Different file for each Deck / Sampler
+    QString DeckStatusTxtLine1 = "var TrackDeck" + trackInfoDeck + " = { ";
+    QString DeckStatusTxtLine5 = "};";
+    QFile DeckStatusFile(DeckStatusFileLocation);
+    DeckStatusFile.remove();
+    DeckStatusFile.open(QIODevice::ReadWrite | QIODevice::Append);
+    // DeckStatusFile.open(QIODevice::ReadWrite | QIODevice::Append);
+    QTextStream DeckStatusTxt(&DeckStatusFile);
+    DeckStatusTxt << DeckStatusTxtLine1 << "\n";
+    DeckStatusTxt << DeckStatusTxtLine2 << "\n";
+    DeckStatusTxt << DeckStatusTxtLine3 << "\n";
+    DeckStatusTxt << DeckStatusTxtLine4 << "\n";
+    DeckStatusTxt << DeckStatusTxtLine5 << "\n";
+    DeckStatusFile.close();
 }
 
 TrackPointer BaseTrackPlayerImpl::getLoadedTrack() const {

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -685,10 +685,23 @@ void MixxxMainWindow::slotUpdateWindowTitle(TrackPointer pTrack) {
         QString trackInfo = pTrack->getInfo();
         if (!trackInfo.isEmpty()) {
             appTitle = QString("%1 | %2").arg(trackInfo, appTitle);
+            //          writing the artist & title of the playing track not only to the windowtitle but also to a file
+            //          location and name for nowplayingfile
+            QString StatusNowPlayingFilePath = m_pCoreServices->getSettings()->getSettingsPath();
+            QString StatusNowPlayingFileLocation = StatusNowPlayingFilePath + "/NowPlaying.txt";
+            QFile StatusNowPlayingFile(StatusNowPlayingFileLocation);
+            //          remove previous nowplayingfile
+            StatusNowPlayingFile.remove();
+            StatusNowPlayingFile.open(QIODevice::ReadWrite);
+            QTextStream StatusNowPlayingTxt(&StatusNowPlayingFile);
+            //          write Artist - Trackname to nowplayingfile
+            StatusNowPlayingTxt << QString("%1").arg(trackInfo) << "\n";
+            StatusNowPlayingFile.close();
         }
         filePath = pTrack->getLocation();
     }
     setWindowTitle(appTitle);
+
 
     // Display a draggable proxy icon for the track in the title bar on
     // platforms that support it, e.g. macOS


### PR DESCRIPTION
- create a nowplaying text file, can be used in other programs (lightmixer, homepage.... )

- create a "Status[Channelx], Status[Samplerx] .... when a track is loaded / ejected, in the file is written: artist / title/ time
 (statusfiles can be listed in controller.xml to display Artist/Title or in other programs (lightmixer, homepage.... ) 

- time can be used to have the controller activate the last manipulated deck, because Mixxx reloads on change of midi.js). Whith the time field you can stay on deck 3/4 after loading / ejecting a track.

- I also inserted the reset for the crossfader, for my own convenience ;-)