### PR TITLE
Refactor: Extract the CountsDuration table logic into PlaylistStatsDAO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -923,6 +923,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/library/dao/directorydao.cpp
   src/library/dao/libraryhashdao.cpp
   src/library/dao/playlistdao.cpp
+  src/library/dao/playliststatsdao.cpp
   src/library/dao/settingsdao.cpp
   src/library/dao/trackdao.cpp
   src/library/dao/trackschema.cpp

--- a/src/library/dao/playliststatsdao.cpp
+++ b/src/library/dao/playliststatsdao.cpp
@@ -1,0 +1,87 @@
+#include "library/dao/playliststatsdao.h"
+
+#include <QtDebug>
+
+#include "library/dao/playlistdao.h"
+#include "library/queryutil.h"
+#include "moc_playliststatsdao.cpp"
+#include "util/db/dbconnection.h"
+#include "util/db/fwdsqlquery.h"
+#include "util/make_const_iterator.h"
+#include "util/math.h"
+
+PlaylistStatsDAO::PlaylistStatsDAO(const QString& countsDurationTableName)
+        : m_countsDurationTableName(countsDurationTableName) {
+}
+
+void PlaylistStatsDAO::initialize(const QSqlDatabase& database) {
+    DAO::initialize(database);
+}
+
+void PlaylistStatsDAO::preparePlaylistSummaryTable() {
+    QString queryString = QStringLiteral(
+            "CREATE TEMPORARY VIEW IF NOT EXISTS %1 "
+            "AS SELECT "
+            "  Playlists.id AS id, "
+            "  Playlists.name AS name, "
+            "  LOWER(Playlists.name) AS sort_name, "
+            "  COUNT(case library.mixxx_deleted when 0 then 1 else null end) "
+            "    AS count, "
+            "  SUM(case library.mixxx_deleted "
+            "    when 0 then library.duration else 0 end) AS durationSeconds "
+            "FROM Playlists "
+            "LEFT JOIN PlaylistTracks "
+            "  ON PlaylistTracks.playlist_id = Playlists.id "
+            "LEFT JOIN library "
+            "  ON PlaylistTracks.track_id = library.id "
+            "  WHERE Playlists.hidden = %2 "
+            "  GROUP BY Playlists.id")
+                                  .arg(m_countsDurationTableName,
+                                          QString::number(
+                                                  PlaylistDAO::PLHT_NOT_HIDDEN));
+    queryString.append(
+            mixxx::DbConnection::collateLexicographically(
+                    " ORDER BY sort_name"));
+    QSqlQuery query(m_database);
+    if (!query.exec(queryString)) {
+        LOG_FAILED_QUERY(query);
+    }
+}
+
+QList<PlaylistStatsDAO::PlaylistSummary> PlaylistStatsDAO::getPlaylistSummaries() {
+    // Setup the sidebar playlist model
+    QSqlTableModel playlistTableModel(this, m_database);
+    playlistTableModel.setTable(m_countsDurationTableName);
+    playlistTableModel.select();
+    while (playlistTableModel.canFetchMore()) {
+        playlistTableModel.fetchMore();
+    }
+    QSqlRecord record = playlistTableModel.record();
+    int nameColumn = record.indexOf("name");
+    int idColumn = record.indexOf("id");
+    int countColumn = record.indexOf("count");
+    int durationColumn = record.indexOf("durationSeconds");
+
+    QList<PlaylistSummary> playlistSummaries;
+    for (int row = 0; row < playlistTableModel.rowCount(); ++row) {
+        int id =
+                playlistTableModel
+                        .data(playlistTableModel.index(row, idColumn))
+                        .toInt();
+        QString name =
+                playlistTableModel
+                        .data(playlistTableModel.index(row, nameColumn))
+                        .toString();
+        int count =
+                playlistTableModel
+                        .data(playlistTableModel.index(row, countColumn))
+                        .toInt();
+        int duration =
+                playlistTableModel
+                        .data(playlistTableModel.index(row, durationColumn))
+                        .toInt();
+
+        playlistSummaries.append(PlaylistSummary(id, name, count, duration));
+    }
+    return playlistSummaries;
+}

