### PR TITLE
Mixxx status files + settings

### DIFF
--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -809,6 +809,52 @@ void BaseTrackPlayerImpl::slotTrackLoaded(TrackPointer pNewTrack,
     // Update the PlayerInfo class that is used in EngineBroadcast to replace
     // the metadata of a stream
     PlayerInfo::instance().setTrackInfo(getGroup(), m_pLoadedTrack);
+
+    // Write a statusfile for each deck / sampler separately
+    if (m_pConfig->getValueString(ConfigKey("[Controls]", "CreateStatusFiles")) != "0") {
+        QString trackInfoArtist = " ";
+        QString trackInfoTitle = " ";
+        QString DeckStatusTxtLine2 = " ";
+        QString DeckStatusTxtLine3 = " ";
+        QString DeckStatusTxtLine4 = " ";
+        QTime tempStatusTime = QTime::currentTime();
+        QString DeckStatusTime = tempStatusTime.toString("hh:mm:ss");
+
+        if (pNewTrack) {
+            trackInfoArtist = pNewTrack->getArtist();
+            trackInfoTitle = pNewTrack->getTitle();
+            trackInfoArtist.replace("\"", "''");
+            trackInfoTitle.replace("\"", "''");
+            DeckStatusTxtLine2 = "Artist : \"" + trackInfoArtist + "\",";
+            DeckStatusTxtLine3 = "Title : \"" + trackInfoTitle + "\",";
+            DeckStatusTxtLine4 = "Time : \"" + DeckStatusTime + "\",";
+        } else {
+            DeckStatusTxtLine2 = "Artist : \" \",";
+            DeckStatusTxtLine3 = "Title : \" \",";
+            DeckStatusTxtLine4 = "Time : \"" + DeckStatusTime + "\",";
+        }
+        QString trackInfoDeck = getGroup();
+        trackInfoDeck.replace("[Channel", "");
+        trackInfoDeck.replace("]", "");
+        QString DeckStatusFilePath = m_pConfig->getSettingsPath();
+        DeckStatusFilePath.replace("Roaming", "Local");
+        DeckStatusFilePath.replace("\\", "/");
+        QString DeckStatusFileLocation =
+                DeckStatusFilePath + "/controllers/Status" + getGroup() + ".js";
+        //  Different file for each Deck / Sampler
+        QString DeckStatusTxtLine1 = "var TrackDeck" + trackInfoDeck + " = { ";
+        QString DeckStatusTxtLine5 = "};";
+        QFile DeckStatusFile(DeckStatusFileLocation);
+        DeckStatusFile.remove();
+        DeckStatusFile.open(QIODevice::ReadWrite | QIODevice::Append);
+        QTextStream DeckStatusTxt(&DeckStatusFile);
+        DeckStatusTxt << DeckStatusTxtLine1 << "\n";
+        DeckStatusTxt << DeckStatusTxtLine2 << "\n";
+        DeckStatusTxt << DeckStatusTxtLine3 << "\n";
+        DeckStatusTxt << DeckStatusTxtLine4 << "\n";
+        DeckStatusTxt << DeckStatusTxtLine5 << "\n";
+        DeckStatusFile.close();
+    }
 }
 
 TrackPointer BaseTrackPlayerImpl::getLoadedTrack() const {

--- a/src/preferences/dialog/dlgprefdeck.cpp
+++ b/src/preferences/dialog/dlgprefdeck.cpp
@@ -78,6 +78,14 @@ DlgPrefDeck::DlgPrefDeck(QWidget* parent, UserSettingsPointer pConfig)
             this,
             &DlgPrefDeck::slotCueModeCombobox);
 
