### PR TITLE
fix: add missing spacer in interface preference

### DIFF
--- a/src/preferences/dialog/dlgprefinterfacedlg.ui
+++ b/src/preferences/dialog/dlgprefinterfacedlg.ui
@@ -282,6 +282,19 @@
      </layout>
     </widget>
    </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>1</verstretch>
+       </sizepolicy>
+      </property>
+    </spacer>
+   </item>
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>


### PR DESCRIPTION
Before:

![image](https://github.com/mixxxdj/mixxx/assets/7086688/142ac97b-9ed8-4444-876b-37fdf6cc39ee)

After:

![image](https://github.com/mixxxdj/mixxx/assets/7086688/97afd88d-b0cd-45f8-af0e-9cd8d5f51a17)
