### PR TITLE
(fix/followup) Tracks: apply played/missing text color also to selected tracks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -945,6 +945,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/library/dao/settingsdao.cpp
   src/library/dao/trackdao.cpp
   src/library/dao/trackschema.cpp
+  src/library/tabledelegates/defaultdelegate.cpp
   src/library/dlgcoverartfullsize.cpp
   src/library/dlgcoverartfullsize.ui
   src/library/dlgtagfetcher.cpp

--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -242,9 +242,22 @@ WTrackTableView::item:selected,
 WLibrarySidebar::item:selected,
 #LibraryBPMButton::item:selected,
 #LibraryPlayedCheckbox::item:selected {
-  color: #D6D6D6;
+  /* disabled since it interferes with selection-color
+   which we use in DefaultDelegate and TableItemDelegate to
+   blend the highlight color with the played/missing color.
+  color: #D6D6D6; */
+  /* This is not required for painting the background,
+   but it is for applying the focus outline. */
   background-color: #006596;
-}
+  }
+  /* Highlight currentIndex which can be moved with Ctrl + arrow keys */
+  WTrackTableView::item:!selected:focus {
+    /* For outline to be applied, background-color must be set, too ...
+       Use a value between #1F1F1F and #1A1A1A (alternate-background-color) */
+    background-color: #1d1d1d;
+    outline: 1px solid #fff;
+    color: #fff;
+  }
 WLibrarySidebar::item:selected:focus {
   outline: none;
 }

--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -2158,10 +2158,22 @@ WLibraryTextBrowser:focus {
 WLibrarySidebar::item:selected,
 WTrackTableView::item:selected,
 #LibraryBPMButton::item:selected,
-#LibraryPlayedCheckbox::item:selected {
-  color: #fff;
+#LibraryPlayedCheckbox::item:selected {  /* disabled since it interferes with selection-color
+     which we use in DefaultDelegate and TableItemDelegate to
+     blend the highlight color with the played/missing color.
+   color: #fff;*/
+  /* This is not required for painting the background,
+     but it is for applying the focus outline. */
   background-color: #5e4507;
-}
+  }
+  /* Highlight currentIndex which can be moved with Ctrl + arrow keys */
+  WTrackTableView::item:!selected:focus {
+    /* For outline to be applied, background-color must be set, too ...
+       Use a value between #0f0f0f and #0a0a0a (alternate-background-color) */
+    background-color: #0c0c0c;
+    outline: 1px solid #fff;
+    color: #fff;
+  }
 WLibrarySidebar::item:selected:focus {
   outline: none;
 }

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -2622,9 +2622,23 @@ WLibrarySidebar::item:selected,
 WTrackTableView::item:selected,
 #LibraryBPMButton::item:selected,
 #LibraryPlayedCheckbox::item:selected {
-  color: #fff;
+  /* disabled since it interferes with selection-color
+     which we use in DefaultDelegate and TableItemDelegate to
+     blend the highlight color with the played/missing color.
+   color: #fff;*/
+  /* This is not required for painting the background,
+     but it is for applying the focus outline. */
   background-color: #2c454f;
-}
+  }
+  /* Highlight currentIndex which can be moved with Ctrl + arrow keys */
+  WTrackTableView::item:!selected:focus {
+    /* For outline to be applied, background-color must be set, too ...
+       Use a value between #0f0f0f and #0a0a0a (alternate-background-color) */
+    background-color: #0c0c0c;
+    outline: 1px solid #fff;
+    color: #fff;
+  }
+
 WLibrarySidebar::item:selected:focus {
   outline: none;
 }

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -521,8 +521,21 @@ WLibrarySidebar::item:selected,
 WLibrarySidebar::branch:selected,
 #LibraryBPMButton::item:selected,
 #LibraryPlayedCheckbox::item:selected {
-  color: #fff;
+  /* disabled since it interferes with selection-color
+     which we use in DefaultDelegate and TableItemDelegate to
+     blend the highlight color with the played/missing color.
+  color: #fff; */
+  /* This is not required for painting the background,
+     but it is for applying the focus outline. */
   background-color: #656d75;
+  }
+  /* Highlight currentIndex which can be moved with Ctrl + arrow keys */
+  WTrackTableView::item:!selected:focus {
+    /* For outline to be applied, background-color must be set, too ...
+       Use a value between #0f0f0f and #1a1a1a (alternate-background-color) */
+    background-color: #151515;
+    outline: 1px solid #fff;
+    color: #fff;
   }
   WSearchLineEdit::item:checked:!selected {
     color: #fff;

--- a/res/skins/Shade/style_dark.qss
+++ b/res/skins/Shade/style_dark.qss
@@ -184,7 +184,12 @@ WTrackTableView::item:selected,
 WLibrarySidebar::branch:selected,
 #LibraryBPMButton::item:selected,
 #LibraryPlayedCheckbox::item:selected {
-  color: #000;
+  /* disabled since it interferes with selection-color
+     which we use in DefaultDelegate and TableItemDelegate to
+     blend the highlight color with the played/missing color.
+  color: #000; */
+  /* This is not required for painting the background,
+     but it is for applying the focus outline. */
   selection-color: #000;
   background-color: #666;
 }

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -2633,9 +2633,22 @@ WLibrarySidebar,
 WTrackTableView::item:selected,
 #LibraryBPMButton::item:selected,
 #LibraryPlayedCheckbox::item:selected {
