### PR TITLE
feat(controllers): add controller settings for the Numark Scratch

### DIFF
--- a/res/controllers/Numark-Scratch-scripts.js
+++ b/res/controllers/Numark-Scratch-scripts.js
@@ -3,35 +3,34 @@ var NumarkScratch = {};
 
 /*
  * USER CONFIGURABLE SETTINGS.
+ * Change settings in the preferences
  */
 
 // Defines the Beatloop Roll sizes for the 4 pads, for available values see:
-// https://manual.mixxx.org/2.4/en/chapters/appendix/mixxx_controls.html#control-[ChannelN]-beatlooproll_X_activate
+// https://manual.mixxx.org/latest/en/chapters/appendix/mixxx_controls.html#control-[ChannelN]-beatlooproll_X_activate
 // Default: [0.25, 0.5, 1, 2]
 NumarkScratch.autoLoopSizes = [
-    "0.25",
-    "0.5",
-    "1",
-    "2",
+    engine.getSetting("beatLoopRollsSize1") || 0.25,
+    engine.getSetting("beatLoopRollsSize2") || 0.5,
+    engine.getSetting("beatLoopRollsSize3") || 1,
+    engine.getSetting("beatLoopRollsSize4") || 2,
 ];
 
 // Defines how the Loop Encoder functions.
 // If 'true' the Encoder scrolls the library/loads track. Shift + Encoder manages looping.
 // If 'false' the Encoder manages looping. Shift + Encoder scrolls the library/loads track (Serato default).
 // Default: false
-NumarkScratch.invertLoopEncoderFunction = false;
+NumarkScratch.invertLoopEncoderFunction = !!engine.getSetting("invertLoopEncoderFunction");
 
-// Defines the bightness of button LEDs when they inactive.
-// '0x00' sets the LEDSs to completely off. '0x01 sets the LEDs to dim.
-// Default: 0x01 (dim)
-NumarkScratch.LOW_LIGHT = 0x01;
+// Define whether or not to keep LEDs dimmed if they are inactive.
+// 0x01 ('true' in UI) will keep them dimmed, 0x00 ('false' in UI) will turn them off. Default: 0x01 ('true')
+NumarkScratch.noLight = 0x00;
+NumarkScratch.dimLight = 0x01;
+components.Button.prototype.off = engine.getSetting("inactiveLightsAlwaysBacklit") ? NumarkScratch.dimLight : NumarkScratch.noLight;
 
 /*
  * CODE
  */
-
-
-components.Button.prototype.off = NumarkScratch.LOW_LIGHT;
 
 NumarkScratch.init = function() {
     // Initialize component containers

--- a/res/controllers/Numark-Scratch.midi.xml
+++ b/res/controllers/Numark-Scratch.midi.xml
@@ -1,12 +1,102 @@
 <?xml version='1.0' encoding='utf-8'?>
-<MixxxControllerPreset schemaVersion="1" mixxxVersion="2.3.0+">
+<MixxxControllerPreset schemaVersion="1" mixxxVersion="2.5.0+">
   <info>
     <name>Numark Scratch</name>
     <author>Al Hadebe(NotYourAverageAl)</author>
     <description>Mapping for the Numark Scratch Mixer</description>
-    <forums>NumarkScratch</forums>
-    <manual>NumarkScratch</manual>
+    <forums>https://mixxx.discourse.group/t/numark-scratch-mapping/25186</forums>
+    <manual>https://manual.mixxx.org/latest/en/hardware/controllers/numark_scratch</manual>
   </info>
+  <settings>
+    <group label="Alternative Mapping">
+      <option
+        variable="invertLoopEncoderFunction"
+        type="boolean"
+        default="false"
+        label="Invert the Loop Encoder functionality">
+        <description>
+          By default the Encoder manages looping and Shift + Encoder scrolls the library/loads track.
+          If this option is selected the Encoder scrolls the library/loads track and Shift + Encoder manages looping.
+        </description>
+      </option>
+    </group>
+    <group label="Mixer Lighting">
+      <option
+        variable="inactiveLightsAlwaysBacklit"
+        type="boolean"
+        default="true"
+        label="Keep LEDs dimmed instead of off when inactive">
+        <description>
+          This will consistently ensure buttons are backlit, which can be helpful in low-light environments.
+          Please note the PAD MODE and CUE buttons are hardware controlled and always dim when inactive.
+        </description>
+      </option>
+    </group>
+    <group label="Beatloop Roll Size">
+      <row orientation="vertical">
+          <option
+              variable="beatLoopRollsSize1"
+              type="enum"
+              label="First Pad">
+              <value label="1/32">0.03125</value>
+              <value label="1/16">0.0625</value>
+              <value label="1/8">0.125</value>
+              <value label="1/4" default="true">0.25</value>
+              <value label="1/2">0.5</value>
+              <value label="1">1</value>
+              <value label="2">2</value>
+              <value label="4">4</value>
+              <value label="8">8</value>
+              <description>The first pad.</description>
+          </option>
+          <option
+              variable="beatLoopRollsSize2"
+              type="enum"
+              label="Second Pad">
+              <value label="1/32">0.03125</value>
+              <value label="1/16">0.0625</value>
+              <value label="1/8">0.125</value>
+              <value label="1/4">0.25</value>
+              <value label="1/2" default="true">0.5</value>
+              <value label="1">1</value>
+              <value label="2">2</value>
+              <value label="4">4</value>
+              <value label="8">8</value>
+              <description>The second pad.</description>
+          </option>
+          <option
+              variable="beatLoopRollsSize3"
+              type="enum"
+              label="Third Pad">
+              <value label="1/32">0.03125</value>
+              <value label="1/16">0.0625</value>
+              <value label="1/8">0.125</value>
+              <value label="1/4">0.25</value>
+              <value label="1/2">0.5</value>
+              <value label="1" default="true">1</value>
+              <value label="2">2</value>
+              <value label="4">4</value>
+              <value label="8">8</value>
+              <description>The third pad.</description>
+          </option>
+          <option
+              variable="beatLoopRollsSize4"
+              type="enum"
+              label="Fourth Pad">
+              <value label="1/32">0.03125</value>
+              <value label="1/16">0.0625</value>
+              <value label="1/8">0.125</value>
+              <value label="1/4">0.25</value>
+              <value label="1/2">0.5</value>
+              <value label="1">1</value>
+              <value label="2" default="true">2</value>
+              <value label="4">4</value>
+              <value label="8">8</value>
+              <description>The fourth pad.</description>
+          </option>
+      </row>
+  </group>
+  </settings>
   <controller id="Numark-Scratch">
     <scriptfiles>
       <file functionprefix="" filename="lodash.mixxx.js"/>


### PR DESCRIPTION
add controller settings for the Numark Scratch , inspired by the [s4mk3](https://github.com/mixxxdj/mixxx/pull/12995#event-12304815386)

![image](https://github.com/mixxxdj/mixxx/assets/24758479/535364ed-4b9e-4709-bbbb-6cfce2034a7c)
