### PR TITLE
Library: Automatically relink paths when iOS sandbox prefix moves

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1190,6 +1190,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/util/safelywritablefile.cpp
   src/util/sample.cpp
   src/util/sandbox.cpp
+  src/util/sandboxios.cpp
   src/util/screensaver.cpp
   src/util/screensavermanager.cpp
   src/util/semanticversion.cpp

--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -395,6 +395,14 @@ void CoreServices::initialize(QApplication* pApp) {
         if (!fd.isEmpty() && m_pLibrary->requestAddDir(fd)) {
             musicDirAdded = true;
         }
+    } else {
+#ifdef Q_OS_IOS
+        // On iOS the sandbox home directory
+        // (/private/var/mobile/Containers/Data/Application/<uuid>/Documents)
+        // may change its UUID across reinstalls and updates, so we have to
+        // relink any music directories in the sandbox on startup.
+        m_pLibrary->requestRelocateiOSSandboxDirs();
+#endif
     }
 
     emit initializationProgressUpdate(60, tr("controllers"));

--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -401,7 +401,7 @@ void CoreServices::initialize(QApplication* pApp) {
         // (/private/var/mobile/Containers/Data/Application/<uuid>/Documents)
         // may change its UUID across reinstalls and updates, so we have to
         // relink any music directories in the sandbox on startup.
-        m_pLibrary->requestRelocateiOSSandboxDirs();
+        m_pLibrary->requestRelocateIOSSandboxDirs();
 #endif
     }
 

--- a/src/library/dao/directorydao.cpp
+++ b/src/library/dao/directorydao.cpp
@@ -217,8 +217,10 @@ std::pair<DirectoryDAO::RelocateResult, QList<RelocatedTrack>> DirectoryDAO::rel
     // Appending '/' is required to disambiguate files from parent
     // directories, e.g. "a/b.mp3" and "a/b/c.mp3" where "a/b" would
     // match both instead of only files in the parent directory "a/b/".
