### PR TITLE
BaseTrackTableModel: Disable inline track editing on iOS

### DIFF
--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -2,6 +2,7 @@
 
 #include <QGuiApplication>
 #include <QScreen>
+#include <QtGlobal>
 
 #include "library/coverartcache.h"
 #include "library/dao/trackschema.h"
@@ -1110,6 +1111,12 @@ Qt::ItemFlags BaseTrackTableModel::readWriteFlags(
         // Cells are editable by default
         itemFlags |= Qt::ItemIsEditable;
     }
+#ifdef Q_OS_IOS
+    // Make items non-editable on iOS by default, since tapping any track will
+    // otherwise trigger the on-screen keyboard (even if they cannot actually
+    // be edited).
+    itemFlags &= ~Qt::ItemIsEditable;
+#endif
     return itemFlags;
 }
 

--- a/src/library/browse/browsetablemodel.cpp
+++ b/src/library/browse/browsetablemodel.cpp
@@ -403,6 +403,12 @@ Qt::ItemFlags BrowseTableModel::flags(const QModelIndex& index) const {
 
     int column = index.column();
 
+#ifdef Q_OS_IOS
+    // Make items non-editable on iOS by default, since tapping any track will
+    // otherwise trigger the on-screen keyboard (even if they cannot actually
+    // be edited).
+    return defaultFlags;
+#else
     switch (column) {
     case COLUMN_FILENAME:
     case COLUMN_BITRATE:
@@ -417,6 +423,7 @@ Qt::ItemFlags BrowseTableModel::flags(const QModelIndex& index) const {
         // editable
         return defaultFlags | Qt::ItemIsEditable;
     }
+#endif
 }
 
 bool BrowseTableModel::setData(

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -8,6 +8,7 @@
 #include <QMessageBox>
 #include <QStandardPaths>
 #include <QUrl>
+#include <QtGlobal>
 
 #include "control/controlproxy.h"
 #include "defs_urls.h"
@@ -86,6 +87,10 @@ DlgPrefLibrary::DlgPrefLibrary(
             QOverload<int>::of(&QSpinBox::valueChanged),
             this,
             &DlgPrefLibrary::slotSearchDebouncingTimeoutMillisChanged);
+
+#ifdef Q_OS_IOS
+    checkBox_edit_metadata_selected_clicked->setEnabled(false);
+#endif
 
     comboBox_search_bpm_fuzzy_range->clear();
     comboBox_search_bpm_fuzzy_range->addItem("25 %", 25);


### PR DESCRIPTION
On iOS tapping a track in the library triggers the on-screen keyboard, even if the track cannot actually be edited. Until we figure out a better user experience here, we should just disable inline editing there. Of course, tracks can still be edited via the `Cmd+Enter` shortcut or by double tapping title/artist on a loaded deck.