### PR TITLE
Library: add overview column

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1212,6 +1212,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/util/workerthreadscheduler.cpp
   src/util/xml.cpp
   src/waveform/guitick.cpp
+  src/waveform/overviews/overviewtype.cpp
   src/waveform/renderers/glwaveformrenderbackground.cpp
   src/waveform/renderers/glvsynctestrenderer.cpp
   src/waveform/renderers/waveformmark.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -960,6 +960,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/library/missing_hidden/hiddentablemodel.cpp
   src/library/missing_hidden/missingtablemodel.cpp
   src/library/mixxxlibraryfeature.cpp
+  src/library/overviewcache.cpp
   src/library/parser.cpp
   src/library/parsercsv.cpp
   src/library/parserm3u.cpp
@@ -989,6 +990,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/library/tabledelegates/keydelegate.cpp
   src/library/tabledelegates/locationdelegate.cpp
   src/library/tabledelegates/multilineeditdelegate.cpp
+  src/library/tabledelegates/overviewdelegate.cpp
   src/library/tabledelegates/previewbuttondelegate.cpp
   src/library/tabledelegates/stardelegate.cpp
   src/library/tabledelegates/stareditor.cpp
@@ -1215,6 +1217,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/waveform/renderers/waveformmark.cpp
   src/waveform/renderers/waveformmarkrange.cpp
   src/waveform/renderers/waveformmarkset.cpp
+  src/waveform/overviews/waveformoverviewrenderer.cpp
   src/waveform/renderers/waveformrenderbackground.cpp
   src/waveform/renderers/waveformrenderbeat.cpp
   src/waveform/renderers/waveformrendererabstract.cpp

--- a/res/skins/LateNight/library.xml
+++ b/res/skins/LateNight/library.xml
@@ -110,6 +110,10 @@
               <Library>
                 <ShowButtonText>false</ShowButtonText>
                 <TrackTableBackgroundColorOpacity>0.175</TrackTableBackgroundColorOpacity>
+                <!-- Colors for the render modes of the Overview column -->
+                <!-- For the decks' overview we only set the signal color,
+                     other colors are the defaults. -->
+                <SignalColor><Variable name="SignalColor_12"/></SignalColor>
               </Library>
 
             </Children>

--- a/src/analyzer/analyzerwaveform.cpp
+++ b/src/analyzer/analyzerwaveform.cpp
@@ -3,6 +3,7 @@
 #include "analyzer/analyzertrack.h"
 #include "analyzer/constants.h"
 #include "engine/filters/enginefilterbessel4.h"
+#include "library/overviewcache.h"
 #include "track/track.h"
 #include "util/logger.h"
 #include "waveform/waveformfactory.h"
@@ -352,6 +353,8 @@ void AnalyzerWaveform::storeResults(TrackPointer tio) {
             tio->getId(),
             m_waveform,
             m_waveformSummary);
+
+    OverviewCache::instance()->onTrackSummaryChanged(tio->getId());
 
     kLogger.debug() << "Waveform generation for track" << tio->getId() << "done"
                     << m_timer.elapsed().debugSecondsWithUnit();

--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -21,6 +21,7 @@
 #include "library/coverartcache.h"
 #include "library/library.h"
 #include "library/library_prefs.h"
+#include "library/overviewcache.h"
 #include "library/trackcollection.h"
 #include "library/trackcollectionmanager.h"
 #include "mixer/playerinfo.h"
@@ -58,6 +59,7 @@
 #include "util/translations.h"
 #include "util/versionstore.h"
 #include "vinylcontrol/vinylcontrolmanager.h"
+#include "waveform/overviews/waveformoverviewrenderer.h"
 
 #ifdef __APPLE__
 #include "util/sandbox.h"
