### PR TITLE
add AutoDJ xfader recenter option (default off)

### DIFF
--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -578,6 +578,10 @@ AutoDJProcessor::AutoDJError AutoDJProcessor::toggleAutoDJ(bool enable) {
         for (const auto& pDeck : std::as_const(m_decks)) {
             pDeck->disconnect(this);
         }
+        if (m_pConfig->getValue<bool>(ConfigKey(kConfigKey,
+                    QStringLiteral("center_xfader_when_disabling")))) {
+            m_pCOCrossfader->set(0);
+        }
         emitAutoDJStateChanged(m_eState);
     }
     return ADJ_OK;

--- a/src/preferences/dialog/dlgprefautodj.cpp
+++ b/src/preferences/dialog/dlgprefautodj.cpp
@@ -70,7 +70,7 @@ void DlgPrefAutoDJ::slotApply() {
     m_pConfig->setValue(ConfigKey("[Auto DJ]", "UseIgnoreTime"),
             RequeueIgnoreCheckBox->isChecked());
     const QString ignTimeStr =
-            RequeueIgnoreTimeEdit->time().toString(RequeueIgnoreTimeEdit->displayFormat());
+            RequeueIgnoreTimeEdit->time().toString();
     m_pConfig->setValue(ConfigKey("[Auto DJ]", "IgnoreTime"), ignTimeStr);
 
     m_pConfig->setValue(ConfigKey("[Auto DJ]", "EnableRandomQueue"),
@@ -88,8 +88,7 @@ void DlgPrefAutoDJ::slotResetToDefaults() {
 
     RequeueIgnoreCheckBox->setChecked(false);
     RequeueIgnoreTimeEdit->setEnabled(false);
-    RequeueIgnoreTimeEdit->setTime(QTime::fromString(
-            "23:59", RequeueIgnoreTimeEdit->displayFormat()));
+    RequeueIgnoreTimeEdit->setTime(QTime::fromString("23:59"));
 
     RandomQueueCheckBox->setChecked(false);
     RandomQueueCheckBox->setEnabled(true);

--- a/src/preferences/dialog/dlgprefautodj.cpp
+++ b/src/preferences/dialog/dlgprefautodj.cpp
@@ -8,22 +8,30 @@ DlgPrefAutoDJ::DlgPrefAutoDJ(QWidget* pParent,
           m_pConfig(pConfig) {
     setupUi(this);
 
-    // The minimum available for randomly-selected tracks
-    MinimumAvailableSpinBox->setValue(
-            m_pConfig->getValue(
-                    ConfigKey("[Auto DJ]", "MinimumAvailable"), 20));
-    connect(MinimumAvailableSpinBox,
-            QOverload<int>::of(&QSpinBox::valueChanged),
-            this,
-            &DlgPrefAutoDJ::slotSetMinimumAvailable);
-
     // The auto-DJ replay-age for randomly-selected tracks
-    RequeueIgnoreCheckBox->setChecked(m_pConfig->getValue(
-            ConfigKey("[Auto DJ]", "UseIgnoreTime"), false));
     connect(RequeueIgnoreCheckBox,
             &QCheckBox::stateChanged,
             this,
             &DlgPrefAutoDJ::slotToggleRequeueIgnore);
+
+    // Auto DJ random enqueue
+    connect(RandomQueueCheckBox,
+            &QCheckBox::stateChanged,
+            this,
+            &DlgPrefAutoDJ::slotToggleRandomQueue);
+
+    setScrollSafeGuardForAllInputWidgets(this);
+}
+
+void DlgPrefAutoDJ::slotUpdate() {
+    // The minimum available for randomly-selected tracks
+    MinimumAvailableSpinBox->setValue(
+            m_pConfig->getValue(
+                    ConfigKey("[Auto DJ]", "MinimumAvailable"), 20));
+
+    // The auto-DJ replay-age for randomly-selected tracks
+    RequeueIgnoreCheckBox->setChecked(m_pConfig->getValue(
+            ConfigKey("[Auto DJ]", "UseIgnoreTime"), false));
     RequeueIgnoreTimeEdit->setTime(
             QTime::fromString(
                     m_pConfig->getValue(
@@ -31,158 +39,65 @@ DlgPrefAutoDJ::DlgPrefAutoDJ(QWidget* pParent,
                     RequeueIgnoreTimeEdit->displayFormat()));
     RequeueIgnoreTimeEdit->setEnabled(
             RequeueIgnoreCheckBox->checkState() == Qt::Checked);
-    connect(RequeueIgnoreTimeEdit,
-            &QTimeEdit::timeChanged,
-            this,
-            &DlgPrefAutoDJ::slotSetRequeueIgnoreTime);
 
     // Auto DJ random enqueue
     RandomQueueCheckBox->setChecked(m_pConfig->getValue(
             ConfigKey("[Auto DJ]", "EnableRandomQueue"), false));
-    // 5-arbitrary
+
     RandomQueueMinimumSpinBox->setValue(
             m_pConfig->getValue(
                     ConfigKey("[Auto DJ]", "RandomQueueMinimumAllowed"), 5));
     // "[Auto DJ], Requeue" is set by 'Repeat Playlist' toggle in DlgAutoDj GUI.
     // If it's checked un-check 'Random Queue'
-    slotConsiderRepeatPlaylistState(
+    // TODO Add 'Repeat' checkbox here, or add a hint why the checkbox may be disabled
+    considerRepeatPlaylistState(
             m_pConfig->getValue<bool>(ConfigKey("[Auto DJ]", "Requeue")));
     slotToggleRandomQueue(
             m_pConfig->getValue<bool>(
                     ConfigKey("[Auto DJ]", "EnableRandomQueue"))
                     ? Qt::Checked
                     : Qt::Unchecked);
-    // Be ready to enable and modify the minimum number and un/check the checkbox
-    connect(RandomQueueCheckBox,
-            &QCheckBox::stateChanged,
-            this,
-            &DlgPrefAutoDJ::slotToggleRandomQueue);
-    connect(RandomQueueMinimumSpinBox,
-            QOverload<int>::of(&QSpinBox::valueChanged),
-            this,
-            &DlgPrefAutoDJ::slotSetRandomQueueMin);
-
-    setScrollSafeGuardForAllInputWidgets(this);
-}
-
-void DlgPrefAutoDJ::slotUpdate() {
 }
 
 void DlgPrefAutoDJ::slotApply() {
-    //Copy from Buffer to actual values
-    m_pConfig->setValue(ConfigKey("[Auto DJ]","MinimumAvailable"),
-            m_pConfig->getValue(
-                    ConfigKey("[Auto DJ]", "MinimumAvailableBuff"), 20));
+    m_pConfig->setValue(ConfigKey("[Auto DJ]", "MinimumAvailable"),
+            MinimumAvailableSpinBox->value());
 
-    m_pConfig->setValue(ConfigKey("[Auto DJ]", "IgnoreTime"),
-            m_pConfig->getValue(
-                    ConfigKey("[Auto DJ]", "IgnoreTimeBuff"), "23:59"));
     m_pConfig->setValue(ConfigKey("[Auto DJ]", "UseIgnoreTime"),
-            m_pConfig->getValue(
-                    ConfigKey("[Auto DJ]", "UseIgnoreTimeBuff"), false));
+            RequeueIgnoreCheckBox->isChecked());
+    const QString ignTimeStr =
+            RequeueIgnoreTimeEdit->time().toString(RequeueIgnoreTimeEdit->displayFormat());
+    m_pConfig->setValue(ConfigKey("[Auto DJ]", "IgnoreTime"), ignTimeStr);
 
-    m_pConfig->setValue(ConfigKey("[Auto DJ]", "RandomQueueMinimumAllowed"),
-            m_pConfig->getValue(
-                    ConfigKey("[Auto DJ]", "RandomQueueMinimumAllowedBuff"), 5));
     m_pConfig->setValue(ConfigKey("[Auto DJ]", "EnableRandomQueue"),
-            m_pConfig->getValue(
-                    ConfigKey("[Auto DJ]", "EnableRandomQueueBuff"), false));
-}
-
-void DlgPrefAutoDJ::slotCancel() {
-    // Load actual values and reset Buffer Values where ever needed
-    MinimumAvailableSpinBox->setValue(
-            m_pConfig->getValue(
-                    ConfigKey("[Auto DJ]", "MinimumAvailable"), 20));
-
-    RequeueIgnoreTimeEdit->setTime(
-            QTime::fromString(
-                    m_pConfig->getValue(
-                            ConfigKey("[Auto DJ]", "IgnoreTime"), "23:59"),
-                    RequeueIgnoreTimeEdit->displayFormat()));
-    RequeueIgnoreCheckBox->setChecked(
-            m_pConfig->getValue(
-                    ConfigKey("[Auto DJ]", "UseIgnoreTime"), false));
-    RequeueIgnoreTimeEdit->setEnabled(
-            RequeueIgnoreCheckBox->checkState() == Qt::Checked);
-    m_pConfig->setValue(ConfigKey("[Auto DJ]", "UseIgnoreTimeBuff"),
-            m_pConfig->getValue(
-                    ConfigKey("[Auto DJ]", "UseIgnoreTime"), false));
-
-    RandomQueueMinimumSpinBox->setValue(
-            m_pConfig->getValue(
-                    ConfigKey("[Auto DJ]", "RandomQueueMinimumAllowed"), 5));
-    RandomQueueCheckBox->setChecked(
-            m_pConfig->getValue(
-                    ConfigKey("[Auto DJ]", "EnableRandomQueue"), false));
-    m_pConfig->setValue(ConfigKey("[Auto DJ]", "EnableRandomQueueBuff"),
-            m_pConfig->getValue(
-                    ConfigKey("[Auto DJ]", "EnableRandomQueue"), false));
-    slotToggleRandomQueue(
-            m_pConfig->getValue(
-                    ConfigKey("[Auto DJ]", "EnableRandomQueue"), false)
-                    ? Qt::Checked
-                    : Qt::Unchecked);
-    slotToggleRandomQueue(
-            m_pConfig->getValue<bool>(ConfigKey("[Auto DJ]", "Requeue")));
+            RandomQueueCheckBox->isChecked());
+    m_pConfig->setValue(
+            ConfigKey("[Auto DJ]", "RandomQueueMinimumAllowed"),
+            RandomQueueMinimumSpinBox->value());
 }
 
 void DlgPrefAutoDJ::slotResetToDefaults() {
-    // Re-queue tracks in AutoDJ
     MinimumAvailableSpinBox->setValue(20);
 
+    RequeueIgnoreCheckBox->setChecked(false);
+    RequeueIgnoreTimeEdit->setEnabled(false);
     RequeueIgnoreTimeEdit->setTime(QTime::fromString(
             "23:59", RequeueIgnoreTimeEdit->displayFormat()));
-    RequeueIgnoreCheckBox->setChecked(false);
-    m_pConfig->setValue(ConfigKey("[Auto DJ]", "UseIgnoreTimeBuff"), false);
-    RequeueIgnoreTimeEdit->setEnabled(false);
 
-    RandomQueueMinimumSpinBox->setValue(5);
     RandomQueueCheckBox->setChecked(false);
-    m_pConfig->setValue(ConfigKey("[Auto DJ]", "EnableRandomQueueBuff"), false);
-    RandomQueueMinimumSpinBox->setEnabled(false);
     RandomQueueCheckBox->setEnabled(true);
-}
-
-void DlgPrefAutoDJ::slotSetMinimumAvailable(int a_iValue) {
-    m_pConfig->setValue(ConfigKey("[Auto DJ]", "MinimumAvailableBuff"), a_iValue);
+    RandomQueueMinimumSpinBox->setEnabled(false);
+    RandomQueueMinimumSpinBox->setValue(5);
 }
 
 void DlgPrefAutoDJ::slotToggleRequeueIgnore(int buttonState) {
-    bool checked = buttonState == Qt::Checked;
-    m_pConfig->setValue(ConfigKey("[Auto DJ]", "UseIgnoreTimeBuff"), checked);
-    RequeueIgnoreTimeEdit->setEnabled(checked);
+    RequeueIgnoreTimeEdit->setEnabled(buttonState == Qt::Checked);
 }
 
-void DlgPrefAutoDJ::slotSetRequeueIgnoreTime(const QTime& a_rTime) {
-    QString str = a_rTime.toString(RequeueIgnoreTimeEdit->displayFormat());
-    m_pConfig->set(ConfigKey("[Auto DJ]", "IgnoreTimeBuff"), str);
-}
-
-void DlgPrefAutoDJ::slotSetRandomQueueMin(int a_iValue) {
-    m_pConfig->setValue(ConfigKey("[Auto DJ]", "RandomQueueMinimumAllowedBuff"), a_iValue);
-}
-
-void DlgPrefAutoDJ::slotConsiderRepeatPlaylistState(bool enable) {
-    if (enable) {
-        // Requeue is enabled
-        RandomQueueCheckBox->setChecked(false);
-        // ToDo(ronso0): Redundant? If programmatic checkbox change is signaled
-        // to slotToggleRandomQueue
-        RandomQueueMinimumSpinBox->setEnabled(false);
-        m_pConfig->setValue(ConfigKey("[Auto DJ]", "EnableRandomQueueBuff"),
-                false);
-    } else {
-        RandomQueueMinimumSpinBox->setEnabled(
-                m_pConfig->getValue(
-                        ConfigKey("[Auto DJ]", "EnableRandomQueueBuff"), false));
-    }
+void DlgPrefAutoDJ::considerRepeatPlaylistState(bool enable) {
+    RandomQueueMinimumSpinBox->setEnabled(enable);
 }
 
 void DlgPrefAutoDJ::slotToggleRandomQueue(int buttonState) {
-    bool enable = buttonState == Qt::Checked;
-    // Toggle the option to select minimum tracks
-    RandomQueueMinimumSpinBox->setEnabled(enable);
-    m_pConfig->setValue(ConfigKey("[Auto DJ]", "EnableRandomQueueBuff"),
-            enable);
+    RandomQueueMinimumSpinBox->setEnabled(buttonState == Qt::Checked);
 }

--- a/src/preferences/dialog/dlgprefautodj.cpp
+++ b/src/preferences/dialog/dlgprefautodj.cpp
@@ -57,6 +57,10 @@ void DlgPrefAutoDJ::slotUpdate() {
                     ConfigKey("[Auto DJ]", "EnableRandomQueue"))
                     ? Qt::Checked
                     : Qt::Unchecked);
+
+    // Re-center the crossfader instantly when AutoDJ is disabled
+    CenterXfaderCheckBox->setChecked(m_pConfig->getValue(
+            ConfigKey("[Auto DJ]", "center_xfader_when_disabling"), false));
 }
 
 void DlgPrefAutoDJ::slotApply() {
@@ -74,6 +78,9 @@ void DlgPrefAutoDJ::slotApply() {
     m_pConfig->setValue(
             ConfigKey("[Auto DJ]", "RandomQueueMinimumAllowed"),
             RandomQueueMinimumSpinBox->value());
+
+    m_pConfig->setValue(ConfigKey("[Auto DJ]", "center_xfader_when_disabling"),
+            CenterXfaderCheckBox->isChecked());
 }
 
 void DlgPrefAutoDJ::slotResetToDefaults() {
@@ -88,6 +95,8 @@ void DlgPrefAutoDJ::slotResetToDefaults() {
     RandomQueueCheckBox->setEnabled(true);
     RandomQueueMinimumSpinBox->setEnabled(false);
     RandomQueueMinimumSpinBox->setValue(5);
+
+    CenterXfaderCheckBox->setChecked(false);
 }
 
 void DlgPrefAutoDJ::slotToggleRequeueIgnore(int buttonState) {

--- a/src/preferences/dialog/dlgprefautodj.h
+++ b/src/preferences/dialog/dlgprefautodj.h
@@ -15,16 +15,13 @@ class DlgPrefAutoDJ : public DlgPreferencePage, public Ui::DlgPrefAutoDJDlg {
     void slotUpdate() override;
     void slotApply() override;
     void slotResetToDefaults() override;
-    void slotCancel() override;
 
   private slots:
-    void slotSetMinimumAvailable(int);
     void slotToggleRequeueIgnore(int buttonState);
-    void slotSetRequeueIgnoreTime(const QTime& a_rTime);
-    void slotSetRandomQueueMin(int);
-    void slotConsiderRepeatPlaylistState(bool);
     void slotToggleRandomQueue(int buttonState);
 
   private:
+    void considerRepeatPlaylistState(bool);
+
     UserSettingsPointer m_pConfig;
 };

--- a/src/preferences/dialog/dlgprefautodjdlg.ui
+++ b/src/preferences/dialog/dlgprefautodjdlg.ui
@@ -254,6 +254,72 @@
    </item>
 
    <item>
+    <widget class="QGroupBox" name="CrossfaderBehaviour">
+      <property name="title">
+       <string>Crossfader Behaviour</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+      </property>
+      <layout class="QGridLayout" name="CrossfaderBehaviourLayout">
+
+        <item row="0" column="0">
+          <widget class="QLabel" name="CenterXfaderLabel">
+            <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+              </sizepolicy>
+            </property>
+            <property name="text">
+              <string>Reset the Crossfader back to center after disabling AutoDJ</string>
+            </property>
+            <property name="buddy">
+              <cstring>CenterXfaderCheckBox</cstring>
+            </property>
+          </widget>
+        </item>
+
+        <item row="0" column="1">
+          <widget class="QCheckBox" name="CenterXfaderCheckBox"/>
+        </item>
+
+        <item row="0" column="2">
+          <spacer name="horizontalSpacerxfaderbehaviour">
+            <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+                <horstretch>1</horstretch>
+                <verstretch>0</verstretch>
+              </sizepolicy>
+            </property>
+          </spacer>
+        </item>
+
+        <item row="1" column="0" colspan="3">
+          <widget class="QLabel" name="CenterXfaderHintText">
+            <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+              </sizepolicy>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+            <property name="text">
+              <string>Hint: Resetting the crossfader to center will cause a drop of the main output's volume if you've selected "Constant Power" crossfader curve in the Mixer preferences.</string>
+            </property>
+          </widget>
+        </item>
+
+      </layout>
+    </widget>
+   </item>
+
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -270,5 +336,6 @@
   </layout>
  </widget>
  <resources/>
+ <!-- tabstops -->
  <connections/>
 </ui>


### PR DESCRIPTION
adopting #13156 but cleaning up the "buffer" settings before
(that dlg wrote some "...Buff" settings to config for storing temp pending settings...)

Fixes #11571

### TODO:
- [x] add a note how re-centering may affect main volume (see #10683 and #4714)