### PR TITLE
Non-floating stem controls for LateNight

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3466,6 +3466,7 @@ if (STEM)
     src/sources/soundsourcestem.cpp
     src/track/steminfoimporter.cpp
     src/track/steminfo.cpp
+    src/widget/wstemlabel.cpp
   )
   if(QOPENGL)
     target_sources(mixxx-lib PRIVATE

--- a/res/skins/LateNight/classic/buttons/btn__stem_controls_collapse.svg
+++ b/res/skins/LateNight/classic/buttons/btn__stem_controls_collapse.svg
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="52"
+   height="104"
+   version="1.1"
+   viewBox="0 0 26 52"
+   id="svg13"
+   sodipodi:docname="btn__stem_controls_collapse.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs13" />
+  <sodipodi:namedview
+     id="namedview13"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="8.5673077"
+     inkscape:cx="25.970819"
+     inkscape:cy="52"
+     inkscape:window-width="1920"
+     inkscape:window-height="1129"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g7" />
+  <g
+     fill="none"
+     stroke="#000001"
+     stroke-linejoin="round"
+     stroke-width="1.6"
+     id="g7">
+    <path
+       d="m 3.4997,27.5001 v 2 h 18 v -2 z"
+       id="path14" />
+    <path
+       d="m 3.4996,32.5001 v 2 h 18 v -2 z"
+       id="path14-2" />
+    <path
+       d="m 3.5000999,37.5004 v 2 H 21.5001 v -2 z"
+       id="path14-1" />
+    <path
+       d="m 3.5001002,42.5004 v 2 H 21.5001 v -2 z"
+       id="path14-6" />
+    <path
+       d="m5.3641 18.098 4.4253-4.4252-4.4253-4.4252 1.1064-1.1063 5.5315 5.5315-5.5315 5.5315z"
+       id="path6" />
+    <path
+       d="m20.636 18.098-4.4253-4.4253 4.4253-4.4253-1.1064-1.1064-5.5315 5.5315 5.5315 5.5316 1.1064-1.1064z"
+       id="path7" />
+  </g>
+  <g
+     fill="#666668"
+     id="g13">
+   <path
+       id="path11"
+       d="M 3.5 27.5 L 3.5 29.5 L 7.4824219 29.5 L 11.484375 29.5 L 21.5 29.5 L 21.5 27.5 L 12.787109 27.5 L 9.7753906 27.5 L 3.5 27.5 z " />
+    <path
+       id="path11-1"
+       d="m 3.4996,32.5001 v 2 H 7.482022 11.483975 21.4996 v -2 H 12.786709 9.7749902 Z" />
+    <path
+       id="path11-13"
+       d="m 3.5001004,37.5004 v 2 H 7.4825224 11.484475 21.5001 v -2 H 12.787209 9.7754914 Z" />
+    <path
+       id="path11-8"
+       d="m 3.5000995,42.5004 v 2 H 7.4825215 11.484475 21.5001 v -2 H 12.787209 9.7754905 Z" />
+    <path
+       d="m5.3641 18.098 4.4253-4.4252-4.4253-4.4252 1.1064-1.1063 5.5315 5.5315-5.5315 5.5315z"
+       stroke-width=".93992"
+       id="path12" />
+    <path
+       d="m20.636 18.098-4.4253-4.4253 4.4253-4.4253-1.1064-1.1064-5.5315 5.5315 5.5315 5.5316 1.1064-1.1064z"
+       stroke-width=".93992"
+       id="path13" />
+  </g>
+</svg>

--- a/res/skins/LateNight/classic/buttons/btn__stem_controls_expand.svg
+++ b/res/skins/LateNight/classic/buttons/btn__stem_controls_expand.svg
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="52"
+   height="104"
+   version="1.1"
+   viewBox="0 0 26 52"
+   id="svg14"
+   sodipodi:docname="btn__stem_controls_expand.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     id="namedview14"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="8.5673077"
+     inkscape:cx="26.087542"
+     inkscape:cy="59.470258"
+     inkscape:window-width="1920"
+     inkscape:window-height="1129"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg14" />
+  <g
+     fill="none"
+     stroke="#000001"
+     stroke-linejoin="round"
+     stroke-width="1.6"
+     id="g7">
+    <path
+       d="m11.648 18.12-4.4253-4.4252 4.4253-4.4252-1.1064-1.1063-5.5316 5.5315 5.5316 5.5315z"
+       id="path6" />
+    <path
+       d="m14.352 18.12 4.4253-4.4253-4.4253-4.4253 1.1064-1.1064 5.5315 5.5316-5.5315 5.5315-1.1064-1.1064z"
+       id="path7" />
+    <path
+       d="m 3.4997,27.5001 v 2 h 18 v -2 z"
+       id="path14" />
+    <path
+       d="m 3.4996,32.5001 v 2 h 18 v -2 z"
+       id="path14-2" />
+    <path
+       d="m 3.5000999,37.5004 v 2 H 21.5001 v -2 z"
+       id="path14-1" />
+    <path
+       d="m 3.5001002,42.5004 v 2 H 21.5001 v -2 z"
+       id="path14-6" />
+  </g>
+  <g
+     fill="#666668"
+     id="g13">
+    <path
+       d="m11.648 18.12-4.4253-4.4252 4.4253-4.4252-1.1064-1.1063-5.5316 5.5315 5.5316 5.5315z"
+       stroke-width=".93992"
+       id="path12" />
+    <path
+       d="m14.352 18.12 4.4253-4.4253-4.4253-4.4253 1.1064-1.1064 5.5315 5.5315-5.5315 5.5316-1.1064-1.1064z"
+       stroke-width=".93992"
+       id="path13" />
+    <path
+       id="path11"
+       d="M 3.5 27.5 L 3.5 29.5 L 7.4824219 29.5 L 11.484375 29.5 L 21.5 29.5 L 21.5 27.5 L 12.787109 27.5 L 9.7753906 27.5 L 3.5 27.5 z " />
+    <path
+       id="path11-1"
+       d="m 3.4996,32.5001 v 2 H 7.482022 11.483975 21.4996 v -2 H 12.786709 9.7749902 Z" />
+    <path
+       id="path11-13"
+       d="m 3.5001004,37.5004 v 2 H 7.4825224 11.484475 21.5001 v -2 H 12.787209 9.7754914 Z" />
+    <path
+       id="path11-8"
+       d="m 3.5000995,42.5004 v 2 H 7.4825215 11.484475 21.5001 v -2 H 12.787209 9.7754905 Z" />
+  </g>
+</svg>

--- a/res/skins/LateNight/classic/buttons/btn__stem_mute.svg
+++ b/res/skins/LateNight/classic/buttons/btn__stem_mute.svg
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="32"
+   height="32"
+   version="1.1"
+   viewBox="0 0 16 16"
+   id="svg2"
+   sodipodi:docname="btn__stem_mute.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="namedview2"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="27.84375"
+     inkscape:cx="16"
+     inkscape:cy="15.497194"
+     inkscape:window-width="1920"
+     inkscape:window-height="1129"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <path
+     d="m 6.9978512,3.6720566 -3.4187944,2.4890685 -1.6798905,0.019412 9.969e-4,3.3738798 1.7411301,0.022271 3.5140795,2.1999681 2.1107698,0.01413 c 0.015497,-1.573273 0.031203,-3.1465432 0.047443,-4.7198102 0.011652,-1.1296972 0.023561,-2.2593922 0.035844,-3.3890845 z"
+     color="#000000"
+     color-rendering="auto"
+     dominant-baseline="auto"
+     fill="none"
+     image-rendering="auto"
+     shape-rendering="auto"
+     solid-color="#000000"
+     stroke="#000000"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     stroke-width="1.43729"
+     style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;isolation:auto;mix-blend-mode:normal;fill:#000000;fill-opacity:1;stroke:#81817e;paint-order:fill markers stroke"
+     id="path1"
+     sodipodi:nodetypes="cccccccscc" />
+  <path
+     style="fill:none;fill-opacity:1;stroke:#81817e;stroke-width:1.25085"
+     d="M 11.092087,2.2296367 C 18.422943,8.044446 11.402726,13.371979 11.402726,13.371979"
+     id="path2" />
+  <path
+     style="fill:none;fill-opacity:1;stroke:#81817e;stroke-width:0.72557"
+     d="m 10.653298,4.4556763 c 4.063655,3.5295651 0.172191,6.7633557 0.172191,6.7633557"
+     id="path2-8" />
+  <rect
+     style="fill:#d2d2d1;fill-opacity:1;stroke-width:0.705247"
+     id="rect2"
+     width="18.943859"
+     height="1.8262962"
+     x="1.6984615"
+     y="-2.3039746"
+     ry="0.17755656"
+     transform="matrix(0.6095364,0.79275808,-0.79839675,0.60213174,0,0)" />
+</svg>

--- a/res/skins/LateNight/classic/buttons/btn__stem_mute.svg
+++ b/res/skins/LateNight/classic/buttons/btn__stem_mute.svg
@@ -1,67 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   width="32"
-   height="32"
-   version="1.1"
-   viewBox="0 0 16 16"
-   id="svg2"
-   sodipodi:docname="btn__stem_mute.svg"
-   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-  <defs
-     id="defs2" />
-  <sodipodi:namedview
-     id="namedview2"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:zoom="27.84375"
-     inkscape:cx="16"
-     inkscape:cy="15.497194"
-     inkscape:window-width="1920"
-     inkscape:window-height="1129"
-     inkscape:window-x="-8"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg2" />
-  <path
-     d="m 6.9978512,3.6720566 -3.4187944,2.4890685 -1.6798905,0.019412 9.969e-4,3.3738798 1.7411301,0.022271 3.5140795,2.1999681 2.1107698,0.01413 c 0.015497,-1.573273 0.031203,-3.1465432 0.047443,-4.7198102 0.011652,-1.1296972 0.023561,-2.2593922 0.035844,-3.3890845 z"
-     color="#000000"
-     color-rendering="auto"
-     dominant-baseline="auto"
-     fill="none"
-     image-rendering="auto"
-     shape-rendering="auto"
-     solid-color="#000000"
-     stroke="#000000"
-     stroke-linecap="round"
-     stroke-linejoin="round"
-     stroke-width="1.43729"
-     style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;isolation:auto;mix-blend-mode:normal;fill:#000000;fill-opacity:1;stroke:#81817e;paint-order:fill markers stroke"
-     id="path1"
-     sodipodi:nodetypes="cccccccscc" />
-  <path
-     style="fill:none;fill-opacity:1;stroke:#81817e;stroke-width:1.25085"
-     d="M 11.092087,2.2296367 C 18.422943,8.044446 11.402726,13.371979 11.402726,13.371979"
-     id="path2" />
-  <path
-     style="fill:none;fill-opacity:1;stroke:#81817e;stroke-width:0.72557"
-     d="m 10.653298,4.4556763 c 4.063655,3.5295651 0.172191,6.7633557 0.172191,6.7633557"
-     id="path2-8" />
-  <rect
-     style="fill:#d2d2d1;fill-opacity:1;stroke-width:0.705247"
-     id="rect2"
-     width="18.943859"
-     height="1.8262962"
-     x="1.6984615"
-     y="-2.3039746"
-     ry="0.17755656"
-     transform="matrix(0.6095364,0.79275808,-0.79839675,0.60213174,0,0)" />
+<svg width="32" height="32" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <path d="M 9.8367342,1.8716446 A 8,8 0 0 1 12.694433,8 8,8 0 0 1 9.8367341,14.128356" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.25" style="paint-order:fill markers stroke"/>
+  <path d="M 9.8367342,1.8716446 A 8,8 0 0 1 12.694433,8 8,8 0 0 1 9.8367341,14.128356" fill="none" stroke="#d2d2d1" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" style="paint-order:fill markers stroke"/>
+  <path d="M 6.4258543,4.1697778 A 5,5 0 0 1 8.2119162,8 5,5 0 0 1 6.4258542,11.830222" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.25" style="paint-order:fill markers stroke"/>
+  <path d="M 6.4258543,4.1697778 A 5,5 0 0 1 8.2119162,8 5,5 0 0 1 6.4258542,11.830222" fill="none" stroke="#d2d2d1" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" style="paint-order:fill markers stroke"/>
+  <path d="M 2.622796,5.7018667 A 3,3 0 0 1 3.6944332,8 3,3 0 0 1 2.622796,10.298133" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.25" style="paint-order:fill markers stroke"/>
+  <path d="M 2.622796,5.7018667 A 3,3 0 0 1 3.6944332,8 3,3 0 0 1 2.622796,10.298133" fill="none" stroke="#d2d2d1" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" style="paint-order:fill markers stroke"/>
 </svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__stem_controls_collapse.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__stem_controls_collapse.svg
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="52"
+   height="104"
+   version="1.1"
+   viewBox="0 0 26 52"
+   id="svg13"
+   sodipodi:docname="btn__stem_controls_collapse.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs13" />
+  <sodipodi:namedview
+     id="namedview13"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="8.5673077"
+     inkscape:cx="25.970819"
+     inkscape:cy="52"
+     inkscape:window-width="1920"
+     inkscape:window-height="1129"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g7" />
+  <g
+     fill="none"
+     stroke="#000001"
+     stroke-linejoin="round"
+     stroke-width="1.6"
+     id="g7">
+    <path
+       d="m 3.4997,27.5001 v 2 h 18 v -2 z"
+       id="path14" />
+    <path
+       d="m 3.4996,32.5001 v 2 h 18 v -2 z"
+       id="path14-2" />
+    <path
+       d="m 3.5000999,37.5004 v 2 H 21.5001 v -2 z"
+       id="path14-1" />
+    <path
+       d="m 3.5001002,42.5004 v 2 H 21.5001 v -2 z"
+       id="path14-6" />
+    <path
+       d="m5.3641 18.098 4.4253-4.4252-4.4253-4.4252 1.1064-1.1063 5.5315 5.5315-5.5315 5.5315z"
+       id="path6" />
+    <path
+       d="m20.636 18.098-4.4253-4.4253 4.4253-4.4253-1.1064-1.1064-5.5315 5.5315 5.5315 5.5316 1.1064-1.1064z"
+       id="path7" />
+  </g>
+  <g
+     fill="#666668"
+     id="g13">
+   <path
+       id="path11"
+       d="M 3.5 27.5 L 3.5 29.5 L 7.4824219 29.5 L 11.484375 29.5 L 21.5 29.5 L 21.5 27.5 L 12.787109 27.5 L 9.7753906 27.5 L 3.5 27.5 z " />
+    <path
+       id="path11-1"
+       d="m 3.4996,32.5001 v 2 H 7.482022 11.483975 21.4996 v -2 H 12.786709 9.7749902 Z" />
+    <path
+       id="path11-13"
+       d="m 3.5001004,37.5004 v 2 H 7.4825224 11.484475 21.5001 v -2 H 12.787209 9.7754914 Z" />
+    <path
+       id="path11-8"
+       d="m 3.5000995,42.5004 v 2 H 7.4825215 11.484475 21.5001 v -2 H 12.787209 9.7754905 Z" />
+    <path
+       d="m5.3641 18.098 4.4253-4.4252-4.4253-4.4252 1.1064-1.1063 5.5315 5.5315-5.5315 5.5315z"
+       stroke-width=".93992"
+       id="path12" />
+    <path
+       d="m20.636 18.098-4.4253-4.4253 4.4253-4.4253-1.1064-1.1064-5.5315 5.5315 5.5315 5.5316 1.1064-1.1064z"
+       stroke-width=".93992"
+       id="path13" />
+  </g>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__stem_controls_expand.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__stem_controls_expand.svg
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="52"
+   height="104"
+   version="1.1"
+   viewBox="0 0 26 52"
+   id="svg14"
+   sodipodi:docname="btn__stem_controls_expand.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs14" />
+  <sodipodi:namedview
+     id="namedview14"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="8.5673077"
+     inkscape:cx="26.087542"
+     inkscape:cy="59.470258"
+     inkscape:window-width="1920"
+     inkscape:window-height="1129"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg14" />
+  <g
+     fill="none"
+     stroke="#000001"
+     stroke-linejoin="round"
+     stroke-width="1.6"
+     id="g7">
+    <path
+       d="m11.648 18.12-4.4253-4.4252 4.4253-4.4252-1.1064-1.1063-5.5316 5.5315 5.5316 5.5315z"
+       id="path6" />
+    <path
+       d="m14.352 18.12 4.4253-4.4253-4.4253-4.4253 1.1064-1.1064 5.5315 5.5316-5.5315 5.5315-1.1064-1.1064z"
+       id="path7" />
+    <path
+       d="m 3.4997,27.5001 v 2 h 18 v -2 z"
+       id="path14" />
+    <path
+       d="m 3.4996,32.5001 v 2 h 18 v -2 z"
+       id="path14-2" />
+    <path
+       d="m 3.5000999,37.5004 v 2 H 21.5001 v -2 z"
+       id="path14-1" />
+    <path
+       d="m 3.5001002,42.5004 v 2 H 21.5001 v -2 z"
+       id="path14-6" />
+  </g>
+  <g
+     fill="#666668"
+     id="g13">
+    <path
+       d="m11.648 18.12-4.4253-4.4252 4.4253-4.4252-1.1064-1.1063-5.5316 5.5315 5.5316 5.5315z"
+       stroke-width=".93992"
+       id="path12" />
+    <path
+       d="m14.352 18.12 4.4253-4.4253-4.4253-4.4253 1.1064-1.1064 5.5315 5.5315-5.5315 5.5316-1.1064-1.1064z"
+       stroke-width=".93992"
+       id="path13" />
+    <path
+       id="path11"
+       d="M 3.5 27.5 L 3.5 29.5 L 7.4824219 29.5 L 11.484375 29.5 L 21.5 29.5 L 21.5 27.5 L 12.787109 27.5 L 9.7753906 27.5 L 3.5 27.5 z " />
+    <path
+       id="path11-1"
+       d="m 3.4996,32.5001 v 2 H 7.482022 11.483975 21.4996 v -2 H 12.786709 9.7749902 Z" />
+    <path
+       id="path11-13"
+       d="m 3.5001004,37.5004 v 2 H 7.4825224 11.484475 21.5001 v -2 H 12.787209 9.7754914 Z" />
+    <path
+       id="path11-8"
+       d="m 3.5000995,42.5004 v 2 H 7.4825215 11.484475 21.5001 v -2 H 12.787209 9.7754905 Z" />
+  </g>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__stem_mute.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__stem_mute.svg
@@ -1,67 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   width="32"
-   height="32"
-   version="1.1"
-   viewBox="0 0 16 16"
-   id="svg2"
-   sodipodi:docname="btn__stem_mute.svg"
-   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
-  <defs
-     id="defs2" />
-  <sodipodi:namedview
-     id="namedview2"
-     pagecolor="#ffffff"
-     bordercolor="#000000"
-     borderopacity="0.25"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     inkscape:zoom="27.84375"
-     inkscape:cx="16"
-     inkscape:cy="15.497194"
-     inkscape:window-width="1920"
-     inkscape:window-height="1129"
-     inkscape:window-x="-8"
-     inkscape:window-y="-8"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg2" />
-  <path
-     d="m 6.9978512,3.6720566 -3.4187944,2.4890685 -1.6798905,0.019412 9.969e-4,3.3738798 1.7411301,0.022271 3.5140795,2.1999681 2.1107698,0.01413 c 0.015497,-1.573273 0.031203,-3.1465432 0.047443,-4.7198102 0.011652,-1.1296972 0.023561,-2.2593922 0.035844,-3.3890845 z"
-     color="#000000"
-     color-rendering="auto"
-     dominant-baseline="auto"
-     fill="none"
-     image-rendering="auto"
-     shape-rendering="auto"
-     solid-color="#000000"
-     stroke="#000000"
-     stroke-linecap="round"
-     stroke-linejoin="round"
-     stroke-width="1.43729"
-     style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;isolation:auto;mix-blend-mode:normal;fill:#000000;fill-opacity:1;stroke:#766a5d;paint-order:fill markers stroke"
-     id="path1"
-     sodipodi:nodetypes="cccccccscc" />
-  <path
-     style="fill:none;fill-opacity:1;stroke:#766a5d;stroke-width:1.25085"
-     d="M 11.092087,2.2296367 C 18.422943,8.044446 11.402726,13.371979 11.402726,13.371979"
-     id="path2" />
-  <path
-     style="fill:none;fill-opacity:1;stroke:#766a5d;stroke-width:0.72557"
-     d="m 10.653298,4.4556763 c 4.063655,3.5295651 0.172191,6.7633557 0.172191,6.7633557"
-     id="path2-8" />
-  <rect
-     style="fill:#afa499;fill-opacity:1;stroke-width:0.705247"
-     id="rect2"
-     width="18.943859"
-     height="1.8262962"
-     x="1.6984615"
-     y="-2.3039746"
-     ry="0.17755656"
-     transform="matrix(0.6095364,0.79275808,-0.79839675,0.60213174,0,0)" />
+<svg width="32" height="32" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <path d="M 9.8367342,1.8716446 A 8,8 0 0 1 12.694433,8 8,8 0 0 1 9.8367341,14.128356" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.25" style="paint-order:fill markers stroke"/>
+  <path d="M 9.8367342,1.8716446 A 8,8 0 0 1 12.694433,8 8,8 0 0 1 9.8367341,14.128356" fill="none" stroke="#666668" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" style="paint-order:fill markers stroke"/>
+  <path d="M 6.4258543,4.1697778 A 5,5 0 0 1 8.2119162,8 5,5 0 0 1 6.4258542,11.830222" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.25" style="paint-order:fill markers stroke"/>
+  <path d="M 6.4258543,4.1697778 A 5,5 0 0 1 8.2119162,8 5,5 0 0 1 6.4258542,11.830222" fill="none" stroke="#666668" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" style="paint-order:fill markers stroke"/>
+  <path d="M 2.622796,5.7018667 A 3,3 0 0 1 3.6944332,8 3,3 0 0 1 2.622796,10.298133" fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="3.25" style="paint-order:fill markers stroke"/>
+  <path d="M 2.622796,5.7018667 A 3,3 0 0 1 3.6944332,8 3,3 0 0 1 2.622796,10.298133" fill="none" stroke="#666668" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" style="paint-order:fill markers stroke"/>
 </svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__stem_mute.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__stem_mute.svg
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="32"
+   height="32"
+   version="1.1"
+   viewBox="0 0 16 16"
+   id="svg2"
+   sodipodi:docname="btn__stem_mute.svg"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="namedview2"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="27.84375"
+     inkscape:cx="16"
+     inkscape:cy="15.497194"
+     inkscape:window-width="1920"
+     inkscape:window-height="1129"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <path
+     d="m 6.9978512,3.6720566 -3.4187944,2.4890685 -1.6798905,0.019412 9.969e-4,3.3738798 1.7411301,0.022271 3.5140795,2.1999681 2.1107698,0.01413 c 0.015497,-1.573273 0.031203,-3.1465432 0.047443,-4.7198102 0.011652,-1.1296972 0.023561,-2.2593922 0.035844,-3.3890845 z"
+     color="#000000"
+     color-rendering="auto"
+     dominant-baseline="auto"
+     fill="none"
+     image-rendering="auto"
+     shape-rendering="auto"
+     solid-color="#000000"
+     stroke="#000000"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     stroke-width="1.43729"
+     style="font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;white-space:normal;shape-padding:0;isolation:auto;mix-blend-mode:normal;fill:#000000;fill-opacity:1;stroke:#766a5d;paint-order:fill markers stroke"
+     id="path1"
+     sodipodi:nodetypes="cccccccscc" />
+  <path
+     style="fill:none;fill-opacity:1;stroke:#766a5d;stroke-width:1.25085"
+     d="M 11.092087,2.2296367 C 18.422943,8.044446 11.402726,13.371979 11.402726,13.371979"
+     id="path2" />
+  <path
+     style="fill:none;fill-opacity:1;stroke:#766a5d;stroke-width:0.72557"
+     d="m 10.653298,4.4556763 c 4.063655,3.5295651 0.172191,6.7633557 0.172191,6.7633557"
+     id="path2-8" />
+  <rect
+     style="fill:#afa499;fill-opacity:1;stroke-width:0.705247"
+     id="rect2"
+     width="18.943859"
+     height="1.8262962"
+     x="1.6984615"
+     y="-2.3039746"
+     ry="0.17755656"
+     transform="matrix(0.6095364,0.79275808,-0.79839675,0.60213174,0,0)" />
+</svg>

--- a/res/skins/LateNight/stem_channel.xml
+++ b/res/skins/LateNight/stem_channel.xml
@@ -24,7 +24,7 @@
 
 
 				<PushButton>
-					<ObjectName>QuickEffectButton</ObjectName>
+					<ObjectName>StemMuteButton</ObjectName>
 					<Pos>36,4</Pos>
 					<Size>18f,18f</Size>
 					<NumberStates>2</NumberStates>

--- a/res/skins/LateNight/stem_channel.xml
+++ b/res/skins/LateNight/stem_channel.xml
@@ -1,0 +1,188 @@
+<!DOCTYPE template>
+<Template>
+  <SetVariable name="QuickEffectGroup">[QuickEffectRack1_<Variable name="Group"/>]</SetVariable>
+
+  <WidgetGroup>
+    <Layout>horizontal</Layout>
+    <SizePolicy>min,min</SizePolicy>
+    <Children>
+		<WidgetGroup>
+			<ObjectName>ChannelMixer_KnobContainer</ObjectName>
+			<Layout>horizontal</Layout>
+			<SizePolicy>min,min</SizePolicy>
+			<Children>
+
+			<StemLabel>
+				<ObjectName>StemLabel</ObjectName>
+				<Group><Variable name="Group"/></Group>
+				<StemNum><Variable name="StemNum"/></StemNum>
+				<Alignment>left</Alignment>
+				<Elide>right</Elide>
+				<Size>50,26</Size>
+				<Text></Text>
+			</StemLabel>
+
+
+				<PushButton>
+					<ObjectName>QuickEffectButton</ObjectName>
+					<Pos>36,4</Pos>
+					<Size>18f,18f</Size>
+					<NumberStates>2</NumberStates>
+					<State>
+						<Number>0</Number>
+						<Unpressed scalemode="STRETCH">
+							skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill.svg
+						</Unpressed>
+						<Pressed scalemode="STRETCH">
+							skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg
+						</Pressed>
+					</State>
+					<State>
+						<Number>1</Number>
+						<Unpressed scalemode="STRETCH">
+							skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg
+						</Unpressed>
+						<Pressed scalemode="STRETCH">
+							skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg
+						</Pressed>
+					</State>
+					<Connection>
+						<ButtonState>LeftButton</ButtonState>
+						<ConfigKey>[Channel<Variable name="ChanNum"/>Stem<Variable name="StemNum"/>],mute_toggle</ConfigKey>
+						<Transform>
+							<Not/>
+						</Transform>
+					</Connection>
+					<Connection>
+						<ButtonState>LeftButton</ButtonState>
+						<ConfigKey>[Channel<Variable name="ChanNum"/>Stem<Variable name="StemNum"/>],mute</ConfigKey>
+                        <ConnectValueFromWidget>true</ConnectValueFromWidget>
+						<Transform>
+							<Not/>
+						</Transform>
+					</Connection>
+				</PushButton>
+
+			   <KnobComposed>
+                <TooltipId>QuickEffectRack_super1</TooltipId>
+				  <Pos>0,0</Pos>
+                <Size>40f,26f</Size>
+                <Knob>skins:LateNight/<Variable name="KnobScheme"/>/knobs/knob_indicator_<Variable name="KnobIndicator"/>_orange.svg</Knob>
+                <BackPath>skins:LateNight/<Variable name="KnobScheme"/>/knobs/knob_bg_<Variable name="KnobBg"/>.svg</BackPath>
+                <MinAngle><Variable name="PotiMinAngle"/></MinAngle>
+                <MaxAngle><Variable name="PotiMaxAngle"/></MaxAngle>
+                <ArcRadius><Variable name="ArcRadius"/></ArcRadius>
+                <ArcUnipolar><Variable name="ArcUnipolar"/></ArcUnipolar>
+                <ArcReversed><Variable name="ArcReversed"/></ArcReversed>
+                <ArcColor><Variable name="ArcColorGain"/></ArcColor>
+                <ArcThickness><Variable name="ArcThickness"/></ArcThickness>
+                <ArcRoundCaps><Variable name="ArcRoundCaps"/></ArcRoundCaps>
+                <KnobCenterYOffset>1.998</KnobCenterYOffset>
+                <Connection>
+                  <ConfigKey>[Channel<Variable name="ChanNum"/>Stem<Variable name="StemNum"/>],volume</ConfigKey>
+                </Connection>
+              </KnobComposed>
+
+
+			<EffectChainPresetSelector>
+				<ObjectName>QuickEffectSelectorLeft</ObjectName>
+				<Size>85f,18f</Size>
+				<EffectUnitGroup>[QuickEffectRack1_[Channel<Variable name="ChanNum"/>Stem<Variable name="StemNum"/>]]</EffectUnitGroup>
+			</EffectChainPresetSelector>
+
+				<PushButton>
+					<TooltipId>QuickEffectRack_enabled</TooltipId>
+					<ObjectName>QuickEffectDot</ObjectName>
+					<Pos>30,20</Pos>
+					<Size>
+						<Variable name="EqKillDotSize"/>
+					</Size>
+					<NumberStates>2</NumberStates>
+					<RightClickIsPushButton>false</RightClickIsPushButton>
+					<State>
+						<Number>0</Number>
+					</State>
+					<State>
+						<Number>1</Number>
+					</State>
+					<Connection>
+						<ConfigKey>[QuickEffectRack1_[Channel<Variable name="ChanNum"/>Stem<Variable name="StemNum"/>]],enabled</ConfigKey>
+						<ButtonState>LeftButton</ButtonState>
+					</Connection>
+					<Connection>
+						<ConfigKey>[Skin],show_eq_kill_buttons</ConfigKey>
+						<Transform>
+							<Not/>
+						</Transform>
+						<BindProperty>visible</BindProperty>
+					</Connection>
+				</PushButton>
+
+				<PushButton>
+					<TooltipId>QuickEffectRack_enabled</TooltipId>
+					<ObjectName>QuickEffectButton</ObjectName>
+					<Pos>36,4</Pos>
+					<Size>18f,18f</Size>
+					<NumberStates>2</NumberStates>
+					<State>
+						<Number>0</Number>
+						<Unpressed scalemode="STRETCH">
+							skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill.svg
+						</Unpressed>
+						<Pressed scalemode="STRETCH">
+							skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg
+						</Pressed>
+					</State>
+					<State>
+						<Number>1</Number>
+						<Unpressed scalemode="STRETCH">
+							skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg
+						</Unpressed>
+						<Pressed scalemode="STRETCH">
+							skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg
+						</Pressed>
+					</State>
+					<Connection>
+						<ConfigKey>[QuickEffectRack1_[Channel<Variable name="ChanNum"/>Stem<Variable name="StemNum"/>]],enabled</ConfigKey>
+						<ButtonState>LeftButton</ButtonState>
+					</Connection>
+					<Connection>
+						<ConfigKey>[Skin],show_eq_kill_buttons</ConfigKey>
+						<BindProperty>visible</BindProperty>
+					</Connection>
+				</PushButton>
+
+              <KnobComposed>
+                <TooltipId>QuickEffectRack_super1</TooltipId>
+				  <Pos>0,0</Pos>
+                <Size>40f,26f</Size>
+                <Knob>skins:LateNight/<Variable name="KnobScheme"/>/knobs/knob_indicator_<Variable name="KnobIndicator"/>_<Variable name="KnobColorQuickEffect"/>.svg</Knob>
+                <BackPath>skins:LateNight/<Variable name="KnobScheme"/>/knobs/knob_bg_<Variable name="KnobBg"/>.svg</BackPath>
+                <MinAngle><Variable name="PotiMinAngle"/></MinAngle>
+                <MaxAngle><Variable name="PotiMaxAngle"/></MaxAngle>
+                <ArcRadius><Variable name="ArcRadius"/></ArcRadius>
+                <ArcUnipolar><Variable name="ArcUnipolar"/></ArcUnipolar>
+                <ArcReversed><Variable name="ArcReversed"/></ArcReversed>
+                <ArcColor><Variable name="ArcColorFx12Quick"/></ArcColor>
+                <ArcThickness><Variable name="ArcThickness"/></ArcThickness>
+                <ArcRoundCaps><Variable name="ArcRoundCaps"/></ArcRoundCaps>
+                <KnobCenterYOffset>1.998</KnobCenterYOffset>
+                <Connection>
+					<ConfigKey>[QuickEffectRack1_[Channel<Variable name="ChanNum"/>Stem<Variable name="StemNum"/>]],super1</ConfigKey>
+                </Connection>
+              </KnobComposed>
+
+            </Children>
+          </WidgetGroup>
+
+    </Children>
+    <Connection>
+      <ConfigKey><Variable name="QuickEffectGroup"/>,loaded_chain_preset</ConfigKey>
+      <Transform>
+        <IsEqual>0</IsEqual>
+        <Not/>
+      </Transform>
+      <BindProperty>visible</BindProperty>
+    </Connection>
+  </WidgetGroup>
+</Template>

--- a/res/skins/LateNight/stem_channel.xml
+++ b/res/skins/LateNight/stem_channel.xml
@@ -1,18 +1,16 @@
-<!DOCTYPE template>
 <Template>
-  <SetVariable name="QuickEffectGroup">[QuickEffectRack1_<Variable name="Group"/>]</SetVariable>
-
-  <WidgetGroup>
+	<WidgetGroup>
     <Layout>horizontal</Layout>
     <SizePolicy>min,min</SizePolicy>
     <Children>
 		<WidgetGroup>
-			<ObjectName>ChannelMixer_KnobContainer</ObjectName>
+			<ObjectName>StemChannel_ControlContainer</ObjectName>
 			<Layout>horizontal</Layout>
 			<SizePolicy>min,min</SizePolicy>
 			<Children>
 
 			<StemLabel>
+				<TooltipId>StemLabel</TooltipId>
 				<ObjectName>StemLabel</ObjectName>
 				<Group><Variable name="Group"/></Group>
 				<StemNum><Variable name="StemNum"/></StemNum>
@@ -24,27 +22,20 @@
 
 
 				<PushButton>
+					<TooltipId>StemMuteButton</TooltipId>
 					<ObjectName>StemMuteButton</ObjectName>
 					<Pos>36,4</Pos>
 					<Size>18f,18f</Size>
 					<NumberStates>2</NumberStates>
 					<State>
 						<Number>0</Number>
-						<Unpressed scalemode="STRETCH">
-							skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill.svg
-						</Unpressed>
-						<Pressed scalemode="STRETCH">
-							skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg
-						</Pressed>
+						<Unpressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill.svg</Unpressed>
+						<Pressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Pressed>
 					</State>
 					<State>
 						<Number>1</Number>
-						<Unpressed scalemode="STRETCH">
-							skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg
-						</Unpressed>
-						<Pressed scalemode="STRETCH">
-							skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg
-						</Pressed>
+						<Unpressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Unpressed>
+						<Pressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Pressed>
 					</State>
 					<Connection>
 						<ButtonState>LeftButton</ButtonState>
@@ -64,7 +55,7 @@
 				</PushButton>
 
 			   <KnobComposed>
-                <TooltipId>QuickEffectRack_super1</TooltipId>
+                <TooltipId>StemVolumeKnob</TooltipId>
 				  <Pos>0,0</Pos>
                 <Size>40f,26f</Size>
                 <Knob>skins:LateNight/<Variable name="KnobScheme"/>/knobs/knob_indicator_<Variable name="KnobIndicator"/>_orange.svg</Knob>
@@ -92,63 +83,23 @@
 
 				<PushButton>
 					<TooltipId>QuickEffectRack_enabled</TooltipId>
-					<ObjectName>QuickEffectDot</ObjectName>
-					<Pos>30,20</Pos>
-					<Size>
-						<Variable name="EqKillDotSize"/>
-					</Size>
-					<NumberStates>2</NumberStates>
-					<RightClickIsPushButton>false</RightClickIsPushButton>
-					<State>
-						<Number>0</Number>
-					</State>
-					<State>
-						<Number>1</Number>
-					</State>
-					<Connection>
-						<ConfigKey>[QuickEffectRack1_[Channel<Variable name="ChanNum"/>Stem<Variable name="StemNum"/>]],enabled</ConfigKey>
-						<ButtonState>LeftButton</ButtonState>
-					</Connection>
-					<Connection>
-						<ConfigKey>[Skin],show_eq_kill_buttons</ConfigKey>
-						<Transform>
-							<Not/>
-						</Transform>
-						<BindProperty>visible</BindProperty>
-					</Connection>
-				</PushButton>
-
-				<PushButton>
-					<TooltipId>QuickEffectRack_enabled</TooltipId>
 					<ObjectName>QuickEffectButton</ObjectName>
 					<Pos>36,4</Pos>
 					<Size>18f,18f</Size>
 					<NumberStates>2</NumberStates>
 					<State>
 						<Number>0</Number>
-						<Unpressed scalemode="STRETCH">
-							skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill.svg
-						</Unpressed>
-						<Pressed scalemode="STRETCH">
-							skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg
-						</Pressed>
+						<Unpressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill.svg</Unpressed>
+						<Pressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Pressed>
 					</State>
 					<State>
 						<Number>1</Number>
-						<Unpressed scalemode="STRETCH">
-							skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg
-						</Unpressed>
-						<Pressed scalemode="STRETCH">
-							skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg
-						</Pressed>
+						<Unpressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Unpressed>
+						<Pressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Pressed>
 					</State>
 					<Connection>
 						<ConfigKey>[QuickEffectRack1_[Channel<Variable name="ChanNum"/>Stem<Variable name="StemNum"/>]],enabled</ConfigKey>
 						<ButtonState>LeftButton</ButtonState>
-					</Connection>
-					<Connection>
-						<ConfigKey>[Skin],show_eq_kill_buttons</ConfigKey>
-						<BindProperty>visible</BindProperty>
 					</Connection>
 				</PushButton>
 
@@ -176,13 +127,5 @@
           </WidgetGroup>
 
     </Children>
-    <Connection>
-      <ConfigKey><Variable name="QuickEffectGroup"/>,loaded_chain_preset</ConfigKey>
-      <Transform>
-        <IsEqual>0</IsEqual>
-        <Not/>
-      </Transform>
-      <BindProperty>visible</BindProperty>
-    </Connection>
   </WidgetGroup>
 </Template>

--- a/res/skins/LateNight/stem_channel.xml
+++ b/res/skins/LateNight/stem_channel.xml
@@ -1,13 +1,11 @@
 <Template>
+  <SetVariable name="StemGroup">[Channel<Variable name="ChanNum"/>Stem<Variable name="StemNum"/>]</SetVariable>
+
 	<WidgetGroup>
-    <Layout>horizontal</Layout>
-    <SizePolicy>min,min</SizePolicy>
-    <Children>
-		<WidgetGroup>
-			<ObjectName>StemChannel_ControlContainer</ObjectName>
-			<Layout>horizontal</Layout>
-			<SizePolicy>min,min</SizePolicy>
-			<Children>
+		<ObjectName>StemChannel_ControlContainer</ObjectName>
+		<Layout>horizontal</Layout>
+		<SizePolicy>min,min</SizePolicy>
+		<Children>
 
 			<StemLabel>
 				<TooltipId>StemLabel</TooltipId>
@@ -20,111 +18,107 @@
 				<Text></Text>
 			</StemLabel>
 
+			<PushButton>
+				<TooltipId>StemMuteButton</TooltipId>
+				<ObjectName>StemMuteButton</ObjectName>
+				<Size>18f,18f</Size>
+				<NumberStates>2</NumberStates>
+				<State>
+					<Number>0</Number>
+					<Unpressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill.svg</Unpressed>
+					<Pressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Pressed>
+				</State>
+				<State>
+					<Number>1</Number>
+					<Unpressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Unpressed>
+					<Pressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Pressed>
+				</State>
+				<Connection>
+					<ButtonState>LeftButton</ButtonState>
+					<ConfigKey><Variable name="StemGroup"/>,mute_toggle</ConfigKey>
+					<Transform>
+						<Not/>
+					</Transform>
+				</Connection>
+				<Connection>
+					<ButtonState>LeftButton</ButtonState>
+					<ConfigKey><Variable name="StemGroup"/>,mute</ConfigKey>
+                      <ConnectValueFromWidget>true</ConnectValueFromWidget>
+					<Transform>
+						<Not/>
+					</Transform>
+				</Connection>
+			</PushButton>
 
-				<PushButton>
-					<TooltipId>StemMuteButton</TooltipId>
-					<ObjectName>StemMuteButton</ObjectName>
-					<Pos>36,4</Pos>
-					<Size>18f,18f</Size>
-					<NumberStates>2</NumberStates>
-					<State>
-						<Number>0</Number>
-						<Unpressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill.svg</Unpressed>
-						<Pressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Pressed>
-					</State>
-					<State>
-						<Number>1</Number>
-						<Unpressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Unpressed>
-						<Pressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Pressed>
-					</State>
-					<Connection>
-						<ButtonState>LeftButton</ButtonState>
-						<ConfigKey>[Channel<Variable name="ChanNum"/>Stem<Variable name="StemNum"/>],mute_toggle</ConfigKey>
-						<Transform>
-							<Not/>
-						</Transform>
-					</Connection>
-					<Connection>
-						<ButtonState>LeftButton</ButtonState>
-						<ConfigKey>[Channel<Variable name="ChanNum"/>Stem<Variable name="StemNum"/>],mute</ConfigKey>
-                        <ConnectValueFromWidget>true</ConnectValueFromWidget>
-						<Transform>
-							<Not/>
-						</Transform>
-					</Connection>
-				</PushButton>
+	    <KnobComposed>
+        <TooltipId>StemVolumeKnob</TooltipId>
+        <Size>26f,26f</Size>
+        <Knob>skins:LateNight/<Variable name="KnobScheme"/>/knobs/knob_indicator_<Variable name="KnobIndicator"/>_orange.svg</Knob>
+        <BackPath>skins:LateNight/<Variable name="KnobScheme"/>/knobs/knob_bg_fx.svg</BackPath>
+        <MinAngle><Variable name="PotiMinAngle"/></MinAngle>
+        <MaxAngle><Variable name="PotiMaxAngle"/></MaxAngle>
+        <ArcRadius><Variable name="ArcRadiusSmall"/></ArcRadius>
+        <ArcUnipolar><Variable name="ArcUnipolar"/></ArcUnipolar>
+        <ArcReversed><Variable name="ArcReversed"/></ArcReversed>
+        <ArcColor><Variable name="ArcColorGain"/></ArcColor>
+        <ArcThickness><Variable name="ArcThickness"/></ArcThickness>
+        <ArcRoundCaps><Variable name="ArcRoundCaps"/></ArcRoundCaps>
+        <!-- <KnobCenterYOffset>1.998</KnobCenterYOffset> -->
+        <Connection>
+          <ConfigKey><Variable name="StemGroup"/>,volume</ConfigKey>
+        </Connection>
+      </KnobComposed>
 
-			   <KnobComposed>
-                <TooltipId>StemVolumeKnob</TooltipId>
-				  <Pos>0,0</Pos>
-                <Size>40f,26f</Size>
-                <Knob>skins:LateNight/<Variable name="KnobScheme"/>/knobs/knob_indicator_<Variable name="KnobIndicator"/>_orange.svg</Knob>
-                <BackPath>skins:LateNight/<Variable name="KnobScheme"/>/knobs/knob_bg_<Variable name="KnobBg"/>.svg</BackPath>
-                <MinAngle><Variable name="PotiMinAngle"/></MinAngle>
-                <MaxAngle><Variable name="PotiMaxAngle"/></MaxAngle>
-                <ArcRadius><Variable name="ArcRadius"/></ArcRadius>
-                <ArcUnipolar><Variable name="ArcUnipolar"/></ArcUnipolar>
-                <ArcReversed><Variable name="ArcReversed"/></ArcReversed>
-                <ArcColor><Variable name="ArcColorGain"/></ArcColor>
-                <ArcThickness><Variable name="ArcThickness"/></ArcThickness>
-                <ArcRoundCaps><Variable name="ArcRoundCaps"/></ArcRoundCaps>
-                <KnobCenterYOffset>1.998</KnobCenterYOffset>
-                <Connection>
-                  <ConfigKey>[Channel<Variable name="ChanNum"/>Stem<Variable name="StemNum"/>],volume</ConfigKey>
-                </Connection>
-              </KnobComposed>
-
+      <WidgetGroup><Size>4f,0min</Size></WidgetGroup>
 
 			<EffectChainPresetSelector>
-				<ObjectName>QuickEffectSelectorLeft</ObjectName>
+				<ObjectName>StemQuickEffectSelector</ObjectName>
 				<Size>85f,18f</Size>
-				<EffectUnitGroup>[QuickEffectRack1_[Channel<Variable name="ChanNum"/>Stem<Variable name="StemNum"/>]]</EffectUnitGroup>
+				<EffectUnitGroup>[QuickEffectRack1_<Variable name="StemGroup"/>]</EffectUnitGroup>
 			</EffectChainPresetSelector>
 
-				<PushButton>
-					<TooltipId>QuickEffectRack_enabled</TooltipId>
-					<ObjectName>QuickEffectButton</ObjectName>
-					<Pos>36,4</Pos>
-					<Size>18f,18f</Size>
-					<NumberStates>2</NumberStates>
-					<State>
-						<Number>0</Number>
-						<Unpressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill.svg</Unpressed>
-						<Pressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Pressed>
-					</State>
-					<State>
-						<Number>1</Number>
-						<Unpressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Unpressed>
-						<Pressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Pressed>
-					</State>
-					<Connection>
-						<ConfigKey>[QuickEffectRack1_[Channel<Variable name="ChanNum"/>Stem<Variable name="StemNum"/>]],enabled</ConfigKey>
-						<ButtonState>LeftButton</ButtonState>
-					</Connection>
-				</PushButton>
+      <WidgetGroup><Size>2f,0min</Size></WidgetGroup>
 
-              <KnobComposed>
-                <TooltipId>QuickEffectRack_super1</TooltipId>
-				  <Pos>0,0</Pos>
-                <Size>40f,26f</Size>
-                <Knob>skins:LateNight/<Variable name="KnobScheme"/>/knobs/knob_indicator_<Variable name="KnobIndicator"/>_<Variable name="KnobColorQuickEffect"/>.svg</Knob>
-                <BackPath>skins:LateNight/<Variable name="KnobScheme"/>/knobs/knob_bg_<Variable name="KnobBg"/>.svg</BackPath>
-                <MinAngle><Variable name="PotiMinAngle"/></MinAngle>
-                <MaxAngle><Variable name="PotiMaxAngle"/></MaxAngle>
-                <ArcRadius><Variable name="ArcRadius"/></ArcRadius>
-                <ArcUnipolar><Variable name="ArcUnipolar"/></ArcUnipolar>
-                <ArcReversed><Variable name="ArcReversed"/></ArcReversed>
-                <ArcColor><Variable name="ArcColorFx12Quick"/></ArcColor>
-                <ArcThickness><Variable name="ArcThickness"/></ArcThickness>
-                <ArcRoundCaps><Variable name="ArcRoundCaps"/></ArcRoundCaps>
-                <KnobCenterYOffset>1.998</KnobCenterYOffset>
-                <Connection>
-					<ConfigKey>[QuickEffectRack1_[Channel<Variable name="ChanNum"/>Stem<Variable name="StemNum"/>]],super1</ConfigKey>
-                </Connection>
-              </KnobComposed>
+			<PushButton>
+				<TooltipId>QuickEffectRack_enabled</TooltipId>
+				<ObjectName>QuickEffectButton</ObjectName>
+				<Size>18f,18f</Size>
+				<NumberStates>2</NumberStates>
+				<State>
+					<Number>0</Number>
+					<Unpressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill.svg</Unpressed>
+					<Pressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Pressed>
+				</State>
+				<State>
+					<Number>1</Number>
+					<Unpressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Unpressed>
+					<Pressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Pressed>
+				</State>
+				<Connection>
+					<ConfigKey>[QuickEffectRack1_<Variable name="StemGroup"/>],enabled</ConfigKey>
+					<ButtonState>LeftButton</ButtonState>
+				</Connection>
+			</PushButton>
 
-            </Children>
-          </WidgetGroup>
+      <WidgetGroup><Size>2f,0min</Size></WidgetGroup>
+
+      <KnobComposed>
+        <TooltipId>QuickEffectRack_super1</TooltipId>
+        <Size>26f,26f</Size>
+        <Knob>skins:LateNight/<Variable name="KnobScheme"/>/knobs/knob_indicator_<Variable name="KnobIndicator"/>_<Variable name="KnobColorQuickEffect"/>.svg</Knob>
+        <BackPath>skins:LateNight/<Variable name="KnobScheme"/>/knobs/knob_bg_fx.svg</BackPath>
+        <MinAngle><Variable name="PotiMinAngle"/></MinAngle>
+        <MaxAngle><Variable name="PotiMaxAngle"/></MaxAngle>
+        <ArcRadius><Variable name="ArcRadiusSmall"/></ArcRadius>
+        <ArcUnipolar><Variable name="ArcUnipolar"/></ArcUnipolar>
+        <ArcReversed><Variable name="ArcReversed"/></ArcReversed>
+        <ArcColor><Variable name="ArcColorFx12Quick"/></ArcColor>
+        <ArcThickness><Variable name="ArcThickness"/></ArcThickness>
+        <ArcRoundCaps><Variable name="ArcRoundCaps"/></ArcRoundCaps>
+        <Connection>
+					<ConfigKey>[QuickEffectRack1_<Variable name="StemGroup"/>],super1</ConfigKey>
+        </Connection>
+      </KnobComposed>
 
     </Children>
   </WidgetGroup>

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -402,6 +402,13 @@ WOverview QLabel {
 
 
 
+/************** Waveforms *****************************************************/
+
+#StemChannel_ControlContainer {
+  margin: 0px 3px 0px 2px;
+}
+
+
 /************** Decks *********************************************************/
 
 #DeckRows12345 {
@@ -660,8 +667,14 @@ WEffectChainPresetSelector {
     padding: 0px -1px 0px -5px;
     margin: 0px;
     text-align: right;
+  }
+  WEffectChainPresetSelector#StemQuickEffectSelector {
+    padding: 0px -5px 0px 2px;
+    margin: 0px;
+    text-align: left;
     }
