### PR TITLE
Paintable cleanup

### DIFF
--- a/src/widget/paintable.cpp
+++ b/src/widget/paintable.cpp
@@ -94,8 +94,7 @@ Paintable::Paintable(const PixmapSource& source, DrawMode mode, double scaleFact
                 m_pSvg->render(&painter);
                 WPixmapStore::correctImageColors(&copy_buffer);
 
-                m_pPixmap.reset(new QPixmap(copy_buffer.size()));
-                m_pPixmap->convertFromImage(copy_buffer);
+                m_pPixmap = std::make_unique<QPixmap>(QPixmap::fromImage(copy_buffer));
         }
     }
 }

--- a/src/widget/paintable.cpp
+++ b/src/widget/paintable.cpp
@@ -85,14 +85,15 @@ Paintable::Paintable(const PixmapSource& source, DrawMode mode, double scaleFact
 #endif
             // The SVG renderer doesn't directly support tiling, so we render
             // it to a pixmap which will then get tiled.
-            QImage copy_buffer(m_pSvg->defaultSize() * scaleFactor, QImage::Format_ARGB32);
-            copy_buffer.fill(Qt::transparent);
-            QPainter painter(&copy_buffer);
-            m_pSvg->render(&painter);
-            WPixmapStore::correctImageColors(&copy_buffer);
+                QImage copy_buffer(m_pSvg->defaultSize() * scaleFactor,
+                        QImage::Format_ARGB32_Premultiplied);
+                copy_buffer.fill(Qt::transparent);
+                QPainter painter(&copy_buffer);
+                m_pSvg->render(&painter);
+                WPixmapStore::correctImageColors(&copy_buffer);
 
-            m_pPixmap.reset(new QPixmap(copy_buffer.size()));
-            m_pPixmap->convertFromImage(copy_buffer);
+                m_pPixmap.reset(new QPixmap(copy_buffer.size()));
+                m_pPixmap->convertFromImage(copy_buffer);
         }
     }
 }
@@ -157,7 +158,7 @@ QImage Paintable::toImage() const {
     }
 
     if (m_pSvg) {
-        QImage image(m_pSvg->defaultSize(), QImage::Format_ARGB32);
+        QImage image(m_pSvg->defaultSize(), QImage::Format_ARGB32_Premultiplied);
         image.fill(Qt::transparent);
         QPainter painter(&image);
         m_pSvg->render(&painter);

--- a/src/widget/paintable.cpp
+++ b/src/widget/paintable.cpp
@@ -87,6 +87,8 @@ Paintable::Paintable(const PixmapSource& source, DrawMode mode, double scaleFact
             // it to a pixmap which will then get tiled.
                 QImage copy_buffer(m_pSvg->defaultSize() * scaleFactor,
                         QImage::Format_ARGB32_Premultiplied);
+                // The constructor doesn't initialize the image with data,
+                // so we need to fill it before we can draw on it.
                 copy_buffer.fill(Qt::transparent);
                 QPainter painter(&copy_buffer);
                 m_pSvg->render(&painter);
@@ -159,6 +161,8 @@ QImage Paintable::toImage() const {
 
     if (m_pSvg) {
         QImage image(m_pSvg->defaultSize(), QImage::Format_ARGB32_Premultiplied);
+        // The constructor doesn't initialize the image with data,
+        // so we need to fill it before we can draw on it.
         image.fill(Qt::transparent);
         QPainter painter(&image);
         m_pSvg->render(&painter);

--- a/src/widget/paintable.h
+++ b/src/widget/paintable.h
@@ -38,7 +38,6 @@ class Paintable {
         return m_drawMode;
     }
 
-    void draw(int x, int y, QPainter* pPainter);
     void draw(const QRectF& targetRect, QPainter* pPainter);
     void draw(const QRectF& targetRect, QPainter* pPainter,
               const QRectF& sourceRect);
@@ -48,7 +47,6 @@ class Paintable {
 
     static DrawMode DrawModeFromString(const QString& str);
     static QString DrawModeToString(DrawMode mode);
-    static QString getAltFileName(const QString& fileName);
 
   private:
     void drawInternal(const QRectF& targetRect, QPainter* pPainter,

--- a/src/widget/wimagestore.cpp
+++ b/src/widget/wimagestore.cpp
@@ -69,7 +69,7 @@ QImage* WImageStore::getImageNoCache(const PixmapSource& source, double scaleFac
         }
 
         auto* pImage = new QImage(renderer.defaultSize() * scaleFactor,
-                QImage::Format_ARGB32);
+                QImage::Format_ARGB32_Premultiplied);
         pImage->fill(Qt::transparent);
         QPainter painter(pImage);
         renderer.render(&painter);


### PR DESCRIPTION
Removed 2 unused methods
Changed code to return early style
Implemented missing SVG branch for Paintable::toImage()
Replaced hardcoded transparency color by Qt::transparent
Use std::move instead reset/release