+    // create statusfiles checkbox
+    CreateStatusFilesCheckBox->setChecked(m_pConfig->getValue(
+            ConfigKey("[Controls]", "CreateStatusFiles"), true));
+    connect(CreateStatusFilesCheckBox,
+            &QCheckBox::stateChanged,
+            this,
+            &DlgPrefDeck::slotToggleCreateStatusFiles);
+
     // Track time display configuration
     connect(m_pControlTrackTimeDisplay.get(),
             &ControlObject::valueChanged,
@@ -792,6 +800,12 @@ void DlgPrefDeck::slotApply() {
     m_pConfig->setValue(
             ConfigKey(kControlsGroup, QStringLiteral("RatePermRight")),
             m_dRatePermFine);
+
+    // Creating statusfiles in settingsfolder with files loaded to js format for controller/web
+    // 1 file for each deck / sampler
+    m_pConfig->setValue(ConfigKey("[Controls]", "CreateStatusFiles"),
+            m_pConfig->getValue(
+                    ConfigKey("[Controls]", "CreateStatusFiles"), false));
 }
 
 void DlgPrefDeck::slotNumDecksChanged(double new_count, bool initializing) {
@@ -879,3 +893,9 @@ int DlgPrefDeck::cueDefaultIndexByData(int userData) const {
                << "returning default";
     return 0;
 }
+
+void DlgPrefDeck::slotToggleCreateStatusFiles(int buttonState) {
+    bool enable = buttonState == Qt::Checked;
+    m_pConfig->setValue(ConfigKey("[Controls]", "CreateStatusFiles"),
+            enable);
+}			

--- a/src/preferences/dialog/dlgprefdeck.h
+++ b/src/preferences/dialog/dlgprefdeck.h
@@ -62,6 +62,10 @@ class DlgPrefDeck : public DlgPreferencePage, public Ui::DlgPrefDeckDlg  {
 
     void slotUpdateSpeedAutoReset(bool);
     void slotUpdatePitchAutoReset(bool);
+	
+  private slots:	
+	// create statusfiles checkbox
+    void slotToggleCreateStatusFiles(int buttonState);	
 
   private:
     // Because the CueDefault list is out of order, we have to set the combo

--- a/src/preferences/dialog/dlgprefdeckdlg.ui
+++ b/src/preferences/dialog/dlgprefdeckdlg.ui
@@ -625,24 +625,105 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
           </attribute>
          </widget>
         </item>
-        <item row="5" column="0">
-         <spacer name="verticalSpacer1">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>15</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
        </layout>
       </item>
      </layout>
     </widget>
    </item>
+   <item row="2" column="0">
+    <widget class="QGroupBox" name="CreateStatusFiles">
+      <property name="title">
+       <string>Create Statusfile for each deck</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+      </property>
+      <layout class="QGridLayout" name="CreateStatusFilesLayout">
+       <item row="0" column="0">
+        <widget class="QLabel" name="CreateStatusFilesLabel">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Create Statusfile for each deck</string>
+          </property>
+          <property name="buddy">
+           <cstring>Create Statusfile for each deck</cstring>
+          </property>
+          </widget>
+        </item>
+         <item row="0" column="1">
+          <widget class="QCheckBox" name="CreateStatusFilesCheckBox">
+            <property name="toolTip">
+         <string>Statusfile:
+If checked, a Statusfile will be created in map with the custom controllermappings.
+A statusfile is a javascriptfile that contains
+- Track-Artist
+- Track-Title
+- Time
+The Artist and Title can be used for display on the controller-screen.
+The time-field can be used in case you want to control 4 decks with a 2 deck-
+controller. Mixxx reloads the controller mapping each time something changes.
+When a new track is loaded and statusfiles are written, the decks switch to 1 and 2.
+With the time field you can set the focus on the last manipulated decjk (1-2 and 3-4).
+
+So if you ejected a track in deck 4, the focus can stay on deck 4 to load another track.
+The statusfiles need to be included in the header of the xml-file.
+
+Statusfiles are named:
+Status[ChannelX].js, Status[ChannelY].js ...
+Status[SamplerX].js, Status[SamplerY].js ...
+
+The contents:
+var TrackDeckX = {
+Artist : "trackartist",
+Title : "tracktitle",
+Time : "12:52:44",
+};
+
+In the beginning of the controller.js file you can load the contents of the Statusfiles
+in a arrays to use them for displaying.
+
+             </string>
+            </property>
+          </widget>
+        </item>
+        <item row="13" column="0">
+          <spacer name="verticalSpacer1">
+            <property name="orientation">
+              <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+              <size>
+                <width>20</width>
+                <height>15</height>
+              </size>
+            </property>
+          </spacer>
+        </item>
+
+
+        <item row="0" column="2">
+          <spacer name="horizontalSpacerstatusfiles">
+            <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+                <horstretch>1</horstretch>
+                <verstretch>0</verstretch>
+              </sizepolicy>
+            </property>
+          </spacer>
+        </item>
+      </layout>
+    </widget>
+   </item>
+
+
    <item row="2" column="0">
     <spacer name="verticalSpacer2">
      <property name="orientation">


### PR DESCRIPTION
Statusfile:
If checked, a Statusfile will be created in map with the custom controllermappings. 
A statusfile is a javascriptfile that contains
- Track-Artist
- Track-Title
- Time
The Artist and Title can be used for display on the controller-screen.
The time-field can be used in case you want to control 4 decks with a 2 deck-
controller. Mixxx reloads the controller mapping each time something changes.
When a new track is loaded and statusfiles are written, the decks switch to 1 and 2.
With the time field you can set the focus on the last manipulated decjk (1-2 and 3-4).

So if you ejected a track in deck 4, the focus can stay on deck 4 to load another track.
The statusfiles need to be included in the header of the xml-file.

Statusfiles are named:
Status[ChannelX].js, Status[ChannelY].js ... 
Status[SamplerX].js, Status[SamplerY].js ...

The contents:
var TrackDeckX = { 
Artist : "trackartist",
Title : "tracktitle",
Time : "12:52:44",
};

In the beginning of the controller.js file you can load the contents of the Statusfiles
in arrays to use them for displaying.