### PR TITLE
fix: `components.Pot` producing wrong result on first value

### DIFF
--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -481,8 +481,7 @@
                 if (this.max === Component.prototype.max) {
                     this.max = (1 << 14) - 1;
                 }
-                value = (value << 7) + (this._firstLSB ? this._firstLSB : 0);
-                this.input(channel, control, value, status, group);
+                this.input(channel, control, (value << 7) + (this._firstLSB ? this._firstLSB : 0), status, group);
             }
             this.MSB = value;
         },


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/mixxxdj/mixxx/pull/4495 and reported as https://github.com/mixxxdj/mixxx/issues/11814