### PR TITLE
iTunes: Obtain FileAccess before accessing iTunes XML

### DIFF
--- a/src/library/itunes/itunesfeature.cpp
+++ b/src/library/itunes/itunesfeature.cpp
@@ -369,8 +369,7 @@ void ITunesFeature::onTrackCollectionLoaded() {
         QMessageBox::warning(
                 nullptr,
                 tr("Error Loading iTunes Library"),
-                tr("There was an error loading your iTunes library. Some of "
-                   "your iTunes tracks or playlists may not have loaded."));
+                tr("There was an error loading your iTunes library. Check the logs for details."));
     }
     // calls a slot in the sidebarmodel such that 'isLoading' is removed from the feature title.
     m_title = tr("iTunes");

--- a/src/library/itunes/itunesxmlimporter.cpp
+++ b/src/library/itunes/itunesxmlimporter.cpp
@@ -11,6 +11,8 @@
 #include "library/itunes/itunesimporter.h"
 #include "library/itunes/ituneslocalhosttoken.h"
 #include "library/treeitem.h"
+#include "util/fileaccess.h"
+#include "util/fileinfo.h"
 #include "util/lcs.h"
 
 namespace {
@@ -64,6 +66,9 @@ ITunesImport ITunesXMLImporter::importLibrary() {
 
     ITunesImport iTunesImport;
     bool isMusicFolderLocatedAfterTracks = false;
+
+    // In sandboxed builds we have to obtain an access token
+    auto access = mixxx::FileAccess(mixxx::FileInfo(m_xmlFilePath));
 
     if (!m_xmlFile.open(QIODevice::ReadOnly)) {
         qWarning() << "Could not open iTunes music collection XML at " << m_xmlFilePath


### PR DESCRIPTION
This fixes an issue where opening an iTunes XML outside sandboxed directories would error in App Sandbox-enabled macOS builds, triggering the following dialog:

![Screenshot 2024-03-27 at 23 33 34](https://github.com/mixxxdj/mixxx/assets/30873659/c68dcaac-e70d-44f8-9e32-0a4813f3d1a4)

#13012 reveals that the error in this case is "Operation not permitted". Obtaining a `mixxx::FileAccess` fixes the issue.