### PR TITLE
Fix Reloop Beatmix 4 eject button

### DIFF
--- a/res/controllers/Reloop-Beatmix-2-4-scripts.js
+++ b/res/controllers/Reloop-Beatmix-2-4-scripts.js
@@ -332,7 +332,7 @@ ReloopBeatmix24.LoadButton = function(channel, control, value, status, group) {
     if (value === DOWN) {
         loadButtonLongPressed[group] = false;
         loadButtonTimers[group] = engine.beginTimer(1000,
-            () => {RegloopBeatmix24.LoadButtonEject(group); }, true);
+            () => { ReloopBeatmix24.LoadButtonEject(group); }, true);
     } else { // UP
         if (!loadButtonLongPressed[group]) { // Short press
             engine.stopTimer(loadButtonTimers[group]);


### PR DESCRIPTION
Fix Reloop Beatmix 2/4 controller mapping eject button (long press on load deck button) by fixing typo introduced by #12401 