### PR TITLE
Refactor: modernize softtakeover code

### DIFF
--- a/src/controllers/midi/midicontroller.cpp
+++ b/src/controllers/midi/midicontroller.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 
 #include "control/controlobject.h"
+#include "control/controlpotmeter.h"
 #include "controllers/defs_controllers.h"
 #include "controllers/midi/midioutputhandler.h"
 #include "controllers/midi/midiutils.h"
@@ -451,7 +452,11 @@ void MidiController::processInputMapping(const MidiInputMapping& mapping,
 
     if (mapping.options.testFlag(MidiOption::SoftTakeover)) {
         // This is the only place to enable it if it isn't already.
-        m_st.enable(pCO);
+        auto* pControlPotmeter = qobject_cast<ControlPotmeter*>(pCO);
+        if (!pControlPotmeter) {
+            return;
+        }
+        m_st.enable(gsl::not_null(pControlPotmeter));
         if (m_st.ignore(pCO, pCO->getParameterForMidi(newValue))) {
             return;
         }

--- a/src/controllers/midi/midicontroller.h
+++ b/src/controllers/midi/midicontroller.h
@@ -1,10 +1,9 @@
 #pragma once
 
 #include <QJSValue>
-#include <utility>
 
 #include "controllers/controller.h"
-#include "controllers/midi/legacymidicontrollermappingfilehandler.h"
+#include "controllers/midi/legacymidicontrollermapping.h"
 #include "controllers/midi/midimessage.h"
 #include "controllers/softtakeover.h"
 

--- a/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
+++ b/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
@@ -1,7 +1,10 @@
 #include "controllerscriptinterfacelegacy.h"
 
+#include <gsl/pointers>
+
 #include "control/controlobject.h"
 #include "control/controlobjectscript.h"
+#include "control/controlpotmeter.h"
 #include "controllers/scripting/legacy/controllerscriptenginelegacy.h"
 #include "controllers/scripting/legacy/scriptconnectionjsproxy.h"
 #include "mixer/playermanager.h"
@@ -584,11 +587,12 @@ void ControllerScriptInterfaceLegacy::softTakeover(
         const QString& group, const QString& name, bool set) {
     ControlObject* pControl = ControlObject::getControl(
             ConfigKey(group, name), ControlFlag::AllowMissingOrInvalid);
-    if (!pControl) {
-        return;
-    }
     if (set) {
-        m_st.enable(pControl);
+        auto* pControlPotmeter = qobject_cast<ControlPotmeter*>(pControl);
+        if (!pControlPotmeter) {
+            return;
+        }
+        m_st.enable(gsl::not_null(pControlPotmeter));
     } else {
         m_st.disable(pControl);
     }

--- a/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
+++ b/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
@@ -609,6 +609,17 @@ void ControllerScriptInterfaceLegacy::softTakeoverIgnoreNextValue(
     m_st.ignoreNext(pControl);
 }
 
+bool ControllerScriptInterfaceLegacy::softTakeoverWillIgnore(
+        const QString& group, const QString& name, double parameter) {
+    ControlObject* pControl = ControlObject::getControl(
+            ConfigKey(group, name));
+    if (!pControl) {
+        return false;
+    }
+
+    return m_st.willIgnore(pControl, parameter);
+}
+
 double ControllerScriptInterfaceLegacy::getDeckRate(const QString& group) {
     double rate = 0.0;
     ControlObjectScript* pRateRatio =

--- a/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.h
+++ b/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.h
@@ -60,6 +60,8 @@ class ControllerScriptInterfaceLegacy : public QObject {
     Q_INVOKABLE bool isScratching(int deck);
     Q_INVOKABLE void softTakeover(const QString& group, const QString& name, bool set);
     Q_INVOKABLE void softTakeoverIgnoreNextValue(const QString& group, const QString& name);
+    Q_INVOKABLE bool softTakeoverWillIgnore(
+            const QString& group, const QString& name, double parameter);
     Q_INVOKABLE void brake(const int deck,
             bool activate,
             double factor = 1.0,

--- a/src/controllers/softtakeover.cpp
+++ b/src/controllers/softtakeover.cpp
@@ -1,86 +1,16 @@
 #include "controllers/softtakeover.h"
+
+#include "control/controlobject.h"
 #include "control/controlpotmeter.h"
-#include "util/math.h"
-#include "util/time.h"
 
-// 3/128 units away from the current is enough to catch fast non-sequential moves
-//  but not cause an audibly noticeable jump, determined experimentally with
-//  slow-refresh controllers.
-const double SoftTakeover::kDefaultTakeoverThreshold = 3.0 / 128;
+using namespace std::chrono_literals;
 
-const mixxx::Duration SoftTakeover::kSubsequentValueOverrideTime =
-        mixxx::Duration::fromMillis(50);
-
-SoftTakeoverCtrl::SoftTakeoverCtrl() {
-
+void SoftTakeoverCtrl::enable(gsl::not_null<ControlPotmeter*> pControl) {
+    // explicitly not in the header to avoid adding dependency on ControlPotmeter
+    m_softTakeoverHash.try_emplace(static_cast<ControlObject*>(pControl.get()));
 }
 
-SoftTakeoverCtrl::~SoftTakeoverCtrl() {
-    QHashIterator<ControlObject*, SoftTakeover*> i(m_softTakeoverHash);
-    while (i.hasNext()) {
-        i.next();
-        delete i.value();
-    }
-}
-
-void SoftTakeoverCtrl::enable(ControlObject* control) {
-    ControlPotmeter* cpo = qobject_cast<ControlPotmeter*>(control);
-    if (cpo == nullptr) {
-        // softtakecover works only for continuous ControlPotmeter based COs
-        return;
-    }
-
-    // Initialize times
-    if (!m_softTakeoverHash.contains(control)) {
-        m_softTakeoverHash.insert(control, new SoftTakeover());
-    }
-}
-
-void SoftTakeoverCtrl::disable(ControlObject* control) {
-    if (control == nullptr) {
-        return;
-    }
-    SoftTakeover* pSt = m_softTakeoverHash.take(control);
-    if (pSt) {
-        delete pSt;
-    }
-}
-
-bool SoftTakeoverCtrl::ignore(ControlObject* control, double newParameter) {
-    if (control == nullptr) {
-        return false;
-    }
-    bool ignore = false;
-    SoftTakeover* pSt = m_softTakeoverHash.value(control);
-    if (pSt) {
-        ignore = pSt->ignore(control, newParameter);
-    }
-    return ignore;
-}
-
-void SoftTakeoverCtrl::ignoreNext(ControlObject* control) {
-    if (control == nullptr) {
-        return;
-    }
-
-    SoftTakeover* pSt = m_softTakeoverHash.value(control);
-    if (pSt == nullptr) {
-        return;
-    }
-
-    pSt->ignoreNext();
-}
-
-SoftTakeover::SoftTakeover()
-    : m_prevParameter(0),
-      m_dThreshold(kDefaultTakeoverThreshold) {
-}
-
-void SoftTakeover::setThreshold(double threshold) {
-    m_dThreshold = threshold;
-}
-
-bool SoftTakeover::ignore(ControlObject* control, double newParameter) {
+bool SoftTakeover::ignore(const ControlObject& control, double newParameter) {
     bool ignore = false;
     /*
      * We only want to ignore the controller when:
@@ -108,22 +38,19 @@ bool SoftTakeover::ignore(ControlObject* control, double newParameter) {
      *      Don't ignore in every other case.
      */
 
-    mixxx::Duration currentTime = mixxx::Time::elapsed();
+    auto currentTime = ClockT::now();
     // We will get a sudden jump if we don't ignore the first value.
-    if (m_time == mixxx::Duration::fromMillis(0)) {
+    if (m_time == kFirstValueTime) {
         ignore = true;
         // Change the stored time (but keep it far away from the current time)
         //  so this block doesn't run again.
-        m_time = mixxx::Duration::fromMillis(1);
-//         qDebug() << "SoftTakeover::ignore: ignoring the first value"
-//                  << newParameter;
-    } else if (currentTime - m_time > kSubsequentValueOverrideTime) {
+        m_time = ClockT::time_point(kFirstValueTime + 1ms);
+    } else if (currentTime >= m_time + kSubsequentValueOverrideTime) {
         // don't ignore value if a previous one was not ignored in time
-        const double currentParameter = control->getParameter();
+        const double currentParameter = control.getParameter();
         const double difference = currentParameter - newParameter;
         const double prevDiff = currentParameter - m_prevParameter;
-        if ((prevDiff < 0 && difference < 0) ||
-                (prevDiff > 0 && difference > 0)) {
+        if (std::signbit(prevDiff) == std::signbit(difference)) {
             // On same side of the current parameter value
             if (fabs(difference) > m_dThreshold && fabs(prevDiff) > m_dThreshold) {
                 // differences are above threshold
@@ -142,8 +69,4 @@ bool SoftTakeover::ignore(ControlObject* control, double newParameter) {
     m_prevParameter = newParameter;
 
     return ignore;
-}
-
-void SoftTakeover::ignoreNext() {
-    m_time = mixxx::Duration::fromMillis(0);
 }

--- a/src/controllers/softtakeover.h
+++ b/src/controllers/softtakeover.h
@@ -1,56 +1,98 @@
 #pragma once
 
-#include <QHash>
+#include <chrono>
+#include <gsl/pointers>
+#include <unordered_map>
 
-#include "util/duration.h"
+#include "util/assert.h"
+#include "util/time.h"
 
 class ControlObject;
+class ControlPotmeter;
 
 class SoftTakeover {
   public:
-    // I would initialize it here but that's C++11 coolness. (Because it's a double.)
-    static const double kDefaultTakeoverThreshold;
+    // 3/128 units away from the current is enough to catch fast non-sequential moves
+    //  but not cause an audibly noticeable jump, determined experimentally with
+    //  slow-refresh controllers.
+    // TODO (XXX): Expose this to the controller mapping environment?
+    static constexpr double kDefaultTakeoverThreshold = 3.0 / 128;
 
-    SoftTakeover();
-    bool ignore(ControlObject* control, double newParameter);
-    void ignoreNext();
-    void setThreshold(double threshold);
+    SoftTakeover() = default;
+    bool ignore(const ControlObject& control, double newParameter);
+    void ignoreNext() {
+        m_time = kFirstValueTime;
+    }
+    void setThreshold(double threshold) {
+        m_dThreshold = threshold;
+    }
 
-    struct TestAccess;
+    // TODO (XXX): find a better testing solution than this TestAccess
+    // front-door coupled to `mixxx::Time`.
+    struct TestAccess {
+        static constexpr mixxx::Time::duration getTimeThreshold() {
+            return kSubsequentValueOverrideTime;
+        }
+        template<class Rep = mixxx::Time::rep,
+                class Period = mixxx::Time::period>
+        static void advanceTimePastThreshold(
+                std::chrono::duration<Rep, Period> offset =
+                        std::chrono::nanoseconds(0)) {
+            mixxx::Time::addTestTime(getTimeThreshold() + offset);
+        }
+    };
 
   private:
+    using ClockT = mixxx::Time;
     // If a new value is received within this amount of time, jump to it
     // regardless. This allows quickly whipping controls to work while retaining
     // the benefits of soft-takeover for slower movements.  Setting this too
     // high will defeat the purpose of soft-takeover.
-    static const mixxx::Duration kSubsequentValueOverrideTime;
+    static constexpr ClockT::duration kSubsequentValueOverrideTime = std::chrono::milliseconds(50);
+    static constexpr ClockT::time_point kFirstValueTime = ClockT::time_point::min();
 
-    mixxx::Duration m_time;
-    double m_prevParameter;
-    double m_dThreshold;
-};
-
-struct SoftTakeover::TestAccess {
-    static mixxx::Duration getTimeThreshold() {
-        return kSubsequentValueOverrideTime;
-    }
+    ClockT::time_point m_time{kFirstValueTime};
+    double m_prevParameter{0};
+    double m_dThreshold{kDefaultTakeoverThreshold};
 };
 
 class SoftTakeoverCtrl {
   public:
-    SoftTakeoverCtrl();
-    ~SoftTakeoverCtrl();
+    SoftTakeoverCtrl() = default;
 
     // Enable soft-takeover for the given Control.
     // This does nothing on a control that already has soft-takeover enabled.
-    void enable(ControlObject* control);
+    void enable(gsl::not_null<ControlPotmeter*> pControl);
     // Disable soft-takeover for the given Control
-    void disable(ControlObject* control);
+    void disable(ControlObject* control) {
+        m_softTakeoverHash.erase(control);
+    }
     // Check to see if the new value for the Control should be ignored
-    bool ignore(ControlObject* control, double newMidiParameter);
+    bool ignore(ControlObject* pControl, double newParameter) {
+        auto it = m_softTakeoverHash.find(pControl);
+        if (it == m_softTakeoverHash.end()) {
+            return false;
+        }
+        VERIFY_OR_DEBUG_ASSERT(pControl) {
+            return false;
+        }
+        auto& [coKey, refSoftTakeover] = *it;
+        return refSoftTakeover.ignore(*pControl, newParameter);
+    }
     // Ignore the next supplied parameter
-    void ignoreNext(ControlObject* control);
+    void ignoreNext(ControlObject* pControl) {
+        auto it = m_softTakeoverHash.find(pControl);
+        if (it == m_softTakeoverHash.end()) {
+            return;
+        }
+        auto& [coKey, refSoftTakeover] = *it;
+        refSoftTakeover.ignoreNext();
+    }
 
   private:
-    QHash<ControlObject*, SoftTakeover*> m_softTakeoverHash;
+    // ControlObjects are borrowed. They must outlive this object.
+    // Note that even though we can only enable softTakeover on
+    // `ControlPotmeter`s, we store the base ControlObject to not force the user
+    // to downcast for `disable()` and `ignore()`/`ignoreNext()`.
+    std::unordered_map<ControlObject*, SoftTakeover> m_softTakeoverHash;
 };

--- a/src/effects/effectknobparameterslot.h
+++ b/src/effects/effectknobparameterslot.h
@@ -5,12 +5,12 @@
 #include <QVariant>
 #include <memory>
 
+#include "controllers/softtakeover.h"
 #include "effects/effectparameterslotbase.h"
 #include "util/class.h"
 
 class ControlPushButton;
 class ControlEffectKnob;
-class SoftTakeover;
 
 /// Refer to EffectParameterSlotBase for documentation
 class EffectKnobParameterSlot : public EffectParameterSlotBase {
@@ -49,7 +49,7 @@ class EffectKnobParameterSlot : public EffectParameterSlotBase {
         return QString("EffectKnobParameterSlot(%1,%2)").arg(m_group).arg(m_iParameterSlotNumber);
     }
 
-    SoftTakeover* m_pMetaknobSoftTakeover;
+    SoftTakeover m_metaknobSoftTakeover;
 
     // Control exposed to the rest of Mixxx
     std::unique_ptr<ControlEffectKnob> m_pControlValue;

--- a/src/effects/effectslot.cpp
+++ b/src/effects/effectslot.cpp
@@ -559,7 +559,7 @@ double EffectSlot::getMetaParameter() const {
 // This function is for the superknob to update individual effects' meta knobs
 // slotEffectMetaParameter does not need to update m_pControlMetaParameter's value
 void EffectSlot::setMetaParameter(double v, bool force) {
-    if (!m_metaknobSoftTakeover.ignore(m_pControlMetaParameter.get(), v) ||
+    if (!m_metaknobSoftTakeover.ignore(*m_pControlMetaParameter, v) ||
             !m_pControlEnabled->toBool() || force) {
         m_pControlMetaParameter->set(v);
         slotEffectMetaParameter(v, force);

--- a/src/test/controller_mapping_file_handler_test.cpp
+++ b/src/test/controller_mapping_file_handler_test.cpp
@@ -13,6 +13,7 @@
 
 using ::testing::_;
 using ::testing::FieldsAre;
+using namespace std::chrono_literals;
 
 class LegacyControllerMappingFileHandlerTest
         : public LegacyControllerMappingFileHandler,
@@ -20,7 +21,7 @@ class LegacyControllerMappingFileHandlerTest
   public:
     void SetUp() override {
         mixxx::Time::setTestMode(true);
-        mixxx::Time::setTestElapsedTime(mixxx::Duration::fromMillis(10));
+        mixxx::Time::addTestTime(10ms);
         SETUP_LOG_CAPTURE();
     }
 

--- a/src/test/controllerrenderingengine_test.cpp
+++ b/src/test/controllerrenderingengine_test.cpp
@@ -12,12 +12,13 @@
 #include "test/mixxxtest.h"
 
 using ::testing::_;
+using namespace std::chrono_literals;
 
 class ControllerRenderingEngineTest : public MixxxTest {
   public:
     void SetUp() override {
         mixxx::Time::setTestMode(true);
-        mixxx::Time::setTestElapsedTime(mixxx::Duration::fromMillis(10));
+        mixxx::Time::addTestTime(10ms);
         SETUP_LOG_CAPTURE();
     }
 

--- a/src/test/controllers/controller_columnid_regression_test.cpp
+++ b/src/test/controllers/controller_columnid_regression_test.cpp
@@ -13,11 +13,13 @@
 #include "test/mixxxtest.h"
 #include "util/time.h"
 
+using namespace std::chrono_literals;
+
 class ControllerLibraryColumnIDRegressionTest : public MixxxTest {
   protected:
     void SetUp() override {
         mixxx::Time::setTestMode(true);
-        mixxx::Time::setTestElapsedTime(mixxx::Duration::fromMillis(10));
+        mixxx::Time::addTestTime(10ms);
     }
 
     void TearDown() override {

--- a/src/test/controllerscriptenginelegacy_test.cpp
+++ b/src/test/controllerscriptenginelegacy_test.cpp
@@ -26,6 +26,7 @@
 #include "util/time.h"
 
 using ::testing::_;
+using namespace std::chrono_literals;
 
 typedef std::unique_ptr<QTemporaryFile> ScopedTemporaryFile;
 
@@ -47,7 +48,7 @@ class ControllerScriptEngineLegacyTest : public ControllerScriptEngineLegacy, pu
 
     void SetUp() override {
         mixxx::Time::setTestMode(true);
-        mixxx::Time::setTestElapsedTime(mixxx::Duration::fromMillis(10));
+        mixxx::Time::addTestTime(10ms);
         QThread::currentThread()->setObjectName("Main");
         initialize();
     }
@@ -209,7 +210,7 @@ TEST_F(ControllerScriptEngineLegacyTest, softTakeover_setValue) {
     EXPECT_DOUBLE_EQ(-10.0, co->get());
 
     // Advance time to 2x the threshold.
-    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
+    SoftTakeover::TestAccess::advanceTimePastThreshold();
 
     // Change the control internally (putting it out of sync with the
     // ControllerEngine).
@@ -240,8 +241,7 @@ TEST_F(ControllerScriptEngineLegacyTest, softTakeover_setParameter) {
     EXPECT_TRUE(evaluateAndAssert("engine.setParameter('[Test]', 'co', 0.0);"));
     EXPECT_DOUBLE_EQ(-10.0, co->get());
 
-    // Advance time to 2x the threshold.
-    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
+    SoftTakeover::TestAccess::advanceTimePastThreshold();
 
     // Change the control internally (putting it out of sync with the
     // ControllerEngine).

--- a/src/test/metaknob_link_test.cpp
+++ b/src/test/metaknob_link_test.cpp
@@ -13,13 +13,14 @@
 #include "test/baseeffecttest.h"
 #include "util/time.h"
 
+using namespace std::chrono_literals;
+
 class MetaLinkTest : public BaseEffectTest {
   protected:
     MetaLinkTest()
             : m_main(m_factory.getOrCreateHandle("[Master]"), "[Master]"),
               m_headphone(m_factory.getOrCreateHandle("[Headphone]"), "[Headphone]") {
         mixxx::Time::setTestMode(true);
-        mixxx::Time::setTestElapsedTime(mixxx::Duration::fromNanos(0));
         m_pEffectsManager->registerInputChannel(m_main);
         m_pEffectsManager->registerInputChannel(m_headphone);
         registerTestBackend();
@@ -126,8 +127,7 @@ TEST_F(MetaLinkTest, MetaToParameter_Softtakeover_EffectEnabled) {
     m_pControlValue->set(0.0);
 
     // Let enough time pass by to exceed soft-takeover's override interval.
-    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() +
-            mixxx::Duration::fromMillis(2));
+    advanceTimePastThreshold(2ms);
 
     // Ignored by SoftTakeover since it is too far from the current
     // parameter value of 0.0.
@@ -148,8 +148,7 @@ TEST_F(MetaLinkTest, MetaToParameter_Softtakeover_EffectDisabled) {
     m_pControlValue->set(0.0);
 
     // Let enough time pass by to exceed soft-takeover's override interval.
-    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() +
-            mixxx::Duration::fromMillis(2));
+    advanceTimePastThreshold(2ms);
 
     m_pEffectSlot->slotEffectMetaParameter(1.0, false);
     EXPECT_EQ(1.0, m_pControlValue->get());
@@ -166,8 +165,7 @@ TEST_F(MetaLinkTest, SuperToMeta_Softtakeover_EffectEnabled) {
     m_pEffectSlot->setMetaParameter(1.0, true);
 
     // Let enough time pass by to exceed soft-takeover's override interval.
-    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() +
-            mixxx::Duration::fromMillis(2));
+    advanceTimePastThreshold(2ms);
 
     // Ignored by SoftTakeover since it is too far from the current
     // metaknob value of 1.0.
@@ -185,8 +183,7 @@ TEST_F(MetaLinkTest, SuperToMeta_Softtakeover_EffectDisabled) {
     m_pEffectSlot->setMetaParameter(1.0, true);
 
     // Let enough time pass by to exceed soft-takeover's override interval.
-    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() +
-            mixxx::Duration::fromMillis(2));
+    advanceTimePastThreshold(2ms);
 
     m_pChainSlot->setSuperParameter(0.0);
     EXPECT_EQ(0.0, m_pEffectSlot->getMetaParameter());

--- a/src/test/softtakeover_test.cpp
+++ b/src/test/softtakeover_test.cpp
@@ -2,23 +2,21 @@
 
 #include <gtest/gtest.h>
 
-#include <QScopedPointer>
-#include <QtDebug>
-#include <memory>
+#include <gsl/pointers>
 
 #include "control/controlpotmeter.h"
-#include "control/controlpushbutton.h"
-#include "preferences/usersettings.h"
 #include "test/mixxxtest.h"
 #include "util/time.h"
 
 namespace {
 
+using namespace std::chrono_literals;
+
 class SoftTakeoverTest : public MixxxTest {
   protected:
     void SetUp() override {
         mixxx::Time::setTestMode(true);
-        mixxx::Time::setTestElapsedTime(mixxx::Duration::fromMillis(10));
+        mixxx::Time::addTestTime(10ms);
     }
 
     void TearDown() override {
@@ -28,82 +26,71 @@ class SoftTakeoverTest : public MixxxTest {
 
 TEST_F(SoftTakeoverTest, DoesntIgnoreDisabledControl) {
     // Range -1.0 to 1.0
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -1.0, 1.0);
+    ControlPotmeter co(ConfigKey("[Channel1]", "test_pot"), -1.0, 1.0);
 
     SoftTakeoverCtrl st_control;
-    EXPECT_FALSE(st_control.ignore(co.get(), co->get()));
-}
-
-TEST_F(SoftTakeoverTest, DoesntIgnoreNonPotmeter) {
-    auto co = std::make_unique<ControlPushButton>(ConfigKey("[Channel1]", "test_button"));
-
-    SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
-
-    // First update is always ignored so this proves the CPB is not enabled for
-    // soft-takeover.
-    EXPECT_FALSE(st_control.ignore(co.get(), 0));
+    EXPECT_FALSE(st_control.ignore(&co, co.get()));
 }
 
 TEST_F(SoftTakeoverTest, IgnoresFirstValue) {
     // Range -1.0 to 1.0
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -1.0, 1.0);
+    ControlPotmeter co(ConfigKey("[Channel1]", "test_pot"), -1.0, 1.0);
 
     SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
-    EXPECT_TRUE(st_control.ignore(co.get(), 5));
+    st_control.enable(gsl::make_not_null(&co));
+    EXPECT_TRUE(st_control.ignore(&co, 5));
 }
 
 TEST_F(SoftTakeoverTest, DoesntIgnoreSameValue) {
     // Range -1.0 to 1.0
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -1.0, 1.0);
+    ControlPotmeter co(ConfigKey("[Channel1]", "test_pot"), -1.0, 1.0);
 
-    co->set(0.6);
+    co.set(0.6);
     SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
+    st_control.enable(gsl::make_not_null(&co));
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(0.6)));
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(0.6)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(0.6)));
+    EXPECT_FALSE(st_control.ignore(&co, co.getParameterForValue(0.6)));
 }
 
 // These are corner cases that allow for quickly flicking/whipping controls
 //  from a standstill when the previous knob value matches the current CO value
 TEST_F(SoftTakeoverTest, SuperFastPrevEqCurrent) {
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -250, 250);
+    ControlPotmeter co(ConfigKey("[Channel1]", "test_pot"), -250, 250);
 
     // From the bottom
-    co->set(-250);
+    co.set(-250);
     SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
+    st_control.enable(gsl::make_not_null(&co));
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(-250)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(-250)));
     // This can happen any time afterwards, so we test 10 seconds
-    mixxx::Time::setTestElapsedTime(mixxx::Duration::fromSeconds(10));
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(200)));
+    mixxx::Time::addTestTime(10s);
+    EXPECT_FALSE(st_control.ignore(&co, co.getParameterForValue(200)));
 
     // From the top
-    co->set(250);
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(250)));
+    co.set(250);
+    EXPECT_FALSE(st_control.ignore(&co, co.getParameterForValue(250)));
     // This can happen any time afterwards, so we test 10 seconds
-    mixxx::Time::setTestElapsedTime(mixxx::Duration::fromSeconds(10));
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(-200)));
+    mixxx::Time::addTestTime(10s);
+    EXPECT_FALSE(st_control.ignore(&co, co.getParameterForValue(-200)));
 }
 
 // But when they don't match, this type of thing should be ignored!
 //  FIXME: This fails on the st::ignore() implementation in 2.0.0-rc1
 TEST_F(SoftTakeoverTest, DISABLED_SuperFastNotSame) {
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -250, 250);
+    ControlPotmeter co(ConfigKey("[Channel1]", "test_pot"), -250, 250);
 
-    co->set(250);
+    co.set(250);
     SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
+    st_control.enable(gsl::make_not_null(&co));
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(249)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(249)));
     // This can happen any time afterwards, so we test 10 seconds
-    mixxx::Time::setTestElapsedTime(mixxx::Duration::fromSeconds(10));
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(-200)));
+    mixxx::Time::addTestTime(10s);
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(-200)));
 }
 
 /* The meat of the tests
@@ -118,476 +105,294 @@ TEST_F(SoftTakeoverTest, DISABLED_SuperFastNotSame) {
  *  - New value arrival time (below or above threshold)
  */
 
+class SoftTakeoverTestWithValue : public SoftTakeoverTest {
+  protected:
+    ControlPotmeter co{ConfigKey("[Channel1]", "test_pot"), -250, 250};
+    SoftTakeoverCtrl st_control{};
+
+    void SetUp() override {
+        SoftTakeoverTest::SetUp();
+        co.set(50);
+        st_control.enable(gsl::make_not_null(&co));
+    }
+};
+
 // ---- Previous Near & less than current
-
-TEST_F(SoftTakeoverTest, PrevNearLess_NewNearLess_Soon) {
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -250, 250);
-
-    co->set(50);
-    SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
-
+TEST_F(SoftTakeoverTestWithValue, PrevNearLess_NewNearLess_Soon) {
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(40)));
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(45)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(40)));
+    EXPECT_FALSE(st_control.ignore(&co, co.getParameterForValue(45)));
 }
 
-TEST_F(SoftTakeoverTest, PrevNearLess_NewNearMore_Soon) {
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -250, 250);
-
-    co->set(50);
-    SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
-
+TEST_F(SoftTakeoverTestWithValue, PrevNearLess_NewNearMore_Soon) {
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(40)));
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(60)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(40)));
+    EXPECT_FALSE(st_control.ignore(&co, co.getParameterForValue(60)));
 }
 
