### PR TITLE
limit play marker hints text height to 1/3rd or full waveform height

### DIFF
--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -81,6 +81,9 @@ DlgPrefWaveform::DlgPrefWaveform(
     untilMarkAlignComboBox->addItem(tr("Center"));
     untilMarkAlignComboBox->addItem(tr("Bottom"));
 
+    untilMarkTextHeightLimitComboBox->addItem(tr("1/3rd of waveform viewer"));
+    untilMarkTextHeightLimitComboBox->addItem(tr("Full waveform viewer height"));
+
     // The GUI is not fully setup so connecting signals before calling
     // slotUpdate can generate rebootMixxxView calls.
     // TODO(XXX): Improve this awkwardness.
@@ -209,6 +212,10 @@ DlgPrefWaveform::DlgPrefWaveform(
             QOverload<int>::of(&QSpinBox::valueChanged),
             this,
             &DlgPrefWaveform::slotSetUntilMarkTextPointSize);
+    connect(untilMarkTextHeightLimitComboBox,
+            QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this,
+            &DlgPrefWaveform::slotSetUntilMarkTextHeightLimit);
 
     setScrollSafeGuardForAllInputWidgets(this);
 }
@@ -293,6 +300,9 @@ void DlgPrefWaveform::slotUpdate() {
             WaveformWidgetFactory::toUntilMarkAlignIndex(
                     factory->getUntilMarkAlign()));
     untilMarkTextPointSizeSpinBox->setValue(factory->getUntilMarkTextPointSize());
+    untilMarkTextHeightLimitComboBox->setCurrentIndex(
+            WaveformWidgetFactory::toUntilMarkTextHeightLimitIndex(
+                    factory->getUntilMarkTextHeightLimit()));
 
     WOverview::Type cfgOverviewType =
             m_pConfig->getValue<WOverview::Type>(kOverviewTypeCfgKey, WOverview::Type::RGB);
@@ -534,6 +544,7 @@ void DlgPrefWaveform::updateEnableUntilMark() {
     untilMarkAlignComboBox->setEnabled(enabled);
     untilMarkTextPointSizeLabel->setEnabled(enabled);
     untilMarkTextPointSizeSpinBox->setEnabled(enabled);
+    untilMarkTextHeightLimitComboBox->setEnabled(enabled);
     requiresGLSLLabel->setVisible(!enabled);
 }
 
