### PR TITLE
improve Taglib/SoundSource logging

### DIFF
--- a/src/sources/metadatasourcetaglib.cpp
+++ b/src/sources/metadatasourcetaglib.cpp
@@ -62,6 +62,10 @@ class AiffFile : public TagLib::RIFF::AIFF::File {
     }
 };
 
+QString fileTypeToString(taglib::FileType fileType) {
+    return QVariant::fromValue(fileType).toString();
+}
+
 } // anonymous namespace
 
 std::pair<MetadataSourceTagLib::ImportResult, QDateTime>
@@ -91,7 +95,7 @@ MetadataSourceTagLib::importTrackMetadataAndCoverImage(
         kLogger.warning()
                 << "Nothing to import"
                 << "from file" << m_fileName
-                << "of type" << m_fileType;
+                << "of type" << fileTypeToString(m_fileType);
         return afterImport(ImportResult::Unavailable);
     }
     if (kLogger.traceEnabled()) {
@@ -101,7 +105,7 @@ MetadataSourceTagLib::importTrackMetadataAndCoverImage(
                                            : (pTrackMetadata ? "track metadata"
                                                              : "cover art"))
                         << "from file" << m_fileName
-                        << "of type" << m_fileType;
+                        << "of type" << fileTypeToString(m_fileType);
     }
 
     // Rationale: If a file contains different types of tags only
@@ -285,14 +289,14 @@ MetadataSourceTagLib::importTrackMetadataAndCoverImage(
         kLogger.warning()
                 << "Cannot import track metadata"
                 << "from file" << m_fileName
-                << "with unknown or unsupported type" << m_fileType;
+                << "of unknown or unsupported type" << fileTypeToString(m_fileType);
         return afterImport(ImportResult::Failed);
     }
 
     kLogger.info()
             << "No track metadata or cover art found"
             << "in file" << m_fileName
-            << "with type" << m_fileType;
+            << "of type" << fileTypeToString(m_fileType);
     return afterImport(ImportResult::Unavailable);
 }
 
@@ -672,8 +676,8 @@ MetadataSourceTagLib::exportTrackMetadata(
         kLogger.debug()
                 << "Cannot export track metadata"
                 << "into file" << m_fileName
-                << "with unknown or unsupported type"
-                << m_fileType;
+                << "of unknown or unsupported type"
+                << fileTypeToString(m_fileType);
         return afterExport(ExportResult::Unsupported);
     }
 

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -503,7 +503,7 @@ void SoundSourceProxy::findProviderAndInitSoundSource() {
     if (!getUrl().isEmpty()) {
         kLogger.warning()
                 << "No SoundSourceProvider for file"
-                << getUrl().toString();
+                << getUrl().toString(QUrl::PreferLocalFile);
     }
 }
 
@@ -517,7 +517,7 @@ bool SoundSourceProxy::initSoundSourceWithProvider(
         kLogger.warning() << "SoundSourceProvider"
                           << pProvider->getDisplayName()
                           << "failed to create a SoundSource for file"
-                          << getUrl().toString();
+                          << getUrl().toString(QUrl::PreferLocalFile);
         return false;
     }
     m_pProvider = pProvider;
@@ -525,7 +525,7 @@ bool SoundSourceProxy::initSoundSourceWithProvider(
         kLogger.debug() << "SoundSourceProvider"
                         << m_pProvider->getDisplayName()
                         << "created a SoundSource for file"
-                        << getUrl().toString()
+                        << getUrl().toString(QUrl::PreferLocalFile)
                         << "of type"
                         << m_pSoundSource->getType();
     }
@@ -628,7 +628,7 @@ SoundSourceProxy::UpdateTrackFromSourceResult SoundSourceProxy::updateTrackFromS
     if (!m_pSoundSource) {
         kLogger.warning()
                 << "Unable to update track from unsupported file type"
-                << getUrl().toString();
+                << getUrl().toString(QUrl::PreferLocalFile);
         return UpdateTrackFromSourceResult::NotUpdated;
     }
 
@@ -644,7 +644,7 @@ SoundSourceProxy::UpdateTrackFromSourceResult SoundSourceProxy::updateTrackFromS
                           << "to"
                           << newType
                           << "for file"