-    WEffectChainPresetSelector#QuickEffectSelectorRight::drop-down {
+    WEffectChainPresetSelector#QuickEffectSelectorRight::drop-down,
+    WEffectChainPresetSelector#StemQuickEffectSelector::drop-down {
       subcontrol-origin: margin;
       subcontrol-position: right center;
     }

--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -1371,6 +1371,7 @@ WEffectSelector[highlight="1"] {  /*
 }
 
 #BeatgridControls WPushButton, WPushButton#BeatgridControlsToggle,
+#StemControls WPushButton, WPushButton#StemControlsToggle,
 #DeckRow_5_LoopCuesTransport WPushButton,
 WPushButton#PlayDeck,
 WPushButton#PreviewIndicator,
@@ -1626,6 +1627,7 @@ WPushButton#FxExpand[displayValue="0"],
 WPushButton#FxExpandOverlay[displayValue="0"],
 WPushButton#SamplerExpand[displayValue="0"],
 #BeatgridControlsToggle,
+#StemControlsToggle,
 #SamplerControlsMini WPushButton,
 #RecDot,
 /* transparent buttons, 0-4 (max button state we have currently) */
@@ -1940,6 +1942,14 @@ WPushButton#BpmLockToggle[value="1"] {
   #BeatgridControlsToggle[displayValue="1"] {
     image: url(skins:LateNight/classic/buttons/btn__beatgrid_controls_collapse.svg) no-repeat center center;
   }
