### PR TITLE
SoundManagerIOS: Remove unsupported/redundant options

### DIFF
--- a/src/soundio/soundmanagerios.mm
+++ b/src/soundio/soundmanagerios.mm
@@ -10,9 +10,7 @@ void initializeAVAudioSession() {
     AVAudioSessionCategory category = AVAudioSessionCategoryPlayback;
     AVAudioSessionMode mode = AVAudioSessionModeDefault;
     AVAudioSessionCategoryOptions options =
-            AVAudioSessionCategoryOptionMixWithOthers |
-            AVAudioSessionCategoryOptionAllowAirPlay |
-            AVAudioSessionCategoryOptionAllowBluetoothA2DP;
+            AVAudioSessionCategoryOptionMixWithOthers;
 
     NSError* error = nil;
     [session setCategory:category mode:mode options:options error:&error];


### PR DESCRIPTION
On iPadOS using [`AVAudioSessionCategoryOptionAllowAirPlay`](https://developer.apple.com/documentation/avfaudio/avaudiosessioncategoryoptions/avaudiosessioncategoryoptionallowairplay) seems to throw an `AVAudioSessionErrorCodeBadParam` and according to the docs it only seems to be allowed when the category is set to [`AVAudioSessionCategoryPlayAndRecord`](https://developer.apple.com/documentation/avfaudio/avaudiosessioncategoryplayandrecord) (which we don't). This PR therefore removes it.

The option [`AVAudioSessionCategoryOptionAllowBluetoothA2DP`](https://developer.apple.com/documentation/avfaudio/avaudiosessioncategoryoptions/avaudiosessioncategoryoptionallowbluetootha2dp) seems to be redundant too, this seems to already be covered by [`AVAudioSessionCategoryPlayback`](https://developer.apple.com/documentation/avfaudio/avaudiosessioncategoryplayback) (the category that we use for now), therefore we remove it too.

> In the future we may wish to investigate using [`AVAudioSessionCategoryMultiRoute`](https://developer.apple.com/documentation/avfaudio/avaudiosessioncategorymultiroute) for more fine-grained control over audio routing, but this also seems to disable the device's volume buttons, so we should look into this more deeply before using this configuration.