### PR TITLE
ControllerScriptInterfaceLegacy: Fix typo

### DIFF
--- a/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
+++ b/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
@@ -509,7 +509,7 @@ int ControllerScriptInterfaceLegacy::beginTimer(
 void ControllerScriptInterfaceLegacy::stopTimer(int timerId) {
     if (!m_timers.contains(timerId)) {
         m_pScriptEngineLegacy->logOrThrowError(QStringLiteral(
-                "Tried to kill Timer \"%1\" that does not exists")
+                "Tried to kill Timer \"%1\" that does not exist")
                                                        .arg(timerId));
         return;
     }


### PR DESCRIPTION
This fixes a small grammatical mistake in `ControllerScriptInterfaceLegacy`