### PR TITLE
Waveforms: Disable textured waveforms when using OpenGL ES

### DIFF
--- a/src/waveform/renderers/allshader/waveformrenderertextured.cpp
+++ b/src/waveform/renderers/allshader/waveformrenderertextured.cpp
@@ -1,5 +1,7 @@
 #include "waveform/renderers/allshader/waveformrenderertextured.h"
 
+#ifndef QT_OPENGL_ES_2
+
 #include <QOpenGLFramebufferObject>
 #include <QOpenGLShaderProgram>
 
@@ -531,3 +533,5 @@ void WaveformRendererTextured::paintGL() {
 }
 
 } // namespace allshader
+
+#endif // QT_OPENGL_ES_2

--- a/src/waveform/renderers/allshader/waveformrenderertextured.h
+++ b/src/waveform/renderers/allshader/waveformrenderertextured.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#ifndef QT_OPENGL_ES_2
+
 #include "shaders/rgbshader.h"
 #include "track/track_decl.h"
 #include "util/class.h"
@@ -65,3 +67,5 @@ class allshader::WaveformRendererTextured : public QObject,
     const QString m_pFragShader;
     std::unique_ptr<QOpenGLShaderProgram> m_frameShaderProgram;
 };
+
+#endif // QT_OPENGL_ES_2

--- a/src/waveform/widgets/allshader/waveformwidget.cpp
+++ b/src/waveform/widgets/allshader/waveformwidget.cpp
@@ -151,17 +151,26 @@ void WaveformWidget::leaveEvent(QEvent* pEvent) {
 /* static */
 WaveformRendererSignalBase::Options WaveformWidget::supportedOptions(
         WaveformWidgetType::Type type) {
+    WaveformRendererSignalBase::Options options = WaveformRendererSignalBase::Option::None;
     switch (type) {
     case WaveformWidgetType::Type::RGB:
-        return WaveformRendererSignalBase::Option::AllOptionsCombined;
+        options = WaveformRendererSignalBase::Option::AllOptionsCombined;
+        break;
     case WaveformWidgetType::Type::Filtered:
-        return WaveformRendererSignalBase::Option::HighDetail;
+        options = WaveformRendererSignalBase::Option::HighDetail;
+        break;
     case WaveformWidgetType::Type::Stacked:
-        return WaveformRendererSignalBase::Option::HighDetail;
+        options = WaveformRendererSignalBase::Option::HighDetail;
+        break;
     default:
         break;
     }
-    return WaveformRendererSignalBase::Option::None;
+#ifdef QT_OPENGL_ES_2
+    // High detail (textured) waveforms are not supported on OpenGL ES.
+    // See https://github.com/mixxxdj/mixxx/issues/13385
+    options &= ~WaveformRendererSignalBase::Options(WaveformRendererSignalBase::Option::HighDetail);
+#endif
+    return options;
 }
 
 /* static */

--- a/src/waveform/widgets/allshader/waveformwidget.cpp
+++ b/src/waveform/widgets/allshader/waveformwidget.cpp
@@ -65,27 +65,30 @@ allshader::WaveformRendererSignalBase*
 WaveformWidget::addWaveformSignalRenderer(WaveformWidgetType::Type type,
         WaveformRendererSignalBase::Options options,
         ::WaveformRendererAbstract::PositionSource positionSource) {
+#ifndef QT_OPENGL_ES_2
+    if (options & allshader::WaveformRendererSignalBase::Option::HighDetail) {
+        switch (type) {
+        case ::WaveformWidgetType::RGB:
+        case ::WaveformWidgetType::Filtered:
+        case ::WaveformWidgetType::Stacked:
+            return addRenderer<WaveformRendererTextured>(type, positionSource, options);
+        default:
+            break;
+        }
+    }
+#endif
+
     switch (type) {
     case ::WaveformWidgetType::Simple:
         return addRenderer<WaveformRendererSimple>();
     case ::WaveformWidgetType::RGB:
-        if (options & allshader::WaveformRendererSignalBase::Option::HighDetail) {
-            return addRenderer<WaveformRendererTextured>(type, positionSource, options);
-        }
         return addRenderer<WaveformRendererRGB>(positionSource, options);
     case ::WaveformWidgetType::HSV:
         return addRenderer<WaveformRendererHSV>();
     case ::WaveformWidgetType::Filtered:
-        if (options & allshader::WaveformRendererSignalBase::Option::HighDetail) {
-            return addRenderer<WaveformRendererTextured>(type, positionSource, options);
-        }
         return addRenderer<WaveformRendererFiltered>(false);
     case ::WaveformWidgetType::Stacked:
-        if (options & allshader::WaveformRendererSignalBase::Option::HighDetail) {
-            return addRenderer<WaveformRendererTextured>(type, positionSource, options);
-        } else {
-            return addRenderer<WaveformRendererFiltered>(true); // true for RGB Stacked
-        }
+        return addRenderer<WaveformRendererFiltered>(true); // true for RGB Stacked
     default:
         break;
     }


### PR DESCRIPTION
Fixes #13380 (potential future refactoring moved to #13385)

The textured waveform renderer seems to use some OpenGL APIs that are unavailable in GL ES (e.g. on iOS), therefore this PR cond-compiles out `WaveformRendererTextured` when `QT_OPENGL_ES_2` is set.