### PR TITLE
Preferences Effects: add Hide/Unhide (move) buttons to Effects tab

### DIFF
--- a/src/preferences/dialog/dlgprefeffects.h
+++ b/src/preferences/dialog/dlgprefeffects.h
@@ -23,6 +23,7 @@ class DlgPrefEffects : public DlgPreferencePage, public Ui::DlgPrefEffectsDlg {
 
   private slots:
     void effectsTableItemSelected(const QModelIndex& selected);
+    void slotHideUnhideEffect();
     void slotChainPresetSelectionChanged(const QItemSelection& selected);
     void slotImportPreset();
     void slotExportPreset();
@@ -35,7 +36,8 @@ class DlgPrefEffects : public DlgPreferencePage, public Ui::DlgPrefEffectsDlg {
 
     void clearEffectInfo();
     void clearChainInfo();
-    void updateButtons(int selectedIndices);
+    void updateChainPresetButtons(int selectedIndices);
+    void updateHideUnhideButtons(const QModelIndex& selected = QModelIndex());
     void loadChainPresetLists();
     void saveChainPresetLists();
 

--- a/src/preferences/dialog/dlgprefeffectsdlg.ui
+++ b/src/preferences/dialog/dlgprefeffectsdlg.ui
@@ -31,6 +31,7 @@
      <property name="currentIndex">
       <number>0</number>
      </property>
+
      <widget class="QWidget" name="chainPresetsTab">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
@@ -230,6 +231,7 @@
        </item>
       </layout>
      </widget>
+
      <widget class="QWidget" name="visibleEffectsTab">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
@@ -243,7 +245,7 @@
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
         <layout class="QGridLayout" name="effectsTablesGridLayout">
-         <item row="0" column="0" colspan="2">
+         <item row="0" column="0" colspan="3">
           <widget class="QLabel" name="effectsTablesHeaderLabel">
            <property name="text">
             <string>Drag and drop to rearrange lists and show or hide effects.</string>
@@ -266,7 +268,7 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="1">
+         <item row="1" column="2">
           <widget class="QLabel" name="hiddenEffectsTableLabel">
            <property name="font">
             <font>
@@ -282,13 +284,95 @@
            </property>
           </widget>
          </item>
+
          <item row="2" column="0">
           <widget class="QTableView" name="visibleEffectsTableView"/>
          </item>
+
          <item row="2" column="1">
+          <layout class="QVBoxLayout" name="moveButtonslayout">
+           <item>
+            <spacer name="hideShowVSpacerTop">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="fixedSize">
+              <size>
+               <width>20</width>
+               <height>60</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+
+           <item>
+            <widget class="QPushButton" name="hideButton">
+             <property name="text">
+              <string>❯</string>
+             </property>
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="fixedSize">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+
+           <item>
+            <widget class="QPushButton" name="unhideButton">
+             <property name="text">
+              <string>❮</string>
+             </property>
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="fixedSize">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+
+           <item>
+            <spacer name="hideShowVSpacerBottom">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+
+          </layout>
+         </item>
+
+         <item row="2" column="2">
           <widget class="QTableView" name="hiddenEffectsTableView"/>
          </item>
-         <item row="3" column="0" colspan="2">
+
+         <item row="3" column="0" colspan="3">
           <widget class="QGroupBox" name="groupBox">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
@@ -469,6 +553,7 @@
      </widget>
     </widget>
    </item>
+
    <item>
     <widget class="QGroupBox" name="groupMetaKnobOption">
      <property name="title">
@@ -498,12 +583,15 @@
      </layout>
     </widget>
    </item>
+
   </layout>
  </widget>
  <tabstops>
   <tabstop>chainListView</tabstop>
   <tabstop>quickEffectListView</tabstop>
   <tabstop>visibleEffectsTableView</tabstop>
+  <tabstop>hideButton</tabstop>
+  <tabstop>unhideButton</tabstop>
   <tabstop>hiddenEffectsTableView</tabstop>
   <tabstop>chainPresetImportButton</tabstop>
   <tabstop>chainPresetExportButton</tabstop>

--- a/src/preferences/effectmanifesttablemodel.cpp
+++ b/src/preferences/effectmanifesttablemodel.cpp
@@ -125,9 +125,11 @@ bool EffectManifestTableModel::dropMimeData(const QMimeData* data,
         return false;
     }
     if (row == -1) {
-        row = parent.row();
+        if (parent.isValid()) {
+            row = parent.row();
+        }
         // Dropping onto an empty model or dropping past the end of a model
-        if (parent.row() == -1) {
+        if (row == -1) {
             row = m_manifests.size();
         }
     }

--- a/src/preferences/effectmanifesttablemodel.h
+++ b/src/preferences/effectmanifesttablemodel.h
@@ -33,12 +33,14 @@ class EffectManifestTableModel : public QAbstractTableModel {
     // These functions are required for drag and drop.
     Qt::ItemFlags flags(const QModelIndex& index) const override;
     QMimeData* mimeData(const QModelIndexList& indexes) const override;
+    // Set defaults so we can call it with mime data only for inserting
+    // an effect at the end
     bool dropMimeData(
             const QMimeData* data,
-            Qt::DropAction action,
-            int row,
-            int column,
-            const QModelIndex& parent) override;
+            Qt::DropAction action = Qt::MoveAction,
+            int row = -1,
+            int column = -1,
+            const QModelIndex& parent = QModelIndex()) override;
     QStringList mimeTypes() const override;
     Qt::DropActions supportedDropActions() const override;
     bool removeRows(int row, int count, const QModelIndex& parent = QModelIndex()) override;


### PR DESCRIPTION
![image](https://github.com/mixxxdj/mixxx/assets/5934199/4a98ec67-8a0d-4862-b80a-88f2a40022cd)

Fixes #10580 

#### ToDo
- [ ] static button positions, currently the move depending on the length of the effect description 

Up/Down buttons would also be nice.