+
+#StemControlsToggle[displayValue="0"] {
+  image: url(skins:LateNight/classic/buttons/btn__stem_controls_expand.svg) no-repeat center center;
+  }
+  #StemControlsToggle[displayValue="1"] {
+    image: url(skins:LateNight/classic/buttons/btn__stem_controls_collapse.svg) no-repeat center center;
+  }
+
   #BpmLockToggle[value="1"] {
     image: url(skins:LateNight/classic/buttons/btn__bpm_locked.svg);
     }

--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -1421,6 +1421,7 @@ WPushButton#LibExpand,
 WPushButton#CueDeck[displayValue="0"],
 WPushButton#PlayIndicator[value="0"],
 WPushButton#LoopActivate[displayValue="0"],
+WPushButton#StemMuteButton[displayValue="0"],
 #FxAssignButtons WPushButton[displayValue="0"],
 #VinylControls WPushButton[displayValue="0"],
 #KeyControls WPushButton[displayValue="0"],
@@ -1484,6 +1485,10 @@ QPushButton#pushButtonRecording:checked {
     border-radius: 0px;
   }
 
+/* Orange for Stem Ch Mute buttons */
+WPushButton#StemMuteButton{
+  background-color: #db7700;
+}
 /* Green for Fx buttons: QuickEffect + Fx 1/2 */
 #FxUnit1 #FxToggleButton[displayValue="1"],
 #FxUnit2 #FxToggleButton[displayValue="1"],