-TEST_F(SoftTakeoverTest, PrevNearLess_NewFarLess_Soon) {
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -250, 250);
-
-    co->set(50);
-    SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
-
+TEST_F(SoftTakeoverTestWithValue, PrevNearLess_NewFarLess_Soon) {
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(40)));
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(1)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(40)));
+    EXPECT_FALSE(st_control.ignore(&co, co.getParameterForValue(1)));
 }
 
-TEST_F(SoftTakeoverTest, PrevNearLess_NewFarMore_Soon) {
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -250, 250);
-
-    co->set(50);
-    SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
-
+TEST_F(SoftTakeoverTestWithValue, PrevNearLess_NewFarMore_Soon) {
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(40)));
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(100)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(40)));
+    EXPECT_FALSE(st_control.ignore(&co, co.getParameterForValue(100)));
 }
 
-TEST_F(SoftTakeoverTest, PrevNearLess_NewNearLess_Late) {
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -250, 250);
-
-    co->set(50);
-    SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
-
+TEST_F(SoftTakeoverTestWithValue, PrevNearLess_NewNearLess_Late) {
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(40)));
-    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(45)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(40)));
+    SoftTakeover::TestAccess::advanceTimePastThreshold();
+    EXPECT_FALSE(st_control.ignore(&co, co.getParameterForValue(45)));
 }
 
