### PR TITLE
Safe Global Predefined Color Palettes

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -11,3 +11,4 @@ ReflectIn
 bufferIn
 indexIn
 allLocations
+statics

--- a/src/dialog/dlgreplacecuecolor.cpp
+++ b/src/dialog/dlgreplacecuecolor.cpp
@@ -84,7 +84,7 @@ DlgReplaceCueColor::DlgReplaceCueColor(
     // Set up new color button
     ColorPaletteSettings colorPaletteSettings(pConfig);
     ColorPalette hotcuePalette = colorPaletteSettings.getHotcueColorPalette();
-    mixxx::RgbColor firstColor = mixxx::PredefinedColorPalettes::kDefaultCueColor;
+    mixxx::RgbColor firstColor = mixxx::predefinedcolorpalettes::kDefaultCueColor;
     DEBUG_ASSERT(hotcuePalette.size() > 0);
     if (hotcuePalette.size() > 0) { // Should always be true
         firstColor = hotcuePalette.at(0);
@@ -116,7 +116,7 @@ DlgReplaceCueColor::DlgReplaceCueColor(
     // Set up 'Current color' button
     setButtonColor(pushButtonCurrentColor,
             mixxx::RgbColor::toQColor(
-                    mixxx::PredefinedColorPalettes::kDefaultCueColor));
+                    mixxx::predefinedcolorpalettes::kDefaultCueColor));
 
     // Update apply button when the current color comparison combobox is
     // modified
@@ -134,7 +134,7 @@ DlgReplaceCueColor::DlgReplaceCueColor(
             this);
     m_pCurrentColorPickerAction->setObjectName("HotcueColorPickerAction");
     m_pCurrentColorPickerAction->setSelectedColor(
-            mixxx::PredefinedColorPalettes::kDefaultCueColor);
+            mixxx::predefinedcolorpalettes::kDefaultCueColor);
     connect(m_pCurrentColorPickerAction,
             &WColorPickerAction::colorPicked,
             this,

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -932,7 +932,7 @@ void CueControl::hotcueSet(HotcueControl* pControl, double value, HotcueSetMode 
 
     int hotcueIndex = pControl->getHotcueIndex();
 
-    mixxx::RgbColor color = mixxx::PredefinedColorPalettes::kDefaultCueColor;
+    mixxx::RgbColor color = mixxx::predefinedcolorpalettes::kDefaultCueColor;
     if (cueType == mixxx::CueType::Loop) {
         ConfigKey autoLoopColorsKey("[Controls]", "auto_loop_colors");
         if (getConfig()->getValue(autoLoopColorsKey, false)) {

--- a/src/preferences/colorpaletteeditor.cpp
+++ b/src/preferences/colorpaletteeditor.cpp
@@ -146,7 +146,9 @@ void ColorPaletteEditor::initialize(
     m_resetPalette = paletteName;
     QString saveName = paletteName;
 
-    for (const ColorPalette& palette : mixxx::PredefinedColorPalettes::kPalettes) {
+    const auto& kPalettes = mixxx::predefinedcolorpalettes::get();
+
+    for (const ColorPalette& palette : kPalettes.palettes) {
         if (paletteName == palette.getName()) {
             saveName = paletteName + QStringLiteral(" (") + tr("Edited") + QChar(')');
             ColorPaletteSettings colorPaletteSettings(m_pConfig);
@@ -206,7 +208,8 @@ void ColorPaletteEditor::slotRemoveColor() {
 void ColorPaletteEditor::slotPaletteNameChanged(const QString& text) {
     bool bPaletteIsReadOnly = false;
     bool bPaletteExists = false;
-    for (const ColorPalette& palette : mixxx::PredefinedColorPalettes::kPalettes) {
+    const auto& kPalettes = mixxx::predefinedcolorpalettes::get();
+    for (const ColorPalette& palette : kPalettes.palettes) {
         if (text == palette.getName()) {
             bPaletteExists = true;
             bPaletteIsReadOnly = true;
@@ -222,7 +225,7 @@ void ColorPaletteEditor::slotPaletteNameChanged(const QString& text) {
     if (bPaletteExists) {
         if (!m_pModel->isDirty()) {
             bool bPaletteFound = false;
-            for (const ColorPalette& palette : mixxx::PredefinedColorPalettes::kPalettes) {
+            for (const ColorPalette& palette : kPalettes.palettes) {
                 if (text == palette.getName()) {
                     bPaletteFound = true;
                     m_pModel->setColorPalette(palette);
@@ -231,7 +234,7 @@ void ColorPaletteEditor::slotPaletteNameChanged(const QString& text) {
             }
             if (!bPaletteFound) {
                 m_pModel->setColorPalette(colorPaletteSettings.getColorPalette(
-                        text, mixxx::PredefinedColorPalettes::kDefaultHotcueColorPalette));
+                        text, kPalettes.defaultHotcueColorPalette));
             }
         }
     }
@@ -277,7 +280,7 @@ void ColorPaletteEditor::slotResetButtonClicked() {
     ColorPaletteSettings colorPaletteSettings(m_pConfig);
     ColorPalette palette = colorPaletteSettings.getColorPalette(
             m_resetPalette,
-            mixxx::PredefinedColorPalettes::kDefaultHotcueColorPalette);
+            mixxx::predefinedcolorpalettes::get().defaultHotcueColorPalette);
     m_pModel->setColorPalette(palette);
     slotUpdateButtons();
 }

--- a/src/preferences/colorpaletteeditor.cpp
+++ b/src/preferences/colorpaletteeditor.cpp
@@ -12,6 +12,7 @@
 
 #include "moc_colorpaletteeditor.cpp"
 #include "preferences/colorpalettesettings.h"
+#include "util/color/colorpalette.h"
 #include "util/color/predefinedcolorpalettes.h"
 
 namespace {
@@ -148,8 +149,8 @@ void ColorPaletteEditor::initialize(
 
     const auto& kPalettes = mixxx::predefinedcolorpalettes::get();
 
-    for (const ColorPalette& palette : kPalettes.palettes) {
-        if (paletteName == palette.getName()) {
+    for (mixxx::predefinedcolorpalettes::ColorPalettePointer palette : kPalettes.palettes) {
+        if (paletteName == palette->getName()) {
             saveName = paletteName + QStringLiteral(" (") + tr("Edited") + QChar(')');
             ColorPaletteSettings colorPaletteSettings(m_pConfig);
             if (colorPaletteSettings.getColorPaletteNames().contains(saveName)) {
@@ -209,8 +210,8 @@ void ColorPaletteEditor::slotPaletteNameChanged(const QString& text) {
     bool bPaletteIsReadOnly = false;
     bool bPaletteExists = false;
     const auto& kPalettes = mixxx::predefinedcolorpalettes::get();
-    for (const ColorPalette& palette : kPalettes.palettes) {
-        if (text == palette.getName()) {
+    for (mixxx::predefinedcolorpalettes::ColorPalettePointer palette : kPalettes.palettes) {
+        if (text == palette->getName()) {
             bPaletteExists = true;
             bPaletteIsReadOnly = true;
             break;
@@ -225,10 +226,10 @@ void ColorPaletteEditor::slotPaletteNameChanged(const QString& text) {
     if (bPaletteExists) {
         if (!m_pModel->isDirty()) {
             bool bPaletteFound = false;
-            for (const ColorPalette& palette : kPalettes.palettes) {
-                if (text == palette.getName()) {
+            for (mixxx::predefinedcolorpalettes::ColorPalettePointer palette : kPalettes.palettes) {
+                if (text == palette->getName()) {
                     bPaletteFound = true;
-                    m_pModel->setColorPalette(palette);
+                    m_pModel->setColorPalette(*palette);
                     break;
                 }
             }

--- a/src/preferences/colorpalettesettings.cpp
+++ b/src/preferences/colorpalettesettings.cpp
@@ -2,6 +2,7 @@
 
 #include <QRegularExpression>
 
+#include "util/color/colorpalette.h"
 #include "util/color/predefinedcolorpalettes.h"
 
 namespace {
@@ -39,9 +40,10 @@ ColorPalette ColorPaletteSettings::getColorPalette(
     }
 
     // If we find a predefined palette with this name, return it
-    for (const ColorPalette& palette : mixxx::predefinedcolorpalettes::get().palettes) {
-        if (name == palette.getName()) {
-            return palette;
+    for (mixxx::predefinedcolorpalettes::ColorPalettePointer palette :
+            mixxx::predefinedcolorpalettes::get().palettes) {
+        if (name == palette->getName()) {
+            return *palette;
         }
     }
 
@@ -87,8 +89,9 @@ void ColorPaletteSettings::setColorPalette(const QString& name, const ColorPalet
         return;
     }
 
-    for (const ColorPalette& palette : mixxx::predefinedcolorpalettes::get().palettes) {
-        if (name == palette.getName()) {
+    for (mixxx::predefinedcolorpalettes::ColorPalettePointer palette :
+            mixxx::predefinedcolorpalettes::get().palettes) {
+        if (name == palette->getName()) {
             qDebug() << "Color Palette" << name << "is a built-in palette, not writing to config!";
             return;
         }

--- a/src/preferences/colorpalettesettings.cpp
+++ b/src/preferences/colorpalettesettings.cpp
@@ -39,7 +39,7 @@ ColorPalette ColorPaletteSettings::getColorPalette(
     }
 
     // If we find a predefined palette with this name, return it
-    for (const ColorPalette& palette : mixxx::PredefinedColorPalettes::kPalettes) {
+    for (const ColorPalette& palette : mixxx::predefinedcolorpalettes::get().palettes) {
         if (name == palette.getName()) {
             return palette;
         }
@@ -87,7 +87,7 @@ void ColorPaletteSettings::setColorPalette(const QString& name, const ColorPalet
         return;
     }
 
-    for (const ColorPalette& palette : mixxx::PredefinedColorPalettes::kPalettes) {
+    for (const ColorPalette& palette : mixxx::predefinedcolorpalettes::get().palettes) {
         if (name == palette.getName()) {
             qDebug() << "Color Palette" << name << "is a built-in palette, not writing to config!";
             return;
@@ -131,7 +131,7 @@ ColorPalette ColorPaletteSettings::getHotcueColorPalette(
         const QString& name) const {
     return getColorPalette(
             name,
-            mixxx::PredefinedColorPalettes::kDefaultHotcueColorPalette);
+            mixxx::predefinedcolorpalettes::get().defaultHotcueColorPalette);
 }
 
 void ColorPaletteSettings::setHotcueColorPalette(const ColorPalette& colorPalette) {
@@ -148,7 +148,7 @@ ColorPalette ColorPaletteSettings::getTrackColorPalette(
         const QString& name) const {
     return getColorPalette(
             name,
-            mixxx::PredefinedColorPalettes::kDefaultTrackColorPalette);
+            mixxx::predefinedcolorpalettes::get().defaultTrackColorPalette);
 }
 
 ColorPalette ColorPaletteSettings::getTrackColorPalette() const {
@@ -170,7 +170,7 @@ ColorPalette ColorPaletteSettings::getKeyColorPalette(
         const QString& name) const {
     return getColorPalette(
             name,
-            mixxx::PredefinedColorPalettes::kDefaultKeyColorPalette);
+            mixxx::predefinedcolorpalettes::get().defaultKeyColorPalette);
 }
 
 ColorPalette ColorPaletteSettings::getConfigKeyColorPalette() const {

--- a/src/preferences/dialog/dlgprefcolors.cpp
+++ b/src/preferences/dialog/dlgprefcolors.cpp
@@ -94,8 +94,9 @@ void DlgPrefColors::slotUpdate() {
     checkboxKeyColorsEnabled->setChecked(
             m_pConfig->getValue(kKeyColorsEnabledConfigKey,
                     BaseTrackTableModel::kKeyColorsEnabledDefault));
-    for (const auto& palette : mixxx::predefinedcolorpalettes::get().palettes) {
-        QString paletteName = palette.getName();
+    for (mixxx::predefinedcolorpalettes::ColorPalettePointer palette :
+            mixxx::predefinedcolorpalettes::get().palettes) {
+        QString paletteName = palette->getName();
         QString translatedName = QCoreApplication::translate(
                 "PredefinedColorPalettes", qPrintable(paletteName));
         QIcon paletteIcon = drawPalettePreview(paletteName);
@@ -109,7 +110,7 @@ void DlgPrefColors::slotUpdate() {
                 comboBoxTrackColors->count() - 1,
                 paletteIcon);
 
-        if (palette.size() == 12) {
+        if (palette->size() == 12) {
             comboBoxKeyColors->addItem(translatedName, paletteName);
             comboBoxKeyColors->setItemIcon(
                     comboBoxKeyColors->count() - 1,
@@ -209,20 +210,22 @@ void DlgPrefColors::slotApply() {
     bool bTrackColorPaletteFound = false;
     bool bKeyColorPaletteFound = false;
 
-    for (const auto& palette : mixxx::predefinedcolorpalettes::get().palettes) {
+    for (mixxx::predefinedcolorpalettes::ColorPalettePointer palette :
+            mixxx::predefinedcolorpalettes::get().palettes) {
+        QString name = palette->getName();
         if (!bHotcueColorPaletteFound &&
-                hotcueColorPaletteName == palette.getName()) {
-            m_colorPaletteSettings.setHotcueColorPalette(palette);
+                hotcueColorPaletteName == name) {
+            m_colorPaletteSettings.setHotcueColorPalette(*palette);
             bHotcueColorPaletteFound = true;
         }
         if (!bTrackColorPaletteFound &&
-                trackColorPaletteName == palette.getName()) {
-            m_colorPaletteSettings.setTrackColorPalette(palette);
+                trackColorPaletteName == name) {
+            m_colorPaletteSettings.setTrackColorPalette(*palette);
             bTrackColorPaletteFound = true;
         }
         if (!bKeyColorPaletteFound &&
-                keyColorPaletteName == palette.getName()) {
-            m_colorPaletteSettings.setKeyColorPalette(palette);
+                keyColorPaletteName == name) {
+            m_colorPaletteSettings.setKeyColorPalette(*palette);
             bKeyColorPaletteFound = true;
         }
     }

--- a/src/preferences/dialog/dlgprefcolors.cpp
+++ b/src/preferences/dialog/dlgprefcolors.cpp
@@ -94,7 +94,7 @@ void DlgPrefColors::slotUpdate() {
     checkboxKeyColorsEnabled->setChecked(
             m_pConfig->getValue(kKeyColorsEnabledConfigKey,
                     BaseTrackTableModel::kKeyColorsEnabledDefault));
-    for (const auto& palette : std::as_const(mixxx::PredefinedColorPalettes::kPalettes)) {
+    for (const auto& palette : mixxx::predefinedcolorpalettes::get().palettes) {
         QString paletteName = palette.getName();
         QString translatedName = QCoreApplication::translate(
                 "PredefinedColorPalettes", qPrintable(paletteName));
@@ -184,23 +184,19 @@ void DlgPrefColors::slotUpdate() {
 
 // Set the default values for all the widgets
 void DlgPrefColors::slotResetToDefaults() {
+    const auto& kPalettes = mixxx::predefinedcolorpalettes::get();
     comboBoxHotcueColors->setCurrentText(QCoreApplication::translate(
             "PredefinedColorPalettes",
             qPrintable(
-                    mixxx::PredefinedColorPalettes::kDefaultHotcueColorPalette
-                            .getName())));
+                    kPalettes.defaultHotcueColorPalette.getName())));
     comboBoxTrackColors->setCurrentText(QCoreApplication::translate(
             "PredefinedColorPalettes",
-            qPrintable(mixxx::PredefinedColorPalettes::kDefaultTrackColorPalette
-                               .getName())));
+            qPrintable(kPalettes.defaultTrackColorPalette.getName())));
     comboBoxKeyColors->setCurrentText(QCoreApplication::translate(
             "PredefinedColorPalettes",
-            qPrintable(mixxx::PredefinedColorPalettes::kDefaultKeyColorPalette
-                               .getName())));
-    comboBoxHotcueDefaultColor->setCurrentIndex(
-            mixxx::PredefinedColorPalettes::kDefaultTrackColorPalette.size());
-    comboBoxLoopDefaultColor->setCurrentIndex(
-            mixxx::PredefinedColorPalettes::kDefaultTrackColorPalette.size() - 1);
+            qPrintable(kPalettes.defaultKeyColorPalette.getName())));
+    comboBoxHotcueDefaultColor->setCurrentIndex(kPalettes.defaultTrackColorPalette.size());
+    comboBoxLoopDefaultColor->setCurrentIndex(kPalettes.defaultTrackColorPalette.size() - 1);
     checkboxKeyColorsEnabled->setChecked(BaseTrackTableModel::kKeyColorsEnabledDefault);
 }
 
@@ -213,8 +209,7 @@ void DlgPrefColors::slotApply() {
     bool bTrackColorPaletteFound = false;
     bool bKeyColorPaletteFound = false;
 
-    for (const auto& palette :
-            std::as_const(mixxx::PredefinedColorPalettes::kPalettes)) {
+    for (const auto& palette : mixxx::predefinedcolorpalettes::get().palettes) {
         if (!bHotcueColorPaletteFound &&
                 hotcueColorPaletteName == palette.getName()) {
             m_colorPaletteSettings.setHotcueColorPalette(palette);

--- a/src/test/colorconfig_test.cpp
+++ b/src/test/colorconfig_test.cpp
@@ -100,8 +100,9 @@ TEST_F(ColorConfigTest, LoadSavePalettes) {
 
 TEST_F(ColorConfigTest, DefaultColorPalette) {
     ColorPaletteSettings colorPaletteSettings(config());
-    ASSERT_EQ(mixxx::PredefinedColorPalettes::kDefaultHotcueColorPalette,
+    const auto& kPalettes = mixxx::predefinedcolorpalettes::get();
+    ASSERT_EQ(kPalettes.defaultHotcueColorPalette,
             colorPaletteSettings.getHotcueColorPalette());
-    ASSERT_EQ(mixxx::PredefinedColorPalettes::kDefaultTrackColorPalette,
+    ASSERT_EQ(kPalettes.defaultTrackColorPalette,
             colorPaletteSettings.getTrackColorPalette());
 }

--- a/src/test/colorpalette_test.cpp
+++ b/src/test/colorpalette_test.cpp
@@ -5,25 +5,25 @@
 #include "test/mixxxtest.h"
 #include "util/color/predefinedcolorpalettes.h"
 
-class ColorPaletteTest : public MixxxTest {};
+class ColorPaletteTest : public MixxxTest {
+  protected:
+    ColorPalette palette{mixxx::predefinedcolorpalettes::get().defaultHotcueColorPalette};
+    void SetUp() override {
+        ASSERT_TRUE(palette.size() >= 1);
+    }
+};
 
 TEST_F(ColorPaletteTest, NextColor) {
-    const ColorPalette palette = mixxx::PredefinedColorPalettes::kDefaultHotcueColorPalette;
-    ASSERT_TRUE(palette.size() >= 1);
     ASSERT_EQ(palette.nextColor(palette.at(0)), palette.at(1));
     ASSERT_EQ(palette.nextColor(palette.at(palette.size() - 1)), palette.at(0));
 }
 
 TEST_F(ColorPaletteTest, PreviousColor) {
-    const ColorPalette palette = mixxx::PredefinedColorPalettes::kDefaultHotcueColorPalette;
-    ASSERT_TRUE(palette.size() >= 1);
     ASSERT_EQ(palette.previousColor(palette.at(1)), palette.at(0));
     ASSERT_EQ(palette.previousColor(palette.at(0)), palette.at(palette.size() - 1));
 }
 
 TEST_F(ColorPaletteTest, NextAndPreviousColorRoundtrip) {
-    const ColorPalette palette = mixxx::PredefinedColorPalettes::kDefaultHotcueColorPalette;
-    ASSERT_TRUE(palette.size() >= 1);
     ASSERT_EQ(palette.nextColor(palette.previousColor(palette.at(0))), palette.at(0));
     ASSERT_EQ(palette.nextColor(palette.previousColor(palette.at(palette.size() - 1))), palette.at(palette.size() - 1));
     ASSERT_EQ(palette.previousColor(palette.nextColor(palette.at(0))), palette.at(0));

--- a/src/test/cue_test.cpp
+++ b/src/test/cue_test.cpp
@@ -15,7 +15,7 @@ TEST(CueTest, NewCueIsDirty) {
             1,
             mixxx::audio::kStartFramePos,
             mixxx::audio::kInvalidFramePos,
-            mixxx::PredefinedColorPalettes::kDefaultCueColor);
+            mixxx::predefinedcolorpalettes::kDefaultCueColor);
     EXPECT_TRUE(cue.isDirty());
 }
 

--- a/src/test/seratotagstest.cpp
+++ b/src/test/seratotagstest.cpp
@@ -256,14 +256,14 @@ TEST_F(SeratoTagsTest, SetIncompatibleCueInfos) {
 }
 
 TEST_F(SeratoTagsTest, CueColorConversionRoundtrip) {
-    for (const auto color : mixxx::PredefinedColorPalettes::
-                    kSeratoTrackMetadataHotcueColorPalette) {
+    const auto& kPalettes = mixxx::predefinedcolorpalettes::get();
+    for (const auto color : kPalettes.seratoTrackMetadataHotcueColorPalette) {
         const auto displayedColor = mixxx::SeratoStoredHotcueColor(color).toDisplayedColor();
         const auto storedColor = mixxx::SeratoStoredHotcueColor::fromDisplayedColor(displayedColor);
         EXPECT_EQ(color, storedColor.toQRgb());
     }
 
-    for (const auto color : mixxx::PredefinedColorPalettes::kSeratoDJProHotcueColorPalette) {
+    for (const auto color : kPalettes.seratoDJProHotcueColorPalette) {
         const auto storedColor = mixxx::SeratoStoredHotcueColor::fromDisplayedColor(color);
         const auto displayedColor = storedColor.toDisplayedColor();
         EXPECT_EQ(color, displayedColor);

--- a/src/track/cue.cpp
+++ b/src/track/cue.cpp
@@ -84,7 +84,7 @@ Cue::Cue(
                           sampleRate)),
           m_iHotCue(cueInfo.getHotCueIndex().value_or(kNoHotCue)),
           m_label(cueInfo.getLabel()),
-          m_color(cueInfo.getColor().value_or(mixxx::PredefinedColorPalettes::kDefaultCueColor)) {
+          m_color(cueInfo.getColor().value_or(mixxx::predefinedcolorpalettes::kDefaultCueColor)) {
     DEBUG_ASSERT(!m_dbId.isValid());
 }
 

--- a/src/track/serato/color.cpp
+++ b/src/track/serato/color.cpp
@@ -80,10 +80,11 @@ RgbColor::optional_t SeratoStoredHotcueColor::toDisplayedColor() const {
     if (m_color == SeratoStoredColor::kNoColor) {
         return RgbColor::nullopt();
     }
+    const auto& kPalettes = mixxx::predefinedcolorpalettes::get();
 
     return RgbColor::optional(getColorFromOtherPalette(
-            PredefinedColorPalettes::kSeratoTrackMetadataHotcueColorPalette,
-            PredefinedColorPalettes::kSeratoDJProHotcueColorPalette,
+            kPalettes.seratoTrackMetadataHotcueColorPalette,
+            kPalettes.seratoDJProHotcueColorPalette,
             m_color));
 }
 
@@ -92,9 +93,10 @@ SeratoStoredHotcueColor SeratoStoredHotcueColor::fromDisplayedColor(RgbColor::op
     if (!color) {
         return SeratoStoredHotcueColor(SeratoStoredColor::kNoColor);
     }
+    const auto& kPalettes = mixxx::predefinedcolorpalettes::get();
     return SeratoStoredHotcueColor(getColorFromOtherPalette(
-            PredefinedColorPalettes::kSeratoDJProHotcueColorPalette,
-            PredefinedColorPalettes::kSeratoTrackMetadataHotcueColorPalette,
+            kPalettes.seratoDJProHotcueColorPalette,
+            kPalettes.seratoTrackMetadataHotcueColorPalette,
             *color));
 }
 

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -955,7 +955,7 @@ void Track::setMainCuePosition(mixxx::audio::FramePos position) {
                     Cue::kNoHotCue,
                     position,
                     mixxx::audio::kInvalidFramePos,
-                    mixxx::PredefinedColorPalettes::kDefaultCueColor));
+                    mixxx::predefinedcolorpalettes::kDefaultCueColor));
             // While this method could be called from any thread,
             // associated Cue objects should always live on the
             // same thread as their host, namely this->thread().

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -305,13 +305,13 @@ class Track : public QObject {
             int hotCueIndex,
             mixxx::audio::FramePos startPosition,
             mixxx::audio::FramePos endPosition,
-            mixxx::RgbColor color = mixxx::PredefinedColorPalettes::kDefaultCueColor);
+            mixxx::RgbColor color = mixxx::predefinedcolorpalettes::kDefaultCueColor);
     CuePointer createAndAddCue(
             mixxx::CueType type,
             int hotCueIndex,
             double startPositionSamples,
             double endPositionSamples,
-            mixxx::RgbColor color = mixxx::PredefinedColorPalettes::kDefaultCueColor) {
+            mixxx::RgbColor color = mixxx::predefinedcolorpalettes::kDefaultCueColor) {
         return createAndAddCue(type,
                 hotCueIndex,
                 mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(

--- a/src/util/color/predefinedcolorpalettes.cpp
+++ b/src/util/color/predefinedcolorpalettes.cpp
@@ -548,24 +548,24 @@ const PredefinedColorPalettes& get() {
             .defaultKeyColorPalette = kPalettes.mixxxKeyColorPalette,
             .palettes{
                     // Hotcue Color Palettes
-                    kPalettes.mixxxHotcueColorPalette,
-                    kPalettes.seratoDJProHotcueColorPalette,
-                    kPalettes.rekordboxCOLD1HotcueColorPalette,
-                    kPalettes.rekordboxCOLD2HotcueColorPalette,
-                    kPalettes.rekordboxCOLORFULHotcueColorPalette,
+                    &kPalettes.mixxxHotcueColorPalette,
+                    &kPalettes.seratoDJProHotcueColorPalette,
+                    &kPalettes.rekordboxCOLD1HotcueColorPalette,
+                    &kPalettes.rekordboxCOLD2HotcueColorPalette,
+                    &kPalettes.rekordboxCOLORFULHotcueColorPalette,
                     // Track Color Palettes
-                    kPalettes.mixxxTrackColorPalette,
-                    kPalettes.rekordboxTrackColorPalette,
-                    kPalettes.seratoDJProTrackColorPalette,
-                    kPalettes.traktorProTrackColorPalette,
-                    kPalettes.virtualDJTrackColorPalette,
+                    &kPalettes.mixxxTrackColorPalette,
+                    &kPalettes.rekordboxTrackColorPalette,
+                    &kPalettes.seratoDJProTrackColorPalette,
+                    &kPalettes.traktorProTrackColorPalette,
+                    &kPalettes.virtualDJTrackColorPalette,
                     // Key Color Palettes
-                    kPalettes.mixxxKeyColorPalette,
-                    kPalettes.traktorKeyColorPalette,
-                    kPalettes.MIKKeyColorPalette,
-                    kPalettes.protKeyColorPalette,
-                    kPalettes.deutKeyColorPalette,
-                    kPalettes.tritKeyColorPalette,
+                    &kPalettes.mixxxKeyColorPalette,
+                    &kPalettes.traktorKeyColorPalette,
+                    &kPalettes.MIKKeyColorPalette,
+                    &kPalettes.protKeyColorPalette,
+                    &kPalettes.deutKeyColorPalette,
+                    &kPalettes.tritKeyColorPalette,
             }};
     return kPalettes;
 }

--- a/src/util/color/predefinedcolorpalettes.cpp
+++ b/src/util/color/predefinedcolorpalettes.cpp
@@ -10,7 +10,7 @@ constexpr mixxx::RgbColor kColorMixxxYellow(0xF8D200);
 constexpr mixxx::RgbColor kColorMixxxBlue(0x0044FF);
 constexpr mixxx::RgbColor kColorMixxxPurple(0xAF00CC);
 constexpr mixxx::RgbColor kColorMixxxPink(0xFCA6D7);
-constexpr mixxx::RgbColor kColorMixxxWhite(0xF2F2FF);
+// white already declared in header
 
 // Default Mixxx Track Color Palette
 constexpr mixxx::RgbColor kMixxxTrackColorDarkRed(0x880000);
@@ -241,367 +241,333 @@ constexpr mixxx::RgbColor kTritKeyColor10(0x666600);
 constexpr mixxx::RgbColor kTritKeyColor11(0x3D7802);
 constexpr mixxx::RgbColor kTritKeyColor12(0x22A50D);
 
-// Replaces "no color" values and is used for new cues if auto_hotcue_colors is
-// disabled
-constexpr mixxx::RgbColor kSchemaMigrationReplacementColor(0xFF8000);
-
 } // anonymous namespace
 
 namespace mixxx {
+namespace predefinedcolorpalettes {
 
-const ColorPalette PredefinedColorPalettes::kMixxxHotcueColorPalette =
-        ColorPalette(
-                QStringLiteral(QT_TRANSLATE_NOOP("PredefinedColorPaletes", "Mixxx Hotcue Colors")),
-                {
-                        kColorMixxxRed,
-                        kColorMixxxGreen,
-                        kColorMixxxCeleste,
-                        kColorMixxxYellow,
-                        kColorMixxxBlue,
-                        kColorMixxxPurple,
-                        kColorMixxxPink,
-                        kColorMixxxWhite,
-                        kSchemaMigrationReplacementColor,
-                },
-                // Exclude kSchemaMigrationReplacementColor from the colors assigned to hotcues.
-                // If there were 9 colors assigned to hotcues, that would look weird on
-                // controllers with >8 hotcue buttons, for example a Novation Launchpad.
-                {0, 1, 2, 3, 4, 5, 6, 7});
+const PredefinedColorPalettes& get() {
+    // All Rekordbox Palette types, share the same color, but their default colors
+    // are not in the selection offered to the user. This usecase is not supported
+    // by mixxx's ColorPalette. The compromise is slightly altering the default
+    // colors used so they're part of the selection. The difference between these
+    // colors should be imperceptible for the unknowing user.
+    const QList<mixxx::RgbColor> kRekordboxColorsSelection = {
+            kRekordboxHotcueColor1,
+            kRekordboxHotcueColor2,
+            kRekordboxHotcueColor3,
+            kRekordboxHotcueColor4,
+            kRekordboxHotcueColor5,
+            kRekordboxHotcueColor6,
+            kRekordboxHotcueColor7,
+            kRekordboxHotcueColor8,
+            kRekordboxHotcueColor9,
+            kRekordboxHotcueColor10,
+            kRekordboxHotcueColor11,
+            kRekordboxHotcueColor12,
+            kRekordboxHotcueColor13,
+            kRekordboxHotcueColor14,
+            kRekordboxHotcueColor15,
+            kRekordboxHotcueColor16,
+    };
 
-const ColorPalette
-        PredefinedColorPalettes::kSeratoTrackMetadataHotcueColorPalette =
-                ColorPalette(
-                        QStringLiteral(QT_TRANSLATE_NOOP("PredefinedColorPalettes",
-                                "Serato DJ Track Metadata Hotcue Colors")),
-                        {
-                                kSeratoTrackMetadataHotcueColorRed,
-                                kSeratoTrackMetadataHotcueColorOrange,
-                                kSeratoTrackMetadataHotcueColorBrown,
-                                kSeratoTrackMetadataHotcueColorYellow,
-                                kSeratoTrackMetadataHotcueColorEmerald,
-                                kSeratoTrackMetadataHotcueColorKelly,
-                                kSeratoTrackMetadataHotcueColorGreen,
-                                kSeratoTrackMetadataHotcueColorSea,
-                                kSeratoTrackMetadataHotcueColorJade,
-                                kSeratoTrackMetadataHotcueColorTurquoise,
-                                kSeratoTrackMetadataHotcueColorTeal,
-                                kSeratoTrackMetadataHotcueColorBlue,
-                                kSeratoTrackMetadataHotcueColorDarkBlue,
-                                kSeratoTrackMetadataHotcueColorViolet,
-                                kSeratoTrackMetadataHotcueColorPurple,
-                                kSeratoTrackMetadataHotcueColorFuchsia,
-                                kSeratoTrackMetadataHotcueColorMagenta,
-                                kSeratoTrackMetadataHotcueColorCarmine,
-                        },
-                        {0, 2, 12, 3, 6, 15, 9, 14});
+    const static PredefinedColorPalettes kPalettes{
+            .mixxxHotcueColorPalette{
+                    QStringLiteral(QT_TRANSLATE_NOOP(
+                            "PredefinedColorPaletes", "Mixxx Hotcue Colors")),
+                    {
+                            kColorMixxxRed,
+                            kColorMixxxGreen,
+                            kColorMixxxCeleste,
+                            kColorMixxxYellow,
+                            kColorMixxxBlue,
+                            kColorMixxxPurple,
+                            kColorMixxxPink,
+                            kColorMixxxWhite,
+                            kSchemaMigrationReplacementColor,
+                    },
+                    // Exclude kSchemaMigrationReplacementColor from the colors
+                    // assigned to hotcues. If there were 9 colors assigned to
+                    // hotcues, that would look weird on controllers with >8
+                    // hotcue buttons, for example a Novation Launchpad.
+                    {0, 1, 2, 3, 4, 5, 6, 7}},
+            .seratoTrackMetadataHotcueColorPalette{
+                    QStringLiteral(QT_TRANSLATE_NOOP("PredefinedColorPalettes",
+                            "Serato DJ Track Metadata Hotcue Colors")),
+                    {
+                            kSeratoTrackMetadataHotcueColorRed,
+                            kSeratoTrackMetadataHotcueColorOrange,
+                            kSeratoTrackMetadataHotcueColorBrown,
+                            kSeratoTrackMetadataHotcueColorYellow,
+                            kSeratoTrackMetadataHotcueColorEmerald,
+                            kSeratoTrackMetadataHotcueColorKelly,
+                            kSeratoTrackMetadataHotcueColorGreen,
+                            kSeratoTrackMetadataHotcueColorSea,
+                            kSeratoTrackMetadataHotcueColorJade,
+                            kSeratoTrackMetadataHotcueColorTurquoise,
+                            kSeratoTrackMetadataHotcueColorTeal,
+                            kSeratoTrackMetadataHotcueColorBlue,
+                            kSeratoTrackMetadataHotcueColorDarkBlue,
+                            kSeratoTrackMetadataHotcueColorViolet,
+                            kSeratoTrackMetadataHotcueColorPurple,
+                            kSeratoTrackMetadataHotcueColorFuchsia,
+                            kSeratoTrackMetadataHotcueColorMagenta,
+                            kSeratoTrackMetadataHotcueColorCarmine,
+                    },
+                    {0, 2, 12, 3, 6, 15, 9, 14}},
+            .seratoDJProHotcueColorPalette{
+                    QStringLiteral(QT_TRANSLATE_NOOP("PredefinedColorPalettes",
+                            "Serato DJ Pro Hotcue Colors")),
+                    {
+                            kSeratoDJProHotcueColorRed1,
+                            kSeratoDJProHotcueColorOrange1,
+                            kSeratoDJProHotcueColorOrange2,
+                            kSeratoDJProHotcueColorYellow,
+                            kSeratoDJProHotcueColorGreen1,
+                            kSeratoDJProHotcueColorGreen2,
+                            kSeratoDJProHotcueColorGreen3,
+                            kSeratoDJProHotcueColorGreen4,
+                            kSeratoDJProHotcueColorBlue1,
+                            kSeratoDJProHotcueColorCyan,
+                            kSeratoDJProHotcueColorBlue2,
+                            kSeratoDJProHotcueColorDarkBlue1,
+                            kSeratoDJProHotcueColorDarkBlue2,
+                            kSeratoDJProHotcueColorViolet1,
+                            kSeratoDJProHotcueColorViolet2,
+                            kSeratoDJProHotcueColorMagenta,
+                            kSeratoDJProHotcueColorPurple,
+                            kSeratoDJProHotcueColorRed2,
+                    },
+                    {0, 2, 12, 3, 6, 15, 9, 14}},
+            .rekordboxCOLD1HotcueColorPalette{
+                    QStringLiteral(QT_TRANSLATE_NOOP("PredefinedColorPalettes",
+                            "Rekordbox COLD1 Hotcue Colors")),
+                    kRekordboxColorsSelection,
+                    {5, 8, 1, 6, 7, 2, 7, 5}},
+            .rekordboxCOLD2HotcueColorPalette{
+                    QStringLiteral(QT_TRANSLATE_NOOP("PredefinedColorPalettes",
+                            "Rekordbox COLD2 Hotcue Colors")),
+                    kRekordboxColorsSelection,
+                    {7, 5, 5, 5, 3, 4, 3, 2}},
+            .rekordboxCOLORFULHotcueColorPalette{
+                    QStringLiteral(QT_TRANSLATE_NOOP("PredefinedColorPalettes",
+                            "Rekordbox COLORFUL Hotcue Colors")),
+                    kRekordboxColorsSelection,
+                    {15, 5, 10, 2, 8, 13, 4, 12}},
+            .mixxxTrackColorPalette{
+                    QStringLiteral(QT_TRANSLATE_NOOP(
+                            "PredefinedColorPalettes", "Mixxx Track Colors")),
+                    {
+                            kMixxxTrackColorDarkRed,
+                            kMixxxTrackColorRed,
+                            kMixxxTrackColorDarkOrange,
+                            kMixxxTrackColorLemonGlacier,
+                            kMixxxTrackColorChartreuse,
+                            kMixxxTrackColorElectricGreen,
+                            kMixxxTrackColorIndiaGreen,
+                            kMixxxTrackColorDarkCyan,
+                            kMixxxTrackColorDodgerBlue,
+                            kMixxxTrackColorBlue,
+                            kMixxxTrackColorNavyBlue,
+                            kMixxxTrackColorMardiGras,
+                            kMixxxTrackColorVividViolet,
+                            kMixxxTrackColorFuchsia,
+                            kMixxxTrackColorViolet,
+                            kMixxxTrackColorWhite,
+                            kMixxxTrackColorAqua,
+                            kMixxxTrackColorSpringGreen,
+                            kMixxxTrackColorBattleshipGrey,
+                    }},
+            .rekordboxTrackColorPalette{
+                    QStringLiteral(QT_TRANSLATE_NOOP("PredefinedColorPalettes",
+                            "Rekordbox Track Colors")),
+                    {
+                            kRekordboxTrackColorPink,
+                            kRekordboxTrackColorRed,
+                            kRekordboxTrackColorOrange,
+                            kRekordboxTrackColorYellow,
+                            kRekordboxTrackColorGreen,
+                            kRekordboxTrackColorAqua,
+                            kRekordboxTrackColorBlue,
+                            kRekordboxTrackColorPurple,
+                    }},
+            .seratoDJProTrackColorPalette{
+                    QStringLiteral(QT_TRANSLATE_NOOP("PredefinedColorPalettes",
+                            "Serato DJ Pro Track Colors")),
+                    {
+                            kSeratoDJProTrackColorGrey1,
+                            kSeratoDJProTrackColorGrey2,
+                            kSeratoDJProTrackColorPink1,
+                            kSeratoDJProTrackColorPink2,
+                            kSeratoDJProTrackColorRed1,
+                            kSeratoDJProTrackColorRed2,
+                            kSeratoDJProTrackColorOrange,
+                            kSeratoDJProTrackColorBrown1,
+                            kSeratoDJProTrackColorBrown2,
+                            kSeratoDJProTrackColorBrown3,
+                            kSeratoDJProTrackColorGreen1,
+                            kSeratoDJProTrackColorGreen2,
+                            kSeratoDJProTrackColorGreen3,
+                            kSeratoDJProTrackColorTurquoise1,
+                            kSeratoDJProTrackColorTurquoise2,
+                            kSeratoDJProTrackColorTurquoise3,
+                            kSeratoDJProTrackColorBlue,
+                            kSeratoDJProTrackColorPurple1,
+                            kSeratoDJProTrackColorPurple2,
+                            kSeratoDJProTrackColorPurple3,
+                    }},
+            .traktorProTrackColorPalette{
+                    QStringLiteral(QT_TRANSLATE_NOOP("PredefinedColorPalettes",
+                            "Traktor Pro Track Colors")),
+                    {
+                            kTraktorProTrackColorRed,
+                            kTraktorProTrackColorOrange,
+                            kTraktorProTrackColorYellow,
+                            kTraktorProTrackColorGreen,
+                            kTraktorProTrackColorBlue,
+                            kTraktorProTrackColorViolet,
+                            kTraktorProTrackColorMagenta,
+                    }},
+            .virtualDJTrackColorPalette{
+                    QStringLiteral(QT_TRANSLATE_NOOP("PredefinedColorPalettes",
+                            "VirtualDJ Track Colors")),
+                    {
+                            kVirtualDJTrackColorRed,
+                            kVirtualDJTrackColorYellow,
+                            kVirtualDJTrackColorGreen,
+                            kVirtualDJTrackColorCyan,
+                            kVirtualDJTrackColorBlue,
+                            kVirtualDJTrackColorFuchsia,
+                            kVirtualDJTrackColorWhite,
+                    }},
+            .mixxxKeyColorPalette{
+                    QStringLiteral(QT_TRANSLATE_NOOP(
+                            "PredefinedColorPalettes", "Mixxx Key Colors")),
+                    {
+                            kMixxxKeyColor1,
+                            kMixxxKeyColor2,
+                            kMixxxKeyColor3,
+                            kMixxxKeyColor4,
+                            kMixxxKeyColor5,
+                            kMixxxKeyColor6,
+                            kMixxxKeyColor7,
+                            kMixxxKeyColor8,
+                            kMixxxKeyColor9,
+                            kMixxxKeyColor10,
+                            kMixxxKeyColor11,
+                            kMixxxKeyColor12,
+                    }},
+            .traktorKeyColorPalette{
+                    QStringLiteral(QT_TRANSLATE_NOOP(
+                            "PredefinedColorPalettes", "Traktor Key Colors")),
+                    {
+                            kTraktorKeyColor1,
+                            kTraktorKeyColor2,
+                            kTraktorKeyColor3,
+                            kTraktorKeyColor4,
+                            kTraktorKeyColor5,
+                            kTraktorKeyColor6,
+                            kTraktorKeyColor7,
+                            kTraktorKeyColor8,
+                            kTraktorKeyColor9,
+                            kTraktorKeyColor10,
+                            kTraktorKeyColor11,
+                            kTraktorKeyColor12,
+                    }},
+            .MIKKeyColorPalette{
+                    QStringLiteral(QT_TRANSLATE_NOOP("PredefinedColorPalettes",
+                            "Mixed In Key - Key Colors")),
+                    {
+                            kMIKKeyColor1,
+                            kMIKKeyColor2,
+                            kMIKKeyColor3,
+                            kMIKKeyColor4,
+                            kMIKKeyColor5,
+                            kMIKKeyColor6,
+                            kMIKKeyColor7,
+                            kMIKKeyColor8,
+                            kMIKKeyColor9,
+                            kMIKKeyColor10,
+                            kMIKKeyColor11,
+                            kMIKKeyColor12,
+                    }},
+            .protKeyColorPalette{
+                    QStringLiteral(QT_TRANSLATE_NOOP("PredefinedColorPalettes",
+                            "Protanopia / Protanomaly Key Colors")),
+                    {
+                            kProtKeyColor1,
+                            kProtKeyColor2,
+                            kProtKeyColor3,
+                            kProtKeyColor4,
+                            kProtKeyColor5,
+                            kProtKeyColor6,
+                            kProtKeyColor7,
+                            kProtKeyColor8,
+                            kProtKeyColor9,
+                            kProtKeyColor10,
+                            kProtKeyColor11,
+                            kProtKeyColor12,
+                    }},
+            .deutKeyColorPalette{
 
-const ColorPalette PredefinedColorPalettes::kSeratoDJProHotcueColorPalette =
-        ColorPalette(QStringLiteral(QT_TRANSLATE_NOOP("PredefinedColorPalettes",
-                             "Serato DJ Pro Hotcue Colors")),
-                {
-                        kSeratoDJProHotcueColorRed1,
-                        kSeratoDJProHotcueColorOrange1,
-                        kSeratoDJProHotcueColorOrange2,
-                        kSeratoDJProHotcueColorYellow,
-                        kSeratoDJProHotcueColorGreen1,
-                        kSeratoDJProHotcueColorGreen2,
-                        kSeratoDJProHotcueColorGreen3,
-                        kSeratoDJProHotcueColorGreen4,
-                        kSeratoDJProHotcueColorBlue1,
-                        kSeratoDJProHotcueColorCyan,
-                        kSeratoDJProHotcueColorBlue2,
-                        kSeratoDJProHotcueColorDarkBlue1,
-                        kSeratoDJProHotcueColorDarkBlue2,
-                        kSeratoDJProHotcueColorViolet1,
-                        kSeratoDJProHotcueColorViolet2,
-                        kSeratoDJProHotcueColorMagenta,
-                        kSeratoDJProHotcueColorPurple,
-                        kSeratoDJProHotcueColorRed2,
-                },
-                {0, 2, 12, 3, 6, 15, 9, 14});
-
-// All Rekordbox Palette types, share the same color, but their default colors
-// are not in the selection offered to the user. This usecase is not supported
-// by mixxx's ColorPalette. The compromise is slightly altering the default
-// colors used so they're part of the selection. The difference between these
-// colors should be imperceptible for the unknowing user.
-const QList<mixxx::RgbColor> kRekordboxColorsSelection = {
-        kRekordboxHotcueColor1,
-        kRekordboxHotcueColor2,
-        kRekordboxHotcueColor3,
-        kRekordboxHotcueColor4,
-        kRekordboxHotcueColor5,
-        kRekordboxHotcueColor6,
-        kRekordboxHotcueColor7,
-        kRekordboxHotcueColor8,
-        kRekordboxHotcueColor9,
-        kRekordboxHotcueColor10,
-        kRekordboxHotcueColor11,
-        kRekordboxHotcueColor12,
-        kRekordboxHotcueColor13,
-        kRekordboxHotcueColor14,
-        kRekordboxHotcueColor15,
-        kRekordboxHotcueColor16,
-};
-
-// the Rekordbox CDJ palette can be emulated by picking kRekordboxHotcueColor9
-// (0x10B176) as the default cue color.
-
-const ColorPalette PredefinedColorPalettes::kRekordboxCOLD1HotcueColorPalette =
-        ColorPalette(QStringLiteral(QT_TRANSLATE_NOOP("PredefinedColorPalettes",
-                             "Rekordbox COLD1 Hotcue Colors")),
-                kRekordboxColorsSelection,
-                {5, 8, 1, 6, 7, 2, 7, 5});
-
-const ColorPalette PredefinedColorPalettes::kRekordboxCOLD2HotcueColorPalette =
-        ColorPalette(QStringLiteral(QT_TRANSLATE_NOOP("PredefinedColorPalettes",
-                             "Rekordbox COLD2 Hotcue Colors")),
-                kRekordboxColorsSelection,
-                {7, 5, 5, 5, 3, 4, 3, 2});
-
-const ColorPalette
-        PredefinedColorPalettes::kRekordboxCOLORFULHotcueColorPalette =
-                ColorPalette(QStringLiteral(QT_TRANSLATE_NOOP(
-                                     "PredefinedColorPalettes",
-                                     "Rekordbox COLORFUL Hotcue Colors")),
-                        kRekordboxColorsSelection,
-                        {15, 5, 10, 2, 8, 13, 4, 12});
-
-const ColorPalette PredefinedColorPalettes::kMixxxTrackColorPalette =
-        ColorPalette(
-                QStringLiteral(QT_TRANSLATE_NOOP("PredefinedColorPalettes", "Mixxx Track Colors")),
-                {
-                        kMixxxTrackColorDarkRed,
-                        kMixxxTrackColorRed,
-                        kMixxxTrackColorDarkOrange,
-                        kMixxxTrackColorLemonGlacier,
-                        kMixxxTrackColorChartreuse,
-                        kMixxxTrackColorElectricGreen,
-                        kMixxxTrackColorIndiaGreen,
-                        kMixxxTrackColorDarkCyan,
-                        kMixxxTrackColorDodgerBlue,
-                        kMixxxTrackColorBlue,
-                        kMixxxTrackColorNavyBlue,
-                        kMixxxTrackColorMardiGras,
-                        kMixxxTrackColorVividViolet,
-                        kMixxxTrackColorFuchsia,
-                        kMixxxTrackColorViolet,
-                        kMixxxTrackColorWhite,
-                        kMixxxTrackColorAqua,
-                        kMixxxTrackColorSpringGreen,
-                        kMixxxTrackColorBattleshipGrey,
-                });
-
-const ColorPalette PredefinedColorPalettes::kRekordboxTrackColorPalette =
-        ColorPalette(QStringLiteral(QT_TRANSLATE_NOOP("PredefinedColorPalettes",
-                             "Rekordbox Track Colors")),
-                {
-                        kRekordboxTrackColorPink,
-                        kRekordboxTrackColorRed,
-                        kRekordboxTrackColorOrange,
-                        kRekordboxTrackColorYellow,
-                        kRekordboxTrackColorGreen,
-                        kRekordboxTrackColorAqua,
-                        kRekordboxTrackColorBlue,
-                        kRekordboxTrackColorPurple,
-                });
-
-const ColorPalette PredefinedColorPalettes::kSeratoDJProTrackColorPalette =
-        ColorPalette(QStringLiteral(QT_TRANSLATE_NOOP("PredefinedColorPalettes",
-                             "Serato DJ Pro Track Colors")),
-                {
-                        kSeratoDJProTrackColorGrey1,
-                        kSeratoDJProTrackColorGrey2,
-                        kSeratoDJProTrackColorPink1,
-                        kSeratoDJProTrackColorPink2,
-                        kSeratoDJProTrackColorRed1,
-                        kSeratoDJProTrackColorRed2,
-                        kSeratoDJProTrackColorOrange,
-                        kSeratoDJProTrackColorBrown1,
-                        kSeratoDJProTrackColorBrown2,
-                        kSeratoDJProTrackColorBrown3,
-                        kSeratoDJProTrackColorGreen1,
-                        kSeratoDJProTrackColorGreen2,
-                        kSeratoDJProTrackColorGreen3,
-                        kSeratoDJProTrackColorTurquoise1,
-                        kSeratoDJProTrackColorTurquoise2,
-                        kSeratoDJProTrackColorTurquoise3,
-                        kSeratoDJProTrackColorBlue,
-                        kSeratoDJProTrackColorPurple1,
-                        kSeratoDJProTrackColorPurple2,
-                        kSeratoDJProTrackColorPurple3,
-                });
-
-const ColorPalette PredefinedColorPalettes::kTraktorProTrackColorPalette =
-        ColorPalette(QStringLiteral(QT_TRANSLATE_NOOP("PredefinedColorPalettes",
-                             "Traktor Pro Track Colors")),
-                {
-                        kTraktorProTrackColorRed,
-                        kTraktorProTrackColorOrange,
-                        kTraktorProTrackColorYellow,
-                        kTraktorProTrackColorGreen,
-                        kTraktorProTrackColorBlue,
-                        kTraktorProTrackColorViolet,
-                        kTraktorProTrackColorMagenta,
-                });
-
-const ColorPalette PredefinedColorPalettes::kVirtualDJTrackColorPalette =
-        ColorPalette(QStringLiteral(QT_TRANSLATE_NOOP("PredefinedColorPalettes",
-                             "VirtualDJ Track Colors")),
-                {
-                        kVirtualDJTrackColorRed,
-                        kVirtualDJTrackColorYellow,
-                        kVirtualDJTrackColorGreen,
-                        kVirtualDJTrackColorCyan,
-                        kVirtualDJTrackColorBlue,
-                        kVirtualDJTrackColorFuchsia,
-                        kVirtualDJTrackColorWhite,
-                });
-
-const ColorPalette PredefinedColorPalettes::kMixxxKeyColorPalette =
-        ColorPalette(
-                QStringLiteral(QT_TRANSLATE_NOOP("PredefinedColorPalettes", "Mixxx Key Colors")),
-                {
-                        kMixxxKeyColor1,
-                        kMixxxKeyColor2,
-                        kMixxxKeyColor3,
-                        kMixxxKeyColor4,
-                        kMixxxKeyColor5,
-                        kMixxxKeyColor6,
-                        kMixxxKeyColor7,
-                        kMixxxKeyColor8,
-                        kMixxxKeyColor9,
-                        kMixxxKeyColor10,
-                        kMixxxKeyColor11,
-                        kMixxxKeyColor12,
-                });
-
-const ColorPalette PredefinedColorPalettes::kTraktorKeyColorPalette =
-        ColorPalette(
-                QStringLiteral(QT_TRANSLATE_NOOP("PredefinedColorPalettes", "Traktor Key Colors")),
-                {
-                        kTraktorKeyColor1,
-                        kTraktorKeyColor2,
-                        kTraktorKeyColor3,
-                        kTraktorKeyColor4,
-                        kTraktorKeyColor5,
-                        kTraktorKeyColor6,
-                        kTraktorKeyColor7,
-                        kTraktorKeyColor8,
-                        kTraktorKeyColor9,
-                        kTraktorKeyColor10,
-                        kTraktorKeyColor11,
-                        kTraktorKeyColor12,
-                });
-
-const ColorPalette PredefinedColorPalettes::kMIKKeyColorPalette =
-        ColorPalette(QStringLiteral(QT_TRANSLATE_NOOP("PredefinedColorPalettes",
-                             "Mixed In Key - Key Colors")),
-                {
-                        kMIKKeyColor1,
-                        kMIKKeyColor2,
-                        kMIKKeyColor3,
-                        kMIKKeyColor4,
-                        kMIKKeyColor5,
-                        kMIKKeyColor6,
-                        kMIKKeyColor7,
-                        kMIKKeyColor8,
-                        kMIKKeyColor9,
-                        kMIKKeyColor10,
-                        kMIKKeyColor11,
-                        kMIKKeyColor12,
-                });
-
-const ColorPalette PredefinedColorPalettes::kProtKeyColorPalette =
-        ColorPalette(QStringLiteral(QT_TRANSLATE_NOOP("PredefinedColorPalettes",
-                             "Protanopia / Protanomaly Key Colors")),
-                {
-                        kProtKeyColor1,
-                        kProtKeyColor2,
-                        kProtKeyColor3,
-                        kProtKeyColor4,
-                        kProtKeyColor5,
-                        kProtKeyColor6,
-                        kProtKeyColor7,
-                        kProtKeyColor8,
-                        kProtKeyColor9,
-                        kProtKeyColor10,
-                        kProtKeyColor11,
-                        kProtKeyColor12,
-                });
-
-const ColorPalette PredefinedColorPalettes::kDeutKeyColorPalette =
-        ColorPalette(
-                QStringLiteral(QT_TRANSLATE_NOOP("PredefinedColorPalettes",
-                        "Deuteranopia / Deuteranomaly Key Colors")),
-                {
-                        kDeutKeyColor1,
-                        kDeutKeyColor2,
-                        kDeutKeyColor3,
-                        kDeutKeyColor4,
-                        kDeutKeyColor5,
-                        kDeutKeyColor6,
-                        kDeutKeyColor7,
-                        kDeutKeyColor8,
-                        kDeutKeyColor9,
-                        kDeutKeyColor10,
-                        kDeutKeyColor11,
-                        kDeutKeyColor12,
-                });
-
-const ColorPalette PredefinedColorPalettes::kTritKeyColorPalette =
-        ColorPalette(QStringLiteral(QT_TRANSLATE_NOOP("PredefinedColorPalettes",
-                             "Tritanopia / Tritanomaly Key Colors")),
-                {
-                        kTritKeyColor1,
-                        kTritKeyColor2,
-                        kTritKeyColor3,
-                        kTritKeyColor4,
-                        kTritKeyColor5,
-                        kTritKeyColor6,
-                        kTritKeyColor7,
-                        kTritKeyColor8,
-                        kTritKeyColor9,
-                        kTritKeyColor10,
-                        kTritKeyColor11,
-                        kTritKeyColor12,
-                });
-
-const ColorPalette PredefinedColorPalettes::kDefaultHotcueColorPalette =
-        mixxx::PredefinedColorPalettes::kMixxxHotcueColorPalette;
-
-const ColorPalette PredefinedColorPalettes::kDefaultTrackColorPalette =
-        mixxx::PredefinedColorPalettes::kMixxxTrackColorPalette;
-
-const ColorPalette PredefinedColorPalettes::kDefaultKeyColorPalette =
-        mixxx::PredefinedColorPalettes::kMixxxKeyColorPalette;
-
-const QList<ColorPalette> PredefinedColorPalettes::kPalettes{
-        // Hotcue Color Palettes
-        mixxx::PredefinedColorPalettes::kMixxxHotcueColorPalette,
-        mixxx::PredefinedColorPalettes::kSeratoDJProHotcueColorPalette,
-        mixxx::PredefinedColorPalettes::kRekordboxCOLD1HotcueColorPalette,
-        mixxx::PredefinedColorPalettes::kRekordboxCOLD2HotcueColorPalette,
-        mixxx::PredefinedColorPalettes::kRekordboxCOLORFULHotcueColorPalette,
-        // Track Color Palettes
-        mixxx::PredefinedColorPalettes::kMixxxTrackColorPalette,
-        mixxx::PredefinedColorPalettes::kRekordboxTrackColorPalette,
-        mixxx::PredefinedColorPalettes::kSeratoDJProTrackColorPalette,
-        mixxx::PredefinedColorPalettes::kTraktorProTrackColorPalette,
-        mixxx::PredefinedColorPalettes::kVirtualDJTrackColorPalette,
-        // Key Color Palettes
-        mixxx::PredefinedColorPalettes::kMixxxKeyColorPalette,
-        mixxx::PredefinedColorPalettes::kTraktorKeyColorPalette,
-        mixxx::PredefinedColorPalettes::kMIKKeyColorPalette,
-        mixxx::PredefinedColorPalettes::kProtKeyColorPalette,
-        mixxx::PredefinedColorPalettes::kDeutKeyColorPalette,
-        mixxx::PredefinedColorPalettes::kTritKeyColorPalette,
-};
-
-const mixxx::RgbColor PredefinedColorPalettes::kDefaultCueColor =
-        kSchemaMigrationReplacementColor;
-
-const mixxx::RgbColor PredefinedColorPalettes::kDefaultLoopColor =
-        kColorMixxxWhite;
-
+                    QStringLiteral(QT_TRANSLATE_NOOP("PredefinedColorPalettes",
+                            "Deuteranopia / Deuteranomaly Key Colors")),
+                    {
+                            kDeutKeyColor1,
+                            kDeutKeyColor2,
+                            kDeutKeyColor3,
+                            kDeutKeyColor4,
+                            kDeutKeyColor5,
+                            kDeutKeyColor6,
+                            kDeutKeyColor7,
+                            kDeutKeyColor8,
+                            kDeutKeyColor9,
+                            kDeutKeyColor10,
+                            kDeutKeyColor11,
+                            kDeutKeyColor12,
+                    }},
+            .tritKeyColorPalette{
+                    QStringLiteral(QT_TRANSLATE_NOOP("PredefinedColorPalettes",
+                            "Tritanopia / Tritanomaly Key Colors")),
+                    {
+                            kTritKeyColor1,
+                            kTritKeyColor2,
+                            kTritKeyColor3,
+                            kTritKeyColor4,
+                            kTritKeyColor5,
+                            kTritKeyColor6,
+                            kTritKeyColor7,
+                            kTritKeyColor8,
+                            kTritKeyColor9,
+                            kTritKeyColor10,
+                            kTritKeyColor11,
+                            kTritKeyColor12,
+                    }},
+            .defaultHotcueColorPalette = kPalettes.mixxxHotcueColorPalette,
+            .defaultTrackColorPalette = kPalettes.mixxxTrackColorPalette,
+            .defaultKeyColorPalette = kPalettes.mixxxKeyColorPalette,
+            .palettes{
+                    // Hotcue Color Palettes
+                    kPalettes.mixxxHotcueColorPalette,
+                    kPalettes.seratoDJProHotcueColorPalette,
+                    kPalettes.rekordboxCOLD1HotcueColorPalette,
+                    kPalettes.rekordboxCOLD2HotcueColorPalette,
+                    kPalettes.rekordboxCOLORFULHotcueColorPalette,
+                    // Track Color Palettes
+                    kPalettes.mixxxTrackColorPalette,
+                    kPalettes.rekordboxTrackColorPalette,
+                    kPalettes.seratoDJProTrackColorPalette,
+                    kPalettes.traktorProTrackColorPalette,
+                    kPalettes.virtualDJTrackColorPalette,
+                    // Key Color Palettes
+                    kPalettes.mixxxKeyColorPalette,
+                    kPalettes.traktorKeyColorPalette,
+                    kPalettes.MIKKeyColorPalette,
+                    kPalettes.protKeyColorPalette,
+                    kPalettes.deutKeyColorPalette,
+                    kPalettes.tritKeyColorPalette,
+            }};
+    return kPalettes;
+}
+} // namespace predefinedcolorpalettes
 } // namespace mixxx

--- a/src/util/color/predefinedcolorpalettes.h
+++ b/src/util/color/predefinedcolorpalettes.h
@@ -1,4 +1,7 @@
 #pragma once
+#include <array>
+#include <gsl/pointers>
+
 #include "util/color/colorpalette.h"
 
 namespace {
@@ -11,6 +14,8 @@ constexpr mixxx::RgbColor kSchemaMigrationReplacementColor(0xFF8000);
 } // namespace
 namespace mixxx {
 namespace predefinedcolorpalettes {
+
+using ColorPalettePointer = gsl::not_null<const ColorPalette* const>;
 
 constexpr static mixxx::RgbColor kDefaultCueColor = kSchemaMigrationReplacementColor;
 constexpr static mixxx::RgbColor kDefaultLoopColor = kColorMixxxWhite;
@@ -36,11 +41,11 @@ struct PredefinedColorPalettes {
     ColorPalette deutKeyColorPalette;
     ColorPalette tritKeyColorPalette;
 
-    ColorPalette defaultHotcueColorPalette;
-    ColorPalette defaultTrackColorPalette;
-    ColorPalette defaultKeyColorPalette;
+    const ColorPalette& defaultHotcueColorPalette;
+    const ColorPalette& defaultTrackColorPalette;
+    const ColorPalette& defaultKeyColorPalette;
 
-    QList<ColorPalette> palettes;
+    std::array<ColorPalettePointer, 16> palettes;
 };
 
 // since the palettes used here are supposed to be used in other translation

--- a/src/util/color/predefinedcolorpalettes.h
+++ b/src/util/color/predefinedcolorpalettes.h
@@ -1,37 +1,55 @@
 #pragma once
 #include "util/color/colorpalette.h"
 
+namespace {
+
+constexpr mixxx::RgbColor kColorMixxxWhite(0xF2F2FF);
+
+// Replaces "no color" values and is used for new cues if auto_hotcue_colors is
+// disabled
+constexpr mixxx::RgbColor kSchemaMigrationReplacementColor(0xFF8000);
+} // namespace
 namespace mixxx {
+namespace predefinedcolorpalettes {
 
-class PredefinedColorPalettes {
-  public:
-    static const ColorPalette kMixxxHotcueColorPalette;
-    static const ColorPalette kSeratoTrackMetadataHotcueColorPalette;
-    static const ColorPalette kSeratoDJProHotcueColorPalette;
-    static const ColorPalette kRekordboxCOLD1HotcueColorPalette;
-    static const ColorPalette kRekordboxCOLD2HotcueColorPalette;
-    static const ColorPalette kRekordboxCOLORFULHotcueColorPalette;
+constexpr static mixxx::RgbColor kDefaultCueColor = kSchemaMigrationReplacementColor;
+constexpr static mixxx::RgbColor kDefaultLoopColor = kColorMixxxWhite;
 
-    static const ColorPalette kMixxxTrackColorPalette;
-    static const ColorPalette kRekordboxTrackColorPalette;
-    static const ColorPalette kSeratoDJProTrackColorPalette;
-    static const ColorPalette kTraktorProTrackColorPalette;
-    static const ColorPalette kVirtualDJTrackColorPalette;
+struct PredefinedColorPalettes {
+    ColorPalette mixxxHotcueColorPalette;
+    ColorPalette seratoTrackMetadataHotcueColorPalette;
+    ColorPalette seratoDJProHotcueColorPalette;
+    ColorPalette rekordboxCOLD1HotcueColorPalette;
+    ColorPalette rekordboxCOLD2HotcueColorPalette;
+    ColorPalette rekordboxCOLORFULHotcueColorPalette;
 
-    static const ColorPalette kMixxxKeyColorPalette;
-    static const ColorPalette kTraktorKeyColorPalette;
-    static const ColorPalette kMIKKeyColorPalette;
-    static const ColorPalette kProtKeyColorPalette;
-    static const ColorPalette kDeutKeyColorPalette;
-    static const ColorPalette kTritKeyColorPalette;
+    ColorPalette mixxxTrackColorPalette;
+    ColorPalette rekordboxTrackColorPalette;
+    ColorPalette seratoDJProTrackColorPalette;
+    ColorPalette traktorProTrackColorPalette;
+    ColorPalette virtualDJTrackColorPalette;
 
-    static const ColorPalette kDefaultHotcueColorPalette;
-    static const ColorPalette kDefaultTrackColorPalette;
-    static const ColorPalette kDefaultKeyColorPalette;
+    ColorPalette mixxxKeyColorPalette;
+    ColorPalette traktorKeyColorPalette;
+    ColorPalette MIKKeyColorPalette;
+    ColorPalette protKeyColorPalette;
+    ColorPalette deutKeyColorPalette;
+    ColorPalette tritKeyColorPalette;
 
-    static const QList<ColorPalette> kPalettes;
-    static const mixxx::RgbColor kDefaultCueColor;
-    static const mixxx::RgbColor kDefaultLoopColor;
+    ColorPalette defaultHotcueColorPalette;
+    ColorPalette defaultTrackColorPalette;
+    ColorPalette defaultKeyColorPalette;
+
+    QList<ColorPalette> palettes;
 };
 
+// since the palettes used here are supposed to be used in other translation
+// units we can't make these global statics without getting involved in the
+// "global initialization order fiasco". So instead we employ this getter which
+// internally implements "initialization on first use". when accessing more than
+// one member of the returned struct, its recommended to store the reference
+// instead of repeatedly calling `get()`.
+const PredefinedColorPalettes& get();
+
+} // namespace predefinedcolorpalettes
 } // namespace mixxx


### PR DESCRIPTION
As suggested (by me) in https://github.com/mixxxdj/mixxx/pull/13594#issuecomment-2308818785 as an alternative to that PR.

Note that in case we manage to make `ColorPalette` constexpr friendly, we can trivially migrate `get` to be constexpr as well without having to change the callers with this approach.