### PR TITLE
(fix) Effects: show newly added effects, read/write HiddenEffects

### DIFF
--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -328,7 +328,8 @@ void EffectsManager::saveEffectsXml() {
                     quickEffectChainPresets,
                     standardEffectChainPresets,
                     outputChainPreset});
-    m_pVisibleEffectsList->saveEffectsXml(&doc);
+
+    m_pVisibleEffectsList->saveEffectsXml(&doc, m_pBackendManager);
 
     QDir settingsPath(m_pConfig->getSettingsPath());
     if (!settingsPath.exists()) {

--- a/src/effects/presets/effectxmlelements.h
+++ b/src/effects/presets/effectxmlelements.h
@@ -20,6 +20,7 @@ const QString kEqualizerEffects(QStringLiteral("EqualizerEffects"));
 const QString kChainPresetName(QStringLiteral("ChainPresetName"));
 
 const QString kVisibleEffects(QStringLiteral("VisibleEffects"));
+const QString kHiddenEffects(QStringLiteral("HiddenEffects"));
 
 const QString kChainsRoot(QStringLiteral("Chains"));
 const QString kChain(QStringLiteral("EffectChain"));

--- a/src/effects/visibleeffectslist.cpp
+++ b/src/effects/visibleeffectslist.cpp
@@ -48,9 +48,37 @@ const EffectManifestPointer VisibleEffectsList::previous(
 }
 
 void VisibleEffectsList::readEffectsXml(
-        const QDomDocument& doc, EffectsBackendManagerPointer pBackendManager) {
+        const QDomDocument& doc,
+        EffectsBackendManagerPointer pBackendManager) {
+    QList<EffectManifestPointer> visibleEffects = readEffectsList(
+            doc,
+            pBackendManager,
+            EffectXml::kVisibleEffects);
+    const QList<EffectManifestPointer> hiddenEffects = readEffectsList(
+            doc,
+            pBackendManager,
+            EffectXml::kHiddenEffects);
+
+    // New effects will remain hidden since they are neither in the VisibleEffects
+    // nor in the newly introduced HiddenEffects list.
+    // Unhide all effects that are not in either list.
+    const auto manifests = pBackendManager->getManifestsForBackend(EffectBackendType::BuiltIn);
+    for (const EffectManifestPointer& pManifest : std::as_const(manifests)) {
+        if (!visibleEffects.contains(pManifest) &&
+                !hiddenEffects.contains(pManifest)) {
+            // pre-pend so un-hidden effects are discoverable
+            visibleEffects.prepend(pManifest);
+        }
+    }
+    setList(visibleEffects);
+}
+
+QList<EffectManifestPointer> VisibleEffectsList::readEffectsList(
+        const QDomDocument& doc,
+        EffectsBackendManagerPointer pBackendManager,
+        const QString& xmlElementName) {
     QDomElement root = doc.documentElement();
-    QDomElement visibleEffectsElement = XmlParse::selectElement(root, EffectXml::kVisibleEffects);
+    QDomElement visibleEffectsElement = XmlParse::selectElement(root, xmlElementName);
     QDomNodeList effectsElementsList = visibleEffectsElement.elementsByTagName(EffectXml::kEffect);
     QList<EffectManifestPointer> list;
 
@@ -67,19 +95,26 @@ void VisibleEffectsList::readEffectsXml(
             }
         }
     }
-
-    if (!list.isEmpty()) {
-        setList(list);
-    } else {
-        setList(pBackendManager->getManifestsForBackend(EffectBackendType::BuiltIn));
-    }
+    return list;
 }
 
-void VisibleEffectsList::saveEffectsXml(QDomDocument* pDoc) {
-    QDomElement root = pDoc->documentElement();
-    QDomElement visibleEffectsElement = pDoc->createElement(EffectXml::kVisibleEffects);
-    root.appendChild(visibleEffectsElement);
+void VisibleEffectsList::saveEffectsXml(QDomDocument* pDoc,
+        EffectsBackendManagerPointer pBackendManager) {
+    saveEffectsListXml(pDoc, m_list, EffectXml::kVisibleEffects);
+    auto hiddenEffects = pBackendManager->getManifests();
     for (const auto& pManifest : std::as_const(m_list)) {
+        hiddenEffects.removeAll(pManifest);
+    }
+    saveEffectsListXml(pDoc, hiddenEffects, EffectXml::kHiddenEffects);
+}
+
+void VisibleEffectsList::saveEffectsListXml(QDomDocument* pDoc,
+        const QList<EffectManifestPointer>& list,
+        const QString& xmlElementName) {
+    QDomElement root = pDoc->documentElement();
+    QDomElement visibleEffectsElement = pDoc->createElement(xmlElementName);
+    root.appendChild(visibleEffectsElement);
+    for (const auto& pManifest : std::as_const(list)) {
         VERIFY_OR_DEBUG_ASSERT(pManifest) {
             continue;
         }

--- a/src/effects/visibleeffectslist.h
+++ b/src/effects/visibleeffectslist.h
@@ -21,12 +21,21 @@ class VisibleEffectsList : public QObject {
     const EffectManifestPointer previous(const EffectManifestPointer pManifest) const;
 
     void setList(const QList<EffectManifestPointer>& newList);
-    void readEffectsXml(const QDomDocument& doc, EffectsBackendManagerPointer pBackendManager);
-    void saveEffectsXml(QDomDocument* pDoc);
+    void readEffectsXml(const QDomDocument& doc,
+            EffectsBackendManagerPointer pBackendManager);
+    void saveEffectsXml(QDomDocument* pDoc,
+            EffectsBackendManagerPointer pBackendManager);
 
   signals:
     void visibleEffectsListChanged();
 
   private:
+    QList<EffectManifestPointer> readEffectsList(const QDomDocument& doc,
+            EffectsBackendManagerPointer pBackendManager,
+            const QString& xmlElementName);
+    void saveEffectsListXml(QDomDocument* pDoc,
+            const QList<EffectManifestPointer>& list,
+            const QString& xmlElementName);
+
     QList<EffectManifestPointer> m_list;
 };


### PR DESCRIPTION
Fixes #11343

Add `HiddenEffects` to effects.xml

Small one-time issue after upgrade:
(new) effects that users have set visible and then set hidden again will now be set visible again :man_shrugging: 