### PR TITLE
S4MK3: Software mixer support and default pad layout customisation

### DIFF
--- a/res/controllers/Traktor Kontrol S4 MK3.hid.xml
+++ b/res/controllers/Traktor Kontrol S4 MK3.hid.xml
@@ -190,6 +190,18 @@
                     This option is useful if you don't use samplers and would like to access a set of predefined beatloop rolls. Beat size can be customized individually.
                 </description>
             </option>
+            <option
+                variable="defaultPadLayout"
+                type="enum"
+                label="Default Pad Layout">
+                <value label="Intro/Outro + 4 hotcues" default="true">default</value>
+                <value label="Hotcues">hotcue</value>
+                <value label="Sampler or beatloop">samplerBeatloop</value>
+                <value label="Keyboard">keyboard</value>
+                <description>
+                    Define the default layout used for the pads.
+                </description>
+            </option>
         </group>
 
         <group label="Mixer">

--- a/res/controllers/Traktor Kontrol S4 MK3.hid.xml
+++ b/res/controllers/Traktor Kontrol S4 MK3.hid.xml
@@ -220,7 +220,7 @@
                 default="false"
                 label="Main gain is handled by the Mixxx built-in mixer">
                 <description>
-                    When enabled, the master potentiometer on top right column of the mixer will drive the main gain of the Mixxx internal mixer as well as the hardware built-in mixer in the device. This is useful if you aren't relying on the hardware output, but will create conflict if enabled when using the hardware outputs.
+                    When enabled, the master potentiometer on top right column of the mixer will drive both the main gain of the Mixxx internal mixer as well as the hardware built-in mixer in the device. This is useful if you aren't relying on the hardware output, but could result in undesired clipping if enabled when using the hardware audio outputs.
                 </description>
             </option>
             <option
@@ -229,7 +229,7 @@
                 default="false"
                 label="Booth gain is handled by the Mixxx built-in mixer">
                 <description>
-                    When enabled, the booth potentiometer on right column of the mixer will drive the booth gain of the Mixxx internal mixer as well as the hardware built-in mixer in the device. This is useful if you aren't relying on the hardware output, but will create conflict if enabled when using the hardware outputs.
+                    When enabled, the booth potentiometer on right column of the mixer will drive both the booth gain of the Mixxx internal mixer as well as the hardware built-in mixer in the device. This is useful if you aren't relying on the hardware output, but could result in undesired clipping if enabled when using the hardware audio outputs.
                 </description>
             </option>
             <option
@@ -238,7 +238,7 @@
                 default="false"
                 label="Headphone gain and cue mix is handled by the Mixxx built-in mixer">
                 <description>
-                    When enabled, the headphone volume and cue potentiometers on bottom right column of the mixer will drive the headphone controls of the Mixxx internal mixer as well as the hardware built-in mixer in the device. This is useful if you aren't relying on the hardware output, but will create conflict if enabled when using the hardware outputs.
+                    When enabled, the headphone volume and cue potentiometers on bottom right column of the mixer will drive both the headphone controls of the Mixxx internal mixer as well as the hardware built-in mixer in the device. This is useful if you aren't relying on the hardware output, but could create undesirable clipping if enabled when using the hardware audio outputs.
                 </description>
             </option>
         </group>

--- a/res/controllers/Traktor Kontrol S4 MK3.hid.xml
+++ b/res/controllers/Traktor Kontrol S4 MK3.hid.xml
@@ -220,7 +220,7 @@
                 default="false"
                 label="Main gain is handled by the Mixxx built-in mixer">
                 <description>
-                    When enable, the master potentiometer on top right column of the mixer will drive the main gain of the Mixxx internal mixer as well as the hardware built-in mixer in the device. This is useful if you aren't relying on the hardware output, but will create conflict if enabled when using the hardware outputs.
+                    When enabled, the master potentiometer on top right column of the mixer will drive the main gain of the Mixxx internal mixer as well as the hardware built-in mixer in the device. This is useful if you aren't relying on the hardware output, but will create conflict if enabled when using the hardware outputs.
                 </description>
             </option>
             <option
@@ -229,7 +229,7 @@
                 default="false"
                 label="Booth gain is handled by the Mixxx built-in mixer">
                 <description>
-                    When enable, the booth potentiometer on right column of the mixer will drive the booth gain of the Mixxx internal mixer as well as the hardware built-in mixer in the device. This is useful if you aren't relying on the hardware output, but will create conflict if enabled when using the hardware outputs.
+                    When enabled, the booth potentiometer on right column of the mixer will drive the booth gain of the Mixxx internal mixer as well as the hardware built-in mixer in the device. This is useful if you aren't relying on the hardware output, but will create conflict if enabled when using the hardware outputs.
                 </description>
             </option>
             <option
