### PR TITLE
Overview waveform: draw minute markers on top of played overlay

### DIFF
--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -634,8 +634,8 @@ void WOverview::paintEvent(QPaintEvent* pEvent) {
         drawEndOfTrackBackground(&painter);
         drawAxis(&painter);
         drawWaveformPixmap(&painter);
-        drawMinuteMarkers(&painter);
         drawPlayedOverlay(&painter);
+        drawMinuteMarkers(&painter);
         drawPlayPosition(&painter);
         drawEndOfTrackFrame(&painter);
         drawAnalyzerProgress(&painter);


### PR DESCRIPTION
I thought "why did the minute markers vanish?" just to realize they're covered by the 'played' overlay.
Let's move them above.