### PR TITLE
Fix reading metadata for some file extensions

### DIFF
--- a/src/sources/metadatasourcetaglib.cpp
+++ b/src/sources/metadatasourcetaglib.cpp
@@ -111,7 +111,7 @@ MetadataSourceTagLib::importTrackMetadataAndCoverImage(
     // is read and data in subsequent tags is ignored.
 
     switch (m_fileType) {
-    case taglib::FileType::MP3: {
+    case taglib::FileType::MPEG: {
         TagLib::MPEG::File file(TAGLIB_FILENAME_FROM_QSTRING(m_fileName));
         if (!taglib::readAudioPropertiesFromFile(pTrackMetadata, file)) {
             break;
@@ -198,7 +198,7 @@ MetadataSourceTagLib::importTrackMetadataAndCoverImage(
         }
         break;
     }
-    case taglib::FileType::OGG: {
+    case taglib::FileType::OggVorbis: {
         TagLib::Ogg::Vorbis::File file(TAGLIB_FILENAME_FROM_QSTRING(m_fileName));
         if (!taglib::readAudioPropertiesFromFile(pTrackMetadata, file)) {
             break;
@@ -207,14 +207,14 @@ MetadataSourceTagLib::importTrackMetadataAndCoverImage(
         if (pTag) {
             taglib::xiph::importTrackMetadataFromTag(pTrackMetadata,
                     *pTag,
-                    taglib::FileType::OGG,
+                    taglib::FileType::OggVorbis,
                     resetMissingTagMetadata);
             taglib::xiph::importCoverImageFromTag(pCoverImage, *pTag);
             return afterImport(ImportResult::Succeeded);
         }
         break;
     }
-    case taglib::FileType::OPUS: {
+    case taglib::FileType::Opus: {
         TagLib::Ogg::Opus::File file(TAGLIB_FILENAME_FROM_QSTRING(m_fileName));
         if (!taglib::readAudioPropertiesFromFile(pTrackMetadata, file)) {
             break;
@@ -223,14 +223,14 @@ MetadataSourceTagLib::importTrackMetadataAndCoverImage(
         if (pTag) {
             taglib::xiph::importTrackMetadataFromTag(pTrackMetadata,
                     *pTag,
-                    taglib::FileType::OPUS,
+                    taglib::FileType::Opus,
                     resetMissingTagMetadata);
             taglib::xiph::importCoverImageFromTag(pCoverImage, *pTag);
             return afterImport(ImportResult::Succeeded);
         }
         break;
     }
-    case taglib::FileType::WV: {
+    case taglib::FileType::WavPack: {
         TagLib::WavPack::File file(TAGLIB_FILENAME_FROM_QSTRING(m_fileName));
         if (!taglib::readAudioPropertiesFromFile(pTrackMetadata, file)) {
             break;
@@ -474,7 +474,7 @@ class OggTagSaver : public TagSaver {
 #else
         return pFile->isOpen() &&
                 taglib::xiph::exportTrackMetadataIntoTag(
-                        pFile->tag(), trackMetadata, taglib::FileType::OGG);
+                        pFile->tag(), trackMetadata, taglib::FileType::OggVorbis);
 #endif
     }
 
@@ -503,7 +503,7 @@ class OpusTagSaver : public TagSaver {
             const TrackMetadata& trackMetadata) {
         return pFile->isOpen() &&
                 taglib::xiph::exportTrackMetadataIntoTag(
-                        pFile->tag(), trackMetadata, taglib::FileType::OPUS);
+                        pFile->tag(), trackMetadata, taglib::FileType::Opus);
     }
 
     TagLib::Ogg::Opus::File m_file;
@@ -636,7 +636,7 @@ MetadataSourceTagLib::exportTrackMetadata(
 
     std::unique_ptr<TagSaver> pTagSaver;
     switch (m_fileType) {
-    case taglib::FileType::MP3: {
+    case taglib::FileType::MPEG: {
         pTagSaver = std::make_unique<MpegTagSaver>(safelyWritableFile.fileName(), trackMetadata);
         break;
     }
@@ -648,15 +648,15 @@ MetadataSourceTagLib::exportTrackMetadata(
         pTagSaver = std::make_unique<FlacTagSaver>(safelyWritableFile.fileName(), trackMetadata);
         break;
     }
-    case taglib::FileType::OGG: {
+    case taglib::FileType::OggVorbis: {
         pTagSaver = std::make_unique<OggTagSaver>(safelyWritableFile.fileName(), trackMetadata);
         break;
     }
-    case taglib::FileType::OPUS: {
+    case taglib::FileType::Opus: {
         pTagSaver = std::make_unique<OpusTagSaver>(safelyWritableFile.fileName(), trackMetadata);
         break;
     }
-    case taglib::FileType::WV: {
+    case taglib::FileType::WavPack: {
         pTagSaver = std::make_unique<WavPackTagSaver>(safelyWritableFile.fileName(), trackMetadata);
         break;
     }

--- a/src/sources/metadatasourcetaglib.h
+++ b/src/sources/metadatasourcetaglib.h
@@ -7,16 +7,11 @@ namespace mixxx {
 // Universal default implementation of IMetadataSource using TagLib.
 class MetadataSourceTagLib : public MetadataSource {
   public:
-    explicit MetadataSourceTagLib(
-            const QString& fileName)
-            : m_fileName(fileName),
-              m_fileType(taglib::getFileTypeFromFileName(fileName)) {
-    }
     MetadataSourceTagLib(
             const QString& fileName,
-            taglib::FileType fileType)
+            const QString& fileType)
             : m_fileName(fileName),
-              m_fileType(fileType) {
+              m_fileType(taglib::stringToEnumFileType(fileType)) {
     }
 
     std::pair<ImportResult, QDateTime> importTrackMetadataAndCoverImage(

--- a/src/sources/soundsource.cpp
+++ b/src/sources/soundsource.cpp
@@ -83,7 +83,7 @@ QString SoundSource::getTypeFromFile(const QFileInfo& fileInfo) {
 
 SoundSource::SoundSource(const QUrl& url, const QString& type)
         : AudioSource(validateLocalFileUrl(url)),
-          MetadataSourceTagLib(getLocalFileName()),
+          MetadataSourceTagLib(getLocalFileName(), type),
           m_type(type) {
 }
 

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -385,12 +385,12 @@ QStringList SoundSourceProviderFFmpeg::getSupportedFileTypes() const {
                 list.append("mp4");
                 continue;
             } else if (!strcmp(pavInputFormat->name, "mov,mp4,m4a,3gp,3g2,mj2")) {
-                list.append("mov");
+                list.append("mov"); // QuickTime File Format video/quicktime
                 list.append("mp4");
                 list.append("m4a");
-                list.append("3gp");
-                list.append("3g2");
-                list.append("mj2");
+                list.append("3gp"); // 3GPP file format audio/3gpp
+                list.append("3g2"); // 3GPP2 file format audio/3gpp2
+                list.append("mj2"); // Motion JPEG 2000 video/mj2
                 continue;
             } else if (!strcmp(pavInputFormat->name, "opus") ||
                     !strcmp(pavInputFormat->name, "libopus")) {
@@ -419,7 +419,7 @@ QStringList SoundSourceProviderFFmpeg::getSupportedFileTypes() const {
                 continue;
             } else if (!strcmp(pavInputFormat->name, "wma") ||
                     !strcmp(pavInputFormat->name, "xwma")) {
-                list.append("wma");
+                list.append("wma"); // Windows Media Audio audio/x-ms-wma
                 continue;
             */
                 ///////////////////////////////////////////////////////////
@@ -427,22 +427,22 @@ QStringList SoundSourceProviderFFmpeg::getSupportedFileTypes() const {
                 ///////////////////////////////////////////////////////////
                 /*
             } else if (!strcmp(pavInputFormat->name, "ac3")) {
-                list.append("ac3");
+                list.append("ac3"); // AC-3 Compressed Audio (Dolby Digital), Revision A audio/ac3
                 continue;
             } else if (!strcmp(pavInputFormat->name, "caf")) {
-                list.append("caf");
+                list.append("caf"); // Apple Lossless
                 continue;
             } else if (!strcmp(pavInputFormat->name, "mpc")) {
-                list.append("mpc");
+                list.append("mpc"); // Musepack encoded audio audio/musepack
                 continue;
             } else if (!strcmp(pavInputFormat->name, "mpeg")) {
                 list.append("mpeg");
                 continue;
             } else if (!strcmp(pavInputFormat->name, "tak")) {
-                list.append("tak");
+                list.append("tak"); // Tom's lossless Audio Kompressor audio/x-tak
                 continue;
             } else if (!strcmp(pavInputFormat->name, "tta")) {
-                list.append("tta");
+                list.append("tta"); // True Audio, version 2
                 continue;
             */
             }

--- a/src/sources/soundsourcesndfile.cpp
+++ b/src/sources/soundsourcesndfile.cpp
@@ -16,7 +16,7 @@ const QStringList kSupportedFileTypes = {
         // ALAC/CAF has been added in version 1.0.26
         // NOTE(uklotzde, 2015-05-26): Unfortunately ALAC in M4A containers
         // is still not supported https://github.com/mixxxdj/mixxx/pull/904#issuecomment-221928362
-        QStringLiteral("caf"),
+        QStringLiteral("caf"), // Core Audio Format / Apple Lossless
         QStringLiteral("flac"),
         QStringLiteral("ogg"),
         QStringLiteral("wav"),

--- a/src/test/seratobeatgridtest.cpp
+++ b/src/test/seratobeatgridtest.cpp
@@ -88,11 +88,11 @@ TEST_F(SeratoBeatGridTest, ParseBeatGridDataMP3) {
     parseBeatGridDataInDirectory(
             QDir(MixxxTest::getOrInitTestDir().filePath(
                     QStringLiteral("serato/data/mp3/beatgrid"))),
-            mixxx::taglib::FileType::MP3);
+            mixxx::taglib::FileType::MPEG);
 }
 
 TEST_F(SeratoBeatGridTest, ParseEmptyDataMP3) {
-    parseEmptyBeatGridData(mixxx::taglib::FileType::MP3);
+    parseEmptyBeatGridData(mixxx::taglib::FileType::MPEG);
 }
 
 TEST_F(SeratoBeatGridTest, ParseBeatGridDataMP4) {

--- a/src/test/seratomarkers2test.cpp
+++ b/src/test/seratomarkers2test.cpp
@@ -429,7 +429,7 @@ TEST_F(SeratoMarkers2Test, ParseMarkers2DataMP3) {
     parseMarkers2DataInDirectory(
             QDir(MixxxTest::getOrInitTestDir().filePath(
                     QStringLiteral("serato/data/mp3/markers2"))),
-            mixxx::taglib::FileType::MP3);
+            mixxx::taglib::FileType::MPEG);
 }
 
 TEST_F(SeratoMarkers2Test, ParseMarkers2DataMP4) {
@@ -450,11 +450,11 @@ TEST_F(SeratoMarkers2Test, ParseMarkers2DataOGG) {
     parseMarkers2DataInDirectory(
             QDir(MixxxTest::getOrInitTestDir().filePath(
                     QStringLiteral("serato/data/ogg/markers2"))),
-            mixxx::taglib::FileType::OGG);
+            mixxx::taglib::FileType::OggVorbis);
 }
 
 TEST_F(SeratoMarkers2Test, ParseEmptyDataMP3) {
-    parseEmptyMarkers2Data(mixxx::taglib::FileType::MP3);
+    parseEmptyMarkers2Data(mixxx::taglib::FileType::MPEG);
 }
 
 TEST_F(SeratoMarkers2Test, ParseEmptyDataMP4) {

--- a/src/test/seratomarkerstest.cpp
+++ b/src/test/seratomarkerstest.cpp
@@ -181,7 +181,7 @@ TEST_F(SeratoMarkersTest, ParseMarkersDataMP3) {
     parseMarkersDataInDirectory(
             QDir(MixxxTest::getOrInitTestDir().filePath(
                     QStringLiteral("serato/data/mp3/markers_"))),
-            mixxx::taglib::FileType::MP3);
+            mixxx::taglib::FileType::MPEG);
 }
 
 TEST_F(SeratoMarkersTest, ParseMarkersDataMP4) {
@@ -192,7 +192,7 @@ TEST_F(SeratoMarkersTest, ParseMarkersDataMP4) {
 }
 
 TEST_F(SeratoMarkersTest, ParseEmptyDataMP3) {
-    parseEmptyMarkersData(mixxx::taglib::FileType::MP3);
+    parseEmptyMarkersData(mixxx::taglib::FileType::MPEG);
 }
 
 TEST_F(SeratoMarkersTest, ParseEmptyDataMP4) {

--- a/src/test/seratotagstest.cpp
+++ b/src/test/seratotagstest.cpp
@@ -271,7 +271,7 @@ TEST_F(SeratoTagsTest, CueColorConversionRoundtrip) {
 }
 
 TEST_F(SeratoTagsTest, MarkersParseDumpRoundtrip) {
-    const auto filetype = mixxx::taglib::FileType::MP3;
+    const auto filetype = mixxx::taglib::FileType::MPEG;
     QDir dir(MixxxTest::getOrInitTestDir().filePath(QStringLiteral("/serato/data/mp3/markers_/")));
     dir.setFilter(QDir::Files);
     dir.setNameFilters(QStringList() << "*.octet-stream");
@@ -306,7 +306,7 @@ TEST_F(SeratoTagsTest, MarkersParseDumpRoundtrip) {
 }
 
 TEST_F(SeratoTagsTest, Markers2RoundTrip) {
-    const auto filetype = mixxx::taglib::FileType::MP3;
+    const auto filetype = mixxx::taglib::FileType::MPEG;
     QDir dir(MixxxTest::getOrInitTestDir().filePath(QStringLiteral("serato/data/mp3/markers2/")));
     dir.setFilter(QDir::Files);
     dir.setNameFilters(QStringList() << "*.octet-stream");

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -7,6 +7,7 @@
 #include "sources/soundsourceproxy.h"
 #include "test/mixxxtest.h"
 #include "test/soundsourceproviderregistration.h"
+#include "track/taglib/trackmetadata_file.h"
 #include "track/track.h"
 #include "track/trackmetadata.h"
 #include "util/samplebuffer.h"
@@ -1084,5 +1085,17 @@ TEST_F(SoundSourceProxyTest, freeModeGarbage) {
                 providerRegistration.getProvider());
         ASSERT_TRUE(pContReadSource != nullptr);
         break;
+    }
+}
+
+TEST_F(SoundSourceProxyTest, taglibStringToEnumFileType) {
+    const QStringList fileTypes = SoundSourceProxy::getSupportedFileTypes();
+    for (const auto& fileType : fileTypes) {
+        qDebug() << fileType;
+        if (fileType != "okt" &&     // Oktalyzer
+                fileType != "stm") { // "Scream Tracker";
+            ASSERT_NE(mixxx::taglib::stringToEnumFileType(fileType),
+                    mixxx::taglib::FileType::Unknown);
+        }
     }
 }

--- a/src/test/taglibtest.cpp
+++ b/src/test/taglibtest.cpp
@@ -36,7 +36,7 @@ TEST_F(TagLibTest, WriteID3v2Tag) {
     trackMetadata.refTrackInfo().setTitle(QStringLiteral("title"));
     const auto exported =
             mixxx::MetadataSourceTagLib(
-                    tmpFileName, mixxx::taglib::FileType::MP3)
+                    tmpFileName, mixxx::taglib::FileType::MPEG)
                     .exportTrackMetadata(trackMetadata);
     ASSERT_EQ(mixxx::MetadataSource::ExportResult::Succeeded, exported.first);
     ASSERT_FALSE(exported.second.isNull());
@@ -56,7 +56,7 @@ TEST_F(TagLibTest, WriteID3v2Tag) {
     trackMetadata.refTrackInfo().setTitle(QStringLiteral("title2"));
     const auto exported2 =
             mixxx::MetadataSourceTagLib(
-                    tmpFileName, mixxx::taglib::FileType::MP3)
+                    tmpFileName, mixxx::taglib::FileType::MPEG)
                     .exportTrackMetadata(trackMetadata);
     ASSERT_EQ(mixxx::MetadataSource::ExportResult::Succeeded, exported.first);
     ASSERT_FALSE(exported.second.isNull());

--- a/src/test/taglibtest.cpp
+++ b/src/test/taglibtest.cpp
@@ -36,7 +36,7 @@ TEST_F(TagLibTest, WriteID3v2Tag) {
     trackMetadata.refTrackInfo().setTitle(QStringLiteral("title"));
     const auto exported =
             mixxx::MetadataSourceTagLib(
-                    tmpFileName, mixxx::taglib::FileType::MPEG)
+                    tmpFileName, "mp3")
                     .exportTrackMetadata(trackMetadata);
     ASSERT_EQ(mixxx::MetadataSource::ExportResult::Succeeded, exported.first);
     ASSERT_FALSE(exported.second.isNull());
@@ -56,7 +56,7 @@ TEST_F(TagLibTest, WriteID3v2Tag) {
     trackMetadata.refTrackInfo().setTitle(QStringLiteral("title2"));
     const auto exported2 =
             mixxx::MetadataSourceTagLib(
-                    tmpFileName, mixxx::taglib::FileType::MPEG)
+                    tmpFileName, "mp3")
                     .exportTrackMetadata(trackMetadata);
     ASSERT_EQ(mixxx::MetadataSource::ExportResult::Succeeded, exported.first);
     ASSERT_FALSE(exported.second.isNull());

--- a/src/track/beatsimporter.h
+++ b/src/track/beatsimporter.h
@@ -19,7 +19,9 @@ class BeatsImporter {
 
     /// Determines the timing offset and returns a Beats object.
     virtual BeatsPointer importBeatsAndApplyTimingOffset(
-            const QString& filePath, const audio::StreamInfo& streamInfo) = 0;
+            const QString& filePath,
+            const QString& fileType,
+            const audio::StreamInfo& streamInfo) = 0;
 };
 
 typedef std::shared_ptr<BeatsImporter> BeatsImporterPointer;

--- a/src/track/cueinfoimporter.cpp
+++ b/src/track/cueinfoimporter.cpp
@@ -12,14 +12,15 @@ bool CueInfoImporter::hasCueOfType(CueType cueType) const {
             return true;
         }
     }
-
     return false;
 }
 
 double CueInfoImporter::guessTimingOffsetMillis(
         const QString& filePath,
+        const QString& fileType,
         const audio::SignalInfo& signalInfo) const {
     Q_UNUSED(filePath);
+    Q_UNUSED(fileType);
     Q_UNUSED(signalInfo);
     return 0;
 };
@@ -34,6 +35,7 @@ bool CueInfoImporter::isEmpty() const {
 
 QList<CueInfo> CueInfoImporter::importCueInfosAndApplyTimingOffset(
         const QString& filePath,
+        const QString& fileType,
         const audio::SignalInfo& signalInfo) {
     // Consume the collected cue points during the import
     QList<CueInfo> cueInfos = m_cueInfos;
@@ -43,7 +45,7 @@ QList<CueInfo> CueInfoImporter::importCueInfosAndApplyTimingOffset(
         return cueInfos;
     }
 
-    double timingOffsetMillis = guessTimingOffsetMillis(filePath, signalInfo);
+    double timingOffsetMillis = guessTimingOffsetMillis(filePath, fileType, signalInfo);
 
     // If we don't have any offset, we can just return the CueInfo objects
     // unchanged.

--- a/src/track/cueinfoimporter.h
+++ b/src/track/cueinfoimporter.h
@@ -22,6 +22,7 @@ class CueInfoImporter {
     /// in subclasses.
     virtual double guessTimingOffsetMillis(
             const QString& filePath,
+            const QString& fileType,
             const audio::SignalInfo& signalInfo) const;
 
     int size() const;
@@ -29,6 +30,7 @@ class CueInfoImporter {
 
     QList<CueInfo> importCueInfosAndApplyTimingOffset(
             const QString& filePath,
+            const QString& fileType,
             const audio::SignalInfo& signalInfo);
 
   private:

--- a/src/track/serato/beatgrid.cpp
+++ b/src/track/serato/beatgrid.cpp
@@ -174,7 +174,7 @@ bool SeratoBeatGrid::parse(SeratoBeatGrid* seratoBeatGrid,
     }
 
     switch (fileType) {
-    case taglib::FileType::MP3:
+    case taglib::FileType::MPEG:
     case taglib::FileType::AIFF:
         return parseID3(seratoBeatGrid, data);
     case taglib::FileType::MP4:
@@ -363,7 +363,7 @@ bool SeratoBeatGrid::parseBase64Encoded(
 
 QByteArray SeratoBeatGrid::dump(taglib::FileType fileType) const {
     switch (fileType) {
-    case taglib::FileType::MP3:
+    case taglib::FileType::MPEG:
     case taglib::FileType::AIFF:
         return dumpID3();
     case taglib::FileType::MP4:

--- a/src/track/serato/beatsimporter.cpp
+++ b/src/track/serato/beatsimporter.cpp
@@ -23,10 +23,12 @@ bool SeratoBeatsImporter::isEmpty() const {
 };
 
 BeatsPointer SeratoBeatsImporter::importBeatsAndApplyTimingOffset(
-        const QString& filePath, const audio::StreamInfo& streamInfo) {
+        const QString& filePath,
+        const QString& fileType,
+        const audio::StreamInfo& streamInfo) {
     const audio::SignalInfo& signalInfo = streamInfo.getSignalInfo();
     const double timingOffsetMillis = SeratoTags::guessTimingOffsetMillis(
-            filePath, signalInfo);
+            filePath, fileType, signalInfo);
 
     return importBeatsAndApplyTimingOffset(timingOffsetMillis, signalInfo);
 }

--- a/src/track/serato/beatsimporter.h
+++ b/src/track/serato/beatsimporter.h
@@ -21,6 +21,7 @@ class SeratoBeatsImporter : public BeatsImporter {
     bool isEmpty() const override;
     BeatsPointer importBeatsAndApplyTimingOffset(
             const QString& filePath,
+            const QString& fileType,
             const audio::StreamInfo& streamInfo) override;
 
   private:

--- a/src/track/serato/cueinfoimporter.cpp
+++ b/src/track/serato/cueinfoimporter.cpp
@@ -22,8 +22,9 @@ bool SeratoCueInfoImporter::hasCueOfType(CueType cueType) const {
 /// the SeratoTags for the time being.
 double SeratoCueInfoImporter::guessTimingOffsetMillis(
         const QString& filePath,
+        const QString& fileType,
         const audio::SignalInfo& signalInfo) const {
-    return SeratoTags::guessTimingOffsetMillis(filePath, signalInfo);
+    return SeratoTags::guessTimingOffsetMillis(filePath, fileType, signalInfo);
 }
 
 } // namespace mixxx

--- a/src/track/serato/cueinfoimporter.h
+++ b/src/track/serato/cueinfoimporter.h
@@ -14,6 +14,7 @@ class SeratoCueInfoImporter : public CueInfoImporter {
 
     double guessTimingOffsetMillis(
             const QString& filePath,
+            const QString& fileType,
             const audio::SignalInfo& signalInfo) const override;
 };
 

--- a/src/track/serato/markers.cpp
+++ b/src/track/serato/markers.cpp
@@ -329,7 +329,7 @@ bool SeratoMarkers::parse(
     }
 
     switch (fileType) {
-    case taglib::FileType::MP3:
+    case taglib::FileType::MPEG:
     case taglib::FileType::AIFF:
         return parseID3(seratoMarkers, data);
     case taglib::FileType::MP4:
@@ -546,7 +546,7 @@ bool SeratoMarkers::parseMP4(
 
 QByteArray SeratoMarkers::dump(taglib::FileType fileType) const {
     switch (fileType) {
-    case taglib::FileType::MP3:
+    case taglib::FileType::MPEG:
     case taglib::FileType::AIFF:
         return dumpID3();
     case taglib::FileType::MP4:

--- a/src/track/serato/markers2.cpp
+++ b/src/track/serato/markers2.cpp
@@ -359,14 +359,14 @@ bool SeratoMarkers2::parse(
     }
 
     switch (fileType) {
-    case taglib::FileType::MP3:
+    case taglib::FileType::MPEG:
     case taglib::FileType::AIFF:
         return parseID3(seratoMarkers2, data);
     case taglib::FileType::MP4:
         return parseBase64Encoded(seratoMarkers2, data);
     case taglib::FileType::FLAC:
         return parseFLAC(seratoMarkers2, data);
-    case taglib::FileType::OGG:
+    case taglib::FileType::OggVorbis:
         return parseCommon(seratoMarkers2, data);
     default:
         return false;
@@ -494,14 +494,14 @@ bool SeratoMarkers2::parseFLAC(
 
 QByteArray SeratoMarkers2::dump(taglib::FileType fileType) const {
     switch (fileType) {
-    case taglib::FileType::MP3:
+    case taglib::FileType::MPEG:
     case taglib::FileType::AIFF:
         return dumpID3();
     case taglib::FileType::MP4:
         return dumpBase64Encoded();
     case taglib::FileType::FLAC:
         return dumpFLAC();
-    case taglib::FileType::OGG:
+    case taglib::FileType::OggVorbis:
         return dumpCommon();
     default:
         DEBUG_ASSERT(false);

--- a/src/track/serato/tags.cpp
+++ b/src/track/serato/tags.cpp
@@ -73,6 +73,7 @@ namespace mixxx {
 
 double SeratoTags::guessTimingOffsetMillis(
         const QString& filePath,
+        const QString& fileType,
         const audio::SignalInfo& signalInfo) {
     // The following code accounts for timing offsets required to
     // correctly align timing information (e.g. cue points) exported from
@@ -82,7 +83,7 @@ double SeratoTags::guessTimingOffsetMillis(
     // PR for more detailed information:
     // https://github.com/mixxxdj/mixxx/pull/2119
     double timingOffset = 0;
-    if (taglib::getFileTypeFromFileName(filePath) == taglib::FileType::MP3) {
+    if (fileType == "mp3") {
         const QString primaryDecoderName =
                 getPrimaryDecoderNameForFilePath(filePath);
         // There should always be an MP3 decoder available

--- a/src/track/serato/tags.h
+++ b/src/track/serato/tags.h
@@ -28,7 +28,9 @@ class SeratoTags final {
     }
 
     static double guessTimingOffsetMillis(
-            const QString& filePath, const audio::SignalInfo& signalInfo);
+            const QString& filePath,
+            const QString& fileType,
+            const audio::SignalInfo& signalInfo);
 
     bool isEmpty() const {
         return m_seratoBeatGrid.isEmpty() && m_seratoMarkers.isEmpty() &&

--- a/src/track/serato/tags.h
+++ b/src/track/serato/tags.h
@@ -127,12 +127,12 @@ class SeratoTags final {
 
 inline bool operator==(const SeratoTags& lhs, const SeratoTags& rhs) {
     // FIXME: Find a more efficient way to do this
-    return (lhs.dumpBeatGrid(taglib::FileType::MP3) ==
-                    rhs.dumpBeatGrid(taglib::FileType::MP3) &&
-            lhs.dumpMarkers(taglib::FileType::MP3) ==
-                    rhs.dumpMarkers(taglib::FileType::MP3) &&
-            lhs.dumpMarkers2(taglib::FileType::MP3) ==
-                    rhs.dumpMarkers2(taglib::FileType::MP3));
+    return (lhs.dumpBeatGrid(taglib::FileType::MPEG) ==
+                    rhs.dumpBeatGrid(taglib::FileType::MPEG) &&
+            lhs.dumpMarkers(taglib::FileType::MPEG) ==
+                    rhs.dumpMarkers(taglib::FileType::MPEG) &&
+            lhs.dumpMarkers2(taglib::FileType::MPEG) ==
+                    rhs.dumpMarkers2(taglib::FileType::MPEG));
 }
 
 inline bool operator!=(const SeratoTags& lhs, const SeratoTags& rhs) {

--- a/src/track/taglib/trackmetadata_file.cpp
+++ b/src/track/taglib/trackmetadata_file.cpp
@@ -105,7 +105,7 @@ FileType stringToEnumFileType(
             TypePair{"dff"_L1, FileType::DSDIFF},
             TypePair{"dsdiff"_L1, FileType::DSDIFF}};
 
-    auto it = std::find_if(lookupTable.cbegin(),
+    const auto it = std::find_if(lookupTable.cbegin(),
             lookupTable.cend(),
             [fileType](const auto& pair) { return pair.strType == fileType; });
     return it != lookupTable.end() ? it->eType : FileType::Unknown;

--- a/src/track/taglib/trackmetadata_file.cpp
+++ b/src/track/taglib/trackmetadata_file.cpp
@@ -45,36 +45,70 @@ void readAudioProperties(
 
 namespace taglib {
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 4, 0)
+using namespace Qt::Literals::StringLiterals;
+#else
+constexpr inline QLatin1String operator""_L1(const char* str, size_t size) noexcept {
+    return QLatin1String{str, static_cast<int>(size)};
+}
+#endif
+
 // Deduce the TagLib file type from the file name
-FileType getFileTypeFromFileName(
-        const QString& fileName) {
-    DEBUG_ASSERT(!fileName.isEmpty());
-    const QString fileSuffix(fileName.section(QChar('.'), -1).toLower().trimmed());
-    if (QStringLiteral("mp3") == fileSuffix) {
-        return FileType::MPEG;
-    }
-    if ((QStringLiteral("m4a") == fileSuffix) || (QStringLiteral("m4v") == fileSuffix)) {
-        return FileType::MP4;
-    }
-    if (QStringLiteral("flac") == fileSuffix) {
-        return FileType::FLAC;
-    }
-    if (QStringLiteral("ogg") == fileSuffix) {
-        return FileType::OggVorbis;
-    }
-    if (QStringLiteral("opus") == fileSuffix) {
-        return FileType::Opus;
-    }
-    if (QStringLiteral("wav") == fileSuffix) {
-        return FileType::WAV;
-    }
-    if (QStringLiteral("wv") == fileSuffix) {
-        return FileType::WavPack;
-    }
-    if (fileSuffix.startsWith(QStringLiteral("aif"))) {
-        return FileType::AIFF;
-    }
-    return FileType::Unknown;
+FileType stringToEnumFileType(
+        const QString& fileType) {
+    DEBUG_ASSERT(!fileType.isEmpty());
+
+    struct TypePair {
+        QLatin1String strType;
+        FileType eType;
+    };
+
+    // This table is aligned with detectByExtension() in fileref.cpp
+    constexpr std::array lookupTable = {
+            TypePair{"mp3"_L1, FileType::MPEG},
+            TypePair{"mp2"_L1, FileType::MPEG},
+            TypePair{"aac"_L1, FileType::MPEG},
+            TypePair{"mpeg"_L1, FileType::MPEG},
+            TypePair{"ogg"_L1, FileType::OggVorbis},
+            TypePair{"oga"_L1, FileType::OggFlac},
+            TypePair{"flac"_L1, FileType::FLAC},
+            TypePair{"mpc"_L1, FileType::MPC},
+            TypePair{"wv"_L1, FileType::WavPack},
+            TypePair{"spx"_L1, FileType::Speex},
+            TypePair{"opus"_L1, FileType::Opus},
+            TypePair{"tta"_L1, FileType::TrueAudio},
+            TypePair{"caf"_L1, FileType::MP4},
+            TypePair{"m4a"_L1, FileType::MP4},
+            TypePair{"m4r"_L1, FileType::MP4},
+            TypePair{"m4b"_L1, FileType::MP4},
+            TypePair{"m4p"_L1, FileType::MP4},
+            TypePair{"m4v"_L1, FileType::MP4},
+            TypePair{"mj2"_L1, FileType::MP4},
+            TypePair{"mov"_L1, FileType::MP4},
+            TypePair{"mp4"_L1, FileType::MP4},
+            TypePair{"3gp"_L1, FileType::MP4},
+            TypePair{"3g2"_L1, FileType::MP4},
+            TypePair{"wma"_L1, FileType::ASF},
+            TypePair{"asf"_L1, FileType::ASF},
+            TypePair{"aiff"_L1, FileType::AIFF},
+            TypePair{"aifc"_L1, FileType::AIFF},
+            TypePair{"wav"_L1, FileType::WAV},
+            TypePair{"ape"_L1, FileType::APE},
+            TypePair{"it"_L1, FileType::IT},
+            TypePair{"mod"_L1, FileType::Mod},
+            TypePair{"module"_L1, FileType::Mod},
+            TypePair{"nst"_L1, FileType::Mod},
+            TypePair{"wow"_L1, FileType::Mod},
+            TypePair{"s3m"_L1, FileType::S3M},
+            TypePair{"xm"_L1, FileType::XM},
+            TypePair{"dsf"_L1, FileType::DSF},
+            TypePair{"dff"_L1, FileType::DSDIFF},
+            TypePair{"dsdiff"_L1, FileType::DSDIFF}};
+
+    auto it = std::find_if(lookupTable.cbegin(),
+            lookupTable.cend(),
+            [fileType](const auto& pair) { return pair.strType == fileType; });
+    return it != lookupTable.end() ? it->eType : FileType::Unknown;
 }
 
 QDebug operator<<(QDebug debug, FileType fileType) {

--- a/src/track/taglib/trackmetadata_file.cpp
+++ b/src/track/taglib/trackmetadata_file.cpp
@@ -51,7 +51,7 @@ FileType getFileTypeFromFileName(
     DEBUG_ASSERT(!fileName.isEmpty());
     const QString fileSuffix(fileName.section(QChar('.'), -1).toLower().trimmed());
     if (QStringLiteral("mp3") == fileSuffix) {
-        return FileType::MP3;
+        return FileType::MPEG;
     }
     if ((QStringLiteral("m4a") == fileSuffix) || (QStringLiteral("m4v") == fileSuffix)) {
         return FileType::MP4;
@@ -60,16 +60,16 @@ FileType getFileTypeFromFileName(
         return FileType::FLAC;
     }
     if (QStringLiteral("ogg") == fileSuffix) {
-        return FileType::OGG;
+        return FileType::OggVorbis;
     }
     if (QStringLiteral("opus") == fileSuffix) {
-        return FileType::OPUS;
+        return FileType::Opus;
     }
     if (QStringLiteral("wav") == fileSuffix) {
         return FileType::WAV;
     }
     if (QStringLiteral("wv") == fileSuffix) {
-        return FileType::WV;
+        return FileType::WavPack;
     }
     if (fileSuffix.startsWith(QStringLiteral("aif"))) {
         return FileType::AIFF;

--- a/src/track/taglib/trackmetadata_file.cpp
+++ b/src/track/taglib/trackmetadata_file.cpp
@@ -105,7 +105,9 @@ FileType stringToEnumFileType(
             TypePair{"dff"_L1, FileType::DSDIFF},
             TypePair{"dsdiff"_L1, FileType::DSDIFF}};
 
-    const auto it = std::find_if(lookupTable.cbegin(),
+    // NOLINTNEXTLINE(readability-qualified-auto)
+    const auto it = std::find_if(
+            lookupTable.cbegin(),
             lookupTable.cend(),
             [fileType](const auto& pair) { return pair.strType == fileType; });
     return it != lookupTable.end() ? it->eType : FileType::Unknown;

--- a/src/track/taglib/trackmetadata_file.cpp
+++ b/src/track/taglib/trackmetadata_file.cpp
@@ -64,7 +64,7 @@ FileType stringToEnumFileType(
     };
 
     // This table is aligned with detectByExtension() in fileref.cpp
-    constexpr std::array lookupTable = {
+    constexpr static std::array lookupTable = {
             TypePair{"mp3"_L1, FileType::MPEG},
             TypePair{"mp2"_L1, FileType::MPEG},
             TypePair{"aac"_L1, FileType::MPEG},

--- a/src/track/taglib/trackmetadata_file.h
+++ b/src/track/taglib/trackmetadata_file.h
@@ -16,16 +16,29 @@ class TrackMetadata;
 
 namespace taglib {
 
+// This enum is aligned with TagLib_File_Type form the TagLib C binding
 enum class FileType {
-    Unknown,
-    AIFF,
+    Unknown = -1,
+    MPEG = 0,
+    OggVorbis,
     FLAC,
-    MP3,
+    MPC,
+    OggFlac,
+    WavPack,
+    Speex,
+    TrueAudio,
     MP4,
-    OGG,
-    OPUS,
+    ASF,
+    AIFF,
     WAV,
-    WV
+    APE,
+    IT,
+    Mod,
+    S3M,
+    XM,
+    Opus,
+    DSF,
+    DSDIFF
 };
 
 QDebug operator<<(QDebug debug, FileType fileType);

--- a/src/track/taglib/trackmetadata_file.h
+++ b/src/track/taglib/trackmetadata_file.h
@@ -43,8 +43,8 @@ enum class FileType {
 
 QDebug operator<<(QDebug debug, FileType fileType);
 
-// Deduce the TagLib file type from the file name
-FileType getFileTypeFromFileName(const QString& fileName);
+// Deduce enum FileType from the fileType String
+FileType stringToEnumFileType(const QString& fileType);
 
 #ifdef _WIN32
 static_assert(sizeof(wchar_t) == sizeof(QChar), "wchar_t is not the same size than QChar");

--- a/src/track/taglib/trackmetadata_id3v2.cpp
+++ b/src/track/taglib/trackmetadata_id3v2.cpp
@@ -1061,21 +1061,21 @@ void importTrackMetadataFromTag(
                     tag,
                     kFrameDescriptionSeratoBeatGrid);
     if (!seratoBeatGrid.isEmpty()) {
-        parseSeratoBeatGrid(pTrackMetadata, seratoBeatGrid, FileType::MP3);
+        parseSeratoBeatGrid(pTrackMetadata, seratoBeatGrid, FileType::MPEG);
     }
     const QByteArray seratoMarkers =
             readFirstGeneralEncapsulatedObjectFrame(
                     tag,
                     kFrameDescriptionSeratoMarkers);
     if (!seratoMarkers.isEmpty()) {
-        parseSeratoMarkers(pTrackMetadata, seratoMarkers, FileType::MP3);
+        parseSeratoMarkers(pTrackMetadata, seratoMarkers, FileType::MPEG);
     }
     const QByteArray seratoMarkers2 =
             readFirstGeneralEncapsulatedObjectFrame(
                     tag,
                     kFrameDescriptionSeratoMarkers2);
     if (!seratoMarkers2.isEmpty()) {
-        parseSeratoMarkers2(pTrackMetadata, seratoMarkers2, FileType::MP3);
+        parseSeratoMarkers2(pTrackMetadata, seratoMarkers2, FileType::MPEG);
     }
 }
 
@@ -1346,15 +1346,15 @@ bool exportTrackMetadataIntoTag(TagLib::ID3v2::Tag* pTag,
         writeGeneralEncapsulatedObjectFrame(
                 pTag,
                 kFrameDescriptionSeratoBeatGrid,
-                trackMetadata.getTrackInfo().getSeratoTags().dumpBeatGrid(FileType::MP3));
+                trackMetadata.getTrackInfo().getSeratoTags().dumpBeatGrid(FileType::MPEG));
         writeGeneralEncapsulatedObjectFrame(
                 pTag,
                 kFrameDescriptionSeratoMarkers,
-                trackMetadata.getTrackInfo().getSeratoTags().dumpMarkers(FileType::MP3));
+                trackMetadata.getTrackInfo().getSeratoTags().dumpMarkers(FileType::MPEG));
         writeGeneralEncapsulatedObjectFrame(
                 pTag,
                 kFrameDescriptionSeratoMarkers2,
-                trackMetadata.getTrackInfo().getSeratoTags().dumpMarkers2(FileType::MP3));
+                trackMetadata.getTrackInfo().getSeratoTags().dumpMarkers2(FileType::MPEG));
     }
 
     return true;

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -1136,7 +1136,7 @@ bool Track::importPendingBeatsWhileLocked() {
             m_record.getMetadata().getStreamInfo().getSignalInfo().getSampleRate());
     const auto pBeats =
             m_pBeatsImporterPending->importBeatsAndApplyTimingOffset(
-                    getLocation(), *m_record.getStreamInfoFromSource());
+                    getLocation(), getType(), *m_record.getStreamInfoFromSource());
     DEBUG_ASSERT(m_pBeatsImporterPending->isEmpty());
     m_pBeatsImporterPending.reset();
     return setBeatsWhileLocked(pBeats);
@@ -1283,7 +1283,9 @@ bool Track::importPendingCueInfosWhileLocked() {
 
     const QList<mixxx::CueInfo> cueInfos =
             m_pCueInfoImporterPending->importCueInfosAndApplyTimingOffset(
-                    getLocation(), m_record.getStreamInfoFromSource()->getSignalInfo());
+                    getLocation(),
+                    getType(),
+                    m_record.getStreamInfoFromSource()->getSignalInfo());
     for (const auto& cueInfo : cueInfos) {
         CuePointer pCue(new Cue(cueInfo, sampleRate, true));
         // While this method could be called from any thread,
@@ -1487,7 +1489,7 @@ bool Track::exportSeratoMetadata() {
     }
 
     const double timingOffset = mixxx::SeratoTags::guessTimingOffsetMillis(
-            getLocation(), streamInfo->getSignalInfo());
+            getLocation(), getType(), streamInfo->getSignalInfo());
     pSeratoTags->setCueInfos(cueInfos, timingOffset);
     pSeratoTags->setBeats(m_pBeats,
             streamInfo->getSignalInfo(),


### PR DESCRIPTION
This replaces all file type guessing code form the file extension, by using the normalized file type stored in the Track object. 
This makes sure all parts are using the same file type, even if the extension is wrong. 

This fixes #13205 