### PR TITLE
(fix) Waveform scratch crossing loop boundaries

### DIFF
--- a/src/engine/controls/ratecontrol.cpp
+++ b/src/engine/controls/ratecontrol.cpp
@@ -441,10 +441,10 @@ double RateControl::calculateSpeed(double baserate, double speed, bool paused,
                 // The buffer is playing, so calculate the buffer rate.
 
                 // There are four rate effects we apply: wheel, scratch, jog and temp.
-                // Wheel: a linear additive effect (no spring-back)
+                // Wheel:   a linear additive effect (no spring-back)
                 // Scratch: a rate multiplier
-                // Jog: a linear additive effect whose value is filtered (springs back)
-                // Temp: pitch bend
+                // Jog:     a linear additive effect whose value is filtered (springs back)
+                // Temp:    pitch bend
 
                 // New scratch behavior - overrides playback speed (and old behavior)
                 if (useScratch2Value) {

--- a/src/engine/controls/ratecontrol.h
+++ b/src/engine/controls/ratecontrol.h
@@ -71,6 +71,11 @@ public:
   static void setRateRampSensitivity(int);
   static int getRateRampSensitivity();
   bool isReverseButtonPressed();
+  // ReadAheadManager::getNextSamples() notifies us each time the play position
+  // wrapped around during one buffer process (beatloop or track repeat) so
+  // PositionScratchController can correctly interpret the sample position delta.
+  void notifyWrapAround(mixxx::audio::FramePos triggerPos,
+          mixxx::audio::FramePos targetPos);
 
 public slots:
   void slotRateRangeChanged(double);
@@ -146,6 +151,10 @@ private:
 
   ControlProxy* m_pSyncMode;
   ControlProxy* m_pSlipEnabled;
+
+  int m_wrapAroundCount;
+  mixxx::audio::FramePos m_jumpPos;
+  mixxx::audio::FramePos m_targetPos;
 
   // This is true if we've already started to ramp the rate
   bool m_bTempStarted;

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -843,9 +843,9 @@ void EngineBuffer::processTrackLocked(
     m_trackSampleRateOld = mixxx::audio::SampleRate::fromDouble(m_pTrackSampleRate->get());
     m_trackEndPositionOld = getTrackEndPosition();
 
-    double baserate = 0.0;
+    double baseSampleRate = 0.0;
     if (sampleRate.isValid()) {
-        baserate = m_trackSampleRateOld / sampleRate;
+        baseSampleRate = m_trackSampleRateOld / sampleRate;
     }
 
     // Sync requests can affect rate, so process those first.
@@ -875,7 +875,7 @@ void EngineBuffer::processTrackLocked(
     // pass for every 1 real second). Depending on whether
     // keylock is enabled, this is applied to either the rate or the tempo.
     double speed = m_pRateControl->calculateSpeed(
-            baserate,
+            baseSampleRate,
             tempoRatio,
             paused,
             iBufferSize,
@@ -980,10 +980,10 @@ void EngineBuffer::processTrackLocked(
     // otherwise tempo and pitch are processed individual
 
     double rate = 0;
-    // If the baserate, speed, or pitch has changed, we need to update the
+    // If the base samplerate, speed, or pitch has changed, we need to update the
     // scaler. Also, if we have changed scalers then we need to update the
     // scaler.
-    if (baserate != m_baserate_old || speed != m_speed_old ||
+    if (baseSampleRate != m_baserate_old || speed != m_speed_old ||
             pitchRatio != m_pitch_old || tempoRatio != m_tempo_ratio_old ||
             m_bScalerChanged) {
         // The rate returned by the scale object can be different from the
@@ -1005,7 +1005,7 @@ void EngineBuffer::processTrackLocked(
             m_pScale->clear();
         }
 
-        m_baserate_old = baserate;
+        m_baserate_old = baseSampleRate;
         m_speed_old = speed;
         m_pitch_old = pitchRatio;
         m_tempo_ratio_old = tempoRatio;
@@ -1016,16 +1016,16 @@ void EngineBuffer::processTrackLocked(
         // main samplerate), the deck speed, the pitch shift, and whether
         // the deck speed should affect the pitch.
 
-        m_pScale->setScaleParameters(baserate,
-                                     &speed,
-                                     &pitchRatio);
+        m_pScale->setScaleParameters(baseSampleRate,
+                &speed,
+                &pitchRatio);
 
         // The way we treat rate inside of EngineBuffer is actually a
         // description of "sample consumption rate" or percentage of samples
         // consumed relative to playing back the track at its native sample
         // rate and normal speed. pitch_adjust does not change the playback
         // rate.
-        rate = baserate * speed;
+        rate = baseSampleRate * speed;
 
         // Scaler is up to date now.
         m_bScalerChanged = false;

--- a/src/engine/positionscratchcontroller.h
+++ b/src/engine/positionscratchcontroller.h
@@ -6,8 +6,8 @@
 #include "audio/frame.h"
 
 class ControlObject;
-class VelocityController;
 class RateIIFilter;
+class VelocityController;
 
 class PositionScratchController : public QObject {
     Q_OBJECT
@@ -15,8 +15,7 @@ class PositionScratchController : public QObject {
     PositionScratchController(const QString& group);
     virtual ~PositionScratchController();
 
-    void process(double currentSample, double releaseRate,
-                 int iBufferSize, double baserate);
+    void process(double currentSample, double releaseRate, int iBufferSize, double baseSampleRate);
     bool isEnabled();
     double getRate();
     void notifySeek(mixxx::audio::FramePos position);
@@ -24,17 +23,17 @@ class PositionScratchController : public QObject {
   private:
     const QString m_group;
     ControlObject* m_pScratchEnable;
-    ControlObject* m_pScratchPosition;
+    ControlObject* m_pScratchPos;
     ControlObject* m_pMainSampleRate;
     VelocityController* m_pVelocityController;
     RateIIFilter* m_pRateIIFilter;
-    bool m_bScratching;
-    bool m_bEnableInertia;
-    double m_dLastPlaypos;
-    double m_dPositionDeltaSum;
-    double m_dTargetDelta;
-    double m_dStartScratchPosition;
-    double m_dRate;
-    double m_dMoveDelay;
-    double m_dMouseSampeTime;
+    bool m_isScratching;
+    bool m_inertiaEnabled;
+    double m_prevSamplePos;
+    double m_samplePosDeltaSum;
+    double m_scratchTargetDelta;
+    double m_scratchStartPos;
+    double m_rate;
+    double m_moveDelay;
+    double m_mouseSampleTime;
 };

--- a/src/engine/positionscratchcontroller.h
+++ b/src/engine/positionscratchcontroller.h
@@ -15,7 +15,13 @@ class PositionScratchController : public QObject {
     PositionScratchController(const QString& group);
     virtual ~PositionScratchController();
 
-    void process(double currentSample, double releaseRate, int iBufferSize, double baseSampleRate);
+    void process(double currentSample,
+            double releaseRate,
+            int iBufferSize,
+            double baseSampleRate,
+            int wrappedAround,
+            mixxx::audio::FramePos trigger,
+            mixxx::audio::FramePos target);
     bool isEnabled();
     double getRate();
     void notifySeek(mixxx::audio::FramePos position);

--- a/src/engine/readaheadmanager.cpp
+++ b/src/engine/readaheadmanager.cpp
@@ -117,6 +117,10 @@ SINT ReadAheadManager::getNextSamples(double dRate, CSAMPLE* pOutput,
     // Activate on this trigger if necessary
     if (reachedTrigger) {
         DEBUG_ASSERT(target != kNoTrigger);
+        if (m_pRateControl) {
+            m_pRateControl->notifyWrapAround(loopTriggerPosition, targetPosition);
+        }
+        // TODO probably also useful for hotcue_X_indicator in CueControl::updateIndicators()
 
         // Jump to other end of loop or track.
         m_currentPosition = target;


### PR DESCRIPTION
Previously, scratching with the waveform and crossing loop boundaries at slow rates caused an infinite wrap-around 'loop' even after the mouse was stopped (while still pressed).
Probably affects Spinny scratching, too, but I didn't test it.

PositionScratchController::process() now knows if the play position was wrapped around and calculates the true sample distance travelled.
_I notice this would also be helpful for and probably simplify #12951 hotcue_X_indicator control_

TL;DR
PositionScratchController didn't know the play position was wrapped around, so it
interpreted the raw (huge) sample delta as play pos move and calculated a huge rate, which was
then applied by the engine, resulting in a (true) long sample distance in the next run,
which caused another loop wrap-around, and so on...