### PR TITLE
Add float widget to control stem UI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3457,6 +3457,7 @@ if (STEM)
     src/sources/soundsourcestem.cpp
     src/track/steminfoimporter.cpp
     src/track/steminfo.cpp
+    src/widget/wstemcontrol.cpp
   )
   if(QOPENGL)
     target_sources(mixxx-lib PRIVATE

--- a/res/skins/Deere/deck.xml
+++ b/res/skins/Deere/deck.xml
@@ -38,7 +38,7 @@
                     <Children>
                       <Template src="skins:Deere/deck_spinny.xml">
                         <SetVariable name="cover">true</SetVariable>
-                        <SetVariable name="Size">55f,55f</SetVariable>
+                        <SetVariable name="Size">68f,68f</SetVariable>
                       </Template>
                     </Children>
                   </WidgetGroup>
@@ -51,7 +51,7 @@
                     <Children>
                       <Template src="skins:Deere/deck_spinny.xml">
                         <SetVariable name="cover">false</SetVariable>
-                        <SetVariable name="Size">55f,55f</SetVariable>
+                        <SetVariable name="Size">68f,68f</SetVariable>
                       </Template>
                     </Children>
                   </WidgetGroup>

--- a/res/skins/Deere/deck_waveform.xml
+++ b/res/skins/Deere/deck_waveform.xml
@@ -128,6 +128,41 @@
         - if a MIDI device which supports more hotcues than buttons are in the current skin has them activated
         - if you change from a skin which supports more hotcues than buttons are in the current skin (and has them activated)
         -->
+        <StemControl alignment="left">
+          <MinimumSize>138,68</MinimumSize>
+          <MaximumSize>158,1920</MaximumSize>
+          <SizePolicy>me,me</SizePolicy>
+          <Stem>
+            <MinimumSize>130,17</MinimumSize>
+            <MaximumSize>150,1920</MaximumSize>
+            <SizePolicy>me,min</SizePolicy>
+            <Layout>horizontal</Layout>
+            <Children>
+              <Label>
+                <ObjectName>stem_label</ObjectName>
+                <SizePolicy>e,max</SizePolicy>
+              </Label>
+              <KnobComposed>
+                <Pos>0,0</Pos>
+                <MinimumSize>20,17</MinimumSize>
+                <MaximumSize>40,34</MaximumSize>
+                <SizePolicy>me,me</SizePolicy>
+                <Knob>knob.svg</Knob>
+                <BackPath>knob_bg_blue.svg</BackPath>
+                <MinAngle>-135</MinAngle>
+                <MaxAngle>135</MaxAngle>
+                <KnobCenterYOffset>1.602</KnobCenterYOffset>
+                <Connection>
+                  <ConfigKey><Variable name="StemGroup"/>,volume</ConfigKey>
+                </Connection>
+              </KnobComposed>
+            </Children>
+          </Stem>
+          <Connection>
+            <ConfigKey persist="true">[Skin],show_stem_controls</ConfigKey>
+            <BindProperty>displayed</BindProperty>
+          </Connection>
+        </StemControl>
       </Visual>
 
       <WidgetGroup>

--- a/res/skins/Deere/skin_settings.xml
+++ b/res/skins/Deere/skin_settings.xml
@@ -61,6 +61,11 @@
             <SetVariable name="skinsetting">[Skin],show_4decks</SetVariable>
           </Template>
 
+          <Template src="skins:Deere/skinsettings_button.xml">
+            <SetVariable name="TooltipId">show_stem_controls</SetVariable>
+            <SetVariable name="text">Show stem controls</SetVariable>
+            <SetVariable name="skinsetting">[Skin],show_stem_controls</SetVariable>
+          </Template>
         </Children>
       </WidgetGroup>
 

--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -1432,11 +1432,6 @@ WWidget, WLabel {
   font-size: 12px;
 }
 
-/* Track text, etc. should be in the deck color. */
-#Deck1 WLabel, #Deck2 WLabel, #Deck3 WLabel, #Deck4 WLabel {
-  color: #D2D2D2;
-}
-
 WNumberRate {
   font-size: 13px;
 }
@@ -2455,4 +2450,18 @@ WRateRange {
 }
 #RateDisplayBottomRate {
     qproperty-alignment: 'AlignRight | AlignBottom';
+}
+
+/** Stem control **/
+WStemControlBox {
+  background-color: transparent;
+}
+WStemControl WLabel {
+  color: #222222;
+  padding-left: 5px;
+  font-weight: 500;
+  font-size: 14px;
+}
+WStemControl {
+  margin: 10px 15px 10px 15px;
 }

