### PR TITLE
Tools: Add `rpm_buildenv.sh` for building on Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,18 @@ source code and navigate to it:
     $ git clone https://github.com/mixxxdj/mixxx.git
     $ cd mixxx
 
-Fetch the required dependencies and set up the build environment (on Windows,
-macOS and Debian/Ubuntu, you can do that by running
-`tools\windows_buildenv.bat`, `source tools/macos_buildenv.sh setup` or `source
-tools/debian_buildenv.sh setup` respectively), then run:
+Fetch the required dependencies and set up the build environment by running the
+corresponding command for your operating system:
+
+| OS | Command |
+| -- | ------- |
+| Windows | `tools\windows_buildenv.bat` |
+| macOS | `source tools/macos_buildenv.sh setup` |
+| Debian/Ubuntu | `source tools/debian_buildenv.sh setup` |
+| Fedora | `source tools/rpm_buildenv.sh setup` |
+| Other Linux distros | See the [wiki article](https://github.com/mixxxdj/mixxx/wiki/Compiling%20on%20Linux) |
+
+To build Mixxx, run
 
     $ mkdir build
     $ cd build

--- a/tools/rpm_buildenv.sh
+++ b/tools/rpm_buildenv.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# This script works with Fedora. While not tested, it may also work with its
+# derivatives (CentOS, RHEL) or even other RPM-based distros, contributions
+# fixing any deviations in package naming are welcome here.
+# shellcheck disable=SC1091
+set -o pipefail
+
+case "$1" in
+    name)
+        echo "No build environment name required for RPM-based distros." >&2
+        echo "This script installs the build dependencies via dnf using the \"setup\" option." >&2
+        ;;
+
+    setup)
+        sudo dnf install -y \
+            appstream \
+            ccache \
+            chrpath \
+            cmake \
+            desktop-file-utils \
+            faad2 \
+            ffmpeg-devel \
+            fftw-devel \
+            flac-devel \
+            gcc-c++ \
+            gmock-devel \
+            google-benchmark-devel \
+            gtest-devel \
+            guidelines-support-library-devel \
+            hidapi-devel \
+            lame-devel \
+            libchromaprint-devel \
+            libebur128-devel \
+            libid3tag-devel \
+            libmad-devel \
+            libmodplug-devel \
+            libmp4v2-devel \
+            libsndfile-devel \
+            libusb1-devel \
+            libvorbis-devel \
+            lilv-devel \
+            mesa-libGL-devel \
+            mesa-libGLU-devel \
+            ninja-build \
+            opus-devel \
+            opusfile-devel \
+            portaudio-devel \
+            portmidi-devel \
+            protobuf-compiler \
+            protobuf-lite-devel \
+            qt6-qt{5compat,base,base-private,declarative,shadertools,svg}-devel \
+            qtkeychain-qt6-devel \
+            rubberband-devel \
+            soundtouch-devel \
+            sqlite-devel \
+            taglib-devel \
+            upower-devel \
+            wavpack-devel \
+            zlib-devel
+        ;;
+    *)
+        echo "Usage: $0 [options]"
+        echo ""
+        echo "options:"
+        echo "   help       Displays this help."
+        echo "   name       Displays the name of the required build environment."
+        echo "   setup      Installs the build environment."
+        ;;
+esac

--- a/tools/rpm_buildenv.sh
+++ b/tools/rpm_buildenv.sh
@@ -12,6 +12,13 @@ case "$1" in
         ;;
 
     setup)
+        if grep -qP '^NAME=.*Fedora.*' /etc/os-release; then
+            # Add RPM Fusion repository (required for faad2 and ffmpeg-devel)
+            sudo dnf install -y "https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm"
+        else
+            echo "Warning: You are not running Fedora and may have to set up RPM Fusion manually if there are missing packages!"
+        fi
+
         sudo dnf install -y \
             appstream \
             ccache \

--- a/tools/rpm_buildenv.sh
+++ b/tools/rpm_buildenv.sh
@@ -19,6 +19,11 @@ case "$1" in
             echo "Warning: You are not running Fedora and may have to set up RPM Fusion manually if there are missing packages!"
         fi
 
+        # Install the build dependencies.
+        # This list is largely identical to what `dnf builddep mixxx` would
+        # install, with the exception of replacing Qt 5 with Qt 6 (once 2.5 is
+        # released, we could install `dnf-command(builddep)` and then use `dnf
+        # builddep mixxx`).
         sudo dnf install -y \
             appstream \
             ccache \


### PR DESCRIPTION
This adds a new buildenv script for RPM-based distributions, specifically Fedora, to simplify the workflow of building the `main` branch. The corresponding section in the README is also updated to reflect this and now includes a link to the wiki for other distributions (e.g. Arch).

[Here](https://github.com/fwcd/docker-mixxx/blob/02bf0ac75d48c312453c311706a9d4c3c93be6b5/fedora.Dockerfile) is a Dockerfile demonstrating the use of this new script.