### PR TITLE
undo/redo cue add/remove, wip

### DIFF
--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -55,6 +55,7 @@
 #include "util/statsmanager.h"
 #include "util/time.h"
 #include "util/translations.h"
+#include "util/undostack.h"
 #include "util/versionstore.h"
 #include "vinylcontrol/vinylcontrolmanager.h"
 
@@ -143,6 +144,8 @@ CoreServices::CoreServices(const CmdlineArgs& args, QApplication* pApp)
     mixxx::Translations::initializeTranslations(
             m_pSettingsManager->settings(), pApp, m_cmdlineArgs.getLocale());
     initializeKeyboard();
+
+    UndoStack::createInstance();
 }
 
 CoreServices::~CoreServices() {
@@ -158,6 +161,8 @@ CoreServices::~CoreServices() {
     if (m_cmdlineArgs.getDeveloper()) {
         StatsManager::destroy();
     }
+
+    UndoStack::destroy();
 
     // HACK: Save config again. We saved it once before doing some dangerous
     // stuff. We only really want to save it here, but the first one was just

--- a/src/test/mixxxtest.cpp
+++ b/src/test/mixxxtest.cpp
@@ -6,6 +6,7 @@
 #include "library/coverartutils.h"
 #include "util/cmdlineargs.h"
 #include "util/logging.h"
+#include "util/undostack.h"
 
 namespace {
 
@@ -43,6 +44,8 @@ MixxxTest::ApplicationScope::ApplicationScope(int& argc, char** argv) {
     // due to timing issues.
     disableConcurrentGuessingOfTrackCoverInfoDuringTests();
 
+    UndoStack::createInstance();
+
     DEBUG_ASSERT(s_pApplication.isNull());
     s_pApplication.reset(new MixxxApplication(argc, argv));
 }
@@ -51,6 +54,8 @@ MixxxTest::ApplicationScope::~ApplicationScope() {
     DEBUG_ASSERT(!s_pApplication.isNull());
     s_pApplication.reset();
     mixxx::Logging::shutdown();
+
+    UndoStack::destroy();
 }
 
 MixxxTest::MixxxTest() {

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -332,6 +332,9 @@ class Track : public QObject {
 
     void setCuePoints(const QList<CuePointer>& cuePoints);
 
+    void doAddCue(const CuePointer& pCue);
+    void doRemoveCue(const CuePointer& pCue);
+
 #ifdef __STEM__
     QList<StemInfo> getStemInfo() const {
         const QMutexLocker lock(&m_qMutex);

--- a/src/util/undostack.h
+++ b/src/util/undostack.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <QUndoStack>
+
+#include "util/singleton.h"
+
+class UndoStack : public QUndoStack, public Singleton<UndoStack> {
+};

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -13,6 +13,7 @@
 #include "util/cmdlineargs.h"
 #include "util/desktophelper.h"
 #include "util/experiment.h"
+#include "util/undostack.h"
 #include "vinylcontrol/defs_vinylcontrol.h"
 
 namespace {
@@ -134,6 +135,20 @@ void WMainMenuBar::initialize() {
     pFileMenu->addAction(pFileQuit);
 
     addMenu(pFileMenu);
+
+    auto* pEditMenu = new QMenu(tr("&Edit"), this);
+#ifndef __APPLE__
+    connectMenuToSlotShowMenuBar(pEditMenu);
+#endif
+
+    auto* undoAction = UndoStack::instance()->createUndoAction(this);
+    pEditMenu->addAction(undoAction);
+    auto* redoAction = UndoStack::instance()->createRedoAction(this);
+    pEditMenu->addAction(redoAction);
+
+    undoAction->setShortcuts(QKeySequence::Undo);
+    redoAction->setShortcuts(QKeySequence::Redo);
+    addMenu(pEditMenu);
 
     // LIBRARY MENU
     QMenu* pLibraryMenu = new QMenu(tr("&Library"), this);


### PR DESCRIPTION
Using a QUndoStack to undo/redo adding and removing (hot)cues.

The undo's/redo's are triggered from the menu bar, edit menu and can also be triggered using the standard shortkeys.

Tested using UI interaction. I am not sure if using a controller goes through the same code path.

The caveat is that when the track is changed, the commands would become invalid. I now use a stop-gap solution and clean the entire stack in the Track destructor. There is unfortunately no way to purge the stack only of the commands that have become invalid.

Maybe we should include loading / unloading tracks in the undo stack? That could solve the issue.

I do feel that using QUndoStack is the correct solution; the amount of code to implement this is minimal. 

I see that Track uses a custom mechanism, m_pBeatsUndoStack. I think it would make sense to also use the QUndoStack  for those changes.