### PR TITLE
fix: Key text is elided from left, should be right

### DIFF
--- a/src/library/tabledelegates/keydelegate.cpp
+++ b/src/library/tabledelegates/keydelegate.cpp
@@ -36,7 +36,7 @@ void KeyDelegate::paintItem(
         const QString keyText = KeyUtils::keyToString(key);
         QString elidedText = option.fontMetrics.elidedText(
                 keyText,
-                Qt::ElideLeft,
+                Qt::ElideRight,
                 columnWidth(index) - rectWidth);
 
         if (option.state & QStyle::State_Selected) {


### PR DESCRIPTION
The text for Key column was being [elided to the left](https://github.com/mixxxdj/mixxx/pull/13390#issuecomment-2227330693) after #13390. This PR changes it back to the right - the default.

Screenshot after the fix:
![image](https://github.com/user-attachments/assets/8ab45af9-9e45-47f4-994b-8e0b1914039f)
