### PR TITLE
feat: use clang-tidy lint readability-identifier-naming

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,7 +7,8 @@ Checks: >-
   modernize-use-override,
   readability-braces-around-statements,
   readability-non-const-parameter,
-  readability-qualified-auto
+  readability-qualified-auto,
+  readability-identifier-naming
 WarningsAsErrors: ""
 HeaderFilterRegex: ""
 FormatStyle: none
@@ -23,3 +24,21 @@ CheckOptions:
     value: true
   - key: modernize-use-nullptr.NullMacros
     value: "NULL"
+  - key: readability-identifier-naming.ClassCase
+    value: CamelCase
+  - key: readability-identifier-naming.ClassConstantPrefix
+    value: k
+  - key: readability-identifier-naming.ClassMemberPrefix
+    value: m_
+  - key: readability-identifier-naming.ConstexprVariablePrefix
+    value: k # constexpr implies const and (likely) known at compile-time and thus k by our rules
+  - key: readability-identifier-naming.GlobalConstantPrefix
+    value: k
+  - key: readability-identifier-naming.LocalPointerPrefix
+    value: p
+  - key: readability-identifier-naming.PointerParameterPrefix
+    value: p
+  - key: readability-identifier-naming.ScopedEnumConstantCase
+    value: CamelCase
+  - key: readability-identifier-naming.ClassMemberPrefix
+    value: k

--- a/.github/workflows/build-checks.yml
+++ b/.github/workflows/build-checks.yml
@@ -87,13 +87,6 @@ jobs:
         working-directory: build
       - name: Set up problem matcher
         uses: ammaraskar/gcc-problem-matcher@0.3.0
-      # Work around https://github.com/actions/runner-images/issues/8659
-      - name: "Remove GCC 13 from runner image (workaround)"
-        shell: bash
-        run: |
-          sudo rm -f /etc/apt/sources.list.d/ubuntu-toolchain-r-ubuntu-test-jammy.list
-          sudo apt-get update
-          sudo apt-get install -y --allow-downgrades libc6=2.35* libc6-dev=2.35* libstdc++6=12.3.0-1ubuntu1~22.04 libgcc-s1=12.3.0-1ubuntu1~22.04
       - name: Build
         # Do not abort on errors and build/check the whole project
         run: cmake --build . -j $(nproc) -- --keep-going

--- a/.github/workflows/build-checks.yml
+++ b/.github/workflows/build-checks.yml
@@ -19,7 +19,6 @@ jobs:
       matrix:
         include:
           - name: clazy
-          - name: clang-tidy
           - name: coverage
     runs-on: ubuntu-22.04
     name: ${{ matrix.name }}
@@ -59,34 +58,6 @@ jobs:
           LD: clang++
           CC: clang
           CXX: clazy
-      - name: Configure (clang-tidy)
-        if: matrix.name == 'clang-tidy'
-        run: |
-          cmake \
-            -DCMAKE_BUILD_TYPE=Debug \
-            -DCLANG_TIDY=clang-tidy \
-            -DWARNINGS_FATAL=ON \
-            -DQT6=ON \
-            -DBATTERY=ON \
-            -DBROADCAST=ON \
-            -DBULK=ON \
-            -DHID=ON \
-            -DLILV=ON \
-            -DOPUS=ON \
-            -DQTKEYCHAIN=ON \
-            -DVINYLCONTROL=ON \
-            -DFFMPEG=ON \
-            -DKEYFINDER=ON \
-            -DLOCALECOMPARE=ON \
-            -DMAD=ON \
-            -DMODPLUG=ON \
-            -DWAVPACK=ON \
-            ..
-        working-directory: build
-        env:
-          LD: clang++
-          CC: clang
-          CXX: clang++
       - name: Configure (coverage)
         if: matrix.name == 'coverage'
         run: |

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -36,6 +36,30 @@ jobs:
         run: |
           git config --global --add safe.directory "${GITHUB_WORKSPACE}"
           git config --global --list
+      - name: "Create compile_commands.json"
+        # this is required for clang-tidy to work
+        run: |
+          cmake \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCLANG_TIDY=clang-tidy \
+            -DWARNINGS_FATAL=ON \
+            -DQT6=ON \
+            -DBATTERY=ON \
+            -DBROADCAST=ON \
+            -DBULK=ON \
+            -DHID=ON \
+            -DLILV=ON \
+            -DOPUS=ON \
+            -DQTKEYCHAIN=ON \
+            -DVINYLCONTROL=ON \
+            -DFFMPEG=ON \
+            -DKEYFINDER=ON \
+            -DLOCALECOMPARE=ON \
+            -DMAD=ON \
+            -DMODPLUG=ON \
+            -DWAVPACK=ON \
+            ..
+        working-directory: build
 
       - name: "Detect code style issues (push)"
         uses: pre-commit/action@v3.0.1