-TEST_F(SoftTakeoverTest, PrevNearLess_NewNearMore_Late) {
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -250, 250);
-
-    co->set(50);
-    SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
-
+TEST_F(SoftTakeoverTestWithValue, PrevNearLess_NewNearMore_Late) {
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(40)));
-    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(60)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(40)));
+    SoftTakeover::TestAccess::advanceTimePastThreshold();
+    EXPECT_FALSE(st_control.ignore(&co, co.getParameterForValue(60)));
 }
 
 // Ignore this case:
 //  Sides    prev distance   new distance    new value arrives   Ignore
 //  same     close           far             later               TRUE
 //  FIXME: This fails on the st::ignore() implementation in 2.0.0-rc1
-TEST_F(SoftTakeoverTest, DISABLED_PrevNearLess_NewFarLess_Late) {
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -250, 250);
-
-    co->set(50);
-    SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
-
+TEST_F(SoftTakeoverTestWithValue, DISABLED_PrevNearLess_NewFarLess_Late) {
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(40)));
-    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(1)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(40)));
+    SoftTakeover::TestAccess::advanceTimePastThreshold();
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(1)));
 }
 
 // Ignore this case:
 //  Sides    prev distance   new distance    new value arrives   Ignore
 //  opposite close           far             later               TRUE
 //  FIXME: This fails on the st::ignore() implementation in 2.0.0-rc1