@@ -1815,6 +1820,10 @@ WPushButton#BpmLockToggle[value="1"] {
 /* Mixer buttons */
 #PflButton {
   image: url(skins:LateNight/classic/buttons/btn__pfl.svg) no-repeat center center;
+}
+
+#StemMuteButton[displayValue="0"] {
+  image: url(skins:LateNight/classic/buttons/btn__stem_mute.svg) no-repeat center center;
 }
 
 #QuickEffectButton[displayValue="0"] {

--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -195,6 +195,16 @@ WSearchLineEdit,
     border: 1px solid red;
   }
 
+#BeatgridControls,
+#StemControls {
+  border-top: 1px solid #222;
+  border-left: 1px solid #222;
+  border-bottom: 1px solid #111;
+  border-right: 1px solid #111;
+  border-radius: 2px;
+  background-color: #171717;
+  }
+
 #VuMainCover {
   background-color: rgba(21, 21, 21, 150);
 }

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -1588,6 +1588,7 @@ WPushButton#CueDeck[displayValue="0"],
 WPushButton#LoopActivate[displayValue="0"],
 #KeyControls WPushButton[displayValue="0"],
 #EQKillButtonBox WPushButton[displayValue="0"],
+WPushButton#StemMuteButton[displayValue="0"],
 WPushButton#QuickEffectButton[displayValue="0"],
 WPushButton#FxToggleButton[displayValue="0"],
 #MicAuxUnit WPushButton[displayValue="0"],