@@ -358,6 +360,10 @@ void CoreServices::initialize(QApplication* pApp) {
     emit initializationProgressUpdate(50, tr("library"));
     CoverArtCache::createInstance();
     Clipboard::createInstance();
+    WaveformOverviewRenderer::createInstance();
+    OverviewCache::createInstance();
+    OverviewCache::instance()->setConfig(pConfig);
+    OverviewCache::instance()->setDbConnectionPool(m_pDbConnectionPool);
 
     m_pTrackCollectionManager = std::make_shared<TrackCollectionManager>(
             this,

--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -360,7 +360,6 @@ void CoreServices::initialize(QApplication* pApp) {
     emit initializationProgressUpdate(50, tr("library"));
     CoverArtCache::createInstance();
     Clipboard::createInstance();
-    WaveformOverviewRenderer::createInstance();
     OverviewCache::createInstance();
     auto* pOverviewCache = OverviewCache::instance();
     pOverviewCache->setConfig(pConfig);

--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -362,8 +362,9 @@ void CoreServices::initialize(QApplication* pApp) {
     Clipboard::createInstance();
     WaveformOverviewRenderer::createInstance();
     OverviewCache::createInstance();
-    OverviewCache::instance()->setConfig(pConfig);
-    OverviewCache::instance()->setDbConnectionPool(m_pDbConnectionPool);
+    auto* pOverviewCache = OverviewCache::instance();
+    pOverviewCache->setConfig(pConfig);
+    pOverviewCache->setDbConnectionPool(m_pDbConnectionPool);
 
     m_pTrackCollectionManager = std::make_shared<TrackCollectionManager>(
             this,
@@ -383,6 +384,12 @@ void CoreServices::initialize(QApplication* pApp) {
     // been created. Otherwise Mixxx might hang when accessing
     // the uninitialized singleton instance!
     m_pPlayerManager->bindToLibrary(m_pLibrary.get());
+    // Connect to analyzer progress so we can update the tacks table immediately
+    // without having to wait for update/paint events.
+    connect(m_pPlayerManager.get(),
+            &PlayerManager::trackAnalyzerProgress,
+            pOverviewCache,
+            &OverviewCache::onTrackAnalysisProgress);
 
     bool musicDirAdded = false;
 

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -258,7 +258,7 @@ void BaseTrackTableModel::initHeaderProperties() {
             defaultColumnWidth() * 6);
     setHeaderProperties(ColumnCache::COLUMN_LIBRARYTABLE_WAVESUMMARYHEX,
             tr("Overview"),
-            defaultColumnWidth());
+            defaultColumnWidth() * 8);
     setHeaderProperties(
             ColumnCache::COLUMN_LIBRARYTABLE_PREVIEW,
             tr("Preview"),
@@ -1217,17 +1217,23 @@ void BaseTrackTableModel::slotRefreshCoverRows(
     emitDataChangedForMultipleRowsInColumn(rows, column);
 }
 
-void BaseTrackTableModel::slotOverviewReady(int row) {
-    const int column = fieldIndex(LIBRARYTABLE_COVERART);
+void BaseTrackTableModel::slotOverviewReady(TrackId trackId) {
+    const int column = fieldIndex(LIBRARYTABLE_WAVESUMMARYHEX);
     VERIFY_OR_DEBUG_ASSERT(column >= 0) {
         return;
     }
-    QModelIndex idx = index(row, column);
-    emit dataChanged(idx, idx);
+    const QList<int> rows = getTrackRows(trackId);
+    for (int row : rows) {
+        if (row == -1) {
+            continue;
+        }
+        QModelIndex idx = index(row, column);
+        emit dataChanged(idx, idx);
+    }
 }
 
 void BaseTrackTableModel::slotOverviewChanged(TrackId trackId) {
-    const int column = fieldIndex(LIBRARYTABLE_COVERART);
+    const int column = fieldIndex(LIBRARYTABLE_WAVESUMMARYHEX);
     VERIFY_OR_DEBUG_ASSERT(column >= 0) {
         return;
     }

--- a/src/library/basetracktablemodel.h
+++ b/src/library/basetracktablemodel.h
@@ -249,6 +249,9 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
     void slotRefreshCoverRows(
             const QList<int>& rows);
 
+    void slotOverviewReady(int row);
+    void slotOverviewChanged(TrackId trackId);
+
     void slotRefreshAllRows();
 
     void slotCoverFound(

--- a/src/library/basetracktablemodel.h
+++ b/src/library/basetracktablemodel.h
@@ -249,7 +249,7 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
     void slotRefreshCoverRows(
             const QList<int>& rows);
 
-    void slotOverviewReady(int row);
+    void slotOverviewReady(TrackId trackId);
     void slotOverviewChanged(TrackId trackId);
 
     void slotRefreshAllRows();

--- a/src/library/librarytablemodel.cpp
+++ b/src/library/librarytablemodel.cpp
@@ -68,7 +68,7 @@ bool LibraryTableModel::isColumnInternal(int column) {
     return column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_ID) ||
             column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_URL) ||
             column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_CUEPOINT) ||
-            column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_WAVESUMMARYHEX) ||
+            // column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_WAVESUMMARYHEX) ||
             column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_SAMPLERATE) ||
             column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_MIXXXDELETED) ||
             column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_HEADERPARSED) ||

--- a/src/library/mixxxlibraryfeature.cpp
+++ b/src/library/mixxxlibraryfeature.cpp
@@ -23,7 +23,6 @@
 #include "widget/wlibrarysidebar.h"
 #endif
 
-
 MixxxLibraryFeature::MixxxLibraryFeature(Library* pLibrary,
         UserSettingsPointer pConfig)
         : LibraryFeature(pLibrary, pConfig, QStringLiteral("tracks")),
@@ -70,7 +69,8 @@ MixxxLibraryFeature::MixxxLibraryFeature(Library* pLibrary,
             LIBRARYTABLE_COVERART_LOCATION,
             LIBRARYTABLE_COVERART_COLOR,
             LIBRARYTABLE_COVERART_DIGEST,
-            LIBRARYTABLE_COVERART_HASH};
+            LIBRARYTABLE_COVERART_HASH,
+            LIBRARYTABLE_WAVESUMMARYHEX};
     QStringList searchColumns = {
             LIBRARYTABLE_ARTIST,
             LIBRARYTABLE_ALBUM,

--- a/src/library/overviewcache.cpp
+++ b/src/library/overviewcache.cpp
@@ -1,0 +1,236 @@
+#include "library/overviewcache.h"
+
+#include <QFutureWatcher>
+#include <QPixmapCache>
+#include <QSqlDatabase>
+#include <QtConcurrentRun>
+#include <QtSql>
+
+#include "library/dao/analysisdao.h"
+#include "moc_overviewcache.cpp"
+#include "util/db/dbconnectionpooled.h"
+#include "util/db/dbconnectionpooler.h"
+#include "util/logger.h"
+#include "waveform/overviews/waveformoverviewrenderer.h"
+#include "waveform/waveformfactory.h"
+
+namespace {
+
+mixxx::Logger kLogger("OverviewCache");
+
+QString pixmapCacheKey(TrackId trackId, QSize size) {
+    // return QString("Overview_%1").arg(trackId.toInt());
+    // return QString("Overview_%1_%2").arg(trackId.toInt()).arg(width);
+    return QString("Overview_%1_%2_%3")
+            .arg(trackId.toString())
+            .arg(size.width())
+            .arg(size.height());
+}
+
+// The transformation mode when scaling images
+const Qt::TransformationMode kTransformationMode = Qt::SmoothTransformation;
+
+// Resizes the image (preserving aspect ratio) to width.
+inline QImage resizeImageWidth(const QImage& image, int width) {
+    return image.scaledToWidth(width, kTransformationMode);
+}
+
+inline QImage resizeImageSize(const QImage& image, QSize size) {
+    return image.scaled(size, Qt::IgnoreAspectRatio, kTransformationMode);
+}
+} // anonymous namespace
+
+// OverviewCache::OverviewCache(QObject *parent) : QObject(parent)
+OverviewCache::OverviewCache() {
+}
+
+// OverviewCache::~OverviewCache() {
+//  qDebug()
+//}
+
+/*
+void OverviewCache::initialize(UserSettingsPointer pConfig) {
+    m_database = QSqlDatabase::addDatabase("QSQLITE", "OVERVIEW_CACHE");
+    if (!m_database.isOpen()) {
+        m_database.setHostName("localhost");
+        m_database.setDatabaseName(QDir(pConfig->getSettingsPath()).filePath("mixxxdb.sqlite"));
+        m_database.setUserName("mixxx");
+        m_database.setPassword("mixxx");
+
+        // Open the database connection in this thread.
+        if (!m_database.open()) {
+            qDebug() << "Failed to open database from overview cacher thread."
+                     << m_database.lastError();
+        }
+    }
+
+    // m_pAnalysisDao = std::make_unique<AnalysisDao>(pConfig);
+}
+*/
+
+void OverviewCache::setConfig(UserSettingsPointer pConfig) {
+    m_pConfig = pConfig;
+}
+
+void OverviewCache::setDbConnectionPool(mixxx::DbConnectionPoolPtr pDbConnectionPool) {
+    m_pDbConnectionPool = std::move(pDbConnectionPool);
+}
+
+void OverviewCache::onTrackSummaryChanged(TrackId trackId) {
+    emit overviewChanged(trackId);
+}
+
+QPixmap OverviewCache::requestOverview(const TrackId trackId,
+        const QObject* pRequester,
+        const QSize desiredSize) {
+    kLogger.info() << "requestOverview()" << trackId << pRequester << desiredSize;
+
+    if (!trackId.isValid()) {
+        return QPixmap();
+    }
+
+    if (m_currentlyLoading.contains(trackId)) {
+        return QPixmap();
+    }
+
+    QString cacheKey = pixmapCacheKey(trackId, desiredSize);
+
+    QPixmap pixmap;
+    if (QPixmapCache::find(cacheKey, &pixmap)) {
+        return pixmap;
+    }
+
+    m_currentlyLoading.insert(trackId);
+
+    QFutureWatcher<FutureResult>* watcher = new QFutureWatcher<FutureResult>(this);
+    QFuture<FutureResult> future = QtConcurrent::run(
+            &OverviewCache::prepareOverview,
+            m_pConfig,
+            m_pDbConnectionPool,
+            trackId,
+            pRequester,
+            desiredSize);
+    connect(watcher,
+            &QFutureWatcher<FutureResult>::finished,
+            this,
+            &OverviewCache::overviewPrepared);
+    watcher->setFuture(future);
+
+    return QPixmap();
+
+    /*
+    ConstWaveformPointer pLoadedTrackWaveformSummary;
+    QList<AnalysisDao::AnalysisInfo> analyses =
+            m_pAnalysisDao->getAnalysesForTrackByType(trackId,
+    AnalysisDao::AnalysisType::TYPE_WAVESUMMARY);
+
+    if (analyses.size() != 1) {
+        return QPixmap();
+    }
+    */
+
+    /*
+    QListIterator<AnalysisDao::AnalysisInfo> it(analyses);
+    while (it.hasNext()) {
+        const AnalysisDao::AnalysisInfo& analysis = it.next();
+        pLoadedTrackWaveformSummary = ConstWaveformPointer(
+                WaveformFactory::loadWaveformFromAnalysis(analysis));
+    }
+    */
+    /*
+    pLoadedTrackWaveformSummary = ConstWaveformPointer(
+                WaveformFactory::loadWaveformFromAnalysis(analyses[0]));
+
+    if (!pLoadedTrackWaveformSummary.isNull() && !pLoadedTrackWaveformSummary->isValid()) {
+        return QPixmap();
+    }
+
+    QImage image = pLoadedTrackWaveformSummary->renderToImage();
+
+    if (!image.isNull() && desiredWidth > 0) {
+        image = resizeImageWidth(image, desiredWidth);
+    }
+    */
+
+    // Create pixmap, GUI thread only
+    /*QPixmap*/
+    /*pixmap = QPixmap::fromImage(image);
+if (!pixmap.isNull() && desiredWidth != 0) {
+// we have to be sure that res.cover.hash is unique
+// because insert replaces the images with the same key
+QString cacheKey = pixmapCacheKey(
+    trackId, desiredWidth);
+QPixmapCache::insert(cacheKey, pixmap);
+}
+
+return pixmap;*/
+}
+
+// static
+OverviewCache::FutureResult OverviewCache::prepareOverview(
+        const UserSettingsPointer pConfig,
+        const mixxx::DbConnectionPoolPtr pDbConnectionPool,
+        const TrackId trackId,
+        const QObject* pRequester,
+        const QSize desiredSize) {
+    mixxx::DbConnectionPooler dbConnectionPooler(pDbConnectionPool);
+
+    AnalysisDao analysisDao(pConfig);
+    analysisDao.initialize(mixxx::DbConnectionPooled(pDbConnectionPool));
+
+    QList<AnalysisDao::AnalysisInfo> analyses =
+            analysisDao.getAnalysesForTrackByType(
+                    trackId, AnalysisDao::AnalysisType::TYPE_WAVESUMMARY);
+
+    /*
+    QListIterator<AnalysisDao::AnalysisInfo> it(analyses);
+    if (it.hasNext()) {
+        const AnalysisDao::AnalysisInfo& analysis = it.next();
+    }
+    */
+
+    QImage image;
+
+    if (!analyses.isEmpty()) {
+        ConstWaveformPointer pLoadedTrackWaveformSummary = ConstWaveformPointer(
+                WaveformFactory::loadWaveformFromAnalysis(analyses.first()));
+
+        /*&& pLoadedTrackWaveformSummary->isValid()*/
+        if (!pLoadedTrackWaveformSummary.isNull()) {
+            image = WaveformOverviewRenderer::instance()->render(pLoadedTrackWaveformSummary);
+
+            if (!image.isNull() && !desiredSize.isEmpty()) {
+                // image = resizeImageWidth(image, desiredWidth);
+                image = resizeImageSize(image, desiredSize);
+            }
+        }
+    }
+
+    FutureResult result;
+    result.trackId = trackId;
+    result.requester = pRequester;
+    result.image = image; // QImage();
+    result.resizedToSize = desiredSize;
+    return result;
+}
+
+// watcher
+void OverviewCache::overviewPrepared() {
+    QFutureWatcher<FutureResult>* watcher = static_cast<QFutureWatcher<FutureResult>*>(sender());
+    FutureResult res = watcher->result();
+    watcher->deleteLater();
+
+    // Create pixmap, GUI thread only
+    QPixmap pixmap = QPixmap::fromImage(res.image);
+    if (!pixmap.isNull() && !res.resizedToSize.isEmpty()) {
+        // we have to be sure that res.cover.hash is unique
+        // because insert replaces the images with the same key
+        QString cacheKey = pixmapCacheKey(
+                res.trackId, res.resizedToSize);
+        QPixmapCache::insert(cacheKey, pixmap);
+    }
+
+    m_currentlyLoading.remove(res.trackId);
+
+    emit overviewReady(res.requester, res.trackId, pixmap, res.resizedToSize);
+}

--- a/src/library/overviewcache.cpp
+++ b/src/library/overviewcache.cpp
@@ -132,7 +132,7 @@ OverviewCache::FutureResult OverviewCache::prepareOverview(
                 WaveformFactory::loadWaveformFromAnalysis(analyses.first()));
 
         if (!pLoadedTrackWaveformSummary.isNull()) {
-            QImage image = WaveformOverviewRenderer::instance()->render(
+            QImage image = WaveformOverviewRenderer::instance()->renderRGB(
                     pLoadedTrackWaveformSummary);
 
             if (!image.isNull()) {

--- a/src/library/overviewcache.cpp
+++ b/src/library/overviewcache.cpp
@@ -138,7 +138,7 @@ OverviewCache::FutureResult OverviewCache::prepareOverview(
                 WaveformFactory::loadWaveformFromAnalysis(analyses.first()));
 
         if (!pLoadedTrackWaveformSummary.isNull()) {
-            QImage image = WaveformOverviewRenderer::instance()->render(
+            QImage image = WaveformOverviewRenderer::render(
                     pLoadedTrackWaveformSummary, type);
 
             if (!image.isNull()) {

--- a/src/library/overviewcache.cpp
+++ b/src/library/overviewcache.cpp
@@ -19,8 +19,6 @@ namespace {
 mixxx::Logger kLogger("OverviewCache");
 
 QString pixmapCacheKey(TrackId trackId, QSize size) {
-    // return QString("Overview_%1").arg(trackId.toInt());
-    // return QString("Overview_%1_%2").arg(trackId.toInt()).arg(width);
     return QString("Overview_%1_%2_%3")
             .arg(trackId.toString())
             .arg(size.width())
@@ -30,43 +28,13 @@ QString pixmapCacheKey(TrackId trackId, QSize size) {
 // The transformation mode when scaling images
 const Qt::TransformationMode kTransformationMode = Qt::SmoothTransformation;
 
-// Resizes the image (preserving aspect ratio) to width.
-inline QImage resizeImageWidth(const QImage& image, int width) {
-    return image.scaledToWidth(width, kTransformationMode);
-}
-
 inline QImage resizeImageSize(const QImage& image, QSize size) {
     return image.scaled(size, Qt::IgnoreAspectRatio, kTransformationMode);
 }
 } // anonymous namespace
 
-// OverviewCache::OverviewCache(QObject *parent) : QObject(parent)
 OverviewCache::OverviewCache() {
 }
-
-// OverviewCache::~OverviewCache() {
-//  qDebug()
-//}
-
-/*
-void OverviewCache::initialize(UserSettingsPointer pConfig) {
-    m_database = QSqlDatabase::addDatabase("QSQLITE", "OVERVIEW_CACHE");
-    if (!m_database.isOpen()) {
-        m_database.setHostName("localhost");
-        m_database.setDatabaseName(QDir(pConfig->getSettingsPath()).filePath("mixxxdb.sqlite"));
-        m_database.setUserName("mixxx");
-        m_database.setPassword("mixxx");
-
-        // Open the database connection in this thread.
-        if (!m_database.open()) {
-            qDebug() << "Failed to open database from overview cacher thread."
-                     << m_database.lastError();
-        }
-    }
-
-    // m_pAnalysisDao = std::make_unique<AnalysisDao>(pConfig);
-}
-*/
 
 void OverviewCache::setConfig(UserSettingsPointer pConfig) {
     m_pConfig = pConfig;
@@ -76,6 +44,15 @@ void OverviewCache::setDbConnectionPool(mixxx::DbConnectionPoolPtr pDbConnection
     m_pDbConnectionPool = std::move(pDbConnectionPool);
 }
 
+void OverviewCache::onTrackAnalysisProgress(TrackId trackId, AnalyzerProgress analyzerProgress) {
+    if (analyzerProgress < 1.0) {
+        return;
+    }
+    m_tracksWithoutOverview.remove(trackId);
+    // request update independent from paint events
+    emit overviewChanged(trackId);
+}
+
 void OverviewCache::onTrackSummaryChanged(TrackId trackId) {
     emit overviewChanged(trackId);
 }
@@ -83,8 +60,6 @@ void OverviewCache::onTrackSummaryChanged(TrackId trackId) {
 QPixmap OverviewCache::requestOverview(const TrackId trackId,
         const QObject* pRequester,
         const QSize desiredSize) {
-    kLogger.info() << "requestOverview()" << trackId << pRequester << desiredSize;
-
     if (!trackId.isValid()) {
         return QPixmap();
     }
@@ -93,13 +68,20 @@ QPixmap OverviewCache::requestOverview(const TrackId trackId,
         return QPixmap();
     }
 
-    QString cacheKey = pixmapCacheKey(trackId, desiredSize);
+    if (m_tracksWithoutOverview.contains(trackId)) {
+        return QPixmap();
+    }
 
+    kLogger.info() << "requestOverview()" << trackId << pRequester << desiredSize;
+
+    // request overview
+    const QString cacheKey = pixmapCacheKey(trackId, desiredSize);
     QPixmap pixmap;
     if (QPixmapCache::find(cacheKey, &pixmap)) {
         return pixmap;
     }
 
+    // no cached overview, request preparation
     m_currentlyLoading.insert(trackId);
 
     QFutureWatcher<FutureResult>* watcher = new QFutureWatcher<FutureResult>(this);
@@ -117,53 +99,6 @@ QPixmap OverviewCache::requestOverview(const TrackId trackId,
     watcher->setFuture(future);
 
     return QPixmap();
-
-    /*
-    ConstWaveformPointer pLoadedTrackWaveformSummary;
-    QList<AnalysisDao::AnalysisInfo> analyses =
-            m_pAnalysisDao->getAnalysesForTrackByType(trackId,
-    AnalysisDao::AnalysisType::TYPE_WAVESUMMARY);
-
-    if (analyses.size() != 1) {
-        return QPixmap();
-    }
-    */
-
-    /*
-    QListIterator<AnalysisDao::AnalysisInfo> it(analyses);
-    while (it.hasNext()) {
-        const AnalysisDao::AnalysisInfo& analysis = it.next();
-        pLoadedTrackWaveformSummary = ConstWaveformPointer(
-                WaveformFactory::loadWaveformFromAnalysis(analysis));
-    }
-    */
-    /*
-    pLoadedTrackWaveformSummary = ConstWaveformPointer(
-                WaveformFactory::loadWaveformFromAnalysis(analyses[0]));
-
-    if (!pLoadedTrackWaveformSummary.isNull() && !pLoadedTrackWaveformSummary->isValid()) {
-        return QPixmap();
-    }
-
-    QImage image = pLoadedTrackWaveformSummary->renderToImage();
-
-    if (!image.isNull() && desiredWidth > 0) {
-        image = resizeImageWidth(image, desiredWidth);
-    }
-    */
-
-    // Create pixmap, GUI thread only
-    /*QPixmap*/
-    /*pixmap = QPixmap::fromImage(image);
-if (!pixmap.isNull() && desiredWidth != 0) {
-// we have to be sure that res.cover.hash is unique
-// because insert replaces the images with the same key
-QString cacheKey = pixmapCacheKey(
-    trackId, desiredWidth);
-QPixmapCache::insert(cacheKey, pixmap);
-}
-
-return pixmap;*/
 }
 
 // static
@@ -173,6 +108,16 @@ OverviewCache::FutureResult OverviewCache::prepareOverview(
         const TrackId trackId,
         const QObject* pRequester,
         const QSize desiredSize) {
+    FutureResult result;
+    result.trackId = trackId;
+    result.requester = pRequester;
+    result.image = QImage();
+    result.resizedToSize = desiredSize;
+
+    if (!trackId.isValid() || desiredSize.isEmpty()) {
+        return result;
+    }
+
     mixxx::DbConnectionPooler dbConnectionPooler(pDbConnectionPool);
 
     AnalysisDao analysisDao(pConfig);
@@ -182,35 +127,21 @@ OverviewCache::FutureResult OverviewCache::prepareOverview(
             analysisDao.getAnalysesForTrackByType(
                     trackId, AnalysisDao::AnalysisType::TYPE_WAVESUMMARY);
 
-    /*
-    QListIterator<AnalysisDao::AnalysisInfo> it(analyses);
-    if (it.hasNext()) {
-        const AnalysisDao::AnalysisInfo& analysis = it.next();
-    }
-    */
-
-    QImage image;
-
     if (!analyses.isEmpty()) {
         ConstWaveformPointer pLoadedTrackWaveformSummary = ConstWaveformPointer(
                 WaveformFactory::loadWaveformFromAnalysis(analyses.first()));
 
-        /*&& pLoadedTrackWaveformSummary->isValid()*/
         if (!pLoadedTrackWaveformSummary.isNull()) {
-            image = WaveformOverviewRenderer::instance()->render(pLoadedTrackWaveformSummary);
+            QImage image = WaveformOverviewRenderer::instance()->render(
+                    pLoadedTrackWaveformSummary);
 
-            if (!image.isNull() && !desiredSize.isEmpty()) {
-                // image = resizeImageWidth(image, desiredWidth);
+            if (!image.isNull()) {
                 image = resizeImageSize(image, desiredSize);
             }
+            result.image = image;
         }
     }
 
-    FutureResult result;
-    result.trackId = trackId;
-    result.requester = pRequester;
-    result.image = image; // QImage();
-    result.resizedToSize = desiredSize;
     return result;
 }
 
@@ -225,12 +156,18 @@ void OverviewCache::overviewPrepared() {
     if (!pixmap.isNull() && !res.resizedToSize.isEmpty()) {
         // we have to be sure that res.cover.hash is unique
         // because insert replaces the images with the same key
-        QString cacheKey = pixmapCacheKey(
+        const QString cacheKey = pixmapCacheKey(
                 res.trackId, res.resizedToSize);
         QPixmapCache::insert(cacheKey, pixmap);
     }
 
+    if (pixmap.isNull()) {
+        // Avoid (too many) repeated lookups.
+        // (there may still be identical request be processed due to
+        // asynchronous processing)
+        m_tracksWithoutOverview.insert(res.trackId);
+    }
     m_currentlyLoading.remove(res.trackId);
 
-    emit overviewReady(res.requester, res.trackId, pixmap, res.resizedToSize);
+    emit overviewReady(res.requester, res.trackId, pixmap.isNull(), res.resizedToSize);
 }

--- a/src/library/overviewcache.cpp
+++ b/src/library/overviewcache.cpp
@@ -18,7 +18,7 @@ namespace {
 
 mixxx::Logger kLogger("OverviewCache");
 
-QString pixmapCacheKey(TrackId trackId, QSize size, WOverview::Type type) {
+QString pixmapCacheKey(TrackId trackId, QSize size, mixxx::OverviewType type) {
     return QString("Overview_%1_%2_%3_%4")
             .arg(static_cast<int>(type))
             .arg(trackId.toString())
@@ -59,7 +59,7 @@ void OverviewCache::onTrackSummaryChanged(TrackId trackId) {
 }
 
 QPixmap OverviewCache::requestOverview(
-        WOverview::Type type,
+        mixxx::OverviewType type,
         const TrackId trackId,
         const QObject* pRequester,
         const QSize desiredSize) {
@@ -109,7 +109,7 @@ QPixmap OverviewCache::requestOverview(
 OverviewCache::FutureResult OverviewCache::prepareOverview(
         const UserSettingsPointer pConfig,
         const mixxx::DbConnectionPoolPtr pDbConnectionPool,
-        const WOverview::Type type,
+        const mixxx::OverviewType type,
         const TrackId trackId,
         const QObject* pRequester,
         const QSize desiredSize) {

--- a/src/library/overviewcache.h
+++ b/src/library/overviewcache.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <QSqlDatabase>
+
+#include "preferences/usersettings.h"
+#include "track/track.h"
+#include "util/db/dbconnectionpool.h"
+#include "util/singleton.h"
+
+class AnalysisDao;
+
+/*
+struct CacheItem{
+    TrackId trackId;
+    bool isLoading;
+    QImage image;
+};
+*/
+
+class OverviewCache : public QObject, public Singleton<OverviewCache> {
+    Q_OBJECT
+  public:
+    void setConfig(UserSettingsPointer pConfig);
+
+    void setDbConnectionPool(mixxx::DbConnectionPoolPtr pDbConnectionPool);
+
+    void onTrackSummaryChanged(TrackId);
+
+    QPixmap requestOverview(
+            const TrackId trackId,
+            const QObject* pRequester,
+            const QSize desiredSize);
+
+    struct FutureResult {
+        FutureResult()
+                : /*resToWidth(0),*/
+                  requester(nullptr) {
+        }
+
+        TrackId trackId;
+        QImage image;
+        QSize resizedToSize;
+        const QObject* requester;
+    };
+
+  public slots:
+    void overviewPrepared();
+
+  signals:
+    void overviewReady(
+            const QObject* pRequester,
+            TrackId trackId,
+            QPixmap pixmap,
+            QSize resizedToSize);
+
+    void overviewChanged(TrackId);
+
+  protected:
+    OverviewCache();
+    virtual ~OverviewCache() override = default;
+    friend class Singleton<OverviewCache>;
+
+    static FutureResult prepareOverview(
+            UserSettingsPointer pConfig,
+            mixxx::DbConnectionPoolPtr pDbConnectionPool,
+            const TrackId trackId,
+            const QObject* pRequester,
+            const QSize desiredSize);
+
+  private:
+    UserSettingsPointer m_pConfig;
+    mixxx::DbConnectionPoolPtr m_pDbConnectionPool;
+
+    // QSqlDatabase m_database;
+    // std::unique_ptr<AnalysisDao> m_pAnalysisDao;
+
+    QSet<TrackId> m_currentlyLoading;
+
+    QHash<TrackId, QImage> m_cache;
+};

--- a/src/library/overviewcache.h
+++ b/src/library/overviewcache.h
@@ -7,7 +7,7 @@
 #include "track/track.h"
 #include "util/db/dbconnectionpool.h"
 #include "util/singleton.h"
-#include "widget/woverview.h"
+#include "waveform/overviews/overviewtype.h"
 
 class OverviewCache : public QObject, public Singleton<OverviewCache> {
     Q_OBJECT
@@ -19,7 +19,7 @@ class OverviewCache : public QObject, public Singleton<OverviewCache> {
     void onTrackSummaryChanged(TrackId);
 
     QPixmap requestOverview(
-            const WOverview::Type type,
+            const mixxx::OverviewType type,
             const TrackId trackId,
             const QObject* pRequester,
             const QSize desiredSize);
@@ -30,7 +30,7 @@ class OverviewCache : public QObject, public Singleton<OverviewCache> {
         }
 
         TrackId trackId;
-        WOverview::Type type;
+        mixxx::OverviewType type;
         QImage image;
         QSize resizedToSize;
         const QObject* requester;
@@ -57,7 +57,7 @@ class OverviewCache : public QObject, public Singleton<OverviewCache> {
     static FutureResult prepareOverview(
             UserSettingsPointer pConfig,
             mixxx::DbConnectionPoolPtr pDbConnectionPool,
-            const WOverview::Type type,
+            const mixxx::OverviewType type,
             const TrackId trackId,
             const QObject* pRequester,
             const QSize desiredSize);

--- a/src/library/overviewcache.h
+++ b/src/library/overviewcache.h
@@ -7,6 +7,7 @@
 #include "track/track.h"
 #include "util/db/dbconnectionpool.h"
 #include "util/singleton.h"
+#include "widget/woverview.h"
 
 class OverviewCache : public QObject, public Singleton<OverviewCache> {
     Q_OBJECT
@@ -18,6 +19,7 @@ class OverviewCache : public QObject, public Singleton<OverviewCache> {
     void onTrackSummaryChanged(TrackId);
 
     QPixmap requestOverview(
+            const WOverview::Type type,
             const TrackId trackId,
             const QObject* pRequester,
             const QSize desiredSize);
@@ -28,6 +30,7 @@ class OverviewCache : public QObject, public Singleton<OverviewCache> {
         }
 
         TrackId trackId;
+        WOverview::Type type;
         QImage image;
         QSize resizedToSize;
         const QObject* requester;
@@ -54,6 +57,7 @@ class OverviewCache : public QObject, public Singleton<OverviewCache> {
     static FutureResult prepareOverview(
             UserSettingsPointer pConfig,
             mixxx::DbConnectionPoolPtr pDbConnectionPool,
+            const WOverview::Type type,
             const TrackId trackId,
             const QObject* pRequester,
             const QSize desiredSize);

--- a/src/library/overviewcache.h
+++ b/src/library/overviewcache.h
@@ -2,20 +2,11 @@
 
 #include <QSqlDatabase>
 
+#include "analyzer/analyzerprogress.h"
 #include "preferences/usersettings.h"
 #include "track/track.h"
 #include "util/db/dbconnectionpool.h"
 #include "util/singleton.h"
-
-class AnalysisDao;
-
-/*
-struct CacheItem{
-    TrackId trackId;
-    bool isLoading;
-    QImage image;
-};
-*/
 
 class OverviewCache : public QObject, public Singleton<OverviewCache> {
     Q_OBJECT
@@ -33,8 +24,7 @@ class OverviewCache : public QObject, public Singleton<OverviewCache> {
 
     struct FutureResult {
         FutureResult()
-                : /*resToWidth(0),*/
-                  requester(nullptr) {
+                : requester(nullptr) {
         }
 
         TrackId trackId;
@@ -45,13 +35,14 @@ class OverviewCache : public QObject, public Singleton<OverviewCache> {
 
   public slots:
     void overviewPrepared();
+    void onTrackAnalysisProgress(TrackId trackId, AnalyzerProgress analyzerProgress);
 
   signals:
     void overviewReady(
             const QObject* pRequester,
-            TrackId trackId,
-            QPixmap pixmap,
-            QSize resizedToSize);
+            const TrackId trackId,
+            bool pixmapValid,
+            const QSize resizedToSize); // Currently only needed for debugging
 
     void overviewChanged(TrackId);
 
@@ -71,10 +62,8 @@ class OverviewCache : public QObject, public Singleton<OverviewCache> {
     UserSettingsPointer m_pConfig;
     mixxx::DbConnectionPoolPtr m_pDbConnectionPool;
 
-    // QSqlDatabase m_database;
-    // std::unique_ptr<AnalysisDao> m_pAnalysisDao;
-
     QSet<TrackId> m_currentlyLoading;
+    QSet<TrackId> m_tracksWithoutOverview;
 
-    QHash<TrackId, QImage> m_cache;
+    // QHash<TrackId, QImage> m_cache;
 };

--- a/src/library/tabledelegates/overviewdelegate.cpp
+++ b/src/library/tabledelegates/overviewdelegate.cpp
@@ -4,7 +4,6 @@
 #include "library/overviewcache.h"
 #include "library/trackmodel.h"
 #include "moc_overviewdelegate.cpp"
-// #include "track/track.h"
 #include "util/logger.h"
 
 namespace {
@@ -21,63 +20,38 @@ inline TrackModel* asTrackModel(
 
 } // anonymous namespace
 
-OverviewDelegate::OverviewDelegate(QTableView* parent)
-        : TableItemDelegate(parent),
-          m_pTrackModel(asTrackModel(parent)),
+OverviewDelegate::OverviewDelegate(QTableView* pTableView)
+        : TableItemDelegate(pTableView),
+          m_pTrackModel(asTrackModel(pTableView)),
           m_pCache(OverviewCache::instance()) {
-    /*
-    TrackModel* pTrackModel = nullptr;
-    if (QTableView* pTableView = qobject_cast<QTableView*>(parent)) {
-        m_pTableView = pTableView;
-        pTrackModel = dynamic_cast<TrackModel*>(pTableView->model());
-    }
-    */
-
-    /*
-    if (pTrackModel) {
-        m_iIdColumn = pTrackModel->fieldIndex(LIBRARYTABLE_ID);
-        m_iOverviewColumn = pTrackModel->fieldIndex(LIBRARYTABLE_WAVESUMMARYHEX);
-    }
-    */
-
-    if (m_pCache) {
-        connect(m_pCache,
-                &OverviewCache::overviewReady,
-                this,
-                &OverviewDelegate::slotOverviewReady);
-
-        connect(m_pCache,
-                &OverviewCache::overviewChanged,
-                this,
-                &OverviewDelegate::slotOverviewChanged);
-    } else {
+    VERIFY_OR_DEBUG_ASSERT(m_pCache) {
         kLogger.warning() << "Caching of overviews is not available";
+        return;
     }
 
-    // (const QObject*, TrackId, QPixmap, QSize))
-    // (const QObject*, TrackId, QPixmap, QSize))
+    connect(m_pCache,
+            &OverviewCache::overviewReady,
+            this,
+            &OverviewDelegate::slotOverviewReady);
+
+    connect(m_pCache,
+            &OverviewCache::overviewChanged,
+            this,
+            &OverviewDelegate::overviewChanged,
+            Qt::DirectConnection); // signal-to-signal
 }
 
-/*
-OverviewDelegate::~OverviewDelegate() {
-}
-*/
-
+/// Maybe request repaint via dataChanged() by BaseTrackTableModel
 void OverviewDelegate::slotOverviewReady(const QObject* pRequester,
-        TrackId trackId,
-        QPixmap pixmap,
-        QSize resizedToSize) {
-    kLogger.info() << "slotOverviewReady()" << trackId << pixmap << resizedToSize;
+        const TrackId trackId,
+        bool pixmapValid,
+        const QSize resizedToSize) {
+    Q_UNUSED(resizedToSize);
+    // kLogger.info() << "slotOverviewReady()" << trackId << pixmap << resizedToSize;
 
-    if (pRequester == this && !pixmap.isNull()) {
-        int row = m_trackIdToRow.take(trackId);
-        emit overviewReady(row);
-        //, m_iOverviewColumn
+    if (pRequester == this && pixmapValid) {
+        emit overviewReady(trackId);
     }
-}
-
-void OverviewDelegate::slotOverviewChanged(TrackId trackId) {
-    emit overviewChanged(trackId);
 }
 
 void OverviewDelegate::paintItem(QPainter* painter,
@@ -85,41 +59,15 @@ void OverviewDelegate::paintItem(QPainter* painter,
         const QModelIndex& index) const {
     paintItemBackground(painter, option, index);
 
-    /*
-    OverviewCache* pCache = OverviewCache::instance();
-    if (pCache == nullptr) {
+    if (!m_pCache) {
         return;
     }
 
-    TrackId trackId(index.sibling(index.row(), m_iIdColumn).data().toInt());
-    */
-
-    TrackId trackId(m_pTrackModel->getTrackId(index));
+    const TrackId trackId(m_pTrackModel->getTrackId(index));
 
     QPixmap pixmap = m_pCache->requestOverview(trackId, this, option.rect.size());
     if (!pixmap.isNull()) {
-        // int width = math_min(pixmap.width(), option.rect.width());
-        // int height = math_min(pixmap.height(), option.rect.height());
-        // QRect target(option.rect.x(), option.rect.y(),                     width, height);
-        // QRect source(0, 0, target.width(), target.height());
-        // painter->drawPixmap(target, pixmap, source);
-        // QRect source(0, 0, pixmap.width(), pixmap.height());
+        // We have a cached pixmap, paint it.
         painter->drawPixmap(option.rect, pixmap);
-    } else {
-        m_trackIdToRow[trackId] = index.row();
     }
-
-    // TrackModel *pTrackModel = dynamic_cast<TrackModel*>(m_pTableView->model());
-    /*
-    if (m_pTrackModel) {
-        TrackPointer pTrack = m_pTrackModel->getTrack(index);
-        if (pTrack) {
-            ConstWaveformPointer pWaveform = pTrack->getWaveform();
-            if (pWaveform) {
-                kLogger.debug() << "Drawing overview for track" << pTrack->getId();
-                painter->drawImage(option.rect, pWaveform->renderToImage());
-            }
-        }
-    }
-    */
 }

--- a/src/library/tabledelegates/overviewdelegate.cpp
+++ b/src/library/tabledelegates/overviewdelegate.cpp
@@ -1,0 +1,125 @@
+#include "library/tabledelegates/overviewdelegate.h"
+
+#include "library/dao/trackdao.h"
+#include "library/overviewcache.h"
+#include "library/trackmodel.h"
+#include "moc_overviewdelegate.cpp"
+// #include "track/track.h"
+#include "util/logger.h"
+
+namespace {
+
+const mixxx::Logger kLogger("OverviewDelegate");
+
+inline TrackModel* asTrackModel(
+        QTableView* pTableView) {
+    auto* pTrackModel =
+            dynamic_cast<TrackModel*>(pTableView->model());
+    DEBUG_ASSERT(pTrackModel);
+    return pTrackModel;
+}
+
+} // anonymous namespace
+
+OverviewDelegate::OverviewDelegate(QTableView* parent)
+        : TableItemDelegate(parent),
+          m_pTrackModel(asTrackModel(parent)),
+          m_pCache(OverviewCache::instance()) {
+    /*
+    TrackModel* pTrackModel = nullptr;
+    if (QTableView* pTableView = qobject_cast<QTableView*>(parent)) {
+        m_pTableView = pTableView;
+        pTrackModel = dynamic_cast<TrackModel*>(pTableView->model());
+    }
+    */
+
+    /*
+    if (pTrackModel) {
+        m_iIdColumn = pTrackModel->fieldIndex(LIBRARYTABLE_ID);
+        m_iOverviewColumn = pTrackModel->fieldIndex(LIBRARYTABLE_WAVESUMMARYHEX);
+    }
+    */
+
+    if (m_pCache) {
+        connect(m_pCache,
+                &OverviewCache::overviewReady,
+                this,
+                &OverviewDelegate::slotOverviewReady);
+
+        connect(m_pCache,
+                &OverviewCache::overviewChanged,
+                this,
+                &OverviewDelegate::slotOverviewChanged);
+    } else {
+        kLogger.warning() << "Caching of overviews is not available";
+    }
+
+    // (const QObject*, TrackId, QPixmap, QSize))
+    // (const QObject*, TrackId, QPixmap, QSize))
+}
+
+/*
+OverviewDelegate::~OverviewDelegate() {
+}
+*/
+
+void OverviewDelegate::slotOverviewReady(const QObject* pRequester,
+        TrackId trackId,
+        QPixmap pixmap,
+        QSize resizedToSize) {
+    kLogger.info() << "slotOverviewReady()" << trackId << pixmap << resizedToSize;
+
+    if (pRequester == this && !pixmap.isNull()) {
+        int row = m_trackIdToRow.take(trackId);
+        emit overviewReady(row);
+        //, m_iOverviewColumn
+    }
+}
+
+void OverviewDelegate::slotOverviewChanged(TrackId trackId) {
+    emit overviewChanged(trackId);
+}
+
+void OverviewDelegate::paintItem(QPainter* painter,
+        const QStyleOptionViewItem& option,
+        const QModelIndex& index) const {
+    paintItemBackground(painter, option, index);
+
+    /*
+    OverviewCache* pCache = OverviewCache::instance();
+    if (pCache == nullptr) {
+        return;
+    }
+
+    TrackId trackId(index.sibling(index.row(), m_iIdColumn).data().toInt());
+    */
+
+    TrackId trackId(m_pTrackModel->getTrackId(index));
+
+    QPixmap pixmap = m_pCache->requestOverview(trackId, this, option.rect.size());
+    if (!pixmap.isNull()) {
+        // int width = math_min(pixmap.width(), option.rect.width());
+        // int height = math_min(pixmap.height(), option.rect.height());
+        // QRect target(option.rect.x(), option.rect.y(),                     width, height);
+        // QRect source(0, 0, target.width(), target.height());
+        // painter->drawPixmap(target, pixmap, source);
+        // QRect source(0, 0, pixmap.width(), pixmap.height());
+        painter->drawPixmap(option.rect, pixmap);
+    } else {
+        m_trackIdToRow[trackId] = index.row();
+    }
+
+    // TrackModel *pTrackModel = dynamic_cast<TrackModel*>(m_pTableView->model());
+    /*
+    if (m_pTrackModel) {
+        TrackPointer pTrack = m_pTrackModel->getTrack(index);
+        if (pTrack) {
+            ConstWaveformPointer pWaveform = pTrack->getWaveform();
+            if (pWaveform) {
+                kLogger.debug() << "Drawing overview for track" << pTrack->getId();
+                painter->drawImage(option.rect, pWaveform->renderToImage());
+            }
+        }
+    }
+    */
+}

--- a/src/library/tabledelegates/overviewdelegate.cpp
+++ b/src/library/tabledelegates/overviewdelegate.cpp
@@ -59,6 +59,9 @@ void OverviewDelegate::slotTypeControlChanged(double v) {
     }
 
     m_type = type;
+    // Instantly update visible overviews so we get a live preview
+    // when changing the type in the preferences.
+    m_pTableView->update();
 }
 
 /// Maybe request repaint via dataChanged() by BaseTrackTableModel

--- a/src/library/tabledelegates/overviewdelegate.cpp
+++ b/src/library/tabledelegates/overviewdelegate.cpp
@@ -25,7 +25,7 @@ OverviewDelegate::OverviewDelegate(QTableView* pTableView)
         : TableItemDelegate(pTableView),
           m_pTrackModel(asTrackModel(pTableView)),
           m_pCache(OverviewCache::instance()),
-          m_type(WOverview::Type::RGB) {
+          m_type(mixxx::OverviewType::RGB) {
     VERIFY_OR_DEBUG_ASSERT(m_pCache) {
         kLogger.warning() << "Caching of overviews is not available";
         return;
@@ -52,8 +52,8 @@ OverviewDelegate::OverviewDelegate(QTableView* pTableView)
 
 void OverviewDelegate::slotTypeControlChanged(double v) {
     // Assert that v is in enum range to prevent UB.
-    DEBUG_ASSERT(v >= 0 && v < QMetaEnum::fromType<WOverview::Type>().keyCount());
-    WOverview::Type type = static_cast<WOverview::Type>(static_cast<int>(v));
+    DEBUG_ASSERT(v >= 0 && v < QMetaEnum::fromType<mixxx::OverviewType>().keyCount());
+    mixxx::OverviewType type = static_cast<mixxx::OverviewType>(static_cast<int>(v));
     if (type == m_type) {
         return;
     }

--- a/src/library/tabledelegates/overviewdelegate.h
+++ b/src/library/tabledelegates/overviewdelegate.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <QPainter>
+#include <QStyledItemDelegate>
+#include <QTableView>
+
+#include "library/tabledelegates/tableitemdelegate.h"
+#include "track/trackid.h"
+
+class OverviewCache;
+class TrackModel;
+
+class OverviewDelegate : public TableItemDelegate {
+    Q_OBJECT
+
+  public:
+    explicit OverviewDelegate(QTableView* parent);
+    ~OverviewDelegate() override = default;
+
+    void paintItem(QPainter* painter,
+            const QStyleOptionViewItem& option,
+            const QModelIndex& index) const final;
+
+  signals:
+    void overviewReady(int row);
+    // int column
+
+    void overviewChanged(TrackId trackId);
+
+  private slots:
+    void slotOverviewReady(const QObject* pRequester,
+            TrackId trackId,
+            QPixmap pixmap,
+            QSize resizedToSize);
+
+    void slotOverviewChanged(TrackId trackId);
+
+  protected:
+    TrackModel* const m_pTrackModel;
+
+  private:
+    OverviewCache* const m_pCache;
+
+    // QTableView* m_pTableView;
+    // int m_iIdColumn;
+    // int m_iOverviewColumn;
+
+    mutable QHash<TrackId, int> m_trackIdToRow;
+};

--- a/src/library/tabledelegates/overviewdelegate.h
+++ b/src/library/tabledelegates/overviewdelegate.h
@@ -6,7 +6,10 @@
 
 #include "library/tabledelegates/tableitemdelegate.h"
 #include "track/trackid.h"
+#include "util/parented_ptr.h"
+#include "widget/woverview.h"
 
+class ControlProxy;
 class OverviewCache;
 class TrackModel;
 
@@ -27,6 +30,7 @@ class OverviewDelegate : public TableItemDelegate {
     void overviewChanged(TrackId trackId);
 
   private slots:
+    void slotTypeControlChanged(double v);
     void slotOverviewReady(const QObject* pRequester,
             const TrackId trackId,
             bool pixmapValid,
@@ -37,6 +41,8 @@ class OverviewDelegate : public TableItemDelegate {
 
   private:
     OverviewCache* const m_pCache;
+    WOverview::Type m_type;
+    parented_ptr<ControlProxy> m_pTypeControl;
 
     mutable QHash<TrackId, int> m_trackIdToRow;
 };

--- a/src/library/tabledelegates/overviewdelegate.h
+++ b/src/library/tabledelegates/overviewdelegate.h
@@ -22,28 +22,21 @@ class OverviewDelegate : public TableItemDelegate {
             const QModelIndex& index) const final;
 
   signals:
-    void overviewReady(int row);
-    // int column
+    void overviewReady(TrackId trackId);
 
     void overviewChanged(TrackId trackId);
 
   private slots:
     void slotOverviewReady(const QObject* pRequester,
-            TrackId trackId,
-            QPixmap pixmap,
-            QSize resizedToSize);
-
-    void slotOverviewChanged(TrackId trackId);
+            const TrackId trackId,
+            bool pixmapValid,
+            const QSize resizedToSize);
 
   protected:
     TrackModel* const m_pTrackModel;
 
   private:
     OverviewCache* const m_pCache;
-
-    // QTableView* m_pTableView;
-    // int m_iIdColumn;
-    // int m_iOverviewColumn;
 
     mutable QHash<TrackId, int> m_trackIdToRow;
 };

--- a/src/library/tabledelegates/overviewdelegate.h
+++ b/src/library/tabledelegates/overviewdelegate.h
@@ -7,7 +7,7 @@
 #include "library/tabledelegates/tableitemdelegate.h"
 #include "track/trackid.h"
 #include "util/parented_ptr.h"
-#include "widget/woverview.h"
+#include "waveform/overviews/overviewtype.h"
 
 class ControlProxy;
 class OverviewCache;
@@ -41,7 +41,7 @@ class OverviewDelegate : public TableItemDelegate {
 
   private:
     OverviewCache* const m_pCache;
-    WOverview::Type m_type;
+    mixxx::OverviewType m_type;
     parented_ptr<ControlProxy> m_pTypeControl;
 
     mutable QHash<TrackId, int> m_trackIdToRow;

--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -8,9 +8,9 @@
 #include "moc_dlgprefwaveform.cpp"
 #include "preferences/waveformsettings.h"
 #include "util/db/dbconnectionpooled.h"
+#include "waveform/overviews/overviewtype.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
 #include "waveform/waveformwidgetfactory.h"
-#include "widget/woverview.h"
 
 namespace {
 const ConfigKey kOverviewTypeCfgKey(QStringLiteral("[Waveform]"),
@@ -28,20 +28,20 @@ DlgPrefWaveform::DlgPrefWaveform(
 
     // Waveform overview init
     waveformOverviewComboBox->addItem(
-            tr("Filtered"), QVariant::fromValue(WOverview::Type::Filtered));
-    waveformOverviewComboBox->addItem(tr("HSV"), QVariant::fromValue(WOverview::Type::HSV));
-    waveformOverviewComboBox->addItem(tr("RGB"), QVariant::fromValue(WOverview::Type::RGB));
+            tr("Filtered"), QVariant::fromValue(mixxx::OverviewType::Filtered));
+    waveformOverviewComboBox->addItem(tr("HSV"), QVariant::fromValue(mixxx::OverviewType::HSV));
+    waveformOverviewComboBox->addItem(tr("RGB"), QVariant::fromValue(mixxx::OverviewType::RGB));
     m_pTypeControl = std::make_unique<ControlPushButton>(kOverviewTypeCfgKey);
-    m_pTypeControl->setStates(QMetaEnum::fromType<WOverview::Type>().keyCount());
+    m_pTypeControl->setStates(QMetaEnum::fromType<mixxx::OverviewType>().keyCount());
     m_pTypeControl->setReadOnly();
     // Update the control with the config value
-    WOverview::Type overviewType =
-            m_pConfig->getValue<WOverview::Type>(kOverviewTypeCfgKey, WOverview::Type::RGB);
+    mixxx::OverviewType overviewType =
+            m_pConfig->getValue<mixxx::OverviewType>(kOverviewTypeCfgKey, mixxx::OverviewType::RGB);
     int cfgTypeIndex = waveformOverviewComboBox->findData(QVariant::fromValue(overviewType));
     if (cfgTypeIndex == -1) {
         // Invalid config value, set default type RGB and write it to config
         waveformOverviewComboBox->setCurrentIndex(
-                waveformOverviewComboBox->findData(QVariant::fromValue(WOverview::Type::RGB)));
+                waveformOverviewComboBox->findData(QVariant::fromValue(mixxx::OverviewType::RGB)));
         m_pConfig->setValue(kOverviewTypeCfgKey, cfgTypeIndex);
     } else {
         waveformOverviewComboBox->setCurrentIndex(cfgTypeIndex);
@@ -294,10 +294,10 @@ void DlgPrefWaveform::slotUpdate() {
                     factory->getUntilMarkAlign()));
     untilMarkTextPointSizeSpinBox->setValue(factory->getUntilMarkTextPointSize());
 
-    WOverview::Type cfgOverviewType =
-            m_pConfig->getValue<WOverview::Type>(kOverviewTypeCfgKey, WOverview::Type::RGB);
+    mixxx::OverviewType cfgOverviewType =
+            m_pConfig->getValue<mixxx::OverviewType>(kOverviewTypeCfgKey, mixxx::OverviewType::RGB);
     // Assumes the combobox index is in sync with the ControlPushButton
-    if (cfgOverviewType != waveformOverviewComboBox->currentData().value<WOverview::Type>()) {
+    if (cfgOverviewType != waveformOverviewComboBox->currentData().value<mixxx::OverviewType>()) {
         int cfgOverviewTypeIndex =
                 waveformOverviewComboBox->findData(QVariant::fromValue(cfgOverviewType));
         waveformOverviewComboBox->setCurrentIndex(cfgOverviewTypeIndex);
@@ -358,7 +358,7 @@ void DlgPrefWaveform::slotResetToDefaults() {
 
     // RGB overview.
     waveformOverviewComboBox->setCurrentIndex(
-            waveformOverviewComboBox->findData(QVariant::fromValue(WOverview::Type::RGB)));
+            waveformOverviewComboBox->findData(QVariant::fromValue(mixxx::OverviewType::RGB)));
 
     // Don't normalize overview.
     normalizeOverviewCheckBox->setChecked(false);
@@ -540,8 +540,8 @@ void DlgPrefWaveform::updateEnableUntilMark() {
 void DlgPrefWaveform::slotSetWaveformOverviewType() {
     // Apply immediately
     QVariant comboboxData = waveformOverviewComboBox->currentData();
-    DEBUG_ASSERT(comboboxData.canConvert<WOverview::Type>());
-    auto type = comboboxData.value<WOverview::Type>();
+    DEBUG_ASSERT(comboboxData.canConvert<mixxx::OverviewType>());
+    auto type = comboboxData.value<mixxx::OverviewType>();
     m_pConfig->setValue(kOverviewTypeCfgKey, type);
     m_pTypeControl->forceSet(static_cast<double>(type));
 }

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -27,6 +27,8 @@
 #include "util/timer.h"
 #include "util/valuetransformer.h"
 #include "util/xml.h"
+#include "waveform/overviews/waveformoverviewrenderer.h"
+#include "waveform/renderers/waveformsignalcolors.h"
 #include "waveform/vsyncthread.h"
 #include "waveform/waveformwidgetfactory.h"
 #include "widget/controlwidgetconnection.h"
@@ -1579,6 +1581,17 @@ QWidget* LegacySkinParser::parseLibrary(const QDomElement& node) {
                     mixxx::library::prefs::kApplyPlayedTrackColorConfigKey,
                     BaseTrackTableModel::kApplyPlayedTrackColorDefault);
     BaseTrackTableModel::setApplyPlayedTrackColor(applyPlayedTrackColor);
+
+    // Get colors for the different render modes of the Overview column
+    WaveformSignalColors* pSignalColors = new WaveformSignalColors();
+    pSignalColors->setup(node, *m_pContext);
+    WaveformOverviewRenderer::setRgbLowColor(pSignalColors->getRgbLowColor());
+    WaveformOverviewRenderer::setRgbMidColor(pSignalColors->getRgbMidColor());
+    WaveformOverviewRenderer::setRgbHighColor(pSignalColors->getRgbHighColor());
+    WaveformOverviewRenderer::setFilteredLowColor(pSignalColors->getLowColor());
+    WaveformOverviewRenderer::setFilteredMidColor(pSignalColors->getMidColor());
+    WaveformOverviewRenderer::setFilteredHighColor(pSignalColors->getHighColor());
+    WaveformOverviewRenderer::setSignalColor(pSignalColors->getSignalColor());
 
     // Connect Library search signals to the WLibrary
     connect(m_pLibrary,

--- a/src/waveform/overviews/overviewtype.cpp
+++ b/src/waveform/overviews/overviewtype.cpp
@@ -1,0 +1,4 @@
+// just a stub so the MOC file can be included somewhere
+#include "overviewtype.h"
+
+#include "moc_overviewtype.cpp"

--- a/src/waveform/overviews/overviewtype.h
+++ b/src/waveform/overviews/overviewtype.h
@@ -1,0 +1,16 @@
+#pragma once
+
+// required for Qt-Macros
+#include <qobjectdefs.h>
+
+namespace mixxx {
+Q_NAMESPACE
+
+enum class OverviewType {
+    Filtered,
+    HSV,
+    RGB,
+};
+Q_ENUM_NS(OverviewType);
+
+} // namespace mixxx

--- a/src/waveform/overviews/waveformoverviewrenderer.cpp
+++ b/src/waveform/overviews/waveformoverviewrenderer.cpp
@@ -5,7 +5,8 @@
 #include "util/colorcomponents.h"
 #include "util/math.h"
 
-QImage WaveformOverviewRenderer::renderRGB(ConstWaveformPointer pWaveform) {
+QImage WaveformOverviewRenderer::render(ConstWaveformPointer pWaveform,
+        WOverview::Type type) {
     const int dataSize = pWaveform->getDataSize();
     if (dataSize <= 0) {
         return QImage();
@@ -17,7 +18,13 @@ QImage WaveformOverviewRenderer::renderRGB(ConstWaveformPointer pWaveform) {
     QPainter painter(&image);
     painter.translate(0.0, static_cast<double>(image.height()) / 2.0);
 
-    drawWaveformPartRGB(&painter, pWaveform, nullptr, dataSize);
+    if (type == WOverview::Type::HSV) {
+        drawWaveformPartHSV(&painter, pWaveform, nullptr, dataSize);
+    } else if (type == WOverview::Type::Filtered) {
+        drawWaveformPartLMH(&painter, pWaveform, nullptr, dataSize);
+    } else {
+        drawWaveformPartRGB(&painter, pWaveform, nullptr, dataSize);
+    }
 
     return image;
 }

--- a/src/waveform/overviews/waveformoverviewrenderer.cpp
+++ b/src/waveform/overviews/waveformoverviewrenderer.cpp
@@ -1,0 +1,50 @@
+#include "waveformoverviewrenderer.h"
+
+#include <QPainter>
+
+#include "util/math.h"
+
+QImage WaveformOverviewRenderer::render(ConstWaveformPointer pWaveform) const {
+    const int dataSize = pWaveform->getDataSize();
+    if (dataSize <= 0) {
+        return QImage();
+    }
+
+    QImage image(dataSize / 2, 2 * 255, QImage::Format_ARGB32_Premultiplied);
+    image.fill(QColor(0, 0, 0, 0).value());
+
+    QPainter painter(&image);
+    painter.translate(0.0, static_cast<double>(image.height()) / 2.0);
+
+    QColor color;
+
+    for (int i = 0, x = 0; i < dataSize; i += 2, ++x) {
+        unsigned char all = pWaveform->getAll(i);
+        unsigned char low = pWaveform->getLow(i);
+        unsigned char mid = pWaveform->getMid(i);
+        unsigned char high = pWaveform->getHigh(i);
+        unsigned char max = math_max3(low, mid, high);
+        qreal maxF = static_cast<qreal>(max);
+
+        if (maxF > 0.0) {
+            color.setRgbF(low / maxF, mid / maxF, high / maxF);
+            painter.setPen(color);
+            painter.drawLine(x, -all, x, 0);
+        }
+
+        all = pWaveform->getAll(i + 1);
+        low = pWaveform->getLow(i + 1);
+        mid = pWaveform->getMid(i + 1);
+        high = pWaveform->getHigh(i + 1);
+        max = math_max3(low, mid, high);
+        maxF = static_cast<qreal>(max);
+
+        if (maxF > 0.0) {
+            color.setRgbF(low / maxF, mid / maxF, high / maxF);
+            painter.setPen(color);
+            painter.drawLine(x, 0, x, all);
+        }
+    }
+
+    return image;
+}

--- a/src/waveform/overviews/waveformoverviewrenderer.cpp
+++ b/src/waveform/overviews/waveformoverviewrenderer.cpp
@@ -19,6 +19,7 @@ QImage WaveformOverviewRenderer::render(ConstWaveformPointer pWaveform) const {
     QColor color;
 
     for (int i = 0, x = 0; i < dataSize; i += 2, ++x) {
+        // paint left channel
         unsigned char all = pWaveform->getAll(i);
         unsigned char low = pWaveform->getLow(i);
         unsigned char mid = pWaveform->getMid(i);
@@ -27,11 +28,14 @@ QImage WaveformOverviewRenderer::render(ConstWaveformPointer pWaveform) const {
         qreal maxF = static_cast<qreal>(max);
 
         if (maxF > 0.0) {
-            color.setRgbF(low / maxF, mid / maxF, high / maxF);
+            color.setRgbF(static_cast<float>(low / maxF),
+                    static_cast<float>(mid / maxF),
+                    static_cast<float>(high / maxF));
             painter.setPen(color);
             painter.drawLine(x, -all, x, 0);
         }
 
+        // paint right channel
         all = pWaveform->getAll(i + 1);
         low = pWaveform->getLow(i + 1);
         mid = pWaveform->getMid(i + 1);
@@ -40,7 +44,9 @@ QImage WaveformOverviewRenderer::render(ConstWaveformPointer pWaveform) const {
         maxF = static_cast<qreal>(max);
 
         if (maxF > 0.0) {
-            color.setRgbF(low / maxF, mid / maxF, high / maxF);
+            color.setRgbF(static_cast<float>(low / maxF),
+                    static_cast<float>(mid / maxF),
+                    static_cast<float>(high / maxF));
             painter.setPen(color);
             painter.drawLine(x, 0, x, all);
         }

--- a/src/waveform/overviews/waveformoverviewrenderer.cpp
+++ b/src/waveform/overviews/waveformoverviewrenderer.cpp
@@ -5,6 +5,44 @@
 #include "util/colorcomponents.h"
 #include "util/math.h"
 
+QColor WaveformOverviewRenderer::s_rgbLowColor = defaultLowColor;
+QColor WaveformOverviewRenderer::s_rgbMidColor = defaultMidColor;
+QColor WaveformOverviewRenderer::s_rgbHighColor = defaultHighColor;
+
+QColor WaveformOverviewRenderer::s_filteredLowColor = defaultLowColor;
+QColor WaveformOverviewRenderer::s_filteredMidColor = defaultMidColor;
+QColor WaveformOverviewRenderer::s_filteredHighColor = defaultHighColor;
+
+QColor WaveformOverviewRenderer::s_signalColor = defaultSignalColor;
+
+void WaveformOverviewRenderer::setRgbLowColor(QColor color) {
+    s_rgbLowColor = color;
+}
+
+void WaveformOverviewRenderer::setRgbMidColor(QColor color) {
+    s_rgbMidColor = color;
+}
+
+void WaveformOverviewRenderer::setRgbHighColor(QColor color) {
+    s_rgbHighColor = color;
+}
+
+void WaveformOverviewRenderer::setFilteredLowColor(QColor color) {
+    s_filteredLowColor = color;
+}
+
+void WaveformOverviewRenderer::setFilteredMidColor(QColor color) {
+    s_filteredMidColor = color;
+}
+
+void WaveformOverviewRenderer::setFilteredHighColor(QColor color) {
+    s_filteredHighColor = color;
+}
+
+void WaveformOverviewRenderer::setSignalColor(QColor color) {
+    s_signalColor = color;
+}
+
 QImage WaveformOverviewRenderer::render(ConstWaveformPointer pWaveform,
         WOverview::Type type) {
     const int dataSize = pWaveform->getDataSize();
@@ -19,11 +57,27 @@ QImage WaveformOverviewRenderer::render(ConstWaveformPointer pWaveform,
     painter.translate(0.0, static_cast<double>(image.height()) / 2.0);
 
     if (type == WOverview::Type::HSV) {
-        drawWaveformPartHSV(&painter, pWaveform, nullptr, dataSize);
+        drawWaveformPartHSV(&painter,
+                pWaveform,
+                nullptr,
+                dataSize,
+                s_signalColor);
     } else if (type == WOverview::Type::Filtered) {
-        drawWaveformPartLMH(&painter, pWaveform, nullptr, dataSize);
+        drawWaveformPartLMH(&painter,
+                pWaveform,
+                nullptr,
+                dataSize,
+                s_filteredLowColor,
+                s_filteredMidColor,
+                s_filteredHighColor);
     } else {
-        drawWaveformPartRGB(&painter, pWaveform, nullptr, dataSize);
+        drawWaveformPartRGB(&painter,
+                pWaveform,
+                nullptr,
+                dataSize,
+                s_rgbLowColor,
+                s_rgbMidColor,
+                s_rgbHighColor);
     }
 
     return image;

--- a/src/waveform/overviews/waveformoverviewrenderer.cpp
+++ b/src/waveform/overviews/waveformoverviewrenderer.cpp
@@ -44,7 +44,7 @@ void WaveformOverviewRenderer::setSignalColor(QColor color) {
 }
 
 QImage WaveformOverviewRenderer::render(ConstWaveformPointer pWaveform,
-        WOverview::Type type) {
+        mixxx::OverviewType type) {
     const int dataSize = pWaveform->getDataSize();
     if (dataSize <= 0) {
         return QImage();
@@ -56,13 +56,13 @@ QImage WaveformOverviewRenderer::render(ConstWaveformPointer pWaveform,
     QPainter painter(&image);
     painter.translate(0.0, static_cast<double>(image.height()) / 2.0);
 
-    if (type == WOverview::Type::HSV) {
+    if (type == mixxx::OverviewType::HSV) {
         drawWaveformPartHSV(&painter,
                 pWaveform,
                 nullptr,
                 dataSize,
                 s_signalColor);
-    } else if (type == WOverview::Type::Filtered) {
+    } else if (type == mixxx::OverviewType::Filtered) {
         drawWaveformPartLMH(&painter,
                 pWaveform,
                 nullptr,

--- a/src/waveform/overviews/waveformoverviewrenderer.h
+++ b/src/waveform/overviews/waveformoverviewrenderer.h
@@ -6,14 +6,4 @@
 class WaveformOverviewRenderer : public Singleton<WaveformOverviewRenderer> {
   public:
     QImage render(ConstWaveformPointer) const;
-
-    // QImage renderToImage() const;
-
-    /*
-    // We do not lock the mutex since m_dataSize and m_visualSampleRate are not
-    // changed after the constructor runs.
-    bool isValid() const {
-        return getDataSize() > 0 && getVisualSampleRate() > 0;
-    }
-*/
 };

--- a/src/waveform/overviews/waveformoverviewrenderer.h
+++ b/src/waveform/overviews/waveformoverviewrenderer.h
@@ -1,9 +1,35 @@
 #pragma once
 
+#include <QColor>
+
 #include "util/singleton.h"
 #include "waveform/waveform.h"
 
+class QPainter;
+
 class WaveformOverviewRenderer : public Singleton<WaveformOverviewRenderer> {
   public:
-    QImage render(ConstWaveformPointer) const;
+    QImage renderRGB(ConstWaveformPointer);
+    void drawWaveformPartRGB(
+            QPainter* pPainter,
+            ConstWaveformPointer pWaveform,
+            int* start,
+            int end,
+            QColor lowColor = Qt::red,
+            QColor midColor = Qt::green,
+            QColor highColor = Qt::blue);
+    void drawWaveformPartLMH(
+            QPainter* pPainter,
+            ConstWaveformPointer pWaveform,
+            int* start,
+            int end,
+            QColor lowColor = Qt::red,
+            QColor midColor = Qt::green,
+            QColor highColor = Qt::blue);
+    void drawWaveformPartHSV(
+            QPainter* pPainter,
+            ConstWaveformPointer pWaveform,
+            int* start,
+            int end,
+            QColor lowColor = Qt::lightGray);
 };

--- a/src/waveform/overviews/waveformoverviewrenderer.h
+++ b/src/waveform/overviews/waveformoverviewrenderer.h
@@ -4,12 +4,13 @@
 
 #include "util/singleton.h"
 #include "waveform/waveform.h"
+#include "widget/woverview.h"
 
 class QPainter;
 
 class WaveformOverviewRenderer : public Singleton<WaveformOverviewRenderer> {
   public:
-    QImage renderRGB(ConstWaveformPointer);
+    QImage render(ConstWaveformPointer, WOverview::Type type);
     void drawWaveformPartRGB(
             QPainter* pPainter,
             ConstWaveformPointer pWaveform,

--- a/src/waveform/overviews/waveformoverviewrenderer.h
+++ b/src/waveform/overviews/waveformoverviewrenderer.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "util/singleton.h"
+#include "waveform/waveform.h"
+
+class WaveformOverviewRenderer : public Singleton<WaveformOverviewRenderer> {
+  public:
+    QImage render(ConstWaveformPointer) const;
+
+    // QImage renderToImage() const;
+
+    /*
+    // We do not lock the mutex since m_dataSize and m_visualSampleRate are not
+    // changed after the constructor runs.
+    bool isValid() const {
+        return getDataSize() > 0 && getVisualSampleRate() > 0;
+    }
+*/
+};

--- a/src/waveform/overviews/waveformoverviewrenderer.h
+++ b/src/waveform/overviews/waveformoverviewrenderer.h
@@ -2,16 +2,15 @@
 
 #include <QColor>
 
-#include "util/singleton.h"
 #include "waveform/waveform.h"
 #include "widget/woverview.h"
 
 class QPainter;
 
-class WaveformOverviewRenderer : public Singleton<WaveformOverviewRenderer> {
+class WaveformOverviewRenderer {
   public:
-    QImage render(ConstWaveformPointer, WOverview::Type type);
-    void drawWaveformPartRGB(
+    static QImage render(ConstWaveformPointer, WOverview::Type type);
+    static void drawWaveformPartRGB(
             QPainter* pPainter,
             ConstWaveformPointer pWaveform,
             int* start,
@@ -19,7 +18,7 @@ class WaveformOverviewRenderer : public Singleton<WaveformOverviewRenderer> {
             QColor rgbLowColor,
             QColor rgbMidColor,
             QColor rgbHighColor);
-    void drawWaveformPartLMH(
+    static void drawWaveformPartLMH(
             QPainter* pPainter,
             ConstWaveformPointer pWaveform,
             int* start,
@@ -27,7 +26,7 @@ class WaveformOverviewRenderer : public Singleton<WaveformOverviewRenderer> {
             QColor lowColor,
             QColor midColor,
             QColor highColor);
-    void drawWaveformPartHSV(
+    static void drawWaveformPartHSV(
             QPainter* pPainter,
             ConstWaveformPointer pWaveform,
             int* start,

--- a/src/waveform/overviews/waveformoverviewrenderer.h
+++ b/src/waveform/overviews/waveformoverviewrenderer.h
@@ -2,14 +2,14 @@
 
 #include <QColor>
 
+#include "waveform/overviews/overviewtype.h"
 #include "waveform/waveform.h"
-#include "widget/woverview.h"
 
 class QPainter;
 
 class WaveformOverviewRenderer {
   public:
-    static QImage render(ConstWaveformPointer, WOverview::Type type);
+    static QImage render(ConstWaveformPointer, mixxx::OverviewType type);
     static void drawWaveformPartRGB(
             QPainter* pPainter,
             ConstWaveformPointer pWaveform,

--- a/src/waveform/overviews/waveformoverviewrenderer.h
+++ b/src/waveform/overviews/waveformoverviewrenderer.h
@@ -16,21 +16,45 @@ class WaveformOverviewRenderer : public Singleton<WaveformOverviewRenderer> {
             ConstWaveformPointer pWaveform,
             int* start,
             int end,
-            QColor lowColor = Qt::red,
-            QColor midColor = Qt::green,
-            QColor highColor = Qt::blue);
+            QColor rgbLowColor,
+            QColor rgbMidColor,
+            QColor rgbHighColor);
     void drawWaveformPartLMH(
             QPainter* pPainter,
             ConstWaveformPointer pWaveform,
             int* start,
             int end,
-            QColor lowColor = Qt::red,
-            QColor midColor = Qt::green,
-            QColor highColor = Qt::blue);
+            QColor lowColor,
+            QColor midColor,
+            QColor highColor);
     void drawWaveformPartHSV(
             QPainter* pPainter,
             ConstWaveformPointer pWaveform,
             int* start,
             int end,
-            QColor lowColor = Qt::lightGray);
+            QColor lowColor);
+
+    static void setRgbLowColor(QColor rgbLow);
+    static void setRgbMidColor(QColor color);
+    static void setRgbHighColor(QColor color);
+    static void setFilteredLowColor(QColor color);
+    static void setFilteredMidColor(QColor color);
+    static void setFilteredHighColor(QColor color);
+    static void setSignalColor(QColor color);
+
+    static constexpr QColor defaultLowColor = QColor(255, 0, 0);
+    static constexpr QColor defaultMidColor = QColor(0, 255, 0);
+    static constexpr QColor defaultHighColor = QColor(0, 0, 255);
+
+    static constexpr QColor defaultSignalColor = QColor(200, 200, 200);
+
+    static QColor s_rgbLowColor;
+    static QColor s_rgbMidColor;
+    static QColor s_rgbHighColor;
+
+    static QColor s_filteredLowColor;
+    static QColor s_filteredMidColor;
+    static QColor s_filteredHighColor;
+
+    static QColor s_signalColor;
 };

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -1379,7 +1379,7 @@ bool WOverview::drawNextPixmapPart() {
 
     if (m_type == Type::Filtered) {
         ScopedTimer t(QStringLiteral("WOverview::drawNextPixmapPartLMH"));
-        WaveformOverviewRenderer::instance()->drawWaveformPartLMH(
+        WaveformOverviewRenderer::drawWaveformPartLMH(
                 &painter,
                 pWaveform,
                 &m_actualCompletion,
@@ -1389,7 +1389,7 @@ bool WOverview::drawNextPixmapPart() {
                 m_signalColors.getHighColor());
     } else if (m_type == Type::HSV) {
         ScopedTimer t(QStringLiteral("WOverview::drawNextPixmapPartHSV"));
-        WaveformOverviewRenderer::instance()->drawWaveformPartHSV(
+        WaveformOverviewRenderer::drawWaveformPartHSV(
                 &painter,
                 pWaveform,
                 &m_actualCompletion,
@@ -1397,7 +1397,7 @@ bool WOverview::drawNextPixmapPart() {
                 m_signalColors.getSignalColor());
     } else { // Type::RGB:
         ScopedTimer t(QStringLiteral("WOverview::drawNextPixmapPartRGB"));
-        WaveformOverviewRenderer::instance()->drawWaveformPartRGB(
+        WaveformOverviewRenderer::drawWaveformPartRGB(
                 &painter,
                 pWaveform,
                 &m_actualCompletion,

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -21,6 +21,7 @@
 #include "util/math.h"
 #include "util/painterscope.h"
 #include "util/timer.h"
+#include "waveform/overviews/waveformoverviewrenderer.h"
 #include "waveform/waveform.h"
 #include "waveform/waveformwidgetfactory.h"
 #include "widget/controlwidgetconnection.h"
@@ -1365,12 +1366,45 @@ bool WOverview::drawNextPixmapPart() {
     QPainter painter(&m_waveformSourceImage);
     painter.translate(0.0, static_cast<double>(m_waveformSourceImage.height()) / 2.0);
 
+    // Evaluate waveform ratio peak
+    for (int currentCompletion = m_actualCompletion;
+            currentCompletion < nextCompletion;
+            currentCompletion += 2) {
+        m_waveformPeak = math_max3(
+                m_waveformPeak,
+                static_cast<float>(pWaveform->getAll(currentCompletion)),
+                static_cast<float>(pWaveform->getAll(currentCompletion + 1)));
+    }
+    // qDebug() << "m_waveformPeakRatio" << m_waveformPeak;
+
     if (m_type == Type::Filtered) {
-        drawNextPixmapPartLMH(&painter, pWaveform, nextCompletion);
+        ScopedTimer t(QStringLiteral("WOverview::drawNextPixmapPartLMH"));
+        WaveformOverviewRenderer::instance()->drawWaveformPartLMH(
+                &painter,
+                pWaveform,
+                &m_actualCompletion,
+                nextCompletion,
+                m_signalColors.getLowColor(),
+                m_signalColors.getMidColor(),
+                m_signalColors.getHighColor());
     } else if (m_type == Type::HSV) {
-        drawNextPixmapPartHSV(&painter, pWaveform, nextCompletion);
+        ScopedTimer t(QStringLiteral("WOverview::drawNextPixmapPartHSV"));
+        WaveformOverviewRenderer::instance()->drawWaveformPartHSV(
+                &painter,
+                pWaveform,
+                &m_actualCompletion,
+                nextCompletion,
+                m_signalColors.getLowColor());
     } else { // Type::RGB:
-        drawNextPixmapPartRGB(&painter, pWaveform, nextCompletion);
+        ScopedTimer t(QStringLiteral("WOverview::drawNextPixmapPartRGB"));
+        WaveformOverviewRenderer::instance()->drawWaveformPartRGB(
+                &painter,
+                pWaveform,
+                &m_actualCompletion,
+                nextCompletion,
+                m_signalColors.getRgbLowColor(),
+                m_signalColors.getRgbMidColor(),
+                m_signalColors.getRgbHighColor());
     }
 
     m_waveformImageScaled = QImage();
@@ -1379,216 +1413,9 @@ bool WOverview::drawNextPixmapPart() {
     // Test if the complete waveform is done
     if (m_actualCompletion >= dataSize - 2) {
         m_pixmapDone = true;
-        // qDebug() << "m_waveformPeakRatio" << m_waveformPeak;
     }
 
     return true;
-}
-
-void WOverview::drawNextPixmapPartHSV(QPainter* pPainter,
-        ConstWaveformPointer pWaveform,
-        const int nextCompletion) {
-    DEBUG_ASSERT(!m_waveformSourceImage.isNull());
-    ScopedTimer t(QStringLiteral("WOverview::drawNextPixmapPartHSV"));
-
-    // Get HSV of low color.
-    float h, s, v;
-    getHsvF(m_signalColors.getLowColor(), &h, &s, &v);
-
-    QColor color;
-    float lo, hi, total;
-
-    unsigned char maxLow[2] = {0, 0};
-    unsigned char maxHigh[2] = {0, 0};
-    unsigned char maxMid[2] = {0, 0};
-    unsigned char maxAll[2] = {0, 0};
-
-    int currentCompletion = 0;
-    for (int currentCompletion = m_actualCompletion;
-            currentCompletion < nextCompletion;
-            currentCompletion += 2) {
-        maxAll[0] = pWaveform->getAll(currentCompletion);
-        maxAll[1] = pWaveform->getAll(currentCompletion + 1);
-        if (maxAll[0] || maxAll[1]) {
-            maxLow[0] = pWaveform->getLow(currentCompletion);
-            maxLow[1] = pWaveform->getLow(currentCompletion + 1);
-            maxMid[0] = pWaveform->getMid(currentCompletion);
-            maxMid[1] = pWaveform->getMid(currentCompletion + 1);
-            maxHigh[0] = pWaveform->getHigh(currentCompletion);
-            maxHigh[1] = pWaveform->getHigh(currentCompletion + 1);
-
-            total = (maxLow[0] + maxLow[1] + maxMid[0] + maxMid[1] +
-                            maxHigh[0] + maxHigh[1]) *
-                    1.2f;
-
-            // Prevent division by zero
-            if (total > 0) {
-                // Normalize low and high
-                // (mid not need, because it not change the color)
-                lo = (maxLow[0] + maxLow[1]) / total;
-                hi = (maxHigh[0] + maxHigh[1]) / total;
-            } else {
-                lo = hi = 0.0;
-            }
-
-            // Set color
-            color.setHsvF(h, 1.0f - hi, 1.0f - lo);
-
-            pPainter->setPen(color);
-            pPainter->drawLine(QPoint(currentCompletion / 2, -maxAll[0]),
-                    QPoint(currentCompletion / 2, maxAll[1]));
-        }
-    }
-
-    // Evaluate waveform ratio peak
-    for (currentCompletion = m_actualCompletion;
-            currentCompletion < nextCompletion;
-            currentCompletion += 2) {
-        m_waveformPeak = math_max3(
-                m_waveformPeak,
-                static_cast<float>(pWaveform->getAll(currentCompletion)),
-                static_cast<float>(pWaveform->getAll(currentCompletion + 1)));
-    }
-
-    m_actualCompletion = nextCompletion;
-}
-
-void WOverview::drawNextPixmapPartLMH(QPainter* pPainter,
-        ConstWaveformPointer pWaveform,
-        const int nextCompletion) {
-    DEBUG_ASSERT(!m_waveformSourceImage.isNull());
-    ScopedTimer t(QStringLiteral("WOverview::drawNextPixmapPartLMH"));
-
-    QColor lowColor = m_signalColors.getLowColor();
-    QPen lowColorPen(QBrush(lowColor), 1);
-
-    QColor midColor = m_signalColors.getMidColor();
-    QPen midColorPen(QBrush(midColor), 1);
-
-    QColor highColor = m_signalColors.getHighColor();
-    QPen highColorPen(QBrush(highColor), 1);
-
-    int currentCompletion = 0;
-    for (currentCompletion = m_actualCompletion;
-            currentCompletion < nextCompletion;
-            currentCompletion += 2) {
-        unsigned char lowNeg = pWaveform->getLow(currentCompletion);
-        unsigned char lowPos = pWaveform->getLow(currentCompletion + 1);
-        if (lowPos || lowNeg) {
-            pPainter->setPen(lowColorPen);
-            pPainter->drawLine(QPoint(currentCompletion / 2, -lowNeg),
-                    QPoint(currentCompletion / 2, lowPos));
-        }
-    }
-
-    for (currentCompletion = m_actualCompletion;
-            currentCompletion < nextCompletion;
-            currentCompletion += 2) {
-        pPainter->setPen(midColorPen);
-        pPainter->drawLine(QPoint(currentCompletion / 2,
-                                   -pWaveform->getMid(currentCompletion)),
-                QPoint(currentCompletion / 2,
-                        pWaveform->getMid(currentCompletion + 1)));
-    }
-
-    for (currentCompletion = m_actualCompletion;
-            currentCompletion < nextCompletion;
-            currentCompletion += 2) {
-        pPainter->setPen(highColorPen);
-        pPainter->drawLine(QPoint(currentCompletion / 2,
-                                   -pWaveform->getHigh(currentCompletion)),
-                QPoint(currentCompletion / 2,
-                        pWaveform->getHigh(currentCompletion + 1)));
-    }
-
-    // Evaluate waveform ratio peak
-
-    for (currentCompletion = m_actualCompletion;
-            currentCompletion < nextCompletion;
-            currentCompletion += 2) {
-        m_waveformPeak = math_max3(
-                m_waveformPeak,
-                static_cast<float>(pWaveform->getAll(currentCompletion)),
-                static_cast<float>(pWaveform->getAll(currentCompletion + 1)));
-    }
-
-    m_actualCompletion = nextCompletion;
-}
-
-void WOverview::drawNextPixmapPartRGB(QPainter* pPainter,
-        ConstWaveformPointer pWaveform,
-        const int nextCompletion) {
-    DEBUG_ASSERT(!m_waveformSourceImage.isNull());
-    ScopedTimer t(QStringLiteral("WOverview::drawNextPixmapPartRGB"));
-
-    QColor color;
-
-    float lowColor_r, lowColor_g, lowColor_b;
-    getRgbF(m_signalColors.getRgbLowColor(), &lowColor_r, &lowColor_g, &lowColor_b);
-
-    float midColor_r, midColor_g, midColor_b;
-    getRgbF(m_signalColors.getRgbMidColor(), &midColor_r, &midColor_g, &midColor_b);
-
-    float highColor_r, highColor_g, highColor_b;
-    getRgbF(m_signalColors.getRgbHighColor(), &highColor_r, &highColor_g, &highColor_b);
-
-    int currentCompletion = 0;
-    for (currentCompletion = m_actualCompletion;
-            currentCompletion < nextCompletion;
-            currentCompletion += 2) {
-        unsigned char left = pWaveform->getAll(currentCompletion);
-        unsigned char right = pWaveform->getAll(currentCompletion + 1);
-
-        // Retrieve "raw" LMH values from waveform
-        float low = static_cast<float>(pWaveform->getLow(currentCompletion));
-        float mid = static_cast<float>(pWaveform->getMid(currentCompletion));
-        float high = static_cast<float>(pWaveform->getHigh(currentCompletion));
-
-        // Do matrix multiplication
-        float red = low * lowColor_r + mid * midColor_r + high * highColor_r;
-        float green = low * lowColor_g + mid * midColor_g + high * highColor_g;
-        float blue = low * lowColor_b + mid * midColor_b + high * highColor_b;
-
-        // Normalize and draw
-        float max = math_max3(red, green, blue);
-        if (max > 0.0) {
-            color.setRgbF(red / max, green / max, blue / max);
-            pPainter->setPen(color);
-            pPainter->drawLine(QPointF(currentCompletion / 2, -left),
-                    QPointF(currentCompletion / 2, 0));
-        }
-
-        // Retrieve "raw" LMH values from waveform
-        low = static_cast<float>(pWaveform->getLow(currentCompletion + 1));
-        mid = static_cast<float>(pWaveform->getMid(currentCompletion + 1));
-        high = static_cast<float>(pWaveform->getHigh(currentCompletion + 1));
-
-        // Do matrix multiplication
-        red = low * lowColor_r + mid * midColor_r + high * highColor_r;
-        green = low * lowColor_g + mid * midColor_g + high * highColor_g;
-        blue = low * lowColor_b + mid * midColor_b + high * highColor_b;
-
-        // Normalize and draw
-        max = math_max3(red, green, blue);
-        if (max > 0.0) {
-            color.setRgbF(red / max, green / max, blue / max);
-            pPainter->setPen(color);
-            pPainter->drawLine(QPointF(currentCompletion / 2, 0),
-                    QPointF(currentCompletion / 2, right));
-        }
-    }
-
-    // Evaluate waveform ratio peak
-    for (currentCompletion = m_actualCompletion;
-            currentCompletion < nextCompletion;
-            currentCompletion += 2) {
-        m_waveformPeak = math_max3(
-                m_waveformPeak,
-                static_cast<float>(pWaveform->getAll(currentCompletion)),
-                static_cast<float>(pWaveform->getAll(currentCompletion + 1)));
-    }
-
-    m_actualCompletion = nextCompletion;
 }
 
 void WOverview::paintText(const QString& text, QPainter* pPainter) {

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -1394,7 +1394,7 @@ bool WOverview::drawNextPixmapPart() {
                 pWaveform,
                 &m_actualCompletion,
                 nextCompletion,
-                m_signalColors.getLowColor());
+                m_signalColors.getSignalColor());
     } else { // Type::RGB:
         ScopedTimer t(QStringLiteral("WOverview::drawNextPixmapPartRGB"));
         WaveformOverviewRenderer::instance()->drawWaveformPartRGB(

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -35,7 +35,7 @@ WOverview::WOverview(
         : WWidget(parent),
           m_group(group),
           m_pConfig(pConfig),
-          m_type(Type::RGB),
+          m_type(mixxx::OverviewType::RGB),
           m_actualCompletion(0),
           m_pixmapDone(false),
           m_waveformPeak(-1.0),
@@ -428,8 +428,8 @@ void WOverview::onPassthroughChange(double v) {
 
 void WOverview::slotTypeControlChanged(double v) {
     // Assert that v is in enum range to prevent UB.
-    DEBUG_ASSERT(v >= 0 && v < QMetaEnum::fromType<Type>().keyCount());
-    Type type = static_cast<Type>(static_cast<int>(v));
+    DEBUG_ASSERT(v >= 0 && v < QMetaEnum::fromType<mixxx::OverviewType>().keyCount());
+    mixxx::OverviewType type = static_cast<mixxx::OverviewType>(static_cast<int>(v));
     if (type == m_type) {
         return;
     }
@@ -1377,7 +1377,7 @@ bool WOverview::drawNextPixmapPart() {
     }
     // qDebug() << "m_waveformPeakRatio" << m_waveformPeak;
 
-    if (m_type == Type::Filtered) {
+    if (m_type == mixxx::OverviewType::Filtered) {
         ScopedTimer t(QStringLiteral("WOverview::drawNextPixmapPartLMH"));
         WaveformOverviewRenderer::drawWaveformPartLMH(
                 &painter,
@@ -1387,7 +1387,7 @@ bool WOverview::drawNextPixmapPart() {
                 m_signalColors.getLowColor(),
                 m_signalColors.getMidColor(),
                 m_signalColors.getHighColor());
-    } else if (m_type == Type::HSV) {
+    } else if (m_type == mixxx::OverviewType::HSV) {
         ScopedTimer t(QStringLiteral("WOverview::drawNextPixmapPartHSV"));
         WaveformOverviewRenderer::drawWaveformPartHSV(
                 &painter,
@@ -1395,7 +1395,7 @@ bool WOverview::drawNextPixmapPart() {
                 &m_actualCompletion,
                 nextCompletion,
                 m_signalColors.getSignalColor());
-    } else { // Type::RGB:
+    } else { // mixxx::OverviewType::RGB:
         ScopedTimer t(QStringLiteral("WOverview::drawNextPixmapPartRGB"));
         WaveformOverviewRenderer::drawWaveformPartRGB(
                 &painter,

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -8,6 +8,7 @@
 #include "track/track_decl.h"
 #include "track/trackid.h"
 #include "util/parented_ptr.h"
+#include "waveform/overviews/overviewtype.h"
 #include "waveform/renderers/waveformmarkrange.h"
 #include "waveform/renderers/waveformmarkset.h"
 #include "waveform/renderers/waveformsignalcolors.h"
@@ -31,13 +32,6 @@ class WOverview : public WWidget, public TrackDropTarget {
 
     void setup(const QDomNode& node, const SkinContext& context);
     virtual void initWithTrack(TrackPointer pTrack);
-
-    enum class Type {
-        Filtered,
-        HSV,
-        RGB,
-    };
-    Q_ENUM(Type);
 
   public slots:
     void onConnectedControlChanged(double dParameter, double dValue) override;
@@ -143,7 +137,7 @@ class WOverview : public WWidget, public TrackDropTarget {
     const QString m_group;
     UserSettingsPointer m_pConfig;
 
-    Type m_type;
+    mixxx::OverviewType m_type;
     int m_actualCompletion;
     bool m_pixmapDone;
     float m_waveformPeak;


### PR DESCRIPTION
This is based on @ninomp's initial POC commit 9932cfcba93a2931271e9e8a612ead5b1374a32b
https://github.com/ninomp/mixxx/tree/overviewsinlibrary

I removed the disabled parts and added some TODOs/concerns.
(I'll split up some of the commits so it's a bit easier to review)
![image](https://github.com/user-attachments/assets/b7269bb8-5c90-4560-8ce6-9893c36f0465)

* all overview renderers are now in src/waveform/overviews, i.e. WOverView and OverviewDelegate use the same renderer
(I adopted the RGB simplifications made by @**Nino MP**, and simplified the others, too)
* the renderer selected for the decks is also used in the library (incl. live update when changing it in the preferences)

Peforms nicely, though I bet some parts can be optimized.
For example, why pass a `mixxx::DbConnectionPoolPtr` to `static FutureResult OverviewCache::prepareOverview` to create a AnyalysisDAO for each request, and not a AnyalysisDAO pointer (probably in TrackCollection)?

