### PR TITLE
FindSndFile: Link FLAC in static builds

### DIFF
--- a/cmake/modules/FindSndFile.cmake
+++ b/cmake/modules/FindSndFile.cmake
@@ -43,6 +43,8 @@ The following cache variables may also be set:
 
 #]=======================================================================]
 
+include(IsStaticLibrary)
+
 find_package(PkgConfig QUIET)
 if(PkgConfig_FOUND)
   pkg_check_modules(PC_SndFile QUIET sndfile)
@@ -94,5 +96,14 @@ if(SndFile_FOUND)
         INTERFACE_COMPILE_OPTIONS "${PC_SndFile_CFLAGS_OTHER}"
         INTERFACE_INCLUDE_DIRECTORIES "${SndFile_INCLUDE_DIR}"
     )
+    is_static_library(SndFile_IS_STATIC SndFile::sndfile)
+    if(SndFile_IS_STATIC)
+      find_package(FLAC)
+      if(FLAC_FOUND)
+        set_property(TARGET SndFile::sndfile APPEND PROPERTY INTERFACE_LINK_LIBRARIES
+          FLAC::FLAC
+        )
+      endif()
+    endif()
   endif()
 endif()


### PR DESCRIPTION
This should fix some linker errors in static builds on Linux ([before](https://github.com/fwcd/m1xxx/actions/runs/8631235981/job/23659220058) vs. [after](https://github.com/fwcd/m1xxx/actions/runs/8635409329/job/23678805859)):

```
/usr/bin/ld: /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux-release/lib/libsndfile.a(flac.c.o): in function `flac_close':
flac.c:(.text+0x958): undefined reference to `FLAC__metadata_object_delete'
/usr/bin/ld: flac.c:(.text+0x9d6): undefined reference to `FLAC__stream_encoder_finish'
/usr/bin/ld: flac.c:(.text+0x9e0): undefined reference to `FLAC__stream_encoder_delete'
/usr/bin/ld: /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux-release/lib/libsndfile.a(flac.c.o): in function `flac_write_header':
flac.c:(.text+0xd37): undefined reference to `FLAC__metadata_object_vorbiscomment_entry_from_name_value_pair'
/usr/bin/ld: flac.c:(.text+0xd4a): undefined reference to `FLAC__metadata_object_vorbiscomment_append_comment'
/usr/bin/ld: flac.c:(.text+0xd65): undefined reference to `FLAC__stream_encoder_set_metadata'
/usr/bin/ld: flac.c:(.text+0xd91): undefined reference to `FLAC__stream_encoder_init_stream'
/usr/bin/ld: flac.c:(.text+0xec7): undefined reference to `FLAC__StreamEncoderInitStatusString'
/usr/bin/ld: flac.c:(.text+0xef2): undefined reference to `FLAC__metadata_object_new'
/usr/bin/ld: /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux-release/lib/libsndfile.a(flac.c.o): in function `sf_flac_meta_callback':
flac.c:(.text+0x10ac): undefined reference to `FLAC__metadata_object_vorbiscomment_find_entry_from'
/usr/bin/ld: /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux-release/lib/libsndfile.a(flac.c.o): in function `flac_enc_init':
flac.c:(.text+0x1d50): undefined reference to `FLAC__stream_encoder_delete'
/usr/bin/ld: flac.c:(.text+0x1d55): undefined reference to `FLAC__stream_encoder_new'
/usr/bin/ld: flac.c:(.text+0x1d70): undefined reference to `FLAC__stream_encoder_set_channels'
/usr/bin/ld: flac.c:(.text+0x1d83): undefined reference to `FLAC__stream_encoder_set_sample_rate'
/usr/bin/ld: flac.c:(.text+0x1d97): undefined reference to `FLAC__stream_encoder_set_bits_per_sample'
/usr/bin/ld: flac.c:(.text+0x1dae): undefined reference to `FLAC__stream_encoder_set_compression_level'
```