-TEST_F(SoftTakeoverTest, DISABLED_PrevNearLess_NewFarMore_Late) {
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -250, 250);
-
-    co->set(50);
-    SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
-
+TEST_F(SoftTakeoverTestWithValue, DISABLED_PrevNearLess_NewFarMore_Late) {
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(40)));
-    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(100)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(40)));
+    SoftTakeover::TestAccess::advanceTimePastThreshold();
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(100)));
 }
 
 // ---- Previous Near & greater than current
 
-TEST_F(SoftTakeoverTest, PrevNearMore_NewNearLess_Soon) {
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -250, 250);
-
-    co->set(50);
-    SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
-
+TEST_F(SoftTakeoverTestWithValue, PrevNearMore_NewNearLess_Soon) {
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(55)));
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(45)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(55)));
+    EXPECT_FALSE(st_control.ignore(&co, co.getParameterForValue(45)));
 }
 
-TEST_F(SoftTakeoverTest, PrevNearMore_NewNearMore_Soon) {
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -250, 250);
-
-    co->set(50);
-    SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
-
+TEST_F(SoftTakeoverTestWithValue, PrevNearMore_NewNearMore_Soon) {
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(55)));
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(60)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(55)));
+    EXPECT_FALSE(st_control.ignore(&co, co.getParameterForValue(60)));
 }
 
