### PR TITLE
Skins: fix time display to allow AM/PM

### DIFF
--- a/res/skins/Deere/tool_bar.xml
+++ b/res/skins/Deere/tool_bar.xml
@@ -34,8 +34,7 @@
               <Time>
                 <TooltipId>time</TooltipId>
                 <ObjectName>Time</ObjectName>
-                <Size>52f,20f</Size>
-                <CustomFormat>hh:mm</CustomFormat>
+                <Size>56f,20f</Size>
               </Time>
 
               <Template src="skin:vumeter_latency.xml">

--- a/res/skins/LateNight/toolbar.xml
+++ b/res/skins/LateNight/toolbar.xml
@@ -144,7 +144,6 @@
         <Children>
           <Time>
             <TooltipId>time</TooltipId>
-            <CustomFormat>hh:mm</CustomFormat>
           </Time>
         </Children>
       </WidgetGroup>

--- a/res/skins/Shade/mixer_panel.xml
+++ b/res/skins/Shade/mixer_panel.xml
@@ -496,21 +496,30 @@
               Text- Clock display
               **********************************************
               -->
-              <Time>
-                <TooltipId>time</TooltipId>
+              <WidgetGroup>
+                <Pos>101,14</Pos>
+                <Size>50f,14f</Size>
+                <Layout>horizontal</Layout>
                 <Style>
-                  QLabel {
-                    font-size: 10px;
-                    font-weight: bold;
-                    background-color: transparent;
-                    color: #191F24;
-                    text-align:center;
+                  WWidgetGroup {
+                    align: center;
                   }
                 </Style>
-                <Pos>113,14</Pos>
-                <CustomFormat>hh:mm</CustomFormat>
-                <ShowSeconds>false</ShowSeconds>
-              </Time>
+                <Children>
+                  <Time>
+                    <TooltipId>time</TooltipId>
+                    <Style>
+                      QLabel {
+                        font-size: 10px;
+                        font-weight: bold;
+                        background-color: transparent;
+                        color: #191F24;
+                        text-align:center;
+                      }
+                    </Style>
+                  </Time>
+                </Children>
+              </WidgetGroup>
 
               <StatusLight>
                 <Pos>113,27</Pos>

--- a/res/skins/Tango/topbar.xml
+++ b/res/skins/Tango/topbar.xml
@@ -281,7 +281,9 @@ Description:
 
           <WidgetGroup><!-- Clock + latency display -->
             <ObjectName>ClockBox</ObjectName>
-            <Size>52f,28f</Size>
+            <MinimumSize>52,28</MinimumSize>
+            <MaximumSize>64,28</MaximumSize>
+            <SizePolicy>max</SizePolicy>
             <Layout>vertical</Layout>
             <Children>
 
@@ -292,9 +294,6 @@ Description:
                   <Time>
                     <TooltipId>time</TooltipId>
                     <ObjectName>Clock</ObjectName>
-                    <!-- <ShowSeconds>false</ShowSeconds>
-                    <ClockFormat>12AP</ClockFormat>
-                    This has no effect, neither has 'text-align' in qss.   -->
                     <Align>center</Align>
                   </Time>
                 </Children>


### PR DESCRIPTION
I removed the fixed hh:mm format which allows AM/PM and adjusted the size policies and the parent WidgetGroups so AM/PM is not cut off.

Please double check each skin.

Fixes #13421 