### PR TITLE
LegacySkinParser: Short-circuit if template fails to open

### DIFF
--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -1728,6 +1728,7 @@ QDomElement LegacySkinParser::loadTemplate(const QString& path) {
 
     if (!templateFile.open(QIODevice::ReadOnly)) {
         qWarning() << "Could not open template file:" << absolutePath;
+        return QDomElement();
     }
 
     QDomDocument tmpl("template");


### PR DESCRIPTION
Continuing if a template file does not exist causes warnings that calling methods on a closed `QIODevice` is deprecated:

```
warning [Main] Could not open template file: "/private/var/containers/Bundle/Application/B671BF01-EDFF-4A05-9728-B742BB59ABE9/Mixxx.app/skin:button_1state_right.xml"
warning [Main] QDomDocument called with unopened QIODevice. This will not be supported in future Qt versions.
warning [Main] QDomDocument::setContent: Failed to open device.
warning [Main] LegacySkinParser::loadTemplate - setContent failed see "/private/var/containers/Bundle/Application/B671BF01-EDFF-4A05-9728-B742BB59ABE9/Mixxx.app/skin:button_1state_right.xml" line: 0 column: 0
```

Since we return an empty element in other places where we use this pattern, I assume the omission was unintentional, hence this little fix.