### PR TITLE
Beats: Add editing controls for bar annotations

### DIFF
--- a/src/audio/types.cpp
+++ b/src/audio/types.cpp
@@ -29,6 +29,12 @@ QDebug operator<<(QDebug dbg, Bitrate arg) {
             << Bitrate::unit();
 }
 
+QDebug operator<<(QDebug dbg, BeatsPerBar arg) {
+    return dbg
+            << static_cast<BeatsPerBar::value_t>(arg)
+            << BeatsPerBar::unit();
+}
+
 } // namespace audio
 
 } // namespace mixxx

--- a/src/audio/types.h
+++ b/src/audio/types.h
@@ -244,6 +244,50 @@ class Bitrate {
 
 QDebug operator<<(QDebug dbg, Bitrate arg);
 
+// The BeatsPerBar is measured in beats and provides information
+// about the number expected within a single bar or phrase.
+class BeatsPerBar {
+  public:
+    using value_t = std::uint32_t;
+
+  private:
+    // The default value is invalid and indicates a missing or unknown value.
+    static constexpr value_t kValueDefault = 4;
+
+  public:
+    static constexpr value_t kValueMin = 2;  // lower bound (inclusive)
+    static constexpr value_t kValueMax = 32; // upper bound (inclusive)
+    static constexpr const char* unit() {
+        return "beats";
+    }
+
+    explicit constexpr BeatsPerBar(
+            value_t value = kValueDefault)
+            : m_value(value) {
+    }
+
+    constexpr bool isValid() const {
+        return m_value >= kValueMin && m_value <= kValueMax;
+    }
+
+    constexpr value_t value() const {
+        return m_value;
+    }
+    /*implicit*/ constexpr operator value_t() const {
+        return value();
+    }
+
+    BeatsPerBar operator+(std::int32_t increment) const {
+        DEBUG_ASSERT(isValid());
+        return BeatsPerBar(m_value + increment);
+    }
+
+  private:
+    value_t m_value;
+};
+
+QDebug operator<<(QDebug dbg, BeatsPerBar arg);
+
 } // namespace audio
 
 } // namespace mixxx
@@ -262,3 +306,6 @@ Q_DECLARE_METATYPE(mixxx::audio::SampleRate)
 
 Q_DECLARE_TYPEINFO(mixxx::audio::Bitrate, Q_PRIMITIVE_TYPE);
 Q_DECLARE_METATYPE(mixxx::audio::Bitrate)
+
+Q_DECLARE_TYPEINFO(mixxx::audio::BeatsPerBar, Q_PRIMITIVE_TYPE);
+Q_DECLARE_METATYPE(mixxx::audio::BeatsPerBar)

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -1,5 +1,7 @@
 #include "engine/controls/bpmcontrol.h"
 
+#include <chrono>
+
 #include "control/controlencoder.h"
 #include "control/controllinpotmeter.h"
 #include "control/controlproxy.h"
@@ -13,6 +15,8 @@
 #include "util/logger.h"
 #include "util/math.h"
 
