### PR TITLE
(fix/UX) Track menu: Left key in Search related & Crates menus closes them again

### DIFF
--- a/src/widget/wsearchrelatedtracksmenu.cpp
+++ b/src/widget/wsearchrelatedtracksmenu.cpp
@@ -91,7 +91,8 @@ void WSearchRelatedTracksMenu::addTriggerSearchAction(
     auto pAction = make_parented<QWidgetAction>(this);
     pAction->setDefaultWidget(pCheckBox.get());
     // While the checkbox is selected (via keyboard, not hovered by pointer)
-    // pressing Space will toggle it whereas pressing Return triggers the action.
+    // pressing Space will toggle it whereas pressing Return triggers the action
+    // and closes the menu (see WTrackMenu).
     connect(pAction.get(),
             &QAction::triggered,
             this,

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -3,6 +3,7 @@
 #include <QCheckBox>
 #include <QDialogButtonBox>
 #include <QInputDialog>
+#include <QKeyEvent>
 #include <QList>
 #include <QListWidget>
 #include <QModelIndex>
@@ -161,6 +162,32 @@ void WTrackMenu::closeEvent(QCloseEvent* event) {
     emit trackMenuVisible(false);
 }
 
+bool WTrackMenu::eventFilter(QObject* pObj, QEvent* e) {
+    // If a checkbox in a QWidgetAction is focused, Left/Right keys are translated
+    // to Up/Down which prevents closing the submenus with Left key like in other
+    // submenus.
+    // We simply call hide() of the submenu if Left is pressed.
+    // We ignore Right.
+    // Don't continue (close track menu) if the checkbox is at the top level.
+    if (pObj->parent() && pObj->parent() != this && e->type() == QEvent::KeyPress) {
+        QCheckBox* pCB = qobject_cast<QCheckBox*>(pObj);
+        QKeyEvent* pKE = static_cast<QKeyEvent*>(e);
+        if (!pCB || !pKE) {
+            return QObject::eventFilter(pObj, e);
+        }
+        if (pKE->key() == Qt::Key_Left) {
+            VERIFY_OR_DEBUG_ASSERT(pCB->parentWidget()) {
+                return QObject::eventFilter(pObj, e);
+            }
+            pCB->parentWidget()->hide();
+            return true;
+        } else if (pKE->key() == Qt::Key_Right) {
+            return true;
+        }
+    }
+    return QObject::eventFilter(pObj, e);
+}
+
 void WTrackMenu::popup(const QPoint& pos, QAction* at) {
     if (isEmpty()) {
         return;
@@ -258,6 +285,16 @@ void WTrackMenu::createMenus() {
                     m_pSearchRelatedMenu->setEnabled(
                             !m_pSearchRelatedMenu->isEmpty());
                     m_bSearchRelatedMenuLoaded = true;
+                    if (!m_pSearchRelatedMenu->isEmpty()) {
+                        // We're interested in keypress Qt::Key_Left, so use our
+                        // event filter like we do for the crate checkboxes.
+                        for (auto* pObj : m_pSearchRelatedMenu->children()) {
+                            QCheckBox* pCB = qobject_cast<QCheckBox*>(pObj);
+                            if (pCB) {
+                                pCB->installEventFilter(this);
+                            }
+                        }
+                    }
                 });
         connect(m_pSearchRelatedMenu,
                 &WSearchRelatedTracksMenu::triggerSearch,
@@ -1651,6 +1688,8 @@ void WTrackMenu::slotPopulateCrateMenu() {
                 m_pCrateMenu);
         pCheckBox->setProperty("crateId", QVariant::fromValue(crate.getId()));
         pCheckBox->setEnabled(!crate.isLocked());
+        // We're interested in keypress Qt::Key_Left
+        pCheckBox->installEventFilter(this);
         // Strangely, the normal styling of QActions does not automatically
         // apply to QWidgetActions. The :selected pseudo-state unfortunately
         // does not work with QWidgetAction. :hover works for selecting items

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -115,6 +115,8 @@ class WTrackMenu : public QMenu {
     void slotRemoveFromDisk();
     const QString getDeckGroup() const;
 
+    bool eventFilter(QObject* pObj, QEvent* e) override;
+
   signals:
 #ifdef __STEM__
     void loadTrackToPlayer(TrackPointer pTrack,


### PR DESCRIPTION
If a QWidgetAction in either Search related & Crates menu is focused, Left/Right keys are translated to Up/Down which prevents closing the submenus with Left key like in other submenus.
(in the Crates menu left works as soon as the New Crate button is reached)

### Fix:
~~Translate Left to Esc to close this submenu.~~
Call hide() of the respective sumenu.

For fixing the crates menu this should actually go to 2.4 ("Search related Tracks" has QWidgetActions only in 2.5), but since we're going to release that shortly before 2.5 I think it's okay to merge the double fix to 2.5-beta