### PR TITLE
close open dialogs on exit (DlgAbout, DlgTrackInfo, DlgTagFetcher)

### DIFF
--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -1260,6 +1260,17 @@ bool MixxxMainWindow::confirmExit() {
         }
     }
 
+    // Some dialogs like DlgTrackInfo, DlgTagFetcher and DlgAbout are
+    // constructed without parent to avoid inheriting their parents' stylesheets.
+    // Though, this way (if they're still visible) they also block destrcution
+    // the main widget and thereby block shutdown.
+    // Just close them.
+    for (auto* pWid : QApplication::topLevelWidgets()) {
+        if (pWid->isVisible() && qobject_cast<QDialog*>(pWid)) {
+            pWid->close();
+        }
+    }
+
     return true;
 }
 


### PR DESCRIPTION
Being construted without parent they prevent shutdown.

Should we instead warn that there may be pending changes, like we do for the preferences?