### PR TITLE
Add minute markers on horizontal waveform overview

### DIFF
--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -49,6 +49,11 @@ DlgPrefWaveform::DlgPrefWaveform(
         defaultZoomComboBox->addItem(QString::number(100 / static_cast<double>(i), 'f', 1) + " %");
     }
 
+    m_pOverviewMinuteMarkersControl = std::make_unique<ControlObject>(
+            ConfigKey(QStringLiteral("[Waveform]"),
+                    QStringLiteral("DrawOverviewMinuteMarkers")));
+    m_pOverviewMinuteMarkersControl->setReadOnly();
+
     // Populate untilMark options
     untilMarkAlignComboBox->addItem(tr("Top"));
     untilMarkAlignComboBox->addItem(tr("Center"));
@@ -146,6 +151,10 @@ DlgPrefWaveform::DlgPrefWaveform(
             &QCheckBox::toggled,
             this,
             &DlgPrefWaveform::slotSetNormalizeOverview);
+    connect(overviewMinuteMarkersCheckBox,
+            &QCheckBox::toggled,
+            this,
+            &DlgPrefWaveform::slotSetOverviewMinuteMarkers);
     connect(factory,
             &WaveformWidgetFactory::waveformMeasured,
             this,
@@ -271,6 +280,11 @@ void DlgPrefWaveform::slotUpdate() {
     }
     slotSetWaveformOverviewType(overviewType);
 
+    bool drawOverviewMinuteMarkers = m_pConfig->getValue(
+            ConfigKey("[Waveform]", "DrawOverviewMinuteMarkers"), true);
+    overviewMinuteMarkersCheckBox->setChecked(drawOverviewMinuteMarkers);
+    m_pOverviewMinuteMarkersControl->forceSet(drawOverviewMinuteMarkers);
+
     WaveformSettings waveformSettings(m_pConfig);
     enableWaveformCaching->setChecked(waveformSettings.waveformCachingEnabled());
     enableWaveformGenerationWithAnalysis->setChecked(
@@ -328,6 +342,9 @@ void DlgPrefWaveform::slotResetToDefaults() {
 
     // Don't normalize overview.
     normalizeOverviewCheckBox->setChecked(false);
+
+    // Show minute markers.
+    overviewMinuteMarkersCheckBox->setChecked(true);
 
     // 60FPS is the default
     frameRateSlider->setValue(60);
@@ -531,6 +548,11 @@ void DlgPrefWaveform::slotSetVisualGainHigh(double gain) {
 
 void DlgPrefWaveform::slotSetNormalizeOverview(bool normalize) {
     WaveformWidgetFactory::instance()->setOverviewNormalized(normalize);
+}
+
+void DlgPrefWaveform::slotSetOverviewMinuteMarkers(bool draw) {
+    m_pConfig->setValue(ConfigKey("[Waveform]", "DrawOverviewMinuteMarkers"), draw);
+    m_pOverviewMinuteMarkersControl->forceSet(draw);
 }
 
 void DlgPrefWaveform::slotWaveformMeasured(float frameRate, int droppedFrames) {

--- a/src/preferences/dialog/dlgprefwaveform.h
+++ b/src/preferences/dialog/dlgprefwaveform.h
@@ -52,6 +52,7 @@ class DlgPrefWaveform : public DlgPreferencePage, public Ui::DlgPrefWaveformDlg 
     void slotSetVisualGainMid(double gain);
     void slotSetVisualGainHigh(double gain);
     void slotSetNormalizeOverview(bool normalize);
+    void slotSetOverviewMinuteMarkers(bool minuteMarkers);
     void slotWaveformMeasured(float frameRate, int droppedFrames);
     void slotClearCachedWaveforms();
     void slotSetBeatGridAlpha(int alpha);
@@ -73,6 +74,7 @@ class DlgPrefWaveform : public DlgPreferencePage, public Ui::DlgPrefWaveformDlg 
             WaveformWidgetType::Type type, WaveformWidgetBackend backend);
 
     std::unique_ptr<ControlObject> m_pTypeControl;
+    std::unique_ptr<ControlObject> m_pOverviewMinuteMarkersControl;
 
     UserSettingsPointer m_pConfig;
     std::shared_ptr<Library> m_pLibrary;

--- a/src/preferences/dialog/dlgprefwaveformdlg.ui
+++ b/src/preferences/dialog/dlgprefwaveformdlg.ui
@@ -76,7 +76,7 @@
        </property>
       </widget>
      </item>
-     <item row="19" column="1" colspan="3">
+     <item row="20" column="1" colspan="3">
       <layout class="QGridLayout" name="cachingGridLayout">
        <item row="4" column="0">
         <widget class="QPushButton" name="clearCachedWaveforms">
@@ -127,7 +127,7 @@
        </item>
       </layout>
      </item>
-     <item row="15" column="0">
+     <item row="16" column="0">
       <widget class="QLabel" name="untilMarkLabel">
        <property name="text">
         <string>Play marker hints</string>
@@ -137,7 +137,7 @@
        </property>
       </widget>
      </item>
-     <item row="21" column="0" colspan="4">
+     <item row="22" column="0" colspan="4">
       <widget class="QGroupBox" name="openGLStatus">
        <property name="title">
         <string>OpenGL status</string>
@@ -191,7 +191,7 @@
        </layout>
       </widget>
      </item>
-     <item row="19" column="0">
+     <item row="20" column="0">
       <widget class="QLabel" name="cachedWaveforms">
        <property name="text">
         <string>Caching</string>
@@ -221,7 +221,7 @@
        </property>
       </widget>
      </item>
-     <item row="14" column="0">
+     <item row="15" column="0">
       <widget class="QLabel" name="visualGainLabel">
        <property name="text">
         <string>Visual gain</string>
@@ -234,7 +234,7 @@
        </property>
       </widget>
      </item>
-     <item row="18" column="1" colspan="2">
+     <item row="19" column="1" colspan="2">
       <widget class="QLabel" name="requiresGLSLLabel">
        <property name="text">
         <string>This functionality requires waveform acceleration.</string>
@@ -244,7 +244,7 @@
        </property>
       </widget>
      </item>
-     <item row="20" column="1">
+     <item row="21" column="1">
       <spacer name="verticalSpacer">
        <property name="orientation">
         <enum>Qt::Vertical</enum>
@@ -295,7 +295,7 @@
        </property>
       </widget>
      </item>
-     <item row="15" column="3">
+     <item row="16" column="3">
       <widget class="QLabel" name="untilMarkTextPointSizeLabel">
        <property name="text">
         <string>Font size</string>
@@ -329,7 +329,7 @@ Select from different types of displays for the waveform overview, which differ 
        </property>
       </widget>
      </item>
-     <item row="16" column="1">
+     <item row="17" column="1">
       <widget class="QCheckBox" name="untilMarkShowTimeCheckBox">
        <property name="text">
         <string>Time until next marker</string>
@@ -355,14 +355,14 @@ Select from different types of displays for the waveform overview, which differ 
        </property>
       </widget>
      </item>
-     <item row="15" column="1">
+     <item row="16" column="1">
       <widget class="QCheckBox" name="untilMarkShowBeatsCheckBox">
        <property name="text">
         <string>Beats until next marker</string>
        </property>
       </widget>
      </item>
-     <item row="14" column="1" colspan="3">
+     <item row="15" column="1" colspan="3">
       <layout class="QGridLayout" name="gridLayout_3">
        <item row="1" column="2">
         <widget class="QDoubleSpinBox" name="midVisualGain">
@@ -578,7 +578,14 @@ Select from different types of displays for the waveform overview, which differ 
        </property>
       </widget>
      </item>
-     <item row="15" column="2">
+     <item row="14" column="1">
+      <widget class="QCheckBox" name="overviewMinuteMarkersCheckBox">
+       <property name="text">
+        <string>Show minute markers on waveform overview</string>
+       </property>
+      </widget>
+     </item>
+     <item row="16" column="2">
       <widget class="QLabel" name="untilMarkAlignLabel">
        <property name="text">
         <string>Placement</string>
@@ -591,7 +598,7 @@ Select from different types of displays for the waveform overview, which differ 
        </property>
       </widget>
      </item>
-     <item row="16" column="3">
+     <item row="17" column="3">
       <widget class="QSpinBox" name="untilMarkTextPointSizeSpinBox">
        <property name="toolTip">
         <string/>
@@ -620,7 +627,7 @@ Select from different types of displays for the waveform overview, which differ 
        </property>
       </widget>
      </item>
-     <item row="16" column="2">
+     <item row="17" column="2">
       <widget class="QComboBox" name="untilMarkAlignComboBox"/>
      </item>
      <item row="9" column="1" colspan="3">
@@ -725,6 +732,7 @@ Select from different types of displays for the waveform, which differ primarily
   <tabstop>defaultZoomComboBox</tabstop>
   <tabstop>synchronizeZoomCheckBox</tabstop>
   <tabstop>normalizeOverviewCheckBox</tabstop>
+  <tabstop>overviewMinuteMarkersCheckBox</tabstop>
   <tabstop>allVisualGain</tabstop>
   <tabstop>lowVisualGain</tabstop>
   <tabstop>midVisualGain</tabstop>

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -83,6 +83,13 @@ WOverview::WOverview(
     m_pTypeControl->connectValueChanged(this, &WOverview::slotTypeChanged);
     slotTypeChanged(m_pTypeControl->get());
 
+    m_pMinuteMarkersControl = make_parented<ControlProxy>(
+            QStringLiteral("[Waveform]"),
+            QStringLiteral("DrawOverviewMinuteMarkers"),
+            this);
+    m_pMinuteMarkersControl->connectValueChanged(this, &WOverview::slotMinuteMarkersChanged);
+    slotMinuteMarkersChanged(static_cast<bool>(m_pMinuteMarkersControl->get()));
+
     m_pPassthroughLabel = make_parented<QLabel>(this);
 
     setAcceptDrops(true);
@@ -414,6 +421,10 @@ void WOverview::slotTypeChanged(double v) {
     slotWaveformSummaryUpdated();
 }
 
+void WOverview::slotMinuteMarkersChanged(bool /*unused*/) {
+    update();
+}
+
 void WOverview::updateCues(const QList<CuePointer> &loadedCues) {
     for (const CuePointer& currentCue : loadedCues) {
         const WaveformMarkPointer pMark = m_marks.getHotCueMark(currentCue->getHotCue());
@@ -618,6 +629,7 @@ void WOverview::paintEvent(QPaintEvent* pEvent) {
         drawEndOfTrackBackground(&painter);
         drawAxis(&painter);
         drawWaveformPixmap(&painter);
+        drawMinuteMarkers(&painter);
         drawPlayedOverlay(&painter);
         drawPlayPosition(&painter);
         drawEndOfTrackFrame(&painter);
@@ -696,6 +708,45 @@ void WOverview::drawWaveformPixmap(QPainter* pPainter) {
         }
 
         pPainter->drawImage(rect(), m_waveformImageScaled);
+    }
+}
+
+void WOverview::drawMinuteMarkers(QPainter* pPainter) {
+    if (!m_trackLoaded) {
+        return;
+    }
+
+    if (!static_cast<bool>(m_pMinuteMarkersControl->get())) {
+        return;
+    }
+
+    // Faster than track->getDuration() and already has playback speed ratio compensated for
+    const double trackSeconds = samplePositionToSeconds(getTrackSamples());
+
+    QLineF line;
+    pPainter->setPen(QPen(m_axesColor, m_scaleFactor));
+    pPainter->setOpacity(1.0);
+
+    const double overviewHeight = height();
+    const double markerHeight = overviewHeight * 0.08;
+    const double lowerMarkerYPos = overviewHeight * 0.92;
+    double currentMarkerXPos;
+    for (double currentMarkerSeconds = 60; currentMarkerSeconds < trackSeconds;
+            currentMarkerSeconds += 60) {
+        currentMarkerXPos = currentMarkerSeconds / trackSeconds * width();
+
+        if (m_orientation == Qt::Horizontal) {
+            line.setLine(currentMarkerXPos, 0.0, currentMarkerXPos, markerHeight);
+            pPainter->drawLine(line);
+            line.setLine(currentMarkerXPos, lowerMarkerYPos, currentMarkerXPos, overviewHeight);
+            pPainter->drawLine(line);
+        } else {
+            // untested, best effort basis
+            line.setLine(0.0, currentMarkerXPos, markerHeight, currentMarkerXPos);
+            pPainter->drawLine(line);
+            line.setLine(lowerMarkerYPos, currentMarkerXPos, overviewHeight, currentMarkerXPos);
+            pPainter->drawLine(line);
+        }
     }
 }
 

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -727,13 +727,14 @@ void WOverview::drawMinuteMarkers(QPainter* pPainter) {
     pPainter->setPen(QPen(m_axesColor, m_scaleFactor));
     pPainter->setOpacity(1.0);
 
-    const double overviewHeight = height();
+    const double overviewHeight = m_orientation == Qt::Horizontal ? height() : width();
     const double markerHeight = overviewHeight * 0.08;
     const double lowerMarkerYPos = overviewHeight * 0.92;
     double currentMarkerXPos;
+    const int iWidth = m_orientation == Qt::Horizontal ? width() : height();
     for (double currentMarkerSeconds = 60; currentMarkerSeconds < trackSeconds;
             currentMarkerSeconds += 60) {
-        currentMarkerXPos = currentMarkerSeconds / trackSeconds * width();
+        currentMarkerXPos = currentMarkerSeconds / trackSeconds * iWidth;
 
         if (m_orientation == Qt::Horizontal) {
             line.setLine(currentMarkerXPos, 0.0, currentMarkerXPos, markerHeight);

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -67,6 +67,7 @@ class WOverview : public WWidget, public TrackDropTarget {
     void slotCueMenuPopupAboutToHide();
 
     void slotTypeChanged(double v);
+    void slotMinuteMarkersChanged(bool v);
 
   private:
     // Append the waveform overview pixmap according to available data
@@ -85,6 +86,7 @@ class WOverview : public WWidget, public TrackDropTarget {
     void drawEndOfTrackBackground(QPainter* pPainter);
     void drawAxis(QPainter* pPainter);
     void drawWaveformPixmap(QPainter* pPainter);
+    void drawMinuteMarkers(QPainter* pPainter);
     void drawPlayedOverlay(QPainter* pPainter);
     void drawPlayPosition(QPainter* pPainter);
     void drawEndOfTrackFrame(QPainter* pPainter);
@@ -181,6 +183,7 @@ class WOverview : public WWidget, public TrackDropTarget {
     parented_ptr<ControlProxy> m_playpositionControl;
     parented_ptr<ControlProxy> m_pPassthroughControl;
     parented_ptr<ControlProxy> m_pTypeControl;
+    parented_ptr<ControlProxy> m_pMinuteMarkersControl;
 
     QPointF m_timeRulerPos;
     WaveformMarkLabel m_timeRulerPositionLabel;


### PR DESCRIPTION
Some users would like a visual indication of minutes on the waveform overview.

There is a discourse thread here: https://mixxx.discourse.group/t/do-minute-markers-exist-in-this-software/27477

There is a bug about it #5843.

Without minute markers:

![image](https://github.com/mixxxdj/mixxx/assets/35075270/7f5e1700-da4b-4a87-86e9-630f3bb8bd9a)

With minute markers:

![image](https://github.com/mixxxdj/mixxx/assets/35075270/a1154986-2eff-4cf2-962e-b7fb800f925b)

An extra setting in the preferences dialog waveform section to control minute markers:

![image](https://github.com/mixxxdj/mixxx/assets/35075270/d01edf62-19bd-4d6d-87c8-a0f81300082a)

It defaults to off to maintain current Mixxx behaviour. There is no support for vertical waveform overviews - I don't know of a skin to use to write and test it with.
