### PR TITLE
fix(basetracktablemodel): Fix `-Wimplicit-fallthrough` warning on GCC 14.1.1

### DIFF
--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -1033,11 +1033,10 @@ QVariant BaseTrackTableModel::roleValue(
             // return whether or not to display the color rectangle
             return QVariant::fromValue(s_keyColorsEnabled);
         }
-        default: {
+        default:
             DEBUG_ASSERT(!"unexpected field for UserRole");
-            break;
         }
-        }
+        break;
     }
     default:
         DEBUG_ASSERT(!"unexpected role");


### PR DESCRIPTION
Fixes the following warning:

    src/library/basetracktablemodel.cpp: In member function ‘QVariant BaseTrackTableModel::roleValue(const QModelIndex&, QVariant&&, int) const’:
    src/library/basetracktablemodel.cpp:1031:9: error: this statement may fall through [-Werror=implicit-fallthrough=]
     1031 |         switch (field) {
          |         ^~~~~~
    src/library/basetracktablemodel.cpp:1042:5: note: here
     1042 |     default:
          |     ^~~~~~~
    cc1plus: all warnings being treated as errors

This seems to be a false-positive, but this commit should fix the issue without any changes to the behavior.