### PR TITLE
CoreServices: Default to `~/Music` as a music directory on Wasm and iOS

### DIFF
--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -380,6 +380,18 @@ void CoreServices::initialize(QApplication* pApp) {
     bool musicDirAdded = false;
 
     if (m_pTrackCollectionManager->internalCollection()->loadRootDirs().isEmpty()) {
+#if defined(Q_OS_IOS) || defined(Q_OS_WASM)
+        // On the web and iOS, we are running in a sandbox (a virtual file
+        // system on the web). Since we are generally limited to this sandbox,
+        // there is not much point in asking the user, so we just default to
+        // ~/Music within it (creating it since it usually does not exist).
+        // Advanced users can still customize this directory in the settings.
+        QString fd = QStandardPaths::writableLocation(QStandardPaths::MusicLocation);
+        QDir dir = fd;
+        if (!dir.exists()) {
+            dir.mkpath(".");
+        }
+#else
         // TODO(XXX) this needs to be smarter, we can't distinguish between an empty
         // path return value (not sure if this is normally possible, but it is
         // possible with the Windows 7 "Music" library, which is what
@@ -391,6 +403,7 @@ void CoreServices::initialize(QApplication* pApp) {
                 tr("Choose music library directory"),
                 QStandardPaths::writableLocation(
                         QStandardPaths::MusicLocation));
+#endif
         // request to add directory to database.
         if (!fd.isEmpty() && m_pLibrary->requestAddDir(fd)) {
             musicDirAdded = true;

--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -382,9 +382,11 @@ void CoreServices::initialize(QApplication* pApp) {
     if (m_pTrackCollectionManager->internalCollection()->loadRootDirs().isEmpty()) {
 #if defined(Q_OS_IOS) || defined(Q_OS_WASM)
         // On the web and iOS, we are running in a sandbox (a virtual file
-        // system on the web). Since we are generally limited to this sandbox,
-        // there is not much point in asking the user, so we just default to
-        // ~/Music within it (creating it since it usually does not exist).
+        // system on the web). Since we are generally limited to paths within
+        // the sandbox, there is not much point in asking the user about a
+        // custom directory, so we just default to Qt's standard music directory
+        // (~/Documents/Music on iOS and ~/Music on Wasm). Since the sandbox is
+        // initially empty, we create that directory automatically.
         // Advanced users can still customize this directory in the settings.
         QString fd = QStandardPaths::writableLocation(QStandardPaths::MusicLocation);
         QDir dir = fd;


### PR DESCRIPTION
Both on the web and on iOS we are running in a sandbox that is generally empty on first launch, so there is not much point in asking the user for a directory. To simplify the UX, this PR proposes to create a music directory at the standard path and use it as a default music directory.

A (potentially undesirable?) side effect of this is that `~/Music` is an ancestor of the default recordings directory at `~/Music/Mixxx/Recordings`, so recordings will show up in the main library.

Maybe just ensuring that `~/Music` exists would already be enough to improve the UX here? On iOS this directory doesn't exist in the sandbox, so the directory picker initially points to the sandbox home instead, which could be confusing for new users.