### PR TITLE
Let some time consuming table delegates render into cached pixmaps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -992,6 +992,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/library/tabledelegates/stardelegate.cpp
   src/library/tabledelegates/stareditor.cpp
   src/library/tabledelegates/tableitemdelegate.cpp
+  src/library/tabledelegates/textdelegate.cpp
   src/library/trackcollection.cpp
   src/library/trackcollectioniterator.cpp
   src/library/trackcollectionmanager.cpp

--- a/enc_temp_folder/de392b1397291642c9d63d3e77eda0af/textdelegate.cpp
+++ b/enc_temp_folder/de392b1397291642c9d63d3e77eda0af/textdelegate.cpp
@@ -1,0 +1,47 @@
+#include "textdelegate.h"
+
+#include <QPainter>
+#include <QPixmapCache>
+#include <QStyleOptionViewItem>
+
+#include "moc_textdelegate.cpp"
+
+TextDelegate::TextDelegate(QObject* parent)
+        : QStyledItemDelegate(parent) {
+}
+
+void TextDelegate::paint(QPainter* painter,
+        const QStyleOptionViewItem& option,
+        const QModelIndex& index) const {
+    QString text = index.data(Qt::DisplayRole).toString(); // Text string
+
+    // Generate a unique cache key that now includes isChecked and playCount
+    QString cacheKey = QString("TextDelegate_%1_%2_%3")
+                               .arg(option.rect.width())
+                               .arg(option.rect.height())
+                               .arg(text);
+
+    QPixmap pixmap;
+    if (!QPixmapCache::find(cacheKey, &pixmap)) {
+        QStyleOptionViewItem opt = option;
+
+        // Pixmap not found in cache, create new pixmap
+        pixmap = QPixmap(opt.rect.size());
+        pixmap.fill(Qt::transparent); // Ensure transparent background
+
+        // Adjust the option rect for drawing on the pixmap
+        opt.rect.moveTo(0, 0);
+
+        QPainter pixmapPainter(&pixmap);
+
+        QStyledItemDelegate::paint(&pixmapPainter, opt, index);
+
+        pixmapPainter.end(); // Finish painting to the pixmap.
+
+        // Insert the pixmap into the cache
+        QPixmapCache::insert(cacheKey, pixmap);
+    }
+
+    // Draw the cached pixmap onto the widget
+    painter->drawPixmap(option.rect.topLeft(), pixmap);
+}

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -15,6 +15,7 @@
 #include "library/tabledelegates/playcountdelegate.h"
 #include "library/tabledelegates/previewbuttondelegate.h"
 #include "library/tabledelegates/stardelegate.h"
+#include "library/tabledelegates/textdelegate.h"
 #include "library/trackcollection.h"
 #include "library/trackcollectionmanager.h"
 #include "mixer/playerinfo.h"
@@ -519,7 +520,7 @@ QAbstractItemDelegate* BaseTrackTableModel::delegateForColumn(
     } else if (index == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_KEY)) {
         return new KeyDelegate(pTableView);
     }