-    DEBUG_ASSERT(!oldDirectory.endsWith('/'));
-    const QString oldDirectoryPrefix = oldDirectory + '/';
+    QString oldDirectoryPrefix = oldDirectory;
+    if (!oldDirectory.endsWith('/')) {
+        oldDirectoryPrefix += '/';
+    }
     query.prepare(QStringLiteral(
             "SELECT library.id,track_locations.id,track_locations.location "
             "FROM library INNER JOIN track_locations ON "

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -703,7 +703,6 @@ void Library::requestRelocateIOSSandboxDirs() {
 
     // TODO: Do we need to handle external track collections?
 
-    bool needsRescan = false;
     QStringList rootDirs = m_pTrackCollectionManager->internalCollection()->getRootDirStrings();
 
     for (const QString& dir : rootDirs) {
@@ -722,13 +721,6 @@ void Library::requestRelocateIOSSandboxDirs() {
             qWarning() << "Could not relink music directory after iOS sandbox moved";
             continue;
         }
-
-        needsRescan = true;
-    }
-
-    if (needsRescan) {
-        qInfo() << "Rescanning library since iOS sandbox moved";
-        m_pTrackCollectionManager->startLibraryScan();
     }
 }
 #endif

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -694,7 +694,7 @@ bool Library::requestRelocateDir(const QString& oldDir, const QString& newDir) {
 }
 
 #ifdef Q_OS_IOS
-void Library::requestRelocateiOSSandboxDirs() {
+void Library::requestRelocateIOSSandboxDirs() {
     // TODO: If the user selects a different app sandbox than ours (which is
     // possible via the file picker) relinking will point those directories to
     // our sandbox. This is not a supported scenario, however, and we should probably
@@ -707,7 +707,7 @@ void Library::requestRelocateiOSSandboxDirs() {
     QStringList rootDirs = m_pTrackCollectionManager->internalCollection()->getRootDirStrings();
 
     for (const QString& dir : rootDirs) {
-        QString newDir = mixxx::updateiOSSandboxPath(dir);
+        QString newDir = mixxx::updateIOSSandboxPath(dir);
 
         if (dir == newDir) {
             // Sandbox directory did not move

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -111,7 +111,7 @@ class Library: public QObject {
     /// Updates the iOS sandbox path prefix on all music directories.
     /// This prefix may change after reinstalls or updates, therefore
     /// this method is called during startup.
-    void requestRelocateiOSSandboxDirs();
+    void requestRelocateIOSSandboxDirs();
 #endif
 
 #ifdef __ENGINEPRIME__

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -4,7 +4,6 @@
 #include <QList>
 #include <QObject>
 #include <QPointer>
-#include <QUrl>
 #include <QtGlobal>
 
 #include "analyzer/trackanalysisscheduler.h"

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -109,6 +109,9 @@ class Library: public QObject {
     bool requestRelocateDir(const QString& previousDirectory, const QString& newDirectory);
 
 #ifdef Q_OS_IOS
+    /// Updates the iOS sandbox path prefix on all music directories.
+    /// This prefix may change after reinstalls or updates, therefore
+    /// this method is called during startup.
     void requestRelocateiOSSandboxDirs();
 #endif
 

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -4,6 +4,8 @@
 #include <QList>
 #include <QObject>
 #include <QPointer>
+#include <QUrl>
+#include <QtGlobal>
 
 #include "analyzer/trackanalysisscheduler.h"
 #include "library/library_decl.h"
@@ -105,6 +107,10 @@ class Library: public QObject {
     bool requestAddDir(const QString& directory);
     bool requestRemoveDir(const QString& directory, LibraryRemovalType removalType);
     bool requestRelocateDir(const QString& previousDirectory, const QString& newDirectory);
+
+#ifdef Q_OS_IOS
+    void requestRelocateiOSSandboxDirs();
+#endif
 
 #ifdef __ENGINEPRIME__
     std::unique_ptr<mixxx::LibraryExporter> makeLibraryExporter(QWidget* parent);

--- a/src/preferences/dialog/dlgprefrecord.cpp
+++ b/src/preferences/dialog/dlgprefrecord.cpp
@@ -35,7 +35,7 @@ DlgPrefRecord::DlgPrefRecord(QWidget* parent, UserSettingsPointer pConfig)
 #ifdef Q_OS_IOS
         // On iOS the sandbox prefix may have changed, so we may need to update
         // the recordings path.
-        QString newPath = mixxx::updateiOSSandboxPath(recordingsPath);
+        QString newPath = mixxx::updateIOSSandboxPath(recordingsPath);
         if (newPath != recordingsPath) {
             qInfo() << "Updating recordings directory since iOS sandbox has "
                        "moved:"

--- a/src/preferences/dialog/dlgprefrecord.cpp
+++ b/src/preferences/dialog/dlgprefrecord.cpp
@@ -3,12 +3,14 @@
 #include <QFileDialog>
 #include <QRadioButton>
 #include <QStandardPaths>
+#include <QtGlobal>
 
 #include "encoder/encoder.h"
 #include "encoder/encodermp3settings.h"
 #include "moc_dlgprefrecord.cpp"
 #include "recording/defs_recording.h"
 #include "util/sandbox.h"
+#include "util/sandboxios.h"
 
 namespace {
 constexpr bool kDefaultCueEnabled = true;
@@ -29,6 +31,19 @@ DlgPrefRecord::DlgPrefRecord(QWidget* parent, UserSettingsPointer pConfig)
         QDir recordDir(musicDir + "/Mixxx/Recordings");
         recordingsPath = recordDir.absolutePath();
         m_pConfig->setValue(ConfigKey(RECORDING_PREF_KEY, "Directory"), recordingsPath);
+    } else {
+#ifdef Q_OS_IOS
+        // On iOS the sandbox prefix may have changed, so we may need to update
+        // the recordings path.
+        QString newPath = mixxx::updateiOSSandboxPath(recordingsPath);
+        if (newPath != recordingsPath) {
+            qInfo() << "Updating recordings directory since iOS sandbox has "
+                       "moved:"
+                    << recordingsPath << "->" << newPath;
+            recordingsPath = newPath;
+            m_pConfig->setValue(ConfigKey(RECORDING_PREF_KEY, "Directory"), recordingsPath);
+        }
+#endif
     }
     LineEditRecordings->setText(recordingsPath);
     connect(PushButtonBrowseRecordings,

--- a/src/util/sandboxios.cpp
+++ b/src/util/sandboxios.cpp
@@ -11,7 +11,7 @@ namespace mixxx {
 #ifdef Q_OS_IOS
 
 static const QRegularExpression sandboxPrefixRegex = QRegularExpression(
-        QStringLiteral("^/private/var/mobile/Containers/Data/Application/"
+        QStringLiteral("^(?:/private)?/var/mobile/Containers/Data/Application/"
                        "[a-zA-Z0-9\\-]+(/.*)"));
 
 QString updateIOSSandboxPath(const QString& path) {

--- a/src/util/sandboxios.cpp
+++ b/src/util/sandboxios.cpp
@@ -1,0 +1,35 @@
+#include "util/sandboxios.h"
+
+#include <QDir>
+#include <QRegularExpression>
+#include <QString>
+#include <QStringLiteral>
+#include <QtGlobal>
+
+namespace mixxx {
+
+#ifdef Q_OS_IOS
+
+static const QRegularExpression sandboxPrefixRegex = QRegularExpression(
+        QStringLiteral("^/private/var/mobile/Containers/Data/Application/"
+                       "[a-zA-Z0-9\\-]+(/.*)"));
+
+QString updateiOSSandboxPath(const QString& path) {
+    QRegularExpressionMatch match = sandboxPrefixRegex.match(path);
+    if (!match.hasMatch()) {
+        qWarning() << "Tried updating iOS sandbox prefix in path outside sandbox:"
+                   << path
+                   << "Perhaps the regex in util/sandboxios.cpp needs to be "
+                      "updated?";
+        return path;
+    }
+
+    QString newSandboxPrefix = QDir::homePath();
+    QString relativePath = match.captured(1);
+
+    return newSandboxPrefix + relativePath;
+}
+
+#endif
+
+} // namespace mixxx

--- a/src/util/sandboxios.cpp
+++ b/src/util/sandboxios.cpp
@@ -14,7 +14,7 @@ static const QRegularExpression sandboxPrefixRegex = QRegularExpression(
         QStringLiteral("^/private/var/mobile/Containers/Data/Application/"
                        "[a-zA-Z0-9\\-]+(/.*)"));
 
-QString updateiOSSandboxPath(const QString& path) {
+QString updateIOSSandboxPath(const QString& path) {
     QRegularExpressionMatch match = sandboxPrefixRegex.match(path);
     if (!match.hasMatch()) {
         qWarning() << "Tried updating iOS sandbox prefix in path outside sandbox:"

--- a/src/util/sandboxios.h
+++ b/src/util/sandboxios.h
@@ -13,7 +13,7 @@ namespace mixxx {
 ///
 ///     /private/var/mobile/Containers/Data/Application/<uuid>
 ///
-QString updateiOSSandboxPath(const QString& path);
+QString updateIOSSandboxPath(const QString& path);
 
 #endif
 

--- a/src/util/sandboxios.h
+++ b/src/util/sandboxios.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <QString>
+#include <QtGlobal>
+
+namespace mixxx {
+
+#ifdef Q_OS_IOS
+
+/// Updates a path into an iOS sandbox with the current sandbox prefix.
+/// This is needed since iOS rotates the UUID in such paths whenever
+/// the app is reinstalled or updated. These paths are of the form
+///
+///     /private/var/mobile/Containers/Data/Application/<uuid>
+///
+QString updateiOSSandboxPath(const QString& path);
+
+#endif
+
+}; // namespace mixxx


### PR DESCRIPTION
On iOS, apps are generally restricted to their sandbox, which is located in the file system at:

```
/private/var/mobile/Containers/Data/Application/<uuid>
```

Unfortunately, this UUID changes after reinstalling or updating the app, so we cannot rely on this prefix being stable (though everything inside the sandbox is persisted, so relative paths stay intact). The general recommendation is to [never store absolute paths into the sandbox](https://aplus.rs/2013/never-save-absolute-file-paths-in-your-ios-app/), but doing so in Mixxx would be impractical, since especially on desktop we want the flexibility to add arbitrary music directories, for example.

Thus this PR implements a slight workaround that queries the current sandbox prefix on startup and automatically relinks music directories and the recordings directory if it has changed. While we're still dealing with absolute paths, this seems like the best compromise that requires few changes and should "just work" in pretty much all standard cases[^1].

[^1]: The only situation where this logic may break down is in edge cases, e.g. when the user adds some path outside our sandbox directory. This is either forbidden by iOS (unless jailbroken) or not well supported by us (when a music directory points to another app's sandbox. This is possible if such a directory was added via the file picker, such directories would, however, be inaccessible on the next launch anyway, unless we implement proper URL bookmarking). In any case, this should be better than the status quo.