### PR TITLE
Track Search Preferences: Fix accidental use of wrong preference controls

### DIFF
--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -254,7 +254,7 @@ void DlgPrefLibrary::slotResetToDefaults() {
     setLibraryFont(QApplication::font());
     spinBox_search_debouncing_timeout->setValue(
             WSearchLineEdit::kDefaultDebouncingTimeoutMillis);
-    checkBox_enable_search_history_shortcuts->setChecked(
+    checkBox_enable_search_completions->setChecked(
             WSearchLineEdit::kCompletionsEnabledDefault);
     checkBox_enable_search_history_shortcuts->setChecked(
             WSearchLineEdit::kHistoryShortcutsEnabledDefault);
@@ -341,7 +341,7 @@ void DlgPrefLibrary::slotUpdate() {
     checkBox_edit_metadata_selected_clicked->setChecked(editMetadataSelectedClick);
     m_pLibrary->setEditMetadataSelectedClick(editMetadataSelectedClick);
 
-    checkBox_enable_search_history_shortcuts->setChecked(m_pConfig->getValue(
+    checkBox_enable_search_completions->setChecked(m_pConfig->getValue(
             kEnableSearchCompletionsConfigKey,
             WSearchLineEdit::kCompletionsEnabledDefault));
     checkBox_enable_search_history_shortcuts->setChecked(m_pConfig->getValue(
@@ -520,7 +520,7 @@ void DlgPrefLibrary::slotApply() {
             ConfigValue((int)checkBox_use_relative_path->isChecked()));
 
     m_pConfig->set(kEnableSearchCompletionsConfigKey,
-            ConfigValue(checkBox_enable_search_history_shortcuts->isChecked()));
+            ConfigValue(checkBox_enable_search_completions->isChecked()));
     m_pConfig->set(kEnableSearchHistoryShortcutsConfigKey,
             ConfigValue(checkBox_enable_search_history_shortcuts->isChecked()));
     updateSearchLineEditHistoryOptions();


### PR DESCRIPTION
Fix the copy-paste error introduced during a refactoring in commit 6e588ec8201d86f7ecd4702fb5baa47b78fdfb5e (merged with PR #12072), where references to `checkBox_enable_search_completions` where accidentally replaced with references to `checkBox_enable_search_history_shortcuts`.

Stumbled upon this while working on #13200