### PR TITLE
Track menu, Remove from disk: stop and eject all affected decks

### DIFF
--- a/src/mixer/playerinfo.cpp
+++ b/src/mixer/playerinfo.cpp
@@ -86,6 +86,20 @@ bool PlayerInfo::isTrackLoaded(const TrackPointer& pTrack) const {
     return false;
 }
 
+QStringList PlayerInfo::getPlayerGroupsWithTracksLoaded(const TrackPointerList& tracks) const {
+    const auto locker = lockMutex(&m_mutex);
+    QStringList groups;
+    QMapIterator<QString, TrackPointer> it(m_loadedTrackMap);
+    while (it.hasNext()) {
+        it.next();
+        TrackPointer pLoadedTrack = it.value();
+        if (pLoadedTrack && tracks.contains(pLoadedTrack)) {
+            groups.append(it.key());
+        }
+    }
+    return groups;
+}
+
 QMap<QString, TrackPointer> PlayerInfo::getLoadedTracks() {
     const auto locker = lockMutex(&m_mutex);
     QMap<QString, TrackPointer> ret = m_loadedTrackMap;

--- a/src/mixer/playerinfo.h
+++ b/src/mixer/playerinfo.h
@@ -20,6 +20,7 @@ class PlayerInfo : public QObject {
     TrackPointer getCurrentPlayingTrack();
     int getCurrentPlayingDeck();
     QMap<QString, TrackPointer> getLoadedTracks();
+    QStringList getPlayerGroupsWithTracksLoaded(const TrackPointerList& tracks) const;
     bool isTrackLoaded(const TrackPointer& pTrack) const;
     bool isFileLoaded(const QString& track_location) const;
 

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -27,6 +27,7 @@
 #include "library/trackset/crate/crate.h"
 #include "library/trackset/crate/cratefeaturehelper.h"
 #include "library/trackset/crate/cratesummary.h"
+#include "mixer/playerinfo.h"
 #include "mixer/playermanager.h"
 #include "moc_wtrackmenu.cpp"
 #include "preferences/colorpalettesettings.h"
@@ -1138,6 +1139,21 @@ TrackPointer WTrackMenu::getFirstTrackPointer() const {
     return m_pTrack;
 }
 
+TrackPointerList WTrackMenu::getTrackPointers() const {
+    TrackPointerList tracks;
+    if (m_pTrackModel) {
+        for (const auto& index : m_trackIndexList) {
+            const auto pTrack = m_pTrackModel->getTrack(index);
+            if (pTrack) {
+                tracks.append(pTrack);
+            }
+        }
+    } else {
+        tracks.append(m_pTrack);
+    }
+    return tracks;
+}
+
 std::unique_ptr<mixxx::TrackPointerIterator> WTrackMenu::newTrackPointerIterator() const {
     if (m_pTrackModel) {
         if (m_trackIndexList.isEmpty()) {
@@ -2117,7 +2133,9 @@ void WTrackMenu::slotRemoveFromDisk() {
 
         QString delWarningText;
         if (m_pTrackModel) {
-#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+            delWarningText = tr("Move these files to the trash bin?");
+#else
             delWarningText = tr("Permanently delete these files from disk?") +
                     QStringLiteral("<br><br><b>") +
                     tr("This can not be undone!") + QStringLiteral("</b>");
@@ -2125,13 +2143,23 @@ void WTrackMenu::slotRemoveFromDisk() {
         } else { // track menu of track labels
 #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
 
-            delWarningText = tr("Stop the deck and move this track file to the trash bin?");
+            delWarningText = tr("Move this track file to the trash bin?");
 #else
             delWarningText =
-                    tr("Stop the deck and permanently delete this track file from disk?") +
+                    tr("Permanently delete this track file from disk?") +
                     QStringLiteral("<br><br><b>") +
                     tr("This can not be undone!") + QStringLiteral("</b>");
 #endif
+        }
+        delWarningText.append(QStringLiteral("<br><br>"));
+        if (m_pTrackModel) {
+            delWarningText.append(tr(
+                    "All decks where these tracks are loaded will be "
+                    "stopped and the tracks will be ejected."));
+        } else {
+            delWarningText.append(tr(
+                    "All decks where this track is loaded will be "
+                    "stopped and the track will be ejected."));
         }
 
         // Setup the warning message and dialog buttons
@@ -2179,24 +2207,19 @@ void WTrackMenu::slotRemoveFromDisk() {
         }
     }
 
-    // If the operation was initiated from a deck's track menu
-    // we'll first stop the deck and eject the track.
-    // TODO(ronso0) Consider querying PlayerManager if any of the tracks is loaded
-    // into another (playing?) deck?
-    // Also (rare situation) the track we work on might have been replaced (in the deck)
-    // by another one in the mean time (Auto DJ) and we would unnecessarily stop & eject.
-    // Ideally, there would be a PlayerManager instance that does
-    // stopAndEjectAllPlayersWithTrackLoaded(TrackPointer / TrackId)
+    // Try to keep a usable index for navigation if the track is in the
+    // current track view.
     bool restoreViewState = false;
-    if (m_pTrack) {
-        ControlObject::set(ConfigKey(m_deckGroup, "stop"), 1.0);
-        ControlObject::set(ConfigKey(m_deckGroup, "eject"), 1.0);
-        // Try to keep a usable index for navigation if the track is in the
-        // current track view.
-        if (m_pLibrary->isTrackIdInCurrentLibraryView(m_pTrack->getId())) {
-            restoreViewState = true;
-            emit saveCurrentViewState();
-        }
+    if (m_pTrack && m_pLibrary->isTrackIdInCurrentLibraryView(m_pTrack->getId())) {
+        restoreViewState = true;
+        emit saveCurrentViewState();
+    }
+    // Stop all affected decks and eject tracks.
+    const TrackPointerList tracks = getTrackPointers();
+    const QStringList groups = PlayerInfo::instance().getPlayerGroupsWithTracksLoaded(tracks);
+    for (const QString& group : groups) {
+        ControlObject::set(ConfigKey(group, "stop"), 1.0);
+        ControlObject::set(ConfigKey(group, "eject"), 1.0);
     }
 
     // Set up and initiate the track batch operation

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -183,6 +183,7 @@ class WTrackMenu : public QMenu {
     QList<TrackRef> getTrackRefs() const;
 
     TrackPointer getFirstTrackPointer() const;
+    TrackPointerList getTrackPointers() const;
 
     std::unique_ptr<mixxx::TrackPointerIterator> newTrackPointerIterator() const;
 


### PR DESCRIPTION
also stop decks and eject tracks if Move to Trash is invoked for track(s) from the tracks view.