### PR TITLE
Refactor/gh13222 util deprecate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1349,7 +1349,6 @@ target_precompile_headers(mixxx-lib PUBLIC
   src/util/mac.h
   src/util/macros.h
   src/util/math.h
-  src/util/memory.h
   src/util/messagepipe.h
   src/util/movinginterquartilemean.h
   src/util/mutex.h

--- a/src/analyzer/analyzerbeats.h
+++ b/src/analyzer/analyzerbeats.h
@@ -2,12 +2,12 @@
 
 #include <QHash>
 #include <QList>
+#include <memory>
 
 #include "analyzer/analyzer.h"
 #include "analyzer/plugins/analyzerplugin.h"
 #include "preferences/beatdetectionsettings.h"
 #include "preferences/usersettings.h"
-#include "util/memory.h"
 
 class AnalyzerBeats : public Analyzer {
   public:

--- a/src/analyzer/analyzerkey.h
+++ b/src/analyzer/analyzerkey.h
@@ -3,12 +3,12 @@
 #include <QHash>
 #include <QList>
 #include <QString>
+#include <memory>
 
 #include "analyzer/analyzer.h"
 #include "analyzer/plugins/analyzerplugin.h"
 #include "preferences/keydetectionsettings.h"
 #include "track/track_decl.h"
-#include "util/memory.h"
 
 class AnalyzerKey : public Analyzer {
   public:

--- a/src/analyzer/analyzerthread.h
+++ b/src/analyzer/analyzerthread.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <optional>
 #include <vector>
 
@@ -12,7 +13,6 @@
 #include "track/track_decl.h"
 #include "track/trackid.h"
 #include "util/db/dbconnectionpool.h"
-#include "util/memory.h"
 #include "util/performancetimer.h"
 #include "util/samplebuffer.h"
 #include "util/workerthread.h"

--- a/src/analyzer/plugins/analyzerqueenmarybeats.h
+++ b/src/analyzer/plugins/analyzerqueenmarybeats.h
@@ -1,12 +1,11 @@
 #pragma once
 
-#include <vector>
-
 #include <QObject>
+#include <memory>
+#include <vector>
 
 #include "analyzer/plugins/analyzerplugin.h"
 #include "analyzer/plugins/buffering_utils.h"
-#include "util/memory.h"
 
 class DetectionFunction;
 

--- a/src/analyzer/plugins/analyzerqueenmarykey.h
+++ b/src/analyzer/plugins/analyzerqueenmarykey.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include <QObject>
+#include <memory>
 
 #include "analyzer/plugins/analyzerplugin.h"
 #include "analyzer/plugins/buffering_utils.h"
-#include "util/memory.h"
 #include "util/types.h"
 
 class GetKeyMode;

--- a/src/analyzer/plugins/analyzersoundtouchbeats.h
+++ b/src/analyzer/plugins/analyzersoundtouchbeats.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <QObject>
+#include <memory>
 
 #include "analyzer/plugins/analyzerplugin.h"
-#include "util/memory.h"
 #include "util/samplebuffer.h"
 
 namespace soundtouch {

--- a/src/control/controlproxy.h
+++ b/src/control/controlproxy.h
@@ -6,7 +6,6 @@
 
 #include "control/control.h"
 #include "preferences/usersettings.h"
-#include "util/platform.h"
 
 //// This class is the successor of ControlObjectThread. It should be used for
 /// new code to avoid unnecessary locking during send if no slot is connected.
@@ -59,7 +58,7 @@ class ControlProxy : public QObject {
             break;
         case Qt::BlockingQueuedConnection:
             // We must not block the signal source by a blocking connection
-            M_FALLTHROUGH_INTENDED;
+            [[fallthrough]];
         default:
             DEBUG_ASSERT(false);
             return false;

--- a/src/effects/backends/builtin/balanceeffect.h
+++ b/src/effects/backends/builtin/balanceeffect.h
@@ -1,8 +1,9 @@
 #pragma once
 
+#include <memory>
+
 #include "effects/backends/effectprocessor.h"
 #include "engine/filters/enginefilterlinkwitzriley4.h"
-#include "util/memory.h"
 #include "util/samplebuffer.h"
 
 class BalanceGroupState : public EffectState {

--- a/src/effects/backends/builtin/biquadfullkilleqeffect.h
+++ b/src/effects/backends/builtin/biquadfullkilleqeffect.h
@@ -1,11 +1,12 @@
 #pragma once
 
+#include <memory>
+
 #include "control/pollingcontrolproxy.h"
 #include "effects/backends/builtin/lvmixeqbase.h"
 #include "effects/backends/effectprocessor.h"
 #include "engine/filters/enginefilterbessel4.h"
 #include "engine/filters/enginefilterbiquad1.h"
-#include "util/memory.h"
 #include "util/samplebuffer.h"
 #include "util/types.h"
 

--- a/src/effects/backends/builtin/loudnesscontoureffect.h
+++ b/src/effects/backends/builtin/loudnesscontoureffect.h
@@ -1,7 +1,8 @@
 #pragma once
 
+#include <memory>
+
 #include "effects/backends/effectprocessor.h"
-#include "util/memory.h"
 #include "util/types.h"
 
 class EngineFilterBiquad1HighShelving;

--- a/src/effects/backends/builtin/parametriceqeffect.h
+++ b/src/effects/backends/builtin/parametriceqeffect.h
@@ -1,13 +1,13 @@
 #pragma once
 
 #include <QMap>
+#include <memory>
 #include <vector>
 
 #include "audio/types.h"
 #include "effects/backends/effectprocessor.h"
 #include "engine/filters/enginefilterbiquad1.h"
 #include "util/class.h"
-#include "util/memory.h"
 #include "util/types.h"
 
 // The ParametricEQEffect models the mid bands from a SSL Black EQ (242)

--- a/src/effects/backends/builtin/threebandbiquadeqeffect.h
+++ b/src/effects/backends/builtin/threebandbiquadeqeffect.h
@@ -1,9 +1,10 @@
 #pragma once
 
+#include <memory>
+
 #include "control/pollingcontrolproxy.h"
 #include "effects/backends/effectprocessor.h"
 #include "engine/filters/enginefilterbiquad1.h"
-#include "util/memory.h"
 #include "util/samplebuffer.h"
 #include "util/types.h"
 

--- a/src/effects/effectchain.h
+++ b/src/effects/effectchain.h
@@ -2,12 +2,12 @@
 
 #include <QList>
 #include <QObject>
+#include <memory>
 
 #include "effects/defs.h"
 #include "effects/effectchainmixmode.h"
 #include "engine/channelhandle.h"
 #include "util/class.h"
-#include "util/memory.h"
 
 class ControlObject;
 class ControlPushButton;

--- a/src/encoder/encoder.h
+++ b/src/encoder/encoder.h
@@ -1,9 +1,10 @@
 #pragma once
 
+#include <memory>
+
 #include "encoder/encoderrecordingsettings.h"
 #include "encoder/encodersettings.h"
 #include "preferences/usersettings.h"
-#include "util/memory.h"
 #include "util/types.h"
 
 class EncoderCallback;

--- a/src/encoder/encoderopus.h
+++ b/src/encoder/encoderopus.h
@@ -6,11 +6,11 @@
 #include <QMap>
 #include <QString>
 #include <QVector>
+#include <memory>
 
 #include "audio/types.h"
 #include "encoder/encoder.h"
 #include "util/fifo.h"
-#include "util/memory.h"
 
 class EncoderCallback;
 class EncoderSettings;

--- a/src/encoder/encodersettings.h
+++ b/src/encoder/encodersettings.h
@@ -2,7 +2,7 @@
 
 #include <QList>
 #include <QObject>
-#include "util/memory.h"
+#include <memory>
 
 /// Encoder settings interface for encoders
 class EncoderSettings {

--- a/src/engine/bufferscalers/enginebufferscalerubberband.h
+++ b/src/engine/bufferscalers/enginebufferscalerubberband.h
@@ -3,9 +3,9 @@
 #include <rubberband/RubberBandStretcher.h>
 
 #include <array>
+#include <memory>
 
 #include "engine/bufferscalers/enginebufferscale.h"
-#include "util/memory.h"
 #include "util/samplebuffer.h"
 
 class ReadAheadManager;

--- a/src/engine/bufferscalers/enginebufferscalest.h
+++ b/src/engine/bufferscalers/enginebufferscalest.h
@@ -1,7 +1,8 @@
 #pragma once
 
+#include <memory>
+
 #include "engine/bufferscalers/enginebufferscale.h"
-#include "util/memory.h"
 #include "util/samplebuffer.h"
 
 class ReadAheadManager;

--- a/src/engine/effects/engineeffect.h
+++ b/src/engine/effects/engineeffect.h
@@ -4,12 +4,12 @@
 #include <QSet>
 #include <QString>
 #include <QVector>
+#include <memory>
 
 #include "effects/backends/effectmanifest.h"
 #include "effects/backends/effectprocessor.h"
 #include "engine/channelhandle.h"
 #include "engine/effects/message.h"
-#include "util/memory.h"
 #include "util/types.h"
 
 /// EngineEffect is a generic wrapper around an EffectProcessor which intermediates

--- a/src/engine/effects/message.h
+++ b/src/engine/effects/message.h
@@ -3,11 +3,11 @@
 #include <QString>
 #include <QVariant>
 #include <QtGlobal>
+#include <memory>
 
 #include "effects/defs.h"
 #include "effects/effectchainmixmode.h"
 #include "engine/channelhandle.h"
-#include "util/memory.h"
 #include "util/messagepipe.h"
 
 class EngineEffectChain;

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -615,7 +615,7 @@ QVariant BaseTrackTableModel::roleValue(
             // Same value as for Qt::DisplayRole (see below)
             break;
         }
-        M_FALLTHROUGH_INTENDED;
+        [[fallthrough]];
     // NOTE: for export we need to fall through to Qt::DisplayRole,
     // so do not add any other role cases here, or the export
     // will be empty

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -5,6 +5,7 @@
 #include <QMenu>
 #include <QPushButton>
 #include <QStringList>
+#include <memory>
 
 #include "library/browse/foldertreemodel.h"
 #include "library/library.h"
@@ -12,7 +13,6 @@
 #include "library/trackcollectionmanager.h"
 #include "library/treeitem.h"
 #include "moc_browsefeature.cpp"
-#include "util/memory.h"
 #include "widget/wlibrary.h"
 #include "widget/wlibrarysidebar.h"
 #include "widget/wlibrarytextbrowser.h"

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -4,13 +4,13 @@
 #include <QObject>
 #include <QSet>
 #include <QString>
+#include <memory>
 
 #include "library/dao/dao.h"
 #include "library/relocatedtrack.h"
 #include "preferences/usersettings.h"
 #include "track/globaltrackcache.h"
 #include "util/class.h"
-#include "util/memory.h"
 
 class SqlTransaction;
 class PlaylistDAO;

--- a/src/library/librarycontrol.h
+++ b/src/library/librarycontrol.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include <QObject>
+#include <memory>
 
 #include "control/controlproxy.h"
 #include "library/library_decl.h"
-#include "util/memory.h"
 
 class ControlEncoder;
 class ControlObject;

--- a/src/library/searchquery.h
+++ b/src/library/searchquery.h
@@ -5,13 +5,13 @@
 #include <QSqlDatabase>
 #include <QString>
 #include <QStringList>
+#include <memory>
 #include <utility>
 #include <vector>
 
 #include "proto/keys.pb.h"
 #include "track/track_decl.h"
 #include "util/assert.h"
-#include "util/memory.h"
 
 class CrateStorage;
 class TrackId;

--- a/src/library/treeitem.h
+++ b/src/library/treeitem.h
@@ -4,9 +4,9 @@
 #include <QList>
 #include <QString>
 #include <QVariant>
+#include <memory>
 
 #include "util/assert.h"
-#include "util/memory.h"
 
 class LibraryFeature;
 

--- a/src/library/treeitemmodel.h
+++ b/src/library/treeitemmodel.h
@@ -3,8 +3,7 @@
 #include <QAbstractItemModel>
 #include <QModelIndex>
 #include <QVariant>
-
-#include "util/memory.h"
+#include <memory>
 
 class TreeItem;
 

--- a/src/mixer/basetrackplayer.h
+++ b/src/mixer/basetrackplayer.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 #include "engine/channels/enginechannel.h"
 #include "mixer/baseplayer.h"
 #include "preferences/usersettings.h"
@@ -7,7 +9,6 @@
 #include "track/track_decl.h"
 #include "track/trackid.h"
 #include "util/color/rgbcolor.h"
-#include "util/memory.h"
 #include "util/parented_ptr.h"
 #include "util/performancetimer.h"
 

--- a/src/mixer/samplerbank.h
+++ b/src/mixer/samplerbank.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <QObject>
+#include <memory>
 
 #include "preferences/usersettings.h"
-#include "util/memory.h"
 
 class ControlObject;
 class ControlProxy;

--- a/src/skin/legacy/legacyskinparser.h
+++ b/src/skin/legacy/legacyskinparser.h
@@ -5,12 +5,12 @@
 #include <QObject>
 #include <QSet>
 #include <QString>
+#include <memory>
 
 #include "preferences/usersettings.h"
 #include "proto/skin.pb.h"
 #include "skin/legacy/skinparser.h"
 #include "skin/legacy/tooltips.h"
-#include "util/memory.h"
 #include "vinylcontrol/vinylcontrolmanager.h"
 
 class WBaseWidget;

--- a/src/soundio/sounddevicenetwork.h
+++ b/src/soundio/sounddevicenetwork.h
@@ -8,11 +8,12 @@
 #include <pthread.h>
 #endif
 
+#include <memory>
+
 #include "control/pollingcontrolproxy.h"
 #include "engine/sidechain/networkoutputstreamworker.h"
 #include "soundio/sounddevice.h"
 #include "util/fifo.h"
-#include "util/memory.h"
 #include "util/performancetimer.h"
 
 #define CPU_USAGE_UPDATE_RATE 30 // in 1/s, fits to display frame rate

--- a/src/sources/audiosource.h
+++ b/src/sources/audiosource.h
@@ -1,10 +1,11 @@
 #pragma once
 
+#include <memory>
+
 #include "audio/streaminfo.h"
 #include "engine/engine.h"
 #include "sources/urlresource.h"
 #include "util/indexrange.h"
-#include "util/memory.h"
 #include "util/samplebuffer.h"
 
 namespace mixxx {

--- a/src/sources/libfaadloader.h
+++ b/src/sources/libfaadloader.h
@@ -2,8 +2,7 @@
 
 #include <QLibrary>
 #include <QtDebug>
-
-#include "util/memory.h"
+#include <memory>
 
 namespace faad2 {
 

--- a/src/sources/metadatasource.h
+++ b/src/sources/metadatasource.h
@@ -3,10 +3,10 @@
 #include <QDateTime>
 #include <QFile>
 #include <QImage>
+#include <memory>
 #include <utility>
 
 #include "track/trackmetadata.h"
-#include "util/memory.h"
 
 namespace mixxx {
 

--- a/src/sources/soundsourceoggvorbis.h
+++ b/src/sources/soundsourceoggvorbis.h
@@ -1,7 +1,8 @@
 #pragma once
 
+#include <memory>
+
 #include "sources/soundsourceprovider.h"
-#include "util/memory.h"
 
 #define OV_EXCLUDE_STATIC_CALLBACKS
 #include <vorbis/vorbisfile.h>

--- a/src/test/beatgridtest.cpp
+++ b/src/test/beatgridtest.cpp
@@ -1,10 +1,10 @@
 #include <gtest/gtest.h>
 
 #include <QtDebug>
+#include <memory>
 
 #include "track/beats.h"
 #include "track/track.h"
-#include "util/memory.h"
 
 using namespace mixxx;
 

--- a/src/test/beatmaptest.cpp
+++ b/src/test/beatmaptest.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
-#include <memory.h>
 
 #include <QtDebug>
+#include <memory>
 
 #include "track/beats.h"
 #include "track/track.h"

--- a/src/test/beatstest.cpp
+++ b/src/test/beatstest.cpp
@@ -1,11 +1,11 @@
 #include <gtest/gtest.h>
 
 #include <QtDebug>
+#include <memory>
 
 #include "audio/types.h"
 #include "track/beats.h"
 #include "track/bpm.h"
-#include "util/memory.h"
 
 using namespace mixxx;
 

--- a/src/test/beatstranslatetest.cpp
+++ b/src/test/beatstranslatetest.cpp
@@ -1,6 +1,7 @@
+#include <memory>
+
 #include "test/mockedenginebackendtest.h"
 #include "track/beats.h"
-#include "util/memory.h"
 
 class BeatsTranslateTest : public MockedEngineBackendTest {
 };

--- a/src/test/controlobjectscripttest.cpp
+++ b/src/test/controlobjectscripttest.cpp
@@ -1,10 +1,11 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <memory>
+
 #include "control/controlobject.h"
 #include "control/controlobjectscript.h"
 #include "test/mixxxtest.h"
-#include "util/memory.h"
 
 using ::testing::_;
 using ::testing::DoubleEq;

--- a/src/test/controlobjecttest.cpp
+++ b/src/test/controlobjecttest.cpp
@@ -1,8 +1,9 @@
 #include <gtest/gtest.h>
+
 #include <QtDebug>
+#include <memory>
 
 #include "control/controlobject.h"
-#include "util/memory.h"
 #include "test/mixxxtest.h"
 
 namespace {

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -1,6 +1,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <memory>
 #include <string>
 
 #include "control/controlobject.h"
@@ -11,7 +12,6 @@
 #include "test/mixxxtest.h"
 #include "test/mockedenginebackendtest.h"
 #include "track/beats.h"
-#include "util/memory.h"
 
 namespace {
 constexpr double kMaxFloatingPointErrorLowPrecision = 0.005;

--- a/src/test/learningutilstest.cpp
+++ b/src/test/learningutilstest.cpp
@@ -1,10 +1,11 @@
 #include <stdint.h>
 
+#include <memory>
+
 #include "control/controlobject.h"
 #include "controllers/learningutils.h"
 #include "controllers/midi/midiutils.h"
 #include "test/mixxxtest.h"
-#include "util/memory.h"
 
 std::ostream& operator<<(std::ostream& stream, const MidiInputMapping& mapping) {
     stream << mapping.key.key << static_cast<uint16_t>(mapping.options);

--- a/src/test/looping_control_test.cpp
+++ b/src/test/looping_control_test.cpp
@@ -1,15 +1,15 @@
 #include <gtest/gtest.h>
 
-#include <QtDebug>
 #include <QScopedPointer>
+#include <QtDebug>
+#include <memory>
 
-#include "mixxxtest.h"
 #include "control/controlobject.h"
-#include "control/controlpushbutton.h"
 #include "control/controlproxy.h"
+#include "control/controlpushbutton.h"
 #include "engine/controls/loopingcontrol.h"
+#include "mixxxtest.h"
 #include "test/mockedenginebackendtest.h"
-#include "util/memory.h"
 
 namespace {
 

--- a/src/test/metadatatest.cpp
+++ b/src/test/metadatatest.cpp
@@ -3,11 +3,11 @@
 #include <tstring.h>
 
 #include <QtDebug>
+#include <memory>
 
 #include "track/bpm.h"
 #include "track/taglib/trackmetadata.h"
 #include "track/taglib/trackmetadata_common.h"
-#include "util/memory.h"
 
 namespace {
 

--- a/src/test/mockedenginebackendtest.h
+++ b/src/test/mockedenginebackendtest.h
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 
 #include <QtDebug>
+#include <memory>
 
 #include "control/controlobject.h"
 #include "effects/effectsmanager.h"
@@ -20,7 +21,6 @@
 #include "preferences/usersettings.h"
 #include "test/signalpathtest.h"
 #include "util/defs.h"
-#include "util/memory.h"
 #include "util/sample.h"
 #include "util/types.h"
 #include "waveform/guitick.h"

--- a/src/test/seratobeatgridtest.cpp
+++ b/src/test/seratobeatgridtest.cpp
@@ -4,12 +4,12 @@
 
 #include <QDir>
 #include <QtDebug>
+#include <memory>
 
 #include "test/mixxxtest.h"
 #include "track/beats.h"
 #include "track/serato/beatgrid.h"
 #include "track/serato/beatsimporter.h"
-#include "util/memory.h"
 
 namespace {
 

--- a/src/test/seratomarkers2test.cpp
+++ b/src/test/seratomarkers2test.cpp
@@ -4,10 +4,10 @@
 
 #include <QDir>
 #include <QtDebug>
+#include <memory>
 
 #include "test/mixxxtest.h"
 #include "track/serato/markers2.h"
-#include "util/memory.h"
 
 namespace {
 

--- a/src/test/seratomarkerstest.cpp
+++ b/src/test/seratomarkerstest.cpp
@@ -4,10 +4,10 @@
 
 #include <QDir>
 #include <QtDebug>
+#include <memory>
 
 #include "test/mixxxtest.h"
 #include "track/serato/markers.h"
-#include "util/memory.h"
 
 namespace {
 

--- a/src/test/signalpathtest.h
+++ b/src/test/signalpathtest.h
@@ -5,6 +5,7 @@
 
 #include <QTest>
 #include <QtDebug>
+#include <memory>
 
 #include "control/controlindicatortimer.h"
 #include "control/controlobject.h"
@@ -25,7 +26,6 @@
 #include "test/soundsourceproviderregistration.h"
 #include "track/track.h"
 #include "util/defs.h"
-#include "util/memory.h"
 #include "util/sample.h"
 #include "util/types.h"
 

--- a/src/test/softtakeover_test.cpp
+++ b/src/test/softtakeover_test.cpp
@@ -1,13 +1,15 @@
+#include "controllers/softtakeover.h"
+
 #include <gtest/gtest.h>
-#include <QtDebug>
+
 #include <QScopedPointer>
+#include <QtDebug>
+#include <memory>
 
 #include "control/controlpotmeter.h"
 #include "control/controlpushbutton.h"
 #include "preferences/usersettings.h"
-#include "controllers/softtakeover.h"
 #include "test/mixxxtest.h"
-#include "util/memory.h"
 #include "util/time.h"
 
 namespace {

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -10,7 +10,6 @@
 #include "audio/frame.h"
 #include "audio/types.h"
 #include "track/bpm.h"
-#include "util/memory.h"
 #include "util/types.h"
 
 #define BEAT_GRID_1_VERSION "BeatGrid-1.0"

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -3,6 +3,7 @@
 #include <QList>
 #include <QObject>
 #include <QUrl>
+#include <memory>
 
 #include "audio/streaminfo.h"
 #include "sources/metadatasource.h"
@@ -14,7 +15,6 @@
 #include "util/color/predefinedcolorpalettes.h"
 #include "util/compatibility/qmutex.h"
 #include "util/fileaccess.h"
-#include "util/memory.h"
 #include "waveform/waveform.h"
 
 class Track : public QObject {

--- a/src/util/db/dbconnectionpool.h
+++ b/src/util/db/dbconnectionpool.h
@@ -2,11 +2,10 @@
 
 #include <QAtomicInt>
 #include <QThreadStorage>
+#include <memory>
 
-#include "util/db/dbconnection.h"
-#include "util/memory.h"
 #include "util/assert.h"
-
+#include "util/db/dbconnection.h"
 
 namespace mixxx {
 

--- a/src/util/defs.h
+++ b/src/util/defs.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <Qt>
 
 // Maximum buffer length to each EngineObject::process call.
 //TODO: Replace this with mixxx::AudioParameters::bufferSize()

--- a/src/util/duration.h
+++ b/src/util/duration.h
@@ -131,6 +131,7 @@ class DurationDebug : public DurationBase {
 
 // Represents a duration in a type-safe manner. Provides conversion methods to
 // convert between physical units. Durations can be negative.
+/// Deprecated: use `std::chrono::duration` in new code instead
 class Duration : public DurationBase {
   public:
     // Returns a Duration object representing a duration of 'seconds'.

--- a/src/util/memory.h
+++ b/src/util/memory.h
@@ -1,5 +1,0 @@
-#pragma once
-
-// TODO: This file with a workaround for std::make_unique() has become obsolete
-// after switching from C++11 to C++14
-#include <memory>

--- a/src/util/platform.h
+++ b/src/util/platform.h
@@ -21,5 +21,3 @@
 #else
 #error We do not support your compiler. Please email mixxx-devel@lists.sourceforge.net and tell us about your use case.
 #endif
-
-#define M_FALLTHROUGH_INTENDED [[fallthrough]]

--- a/src/util/samplebuffer.h
+++ b/src/util/samplebuffer.h
@@ -102,6 +102,8 @@ class SampleBuffer final {
     // Fills the whole buffer with the same value
     void fill(CSAMPLE value);
 
+    /// Deprecated: use std::span<const CSAMPLE>, SampleBuffer::span() const and
+    /// mixxx::spanutil::spanFromPtrLen from util/span.h instead.
     class ReadableSlice {
       public:
         ReadableSlice()
@@ -143,6 +145,8 @@ class SampleBuffer final {
         SINT m_length;
     };
 
+    /// Deprecated: use std::span<CSAMPLE>, SampleBuffer::span() and
+    /// mixxx::spanutil::spanFromPtrLen from util/span.h instead.
     class WritableSlice {
       public:
         WritableSlice()

--- a/src/waveform/guitick.h
+++ b/src/waveform/guitick.h
@@ -1,8 +1,9 @@
 #pragma once
 
+#include <memory>
+
 #include "control/controlobject.h"
 #include "util/duration.h"
-#include "util/memory.h"
 #include "util/performancetimer.h"
 
 /// A helper class that manages the `gui_Tick` COs, that drive updates of the

--- a/src/waveform/renderers/glslwaveformrenderersignal.h
+++ b/src/waveform/renderers/glslwaveformrenderersignal.h
@@ -3,8 +3,9 @@
 #include "waveform/renderers/glwaveformrenderersignal.h"
 #if !defined(QT_NO_OPENGL) && !defined(QT_OPENGL_ES_2)
 
+#include <memory>
+
 #include "track/track_decl.h"
-#include "util/memory.h"
 
 #ifdef MIXXX_USE_QOPENGL
 class QOpenGLFramebufferObject;

--- a/src/waveform/renderers/waveformmark.h
+++ b/src/waveform/renderers/waveformmark.h
@@ -1,10 +1,10 @@
 #pragma once
 #include <QDomNode>
 #include <QImage>
+#include <memory>
 
 #include "control/controlproxy.h"
 #include "track/cue.h"
-#include "util/memory.h"
 #include "waveform/waveformmarklabel.h"
 
 class SkinContext;

--- a/src/waveform/visualsmanager.h
+++ b/src/waveform/visualsmanager.h
@@ -1,11 +1,11 @@
 #pragma once
 
+#include <memory>
 #include <vector>
 
 #include "control/controlobject.h"
 #include "control/controlproxy.h"
 #include "util/duration.h"
-#include "util/memory.h"
 #include "util/performancetimer.h"
 
 class VisualPlayPosition;

--- a/src/widget/paintable.cpp
+++ b/src/widget/paintable.cpp
@@ -7,9 +7,9 @@
 #include <QString>
 #include <QSvgRenderer>
 #include <QtDebug>
+#include <memory>
 
 #include "util/math.h"
-#include "util/memory.h"
 #include "util/painterscope.h"
 #include "widget/wpixmapstore.h"
 


### PR DESCRIPTION
as requested in #13222

One primary issue is that marking entire classes `[[deprecated]]` will result in build failures due to `-Wdeprecated -Werror`. So marking them deprecated formally would require their removal in the same step. That's why I only made them deprecated in the form of a comment. 