### PR TITLE
Tempo locking controls

### DIFF
--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -272,6 +272,10 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
             tr("Adjust Beatgrid - Match Alignment"),
             tr("Adjust beatgrid to match another playing deck."),
             pBpmMenu);
+    addDeckAndSamplerControl("bpm_toggle_lock",
+            tr("Toggle the BPM/beatgrid lock"),
+            tr("Toggle the BPM/beatgrid lock"),
+            pBpmMenu);
     pBpmMenu->addSeparator();
     addDeckAndSamplerControl("quantize", tr("Quantize Mode"), tr("Toggle quantize mode"), pBpmMenu);
 

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -130,6 +130,15 @@ BpmControl::BpmControl(const QString& group,
             this, &BpmControl::slotTapFilter,
             Qt::DirectConnection);
 
+    m_pToggleBpmLock = std::make_unique<ControlPushButton>(
+            ConfigKey(group, "bpm_toggle_lock"), false);
+    m_pToggleBpmLock->setKbdRepeatable(true);
+    connect(m_pToggleBpmLock.get(),
+            &ControlObject::valueChanged,
+            this,
+            &BpmControl::slotToggleBpmLock,
+            Qt::DirectConnection);
+
     // Measures distance from last beat in percentage: 0.5 = half-beat away.
     m_pThisBeatDistance = new ControlProxy(group, "beat_distance", this);
     m_pSyncMode = new ControlProxy(group, "sync_mode", this);
@@ -1019,6 +1028,18 @@ void BpmControl::slotBeatsTranslateMatchAlignment(double v) {
             pTrack->trySetBeats(*translatedBeats);
         }
     }
+}
+
+void BpmControl::slotToggleBpmLock(double v) {
+    if (v <= 0) {
+        return;
+    }
+    const TrackPointer pTrack = getEngineBuffer()->getLoadedTrack();
+    if (!pTrack) {
+        return;
+    }
+    bool locked = pTrack->isBpmLocked();
+    pTrack->setBpmLocked(!locked);
 }
 
 mixxx::Bpm BpmControl::updateLocalBpm() {

--- a/src/engine/controls/bpmcontrol.h
+++ b/src/engine/controls/bpmcontrol.h
@@ -108,6 +108,7 @@ class BpmControl : public EngineControl {
     void slotUpdateEngineBpm(double v = 0.0);
     void slotBeatsTranslate(double);
     void slotBeatsTranslateMatchAlignment(double);
+    void slotToggleBpmLock(double);
 
   private:
     SyncMode getSyncMode() const {
@@ -144,6 +145,8 @@ class BpmControl : public EngineControl {
     ControlPushButton* m_pTranslateBeatsEarlier;
     ControlPushButton* m_pTranslateBeatsLater;
     ControlEncoder* m_pTranslateBeatsMove;
+
+    std::unique_ptr<ControlPushButton> m_pToggleBpmLock;
 
     // The current effective BPM of the engine
     ControlLinPotmeter* m_pEngineBpm;


### PR DESCRIPTION
This PR adds controls for tempo locking (`tempo_lock`) and unlocking (`locking`) so they can be used through keyboard shortcuts or MIDI inputs,a s suggested in [13038](https://github.com/mixxxdj/mixxx/issues/13038).