### PR TITLE
3-band waveform with moving average

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1517,6 +1517,7 @@ if(QOPENGL)
     src/waveform/renderers/allshader/waveformrendererfiltered.cpp
     src/waveform/renderers/allshader/waveformrendererhsv.cpp
     src/waveform/renderers/allshader/waveformrendererlrrgb.cpp
+    src/waveform/renderers/allshader/waveformrenderer3band.cpp
     src/waveform/renderers/allshader/waveformrendererpreroll.cpp
     src/waveform/renderers/allshader/waveformrendererrgb.cpp
     src/waveform/renderers/allshader/waveformrenderersignalbase.cpp
@@ -1526,6 +1527,7 @@ if(QOPENGL)
     src/waveform/widgets/allshader/filteredwaveformwidget.cpp
     src/waveform/widgets/allshader/hsvwaveformwidget.cpp
     src/waveform/widgets/allshader/lrrgbwaveformwidget.cpp
+    src/waveform/widgets/allshader/3bandwaveformwidget.cpp
     src/waveform/widgets/allshader/rgbwaveformwidget.cpp
     src/waveform/widgets/allshader/simplewaveformwidget.cpp
     src/waveform/widgets/allshader/waveformwidget.cpp

--- a/res/skins/LateNight/skin.xml
+++ b/res/skins/LateNight/skin.xml
@@ -154,8 +154,6 @@
       <SetVariable name="SignalColor_12">#d9b28c</SetVariable>
       <SetVariable name="SignalColor_34">#7bc6c3</SetVariable>
 
-      <!-- Only named colors are accepted, see w3 color chart
-          https://www.w3.org/wiki/CSS/Properties/color/keywords -->
       <SetVariable name="SignalHighColor">mediumblue</SetVariable><!-- #0000cd -->
       <SetVariable name="SignalMidColor">darkgreen</SetVariable><!-- #006400 -->
       <SetVariable name="SignalLowColor">orangered</SetVariable><!-- #ff4500 -->

--- a/res/skins/LateNight/waveform.xml
+++ b/res/skins/LateNight/waveform.xml
@@ -19,12 +19,21 @@
             <BgColor><Variable name="BgColorWaveform"/></BgColor>
             <SignalColor><Variable name="SignalColor"/></SignalColor>
             <!-- Default colors are used for high/mid/low: blue/green/red -->
-            <SignalHighColor></SignalHighColor>
-            <SignalMidColor></SignalMidColor>
-            <SignalLowColor></SignalLowColor>
+            <SignalHighColor><Variable name="SignalHighColor"/></SignalHighColor>
+            <SignalMidColor><Variable name="SignalMidColor"/></SignalMidColor>
+            <SignalLowColor><Variable name="SignalLowColor"/></SignalLowColor>
             <SignalRGBHighColor></SignalRGBHighColor>
             <SignalRGBMidColor></SignalRGBMidColor>
             <SignalRGBLowColor></SignalRGBLowColor>
+
+            <!-- Parameter used for the moving average of the 3-band waveform. This settings can be adjusted to tweak the right trade-off between sharpeness, accuracy and smoothing curves -->
+            <SmoothFactorLow></SmoothFactorLow>
+            <SmoothFactorMid></SmoothFactorMid>
+            <SmoothFactorHigh>10</SmoothFactorHigh>
+            <SmoothThresholdLow></SmoothThresholdLow>
+            <SmoothThresholdMid>96</SmoothThresholdMid>
+            <SmoothThresholdHigh>16</SmoothThresholdHigh>
+
             <BeatColor><Variable name="BeatColor"/></BeatColor>
             <AxesColor><Variable name="AxesColor"/></AxesColor>
             <BeatHighlightColor></BeatHighlightColor>

