### PR TITLE
Midi input table fixes

### DIFF
--- a/src/controllers/controllerinputmappingtablemodel.cpp
+++ b/src/controllers/controllerinputmappingtablemodel.cpp
@@ -221,7 +221,7 @@ QVariant ControllerInputMappingTableModel::data(const QModelIndex& index,
                     const auto* const ppJSValue =
                             std::get_if<std::shared_ptr<QJSValue>>(
                                     &mapping.control);
-                    if (ppJSValue) {
+                    if (ppJSValue && *ppJSValue) {
                     return QVariant::fromValue((*ppJSValue)->toString());
                     }
                     return QVariant();

--- a/src/controllers/controllerinputmappingtablemodel.cpp
+++ b/src/controllers/controllerinputmappingtablemodel.cpp
@@ -204,7 +204,11 @@ QVariant ControllerInputMappingTableModel::data(const QModelIndex& index,
             case MIDI_COLUMN_OPCODE:
                 return MidiUtils::opCodeValue(MidiUtils::opCodeFromStatus(mapping.key.status));
             case MIDI_COLUMN_CONTROL:
+                if (MidiUtils::isMessageTwoBytes(mapping.key.status)) {
                 return mapping.key.control;
+                } else {
+                return QVariant();
+                }
             case MIDI_COLUMN_OPTIONS:
                 // UserRole is used for sorting.
                 if (role == Qt::UserRole) {

--- a/src/controllers/controllerinputmappingtablemodel.cpp
+++ b/src/controllers/controllerinputmappingtablemodel.cpp
@@ -198,16 +198,6 @@ QVariant ControllerInputMappingTableModel::data(const QModelIndex& index,
 
         const MidiInputMapping& mapping = m_midiInputMappings.at(row);
 
-        if (std::holds_alternative<std::shared_ptr<QJSValue>>(mapping.control)) {
-            return QVariant();
-        }
-
-        const auto* const control = std::get_if<ConfigKey>(&mapping.control);
-
-        VERIFY_OR_DEBUG_ASSERT(control != nullptr) {
-            return QVariant();
-        }
-
         switch (column) {
             case MIDI_COLUMN_CHANNEL:
                 return MidiUtils::channelFromStatus(mapping.key.status);
@@ -222,14 +212,24 @@ QVariant ControllerInputMappingTableModel::data(const QModelIndex& index,
                 }
                 return QVariant::fromValue(mapping.options);
             case MIDI_COLUMN_ACTION: {
+                const auto* const pControl = std::get_if<ConfigKey>(&mapping.control);
+                if (!pControl) {
+                    const auto* const ppJSValue =
+                            std::get_if<std::shared_ptr<QJSValue>>(
+                                    &mapping.control);
+                    if (ppJSValue) {
+                    return QVariant::fromValue((*ppJSValue)->toString());
+                    }
+                    return QVariant();
+                }
                 if (role == Qt::UserRole) { // sort by displaystring
                     QStyledItemDelegate* del = getDelegateForIndex(index);
                     VERIFY_OR_DEBUG_ASSERT(del) {
-                    return QString();
+                    return QVariant();
                     }
-                    return del->displayText(QVariant::fromValue(*control), QLocale());
+                    return del->displayText(QVariant::fromValue(*pControl), QLocale());
                 }
-                return QVariant::fromValue(*control);
+                return QVariant::fromValue(*pControl);
             }
             case MIDI_COLUMN_COMMENT:
                 return mapping.description;
@@ -272,13 +272,16 @@ QString ControllerInputMappingTableModel::getDisplayString(const QModelIndex& in
         VERIFY_OR_DEBUG_ASSERT(del) {
             return QString();
         }
+        QString displayText;
         // Return both the raw ConfigKey group + key and the translated display
         // string and the translated description from ControlPickerMenu.
         // Note: this may contain duplicate key strings in case this is an
         // untranslated script control
-        return data(index, Qt::UserRole).toString() + QStringLiteral(" ") +
-                del->displayText(
-                        QVariant::fromStdVariant(mapping.control), QLocale());
+        const auto* const pControl = std::get_if<ConfigKey>(&mapping.control);
+        if (pControl) {
+            displayText = pControl->group + QChar(',') + pControl->item + QChar(' ');
+        }
+        return displayText + data(index, Qt::UserRole).toString();
     }
     default:
         return QString();

--- a/src/controllers/delegates/controldelegate.cpp
+++ b/src/controllers/delegates/controldelegate.cpp
@@ -46,22 +46,24 @@ void ControlDelegate::paint(QPainter* painter,
 QString ControlDelegate::displayText(const QVariant& value,
                                      const QLocale& locale) const {
     Q_UNUSED(locale);
-    ConfigKey key = value.value<ConfigKey>();
+    if (value.canConvert<ConfigKey>()) {
+        ConfigKey key = value.value<ConfigKey>();
 
-    if (key.group.isEmpty() && key.item.isEmpty()) {
+        QString description = m_pPicker->descriptionForConfigKey(key);
+        if (!description.isEmpty()) {
+            return description;
+        }
+
+        if (m_bIsIndexScript || description.isEmpty()) {
+            return QString("%1: %2").arg(translateConfigKeyGroup(key.group), key.item);
+        }
+
+        return key.group + "," + key.item;
+    } else if (value.canConvert<QString>()) {
+        return value.value<QString>();
+    } else {
         return tr("No control chosen.");
     }
-
-    QString description = m_pPicker->descriptionForConfigKey(key);
-    if (!description.isEmpty()) {
-        return description;
-    }
-
-    if (m_bIsIndexScript || description.isEmpty()) {
-        return QString("%1: %2").arg(translateConfigKeyGroup(key.group), key.item);
-    }
-
-    return key.group + "," + key.item;
 }
 
 void ControlDelegate::setEditorData(QWidget* editor,

--- a/src/controllers/delegates/midibytedelegate.cpp
+++ b/src/controllers/delegates/midibytedelegate.cpp
@@ -16,9 +16,12 @@ QWidget* MidiByteDelegate::createEditor(QWidget* parent,
                                         const QModelIndex& index) const {
     Q_UNUSED(option);
     Q_UNUSED(index);
-    HexSpinBox* pSpinBox = new HexSpinBox(parent);
-    pSpinBox->setRange(0x00, 0x7F);
-    return pSpinBox;
+    if (!index.data(Qt::EditRole).isNull()) {
+        HexSpinBox* pSpinBox = new HexSpinBox(parent);
+        pSpinBox->setRange(0x00, 0x7F);
+        return pSpinBox;
+    }
+    return nullptr;
 }
 
 QString MidiByteDelegate::displayText(const QVariant& value,


### PR DESCRIPTION
This fixes searching for the untranslated connected control in the midi Intput mapping table and hides 0xFF as midi option in case of two byte messages.