--- a/src/library/dao/playliststatsdao.cpp
+++ b/src/library/dao/playliststatsdao.cpp
@@ -10,10 +10,8 @@
 #include "util/make_const_iterator.h"
 #include "util/math.h"
 
-PlaylistStatsDAO::PlaylistStatsDAO(const QString& countsDurationTableName,
-        const PlaylistDAO::HiddenType playlistType)
-        : m_countsDurationTableName(countsDurationTableName),
-          m_hiddenType(playlistType) {
+PlaylistStatsDAO::PlaylistStatsDAO()
+        : m_countsDurationTableName(QStringLiteral("PlaylistsCountsDurations")) {
 }
 
 void PlaylistStatsDAO::initialize(const QSqlDatabase& database) {
@@ -22,38 +20,36 @@ void PlaylistStatsDAO::initialize(const QSqlDatabase& database) {
 }
 
 void PlaylistStatsDAO::preparePlaylistSummaryTable() {
-    // If true, deleted tracks should still be counted
-    // towards the track count and duration totals.
-    // If false, treat deleted tracks as if they weren't there.
-    bool includeDeleted = m_hiddenType == PlaylistDAO::PLHT_SET_LOG;
-
+    // Deleted tracks should still be counted towards the track count
+    // and duration totals for playlists with hidden == PLHT_SET_LOG.
+    // Otherwise, we treat deleted tracks as if they weren't there.
     QString queryString = QStringLiteral(
             "CREATE TEMPORARY VIEW IF NOT EXISTS %1 "
             "AS SELECT "
             "  Playlists.id AS id, "
             "  Playlists.name AS name, "
             "  Playlists.date_created AS date_created, "
+            "  Playlists.hidden as hidden, "
             "  LOWER(Playlists.name) AS sort_name, "
-            "  IF(%3, "
-            "    max(PlaylistTracks.position),"
-            "    COUNT(case library.mixxx_deleted "
-            "      when 0 then 1 else null end)) "
-            "    AS count, "
-            "  IF(%3, "
-            "    SUM(library.duration), "
-            "    SUM(case library.mixxx_deleted "
-            "      when 0 then library.duration else 0 end)) "
-            "    AS durationSeconds "
+            "  (case Playlists.hidden "
+            "    when %2 then max(PlaylistTracks.position) "
+            "    else COUNT(case library.mixxx_deleted "
+            "      when 0 then 1 else null end) "
+            "    end) AS count, "
+            "  (case Playlists.hidden "
+            "    when %2 then SUM(library.duration), "
+            "    else SUM(case library.mixxx_deleted "
+            "      when 0 then library.duration else 0 end) "
+            "    end) AS durationSeconds, "
             "FROM Playlists "
             "LEFT JOIN PlaylistTracks "
             "  ON PlaylistTracks.playlist_id = Playlists.id "
-            "LEFT JOIN library "
+            "LEFT JOIN lim_countsDurationTableNamebrary "
             "  ON PlaylistTracks.track_id = library.id "
-            "  WHERE Playlists.hidden = %2 "
-            "  GROUP BY Playlists.id")
-                                  .arg(m_countsDurationTableName,
-                                          QString::number(m_hiddenType),
-                                          includeDeleted ? "true" : "false");
+            "WHERE  "
+            "GROUP BY Playlists.id")
+                                  .arg("m_countsDurationTableName",
+                                          QString::number(PlaylistDAO::PLHT_SET_LOG));
 
     queryString.append(
             mixxx::DbConnection::collateLexicographically(
@@ -64,14 +60,17 @@ void PlaylistStatsDAO::preparePlaylistSummaryTable() {
     }
 }
 
-QList<PlaylistStatsDAO::PlaylistSummary> PlaylistStatsDAO::getPlaylistSummaries() {
+QList<PlaylistStatsDAO::PlaylistSummary> PlaylistStatsDAO::getPlaylistSummaries(
+        PlaylistDAO::HiddenType playlistType) {
     // Setup the sidebar playlist model
     QSqlTableModel playlistTableModel(this, m_database);
     playlistTableModel.setTable(m_countsDurationTableName);
-    if (m_hiddenType == PlaylistDAO::PLHT_SET_LOG) {
+    if (playlistType == PlaylistDAO::PLHT_SET_LOG) {
         // TODO: Can we remove this special handling for the SetLog?
         playlistTableModel.setSort(playlistTableModel.fieldIndex("id"), Qt::DescendingOrder);
     }
+    const QString filter = "hidden=" + QString::number(playlistType);
+    playlistTableModel.setFilter(filter);
     playlistTableModel.select();
     while (playlistTableModel.canFetchMore()) {
         playlistTableModel.fetchMore();

--- a/src/library/dao/playliststatsdao.cpp
+++ b/src/library/dao/playliststatsdao.cpp
@@ -11,13 +11,14 @@
 #include "util/math.h"
 
 PlaylistStatsDAO::PlaylistStatsDAO(const QString& countsDurationTableName,
-        const PlaylistDAO::HiddenType hiddenType)
+        const PlaylistDAO::HiddenType playlistType)
         : m_countsDurationTableName(countsDurationTableName),
-          m_hiddenType(hiddenType) {
+          m_hiddenType(playlistType) {
 }
 
 void PlaylistStatsDAO::initialize(const QSqlDatabase& database) {
     DAO::initialize(database);
+    preparePlaylistSummaryTable();
 }
 
 void PlaylistStatsDAO::preparePlaylistSummaryTable() {

--- a/src/library/dao/playliststatsdao.h
+++ b/src/library/dao/playliststatsdao.h
@@ -50,6 +50,9 @@ class PlaylistStatsDAO : public QObject, public virtual DAO {
     /// Returns the name, track count and total duration of all playlists.
     QList<PlaylistSummary> getPlaylistSummaries();
 
+    /// Returns the name, track count and total duration of the given playlist.
+    PlaylistSummary getPlaylistSummary(const int playlistId);
+
   private:
     QString m_countsDurationTableName;
     DISALLOW_COPY_AND_ASSIGN(PlaylistStatsDAO);

--- a/src/library/dao/playliststatsdao.h
+++ b/src/library/dao/playliststatsdao.h
@@ -12,8 +12,7 @@
 class PlaylistStatsDAO : public QObject, public virtual DAO {
     Q_OBJECT
   public:
-    PlaylistStatsDAO(const QString& countsDurationTableName,
-            const PlaylistDAO::HiddenType playlistType);
+    PlaylistStatsDAO();
     ~PlaylistStatsDAO() override = default;
 
     void initialize(const QSqlDatabase& database) override;
@@ -54,14 +53,14 @@ class PlaylistStatsDAO : public QObject, public virtual DAO {
     /// Prepares the table view used by getPlaylistSummary.
     void preparePlaylistSummaryTable();
 
-    /// Returns the name, track count and total duration of all playlists.
-    QList<PlaylistSummary> getPlaylistSummaries();
+    /// Returns the name, track count and total duration
+    /// of all playlists of the given type.
+    QList<PlaylistSummary> getPlaylistSummaries(PlaylistDAO::HiddenType playlistType);
 
     /// Returns the name, track count and total duration of the given playlist.
     PlaylistSummary getPlaylistSummary(const int playlistId);
 
   private:
     QString m_countsDurationTableName;
-    PlaylistDAO::HiddenType m_hiddenType;
     DISALLOW_COPY_AND_ASSIGN(PlaylistStatsDAO);
 };

--- a/src/library/dao/playliststatsdao.h
+++ b/src/library/dao/playliststatsdao.h
@@ -1,16 +1,19 @@
 #pragma once
 
+#include <QDateTime>
 #include <QList>
 #include <QObject>
 
 #include "library/dao/dao.h"
+#include "library/dao/playlistdao.h"
 #include "track/trackid.h"
 #include "util/class.h"
 
 class PlaylistStatsDAO : public QObject, public virtual DAO {
     Q_OBJECT
   public:
-    PlaylistStatsDAO(const QString& countsDurationTableName);
+    PlaylistStatsDAO(const QString& countsDurationTableName,
+            const PlaylistDAO::HiddenType hiddenType);
     ~PlaylistStatsDAO() override = default;
 
     void initialize(const QSqlDatabase& database) override;
@@ -19,16 +22,19 @@ class PlaylistStatsDAO : public QObject, public virtual DAO {
         PlaylistSummary()
                 : hasValue(false),
                   name(),
+                  dateCreated(),
                   count(0),
                   duration(0) {
         }
         PlaylistSummary(const int playlistId,
                 const QString& name,
+                const QDateTime& dateCreated,
                 int count,
                 int duration)
                 : hasValue(true),
                   playlistId(playlistId),
                   name(name),
+                  dateCreated(dateCreated),
                   count(count),
                   duration(duration) {
         }
@@ -40,6 +46,7 @@ class PlaylistStatsDAO : public QObject, public virtual DAO {
         bool hasValue;
         int playlistId;
         QString name;
+        QDateTime dateCreated;
         int count;
         int duration;
     };
@@ -55,5 +62,6 @@ class PlaylistStatsDAO : public QObject, public virtual DAO {
 
   private:
     QString m_countsDurationTableName;
+    PlaylistDAO::HiddenType m_hiddenType;
     DISALLOW_COPY_AND_ASSIGN(PlaylistStatsDAO);
 };

--- a/src/library/dao/playliststatsdao.h
+++ b/src/library/dao/playliststatsdao.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <QList>
+#include <QObject>
+
+#include "library/dao/dao.h"
+#include "track/trackid.h"
+#include "util/class.h"
+
+class PlaylistStatsDAO : public QObject, public virtual DAO {
+    Q_OBJECT
+  public:
+    PlaylistStatsDAO(const QString& countsDurationTableName);
+    ~PlaylistStatsDAO() override = default;
+
+    void initialize(const QSqlDatabase& database) override;
+
+    struct PlaylistSummary {
+        PlaylistSummary()
+                : hasValue(false),
+                  name(),
+                  count(0),
+                  duration(0) {
+        }
+        PlaylistSummary(const int playlistId,
+                const QString& name,
+                int count,
+                int duration)
+                : hasValue(true),
+                  playlistId(playlistId),
+                  name(name),
+                  count(count),
+                  duration(duration) {
+        }
+
+        bool isEmpty() const {
+            return !hasValue;
+        }
+
+        bool hasValue;
+        int playlistId;
+        QString name;
+        int count;
+        int duration;
+    };
+
+    /// Prepares the table view used by getPlaylistSummary.
+    void preparePlaylistSummaryTable();
+
+    /// Returns the name, track count and total duration of all playlists.
+    QList<PlaylistSummary> getPlaylistSummaries();
+
+  private:
+    QString m_countsDurationTableName;
+    DISALLOW_COPY_AND_ASSIGN(PlaylistStatsDAO);
+};

--- a/src/library/dao/playliststatsdao.h
+++ b/src/library/dao/playliststatsdao.h
@@ -13,7 +13,7 @@ class PlaylistStatsDAO : public QObject, public virtual DAO {
     Q_OBJECT
   public:
     PlaylistStatsDAO(const QString& countsDurationTableName,
-            const PlaylistDAO::HiddenType hiddenType);
+            const PlaylistDAO::HiddenType playlistType);
     ~PlaylistStatsDAO() override = default;
 
     void initialize(const QSqlDatabase& database) override;

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -18,10 +18,6 @@ mixxx::Logger kLogger("TrackCollection");
 TrackCollection::TrackCollection(
         QObject* parent, const UserSettingsPointer& pConfig)
         : QObject(parent),
-          m_playlistStatsDao(QStringLiteral("PlaylistsCountsDurations"),
-                  PlaylistDAO::PLHT_NOT_HIDDEN),
-          m_setlogStatsDao(QStringLiteral("SetlogCountsDurations"),
-                  PlaylistDAO::PLHT_SET_LOG),
           m_analysisDao(pConfig),
           m_trackDao(m_cueDao,
                   m_playlistDao,
@@ -85,7 +81,6 @@ void TrackCollection::connectDatabase(const QSqlDatabase& database) {
     m_trackDao.initialize(database);
     m_playlistDao.initialize(database);
     m_playlistStatsDao.initialize(database);
-    m_setlogStatsDao.initialize(database);
     m_cueDao.initialize(database);
     m_directoryDao.initialize(database);
     m_analysisDao.initialize(database);

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -16,12 +16,18 @@ mixxx::Logger kLogger("TrackCollection");
 } // anonymous namespace
 
 TrackCollection::TrackCollection(
-        QObject* parent,
-        const UserSettingsPointer& pConfig)
+        QObject* parent, const UserSettingsPointer& pConfig)
         : QObject(parent),
+          m_playlistStatsDao(QStringLiteral("PlaylistsCountsDurations"),
+                  PlaylistDAO::PLHT_NOT_HIDDEN),
+          m_setlogStatsDao(QStringLiteral("SetlogCountsDurations"),
+                  PlaylistDAO::PLHT_SET_LOG),
           m_analysisDao(pConfig),
-          m_trackDao(m_cueDao, m_playlistDao,
-                     m_analysisDao, m_libraryHashDao, pConfig) {
+          m_trackDao(m_cueDao,
+                  m_playlistDao,
+                  m_analysisDao,
+                  m_libraryHashDao,
+                  pConfig) {
     // Forward signals from TrackDAO
     connect(&m_trackDao,
             &TrackDAO::trackClean,
@@ -78,6 +84,8 @@ void TrackCollection::connectDatabase(const QSqlDatabase& database) {
     m_database = database;
     m_trackDao.initialize(database);
     m_playlistDao.initialize(database);
+    m_playlistStatsDao.initialize(database);
+    m_setlogStatsDao.initialize(database);
     m_cueDao.initialize(database);
     m_directoryDao.initialize(database);
     m_analysisDao.initialize(database);

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -11,6 +11,7 @@
 #include "library/dao/directorydao.h"
 #include "library/dao/libraryhashdao.h"
 #include "library/dao/playlistdao.h"
+#include "library/dao/playliststatsdao.h"
 #include "library/dao/trackdao.h"
 #include "library/trackset/crate/cratestorage.h"
 #include "preferences/usersettings.h"
@@ -59,6 +60,24 @@ class TrackCollection : public QObject,
     PlaylistDAO& getPlaylistDAO() {
         DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
         return m_playlistDao;
+    }
+    PlaylistStatsDAO& getPlaylistStatsDAO(PlaylistDAO::HiddenType playlistType) {
+        DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
+        switch (playlistType) {
+        case PlaylistDAO::PLHT_NOT_HIDDEN: {
+            return m_playlistStatsDao;
+        }
+        case PlaylistDAO::PLHT_SET_LOG: {
+            return m_setlogStatsDao;
+        }
+        case PlaylistDAO::PLHT_AUTO_DJ:
+        case PlaylistDAO::PLHT_UNKNOWN:
+        default: {
+            // This can only ever happen due to a coding error
+            DEBUG_ASSERT(false);
+            return m_playlistStatsDao;
+        }
+        }
     }
     const DirectoryDAO& getDirectoryDAO() const {
         DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
@@ -169,6 +188,8 @@ class TrackCollection : public QObject,
     QSqlDatabase m_database;
 
     PlaylistDAO m_playlistDao;
+    PlaylistStatsDAO m_playlistStatsDao;
+    PlaylistStatsDAO m_setlogStatsDao;
     CrateStorage m_crates;
     CueDAO m_cueDao;
     DirectoryDAO m_directoryDao;

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -61,23 +61,9 @@ class TrackCollection : public QObject,
         DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
         return m_playlistDao;
     }
-    PlaylistStatsDAO& getPlaylistStatsDAO(PlaylistDAO::HiddenType playlistType) {
+    PlaylistStatsDAO& getPlaylistStatsDAO() {
         DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
-        switch (playlistType) {
-        case PlaylistDAO::PLHT_NOT_HIDDEN: {
-            return m_playlistStatsDao;
-        }
-        case PlaylistDAO::PLHT_SET_LOG: {
-            return m_setlogStatsDao;
-        }
-        case PlaylistDAO::PLHT_AUTO_DJ:
-        case PlaylistDAO::PLHT_UNKNOWN:
-        default: {
-            // This can only ever happen due to a coding error
-            DEBUG_ASSERT(false);
-            return m_playlistStatsDao;
-        }
-        }
+        return m_playlistStatsDao;
     }
     const DirectoryDAO& getDirectoryDAO() const {
         DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
@@ -189,7 +175,6 @@ class TrackCollection : public QObject,
 
     PlaylistDAO m_playlistDao;
     PlaylistStatsDAO m_playlistStatsDao;
-    PlaylistStatsDAO m_setlogStatsDao;
     CrateStorage m_crates;
     CueDAO m_cueDao;
     DirectoryDAO m_directoryDao;

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -711,12 +711,9 @@ void BasePlaylistFeature::htmlLinkClicked(const QUrl& link) {
 }
 
 QString BasePlaylistFeature::fetchPlaylistLabel(int playlistId) {
-    // This queries the temporary id/count/duration table that was has been created
-    // by the features' createPlaylistLabels() (updated each time playlists are added/removed)
+    // Query the temporary id/count/duration table
     PlaylistStatsDAO& playlistStatsDao =
-            m_pLibrary->trackCollectionManager()
-                    ->internalCollection()
-                    ->getPlaylistStatsDAO(PlaylistDAO::PLHT_NOT_HIDDEN);
+            m_pLibrary->trackCollectionManager()->internalCollection()->getPlaylistStatsDAO();
 
     auto playlistInfo = playlistStatsDao.getPlaylistSummary(playlistId);
     if (!playlistInfo.isEmpty()) {

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -41,14 +41,12 @@ BasePlaylistFeature::BasePlaylistFeature(
         PlaylistTableModel* pModel,
         const QString& rootViewName,
         const QString& iconName,
-        const QString& countsDurationTableName,
         bool keepHiddenTracks)
         : BaseTrackSetFeature(pLibrary, pConfig, rootViewName, iconName),
           m_playlistDao(pLibrary->trackCollectionManager()
                                 ->internalCollection()
                                 ->getPlaylistDAO()),
           m_pPlaylistTableModel(pModel),
-          m_countsDurationTableName(countsDurationTableName),
           m_keepHiddenTracks(keepHiddenTracks) {
     pModel->setParent(this);
 
@@ -715,14 +713,10 @@ void BasePlaylistFeature::htmlLinkClicked(const QUrl& link) {
 QString BasePlaylistFeature::fetchPlaylistLabel(int playlistId) {
     // This queries the temporary id/count/duration table that was has been created
     // by the features' createPlaylistLabels() (updated each time playlists are added/removed)
-    QSqlDatabase database =
-            m_pLibrary->trackCollectionManager()->internalCollection()->database();
-
-    PlaylistStatsDAO playlistStatsDao(
-            m_countsDurationTableName,
-            PlaylistDAO::PLHT_NOT_HIDDEN);
-
-    playlistStatsDao.initialize(database);
+    PlaylistStatsDAO& playlistStatsDao =
+            m_pLibrary->trackCollectionManager()
+                    ->internalCollection()
+                    ->getPlaylistStatsDAO(PlaylistDAO::PLHT_NOT_HIDDEN);
 
     auto playlistInfo = playlistStatsDao.getPlaylistSummary(playlistId);
     if (!playlistInfo.isEmpty()) {

--- a/src/library/trackset/baseplaylistfeature.h
+++ b/src/library/trackset/baseplaylistfeature.h
@@ -26,7 +26,6 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
             PlaylistTableModel* pModel,
             const QString& rootViewName,
             const QString& iconName,
-            const QString& countsDurationTableName,
             bool keepHiddenTracks = false);
     ~BasePlaylistFeature() override = default;
 
@@ -117,7 +116,6 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
 
     PlaylistTableModel* m_pPlaylistTableModel;
     QSet<int> m_playlistIdsOfSelectedTrack;
-    const QString m_countsDurationTableName;
 
   private slots:
     void slotTrackSelected(TrackId trackId);

--- a/src/library/trackset/playlistfeature.cpp
+++ b/src/library/trackset/playlistfeature.cpp
@@ -121,12 +121,11 @@ bool PlaylistFeature::dragMoveAcceptChild(const QModelIndex& index, const QUrl& 
 QList<BasePlaylistFeature::IdAndLabel> PlaylistFeature::createPlaylistLabels() {
     // Setup the sidebar playlist model
     PlaylistStatsDAO& playlistStatsDao =
-            m_pLibrary->trackCollectionManager()
-                    ->internalCollection()
-                    ->getPlaylistStatsDAO(PlaylistDAO::PLHT_NOT_HIDDEN);
+            m_pLibrary->trackCollectionManager()->internalCollection()->getPlaylistStatsDAO();
 
     QList<BasePlaylistFeature::IdAndLabel> playlistLabels;
-    for (auto playlistInfo : playlistStatsDao.getPlaylistSummaries()) {
+    for (const auto& playlistInfo : playlistStatsDao.getPlaylistSummaries(
+                 PlaylistDAO::PLHT_NOT_HIDDEN)) {
         BasePlaylistFeature::IdAndLabel idAndLabel;
         idAndLabel.id = playlistInfo.playlistId;
         idAndLabel.label = createPlaylistLabel(

--- a/src/library/trackset/playlistfeature.cpp
+++ b/src/library/trackset/playlistfeature.cpp
@@ -123,7 +123,10 @@ QList<BasePlaylistFeature::IdAndLabel> PlaylistFeature::createPlaylistLabels() {
     QSqlDatabase database =
             m_pLibrary->trackCollectionManager()->internalCollection()->database();
 
-    PlaylistStatsDAO playlistStatsDao(m_countsDurationTableName);
+    PlaylistStatsDAO playlistStatsDao(
+            m_countsDurationTableName,
+            PlaylistDAO::PLHT_NOT_HIDDEN);
+
     playlistStatsDao.initialize(database);
     playlistStatsDao.preparePlaylistSummaryTable();
 

--- a/src/library/trackset/playlistfeature.cpp
+++ b/src/library/trackset/playlistfeature.cpp
@@ -26,8 +26,7 @@ PlaylistFeature::PlaylistFeature(Library* pLibrary, UserSettingsPointer pConfig)
                           pLibrary->trackCollectionManager(),
                           "mixxx.db.model.playlist"),
                   QStringLiteral("PLAYLISTHOME"),
-                  QStringLiteral("playlist"),
-                  QStringLiteral("PlaylistsCountsDurations")) {
+                  QStringLiteral("playlist")) {
     // construct child model
     std::unique_ptr<TreeItem> pRootItem = TreeItem::newRoot(this);
     m_pSidebarModel->setRootItem(std::move(pRootItem));
@@ -120,17 +119,12 @@ bool PlaylistFeature::dragMoveAcceptChild(const QModelIndex& index, const QUrl& 
 }
 
 QList<BasePlaylistFeature::IdAndLabel> PlaylistFeature::createPlaylistLabels() {
-    QSqlDatabase database =
-            m_pLibrary->trackCollectionManager()->internalCollection()->database();
-
-    PlaylistStatsDAO playlistStatsDao(
-            m_countsDurationTableName,
-            PlaylistDAO::PLHT_NOT_HIDDEN);
-
-    playlistStatsDao.initialize(database);
-    playlistStatsDao.preparePlaylistSummaryTable();
-
     // Setup the sidebar playlist model
+    PlaylistStatsDAO& playlistStatsDao =
+            m_pLibrary->trackCollectionManager()
+                    ->internalCollection()
+                    ->getPlaylistStatsDAO(PlaylistDAO::PLHT_NOT_HIDDEN);
+
     QList<BasePlaylistFeature::IdAndLabel> playlistLabels;
     for (auto playlistInfo : playlistStatsDao.getPlaylistSummaries()) {
         BasePlaylistFeature::IdAndLabel idAndLabel;

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -38,7 +38,6 @@ SetlogFeature::SetlogFeature(
                           /*keep hidden tracks*/ true),
                   QStringLiteral("SETLOGHOME"),
                   QStringLiteral("history"),
-                  QStringLiteral("SetlogCountsDurations"),
                   /*keep hidden tracks*/ true),
           m_currentPlaylistId(kInvalidPlaylistId),
           m_yearNodeId(kInvalidPlaylistId),
@@ -231,15 +230,10 @@ void SetlogFeature::onRightClickChild(const QPoint& globalPos, const QModelIndex
 QModelIndex SetlogFeature::constructChildModel(int selectedId) {
     // qDebug() << "SetlogFeature::constructChildModel() selected:" << selectedId;
     // Setup the sidebar playlist model
-    QSqlDatabase database =
-            m_pLibrary->trackCollectionManager()->internalCollection()->database();
-
-    PlaylistStatsDAO playlistStatsDao(
-            m_countsDurationTableName,
-            PlaylistDAO::PLHT_SET_LOG);
-
-    playlistStatsDao.initialize(database);
-    playlistStatsDao.preparePlaylistSummaryTable();
+    PlaylistStatsDAO& playlistStatsDao =
+            m_pLibrary->trackCollectionManager()
+                    ->internalCollection()
+                    ->getPlaylistStatsDAO(PlaylistDAO::PLHT_SET_LOG);
 
     // Nice to have: restore previous expanded/collapsed state of YEAR items
     clearChildModel();

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -231,9 +231,7 @@ QModelIndex SetlogFeature::constructChildModel(int selectedId) {
     // qDebug() << "SetlogFeature::constructChildModel() selected:" << selectedId;
     // Setup the sidebar playlist model
     PlaylistStatsDAO& playlistStatsDao =
-            m_pLibrary->trackCollectionManager()
-                    ->internalCollection()
-                    ->getPlaylistStatsDAO(PlaylistDAO::PLHT_SET_LOG);
+            m_pLibrary->trackCollectionManager()->internalCollection()->getPlaylistStatsDAO();
 
     // Nice to have: restore previous expanded/collapsed state of YEAR items
     clearChildModel();
@@ -242,7 +240,8 @@ QModelIndex SetlogFeature::constructChildModel(int selectedId) {
     // Generous estimate (number of years the db is used ;))
     itemList.reserve(kNumToplevelHistoryEntries + 15);
     int numEntries = 0;
-    for (auto playlistInfo : playlistStatsDao.getPlaylistSummaries()) {
+    for (const auto& playlistInfo :
+            playlistStatsDao.getPlaylistSummaries(PlaylistDAO::PLHT_SET_LOG)) {
         int id = playlistInfo.playlistId;
         QString label = createPlaylistLabel(
                 playlistInfo.name, playlistInfo.count, playlistInfo.duration);


### PR DESCRIPTION
`SetlogFeature` and `PlaylistFeature` (as well as `BasePlaylistFeature`) contain nearly identical code for creating a summary table of the track number and total duration of all playlists (both history playlists and normal playlists).

This PR unifies the code into a single `PlaylistStatsDAO` class, which has the added advantage of moving DB-layer code from the `*Feature` classes to a more appropriate location.