### PR TITLE
ControllerRenderingEngine: Disable BGRA when targeting Wasm

### DIFF
--- a/src/controllers/rendering/controllerrenderingengine.cpp
+++ b/src/controllers/rendering/controllerrenderingengine.cpp
@@ -74,7 +74,16 @@ ControllerRenderingEngine::ControllerRenderingEngine(
         m_GLDataType = GL_UNSIGNED_BYTE;
         break;
     case QImage::Format_RGBA8888:
-        m_GLDataFormat = m_screenInfo.reversedColor ? GL_BGRA : GL_RGBA;
+        if (m_screenInfo.reversedColor) {
+#ifdef __EMSCRIPTEN__
+            m_isValid = false;
+            kLogger.critical() << "Reversed RGBA format is not supported in Emscripten/WebAssembly";
+#else
+            m_GLDataFormat = GL_BGRA;
+#endif
+        } else {
+            m_GLDataFormat = GL_RGBA;
+        }
         m_GLDataType = GL_UNSIGNED_BYTE;
         break;
     default:


### PR DESCRIPTION
This seems to be [be unavailable when targeting WebAssembly/Emscripten](https://github.com/fwcd/m1xxx/actions/runs/10043820520/job/27757434901), even though we [already require WebGL 2.0](https://github.com/mixxxdj/mixxx/blob/a9b3e7f5d4e7285e65f665537bdc13af934586cf/CMakeLists.txt#L2598-L2601), which is a subset of OpenGL ES 3.0:

```
/home/runner/work/m1xxx/m1xxx/mixxx/src/controllers/rendering/controllerrenderingengine.cpp:77:55: error: use of undeclared identifier 'GL_BGRA'
   77 |         m_GLDataFormat = m_screenInfo.reversedColor ? GL_BGRA : GL_RGBA;
      |                                                       ^
1 error generated.
```

Since other OpenGL ES implementations (e.g. iOS) do implement this extension, I have scoped it to non-Emscripten-platforms. Otherwise this follows the approach taken in #13382.