@@ -621,6 +632,11 @@ void DlgPrefWaveform::slotSetUntilMarkAlign(int index) {
 
 void DlgPrefWaveform::slotSetUntilMarkTextPointSize(int value) {
     WaveformWidgetFactory::instance()->setUntilMarkTextPointSize(value);
+}
+
+void DlgPrefWaveform::slotSetUntilMarkTextHeightLimit(int index) {
+    WaveformWidgetFactory::instance()->setUntilMarkTextHeightLimit(
+            WaveformWidgetFactory::toUntilMarkTextHeightLimit(index));
 }
 
 void DlgPrefWaveform::calculateCachedWaveformDiskUsage() {

--- a/src/preferences/dialog/dlgprefwaveform.h
+++ b/src/preferences/dialog/dlgprefwaveform.h
@@ -62,6 +62,7 @@ class DlgPrefWaveform : public DlgPreferencePage, public Ui::DlgPrefWaveformDlg 
     void slotSetUntilMarkShowTime(bool checked);
     void slotSetUntilMarkAlign(int index);
     void slotSetUntilMarkTextPointSize(int value);
+    void slotSetUntilMarkTextHeightLimit(int index);
 
   private:
     void initWaveformControl();

--- a/src/preferences/dialog/dlgprefwaveformdlg.ui
+++ b/src/preferences/dialog/dlgprefwaveformdlg.ui
@@ -133,7 +133,7 @@
         <string>Play marker hints</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
        </property>
       </widget>
      </item>

--- a/src/preferences/dialog/dlgprefwaveformdlg.ui
+++ b/src/preferences/dialog/dlgprefwaveformdlg.ui
@@ -295,19 +295,6 @@
        </property>
       </widget>
      </item>
-     <item row="16" column="3">
-      <widget class="QLabel" name="untilMarkTextPointSizeLabel">
-       <property name="text">
-        <string>Font size</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-       </property>
-       <property name="buddy">
-        <cstring>untilMarkTextPointSizeSpinBox</cstring>
-       </property>
-      </widget>
-     </item>
      <item row="5" column="1" colspan="3">
       <widget class="QComboBox" name="waveformOverviewComboBox">
        <property name="toolTip">
@@ -329,13 +316,6 @@ Select from different types of displays for the waveform overview, which differ 
        </property>
       </widget>
      </item>
-     <item row="17" column="1">
-      <widget class="QCheckBox" name="untilMarkShowTimeCheckBox">
-       <property name="text">
-        <string>Time until next marker</string>
-       </property>
-      </widget>
-     </item>
      <item row="7" column="3">
       <widget class="QSpinBox" name="endOfTrackWarningTimeSpinBox">
        <property name="toolTip">
@@ -352,13 +332,6 @@ Select from different types of displays for the waveform overview, which differ 
        </property>
        <property name="value">
         <number>30</number>
-       </property>
-      </widget>
-     </item>
-     <item row="16" column="1">
-      <widget class="QCheckBox" name="untilMarkShowBeatsCheckBox">
-       <property name="text">
-        <string>Beats until next marker</string>
        </property>
       </widget>
      </item>
@@ -585,37 +558,87 @@ Select from different types of displays for the waveform overview, which differ 
        </property>
       </widget>
      </item>
-     <item row="16" column="2">
-      <widget class="QLabel" name="untilMarkAlignLabel">
-       <property name="text">
-        <string>Placement</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-       </property>
-       <property name="buddy">
-        <cstring>untilMarkAlignComboBox</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="17" column="3">
-      <widget class="QSpinBox" name="untilMarkTextPointSizeSpinBox">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="suffix">
-        <string> pt</string>
-       </property>
-       <property name="minimum">
-        <number>10</number>
-       </property>
-       <property name="maximum">
-        <number>50</number>
-       </property>
-       <property name="value">
-        <number>30</number>
-       </property>
-      </widget>
+     <item row="16" column="1" colspan="3">
+      <layout class="QGridLayout" name="gridLayout_4">
+       <item row="0" column="0">
+        <widget class="QCheckBox" name="untilMarkShowBeatsCheckBox">
+         <property name="text">
+          <string>Beats until next marker</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLabel" name="untilMarkAlignLabel">
+         <property name="text">
+          <string>Placement</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+         <property name="buddy">
+          <cstring>untilMarkAlignComboBox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="2">
+        <widget class="QLabel" name="untilMarkTextPointSizeLabel">
+         <property name="text">
+          <string>Preferred font size</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+         <property name="buddy">
+          <cstring>untilMarkTextPointSizeSpinBox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="3">
+        <widget class="QLabel" name="untilMarkTextHeightLimitLabel">
+         <property name="text">
+          <string>Text height limit</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+         <property name="buddy">
+          <cstring>untilMarkTextHeightLimitComboBox</cstring>
+         </property>
+        </widget>
+       </item>
+        <item row="1" column="0">
+        <widget class="QCheckBox" name="untilMarkShowTimeCheckBox">
+         <property name="text">
+          <string>Time until next marker</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QComboBox" name="untilMarkAlignComboBox"/>
+       </item>
+       <item row="1" column="2">
+        <widget class="QSpinBox" name="untilMarkTextPointSizeSpinBox">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="suffix">
+          <string> pt</string>
+         </property>
+         <property name="minimum">
+          <number>10</number>
+         </property>
+         <property name="maximum">
+          <number>100</number>
+         </property>
+         <property name="value">
+          <number>30</number>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="3">
+        <widget class="QComboBox" name="untilMarkTextHeightLimitComboBox"/>
+       </item>
+      </layout>
      </item>
      <item row="5" column="0">
       <widget class="QLabel" name="waveformOverviewLabel">
@@ -626,9 +649,6 @@ Select from different types of displays for the waveform overview, which differ 
         <string>Waveform overview type</string>
        </property>
       </widget>
-     </item>
-     <item row="17" column="2">
-      <widget class="QComboBox" name="untilMarkAlignComboBox"/>
      </item>
      <item row="9" column="1" colspan="3">
       <widget class="QSlider" name="playMarkerPositionSlider">

--- a/src/waveform/renderers/allshader/waveformrendermark.cpp
+++ b/src/waveform/renderers/allshader/waveformrendermark.cpp
@@ -85,8 +85,14 @@ void allshader::WaveformRenderMark::initializeGL() {
     updatePlayPosMarkTexture();
     const auto untilMarkTextPointSize =
             WaveformWidgetFactory::instance()->getUntilMarkTextPointSize();
+    const auto untilMarkTextHeightLimit =
+            WaveformWidgetFactory::instance()
+                    ->getUntilMarkTextHeightLimit(); // proportion of waveform
+                                                     // height
+    const auto untilMarkMaxHeightForText = getMaxHeightForText(untilMarkTextHeightLimit);
+
     m_digitsRenderer.updateTexture(untilMarkTextPointSize,
-            getMaxHeightForText(),
+            untilMarkMaxHeightForText,
             m_waveformRenderer->getDevicePixelRatio());
 }
 
@@ -319,8 +325,14 @@ void allshader::WaveformRenderMark::drawUntilMark(const QMatrix4x4& matrix, floa
 
     const auto untilMarkTextPointSize =
             WaveformWidgetFactory::instance()->getUntilMarkTextPointSize();
+    const auto untilMarkTextHeightLimit =
+            WaveformWidgetFactory::instance()
+                    ->getUntilMarkTextHeightLimit(); // proportion of waveform
+                                                     // height
+    const auto untilMarkMaxHeightForText = getMaxHeightForText(untilMarkTextHeightLimit);
+
     m_digitsRenderer.updateTexture(untilMarkTextPointSize,
-            getMaxHeightForText(),
+            untilMarkMaxHeightForText,
             m_waveformRenderer->getDevicePixelRatio());
 
     if (m_timeUntilMark == 0.0) {
@@ -333,7 +345,8 @@ void allshader::WaveformRenderMark::drawUntilMark(const QMatrix4x4& matrix, floa
             ? m_waveformRenderer->getBreadth() - ch
             : m_waveformRenderer->getBreadth() / 2.f;
 
-    bool multiLine = untilMarkShowBeats && untilMarkShowTime && ch * 2.f < getMaxHeightForText();
+    bool multiLine = untilMarkShowBeats && untilMarkShowTime &&
+            ch * 2.f < untilMarkMaxHeightForText;
 
     if (multiLine) {
         if (untilMarkAlign != Qt::AlignTop) {
@@ -513,6 +526,6 @@ void allshader::WaveformRenderMark::updateUntilMark(
                     (endPosition - playPosition));
 }
 
-float allshader::WaveformRenderMark::getMaxHeightForText() const {
-    return m_waveformRenderer->getBreadth() / 3;
+float allshader::WaveformRenderMark::getMaxHeightForText(float proportion) const {
+    return std::roundf(m_waveformRenderer->getBreadth() * proportion);
 }

--- a/src/waveform/renderers/allshader/waveformrendermark.h
+++ b/src/waveform/renderers/allshader/waveformrendermark.h
@@ -54,7 +54,7 @@ class allshader::WaveformRenderMark : public ::WaveformRenderMarkBase,
     void drawTexture(const QMatrix4x4& matrix, float x, float y, QOpenGLTexture* texture);
     void updateUntilMark(double playPosition, double markerPosition);
     void drawUntilMark(const QMatrix4x4& matrix, float x);
-    float getMaxHeightForText() const;
+    float getMaxHeightForText(float proportion) const;
 
     mixxx::RGBAShader m_rgbaShader;
     mixxx::TextureShader m_textureShader;

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -102,6 +102,7 @@ WaveformWidgetFactory::WaveformWidgetFactory()
           m_untilMarkShowTime(false),
           m_untilMarkAlign(Qt::AlignVCenter),
           m_untilMarkTextPointSize(24),
+          m_untilMarkTextHeightLimit(toUntilMarkTextHeightLimit(0)),
           m_openGlAvailable(false),
           m_openGlesAvailable(false),
           m_openGLShaderAvailable(false),
@@ -421,6 +422,9 @@ bool WaveformWidgetFactory::setConfig(UserSettingsPointer config) {
     setUntilMarkTextPointSize(
             m_config->getValue(ConfigKey("[Waveform]", "UntilMarkTextPointSize"),
                     m_untilMarkTextPointSize));
+    setUntilMarkTextHeightLimit(toUntilMarkTextHeightLimit(
+            m_config->getValue(ConfigKey("[Waveform]", "UntilMarkTextHeightLimit"),
+                    toUntilMarkTextHeightLimitIndex(m_untilMarkTextHeightLimit))));
 
     return true;
 }
@@ -1323,11 +1327,20 @@ void WaveformWidgetFactory::setUntilMarkAlign(Qt::Alignment align) {
                 toUntilMarkAlignIndex(m_untilMarkAlign));
     }
 }
+
 void WaveformWidgetFactory::setUntilMarkTextPointSize(int value) {
     m_untilMarkTextPointSize = value;
     if (m_config) {
         m_config->setValue(ConfigKey("[Waveform]", "UntilMarkTextPointSize"),
                 m_untilMarkTextPointSize);
+    }
+}
+
+void WaveformWidgetFactory::setUntilMarkTextHeightLimit(float value) {
+    m_untilMarkTextHeightLimit = value;
+    if (m_config) {
+        m_config->setValue(ConfigKey("[Waveform]", "UntilMarkTextHeightLimit"),
+                toUntilMarkTextHeightLimitIndex(m_untilMarkTextHeightLimit));
     }
 }
 
@@ -1358,4 +1371,26 @@ int WaveformWidgetFactory::toUntilMarkAlignIndex(Qt::Alignment align) {
     }
     assert(false);
     return 1;
+}
+// static
+float WaveformWidgetFactory::toUntilMarkTextHeightLimit(int index) {
+    switch (index) {
+    case 0:
+        return 0.333f;
+    case 1:
+        return 1.f;
+    }
+    assert(false);
+    return 0.33f;
+}
+// static
+int WaveformWidgetFactory::toUntilMarkTextHeightLimitIndex(float value) {
+    if (value == 0.333f) {
+        return 0;
+    }
+    if (value == 1.f) {
+        return 1;
+    }
+    assert(false);
+    return 0;
 }

--- a/src/waveform/waveformwidgetfactory.h
+++ b/src/waveform/waveformwidgetfactory.h
@@ -156,6 +156,7 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
     void setUntilMarkShowTime(bool value);
     void setUntilMarkAlign(Qt::Alignment align);
     void setUntilMarkTextPointSize(int value);
+    void setUntilMarkTextHeightLimit(float value);
 
     bool getUntilMarkShowBeats() const {
         return m_untilMarkShowBeats;
@@ -169,9 +170,13 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
     int getUntilMarkTextPointSize() const {
         return m_untilMarkTextPointSize;
     }
-
+    float getUntilMarkTextHeightLimit() const {
+        return m_untilMarkTextHeightLimit;
+    }
     static Qt::Alignment toUntilMarkAlign(int index);
     static int toUntilMarkAlignIndex(Qt::Alignment align);
+    static float toUntilMarkTextHeightLimit(int index);
+    static int toUntilMarkTextHeightLimitIndex(float value);
 
     /// Returns the desired surface format for the OpenGLWindow
     static QSurfaceFormat getSurfaceFormat(UserSettingsPointer config = nullptr);
@@ -276,6 +281,7 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
     bool m_untilMarkShowTime;
     Qt::Alignment m_untilMarkAlign;
     int m_untilMarkTextPointSize;
+    float m_untilMarkTextHeightLimit;
 
     bool m_openGlAvailable;
     bool m_openGlesAvailable;


### PR DESCRIPTION
The text height of the Play marker hints (beats and time until next marker) was limited to a third of the waveform viewer. Increasing the font size beyond that had no effect, until the waveform viewer was made higher.

This was confusing to the user and could be interpreted as a bug. Also, this limit of 1/3rd was arbitrary and not obvious. See this comment from Eve:

https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/.28RFC.29.20show.20beats.20until.20next.20marker/near/449084479

To make the mechanism more clear, I have renamed "Font size" to "Preferred font size" and added a combobox "Text height limit" with options "1/3rd on waveform viewer" and "Full waveform viewer". (This could also have been a spinbox, but I feel this is more clear and I don't see much value in more find grained control, though I am open to adding more options. Maybe 1/2 and 2/3rd?)