### PR TITLE
Tooltips: immediatly show/hide keyboard hints when option is toggled

### DIFF
--- a/src/controllers/keyboard/keyboardeventfilter.h
+++ b/src/controllers/keyboard/keyboardeventfilter.h
@@ -9,6 +9,7 @@
 class ControlObject;
 class QEvent;
 class QKeyEvent;
+class WBaseWidget;
 
 // This class provides handling of keyboard events.
 class KeyboardEventFilter : public QObject {
@@ -24,6 +25,17 @@ class KeyboardEventFilter : public QObject {
     // ownership of pKbdConfigObject.
     void setKeyboardConfig(ConfigObject<ConfigValueKbd> *pKbdConfigObject);
     ConfigObject<ConfigValueKbd>* getKeyboardConfig();
+
+    void setEnabled(bool enabled);
+    bool isEnabled() {
+        return m_enabled;
+    }
+
+    void connectBaseWidgetShortcutToggle(WBaseWidget* pWidget); // const
+
+  signals:
+    // We're only the relay here: CoreServices -> this -> WBaseWidget
+    void shortcutsEnabled(bool enabled);
 
   private:
     struct KeyDownInformation {
@@ -56,6 +68,8 @@ class KeyboardEventFilter : public QObject {
     QList<KeyDownInformation> m_qActiveKeyList;
     // Pointer to keyboard config object
     ConfigObject<ConfigValueKbd> *m_pKbdConfigObject;
+    bool m_enabled;
+
     // Multi-hash of key sequence to
     QMultiHash<ConfigValueKbd, ConfigKey> m_keySequenceToControlHash;
 };

--- a/src/coreservices.h
+++ b/src/coreservices.h
@@ -139,7 +139,6 @@ class CoreServices : public QObject {
 
     std::shared_ptr<KeyboardEventFilter> m_pKeyboardEventFilter;
     std::shared_ptr<ConfigObject<ConfigValueKbd>> m_pKbdConfig;
-    std::shared_ptr<ConfigObject<ConfigValueKbd>> m_pKbdConfigEmpty;
 
     std::shared_ptr<mixxx::ScreensaverManager> m_pScreensaverManager;
 

--- a/src/skin/legacy/legacyskinparser.h
+++ b/src/skin/legacy/legacyskinparser.h
@@ -133,7 +133,8 @@ class LegacySkinParser : public QObject, public SkinParser {
     void setupWidget(const QDomNode& node, QWidget* pWidget,
                      bool setupPosition=true);
     void setupConnections(const QDomNode& node, WBaseWidget* pWidget);
-    void addShortcutToToolTip(WBaseWidget* pWidget, const QString& shortcut, const QString& cmd);
+    const QString buildShortcutString(const QString& shortcut, const QString& cmd) const;
+
     QString getLibraryStyle(const QDomNode& node);
 
     QString lookupNodeGroup(const QDomElement& node);

--- a/src/widget/wbasewidget.cpp
+++ b/src/widget/wbasewidget.cpp
@@ -6,7 +6,8 @@
 
 WBaseWidget::WBaseWidget(QWidget* pWidget)
         : m_pDisplayConnection(nullptr),
-          m_pWidget(pWidget) {
+          m_pWidget(pWidget),
+          m_showKeyboardShortcuts(false) {
 }
 
 WBaseWidget::~WBaseWidget() {
@@ -151,7 +152,7 @@ void WBaseWidget::updateTooltip() {
         QStringList debug;
         fillDebugTooltip(&debug);
 
-        QString base = baseTooltip();
+        QString base = baseTooltipOptShortcuts();
         if (!base.isEmpty()) {
             debug.append(QString("Tooltip: \"%1\"").arg(base));
         }

--- a/src/widget/wbasewidget.h
+++ b/src/widget/wbasewidget.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <QList>
 #include <QString>
 #include <QWidget>
-#include <QList>
 
 class ControlWidgetPropertyConnection;
 class ControlParameterWidgetConnection;
@@ -20,21 +20,51 @@ class WBaseWidget {
 
     void appendBaseTooltip(const QString& tooltip) {
         m_baseTooltip.append(tooltip);
-        m_pWidget->setToolTip(m_baseTooltip);
+        updateBaseTooltipOptShortcuts();
     }
 
     void prependBaseTooltip(const QString& tooltip) {
         m_baseTooltip.prepend(tooltip);
-        m_pWidget->setToolTip(m_baseTooltip);
+        updateBaseTooltipOptShortcuts();
     }
 
     void setBaseTooltip(const QString& tooltip) {
         m_baseTooltip = tooltip;
-        m_pWidget->setToolTip(tooltip);
+        updateBaseTooltipOptShortcuts();
+    }
+
+    void appendShortcutTooltip(const QString& tooltip) {
+        m_shortcutTooltip.append(tooltip);
+        updateBaseTooltipOptShortcuts();
     }
 
     QString baseTooltip() const {
         return m_baseTooltip;
+    }
+
+    QString shortcutHints() const {
+        return m_shortcutTooltip;
+    }
+
+    QString baseTooltipOptShortcuts() const {
+        return m_baseTooltipOptShortcuts;
+    }
+
+    /// Append/remove shortcuts hint when shortcuts are toggled
+    void toggleKeyboardShortcutHints(bool enabled) {
+        m_showKeyboardShortcuts = enabled;
+        updateBaseTooltipOptShortcuts();
+    }
+
+    void updateBaseTooltipOptShortcuts() {
+        QString tooltip;
+        tooltip += m_baseTooltip;
+        if (m_showKeyboardShortcuts && !m_shortcutTooltip.isEmpty()) {
+            tooltip += "\n";
+            tooltip += m_shortcutTooltip;
+        }
+        m_baseTooltipOptShortcuts = tooltip;
+        m_pWidget->setToolTip(tooltip);
     }
 
     void addLeftConnection(ControlParameterWidgetConnection* pConnection);
@@ -59,7 +89,6 @@ class WBaseWidget {
     inline const QList<ControlParameterWidgetConnection*>& leftConnections() const {
         return m_leftConnections;
     };
-
 
   protected:
     // Whenever a connected control is changed, onConnectedControlChanged is
@@ -95,7 +124,12 @@ class WBaseWidget {
 
   private:
     QWidget* m_pWidget;
+
     QString m_baseTooltip;
+    QString m_shortcutTooltip;
+    QString m_baseTooltipOptShortcuts;
+
+    bool m_showKeyboardShortcuts;
 
     friend class ControlParameterWidgetConnection;
 };


### PR DESCRIPTION
Fixes #9814

Keyboard shortcuts are removed / added to tooltips when shortcuts are toggled, which previously required a restart
<sub>(kbd mapping was read by CoreServices once on initialization, if shortcuts disabled = no mapping = LegacySkinParser didn't append the shortcuts to the tooltip).</sub>

For this the entire shortcuts strings is stored by the widget and the base tooltip is reconstructed each time keyboard is toggled.
I think this refactoring might also speed up skin loading a little since the shortcuts are sent to each widget as a whole, not line by line (incl. setTooltip() each time).

This is a very low-level fix IMO, but it creates conflicts for the huge, yet unreviewed Keyboard controller PR #1746.
(I took a brief look and noticed I'm not the right one to do that)
In case someone starts reviewing that I'll help fixing conflicts, of course.