### PR TITLE
(fix/Qt6) Skins: hide reserved space for invisible table header sort indicators

### DIFF
--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -374,7 +374,7 @@ WTrackTableViewHeader {
 WTrackTableViewHeader::section {
   height: 1.1em;
   font-weight: bold;
-  padding: 0.1em;
+  padding: 0.1em -1em 0.1em 0.1em;
   background-color: #1A1A1A;
   border-top: none;
   border-left: none;

--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -2272,6 +2272,9 @@ WTrackTableViewHeader {
       stop:1 #111);
   }
   WTrackTableViewHeader::section {
+    /* Workaround Qt bug that causes space being reserved for invisible sort indicators.
+       For details see style-plaemon.qss */
+    padding-right: -0.95em;
     border-right: 1px solid #000;
     border-bottom: 1px solid #000;
   }

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -1512,23 +1512,6 @@ WEffectSelector:!editable,
     border-image: url(skins:LateNight/palemoon/buttons/btn_embedded_library_active.svg) 2 2 2 2;
   }
 
-  WTrackTableViewHeader {
-    border-bottom-right-radius: 1px solid #000;
-    outline: none;
-  }
-  WTrackTableViewHeader::section {
-    outline: none;
-    border-width: 1px 2px 1px 1px;
-    border-image: url(skins:LateNight/palemoon/buttons/btn_embedded_library_header.svg) 1 2 1 1;
-  }
-  WTrackTableViewHeader::up-arrow,
-  WTrackTableViewHeader::down-arrow {
-    outline: none;
-    /* ToDo: restore image
-    border-width: 1px 2px 1px 0px;
-    border-image: url(skins:LateNight/palemoon/buttons/btn_embedded_library_header_sort.svg) 1 2 1 1; */
-  }
-
   #LibraryFeatureControls QPushButton:!enabled {
     outline: none;
     border-width: 2px;
@@ -2734,16 +2717,40 @@ WTrackPropertyEditor {
 /*********** table header styles *********************************/
 
 WTrackTableViewHeader {
+  border-bottom-right-radius: 1px solid #000;
+  outline: none;
+}
+
+WTrackTableViewHeader::section {
+/* Setting an image causes QHeaderView to reserve space for the sort indicator,
+   i.e. column titles are truncated, even where no indicators are shown.
+   The arrow width and padding are set in style.qss (0.8em + .15em),
+   so let's set a negative padding-right to shift the text. This will push the
+   reserved space out of the visible region, but the actual arrow will still be visible.
+   Now the arrow overlaps the column title again like in Qt5 (bug), so the arrow images
+   could use a background-color to cover the text, or a gradient to fade it out gently. */
+  padding: 2px -0.95em 0px 3px;
+  outline: none;
+  border-width: 1px 2px 1px 1px;
+  border-image: url(skins:LateNight/palemoon/buttons/btn_embedded_library_header.svg) 1 2 1 1;
+}
+
+WTrackTableViewHeader::up-arrow,
+WTrackTableViewHeader::down-arrow {
+  outline: none;
+  /* horizontal gradient to fade out the text */
+  background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0,
+    stop: 0 transparent,
+    stop: 0.2 #171719,
+    stop: 1 #171719);
   }
-  WTrackTableViewHeader::section {
-    padding: 2px 1px 0px 3px;
-    }
-    WTrackTableViewHeader::up-arrow {
-      image: url(skins:LateNight/palemoon/buttons/btn__lib_sort_up.svg);
-    }
-    WTrackTableViewHeader::down-arrow {
-      image: url(skins:LateNight/palemoon/buttons/btn__lib_sort_down.svg);
-    }
+  WTrackTableViewHeader::up-arrow {
+    image: url(skins:LateNight/palemoon/buttons/btn__lib_sort_up.svg);
+  }
+  WTrackTableViewHeader::down-arrow {
+    image: url(skins:LateNight/palemoon/buttons/btn__lib_sort_down.svg);
+  }
+
 
 
 

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -763,7 +763,7 @@ WTrackTableViewHeader {
 /*	Library header 'buttons'	*/
 WTrackTableViewHeader::section {
   height: 1.1em;
-  padding: 0.1em;
+  padding: 0.1em -0.7em 0.1em 0.1em;
   /*	set right border so that first column header
   on the left doesn't have double border on the left	*/
   border-right: 1px solid #0f0f0f;

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -2756,7 +2756,7 @@ WTrackTableViewHeader {
   /*  Library header 'buttons'  */
   WTrackTableViewHeader::section {
     height: 1.1em;
-    padding: 0 0.1em;
+    padding: 0 -0.7em 0 0.1em;
     /*  use 'border-right' so that for the header of the leftmost column
     the border doesn't add to the border of the surrounding qtableview */
     border-right: 1px solid #585858;

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -2782,14 +2782,8 @@ WTrackTableViewHeader {
     WTrackTableViewHeader::up-arrow {
       image: url(skin:/../Tango/graphics/library_sort_up.svg);
       }
-      WTrackTableViewHeader::up-arrow:hover {
-        image: url(skin:/../Tango/graphics/library_sort_down.svg);
-      }
     WTrackTableViewHeader::down-arrow {
       image: url(skin:/../Tango/graphics/library_sort_down.svg);
-      }
-      WTrackTableViewHeader::down-arrow:hover {
-        image: url(skin:/../Tango/graphics/library_sort_up.svg);
       }
 
 WLibraryTextBrowser {


### PR DESCRIPTION
before:
![Screenshot_2024-08-04_17-25-48](https://github.com/user-attachments/assets/8daf9d82-fdbd-4b88-8ea7-8d60917e50c8)

after:
![Screenshot_2024-08-04_17-25-26](https://github.com/user-attachments/assets/ea2cf209-96bc-4377-a0e8-1bb4cf2c3911)

Working around a Qt 6 regression, probably this one again https://bugreports.qt.io/browse/QTBUG-27038
(I don't care about reporting this upstream with a minimal reproducible example, usually takes ages until being fixed)

### Issue:
QHeaderView will reserve space in the header section for sort indicators, even if they're invisble as soon as we set either an image
```
WTrackTableViewHeader::up-arrow {
  image: url(skins:LateNight/classic/buttons/btn__lib_sort_up.svg);
}
```
or the width
```
WTrackTableViewHeader::up-arrow,
WTrackTableViewHeader::down-arrow {
  width: 0.8em;
}
```

### Fix:
Set a negative `padding-right` to push the space out of the visible region.
The indicator will be inside nonetheless :man_shrugging: 

Please test on Windows and macOS.