+using namespace std::literals;
+
 namespace {
 const mixxx::Logger kLogger("BpmControl");
 
@@ -22,8 +26,8 @@ constexpr double kBpmRangeMax = 200.0;
 constexpr double kBpmRangeStep = 1.0;
 constexpr double kBpmRangeSmallStep = 0.1;
 
-constexpr double kBpmAdjustMin = kBpmRangeMin;
-constexpr double kBpmAdjustStep = 0.01;
+constexpr std::chrono::milliseconds kBpmAdjustRepeatInterval = 50ms;
+constexpr std::chrono::milliseconds kBpmAdjustTimeBeforeRepeat = 500ms;
 constexpr double kBpmTapRounding = 1 / 12.0;
 
 // Maximum allowed interval between beats (calculated from kBpmTapMin).
@@ -86,6 +90,17 @@ BpmControl::BpmControl(const QString& group,
             this,
             &BpmControl::slotAdjustBeatsFaster,
             Qt::DirectConnection);
+    m_pAdjustBeatsMuchFaster = std::make_unique<ControlPushButton>(
+            ConfigKey(group, "beats_adjust_much_faster"), false);
+    m_pAdjustBeatsMuchFaster->setKbdRepeatable(true);
+    connect(
+            m_pAdjustBeatsMuchFaster.get(),
+            &ControlObject::valueChanged,
+            this,
+            [this](double v) {
+                slotAdjustBeatsFaster(v * 10);
+            },
+            Qt::DirectConnection);
     m_pAdjustBeatsSlower = std::make_unique<ControlPushButton>(
             ConfigKey(group, "beats_adjust_slower"), false);
     m_pAdjustBeatsSlower->setKbdRepeatable(true);
@@ -93,6 +108,17 @@ BpmControl::BpmControl(const QString& group,
             &ControlObject::valueChanged,
             this,
             &BpmControl::slotAdjustBeatsSlower,
+            Qt::DirectConnection);
+    m_pAdjustBeatsMuchSlower = std::make_unique<ControlPushButton>(
+            ConfigKey(group, "beats_adjust_much_slower"), false);
+    m_pAdjustBeatsMuchSlower->setKbdRepeatable(true);
+    connect(
+            m_pAdjustBeatsMuchSlower.get(),
+            &ControlObject::valueChanged,
+            this,
+            [this](double v) {
+                slotAdjustBeatsSlower(v * 10);
+            },
             Qt::DirectConnection);
     m_pTranslateBeatsEarlier = std::make_unique<ControlPushButton>(
             ConfigKey(group, "beats_translate_earlier"), false);
@@ -116,6 +142,34 @@ BpmControl::BpmControl(const QString& group,
             &ControlObject::valueChanged,
             this,
             &BpmControl::slotTranslateBeatsMove,
+            Qt::DirectConnection);
+    m_pBeatsSetMarker = std::make_unique<ControlPushButton>(
+            ConfigKey(group, "beats_set_change_marker"), false);
+    connect(m_pBeatsSetMarker.get(),
+            &ControlObject::valueChanged,
+            this,
+            &BpmControl::slotBeatsSetMarker,
+            Qt::DirectConnection);
+    m_pBeatsRemoveMarker = std::make_unique<ControlPushButton>(
+            ConfigKey(group, "beats_remove_marker"), false);
+    connect(m_pBeatsRemoveMarker.get(),
+            &ControlObject::valueChanged,
+            this,
+            &BpmControl::slotBeatsRemoveMarker,
+            Qt::DirectConnection);
+    m_pBeatsBarCountUp = std::make_unique<ControlPushButton>(
+            ConfigKey(group, "beats_increase_bar_length"), false);
+    connect(m_pBeatsBarCountUp.get(),
+            &ControlObject::valueChanged,
+            this,
+            &BpmControl::slotBeatsBarCountUp,
+            Qt::DirectConnection);
+    m_pBeatsBarCountDown = std::make_unique<ControlPushButton>(
+            ConfigKey(group, "beats_decrease_bar_length"), false);
+    connect(m_pBeatsBarCountDown.get(),
+            &ControlObject::valueChanged,
+            this,
+            &BpmControl::slotBeatsBarCountDown,
             Qt::DirectConnection);
 
     m_pBeatsHalve = std::make_unique<ControlPushButton>(ConfigKey(group, "beats_set_halve"), false);
@@ -264,7 +318,33 @@ mixxx::Bpm BpmControl::getBpm() const {
     return mixxx::Bpm(m_pEngineBpm->get());
 }
 
-void BpmControl::adjustBeatsBpm(double deltaBpm) {
+void BpmControl::clearActionRepeater() {
+    m_repeatOperation.stop();
+    m_repeatOperation.disconnect();
+    return;
+}
+
+void BpmControl::activateActionRepeater(const std::function<void()>& callback) {
+    VERIFY_OR_DEBUG_ASSERT(callback) {
+        clearActionRepeater();
+        return;
+    }
+
+    if (m_repeatOperation.isActive()) {
+        m_repeatOperation.setInterval(kBpmAdjustRepeatInterval);
+    } else {
+        m_repeatOperation.disconnect();
+        connect(&m_repeatOperation, &QTimer::timeout, this, callback);
+        m_repeatOperation.start(kBpmAdjustTimeBeforeRepeat);
+    }
+}
+
+void BpmControl::slotAdjustBeatsFaster(double v) {
+    if (v <= 0) {
+        clearActionRepeater();
+        return;
+    }
+
     const TrackPointer pTrack = getEngineBuffer()->getLoadedTrack();
     if (!pTrack) {
         return;
@@ -274,44 +354,68 @@ void BpmControl::adjustBeatsBpm(double deltaBpm) {
         return;
     }
 
-    const mixxx::Bpm bpm = pBeats->getBpmInRange(
-            mixxx::audio::kStartFramePos, frameInfo().trackEndPosition);
-    // FIXME: calling bpm.value() without checking bpm.isValid()
-    const auto centerBpm = mixxx::Bpm(math_max(kBpmAdjustMin, bpm.value() + deltaBpm));
-    mixxx::Bpm adjustedBpm = BeatUtils::roundBpmWithinRange(
-            centerBpm - kBpmAdjustStep / 2, centerBpm, centerBpm + kBpmAdjustStep / 2);
-    const auto newBeats = pBeats->trySetBpm(adjustedBpm);
-    if (!newBeats) {
-        return;
-    }
-    pTrack->trySetBeats(*newBeats);
-}
+    activateActionRepeater([this, v]() {
+        slotAdjustBeatsFaster(v);
+    });
 
-void BpmControl::slotAdjustBeatsFaster(double v) {
-    if (v <= 0) {
-        return;
+    const auto adjustedBeats =
+            pBeats->tryAdjustTempo(frameInfo().currentPosition,
+                    v > 1 ? mixxx::Beats::TempoAdjustment::MuchFaster
+                          : mixxx::Beats::TempoAdjustment::Faster);
+    if (adjustedBeats) {
+        pTrack->trySetBeats(*adjustedBeats);
     }
-    adjustBeatsBpm(kBpmAdjustStep);
 }
 
 void BpmControl::slotAdjustBeatsSlower(double v) {
     if (v <= 0) {
+        clearActionRepeater();
         return;
     }
-    adjustBeatsBpm(-kBpmAdjustStep);
+
+    const TrackPointer pTrack = getEngineBuffer()->getLoadedTrack();
+    if (!pTrack) {
+        return;
+    }
+    const mixxx::BeatsPointer pBeats = pTrack->getBeats();
+    if (!pBeats) {
+        return;
+    }
+
+    activateActionRepeater([this, v]() {
+        slotAdjustBeatsSlower(v);
+    });
+
+    const auto adjustedBeats =
+            pBeats->tryAdjustTempo(frameInfo().currentPosition,
+                    v > 1 ? mixxx::Beats::TempoAdjustment::MuchSlower
+                          : mixxx::Beats::TempoAdjustment::Slower);
+    if (adjustedBeats) {
+        pTrack->trySetBeats(*adjustedBeats);
+    }
 }
 
 void BpmControl::slotTranslateBeatsEarlier(double v) {
     if (v <= 0) {
+        clearActionRepeater();
         return;
     }
+
+    activateActionRepeater([this]() {
+        slotTranslateBeatsEarlier(1);
+    });
     slotTranslateBeatsMove(-1);
 }
 
 void BpmControl::slotTranslateBeatsLater(double v) {
     if (v <= 0) {
+        clearActionRepeater();
         return;
     }
+
+    activateActionRepeater([this]() {
+        slotTranslateBeatsLater(1);
+    });
     slotTranslateBeatsMove(1);
 }
 
@@ -330,7 +434,7 @@ void BpmControl::slotTranslateBeatsMove(double v) {
         const double sampleOffset = frameInfo().sampleRate * v * 0.01;
         const mixxx::audio::FrameDiff_t frameOffset =
                 sampleOffset / mixxx::kEngineChannelOutputCount;
-        const auto translatedBeats = pBeats->tryTranslate(frameOffset);
+        const auto translatedBeats = pBeats->tryTranslate(frameOffset, frameInfo().currentPosition);
         if (translatedBeats) {
             pTrack->trySetBeats(*translatedBeats);
         }
@@ -347,6 +451,80 @@ void BpmControl::slotBeatsUndoAdjustment(double v) {
     }
     pTrack->undoBeatsChange();
     m_pBeatsUndoPossible->forceSet(pTrack->canUndoBeatsChange());
+}
+
+void BpmControl::slotBeatsSetMarker(double v) {
+    if (v <= 0) {
+        return;
+    }
+    const TrackPointer pTrack = getEngineBuffer()->getLoadedTrack();
+    if (!pTrack) {
+        return;
+    }
+    const mixxx::BeatsPointer pBeats = pTrack->getBeats();
+    if (!pBeats) {
+        return;
+    }
+
+    const auto modifiedBeats = pBeats->trySetMarker(frameInfo().currentPosition);
+    if (modifiedBeats) {
+        pTrack->trySetBeats(*modifiedBeats);
+    }
+}
+
+void BpmControl::slotBeatsBarCountUp(double v) {
+    if (v <= 0) {
+        return;
+    }
+    const TrackPointer pTrack = getEngineBuffer()->getLoadedTrack();
+    if (!pTrack) {
+        return;
+    }
+    const mixxx::BeatsPointer pBeats = pTrack->getBeats();
+    if (!pBeats) {
+        return;
+    }
+
+    const auto modifiedBeats = pBeats->tryAdjustBeatsPerBar(frameInfo().currentPosition, 1);
+    if (modifiedBeats) {
+        pTrack->trySetBeats(*modifiedBeats);
+    }
+}
+void BpmControl::slotBeatsBarCountDown(double v) {
+    if (v <= 0) {
+        return;
+    }
+    const TrackPointer pTrack = getEngineBuffer()->getLoadedTrack();
+    if (!pTrack) {
+        return;
+    }
+    const mixxx::BeatsPointer pBeats = pTrack->getBeats();
+    if (!pBeats) {
+        return;
+    }
+
+    const auto modifiedBeats = pBeats->tryAdjustBeatsPerBar(frameInfo().currentPosition, -1);
+    if (modifiedBeats) {
+        pTrack->trySetBeats(*modifiedBeats);
+    }
+}
+void BpmControl::slotBeatsRemoveMarker(double v) {
+    if (v <= 0) {
+        return;
+    }
+    const TrackPointer pTrack = getEngineBuffer()->getLoadedTrack();
+    if (!pTrack) {
+        return;
+    }
+    const mixxx::BeatsPointer pBeats = pTrack->getBeats();
+    if (!pBeats) {
+        return;
+    }
+
+    const auto modifiedBeats = pBeats->tryRemoveMarker(frameInfo().currentPosition);
+    if (modifiedBeats) {
+        pTrack->trySetBeats(*modifiedBeats);
+    }
 }
 
 void BpmControl::slotBpmTap(double v) {
@@ -1169,7 +1347,7 @@ void BpmControl::slotBeatsTranslate(double v) {
         const auto currentPosition = frameInfo().currentPosition.toLowerFrameBoundary();
         const auto closestBeat = pBeats->findClosestBeat(currentPosition);
         const mixxx::audio::FrameDiff_t frameOffset = currentPosition - closestBeat;
-        const auto translatedBeats = pBeats->tryTranslate(frameOffset);
+        const auto translatedBeats = pBeats->tryTranslate(frameOffset, currentPosition);
         if (translatedBeats) {
             pTrack->trySetBeats(*translatedBeats);
         }

--- a/src/engine/controls/bpmcontrol.h
+++ b/src/engine/controls/bpmcontrol.h
@@ -109,12 +109,16 @@ class BpmControl : public EngineControl {
     void slotTempoTap(double value);
     void slotTempoTapFilter(double averageLength, int numSamples);
 
+    void slotBeatsSetMarker(double);
+    void slotBeatsRemoveMarker(double);
     void slotUpdateRateSlider(double v = 0.0);
     void slotUpdateEngineBpm(double v = 0.0);
     void slotBeatsTranslate(double);
     void slotBeatsTranslateMatchAlignment(double);
     void slotToggleBpmLock(double);
     void slotBeatsUndoAdjustment(double value);
+    void slotBeatsBarCountUp(double);
+    void slotBeatsBarCountDown(double);
 
   private:
     SyncMode getSyncMode() const {
@@ -126,6 +130,9 @@ class BpmControl : public EngineControl {
     double calcSyncAdjustment(bool userTweakingSync);
     void adjustBeatsBpm(double deltaBpm);
     void slotScaleBpm(mixxx::Beats::BpmScale bpmScale);
+
+    void clearActionRepeater();
+    void activateActionRepeater(const std::function<void()>& = nullptr);
 
     friend class SyncControl;
 
@@ -146,11 +153,17 @@ class BpmControl : public EngineControl {
     // The average bpm around the current playposition;
     std::unique_ptr<ControlObject> m_pLocalBpm;
     std::unique_ptr<ControlPushButton> m_pAdjustBeatsFaster;
+    std::unique_ptr<ControlPushButton> m_pAdjustBeatsMuchFaster;
     std::unique_ptr<ControlPushButton> m_pAdjustBeatsSlower;
+    std::unique_ptr<ControlPushButton> m_pAdjustBeatsMuchSlower;
     std::unique_ptr<ControlPushButton> m_pTranslateBeatsEarlier;
     std::unique_ptr<ControlPushButton> m_pTranslateBeatsLater;
     std::unique_ptr<ControlEncoder> m_pTranslateBeatsMove;
     std::unique_ptr<ControlPushButton> m_pBeatsUndo;
+    std::unique_ptr<ControlPushButton> m_pBeatsSetMarker;
+    std::unique_ptr<ControlPushButton> m_pBeatsRemoveMarker;
+    std::unique_ptr<ControlPushButton> m_pBeatsBarCountUp;
+    std::unique_ptr<ControlPushButton> m_pBeatsBarCountDown;
     std::unique_ptr<ControlObject> m_pBeatsUndoPossible;
 
     std::unique_ptr<ControlPushButton> m_pBeatsHalve;
@@ -190,6 +203,8 @@ class BpmControl : public EngineControl {
     // used in the engine thread only
     double m_dSyncInstantaneousBpm;
     double m_dLastSyncAdjustment;
+
+    QTimer m_repeatOperation;
 
     // m_pBeats is written from an engine worker thread
     mixxx::BeatsPointer m_pBeats;

--- a/src/skin/legacy/tooltips.cpp
+++ b/src/skin/legacy/tooltips.cpp
@@ -427,13 +427,42 @@ void Tooltips::addStandardTooltips() {
             << QString("%1: %2").arg(leftClick, tempoTapButton)
             << QString("%1: %2").arg(rightClick, bpmTapButton);
 
+    add("beats_set_change_marker")
+            << tr("Set Beat Change Marker")
+            << tr("Set a marker at the current play position, that indicates a "
+                  "bar or tempo change.");
+
+    add("beats_remove_change_marker")
+            << tr("Remove Beat Change Marker")
+            << tr("Remove the beat change marker at the current play position.");
+
+    add("beats_increase_bar_length")
+            << tr("Adjust the bar length")
+            << tr("Increment bar length by one beat, between adjacent markers.");
+
+    add("beats_decrease_bar_length")
+            << tr("Adjust the bar length")
+            << tr("Decrement the bar length by one beat between adjacent markers.");
+
     add("beats_adjust_slower")
             << tr("Adjust BPM Down")
-            << tr("When tapped, adjusts the average BPM down by a small amount.");
+            << tr("When tapped, decrease the BPM between adjacent markers around the "
+                  "current play position by a small amount.");
+
+    add("beats_adjust_much_slower")
+            << tr("Adjust BPM Down")
+            << tr("When tapped, decrease the BPM of the region around the "
+                  "current play position by a large amount.");
 
     add("beats_adjust_faster")
             << tr("Adjust BPM Up")
-            << tr("When tapped, adjusts the average BPM up by a small amount.");
+            << tr("When tapped, increases the BPM of the region around the "
+                  "current play position by a small amount.");
+
+    add("beats_adjust_much_faster")
+            << tr("Adjust BPM Up")
+            << tr("When tapped, increases the BPM of the region around the "
+                  "current play position by a large amount.");
 
     add("beats_translate_earlier")
             << tr("Adjust Beats Earlier")

--- a/src/track/serato/beatgrid.cpp
+++ b/src/track/serato/beatgrid.cpp
@@ -441,7 +441,7 @@ void SeratoBeatGrid::setBeats(BeatsPointer pBeats,
                 pBeats->getLastMarkerBpm().value();
         const auto previousBeatLengthFrames =
                 (pBeats->getLastMarkerPosition() - marker.position()) /
-                marker.beatsTillNextMarker();
+                marker.beatsUntilPositionExtrapolated(pBeats->getLastMarkerPosition());
         // If the following condition holds true, the marker only exists for backwards compatibility with the legacy beatgrid format.
         //
         // TODO: Remove this when the protobuf format is changed.
@@ -457,18 +457,23 @@ void SeratoBeatGrid::setBeats(BeatsPointer pBeats,
     }
 
     nonTerminalMarkers.reserve(static_cast<int>(markers.size()));
-    std::transform(markers.cbegin(),
-            markers.cend(),
-            std::back_inserter(nonTerminalMarkers),
-            [&signalInfo, timingOffsetSecs](const BeatMarker& marker)
-                    -> SeratoBeatGridNonTerminalMarkerPointer {
-                const float positionSecs =
-                        static_cast<float>(signalInfo.frames2secsFractional(
-                                                   marker.position().value()) -
-                                timingOffsetSecs);
-                return std::make_shared<SeratoBeatGridNonTerminalMarker>(
-                        positionSecs, marker.beatsTillNextMarker());
-            });
+
+    const auto* pMarker = !markers.empty() ? &markers.front() : nullptr;
+    for (std::size_t i = 1; i <= markers.size(); i++) {
+        const auto* pNextMarker = i < markers.size() ? &markers[i] : nullptr;
+
+        const float positionSecs =
+                static_cast<float>(signalInfo.frames2secsFractional(
+                                           pMarker->position().value()) -
+                        timingOffsetSecs);
+
+        const auto nextPosition = pNextMarker ? pNextMarker->position()
+                                              : pBeats->getLastMarkerPosition();
+
+        nonTerminalMarkers.push_back(std::make_shared<SeratoBeatGridNonTerminalMarker>(
+                positionSecs, pMarker->beatsUntilPositionExtrapolated(nextPosition)));
+        pMarker = pNextMarker;
+    }
 
     const float positionSecs =
             static_cast<float>(signalInfo.frames2secsFractional(

--- a/src/track/serato/beatsimporter.cpp
+++ b/src/track/serato/beatsimporter.cpp
@@ -3,6 +3,7 @@
 #include "track/serato/tags.h"
 
 namespace mixxx {
+constexpr audio::BeatsPerBar kDefaultBeatPerBar = audio::BeatsPerBar(4);
 
 SeratoBeatsImporter::SeratoBeatsImporter()
         : BeatsImporter(),
@@ -43,22 +44,38 @@ BeatsPointer SeratoBeatsImporter::importBeatsAndApplyTimingOffset(
 
     std::vector<BeatMarker> markers;
     markers.reserve(m_nonTerminalMarkers.size());
-    for (const auto& pMarker : std::as_const(m_nonTerminalMarkers)) {
+    auto pMarker = !m_nonTerminalMarkers.isEmpty() ? m_nonTerminalMarkers.first() : nullptr;
+    for (int i = 1; i <= m_nonTerminalMarkers.size(); i++) {
+        auto pNextMarker = i < m_nonTerminalMarkers.size() ? m_nonTerminalMarkers[i] : nullptr;
         VERIFY_OR_DEBUG_ASSERT(pMarker != nullptr) {
             return nullptr;
         }
 
         const auto position = audio::FramePos(
                 signalInfo.secs2frames(pMarker->positionSecs()) +
-                timingOffsetFrames);
-        const auto beatsTillNextMarker = static_cast<int>(pMarker->beatsTillNextMarker());
+                timingOffsetFrames)
+                                      .toLowerFrameBoundary();
+        const auto beatsTillNextMarker = static_cast<double>(pMarker->beatsTillNextMarker());
         if (static_cast<quint32>(beatsTillNextMarker) != pMarker->beatsTillNextMarker()) {
             // This will *never* happen with proper data, but better safe than sorry.
             qWarning() << "SeratoBeatsImporter: Import failed because number "
                           "of beats till next marker exceeds int range!";
             return nullptr;
         }
-        markers.push_back(BeatMarker{position.toLowerFrameBoundary(), beatsTillNextMarker});
+
+        const auto nextPosition = audio::FramePos(
+                signalInfo.secs2frames(pNextMarker
+                                ? pNextMarker->positionSecs()
+                                : m_pTerminalMarker->positionSecs()) +
+                timingOffsetFrames)
+                                          .toLowerFrameBoundary();
+
+        DEBUG_ASSERT(position < nextPosition);
+
+        markers.push_back(BeatMarker{position,
+                (nextPosition - position) / beatsTillNextMarker,
+                kDefaultBeatPerBar});
+        pMarker = pNextMarker;
     }
 
     const auto lastMarkerPosition = audio::FramePos(
@@ -73,6 +90,7 @@ BeatsPointer SeratoBeatsImporter::importBeatsAndApplyTimingOffset(
             signalInfo.getSampleRate(),
             std::move(markers),
             lastMarkerPosition.toLowerFrameBoundary(),
+            kDefaultBeatPerBar,
             lastMarkerBpm);
 }
 


### PR DESCRIPTION
This PR is based on @fwcd 's PR #12343, itself based on @Holzhaus 's #4489 PR.

![image](https://github.com/mixxxdj/mixxx/assets/7086688/fc426819-4b1f-4c13-a1b1-7044f06c478b)

https://github.com/mixxxdj/mixxx/assets/7086688/93cb8f4d-eced-40b4-824f-1ba749f6473d


This attempt TL;DR; is: do not disrupt the way the beat grid currently works

This is how this attempt differs from the previous one:
- BPM doesn't get change when adding or removing a new marker
- Adjusting the BPM will have a consistent behaviour whether editing a specific marker or the end of track marker
- Faster/slower BPM will adjust the BPM by 0.01, and will auto repeat if the button stays pressed for more than half a second
- Faster/slower BPM will behave like above but with a 0.1 if the right click is used instead
- Translating the grid will only impact the current marker, and the button can stay pressed to repeat
- Beatgrid markers can be turn on and off as waveform options
- Beat colours support alpha

TODO:
- [x] Fix Serato beat grid import
- [x] Store the bar length using the beatmap
- [x] Implement missing usecase
- [x] Fix the "last beat" not displayed when the next marker grid uses a different beat length 

Fixes #13308 and #10164

**Disclaimer:**
_I know there was a lot of discussion on these types of change in each of the above PRs as well as in the Zulip thread that goes with it. I'm sorry, but I only read the latest messages of each as there was a few hundreds of them, going over a few years of activity. Apologies if this proposal contains approaches that have been discussed and ruled out already._ 