### PR TITLE
(fix) WStarRating: remove unneeded signal that may cause rating reset via track menu

### DIFF
--- a/src/library/dlgtrackinfomulti.cpp
+++ b/src/library/dlgtrackinfomulti.cpp
@@ -313,11 +313,8 @@ void DlgTrackInfoMulti::updateFromTracks() {
         }
     }
     // Update the star widget
-    // Block signals to not set the 'modified' flag.
-    m_pWStarRating->blockSignals(true);
     m_pWStarRating->slotSetRating(commonRating);
     m_starRatingModified = false;
-    m_pWStarRating->blockSignals(false);
 
     // Same procedure for the track color
     mixxx::RgbColor::optional_t commonColor = m_trackRecords.first().getColor();

--- a/src/widget/wstarrating.cpp
+++ b/src/widget/wstarrating.cpp
@@ -39,7 +39,6 @@ void WStarRating::slotSetRating(int starCount) {
     }
     m_starCount = starCount;
     updateVisualRating(starCount);
-    emit ratingChangeRequest(starCount);
 }
 
 void WStarRating::paintEvent(QPaintEvent * /*unused*/) {

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -772,7 +772,7 @@ int WTrackMenu::getCommonTrackRating() const {
     VERIFY_OR_DEBUG_ASSERT(!isEmpty()) {
         return 0;
     }
-    int commonRating;
+    int commonRating = 0;
     if (m_pTrackModel) {
         const int column =
                 m_pTrackModel->fieldIndex(LIBRARYTABLE_RATING);


### PR DESCRIPTION
fixes #13597 

I removed the unneeded signal added in e4ce36207c0a3bc9a1c94936374a5eeefa5d5f8a
Still don't understand why this signal is emitted (received/processed) only if the [repro steps](https://github.com/mixxxdj/mixxx/issues/13597#issuecomment-2314142159) are done in quick succession.