### PR TITLE
Auto DJ: Add new random tracks if one track does not exists

### DIFF
--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -899,6 +899,8 @@ TrackPointer AutoDJProcessor::getNextTrackFromQueue() {
                 // Remove missing song from auto DJ playlist.
                 m_pAutoDJTableModel->removeTrack(
                         m_pAutoDJTableModel->index(0, 0));
+                // Don't "Requeue" missing tracks to avoid andless loops
+                maybeFillRandomTracks();
             }
         } else {
             // We're out of tracks. Return the null TrackPointer.

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -889,14 +889,15 @@ TrackPointer AutoDJProcessor::getNextTrackFromQueue() {
     }
 
     while (true) {
-        TrackPointer nextTrack = m_pAutoDJTableModel->getTrack(
-            m_pAutoDJTableModel->index(0, 0));
+        TrackPointer pNextTrack = m_pAutoDJTableModel->getTrack(
+                m_pAutoDJTableModel->index(0, 0));
 
-        if (nextTrack) {
-            if (nextTrack->getFileInfo().checkFileExists()) {
-                return nextTrack;
+        if (pNextTrack) {
+            if (pNextTrack->getFileInfo().checkFileExists()) {
+                return pNextTrack;
             } else {
-                // Remove missing song from auto DJ playlist.
+                // Remove missing track from auto DJ playlist.
+                qWarning() << "Auto DJ: Skip missing track" << pNextTrack->getLocation();
                 m_pAutoDJTableModel->removeTrack(
                         m_pAutoDJTableModel->index(0, 0));
                 // Don't "Requeue" missing tracks to avoid andless loops
@@ -904,7 +905,7 @@ TrackPointer AutoDJProcessor::getNextTrackFromQueue() {
             }
         } else {
             // We're out of tracks. Return the null TrackPointer.
-            return nextTrack;
+            return pNextTrack;
         }
     }
 }

--- a/src/sources/soundsource.cpp
+++ b/src/sources/soundsource.cpp
@@ -59,7 +59,11 @@ QString SoundSource::getTypeFromFile(const QFileInfo& fileInfo) {
     // type, using the generic type application/octet-stream as a fallback.
     // This might also occur for missing files as seen on Qt 5.12.
     if (!mimeType.isValid() || mimeType.isDefault()) {
-        qInfo() << "Unable to detect MIME type from file" << fileInfo.filePath();
+        if (fileInfo.exists()) {
+            qInfo() << "Unable to detect MIME type from file" << fileInfo.filePath();
+        } else {
+            qInfo() << "Unable to detect MIME type from not existing file" << fileInfo.filePath();
+        }
         mimeType = QMimeDatabase().mimeTypeForFile(
                 fileInfo, QMimeDatabase::MatchExtension);
         if (!mimeType.isValid() || mimeType.isDefault()) {

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -656,6 +656,13 @@ SoundSourceProxy::UpdateTrackFromSourceResult SoundSourceProxy::updateTrackFromS
     mixxx::TrackMetadata trackMetadata =
             m_pTrack->getMetadata(&sourceSyncStatus);
 
+    if (sourceSyncStatus == mixxx::TrackRecord::SourceSyncStatus::Undefined) {
+        kLogger.warning()
+                << "Unable to update track from missing or inaccessible file"
+                << getUrl().toString();
+        return UpdateTrackFromSourceResult::NotUpdated;
+    }
+
     // Save for later to replace the unreliable and imprecise audio
     // properties imported from file tags (see below).
     const auto preciseStreamInfo = trackMetadata.getStreamInfo();

--- a/src/track/trackrecord.cpp
+++ b/src/track/trackrecord.cpp
@@ -161,6 +161,12 @@ TrackRecord::SourceSyncStatus TrackRecord::checkSourceSyncStatus(
         // 37 don't have a synchronization time stamp.
         return SourceSyncStatus::Unknown;
     }
+    if (!fileInfo.exists()) {
+        kLogger.warning()
+                << "Failed to obtain synchronization time stamp for not existing file"
+                << mixxx::FileInfo(fileInfo);
+        return SourceSyncStatus::Undefined;
+    }
     const QDateTime fileSourceSynchronizedAt =
             MetadataSource::getFileSynchronizedAt(fileInfo.toQFile());
     if (!fileSourceSynchronizedAt.isValid()) {


### PR DESCRIPTION
This fixes an issue reported in #13544 

In addition the logging is improved for such situation by failing earlier. Now it looks like this: 

```
info [Main] Unable to detect MIME type from not existing file "/home/daniel/Musik/- Humillaci¢n (Kopie).mp3"
info [Main] Unable to detect MIME type from not existing file "/home/daniel/Musik/- Humillaci¢n (Kopie).mp3"
debug [Main] SoundSourceProxy - SoundSourceProvider "MAD: MPEG Audio Decoder 0.15.1 (beta) NDEBUG FPM_64BIT" created a SoundSource for file "file:///home/daniel/Musik/- Humillaci¢n (Kopie).mp3" of type "mp3"
warning [Main] TrackRecord - Failed to obtain synchronization time stamp for not existing file QFileInfo(/home/daniel/Musik/- Humillaci¢n (Kopie).mp3)
warning [Main] SoundSourceProxy - Unable to update track from missing or inaccessible file "file:///home/daniel/Musik/- Humillaci¢n (Kopie).mp3"
debug [Main] BaseTrackCache(0x5612c6c9ba70) updateIndexWithQuery took 0 ms
warning [Main] Auto DJ: Skip missing track "/home/daniel/Musik/- Humillaci¢n (Kopie).mp3"
debug [Main] Committing transaction successfully on "MIXXX-1"
debug [Main] PlaylistTableModel(0x5612c6c96150) select() returned 0 results in 0 ms
debug [Main] GlobalTrackCache - Evicting track  TrackRef {"/home/daniel/Musik/- Humillaci¢n (Kopie).mp3","",390} Track(0x5612d4798d10)
debug [Main] GlobalTrackCache - Deleting Track(0x5612d4798d10)
debug [Main] Auto DJ disabled
``` 
