### PR TITLE
feat: Add CLI option to auto start Auto DJ

### DIFF
--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -398,6 +398,12 @@ void MixxxMainWindow::initialize() {
             &PlayerInfo::currentPlayingTrackChanged,
             this,
             &MixxxMainWindow::slotUpdateWindowTitle);
+
+    // Start Auto DJ if the cmdline arg is passed.
+    if (CmdlineArgs::Instance().getStartAutoDJ()) {
+        qDebug("Enabling Auto DJ from CLI flag.");
+        ControlObject::set(ConfigKey("[AutoDJ]", "enabled"), 1.0);
+    }
 }
 
 MixxxMainWindow::~MixxxMainWindow() {

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -20,6 +20,7 @@
 
 CmdlineArgs::CmdlineArgs()
         : m_startInFullscreen(false), // Initialize vars
+          m_startAutoDJ(false),
           m_controllerDebug(false),
           m_controllerAbortOnWarning(false),
           m_developer(false),
@@ -148,6 +149,12 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
                             : QString(),
             QStringLiteral("locale"));
     parser.addOption(locale);
+
+    const QCommandLineOption startAutoDJ(QStringLiteral("start-autodj"),
+            forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
+                                      "Starts Auto DJ when Mixxx is launched.")
+                            : QString());
+    parser.addOption(startAutoDJ);
 
     // An option with a value
     const QCommandLineOption settingsPath(QStringLiteral("settings-path"),
@@ -341,6 +348,10 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
 
     if (parser.isSet(locale)) {
         m_locale = parser.value(locale);
+    }
+
+    if (parser.isSet(startAutoDJ)) {
+        m_startAutoDJ = true;
     }
 
     if (parser.isSet(settingsPath)) {

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -30,6 +30,9 @@ class CmdlineArgs final {
 
     const QList<QString>& getMusicFiles() const { return m_musicFiles; }
     bool getStartInFullscreen() const { return m_startInFullscreen; }
+    bool getStartAutoDJ() const {
+        return m_startAutoDJ;
+    }
     bool getControllerDebug() const {
         return m_controllerDebug;
     }
@@ -82,6 +85,7 @@ class CmdlineArgs final {
 
     QList<QString> m_musicFiles;    // List of files to load into players at startup
     bool m_startInFullscreen;       // Start in fullscreen mode
+    bool m_startAutoDJ;
     bool m_controllerDebug;
     bool m_controllerAbortOnWarning; // Controller Engine will be stricter
     bool m_developer; // Developer Mode


### PR DESCRIPTION
This PR resolves #10189.

The CLI flag `--start-autodj` was added. When this flag is set, Mixxx enables Auto DJ mode on startup.