### PR TITLE
CMakeLists: Work around Qt shader bug with Xcode

### DIFF
--- a/res/shaders/CMakeLists.txt
+++ b/res/shaders/CMakeLists.txt
@@ -3,3 +3,10 @@ qt_add_shaders(mixxx-lib "waveform_shaders"
   FILES
       "rgbsignal_qml.frag"
 )
+
+# Workaround for https://bugreports.qt.io/browse/QTBUG-118500 that can be
+# removed once Qt fixes the shader target generation for Xcode.
+# See also https://github.com/mixxxdj/mixxx/issues/13378
+if(CMAKE_GENERATOR STREQUAL "Xcode")
+  add_dependencies(mixxx-lib_resources_1 mixxx-lib_waveform_shaders)
+endif()


### PR DESCRIPTION
### Fixes #13378 

This fixes a CMake configuration issue when targeting Xcode (which is needed for iOS) using the [suggested workaround](https://bugreports.qt.io/browse/QTBUG-118500#comment-760580) until the corresponding [upstream Qt bug](https://bugreports.qt.io/browse/QTBUG-118500) is fixed.