### PR TITLE
(fix) Controller IO table: fix display text for Action/control delegate

### DIFF
--- a/src/controllers/controllerinputmappingtablemodel.cpp
+++ b/src/controllers/controllerinputmappingtablemodel.cpp
@@ -227,9 +227,9 @@ QVariant ControllerInputMappingTableModel::data(const QModelIndex& index,
                     VERIFY_OR_DEBUG_ASSERT(del) {
                     return QString();
                     }
-                    return del->displayText(QVariant::fromValue(mapping.control), QLocale());
+                    return del->displayText(QVariant::fromValue(*control), QLocale());
                 }
-                return QVariant::fromValue(mapping.control);
+                return QVariant::fromValue(*control);
             }
             case MIDI_COLUMN_COMMENT:
                 return mapping.description;


### PR DESCRIPTION
The Action column displayed only "No control chosen".