-  color: #fff;
+  /* disabled since it interferes with selection-color
+     which we use in DefaultDelegate and TableItemDelegate to
+     blend the highlight color with the played/missing color.
+   color: #fff;*/
+  /* This is not required for painting the background,
+     but it is for applying the focus outline. */
   background-color: #555;
-}
+  }
+  /* Highlight currentIndex which can be moved with Ctrl + arrow keys */
+  WTrackTableView::item:!selected:focus {
+    /* For outline to be applied, background-color must be set, too ...
+       Use a value between #0f0f0f and #161616 (alternate-background-color) */
+    background-color: #151515;
+    outline: 1px solid #fff;
+    color: #fff;
+  }
 WLibrarySidebar,
 WLibrarySidebar::item:focus {
   outline: none;

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -12,6 +12,7 @@
 #include "library/tabledelegates/checkboxdelegate.h"
 #include "library/tabledelegates/colordelegate.h"
 #include "library/tabledelegates/coverartdelegate.h"
+#include "library/tabledelegates/defaultdelegate.h"
 #include "library/tabledelegates/locationdelegate.h"
 #include "library/tabledelegates/multilineeditdelegate.h"
 #include "library/tabledelegates/previewbuttondelegate.h"
@@ -509,7 +510,7 @@ QAbstractItemDelegate* BaseTrackTableModel::delegateForColumn(
                 &BaseTrackTableModel::slotRefreshCoverRows);
         return pCoverArtDelegate;
     }
