### PR TITLE
AutoDJProcessor: Add option to reset the crossfader to neutral

### DIFF
--- a/src/library/autodj/autodjprocessor.h
+++ b/src/library/autodj/autodjprocessor.h
@@ -242,6 +242,7 @@ class AutoDJProcessor : public QObject {
     // every time)
     double getCrossfader() const;
     void setCrossfader(double value);
+    void setCrossfaderToIdle(double value);
 
     // Following functions return seconds computed from samples or -1 if
     // track in deck has invalid sample rate (<= 0)

--- a/src/preferences/dialog/dlgprefautodj.cpp
+++ b/src/preferences/dialog/dlgprefautodj.cpp
@@ -8,6 +8,14 @@ DlgPrefAutoDJ::DlgPrefAutoDJ(QWidget* pParent,
           m_pConfig(pConfig) {
     setupUi(this);
 
+    // Whether to reset the crossfader to neutral when not fading
+    ResetFaderToNeutralOnIdleCheckBox->setChecked(m_pConfig->getValue(
+            ConfigKey("[Auto DJ]", "ResetFaderToNeutralOnIdle"), false));
+    connect(ResetFaderToNeutralOnIdleCheckBox,
+            &QCheckBox::stateChanged,
+            this,
+            &DlgPrefAutoDJ::slotToggleResetFaderToNeutralOnIdle);
+
     // The minimum available for randomly-selected tracks
     MinimumAvailableSpinBox->setValue(
             m_pConfig->getValue(
@@ -152,6 +160,11 @@ void DlgPrefAutoDJ::slotToggleRequeueIgnore(int buttonState) {
     bool checked = buttonState == Qt::Checked;
     m_pConfig->setValue(ConfigKey("[Auto DJ]", "UseIgnoreTimeBuff"), checked);
     RequeueIgnoreTimeEdit->setEnabled(checked);
+}
+
+void DlgPrefAutoDJ::slotToggleResetFaderToNeutralOnIdle(int buttonState) {
+    bool checked = buttonState == Qt::Checked;
+    m_pConfig->setValue(ConfigKey("[Auto DJ]", "ResetFaderToNeutralOnIdle"), checked);
 }
 
 void DlgPrefAutoDJ::slotSetRequeueIgnoreTime(const QTime& a_rTime) {

--- a/src/preferences/dialog/dlgprefautodj.h
+++ b/src/preferences/dialog/dlgprefautodj.h
@@ -20,6 +20,7 @@ class DlgPrefAutoDJ : public DlgPreferencePage, public Ui::DlgPrefAutoDJDlg {
   private slots:
     void slotSetMinimumAvailable(int);
     void slotToggleRequeueIgnore(int buttonState);
+    void slotToggleResetFaderToNeutralOnIdle(int buttonState);
     void slotSetRequeueIgnoreTime(const QTime& a_rTime);
     void slotSetRandomQueueMin(int);
     void slotConsiderRepeatPlaylistState(bool);

--- a/src/preferences/dialog/dlgprefautodjdlg.ui
+++ b/src/preferences/dialog/dlgprefautodjdlg.ui
@@ -15,6 +15,65 @@
   </property>
   <layout class="QVBoxLayout" name="AutoDJGridLayout">
 
+    <item>
+    <widget class="QGroupBox" name="CrossfaderOptions">
+      <property name="title">
+       <string>Crossfader</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+      </property>
+      <layout class="QGridLayout" name="CrossfaderGridLayout">
+
+       <item row="0" column="0">
+        <widget class="QLabel" name="ResetFaderToNeutralOnIdleLabel">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Check to always reset the crossfader to neutral when no fade is in progress.</string>
+         </property>
+         <property name="text">
+          <string>Reset fader to neutral after crossfading</string>
+         </property>
+          <property name="buddy">
+           <cstring>ResetFaderToNeutralOnIdleCheckBox</cstring>
+          </property>
+        </widget>
+       </item>
+
+       <item row="0" column="1">
+        <widget class="QCheckBox" name="ResetFaderToNeutralOnIdleCheckBox">
+         <property name="toolTip">
+          <string>Check to always reset the crossfader to neutral when no fade is in progress.</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+
+       <item row="1" column="2">
+        <spacer name="horizontalSpacerCrossfader">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+            <horstretch>1</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+        </spacer>
+       </item>
+
+      </layout>
+    </widget>
+   </item>
+
    <item>
     <widget class="QGroupBox" name="RequeueOptions">
       <property name="title">


### PR DESCRIPTION
**Update:** Closed, see #13303 for a different solution to the same underlying problem (#11571).

# What does it do?
Add a simple configuration option for the Auto DJ that always resets the crossfader to neutral (`0.0`) while only one track is playing. This improves the use case of switching back and force between manually loading tracks and using the Auto DJ.

## Is it tested?
I've been actively using a build that includes these changes for a few weeks now, and so far everything seems to work exactly as expected.

## Are there any remaining open questions?
- Suggestions for improving the label and tooltip texts for the settings are more than welcome.
- The same goes for the name of the config option (`[Auto DJ] ResetFaderToNeutralOnIdle`)

The setting's default value is currently `false`, so the non-reset behavior is the default.
- For new users that just use Mixxx as a player with tempo control, a default value of `true` would be best to avoid the "surprise" that I had.
- For advanced users, the only use case that would be affected by a default value of `true` is:
  - (1) Disable the Auto DJ while only one track is playing.
    or (2) Auto DJ is enabled and only one track is playing.
  - Crossfader is not touched before they...
  - ...manually start playing a second deck, and expect it to not be hearable until the fader is moved manually.
  
  I don't know how common this use case is in practice - maybe one of you has more insight into this?

# What Problem Does This Solve?
> Use a laptop with a small screen, and no external DJ controller. Play two tracks using Auto DJ, then turn it off. Load another track manually, press play, and.... wonder if you have broken Mixxx because now, only one of two decks works. The UI looks the same, so you have no idea why, and just assume it's a bug.[^1]

[^1]: This story happened to me a few times (a part of those live...) before I had figured it out:
    - I had (inadvertenly, due to screen size) configured the skin to not show the crossfader.
    - I expected that turning the Auto DJ on and then later off again would not have any lingering side effects.
    - I just happened to lose on a 50/50 coin toss on which deck was active last.

So, my expectations as a user are:
- **For Novice Users:** I can use Auto DJ to play a few tracks in full, turn it off, and play a few tracks manually without having to care about anything else.

  Which implies: I expect both decks to be playable from (aka. the crossfader to be neutral) when there's no reason (at this moment) for it not to be neutral, and no other visible indicator telling me otherwise.

- **For Advanced Users:** Turning the Auto DJ off while two decks are playing and/or I want to manually control the crossfader does not cause the crossfader to jump.

Three solutions come to my mind, the last of which was implemented here:
1. Make sure the crossfader is always visible (but a user might still overlook it)
2. Reset the crossfader when the Auto DJ is being turned off (but avoid doing so when the user has actively changed the crossfader's value, which could get complicated).
3. Reset the crossfader as soon as the Auto DJ is not actively using it to perform a crossfade.