### PR TITLE
Reduce log noise with HID device

### DIFF
--- a/src/controllers/hid/hidiooutputreport.cpp
+++ b/src/controllers/hid/hidiooutputreport.cpp
@@ -2,6 +2,7 @@
 
 #include <hidapi.h>
 
+#include "util/cmdlineargs.h"
 #include "util/compatibility/qbytearray.h"
 #include "util/runtimeloggingcategory.h"
 #include "util/string.h"
@@ -34,7 +35,9 @@ void HidIoOutputReport::updateCachedData(const QByteArray& data,
         m_lastCachedDataSize = data.size();
 
     } else {
-        if (m_possiblyUnsentDataCached && !useNonSkippingFIFO) {
+        if (CmdlineArgs::Instance()
+                        .getControllerDebug() &&
+                m_possiblyUnsentDataCached && !useNonSkippingFIFO) {
             qCDebug(logOutput) << "t:" << mixxx::Time::elapsed().formatMillisWithUnit()
                                << "skipped superseded OutputReport data for ReportID"
                                << m_reportId;
@@ -95,9 +98,13 @@ bool HidIoOutputReport::sendCachedData(QMutex* pHidDeviceAndPollMutex,
 
         cacheLock.unlock();
 
-        qCDebug(logOutput) << "t:" << startOfHidWrite.formatMillisWithUnit()
-                           << "Skipped sending identical OutputReport data from cache for ReportID"
-                           << m_reportId;
+        if (CmdlineArgs::Instance()
+                        .getControllerDebug()) {
+            qCDebug(logOutput) << "t:" << startOfHidWrite.formatMillisWithUnit()
+                               << "Skipped sending identical OutputReport data "
+                                  "from cache for ReportID"
+                               << m_reportId;
+        }
 
         // Return with false, to signal the caller, that no time consuming IO operation was necessary
         return false;
@@ -144,11 +151,14 @@ bool HidIoOutputReport::sendCachedData(QMutex* pHidDeviceAndPollMutex,
         return true;
     }
 
-    qCDebug(logOutput) << "t:" << startOfHidWrite.formatMillisWithUnit() << " "
-                       << result << "bytes ( including ReportID of"
-                       << static_cast<quint8>(m_reportId)
-                       << ") sent from skipping cache - Needed:"
-                       << (mixxx::Time::elapsed() - startOfHidWrite).formatMicrosWithUnit();
+    if (CmdlineArgs::Instance()
+                    .getControllerDebug()) {
+        qCDebug(logOutput) << "t:" << startOfHidWrite.formatMillisWithUnit() << " "
+                           << result << "bytes ( including ReportID of"
+                           << static_cast<quint8>(m_reportId)
+                           << ") sent from skipping cache - Needed:"
+                           << (mixxx::Time::elapsed() - startOfHidWrite).formatMicrosWithUnit();
+    }
 
     // Return with true, to signal the caller, that the time consuming hid_write operation was executed
     return true;


### PR DESCRIPTION
Currently, when running in `--log-level debug`, logs can be unusable due to the amount of messages related to received HID packets. 

This PR makes these logging messages only if `--controller-debug` is set