### PR TITLE
(fix) Sound preferences: don't set m_settingsModified in update slots

### DIFF
--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -22,6 +22,11 @@
 namespace {
 
 const QString kAppGroup = QStringLiteral("[App]");
+const QString kMasterGroup = QStringLiteral("[Master]");
+const ConfigKey kKeylockEngingeCfgkey =
+        ConfigKey(kAppGroup, QStringLiteral("keylock_engine"));
+const ConfigKey kKeylockMultiThreadingCfgkey =
+        ConfigKey(kAppGroup, QStringLiteral("keylock_multithreading"));
 
 bool soundItemAlreadyExists(const AudioPath& output, const QWidget& widget) {
     for (const QObject* pObj : widget.children()) {
@@ -69,6 +74,12 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
           m_pSoundManager(pSoundManager),
           m_pSettings(pSettings),
           m_config(pSoundManager.get()),
+          m_pLatencyCompensation(kMasterGroup, QStringLiteral("microphoneLatencyCompensation")),
+          m_pMainDelay(kMasterGroup, QStringLiteral("delay")),
+          m_pHeadDelay(kMasterGroup, QStringLiteral("headDelay")),
+          m_pBoothDelay(kMasterGroup, QStringLiteral("boothDelay")),
+          m_pMicMonitorMode(kMasterGroup, QStringLiteral("talkover_mix")),
+          m_pKeylockEngine(kKeylockEngingeCfgkey),
           m_settingsModified(false),
           m_bLatencyChanged(false),
           m_bSkipConfigClear(true),
@@ -137,16 +148,11 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
         }
     }
 
-    m_pLatencyCompensation = new ControlProxy("[Master]", "microphoneLatencyCompensation", this);
-    m_pMainDelay = new ControlProxy("[Master]", "delay", this);
-    m_pHeadDelay = new ControlProxy("[Master]", "headDelay", this);
-    m_pBoothDelay = new ControlProxy("[Master]", "boothDelay", this);
-
-    latencyCompensationSpinBox->setValue(m_pLatencyCompensation->get());
+    latencyCompensationSpinBox->setValue(m_pLatencyCompensation.get());
     latencyCompensationWarningLabel->setWordWrap(true);
-    mainDelaySpinBox->setValue(m_pMainDelay->get());
-    headDelaySpinBox->setValue(m_pHeadDelay->get());
-    boothDelaySpinBox->setValue(m_pBoothDelay->get());
+    mainDelaySpinBox->setValue(m_pMainDelay.get());
+    headDelaySpinBox->setValue(m_pHeadDelay.get());
+    boothDelaySpinBox->setValue(m_pBoothDelay.get());
 
     // TODO These settings are applied immediately via ControlProxies.
     // While this is handy for testing the delays, it breaks the rule to
@@ -168,7 +174,6 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
             this,
             &DlgPrefSound::boothDelaySpinboxChanged);
 
-    m_pMicMonitorMode = new ControlProxy("[Master]", "talkover_mix", this);
     micMonitorModeComboBox->addItem(tr("Main output only"),
             QVariant(static_cast<int>(EngineMixer::MicMonitorMode::Main)));
     micMonitorModeComboBox->addItem(tr("Main and booth outputs"),
@@ -176,7 +181,7 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
     micMonitorModeComboBox->addItem(tr("Direct monitor (recording and broadcasting only)"),
             QVariant(static_cast<int>(EngineMixer::MicMonitorMode::DirectMonitor)));
     int modeIndex = micMonitorModeComboBox->findData(
-        static_cast<int>(m_pMicMonitorMode->get()));
+            static_cast<int>(m_pMicMonitorMode.get()));
     micMonitorModeComboBox->setCurrentIndex(modeIndex);
     micMonitorModeComboBoxChanged(modeIndex);
     connect(micMonitorModeComboBox,
@@ -240,16 +245,18 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
                 loadSettings();
             });
 
-    m_pAudioLatencyOverloadCount =
-            new ControlProxy(kAppGroup, QStringLiteral("audio_latency_overload_count"), this);
+    m_pAudioLatencyOverloadCount = make_parented<ControlProxy>(
+            kAppGroup, QStringLiteral("audio_latency_overload_count"), this);
     m_pAudioLatencyOverloadCount->connectValueChanged(this, &DlgPrefSound::bufferUnderflow);
 
-    m_pOutputLatencyMs = new ControlProxy(kAppGroup, QStringLiteral("output_latency_ms"), this);
+    m_pOutputLatencyMs = make_parented<ControlProxy>(
+            kAppGroup, QStringLiteral("output_latency_ms"), this);
     m_pOutputLatencyMs->connectValueChanged(this, &DlgPrefSound::outputLatencyChanged);
 
     // TODO: remove this option by automatically disabling/enabling the main mix
     // when recording, broadcasting, headphone, and main outputs are enabled/disabled
-    m_pMainEnabled = new ControlProxy("[Master]", "enabled", this);
+    m_pMainEnabled =
+            make_parented<ControlProxy>(kMasterGroup, QStringLiteral("enabled"), this);
     mainMixComboBox->addItem(tr("Disabled"));
     mainMixComboBox->addItem(tr("Enabled"));
     mainMixComboBox->setCurrentIndex(m_pMainEnabled->toBool() ? 1 : 0);
