### PR TITLE
fix: incorrect reboot required notification on preference updates

### DIFF
--- a/src/preferences/dialog/dlgprefinterface.cpp
+++ b/src/preferences/dialog/dlgprefinterface.cpp
@@ -202,6 +202,9 @@ DlgPrefInterface::DlgPrefInterface(
     } else
 #endif
     {
+#ifdef MIXXX_USE_QML
+        m_multiSampling = 0;
+#endif
         multiSamplingLabel->hide();
         multiSamplingComboBox->hide();
     }


### PR DESCRIPTION
This fixes the pop up message suggesting to reboot Mixxx after setting updates that shouldn't require a reboot