### PR TITLE
adding controls for BPM operations (so we can create shortcuts)

### DIFF
--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -257,27 +257,27 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
             tr("Multiply the BPM by 1/2"),
             tr("Multiply the BPM by 1/2"),
             pBpmMenu);
-    
+
     addDeckAndSamplerControl("beats_adjust_2_3",
             tr("Multiply the BPM by 2/3"),
             tr("Multiply the BPM by 2/3"),
             pBpmMenu);
-    
+
     addDeckAndSamplerControl("beats_adjust_3_4",
             tr("Multiply the BPM by 3/4"),
             tr("Multiply the BPM by 3/4"),
             pBpmMenu);
-    
+
     addDeckAndSamplerControl("beats_adjust_4_3",
             tr("Multiply the BPM by 4/3"),
             tr("Multiply the BPM by 4/3"),
             pBpmMenu);
-    
+
     addDeckAndSamplerControl("beats_adjust_3_2",
             tr("Multiply the BPM by 3/2"),
             tr("Multiply the BPM by 3/2"),
             pBpmMenu);
-    
+
     addDeckAndSamplerControl("beats_adjust_2_1",
             tr("Multiply the BPM by 2"),
             tr("Multiply the BPM by 2"),

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -252,6 +252,37 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
             tr("Adjust Beatgrid Slower -.01"),
             tr("Decrease track's average BPM by 0.01"),
             pBpmMenu);
