### PR TITLE
fix: invalid slip render marker

### DIFF
--- a/src/waveform/renderers/allshader/waveformrendermark.cpp
+++ b/src/waveform/renderers/allshader/waveformrendermark.cpp
@@ -207,7 +207,7 @@ void allshader::WaveformRenderMark::paintGL() {
 
     QMatrix4x4 matrix = matrixForWidgetGeometry(m_waveformRenderer, false);
 
-    const double playPosition = m_waveformRenderer->getTruePosSample();
+    const double playPosition = m_waveformRenderer->getTruePosSample(positionType);
     double nextMarkPosition = std::numeric_limits<double>::max();
 
     for (const auto& pMark : std::as_const(m_marks)) {
@@ -230,7 +230,7 @@ void allshader::WaveformRenderMark::paintGL() {
                         static_cast<float>(
                                 m_waveformRenderer
                                         ->transformSamplePositionInRendererWorld(
-                                                samplePosition)) *
+                                                samplePosition, positionType)) *
                         devicePixelRatio) /
                 devicePixelRatio;
         if (pMark->isShowUntilNext() &&


### PR DESCRIPTION
Looks like the `playposition` was missing in the marker render, likely following a conflict resolution when working on the waveform clean up 