### PR TITLE
Fix missing template parameter in specialization

### DIFF
--- a/src/control/controlvalue.h
+++ b/src/control/controlvalue.h
@@ -123,8 +123,8 @@ class ControlValueAtomicBase {
 // Specialized template for types that are deemed to be atomic on the target
 // architecture. Instead of using a read/write ring to guarantee atomicity,
 // direct assignment/read of an aligned member variable is used.
-template <typename T>
-class ControlValueAtomicBase<T, true> {
+template<typename T, int cRingSize>
+class ControlValueAtomicBase<T, cRingSize, true> {
   public:
     inline T getValue() const {
         return m_value;


### PR DESCRIPTION
This is a regression since c236956884e3c7b9a47536f98eb7eb5a126a26e4 merged into 2.3 which prevents to use the fast ControlValueAtomicBase specialization.