-TEST_F(SoftTakeoverTest, PrevNearMore_NewFarLess_Soon) {
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -250, 250);
-
-    co->set(50);
-    SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
-
+TEST_F(SoftTakeoverTestWithValue, PrevNearMore_NewFarLess_Soon) {
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(55)));
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(1)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(55)));
+    EXPECT_FALSE(st_control.ignore(&co, co.getParameterForValue(1)));
 }
 
-TEST_F(SoftTakeoverTest, PrevNearMore_NewFarMore_Soon) {
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -250, 250);
-
-    co->set(50);
-    SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
-
+TEST_F(SoftTakeoverTestWithValue, PrevNearMore_NewFarMore_Soon) {
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(55)));
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(100)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(55)));
+    EXPECT_FALSE(st_control.ignore(&co, co.getParameterForValue(100)));
 }
 
-TEST_F(SoftTakeoverTest, PrevNearMore_NewNearLess_Late) {
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -250, 250);
-
-    co->set(50);
-    SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
-
+TEST_F(SoftTakeoverTestWithValue, PrevNearMore_NewNearLess_Late) {
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(55)));
-    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(45)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(55)));
+    SoftTakeover::TestAccess::advanceTimePastThreshold();
+    EXPECT_FALSE(st_control.ignore(&co, co.getParameterForValue(45)));
 }
 
