### PR TITLE
GitHub CI: Skip the manifest update job on forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -481,7 +481,9 @@ jobs:
     needs: build
     # Always run this job, even if one or more jobs from the `build` jobs
     # fail to allow partial updates of the manifest.
-    if: always()
+    # Don't run it on forks that do not have access to our external
+    # infrastructure, though.
+    if: always() && github.repository == 'mixxxdj/mixxx'
     steps:
       - name: "Check out repository"
         uses: actions/checkout@v4.1.6


### PR DESCRIPTION
The steps of manifest update job are already skipped on forks because they do not have the necessary secrets configured, so we skip the job altogether for any repository that is not the main `mixxxdj/mixxx` repository to avoid unnecessary noise in the build log (as well as some issues related to canceling build jobs).

It would be preferable to directly check for the presence of the secrets in `jobs.<job_id>.if`, but that is not possible, as per actions/runner#520.