### PR TITLE
Denon MC7000: Fix star up/down logic by only handling button down events

### DIFF
--- a/res/controllers/Denon-MC7000-scripts.js
+++ b/res/controllers/Denon-MC7000-scripts.js
@@ -936,7 +936,7 @@ MC7000.censor = function(channel, control, value, status, group) {
 MC7000.StarsDown = function(channel, control, value, status, group) {
     const deckNumber = script.deckFromGroup(group);
     const deckIndex = deckNumber - 1;
-    if (value >= 0x00) {
+    if (value > 0x00) {
         if (MC7000.PADMode[deckIndex] === "Pitch") {
             for (let padIdx = 0; padIdx < 8; padIdx++) {
                 MC7000.halftoneToPadMap[deckIndex][padIdx] = MC7000.halftoneToPadMap[deckIndex][padIdx] - 8; // pitch down
@@ -950,7 +950,7 @@ MC7000.StarsDown = function(channel, control, value, status, group) {
 MC7000.StarsUp = function(channel, control, value, status, group) {
     const deckNumber = script.deckFromGroup(group);
     const deckIndex = deckNumber - 1;
-    if (value >= 0x00) {
+    if (value > 0x00) {
         if (MC7000.PADMode[deckIndex] === "Pitch") {
             for (let padIdx = 0; padIdx < 8; padIdx++) {
                 MC7000.halftoneToPadMap[deckIndex][padIdx] = MC7000.halftoneToPadMap[deckIndex][padIdx] + 8; // pitch up


### PR DESCRIPTION
### Fixes #13587 

This fixes what looks like a typo, making sure that the logic in `StarsUp` and `StarsDown` only executes when a button is pressed down and not when released.