### PR TITLE
(fix) WCoverArt: popup on click release

### DIFF
--- a/src/widget/wcoverart.cpp
+++ b/src/widget/wcoverart.cpp
@@ -259,7 +259,8 @@ void WCoverArt::mouseReleaseEvent(QMouseEvent* pEvent) {
         return;
     }
 
-    if (pEvent->buttons() == Qt::LeftButton && m_loadedTrack &&
+    if (pEvent->button() == Qt::LeftButton &&
+            m_loadedTrack &&
             m_clickTimer.isActive()) { // init/close fullsize cover
         if (m_pDlgFullSize->isVisible()) {
             m_pDlgFullSize->close();


### PR DESCRIPTION
Fixes #13181 
Forgot to backport #13035 



Though, I'm confused why this can break so easily.

FWIW, this is what various button tests return for trackpad click release with Qt 5.12.8:
**FALSE** pEvent->buttons() & Qt::LeftButton
**FALSE** pEvent->buttons() == Qt::LeftButton
**FALSE** pEvent->buttons().testFlag(Qt::LeftButton)
**TRUE** pEvent->button() == Qt::LeftButton (fix)

* various widgets' mouse**Press**Event() succesfully use 
`pEvent->buttons() == Qt::LeftButton`
* in release events however we use
`pEvent->button()`
