### PR TITLE
(opti/cleanup) make use of WLibrary::getCurrentTrackTableView()

### DIFF
--- a/src/library/analysis/dlganalysis.cpp
+++ b/src/library/analysis/dlganalysis.cpp
@@ -116,31 +116,6 @@ void DlgAnalysis::onSearch(const QString& text) {
     m_pAnalysisLibraryTableModel->search(text);
 }
 
-void DlgAnalysis::activateSelectedTrack() {
-    m_pAnalysisLibraryTableView->activateSelectedTrack();
-}
-
-void DlgAnalysis::loadSelectedTrackToGroup(const QString& group, bool play) {
-    m_pAnalysisLibraryTableView->loadSelectedTrackToGroup(group, play);
-}
-
-void DlgAnalysis::slotAddToAutoDJBottom() {
-    // append to auto DJ
-    m_pAnalysisLibraryTableView->slotAddToAutoDJBottom();
-}
-
-void DlgAnalysis::slotAddToAutoDJTop() {
-    m_pAnalysisLibraryTableView->slotAddToAutoDJTop();
-}
-
-void DlgAnalysis::slotAddToAutoDJReplace() {
-    m_pAnalysisLibraryTableView->slotAddToAutoDJReplace();
-}
-
-void DlgAnalysis::moveSelection(int delta) {
-    m_pAnalysisLibraryTableView->moveSelection(delta);
-}
-
 void DlgAnalysis::tableSelectionChanged(const QItemSelection& selected,
                                        const QItemSelection& deselected) {
     Q_UNUSED(selected);

--- a/src/library/analysis/dlganalysis.h
+++ b/src/library/analysis/dlganalysis.h
@@ -26,12 +26,6 @@ class DlgAnalysis : public QWidget, public Ui::DlgAnalysis, public virtual Libra
     void onShow() override;
     bool hasFocus() const override;
     void setFocus() override;
-    void activateSelectedTrack() override;
-    void loadSelectedTrackToGroup(const QString& group, bool play) override;
-    void slotAddToAutoDJBottom() override;
-    void slotAddToAutoDJTop() override;
-    void slotAddToAutoDJReplace() override;
-    void moveSelection(int delta) override;
     inline const QString currentSearch() {
         return m_pAnalysisLibraryTableModel->currentSearch();
     }

--- a/src/library/autodj/dlgautodj.cpp
+++ b/src/library/autodj/dlgautodj.cpp
@@ -248,18 +248,6 @@ void DlgAutoDJ::onSearch(const QString& text) {
     Q_UNUSED(text);
 }
 
-void DlgAutoDJ::activateSelectedTrack() {
-    m_pTrackTableView->activateSelectedTrack();
-}
-
-void DlgAutoDJ::loadSelectedTrackToGroup(const QString& group, bool play) {
-    m_pTrackTableView->loadSelectedTrackToGroup(group, play);
-}
-
-void DlgAutoDJ::moveSelection(int delta) {
-    m_pTrackTableView->moveSelection(delta);
-}
-
 void DlgAutoDJ::shufflePlaylistButton(bool) {
     QModelIndexList indexList = m_pTrackTableView->selectionModel()->selectedRows();
 

--- a/src/library/autodj/dlgautodj.h
+++ b/src/library/autodj/dlgautodj.h
@@ -30,9 +30,6 @@ class DlgAutoDJ : public QWidget, public Ui::DlgAutoDJ, public LibraryView {
     void setFocus() override;
     void pasteFromSidebar() override;
     void onSearch(const QString& text) override;
-    void activateSelectedTrack() override;
-    void loadSelectedTrackToGroup(const QString& group, bool play) override;
-    void moveSelection(int delta) override;
     void saveCurrentViewState() override;
     bool restoreCurrentViewState() override;
 

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -17,6 +17,7 @@
 #include "widget/wlibrary.h"
 #include "widget/wlibrarysidebar.h"
 #include "widget/wsearchlineedit.h"
+#include "widget/wtracktableview.h"
 
 namespace {
 const QString kAppGroup = QStringLiteral("[App]");
@@ -577,64 +578,53 @@ void LibraryControl::slotLoadSelectedTrackToGroup(const QString& group, bool pla
         return;
     }
 
-    LibraryView* pActiveView = m_pLibraryWidget->getActiveView();
-    if (!pActiveView) {
-        return;
+    WTrackTableView* pTrackTableView = m_pLibraryWidget->getCurrentTrackTableView();
+    if (pTrackTableView) {
+        pTrackTableView->loadSelectedTrackToGroup(group, play);
     }
-    pActiveView->loadSelectedTrackToGroup(group, play);
 }
 
 void LibraryControl::slotLoadSelectedIntoFirstStopped(double v) {
-    if (!m_pLibraryWidget) {
+    if (!m_pLibraryWidget || v <= 0) {
         return;
     }
 
-    if (v > 0) {
-        LibraryView* pActiveView = m_pLibraryWidget->getActiveView();
-        if (!pActiveView) {
-            return;
-        }
-        pActiveView->activateSelectedTrack();
+    WTrackTableView* pTrackTableView = m_pLibraryWidget->getCurrentTrackTableView();
+    if (pTrackTableView) {
+        pTrackTableView->activateSelectedTrack();
     }
 }
 
 void LibraryControl::slotAutoDjAddTop(double v) {
-    if (!m_pLibraryWidget) {
+    if (!m_pLibraryWidget || v <= 0) {
         return;
     }
 
-    if (v > 0) {
-        LibraryView* pActiveView = m_pLibraryWidget->getActiveView();
-        if (!pActiveView) {
-            return;
-        }
-        pActiveView->slotAddToAutoDJTop();
+    WTrackTableView* pTrackTableView = m_pLibraryWidget->getCurrentTrackTableView();
+    if (pTrackTableView) {
+        pTrackTableView->addToAutoDJTop();
     }
 }
 
 void LibraryControl::slotAutoDjAddBottom(double v) {
-    if (!m_pLibraryWidget) {
+    if (!m_pLibraryWidget || v <= 0) {
         return;
     }
-    if (v > 0) {
-        LibraryView* pActiveView = m_pLibraryWidget->getActiveView();
-        if (!pActiveView) {
-            return;
-        }
-        pActiveView->slotAddToAutoDJBottom();
+
+    WTrackTableView* pTrackTableView = m_pLibraryWidget->getCurrentTrackTableView();
+    if (pTrackTableView) {
+        pTrackTableView->addToAutoDJBottom();
     }
 }
 
 void LibraryControl::slotAutoDjAddReplace(double v) {
-    if (!m_pLibraryWidget) {
+    if (!m_pLibraryWidget || v <= 0) {
         return;
     }
-    if (v > 0) {
-        LibraryView* pActiveView = m_pLibraryWidget->getActiveView();
-        if (!pActiveView) {
-            return;
-        }
-        pActiveView->slotAddToAutoDJReplace();
+
+    WTrackTableView* pTrackTableView = m_pLibraryWidget->getCurrentTrackTableView();
+    if (pTrackTableView) {
+        pTrackTableView->addToAutoDJReplace();
     }
 }
 
@@ -651,17 +641,15 @@ void LibraryControl::slotSelectPrevTrack(double v) {
 }
 
 void LibraryControl::slotSelectTrack(double v) {
-    if (!m_pLibraryWidget) {
+    if (!m_pLibraryWidget || v == 0) {
         return;
     }
 
-    LibraryView* pActiveView = m_pLibraryWidget->getActiveView();
-    if (!pActiveView) {
-        return;
+    WTrackTableView* pTrackTableView = m_pLibraryWidget->getCurrentTrackTableView();
+    if (pTrackTableView) {
+        int i = (int)v;
+        pTrackTableView->moveSelection(i);
     }
-
-    int i = (int)v;
-    pActiveView->moveSelection(i);
 }
 
 void LibraryControl::slotMoveUp(double v) {
@@ -982,9 +970,13 @@ void LibraryControl::slotGoToItem(double v) {
             m_pSidebarWidget->toggleSelectedItem();
         }
         return;
-    case FocusWidget::TracksTable:
-        m_pLibraryWidget->getActiveView()->activateSelectedTrack();
+    case FocusWidget::TracksTable: {
+        WTrackTableView* pTrackTableView = m_pLibraryWidget->getCurrentTrackTableView();
+        if (pTrackTableView) {
+            pTrackTableView->activateSelectedTrack();
+        }
         return;
+    }
     case FocusWidget::Dialog: {
         // press & release Space (QAbstractButton::clicked() is emitted on release)
         QKeyEvent pressSpace = QKeyEvent{QEvent::KeyPress, Qt::Key_Space, Qt::NoModifier};
@@ -1060,29 +1052,23 @@ void LibraryControl::slotDecrementFontSize(double v) {
 }
 
 void LibraryControl::slotTrackColorPrev(double v) {
-    if (!m_pLibraryWidget) {
+    if (!m_pLibraryWidget || v <= 0) {
         return;
     }
 
-    if (v > 0) {
-        LibraryView* pActiveView = m_pLibraryWidget->getActiveView();
-        if (!pActiveView) {
-            return;
-        }
-        pActiveView->assignPreviousTrackColor();
+    WTrackTableView* pTrackTableView = m_pLibraryWidget->getCurrentTrackTableView();
+    if (pTrackTableView) {
+        pTrackTableView->assignPreviousTrackColor();
     }
 }
 
 void LibraryControl::slotTrackColorNext(double v) {
-    if (!m_pLibraryWidget) {
+    if (!m_pLibraryWidget || v <= 0) {
         return;
     }
 
-    if (v > 0) {
-        LibraryView* pActiveView = m_pLibraryWidget->getActiveView();
-        if (!pActiveView) {
-            return;
-        }
-        pActiveView->assignNextTrackColor();
+    WTrackTableView* pTrackTableView = m_pLibraryWidget->getCurrentTrackTableView();
+    if (pTrackTableView) {
+        pTrackTableView->assignNextTrackColor();
     }
 }

--- a/src/library/libraryview.h
+++ b/src/library/libraryview.h
@@ -25,17 +25,6 @@ class LibraryView {
     virtual void pasteFromSidebar() {
     }
 
-    /// If applicable, requests that the LibraryView load the selected
-    /// track. Does nothing otherwise.
-    virtual void activateSelectedTrack() {
-    }
-
-    virtual void slotAddToAutoDJBottom() {
-    }
-    virtual void slotAddToAutoDJTop() {
-    }
-    virtual void slotAddToAutoDJReplace() {
-    }
     virtual void saveCurrentViewState() {
     }
     /// @brief restores current view state.
@@ -43,17 +32,6 @@ class LibraryView {
     virtual bool restoreCurrentViewState() {
         return false;
     };
-
-    /// If applicable, requests that the LibraryView load the selected track to
-    /// the specified group. Does nothing otherwise.
-    virtual void loadSelectedTrackToGroup(const QString& group, bool play) {
-        Q_UNUSED(group); Q_UNUSED(play);
-    }
-
-    /// If a selection is applicable for this view, request that the selection be
-    /// increased or decreased by the provided delta. For example, for a value of
-    /// 1, the view should move to the next selection in the list.
-    virtual void moveSelection(int delta) {Q_UNUSED(delta);}
 
     virtual TrackModel::SortColumnId getColumnIdFromCurrentIndex() {
         return TrackModel::SortColumnId::Invalid;

--- a/src/library/recording/dlgrecording.cpp
+++ b/src/library/recording/dlgrecording.cpp
@@ -124,30 +124,6 @@ void DlgRecording::slotRestoreSearch() {
     emit restoreSearch(currentSearch());
 }
 
-void DlgRecording::activateSelectedTrack() {
-    m_pTrackTableView->activateSelectedTrack();
-}
-
-void DlgRecording::slotAddToAutoDJBottom() {
-    m_pTrackTableView->slotAddToAutoDJBottom();
-}
-
-void DlgRecording::slotAddToAutoDJTop() {
-    m_pTrackTableView->slotAddToAutoDJTop();
-}
-
-void DlgRecording::slotAddToAutoDJReplace() {
-    m_pTrackTableView->slotAddToAutoDJReplace();
-}
-
-void DlgRecording::loadSelectedTrackToGroup(const QString& group, bool play) {
-    m_pTrackTableView->loadSelectedTrackToGroup(group, play);
-}
-
-void DlgRecording::moveSelection(int delta) {
-    m_pTrackTableView->moveSelection(delta);
-}
-
 void DlgRecording::slotRecButtonClicked(bool toggle) {
     Q_UNUSED(toggle);
     m_pRecordingManager->slotToggleRecording(1);

--- a/src/library/recording/dlgrecording.h
+++ b/src/library/recording/dlgrecording.h
@@ -24,12 +24,6 @@ class DlgRecording : public QWidget, public Ui::DlgRecording, public virtual Lib
     void onShow() override{};
     bool hasFocus() const override;
     void setFocus() override;
-    void activateSelectedTrack() override;
-    void slotAddToAutoDJBottom() override;
-    void slotAddToAutoDJTop() override;
-    void slotAddToAutoDJReplace() override;
-    void loadSelectedTrackToGroup(const QString& group, bool play) override;
-    void moveSelection(int delta) override;
     inline const QString currentSearch() { return m_proxyModel.currentSearch(); }
     void saveCurrentViewState() override;
     bool restoreCurrentViewState() override;

--- a/src/widget/wlibrary.cpp
+++ b/src/widget/wlibrary.cpp
@@ -106,12 +106,11 @@ WTrackTableView* WLibrary::getCurrentTrackTableView() const {
     QWidget* pCurrent = currentWidget();
     WTrackTableView* pTracksView = qobject_cast<WTrackTableView*>(pCurrent);
     if (!pTracksView) {
-        // This view is no tracks view, but maybe a special tracks view with a
-        // controls row (DlgAutoDJ, DlgRecording)?
-        // qDebug() << "   view is no tracks view. look for tracks view child";
+        // This view is not a tracks view, but possibly a special library view
+        // with a controls row and a track view (DlgAutoDJ, DlgRecording etc.)?
         pTracksView = pCurrent->findChild<WTrackTableView*>();
     }
-    return pTracksView; // might be nullptr
+    return pTracksView; // might still be nullptr
 }
 
 bool WLibrary::isTrackInCurrentView(const TrackId& trackId) {
@@ -136,7 +135,7 @@ void WLibrary::slotSelectTrackInActiveTrackView(const TrackId& trackId) {
     if (!pTracksView) {
         return;
     }
-    pTracksView->slotSelectTrack(trackId);
+    pTracksView->selectTrack(trackId);
 }
 
 void WLibrary::saveCurrentViewState() const {

--- a/src/widget/wlibrarytableview.cpp
+++ b/src/widget/wlibrarytableview.cpp
@@ -60,52 +60,6 @@ WLibraryTableView::WLibraryTableView(QWidget* parent,
 WLibraryTableView::~WLibraryTableView() {
 }
 
-void WLibraryTableView::moveSelection(int delta) {
-    QAbstractItemModel* pModel = model();
-
-    if (pModel == nullptr) {
-        return;
-    }
-
-    while (delta != 0) {
-        QItemSelectionModel* currentSelection = selectionModel();
-        if (currentSelection->selectedRows().length() > 0) {
-            if (delta > 0) {
-                // i is positive, so we want to move the highlight down
-                int row = currentSelection->selectedRows().last().row();
-                if (row + 1 < pModel->rowCount()) {
-                    selectRow(row + 1);
-                } else {
-                    // we wrap around at the end of the list so it is faster to get
-                    // to the top of the list again
-                    selectRow(0);
-                }
-
-                delta--;
-            } else {
-                // i is negative, so move down
-                int row = currentSelection->selectedRows().first().row();
-                if (row - 1 >= 0) {
-                    selectRow(row - 1);
-                } else {
-                    selectRow(pModel->rowCount() - 1);
-                }
-
-                delta++;
-            }
-        } else {
-            // no selection, so select the first or last element depending on delta
-            if (delta > 0) {
-                selectRow(0);
-                delta--;
-            } else {
-                selectRow(pModel->rowCount() - 1);
-                delta++;
-            }
-        }
-    }
-}
-
 void WLibraryTableView::saveTrackModelState(
         const QAbstractItemModel* model, const QString& key) {
     //qDebug() << "saveTrackModelState:" << model << key;
@@ -319,11 +273,11 @@ QModelIndex WLibraryTableView::moveCursor(CursorAction cursorAction,
         // browsing a key-sorted library list requires either a serious workout
         // or the user needs to reach for the mouse or keyboard when moving
         // between 12/C#m/E and 1/G#m/B. This is very similar to
-        // `moveSelection()`, except that it doesn't actually modify the
-        // selection. It simply returns a new cursor that the keyboard event
-        // handler in `QAbstractItemView` uses to either move the cursor, move
-        // the selection, or extend the selection depending on which modifier
-        // keys are held down.
+        // WTrackTableView::moveSelection(), except that it doesn't actually
+        // modify the selection. It simply returns a new cursor that the
+        // keyboard event handler in `QAbstractItemView` uses to either move the
+        // cursor, move the selection, or extend the selection depending on
+        // which modifier keys are held down.
         // Note: Shift modifier prevents wrap-around.
         case QAbstractItemView::MoveUp:
         case QAbstractItemView::MoveDown: {

--- a/src/widget/wlibrarytableview.h
+++ b/src/widget/wlibrarytableview.h
@@ -26,8 +26,6 @@ class WLibraryTableView : public QTableView, public virtual LibraryView {
             UserSettingsPointer pConfig);
     ~WLibraryTableView() override;
 
-    void moveSelection(int delta) override;
-
     /// @brief saveTrackModelState function saves current positions of scrollbars,
     /// current item selection and current index in a QCache using a unique
     /// string key - can be any value but should invariant for model

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1427,23 +1427,69 @@ void WTrackTableView::addToAutoDJ(PlaylistDAO::AutoDJSendLoc loc) {
     playlistDao.addTracksToAutoDJQueue(trackIds, loc);
 }
 
-void WTrackTableView::slotAddToAutoDJBottom() {
+void WTrackTableView::addToAutoDJBottom() {
     addToAutoDJ(PlaylistDAO::AutoDJSendLoc::BOTTOM);
 }
 
-void WTrackTableView::slotAddToAutoDJTop() {
+void WTrackTableView::addToAutoDJTop() {
     addToAutoDJ(PlaylistDAO::AutoDJSendLoc::TOP);
 }
 
-void WTrackTableView::slotAddToAutoDJReplace() {
+void WTrackTableView::addToAutoDJReplace() {
     addToAutoDJ(PlaylistDAO::AutoDJSendLoc::REPLACE);
 }
 
-void WTrackTableView::slotSelectTrack(const TrackId& trackId) {
+void WTrackTableView::selectTrack(const TrackId& trackId) {
     if (trackId.isValid() && setCurrentTrackId(trackId, 0, true)) {
         setSelectedTracks({trackId});
     } else {
         setSelectedTracks({});
+    }
+}
+
+void WTrackTableView::moveSelection(int delta) {
+    QAbstractItemModel* pModel = model();
+
+    if (pModel == nullptr) {
+        return;
+    }
+
+    while (delta != 0) {
+        QItemSelectionModel* currentSelection = selectionModel();
+        if (currentSelection->selectedRows().length() > 0) {
+            if (delta > 0) {
+                // i is positive, so we want to move the highlight down
+                int row = currentSelection->selectedRows().last().row();
+                if (row + 1 < pModel->rowCount()) {
+                    selectRow(row + 1);
+                } else {
+                    // we wrap around at the end of the list so it is faster to get
+                    // to the top of the list again
+                    selectRow(0);
+                }
+
+                delta--;
+            } else {
+                // i is negative, so move down
+                int row = currentSelection->selectedRows().first().row();
+                if (row - 1 >= 0) {
+                    selectRow(row - 1);
+                } else {
+                    selectRow(pModel->rowCount() - 1);
+                }
+
+                delta++;
+            }
+        } else {
+            // no selection, so select the first or last element depending on delta
+            if (delta > 0) {
+                selectRow(0);
+                delta--;
+            } else {
+                selectRow(pModel->rowCount() - 1);
+                delta++;
+            }
+        }
     }
 }
 

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -37,8 +37,8 @@ class WTrackTableView : public WLibraryTableView {
     void pasteFromSidebar() override;
     void keyPressEvent(QKeyEvent* event) override;
     void resizeEvent(QResizeEvent* event) override;
-    void activateSelectedTrack() override;
-    void loadSelectedTrackToGroup(const QString& group, bool play) override;
+    void activateSelectedTrack();
+    void loadSelectedTrackToGroup(const QString& group, bool play);
     void assignNextTrackColor() override;
     void assignPreviousTrackColor() override;
     TrackModel::SortColumnId getColumnIdFromCurrentIndex() override;
@@ -48,10 +48,17 @@ class WTrackTableView : public WLibraryTableView {
     TrackId getCurrentTrackId() const;
     bool setCurrentTrackId(const TrackId& trackId, int column = 0, bool scrollToTrack = false);
 
+    void addToAutoDJBottom();
+    void addToAutoDJTop();
+    void addToAutoDJReplace();
+    void selectTrack(const TrackId&);
+
     void removeSelectedTracks();
     void cutSelectedTracks();
     void copySelectedTracks();
     void pasteTracks(const QModelIndex& index);
+
+    void moveSelection(int delta);
     void moveRows(QList<int> selectedRows, int destRow);
     void moveSelectedTracks(QKeyEvent* event);
     void selectTracksById(const QList<TrackId>& tracks, int prevColumn);
@@ -103,9 +110,6 @@ class WTrackTableView : public WLibraryTableView {
     void slotDeleteTracksFromDisk();
     void slotShowHideTrackMenu(bool show);
 
-    void slotAddToAutoDJBottom() override;
-    void slotAddToAutoDJTop() override;
-    void slotAddToAutoDJReplace() override;
     void slotSaveCurrentViewState() {
         saveCurrentViewState();
     };
@@ -115,7 +119,6 @@ class WTrackTableView : public WLibraryTableView {
     void slotrestoreCurrentIndex() {
         restoreCurrentIndex();
     }
-    void slotSelectTrack(const TrackId&);
 
   private slots:
     void doSortByColumn(int headerSection, Qt::SortOrder sortOrder);


### PR DESCRIPTION
and move WLibraryTableView::moveSelection to WTracktableView (simplifies LibraryControl etc.)

This allows to call many methods directly from LibraryControl and remove virtuals from libraryview.h and the respective overrides from various library features.