### PR TITLE
Remove optimization mode "legacy" for 2.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,8 +307,8 @@ endif()
 # Optimizations
 #
 
-set(OPTIMIZE "portable" CACHE STRING "Optimization and Tuning (set to off, portable, native, legacy)")
-set_property(CACHE OPTIMIZE PROPERTY STRINGS "off" "portable" "native" "legacy")
+set(OPTIMIZE "portable" CACHE STRING "Optimization and Tuning (set to off, portable, native)")
+set_property(CACHE OPTIMIZE PROPERTY STRINGS "off" "portable" "native")
 string(TOLOWER "${OPTIMIZE}" OPTIMIZE)
 message(STATUS "Optimization level: ${OPTIMIZE}")
 
@@ -423,12 +423,6 @@ if(MSVC)
       # add_compile_options(/arch:AVX512)
       message(FATAL_ERROR "User need to set the MSVC compiler flags for the native processor here!")
       add_compile_options("/favor:${CMAKE_SYSTEM_PROCESSOR}")
-    elseif(OPTIMIZE STREQUAL "legacy")
-      if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-        message("Enabling pure x64 instruction set (without AVX etc.)")
-      else()
-        message("Enabling pure i386 instruction set (without SSE/SSE2 etc.)")
-      endif()
     else()
       message(FATAL_ERROR "Invalid value passed to OPTIMIZE option: ${OPTIMIZE}")
     endif()
@@ -531,13 +525,6 @@ elseif(GNU_GCC OR LLVM_CLANG)
           -mfloat-abi=hard
           -mfpu=neon
         )
-      endif()
-    elseif(OPTIMIZE STREQUAL "legacy")
-      if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(i[3456]86|x86|x64|x86_64|AMD64)$")
-        message("Enabling pure i386 code")
-        add_compile_options(-mtune=generic)
-        # -mtune=generic pick the most common, but compatible options.
-        # on arm platforms equivalent to -march=arch
       endif()
     else()
       message(FATAL_ERROR "Invalid value passed to OPTIMIZE option: ${OPTIMIZE}")

--- a/tools/windows_buildenv.bat
+++ b/tools/windows_buildenv.bat
@@ -183,7 +183,6 @@ REM Generate CMakeSettings.json which is read by MS Visual Studio to determine t
     IF NOT DEFINED BUILDENV_RELEASE (
         CALL :Configuration2CMakeSettings_JSON off       Debug
     )
-    CALL :Configuration2CMakeSettings_JSON legacy    RelWithDebInfo
     CALL :Configuration2CMakeSettings_JSON portable  RelWithDebInfo
     SET configElementTermination=
     CALL :Configuration2CMakeSettings_JSON native    Release


### PR DESCRIPTION
With the switch to Qt6, we raise the system requirment a lot: https://doc.qt.io/qt-6.2/supported-platforms.html#desktop-platforms Support for i386 legacy instruction set makes no sense anymore and on Windows it did nothing than printing a message anyway.