### PR TITLE
(fix) Controller engine: unify/improve logging, expand error dialog's Details box

### DIFF
--- a/src/controllers/controller.cpp
+++ b/src/controllers/controller.cpp
@@ -36,20 +36,19 @@ ControllerJSProxy* Controller::jsProxy() {
     return new ControllerJSProxy(this);
 }
 
-void Controller::startEngine()
-{
-    qCInfo(m_logBase) << "  Starting engine";
+void Controller::startEngine() {
+    qCInfo(m_logBase) << "Starting engine";
     if (m_pScriptEngineLegacy) {
-        qCWarning(m_logBase) << "Controller: Engine already exists! Restarting:";
+        qCWarning(m_logBase) << "startEngine(): Engine already exists! Restarting:";
         stopEngine();
     }
     m_pScriptEngineLegacy = new ControllerScriptEngineLegacy(this, m_logBase);
 }
 
 void Controller::stopEngine() {
-    qCInfo(m_logBase) << "  Shutting down engine";
+    qCInfo(m_logBase) << "Shutting down engine";
     if (!m_pScriptEngineLegacy) {
-        qCWarning(m_logBase) << "Controller::stopEngine(): No engine exists!";
+        qCWarning(m_logBase) << "No engine exists!";
         return;
     }
     delete m_pScriptEngineLegacy;
@@ -59,14 +58,13 @@ void Controller::stopEngine() {
 bool Controller::applyMapping() {
     qCInfo(m_logBase) << "Applying controller mapping...";
 
-    const std::shared_ptr<LegacyControllerMapping> pMapping = cloneMapping();
-
     // Load the script code into the engine
     if (!m_pScriptEngineLegacy) {
-        qCWarning(m_logBase) << "Controller::applyMapping(): No engine exists!";
+        qCWarning(m_logBase) << "No engine exists!";
         return false;
     }
 
+    const std::shared_ptr<LegacyControllerMapping> pMapping = cloneMapping();
     QList<LegacyControllerMapping::ScriptFileInfo> scriptFiles = pMapping->getScriptFiles();
     if (scriptFiles.isEmpty()) {
         qCWarning(m_logBase)
@@ -104,14 +102,14 @@ void Controller::send(const QList<int>& data, unsigned int length) {
     sendBytes(msg);
 }
 
-void Controller::triggerActivity()
-{
-     // Inhibit Updates for 1000 milliseconds
+void Controller::triggerActivity() {
+    // Inhibit Updates for 1000 milliseconds
     if (m_userActivityInhibitTimer.elapsed() > 1000) {
         mixxx::ScreenSaverHelper::triggerUserActivity();
         m_userActivityInhibitTimer.start();
     }
 }
+
 void Controller::receive(const QByteArray& data, mixxx::Duration timestamp) {
     if (!m_pScriptEngineLegacy) {
         //qWarning() << "Controller::receive called with no active engine!";

--- a/src/controllers/midi/legacymidicontrollermappingfilehandler.cpp
+++ b/src/controllers/midi/legacymidicontrollermappingfilehandler.cpp
@@ -1,11 +1,16 @@
 #include "controllers/midi/legacymidicontrollermappingfilehandler.h"
 
 #include "controllers/midi/midiutils.h"
+#include "util/logger.h"
 
 #define DEFAULT_OUTPUT_MAX 1.0
 #define DEFAULT_OUTPUT_MIN 0.0 // Anything above 0 is "on"
 #define DEFAULT_OUTPUT_ON 0x7F
 #define DEFAULT_OUTPUT_OFF 0x00
+
+namespace {
+const mixxx::Logger kLogger("LegacyMidiControllerMappingFileHandler");
+} // namespace
 
 std::shared_ptr<LegacyControllerMapping>
 LegacyMidiControllerMappingFileHandler::load(const QDomElement& root,
@@ -119,7 +124,7 @@ LegacyMidiControllerMappingFileHandler::load(const QDomElement& root,
         control = control.nextSiblingElement("control");
     }
 
-    qDebug() << "LegacyMidiControllerMappingFileHandler: Input mapping parsing complete.";
+    kLogger.debug() << "Input mapping parsing complete.";
 
     // Parse static output mappings
 
@@ -211,7 +216,7 @@ LegacyMidiControllerMappingFileHandler::load(const QDomElement& root,
         output = output.nextSiblingElement("output");
     }
 
-    qDebug() << "MidiMappingFileHandler: Output mapping parsing complete.";
+    kLogger.debug() << "Output mapping parsing complete.";
 
     return pMapping;
 }

--- a/src/controllers/midi/midicontroller.cpp
+++ b/src/controllers/midi/midicontroller.cpp
@@ -151,7 +151,8 @@ void MidiController::createOutputHandlers() {
                 " Visit the manual for a complete list: ");
         detailsText += MIXXX_MANUAL_CONTROLS_URL + QStringLiteral("\n\n");
         detailsText += failures.join("\n");
-        props->setDetails(detailsText);
+        props->setDetails(detailsText,
+                true /* use monospace font / expand Details box */);
         ErrorDialogHandler::instance()->requestErrorDialog(props);
     }
 }

--- a/src/controllers/scripting/controllerscriptenginebase.cpp
+++ b/src/controllers/scripting/controllerscriptenginebase.cpp
@@ -109,7 +109,7 @@ void ControllerScriptEngineBase::showScriptExceptionDialog(
     if (filename.isEmpty()) {
         filename = QStringLiteral("<passed code>");
     }
-    QString errorText = QString("Uncaught exception: %1:%2: %3").arg(filename, line, errorMessage);
+    QString errorText = QString("Uncaught exception: %1:%2:\n%3").arg(filename, line, errorMessage);
 
     // Do not include backtrace in dialog key because it might contain midi
     // slider values that will differ most of the time. This would break
@@ -117,7 +117,7 @@ void ControllerScriptEngineBase::showScriptExceptionDialog(
     QString key = errorText;
 
     // Add backtrace to the error details
-    errorText += QStringLiteral("\nBacktrace: ") + backtrace;
+    errorText += QStringLiteral("\n\nBacktrace: ") + backtrace;
     qCWarning(m_logger) << "ControllerScriptHandlerBase:" << errorText;
 
     if (!m_bDisplayingExceptionDialog) {

--- a/src/controllers/scripting/legacy/controllerscriptenginelegacy.cpp
+++ b/src/controllers/scripting/legacy/controllerscriptenginelegacy.cpp
@@ -245,8 +245,9 @@ bool ControllerScriptEngineLegacy::evaluateScriptFile(const QFileInfo& scriptFil
         // issue). Translating this will help users to fix the issue even
         // when they don't speak english.
         props->setDetails(tr("File:") + QStringLiteral(" ") + filename +
-                QStringLiteral("\n") + tr("Error:") + QStringLiteral(" ") +
-                input.errorString());
+                        QStringLiteral("\n") + tr("Error:") + QStringLiteral(" ") +
+                        input.errorString(),
+                true /* use monospace font / expand Details box */);
 
         // Ask above layer to display the dialog & handle user response
         ErrorDialogHandler::instance()->requestErrorDialog(props);


### PR DESCRIPTION
1. The error dialog's Details box was way to small for mapping errors.
Set the `m_detailsUseMonospaceFont` flag to expand that box for mapping errors.
2. improve logging / fix code style

I multiplied the invalid mappings in the Numark Total Control mapping, load that to MIDI Through Port for easy testing.

**Note:**
In case you run into the selectionModel()/model() DEBUG_ASSERT during startup (see #13620 / #13623) you should cherry-pick 1a61e0f013 (or build with DEBUG_ASSERTIONS_FATAL set OFF)
- [x] remove TEST commit
