### PR TITLE
Scrolling waveform using SceneGraph in QML

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -334,6 +334,7 @@ jobs:
           timeout: 600
 
       - name: "Package"
+        id: package
         if: matrix.cpack_generator != null
         # Use retry loop to work around a race condition on macOS causing
         # 'Resource busy' errors with 'hdiutil'. See
@@ -341,11 +342,18 @@ jobs:
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 30
-          max_attempts: 12
+          max_attempts: ${{ runner.os == 'macOS' && 12 || 1 }}
           retry_wait_seconds: 1
           command: |
             cd build
             cpack -G ${{ matrix.cpack_generator }} -V
+
+      - name: Upload failed packaging logs
+        if: always() && steps.package.outcome == 'failure' && runner.os == 'windows'
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs-packages-wix
+          path: D:/a/mixxx/mixxx/build/_CPack_Packages/win64/WIX/wix.log
 
       - name: "[Ubuntu] Import PPA GPG key"
         if: startsWith(matrix.os, 'ubuntu') && env.RRYAN_AT_MIXXX_DOT_ORG_GPG_PRIVATE_KEY != null

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
               -DMEDIAFOUNDATION=ON
               -DMODPLUG=ON
               -DQT6=ON
-              -DQML=OFF
+              -DQML=ON
               -DWAVPACK=ON
               -DVCPKG_TARGET_TRIPLET=x64-windows-release
               -DVCPKG_DEFAULT_HOST_TRIPLET=x64-windows-release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4750,6 +4750,7 @@ if(QML)
   )
   target_link_libraries(mixxx-qml-lib PRIVATE rendergraph_sg)
   target_compile_definitions(mixxx-qml-lib PRIVATE rendergraph=rendergraph_sg)
+  target_compile_definitions(mixxx-qml-lib PRIVATE __SCENEGRAPH__)
   target_compile_definitions(mixxx-qml-lib PRIVATE allshader=allshader_sg)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3372,6 +3372,7 @@ if(QML)
       res/qml/Mixxx/Controls/WaveformOverviewHotcueMarker.qml
       res/qml/Mixxx/Controls/WaveformOverviewMarker.qml
       res/qml/Mixxx/Controls/WaveformOverview.qml
+      res/qml/Mixxx/Controls/WaveformDisplay.qml
   )
   target_link_libraries(mixxx-qml-lib PRIVATE mixxx-qml-mixxxcontrolsplugin)
 
@@ -3397,6 +3398,21 @@ if(QML)
       src/qml/qmlchainpresetmodel.cpp
       src/qml/qmlwaveformoverview.cpp
       src/qml/qmlmixxxcontrollerscreen.cpp
+      src/qml/qmlwaveformdisplay.cpp
+      src/qml/qmlwaveformrenderer.cpp
+      src/waveform/renderers/allshader/digitsrenderer.cpp
+      src/waveform/renderers/allshader/waveformrenderbeat.cpp
+      src/waveform/renderers/allshader/waveformrenderer.cpp
+      src/waveform/renderers/allshader/waveformrendererendoftrack.cpp
+      src/waveform/renderers/allshader/waveformrendererpreroll.cpp
+      src/waveform/renderers/allshader/waveformrendererrgb.cpp
+      src/waveform/renderers/allshader/waveformrenderersignalbase.cpp
+      src/waveform/renderers/allshader/waveformrendermark.cpp
+      src/waveform/renderers/allshader/waveformrendermarkrange.cpp
+      src/waveform/renderers/allshader/waveformrendererslipmode.cpp
+      src/waveform/renderers/allshader/waveformrendererfiltered.cpp
+      src/waveform/renderers/allshader/waveformrendererhsv.cpp
+      src/waveform/renderers/allshader/waveformrenderersimple.cpp
       # The following sources need to be in this target to get QML_ELEMENT properly interpreted
       src/control/controlmodel.cpp
       src/control/controlsortfiltermodel.cpp
@@ -4359,7 +4375,12 @@ if(STEM)
   endif()
   if(QML)
     target_compile_definitions(mixxx-qml-lib PUBLIC __STEM__)
-    target_sources(mixxx-qml-lib PRIVATE src/qml/qmlstemsmodel.cpp)
+    target_sources(
+      mixxx-qml-lib
+      PRIVATE
+        src/waveform/renderers/allshader/waveformrendererstem.cpp
+        src/qml/qmlstemsmodel.cpp
+    )
   endif()
 endif()
 
@@ -4714,8 +4735,23 @@ endif()
 
 # rendergraph
 add_subdirectory(src/rendergraph)
+target_compile_definitions(
+  rendergraph_gl
+  PUBLIC $<$<CONFIG:Debug>:MIXXX_DEBUG_ASSERTIONS_ENABLED>
+)
 target_link_libraries(mixxx-lib PUBLIC rendergraph_gl)
 target_compile_definitions(mixxx-lib PUBLIC rendergraph=rendergraph_gl)
