### PR TITLE
FindSndFile: Link mpg123 in static builds

### DIFF
--- a/cmake/modules/FindSndFile.cmake
+++ b/cmake/modules/FindSndFile.cmake
@@ -105,11 +105,14 @@ if(SndFile_FOUND)
         )
       endif()
 
-      find_package(mpg123 CONFIG)
-      if(mpg123_FOUND)
-        set_property(TARGET SndFile::sndfile APPEND PROPERTY INTERFACE_LINK_LIBRARIES
-          MPG123::libmpg123
-        )
+      # The mpg123 dependency was introduced in libsndfile 1.1.0
+      if(SndFile_VERSION_MAJOR GREATER 1 OR (SndFile_VERSION_MAJOR EQUAL 1 AND SndFile_VERSION_MINOR GREATER_EQUAL 1))
+        find_package(mpg123 CONFIG)
+        if(mpg123_FOUND)
+          set_property(TARGET SndFile::sndfile APPEND PROPERTY INTERFACE_LINK_LIBRARIES
+            MPG123::libmpg123
+          )
+        endif()
       endif()
     endif()
   endif()

--- a/cmake/modules/FindSndFile.cmake
+++ b/cmake/modules/FindSndFile.cmake
@@ -104,6 +104,13 @@ if(SndFile_FOUND)
           FLAC::FLAC
         )
       endif()
+
+      find_package(mpg123 CONFIG)
+      if(mpg123_FOUND)
+        set_property(TARGET SndFile::sndfile APPEND PROPERTY INTERFACE_LINK_LIBRARIES
+          MPG123::libmpg123
+        )
+      endif()
     endif()
   endif()
 endif()

--- a/cmake/modules/FindSndFile.cmake
+++ b/cmake/modules/FindSndFile.cmake
@@ -106,7 +106,7 @@ if(SndFile_FOUND)
       endif()
 
       # The mpg123 dependency was introduced in libsndfile 1.1.0
-      if(SndFile_VERSION_MAJOR GREATER 1 OR (SndFile_VERSION_MAJOR EQUAL 1 AND SndFile_VERSION_MINOR GREATER_EQUAL 1))
+      if(SndFile_VERSION VERSION_GREATER_EQUAL "1.1.0")
         find_package(mpg123 CONFIG)
         if(mpg123_FOUND)
           set_property(TARGET SndFile::sndfile APPEND PROPERTY INTERFACE_LINK_LIBRARIES

--- a/cmake/modules/FindSndFile.cmake
+++ b/cmake/modules/FindSndFile.cmake
@@ -43,6 +43,8 @@ The following cache variables may also be set:
 
 #]=======================================================================]
 
+include(IsStaticLibrary)
+
 find_package(PkgConfig QUIET)
 if(PkgConfig_FOUND)
   pkg_check_modules(PC_SndFile QUIET sndfile)
@@ -94,5 +96,14 @@ if(SndFile_FOUND)
         INTERFACE_COMPILE_OPTIONS "${PC_SndFile_CFLAGS_OTHER}"
         INTERFACE_INCLUDE_DIRECTORIES "${SndFile_INCLUDE_DIR}"
     )
+    is_static_library(SndFile_IS_STATIC SndFile::sndfile)
+    if(SndFile_IS_STATIC)
+      find_package(FLAC)
+      if(FLAC_FOUND)
+        set_property(TARGET SndFile::sndfile APPEND PROPERTY INTERFACE_LINK_LIBRARIES
+          FLAC::FLAC
+        )
+      endif()
+    endif()
   endif()
 endif()


### PR DESCRIPTION
### Based on #13085 

This fixes another linker error in static builds that link `libsndfile` ([before](https://github.com/fwcd/m1xxx/actions/runs/8635409329/job/23678805859) vs. [after](https://github.com/fwcd/m1xxx/actions/runs/8638645976/job/23683484417)):

```
/usr/bin/ld: /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux-release/lib/libsndfile.a(mpeg_decode.c.o): in function `mpeg_dec_byterate':
mpeg_decode.c:(.text+0x36): undefined reference to `mpg123_info2'
/usr/bin/ld: /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux-release/lib/libsndfile.a(mpeg_decode.c.o): in function `mpeg_dec_seek':
mpeg_decode.c:(.text+0xa6): undefined reference to `mpg123_seek'
/usr/bin/ld: /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux-release/lib/libsndfile.a(mpeg_decode.c.o): in function `mpeg_dec_read_f':
mpeg_decode.c:(.text+0x112): undefined reference to `mpg123_read'
/usr/bin/ld: /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux-release/lib/libsndfile.a(mpeg_decode.c.o): in function `mpeg_dec_close':
mpeg_decode.c:(.text+0x273): undefined reference to `mpg123_close'
/usr/bin/ld: mpeg_decode.c:(.text+0x27c): undefined reference to `mpg123_delete'
/usr/bin/ld: /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux-release/lib/libsndfile.a(mpeg_decode.c.o): in function `mpeg_dec_read_s':
mpeg_decode.c:(.text+0x3c0): undefined reference to `mpg123_read'
/usr/bin/ld: /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux-release/lib/libsndfile.a(mpeg_decode.c.o): in function `mpeg_dec_read_i':
mpeg_decode.c:(.text+0x500): undefined reference to `mpg123_read'
/usr/bin/ld: /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux-release/lib/libsndfile.a(mpeg_decode.c.o): in function `mpeg_dec_read_d':
mpeg_decode.c:(.text+0x64a): undefined reference to `mpg123_read'
/usr/bin/ld: /home/runner/work/m1xxx/m1xxx/vcpkg/installed/x64-linux-release/lib/libsndfile.a(mpeg_decode.c.o): in function `mpeg_decoder_init':
mpeg_decode.c:(.text+0x7d9): undefined reference to `mpg123_init'
```