### PR TITLE
more `ControlDoublePrivate` optimization

### DIFF
--- a/src/control/control.cpp
+++ b/src/control/control.cpp
@@ -14,6 +14,10 @@ namespace {
 /// configuration object would be arduous.
 UserSettingsPointer s_pUserConfig;
 
+const QString statTrackKey = QStringLiteral("control %1,%2"); // CO group,key
+
+constexpr double kDefaultValue = 0.0;
+
 /// Mutex guarding access to s_qCOHash and s_qCOAliasHash.
 MMutex s_qCOHashMutex;
 
@@ -30,18 +34,9 @@ QHash<ConfigKey, ConfigKey> s_qCOAliasHash
 QWeakPointer<ControlDoublePrivate> s_pDefaultCO;
 } // namespace
 
+// TODO: re-evaluate whether this is needed.
 ControlDoublePrivate::ControlDoublePrivate()
-        : m_trackType(Stat::UNSPECIFIED),
-          m_trackFlags(Stat::COUNT | Stat::SUM | Stat::AVERAGE |
-                  Stat::SAMPLE_VARIANCE | Stat::MIN | Stat::MAX),
-          m_bTrack(false),
-          // default CO is read only
-          m_confirmRequired(true),
-          m_bPersistInConfiguration(false),
-          m_bIgnoreNops(true),
-          m_kbdRepeatable(false) {
-    m_value.setValue(0.0);
-}
+        : ControlDoublePrivate({}, nullptr, true, false, false, kDefaultValue, true){};
 
 ControlDoublePrivate::ControlDoublePrivate(
         const ConfigKey& key,
@@ -49,38 +44,35 @@ ControlDoublePrivate::ControlDoublePrivate(
         bool bIgnoreNops,
         bool bTrack,
         bool bPersist,
-        double defaultValue)
+        double defaultValue,
+        bool confirmRequired = false)
         : m_key(key),
+          m_pBehavior(nullptr),
+          m_name(QString()),
+          m_description(QString()),
+          m_value(defaultValue),
+          m_defaultValue(defaultValue),
           m_pCreatorCO(pCreatorCO),
+          m_trackKey(QString()),
           m_trackType(Stat::UNSPECIFIED),
           m_trackFlags(Stat::COUNT | Stat::SUM | Stat::AVERAGE |
                   Stat::SAMPLE_VARIANCE | Stat::MIN | Stat::MAX),
           m_bTrack(bTrack),
