### PR TITLE
(fix) turn missing effects assert into warning

### DIFF
--- a/src/effects/backends/effectsbackendmanager.cpp
+++ b/src/effects/backends/effectsbackendmanager.cpp
@@ -89,28 +89,12 @@ EffectManifestPointer EffectsBackendManager::getManifest(
     return pEffectsBackend->getManifest(id);
 }
 
-const QString EffectsBackendManager::getDisplayNameForEffectPreset(
-        EffectPresetPointer pPreset) const {
-    // "---" id displayed when no effect is loaded
-    QString displayName(kNoEffectString);
-    if (!pPreset || pPreset->isEmpty()) {
-        return displayName;
-    }
-
-    bool manifestFound = false;
-    for (const auto& pManifest : std::as_const(m_manifests)) {
-        if (pManifest->id() == pPreset->id() &&
-                pManifest->backendType() == pPreset->backendType()) {
-            displayName = pManifest->name();
-            manifestFound = true;
-            break;
-        }
-    }
-    if (!manifestFound) {
+EffectManifestPointer EffectsBackendManager::getManifest(EffectPresetPointer pPreset) const {
+    EffectManifestPointer pManifest = getManifest(pPreset->id(), pPreset->backendType());
+    if (!pManifest) {
         qWarning() << "Failed to find manifest for effect preset " << pPreset->id();
-        DEBUG_ASSERT(false);
     }
-    return displayName;
+    return pManifest;
 }
 
 std::unique_ptr<EffectProcessor> EffectsBackendManager::createProcessor(

--- a/src/effects/backends/effectsbackendmanager.h
+++ b/src/effects/backends/effectsbackendmanager.h
@@ -20,7 +20,7 @@ class EffectsBackendManager {
     /// returns a pointer to the manifest or a null pointer in case a
     /// the previously stored backend or effect is no longer available
     EffectManifestPointer getManifest(const QString& id, EffectBackendType backendType) const;
-    const QString getDisplayNameForEffectPreset(EffectPresetPointer pPreset) const;
+    EffectManifestPointer getManifest(EffectPresetPointer pPreset) const;
 
     std::unique_ptr<EffectProcessor> createProcessor(const EffectManifestPointer pManifest);
 

--- a/src/effects/effectslot.cpp
+++ b/src/effects/effectslot.cpp
@@ -247,12 +247,14 @@ EffectParameterSlotBasePointer EffectSlot::getEffectParameterSlot(
 }
 
 void EffectSlot::loadEffectFromPreset(const EffectPresetPointer pPreset) {
-    if (!pPreset || pPreset->isEmpty()) {
+    EffectManifestPointer pManifest;
+    if (pPreset && !pPreset->isEmpty()) {
+        pManifest = m_pBackendManager->getManifest(pPreset);
+    }
+    if (!pManifest) {
         loadEffectInner(nullptr, nullptr, true);
         return;
     }
-    EffectManifestPointer pManifest = m_pBackendManager->getManifest(
-            pPreset->id(), pPreset->backendType());
     loadEffectInner(pManifest, pPreset, true);
 }
 

--- a/src/preferences/dialog/dlgprefeffects.cpp
+++ b/src/preferences/dialog/dlgprefeffects.cpp
@@ -243,17 +243,17 @@ void DlgPrefEffects::slotChainPresetSelectionChanged(const QItemSelection& selec
     }
 
     for (int i = 0; i < m_effectsLabels.size(); ++i) {
+        EffectManifestPointer pManifest;
         if (i < pChainPreset->effectPresets().size()) {
             EffectPresetPointer pEffectPreset = pChainPreset->effectPresets().at(i);
             if (!pEffectPreset->isEmpty()) {
-                QString displayName =
-                        m_pBackendManager->getDisplayNameForEffectPreset(
-                                pEffectPreset);
-                // Code uses 0-indexed numbers; users see 1 indexed numbers
-                m_effectsLabels[i]->setText(QString::number(i + 1) + ": " + displayName);
-            } else {
-                m_effectsLabels[i]->setText(QString::number(i + 1) + ": " + kNoEffectString);
+                pManifest = m_pBackendManager->getManifest(pEffectPreset);
             }
+        }
+        if (pManifest) {
+            QString displayName = pManifest->name();
+            // Code uses 0-indexed numbers; users see 1 indexed numbers
+            m_effectsLabels[i]->setText(QString::number(i + 1) + ": " + displayName);
         } else {
             m_effectsLabels[i]->setText(QString::number(i + 1) + ": " + kNoEffectString);
         }

--- a/src/widget/weffectchainpresetbutton.cpp
+++ b/src/widget/weffectchainpresetbutton.cpp
@@ -72,7 +72,10 @@ void WEffectChainPresetButton::populateMenu() {
                 QStringLiteral("<b>") + pChainPreset->name() + QStringLiteral("</b>");
         for (const auto& pEffectPreset : pChainPreset->effectPresets()) {
             if (!pEffectPreset->isEmpty()) {
-                effectNames.append(pBackendManager->getDisplayNameForEffectPreset(pEffectPreset));
+                EffectManifestPointer pManifest = pBackendManager->getManifest(pEffectPreset);
+                if (pManifest) {
+                    effectNames.append(pManifest->name());
+                }
             }
         }
         if (effectNames.size() > 1) {

--- a/src/widget/weffectchainpresetbutton.cpp
+++ b/src/widget/weffectchainpresetbutton.cpp
@@ -58,7 +58,7 @@ void WEffectChainPresetButton::populateMenu() {
     m_pMenu->clear();
 
     // Chain preset items
-    const EffectsBackendManagerPointer bem = m_pEffectsManager->getBackendManager();
+    const EffectsBackendManagerPointer pBackendManager = m_pEffectsManager->getBackendManager();
     bool presetIsReadOnly = true;
     QStringList effectNames;
     for (const auto& pChainPreset : m_pChainPresetManager->getPresetsSorted()) {
@@ -72,7 +72,7 @@ void WEffectChainPresetButton::populateMenu() {
                 QStringLiteral("<b>") + pChainPreset->name() + QStringLiteral("</b>");
         for (const auto& pEffectPreset : pChainPreset->effectPresets()) {
             if (!pEffectPreset->isEmpty()) {
-                effectNames.append(bem->getDisplayNameForEffectPreset(pEffectPreset));
+                effectNames.append(pBackendManager->getDisplayNameForEffectPreset(pEffectPreset));
             }
         }
         if (effectNames.size() > 1) {

--- a/src/widget/weffectchainpresetselector.cpp
+++ b/src/widget/weffectchainpresetselector.cpp
@@ -77,7 +77,7 @@ void WEffectChainPresetSelector::populate() {
         presetList = m_pEffectsManager->getChainPresetManager()->getPresetsSorted();
     }
 
-    const EffectsBackendManagerPointer bem = m_pEffectsManager->getBackendManager();
+    const EffectsBackendManagerPointer pBackendManager = m_pEffectsManager->getBackendManager();
     QStringList effectNames;
     for (int i = 0; i < presetList.size(); i++) {
         auto pChainPreset = presetList.at(i);
@@ -89,7 +89,7 @@ void WEffectChainPresetSelector::populate() {
                 QStringLiteral("<b>") + pChainPreset->name() + QStringLiteral("</b>");
         for (const auto& pEffectPreset : pChainPreset->effectPresets()) {
             if (!pEffectPreset->isEmpty()) {
-                effectNames.append(bem->getDisplayNameForEffectPreset(pEffectPreset));
+                effectNames.append(pBackendManager->getDisplayNameForEffectPreset(pEffectPreset));
             }
         }
         if (effectNames.size() > 1) {

--- a/src/widget/weffectchainpresetselector.cpp
+++ b/src/widget/weffectchainpresetselector.cpp
@@ -89,7 +89,10 @@ void WEffectChainPresetSelector::populate() {
                 QStringLiteral("<b>") + pChainPreset->name() + QStringLiteral("</b>");
         for (const auto& pEffectPreset : pChainPreset->effectPresets()) {
             if (!pEffectPreset->isEmpty()) {
-                effectNames.append(pBackendManager->getDisplayNameForEffectPreset(pEffectPreset));
+                EffectManifestPointer pManifest = pBackendManager->getManifest(pEffectPreset);
+                if (pManifest) {
+                    effectNames.append(pManifest->name());
+                }
             }
         }
         if (effectNames.size() > 1) {


### PR DESCRIPTION
This fixes the handling of no longer available effects. 
Before Mixxx was aborted by an assertion. Now the missing effect is handle gracefully, and just not displayed.
It is still a warning logged.   