### PR TITLE
Library: fix font reset in multiline comment editor

### DIFF
--- a/src/library/tabledelegates/multilineeditdelegate.cpp
+++ b/src/library/tabledelegates/multilineeditdelegate.cpp
@@ -32,6 +32,11 @@ MultiLineEditor::MultiLineEditor(QWidget* pParent,
     // Add event filter to catch right-clicks and key presses, see eventFilter()
     installEventFilter(this);
 
+    // Explicitly set the font, otherwise the font might be reset
+    // after first edit.
+    const auto font = m_pTableView->font();
+    setFont(font);
+
     // Adjust size to fit content and maybe shift vertically to fit into the
     // library view. documentSizeChanged() is emitted when the layout has been
     // adjusted according to text changes, incl. initial fill.


### PR DESCRIPTION
In the multi-line comment editor, with Qt6 and with a library font significantly taller than the default, I noticed this a few times:
* initially the editor font is the library font (size)
* add a line break and the editor font is reset (to app default? library default?)

I have no idea  what exactly was causing this, but at least I can't reproduce anymore when adopting the library font explicitly when constructung the editor.