### PR TITLE
(fix) backport: require a minimum movement before initiating the drag&drop of tracks

### DIFF
--- a/src/util/dnd.cpp
+++ b/src/util/dnd.cpp
@@ -100,6 +100,37 @@ bool allowLoadToPlayer(
     return allowLoadTrackIntoPlayingDeck;
 }
 
+// Helper function for DragAndDropHelper::mousePressed and DragAndDropHelper::mouseMoveInitiatesDrag
+bool mouseMoveInitiatesDragHelper(QMouseEvent* pEvent, bool isPress) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    const qreal x = pEvent->position().x();
+    const qreal y = pEvent->position().y();
+#else
+    const qreal x = pEvent->x();
+    const qreal y = pEvent->y();
+#endif
+
+    static qreal pressX{};
+    static qreal pressY{};
+
+    if (isPress) {
+        pressX = x;
+        pressY = y;
+        return false;
+    }
+
+    const qreal threshold = static_cast<qreal>(QApplication::startDragDistance());
+    // X and Y distance since press
+    const qreal dx = x - pressX;
+    const qreal dy = y - pressY;
+
+    // Check if the distance surpasses the threshold. Per Pythagoras Theorem:
+    // distance = sqrt(dx^2 + dy^2)
+    // We can avoid the sqrt by squaring the threshold.
+
+    return dx * dx + dy * dy >= threshold * threshold;
+}
+
 } // anonymous namespace
 
 //static
@@ -174,6 +205,18 @@ bool DragAndDropHelper::allowDeckCloneAttempt(
     }
 
     return true;
+}
+
+// static
+void DragAndDropHelper::mousePressed(QMouseEvent* pEvent) {
+    if (pEvent->button() == Qt::LeftButton) {
+        mouseMoveInitiatesDragHelper(pEvent, true);
+    }
+}
+
+// static
+bool DragAndDropHelper::mouseMoveInitiatesDrag(QMouseEvent* pEvent) {
+    return mouseMoveInitiatesDragHelper(pEvent, false);
 }
 
 //static

--- a/src/util/dnd.h
+++ b/src/util/dnd.h
@@ -51,4 +51,8 @@ class DragAndDropHelper final {
             TrackDropTarget& target,
             const QString& group,
             UserSettingsPointer pConfig);
+
+    static void mousePressed(QMouseEvent* pEvent);
+
+    static bool mouseMoveInitiatesDrag(QMouseEvent* pEvent);
 };

--- a/src/widget/wcoverart.cpp
+++ b/src/widget/wcoverart.cpp
@@ -230,21 +230,23 @@ void WCoverArt::resizeEvent(QResizeEvent* /*unused*/) {
     m_defaultCoverScaled = scaledCoverArt(m_defaultCover);
 }
 