@@ -1708,6 +1709,10 @@ QPushButton#pushButtonRecording:checked,
   background-color: #a80000;
 }
 
+/* Orange for Stem Ch Mute buttons */
+WPushButton#StemMuteButton{
+  background-color: #b24c12;
+}
 /* Green for Fx toggles, QuickEffect + Fx12 */
 #FxUnit1 #FxToggleButton[displayValue="1"],
 #FxUnit2 #FxToggleButton[displayValue="1"],
@@ -2219,6 +2224,10 @@ WPushButton#PlayDeck[value="0"] {
   #PflButton[value="1"] {
     image: url(skins:LateNight/palemoon/buttons/btn__pfl_active.svg) no-repeat center center;
   }
+
+#StemMuteButton[displayValue="0"] {
+  image: url(skins:LateNight/palemoon/buttons/btn__stem_mute.svg) no-repeat center center;
+}
 
 #QuickEffectButton[displayValue="0"] {
   image: url(skins:LateNight/palemoon/buttons/btn__star.svg) no-repeat center center;

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -241,6 +241,17 @@ WSearchLineEdit {
   border-bottom: 1px solid #0c0c0c;
 }
 
+#BeatgridControls,
+#StemControls {
+  border-top: 1px solid #1c1c1c;
+  border-left: 1px solid #1c1c1c;
+  border-bottom: 1px solid #020202;
+  border-right: 1px solid #111;
+  border-radius: 1px;
+  background-color: #151517;
+  }
+
+
 #FxParametersFocusBg {
   border: 1px solid #257B82;
   background-color: rgba(0,0,1,50);

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -911,7 +911,8 @@ WEffectSelector:!editable:on {
       names start getting cut off. Adding explicit padding improves this. */
   padding: 3px 0px 1px 5px;
   margin: 0px;
-}
+  }
+
 #fadeModeCombobox:!editable,
 #fadeModeCombobox:!editable:on {
   min-height: 17px;
@@ -1685,6 +1686,7 @@ WPushButton#Reverse[pressed="true"],
 #MicTalk[value="1"], #AuxPlay[value="1"],
 #MicDucking[value="1"],
 #MicDucking[value="2"],
+WPushButton#StemMuteButton,
 #PassthroughButton[displayValue="1"],
 #BroadcastButton[displayValue="4"], /* warning */
 QPushButton#pushButtonAutoDJ:checked,
@@ -1720,10 +1722,6 @@ QPushButton#pushButtonRecording:checked,
   background-color: #a80000;
 }
 
-/* Orange for Stem Ch Mute buttons */
-WPushButton#StemMuteButton{
-  background-color: #b24c12;
-}
 /* Green for Fx toggles, QuickEffect + Fx12 */
 #FxUnit1 #FxToggleButton[displayValue="1"],
 #FxUnit2 #FxToggleButton[displayValue="1"],

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -1536,6 +1536,7 @@ WEffectSelector:!editable,
   }
 
 #BeatgridControls WPushButton, WPushButton#BeatgridControlsToggle,
+#StemControls WPushButton, WPushButton#StemControlsToggle,
 #DeckRow_5_LoopCuesTransport WPushButton,
 #RateControls WPushButton,
 WPushButton#PlayDeck,
@@ -1849,6 +1850,7 @@ QPushButton#pushButtonRepeatPlaylist:checked {
 
 /* Special flat/invisible buttons */
 #BeatgridControlsToggle,
+#StemControlsToggle,
 WPushButton#PlayDeck[displayValue="0"],
 WPushButton#PlayDeckMini[displayValue="0"],
 WPushButton#PlaySampler[displayValue="0"],
@@ -2351,6 +2353,13 @@ WPushButton#PlayDeck[value="0"] {
     #KeylockButton34[displayValue="1"] {
       image: url(skins:LateNight/palemoon/buttons/btn__keylock_active_34.svg) no-repeat center center;
     }
+
+#StemControlsToggle[displayValue="0"] {
+  image: url(skins:LateNight/palemoon/buttons/btn__stem_controls_expand.svg) no-repeat center center;
+  }
+  #StemControlsToggle[displayValue="1"] {
+    image: url(skins:LateNight/palemoon/buttons/btn__stem_controls_collapse.svg) no-repeat center center;
+  }
 
 #BeatgridControlsToggle[displayValue="0"] {
   image: url(skins:LateNight/palemoon/buttons/btn__beatgrid_controls_expand.svg) no-repeat center center;

--- a/res/skins/LateNight/waveform.xml
+++ b/res/skins/LateNight/waveform.xml
@@ -5,25 +5,16 @@
   <SetVariable name="CoverName">BeatEditCover</SetVariable>
   <SetVariable name="CoverConfigKey"><Variable name="Group"/>,bpmlock</SetVariable>
 
