### PR TITLE
feat: static color coding for key column

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -984,6 +984,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/library/tabledelegates/bpmdelegate.cpp
   src/library/tabledelegates/colordelegate.cpp
   src/library/tabledelegates/coverartdelegate.cpp
+  src/library/tabledelegates/keydelegate.cpp
   src/library/tabledelegates/locationdelegate.cpp
   src/library/tabledelegates/multilineeditdelegate.cpp
   src/library/tabledelegates/playcountdelegate.cpp

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -904,10 +904,6 @@ QVariant BaseTrackTableModel::roleValue(
                 // Otherwise, just use the column value as is
                 return std::move(rawValue);
             }
-            // Convert or clear invalid values
-            VERIFY_OR_DEBUG_ASSERT(keyCodeValue.canConvert<int>()) {
-                return QVariant();
-            }
             bool ok;
             const auto keyCode = keyCodeValue.toInt(&ok);
             VERIFY_OR_DEBUG_ASSERT(ok) {

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -886,8 +886,7 @@ QVariant BaseTrackTableModel::roleValue(
         case ColumnCache::COLUMN_LIBRARYTABLE_KEY: {
             // If we know the semantic key via the LIBRARYTABLE_KEY_ID
             // column (as opposed to the string representation of the key
-            // currently stored in the DB) then lookup the key and render it
-            // using the user's selected notation.
+            // currently stored in the DB) then lookup the key and return it
             const QVariant keyCodeValue = rawSiblingValue(
                     index,
                     ColumnCache::COLUMN_LIBRARYTABLE_KEY_ID);
@@ -908,8 +907,7 @@ QVariant BaseTrackTableModel::roleValue(
             if (key == mixxx::track::io::key::INVALID) {
                 return QVariant();
             }
-            // Render the key with the user-provided notation
-            return KeyUtils::keyToString(key);
+            return QVariant::fromValue(key);
         }
         case ColumnCache::COLUMN_LIBRARYTABLE_REPLAYGAIN: {
             if (rawValue.isNull()) {

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -9,6 +9,7 @@
 #include "library/tabledelegates/bpmdelegate.h"
 #include "library/tabledelegates/colordelegate.h"
 #include "library/tabledelegates/coverartdelegate.h"
+#include "library/tabledelegates/keydelegate.h"
 #include "library/tabledelegates/locationdelegate.h"
 #include "library/tabledelegates/multilineeditdelegate.h"
 #include "library/tabledelegates/playcountdelegate.h"
@@ -121,7 +122,7 @@ void BaseTrackTableModel::setApplyPlayedTrackColor(bool apply) {
     s_bApplyPlayedTrackColor = apply;
 }
 
-//static
+// static
 QStringList BaseTrackTableModel::defaultTableColumns() {
     return kDefaultTableColumns;
 }
@@ -506,6 +507,8 @@ QAbstractItemDelegate* BaseTrackTableModel::delegateForColumn(
                 this,
                 &BaseTrackTableModel::slotRefreshCoverRows);
         return pCoverArtDelegate;
+    } else if (index == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_KEY)) {
+        return new KeyDelegate(pTableView);
     }
     return nullptr;
 }

--- a/src/library/basetracktablemodel.h
+++ b/src/library/basetracktablemodel.h
@@ -105,6 +105,9 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
     static constexpr int kBpmColumnPrecisionMaximum = 10;
     static void setBpmColumnPrecision(int precision);
 
+    static constexpr bool kKeyColorsEnabledDefault = true;
+    static void setKeyColorsEnabled(bool keyColorsEnabled);
+
     static constexpr bool kApplyPlayedTrackColorDefault = true;
     static void setApplyPlayedTrackColor(bool apply);
 
@@ -293,6 +296,7 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
     mutable QModelIndex m_toolTipIndex;
 
     static int s_bpmColumnPrecision;
+    static bool s_keyColorsEnabled;
 
     static bool s_bApplyPlayedTrackColor;
 };

--- a/src/library/tabledelegates/keydelegate.cpp
+++ b/src/library/tabledelegates/keydelegate.cpp
@@ -15,47 +15,45 @@ void KeyDelegate::paintItem(
 
     mixxx::track::io::key::ChromaticKey key =
             index.data().value<mixxx::track::io::key::ChromaticKey>();
-    // Get the key text with the user-provided notation
-    bool keyColorsEnabled = index.data(Qt::UserRole).value<bool>();
-    int rectWidth = 0; // only leave space for rect if it is rendered
-    if (keyColorsEnabled) {
-        const QColor keyColor = KeyUtils::keyToColor(key);
-        rectWidth = 8; // 4px width + 4px right padding
-        if (keyColor.isValid()) {
-            // Draw the colored rectangle next to the key label
-            painter->fillRect(
-                    option.rect.x(),
-                    option.rect.y() + 2,
-                    4, // width
-                    option.rect.height() - 4,
-                    keyColor);
+    if (key != mixxx::track::io::key::INVALID) {
+        // Display the key colors if enabled
+        bool keyColorsEnabled = index.data(Qt::UserRole).value<bool>();
+        if (keyColorsEnabled) {
+            const QColor keyColor = KeyUtils::keyToColor(key);
+            if (keyColor.isValid()) {
+                // Draw the colored rectangle next to the key label
+                painter->fillRect(
+                        option.rect.x(),
+                        option.rect.y() + 2,
+                        4, // width
+                        option.rect.height() - 4,
+                        keyColor);
+            }
         }
+
+        // Display the key text with the user-provided notation
+        int rectWidth = keyColorsEnabled ? 8 : 0; //  4px width + 4px right padding
+        const QString keyText = KeyUtils::keyToString(key);
+        QString elidedText = option.fontMetrics.elidedText(
+                keyText,
+                Qt::ElideLeft,
+                columnWidth(index) - rectWidth);
+
+        if (option.state & QStyle::State_Selected) {
+            // This uses selection-color from stylesheet for the text pen:
+            // #LibraryContainer QTableView {
+            //   selection-color: #fff;
+            // }
+            painter->setPen(QPen(option.palette.highlightedText().color()));
+        }
+
+        painter->drawText(option.rect.x() + rectWidth,
+                option.rect.y(),
+                option.rect.width() - rectWidth,
+                option.rect.height(),
+                Qt::AlignVCenter,
+                elidedText);
     }
-
-    QString keyText = KeyUtils::keyToString(key);
-    if (QString("INVALID").compare(keyText) == 0) { // if the key is invalid, display empty string
-        keyText.clear();
-    }
-
-    QString elidedText = option.fontMetrics.elidedText(
-            keyText,
-            Qt::ElideLeft,
-            columnWidth(index) - rectWidth);
-
-    if (option.state & QStyle::State_Selected) {
-        // This uses selection-color from stylesheet for the text pen:
-        // #LibraryContainer QTableView {
-        //   selection-color: #fff;
-        // }
-        painter->setPen(QPen(option.palette.highlightedText().color()));
-    }
-
-    painter->drawText(option.rect.x() + rectWidth,
-            option.rect.y(),
-            option.rect.width() - rectWidth,
-            option.rect.height(),
-            Qt::AlignVCenter,
-            elidedText);
 
     // Draw a border if the key cell has focus
     if (option.state & QStyle::State_HasFocus) {

--- a/src/library/tabledelegates/keydelegate.cpp
+++ b/src/library/tabledelegates/keydelegate.cpp
@@ -19,31 +19,41 @@ void KeyDelegate::paintItem(
         QPainter* painter,
         const QStyleOptionViewItem& option,
         const QModelIndex& index) const {
+    paintItemBackground(painter, option, index);
+
     QString keyText = index.data().toString();
     mixxx::track::io::key::ChromaticKey key = KeyUtils::guessKeyFromText(keyText);
     int openKeyNumber = KeyUtils::keyToOpenKeyNumber(key);
 
     if (openKeyNumber != 0) {
-        // Open Key numbers start from 1
-        const auto color =
+        const auto rgbColor =
                 mixxx::PredefinedColorPalettes::kDefaultKeyColorPalette.at(
-                        openKeyNumber - 1);
+                        openKeyNumber - 1); // Open Key numbers start from 1
+        const auto qcolor = mixxx::RgbColor::toQColor(rgbColor);
 
-        // this code is from the ColorDelegate, using it temporarily for testing.
-        if (color) {
-            painter->fillRect(option.rect, mixxx::RgbColor::toQColor(color));
-        } else {
-            // Filter out track color that is hidden
-            if (option.state & QStyle::State_Selected) {
-                painter->fillRect(option.rect, option.palette.highlight());
-            }
-        }
-
-        // Draw a border if the color cell has focus
-        if (option.state & QStyle::State_HasFocus) {
-            drawBorder(painter, m_focusBorderColor, option.rect);
-        }
+        // Draw the colored rectangle next to the key label
+        painter->fillRect(
+                option.rect.x() + 2,
+                option.rect.y() + 2,
+                4, // width
+                option.rect.height() - 4,
+                qcolor);
     }
 
-    // QStyledItemDelegate::paint(painter, option, index);
+    QString elidedText = option.fontMetrics.elidedText(
+            index.data().toString(),
+            Qt::ElideLeft,
+            columnWidth(index) - 8); // Subtracting total width of the rectangle
+
+    painter->drawText(option.rect.x() + 8,
+            option.rect.y(),
+            option.rect.width() - 8,
+            option.rect.height(),
+            Qt::AlignVCenter,
+            elidedText);
+
+    // Draw a border if the key cell has focus
+    if (option.state & QStyle::State_HasFocus) {
+        drawBorder(painter, m_focusBorderColor, option.rect);
+    }
 }

--- a/src/library/tabledelegates/keydelegate.cpp
+++ b/src/library/tabledelegates/keydelegate.cpp
@@ -1,7 +1,5 @@
 #include "library/tabledelegates/keydelegate.h"
 
-#include <qnamespace.h>
-
 #include <QPainter>
 #include <QStyle>
 #include <QTableView>
@@ -10,10 +8,6 @@
 #include "track/keyutils.h"
 #include "util/color/predefinedcolorpalettes.h"
 #include "util/color/rgbcolor.h"
-
-KeyDelegate::KeyDelegate(QTableView* pTableView)
-        : TableItemDelegate(pTableView) {
-}
 
 void KeyDelegate::paintItem(
         QPainter* painter,

--- a/src/library/tabledelegates/keydelegate.cpp
+++ b/src/library/tabledelegates/keydelegate.cpp
@@ -41,6 +41,14 @@ void KeyDelegate::paintItem(
             Qt::ElideLeft,
             columnWidth(index) - rectWidth);
 
+    if (option.state & QStyle::State_Selected) {
+        // This uses selection-color from stylesheet for the text pen:
+        // #LibraryContainer QTableView {
+        //   selection-color: #fff;
+        // }
+        painter->setPen(QPen(option.palette.highlightedText().color()));
+    }
+
     painter->drawText(option.rect.x() + rectWidth,
             option.rect.y(),
             option.rect.width() - rectWidth,

--- a/src/library/tabledelegates/keydelegate.cpp
+++ b/src/library/tabledelegates/keydelegate.cpp
@@ -40,14 +40,16 @@ void KeyDelegate::paintItem(
                 qcolor);
     }
 
+    const int rectWidth = 10; // 2px left padding + 4px width + 4px right padding
+
     QString elidedText = option.fontMetrics.elidedText(
             index.data().toString(),
             Qt::ElideLeft,
-            columnWidth(index) - 8); // Subtracting total width of the rectangle
+            columnWidth(index) - rectWidth);
 
-    painter->drawText(option.rect.x() + 8,
+    painter->drawText(option.rect.x() + rectWidth,
             option.rect.y(),
-            option.rect.width() - 8,
+            option.rect.width() - rectWidth,
             option.rect.height(),
             Qt::AlignVCenter,
             elidedText);

--- a/src/library/tabledelegates/keydelegate.cpp
+++ b/src/library/tabledelegates/keydelegate.cpp
@@ -32,7 +32,11 @@ void KeyDelegate::paintItem(
         }
     }
 
-    const QString keyText = KeyUtils::keyToString(key);
+    QString keyText = KeyUtils::keyToString(key);
+    if (QString("INVALID").compare(keyText) == 0) { // if the key is invalid, display empty string
+        keyText.clear();
+    }
+
     QString elidedText = option.fontMetrics.elidedText(
             keyText,
             Qt::ElideLeft,

--- a/src/library/tabledelegates/keydelegate.cpp
+++ b/src/library/tabledelegates/keydelegate.cpp
@@ -1,0 +1,37 @@
+#include "library/tabledelegates/keydelegate.h"
+
+#include <qnamespace.h>
+
+#include <QPainter>
+#include <QStyle>
+#include <QTableView>
+
+#include "moc_keydelegate.cpp"
+#include "util/color/rgbcolor.h"
+
+KeyDelegate::KeyDelegate(QTableView* pTableView)
+        : TableItemDelegate(pTableView) {
+}
+
+void KeyDelegate::paintItem(
+        QPainter* painter,
+        const QStyleOptionViewItem& option,
+        const QModelIndex& index) const {
+    const auto color = mixxx::RgbColor::fromQVariant(index.data());
+
+    if (color) {
+        painter->fillRect(option.rect, mixxx::RgbColor::toQColor(color));
+    } else {
+        // Filter out track color that is hidden
+        if (option.state & QStyle::State_Selected) {
+            painter->fillRect(option.rect, option.palette.highlight());
+        }
+    }
+
+    // Draw a border if the color cell has focus
+    if (option.state & QStyle::State_HasFocus) {
+        drawBorder(painter, m_focusBorderColor, option.rect);
+    }
+
+    // QStyledItemDelegate::paint(painter, option, index);
+}

--- a/src/library/tabledelegates/keydelegate.cpp
+++ b/src/library/tabledelegates/keydelegate.cpp
@@ -17,19 +17,21 @@ void KeyDelegate::paintItem(
             index.data().value<mixxx::track::io::key::ChromaticKey>();
     // Get the key text with the user-provided notation
     QString keyText = KeyUtils::keyToString(key);
-    QColor keyColor = KeyUtils::keyToColor(key);
-
-    if (keyColor.isValid()) {
-        // Draw the colored rectangle next to the key label
-        painter->fillRect(
-                option.rect.x(),
-                option.rect.y() + 2,
-                4, // width
-                option.rect.height() - 4,
-                keyColor);
+    bool keyColorsEnabled = index.data(Qt::UserRole).value<bool>();
+    int rectWidth = 0; // only leave space for rect if it is rendered
+    if (keyColorsEnabled) {
+        QColor keyColor = KeyUtils::keyToColor(key);
+        rectWidth = 8; // 4px width + 4px right padding
+        if (keyColor.isValid()) {
+            // Draw the colored rectangle next to the key label
+            painter->fillRect(
+                    option.rect.x(),
+                    option.rect.y() + 2,
+                    4, // width
+                    option.rect.height() - 4,
+                    keyColor);
+        }
     }
-
-    const int rectWidth = 8; // 4px width + 4px right padding
 
     QString elidedText = option.fontMetrics.elidedText(
             keyText,

--- a/src/library/tabledelegates/keydelegate.cpp
+++ b/src/library/tabledelegates/keydelegate.cpp
@@ -13,9 +13,11 @@ void KeyDelegate::paintItem(
         const QModelIndex& index) const {
     paintItemBackground(painter, option, index);
 
-    QString keyText = index.data().toString();
-    mixxx::track::io::key::ChromaticKey key = KeyUtils::guessKeyFromText(keyText);
-    const auto keyColor = KeyUtils::keyToColor(key);
+    mixxx::track::io::key::ChromaticKey key =
+            index.data().value<mixxx::track::io::key::ChromaticKey>();
+    // Get the key text with the user-provided notation
+    QString keyText = KeyUtils::keyToString(key);
+    QColor keyColor = KeyUtils::keyToColor(key);
 
     if (keyColor.isValid()) {
         // Draw the colored rectangle next to the key label
@@ -30,7 +32,7 @@ void KeyDelegate::paintItem(
     const int rectWidth = 8; // 4px width + 4px right padding
 
     QString elidedText = option.fontMetrics.elidedText(
-            index.data().toString(),
+            keyText,
             Qt::ElideLeft,
             columnWidth(index) - rectWidth);
 

--- a/src/library/tabledelegates/keydelegate.cpp
+++ b/src/library/tabledelegates/keydelegate.cpp
@@ -6,8 +6,6 @@
 
 #include "moc_keydelegate.cpp"
 #include "track/keyutils.h"
-#include "util/color/predefinedcolorpalettes.h"
-#include "util/color/rgbcolor.h"
 
 void KeyDelegate::paintItem(
         QPainter* painter,
@@ -17,21 +15,16 @@ void KeyDelegate::paintItem(
 
     QString keyText = index.data().toString();
     mixxx::track::io::key::ChromaticKey key = KeyUtils::guessKeyFromText(keyText);
-    int openKeyNumber = KeyUtils::keyToOpenKeyNumber(key);
+    const auto keyColor = KeyUtils::keyToColor(key);
 
-    if (openKeyNumber != 0) {
-        const auto rgbColor =
-                mixxx::PredefinedColorPalettes::kDefaultKeyColorPalette.at(
-                        openKeyNumber - 1); // Open Key numbers start from 1
-        const auto qcolor = mixxx::RgbColor::toQColor(rgbColor);
-
+    if (keyColor.isValid()) {
         // Draw the colored rectangle next to the key label
         painter->fillRect(
                 option.rect.x() + 2,
                 option.rect.y() + 2,
                 4, // width
                 option.rect.height() - 4,
-                qcolor);
+                keyColor);
     }
 
     const int rectWidth = 10; // 2px left padding + 4px width + 4px right padding

--- a/src/library/tabledelegates/keydelegate.cpp
+++ b/src/library/tabledelegates/keydelegate.cpp
@@ -16,11 +16,10 @@ void KeyDelegate::paintItem(
     mixxx::track::io::key::ChromaticKey key =
             index.data().value<mixxx::track::io::key::ChromaticKey>();
     // Get the key text with the user-provided notation
-    QString keyText = KeyUtils::keyToString(key);
     bool keyColorsEnabled = index.data(Qt::UserRole).value<bool>();
     int rectWidth = 0; // only leave space for rect if it is rendered
     if (keyColorsEnabled) {
-        QColor keyColor = KeyUtils::keyToColor(key);
+        const QColor keyColor = KeyUtils::keyToColor(key);
         rectWidth = 8; // 4px width + 4px right padding
         if (keyColor.isValid()) {
             // Draw the colored rectangle next to the key label
@@ -33,6 +32,7 @@ void KeyDelegate::paintItem(
         }
     }
 
+    const QString keyText = KeyUtils::keyToString(key);
     QString elidedText = option.fontMetrics.elidedText(
             keyText,
             Qt::ElideLeft,

--- a/src/library/tabledelegates/keydelegate.cpp
+++ b/src/library/tabledelegates/keydelegate.cpp
@@ -20,14 +20,14 @@ void KeyDelegate::paintItem(
     if (keyColor.isValid()) {
         // Draw the colored rectangle next to the key label
         painter->fillRect(
-                option.rect.x() + 2,
+                option.rect.x(),
                 option.rect.y() + 2,
                 4, // width
                 option.rect.height() - 4,
                 keyColor);
     }
 
-    const int rectWidth = 10; // 2px left padding + 4px width + 4px right padding
+    const int rectWidth = 8; // 4px width + 4px right padding
 
     QString elidedText = option.fontMetrics.elidedText(
             index.data().toString(),

--- a/src/library/tabledelegates/keydelegate.h
+++ b/src/library/tabledelegates/keydelegate.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <QObject>
+
 #include "library/tabledelegates/tableitemdelegate.h"
 
 class QModelIndex;
@@ -9,7 +11,9 @@ class QStyleOptionViewItem;
 class KeyDelegate : public TableItemDelegate {
     Q_OBJECT
   public:
-    explicit KeyDelegate(QTableView* pTableView);
+    explicit KeyDelegate(QTableView* pTableView)
+            : TableItemDelegate(pTableView) {
+    }
 
     void paintItem(
             QPainter* painter,

--- a/src/library/tabledelegates/keydelegate.h
+++ b/src/library/tabledelegates/keydelegate.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "library/tabledelegates/tableitemdelegate.h"
+
+class QModelIndex;
+class QPainter;
+class QStyleOptionViewItem;
+
+class KeyDelegate : public TableItemDelegate {
+    Q_OBJECT
+  public:
+    explicit KeyDelegate(QTableView* pTableView);
+
+    void paintItem(
+            QPainter* painter,
+            const QStyleOptionViewItem& option,
+            const QModelIndex& index) const override;
+};

--- a/src/preferences/colorpalettesettings.h
+++ b/src/preferences/colorpalettesettings.h
@@ -3,8 +3,6 @@
 #include "preferences/usersettings.h"
 #include "util/color/colorpalette.h"
 
-#define KEY_COLORS_ENABLED "KeyColorsEnabled"
-
 // Saves ColorPalettes to and loads ColorPalettes from the mixxx.cfg file
 class ColorPaletteSettings {
   public:
@@ -27,7 +25,7 @@ class ColorPaletteSettings {
     void removePalette(const QString& name);
     QSet<QString> getColorPaletteNames() const;
 
-    DEFINE_PREFERENCE_HELPERS(KeyColorsEnabled, bool, "[Config]", KEY_COLORS_ENABLED, true);
+    DEFINE_PREFERENCE_HELPERS(KeyColorsEnabled, bool, "[Config]", "KeyColorsEnabled", true);
 
   private:
     UserSettingsPointer m_pConfig;

--- a/src/preferences/colorpalettesettings.h
+++ b/src/preferences/colorpalettesettings.h
@@ -3,6 +3,8 @@
 #include "preferences/usersettings.h"
 #include "util/color/colorpalette.h"
 
+#define KEY_COLORS_ENABLED "KeyColorsEnabled"
+
 // Saves ColorPalettes to and loads ColorPalettes from the mixxx.cfg file
 class ColorPaletteSettings {
   public:
@@ -24,6 +26,8 @@ class ColorPaletteSettings {
     void setColorPalette(const QString& name, const ColorPalette& colorPalette);
     void removePalette(const QString& name);
     QSet<QString> getColorPaletteNames() const;
+
+    DEFINE_PREFERENCE_HELPERS(KeyColorsEnabled, bool, "[Config]", KEY_COLORS_ENABLED, true);
 
   private:
     UserSettingsPointer m_pConfig;

--- a/src/preferences/dialog/dlgprefcolors.cpp
+++ b/src/preferences/dialog/dlgprefcolors.cpp
@@ -66,6 +66,11 @@ DlgPrefColors::DlgPrefColors(
             this,
             &DlgPrefColors::slotReplaceCueColorClicked);
 
+    connect(bKeyColorsEnabled,
+            &QCheckBox::stateChanged,
+            this,
+            &DlgPrefColors::slotKeyColorsEnabled);
+
     setScrollSafeGuardForAllInputWidgets(this);
 
     slotUpdate();
@@ -77,6 +82,7 @@ DlgPrefColors::~DlgPrefColors() {
 void DlgPrefColors::slotUpdate() {
     comboBoxHotcueColors->clear();
     comboBoxTrackColors->clear();
+    bKeyColorsEnabled->setChecked(m_bKeyColorsEnabled);
     for (const auto& palette : std::as_const(mixxx::PredefinedColorPalettes::kPalettes)) {
         QString paletteName = palette.getName();
         QIcon paletteIcon = drawPalettePreview(paletteName);
@@ -343,6 +349,11 @@ void DlgPrefColors::slotEditTrackPaletteClicked() {
 void DlgPrefColors::slotEditHotcuePaletteClicked() {
     QString hotcueColorPaletteName = comboBoxHotcueColors->currentText();
     openColorPaletteEditor(hotcueColorPaletteName, true);
+}
+
+void DlgPrefColors::slotKeyColorsEnabled(int i) {
+    m_bKeyColorsEnabled = static_cast<bool>(i);
+    slotUpdate();
 }
 
 void DlgPrefColors::openColorPaletteEditor(

--- a/src/preferences/dialog/dlgprefcolors.cpp
+++ b/src/preferences/dialog/dlgprefcolors.cpp
@@ -5,6 +5,7 @@
 #include <QTableView>
 
 #include "dialog/dlgreplacecuecolor.h"
+#include "library/basetracktablemodel.h"
 #include "library/library.h"
 #include "library/trackcollection.h"
 #include "moc_dlgprefcolors.cpp"
@@ -21,6 +22,7 @@ const ConfigKey kAutoHotcueColorsConfigKey("[Controls]", "auto_hotcue_colors");
 const ConfigKey kAutoLoopColorsConfigKey("[Controls]", "auto_loop_colors");
 const ConfigKey kHotcueDefaultColorIndexConfigKey("[Controls]", "HotcueDefaultColorIndex");
 const ConfigKey kLoopDefaultColorIndexConfigKey("[Controls]", "LoopDefaultColorIndex");
+const ConfigKey kKeyColorsEnabledConfigKey("[Config]", "KeyColorsEnabled");
 
 } // anonymous namespace
 
@@ -167,6 +169,7 @@ void DlgPrefColors::slotResetToDefaults() {
             mixxx::PredefinedColorPalettes::kDefaultTrackColorPalette.size());
     comboBoxLoopDefaultColor->setCurrentIndex(
             mixxx::PredefinedColorPalettes::kDefaultTrackColorPalette.size() - 1);
+    bKeyColorsEnabled->setChecked(BaseTrackTableModel::kKeyColorsEnabledDefault);
 }
 
 // Apply and save any changes made in the dialog
@@ -221,6 +224,8 @@ void DlgPrefColors::slotApply() {
         m_pConfig->setValue(kAutoLoopColorsConfigKey, true);
         m_pConfig->setValue(kLoopDefaultColorIndexConfigKey, -1);
     }
+
+    m_pConfig->setValue(kKeyColorsEnabledConfigKey, bKeyColorsEnabled->checkState());
 }
 
 void DlgPrefColors::slotReplaceCueColorClicked() {
@@ -353,6 +358,7 @@ void DlgPrefColors::slotEditHotcuePaletteClicked() {
 
 void DlgPrefColors::slotKeyColorsEnabled(int i) {
     m_bKeyColorsEnabled = static_cast<bool>(i);
+    BaseTrackTableModel::setKeyColorsEnabled(m_bKeyColorsEnabled);
     slotUpdate();
 }
 

--- a/src/preferences/dialog/dlgprefcolors.cpp
+++ b/src/preferences/dialog/dlgprefcolors.cpp
@@ -68,7 +68,7 @@ DlgPrefColors::DlgPrefColors(
             this,
             &DlgPrefColors::slotReplaceCueColorClicked);
 
-    connect(bKeyColorsEnabled,
+    connect(checkboxKeyColorsEnabled,
             &QCheckBox::stateChanged,
             this,
             &DlgPrefColors::slotKeyColorsEnabled);
@@ -84,7 +84,7 @@ DlgPrefColors::~DlgPrefColors() {
 void DlgPrefColors::slotUpdate() {
     comboBoxHotcueColors->clear();
     comboBoxTrackColors->clear();
-    bKeyColorsEnabled->setChecked(
+    checkboxKeyColorsEnabled->setChecked(
             m_pConfig->getValue(kKeyColorsEnabledConfigKey,
                     BaseTrackTableModel::kKeyColorsEnabledDefault));
     for (const auto& palette : std::as_const(mixxx::PredefinedColorPalettes::kPalettes)) {
@@ -171,7 +171,7 @@ void DlgPrefColors::slotResetToDefaults() {
             mixxx::PredefinedColorPalettes::kDefaultTrackColorPalette.size());
     comboBoxLoopDefaultColor->setCurrentIndex(
             mixxx::PredefinedColorPalettes::kDefaultTrackColorPalette.size() - 1);
-    bKeyColorsEnabled->setChecked(BaseTrackTableModel::kKeyColorsEnabledDefault);
+    checkboxKeyColorsEnabled->setChecked(BaseTrackTableModel::kKeyColorsEnabledDefault);
 }
 
 // Apply and save any changes made in the dialog
@@ -227,7 +227,7 @@ void DlgPrefColors::slotApply() {
         m_pConfig->setValue(kLoopDefaultColorIndexConfigKey, -1);
     }
 
-    m_pConfig->setValue(kKeyColorsEnabledConfigKey, bKeyColorsEnabled->checkState());
+    m_pConfig->setValue(kKeyColorsEnabledConfigKey, checkboxKeyColorsEnabled->checkState());
 }
 
 void DlgPrefColors::slotReplaceCueColorClicked() {
@@ -361,7 +361,7 @@ void DlgPrefColors::slotEditHotcuePaletteClicked() {
 void DlgPrefColors::slotKeyColorsEnabled(int i) {
     m_bKeyColorsEnabled = static_cast<bool>(i);
     BaseTrackTableModel::setKeyColorsEnabled(m_bKeyColorsEnabled);
-    m_pConfig->setValue(kKeyColorsEnabledConfigKey, bKeyColorsEnabled->checkState());
+    m_pConfig->setValue(kKeyColorsEnabledConfigKey, checkboxKeyColorsEnabled->checkState());
 }
 
 void DlgPrefColors::openColorPaletteEditor(

--- a/src/preferences/dialog/dlgprefcolors.cpp
+++ b/src/preferences/dialog/dlgprefcolors.cpp
@@ -362,7 +362,6 @@ void DlgPrefColors::slotKeyColorsEnabled(int i) {
     m_bKeyColorsEnabled = static_cast<bool>(i);
     BaseTrackTableModel::setKeyColorsEnabled(m_bKeyColorsEnabled);
     m_pConfig->setValue(kKeyColorsEnabledConfigKey, bKeyColorsEnabled->checkState());
-    slotUpdate();
 }
 
 void DlgPrefColors::openColorPaletteEditor(

--- a/src/preferences/dialog/dlgprefcolors.cpp
+++ b/src/preferences/dialog/dlgprefcolors.cpp
@@ -84,7 +84,9 @@ DlgPrefColors::~DlgPrefColors() {
 void DlgPrefColors::slotUpdate() {
     comboBoxHotcueColors->clear();
     comboBoxTrackColors->clear();
-    bKeyColorsEnabled->setChecked(m_bKeyColorsEnabled);
+    bKeyColorsEnabled->setChecked(
+            m_pConfig->getValue(kKeyColorsEnabledConfigKey,
+                    BaseTrackTableModel::kKeyColorsEnabledDefault));
     for (const auto& palette : std::as_const(mixxx::PredefinedColorPalettes::kPalettes)) {
         QString paletteName = palette.getName();
         QIcon paletteIcon = drawPalettePreview(paletteName);
@@ -359,6 +361,7 @@ void DlgPrefColors::slotEditHotcuePaletteClicked() {
 void DlgPrefColors::slotKeyColorsEnabled(int i) {
     m_bKeyColorsEnabled = static_cast<bool>(i);
     BaseTrackTableModel::setKeyColorsEnabled(m_bKeyColorsEnabled);
+    m_pConfig->setValue(kKeyColorsEnabledConfigKey, bKeyColorsEnabled->checkState());
     slotUpdate();
 }
 

--- a/src/preferences/dialog/dlgprefcolors.h
+++ b/src/preferences/dialog/dlgprefcolors.h
@@ -39,6 +39,7 @@ class DlgPrefColors : public DlgPreferencePage, public Ui::DlgPrefColorsDlg {
     void slotReplaceCueColorClicked();
     void slotEditTrackPaletteClicked();
     void slotEditHotcuePaletteClicked();
+    void slotKeyColorsEnabled(int i);
 
   private:
     void openColorPaletteEditor(
@@ -54,6 +55,7 @@ class DlgPrefColors : public DlgPreferencePage, public Ui::DlgPrefColorsDlg {
 
     const UserSettingsPointer m_pConfig;
     ColorPaletteSettings m_colorPaletteSettings;
+    bool m_bKeyColorsEnabled;
     // Pointer to color replace dialog
     DlgReplaceCueColor* m_pReplaceCueColorDlg;
 };

--- a/src/preferences/dialog/dlgprefcolorsdlg.ui
+++ b/src/preferences/dialog/dlgprefcolorsdlg.ui
@@ -101,7 +101,7 @@
     </item>
 
     <item row="4" column="0" colspan="2">
-     <widget class="QCheckBox" name="bKeyColorsEnabled">
+     <widget class="QCheckBox" name="checkboxKeyColorsEnabled">
       <property name="toolTip">
        <string>When key colors are enabled, Mixxx will display a color hint
 associated with each key.</string>
@@ -136,6 +136,7 @@ associated with each key.</string>
   <tabstop>pushButtonEditHotcuePalette</tabstop>
   <tabstop>comboBoxHotcueDefaultColor</tabstop>
   <tabstop>pushButtonReplaceCueColor</tabstop>
+  <tabstop>checkboxKeyColorsEnabled</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/preferences/dialog/dlgprefcolorsdlg.ui
+++ b/src/preferences/dialog/dlgprefcolorsdlg.ui
@@ -100,7 +100,19 @@
      <widget class="QComboBox" name="comboBoxLoopDefaultColor"/>
     </item>
 
-    <item row="4" column="0" colspan="2">
+   <item row="4" column="0">
+    <widget class="QCheckBox" name="bKeyColorsEnabled">
+     <property name="toolTip">
+      <string>When key colors are enabled, Mixxx will display a color hint
+associated with each key.</string>
+     </property>
+     <property name="text">
+      <string>Enable Key Colors</string>
+     </property>
+    </widget>
+   </item>
+
+    <item row="5" column="0" colspan="2">
      <spacer>
       <property name="orientation">
        <enum>Qt::Vertical</enum>

--- a/src/preferences/dialog/dlgprefcolorsdlg.ui
+++ b/src/preferences/dialog/dlgprefcolorsdlg.ui
@@ -100,17 +100,17 @@
      <widget class="QComboBox" name="comboBoxLoopDefaultColor"/>
     </item>
 
-   <item row="4" column="0">
-    <widget class="QCheckBox" name="bKeyColorsEnabled">
-     <property name="toolTip">
-      <string>When key colors are enabled, Mixxx will display a color hint
+    <item row="4" column="0" colspan="2">
+     <widget class="QCheckBox" name="bKeyColorsEnabled">
+      <property name="toolTip">
+       <string>When key colors are enabled, Mixxx will display a color hint
 associated with each key.</string>
-     </property>
-     <property name="text">
-      <string>Enable Key Colors</string>
-     </property>
-    </widget>
-   </item>
+      </property>
+      <property name="text">
+       <string>Enable Key Colors</string>
+      </property>
+     </widget>
+    </item>
 
     <item row="5" column="0" colspan="2">
      <spacer>

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -1577,6 +1577,12 @@ QWidget* LegacySkinParser::parseLibrary(const QDomElement& node) {
                     BaseTrackTableModel::kBpmColumnPrecisionDefault);
     BaseTrackTableModel::setBpmColumnPrecision(bpmColumnPrecision);
 
+    const auto keyColorsEnabled =
+            m_pConfig->getValue(
+                    ConfigKey("[Config]", "KeyColorsEnabled"),
+                    BaseTrackTableModel::kKeyColorsEnabledDefault);
+    BaseTrackTableModel::setKeyColorsEnabled(keyColorsEnabled);
+
     const auto applyPlayedTrackColor =
             m_pConfig->getValue(
                     mixxx::library::prefs::kApplyPlayedTrackColorConfigKey,

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -5,6 +5,8 @@
 #include <QRegularExpression>
 #include <QtDebug>
 
+#include "util/color/predefinedcolorpalettes.h"
+#include "util/color/rgbcolor.h"
 #include "util/compatibility/qmutex.h"
 
 using mixxx::track::io::key::ChromaticKey;
@@ -460,6 +462,20 @@ KeyUtils::KeyNotation KeyUtils::keyNotationFromNumericValue(double value) {
 // static
 double KeyUtils::keyToNumericValue(ChromaticKey key) {
     return key;
+}
+
+// static
+QColor KeyUtils::keyToColor(ChromaticKey key) {
+    int openKeyNumber = KeyUtils::keyToOpenKeyNumber(key);
+
+    if (openKeyNumber != 0) {
+        const auto& palette = mixxx::PredefinedColorPalettes::kDefaultKeyColorPalette;
+        DEBUG_ASSERT(openKeyNumber <= palette.size() && openKeyNumber >= 1);
+        const auto rgbColor = palette.at(openKeyNumber - 1); // Open Key numbers start from 1
+        return mixxx::RgbColor::toQColor(rgbColor);
+    } else {
+        return {}; // return invalid color
+    }
 }
 
 // static

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -466,7 +466,7 @@ double KeyUtils::keyToNumericValue(ChromaticKey key) {
 
 // static
 QColor KeyUtils::keyToColor(ChromaticKey key) {
-    int openKeyNumber = KeyUtils::keyToOpenKeyNumber(key);
+    int openKeyNumber = keyToOpenKeyNumber(key);
 
     if (openKeyNumber != 0) {
         const auto& palette = mixxx::PredefinedColorPalettes::kDefaultKeyColorPalette;

--- a/src/track/keyutils.h
+++ b/src/track/keyutils.h
@@ -68,6 +68,8 @@ class KeyUtils {
 
     static double keyToNumericValue(mixxx::track::io::key::ChromaticKey key);
 
+    static QColor keyToColor(mixxx::track::io::key::ChromaticKey key);
+
     static QPair<mixxx::track::io::key::ChromaticKey, double> scaleKeyOctaves(
         mixxx::track::io::key::ChromaticKey key, double scale);
 

--- a/src/util/color/predefinedcolorpalettes.cpp
+++ b/src/util/color/predefinedcolorpalettes.cpp
@@ -144,7 +144,7 @@ constexpr mixxx::RgbColor kVirtualDJTrackColorBlue(0x0000FF);
 constexpr mixxx::RgbColor kVirtualDJTrackColorFuchsia(0xFF00FF);
 constexpr mixxx::RgbColor kVirtualDJTrackColorWhite(0xFFFFFF);
 
-// Default Mixxx Key Color Palette
+// Default Mixxx Key Color Palette (obtained from Mixxx Keywheel)
 
 constexpr mixxx::RgbColor kMixxxKeyColor1(0xFC4949);
 constexpr mixxx::RgbColor kMixxxKeyColor2(0xFE642D);

--- a/src/util/color/predefinedcolorpalettes.cpp
+++ b/src/util/color/predefinedcolorpalettes.cpp
@@ -144,6 +144,21 @@ constexpr mixxx::RgbColor kVirtualDJTrackColorBlue(0x0000FF);
 constexpr mixxx::RgbColor kVirtualDJTrackColorFuchsia(0xFF00FF);
 constexpr mixxx::RgbColor kVirtualDJTrackColorWhite(0xFFFFFF);
 
+// Default Mixxx Key Color Palette
+
+constexpr mixxx::RgbColor kMixxxKeyColor1(0xFC4949);
+constexpr mixxx::RgbColor kMixxxKeyColor2(0xFE642D);
+constexpr mixxx::RgbColor kMixxxKeyColor3(0xF98C27);
+constexpr mixxx::RgbColor kMixxxKeyColor4(0xFED600);
+constexpr mixxx::RgbColor kMixxxKeyColor5(0x99FE00);
+constexpr mixxx::RgbColor kMixxxKeyColor6(0x42FE3E);
+constexpr mixxx::RgbColor kMixxxKeyColor7(0x0AD58F);
+constexpr mixxx::RgbColor kMixxxKeyColor8(0x0AE7E7);
+constexpr mixxx::RgbColor kMixxxKeyColor9(0x04C9FE);
+constexpr mixxx::RgbColor kMixxxKeyColor10(0x3D8AFD);
+constexpr mixxx::RgbColor kMixxxKeyColor11(0xAC64FE);
+constexpr mixxx::RgbColor kMixxxKeyColor12(0xFD3FEA);
+
 // Replaces "no color" values and is used for new cues if auto_hotcue_colors is
 // disabled
 constexpr mixxx::RgbColor kSchemaMigrationReplacementColor(0xFF8000);
@@ -357,11 +372,32 @@ const ColorPalette PredefinedColorPalettes::kVirtualDJTrackColorPalette =
                         kVirtualDJTrackColorWhite,
                 });
 
+const ColorPalette PredefinedColorPalettes::kMixxxKeyColorPalette =
+        ColorPalette(
+                QStringLiteral("Mixxx Key Colors"),
+                {
+                        kMixxxKeyColor1,
+                        kMixxxKeyColor2,
+                        kMixxxKeyColor3,
+                        kMixxxKeyColor4,
+                        kMixxxKeyColor5,
+                        kMixxxKeyColor6,
+                        kMixxxKeyColor7,
+                        kMixxxKeyColor8,
+                        kMixxxKeyColor9,
+                        kMixxxKeyColor10,
+                        kMixxxKeyColor11,
+                        kMixxxKeyColor12,
+                });
+
 const ColorPalette PredefinedColorPalettes::kDefaultHotcueColorPalette =
         mixxx::PredefinedColorPalettes::kMixxxHotcueColorPalette;
 
 const ColorPalette PredefinedColorPalettes::kDefaultTrackColorPalette =
         mixxx::PredefinedColorPalettes::kMixxxTrackColorPalette;
+
+const ColorPalette PredefinedColorPalettes::kDefaultKeyColorPalette =
+        mixxx::PredefinedColorPalettes::kMixxxKeyColorPalette;
 
 const QList<ColorPalette> PredefinedColorPalettes::kPalettes{
         // Hotcue Color Palettes
@@ -376,6 +412,8 @@ const QList<ColorPalette> PredefinedColorPalettes::kPalettes{
         mixxx::PredefinedColorPalettes::kSeratoDJProTrackColorPalette,
         mixxx::PredefinedColorPalettes::kTraktorProTrackColorPalette,
         mixxx::PredefinedColorPalettes::kVirtualDJTrackColorPalette,
+        // Key Color Palettes
+        mixxx::PredefinedColorPalettes::kMixxxKeyColorPalette,
 };
 
 const mixxx::RgbColor PredefinedColorPalettes::kDefaultCueColor =

--- a/src/util/color/predefinedcolorpalettes.h
+++ b/src/util/color/predefinedcolorpalettes.h
@@ -18,8 +18,11 @@ class PredefinedColorPalettes {
     static const ColorPalette kTraktorProTrackColorPalette;
     static const ColorPalette kVirtualDJTrackColorPalette;
 
+    static const ColorPalette kMixxxKeyColorPalette;
+
     static const ColorPalette kDefaultHotcueColorPalette;
     static const ColorPalette kDefaultTrackColorPalette;
+    static const ColorPalette kDefaultKeyColorPalette;
 
     static const QList<ColorPalette> kPalettes;
     static const mixxx::RgbColor kDefaultCueColor;


### PR DESCRIPTION
Hi! I just got the core of this feature working and I'm seeking feedback.

A small rectangle is drawn next to the Key label in the Library. The color of the rectangle is based on the Key of the track.

![image](https://github.com/mixxxdj/mixxx/assets/57069381/c4536a72-dcd4-47e6-a2e5-58f140b99f00)

---

I'm concerned about the method used for finding the track's key. Right now, I'm using `KeyUtils::guessKeyFromText` on the Key string, but I don't think that'll work if the user sets custom Key Notation. 

I want to use the value in [`ColumnCache::COLUMN_LIBRARYTABLE_KEY_ID`](https://github.com/danferns/mixxx/blob/7931a0756cd8fb00422806d685c7029530864f14/src/library/basetracktablemodel.cpp#L888). But I haven't been able to figure out how to access this column from the `QModelIndex& index` that is passed into `KeyDelegate::paintItem`. I'm not sure if the column is even available.

Is there a place where I can see how the index is structured?

---

Once complete, this will resolve #7810.