@@ -259,7 +266,8 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
             &DlgPrefSound::mainMixChanged);
     m_pMainEnabled->connectValueChanged(this, &DlgPrefSound::mainEnabledChanged);
 
-    m_pMainMonoMixdown = new ControlProxy("[Master]", "mono_mixdown", this);
+    m_pMainMonoMixdown =
+            make_parented<ControlProxy>(kMasterGroup, QStringLiteral("mono_mixdown"), this);
     mainOutputModeComboBox->addItem(tr("Stereo"));
     mainOutputModeComboBox->addItem(tr("Mono"));
     mainOutputModeComboBox->setCurrentIndex(m_pMainMonoMixdown->toBool() ? 1 : 0);
@@ -268,9 +276,6 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
             this,
             &DlgPrefSound::mainOutputModeComboBoxChanged);
     m_pMainMonoMixdown->connectValueChanged(this, &DlgPrefSound::mainMonoMixdownChanged);
-
-    m_pKeylockEngine =
-            new ControlProxy(kAppGroup, QStringLiteral("keylock_engine"), this);
 
 #ifdef __LINUX__
     qDebug() << "RLimit Cur " << RLimit::getCurRtPrio();
@@ -326,14 +331,14 @@ void DlgPrefSound::slotApply() {
         ScopedWaitCursor cursor;
         const auto keylockEngine =
                 keylockComboBox->currentData().value<EngineBuffer::KeylockEngine>();
-        m_pKeylockEngine->set(static_cast<double>(keylockEngine));
-        m_pSettings->set(ConfigKey("[Master]", "keylock_engine"),
+        m_pKeylockEngine.set(static_cast<double>(keylockEngine));
+        m_pSettings->set(kKeylockEngingeCfgkey,
                 ConfigValue(static_cast<int>(keylockEngine)));
 
 #ifdef __RUBBERBAND__
         bool keylockMultithreading = m_pSettings->getValue(
-                ConfigKey(kAppGroup, "keylock_multithreading"), false);
-        m_pSettings->setValue(ConfigKey(kAppGroup, "keylock_multithreading"),
+                kKeylockMultiThreadingCfgkey, false);
+        m_pSettings->setValue(kKeylockMultiThreadingCfgkey,
                 keylockDualthreadedCheckBox->isChecked() &&
                         keylockDualthreadedCheckBox->isEnabled());
         if (keylockMultithreading !=
@@ -527,7 +532,7 @@ void DlgPrefSound::loadSettings(const SoundManagerConfig& config) {
 
     // Default keylock engine is Rubberband Faster (v2)
     const auto keylockEngine = static_cast<EngineBuffer::KeylockEngine>(
-            m_pSettings->getValue(ConfigKey("[Master]", "keylock_engine"),
+            m_pSettings->getValue(kKeylockEngingeCfgkey,
                     static_cast<int>(EngineBuffer::defaultKeylockEngine())));
     const auto keylockEngineVariant = QVariant::fromValue(keylockEngine);
     const int index = keylockComboBox->findData(keylockEngineVariant);
@@ -542,7 +547,7 @@ void DlgPrefSound::loadSettings(const SoundManagerConfig& config) {
 #ifdef __RUBBERBAND__
     // Default is no multi threading on keylock
     keylockDualthreadedCheckBox->setChecked(m_pSettings->getValue(
-            ConfigKey(kAppGroup, QStringLiteral("keylock_multithreading")),
+            kKeylockMultiThreadingCfgkey,
             false));
 #endif
 
@@ -871,22 +876,22 @@ void DlgPrefSound::slotResetToDefaults() {
     if (index >= 0) {
         keylockComboBox->setCurrentIndex(index);
     }
-    m_pKeylockEngine->set(static_cast<double>(keylockEngine));
+    m_pKeylockEngine.set(static_cast<double>(keylockEngine));
 
     mainMixComboBox->setCurrentIndex(1);
     m_pMainEnabled->set(1.0);
 
     mainDelaySpinBox->setValue(0.0);
-    m_pMainDelay->set(0.0);
+    m_pMainDelay.set(0.0);
 
     headDelaySpinBox->setValue(0.0);
-    m_pHeadDelay->set(0.0);
+    m_pHeadDelay.set(0.0);
 
     boothDelaySpinBox->setValue(0.0);
-    m_pBoothDelay->set(0.0);
+    m_pBoothDelay.set(0.0);
 
     // Enable talkover main output
-    m_pMicMonitorMode->set(
+    m_pMicMonitorMode.set(
             static_cast<double>(
                     static_cast<int>(EngineMixer::MicMonitorMode::Main)));
     micMonitorModeComboBox->setCurrentIndex(
@@ -909,20 +914,20 @@ void DlgPrefSound::outputLatencyChanged(double latency) {
 }
 
 void DlgPrefSound::latencyCompensationSpinboxChanged(double value) {
-    m_pLatencyCompensation->set(value);
+    m_pLatencyCompensation.set(value);
     checkLatencyCompensation();
 }
 
 void DlgPrefSound::mainDelaySpinboxChanged(double value) {
-    m_pMainDelay->set(value);
+    m_pMainDelay.set(value);
 }
 
 void DlgPrefSound::headDelaySpinboxChanged(double value) {
-    m_pHeadDelay->set(value);
+    m_pHeadDelay.set(value);
 }
 
 void DlgPrefSound::boothDelaySpinboxChanged(double value) {
-    m_pBoothDelay->set(value);
+    m_pBoothDelay.set(value);
 }
 
 void DlgPrefSound::mainMixChanged(int value) {
@@ -960,7 +965,7 @@ void DlgPrefSound::micMonitorModeComboBoxChanged(int value) {
             static_cast<EngineMixer::MicMonitorMode>(
                     micMonitorModeComboBox->itemData(value).toInt());
 
-    m_pMicMonitorMode->set(static_cast<double>(newMode));
+    m_pMicMonitorMode.set(static_cast<double>(newMode));
 
     checkLatencyCompensation();
 }
@@ -968,7 +973,7 @@ void DlgPrefSound::micMonitorModeComboBoxChanged(int value) {
 void DlgPrefSound::checkLatencyCompensation() {
     EngineMixer::MicMonitorMode configuredMicMonitorMode =
             static_cast<EngineMixer::MicMonitorMode>(
-                    static_cast<int>(m_pMicMonitorMode->get()));
+                    static_cast<int>(m_pMicMonitorMode.get()));
 
     // Do not clear the SoundManagerConfig on startup, from slotApply, or from slotUpdate
     if (!m_bSkipConfigClear) {
@@ -984,7 +989,7 @@ void DlgPrefSound::checkLatencyCompensation() {
             latencyCompensationSpinBox->setEnabled(true);
             QString lineBreak("<br/>");
             // TODO(Be): Make the "User Manual" text link to the manual.
-            if (m_pLatencyCompensation->get() == 0.0) {
+            if (m_pLatencyCompensation.get() == 0.0) {
                 latencyCompensationWarningLabel->setText(kWarningIconHtmlString +
                         tr("Microphone inputs are out of time in the record & "
                            "broadcast signal compared to what you hear.") +

--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -75,6 +75,7 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     void configuredDeviceNotFound();
     void queryClicked();
 #ifdef __RUBBERBAND__
+    void updateKeylockDualThreadingCheckbox();
     void updateKeylockMultithreading(bool enabled);
 #endif
 

--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include "control/pollingcontrolproxy.h"
 #include "defs_urls.h"
 #include "preferences/dialog/dlgpreferencepage.h"
 #include "preferences/dialog/ui_dlgprefsounddlg.h"
@@ -9,6 +10,7 @@
 #include "soundio/sounddevice.h"
 #include "soundio/sounddevicestatus.h"
 #include "soundio/soundmanagerconfig.h"
+#include "util/parented_ptr.h"
 
 class SoundManager;
 class PlayerManager;
@@ -86,16 +88,19 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     std::shared_ptr<SoundManager> m_pSoundManager;
     UserSettingsPointer m_pSettings;
     SoundManagerConfig m_config;
-    ControlProxy* m_pAudioLatencyOverloadCount;
-    ControlProxy* m_pOutputLatencyMs;
-    ControlProxy* m_pHeadDelay;
-    ControlProxy* m_pMainDelay;
-    ControlProxy* m_pBoothDelay;
-    ControlProxy* m_pLatencyCompensation;
-    ControlProxy* m_pKeylockEngine;
-    ControlProxy* m_pMainEnabled;
-    ControlProxy* m_pMainMonoMixdown;
-    ControlProxy* m_pMicMonitorMode;
+
+    PollingControlProxy m_pLatencyCompensation;
+    PollingControlProxy m_pMainDelay;
+    PollingControlProxy m_pHeadDelay;
+    PollingControlProxy m_pBoothDelay;
+    PollingControlProxy m_pMicMonitorMode;
+    PollingControlProxy m_pKeylockEngine;
+
+    parented_ptr<ControlProxy> m_pAudioLatencyOverloadCount;
+    parented_ptr<ControlProxy> m_pOutputLatencyMs;
+    parented_ptr<ControlProxy> m_pMainEnabled;
+    parented_ptr<ControlProxy> m_pMainMonoMixdown;
+
     QList<SoundDevicePointer> m_inputDevices;
     QList<SoundDevicePointer> m_outputDevices;
     QHash<DlgPrefSoundItem*, QPair<SoundDeviceId, int>> m_selectedOutputChannelIndices;


### PR DESCRIPTION
Currently the `m_settingsModified` is set in `DlgPrefSound::slotUpdate()` which will cause a sound pause when pressing **Apply** in any pref page, because `DlgPrefSound::slotApply()` would reapply the current (unchanged) sound config.
https://github.com/mixxxdj/mixxx/pull/13070#discussion_r1667683929

Fixed by moving the keylock dual-threading checkbox update to a dedicated method and call then when necessary.

@acolombier please check if I got everything right.