### PR TITLE
FindRubberband: Make sure sleefdft is present before linking it

### DIFF
--- a/cmake/modules/FindSleef.cmake
+++ b/cmake/modules/FindSleef.cmake
@@ -63,7 +63,7 @@ mark_as_advanced(Sleef_LIBRARY)
 
 foreach(_component ${Sleef_FIND_COMPONENTS})
   find_library(Sleef_${_component}_LIBRARY
-    NAMES ${_component}
+    NAMES sleef${_component}
     PATHS ${PC_Sleef_LIBRARY_DIRS})
   mark_as_advanced(Sleef_${_component}_LIBRARY)
   set(ADDITIONAL_REQUIRED_VARS ${ADDITIONAL_REQUIRED_VARS} Sleef_${_component}_LIBRARY)
@@ -125,16 +125,16 @@ if(Sleef_FOUND)
   set(Sleef_INCLUDE_DIRS "${Sleef_INCLUDE_DIR}")
   set(Sleef_DEFINITIONS ${PC_Sleef_CFLAGS_OTHER})
 
-  if(Sleef_sleefdft_FOUND)
-    is_static_library(Sleef_sleefdft_IS_STATIC Sleef::sleefdft)
-    if(Sleef_sleefdft_IS_STATIC)
-      set_property(TARGET Sleef::sleefdft APPEND PROPERTY INTERFACE_LINK_LIBRARIES
+  if(Sleef_dft_FOUND)
+    is_static_library(Sleef_dft_IS_STATIC Sleef::dft)
+    if(Sleef_dft_IS_STATIC)
+      set_property(TARGET Sleef::dft APPEND PROPERTY INTERFACE_LINK_LIBRARIES
         Sleef::sleef
       )
 
       find_package(OpenMP)
       if(OpenMP_CXX_FOUND)
-        set_property(TARGET Sleef::sleefdft APPEND PROPERTY INTERFACE_LINK_LIBRARIES
+        set_property(TARGET Sleef::dft APPEND PROPERTY INTERFACE_LINK_LIBRARIES
           OpenMP::OpenMP_CXX
         )
       endif()

--- a/cmake/modules/FindSleef.cmake
+++ b/cmake/modules/FindSleef.cmake
@@ -61,10 +61,28 @@ find_library(Sleef_LIBRARY
   PATHS ${PC_Sleef_LIBRARY_DIRS})
 mark_as_advanced(Sleef_LIBRARY)
 
-find_library(SleefDFT_LIBRARY
-  NAMES sleefdft
-  PATHS ${PC_Sleef_LIBRARY_DIRS})
-mark_as_advanced(SleefDFT_LIBRARY)
+foreach(_component ${Sleef_FIND_COMPONENTS})
+  find_library(Sleef_${_component}_LIBRARY
+    NAMES ${_component}
+    PATHS ${PC_Sleef_LIBRARY_DIRS})
+  mark_as_advanced(Sleef_${_component}_LIBRARY)
+  set(ADDITIONAL_REQUIRED_VARS ${ADDITIONAL_REQUIRED_VARS} Sleef_${_component}_LIBRARY)
+
+  if(Sleef_${_component}_LIBRARY)
+    set(Sleef_${_component}_FOUND TRUE)
+    if(NOT TARGET Sleef::${_component})
+      add_library(Sleef::${_component} UNKNOWN IMPORTED)
+      set_target_properties(Sleef::${_component}
+        PROPERTIES
+          IMPORTED_LOCATION "${Sleef_${_component}_LIBRARY}"
+          INTERFACE_COMPILE_OPTIONS "${PC_Sleef_CFLAGS_OTHER}"
+          INTERFACE_INCLUDE_DIRECTORIES "${Sleef_INCLUDE_DIR}"
+      )
+    endif()
+  else()
+    set(Sleef_${_component}_FOUND FALSE)
+  endif()
+endforeach()
 
 if(DEFINED PC_Sleef_VERSION AND NOT PC_Sleef_VERSION STREQUAL "")
   set(Sleef_VERSION "${PC_Sleef_VERSION}")
@@ -99,7 +117,7 @@ endif()
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
   Sleef
-  REQUIRED_VARS Sleef_INCLUDE_DIR Sleef_LIBRARY
+  REQUIRED_VARS Sleef_INCLUDE_DIR Sleef_LIBRARY ${ADDITIONAL_REQUIRED_VARS}
   VERSION_VAR Sleef_VERSION)
 
 if(Sleef_FOUND)
@@ -107,17 +125,9 @@ if(Sleef_FOUND)
   set(Sleef_INCLUDE_DIRS "${Sleef_INCLUDE_DIR}")
   set(Sleef_DEFINITIONS ${PC_Sleef_CFLAGS_OTHER})
 
-  if(SleefDFT_LIBRARY AND NOT TARGET Sleef::sleefdft)
-    add_library(Sleef::sleefdft UNKNOWN IMPORTED)
-    set_target_properties(Sleef::sleefdft
-      PROPERTIES
-        IMPORTED_LOCATION "${SleefDFT_LIBRARY}"
-        INTERFACE_COMPILE_OPTIONS "${PC_Sleef_CFLAGS_OTHER}"
-        INTERFACE_INCLUDE_DIRECTORIES "${Sleef_INCLUDE_DIR}"
-    )
-
-    is_static_library(SleefDFT_IS_STATIC Sleef::sleefdft)
-    if(SleefDFT_IS_STATIC)
+  if(Sleef_sleefdft_FOUND)
+    is_static_library(Sleef_sleefdft_IS_STATIC Sleef::sleefdft)
+    if(Sleef_sleefdft_IS_STATIC)
       set_property(TARGET Sleef::sleefdft APPEND PROPERTY INTERFACE_LINK_LIBRARIES
         Sleef::sleef
       )
@@ -139,9 +149,5 @@ if(Sleef_FOUND)
         INTERFACE_COMPILE_OPTIONS "${PC_Sleef_CFLAGS_OTHER}"
         INTERFACE_INCLUDE_DIRECTORIES "${Sleef_INCLUDE_DIR}"
     )
