### PR TITLE
Fix playlist parser warning with MSVC from VS2022

### DIFF
--- a/src/library/parsercsv.cpp
+++ b/src/library/parsercsv.cpp
@@ -67,8 +67,13 @@ QList<QString> ParserCsv::parseAllLocations(const QString& playlistFile) {
                 // and other rows might contain paths to existing files
                 locationColumnIndex = detect_location_column(tokens[1],
                         [&](auto i) {
-                            return (i.contains(QDir::separator()) || i.contains(QChar('/')));
+#ifdef Q_OS_WIN
+                            return (i.contains(QChar('\\')) || i.contains(QChar('/')));
                         });
+#else
+                            return i.contains(QChar('/'));
+                        });
+#endif
             }
             if (locationColumnIndex.has_value()) {
                 for (int row = 1; row < tokens.size(); ++row) {

--- a/src/library/parsercsv.cpp
+++ b/src/library/parsercsv.cpp
@@ -48,7 +48,7 @@ QList<QString> ParserCsv::parseAllLocations(const QString& playlistFile) {
                         auto predicate) -> std::optional<std::size_t> {
             const auto it = std::find_if(std::begin(tokens_list), std::end(tokens_list), predicate);
             return (it != std::end(tokens_list))
-                    ? std::distance(std::begin(tokens_list), it)
+                    ? static_cast<std::size_t>(std::distance(std::begin(tokens_list), it))
                     : std::optional<std::size_t>{};
         };
         if (!tokens.isEmpty()) {
@@ -63,8 +63,12 @@ QList<QString> ParserCsv::parseAllLocations(const QString& playlistFile) {
             }
             if (locationColumnIndex.has_value()) {
                 for (int row = 1; row < tokens.size(); ++row) {
-                    if (locationColumnIndex < tokens[row].size()) {
-                        locations.append(tokens[row][static_cast<int>(*locationColumnIndex)]);
+                    if (locationColumnIndex.has_value() &&
+                            locationColumnIndex.value() <
+                                    static_cast<std::size_t>(
+                                            tokens[row].size())) {
+                        locations.append(tokens[row][static_cast<int>(
+                                locationColumnIndex.value())]);
                     }
                 }
             } else {

--- a/src/test/playlisttest.cpp
+++ b/src/test/playlisttest.cpp
@@ -25,6 +25,55 @@ class DummyParser : public Parser {
 
 class PlaylistTest : public testing::Test {};
 
+TEST_F(PlaylistTest, IsPlaylistFilenameSupported) {
+    EXPECT_TRUE(ParserCsv::isPlaylistFilenameSupported("test.csv"));
+    EXPECT_FALSE(ParserCsv::isPlaylistFilenameSupported("test.mp3"));
+}
+
+TEST_F(PlaylistTest, ParseAllLocations) {
+    QTemporaryFile csvFile;
+    ASSERT_TRUE(csvFile.open());
+    csvFile.write("Location,OtherData\n");
+    csvFile.write("/path/to/file1,/other/data\n");
+    csvFile.write("/path/to/file2,/other/data\n");
+    csvFile.close();
+
+    QList<QString> locations = ParserCsv::parseAllLocations(csvFile.fileName());
+
+    EXPECT_EQ(locations.size(), 2);
+    EXPECT_EQ(locations[0], "/path/to/file1");
+    EXPECT_EQ(locations[1], "/path/to/file2");
+}
+
+TEST_F(PlaylistTest, ParseEmptyFile) {
+    QTemporaryFile csvFile;
+    ASSERT_TRUE(csvFile.open());
+    csvFile.close();
+
+    const QList<QString> entries = ParserCsv().parseAllLocations(csvFile.fileName());
+
+    // Check that the entries list is empty
+    EXPECT_TRUE(entries.isEmpty());
+}
+
+TEST_F(PlaylistTest, ParseWithLocationColumn) {
+    QTemporaryFile csvFile;
+    ASSERT_TRUE(csvFile.open());
+    csvFile.write("#,Location\n");
+    csvFile.write("1,/path/to/file1\n");
+    csvFile.write("2,/path/to/file2\n");
+    csvFile.close();
+
+    const QList<QString> entries = ParserCsv().parseAllLocations(csvFile.fileName());
+
+    // Check the size of the entries list
+    EXPECT_EQ(entries.size(), 2);
+
+    // Check the contents of the entries list
+    EXPECT_EQ(entries[0], "/path/to/file1");
+    EXPECT_EQ(entries[1], "/path/to/file2");
+}
+
 TEST_F(PlaylistTest, Normalize) {
     DummyParser parser;
 


### PR DESCRIPTION
This PR improves the test coverage of the csv parser used for playlists and fixes the following MSVC warnings:
```
  [412/982] Building CXX object CMakeFiles\mixxx-lib.dir\src\library\parsercsv.cpp.obj
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.40.33807\include\optional(864): warning C4018: '<': signed/unsigned mismatch
  C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.40.33807\include\optional(864): note: the template instantiation context (the oldest one first) is
  D:\mixxx-main-worktree\src\library\parsercsv.cpp(66): note: see reference to function template instantiation 'bool std::operator <<unsigned __int64,qsizetype,0>(const std::optional<unsigned __int64> &,const _Ty2 &) noexcept(<expr>)' being compiled
          with
          [
              _Ty2=qsizetype
          ]
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.40.33807\include\optional(866): warning C4018: '<': signed/unsigned mismatch
  C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.40.33807\include\optional(866): note: the template instantiation context (the oldest one first) is
  D:\mixxx-main-worktree\src\library\parsercsv.cpp(66): note: see reference to function template instantiation 'bool std::operator <<unsigned __int64,qsizetype,0>(const std::optional<unsigned __int64> &,const _Ty2 &) noexcept' being compiled
          with
          [
              _Ty2=qsizetype
          ]
```
Note, that this warning doesn't occur with 2.4 builds.

While extending the test cases, I noticed, that Windows and Unixes behave different in the case, that the location column is not named "Location"

I therefore enhanced the logic for detecting the location column in CSV files. Instead of looking only for the \ path separator on Windows, we now look for the also allowed / too.