### PR TITLE
(fix) Playlists: paint sidebar items bold immediateley after dropping tracks

### DIFF
--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -772,6 +772,7 @@ void BasePlaylistFeature::updateChildModel(const QSet<int>& playlistIds) {
                     label = fetchPlaylistLabel(id);
                     pChild->setLabel(label);
                     decorateChild(pChild, id);
+                    markTreeItem(pChild);
                 }
             }
         } else {
@@ -780,6 +781,7 @@ void BasePlaylistFeature::updateChildModel(const QSet<int>& playlistIds) {
                 label = fetchPlaylistLabel(id);
                 pTreeItem->setLabel(label);
                 decorateChild(pTreeItem, id);
+                markTreeItem(pTreeItem);
             }
         }
     }

--- a/src/library/trackset/baseplaylistfeature.h
+++ b/src/library/trackset/baseplaylistfeature.h
@@ -117,6 +117,7 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
     PlaylistTableModel* m_pPlaylistTableModel;
     QSet<int> m_playlistIdsOfSelectedTrack;
     const QString m_countsDurationTableName;
+    TrackId m_selectedTrackId;
 
   private slots:
     void slotTrackSelected(TrackId trackId);
@@ -129,7 +130,6 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
     void markTreeItem(TreeItem* pTreeItem);
     QString fetchPlaylistLabel(int playlistId);
 
-    TrackId m_selectedTrackId;
 
     const bool m_keepHiddenTracks;
 };

--- a/src/library/trackset/playlistfeature.cpp
+++ b/src/library/trackset/playlistfeature.cpp
@@ -265,6 +265,9 @@ void PlaylistFeature::slotPlaylistContentOrLockChanged(const QSet<int>& playlist
             idsToBeUpdated.insert(playlistId);
         }
     }
+    // Update the playlists set to allow toggling bold correctly after
+    // tracks have been dropped on sidebar items
+    m_playlistDao.getPlaylistsTrackIsIn(m_selectedTrackId, &m_playlistIdsOfSelectedTrack);
     updateChildModel(idsToBeUpdated);
 }
 


### PR DESCRIPTION
... like it already works for crates.

Currently playlists are updated only after selection in the sidebar changes.