### PR TITLE
Refactor/modernize shrink scopedtimer

### DIFF
--- a/src/analyzer/analyzerebur128.cpp
+++ b/src/analyzer/analyzerebur128.cpp
@@ -49,7 +49,7 @@ bool AnalyzerEbur128::processSamples(const CSAMPLE* pIn, SINT count) {
     VERIFY_OR_DEBUG_ASSERT(m_pState) {
         return false;
     }
-    ScopedTimer t("AnalyzerEbur128::processSamples()");
+    ScopedTimer t(QStringLiteral("AnalyzerEbur128::processSamples()"));
     size_t frames = count / mixxx::kAnalysisChannels;
     int e = ebur128_add_frames_float(m_pState, pIn, frames);
     VERIFY_OR_DEBUG_ASSERT(e == EBUR128_SUCCESS) {

--- a/src/analyzer/analyzergain.cpp
+++ b/src/analyzer/analyzergain.cpp
@@ -37,7 +37,7 @@ void AnalyzerGain::cleanup() {
 }
 
 bool AnalyzerGain::processSamples(const CSAMPLE* pIn, SINT count) {
-    ScopedTimer t("AnalyzerGain::process()");
+    ScopedTimer t(QStringLiteral("AnalyzerGain::process()"));
 
     SINT numFrames = count / mixxx::kAnalysisChannels;
     if (numFrames > static_cast<SINT>(m_pLeftTempBuffer.size())) {

--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -111,7 +111,7 @@ CoreServices::CoreServices(const CmdlineArgs& args, QApplication* pApp)
           m_isInitialized(false) {
     m_runtime_timer.start();
     mixxx::Time::start();
-    ScopedTimer t("CoreServices::CoreServices");
+    ScopedTimer t(QStringLiteral("CoreServices::CoreServices"));
     // All this here is running without without start up screen
     // Defer long initializations to CoreServices::initialize() which is
     // called after the GUI is initialized
@@ -211,7 +211,7 @@ void CoreServices::initialize(QApplication* pApp) {
         return;
     }
 
-    ScopedTimer t("CoreServices::initialize");
+    ScopedTimer t(QStringLiteral("CoreServices::initialize"));
 
     VERIFY_OR_DEBUG_ASSERT(SoundSourceProxy::registerProviders()) {
         qCritical() << "Failed to register any SoundSource providers";

--- a/src/engine/channelmixer.cpp
+++ b/src/engine/channelmixer.cpp
@@ -23,7 +23,7 @@ void ChannelMixer::applyEffectsAndMixChannels(const EngineMixer::GainCalculator&
     //     D) Mixes the temporary buffer into pOutput
     // The original channel input buffers are not modified.
     SampleUtil::clear(pOutput, iBufferSize);
-    ScopedTimer t("EngineMixer::applyEffectsAndMixChannels");
+    ScopedTimer t(QStringLiteral("EngineMixer::applyEffectsAndMixChannels"));
     for (auto* pChannelInfo : activeChannels) {
         EngineMixer::GainCache& gainCache = (*channelGainCache)[pChannelInfo->m_index];
         CSAMPLE_GAIN oldGain = gainCache.m_gain;
@@ -68,7 +68,7 @@ void ChannelMixer::applyEffectsInPlaceAndMixChannels(
     //    A) Applies the calculated gain to the channel buffer, modifying the original input buffer
     //    B) Applies effects to the buffer, modifying the original input buffer
     // 4. Mix the channel buffers together to make pOutput, overwriting the pOutput buffer from the last engine callback
-    ScopedTimer t("EngineMixer::applyEffectsInPlaceAndMixChannels");
+    ScopedTimer t(QStringLiteral("EngineMixer::applyEffectsInPlaceAndMixChannels"));
     SampleUtil::clear(pOutput, iBufferSize);
     for (auto* pChannelInfo : activeChannels) {
         EngineMixer::GainCache& gainCache = (*channelGainCache)[pChannelInfo->m_index];

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -838,7 +838,7 @@ void EngineBuffer::slotKeylockEngineChanged(double dIndex) {
 
 void EngineBuffer::processTrackLocked(
         CSAMPLE* pOutput, const int iBufferSize, mixxx::audio::SampleRate sampleRate) {
-    ScopedTimer t("EngineBuffer::process_pauselock");
+    ScopedTimer t(QStringLiteral("EngineBuffer::process_pauselock"));
 
     m_trackSampleRateOld = mixxx::audio::SampleRate::fromDouble(m_pTrackSampleRate->get());
     m_trackEndPositionOld = getTrackEndPosition();

--- a/src/engine/enginemixer.cpp
+++ b/src/engine/enginemixer.cpp
@@ -291,7 +291,7 @@ void EngineMixer::processChannels(int iBufferSize) {
     m_activeTalkoverChannels.clear();
     m_activeChannels.clear();
 
-    // ScopedTimer timer("EngineMixer::processChannels");
+    // ScopedTimer timer(QStringLiteral("EngineMixer::processChannels"));
     EngineChannel* pLeaderChannel = m_pEngineSync->getLeaderChannel();
     // Reserve the first place for the main channel which
     // should be processed first

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1368,7 +1368,7 @@ TrackPointer TrackDAO::getTrackById(TrackId trackId) const {
     // be executed with a lock on the GlobalTrackCache. The GlobalTrackCache
     // will be locked again after the query has been executed (see below)
     // and potential race conditions will be resolved.
-    ScopedTimer t("TrackDAO::getTrackById");
+    ScopedTimer t(QStringLiteral("TrackDAO::getTrackById"));
 
     QSqlRecord queryRecord;
     {

--- a/src/library/scanner/importfilestask.cpp
+++ b/src/library/scanner/importfilestask.cpp
@@ -21,7 +21,7 @@ ImportFilesTask::ImportFilesTask(LibraryScanner* pScanner,
 }
 
 void ImportFilesTask::run() {
-    ScopedTimer timer("ImportFilesTask::run");
+    ScopedTimer timer(QStringLiteral("ImportFilesTask::run"));
     for (const QFileInfo& fileInfo: m_filesToImport) {
         // If a flag was raised telling us to cancel the library scan then stop.
         if (m_scannerGlobal->shouldCancel()) {

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -489,7 +489,7 @@ void LibraryScanner::cancel() {
 
 void LibraryScanner::queueTask(ScannerTask* pTask) {
     //kLogger.debug() << "queueTask" << pTask;
-    ScopedTimer timer("LibraryScanner::queueTask");
+    ScopedTimer timer(QStringLiteral("LibraryScanner::queueTask"));
     if (m_scannerGlobal.isNull() || m_scannerGlobal->shouldCancel()) {
         return;
     }
@@ -531,7 +531,7 @@ void LibraryScanner::queueTask(ScannerTask* pTask) {
 
 void LibraryScanner::slotDirectoryHashedAndScanned(const QString& directoryPath,
                                                bool newDirectory, mixxx::cache_key_t hash) {
-    ScopedTimer timer("LibraryScanner::slotDirectoryHashedAndScanned");
+    ScopedTimer timer(QStringLiteral("LibraryScanner::slotDirectoryHashedAndScanned"));
     //kLogger.debug() << "sloDirectoryHashedAndScanned" << directoryPath
     //          << newDirectory << hash;
 
@@ -550,7 +550,7 @@ void LibraryScanner::slotDirectoryHashedAndScanned(const QString& directoryPath,
 }
 
 void LibraryScanner::slotDirectoryUnchanged(const QString& directoryPath) {
-    ScopedTimer timer("LibraryScanner::slotDirectoryUnchanged");
+    ScopedTimer timer(QStringLiteral("LibraryScanner::slotDirectoryUnchanged"));
     //kLogger.debug() << "slotDirectoryUnchanged" << directoryPath;
     if (m_scannerGlobal) {
         m_scannerGlobal->addVerifiedDirectory(directoryPath);
@@ -560,7 +560,7 @@ void LibraryScanner::slotDirectoryUnchanged(const QString& directoryPath) {
 
 void LibraryScanner::slotTrackExists(const QString& trackPath) {
     //kLogger.debug() << "slotTrackExists" << trackPath;
-    ScopedTimer timer("LibraryScanner::slotTrackExists");
+    ScopedTimer timer(QStringLiteral("LibraryScanner::slotTrackExists"));
     if (m_scannerGlobal) {
         m_scannerGlobal->addVerifiedTrack(trackPath);
     }
@@ -568,7 +568,7 @@ void LibraryScanner::slotTrackExists(const QString& trackPath) {
 
 void LibraryScanner::slotAddNewTrack(const QString& trackPath) {
     //kLogger.debug() << "slotAddNewTrack" << trackPath;
-    ScopedTimer timer("LibraryScanner::addNewTrack");
+    ScopedTimer timer(QStringLiteral("LibraryScanner::addNewTrack"));
     // For statistics tracking and to detect moved tracks
     TrackPointer pTrack = m_trackDao.addTracksAddFile(
             trackPath,

--- a/src/library/scanner/recursivescandirectorytask.cpp
+++ b/src/library/scanner/recursivescandirectorytask.cpp
@@ -20,7 +20,7 @@ RecursiveScanDirectoryTask::RecursiveScanDirectoryTask(
 }
 
 void RecursiveScanDirectoryTask::run() {
-    ScopedTimer timer("RecursiveScanDirectoryTask::run");
+    ScopedTimer timer(QStringLiteral("RecursiveScanDirectoryTask::run"));
     if (m_scannerGlobal->shouldCancel()) {
         setSuccess(false);
         return;

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -673,7 +673,7 @@ void MixxxMainWindow::slotUpdateWindowTitle(TrackPointer pTrack) {
 }
 
 void MixxxMainWindow::createMenuBar() {
-    ScopedTimer t("MixxxMainWindow::createMenuBar");
+    ScopedTimer t(QStringLiteral("MixxxMainWindow::createMenuBar"));
     DEBUG_ASSERT(m_pCoreServices->getKeyboardConfig());
     m_pMenuBar = make_parented<WMainMenuBar>(
             this, m_pCoreServices->getSettings(), m_pCoreServices->getKeyboardConfig().get());
@@ -687,7 +687,7 @@ void MixxxMainWindow::connectMenuBar() {
     // This function might be invoked multiple times on startup
     // so all connections must be unique!
 
-    ScopedTimer t("MixxxMainWindow::connectMenuBar");
+    ScopedTimer t(QStringLiteral("MixxxMainWindow::connectMenuBar"));
     connect(this,
             &MixxxMainWindow::skinLoaded,
             m_pMenuBar,

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -324,7 +324,7 @@ Qt::MouseButton LegacySkinParser::parseButtonState(const QDomNode& node,
 }
 
 QWidget* LegacySkinParser::parseSkin(const QString& skinPath, QWidget* pParent) {
-    ScopedTimer timer("SkinLoader::parseSkin");
+    ScopedTimer timer(QStringLiteral("SkinLoader::parseSkin"));
     qDebug() << "LegacySkinParser loading skin:" << skinPath;
 
     m_pContext = std::make_unique<SkinContext>(m_pConfig, skinPath + "/skin.xml");

--- a/src/skin/skinloader.cpp
+++ b/src/skin/skinloader.cpp
@@ -131,7 +131,7 @@ QString SkinLoader::getDefaultSkinName() const {
 QWidget* SkinLoader::loadConfiguredSkin(QWidget* pParent,
         QSet<ControlObject*>* pSkinCreatedControls,
         mixxx::CoreServices* pCoreServices) {
-    ScopedTimer timer("SkinLoader::loadConfiguredSkin");
+    ScopedTimer timer(QStringLiteral("SkinLoader::loadConfiguredSkin"));
     SkinPointer pSkin = getConfiguredSkin();
 
     // If we don't have a skin then fail. This makes sense here, because the

--- a/src/soundio/sounddevicenetwork.cpp
+++ b/src/soundio/sounddevicenetwork.cpp
@@ -486,7 +486,7 @@ void SoundDeviceNetwork::callbackProcessClkRef() {
     m_pSoundManager->readProcess(framesPerBuffer);
 
     {
-        ScopedTimer t("SoundDevicePortAudio::callbackProcess prepare %1",
+        ScopedTimer t(QStringLiteral("SoundDevicePortAudio::callbackProcess prepare %1"),
                 m_deviceId.name);
         m_pSoundManager->onDeviceOutputCallback(framesPerBuffer);
     }

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -976,7 +976,7 @@ int SoundDevicePortAudio::callbackProcessClkRef(
 
     // Send audio from the soundcard's input off to the SoundManager...
     if (in) {
-        ScopedTimer t("SoundDevicePortAudio::callbackProcess input %1",
+        ScopedTimer t(QStringLiteral("SoundDevicePortAudio::callbackProcess input %1"),
                 m_deviceId.debugName());
         composeInputBuffer(in, framesPerBuffer, 0, m_inputParams.channelCount);
         m_pSoundManager->pushInputBuffers(m_audioInputs, framesPerBuffer);
@@ -985,13 +985,13 @@ int SoundDevicePortAudio::callbackProcessClkRef(
     m_pSoundManager->readProcess(framesPerBuffer);
 
     {
-        ScopedTimer t("SoundDevicePortAudio::callbackProcess prepare %1",
+        ScopedTimer t(QStringLiteral("SoundDevicePortAudio::callbackProcess prepare %1"),
                 m_deviceId.debugName());
         m_pSoundManager->onDeviceOutputCallback(framesPerBuffer);
     }
 
     if (out) {
-        ScopedTimer t("SoundDevicePortAudio::callbackProcess output %1",
+        ScopedTimer t(QStringLiteral("SoundDevicePortAudio::callbackProcess output %1"),
                 m_deviceId.debugName());
 
         if (m_outputParams.channelCount <= 0) {

--- a/src/sources/soundsourcemodplug.cpp
+++ b/src/sources/soundsourcemodplug.cpp
@@ -117,7 +117,7 @@ SoundSourceModPlug::importTrackMetadataAndCoverImage(
 SoundSource::OpenResult SoundSourceModPlug::tryOpen(
         OpenMode /*mode*/,
         const OpenParams& /*config*/) {
-    ScopedTimer t("SoundSourceModPlug::open()");
+    ScopedTimer t(QStringLiteral("SoundSourceModPlug::open()"));
 
     // read module file to byte array
     const QString fileName(getLocalFileName());

--- a/src/util/qstringformat.h
+++ b/src/util/qstringformat.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <QString>
+#include <type_traits>
+#include <utility>
+
+namespace {
+
+// taken from Qt
+template<typename T>
+static constexpr bool is_convertible_to_view_or_qstring_v =
+        std::is_convertible_v<T, QString> ||
+        std::is_convertible_v<T, QStringView> ||
+        std::is_convertible_v<T, QLatin1String>;
+
+// check if we can call QString::number(T) with T
+template<typename T>
+static constexpr bool is_number_compatible_v =
+        std::is_invocable_v<decltype(QString::number(std::declval<T>()))(T), T>;
+
+// always false, used for static_assert and workaround for compilers without
+// https://cplusplus.github.io/CWG/issues/2518.html
+template<typename T>
+static constexpr bool always_false_v = false;
+} // namespace
+
+// Try to convert T to a type that would be accepted by QString::args(Args&&...)
+template<typename T>
+auto convertToQStringConvertible(T&& arg) {
+    if constexpr (is_convertible_to_view_or_qstring_v<T>) {
+        // no need to do anything, just return verbatim
+        return std::forward<T>(arg);
+    } else if constexpr (is_number_compatible_v<T>) {
+        return QString::number(std::forward<T>(arg));
+    } else {
+        static_assert(always_false_v<T>, "Unsupported type for QString::arg");
+        // unreachable, but returning a QString results in a better error message
+        // because the log won't be spammed with all the QString::arg overloads
+        // it couldn't match with `void`.
+        return QString();
+    }
+}

--- a/src/util/timer.h
+++ b/src/util/timer.h
@@ -65,7 +65,7 @@ class ScopedTimer {
     template<typename T, typename... Ts>
     ScopedTimer(Stat::ComputeFlags compute, T&& key, Ts&&... args)
             : m_timer(std::nullopt) {
-        static_assert(!std::is_same_v<std::remove_cvref_t<std::decay_t<T>>, char*>,
+        static_assert(!std::is_same_v<std::decay_t<T>, char const*>,
                 "string type likely not UTF-16, please pass QStringLiteral by "
                 "means of u\"key text\"_s");
         if (!CmdlineArgs::Instance().getDeveloper()) {
@@ -74,6 +74,8 @@ class ScopedTimer {
         // key is explicitly `auto` to allow passing non-QString types such as `const char*`
         // its conversion is delayed until after we've checked if we're in developer mode
         auto assembledKey = QString(std::forward<T>(key));
+        // ensure the string was indeed a literal an not unnecessarily heap-allocated
+        DEBUG_ASSERT(assembledKey.capacity() == 0);
         if constexpr (sizeof...(args) > 0) {
             // only try to call QString::arg when we've been given parameters
             assembledKey = assembledKey.arg(convertToQStringConvertible(std::forward<Ts>(args))...);

--- a/src/util/timer.h
+++ b/src/util/timer.h
@@ -65,7 +65,7 @@ class ScopedTimer {
     template<typename T, typename... Ts>
     ScopedTimer(Stat::ComputeFlags compute, T&& key, Ts&&... args)
             : m_timer(std::nullopt) {
-        static_assert(char_type_size<T>() == sizeof(QString::value_type),
+        static_assert(!std::is_same_v<std::remove_cvref_t<std::decay_t<T>>, char*>,
                 "string type likely not UTF-16, please pass QStringLiteral by "
                 "means of u\"key text\"_s");
         if (!CmdlineArgs::Instance().getDeveloper()) {
@@ -96,19 +96,6 @@ class ScopedTimer {
         m_timer.reset();
     }
   private:
-    // utility function
-    template<typename T>
-    constexpr static std::size_t char_type_size() {
-        if constexpr (std::is_array_v<T>) {
-            return sizeof(std::remove_all_extents_t<T>);
-        } else if constexpr (std::is_pointer_v<T>) {
-            // assume this is some point to char array then.
-            return sizeof(std::remove_pointer_t<T>);
-        } else {
-            // assume this is some QString or std::string type
-            return sizeof(typename T::value_type);
-        }
-    }
     // nullopt also counts as cancelled
     std::optional<Timer> m_timer;
 };

--- a/src/vinylcontrol/vinylcontrolprocessor.cpp
+++ b/src/vinylcontrol/vinylcontrolprocessor.cpp
@@ -204,7 +204,7 @@ bool VinylControlProcessor::deckConfigured(int index) const {
 void VinylControlProcessor::receiveBuffer(const AudioInput& input,
         const CSAMPLE* pBuffer,
         unsigned int nFrames) {
-    ScopedTimer t("VinylControlProcessor::receiveBuffer");
+    ScopedTimer t(QStringLiteral("VinylControlProcessor::receiveBuffer"));
     if (input.getType() != AudioPathType::VinylControl) {
         qDebug() << "WARNING: AudioInput type is not VINYLCONTROL. Ignoring incoming buffer.";
         return;

--- a/src/vinylcontrol/vinylcontrolxwax.cpp
+++ b/src/vinylcontrol/vinylcontrolxwax.cpp
@@ -200,7 +200,7 @@ bool VinylControlXwax::writeQualityReport(VinylSignalQualityReport* pReport) {
 
 
 void VinylControlXwax::analyzeSamples(CSAMPLE* pSamples, size_t nFrames) {
-    ScopedTimer t("VinylControlXwax::analyzeSamples");
+    ScopedTimer t(QStringLiteral("VinylControlXwax::analyzeSamples"));
     auto gain = static_cast<CSAMPLE_GAIN>(m_pVinylControlInputGain->get());
 
     // We only support amplifying with the VC pre-amp.

--- a/src/waveform/renderers/waveformrendererendoftrack.cpp
+++ b/src/waveform/renderers/waveformrendererendoftrack.cpp
@@ -57,7 +57,7 @@ void WaveformRendererEndOfTrack::draw(QPainter* painter,
         return;
     }
 
-    //ScopedTimer t("WaveformRendererEndOfTrack::draw");
+    // ScopedTimer t(QStringLiteral("WaveformRendererEndOfTrack::draw"));
 
     const int elapsed = m_timer.elapsed().toIntegerMillis() % kBlinkingPeriodMillis;
 

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -688,7 +688,7 @@ void WaveformWidgetFactory::notifyZoomChange(WWaveformViewer* viewer) {
 }
 
 void WaveformWidgetFactory::renderSelf() {
-    ScopedTimer t("WaveformWidgetFactory::render() %1 waveforms",
+    ScopedTimer t(QStringLiteral("WaveformWidgetFactory::render() %1 waveforms"),
             m_waveformWidgetHolders.size());
 
     if (!m_skipRender) {
@@ -762,7 +762,7 @@ void WaveformWidgetFactory::render() {
 }
 
 void WaveformWidgetFactory::swapSelf() {
-    ScopedTimer t("WaveformWidgetFactory::swap() %1waveforms",
+    ScopedTimer t(QStringLiteral("WaveformWidgetFactory::swap() %1waveforms"),
             static_cast<int>(m_waveformWidgetHolders.size()));
 
     // Do this in an extra slot to be sure to hit the desired interval

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -688,8 +688,8 @@ void WaveformWidgetFactory::notifyZoomChange(WWaveformViewer* viewer) {
 }
 
 void WaveformWidgetFactory::renderSelf() {
-    ScopedTimer t("WaveformWidgetFactory::render() %1waveforms",
-            static_cast<int>(m_waveformWidgetHolders.size()));
+    ScopedTimer t("WaveformWidgetFactory::render() %1 waveforms",
+            QString::number(m_waveformWidgetHolders.size()));
 
     if (!m_skipRender) {
         if (m_type) {   // no regular updates for an empty waveform

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -689,7 +689,7 @@ void WaveformWidgetFactory::notifyZoomChange(WWaveformViewer* viewer) {
 
 void WaveformWidgetFactory::renderSelf() {
     ScopedTimer t("WaveformWidgetFactory::render() %1 waveforms",
-            QString::number(m_waveformWidgetHolders.size()));
+            m_waveformWidgetHolders.size());
 
     if (!m_skipRender) {
         if (m_type) {   // no regular updates for an empty waveform

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -577,7 +577,7 @@ void WOverview::leaveEvent(QEvent* pEvent) {
 
 void WOverview::paintEvent(QPaintEvent* pEvent) {
     Q_UNUSED(pEvent);
-    ScopedTimer t("WOverview::paintEvent");
+    ScopedTimer t(QStringLiteral("WOverview::paintEvent"));
 
     QPainter painter(this);
     painter.fillRect(rect(), m_backgroundColor);

--- a/src/widget/woverviewhsv.cpp
+++ b/src/widget/woverviewhsv.cpp
@@ -18,7 +18,7 @@ WOverviewHSV::WOverviewHSV(
 }
 
 bool WOverviewHSV::drawNextPixmapPart() {
-    ScopedTimer t("WOverviewHSV::drawNextPixmapPart");
+    ScopedTimer t(QStringLiteral("WOverviewHSV::drawNextPixmapPart"));
 
     //qDebug() << "WOverview::drawNextPixmapPart()";
 

--- a/src/widget/woverviewlmh.cpp
+++ b/src/widget/woverviewlmh.cpp
@@ -18,7 +18,7 @@ WOverviewLMH::WOverviewLMH(
 }
 
 bool WOverviewLMH::drawNextPixmapPart() {
-    ScopedTimer t("WOverviewLMH::drawNextPixmapPart");
+    ScopedTimer t(QStringLiteral("WOverviewLMH::drawNextPixmapPart"));
 
     //qDebug() << "WOverview::drawNextPixmapPart()";
 

--- a/src/widget/woverviewrgb.cpp
+++ b/src/widget/woverviewrgb.cpp
@@ -17,7 +17,7 @@ WOverviewRGB::WOverviewRGB(
 }
 
 bool WOverviewRGB::drawNextPixmapPart() {
-    ScopedTimer t("WOverviewRGB::drawNextPixmapPart");
+    ScopedTimer t(QStringLiteral("WOverviewRGB::drawNextPixmapPart"));
 
     //qDebug() << "WOverview::drawNextPixmapPart()";
 

--- a/src/widget/wvumeterbase.cpp
+++ b/src/widget/wvumeterbase.cpp
@@ -181,7 +181,7 @@ void WVuMeterBase::render(VSyncThread* vSyncThread) {
         return;
     }
 
-    ScopedTimer t("WVuMeterBase::render");
+    ScopedTimer t(QStringLiteral("WVuMeterBase::render"));
 
     updateState(vSyncThread->sinceLastSwap());
 

--- a/src/widget/wvumeterlegacy.cpp
+++ b/src/widget/wvumeterlegacy.cpp
@@ -165,7 +165,7 @@ void WVuMeterLegacy::showEvent(QShowEvent* e) {
 }
 
 void WVuMeterLegacy::paintEvent(QPaintEvent* /*unused*/) {
-    ScopedTimer t("WVuMeterLegacy::paintEvent");
+    ScopedTimer t(QStringLiteral("WVuMeterLegacy::paintEvent"));
 
     QPainter p(this);
 


### PR DESCRIPTION
first commit just modernizes it a bit, and doesn't touch the API, the second commit goes a step further and leverages `QString::arg(Args&&...)` to provide arbitrary formastring support. let me know what you think.