### PR TITLE
CmdLineArgs: Determine whether to color output based on `TERM` variable

### DIFF
--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -38,7 +38,7 @@ bool calcUseColorsAuto() {
 
     // Check if terminal is known to support ANSI colors
     QString term = QProcessEnvironment::systemEnvironment().value("TERM");
-    return term == "ansi" || term == "cygwin" || term == "linux" ||
+    return term == "alacritty" || term == "ansi" || term == "cygwin" || term == "linux" ||
             term.startsWith("screen") || term.startsWith("xterm") ||
             term.startsWith("vt100") || term.startsWith("rxvt") ||
             term.endsWith("color");

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -24,18 +24,24 @@ bool calcUseColorsAuto() {
     // see https://no-color.org/
     if (QProcessEnvironment::systemEnvironment().contains(QLatin1String("NO_COLOR"))) {
         return false;
-    } else {
-#ifndef __WINDOWS__
-        if (isatty(fileno(stderr))) {
-            return true;
-        }
-#else
-        if (_isatty(_fileno(stderr))) {
-            return true;
-        }
-#endif
     }
-    return false;
+
+#ifndef __WINDOWS__
+    if (!isatty(fileno(stderr))) {
+        return false;
+    }
+#else
+    if (!_isatty(_fileno(stderr))) {
+        return false;
+    }
+#endif
+
+    // Check if terminal is known to support ANSI colors
+    QString term = QProcessEnvironment::systemEnvironment().value("TERM");
+    return term == "ansi" || term == "cygwin" || term == "linux" ||
+            term.startsWith("screen") || term.startsWith("xterm") ||
+            term.startsWith("vt100") || term.startsWith("rxvt") ||
+            term.endsWith("color");
 }
 
 } // namespace


### PR DESCRIPTION
To avoid cluttering up the output with ANSI escape sequences in terminals that do not support them (e.g. Xcode), this adds a heuristic that checks the `TERM` environment variable.