-                          << getUrl().toString();
+                          << getUrl().toString(QUrl::PreferLocalFile);
     }
 
     // Use the existing track metadata as default values. Otherwise
@@ -680,7 +680,7 @@ SoundSourceProxy::UpdateTrackFromSourceResult SoundSourceProxy::updateTrackFromS
             if (kLogger.debugEnabled()) {
                 kLogger.debug()
                         << "Skip importing of embedded cover art from file"
-                        << getUrl().toString();
+                        << getUrl().toString(QUrl::PreferLocalFile);
             }
         } else {
             // Request reimport of embedded cover art
@@ -706,7 +706,7 @@ SoundSourceProxy::UpdateTrackFromSourceResult SoundSourceProxy::updateTrackFromS
                 << "Failed to import track metadata"
                 << (pCoverImg ? "and embedded cover art" : "")
                 << "from file"
-                << getUrl().toString();
+                << getUrl().toString(QUrl::PreferLocalFile);
         // make sure that the trackMetadata was not messed up due to the failure
         mixxx::TrackRecord::SourceSyncStatus sourceSyncStatusNew;
         trackMetadata = m_pTrack->getMetadata(&sourceSyncStatusNew);
@@ -750,7 +750,7 @@ SoundSourceProxy::UpdateTrackFromSourceResult SoundSourceProxy::updateTrackFromS
         if (kLogger.debugEnabled()) {
             kLogger.debug()
                     << "Initializing track metadata and embedded cover art from file"
-                    << getUrl().toString();
+                    << getUrl().toString(QUrl::PreferLocalFile);
         }
     } else {
         if (kLogger.debugEnabled()) {
@@ -758,7 +758,7 @@ SoundSourceProxy::UpdateTrackFromSourceResult SoundSourceProxy::updateTrackFromS
                     << "Re-importing track metadata"
                     << (pCoverImg ? "and embedded cover art" : "")
                     << "from file"
-                    << getUrl().toString();
+                    << getUrl().toString(QUrl::PreferLocalFile);
         }
     }
 
@@ -870,14 +870,14 @@ bool SoundSourceProxy::openSoundSource(
             }
             kLogger.warning()
                     << "Failed to read file"
-                    << getUrl().toString()
+                    << getUrl().toString(QUrl::PreferLocalFile)
                     << "with provider"
                     << m_pProvider->getDisplayName();
             m_pSoundSource->close(); // cleanup
         } else {
             kLogger.warning()
                     << "Failed to open file"
-                    << getUrl().toString()
+                    << getUrl().toString(QUrl::PreferLocalFile)
                     << "with provider"
                     << m_pProvider->getDisplayName()
                     << "using mode"
@@ -915,7 +915,7 @@ bool SoundSourceProxy::openSoundSource(
     // getting here. m_pSoundSource might already be invalid/null!
     kLogger.warning()
             << "Giving up to open file"
-            << getUrl().toString()
+            << getUrl().toString(QUrl::PreferLocalFile)
             << "after"
             << attemptCount
             << "unsuccessful attempts";

--- a/src/track/taglib/trackmetadata_file.cpp
+++ b/src/track/taglib/trackmetadata_file.cpp
@@ -11,6 +11,7 @@
 
 #include <tfile.h>
 
+#include "moc_trackmetadata_file.cpp"
 #include "track/taglib/trackmetadata_common.h"
 #include "util/logger.h"
 

--- a/src/track/taglib/trackmetadata_file.h
+++ b/src/track/taglib/trackmetadata_file.h
@@ -15,6 +15,7 @@ namespace mixxx {
 class TrackMetadata;
 
 namespace taglib {
+Q_NAMESPACE
 
 enum class FileType {
     Unknown,
@@ -27,6 +28,7 @@ enum class FileType {
     WAV,
     WV
 };
+Q_ENUM_NS(FileType);
 
 QDebug operator<<(QDebug debug, FileType fileType);
 


### PR DESCRIPTION
* log `taglib::FileType` enum as string (char*)
* omit `file://` prefix for local files