### PR TITLE
Track/BPM: add `bpmlock` control

### DIFF
--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -130,10 +130,10 @@ BpmControl::BpmControl(const QString& group,
             this, &BpmControl::slotTapFilter,
             Qt::DirectConnection);
 
-    m_pToggleBpmLock = std::make_unique<ControlPushButton>(
-            ConfigKey(group, "bpm_toggle_lock"), false);
-    connect(m_pToggleBpmLock.get(),
-            &ControlObject::valueChanged,
+    m_pBpmLock = std::make_unique<ControlPushButton>(
+            ConfigKey(group, "bpmlock"), false);
+    m_pBpmLock->setButtonMode(ControlPushButton::TOGGLE);
+    m_pBpmLock->connectValueChangeRequest(
             this,
             &BpmControl::slotToggleBpmLock,
             Qt::DirectConnection);
@@ -983,6 +983,10 @@ void BpmControl::trackBeatsUpdated(mixxx::BeatsPointer pBeats) {
     resetSyncAdjustment();
 }
 
+void BpmControl::trackBpmLockChanged(bool locked) {
+    m_pBpmLock->setAndConfirm(locked);
+}
+
 void BpmControl::notifySeek(mixxx::audio::FramePos position) {
     updateBeatDistance(position);
 }
@@ -1030,15 +1034,14 @@ void BpmControl::slotBeatsTranslateMatchAlignment(double v) {
 }
 
 void BpmControl::slotToggleBpmLock(double v) {
-    if (v <= 0) {
-        return;
-    }
+    Q_UNUSED(v);
     const TrackPointer pTrack = getEngineBuffer()->getLoadedTrack();
     if (!pTrack) {
         return;
     }
     bool locked = pTrack->isBpmLocked();
     pTrack->setBpmLocked(!locked);
+    // The pushbutton is updated in trackBpmLockChanged() via bpmLockChanged() signal.
 }
 
 mixxx::Bpm BpmControl::updateLocalBpm() {

--- a/src/engine/controls/bpmcontrol.h
+++ b/src/engine/controls/bpmcontrol.h
@@ -94,6 +94,7 @@ class BpmControl : public EngineControl {
     double getRateRatio() const;
     void trackLoaded(TrackPointer pNewTrack) override;
     void trackBeatsUpdated(mixxx::BeatsPointer pBeats) override;
+    void trackBpmLockChanged(bool locked);
     void notifySeek(mixxx::audio::FramePos position) override;
 
   private slots:
@@ -146,7 +147,7 @@ class BpmControl : public EngineControl {
     ControlPushButton* m_pTranslateBeatsLater;
     ControlEncoder* m_pTranslateBeatsMove;
 
-    std::unique_ptr<ControlPushButton> m_pToggleBpmLock;
+    std::unique_ptr<ControlPushButton> m_pBpmLock;
 
     // The current effective BPM of the engine
     ControlLinPotmeter* m_pEngineBpm;

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -651,12 +651,18 @@ void EngineBuffer::notifyTrackLoaded(
     }
 
     if (pNewTrack) {
-        connect(
-                pNewTrack.get(),
+        connect(pNewTrack.get(),
                 &Track::beatsUpdated,
                 this,
                 &EngineBuffer::slotUpdatedTrackBeats,
                 Qt::DirectConnection);
+        connect(pNewTrack.get(),
+                &Track::bpmLockChanged,
+                m_pBpmControl,
+                &BpmControl::trackBpmLockChanged,
+                Qt::DirectConnection);
+        bool bpmLocked = pNewTrack.get()->isBpmLocked();
+        m_pBpmControl->trackBpmLockChanged(bpmLocked);
     }
 
     // Inform BaseTrackPlayer via a queued connection

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -1426,6 +1426,7 @@ void Track::setBpmLocked(bool bpmLocked) {
     auto locked = lockMutex(&m_qMutex);
     if (compareAndSet(m_record.ptrBpmLocked(), bpmLocked)) {
         markDirtyAndUnlock(&locked);
+        emit bpmLockChanged(bpmLocked);
     }
 }
 

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -425,6 +425,7 @@ class Track : public QObject {
     void trackTotalChanged(const QString&);
     void commentChanged(const QString&);
     void bpmChanged();
+    void bpmLockChanged(bool locked);
     void keyChanged();
     void timesPlayedChanged();
     void durationChanged();


### PR DESCRIPTION
This replaces recently introduced `bpm_toggle_lock` with `bpmlock`.
Benefit is that we can now bind GUI controls also for feedback, e.g. have a BPM lock toggle and block/disable beatgrid controls if BPM are locked.

The pushbutton only triggers the un/locking in Track, CO is updated by track signal.