### PR TITLE
feat: enable controller setting on MIDI

### DIFF
--- a/src/controllers/midi/legacymidicontrollermappingfilehandler.cpp
+++ b/src/controllers/midi/legacymidicontrollermappingfilehandler.cpp
@@ -11,7 +11,6 @@ std::shared_ptr<LegacyControllerMapping>
 LegacyMidiControllerMappingFileHandler::load(const QDomElement& root,
         const QString& filePath,
         const QDir& systemMappingsPath) {
-    // TODO (XXX): support for controller settings
     if (root.isNull()) {
         return nullptr;
     }
@@ -26,6 +25,7 @@ LegacyMidiControllerMappingFileHandler::load(const QDomElement& root,
 
     // Superclass handles parsing <info> tag and script files
     parseMappingInfo(root, pMapping);
+    parseMappingSettings(root, pMapping.get());
     addScriptFilesToMapping(controller, pMapping, systemMappingsPath);
 
     QDomElement control = controller.firstChildElement("controls").firstChildElement("control");


### PR DESCRIPTION
The original plan was to also support settings when parsing the XML mapping definition, thus why a follow up PR was dedicated for this feature.

As the latter is likely not happening, this PR exposes the settings in the JS engine only.

I don't have a MIDI controller available for testing yet, can anyone give it a go please?