### PR TITLE
fix(Roland DJ_505): generate proper warning if audio inputs are not setup for passthrough

### DIFF
--- a/res/controllers/Roland_DJ-505-scripts.js
+++ b/res/controllers/Roland_DJ-505-scripts.js
@@ -377,6 +377,9 @@ DJ505.setChannelInput = function(channel, control, value, _status, _group) {
         break;
     case 0x01:  // LINE
     case 0x02:  // PHONO
+        if (engine.getValue(channelgroup, "input_configured") === 0) {
+            throw "Configuration Error: a PC/Line/Phono switch has been set to Line or Phono. In order to use these modes audio inputs to be configured accordingly! Please refer to https://manual.mixxx.org/latest/hardware/controllers/roland_dj_505#audio-setup";
+        }
         engine.setValue(channelgroup, "passthrough", 1);
         break;
     }

--- a/res/controllers/Roland_DJ-505.midi.xml
+++ b/res/controllers/Roland_DJ-505.midi.xml
@@ -3,7 +3,7 @@
     <info>
         <name>Roland DJ-505</name>
         <author>Jan Holthuis</author>
-        <description>4-deck mapping for Roland DJ-505 controller</description>
+        <description>4-deck mapping for Roland DJ-505 controller. Make sure you setup audio outputs and inputs correctly (see manual)</description>
         <forums>https://mixxx.discourse.group/t/roland-dj-505/17916</forums>
         <manual>roland_dj_505</manual>
     </info>


### PR DESCRIPTION
Fixes #13252
Untested as I don't have the controller.
CC @Holzhaus @spotlesscoder 