-    <SetVariable name="EqFxUnit">
-	    [EqualizerRack1_<Variable name="Group"/>]
-    </SetVariable>
-    <SetVariable name="EqEffect">
-	    [EqualizerRack1_<Variable name="Group"/>_Effect1]
-    </SetVariable>
+	<SetVariable name="KnobBg">regular</SetVariable>
+	<SetVariable name="KnobIndicator">regular</SetVariable>
+	<SetVariable name="ArcRadius">
+		<Variable name="ArcRadiusBig"/>
+	</SetVariable>
+	<SetVariable name="ArcThickness">
+		<Variable name="ArcThicknessBig"/>
+	</SetVariable>
 
-    <SetVariable name="KnobBg">regular</SetVariable>
-    <SetVariable name="KnobIndicator">regular</SetVariable>
-    <SetVariable name="ArcRadius">
-	    <Variable name="ArcRadiusBig"/>
-    </SetVariable>
-    <SetVariable name="ArcThickness">
-	    <Variable name="ArcThicknessBig"/>
-    </SetVariable>
-
-
-
-  <WidgetGroup>
+	<WidgetGroup>
     <ObjectName>Waveform</ObjectName>
     <Layout>horizontal</Layout>
     <SizePolicy>me,me</SizePolicy>
@@ -38,7 +29,7 @@
 				</WidgetGroup>
 
 				<WidgetGroup>
-					<!-- beat grid & hotcue shift buttons row -->
+					<!-- StemControlsInner -->
 					<Layout>horizontal</Layout>
 					<SizePolicy>f,f</SizePolicy>
 					<Children>
@@ -48,11 +39,11 @@
 						</WidgetGroup>
 
 						<WidgetGroup>
-							<!-- beats earlier & faster -->
+							<!-- StemControls 4ch -->
 							<Layout>vertical</Layout>
 							<Children>
 								<WidgetGroup>
-									<!-- Curr. pos & Lock -->
+									<!-- StemCh1 controls  -->
 									<Layout>horizontal</Layout>
 									<Children>
 										<WidgetGroup>
@@ -67,7 +58,7 @@
 									</Children>
 								</WidgetGroup>
 								<WidgetGroup>
-									<!-- Curr. pos & Lock -->
+									<!-- StemCh2 controls  -->
 									<Layout>horizontal</Layout>
 									<Children>
 										<WidgetGroup>
@@ -82,7 +73,7 @@
 									</Children>
 								</WidgetGroup>
 								<WidgetGroup>
-									<!-- Curr. pos & Lock -->
+									<!-- StemCh3 controls  -->
 									<Layout>horizontal</Layout>
 									<Children>
 										<WidgetGroup>
@@ -97,7 +88,7 @@
 									</Children>
 								</WidgetGroup>
 								<WidgetGroup>
-									<!-- Curr. pos & Lock -->
+									<!-- StemCh4 controls  -->
 									<Layout>horizontal</Layout>
 									<Children>
 										<WidgetGroup>
@@ -113,11 +104,11 @@
 								</WidgetGroup>
 							</Children>
 						</WidgetGroup>
-						<!-- /beats earlier & faster -->
+						<!-- /StemControls 4ch -->
 
 					</Children>
 				</WidgetGroup>
-				<!-- /beat grid & hotcue shift buttons row -->
+				<!-- /StemControlsInner -->
 
 				<WidgetGroup>
 					<Size>1me,1me</Size>
@@ -127,8 +118,7 @@
 				<ConfigKey persist="true">[Skin],show_stem_controls</ConfigKey>
 				<BindProperty>visible</BindProperty>
 			</Connection>
-		</WidgetGroup>
-		<!-- StemControls -->
+		</WidgetGroup><!-- StemControls -->
 
 
 		<WidgetGroup>

--- a/res/skins/LateNight/waveform.xml
+++ b/res/skins/LateNight/waveform.xml
@@ -5,12 +5,133 @@
   <SetVariable name="CoverName">BeatEditCover</SetVariable>
   <SetVariable name="CoverConfigKey"><Variable name="Group"/>,bpmlock</SetVariable>
 
+    <SetVariable name="EqFxUnit">
+	    [EqualizerRack1_<Variable name="Group"/>]
+    </SetVariable>
+    <SetVariable name="EqEffect">
+	    [EqualizerRack1_<Variable name="Group"/>_Effect1]
+    </SetVariable>
+
+    <SetVariable name="KnobBg">regular</SetVariable>
+    <SetVariable name="KnobIndicator">regular</SetVariable>
+    <SetVariable name="ArcRadius">
+	    <Variable name="ArcRadiusBig"/>
+    </SetVariable>
+    <SetVariable name="ArcThickness">
+	    <Variable name="ArcThicknessBig"/>
+    </SetVariable>
+
+
+
   <WidgetGroup>
     <ObjectName>Waveform</ObjectName>
     <Layout>horizontal</Layout>
     <SizePolicy>me,me</SizePolicy>
     <Children>
-      <WidgetGroup>
+		<WidgetGroup>
+			<ObjectName>StemControls</ObjectName>
+			<Layout>vertical</Layout>
+			<SizePolicy>max,me</SizePolicy>
+			<Children>
+				<WidgetGroup>
+					<Size>0me,1me</Size>
+				</WidgetGroup>
+
+				<WidgetGroup>
+					<!-- beat grid & hotcue shift buttons row -->
+					<Layout>horizontal</Layout>
+					<SizePolicy>f,f</SizePolicy>
+					<Children>
+
+						<WidgetGroup>
+							<Size>1f,0min</Size>
+						</WidgetGroup>
+
+						<WidgetGroup>
+							<!-- beats earlier & faster -->
+							<Layout>vertical</Layout>
+							<Children>
+								<WidgetGroup>
+									<!-- Curr. pos & Lock -->
+									<Layout>horizontal</Layout>
+									<Children>
+										<WidgetGroup>
+											<Size>1min,2me</Size>
+										</WidgetGroup>
+										<Template src="skins:LateNight/stem_channel.xml">
+											<SetVariable name="StemNum">1</SetVariable>
+										</Template>
+										<WidgetGroup>
+											<Size>1min,3f</Size>
+										</WidgetGroup>
+									</Children>
+								</WidgetGroup>
+								<WidgetGroup>
+									<!-- Curr. pos & Lock -->
+									<Layout>horizontal</Layout>
+									<Children>
+										<WidgetGroup>
+											<Size>1min,2me</Size>
+										</WidgetGroup>
+										<Template src="skins:LateNight/stem_channel.xml">
+											<SetVariable name="StemNum">2</SetVariable>
+										</Template>
+										<WidgetGroup>
+											<Size>1min,3f</Size>
+										</WidgetGroup>
+									</Children>
+								</WidgetGroup>
+								<WidgetGroup>
+									<!-- Curr. pos & Lock -->
+									<Layout>horizontal</Layout>
+									<Children>
+										<WidgetGroup>
+											<Size>1min,2me</Size>
+										</WidgetGroup>
+										<Template src="skins:LateNight/stem_channel.xml">
+											<SetVariable name="StemNum">3</SetVariable>
+										</Template>
+										<WidgetGroup>
+											<Size>1min,3f</Size>
+										</WidgetGroup>
+									</Children>
+								</WidgetGroup>
+								<WidgetGroup>
+									<!-- Curr. pos & Lock -->
+									<Layout>horizontal</Layout>
+									<Children>
+										<WidgetGroup>
+											<Size>1min,2me</Size>
+										</WidgetGroup>
+										<Template src="skins:LateNight/stem_channel.xml">
+											<SetVariable name="StemNum">4</SetVariable>
+										</Template>
+										<WidgetGroup>
+											<Size>1min,3f</Size>
+										</WidgetGroup>
+									</Children>
+								</WidgetGroup>
+							</Children>
+						</WidgetGroup>
+						<!-- /beats earlier & faster -->
+
+					</Children>
+				</WidgetGroup>
+				<!-- /beat grid & hotcue shift buttons row -->
+
+				<WidgetGroup>
+					<Size>1me,1me</Size>
+				</WidgetGroup>
+			</Children>
+			<Connection>
+				<ConfigKey persist="true">[Skin],show_stem_controls</ConfigKey>
+				<BindProperty>visible</BindProperty>
+			</Connection>
+		</WidgetGroup>
+		<!-- StemControls -->
+
+
+		<WidgetGroup>
         <ObjectName>WaveformBox<Variable name="ChanNum"/></ObjectName>
         <Layout>horizontal</Layout>
         <SizePolicy>me,me</SizePolicy>

--- a/res/skins/LateNight/waveform.xml
+++ b/res/skins/LateNight/waveform.xml
@@ -5,123 +5,124 @@
   <SetVariable name="CoverName">BeatEditCover</SetVariable>
   <SetVariable name="CoverConfigKey"><Variable name="Group"/>,bpmlock</SetVariable>
 
-	<SetVariable name="KnobBg">regular</SetVariable>
-	<SetVariable name="KnobIndicator">regular</SetVariable>
-	<SetVariable name="ArcRadius">
-		<Variable name="ArcRadiusBig"/>
-	</SetVariable>
-	<SetVariable name="ArcThickness">
-		<Variable name="ArcThicknessBig"/>
-	</SetVariable>
+  <SetVariable name="KnobBg">regular</SetVariable>
+  <SetVariable name="KnobIndicator">regular</SetVariable>
+  <SetVariable name="ArcRadius">
+    <Variable name="ArcRadiusBig"/>
+  </SetVariable>
+  <SetVariable name="ArcThickness">
+    <Variable name="ArcThicknessBig"/>
+  </SetVariable>
 
-	<WidgetGroup>
+  <WidgetGroup>
     <ObjectName>Waveform</ObjectName>
     <Layout>horizontal</Layout>
     <SizePolicy>me,me</SizePolicy>
     <Children>
-		<WidgetGroup>
-			<ObjectName>StemControls</ObjectName>
-			<Layout>vertical</Layout>
-			<SizePolicy>max,me</SizePolicy>
-			<Children>
-				<WidgetGroup>
-					<Size>0me,1me</Size>
-				</WidgetGroup>
+      <WidgetGroup>
+        <RequiresStem>true</RequiresStem>
+        <ObjectName>StemControls</ObjectName>
+        <Layout>vertical</Layout>
+        <SizePolicy>max,me</SizePolicy>
+        <Children>
+          <WidgetGroup>
+            <Size>0me,1me</Size>
+          </WidgetGroup>
 
-				<WidgetGroup>
-					<!-- StemControlsInner -->
-					<Layout>horizontal</Layout>
-					<SizePolicy>f,f</SizePolicy>
-					<Children>
+          <WidgetGroup>
+            <!-- StemControlsInner -->
+            <Layout>horizontal</Layout>
+            <SizePolicy>f,f</SizePolicy>
+            <Children>
 
-						<WidgetGroup>
-							<Size>1f,0min</Size>
-						</WidgetGroup>
+              <WidgetGroup>
+                <Size>1f,0min</Size>
+              </WidgetGroup>
 
