### PR TITLE
Added tooltip for expand/collapse samplers button.

### DIFF
--- a/res/skins/Deere/sampler_row.xml
+++ b/res/skins/Deere/sampler_row.xml
@@ -45,6 +45,7 @@
 
           <Template src="skin:hide_show_button.xml">
             <SetVariable name="object_name">SamplerRowExpandButton</SetVariable>
+            <SetVariable name="TooltipId">expand_samplers</SetVariable>
             <SetVariable name="control">[Skin],sampler_row_<Variable name="row"/>_expanded</SetVariable>
           </Template>
 

--- a/res/skins/LateNight/samplers/sampler_expand_button.xml
+++ b/res/skins/LateNight/samplers/sampler_expand_button.xml
@@ -9,7 +9,7 @@
         <Layout>stacked</Layout>
         <Children>
           <PushButton>
-            <TooltipId>show_samplers</TooltipId>
+            <TooltipId>expand_samplers</TooltipId>
             <ObjectName>SamplerExpandOverlay</ObjectName>
             <Size>16f,36me</Size>
             <NumberStates>2</NumberStates>

--- a/res/skins/Shade/samplerrow.xml
+++ b/res/skins/Shade/samplerrow.xml
@@ -31,7 +31,7 @@
 						<Layout>horizontal</Layout>
 						<Children>
 							<PushButton>
-								<TooltipId>show_samplers</TooltipId>
+								<TooltipId>expand_samplers</TooltipId>
 								<NumberStates>2</NumberStates>
 								<State>
 									<Number>0</Number>
@@ -158,7 +158,7 @@
 						<BackPath>style/style_bg_sampler_right.png</BackPath>
 						<Children>
 							<PushButton>
-								<TooltipId>show_samplers</TooltipId>
+								<TooltipId>expand_samplers</TooltipId>
 								<NumberStates>2</NumberStates>
 								<State>
 									<Number>0</Number>

--- a/res/skins/Tango/mic_aux_sampler/sampler_row.xml
+++ b/res/skins/Tango/mic_aux_sampler/sampler_row.xml
@@ -47,6 +47,7 @@ Variables:
               <WidgetGroup><Size>1min,3f</Size></WidgetGroup>
               <Template src="skins:Tango/controls/button_2state_persist.xml">
                 <SetVariable name="ObjectName">SamplersMiniMaxi</SetVariable>
+                <SetVariable name="TooltipId">expand_samplers</SetVariable>
                 <SetVariable name="Size">20f,30me</SetVariable>
                 <SetVariable name="ConfigKey">[Skin],sampler_row_<Variable name="row"/>_expanded</SetVariable>
               </Template>

--- a/src/skin/legacy/tooltips.cpp
+++ b/src/skin/legacy/tooltips.cpp
@@ -664,6 +664,10 @@ void Tooltips::addStandardTooltips() {
             << tr("Record Mix")
             << tr("Toggle mix recording.");
 
+    add("expand_samplers")
+            << tr("Expand/Collapse Samplers")
+            << tr("Toggle expanded samplers view.");
+
     // Status displays and toggle buttons
     add("recording_duration")
             << tr("Recording Duration")


### PR DESCRIPTION
 Resolves #12998.
 I added tooltip for the expand/collapse samplers buttons.
The tooltip used is as follows:

**Expand/Collapse Samplers**
**Toggle expanded samplers view.**

I have tested the same for all the skins available. 
Kindly review.

Here are the screenshots taken in different skins -
![Screenshot from 2024-03-27 13-07-03](https://github.com/mixxxdj/mixxx/assets/44440524/3cf234c9-d7a9-498d-aba9-72c29d80444d)
![Screenshot from 2024-03-27 13-08-25](https://github.com/mixxxdj/mixxx/assets/44440524/2ade750b-ce3b-496e-bec6-affc09808dbf)

 
![Screenshot from 2024-03-27 13-08-51](https://github.com/mixxxdj/mixxx/assets/44440524/3e27a425-fbf5-4f7b-94e2-5718183ad389)
![Screenshot from 2024-03-27 13-09-18](https://github.com/mixxxdj/mixxx/assets/44440524/34c73404-c8a6-421b-a714-8806ce8d1c25)
