### PR TITLE
(fix) Library: repair Del hotkey in sidebar, add Clear Queue action to AutoDJ, add hotkeys

### DIFF
--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -94,6 +94,11 @@ AutoDJFeature::AutoDJFeature(Library* pLibrary,
             this,
             &AutoDJFeature::slotCrateChanged);
 
+    m_pClearQueueAction = make_parented<QAction>(tr("Clear Auto DJ Queue"), this);
+    connect(m_pClearQueueAction.get(),
+            &QAction::triggered,
+            this,
+            &AutoDJFeature::slotClearQueue);
     // Create context-menu items to allow crates to be added to, and removed
     // from, the auto-DJ queue.
     m_pRemoveCrateFromAutoDjAction =
@@ -164,7 +169,15 @@ void AutoDJFeature::activate() {
 }
 
 void AutoDJFeature::clear() {
-    m_playlistDao.clearAutoDJQueue();
+    QMessageBox::StandardButton btn = QMessageBox::question(nullptr,
+            tr("Confirmation Clear"),
+            tr("Do you really want to remove all tracks from the Auto DJ queue?") +
+                    tr("This can not be undone."),
+            QMessageBox::Yes | QMessageBox::No,
+            QMessageBox::No);
+    if (btn == QMessageBox::Yes) {
+            m_playlistDao.clearAutoDJQueue();
+    }
 }
 
 void AutoDJFeature::paste() {
@@ -190,6 +203,10 @@ bool AutoDJFeature::dropAccept(const QList<QUrl>& urls, QObject* pSource) {
 bool AutoDJFeature::dragMoveAccept(const QUrl& url) {
     return SoundSourceProxy::isUrlSupported(url) ||
             Parser::isPlaylistFilenameSupported(url.toLocalFile());
+}
+
+void AutoDJFeature::slotClearQueue() {
+    clear();
 }
 
 // Add a crate to the auto-DJ queue.
@@ -292,6 +309,12 @@ void AutoDJFeature::constructCrateChildModel() {
         m_pCratesTreeItem->appendChild(crate.getName(), crate.getId().toVariant());
         m_crateList.append(crate);
     }
+}
+
+void AutoDJFeature::onRightClick(const QPoint& globalPos) {
+    QMenu menu(m_pSidebarWidget);
+    menu.addAction(m_pClearQueueAction.get());
+    menu.exec(globalPos);
 }
 
 void AutoDJFeature::onRightClickChild(const QPoint& globalPos,

--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -96,15 +96,15 @@ AutoDJFeature::AutoDJFeature(Library* pLibrary,
 
     // Create context-menu items to allow crates to be added to, and removed
     // from, the auto-DJ queue.
-    m_pRemoveCrateFromAutoDj = new QAction(tr("Remove Crate as Track Source"), this);
-    connect(m_pRemoveCrateFromAutoDj,
+    m_pRemoveCrateFromAutoDjAction =
+            make_parented<QAction>(tr("Remove Crate as Track Source"), this);
+    connect(m_pRemoveCrateFromAutoDjAction.get(),
             &QAction::triggered,
             this,
             &AutoDJFeature::slotRemoveCrateFromAutoDj);
 }
 
 AutoDJFeature::~AutoDJFeature() {
-    delete m_pRemoveCrateFromAutoDj;
     delete m_pAutoDJProcessor;
 }
 
@@ -198,7 +198,7 @@ void AutoDJFeature::slotAddCrateToAutoDj(CrateId crateId) {
 }
 
 void AutoDJFeature::slotRemoveCrateFromAutoDj() {
-    CrateId crateId(m_pRemoveCrateFromAutoDj->data());
+    CrateId crateId(m_pRemoveCrateFromAutoDjAction->data());
     DEBUG_ASSERT(crateId.isValid());
     m_pTrackCollection->updateAutoDjCrate(crateId, false);
 }
@@ -319,8 +319,8 @@ void AutoDJFeature::onRightClickChild(const QPoint& globalPos,
     } else {
         // A crate child item was right-clicked.
         // Bring up the context menu.
-        m_pRemoveCrateFromAutoDj->setData(pClickedItem->getData()); // the selected CrateId
-        menu.addAction(m_pRemoveCrateFromAutoDj);
+        m_pRemoveCrateFromAutoDjAction->setData(pClickedItem->getData()); // the selected CrateId
+        menu.addAction(m_pRemoveCrateFromAutoDjAction);
         menu.exec(globalPos);
     }
 }

--- a/src/library/autodj/autodjfeature.h
+++ b/src/library/autodj/autodjfeature.h
@@ -80,22 +80,18 @@ class AutoDJFeature : public LibraryFeature {
 
     // A context-menu item that allows crates to be removed from the
     // auto-DJ list.
-    QAction* m_pRemoveCrateFromAutoDj;
+    parented_ptr<QAction> m_pRemoveCrateFromAutoDjAction;
 
     QPointer<WLibrarySidebar> m_pSidebarWidget;
 
   private slots:
     // Add a crate to the auto-DJ queue.
     void slotAddCrateToAutoDj(CrateId crateId);
-
     // Implements the context-menu item.
     void slotRemoveCrateFromAutoDj();
-
     void slotCrateChanged(CrateId crateId);
-
     // Adds a random track from all loaded crates to the auto-DJ queue.
     void slotAddRandomTrack();
-
     // Adds a random track from the queue upon hitting minimum number
     // of tracks in the playlist
     void slotRandomQueue(int numTracksToAdd);

--- a/src/library/autodj/autodjfeature.h
+++ b/src/library/autodj/autodjfeature.h
@@ -34,6 +34,7 @@ class AutoDJFeature : public LibraryFeature {
 
     void clear() override;
     void paste() override;
+    void deleteItem(const QModelIndex& index) override;
 
     bool dropAccept(const QList<QUrl>& urls, QObject* pSource) override;
     bool dragMoveAccept(const QUrl& url) override;
@@ -67,6 +68,7 @@ class AutoDJFeature : public LibraryFeature {
 
     // Initialize the list of crates loaded into the auto-DJ queue.
     void constructCrateChildModel();
+    void removeCrateFromAutoDj(CrateId crateId = CrateId());
 
     // The "Crates" tree-item under the "Auto DJ" tree-item.
     TreeItem* m_pCratesTreeItem;

--- a/src/library/autodj/autodjfeature.h
+++ b/src/library/autodj/autodjfeature.h
@@ -51,6 +51,7 @@ class AutoDJFeature : public LibraryFeature {
   public slots:
     void activate() override;
 
+    void onRightClick(const QPoint& globalPos) override;
     // Temporary, until WCrateTableView can be written.
     void onRightClickChild(const QPoint& globalPos, const QModelIndex& index) override;
 
@@ -78,6 +79,7 @@ class AutoDJFeature : public LibraryFeature {
     // How we access the auto-DJ-crates database.
     AutoDJCratesDAO m_autoDjCratesDao;
 
+    parented_ptr<QAction> m_pClearQueueAction;
     // A context-menu item that allows crates to be removed from the
     // auto-DJ list.
     parented_ptr<QAction> m_pRemoveCrateFromAutoDjAction;
@@ -85,6 +87,7 @@ class AutoDJFeature : public LibraryFeature {
     QPointer<WLibrarySidebar> m_pSidebarWidget;
 
   private slots:
+    void slotClearQueue();
     // Add a crate to the auto-DJ queue.
     void slotAddCrateToAutoDj(CrateId crateId);
     // Implements the context-menu item.

--- a/src/library/sidebarmodel.cpp
+++ b/src/library/sidebarmodel.cpp
@@ -405,7 +405,8 @@ void SidebarModel::deleteItem(const QModelIndex& index) {
     }
 
     if (index.internalPointer() == this) {
-        // can't delete root features
+        // Used only to call AutoDJFeature::clear()
+        m_sFeatures[index.row()]->clear();
         return;
     } else {
         TreeItem* pTreeItem = static_cast<TreeItem*>(index.internalPointer());

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -240,17 +240,10 @@ void WLibrarySidebar::keyPressEvent(QKeyEvent* event) {
     // item is not focused, require second press to perform the desired action.
 
     SidebarModel* sidebarModel = qobject_cast<SidebarModel*>(model());
-    QModelIndexList selectedIndices = selectionModel()->selectedRows();
-    if (sidebarModel && !selectedIndices.isEmpty()) {
-        QModelIndex index = selectedIndices.at(0);
-        if (event->matches(QKeySequence::Delete) || event->key() == Qt::Key_Backspace) {
-            sidebarModel->clear(index);
-            return;
-        }
-        if (event->matches(QKeySequence::Paste)) {
-            sidebarModel->paste(index);
-            return;
-        }
+    QModelIndex selIndex = selectedIndex();
+    if (sidebarModel && selIndex.isValid() && event->matches(QKeySequence::Paste)) {
+        sidebarModel->paste(selIndex);
+        return;
     }
 
     focusSelectedIndex();


### PR DESCRIPTION
Fixes #13361 

1. restore Del hotkey (delete playlist / crate)
2. to not drop the 'clear' function I added a 'Clear Queue' menu action to the AutoDJ root view incl. a confirmatio dialog
3. show Del hotkey in AutoDJ -> Clear and 'Remove crate/playlist' actions

Alternatively, we pick only the fix for 2.5 and the new action goes to 2.6