### PR TITLE
Track colors controls update

### DIFF
--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -833,6 +833,18 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
             tr("Clears the search query"),
             pLibraryMenu);
 
+    // Color selection
+    addLibraryControl("track_color_next",
+            tr("Select Next Color Available"),
+            tr("Select the next color in the color palette"
+               " for the first selected track"),
+            pLibraryMenu);
+    addLibraryControl("track_color_prev",
+            tr("Select Previous Color Available"),
+            tr("Select the previous color in the color palette"
+               " for the first selected track"),
+            pLibraryMenu);
+
     pLibraryMenu->addSeparator();
     addControl("[Recording]",
             "toggle_recording",

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -1398,6 +1398,20 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
             tr("Decrease the track rating by one star"),
             pGuiMenu);
 
+    // Controls to change a deck's loaded track color
+    addDeckAndPreviewDeckControl("track_color_next",
+            tr("Select Next Color Available"),
+            tr("Select the next color in the color palette for the loaded track."),
+            pGuiMenu);
+    addDeckAndPreviewDeckControl("track_color_prev",
+            tr("Select Previous Color Available"),
+            tr("Select previous color in the color palette for the loaded track."),
+            pGuiMenu);
+    addDeckAndPreviewDeckControl("track_color_selector",
+            tr("Navigate Through Track Colors"),
+            tr("Select either next or previous color in the palette for the loaded track."),
+            pGuiMenu);
+
     // Misc. controls
     addControl("[Shoutcast]",
             "enabled",

--- a/src/mixer/basetrackplayer.h
+++ b/src/mixer/basetrackplayer.h
@@ -2,6 +2,7 @@
 
 #include "engine/channels/enginechannel.h"
 #include "mixer/baseplayer.h"
+#include "preferences/colorpalettesettings.h"
 #include "preferences/usersettings.h"
 #include "track/replaygain.h"
 #include "track/track_decl.h"
@@ -14,14 +15,15 @@
 class EngineMixer;
 class ControlObject;
 class ControlProxy;
+class ControlEncoder;
 class EffectsManager;
 class QString;
 class EngineDeck;
 
 constexpr int kUnreplaceDelay = 500;
 
-// Interface for not leaking implementation details of BaseTrackPlayer into the
-// rest of Mixxx. Also makes testing a lot easier.
+/// Interface for not leaking implementation details of BaseTrackPlayer into the
+/// rest of Mixxx. Also makes testing a lot easier.
 class BaseTrackPlayer : public BasePlayer {
     Q_OBJECT
   public:
@@ -109,6 +111,8 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
     /// to compensate so there is no audible change in volume.
     void slotAdjustReplayGain(mixxx::ReplayGain replayGain);
     void slotSetTrackColor(const mixxx::RgbColor::optional_t& color);
+    void slotTrackColorSelector(int steps);
+
     void slotSetTrackRating(int rating) final;
     /// Called via signal from WTrackProperty. Just set and confirm as requested.
     void slotSetAndConfirmTrackMenuControl(bool visible) final;
@@ -162,6 +166,9 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
 
     // Track color control
     std::unique_ptr<ControlObject> m_pTrackColor;
+    std::unique_ptr<ControlPushButton> m_pTrackColorPrev;
+    std::unique_ptr<ControlPushButton> m_pTrackColorNext;
+    std::unique_ptr<ControlEncoder> m_pTrackColorSelect;
 
     // Waveform display related controls
     std::unique_ptr<ControlObject> m_pWaveformZoom;


### PR DESCRIPTION
Implements #12905 
Follows #2541 

Tested on debian Bookworm.
Tested for Channel1, Channel2, with "track_color_next" & "track_color_prev".

When the button mapped to `[Channel1], track_color_next` is pressed, the color of the loaded track switches to the next color in the palette. The change is visible in the library view. 

_Hi there !
First contribution, I look forward to do more.
Please tell me if anything's wrong / to improve.
I couldn't find how to add these new config keys in the documentation, is it automatic, or handled by core developers only ?_