@@ -44,7 +68,7 @@ jobs:
         # disable these checks for now when pushing directly (but still run these
         # on Pull Requests!).
         env:
-          SKIP: clang-format,eslint,no-commit-to-branch
+          SKIP: clang-format,clang-tidy,eslint,no-commit-to-branch
 
       - name: "Detect code style issues (pull_request)"
         uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     # The Dockerfile for this container can be found at:
     # https://github.com/Holzhaus/mixxx-ci-docker
-    container: holzhaus/mixxx-ci:20220930
+    container: holzhaus/mixxx-ci:20220612-qt6
     steps:
       - name: "Check out repository"
         uses: actions/checkout@v4.1.7

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -36,6 +36,10 @@ jobs:
         run: |
           git config --global --add safe.directory "${GITHUB_WORKSPACE}"
           git config --global --list
+
+      - name: "Create build directory"
+        run: mkdir build
+
       - name: "Create compile_commands.json"
         # this is required for clang-tidy to work
         run: |

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,9 +13,6 @@ jobs:
   pre-commit:
     name: Detecting code style issues
     runs-on: ubuntu-latest
-    # The Dockerfile for this container can be found at:
-    # https://github.com/Holzhaus/mixxx-ci-docker
-    container: holzhaus/mixxx-ci:20220612-qt6
     steps:
       - name: "Check out repository"
         uses: actions/checkout@v4.1.7
@@ -36,10 +33,10 @@ jobs:
         run: |
           git config --global --add safe.directory "${GITHUB_WORKSPACE}"
           git config --global --list
-
+      - name: Install build dependencies
+        run: tools/debian_buildenv.sh setup
       - name: "Create build directory"
         run: mkdir build
-
       - name: "Create compile_commands.json"
         # this is required for clang-tidy to work
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -95,6 +95,14 @@ repos:
         additional_dependencies:
           - clang-format==16.0.6
         files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|m|mm|proto|vert)$
