### PR TITLE
fix: remove removed clang-tidy AnalyzeTemporaryDtors setting

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,7 +10,6 @@ Checks: >-
   readability-qualified-auto
 WarningsAsErrors: ""
 HeaderFilterRegex: ""
-AnalyzeTemporaryDtors: false
 FormatStyle: none
 User: user
 CheckOptions:


### PR DESCRIPTION
My local builds always had this:
```
/home/swiftb0y/Sourcerepositories/mixxx/.clang-tidy:13:1: error: unknown key 'AnalyzeTemporaryDtors'
AnalyzeTemporaryDtors: false
^~~~~~~~~~~~~~~~~~~~~
Error parsing /home/swiftb0y/Sourcerepositories/mixxx/.clang-tidy: Invalid argument
```

Which seems to have been removed: https://stackoverflow.com/questions/63920634/what-is-the-meaning-of-the-analyzetemporarydtors-option-in-clang-tidy