### PR TITLE
localDateTimeFromUtc: Make argument a const reference and initialize QDateTime at construction

### DIFF
--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -790,6 +790,9 @@ QVariant BaseTrackTableModel::roleValue(
             VERIFY_OR_DEBUG_ASSERT(rawValue.canConvert<QDateTime>()) {
                 return QVariant();
             }
+            // TODO: This is a hot code path, executed very often while library scrolling,
+            // and localDateTimeFromUtc is time consuming, probably because,
+            // we pass around QDateTime with a wrong time zone set
             QDateTime dt = mixxx::localDateTimeFromUtc(rawValue.toDateTime());
             if (role == Qt::ToolTipRole || role == kDataExportRole) {
                 // localized text date: "Wednesday, May 20, 1998 03:40:13 AM CEST"
@@ -820,6 +823,9 @@ QVariant BaseTrackTableModel::roleValue(
                 return QVariant();
             }
             DEBUG_ASSERT(lastPlayedAt.timeSpec() == Qt::UTC);
+            // TODO: This is a hot code path, executed very often while library scrolling,
+            // and localDateTimeFromUtc is time consuming, probably because,
+            // we pass around QDateTime with a wrong time zone set
             QDateTime dt = mixxx::localDateTimeFromUtc(lastPlayedAt);
             if (role == Qt::ToolTipRole || role == kDataExportRole) {
                 return dt;

--- a/src/util/datetime.h
+++ b/src/util/datetime.h
@@ -12,9 +12,8 @@ namespace mixxx {
 
 /// Obtain the local date time from an UTC date time.
 inline QDateTime localDateTimeFromUtc(
-        QDateTime dt) {
-    dt.setTimeSpec(Qt::UTC);
-    return dt.toLocalTime();
+        const QDateTime& dt) {
+    return QDateTime(dt.date(), dt.time(), Qt::UTC).toLocalTime();
 }
 
 /// Extract a QDateTime from a QVariant.


### PR DESCRIPTION
This shows a small but measureable improvement in the profiler.