### PR TITLE
(fix) Waveform viewer: reject focus on click, allow global keyboard shortcuts

### DIFF
--- a/src/widget/openglwindow.cpp
+++ b/src/widget/openglwindow.cpp
@@ -93,6 +93,11 @@ bool OpenGLWindow::event(QEvent* pEv) {
             return result;
         }
 
+        if (t == QEvent::FocusIn) {
+            pEv->ignore();
+            return false; // clazy:exclude=base-class-event
+        }
+
         // Send all remaining events to the widget that owns the window
         // container widget that contains this QOpenGLWindow. With this mouse
         // events, keyboard events, etc all arrive as intended, including the


### PR DESCRIPTION
Fixes #13160 for waveforms and spinnies, already noticed in the waveforms PR https://github.com/mixxxdj/mixxx/pull/10989#issuecomment-1526191537

Focus is still removed from the current focus widget, but cleared right away so keyboard shortcuts still work.

Obviously, it'd be better not to move focus in the first place, but I didn't manage to prevent that.
Previously I tried with eventFilter in OpenGLWindow but that didn't work for some reason.
Also, only rejecting the FocusIn event is not sufficient, even though the child widget has the Qt::NoFocus policy, so it shouldn't accept focus in the first place :man_shrugging: 

**edit** I'm experiencing inconsitent behaviour: doing another test (since I'm not happy with this hack) it turns out that rejecting the FocusIn **is** sufficient.
However, I'd still prefer to not focus the QOpenGLWindow in the first place.

@m0dB What do you think?