### PR TITLE
WOverview: update immediately when the normalize option or Global gain changed

### DIFF
--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -718,6 +718,9 @@ void WaveformWidgetFactory::setVisualGain(FilterIndex index, double gain) {
     if (m_config) {
         m_config->set(ConfigKey("[Waveform]","VisualGain_" + QString::number(index)), QString::number(m_visualGain[index]));
     }
+    if (!m_overviewNormalized && index == FilterIndex::All) {
+        emit overallVisualGainChanged();
+    }
 }
 
 double WaveformWidgetFactory::getVisualGain(FilterIndex index) const {
@@ -729,6 +732,7 @@ void WaveformWidgetFactory::setOverviewNormalized(bool normalize) {
     if (m_config) {
         m_config->set(ConfigKey("[Waveform]","OverviewNormalized"), ConfigValue(m_overviewNormalized));
     }
+    emit overviewNormalizeChanged();
 }
 
 void WaveformWidgetFactory::setPlayMarkerPosition(double position) {
@@ -1397,6 +1401,7 @@ void WaveformWidgetFactory::setUntilMarkAlign(Qt::Alignment align) {
                 toUntilMarkAlignIndex(m_untilMarkAlign));
     }
 }
+
 void WaveformWidgetFactory::setUntilMarkTextPointSize(int value) {
     m_untilMarkTextPointSize = value;
     if (m_config) {

--- a/src/waveform/waveformwidgetfactory.h
+++ b/src/waveform/waveformwidgetfactory.h
@@ -169,6 +169,9 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
     void renderVuMeters(VSyncThread*);
     void swapVuMeters();
 
+    void overviewNormalizeChanged();
+    void overallVisualGainChanged();
+
   public slots:
     void slotSkinLoaded();
 

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -86,6 +86,18 @@ WOverview::WOverview(
     m_pTypeControl->connectValueChanged(this, &WOverview::slotTypeControlChanged);
     slotTypeControlChanged(m_pTypeControl->get());
 
+    // Update immediately when the normalize option or the visual gain have been
+    // changed in the preferences.
+    WaveformWidgetFactory* widgetFactory = WaveformWidgetFactory::instance();
+    connect(widgetFactory,
+            &WaveformWidgetFactory::overviewNormalizeChanged,
+            this,
+            &WOverview::slotNormalizeOrVisualGainChanged);
+    connect(widgetFactory,
+            &WaveformWidgetFactory::overallVisualGainChanged,
+            this,
+            &WOverview::slotNormalizeOrVisualGainChanged);
+
     m_pPassthroughLabel = make_parented<QLabel>(this);
 
     setAcceptDrops(true);
@@ -414,6 +426,10 @@ void WOverview::slotTypeControlChanged(double v) {
     m_type = type;
     m_pWaveform.clear();
     slotWaveformSummaryUpdated();
+}
+
+void WOverview::slotNormalizeOrVisualGainChanged() {
+    update();
 }
 
 void WOverview::updateCues(const QList<CuePointer> &loadedCues) {

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -74,6 +74,7 @@ class WOverview : public WWidget, public TrackDropTarget {
     void slotCueMenuPopupAboutToHide();
 
     void slotTypeControlChanged(double v);
+    void slotNormalizeOrVisualGainChanged();
 
   private:
     // Append the waveform overview pixmap according to available data


### PR DESCRIPTION
Just another step to get the same immediate update as for the scrolling waveforms.

Initially I thought about adding a control for Normalize to move some stuff out of WaveformWidgetFactory, but actually it's okay with the new signals.