### PR TITLE
ScreenSaver: Add inhibit portal support on Linux

### DIFF
--- a/src/util/screensaver.cpp
+++ b/src/util/screensaver.cpp
@@ -1,11 +1,16 @@
 /**
 Documentation:
-OSX: https://developer.apple.com/reference/iokit/1557134-iopmassertioncreatewithname
-Windows: https://msdn.microsoft.com/en-us/library/windows/desktop/aa373208(v=vs.85).aspx
-Freedesktop: https://people.freedesktop.org/~hadess/idle-inhibition-spec/re01.html
+OSX:
+https://developer.apple.com/reference/iokit/1557134-iopmassertioncreatewithname
+Windows:
+https://msdn.microsoft.com/en-us/library/windows/desktop/aa373208(v=vs.85).aspx
+Freedesktop:
+https://people.freedesktop.org/~hadess/idle-inhibition-spec/re01.html
 XScreenSaver: https://linux.die.net/man/3/xscreensaversuspend
-GTK: https://developer.gnome.org/gtk3/stable/GtkApplication.html#gtk-application-inhibit
-Portal: https://docs.flatpak.org/en/latest/portal-api-reference.html#gdbus-org.freedesktop.portal.Inhibit
+GTK:
+https://developer.gnome.org/gtk3/stable/GtkApplication.html#gtk-application-inhibit
+Portal:
+https://docs.flatpak.org/en/latest/portal-api-reference.html#gdbus-org.freedesktop.portal.Inhibit
 
 With the help of the following source codes:
 
@@ -205,8 +210,7 @@ void ScreenSaverHelper::triggerUserActivity()
     return;
 }
 
-void ScreenSaverHelper::inhibitInternal()
-{
+void ScreenSaverHelper::inhibitInternal() {
     if (!QDBusConnection::sessionBus().isConnected()) {
         qWarning() << "Cannot connect to the D-Bus session bus";
         return;
@@ -273,8 +277,7 @@ void ScreenSaverHelper::inhibitInternal()
     }
 }
 
-void ScreenSaverHelper::uninhibitInternal()
-{
+void ScreenSaverHelper::uninhibitInternal() {
     if (!inhibitor) {
         qDebug() << "Cannot uninhibit without a selected interface";
         return;

--- a/src/util/screensaver.h
+++ b/src/util/screensaver.h
@@ -30,8 +30,8 @@ private:
    static IOPMAssertionID s_systemSleepAssertionID;
    static IOPMAssertionID s_userActivityAssertionID;
 #elif defined(Q_OS_LINUX)
-   static QString session_handle;
-   static uint32_t inhibit_cookie;
+   static QString s_session_handle;
+   static uint32_t s_inhibit_cookie;
 #endif // Q_OS_MACOS
 };
 

--- a/src/util/screensaver.h
+++ b/src/util/screensaver.h
@@ -30,8 +30,8 @@ private:
    static IOPMAssertionID s_systemSleepAssertionID;
    static IOPMAssertionID s_userActivityAssertionID;
 #elif defined(Q_OS_LINUX)
-    static uint32_t s_cookie;
-    static int s_saverindex;
+   static QString session_handle;
+   static uint32_t inhibit_cookie;
 #endif // Q_OS_MACOS
 };
 


### PR DESCRIPTION
This PR implements modern portal based idle inhibit support on Linux and also fixes non-functional idle inhibit on Flatpak Mixxx.

The inhibit portal is supported by both Gnome and KDE and the original idea was to use it as a default. Unfortunately testing revealed undocumented compatibility issues, so portal inhibit is now attempted as a fallback and only if Mixxx is running in a Flatpak sandbox.

I tried to keep the original code logic unchanged and improve things where it seemed appropriate. Let me know if there's anything that should be further improved. Thanks!