### PR TITLE
Usability/Keyboard: Add a rebindable keyboard shortcut for editing items as a replacement for F2

### DIFF
--- a/res/keyboard/cs_CZ.kbd.cfg
+++ b/res/keyboard/cs_CZ.kbd.cfg
@@ -163,3 +163,6 @@ OptionsMenu_DeveloperStatsExperiment Ctrl+Shift+E
 OptionsMenu_DeveloperStatsBase Ctrl+Shift+B
 DeveloperMenu_EnableDebugger Ctrl+Shift+D
 OptionsMenu_EnableShortcuts Ctrl+\
+
+[Library]
+EditItem r

--- a/res/keyboard/da_DK.kbd.cfg
+++ b/res/keyboard/da_DK.kbd.cfg
@@ -163,3 +163,6 @@ OptionsMenu_DeveloperStatsExperiment Ctrl+Shift+E
 OptionsMenu_DeveloperStatsBase Ctrl+Shift+B
 DeveloperMenu_EnableDebugger Ctrl+Shift+D
 OptionsMenu_EnableShortcuts Ctrl+<
+
+[Library]
+EditItem r

--- a/res/keyboard/de_CH.kbd.cfg
+++ b/res/keyboard/de_CH.kbd.cfg
@@ -163,3 +163,6 @@ OptionsMenu_DeveloperStatsExperiment Ctrl+Shift+E
 OptionsMenu_DeveloperStatsBase Ctrl+Shift+B
 DeveloperMenu_EnableDebugger Ctrl+Shift+D
 OptionsMenu_EnableShortcuts Ctrl+<
+
+[Library]
+EditItem r

--- a/res/keyboard/de_DE.kbd.cfg
+++ b/res/keyboard/de_DE.kbd.cfg
@@ -163,3 +163,6 @@ OptionsMenu_DeveloperStatsExperiment Ctrl+Shift+E
 OptionsMenu_DeveloperStatsBase Ctrl+Shift+B
 DeveloperMenu_EnableDebugger Ctrl+Shift+D
 OptionsMenu_EnableShortcuts Ctrl+<
+
+[Library]
+EditItem r

--- a/res/keyboard/el_GR.kbd.cfg
+++ b/res/keyboard/el_GR.kbd.cfg
@@ -168,3 +168,6 @@ OptionsMenu_DeveloperStatsExperiment Ctrl+Shift+E
 OptionsMenu_DeveloperStatsBase Ctrl+Shift+B
 DeveloperMenu_EnableDebugger Ctrl+Shift+D
 OptionsMenu_EnableShortcuts Ctrl+`
+
+[Library]
+EditItem r

--- a/res/keyboard/en_US.kbd.cfg
+++ b/res/keyboard/en_US.kbd.cfg
@@ -163,3 +163,6 @@ OptionsMenu_DeveloperStatsExperiment Ctrl+Shift+E
 OptionsMenu_DeveloperStatsBase Ctrl+Shift+B
 DeveloperMenu_EnableDebugger Ctrl+Shift+D
 OptionsMenu_EnableShortcuts Ctrl+`
+
+[Library]
+EditItem r

--- a/res/keyboard/es_ES.kbd.cfg
+++ b/res/keyboard/es_ES.kbd.cfg
@@ -163,3 +163,6 @@ OptionsMenu_DeveloperStatsExperiment Ctrl+Shift+E
 OptionsMenu_DeveloperStatsBase Ctrl+Shift+B
 DeveloperMenu_EnableDebugger Ctrl+Shift+D
 OptionsMenu_EnableShortcuts Ctrl+<
+
+[Library]
+EditItem r

--- a/res/keyboard/fi_FI.kbd.cfg
+++ b/res/keyboard/fi_FI.kbd.cfg
@@ -163,3 +163,6 @@ OptionsMenu_DeveloperStatsExperiment Ctrl+Shift+E
 OptionsMenu_DeveloperStatsBase Ctrl+Shift+B
 DeveloperMenu_EnableDebugger Ctrl+Shift+D
 OptionsMenu_EnableShortcuts Ctrl+<
+
+[Library]
+EditItem r

--- a/res/keyboard/fr_CH.kbd.cfg
+++ b/res/keyboard/fr_CH.kbd.cfg
@@ -163,3 +163,6 @@ OptionsMenu_DeveloperStatsExperiment Ctrl+Shift+E
 OptionsMenu_DeveloperStatsBase Ctrl+Shift+B
 DeveloperMenu_EnableDebugger Ctrl+Shift+D
 OptionsMenu_EnableShortcuts Ctrl+<
