### PR TITLE
refactor(assert): replace source location macros with `std::source_location`

### DIFF
--- a/src/util/assert.h
+++ b/src/util/assert.h
@@ -1,47 +1,47 @@
 #pragma once
 
 #include <QtDebug>
+#include <source_location>
 
 static constexpr const char* kDebugAssertPrefix = "DEBUG ASSERT";
 
 #ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
-inline void mixxx_debug_assert(const char* assertion, const char* file, int line, const char* function) {
-    qCritical("%s: \"%s\" in function %s at %s:%d", kDebugAssertPrefix, assertion, function, file, line);
+inline void mixxx_debug_assert(const char* assertion, const std::source_location& loc) {
+    qCritical("%s: \"%s\" in function %s at %s:%d:%d",
+            kDebugAssertPrefix,
+            assertion,
+            loc.function_name(),
+            loc.file_name(),
+            loc.line(),
+            loc.column());
 }
 #endif
 
 #ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
-inline bool mixxx_debug_assert_return_true(const char* assertion,
-        const char* file,
-        int line,
-        const char* function) {
-    mixxx_debug_assert(assertion, file, line, function);
+inline bool mixxx_debug_assert_return_true(const char* assertion, const std::source_location& loc) {
+    mixxx_debug_assert(assertion, loc);
     return true;
 }
 #endif
 
-inline void mixxx_release_assert(const char* assertion, const char* file, int line, const char* function) {
-    qFatal("ASSERT: \"%s\" in function %s at %s:%d", assertion, function, file, line);
+inline void mixxx_release_assert(const char* assertion, const std::source_location& loc) {
+    qFatal("ASSERT: \"%s\" in function %s at %s:%d:%d",
+            assertion,
+            loc.function_name(),
+            loc.file_name(),
+            loc.line(),
+            loc.column());
 }
-
-// These macros provide the demangled function name (including helpful template
-// type information) and are supported on every version of GCC, Clang, and MSVC
-// that Mixxx supports.
-#if defined(_MSC_VER)
-#define ASSERT_FUNCTION __FUNCSIG__
-#else
-#define ASSERT_FUNCTION __PRETTY_FUNCTION__
-#endif
 
 /// If cond is false, produces a fatal assertion and quits ungracefully. Think
 /// very hard before using this -- this should only be for the most dire of
 /// situations where we know Mixxx cannot take any action without potentially
 /// corrupting user data. Handle errors gracefully whenever possible.
-#define RELEASE_ASSERT(cond)                                                  \
-    do                                                                        \
-        if (!static_cast<bool>(cond)) [[unlikely]] {                          \
-            mixxx_release_assert(#cond, __FILE__, __LINE__, ASSERT_FUNCTION); \
-        }                                                                     \
+#define RELEASE_ASSERT(cond)                                              \
+    do                                                                    \
+        if (!static_cast<bool>(cond)) [[unlikely]] {                      \
+            mixxx_release_assert(#cond, std::source_location::current()); \
+        }                                                                 \
     while (0)
 
 /// Checks that cond is true in debug builds. If cond is false then prints a
@@ -54,11 +54,11 @@ inline void mixxx_release_assert(const char* assertion, const char* file, int li
 ///
 /// In release builds, doSomething() is never called!
 #ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
-#define DEBUG_ASSERT(cond)                                                  \
-    do                                                                      \
-        if (!static_cast<bool>(cond)) [[unlikely]] {                        \
-            mixxx_debug_assert(#cond, __FILE__, __LINE__, ASSERT_FUNCTION); \
-        }                                                                   \
+#define DEBUG_ASSERT(cond)                                              \
+    do                                                                  \
+        if (!static_cast<bool>(cond)) [[unlikely]] {                    \
+            mixxx_debug_assert(#cond, std::source_location::current()); \
+        }                                                               \
     while (0)
 #else
 #define DEBUG_ASSERT(cond) \
@@ -78,7 +78,7 @@ inline void mixxx_release_assert(const char* assertion, const char* file, int li
 #ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
 #define VERIFY_OR_DEBUG_ASSERT(cond)            \
     if (Q_UNLIKELY(!static_cast<bool>(cond)) && \
-            mixxx_debug_assert_return_true(#cond, __FILE__, __LINE__, ASSERT_FUNCTION))
+            mixxx_debug_assert_return_true(#cond, std::source_location::current()))
 #else
 #define VERIFY_OR_DEBUG_ASSERT(cond) if (!static_cast<bool>(cond)) [[unlikely]]
 #endif


### PR DESCRIPTION
cuz, why not. 