### PR TITLE
(fix) Drag'n'drop: avoid unintended drag on hover (WTrackProperty, WCoverArt etc.)

### DIFF
--- a/src/util/dnd.cpp
+++ b/src/util/dnd.cpp
@@ -102,6 +102,9 @@ bool allowLoadToPlayer(
 
 // Helper function for DragAndDropHelper::mousePressed and DragAndDropHelper::mouseMoveInitiatesDrag
 bool mouseMoveInitiatesDragHelper(QMouseEvent* pEvent, bool isPress) {
+    if (pEvent->buttons() != Qt::LeftButton) {
+        return false;
+    }
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     const qreal x = pEvent->position().x();
     const qreal y = pEvent->position().y();
@@ -209,9 +212,7 @@ bool DragAndDropHelper::allowDeckCloneAttempt(
 
 // static
 void DragAndDropHelper::mousePressed(QMouseEvent* pEvent) {
-    if (pEvent->button() == Qt::LeftButton) {
-        mouseMoveInitiatesDragHelper(pEvent, true);
-    }
+    mouseMoveInitiatesDragHelper(pEvent, true);
 }
 
 // static

--- a/src/widget/wcoverart.cpp
+++ b/src/widget/wcoverart.cpp
@@ -245,7 +245,7 @@ void WCoverArt::mousePressEvent(QMouseEvent* pEvent) {
 
     DragAndDropHelper::mousePressed(pEvent);
 
-    if (pEvent->button() == Qt::LeftButton) {
+    if (pEvent->buttons() == Qt::LeftButton) {
         pEvent->accept();
         // do nothing if left button is pressed,
         // wait for button release
@@ -259,7 +259,7 @@ void WCoverArt::mouseReleaseEvent(QMouseEvent* pEvent) {
         return;
     }
 
-    if (pEvent->button() == Qt::LeftButton && m_loadedTrack &&
+    if (pEvent->buttons() == Qt::LeftButton && m_loadedTrack &&
             m_clickTimer.isActive()) { // init/close fullsize cover
         if (m_pDlgFullSize->isVisible()) {
             m_pDlgFullSize->close();


### PR DESCRIPTION
Fixes #13033 on Linux with Qt 6.2.3