-    return nullptr;
+    return new DefaultDelegate(pTableView);
 }
 
 QVariant BaseTrackTableModel::data(
@@ -557,6 +558,8 @@ QVariant BaseTrackTableModel::data(
             if (!playedRaw.isNull() &&
                     playedRaw.canConvert<bool>() &&
                     playedRaw.toBool()) {
+                // TODO Maybe adjust color for bright track colors?
+                // Here or in DefaultDelegate
                 return QVariant::fromValue(m_trackPlayedColor);
             }
         }

--- a/src/library/tabledelegates/checkboxdelegate.cpp
+++ b/src/library/tabledelegates/checkboxdelegate.cpp
@@ -60,16 +60,13 @@ void CheckboxDelegate::paintItem(QPainter* painter,
     // BaseTrackTableModel::data().
     // Enforce it with an explicit stylesheet. Note: the stylesheet persists so
     // we need to reset it to normal/highlighted.
+    // By now, we have already changed the palette's highlight color in
+    // TableItemDelegate::paint(), so we can pick that here.
     QColor textColor;
     if (option.state & QStyle::State_Selected) {
-        textColor = option.palette.color(QPalette::Normal, QPalette::HighlightedText);
+        textColor = option.palette.highlightedText().color();
     } else {
-        auto colorData = index.data(Qt::ForegroundRole);
-        if (colorData.canConvert<QColor>()) {
-            textColor = colorData.value<QColor>();
-        } else {
-            textColor = option.palette.color(QPalette::Normal, QPalette::Text);
-        }
+        textColor = option.palette.text().color();
     }
 
     if (textColor.isValid() && textColor != m_cachedTextColor) {

--- a/src/library/tabledelegates/defaultdelegate.cpp
+++ b/src/library/tabledelegates/defaultdelegate.cpp
@@ -1,0 +1,46 @@
+#include "library/tabledelegates/defaultdelegate.h"
+
+#include <QPainter>
+
+#include "moc_defaultdelegate.cpp"
+
+DefaultDelegate::DefaultDelegate(QTableView* pTableView)
+        : QStyledItemDelegate(pTableView) {
+}
+
+void DefaultDelegate::paint(
+        QPainter* painter,
+        const QStyleOptionViewItem& option,
+        const QModelIndex& index) const {
+    QStyleOptionViewItem opt = option;
+    initStyleOption(&opt, index);
+
+    if (opt.state & QStyle::State_Selected) {
+        setHighlightedTextColor(opt, index);
+    }
+    // TODO Guarantee font/bg contrast with ALL track colors
+
+    QStyledItemDelegate::paint(painter, opt, index);
+}
+
+void DefaultDelegate::setHighlightedTextColor(
+        QStyleOptionViewItem& option,
+        const QModelIndex& index) const {
+    // Get the palette's selected text color
+    QColor hlColor = option.palette.highlightedText().color();
+    //  Get the 'played' or 'missing' color from the model.
+    auto colorData = index.data(Qt::ForegroundRole);
+    if (colorData.canConvert<QColor>()) {
+        const QColor fgColor = colorData.value<QColor>();
+        if (fgColor == hlColor) {
+            return;
+        }
+        // Blend the colors 50/50
+        hlColor = QColor(
+                static_cast<int>((fgColor.red() + hlColor.red()) / 2),
+                static_cast<int>((fgColor.green() + hlColor.green()) / 2),
+                static_cast<int>((fgColor.blue() + hlColor.blue()) / 2));
+        option.palette.setColor(QPalette::Normal, QPalette::HighlightedText, hlColor);
+        option.palette.setColor(QPalette::Inactive, QPalette::HighlightedText, hlColor);
+    }
+}

--- a/src/library/tabledelegates/defaultdelegate.h
+++ b/src/library/tabledelegates/defaultdelegate.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <QStyledItemDelegate>
+#include <QTableView>
+
+class DefaultDelegate : public QStyledItemDelegate {
+    Q_OBJECT
+  public:
+    explicit DefaultDelegate(QTableView* pTableView);
+    ~DefaultDelegate() override = default;
+
+    void paint(
+            QPainter* painter,
+            const QStyleOptionViewItem& option,
+            const QModelIndex& index) const override;
+
+    void setHighlightedTextColor(
+            QStyleOptionViewItem& option,
+            const QModelIndex& index) const;
+};

--- a/src/library/tabledelegates/stardelegate.cpp
+++ b/src/library/tabledelegates/stardelegate.cpp
@@ -43,6 +43,13 @@ QWidget* StarDelegate::createEditor(QWidget* parent,
     QStyleOptionViewItem newOption = option;
     initStyleOption(&newOption, index);
 
+    // Set the color for the star polygons.
+    // Only remaining very minor issue: if the editor is active while the played
+    // state changes, the polygon color will not be updated (though that's a
+    // confusing situation anyway since changed index (row) data will trigger a
+    // paint event which resets the pending (unsaved) rating anyway.
+    setHighlightedTextColor(newOption, index);
+
     StarEditor* editor =
             new StarEditor(parent, m_pTableView, index, newOption, m_focusBorderColor);
     connect(editor,

--- a/src/library/tabledelegates/stareditor.cpp
+++ b/src/library/tabledelegates/stareditor.cpp
@@ -73,20 +73,10 @@ void StarEditor::paintEvent(QPaintEvent*) {
         style->drawControl(QStyle::CE_ItemViewItem, &m_styleOption, &painter, m_pTableView);
     }
 
-    // Set the palette appropriately based on whether the row is selected or
-    // not. We also have to check if it is inactive or not and use the
-    // appropriate ColorGroup.
-    QPalette::ColorGroup cg = m_styleOption.state & QStyle::State_Enabled
-            ? QPalette::Normal
-            : QPalette::Disabled;
-    if (cg == QPalette::Normal && !(m_styleOption.state & QStyle::State_Active)) {
-        cg = QPalette::Inactive;
-    }
-
     if (m_styleOption.state & QStyle::State_Selected) {
-        painter.setBrush(m_styleOption.palette.color(cg, QPalette::HighlightedText));
+        painter.setBrush(m_styleOption.palette.highlightedText().color());
     } else {
-        painter.setBrush(m_styleOption.palette.color(cg, QPalette::Text));
+        painter.setBrush(m_styleOption.palette.text().color());
     }
 
     m_starRating.paint(&painter, m_styleOption.rect);

--- a/src/library/tabledelegates/tableitemdelegate.h
+++ b/src/library/tabledelegates/tableitemdelegate.h
@@ -1,14 +1,11 @@
 #pragma once
 
-#include <QStyledItemDelegate>
+#include "library/tabledelegates/defaultdelegate.h"
 
-class QTableView;
-
-class TableItemDelegate : public QStyledItemDelegate {
+class TableItemDelegate : public DefaultDelegate {
     Q_OBJECT
   public:
-    explicit TableItemDelegate(
-            QTableView* pTableView);
+    explicit TableItemDelegate(QTableView* pTableView);
     ~TableItemDelegate() override = default;
 
     void paint(
@@ -36,6 +33,6 @@ class TableItemDelegate : public QStyledItemDelegate {
     // Having this here avoids including QTableView there.
     int columnWidth(const QModelIndex &index) const;
 
-    QColor m_focusBorderColor;
     QTableView* m_pTableView;
+    QColor m_focusBorderColor;
 };


### PR DESCRIPTION
During performance I find it quite confusing that when selecting played tracks they are marked like unplayed tracks.

### Fix
I picked the **DefaultDelegate** from #11644 and tweaked some paint methods.
Works great, also for the star editor.

As a bycatch I managed to simplify some of them (see StarEditor for example, and removed QColorGroup setting).

<sub>Only remaining very minor issue: if the editor is active while the played state changes, the polygon color will not be updated immediately (though that's a confusing situation anyway since changed index (row) data will trigger a paint event which resets the pending (unsaved) rating anyway.
The style of hovered star editors when changing row selection is updated correctly as before.</sub>