--- a/res/skins/LateNight/skin.xml
+++ b/res/skins/LateNight/skin.xml
@@ -41,6 +41,7 @@
       <attribute config_key="[App],num_samplers">16</attribute>
       <attribute persist="true" config_key="[Skin],show_waveforms">1</attribute>
       <attribute persist="true" config_key="[Skin],timing_shift_buttons">0</attribute>
+      <attribute persist="true" config_key="[Skin],show_stem_controls">0</attribute>
 
     <!-- Decks -->
       <!-- general -->
@@ -63,6 +64,7 @@
       <attribute persist="true" config_key="[Skin],show_rate_controls">1</attribute>
       <attribute persist="true" config_key="[Skin],show_rate_control_buttons">1</attribute>
       <attribute persist="true" config_key="[Skin],show_beatgrid_controls">1</attribute>
+      <attribute persist="true" config_key="[Skin],show_stem_controls">1</attribute>
       <!-- Compact deck -->
       <attribute persist="true" config_key="[Skin],show_rate_controls_compact">1</attribute>
       <attribute persist="true" config_key="[Skin],show_loop_controls_compact">1</attribute>

--- a/res/skins/LateNight/skin_settings.xml
+++ b/res/skins/LateNight/skin_settings.xml
@@ -266,6 +266,26 @@ Description:
 
                     </Children>
                   </WidgetGroup>
+
+                  <!-- Stem control over the waveform -->
+                  <WidgetGroup>
+                    <ObjectName>SkinSettingsCategory</ObjectName>
+                    <SizePolicy>me,f</SizePolicy>
+                    <Layout>stacked</Layout>
+                    <Children>
+                      <!-- translucent cover when waveforms are hidden -->
+                      <Template src="skins:LateNight/helpers/skin_settings_cover_inverted.xml">
+                        <SetVariable name="Setting">[Skin],show_waveforms</SetVariable>
+                      </Template>
+
+                      <Template src="skins:LateNight/helpers/skin_settings_button_2state.xml">
+                        <SetVariable name="TooltipId">show_stem_controls</SetVariable>
+                        <SetVariable name="Text">Stem control</SetVariable>
+                        <SetVariable name="Setting">[Skin],show_stem_controls</SetVariable>
+                      </Template>
+
+                    </Children>
+                  </WidgetGroup>
                 </Children>
               </WidgetGroup>
             </Children>

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -3208,3 +3208,18 @@ WSearchLineEdit::indicator:unchecked:selected {
 }
 /************** common styles for WEffectSelector ******************************
 *************** QSpinBox, QMenu, QToolTip *************************************/
+
+/** Stem control **/
+WStemControlBox {
+  padding-left: 8px;
+  background-color: transparent;
+}
+WStemControl WLabel {
+  padding-left: 5px;
+  font-weight: 500;
+  font-size: 14px;
+}
+WStemControl {
+  border-radius: 7px;
+  opacity: 0.2;
+}

--- a/res/skins/LateNight/waveform.xml
+++ b/res/skins/LateNight/waveform.xml
@@ -137,6 +137,45 @@
               <Color><Variable name="IntroOutroColor"/></Color>
               <TextColor>#FFFFFF</TextColor>
             </Mark>
+            <StemControl alignment="left">
+              <MinimumSize>138,68</MinimumSize>
+              <MaximumSize>158,1920</MaximumSize>
+              <SizePolicy>me,me</SizePolicy>
+              <Stem>
+                <MinimumSize>130,17</MinimumSize>
+                <MaximumSize>150,34</MaximumSize>
+                <SizePolicy>me,min</SizePolicy>
+                <Layout>horizontal</Layout>
+                <Children>
+                  <Label>
+                    <ObjectName>stem_label</ObjectName>
+                    <SizePolicy>e,max</SizePolicy>
+                  </Label>
+                  <KnobComposed>
+                    <Pos>0,0</Pos>
+                    <MinimumSize>20,17</MinimumSize>
+                    <MaximumSize>40,34</MaximumSize>
+                    <SizePolicy>me,me</SizePolicy>
+                    <Knob>skins:LateNight/<Variable name="KnobScheme"/>/knobs/knob_indicator_regular_<Variable name="KnobColorEq"/>.svg</Knob>
+                    <BackPath>skins:LateNight/<Variable name="KnobScheme"/>/knobs/knob_bg_regular.svg</BackPath>
+                    <MinAngle><Variable name="PotiMinAngle"/></MinAngle>
+                    <MaxAngle><Variable name="PotiMaxAngle"/></MaxAngle>
+                    <ArcRadius><Variable name="ArcRadius"/></ArcRadius>
+                    <ArcThickness><Variable name="ArcThickness"/></ArcThickness>
+                    <ArcColor><Variable name="ArcColorEq"/></ArcColor>
+                    <ArcRoundCaps><Variable name="ArcRoundCaps"/></ArcRoundCaps>
+                    <KnobCenterYOffset>1.998</KnobCenterYOffset>
+                    <Connection>
+                      <ConfigKey><Variable name="StemGroup"/>,volume</ConfigKey>
+                    </Connection>
+                  </KnobComposed>
+                </Children>
+              </Stem>
+              <Connection>
+                <ConfigKey persist="true">[Skin],show_stem_controls</ConfigKey>
+                <BindProperty>displayed</BindProperty>
+              </Connection>
+            </StemControl>
           </Visual>
         </Children>
         <Connection>

