### PR TITLE
macOS buildenv: Use arm64 buildenv on arm64 Macs by default

### DIFF
--- a/tools/macos_buildenv.sh
+++ b/tools/macos_buildenv.sh
@@ -19,7 +19,7 @@ realpath() {
 THIS_SCRIPT_NAME=${BASH_SOURCE[0]}
 [ -z "$THIS_SCRIPT_NAME" ] && THIS_SCRIPT_NAME=$0
 
-if [ -n "${BUILDENV_ARM64}" ]; then
+if [ -n "${BUILDENV_ARM64}" ] || [ "$(uname -m)" = "arm64" ]; then
     if [ -n "${BUILDENV_RELEASE}" ]; then
         VCPKG_TARGET_TRIPLET="arm64-osx-min1100-release"
         BUILDENV_BRANCH="2.4-rel"


### PR DESCRIPTION
Currently, users trying to use the `macos_buildenv.sh` script on Apple Silicon Macs will download an x64 environment by default, which will result in a bunch of obscure linker errors as the compiler tries to link the arm64 Mixxx objects with the x64 dependencies.

Since building with the cross-built arm64 environment seems to work even when building natively on an Apple Silicon Mac, we should just enable it by default. This should reduce confusion and there have been reports of other users succeeding with this configuration. Some more testing by other contributors on macOS would be welcome, however.

Note that the x64 buildenv can and will still be used when running the script in a Rosetta shell (e.g. `arch -x86_64 zsh`).