### PR TITLE
add WDoubleSpinbox: allow . and , in library BPM editor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1195,6 +1195,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/widget/wcoverartmenu.cpp
   src/widget/wcuemenupopup.cpp
   src/widget/wdisplay.cpp
+  src/widget/wdoublespinbox.cpp
   src/widget/weffectbuttonparametername.cpp
   src/widget/weffectchain.cpp
   src/widget/weffectchainpresetbutton.cpp

--- a/src/library/bpmdelegate.cpp
+++ b/src/library/bpmdelegate.cpp
@@ -8,6 +8,7 @@
 #include <QTableView>
 
 #include "moc_bpmdelegate.cpp"
+#include "widget/wdoublespinbox.h"
 
 // We override the typical QDoubleSpinBox editor by registering this class with
 // a QItemEditorFactory for the BPMDelegate.
@@ -18,7 +19,7 @@ class BpmEditorCreator : public QItemEditorCreatorBase {
     }
 
     QWidget* createWidget(QWidget* parent) const override {
-        QDoubleSpinBox* pBpmSpinbox = new QDoubleSpinBox(parent);
+        WDoubleSpinBox* pBpmSpinbox = new WDoubleSpinBox(parent);
         pBpmSpinbox->setFrame(false);
         pBpmSpinbox->setMinimum(0);
         pBpmSpinbox->setMaximum(1000);

--- a/src/library/bpmdelegate.cpp
+++ b/src/library/bpmdelegate.cpp
@@ -22,7 +22,7 @@ class BpmEditorCreator : public QItemEditorCreatorBase {
         WDoubleSpinBox* pBpmSpinbox = new WDoubleSpinBox(parent);
         pBpmSpinbox->setFrame(false);
         pBpmSpinbox->setMinimum(0);
-        pBpmSpinbox->setMaximum(1000);
+        pBpmSpinbox->setMaximum(99999);
         pBpmSpinbox->setSingleStep(1e-3);
         pBpmSpinbox->setDecimals(8);
         pBpmSpinbox->setObjectName("LibraryBPMSpinBox");

--- a/src/widget/wdoublespinbox.cpp
+++ b/src/widget/wdoublespinbox.cpp
@@ -1,0 +1,25 @@
+#include "widget/wdoublespinbox.h"
+
+#include <QLineEdit>
+#include <QLocale>
+
+#include "moc_wdoublespinbox.cpp"
+
+WDoubleSpinBox::WDoubleSpinBox(QWidget* pParent)
+        : QDoubleSpinBox(pParent),
+          m_decSep(QLocale().decimalPoint()) {
+    lineEdit()->setValidator(new QRegExpValidator(
+            QRegExp("[0-9]{1,5}[." +
+                    // add locale decimal point if it's not a dot
+                    (m_decSep != '.' ? m_decSep : QChar()) +
+                    "]?[0-9]{,8}"),
+            this));
+}
+
+// This gets the text from lineEdit()
+double WDoubleSpinBox::valueFromText(const QString& text) const {
+    QString temp = text;
+    // replace , with dot before toDouble()
+    temp.replace(",", ".");
+    return temp.toDouble();
+}

--- a/src/widget/wdoublespinbox.h
+++ b/src/widget/wdoublespinbox.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <QDoubleSpinBox>
+
+// This spinbox accepts , and . as decimal separator which comes in handy when
+// the used (typed) decimal separator doesn't match  the locale's separator for
+// some reason, e.g. when typing with numpads that have a fixed separator char.
+class WDoubleSpinBox : public QDoubleSpinBox {
+    Q_OBJECT
+  public:
+    explicit WDoubleSpinBox(QWidget* pParent);
+
+    double valueFromText(const QString& text) const override;
+
+  private:
+    const QChar m_decSep;
+};


### PR DESCRIPTION
currently only used in BPMDelegate.
Fixes #13051 for me.

I guess it's debatable whether we 'need' this, so this is a draft until we agreed on yes or no.

I'll probably look into making WBeatSpinBox equally permissive.