### PR TITLE
CMakeLists: Generate hierarchical source groups for IDEs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4922,3 +4922,9 @@ if(APPLE AND MACOS_BUNDLE)
   )
   install(SCRIPT "${CMAKE_CURRENT_BINARY_DIR}/BundleInstall.cmake")
 endif()
+
+# Generate hierarchical source groups when using IDE generators such as
+# Xcode or Visual Studio. Has to be done after all sources have been added.
+get_target_property(MIXXX_LIB_SOURCES mixxx-lib SOURCES)
+list(FILTER MIXXX_LIB_SOURCES INCLUDE REGEX "^src/.*") # Ignore files outside src, e.g. lib/apple
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/src PREFIX "Source Files" FILES ${MIXXX_LIB_SOURCES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4923,8 +4923,10 @@ if(APPLE AND MACOS_BUNDLE)
   install(SCRIPT "${CMAKE_CURRENT_BINARY_DIR}/BundleInstall.cmake")
 endif()
 
-# Generate hierarchical source groups when using IDE generators such as
-# Xcode or Visual Studio. Has to be done after all sources have been added.
-get_target_property(MIXXX_LIB_SOURCES mixxx-lib SOURCES)
-list(FILTER MIXXX_LIB_SOURCES INCLUDE REGEX "^src/.*") # Ignore files outside src, e.g. lib/apple
-source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/src PREFIX "Source Files" FILES ${MIXXX_LIB_SOURCES})
+if(CMAKE_GENERATOR STREQUAL "Xcode")
+  # Generate hierarchical source groups that mirror the folder structure when
+  # using Xcode. Has to be done after all sources have been added.
+  get_target_property(MIXXX_LIB_SOURCES mixxx-lib SOURCES)
+  list(FILTER MIXXX_LIB_SOURCES INCLUDE REGEX "^src/.*") # Ignore files outside src, e.g. lib/apple
+  source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/src PREFIX "Source Files" FILES ${MIXXX_LIB_SOURCES})
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4928,5 +4928,9 @@ if(CMAKE_GENERATOR STREQUAL "Xcode")
   # using Xcode. Has to be done after all sources have been added.
   get_target_property(MIXXX_LIB_SOURCES mixxx-lib SOURCES)
   list(FILTER MIXXX_LIB_SOURCES INCLUDE REGEX "^src/.*") # Ignore files outside src, e.g. lib/apple
-  source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/src PREFIX "Source Files" FILES ${MIXXX_LIB_SOURCES})
+  source_group(
+    TREE ${CMAKE_CURRENT_SOURCE_DIR}/src
+    PREFIX "Source Files"
+    FILES ${MIXXX_LIB_SOURCES}
+  )
 endif()


### PR DESCRIPTION
This is a largely cosmetic improvement, but when generating a Visual Studio or Xcode project from Mixxx, the default is to generate a flat list of source files. For editing, however, it would be much nicer to have the same directory structure as we do in the file system. Therefore this PR uses the [`source_group(TREE ...)`](https://cmake.org/cmake/help/latest/command/source_group.html) command[^1] to mimic this layout.

For comparison, this is how it looks in Xcode:

| Before | After |
| - | - |
| <img src="https://github.com/user-attachments/assets/e8bf8c8e-3ef3-4a41-a242-08c1e0eac79b" height="500"> | <img src="https://github.com/user-attachments/assets/174acef3-f246-409f-8b09-ac93360a44d2" height="500"> |


[^1]: As e.g. suggested in https://stackoverflow.com/a/56496104