### PR TITLE
(fixup) OpenGLWindow / waveform / spinnies: don't get keyboard focus on click

### DIFF
--- a/src/widget/openglwindow.cpp
+++ b/src/widget/openglwindow.cpp
@@ -12,9 +12,8 @@
 OpenGLWindow::OpenGLWindow(WGLWidget* pWidget)
         : m_pWidget(pWidget) {
     setFormat(WaveformWidgetFactory::getSurfaceFormat());
-    // Set the tooltip flag to prevent this window/widget from getting
-    // keyboard focus on click.
-    setFlag(Qt::ToolTip);
+    // Prevent this window/widget from getting keyboard focus on click.
+    setFlag(Qt::WindowDoesNotAcceptFocus);
 }
 
 OpenGLWindow::~OpenGLWindow() {


### PR DESCRIPTION
fixup for #13174 that also work with Qt6 (Qt 6.2.3 on Linux).

@m0dB Please take a look / test on macOS.