-TEST_F(SoftTakeoverTest, PrevNearMore_NewNearMore_Late) {
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -250, 250);
-
-    co->set(50);
-    SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
-
+TEST_F(SoftTakeoverTestWithValue, PrevNearMore_NewNearMore_Late) {
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(55)));
-    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(60)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(55)));
+    SoftTakeover::TestAccess::advanceTimePastThreshold();
+    EXPECT_FALSE(st_control.ignore(&co, co.getParameterForValue(60)));
 }
 
 // Ignore this case:
 //  Sides    prev distance   new distance    new value arrives   Ignore
 //  opposite close           far             later               TRUE
 //  FIXME: This fails on the st::ignore() implementation in 2.0.0-rc1
-TEST_F(SoftTakeoverTest, DISABLED_PrevNearMore_NewFarLess_Late) {
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -250, 250);
-
-    co->set(50);
-    SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
-
+TEST_F(SoftTakeoverTestWithValue, DISABLED_PrevNearMore_NewFarLess_Late) {
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(55)));
-    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(1)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(55)));
+    SoftTakeover::TestAccess::advanceTimePastThreshold();
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(1)));
 }
 
 // Ignore this case:
 //  Sides    prev distance   new distance    new value arrives   Ignore
 //  same     close           far             later               TRUE
 //  FIXME: This fails on the st::ignore() implementation in 2.0.0-rc1
-TEST_F(SoftTakeoverTest, DISABLED_PrevNearMore_NewFarMore_Late) {
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -250, 250);
-
-    co->set(50);
-    SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
-
+TEST_F(SoftTakeoverTestWithValue, DISABLED_PrevNearMore_NewFarMore_Late) {
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(55)));
-    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(100)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(55)));
+    SoftTakeover::TestAccess::advanceTimePastThreshold();
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(100)));
 }
 
 // ---- Previous Far & less than current
 
-TEST_F(SoftTakeoverTest, PrevFarLess_NewNearLess_Soon) {
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -250, 250);
-
-    co->set(50);
-    SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
-
+TEST_F(SoftTakeoverTestWithValue, PrevFarLess_NewNearLess_Soon) {
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(-50)));
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(45)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(-50)));
+    EXPECT_FALSE(st_control.ignore(&co, co.getParameterForValue(45)));
 }
 
-TEST_F(SoftTakeoverTest, PrevFarLess_NewNearMore_Soon) {
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -250, 250);
-
-    co->set(50);
-    SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
-
+TEST_F(SoftTakeoverTestWithValue, PrevFarLess_NewNearMore_Soon) {
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(-50)));
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(60)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(-50)));
+    EXPECT_FALSE(st_control.ignore(&co, co.getParameterForValue(60)));
 }
 
 // Ignore this case:
 //  Sides    prev distance   new distance    new value arrives   Ignore
 //  same     far             far             soon                TRUE
 //  FIXME: This fails on the st::ignore() implementation in 2.0.0-rc1
-TEST_F(SoftTakeoverTest, DISABLED_PrevFarLess_NewFarLess_Soon) {
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -250, 250);
-
-    co->set(50);
-    SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
-
+TEST_F(SoftTakeoverTestWithValue, DISABLED_PrevFarLess_NewFarLess_Soon) {
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(-50)));
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(1)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(-50)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(1)));
 }
 
-TEST_F(SoftTakeoverTest, PrevFarLess_NewFarMore_Soon) {
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -250, 250);
-
-    co->set(50);
-    SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
-
+TEST_F(SoftTakeoverTestWithValue, PrevFarLess_NewFarMore_Soon) {
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(-50)));
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(100)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(-50)));
+    EXPECT_FALSE(st_control.ignore(&co, co.getParameterForValue(100)));
 }
 
-TEST_F(SoftTakeoverTest, PrevFarLess_NewNearLess_Late) {
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -250, 250);
-
-    co->set(50);
-    SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
-
+TEST_F(SoftTakeoverTestWithValue, PrevFarLess_NewNearLess_Late) {
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(-50)));
-    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(45)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(-50)));
+    SoftTakeover::TestAccess::advanceTimePastThreshold();
+    EXPECT_FALSE(st_control.ignore(&co, co.getParameterForValue(45)));
 }
 