+
+[Library]
+EditItem r

--- a/res/keyboard/fr_FR.kbd.cfg
+++ b/res/keyboard/fr_FR.kbd.cfg
@@ -163,3 +163,6 @@ OptionsMenu_DeveloperStatsExperiment Ctrl+Shift+E
 OptionsMenu_DeveloperStatsBase Ctrl+Shift+B
 DeveloperMenu_EnableDebugger Ctrl+Shift+D
 OptionsMenu_EnableShortcuts Ctrl+`
+
+[Library]
+EditItem r

--- a/res/keyboard/it_IT.kbd.cfg
+++ b/res/keyboard/it_IT.kbd.cfg
@@ -163,3 +163,6 @@ OptionsMenu_DeveloperStatsExperiment Ctrl+Shift+E
 OptionsMenu_DeveloperStatsBase Ctrl+Shift+B
 DeveloperMenu_EnableDebugger Ctrl+Shift+D
 OptionsMenu_EnableShortcuts Ctrl+<
+
+[Library]
+EditItem r

--- a/res/keyboard/ru_RU.kbd.cfg
+++ b/res/keyboard/ru_RU.kbd.cfg
@@ -163,3 +163,6 @@ OptionsMenu_DeveloperStatsExperiment Ctrl+Shift+E
 OptionsMenu_DeveloperStatsBase Ctrl+Shift+B
 DeveloperMenu_EnableDebugger Ctrl+Shift+D
 OptionsMenu_EnableShortcuts Ctrl+|
+
+[Library]
+EditItem r

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -257,6 +257,18 @@ LibraryControl::LibraryControl(Library* pLibrary)
                 &LibraryControl::refocusPrevLibraryWidget);
     }
 
+    // Control to "edit" the currently selected item/field in focused widget (context dependent)
+    m_pEditItem = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "EditItem"));
+#ifdef MIXXX_USE_QML
+    if (!CmdlineArgs::Instance().isQml())
+#endif
+    {
+        connect(m_pEditItem.get(),
+                &ControlPushButton::valueChanged,
+                this,
+                &LibraryControl::slotEditItem);
+    }
+
     // Control to "goto" the currently selected item in focused widget (context dependent)
     m_pGoToItem = std::make_unique<ControlPushButton>(ConfigKey("[Library]", "GoToItem"));
 #ifdef MIXXX_USE_QML
@@ -1043,6 +1055,16 @@ void LibraryControl::slotSelectPrevSidebarItem(double v) {
 void LibraryControl::slotToggleSelectedSidebarItem(double v) {
     if (m_pSidebarWidget && v > 0) {
         m_pSidebarWidget->toggleSelectedItem();
+    }
+}
+
+void LibraryControl::slotEditItem(double v) {
+    if (v <= 0) {
+        return;
+    }
+    WTrackTableView* pTrackTableView = m_pLibraryWidget->getCurrentTrackTableView();
+    if (pTrackTableView) {
+        pTrackTableView->editSelectedItem();
     }
 }
 

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -1065,7 +1065,7 @@ void LibraryControl::slotEditItem(double v) {
 
     switch (m_focusedWidget) {
     case FocusWidget::Sidebar: {
-        m_pSidebarWidget->editSelectedItem();
+        m_pSidebarWidget->renameSelectedItem();
         break;
     }
     case FocusWidget::TracksTable: {

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -1062,9 +1062,22 @@ void LibraryControl::slotEditItem(double v) {
     if (v <= 0) {
         return;
     }
-    WTrackTableView* pTrackTableView = m_pLibraryWidget->getCurrentTrackTableView();
-    if (pTrackTableView) {
-        pTrackTableView->editSelectedItem();
+
+    switch (m_focusedWidget) {
+    case FocusWidget::Sidebar: {
+        m_pSidebarWidget->editSelectedItem();
+        break;
+    }
+    case FocusWidget::TracksTable: {
+        WTrackTableView* pTrackTableView = m_pLibraryWidget->getCurrentTrackTableView();
+        if (pTrackTableView) {
+            pTrackTableView->editSelectedItem();
+        }
+        break;
+    }
+    default: {
+        break;
+    }
     }
 }
 

--- a/src/library/librarycontrol.h
+++ b/src/library/librarycontrol.h
@@ -102,6 +102,7 @@ class LibraryControl : public QObject {
     void slotMoveTrackUp(double);
     void slotMoveTrackDown(double);
     void slotMoveTrack(double);
+    void slotEditItem(double);
     void slotGoToItem(double v);
 
     void slotTrackColorPrev(double v);
@@ -167,6 +168,9 @@ class LibraryControl : public QObject {
     std::unique_ptr<ControlPushButton> m_pMoveTrackUp;
     std::unique_ptr<ControlPushButton> m_pMoveTrackDown;
     std::unique_ptr<ControlEncoder> m_pMoveTrack;
+
+    // Control to edit the currently selected item/field in focused widget
+    std::unique_ptr<ControlObject> m_pEditItem;
 
     // Control to choose the currently selected item in focused widget (double click)
     std::unique_ptr<ControlObject> m_pGoToItem;

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -76,7 +76,6 @@ void BasePlaylistFeature::initActions() {
             &BasePlaylistFeature::slotCreatePlaylist);
 
     m_pRenamePlaylistAction = new QAction(tr("Rename"), this);
-    m_pRenamePlaylistAction->setShortcut(kRenameSidebarItemShortcutKey);
     connect(m_pRenamePlaylistAction,
             &QAction::triggered,
             this,

--- a/src/library/trackset/crate/cratefeature.cpp
+++ b/src/library/trackset/crate/cratefeature.cpp
@@ -69,7 +69,6 @@ void CrateFeature::initActions() {
             &CrateFeature::slotCreateCrate);
 
     m_pRenameCrateAction = make_parented<QAction>(tr("Rename"), this);
-    m_pRenameCrateAction->setShortcut(kRenameSidebarItemShortcutKey);
     connect(m_pRenameCrateAction.get(),
             &QAction::triggered,
             this,

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -178,6 +178,20 @@ void WLibrarySidebar::dropEvent(QDropEvent * event) {
     }
 }
 
+void WLibrarySidebar::editSelectedItem() {
+    // Rename crate or playlist (internal, external, history)
+    QModelIndex selIndex = selectedIndex();
+    if (!selIndex.isValid()) {
+        return;
+    }
+    if (isExpanded(selIndex)) {
+        // Root views / knots can not be renamed
+        return;
+    }
+    emit renameItem(selIndex);
+    return;
+}
+
 void WLibrarySidebar::toggleSelectedItem() {
     QModelIndex index = selectedIndex();
     if (index.isValid()) {
@@ -307,16 +321,7 @@ void WLibrarySidebar::keyPressEvent(QKeyEvent* event) {
         emit setLibraryFocus(FocusWidget::TracksTable);
         return;
     case kRenameSidebarItemShortcutKey: { // F2
-        // Rename crate or playlist (internal, external, history)
-        QModelIndex selIndex = selectedIndex();
-        if (!selIndex.isValid()) {
-            return;
-        }
-        if (isExpanded(selIndex)) {
-            // Root views / knots can not be renamed
-            return;
-        }
-        emit renameItem(selIndex);
+        editSelectedItem();
         return;
     }
     case kHideRemoveShortcutKey: { // Del (macOS: Cmd+Backspace)

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -184,10 +184,6 @@ void WLibrarySidebar::renameSelectedItem() {
     if (!selIndex.isValid()) {
         return;
     }
-    if (isExpanded(selIndex)) {
-        // Root views / knots can not be renamed
-        return;
-    }
     emit renameItem(selIndex);
     return;
 }

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -178,7 +178,7 @@ void WLibrarySidebar::dropEvent(QDropEvent * event) {
     }
 }
 
-void WLibrarySidebar::editSelectedItem() {
+void WLibrarySidebar::renameSelectedItem() {
     // Rename crate or playlist (internal, external, history)
     QModelIndex selIndex = selectedIndex();
     if (!selIndex.isValid()) {
@@ -321,7 +321,7 @@ void WLibrarySidebar::keyPressEvent(QKeyEvent* event) {
         emit setLibraryFocus(FocusWidget::TracksTable);
         return;
     case kRenameSidebarItemShortcutKey: { // F2
-        editSelectedItem();
+        renameSelectedItem();
         return;
     }
     case kHideRemoveShortcutKey: { // Del (macOS: Cmd+Backspace)

--- a/src/widget/wlibrarysidebar.h
+++ b/src/widget/wlibrarysidebar.h
@@ -24,6 +24,7 @@ class WLibrarySidebar : public QTreeView, public WBaseWidget {
     void focusInEvent(QFocusEvent* event) override;
     void timerEvent(QTimerEvent* event) override;
     void toggleSelectedItem();
+    void editSelectedItem();
     bool isLeafNodeSelected();
     bool isChildIndexSelected(const QModelIndex& index);
     bool isFeatureRootIndexSelected(LibraryFeature* pFeature);

--- a/src/widget/wlibrarysidebar.h
+++ b/src/widget/wlibrarysidebar.h
@@ -24,7 +24,7 @@ class WLibrarySidebar : public QTreeView, public WBaseWidget {
     void focusInEvent(QFocusEvent* event) override;
     void timerEvent(QTimerEvent* event) override;
     void toggleSelectedItem();
-    void editSelectedItem();
+    void renameSelectedItem();
     bool isLeafNodeSelected();
     bool isChildIndexSelected(const QModelIndex& index);
     bool isFeatureRootIndexSelected(LibraryFeature* pFeature);

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1297,6 +1297,14 @@ void WTrackTableView::hideOrRemoveSelectedTracks() {
     restoreCurrentIndex();
 }
 
+/// If applicable, requests that the selected field/item be edited
+/// Does nothing otherwise.
+void WTrackTableView::editSelectedItem() {
+    if (state() != EditingState) {
+        edit(currentIndex(), EditKeyPressed, nullptr);
+    }
+}
+
 void WTrackTableView::activateSelectedTrack() {
     const QModelIndexList indices = getSelectedRows();
     if (indices.isEmpty()) {

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -41,6 +41,7 @@ class WTrackTableView : public WLibraryTableView {
     void pasteFromSidebar() override;
     void keyPressEvent(QKeyEvent* event) override;
     void resizeEvent(QResizeEvent* event) override;
+    void editSelectedItem();
     void activateSelectedTrack();
 #ifdef __STEM__
     void loadSelectedTrackToGroup(const QString& group,


### PR DESCRIPTION
## Issue Statement

Right now, one cannot easily use a keyboard shortcut to begin editing a track table cell when keyboard shortcuts are **enabled**, because the usual F2 key is bound to something else by default the default `.kbd.cfg` files provided.

## Use Case

I am currently setting up my music library, and it is quite annoying that I can't use keyboard shortcuts to both play a track in the preview deck using `p` (which is only possible when keyboard shortcuts are enabled) and then enter edit mode using the keyboard too (the F2 key is only bound to this function when keyboard shortcuts are disabled).

## Proposed Solution (as implemented)

Add a keyboard-triggerable `EditItem` action (name is up for debate, but matches the existing `GoToItem` action) that can be remapped using `Custom.kbd.cfg`. The default keyboard mappings bind `EditItem` to the `r` key,
basically because it was the only easily-reachable key not bound yet, but due to being able to rebind it myself, I am open for other suggestions. What I considered so far:

1. **Not providing a default mapping**: Kinda bad for discoverability of the feature, but would be fine by me
2. **Binding `EditItem` to `Ctrl+Shift+Return`**: Makes sense from the viewpoint of consistency (because `Ctrl+Enter` is already bound to opening the track menu, and `Enter` is interpreted as "edit this shell" e.g. in Excel and  Google Sheets.
3. **Binding `EditItem` to `Ctrl+e`**: Would work, is easily reachable, but incurs the risk of mistiming the `Ctrl` press and invoking `loop_double` (which is mapped to `e`) instead when editing a lot of tracks.
4. **Binding `EditItem` to `r`**: The key is easily reachable, not mapped to anything important yet, and has the mnemonic of **R**ename to remember it by.

## Further Work

- Adapt the keyboard shortcut table at [mixxxdj/manual](https://github.com/mixxxdj/manual) once the default key binding has been agreed upon.

- Making the "Star Rating" column editable by keyboard: I'm already working on this, and have a PR nearly ready, but due to the "special" behavior of the star rating column that allows you to edit it simply by hovering over & clicking a star without focusing the cell first, care has to be taken so that the feature works as expected in all circumstances.

- Open a context menu providing the option to clear the playing count when attempting to edit the playing count column.

- Possibly adding a toggle option (or separate command) that keeps the "editor mode" active not only when navigating horizontally using `Tab`/`Shift+Tab`, but also when navigating vertically using the `Up` and `Down` arrow keys.