### PR TITLE
Playlists: improve table update after deleting (purging) track files

### DIFF
--- a/src/library/dao/playlistdao.h
+++ b/src/library/dao/playlistdao.h
@@ -96,7 +96,7 @@ class PlaylistDAO : public QObject, public virtual DAO {
     // Returns the maximum position of the given playlist
     int getMaxPosition(const int playlistId) const;
     // Remove a track from all playlists
-    void removeTracksFromPlaylists(const QList<TrackId>& trackIds);
+    void removeTracksFromPlaylists(const QList<TrackId>& trackIds, bool purged = false);
     // removes all hidden and purged Tracks from the playlist
     void removeHiddenTracks(const int playlistId);
     // Remove a track from a playlist
@@ -139,7 +139,12 @@ class PlaylistDAO : public QObject, public virtual DAO {
     void lockChanged(const QSet<int>& playlistIds);
     void trackAdded(int playlistId, TrackId trackId, int position);
     void trackRemoved(int playlistId, TrackId trackId, int position);
-    void tracksChanged(const QSet<int>& playlistIds); // added/removed/reordered
+    // added / removed / un/locked. Triggers playlist features to update the sidebar
+    void playlistContentChanged(const QSet<int>& playlistIds);
+    // Separate signals for PlaylistTableModel
+    void tracksAdded(const QSet<int>& playlistIds);
+    void tracksMoved(const QSet<int>& playlistIds);
+    void tracksRemoved(const QSet<int>& playlistIds);
     void tracksRemovedFromPlayedHistory(const QSet<TrackId>& playedTrackIds);
 
   private:

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -694,6 +694,18 @@ bool Library::isTrackIdInCurrentLibraryView(const TrackId& trackId) {
     }
 }
 
+void Library::slotSaveCurrentViewState() const {
+    if (m_pLibraryWidget) {
+        return m_pLibraryWidget->saveCurrentViewState();
+    }
+}
+
+void Library::slotRestoreCurrentViewState() const {
+    if (m_pLibraryWidget) {
+        return m_pLibraryWidget->restoreCurrentViewState();
+    }
+}
+
 LibraryTableModel* Library::trackTableModel() const {
     VERIFY_OR_DEBUG_ASSERT(m_pMixxxLibraryFeature) {
         return nullptr;

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -115,6 +115,8 @@ class Library: public QObject {
     void slotRequestRemoveDir(const QString& directory, LibraryRemovalType removalType);
     void slotRequestRelocateDir(const QString& previousDirectory, const QString& newDirectory);
     void onSkinLoadFinished();
+    void slotSaveCurrentViewState() const;
+    void slotRestoreCurrentViewState() const;
 
   signals:
     void showTrackModel(QAbstractItemModel* model, bool restoreState = true);

--- a/src/library/playlisttablemodel.cpp
+++ b/src/library/playlisttablemodel.cpp
@@ -21,7 +21,15 @@ PlaylistTableModel::PlaylistTableModel(QObject* parent,
           m_iPlaylistId(kInvalidPlaylistId),
           m_keepHiddenTracks(keepHiddenTracks) {
     connect(&m_pTrackCollectionManager->internalCollection()->getPlaylistDAO(),
-            &PlaylistDAO::tracksChanged,
+            &PlaylistDAO::tracksAdded,
+            this,
+            &PlaylistTableModel::playlistsChanged);
+    connect(&m_pTrackCollectionManager->internalCollection()->getPlaylistDAO(),
+            &PlaylistDAO::tracksMoved,
+            this,
+            &PlaylistTableModel::playlistsChanged);
+    connect(&m_pTrackCollectionManager->internalCollection()->getPlaylistDAO(),
+            &PlaylistDAO::tracksRemoved,
             this,
             &PlaylistTableModel::playlistsChanged);
 }
@@ -359,6 +367,7 @@ TrackModel::Capabilities PlaylistTableModel::getCapabilities() const {
             Capability::LoadToSampler |
             Capability::LoadToPreviewDeck |
             Capability::ResetPlayed |
+            Capability::RemoveFromDisk |
             Capability::Analyze;
 
     if (m_iPlaylistId !=

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -373,7 +373,7 @@ bool TrackCollection::purgeTracks(
     }
     // TODO(XXX): Move reversible actions inside transaction
     m_cueDao.deleteCuesForTracks(trackIds);
-    m_playlistDao.removeTracksFromPlaylists(trackIds);
+    m_playlistDao.removeTracksFromPlaylists(trackIds, true);
     m_analysisDao.deleteAnalyses(trackIds);
 
     // Post-processing

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -158,7 +158,7 @@ void BasePlaylistFeature::connectPlaylistDAO() {
             this,
             &BasePlaylistFeature::slotPlaylistTableChanged);
     connect(&m_playlistDao,
-            &PlaylistDAO::tracksChanged,
+            &PlaylistDAO::playlistContentChanged,
             this,
             &BasePlaylistFeature::slotPlaylistContentOrLockChanged);
     connect(&m_playlistDao,

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -1096,6 +1096,20 @@ QWidget* LegacySkinParser::parseTrackProperty(const QDomElement& node) {
             group);
     setupLabelWidget(node, pTrackProperty);
 
+    // Relay for the label's WTrackMenu (which is created only on demand):
+    // Emitted before/after deleting a track file via that menu
+    // IF that track is in the current view.
+    connect(pTrackProperty,
+            &WTrackProperty::saveCurrentViewState,
+            m_pLibrary,
+            &Library::slotSaveCurrentViewState,
+            Qt::DirectConnection);
+    connect(pTrackProperty,
+            &WTrackProperty::restoreCurrentViewState,
+            m_pLibrary,
+            &Library::slotRestoreCurrentViewState,
+            Qt::DirectConnection);
+
     connect(pPlayer,
             &BaseTrackPlayer::newTrackLoaded,
             pTrackProperty,

--- a/src/widget/wlibrary.h
+++ b/src/widget/wlibrary.h
@@ -8,6 +8,7 @@
 #include "widget/wbasewidget.h"
 
 class LibraryView;
+class WTrackTableView;
 class TrackId;
 class QDomNode;
 class SkinContext;
@@ -28,12 +29,15 @@ class WLibrary : public QStackedWidget, public WBaseWidget {
     bool registerView(const QString& name, QWidget* view);
 
     LibraryView* getActiveView() const;
-
+    WTrackTableView* getCurrentTrackTableView() const;
     // This returns true if the current view is or has a WTracksTableView and
     // contains trackId, otherwise false.
     // This is primarily used to disable the "Select track in library" track menu action
     // to avoid unintended behaviour if the current view has no tracks table.
     bool isTrackInCurrentView(const TrackId& trackId);
+
+    void saveCurrentViewState() const;
+    void restoreCurrentViewState() const;
 
     // Alpha value for row color background
     static constexpr double kDefaultTrackTableBackgroundColorOpacity = 0.125; // 12.5% opacity

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -109,7 +109,8 @@ class WTrackMenu : public QMenu {
   signals:
     void loadTrackToPlayer(TrackPointer pTrack, const QString& group, bool play = false);
     void trackMenuVisible(bool visible);
-    void restoreCurrentIndex();
+    void saveCurrentViewState();
+    void restoreCurrentViewStateOrIndex();
 
   private slots:
     // File

--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -121,4 +121,16 @@ void WTrackProperty::ensureTrackMenuIsCreated() {
         m_pTrackMenu = make_parented<WTrackMenu>(
                 this, m_pConfig, m_pLibrary, WTrackMenu::kDeckTrackMenuFeatures);
     }
+
+    // Before and after the loaded tracks file has been removed from disk,
+    // instruct the library to save and restore the current inde for
+    // keyboard/controller navigation.
+    connect(m_pTrackMenu,
+            &WTrackMenu::saveCurrentViewState,
+            this,
+            &WTrackProperty::saveCurrentViewState);
+    connect(m_pTrackMenu,
+            &WTrackMenu::restoreCurrentViewStateOrIndex,
+            this,
+            &WTrackProperty::restoreCurrentViewState);
 }

--- a/src/widget/wtrackproperty.h
+++ b/src/widget/wtrackproperty.h
@@ -25,6 +25,8 @@ class WTrackProperty : public WLabel, public TrackDropTarget {
   signals:
     void trackDropped(const QString& filename, const QString& group) override;
     void cloneDeck(const QString& sourceGroup, const QString& targetGroup) override;
+    void saveCurrentViewState();
+    void restoreCurrentViewState();
 
   public slots:
     void slotTrackLoaded(TrackPointer pTrack);

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -349,7 +349,7 @@ void WTrackTableView::initTrackMenu() {
     // after removing tracks from the view via track menu, restore a usable
     // selection/currentIndex for navigation via keyboard & controller
     connect(m_pTrackMenu,
-            &WTrackMenu::restoreCurrentIndex,
+            &WTrackMenu::restoreCurrentViewStateOrIndex,
             this,
             &WTrackTableView::slotrestoreCurrentIndex);
 }
@@ -464,7 +464,7 @@ void WTrackTableView::slotDeleteTracksFromDisk() {
     saveCurrentIndex();
     m_pTrackMenu->loadTrackModelIndices(indices);
     m_pTrackMenu->slotRemoveFromDisk();
-    // WTrackmenu emits restoreCurrentIndex()
+    // WTrackmenu emits restoreCurrentViewStateOrIndex()
 }
 
 void WTrackTableView::slotUnhide() {
@@ -512,7 +512,7 @@ void WTrackTableView::contextMenuEvent(QContextMenuEvent* event) {
 
     // Create the right-click menu
     m_pTrackMenu->popup(event->globalPos());
-    // WTrackmenu emits restoreCurrentIndex() if required
+    // WTrackmenu emits restoreCurrentViewStateOrIndex() if required
 }
 
 void WTrackTableView::onSearch(const QString& text) {


### PR DESCRIPTION
Fixes #13111 which I can actually only reproduce with main (couldn't find the change causing it).
But it doesn't hurt to get rid of the double select and have the now separate PlaylistDAO signals for
a) updating the sidebar and
b) reloading the current tracks in 2.4

Also enables _Delete Track Files_ in playlists #13112 

_Though, no matter if main or 2.4, this feels like a bandaid anyway. PlaylistDAO looks unnecessarily complex, a better solution would probably be PlaylistStorage / PlaylistSummary (Crate equivalent) like proposed by @ninomp in #4846_ 