### PR TITLE
Remove custom clock format from skins

### DIFF
--- a/res/skins/Deere/tool_bar.xml
+++ b/res/skins/Deere/tool_bar.xml
@@ -35,7 +35,6 @@
                 <TooltipId>time</TooltipId>
                 <ObjectName>Time</ObjectName>
                 <Size>52f,20f</Size>
-                <CustomFormat>hh:mm</CustomFormat>
               </Time>
 
               <Template src="skin:vumeter_latency.xml">

--- a/res/skins/LateNight/toolbar.xml
+++ b/res/skins/LateNight/toolbar.xml
@@ -144,7 +144,6 @@
         <Children>
           <Time>
             <TooltipId>time</TooltipId>
-            <CustomFormat>hh:mm</CustomFormat>
           </Time>
         </Children>
       </WidgetGroup>

--- a/res/skins/Shade/mixer_panel.xml
+++ b/res/skins/Shade/mixer_panel.xml
@@ -508,7 +508,6 @@
                   }
                 </Style>
                 <Pos>113,14</Pos>
-                <CustomFormat>hh:mm</CustomFormat>
                 <ShowSeconds>false</ShowSeconds>
               </Time>
 


### PR DESCRIPTION
Mixxx should use the locale's preferred clock format rather than arbitrarily overriding it.  For instance on en_US locale, it's customary to use 12 hour time + am/pm rather than 24 hour time. This should have no effect on machines set to locales that use 24hr time.

If people would prefer to have a preference for clock format I could see adding one.