### PR TITLE
chore(ci): update azure code-signing action to renamed replacement

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -332,7 +332,7 @@ jobs:
         env:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
         if: runner.os == 'Windows' && env.AZURE_TENANT_ID
-        uses: azure/azure-code-signing-action@v0.3.0
+        uses: azure/trusted-signing-action@v0.3.20
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -387,7 +387,7 @@ jobs:
         env:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
         if: runner.os == 'Windows' && env.AZURE_TENANT_ID
-        uses: azure/azure-code-signing-action@v0.3.0
+        uses: azure/trusted-signing-action@v0.3.20
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}


### PR DESCRIPTION
The github action `azure/azure-code-signing-action` has been renamed to `azure/trusted-signing-action`. The former is being deleted on Jun 30th so this updates to the new name along with bumping the version to latest.

https://github.com/azure/azure-code-signing-action?tab=readme-ov-file

![deprecation notice from repo](https://github.com/mixxxdj/mixxx/assets/12380386/cd5d99a8-aad8-4588-8096-baaf2bcf07fd)
