### PR TITLE
(fix) Library: show Properties action in Missing and Hidden

### DIFF
--- a/src/library/librarytablemodel.cpp
+++ b/src/library/librarytablemodel.cpp
@@ -98,5 +98,6 @@ TrackModel::Capabilities LibraryTableModel::getCapabilities() const {
             Capability::Hide |
             Capability::ResetPlayed |
             Capability::RemoveFromDisk |
-            Capability::Analyze;
+            Capability::Analyze |
+            Capability::Properties;
 }

--- a/src/library/missing_hidden/hiddentablemodel.cpp
+++ b/src/library/missing_hidden/hiddentablemodel.cpp
@@ -97,7 +97,9 @@ Qt::ItemFlags HiddenTableModel::flags(const QModelIndex& index) const {
 TrackModel::Capabilities HiddenTableModel::getCapabilities() const {
     return Capability::Purge |
             Capability::Unhide |
-            Capability::RemoveFromDisk;
+            Capability::RemoveFromDisk |
+            Capability::EditMetadata |
+            Capability::Properties;
 }
 
 QString HiddenTableModel::modelKey(bool noSearch) const {

--- a/src/library/missing_hidden/missingtablemodel.cpp
+++ b/src/library/missing_hidden/missingtablemodel.cpp
@@ -88,7 +88,7 @@ Qt::ItemFlags MissingTableModel::flags(const QModelIndex &index) const {
 }
 
 TrackModel::Capabilities MissingTableModel::getCapabilities() const {
-    return Capability::Purge;
+    return Capability::Purge | Capability::Properties;
 }
 
 QString MissingTableModel::modelKey(bool noSearch) const {

--- a/src/library/playlisttablemodel.cpp
+++ b/src/library/playlisttablemodel.cpp
@@ -373,7 +373,8 @@ TrackModel::Capabilities PlaylistTableModel::getCapabilities() const {
             Capability::ResetPlayed |
             Capability::RemoveFromDisk |
             Capability::Hide |
-            Capability::Analyze;
+            Capability::Analyze |
+            Capability::Properties;
 
     if (m_iPlaylistId !=
             m_pTrackCollectionManager->internalCollection()

--- a/src/library/trackmodel.h
+++ b/src/library/trackmodel.h
@@ -52,6 +52,7 @@ class TrackModel {
         RemoveCrate = 1u << 15u,
         RemoveFromDisk = 1u << 16u,
         Analyze = 1u << 17u,
+        Properties = 1u << 18u,
     };
     Q_DECLARE_FLAGS(Capabilities, Capability)
 

--- a/src/library/trackset/crate/cratetablemodel.cpp
+++ b/src/library/trackset/crate/cratetablemodel.cpp
@@ -133,7 +133,8 @@ TrackModel::Capabilities CrateTableModel::getCapabilities() const {
             Capability::ResetPlayed |
             Capability::Hide |
             Capability::RemoveFromDisk |
-            Capability::Analyze;
+            Capability::Analyze |
+            Capability::Properties;
 
     if (m_selectedCrate.isValid()) {
         Crate crate;

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -345,14 +345,16 @@ void WTrackMenu::createActions() {
                 &WTrackMenu::slotRemoveFromDisk);
     }
 
-    if (featureIsEnabled(Feature::Properties)) {
+    if (featureIsEnabled(Feature::Metadata)) {
         m_pStarRatingAction = new WStarRatingAction(this);
         m_pStarRatingAction->setObjectName("RatingAction");
         connect(m_pStarRatingAction,
                 &WStarRatingAction::ratingSet,
                 this,
                 &WTrackMenu::slotSetRating);
+    }
 
+    if (featureIsEnabled(Feature::Properties)) {
         m_pPropertiesAct = new QAction(tr("Properties"), this);
         // This is just for having the shortcut displayed next to the action
         // when the menu is invoked from the tracks table.
@@ -631,7 +633,7 @@ void WTrackMenu::setupActions() {
         addMenu(m_pBPMMenu);
     }
 
-    if (featureIsEnabled(Feature::Properties)) {
+    if (featureIsEnabled(Feature::Metadata)) {
         addAction(m_pStarRatingAction);
     }
 
@@ -1101,12 +1103,14 @@ void WTrackMenu::updateMenus() {
         m_pSelectInLibraryAct->setEnabled(enabled);
     }
 
-    if (featureIsEnabled(Feature::Properties)) {
+    if (featureIsEnabled(Feature::Metadata)) {
         // Might be needed to resize Menu to fit the star rating
         // QResizeEvent resizeEvent(QSize(), m_pStarRatingAction->sizeHint());
         // qApp->sendEvent(m_pStarRatingAction, &resizeEvent);
         m_pStarRatingAction->setRating(getCommonTrackRating());
+    }
 
+    if (featureIsEnabled(Feature::Properties)) {
         m_pPropertiesAct->setEnabled(true);
     }
 
@@ -2753,7 +2757,7 @@ bool WTrackMenu::featureIsEnabled(Feature flag) const {
     case Feature::FindOnWeb:
         return true;
     case Feature::Properties:
-        return m_pTrackModel->hasCapabilities(TrackModel::Capability::EditMetadata);
+        return m_pTrackModel->hasCapabilities(TrackModel::Capability::Properties);
     case Feature::SearchRelated:
         return m_pLibrary != nullptr;
     case Feature::SelectInLibrary:


### PR DESCRIPTION
The Properties dialog is helpful also in Hidden and Missing. You can quickly check stored metadata like album, bitrate etc. of removed tracks. Though the entire Metadata doesn't make much sense there IMO.

Previously, `Capability::EditMetadata` was used to show/hide the metadata menu, star rating (and cover art menu?), that's why I decided to separate that and add `Capability::Properties` only for the properties action.

Wdyt?