### PR TITLE
ES6+ ComponentsJS

### DIFF
--- a/res/controllers/engine-api.d.ts
+++ b/res/controllers/engine-api.d.ts
@@ -1,6 +1,4 @@
-
 /** ScriptConnectionJSProxy */
-
 declare interface ScriptConnection {
     /**
      * Disconnect the script connection,

--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -1,7 +1,7 @@
 /**
  * Components JS library for Mixxx
  * Documentation is on the Mixxx wiki at
- * http://mixxx.org/wiki/doku.php/components_js
+ * https://github.com/mixxxdj/mixxx/wiki/Components-JS
  *
  * Copyright (C) 2017 Be <be.0@gmx.com>
  *
@@ -18,12 +18,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- *
- *
- *
- * This library depends on Lodash, which is copyright JS Foundation
- * and other contributors and licensed under the MIT license. Refer to
- * the lodash.mixxx.js file in this directory for details.
  */
 
 (function(global) {

--- a/res/controllers/midi-components-0.1.js
+++ b/res/controllers/midi-components-0.1.js
@@ -1,0 +1,219 @@
+/**
+ * Components JS library for Mixxx
+ * Documentation is on the Mixxx wiki at
+ * https://github.com/mixxxdj/mixxx/wiki/Components-JS
+ *
+ * Copyright (C) 2017 Be <be.0@gmx.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+(function(global) {
+    /**
+     * @typedef ComponentOpts
+     * @property {number=} midiStatus
+     * @property {number=} midiNo
+     * @property {string=} group
+     * @property {string=} inKey
+     * @property {string=} outKey
+     * @property {boolean} [outConnect=true]
+     * @property {boolean} [outTrigger=true]
+     * @property {number} [max=127]
+     * @property {number} [shiftOffset=0]
+     * @property {Component.SendShifted} [sendShifted=Component.SendShifted.NO]
+     */
+    class Component {
+        /** @param {ComponentOpts} opts */
+        constructor({
+            midiStatus = undefined,
+            midiNo = undefined,
+            group = undefined,
+            inKey = undefined,
+            outKey = undefined,
+            outConnect = true,
+            outTrigger = true,
+            max = 127,
+            shiftOffset = 0,
+            sendShifted = Component.SendShifted.NO
+        } = {}) {
+            /**
+             * @type {ScriptConnection[]}
+             * @protected
+             */
+            this._connections = [];
+            this.isShifted = false;
+
+            this.midiStatus = midiStatus;
+            this.midiNo = midiNo;
+            this.group = group;
+            this.inKey = inKey;
+            this.outKey = outKey;
+            this.outConnect = outConnect;
+            this.outTrigger = outTrigger;
+            this.max = max;
+            this.shiftOffset = shiftOffset;
+            this.sendShifted = sendShifted;
+
+            if (this.outConnect) {
+                this.connect();
+                this.outTrigger ? this.trigger() : this.noop();
+            }
+        }
+
+        noop() { /* Does nothing */ }
+
+        inValueScale(value) {
+            // Hack to get exact center of pots to return 0.5
+            return (value > (this.max / 2))
+                ? (value - 1) / (this.max - 1)
+                : value / (this.max + 1);
+        }
+
+        /**
+         * Processes a MIDI event received received from the HID/MIDI device
+         *
+         * By default, sets the Mixxx control {@link value} specified by {@link Component#inKey} in the group
+         * {@link Component#group}.
+         *
+         * @callback InputCallback
+         * @param {number} channel The MIDI channel
+         * @param {number} control The MIDI control (MIDI data 2)
+         * @param {number} value The MIDI value (MIDI byte 3)
+         * @param {number} status The MIDI statut (MIDI byte 1, ex: 0x9n)
+         * @param {string} group The Mixxx control group (ex: "[Master]")
+         * {@see https://manual.mixxx.org/2.3/en/chapters/appendix/mixxx_controls.html}
+         */
+        // eslint-disable-next-line no-unused-vars
+        input(channel, control, value, status, group) {
+            this.inSetParameter(this.inValueScale(value));
+        }
+
+        outValueScale(value) {
+            return value * this.max;
+        }
+
+        /**
+         * Processes a MIDI event specified by {@link Component#outKey} received from Mixxx in the group specified
+         * by {@link Component#group}
+         *
+         * By default, forwards the value, transformed by {@link Component#outValueScale} to the HID/MIDI controller
+         * using the MIDI status and MIDI group specified by {@link Component#midiStatus} and {@link Component#midiNo}
+         * @param {number} value The MIDI value (MIDI byte 3)
+         * @param {number} control The Mixxx control (Ex: play_indicator)
+         * @param {string} group The Mixxx control group (ex: "[Channel1]")
+         * {@see https://manual.mixxx.org/2.3/en/chapters/appendix/mixxx_controls.html}
+         */
+        // eslint-disable-next-line no-unused-vars
+        output(value, group, control) {
+            this.send(this.outValueScale(value));
+        }
+
+        // common functions
+        // In most cases, you should not overwrite these.
+        inGetParameter() {
+            return engine.getParameter(this.group, this.inKey);
+        }
+
+        inSetParameter(value) {
+            engine.setParameter(this.group, this.inKey, value);
+        }
+
+        inGetValue() {
+            return engine.getValue(this.group, this.inKey);
+        }
+
+        inSetValue(value) {
+            engine.setValue(this.group, this.inKey, value);
+        }
+
+        inToggle() {
+            this.inSetValue(!this.inGetValue());
+        }
+
+        outGetParameter() {
+            return engine.getParameter(this.group, this.outKey);
+        }
+
+        outSetParameter(value) {
+            engine.setParameter(this.group, this.outKey, value);
+        }
+
+        outGetValue() {
+            return engine.getValue(this.group, this.outKey);
+        }
+
+        outSetValue(value) {
+            engine.setValue(this.group, this.outKey, value);
+        }
+
+        outToggle() {
+            this.outSetValue(!this.outGetValue());
+        }
+
+        /**
+         * Override this method with a custom one to connect multiple Mixxx COs for a single Component.
+         * Add the connection objects to the this.connections array so they all get disconnected just
+         * by calling {@link Component#disconnect}. This can be helpful for multicolor LEDs that show a
+         * different color depending on the state of different Mixxx COs. Refer to
+         * {@link SamplerButton#connect} and {@link SamplerButton#output} for an example.
+         */
+        connect() {
+            if (this.group === undefined && this.outKey === undefined) {
+                return;
+            }
+
+            const connection = engine.makeConnection(this.group, this.outKey, this.output);
+            if (connection !== undefined) {
+                this._connections.push(connection);
+            }
+        }
+
+        disconnect() {
+            this._connections.forEach(it => it.disconnect());
+        }
+
+        trigger() {
+            this._connections.forEach(it => it.trigger());
+        }
+
+        send(value) {
+            if (this.midiStatus === undefined || this.midiNo === undefined) {
+                return;
+            }
+
+            midi.sendShortMsg(this.midiStatus, this.midiNo, value);
+
+            if (this.sendShifted === Component.SendShifted.CHANNEL) {
+                midi.sendShortMsg(this.midiStatus + this.shiftOffset, this.midiNo, value);
+            } else if (this.sendShifted === Component.SendShifted.CONTROL) {
+                midi.sendShortMsg(this.midiStatus, this.midiNo + this.shiftOffset, value);
+            }
+        }
+    }
+
+    /**
+     * @readonly
+     * @enum {number}
+     */
+    Component.SendShifted = Object.freeze({
+        NO: 0,
+        CHANNEL: 1,
+        CONTROL: 2
+    });
+
+    global.components = Object.freeze({
+        Component
+    });
+}(this));

--- a/res/controllers/midi-components-0.1.midi.xml
+++ b/res/controllers/midi-components-0.1.midi.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MixxxControllerPreset mixxxVersion="2.5.0" schemaVersion="1">
+    <info>
+        <name>Dummy controller for testing midi-components-0.1.js</name>
+        <author>christophehenry</author>
+        <description>
+            Dummy controller to assert midi-components-0.1.js code is correctly interpretable by Mixxx' JS engine
+        </description>
+    </info>
+    <controller id="Dummy">
+        <scriptfiles>
+            <file filename="midi-components-0.1.js" functionprefix=""/>
+        </scriptfiles>
+        <controls/>
+        <outputs/>
+    </controller>
+</MixxxControllerPreset>


### PR DESCRIPTION
Superseeds #4550

This is an attempt at rewriting `midi-components-0.0.js` with modern JS and correct type hinting fr IDEs.

I'm starting small. Component by component in order to get regular feedbacks, starting with the general `Component`.

Some rationals guiding the development of the new API and design decisions (will be updated as development goes):
1. The API is developped for eas of use first. It priorizes readability and documentation with JSDoc to ease IDEs type hinting.
2. The `Component`'s constructor doesn't not merge all of its parameters into `this`. This is to avoid multiple ways of overriding `Component`'s behavior and easier documenting constructor parameters with JSDoc. If you need a more specific behavior, you should create a new class extending the original component.
