### PR TITLE
Waveforms: don't elide hotcue labels

### DIFF
--- a/src/waveform/renderers/waveformmark.cpp
+++ b/src/waveform/renderers/waveformmark.cpp
@@ -310,14 +310,10 @@ QImage WaveformMark::generateImage(float devicePixelRatio) {
 
     // Determine mark text.
     if (getHotCue() >= 0) {
-        constexpr int kMaxCueLabelLength = 23;
         if (!label.isEmpty()) {
             label.prepend(": ");
         }
         label.prepend(QString::number(getHotCue() + 1));
-        if (label.size() > kMaxCueLabelLength) {
-            label = label.left(kMaxCueLabelLength - 3) + "...";
-        }
     }
 
     const bool useIcon = m_iconPath != "";


### PR DESCRIPTION
fixes #10722 

As explained in #10722, there is no reason to truncate the labels:
* later marks would overlap the longer, previous marks
* as soon as hotcues are out of sight, their labels are hidden

Is there some aspect I overlooked?