### PR TITLE
README: Recommend running buildenvs over sourcing them on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ corresponding command for your operating system:
 | -- | ------- |
 | Windows | `tools\windows_buildenv.bat` |
 | macOS | `source tools/macos_buildenv.sh setup` |
-| Debian/Ubuntu | `source tools/debian_buildenv.sh setup` |
-| Fedora | `source tools/rpm_buildenv.sh setup` |
+| Debian/Ubuntu | `tools/debian_buildenv.sh setup` |
+| Fedora | `tools/rpm_buildenv.sh setup` |
 | Other Linux distros | See the [wiki article](https://github.com/mixxxdj/mixxx/wiki/Compiling%20on%20Linux) |
 
 To build Mixxx, run


### PR DESCRIPTION
A small addendum to #13069, I've noticed that the wiki recommends running the `debian_buildenv.sh` script (in a subshell) instead of sourcing it. Since neither the Debian nor the Fedora/RPM script export any variables, I think we can safely recommend that in the README too, this makes them a bit more robust against users running other shells too, since that way the scripts will always run in Bash. For macOS, we'll still need to source, but the script already guards against that.

