### PR TITLE
Labeler: Use more fine-grained controller labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -22,7 +22,12 @@ code quality:
           - .pre-commit-config.yaml
           - pyproject.toml
 
-controllers:
+controller backend:
+  - changed-files:
+      - any-glob-to-any-file:
+          - src/controllers/**
+
+controller mappings:
   - changed-files:
       - any-glob-to-any-file:
           - res/controllers/**


### PR DESCRIPTION
This should make it easier to determine whether PRs update mappings or change the underlying engine code.