### PR TITLE
Auto DJ: Add context menu action for enabling/disabling the Auto DJ

### DIFF
--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -3,6 +3,7 @@
 #include <QMenu>
 #include <QtDebug>
 
+#include "controllers/keyboard/keyboardeventfilter.h"
 #include "library/autodj/autodjprocessor.h"
 #include "library/autodj/dlgautodj.h"
 #include "library/library.h"
@@ -95,6 +96,20 @@ AutoDJFeature::AutoDJFeature(Library* pLibrary,
             this,
             &AutoDJFeature::slotCrateChanged);
 
+    // Create context-menu items for enabling/disabling the auto-DJ
+    m_pEnableAutoDJAction = make_parented<QAction>(tr("Enable Auto DJ"), this);
+    connect(m_pEnableAutoDJAction.get(),
+            &QAction::triggered,
+            this,
+            &AutoDJFeature::slotEnableAutoDJ);
+
+    m_pDisableAutoDJAction = make_parented<QAction>(tr("Disable Auto DJ"), this);
+    connect(m_pDisableAutoDJAction.get(),
+            &QAction::triggered,
+            this,
+            &AutoDJFeature::slotDisableAutoDJ);
+
+    // Create context-menu item for clearing the auto-DJ queue
     m_pClearQueueAction = make_parented<QAction>(tr("Clear Auto DJ Queue"), this);
     const auto removeKeySequence =
             // TODO(XXX): Qt6 replace enum | with QKeyCombination
@@ -105,6 +120,7 @@ AutoDJFeature::AutoDJFeature(Library* pLibrary,
             &QAction::triggered,
             this,
             &AutoDJFeature::slotClearQueue);
+
     // Create context-menu items to allow crates to be added to, and removed
     // from, the auto-DJ queue.
     m_pRemoveCrateFromAutoDjAction =
@@ -157,6 +173,13 @@ void AutoDJFeature::bindLibraryWidget(
             &DlgAutoDJ::addRandomTrackButton,
             this,
             &AutoDJFeature::slotAddRandomTrack);
+
+    // Update shortcuts displayed in the context menu
+    QKeySequence toggleAutoDJShortcut = QKeySequence(
+            keyboard->getKeyboardConfig()->getValueString(ConfigKey("[AutoDJ]", "enabled")),
+            QKeySequence::PortableText);
+    m_pEnableAutoDJAction->setShortcut(toggleAutoDJShortcut);
+    m_pDisableAutoDJAction->setShortcut(toggleAutoDJShortcut);
 }
 
 void AutoDJFeature::bindSidebarWidget(WLibrarySidebar* pSidebarWidget) {
@@ -227,6 +250,14 @@ bool AutoDJFeature::dropAccept(const QList<QUrl>& urls, QObject* pSource) {
 bool AutoDJFeature::dragMoveAccept(const QUrl& url) {
     return SoundSourceProxy::isUrlSupported(url) ||
             Parser::isPlaylistFilenameSupported(url.toLocalFile());
+}
+
+void AutoDJFeature::slotEnableAutoDJ() {
+    m_pAutoDJProcessor->toggleAutoDJ(true);
+}
+
+void AutoDJFeature::slotDisableAutoDJ() {
+    m_pAutoDJProcessor->toggleAutoDJ(false);
 }
 
 void AutoDJFeature::slotClearQueue() {
@@ -336,6 +367,11 @@ void AutoDJFeature::constructCrateChildModel() {
 
 void AutoDJFeature::onRightClick(const QPoint& globalPos) {
     QMenu menu(m_pSidebarWidget);
+    if (m_pAutoDJProcessor->getState() == AutoDJProcessor::ADJ_DISABLED) {
+        menu.addAction(m_pEnableAutoDJAction.get());
+    } else {
+        menu.addAction(m_pDisableAutoDJAction.get());
+    }
     menu.addAction(m_pClearQueueAction.get());
     menu.exec(globalPos);
 }

--- a/src/library/autodj/autodjfeature.h
+++ b/src/library/autodj/autodjfeature.h
@@ -81,7 +81,10 @@ class AutoDJFeature : public LibraryFeature {
     // How we access the auto-DJ-crates database.
     AutoDJCratesDAO m_autoDjCratesDao;
 
+    parented_ptr<QAction> m_pEnableAutoDJAction;
+    parented_ptr<QAction> m_pDisableAutoDJAction;
     parented_ptr<QAction> m_pClearQueueAction;
+
     // A context-menu item that allows crates to be removed from the
     // auto-DJ list.
     parented_ptr<QAction> m_pRemoveCrateFromAutoDjAction;
@@ -89,7 +92,10 @@ class AutoDJFeature : public LibraryFeature {
     QPointer<WLibrarySidebar> m_pSidebarWidget;
 
   private slots:
+    void slotEnableAutoDJ();
+    void slotDisableAutoDJ();
     void slotClearQueue();
+
     // Add a crate to the auto-DJ queue.
     void slotAddCrateToAutoDj(CrateId crateId);
     // Implements the context-menu item.


### PR DESCRIPTION
Add context menu actions for enabling/disabling the Auto DJ.
Either the "Enable Auto DJ" or "Disable Auto DJ" shortcut is displayed, depending on the current state of the Auto DJ.

This fits in nicely with the "Clear Auto DJ Queue" action introduced by #13364.