-    return nullptr;
+    return new TextDelegate(pTableView);
 }
 
 QVariant BaseTrackTableModel::data(

--- a/src/library/tabledelegates/bpmdelegate.h
+++ b/src/library/tabledelegates/bpmdelegate.h
@@ -17,5 +17,4 @@ class BPMDelegate : public TableItemDelegate {
   private:
     QCheckBox* m_pCheckBox;
     QItemEditorFactory* m_pFactory;
-    mutable QColor m_cachedTextColor;
 };

--- a/src/library/tabledelegates/playcountdelegate.cpp
+++ b/src/library/tabledelegates/playcountdelegate.cpp
@@ -2,6 +2,7 @@
 
 #include <QCheckBox>
 #include <QPainter>
+#include <QPixmapCache>
 #include <QTableView>
 
 #include "moc_playcountdelegate.cpp"
@@ -24,13 +25,63 @@ void PlayCountDelegate::paintItem(QPainter* painter,
     // them and why we need paintItemBackground() here, see bpmdelegate.cpp
     paintItemBackground(painter, option, index);
 
-    QStyleOptionViewItem opt = option;
-    initStyleOption(&opt, index);
+    // Retrieve the check state and BPM value
+    bool isChecked = index.data(Qt::CheckStateRole).toInt() == Qt::Checked;
+    QString playCount =
+            index.data(Qt::UserRole + 2)
+                    .toString(); // Playcount value is stored with UserRole + 2
 
-    if (m_pTableView != nullptr) {
-        QStyle* style = m_pTableView->style();
-        if (style != nullptr) {
-            style->drawControl(QStyle::CE_ItemViewItem, &opt, painter, m_pCheckBox);
+    QColor textColor;
+    if (option.state & QStyle::State_Selected) {
+        textColor = option.palette.color(QPalette::Normal, QPalette::HighlightedText);
+    } else {
+        auto colorData = index.data(Qt::ForegroundRole);
+        if (colorData.canConvert<QColor>()) {
+            textColor = colorData.value<QColor>();
+        } else {
+            textColor = option.palette.color(QPalette::Normal, QPalette::Text);
         }
     }
+
+    // Generate a unique cache key that now includes isChecked and playCount
+    QString cacheKey = QString("PlayCountDelegate_%1_%2_%3_%4_%5")
+                               .arg(option.rect.width())
+                               .arg(option.rect.height())
+                               .arg(textColor.name(QColor::HexRgb),
+                                       isChecked ? "checked" : "unchecked")
+                               .arg(playCount);
+
+    QPixmap pixmap;
+    if (!QPixmapCache::find(cacheKey, &pixmap)) {
+        // Pixmap not in cache, create a new one
+        pixmap = QPixmap(option.rect.size());
+        pixmap.fill(Qt::transparent); // Fill uninitialized pixmap's background transparent
+        QPainter pixmapPainter(&pixmap);
+
+        QStyleOptionViewItem opt = option;
+        initStyleOption(&opt, index);
+
+        m_pCheckBox->setStyleSheet(QStringLiteral(
+                "#LibraryPlayedCheckbox::item { color: %1; }")
+                                           .arg(textColor.name(QColor::HexRgb)));
+
+        // Adjust the option rect for drawing on the pixmap
+        opt.rect.moveTo(0, 0);
+
+        if (m_pTableView != nullptr) {
+            QStyle* style = m_pTableView->style();
+            if (style != nullptr) {
+                // Draw the item onto the pixmap
+                style->drawControl(QStyle::CE_ItemViewItem, &opt, &pixmapPainter, m_pCheckBox);
+            }
+        }
+
+        pixmapPainter.end(); // Finish painting to the pixmap.
+
+        // Cache the newly created pixmap
+        QPixmapCache::insert(cacheKey, pixmap);
+    }
+
+    // Draw the cached pixmap onto the painter
+    painter->drawPixmap(option.rect.topLeft(), pixmap);
 }

--- a/src/library/tabledelegates/textdelegate.cpp
+++ b/src/library/tabledelegates/textdelegate.cpp
@@ -1,0 +1,47 @@
+#include "textdelegate.h"
+
+#include <QPainter>
+#include <QPixmapCache>
+#include <QStyleOptionViewItem>
+
+#include "moc_textdelegate.cpp"
+
+TextDelegate::TextDelegate(QObject* parent)
+        : QStyledItemDelegate(parent) {
+}
+
+void TextDelegate::paint(QPainter* painter,
+        const QStyleOptionViewItem& option,
+        const QModelIndex& index) const {
+    QString text = index.data(Qt::DisplayRole).toString(); // Text string
+
+    // Generate a unique cache key that now includes isChecked and playCount
+    QString cacheKey = QString("TextDelegate_%1_%2_%3")
+                               .arg(option.rect.width())
+                               .arg(option.rect.height())
+                               .arg(text);
+
+    QPixmap pixmap;
+    if (!QPixmapCache::find(cacheKey, &pixmap)) {
+        QStyleOptionViewItem opt = option;
+
+        // Pixmap not found in cache, create new pixmap
+        pixmap = QPixmap(opt.rect.size());
+        pixmap.fill(Qt::transparent); // Ensure transparent background
+
+        // Adjust the option rect for drawing on the pixmap
+        opt.rect.moveTo(0, 0);
+
+        QPainter pixmapPainter(&pixmap);
+
+        QStyledItemDelegate::paint(&pixmapPainter, opt, index);
+
+        pixmapPainter.end(); // Finish painting to the pixmap.
+
+        // Insert the pixmap into the cache
+        QPixmapCache::insert(cacheKey, pixmap);
+    }
+
+    // Draw the cached pixmap onto the widget
+    painter->drawPixmap(option.rect.topLeft(), pixmap);
+}

--- a/src/library/tabledelegates/textdelegate.h
+++ b/src/library/tabledelegates/textdelegate.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <QStyledItemDelegate>
+
+class TextDelegate : public QStyledItemDelegate {
+    Q_OBJECT
+  public:
+    explicit TextDelegate(QObject* parent = nullptr);
+
+    void paint(QPainter* painter,
+            const QStyleOptionViewItem& option,
+            const QModelIndex& index) const override;
+};


### PR DESCRIPTION
The table delegates of the library take a lot time to paint, especially these with complex widgets, but also normal text rendering. This results in #11603.
This PR improves the execution time for BPM, Preview and the PlayCount delegates by painting into cached pixmaps instead of rendering every control again and again at each scroll iteration.