### PR TITLE
Improve use of parented_ptr

### DIFF
--- a/src/controllers/legacycontrollersettingslayout.cpp
+++ b/src/controllers/legacycontrollersettingslayout.cpp
@@ -25,7 +25,7 @@ void LegacyControllerSettingsLayoutContainer::addItem(
 }
 
 QBoxLayout* LegacyControllerSettingsLayoutContainer::buildLayout(QWidget* pParent) const {
-    auto pLayout = make_parented<QBoxLayout>(QBoxLayout::TopToBottom);
+    auto pLayout = make_parented<QBoxLayout>(QBoxLayout::TopToBottom, pParent);
 
     pParent->setLayout(pLayout);
 

--- a/src/library/export/dlglibraryexport.cpp
+++ b/src/library/export/dlglibraryexport.cpp
@@ -106,7 +106,7 @@ DlgLibraryExport::DlgLibraryExport(
     auto pExportButton = make_parented<QPushButton>(tr("Export"), this);
     pExportButton->setDefault(true);
     connect(pExportButton, &QPushButton::clicked, this, &DlgLibraryExport::exportRequested);
-    auto pCancelButton = make_parented<QPushButton>(tr("Cancel"));
+    auto pCancelButton = make_parented<QPushButton>(tr("Cancel"), this);
     connect(pCancelButton, &QPushButton::clicked, this, &QDialog::reject);
 
     // Arrange action buttons at bottom of dialog.

--- a/src/library/export/dlglibraryexport.cpp
+++ b/src/library/export/dlglibraryexport.cpp
@@ -47,11 +47,11 @@ DlgLibraryExport::DlgLibraryExport(
           m_pConfig{pConfig},
           m_pTrackCollectionManager{pTrackCollectionManager} {
     // Selectable list of crates from the Mixxx library.
-    m_pCratesList = make_parented<QListWidget>();
+    m_pCratesList = make_parented<QListWidget>(this);
     m_pCratesList->setSelectionMode(QListWidget::ExtendedSelection);
 
     // Read-only text fields showing key directories for export.
-    m_pExportDirectoryTextField = make_parented<QLineEdit>();
+    m_pExportDirectoryTextField = make_parented<QLineEdit>(this);
     m_pExportDirectoryTextField->setReadOnly(true);
 
     // Remember the last export directory, or use documents as a fallback.
@@ -66,56 +66,56 @@ DlgLibraryExport::DlgLibraryExport(
 
     m_pExportDirectoryTextField->setText(lastExportDirectory);
 
-    m_pVersionCombo = make_parented<QComboBox>();
+    m_pVersionCombo = make_parented<QComboBox>(this);
     m_pVersionCombo->setSizeAdjustPolicy(QComboBox::AdjustToContents);
 
-    m_pExistingDatabaseLabel = make_parented<QLabel>();
+    m_pExistingDatabaseLabel = make_parented<QLabel>(this);
     m_pExistingDatabaseLabel->setWordWrap(true);
 
     // Radio buttons to allow choice between exporting the whole music library
     // or just tracks in a selection of crates.
-    m_pWholeLibraryRadio = make_parented<QRadioButton>(tr("Entire music library"));
+    m_pWholeLibraryRadio = make_parented<QRadioButton>(tr("Entire music library"), this);
     m_pWholeLibraryRadio->setChecked(true);
     m_pCratesList->setEnabled(false);
     connect(m_pWholeLibraryRadio,
             &QRadioButton::clicked,
             this,
             [this]() { m_pCratesList->setEnabled(false); });
-    m_pCratesRadio = make_parented<QRadioButton>(tr("Selected crates"));
+    m_pCratesRadio = make_parented<QRadioButton>(tr("Selected crates"), this);
     connect(m_pCratesRadio,
             &QRadioButton::clicked,
             this,
             [this]() { m_pCratesList->setEnabled(true); });
 
     // Button to allow ability to browse for the export directory.
-    auto pExportDirBrowseButton = make_parented<QPushButton>(tr("Browse"));
+    auto pExportDirBrowseButton = make_parented<QPushButton>(tr("Browse"), this);
     connect(pExportDirBrowseButton,
             &QPushButton::clicked,
             this,
             &DlgLibraryExport::browseExportDirectory);
-    auto pExportDirLayout = make_parented<QHBoxLayout>();
+    auto pExportDirLayout = make_parented<QHBoxLayout>(this);
     pExportDirLayout->addWidget(m_pExportDirectoryTextField);
     pExportDirLayout->addWidget(pExportDirBrowseButton);
 
-    auto pFormLayout = make_parented<QFormLayout>();
+    auto pFormLayout = make_parented<QFormLayout>(this);
     pFormLayout->addRow(tr("Export directory"), pExportDirLayout);
     pFormLayout->addRow(tr("Database version"), m_pVersionCombo);
     pFormLayout->addRow(m_pExistingDatabaseLabel);
 
     // Buttons to begin the export or cancel.
-    auto pExportButton = make_parented<QPushButton>(tr("Export"));
+    auto pExportButton = make_parented<QPushButton>(tr("Export"), this);
     pExportButton->setDefault(true);
     connect(pExportButton, &QPushButton::clicked, this, &DlgLibraryExport::exportRequested);
     auto pCancelButton = make_parented<QPushButton>(tr("Cancel"));
     connect(pCancelButton, &QPushButton::clicked, this, &QDialog::reject);
 
     // Arrange action buttons at bottom of dialog.
-    auto pButtonBarLayout = make_parented<QHBoxLayout>();
+    auto pButtonBarLayout = make_parented<QHBoxLayout>(this);
     pButtonBarLayout->addStretch(1);
     pButtonBarLayout->addWidget(pExportButton);
     pButtonBarLayout->addWidget(pCancelButton);
 
-    auto pLayout = make_parented<QGridLayout>();
+    auto pLayout = make_parented<QGridLayout>(this);
     pLayout->setColumnStretch(0, 1);
     pLayout->setColumnStretch(1, 2);
     pLayout->addWidget(m_pWholeLibraryRadio, 0, 0);

--- a/src/util/parented_ptr.h
+++ b/src/util/parented_ptr.h
@@ -29,17 +29,12 @@ class parented_ptr final {
 
     explicit parented_ptr(T* t) noexcept
             : m_ptr{t} {
-    }
-// Only generate destructor if not empty, otherwise its empty but will
-// cause the parented_ptr to be not trivially destructible even though it could be.
-#ifdef MIXXX_DEBUG_ASSERTIONS_ENABLED
-    ~parented_ptr() noexcept {
         DEBUG_ASSERT(!m_ptr || static_cast<const QObject*>(m_ptr)->parent());
     }
-#else
+
     // explicitly generate trivial destructor (since decltype(m_ptr) is not a class type)
     ~parented_ptr() noexcept = default;
-#endif
+
     // Rule of 5
     parented_ptr(const parented_ptr<T>&) = delete;
     parented_ptr& operator=(const parented_ptr<T>&) = delete;

--- a/src/util/parented_ptr.h
+++ b/src/util/parented_ptr.h
@@ -99,7 +99,11 @@ class parented_ptr final {
     friend class parented_ptr;
 };
 
+template<typename... Args>
+concept AnyIsQObject = (... || std::is_convertible_v<Args, QObject*>);
+
 template<typename T, typename... Args>
+    requires(std::is_base_of_v<QObject, T> && AnyIsQObject<Args...>)
 inline parented_ptr<T> make_parented(Args&&... args) {
     return parented_ptr<T>(new T(std::forward<Args>(args)...));
 }

--- a/src/widget/findonwebmenufactory.cpp
+++ b/src/widget/findonwebmenufactory.cpp
@@ -12,9 +12,9 @@ namespace mixxx {
 namespace library {
 
 void createFindOnWebSubmenus(QMenu* pFindOnWebMenu, const Track& track) {
-    make_parented<QMenu>(new FindOnWebMenuSoundcloud(pFindOnWebMenu, track));
-    make_parented<QMenu>(new FindOnWebMenuDiscogs(pFindOnWebMenu, track));
-    make_parented<QMenu>(new FindOnWebMenuLastfm(pFindOnWebMenu, track));
+    make_parented<FindOnWebMenuSoundcloud>(pFindOnWebMenu, track);
+    make_parented<FindOnWebMenuDiscogs>(pFindOnWebMenu, track);
+    make_parented<FindOnWebMenuLastfm>(pFindOnWebMenu, track);
 }
 
 } // namespace library

--- a/src/widget/findonwebmenuservices/findonwebmenudiscogs.cpp
+++ b/src/widget/findonwebmenuservices/findonwebmenudiscogs.cpp
@@ -29,17 +29,17 @@ const QUrl composeDiscogsUrl(const QString& serviceDefaultUrl,
 }
 } //namespace
 
-FindOnWebMenuDiscogs::FindOnWebMenuDiscogs(QMenu* pFindOnWebMenu, const Track& track) {
+FindOnWebMenuDiscogs::FindOnWebMenuDiscogs(QMenu* pFindOnWebMenu, const Track& track)
+        : WFindOnWebMenu(pFindOnWebMenu) {
     const QString artist = track.getArtist();
     const QString trackTitle = track.getTitle();
     const QString album = track.getAlbum();
-    auto pDiscogsMenu = make_parented<QMenu>(pFindOnWebMenu);
-    pDiscogsMenu->setTitle(kServiceTitle);
-    pFindOnWebMenu->addMenu(pDiscogsMenu);
+    setTitle(kServiceTitle);
+    pFindOnWebMenu->addMenu(this);
     addSeparator();
     if (!artist.isEmpty()) {
         const QUrl discogsUrlArtist = composeDiscogsUrl(kSearchUrl, artist, kQueryTypeArtist);
-        addActionToServiceMenu(pDiscogsMenu,
+        addActionToServiceMenu(
                 composeActionText(tr("Artist"), artist),
                 discogsUrlArtist);
     }
@@ -48,14 +48,14 @@ FindOnWebMenuDiscogs::FindOnWebMenuDiscogs(QMenu* pFindOnWebMenu, const Track& t
             const QString artistWithTrackTitle = composeSearchQuery(artist, trackTitle);
             const QUrl discogsUrlArtistWithTrackTitle = composeDiscogsUrl(
                     kSearchUrl, artistWithTrackTitle, kQueryTypeRelease);
-            addActionToServiceMenu(pDiscogsMenu,
+            addActionToServiceMenu(
                     composeActionText(
                             tr("Artist + Title"), artistWithTrackTitle),
                     discogsUrlArtistWithTrackTitle);
         }
         const QUrl discogsUrlTrackTitle =
                 composeDiscogsUrl(kSearchUrl, trackTitle, kQueryTypeRelease);
-        addActionToServiceMenu(pDiscogsMenu,
+        addActionToServiceMenu(
                 composeActionText(tr("Title"), trackTitle),
                 discogsUrlTrackTitle);
     }
@@ -64,12 +64,12 @@ FindOnWebMenuDiscogs::FindOnWebMenuDiscogs(QMenu* pFindOnWebMenu, const Track& t
             const QString artistWithAlbum = composeSearchQuery(artist, album);
             const QUrl discogsUrlArtistWithAlbum = composeDiscogsUrl(
                     kSearchUrl, artistWithAlbum, kQueryTypeRelease);
-            addActionToServiceMenu(pDiscogsMenu,
+            addActionToServiceMenu(
                     composeActionText(tr("Artist + Album"), artistWithAlbum),
                     discogsUrlArtistWithAlbum);
         } else {
             const QUrl discogsUrlAlbum = composeDiscogsUrl(kSearchUrl, album, kQueryTypeRelease);
-            addActionToServiceMenu(pDiscogsMenu,
+            addActionToServiceMenu(
                     composeActionText(tr("Album"), album),
                     discogsUrlAlbum);
         }

--- a/src/widget/findonwebmenuservices/findonwebmenulastfm.cpp
+++ b/src/widget/findonwebmenuservices/findonwebmenulastfm.cpp
@@ -27,17 +27,17 @@ const QUrl composeLastfmUrl(const QString& serviceSearchUrl,
 
 } //namespace
 
-FindOnWebMenuLastfm::FindOnWebMenuLastfm(QMenu* pFindOnWebMenu, const Track& track) {
+FindOnWebMenuLastfm::FindOnWebMenuLastfm(QMenu* pFindOnWebMenu, const Track& track)
+        : WFindOnWebMenu(pFindOnWebMenu) {
     const QString artist = track.getArtist();
     const QString trackTitle = track.getTitle();
     const QString album = track.getAlbum();
-    auto pLastfmMenu = make_parented<QMenu>(pFindOnWebMenu);
-    pLastfmMenu->setTitle(kServiceTitle);
-    pFindOnWebMenu->addMenu(pLastfmMenu);
-    pLastfmMenu->addSeparator();
+    setTitle(kServiceTitle);
+    pFindOnWebMenu->addMenu(this);
+    addSeparator();
     if (!artist.isEmpty()) {
         const QUrl lastfmUrlArtist = composeLastfmUrl(kSearchUrlArtist, artist);
-        addActionToServiceMenu(pLastfmMenu,
+        addActionToServiceMenu(
                 composeActionText(tr("Artist"), artist),
                 lastfmUrlArtist);
     }
@@ -46,13 +46,13 @@ FindOnWebMenuLastfm::FindOnWebMenuLastfm(QMenu* pFindOnWebMenu, const Track& tra
             const QString artistWithTrackTitle = composeSearchQuery(artist, trackTitle);
             const QUrl lastfmUrlArtistWithTrackTitle =
                     composeLastfmUrl(kSearchUrlTitle, artistWithTrackTitle);
-            addActionToServiceMenu(pLastfmMenu,
+            addActionToServiceMenu(
                     composeActionText(
                             tr("Artist + Title"), artistWithTrackTitle),
                     lastfmUrlArtistWithTrackTitle);
         }
         const QUrl lastfmUrlTrackTitle = composeLastfmUrl(kSearchUrlTitle, trackTitle);
-        addActionToServiceMenu(pLastfmMenu,
+        addActionToServiceMenu(
                 composeActionText(tr("Title"), trackTitle),
                 lastfmUrlTrackTitle);
     }
@@ -61,12 +61,12 @@ FindOnWebMenuLastfm::FindOnWebMenuLastfm(QMenu* pFindOnWebMenu, const Track& tra
             const QString artistWithAlbum = composeSearchQuery(artist, album);
             const QUrl lastfmUrlArtistWithAlbum =
                     composeLastfmUrl(kSearchUrlAlbum, artistWithAlbum);
-            addActionToServiceMenu(pLastfmMenu,
+            addActionToServiceMenu(
                     composeActionText(tr("Artist + Album"), artistWithAlbum),
                     lastfmUrlArtistWithAlbum);
         } else {
             const QUrl lastfmUrlAlbum = composeLastfmUrl(kSearchUrlAlbum, album);
-            addActionToServiceMenu(pLastfmMenu,
+            addActionToServiceMenu(
                     composeActionText(tr("Album"), album),
                     lastfmUrlAlbum);
         }

--- a/src/widget/findonwebmenuservices/findonwebmenusoundcloud.cpp
+++ b/src/widget/findonwebmenuservices/findonwebmenusoundcloud.cpp
@@ -27,17 +27,17 @@ const QUrl composeSoundcloudUrl(const QString& serviceSearchUrl,
 } // namespace
 
 FindOnWebMenuSoundcloud::FindOnWebMenuSoundcloud(
-        QMenu* pFindOnWebMenu, const Track& track) {
+        QMenu* pFindOnWebMenu, const Track& track)
+        : WFindOnWebMenu(pFindOnWebMenu) {
     const QString artist = track.getArtist();
     const QString trackTitle = track.getTitle();
     const QString album = track.getAlbum();
-    auto pSoundcloudMenu = make_parented<QMenu>(pFindOnWebMenu);
-    pSoundcloudMenu->setTitle(kServiceTitle);
-    pFindOnWebMenu->addMenu(pSoundcloudMenu);
-    pSoundcloudMenu->addSeparator();
+    setTitle(kServiceTitle);
+    pFindOnWebMenu->addMenu(this);
+    addSeparator();
     if (!artist.isEmpty()) {
         const QUrl SoundcloudUrlArtist = composeSoundcloudUrl(kSearchUrlArtist, artist);
-        addActionToServiceMenu(pSoundcloudMenu,
+        addActionToServiceMenu(
                 composeActionText(tr("Artist"), artist),
                 SoundcloudUrlArtist);
     }
@@ -46,13 +46,13 @@ FindOnWebMenuSoundcloud::FindOnWebMenuSoundcloud(
             const QString artistWithTrackTitle = composeSearchQuery(artist, trackTitle);
             const QUrl SoundcloudUrlArtistWithTrackTitle =
                     composeSoundcloudUrl(kSearchUrlTitle, artistWithTrackTitle);
-            addActionToServiceMenu(pSoundcloudMenu,
+            addActionToServiceMenu(
                     composeActionText(
                             tr("Artist + Title"), artistWithTrackTitle),
                     SoundcloudUrlArtistWithTrackTitle);
         }
         const QUrl SoundcloudUrlTrackTitle = composeSoundcloudUrl(kSearchUrlTitle, trackTitle);
-        addActionToServiceMenu(pSoundcloudMenu,
+        addActionToServiceMenu(
                 composeActionText(tr("Title"), trackTitle),
                 SoundcloudUrlTrackTitle);
     }
@@ -61,12 +61,12 @@ FindOnWebMenuSoundcloud::FindOnWebMenuSoundcloud(
             const QString artistWithAlbum = composeSearchQuery(artist, album);
             const QUrl SoundcloudUrlArtistWithAlbum =
                     composeSoundcloudUrl(kSearchUrlAlbum, artistWithAlbum);
-            addActionToServiceMenu(pSoundcloudMenu,
+            addActionToServiceMenu(
                     composeActionText(tr("Artist + Album"), artistWithAlbum),
                     SoundcloudUrlArtistWithAlbum);
         } else {
             const QUrl SoundcloudUrlAlbum = composeSoundcloudUrl(kSearchUrlAlbum, album);
-            addActionToServiceMenu(pSoundcloudMenu,
+            addActionToServiceMenu(
                     composeActionText(tr("Album"), album),
                     SoundcloudUrlAlbum);
         }

--- a/src/widget/wcolorpickeraction.cpp
+++ b/src/widget/wcolorpickeraction.cpp
@@ -1,22 +1,24 @@
 #include "widget/wcolorpickeraction.h"
 
 #include <QHBoxLayout>
+#include <memory>
 
 #include "moc_wcolorpickeraction.cpp"
 
 WColorPickerAction::WColorPickerAction(WColorPicker::Options options, const ColorPalette& palette, QWidget* parent)
-        : QWidgetAction(parent),
-          m_pColorPicker(make_parented<WColorPicker>(options, palette)) {
-    connect(m_pColorPicker.get(), &WColorPicker::colorPicked, this, &WColorPickerAction::colorPicked);
-
-    QHBoxLayout* pLayout = new QHBoxLayout();
-    pLayout->addWidget(m_pColorPicker);
-    pLayout->setSizeConstraint(QLayout::SetFixedSize);
-
-    QWidget* pWidget = new QWidget();
+        : QWidgetAction(parent) {
+    auto pWidget = std::make_unique<QWidget>();
+    auto pLayout = make_parented<QHBoxLayout>(pWidget.get());
     pWidget->setLayout(pLayout);
     pWidget->setSizePolicy(QSizePolicy());
-    setDefaultWidget(pWidget);
+    m_pColorPicker = make_parented<WColorPicker>(options, palette, pWidget.get());
+    pLayout->addWidget(m_pColorPicker);
+    pLayout->setSizeConstraint(QLayout::SetFixedSize);
+    setDefaultWidget(pWidget.release());
+    connect(m_pColorPicker.get(),
+            &WColorPicker::colorPicked,
+            this,
+            &WColorPickerAction::colorPicked);
 }
 
 void WColorPickerAction::resetSelectedColor() {

--- a/src/widget/wfindonwebmenu.cpp
+++ b/src/widget/wfindonwebmenu.cpp
@@ -18,8 +18,8 @@ bool WFindOnWebMenu::hasEntriesForTrack(const Track& track) {
 }
 
 void WFindOnWebMenu::addActionToServiceMenu(
-        QMenu* serviceMenu, const QString& actionText, const QUrl& serviceUrl) {
-    serviceMenu->addAction(actionText,
+        const QString& actionText, const QUrl& serviceUrl) {
+    addAction(actionText,
             this,
             [this, serviceUrl] {
                 openInBrowser(serviceUrl);

--- a/src/widget/wfindonwebmenu.h
+++ b/src/widget/wfindonwebmenu.h
@@ -11,7 +11,7 @@ class WFindOnWebMenu : public QMenu {
             QWidget* parent = nullptr);
     ~WFindOnWebMenu() override = default;
 
-    void addActionToServiceMenu(QMenu* serviceMenu,
+    void addActionToServiceMenu(
             const QString& actionText,
             const QUrl& serviceUrl);
 


### PR DESCRIPTION
This PR fixed some cases where a patented_ptr is constructed without a parent. This creates a pointer that is temporary without any owner. 

I have moved the assertion to the constructor to avoid this situation in future. 

The risk is that we with debug assertion enabled, Mixxx will crash in case I have missed a case. So a double check during review is required. 

This is part of the pending discussion about the future of parented_ptr in: https://github.com/mixxxdj/mixxx/pull/13395