### PR TITLE
fix: support for new WaveformData struct in shaders

### DIFF
--- a/res/shaders/filteredsignal.frag
+++ b/res/shaders/filteredsignal.frag
@@ -21,6 +21,11 @@ uniform sampler2D waveformDataTexture;
 
 vec4 getWaveformData(float index) {
     vec2 uv_data;
+    // The Waveform data is composed of 8 bytes per sample, (low, mid, high, all,
+    // stem1, stem2, stem3, stem4), see WaveformData struct. Currently, shaders
+    // don't support stem rendering.
+    index = 2 * index;
+
     uv_data.y = floor(index / float(textureStride));
     uv_data.x = floor(index - uv_data.y * float(textureStride));
     // Divide again to convert to normalized UV coordinates.

--- a/res/shaders/rgbsignal.frag
+++ b/res/shaders/rgbsignal.frag
@@ -22,8 +22,19 @@ uniform sampler2D waveformDataTexture;
 
 vec4 getWaveformData(float index) {
     vec2 uv_data;
-    uv_data.y = splitStereoSignal ? floor(index / float(textureStride)) : max(floor(index / float(textureStride)), floor((index + 1) / float(textureStride)));
-    uv_data.x = splitStereoSignal ? floor(index - uv_data.y * float(textureStride)) : max(floor(index - uv_data.y * float(textureStride)), floor((index + 1) - uv_data.y * float(textureStride)));
+    // The Waveform data is composed of 8 bytes per sample, (low, mid, high,
+    // all, stem1, stem2, stem3, stem4), see WaveformData struct. Currently,
+    // shaders don't support stem rendering.
+    index = 2 * index;
+
+    uv_data.y = splitStereoSignal
+            ? floor(index / float(textureStride))
+            : max(floor(index / float(textureStride)),
+                      floor((index + 2) / float(textureStride)));
+    uv_data.x = splitStereoSignal
+            ? floor(index - uv_data.y * float(textureStride))
+            : max(floor(index - uv_data.y * float(textureStride)),
+                      floor((index + 2) - uv_data.y * float(textureStride)));
     // Divide again to convert to normalized UV coordinates.
     return texture2D(waveformDataTexture, uv_data / float(textureStride));
 }

--- a/res/shaders/stackedsignal.frag
+++ b/res/shaders/stackedsignal.frag
@@ -24,6 +24,11 @@ uniform sampler2D waveformDataTexture;
 
 vec4 getWaveformData(float index) {
     vec2 uv_data;
+    // The Waveform data is composed of 8 bytes per sample, (low, mid, high, all,
+    // stem1, stem2, stem3, stem4), see WaveformData struct. Currently, shaders
+    // don't support stem rendering.
+    index = 2 * index;
+
     uv_data.y = floor(index / float(textureStride));
     uv_data.x = floor(index - uv_data.y * float(textureStride));
     // Divide again to convert to normalized UV coordinates.


### PR DESCRIPTION
Fixes #13472

As part of the newly introduce `Waveform-6.0` format, the waveform data now allocates space for stem information. This PR fixes the rendering issues with shaders, by offsetting the waveform data.

Going forward, we may consider add some more advanced logic to use the stem data if available, but this will require feeding more attribute to GLSL, such as stem gain.

@daschuer @ywwg would appreciate a test if you can :) 