--- a/res/skins/Shade/deck.xml
+++ b/res/skins/Shade/deck.xml
@@ -148,19 +148,19 @@
                   </WidgetGroup><!-- Cover art / Artist/title / Playposition -->
                   <WidgetGroup><!-- Scrolling waveform / Spinny / Vinyl controls -->
                     <ObjectName>DeckUpperLeftMidPart</ObjectName>
-                    <Size>0e,81f</Size>
+                    <Size>0e,91f</Size>
                     <Layout>horizontal</Layout>
                     <Children>
                       <WidgetGroup>
                         <ObjectName>DeckUpperMidPart</ObjectName>
-                        <Size>0e,81f</Size>
+                        <Size>0e,91f</Size>
                         <BackPath>style/style_bg_deck_pane.png</BackPath>
                         <Layout>horizontal</Layout>
                         <Children>
                           <!-- Collapsing Waveform, VinylControl & spinning Vinyl widget-->
                           <WidgetGroup>
                             <ObjectName>DeckWaveformVinylControlSpinny</ObjectName>
-                            <Size>0e,81f</Size>
+                            <Size>0e,91f</Size>
                             <Layout>horizontal</Layout>
                             <Children>
                               <!--If you want the waveforms center to adjust when resizing in a collapsing widget
@@ -179,7 +179,7 @@
                               -->
                               <WidgetGroup>
                                 <Layout>horizontal</Layout>
-                                <Size>0e,81f</Size>
+                                <Size>0e,91f</Size>
                                 <Children>
                                   <Template src="skin:waveform.xml"/>
                                 </Children>
@@ -191,7 +191,7 @@
                                 <Children>
                                   <!-- Spinning Vinyl sub-widget -->
                                   <WidgetGroup>
-                                    <Size>81f,81f</Size>
+                                    <Size>91f,91f</Size>
                                     <Layout>horizontal</Layout>
                                     <Children>
                                       <!--
@@ -201,7 +201,7 @@
                                       -->
                                       <Spinny>
                                         <TooltipId>spinny</TooltipId>
-                                        <Size>81f,81f</Size>
+                                        <Size>91f,91f</Size>
                                         <Channel><Variable name="channum"/></Channel>
                                         <PathBackground scalemode="STRETCH_ASPECT">vinyl_spinny_background.png</PathBackground>
                                         <PathForeground scalemode="STRETCH_ASPECT">vinyl_spinny_foreground.png</PathForeground>

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -1047,3 +1047,19 @@ WRateRange {
   font-size: 10px;
   qproperty-alignment: 'AlignCenter';
 }
+
+/** Stem control **/
+WStemControlBox {
+  background-color: transparent;
+}
+WStemControl WLabel {
+  padding-left: 5px;
+  font-weight: bold;
+  font-size: 14px;
+}
+WStemControl WKnob {
+  background-color: #717171;
+}
+WStemControl {
+  margin: 10px 15px 10px 15px;
+}

