### PR TITLE
refactor: split out `AutoFileReloader` from `QmlAutoReload`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1146,6 +1146,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/track/tracknumbers.cpp
   src/track/trackrecord.cpp
   src/track/trackref.cpp
+  src/util/autofilereloader.cpp
   src/util/battery/battery.cpp
   src/util/cache.cpp
   src/util/clipboard.cpp

--- a/src/qml/qmlautoreload.h
+++ b/src/qml/qmlautoreload.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <QFileSystemWatcher>
 #include <QObject>
 #include <QQmlAbstractUrlInterceptor>
-#include <QSet>
+
+#include "util/autofilereloader.h"
 
 namespace mixxx {
 namespace qml {
@@ -15,35 +15,15 @@ class QmlAutoReload : public QObject, public QQmlAbstractUrlInterceptor {
 
     QUrl intercept(const QUrl& url, QQmlAbstractUrlInterceptor::DataType type) override;
 
+    void clear() {
+        m_autoReloader.clear();
+    }
+
   signals:
     void triggered();
 
-  private slots:
-    void slotFileChanged(const QString& changedFile);
-
-  public slots:
-    void clear();
-
   private:
-    QFileSystemWatcher m_fileWatcher;
-    // We use a separate set to keep track of file allowed to trigger a reload.
-    // This is to prevent double-reload when a file is updated twice
-    // in a row as part of the normal saving process. See note in
-    // QFileSystemWatcher::fileChanged documentation.
-    // We've identified to saving policy so far:
-    // 1. Append/Truncate (VSCode)
-    //    The program first append the new content to the file (firing a signal,
-    //    while keeping the path in the watch list) then subsequent truncate to
-    //    move the previous file content (firing a second signal, and also
-    //    keeping the path in the watch list)
-    // 2. Delete/Rewrite (sed in-place, vim)
-    //    The program first delete the file (firing a signal, AND removing the
-    //    path from the watch list) then subsequent create/write to the same
-    //    file path (not firing a second signal, since it has been removed from
-    //    the watch path previously)
-    // Using a set allows us to ensure the same single reload behavior across
-    // the different policies
-    QSet<QString> m_pathTriggeringReload;
+    AutoFileReloader m_autoReloader;
 };
 
 } // namespace qml

--- a/src/util/autofilereloader.cpp
+++ b/src/util/autofilereloader.cpp
@@ -1,0 +1,23 @@
+#include "util/autofilereloader.h"
+
+#include <QDebug>
+#include <QString>
+
+#include "moc_autofilereloader.cpp"
+#include "util/runtimeloggingcategory.h"
+
+AutoFileReloader::AutoFileReloader(const RuntimeLoggingCategory& loggingCategory)
+        : m_loggingCategory(loggingCategory) {
+    connect(&m_fileWatcher,
+            &QFileSystemWatcher::fileChanged,
+            this,
+            &AutoFileReloader::slotFileChanged);
+}
+
+void AutoFileReloader::slotFileChanged(const QString& changedFile) {
+    qCDebug(m_loggingCategory) << "File" << changedFile << "has been changed.";
+    if (m_pathTriggeringReload.remove(changedFile)) {
+        m_fileWatcher.removePath(changedFile);
+        emit fileChanged(changedFile);
+    }
+}

--- a/src/util/autofilereloader.h
+++ b/src/util/autofilereloader.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <QFileSystemWatcher>
+#include <QObject>
+#include <QSet>
+
+#include "util/runtimeloggingcategory.h"
+
+class AutoFileReloader : public QObject {
+    Q_OBJECT
+  public:
+    explicit AutoFileReloader(const RuntimeLoggingCategory& loggingCategory);
+
+    void clear() {
+        const auto files = m_fileWatcher.files();
+        if (!files.isEmpty()) {
+            m_fileWatcher.removePaths(files);
+        }
+    }
+    void addPath(const QString& path) {
+        m_fileWatcher.addPath(path);
+        m_pathTriggeringReload.insert(path);
+    }
+
+  signals:
+    void fileChanged(const QString& filepath);
+
+  private slots:
+    void slotFileChanged(const QString& changedFile);
+
+  private:
+    QFileSystemWatcher m_fileWatcher;
+    // We use a separate set to keep track of file allowed to trigger a reload.
+    // This is to prevent double-reload when a file is updated twice
+    // in a row as part of the normal saving process. See note in
+    // QFileSystemWatcher::fileChanged documentation.
+    // We've identified two saving policies so far:
+    // 1. Append/Truncate (VSCode)
+    //    The program first append the new content to the file (firing a signal,
+    //    while keeping the path in the watch list) then subsequent truncate to
+    //    move the previous file content (firing a second signal, and also
+    //    keeping the path in the watch list)
+    // 2. Delete/Rewrite (sed in-place, vim)
+    //    The program first delete the file (firing a signal, AND removing the
+    //    path from the watch list) then subsequent create/write to the same
+    //    file path (not firing a second signal, since it has been removed from
+    //    the watch path previously)
+    // Using a set allows us to ensure the same single reload behavior across
+    // the different policies
+    QSet<QString> m_pathTriggeringReload;
+    RuntimeLoggingCategory m_loggingCategory;
+};

--- a/src/util/autofilereloader.h
+++ b/src/util/autofilereloader.h
@@ -17,12 +17,16 @@ class AutoFileReloader : public QObject {
             m_fileWatcher.removePaths(files);
         }
     }
+    // this is idempotent, so while not particularly efficient it is safe
+    // to call this on the same path multiple times.
     void addPath(const QString& path) {
         m_fileWatcher.addPath(path);
         m_pathTriggeringReload.insert(path);
     }
 
   signals:
+    // Note that once the reload was handled, any changed paths need to be added back
+    // to the watcher using `addPath`.
     void fileChanged(const QString& filepath);
 
   private slots:


### PR DESCRIPTION
`AutoFileReload` is useful for almost all occasions where hot- reloading is needed. Thus it belongs into a separate class for easier reuse. Plus I added an extra RuntimeLoggingCategory so we don't have a category-less `qDebug` call. 