### PR TITLE
Track File Export: add 'Apply to all' checkbox, remove ".. All" buttons

### DIFF
--- a/src/library/export/trackexportdlg.cpp
+++ b/src/library/export/trackexportdlg.cpp
@@ -1,5 +1,6 @@
 #include "library/export/trackexportdlg.h"
 
+#include <QCheckBox>
 #include <QMessageBox>
 
 #include "moc_trackexportdlg.cpp"
@@ -66,30 +67,31 @@ void TrackExportDlg::slotAskOverwriteMode(
         std::promise<TrackExportWorker::OverwriteAnswer>* promise) {
     QMessageBox question_box(
             QMessageBox::Warning,
-            tr("Overwrite Existing File?"),
-            tr("\"%1\" already exists, overwrite?").arg(filename),
-            QMessageBox::Cancel);
+            tr("Replace Existing File?"),
+            tr("\"%1\" already exists, replace?").arg(filename),
+            QMessageBox::Cancel,
+            this);
 
     QPushButton* pSkip = question_box.addButton(
             tr("&Skip"), QMessageBox::NoRole);
-    QPushButton* pSkipAll = question_box.addButton(
-            tr("Skip &All"), QMessageBox::NoRole);
     QPushButton* pOverwrite = question_box.addButton(
-            tr("&Overwrite"), QMessageBox::YesRole);
-    QPushButton* pOverwriteAll = question_box.addButton(
-            tr("Over&write All"), QMessageBox::YesRole);
+            tr("&Replace"), QMessageBox::YesRole);
     question_box.setDefaultButton(pSkip);
+
+    QCheckBox* pApplyToAll = new QCheckBox(tr("Apply to all files"));
+    pApplyToAll->setChecked(false);
+    question_box.setCheckBox(pApplyToAll);
 
     question_box.exec();
     auto* pBtn = question_box.clickedButton();
     if (pBtn == pSkip) {
-        promise->set_value(TrackExportWorker::OverwriteAnswer::SKIP);
-    } else if (pBtn == pSkipAll) {
-        promise->set_value(TrackExportWorker::OverwriteAnswer::SKIP_ALL);
+        promise->set_value(pApplyToAll->isChecked()
+                        ? TrackExportWorker::OverwriteAnswer::SKIP_ALL
+                        : TrackExportWorker::OverwriteAnswer::SKIP);
     } else if (pBtn == pOverwrite) {
-        promise->set_value(TrackExportWorker::OverwriteAnswer::OVERWRITE);
-    } else if (pBtn == pOverwriteAll) {
-        promise->set_value(TrackExportWorker::OverwriteAnswer::OVERWRITE_ALL);
+        promise->set_value(pApplyToAll->isChecked()
+                        ? TrackExportWorker::OverwriteAnswer::OVERWRITE_ALL
+                        : TrackExportWorker::OverwriteAnswer::OVERWRITE);
     } else {
         // Cancel
         promise->set_value(TrackExportWorker::OverwriteAnswer::CANCEL);


### PR DESCRIPTION
based on #13610, so it's only the last commit 1392b33cae056e817fc3172af6a2cb19de2d9104

Looks like this now:
![track-export-checkbox](https://github.com/user-attachments/assets/fab27869-4aef-4d7f-82eb-ecf45d3d9d00)

**new tr strings:**
Replace
Apply to all files

(if you like I can rebase onto 2.5)


Fixes #13613 