--- a/res/skins/Shade/style_dark.qss
+++ b/res/skins/Shade/style_dark.qss
@@ -288,3 +288,19 @@ WTrackTableViewHeader::down-arrow {
 WRateRange {
   color: #181319;
 }
+
+/** Stem control **/
+WStemControlBox {
+  background-color: transparent;
+}
+WStemControl WLabel {
+  padding-left: 5px;
+  font-weight: bold;
+  font-size: 14px;
+}
+WStemControl WKnob {
+  background-color: #aab2b7;
+}
+WStemControl {
+  margin: 10px 15px 10px 15px;
+}

--- a/res/skins/Shade/style_summer_sunset.qss
+++ b/res/skins/Shade/style_summer_sunset.qss
@@ -198,3 +198,19 @@ QPushButton#pushButtonAnalyze:hover {
 WRateRange {
   color: #4B515F;
 }
+
+/** Stem control **/
+WStemControlBox {
+  background-color: transparent;
+}
+WStemControl WLabel {
+  padding-left: 5px;
+  font-weight: bold;
+  font-size: 14px;
+}
+WStemControl WKnob {
+  background-color: #d9c663;
+}
+WStemControl {
+  margin: 10px 15px 10px 15px;
+}

--- a/res/skins/Shade/waveform.xml
+++ b/res/skins/Shade/waveform.xml
@@ -108,5 +108,35 @@
     - if you change from a skin which supports more hotcues
       than buttons are in the current skin (and has them activated)
     -->
+    <StemControl alignment="right">
+      <MinimumSize>138,68</MinimumSize>
+      <MaximumSize>158,1920</MaximumSize>
+      <SizePolicy>me,me</SizePolicy>
+      <Stem>
+        <MinimumSize>130,17</MinimumSize>
+        <MaximumSize>150,1920</MaximumSize>
+        <SizePolicy>me,min</SizePolicy>
+        <Layout>horizontal</Layout>
+        <Children>
+          <Label>
+            <ObjectName>stem_label</ObjectName>
+            <SizePolicy>e,max</SizePolicy>
+          </Label>
+          <Knob>
+            <TooltipId>main_gain</TooltipId>
+            <NumberStates>64</NumberStates>
+            <Path>knobs_no_center/knob_rotary_s%1.png</Path>
+            <Pos>151,15</Pos>
+            <Connection>
+              <ConfigKey><Variable name="StemGroup"/>,volume</ConfigKey>
+            </Connection>
+          </Knob>
+        </Children>
+      </Stem>
+      <Connection>
+        <ConfigKey persist="true">[Skin],show_stem_controls</ConfigKey>
+        <BindProperty>displayed</BindProperty>
+      </Connection>
+    </StemControl>
   </Visual>
 </Template>

--- a/res/skins/Tango/skin_settings.xml
+++ b/res/skins/Tango/skin_settings.xml
@@ -64,6 +64,11 @@ Description:
           </Template>
 
           <Template src="skins:Tango/controls/skin_settings_button_2state.xml">
+            <SetVariable name="text">Show stem control</SetVariable>
+            <SetVariable name="Setting">[Skin],show_stem_controls</SetVariable>
+          </Template>
+
+          <Template src="skins:Tango/controls/skin_settings_button_2state.xml">
             <SetVariable name="text">Symmetric Time/Duration</SetVariable>
             <SetVariable name="Setting">[Tango],symmetric_time</SetVariable>
           </Template>

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -3223,3 +3223,17 @@ WRateRange {
 #RateDisplayBottomRate {
     qproperty-alignment: 'AlignHCenter';
 }
+
+/** Stem control **/
+WStemControlBox {
+  padding-left: 8px;
+  background-color: transparent;
+}
+WStemControl WLabel {
+  padding-left: 5px;
+  font-weight: bold;
+  font-size: 14px;
+}
+WStemControl {
+  margin: 10px 15px 10px 15px;
+}

--- a/res/skins/Tango/waveform.xml
+++ b/res/skins/Tango/waveform.xml
@@ -124,6 +124,41 @@ Variables:
           - if you change from a skin which supports more hotcues than buttons are in the current skin
           (and has them activated)
         -->
+        <StemControl alignment="left">
+          <MinimumSize>138,68</MinimumSize>
+          <MaximumSize>158,1920</MaximumSize>
+          <SizePolicy>me,me</SizePolicy>
+          <Stem>
+            <MinimumSize>130,17</MinimumSize>
+            <MaximumSize>150,34</MaximumSize>
+            <SizePolicy>me,min</SizePolicy>
+            <Layout>horizontal</Layout>
+            <Children>
+              <Label>
+                <ObjectName>stem_label</ObjectName>
+                <SizePolicy>e,max</SizePolicy>
+              </Label>
+              <KnobComposed>
+                <Pos>0,0</Pos>
+                <MinimumSize>20,17</MinimumSize>
+                <MaximumSize>40,34</MaximumSize>
+                <SizePolicy>me,me</SizePolicy>
+                <Knob>skins:Tango/knobs_sliders/knob_blue.svg</Knob>
+                <BackPath>skins:Tango/knobs_sliders/knob_bg.svg</BackPath>
+                <MinAngle><Variable name="PotiMinAngle"/></MinAngle>
+                <MaxAngle><Variable name="PotiMaxAngle"/></MaxAngle>
+                <KnobCenterYOffset>2.000</KnobCenterYOffset>
+                <Connection>
+                  <ConfigKey><Variable name="StemGroup"/>,volume</ConfigKey>
+                </Connection>
+              </KnobComposed>
+            </Children>
+          </Stem>
+          <Connection>
+            <ConfigKey persist="true">[Skin],show_stem_controls</ConfigKey>
+            <BindProperty>displayed</BindProperty>
+          </Connection>
+        </StemControl>
       </Visual>
 
       <WidgetGroup><!-- Transparent container for beatgrid buttons -->

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -65,9 +65,9 @@ int runMixxx(MixxxApplication* pApp, const CmdlineArgs& args) {
         // This scope ensures that `MixxxMainWindow` is destroyed *before*
         // CoreServices is shut down. Otherwise a debug assertion complaining about
         // leaked COs may be triggered.
-        MixxxMainWindow mainWindow(pCoreServices);
+        MixxxMainWindow* pMainWindow = MixxxMainWindow::createInstance(pCoreServices);
         pApp->processEvents();
-        pApp->installEventFilter(&mainWindow);
+        pApp->installEventFilter(pMainWindow);
 
 #if defined(__WINDOWS__)
         WindowsEventHandler winEventHandler;
@@ -76,7 +76,7 @@ int runMixxx(MixxxApplication* pApp, const CmdlineArgs& args) {
 
         QObject::connect(pCoreServices.get(),
                 &mixxx::CoreServices::initializationProgressUpdate,
-                &mainWindow,
+                pMainWindow,
                 &MixxxMainWindow::initializationProgressUpdate);
 
         // The size of cached pixmaps increases with the square of devicePixelRatio
@@ -89,9 +89,9 @@ int runMixxx(MixxxApplication* pApp, const CmdlineArgs& args) {
 #ifdef MIXXX_USE_QOPENGL
         // Will call initialize when the initial wglwidget's
         // qopenglwindow has been exposed
-        mainWindow.initializeQOpenGL();
+        pMainWindow->initializeQOpenGL();
 #else
-        mainWindow.initialize();
+        pMainWindow->initialize();
 #endif
 
         pCoreServices->getControllerManager()->setUpDevices();
@@ -102,11 +102,12 @@ int runMixxx(MixxxApplication* pApp, const CmdlineArgs& args) {
             exitCode = kFatalErrorOnStartupExitCode;
         } else {
             qDebug() << "Displaying main window";
-            mainWindow.show();
+            pMainWindow->show();
 
             qDebug() << "Running Mixxx";
             exitCode = pApp->exec();
         }
+        MixxxMainWindow::destroy();
     }
     return exitCode;
 }

--- a/src/mixxxmainwindow.h
+++ b/src/mixxxmainwindow.h
@@ -8,6 +8,7 @@
 #include "soundio/sounddevicestatus.h"
 #include "track/track_decl.h"
 #include "util/parented_ptr.h"
+#include "util/singleton.h"
 
 class ControlObject;
 class DlgDeveloperTools;
@@ -36,12 +37,9 @@ class LibraryExporter;
 /// It sets up the main window providing a menubar.
 /// For the main view, an instance of class MixxxView is
 /// created which creates your view.
-class MixxxMainWindow : public QMainWindow {
+class MixxxMainWindow : public QMainWindow, public Singleton<MixxxMainWindow> {
     Q_OBJECT
   public:
-    MixxxMainWindow(std::shared_ptr<mixxx::CoreServices> pCoreServices);
-    ~MixxxMainWindow() override;
-
 #ifdef MIXXX_USE_QOPENGL
     void initializeQOpenGL();
 #endif
@@ -55,6 +53,15 @@ class MixxxMainWindow : public QMainWindow {
 
     inline GuiTick* getGuiTick() { return m_pGuiTick; };
 
+    static void destroy() {
+        Singleton<MixxxMainWindow>::destroy();
+    };
+
+  protected:
+    MixxxMainWindow(std::shared_ptr<mixxx::CoreServices> pCoreServices);
+    ~MixxxMainWindow() override;
+
+    friend class Singleton<MixxxMainWindow>;
   public slots:
     void rebootMixxxView();
 

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -74,6 +74,9 @@
 #include "widget/wsplitter.h"
 #include "widget/wstarrating.h"
 #include "widget/wstatuslight.h"
+#ifdef __STEM__
+#include "widget/wstemcontrol.h"
+#endif
 #include "widget/wtime.h"
 #include "widget/wtrackproperty.h"
 #include "widget/wtrackwidgetgroup.h"
@@ -86,6 +89,12 @@
 #include "widget/wwidgetstack.h"
 
 using mixxx::skin::SkinManifest;
+
+#ifdef __STEM__
+namespace {
+constexpr int kMaxSupportedStems = 4;
+} // anonymous namespace
+#endif
 
 /// This QSet allows to make use of the implicit sharing
 /// of QString instead of every widget keeping its own copy.
@@ -1021,6 +1030,27 @@ QWidget* LegacySkinParser::parseVisual(const QDomElement& node) {
     WaveformWidgetFactory* pFactory = WaveformWidgetFactory::instance();
     pFactory->setWaveformWidget(viewer, node, *m_pContext);
 
+#ifdef __STEM__
+    DEBUG_ASSERT(viewer->stemControlWidget());
+
+    QDomNode child = node.firstChildElement("StemControl");
+    if (!child.isNull()) {
+        setupSize(child, viewer->stemControlWidget());
+        setupConnections(child, viewer->stemControlWidget());
+        QDomElement stem = child.firstChildElement("Stem");
+        DEBUG_ASSERT(group.endsWith("]"));
+        for (int stemIdx = 1; stemIdx <= kMaxSupportedStems; stemIdx++) {
+            m_pContext->setVariable("StemGroup",
+                    QStringLiteral("%1Stem%2]")
+                            .arg(group.left(group.size() - 1),
+                                    QString::number(stemIdx)));
+            auto* pWidget = parseWidgetGroup(stem);
+            setupSize(stem, pWidget);
+            viewer->stemControlWidget()->addControl(pWidget);
+        }
+    }
+#endif
+
     //qDebug() << "::parseVisual: parent" << m_pParent << m_pParent->size();
     //qDebug() << "::parseVisual: viewer" << viewer << viewer->size();
 
@@ -1038,6 +1068,11 @@ QWidget* LegacySkinParser::parseVisual(const QDomElement& node) {
             &BaseTrackPlayer::loadingTrack,
             viewer,
             &WWaveformViewer::slotLoadingTrack);
+
+    QObject::connect(pPlayer,
+            &BaseTrackPlayer::trackUnloaded,
+            viewer,
+            &WWaveformViewer::slotTrackUnloaded);
 
     connect(viewer,
             &WWaveformViewer::trackDropped,

--- a/src/skin/legacy/tooltips.cpp
+++ b/src/skin/legacy/tooltips.cpp
@@ -269,6 +269,11 @@ void Tooltips::addStandardTooltips() {
     add("show_beatgrid_controls")
             << tr("Show/hide the beatgrid controls section");
 
+#ifdef __STEM__
+    add("show_stem_controls")
+            << tr("Show/hide the stem controls section for stem decks");
+#endif
+
     add("show_library")
             << tr("Show Library")
             << tr("Show or hide the track library.");

--- a/src/waveform/renderers/allshader/waveformrendererstem.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererstem.cpp
@@ -40,9 +40,9 @@ void WaveformRendererStem::initializeGL() {
                                             QString::number(stemIdx));
         m_pStemGain.emplace_back(
                 std::make_unique<ControlProxy>(stemGroup,
-                        QStringLiteral("volume").arg(stemIdx)));
+                        QStringLiteral("volume")));
         m_pStemMute.emplace_back(std::make_unique<ControlProxy>(
-                stemGroup, QStringLiteral("mute").arg(stemIdx)));
+                stemGroup, QStringLiteral("mute")));
     }
 }
 

--- a/src/widget/wstemcontrol.cpp
+++ b/src/widget/wstemcontrol.cpp
@@ -1,0 +1,173 @@
+#include "widget/wstemcontrol.h"
+
+#include <QCoreApplication>
+#include <QDragEnterEvent>
+#include <QEvent>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QMainWindow>
+#include <QPalette>
+#include <QPushButton>
+#include <QStyleOption>
+#include <QVBoxLayout>
+
+#include "control/controlproxy.h"
+#include "moc_wstemcontrol.cpp"
+#include "track/track.h"
+#include "util/math.h"
+#include "util/parented_ptr.h"
+#include "widget/controlwidgetconnection.h"
+#include "widget/wglwidget.h"
+#include "widget/wknob.h"
+#include "widget/wknobcomposed.h"
+#include "widget/wlabel.h"
+
+namespace {
+// FIXME(XXX) this is a workaround to ensure that that knob keep the aspect
+// ratio as defined in its maxSize. This needs to be moved an implemented by the
+// component directly
+void ensureWidgetRatio(QLayout* layout) {
+    for (int i = 0; i < layout->count(); i++) {
+        auto pWidget = layout->itemAt(i)->widget();
+        if (!qobject_cast<WKnobComposed*>(pWidget) && !qobject_cast<WKnob*>(pWidget)) {
+            continue;
+        }
+        float ratio = static_cast<float>(pWidget->maximumWidth()) /
+                static_cast<float>(pWidget->maximumHeight());
+        int maxSize = qMin(pWidget->width(), pWidget->height());
+        QSize currentSize = pWidget->size();
+        QSize newSize;
+
+        if (ratio > 1) {
+            newSize = QSize(maxSize, static_cast<int>(maxSize / ratio));
+        } else {
+            newSize = QSize(static_cast<int>(maxSize * ratio), maxSize);
+        }
+
+        if (currentSize == newSize) {
+            continue;
+        }
+
+        pWidget->resize(newSize);
+        layout->itemAt(i)->invalidate();
+    }
+}
+
+QString getGroupForStem(const QString& deckGroup, int stemIdx) {
+    DEBUG_ASSERT(deckGroup.endsWith("]"));
+    return QStringLiteral("%1Stem%2]")
+            .arg(deckGroup.left(deckGroup.size() - 1),
+                    QString::number(stemIdx + 1));
+}
+} // namespace
+
+WStemControlBox::WStemControlBox(
+        const QString& group, QWidget* parent)
+        : WWidgetGroup(parent), m_group(group), m_hasStem(false), m_displayed(true) {
+    auto pLayout = make_parented<QVBoxLayout>(this);
+    pLayout->setSpacing(0);
+    pLayout->setContentsMargins(0, 0, 0, 0);
+    setLayout(pLayout);
+
+    setObjectName("StemControlBox");
+
+    setWindowFlag(Qt::Sheet);
+    setWindowFlag(Qt::FramelessWindowHint);
+    setWindowFlag(Qt::NoDropShadowWindowHint);
+    setWindowFlag(Qt::WindowDoesNotAcceptFocus);
+
+    // setWindowFlag(Qt::BypassWindowManagerHint); // Make it fly over?
+
+    setAttribute(Qt::WA_OpaquePaintEvent);
+    setAttribute(Qt::WA_NoSystemBackground);
+    setAttribute(Qt::WA_TranslucentBackground);
+    setFocusPolicy(Qt::NoFocus);
+}
+
+void WStemControlBox::setDisplayed(bool displayed) {
+    m_displayed = displayed;
+    emit displayedChanged(m_displayed);
+}
+
+void WStemControlBox::slotTrackLoaded(TrackPointer track) {
+    m_hasStem = false;
+    if (!track) {
+        return;
+    }
+
+    auto stemInfo = track->getStemInfo();
+
+    if (stemInfo.isEmpty()) {
+        return;
+    }
+
+    m_hasStem = true;
+
+    int stemCount = qMin(m_stemControl.size(),
+            static_cast<std::size_t>(stemInfo.size()));
+    for (int stemIdx = 0; stemIdx < stemCount; stemIdx++) {
+        m_stemControl[stemIdx]->setStem(stemInfo[stemIdx]);
+    }
+}
+
+void WStemControlBox::addControl(QWidget* control) {
+    auto pWidget = std::make_unique<WStemControl>(control, this, m_group, m_stemControl.size());
+    layout()->addWidget(pWidget.get());
+    m_stemControl.push_back(std::move(pWidget));
+}
+
+WStemControl::WStemControl(QWidget* widgetGroup, QWidget* parent, const QString& group, int stemIdx)
+        : WWidget(parent),
+          m_widget(widgetGroup),
+          m_mutedCo(std::make_unique<ControlProxy>(
+                  getGroupForStem(group, stemIdx), QStringLiteral("mute"))) {
+    auto pLayout = make_parented<QHBoxLayout>(this);
+    pLayout->setSpacing(0);
+    pLayout->setContentsMargins(0, 0, 0, 0);
+
+    m_widget->setParent(this);
+    setMinimumSize(m_widget->minimumSize());
+    setMaximumSize(m_widget->maximumSize());
+    setSizePolicy(m_widget->sizePolicy());
+
+    layout()->addWidget(m_widget);
+
+    m_mutedCo->connectValueChanged(this, [this](double value) {
+        m_stemColor.setAlphaF(value == 1 ? 0.5 : 1.0);
+        updateStyle();
+    });
+}
+
+void WStemControl::setStem(const StemInfo& stemInfo) {
+    m_stemColor = stemInfo.getColor();
+    m_stemColor.setAlphaF(m_mutedCo->get() == 1 ? 0.5 : 1.0);
+    updateStyle();
+    WLabel* label = findChild<WLabel*>("stem_label");
+    VERIFY_OR_DEBUG_ASSERT(label) {
+        qWarning() << "Cannot find the Label \"stem_label\" in the Stem control";
+        return;
+    }
+    label->setText(stemInfo.getLabel());
+}
+
+void WStemControl::updateStyle() {
+    setStyleSheet(QString("WStemControl { background-color: %1; }")
+                          .arg(m_stemColor.name(QColor::HexArgb)));
+}
+
+void WStemControl::resizeEvent(QResizeEvent* e) {
+    WWidget::resizeEvent(e);
+    ensureWidgetRatio(m_widget->layout());
+}
+
+void WStemControl::showEvent(QShowEvent* e) {
+    WWidget::showEvent(e);
+    ensureWidgetRatio(m_widget->layout());
+}
+
+void WStemControl::paintEvent(QPaintEvent*) {
+    QStyleOption opt;
+    opt.initFrom(this);
+    QPainter p(this);
+    style()->drawPrimitive(QStyle::PE_Widget, &opt, &p, this);
+}

--- a/src/widget/wstemcontrol.h
+++ b/src/widget/wstemcontrol.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <vector>
+
+#include "track/steminfo.h"
+#include "track/track_decl.h"
+#include "util/parented_ptr.h"
+#include "waveform/renderers/waveformmark.h"
+#include "widget/trackdroptarget.h"
+#include "widget/wwidget.h"
+#include "widget/wwidgetgroup.h"
+
+class ControlProxy;
+class WKnob;
+class WStemControl;
+
+class WStemControlBox : public WWidgetGroup {
+    Q_OBJECT
+  public:
+    Q_PROPERTY(bool displayed READ isDisplayed WRITE setDisplayed NOTIFY displayedChanged);
+
+    WStemControlBox(
+            const QString& group, QWidget* parent = nullptr);
+
+    void addControl(QWidget* control);
+    bool shouldShow() const {
+        return m_hasStem && m_displayed;
+    }
+
+    bool isDisplayed() const {
+        return m_displayed;
+    }
+
+    void setDisplayed(bool displayed);
+  public slots:
+    void slotTrackLoaded(TrackPointer track);
+
+  signals:
+    void displayedChanged(bool);
+
+  private:
+    std::vector<std::unique_ptr<WStemControl>> m_stemControl;
+    QString m_group;
+    bool m_hasStem;
+    bool m_displayed;
+};
+
+class WStemControl : public WWidget {
+    Q_OBJECT
+  public:
+    WStemControl(QWidget* widgetGroup, QWidget* parent, const QString& group, int stemIdx);
+    void setStem(const StemInfo& stemInfo);
+
+  protected:
+    void paintEvent(QPaintEvent*) override;
+    void resizeEvent(QResizeEvent*) override;
+    void showEvent(QShowEvent*) override;
+
+  private:
+    QWidget* m_widget;
+    QColor m_stemColor;
+    std::unique_ptr<ControlProxy> m_mutedCo;
+
+    void updateStyle();
+};

--- a/src/widget/wwaveformviewer.h
+++ b/src/widget/wwaveformviewer.h
@@ -8,6 +8,7 @@
 
 class ControlProxy;
 class WaveformWidgetAbstract;
+class WStemControlBox;
 class WCueMenuPopup;
 class QDomNode;
 class SkinContext;
@@ -15,6 +16,11 @@ class SkinContext;
 class WWaveformViewer : public WWidget, public TrackDropTarget {
     Q_OBJECT
   public:
+    enum StemControlAlignment {
+        Left = Qt::AlignLeft,
+        Right = Qt::AlignRight
+    };
+
     WWaveformViewer(
             const QString& group,
             UserSettingsPointer pConfig,
@@ -36,6 +42,14 @@ class WWaveformViewer : public WWidget, public TrackDropTarget {
     void mouseReleaseEvent(QMouseEvent * /*unused*/) override;
     void leaveEvent(QEvent* /*unused*/) override;
 
+#ifdef __STEM__
+    // Used by LegacySkinParser to inject the stem toolbox if defined
+    WStemControlBox* stemControlWidget() const {
+        return m_stemControlWidget.get();
+    }
+
+    bool eventFilter(QObject* object, QEvent* event) override;
+#endif
   signals:
     void trackDropped(const QString& filename, const QString& group) override;
     void cloneDeck(const QString& sourceGroup, const QString& targetGroup) override;
@@ -43,10 +57,12 @@ class WWaveformViewer : public WWidget, public TrackDropTarget {
 
   public slots:
     void slotTrackLoaded(TrackPointer track);
+    void slotTrackUnloaded(TrackPointer pOldTrack);
     void slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack);
 
   protected:
     void showEvent(QShowEvent* event) override;
+    void hideEvent(QHideEvent* event) override;
     void resizeEvent(QResizeEvent *event) override;
     void wheelEvent(QWheelEvent *event) override;
 
@@ -80,6 +96,14 @@ class WWaveformViewer : public WWidget, public TrackDropTarget {
     WaveformMarkPointer m_pHoveredMark;
 
     WaveformWidgetAbstract* m_waveformWidget;
+#ifdef __STEM__
+    std::unique_ptr<WStemControlBox> m_stemControlWidget;
+    QWidget* m_mainWindow;
+
+    void adjustStemControl();
+#endif
+
+    StemControlAlignment m_stemControlWidgetAlignment;
 
     int m_dimBrightThreshold;
 


### PR DESCRIPTION
This PR adds a widget allowing to control stems from the UI.

Due to how waveform are rendered, this widget had a to be a floating widget, which is making it quite unreliable, and thus is likely never to make it to `main`.

This PR is mostly hear as reference for anyone willing to test stem on legacy UI.

Note that stem can already be controlled on QML UI