### PR TITLE
adjust FocusWidget: GoToItem emulates Space key in WSearchRelatedTracksMenu

### DIFF
--- a/src/library/library_decl.h
+++ b/src/library/library_decl.h
@@ -10,12 +10,13 @@ enum class LibraryRemovalType {
 
 enum class FocusWidget {
     None,
-    Searchbar,
-    Sidebar,
-    TracksTable, // or a feature root view (WLibraryTextBrowser)
-    ContextMenu, // See LibraryControl::getFocusedWidget() for detailed
-    Dialog,      // descriptions
-    Unknown,     // Unknown skin widget or unknown window
-    Count        // Used for setting the number of PushButton states of
-                 // m_pFocusedWidget in librarycontrol.cpp
+    Searchbar,   // Try not to change the position/order of the library widgets,
+    Sidebar,     //
+    TracksTable, // tracks table or a feature root view (WLibraryTextBrowser)
+    ContextMenu, // See LibraryControl::getFocusedWidget() for detailed descriptions
+    Dialog,
+    SearchRelatedMenu,
+    Unknown, // Unknown skin widget or unknown window
+    Count    // Used for setting the number of PushButton states of
+             // m_pFocusedWidget in librarycontrol.cpp
 };

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -1,6 +1,7 @@
 #include "library/librarycontrol.h"
 
 #include <QApplication>
+#include <QCheckBox>
 #include <QKeyEvent>
 #include <QModelIndex>
 #include <QWindow>
@@ -17,6 +18,7 @@
 #include "widget/wlibrary.h"
 #include "widget/wlibrarysidebar.h"
 #include "widget/wsearchlineedit.h"
+#include "widget/wsearchrelatedtracksmenu.h"
 #include "widget/wtracktableview.h"
 
 namespace {
@@ -692,7 +694,8 @@ void LibraryControl::slotMoveVertical(double v) {
                 QEvent::KeyPress, key, Qt::NoModifier, QString(), false, times});
         return;
     }
-    case FocusWidget::ContextMenu: {
+    case FocusWidget::ContextMenu:
+    case FocusWidget::SearchRelatedMenu: {
         // To navigate menus (and activate menus that were just opened) send the
         // keyEvent to focusWindow() (not focusWidget() like emitKeyEvent() does)
         const auto key = (v < 0) ? Qt::Key_Up : Qt::Key_Down;
@@ -818,7 +821,15 @@ FocusWidget LibraryControl::getFocusedWidget() {
         // qt_edit_menuWindow    = QLineEdit/QCombobox context menu
         // QComboBoxPrivateContainerClassWindow
         //    = QComboBoxListView of WEffectSelector, WSearchLineEdit, ...
-        return FocusWidget::ContextMenu;
+        auto* pFocusWidget = QApplication::focusWidget();
+        if (pFocusWidget &&
+                qobject_cast<QCheckBox*>(pFocusWidget) &&
+                qobject_cast<WSearchRelatedTracksMenu*>(pFocusWidget->parent())) {
+            // TODO Also use this for the Crates menu?
+            return FocusWidget::SearchRelatedMenu;
+        } else {
+            return FocusWidget::ContextMenu;
+        }
     } else if (focusWindow->type() == Qt::Dialog) {
         // DlgPreferencesDlgWindow
         // DlgDeveloperToolsWindow
@@ -977,8 +988,11 @@ void LibraryControl::slotGoToItem(double v) {
         }
         return;
     }
-    case FocusWidget::Dialog: {
-        // press & release Space (QAbstractButton::clicked() is emitted on release)
+    case FocusWidget::Dialog:
+    case FocusWidget::SearchRelatedMenu: {
+        // Press Space to click dialog buttons. In SearchRelatedMenu this toggles
+        // individual search checkboxes and triggers the Search Selected action.
+        // Press & release Space because QAbstractButton::clicked() is emitted on release.
         QKeyEvent pressSpace = QKeyEvent{QEvent::KeyPress, Qt::Key_Space, Qt::NoModifier};
         QKeyEvent releaseSpace = QKeyEvent{QEvent::KeyRelease, Qt::Key_Space, Qt::NoModifier};
         QApplication::sendEvent(QApplication::focusWindow(), &pressSpace);


### PR DESCRIPTION
Requested here https://github.com/mixxxdj/mixxx/pull/12213#issuecomment-2128069547

This allows to toggle the search actions and click the Search button with `[Library],GoToItem`, which would previously activate the actions (trigger search and close the menu).

Needs some testing with controllers !