### PR TITLE
Fix "Wrong Key format written to the file Tags"

### DIFF
--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -38,31 +38,66 @@ const QString s_sharpSymbol = QString::fromUtf8("♯");
 //static const QString s_flatSymbol = QString::fromUtf8("♭");
 
 const QString s_traditionalKeyNames[] = {
-        QString::fromUtf8("INVALID"),
-        QString::fromUtf8("C"),
-        QString::fromUtf8("D♭"),
-        QString::fromUtf8("D"),
-        QString::fromUtf8("E♭"),
-        QString::fromUtf8("E"),
-        QString::fromUtf8("F"),
-        QString::fromUtf8("F♯/G♭"),
-        QString::fromUtf8("G"),
-        QString::fromUtf8("A♭"),
-        QString::fromUtf8("A"),
-        QString::fromUtf8("B♭"),
-        QString::fromUtf8("B"),
-        QString::fromUtf8("Cm"),
-        QString::fromUtf8("C♯m"),
-        QString::fromUtf8("Dm"),
-        QString::fromUtf8("D♯m/E♭m"),
-        QString::fromUtf8("Em"),
-        QString::fromUtf8("Fm"),
-        QString::fromUtf8("F♯m"),
-        QString::fromUtf8("Gm"),
-        QString::fromUtf8("G♯m"),
-        QString::fromUtf8("Am"),
-        QString::fromUtf8("B♭m"),
-        QString::fromUtf8("Bm")};
+        QStringLiteral(u"INVALID"),
+        QStringLiteral(u"C"),
+        QStringLiteral(u"D♭"),
+        QStringLiteral(u"D"),
+        QStringLiteral(u"E♭"),
+        QStringLiteral(u"E"),
+        QStringLiteral(u"F"),
+        QStringLiteral(u"F♯/G♭"),
+        QStringLiteral(u"G"),
+        QStringLiteral(u"A♭"),
+        QStringLiteral(u"A"),
+        QStringLiteral(u"B♭"),
+        QStringLiteral(u"B"),
+        QStringLiteral(u"Cm"),
+        QStringLiteral(u"C♯m"),
+        QStringLiteral(u"Dm"),
+        QStringLiteral(u"D♯m/E♭m"),
+        QStringLiteral(u"Em"),
+        QStringLiteral(u"Fm"),
+        QStringLiteral(u"F♯m"),
+        QStringLiteral(u"Gm"),
+        QStringLiteral(u"G♯m"),
+        QStringLiteral(u"Am"),
+        QStringLiteral(u"B♭m"),
+        QStringLiteral(u"Bm")};
+
+// ID3v2.3.0 specification (https://id3.org/id3v2.3.0):
+// The 'Initial key' frame contains the musical key in which the sound starts.
+// It is represented as a string with a maximum length of three characters.
+// The ground keys are represented with "A","B","C","D","E", "F" and "G" and halfkeys
+// represented with "b" and "#". Minor is represented as "m". Example "Cbm".
+// Off key is represented with an "o" only.
+const std::array s_IDv3KeyNames = {
+        // these are QStringLiterals because they're used as QStrings below, even though they
+        // only contain ASCII characters
+        QStringLiteral("o"),
+        QStringLiteral("C"),
+        QStringLiteral("Db"),
+        QStringLiteral("D"),
+        QStringLiteral("Eb"),
+        QStringLiteral("E"),
+        QStringLiteral("F"),
+        QStringLiteral("F#"),
+        QStringLiteral("G"),
+        QStringLiteral("Ab"),
+        QStringLiteral("A"),
+        QStringLiteral("Bb"),
+        QStringLiteral("B"),
+        QStringLiteral("Cm"),
+        QStringLiteral("C#m"),
+        QStringLiteral("Dm"),
+        QStringLiteral("D#m"),
+        QStringLiteral("Em"),
+        QStringLiteral("Fm"),
+        QStringLiteral("F#m"),
+        QStringLiteral("Gm"),
+        QStringLiteral("G#m"),
+        QStringLiteral("Am"),
+        QStringLiteral("B#m"),
+        QStringLiteral("Bm")};
 
 // Maps an OpenKey number to its major and minor key.
 constexpr ChromaticKey s_openKeyToKeys[][2] = {
@@ -272,6 +307,50 @@ void KeyUtils::setNotation(const QMap<ChromaticKey, QString>& notation) {
 }
 
 // static
+int KeyUtils::keyToOpenKeyNumber(mixxx::track::io::key::ChromaticKey key) {
+    switch (key) {
+    case mixxx::track::io::key::C_MAJOR:
+    case mixxx::track::io::key::A_MINOR:
+        return 1;
+    case mixxx::track::io::key::G_MAJOR:
+    case mixxx::track::io::key::E_MINOR:
+        return 2;
+    case mixxx::track::io::key::D_MAJOR:
+    case mixxx::track::io::key::B_MINOR:
+        return 3;
+    case mixxx::track::io::key::A_MAJOR:
+    case mixxx::track::io::key::F_SHARP_MINOR:
+        return 4;
+    case mixxx::track::io::key::E_MAJOR:
+    case mixxx::track::io::key::C_SHARP_MINOR:
+        return 5;
+    case mixxx::track::io::key::B_MAJOR:
+    case mixxx::track::io::key::G_SHARP_MINOR:
+        return 6;
+    case mixxx::track::io::key::F_SHARP_MAJOR:
+    case mixxx::track::io::key::E_FLAT_MINOR:
+        return 7;
+    case mixxx::track::io::key::D_FLAT_MAJOR:
+    case mixxx::track::io::key::B_FLAT_MINOR:
+        return 8;
+    case mixxx::track::io::key::A_FLAT_MAJOR:
+    case mixxx::track::io::key::F_MINOR:
+        return 9;
+    case mixxx::track::io::key::E_FLAT_MAJOR:
+    case mixxx::track::io::key::C_MINOR:
+        return 10;
+    case mixxx::track::io::key::B_FLAT_MAJOR:
+    case mixxx::track::io::key::G_MINOR:
+        return 11;
+    case mixxx::track::io::key::F_MAJOR:
+    case mixxx::track::io::key::D_MINOR:
+        return 12;
+    default:
+        return 0;
+    }
+}
+
+// static
 QString KeyUtils::keyToString(ChromaticKey key,
                               KeyNotation notation) {
     if (!ChromaticKey_IsValid(key) ||
@@ -309,6 +388,8 @@ QString KeyUtils::keyToString(ChromaticKey key,
         return QString::number(number) + (major ? "B" : "A") + " (" + trad + ")";
     } else if (notation == KeyNotation::Traditional) {
         return s_traditionalKeyNames[static_cast<int>(key)];
+    } else if (notation == KeyNotation::ID3v2) {
+        return s_IDv3KeyNames[static_cast<int>(key)];
     }
     return keyDebugName(key);
 }

--- a/src/track/keyutils.h
+++ b/src/track/keyutils.h
@@ -21,7 +21,8 @@ class KeyUtils {
         Traditional = 4,
         OpenKeyAndTraditional = 5,
         LancelotAndTraditional = 6,
-        NumKeyNotations = 7
+        ID3v2 = 7,
+        NumKeyNotations = 8
     };
 
     enum class ScaleMode {
@@ -125,48 +126,7 @@ class KeyUtils {
 
     static mixxx::track::io::key::ChromaticKey openKeyNumberToKey(int openKeyNumber, bool major);
 
-    static inline int keyToOpenKeyNumber(mixxx::track::io::key::ChromaticKey key) {
-        switch (key) {
-            case mixxx::track::io::key::C_MAJOR:
-            case mixxx::track::io::key::A_MINOR:
-                return 1;
-            case mixxx::track::io::key::G_MAJOR:
-            case mixxx::track::io::key::E_MINOR:
-                return 2;
-            case mixxx::track::io::key::D_MAJOR:
-            case mixxx::track::io::key::B_MINOR:
-                return 3;
-            case mixxx::track::io::key::A_MAJOR:
-            case mixxx::track::io::key::F_SHARP_MINOR:
-                return 4;
-            case mixxx::track::io::key::E_MAJOR:
-            case mixxx::track::io::key::C_SHARP_MINOR:
-                return 5;
-            case mixxx::track::io::key::B_MAJOR:
-            case mixxx::track::io::key::G_SHARP_MINOR:
-                return 6;
-            case mixxx::track::io::key::F_SHARP_MAJOR:
-            case mixxx::track::io::key::E_FLAT_MINOR:
-                return 7;
-            case mixxx::track::io::key::D_FLAT_MAJOR:
-            case mixxx::track::io::key::B_FLAT_MINOR:
-                return 8;
-            case mixxx::track::io::key::A_FLAT_MAJOR:
-            case mixxx::track::io::key::F_MINOR:
-                return 9;
-            case mixxx::track::io::key::E_FLAT_MAJOR:
-            case mixxx::track::io::key::C_MINOR:
-                return 10;
-            case mixxx::track::io::key::B_FLAT_MAJOR:
-            case mixxx::track::io::key::G_MINOR:
-                return 11;
-            case mixxx::track::io::key::F_MAJOR:
-            case mixxx::track::io::key::D_MINOR:
-                return 12;
-            default:
-                return 0;
-        }
-    }
+    static int keyToOpenKeyNumber(mixxx::track::io::key::ChromaticKey key);
 
     static int keyToCircleOfFifthsOrder(mixxx::track::io::key::ChromaticKey key,
                                         KeyNotation notation);

--- a/src/track/taglib/trackmetadata_id3v2.cpp
+++ b/src/track/taglib/trackmetadata_id3v2.cpp
@@ -7,6 +7,8 @@
 #include <unknownframe.h>
 
 #include <array>
+
+#include "track/keyutils.h"
 #if defined(__EXTRA_METADATA__)
 #include <uniquefileidentifierframe.h>
 #endif // __EXTRA_METADATA__
@@ -1211,10 +1213,10 @@ bool exportTrackMetadataIntoTag(TagLib::ID3v2::Tag* pTag,
             formatBpmInteger(trackMetadata),
             true);
 
-    writeTextIdentificationFrame(
-            pTag,
+    writeTextIdentificationFrame(pTag,
             "TKEY",
-            trackMetadata.getTrackInfo().getKeyText());
+            KeyUtils::keyToString(trackMetadata.getTrackInfo().getGlobalKey(),
+                    KeyUtils::KeyNotation::ID3v2));
 
     writeUserTextIdentificationFrame(
             pTag,

--- a/src/track/trackinfo.cpp
+++ b/src/track/trackinfo.cpp
@@ -61,7 +61,7 @@ bool TrackInfo::compareEq(
 #if defined(__EXTRA_METADATA__)
             (getISRC() == trackInfo.getISRC()) &&
 #endif // __EXTRA_METADATA__
-            (getKeyText() == trackInfo.getKeyText()) &&
+            (getGlobalKey() == trackInfo.getGlobalKey()) &&
 #if defined(__EXTRA_METADATA__)
             (getLanguage() == trackInfo.getLanguage()) &&
             (getLyricist() == trackInfo.getLyricist()) &&

--- a/src/track/trackinfo.h
+++ b/src/track/trackinfo.h
@@ -3,11 +3,11 @@
 #include <QString>
 #include <QUuid>
 
+#include "proto/keys.pb.h"
 #include "sources/audiosource.h"
 #include "track/bpm.h"
 #include "track/replaygain.h"
 #include "track/serato/tags.h"
-#include "util/duration.h"
 #include "util/macros.h"
 
 namespace mixxx {
@@ -31,6 +31,7 @@ class TrackInfo final {
     MIXXX_DECL_PROPERTY(QString, isrc, ISRC)
 #endif // __EXTRA_METADATA__
     MIXXX_DECL_PROPERTY(QString, keyText, KeyText)
+    MIXXX_DECL_PROPERTY(mixxx::track::io::key::ChromaticKey, globalKey, GlobalKey)
 #if defined(__EXTRA_METADATA__)
     MIXXX_DECL_PROPERTY(QString, language, Language)
     MIXXX_DECL_PROPERTY(QString, lyricist, Lyricist)

--- a/src/track/trackrecord.cpp
+++ b/src/track/trackrecord.cpp
@@ -23,7 +23,9 @@ TrackRecord::TrackRecord(TrackId id)
 }
 
 void TrackRecord::setKeys(const Keys& keys) {
-    refMetadata().refTrackInfo().setKeyText(KeyUtils::formatGlobalKey(keys));
+    auto& trackInfo = refMetadata().refTrackInfo();
+    trackInfo.setKeyText(KeyUtils::formatGlobalKey(keys));
+    trackInfo.setGlobalKey(keys.getGlobalKey());
     m_keys = std::move(keys);
 }
 


### PR DESCRIPTION
This is my yet untested attempt at fixing #10890

The reading of the tag is there, I have yet do discover all the places where the `TrackInfo` needs the key to be properly set. I have also not yet decided to how to handle the case where the user sets some custom key (guess the appropriate `ChromaticKey` and handle appropriately when we can't guess it). Also yet untested. 

Adoption is welcome.