### PR TITLE
Fix Sony SixxAxis controller not working

### DIFF
--- a/res/controllers/Sony-SixxAxis.js
+++ b/res/controllers/Sony-SixxAxis.js
@@ -10,7 +10,8 @@ function SonySixxAxisController() {
     this.controller.activeDeck = 1;
 
     this.registerInputPackets = function() {
-        packet = new HIDPacket("control",[],49);
+        const packet = new HIDPacket("control", 0);
+        packet.length = 49;
 
         // Toggle buttons
         packet.addControl("hid","select",2,"B",0x1);


### PR DESCRIPTION
Minor fix in mapping file of sony sixxaxis controller. A wrong `HIDPacket` initialization was setting the length to 0, thus packets couldn't be parsed.