+      - id: clang-tidy
+        name: clang-tidy
+        require_serial: true
+        entry: python tools/clang_tidy.py
+        language: python
+        files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|m|mm|vert)$
+        additional_dependencies:
+          - clang-tidy==18.1.8
   - repo: https://github.com/psf/black
     rev: 24.4.2
     hooks:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1546,6 +1546,7 @@ endif()
 
 set_source_files_properties(src/util/moc_included_test.cpp PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
 
+set_target_properties(mixxx-lib PROPERTIES AUTOMOC ON AUTOUIC ON)
 target_include_directories(mixxx-lib PUBLIC src "${CMAKE_CURRENT_BINARY_DIR}/src")
 if(UNIX AND NOT APPLE)
   target_sources(mixxx-lib PRIVATE src/util/rlimit.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -689,8 +689,6 @@ if(CMAKE_VERSION VERSION_LESS "3.7.0")
   set(CMAKE_INCLUDE_CURRENT_DIR ON)
 endif()
 
-set(CLANG_TIDY "" CACHE STRING "CMAKE_CXX_CLANG_TIDY equivalent that only applies to mixxx sources, not bundled dependencies")
-
 # Mixxx itself
 add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/analyzer/analyzerbeats.cpp
@@ -1548,7 +1546,6 @@ endif()
 
 set_source_files_properties(src/util/moc_included_test.cpp PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
 
-set_target_properties(mixxx-lib PROPERTIES AUTOMOC ON AUTOUIC ON CXX_CLANG_TIDY "${CLANG_TIDY}")
 target_include_directories(mixxx-lib PUBLIC src "${CMAKE_CURRENT_BINARY_DIR}/src")
 if(UNIX AND NOT APPLE)
   target_sources(mixxx-lib PRIVATE src/util/rlimit.cpp)
@@ -1781,7 +1778,6 @@ else()
   add_executable(mixxx WIN32 src/main.cpp)
 endif()
 
-set_target_properties(mixxx-lib PROPERTIES CXX_CLANG_TIDY "${CLANG_TIDY}")
 target_link_libraries(mixxx PRIVATE mixxx-lib mixxx-gitinfostore)
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,6 +213,8 @@ set(MIXXX_VERSION_PRERELEASE "alpha") # set to "alpha" "beta" or ""
 set(CMAKE_PROJECT_HOMEPAGE_URL "https://www.mixxx.org")
 set(CMAKE_PROJECT_DESCRIPTION "Mixxx is Free DJ software that gives you everything you need to perform live mixes.")
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # Used for force control of color output
 set(BUILD_COLORS "auto" CACHE STRING "Try to use colors auto/always/no")
 

--- a/tools/clang_tidy.py
+++ b/tools/clang_tidy.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+import argparse
+import logging
+import os
+import subprocess
+import sys
+import typing
+import json
+
+import githelper
+
+
+# Function to transform FileLines to desired JSON format
+def file_lines_to_json(
+    file_lines_list: typing.List[githelper.FileLines],
+) -> str:
+    json_list = []
+    for file in file_lines_list:
+        # Transform each file to the desired format
+        file_obj = {"name": file.filename}
+        # Only include "lines" key if lines exist
+        if file.lines:
+            file_obj["lines"] = [list(line) for line in file.lines]
+        json_list.append(file_obj)
+
+    return json.dumps(json_list, separators=(",", ":"))
+
+
+def find_compile_commands(rootdir):
+    for root, dirs, files in os.walk(rootdir):
+        if "compile_commands.json" in files:
+            return os.path.join(root, "compile_commands.json")
+    return None
+
+
+def run_clang_tidy_on_lines(rootdir, lines, compile_commands):
+    logger = logging.getLogger(__name__)
+
+    line_filter = file_lines_to_json(lines)
+    assert line_filter
+
+    filenames = [os.path.join(rootdir, file.filename) for file in lines]
+
+    cmd = [
+        "clang-tidy",
+        "--format-style=file",
+        "--fix-notes",
+        "--fix-errors",
+        "--warnings-as-errors=*",
+        "-p=" + compile_commands,
+        "--line-filter=" + line_filter,
+        *filenames,
+    ]
+
+    logger.info(f"running on {line_filter}")
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        logger.error(proc.stdout)
+        sys.exit(1)
+
+
+def main(argv: typing.Optional[typing.List[str]] = None) -> int:
+    logging.basicConfig(
+        format="[%(levelname)s] %(message)s", level=logging.INFO
+    )
+
+    logger = logging.getLogger(__name__)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--from-ref", help="use changes changes since commit")
+    parser.add_argument("--to-ref", help="use changes until commit")
+    parser.add_argument("files", nargs="*", help="only check these files")
+    args = parser.parse_args(argv)
+
+    if not args.from_ref:
+        args.from_ref = os.getenv("PRE_COMMIT_FROM_REF") or os.getenv(
+            "PRE_COMMIT_SOURCE"
+        )
+
+    if not args.to_ref:
+        args.to_ref = os.getenv("PRE_COMMIT_TO_REF") or os.getenv(
+            "PRE_COMMIT_ORIGIN"
+        )
+
+    # Filter filenames
+    rootdir = githelper.get_toplevel_path()
+
+    logger.debug("Looking for compile_commands.json...")
+    compile_commands = find_compile_commands(rootdir)
+
+    logger.debug("getting changed lines")
+    changed_lines = githelper.get_changed_lines_grouped(
+        from_ref=args.from_ref,
+        to_ref=args.to_ref,
+        filter_lines=lambda line: line.added,
+        include_files=args.files,
+    )
+    logger.debug("running clang-tidy")
+    run_clang_tidy_on_lines(rootdir, list(changed_lines), compile_commands)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/clang_tidy.py
+++ b/tools/clang_tidy.py
@@ -89,6 +89,10 @@ def main(argv: typing.Optional[typing.List[str]] = None) -> int:
     logger.debug("Looking for compile_commands.json...")
     compile_commands = find_compile_commands(rootdir)
 
+    if not compile_commands:
+        logger.error("could not find compile_commands.json\n")
+        sys.exit(1)
+
     logger.debug("getting changed lines")
     changed_lines = githelper.get_changed_lines_grouped(
         from_ref=args.from_ref,


### PR DESCRIPTION
This is a best effort attempt to encode our naming rules in clang-tidy. This obviously creates a lot of warnings and we need to decide on how to resolve them. should I just go through in fix them all, risking merge conflicts?