### PR TITLE
iTunes/Serato/Traktor/Rhythmbox: Print error if library file could not be opened

### DIFF
--- a/src/library/itunes/itunesxmlimporter.cpp
+++ b/src/library/itunes/itunesxmlimporter.cpp
@@ -66,7 +66,8 @@ ITunesImport ITunesXMLImporter::importLibrary() {
     bool isMusicFolderLocatedAfterTracks = false;
 
     if (!m_xmlFile.open(QIODevice::ReadOnly)) {
-        qWarning() << "Could not open iTunes music collection XML at " << m_xmlFilePath;
+        qWarning() << "Could not open iTunes music collection XML at " << m_xmlFilePath
+                   << ":" << m_xmlFile.errorString();
         return iTunesImport;
     }
 

--- a/src/library/rhythmbox/rhythmboxfeature.cpp
+++ b/src/library/rhythmbox/rhythmboxfeature.cpp
@@ -164,6 +164,7 @@ TreeItem* RhythmboxFeature::importMusicCollection() {
     mixxx::FileInfo fileInfo(db);
     if (!Sandbox::askForAccess(&fileInfo) ||
             !db.open(QIODevice::ReadOnly)) {
+        qWarning() << "Could not open Rhythmbox db at" << db.fileName() << db.errorString();
         return nullptr;
     }
 

--- a/src/library/serato/seratofeature.cpp
+++ b/src/library/serato/seratofeature.cpp
@@ -348,7 +348,8 @@ QString parseCrate(
     if (!Sandbox::askForAccess(&fileInfo) || !crateFile.open(QIODevice::ReadOnly)) {
         qWarning() << "Failed to open file "
                    << crateFilePath
-                   << " for reading.";
+                   << " for reading:"
+                   << crateFile.errorString();
         return QString();
     }
 

--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -224,7 +224,7 @@ TreeItem* TraktorFeature::importLibrary(const QString& file) {
     mixxx::FileInfo fileInfo(file);
     QFile traktor_file(file);
     if (!Sandbox::askForAccess(&fileInfo) || !traktor_file.open(QIODevice::ReadOnly)) {
-        qDebug() << "Cannot open Traktor music collection";
+        qDebug() << "Cannot open Traktor music collection: " << traktor_file.errorString();
         return nullptr;
     }
     QXmlStreamReader xml(&traktor_file);


### PR DESCRIPTION
Just a minor improvement of the error message to aid debugging.