### PR TITLE
Keyboard: automatically reload mapping file and update tooltips + menubar accelerators

### DIFF
--- a/src/control/controlpotmeter.cpp
+++ b/src/control/controlpotmeter.cpp
@@ -67,8 +67,10 @@ void ControlPotmeter::privateValueChanged(double dValue, QObject* pSender) {
 
 PotmeterControls::PotmeterControls(const ConfigKey& key)
         : m_control(key, this),
-          // When adding an additional control here, do not forget to also add
-          // it to the `PotmeterControls::addAlias()` method, too.
+          // When adding an additional control here, remember to also add
+          // it to the PotmeterControls::addAlias() method.
+          // Also remember to add it to LegacySkinParser::setupConnections()
+          // for constructing the keyboard shortcut tooltip strings.
           m_controlUp(configKeyFromBaseKey(key, QStringLiteral("_up"))),
           m_controlDown(configKeyFromBaseKey(key, QStringLiteral("_down"))),
           m_controlUpSmall(configKeyFromBaseKey(key, QStringLiteral("_up_small"))),

--- a/src/controllers/keyboard/keyboardeventfilter.cpp
+++ b/src/controllers/keyboard/keyboardeventfilter.cpp
@@ -110,7 +110,7 @@ bool KeyboardEventFilter::eventFilter(QObject*, QEvent* e) {
 
         //qDebug() << "KeyRelease event =" << ke->key() << "AutoRepeat =" << autoRepeat << "KeyId =" << keyId;
 
-        int clearModifiers = 0;
+        Qt::KeyboardModifiers clearModifiers = Qt::NoModifier;
 #ifdef __APPLE__
         // OS X apparently doesn't deliver KeyRelease events when you are
         // holding Ctrl. So release all key-presses that were triggered with
@@ -126,7 +126,8 @@ bool KeyboardEventFilter::eventFilter(QObject*, QEvent* e) {
             const KeyDownInformation& keyDownInfo = m_qActiveKeyList[i];
             ControlObject* pControl = keyDownInfo.pControl;
             if (keyDownInfo.keyId == keyId ||
-                    (clearModifiers > 0 && keyDownInfo.modifiers == clearModifiers)) {
+                    (clearModifiers != Qt::NoModifier &&
+                            keyDownInfo.modifiers == clearModifiers)) {
                 if (!autoRepeat) {
                     //qDebug() << pControl->getKey() << "MidiOpCode::NoteOff" << 0;
                     pControl->setValueFromMidi(MidiOpCode::NoteOff, 0);

--- a/src/controllers/keyboard/keyboardeventfilter.cpp
+++ b/src/controllers/keyboard/keyboardeventfilter.cpp
@@ -7,6 +7,12 @@
 #include "moc_keyboardeventfilter.cpp"
 #include "util/cmdlineargs.h"
 
+namespace {
+const QString mappingFilePath(const QString& dir, const QString& fileName) {
+    return QDir(dir).filePath(fileName + QStringLiteral(".kbd.cfg"));
+}
+} // anonymous namespace
+
 KeyboardEventFilter::KeyboardEventFilter(UserSettingsPointer pConfig,
         const QLocale& locale,
         QObject* pParent)
@@ -222,24 +228,22 @@ void KeyboardEventFilter::setEnabled(bool enabled) {
 void KeyboardEventFilter::createKeyboardConfig() {
     // Read keyboard configuration and set kdbConfig object in WWidget
     // Check first in user's Mixxx directory
-    QString keyboardFile = QDir(m_pConfig->getSettingsPath()).filePath("Custom.kbd.cfg");
+    QString keyboardFile = mappingFilePath(m_pConfig->getSettingsPath(), QStringLiteral("Custom"));
     if (QFile::exists(keyboardFile)) {
         qDebug() << "Found and will use custom keyboard mapping" << keyboardFile;
     } else {
         // check if a default keyboard exists
-        QString resourcePath = m_pConfig->getResourcePath();
-        keyboardFile = QString(resourcePath).append("keyboard/");
-        keyboardFile += m_locale.name();
-        keyboardFile += ".kbd.cfg";
-        if (!QFile::exists(keyboardFile)) {
-            qDebug() << keyboardFile << " not found, using en_US.kbd.cfg";
-            keyboardFile = QString(resourcePath).append("keyboard/").append("en_US.kbd.cfg");
+        const QString resourcePath = m_pConfig->getResourcePath() + QStringLiteral("keyboard/");
+        keyboardFile = mappingFilePath(resourcePath, m_locale.name());
+        if (QFile::exists(keyboardFile)) {
+            qDebug() << "Found and will use default keyboard mapping" << keyboardFile;
+        } else {
+            qDebug() << keyboardFile << " not found, try to use en_US.kbd.cfg";
+            keyboardFile = mappingFilePath(resourcePath, QStringLiteral("en_US"));
             if (!QFile::exists(keyboardFile)) {
                 qDebug() << keyboardFile << " not found, starting without shortcuts";
                 keyboardFile = "";
             }
-        } else {
-            qDebug() << "Found and will use default keyboard mapping" << keyboardFile;
         }
     }
 

--- a/src/controllers/keyboard/keyboardeventfilter.cpp
+++ b/src/controllers/keyboard/keyboardeventfilter.cpp
@@ -6,6 +6,7 @@
 #include <QtDebug>
 
 #include "moc_keyboardeventfilter.cpp"
+#include "preferences/constants.h"
 #include "util/cmdlineargs.h"
 #include "util/logger.h"
 #include "widget/wbasewidget.h"
@@ -59,6 +60,13 @@ KeyboardEventFilter::KeyboardEventFilter(UserSettingsPointer pConfig,
     m_enabled = m_pConfig->getValue(ConfigKey(QStringLiteral("[Keyboard]"),
                                             QStringLiteral("Enabled")),
             true);
+
+    mixxx::preferences::Tooltips cfgOnlyKbdShortcts =
+            pConfig->getValue(
+                    ConfigKey("[Controls]", "Tooltips"),
+                    mixxx::preferences::Tooltips::OnlyKbdShortcuts);
+    m_showOnlyKeyboardShortcuts =
+            cfgOnlyKbdShortcts == mixxx::preferences::Tooltips::OnlyKbdShortcuts;
 
     createKeyboardConfig();
 
@@ -266,6 +274,14 @@ void KeyboardEventFilter::setEnabled(bool enabled) {
     emit shortcutsEnabled(enabled);
 }
 
+void KeyboardEventFilter::setShowOnlyKbdShortcuts(bool enabled) {
+    if (m_showOnlyKeyboardShortcuts == enabled) {
+        return;
+    }
+    m_showOnlyKeyboardShortcuts = enabled;
+    emit showOnlyKbdShortcuts(enabled);
+}
+
 void KeyboardEventFilter::registerShortcutWidget(WBaseWidget* pWidget) {
     m_widgets.append(pWidget);
 
@@ -276,6 +292,19 @@ void KeyboardEventFilter::registerShortcutWidget(WBaseWidget* pWidget) {
             this,
             [pWidget](bool enabled) {
                 pWidget->toggleKeyboardShortcutHints(enabled);
+            });
+
+    connectShowOnlyKbdShortcuts(pWidget);
+}
+
+void KeyboardEventFilter::connectShowOnlyKbdShortcuts(WBaseWidget* pWidget) {
+    // If toggled in Preferences -> Interface, we tell the widgets to show
+    // only the keyboard shortcuts tooltip.
+    connect(this,
+            &KeyboardEventFilter::showOnlyKbdShortcuts,
+            this,
+            [pWidget](bool enabled) {
+                pWidget->toggleShowOnlyKeyboardShortcuts(enabled);
             });
 }
 
@@ -297,7 +326,10 @@ void KeyboardEventFilter::updateWidgetShortcuts() {
         pWidget->setShortcutTooltip(shortcutHints.join(QStringLiteral("\n")));
     }
     // Update widget tooltips (WBaseWidget handles no-ops).
+    // TODO make this two set() functions and one update() function to avoid the
+    // double update.
     emit shortcutsEnabled(m_enabled);
+    emit showOnlyKbdShortcuts(m_showOnlyKeyboardShortcuts);
 }
 
 void KeyboardEventFilter::clearWidgets() {

--- a/src/controllers/keyboard/keyboardeventfilter.cpp
+++ b/src/controllers/keyboard/keyboardeventfilter.cpp
@@ -7,6 +7,7 @@
 
 #include "moc_keyboardeventfilter.cpp"
 #include "util/cmdlineargs.h"
+#include "util/logger.h"
 #include "widget/wbasewidget.h"
 #include "widget/wsearchlineedit.h"
 
@@ -37,6 +38,8 @@ QKeySequence safeKeySequence(const QString& str) {
     }
     return ks;
 }
+
+mixxx::Logger kLogger("KeyboardEventFilter");
 } // anonymous namespace
 
 KeyboardEventFilter::KeyboardEventFilter(UserSettingsPointer pConfig,
@@ -115,7 +118,6 @@ bool KeyboardEventFilter::eventFilter(QObject*, QEvent* e) {
 
                 ControlObject* pControl = ControlObject::getControl(configKey);
                 if (pControl) {
-                    // qDebug() << configKey << "MidiOpCode::NoteOn" << 1;
                     // Add key to active key list
                     m_qActiveKeyList.append(KeyDownInformation(
                             keyId, pKE->modifiers(), pControl));
@@ -125,9 +127,9 @@ bool KeyboardEventFilter::eventFilter(QObject*, QEvent* e) {
                     pControl->setValueFromMidi(MidiOpCode::NoteOn, 1);
                     result = true;
                 } else {
-                    qWarning() << "Key" << keyId
-                               << "is configured for nonexistent control:"
-                               << configKey.group << configKey.item;
+                    kLogger.warning() << "Key" << keyId
+                                      << "is configured for nonexistent control:"
+                                      << configKey.group << configKey.item;
                 }
             }
             return result;
@@ -164,8 +166,6 @@ bool KeyboardEventFilter::eventFilter(QObject*, QEvent* e) {
         int keyId = pKE->nativeScanCode();
 #endif
 
-        //qDebug() << "KeyRelease event =" << ke->key() << "AutoRepeat =" << autoRepeat << "KeyId =" << keyId;
-
         Qt::KeyboardModifiers clearModifiers = Qt::NoModifier;
 #ifdef __APPLE__
         // OS X apparently doesn't deliver KeyRelease events when you are
@@ -187,7 +187,6 @@ bool KeyboardEventFilter::eventFilter(QObject*, QEvent* e) {
                     (clearModifiers != Qt::NoModifier &&
                             keyDownInfo.modifiers == clearModifiers)) {
                 if (!autoRepeat) {
-                    //qDebug() << pControl->getKey() << "MidiOpCode::NoteOff" << 0;
                     pControl->setValueFromMidi(MidiOpCode::NoteOff, 0);
                     m_qActiveKeyList.removeAt(i);
                 }
@@ -201,7 +200,7 @@ bool KeyboardEventFilter::eventFilter(QObject*, QEvent* e) {
         // This event is not fired on ubunty natty, why?
         // TODO: find a way to support KeyboardLayoutChange
         // https://github.com/mixxxdj/mixxx/issues/6424
-        //qDebug() << "QEvent::KeyboardLayoutChange";
+        // kLogger.debug() << "QEvent::KeyboardLayoutChange";
     }
     return false;
 }
@@ -239,9 +238,9 @@ QKeySequence KeyboardEventFilter::getKeySeq(QKeyEvent* e) {
 
     if (CmdlineArgs::Instance().getDeveloper()) {
         if (e->type() == QEvent::KeyPress) {
-            qDebug() << "keyboard press: " << k.toString();
+            kLogger.debug() << "keyboard press: " << k.toString();
         } else if (e->type() == QEvent::KeyRelease) {
-            qDebug() << "keyboard release: " << k.toString();
+            kLogger.debug() << "keyboard release: " << k.toString();
         }
     }
 
@@ -250,9 +249,9 @@ QKeySequence KeyboardEventFilter::getKeySeq(QKeyEvent* e) {
 
 void KeyboardEventFilter::setEnabled(bool enabled) {
     if (enabled) {
-        qDebug() << "Enable keyboard shortcuts/mappings";
+        kLogger.debug() << "Enable keyboard shortcuts/mappings";
     } else {
-        qDebug() << "Disable keyboard shortcuts/mappings";
+        kLogger.debug() << "Disable keyboard shortcuts/mappings";
     }
     m_enabled = enabled;
     m_pConfig->setValue(ConfigKey("[Keyboard]", "Enabled"), enabled);
@@ -281,7 +280,7 @@ void KeyboardEventFilter::registerShortcutWidget(WBaseWidget* pWidget) {
 }
 
 void KeyboardEventFilter::updateWidgetShortcuts() {
-    qDebug() << "Update widget shortcuts";
+    kLogger.debug() << "update widget shortcuts";
     QStringList shortcutHints;
     for (auto* pWidget : std::as_const(m_widgets)) {
         QString keyString;
@@ -360,6 +359,8 @@ void KeyboardEventFilter::registerMenuBarActionSetShortcut(QAction* pAction,
         return;
     }
     VERIFY_OR_DEBUG_ASSERT(cfgKey.isValid()) {
+        kLogger.warning() << "registerMenuBarActionSetShortcut: ConfigKey invalid"
+                          << cfgKey.group << cfgKey.item << "- Ignoring";
         return;
     }
     // TODO Allow clearing the shortcut so it can be used for something else ??
@@ -374,11 +375,13 @@ void KeyboardEventFilter::clearMenuBarActions() {
 }
 
 void KeyboardEventFilter::updateMenuBarActionShortcuts() {
+    kLogger.debug() << "updateMenuBarActionShortcuts";
     QHashIterator<QAction*, std::pair<ConfigKey, QString>> it(m_menuBarActions);
     while (it.hasNext()) {
         it.next();
         auto* pAction = it.key();
         VERIFY_OR_DEBUG_ASSERT(pAction) {
+            kLogger.warning() << "Could not find a valid action for" << it.value() << "- Ignoring";
             continue;
         }
         const QString keyStr = m_pKbdConfig->getValue(it.value().first, it.value().second);
@@ -388,6 +391,7 @@ void KeyboardEventFilter::updateMenuBarActionShortcuts() {
 }
 
 void KeyboardEventFilter::reloadKeyboardConfig() {
+    kLogger.debug() << "reloadKeyboardConfig, enabled:" << m_enabled;
     createKeyboardConfig();
     updateWidgetShortcuts();
     updateSearchBarShortcuts();
@@ -395,6 +399,7 @@ void KeyboardEventFilter::reloadKeyboardConfig() {
 }
 
 void KeyboardEventFilter::createKeyboardConfig() {
+    kLogger.debug() << "createKeyboardConfig";
     // Remove the previously watched file.
     // Could be the user mapping has been removed and we'll need to switch
     // to the built-in default mapping.
@@ -403,7 +408,7 @@ void KeyboardEventFilter::createKeyboardConfig() {
     // Check first in user's Mixxx directory
     QString keyboardFile = mappingFilePath(m_pConfig->getSettingsPath(), QStringLiteral("Custom"));
     if (QFile::exists(keyboardFile)) {
-        qDebug() << "Found and will use custom keyboard mapping" << keyboardFile;
+        kLogger.debug() << "Found and will use custom keyboard mapping" << keyboardFile;
     } else {
         // check if a default keyboard exists
         const QString resourcePath = m_pConfig->getResourcePath();
@@ -411,12 +416,12 @@ void KeyboardEventFilter::createKeyboardConfig() {
         keyboardFile += m_locale.name();
         keyboardFile += ".kbd.cfg";
         if (QFile::exists(keyboardFile)) {
-            qDebug() << "Found and will use default keyboard mapping" << keyboardFile;
+            kLogger.debug() << "Found and will use default keyboard mapping" << keyboardFile;
         } else {
-            qDebug() << keyboardFile << " not found, try to use en_US.kbd.cfg";
+            kLogger.debug() << keyboardFile << " not found, using en_US.kbd.cfg";
             keyboardFile = mappingFilePath(resourcePath, QStringLiteral("en_US"));
             if (!QFile::exists(keyboardFile)) {
-                qDebug() << keyboardFile << " not found, starting without shortcuts";
+                kLogger.debug() << keyboardFile << " not found, starting without shortcuts";
                 keyboardFile = "";
             }
         }

--- a/src/controllers/keyboard/keyboardeventfilter.cpp
+++ b/src/controllers/keyboard/keyboardeventfilter.cpp
@@ -1,5 +1,6 @@
 #include "controllers/keyboard/keyboardeventfilter.h"
 
+#include <QAction>
 #include <QEvent>
 #include <QKeyEvent>
 #include <QtDebug>
@@ -12,6 +13,29 @@
 namespace {
 const QString mappingFilePath(const QString& dir, const QString& fileName) {
     return QDir(dir).filePath(fileName + QStringLiteral(".kbd.cfg"));
+}
+
+// Returns a QKeySequence from str, or an empty QKeySequence if str contains an
+// invalid key name. Prevents a macOS crash where QCocoaMenuItem::sync() cannot
+// convert Qt::Key_unknown (> 0xFFFF) to QChar. See
+// https://github.com/mixxxdj/mixxx/issues/16216
+QKeySequence safeKeySequence(const QString& str) {
+    if (str.isEmpty()) {
+        return {};
+    }
+    const QKeySequence ks(str);
+    for (int i = 0; i < ks.count(); ++i) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        const Qt::Key key = ks[i].key();
+#else
+        const int key = ks[i] & ~Qt::KeyboardModifierMask;
+#endif
+        if (key == Qt::Key_unknown) {
+            qWarning() << "Ignoring invalid keyboard shortcut:" << str;
+            return {};
+        }
+    }
+    return ks;
 }
 } // anonymous namespace
 
@@ -329,10 +353,45 @@ QString KeyboardEventFilter::buildShortcutString(
     return shortcutTooltip;
 }
 
+void KeyboardEventFilter::registerMenuBarActionSetShortcut(QAction* pAction,
+        const ConfigKey& cfgKey,
+        const QString& defaultShortcut) {
+    VERIFY_OR_DEBUG_ASSERT(pAction) {
+        return;
+    }
+    VERIFY_OR_DEBUG_ASSERT(cfgKey.isValid()) {
+        return;
+    }
+    // TODO Allow clearing the shortcut so it can be used for something else ??
+    m_menuBarActions.emplace(pAction, std::make_pair(cfgKey, defaultShortcut));
+    const QKeySequence ks = safeKeySequence(m_pKbdConfig->getValue(cfgKey, defaultShortcut));
+    pAction->setShortcut(ks);
+    pAction->setShortcutContext(Qt::ApplicationShortcut);
+}
+
+void KeyboardEventFilter::clearMenuBarActions() {
+    m_menuBarActions.clear();
+}
+
+void KeyboardEventFilter::updateMenuBarActionShortcuts() {
+    QHashIterator<QAction*, std::pair<ConfigKey, QString>> it(m_menuBarActions);
+    while (it.hasNext()) {
+        it.next();
+        auto* pAction = it.key();
+        VERIFY_OR_DEBUG_ASSERT(pAction) {
+            continue;
+        }
+        const QString keyStr = m_pKbdConfig->getValue(it.value().first, it.value().second);
+        const QKeySequence ks = safeKeySequence(keyStr);
+        pAction->setShortcut(ks);
+    }
+}
+
 void KeyboardEventFilter::reloadKeyboardConfig() {
     createKeyboardConfig();
     updateWidgetShortcuts();
     updateSearchBarShortcuts();
+    updateMenuBarActionShortcuts();
 }
 
 void KeyboardEventFilter::createKeyboardConfig() {

--- a/src/controllers/keyboard/keyboardeventfilter.cpp
+++ b/src/controllers/keyboard/keyboardeventfilter.cpp
@@ -392,11 +392,12 @@ void KeyboardEventFilter::registerMenuBarActionSetShortcut(QAction* pAction,
     }
     VERIFY_OR_DEBUG_ASSERT(cfgKey.isValid()) {
         kLogger.warning() << "registerMenuBarActionSetShortcut: ConfigKey invalid"
-                          << cfgKey.group << cfgKey.item << "- Ignoring";
+                          << cfgKey << "- Ignoring";
         return;
     }
     // TODO Allow clearing the shortcut so it can be used for something else ??
-    m_menuBarActions.emplace(pAction, std::make_pair(cfgKey, defaultShortcut));
+    CfgkeyAndShortcut cfgKeyShortcut(cfgKey, defaultShortcut);
+    m_menuBarActions.emplace(pAction, cfgKeyShortcut);
     const QKeySequence ks = safeKeySequence(m_pKbdConfig->getValue(cfgKey, defaultShortcut));
     pAction->setShortcut(ks);
     pAction->setShortcutContext(Qt::ApplicationShortcut);
@@ -408,15 +409,18 @@ void KeyboardEventFilter::clearMenuBarActions() {
 
 void KeyboardEventFilter::updateMenuBarActionShortcuts() {
     kLogger.debug() << "updateMenuBarActionShortcuts";
-    QHashIterator<QAction*, std::pair<ConfigKey, QString>> it(m_menuBarActions);
+    QHashIterator<QAction*, CfgkeyAndShortcut> it(m_menuBarActions);
     while (it.hasNext()) {
         it.next();
         auto* pAction = it.key();
+        CfgkeyAndShortcut cfgKeyShortcut(it.value());
         VERIFY_OR_DEBUG_ASSERT(pAction) {
-            kLogger.warning() << "Could not find a valid action for" << it.value() << "- Ignoring";
+            kLogger.warning() << "Could not find a menubar action for"
+                              << cfgKeyShortcut.cfgKey << "- Ignoring";
             continue;
         }
-        const QString keyStr = m_pKbdConfig->getValue(it.value().first, it.value().second);
+        const QString keyStr = m_pKbdConfig->getValue(
+                cfgKeyShortcut.cfgKey, cfgKeyShortcut.defaultShortcut);
         const QKeySequence ks = safeKeySequence(keyStr);
         pAction->setShortcut(ks);
     }
@@ -450,10 +454,10 @@ void KeyboardEventFilter::createKeyboardConfig() {
         if (QFile::exists(keyboardFile)) {
             kLogger.debug() << "Found and will use default keyboard mapping" << keyboardFile;
         } else {
-            kLogger.debug() << keyboardFile << " not found, using en_US.kbd.cfg";
+            kLogger.debug() << keyboardFile << " not found, trying en_US.kbd.cfg";
             keyboardFile = mappingFilePath(resourcePath, QStringLiteral("en_US"));
             if (!QFile::exists(keyboardFile)) {
-                kLogger.debug() << keyboardFile << " not found, starting without shortcuts";
+                kLogger.warning() << keyboardFile << " not found, starting without shortcuts";
                 keyboardFile = "";
             }
         }

--- a/src/controllers/keyboard/keyboardeventfilter.h
+++ b/src/controllers/keyboard/keyboardeventfilter.h
@@ -46,6 +46,13 @@ class KeyboardEventFilter : public QObject {
     void registerSearchBar(WSearchLineEdit* pSearchBar);
     void updateSearchBarShortcuts();
 
+    void registerMenuBarActionSetShortcut(
+            QAction* pAction,
+            const ConfigKey& command,
+            const QString& defaultShortcut);
+    void clearMenuBarActions();
+    void updateMenuBarActionShortcuts();
+
   public slots:
     void reloadKeyboardConfig();
 
@@ -98,6 +105,10 @@ class KeyboardEventFilter : public QObject {
     bool m_enabled;
 
     AutoFileReloader m_autoReloader;
+
+    // Actions in the menu bar
+    // Value pair is the ConfigKey and the default QKeySequence (as QString).
+    QHash<QAction*, std::pair<ConfigKey, QString>> m_menuBarActions;
 
     // Widgets that have mappable connections, registered by LegacySkinParser
     // during skin construction.

--- a/src/controllers/keyboard/keyboardeventfilter.h
+++ b/src/controllers/keyboard/keyboardeventfilter.h
@@ -33,7 +33,6 @@ class KeyboardEventFilter : public QObject {
     // Returns a valid QString with modifier keys from a QKeyEvent
     static QKeySequence getKeySeq(QKeyEvent* e);
 
-    void setEnabled(bool enabled);
     bool isEnabled() {
         return m_enabled;
     }
@@ -54,6 +53,7 @@ class KeyboardEventFilter : public QObject {
     void updateMenuBarActionShortcuts();
 
   public slots:
+    void setEnabled(bool enabled);
     void reloadKeyboardConfig();
 
   signals:

--- a/src/controllers/keyboard/keyboardeventfilter.h
+++ b/src/controllers/keyboard/keyboardeventfilter.h
@@ -35,14 +35,14 @@ class KeyboardEventFilter : public QObject {
 
   private:
     struct KeyDownInformation {
-        KeyDownInformation(int keyId, int modifiers, ControlObject* pControl)
+        KeyDownInformation(int keyId, Qt::KeyboardModifiers modifiers, ControlObject* pControl)
                 : keyId(keyId),
                   modifiers(modifiers),
                   pControl(pControl) {
         }
 
         int keyId;
-        int modifiers;
+        Qt::KeyboardModifiers modifiers;
         ControlObject* pControl;
     };
 

--- a/src/controllers/keyboard/keyboardeventfilter.h
+++ b/src/controllers/keyboard/keyboardeventfilter.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QLocale>
 #include <QMultiHash>
 #include <QObject>
 
@@ -14,19 +15,24 @@ class QKeyEvent;
 class KeyboardEventFilter : public QObject {
     Q_OBJECT
   public:
-    KeyboardEventFilter(ConfigObject<ConfigValueKbd> *pKbdConfigObject,
-                        QObject *parent = nullptr, const char* name = nullptr);
+    KeyboardEventFilter(UserSettingsPointer pConfig,
+            const QLocale& locale,
+            QObject* pParent = nullptr);
     virtual ~KeyboardEventFilter();
 
     bool eventFilter(QObject* obj, QEvent* e);
 
-    // Set the keyboard config object. KeyboardEventFilter does NOT take
-    // ownership of pKbdConfigObject.
-    void setKeyboardConfig(ConfigObject<ConfigValueKbd> *pKbdConfigObject);
-    ConfigObject<ConfigValueKbd>* getKeyboardConfig();
+    std::shared_ptr<ConfigObject<ConfigValueKbd>> getKeyboardConfig() const {
+        return m_pKbdConfig;
+    };
 
     // Returns a valid QString with modifier keys from a QKeyEvent
     static QKeySequence getKeySeq(QKeyEvent* e);
+
+    void setEnabled(bool enabled);
+    bool isEnabled() {
+        return m_enabled;
+    }
 
 #ifndef __APPLE__
   signals:
@@ -60,10 +66,18 @@ class KeyboardEventFilter : public QObject {
                     return keyDownInfo.keyId == keyId && !keyDownInfo.pControl->getKbdRepeatable();
                 });
     }
+
+    void createKeyboardConfig();
+
     // List containing keys which is currently pressed
     QList<KeyDownInformation> m_qActiveKeyList;
+
+    UserSettingsPointer m_pConfig;
     // Pointer to keyboard config object
-    ConfigObject<ConfigValueKbd> *m_pKbdConfigObject;
+    std::shared_ptr<ConfigObject<ConfigValueKbd>> m_pKbdConfig;
+    QLocale m_locale;
+    bool m_enabled;
+
     // Multi-hash of key sequence to
     QMultiHash<ConfigValueKbd, ConfigKey> m_keySequenceToControlHash;
 };

--- a/src/controllers/keyboard/keyboardeventfilter.h
+++ b/src/controllers/keyboard/keyboardeventfilter.h
@@ -38,6 +38,7 @@ class KeyboardEventFilter : public QObject {
     }
 
     void registerShortcutWidget(WBaseWidget* pWidget);
+    void connectShowOnlyKbdShortcuts(WBaseWidget* pWidget);
     void updateWidgetShortcuts();
     void clearWidgets();
     QString buildShortcutString(const QString& shortcut, const QString& cmd) const;
@@ -54,6 +55,7 @@ class KeyboardEventFilter : public QObject {
 
   public slots:
     void setEnabled(bool enabled);
+    void setShowOnlyKbdShortcuts(bool enabled);
     void reloadKeyboardConfig();
 
   signals:
@@ -62,6 +64,7 @@ class KeyboardEventFilter : public QObject {
 #endif
     // We're only the relay here: CoreServices -> this -> WBaseWidget
     void shortcutsEnabled(bool enabled);
+    void showOnlyKbdShortcuts(bool enabled);
 
   private:
     struct KeyDownInformation {
@@ -103,6 +106,7 @@ class KeyboardEventFilter : public QObject {
     std::shared_ptr<ConfigObject<ConfigValueKbd>> m_pKbdConfig;
     QLocale m_locale;
     bool m_enabled;
+    bool m_showOnlyKeyboardShortcuts;
 
     AutoFileReloader m_autoReloader;
 

--- a/src/controllers/keyboard/keyboardeventfilter.h
+++ b/src/controllers/keyboard/keyboardeventfilter.h
@@ -30,6 +30,11 @@ class KeyboardEventFilter : public QObject {
         return m_pKbdConfig;
     };
 
+    struct CfgkeyAndShortcut {
+        ConfigKey cfgKey;
+        QString defaultShortcut;
+    };
+
     // Returns a valid QString with modifier keys from a QKeyEvent
     static QKeySequence getKeySeq(QKeyEvent* e);
 
@@ -110,9 +115,9 @@ class KeyboardEventFilter : public QObject {
 
     AutoFileReloader m_autoReloader;
 
-    // Actions in the menu bar
-    // Value pair is the ConfigKey and the default QKeySequence (as QString).
-    QHash<QAction*, std::pair<ConfigKey, QString>> m_menuBarActions;
+    // Actions in the menu bar with the associated ConfigKey and
+    // the default QKeySequence (as QString).
+    QHash<QAction*, CfgkeyAndShortcut> m_menuBarActions;
 
     // Widgets that have mappable connections, registered by LegacySkinParser
     // during skin construction.

--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -835,15 +835,6 @@ std::shared_ptr<ConfigObject<ConfigValueKbd>> CoreServices::getKeyboardConfig() 
     return m_pKeyboardEventFilter->getKeyboardConfig();
 }
 
-void CoreServices::slotOptionsKeyboard(bool toggle) {
-    if (toggle) {
-        qDebug() << "Enable keyboard shortcuts/mappings";
-    } else {
-        qDebug() << "Disable keyboard shortcuts/mappings";
-    }
-    m_pKeyboardEventFilter->setEnabled(toggle);
-}
-
 bool CoreServices::initializeDatabase() {
     kLogger.info() << "Connecting to database";
     QSqlDatabase dbConnection = mixxx::DbConnectionPooled(m_pDbConnectionPool);

--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -384,8 +384,6 @@ CoreServices::~CoreServices() {
 
     // Tear down remaining stuff that was initialized in the constructor.
     CLEAR_AND_CHECK_DELETED(m_pKeyboardEventFilter);
-    CLEAR_AND_CHECK_DELETED(m_pKbdConfig);
-    CLEAR_AND_CHECK_DELETED(m_pKbdConfigEmpty);
 
     if (m_cmdlineArgs.getDeveloper()) {
         StatsManager::destroy();
@@ -829,64 +827,21 @@ void CoreServices::initializeQMLSingletons() {
 
 void CoreServices::initializeKeyboard() {
     UserSettingsPointer pConfig = m_pSettingsManager->settings();
-    QString resourcePath = pConfig->getResourcePath();
+    const QLocale locale = inputLocale();
+    m_pKeyboardEventFilter = std::make_shared<KeyboardEventFilter>(pConfig, locale);
+}
 
-    // Set the default value in settings file
-    if (pConfig->getValueString(ConfigKey("[Keyboard]", "Enabled")).length() == 0) {
-        pConfig->set(ConfigKey("[Keyboard]", "Enabled"), ConfigValue(1));
-    }
-
-    // Read keyboard configuration and set kdbConfig object in WWidget
-    // Check first in user's Mixxx directory
-    QString userKeyboard = QDir(pConfig->getSettingsPath()).filePath("Custom.kbd.cfg");
-
-    // Empty keyboard configuration
-    m_pKbdConfigEmpty = std::make_shared<ConfigObject<ConfigValueKbd>>(QString());
-
-    if (QFile::exists(userKeyboard)) {
-        qDebug() << "Found and will use custom keyboard mapping" << userKeyboard;
-        m_pKbdConfig = std::make_shared<ConfigObject<ConfigValueKbd>>(userKeyboard);
-    } else {
-        // Default to the locale for the main input method (e.g. keyboard).
-        QLocale locale = inputLocale();
-
-        // check if a default keyboard exists
-        QString defaultKeyboard = QString(resourcePath).append("keyboard/");
-        defaultKeyboard += locale.name();
-        defaultKeyboard += ".kbd.cfg";
-        qDebug() << "Found and will use default keyboard mapping" << defaultKeyboard;
-
-        if (!QFile::exists(defaultKeyboard)) {
-            qDebug() << defaultKeyboard << " not found, using en_US.kbd.cfg";
-            defaultKeyboard = QString(resourcePath).append("keyboard/").append("en_US.kbd.cfg");
-            if (!QFile::exists(defaultKeyboard)) {
-                qDebug() << defaultKeyboard << " not found, starting without shortcuts";
-                defaultKeyboard = "";
-            }
-        }
-        m_pKbdConfig = std::make_shared<ConfigObject<ConfigValueKbd>>(defaultKeyboard);
-    }
-
-    // TODO(XXX) leak pKbdConfig, KeyboardEventFilter owns it? Maybe roll all keyboard
-    // initialization into KeyboardEventFilter
-    // Workaround for today: KeyboardEventFilter calls delete
-    bool keyboardShortcutsEnabled = pConfig->getValue<bool>(
-            ConfigKey("[Keyboard]", "Enabled"));
-    m_pKeyboardEventFilter = std::make_shared<KeyboardEventFilter>(
-            keyboardShortcutsEnabled ? m_pKbdConfig.get() : m_pKbdConfigEmpty.get());
+std::shared_ptr<ConfigObject<ConfigValueKbd>> CoreServices::getKeyboardConfig() const {
+    return m_pKeyboardEventFilter->getKeyboardConfig();
 }
 
 void CoreServices::slotOptionsKeyboard(bool toggle) {
-    UserSettingsPointer pConfig = m_pSettingsManager->settings();
     if (toggle) {
-        // qDebug() << "Enable keyboard shortcuts/mappings";
-        m_pKeyboardEventFilter->setKeyboardConfig(m_pKbdConfig.get());
-        pConfig->set(ConfigKey("[Keyboard]", "Enabled"), ConfigValue(1));
+        qDebug() << "Enable keyboard shortcuts/mappings";
     } else {
-        // qDebug() << "Disable keyboard shortcuts/mappings";
-        m_pKeyboardEventFilter->setKeyboardConfig(m_pKbdConfigEmpty.get());
-        pConfig->set(ConfigKey("[Keyboard]", "Enabled"), ConfigValue(0));
+        qDebug() << "Disable keyboard shortcuts/mappings";
     }
+    m_pKeyboardEventFilter->setEnabled(toggle);
 }
 
 bool CoreServices::initializeDatabase() {

--- a/src/coreservices.h
+++ b/src/coreservices.h
@@ -106,9 +106,6 @@ class CoreServices : public QObject {
     void initializationProgressUpdate(int progress, const QString& serviceName);
     void libraryScanSummary(const LibraryScanResultSummary& result);
 
-  public slots:
-    void slotOptionsKeyboard(bool toggle);
-
   private:
     bool initializeDatabase();
     void initializeKeyboard();

--- a/src/coreservices.h
+++ b/src/coreservices.h
@@ -44,9 +44,7 @@ class CoreServices : public QObject {
         return m_pKeyboardEventFilter;
     }
 
-    std::shared_ptr<ConfigObject<ConfigValueKbd>> getKeyboardConfig() const {
-        return m_pKbdConfig;
-    }
+    std::shared_ptr<ConfigObject<ConfigValueKbd>> getKeyboardConfig() const;
 
     std::shared_ptr<mixxx::ControlIndicatorTimer> getControlIndicatorTimer() const {
         return m_pControlIndicatorTimer;
@@ -143,8 +141,6 @@ class CoreServices : public QObject {
     std::shared_ptr<Library> m_pLibrary;
 
     std::shared_ptr<KeyboardEventFilter> m_pKeyboardEventFilter;
-    std::shared_ptr<ConfigObject<ConfigValueKbd>> m_pKbdConfig;
-    std::shared_ptr<ConfigObject<ConfigValueKbd>> m_pKbdConfigEmpty;
 
     std::shared_ptr<mixxx::ScreensaverManager> m_pScreensaverManager;
 

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -1332,6 +1332,8 @@ void MixxxMainWindow::slotShowKeywheel(bool toggle) {
 
 void MixxxMainWindow::slotTooltipModeChanged(mixxx::preferences::Tooltips tt) {
     m_toolTipsCfg = tt;
+    m_pCoreServices->getKeyboardEventFilter()->setShowOnlyKbdShortcuts(
+            tt == mixxx::preferences::Tooltips::OnlyKbdShortcuts);
 #ifdef MIXXX_USE_QOPENGL
     ToolTipQOpenGL::singleton().setActive(
             m_toolTipsCfg == mixxx::preferences::Tooltips::On);
@@ -1460,7 +1462,13 @@ bool MixxxMainWindow::eventFilter(QObject* obj, QEvent* event) {
         // Return true for no tool tips
         switch (m_toolTipsCfg) {
         case mixxx::preferences::Tooltips::OnlyInLibrary:
+            // WLibrary's stacked widgets are not derived from WBaseWidget
             if (dynamic_cast<WBaseWidget*>(obj) != nullptr) {
+                return true;
+            }
+            break;
+        case mixxx::preferences::Tooltips::OnlyKbdShortcuts:
+            if (dynamic_cast<WBaseWidget*>(obj) == nullptr) {
                 return true;
             }
             break;

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -886,13 +886,6 @@ void MixxxMainWindow::connectMenuBar() {
     // Refresh the Fullscreen checkbox for the case we went fullscreen earlier
     m_pMenuBar->onFullScreenStateChange(isFullScreen());
 
-    // Keyboard shortcuts
-    connect(m_pMenuBar,
-            &WMainMenuBar::toggleKeyboardShortcuts,
-            m_pCoreServices.get(),
-            &mixxx::CoreServices::slotOptionsKeyboard,
-            Qt::UniqueConnection);
-
     // Help
     connect(m_pMenuBar,
             &WMainMenuBar::showAbout,

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -528,7 +528,9 @@ MixxxMainWindow::~MixxxMainWindow() {
     // outside of MixxxMainWindow the parent relationship will directly destroy
     // the WMainMenuBar and this will no longer be a problem.
     qDebug() << t.elapsed(false).debugMillisWithUnit() << "deleting menubar";
-
+    // Clear action pointer list before we delete the menubar
+    // to prevent KeyboardEventFilter accessing dangling pointers.
+    m_pCoreServices->getKeyboardEventFilter()->clearMenuBarActions();
     QPointer<WMainMenuBar> pMenuBar = m_pMenuBar.toWeakRef();
     DEBUG_ASSERT(menuBar() == m_pMenuBar.get());
     // We need to reset the parented pointer here that it does not become a
@@ -819,9 +821,9 @@ void MixxxMainWindow::slotUpdateWindowTitle(TrackPointer pTrack) {
 
 void MixxxMainWindow::createMenuBar() {
     ScopedTimer t(QStringLiteral("MixxxMainWindow::createMenuBar"));
-    DEBUG_ASSERT(m_pCoreServices->getKeyboardConfig());
+    DEBUG_ASSERT(m_pCoreServices->getKeyboardEventFilter());
     m_pMenuBar = make_parented<WMainMenuBar>(
-            this, m_pCoreServices->getSettings(), m_pCoreServices->getKeyboardConfig().get());
+            this, m_pCoreServices->getSettings(), m_pCoreServices->getKeyboardEventFilter());
     if (m_pCentralWidget) {
         m_pMenuBar->setStyleSheet(m_pCentralWidget->styleSheet());
     }

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -501,6 +501,10 @@ MixxxMainWindow::~MixxxMainWindow() {
 
     // GUI depends on KeyboardEventFilter, PlayerManager, Library
     qDebug() << t.elapsed(false).debugMillisWithUnit() << "deleting skin";
+    // Clear widget pointer list and destroy all update connections before we
+    // delete the main widget (ie. all WBaseWidgets) to prevent KeyboardEventFilter
+    // accessing dangling pointers.
+    m_pCoreServices->getKeyboardEventFilter()->clearWidgets();
     m_pCentralWidget = nullptr;
     QPointer<QWidget> pSkin(centralWidget());
     setCentralWidget(nullptr);
@@ -1354,6 +1358,11 @@ void MixxxMainWindow::rebootMixxxView() {
     m_pMenuBar->onNewSkinAboutToLoad();
 
     if (m_pCentralWidget) {
+        // Clear widget pointer list and destroy all update connections before
+        // we delete the main widget (ie. all WBaseWidgets) to prevent
+        // KeyboardEventFilter accessing dangling pointers, just in case a
+        // shortcuts/tooltip update is triggered while we re/load a skin.
+        m_pCoreServices->getKeyboardEventFilter()->clearWidgets();
         m_pCentralWidget->hide();
         WaveformWidgetFactory::instance()->destroyWidgets();
         delete m_pCentralWidget;

--- a/src/preferences/constants.h
+++ b/src/preferences/constants.h
@@ -19,6 +19,7 @@ enum class Tooltips {
     Off = 0,
     On = 1,
     OnlyInLibrary = 2,
+    OnlyKbdShortcuts = 3,
 };
 Q_ENUM_NS(Tooltips);
 

--- a/src/preferences/dialog/dlgprefinterface.cpp
+++ b/src/preferences/dialog/dlgprefinterface.cpp
@@ -437,6 +437,8 @@ void DlgPrefInterface::slotSetTooltips() {
         m_tooltipMode = mixxx::preferences::Tooltips::Off;
     } else if (radioButtonTooltipsLibrary->isChecked()) {
         m_tooltipMode = mixxx::preferences::Tooltips::OnlyInLibrary;
+    } else if (radioButtonTooltipsOnlyKbdShortcuts->isChecked()) {
+        m_tooltipMode = mixxx::preferences::Tooltips::OnlyKbdShortcuts;
     }
 }
 
@@ -603,6 +605,9 @@ void DlgPrefInterface::loadTooltipPreferenceFromConfig() {
         break;
     case mixxx::preferences::Tooltips::OnlyInLibrary:
         radioButtonTooltipsLibrary->setChecked(true);
+        break;
+    case mixxx::preferences::Tooltips::OnlyKbdShortcuts:
+        radioButtonTooltipsOnlyKbdShortcuts->setChecked(true);
         break;
     case mixxx::preferences::Tooltips::On:
     default:

--- a/src/preferences/dialog/dlgprefinterfacedlg.ui
+++ b/src/preferences/dialog/dlgprefinterfacedlg.ui
@@ -274,6 +274,16 @@
           </attribute>
          </widget>
         </item>
+        <item>
+         <widget class="QRadioButton" name="radioButtonTooltipsOnlyKbdShortcuts">
+          <property name="text">
+           <string>Only Keyboard Shortcuts</string>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">buttonGroupTooltips</string>
+          </attribute>
+         </widget>
+        </item>
        </layout>
       </item>
 

--- a/src/preferences/usersettings.h
+++ b/src/preferences/usersettings.h
@@ -4,7 +4,6 @@
 #include <QWeakPointer>
 
 #include "preferences/configobject.h"
-#include "preferences/usersettings.h"
 
 typedef ConfigObject<ConfigValue> UserSettings;
 typedef QSharedPointer<UserSettings> UserSettingsPointer;

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -337,6 +337,9 @@ QWidget* LegacySkinParser::parseSkin(const QString& skinPath, QWidget* pParent) 
     ScopedTimer timer(QStringLiteral("SkinLoader::parseSkin"));
     qDebug() << "LegacySkinParser loading skin:" << skinPath;
 
+    // Remove all widget pointers we previously registered for shortcut tooltips.
+    m_pKeyboard->clearWidgets();
+
     m_pContext = std::make_unique<SkinContext>(m_pConfig, skinPath + "/skin.xml");
     m_pContext->setSkinBasePath(skinPath);
 
@@ -436,6 +439,11 @@ QWidget* LegacySkinParser::parseSkin(const QString& skinPath, QWidget* pParent) 
                 *m_pContext,
                 QStringLiteral("Skin produced more than 1 widget!"));
     }
+
+    // We have now registered all widgets with mappable connections.
+    // Trigger creation/population of shortcut tooltips.
+    m_pKeyboard->updateWidgetShortcuts();
+
     return widgets[0];
 }
 
@@ -1558,18 +1566,7 @@ QWidget* LegacySkinParser::parseSearchBox(const QDomElement& node) {
     commonWidgetSetup(node, pLineEditSearch, false);
     pLineEditSearch->setup(node, *m_pContext);
 
-    // Translate shortcuts to native text
-    QString searchInCurrentViewShortcut =
-            localizeShortcutKeys(m_pKeyboard->getKeyboardConfig()->getValue(
-                    ConfigKey("[KeyboardShortcuts]",
-                            "LibraryMenu_SearchInCurrentView"),
-                    "Ctrl+f"));
-    QString searchInAllTracksShortcut =
-            localizeShortcutKeys(m_pKeyboard->getKeyboardConfig()->getValue(
-                    ConfigKey("[KeyboardShortcuts]",
-                            "LibraryMenu_SearchInAllTracks"),
-                    "Ctrl+Shift+F"));
-    pLineEditSearch->setupToolTip(searchInCurrentViewShortcut, searchInAllTracksShortcut);
+    m_pKeyboard->registerSearchBar(pLineEditSearch);
 
     m_pLibrary->bindSearchboxWidget(pLineEditSearch);
 
@@ -1983,6 +1980,12 @@ QWidget* LegacySkinParser::parseHotcueButton(const QDomElement& element) {
             Qt::RightButton,
             controlFromConfigKey(pWidget->getClearConfigKey(), false),
             ControlParameterWidgetConnection::EmitOption::EMIT_ON_PRESS_AND_RELEASE);
+
+    // The list of ConfigKeys and translatable command strings for the tooltip
+    // is created in WHotcueButton::setup().
+    // KeyboardEventFilter will take care of creating the tooltips,
+    // as well as updating them when the mapping file has changed.
+    m_pKeyboard->registerShortcutWidget(pWidget);
 
     pWidget->Init();
     return pWidget;
@@ -2442,6 +2445,9 @@ void LegacySkinParser::setupWidget(const QDomNode& node,
 }
 
 void LegacySkinParser::setupConnections(const QDomNode& node, WBaseWidget* pWidget) {
+    // List of ConfigKeys and translatable command strings for the tooltip
+    QList<std::pair<ConfigKey, QString>> shortcutKeys;
+
     for (QDomNode con = m_pContext->selectNode(node, "Connection");
             !con.isNull();
             con = con.nextSibling()) {
@@ -2565,113 +2571,80 @@ void LegacySkinParser::setupConnections(const QDomNode& node, WBaseWidget* pWidg
                 break;
             }
 
+            // Add keyboard shortcuts to tooltip.
             // We only add info for controls that this widget affects, not
             // controls that only affect the widget.
+            // I.e. do not add Shortcut string for feedback connections
             if (directionOption & ControlParameterWidgetConnection::DIR_FROM_WIDGET) {
                 m_pControllerManager->getControllerLearningEventFilter()
                         ->addWidgetClickInfo(pWidget->toQWidget(), state, control,
                                 static_cast<ControlParameterWidgetConnection::EmitOption>(emitOption));
 
-                // Add keyboard shortcut info to tooltip string
-                QString key = m_pContext->selectString(con, "ConfigKey");
-                ConfigKey configKey = ConfigKey::parseCommaSeparated(key);
-
-                // do not add Shortcut string for feedback connections
-                QString shortcut = m_pKeyboard->getKeyboardConfig()->getValueString(configKey);
-                addShortcutToToolTip(pWidget, shortcut, QString(""));
-
                 const WSliderComposed* pSlider;
 
                 if (qobject_cast<const  WPushButton*>(pWidget->toQWidget())) {
-                    // check for "_activate", "_toggle"
-                    ConfigKey subkey;
-                    QString shortcut;
-
-                    subkey = configKey;
-                    subkey.item += "_activate";
-                    shortcut = m_pKeyboard->getKeyboardConfig()->getValueString(subkey);
-                    addShortcutToToolTip(pWidget, shortcut, tr("activate"));
-
-                    subkey = configKey;
-                    subkey.item += "_toggle";
-                    shortcut = m_pKeyboard->getKeyboardConfig()->getValueString(subkey);
-                    addShortcutToToolTip(pWidget, shortcut, tr("toggle"));
+                    shortcutKeys.append(std::make_pair(control->getKey(), QString()));
                 } else if ((pSlider = qobject_cast<const WSliderComposed*>(pWidget->toQWidget())) ||
                         qobject_cast<const WKnobComposed*>(pWidget->toQWidget())) {
-                    // check for "_up", "_down", "_up_small", "_down_small"
-                    ConfigKey subkey;
-                    QString shortcut;
-
+                    const ConfigKey cfgKey = control->getKey();
+                    // Add up/down controls with orientation-dependent tr strings
                     if (pSlider && pSlider->tryParseHorizontal(node)) {
-                        subkey = configKey;
-                        subkey.item += "_up";
-                        shortcut = m_pKeyboard->getKeyboardConfig()->getValueString(subkey);
-                        addShortcutToToolTip(pWidget, shortcut, tr("right"));
-
-                        subkey = configKey;
-                        subkey.item += "_down";
-                        shortcut = m_pKeyboard->getKeyboardConfig()->getValueString(subkey);
-                        addShortcutToToolTip(pWidget, shortcut, tr("left"));
-
-                        subkey = configKey;
-                        subkey.item += "_up_small";
-                        shortcut = m_pKeyboard->getKeyboardConfig()->getValueString(subkey);
-                        addShortcutToToolTip(pWidget, shortcut, tr("right small"));
-
-                        subkey = configKey;
-                        subkey.item += "_down_small";
-                        shortcut = m_pKeyboard->getKeyboardConfig()->getValueString(subkey);
-                        addShortcutToToolTip(pWidget, shortcut, tr("left small"));
-                    } else { // vertical slider of knob
-                        subkey = configKey;
-                        subkey.item += "_up";
-                        shortcut = m_pKeyboard->getKeyboardConfig()->getValueString(subkey);
-                        addShortcutToToolTip(pWidget, shortcut, tr("up"));
-
-                        subkey = configKey;
-                        subkey.item += "_down";
-                        shortcut = m_pKeyboard->getKeyboardConfig()->getValueString(subkey);
-                        addShortcutToToolTip(pWidget, shortcut, tr("down"));
-
-                        subkey = configKey;
-                        subkey.item += "_up_small";
-                        shortcut = m_pKeyboard->getKeyboardConfig()->getValueString(subkey);
-                        addShortcutToToolTip(pWidget, shortcut, tr("up small"));
-
-                        subkey = configKey;
-                        subkey.item += "_down_small";
-                        shortcut = m_pKeyboard->getKeyboardConfig()->getValueString(subkey);
-                        addShortcutToToolTip(pWidget, shortcut, tr("down small"));
+                        shortcutKeys.emplace_back(
+                                subKey(cfgKey, QStringLiteral("_down")),
+                                tr("left"));
+                        shortcutKeys.emplace_back(
+                                subKey(cfgKey, QStringLiteral("_down_small")),
+                                tr("left small"));
+                        shortcutKeys.emplace_back(
+                                subKey(cfgKey, QStringLiteral("_up")),
+                                tr("right"));
+                        shortcutKeys.emplace_back(
+                                subKey(cfgKey, QStringLiteral("_up_small")),
+                                tr("right small"));
+                    } else { // vertical slider or knob
+                        shortcutKeys.emplace_back(
+                                subKey(cfgKey, QStringLiteral("_down")),
+                                tr("down"));
+                        shortcutKeys.emplace_back(
+                                subKey(cfgKey, QStringLiteral("_down_small")),
+                                tr("down small"));
+                        shortcutKeys.emplace_back(
+                                subKey(cfgKey, QStringLiteral("_up")),
+                                tr("up"));
+                        shortcutKeys.emplace_back(
+                                subKey(cfgKey, QStringLiteral("_up_small")),
+                                tr("up small"));
                     }
+                    // Add common PotmeterControls
+                    shortcutKeys.emplace_back(
+                            subKey(cfgKey, QStringLiteral("_set_default")),
+                            tr("set default"));
+                    shortcutKeys.emplace_back(
+                            subKey(cfgKey, QStringLiteral("_set_minus_one")),
+                            tr("set -1"));
+                    shortcutKeys.emplace_back(
+                            subKey(cfgKey, QStringLiteral("_set_zero")),
+                            tr("set 0"));
+                    shortcutKeys.emplace_back(
+                            subKey(cfgKey, QStringLiteral("_set_one")),
+                            tr("set 1"));
+                    shortcutKeys.emplace_back(
+                            subKey(cfgKey, QStringLiteral("_toggle")),
+                            tr("toggle"));
+                    shortcutKeys.emplace_back(
+                            subKey(cfgKey, QStringLiteral("_minus_toggle")),
+                            tr("minus toggle"));
                 }
             }
         }
     }
-}
 
-void LegacySkinParser::addShortcutToToolTip(WBaseWidget* pWidget,
-                                            const QString& shortcut, const QString& cmd) {
-    if (shortcut.isEmpty()) {
-        return;
+    if (!shortcutKeys.isEmpty()) {
+        pWidget->setShortcutControlsAndCommands(shortcutKeys);
+        // KeyboardEventFilter will take care of creating the tooltips,
+        // as well as updating them when the mapping file has changed.
+        m_pKeyboard->registerShortcutWidget(pWidget);
     }
-
-    QString tooltip;
-
-    tooltip += "\n";
-    tooltip += tr("Shortcut");
-    if (!cmd.isEmpty()) {
-        tooltip += " ";
-        tooltip += cmd;
-    }
-    tooltip += ": ";
-    tooltip += localizeShortcutKeys(shortcut);
-    pWidget->appendBaseTooltip(tooltip);
-}
-
-QString LegacySkinParser::localizeShortcutKeys(const QString& shortcut) {
-    // Translate shortcut to native text
-    return QKeySequence(shortcut, QKeySequence::PortableText)
-            .toString(QKeySequence::NativeText);
 }
 
 QString LegacySkinParser::parseLaunchImageStyle(const QDomNode& skinDoc) {

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -2639,10 +2639,16 @@ void LegacySkinParser::setupConnections(const QDomNode& node, WBaseWidget* pWidg
         }
     }
 
-    if (!shortcutKeys.isEmpty()) {
-        pWidget->setShortcutControlsAndCommands(shortcutKeys);
+    if (shortcutKeys.isEmpty()) {
+        // A widget with no control connections.
+        // We only make the connection to clear/fill the tooltip when the
+        //  tooltips mode "Keyboard shortcuts only" is toggled.
+        m_pKeyboard->connectShowOnlyKbdShortcuts(pWidget);
+    } else {
+        // A widget with at least one control connection.
         // KeyboardEventFilter will take care of creating the tooltips,
         // as well as updating them when the mapping file has changed.
+        pWidget->setShortcutControlsAndCommands(shortcutKeys);
         m_pKeyboard->registerShortcutWidget(pWidget);
     }
 }

--- a/src/skin/legacy/legacyskinparser.h
+++ b/src/skin/legacy/legacyskinparser.h
@@ -142,8 +142,14 @@ class LegacySkinParser : public QObject, public SkinParser {
     void setupWidget(const QDomNode& node, QWidget* pWidget,
                      bool setupPosition=true);
     void setupConnections(const QDomNode& node, WBaseWidget* pWidget);
-    void addShortcutToToolTip(WBaseWidget* pWidget, const QString& shortcut, const QString& cmd);
+
     QString localizeShortcutKeys(const QString& shortcut);
+
+    /// Helper to create a ConfigKey from a ControlPotmeter base key
+    inline const ConfigKey subKey(const ConfigKey& cfgKey, const QString& subctrl) {
+        return ConfigKey{cfgKey.group, cfgKey.item + subctrl};
+    }
+
     QString getLibraryStyle(const QDomNode& node);
 
     QString lookupNodeGroup(const QDomElement& node);

--- a/src/widget/wbasewidget.cpp
+++ b/src/widget/wbasewidget.cpp
@@ -1,12 +1,13 @@
 #include "widget/wbasewidget.h"
 
-#include "widget/controlwidgetconnection.h"
 #include "util/cmdlineargs.h"
 #include "util/debug.h"
+#include "widget/controlwidgetconnection.h"
 
 WBaseWidget::WBaseWidget(QWidget* pWidget)
         : m_pDisplayConnection(nullptr),
-          m_pWidget(pWidget) {
+          m_pWidget(pWidget),
+          m_showKeyboardShortcuts(false) {
 }
 
 WBaseWidget::~WBaseWidget() = default;
@@ -138,13 +139,24 @@ void WBaseWidget::setControlParameterRightUp(double v) {
     }
 }
 
+void WBaseWidget::updateBaseTooltipOptShortcuts() {
+    QString tooltip;
+    tooltip += m_baseTooltip;
+    if (m_showKeyboardShortcuts && !m_shortcutTooltip.isEmpty()) {
+        tooltip += "\n";
+        tooltip += m_shortcutTooltip;
+    }
+    m_baseTooltipOptShortcuts = tooltip;
+    m_pWidget->setToolTip(tooltip);
+}
+
 void WBaseWidget::updateTooltip() {
     // If we are in developer mode, expand the tooltip.
     if (CmdlineArgs::Instance().getDeveloper()) {
         QStringList debug;
         fillDebugTooltip(&debug);
 
-        QString base = baseTooltip();
+        const QString base = baseTooltipOptShortcuts();
         if (!base.isEmpty()) {
             debug.append(QStringLiteral("Tooltip: \"%1\"").arg(base));
         }

--- a/src/widget/wbasewidget.cpp
+++ b/src/widget/wbasewidget.cpp
@@ -7,7 +7,8 @@
 WBaseWidget::WBaseWidget(QWidget* pWidget)
         : m_pDisplayConnection(nullptr),
           m_pWidget(pWidget),
-          m_showKeyboardShortcuts(false) {
+          m_showKeyboardShortcuts(false),
+          m_showOnlyKeyboardShortcuts(false) {
 }
 
 WBaseWidget::~WBaseWidget() = default;
@@ -141,9 +142,18 @@ void WBaseWidget::setControlParameterRightUp(double v) {
 
 void WBaseWidget::updateBaseTooltipOptShortcuts() {
     QString tooltip;
-    tooltip += m_baseTooltip;
+    if (!m_showOnlyKeyboardShortcuts) {
+        tooltip += m_baseTooltip;
+    }
+    // TODO Construct & localize kbd shortcuts here (somewhere in WBaseWidget
+    // So, in case of OnlyKbdShortcuts, we can show
+    // control (key only): shortcut
+    // Currently, we see the shortcuts but not which controls they trigger.
+    // This is relevant only for the right-click action though.
     if (m_showKeyboardShortcuts && !m_shortcutTooltip.isEmpty()) {
-        tooltip += "\n";
+        if (!m_showOnlyKeyboardShortcuts) {
+            tooltip += "\n";
+        }
         tooltip += m_shortcutTooltip;
     }
     m_baseTooltipOptShortcuts = tooltip;

--- a/src/widget/wbasewidget.h
+++ b/src/widget/wbasewidget.h
@@ -109,6 +109,14 @@ class WBaseWidget {
         updateBaseTooltipOptShortcuts();
     }
 
+    void toggleShowOnlyKeyboardShortcuts(bool show) {
+        if (m_showOnlyKeyboardShortcuts == show) {
+            return;
+        }
+        m_showOnlyKeyboardShortcuts = show;
+        updateBaseTooltipOptShortcuts();
+    }
+
     void updateBaseTooltipOptShortcuts();
 
   protected:
@@ -153,6 +161,7 @@ class WBaseWidget {
     QList<std::pair<ConfigKey, QString>> m_shortcutControlsAndCommands;
 
     bool m_showKeyboardShortcuts;
+    bool m_showOnlyKeyboardShortcuts;
 
     friend class ControlParameterWidgetConnection;
 };

--- a/src/widget/wbasewidget.h
+++ b/src/widget/wbasewidget.h
@@ -1,10 +1,12 @@
 #pragma once
 
+#include <QList>
 #include <QString>
 #include <QWidget>
 #include <memory>
 #include <vector>
 
+#include "preferences/configobject.h"
 #include "util/string.h"
 
 class ControlWidgetPropertyConnection;
@@ -29,17 +31,30 @@ class WBaseWidget {
 
     void appendBaseTooltip(const QString& tooltip) {
         m_baseTooltip.append(mixxx::removeTrailingWhitespaces(tooltip));
-        m_pWidget->setToolTip(m_baseTooltip);
+        updateBaseTooltipOptShortcuts();
     }
 
     void prependBaseTooltip(const QString& tooltip) {
         m_baseTooltip.prepend(mixxx::removeTrailingWhitespaces(tooltip));
-        m_pWidget->setToolTip(m_baseTooltip);
+        updateBaseTooltipOptShortcuts();
     }
 
     void setBaseTooltip(const QString& tooltip) {
         m_baseTooltip = mixxx::removeTrailingWhitespaces(tooltip);
-        m_pWidget->setToolTip(m_baseTooltip);
+        updateBaseTooltipOptShortcuts();
+    }
+
+    void setShortcutTooltip(const QString& tooltip) {
+        // While the other set functions are called only during widget construction,
+        // this is also called each time the keyboard config file is reloaded,
+        // so this may be called even though this widget's shortcuts are unchanged
+        // and/or while we currently don't show shortcuts, so just update when
+        // we need in order to prevent thousands of no-ops.
+        bool reloadNow = m_showKeyboardShortcuts && m_shortcutTooltip != tooltip;
+        m_shortcutTooltip = tooltip;
+        if (reloadNow) {
+            updateBaseTooltipOptShortcuts();
+        }
     }
 
     QString baseTooltip() const {
@@ -65,6 +80,36 @@ class WBaseWidget {
     double getControlParameterRight() const;
     double getControlParameterDisplay() const;
 
+    QString shortcutHints() const {
+        return m_shortcutTooltip;
+    }
+
+    QString baseTooltipOptShortcuts() const {
+        return m_baseTooltipOptShortcuts;
+    }
+
+    /// Set by LegacySkinParser on widget construction
+    void setShortcutControlsAndCommands(
+            const QList<std::pair<ConfigKey, QString>>& controlsCommands) {
+        m_shortcutControlsAndCommands = controlsCommands;
+    }
+
+    /// Called by KeyboardEventFilter::updateWidgetShortcuts() when the keyboard
+    /// config has been (re)loaded in order to update the shortcut tooltips
+    const QList<std::pair<ConfigKey, QString>>& getShortcutControlsAndCommands() const {
+        return m_shortcutControlsAndCommands;
+    }
+
+    /// Append/remove shortcuts hint when shortcuts are toggled
+    void toggleKeyboardShortcutHints(bool enabled) {
+        if (m_showKeyboardShortcuts == enabled) {
+            return;
+        }
+        m_showKeyboardShortcuts = enabled;
+        updateBaseTooltipOptShortcuts();
+    }
+
+    void updateBaseTooltipOptShortcuts();
 
   protected:
     // Whenever a connected control is changed, onConnectedControlChanged is
@@ -100,7 +145,14 @@ class WBaseWidget {
 
   private:
     QWidget* m_pWidget;
+
     QString m_baseTooltip;
+    QString m_shortcutTooltip;
+    QString m_baseTooltipOptShortcuts;
+    // Map of [ConfigKey, tr string] of control or all sub-controls.
+    QList<std::pair<ConfigKey, QString>> m_shortcutControlsAndCommands;
+
+    bool m_showKeyboardShortcuts;
 
     friend class ControlParameterWidgetConnection;
 };

--- a/src/widget/whotcuebutton.cpp
+++ b/src/widget/whotcuebutton.cpp
@@ -132,6 +132,38 @@ void WHotcueButton::setup(const QDomNode& node, const SkinContext& context) {
     if (!con.isNull()) {
         SKIN_WARNING(node, context, QStringLiteral("Additional Connections are not allowed"));
     }
+
+    // Create the list of ConfigKeys and translatable command strings
+    // for the keyboard shortcut tooltip and store it in WBaseWidget.
+    // KeyboardEventFilter::updateWidgetShortcuts() will fetch it to
+    // update the tooltip when the keyboard mapping is (re)loaded.
+    QList<std::pair<ConfigKey, QString>> shortcutKeys;
+    shortcutKeys.emplace_back(getLeftClickConfigKey(), tr("activate"));
+    shortcutKeys.emplace_back(getClearConfigKey(), tr("clear"));
+    // Add dedicated cue/loop cue controls
+    shortcutKeys.emplace_back(
+            createConfigKey(QStringLiteral("set")), tr("set"));
+    shortcutKeys.emplace_back(
+            createConfigKey(QStringLiteral("setcue")), tr("set cue"));
+    shortcutKeys.emplace_back(
+            createConfigKey(QStringLiteral("setloop")), tr("set loop"));
+    shortcutKeys.emplace_back(
+            createConfigKey(QStringLiteral("goto")), tr("go to"));
+    shortcutKeys.emplace_back(
+            createConfigKey(QStringLiteral("gotoandplay")), tr("go to and play"));
+    shortcutKeys.emplace_back(
+            createConfigKey(QStringLiteral("gotoandstop")), tr("go to and stop"));
+    shortcutKeys.emplace_back(
+            createConfigKey(QStringLiteral("gotoandloop")), tr("go to and loop"));
+    shortcutKeys.emplace_back(
+            createConfigKey(QStringLiteral("cueloop")), tr("cue loop"));
+    shortcutKeys.emplace_back(
+            createConfigKey(QStringLiteral("activatecue")), tr("activat cue"));
+    shortcutKeys.emplace_back(
+            createConfigKey(QStringLiteral("activateloop")), tr("activate loop"));
+    shortcutKeys.emplace_back(
+            createConfigKey(QStringLiteral("activate_preview")), tr("activate preview"));
+    setShortcutControlsAndCommands(shortcutKeys);
 }
 
 bool WHotcueButton::isActive() const {

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -545,8 +545,12 @@ void WMainMenuBar::initialize() {
 
     QString keyboardShortcutTitle = tr("Enable &Keyboard Shortcuts");
     QString keyboardShortcutText = tr("Toggles keyboard shortcuts on or off");
-    bool keyboardShortcutsEnabled = m_pConfig->getValueString(
-        ConfigKey("[Keyboard]", "Enabled")) == "1";
+    // Note: use the same default value in KeyboardEventFilter ctor so that this
+    // action and KeyboardEventFilter are in sync.
+    bool keyboardShortcutsEnabled =
+            m_pConfig->getValue(ConfigKey(QStringLiteral("[Keyboard]"),
+                                        QStringLiteral("Enabled")),
+                    true);
     auto* pOptionsKeyboard = new QAction(keyboardShortcutTitle, this);
     pOptionsKeyboard->setShortcut(
             safeKeySequence(m_pKbdConfig->getValue(

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -532,7 +532,10 @@ void WMainMenuBar::initialize() {
     pOptionsKeyboard->setChecked(keyboardShortcutsEnabled);
     pOptionsKeyboard->setStatusTip(keyboardShortcutText);
     pOptionsKeyboard->setWhatsThis(buildWhatsThis(keyboardShortcutTitle, keyboardShortcutText));
-    connect(pOptionsKeyboard, &QAction::triggered, this, &WMainMenuBar::toggleKeyboardShortcuts);
+    connect(pOptionsKeyboard,
+            &QAction::triggered,
+            m_pKeyboard.get(),
+            &KeyboardEventFilter::setEnabled);
 
     pOptionsMenu->addAction(pOptionsKeyboard);
 

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -8,6 +8,7 @@
 
 #include "config.h"
 #include "control/controlproxy.h"
+#include "controllers/keyboard/keyboardeventfilter.h"
 #include "defs_urls.h"
 #include "moc_wmainmenubar.cpp"
 #include "util/cmdlineargs.h"
@@ -19,33 +20,13 @@ namespace {
 
 constexpr int kMaxLoadToDeckActions = 4;
 const QString kSkinGroup = QStringLiteral("[Skin]");
+const QString kKbdShortcutsGroup = QStringLiteral("[KeyboardShortcuts]");
+const ConfigKey kHideMenuCfgKey =
+        ConfigKey(QStringLiteral("[Config]"), QStringLiteral("hide_menubar"));
 
 QString buildWhatsThis(const QString& title, const QString& text) {
     QString preparedTitle = title;
-    return QString("%1\n\n%2").arg(preparedTitle.remove("&"), text);
-}
-
-// Returns a QKeySequence from str, or an empty QKeySequence if str contains an
-// invalid key name. Prevents a macOS crash where QCocoaMenuItem::sync() cannot
-// convert Qt::Key_unknown (> 0xFFFF) to QChar. See
-// https://github.com/mixxxdj/mixxx/issues/16216
-QKeySequence safeKeySequence(const QString& str) {
-    if (str.isEmpty()) {
-        return {};
-    }
-    const QKeySequence ks(str);
-    for (int i = 0; i < ks.count(); ++i) {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-        const Qt::Key key = ks[i].key();
-#else
-        const int key = ks[i] & ~Qt::KeyboardModifierMask;
-#endif
-        if (key == Qt::Key_unknown) {
-            qWarning() << "Ignoring invalid keyboard shortcut:" << str;
-            return {};
-        }
-    }
-    return ks;
+    return QStringLiteral("%1\n\n%2").arg(preparedTitle.remove("&"), text);
 }
 
 #ifdef __VINYLCONTROL__
@@ -105,16 +86,19 @@ QUrl documentationUrl(
 }
 }  // namespace
 
-WMainMenuBar::WMainMenuBar(QWidget* pParent, UserSettingsPointer pConfig,
-                           ConfigObject<ConfigValueKbd>* pKbdConfig)
+WMainMenuBar::WMainMenuBar(QWidget* pParent,
+        UserSettingsPointer pConfig,
+        std::shared_ptr<KeyboardEventFilter> pKbd)
         : QMenuBar(pParent),
           m_pConfig(pConfig),
-          m_pKbdConfig(pKbdConfig) {
+          m_pKeyboard(std::move(pKbd)) {
     setObjectName(QStringLiteral("MainMenu"));
     initialize();
 }
 
 void WMainMenuBar::initialize() {
+    // Clear hash of previous actions
+    m_pKeyboard->clearMenuBarActions();
     // FILE MENU
     QMenu* pFileMenu = new QMenu(tr("&File"), this);
 #ifndef __APPLE__
@@ -128,14 +112,10 @@ void WMainMenuBar::initialize() {
         QString playerLoadStatusText = loadTrackStatusText.arg(QString::number(deck + 1));
         QAction* pFileLoadSongToPlayer = new QAction(
             loadTrackText.arg(QString::number(deck + 1)), this);
-
-        QString binding = m_pKbdConfig->getValue(
-                ConfigKey("[KeyboardShortcuts]", QString("FileMenu_LoadDeck%1").arg(deck + 1)),
+        m_pKeyboard->registerMenuBarActionSetShortcut(pFileLoadSongToPlayer,
+                ConfigKey(kKbdShortcutsGroup,
+                        QStringLiteral("FileMenu_LoadDeck%1").arg(deck + 1)),
                 loadToDeckDefaultKeyBinding(deck));
-        if (!binding.isEmpty()) {
-            pFileLoadSongToPlayer->setShortcut(safeKeySequence(binding));
-            pFileLoadSongToPlayer->setShortcutContext(Qt::ApplicationShortcut);
-        }
         pFileLoadSongToPlayer->setStatusTip(playerLoadStatusText);
         pFileLoadSongToPlayer->setWhatsThis(
             buildWhatsThis(openText, playerLoadStatusText));
@@ -154,10 +134,10 @@ void WMainMenuBar::initialize() {
     QString quitTitle = tr("&Exit");
     QString quitText = tr("Quits Mixxx");
     auto* pFileQuit = new QAction(quitTitle, this);
-    pFileQuit->setShortcut(safeKeySequence(m_pKbdConfig->getValue(
-            ConfigKey("[KeyboardShortcuts]", "FileMenu_Quit"),
-            QStringLiteral("Ctrl+q"))));
-    pFileQuit->setShortcutContext(Qt::ApplicationShortcut);
+    m_pKeyboard->registerMenuBarActionSetShortcut(
+            pFileQuit,
+            ConfigKey(kKbdShortcutsGroup, QStringLiteral("FileMenu_Quit")),
+            QStringLiteral("Ctrl+q"));
     pFileQuit->setStatusTip(quitText);
     pFileQuit->setWhatsThis(buildWhatsThis(quitTitle, quitText));
     pFileQuit->setMenuRole(QAction::QuitRole);
@@ -175,9 +155,10 @@ void WMainMenuBar::initialize() {
     QString rescanTitle = tr("&Rescan Library");
     QString rescanText = tr("Rescans library folders for changes to tracks.");
     auto* pLibraryRescan = new QAction(rescanTitle, this);
-    pLibraryRescan->setShortcut(safeKeySequence(m_pKbdConfig->getValue(
-            ConfigKey("[KeyboardShortcuts]", "LibraryMenu_Rescan"),
-            QStringLiteral("Ctrl+Shift+L"))));
+    m_pKeyboard->registerMenuBarActionSetShortcut(
+            pLibraryRescan,
+            ConfigKey(kKbdShortcutsGroup, QStringLiteral("LibraryMenu_Rescan")),
+            QStringLiteral("Ctrl+Shift+L"));
     pLibraryRescan->setStatusTip(rescanText);
     pLibraryRescan->setWhatsThis(buildWhatsThis(rescanTitle, rescanText));
     pLibraryRescan->setCheckable(false);
@@ -203,10 +184,10 @@ void WMainMenuBar::initialize() {
     QString searchHereTitle = tr("Search in Current View...");
     QString searchHereText = tr("Search for tracks in the current library view");
     auto* pSearchHere = new QAction(searchHereTitle, this);
-    pSearchHere->setShortcut(QKeySequence(m_pKbdConfig->getValue(
+    m_pKeyboard->registerMenuBarActionSetShortcut(
+            pSearchHere,
             ConfigKey("[KeyboardShortcuts]", "LibraryMenu_SearchInCurrentView"),
-            tr("Ctrl+f"))));
-    pSearchHere->setShortcutContext(Qt::ApplicationShortcut);
+            QStringLiteral("Ctrl+f"));
     pSearchHere->setStatusTip(searchHereText);
     pSearchHere->setWhatsThis(buildWhatsThis(searchHereTitle, searchHereText));
     connect(pSearchHere, &QAction::triggered, this, &WMainMenuBar::searchInCurrentView);
@@ -217,10 +198,10 @@ void WMainMenuBar::initialize() {
             tr("Search in the internal track collection under \"Tracks\" in "
                "the library");
     auto* pSearchAll = new QAction(searchAllTitle, this);
-    pSearchAll->setShortcut(QKeySequence(m_pKbdConfig->getValue(
+    m_pKeyboard->registerMenuBarActionSetShortcut(
+            pSearchAll,
             ConfigKey("[KeyboardShortcuts]", "LibraryMenu_SearchInAllTracks"),
-            tr("Ctrl+Shift+F"))));
-    pSearchAll->setShortcutContext(Qt::ApplicationShortcut);
+            QStringLiteral("Ctrl+Shift+F"));
     pSearchAll->setStatusTip(searchAllText);
     pSearchAll->setWhatsThis(buildWhatsThis(searchAllText, searchAllText));
     connect(pSearchAll, &QAction::triggered, this, &WMainMenuBar::searchInAllTracks);
@@ -231,11 +212,10 @@ void WMainMenuBar::initialize() {
     QString createPlaylistTitle = tr("Create &New Playlist");
     QString createPlaylistText = tr("Create a new playlist");
     auto* pLibraryCreatePlaylist = new QAction(createPlaylistTitle, this);
-    pLibraryCreatePlaylist->setShortcut(
-            safeKeySequence(m_pKbdConfig->getValue(
-                    ConfigKey("[KeyboardShortcuts]", "LibraryMenu_NewPlaylist"),
-                    QStringLiteral("Ctrl+n"))));
-    pLibraryCreatePlaylist->setShortcutContext(Qt::ApplicationShortcut);
+    m_pKeyboard->registerMenuBarActionSetShortcut(
+            pLibraryCreatePlaylist,
+            ConfigKey(kKbdShortcutsGroup, QStringLiteral("LibraryMenu_NewPlaylist")),
+            QStringLiteral("Ctrl+n"));
     pLibraryCreatePlaylist->setStatusTip(createPlaylistText);
     pLibraryCreatePlaylist->setWhatsThis(buildWhatsThis(createPlaylistTitle, createPlaylistText));
     connect(pLibraryCreatePlaylist, &QAction::triggered, this, &WMainMenuBar::createPlaylist);
@@ -244,11 +224,10 @@ void WMainMenuBar::initialize() {
     QString createCrateTitle = tr("Create New &Crate");
     QString createCrateText = tr("Create a new crate");
     auto* pLibraryCreateCrate = new QAction(createCrateTitle, this);
-    pLibraryCreateCrate->setShortcut(
-            safeKeySequence(m_pKbdConfig->getValue(ConfigKey("[KeyboardShortcuts]",
-                                                           "LibraryMenu_NewCrate"),
-                    QStringLiteral("Ctrl+Shift+N"))));
-    pLibraryCreateCrate->setShortcutContext(Qt::ApplicationShortcut);
+    m_pKeyboard->registerMenuBarActionSetShortcut(
+            pLibraryCreateCrate,
+            ConfigKey(kKbdShortcutsGroup, QStringLiteral("LibraryMenu_NewCrate")),
+            QStringLiteral("Ctrl+Shift+N"));
     pLibraryCreateCrate->setStatusTip(createCrateText);
     pLibraryCreateCrate->setWhatsThis(buildWhatsThis(createCrateTitle, createCrateText));
     connect(pLibraryCreateCrate, &QAction::triggered, this, &WMainMenuBar::createCrate);
@@ -285,8 +264,7 @@ void WMainMenuBar::initialize() {
             &QMenu::aboutToShow,
             this,
             [this, pViewAutoHideMenuBar]() {
-                bool autoHide = m_pConfig->getValue<bool>(
-                        ConfigKey("[Config]", "hide_menubar"), false);
+                bool autoHide = m_pConfig->getValue<bool>(kHideMenuCfgKey, false);
                 pViewAutoHideMenuBar->setChecked(autoHide);
             });
     pViewMenu->addAction(pViewAutoHideMenuBar);
@@ -301,10 +279,10 @@ void WMainMenuBar::initialize() {
             " " + mayNotBeSupported;
     auto* pViewShowSkinSettings = new QAction(showSkinSettingsTitle, this);
     pViewShowSkinSettings->setCheckable(true);
-    pViewShowSkinSettings->setShortcut(
-            safeKeySequence(m_pKbdConfig->getValue(
-                    ConfigKey("[KeyboardShortcuts]", "ViewMenu_ShowSkinSettings"),
-                    QStringLiteral("Ctrl+1"))));
+    m_pKeyboard->registerMenuBarActionSetShortcut(
+            pViewShowSkinSettings,
+            ConfigKey(kKbdShortcutsGroup, QStringLiteral("ViewMenu_ShowSkinSettings")),
+            QStringLiteral("Ctrl+1"));
     pViewShowSkinSettings->setStatusTip(showSkinSettingsText);
     pViewShowSkinSettings->setWhatsThis(buildWhatsThis(showSkinSettingsTitle, showSkinSettingsText));
     createVisibilityControl(pViewShowSkinSettings,
@@ -317,10 +295,10 @@ void WMainMenuBar::initialize() {
             " " + mayNotBeSupported;
     auto* pViewShowMicrophone = new QAction(showMicrophoneTitle, this);
     pViewShowMicrophone->setCheckable(true);
-    pViewShowMicrophone->setShortcut(
-            safeKeySequence(m_pKbdConfig->getValue(
-                    ConfigKey("[KeyboardShortcuts]", "ViewMenu_ShowMicrophone"),
-                    QStringLiteral("Ctrl+2"))));
+    m_pKeyboard->registerMenuBarActionSetShortcut(
+            pViewShowMicrophone,
+            ConfigKey(kKbdShortcutsGroup, QStringLiteral("ViewMenu_ShowMicrophone")),
+            QStringLiteral("Ctrl+2"));
     pViewShowMicrophone->setStatusTip(showMicrophoneText);
     pViewShowMicrophone->setWhatsThis(buildWhatsThis(showMicrophoneTitle, showMicrophoneText));
     createVisibilityControl(pViewShowMicrophone,
@@ -333,10 +311,10 @@ void WMainMenuBar::initialize() {
             " " + mayNotBeSupported;
     auto* pViewVinylControl = new QAction(showVinylControlTitle, this);
     pViewVinylControl->setCheckable(true);
-    pViewVinylControl->setShortcut(
-            safeKeySequence(m_pKbdConfig->getValue(
-                    ConfigKey("[KeyboardShortcuts]", "ViewMenu_ShowVinylControl"),
-                    QStringLiteral("Ctrl+3"))));
+    m_pKeyboard->registerMenuBarActionSetShortcut(
+            pViewVinylControl,
+            ConfigKey(kKbdShortcutsGroup, QStringLiteral("ViewMenu_ShowVinylControl")),
+            QStringLiteral("Ctrl+3"));
     pViewVinylControl->setStatusTip(showVinylControlText);
     pViewVinylControl->setWhatsThis(buildWhatsThis(showVinylControlTitle, showVinylControlText));
     createVisibilityControl(pViewVinylControl,
@@ -349,10 +327,10 @@ void WMainMenuBar::initialize() {
             " " + mayNotBeSupported;
     auto* pViewShowPreviewDeck = new QAction(showPreviewDeckTitle, this);
     pViewShowPreviewDeck->setCheckable(true);
-    pViewShowPreviewDeck->setShortcut(
-            safeKeySequence(m_pKbdConfig->getValue(
-                    ConfigKey("[KeyboardShortcuts]", "ViewMenu_ShowPreviewDeck"),
-                    QStringLiteral("Ctrl+4"))));
+    m_pKeyboard->registerMenuBarActionSetShortcut(
+            pViewShowPreviewDeck,
+            ConfigKey(kKbdShortcutsGroup, QStringLiteral("ViewMenu_ShowPreviewDeck")),
+            QStringLiteral("Ctrl+4"));
     pViewShowPreviewDeck->setStatusTip(showPreviewDeckText);
     pViewShowPreviewDeck->setWhatsThis(buildWhatsThis(showPreviewDeckTitle, showPreviewDeckText));
     createVisibilityControl(pViewShowPreviewDeck,
@@ -365,10 +343,10 @@ void WMainMenuBar::initialize() {
             " " + mayNotBeSupported;
     auto* pViewShowCoverArt = new QAction(showCoverArtTitle, this);
     pViewShowCoverArt->setCheckable(true);
-    pViewShowCoverArt->setShortcut(
-            safeKeySequence(m_pKbdConfig->getValue(
-                    ConfigKey("[KeyboardShortcuts]", "ViewMenu_ShowCoverArt"),
-                    QStringLiteral("Ctrl+6"))));
+    m_pKeyboard->registerMenuBarActionSetShortcut(
+            pViewShowCoverArt,
+            ConfigKey(kKbdShortcutsGroup, QStringLiteral("ViewMenu_ShowCoverArt")),
+            QStringLiteral("Ctrl+6"));
     pViewShowCoverArt->setStatusTip(showCoverArtText);
     pViewShowCoverArt->setWhatsThis(buildWhatsThis(showCoverArtTitle, showCoverArtText));
     createVisibilityControl(pViewShowCoverArt,
@@ -381,10 +359,10 @@ void WMainMenuBar::initialize() {
     QString keywheelText = tr("Show keywheel");
     m_pViewKeywheel = new QAction(keywheelTitle, this);
     m_pViewKeywheel->setCheckable(true);
-    m_pViewKeywheel->setShortcut(
-            safeKeySequence(m_pKbdConfig->getValue(
-                    ConfigKey("[KeyboardShortcuts]", "ViewMenu_ShowKeywheel"),
-                    QStringLiteral("F12"))));
+    m_pKeyboard->registerMenuBarActionSetShortcut(
+            m_pViewKeywheel,
+            ConfigKey(kKbdShortcutsGroup, QStringLiteral("ViewMenu_ShowKeywheel")),
+            QStringLiteral("F12"));
     m_pViewKeywheel->setShortcutContext(Qt::ApplicationShortcut);
     m_pViewKeywheel->setStatusTip(keywheelText);
     m_pViewKeywheel->setWhatsThis(buildWhatsThis(keywheelTitle, keywheelText));
@@ -396,10 +374,10 @@ void WMainMenuBar::initialize() {
             " " + mayNotBeSupported;
     auto* pViewMaximizeLibrary = new QAction(maximizeLibraryTitle, this);
     pViewMaximizeLibrary->setCheckable(true);
-    pViewMaximizeLibrary->setShortcut(
-            safeKeySequence(m_pKbdConfig->getValue(
-                    ConfigKey("[KeyboardShortcuts]", "ViewMenu_MaximizeLibrary"),
-                    QStringLiteral("Space"))));
+    m_pKeyboard->registerMenuBarActionSetShortcut(
+            pViewMaximizeLibrary,
+            ConfigKey(kKbdShortcutsGroup, QStringLiteral("ViewMenu_MaximizeLibrary")),
+            QStringLiteral("Space"));
     pViewMaximizeLibrary->setStatusTip(maximizeLibraryText);
     pViewMaximizeLibrary->setWhatsThis(buildWhatsThis(maximizeLibraryTitle, maximizeLibraryText));
     createVisibilityControl(pViewMaximizeLibrary,
@@ -411,9 +389,10 @@ void WMainMenuBar::initialize() {
     QString autoDJTitle = tr("Show Auto DJ");
     QString autoDJText = tr("Switch to the Auto DJ view.");
     auto* pViewAutoDJ = new QAction(autoDJTitle, this);
-    pViewAutoDJ->setShortcut(QKeySequence(m_pKbdConfig->getValue(
-            ConfigKey("[KeyboardShortcuts]", "ViewMenu_ShowAutoDJ"),
-            tr("Ctrl+9", "Menubar|View|Show Auto DJ"))));
+    m_pKeyboard->registerMenuBarActionSetShortcut(
+            pViewAutoDJ,
+            ConfigKey(kKbdShortcutsGroup, QStringLiteral("ViewMenu_ShowAutoDJ")),
+            QStringLiteral("Ctrl+9"));
     pViewAutoDJ->setStatusTip(autoDJText);
     pViewAutoDJ->setWhatsThis(buildWhatsThis(autoDJTitle, autoDJText));
     pViewAutoDJ->setCheckable(false);
@@ -430,7 +409,7 @@ void WMainMenuBar::initialize() {
     // newer macOS versions there might be issues with getting F11 working.
     // https://github.com/mixxxdj/mixxx/pull/3011#issuecomment-678678328
 #ifndef __APPLE__
-    shortcuts << safeKeySequence("F11");
+    shortcuts << QStringLiteral("F11");
 #endif
     QKeySequence osShortcut = QKeySequence::FullScreen;
     // Note(ronso0) Only add the OS shortcut if it's not empty and not F11.
@@ -444,7 +423,6 @@ void WMainMenuBar::initialize() {
     }
 
     pViewFullScreen->setShortcuts(shortcuts);
-    pViewFullScreen->setShortcutContext(Qt::ApplicationShortcut);
     pViewFullScreen->setCheckable(true);
     pViewFullScreen->setChecked(false);
     pViewFullScreen->setStatusTip(fullScreenText);
@@ -473,15 +451,11 @@ void WMainMenuBar::initialize() {
         QString vinylControlTitle = tr("Enable Vinyl Control &%1").arg(i + 1);
         auto* vc_checkbox = new QAction(vinylControlTitle, this);
         m_vinylControlEnabledActions.push_back(vc_checkbox);
-
-        QString binding = m_pKbdConfig->getValue(
-            ConfigKey("[KeyboardShortcuts]",
-                    QString("OptionsMenu_EnableVinyl%1").arg(i + 1)),
-            vinylControlDefaultKeyBinding(i));
-        if (!binding.isEmpty()) {
-            vc_checkbox->setShortcut(safeKeySequence(binding));
-            vc_checkbox->setShortcutContext(Qt::ApplicationShortcut);
-        }
+        m_pKeyboard->registerMenuBarActionSetShortcut(
+                vc_checkbox,
+                ConfigKey(QStringLiteral("[KeyboardShortcuts]"),
+                        QStringLiteral("OptionsMenu_EnableVinyl%1").arg(i + 1)),
+                vinylControlDefaultKeyBinding(i));
 
         // Either check or uncheck the vinyl control menu item depending on what
         // it was saved as.
@@ -504,11 +478,10 @@ void WMainMenuBar::initialize() {
     QString recordTitle = tr("&Record Mix");
     QString recordText = tr("Record your mix to a file");
     auto* pOptionsRecord = new QAction(recordTitle, this);
-    pOptionsRecord->setShortcut(
-            safeKeySequence(m_pKbdConfig->getValue(
-                    ConfigKey("[KeyboardShortcuts]", "OptionsMenu_RecordMix"),
-                    QStringLiteral("Ctrl+R"))));
-    pOptionsRecord->setShortcutContext(Qt::ApplicationShortcut);
+    m_pKeyboard->registerMenuBarActionSetShortcut(
+            pOptionsRecord,
+            ConfigKey(kKbdShortcutsGroup, QStringLiteral("OptionsMenu_RecordMix")),
+            QStringLiteral("Ctrl+R"));
     pOptionsRecord->setCheckable(true);
     pOptionsRecord->setStatusTip(recordText);
     pOptionsRecord->setWhatsThis(buildWhatsThis(recordTitle, recordText));
@@ -523,12 +496,11 @@ void WMainMenuBar::initialize() {
     QString broadcastingTitle = tr("Enable Live &Broadcasting");
     QString broadcastingText = tr("Stream your mixes to a shoutcast or icecast server");
     auto* pOptionsBroadcasting = new QAction(broadcastingTitle, this);
-    pOptionsBroadcasting->setShortcut(
-            safeKeySequence(m_pKbdConfig->getValue(
-                    ConfigKey("[KeyboardShortcuts]",
-                            "OptionsMenu_EnableLiveBroadcasting"),
-                    QStringLiteral("Ctrl+L"))));
-    pOptionsBroadcasting->setShortcutContext(Qt::ApplicationShortcut);
+    m_pKeyboard->registerMenuBarActionSetShortcut(
+            pOptionsBroadcasting,
+            ConfigKey(kKbdShortcutsGroup,
+                    QStringLiteral("OptionsMenu_EnableLiveBroadcasting")),
+            tr("Ctrl+L"));
     pOptionsBroadcasting->setCheckable(true);
     pOptionsBroadcasting->setStatusTip(broadcastingText);
     pOptionsBroadcasting->setWhatsThis(buildWhatsThis(broadcastingTitle, broadcastingText));
@@ -552,11 +524,10 @@ void WMainMenuBar::initialize() {
                                         QStringLiteral("Enabled")),
                     true);
     auto* pOptionsKeyboard = new QAction(keyboardShortcutTitle, this);
-    pOptionsKeyboard->setShortcut(
-            safeKeySequence(m_pKbdConfig->getValue(
-                    ConfigKey("[KeyboardShortcuts]", "OptionsMenu_EnableShortcuts"),
-                    QStringLiteral("Ctrl+`"))));
-    pOptionsKeyboard->setShortcutContext(Qt::ApplicationShortcut);
+    m_pKeyboard->registerMenuBarActionSetShortcut(
+            pOptionsKeyboard,
+            ConfigKey(kKbdShortcutsGroup, QStringLiteral("OptionsMenu_EnableShortcuts")),
+            QStringLiteral("Ctrl+`"));
     pOptionsKeyboard->setCheckable(true);
     pOptionsKeyboard->setChecked(keyboardShortcutsEnabled);
     pOptionsKeyboard->setStatusTip(keyboardShortcutText);
@@ -570,11 +541,10 @@ void WMainMenuBar::initialize() {
     QString preferencesTitle = tr("&Preferences");
     QString preferencesText = tr("Change Mixxx settings (e.g. playback, MIDI, controls)");
     auto* pOptionsPreferences = new QAction(preferencesTitle, this);
-    pOptionsPreferences->setShortcut(
-            safeKeySequence(m_pKbdConfig->getValue(
-                    ConfigKey("[KeyboardShortcuts]", "OptionsMenu_Preferences"),
-                    showPreferencesKeyBinding())));
-    pOptionsPreferences->setShortcutContext(Qt::ApplicationShortcut);
+    m_pKeyboard->registerMenuBarActionSetShortcut(
+            pOptionsPreferences,
+            ConfigKey(kKbdShortcutsGroup, QStringLiteral("OptionsMenu_Preferences")),
+            showPreferencesKeyBinding());
     pOptionsPreferences->setStatusTip(preferencesText);
     pOptionsPreferences->setWhatsThis(buildWhatsThis(preferencesTitle, preferencesText));
     pOptionsPreferences->setMenuRole(QAction::PreferencesRole);
@@ -593,10 +563,10 @@ void WMainMenuBar::initialize() {
         QString reloadSkinTitle = tr("&Reload Skin");
         QString reloadSkinText = tr("Reload the skin");
         auto* pDeveloperReloadSkin = new QAction(reloadSkinTitle, this);
-        pDeveloperReloadSkin->setShortcut(
-                safeKeySequence(m_pKbdConfig->getValue(
-                        ConfigKey("[KeyboardShortcuts]", "OptionsMenu_ReloadSkin"),
-                        QStringLiteral("Ctrl+Shift+R"))));
+        m_pKeyboard->registerMenuBarActionSetShortcut(
+                pDeveloperReloadSkin,
+                ConfigKey(kKbdShortcutsGroup, QStringLiteral("OptionsMenu_ReloadSkin")),
+                QStringLiteral("Ctrl+Shift+R"));
         pDeveloperReloadSkin->setShortcutContext(Qt::ApplicationShortcut);
         pDeveloperReloadSkin->setStatusTip(reloadSkinText);
         pDeveloperReloadSkin->setWhatsThis(buildWhatsThis(reloadSkinTitle, reloadSkinText));
@@ -606,10 +576,10 @@ void WMainMenuBar::initialize() {
         QString developerToolsTitle = tr("Developer &Tools");
         QString developerToolsText = tr("Opens the developer tools dialog");
         auto* pDeveloperTools = new QAction(developerToolsTitle, this);
-        pDeveloperTools->setShortcut(
-                safeKeySequence(m_pKbdConfig->getValue(
-                        ConfigKey("[KeyboardShortcuts]", "OptionsMenu_DeveloperTools"),
-                        QStringLiteral("Ctrl+Shift+T"))));
+        m_pKeyboard->registerMenuBarActionSetShortcut(
+                pDeveloperTools,
+                ConfigKey(kKbdShortcutsGroup, QStringLiteral("OptionsMenu_DeveloperTools")),
+                QStringLiteral("Ctrl+Shift+T"));
         pDeveloperTools->setShortcutContext(Qt::ApplicationShortcut);
         pDeveloperTools->setCheckable(true);
         pDeveloperTools->setChecked(false);
@@ -626,10 +596,10 @@ void WMainMenuBar::initialize() {
         QString enableExperimentToolsText = tr(
             "Enables experiment mode. Collects stats in the EXPERIMENT tracking bucket.");
         auto* pDeveloperStatsExperiment = new QAction(enableExperimentTitle, this);
-        pDeveloperStatsExperiment->setShortcut(
-                safeKeySequence(m_pKbdConfig->getValue(
-                        ConfigKey("[KeyboardShortcuts]", "OptionsMenu_DeveloperStatsExperiment"),
-                        QStringLiteral("Ctrl+Shift+E"))));
+        m_pKeyboard->registerMenuBarActionSetShortcut(pDeveloperStatsExperiment,
+                ConfigKey(kKbdShortcutsGroup,
+                        QStringLiteral("OptionsMenu_DeveloperStatsExperiment")),
+                QStringLiteral("Ctrl+Shift+E"));
         pDeveloperStatsExperiment->setShortcutContext(Qt::ApplicationShortcut);
         pDeveloperStatsExperiment->setStatusTip(enableExperimentToolsText);
         pDeveloperStatsExperiment->setWhatsThis(buildWhatsThis(
@@ -646,10 +616,10 @@ void WMainMenuBar::initialize() {
         QString enableBaseToolsText = tr(
             "Enables base mode. Collects stats in the BASE tracking bucket.");
         auto* pDeveloperStatsBase = new QAction(enableBaseTitle, this);
-        pDeveloperStatsBase->setShortcut(
-                safeKeySequence(m_pKbdConfig->getValue(
-                        ConfigKey("[KeyboardShortcuts]", "OptionsMenu_DeveloperStatsBase"),
-                        QStringLiteral("Ctrl+Shift+B"))));
+        m_pKeyboard->registerMenuBarActionSetShortcut(
+                pDeveloperStatsBase,
+                ConfigKey(kKbdShortcutsGroup, QStringLiteral("OptionsMenu_DeveloperStatsBase")),
+                QStringLiteral("Ctrl+Shift+B"));
         pDeveloperStatsBase->setShortcutContext(Qt::ApplicationShortcut);
         pDeveloperStatsBase->setStatusTip(enableBaseToolsText);
         pDeveloperStatsBase->setWhatsThis(buildWhatsThis(
@@ -665,13 +635,14 @@ void WMainMenuBar::initialize() {
         // "D" cannot be used with Alt here as it is already by the Developer menu
         QString scriptDebuggerTitle = tr("Deb&ugger Enabled");
         QString scriptDebuggerText = tr("Enables the debugger during skin parsing");
-        bool scriptDebuggerEnabled = m_pConfig->getValueString(
-            ConfigKey("[ScriptDebugger]", "Enabled")) == "1";
+        bool scriptDebuggerEnabled = m_pConfig->getValue<bool>(ConfigKey(
+                QStringLiteral("[ScriptDebugger]"),
+                QStringLiteral("Enabled")));
         auto* pDeveloperDebugger = new QAction(scriptDebuggerTitle, this);
-        pDeveloperDebugger->setShortcut(
-                safeKeySequence(m_pKbdConfig->getValue(
-                        ConfigKey("[KeyboardShortcuts]", "DeveloperMenu_EnableDebugger"),
-                        QStringLiteral("Ctrl+Shift+D"))));
+        m_pKeyboard->registerMenuBarActionSetShortcut(
+                pDeveloperDebugger,
+                ConfigKey(kKbdShortcutsGroup, QStringLiteral("DeveloperMenu_EnableDebugger")),
+                QStringLiteral("Ctrl+Shift+D"));
         pDeveloperDebugger->setShortcutContext(Qt::ApplicationShortcut);
         pDeveloperDebugger->setWhatsThis(buildWhatsThis(keyboardShortcutTitle, keyboardShortcutText));
         pDeveloperDebugger->setCheckable(true);
@@ -921,14 +892,14 @@ void WMainMenuBar::hideMenuBar() {
     if (isNativeMenuBar()) {
         return;
     }
-    if (m_pConfig->getValue<bool>(ConfigKey("[Config]", "hide_menubar"), false)) {
+    if (m_pConfig->getValue<bool>(kHideMenuCfgKey, false)) {
         // don't use setHidden(true) because Alt hotkeys wouldn't work anymore
         setFixedHeight(0);
     }
 }
 
 void WMainMenuBar::slotAutoHideMenuBarToggled(bool autoHide) {
-    m_pConfig->setValue(ConfigKey("[Config]", "hide_menubar"), autoHide ? 1 : 0);
+    m_pConfig->setValue(kHideMenuCfgKey, autoHide);
     // Trigger slotUpdateMenuBarAltKeyConnection() inorder to get Alt work immediately
     emit menubarAutoHideChanged(autoHide);
     // Just in case it was hidden after toggling the menu action
@@ -962,8 +933,8 @@ void WMainMenuBar::slotDeveloperStatsExperiment(bool enable) {
 }
 
 void WMainMenuBar::slotDeveloperDebugger(bool toggle) {
-    m_pConfig->set(ConfigKey("[ScriptDebugger]","Enabled"),
-                   ConfigValue(toggle ? 1 : 0));
+    m_pConfig->setValue(ConfigKey(QStringLiteral("[ScriptDebugger]"), QStringLiteral("Enabled")),
+            toggle);
 }
 
 void WMainMenuBar::slotVisitUrl(const QUrl& url) {

--- a/src/widget/wmainmenubar.h
+++ b/src/widget/wmainmenubar.h
@@ -10,6 +10,7 @@
 #include "preferences/usersettings.h"
 
 class QAction;
+class KeyboardEventFilter;
 
 class VisibilityControlConnection : public QObject {
     Q_OBJECT
@@ -34,8 +35,9 @@ class VisibilityControlConnection : public QObject {
 class WMainMenuBar : public QMenuBar {
     Q_OBJECT
   public:
-    WMainMenuBar(QWidget* pParent, UserSettingsPointer pConfig,
-                 ConfigObject<ConfigValueKbd>* pKbdConfig);
+    WMainMenuBar(QWidget* pParent,
+            UserSettingsPointer pConfig,
+            std::shared_ptr<KeyboardEventFilter> pKbd);
 #ifndef __APPLE__
     void hideMenuBar();
     void showMenuBar();
@@ -112,7 +114,8 @@ class WMainMenuBar : public QMenuBar {
 
     UserSettingsPointer m_pConfig;
     QAction* m_pViewKeywheel;
-    ConfigObject<ConfigValueKbd>* m_pKbdConfig;
+    // TODO KeyboardEventFilterPointer ??
+    std::shared_ptr<KeyboardEventFilter> m_pKeyboard;
     QList<QAction*> m_loadToDeckActions;
     QList<QAction*> m_vinylControlEnabledActions;
 };


### PR DESCRIPTION
Yeeiij, finally!
When keyboard shortcuts are toggled On/Off, the widget tooltips are adjusted accordingly.
When the keyboard mapping file has been changed (or removed), tooltips and the mapping are rebuilt.
Same applies to **menubar** shortcuts.

As before, we look for the user's `Custom.kbd.cfg` first, then use the built-in mapping based on the selected locale.
____
Also adds a new tooltip option: Keyboard shortcuts only
____

Fixes #9814 
Update for the Manual is https://github.com/mixxxdj/manual/pull/735