-TEST_F(SoftTakeoverTest, PrevFarLess_NewNearMore_Late) {
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -250, 250);
-
-    co->set(50);
-    SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
-
+TEST_F(SoftTakeoverTestWithValue, PrevFarLess_NewNearMore_Late) {
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(-50)));
-    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(60)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(-50)));
+    SoftTakeover::TestAccess::advanceTimePastThreshold();
+    EXPECT_FALSE(st_control.ignore(&co, co.getParameterForValue(60)));
 }
 
 // Ignore this case:
 //  Sides    prev distance   new distance    new value arrives   Ignore
 //  same     far             far             later               TRUE
-TEST_F(SoftTakeoverTest, PrevFarLess_NewFarLess_Late) {
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -250, 250);
-
-    co->set(50);
-    SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
-
+TEST_F(SoftTakeoverTestWithValue, PrevFarLess_NewFarLess_Late) {
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(-50)));
-    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(1)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(-50)));
+    SoftTakeover::TestAccess::advanceTimePastThreshold();
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(1)));
 }
 
 // Ignore this case:
 //  Sides    prev distance   new distance    new value arrives   Ignore
 //  opposite far             far             later               TRUE
 //  FIXME: This fails on the st::ignore() implementation in 2.0.0-rc1
-TEST_F(SoftTakeoverTest, DISABLED_PrevFarLess_NewFarMore_Late) {
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -250, 250);
-
-    co->set(50);
-    SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
-
+TEST_F(SoftTakeoverTestWithValue, DISABLED_PrevFarLess_NewFarMore_Late) {
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(-50)));
-    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(100)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(-50)));
+    SoftTakeover::TestAccess::advanceTimePastThreshold();
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(100)));
 }
 
 // ---- Previous Far & greater than current
 
-TEST_F(SoftTakeoverTest, PrevFarMore_NewNearLess_Soon) {
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -250, 250);
-
-    co->set(50);
-    SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
-
+TEST_F(SoftTakeoverTestWithValue, PrevFarMore_NewNearLess_Soon) {
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(120)));
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(45)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(120)));
+    EXPECT_FALSE(st_control.ignore(&co, co.getParameterForValue(45)));
 }
 
-TEST_F(SoftTakeoverTest, PrevFarMore_NewNearMore_Soon) {
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -250, 250);
-
-    co->set(50);
-    SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
-
+TEST_F(SoftTakeoverTestWithValue, PrevFarMore_NewNearMore_Soon) {
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(120)));
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(60)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(120)));
+    EXPECT_FALSE(st_control.ignore(&co, co.getParameterForValue(60)));
 }
 
-TEST_F(SoftTakeoverTest, PrevFarMore_NewFarLess_Soon) {
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -250, 250);
-
-    co->set(50);
-    SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
-
+TEST_F(SoftTakeoverTestWithValue, PrevFarMore_NewFarLess_Soon) {
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(120)));
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(1)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(120)));
+    EXPECT_FALSE(st_control.ignore(&co, co.getParameterForValue(1)));
 }
 
 // Ignore this case:
 //  Sides    prev distance   new distance    new value arrives   Ignore
 //  same     far             far             soon                TRUE
 //  FIXME: This fails on the st::ignore() implementation in 2.0.0-rc1
-TEST_F(SoftTakeoverTest, DISABLED_PrevFarMore_NewFarMore_Soon) {
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -250, 250);
-
-    co->set(50);
-    SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
-
+TEST_F(SoftTakeoverTestWithValue, DISABLED_PrevFarMore_NewFarMore_Soon) {
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(120)));
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(100)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(120)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(100)));
 }
 
-TEST_F(SoftTakeoverTest, PrevFarMore_NewNearLess_Late) {
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -250, 250);
-
-    co->set(50);
-    SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
-
+TEST_F(SoftTakeoverTestWithValue, PrevFarMore_NewNearLess_Late) {
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(120)));
-    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(45)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(120)));
+    SoftTakeover::TestAccess::advanceTimePastThreshold();
+    EXPECT_FALSE(st_control.ignore(&co, co.getParameterForValue(45)));
 }
 
-TEST_F(SoftTakeoverTest, PrevFarMore_NewNearMore_Late) {
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -250, 250);
-
-    co->set(50);
-    SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
-
+TEST_F(SoftTakeoverTestWithValue, PrevFarMore_NewNearMore_Late) {
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(120)));
-    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(60)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(120)));
+    SoftTakeover::TestAccess::advanceTimePastThreshold();
+    EXPECT_FALSE(st_control.ignore(&co, co.getParameterForValue(60)));
 }
 
 // Ignore this case:
 //  Sides    prev distance   new distance    new value arrives   Ignore
 //  opposite far             far             later               TRUE
 //  FIXME: This fails on the st::ignore() implementation in 2.0.0-rc1
-TEST_F(SoftTakeoverTest, DISABLED_PrevFarMore_NewFarLess_Late) {
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -250, 250);
-
-    co->set(50);
-    SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
-
+TEST_F(SoftTakeoverTestWithValue, DISABLED_PrevFarMore_NewFarLess_Late) {
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(120)));
-    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(1)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(120)));
+    SoftTakeover::TestAccess::advanceTimePastThreshold();
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(1)));
 }
 
 // Ignore this case:
 //  Sides    prev distance   new distance    new value arrives   Ignore
 //  same     far             far             later               TRUE
-TEST_F(SoftTakeoverTest, PrevFarMore_NewFarMore_Late) {
-    auto co = std::make_unique<ControlPotmeter>(ConfigKey("[Channel1]", "test_pot"), -250, 250);
-
-    co->set(50);
-    SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
-
+TEST_F(SoftTakeoverTestWithValue, PrevFarMore_NewFarMore_Late) {
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(120)));
-    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(100)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(120)));
+    SoftTakeover::TestAccess::advanceTimePastThreshold();
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(100)));
 }
 
 TEST_F(SoftTakeoverTest, CatchOutOfBounds) {
-    auto co = std::make_unique<ControlPotmeter>(
-            ConfigKey("[Channel1]", "test_pot"), -250, 250, true);
+    ControlPotmeter co(ConfigKey("[Channel1]", "test_pot"), -250, 250, true);
 
-    co->set(50);
+    co.set(50);
     SoftTakeoverCtrl st_control;
-    st_control.enable(co.get());
+    st_control.enable(&co);
 
     // First is always ignored.
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(45)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(45)));
     // Cross the original value to take over
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(55)));
+    EXPECT_FALSE(st_control.ignore(&co, co.getParameterForValue(55)));
 
     // Set value to an out of bounds value
