### PR TITLE
Fix BPM and Bitrate columns were wider than normal

### DIFF
--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -1061,7 +1061,7 @@ QVariant BaseTrackTableModel::roleValue(
             return QVariant::fromValue(KeyUtils::keyToColor(key, s_keyColorPalette));
         }
         default:
-            break;
+            return QVariant();
         }
         break;
     }


### PR DESCRIPTION
Fixes #13570. It was caused by DecorationRole receiving the wrong default value. 

![image](https://github.com/user-attachments/assets/656eabb7-81a5-44c1-b7b7-a11f62e7fe80)
