### PR TITLE
Fix QML build regressions on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
               -DMACOS_BUNDLE=ON
               -DMODPLUG=ON
               -DQT6=ON
-              -DQML=OFF
+              -DQML=ON
               -DWAVPACK=ON
               -DVCPKG_TARGET_TRIPLET=x64-osx-min1100-release
               -DVCPKG_DEFAULT_HOST_TRIPLET=x64-osx-min1100-release
@@ -72,7 +72,7 @@ jobs:
               -DMACOS_BUNDLE=ON
               -DMODPLUG=ON
               -DQT6=ON
-              -DQML=OFF
+              -DQML=ON
               -DWAVPACK=ON
               -DVCPKG_TARGET_TRIPLET=arm64-osx-min1100-release
               -DVCPKG_DEFAULT_HOST_TRIPLET=x64-osx-min1100-release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
               -DMACOS_BUNDLE=ON
               -DMODPLUG=ON
               -DQT6=ON
-              -DQML=ON
+              -DQML=OFF
               -DWAVPACK=ON
               -DVCPKG_TARGET_TRIPLET=x64-osx-min1100-release
               -DVCPKG_DEFAULT_HOST_TRIPLET=x64-osx-min1100-release

--- a/src/controllers/rendering/controllerrenderingengine.h
+++ b/src/controllers/rendering/controllerrenderingengine.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <GL/gl.h>
-
 #include <QObject>
+#include <QOpenGLContext>
+#include <QOpenGLFramebufferObject>
 #include <chrono>
 #include <gsl/pointers>
 

--- a/src/controllers/scripting/legacy/controllerscriptenginelegacy.cpp
+++ b/src/controllers/scripting/legacy/controllerscriptenginelegacy.cpp
@@ -7,6 +7,7 @@
 #include <QQuickWindow>
 #include <QtEndian>
 #include <algorithm>
+#include <version>
 
 // Prevent conflict with methods called 'emit' in <execution> source
 #pragma push_macro("emit")
@@ -323,7 +324,11 @@ void ControllerScriptEngineLegacy::setScriptFiles(
     m_scriptFiles = scripts;
 
 #ifdef MIXXX_USE_QML
-    setQMLMode(std::any_of(std::execution::par_unseq,
+    setQMLMode(std::any_of(
+#ifndef _LIBCPP_VERSION // Still experimental in Clang's libc++ as of June 2024:
+                        // https://github.com/llvm/llvm-project/issues/65125
+            std::execution::par_unseq,
+#endif
             m_scriptFiles.cbegin(),
             m_scriptFiles.cend(),
             [](const auto& scriptFileInfo) {

--- a/src/controllers/scripting/legacy/controllerscriptenginelegacy.cpp
+++ b/src/controllers/scripting/legacy/controllerscriptenginelegacy.cpp
@@ -654,7 +654,7 @@ void ControllerScriptEngineLegacy::handleScreenFrame(
         emit previewRenderedScreen(screenInfo, screenDebug);
     }
 
-    QByteArray input(std::bit_cast<const char*>(frame.constBits()), frame.sizeInBytes());
+    QByteArray input(reinterpret_cast<const char*>(frame.constBits()), frame.sizeInBytes());
     const TransformScreenFrameFunction& transformMethod =
             m_transformScreenFrameFunctions[screenInfo.identifier];
 

--- a/src/controllers/scripting/legacy/controllerscriptenginelegacy.cpp
+++ b/src/controllers/scripting/legacy/controllerscriptenginelegacy.cpp
@@ -654,6 +654,8 @@ void ControllerScriptEngineLegacy::handleScreenFrame(
         emit previewRenderedScreen(screenInfo, screenDebug);
     }
 
+    // TODO: Refactor this to a `std::bit_cast` once we drop support for older
+    // compilers that don't support it (e.g. Clang/libc++ on macOS 11)
     QByteArray input(reinterpret_cast<const char*>(frame.constBits()), frame.sizeInBytes());
     const TransformScreenFrameFunction& transformMethod =
             m_transformScreenFrameFunctions[screenInfo.identifier];

--- a/src/controllers/scripting/legacy/controllerscriptenginelegacy.cpp
+++ b/src/controllers/scripting/legacy/controllerscriptenginelegacy.cpp
@@ -655,7 +655,7 @@ void ControllerScriptEngineLegacy::handleScreenFrame(
     }
 
     // TODO: Refactor this to a `std::bit_cast` once we drop support for older
-    // compilers that don't support it (e.g. Clang/libc++ on macOS 11)
+    // compilers that don't support it (e.g. older than Xcode 14.3/macOS 13)
     QByteArray input(reinterpret_cast<const char*>(frame.constBits()), frame.sizeInBytes());
     const TransformScreenFrameFunction& transformMethod =
             m_transformScreenFrameFunctions[screenInfo.identifier];

--- a/src/controllers/scripting/legacy/controllerscriptenginelegacy.cpp
+++ b/src/controllers/scripting/legacy/controllerscriptenginelegacy.cpp
@@ -7,13 +7,6 @@
 #include <QQuickWindow>
 #include <QtEndian>
 #include <algorithm>
-#include <version>
-
-// Prevent conflict with methods called 'emit' in <execution> source
-#pragma push_macro("emit")
-#undef emit
-#include <execution>
-#pragma pop_macro("emit")
 #endif
 
 #include "control/controlobject.h"
@@ -325,10 +318,6 @@ void ControllerScriptEngineLegacy::setScriptFiles(
 
 #ifdef MIXXX_USE_QML
     setQMLMode(std::any_of(
-#ifndef _LIBCPP_VERSION // Still experimental in Clang's libc++ as of June 2024:
-                        // https://github.com/llvm/llvm-project/issues/65125
-            std::execution::par_unseq,
-#endif
             m_scriptFiles.cbegin(),
             m_scriptFiles.cend(),
             [](const auto& scriptFileInfo) {


### PR DESCRIPTION
This fixes a few minor regressions introduced by #11407 when building with `-DQML=ON` on macOS and re-enables QML in the CI build for macOS.