### PR TITLE
fix(util): fix ambigous overload error due to native qDebug impl for std::optional

### DIFF
--- a/src/util/optional.h
+++ b/src/util/optional.h
@@ -1,6 +1,10 @@
 #pragma once
 
 #include <QtDebug>
+// support for QDebugging std::optional<T> has been added natively in Qt 6.7
+// this definition clashes with Qt's so disable it.
+#if QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
+
 #include <optional>
 
 template<typename T>
@@ -11,3 +15,5 @@ inline QDebug operator<<(QDebug dbg, std::optional<T> arg) {
         return dbg << "nullopt";
     }
 }
+
+#endif


### PR DESCRIPTION
fixes #12981