@@ -238,7 +238,7 @@
                 default="false"
                 label="Headphone gain and cue mix is handled by the Mixxx built-in mixer">
                 <description>
-                    When enable, the headphone volume and cue potentiometers on bottom right column of the mixer will drive the headphone controls of the Mixxx internal mixer as well as the hardware built-in mixer in the device. This is useful if you aren't relying on the hardware output, but will create conflict if enabled when using the hardware outputs.
+                    When enabled, the headphone volume and cue potentiometers on bottom right column of the mixer will drive the headphone controls of the Mixxx internal mixer as well as the hardware built-in mixer in the device. This is useful if you aren't relying on the hardware output, but will create conflict if enabled when using the hardware outputs.
                 </description>
             </option>
         </group>

--- a/res/controllers/Traktor Kontrol S4 MK3.hid.xml
+++ b/res/controllers/Traktor Kontrol S4 MK3.hid.xml
@@ -190,6 +190,9 @@
                     This option is useful if you don't use samplers and would like to access a set of predefined beatloop rolls. Beat size can be customized individually.
                 </description>
             </option>
+        </group>
+
+        <group label="Mixer">
             <option
                 variable="mixerControlsMicAuxOnShift"
                 type="boolean"
@@ -197,6 +200,33 @@
                 label="Shift to mix microphones or auxiliary lines">
                 <description>
                     When shifting decks, the mixer controls microphones or auxiliary lines. If both a microphone and an auxiliary are configured on the same channel, the mixer will prioritize controlling the auxiliary.
+                </description>
+            </option>
+            <option
+                variable="softwareMixerMain"
+                type="boolean"
+                default="false"
+                label="Main gain is handled by the Mixxx built-in mixer">
+                <description>
+                    When enable, the master potentiometer on top right column of the mixer will drive the main gain of the Mixxx internal mixer as well as the hardware built-in mixer in the device. This is useful if you aren't relying on the hardware output, but will create conflict if enabled when using the hardware outputs.
+                </description>
+            </option>
+            <option
+                variable="softwareMixerBooth"
+                type="boolean"
+                default="false"
+                label="Booth gain is handled by the Mixxx built-in mixer">
+                <description>
+                    When enable, the booth potentiometer on right column of the mixer will drive the booth gain of the Mixxx internal mixer as well as the hardware built-in mixer in the device. This is useful if you aren't relying on the hardware output, but will create conflict if enabled when using the hardware outputs.
+                </description>
+            </option>
+            <option
+                variable="softwareMixerHeadphone"
+                type="boolean"
+                default="false"
+                label="Headphone gain and cue mix is handled by the Mixxx built-in mixer">
+                <description>
+                    When enable, the headphone volume and cue potentiometers on bottom right column of the mixer will drive the headphone controls of the Mixxx internal mixer as well as the hardware built-in mixer in the device. This is useful if you aren't relying on the hardware output, but will create conflict if enabled when using the hardware outputs.
                 </description>
             </option>
         </group>

--- a/res/controllers/Traktor Kontrol S4 MK3.hid.xml
+++ b/res/controllers/Traktor Kontrol S4 MK3.hid.xml
@@ -6,7 +6,7 @@
         <description>HID Mapping for Traktor Kontrol S4 MK3</description>
         <manual>native_instruments_traktor_kontrol_s4_mk3</manual>
         <devices>
-            <product protocol="hid" vendor_id="0x17cc" product_id="0x1720" usage_page="0xff01" usage="0x1" interface_number="0x4" />
+            <product protocol="hid" vendor_id="0x17cc" product_id="0x1720" usage_page="0xff01" usage="0x0" interface_number="0x3" />
         </devices>
     </info>
     <settings>
@@ -56,7 +56,7 @@
                     label="Deck C">
                     <value label="Aqua">aqua</value>
                     <value label="Azalea">azalea</value>
-                    <value label="Blue" default="true">blue</value>
+                    <value label="Blue">blue</value>
                     <value label="Celeste">celeste</value>
                     <value label="Fuscia">fuscia</value>
                     <value label="Green">green</value>
@@ -131,7 +131,7 @@
                 label="Tempo fader low soft takeover color">
                 <value label="Aqua">aqua</value>
                 <value label="Azalea">azalea</value>
-                <value label="Blue" default="true">blue</value>
+                <value label="Blue">blue</value>
                 <value label="Celeste">celeste</value>
                 <value label="Fuscia">fuscia</value>
                 <value label="Green">green</value>

--- a/res/controllers/Traktor-Kontrol-S4-MK3.js
+++ b/res/controllers/Traktor-Kontrol-S4-MK3.js
@@ -38,6 +38,11 @@ const KeyboardColors = [
     LedColors.white,
 ];
 
