### PR TITLE
(fix) Slider tooltip: consider orientation for up/down shortcut tooltips + add support for WKnobComposed

### DIFF
--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -2404,7 +2404,7 @@ void LegacySkinParser::setupConnections(const QDomNode& node, WBaseWidget* pWidg
                     ConfigKey subkey;
                     QString shortcut;
 
-                    if (pSlider->isHorizontal()) {
+                    if (pSlider->tryParseHorizontal(node)) {
                         subkey = configKey;
                         subkey.item += "_up";
                         shortcut = m_pKeyboard->getKeyboardConfig()->getValueString(subkey);

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -2399,12 +2399,13 @@ void LegacySkinParser::setupConnections(const QDomNode& node, WBaseWidget* pWidg
                     subkey.item += "_toggle";
                     shortcut = m_pKeyboard->getKeyboardConfig()->getValueString(subkey);
                     addShortcutToToolTip(pWidget, shortcut, tr("toggle"));
-                } else if ((pSlider = qobject_cast<const WSliderComposed*>(pWidget->toQWidget()))) {
+                } else if ((pSlider = qobject_cast<const WSliderComposed*>(pWidget->toQWidget())) ||
+                        qobject_cast<const WKnobComposed*>(pWidget->toQWidget())) {
                     // check for "_up", "_down", "_up_small", "_down_small"
                     ConfigKey subkey;
                     QString shortcut;
 
-                    if (pSlider->tryParseHorizontal(node)) {
+                    if (pSlider && pSlider->tryParseHorizontal(node)) {
                         subkey = configKey;
                         subkey.item += "_up";
                         shortcut = m_pKeyboard->getKeyboardConfig()->getValueString(subkey);
@@ -2424,7 +2425,7 @@ void LegacySkinParser::setupConnections(const QDomNode& node, WBaseWidget* pWidg
                         subkey.item += "_down_small";
                         shortcut = m_pKeyboard->getKeyboardConfig()->getValueString(subkey);
                         addShortcutToToolTip(pWidget, shortcut, tr("left small"));
-                    } else {
+                    } else { // vertical slider of knob
                         subkey = configKey;
                         subkey.item += "_up";
                         shortcut = m_pKeyboard->getKeyboardConfig()->getValueString(subkey);

--- a/src/widget/wslidercomposed.h
+++ b/src/widget/wslidercomposed.h
@@ -9,7 +9,7 @@
 class QDomNode;
 class SkinContext;
 
-/** A widget for a slider composed of a background pixmap and a handle. */
+/// A widget for a slider composed of a background pixmap and a handle.
 class WSliderComposed : public WWidget  {
     Q_OBJECT
   public:
@@ -22,11 +22,15 @@ class WSliderComposed : public WWidget  {
             Paintable::DrawMode drawMode,
             double scaleFactor);
     void setHandlePixmap(
-            bool bHorizontal,
             const PixmapSource& sourceHandle,
             Paintable::DrawMode mode,
             double scaleFactor);
-    inline bool isHorizontal() const { return m_bHorizontal; };
+    // This is called by LegacySkinParser::setupConnections() before setup()
+    // because it needs 'horizontal' for picking the correct keyboard shortcut
+    // command (left/right or up/down.
+    // Doesn't recognize variables, hence we don't store the result in m_bHorizontal,
+    // that's done in setup() where we have a SkinContext, i.e. variable support.
+    bool tryParseHorizontal(const QDomNode& node) const;
     void inputActivity();
 
   public slots:


### PR DESCRIPTION
Horizontal sliders were using the keyboard shortcut hints of the default (vertical) slider.
This was broken by 5f86ed50007f7a21a21bd93469bdc5aff7be253e

### Fix
Parse the 'Horizontal' property separately so it's available in `LegacySkinParser::setupConnections()` already (which does the shortcut setup), before WSliderComposed::setup() is called. setup() parses again, but this time with SkinContext (variable support, for whoever needs variable orientation in a slider template...)
Done with a stripped conglomerate of SkinContext member functions (or we add a dedicated static?)
(I have no patience to check whether 5f86ed50007f7a21a21bd93469bdc5aff7be253e can partially be reverted without breaking something else)
There's an alternative which requires passing a SkinContext pointer (unneeded for 99% of the widgets) which I may outline if desired.

### By-catch:
Add shortcut tooltip support for WKnobComposed. (I though we had this before at some point? git history says No)