--- a/src/preferences/upgrade.cpp
+++ b/src/preferences/upgrade.cpp
@@ -46,6 +46,7 @@ WaveformWidgetType::Type upgradeToAllShaders(WaveformWidgetType::Type waveformTy
     case WWT::AllShaderFilteredWaveform:
     case WWT::AllShaderSimpleWaveform:
     case WWT::AllShaderHSVWaveform:
+    case WWT::AllShaderThreeBandWaveform:
     case WWT::Count_WaveformwidgetType:
         return waveformType;
     case WWT::QtSimpleWaveform:

--- a/src/waveform/renderers/allshader/waveformrenderer3band.cpp
+++ b/src/waveform/renderers/allshader/waveformrenderer3band.cpp
@@ -1,0 +1,293 @@
+#include "waveform/renderers/allshader/waveformrenderer3band.h"
+
+#include "track/track.h"
+#include "util/colorcomponents.h"
+#include "waveform/renderers/allshader/matrixforwidgetgeometry.h"
+#include "waveform/renderers/waveformwidgetrenderer.h"
+#include "waveform/waveform.h"
+
+namespace allshader {
+
+namespace {
+// This factor defined the number of sample used for the moving average. Signal
+// will look smoother but also less accurate
+constexpr int kDefaultSmoothFactor = 5;
+// The threshold allows the moving average to be reset in case a sample is
+// significantly different from the current average value and allow to keep some
+// sharpness on the waveform (e.g beat)
+constexpr int kDefaultSmoothThreshold = 64.f;
+constexpr int kLowIdx = 0;
+constexpr int kMidIdx = 1;
+constexpr int kHighIdx = 2;
+// The following gains are applied on top of the existing gain (user setting and
+// EQ levels) in order to prevent a complete overlapping of the signal and help
+// choose a right mix of stacking and overlapping
+constexpr float kLowGain = 1.3f;
+constexpr float kMidGain = 0.9f;
+constexpr float kHighGain = 0.4f;
+} // namespace
+
+WaveformRendererThreeBand::WaveformRendererThreeBand(
+        WaveformWidgetRenderer* waveformWidget)
+        : WaveformRendererSignalBase(waveformWidget),
+          m_lowSmoothFactor(kDefaultSmoothFactor),
+          m_midSmoothFactor(kDefaultSmoothFactor),
+          m_highSmoothFactor(kDefaultSmoothFactor),
+          m_lowSmoothThreshold(kDefaultSmoothThreshold),
+          m_midSmoothThreshold(kDefaultSmoothThreshold),
+          m_highSmoothThreshold(kDefaultSmoothThreshold) {
+}
+
+void WaveformRendererThreeBand::onSetup(const QDomNode& node) {
+    bool ok;
+    QDomElement lowFactor = node.firstChildElement("SmoothFactorLow");
+    if (!lowFactor.isNull()) {
+        int newLowFactor = lowFactor.text().toInt(&ok);
+        if (ok) {
+            m_lowSmoothFactor = newLowFactor;
+        }
+    }
+    QDomElement midFactor = node.firstChildElement("SmoothFactorMid");
+    if (!midFactor.isNull()) {
+        int newMidFactor = midFactor.text().toInt(&ok);
+        if (ok) {
+            m_midSmoothFactor = newMidFactor;
+        }
+    }
+    QDomElement highFactor = node.firstChildElement("SmoothFactorHigh");
+    if (!highFactor.isNull()) {
+        int newHighFactor = highFactor.text().toInt(&ok);
+        if (ok) {
+            m_highSmoothFactor = newHighFactor;
+        }
+    }
+    QDomElement lowThreshold = node.firstChildElement("SmoothThresholdLow");
+    if (!lowThreshold.isNull()) {
+        float newLowThreshold = lowThreshold.text().toFloat(&ok);
+        if (ok) {
+            m_lowSmoothThreshold = newLowThreshold;
+        }
+    }
+    QDomElement midThreshold = node.firstChildElement("SmoothThresholdMid");
+    if (!midThreshold.isNull()) {
+        float newMidThreshold = midThreshold.text().toFloat(&ok);
+        if (ok) {
+            m_midSmoothThreshold = newMidThreshold;
+        }
+    }
+    QDomElement highThreshold = node.firstChildElement("SmoothThresholdHigh");
+    if (!highThreshold.isNull()) {
+        float newHighThreshold = highThreshold.text().toFloat(&ok);
+        if (ok) {
+            m_highSmoothThreshold = newHighThreshold;
+        }
+    }
+    m_normalisers[kLowIdx] = MovingAverageThreshold(m_lowSmoothThreshold, m_lowSmoothFactor);
+    m_normalisers[kMidIdx] = MovingAverageThreshold(m_midSmoothThreshold, m_midSmoothFactor);
+    m_normalisers[kHighIdx] = MovingAverageThreshold(m_highSmoothThreshold, m_highSmoothFactor);
+}
+
+void WaveformRendererThreeBand::initializeGL() {
+    WaveformRendererSignalBase::initializeGL();
+    m_shader.init();
+}
+
+void WaveformRendererThreeBand::paintGL() {
+    TrackPointer pTrack = m_waveformRenderer->getTrackInfo();
+    if (!pTrack) {
+        return;
+    }
+
+    ConstWaveformPointer waveform = pTrack->getWaveform();
+    if (waveform.isNull()) {
+        return;
+    }
+
+    const int dataSize = waveform->getDataSize();
+    if (dataSize <= 1) {
+        return;
+    }
+
+    const WaveformData* data = waveform->data();
+    if (data == nullptr) {
+        return;
+    }
+
+    const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
+    const int length = static_cast<int>(m_waveformRenderer->getLength() * devicePixelRatio);
+
+    // See waveformrenderersimple.cpp for a detailed explanation of the frame and index calculation
+    const int visualFramesSize = dataSize / 2;
+    const double firstVisualFrame =
+            m_waveformRenderer->getFirstDisplayedPosition() * visualFramesSize;
+    const double lastVisualFrame =
+            m_waveformRenderer->getLastDisplayedPosition() * visualFramesSize;
+
+    // Represents the # of visual frames per horizontal pixel.
+    const double visualIncrementPerPixel =
+            (lastVisualFrame - firstVisualFrame) / static_cast<double>(length);
+
+    // Per-band gain from the EQ knobs.
+    float allGain(1.0), gains[3]{0};
+    // applyCompensation = true, as we scale to match filtered.all
+    getGains(&allGain, true, gains + kLowIdx, gains + kMidIdx, gains + kHighIdx);
+
+    gains[kLowIdx] *= kLowGain;
+    gains[kMidIdx] *= kMidGain;
+    gains[kHighIdx] *= kHighGain;
+
+    const float breadth = static_cast<float>(m_waveformRenderer->getBreadth()) * devicePixelRatio;
+    const float halfBreadth = breadth / 2.0f;
+
+    const float heightFactor = allGain * halfBreadth / m_maxValue;
+
+    // Effective visual frame for x
+    double xVisualFrame = qRound(firstVisualFrame / visualIncrementPerPixel) *
+            visualIncrementPerPixel;
+
+    const int numVerticesPerLine = 6; // 2 triangles
+
+    const int reserved = numVerticesPerLine * (3 * length + 1);
+
+    m_vertices.clear();
+    m_vertices.reserve(reserved);
+    m_colors.clear();
+    m_colors.reserve(reserved);
+
+    m_vertices.addRectangle(0.f,
+            halfBreadth - 0.5f * devicePixelRatio,
+            static_cast<float>(length),
+            halfBreadth + 0.5f * devicePixelRatio);
+    m_colors.addForRectangle(0.f, 0.f, 0.f, 0.f);
+
+    const double maxSamplingRange = visualIncrementPerPixel / 2.0;
+
+    for (int pos = 0; pos < length; ++pos) {
+        for (int eq = kLowIdx; eq < kHighIdx + 1; eq++) {
+            const int visualFrameStart = std::lround(xVisualFrame - maxSamplingRange);
+            const int visualFrameStop = std::lround(xVisualFrame + maxSamplingRange);
+
+            const int visualIndexStart = std::max(visualFrameStart * 2, 0);
+            const int visualIndexStop =
+                    std::min(std::max(visualFrameStop, visualFrameStart + 1) * 2, dataSize - 1);
+
+            const float fpos = static_cast<float>(pos);
+
+            // Find the max values for current eq in the waveform data.
+            // - Max of left and right
+            uchar u8max{};
+            for (int chn = 0; chn < 2; chn++) {
+                // data is interleaved left / right
+                for (int i = visualIndexStart + chn; i < visualIndexStop + chn; i += 2) {
+                    const WaveformData& waveformData = data[i];
+
+                    switch (eq) {
+                    default:
+                        DEBUG_ASSERT(!"Invalid EQ index");
+                    case kLowIdx:
+                        u8max = math_max(u8max, waveformData.filtered.low);
+                        break;
+                    case kMidIdx:
+                        u8max = math_max(u8max, waveformData.filtered.mid);
+                        break;
+                    case kHighIdx:
+                        u8max = math_max(u8max, waveformData.filtered.high);
+                        break;
+                    }
+                }
+            }
+
+            // Cast to float
+            float max = static_cast<float>(u8max);
+
+            // Apply the gains
+            max *= gains[eq];
+
+            // Smooth data with a moving average
+            max = m_normalisers[eq].add(max);
+
+            // Lines are thin rectangles
+            m_vertices.addRectangle(fpos - 0.5f,
+                    halfBreadth - heightFactor * max,
+                    fpos + 0.5f,
+                    halfBreadth + heightFactor * max);
+            switch (eq) {
+            default:
+                DEBUG_ASSERT(!"Invalid EQ index");
+            case kLowIdx:
+                m_colors.addForRectangle(m_lowColor_r, m_lowColor_g, m_lowColor_b, m_lowColor_a);
+                break;
+            case kMidIdx:
+                m_colors.addForRectangle(m_midColor_r, m_midColor_g, m_midColor_b, m_midColor_a);
+                break;
+            case kHighIdx:
+                m_colors.addForRectangle(m_highColor_r,
+                        m_highColor_g,
+                        m_highColor_b,
+                        m_highColor_a);
+                break;
+            }
+        }
+        xVisualFrame += visualIncrementPerPixel;
+    }
+
+    DEBUG_ASSERT(reserved == m_vertices.size());
+    DEBUG_ASSERT(reserved == m_colors.size());
+
+    const QMatrix4x4 matrix = matrixForWidgetGeometry(m_waveformRenderer, true);
+
+    const int matrixLocation = m_shader.matrixLocation();
+    const int positionLocation = m_shader.positionLocation();
+    const int colorLocation = m_shader.colorLocation();
+
+    m_shader.bind();
+    m_shader.enableAttributeArray(positionLocation);
+    m_shader.enableAttributeArray(colorLocation);
+
+    m_shader.setUniformValue(matrixLocation, matrix);
+
+    m_shader.setAttributeArray(
+            positionLocation, GL_FLOAT, m_vertices.constData(), 2);
+    m_shader.setAttributeArray(
+            colorLocation, GL_FLOAT, m_colors.constData(), 4);
+
+    glDrawArrays(GL_TRIANGLES, 0, m_vertices.size());
+
+    m_shader.disableAttributeArray(positionLocation);
+    m_shader.disableAttributeArray(colorLocation);
+    m_shader.release();
+}
+
+} // namespace allshader
+
+MovingAverageThreshold::MovingAverageThreshold(float threshold, int max)
+        : m_stack(),
+          m_threshold(threshold),
+          m_currentAverage(-1.f),
+          m_cursor(0),
+          m_size(0),
+          m_max(max) {
+    m_stack.resize(m_max);
+}
+
+void MovingAverageThreshold::reset() {
+    m_currentAverage = -1.f;
+    m_cursor = 0;
+    m_size = 0;
+}
+
+float MovingAverageThreshold::add(float sample) {
+    if (m_currentAverage > 0 && fabs(sample - m_currentAverage) > m_threshold) {
+        m_cursor = 0;
+        m_size = 0;
+    }
+    m_stack[m_cursor] = sample;
+    m_size = math_min(m_size + 1, m_max);
+    m_currentAverage = m_stack[m_cursor];
+    for (uint8_t i = 1; i < m_size; i++) {
+        m_currentAverage += m_stack[(m_cursor + m_max - i) % m_max];
+    }
+    m_cursor = (m_cursor + 1) % m_max;
+    m_currentAverage /= m_size;
+    return m_currentAverage;
+}

--- a/src/waveform/renderers/allshader/waveformrenderer3band.h
+++ b/src/waveform/renderers/allshader/waveformrenderer3band.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <vector>
+
+#include "shaders/rgbashader.h"
+#include "util/class.h"
+#include "waveform/renderers/allshader/rgbadata.h"
+#include "waveform/renderers/allshader/vertexdata.h"
+#include "waveform/renderers/allshader/waveformrenderersignalbase.h"
+
+namespace allshader {
+class WaveformRendererThreeBand;
+}
+
+/// @brief Normaliser use to reduce noise and smooth curves on the waveform
+class MovingAverageThreshold {
+  public:
+    MovingAverageThreshold()
+            : MovingAverageThreshold(0.f, 0) {
+    }
+    MovingAverageThreshold(float threshold, int max);
+    float add(float sample);
+    void reset();
+
+  private:
+    std::vector<float> m_stack;
+    float m_threshold;
+    float m_currentAverage;
+    int m_cursor;
+    int m_size;
+    int m_max;
+};
+
+class allshader::WaveformRendererThreeBand final : public allshader::WaveformRendererSignalBase {
+  public:
+    explicit WaveformRendererThreeBand(WaveformWidgetRenderer* waveformWidget);
+
+    // override ::WaveformRendererSignalBase
+    void onSetup(const QDomNode& node) override;
+
+    void initializeGL() override;
+    void paintGL() override;
+
+  private:
+    mixxx::RGBAShader m_shader;
+    VertexData m_vertices;
+    RGBAData m_colors;
+
+    int m_lowSmoothFactor;
+    int m_midSmoothFactor;
+    int m_highSmoothFactor;
+
+    float m_lowSmoothThreshold;
+    float m_midSmoothThreshold;
+    float m_highSmoothThreshold;
+
+    MovingAverageThreshold m_normalisers[3];
+
+    DISALLOW_COPY_AND_ASSIGN(WaveformRendererThreeBand);
+};

--- a/src/waveform/renderers/waveformrenderersignalbase.cpp
+++ b/src/waveform/renderers/waveformrenderersignalbase.cpp
@@ -125,13 +125,13 @@ void WaveformRendererSignalBase::setup(const QDomNode& node,
     m_pColors = m_waveformRenderer->getWaveformSignalColors();
 
     const QColor& l = m_pColors->getLowColor();
-    getRgbF(l, &m_lowColor_r, &m_lowColor_g, &m_lowColor_b);
+    getRgbF(l, &m_lowColor_r, &m_lowColor_g, &m_lowColor_b, &m_lowColor_a);
 
     const QColor& m = m_pColors->getMidColor();
-    getRgbF(m, &m_midColor_r, &m_midColor_g, &m_midColor_b);
+    getRgbF(m, &m_midColor_r, &m_midColor_g, &m_midColor_b, &m_midColor_a);
 
     const QColor& h = m_pColors->getHighColor();
-    getRgbF(h, &m_highColor_r, &m_highColor_g, &m_highColor_b);
+    getRgbF(h, &m_highColor_r, &m_highColor_g, &m_highColor_b, &m_highColor_a);
 
     const QColor& rgbLow = m_pColors->getRgbLowColor();
     getRgbF(rgbLow, &m_rgbLowColor_r, &m_rgbLowColor_g, &m_rgbLowColor_b);

--- a/src/waveform/renderers/waveformrenderersignalbase.h
+++ b/src/waveform/renderers/waveformrenderersignalbase.h
@@ -51,9 +51,9 @@ public:
     const WaveformSignalColors* m_pColors;
     float m_axesColor_r, m_axesColor_g, m_axesColor_b, m_axesColor_a;
     float m_signalColor_r, m_signalColor_g, m_signalColor_b;
-    float m_lowColor_r, m_lowColor_g, m_lowColor_b;
-    float m_midColor_r, m_midColor_g, m_midColor_b;
-    float m_highColor_r, m_highColor_g, m_highColor_b;
+    float m_lowColor_r, m_lowColor_g, m_lowColor_b, m_lowColor_a;
+    float m_midColor_r, m_midColor_g, m_midColor_b, m_midColor_a;
+    float m_highColor_r, m_highColor_g, m_highColor_b, m_highColor_a;
     float m_rgbLowColor_r, m_rgbLowColor_g, m_rgbLowColor_b;
     float m_rgbMidColor_r, m_rgbMidColor_g, m_rgbMidColor_b;
     float m_rgbHighColor_r, m_rgbHighColor_g, m_rgbHighColor_b;

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -24,6 +24,7 @@
 #include "waveform/visualsmanager.h"
 #include "waveform/vsyncthread.h"
 #ifdef MIXXX_USE_QOPENGL
+#include "waveform/widgets/allshader/3bandwaveformwidget.h"
 #include "waveform/widgets/allshader/filteredwaveformwidget.h"
 #include "waveform/widgets/allshader/hsvwaveformwidget.h"
 #include "waveform/widgets/allshader/lrrgbwaveformwidget.h"
@@ -968,6 +969,13 @@ void WaveformWidgetFactory::evaluateWidgets() {
             setWaveformVarsByType.operator()<allshader::HSVWaveformWidget>();
             break;
 #endif
+        case WaveformWidgetType::AllShaderThreeBandWaveform:
+#ifndef MIXXX_USE_QOPENGL
+            continue;
+#else
+            setWaveformVarsByType.operator()<allshader::ThreeBandWaveformWidget>();
+            break;
+#endif
         default:
             DEBUG_ASSERT(!"Unexpected WaveformWidgetType");
             continue;
@@ -1063,6 +1071,9 @@ WaveformWidgetAbstract* WaveformWidgetFactory::createWaveformWidget(
             break;
         case WaveformWidgetType::AllShaderHSVWaveform:
             widget = new allshader::HSVWaveformWidget(viewer->getGroup(), viewer);
+            break;
+        case WaveformWidgetType::AllShaderThreeBandWaveform:
+            widget = new allshader::ThreeBandWaveformWidget(viewer->getGroup(), viewer);
             break;
 #else
         case WaveformWidgetType::QtSimpleWaveform:

--- a/src/waveform/widgets/allshader/3bandwaveformwidget.cpp
+++ b/src/waveform/widgets/allshader/3bandwaveformwidget.cpp
@@ -1,0 +1,35 @@
+#include "waveform/widgets/allshader/3bandwaveformwidget.h"
+
+#include "waveform/renderers/allshader/waveformrenderbackground.h"
+#include "waveform/renderers/allshader/waveformrenderbeat.h"
+#include "waveform/renderers/allshader/waveformrenderer3band.h"
+#include "waveform/renderers/allshader/waveformrendererendoftrack.h"
+#include "waveform/renderers/allshader/waveformrendererpreroll.h"
+#include "waveform/renderers/allshader/waveformrendermark.h"
+#include "waveform/renderers/allshader/waveformrendermarkrange.h"
+#include "waveform/widgets/allshader/moc_3bandwaveformwidget.cpp"
+
+namespace allshader {
+
+ThreeBandWaveformWidget::ThreeBandWaveformWidget(const QString& group, QWidget* parent)
+        : WaveformWidget(group, parent) {
+    addRenderer<WaveformRenderBackground>();
+    addRenderer<WaveformRendererEndOfTrack>();
+    addRenderer<WaveformRendererPreroll>();
+    addRenderer<WaveformRenderMarkRange>();
+    addRenderer<WaveformRendererThreeBand>();
+    addRenderer<WaveformRenderBeat>();
+    addRenderer<WaveformRenderMark>();
+
+    m_initSuccess = init();
+}
+
+void ThreeBandWaveformWidget::castToQWidget() {
+    m_widget = this;
+}
+
+void ThreeBandWaveformWidget::paintEvent(QPaintEvent* event) {
+    Q_UNUSED(event);
+}
+
+} // namespace allshader

--- a/src/waveform/widgets/allshader/3bandwaveformwidget.h
+++ b/src/waveform/widgets/allshader/3bandwaveformwidget.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "util/class.h"
+#include "waveform/widgets/allshader/waveformwidget.h"
+
+class WaveformWidgetFactory;
+
+namespace allshader {
+class ThreeBandWaveformWidget;
+}
+
+class allshader::ThreeBandWaveformWidget final : public allshader::WaveformWidget {
+    Q_OBJECT
+  public:
+    WaveformWidgetType::Type getType() const override {
+        return WaveformWidgetType::AllShaderThreeBandWaveform;
+    }
+
+    static inline QString getWaveformWidgetName() {
+        return tr("3-Band");
+    }
+    static constexpr bool useOpenGl() {
+        return true;
+    }
+    static constexpr bool useOpenGles() {
+        return true;
+    }
+    static constexpr bool useOpenGLShaders() {
+        return true;
+    }
+    static constexpr WaveformWidgetCategory category() {
+        return WaveformWidgetCategory::AllShader;
+    }
+
+  protected:
+    void castToQWidget() override;
+    void paintEvent(QPaintEvent* event) override;
+
+  private:
+    ThreeBandWaveformWidget(const QString& group, QWidget* parent);
+    friend class ::WaveformWidgetFactory;
+
+    DISALLOW_COPY_AND_ASSIGN(ThreeBandWaveformWidget);
+};

--- a/src/waveform/widgets/waveformwidgettype.h
+++ b/src/waveform/widgets/waveformwidgettype.h
@@ -6,27 +6,28 @@ class WaveformWidgetType {
         // The order must not be changed because the waveforms are referenced
         // from the sorted preferences by a number.
         EmptyWaveform = 0,
-        SoftwareSimpleWaveform,    // 1  TODO
-        SoftwareWaveform,          // 2  Filtered
-        QtSimpleWaveform,          // 3  Simple Qt
-        QtWaveform,                // 4  Filtered Qt
-        GLSimpleWaveform,          // 5  Simple GL
-        GLFilteredWaveform,        // 6  Filtered GL
-        GLSLFilteredWaveform,      // 7  Filtered GLSL
-        HSVWaveform,               // 8  HSV
-        GLVSyncTest,               // 9  VSync GL
-        RGBWaveform,               // 10 RGB
-        GLRGBWaveform,             // 11 RGB GL
-        GLSLRGBWaveform,           // 12 RGB GLSL
-        QtVSyncTest,               // 13 VSync Qt
-        QtHSVWaveform,             // 14 HSV Qt
-        QtRGBWaveform,             // 15 RGB Qt
-        GLSLRGBStackedWaveform,    // 16 RGB Stacked
-        AllShaderRGBWaveform,      // 17 RGB (all-shaders)
-        AllShaderLRRGBWaveform,    // 18 L/R RGB (all-shaders)
-        AllShaderFilteredWaveform, // 19 Filtered (all-shaders)
-        AllShaderSimpleWaveform,   // 20 Simple (all-shaders)
-        AllShaderHSVWaveform,      // 21 HSV (all-shaders)
-        Count_WaveformwidgetType   //    Also used as invalid value
+        SoftwareSimpleWaveform,     // 1  TODO
+        SoftwareWaveform,           // 2  Filtered
+        QtSimpleWaveform,           // 3  Simple Qt
+        QtWaveform,                 // 4  Filtered Qt
+        GLSimpleWaveform,           // 5  Simple GL
+        GLFilteredWaveform,         // 6  Filtered GL
+        GLSLFilteredWaveform,       // 7  Filtered GLSL
+        HSVWaveform,                // 8  HSV
+        GLVSyncTest,                // 9  VSync GL
+        RGBWaveform,                // 10 RGB
+        GLRGBWaveform,              // 11 RGB GL
+        GLSLRGBWaveform,            // 12 RGB GLSL
+        QtVSyncTest,                // 13 VSync Qt
+        QtHSVWaveform,              // 14 HSV Qt
+        QtRGBWaveform,              // 15 RGB Qt
+        GLSLRGBStackedWaveform,     // 16 RGB Stacked
+        AllShaderRGBWaveform,       // 17 RGB (all-shaders)
+        AllShaderLRRGBWaveform,     // 18 L/R RGB (all-shaders)
+        AllShaderFilteredWaveform,  // 19 Filtered (all-shaders)
+        AllShaderSimpleWaveform,    // 20 Simple (all-shaders)
+        AllShaderHSVWaveform,       // 21 HSV (all-shaders)
+        AllShaderThreeBandWaveform, // 22 Stacked EQ (all-shaders)
+        Count_WaveformwidgetType    //    Also used as invalid value
     };
 };


### PR DESCRIPTION
This adds a new type of waveform, using 3-band EQ with overlapped. It also includes a moving average feature to allow adjusting the smoothness of the Waveform.

Here is a preview with different genre of music (Hardcore, Funk and Symphonic):
(Zoomed waveforms)
![image](https://github.com/mixxxdj/mixxx/assets/7086688/2205c4d1-5997-497f-baa9-3f1b436f74b5)
("Normal" look)
![image](https://github.com/mixxxdj/mixxx/assets/7086688/7ecc10e2-721f-4ce9-89e5-829666328f01)
(Using a custom coloring)
![image](https://github.com/mixxxdj/mixxx/assets/7086688/8bfb28d4-91e4-4f6b-88fc-600990460b0c)

The custom coloring used is the following
```xml
      <SetVariable name="SignalHighColor">#aff1eed8</SetVariable>
      <SetVariable name="SignalMidColor">#cfb26606</SetVariable>
      <SetVariable name="SignalLowColor">#ff2154d7</SetVariable>
```

Look with **Deere** skin
![image](https://github.com/mixxxdj/mixxx/assets/7086688/fdad9e6b-b5a6-4f1e-9f9d-c192fd28fdd2)
Look with **Shade** skin
![image](https://github.com/mixxxdj/mixxx/assets/7086688/3cd1c025-216d-445b-ac13-ba61a6f8a70b)
Look with **Tango** skin
![image](https://github.com/mixxxdj/mixxx/assets/7086688/fcc10408-366f-4d18-a679-dd4a8f72e6d9)