+// Constant used to define custom default pad layout
+const DefaultPadLayoutHotcue = "hotcue";
+const DefaultPadLayoutSamplerBeatloop = "samplerBeatloop";
+const DefaultPadLayoutKeyboard = "keyboard";
+
 /*
  * USER CONFIGURABLE SETTINGS
  * Change settings in the preferences
@@ -142,6 +147,9 @@ const MaxWheelForce = engine.getSetting("maxWheelForce") || 25000;  // Traktor s
 const SoftwareMixerMain = !!engine.getSetting("softwareMixerMain");
 const SoftwareMixerBooth = !!engine.getSetting("softwareMixerBooth");
 const SoftwareMixerHeadphone = !!engine.getSetting("softwareMixerHeadphone");
+
+// Define custom default layout used by the pads, instead of intro/outro  and first 4 hotcues.
+const DefaultPadLayout = engine.getSetting("defaultPadLayout");
 
 
 // The LEDs only support 16 base colors. Adding 1 in addition to
@@ -2254,8 +2262,24 @@ class S4Mk3Deck extends Deck {
             samplerPage: 3,
             keyboard: 5,
         };
-        switchPadLayer(this, defaultPadLayer);
-        this.currentPadLayer = this.padLayers.defaultLayer;
+        switch (DefaultPadLayout) {
+        case DefaultPadLayoutHotcue:
+            switchPadLayer(this, hotcuePage2);
+            this.currentPadLayer = this.padLayers.hotcuePage2;
+            break;
+        case DefaultPadLayoutSamplerBeatloop:
+            switchPadLayer(this, samplerOrBeatloopRollPage);
+            this.currentPadLayer = this.padLayers.samplerPage;
+            break;
+        case DefaultPadLayoutKeyboard:
+            switchPadLayer(this, this.keyboard);
+            this.currentPadLayer = this.padLayers.keyboard;
+            break;
+        default:
+            switchPadLayer(this, defaultPadLayer);
+            this.currentPadLayer = this.padLayers.defaultLayer;
+            break;
+        }
 
         this.hotcuePadModeButton = new Button({
             deck: this,

--- a/res/controllers/Traktor-Kontrol-S4-MK3.js
+++ b/res/controllers/Traktor-Kontrol-S4-MK3.js
@@ -137,6 +137,11 @@ const TightnessFactor = engine.getSetting("tightnessFactor") || 0.5;
 // This will also affect how quick the wheel starts spinning when enabling motor mode, or starting a deck with motor mode on
 const MaxWheelForce = engine.getSetting("maxWheelForce") || 25000;  // Traktor seems to cap the max value at 60000, which just sounds insane
 
+// Map the mixer potentiometers to different components of the software mixer in Mixxx, on top of the physical control of the hardware
+// mixer embedded in the S4 Mk3. This is useful if you are not using certain S4 Mk3 outputs.
+const SoftwareMixerMain = !!engine.getSetting("softwareMixerMain");
+const SoftwareMixerBooth = !!engine.getSetting("softwareMixerBooth");
+const SoftwareMixerHeadphone = !!engine.getSetting("softwareMixerHeadphone");
 
 
 // The LEDs only support 16 base colors. Adding 1 in addition to
@@ -1143,6 +1148,42 @@ class Mixer extends ComponentContainer {
                 }
             },
         });
+
+        if (SoftwareMixerMain) {
+            this.master = new Pot({
+                group: "[Master]",
+                inKey: "gain",
+                inByte: 22,
+                bitLength: 12,
+                inReport: inReports[2]
+            });
+        }
+        if (SoftwareMixerBooth) {
+            this.booth = new Pot({
+                group: "[Master]",
+                inKey: "booth_gain",
+                inByte: 24,
+                bitLength: 12,
+                inReport: inReports[2]
+            });
+        }
+        if (SoftwareMixerHeadphone) {
+            this.cue = new Pot({
+                group: "[Master]",
+                inKey: "headMix",
+                inByte: 28,
+                bitLength: 12,
+                inReport: inReports[2]
+            });
+
+            this.pflGain = new Pot({
+                group: "[Master]",
+                inKey: "headGain",
+                inByte: 26,
+                bitLength: 12,
+                inReport: inReports[2]
+            });
+        }
 
         for (const component of this) {
             if (component.inReport === undefined) {


### PR DESCRIPTION
This addresses two feature requested raised on Zulip

UI change:

_Before:_
![image](https://github.com/mixxxdj/mixxx/assets/7086688/41ca1d8d-e0c3-4d87-8b75-1f9f5f9d5e54)

_After:_
![image](https://github.com/mixxxdj/mixxx/assets/7086688/3b678fab-c417-4eca-862e-1e3e3c65cb2d)
