### PR TITLE
Renamed symbols (Parameter -> NormalizedValue) and added aliases for controller script backward compatibility

### DIFF
--- a/res/controllers/engine-api.d.ts
+++ b/res/controllers/engine-api.d.ts
@@ -61,6 +61,15 @@ declare namespace engine {
      * @param name Name of the control e.g. "play_indicator"
      * @returns Value of the control normalized to range of 0..1
      */
+    function getNormalizedValue(group: string, name: string): number;
+
+    /**
+     * Gets the control value normalized to a range of 0..1
+     * @param group Group of the control e.g. "[Channel1]"
+     * @param name Name of the control e.g. "play_indicator"
+     * @returns Value of the control normalized to range of 0..1
+     * @deprecated Use {@link getNormalizedValue} instead
+     */
     function getParameter(group: string, name: string): number;
 
     /**
@@ -69,6 +78,15 @@ declare namespace engine {
      * @param group Group of the control e.g. "[Channel1]"
      * @param name Name of the control e.g. "play_indicator"
      * @param newValue Value to be set, normalized to a range of 0..1
+     */
+    function setNormalizedValue(group: string, name: string, newValue: number): void;
+
+    /**
+     * Sets the control value specified with normalized range of 0..1
+     * @param group Group of the control e.g. "[Channel1]"
+     * @param name Name of the control e.g. "play_indicator"
+     * @param newValue Value to be set, normalized to a range of 0..1
+     * @deprecated Use {@link setNormalizedValue} instead
      */
     function setParameter(group: string, name: string, newValue: number): void;
 
@@ -81,6 +99,18 @@ declare namespace engine {
      * @param value Value with the controls range according Mixxx Controls manual page:
      *              https://manual.mixxx.org/latest/chapters/appendix/mixxx_controls.html
      * @returns Value normalized to range of 0..1
+     */
+    function getNormalizedValueForValue(group: string, name: string, value: number): number;
+
+    /**
+     * Normalizes a specified value using the range of the given control,
+     * to the range of 0..1
+     * @param group Group of the control e.g. "[Channel1]"
+     * @param name Name of the control e.g. "play_indicator"
+     * @param value Value with the controls range according Mixxx Controls manual page:
+     *              https://manual.mixxx.org/latest/chapters/appendix/mixxx_controls.html
+     * @returns Value normalized to range of 0..1
+     * @deprecated Use {@link getNormalizedValueForValue} instead
      */
     function getParameterForValue(group: string, name: string, value: number): number;
 
@@ -108,6 +138,15 @@ declare namespace engine {
      * @param group Group of the control e.g. "[Channel1]"
      * @param name Name of the control e.g. "play_indicator"
      * @returns Default value of the specified control normalized to range of 0..1
+     */
+    function getNormalizedDefaultValue(group: string, name: string): number;
+
+    /**
+     * Returns the default value of a control, normalized to a range of 0..1
+     * @param group Group of the control e.g. "[Channel1]"
+     * @param name Name of the control e.g. "play_indicator"
+     * @returns Default value of the specified control normalized to range of 0..1
+     * @deprecated Use {@link getNormalizedDefaultValue} instead
      */
     function getDefaultParameter(group: string, name: string): number;
 

--- a/res/controllers/engine-api.d.ts
+++ b/res/controllers/engine-api.d.ts
@@ -58,7 +58,7 @@ declare namespace engine {
      * Gets the control value normalized to a range of 0..1
      *
      * @param group Group of the control e.g. "[Channel1]"
-     * @param name Name of the control e.g. "play_indicator"
+     * @param name Name of the control e.g. "rate" or "pregain"
      * @returns Value of the control normalized to range of 0..1
      */
     function getNormalizedValue(group: string, name: string): number;
@@ -66,7 +66,7 @@ declare namespace engine {
     /**
      * Gets the control value normalized to a range of 0..1
      * @param group Group of the control e.g. "[Channel1]"
-     * @param name Name of the control e.g. "play_indicator"
+     * @param name Name of the control e.g. "rate" or "pregain"
      * @returns Value of the control normalized to range of 0..1
      * @deprecated Use {@link getNormalizedValue} instead
      */
@@ -76,7 +76,7 @@ declare namespace engine {
      * Sets the control value specified with normalized range of 0..1
      *
      * @param group Group of the control e.g. "[Channel1]"
-     * @param name Name of the control e.g. "play_indicator"
+     * @param name Name of the control e.g.  "rate" or "pregain"
      * @param newValue Value to be set, normalized to a range of 0..1
      */
     function setNormalizedValue(group: string, name: string, newValue: number): void;
@@ -84,7 +84,7 @@ declare namespace engine {
     /**
      * Sets the control value specified with normalized range of 0..1
      * @param group Group of the control e.g. "[Channel1]"
-     * @param name Name of the control e.g. "play_indicator"
+     * @param name Name of the control e.g. "rate" or "pregain"
      * @param newValue Value to be set, normalized to a range of 0..1
      * @deprecated Use {@link setNormalizedValue} instead
      */
@@ -95,7 +95,7 @@ declare namespace engine {
      * to the range of 0..1
      *
      * @param group Group of the control e.g. "[Channel1]"
-     * @param name Name of the control e.g. "play_indicator"
+     * @param name Name of the control e.g. "rate" or "pregain"
      * @param value Value with the controls range according Mixxx Controls manual page:
      *              https://manual.mixxx.org/latest/chapters/appendix/mixxx_controls.html
      * @returns Value normalized to range of 0..1
@@ -106,7 +106,7 @@ declare namespace engine {
      * Normalizes a specified value using the range of the given control,
      * to the range of 0..1
      * @param group Group of the control e.g. "[Channel1]"
-     * @param name Name of the control e.g. "play_indicator"
+     * @param name Name of the control e.g. "rate" or "pregain"
      * @param value Value with the controls range according Mixxx Controls manual page:
      *              https://manual.mixxx.org/latest/chapters/appendix/mixxx_controls.html
      * @returns Value normalized to range of 0..1
@@ -136,7 +136,7 @@ declare namespace engine {
      * Returns the default value of a control, normalized to a range of 0..1
      *
      * @param group Group of the control e.g. "[Channel1]"
-     * @param name Name of the control e.g. "play_indicator"
+     * @param name Name of the control e.g. "rate" or "pregain"
      * @returns Default value of the specified control normalized to range of 0..1
      */
     function getNormalizedDefaultValue(group: string, name: string): number;
@@ -144,7 +144,7 @@ declare namespace engine {
     /**
      * Returns the default value of a control, normalized to a range of 0..1
      * @param group Group of the control e.g. "[Channel1]"
-     * @param name Name of the control e.g. "play_indicator"
+     * @param name Name of the control e.g.  "rate" or "pregain"
      * @returns Default value of the specified control normalized to range of 0..1
      * @deprecated Use {@link getNormalizedDefaultValue} instead
      */

--- a/res/qml/ControlKnob.qml
+++ b/res/qml/ControlKnob.qml
@@ -8,8 +8,8 @@ Skin.Knob {
     property alias group: control.group
     property alias key: control.key
 
-    value: control.parameter
-    onTurned: control.parameter = value
+    value: control.normalizedValue
+    onTurned: control.normalizedValue = value
 
     Mixxx.ControlProxy {
         id: control

--- a/res/qml/ControlMiniKnob.qml
+++ b/res/qml/ControlMiniKnob.qml
@@ -8,8 +8,8 @@ Skin.MiniKnob {
     property alias group: control.group
     property alias key: control.key
 
-    value: control.parameter
-    onTurned: control.parameter = value
+    value: control.normalizedValue
+    onTurned: control.normalizedValue = value
 
     Mixxx.ControlProxy {
         id: control

--- a/res/qml/ControlSlider.qml
+++ b/res/qml/ControlSlider.qml
@@ -6,8 +6,8 @@ Skin.Slider {
     property alias group: control.group
     property alias key: control.key
 
-    value: control.parameter
-    onMoved: control.parameter = value
+    value: control.normalizedValue
+    onMoved: control.normalizedValue = value
 
     Mixxx.ControlProxy {
         id: control

--- a/res/qml/VuMeter.qml
+++ b/res/qml/VuMeter.qml
@@ -31,7 +31,7 @@ Rectangle {
             anchors.bottom: parent.bottom
             anchors.margins: 1
             antialiasing: false // for performance reasons
-            height: control.parameter * (parent.height - 2 * anchors.margins)
+            height: control.normalizedValue * (parent.height - 2 * anchors.margins)
             radius: width / 2
         }
     }

--- a/res/qml/WaveformRow.qml
+++ b/res/qml/WaveformRow.qml
@@ -332,7 +332,7 @@ Item {
             mouseAnchor = Qt.point(mouse.x, mouse.y);
             if (mouse.button == Qt.LeftButton) {
                 if (mouseStatus == WaveformRow.MouseStatus.Bending)
-                    wheelControl.parameter = 0.5;
+                    wheelControl.normalizedValue = 0.5;
 
                 mouseStatus = WaveformRow.MouseStatus.Scratching;
                 scratchPositionEnableControl.value = 1;
@@ -343,7 +343,7 @@ Item {
                 if (mouseStatus == WaveformRow.MouseStatus.Scratching)
                     scratchPositionEnableControl.value = 0;
 
-                wheelControl.parameter = 0.5;
+                wheelControl.normalizedValue = 0.5;
                 mouseStatus = WaveformRow.MouseStatus.Bending;
             }
         }
@@ -356,7 +356,7 @@ Item {
                     // this is tuned to 127.
                     const v = 0.5 + (diff / 1270);
                     // clamp to [0.0, 1.0]
-                    wheelControl.parameter = Mixxx.MathUtils.clamp(v, 0, 1);
+                    wheelControl.normalizedValue = Mixxx.MathUtils.clamp(v, 0, 1);
                     break;
                 };
                 case WaveformRow.MouseStatus.Scratching:
@@ -368,7 +368,7 @@ Item {
         onReleased: {
             switch (mouseStatus) {
                 case WaveformRow.MouseStatus.Bending:
-                    wheelControl.parameter = 0.5;
+                    wheelControl.normalizedValue = 0.5;
                     break;
                 case WaveformRow.MouseStatus.Scratching:
                     scratchPositionEnableControl.value = 0;

--- a/src/control/control.cpp
+++ b/src/control/control.cpp
@@ -309,53 +309,53 @@ void ControlDoublePrivate::setBehavior(ControlNumericBehavior* pBehavior) {
     m_pBehavior = QSharedPointer<ControlNumericBehavior>(pBehavior);
 }
 
-void ControlDoublePrivate::setParameter(double dParam, QObject* pSender) {
+void ControlDoublePrivate::setNormalizedValue(double dParam, QObject* pSender) {
     QSharedPointer<ControlNumericBehavior> pBehavior = m_pBehavior;
     if (pBehavior.isNull()) {
         set(dParam, pSender);
     } else {
-        set(pBehavior->parameterToValue(dParam), pSender);
+        set(pBehavior->normalizedValueToValue(dParam), pSender);
     }
 }
 
-double ControlDoublePrivate::getParameter() const {
-    return getParameterForValue(get());
+double ControlDoublePrivate::getNormalizedValue() const {
+    return getNormalizedValueForValue(get());
 }
 
-double ControlDoublePrivate::getParameterForValue(double value) const {
+double ControlDoublePrivate::getNormalizedValueForValue(double value) const {
     QSharedPointer<ControlNumericBehavior> pBehavior = m_pBehavior;
     if (!pBehavior.isNull()) {
-        value = pBehavior->valueToParameter(value);
+        value = pBehavior->valueToNormalizedValue(value);
     }
     return value;
 }
 
-double ControlDoublePrivate::getParameterForMidi(double midiParam) const {
+double ControlDoublePrivate::getNormalizedValueForMidi7Bit(double midiParam) const {
     QSharedPointer<ControlNumericBehavior> pBehavior = m_pBehavior;
     if (!pBehavior) {
         qWarning() << "Cannot get" << m_key << "for Midi";
-        DEBUG_ASSERT(!"pBehavior == nullptr, getParameterForMidi is returning 0");
+        DEBUG_ASSERT(!"pBehavior == nullptr, getNormalizedValueForMidi7Bit is returning 0");
         return 0;
     }
-    return pBehavior->midiToParameter(midiParam);
+    return pBehavior->midi7BitToNormalizedValue(midiParam);
 }
 
-void ControlDoublePrivate::setValueFromMidi(MidiOpCode opcode, double midiParam) {
+void ControlDoublePrivate::setValueFromMidi7Bit(MidiOpCode opcode, double midiParam) {
     QSharedPointer<ControlNumericBehavior> pBehavior = m_pBehavior;
     if (!pBehavior) {
         qWarning() << "Cannot set" << m_key << "from Midi";
-        DEBUG_ASSERT(!"pBehavior == nullptr, abort setValueFromMidi()");
+        DEBUG_ASSERT(!"pBehavior == nullptr, abort setValueFromMidi7Bit()");
         return;
     }
-    pBehavior->setValueFromMidi(opcode, midiParam, this);
+    pBehavior->setValueFromMidi7Bit(opcode, midiParam, this);
 }
 
-double ControlDoublePrivate::getMidiParameter() const {
+double ControlDoublePrivate::getValueScaledAsMidi7Bit() const {
     QSharedPointer<ControlNumericBehavior> pBehavior = m_pBehavior;
     if (!pBehavior) {
         qWarning() << "Cannot get" << m_key << "as Midi";
-        DEBUG_ASSERT(!"pBehavior == nullptr, getMidiParameter() is returning 0");
+        DEBUG_ASSERT(!"pBehavior == nullptr, getValueScaledAsMidi7Bit() is returning 0");
         return 0;
     }
-    return pBehavior->valueToMidiParameter(get());
+    return pBehavior->valueToMidi7Bit(get());
 }

--- a/src/control/control.cpp
+++ b/src/control/control.cpp
@@ -330,24 +330,24 @@ double ControlDoublePrivate::getNormalizedValueForValue(double value) const {
     return value;
 }
 
-double ControlDoublePrivate::getNormalizedValueForMidi7Bit(double midiParam) const {
+double ControlDoublePrivate::getNormalizedValueForMidi7Bit(double dMidi7BitValue) const {
     QSharedPointer<ControlNumericBehavior> pBehavior = m_pBehavior;
     if (!pBehavior) {
         qWarning() << "Cannot get" << m_key << "for Midi";
         DEBUG_ASSERT(!"pBehavior == nullptr, getNormalizedValueForMidi7Bit is returning 0");
         return 0;
     }
-    return pBehavior->midi7BitToNormalizedValue(midiParam);
+    return pBehavior->midi7BitToNormalizedValue(dMidi7BitValue);
 }
 
-void ControlDoublePrivate::setValueFromMidi7Bit(MidiOpCode opcode, double midiParam) {
+void ControlDoublePrivate::setValueFromMidi7Bit(MidiOpCode opcode, double dMidi7BitValue) {
     QSharedPointer<ControlNumericBehavior> pBehavior = m_pBehavior;
     if (!pBehavior) {
         qWarning() << "Cannot set" << m_key << "from Midi";
         DEBUG_ASSERT(!"pBehavior == nullptr, abort setValueFromMidi7Bit()");
         return;
     }
-    pBehavior->setValueFromMidi7Bit(opcode, midiParam, this);
+    pBehavior->setValueFromMidi7Bit(opcode, dMidi7BitValue, this);
 }
 
 double ControlDoublePrivate::getValueScaledAsMidi7Bit() const {

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -101,20 +101,20 @@ class ControlDoublePrivate : public QObject {
     void reset();
 
     // Set the behavior to be used when setting values and translating between
-    // parameter and value space. Returns the previously set behavior (if any).
+    // normalized value and value space. Returns the previously set behavior (if any).
     // Callers must allocate the passed behavior using new and ownership to this
     // memory is passed with the function call!!
     // TODO: Pass a std::unique_ptr instead of a plain pointer to ensure this
     // transfer of ownership.
     void setBehavior(ControlNumericBehavior* pBehavior);
 
-    void setParameter(double dParam, QObject* pSender);
-    double getParameter() const;
-    double getParameterForValue(double value) const;
-    double getParameterForMidi(double midiValue) const;
+    void setNormalizedValue(double dParam, QObject* pSender);
+    double getNormalizedValue() const;
+    double getNormalizedValueForValue(double value) const;
+    double getNormalizedValueForMidi7Bit(double midiValue) const;
 
-    void setValueFromMidi(MidiOpCode opcode, double dParam);
-    double getMidiParameter() const;
+    void setValueFromMidi7Bit(MidiOpCode opcode, double dParam);
+    double getValueScaledAsMidi7Bit() const;
 
     bool ignoreNops() const {
         return m_bIgnoreNops;

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -111,9 +111,9 @@ class ControlDoublePrivate : public QObject {
     void setNormalizedValue(double dParam, QObject* pSender);
     double getNormalizedValue() const;
     double getNormalizedValueForValue(double value) const;
-    double getNormalizedValueForMidi7Bit(double midiValue) const;
+    double getNormalizedValueForMidi7Bit(double dMidi7BitValue) const;
 
-    void setValueFromMidi7Bit(MidiOpCode opcode, double dParam);
+    void setValueFromMidi7Bit(MidiOpCode opcode, double dMidi7BitValue);
     double getValueScaledAsMidi7Bit() const;
 
     bool ignoreNops() const {

--- a/src/control/controlbehavior.h
+++ b/src/control/controlbehavior.h
@@ -16,26 +16,26 @@ class ControlNumericBehavior {
     // Returns false to reject the new value entirely
     virtual bool setFilter(double* dValue);
 
-    // returns the normalized parameter range 0..1
-    virtual double valueToParameter(double dValue);
-    // returns the normalized parameter range 0..1
-    virtual double midiToParameter(double midiValue);
+    // returns the normalized value range 0..1
+    virtual double valueToNormalizedValue(double dValue);
+    // returns the normalized value range 0..1
+    virtual double midi7BitToNormalizedValue(double midiValue);
     // returns the scaled user visible value
-    virtual double parameterToValue(double dParam);
-    // returns the midi range parameter 0..127
-    virtual double valueToMidiParameter(double dValue);
+    virtual double normalizedValueToValue(double dParam);
+    // returns the midi range value 0..127
+    virtual double valueToMidi7Bit(double dValue);
 
-    virtual void setValueFromMidi(
+    virtual void setValueFromMidi7Bit(
             MidiOpCode o, double dParam, ControlDoublePrivate* pControl);
 };
 
-// ControlEncoderBehavior passes the midi value directly to the internal parameter value.  It's
+// ControlEncoderBehavior passes the midi value directly to the internal parameter value. It's
 // useful for selector knobs that pass +1 in one direction and -1 in the other.
 class ControlEncoderBehavior : public ControlNumericBehavior {
   public:
     ControlEncoderBehavior() {}
-    double midiToParameter(double midiValue) override;
-    double valueToMidiParameter(double dValue) override;
+    double midi7BitToNormalizedValue(double midiValue) override;
+    double valueToMidi7Bit(double dValue) override;
 };
 
 class ControlPotmeterBehavior : public ControlNumericBehavior {
@@ -44,10 +44,10 @@ class ControlPotmeterBehavior : public ControlNumericBehavior {
                             bool allowOutOfBounds);
 
     bool setFilter(double* dValue) override;
-    double valueToParameter(double dValue) override;
-    double midiToParameter(double midiValue) override;
-    double parameterToValue(double dParam) override;
-    double valueToMidiParameter(double dValue) override;
+    double valueToNormalizedValue(double dValue) override;
+    double midi7BitToNormalizedValue(double midiValue) override;
+    double normalizedValueToValue(double dParam) override;
+    double valueToMidi7Bit(double dValue) override;
 
   protected:
     double m_dMinValue;
@@ -60,8 +60,8 @@ class ControlLogPotmeterBehavior : public ControlPotmeterBehavior {
   public:
     ControlLogPotmeterBehavior(double dMinValue, double dMaxValue, double minDB);
 
-    double valueToParameter(double dValue) override;
-    double parameterToValue(double dParam) override;
+    double valueToNormalizedValue(double dValue) override;
+    double normalizedValueToValue(double dParam) override;
 
   protected:
     double m_minDB;
@@ -72,8 +72,8 @@ class ControlLogInvPotmeterBehavior : public ControlLogPotmeterBehavior {
   public:
     ControlLogInvPotmeterBehavior(double dMinValue, double dMaxValue, double minDB);
 
-    double valueToParameter(double dValue) override;
-    double parameterToValue(double dParam) override;
+    double valueToNormalizedValue(double dValue) override;
+    double normalizedValueToValue(double dParam) override;
 };
 
 class ControlLinPotmeterBehavior : public ControlPotmeterBehavior {
@@ -86,8 +86,8 @@ class ControlLinInvPotmeterBehavior : public ControlPotmeterBehavior {
   public:
     ControlLinInvPotmeterBehavior(
             double dMinValue, double dMaxValue, bool allowOutOfBounds);
-    double valueToParameter(double dValue) override;
-    double parameterToValue(double dParam) override;
+    double valueToNormalizedValue(double dValue) override;
+    double normalizedValueToValue(double dParam) override;
 };
 
 class ControlAudioTaperPotBehavior : public ControlPotmeterBehavior {
@@ -95,13 +95,13 @@ class ControlAudioTaperPotBehavior : public ControlPotmeterBehavior {
     ControlAudioTaperPotBehavior(double minDB, double maxDB,
                                  double neutralParameter);
 
-    double valueToParameter(double dValue) override;
-    double parameterToValue(double dParam) override;
-    double midiToParameter(double midiValue) override;
-    double valueToMidiParameter(double dValue) override;
-    void setValueFromMidi(
+    double valueToNormalizedValue(double dValue) override;
+    double normalizedValueToValue(double dParam) override;
+    double midi7BitToNormalizedValue(double midiValue) override;
+    double valueToMidi7Bit(double dValue) override;
+    void setValueFromMidi7Bit(
             MidiOpCode o, double dParam, ControlDoublePrivate* pControl)
-                    override;
+            override;
 
   protected:
     // a knob position between 0 and 1 where the gain is 1 (0dB)
@@ -121,8 +121,8 @@ class ControlAudioTaperPotBehavior : public ControlPotmeterBehavior {
 
 class ControlTTRotaryBehavior : public ControlNumericBehavior {
   public:
-    double valueToParameter(double dValue) override;
-    double parameterToValue(double dParam) override;
+    double valueToNormalizedValue(double dValue) override;
+    double normalizedValueToValue(double dParam) override;
 };
 
 class ControlPushButtonBehavior : public ControlNumericBehavior {
@@ -141,9 +141,9 @@ class ControlPushButtonBehavior : public ControlNumericBehavior {
     };
 
     ControlPushButtonBehavior(ButtonMode buttonMode, int iNumStates);
-    void setValueFromMidi(
+    void setValueFromMidi7Bit(
             MidiOpCode o, double dParam, ControlDoublePrivate* pControl)
-                override;
+            override;
 
   private:
     // We create many hundreds of push buttons at Mixxx startup and most of them
@@ -164,8 +164,8 @@ class ControlLinSteppedIntPotBehavior : public ControlPotmeterBehavior {
     ControlLinSteppedIntPotBehavior(
             double dMinValue, double dMaxValue, bool allowOutOfBounds);
 
-    double valueToParameter(double dValue) override;
-    double parameterToValue(double dParam) override;
+    double valueToNormalizedValue(double dValue) override;
+    double normalizedValueToValue(double dParam) override;
 
   protected:
     double m_lastSnappedParam;

--- a/src/control/controlbehavior.h
+++ b/src/control/controlbehavior.h
@@ -19,23 +19,23 @@ class ControlNumericBehavior {
     // returns the normalized value range 0..1
     virtual double valueToNormalizedValue(double dValue);
     // returns the normalized value range 0..1
-    virtual double midi7BitToNormalizedValue(double midiValue);
+    virtual double midi7BitToNormalizedValue(double dMidi7BitValue);
     // returns the scaled user visible value
-    virtual double normalizedValueToValue(double dParam);
+    virtual double normalizedValueToValue(double dNormalizedValue);
     // returns the midi range value 0..127
     virtual double valueToMidi7Bit(double dValue);
 
     virtual void setValueFromMidi7Bit(
-            MidiOpCode o, double dParam, ControlDoublePrivate* pControl);
+            MidiOpCode o, double dNormalizedValue, ControlDoublePrivate* pControl);
 };
 
-// ControlEncoderBehavior passes the midi value directly to the internal parameter value. It's
+// ControlEncoderBehavior passes the midi value directly to the internal normalized value. It's
 // useful for selector knobs that pass +1 in one direction and -1 in the other.
 class ControlEncoderBehavior : public ControlNumericBehavior {
   public:
     ControlEncoderBehavior() {}
-    double midi7BitToNormalizedValue(double midiValue) override;
-    double valueToMidi7Bit(double dValue) override;
+    double midi7BitToNormalizedValue(double dMidi7BitValue) override;
+    double valueToMidi7Bit(double dNormalizedValue) override;
 };
 
 class ControlPotmeterBehavior : public ControlNumericBehavior {
@@ -45,8 +45,8 @@ class ControlPotmeterBehavior : public ControlNumericBehavior {
 
     bool setFilter(double* dValue) override;
     double valueToNormalizedValue(double dValue) override;
-    double midi7BitToNormalizedValue(double midiValue) override;
-    double normalizedValueToValue(double dParam) override;
+    double midi7BitToNormalizedValue(double dMidi7BitValue) override;
+    double normalizedValueToValue(double dNormalizedValue) override;
     double valueToMidi7Bit(double dValue) override;
 
   protected:
@@ -61,7 +61,7 @@ class ControlLogPotmeterBehavior : public ControlPotmeterBehavior {
     ControlLogPotmeterBehavior(double dMinValue, double dMaxValue, double minDB);
 
     double valueToNormalizedValue(double dValue) override;
-    double normalizedValueToValue(double dParam) override;
+    double normalizedValueToValue(double dNormalizedValue) override;
 
   protected:
     double m_minDB;
@@ -73,7 +73,7 @@ class ControlLogInvPotmeterBehavior : public ControlLogPotmeterBehavior {
     ControlLogInvPotmeterBehavior(double dMinValue, double dMaxValue, double minDB);
 
     double valueToNormalizedValue(double dValue) override;
-    double normalizedValueToValue(double dParam) override;
+    double normalizedValueToValue(double dNormalizedValue) override;
 };
 
 class ControlLinPotmeterBehavior : public ControlPotmeterBehavior {
@@ -87,31 +87,30 @@ class ControlLinInvPotmeterBehavior : public ControlPotmeterBehavior {
     ControlLinInvPotmeterBehavior(
             double dMinValue, double dMaxValue, bool allowOutOfBounds);
     double valueToNormalizedValue(double dValue) override;
-    double normalizedValueToValue(double dParam) override;
+    double normalizedValueToValue(double dNormalizedValue) override;
 };
 
 class ControlAudioTaperPotBehavior : public ControlPotmeterBehavior {
   public:
-    ControlAudioTaperPotBehavior(double minDB, double maxDB,
-                                 double neutralParameter);
+    ControlAudioTaperPotBehavior(double minDB, double maxDB, double neutralNormalizedValue);
 
     double valueToNormalizedValue(double dValue) override;
-    double normalizedValueToValue(double dParam) override;
-    double midi7BitToNormalizedValue(double midiValue) override;
+    double normalizedValueToValue(double dNormalizedValue) override;
+    double midi7BitToNormalizedValue(double dMidi7BitValue) override;
     double valueToMidi7Bit(double dValue) override;
     void setValueFromMidi7Bit(
-            MidiOpCode o, double dParam, ControlDoublePrivate* pControl)
+            MidiOpCode o, double dNormalizedValue, ControlDoublePrivate* pControl)
             override;
 
   protected:
     // a knob position between 0 and 1 where the gain is 1 (0dB)
-    double m_neutralParameter;
+    double m_neutralNormalizedValue;
     // the Start value of the pure db scale it cranked to -Infinity by the
     // linear part of the AudioTaperPot
     double m_minDB;
     // maxDB is the upper gain Value
     double m_maxDB;
-    // offset at knob position 0 (Parameter = 0) to reach -Infinity
+    // offset at knob position 0 (normalized value = 0) to reach -Infinity
     double m_offset;
     // ensures that the neutral position on a integer midi value
     // This value is subtracted from the Midi value at neutral position
@@ -122,7 +121,7 @@ class ControlAudioTaperPotBehavior : public ControlPotmeterBehavior {
 class ControlTTRotaryBehavior : public ControlNumericBehavior {
   public:
     double valueToNormalizedValue(double dValue) override;
-    double normalizedValueToValue(double dParam) override;
+    double normalizedValueToValue(double dNormalizedValue) override;
 };
 
 class ControlPushButtonBehavior : public ControlNumericBehavior {
@@ -142,7 +141,7 @@ class ControlPushButtonBehavior : public ControlNumericBehavior {
 
     ControlPushButtonBehavior(ButtonMode buttonMode, int iNumStates);
     void setValueFromMidi7Bit(
-            MidiOpCode o, double dParam, ControlDoublePrivate* pControl)
+            MidiOpCode o, double dNormalizedValue, ControlDoublePrivate* pControl)
             override;
 
   private:
@@ -165,10 +164,10 @@ class ControlLinSteppedIntPotBehavior : public ControlPotmeterBehavior {
             double dMinValue, double dMaxValue, bool allowOutOfBounds);
 
     double valueToNormalizedValue(double dValue) override;
-    double normalizedValueToValue(double dParam) override;
+    double normalizedValueToValue(double dNormalizedValue) override;
 
   protected:
-    double m_lastSnappedParam;
+    double m_lastSnappedNormalizedValue;
     double m_dist;
     double m_oldVal;
 };

--- a/src/control/controlmodel.cpp
+++ b/src/control/controlmodel.cpp
@@ -101,7 +101,7 @@ QVariant ControlModel::data(const QModelIndex& index,
         case CONTROL_COLUMN_VALUE:
             return control.pControl->get();
         case CONTROL_COLUMN_PARAMETER:
-            return control.pControl->getParameter();
+            return control.pControl->getNormalizedValue();
         case CONTROL_COLUMN_TITLE:
             return control.title;
         case CONTROL_COLUMN_DESCRIPTION:
@@ -175,7 +175,7 @@ bool ControlModel::setData(const QModelIndex& modelIndex,
             emit dataChanged(modelIndex, index(modelIndex.row(), CONTROL_COLUMN_PARAMETER));
             return true;
         case CONTROL_COLUMN_PARAMETER:
-            control.pControl->setParameter(value.toDouble());
+            control.pControl->setNormalizedValue(value.toDouble());
             emit dataChanged(index(modelIndex.row(), CONTROL_COLUMN_VALUE), modelIndex);
             return true;
     }

--- a/src/control/controlobject.cpp
+++ b/src/control/controlobject.cpp
@@ -89,8 +89,8 @@ double ControlObject::getNormalizedValueForValue(double value) const {
     return m_pControl->getNormalizedValueForValue(value);
 }
 
-double ControlObject::getNormalizedValueForMidi7Bit(double midiParameter) const {
-    return m_pControl->getNormalizedValueForMidi7Bit(midiParameter);
+double ControlObject::getNormalizedValueForMidi7Bit(double midi7BitValue) const {
+    return m_pControl->getNormalizedValueForMidi7Bit(midi7BitValue);
 }
 
 void ControlObject::setNormalizedValue(double v) {

--- a/src/control/controlobject.cpp
+++ b/src/control/controlobject.cpp
@@ -67,12 +67,12 @@ bool ControlObject::exists(const ConfigKey& key) {
     return !ControlDoublePrivate::getControl(key, ControlFlag::NoWarnIfMissing).isNull();
 }
 
-void ControlObject::setValueFromMidi(MidiOpCode o, double v) {
-    m_pControl->setValueFromMidi(o, v);
+void ControlObject::setValueFromMidi7Bit(MidiOpCode o, double v) {
+    m_pControl->setValueFromMidi7Bit(o, v);
 }
 
-double ControlObject::getMidiParameter() const {
-    return m_pControl->getMidiParameter();
+double ControlObject::getValueScaledAsMidi7Bit() const {
+    return m_pControl->getValueScaledAsMidi7Bit();
 }
 
 // static
@@ -81,24 +81,24 @@ double ControlObject::get(const ConfigKey& key) {
     return pCop ? pCop->get() : 0.0;
 }
 
-double ControlObject::getParameter() const {
-    return m_pControl->getParameter();
+double ControlObject::getNormalizedValue() const {
+    return m_pControl->getNormalizedValue();
 }
 
-double ControlObject::getParameterForValue(double value) const {
-    return m_pControl->getParameterForValue(value);
+double ControlObject::getNormalizedValueForValue(double value) const {
+    return m_pControl->getNormalizedValueForValue(value);
 }
 
-double ControlObject::getParameterForMidi(double midiParameter) const {
-    return m_pControl->getParameterForMidi(midiParameter);
+double ControlObject::getNormalizedValueForMidi7Bit(double midiParameter) const {
+    return m_pControl->getNormalizedValueForMidi7Bit(midiParameter);
 }
 
-void ControlObject::setParameter(double v) {
-    m_pControl->setParameter(v, this);
+void ControlObject::setNormalizedValue(double v) {
+    m_pControl->setNormalizedValue(v, this);
 }
 
-void ControlObject::setParameterFrom(double v, QObject* pSender) {
-    m_pControl->setParameter(v, pSender);
+void ControlObject::setNormalizedValueFrom(double v, QObject* pSender) {
+    m_pControl->setNormalizedValue(v, pSender);
 }
 
 // static

--- a/src/control/controlobject.h
+++ b/src/control/controlobject.h
@@ -139,7 +139,7 @@ class ControlObject : public QObject {
     virtual double getNormalizedValueForValue(double value) const;
 
     // Returns the normalized value of the object. Thread safe, non-blocking.
-    virtual double getNormalizedValueForMidi7Bit(double midiValue) const;
+    virtual double getNormalizedValueForMidi7Bit(double midi7BitValue) const;
 
     // Sets the control normalized value to v. Thread safe, non-blocking.
     virtual void setNormalizedValue(double v);

--- a/src/control/controlobject.h
+++ b/src/control/controlobject.h
@@ -132,20 +132,20 @@ class ControlObject : public QObject {
         return m_pControl ? m_pControl->defaultValue() : 0.0;
     }
 
-    // Returns the parameterized value of the object. Thread safe, non-blocking.
-    virtual double getParameter() const;
+    // Returns the normalized value of the object. Thread safe, non-blocking.
+    virtual double getNormalizedValue() const;
 
-    // Returns the parameterized value of the object. Thread safe, non-blocking.
-    virtual double getParameterForValue(double value) const;
+    // Returns the normalized value of the object. Thread safe, non-blocking.
+    virtual double getNormalizedValueForValue(double value) const;
 
-    // Returns the parameterized value of the object. Thread safe, non-blocking.
-    virtual double getParameterForMidi(double midiValue) const;
+    // Returns the normalized value of the object. Thread safe, non-blocking.
+    virtual double getNormalizedValueForMidi7Bit(double midiValue) const;
 
-    // Sets the control parameterized value to v. Thread safe, non-blocking.
-    virtual void setParameter(double v);
+    // Sets the control normalized value to v. Thread safe, non-blocking.
+    virtual void setNormalizedValue(double v);
 
-    // Sets the control parameterized value to v. Thread safe, non-blocking.
-    virtual void setParameterFrom(double v, QObject* pSender = NULL);
+    // Sets the control normalized value to v. Thread safe, non-blocking.
+    virtual void setNormalizedValueFrom(double v, QObject* pSender = NULL);
 
     // Connects a Qt slot to a signal that is delivered when a new value change
     // request arrives for this control.
@@ -173,8 +173,8 @@ class ControlObject : public QObject {
   public:
     // DEPRECATED: Called to set the control value from the controller
     // subsystem.
-    virtual void setValueFromMidi(MidiOpCode o, double v);
-    virtual double getMidiParameter() const;
+    virtual void setValueFromMidi7Bit(MidiOpCode o, double v);
+    virtual double getValueScaledAsMidi7Bit() const;
 
   protected:
     // Key of the object

--- a/src/control/controlpotmeter.cpp
+++ b/src/control/controlpotmeter.cpp
@@ -141,33 +141,33 @@ void PotmeterControls::addAlias(const ConfigKey& key) {
 
 void PotmeterControls::incValue(double v) {
     if (v > 0) {
-        double parameter = m_control.getNormalizedValue();
-        parameter += 1.0 / m_stepCount;
-        m_control.setNormalizedValue(parameter);
+        double normalizedValue = m_control.getNormalizedValue();
+        normalizedValue += 1.0 / m_stepCount;
+        m_control.setNormalizedValue(normalizedValue);
     }
 }
 
 void PotmeterControls::decValue(double v) {
     if (v > 0) {
-        double parameter = m_control.getNormalizedValue();
-        parameter -= 1.0 / m_stepCount;
-        m_control.setNormalizedValue(parameter);
+        double normalizedValue = m_control.getNormalizedValue();
+        normalizedValue -= 1.0 / m_stepCount;
+        m_control.setNormalizedValue(normalizedValue);
     }
 }
 
 void PotmeterControls::incSmallValue(double v) {
     if (v > 0) {
-        double parameter = m_control.getNormalizedValue();
-        parameter += 1.0 / m_smallStepCount;
-        m_control.setNormalizedValue(parameter);
+        double normalizedValue = m_control.getNormalizedValue();
+        normalizedValue += 1.0 / m_smallStepCount;
+        m_control.setNormalizedValue(normalizedValue);
     }
 }
 
 void PotmeterControls::decSmallValue(double v) {
     if (v > 0) {
-        double parameter = m_control.getNormalizedValue();
-        parameter -= 1.0 / m_smallStepCount;
-        m_control.setNormalizedValue(parameter);
+        double normalizedValue = m_control.getNormalizedValue();
+        normalizedValue -= 1.0 / m_smallStepCount;
+        m_control.setNormalizedValue(normalizedValue);
     }
 }
 

--- a/src/control/controlpotmeter.cpp
+++ b/src/control/controlpotmeter.cpp
@@ -141,33 +141,33 @@ void PotmeterControls::addAlias(const ConfigKey& key) {
 
 void PotmeterControls::incValue(double v) {
     if (v > 0) {
-        double parameter = m_control.getParameter();
+        double parameter = m_control.getNormalizedValue();
         parameter += 1.0 / m_stepCount;
-        m_control.setParameter(parameter);
+        m_control.setNormalizedValue(parameter);
     }
 }
 
 void PotmeterControls::decValue(double v) {
     if (v > 0) {
-        double parameter = m_control.getParameter();
+        double parameter = m_control.getNormalizedValue();
         parameter -= 1.0 / m_stepCount;
-        m_control.setParameter(parameter);
+        m_control.setNormalizedValue(parameter);
     }
 }
 
 void PotmeterControls::incSmallValue(double v) {
     if (v > 0) {
-        double parameter = m_control.getParameter();
+        double parameter = m_control.getNormalizedValue();
         parameter += 1.0 / m_smallStepCount;
-        m_control.setParameter(parameter);
+        m_control.setNormalizedValue(parameter);
     }
 }
 
 void PotmeterControls::decSmallValue(double v) {
     if (v > 0) {
-        double parameter = m_control.getParameter();
+        double parameter = m_control.getNormalizedValue();
         parameter -= 1.0 / m_smallStepCount;
-        m_control.setParameter(parameter);
+        m_control.setNormalizedValue(parameter);
     }
 }
 

--- a/src/control/controlproxy.h
+++ b/src/control/controlproxy.h
@@ -119,29 +119,29 @@ class ControlProxy : public QObject {
         return get() > 0.0;
     }
 
-    /// Returns the parameterized value of the object. Thread safe, non-blocking.
-    inline double getParameter() const {
-        return m_pControl->getParameter();
+    /// Returns the normalized value of the object. Thread safe, non-blocking.
+    inline double getNormalizedValue() const {
+        return m_pControl->getNormalizedValue();
     }
 
-    /// Returns the parameterized value of the object. Thread safe, non-blocking.
-    inline double getParameterForValue(double value) const {
-        return m_pControl->getParameterForValue(value);
+    /// Returns the normalized value of the object. Thread safe, non-blocking.
+    inline double getNormalizedValueForValue(double value) const {
+        return m_pControl->getNormalizedValueForValue(value);
     }
 
-    /// Returns the normalized parameter of the object. Thread safe, non-blocking.
+    /// Returns the default value of the object. Thread safe, non-blocking.
     inline double getDefault() const {
         return m_pControl->defaultValue();
     }
 
   public slots:
-    /// Sets the control value to v. Thread safe, non-blocking.
+    /// Sets the controls value to v. Thread safe, non-blocking.
     void set(double v) {
         m_pControl->set(v, this);
     }
-    /// Sets the control parameterized value to v. Thread safe, non-blocking.
-    void setParameter(double v) {
-        m_pControl->setParameter(v, this);
+    /// Sets the controls normalized value to v. Thread safe, non-blocking.
+    void setNormalizedValue(double v) {
+        m_pControl->setNormalizedValue(v, this);
     }
     /// Resets the control to its default value. Thread safe, non-blocking.
     void reset() {

--- a/src/control/pollingcontrolproxy.h
+++ b/src/control/pollingcontrolproxy.h
@@ -41,17 +41,17 @@ class PollingControlProxy {
         return get() > 0.0;
     }
 
-    /// Returns the parameterized value of the object. Thread safe, non-blocking.
-    double getParameter() const {
-        return m_pControl->getParameter();
+    /// Returns the normalized value of the object. Thread safe, non-blocking.
+    double getNormalizedValue() const {
+        return m_pControl->getNormalizedValue();
     }
 
-    /// Returns the parameterized value of the object. Thread safe, non-blocking.
-    double getParameterForValue(double value) const {
-        return m_pControl->getParameterForValue(value);
+    /// Returns the normalized value of the object. Thread safe, non-blocking.
+    double getNormalizedValueForValue(double value) const {
+        return m_pControl->getNormalizedValueForValue(value);
     }
 
-    /// Returns the normalized parameter of the object. Thread safe, non-blocking.
+    /// Returns the default value of the object. Thread safe, non-blocking.
     double getDefault() const {
         return m_pControl->defaultValue();
     }
@@ -60,9 +60,9 @@ class PollingControlProxy {
     void set(double v) {
         m_pControl->set(v, nullptr);
     }
-    /// Sets the control parameterized value to v. Thread safe, non-blocking.
-    void setParameter(double v) {
-        m_pControl->setParameter(v, nullptr);
+    /// Sets the control normalized value to v. Thread safe, non-blocking.
+    void setNormalizedValue(double v) {
+        m_pControl->setNormalizedValue(v, nullptr);
     }
 
   private:

--- a/src/controllers/keyboard/keyboardeventfilter.cpp
+++ b/src/controllers/keyboard/keyboardeventfilter.cpp
@@ -59,7 +59,7 @@ bool KeyboardEventFilter::eventFilter(QObject*, QEvent* e) {
                         // Since setting the value might cause us to go down
                         // a route that would eventually clear the active
                         // key list, do that last.
-                        control->setValueFromMidi(MidiOpCode::NoteOn, 1);
+                        control->setValueFromMidi7Bit(MidiOpCode::NoteOn, 1);
                         result = true;
                     } else {
                         qDebug() << "Warning: Keyboard key is configured for nonexistent control:"
@@ -101,7 +101,7 @@ bool KeyboardEventFilter::eventFilter(QObject*, QEvent* e) {
                     (clearModifiers > 0 && keyDownInfo.modifiers == clearModifiers)) {
                 if (!autoRepeat) {
                     //qDebug() << pControl->getKey() << "MidiOpCode::NoteOff" << 0;
-                    pControl->setValueFromMidi(MidiOpCode::NoteOff, 0);
+                    pControl->setValueFromMidi7Bit(MidiOpCode::NoteOff, 0);
                     m_qActiveKeyList.removeAt(i);
                 }
                 // Due to the modifier clearing workaround we might match multiple keys for

--- a/src/controllers/midi/midicontroller.cpp
+++ b/src/controllers/midi/midicontroller.cpp
@@ -375,7 +375,7 @@ void MidiController::processInputMapping(const MidiInputMapping& mapping,
         newValue = static_cast<double>(iValue) / 128.0;
         newValue = math_min(newValue, 127.0);
     } else {
-        double currControlValue = pCO->getMidiParameter();
+        double currControlValue = pCO->getValueScaledAsMidi7Bit();
         newValue = computeValue(mapping.options, currControlValue, value);
     }
 
@@ -388,11 +388,11 @@ void MidiController::processInputMapping(const MidiInputMapping& mapping,
     if (mapping.options.testFlag(MidiOption::SoftTakeover)) {
         // This is the only place to enable it if it isn't already.
         m_st.enable(pCO);
-        if (m_st.ignore(pCO, pCO->getParameterForMidi(newValue))) {
+        if (m_st.ignore(pCO, pCO->getNormalizedValueForMidi7Bit(newValue))) {
             return;
         }
     }
-    pCO->setValueFromMidi(static_cast<MidiOpCode>(opCode), newValue);
+    pCO->setValueFromMidi7Bit(static_cast<MidiOpCode>(opCode), newValue);
 }
 
 double MidiController::computeValue(

--- a/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
+++ b/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
@@ -158,13 +158,14 @@ void ControllerScriptInterfaceLegacy::setValue(
                 coScript->getKey(), ControlFlag::AllowMissingOrInvalid);
         if (pControl &&
                 !m_st.ignore(
-                        pControl, coScript->getParameterForValue(newValue))) {
+                        pControl, coScript->getNormalizedValueForValue(newValue))) {
             coScript->set(newValue);
         }
     }
 }
 
-double ControllerScriptInterfaceLegacy::getParameter(const QString& group, const QString& name) {
+double ControllerScriptInterfaceLegacy::getNormalizedValue(
+        const QString& group, const QString& name) {
     ControlObjectScript* coScript = getControlObjectScript(group, name);
     if (coScript == nullptr) {
         m_pScriptEngineLegacy->logOrThrowError(
@@ -172,10 +173,10 @@ double ControllerScriptInterfaceLegacy::getParameter(const QString& group, const
                         .arg(group, name));
         return 0.0;
     }
-    return coScript->getParameter();
+    return coScript->getNormalizedValue();
 }
 
-void ControllerScriptInterfaceLegacy::setParameter(
+void ControllerScriptInterfaceLegacy::setNormalizedValue(
         const QString& group, const QString& name, double newParameter) {
     if (util_isnan(newParameter)) {
         m_pScriptEngineLegacy->logOrThrowError(QStringLiteral(
@@ -190,12 +191,12 @@ void ControllerScriptInterfaceLegacy::setParameter(
         ControlObject* pControl = ControlObject::getControl(
                 coScript->getKey(), ControlFlag::AllowMissingOrInvalid);
         if (pControl && !m_st.ignore(pControl, newParameter)) {
-            coScript->setParameter(newParameter);
+            coScript->setNormalizedValue(newParameter);
         }
     }
 }
 
-double ControllerScriptInterfaceLegacy::getParameterForValue(
+double ControllerScriptInterfaceLegacy::getNormalizedValueForValue(
         const QString& group, const QString& name, double value) {
     if (util_isnan(value)) {
         m_pScriptEngineLegacy->logOrThrowError(QStringLiteral(
@@ -213,7 +214,7 @@ double ControllerScriptInterfaceLegacy::getParameterForValue(
         return 0.0;
     }
 
-    return coScript->getParameterForValue(value);
+    return coScript->getNormalizedValueForValue(value);
 }
 
 void ControllerScriptInterfaceLegacy::reset(const QString& group, const QString& name) {
@@ -236,7 +237,7 @@ double ControllerScriptInterfaceLegacy::getDefaultValue(const QString& group, co
     return coScript->getDefault();
 }
 
-double ControllerScriptInterfaceLegacy::getDefaultParameter(
+double ControllerScriptInterfaceLegacy::getNormalizedDefaultValue(
         const QString& group, const QString& name) {
     ControlObjectScript* coScript = getControlObjectScript(group, name);
 
@@ -247,7 +248,7 @@ double ControllerScriptInterfaceLegacy::getDefaultParameter(
         return 0.0;
     }
 
-    return coScript->getParameterForValue(coScript->getDefault());
+    return coScript->getNormalizedValueForValue(coScript->getDefault());
 }
 
 QJSValue ControllerScriptInterfaceLegacy::makeConnection(

--- a/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
+++ b/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
@@ -177,8 +177,8 @@ double ControllerScriptInterfaceLegacy::getNormalizedValue(
 }
 
 void ControllerScriptInterfaceLegacy::setNormalizedValue(
-        const QString& group, const QString& name, double newParameter) {
-    if (util_isnan(newParameter)) {
+        const QString& group, const QString& name, double normalizedValue) {
+    if (util_isnan(normalizedValue)) {
         m_pScriptEngineLegacy->logOrThrowError(QStringLiteral(
                 "Script tried setting (%1, %2) to NotANumber (NaN)")
                                                        .arg(group, name));
@@ -190,8 +190,8 @@ void ControllerScriptInterfaceLegacy::setNormalizedValue(
     if (coScript != nullptr) {
         ControlObject* pControl = ControlObject::getControl(
                 coScript->getKey(), ControlFlag::AllowMissingOrInvalid);
-        if (pControl && !m_st.ignore(pControl, newParameter)) {
-            coScript->setNormalizedValue(newParameter);
+        if (pControl && !m_st.ignore(pControl, normalizedValue)) {
+            coScript->setNormalizedValue(normalizedValue);
         }
     }
 }

--- a/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.h
+++ b/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.h
@@ -25,13 +25,42 @@ class ControllerScriptInterfaceLegacy : public QObject {
     Q_INVOKABLE QJSValue getSetting(const QString& name);
     Q_INVOKABLE double getValue(const QString& group, const QString& name);
     Q_INVOKABLE void setValue(const QString& group, const QString& name, double newValue);
-    Q_INVOKABLE double getParameter(const QString& group, const QString& name);
-    Q_INVOKABLE void setParameter(const QString& group, const QString& name, double newValue);
-    Q_INVOKABLE double getParameterForValue(
+
+    Q_INVOKABLE double getNormalizedValue(const QString& group, const QString& name);
+    Q_INVOKABLE double getParameter(const QString& group, const QString& name) {
+        qCDebug(m_logger) << "engine.getParameter is deprecated, use the alias "
+                             "engine.getNormalizedValue instead!";
+        return getNormalizedValue(group, name);
+    };
+
+    Q_INVOKABLE void setNormalizedValue(const QString& group, const QString& name, double newValue);
+    Q_INVOKABLE void setParameter(const QString& group, const QString& name, double newValue) {
+        qCDebug(m_logger) << "engine.setParameter is deprecated, use the alias "
+                             "engine.setNormalizedValue instead!";
+        setNormalizedValue(group, name, newValue);
+    };
+
+    Q_INVOKABLE double getNormalizedValueForValue(
             const QString& group, const QString& name, double value);
+    Q_INVOKABLE double getParameterForValue(
+            const QString& group, const QString& name, double value) {
+        qCDebug(m_logger)
+                << "engine.getParameterForValue is deprecated, use the alias "
+                   "engine.getNormalizedValueForValue instead!";
+        return getNormalizedValueForValue(group, name, value);
+    };
+
     Q_INVOKABLE void reset(const QString& group, const QString& name);
     Q_INVOKABLE double getDefaultValue(const QString& group, const QString& name);
-    Q_INVOKABLE double getDefaultParameter(const QString& group, const QString& name);
+
+    Q_INVOKABLE double getNormalizedDefaultValue(const QString& group, const QString& name);
+    Q_INVOKABLE double getDefaultParameter(const QString& group, const QString& name) {
+        qCDebug(m_logger)
+                << "engine.getDefaultParameter is deprecated, use the alias "
+                   "engine.getNormalizedDefaultValue instead!";
+        return getNormalizedDefaultValue(group, name);
+    };
+
     Q_INVOKABLE QJSValue makeConnection(const QString& group,
             const QString& name,
             const QJSValue& callback);

--- a/src/controllers/softtakeover.cpp
+++ b/src/controllers/softtakeover.cpp
@@ -119,7 +119,7 @@ bool SoftTakeover::ignore(ControlObject* control, double newParameter) {
 //                  << newParameter;
     } else if (currentTime - m_time > kSubsequentValueOverrideTime) {
         // don't ignore value if a previous one was not ignored in time
-        const double currentParameter = control->getParameter();
+        const double currentParameter = control->getNormalizedValue();
         const double difference = currentParameter - newParameter;
         const double prevDiff = currentParameter - m_prevParameter;
         if ((prevDiff < 0 && difference < 0) ||

--- a/src/controllers/softtakeover.h
+++ b/src/controllers/softtakeover.h
@@ -12,7 +12,7 @@ class SoftTakeover {
     static const double kDefaultTakeoverThreshold;
 
     SoftTakeover();
-    bool ignore(ControlObject* control, double newParameter);
+    bool ignore(ControlObject* control, double newNormalizedValue);
     void ignoreNext();
     void setThreshold(double threshold);
 
@@ -26,7 +26,7 @@ class SoftTakeover {
     static const mixxx::Duration kSubsequentValueOverrideTime;
 
     mixxx::Duration m_time;
-    double m_prevParameter;
+    double m_prevNormalizedValue;
     double m_dThreshold;
 };
 
@@ -46,8 +46,8 @@ class SoftTakeoverCtrl {
     void enable(ControlObject* control);
     // Disable soft-takeover for the given Control
     void disable(ControlObject* control);
-    // Check to see if the new value for the Control should be ignored
-    bool ignore(ControlObject* control, double newMidiParameter);
+    // Check to see if the new normalized value for the Control should be ignored
+    bool ignore(ControlObject* control, double newNormalizedValue);
     // Ignore the next supplied parameter
     void ignoreNext(ControlObject* control);
 

--- a/src/effects/effectbuttonparameterslot.cpp
+++ b/src/effects/effectbuttonparameterslot.cpp
@@ -73,5 +73,5 @@ void EffectButtonParameterSlot::clear() {
 }
 
 void EffectButtonParameterSlot::setParameter(double value) {
-    m_pControlValue->setParameterFrom(value, this);
+    m_pControlValue->setNormalizedValueFrom(value, this);
 }

--- a/src/effects/effectknobparameterslot.cpp
+++ b/src/effects/effectknobparameterslot.cpp
@@ -108,7 +108,7 @@ void EffectKnobParameterSlot::clear() {
 }
 
 void EffectKnobParameterSlot::setParameter(double value) {
-    m_pControlValue->setParameterFrom(value, this);
+    m_pControlValue->setNormalizedValueFrom(value, this);
 }
 
 void EffectKnobParameterSlot::slotLinkTypeChanging(double v) {
@@ -222,20 +222,20 @@ void EffectKnobParameterSlot::onEffectMetaParameterChanged(double parameter, boo
 
         //qDebug() << "onEffectMetaParameterChanged" << debugString() << parameter << "force?" << force;
         if (force) {
-            m_pControlValue->setParameterFrom(parameter, nullptr);
+            m_pControlValue->setNormalizedValueFrom(parameter, nullptr);
             // This ensures that softtakover is in sync for following updates
             m_pMetaknobSoftTakeover->ignore(m_pControlValue, parameter);
         } else if (!m_pMetaknobSoftTakeover->ignore(m_pControlValue, parameter)) {
-            m_pControlValue->setParameterFrom(parameter, nullptr);
+            m_pControlValue->setNormalizedValueFrom(parameter, nullptr);
         }
     }
 }
 
 void EffectKnobParameterSlot::syncSofttakeover() {
-    double parameter = m_pControlValue->getParameter();
+    double parameter = m_pControlValue->getNormalizedValue();
     m_pMetaknobSoftTakeover->ignore(m_pControlValue, parameter);
 }
 
 double EffectKnobParameterSlot::getValueParameter() const {
-    return m_pControlValue->getParameter();
+    return m_pControlValue->getNormalizedValue();
 }

--- a/src/qml/qmlcontrolproxy.cpp
+++ b/src/qml/qmlcontrolproxy.cpp
@@ -7,7 +7,7 @@ namespace qml {
 
 namespace {
 constexpr double kDefaultValue = 0.0;
-constexpr double kDefaultParameter = 0.0;
+constexpr double kDefaultNormalizedValue = 0.0;
 } // namespace
 
 QmlControlProxy::QmlControlProxy(QObject* parent)
@@ -87,21 +87,21 @@ double QmlControlProxy::getValue() const {
     return m_pControlProxy->get();
 }
 
-void QmlControlProxy::setParameter(double newValue) {
+void QmlControlProxy::setNormalizedValue(double newValue) {
     if (!isInitialized()) {
-        emit parameterChanged(kDefaultValue);
+        emit normalizedValueChanged(kDefaultNormalizedValue);
         return;
     }
-    m_pControlProxy->setParameter(newValue);
+    m_pControlProxy->setNormalizedValue(newValue);
     emit valueChanged(m_pControlProxy->get());
-    emit parameterChanged(newValue);
+    emit normalizedValueChanged(newValue);
 }
 
-double QmlControlProxy::getParameter() const {
+double QmlControlProxy::getNormalizedValue() const {
     if (!isInitialized()) {
-        return kDefaultParameter;
+        return kDefaultNormalizedValue;
     }
-    return m_pControlProxy->getParameter();
+    return m_pControlProxy->getNormalizedValue();
 }
 
 void QmlControlProxy::reset() {
@@ -175,7 +175,7 @@ void QmlControlProxy::reinitializeFromKey() {
 
 void QmlControlProxy::slotControlProxyValueChanged(double newValue) {
     emit valueChanged(newValue);
-    emit parameterChanged(m_pControlProxy->getParameter());
+    emit normalizedValueChanged(m_pControlProxy->getNormalizedValue());
 }
 
 } // namespace qml

--- a/src/qml/qmlcontrolproxy.h
+++ b/src/qml/qmlcontrolproxy.h
@@ -21,7 +21,8 @@ class QmlControlProxy : public QObject, public QQmlParserStatus {
     Q_PROPERTY(bool keyValid READ isKeyValid NOTIFY keyValidChanged)
     Q_PROPERTY(bool initialized READ isInitialized NOTIFY initializedChanged)
     Q_PROPERTY(double value READ getValue WRITE setValue NOTIFY valueChanged)
-    Q_PROPERTY(double parameter READ getParameter WRITE setParameter NOTIFY parameterChanged)
+    Q_PROPERTY(double normalizedValue READ getNormalizedValue WRITE
+                    setNormalizedValue NOTIFY normalizedValueChanged)
     QML_NAMED_ELEMENT(ControlProxy)
 
   public:
@@ -49,8 +50,8 @@ class QmlControlProxy : public QObject, public QQmlParserStatus {
     void setValue(double newValue);
     double getValue() const;
 
-    void setParameter(double newValue);
-    double getParameter() const;
+    void setNormalizedValue(double newValue);
+    double getNormalizedValue() const;
 
     bool isKeyValid() const;
     bool isInitialized() const;
@@ -64,10 +65,10 @@ class QmlControlProxy : public QObject, public QQmlParserStatus {
     void keyValidChanged(bool valid);
     void initializedChanged(bool initialized);
     void valueChanged(double newValue);
-    void parameterChanged(double newParameter);
+    void normalizedValueChanged(double newNormalizedValue);
 
   private slots:
-    /// Emits both the valueChanged and parameterChanged signals
+    /// Emits both the valueChanged and normalizedValueChanged signals
     void slotControlProxyValueChanged(double newValue);
 
   private:

--- a/src/test/audiotaperpot_test.cpp
+++ b/src/test/audiotaperpot_test.cpp
@@ -16,19 +16,23 @@ TEST_F(AudioTaperPotTest, ScaleTest) {
         constexpr double neutralParameter = 0.5;
         ControlAudioTaperPotBehavior catpb(minDB, maxDB, neutralParameter);
         // Parameter 0 is always 0 (-Infinity)
-        ASSERT_DOUBLE_EQ(0.0, catpb.parameterToValue(0));
+        ASSERT_DOUBLE_EQ(0.0, catpb.normalizedValueToValue(0));
         // Parameter 0 is always 0 (-Infinity)
-        ASSERT_DOUBLE_EQ(1.0, catpb.parameterToValue(neutralParameter));
+        ASSERT_DOUBLE_EQ(1.0, catpb.normalizedValueToValue(neutralParameter));
         // Parameter 1 is always maxDB
-        ASSERT_DOUBLE_EQ(db2ratio(maxDB), catpb.parameterToValue(1));
+        ASSERT_DOUBLE_EQ(db2ratio(maxDB), catpb.normalizedValueToValue(1));
         // value 1 is always on a Integer midi value
-        double neutralMidi = catpb.valueToMidiParameter(1);
+        double neutralMidi = catpb.valueToMidi7Bit(1);
         ASSERT_DOUBLE_EQ(0.0, fmod(neutralMidi, 1));
         // Midi value 64 should result in 0,5
-        ASSERT_DOUBLE_EQ(neutralParameter, catpb.midiToParameter(neutralMidi));
+        ASSERT_DOUBLE_EQ(neutralParameter, catpb.midi7BitToNormalizedValue(neutralMidi));
         // roundtrip check
-        ASSERT_DOUBLE_EQ(0.25, catpb.parameterToValue(catpb.midiToParameter(catpb.valueToMidiParameter(0.25))));
-        ASSERT_DOUBLE_EQ(0.75, catpb.parameterToValue(catpb.midiToParameter(catpb.valueToMidiParameter(0.75))));
+        ASSERT_DOUBLE_EQ(0.25,
+                catpb.normalizedValueToValue(catpb.midi7BitToNormalizedValue(
+                        catpb.valueToMidi7Bit(0.25))));
+        ASSERT_DOUBLE_EQ(0.75,
+                catpb.normalizedValueToValue(catpb.midi7BitToNormalizedValue(
+                        catpb.valueToMidi7Bit(0.75))));
     }
 
     {
@@ -37,19 +41,23 @@ TEST_F(AudioTaperPotTest, ScaleTest) {
         constexpr double neutralParameter = 0.5;
         ControlAudioTaperPotBehavior catpb(minDB, maxDB, neutralParameter);
         // Parameter 0 is always 0 (-Infinity)
-        ASSERT_DOUBLE_EQ(0.0, catpb.parameterToValue(0));
+        ASSERT_DOUBLE_EQ(0.0, catpb.normalizedValueToValue(0));
         // Parameter 0 is always 0 (-Infinity)
-        ASSERT_DOUBLE_EQ(1.0, catpb.parameterToValue(neutralParameter));
+        ASSERT_DOUBLE_EQ(1.0, catpb.normalizedValueToValue(neutralParameter));
         // Parameter 1 is always maxDB
-        ASSERT_DOUBLE_EQ(db2ratio(maxDB), catpb.parameterToValue(1));
+        ASSERT_DOUBLE_EQ(db2ratio(maxDB), catpb.normalizedValueToValue(1));
         // value 1 is always on a Integer midi value
-        double neutralMidi = catpb.valueToMidiParameter(1);
+        double neutralMidi = catpb.valueToMidi7Bit(1);
         ASSERT_DOUBLE_EQ(0.0, fmod(neutralMidi, 1));
         // Midi value 64 should result in 0,5
-        ASSERT_DOUBLE_EQ(neutralParameter, catpb.midiToParameter(neutralMidi));
+        ASSERT_DOUBLE_EQ(neutralParameter, catpb.midi7BitToNormalizedValue(neutralMidi));
         // roundtrip check
-        ASSERT_DOUBLE_EQ(0.25, catpb.parameterToValue(catpb.midiToParameter(catpb.valueToMidiParameter(0.25))));
-        ASSERT_DOUBLE_EQ(0.75, catpb.parameterToValue(catpb.midiToParameter(catpb.valueToMidiParameter(0.75))));
+        ASSERT_DOUBLE_EQ(0.25,
+                catpb.normalizedValueToValue(catpb.midi7BitToNormalizedValue(
+                        catpb.valueToMidi7Bit(0.25))));
+        ASSERT_DOUBLE_EQ(0.75,
+                catpb.normalizedValueToValue(catpb.midi7BitToNormalizedValue(
+                        catpb.valueToMidi7Bit(0.75))));
     }
 
     {
@@ -58,18 +66,22 @@ TEST_F(AudioTaperPotTest, ScaleTest) {
         constexpr double neutralParameter = 1;
         ControlAudioTaperPotBehavior catpb(minDB, maxDB, neutralParameter);
         // Parameter 0 is always 0 (-Infinity)
-        ASSERT_DOUBLE_EQ(0.0, catpb.parameterToValue(0));
+        ASSERT_DOUBLE_EQ(0.0, catpb.normalizedValueToValue(0));
         // Parameter 0 is always 0 (-Infinity)
-        ASSERT_DOUBLE_EQ(1.0, catpb.parameterToValue(neutralParameter));
+        ASSERT_DOUBLE_EQ(1.0, catpb.normalizedValueToValue(neutralParameter));
         // Parameter 1 is always maxDB
-        ASSERT_DOUBLE_EQ(db2ratio(maxDB), catpb.parameterToValue(1));
+        ASSERT_DOUBLE_EQ(db2ratio(maxDB), catpb.normalizedValueToValue(1));
         // value 1 is always on a Integer midi value
-        double neutralMidi = catpb.valueToMidiParameter(1);
+        double neutralMidi = catpb.valueToMidi7Bit(1);
         ASSERT_DOUBLE_EQ(0.0, fmod(neutralMidi, 1));
         // Midi value 64 should result in 0,5
-        ASSERT_DOUBLE_EQ(neutralParameter, catpb.midiToParameter(neutralMidi));
+        ASSERT_DOUBLE_EQ(neutralParameter, catpb.midi7BitToNormalizedValue(neutralMidi));
         // roundtrip checkx
-        ASSERT_DOUBLE_EQ(0.25, catpb.parameterToValue(catpb.midiToParameter(catpb.valueToMidiParameter(0.25))));
-        ASSERT_DOUBLE_EQ(0.75, catpb.parameterToValue(catpb.midiToParameter(catpb.valueToMidiParameter(0.75))));
+        ASSERT_DOUBLE_EQ(0.25,
+                catpb.normalizedValueToValue(catpb.midi7BitToNormalizedValue(
+                        catpb.valueToMidi7Bit(0.25))));
+        ASSERT_DOUBLE_EQ(0.75,
+                catpb.normalizedValueToValue(catpb.midi7BitToNormalizedValue(
+                        catpb.valueToMidi7Bit(0.75))));
     }
 }

--- a/src/test/controllerscriptenginelegacy_test.cpp
+++ b/src/test/controllerscriptenginelegacy_test.cpp
@@ -109,38 +109,48 @@ TEST_F(ControllerScriptEngineLegacyTest, getSetValue) {
     EXPECT_DOUBLE_EQ(1.0, co->get());
 }
 
-TEST_F(ControllerScriptEngineLegacyTest, setParameter) {
+TEST_F(ControllerScriptEngineLegacyTest, setNormalizedValue) {
     auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Test]", "co"),
             -10.0,
             10.0);
-    EXPECT_TRUE(evaluateAndAssert("engine.setParameter('[Test]', 'co', 1.0);"));
+    EXPECT_TRUE(evaluateAndAssert("engine.setNormalizedValue('[Test]', 'co', 1.0);"));
     EXPECT_DOUBLE_EQ(10.0, co->get());
-    EXPECT_TRUE(evaluateAndAssert("engine.setParameter('[Test]', 'co', 0.0);"));
+    EXPECT_TRUE(evaluateAndAssert("engine.setNormalizedValue('[Test]', 'co', 0.0);"));
     EXPECT_DOUBLE_EQ(-10.0, co->get());
-    EXPECT_TRUE(evaluateAndAssert("engine.setParameter('[Test]', 'co', 0.5);"));
+    EXPECT_TRUE(evaluateAndAssert("engine.setNormalizedValue('[Test]', 'co', 0.5);"));
     EXPECT_DOUBLE_EQ(0.0, co->get());
 }
 
-TEST_F(ControllerScriptEngineLegacyTest, setParameter_OutOfRange) {
+TEST_F(ControllerScriptEngineLegacyTest, setNormalizedValue_OutOfRange) {
     auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Test]", "co"),
             -10.0,
             10.0);
-    EXPECT_TRUE(evaluateAndAssert("engine.setParameter('[Test]', 'co', 1000);"));
+    EXPECT_TRUE(evaluateAndAssert("engine.setNormalizedValue('[Test]', 'co', 1000);"));
     EXPECT_DOUBLE_EQ(10.0, co->get());
-    EXPECT_TRUE(evaluateAndAssert("engine.setParameter('[Test]', 'co', -1000);"));
+    EXPECT_TRUE(evaluateAndAssert("engine.setNormalizedValue('[Test]', 'co', -1000);"));
     EXPECT_DOUBLE_EQ(-10.0, co->get());
 }
 
-TEST_F(ControllerScriptEngineLegacyTest, setParameter_NaN) {
+TEST_F(ControllerScriptEngineLegacyTest, setNormalizedValue_NaN) {
     // Test that NaNs are ignored.
     auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Test]", "co"),
             -10.0,
             10.0);
-    EXPECT_TRUE(evaluateAndAssert("engine.setParameter('[Test]', 'co', NaN);"));
+    EXPECT_TRUE(evaluateAndAssert("engine.setNormalizedValue('[Test]', 'co', NaN);"));
     EXPECT_DOUBLE_EQ(0.0, co->get());
 }
 
-TEST_F(ControllerScriptEngineLegacyTest, getSetParameter) {
+TEST_F(ControllerScriptEngineLegacyTest, getSetNormalizedValue) {
+    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Test]", "co"),
+            -10.0,
+            10.0);
+    EXPECT_TRUE(evaluateAndAssert(
+            "engine.setNormalizedValue('[Test]', 'co', "
+            "  engine.getNormalizedValue('[Test]', 'co') + 0.1);"));
+    EXPECT_DOUBLE_EQ(2.0, co->get());
+}
+
+TEST_F(ControllerScriptEngineLegacyTest, getSetParameterAlias) {
     auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Test]", "co"),
             -10.0,
             10.0);
@@ -148,6 +158,57 @@ TEST_F(ControllerScriptEngineLegacyTest, getSetParameter) {
             "engine.setParameter('[Test]', 'co', "
             "  engine.getParameter('[Test]', 'co') + 0.1);"));
     EXPECT_DOUBLE_EQ(2.0, co->get());
+    EXPECT_TRUE(evaluateAndAssert(
+            "engine.setParameter('[Test]', 'co', "
+            "  engine.getNormalizedValue('[Test]', 'co') + 0.1);"));
+    EXPECT_DOUBLE_EQ(4.0, co->get());
+    EXPECT_TRUE(evaluateAndAssert(
+            "engine.setNormalizedValue('[Test]', 'co', "
+            "  engine.getParameter('[Test]', 'co') + 0.1);"));
+    EXPECT_DOUBLE_EQ(6.0, co->get());
+}
+
+TEST_F(ControllerScriptEngineLegacyTest, getNormalizedValueForValue) {
+    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Test]", "co"),
+            -10.0,
+            10.0);
+    auto co2 = std::make_unique<ControlPotmeter>(ConfigKey("[Test]", "co2"),
+            -10.0,
+            10.0);
+    EXPECT_TRUE(evaluateAndAssert(
+            "engine.setValue('[Test]', 'co2', "
+            "  engine.getNormalizedValueForValue('[Test]', 'co', 7.0));"));
+    EXPECT_DOUBLE_EQ(0.85, co2->get());
+
+    EXPECT_TRUE(evaluateAndAssert(
+            "engine.setValue('[Test]', 'co2', "
+            "  engine.getParameterForValue('[Test]', 'co', -8.0));"));
+    // ControlObjectScript connections are processed via QueuedConnection. Use
+    // processEvents() to cause Qt to deliver them.
+    processEvents();
+    EXPECT_DOUBLE_EQ(0.1, co2->get());
+}
+
+TEST_F(ControllerScriptEngineLegacyTest, getNormalizedDefaultValue) {
+    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Test]", "co"),
+            -10.0,
+            10.0);
+    auto co2 = std::make_unique<ControlPotmeter>(ConfigKey("[Test]", "co2"),
+            -10.0,
+            10.0);
+
+    co->setDefaultValue(6.0);
+    EXPECT_TRUE(evaluateAndAssert(
+            "engine.setValue('[Test]', 'co2', "
+            "  engine.getNormalizedDefaultValue('[Test]', 'co'));"));
+    EXPECT_DOUBLE_EQ(0.8, co2->get());
+
+    co2->setNormalizedValue(0.0);
+    co->setDefaultValue(-4.0);
+    EXPECT_TRUE(evaluateAndAssert(
+            "engine.setValue('[Test]', 'co2', "
+            "  engine.getDefaultParameter('[Test]', 'co'));"));
+    EXPECT_DOUBLE_EQ(0.3, co2->get());
 }
 
 TEST_F(ControllerScriptEngineLegacyTest, softTakeover_setValue) {
@@ -189,7 +250,7 @@ TEST_F(ControllerScriptEngineLegacyTest, softTakeover_setParameter) {
     co->setNormalizedValue(0.0);
     EXPECT_TRUE(evaluateAndAssert(
             "engine.softTakeover('[Test]', 'co', true);"
-            "engine.setParameter('[Test]', 'co', 1.0);"));
+            "engine.setNormalizedValue('[Test]', 'co', 1.0);"));
     // The first set after enabling is always ignored.
     EXPECT_DOUBLE_EQ(-10.0, co->get());
 
@@ -199,7 +260,7 @@ TEST_F(ControllerScriptEngineLegacyTest, softTakeover_setParameter) {
 
     // Time elapsed is not greater than the threshold, so we do not ignore this
     // set.
-    EXPECT_TRUE(evaluateAndAssert("engine.setParameter('[Test]', 'co', 0.0);"));
+    EXPECT_TRUE(evaluateAndAssert("engine.setNormalizedValue('[Test]', 'co', 0.0);"));
     EXPECT_DOUBLE_EQ(-10.0, co->get());
 
     // Advance time to 2x the threshold.
@@ -210,7 +271,7 @@ TEST_F(ControllerScriptEngineLegacyTest, softTakeover_setParameter) {
     co->setNormalizedValue(0.5);
 
     // Ignore the change since it occurred after the threshold and is too large.
-    EXPECT_TRUE(evaluateAndAssert("engine.setParameter('[Test]', 'co', 0.0);"));
+    EXPECT_TRUE(evaluateAndAssert("engine.setNormalizedValue('[Test]', 'co', 0.0);"));
     EXPECT_DOUBLE_EQ(0.0, co->get());
 }
 
@@ -221,7 +282,7 @@ TEST_F(ControllerScriptEngineLegacyTest, softTakeover_ignoreNextValue) {
     co->setNormalizedValue(0.0);
     EXPECT_TRUE(evaluateAndAssert(
             "engine.softTakeover('[Test]', 'co', true);"
-            "engine.setParameter('[Test]', 'co', 1.0);"));
+            "engine.setNormalizedValue('[Test]', 'co', 1.0);"));
     // The first set after enabling is always ignored.
     EXPECT_DOUBLE_EQ(-10.0, co->get());
 
@@ -233,7 +294,7 @@ TEST_F(ControllerScriptEngineLegacyTest, softTakeover_ignoreNextValue) {
 
     // We would normally allow this set since it is below the time threshold,
     // but we are ignoring the next value.
-    EXPECT_TRUE(evaluateAndAssert("engine.setParameter('[Test]', 'co', 0.0);"));
+    EXPECT_TRUE(evaluateAndAssert("engine.setNormalizedValue('[Test]', 'co', 0.0);"));
     EXPECT_DOUBLE_EQ(0.0, co->get());
 }
 

--- a/src/test/controllerscriptenginelegacy_test.cpp
+++ b/src/test/controllerscriptenginelegacy_test.cpp
@@ -154,7 +154,7 @@ TEST_F(ControllerScriptEngineLegacyTest, softTakeover_setValue) {
     auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Test]", "co"),
             -10.0,
             10.0);
-    co->setParameter(0.0);
+    co->setNormalizedValue(0.0);
     EXPECT_TRUE(evaluateAndAssert(
             "engine.softTakeover('[Test]', 'co', true);"
             "engine.setValue('[Test]', 'co', 0.0);"));
@@ -163,7 +163,7 @@ TEST_F(ControllerScriptEngineLegacyTest, softTakeover_setValue) {
 
     // Change the control internally (putting it out of sync with the
     // ControllerEngine).
-    co->setParameter(0.5);
+    co->setNormalizedValue(0.5);
 
     // Time elapsed is not greater than the threshold, so we do not ignore this
     // set.
@@ -175,7 +175,7 @@ TEST_F(ControllerScriptEngineLegacyTest, softTakeover_setValue) {
 
     // Change the control internally (putting it out of sync with the
     // ControllerEngine).
-    co->setParameter(0.5);
+    co->setNormalizedValue(0.5);
 
     // Ignore the change since it occurred after the threshold and is too large.
     EXPECT_TRUE(evaluateAndAssert("engine.setValue('[Test]', 'co', -10.0);"));
@@ -186,7 +186,7 @@ TEST_F(ControllerScriptEngineLegacyTest, softTakeover_setParameter) {
     auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Test]", "co"),
             -10.0,
             10.0);
-    co->setParameter(0.0);
+    co->setNormalizedValue(0.0);
     EXPECT_TRUE(evaluateAndAssert(
             "engine.softTakeover('[Test]', 'co', true);"
             "engine.setParameter('[Test]', 'co', 1.0);"));
@@ -195,7 +195,7 @@ TEST_F(ControllerScriptEngineLegacyTest, softTakeover_setParameter) {
 
     // Change the control internally (putting it out of sync with the
     // ControllerEngine).
-    co->setParameter(0.5);
+    co->setNormalizedValue(0.5);
 
     // Time elapsed is not greater than the threshold, so we do not ignore this
     // set.
@@ -207,7 +207,7 @@ TEST_F(ControllerScriptEngineLegacyTest, softTakeover_setParameter) {
 
     // Change the control internally (putting it out of sync with the
     // ControllerEngine).
-    co->setParameter(0.5);
+    co->setNormalizedValue(0.5);
 
     // Ignore the change since it occurred after the threshold and is too large.
     EXPECT_TRUE(evaluateAndAssert("engine.setParameter('[Test]', 'co', 0.0);"));
@@ -218,7 +218,7 @@ TEST_F(ControllerScriptEngineLegacyTest, softTakeover_ignoreNextValue) {
     auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Test]", "co"),
             -10.0,
             10.0);
-    co->setParameter(0.0);
+    co->setNormalizedValue(0.0);
     EXPECT_TRUE(evaluateAndAssert(
             "engine.softTakeover('[Test]', 'co', true);"
             "engine.setParameter('[Test]', 'co', 1.0);"));
@@ -227,7 +227,7 @@ TEST_F(ControllerScriptEngineLegacyTest, softTakeover_ignoreNextValue) {
 
     // Change the control internally (putting it out of sync with the
     // ControllerEngine).
-    co->setParameter(0.5);
+    co->setNormalizedValue(0.5);
 
     EXPECT_TRUE(evaluateAndAssert("engine.softTakeoverIgnoreNextValue('[Test]', 'co');"));
 
@@ -242,7 +242,7 @@ TEST_F(ControllerScriptEngineLegacyTest, reset) {
     auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Test]", "co"),
             -10.0,
             10.0);
-    co->setParameter(1.0);
+    co->setNormalizedValue(1.0);
     EXPECT_TRUE(evaluateAndAssert("engine.reset('[Test]', 'co');"));
     EXPECT_DOUBLE_EQ(0.0, co->get());
 }

--- a/src/test/softtakeover_test.cpp
+++ b/src/test/softtakeover_test.cpp
@@ -60,8 +60,8 @@ TEST_F(SoftTakeoverTest, DoesntIgnoreSameValue) {
     SoftTakeoverCtrl st_control;
     st_control.enable(co.get());
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(0.6)));
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(0.6)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(0.6)));
+    EXPECT_FALSE(st_control.ignore(co.get(), co->getNormalizedValueForValue(0.6)));
 }
 
 // These are corner cases that allow for quickly flicking/whipping controls
@@ -75,17 +75,17 @@ TEST_F(SoftTakeoverTest, SuperFastPrevEqCurrent) {
     st_control.enable(co.get());
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(-250)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(-250)));
     // This can happen any time afterwards, so we test 10 seconds
     mixxx::Time::setTestElapsedTime(mixxx::Duration::fromSeconds(10));
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(200)));
+    EXPECT_FALSE(st_control.ignore(co.get(), co->getNormalizedValueForValue(200)));
 
     // From the top
     co->set(250);
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(250)));
+    EXPECT_FALSE(st_control.ignore(co.get(), co->getNormalizedValueForValue(250)));
     // This can happen any time afterwards, so we test 10 seconds
     mixxx::Time::setTestElapsedTime(mixxx::Duration::fromSeconds(10));
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(-200)));
+    EXPECT_FALSE(st_control.ignore(co.get(), co->getNormalizedValueForValue(-200)));
 }
 
 // But when they don't match, this type of thing should be ignored!
@@ -98,10 +98,10 @@ TEST_F(SoftTakeoverTest, DISABLED_SuperFastNotSame) {
     st_control.enable(co.get());
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(249)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(249)));
     // This can happen any time afterwards, so we test 10 seconds
     mixxx::Time::setTestElapsedTime(mixxx::Duration::fromSeconds(10));
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(-200)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(-200)));
 }
 
 /* The meat of the tests
@@ -126,8 +126,8 @@ TEST_F(SoftTakeoverTest, PrevNearLess_NewNearLess_Soon) {
     st_control.enable(co.get());
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(40)));
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(45)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(40)));
+    EXPECT_FALSE(st_control.ignore(co.get(), co->getNormalizedValueForValue(45)));
 }
 
 TEST_F(SoftTakeoverTest, PrevNearLess_NewNearMore_Soon) {
@@ -138,8 +138,8 @@ TEST_F(SoftTakeoverTest, PrevNearLess_NewNearMore_Soon) {
     st_control.enable(co.get());
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(40)));
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(60)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(40)));
+    EXPECT_FALSE(st_control.ignore(co.get(), co->getNormalizedValueForValue(60)));
 }
 
 TEST_F(SoftTakeoverTest, PrevNearLess_NewFarLess_Soon) {
@@ -150,8 +150,8 @@ TEST_F(SoftTakeoverTest, PrevNearLess_NewFarLess_Soon) {
     st_control.enable(co.get());
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(40)));
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(1)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(40)));
+    EXPECT_FALSE(st_control.ignore(co.get(), co->getNormalizedValueForValue(1)));
 }
 
 TEST_F(SoftTakeoverTest, PrevNearLess_NewFarMore_Soon) {
@@ -162,8 +162,8 @@ TEST_F(SoftTakeoverTest, PrevNearLess_NewFarMore_Soon) {
     st_control.enable(co.get());
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(40)));
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(100)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(40)));
+    EXPECT_FALSE(st_control.ignore(co.get(), co->getNormalizedValueForValue(100)));
 }
 
 TEST_F(SoftTakeoverTest, PrevNearLess_NewNearLess_Late) {
@@ -174,9 +174,9 @@ TEST_F(SoftTakeoverTest, PrevNearLess_NewNearLess_Late) {
     st_control.enable(co.get());
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(40)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(40)));
     mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(45)));
+    EXPECT_FALSE(st_control.ignore(co.get(), co->getNormalizedValueForValue(45)));
 }
 
 TEST_F(SoftTakeoverTest, PrevNearLess_NewNearMore_Late) {
@@ -187,9 +187,9 @@ TEST_F(SoftTakeoverTest, PrevNearLess_NewNearMore_Late) {
     st_control.enable(co.get());
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(40)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(40)));
     mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(60)));
+    EXPECT_FALSE(st_control.ignore(co.get(), co->getNormalizedValueForValue(60)));
 }
 
 // Ignore this case:
@@ -204,9 +204,9 @@ TEST_F(SoftTakeoverTest, DISABLED_PrevNearLess_NewFarLess_Late) {
     st_control.enable(co.get());
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(40)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(40)));
     mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(1)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(1)));
 }
 
 // Ignore this case:
@@ -221,9 +221,9 @@ TEST_F(SoftTakeoverTest, DISABLED_PrevNearLess_NewFarMore_Late) {
     st_control.enable(co.get());
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(40)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(40)));
     mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(100)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(100)));
 }
 
 // ---- Previous Near & greater than current
@@ -236,8 +236,8 @@ TEST_F(SoftTakeoverTest, PrevNearMore_NewNearLess_Soon) {
     st_control.enable(co.get());
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(55)));
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(45)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(55)));
+    EXPECT_FALSE(st_control.ignore(co.get(), co->getNormalizedValueForValue(45)));
 }
 
 TEST_F(SoftTakeoverTest, PrevNearMore_NewNearMore_Soon) {
@@ -248,8 +248,8 @@ TEST_F(SoftTakeoverTest, PrevNearMore_NewNearMore_Soon) {
     st_control.enable(co.get());
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(55)));
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(60)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(55)));
+    EXPECT_FALSE(st_control.ignore(co.get(), co->getNormalizedValueForValue(60)));
 }
 
 TEST_F(SoftTakeoverTest, PrevNearMore_NewFarLess_Soon) {
@@ -260,8 +260,8 @@ TEST_F(SoftTakeoverTest, PrevNearMore_NewFarLess_Soon) {
     st_control.enable(co.get());
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(55)));
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(1)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(55)));
+    EXPECT_FALSE(st_control.ignore(co.get(), co->getNormalizedValueForValue(1)));
 }
 
 TEST_F(SoftTakeoverTest, PrevNearMore_NewFarMore_Soon) {
@@ -272,8 +272,8 @@ TEST_F(SoftTakeoverTest, PrevNearMore_NewFarMore_Soon) {
     st_control.enable(co.get());
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(55)));
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(100)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(55)));
+    EXPECT_FALSE(st_control.ignore(co.get(), co->getNormalizedValueForValue(100)));
 }
 
 TEST_F(SoftTakeoverTest, PrevNearMore_NewNearLess_Late) {
@@ -284,9 +284,9 @@ TEST_F(SoftTakeoverTest, PrevNearMore_NewNearLess_Late) {
     st_control.enable(co.get());
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(55)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(55)));
     mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(45)));
+    EXPECT_FALSE(st_control.ignore(co.get(), co->getNormalizedValueForValue(45)));
 }
 
 TEST_F(SoftTakeoverTest, PrevNearMore_NewNearMore_Late) {
@@ -297,9 +297,9 @@ TEST_F(SoftTakeoverTest, PrevNearMore_NewNearMore_Late) {
     st_control.enable(co.get());
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(55)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(55)));
     mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(60)));
+    EXPECT_FALSE(st_control.ignore(co.get(), co->getNormalizedValueForValue(60)));
 }
 
 // Ignore this case:
@@ -314,9 +314,9 @@ TEST_F(SoftTakeoverTest, DISABLED_PrevNearMore_NewFarLess_Late) {
     st_control.enable(co.get());
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(55)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(55)));
     mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(1)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(1)));
 }
 
 // Ignore this case:
@@ -331,9 +331,9 @@ TEST_F(SoftTakeoverTest, DISABLED_PrevNearMore_NewFarMore_Late) {
     st_control.enable(co.get());
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(55)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(55)));
     mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(100)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(100)));
 }
 
 // ---- Previous Far & less than current
@@ -346,8 +346,8 @@ TEST_F(SoftTakeoverTest, PrevFarLess_NewNearLess_Soon) {
     st_control.enable(co.get());
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(-50)));
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(45)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(-50)));
+    EXPECT_FALSE(st_control.ignore(co.get(), co->getNormalizedValueForValue(45)));
 }
 
 TEST_F(SoftTakeoverTest, PrevFarLess_NewNearMore_Soon) {
@@ -358,8 +358,8 @@ TEST_F(SoftTakeoverTest, PrevFarLess_NewNearMore_Soon) {
     st_control.enable(co.get());
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(-50)));
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(60)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(-50)));
+    EXPECT_FALSE(st_control.ignore(co.get(), co->getNormalizedValueForValue(60)));
 }
 
 // Ignore this case:
@@ -374,8 +374,8 @@ TEST_F(SoftTakeoverTest, DISABLED_PrevFarLess_NewFarLess_Soon) {
     st_control.enable(co.get());
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(-50)));
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(1)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(-50)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(1)));
 }
 
 TEST_F(SoftTakeoverTest, PrevFarLess_NewFarMore_Soon) {
@@ -386,8 +386,8 @@ TEST_F(SoftTakeoverTest, PrevFarLess_NewFarMore_Soon) {
     st_control.enable(co.get());
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(-50)));
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(100)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(-50)));
+    EXPECT_FALSE(st_control.ignore(co.get(), co->getNormalizedValueForValue(100)));
 }
 
 TEST_F(SoftTakeoverTest, PrevFarLess_NewNearLess_Late) {
@@ -398,9 +398,9 @@ TEST_F(SoftTakeoverTest, PrevFarLess_NewNearLess_Late) {
     st_control.enable(co.get());
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(-50)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(-50)));
     mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(45)));
+    EXPECT_FALSE(st_control.ignore(co.get(), co->getNormalizedValueForValue(45)));
 }
 
 TEST_F(SoftTakeoverTest, PrevFarLess_NewNearMore_Late) {
@@ -411,9 +411,9 @@ TEST_F(SoftTakeoverTest, PrevFarLess_NewNearMore_Late) {
     st_control.enable(co.get());
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(-50)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(-50)));
     mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(60)));
+    EXPECT_FALSE(st_control.ignore(co.get(), co->getNormalizedValueForValue(60)));
 }
 
 // Ignore this case:
@@ -427,9 +427,9 @@ TEST_F(SoftTakeoverTest, PrevFarLess_NewFarLess_Late) {
     st_control.enable(co.get());
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(-50)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(-50)));
     mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(1)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(1)));
 }
 
 // Ignore this case:
@@ -444,9 +444,9 @@ TEST_F(SoftTakeoverTest, DISABLED_PrevFarLess_NewFarMore_Late) {
     st_control.enable(co.get());
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(-50)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(-50)));
     mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(100)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(100)));
 }
 
 // ---- Previous Far & greater than current
@@ -459,8 +459,8 @@ TEST_F(SoftTakeoverTest, PrevFarMore_NewNearLess_Soon) {
     st_control.enable(co.get());
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(120)));
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(45)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(120)));
+    EXPECT_FALSE(st_control.ignore(co.get(), co->getNormalizedValueForValue(45)));
 }
 
 TEST_F(SoftTakeoverTest, PrevFarMore_NewNearMore_Soon) {
@@ -471,8 +471,8 @@ TEST_F(SoftTakeoverTest, PrevFarMore_NewNearMore_Soon) {
     st_control.enable(co.get());
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(120)));
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(60)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(120)));
+    EXPECT_FALSE(st_control.ignore(co.get(), co->getNormalizedValueForValue(60)));
 }
 
 TEST_F(SoftTakeoverTest, PrevFarMore_NewFarLess_Soon) {
@@ -483,8 +483,8 @@ TEST_F(SoftTakeoverTest, PrevFarMore_NewFarLess_Soon) {
     st_control.enable(co.get());
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(120)));
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(1)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(120)));
+    EXPECT_FALSE(st_control.ignore(co.get(), co->getNormalizedValueForValue(1)));
 }
 
 // Ignore this case:
@@ -499,8 +499,8 @@ TEST_F(SoftTakeoverTest, DISABLED_PrevFarMore_NewFarMore_Soon) {
     st_control.enable(co.get());
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(120)));
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(100)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(120)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(100)));
 }
 
 TEST_F(SoftTakeoverTest, PrevFarMore_NewNearLess_Late) {
@@ -511,9 +511,9 @@ TEST_F(SoftTakeoverTest, PrevFarMore_NewNearLess_Late) {
     st_control.enable(co.get());
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(120)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(120)));
     mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(45)));
+    EXPECT_FALSE(st_control.ignore(co.get(), co->getNormalizedValueForValue(45)));
 }
 
 TEST_F(SoftTakeoverTest, PrevFarMore_NewNearMore_Late) {
@@ -524,9 +524,9 @@ TEST_F(SoftTakeoverTest, PrevFarMore_NewNearMore_Late) {
     st_control.enable(co.get());
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(120)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(120)));
     mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(60)));
+    EXPECT_FALSE(st_control.ignore(co.get(), co->getNormalizedValueForValue(60)));
 }
 
 // Ignore this case:
@@ -541,9 +541,9 @@ TEST_F(SoftTakeoverTest, DISABLED_PrevFarMore_NewFarLess_Late) {
     st_control.enable(co.get());
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(120)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(120)));
     mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(1)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(1)));
 }
 
 // Ignore this case:
@@ -557,9 +557,9 @@ TEST_F(SoftTakeoverTest, PrevFarMore_NewFarMore_Late) {
     st_control.enable(co.get());
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(120)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(120)));
     mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(100)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(100)));
 }
 
 TEST_F(SoftTakeoverTest, CatchOutOfBounds) {
@@ -571,21 +571,21 @@ TEST_F(SoftTakeoverTest, CatchOutOfBounds) {
     st_control.enable(co.get());
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(45)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(45)));
     // Cross the original value to take over
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(55)));
+    EXPECT_FALSE(st_control.ignore(co.get(), co->getNormalizedValueForValue(55)));
 
     // Set value to an out of bounds value
     co->set(300);
     mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
     // Actions in the same direction shall be ignored
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(60)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(60)));
     // actions in the other edirection shall be ignored
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(40)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(40)));
     // reaching the lower border should be ignored
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(-250)));
+    EXPECT_TRUE(st_control.ignore(co.get(), co->getNormalizedValueForValue(-250)));
     // reaching the upper border near the out of bounds value should not be ignored.
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(250)));
+    EXPECT_FALSE(st_control.ignore(co.get(), co->getNormalizedValueForValue(250)));
 }
 
 // For the ignore cases, check that they work correctly with various signed values

--- a/src/widget/controlwidgetconnection.cpp
+++ b/src/widget/controlwidgetconnection.cpp
@@ -44,11 +44,11 @@ void ControlWidgetConnection::setControlParameter(double parameter) {
     if (m_pValueTransformer != nullptr) {
         parameter = m_pValueTransformer->transformInverse(parameter);
     }
-    m_pControl->setParameter(parameter);
+    m_pControl->setNormalizedValue(parameter);
 }
 
 double ControlWidgetConnection::getControlParameter() const {
-    double parameter = m_pControl->getParameter();
+    double parameter = m_pControl->getNormalizedValue();
     if (m_pValueTransformer != nullptr) {
         parameter = m_pValueTransformer->transform(parameter);
     }
@@ -56,7 +56,7 @@ double ControlWidgetConnection::getControlParameter() const {
 }
 
 double ControlWidgetConnection::getControlParameterForValue(double value) const {
-    double parameter = m_pControl->getParameterForValue(value);
+    double parameter = m_pControl->getNormalizedValueForValue(value);
     if (m_pValueTransformer != nullptr) {
         parameter = m_pValueTransformer->transform(parameter);
     }
@@ -79,11 +79,12 @@ void ControlParameterWidgetConnection::Init() {
 QString ControlParameterWidgetConnection::toDebugString() const {
     const ConfigKey& key = getKey();
     return QString("%1,%2 Parameter: %3 Value: %4 Direction: %5 Emit: %6")
-            .arg(key.group, key.item,
-                 QString::number(m_pControl->getParameter()),
-                 QString::number(m_pControl->get()),
-                 directionOptionToString(m_directionOption),
-                 emitOptionToString(m_emitOption));
+            .arg(key.group,
+                    key.item,
+                    QString::number(m_pControl->getNormalizedValue()),
+                    QString::number(m_pControl->get()),
+                    directionOptionToString(m_directionOption),
+                    emitOptionToString(m_emitOption));
 }
 
 void ControlParameterWidgetConnection::slotControlValueChanged(double value) {
@@ -134,7 +135,7 @@ QString ControlWidgetPropertyConnection::toDebugString() const {
     return QString("%1,%2 Parameter: %3 Property: %4 Value: %5")
             .arg(key.group,
                     key.item,
-                    QString::number(m_pControl->getParameter()),
+                    QString::number(m_pControl->getNormalizedValue()),
                     m_propertyName,
                     m_property.read(m_pWidget->toQWidget()).toString());
 }

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -87,7 +87,7 @@ void WWaveformViewer::mousePressEvent(QMouseEvent* event) {
         // If we are pitch-bending then disable and reset because the two
         // shouldn't be used at once.
         if (m_bBending) {
-            m_pWheel->setParameter(0.5);
+            m_pWheel->setNormalizedValue(0.5);
             m_bBending = false;
         }
         m_bScratching = true;
@@ -116,7 +116,7 @@ void WWaveformViewer::mousePressEvent(QMouseEvent* event) {
                 m_pScratchPositionEnable->set(0.0);
                 m_bScratching = false;
             }
-            m_pWheel->setParameter(0.5);
+            m_pWheel->setNormalizedValue(0.5);
             m_bBending = true;
         }
     }
@@ -155,7 +155,7 @@ void WWaveformViewer::mouseMoveEvent(QMouseEvent* event) {
         double v = 0.5 + (diffValue / 1270.0);
         // clamp to [0.0, 1.0]
         v = math_clamp(v, 0.0, 1.0);
-        m_pWheel->setParameter(v);
+        m_pWheel->setNormalizedValue(v);
     } else if (!isPlaying()) {
         WaveformMarkPointer pMark;
         pMark = m_waveformWidget->getCueMarkAtPoint(event->pos());
@@ -183,7 +183,7 @@ void WWaveformViewer::mouseReleaseEvent(QMouseEvent* /*event*/) {
         m_bScratching = false;
     }
     if (m_bBending) {
-        m_pWheel->setParameter(0.5);
+        m_pWheel->setNormalizedValue(0.5);
         m_bBending = false;
     }
     m_mouseAnchor = QPoint();


### PR DESCRIPTION
In the COs and the controller script API, the meaningless term "Parameter" was systematically used instead of the obviously correct term "Normalized Value".
This is particularly problematic as it is a symbol that is exposed to the user through our controller scripting API. A user has no chance to understand, that "Parameter" indicates a value with normalized range - unless he looks up in the documentation for it.

I renamed the affected methods therefore, and added aliases to the controller scripting API for backward compatibility.

Additionally I expanded the term Midi in some CO methods to Midi7Bit, as nowadays Midi allows larger ranges than 0...127. But this range is meant here. 

Last change was extending the controllerscriptenginelegacy_test.cpp to cover the previously uncovered methods which were renamed, and a check for the aliases itself.