### PR TITLE
fix: Replace deprecated `qAsConst` with `std::as_const`

### DIFF
--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -853,7 +853,7 @@ void DlgPrefController::slotShowMapping(std::shared_ptr<LegacyControllerMapping>
         if (pLayout != nullptr && !settings.isEmpty()) {
             m_ui.groupBoxSettings->layout()->addWidget(pLayout->build(m_ui.groupBoxSettings));
 
-            for (const auto& setting : qAsConst(settings)) {
+            for (const auto& setting : std::as_const(settings)) {
                 connect(setting.get(),
                         &AbstractLegacyControllerSetting::changed,
                         this,

--- a/src/controllers/legacycontrollermapping.cpp
+++ b/src/controllers/legacycontrollermapping.cpp
@@ -26,7 +26,7 @@ void LegacyControllerMapping::loadSettings(UserSettingsPointer pConfig,
     QList<ConfigKey> definedSettings = pConfig->getKeysWithGroup(controllerKey);
 
     QList<QString> availableSettingKeys;
-    for (const auto& pSetting : qAsConst(availableSettings)) {
+    for (const auto& pSetting : std::as_const(availableSettings)) {
         availableSettingKeys.append(pSetting->variableName());
     }
 

--- a/src/controllers/legacycontrollermapping.h
+++ b/src/controllers/legacycontrollermapping.h
@@ -91,7 +91,7 @@ class LegacyControllerMapping {
         VERIFY_OR_DEBUG_ASSERT(option->valid()) {
             return false;
         }
-        for (const auto& setting : qAsConst(m_settings)) {
+        for (const auto& setting : std::as_const(m_settings)) {
             if (*setting == *option) {
                 qWarning() << "Mapping setting duplication detected for "
                               "setting with name"

--- a/src/controllers/legacycontrollersettings.cpp
+++ b/src/controllers/legacycontrollersettings.cpp
@@ -197,7 +197,7 @@ void LegacyControllerEnumSetting::parse(const QString& in, bool* ok) {
     save();
 
     size_t pos = 0;
-    for (const auto& value : qAsConst(m_options)) {
+    for (const auto& value : std::as_const(m_options)) {
         if (std::get<0>(value) == in) {
             if (ok != nullptr) {
                 *ok = true;
@@ -213,7 +213,7 @@ void LegacyControllerEnumSetting::parse(const QString& in, bool* ok) {
 QWidget* LegacyControllerEnumSetting::buildInputWidget(QWidget* pParent) {
     auto* pComboBox = new QComboBox(pParent);
 
-    for (const auto& value : qAsConst(m_options)) {
+    for (const auto& value : std::as_const(m_options)) {
         pComboBox->addItem(std::get<1>(value));
     }
     pComboBox->setCurrentIndex(static_cast<int>(m_editedValue));

--- a/src/controllers/legacycontrollersettingsfactory.h
+++ b/src/controllers/legacycontrollersettingsfactory.h
@@ -43,7 +43,7 @@ class LegacyControllerSettingBuilder {
     /// @return an instance if a a supported setting has been found, null
     /// otherwise
     static AbstractLegacyControllerSetting* build(const QDomElement& element) {
-        for (const auto& settingType : qAsConst(instance()->m_supportedSettings)) {
+        for (const auto& settingType : std::as_const(instance()->m_supportedSettings)) {
             if (settingType.matcher(element)) {
                 return settingType.builder(element);
             }

--- a/src/controllers/scripting/legacy/controllerscriptenginelegacy.cpp
+++ b/src/controllers/scripting/legacy/controllerscriptenginelegacy.cpp
@@ -102,7 +102,7 @@ void ControllerScriptEngineLegacy::setScriptFiles(
 void ControllerScriptEngineLegacy::setSettings(
         const QList<std::shared_ptr<AbstractLegacyControllerSetting>>& settings) {
     m_settings.clear();
-    for (const auto& pSetting : qAsConst(settings)) {
+    for (const auto& pSetting : std::as_const(settings)) {
         QString name = pSetting->variableName();
         VERIFY_OR_DEBUG_ASSERT(!name.isEmpty()) {
             continue;


### PR DESCRIPTION
This fixes build warnings/errors like this:

    In file included from src/controllers/legacycontrollersettings.h:5,
                     from src/controllers/legacycontrollersettingslayout.cpp:13:
    src/controllers/legacycontrollersettingsfactory.h: In static member function ‘static AbstractLegacyControllerSetting* LegacyControllerSettingBuilder::build(const QDomElement&)’:
    src/controllers/legacycontrollersettingsfactory.h:46:48: error: ‘constexpr typename std::add_const<_Tp>::type& qAsConst(T&) [with T = QList<LegacyControllerSettingBuilder::SupportedSetting>; typename std::add_const<_Tp>::type = const QList<LegacyControllerSettingBuilder::SupportedSetting>]’ is deprecated: Use std::as_const() instead. [-Werror=deprecated-declarations]
       46 |         for (const auto& settingType : qAsConst(instance()->m_supportedSettings)) {
          |                                        ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~