### PR TITLE
Add Key Color Palettes

### DIFF
--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -128,7 +128,7 @@ void BaseTrackTableModel::setKeyColorsEnabled(bool keyColorsEnabled) {
 }
 
 // static
-void BaseTrackTableModel::setKeyColorPalette(ColorPalette palette) {
+void BaseTrackTableModel::setKeyColorPalette(const ColorPalette& palette) {
     s_keyColorPalette = palette;
 }
 

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -1063,7 +1063,7 @@ QVariant BaseTrackTableModel::roleValue(
             return QVariant::fromValue(color);
         }
         default:
-            DEBUG_ASSERT(!"unexpected field for DecorationRole");
+            break;
         }
         break;
     }

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -928,8 +928,7 @@ QVariant BaseTrackTableModel::roleValue(
             if (key == mixxx::track::io::key::INVALID) {
                 return QVariant();
             }
-            const QString keyString = KeyUtils::keyToString(key);
-            return QVariant::fromValue(keyString);
+            return QVariant::fromValue(KeyUtils::keyToString(key));
         }
         case ColumnCache::COLUMN_LIBRARYTABLE_REPLAYGAIN: {
             if (rawValue.isNull()) {
@@ -1059,8 +1058,7 @@ QVariant BaseTrackTableModel::roleValue(
             if (key == mixxx::track::io::key::INVALID) {
                 return QVariant();
             }
-            const QColor color = KeyUtils::keyToColor(key, s_keyColorPalette);
-            return QVariant::fromValue(color);
+            return QVariant::fromValue(KeyUtils::keyToColor(key, s_keyColorPalette));
         }
         default:
             break;

--- a/src/library/basetracktablemodel.h
+++ b/src/library/basetracktablemodel.h
@@ -109,7 +109,7 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
     static constexpr bool kKeyColorsEnabledDefault = true;
     static void setKeyColorsEnabled(bool keyColorsEnabled);
 
-    static void setKeyColorPalette(ColorPalette palette);
+    static void setKeyColorPalette(const ColorPalette& palette);
 
     static constexpr bool kApplyPlayedTrackColorDefault = true;
     static void setApplyPlayedTrackColor(bool apply);

--- a/src/library/basetracktablemodel.h
+++ b/src/library/basetracktablemodel.h
@@ -7,6 +7,7 @@
 #include "library/columncache.h"
 #include "library/trackmodel.h"
 #include "track/track_decl.h"
+#include "util/color/colorpalette.h"
 
 class TrackCollectionManager;
 
@@ -107,6 +108,8 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
 
     static constexpr bool kKeyColorsEnabledDefault = true;
     static void setKeyColorsEnabled(bool keyColorsEnabled);
+
+    static void setKeyColorPalette(ColorPalette palette);
 
     static constexpr bool kApplyPlayedTrackColorDefault = true;
     static void setApplyPlayedTrackColor(bool apply);
@@ -297,6 +300,7 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
 
     static int s_bpmColumnPrecision;
     static bool s_keyColorsEnabled;
+    static ColorPalette s_keyColorPalette;
 
     static bool s_bApplyPlayedTrackColor;
 };

--- a/src/library/tabledelegates/keydelegate.cpp
+++ b/src/library/tabledelegates/keydelegate.cpp
@@ -5,7 +5,6 @@
 #include <QTableView>
 
 #include "moc_keydelegate.cpp"
-#include "track/keyutils.h"
 
 void KeyDelegate::paintItem(
         QPainter* painter,
@@ -13,47 +12,41 @@ void KeyDelegate::paintItem(
         const QModelIndex& index) const {
     paintItemBackground(painter, option, index);
 
-    mixxx::track::io::key::ChromaticKey key =
-            index.data().value<mixxx::track::io::key::ChromaticKey>();
-    if (key != mixxx::track::io::key::INVALID) {
-        // Display the key colors if enabled
-        bool keyColorsEnabled = index.data(Qt::UserRole).value<bool>();
-        if (keyColorsEnabled) {
-            const QColor keyColor = KeyUtils::keyToColor(key);
-            if (keyColor.isValid()) {
-                // Draw the colored rectangle next to the key label
-                painter->fillRect(
-                        option.rect.x(),
-                        option.rect.y() + 2,
-                        4, // width
-                        option.rect.height() - 4,
-                        keyColor);
-            }
-        }
+    const QString keyText = index.data().value<QString>();
+    const QColor keyColor = index.data(Qt::DecorationRole).value<QColor>();
+    int rectWidth = 0;
 
-        // Display the key text with the user-provided notation
-        int rectWidth = keyColorsEnabled ? 8 : 0; //  4px width + 4px right padding
-        const QString keyText = KeyUtils::keyToString(key);
-        QString elidedText = option.fontMetrics.elidedText(
-                keyText,
-                Qt::ElideRight,
-                columnWidth(index) - rectWidth);
-
-        if (option.state & QStyle::State_Selected) {
-            // This uses selection-color from stylesheet for the text pen:
-            // #LibraryContainer QTableView {
-            //   selection-color: #fff;
-            // }
-            painter->setPen(QPen(option.palette.highlightedText().color()));
-        }
-
-        painter->drawText(option.rect.x() + rectWidth,
-                option.rect.y(),
-                option.rect.width() - rectWidth,
-                option.rect.height(),
-                Qt::AlignVCenter,
-                elidedText);
+    if (keyColor.isValid()) {
+        // Draw the colored rectangle next to the key label
+        rectWidth = 8; //  4px width + 4px right padding
+        painter->fillRect(
+                option.rect.x(),
+                option.rect.y() + 2,
+                4, // width
+                option.rect.height() - 4,
+                keyColor);
     }
+
+    // Display the key text with the user-provided notation
+    QString elidedText = option.fontMetrics.elidedText(
+            keyText,
+            Qt::ElideRight,
+            columnWidth(index) - rectWidth);
+
+    if (option.state & QStyle::State_Selected) {
+        // This uses selection-color from stylesheet for the text pen:
+        // #LibraryContainer QTableView {
+        //   selection-color: #fff;
+        // }
+        painter->setPen(QPen(option.palette.highlightedText().color()));
+    }
+
+    painter->drawText(option.rect.x() + rectWidth,
+            option.rect.y(),
+            option.rect.width() - rectWidth,
+            option.rect.height(),
+            Qt::AlignVCenter,
+            elidedText);
 
     // Draw a border if the key cell has focus
     if (option.state & QStyle::State_HasFocus) {

--- a/src/preferences/colorpalettesettings.cpp
+++ b/src/preferences/colorpalettesettings.cpp
@@ -173,7 +173,7 @@ ColorPalette ColorPaletteSettings::getKeyColorPalette(
             mixxx::PredefinedColorPalettes::kDefaultKeyColorPalette);
 }
 
-ColorPalette ColorPaletteSettings::getKeyColorPalette() const {
+ColorPalette ColorPaletteSettings::getConfigKeyColorPalette() const {
     QString name = m_pConfig->getValueString(kKeyColorPaletteConfigKey);
     return getKeyColorPalette(name);
 }

--- a/src/preferences/colorpalettesettings.cpp
+++ b/src/preferences/colorpalettesettings.cpp
@@ -15,6 +15,8 @@ const QString kColorPaletteHotcueIndicesConfigSeparator = QStringLiteral(" ");
 const QString kColorPaletteGroup = QStringLiteral("[ColorPalette %1]");
 const ConfigKey kHotcueColorPaletteConfigKey(kColorPaletteConfigGroup, QStringLiteral("HotcueColorPalette"));
 const ConfigKey kTrackColorPaletteConfigKey(kColorPaletteConfigGroup, QStringLiteral("TrackColorPalette"));
+const ConfigKey kKeyColorPaletteConfigKey(
+        kColorPaletteConfigGroup, QStringLiteral("KeyColorPalette"));
 
 int numberOfDecimalDigits(int number) {
     int numDigits = 1;
@@ -161,6 +163,28 @@ void ColorPaletteSettings::setTrackColorPalette(const ColorPalette& colorPalette
         return;
     }
     m_pConfig->setValue(kTrackColorPaletteConfigKey, name);
+    setColorPalette(name, colorPalette);
+}
+
+ColorPalette ColorPaletteSettings::getKeyColorPalette(
+        const QString& name) const {
+    return getColorPalette(
+            name,
+            mixxx::PredefinedColorPalettes::kDefaultKeyColorPalette);
+}
+
+ColorPalette ColorPaletteSettings::getKeyColorPalette() const {
+    QString name = m_pConfig->getValueString(kKeyColorPaletteConfigKey);
+    return getKeyColorPalette(name);
+}
+
+void ColorPaletteSettings::setKeyColorPalette(const ColorPalette& colorPalette) {
+    QString name = colorPalette.getName();
+    VERIFY_OR_DEBUG_ASSERT(!name.isEmpty()) {
+        qWarning() << "Palette name must not be empty!";
+        return;
+    }
+    m_pConfig->setValue(kKeyColorPaletteConfigKey, name);
     setColorPalette(name, colorPalette);
 }
 

--- a/src/preferences/colorpalettesettings.h
+++ b/src/preferences/colorpalettesettings.h
@@ -19,7 +19,7 @@ class ColorPaletteSettings {
     void setTrackColorPalette(const ColorPalette& colorPalette);
 
     ColorPalette getKeyColorPalette(const QString& name) const;
-    ColorPalette getKeyColorPalette() const;
+    ColorPalette getConfigKeyColorPalette() const;
     void setKeyColorPalette(const ColorPalette& colorPalette);
 
     ColorPalette getColorPalette(

--- a/src/preferences/colorpalettesettings.h
+++ b/src/preferences/colorpalettesettings.h
@@ -18,6 +18,10 @@ class ColorPaletteSettings {
     ColorPalette getTrackColorPalette() const;
     void setTrackColorPalette(const ColorPalette& colorPalette);
 
+    ColorPalette getKeyColorPalette(const QString& name) const;
+    ColorPalette getKeyColorPalette() const;
+    void setKeyColorPalette(const ColorPalette& colorPalette);
+
     ColorPalette getColorPalette(
             const QString& name,
             const ColorPalette& defaultPalette) const;

--- a/src/preferences/dialog/dlgprefcolors.cpp
+++ b/src/preferences/dialog/dlgprefcolors.cpp
@@ -96,19 +96,21 @@ void DlgPrefColors::slotUpdate() {
                     BaseTrackTableModel::kKeyColorsEnabledDefault));
     for (const auto& palette : std::as_const(mixxx::PredefinedColorPalettes::kPalettes)) {
         QString paletteName = palette.getName();
+        QString translatedName = QCoreApplication::translate(
+                "PredefinedColorPalettes", qPrintable(paletteName));
         QIcon paletteIcon = drawPalettePreview(paletteName);
-        comboBoxHotcueColors->addItem(paletteName);
+        comboBoxHotcueColors->addItem(translatedName, paletteName);
         comboBoxHotcueColors->setItemIcon(
                 comboBoxHotcueColors->count() - 1,
                 paletteIcon);
 
-        comboBoxTrackColors->addItem(paletteName);
+        comboBoxTrackColors->addItem(translatedName, paletteName);
         comboBoxTrackColors->setItemIcon(
                 comboBoxTrackColors->count() - 1,
                 paletteIcon);
 
         if (palette.size() == 12) {
-            comboBoxKeyColors->addItem(paletteName);
+            comboBoxKeyColors->addItem(translatedName, paletteName);
             comboBoxKeyColors->setItemIcon(
                     comboBoxKeyColors->count() - 1,
                     paletteIcon);
@@ -117,12 +119,14 @@ void DlgPrefColors::slotUpdate() {
 
     const QSet<QString> colorPaletteNames = m_colorPaletteSettings.getColorPaletteNames();
     for (const auto& paletteName : colorPaletteNames) {
+        QString translatedName = QCoreApplication::translate(
+                "PredefinedColorPalettes", qPrintable(paletteName));
         QIcon paletteIcon = drawPalettePreview(paletteName);
-        comboBoxHotcueColors->addItem(paletteName);
+        comboBoxHotcueColors->addItem(translatedName, paletteName);
         comboBoxHotcueColors->setItemIcon(
                 comboBoxHotcueColors->count() - 1,
                 paletteIcon);
-        comboBoxTrackColors->addItem(paletteName);
+        comboBoxTrackColors->addItem(translatedName, paletteName);
         comboBoxTrackColors->setItemIcon(
                 comboBoxHotcueColors->count() - 1,
                 paletteIcon);
@@ -130,19 +134,19 @@ void DlgPrefColors::slotUpdate() {
 
     const ColorPalette trackPalette =
             m_colorPaletteSettings.getTrackColorPalette();
-    comboBoxTrackColors->setCurrentText(
-            trackPalette.getName());
+    comboBoxTrackColors->setCurrentText(QCoreApplication::translate(
+            "PredefinedColorPalettes", qPrintable(trackPalette.getName())));
 
     const ColorPalette hotcuePalette =
             m_colorPaletteSettings.getHotcueColorPalette();
-    comboBoxHotcueColors->setCurrentText(
-            hotcuePalette.getName());
+    comboBoxHotcueColors->setCurrentText(QCoreApplication::translate(
+            "PredefinedColorPalettes", qPrintable(hotcuePalette.getName())));
     slotHotcuePaletteIndexChanged(comboBoxHotcueColors->currentIndex());
 
     const ColorPalette keyPalette =
             m_colorPaletteSettings.getKeyColorPalette();
-    comboBoxKeyColors->setCurrentText(
-            keyPalette.getName());
+    comboBoxKeyColors->setCurrentText(QCoreApplication::translate(
+            "PredefinedColorPalettes", qPrintable(keyPalette.getName())));
 
     bool autoHotcueColors = m_pConfig->getValue(kAutoHotcueColorsConfigKey, false);
     if (autoHotcueColors) {
@@ -180,15 +184,19 @@ void DlgPrefColors::slotUpdate() {
 
 // Set the default values for all the widgets
 void DlgPrefColors::slotResetToDefaults() {
-    comboBoxHotcueColors->setCurrentText(
-            mixxx::PredefinedColorPalettes::kDefaultHotcueColorPalette
-                    .getName());
-    comboBoxTrackColors->setCurrentText(
-            mixxx::PredefinedColorPalettes::kDefaultTrackColorPalette
-                    .getName());
-    comboBoxKeyColors->setCurrentText(
-            mixxx::PredefinedColorPalettes::kDefaultKeyColorPalette
-                    .getName());
+    comboBoxHotcueColors->setCurrentText(QCoreApplication::translate(
+            "PredefinedColorPalettes",
+            qPrintable(
+                    mixxx::PredefinedColorPalettes::kDefaultHotcueColorPalette
+                            .getName())));
+    comboBoxTrackColors->setCurrentText(QCoreApplication::translate(
+            "PredefinedColorPalettes",
+            qPrintable(mixxx::PredefinedColorPalettes::kDefaultTrackColorPalette
+                               .getName())));
+    comboBoxKeyColors->setCurrentText(QCoreApplication::translate(
+            "PredefinedColorPalettes",
+            qPrintable(mixxx::PredefinedColorPalettes::kDefaultKeyColorPalette
+                               .getName())));
     comboBoxHotcueDefaultColor->setCurrentIndex(
             mixxx::PredefinedColorPalettes::kDefaultTrackColorPalette.size());
     comboBoxLoopDefaultColor->setCurrentIndex(
@@ -198,9 +206,9 @@ void DlgPrefColors::slotResetToDefaults() {
 
 // Apply and save any changes made in the dialog
 void DlgPrefColors::slotApply() {
-    QString hotcueColorPaletteName = comboBoxHotcueColors->currentText();
-    QString trackColorPaletteName = comboBoxTrackColors->currentText();
-    QString keyColorPaletteName = comboBoxKeyColors->currentText();
+    QString hotcueColorPaletteName = comboBoxHotcueColors->currentData().toString();
+    QString trackColorPaletteName = comboBoxTrackColors->currentData().toString();
+    QString keyColorPaletteName = comboBoxKeyColors->currentData().toString();
     bool bHotcueColorPaletteFound = false;
     bool bTrackColorPaletteFound = false;
     bool bKeyColorPaletteFound = false;
@@ -270,7 +278,7 @@ void DlgPrefColors::slotReplaceCueColorClicked() {
 
     ColorPalette savedPalette = colorPaletteSettings.getHotcueColorPalette();
     ColorPalette newPalette = colorPaletteSettings.getColorPalette(
-            comboBoxHotcueColors->currentText(), savedPalette);
+            comboBoxHotcueColors->currentData().toString(), savedPalette);
     m_pReplaceCueColorDlg->setColorPalette(newPalette);
 
     int savedDefaultColorIndex = m_pConfig->getValue(
@@ -335,7 +343,7 @@ QIcon DlgPrefColors::drawHotcueColorByPaletteIcon(const QString& paletteName) {
 }
 
 void DlgPrefColors::slotHotcuePaletteIndexChanged(int paletteIndex) {
-    QString paletteName = comboBoxHotcueColors->itemText(paletteIndex);
+    QString paletteName = comboBoxHotcueColors->itemData(paletteIndex).toString();
     ColorPalette palette =
             m_colorPaletteSettings.getHotcueColorPalette(paletteName);
 
@@ -384,19 +392,19 @@ void DlgPrefColors::slotHotcuePaletteIndexChanged(int paletteIndex) {
 }
 
 void DlgPrefColors::slotKeyPaletteIndexChanged(int paletteIndex) {
-    QString paletteName = comboBoxKeyColors->itemText(paletteIndex);
+    QString paletteName = comboBoxKeyColors->itemData(paletteIndex).toString();
     ColorPalette palette =
             m_colorPaletteSettings.getKeyColorPalette(paletteName);
     BaseTrackTableModel::setKeyColorPalette(palette);
 }
 
 void DlgPrefColors::slotEditTrackPaletteClicked() {
-    QString trackColorPaletteName = comboBoxTrackColors->currentText();
+    QString trackColorPaletteName = comboBoxTrackColors->currentData().toString();
     openColorPaletteEditor(trackColorPaletteName, false);
 }
 
 void DlgPrefColors::slotEditHotcuePaletteClicked() {
-    QString hotcueColorPaletteName = comboBoxHotcueColors->currentText();
+    QString hotcueColorPaletteName = comboBoxHotcueColors->currentData().toString();
     openColorPaletteEditor(hotcueColorPaletteName, true);
 }
 
@@ -433,7 +441,7 @@ void DlgPrefColors::openColorPaletteEditor(
 }
 
 void DlgPrefColors::trackPaletteUpdated(const QString& trackColors) {
-    QString hotcueColors = comboBoxHotcueColors->currentText();
+    QString hotcueColors = comboBoxHotcueColors->currentData().toString();
     int defaultHotcueColor = comboBoxHotcueDefaultColor->currentIndex();
     int defaultLoopColor = comboBoxLoopDefaultColor->currentIndex();
 
@@ -442,7 +450,7 @@ void DlgPrefColors::trackPaletteUpdated(const QString& trackColors) {
 }
 
 void DlgPrefColors::hotcuePaletteUpdated(const QString& hotcueColors) {
-    QString trackColors = comboBoxTrackColors->currentText();
+    QString trackColors = comboBoxTrackColors->currentData().toString();
     int defaultHotcueColor = comboBoxHotcueDefaultColor->currentIndex();
     int defaultLoopColor = comboBoxLoopDefaultColor->currentIndex();
 
@@ -451,8 +459,8 @@ void DlgPrefColors::hotcuePaletteUpdated(const QString& hotcueColors) {
 }
 
 void DlgPrefColors::palettesUpdated() {
-    QString hotcueColors = comboBoxHotcueColors->currentText();
-    QString trackColors = comboBoxTrackColors->currentText();
+    QString hotcueColors = comboBoxHotcueColors->currentData().toString();
+    QString trackColors = comboBoxTrackColors->currentData().toString();
     int defaultHotcueColor = comboBoxHotcueDefaultColor->currentIndex();
     int defaultLoopColor = comboBoxLoopDefaultColor->currentIndex();
 
@@ -465,8 +473,10 @@ void DlgPrefColors::restoreComboBoxes(
         const QString& trackColors,
         int defaultHotcueColor,
         int defaultLoopColor) {
-    comboBoxHotcueColors->setCurrentText(hotcueColors);
-    comboBoxTrackColors->setCurrentText(trackColors);
+    comboBoxHotcueColors->setCurrentText(QCoreApplication::translate(
+            "PredefinedColorPalettes", qPrintable(hotcueColors)));
+    comboBoxTrackColors->setCurrentText(QCoreApplication::translate(
+            "PredefinedColorPalettes", qPrintable(trackColors)));
     if (comboBoxHotcueDefaultColor->count() > defaultHotcueColor) {
         comboBoxHotcueDefaultColor->setCurrentIndex(defaultHotcueColor);
     } else {

--- a/src/preferences/dialog/dlgprefcolors.cpp
+++ b/src/preferences/dialog/dlgprefcolors.cpp
@@ -64,11 +64,6 @@ DlgPrefColors::DlgPrefColors(
             this,
             &DlgPrefColors::slotEditTrackPaletteClicked);
 
-    connect(pushButtonEditKeyPalette,
-            &QPushButton::clicked,
-            this,
-            &DlgPrefColors::slotEditKeyPaletteClicked);
-
     connect(pushButtonReplaceCueColor,
             &QPushButton::clicked,
             this,
@@ -385,17 +380,12 @@ void DlgPrefColors::slotHotcuePaletteIndexChanged(int paletteIndex) {
 
 void DlgPrefColors::slotEditTrackPaletteClicked() {
     QString trackColorPaletteName = comboBoxTrackColors->currentText();
-    openColorPaletteEditor(trackColorPaletteName, &DlgPrefColors::trackPaletteUpdated);
+    openColorPaletteEditor(trackColorPaletteName, false);
 }
 
 void DlgPrefColors::slotEditHotcuePaletteClicked() {
     QString hotcueColorPaletteName = comboBoxHotcueColors->currentText();
-    openColorPaletteEditor(hotcueColorPaletteName, &DlgPrefColors::hotcuePaletteUpdated);
-}
-
-void DlgPrefColors::slotEditKeyPaletteClicked() {
-    QString keyColorPaletteName = comboBoxKeyColors->currentText();
-    openColorPaletteEditor(keyColorPaletteName, &DlgPrefColors::keyPaletteUpdated);
+    openColorPaletteEditor(hotcueColorPaletteName, true);
 }
 
 void DlgPrefColors::slotKeyColorsEnabled(int i) {
@@ -406,16 +396,21 @@ void DlgPrefColors::slotKeyColorsEnabled(int i) {
 
 void DlgPrefColors::openColorPaletteEditor(
         const QString& paletteName,
-        void (DlgPrefColors::*paletteUpdatedSlot)(const QString&)) {
-    bool showHotcueNumbers = paletteUpdatedSlot == &DlgPrefColors::hotcuePaletteUpdated;
+        bool editHotcuePalette) {
     std::unique_ptr<ColorPaletteEditor> pColorPaletteEditor =
-            std::make_unique<ColorPaletteEditor>(this, showHotcueNumbers);
+            std::make_unique<ColorPaletteEditor>(this, editHotcuePalette);
 
-    connect(pColorPaletteEditor.get(),
-            &ColorPaletteEditor::paletteChanged,
-            this,
-            paletteUpdatedSlot);
-
+    if (editHotcuePalette) {
+        connect(pColorPaletteEditor.get(),
+                &ColorPaletteEditor::paletteChanged,
+                this,
+                &DlgPrefColors::hotcuePaletteUpdated);
+    } else {
+        connect(pColorPaletteEditor.get(),
+                &ColorPaletteEditor::paletteChanged,
+                this,
+                &DlgPrefColors::trackPaletteUpdated);
+    }
     connect(pColorPaletteEditor.get(),
             &ColorPaletteEditor::paletteRemoved,
             this,
@@ -427,54 +422,39 @@ void DlgPrefColors::openColorPaletteEditor(
 
 void DlgPrefColors::trackPaletteUpdated(const QString& trackColors) {
     QString hotcueColors = comboBoxHotcueColors->currentText();
-    QString keyColors = comboBoxKeyColors->currentText();
     int defaultHotcueColor = comboBoxHotcueDefaultColor->currentIndex();
     int defaultLoopColor = comboBoxLoopDefaultColor->currentIndex();
 
     slotUpdate();
-    restoreComboBoxes(hotcueColors, trackColors, keyColors, defaultHotcueColor, defaultLoopColor);
+    restoreComboBoxes(hotcueColors, trackColors, defaultHotcueColor, defaultLoopColor);
 }
 
 void DlgPrefColors::hotcuePaletteUpdated(const QString& hotcueColors) {
     QString trackColors = comboBoxTrackColors->currentText();
-    QString keyColors = comboBoxKeyColors->currentText();
     int defaultHotcueColor = comboBoxHotcueDefaultColor->currentIndex();
     int defaultLoopColor = comboBoxLoopDefaultColor->currentIndex();
 
     slotUpdate();
-    restoreComboBoxes(hotcueColors, trackColors, keyColors, defaultHotcueColor, defaultLoopColor);
-}
-
-void DlgPrefColors::keyPaletteUpdated(const QString& keyColors) {
-    QString trackColors = comboBoxTrackColors->currentText();
-    QString hotcueColors = comboBoxHotcueColors->currentText();
-    int defaultHotcueColor = comboBoxHotcueDefaultColor->currentIndex();
-    int defaultLoopColor = comboBoxLoopDefaultColor->currentIndex();
-
-    slotUpdate();
-    restoreComboBoxes(hotcueColors, trackColors, keyColors, defaultHotcueColor, defaultLoopColor);
+    restoreComboBoxes(hotcueColors, trackColors, defaultHotcueColor, defaultLoopColor);
 }
 
 void DlgPrefColors::palettesUpdated() {
     QString hotcueColors = comboBoxHotcueColors->currentText();
     QString trackColors = comboBoxTrackColors->currentText();
-    QString keyColors = comboBoxKeyColors->currentText();
     int defaultHotcueColor = comboBoxHotcueDefaultColor->currentIndex();
     int defaultLoopColor = comboBoxLoopDefaultColor->currentIndex();
 
     slotUpdate();
-    restoreComboBoxes(hotcueColors, trackColors, keyColors, defaultHotcueColor, defaultLoopColor);
+    restoreComboBoxes(hotcueColors, trackColors, defaultHotcueColor, defaultLoopColor);
 }
 
 void DlgPrefColors::restoreComboBoxes(
         const QString& hotcueColors,
         const QString& trackColors,
-        const QString& keyColors,
         int defaultHotcueColor,
         int defaultLoopColor) {
     comboBoxHotcueColors->setCurrentText(hotcueColors);
     comboBoxTrackColors->setCurrentText(trackColors);
-    comboBoxKeyColors->setCurrentText(keyColors);
     if (comboBoxHotcueDefaultColor->count() > defaultHotcueColor) {
         comboBoxHotcueDefaultColor->setCurrentIndex(defaultHotcueColor);
     } else {

--- a/src/preferences/dialog/dlgprefcolors.cpp
+++ b/src/preferences/dialog/dlgprefcolors.cpp
@@ -144,7 +144,7 @@ void DlgPrefColors::slotUpdate() {
     slotHotcuePaletteIndexChanged(comboBoxHotcueColors->currentIndex());
 
     const ColorPalette keyPalette =
-            m_colorPaletteSettings.getKeyColorPalette();
+            m_colorPaletteSettings.getConfigKeyColorPalette();
     comboBoxKeyColors->setCurrentText(QCoreApplication::translate(
             "PredefinedColorPalettes", qPrintable(keyPalette.getName())));
 
@@ -247,7 +247,7 @@ void DlgPrefColors::slotApply() {
     if (!bKeyColorPaletteFound) {
         m_colorPaletteSettings.setKeyColorPalette(
                 m_colorPaletteSettings.getColorPalette(keyColorPaletteName,
-                        m_colorPaletteSettings.getKeyColorPalette()));
+                        m_colorPaletteSettings.getConfigKeyColorPalette()));
     }
 
     int hotcueColorIndex = comboBoxHotcueDefaultColor->currentIndex();

--- a/src/preferences/dialog/dlgprefcolors.cpp
+++ b/src/preferences/dialog/dlgprefcolors.cpp
@@ -54,6 +54,11 @@ DlgPrefColors::DlgPrefColors(
             this,
             &DlgPrefColors::slotHotcuePaletteIndexChanged);
 
+    connect(comboBoxKeyColors,
+            QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this,
+            &DlgPrefColors::slotKeyPaletteIndexChanged);
+
     connect(pushButtonEditHotcuePalette,
             &QPushButton::clicked,
             this,
@@ -376,6 +381,13 @@ void DlgPrefColors::slotHotcuePaletteIndexChanged(int paletteIndex) {
         comboBoxLoopDefaultColor->setCurrentIndex(
                 comboBoxLoopDefaultColor->count() - 1);
     }
+}
+
+void DlgPrefColors::slotKeyPaletteIndexChanged(int paletteIndex) {
+    QString paletteName = comboBoxKeyColors->itemText(paletteIndex);
+    ColorPalette palette =
+            m_colorPaletteSettings.getKeyColorPalette(paletteName);
+    BaseTrackTableModel::setKeyColorPalette(palette);
 }
 
 void DlgPrefColors::slotEditTrackPaletteClicked() {

--- a/src/preferences/dialog/dlgprefcolors.cpp
+++ b/src/preferences/dialog/dlgprefcolors.cpp
@@ -107,10 +107,12 @@ void DlgPrefColors::slotUpdate() {
                 comboBoxTrackColors->count() - 1,
                 paletteIcon);
 
-        comboBoxKeyColors->addItem(paletteName);
-        comboBoxKeyColors->setItemIcon(
-                comboBoxKeyColors->count() - 1,
-                paletteIcon);
+        if (palette.size() == 12) {
+            comboBoxKeyColors->addItem(paletteName);
+            comboBoxKeyColors->setItemIcon(
+                    comboBoxKeyColors->count() - 1,
+                    paletteIcon);
+        }
     }
 
     const QSet<QString> colorPaletteNames = m_colorPaletteSettings.getColorPaletteNames();
@@ -123,10 +125,6 @@ void DlgPrefColors::slotUpdate() {
         comboBoxTrackColors->addItem(paletteName);
         comboBoxTrackColors->setItemIcon(
                 comboBoxHotcueColors->count() - 1,
-                paletteIcon);
-        comboBoxKeyColors->addItem(paletteName);
-        comboBoxKeyColors->setItemIcon(
-                comboBoxKeyColors->count() - 1,
                 paletteIcon);
     }
 

--- a/src/preferences/dialog/dlgprefcolors.h
+++ b/src/preferences/dialog/dlgprefcolors.h
@@ -35,24 +35,21 @@ class DlgPrefColors : public DlgPreferencePage, public Ui::DlgPrefColorsDlg {
     void slotHotcuePaletteIndexChanged(int paletteIndex);
     void trackPaletteUpdated(const QString& palette);
     void hotcuePaletteUpdated(const QString& palette);
-    void keyPaletteUpdated(const QString& palette);
     void palettesUpdated();
     void slotReplaceCueColorClicked();
     void slotEditTrackPaletteClicked();
     void slotEditHotcuePaletteClicked();
-    void slotEditKeyPaletteClicked();
     void slotKeyColorsEnabled(int i);
 
   private:
     void openColorPaletteEditor(
             const QString& paletteName,
-            void (DlgPrefColors::*paletteUpdatedSlot)(const QString&));
+            bool editHotcuePalette);
     QPixmap drawPalettePreview(const QString& paletteName);
     QIcon drawHotcueColorByPaletteIcon(const QString& paletteName);
     void restoreComboBoxes(
             const QString& hotcueColors,
             const QString& trackColors,
-            const QString& keyColors,
             int defaultHotcueColor,
             int defaultLoopColor);
 

--- a/src/preferences/dialog/dlgprefcolors.h
+++ b/src/preferences/dialog/dlgprefcolors.h
@@ -33,6 +33,7 @@ class DlgPrefColors : public DlgPreferencePage, public Ui::DlgPrefColorsDlg {
 
   private slots:
     void slotHotcuePaletteIndexChanged(int paletteIndex);
+    void slotKeyPaletteIndexChanged(int paletteIndex);
     void trackPaletteUpdated(const QString& palette);
     void hotcuePaletteUpdated(const QString& palette);
     void palettesUpdated();

--- a/src/preferences/dialog/dlgprefcolors.h
+++ b/src/preferences/dialog/dlgprefcolors.h
@@ -35,21 +35,24 @@ class DlgPrefColors : public DlgPreferencePage, public Ui::DlgPrefColorsDlg {
     void slotHotcuePaletteIndexChanged(int paletteIndex);
     void trackPaletteUpdated(const QString& palette);
     void hotcuePaletteUpdated(const QString& palette);
+    void keyPaletteUpdated(const QString& palette);
     void palettesUpdated();
     void slotReplaceCueColorClicked();
     void slotEditTrackPaletteClicked();
     void slotEditHotcuePaletteClicked();
+    void slotEditKeyPaletteClicked();
     void slotKeyColorsEnabled(int i);
 
   private:
     void openColorPaletteEditor(
             const QString& paletteName,
-            bool editHotcuePalette);
+            void (DlgPrefColors::*paletteUpdatedSlot)(const QString&));
     QPixmap drawPalettePreview(const QString& paletteName);
     QIcon drawHotcueColorByPaletteIcon(const QString& paletteName);
     void restoreComboBoxes(
             const QString& hotcueColors,
             const QString& trackColors,
+            const QString& keyColors,
             int defaultHotcueColor,
             int defaultLoopColor);
 

--- a/src/preferences/dialog/dlgprefcolorsdlg.ui
+++ b/src/preferences/dialog/dlgprefcolorsdlg.ui
@@ -129,13 +129,6 @@ associated with each key.</string>
       </property>
      </widget>
     </item>
-    <item row="5" column="2">
-     <widget class="QPushButton" name="pushButtonEditKeyPalette">
-      <property name="text">
-       <string>Edit…</string>
-      </property>
-     </widget>
-    </item>
 
     <item row="6" column="0" colspan="2">
      <spacer>

--- a/src/preferences/dialog/dlgprefcolorsdlg.ui
+++ b/src/preferences/dialog/dlgprefcolorsdlg.ui
@@ -112,7 +112,32 @@ associated with each key.</string>
      </widget>
     </item>
 
-    <item row="5" column="0" colspan="2">
+    <item row="5" column="0">
+     <widget class="QLabel" name="labelKeyColors">
+      <property name="text">
+       <string>Key palette</string>
+      </property>
+     </widget>
+    </item>
+    <item row="5" column="1">
+     <widget class="QComboBox" name="comboBoxKeyColors">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+     </widget>
+    </item>
+    <item row="5" column="2">
+     <widget class="QPushButton" name="pushButtonEditKeyPalette">
+      <property name="text">
+       <string>Edit…</string>
+      </property>
+     </widget>
+    </item>
+
+    <item row="6" column="0" colspan="2">
      <spacer>
       <property name="orientation">
        <enum>Qt::Vertical</enum>

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -1570,6 +1570,10 @@ QWidget* LegacySkinParser::parseLibrary(const QDomElement& node) {
                     BaseTrackTableModel::kKeyColorsEnabledDefault);
     BaseTrackTableModel::setKeyColorsEnabled(keyColorsEnabled);
 
+    ColorPaletteSettings colorPaletteSettings(m_pConfig);
+    ColorPalette colorPalette = colorPaletteSettings.getTrackColorPalette();
+    BaseTrackTableModel::setKeyColorPalette(colorPaletteSettings.getKeyColorPalette());
+
     const auto applyPlayedTrackColor =
             m_pConfig->getValue(
                     mixxx::library::prefs::kApplyPlayedTrackColorConfigKey,

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -1572,7 +1572,7 @@ QWidget* LegacySkinParser::parseLibrary(const QDomElement& node) {
 
     ColorPaletteSettings colorPaletteSettings(m_pConfig);
     ColorPalette colorPalette = colorPaletteSettings.getTrackColorPalette();
-    BaseTrackTableModel::setKeyColorPalette(colorPaletteSettings.getKeyColorPalette());
+    BaseTrackTableModel::setKeyColorPalette(colorPaletteSettings.getConfigKeyColorPalette());
 
     const auto applyPlayedTrackColor =
             m_pConfig->getValue(

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -466,7 +466,7 @@ double KeyUtils::keyToNumericValue(ChromaticKey key) {
 }
 
 // static
-QColor KeyUtils::keyToColor(ChromaticKey key, ColorPalette palette) {
+QColor KeyUtils::keyToColor(ChromaticKey key, const ColorPalette& palette) {
     int openKeyNumber = keyToOpenKeyNumber(key);
 
     if (openKeyNumber != 0) {

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -5,6 +5,7 @@
 #include <QRegularExpression>
 #include <QtDebug>
 
+#include "util/color/colorpalette.h"
 #include "util/color/predefinedcolorpalettes.h"
 #include "util/color/rgbcolor.h"
 #include "util/compatibility/qmutex.h"
@@ -465,11 +466,10 @@ double KeyUtils::keyToNumericValue(ChromaticKey key) {
 }
 
 // static
-QColor KeyUtils::keyToColor(ChromaticKey key) {
+QColor KeyUtils::keyToColor(ChromaticKey key, ColorPalette palette) {
     int openKeyNumber = keyToOpenKeyNumber(key);
 
     if (openKeyNumber != 0) {
-        const auto& palette = mixxx::PredefinedColorPalettes::kDefaultKeyColorPalette;
         DEBUG_ASSERT(openKeyNumber <= palette.size() && openKeyNumber >= 1);
         const auto rgbColor = palette.at(openKeyNumber - 1); // Open Key numbers start from 1
         return mixxx::RgbColor::toQColor(rgbColor);

--- a/src/track/keyutils.h
+++ b/src/track/keyutils.h
@@ -8,6 +8,7 @@
 #include "control/controlproxy.h"
 #include "proto/keys.pb.h"
 #include "track/keys.h"
+#include "util/color/colorpalette.h"
 #include "util/math.h"
 #include "util/types.h"
 
@@ -68,7 +69,7 @@ class KeyUtils {
 
     static double keyToNumericValue(mixxx::track::io::key::ChromaticKey key);
 
-    static QColor keyToColor(mixxx::track::io::key::ChromaticKey key);
+    static QColor keyToColor(mixxx::track::io::key::ChromaticKey key, ColorPalette palette);
 
     static QPair<mixxx::track::io::key::ChromaticKey, double> scaleKeyOctaves(
         mixxx::track::io::key::ChromaticKey key, double scale);

--- a/src/track/keyutils.h
+++ b/src/track/keyutils.h
@@ -69,7 +69,7 @@ class KeyUtils {
 
     static double keyToNumericValue(mixxx::track::io::key::ChromaticKey key);
 
-    static QColor keyToColor(mixxx::track::io::key::ChromaticKey key, ColorPalette palette);
+    static QColor keyToColor(mixxx::track::io::key::ChromaticKey key, const ColorPalette& palette);
 
     static QPair<mixxx::track::io::key::ChromaticKey, double> scaleKeyOctaves(
         mixxx::track::io::key::ChromaticKey key, double scale);

--- a/src/util/color/predefinedcolorpalettes.cpp
+++ b/src/util/color/predefinedcolorpalettes.cpp
@@ -251,7 +251,7 @@ namespace mixxx {
 
 const ColorPalette PredefinedColorPalettes::kMixxxHotcueColorPalette =
         ColorPalette(
-                QStringLiteral("Mixxx Hotcue Colors"),
+                QT_TRANSLATE_NOOP("PredefinedColorPaletes", "Mixxx Hotcue Colors"),
                 {
                         kColorMixxxRed,
                         kColorMixxxGreen,
@@ -268,34 +268,35 @@ const ColorPalette PredefinedColorPalettes::kMixxxHotcueColorPalette =
                 // controllers with >8 hotcue buttons, for example a Novation Launchpad.
                 {0, 1, 2, 3, 4, 5, 6, 7});
 
-const ColorPalette PredefinedColorPalettes::kSeratoTrackMetadataHotcueColorPalette =
-        ColorPalette(
-                QStringLiteral("Serato DJ Track Metadata Hotcue Colors"),
-                {
-                        kSeratoTrackMetadataHotcueColorRed,
-                        kSeratoTrackMetadataHotcueColorOrange,
-                        kSeratoTrackMetadataHotcueColorBrown,
-                        kSeratoTrackMetadataHotcueColorYellow,
-                        kSeratoTrackMetadataHotcueColorEmerald,
-                        kSeratoTrackMetadataHotcueColorKelly,
-                        kSeratoTrackMetadataHotcueColorGreen,
-                        kSeratoTrackMetadataHotcueColorSea,
-                        kSeratoTrackMetadataHotcueColorJade,
-                        kSeratoTrackMetadataHotcueColorTurquoise,
-                        kSeratoTrackMetadataHotcueColorTeal,
-                        kSeratoTrackMetadataHotcueColorBlue,
-                        kSeratoTrackMetadataHotcueColorDarkBlue,
-                        kSeratoTrackMetadataHotcueColorViolet,
-                        kSeratoTrackMetadataHotcueColorPurple,
-                        kSeratoTrackMetadataHotcueColorFuchsia,
-                        kSeratoTrackMetadataHotcueColorMagenta,
-                        kSeratoTrackMetadataHotcueColorCarmine,
-                },
-                {0, 2, 12, 3, 6, 15, 9, 14});
+const ColorPalette
+        PredefinedColorPalettes::kSeratoTrackMetadataHotcueColorPalette =
+                ColorPalette(QT_TRANSLATE_NOOP("PredefinedColorPalettes",
+                                     "Serato DJ Track Metadata Hotcue Colors"),
+                        {
+                                kSeratoTrackMetadataHotcueColorRed,
+                                kSeratoTrackMetadataHotcueColorOrange,
+                                kSeratoTrackMetadataHotcueColorBrown,
+                                kSeratoTrackMetadataHotcueColorYellow,
+                                kSeratoTrackMetadataHotcueColorEmerald,
+                                kSeratoTrackMetadataHotcueColorKelly,
+                                kSeratoTrackMetadataHotcueColorGreen,
+                                kSeratoTrackMetadataHotcueColorSea,
+                                kSeratoTrackMetadataHotcueColorJade,
+                                kSeratoTrackMetadataHotcueColorTurquoise,
+                                kSeratoTrackMetadataHotcueColorTeal,
+                                kSeratoTrackMetadataHotcueColorBlue,
+                                kSeratoTrackMetadataHotcueColorDarkBlue,
+                                kSeratoTrackMetadataHotcueColorViolet,
+                                kSeratoTrackMetadataHotcueColorPurple,
+                                kSeratoTrackMetadataHotcueColorFuchsia,
+                                kSeratoTrackMetadataHotcueColorMagenta,
+                                kSeratoTrackMetadataHotcueColorCarmine,
+                        },
+                        {0, 2, 12, 3, 6, 15, 9, 14});
 
 const ColorPalette PredefinedColorPalettes::kSeratoDJProHotcueColorPalette =
         ColorPalette(
-                QStringLiteral("Serato DJ Pro Hotcue Colors"),
+                QT_TRANSLATE_NOOP("PredefinedColorPalettes", "Serato DJ Pro Hotcue Colors"),
                 {
                         kSeratoDJProHotcueColorRed1,
                         kSeratoDJProHotcueColorOrange1,
@@ -347,25 +348,25 @@ const QList<mixxx::RgbColor> kRekordboxColorsSelection = {
 
 const ColorPalette PredefinedColorPalettes::kRekordboxCOLD1HotcueColorPalette =
         ColorPalette(
-                QStringLiteral("Rekordbox COLD1 Hotcue Colors"),
+                QT_TRANSLATE_NOOP("PredefinedColorPalettes", "Rekordbox COLD1 Hotcue Colors"),
                 kRekordboxColorsSelection,
                 {5, 8, 1, 6, 7, 2, 7, 5});
 
 const ColorPalette PredefinedColorPalettes::kRekordboxCOLD2HotcueColorPalette =
         ColorPalette(
-                QStringLiteral("Rekordbox COLD2 Hotcue Colors"),
+                QT_TRANSLATE_NOOP("PredefinedColorPalettes", "Rekordbox COLD2 Hotcue Colors"),
                 kRekordboxColorsSelection,
                 {7, 5, 5, 5, 3, 4, 3, 2});
 
 const ColorPalette PredefinedColorPalettes::kRekordboxCOLORFULHotcueColorPalette =
         ColorPalette(
-                QStringLiteral("Rekordbox COLORFUL Hotcue Colors"),
+                QT_TRANSLATE_NOOP("PredefinedColorPalettes", "Rekordbox COLORFUL Hotcue Colors"),
                 kRekordboxColorsSelection,
                 {15, 5, 10, 2, 8, 13, 4, 12});
 
 const ColorPalette PredefinedColorPalettes::kMixxxTrackColorPalette =
         ColorPalette(
-                QStringLiteral("Mixxx Track Colors"),
+                QT_TRANSLATE_NOOP("PredefinedColorPalettes", "Mixxx Track Colors"),
                 {
                         kMixxxTrackColorDarkRed,
                         kMixxxTrackColorRed,
@@ -390,7 +391,7 @@ const ColorPalette PredefinedColorPalettes::kMixxxTrackColorPalette =
 
 const ColorPalette PredefinedColorPalettes::kRekordboxTrackColorPalette =
         ColorPalette(
-                QStringLiteral("Rekordbox Track Colors"),
+                QT_TRANSLATE_NOOP("PredefinedColorPalettes", "Rekordbox Track Colors"),
                 {
                         kRekordboxTrackColorPink,
                         kRekordboxTrackColorRed,
@@ -404,7 +405,7 @@ const ColorPalette PredefinedColorPalettes::kRekordboxTrackColorPalette =
 
 const ColorPalette PredefinedColorPalettes::kSeratoDJProTrackColorPalette =
         ColorPalette(
-                QStringLiteral("Serato DJ Pro Track Colors"),
+                QT_TRANSLATE_NOOP("PredefinedColorPalettes", "Serato DJ Pro Track Colors"),
                 {
                         kSeratoDJProTrackColorGrey1,
                         kSeratoDJProTrackColorGrey2,
@@ -430,7 +431,7 @@ const ColorPalette PredefinedColorPalettes::kSeratoDJProTrackColorPalette =
 
 const ColorPalette PredefinedColorPalettes::kTraktorProTrackColorPalette =
         ColorPalette(
-                QStringLiteral("Traktor Pro Track Colors"),
+                QT_TRANSLATE_NOOP("PredefinedColorPalettes", "Traktor Pro Track Colors"),
                 {
                         kTraktorProTrackColorRed,
                         kTraktorProTrackColorOrange,
@@ -443,7 +444,7 @@ const ColorPalette PredefinedColorPalettes::kTraktorProTrackColorPalette =
 
 const ColorPalette PredefinedColorPalettes::kVirtualDJTrackColorPalette =
         ColorPalette(
-                QStringLiteral("VirtualDJ Track Colors"),
+                QT_TRANSLATE_NOOP("PredefinedColorPalettes", "VirtualDJ Track Colors"),
                 {
                         kVirtualDJTrackColorRed,
                         kVirtualDJTrackColorYellow,
@@ -456,7 +457,7 @@ const ColorPalette PredefinedColorPalettes::kVirtualDJTrackColorPalette =
 
 const ColorPalette PredefinedColorPalettes::kMixxxKeyColorPalette =
         ColorPalette(
-                QStringLiteral("Mixxx Key Colors"),
+                QT_TRANSLATE_NOOP("PredefinedColorPalettes", "Mixxx Key Colors"),
                 {
                         kMixxxKeyColor1,
                         kMixxxKeyColor2,
@@ -474,7 +475,7 @@ const ColorPalette PredefinedColorPalettes::kMixxxKeyColorPalette =
 
 const ColorPalette PredefinedColorPalettes::kTraktorKeyColorPalette =
         ColorPalette(
-                QStringLiteral("Traktor Key Colors"),
+                QT_TRANSLATE_NOOP("PredefinedColorPalettes", "Traktor Key Colors"),
                 {
                         kTraktorKeyColor1,
                         kTraktorKeyColor2,
@@ -492,7 +493,7 @@ const ColorPalette PredefinedColorPalettes::kTraktorKeyColorPalette =
 
 const ColorPalette PredefinedColorPalettes::kMIKKeyColorPalette =
         ColorPalette(
-                QStringLiteral("Mixed In Key - Key Colors"),
+                QT_TRANSLATE_NOOP("PredefinedColorPalettes", "Mixed In Key - Key Colors"),
                 {
                         kMIKKeyColor1,
                         kMIKKeyColor2,
@@ -510,7 +511,7 @@ const ColorPalette PredefinedColorPalettes::kMIKKeyColorPalette =
 
 const ColorPalette PredefinedColorPalettes::kProtKeyColorPalette =
         ColorPalette(
-                QStringLiteral("Protanopia / Protanomaly Key Colors"),
+                QT_TRANSLATE_NOOP("PredefinedColorPalettes", "Protanopia / Protanomaly Key Colors"),
                 {
                         kProtKeyColor1,
                         kProtKeyColor2,
@@ -527,8 +528,8 @@ const ColorPalette PredefinedColorPalettes::kProtKeyColorPalette =
                 });
 
 const ColorPalette PredefinedColorPalettes::kDeutKeyColorPalette =
-        ColorPalette(
-                QStringLiteral("Deuteranopia / Deuteranomaly Key Colors"),
+        ColorPalette(QT_TRANSLATE_NOOP("PredefinedColorPalettes",
+                             "Deuteranopia / Deuteranomaly Key Colors"),
                 {
                         kDeutKeyColor1,
                         kDeutKeyColor2,
@@ -546,7 +547,7 @@ const ColorPalette PredefinedColorPalettes::kDeutKeyColorPalette =
 
 const ColorPalette PredefinedColorPalettes::kTritKeyColorPalette =
         ColorPalette(
-                QStringLiteral("Tritanopia / Tritanomaly Key Colors"),
+                QT_TRANSLATE_NOOP("PredefinedColorPalettes", "Tritanopia / Tritanomaly Key Colors"),
                 {
                         kTritKeyColor1,
                         kTritKeyColor2,

--- a/src/util/color/predefinedcolorpalettes.cpp
+++ b/src/util/color/predefinedcolorpalettes.cpp
@@ -191,6 +191,53 @@ constexpr mixxx::RgbColor kMIKKeyColor10(0xFDA078);
 constexpr mixxx::RgbColor kMIKKeyColor11(0xFF8693);
 constexpr mixxx::RgbColor kMIKKeyColor12(0xFD7EB3);
 
+// Accessible Color Palettes
+
+// Protanopia / Protanomaly
+
+constexpr mixxx::RgbColor kProtKeyColor1(0x2626D9);
+constexpr mixxx::RgbColor kProtKeyColor2(0x7582D7);
+constexpr mixxx::RgbColor kProtKeyColor3(0xA7C2DD);
+constexpr mixxx::RgbColor kProtKeyColor4(0xB8E0E0);
+constexpr mixxx::RgbColor kProtKeyColor5(0xA7DDC2);
+constexpr mixxx::RgbColor kProtKeyColor6(0x75D782);
+constexpr mixxx::RgbColor kProtKeyColor7(0x26D926);
+constexpr mixxx::RgbColor kProtKeyColor8(0x0DA522);
+constexpr mixxx::RgbColor kProtKeyColor9(0x02783D);
+constexpr mixxx::RgbColor kProtKeyColor10(0x006666);
+constexpr mixxx::RgbColor kProtKeyColor11(0x023D78);
+constexpr mixxx::RgbColor kProtKeyColor12(0x0D22A5);
+
+// Deuteranopia / Deuteranomaly
+
+constexpr mixxx::RgbColor kDeutKeyColor1(0xD92626);
+constexpr mixxx::RgbColor kDeutKeyColor2(0xD77582);
+constexpr mixxx::RgbColor kDeutKeyColor3(0xDDA7C2);
+constexpr mixxx::RgbColor kDeutKeyColor4(0xE0B8E0);
+constexpr mixxx::RgbColor kDeutKeyColor5(0xC2A7DD);
+constexpr mixxx::RgbColor kDeutKeyColor6(0x8275D7);
+constexpr mixxx::RgbColor kDeutKeyColor7(0x2626D9);
+constexpr mixxx::RgbColor kDeutKeyColor8(0x220DA5);
+constexpr mixxx::RgbColor kDeutKeyColor9(0x3D0278);
+constexpr mixxx::RgbColor kDeutKeyColor10(0x660066);
+constexpr mixxx::RgbColor kDeutKeyColor11(0x78023D);
+constexpr mixxx::RgbColor kDeutKeyColor12(0xA50D22);
+
+// Deuteranopia / Deuteranomaly
+
+constexpr mixxx::RgbColor kTritKeyColor1(0x26D926);
+constexpr mixxx::RgbColor kTritKeyColor2(0x82D775);
+constexpr mixxx::RgbColor kTritKeyColor3(0xC2DDA7);
+constexpr mixxx::RgbColor kTritKeyColor4(0xE0E0B8);
+constexpr mixxx::RgbColor kTritKeyColor5(0xDDC2A7);
+constexpr mixxx::RgbColor kTritKeyColor6(0xD78275);
+constexpr mixxx::RgbColor kTritKeyColor7(0xD92626);
+constexpr mixxx::RgbColor kTritKeyColor8(0xA5220D);
+constexpr mixxx::RgbColor kTritKeyColor9(0x783D02);
+constexpr mixxx::RgbColor kTritKeyColor10(0x666600);
+constexpr mixxx::RgbColor kTritKeyColor11(0x3D7802);
+constexpr mixxx::RgbColor kTritKeyColor12(0x22A50D);
+
 // Replaces "no color" values and is used for new cues if auto_hotcue_colors is
 // disabled
 constexpr mixxx::RgbColor kSchemaMigrationReplacementColor(0xFF8000);
@@ -458,6 +505,60 @@ const ColorPalette PredefinedColorPalettes::kMIKKeyColorPalette =
                         kMIKKeyColor12,
                 });
 
+const ColorPalette PredefinedColorPalettes::kProtKeyColorPalette =
+        ColorPalette(
+                QStringLiteral("Protanopia / Protanomaly Key Colors"),
+                {
+                        kProtKeyColor1,
+                        kProtKeyColor2,
+                        kProtKeyColor3,
+                        kProtKeyColor4,
+                        kProtKeyColor5,
+                        kProtKeyColor6,
+                        kProtKeyColor7,
+                        kProtKeyColor8,
+                        kProtKeyColor9,
+                        kProtKeyColor10,
+                        kProtKeyColor11,
+                        kProtKeyColor12,
+                });
+
+const ColorPalette PredefinedColorPalettes::kDeutKeyColorPalette =
+        ColorPalette(
+                QStringLiteral("Deuteranopia / Deuteranomaly Key Colors"),
+                {
+                        kDeutKeyColor1,
+                        kDeutKeyColor2,
+                        kDeutKeyColor3,
+                        kDeutKeyColor4,
+                        kDeutKeyColor5,
+                        kDeutKeyColor6,
+                        kDeutKeyColor7,
+                        kDeutKeyColor8,
+                        kDeutKeyColor9,
+                        kDeutKeyColor10,
+                        kDeutKeyColor11,
+                        kDeutKeyColor12,
+                });
+
+const ColorPalette PredefinedColorPalettes::kTritKeyColorPalette =
+        ColorPalette(
+                QStringLiteral("Tritanopia / Tritanomaly Key Colors"),
+                {
+                        kTritKeyColor1,
+                        kTritKeyColor2,
+                        kTritKeyColor3,
+                        kTritKeyColor4,
+                        kTritKeyColor5,
+                        kTritKeyColor6,
+                        kTritKeyColor7,
+                        kTritKeyColor8,
+                        kTritKeyColor9,
+                        kTritKeyColor10,
+                        kTritKeyColor11,
+                        kTritKeyColor12,
+                });
+
 const ColorPalette PredefinedColorPalettes::kDefaultHotcueColorPalette =
         mixxx::PredefinedColorPalettes::kMixxxHotcueColorPalette;
 
@@ -484,6 +585,9 @@ const QList<ColorPalette> PredefinedColorPalettes::kPalettes{
         mixxx::PredefinedColorPalettes::kMixxxKeyColorPalette,
         mixxx::PredefinedColorPalettes::kTraktorKeyColorPalette,
         mixxx::PredefinedColorPalettes::kMIKKeyColorPalette,
+        mixxx::PredefinedColorPalettes::kProtKeyColorPalette,
+        mixxx::PredefinedColorPalettes::kDeutKeyColorPalette,
+        mixxx::PredefinedColorPalettes::kTritKeyColorPalette,
 };
 
 const mixxx::RgbColor PredefinedColorPalettes::kDefaultCueColor =

--- a/src/util/color/predefinedcolorpalettes.cpp
+++ b/src/util/color/predefinedcolorpalettes.cpp
@@ -159,6 +159,38 @@ constexpr mixxx::RgbColor kMixxxKeyColor10(0x3D8AFD);
 constexpr mixxx::RgbColor kMixxxKeyColor11(0xAC64FE);
 constexpr mixxx::RgbColor kMixxxKeyColor12(0xFD3FEA);
 
+// Traktor Key Color Palette
+// NOTE: C Major is 1d in Open Key Notation
+
+constexpr mixxx::RgbColor kTraktorKeyColor1(0xB960A2);
+constexpr mixxx::RgbColor kTraktorKeyColor2(0x8269AB);
+constexpr mixxx::RgbColor kTraktorKeyColor3(0x527FC0);
+constexpr mixxx::RgbColor kTraktorKeyColor4(0x3CC0EF);
+constexpr mixxx::RgbColor kTraktorKeyColor5(0x5BC1CE);
+constexpr mixxx::RgbColor kTraktorKeyColor6(0x4CB686);
+constexpr mixxx::RgbColor kTraktorKeyColor7(0x73B629);
+constexpr mixxx::RgbColor kTraktorKeyColor8(0x9FC516);
+constexpr mixxx::RgbColor kTraktorKeyColor9(0xFDD615);
+constexpr mixxx::RgbColor kTraktorKeyColor10(0xF28B2E);
+constexpr mixxx::RgbColor kTraktorKeyColor11(0xEC6637);
+constexpr mixxx::RgbColor kTraktorKeyColor12(0xE84C4D);
+
+// Mixed In Key Key Color Palette
+// NOTE: C Major is 8B in Camelot Notation
+
+constexpr mixxx::RgbColor kMIKKeyColor1(0xF17EDB);
+constexpr mixxx::RgbColor kMIKKeyColor2(0xD18BFD);
+constexpr mixxx::RgbColor kMIKKeyColor3(0x9EB4FD);
+constexpr mixxx::RgbColor kMIKKeyColor4(0x4DD3F8);
+constexpr mixxx::RgbColor kMIKKeyColor5(0x01EAEC);
+constexpr mixxx::RgbColor kMIKKeyColor6(0x00EECB);
+constexpr mixxx::RgbColor kMIKKeyColor7(0x20EF7F);
+constexpr mixxx::RgbColor kMIKKeyColor8(0x7FF448);
+constexpr mixxx::RgbColor kMIKKeyColor9(0xE0CA6D);
+constexpr mixxx::RgbColor kMIKKeyColor10(0xFDA078);
+constexpr mixxx::RgbColor kMIKKeyColor11(0xFF8693);
+constexpr mixxx::RgbColor kMIKKeyColor12(0xFD7EB3);
+
 // Replaces "no color" values and is used for new cues if auto_hotcue_colors is
 // disabled
 constexpr mixxx::RgbColor kSchemaMigrationReplacementColor(0xFF8000);
@@ -390,6 +422,42 @@ const ColorPalette PredefinedColorPalettes::kMixxxKeyColorPalette =
                         kMixxxKeyColor12,
                 });
 
+const ColorPalette PredefinedColorPalettes::kTraktorKeyColorPalette =
+        ColorPalette(
+                QStringLiteral("Traktor Key Colors"),
+                {
+                        kTraktorKeyColor1,
+                        kTraktorKeyColor2,
+                        kTraktorKeyColor3,
+                        kTraktorKeyColor4,
+                        kTraktorKeyColor5,
+                        kTraktorKeyColor6,
+                        kTraktorKeyColor7,
+                        kTraktorKeyColor8,
+                        kTraktorKeyColor9,
+                        kTraktorKeyColor10,
+                        kTraktorKeyColor11,
+                        kTraktorKeyColor12,
+                });
+
+const ColorPalette PredefinedColorPalettes::kMIKKeyColorPalette =
+        ColorPalette(
+                QStringLiteral("Mixed In Key - Key Colors"),
+                {
+                        kMIKKeyColor1,
+                        kMIKKeyColor2,
+                        kMIKKeyColor3,
+                        kMIKKeyColor4,
+                        kMIKKeyColor5,
+                        kMIKKeyColor6,
+                        kMIKKeyColor7,
+                        kMIKKeyColor8,
+                        kMIKKeyColor9,
+                        kMIKKeyColor10,
+                        kMIKKeyColor11,
+                        kMIKKeyColor12,
+                });
+
 const ColorPalette PredefinedColorPalettes::kDefaultHotcueColorPalette =
         mixxx::PredefinedColorPalettes::kMixxxHotcueColorPalette;
 
@@ -414,6 +482,8 @@ const QList<ColorPalette> PredefinedColorPalettes::kPalettes{
         mixxx::PredefinedColorPalettes::kVirtualDJTrackColorPalette,
         // Key Color Palettes
         mixxx::PredefinedColorPalettes::kMixxxKeyColorPalette,
+        mixxx::PredefinedColorPalettes::kTraktorKeyColorPalette,
+        mixxx::PredefinedColorPalettes::kMIKKeyColorPalette,
 };
 
 const mixxx::RgbColor PredefinedColorPalettes::kDefaultCueColor =

--- a/src/util/color/predefinedcolorpalettes.cpp
+++ b/src/util/color/predefinedcolorpalettes.cpp
@@ -192,6 +192,9 @@ constexpr mixxx::RgbColor kMIKKeyColor11(0xFF8693);
 constexpr mixxx::RgbColor kMIKKeyColor12(0xFD7EB3);
 
 // Accessible Color Palettes
+// When arranged in a circle, the hue varies vertically and lightness/saturation
+// varies horizontally so that every color is unique, but adjacent colors are
+// similar.
 
 // Protanopia / Protanomaly
 

--- a/src/util/color/predefinedcolorpalettes.h
+++ b/src/util/color/predefinedcolorpalettes.h
@@ -19,6 +19,8 @@ class PredefinedColorPalettes {
     static const ColorPalette kVirtualDJTrackColorPalette;
 
     static const ColorPalette kMixxxKeyColorPalette;
+    static const ColorPalette kTraktorKeyColorPalette;
+    static const ColorPalette kMIKKeyColorPalette;
 
     static const ColorPalette kDefaultHotcueColorPalette;
     static const ColorPalette kDefaultTrackColorPalette;

--- a/src/util/color/predefinedcolorpalettes.h
+++ b/src/util/color/predefinedcolorpalettes.h
@@ -21,6 +21,9 @@ class PredefinedColorPalettes {
     static const ColorPalette kMixxxKeyColorPalette;
     static const ColorPalette kTraktorKeyColorPalette;
     static const ColorPalette kMIKKeyColorPalette;
+    static const ColorPalette kProtKeyColorPalette;
+    static const ColorPalette kDeutKeyColorPalette;
+    static const ColorPalette kTritKeyColorPalette;
 
     static const ColorPalette kDefaultHotcueColorPalette;
     static const ColorPalette kDefaultTrackColorPalette;


### PR DESCRIPTION
This PR adds color palette support for the Key Colors that were added in #13390. 

New third party key palettes:
- Traktor
- Mixed In Key

New accessible key palettes:
- Protanopia / Protanomaly
- Deuteranopia / Deuteranomaly
- Tritanopia / Tritanomaly

### Screenshots

![image](https://github.com/user-attachments/assets/c92199a4-8724-40ef-833d-47e2e900980e)

(Tritanopia Palette)

![image](https://github.com/user-attachments/assets/37d0a827-dab0-459c-8042-22dc40c7c1c6)