-    co->set(300);
-    mixxx::Time::setTestElapsedTime(SoftTakeover::TestAccess::getTimeThreshold() * 2);
+    co.set(300);
+    SoftTakeover::TestAccess::advanceTimePastThreshold();
     // Actions in the same direction shall be ignored
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(60)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(60)));
     // actions in the other edirection shall be ignored
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(40)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(40)));
     // reaching the lower border should be ignored
-    EXPECT_TRUE(st_control.ignore(co.get(), co->getParameterForValue(-250)));
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(-250)));
     // reaching the upper border near the out of bounds value should not be ignored.
-    EXPECT_FALSE(st_control.ignore(co.get(), co->getParameterForValue(250)));
+    EXPECT_FALSE(st_control.ignore(&co, co.getParameterForValue(250)));
 }
 
 // For the ignore cases, check that they work correctly with various signed values

--- a/src/test/softtakeover_test.cpp
+++ b/src/test/softtakeover_test.cpp
@@ -395,6 +395,17 @@ TEST_F(SoftTakeoverTest, CatchOutOfBounds) {
     EXPECT_FALSE(st_control.ignore(&co, co.getParameterForValue(250)));
 }
 
+TEST_F(SoftTakeoverTestWithValue, willIgnore) {
+    // First is always ignored.
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(120)));
+    SoftTakeover::TestAccess::advanceTimePastThreshold();
+    EXPECT_TRUE(st_control.willIgnore(&co, co.getParameterForValue(80)));
+    // do not ignore a value in range;
+    EXPECT_FALSE(st_control.willIgnore(&co, co.getParameterForValue(51)));
+    // but still ignore a value outside range because willIgnore just tests
+    EXPECT_TRUE(st_control.ignore(&co, co.getParameterForValue(80)));
+}
+
 // For the ignore cases, check that they work correctly with various signed values
 // TODO
 

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -9,6 +9,6 @@ Time::LLTIMER Time::s_timer;
 bool Time::s_testMode = false;
 
 // static
-Time::time_point Time::s_testElapsed{};
+Time::time_point Time::s_testElapsed = Time::time_point::min();
 
 } // namespace mixxx

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -3,12 +3,12 @@
 namespace mixxx {
 
 // static
-LLTIMER Time::s_timer;
+Time::LLTIMER Time::s_timer;
 
 // static
 bool Time::s_testMode = false;
 
 // static
-Duration Time::s_testElapsed = Duration::fromNanos(0);
+Time::time_point Time::s_testElapsed{};
 
 } // namespace mixxx

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -1,24 +1,41 @@
 #pragma once
 
+#include <chrono>
+
+#include "util/duration.h"
 #include "util/performancetimer.h"
 #include "util/threadcputimer.h"
-#include "util/duration.h"
 
 namespace mixxx {
 
-#define LLTIMER PerformanceTimer
-//#define LLTIMER ThreadCpuTimer
-
 class Time {
+    using LLTIMER = PerformanceTimer;
+    // using LLTIMER = ThreadCpuTimer;
+
   public:
+    using rep = LLTIMER::ClockT::rep;
+    using duration = LLTIMER::ClockT::duration;
+    using period = LLTIMER::ClockT::period;
+    using time_point = LLTIMER::ClockT::time_point;
+
+    // default to underlying clock. In testmode, all bets are off anyways.
+    static constexpr bool is_steady = LLTIMER::ClockT::is_steady;
+
     static void start() {
         s_timer.start();
+    }
+    // <chrono> like interface that includes the testMode hack.
+    static time_point now() {
+        if (s_testMode) {
+            return s_testElapsed;
+        }
+        return time_point(s_timer.elapsed().toStdDuration());
     }
 
     // Returns a Duration representing time elapsed since Mixxx started up.
     static mixxx::Duration elapsed() {
         if (s_testMode) {
-            return s_testElapsed;
+            return Duration::fromStdDuration(s_testElapsed.time_since_epoch());
         }
         return s_timer.elapsed();
     }
@@ -28,9 +45,15 @@ class Time {
     static void setTestMode(bool test) {
         s_testMode = test;
     }
-
-    static void setTestElapsedTime(mixxx::Duration elapsed) {
-        s_testElapsed = elapsed;
+    [[deprecated(
+            "do not explicitly set time, just add to the unspecified initial "
+            "value using `addTestTime(duration)`")]] static void
+    setTestElapsedTime(mixxx::Duration elapsed) {
+        s_testElapsed = LLTIMER::ClockT::time_point(elapsed.toStdDuration());
+    }
+    template<class Rep, class Period>
+    static void addTestTime(std::chrono::duration<Rep, Period> elapsed) {
+        s_testElapsed += elapsed;
     }
 
   private:
@@ -38,7 +61,12 @@ class Time {
 
     // For testing timing related behavior.
     static bool s_testMode;
-    static mixxx::Duration s_testElapsed;
+    static time_point s_testElapsed;
 };
+
+// Working around incomplete C++20 support on MacOS
+#if defined(__cpp_lib_chrono) && __cpp_lib_chrono >= 201907L
+static_assert(std::chrono::is_clock_v<Time>);
+#endif
 
 } // namespace mixxx

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -45,12 +45,6 @@ class Time {
     static void setTestMode(bool test) {
         s_testMode = test;
     }
-    [[deprecated(
-            "do not explicitly set time, just add to the unspecified initial "
-            "value using `addTestTime(duration)`")]] static void
-    setTestElapsedTime(mixxx::Duration elapsed) {
-        s_testElapsed = LLTIMER::ClockT::time_point(elapsed.toStdDuration());
-    }
     template<class Rep, class Period>
     static void addTestTime(std::chrono::duration<Rep, Period> elapsed) {
         s_testElapsed += elapsed;


### PR DESCRIPTION
* refactor mixxx::Time to be a std::chrono-compatible clock
* eliminate unnecessary allocation in `EffectKnobParameterSlot`
* remove unnecessary allocation in `SoftTakeoverTest*`
* eliminate checks in `SoftTakeoverCtrl::enable` by encoding constraints
  in the type system
* deduplicate common code in `SoftTakeoverTest`. Now bundled as
  `SoftTakeoverTestWithValue`
* remove unnecessary allocation in `SoftTakeoverCtrl`
* many more miscellaneous improvements to `SoftTakeover(-Ctrl)`.

I'm trying to add add a follow up commit that fixes the currently disabled test cases but it turns out the Truth table documented doesn't really match the unit tests (especially the currently enabled edge-case tests). So I've decided to not touch that logic for now. This is already a substantial improvement IMO. 