### PR TITLE
Add test button(logs midi values)

### DIFF
--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -75,6 +75,8 @@ DlgPreferences::DlgPreferences(
     buttonBox->button(QDialogButtonBox::Cancel)->setText(tr("&Cancel"));
     //: Preferences standard buttons: consider the other buttons to choose a unique Alt hotkey (&)
     buttonBox->button(QDialogButtonBox::Ok)->setText(tr("&Ok"));
+    //: Preferences standard buttons: consider the other buttons to choose a unique Alt hotkey (&)
+    buttonBox->button(QDialogButtonBox::Test)->setText(tr("&Test"));
 
     connect(buttonBox,
             QOverload<QAbstractButton*>::of(&QDialogButtonBox::clicked),

--- a/src/preferences/dialog/dlgpreferencesdlg.ui
+++ b/src/preferences/dialog/dlgpreferencesdlg.ui
@@ -123,7 +123,7 @@
           <enum>Qt::Horizontal</enum>
          </property>
          <property name="standardButtons">
-          <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok|QDialogButtonBox::RestoreDefaults</set>
+          <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Test|QDialogButtonBox::Help|QDialogButtonBox::Ok|QDialogButtonBox::RestoreDefaults</set>
          </property>
          <property name="centerButtons">
           <bool>false</bool>


### PR DESCRIPTION
Fix: #10176 
Added a `test` button on the main controller page for now, setting it to the left of 'help' and then keeping it active(if any MIDIs are found) will be done further. Is the placement ok? 