-          m_confirmRequired(false),
+          m_confirmRequired(confirmRequired),
           m_bPersistInConfiguration(bPersist),
           m_bIgnoreNops(bIgnoreNops),
           m_kbdRepeatable(false) {
-    initialize(defaultValue);
-}
-
-void ControlDoublePrivate::initialize(double defaultValue) {
-    double value = defaultValue;
-    if (m_bPersistInConfiguration) {
+    if (bPersist) {
         UserSettingsPointer pConfig = s_pUserConfig;
         if (pConfig) {
-            value = pConfig->getValue(m_key, defaultValue);
+            m_value.setValue(pConfig->getValue(m_key, defaultValue));
         } else {
             DEBUG_ASSERT(!"Can't load persistent value s_pUserConfig is null");
         }
     }
-    m_defaultValue.setValue(defaultValue);
-    m_value.setValue(value);
-
-    //qDebug() << "Creating:" << m_trackKey << "at" << &m_value << sizeof(m_value);
 
     if (m_bTrack) {
-        // TODO(rryan): Make configurable.
-        m_trackKey = "control " + m_key.group + "," + m_key.item;
+        m_trackKey = statTrackKey.arg(key.group, key.item);
         Stat::track(m_trackKey, m_trackType, m_trackFlags, m_value.getValue());
     }
 }

--- a/src/control/control.cpp
+++ b/src/control/control.cpp
@@ -2,6 +2,7 @@
 
 #include "control/controlobject.h"
 #include "moc_control.cpp"
+#include "util/mutex.h"
 #include "util/stat.h"
 
 namespace {
@@ -80,9 +81,7 @@ void ControlDoublePrivate::initialize(double defaultValue) {
     if (m_bTrack) {
         // TODO(rryan): Make configurable.
         m_trackKey = "control " + m_key.group + "," + m_key.item;
-        Stat::track(m_trackKey, static_cast<Stat::StatType>(m_trackType),
-                    static_cast<Stat::ComputeFlags>(m_trackFlags),
-                    m_value.getValue());
+        Stat::track(m_trackKey, m_trackType, m_trackFlags, m_value.getValue());
     }
 }
 

--- a/src/control/control.cpp
+++ b/src/control/control.cpp
@@ -14,7 +14,7 @@ namespace {
 /// configuration object would be arduous.
 UserSettingsPointer s_pUserConfig;
 
-const QString statTrackKey = QStringLiteral("control %1,%2"); // CO group,key
+const QString statTrackingKey = QStringLiteral("control %1,%2"); // CO group,key
 
 constexpr Stat::StatType kStatType = Stat::UNSPECIFIED;
 
@@ -60,7 +60,7 @@ ControlDoublePrivate::ControlDoublePrivate(
           m_value(defaultValue),
           m_defaultValue(defaultValue),
           m_pCreatorCO(pCreatorCO),
-          m_trackKey(bTrack ? statTrackKey.arg(key.group, key.item) : QString()),
+          m_trackingKey(bTrack ? statTrackingKey.arg(key.group, key.item) : QString()),
           m_confirmRequired(confirmRequired),
           m_bPersistInConfiguration(bPersist),
           m_bIgnoreNops(bIgnoreNops),
@@ -74,8 +74,8 @@ ControlDoublePrivate::ControlDoublePrivate(
         }
     }
 
-    if (!m_trackKey.isNull()) {
-        Stat::track(m_trackKey, kStatType, kComputeFlags, m_value.getValue());
+    if (!m_trackingKey.isNull()) {
+        Stat::track(m_trackingKey, kStatType, kComputeFlags, m_value.getValue());
     }
 }
 
@@ -290,8 +290,8 @@ void ControlDoublePrivate::setInner(double value, QObject* pSender) {
     m_value.setValue(value);
     emit valueChanged(value, pSender);
 
-    if (!m_trackKey.isNull()) {
-        Stat::track(m_trackKey, kStatType, kComputeFlags, value);
+    if (!m_trackingKey.isNull()) {
+        Stat::track(m_trackingKey, kStatType, kComputeFlags, value);
     }
 }
 

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -230,14 +230,8 @@ class ControlDoublePrivateConst : public ControlDoublePrivate {
   public:
     ~ControlDoublePrivateConst() override = default;
 
-    void setInner(double value, QObject* pSender) override {
-        Q_UNUSED(value)
-        Q_UNUSED(pSender)
+  private:
+    void setInner(double, QObject*) override {
         DEBUG_ASSERT(!"Trying to modify a default constructed (const) control object");
     };
-
-  protected:
-    ControlDoublePrivateConst() = default;
-
-    friend ControlDoublePrivate;
 };

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -201,8 +201,8 @@ class ControlDoublePrivate : public QObject {
 
     QAtomicPointer<ControlObject> m_pCreatorCO;
 
-    // name of the key to track using stats framework, unless the trackKey isNull().
-    QString m_trackKey;
+    // name of the key to track using stats framework, unless the m_trackingKey isNull().
+    QString m_trackingKey;
 
     // Note: keep the order of the members below to not introduce gaps due to
     // memory alignment in this often used class.

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -9,7 +9,7 @@
 #include "control/controlbehavior.h"
 #include "control/controlvalue.h"
 #include "preferences/usersettings.h"
-#include "util/mutex.h"
+#include "util/stat.h"
 
 class ControlObject;
 
@@ -203,8 +203,8 @@ class ControlDoublePrivate : public QObject {
     // Note: keep the order of the members below to not introduce gaps due to
     // memory alignment in this often used class. Whether to track value changes
     // with the stats framework.
-    int m_trackType;
-    int m_trackFlags;
+    Stat::StatType m_trackType;
+    Stat::ComputeFlags m_trackFlags;
     bool m_bTrack;
     bool m_confirmRequired;
 

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -34,6 +34,9 @@ class ControlDoublePrivate : public QObject {
   public:
     ~ControlDoublePrivate() override;
 
+    // TODO: don't expose this implementation detail
+    constexpr static double kDefaultValue = 0.0;
+
     // Used to implement control persistence. All controls that are marked
     // "persist in user config" get and set their value on creation/deletion
     // using this UserSettings.
@@ -54,7 +57,7 @@ class ControlDoublePrivate : public QObject {
             bool bIgnoreNops = true,
             bool bTrack = false,
             bool bPersist = false,
-            double defaultValue = 0.0);
+            double defaultValue = kDefaultValue);
     static QSharedPointer<ControlDoublePrivate> getDefaultControl();
 
     // Returns a list of all existing instances.
@@ -172,7 +175,8 @@ class ControlDoublePrivate : public QObject {
             bool bIgnoreNops,
             bool bTrack,
             bool bPersist,
-            double defaultValue);
+            double defaultValue,
+            bool confirmRequired);
     ControlDoublePrivate(ControlDoublePrivate&&) = delete;
     ControlDoublePrivate(const ControlDoublePrivate&) = delete;
     ControlDoublePrivate& operator=(ControlDoublePrivate&&) = delete;

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -9,7 +9,6 @@
 #include "control/controlbehavior.h"
 #include "control/controlvalue.h"
 #include "preferences/usersettings.h"
-#include "util/stat.h"
 
 class ControlObject;
 
@@ -202,14 +201,12 @@ class ControlDoublePrivate : public QObject {
 
     QAtomicPointer<ControlObject> m_pCreatorCO;
 
+    // name of the key to track using stats framework, unless the trackKey isNull().
     QString m_trackKey;
 
     // Note: keep the order of the members below to not introduce gaps due to
-    // memory alignment in this often used class. Whether to track value changes
-    // with the stats framework.
-    Stat::StatType m_trackType;
-    Stat::ComputeFlags m_trackFlags;
-    bool m_bTrack;
+    // memory alignment in this often used class.
+
     bool m_confirmRequired;
 
     // Whether the control should persist in the Mixxx user configuration. The


### PR DESCRIPTION
Taking the cleanup parts from #13572 and adding a little extra (saving another 9 bytes). 