### PR TITLE
Skins: Add a <NumberDuration> control for skins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1292,6 +1292,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/widget/wmainmenubar.cpp
   src/widget/wnumber.cpp
   src/widget/wnumberdb.cpp
+  src/widget/wnumberduration.cpp
   src/widget/wnumberpos.cpp
   src/widget/wnumberrate.cpp
   src/widget/woverview.cpp

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -55,6 +55,7 @@
 #include "widget/wlibrarysidebar.h"
 #include "widget/wnumber.h"
 #include "widget/wnumberdb.h"
+#include "widget/wnumberduration.h"
 #include "widget/wnumberpos.h"
 #include "widget/wnumberrate.h"
 #include "widget/woverviewhsv.h"
@@ -558,6 +559,8 @@ QList<QWidget*> LegacySkinParser::parseNode(const QDomElement& node) {
         result = wrapWidget(parseLabelWidget<WNumber>(node));
     } else if (nodeName == "NumberDb") {
         result = wrapWidget(parseLabelWidget<WNumberDb>(node));
+    } else if (nodeName == "NumberDuration") {
+        result = wrapWidget(parseLabelWidget<WNumberDuration>(node));
     } else if (nodeName == "Label") {
         result = wrapWidget(parseLabelWidget<WLabel>(node));
     } else if (nodeName == "Knob") {

--- a/src/widget/wnumberduration.cpp
+++ b/src/widget/wnumberduration.cpp
@@ -1,0 +1,64 @@
+#include "widget/wnumberduration.h"
+
+#include "control/controlproxy.h"
+#include "moc_wnumberduration.cpp"
+#include "util/duration.h"
+
+WNumberDuration::WNumberDuration(QWidget* parent)
+        : WNumber(parent),
+          m_displayFormat(TrackTime::DisplayFormat::TRADITIONAL) {
+}
+
+void WNumberDuration::setup(const QDomNode& node, const SkinContext& context) {
+    WNumber::setup(node, context);
+
+    QString formatString = context.selectString(node, "TimeFormat");
+    if (formatString == "kilo_seconds") {
+        m_displayFormat = TrackTime::DisplayFormat::KILO_SECONDS;
+    } else if (formatString == "seconds_long") {
+        m_displayFormat = TrackTime::DisplayFormat::SECONDS_LONG;
+    } else if (formatString == "seconds") {
+        m_displayFormat = TrackTime::DisplayFormat::SECONDS;
+    } else if (formatString == "traditional") {
+        m_displayFormat = TrackTime::DisplayFormat::TRADITIONAL;
+    } else if (formatString == "traditional_coarse") {
+        m_displayFormat = TrackTime::DisplayFormat::TRADITIONAL_COARSE;
+    } else {
+        m_displayFormat = TrackTime::DisplayFormat::TRADITIONAL;
+    }
+}
+
+// Reimplementing WNumber::setValue
+void WNumberDuration::setValue(double dSeconds) {
+    QString (*timeFormat)(double dSeconds, mixxx::Duration::Precision precision);
+
+    if (m_displayFormat == TrackTime::DisplayFormat::KILO_SECONDS) {
+        timeFormat = &mixxx::Duration::formatKiloSeconds;
+    } else if (m_displayFormat == TrackTime::DisplayFormat::SECONDS_LONG) {
+        timeFormat = &mixxx::Duration::formatSecondsLong;
+    } else if (m_displayFormat == TrackTime::DisplayFormat::SECONDS) {
+        timeFormat = &mixxx::Duration::formatSeconds;
+    } else {
+        timeFormat = &mixxx::Duration::formatTime;
+    }
+
+    mixxx::Duration::Precision precision;
+    if (m_displayFormat != TrackTime::DisplayFormat::TRADITIONAL_COARSE) {
+        precision = mixxx::Duration::Precision::CENTISECONDS;
+    } else {
+        precision = mixxx::Duration::Precision::SECONDS;
+    }
+
+    QString formattedValue;
+    if (dSeconds >= 0.0) {
+        formattedValue = timeFormat(dSeconds, precision);
+    } else {
+        formattedValue = QLatin1String("-") % timeFormat(-dSeconds, precision);
+    }
+
+    if (m_skinText.contains("%1")) {
+        setText(m_skinText.arg(formattedValue));
+    } else {
+        setText(m_skinText + formattedValue);
+    }
+}

--- a/src/widget/wnumberduration.h
+++ b/src/widget/wnumberduration.h
@@ -19,4 +19,5 @@ class WNumberDuration : public WNumber {
 
   private:
     TrackTime::DisplayFormat m_displayFormat;
+    QString m_displayFormatString;
 };

--- a/src/widget/wnumberduration.h
+++ b/src/widget/wnumberduration.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "preferences/dialog/dlgprefdeck.h"
+#include "skin/legacy/skincontext.h"
+#include "wnumber.h"
+
+class ControlProxy;
+
+class WNumberDuration : public WNumber {
+    Q_OBJECT
+
+  public:
+    explicit WNumberDuration(QWidget* parent = nullptr);
+
+    void setup(const QDomNode& node, const SkinContext& context) override;
+
+  private slots:
+    void setValue(double dValue) override;
+
+  private:
+    TrackTime::DisplayFormat m_displayFormat;
+};


### PR DESCRIPTION
This PR adds a `WNumberDuration`control for displaying a control value given in seconds as a formatted time (e.g. `hh:mm:ss`).
Although the `WNumberPos` has a similar purpose, it is tailored strictly for displaying the play position of a deck. The `WTime` control is also similar, but only displays the current time.

The goal is to be able to display e.g. the remaining duration of the Auto DJ queue in the UI in a skin-controllable way, like so:
![Example screenshot](https://github.com/mixxxdj/mixxx/assets/3719586/6baf8fd4-4eb1-4bb7-ab8f-1e6c2299a517)

(Note: The above screenshot is from one of my development builds. Automatically calculating the remaining duration of the Auto DJ queue has its own gotchas, and so will be provided in a separate PR)