-						<WidgetGroup>
-							<!-- StemControls 4ch -->
-							<Layout>vertical</Layout>
-							<Children>
-								<WidgetGroup>
-									<!-- StemCh1 controls  -->
-									<Layout>horizontal</Layout>
-									<Children>
-										<WidgetGroup>
-											<Size>1min,2me</Size>
-										</WidgetGroup>
-										<Template src="skins:LateNight/stem_channel.xml">
-											<SetVariable name="StemNum">1</SetVariable>
-										</Template>
-										<WidgetGroup>
-											<Size>1min,3f</Size>
-										</WidgetGroup>
-									</Children>
-								</WidgetGroup>
-								<WidgetGroup>
-									<!-- StemCh2 controls  -->
-									<Layout>horizontal</Layout>
-									<Children>
-										<WidgetGroup>
-											<Size>1min,2me</Size>
-										</WidgetGroup>
-										<Template src="skins:LateNight/stem_channel.xml">
-											<SetVariable name="StemNum">2</SetVariable>
-										</Template>
-										<WidgetGroup>
-											<Size>1min,3f</Size>
-										</WidgetGroup>
-									</Children>
-								</WidgetGroup>
-								<WidgetGroup>
-									<!-- StemCh3 controls  -->
-									<Layout>horizontal</Layout>
-									<Children>
-										<WidgetGroup>
-											<Size>1min,2me</Size>
-										</WidgetGroup>
-										<Template src="skins:LateNight/stem_channel.xml">
-											<SetVariable name="StemNum">3</SetVariable>
-										</Template>
-										<WidgetGroup>
-											<Size>1min,3f</Size>
-										</WidgetGroup>
-									</Children>
-								</WidgetGroup>
-								<WidgetGroup>
-									<!-- StemCh4 controls  -->
-									<Layout>horizontal</Layout>
-									<Children>
-										<WidgetGroup>
-											<Size>1min,2me</Size>
-										</WidgetGroup>
-										<Template src="skins:LateNight/stem_channel.xml">
-											<SetVariable name="StemNum">4</SetVariable>
-										</Template>
-										<WidgetGroup>
-											<Size>1min,3f</Size>
-										</WidgetGroup>
-									</Children>
-								</WidgetGroup>
-							</Children>
-						</WidgetGroup>
-						<!-- /StemControls 4ch -->
+              <WidgetGroup>
+                <!-- StemControls 4ch -->
+                <Layout>vertical</Layout>
+                <Children>
+                  <WidgetGroup>
+                    <!-- StemCh1 controls  -->
+                    <Layout>horizontal</Layout>
+                    <Children>
+                      <WidgetGroup>
+                        <Size>1min,2me</Size>
+                      </WidgetGroup>
+                      <Template src="skins:LateNight/stem_channel.xml">
+                        <SetVariable name="StemNum">1</SetVariable>
+                      </Template>
+                      <WidgetGroup>
+                        <Size>1min,3f</Size>
+                      </WidgetGroup>
+                    </Children>
+                  </WidgetGroup>
+                  <WidgetGroup>
+                    <!-- StemCh2 controls  -->
+                    <Layout>horizontal</Layout>
+                    <Children>
+                      <WidgetGroup>
+                        <Size>1min,2me</Size>
+                      </WidgetGroup>
+                      <Template src="skins:LateNight/stem_channel.xml">
+                        <SetVariable name="StemNum">2</SetVariable>
+                      </Template>
+                      <WidgetGroup>
+                        <Size>1min,3f</Size>
+                      </WidgetGroup>
+                    </Children>
+                  </WidgetGroup>
+                  <WidgetGroup>
+                    <!-- StemCh3 controls  -->
+                    <Layout>horizontal</Layout>
+                    <Children>
+                      <WidgetGroup>
+                        <Size>1min,2me</Size>
+                      </WidgetGroup>
+                      <Template src="skins:LateNight/stem_channel.xml">
+                        <SetVariable name="StemNum">3</SetVariable>
+                      </Template>
+                      <WidgetGroup>
+                        <Size>1min,3f</Size>
+                      </WidgetGroup>
+                    </Children>
+                  </WidgetGroup>
+                  <WidgetGroup>
+                    <!-- StemCh4 controls  -->
+                    <Layout>horizontal</Layout>
+                    <Children>
+                      <WidgetGroup>
+                        <Size>1min,2me</Size>
+                      </WidgetGroup>
+                      <Template src="skins:LateNight/stem_channel.xml">
+                        <SetVariable name="StemNum">4</SetVariable>
+                      </Template>
+                      <WidgetGroup>
+                        <Size>1min,3f</Size>
+                      </WidgetGroup>
+                    </Children>
+                  </WidgetGroup>
+                </Children>
+              </WidgetGroup>
+              <!-- /StemControls 4ch -->
 
-					</Children>
-				</WidgetGroup>
-				<!-- /StemControlsInner -->
+            </Children>
+          </WidgetGroup>
+          <!-- /StemControlsInner -->
 
-				<WidgetGroup>
-					<Size>1me,1me</Size>
-				</WidgetGroup>
-			</Children>
-			<Connection>
-				<ConfigKey persist="true">[Skin],show_stem_controls</ConfigKey>
-				<BindProperty>visible</BindProperty>
-			</Connection>
-		</WidgetGroup><!-- StemControls -->
+          <WidgetGroup>
+            <Size>1me,1me</Size>
+          </WidgetGroup>
+        </Children>
+        <Connection>
+          <ConfigKey persist="true">[Skin],show_stem_controls</ConfigKey>
+          <BindProperty>visible</BindProperty>
+        </Connection>
+      </WidgetGroup><!-- StemControls -->
 
 
-		<WidgetGroup>
+      <WidgetGroup>
         <ObjectName>WaveformBox<Variable name="ChanNum"/></ObjectName>
         <Layout>horizontal</Layout>
         <SizePolicy>me,me</SizePolicy>

--- a/res/skins/LateNight/waveforms_container.xml
+++ b/res/skins/LateNight/waveforms_container.xml
@@ -4,26 +4,26 @@
     <Layout>horizontal</Layout>
     <SizePolicy>me,min</SizePolicy>
     <Children>
-		<WidgetGroup>
+      <WidgetGroup>
         <ObjectName>WaveformsContainer</ObjectName>
         <Layout>horizontal</Layout>
         <SizePolicy>me,min</SizePolicy>
         <Children>
 
-    			<Template src="skins:LateNight/controls/button_2state_persist.xml">
-    				<SetVariable name="TooltipId">show_stem_controls</SetVariable>
-    				<SetVariable name="ObjectName">StemControlsToggle</SetVariable>
-    				<SetVariable name="Size">26f,52f</SetVariable>
-    				<SetVariable name="BtnSize"></SetVariable>
-    				<SetVariable name="ConfigKey">[Skin],show_stem_controls</SetVariable>
-    			</Template>
+          <Template src="skins:LateNight/controls/button_2state_persist.xml">
+            <SetVariable name="TooltipId">show_stem_controls</SetVariable>
+            <SetVariable name="ObjectName">StemControlsToggle</SetVariable>
+            <SetVariable name="Size">26f,52f</SetVariable>
+            <SetVariable name="BtnSize"></SetVariable>
+            <SetVariable name="ConfigKey">[Skin],show_stem_controls</SetVariable>
+          </Template>
 
-    			<WidgetGroup>
+          <WidgetGroup>
             <Layout>vertical</Layout>
             <Size>100me,40me</Size>
             <Children>
 
-    				  <WidgetGroup>
+              <WidgetGroup>
                 <Layout>horizontal</Layout>
                 <SizePolicy>me,me</SizePolicy>
                 <Children>

--- a/res/skins/LateNight/waveforms_container.xml
+++ b/res/skins/LateNight/waveforms_container.xml
@@ -10,13 +10,20 @@
         <SizePolicy>me,min</SizePolicy>
         <Children>
 
-          <Template src="skins:LateNight/controls/button_2state_persist.xml">
-            <SetVariable name="TooltipId">show_stem_controls</SetVariable>
-            <SetVariable name="ObjectName">StemControlsToggle</SetVariable>
-            <SetVariable name="Size">26f,52f</SetVariable>
-            <SetVariable name="BtnSize"></SetVariable>
-            <SetVariable name="ConfigKey">[Skin],show_stem_controls</SetVariable>
-          </Template>
+          <WidgetGroup>
+            <RequiresStem>true</RequiresStem>
+            <Layout>vertical</Layout>
+            <SizePolicy>min,min</SizePolicy>
+            <Children>
+              <Template src="skins:LateNight/controls/button_2state_persist.xml">
+                <SetVariable name="TooltipId">show_stem_controls</SetVariable>
+                <SetVariable name="ObjectName">StemControlsToggle</SetVariable>
+                <SetVariable name="Size">26f,52f</SetVariable>
+                <SetVariable name="BtnSize"></SetVariable>
+                <SetVariable name="ConfigKey">[Skin],show_stem_controls</SetVariable>
+              </Template>
+            </Children>
+          </WidgetGroup>
 
           <WidgetGroup>
             <Layout>vertical</Layout>

--- a/res/skins/LateNight/waveforms_container.xml
+++ b/res/skins/LateNight/waveforms_container.xml
@@ -4,22 +4,21 @@
     <Layout>horizontal</Layout>
     <SizePolicy>me,min</SizePolicy>
     <Children>
-
-		<Template src="skins:LateNight/controls/button_2state_persist.xml">
-			<SetVariable name="TooltipId">show_stem_controls</SetVariable>
-			<SetVariable name="ObjectName">StemControlsToggle</SetVariable>
-			<SetVariable name="Size">26f,52f</SetVariable>
-			<SetVariable name="BtnSize"></SetVariable>
-			<SetVariable name="ConfigKey">[Skin],show_stem_controls</SetVariable>
-		</Template>
-
 		<WidgetGroup>
         <ObjectName>WaveformsContainer</ObjectName>
         <Layout>horizontal</Layout>
         <SizePolicy>me,min</SizePolicy>
         <Children>
 
-          <WidgetGroup>
+			<Template src="skins:LateNight/controls/button_2state_persist.xml">
+				<SetVariable name="TooltipId">show_stem_controls</SetVariable>
+				<SetVariable name="ObjectName">StemControlsToggle</SetVariable>
+				<SetVariable name="Size">26f,52f</SetVariable>
+				<SetVariable name="BtnSize"></SetVariable>
+				<SetVariable name="ConfigKey">[Skin],show_stem_controls</SetVariable>
+			</Template>
+
+			<WidgetGroup>
             <Layout>vertical</Layout>
             <Size>100me,40me</Size>
             <Children>

--- a/res/skins/LateNight/waveforms_container.xml
+++ b/res/skins/LateNight/waveforms_container.xml
@@ -10,20 +10,20 @@
         <SizePolicy>me,min</SizePolicy>
         <Children>
 
-			<Template src="skins:LateNight/controls/button_2state_persist.xml">
-				<SetVariable name="TooltipId">show_stem_controls</SetVariable>
-				<SetVariable name="ObjectName">StemControlsToggle</SetVariable>
-				<SetVariable name="Size">26f,52f</SetVariable>
-				<SetVariable name="BtnSize"></SetVariable>
-				<SetVariable name="ConfigKey">[Skin],show_stem_controls</SetVariable>
-			</Template>
+    			<Template src="skins:LateNight/controls/button_2state_persist.xml">
+    				<SetVariable name="TooltipId">show_stem_controls</SetVariable>
+    				<SetVariable name="ObjectName">StemControlsToggle</SetVariable>
+    				<SetVariable name="Size">26f,52f</SetVariable>
+    				<SetVariable name="BtnSize"></SetVariable>
+    				<SetVariable name="ConfigKey">[Skin],show_stem_controls</SetVariable>
+    			</Template>
 
-			<WidgetGroup>
+    			<WidgetGroup>
             <Layout>vertical</Layout>
             <Size>100me,40me</Size>
             <Children>
 
-				<WidgetGroup>
+    				  <WidgetGroup>
                 <Layout>horizontal</Layout>
                 <SizePolicy>me,me</SizePolicy>
                 <Children>

--- a/res/skins/LateNight/waveforms_container.xml
+++ b/res/skins/LateNight/waveforms_container.xml
@@ -5,7 +5,15 @@
     <SizePolicy>me,min</SizePolicy>
     <Children>
 
-      <WidgetGroup>
+		<Template src="skins:LateNight/controls/button_2state_persist.xml">
+			<SetVariable name="TooltipId">show_stem_controls</SetVariable>
+			<SetVariable name="ObjectName">StemControlsToggle</SetVariable>
+			<SetVariable name="Size">26f,52f</SetVariable>
+			<SetVariable name="BtnSize"></SetVariable>
+			<SetVariable name="ConfigKey">[Skin],show_stem_controls</SetVariable>
+		</Template>
+
+		<WidgetGroup>
         <ObjectName>WaveformsContainer</ObjectName>
         <Layout>horizontal</Layout>
         <SizePolicy>me,min</SizePolicy>
@@ -16,7 +24,7 @@
             <Size>100me,40me</Size>
             <Children>
 