+
+    addDeckAndSamplerControl("beats_adjust_1_2",
+            tr("Multiply the BPM by 1/2"),
+            tr("Multiply the BPM by 1/2"),
+            pBpmMenu);
+    
+    addDeckAndSamplerControl("beats_adjust_2_3",
+            tr("Multiply the BPM by 2/3"),
+            tr("Multiply the BPM by 2/3"),
+            pBpmMenu);
+    
+    addDeckAndSamplerControl("beats_adjust_3_4",
+            tr("Multiply the BPM by 3/4"),
+            tr("Multiply the BPM by 3/4"),
+            pBpmMenu);
+    
+    addDeckAndSamplerControl("beats_adjust_4_3",
+            tr("Multiply the BPM by 4/3"),
+            tr("Multiply the BPM by 4/3"),
+            pBpmMenu);
+    
+    addDeckAndSamplerControl("beats_adjust_3_2",
+            tr("Multiply the BPM by 3/2"),
+            tr("Multiply the BPM by 3/2"),
+            pBpmMenu);
+    
+    addDeckAndSamplerControl("beats_adjust_2_1",
+            tr("Multiply the BPM by 2"),
+            tr("Multiply the BPM by 2"),
+            pBpmMenu);
+
     addDeckAndSamplerControl("beats_translate_earlier",
             tr("Move Beatgrid Earlier"),
             tr("Adjust the beatgrid to the left"),

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -54,8 +54,7 @@ BpmControl::BpmControl(const QString& group,
     m_pPlayButton = new ControlProxy(group, "play", this);
     m_pReverseButton = new ControlProxy(group, "reverse", this);
     m_pRateRatio = new ControlProxy(group, "rate_ratio", this);
-    m_pRateRatio->connectValueChanged(this, &BpmControl::slotUpdateEngineBpm,
-                                      Qt::DirectConnection);
+    m_pRateRatio->connectValueChanged(this, &BpmControl::slotUpdateEngineBpm, Qt::DirectConnection);
 
     m_pQuantize = ControlObject::getControl(group, "quantize");
 
@@ -69,63 +68,41 @@ BpmControl::BpmControl(const QString& group,
     m_pLocalBpm = new ControlObject(ConfigKey(group, "local_bpm"));
     m_pAdjustBeatsFaster = new ControlPushButton(ConfigKey(group, "beats_adjust_faster"), false);
     m_pAdjustBeatsFaster->setKbdRepeatable(true);
-    connect(m_pAdjustBeatsFaster, &ControlObject::valueChanged,
-            this, &BpmControl::slotAdjustBeatsFaster,
-            Qt::DirectConnection);
+    connect(m_pAdjustBeatsFaster, &ControlObject::valueChanged, this, &BpmControl::slotAdjustBeatsFaster, Qt::DirectConnection);
     m_pAdjustBeatsSlower = new ControlPushButton(ConfigKey(group, "beats_adjust_slower"), false);
     m_pAdjustBeatsSlower->setKbdRepeatable(true);
-    connect(m_pAdjustBeatsSlower, &ControlObject::valueChanged,
-            this, &BpmControl::slotAdjustBeatsSlower,
-            Qt::DirectConnection);
+    connect(m_pAdjustBeatsSlower, &ControlObject::valueChanged, this, &BpmControl::slotAdjustBeatsSlower, Qt::DirectConnection);
 
     m_pAdjustBeats_1_2 = new ControlPushButton(ConfigKey(group, "beats_adjust_1_2"), false);
     m_pAdjustBeats_1_2->setKbdRepeatable(true);
-    connect(m_pAdjustBeats_1_2, &ControlObject::valueChanged,
-            this, &BpmControl::slotAdjustBeats_1_2,
-            Qt::DirectConnection);
+    connect(m_pAdjustBeats_1_2, &ControlObject::valueChanged, this, &BpmControl::slotAdjustBeats_1_2, Qt::DirectConnection);
 
     m_pAdjustBeats_2_3 = new ControlPushButton(ConfigKey(group, "beats_adjust_2_3"), false);
     m_pAdjustBeats_2_3->setKbdRepeatable(true);
-    connect(m_pAdjustBeats_2_3, &ControlObject::valueChanged,
-            this, &BpmControl::slotAdjustBeats_2_3,
-            Qt::DirectConnection);
+    connect(m_pAdjustBeats_2_3, &ControlObject::valueChanged, this, &BpmControl::slotAdjustBeats_2_3, Qt::DirectConnection);
 
     m_pAdjustBeats_3_4 = new ControlPushButton(ConfigKey(group, "beats_adjust_3_4"), false);
     m_pAdjustBeats_3_4->setKbdRepeatable(true);
-    connect(m_pAdjustBeats_3_4, &ControlObject::valueChanged,
-            this, &BpmControl::slotAdjustBeats_3_4,
-            Qt::DirectConnection);            
+    connect(m_pAdjustBeats_3_4, &ControlObject::valueChanged, this, &BpmControl::slotAdjustBeats_3_4, Qt::DirectConnection);
 
     m_pAdjustBeats_4_3 = new ControlPushButton(ConfigKey(group, "beats_adjust_4_3"), false);
     m_pAdjustBeats_4_3->setKbdRepeatable(true);
-    connect(m_pAdjustBeats_4_3, &ControlObject::valueChanged,
-            this, &BpmControl::slotAdjustBeats_4_3,
-            Qt::DirectConnection);
+    connect(m_pAdjustBeats_4_3, &ControlObject::valueChanged, this, &BpmControl::slotAdjustBeats_4_3, Qt::DirectConnection);
 
     m_pAdjustBeats_3_2 = new ControlPushButton(ConfigKey(group, "beats_adjust_3_2"), false);
     m_pAdjustBeats_3_2->setKbdRepeatable(true);
-    connect(m_pAdjustBeats_3_2, &ControlObject::valueChanged,
-            this, &BpmControl::slotAdjustBeats_3_2,
-            Qt::DirectConnection);
+    connect(m_pAdjustBeats_3_2, &ControlObject::valueChanged, this, &BpmControl::slotAdjustBeats_3_2, Qt::DirectConnection);
 
     m_pAdjustBeats_2_1 = new ControlPushButton(ConfigKey(group, "beats_adjust_2_1"), false);
     m_pAdjustBeats_2_1->setKbdRepeatable(true);
-    connect(m_pAdjustBeats_2_1, &ControlObject::valueChanged,
-            this, &BpmControl::slotAdjustBeats_2_1,
-            Qt::DirectConnection);
-
-
+    connect(m_pAdjustBeats_2_1, &ControlObject::valueChanged, this, &BpmControl::slotAdjustBeats_2_1, Qt::DirectConnection);
 
     m_pTranslateBeatsEarlier = new ControlPushButton(ConfigKey(group, "beats_translate_earlier"), false);
     m_pTranslateBeatsEarlier->setKbdRepeatable(true);
-    connect(m_pTranslateBeatsEarlier, &ControlObject::valueChanged,
-            this, &BpmControl::slotTranslateBeatsEarlier,
-            Qt::DirectConnection);
+    connect(m_pTranslateBeatsEarlier, &ControlObject::valueChanged, this, &BpmControl::slotTranslateBeatsEarlier, Qt::DirectConnection);
     m_pTranslateBeatsLater = new ControlPushButton(ConfigKey(group, "beats_translate_later"), false);
     m_pTranslateBeatsLater->setKbdRepeatable(true);
-    connect(m_pTranslateBeatsLater, &ControlObject::valueChanged,
-            this, &BpmControl::slotTranslateBeatsLater,
-            Qt::DirectConnection);
+    connect(m_pTranslateBeatsLater, &ControlObject::valueChanged, this, &BpmControl::slotTranslateBeatsLater, Qt::DirectConnection);
     m_pTranslateBeatsMove = new ControlEncoder(ConfigKey(group, "beats_translate_move"), false);
     connect(m_pTranslateBeatsMove,
             &ControlObject::valueChanged,
@@ -146,28 +123,18 @@ BpmControl::BpmControl(const QString& group,
             kBpmRangeSmallStep,
             true);
     m_pEngineBpm->set(0.0);
-    connect(m_pEngineBpm, &ControlObject::valueChanged,
-            this, &BpmControl::slotUpdateRateSlider,
-            Qt::DirectConnection);
+    connect(m_pEngineBpm, &ControlObject::valueChanged, this, &BpmControl::slotUpdateRateSlider, Qt::DirectConnection);
 
     m_pButtonTap = new ControlPushButton(ConfigKey(group, "bpm_tap"));
-    connect(m_pButtonTap, &ControlObject::valueChanged,
-            this, &BpmControl::slotBpmTap,
-            Qt::DirectConnection);
+    connect(m_pButtonTap, &ControlObject::valueChanged, this, &BpmControl::slotBpmTap, Qt::DirectConnection);
 
     m_pTranslateBeats = new ControlPushButton(ConfigKey(group, "beats_translate_curpos"));
-    connect(m_pTranslateBeats, &ControlObject::valueChanged,
-            this, &BpmControl::slotBeatsTranslate,
-            Qt::DirectConnection);
+    connect(m_pTranslateBeats, &ControlObject::valueChanged, this, &BpmControl::slotBeatsTranslate, Qt::DirectConnection);
 
     m_pBeatsTranslateMatchAlignment = new ControlPushButton(ConfigKey(group, "beats_translate_match_alignment"));
-    connect(m_pBeatsTranslateMatchAlignment, &ControlObject::valueChanged,
-            this, &BpmControl::slotBeatsTranslateMatchAlignment,
-            Qt::DirectConnection);
+    connect(m_pBeatsTranslateMatchAlignment, &ControlObject::valueChanged, this, &BpmControl::slotBeatsTranslateMatchAlignment, Qt::DirectConnection);
 
-    connect(&m_tapFilter, &TapFilter::tapped,
-            this, &BpmControl::slotTapFilter,
-            Qt::DirectConnection);
+    connect(&m_tapFilter, &TapFilter::tapped, this, &BpmControl::slotTapFilter, Qt::DirectConnection);
 
     // Measures distance from last beat in percentage: 0.5 = half-beat away.
     m_pThisBeatDistance = new ControlProxy(group, "beat_distance", this);
@@ -190,7 +157,7 @@ BpmControl::~BpmControl() {
     delete m_pAdjustBeats_3_4;
     delete m_pAdjustBeats_4_3;
     delete m_pAdjustBeats_3_2;
-    delete m_pAdjustBeats_2_1;   
+    delete m_pAdjustBeats_2_1;
 }
 
 mixxx::Bpm BpmControl::getBpm() const {
@@ -231,7 +198,7 @@ void BpmControl::adjustBeatsBpmRatio(double deltaBpmRatio) {
     }
     const mixxx::Bpm bpm = pBeats->getBpmInRange(
             mixxx::audio::kStartFramePos, frameInfo().trackEndPosition);
-    adjustBeatsBpm(deltaBpmRatio*bpm.value());
+    adjustBeatsBpm(deltaBpmRatio * bpm.value());
 }
 
 void BpmControl::slotAdjustBeatsFaster(double v) {
@@ -252,44 +219,43 @@ void BpmControl::slotAdjustBeats_1_2(double v) {
     if (v <= 0) {
         return;
     }
-    adjustBeatsBpmRatio(1./2.-1.);
+    adjustBeatsBpmRatio(1. / 2. - 1.);
 }
 
 void BpmControl::slotAdjustBeats_2_3(double v) {
     if (v <= 0) {
         return;
     }
-    adjustBeatsBpmRatio(2./3.-1.);
+    adjustBeatsBpmRatio(2. / 3. - 1.);
 }
 
 void BpmControl::slotAdjustBeats_3_4(double v) {
     if (v <= 0) {
         return;
     }
-    adjustBeatsBpmRatio(3./4.-1.);
+    adjustBeatsBpmRatio(3. / 4. - 1.);
 }
 
 void BpmControl::slotAdjustBeats_4_3(double v) {
     if (v <= 0) {
         return;
     }
-    adjustBeatsBpmRatio(4./3.-1.);
+    adjustBeatsBpmRatio(4. / 3. - 1.);
 }
 
 void BpmControl::slotAdjustBeats_3_2(double v) {
     if (v <= 0) {
         return;
     }
-    adjustBeatsBpmRatio(3./2.-1.);
+    adjustBeatsBpmRatio(3. / 2. - 1.);
 }
 
 void BpmControl::slotAdjustBeats_2_1(double v) {
     if (v <= 0) {
         return;
     }
-    adjustBeatsBpmRatio(2./1.-1.);
+    adjustBeatsBpmRatio(2. / 1. - 1.);
 }
-
 
 void BpmControl::slotTranslateBeatsEarlier(double v) {
     if (v <= 0) {
@@ -368,7 +334,7 @@ void BpmControl::slotTapFilter(double averageLength, int numSamples) {
 
 // static
 double BpmControl::shortestPercentageChange(const double& current_percentage,
-                                            const double& target_percentage) {
+        const double& target_percentage) {
     if (current_percentage == target_percentage) {
         return 0.0;
     } else if (current_percentage < target_percentage) {
@@ -386,8 +352,7 @@ double BpmControl::shortestPercentageChange(const double& current_percentage,
         // my: 0.98 target: 0.99 backwards: -0.99
         const double backwardsDistance = target_percentage - current_percentage - 1.0;
 
-        return (fabs(forwardDistance) < fabs(backwardsDistance)) ?
-                forwardDistance : backwardsDistance;
+        return (fabs(forwardDistance) < fabs(backwardsDistance)) ? forwardDistance : backwardsDistance;
     } else { // current_percentage > target_percentage
         // Invariant: forwardDistance - backwardsDistance == 1.0
 
@@ -397,8 +362,7 @@ double BpmControl::shortestPercentageChange(const double& current_percentage,
         // my: 0.99 target:0.01 backwards: -0.98
         const double backwardsDistance = target_percentage - current_percentage;
 
-        return (fabs(forwardDistance) < fabs(backwardsDistance)) ?
-                forwardDistance : backwardsDistance;
+        return (fabs(forwardDistance) < fabs(backwardsDistance)) ? forwardDistance : backwardsDistance;
     }
 }
 
@@ -517,9 +481,7 @@ double BpmControl::calcSyncAdjustment(bool userTweakingSync) {
             delta = math_clamp(delta, -kSyncDeltaCap, kSyncDeltaCap);
 
             // Cap the adjustment between -kSyncAdjustmentCap and +kSyncAdjustmentCap
-            adjustment = 1.0 + math_clamp(
-                    m_dLastSyncAdjustment - 1.0 + delta,
-                    -kSyncAdjustmentCap, kSyncAdjustmentCap);
+            adjustment = 1.0 + math_clamp(m_dLastSyncAdjustment - 1.0 + delta, -kSyncAdjustmentCap, kSyncAdjustmentCap);
         } else {
             // We are in sync, no adjustment needed.
             adjustment = 1.0;
@@ -754,7 +716,7 @@ mixxx::audio::FramePos BpmControl::getNearestPositionInPhase(
         newPlayPosition = thisPrevBeatPosition;
     } else if (thisNearNextBeat && !otherNearNextBeat) {
         newPlayPosition = thisNextBeatPosition;
-    } else { //!thisNearNextBeat && otherNearNextBeat
+    } else { //! thisNearNextBeat && otherNearNextBeat
         thisPrevBeatPosition = pBeats->findNthBeat(thisPosition, -2);
         newPlayPosition = thisPrevBeatPosition;
     }

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -77,6 +77,45 @@ BpmControl::BpmControl(const QString& group,
     connect(m_pAdjustBeatsSlower, &ControlObject::valueChanged,
             this, &BpmControl::slotAdjustBeatsSlower,
             Qt::DirectConnection);
+
+    m_pAdjustBeats_1_2 = new ControlPushButton(ConfigKey(group, "beats_adjust_1_2"), false);
+    m_pAdjustBeats_1_2->setKbdRepeatable(true);
+    connect(m_pAdjustBeats_1_2, &ControlObject::valueChanged,
+            this, &BpmControl::slotAdjustBeats_1_2,
+            Qt::DirectConnection);
+
+    m_pAdjustBeats_2_3 = new ControlPushButton(ConfigKey(group, "beats_adjust_2_3"), false);
+    m_pAdjustBeats_2_3->setKbdRepeatable(true);
+    connect(m_pAdjustBeats_2_3, &ControlObject::valueChanged,
+            this, &BpmControl::slotAdjustBeats_2_3,
+            Qt::DirectConnection);
+
+    m_pAdjustBeats_3_4 = new ControlPushButton(ConfigKey(group, "beats_adjust_3_4"), false);
+    m_pAdjustBeats_3_4->setKbdRepeatable(true);
+    connect(m_pAdjustBeats_3_4, &ControlObject::valueChanged,
+            this, &BpmControl::slotAdjustBeats_3_4,
+            Qt::DirectConnection);            
+
+    m_pAdjustBeats_4_3 = new ControlPushButton(ConfigKey(group, "beats_adjust_4_3"), false);
+    m_pAdjustBeats_4_3->setKbdRepeatable(true);
+    connect(m_pAdjustBeats_4_3, &ControlObject::valueChanged,
+            this, &BpmControl::slotAdjustBeats_4_3,
+            Qt::DirectConnection);
+
+    m_pAdjustBeats_3_2 = new ControlPushButton(ConfigKey(group, "beats_adjust_3_2"), false);
+    m_pAdjustBeats_3_2->setKbdRepeatable(true);
+    connect(m_pAdjustBeats_3_2, &ControlObject::valueChanged,
+            this, &BpmControl::slotAdjustBeats_3_2,
+            Qt::DirectConnection);
+
+    m_pAdjustBeats_2_1 = new ControlPushButton(ConfigKey(group, "beats_adjust_2_1"), false);
+    m_pAdjustBeats_2_1->setKbdRepeatable(true);
+    connect(m_pAdjustBeats_2_1, &ControlObject::valueChanged,
+            this, &BpmControl::slotAdjustBeats_2_1,
+            Qt::DirectConnection);
+
+
+
     m_pTranslateBeatsEarlier = new ControlPushButton(ConfigKey(group, "beats_translate_earlier"), false);
     m_pTranslateBeatsEarlier->setKbdRepeatable(true);
     connect(m_pTranslateBeatsEarlier, &ControlObject::valueChanged,
@@ -146,6 +185,12 @@ BpmControl::~BpmControl() {
     delete m_pTranslateBeatsMove;
     delete m_pAdjustBeatsFaster;
     delete m_pAdjustBeatsSlower;
+    delete m_pAdjustBeats_1_2;
+    delete m_pAdjustBeats_2_3;
+    delete m_pAdjustBeats_3_4;
+    delete m_pAdjustBeats_4_3;
+    delete m_pAdjustBeats_3_2;
+    delete m_pAdjustBeats_2_1;   
 }
 
 mixxx::Bpm BpmControl::getBpm() const {
@@ -175,6 +220,20 @@ void BpmControl::adjustBeatsBpm(double deltaBpm) {
     pTrack->trySetBeats(*newBeats);
 }
 
+void BpmControl::adjustBeatsBpmRatio(double deltaBpmRatio) {
+    const TrackPointer pTrack = getEngineBuffer()->getLoadedTrack();
+    if (!pTrack) {
+        return;
+    }
+    const mixxx::BeatsPointer pBeats = pTrack->getBeats();
+    if (!pBeats) {
+        return;
+    }
+    const mixxx::Bpm bpm = pBeats->getBpmInRange(
+            mixxx::audio::kStartFramePos, frameInfo().trackEndPosition);
+    adjustBeatsBpm(deltaBpmRatio*bpm.value());
+}
+
 void BpmControl::slotAdjustBeatsFaster(double v) {
     if (v <= 0) {
         return;
@@ -188,6 +247,49 @@ void BpmControl::slotAdjustBeatsSlower(double v) {
     }
     adjustBeatsBpm(-kBpmAdjustStep);
 }
+
+void BpmControl::slotAdjustBeats_1_2(double v) {
+    if (v <= 0) {
+        return;
+    }
+    adjustBeatsBpmRatio(1./2.-1.);
+}
+
+void BpmControl::slotAdjustBeats_2_3(double v) {
+    if (v <= 0) {
+        return;
+    }
+    adjustBeatsBpmRatio(2./3.-1.);
+}
+
+void BpmControl::slotAdjustBeats_3_4(double v) {
+    if (v <= 0) {
+        return;
+    }
+    adjustBeatsBpmRatio(3./4.-1.);
+}
+
+void BpmControl::slotAdjustBeats_4_3(double v) {
+    if (v <= 0) {
+        return;
+    }
+    adjustBeatsBpmRatio(4./3.-1.);
+}
+
+void BpmControl::slotAdjustBeats_3_2(double v) {
+    if (v <= 0) {
+        return;
+    }
+    adjustBeatsBpmRatio(3./2.-1.);
+}
+
+void BpmControl::slotAdjustBeats_2_1(double v) {
+    if (v <= 0) {
+        return;
+    }
+    adjustBeatsBpmRatio(2./1.-1.);
+}
+
 
 void BpmControl::slotTranslateBeatsEarlier(double v) {
     if (v <= 0) {

--- a/src/engine/controls/bpmcontrol.h
+++ b/src/engine/controls/bpmcontrol.h
@@ -90,7 +90,7 @@ class BpmControl : public EngineControl {
     // target_percentage.
     // Example: shortestPercentageChange(0.99, 0.01) == 0.02
     static double shortestPercentageChange(const double& current_percentage,
-                                           const double& target_percentage);
+            const double& target_percentage);
     double getRateRatio() const;
     void trackLoaded(TrackPointer pNewTrack) override;
     void trackBeatsUpdated(mixxx::BeatsPointer pBeats) override;
@@ -108,7 +108,7 @@ class BpmControl : public EngineControl {
     void slotTranslateBeatsEarlier(double);
     void slotTranslateBeatsLater(double);
     void slotTranslateBeatsMove(double);
-    void slotTapFilter(double,int);
+    void slotTapFilter(double, int);
     void slotBpmTap(double);
     void slotUpdateRateSlider(double v = 0.0);
     void slotUpdateEngineBpm(double v = 0.0);

--- a/src/engine/controls/bpmcontrol.h
+++ b/src/engine/controls/bpmcontrol.h
@@ -99,6 +99,12 @@ class BpmControl : public EngineControl {
   private slots:
     void slotAdjustBeatsFaster(double);
     void slotAdjustBeatsSlower(double);
+    void slotAdjustBeats_1_2(double);
+    void slotAdjustBeats_2_3(double);
+    void slotAdjustBeats_3_4(double);
+    void slotAdjustBeats_4_3(double);
+    void slotAdjustBeats_3_2(double);
+    void slotAdjustBeats_2_1(double);
     void slotTranslateBeatsEarlier(double);
     void slotTranslateBeatsLater(double);
     void slotTranslateBeatsMove(double);
@@ -118,6 +124,7 @@ class BpmControl : public EngineControl {
     }
     double calcSyncAdjustment(bool userTweakingSync);
     void adjustBeatsBpm(double deltaBpm);
+    void adjustBeatsBpmRatio(double deltaBpmRatio);
 
     friend class SyncControl;
 
@@ -141,6 +148,12 @@ class BpmControl : public EngineControl {
     ControlObject* m_pLocalBpm;
     ControlPushButton* m_pAdjustBeatsFaster;
     ControlPushButton* m_pAdjustBeatsSlower;
+    ControlPushButton* m_pAdjustBeats_1_2;
+    ControlPushButton* m_pAdjustBeats_2_3;
+    ControlPushButton* m_pAdjustBeats_3_4;
+    ControlPushButton* m_pAdjustBeats_4_3;
+    ControlPushButton* m_pAdjustBeats_3_2;
+    ControlPushButton* m_pAdjustBeats_2_1;
     ControlPushButton* m_pTranslateBeatsEarlier;
     ControlPushButton* m_pTranslateBeatsLater;
     ControlEncoder* m_pTranslateBeatsMove;


### PR DESCRIPTION
Hi!

My objective is to accelerate the track preparations by using keyboard shortcuts.

The basics are:
- adjusting the BPM (x1/2, …, x2)
- translating the beatgrid
- locking/unlocking the BPM

So far it's only possible to create shortcuts for "translating the beatgrid", using `beats_translate_earlier`, `beats_translate_later`, and `beats_translate_curpos` controls.


This PR is about creating controls for "adjusting the BPM (x1/2, …, x2)", so it's possible to create shortcuts.  
BTW I've found this old post asking for such feature: https://mixxx.discourse.group/t/double-halve-bpm-with-keyboard/13333


Side note:  
I play music with breakbeats like dnb, jungle, breakcore… and I think these are among the trickiest BPM to guess.   
Yet, I only use x3/2 and x2 BPM adjustment and I'm wondering if the other adjustments are actually useful at all. Were there requests for these or is it a YAGNI case?