### PR TITLE
(fix) assert WTrackTableView has a selectionModel()

### DIFF
--- a/src/library/trackmodel.h
+++ b/src/library/trackmodel.h
@@ -217,7 +217,6 @@ class TrackModel {
 
     /// @brief modelKey returns a unique identifier for the model
     /// @param noSearch don't include the current search in the key
-    /// @param baseOnly return only a identifier for the whole subsystem
     virtual QString modelKey(bool noSearch) const = 0;
 
     virtual bool getRequireConfirmationToHideRemoveTracks() {

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -111,6 +111,9 @@ class WTrackTableView : public WLibraryTableView {
     // when dragging.
     void mouseMoveEvent(QMouseEvent *pEvent) override;
 
+    // Returns the list of selected rows, or an empty list if none are selected.
+    QModelIndexList getSelectedRows() const;
+
     // Returns the current TrackModel, or returns NULL if none is set.
     TrackModel* getTrackModel() const;
 


### PR DESCRIPTION
### Issue:
Apparently it can happen that `WTrackTableView::slotGuiTick50ms` is called while may not yet have an item model, which in turn results in nonexistant `selectionModel()`



### Fix:
(actually only a workaround for the WTrackTableView with no model when GuiTick `[App], gui_tick_50ms_period_s` is started)
Assert we have a selection model, ie. cherry-pick and extend a6f1ba45dfe5bbacfcd266b0c858b5d4725a910b
exit `WTrackTableView::slotGuiTick50ms` early if WTrackTableView `!isVisible()`

(I already did this locally and I didn' notice any regressions, but it'll cause quite some conflicts when merging 2.4 into 2.5/main)

_Initially experienced this with main, but also happens with 2.4_


<sub>
old description, based on wrong assumption:
Issue:
Mapping error dialog can block loading the main GUI.
If this happens sufficiently fast (eg. with MIDI Through in developer mode), WTrackTableView may not yet have an item model, which in turn results in nonexistant selectionModel() in WTrackTableView::slotGuiTick50ms.
</sub>
<sub>
More precisely:
ErrorDialogProperties show a modal dialog by default, which can block MixxxMainWindow::initialize() before it reaches loadConfiguredSkin(). This function emits skinLoaded --> SidebarModel::activateDefaultSelection() --> WTrackTableView loads LibraryTableModel.
Ie. if this is blocked there is one WTrackTableView without a model, and thereby without a selectionModel(), which causes the crash.
</sub>
<sub>
Quick fix:
Make the mapping error dialogs non-modal. IIUC the purpose of modal dialogs is solely
[Blocks so the user has a chance to read it before application exit](https://github.com/mixxxdj/mixxx/blob/d9704db8b9be57730d64594437a9a0b1fc754d56/src/errordialoghandler.cpp#L227)
</sub>
<sub>
which (IIUC) is not required during startup.
(if a mapping can crash Mixxx would this dialog be brought up in time?)
</sub>