-              <WidgetGroup>
+				<WidgetGroup>
                 <Layout>horizontal</Layout>
                 <SizePolicy>me,me</SizePolicy>
                 <Children>

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -983,6 +983,13 @@ QWidget* LegacySkinParser::parseStemLabelWidget(const QDomElement& element) {
 
     QString group = lookupNodeGroup(element);
     BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(group);
+    if (!pPlayer) {
+        SKIN_WARNING(element,
+                *m_pContext,
+                QStringLiteral("No player found for group: %1").arg(group));
+        return nullptr;
+    }
+
     connect(pPlayer,
             &BaseTrackPlayer::newTrackLoaded,
             pLabel,
@@ -992,6 +999,13 @@ QWidget* LegacySkinParser::parseStemLabelWidget(const QDomElement& element) {
             &BaseTrackPlayer::trackUnloaded,
             pLabel,
             &WStemLabel::slotTrackUnloaded);
+
+    TrackPointer pTrack = pPlayer->getLoadedTrack();
+    if (pTrack) {
+        // Set the trackpoinnter to the already loaded track,
+        // needed at skin change
+        pLabel->slotTrackLoaded(pTrack);
+    }
 
     return pLabel;
 }

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -740,6 +740,11 @@ void LegacySkinParser::parseChildren(
 }
 
 QWidget* LegacySkinParser::parseWidgetGroup(const QDomElement& node) {
+#ifndef __STEM__
+    if (requiresStem(node)) {
+        return nullptr;
+    }
+#endif
     WWidgetGroup* pGroup = new WWidgetGroup(m_pParent);
     setupBaseWidget(node, pGroup);
     setupWidget(node, pGroup->toQWidget());
@@ -2576,4 +2581,9 @@ QString LegacySkinParser::stylesheetAbsIconPaths(QString& style) {
     // skins directory for the launch image style.
     style.replace("url(skins:", "url(" + m_pConfig->getResourcePath() + "skins/");
     return style.replace("url(skin:", "url(" + m_pContext->getSkinBasePath());
+}
+
+bool LegacySkinParser::requiresStem(const QDomElement& node) {
+    QDomElement requiresStemNode = node.firstChildElement("RequiresStem");
+    return !requiresStemNode.isNull() && requiresStemNode.text() == "true";
 }

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -979,7 +979,7 @@ void LegacySkinParser::setupLabelWidget(const QDomElement& element, WLabel* pLab
 #ifdef __STEM__
 QWidget* LegacySkinParser::parseStemLabelWidget(const QDomElement& element) {
     WStemLabel* pLabel = new WStemLabel(m_pParent);
-    setupStemLabelWidget(element, pLabel);
+    setupLabelWidget(element, pLabel);
 
     QString group = lookupNodeGroup(element);
     BaseTrackPlayer* pPlayer = m_pPlayerManager->getPlayer(group);
@@ -1008,20 +1008,6 @@ QWidget* LegacySkinParser::parseStemLabelWidget(const QDomElement& element) {
     }
 
     return pLabel;
-}
-
-void LegacySkinParser::setupStemLabelWidget(const QDomElement& element, WStemLabel* pLabel) {
-    // NOTE(rryan): To support color schemes, the WWidget::setup() call must
-    // come first. This is because WLabel derivatives change the palette based
-    // on the node and setupWidget() will set the widget style. If the style is
-    // set before the palette is set then the custom palette will not take
-    // effect which breaks color scheme support.
-    pLabel->setup(element, *m_pContext);
-    commonWidgetSetup(element, pLabel);
-    pLabel->installEventFilter(m_pKeyboard);
-    pLabel->installEventFilter(
-            m_pControllerManager->getControllerLearningEventFilter());
-    pLabel->Init();
 }
 #endif
 

--- a/src/skin/legacy/legacyskinparser.h
+++ b/src/skin/legacy/legacyskinparser.h
@@ -22,6 +22,7 @@ class RecordingManager;
 class ControllerManager;
 class SkinContext;
 class WLabel;
+class WStemLabel;
 class ControlObject;
 class LaunchImage;
 class WWidgetGroup;
@@ -75,6 +76,12 @@ class LegacySkinParser : public QObject, public SkinParser {
     template <class T>
     QWidget* parseLabelWidget(const QDomElement& element);
     void setupLabelWidget(const QDomElement& element, WLabel* pLabel);
+
+#ifdef __STEM__
+    QWidget* parseStemLabelWidget(const QDomElement& element);
+    void setupStemLabelWidget(const QDomElement& element, WStemLabel* pLabel);
+#endif
+
     QWidget* parseText(const QDomElement& node);
     QWidget* parseTrackProperty(const QDomElement& node);
     QWidget* parseStarRating(const QDomElement& node);

--- a/src/skin/legacy/legacyskinparser.h
+++ b/src/skin/legacy/legacyskinparser.h
@@ -79,7 +79,6 @@ class LegacySkinParser : public QObject, public SkinParser {
 
 #ifdef __STEM__
     QWidget* parseStemLabelWidget(const QDomElement& element);
-    void setupStemLabelWidget(const QDomElement& element, WStemLabel* pLabel);
 #endif
 
     QWidget* parseText(const QDomElement& node);

--- a/src/skin/legacy/legacyskinparser.h
+++ b/src/skin/legacy/legacyskinparser.h
@@ -154,6 +154,7 @@ class LegacySkinParser : public QObject, public SkinParser {
 
     QString parseLaunchImageStyle(const QDomNode& node);
     QString stylesheetAbsIconPaths(QString& style);
+    bool requiresStem(const QDomElement& node);
     void parseChildren(const QDomElement& node, WWidgetGroup* pGroup);
 
     UserSettingsPointer m_pConfig;

--- a/src/skin/legacy/tooltips.cpp
+++ b/src/skin/legacy/tooltips.cpp
@@ -269,6 +269,9 @@ void Tooltips::addStandardTooltips() {
     add("show_beatgrid_controls")
             << tr("Show/hide the beatgrid controls section");
 
+    add("show_stem_controls")
+            << tr("Show/hide the stem mixing controls section");
+
     add("show_library")
             << tr("Show Library")
             << tr("Show or hide the track library.");
@@ -1149,6 +1152,22 @@ void Tooltips::addStandardTooltips() {
             << tr("Toggle")
             << tr("Toggle the current effect.")
             << eqKillLatch;
+
+    // Stem Channel Controls
+    add("StemLabel")
+            << tr("Stem Label")
+            << tr("Name of the stem stored in the stem file")
+            << tr("Text is displayed in the stem color stored in the stem file")
+            << tr("this stem color is also used for the waveform of this stem");
+
+    add("StemMuteButton")
+            << tr("Stem Mute")
+            << tr("Toggle the stem mute/unmuted");
+
+    add("StemVolumeKnob")
+            << tr("Stem Volume Knob")
+            << tr("Adjusts the volume of the stem")
+            << resetWithRightAndDoubleClick;
 
     // Equalizer Rack Controls
     add("EqualizerRack_effect_parameter")

--- a/src/widget/wstemlabel.cpp
+++ b/src/widget/wstemlabel.cpp
@@ -12,18 +12,18 @@ void WStemLabel::setup(const QDomNode& node, const SkinContext& context) {
     m_stemNo = context.selectInt(node, "StemNum");
 }
 
-void WStemLabel::slotTrackUnloaded(TrackPointer track) {
-    Q_UNUSED(track);
+void WStemLabel::slotTrackUnloaded(TrackPointer pTrack) {
+    Q_UNUSED(pTrack);
     m_stemInfo = StemInfo();
     updateLabel();
 }
 
-void WStemLabel::slotTrackLoaded(TrackPointer track) {
-    if (!track) {
+void WStemLabel::slotTrackLoaded(TrackPointer pTrack) {
+    if (!pTrack) {
         return;
     }
 
-    auto stemInfo = track->getStemInfo();
+    auto stemInfo = pTrack->getStemInfo();
 
     if (stemInfo.isEmpty()) {
         return;

--- a/src/widget/wstemlabel.cpp
+++ b/src/widget/wstemlabel.cpp
@@ -1,0 +1,51 @@
+#include "wstemlabel.h"
+
+#include "moc_wstemlabel.cpp"
+
+WStemLabel::WStemLabel(QWidget* pParent)
+        : WLabel(pParent),
+          m_stemInfo(QString(), QColor()),
+          m_stemNo(0) {
+}
+
+void WStemLabel::setup(const QDomNode& node, const SkinContext& context) {
+    m_stemNo = context.selectInt(node, "StemNum");
+}
+
+void WStemLabel::slotTrackUnloaded(TrackPointer track) {
+    Q_UNUSED(track);
+    m_stemInfo = StemInfo();
+    updateLabel();
+}
+
+void WStemLabel::slotTrackLoaded(TrackPointer track) {
+    if (!track) {
+        return;
+    }
+
+    auto stemInfo = track->getStemInfo();
+
+    if (stemInfo.isEmpty()) {
+        return;
+    }
+
+    m_stemInfo = stemInfo[m_stemNo - 1];
+    updateLabel();
+}
+
+void WStemLabel::updateLabel() {
+    QColor color = m_stemInfo.getColor();
+    QString text = m_stemInfo.getLabel();
+    setTextColor(color);
+    setLabelText(text);
+}
+
+void WStemLabel::setTextColor(const QColor& color) {
+    QPalette palette = this->palette();
+    palette.setColor(QPalette::WindowText, color);
+    this->setPalette(palette);
+}
+
+void WStemLabel::setLabelText(const QString& text) {
+    this->setText(text);
+}

--- a/src/widget/wstemlabel.cpp
+++ b/src/widget/wstemlabel.cpp
@@ -12,8 +12,7 @@ void WStemLabel::setup(const QDomNode& node, const SkinContext& context) {
     m_stemNo = context.selectInt(node, "StemNum");
 }
 
-void WStemLabel::slotTrackUnloaded(TrackPointer pTrack) {
-    Q_UNUSED(pTrack);
+void WStemLabel::slotTrackUnloaded(TrackPointer) {
     m_stemInfo = StemInfo();
     updateLabel();
 }

--- a/src/widget/wstemlabel.h
+++ b/src/widget/wstemlabel.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "control/controlproxy.h"
+#include "skin/legacy/skincontext.h"
+#include "track/track.h"
+#include "widget/wlabel.h"
+
+class WStemLabel : public WLabel {
+    Q_OBJECT
+  public:
+    explicit WStemLabel(QWidget* pParent = nullptr);
+
+    void setup(const QDomNode& node, const SkinContext& context) override;
+
+  public slots:
+    void slotTrackLoaded(TrackPointer track);
+    void slotTrackUnloaded(TrackPointer track);
+
+  private slots:
+    void updateLabel();
+
+  private:
+    void setTextColor(const QColor& color);
+    void setLabelText(const QString& text);
+
+    StemInfo m_stemInfo;
+    QString m_group;
+    int m_stemNo;
+};

--- a/src/widget/wstemlabel.h
+++ b/src/widget/wstemlabel.h
@@ -13,8 +13,8 @@ class WStemLabel : public WLabel {
     void setup(const QDomNode& node, const SkinContext& context) override;
 
   public slots:
-    void slotTrackLoaded(TrackPointer track);
-    void slotTrackUnloaded(TrackPointer track);
+    void slotTrackLoaded(TrackPointer pTrack);
+    void slotTrackUnloaded(TrackPointer pTrack);
 
   private slots:
     void updateLabel();


### PR DESCRIPTION
This is an alternative to the UI PR #13515 by @acolombier . It use classic widget groups instead of the floating widget.
![grafik](https://github.com/user-attachments/assets/e55a419e-70c5-4d5e-bd15-7cf9a85fa44e)

![grafik](https://github.com/user-attachments/assets/f1dd70e7-657e-4301-b9a9-518a25a78659)


The functionality is the same, but the widget positioning differs. Both PRs are in prove of concept state and not visually fine tuned.

The benefit of the floating widgets is that the waveform is only hidden by the stem widgets for the tracks that are stem files, while here, the stem widgets are either shown for all tracks or for none.

Please test both PRs #13515 and this one. (Build with FFMPEG and STEM enabled in CMake) and load a .stem file. And review the code of the second commit here. Which approach should we follow?

If you need STEM files for test, you can download the reference files here: https://www.native-instruments.com/fileadmin/ni_media/downloads/stems/free_stems_for_traktor_pro_2.zip