### PR TITLE
Denon MC7000: Unify parameter button logic and add customizable modes

### DIFF
--- a/res/controllers/Denon-MC7000-scripts.js
+++ b/res/controllers/Denon-MC7000-scripts.js
@@ -989,6 +989,13 @@ MC7000.parameterButton = function(value, group, {isLeftButton, isShiftPressed}) 
                 script.triggerControl(group, `beatjump_${isLeftButton ? "backward" : "forward"}`);
             }
             break;
+        case "introOutro":
+            {
+                const cue = isLeftButton ? "intro_end" : "outro_start";
+                const action = isShiftPressed ? "clear" : "activate";
+                script.triggerControl(group, `${cue}_${action}`);
+            }
+            break;
         default:
             break;
         }

--- a/res/controllers/Denon-MC7000-scripts.js
+++ b/res/controllers/Denon-MC7000-scripts.js
@@ -980,42 +980,46 @@ MC7000.StarsUp = function(channel, control, value, status, group) {
 
 // Parameter Button '<'
 MC7000.parameterButtonDown = function(channel, control, value, status, group) {
-    if (value) {
-        script.triggerControl(group, "beatjump_backward");
+    if (value === 0) {
+        return;
     }
+    script.triggerControl(group, "beatjump_backward");
 };
 
 // Parameter Button '>'
 MC7000.parameterButtonUp = function(channel, control, value, status, group) {
-    if (value) {
-        script.triggerControl(group, "beatjump_forward");
+    if (value === 0) {
+        return;
     }
+    script.triggerControl(group, "beatjump_forward");
 };
 
 // Parameter Button '<' + 'SHIFT'
 MC7000.parameterButtonDownShifted = function(channel, control, value, status, group) {
-    if (value) {
-        const beatJumpSize = engine.getValue(group, "beatjump_size");
-        let decreasedIndex = MC7000.beatJump.indexOf(beatJumpSize) - 1;
-        if (decreasedIndex < 0) {
-            decreasedIndex = 0;
-        }
-        const newBeatJumpSize = MC7000.beatJump[decreasedIndex];
-        engine.setValue(group, "beatjump_size", newBeatJumpSize);
+    if (value === 0) {
+        return;
     }
+    const beatJumpSize = engine.getValue(group, "beatjump_size");
+    let decreasedIndex = MC7000.beatJump.indexOf(beatJumpSize) - 1;
+    if (decreasedIndex < 0) {
+        decreasedIndex = 0;
+    }
+    const newBeatJumpSize = MC7000.beatJump[decreasedIndex];
+    engine.setValue(group, "beatjump_size", newBeatJumpSize);
 };
 
 // Parameter Button '>' + 'SHIFT'
 MC7000.parameterButtonUpShifted = function(channel, control, value, status, group) {
-    if (value) {
-        const beatjumpSize = engine.getValue(group, "beatjump_size");
-        let increasedIndex = MC7000.beatJump.indexOf(beatjumpSize) + 1;
-        if (increasedIndex >= MC7000.beatJump.length) {
-            increasedIndex = MC7000.beatJump.length === 0 ? 0 : MC7000.beatJump.length - 1;
-        }
-        const newBeatJumpSize = MC7000.beatJump[increasedIndex];
-        engine.setValue(group, "beatjump_size", newBeatJumpSize);
+    if (value === 0) {
+        return;
     }
+    const beatjumpSize = engine.getValue(group, "beatjump_size");
+    let increasedIndex = MC7000.beatJump.indexOf(beatjumpSize) + 1;
+    if (increasedIndex >= MC7000.beatJump.length) {
+        increasedIndex = MC7000.beatJump.length === 0 ? 0 : MC7000.beatJump.length - 1;
+    }
+    const newBeatJumpSize = MC7000.beatJump[increasedIndex];
+    engine.setValue(group, "beatjump_size", newBeatJumpSize);
 };
 
 // Set Crossfader Curve

--- a/res/controllers/Denon-MC7000-scripts.js
+++ b/res/controllers/Denon-MC7000-scripts.js
@@ -110,9 +110,14 @@ MC7000.jogParams = {
     }
 };
 
-// Parameter button mode. See Denon-MC7000.midi.xml for documentation of the available modes.
+// Parameter button settings (the orange buttons at the bottom left/right of the controller).
 MC7000.parameterButtonSettings = {
+    // Parameter button mode. Available modes are `starsAndColor`, `beatjump` and `introOutro`.
     mode: engine.getSetting("parameterButtonMode") || "starsAndColor",
+    // Whether to use the parameter buttons to change the pitch range during
+    // pitch play mode. If this option is enabled, the pitch change
+    // functionality overrides the normal parameter button mode during pitch play.
+    parameterButtonPitchPlayOverrideEnabled: engine.getSetting("parameterButtonPitchPlayOverrideEnabled"),
 };
 
 /*/////////////////////////////////
@@ -963,14 +968,15 @@ MC7000.parameterButton = function(value, group, {isLeftButton, isShiftPressed}) 
 
     const deckNumber = script.deckFromGroup(group);
     const deckIndex = deckNumber - 1;
+    const settings = MC7000.parameterButtonSettings;
 
-    if (MC7000.PADMode[deckIndex] === "Pitch") {
+    if (settings.parameterButtonPitchPlayOverrideEnabled && MC7000.PADMode[deckIndex] === "Pitch") {
         const pitchDelta = isLeftButton ? -8 : 8;
         for (let padIdx = 0; padIdx < 8; padIdx++) {
             MC7000.halftoneToPadMap[deckIndex][padIdx] += pitchDelta;
         }
     } else {
-        switch (MC7000.parameterButtonSettings.mode) {
+        switch (settings.mode) {
         case "starsAndColor":
             if (isShiftPressed) {
                 script.triggerControl(group, `track_color_${isLeftButton ? "prev" : "next"}`);

--- a/res/controllers/Denon-MC7000-scripts.js
+++ b/res/controllers/Denon-MC7000-scripts.js
@@ -113,11 +113,11 @@ MC7000.jogParams = {
 // Parameter button settings (the orange buttons at the bottom left/right of the controller).
 MC7000.parameterButtonSettings = {
     // Parameter button mode. Available modes are `starsAndColor`, `beatjump` and `introOutro`.
-    mode: engine.getSetting("parameterButtonMode") || "starsAndColor",
+    mode: engine.getSetting("parameterButtonMode") ?? "starsAndColor",
     // Whether to use the parameter buttons to change the pitch range during
     // pitch play mode. If this option is enabled, the pitch change
     // functionality overrides the normal parameter button mode during pitch play.
-    parameterButtonPitchPlayOverrideEnabled: engine.getSetting("parameterButtonPitchPlayOverrideEnabled"),
+    parameterButtonPitchPlayOverrideEnabled: engine.getSetting("parameterButtonPitchPlayOverrideEnabled") ?? true,
 };
 
 /*/////////////////////////////////

--- a/res/controllers/Denon-MC7000-scripts.js
+++ b/res/controllers/Denon-MC7000-scripts.js
@@ -162,9 +162,6 @@ MC7000.prevVuLevel = [0, 0, 0, 0];
 MC7000.prevJogLED = [0, 0, 0, 0];
 MC7000.prevPadLED = [0, 0, 0, 0];
 
-// Param Buttons for Pitch Play
-MC7000.paramButton = [0, 0, 0, 0];
-
 /*
 Color Codes:
 Colors are encoded using the following schema: Take the individual components of the color (R, G, B). Then use

--- a/res/controllers/Denon-MC7000-scripts.js
+++ b/res/controllers/Denon-MC7000-scripts.js
@@ -981,6 +981,46 @@ MC7000.StarsUp = function(channel, control, value, status, group) {
     }
 };
 
+// Parameter Button '<'
+MC7000.parameterButtonDown = function(channel, control, value, status, group) {
+    if (value) {
+        script.triggerControl(group, "beatjump_backward");
+    }
+};
+
+// Parameter Button '>'
+MC7000.parameterButtonUp = function(channel, control, value, status, group) {
+    if (value) {
+        script.triggerControl(group, "beatjump_forward");
+    }
+};
+
+// Parameter Button '<' + 'SHIFT'
+MC7000.parameterButtonDownShifted = function(channel, control, value, status, group) {
+    if (value) {
+        const beatJumpSize = engine.getValue(group, "beatjump_size");
+        let decreasedIndex = MC7000.beatJump.indexOf(beatJumpSize) - 1;
+        if (decreasedIndex < 0) {
+            decreasedIndex = 0;
+        }
+        const newBeatJumpSize = MC7000.beatJump[decreasedIndex];
+        engine.setValue(group, "beatjump_size", newBeatJumpSize);
+    }
+};
+
+// Parameter Button '>' + 'SHIFT'
+MC7000.parameterButtonUpShifted = function(channel, control, value, status, group) {
+    if (value) {
+        const beatjumpSize = engine.getValue(group, "beatjump_size");
+        let increasedIndex = MC7000.beatJump.indexOf(beatjumpSize) + 1;
+        if (increasedIndex >= MC7000.beatJump.length) {
+            increasedIndex = MC7000.beatJump.length === 0 ? 0 : MC7000.beatJump.length - 1;
+        }
+        const newBeatJumpSize = MC7000.beatJump[increasedIndex];
+        engine.setValue(group, "beatjump_size", newBeatJumpSize);
+    }
+};
+
 // Set Crossfader Curve
 MC7000.crossFaderCurve = function(control, value) {
     script.crossfaderCurve(value);

--- a/res/controllers/Denon-MC7000.midi.xml
+++ b/res/controllers/Denon-MC7000.midi.xml
@@ -64,6 +64,17 @@
                 </option>
             </group>
         </group>
+        <group label="Alternative Mapping">
+            <group label="Parameter Buttons">
+                <option
+                    variable="parameterButtonMode"
+                    type="enum"
+                    label="Parameter Button Mode">
+                    <value label="Change Star Rating (Shift: Track Color)">starsAndColor</value>
+                    <value label="Perform Beat Jump (Shift: Adjust Jump Size)">beatjump</value>
+                </option>
+            </group>
+        </group>
     </settings>
     <controller id="DENON MC7000">
         <scriptfiles>
@@ -1984,7 +1995,7 @@
 <!-- PARAMETER BUTTONS -->
 			<control>
                 <group>[Channel1]</group>
-                <key>MC7000.parameterButtonDown</key>
+                <key>MC7000.parameterButtonLeft</key>
                 <description></description>
                 <status>0x94</status>
                 <midino>0x28</midino>
@@ -1994,7 +2005,7 @@
             </control>
             <control>
                 <group>[Channel1]</group>
-                <key>MC7000.parameterButtonUp</key>
+                <key>MC7000.parameterButtonRight</key>
                 <description></description>
                 <status>0x94</status>
                 <midino>0x29</midino>
@@ -2004,7 +2015,7 @@
             </control>
             <control>
                 <group>[Channel1]</group>
-                <key>MC7000.parameterButtonDownShifted</key>
+                <key>MC7000.parameterButtonLeftShifted</key>
                 <description></description>
                 <status>0x94</status>
                 <midino>0x2A</midino>
@@ -2014,7 +2025,7 @@
             </control>
             <control>
                 <group>[Channel1]</group>
-                <key>MC7000.parameterButtonUpShifted</key>
+                <key>MC7000.parameterButtonRightShifted</key>
                 <description></description>
                 <status>0x94</status>
                 <midino>0x2B</midino>
@@ -2024,7 +2035,7 @@
             </control>
             <control>
                 <group>[Channel2]</group>
-                <key>MC7000.parameterButtonDown</key>
+                <key>MC7000.parameterButtonLeft</key>
                 <description></description>
                 <status>0x95</status>
                 <midino>0x28</midino>
@@ -2034,7 +2045,7 @@
             </control>
             <control>
                 <group>[Channel2]</group>
-                <key>MC7000.parameterButtonUp</key>
+                <key>MC7000.parameterButtonRight</key>
                 <description></description>
                 <status>0x95</status>
                 <midino>0x29</midino>
@@ -2044,7 +2055,7 @@
             </control>
             <control>
                 <group>[Channel2]</group>
-                <key>MC7000.parameterButtonDownShifted</key>
+                <key>MC7000.parameterButtonLeftShifted</key>
                 <description></description>
                 <status>0x95</status>
                 <midino>0x2A</midino>
@@ -2054,7 +2065,7 @@
             </control>
             <control>
                 <group>[Channel2]</group>
-                <key>MC7000.parameterButtonUpShifted</key>
+                <key>MC7000.parameterButtonRightShifted</key>
                 <description></description>
                 <status>0x95</status>
                 <midino>0x2B</midino>
@@ -2064,7 +2075,7 @@
             </control>
             <control>
                 <group>[Channel3]</group>
-                <key>MC7000.parameterButtonDown</key>
+                <key>MC7000.parameterButtonLeft</key>
                 <description></description>
                 <status>0x96</status>
                 <midino>0x28</midino>
@@ -2074,7 +2085,7 @@
             </control>
             <control>
                 <group>[Channel3]</group>
-                <key>MC7000.parameterButtonUp</key>
+                <key>MC7000.parameterButtonRight</key>
                 <description></description>
                 <status>0x96</status>
                 <midino>0x29</midino>
@@ -2084,7 +2095,7 @@
             </control>
             <control>
                 <group>[Channel3]</group>
-                <key>MC7000.parameterButtonDownShifted</key>
+                <key>MC7000.parameterButtonLeftShifted</key>
                 <description></description>
                 <status>0x96</status>
                 <midino>0x2A</midino>
@@ -2094,7 +2105,7 @@
             </control>
             <control>
                 <group>[Channel3]</group>
-                <key>MC7000.parameterButtonUpShifted</key>
+                <key>MC7000.parameterButtonRightShifted</key>
                 <description></description>
                 <status>0x96</status>
                 <midino>0x2B</midino>
@@ -2104,7 +2115,7 @@
             </control>
             <control>
                 <group>[Channel4]</group>
-                <key>MC7000.parameterButtonDown</key>
+                <key>MC7000.parameterButtonLeft</key>
                 <description></description>
                 <status>0x97</status>
                 <midino>0x28</midino>
@@ -2114,7 +2125,7 @@
             </control>
             <control>
                 <group>[Channel4]</group>
-                <key>MC7000.parameterButtonUp</key>
+                <key>MC7000.parameterButtonRight</key>
                 <description></description>
                 <status>0x97</status>
                 <midino>0x29</midino>
@@ -2124,7 +2135,7 @@
             </control>
             <control>
                 <group>[Channel4]</group>
-                <key>MC7000.parameterButtonDownShifted</key>
+                <key>MC7000.parameterButtonLeftShifted</key>
                 <description></description>
                 <status>0x97</status>
                 <midino>0x2A</midino>
@@ -2134,7 +2145,7 @@
             </control>
             <control>
                 <group>[Channel4]</group>
-                <key>MC7000.parameterButtonUpShifted</key>
+                <key>MC7000.parameterButtonRightShifted</key>
                 <description></description>
                 <status>0x97</status>
                 <midino>0x2B</midino>

--- a/res/controllers/Denon-MC7000.midi.xml
+++ b/res/controllers/Denon-MC7000.midi.xml
@@ -72,6 +72,7 @@
                     label="Parameter Button Mode">
                     <value label="Change Star Rating (Shift: Track Color)">starsAndColor</value>
                     <value label="Perform Beat Jump (Shift: Adjust Jump Size)">beatjump</value>
+                    <value label="Set Intro/Outro (Shift: Clear Intro/Outro)">introOutro</value>
                 </option>
             </group>
         </group>

--- a/res/controllers/Denon-MC7000.midi.xml
+++ b/res/controllers/Denon-MC7000.midi.xml
@@ -78,6 +78,18 @@
                         in the bottom left/right corner of the controller.
                     </description>
                 </option>
+                <option
+                    variable="parameterButtonPitchPlayOverrideEnabled"
+                    label="Override parameter button mode during pitch play to set pitch range"
+                    type="boolean"
+                    default="true">
+                    <description>
+                        Whether to use the parameter buttons to change the pitch
+                        range during pitch play mode. If this option is enabled,
+                        the pitch change functionality overrides the normal
+                        parameter button mode during pitch play.
+                    </description>
+                </option>
             </group>
         </group>
     </settings>

--- a/res/controllers/Denon-MC7000.midi.xml
+++ b/res/controllers/Denon-MC7000.midi.xml
@@ -1984,7 +1984,7 @@
 <!-- PARAMETER BUTTONS -->
 			<control>
                 <group>[Channel1]</group>
-                <key>MC7000.StarsDown</key>
+                <key>MC7000.parameterButtonDown</key>
                 <description></description>
                 <status>0x94</status>
                 <midino>0x28</midino>
@@ -1994,7 +1994,7 @@
             </control>
             <control>
                 <group>[Channel1]</group>
-                <key>MC7000.StarsUp</key>
+                <key>MC7000.parameterButtonUp</key>
                 <description></description>
                 <status>0x94</status>
                 <midino>0x29</midino>
@@ -2003,38 +2003,38 @@
                 </options>
             </control>
             <control>
-                <group>[Library]</group>
-                <key>track_color_prev</key>
+                <group>[Channel1]</group>
+                <key>MC7000.parameterButtonDownShifted</key>
                 <description></description>
                 <status>0x94</status>
                 <midino>0x2A</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
-                <group>[Library]</group>
-                <key>track_color_next</key>
+                <group>[Channel1]</group>
+                <key>MC7000.parameterButtonUpShifted</key>
                 <description></description>
                 <status>0x94</status>
                 <midino>0x2B</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>MC7000.StarsDown</key>
-                <description></description>
-                <status>0x95</status>
-                <midino>0x28</midino>
                 <options>
                     <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel2]</group>
-                <key>MC7000.StarsUp</key>
+                <key>MC7000.parameterButtonDown</key>
+                <description></description>
+                <status>0x95</status>
+                <midino>0x28</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>MC7000.parameterButtonUp</key>
                 <description></description>
                 <status>0x95</status>
                 <midino>0x29</midino>
@@ -2043,28 +2043,28 @@
                 </options>
             </control>
             <control>
-                <group>[Library]</group>
-                <key>track_color_prev</key>
+                <group>[Channel2]</group>
+                <key>MC7000.parameterButtonDownShifted</key>
                 <description></description>
                 <status>0x95</status>
                 <midino>0x2A</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
-                <group>[Library]</group>
-                <key>track_color_next</key>
+                <group>[Channel2]</group>
+                <key>MC7000.parameterButtonUpShifted</key>
                 <description></description>
                 <status>0x95</status>
                 <midino>0x2B</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel3]</group>
-                <key>MC7000.StarsDown</key>
+                <key>MC7000.parameterButtonDown</key>
                 <description></description>
                 <status>0x96</status>
                 <midino>0x28</midino>
@@ -2074,7 +2074,7 @@
             </control>
             <control>
                 <group>[Channel3]</group>
-                <key>MC7000.StarsUp</key>
+                <key>MC7000.parameterButtonUp</key>
                 <description></description>
                 <status>0x96</status>
                 <midino>0x29</midino>
@@ -2083,28 +2083,28 @@
                 </options>
             </control>
             <control>
-                <group>[Library]</group>
-                <key>track_color_prev</key>
+                <group>[Channel3]</group>
+                <key>MC7000.parameterButtonDownShifted</key>
                 <description></description>
                 <status>0x96</status>
                 <midino>0x2A</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
-                <group>[Library]</group>
-                <key>track_color_next</key>
+                <group>[Channel3]</group>
+                <key>MC7000.parameterButtonUpShifted</key>
                 <description></description>
                 <status>0x96</status>
                 <midino>0x2B</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
                 <group>[Channel4]</group>
-                <key>MC7000.StarsDown</key>
+                <key>MC7000.parameterButtonDown</key>
                 <description></description>
                 <status>0x97</status>
                 <midino>0x28</midino>
@@ -2114,7 +2114,7 @@
             </control>
             <control>
                 <group>[Channel4]</group>
-                <key>MC7000.StarsUp</key>
+                <key>MC7000.parameterButtonUp</key>
                 <description></description>
                 <status>0x97</status>
                 <midino>0x29</midino>
@@ -2123,23 +2123,23 @@
                 </options>
             </control>
             <control>
-                <group>[Library]</group>
-                <key>track_color_prev</key>
+                <group>[Channel4]</group>
+                <key>MC7000.parameterButtonDownShifted</key>
                 <description></description>
                 <status>0x97</status>
                 <midino>0x2A</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
-                <group>[Library]</group>
-                <key>track_color_next</key>
+                <group>[Channel4]</group>
+                <key>MC7000.parameterButtonUpShifted</key>
                 <description></description>
                 <status>0x97</status>
                 <midino>0x2B</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
 <!-- LIBRARY -->

--- a/res/controllers/Denon-MC7000.midi.xml
+++ b/res/controllers/Denon-MC7000.midi.xml
@@ -70,7 +70,7 @@
                     variable="parameterButtonMode"
                     type="enum"
                     label="Parameter Button Mode">
-                    <value label="Change Star Rating (Shift: Track Color)">starsAndColor</value>
+                    <value label="Change Star Rating (Shift: Track Color)" default="true">starsAndColor</value>
                     <value label="Perform Beat Jump (Shift: Adjust Jump Size)">beatjump</value>
                     <value label="Set Intro/Outro (Shift: Clear Intro/Outro)">introOutro</value>
                     <description>

--- a/res/controllers/Denon-MC7000.midi.xml
+++ b/res/controllers/Denon-MC7000.midi.xml
@@ -73,6 +73,10 @@
                     <value label="Change Star Rating (Shift: Track Color)">starsAndColor</value>
                     <value label="Perform Beat Jump (Shift: Adjust Jump Size)">beatjump</value>
                     <value label="Set Intro/Outro (Shift: Clear Intro/Outro)">introOutro</value>
+                    <description>
+                        Change the functionality of the orange parameter buttons
+                        in the bottom left/right corner of the controller.
+                    </description>
                 </option>
             </group>
         </group>


### PR DESCRIPTION
This is a rebased version of #4310, which aims to refactor the logic for the customizable parameter buttons on the Denon MC7000. Currently, the buttons change the star rating (track color if shifted), but some users rarely change these and would rather wish to map them differently.

Fortunately, the new controller settings feature lets us have our cake and it eat it too. This PR unifies the parameter button, refactors the code to be more concise/readable and adds three new parameter button modes:

| Mode | Description |
| - | - |
| `Change Star Rating (Shift: Track Color)` | The current and default mode |
| `Perform Beat Jump (Shift: Adjust Jump Size)` | The logic from the previous PR |
| `Set Intro/Outro (Shift: Clear Intro/Outro)` | A new mode that sets/clears intro-end/outro-start |

![image](https://github.com/user-attachments/assets/0e322d37-3ff4-452b-912d-49905407b268)

This PR also lets the user customize whether to override the parameter button mode with changing the pitch range. This is the default behavior as of #4729, which might be surprising to users that change the mode, hence the ability to disable it.