### PR TITLE
Novation Dicer: remove flanger mapping with quickeffect toggle

### DIFF
--- a/res/controllers/Novation Dicer.midi.xml
+++ b/res/controllers/Novation Dicer.midi.xml
@@ -274,8 +274,8 @@
             <control>
                 <status>0x9f</status>
                 <midino>0x3e</midino>
-                <group>[Channel2]</group>
-                <key>NovationDicer.flangeEffect</key>
+                <group>[QuickEffectRack1_[Channel2]_Effect1]</group>
+                <key>NovationDicer.toggleQuickEffect</key>
                 <description></description>
                 <options>
                     <script-binding/>
@@ -574,8 +574,8 @@
             <control>
                 <status>0x9c</status>
                 <midino>0x3e</midino>
-                <group>[Channel1]</group>
-                <key>NovationDicer.flangeEffect</key>
+                <group>[QuickEffectRack1_[Channel1]_Effect1]</group>
+                <key>NovationDicer.toggleQuickEffect</key>
                 <description></description>
                 <options>
                     <script-binding/>
@@ -779,8 +779,8 @@
                 <off>0x0</off>
             </output>
             <output>
-                <group>[Channel1]</group>
-                <key>flanger</key>
+                <group>[QuickEffectRack1_[Channel1]_Effect1]</group>
+                <key>enabled</key>
                 <description></description>
                 <minimum>0.1</minimum>
                 <maximum>1</maximum>
@@ -856,8 +856,8 @@
                 <off>0x0</off>
             </output>
             <output>
-                <group>[Channel2]</group>
-                <key>flanger</key>
+                <group>[QuickEffectRack1_[Channel2]_Effect1]</group>
+                <key>enabled</key>
                 <description></description>
                 <minimum>0.1</minimum>
                 <maximum>1</maximum>

--- a/res/controllers/Novation-Dicer-scripts.js
+++ b/res/controllers/Novation-Dicer-scripts.js
@@ -78,8 +78,6 @@ NovationDicer.init = function (id)
     midi.sendShortMsg(0x9f,0x43,NovationDicer.softOrange);
     midi.sendShortMsg(0x9f,0x44,NovationDicer.softOrange);
     midi.sendShortMsg(0x9f,0x45,NovationDicer.softOrange);
-
-    engine.setValue("[Flanger]", "lfoDepth", 1);    //Crank up the depth so the flanger does something
 }
 
 
@@ -358,11 +356,11 @@ NovationDicer.stutter = function(group)
      }
 }
 
-NovationDicer.flangeEffect = function(channel, control, value, status, group)
+NovationDicer.toggleQuickEffect = function(channel, control, value, status, group)
 {
     if (value)  //Button pressed
     {
-        engine.setValue(group, "flanger", !engine.getValue(group, "flanger"));  //Toggle the flanger
+        script.toggleControl(group, "enabled");
     }
 }
 


### PR DESCRIPTION
Fixes #13134

Tbh. this is just an idea. I don't know how much sense it makes. I would appreciate alternative suggestions.