### PR TITLE
AutoDJ: force-show decks 3/4 if we are going to use them

### DIFF
--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -407,6 +407,12 @@ AutoDJProcessor::AutoDJError AutoDJProcessor::toggleAutoDJ(bool enable) {
             }
         }
 
+        if (pLeftDeck->index > 1 || pRightDeck->index > 1) {
+            // Left and/or right deck is deck 3/4 which may not be visible.
+            // Make sure it is, if the current skin is a 4-deck skin.
+            ControlObject::set(ConfigKey("[Skin]", "show_4decks"), 1);
+        }
+
         // Never load the same track if it is already playing
         if (leftDeckPlaying) {
             removeLoadedTrackFromTopOfQueue(*pLeftDeck);


### PR DESCRIPTION
Avoids potential of confusion if AutoDJ resorts to deck 3 and/or 4 while deck 1/2 are assigned to crossfader center.

(obviously doesn't cover the case where controller mappings request 4 decks but e.g. Shade skin can't show them)

Fixes: https://github.com/mixxxdj/mixxx/issues/13396