-  endif()
-
-  if(NOT TARGET Sleef::sleefdft)
-    message(WARNING "Sleef found at ${Sleef_LIBRARY} does not have sleefdft, this means static builds will not link it with Rubberband! Perhaps you meant to use some other version of Sleef?")
   endif()
 endif()

--- a/cmake/modules/FindSleef.cmake
+++ b/cmake/modules/FindSleef.cmake
@@ -140,4 +140,8 @@ if(Sleef_FOUND)
         INTERFACE_INCLUDE_DIRECTORIES "${Sleef_INCLUDE_DIR}"
     )
   endif()
+
+  if(NOT TARGET Sleef::sleefdft)
+    message(WARNING "Sleef found at ${Sleef_LIBRARY} does not have sleefdft, this means static builds will not link it with Rubberband! Perhaps you meant to use some other version of Sleef?")
+  endif()
 endif()

--- a/cmake/modules/Findrubberband.cmake
+++ b/cmake/modules/Findrubberband.cmake
@@ -97,11 +97,11 @@ if(rubberband_FOUND)
           FFTW::FFTW
         )
       endif()
-      find_package(Sleef COMPONENTS sleefdft)
+      find_package(Sleef COMPONENTS dft)
       if (Sleef_FOUND)
         set_property(TARGET rubberband::rubberband APPEND PROPERTY INTERFACE_LINK_LIBRARIES
           Sleef::sleef
-          Sleef::sleefdft
+          Sleef::dft
         )
       endif()
     endif()

--- a/cmake/modules/Findrubberband.cmake
+++ b/cmake/modules/Findrubberband.cmake
@@ -97,8 +97,8 @@ if(rubberband_FOUND)
           FFTW::FFTW
         )
       endif()
-      find_package(Sleef)
-      if (Sleef_FOUND AND TARGET Sleef::sleefdft)
+      find_package(Sleef COMPONENTS sleefdft)
+      if (Sleef_FOUND)
         set_property(TARGET rubberband::rubberband APPEND PROPERTY INTERFACE_LINK_LIBRARIES
           Sleef::sleef
           Sleef::sleefdft

--- a/cmake/modules/Findrubberband.cmake
+++ b/cmake/modules/Findrubberband.cmake
@@ -98,7 +98,7 @@ if(rubberband_FOUND)
         )
       endif()
       find_package(Sleef)
-      if (Sleef_FOUND)
+      if (Sleef_FOUND AND TARGET Sleef::sleefdft)
         set_property(TARGET rubberband::rubberband APPEND PROPERTY INTERFACE_LINK_LIBRARIES
           Sleef::sleef
           Sleef::sleefdft


### PR DESCRIPTION
I have encountered configuration errors when Sleef was built without SleefDFT (`FindSleef.cmake` seems to handle this correctly). To avoid this, this PR makes sure to only link Sleef if the DFT library is present.

In my case this happened because Homebrew Sleef (which apparently is not built with DFT) slipped into the build. While this is not ideal, we should at least make sure that we build against a working version of Sleef.