### PR TITLE
Fix/gh12894 single quote sqlite string literals

### DIFF
--- a/src/library/banshee/bansheedbconnection.cpp
+++ b/src/library/banshee/bansheedbconnection.cpp
@@ -41,7 +41,7 @@ bool BansheeDbConnection::open(const QString& databaseFile) {
 
 int BansheeDbConnection::getSchemaVersion() {
     QSqlQuery query(m_database);
-    query.prepare("SELECT Value FROM CoreConfiguration WHERE Key = \"DatabaseVersion\"");
+    query.prepare("SELECT Value FROM CoreConfiguration WHERE Key = 'DatabaseVersion'");
 
     if (query.exec()) {
         if (query.next()) {

--- a/src/library/dao/autodjcratesdao.cpp
+++ b/src/library/dao/autodjcratesdao.cpp
@@ -459,25 +459,29 @@ bool AutoDJCratesDAO::updateLastPlayedDateTime() {
     // WHERE newlastplayed != "";
     QString strSetLog;
     strSetLog.setNum(PlaylistDAO::PLHT_SET_LOG);
-    QString strQuery(QString ("INSERT OR REPLACE INTO " AUTODJCRATES_TABLE
-            " (" AUTODJCRATESTABLE_TRACKID ", " AUTODJCRATESTABLE_CRATEREFS ", "
-            AUTODJCRATESTABLE_TIMESPLAYED ", " AUTODJCRATESTABLE_AUTODJREFS ", "
-            AUTODJCRATESTABLE_LASTPLAYED ")"
-            " SELECT * FROM (SELECT " PLAYLIST_TRACKS_TABLE ".%1, "
-            AUTODJCRATESTABLE_CRATEREFS ", " AUTODJCRATESTABLE_TIMESPLAYED ", "
-            AUTODJCRATESTABLE_AUTODJREFS ", MAX(%3) AS new"
-            AUTODJCRATESTABLE_LASTPLAYED " FROM " PLAYLIST_TRACKS_TABLE ", "
-            AUTODJCRATES_TABLE " WHERE " PLAYLIST_TRACKS_TABLE
-            ".%2 IN (SELECT %4 FROM " PLAYLIST_TABLE " WHERE %5 = %6) AND "
-            PLAYLIST_TRACKS_TABLE ".%1 = " AUTODJCRATES_TABLE "."
-            AUTODJCRATESTABLE_TRACKID " GROUP BY " PLAYLIST_TRACKS_TABLE
-            ".%1) WHERE new" AUTODJCRATESTABLE_LASTPLAYED " != \"\"")
-            .arg(PLAYLISTTRACKSTABLE_TRACKID, // %1
-                 PLAYLISTTRACKSTABLE_PLAYLISTID, // %2
-                 PLAYLISTTRACKSTABLE_DATETIMEADDED, // %3
-                 PLAYLISTTABLE_ID, // %4
-                 PLAYLISTTABLE_HIDDEN, // %5
-                 strSetLog)); // %6
+    QString strQuery(QString(
+            "INSERT OR REPLACE INTO " AUTODJCRATES_TABLE
+            " (" AUTODJCRATESTABLE_TRACKID ", " AUTODJCRATESTABLE_CRATEREFS
+            ", " AUTODJCRATESTABLE_TIMESPLAYED ", " AUTODJCRATESTABLE_AUTODJREFS
+            ", " AUTODJCRATESTABLE_LASTPLAYED
+            ")"
+            " SELECT * FROM (SELECT " PLAYLIST_TRACKS_TABLE
+            ".%1, " AUTODJCRATESTABLE_CRATEREFS
+            ", " AUTODJCRATESTABLE_TIMESPLAYED ", " AUTODJCRATESTABLE_AUTODJREFS
+            ", MAX(%3) AS new" AUTODJCRATESTABLE_LASTPLAYED
+            " FROM " PLAYLIST_TRACKS_TABLE ", " AUTODJCRATES_TABLE
+            " WHERE " PLAYLIST_TRACKS_TABLE
+            ".%2 IN (SELECT %4 FROM " PLAYLIST_TABLE
+            " WHERE %5 = %6) AND " PLAYLIST_TRACKS_TABLE
+            ".%1 = " AUTODJCRATES_TABLE "." AUTODJCRATESTABLE_TRACKID
+            " GROUP BY " PLAYLIST_TRACKS_TABLE
+            ".%1) WHERE new" AUTODJCRATESTABLE_LASTPLAYED " != ''")
+                             .arg(PLAYLISTTRACKSTABLE_TRACKID,          // %1
+                                     PLAYLISTTRACKSTABLE_PLAYLISTID,    // %2
+                                     PLAYLISTTRACKSTABLE_DATETIMEADDED, // %3
+                                     PLAYLISTTABLE_ID,                  // %4
+                                     PLAYLISTTABLE_HIDDEN,              // %5
+                                     strSetLog));                       // %6
     oQuery.prepare(strQuery);
     if (!oQuery.exec()) {
         LOG_FAILED_QUERY(oQuery);
@@ -507,26 +511,30 @@ bool AutoDJCratesDAO::updateLastPlayedDateTimeForTrack(TrackId trackId) {
     // WHERE newlastplayed != "";
     QString strSetLog;
     strSetLog.setNum(PlaylistDAO::PLHT_SET_LOG);
-    oQuery.prepare(QString ("INSERT OR REPLACE INTO " AUTODJCRATES_TABLE
-            " (" AUTODJCRATESTABLE_TRACKID ", " AUTODJCRATESTABLE_CRATEREFS ", "
-            AUTODJCRATESTABLE_TIMESPLAYED ", " AUTODJCRATESTABLE_AUTODJREFS ", "
-            AUTODJCRATESTABLE_LASTPLAYED ")"
-            " SELECT * FROM (SELECT " PLAYLIST_TRACKS_TABLE ".%1, "
-            AUTODJCRATESTABLE_CRATEREFS ", " AUTODJCRATESTABLE_TIMESPLAYED ", "
-            AUTODJCRATESTABLE_AUTODJREFS ", MAX(%3) AS new"
-            AUTODJCRATESTABLE_LASTPLAYED " FROM " PLAYLIST_TRACKS_TABLE ", "
-            AUTODJCRATES_TABLE " WHERE " PLAYLIST_TRACKS_TABLE
-            ".%2 IN (SELECT %4 FROM " PLAYLIST_TABLE " WHERE %5 = %6) AND "
-            PLAYLIST_TRACKS_TABLE ".%1 = :track_id AND " PLAYLIST_TRACKS_TABLE
+    oQuery.prepare(QString(
+            "INSERT OR REPLACE INTO " AUTODJCRATES_TABLE
+            " (" AUTODJCRATESTABLE_TRACKID ", " AUTODJCRATESTABLE_CRATEREFS
+            ", " AUTODJCRATESTABLE_TIMESPLAYED ", " AUTODJCRATESTABLE_AUTODJREFS
+            ", " AUTODJCRATESTABLE_LASTPLAYED
+            ")"
+            " SELECT * FROM (SELECT " PLAYLIST_TRACKS_TABLE
+            ".%1, " AUTODJCRATESTABLE_CRATEREFS
+            ", " AUTODJCRATESTABLE_TIMESPLAYED ", " AUTODJCRATESTABLE_AUTODJREFS
+            ", MAX(%3) AS new" AUTODJCRATESTABLE_LASTPLAYED
+            " FROM " PLAYLIST_TRACKS_TABLE ", " AUTODJCRATES_TABLE
+            " WHERE " PLAYLIST_TRACKS_TABLE
+            ".%2 IN (SELECT %4 FROM " PLAYLIST_TABLE
+            " WHERE %5 = %6) AND " PLAYLIST_TRACKS_TABLE
+            ".%1 = :track_id AND " PLAYLIST_TRACKS_TABLE
             ".%1 = " AUTODJCRATES_TABLE "." AUTODJCRATESTABLE_TRACKID
-            " GROUP BY " PLAYLIST_TRACKS_TABLE ".%1) WHERE new"
-            AUTODJCRATESTABLE_LASTPLAYED " != \"\"")
-            .arg(PLAYLISTTRACKSTABLE_TRACKID, // %1
-                 PLAYLISTTRACKSTABLE_PLAYLISTID, // %2
-                 PLAYLISTTRACKSTABLE_DATETIMEADDED, // %3
-                 PLAYLISTTABLE_ID, // %4
-                 PLAYLISTTABLE_HIDDEN, // %5
-                 strSetLog)); // %6
+            " GROUP BY " PLAYLIST_TRACKS_TABLE
+            ".%1) WHERE new" AUTODJCRATESTABLE_LASTPLAYED " != ''")
+                           .arg(PLAYLISTTRACKSTABLE_TRACKID,          // %1
+                                   PLAYLISTTRACKSTABLE_PLAYLISTID,    // %2
+                                   PLAYLISTTRACKSTABLE_DATETIMEADDED, // %3
+                                   PLAYLISTTABLE_ID,                  // %4
+                                   PLAYLISTTABLE_HIDDEN,              // %5
+                                   strSetLog));                       // %6
     oQuery.bindValue(":track_id", trackId.toVariant());
     if (!oQuery.exec()) {
         LOG_FAILED_QUERY(oQuery);


### PR DESCRIPTION
Alternative to #13247 along with some manual follow up trying to replace these literals in our query-strings as well. Also based on 2.4 instead of `main` (as #13247 currently is). I'd appreciate if someone could double check if I've missed any string.