### PR TITLE
(fix) Library: BPM display uses decimal separator of selected locale

### DIFF
--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -726,8 +726,9 @@ QVariant BaseTrackTableModel::roleValue(
                 if (role == Qt::ToolTipRole || role == kDataExportRole) {
                     return QString::number(bpm.value(), 'f', 4);
                 } else {
-                    // custom precision, set in DlgPrefLibrary
-                    return QString::number(bpm.value(), 'f', s_bpmColumnPrecision);
+                    // Use the locale here to make the display and editor consistent.
+                    // Custom precision, set in DlgPrefLibrary.
+                    return QLocale().toString(bpm.value(), 'f', s_bpmColumnPrecision);
                 }
             } else {
                 return QChar('-');

--- a/src/library/bpmdelegate.cpp
+++ b/src/library/bpmdelegate.cpp
@@ -21,7 +21,7 @@ class BpmEditorCreator : public QItemEditorCreatorBase {
         QDoubleSpinBox* pBpmSpinbox = new QDoubleSpinBox(parent);
         pBpmSpinbox->setFrame(false);
         pBpmSpinbox->setMinimum(0);
-        pBpmSpinbox->setMaximum(1000);
+        pBpmSpinbox->setMaximum(9999);
         pBpmSpinbox->setSingleStep(1e-3);
         pBpmSpinbox->setDecimals(8);
         pBpmSpinbox->setObjectName("LibraryBPMSpinBox");


### PR DESCRIPTION
fixes #13051 

[`QString::number(double, format, precision)` is locale-independent](https://github.com/qt/qtbase/blob/d12490f6614ca0ccf43a73fd938144aa5f1b4e8b/src/corelib/text/qlocale_tools.cpp#L769-L771).

IMO this raises the question how we want to display BPM / beats in general:
* Consistent according to selected locale?
Need to fix `WNumber`, too.
Maybe also dialogs like ~~Track Properties~~ :heavy_check_mark:  uses locale
~~And `WBeatSpinBox`~~ :heavy_check_mark:  uses locale
* "International"? (decimal separator is `.` everywhere)
Need to adjust library's BPM delegate (it's editor), since that currently correctly uses the selected locale (`,` or `.`)

The second commit fixes #13065 

The max BPM limit may be moved to some prefs.h file and made available for BPMDelegate, WTrackProperties etc.