### PR TITLE
Don't return in JogWheelBasic on deck absent in option

### DIFF
--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -762,16 +762,50 @@
     });
 
     const JogWheelBasic = function(options) {
+        if (options.deck !== undefined && options.group !== undefined) {
+            console.warn(
+                "options.deck and option.group are both set; " +
+                "options.deck will take priority"
+            );
+        }
+
+        const deck = options.deck;
+        const group = script.deckFromGroup(options.group);
+        delete options.deck;
+        delete options.group;
+
         Component.call(this, options);
 
-        if (!Number.isInteger(this.deck)) {
-            console.warn("missing scratch deck");
-            return;
+        this._deck = undefined;
+
+        Object.defineProperties(this, {
+            deck: {
+                get: () => this._deck,
+                set: (value) => {
+                    if (Number.isInteger(value) && value > 0) {
+                        this._deck = value;
+                        this.reset();
+                    }
+                },
+            },
+            group: {
+                get: () => `[Channel${deck}]`,
+                set: value => {
+                    const deck = script.deckFromGroup(value);
+                    if (deck > 0) {
+                        this._deck = deck;
+                        this.reset();
+                    }
+                },
+            }
+        });
+
+        this.deck = deck;
+
+        if (!this.deck) {
+            this.group = group;  // try setting deck from group
         }
-        if (this.deck <= 0) {
-            console.warn("invalid deck number: " + this.deck);
-            return;
-        }
+
         if (!Number.isInteger(this.wheelResolution)) {
             console.warn("missing jogwheel resolution");
             return;
@@ -786,9 +820,7 @@
         if (!Number.isFinite(this.rpm)) {
             this.rpm = 33 + 1/3;
         }
-        if (this.group === undefined) {
-            this.group = "[Channel" + this.deck + "]";
-        }
+
         this.inKey = "jog";
     };
 
@@ -800,6 +832,10 @@
             return value < 0x40 ? value : value - (this.max + 1);
         },
         inputWheel: function(_channel, _control, value, _status, _group) {
+            if (!this.deck) {
+                return;
+            }
+
             value = this.inValueScale(value);
             if (engine.isScratching(this.deck)) {
                 engine.scratchTick(this.deck, value);
@@ -808,6 +844,10 @@
             }
         },
         inputTouch: function(channel, control, value, status, _group) {
+            if (!this.deck) {
+                return;
+            }
+
             if (this.isPress(channel, control, value, status) && this.vinylMode) {
                 engine.scratchEnable(this.deck,
                     this.wheelResolution,
@@ -822,13 +862,7 @@
             throw "Called wrong input handler for " + status + ": " + control + ".\n" +
                 "Please bind jogwheel-related messages to inputWheel and inputTouch!\n";
         },
-        // this is needed for features such as "deck switching" that work
-        // by changing the component group. It is assumed they call `connect`
-        // afterwards.
-        connect: function() {
-            Component.prototype.connect.call(this);
-            this.deck = parseInt(script.channelRegEx.exec(this.group)[1]);
-        }
+        reset() {},
     });
 
     const EffectUnit = function(unitNumbers, allowFocusWhenParametersHidden, colors) {


### PR DESCRIPTION
This allows late binding of `JogWheelBasic` using `ComponentContainer.reconnectComponents` and `Deck.setCurrentDeck`.