### PR TITLE
destroy spinny and vumeter textures inside openglcontext

### DIFF
--- a/src/widget/wspinnyglsl.cpp
+++ b/src/widget/wspinnyglsl.cpp
@@ -14,6 +14,21 @@ WSpinnyGLSL::WSpinnyGLSL(
         : WSpinnyBase(parent, group, pConfig, pVCMan, pPlayer) {
 }
 
+WSpinnyGLSL::~WSpinnyGLSL() {
+    cleanupGL();
+}
+
+void WSpinnyGLSL::cleanupGL() {
+    makeCurrentIfNeeded();
+    m_bgTexture.destroy();
+    m_maskTexture.destroy();
+    m_fgTextureScaled.destroy();
+    m_ghostTextureScaled.destroy();
+    m_loadedCoverTextureScaled.destroy();
+    m_qTexture.destroy();
+    doneCurrent();
+}
+
 void WSpinnyGLSL::coverChanged() {
     if (isContextValid()) {
         makeCurrentIfNeeded();

--- a/src/widget/wspinnyglsl.h
+++ b/src/widget/wspinnyglsl.h
@@ -17,7 +17,7 @@ class WSpinnyGLSL : public WSpinnyBase, private QOpenGLFunctions {
             UserSettingsPointer pConfig,
             VinylControlManager* pVCMan,
             BaseTrackPlayer* pPlayer);
-    ~WSpinnyGLSL() override = default;
+    ~WSpinnyGLSL() override;
 
   private:
     void draw() override;
@@ -27,6 +27,7 @@ class WSpinnyGLSL : public WSpinnyBase, private QOpenGLFunctions {
     void paintGL() override;
     void resizeGL(int w, int h) override;
     void drawTexture(QOpenGLTexture* texture);
+    void cleanupGL();
     void updateTextures();
 
     void setupVinylSignalQuality() override;

--- a/src/widget/wvumeterglsl.cpp
+++ b/src/widget/wvumeterglsl.cpp
@@ -11,6 +11,10 @@ WVuMeterGLSL::WVuMeterGLSL(QWidget* pParent)
         : WVuMeterBase(pParent) {
 }
 
+WVuMeterGLSL::~WVuMeterGLSL() {
+    cleanupGL();
+}
+
 void WVuMeterGLSL::draw() {
     if (shouldRender()) {
         makeCurrentIfNeeded();
@@ -137,6 +141,13 @@ void WVuMeterGLSL::paintGL() {
     m_textureShader.disableAttributeArray(positionLocation);
     m_textureShader.disableAttributeArray(texcoordLocation);
     m_textureShader.release();
+}
+
+void WVuMeterGLSL::cleanupGL() {
+    makeCurrentIfNeeded();
+    m_textureBack.destroy();
+    m_textureVu.destroy();
+    doneCurrent();
 }
 
 void WVuMeterGLSL::drawTexture(QOpenGLTexture* texture,

--- a/src/widget/wvumeterglsl.h
+++ b/src/widget/wvumeterglsl.h
@@ -13,7 +13,7 @@ class WVuMeterGLSL : public WVuMeterBase, private QOpenGLFunctions {
     Q_OBJECT
   public:
     explicit WVuMeterGLSL(QWidget* pParent = nullptr);
-    ~WVuMeterGLSL() override = default;
+    ~WVuMeterGLSL() override;
 
   private:
     OpenGLTexture2D m_textureBack;
@@ -22,6 +22,7 @@ class WVuMeterGLSL : public WVuMeterBase, private QOpenGLFunctions {
 
     void draw() override;
     void initializeGL() override;
+    void cleanupGL();
     void paintGL() override;
     void drawTexture(QOpenGLTexture* texture, const QRectF& sourceRect, const QRectF& targetRect);
 };


### PR DESCRIPTION
Destroy spinny and vumeter textures making the widget's openglcontext current first, to avoid a bunch (22) of the following warnings on quit:

```
warning [Main] QOpenGLTexturePrivate::destroy() called without a current context.
Texture has not been destroyed
```

This is a regression introduced in 07f05f1a0ef39e12b870718c9f1203f6f9335b14