### PR TITLE
(fix) Sound config: fix UX when applying config with missing/busy devices

### DIFF
--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -428,6 +428,9 @@ void DlgPreferences::slotButtonPressed(QAbstractButton* pButton) {
     case QDialogButtonBox::AcceptRole:
         // Same as Apply but close the dialog
         emit applyPreferences();
+        // TODO Unfortunately this will accept() even if DlgPrefSound threw a warning
+        // due to inaccessible device(s) or inapplicable samplerate.
+        // https://github.com/mixxxdj/mixxx/issues/6077
         accept();
         break;
     case QDialogButtonBox::RejectRole:

--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -70,6 +70,7 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     void settingChanged();
     void deviceChanged();
     void deviceChannelsChanged();
+    void configuredDeviceNotFound();
     void queryClicked();
 
   private:

--- a/src/preferences/dialog/dlgprefsounditem.cpp
+++ b/src/preferences/dialog/dlgprefsounditem.cpp
@@ -246,14 +246,18 @@ SoundDevicePointer DlgPrefSoundItem::getDevice() const {
     return SoundDevicePointer();
 }
 
-/// Selects a device in the device combo box given a SoundDevice
-/// internal name, or selects "None" if the device isn't found.
+/// Selects a device in the device combo box given a SoundDevice' internal name,
+/// or selects "None" if the device is nullptr or isn't found.
+/// Called only internally via DlPrefSound::loadPaths()
 void DlgPrefSoundItem::setDevice(const SoundDeviceId& device) {
     int index = deviceComboBox->findData(QVariant::fromValue(device));
-    //qDebug() << "DlgPrefSoundItem::setDevice" << device;
     if (index == -1) {
         deviceComboBox->setCurrentIndex(0); // None
         emit selectedDeviceChanged();
+        if (device != SoundDeviceId()) {
+            // Notify DlgPrefSound that the device that can't be found.
+            emit configuredDeviceNotFound();
+        }
     } else {
         m_emitSettingChanged = false;
         deviceComboBox->setCurrentIndex(index);

--- a/src/preferences/dialog/dlgprefsounditem.h
+++ b/src/preferences/dialog/dlgprefsounditem.h
@@ -36,6 +36,7 @@ class DlgPrefSoundItem : public QWidget, public Ui::DlgPrefSoundItem {
   signals:
     void selectedDeviceChanged();
     void selectedChannelsChanged();
+    void configuredDeviceNotFound();
 
   public slots:
     void refreshDevices(const QList<SoundDevicePointer>& devices);


### PR DESCRIPTION
Fixes one cause of #13238 leaking EQ shelf controls / stuck overview on track load.

### The scenario:
* start Mixxx without a previously configured sound I/O
* get warning that previous sound device for Main is n/a
   > Mixxx was unable to open all the configured sound devices.
* click Reconfigure
* (no selection for Main), click **Okay** (or Apply + Okay)
* Mixxx proceeds (should actually throw the "No output devices" warning)

### The issue:
There is a 'modified' flag in DlgPrefSound set on user changes, if false this will prevent re-applying the current config and the resulting sound pause when querying and re-setting the devices.
However, when the sound config is loaded in DlgPrefSound and devices are not found, the respective combobox will display 'None' even though that device is still set in the config. I.e. the visual state diverges from the config.
Clicking Apply would then **not** apply this new (visual) state since the 'modified' flag has not been set.

### The fix:
Set the 'modified' flag if configured devices are not found.
Apply will then apply as desired.
(and, in case of missing Main output, Mixxx will throw the "No output devices" warning)

Leaking EQ shelf controls and stuck overview on track load is another story...