### PR TITLE
Optimize BPMDelegate::paintItem

### DIFF
--- a/src/library/tabledelegates/bpmdelegate.cpp
+++ b/src/library/tabledelegates/bpmdelegate.cpp
@@ -108,7 +108,9 @@ void BPMDelegate::paintItem(QPainter* painter,const QStyleOptionViewItem &option
             textColor = option.palette.color(QPalette::Normal, QPalette::Text);
         }
     }
-    if (textColor.isValid()) {
+
+    if (textColor.isValid() && textColor != m_cachedTextColor) {
+        m_cachedTextColor = textColor;
         m_pCheckBox->setStyleSheet(QStringLiteral(
                 "#LibraryBPMButton::item { color: %1; }")
                                            .arg(textColor.name(QColor::HexRgb)));

--- a/src/library/tabledelegates/bpmdelegate.h
+++ b/src/library/tabledelegates/bpmdelegate.h
@@ -17,4 +17,5 @@ class BPMDelegate : public TableItemDelegate {
   private:
     QCheckBox* m_pCheckBox;
     QItemEditorFactory* m_pFactory;
+    mutable QColor m_cachedTextColor;
 };


### PR DESCRIPTION
Execute expensive setStleSheet only, if textcolor of BPM checkbox(padlock) changed.
This change shows a significiant performance gain in the profiler during library scrolling - but that's unfortunately not enough to solve #11603 alone.