-void WCoverArt::contextMenuEvent(QContextMenuEvent* event) {
-    event->accept();
+void WCoverArt::contextMenuEvent(QContextMenuEvent* pEvent) {
+    pEvent->accept();
     if (m_loadedTrack) {
         m_pMenu->setCoverArt(m_lastRequestedCover);
-        m_pMenu->popup(event->globalPos());
+        m_pMenu->popup(pEvent->globalPos());
     }
 }
 
-void WCoverArt::mousePressEvent(QMouseEvent* event) {
+void WCoverArt::mousePressEvent(QMouseEvent* pEvent) {
     if (!m_bEnable) {
         return;
     }
 
-    if (event->button() == Qt::LeftButton) {
-        event->accept();
+    DragAndDropHelper::mousePressed(pEvent);
+
+    if (pEvent->button() == Qt::LeftButton) {
+        pEvent->accept();
         // do nothing if left button is pressed,
         // wait for button release
         m_clickTimer.setSingleShot(true);
@@ -252,12 +254,12 @@ void WCoverArt::mousePressEvent(QMouseEvent* event) {
     }
 }
 
-void WCoverArt::mouseReleaseEvent(QMouseEvent* event) {
+void WCoverArt::mouseReleaseEvent(QMouseEvent* pEvent) {
     if (!m_bEnable) {
         return;
     }
 
-    if (event->button() == Qt::LeftButton && m_loadedTrack &&
+    if (pEvent->button() == Qt::LeftButton && m_loadedTrack &&
             m_clickTimer.isActive()) { // init/close fullsize cover
         if (m_pDlgFullSize->isVisible()) {
             m_pDlgFullSize->close();
@@ -271,29 +273,29 @@ void WCoverArt::mouseReleaseEvent(QMouseEvent* event) {
     } // else it was a long leftclick or a right click that's already been processed
 }
 
-void WCoverArt::mouseMoveEvent(QMouseEvent* event) {
-    if ((event->buttons().testFlag(Qt::LeftButton)) && m_loadedTrack) {
+void WCoverArt::mouseMoveEvent(QMouseEvent* pEvent) {
+    if (m_loadedTrack && DragAndDropHelper::mouseMoveInitiatesDrag(pEvent)) {
         DragAndDropHelper::dragTrack(m_loadedTrack, this, m_group);
     }
 }
 
-void WCoverArt::dragEnterEvent(QDragEnterEvent* event) {
+void WCoverArt::dragEnterEvent(QDragEnterEvent* pEvent) {
     // If group is empty then we are a library cover art widget and we don't
     // accept track drops.
     if (!m_group.isEmpty()) {
-        DragAndDropHelper::handleTrackDragEnterEvent(event, m_group, m_pConfig);
+        DragAndDropHelper::handleTrackDragEnterEvent(pEvent, m_group, m_pConfig);
     } else {
-        event->ignore();
+        pEvent->ignore();
     }
 }
 
-void WCoverArt::dropEvent(QDropEvent *event) {
+void WCoverArt::dropEvent(QDropEvent* pEvent) {
     // If group is empty then we are a library cover art widget and we don't
     // accept track drops.
     if (!m_group.isEmpty()) {
-        DragAndDropHelper::handleTrackDropEvent(event, *this, m_group, m_pConfig);
+        DragAndDropHelper::handleTrackDropEvent(pEvent, *this, m_group, m_pConfig);
     } else {
-        event->ignore();
+        pEvent->ignore();
     }
 }
 

--- a/src/widget/weffectparameternamebase.cpp
+++ b/src/widget/weffectparameternamebase.cpp
@@ -9,6 +9,7 @@
 #include "effects/effectparameterslotbase.h"
 #include "effects/effectslot.h"
 #include "moc_weffectparameternamebase.cpp"
+#include "util/dnd.h"
 #include "util/math.h"
 
 namespace {
@@ -113,14 +114,18 @@ void WEffectParameterNameBase::showNewValue(double newValue) {
     m_displayNameResetTimer.start();
 }
 
-void WEffectParameterNameBase::mousePressEvent(QMouseEvent* event) {
+void WEffectParameterNameBase::mousePressEvent(QMouseEvent* pEvent) {
     VERIFY_OR_DEBUG_ASSERT(m_pParameterSlot && m_pParameterSlot->isLoaded()) {
         return;
     }
     VERIFY_OR_DEBUG_ASSERT(m_pEffectSlot && m_pEffectSlot->isLoaded()) {
         return;
     }
-    if (event->button() == Qt::LeftButton) {
+    DragAndDropHelper::mousePressed(pEvent);
+}
+
+void WEffectParameterNameBase::mouseMoveEvent(QMouseEvent* pEvent) {
+    if (DragAndDropHelper::mouseMoveInitiatesDrag(pEvent)) {
         QDrag* drag = new QDrag(this);
         QMimeData* mimeData = new QMimeData;
 
@@ -133,29 +138,29 @@ void WEffectParameterNameBase::mousePressEvent(QMouseEvent* event) {
     }
 }
 
-void WEffectParameterNameBase::dragEnterEvent(QDragEnterEvent* event) {
+void WEffectParameterNameBase::dragEnterEvent(QDragEnterEvent* pEvent) {
     VERIFY_OR_DEBUG_ASSERT(m_pParameterSlot && m_pParameterSlot->isLoaded()) {
         return;
     }
     VERIFY_OR_DEBUG_ASSERT(m_pEffectSlot && m_pEffectSlot->isLoaded()) {
         return;
     }
-    const QString& mimeText = event->mimeData()->text();
+    const QString& mimeText = pEvent->mimeData()->text();
     QStringList mimeTextLines = mimeText.split(kMimeTextDelimiter);
     if (mimeTextLines.at(0) == mimeTextIdentifier() &&
             mimeTextLines.at(1) == m_pEffectSlot->getManifest()->uniqueId()) {
-        event->acceptProposedAction();
+        pEvent->acceptProposedAction();
     }
 }
 
-void WEffectParameterNameBase::dropEvent(QDropEvent* event) {
+void WEffectParameterNameBase::dropEvent(QDropEvent* pEvent) {
     VERIFY_OR_DEBUG_ASSERT(m_pParameterSlot && m_pParameterSlot->isLoaded()) {
         return;
     }
     VERIFY_OR_DEBUG_ASSERT(m_pEffectSlot && m_pEffectSlot->isLoaded()) {
         return;
     }
-    const QString& mimeText = event->mimeData()->text();
+    const QString& mimeText = pEvent->mimeData()->text();
     QStringList mimeTextLines = mimeText.split(kMimeTextDelimiter);
     m_pEffectSlot->swapParameters(m_pParameterSlot->parameterType(),
             m_pParameterSlot->slotNumber(),

--- a/src/widget/weffectparameternamebase.h
+++ b/src/widget/weffectparameternamebase.h
@@ -15,6 +15,7 @@ class WEffectParameterNameBase : public WLabel {
     void setup(const QDomNode& node, const SkinContext& context) override = 0;
 
     void mousePressEvent(QMouseEvent* event) override;
+    void mouseMoveEvent(QMouseEvent* event) override;
     void dragEnterEvent(QDragEnterEvent* event) override;
     void dropEvent(QDropEvent* event) override;
     QSize sizeHint() const override;

--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -82,14 +82,18 @@ void WTrackProperty::updateLabel() {
     setText("");
 }
 
-void WTrackProperty::mouseMoveEvent(QMouseEvent* event) {
-    if (event->buttons().testFlag(Qt::LeftButton) && m_pCurrentTrack) {
+void WTrackProperty::mousePressEvent(QMouseEvent* pEvent) {
+    DragAndDropHelper::mousePressed(pEvent);
+}
+
+void WTrackProperty::mouseMoveEvent(QMouseEvent* pEvent) {
+    if (m_pCurrentTrack && DragAndDropHelper::mouseMoveInitiatesDrag(pEvent)) {
         DragAndDropHelper::dragTrack(m_pCurrentTrack, this, m_group);
     }
 }
 
-void WTrackProperty::mouseDoubleClickEvent(QMouseEvent* event) {
-    Q_UNUSED(event);
+void WTrackProperty::mouseDoubleClickEvent(QMouseEvent* pEvent) {
+    Q_UNUSED(pEvent);
     if (!m_pCurrentTrack) {
         return;
     }
@@ -98,21 +102,21 @@ void WTrackProperty::mouseDoubleClickEvent(QMouseEvent* event) {
     m_pTrackMenu->showDlgTrackInfo(m_property);
 }
 
-void WTrackProperty::dragEnterEvent(QDragEnterEvent* event) {
-    DragAndDropHelper::handleTrackDragEnterEvent(event, m_group, m_pConfig);
+void WTrackProperty::dragEnterEvent(QDragEnterEvent* pEvent) {
+    DragAndDropHelper::handleTrackDragEnterEvent(pEvent, m_group, m_pConfig);
 }
 
-void WTrackProperty::dropEvent(QDropEvent* event) {
-    DragAndDropHelper::handleTrackDropEvent(event, *this, m_group, m_pConfig);
+void WTrackProperty::dropEvent(QDropEvent* pEvent) {
+    DragAndDropHelper::handleTrackDropEvent(pEvent, *this, m_group, m_pConfig);
 }
 
-void WTrackProperty::contextMenuEvent(QContextMenuEvent* event) {
-    event->accept();
+void WTrackProperty::contextMenuEvent(QContextMenuEvent* pEvent) {
+    pEvent->accept();
     if (m_pCurrentTrack) {
         ensureTrackMenuIsCreated();
         m_pTrackMenu->loadTrack(m_pCurrentTrack, m_group);
-        // Create the right-click menu
-        m_pTrackMenu->popup(event->globalPos());
+        // Show the right-click menu
+        m_pTrackMenu->popup(pEvent->globalPos());
     }
 }
 

--- a/src/widget/wtrackproperty.h
+++ b/src/widget/wtrackproperty.h
@@ -34,6 +34,7 @@ class WTrackProperty : public WLabel, public TrackDropTarget {
     void contextMenuEvent(QContextMenuEvent* event) override;
     void dragEnterEvent(QDragEnterEvent* event) override;
     void dropEvent(QDropEvent* event) override;
+    void mousePressEvent(QMouseEvent* event) override;
     void mouseMoveEvent(QMouseEvent* event) override;
     void mouseDoubleClickEvent(QMouseEvent* event) override;
 

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -550,6 +550,11 @@ void WTrackTableView::onSearch(const QString& text) {
 void WTrackTableView::onShow() {
 }
 
+void WTrackTableView::mousePressEvent(QMouseEvent* pEvent) {
+    DragAndDropHelper::mousePressed(pEvent);
+    WLibraryTableView::mousePressEvent(pEvent);
+}
+
 void WTrackTableView::mouseMoveEvent(QMouseEvent* pEvent) {
     // Only use this for drag and drop if the LeftButton is pressed we need to
     // check for this because mousetracking is activated and this function is
@@ -567,17 +572,20 @@ void WTrackTableView::mouseMoveEvent(QMouseEvent* pEvent) {
         return;
     }
     //qDebug() << "MouseMoveEvent";
-    // Iterate over selected rows and append each item's location url to a list.
-    QList<QString> locations;
-    const QModelIndexList indices = selectionModel()->selectedRows();
 
-    for (const QModelIndex& index : indices) {
-        if (!index.isValid()) {
-            continue;
+    if (DragAndDropHelper::mouseMoveInitiatesDrag(pEvent)) {
+        // Iterate over selected rows and append each item's location url to a list.
+        QList<QString> locations;
+        const QModelIndexList indices = selectionModel()->selectedRows();
+
+        for (const QModelIndex& index : indices) {
+            if (!index.isValid()) {
+                continue;
+            }
+            locations.append(trackModel->getTrackLocation(index));
         }
-        locations.append(trackModel->getTrackLocation(index));
+        DragAndDropHelper::dragTrackLocations(locations, this, "library");
     }
-    DragAndDropHelper::dragTrackLocations(locations, this, "library");
 }
 
 // Drag enter event, happens when a dragged item hovers over the track table view

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -106,6 +106,7 @@ class WTrackTableView : public WLibraryTableView {
     void selectionChanged(const QItemSelection &selected,
                           const QItemSelection &deselected) override;
 
+    void mousePressEvent(QMouseEvent* pEvent) override;
     // Mouse move event, implemented to hide the text and show an icon instead
     // when dragging.
     void mouseMoveEvent(QMouseEvent *pEvent) override;

--- a/src/widget/wtrackwidgetgroup.cpp
+++ b/src/widget/wtrackwidgetgroup.cpp
@@ -90,27 +90,31 @@ void WTrackWidgetGroup::paintEvent(QPaintEvent* pe) {
     }
 }
 
-void WTrackWidgetGroup::mouseMoveEvent(QMouseEvent* event) {
-    if (event->buttons().testFlag(Qt::LeftButton) && m_pCurrentTrack) {
+void WTrackWidgetGroup::mousePressEvent(QMouseEvent* pEvent) {
+    DragAndDropHelper::mousePressed(pEvent);
+}
+
+void WTrackWidgetGroup::mouseMoveEvent(QMouseEvent* pEvent) {
+    if (m_pCurrentTrack && DragAndDropHelper::mouseMoveInitiatesDrag(pEvent)) {
         DragAndDropHelper::dragTrack(m_pCurrentTrack, this, m_group);
     }
 }
 
-void WTrackWidgetGroup::dragEnterEvent(QDragEnterEvent* event) {
-    DragAndDropHelper::handleTrackDragEnterEvent(event, m_group, m_pConfig);
+void WTrackWidgetGroup::dragEnterEvent(QDragEnterEvent* pEvent) {
+    DragAndDropHelper::handleTrackDragEnterEvent(pEvent, m_group, m_pConfig);
 }
 
-void WTrackWidgetGroup::dropEvent(QDropEvent* event) {
-    DragAndDropHelper::handleTrackDropEvent(event, *this, m_group, m_pConfig);
+void WTrackWidgetGroup::dropEvent(QDropEvent* pEvent) {
+    DragAndDropHelper::handleTrackDropEvent(pEvent, *this, m_group, m_pConfig);
 }
 
-void WTrackWidgetGroup::contextMenuEvent(QContextMenuEvent* event) {
-    event->accept();
+void WTrackWidgetGroup::contextMenuEvent(QContextMenuEvent* pEvent) {
+    pEvent->accept();
     if (m_pCurrentTrack) {
         ensureTrackMenuIsCreated();
         m_pTrackMenu->loadTrack(m_pCurrentTrack, m_group);
         // Create the right-click menu
-        m_pTrackMenu->popup(event->globalPos());
+        m_pTrackMenu->popup(pEvent->globalPos());
     }
 }
 

--- a/src/widget/wtrackwidgetgroup.h
+++ b/src/widget/wtrackwidgetgroup.h
@@ -37,6 +37,7 @@ class WTrackWidgetGroup : public WWidgetGroup, public TrackDropTarget {
   private:
     void dragEnterEvent(QDragEnterEvent* event) override;
     void dropEvent(QDropEvent* event) override;
+    void mousePressEvent(QMouseEvent* event) override;
     void mouseMoveEvent(QMouseEvent* event) override;
 
     void updateColor();


### PR DESCRIPTION
#12903 for 2.4

Might already fix #13095 
If not I'll try to refactor mouse move in StarEditor.