### PR TITLE
Auto DJ: (Re-)enable search in the Auto DJ view

### DIFF
--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -192,7 +192,9 @@ TreeItemModel* AutoDJFeature::sidebarModel() const {
 void AutoDJFeature::activate() {
     //qDebug() << "AutoDJFeature::activate()";
     emit switchToView(m_viewName);
-    emit disableSearch();
+    if (m_pAutoDJView) {
+        emit restoreSearch(m_pAutoDJView->currentSearch());
+    }
     emit enableCoverArtDisplay(true);
 }
 

--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -25,18 +25,18 @@
 namespace {
 constexpr int kMaxRetrieveAttempts = 3;
 
-    int findOrCrateAutoDjPlaylistId(PlaylistDAO& playlistDAO) {
-        int playlistId = playlistDAO.getPlaylistIdFromName(AUTODJ_TABLE);
-        // If the AutoDJ playlist does not exist yet then create it.
-        if (playlistId < 0) {
-            playlistId = playlistDAO.createPlaylist(
-                    AUTODJ_TABLE, PlaylistDAO::PLHT_AUTO_DJ);
-            VERIFY_OR_DEBUG_ASSERT(playlistId >= 0) {
-                qWarning() << "Failed to create Auto DJ playlist!";
-            }
+int findOrCrateAutoDjPlaylistId(PlaylistDAO& playlistDAO) {
+    int playlistId = playlistDAO.getPlaylistIdFromName(AUTODJ_TABLE);
+    // If the AutoDJ playlist does not exist yet then create it.
+    if (playlistId < 0) {
+        playlistId = playlistDAO.createPlaylist(
+                AUTODJ_TABLE, PlaylistDAO::PLHT_AUTO_DJ);
+        VERIFY_OR_DEBUG_ASSERT(playlistId >= 0) {
+            qWarning() << "Failed to create Auto DJ playlist!";
         }
-        return playlistId;
     }
+    return playlistId;
+}
 } // anonymous namespace
 
 AutoDJFeature::AutoDJFeature(Library* pLibrary,

--- a/src/library/autodj/dlgautodj.cpp
+++ b/src/library/autodj/dlgautodj.cpp
@@ -7,6 +7,7 @@
 #include "controllers/keyboard/keyboardeventfilter.h"
 #include "library/library.h"
 #include "library/playlisttablemodel.h"
+#include "library/proxytrackmodel.h"
 #include "moc_dlgautodj.cpp"
 #include "track/track.h"
 #include "util/assert.h"
@@ -33,6 +34,7 @@ DlgAutoDJ::DlgAutoDJ(WLibrary* parent,
                   pLibrary,
                   parent->getTrackTableBackgroundColorOpacity())),
           m_bShowButtonText(parent->getShowButtonText()),
+          m_pProxyTableModel(nullptr),
           m_pAutoDJTableModel(nullptr) {
     setupUi(this);
 
@@ -78,7 +80,15 @@ DlgAutoDJ::DlgAutoDJ(WLibrary* parent,
 
     // We do _NOT_ take ownership of this from AutoDJProcessor.
     m_pAutoDJTableModel = m_pAutoDJProcessor->getTableModel();
-    m_pTrackTableView->loadTrackModel(m_pAutoDJTableModel);
+
+    // Wrap the table model so users can search it without
+    // messing up the table view for the AutoDJProcessor.
+    m_pProxyTableModel = new ProxyTrackModel(
+            m_pAutoDJTableModel,
+            /* handle searches*/ true);
+
+    // Use the proxy model for the displayed table & searches
+    m_pTrackTableView->loadTrackModel(m_pProxyTableModel);
 
     // Do not set this because it disables auto-scrolling
     //m_pTrackTableView->setDragDropMode(QAbstractItemView::InternalMove);
@@ -232,6 +242,7 @@ DlgAutoDJ::~DlgAutoDJ() {
     // Delete m_pTrackTableView before the table model. This is because the
     // table view saves the header state using the model.
     delete m_pTrackTableView;
+    delete m_pProxyTableModel;
 }
 
 void DlgAutoDJ::setupActionButton(QPushButton* pButton,
@@ -245,12 +256,15 @@ void DlgAutoDJ::setupActionButton(QPushButton* pButton,
 
 void DlgAutoDJ::onShow() {
     m_pAutoDJTableModel->select();
+    m_pProxyTableModel->select();
 }
 
 void DlgAutoDJ::onSearch(const QString& text) {
-    // Do not allow filtering the Auto DJ playlist, because
-    // Auto DJ will work from the filtered table
-    Q_UNUSED(text);
+    m_pTrackTableView->onSearch(text);
+}
+
+const QString DlgAutoDJ::currentSearch() const {
+    return m_pProxyTableModel->currentSearch();
 }
 
 void DlgAutoDJ::shufflePlaylistButton(bool) {

--- a/src/library/autodj/dlgautodj.h
+++ b/src/library/autodj/dlgautodj.h
@@ -10,6 +10,7 @@
 #include "track/track_decl.h"
 
 class PlaylistTableModel;
+class ProxyTrackModel;
 class WLibrary;
 class WTrackTableView;
 class Library;
@@ -32,6 +33,7 @@ class DlgAutoDJ : public QWidget, public Ui::DlgAutoDJ, public LibraryView {
     void onSearch(const QString& text) override;
     void saveCurrentViewState() override;
     bool restoreCurrentViewState() override;
+    const QString currentSearch() const;
 
   public slots:
     void shufflePlaylistButton(bool buttonChecked);
@@ -71,6 +73,7 @@ class DlgAutoDJ : public QWidget, public Ui::DlgAutoDJ, public LibraryView {
     WTrackTableView* const m_pTrackTableView;
     const bool m_bShowButtonText;
 
+    ProxyTrackModel* m_pProxyTableModel;
     PlaylistTableModel* m_pAutoDJTableModel;
 
     QString m_enableBtnTooltip;

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -36,6 +36,19 @@ const QString COLUMNS_SORTING = QStringLiteral("ColumnsSorting");
 
 const QString kModelName = "table:";
 
+QList<int> columnNamesToIndices(
+        const QStringList& columnNames, const BaseSqlTableModel& tableModel) {
+    QList<int> indices;
+    indices.reserve(columnNames.size());
+    for (const QString& columnName : columnNames) {
+        auto index = tableModel.fieldIndex(columnName);
+        if (index < 0) {
+            continue;
+        }
+        indices.append(index);
+    }
+    return indices;
+}
 } // anonymous namespace
 
 BaseSqlTableModel::BaseSqlTableModel(
@@ -146,6 +159,13 @@ void BaseSqlTableModel::initSortColumnMapping() {
         m_sortColumnIdByColumnIndex.insert(
                 m_columnIndexBySortColumnId[static_cast<int>(sortColumn)],
                 sortColumn);
+    }
+}
+
+void BaseSqlTableModel::initSearchColumns() {
+    if (m_trackSource) {
+        m_searchColumns = columnNamesToIndices(
+                m_trackSource->searchColumnsByName(), *this);
     }
 }
 
@@ -366,6 +386,7 @@ void BaseSqlTableModel::setTable(QString tableName,
     m_tableName = std::move(tableName);
     m_idColumn = std::move(idColumn);
     m_tableColumns = std::move(tableColumns);
+    m_searchColumns.clear();
 
     if (m_trackSource) {
         disconnect(m_trackSource.data(),
@@ -391,6 +412,7 @@ void BaseSqlTableModel::setTable(QString tableName,
 
     initTableColumnsAndHeaderProperties(m_tableColumns);
     initSortColumnMapping();
+    initSearchColumns();
 
     m_bInitialized = true;
 }
@@ -432,6 +454,10 @@ void BaseSqlTableModel::search(const QString& searchText) {
     }
     setSearch(searchText);
     select();
+}
+
+const QList<int>& BaseSqlTableModel::searchColumns() const {
+    return m_searchColumns;
 }
 
 void BaseSqlTableModel::setSort(int column, Qt::SortOrder order) {

--- a/src/library/basesqltablemodel.h
+++ b/src/library/basesqltablemodel.h
@@ -62,6 +62,7 @@ class BaseSqlTableModel : public BaseTrackTableModel {
 
     void search(const QString& searchText) override;
     const QString currentSearch() const override;
+    const QList<int>& searchColumns() const override;
 
     TrackModel::SortColumnId sortColumnIdFromColumnIndex(int column) const override;
     int columnIndexFromSortColumnId(TrackModel::SortColumnId sortColumn) const override;
@@ -99,6 +100,7 @@ class BaseSqlTableModel : public BaseTrackTableModel {
             QSharedPointer<BaseTrackCache> trackSource);
 
     virtual void initSortColumnMapping();
+    void initSearchColumns();
 
     TrackCollectionManager* const m_pTrackCollectionManager;
 
@@ -169,6 +171,7 @@ class BaseSqlTableModel : public BaseTrackTableModel {
     QString m_idColumn;
     QSharedPointer<BaseTrackCache> m_trackSource;
     QStringList m_tableColumns;
+    QList<int> m_searchColumns;
     QList<SortColumn> m_sortColumns;
     bool m_bInitialized;
     QHash<TrackId, int> m_trackSortOrder;

--- a/src/library/basetrackcache.cpp
+++ b/src/library/basetrackcache.cpp
@@ -14,6 +14,18 @@ namespace {
 
 constexpr bool sDebug = false;
 
+QList<int> columnNamesToIndices(const QStringList& columnNames, const ColumnCache& columnCache) {
+    QList<int> indices;
+    indices.reserve(columnNames.size());
+    for (const QString& columnName : columnNames) {
+        auto index = columnCache.fieldIndex(columnName);
+        if (index < 0) {
+            continue;
+        }
+        indices.append(index);
+    }
+    return indices;
+}
 }  // namespace
 
 BaseTrackCache::BaseTrackCache(TrackCollection* pTrackCollection,
@@ -27,8 +39,11 @@ BaseTrackCache::BaseTrackCache(TrackCollection* pTrackCollection,
           m_columnCount(columns.size()),
           m_columnsJoined(columns.join(",")),
           m_columnCache(std::move(columns)),
+          m_searchColumnNames(std::move(searchColumns)),
+          m_searchColumns(columnNamesToIndices(
+                  m_searchColumnNames, m_columnCache)),
           m_pQueryParser(std::make_unique<SearchQueryParser>(
-                  pTrackCollection, std::move(searchColumns))),
+                  pTrackCollection, m_searchColumnNames)),
           m_bIndexBuilt(false),
           m_bIsCaching(isCaching),
           m_database(pTrackCollection->database()) {
@@ -444,6 +459,14 @@ QVariant BaseTrackCache::data(TrackId trackId, int column) const {
                 fields.value(columnForKeyId, QVariant{}));
     }
     return fields.value(column, QVariant{});
+}
+
+const QList<int>& BaseTrackCache::searchColumnsByIndex() const {
+    return m_searchColumns;
+}
+
+const QStringList& BaseTrackCache::searchColumnsByName() const {
+    return m_searchColumnNames;
 }
 
 void BaseTrackCache::filterAndSort(const QSet<TrackId>& trackIds,

--- a/src/library/basetrackcache.h
+++ b/src/library/basetrackcache.h
@@ -65,6 +65,8 @@ class BaseTrackCache : public QObject {
     QString columnSortForFieldIndex(int index) const;
     int fieldIndex(ColumnCache::Column column) const;
     int endFieldIndex() const;
+    const QList<int>& searchColumnsByIndex() const;
+    const QStringList& searchColumnsByName() const;
     virtual void filterAndSort(const QSet<TrackId>& trackIds,
                                const QString& query,
                                const QString& extraFilter,
@@ -114,6 +116,8 @@ class BaseTrackCache : public QObject {
 
     const ColumnCache m_columnCache;
 
+    const QStringList m_searchColumnNames;
+    const QList<int> m_searchColumns;
     const std::unique_ptr<SearchQueryParser> m_pQueryParser;
 
     const mixxx::StringCollator m_collator;

--- a/src/library/proxytrackmodel.cpp
+++ b/src/library/proxytrackmodel.cpp
@@ -128,6 +128,17 @@ void ProxyTrackModel::removeTracks(const QModelIndexList& indices) {
     }
 }
 
+void ProxyTrackModel::cutTracks(const QModelIndexList& indices) {
+    QModelIndexList translatedList;
+    foreach (QModelIndex index, indices) {
+        QModelIndex indexSource = mapToSource(index);
+        translatedList.append(indexSource);
+    }
+    if (m_pTrackModel) {
+        m_pTrackModel->cutTracks(translatedList);
+    }
+}
+
 void ProxyTrackModel::copyTracks(const QModelIndexList& indices) const {
     QModelIndexList translatedList;
     foreach (QModelIndex index, indices) {
@@ -137,6 +148,18 @@ void ProxyTrackModel::copyTracks(const QModelIndexList& indices) const {
     if (m_pTrackModel) {
         m_pTrackModel->copyTracks(translatedList);
     }
+}
+
+QList<int> ProxyTrackModel::pasteTracks(const QModelIndex& index) {
+    QList<int> translatedList;
+    if (m_pTrackModel) {
+        QList<int> rowIndices = m_pTrackModel->pasteTracks(mapToSource(index));
+        foreach (int row, rowIndices) {
+            QModelIndex indexProxy = mapFromSource(sourceModel()->index(row, 0));
+            translatedList.append(indexProxy.row());
+        }
+    }
+    return translatedList;
 }
 
 void ProxyTrackModel::moveTrack(const QModelIndex& sourceIndex,

--- a/src/library/proxytrackmodel.h
+++ b/src/library/proxytrackmodel.h
@@ -38,7 +38,9 @@ class ProxyTrackModel : public QSortFilterProxyModel, public TrackModel {
     bool isColumnInternal(int column) final;
     bool isColumnHiddenByDefault(int column) final;
     void removeTracks(const QModelIndexList& indices) final;
+    void cutTracks(const QModelIndexList& indices) final;
     void copyTracks(const QModelIndexList& indices) const final;
+    QList<int> pasteTracks(const QModelIndex& index) final;
     void moveTrack(const QModelIndex& sourceIndex, const QModelIndex& destIndex) final;
     QAbstractItemDelegate* delegateForColumn(const int i, QObject* pParent) final;
     QString getModelSetting(const QString& name) final;

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -39,6 +39,20 @@ const ConfigKey kVScrollBarPosConfigKey{
         QStringLiteral("[Library]"),
         QStringLiteral("VScrollBarPos")};
 
+QModelIndex calculateCutIndex(const QModelIndex& currentIndex,
+        const QModelIndexList& removedIndices) {
+    if (removedIndices.empty()) {
+        return QModelIndex();
+    }
+    const int row = currentIndex.row();
+    int rowAfterRemove = row;
+    for (const auto& removeIndex : removedIndices) {
+        if (removeIndex.row() < row) {
+            rowAfterRemove--;
+        }
+    }
+    return currentIndex.siblingAtRow(rowAfterRemove);
+}
 } // anonymous namespace
 
 WTrackTableView::WTrackTableView(QWidget* pParent,
@@ -509,9 +523,9 @@ void WTrackTableView::slotPurge() {
     if (indices.isEmpty()) {
         return;
     }
-    saveCurrentIndex();
+    const QModelIndex newIndex = calculateCutIndex(currentIndex(), indices);
     pTrackModel->purgeTracks(indices);
-    restoreCurrentIndex();
+    setCurrentIndex(newIndex);
 }
 
 void WTrackTableView::slotDeleteTracksFromDisk() {
@@ -534,9 +548,9 @@ void WTrackTableView::slotUnhide() {
     if (indices.isEmpty()) {
         return;
     }
-    saveCurrentIndex();
+    const QModelIndex newIndex = calculateCutIndex(currentIndex(), indices);
     pTrackModel->unhideTracks(indices);
-    restoreCurrentIndex();
+    setCurrentIndex(newIndex);
 }
 
 void WTrackTableView::slotShowHideTrackMenu(bool show) {
@@ -957,23 +971,6 @@ TrackModel* WTrackTableView::getTrackModel() const {
     return pTrackModel;
 }
 
-namespace {
-QModelIndex calculateCutIndex(const QModelIndex& currentIndex,
-        const QModelIndexList& removedIndices) {
-    if (removedIndices.empty()) {
-        return QModelIndex();
-    }
-    const int row = currentIndex.row();
-    int rowAfterRemove = row;
-    for (const auto& removeIndex : removedIndices) {
-        if (removeIndex.row() < row) {
-            rowAfterRemove--;
-        }
-    }
-    return currentIndex.siblingAtRow(rowAfterRemove);
-}
-} // namespace
-
 void WTrackTableView::removeSelectedTracks() {
     const QModelIndexList indices = getSelectedRows();
     const QModelIndex newIndex = calculateCutIndex(currentIndex(), indices);
@@ -994,14 +991,14 @@ void WTrackTableView::copySelectedTracks() {
 }
 
 void WTrackTableView::pasteTracks(const QModelIndex& index) {
-    TrackModel* trackModel = getTrackModel();
-    if (!trackModel) {
+    TrackModel* pTrackModel = getTrackModel();
+    if (!pTrackModel) {
         return;
     }
 
     const auto prevIdx = currentIndex();
 
-    const QList<int> rows = trackModel->pasteTracks(index);
+    const QList<int> rows = pTrackModel->pasteTracks(index);
     if (rows.empty()) {
         return;
     }
@@ -1433,7 +1430,7 @@ void WTrackTableView::hideOrRemoveSelectedTracks() {
         }
     }
 
-    saveCurrentIndex();
+    auto newIndex = calculateCutIndex(currentIndex(), indices);
 
     if (cap == TrackModel::Capability::Hide) {
         pTrackModel->hideTracks(indices);
@@ -1441,7 +1438,7 @@ void WTrackTableView::hideOrRemoveSelectedTracks() {
         pTrackModel->removeTracks(indices);
     }
 
-    restoreCurrentIndex();
+    setCurrentIndex(newIndex);
 }
 
 /// If applicable, requests that the selected field/item be edited


### PR DESCRIPTION
The search feature for the Auto DJ view  was originally disabled by 54f71ea7b8e5d6e87ad9132bcf7fdfe2a7c8372a over 12 years ago.

We now have some new tools available, which means we can implement a workaround instead of disabling search altogether. Searching within normal playlists is already possible and works correctly, and the Auto DJ queue is basically just another playlist, so being able to search there matches user expectations.

The implementation here reuses the `ProxyTrackModel` code already used by the file browser view for the actual filtering behavior (4970e30b0fd67ff3d2094bb080ec2ff749ef3701). Most of the changes here are for making `BaseSqlTableModel` play nicely with `ProxyTrackModel` (75ce4d0a48d672249100bbaa9da7c00959575f09), for making cut, copy & paste work (62c3a0f0435121e0ebbdc800ca1f6c657fa72a39) and behave correctly w.r.t. keyboard focus (35569a49f71955256cb8f514be2ef25f9de94b4f).