### PR TITLE
(fix) waveform / spinnies: don't take keyboard focus on click

### DIFF
--- a/src/widget/openglwindow.cpp
+++ b/src/widget/openglwindow.cpp
@@ -12,6 +12,9 @@
 OpenGLWindow::OpenGLWindow(WGLWidget* pWidget)
         : m_pWidget(pWidget) {
     setFormat(WaveformWidgetFactory::getSurfaceFormat());
+    // Set the tooltip flag to prevent this window/widget from getting
+    // keyboard focus on click.
+    setFlag(Qt::ToolTip);
 }
 
 OpenGLWindow::~OpenGLWindow() {


### PR DESCRIPTION
_Currently keyboard shortcuts still work when waveforms/spinnies are click (OpenGLWindow is activated), but focus is removed from the library widgets for example which is not optimal since waveforms/spinnies don't have any special keyboard functions._

_This PR just prevents the focus shift._

Simply set the `ToolTip` flag to reject focus.
Couldn't spot any regressions, waveform/spinny interaction works flawlessly, tooltips are shown correctly.

Tested on Linux with Qt 5.12.8

Note: this trick does apparently not work with Qt 6 :laughing: (Qt 6.2.3)
____

_Remaining issue:
on window activation, and when no widget has focus, the searchbar gets focus, which also prevents keyboard shortcuts to work right away._