### PR TITLE
Reduce log noise with HID device

### DIFF
--- a/src/controllers/controller.cpp
+++ b/src/controllers/controller.cpp
@@ -5,6 +5,7 @@
 
 #include "controllers/scripting/legacy/controllerscriptenginelegacy.h"
 #include "moc_controller.cpp"
+#include "util/cmdlineargs.h"
 #include "util/screensaver.h"
 
 namespace {
@@ -129,7 +130,9 @@ void Controller::receive(const QByteArray& data, mixxx::Duration timestamp) {
     triggerActivity();
 
     int length = data.size();
-    if (m_logInput().isDebugEnabled()) {
+    if (CmdlineArgs::Instance()
+                    .getControllerDebug() &&
+            m_logInput().isDebugEnabled()) {
         // Formatted packet display
         QString message = QString("t:%2, %3 bytes:\n")
                                   .arg(timestamp.formatMillisWithUnit(),

--- a/src/controllers/hid/hidioglobaloutputreportfifo.cpp
+++ b/src/controllers/hid/hidioglobaloutputreportfifo.cpp
@@ -3,6 +3,7 @@
 #include <hidapi.h>
 
 #include "controllers/hid/hiddevice.h"
+#include "util/cmdlineargs.h"
 #include "util/compatibility/qmutex.h"
 #include "util/runtimeloggingcategory.h"
 #include "util/string.h"
@@ -77,7 +78,7 @@ bool HidIoGlobalOutputReportFifo::sendNextReportDataset(QMutex* pHidDeviceAndPol
 
     hidDeviceLock.unlock();
 
-    if (result != -1) {
+    if (result != -1 && CmdlineArgs::Instance().getControllerDebug()) {
         qCDebug(logOutput) << "t:" << startOfHidWrite.formatMillisWithUnit()
                            << " " << result << "bytes (including ReportID of"
                            << static_cast<quint8>(reportToSend[0])


### PR DESCRIPTION
This is a follow up on #13010. 
Not sure how come I didn't notice these log output previously as there are quite noisy too. I suspect my dev (The S4 Mk3 screen) branch which I use all the time must already have the fix 