### PR TITLE
clang-format: Indent Objective-C blocks with 4 spaces

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -41,6 +41,7 @@ StatementMacros:
   - QT_REQUIRE_VERSION
 ---
 Language: ObjC
+ObjCBlockIndentWidth: 4
 # We exclude Objective-C(++) from the second line-wrapping pass in tools/clang_format.py
 # since this pass only applies C++ rules and therefore include the ColumnLimit in the
 # 'main' clang-format config here.


### PR DESCRIPTION
The default indent width of Objective-C blocks (the Objective-C equivalent of lambdas) in clang-format seems to be 2 spaces. For consistency this PR sets this indent width to 4 spaces too.

This PR forms the base for other PRs that use Objective-C blocks:

- #4809
- #12690