+target_compile_definitions(mixxx-lib PRIVATE allshader=allshader_gl)
+target_compile_definitions(mixxx-test PRIVATE allshader=allshader_gl)
+if(QML)
+  target_compile_definitions(
+    rendergraph_sg
+    PUBLIC $<$<CONFIG:Debug>:MIXXX_DEBUG_ASSERTIONS_ENABLED>
+  )
+  target_link_libraries(mixxx-qml-lib PRIVATE rendergraph_sg)
+  target_compile_definitions(mixxx-qml-lib PRIVATE rendergraph=rendergraph_sg)
+  target_compile_definitions(mixxx-qml-lib PRIVATE allshader=allshader_sg)
+endif()
 
 # WavPack audio file support
 find_package(wavpack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3613,15 +3613,6 @@ else()
 
       install(
         IMPORTED_RUNTIME_ARTIFACTS
-          Qt${QT_VERSION_MAJOR}::QuickControls2
-          DESTINATION
-          "${MIXXX_INSTALL_DATADIR}"
-          COMPONENT
-          applocal
-      )
-
-      install(
-        IMPORTED_RUNTIME_ARTIFACTS
           Qt${QT_VERSION_MAJOR}::QuickControls2Impl
           DESTINATION
           "${MIXXX_INSTALL_DATADIR}"
@@ -3641,15 +3632,6 @@ else()
       install(
         IMPORTED_RUNTIME_ARTIFACTS
           Qt${QT_VERSION_MAJOR}::QuickShapesPrivate
-          DESTINATION
-          "${MIXXX_INSTALL_DATADIR}"
-          COMPONENT
-          applocal
-      )
-
-      install(
-        IMPORTED_RUNTIME_ARTIFACTS
-          Qt${QT_VERSION_MAJOR}::QuickTemplates2
           DESTINATION
           "${MIXXX_INSTALL_DATADIR}"
           COMPONENT

--- a/res/controllers/DummyDeviceDefaultScreen.qml
+++ b/res/controllers/DummyDeviceDefaultScreen.qml
@@ -170,7 +170,7 @@ Mixxx.ControllerScreen {
                         Layout.fillHeight: true
                         Text {
                             text: qsTr("Group")
-                            font.pixelSize: 24
+                            font.pixelSize: 18
                             font.family: "Noto Sans"
                             font.letterSpacing: -1
                             color: fontColor
@@ -183,7 +183,7 @@ Mixxx.ControllerScreen {
                         Layout.fillHeight: true
                         Text {
                             text: `${root.group}`
-                            font.pixelSize: 24
+                            font.pixelSize: 18
                             font.family: "Noto Sans"
                             font.letterSpacing: -1
                             color: fontColor
@@ -207,7 +207,7 @@ Mixxx.ControllerScreen {
                         Layout.fillHeight: true
                         Text {
                             text: qsTr("Widget")
-                            font.pixelSize: 24
+                            font.pixelSize: 18
                             font.family: "Noto Sans"
                             font.letterSpacing: -1
                             color: fontColor
@@ -258,7 +258,7 @@ Mixxx.ControllerScreen {
                         anchors.bottomMargin: 6
                         Layout.fillWidth: true
                         Layout.fillHeight: true
-                        spacing: 6
+                        spacing: 4
                         required property var modelData
 
                         Mixxx.ControlProxy {
@@ -273,7 +273,7 @@ Mixxx.ControllerScreen {
                             Layout.fillHeight: true
                             Text {
                                 text: qsTr(modelData.title)
-                                font.pixelSize: 24
+                                font.pixelSize: 18
                                 font.family: "Noto Sans"
                                 font.letterSpacing: -1
                                 color: fontColor
@@ -286,10 +286,161 @@ Mixxx.ControllerScreen {
                             Layout.fillHeight: true
                             Text {
                                 text: `${mixxxValue.value}`
-                                font.pixelSize: 24
+                                font.pixelSize: 18
                                 font.family: "Noto Sans"
                                 font.letterSpacing: -1
                                 color: fontColor
+                            }
+                        }
+                    }
+                }
+                RowLayout {
+                    anchors.leftMargin: 6
+                    anchors.rightMargin: 6
+                    anchors.topMargin: 6
+                    anchors.bottomMargin: 6
+
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+
+                    Mixxx.ControlProxy {
+                        id: zoomControl
+
+                        group: root.group
+                        key: "waveform_zoom"
+                    }
+
+                    MixxxControls.WaveformDisplay {
+                        group: root.group
+                        x: 0
+                        width: root.width
+                        height: 100
+
+                        zoom: zoomControl.value
+                        backgroundColor: "#36000000"
+
+                        Mixxx.WaveformRendererEndOfTrack {
+                            color: 'blue'
+                            endOfTrackWarningTime: 30
+                        }
+
+                        Mixxx.WaveformRendererPreroll {
+                            color: '#998977'
+                        }
+
+                        Mixxx.WaveformRendererMarkRange {
+                            // Loop
+                            Mixxx.WaveformMarkRange {
+                                startControl: "loop_start_position"
+                                endControl: "loop_end_position"
+                                enabledControl: "loop_enabled"
+                                color: '#00b400'
+                                opacity: 0.7
+                                disabledColor: '#FFFFFF'
+                                disabledOpacity: 0.6
+                            }
+                            // Intro
+                            Mixxx.WaveformMarkRange {
+                                startControl: "intro_start_position"
+                                endControl: "intro_end_position"
+                                color: '#2c5c9a'
+                                opacity: 0.6
+                                durationTextColor: '#ffffff'
+                                durationTextLocation: 'after'
+                            }
+                            // Outro
+                            Mixxx.WaveformMarkRange {
+                                startControl: "outro_start_position"
+                                endControl: "outro_end_position"
+                                color: '#2c5c9a'
+                                opacity: 0.6
+                                durationTextColor: '#ffffff'
+                                durationTextLocation: 'before'
+                            }
+                        }
+
+                        Mixxx.WaveformRendererRGB {
+                            axesColor: '#00ffffff'
+                            lowColor: 'red'
+                            midColor: 'green'
+                            highColor: 'blue'
+
+                            gainAll: 1.0
+                            gainLow: 1.0
+                            gainMid: 1.0
+                            gainHigh: 1.0
+                        }
+
+                        Mixxx.WaveformRendererStem {
+                            gainAll: 1.0
+                        }
+
+                        Mixxx.WaveformRendererBeat {
+                            color: '#cfcfcf'
+                        }
+
+                        Mixxx.WaveformRendererMark {
+                            playMarkerColor: 'cyan'
+                            playMarkerBackground: 'transparent'
+                            defaultMark: Mixxx.WaveformMark {
+                                align: "bottom|center"
+                                color: "#FF0000"
+                                textColor: "#FFFFFF"
+                                text: " %1 "
+                            }
+
+                            untilMark.showTime: false
+                            untilMark.showBeats: false
+                            untilMark.align: Qt.AlignCenter
+                            untilMark.textSize: 14
+
+                            Mixxx.WaveformMark {
+                                control: "cue_point"
+                                text: 'CUE'
+                                align: 'top|right'
+                                color: '#FF8000'
+                                textColor: '#FFFFFF'
+                            }
+                            Mixxx.WaveformMark {
+                                control: "loop_start_position"
+                                text: '↻'
+                                align: 'top|left'
+                                color: 'green'
+                                textColor: '#FFFFFF'
+                            }
+                            Mixxx.WaveformMark {
+                                control: "loop_end_position"
+                                align: 'bottom|right'
+                                color: 'green'
+                                textColor: '#FFFFFF'
+                            }
+                            Mixxx.WaveformMark {
+                                control: "intro_start_position"
+                                text: '◢'
+                                align: 'top|right'
+                                color: 'blue'
+                                textColor: '#FFFFFF'
+                            }
+                            Mixxx.WaveformMark {
+                                control: "intro_end_position"
+                                text: '◢'
+                                align: 'top|left'
+                                color: 'blue'
+                                textColor: '#FFFFFF'
+                            }
+                            Mixxx.WaveformMark {
+                                control: "outro_start_position"
+                                text: '◣'
+                                align: 'top|right'
+                                color: 'blue'
+                                textColor: '#FFFFFF'
+                            }
+                            Mixxx.WaveformMark {
+                                control: "outro_end_position"
+                                text: '◣'
+                                align: 'top|left'
+                                color: 'blue'
+                                textColor: '#FFFFFF'
                             }
                         }
                     }

--- a/res/qml/Deck.qml
+++ b/res/qml/Deck.qml
@@ -327,6 +327,54 @@ Item {
         }
 
         Row {
+            anchors.left: playButton.right
+            anchors.leftMargin: 10
+            anchors.bottom: playButton.bottom
+            anchors.topMargin: 5
+            spacing: -1
+
+            Skin.IntroOutroButton {
+                keyPrefix: "intro_start"
+                group: root.group
+
+                text: "Intro\nStart"
+
+                width: playButton.height * 2 - 1
+                height: playButton.height
+            }
+
+            Skin.IntroOutroButton {
+                keyPrefix: "intro_end"
+                group: root.group
+
+                text: "Intro\nEnd"
+
+                width: playButton.height * 2 - 1
+                height: playButton.height
+            }
+
+            Skin.IntroOutroButton {
+                keyPrefix: "outro_start"
+                group: root.group
+
+                text: "Outro\nStart"
+
+                width: playButton.height * 2 - 1
+                height: playButton.height
+            }
+
+            Skin.IntroOutroButton {
+                keyPrefix: "outro_end"
+                group: root.group
+
+                text: "Outro\nEnd"
+
+                width: playButton.height * 2 - 1
+                height: playButton.height
+            }
+        }
+
+        Row {
             anchors.left: cueButton.right
             anchors.top: parent.top
             anchors.leftMargin: 10

--- a/res/qml/IntroOutroButton.qml
+++ b/res/qml/IntroOutroButton.qml
@@ -1,0 +1,45 @@
+import "." as Skin
+import Mixxx 1.0 as Mixxx
+import QtQuick 2.12
+
+import "Theme"
+
+Skin.Button {
+    id: root
+
+    required property string keyPrefix
+    required property string group
+
+    activeColor: Theme.deckActiveColor
+    highlight: enabledControl.value
+
+    Mixxx.ControlProxy {
+        id: control
+
+        group: root.group
+        key: `${root.keyPrefix}_activate`
+        value: root.down
+    }
+
+    Mixxx.ControlProxy {
+        id: enabledControl
+
+        group: root.group
+        key: `${root.keyPrefix}_enabled`
+    }
+
+    Mixxx.ControlProxy {
+        id: cleanControl
+
+        group: root.group
+        key: `${root.keyPrefix}_clear`
+        value: mousearea.pressed && enabledControl.value
+    }
+
+    MouseArea {
+        id: mousearea
+
+        anchors.fill: parent
+        acceptedButtons: Qt.RightButton
+    }
+}

--- a/res/qml/Mixxx/Controls/WaveformDisplay.qml
+++ b/res/qml/Mixxx/Controls/WaveformDisplay.qml
@@ -1,0 +1,7 @@
+import Mixxx 1.0 as Mixxx
+
+Mixxx.WaveformDisplay {
+    id: root
+
+    player: Mixxx.PlayerManager.getPlayer(root.group)
+}

--- a/res/qml/WaveformDisplay.qml
+++ b/res/qml/WaveformDisplay.qml
@@ -8,6 +8,7 @@ Item {
     id: root
 
     required property string group
+    property bool splitStemTracks: false
 
     enum MouseStatus {
         Normal,
@@ -74,7 +75,8 @@ Item {
         }
 
         Mixxx.WaveformRendererStem {
-            gainAll: 1.0
+            gainAll: root.splitStemTracks ? 2.0 : 1.0
+            splitStemTracks: root.splitStemTracks
         }
 
         Mixxx.WaveformRendererBeat {
@@ -188,6 +190,11 @@ Item {
 
         anchors.fill: parent
         acceptedButtons: Qt.LeftButton | Qt.RightButton
+        onDoubleClicked: {
+            if (mouse.button == Qt.RightButton) {
+                root.splitStemTracks = !root.splitStemTracks;
+            }
+        }
         onPressed: {
             mouseAnchor = Qt.point(mouse.x, mouse.y);
             if (mouse.button == Qt.LeftButton) {

--- a/res/qml/WaveformDisplay.qml
+++ b/res/qml/WaveformDisplay.qml
@@ -1,0 +1,247 @@
+import "." as Skin
+import Mixxx 1.0 as Mixxx
+import Mixxx.Controls 1.0 as MixxxControls
+import QtQuick 2.12
+import "Theme"
+
+Item {
+    id: root
+
+    required property string group
+
+    enum MouseStatus {
+        Normal,
+        Bending,
+        Scratching
+    }
+
+    MixxxControls.WaveformDisplay {
+        anchors.fill: parent
+        group: root.group
+        zoom: zoomControl.value
+        backgroundColor: "#5e000000"
+
+        Mixxx.WaveformRendererEndOfTrack {
+            color: '#ff8872'
+            endOfTrackWarningTime: 30
+        }
+
+        Mixxx.WaveformRendererPreroll {
+            color: '#ff8872'
+        }
+
+        Mixxx.WaveformRendererMarkRange {
+            // Loop
+            Mixxx.WaveformMarkRange {
+                startControl: "loop_start_position"
+                endControl: "loop_end_position"
+                enabledControl: "loop_enabled"
+                color: '#00b400'
+                opacity: 0.7
+                disabledColor: '#FFFFFF'
+                disabledOpacity: 0.6
+            }
+            // Intro
+            Mixxx.WaveformMarkRange {
+                startControl: "intro_start_position"
+                endControl: "intro_end_position"
+                color: '#2c5c9a'
+                opacity: 0.6
+                durationTextColor: '#ffffff'
+                durationTextLocation: 'after'
+            }
+            // Outro
+            Mixxx.WaveformMarkRange {
+                startControl: "outro_start_position"
+                endControl: "outro_end_position"
+                color: '#2c5c9a'
+                opacity: 0.6
+                durationTextColor: '#ffffff'
+                durationTextLocation: 'before'
+            }
+        }
+
+        Mixxx.WaveformRendererRGB {
+            axesColor: '#a1a1a1a1'
+            lowColor: '#ff2154d7'
+            midColor: '#cfb26606'
+            highColor: '#e5029c5c'
+
+            gainAll: 1.0
+            gainLow: 1.0
+            gainMid: 1.0
+            gainHigh: 1.0
+        }
+
+        Mixxx.WaveformRendererStem {
+            gainAll: 1.0
+        }
+
+        Mixxx.WaveformRendererBeat {
+            color: '#a1a1a1a1'
+        }
+
+        Mixxx.WaveformRendererMark {
+            playMarkerColor: 'cyan'
+            playMarkerBackground: 'orange'
+            defaultMark: Mixxx.WaveformMark {
+                align: "bottom|right"
+                color: "#00d9ff"
+                textColor: "#1a1a1a"
+                text: " %1 "
+            }
+
+            untilMark.showTime: true
+            untilMark.showBeats: true
+            untilMark.align: Qt.AlignBottom
+            untilMark.textSize: 11
+
+            Mixxx.WaveformMark {
+                control: "cue_point"
+                text: 'CUE'
+                align: 'top|right'
+                color: 'red'
+                textColor: '#1a1a1a'
+            }
+            Mixxx.WaveformMark {
+                control: "loop_start_position"
+                text: '↻'
+                align: 'top|left'
+                color: 'green'
+                textColor: '#FFFFFF'
+            }
+            Mixxx.WaveformMark {
+                control: "loop_end_position"
+                align: 'bottom|right'
+                color: 'green'
+                textColor: '#FFFFFF'
+            }
+            Mixxx.WaveformMark {
+                control: "intro_start_position"
+                text: '◢'
+                align: 'top|right'
+                color: 'blue'
+                textColor: '#FFFFFF'
+            }
+            Mixxx.WaveformMark {
+                control: "intro_end_position"
+                text: '◢'
+                align: 'top|left'
+                color: 'blue'
+                textColor: '#FFFFFF'
+            }
+            Mixxx.WaveformMark {
+                control: "outro_start_position"
+                text: '◣'
+                align: 'top|right'
+                color: 'blue'
+                textColor: '#FFFFFF'
+            }
+            Mixxx.WaveformMark {
+                control: "outro_end_position"
+                text: '◣'
+                align: 'top|left'
+                color: 'blue'
+                textColor: '#FFFFFF'
+            }
+        }
+    }
+
+    Mixxx.ControlProxy {
+        id: scratchPositionEnableControl
+
+        group: root.group
+        key: "scratch_position_enable"
+    }
+
+    Mixxx.ControlProxy {
+        id: scratchPositionControl
+
+        group: root.group
+        key: "scratch_position"
+    }
+
+    Mixxx.ControlProxy {
+        id: wheelControl
+
+        group: root.group
+        key: "wheel"
+    }
+
+    Mixxx.ControlProxy {
+        id: rateRatioControl
+
+        group: root.group
+        key: "rate_ratio"
+    }
+
+    Mixxx.ControlProxy {
+        id: zoomControl
+
+        group: root.group
+        key: "waveform_zoom"
+    }
+
+    MouseArea {
+        property int mouseStatus: WaveformDisplay.MouseStatus.Normal
+        property point mouseAnchor: Qt.point(0, 0)
+
+        anchors.fill: parent
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
+        onPressed: {
+            mouseAnchor = Qt.point(mouse.x, mouse.y);
+            if (mouse.button == Qt.LeftButton) {
+                if (mouseStatus == WaveformDisplay.MouseStatus.Bending)
+                    wheelControl.parameter = 0.5;
+
+                mouseStatus = WaveformDisplay.MouseStatus.Scratching;
+                scratchPositionControl.value = 0;
+                scratchPositionEnableControl.value = 1;
+            } else {
+                if (mouseStatus == WaveformDisplay.MouseStatus.Scratching)
+                    scratchPositionEnableControl.value = 0;
+
+                wheelControl.parameter = 0.5;
+                mouseStatus = WaveformDisplay.MouseStatus.Bending;
+            }
+        }
+        onPositionChanged: {
+            const diff = mouse.x - mouseAnchor.x;
+            switch (mouseStatus) {
+                case WaveformDisplay.MouseStatus.Bending: {
+                    // Start at the middle of [0.0, 1.0], and emit values based on how far
+                    // the mouse has traveled horizontally. Note, for legacy (MIDI) reasons,
+                    // this is tuned to 127.
+                    const v = 0.5 + (diff / root.width);
+                    // clamp to [0.0, 1.0]
+                    wheelControl.parameter = Math.max(Math.min(v, 1), 0);
+                    break;
+                };
+                case WaveformDisplay.MouseStatus.Scratching:
+                // TODO: Calculate position properly
+                    scratchPositionControl.value = -diff * zoomControl.value * 200;
+                    break;
+            }
+        }
+        onReleased: {
+            switch (mouseStatus) {
+                case WaveformDisplay.MouseStatus.Bending:
+                    wheelControl.parameter = 0.5;
+                    break;
+                case WaveformDisplay.MouseStatus.Scratching:
+                    scratchPositionEnableControl.value = 0;
+                    scratchPositionControl.value = 0;
+                    break;
+            }
+            mouseStatus = WaveformDisplay.MouseStatus.Normal;
+        }
+
+        onWheel: {
+            if (wheel.angleDelta.y < 0 && zoomControl.value > 1) {
+                zoomControl.value -= 1;
+            } else if (wheel.angleDelta.y > 0 && zoomControl.value < 10.0) {
+                zoomControl.value += 1;
+            }
+        }
+    }
+}

--- a/res/qml/main.qml
+++ b/res/qml/main.qml
@@ -98,12 +98,12 @@ ApplicationWindow {
             }
         }
 
-        WaveformRow {
+        Skin.WaveformDisplay {
             id: deck3waveform
 
             group: "[Channel3]"
             width: root.width
-            height: 60
+            height: 120
             visible: root.show4decks && !root.maximizeLibrary
 
             FadeBehavior on visible {
@@ -111,12 +111,12 @@ ApplicationWindow {
             }
         }
 
-        WaveformRow {
+        Skin.WaveformDisplay {
             id: deck1waveform
 
             group: "[Channel1]"
             width: root.width
-            height: 60
+            height: 120
             visible: !root.maximizeLibrary
 
             FadeBehavior on visible {
@@ -124,12 +124,12 @@ ApplicationWindow {
             }
         }
 
-        WaveformRow {
+        Skin.WaveformDisplay {
             id: deck2waveform
 
             group: "[Channel2]"
             width: root.width
-            height: 60
+            height: 120
             visible: !root.maximizeLibrary
 
             FadeBehavior on visible {
@@ -137,12 +137,12 @@ ApplicationWindow {
             }
         }
 
-        WaveformRow {
+        Skin.WaveformDisplay {
             id: deck4waveform
 
             group: "[Channel4]"
             width: root.width
-            height: 60
+            height: 120
             visible: root.show4decks && !root.maximizeLibrary
 
             FadeBehavior on visible {

--- a/src/analyzer/analyzerwaveform.cpp
+++ b/src/analyzer/analyzerwaveform.cpp
@@ -1,10 +1,14 @@
 #include "analyzer/analyzerwaveform.h"
 
+#include <memory>
+#include <vector>
+
 #include "analyzer/analyzertrack.h"
 #include "analyzer/constants.h"
 #include "engine/filters/enginefilterbessel4.h"
 #include "track/track.h"
 #include "util/logger.h"
+#include "waveform/waveform.h"
 #include "waveform/waveformfactory.h"
 
 namespace {
@@ -26,9 +30,6 @@ AnalyzerWaveform::AnalyzerWaveform(
           m_stride(0, 0, 0),
           m_currentStride(0),
           m_currentSummaryStride(0) {
-    m_filter[0] = nullptr;
-    m_filter[1] = nullptr;
-    m_filter[2] = nullptr;
     m_analysisDao.initialize(dbConnection);
 }
 
@@ -175,22 +176,19 @@ void AnalyzerWaveform::createFilters(mixxx::audio::SampleRate sampleRate) {
     // m_filter[Low] = new EngineFilterButterworth8Low(sampleRate, kLowMidFreqHz);
     // m_filter[Mid] = new EngineFilterButterworth8Band(sampleRate, kLowMidFreqHz, kMidHighFreqHz);
     // m_filter[High] = new EngineFilterButterworth8High(sampleRate, kMidHighFreqHz);
-    m_filter[Low] = new EngineFilterBessel4Low(sampleRate, kLowMidFreqHz);
-    m_filter[Mid] = new EngineFilterBessel4Band(sampleRate, kLowMidFreqHz, kMidHighFreqHz);
-    m_filter[High] = new EngineFilterBessel4High(sampleRate, kMidHighFreqHz);
+    m_filters = {
+            std::make_unique<EngineFilterBessel4Low>(sampleRate, kLowMidFreqHz),
+            std::make_unique<EngineFilterBessel4Band>(sampleRate, kLowMidFreqHz, kMidHighFreqHz),
+            std::make_unique<EngineFilterBessel4High>(sampleRate, kMidHighFreqHz)};
+
     // settle filters for silence in preroll to avoids ramping (Issue #7776)
-    for (int i = 0; i < FilterCount; ++i) {
-        m_filter[i]->assumeSettled();
-    }
+    m_filters.low->assumeSettled();
+    m_filters.mid->assumeSettled();
+    m_filters.high->assumeSettled();
 }
 
 void AnalyzerWaveform::destroyFilters() {
-    for (int i = 0; i < FilterCount; ++i) {
-        if (m_filter[i]) {
-            delete m_filter[i];
-            m_filter[i] = nullptr;
-        }
-    }
+    m_filters = {};
 }
 
 bool AnalyzerWaveform::processSamples(const CSAMPLE* pIn, SINT count) {
@@ -221,15 +219,16 @@ bool AnalyzerWaveform::processSamples(const CSAMPLE* pIn, SINT count) {
     }
 
     // This should only append once if count is constant
-    if (count > static_cast<SINT>(m_buffers[0].size())) {
-        m_buffers[Low].resize(count);
-        m_buffers[Mid].resize(count);
-        m_buffers[High].resize(count);
+    if (count > m_buffers.size) {
+        m_buffers.low.resize(count);
+        m_buffers.mid.resize(count);
+        m_buffers.high.resize(count);
+        m_buffers.size = count;
     }
 
-    m_filter[Low]->process(pWaveformInput, &m_buffers[Low][0], count);
-    m_filter[Mid]->process(pWaveformInput, &m_buffers[Mid][0], count);
-    m_filter[High]->process(pWaveformInput, &m_buffers[High][0], count);
+    m_filters.low->process(pWaveformInput, &m_buffers.low[0], count);
+    m_filters.mid->process(pWaveformInput, &m_buffers.mid[0], count);
+    m_filters.high->process(pWaveformInput, &m_buffers.high[0], count);
 
     m_waveform->setSaveState(Waveform::SaveState::NotSaved);
     m_waveformSummary->setSaveState(Waveform::SaveState::NotSaved);
@@ -237,20 +236,20 @@ bool AnalyzerWaveform::processSamples(const CSAMPLE* pIn, SINT count) {
     for (SINT i = 0; i < count; i += 2) {
         // Take max value, not average of data
         CSAMPLE cover[2] = {fabs(pWaveformInput[i]), fabs(pWaveformInput[i + 1])};
-        CSAMPLE clow[2] = {fabs(m_buffers[Low][i]), fabs(m_buffers[Low][i + 1])};
-        CSAMPLE cmid[2] = {fabs(m_buffers[Mid][i]), fabs(m_buffers[Mid][i + 1])};
-        CSAMPLE chigh[2] = {fabs(m_buffers[High][i]), fabs(m_buffers[High][i + 1])};
+        CSAMPLE clow[2] = {fabs(m_buffers.low[i]), fabs(m_buffers.low[i + 1])};
+        CSAMPLE cmid[2] = {fabs(m_buffers.mid[i]), fabs(m_buffers.mid[i + 1])};
+        CSAMPLE chigh[2] = {fabs(m_buffers.high[i]), fabs(m_buffers.high[i + 1])};
 
         // This is for if you want to experiment with averaging instead of
         // maxing.
         // m_stride.m_overallData[Right] += buffer[i]*buffer[i];
         // m_stride.m_overallData[Left] += buffer[i + 1]*buffer[i + 1];
-        // m_stride.m_filteredData[Right][Low] += m_buffers[Low][i]*m_buffers[Low][i];
-        // m_stride.m_filteredData[Left][Low] += m_buffers[Low][i + 1]*m_buffers[Low][i + 1];
-        // m_stride.m_filteredData[Right][Mid] += m_buffers[Mid][i]*m_buffers[Mid][i];
-        // m_stride.m_filteredData[Left][Mid] += m_buffers[Mid][i + 1]*m_buffers[Mid][i + 1];
-        // m_stride.m_filteredData[Right][High] += m_buffers[High][i]*m_buffers[High][i];
-        // m_stride.m_filteredData[Left][High] += m_buffers[High][i + 1]*m_buffers[High][i + 1];
+        // m_stride.m_filteredData[Right][Low] += m_buffers.low[i]*m_buffers.low[i];
+        // m_stride.m_filteredData[Left][Low] += m_buffers.low[i + 1]*m_buffers.low[i + 1];
+        // m_stride.m_filteredData[Right][Mid] += m_buffers.mid[i]*m_buffers.mid[i];
+        // m_stride.m_filteredData[Left][Mid] += m_buffers.mid[i + 1]*m_buffers.mid[i + 1];
+        // m_stride.m_filteredData[Right][High] += m_buffers.high[i]*m_buffers.high[i];
+        // m_stride.m_filteredData[Left][High] += m_buffers.high[i + 1]*m_buffers.high[i + 1];
 
         // Record the max across this stride.
         storeIfGreater(&m_stride.m_overallData[Left], cover[Left]);

--- a/src/analyzer/analyzerwaveform.h
+++ b/src/analyzer/analyzerwaveform.h
@@ -37,8 +37,8 @@ struct WaveformStride {
         for (int i = 0; i < ChannelCount; ++i) {
             m_overallData[i] = 0.0f;
             m_averageOverallData[i] = 0.0f;
-            SampleUtil::clear(m_filteredData[i], FilterCount);
-            SampleUtil::clear(m_averageFilteredData[i], FilterCount);
+            SampleUtil::clear(m_filteredData[i], BandCount);
+            SampleUtil::clear(m_averageFilteredData[i], BandCount);
             SampleUtil::clear(m_stemData[i], m_stemCount);
         }
     }
@@ -64,7 +64,7 @@ struct WaveformStride {
         for (int i = 0; i < ChannelCount; ++i) {
             m_averageOverallData[i] += m_overallData[i];
             m_overallData[i] = 0.0f;
-            for (int f = 0; f < FilterCount; ++f) {
+            for (int f = 0; f < BandCount; ++f) {
                 m_averageFilteredData[i][f] += m_filteredData[i][f];
                 m_filteredData[i][f] = 0.0f;
             }
@@ -111,7 +111,7 @@ struct WaveformStride {
         m_averageDivisor = 0;
         for (int i = 0; i < ChannelCount; ++i) {
             m_averageOverallData[i] = 0.0f;
-            for (int f = 0; f < FilterCount; ++f) {
+            for (int f = 0; f < BandCount; ++f) {
                 m_averageFilteredData[i][f] = 0.0f;
             }
         }
@@ -125,11 +125,11 @@ struct WaveformStride {
     int m_averageDivisor;
 
     float m_overallData[ChannelCount];
-    float m_filteredData[ChannelCount][FilterCount];
+    float m_filteredData[ChannelCount][BandCount];
     float m_stemData[ChannelCount][mixxx::kMaxSupportedStems];
 
     float m_averageOverallData[ChannelCount];
-    float m_averageFilteredData[ChannelCount][FilterCount];
+    float m_averageFilteredData[ChannelCount][BandCount];
 
     float m_postScaleConversion;
 };
@@ -172,8 +172,30 @@ class AnalyzerWaveform : public Analyzer {
     int m_currentSummaryStride;
     mixxx::audio::ChannelCount m_channelCount;
 
-    EngineFilterIIRBase* m_filter[FilterCount];
-    std::vector<float> m_buffers[FilterCount];
+    struct Filters {
+        std::unique_ptr<EngineFilterIIRBase> low;
+        std::unique_ptr<EngineFilterIIRBase> mid;
+        std::unique_ptr<EngineFilterIIRBase> high;
+    };
+
+    Filters m_filters;
+
+    struct Buffers {
+        std::vector<float> low;
+        std::vector<float> mid;
+        std::vector<float> high;
+
+        SINT size;
+
+        Buffers()
+                : low(),
+                  mid(),
+                  high(),
+                  size(0) {
+        }
+    };
+
+    Buffers m_buffers;
 
     PerformanceTimer m_timer;
 

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -274,7 +274,7 @@ void MixxxMainWindow::initialize() {
 
     WaveformWidgetFactory::createInstance(); // takes a long time
     WaveformWidgetFactory::instance()->setConfig(m_pCoreServices->getSettings());
-    WaveformWidgetFactory::instance()->startVSync(m_pGuiTick, m_pVisualsManager);
+    WaveformWidgetFactory::instance()->startVSync(m_pGuiTick, m_pVisualsManager, false);
 
     connect(this,
             &MixxxMainWindow::skinLoaded,
@@ -514,6 +514,8 @@ MixxxMainWindow::~MixxxMainWindow() {
     delete m_pPrefDlg;
 
     m_pCoreServices->getControlIndicatorTimer()->setLegacyVsyncEnabled(false);
+
+    qDebug() << t.elapsed(false).debugMillisWithUnit() << "deleting ControllerManager";
 
     WaveformWidgetFactory::destroy();
 

--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -285,10 +285,10 @@ void DlgPrefWaveform::slotUpdate() {
     endOfTrackWarningTimeSpinBox->setValue(factory->getEndOfTrackWarningTime());
     endOfTrackWarningTimeSlider->setValue(factory->getEndOfTrackWarningTime());
     synchronizeZoomCheckBox->setChecked(factory->isZoomSync());
-    allVisualGain->setValue(factory->getVisualGain(WaveformWidgetFactory::All));
-    lowVisualGain->setValue(factory->getVisualGain(WaveformWidgetFactory::Low));
-    midVisualGain->setValue(factory->getVisualGain(WaveformWidgetFactory::Mid));
-    highVisualGain->setValue(factory->getVisualGain(WaveformWidgetFactory::High));
+    allVisualGain->setValue(factory->getVisualGain(BandIndex::AllBand));
+    lowVisualGain->setValue(factory->getVisualGain(BandIndex::Low));
+    midVisualGain->setValue(factory->getVisualGain(BandIndex::Mid));
+    highVisualGain->setValue(factory->getVisualGain(BandIndex::High));
     normalizeOverviewCheckBox->setChecked(factory->isOverviewNormalized());
     // Round zoom to int to get a default zoom index.
     defaultZoomComboBox->setCurrentIndex(static_cast<int>(factory->getDefaultZoom()) - 1);
@@ -598,19 +598,19 @@ void DlgPrefWaveform::slotSetZoomSynchronization(bool checked) {
 }
 
 void DlgPrefWaveform::slotSetVisualGainAll(double gain) {
-    WaveformWidgetFactory::instance()->setVisualGain(WaveformWidgetFactory::All,gain);
+    WaveformWidgetFactory::instance()->setVisualGain(BandIndex::AllBand, gain);
 }
 
 void DlgPrefWaveform::slotSetVisualGainLow(double gain) {
-    WaveformWidgetFactory::instance()->setVisualGain(WaveformWidgetFactory::Low,gain);
+    WaveformWidgetFactory::instance()->setVisualGain(BandIndex::Low, gain);
 }
 
 void DlgPrefWaveform::slotSetVisualGainMid(double gain) {
-    WaveformWidgetFactory::instance()->setVisualGain(WaveformWidgetFactory::Mid,gain);
+    WaveformWidgetFactory::instance()->setVisualGain(BandIndex::Mid, gain);
 }
 
 void DlgPrefWaveform::slotSetVisualGainHigh(double gain) {
-    WaveformWidgetFactory::instance()->setVisualGain(WaveformWidgetFactory::High,gain);
+    WaveformWidgetFactory::instance()->setVisualGain(BandIndex::High, gain);
 }
 
 void DlgPrefWaveform::slotSetNormalizeOverview(bool normalize) {

--- a/src/qml/qmlapplication.h
+++ b/src/qml/qmlapplication.h
@@ -6,6 +6,9 @@
 #include "coreservices.h"
 #include "qmlautoreload.h"
 
+class GuiTick;
+class VisualsManager;
+
 namespace mixxx {
 namespace qml {
 
@@ -14,14 +17,15 @@ class QmlApplication : public QObject {
   public:
     QmlApplication(
             QApplication* app,
-            std::shared_ptr<CoreServices> pCoreServices);
+            const CmdlineArgs& args);
     ~QmlApplication() override;
 
   public slots:
     void loadQml(const QString& path);
 
   private:
-    std::shared_ptr<CoreServices> m_pCoreServices;
+    std::unique_ptr<CoreServices> m_pCoreServices;
+    std::unique_ptr<::VisualsManager> m_visualsManager;
 
     QString m_mainFilePath;
 

--- a/src/qml/qmldlgpreferencesproxy.cpp
+++ b/src/qml/qmldlgpreferencesproxy.cpp
@@ -43,8 +43,8 @@ QmlDlgPreferencesProxy* QmlDlgPreferencesProxy::create(
 
     // Explicitly specify C++ ownership so that the engine doesn't delete
     // the instance.
-    QJSEngine::setObjectOwnership(s_pInstance, QJSEngine::CppOwnership);
-    return s_pInstance;
+    QJSEngine::setObjectOwnership(s_pInstance.get(), QJSEngine::CppOwnership);
+    return s_pInstance.get();
 }
 
 } // namespace qml

--- a/src/qml/qmldlgpreferencesproxy.h
+++ b/src/qml/qmldlgpreferencesproxy.h
@@ -20,7 +20,7 @@ class QmlDlgPreferencesProxy : public QObject {
     Q_INVOKABLE void show();
 
     static QmlDlgPreferencesProxy* create(QQmlEngine* pQmlEngine, QJSEngine* pJsEngine);
-    static inline QmlDlgPreferencesProxy* s_pInstance = nullptr;
+    static inline std::unique_ptr<QmlDlgPreferencesProxy> s_pInstance;
 
   private:
     static inline QJSEngine* s_pJsEngine = nullptr;

--- a/src/qml/qmlplayermanagerproxy.cpp
+++ b/src/qml/qmlplayermanagerproxy.cpp
@@ -14,7 +14,7 @@ QmlPlayerManagerProxy::QmlPlayerManagerProxy(
         : QObject(parent), m_pPlayerManager(pPlayerManager) {
 }
 
-QObject* QmlPlayerManagerProxy::getPlayer(const QString& group) {
+QmlPlayerProxy* QmlPlayerManagerProxy::getPlayer(const QString& group) {
     BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(group);
     if (!pPlayer) {
         qWarning() << "PlayerManagerProxy failed to find player for group" << group;

--- a/src/qml/qmlplayermanagerproxy.h
+++ b/src/qml/qmlplayermanagerproxy.h
@@ -18,7 +18,7 @@ class QmlPlayerManagerProxy : public QObject {
             std::shared_ptr<PlayerManager> pPlayerManager,
             QObject* parent = nullptr);
 
-    Q_INVOKABLE QmlPlayerProxy* getPlayer(const QString& deck);
+    Q_INVOKABLE mixxx::qml::QmlPlayerProxy* getPlayer(const QString& deck);
     Q_INVOKABLE void loadLocationIntoNextAvailableDeck(const QString& location, bool play = false);
     Q_INVOKABLE void loadLocationUrlIntoNextAvailableDeck(
             const QUrl& locationUrl, bool play = false);

--- a/src/qml/qmlplayermanagerproxy.h
+++ b/src/qml/qmlplayermanagerproxy.h
@@ -18,7 +18,7 @@ class QmlPlayerManagerProxy : public QObject {
             std::shared_ptr<PlayerManager> pPlayerManager,
             QObject* parent = nullptr);
 
-    Q_INVOKABLE QObject* getPlayer(const QString& deck);
+    Q_INVOKABLE QmlPlayerProxy* getPlayer(const QString& deck);
     Q_INVOKABLE void loadLocationIntoNextAvailableDeck(const QString& location, bool play = false);
     Q_INVOKABLE void loadLocationUrlIntoNextAvailableDeck(
             const QUrl& locationUrl, bool play = false);

--- a/src/qml/qmlwaveformdisplay.cpp
+++ b/src/qml/qmlwaveformdisplay.cpp
@@ -118,6 +118,9 @@ QSGNode* QmlWaveformDisplay::updatePaintNode(QSGNode* node, UpdatePaintNodeData*
 
         m_rendererStack.clear();
         for (auto* pQmlRenderer : std::as_const(m_waveformRenderers)) {
+            if (!pQmlRenderer->isSupported()) {
+                qDebug() << "Ignoring the unsupported" << pQmlRenderer << "renderer";
+            }
             auto renderer = pQmlRenderer->create(this);
             VERIFY_OR_DEBUG_ASSERT(renderer.renderer) {
                 continue;

--- a/src/qml/qmlwaveformdisplay.cpp
+++ b/src/qml/qmlwaveformdisplay.cpp
@@ -1,0 +1,249 @@
+#include "qml/qmlwaveformdisplay.h"
+
+#include <qnamespace.h>
+
+#include <QQuickWindow>
+#include <QSGFlatColorMaterial>
+#include <QSGSimpleRectNode>
+#include <QSGVertexColorMaterial>
+#include <QtQuick/QSGGeometryNode>
+#include <QtQuick/QSGMaterial>
+#include <QtQuick/QSGRectangleNode>
+#include <QtQuick/QSGTexture>
+#include <QtQuick/QSGTextureProvider>
+#include <cmath>
+
+#include "mixer/basetrackplayer.h"
+#include "moc_qmlwaveformdisplay.cpp"
+#include "qml/qmlplayerproxy.h"
+#include "rendergraph/context.h"
+#include "rendergraph/node.h"
+#include "util/assert.h"
+
+using namespace allshader;
+
+namespace {
+constexpr int kDefaultSyncInternalMs = 100;
+}
+
+namespace mixxx {
+namespace qml {
+
+QmlWaveformDisplay::QmlWaveformDisplay(QQuickItem* parent)
+        : QQuickItem(parent),
+          WaveformWidgetRenderer(),
+          m_syncInterval(kDefaultSyncInternalMs),
+          m_pPlayer(nullptr) {
+    setFlag(QQuickItem::ItemHasContents, true);
+
+    connect(this,
+            &QmlWaveformDisplay::windowChanged,
+            this,
+            &QmlWaveformDisplay::slotWindowChanged,
+            Qt::DirectConnection);
+    slotWindowChanged(window());
+}
+
+QmlWaveformDisplay::~QmlWaveformDisplay() {
+    // The stack contains references to Renderer that are owned and cleared by a BaseNode
+    m_rendererStack.clear();
+}
+
+void QmlWaveformDisplay::componentComplete() {
+    qDebug() << "QmlWaveformDisplay ready for group" << getGroup() << "with"
+             << m_waveformRenderers.count() << "renderer(s)";
+    QQuickItem::componentComplete();
+}
+
+void QmlWaveformDisplay::slotWindowChanged(QQuickWindow* window) {
+    m_rendererStack.clear();
+
+    m_dirtyFlag.setFlag(DirtyFlag::Window, true);
+    if (window) {
+        connect(window, &QQuickWindow::afterFrameEnd, this, &QmlWaveformDisplay::slotFrameSwapped);
+    }
+    m_timer.restart();
+}
+
+std::chrono::microseconds QmlWaveformDisplay::fromTimerToNextSync(const PerformanceTimer& timer) {
+    // TODO @m0dB probably better to use a singleton instead of deriving QmlWaveformDisplay from
+    // ISyncTimeProvider and have each keep track of this.
+    return m_syncInterval + std::chrono::microseconds(m_timer.difference(timer).toIntegerMicros());
+}
+
+void QmlWaveformDisplay::slotFrameSwapped() {
+    m_timer.restart();
+
+    // continuous redraw
+    update();
+}
+
+void QmlWaveformDisplay::geometryChange(const QRectF& newGeometry, const QRectF& oldGeometry) {
+    m_dirtyFlag.setFlag(DirtyFlag::Geometry, true);
+    update();
+    QQuickItem::geometryChange(newGeometry, oldGeometry);
+}
+
+QSGNode* QmlWaveformDisplay::updatePaintNode(QSGNode* node, UpdatePaintNodeData*) {
+    if (m_dirtyFlag.testFlag(DirtyFlag::Window)) {
+        delete node;
+        m_dirtyFlag.setFlag(DirtyFlag::Window, false);
+    }
+
+    DEBUG_ASSERT(!node || node->childCount() == 1);
+
+    auto* pClipNode = dynamic_cast<QSGClipNode*>(node);
+    auto* pBgNode = pClipNode ? dynamic_cast<QSGSimpleRectNode*>(pClipNode->lastChild()) : nullptr;
+
+    if (!pBgNode) {
+        if (pClipNode) {
+            delete pClipNode;
+        }
+        pClipNode = new QSGClipNode();
+        pBgNode = new QSGSimpleRectNode();
+        m_dirtyFlag.setFlag(DirtyFlag::Background, true);
+        m_dirtyFlag.setFlag(DirtyFlag::Geometry, true);
+
+        pClipNode->setIsRectangular(true);
+        pClipNode->setGeometry(pBgNode->geometry());
+
+        pClipNode->setClipRect(boundingRect());
+        pBgNode->setRect(boundingRect());
+
+        if (getContext()) {
+            delete getContext();
+        }
+        setContext(new rendergraph::Context(window()));
+        rendergraph::Node* pTopNode = new rendergraph::Node;
+
+        m_rendererStack.clear();
+        for (auto* pQmlRenderer : std::as_const(m_waveformRenderers)) {
+            auto renderer = pQmlRenderer->create(this);
+            VERIFY_OR_DEBUG_ASSERT(renderer.renderer) {
+                continue;
+            }
+            addRenderer(renderer.renderer);
+            pTopNode->appendChildNode(std::move(renderer.node));
+        }
+
+        pBgNode->appendChildNode(pTopNode);
+        pClipNode->appendChildNode(pBgNode);
+        init();
+    }
+
+    if (m_dirtyFlag.testFlag(DirtyFlag::Background)) {
+        m_dirtyFlag.setFlag(DirtyFlag::Background, false);
+        pBgNode->setColor(m_backgroundColor);
+    }
+
+    if (m_dirtyFlag.testFlag(DirtyFlag::Geometry)) {
+        m_dirtyFlag.setFlag(DirtyFlag::Geometry, false);
+        pBgNode->setRect(boundingRect());
+        pClipNode->setClipRect(boundingRect());
+        resizeRenderer(boundingRect().width(),
+                boundingRect().height(),
+                window()->devicePixelRatio());
+    }
+
+    onPreRender(this);
+
+    for (auto* pRenderer : std::as_const(m_rendererStack)) {
+        pRenderer->update();
+    }
+
+    pBgNode->markDirty(QSGNode::DirtyForceUpdate);
+    return pClipNode;
+}
+
+QmlPlayerProxy* QmlWaveformDisplay::getPlayer() const {
+    return m_pPlayer;
+}
+
+void QmlWaveformDisplay::setPlayer(QmlPlayerProxy* pPlayer) {
+    if (m_pPlayer == pPlayer) {
+        return;
+    }
+
+    if (m_pPlayer != nullptr) {
+        m_pPlayer->internalTrackPlayer()->disconnect(this);
+    }
+
+    m_pPlayer = pPlayer;
+
+    if (m_pPlayer != nullptr) {
+        setCurrentTrack(m_pPlayer->internalTrackPlayer()->getLoadedTrack());
+        connect(m_pPlayer->internalTrackPlayer(),
+                &BaseTrackPlayer::newTrackLoaded,
+                this,
+                &QmlWaveformDisplay::slotTrackLoaded);
+        connect(m_pPlayer->internalTrackPlayer(),
+                &BaseTrackPlayer::loadingTrack,
+                this,
+                &QmlWaveformDisplay::slotTrackLoading);
+        connect(m_pPlayer->internalTrackPlayer(),
+                &BaseTrackPlayer::playerEmpty,
+                this,
+                &QmlWaveformDisplay::slotTrackUnloaded);
+    }
+
+    emit playerChanged();
+    update();
+}
+
+void QmlWaveformDisplay::setGroup(const QString& group) {
+    if (getGroup() == group) {
+        return;
+    }
+
+    WaveformWidgetRenderer::setGroup(group);
+    emit groupChanged(group);
+}
+
+void QmlWaveformDisplay::slotTrackLoaded(TrackPointer pTrack) {
+    // TODO: Investigate if it's a bug that this debug assertion fails when
+    // passing tracks on the command line
+    // DEBUG_ASSERT(m_pCurrentTrack == pTrack);
+    setCurrentTrack(pTrack);
+}
+
+void QmlWaveformDisplay::slotTrackLoading(TrackPointer pNewTrack, TrackPointer pOldTrack) {
+    Q_UNUSED(pOldTrack); // only used in DEBUG_ASSERT
+    DEBUG_ASSERT(getTrackInfo() == pOldTrack);
+    setCurrentTrack(pNewTrack);
+}
+
+void QmlWaveformDisplay::slotTrackUnloaded() {
+    setCurrentTrack(nullptr);
+}
+
+void QmlWaveformDisplay::setCurrentTrack(TrackPointer pTrack) {
+    auto pCurrentTrack = getTrackInfo();
+    // TODO: Check if this is actually possible
+    if (pCurrentTrack == pTrack) {
+        return;
+    }
+
+    if (pCurrentTrack != nullptr) {
+        disconnect(pCurrentTrack.get(), nullptr, this, nullptr);
+    }
+
+    setTrack(pTrack);
+    if (pTrack != nullptr) {
+        connect(pTrack.get(),
+                &Track::waveformSummaryUpdated,
+                this,
+                &QmlWaveformDisplay::slotWaveformUpdated);
+    }
+    slotWaveformUpdated();
+}
+
+void QmlWaveformDisplay::slotWaveformUpdated() {
+    update();
+}
+
+QQmlListProperty<QmlWaveformRendererFactory> QmlWaveformDisplay::renderers() {
+    return {this, &m_waveformRenderers};
+}
+
+} // namespace qml
+} // namespace mixxx

--- a/src/qml/qmlwaveformdisplay.h
+++ b/src/qml/qmlwaveformdisplay.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <QPointer>
+#include <QQuickItem>
+#include <QQuickWindow>
+#include <QSGNode>
+#include <QSGSimpleRectNode>
+#include <chrono>
+
+#include "qml/qmlplayerproxy.h"
+#include "qml/qmlwaveformrenderer.h"
+#include "track/track.h"
+#include "util/performancetimer.h"
+#include "waveform/isynctimeprovider.h"
+#include "waveform/renderers/waveformwidgetrenderer.h"
+
+class WaveformRendererAbstract;
+
+namespace allshader {
+class WaveformWidget;
+class WaveformRenderMark;
+class WaveformRenderMarkRange;
+} // namespace allshader
+namespace rendergraph {
+class Node;
+class OpacityNode;
+class TreeNode;
+} // namespace rendergraph
+
+namespace mixxx {
+namespace qml {
+
+class QmlPlayerProxy;
+
+class QmlWaveformDisplay : public QQuickItem, VSyncTimeProvider, public WaveformWidgetRenderer {
+    Q_OBJECT
+    Q_INTERFACES(QQmlParserStatus)
+    Q_PROPERTY(QmlPlayerProxy* player READ getPlayer WRITE setPlayer
+                    NOTIFY playerChanged REQUIRED)
+    Q_PROPERTY(QString group READ getGroup WRITE setGroup NOTIFY groupChanged REQUIRED)
+    Q_PROPERTY(QQmlListProperty<QmlWaveformRendererFactory> renderers READ renderers)
+    Q_PROPERTY(double zoom READ getZoom WRITE setZoom NOTIFY zoomChanged)
+    Q_PROPERTY(QColor backgroundColor READ getBackgroundColor WRITE
+                    setBackgroundColor NOTIFY backgroundColorChanged)
+    Q_CLASSINFO("DefaultProperty", "renderers")
+    QML_NAMED_ELEMENT(WaveformDisplay)
+
+  public:
+    QmlWaveformDisplay(QQuickItem* parent = nullptr);
+    ~QmlWaveformDisplay() override;
+
+    void setPlayer(QmlPlayerProxy* player);
+    QmlPlayerProxy* getPlayer() const;
+
+    QColor getBackgroundColor() const {
+        return m_backgroundColor;
+    }
+    void setBackgroundColor(QColor color) {
+        m_backgroundColor = color;
+        m_dirtyFlag.setFlag(DirtyFlag::Background, true);
+        emit backgroundColorChanged();
+    }
+
+    void setGroup(const QString& group) override;
+    void setZoom(double zoom) {
+        WaveformWidgetRenderer::setZoom(zoom);
+        emit zoomChanged();
+    }
+
+    std::chrono::microseconds fromTimerToNextSync(const PerformanceTimer& timer) override;
+    std::chrono::microseconds getSyncInterval() const override {
+        return m_syncInterval;
+    }
+
+    void componentComplete() override;
+
+    QQmlListProperty<QmlWaveformRendererFactory> renderers();
+
+  protected:
+    QSGNode* updatePaintNode(QSGNode* old, QQuickItem::UpdatePaintNodeData*) override;
+    void geometryChange(const QRectF& newGeometry, const QRectF& oldGeometry) override;
+  private slots:
+    void slotTrackLoaded(TrackPointer pLoadedTrack);
+    void slotTrackLoading(TrackPointer pNewTrack, TrackPointer pOldTrack);
+    void slotTrackUnloaded();
+    void slotWaveformUpdated();
+
+    void slotFrameSwapped();
+    void slotWindowChanged(QQuickWindow* window);
+  signals:
+    void playerChanged();
+    void zoomChanged();
+    void groupChanged(const QString& group);
+    void backgroundColorChanged();
+
+  private:
+    void setCurrentTrack(TrackPointer pTrack);
+
+    // Properties
+    QPointer<QmlPlayerProxy> m_pPlayer;
+    QColor m_backgroundColor{QColor(0, 0, 0, 255)};
+
+    PerformanceTimer m_timer;
+
+    std::chrono::milliseconds m_syncInterval;
+    enum class DirtyFlag : int {
+        None = 0x0,
+        Geometry = 0x1,
+        Window = 0x2,
+        Background = 0x4,
+    };
+    Q_DECLARE_FLAGS(DirtyFlags, DirtyFlag)
+
+    DirtyFlags m_dirtyFlag{DirtyFlag::None};
+    QList<QmlWaveformRendererFactory*> m_waveformRenderers;
+};
+
+} // namespace qml
+} // namespace mixxx

--- a/src/qml/qmlwaveformrenderer.cpp
+++ b/src/qml/qmlwaveformrenderer.cpp
@@ -141,6 +141,7 @@ QmlWaveformRendererFactory::Renderer QmlWaveformRendererStem::create(
             waveformWidget, m_position);
 
     pRenderer->setAllChannelVisualGain(m_gainAll);
+    pRenderer->setSplitStemTracks(m_splitStemTracks);
     connect(this,
             &QmlWaveformRendererStem::gainAllChanged,
             pRenderer.get(),

--- a/src/qml/qmlwaveformrenderer.cpp
+++ b/src/qml/qmlwaveformrenderer.cpp
@@ -1,0 +1,233 @@
+#include "qml/qmlwaveformrenderer.h"
+
+#include <memory>
+
+#include "moc_qmlwaveformrenderer.cpp"
+#include "util/assert.h"
+#include "waveform/renderers/allshader/waveformrenderbeat.h"
+#include "waveform/renderers/allshader/waveformrendererendoftrack.h"
+#include "waveform/renderers/allshader/waveformrendererpreroll.h"
+#include "waveform/renderers/allshader/waveformrendererrgb.h"
+#ifdef __STEM__
+#include "waveform/renderers/allshader/waveformrendererstem.h"
+#endif
+#include "waveform/renderers/allshader/waveformrendermark.h"
+#include "waveform/renderers/allshader/waveformrendermarkrange.h"
+
+namespace mixxx {
+namespace qml {
+
+QmlWaveformRendererMark::QmlWaveformRendererMark()
+        : m_defaultMark(nullptr),
+          m_untilMark(std::make_unique<QmlWaveformUntilMark>()) {
+}
+
+QmlWaveformRendererFactory::Renderer QmlWaveformRendererEndOfTrack::create(
+        WaveformWidgetRenderer* waveformWidget) const {
+    auto pRenderer = std::make_unique<allshader::WaveformRendererEndOfTrack>(waveformWidget);
+
+    pRenderer->setColor(m_color);
+    pRenderer->setEndOfTrackWarningTime(m_endOfTrackWarningTime);
+    connect(this,
+            &QmlWaveformRendererEndOfTrack::colorChanged,
+            pRenderer.get(),
+            &allshader::WaveformRendererEndOfTrack::setColor);
+    connect(this,
+            &QmlWaveformRendererEndOfTrack::endOfTrackWarningTimeChanged,
+            pRenderer.get(),
+            &allshader::WaveformRendererEndOfTrack::setEndOfTrackWarningTime);
+    return QmlWaveformRendererFactory::Renderer{pRenderer.get(), std::move(pRenderer)};
+}
+
+QmlWaveformRendererFactory::Renderer QmlWaveformRendererPreroll::create(
+        WaveformWidgetRenderer* waveformWidget) const {
+    auto pRenderer = std::make_unique<allshader::WaveformRendererPreroll>(
+            waveformWidget, m_position);
+    pRenderer->setColor(m_color);
+    connect(this,
+            &QmlWaveformRendererPreroll::colorChanged,
+            pRenderer.get(),
+            &allshader::WaveformRendererPreroll::setColor);
+    return QmlWaveformRendererFactory::Renderer{pRenderer.get(), std::move(pRenderer)};
+}
+
+QmlWaveformRendererFactory::Renderer QmlWaveformRendererRGB::create(
+        WaveformWidgetRenderer* waveformWidget) const {
+    auto pRenderer = std::make_unique<allshader::WaveformRendererRGB>(
+            waveformWidget, m_position, m_options);
+
+    pRenderer->setAxesColor(m_axesColor);
+    pRenderer->setLowColor(m_lowColor);
+    pRenderer->setMidColor(m_midColor);
+    pRenderer->setHighColor(m_highColor);
+    connect(this,
+            &QmlWaveformRendererRGB::axesColorChanged,
+            pRenderer.get(),
+            &allshader::WaveformRendererRGB::setAxesColor);
+    connect(this,
+            &QmlWaveformRendererRGB::lowColorChanged,
+            pRenderer.get(),
+            &allshader::WaveformRendererRGB::setLowColor);
+    connect(this,
+            &QmlWaveformRendererRGB::midColorChanged,
+            pRenderer.get(),
+            &allshader::WaveformRendererRGB::setMidColor);
+    connect(this,
+            &QmlWaveformRendererRGB::highColorChanged,
+            pRenderer.get(),
+            &allshader::WaveformRendererRGB::setHighColor);
+
+    pRenderer->setAllChannelVisualGain(m_gainAll);
+    pRenderer->setLowVisualGain(m_gainLow);
+    pRenderer->setMidVisualGain(m_gainMid);
+    pRenderer->setHighVisualGain(m_gainHigh);
+    connect(this,
+            &QmlWaveformRendererRGB::gainAllChanged,
+            pRenderer.get(),
+            &allshader::WaveformRendererRGB::setAllChannelVisualGain);
+    connect(this,
+            &QmlWaveformRendererRGB::gainLowChanged,
+            pRenderer.get(),
+            &allshader::WaveformRendererRGB::setLowVisualGain);
+    connect(this,
+            &QmlWaveformRendererRGB::gainMidChanged,
+            pRenderer.get(),
+            &allshader::WaveformRendererRGB::setMidVisualGain);
+    connect(this,
+            &QmlWaveformRendererRGB::gainHighChanged,
+            pRenderer.get(),
+            &allshader::WaveformRendererRGB::setHighVisualGain);
+    return QmlWaveformRendererFactory::Renderer{pRenderer.get(), std::move(pRenderer)};
+}
+
+QmlWaveformRendererFactory::Renderer QmlWaveformRendererBeat::create(
+        WaveformWidgetRenderer* waveformWidget) const {
+    auto pRenderer = std::make_unique<allshader::WaveformRenderBeat>(
+            waveformWidget, m_position);
+    pRenderer->setColor(m_color);
+    connect(this,
+            &QmlWaveformRendererBeat::colorChanged,
+            pRenderer.get(),
+            &allshader::WaveformRenderBeat::setColor);
+    return QmlWaveformRendererFactory::Renderer{pRenderer.get(), std::move(pRenderer)};
+}
+
+QmlWaveformRendererFactory::Renderer QmlWaveformRendererMarkRange::create(
+        WaveformWidgetRenderer* waveformWidget) const {
+    auto pRenderer = std::make_unique<allshader::WaveformRenderMarkRange>(
+            waveformWidget);
+
+    for (auto* pMark : std::as_const(m_ranges)) {
+        pRenderer->addRange(WaveformMarkRange(
+                waveformWidget->getGroup(),
+                pMark->color(),
+                pMark->disabledColor(),
+                pMark->opacity(),
+                pMark->disabledOpacity(),
+                pMark->durationTextColor(),
+                pMark->startControl(),
+                pMark->endControl(),
+                pMark->enabledControl(),
+                pMark->visibilityControl(),
+                pMark->durationTextLocation()));
+    }
+    return QmlWaveformRendererFactory::Renderer{pRenderer.get(), std::move(pRenderer)};
+}
+
+#ifdef __STEM__
+QmlWaveformRendererFactory::Renderer QmlWaveformRendererStem::create(
+        WaveformWidgetRenderer* waveformWidget) const {
+    auto pRenderer = std::make_unique<allshader::WaveformRendererStem>(
+            waveformWidget, m_position);
+
+    pRenderer->setAllChannelVisualGain(m_gainAll);
+    connect(this,
+            &QmlWaveformRendererStem::gainAllChanged,
+            pRenderer.get(),
+            &allshader::WaveformRendererStem::setAllChannelVisualGain);
+    connect(this,
+            &QmlWaveformRendererStem::splitStemTracksChanged,
+            pRenderer.get(),
+            &allshader::WaveformRendererStem::setSplitStemTracks);
+    return QmlWaveformRendererFactory::Renderer{pRenderer.get(), std::move(pRenderer)};
+}
+#endif
+
+QmlWaveformRendererFactory::Renderer QmlWaveformRendererMark::create(
+        WaveformWidgetRenderer* waveformWidget) const {
+    VERIFY_OR_DEBUG_ASSERT(!!m_untilMark) {
+        return QmlWaveformRendererFactory::Renderer{};
+    }
+    auto pRenderer = std::make_unique<allshader::WaveformRenderMark>(waveformWidget,
+            ::WaveformRendererAbstract::Play);
+
+    pRenderer->setPlayMarkerForegroundColor(m_playMarkerColor);
+    pRenderer->setPlayMarkerBackgroundColor(m_playMarkerBackground);
+
+    pRenderer->setUntilMarkShowBeats(m_untilMark->showTime());
+    pRenderer->setUntilMarkShowTime(m_untilMark->showBeats());
+    pRenderer->setUntilMarkAlign(m_untilMark->align());
+    pRenderer->setUntilMarkTextSize(m_untilMark->textSize());
+    pRenderer->setUntilMarkTextHeightLimit(m_untilMark->textHeightLimit());
+
+    connect(m_untilMark.get(),
+            &QmlWaveformUntilMark::showTimeChanged,
+            pRenderer.get(),
+            &allshader::WaveformRenderMark::setUntilMarkShowTime);
+    connect(m_untilMark.get(),
+            &QmlWaveformUntilMark::showBeatsChanged,
+            pRenderer.get(),
+            &allshader::WaveformRenderMark::setUntilMarkShowBeats);
+    connect(m_untilMark.get(),
+            &QmlWaveformUntilMark::alignChanged,
+            pRenderer.get(),
+            &allshader::WaveformRenderMark::setUntilMarkAlign);
+    connect(m_untilMark.get(),
+            &QmlWaveformUntilMark::textSizeChanged,
+            pRenderer.get(),
+            &allshader::WaveformRenderMark::setUntilMarkTextSize);
+
+    connect(this,
+            &QmlWaveformRendererMark::playMarkerColorChanged,
+            pRenderer.get(),
+            &allshader::WaveformRenderMark::setPlayMarkerForegroundColor);
+    connect(this,
+            &QmlWaveformRendererMark::playMarkerBackgroundChanged,
+            pRenderer.get(),
+            &allshader::WaveformRenderMark::setPlayMarkerBackgroundColor);
+
+    // The initialisation is closely inspired from WaveformMarkSet::setup
+    int priority = 0;
+    for (const auto* pMark : std::as_const(m_marks)) {
+        pRenderer->addMark(WaveformMarkPointer(new WaveformMark(
+                waveformWidget->getGroup(),
+                pMark->control(),
+                pMark->visibilityControl(),
+                pMark->textColor(),
+                pMark->align(),
+                pMark->text(),
+                pMark->pixmap(),
+                pMark->icon(),
+                pMark->color(),
+                priority)));
+        priority--;
+    }
+    const auto* pMark = defaultMark();
+    if (pMark != nullptr) {
+        pRenderer->setDefaultMark(
+                waveformWidget->getGroup(),
+                WaveformMarkSet::DefaultMarkerStyle{
+                        pMark->control(),
+                        pMark->visibilityControl(),
+                        pMark->textColor(),
+                        pMark->align(),
+                        pMark->text(),
+                        pMark->pixmap(),
+                        pMark->icon(),
+                        pMark->color(),
+                });
+    }
+    return QmlWaveformRendererFactory::Renderer{pRenderer.get(), std::move(pRenderer)};
+}
+} // namespace qml
+} // namespace mixxx

--- a/src/qml/qmlwaveformrenderer.h
+++ b/src/qml/qmlwaveformrenderer.h
@@ -330,7 +330,8 @@ class QmlWaveformRendererMarkRange
 class QmlWaveformRendererStem
         : public QmlWaveformRendererFactory {
     Q_OBJECT
-    Q_PROPERTY(double gainAll MEMBER m_gainAll NOTIFY gainAllChanged REQUIRED)
+    Q_PROPERTY(double gainAll MEMBER m_gainAll NOTIFY gainAllChanged)
+    Q_PROPERTY(bool splitStemTracks MEMBER m_splitStemTracks NOTIFY splitStemTracksChanged)
     QML_NAMED_ELEMENT(WaveformRendererStem)
 
   public:
@@ -344,9 +345,11 @@ class QmlWaveformRendererStem
 
   signals:
     void gainAllChanged(double);
+    void splitStemTracksChanged(bool);
 
   private:
-    double m_gainAll;
+    double m_gainAll{1.0};
+    bool m_splitStemTracks{false};
 
     ::WaveformRendererAbstract::PositionSource m_position{::WaveformRendererAbstract::Play};
 };

--- a/src/qml/qmlwaveformrenderer.h
+++ b/src/qml/qmlwaveformrenderer.h
@@ -28,6 +28,10 @@ class QmlWaveformRendererFactory : public QObject {
         std::unique_ptr<rendergraph::BaseNode> node{nullptr};
     };
 
+    virtual bool isSupported() const {
+        return true;
+    }
+
     virtual Renderer create(WaveformWidgetRenderer* waveformWidget) const = 0;
 };
 
@@ -337,9 +341,17 @@ class QmlWaveformRendererStem
   public:
 #ifdef __STEM__
     Renderer create(WaveformWidgetRenderer* waveformWidget) const override;
+
+    bool isSupported() const override {
+        return true;
+    }
 #else
     Renderer create(WaveformWidgetRenderer* waveformWidget) const override {
         return Renderer{};
+    }
+
+    bool isSupported() const override {
+        return false;
     }
 #endif
 

--- a/src/qml/qmlwaveformrenderer.h
+++ b/src/qml/qmlwaveformrenderer.h
@@ -1,0 +1,396 @@
+#pragma once
+
+#include <QObject>
+#include <QQmlEngine>
+
+#include "waveform/renderers/allshader/waveformrenderersignalbase.h"
+#include "waveform/renderers/waveformrendererabstract.h"
+#include "waveform/renderers/waveformwidgetrenderer.h"
+
+class WaveformWidgetRenderer;
+
+namespace allshaders {
+class WaveformRendererEndOfTrack;
+class WaveformRendererPreroll;
+class WaveformRendererRGB;
+class WaveformRenderBeat;
+} // namespace allshaders
+
+namespace mixxx {
+namespace qml {
+
+class QmlWaveformRendererFactory : public QObject {
+    Q_OBJECT
+    QML_ANONYMOUS
+  public:
+    struct Renderer {
+        ::WaveformRendererAbstract* renderer{nullptr};
+        std::unique_ptr<rendergraph::BaseNode> node{nullptr};
+    };
+
+    virtual Renderer create(WaveformWidgetRenderer* waveformWidget) const = 0;
+};
+
+class QmlWaveformRendererEndOfTrack
+        : public QmlWaveformRendererFactory {
+    Q_OBJECT
+    Q_PROPERTY(QColor color MEMBER m_color NOTIFY colorChanged REQUIRED)
+    Q_PROPERTY(int endOfTrackWarningTime MEMBER m_endOfTrackWarningTime NOTIFY
+                    endOfTrackWarningTimeChanged REQUIRED)
+    QML_NAMED_ELEMENT(WaveformRendererEndOfTrack)
+
+  public:
+    Renderer create(WaveformWidgetRenderer* waveformWidget) const override;
+
+  signals:
+    void colorChanged(const QColor&);
+    void endOfTrackWarningTimeChanged(int m_endOfTrackWarningTime);
+
+  private:
+    QColor m_color;
+    int m_endOfTrackWarningTime;
+};
+
+class QmlWaveformRendererPreroll
+        : public QmlWaveformRendererFactory {
+    Q_OBJECT
+    Q_PROPERTY(QColor color MEMBER m_color NOTIFY colorChanged REQUIRED)
+    QML_NAMED_ELEMENT(WaveformRendererPreroll)
+
+  public:
+    Renderer create(WaveformWidgetRenderer* waveformWidget) const override;
+  signals:
+    void colorChanged(const QColor&);
+
+  private:
+    QColor m_color;
+    ::WaveformRendererAbstract::PositionSource m_position{::WaveformRendererAbstract::Play};
+};
+
+class QmlWaveformRendererRGB
+        : public QmlWaveformRendererFactory {
+    Q_OBJECT
+    Q_PROPERTY(QColor axesColor MEMBER m_axesColor NOTIFY axesColorChanged REQUIRED)
+    Q_PROPERTY(QColor lowColor MEMBER m_lowColor NOTIFY lowColorChanged REQUIRED)
+    Q_PROPERTY(QColor midColor MEMBER m_midColor NOTIFY midColorChanged REQUIRED)
+    Q_PROPERTY(QColor highColor MEMBER m_highColor NOTIFY highColorChanged REQUIRED)
+    Q_PROPERTY(double gainAll MEMBER m_gainAll NOTIFY gainAllChanged REQUIRED)
+    Q_PROPERTY(double gainLow MEMBER m_gainLow NOTIFY gainLowChanged REQUIRED)
+    Q_PROPERTY(double gainMid MEMBER m_gainMid NOTIFY gainMidChanged REQUIRED)
+    Q_PROPERTY(double gainHigh MEMBER m_gainHigh NOTIFY gainHighChanged REQUIRED)
+    QML_NAMED_ELEMENT(WaveformRendererRGB)
+
+  public:
+    Renderer create(WaveformWidgetRenderer* waveformWidget) const override;
+
+  signals:
+    void axesColorChanged(const QColor&);
+    void lowColorChanged(const QColor&);
+    void midColorChanged(const QColor&);
+    void highColorChanged(const QColor&);
+    void gainAllChanged(double);
+    void gainLowChanged(double);
+    void gainMidChanged(double);
+    void gainHighChanged(double);
+
+  private:
+    QColor m_axesColor;
+    QColor m_lowColor;
+    QColor m_midColor;
+    QColor m_highColor;
+
+    double m_gainAll;
+    double m_gainLow;
+    double m_gainMid;
+    double m_gainHigh;
+
+    ::WaveformRendererAbstract::PositionSource m_position{::WaveformRendererAbstract::Play};
+    allshader::WaveformRendererSignalBase::Options m_options{
+            allshader::WaveformRendererSignalBase::Option::None};
+};
+
+class QmlWaveformRendererBeat
+        : public QmlWaveformRendererFactory {
+    Q_OBJECT
+    Q_PROPERTY(QColor color MEMBER m_color NOTIFY colorChanged REQUIRED)
+    QML_NAMED_ELEMENT(WaveformRendererBeat)
+
+  public:
+    Renderer create(WaveformWidgetRenderer* waveformWidget) const override;
+  signals:
+    void colorChanged(const QColor&);
+
+  private:
+    QColor m_color;
+    ::WaveformRendererAbstract::PositionSource m_position{::WaveformRendererAbstract::Play};
+};
+
+class QmlWaveformMarkRange : public QObject {
+    Q_OBJECT
+    Q_PROPERTY(QColor color MEMBER m_color NOTIFY colorChanged)
+    Q_PROPERTY(QColor disabledColor MEMBER m_disabledColor NOTIFY disabledColorChanged)
+    Q_PROPERTY(double opacity MEMBER m_opacity NOTIFY opacityChanged)
+    Q_PROPERTY(double disabledOpacity MEMBER m_disabledOpacity NOTIFY disabledOpacityChanged)
+    Q_PROPERTY(QColor durationTextColor MEMBER m_durationTextColor NOTIFY durationTextColorChanged)
+    Q_PROPERTY(QString startControl MEMBER m_startControl NOTIFY startControlChanged)
+    Q_PROPERTY(QString endControl MEMBER m_endControl NOTIFY endControlChanged)
+    Q_PROPERTY(QString enabledControl MEMBER m_enabledControl NOTIFY enabledControlChanged)
+    Q_PROPERTY(QString visibilityControl MEMBER m_visibilityControl NOTIFY visibilityControlChanged)
+    Q_PROPERTY(QString durationTextLocation MEMBER m_durationTextLocation NOTIFY
+                    durationTextLocationChanged)
+    QML_NAMED_ELEMENT(WaveformMarkRange)
+
+  public:
+    QColor color() const {
+        return m_color;
+    }
+
+    QColor disabledColor() const {
+        return m_disabledColor;
+    }
+
+    double opacity() const {
+        return m_opacity;
+    }
+
+    double disabledOpacity() const {
+        return m_disabledOpacity;
+    }
+
+    QColor durationTextColor() const {
+        return m_durationTextColor;
+    }
+
+    QString startControl() const {
+        return m_startControl;
+    }
+
+    QString endControl() const {
+        return m_endControl;
+    }
+
+    QString enabledControl() const {
+        return m_enabledControl;
+    }
+
+    QString visibilityControl() const {
+        return m_visibilityControl;
+    }
+
+    QString durationTextLocation() const {
+        return m_durationTextLocation;
+    }
+
+  signals:
+    void colorChanged(QColor color);
+    void disabledColorChanged(QColor disabledColor);
+    void opacityChanged(double opacity);
+    void disabledOpacityChanged(double disabledOpacity);
+    void durationTextColorChanged(QColor durationTextColor);
+    void startControlChanged(QString startControl);
+    void endControlChanged(QString endControl);
+    void enabledControlChanged(QString enabledControl);
+    void visibilityControlChanged(QString visibilityControl);
+    void durationTextLocationChanged(QString durationTextLocation);
+
+  private:
+    double m_opacity{0.5};
+    double m_disabledOpacity{0.5};
+    QColor m_color;
+    QColor m_disabledColor;
+    QColor m_durationTextColor;
+    QString m_startControl;
+    QString m_endControl;
+    QString m_enabledControl;
+    QString m_visibilityControl;
+    QString m_durationTextLocation;
+};
+
+class QmlWaveformMark : public QObject {
+    Q_OBJECT
+    Q_PROPERTY(QString control MEMBER m_control NOTIFY controlChanged)
+    Q_PROPERTY(QString visibilityControl MEMBER m_visibilityControl NOTIFY visibilityControlChanged)
+    Q_PROPERTY(QString color MEMBER m_color NOTIFY colorChanged)
+    Q_PROPERTY(QString textColor MEMBER m_textColor NOTIFY textColorChanged)
+    Q_PROPERTY(QString align MEMBER m_align NOTIFY alignChanged)
+    Q_PROPERTY(QString text MEMBER m_text NOTIFY textChanged)
+    Q_PROPERTY(QString pixmap MEMBER m_pixmap NOTIFY pixmapChanged)
+    Q_PROPERTY(QString icon MEMBER m_icon NOTIFY iconChanged)
+    QML_NAMED_ELEMENT(WaveformMark)
+  public:
+    QString control() const {
+        return m_control;
+    }
+    QString visibilityControl() const {
+        return m_visibilityControl;
+    }
+    QString color() const {
+        return m_color;
+    }
+    QString textColor() const {
+        return m_textColor;
+    }
+    QString align() const {
+        return m_align;
+    }
+    QString text() const {
+        return m_text;
+    }
+    QString pixmap() const {
+        return m_pixmap;
+    }
+    QString icon() const {
+        return m_icon;
+    }
+
+  signals:
+    void controlChanged(QString control);
+    void visibilityControlChanged(QString visibilityControl);
+    void colorChanged(QString color);
+    void textColorChanged(QString textColor);
+    void alignChanged(QString align);
+    void textChanged(QString text);
+    void pixmapChanged(QString pixmap);
+    void iconChanged(QString icon);
+
+  private:
+    QString m_control;
+    QString m_visibilityControl;
+    QString m_color;
+    QString m_textColor;
+    QString m_align;
+    QString m_text;
+    QString m_pixmap;
+    QString m_icon;
+};
+
+class QmlWaveformUntilMark : public QObject {
+    Q_OBJECT
+    Q_PROPERTY(bool showTime MEMBER m_showTime NOTIFY showTimeChanged)
+    Q_PROPERTY(bool showBeats MEMBER m_showBeats NOTIFY showBeatsChanged)
+    Q_PROPERTY(Qt::Alignment align MEMBER m_align NOTIFY alignChanged)
+    Q_PROPERTY(int textSize MEMBER m_textSize NOTIFY textSizeChanged)
+
+    QML_NAMED_ELEMENT(WaveformUntilMark)
+  public:
+    Q_ENUM(Qt::Alignment)
+
+    bool showTime() const {
+        return m_showTime;
+    }
+
+    bool showBeats() const {
+        return m_showBeats;
+    }
+
+    Qt::Alignment align() const {
+        return m_align;
+    }
+
+    int textSize() const {
+        return m_textSize;
+    }
+
+    float textHeightLimit() const {
+        return m_textSize;
+    }
+
+  signals:
+    void showTimeChanged(bool);
+    void showBeatsChanged(bool);
+    void alignChanged(Qt::Alignment);
+    void textSizeChanged(int);
+
+  private:
+    bool m_showTime;
+    bool m_showBeats;
+    Qt::Alignment m_align;
+    int m_textSize;
+    int m_textHeightLimit;
+};
+
+class QmlWaveformRendererMarkRange
+        : public QmlWaveformRendererFactory {
+    Q_OBJECT
+    Q_PROPERTY(QQmlListProperty<QmlWaveformMarkRange> ranges READ ranges)
+    Q_CLASSINFO("DefaultProperty", "ranges")
+    QML_NAMED_ELEMENT(WaveformRendererMarkRange)
+
+  public:
+    QQmlListProperty<QmlWaveformMarkRange> ranges() {
+        return {this, &m_ranges};
+    }
+
+    Renderer create(WaveformWidgetRenderer* waveformWidget) const override;
+
+  private:
+    QList<QmlWaveformMarkRange*> m_ranges;
+};
+
+class QmlWaveformRendererStem
+        : public QmlWaveformRendererFactory {
+    Q_OBJECT
+    Q_PROPERTY(double gainAll MEMBER m_gainAll NOTIFY gainAllChanged REQUIRED)
+    QML_NAMED_ELEMENT(WaveformRendererStem)
+
+  public:
+#ifdef __STEM__
+    Renderer create(WaveformWidgetRenderer* waveformWidget) const override;
+#else
+    Renderer create(WaveformWidgetRenderer* waveformWidget) const override {
+        return Renderer{};
+    }
+#endif
+
+  signals:
+    void gainAllChanged(double);
+
+  private:
+    double m_gainAll;
+
+    ::WaveformRendererAbstract::PositionSource m_position{::WaveformRendererAbstract::Play};
+};
+
+class QmlWaveformRendererMark
+        : public QmlWaveformRendererFactory {
+    Q_OBJECT
+    Q_PROPERTY(QQmlListProperty<QmlWaveformMark> marks READ marks)
+    Q_PROPERTY(QColor playMarkerColor MEMBER m_playMarkerColor NOTIFY playMarkerColorChanged)
+    Q_PROPERTY(QColor playMarkerBackground MEMBER m_playMarkerBackground NOTIFY
+                    playMarkerBackgroundChanged)
+    Q_PROPERTY(QmlWaveformMark* defaultMark MEMBER m_defaultMark NOTIFY defaultMarkChanged)
+    Q_PROPERTY(QmlWaveformUntilMark* untilMark READ untilMark FINAL)
+    Q_CLASSINFO("DefaultProperty", "marks")
+    QML_NAMED_ELEMENT(WaveformRendererMark)
+
+  public:
+    QmlWaveformRendererMark();
+
+    QmlWaveformMark* defaultMark() const {
+        return m_defaultMark;
+    }
+
+    QmlWaveformUntilMark* untilMark() const {
+        return m_untilMark.get();
+    }
+
+    Renderer create(WaveformWidgetRenderer* waveformWidget) const override;
+
+    QQmlListProperty<QmlWaveformMark> marks() {
+        return {this, &m_marks};
+    }
+  signals:
+    void playMarkerColorChanged(const QColor&);
+    void playMarkerBackgroundChanged(const QColor&);
+    void defaultMarkChanged(mixxx::qml::QmlWaveformMark*);
+
+  private:
+    QColor m_playMarkerColor;
+    QColor m_playMarkerBackground;
+    QList<QmlWaveformMark*> m_marks;
+    QmlWaveformMark* m_defaultMark;
+    std::unique_ptr<QmlWaveformUntilMark> m_untilMark;
+};
+
+} // namespace qml
+} // namespace mixxx

--- a/src/rendergraph/CMakeLists.txt
+++ b/src/rendergraph/CMakeLists.txt
@@ -39,8 +39,5 @@ set(
 )
 
 add_subdirectory(opengl)
-#################################
-# TODO: uncomment in follow-up PR
-# add_subdirectory(scenegraph)
-#################################
+add_subdirectory(scenegraph)
 add_subdirectory(shaders)

--- a/src/rendergraph/opengl/texture.cpp
+++ b/src/rendergraph/opengl/texture.cpp
@@ -1,7 +1,4 @@
 #include "rendergraph/texture.h"
-#include <qnamespace.h>
-#include <qrgb.h>
-#include "rendergraph/assert.h"
 
 #include <qnamespace.h>
 #include <qrgb.h>

--- a/src/rendergraph/opengl/texture.cpp
+++ b/src/rendergraph/opengl/texture.cpp
@@ -1,4 +1,7 @@
 #include "rendergraph/texture.h"
+#include <qnamespace.h>
+#include <qrgb.h>
+#include "rendergraph/assert.h"
 
 #include <qnamespace.h>
 #include <qrgb.h>

--- a/src/rendergraph/scenegraph/backend/baseattributeset.cpp
+++ b/src/rendergraph/scenegraph/backend/baseattributeset.cpp
@@ -1,5 +1,7 @@
 #include "backend/baseattributeset.h"
 
+#include <stdexcept>
+
 using namespace rendergraph;
 
 namespace {
@@ -9,6 +11,8 @@ int toQSGGeometryType(const PrimitiveType& t) {
         return QSGGeometry::FloatType;
     case PrimitiveType::UInt:
         return QSGGeometry::UnsignedIntType;
+    default:
+        throw std::runtime_error("not implemented");
     }
 }
 } // namespace

--- a/src/rendergraph/shaders/CMakeLists.txt
+++ b/src/rendergraph/shaders/CMakeLists.txt
@@ -18,7 +18,9 @@ if(TARGET rendergraph_sg)
   qt6_add_shaders(rendergraph_sg "shaders-qsb"
       BATCHABLE
       PRECOMPILE
-      OPTIMIZED
+      # FIXME qsl relies on 'spirv-opt' to be available in the path, so only installing it via VCPKG is not sufficient
+      # See https://doc.qt.io/qt-6/qtshadertools-build.html#invoking-external-tools
+      # OPTIMIZED
       PREFIX
           /shaders/rendergraph
       FILES
@@ -35,7 +37,9 @@ if(TARGET rendergraph_gl)
     qt6_add_shaders(rendergraph_gl "shaders-qsb"
           BATCHABLE
           PRECOMPILE
-          OPTIMIZED
+          # FIXME qsl relies on 'spirv-opt' to be available in the path, so only installing it via VCPKG is not sufficient
+          # See https://doc.qt.io/qt-6/qtshadertools-build.html#invoking-external-tools
+          # OPTIMIZED
           PREFIX
               /shaders/rendergraph
           FILES

--- a/src/waveform/isynctimeprovider.h
+++ b/src/waveform/isynctimeprovider.h
@@ -2,8 +2,8 @@
 
 #include "util/performancetimer.h"
 
-class ISyncTimeProvider {
+class VSyncTimeProvider {
   public:
-    virtual int fromTimerToNextSyncMicros(const PerformanceTimer& timer) = 0;
-    virtual int getSyncIntervalTimeMicros() const = 0;
+    virtual std::chrono::microseconds fromTimerToNextSync(const PerformanceTimer& timer) = 0;
+    virtual std::chrono::microseconds getSyncInterval() const = 0;
 };

--- a/src/waveform/isynctimeprovider.h
+++ b/src/waveform/isynctimeprovider.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "util/performancetimer.h"
+
+class ISyncTimeProvider {
+  public:
+    virtual int fromTimerToNextSyncMicros(const PerformanceTimer& timer) = 0;
+    virtual int getSyncIntervalTimeMicros() const = 0;
+};

--- a/src/waveform/renderers/allshader/waveformrenderbeat.cpp
+++ b/src/waveform/renderers/allshader/waveformrenderbeat.cpp
@@ -2,6 +2,7 @@
 
 #include <QDomNode>
 
+#include "moc_waveformrenderbeat.cpp"
 #include "rendergraph/geometry.h"
 #include "rendergraph/material/unicolormaterial.h"
 #include "rendergraph/vertexupdaters/vertexupdater.h"

--- a/src/waveform/renderers/allshader/waveformrenderbeat.h
+++ b/src/waveform/renderers/allshader/waveformrenderbeat.h
@@ -14,8 +14,10 @@ class WaveformRenderBeat;
 } // namespace allshader
 
 class allshader::WaveformRenderBeat final
-        : public ::WaveformRendererAbstract,
+        : public QObject,
+          public ::WaveformRendererAbstract,
           public rendergraph::GeometryNode {
+    Q_OBJECT
   public:
     explicit WaveformRenderBeat(WaveformWidgetRenderer* waveformWidget,
             ::WaveformRendererAbstract::PositionSource type =
@@ -28,6 +30,11 @@ class allshader::WaveformRenderBeat final
 
     // Virtuals for rendergraph::Node
     void preprocess() override;
+
+  public slots:
+    void setColor(const QColor& color) {
+        m_color = color;
+    }
 
   private:
     QColor m_color;

--- a/src/waveform/renderers/allshader/waveformrendererendoftrack.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererendoftrack.cpp
@@ -5,6 +5,7 @@
 #include <memory>
 
 #include "control/controlproxy.h"
+#include "moc_waveformrendererendoftrack.cpp"
 #include "rendergraph/geometry.h"
 #include "rendergraph/material/rgbamaterial.h"
 #include "rendergraph/vertexupdaters/rgbavertexupdater.h"
@@ -16,6 +17,7 @@
 namespace {
 
 constexpr int kBlinkingPeriodMillis = 1000;
+constexpr int kDefaultRemainingSeccondTrigger = 30;
 
 } // anonymous namespace
 
@@ -27,7 +29,8 @@ WaveformRendererEndOfTrack::WaveformRendererEndOfTrack(
         WaveformWidgetRenderer* waveformWidget)
         : ::WaveformRendererAbstract(waveformWidget),
           m_pEndOfTrackControl(nullptr),
-          m_pTimeRemainingControl(nullptr) {
+          m_pTimeRemainingControl(nullptr),
+          m_remainingTimeTriggerSeconds(kDefaultRemainingSeccondTrigger) {
     initForRectangles<RGBAMaterial>(0);
     setUsePreprocess(true);
 }
@@ -79,10 +82,8 @@ bool WaveformRendererEndOfTrack::preprocessInner() {
             kBlinkingPeriodMillis;
 
     const double remainingTime = m_pTimeRemainingControl->get();
-    const double remainingTimeTriggerSeconds =
-            WaveformWidgetFactory::instance()->getEndOfTrackWarningTime();
-    const double criticalIntensity = (remainingTimeTriggerSeconds - remainingTime) /
-            remainingTimeTriggerSeconds;
+    const double criticalIntensity = (m_remainingTimeTriggerSeconds - remainingTime) /
+            m_remainingTimeTriggerSeconds;
 
     const double alpha = std::clamp(criticalIntensity * blinkIntensity, 0.0, 1.0);
 

--- a/src/waveform/renderers/allshader/waveformrendererendoftrack.h
+++ b/src/waveform/renderers/allshader/waveformrendererendoftrack.h
@@ -18,8 +18,10 @@ class WaveformRendererEndOfTrack;
 } // namespace allshader
 
 class allshader::WaveformRendererEndOfTrack final
-        : public ::WaveformRendererAbstract,
+        : public QObject,
+          public ::WaveformRendererAbstract,
           public rendergraph::GeometryNode {
+    Q_OBJECT
   public:
     explicit WaveformRendererEndOfTrack(
             WaveformWidgetRenderer* waveformWidget);
@@ -34,11 +36,20 @@ class allshader::WaveformRendererEndOfTrack final
     // Virtual for rendergraph::Node
     void preprocess() override;
 
+  public slots:
+    void setColor(const QColor& color) {
+        m_color = color;
+    }
+    void setEndOfTrackWarningTime(int endOfTrackWarningTime) {
+        m_remainingTimeTriggerSeconds = endOfTrackWarningTime;
+    }
+
   private:
     std::unique_ptr<ControlProxy> m_pEndOfTrackControl;
     std::unique_ptr<ControlProxy> m_pTimeRemainingControl;
 
     QColor m_color;
+    int m_remainingTimeTriggerSeconds;
     PerformanceTimer m_timer;
 
     bool preprocessInner();

--- a/src/waveform/renderers/allshader/waveformrendererfiltered.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererfiltered.cpp
@@ -12,7 +12,8 @@ using namespace rendergraph;
 namespace allshader {
 
 WaveformRendererFiltered::WaveformRendererFiltered(
-        WaveformWidgetRenderer* waveformWidget, bool bRgbStacked)
+        WaveformWidgetRenderer* waveformWidget,
+        bool bRgbStacked)
         : WaveformRendererSignalBase(waveformWidget),
           m_bRgbStacked(bRgbStacked) {
     initForRectangles<RGBMaterial>(0);

--- a/src/waveform/renderers/allshader/waveformrendererfiltered.h
+++ b/src/waveform/renderers/allshader/waveformrendererfiltered.h
@@ -12,7 +12,8 @@ class allshader::WaveformRendererFiltered final
         : public allshader::WaveformRendererSignalBase,
           public rendergraph::GeometryNode {
   public:
-    explicit WaveformRendererFiltered(WaveformWidgetRenderer* waveformWidget, bool rgbStacked);
+    explicit WaveformRendererFiltered(WaveformWidgetRenderer* waveformWidget,
+            bool rgbStacked);
 
     // Pure virtual from WaveformRendererSignalBase, not used
     void onSetup(const QDomNode& node) override;

--- a/src/waveform/renderers/allshader/waveformrendererhsv.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererhsv.cpp
@@ -81,7 +81,7 @@ bool WaveformRendererHSV::preprocessInner() {
 
     // Get base color of waveform in the HSV format (s and v isn't use)
     float h, s, v;
-    getHsvF(m_pColors->getLowColor(), &h, &s, &v);
+    getHsvF(m_waveformRenderer->getWaveformSignalColors()->getLowColor(), &h, &s, &v);
 
     const float breadth = static_cast<float>(m_waveformRenderer->getBreadth());
     const float halfBreadth = breadth / 2.0f;

--- a/src/waveform/renderers/allshader/waveformrendererpreroll.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererpreroll.cpp
@@ -3,6 +3,7 @@
 #include <QDomNode>
 #include <QPainterPath>
 
+#include "moc_waveformrendererpreroll.cpp"
 #include "rendergraph/geometry.h"
 #include "rendergraph/material/patternmaterial.h"
 #include "rendergraph/vertexupdaters/texturedvertexupdater.h"

--- a/src/waveform/renderers/allshader/waveformrendererpreroll.h
+++ b/src/waveform/renderers/allshader/waveformrendererpreroll.h
@@ -14,8 +14,10 @@ class WaveformRendererPreroll;
 } // namespace allshader
 
 class allshader::WaveformRendererPreroll final
-        : public ::WaveformRendererAbstract,
+        : public QObject,
+          public ::WaveformRendererAbstract,
           public rendergraph::GeometryNode {
+    Q_OBJECT
   public:
     explicit WaveformRendererPreroll(
             WaveformWidgetRenderer* waveformWidget,
@@ -30,6 +32,11 @@ class allshader::WaveformRendererPreroll final
 
     // Virtual for rendergraph::Node
     void preprocess() override;
+
+  public slots:
+    void setColor(const QColor& color) {
+        m_color = color;
+    }
 
   private:
     QColor m_color;

--- a/src/waveform/renderers/allshader/waveformrendererrgb.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererrgb.cpp
@@ -3,6 +3,7 @@
 #include "rendergraph/material/rgbmaterial.h"
 #include "rendergraph/vertexupdaters/rgbvertexupdater.h"
 #include "track/track.h"
+#include "util/colorcomponents.h"
 #include "util/math.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
 #include "waveform/waveform.h"
@@ -25,6 +26,22 @@ WaveformRendererRGB::WaveformRendererRGB(WaveformWidgetRenderer* waveformWidget,
           m_options(options) {
     initForRectangles<RGBMaterial>(0);
     setUsePreprocess(true);
+}
+
+void WaveformRendererRGB::setAxesColor(const QColor& axesColor) {
+    getRgbF(axesColor, &m_axesColor_r, &m_axesColor_g, &m_axesColor_b, &m_axesColor_a);
+}
+
+void WaveformRendererRGB::setLowColor(const QColor& lowColor) {
+    getRgbF(lowColor, &m_rgbLowColor_r, &m_rgbLowColor_g, &m_rgbLowColor_b);
+}
+
+void WaveformRendererRGB::setMidColor(const QColor& midColor) {
+    getRgbF(midColor, &m_rgbMidColor_r, &m_rgbMidColor_g, &m_rgbMidColor_b);
+}
+
+void WaveformRendererRGB::setHighColor(const QColor& highColor) {
+    getRgbF(highColor, &m_rgbHighColor_r, &m_rgbHighColor_g, &m_rgbHighColor_b);
 }
 
 void WaveformRendererRGB::onSetup(const QDomNode&) {
@@ -117,7 +134,7 @@ bool WaveformRendererRGB::preprocessInner() {
     const int numVerticesPerLine = 6; // 2 triangles
 
     const int reserved = numVerticesPerLine *
-            // Slip rendere only render a single channel, so the vertices count doesn't change
+            // Slip renderer only render a single channel, so the vertices count doesn't change
             ((splitLeftRight && !m_isSlipRenderer ? pixelLength * 2 : pixelLength) + 1);
 
     geometry().setDrawingMode(Geometry::DrawingMode::Triangles);

--- a/src/waveform/renderers/allshader/waveformrendererrgb.h
+++ b/src/waveform/renderers/allshader/waveformrendererrgb.h
@@ -27,6 +27,12 @@ class allshader::WaveformRendererRGB final
     // Virtuals for rendergraph::Node
     void preprocess() override;
 
+  public slots:
+    void setAxesColor(const QColor& axesColor);
+    void setLowColor(const QColor& lowColor);
+    void setMidColor(const QColor& midColor);
+    void setHighColor(const QColor& highColor);
+
   private:
     bool m_isSlipRenderer;
     WaveformRendererSignalBase::Options m_options;

--- a/src/waveform/renderers/allshader/waveformrenderersimple.cpp
+++ b/src/waveform/renderers/allshader/waveformrenderersimple.cpp
@@ -11,7 +11,8 @@ using namespace rendergraph;
 
 namespace allshader {
 
-WaveformRendererSimple::WaveformRendererSimple(WaveformWidgetRenderer* waveformWidget)
+WaveformRendererSimple::WaveformRendererSimple(
+        WaveformWidgetRenderer* waveformWidget)
         : WaveformRendererSignalBase(waveformWidget) {
     initForRectangles<RGBMaterial>(0);
     setUsePreprocess(true);

--- a/src/waveform/renderers/allshader/waveformrendererstem.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererstem.cpp
@@ -124,7 +124,8 @@ bool WaveformRendererStem::preprocessInner() {
     getGains(&allGain, false, nullptr, nullptr, nullptr);
 
     const float breadth = static_cast<float>(m_waveformRenderer->getBreadth());
-    const float halfBreadth = breadth / 2.0f;
+    const float stemBreadth = m_splitStemTracks ? breadth / 4.0f : 0;
+    const float halfBreadth = (m_splitStemTracks ? stemBreadth : breadth) / 2.0f;
 
     const float heightFactor = allGain * halfBreadth / m_maxValue;
 
@@ -195,10 +196,15 @@ bool WaveformRendererStem::preprocessInner() {
 
                 // Lines are thin rectangles
                 // shadow
-                vertexUpdater.addRectangle({fVisualIdx - halfStripSize,
-                                                   halfBreadth - heightFactor * max},
+                vertexUpdater.addRectangle(
+                        {fVisualIdx - halfStripSize,
+                                stemIdx * stemBreadth + halfBreadth -
+                                        heightFactor * max},
                         {fVisualIdx + halfStripSize,
-                                m_isSlipRenderer ? halfBreadth : halfBreadth + heightFactor * max},
+                                m_isSlipRenderer
+                                        ? stemIdx * stemBreadth + halfBreadth
+                                        : stemIdx * stemBreadth + halfBreadth +
+                                                heightFactor * max},
                         {color_r, color_g, color_b, color_a});
             }
         }

--- a/src/waveform/renderers/allshader/waveformrendererstem.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererstem.cpp
@@ -22,7 +22,8 @@ WaveformRendererStem::WaveformRendererStem(
         WaveformWidgetRenderer* waveformWidget,
         ::WaveformRendererAbstract::PositionSource type)
         : WaveformRendererSignalBase(waveformWidget),
-          m_isSlipRenderer(type == ::WaveformRendererAbstract::Slip) {
+          m_isSlipRenderer(type == ::WaveformRendererAbstract::Slip),
+          m_splitStemTracks(false) {
     initForRectangles<RGBAMaterial>(0);
     setUsePreprocess(true);
 }
@@ -107,7 +108,7 @@ bool WaveformRendererStem::preprocessInner() {
 
     // Per-band gain from the EQ knobs.
     float allGain(1.0);
-    // applyCompensation = true, as we scale to match filtered.all
+    // applyCompensation = false, as we scale to match filtered.all
     getGains(&allGain, false, nullptr, nullptr, nullptr);
 
     const float breadth = static_cast<float>(m_waveformRenderer->getBreadth());
@@ -121,7 +122,8 @@ bool WaveformRendererStem::preprocessInner() {
 
     const int numVerticesPerLine = 6; // 2 triangles
 
-    const int reserved = numVerticesPerLine * (8 * pixelLength + 1);
+    const int reserved = numVerticesPerLine *
+            (mixxx::audio::ChannelCount::stem() * pixelLength + 1);
 
     geometry().setDrawingMode(Geometry::DrawingMode::Triangles);
     geometry().allocate(reserved);

--- a/src/waveform/renderers/allshader/waveformrendererstem.h
+++ b/src/waveform/renderers/allshader/waveformrendererstem.h
@@ -33,8 +33,14 @@ class allshader::WaveformRendererStem final
     // Virtuals for rendergraph::Node
     void preprocess() override;
 
+  public slots:
+    void setSplitStemTracks(bool splitStemTracks) {
+        m_splitStemTracks = splitStemTracks;
+    }
+
   private:
     bool m_isSlipRenderer;
+    bool m_splitStemTracks;
 
     std::vector<std::unique_ptr<PollingControlProxy>> m_pStemGain;
     std::vector<std::unique_ptr<PollingControlProxy>> m_pStemMute;

--- a/src/waveform/renderers/allshader/waveformrenderertextured.h
+++ b/src/waveform/renderers/allshader/waveformrenderertextured.h
@@ -16,8 +16,7 @@ class WaveformRendererTextured;
 } // namespace allshader
 
 // Based on GLSLWaveformRendererSignal (waveform/renderers/glslwaveformrenderersignal.h)
-class allshader::WaveformRendererTextured final : public QObject,
-                                                  public allshader::WaveformRendererSignalBase,
+class allshader::WaveformRendererTextured final : public allshader::WaveformRendererSignalBase,
                                                   public rendergraph::OpenGLNode {
     Q_OBJECT
   public:

--- a/src/waveform/renderers/allshader/waveformrendermark.cpp
+++ b/src/waveform/renderers/allshader/waveformrendermark.cpp
@@ -2,6 +2,7 @@
 
 #include <QPainterPath>
 
+#include "moc_waveformrendermark.cpp"
 #include "rendergraph/context.h"
 #include "rendergraph/geometry.h"
 #include "rendergraph/geometrynode.h"
@@ -174,6 +175,34 @@ allshader::WaveformRenderMark::WaveformRenderMark(
 
 void allshader::WaveformRenderMark::draw(QPainter*, QPaintEvent*) {
     DEBUG_ASSERT(false);
+}
+
+void allshader::WaveformRenderMark::setup(const QDomNode& node, const SkinContext& context) {
+    ::WaveformRenderMarkBase::setup(node, context);
+    auto* pWaveformWidgetFactory = WaveformWidgetFactory::instance();
+    connect(pWaveformWidgetFactory,
+            &WaveformWidgetFactory::untilMarkShowBeatsChanged,
+            this,
+            &WaveformRenderMark::setUntilMarkShowBeats);
+    connect(pWaveformWidgetFactory,
+            &WaveformWidgetFactory::untilMarkShowTimeChanged,
+            this,
+            &WaveformRenderMark::setUntilMarkShowTime);
+    connect(pWaveformWidgetFactory,
+            &WaveformWidgetFactory::untilMarkAlignChanged,
+            this,
+            &WaveformRenderMark::setUntilMarkAlign);
+    connect(pWaveformWidgetFactory,
+            &WaveformWidgetFactory::untilMarkTextPointSizeChanged,
+            this,
+            &WaveformRenderMark::setUntilMarkTextSize);
+    connect(pWaveformWidgetFactory,
+            &WaveformWidgetFactory::untilMarkTextHeightLimitChanged,
+            this,
+            &WaveformRenderMark::setUntilMarkTextHeightLimit);
+
+    m_playMarkerForegroundColor = m_waveformRenderer->getWaveformSignalColors()->getPlayPosColor();
+    m_playMarkerBackgroundColor = m_waveformRenderer->getWaveformSignalColors()->getBgColor();
 }
 
 bool allshader::WaveformRenderMark::init() {
@@ -365,28 +394,17 @@ void allshader::WaveformRenderMark::update() {
                 {1.f, 1.f});
     }
 
-    if (WaveformWidgetFactory::instance()->getUntilMarkShowBeats() ||
-            WaveformWidgetFactory::instance()->getUntilMarkShowTime()) {
+    if (m_untilMarkShowBeats || m_untilMarkShowTime) {
         updateUntilMark(playPosition, nextMarkPosition);
         updateDigitsNodeForUntilMark(roundToPixel(playMarkerPos + 20.f));
     }
 }
 
 void allshader::WaveformRenderMark::updateDigitsNodeForUntilMark(float x) {
-    const bool untilMarkShowBeats = WaveformWidgetFactory::instance()->getUntilMarkShowBeats();
-    const bool untilMarkShowTime = WaveformWidgetFactory::instance()->getUntilMarkShowTime();
-    const auto untilMarkAlign = WaveformWidgetFactory::instance()->getUntilMarkAlign();
-
-    const auto untilMarkTextPointSize =
-            WaveformWidgetFactory::instance()->getUntilMarkTextPointSize();
-    const auto untilMarkTextHeightLimit =
-            WaveformWidgetFactory::instance()
-                    ->getUntilMarkTextHeightLimit(); // proportion of waveform
-                                                     // height
-    const auto untilMarkMaxHeightForText = getMaxHeightForText(untilMarkTextHeightLimit);
+    const auto untilMarkMaxHeightForText = getMaxHeightForText(m_untilMarkTextHeightLimit);
 
     m_pDigitsRenderNode->updateTexture(m_waveformRenderer->getContext(),
-            untilMarkTextPointSize,
+            m_untilMarkTextSize,
             untilMarkMaxHeightForText,
             m_waveformRenderer->getDevicePixelRatio());
 
@@ -396,20 +414,20 @@ void allshader::WaveformRenderMark::updateDigitsNodeForUntilMark(float x) {
     }
     const float ch = m_pDigitsRenderNode->height();
 
-    float y = untilMarkAlign == Qt::AlignTop ? 0.f
-            : untilMarkAlign == Qt::AlignBottom
+    float y = m_untilMarkAlign == Qt::AlignTop ? 0.f
+            : m_untilMarkAlign == Qt::AlignBottom
             ? m_waveformRenderer->getBreadth() - ch
             : m_waveformRenderer->getBreadth() / 2.f;
 
-    bool multiLine = untilMarkShowBeats && untilMarkShowTime &&
+    bool multiLine = m_untilMarkShowBeats && m_untilMarkShowTime &&
             ch * 2.f < untilMarkMaxHeightForText;
 
     if (multiLine) {
-        if (untilMarkAlign != Qt::AlignTop) {
+        if (m_untilMarkAlign != Qt::AlignTop) {
             y -= ch;
         }
     } else {
-        if (untilMarkAlign != Qt::AlignTop && untilMarkAlign != Qt::AlignBottom) {
+        if (m_untilMarkAlign != Qt::AlignTop && m_untilMarkAlign != Qt::AlignBottom) {
             // center
             y -= ch / 2.f;
         }
@@ -419,8 +437,8 @@ void allshader::WaveformRenderMark::updateDigitsNodeForUntilMark(float x) {
             x,
             y,
             multiLine,
-            untilMarkShowBeats ? QString::number(m_beatsUntilMark) : QString{},
-            untilMarkShowTime ? timeSecToString(m_timeUntilMark) : QString{});
+            m_untilMarkShowBeats ? QString::number(m_beatsUntilMark) : QString{},
+            m_untilMarkShowTime ? timeSecToString(m_timeUntilMark) : QString{});
 }
 
 // Generate the texture used to draw the play position marker.
@@ -466,11 +484,8 @@ void allshader::WaveformRenderMark::updatePlayPosMarkTexture(rendergraph::Contex
 
     painter.setWorldMatrixEnabled(false);
 
-    const QColor fgColor{m_waveformRenderer->getWaveformSignalColors()->getPlayPosColor()};
-    const QColor bgColor{m_waveformRenderer->getWaveformSignalColors()->getBgColor()};
-
     // draw dim outlines to increase playpos/waveform contrast
-    painter.setPen(bgColor);
+    painter.setPen(m_playMarkerBackgroundColor);
     painter.setOpacity(0.5);
     // lines next to playpos
     // Note: don't draw lines where they would overlap the triangles,
@@ -485,10 +500,10 @@ void allshader::WaveformRenderMark::updatePlayPosMarkTexture(rendergraph::Contex
         QPointF baseL = QPointF(lineX - 5.f, 0.f);
         QPointF baseR = QPointF(lineX + 5.f, 0.f);
         QPointF tip = QPointF(lineX, 5.f);
-        drawTriangle(&painter, bgColor, baseL, baseR, tip);
+        drawTriangle(&painter, m_playMarkerBackgroundColor, baseL, baseR, tip);
     }
     // draw colored play position indicators
-    painter.setPen(fgColor);
+    painter.setPen(m_playMarkerForegroundColor);
     painter.setOpacity(1.0);
     // play position line
     painter.drawLine(QLineF(lineX, 0.f, lineX, imgHeight));
@@ -497,7 +512,7 @@ void allshader::WaveformRenderMark::updatePlayPosMarkTexture(rendergraph::Contex
         QPointF baseL = QPointF(lineX - 4.f, 0.f);
         QPointF baseR = QPointF(lineX + 4.f, 0.f);
         QPointF tip = QPointF(lineX, 4.f);
-        drawTriangle(&painter, fgColor, baseL, baseR, tip);
+        drawTriangle(&painter, m_playMarkerForegroundColor, baseL, baseR, tip);
     }
     painter.end();
 

--- a/src/waveform/renderers/allshader/waveformrendermark.h
+++ b/src/waveform/renderers/allshader/waveformrendermark.h
@@ -20,6 +20,7 @@ class WaveformRenderMark;
 
 class allshader::WaveformRenderMark : public ::WaveformRenderMarkBase,
                                       public rendergraph::Node {
+    Q_OBJECT
   public:
     explicit WaveformRenderMark(WaveformWidgetRenderer* waveformWidget,
             ::WaveformRendererAbstract::PositionSource type =
@@ -28,11 +29,36 @@ class allshader::WaveformRenderMark : public ::WaveformRenderMarkBase,
     // Pure virtual from WaveformRendererAbstract, not used
     void draw(QPainter* painter, QPaintEvent* event) override final;
 
+    void setup(const QDomNode& node, const SkinContext& skinContext) override;
+
     bool init() override;
 
-    void update();
+    void update() override;
 
     bool isSubtreeBlocked() const override;
+
+  public slots:
+    void setPlayMarkerForegroundColor(const QColor& fgPlayColor) {
+        m_playMarkerForegroundColor = fgPlayColor;
+    }
+    void setPlayMarkerBackgroundColor(const QColor& bgPlayColor) {
+        m_playMarkerBackgroundColor = bgPlayColor;
+    }
+    void setUntilMarkShowBeats(bool untilMarkShowBeats) {
+        m_untilMarkShowBeats = untilMarkShowBeats;
+    }
+    void setUntilMarkShowTime(bool untilMarkShowTime) {
+        m_untilMarkShowTime = untilMarkShowTime;
+    }
+    void setUntilMarkAlign(Qt::Alignment untilMarkAlign) {
+        m_untilMarkAlign = untilMarkAlign;
+    }
+    void setUntilMarkTextSize(int untilMarkTextSize) {
+        m_untilMarkTextSize = untilMarkTextSize;
+    }
+    void setUntilMarkTextHeightLimit(float untilMarkTextHeightLimit) {
+        m_untilMarkTextHeightLimit = untilMarkTextHeightLimit;
+    }
 
   private:
     void updateMarkImage(WaveformMarkPointer pMark) override;
@@ -68,6 +94,15 @@ class allshader::WaveformRenderMark : public ::WaveformRenderMarkBase,
     float m_playPosDevicePixelRatio;
 
     DigitsRenderNode* m_pDigitsRenderNode{};
+
+    QColor m_playMarkerForegroundColor;
+    QColor m_playMarkerBackgroundColor;
+
+    bool m_untilMarkShowBeats;
+    bool m_untilMarkShowTime;
+    Qt::Alignment m_untilMarkAlign;
+    int m_untilMarkTextSize;
+    float m_untilMarkTextHeightLimit;
 
     DISALLOW_COPY_AND_ASSIGN(WaveformRenderMark);
 };

--- a/src/waveform/renderers/allshader/waveformrendermarkrange.h
+++ b/src/waveform/renderers/allshader/waveformrendermarkrange.h
@@ -33,7 +33,7 @@ class allshader::WaveformRenderMarkRange final : public ::WaveformRendererAbstra
 
     void setup(const QDomNode& node, const SkinContext& skinContext) override;
 
-    void update();
+    void update() override;
 
   private:
     void updateNode(rendergraph::GeometryNode* pChild,

--- a/src/waveform/renderers/qtwaveformrendererfilteredsignal.cpp
+++ b/src/waveform/renderers/qtwaveformrendererfilteredsignal.cpp
@@ -20,9 +20,10 @@ QtWaveformRendererFilteredSignal::~QtWaveformRendererFilteredSignal() {
 }
 
 void QtWaveformRendererFilteredSignal::onSetup(const QDomNode& /*node*/) {
-    QColor low = m_pColors->getLowColor();
-    QColor mid = m_pColors->getMidColor();
-    QColor high = m_pColors->getHighColor();
+    const auto* pColors = m_waveformRenderer->getWaveformSignalColors();
+    QColor low = pColors->getLowColor();
+    QColor mid = pColors->getMidColor();
+    QColor high = pColors->getHighColor();
 
     QColor lowCenter = low;
     QColor midCenter = mid;
@@ -316,7 +317,7 @@ void QtWaveformRendererFilteredSignal::draw(QPainter* painter, QPaintEvent* /*ev
 
     //draw reference line
     if (m_alignment == Qt::AlignCenter) {
-        painter->setPen(m_pColors->getAxesColor());
+        painter->setPen(m_waveformRenderer->getWaveformSignalColors()->getAxesColor());
         painter->drawLine(0, 0, m_waveformRenderer->getLength(), 0);
     }
 

--- a/src/waveform/renderers/qtwaveformrenderersimplesignal.cpp
+++ b/src/waveform/renderers/qtwaveformrenderersimplesignal.cpp
@@ -22,12 +22,13 @@ QtWaveformRendererSimpleSignal::~QtWaveformRendererSimpleSignal() {
 void QtWaveformRendererSimpleSignal::onSetup(const QDomNode& node) {
     Q_UNUSED(node);
 
-    QColor borderColor = m_pColors->getSignalColor().lighter(125);
+    const auto* pColors = m_waveformRenderer->getWaveformSignalColors();
+    QColor borderColor = pColors->getSignalColor().lighter(125);
     borderColor.setAlphaF(0.5f);
     m_borderPen.setColor(borderColor);
     m_borderPen.setWidthF(1.25f);
 
-    QColor signalColor = m_pColors->getSignalColor();
+    QColor signalColor = pColors->getSignalColor();
     signalColor.setAlphaF(0.8f);
     m_brush = QBrush(signalColor);
 }
@@ -90,7 +91,7 @@ void QtWaveformRendererSimpleSignal::draw(QPainter* painter, QPaintEvent* /*even
 
     //draw reference line
     if (m_alignment == Qt::AlignCenter) {
-        painter->setPen(m_pColors->getAxesColor());
+        painter->setPen(m_waveformRenderer->getWaveformSignalColors()->getAxesColor());
         painter->drawLine(0,0,m_waveformRenderer->getLength(),0);
     }
 

--- a/src/waveform/renderers/waveformmark.cpp
+++ b/src/waveform/renderers/waveformmark.cpp
@@ -94,6 +94,76 @@ bool isShowUntilNextPositionControl(const QString& positionControl) {
 } // anonymous namespace
 
 WaveformMark::WaveformMark(const QString& group,
+        QString positionControl,
+        const QString& visibilityControl,
+        const QString& textColor,
+        const QString& markAlign,
+        const QString& text,
+        const QString& pixmapPath,
+        const QString& iconPath,
+        QColor color,
+        int priority,
+        int hotCue,
+        const WaveformSignalColors& signalColors)
+        : m_textColor(textColor),
+          m_pixmapPath(pixmapPath),
+          m_iconPath(iconPath),
+          m_linePosition{},
+          m_breadth{},
+          m_level{},
+          m_iPriority(priority),
+          m_iHotCue(hotCue),
+          m_showUntilNext{} {
+    QString endPositionControl;
+    QString typeControl;
+    if (hotCue != Cue::kNoHotCue) {
+        QString hotcueNumber = QString::number(hotCue + 1);
+        positionControl = QStringLiteral("hotcue_%1_position").arg(hotcueNumber);
+        endPositionControl = QStringLiteral("hotcue_%1_endposition").arg(hotcueNumber);
+        typeControl = QStringLiteral("hotcue_%1_type").arg(hotcueNumber);
+        m_showUntilNext = true;
+    } else {
+        m_showUntilNext = isShowUntilNextPositionControl(positionControl);
+    }
+
+    if (!positionControl.isEmpty()) {
+        m_pPositionCO = std::make_unique<ControlProxy>(group, positionControl);
+    }
+    if (!endPositionControl.isEmpty()) {
+        m_pEndPositionCO = std::make_unique<ControlProxy>(group, endPositionControl);
+        m_pTypeCO = std::make_unique<ControlProxy>(group, typeControl);
+    }
+
+    if (!visibilityControl.isEmpty()) {
+        ConfigKey key = ConfigKey::parseCommaSeparated(visibilityControl);
+        m_pVisibleCO = std::make_unique<ControlProxy>(key);
+    }
+
+    if (!color.isValid()) {
+        // As a fallback, grab the color from the parent's AxesColor
+        // color = signalColors.getAxesColor();
+        qDebug() << "Didn't get mark <Color>:" << color;
+    } else {
+        color = WSkinColor::getCorrectColor(color);
+    }
+    int dimBrightThreshold = signalColors.getDimBrightThreshold();
+    setBaseColor(color, dimBrightThreshold);
+
+    if (!m_textColor.isValid()) {
+        // Read the text color, otherwise use the parent's BgColor.
+        m_textColor = signalColors.getBgColor();
+        qDebug() << "Didn't get mark <TextColor>, using parent's <BgColor>:" << m_textColor;
+    }
+
+    m_align = decodeAlignmentFlags(markAlign, Qt::AlignBottom | Qt::AlignHCenter);
+
+    // Hotcue text is set by the cue's label in the database, not by the skin.
+    if (hotCue == Cue::kNoHotCue) {
+        m_text = text;
+    }
+}
+
+WaveformMark::WaveformMark(const QString& group,
         const QDomNode& node,
         const SkinContext& context,
         int priority,

--- a/src/waveform/renderers/waveformmark.h
+++ b/src/waveform/renderers/waveformmark.h
@@ -13,7 +13,7 @@ class QOpenGLTexture;
 
 namespace allshader {
 class WaveformRenderMark;
-}
+} // namespace allshader
 
 class WaveformMark {
   public:
@@ -31,6 +31,20 @@ class WaveformMark {
             int priority,
             const WaveformSignalColors& signalColors,
             int hotCue = Cue::kNoHotCue);
+
+    WaveformMark(
+            const QString& group,
+            QString positionControl,
+            const QString& visibilityControl,
+            const QString& textColor,
+            const QString& markAlign,
+            const QString& text,
+            const QString& pixmapPath,
+            const QString& iconPath,
+            QColor color,
+            int priority,
+            int hotCue = Cue::kNoHotCue,
+            const WaveformSignalColors& signalColors = {});
     ~WaveformMark();
 
     // Disable copying

--- a/src/waveform/renderers/waveformmarkrange.h
+++ b/src/waveform/renderers/waveformmarkrange.h
@@ -24,6 +24,18 @@ class WaveformMarkRange {
             const QDomNode& node,
             const SkinContext& context,
             const WaveformSignalColors& signalColors);
+    WaveformMarkRange(
+            const QString& group,
+            const QColor& activeColor,
+            const QColor& disabledColor,
+            double enabledOpacity,
+            double disabledOpacity,
+            const QColor& durationTextColor,
+            const QString& startControl,
+            const QString& endControl,
+            const QString& enabledControl,
+            const QString& visibilityControl,
+            const QString& durationTextLocation);
     // This class is only moveable, but not copiable!
     WaveformMarkRange(WaveformMarkRange&&) = default;
     WaveformMarkRange(const WaveformMarkRange&) = delete;

--- a/src/waveform/renderers/waveformmarkset.h
+++ b/src/waveform/renderers/waveformmarkset.h
@@ -11,6 +11,17 @@
 // rendered.
 class WaveformMarkSet {
   public:
+    struct DefaultMarkerStyle {
+        QString positionControl;
+        QString visibilityControl;
+        QString textColor;
+        QString markAlign;
+        QString text;
+        QString pixmapPath;
+        QString iconPath;
+        QColor color;
+    };
+
     WaveformMarkSet();
     virtual ~WaveformMarkSet();
 
@@ -67,11 +78,20 @@ class WaveformMarkSet {
 
     void setBreadth(float breadth);
 
-  private:
     void clear() {
         m_marks.clear();
         m_marksToRender.clear();
     }
+
+    void addMark(WaveformMarkPointer pMark) {
+        m_marks.push_back(pMark);
+    }
+
+    void setDefault(const QString& group,
+            const DefaultMarkerStyle& model,
+            const WaveformSignalColors& signalColors = {});
+
+  private:
     WaveformMarkPointer m_pDefaultMark;
     QList<WaveformMarkPointer> m_marks;
     // List of visible WaveformMarks sorted by the order they appear in the track

--- a/src/waveform/renderers/waveformrendererabstract.h
+++ b/src/waveform/renderers/waveformrendererabstract.h
@@ -6,6 +6,10 @@ QT_FORWARD_DECLARE_CLASS(QDomNode)
 QT_FORWARD_DECLARE_CLASS(QPaintEvent)
 QT_FORWARD_DECLARE_CLASS(QPainter)
 
+namespace rendergraph {
+class Node;
+}
+
 class SkinContext;
 class WaveformWidgetRenderer;
 
@@ -28,6 +32,8 @@ class WaveformRendererAbstract {
 
     virtual void onResize() {}
     virtual void onSetTrack() {}
+    virtual void update() {
+    }
 
   protected:
     bool isDirty() const {

--- a/src/waveform/renderers/waveformrendererfilteredsignal.cpp
+++ b/src/waveform/renderers/waveformrendererfilteredsignal.cpp
@@ -96,7 +96,7 @@ void WaveformRendererFilteredSignal::draw(QPainter* painter,
 
     //draw reference line
     if (m_alignment == Qt::AlignCenter) {
-        painter->setPen(m_pColors->getAxesColor());
+        painter->setPen(m_waveformRenderer->getWaveformSignalColors()->getAxesColor());
         painter->drawLine(QLineF(0, halfBreadth, length, halfBreadth));
     }
 
@@ -237,16 +237,26 @@ void WaveformRendererFilteredSignal::draw(QPainter* painter,
     }
 
     double lineThickness = math_max(1.0, 1.0 / m_waveformRenderer->getVisualSamplePerPixel());
+    const auto* pColors = m_waveformRenderer->getWaveformSignalColors();
 
-    painter->setPen(QPen(QBrush(m_pColors->getLowColor()), lineThickness, Qt::SolidLine, Qt::FlatCap));
+    painter->setPen(QPen(QBrush(pColors->getLowColor()),
+            lineThickness,
+            Qt::SolidLine,
+            Qt::FlatCap));
     if (m_pLowKillControlObject && m_pLowKillControlObject->get() == 0.0) {
        painter->drawLines(&m_lowLines[0], actualLowLineNumber);
     }
-    painter->setPen(QPen(QBrush(m_pColors->getMidColor()), lineThickness, Qt::SolidLine, Qt::FlatCap));
+    painter->setPen(QPen(QBrush(pColors->getMidColor()),
+            lineThickness,
+            Qt::SolidLine,
+            Qt::FlatCap));
     if (m_pMidKillControlObject && m_pMidKillControlObject->get() == 0.0) {
         painter->drawLines(&m_midLines[0], actualMidLineNumber);
     }
-    painter->setPen(QPen(QBrush(m_pColors->getHighColor()), lineThickness, Qt::SolidLine, Qt::FlatCap));
+    painter->setPen(QPen(QBrush(pColors->getHighColor()),
+            lineThickness,
+            Qt::SolidLine,
+            Qt::FlatCap));
     if (m_pHighKillControlObject && m_pHighKillControlObject->get() == 0.0) {
         painter->drawLines(&m_highLines[0], actualHighLineNumber);
     }

--- a/src/waveform/renderers/waveformrendererhsv.cpp
+++ b/src/waveform/renderers/waveformrendererhsv.cpp
@@ -76,13 +76,14 @@ void WaveformRendererHSV::draw(
 
     // Represents the # of waveform data points per horizontal pixel.
     const double gain = (lastVisualIndex - firstVisualIndex) / length;
+    const auto* pColors = m_waveformRenderer->getWaveformSignalColors();
 
     float allGain(1.0);
     getGains(&allGain, false, nullptr, nullptr, nullptr);
 
     // Get base color of waveform in the HSV format (s and v isn't use)
     float h, s, v;
-    getHsvF(m_pColors->getLowColor(), &h, &s, &v);
+    getHsvF(pColors->getLowColor(), &h, &s, &v);
 
     QColor color;
     float lo, hi, total;
@@ -97,7 +98,7 @@ void WaveformRendererHSV::draw(
     const float heightFactor = allGain * halfBreadth / 255.0f;
 
     //draw reference line
-    painter->setPen(m_pColors->getAxesColor());
+    painter->setPen(pColors->getAxesColor());
     painter->drawLine(QLineF(0, halfBreadth, length, halfBreadth));
 
     for (int x = 0; x < static_cast<int>(length); ++x) {

--- a/src/waveform/renderers/waveformrendererrgb.cpp
+++ b/src/waveform/renderers/waveformrendererrgb.cpp
@@ -91,7 +91,7 @@ void WaveformRendererRGB::draw(
     const float heightFactor = allGain * halfBreadth / sqrtf(255 * 255 * 3);
 
     // Draw reference line
-    painter->setPen(m_pColors->getAxesColor());
+    painter->setPen(m_waveformRenderer->getWaveformSignalColors()->getAxesColor());
     painter->drawLine(QLineF(0, halfBreadth, m_waveformRenderer->getLength(), halfBreadth));
 
     for (int x = 0; x < static_cast<int>(length); ++x) {

--- a/src/waveform/renderers/waveformrenderersignalbase.h
+++ b/src/waveform/renderers/waveformrenderersignalbase.h
@@ -2,21 +2,41 @@
 
 #include "skin/legacy/skincontext.h"
 #include "util/span.h"
+#include "util/types.h"
+#include "waveform/waveform.h"
 #include "waveformrendererabstract.h"
 
 class ControlProxy;
 class WaveformSignalColors;
 
-class WaveformRendererSignalBase : public WaveformRendererAbstract {
-public:
-    explicit WaveformRendererSignalBase(WaveformWidgetRenderer* waveformWidgetRenderer);
+class WaveformRendererSignalBase : public QObject, public WaveformRendererAbstract {
+    Q_OBJECT
+  public:
+    explicit WaveformRendererSignalBase(
+            WaveformWidgetRenderer* waveformWidgetRenderer);
     virtual ~WaveformRendererSignalBase();
 
     virtual bool init();
     virtual void setup(const QDomNode& node, const SkinContext& context);
 
-    virtual bool onInit() {return true;}
-    virtual void onSetup(const QDomNode &node) = 0;
+    virtual bool onInit() {
+        return true;
+    }
+    virtual void onSetup(const QDomNode& node) = 0;
+
+  public slots:
+    void setAllChannelVisualGain(double gain) {
+        m_allChannelVisualGain = static_cast<CSAMPLE_GAIN>(gain);
+    }
+    void setLowVisualGain(double gain) {
+        m_lowVisualGain = static_cast<CSAMPLE_GAIN>(gain);
+    }
+    void setMidVisualGain(double gain) {
+        m_midVisualGain = static_cast<CSAMPLE_GAIN>(gain);
+    }
+    void setHighVisualGain(double gain) {
+        m_highVisualGain = static_cast<CSAMPLE_GAIN>(gain);
+    }
 
   protected:
     void deleteControls();
@@ -39,7 +59,11 @@ public:
     Qt::Alignment m_alignment;
     Qt::Orientation m_orientation;
 
-    const WaveformSignalColors* m_pColors;
+    CSAMPLE_GAIN m_allChannelVisualGain;
+    CSAMPLE_GAIN m_lowVisualGain;
+    CSAMPLE_GAIN m_midVisualGain;
+    CSAMPLE_GAIN m_highVisualGain;
+
     float m_axesColor_r, m_axesColor_g, m_axesColor_b, m_axesColor_a;
     float m_signalColor_r, m_signalColor_g, m_signalColor_b;
     float m_lowColor_r, m_lowColor_g, m_lowColor_b;

--- a/src/waveform/renderers/waveformrendermarkbase.h
+++ b/src/waveform/renderers/waveformrendermarkbase.h
@@ -24,6 +24,18 @@ class WaveformRenderMarkBase : public QObject, public WaveformRendererAbstract {
 
     void onResize() override;
 
+    void clearMarks() {
+        m_marks.clear();
+    }
+
+    void setDefaultMark(const QString& group, const WaveformMarkSet::DefaultMarkerStyle& model) {
+        m_marks.setDefault(group, model);
+    }
+
+    void addMark(WaveformMarkPointer pMark) {
+        m_marks.addMark(pMark);
+    }
+
   public slots:
     // Called when the loaded track's cues are added, deleted or modified and
     // when a new track is loaded.

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -5,9 +5,12 @@
 
 #include "control/controlproxy.h"
 #include "track/track.h"
+#include "util/assert.h"
 #include "util/math.h"
+#include "waveform/isynctimeprovider.h"
 #include "waveform/renderers/waveformrendererabstract.h"
 #include "waveform/visualplayposition.h"
+#include "waveform/vsyncthread.h"
 #include "waveform/waveform.h"
 
 const double WaveformWidgetRenderer::s_waveformMinZoom = 1.0;
@@ -83,7 +86,26 @@ WaveformWidgetRenderer::~WaveformWidgetRenderer() {
 }
 
 bool WaveformWidgetRenderer::init() {
-    //qDebug() << "WaveformWidgetRenderer::init, m_group=" << m_group;
+    m_trackPixelCount = 0.0;
+    m_visualSamplePerPixel = 1.0;
+    m_audioSamplePerPixel = 1.0;
+    m_totalVSamples = 0;
+    m_gain = 1.0;
+    m_trackSamples = 0.0;
+
+    for (int type = ::WaveformRendererAbstract::Play;
+            type <= ::WaveformRendererAbstract::Slip;
+            type++) {
+        m_firstDisplayedPosition[type] = 0.0;
+        m_lastDisplayedPosition[type] = 0.0;
+        m_posVSample[type] = 0.0;
+        m_pos[type] = -1.0; // disable renderers
+        m_truePosSample[type] = -1.0;
+    }
+
+    VERIFY_OR_DEBUG_ASSERT(!m_group.isEmpty()) {
+        return false;
+    }
 
     m_visualPlayPosition = VisualPlayPosition::getVisualPlayPosition(m_group);
 
@@ -102,7 +124,7 @@ bool WaveformWidgetRenderer::init() {
     return true;
 }
 
-void WaveformWidgetRenderer::onPreRender(VSyncThread* vsyncThread) {
+void WaveformWidgetRenderer::onPreRender(VSyncTimeProvider* vsyncThread) {
     if (m_passthroughEnabled) {
         // disables renderers in draw()
         for (int type = ::WaveformRendererAbstract::Play;

--- a/src/waveform/renderers/waveformwidgetrenderer.h
+++ b/src/waveform/renderers/waveformwidgetrenderer.h
@@ -11,7 +11,7 @@
 
 class ControlProxy;
 class VisualPlayPosition;
-class VSyncThread;
+class VSyncTimeProvider;
 class QPainter;
 class WaveformRendererAbstract;
 
@@ -32,18 +32,23 @@ class WaveformWidgetRenderer {
     };
 
   public:
-    explicit WaveformWidgetRenderer(const QString& group);
+    explicit WaveformWidgetRenderer(const QString& group = {});
     virtual ~WaveformWidgetRenderer();
 
     bool init();
     virtual bool onInit() {return true;}
 
     void setup(const QDomNode& node, const SkinContext& context);
-    void onPreRender(VSyncThread* vsyncThread);
+    void onPreRender(VSyncTimeProvider* vsyncThread);
     void draw(QPainter* painter, QPaintEvent* event);
 
     const QString& getGroup() const {
         return m_group;
+    }
+
+    virtual void setGroup(const QString& group) {
+        m_group = group;
+        init();
     }
 
     const TrackPointer& getTrackInfo() const {
@@ -119,7 +124,7 @@ class WaveformWidgetRenderer {
     int getTotalVSample() const {
         return m_totalVSamples;
     }
-    double getZoomFactor() const {
+    double getZoom() const {
         return m_zoomFactor;
     }
     double getGain(bool applyCompensation) const {
@@ -183,6 +188,11 @@ class WaveformWidgetRenderer {
 #ifdef __STEM__
     void selectStem(mixxx::StemChannelSelection stemMask);
 #endif
+
+    void addRenderer(WaveformRendererAbstract* renderer) {
+        m_rendererStack.push_back(renderer);
+    }
+
     void setTrack(TrackPointer track);
     void setMarkPositions(const QList<WaveformMarkOnScreen>& markPositions) {
         m_markPositions = markPositions;
@@ -214,7 +224,7 @@ class WaveformWidgetRenderer {
     }
 
   protected:
-    const QString m_group;
+    QString m_group;
     TrackPointer m_pTrack;
 #ifdef __STEM__
     uint m_selectedStems;

--- a/src/waveform/visualplayposition.cpp
+++ b/src/waveform/visualplayposition.cpp
@@ -57,10 +57,10 @@ void VisualPlayPosition::set(
 }
 
 double VisualPlayPosition::calcOffsetAtNextVSync(
-        ISyncTimeProvider* pSyncTimeProvider, const VisualPlayPositionData& data) {
+        VSyncTimeProvider* pSyncTimeProvider, const VisualPlayPositionData& data) {
     if (data.m_audioBufferMicroS != 0.0) {
-        int refToVSync = pSyncTimeProvider->fromTimerToNextSyncMicros(data.m_referenceTime);
-        int syncIntervalTimeMicros = pSyncTimeProvider->getSyncIntervalTimeMicros();
+        int refToVSync = pSyncTimeProvider->fromTimerToNextSync(data.m_referenceTime).count();
+        int syncIntervalTimeMicros = pSyncTimeProvider->getSyncInterval().count();
         // The positive offset is limited to the audio buffer + 2 x waveform sync interval
         // This should be sufficient to compensate jitter, but does not continue
         // in case of underflows.
@@ -151,7 +151,7 @@ double VisualPlayPosition::determinePlayPosInLoopBoundries(
     return interpolatedPlayPos;
 }
 
-double VisualPlayPosition::getAtNextVSync(ISyncTimeProvider* pSyncTimeProvider) {
+double VisualPlayPosition::getAtNextVSync(VSyncTimeProvider* pSyncTimeProvider) {
     if (m_valid.load()) {
         const VisualPlayPositionData data = m_data.getValue();
         const double offset = calcOffsetAtNextVSync(pSyncTimeProvider, data);
@@ -162,7 +162,7 @@ double VisualPlayPosition::getAtNextVSync(ISyncTimeProvider* pSyncTimeProvider) 
 }
 
 void VisualPlayPosition::getPlaySlipAtNextVSync(
-        ISyncTimeProvider* pSyncTimeProvider,
+        VSyncTimeProvider* pSyncTimeProvider,
         double* pPlayPosition,
         double* pSlipPosition) {
     if (m_valid.load()) {

--- a/src/waveform/visualplayposition.cpp
+++ b/src/waveform/visualplayposition.cpp
@@ -3,7 +3,7 @@
 #include "moc_visualplayposition.cpp"
 #include "util/cmdlineargs.h"
 #include "util/math.h"
-#include "waveform/vsyncthread.h"
+#include "waveform/isynctimeprovider.h"
 
 //static
 QMap<QString, QWeakPointer<VisualPlayPosition>> VisualPlayPosition::m_listVisualPlayPosition;
@@ -57,20 +57,10 @@ void VisualPlayPosition::set(
 }
 
 double VisualPlayPosition::calcOffsetAtNextVSync(
-        VSyncThread* pVSyncThread, const VisualPlayPositionData& data) {
+        ISyncTimeProvider* pSyncTimeProvider, const VisualPlayPositionData& data) {
     if (data.m_audioBufferMicroS != 0.0) {
-        int refToVSync;
-        int syncIntervalTimeMicros;
-#ifdef MIXXX_USE_QML
-        if (CmdlineArgs::Instance().isQml()) {
-            refToVSync = 0;
-            syncIntervalTimeMicros = 0;
-        } else
-#endif
-        {
-            refToVSync = pVSyncThread->fromTimerToNextSyncMicros(data.m_referenceTime);
-            syncIntervalTimeMicros = pVSyncThread->getSyncIntervalTimeMicros();
-        }
+        int refToVSync = pSyncTimeProvider->fromTimerToNextSyncMicros(data.m_referenceTime);
+        int syncIntervalTimeMicros = pSyncTimeProvider->getSyncIntervalTimeMicros();
         // The positive offset is limited to the audio buffer + 2 x waveform sync interval
         // This should be sufficient to compensate jitter, but does not continue
         // in case of underflows.
@@ -161,22 +151,23 @@ double VisualPlayPosition::determinePlayPosInLoopBoundries(
     return interpolatedPlayPos;
 }
 
-double VisualPlayPosition::getAtNextVSync(VSyncThread* pVSyncThread) {
+double VisualPlayPosition::getAtNextVSync(ISyncTimeProvider* pSyncTimeProvider) {
     if (m_valid.load()) {
         const VisualPlayPositionData data = m_data.getValue();
-        const double offset = calcOffsetAtNextVSync(pVSyncThread, data);
+        const double offset = calcOffsetAtNextVSync(pSyncTimeProvider, data);
 
         return determinePlayPosInLoopBoundries(data, offset);
     }
     return -1;
 }
 
-void VisualPlayPosition::getPlaySlipAtNextVSync(VSyncThread* pVSyncThread,
+void VisualPlayPosition::getPlaySlipAtNextVSync(
+        ISyncTimeProvider* pSyncTimeProvider,
         double* pPlayPosition,
         double* pSlipPosition) {
     if (m_valid.load()) {
         const VisualPlayPositionData data = m_data.getValue();
-        const double offset = calcOffsetAtNextVSync(pVSyncThread, data);
+        const double offset = calcOffsetAtNextVSync(pSyncTimeProvider, data);
 
         double interpolatedPlayPos = determinePlayPosInLoopBoundries(data, offset);
         *pPlayPosition = interpolatedPlayPos;

--- a/src/waveform/visualplayposition.h
+++ b/src/waveform/visualplayposition.h
@@ -10,7 +10,7 @@
 #include "util/performancetimer.h"
 
 class ControlProxy;
-class ISyncTimeProvider;
+class VSyncTimeProvider;
 
 // This class is for synchronizing the sound device DAC time with the waveforms, displayed on the
 // graphic device, using the CPU time
@@ -68,8 +68,8 @@ class VisualPlayPosition : public QObject {
             double tempoTrackSeconds,
             double audioBufferMicroS);
 
-    double getAtNextVSync(ISyncTimeProvider* pSyncTimeProvider);
-    void getPlaySlipAtNextVSync(ISyncTimeProvider* pSyncTimeProvider,
+    double getAtNextVSync(VSyncTimeProvider* pSyncTimeProvider);
+    void getPlaySlipAtNextVSync(VSyncTimeProvider* pSyncTimeProvider,
             double* playPosition,
             double* slipPosition);
     double determinePlayPosInLoopBoundries(
@@ -92,7 +92,7 @@ class VisualPlayPosition : public QObject {
     }
 
   private:
-    double calcOffsetAtNextVSync(ISyncTimeProvider* pSyncTimeProvider,
+    double calcOffsetAtNextVSync(VSyncTimeProvider* pSyncTimeProvider,
             const VisualPlayPositionData& data);
     ControlValueAtomic<VisualPlayPositionData> m_data;
     std::atomic<bool> m_valid;

--- a/src/waveform/visualplayposition.h
+++ b/src/waveform/visualplayposition.h
@@ -10,7 +10,7 @@
 #include "util/performancetimer.h"
 
 class ControlProxy;
-class VSyncThread;
+class ISyncTimeProvider;
 
 // This class is for synchronizing the sound device DAC time with the waveforms, displayed on the
 // graphic device, using the CPU time
@@ -68,8 +68,8 @@ class VisualPlayPosition : public QObject {
             double tempoTrackSeconds,
             double audioBufferMicroS);
 
-    double getAtNextVSync(VSyncThread* pVSyncThread);
-    void getPlaySlipAtNextVSync(VSyncThread* pVSyncThread,
+    double getAtNextVSync(ISyncTimeProvider* pSyncTimeProvider);
+    void getPlaySlipAtNextVSync(ISyncTimeProvider* pSyncTimeProvider,
             double* playPosition,
             double* slipPosition);
     double determinePlayPosInLoopBoundries(
@@ -92,7 +92,8 @@ class VisualPlayPosition : public QObject {
     }
 
   private:
-    double calcOffsetAtNextVSync(VSyncThread* pVSyncThread, const VisualPlayPositionData& data);
+    double calcOffsetAtNextVSync(ISyncTimeProvider* pSyncTimeProvider,
+            const VisualPlayPositionData& data);
     ControlValueAtomic<VisualPlayPositionData> m_data;
     std::atomic<bool> m_valid;
     QString m_key;

--- a/src/waveform/vsyncthread.cpp
+++ b/src/waveform/vsyncthread.cpp
@@ -230,7 +230,7 @@ void VSyncThread::setSyncIntervalTimeMicros(int syncTime) {
     }
 }
 
-int VSyncThread::fromTimerToNextSyncMicros(const PerformanceTimer& timer) {
+std::chrono::microseconds VSyncThread::fromTimerToNextSync(const PerformanceTimer& timer) {
     int difference = static_cast<int>(m_timer.difference(timer).toIntegerMicros());
     // int math is fine here, because we do not expect times > 4.2 s
     int toNextSync = difference + m_waitToSwapMicros;
@@ -239,7 +239,7 @@ int VSyncThread::fromTimerToNextSyncMicros(const PerformanceTimer& timer) {
         // an attempt to render an outdated frame. Render the next frame instead
         toNextSync += m_syncIntervalTimeMicros;
     }
-    return toNextSync;
+    return std::chrono::microseconds(toNextSync);
 }
 
 int VSyncThread::droppedFrames() {

--- a/src/waveform/vsyncthread.h
+++ b/src/waveform/vsyncthread.h
@@ -10,7 +10,7 @@
 
 class WGLWidget;
 
-class VSyncThread : public QThread, public ISyncTimeProvider {
+class VSyncThread : public QThread, public VSyncTimeProvider {
     Q_OBJECT
   public:
     enum VSyncMode {
@@ -34,16 +34,16 @@ class VSyncThread : public QThread, public ISyncTimeProvider {
     void setSyncIntervalTimeMicros(int usSyncTimer);
     int droppedFrames();
     void setSwapWait(int sw);
-    // ISyncTimerProvider
-    int fromTimerToNextSyncMicros(const PerformanceTimer& timer) override;
+    // VSyncTimerProvider
+    std::chrono::microseconds fromTimerToNextSync(const PerformanceTimer& timer) override;
     void vsyncSlotFinished();
     void getAvailableVSyncTypes(QList<QPair<int, QString>>* list);
     void setupSync(WGLWidget* glw, int index);
     void waitUntilSwap(WGLWidget* glw);
     mixxx::Duration sinceLastSwap() const;
-    // ISyncTimerProvider
-    int getSyncIntervalTimeMicros() const override {
-        return m_syncIntervalTimeMicros;
+    // VSyncTimerProvider
+    std::chrono::microseconds getSyncInterval() const override {
+        return std::chrono::microseconds(m_syncIntervalTimeMicros);
     }
     void updatePLL();
     bool pllInitializing() const;

--- a/src/waveform/vsyncthread.h
+++ b/src/waveform/vsyncthread.h
@@ -6,10 +6,11 @@
 #include <mutex>
 
 #include "util/performancetimer.h"
+#include "waveform/isynctimeprovider.h"
 
 class WGLWidget;
 
-class VSyncThread : public QThread {
+class VSyncThread : public QThread, public ISyncTimeProvider {
     Q_OBJECT
   public:
     enum VSyncMode {
@@ -26,20 +27,22 @@ class VSyncThread : public QThread {
     VSyncThread(QObject* pParent, VSyncMode vSyncMode);
     ~VSyncThread();
 
-    void run();
+    void run() override;
 
     bool waitForVideoSync(WGLWidget* glw);
     int elapsed();
     void setSyncIntervalTimeMicros(int usSyncTimer);
     int droppedFrames();
     void setSwapWait(int sw);
-    int fromTimerToNextSyncMicros(const PerformanceTimer& timer);
+    // ISyncTimerProvider
+    int fromTimerToNextSyncMicros(const PerformanceTimer& timer) override;
     void vsyncSlotFinished();
     void getAvailableVSyncTypes(QList<QPair<int, QString>>* list);
     void setupSync(WGLWidget* glw, int index);
     void waitUntilSwap(WGLWidget* glw);
     mixxx::Duration sinceLastSwap() const;
-    int getSyncIntervalTimeMicros() const {
+    // ISyncTimerProvider
+    int getSyncIntervalTimeMicros() const override {
         return m_syncIntervalTimeMicros;
     }
     void updatePLL();

--- a/src/waveform/waveform.h
+++ b/src/waveform/waveform.h
@@ -12,7 +12,11 @@
 #include "util/class.h"
 #include "util/compatibility/qmutex.h"
 
-enum FilterIndex { Low = 0, Mid = 1, High = 2, FilterCount = 3};
+enum BandIndex { AllBand = 0,
+    Low = 1,
+    Mid = 2,
+    High = 3,
+    BandCount = 4 };
 enum ChannelIndex { Left = 0, Right = 1, ChannelCount = 2};
 
 struct WaveformFilteredData {

--- a/src/waveform/waveformwidgetfactory.h
+++ b/src/waveform/waveformwidgetfactory.h
@@ -104,12 +104,10 @@ class WaveformWidgetHolder {
 
 //########################################
 
-class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFactory> {
+class WaveformWidgetFactory : public QObject,
+                              public Singleton<WaveformWidgetFactory> {
     Q_OBJECT
   public:
-    //TODO merge this enum with the waveform analyzer one
-    enum FilterIndex { All = 0, Low = 1, Mid = 2, High = 3, FilterCount = 4};
-
     bool setConfig(UserSettingsPointer config);
 
     /// Creates the waveform widget using the type set with setWidgetType
@@ -196,8 +194,8 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
     void setDisplayBeatGridAlpha(int alpha);
     int getBeatGridAlpha() const { return m_beatGridAlpha; }
 
-    void setVisualGain(FilterIndex index, double gain);
-    double getVisualGain(FilterIndex index) const;
+    void setVisualGain(BandIndex index, double gain);
+    double getVisualGain(BandIndex index) const;
 
     void setOverviewNormalized(bool normalize);
     int isOverviewNormalized() const { return m_overviewNormalized;}
@@ -211,7 +209,7 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
     void addVuMeter(WVuMeterLegacy* pWidget);
     void addVuMeter(WVuMeterBase* pWidget);
 
-    void startVSync(GuiTick* pGuiTick, VisualsManager* pVisualsManager);
+    void startVSync(GuiTick* pGuiTick, VisualsManager* pVisualsManager, bool useQML);
 
     void setPlayMarkerPosition(double position);
     double getPlayMarkerPosition() const { return m_playMarkerPosition; }
@@ -226,7 +224,13 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
     void swapVuMeters();
 
     void overviewNormalizeChanged();
-    void overallVisualGainChanged();
+    void visualGainChanged(double allChannelGain, double lowGain, double midGain, double highGain);
+
+    void untilMarkShowBeatsChanged(bool value);
+    void untilMarkShowTimeChanged(bool value);
+    void untilMarkAlignChanged(Qt::Alignment align);
+    void untilMarkTextPointSizeChanged(int value);
+    void untilMarkTextHeightLimitChanged(float value);
 
   public slots:
     void slotSkinLoaded();
@@ -279,7 +283,7 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
     int m_endOfTrackWarningTime;
     double m_defaultZoom;
     bool m_zoomSync;
-    double m_visualGain[FilterCount];
+    double m_visualGain[BandCount];
     bool m_overviewNormalized;
 
     bool m_untilMarkShowBeats;

--- a/src/waveform/widgets/allshader/waveformwidget.cpp
+++ b/src/waveform/widgets/allshader/waveformwidget.cpp
@@ -17,6 +17,7 @@
 #include "waveform/renderers/allshader/waveformrenderertextured.h"
 #include "waveform/renderers/allshader/waveformrendermark.h"
 #include "waveform/renderers/allshader/waveformrendermarkrange.h"
+#include "waveform/waveformwidgetfactory.h"
 #include "waveform/widgets/allshader/moc_waveformwidget.cpp"
 
 namespace allshader {
@@ -32,7 +33,10 @@ WaveformWidget::WaveformWidget(QWidget* parent,
     auto pOpacityNode = std::make_unique<rendergraph::OpacityNode>();
 
     pTopNode->appendChildNode(addRendererNode<WaveformRenderBackground>());
-    pOpacityNode->appendChildNode(addRendererNode<WaveformRendererEndOfTrack>());
+    auto pEndOfTrackRenderer = addRendererNode<WaveformRendererEndOfTrack>();
+    pEndOfTrackRenderer->setEndOfTrackWarningTime(
+            WaveformWidgetFactory::instance()->getEndOfTrackWarningTime());
+    pOpacityNode->appendChildNode(std::move(pEndOfTrackRenderer));
     pOpacityNode->appendChildNode(addRendererNode<WaveformRendererPreroll>());
     m_pWaveformRenderMarkRange = pOpacityNode->appendChildNode(
             addRendererNode<WaveformRenderMarkRange>());

--- a/src/waveform/widgets/waveformwidgetabstract.cpp
+++ b/src/waveform/widgets/waveformwidgetabstract.cpp
@@ -3,6 +3,7 @@
 #include <QWidget>
 
 #include "waveform/renderers/waveformwidgetrenderer.h"
+#include "waveform/vsyncthread.h"
 
 WaveformWidgetAbstract::WaveformWidgetAbstract(const QString& group)
         : WaveformWidgetRenderer(group),

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -108,7 +108,7 @@ WOverview::WOverview(
             this,
             &WOverview::slotNormalizeOrVisualGainChanged);
     connect(pWidgetFactory,
-            &WaveformWidgetFactory::overallVisualGainChanged,
+            &WaveformWidgetFactory::visualGainChanged,
             this,
             &WOverview::slotNormalizeOrVisualGainChanged);
     // Also listen to ReplayGain changes to scale the waveform
@@ -742,7 +742,7 @@ void WOverview::drawWaveformPixmap(QPainter* pPainter) {
             DEBUG_ASSERT(m_pCurrentTrack);
             const auto replayGain = m_pCurrentTrack->getReplayGain();
             const auto visualGain = static_cast<float>(
-                    pWidgetFactory->getVisualGain(WaveformWidgetFactory::All) *
+                    pWidgetFactory->getVisualGain(BandIndex::AllBand) *
                     (replayGain.hasRatio()
                                     ? replayGain.getRatio()
                                     : 1.0));

--- a/src/widget/wspinnybase.cpp
+++ b/src/widget/wspinnybase.cpp
@@ -15,6 +15,7 @@
 #include "util/fpclassify.h"
 #include "vinylcontrol/vinylcontrolmanager.h"
 #include "waveform/visualplayposition.h"
+#include "waveform/vsyncthread.h"
 #include "wimagestore.h"
 
 // The SampleBuffers format enables antialiasing.

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -195,9 +195,9 @@ void WWaveformViewer::mouseReleaseEvent(QMouseEvent* /*event*/) {
 void WWaveformViewer::wheelEvent(QWheelEvent* event) {
     if (m_waveformWidget) {
         if (event->angleDelta().y() > 0) {
-            onZoomChange(m_waveformWidget->getZoomFactor() / 1.05);
+            onZoomChange(m_waveformWidget->getZoom() / 1.05);
         } else if (event->angleDelta().y() < 0) {
-            onZoomChange(m_waveformWidget->getZoomFactor() * 1.05);
+            onZoomChange(m_waveformWidget->getZoom() * 1.05);
         }
     }
 }


### PR DESCRIPTION
This PR is a rebase of @m0dB's `qml_scrolling_waveform` on the latest main

The waveform rendering approach should provided better result in the long run and should integrate with the new `allshader` approach.

Currently, the waveform rendering logic which happen in `QmlWaveformDisplay::updatePaintNode` is duplicated (or rather strongly inspired) from the RGB allshader rendering. A "definition of ready" for this PR would be to have some kind of compatibility layer/integration to reuse the rendering logic define in `allshader` and should support at least one waveform type logic (e.g `RGB`)

Depends on:
- [x] #14185 
- [x] #14186 
- [x] #14187 
- [x] #14188 
- [x] #14189 
- [x] #14190 
- [x] #14191 
- [x] #14192 

TODO:
 - [x] Crash on shutdown
 - [x] Waveform zoom init
 - [X] Something is wrong with the clipping
 - [x] Something is wrong with the stem waveform
