### PR TITLE
fix(engine-prime): build-failure

### DIFF
--- a/src/library/export/engineprimeexportjob.cpp
+++ b/src/library/export/engineprimeexportjob.cpp
@@ -378,6 +378,10 @@ EnginePrimeExportJob::EnginePrimeExportJob(
     }
 }
 
+// out-of-line declaration because we can't generate dtor in
+// header with unique_ptr's of incomplete types.
+EnginePrimeExportJob::~EnginePrimeExportJob() = default;
+
 void EnginePrimeExportJob::loadIds(const QSet<CrateId>& crateIds) {
     DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(m_pTrackCollectionManager);
 

--- a/src/library/export/engineprimeexportjob.h
+++ b/src/library/export/engineprimeexportjob.h
@@ -32,6 +32,8 @@ class EnginePrimeExportJob : public QThread {
             TrackCollectionManager* pTrackCollectionManager,
             QSharedPointer<EnginePrimeExportRequest> pRequest);
 
+    ~EnginePrimeExportJob() override;
+
     /// Run the export job.
     void run() override;
 


### PR DESCRIPTION
Explicitly instantiate default destructor in out-of-line (in .cpp) because destructing a `std::unique_ptr<Waveform>` needs `Waveform` to be complete at the point of destruction.