### PR TITLE
add `hotcue_X_indicator` control, is 1.0 if playposition is at hotcue -- alternative to #12951

### DIFF
--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -500,6 +500,7 @@ void CueControl::trackLoaded(TrackPointer pNewTrack) {
         setHotcueFocusIndex(Cue::kNoHotCue);
         m_pLoadedTrack.reset();
         m_usedSeekOnLoadPosition.setValue(mixxx::audio::kStartFramePos);
+        m_prevPosition.setValue(mixxx::audio::kStartFramePos);
     }
 
     if (!pNewTrack) {
@@ -2178,11 +2179,44 @@ void CueControl::updateIndicators() {
             m_pCueIndicator->setBlinkValue(ControlIndicator::ON);
         }
     }
+
+    // Update hotcue indicators: activate the indicator if we are at the cue pos
+    // or if we passed it since the last update, else deactivate.
+    const auto prevPos = m_prevPosition.getValue();
+    const auto currPos = frameInfo().currentPosition;
+    VERIFY_OR_DEBUG_ASSERT(prevPos.isValid()) {
+        m_prevPosition.setValue(currPos);
+        return;
+    }
+
+    for (const auto& pControl : std::as_const(m_hotcueControls)) {
+        const auto cuePos = pControl->getPosition();
+        if (!cuePos.isValid()) {
+            continue;
+        }
+        if ((cuePos >= prevPos && cuePos <= currPos) ||     // forward
+                (cuePos <= prevPos && cuePos >= currPos)) { // reverse
+            pControl->setIndicator(1.0);
+        } else {
+            pControl->setIndicator(0.0);
+        }
+    }
+    m_prevPosition.setValue(currPos);
 }
 
 void CueControl::resetIndicators() {
     m_pCueIndicator->setBlinkValue(ControlIndicator::OFF);
     m_pPlayIndicator->setBlinkValue(ControlIndicator::OFF);
+    for (const auto& pControl : std::as_const(m_hotcueControls)) {
+        pControl->setIndicator(0.0);
+    }
+}
+
+/// Store the position so we can do a correct range check when updating the
+/// hotcue indicators. Otherwise m_prevPosition would be the position from before
+/// the seek and we'd falsely activate indicators.
+void CueControl::notifySeek(mixxx::audio::FramePos position) {
+    m_prevPosition.setValue(position);
 }
 
 CueControl::TrackAt CueControl::getTrackAt() const {
@@ -2471,9 +2505,12 @@ HotcueControl::HotcueControl(const QString& group, int hotcueIndex)
 
     m_pHotcueStatus = std::make_unique<ControlObject>(keyForControl(QStringLiteral("status")));
     m_pHotcueStatus->setReadOnly();
-
     // Add an alias for the legacy hotcue_X_enabled CO
     m_pHotcueStatus->addAlias(keyForControl(QStringLiteral("enabled")));
+
+    m_pHotcueIndicator = std::make_unique<ControlObject>(
+            keyForControl(QStringLiteral("indicator")));
+    m_pHotcueIndicator->setReadOnly();
 
     m_hotcueType = std::make_unique<ControlObject>(keyForControl(QStringLiteral("type")));
     m_hotcueType->setReadOnly();
@@ -2712,6 +2749,7 @@ void HotcueControl::resetCue() {
     setEndPosition(mixxx::audio::kInvalidFramePos);
     setType(mixxx::CueType::Invalid);
     setStatus(Status::Empty);
+    setIndicator(0.0);
 }
 
 void HotcueControl::setPosition(mixxx::audio::FramePos position) {
@@ -2728,6 +2766,12 @@ void HotcueControl::setType(mixxx::CueType type) {
 
 void HotcueControl::setStatus(HotcueControl::Status status) {
     m_pHotcueStatus->forceSet(static_cast<double>(status));
+}
+
+void HotcueControl::setIndicator(double on) {
+    m_pHotcueIndicator->forceSet(on);
+    // TODO: check if we can squeez this into hotcue_N_status without too much effort.
+    // IINM that would require reading e.g. m_pCurrentSavedLoopControl.
 }
 
 HotcueControl::Status HotcueControl::getStatus() const {

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -96,6 +96,8 @@ class HotcueControl : public QObject {
     void setStatus(HotcueControl::Status status);
     HotcueControl::Status getStatus() const;
 
+    void setIndicator(double on);
+
     void setColor(mixxx::RgbColor::optional_t newColor);
     mixxx::RgbColor::optional_t getColor() const;
 
@@ -165,6 +167,7 @@ class HotcueControl : public QObject {
     std::unique_ptr<ControlObject> m_hotcuePosition;
     std::unique_ptr<ControlObject> m_hotcueEndPosition;
     std::unique_ptr<ControlObject> m_pHotcueStatus;
+    std::unique_ptr<ControlObject> m_pHotcueIndicator;
     std::unique_ptr<ControlObject> m_hotcueType;
     std::unique_ptr<ControlObject> m_hotcueColor;
     // Hotcue button controls
@@ -194,6 +197,7 @@ class CueControl : public EngineControl {
     ~CueControl() override;
 
     void hintReader(gsl::not_null<HintVector*> pHintList) override;
+    void notifySeek(mixxx::audio::FramePos position) override;
     bool updateIndicatorsAndModifyPlay(bool newPlay, bool oldPlay, bool playPossible);
     void updateIndicators();
     bool isTrackAtIntroCue();
@@ -362,6 +366,9 @@ class CueControl : public EngineControl {
 
     // Tells us which controls map to which hotcue
     QMap<QObject*, int> m_controlMap;
+
+    // Position used to update hotcue indicators in updateIndicators()
+    ControlValueAtomic<mixxx::audio::FramePos> m_prevPosition;
 
     // Must be locked when using the m_pLoadedTrack and it's properties
     QT_RECURSIVE_MUTEX m_trackMutex;

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -208,6 +208,9 @@ class CueControl : public EngineControl {
     void trackLoaded(TrackPointer pNewTrack) override;
     void trackBeatsUpdated(mixxx::BeatsPointer pBeats) override;
 
+    void notifyWrapAround(mixxx::audio::FramePos triggerPos,
+            mixxx::audio::FramePos targetPos);
+
   signals:
     void loopRemove();
 
@@ -369,6 +372,10 @@ class CueControl : public EngineControl {
 
     // Position used to update hotcue indicators in updateIndicators()
     ControlValueAtomic<mixxx::audio::FramePos> m_prevPosition;
+
+    int m_wrapAroundCount;
+    mixxx::audio::FramePos m_jumpPos;
+    mixxx::audio::FramePos m_targetPos;
 
     // Must be locked when using the m_pLoadedTrack and it's properties
     QT_RECURSIVE_MUTEX m_trackMutex;

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -250,6 +250,7 @@ EngineBuffer::EngineBuffer(const QString& group,
 
     m_pReadAheadManager = new ReadAheadManager(m_pReader,
                                                m_pLoopingControl);
+    m_pReadAheadManager->addCueControl(m_pCueControl);
     m_pReadAheadManager->addRateControl(m_pRateControl);
 
     m_pKeylockEngine = new ControlProxy(kAppGroup, QStringLiteral("keylock_engine"), this);

--- a/src/engine/readaheadmanager.cpp
+++ b/src/engine/readaheadmanager.cpp
@@ -1,13 +1,15 @@
 #include "engine/readaheadmanager.h"
 
 #include "engine/cachingreader/cachingreader.h"
+#include "engine/controls/cuecontrol.h"
 #include "engine/controls/loopingcontrol.h"
 #include "engine/controls/ratecontrol.h"
 #include "util/defs.h"
 #include "util/sample.h"
 
 ReadAheadManager::ReadAheadManager()
-        : m_pLoopingControl(nullptr),
+        : m_pCueControl(nullptr),
+          m_pLoopingControl(nullptr),
           m_pRateControl(nullptr),
           m_currentPosition(0),
           m_pReader(nullptr),
@@ -18,7 +20,8 @@ ReadAheadManager::ReadAheadManager()
 
 ReadAheadManager::ReadAheadManager(CachingReader* pReader,
         LoopingControl* pLoopingControl)
-        : m_pLoopingControl(pLoopingControl),
+        : m_pCueControl(nullptr),
+          m_pLoopingControl(pLoopingControl),
           m_pRateControl(nullptr),
           m_currentPosition(0),
           m_pReader(pReader),
@@ -120,7 +123,9 @@ SINT ReadAheadManager::getNextSamples(double dRate, CSAMPLE* pOutput,
         if (m_pRateControl) {
             m_pRateControl->notifyWrapAround(loopTriggerPosition, targetPosition);
         }
-        // TODO probably also useful for hotcue_X_indicator in CueControl::updateIndicators()
+        if (m_pCueControl) {
+            m_pCueControl->notifyWrapAround(loopTriggerPosition, targetPosition);
+        }
 
         // Jump to other end of loop or track.
         m_currentPosition = target;
@@ -191,6 +196,10 @@ SINT ReadAheadManager::getNextSamples(double dRate, CSAMPLE* pOutput,
 
     // qDebug() << "read" << m_currentPosition << samples_from_reader;
     return samples_from_reader;
+}
+
+void ReadAheadManager::addCueControl(CueControl* pCueControl) {
+    m_pCueControl = pCueControl;
 }
 
 void ReadAheadManager::addRateControl(RateControl* pRateControl) {

--- a/src/engine/readaheadmanager.h
+++ b/src/engine/readaheadmanager.h
@@ -8,6 +8,7 @@
 #include "util/math.h"
 #include "util/types.h"
 
+class CueControl;
 class LoopingControl;
 class RateControl;
 
@@ -36,7 +37,7 @@ class ReadAheadManager {
 
     /// Used to add a new EngineControls that ReadAheadManager will use to decide
     /// which samples to return.
-    void addLoopingControl();
+    void addCueControl(CueControl* pCueControl);
     void addRateControl(RateControl* pRateControl);
 
     /// Get the current read-ahead position in samples.
@@ -117,6 +118,7 @@ class ReadAheadManager {
     void addReadLogEntry(double virtualPlaypositionStart,
                          double virtualPlaypositionEndNonInclusive);
 
+    CueControl* m_pCueControl;
     LoopingControl* m_pLoopingControl;
     RateControl* m_pRateControl;
     std::list<ReadLogEntry> m_readAheadLog;


### PR DESCRIPTION
alternative to #12951, see https://github.com/mixxxdj/mixxx/pull/12951#issuecomment-2045022685

Just a little helper that allows having callbacks for when the playposition crosses a hotcue / loopcue.
For example:
* always trigger the fog machine on hotcue5 via MIDI_4_Lights
* auto-censor certain spots in _all_ tracks by making hotcue17 trigger a certain sample / engage revere-roll for 1 sec
* flash controller hotcue buttons if deck is stopped at a hotcue
* ...

### Description
Basically, it's something like `beat_active` and `cue_indicator`: it is activated (1.0) if
* the play position is on the hotcue
(when stopped or when the buffer's new position is coincidentally at the hotcue position)
* the play position crossed the hotcue since the last update
(while playing forward or backward and while scratching, **not** when seeking over a hotcue)

_`beat_active` is 1.0 if the playposition is in a certain **range** around a beat marker_
_`cue_indicator`_ is 1.0 (maybe flashing) if the play position is **exactly** at the Cue (unlikely when playing)_



### Improvements?
Integrating it into `hotcue_X_status` would allow GUI feedback via WHotcueButton, it'd be just two more states that could be styled rather easily. #9760 
For now this is separate because integration/extension seems a bit cumbersome.

### Nice to have
- [ ] tests that covers looping (hotcue slight before and at loop_out, slightly after loop_in)

### Proposal for testing
* load this mapping to the MIDI Through controller https://gist.github.com/ronso0/2dd322622ddac2590020ce9b2af5d695
* load a track to deck1, set hotcues 1-2-3 with a distance of ~10s
* load a track to deck2
* both decks stoped
* Test1:
   * play from start
   * jump to hotcue 1
   * jump to hotcue 3
   * == deck2 should **not** start
* Test2:
   * play from start
   * jump to hotcue 1
   * jump to hotcue 2
   * == deck2 should start
* Test1:
   * stopped
   * jump to hotcue 3
   * scratch backwards over hotcue 2
   * == deck2 should start