### PR TITLE
Recording: with empty config, save default split size immediately

### DIFF
--- a/src/preferences/dialog/dlgprefrecord.cpp
+++ b/src/preferences/dialog/dlgprefrecord.cpp
@@ -92,10 +92,10 @@ DlgPrefRecord::DlgPrefRecord(QWidget* parent, UserSettingsPointer pConfig)
     if (index >= 0) {
         // Set file split size
         comboBoxSplitting->setCurrentIndex(index);
-    }
-    else {
+    } else {
         //Use max RIFF size (4GB) as default index, since usually people don't want to split.
         comboBoxSplitting->setCurrentIndex(4);
+        saveSplitSize();
     }
 
     setScrollSafeGuard(comboBoxSplitting);

--- a/src/recording/recordingmanager.cpp
+++ b/src/recording/recordingmanager.cpp
@@ -325,7 +325,7 @@ quint64 RecordingManager::getFileSplitSize() {
     } else if (fileSizeStr == SPLIT_120MIN) {
         return SIZE_4GB; //Ignore size limit. use time limit
     } else {
-        return SIZE_650MB;
+        return SIZE_4GB; // default
     }
 }
 


### PR DESCRIPTION
reported in the forum
https://mixxx.discourse.group/t/recording-cut-into-parts/29631