### PR TITLE
WIP: Overviews in library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -988,6 +988,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/library/tabledelegates/keydelegate.cpp
   src/library/tabledelegates/locationdelegate.cpp
   src/library/tabledelegates/multilineeditdelegate.cpp
+  src/library/tabledelegates/overviewdelegate.cpp
   src/library/tabledelegates/previewbuttondelegate.cpp
   src/library/tabledelegates/stardelegate.cpp
   src/library/tabledelegates/stareditor.cpp
@@ -1209,6 +1210,9 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/util/workerthreadscheduler.cpp
   src/util/xml.cpp
   src/waveform/guitick.cpp
+  src/waveform/overviews/overviewcache.cpp
+  src/waveform/overviews/overviewrenderthread.cpp
+  src/waveform/overviews/overviewtype.cpp
   src/waveform/renderers/glwaveformrenderbackground.cpp
   src/waveform/renderers/glvsynctestrenderer.cpp
   src/waveform/renderers/waveformmark.cpp

--- a/res/skins/LateNight/library.xml
+++ b/res/skins/LateNight/library.xml
@@ -110,6 +110,15 @@
               <Library>
                 <ShowButtonText>false</ShowButtonText>
                 <TrackTableBackgroundColorOpacity>0.175</TrackTableBackgroundColorOpacity>
+                <!-- Waveform signal colors used for Overviews in library -->
+                <SignalColor>#fedcba</SignalColor>
+                <!-- Default colors are used for high/mid/low: blue/green/red -->
+                <SignalHighColor></SignalHighColor>
+                <SignalMidColor></SignalMidColor>
+                <SignalLowColor></SignalLowColor>
+                <SignalRGBHighColor></SignalRGBHighColor>
+                <SignalRGBMidColor></SignalRGBMidColor>
+                <SignalRGBLowColor></SignalRGBLowColor>
               </Library>
 
             </Children>

--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -58,6 +58,7 @@
 #include "util/translations.h"
 #include "util/versionstore.h"
 #include "vinylcontrol/vinylcontrolmanager.h"
+#include "waveform/overviews/overviewcache.h"
 
 #ifdef __APPLE__
 #include "util/sandbox.h"
@@ -358,6 +359,7 @@ void CoreServices::initialize(QApplication* pApp) {
     emit initializationProgressUpdate(50, tr("library"));
     CoverArtCache::createInstance();
     Clipboard::createInstance();
+    OverviewCache::createInstance(pConfig, m_pDbConnectionPool, m_pPlayerManager);
 
     m_pTrackCollectionManager = std::make_shared<TrackCollectionManager>(
             this,

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -14,6 +14,7 @@
 #include "library/tabledelegates/keydelegate.h"
 #include "library/tabledelegates/locationdelegate.h"
 #include "library/tabledelegates/multilineeditdelegate.h"
+#include "library/tabledelegates/overviewdelegate.h"
 #include "library/tabledelegates/previewbuttondelegate.h"
 #include "library/tabledelegates/stardelegate.h"
 #include "library/trackcollection.h"
@@ -69,6 +70,7 @@ const QStringList kDefaultTableColumns = {
         LIBRARYTABLE_TITLE,
         LIBRARYTABLE_TRACKNUMBER,
         LIBRARYTABLE_YEAR,
+        LIBRARYTABLE_WAVESUMMARYHEX,
 };
 
 inline QSqlDatabase cloneDatabase(
@@ -254,6 +256,9 @@ void BaseTrackTableModel::initHeaderProperties() {
             ColumnCache::COLUMN_TRACKLOCATIONSTABLE_LOCATION,
             tr("Location"),
             defaultColumnWidth() * 6);
+    setHeaderProperties(ColumnCache::COLUMN_LIBRARYTABLE_WAVESUMMARYHEX,
+            tr("Overview"),
+            defaultColumnWidth());
     setHeaderProperties(
             ColumnCache::COLUMN_LIBRARYTABLE_PREVIEW,
             tr("Preview"),
@@ -526,6 +531,23 @@ QAbstractItemDelegate* BaseTrackTableModel::delegateForColumn(
         return pCoverArtDelegate;
     } else if (index == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_KEY)) {
         return new KeyDelegate(pTableView);
+    } else if (index == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_WAVESUMMARYHEX)) {
+        auto* pOverviewDelegate = new OverviewDelegate(pTableView);
+        // WLibraryTableView -> OverviewDelegate
+        connect(pTableView,
+                &WLibraryTableView::onlyCachedCoverArt,
+                pOverviewDelegate,
+                &OverviewDelegate::slotInhibitLazyLoading);
+        // OverviewDelegate -> BaseTrackTableModel
+        connect(pOverviewDelegate,
+                &OverviewDelegate::rowsChanged,
+                this,
+                &BaseTrackTableModel::slotRefreshOverviewRows);
+        connect(pOverviewDelegate,
+                &OverviewDelegate::overviewChanged,
+                this,
+                &BaseTrackTableModel::slotRefreshOverview);
+        return pOverviewDelegate;
     }
     return nullptr;
 }
@@ -1199,6 +1221,30 @@ void BaseTrackTableModel::slotRefreshCoverRows(
         return;
     }
     emitDataChangedForMultipleRowsInColumn(rows, column);
+}
+
+void BaseTrackTableModel::slotRefreshOverviewRows(const QList<int>& rows) {
+    if (rows.isEmpty()) {
+        return;
+    }
+    const int column = fieldIndex(LIBRARYTABLE_WAVESUMMARYHEX);
+    VERIFY_OR_DEBUG_ASSERT(column >= 0) {
+        return;
+    }
+    emitDataChangedForMultipleRowsInColumn(rows, column);
+}
+
+void BaseTrackTableModel::slotRefreshOverview(const TrackId trackId) {
+    const int column = fieldIndex(LIBRARYTABLE_WAVESUMMARYHEX);
+    VERIFY_OR_DEBUG_ASSERT(column >= 0) {
+        return;
+    }
+
+    const auto rows = getTrackRows(trackId);
+    for (int row : rows) {
+        QModelIndex idx = index(row, column);
+        emit dataChanged(idx, idx);
+    }
 }
 
 void BaseTrackTableModel::slotRefreshAllRows() {

--- a/src/library/basetracktablemodel.h
+++ b/src/library/basetracktablemodel.h
@@ -249,6 +249,10 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
     void slotRefreshCoverRows(
             const QList<int>& rows);
 
+    void slotRefreshOverviewRows(const QList<int>& rows);
+
+    void slotRefreshOverview(const TrackId trackId);
+
     void slotRefreshAllRows();
 
     void slotCoverFound(

--- a/src/library/coverartcache.cpp
+++ b/src/library/coverartcache.cpp
@@ -9,6 +9,7 @@
 #include "track/track.h"
 #include "util/logger.h"
 #include "util/thread_affinity.h"
+#include "util/timer.h"
 
 namespace {
 
@@ -188,6 +189,8 @@ CoverArtCache::FutureResult CoverArtCache::loadCover(
         TrackPointer pTrack,
         CoverInfo coverInfo,
         int desiredWidth) {
+    ScopedTimer t(QStringLiteral("CoverArtCache::loadCover"));
+
     if (kLogger.traceEnabled()) {
         kLogger.trace()
                 << "loadCover"
@@ -245,7 +248,7 @@ void CoverArtCache::coverLoaded() {
     }
 
     if (kLogger.traceEnabled()) {
-        kLogger.trace() << "coverLoaded" << res.coverArt;
+        kLogger.info() << "coverLoaded" << res.coverArt;
     }
 
     QString cacheKey = pixmapCacheKey(

--- a/src/library/dao/trackschema.h
+++ b/src/library/dao/trackschema.h
@@ -47,6 +47,7 @@ const QString LIBRARYTABLE_COVERART_COLOR = QStringLiteral("coverart_color");
 const QString LIBRARYTABLE_COVERART_DIGEST = QStringLiteral("coverart_digest");
 const QString LIBRARYTABLE_COVERART_HASH = QStringLiteral("coverart_hash");
 const QString LIBRARYTABLE_CRATE = QStringLiteral("crate");
+const QString LIBRARYTABLE_OVERVIEW = QStringLiteral("overview");
 
 const QString TRACKLOCATIONSTABLE_ID = QStringLiteral("id");
 const QString TRACKLOCATIONSTABLE_LOCATION = QStringLiteral("location");

--- a/src/library/librarytablemodel.cpp
+++ b/src/library/librarytablemodel.cpp
@@ -68,7 +68,7 @@ bool LibraryTableModel::isColumnInternal(int column) {
     return column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_ID) ||
             column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_URL) ||
             column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_CUEPOINT) ||
-            column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_WAVESUMMARYHEX) ||
+            // column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_WAVESUMMARYHEX) ||
             column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_SAMPLERATE) ||
             column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_MIXXXDELETED) ||
             column == fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_HEADERPARSED) ||

--- a/src/library/mixxxlibraryfeature.cpp
+++ b/src/library/mixxxlibraryfeature.cpp
@@ -23,7 +23,6 @@
 #include "widget/wlibrarysidebar.h"
 #endif
 
-
 MixxxLibraryFeature::MixxxLibraryFeature(Library* pLibrary,
         UserSettingsPointer pConfig)
         : LibraryFeature(pLibrary, pConfig, QStringLiteral("tracks")),
@@ -70,7 +69,8 @@ MixxxLibraryFeature::MixxxLibraryFeature(Library* pLibrary,
             LIBRARYTABLE_COVERART_LOCATION,
             LIBRARYTABLE_COVERART_COLOR,
             LIBRARYTABLE_COVERART_DIGEST,
-            LIBRARYTABLE_COVERART_HASH};
+            LIBRARYTABLE_COVERART_HASH,
+            LIBRARYTABLE_WAVESUMMARYHEX};
     QStringList searchColumns = {
             LIBRARYTABLE_ARTIST,
             LIBRARYTABLE_ALBUM,

--- a/src/library/tabledelegates/coverartdelegate.cpp
+++ b/src/library/tabledelegates/coverartdelegate.cpp
@@ -10,6 +10,7 @@
 #include "track/track.h"
 #include "util/logger.h"
 #include "util/make_const_iterator.h"
+#include "util/timer.h"
 
 namespace {
 
@@ -108,6 +109,8 @@ void CoverArtDelegate::paintItem(
         QPainter* painter,
         const QStyleOptionViewItem& option,
         const QModelIndex& index) const {
+    ScopedTimer t(QStringLiteral("CoverArtDelegate::paintItem"));
+
     paintItemBackground(painter, option, index);
 
     CoverInfo coverInfo = m_pTrackModel->getCoverInfo(index);

--- a/src/library/tabledelegates/overviewdelegate.cpp
+++ b/src/library/tabledelegates/overviewdelegate.cpp
@@ -1,0 +1,142 @@
+#include "library/tabledelegates/overviewdelegate.h"
+
+#include "library/dao/trackdao.h"
+#include "library/trackmodel.h"
+#include "moc_overviewdelegate.cpp"
+#include "util/logger.h"
+#include "util/make_const_iterator.h"
+#include "util/timer.h"
+#include "waveform/overviews/overviewcache.h"
+#include "widget/wlibrary.h"
+
+namespace {
+
+const mixxx::Logger kLogger("OverviewDelegate");
+
+inline TrackModel* asTrackModel(
+        QTableView* pTableView) {
+    auto* pTrackModel =
+            dynamic_cast<TrackModel*>(pTableView->model());
+    DEBUG_ASSERT(pTrackModel);
+    return pTrackModel;
+}
+
+inline WLibrary* findLibraryWidgetParent(QWidget* pWidget) {
+    while (pWidget) {
+        WLibrary* pLibrary = qobject_cast<WLibrary*>(pWidget);
+        if (pLibrary) {
+            return pLibrary;
+        }
+
+        pWidget = pWidget->parentWidget();
+    }
+
+    return nullptr;
+}
+
+} // anonymous namespace
+
+OverviewDelegate::OverviewDelegate(QTableView* parent)
+        : TableItemDelegate(parent),
+          m_pTrackModel(asTrackModel(parent)),
+          m_pCache(OverviewCache::instance()),
+          m_inhibitLazyLoading(false) {
+    WLibrary* pLibrary = findLibraryWidgetParent(parent);
+    if (pLibrary) {
+        m_signalColors = pLibrary->getOverviewSignalColors();
+    }
+
+    if (m_pCache) {
+        connect(m_pCache,
+                &OverviewCache::overviewReady,
+                this,
+                &OverviewDelegate::slotOverviewReady);
+
+        connect(m_pCache,
+                &OverviewCache::overviewChanged,
+                this,
+                &OverviewDelegate::slotOverviewChanged);
+    } else {
+        kLogger.warning() << "Caching of overviews is not available";
+    }
+}
+
+void OverviewDelegate::emitRowsChanged(QList<int>&& rows) {
+    if (rows.isEmpty()) {
+        return;
+    }
+    // Sort in ascending order...
+    std::sort(rows.begin(), rows.end());
+    // ...and then deduplicate...
+    constErase(
+            &rows,
+            make_const_iterator(
+                    rows, std::unique(rows.begin(), rows.end())),
+            rows.constEnd());
+    // ...before emitting the signal.
+    DEBUG_ASSERT(!rows.isEmpty());
+    emit rowsChanged(std::move(rows));
+}
+
+void OverviewDelegate::slotInhibitLazyLoading(bool inhibitLazyLoading) {
+    m_inhibitLazyLoading = inhibitLazyLoading;
+    if (m_inhibitLazyLoading || m_cacheMissRows.isEmpty()) {
+        return;
+    }
+    // If we can request non-cache covers now, request updates
+    // for all rows that were cache misses since the last time.
+    // Reset the member variable before mutating the aggregated
+    // rows list (-> implicit sharing) and emitting a signal that
+    // in turn may trigger new signals for CoverArtDelegate!
+    QList<int> staleRows = std::move(m_cacheMissRows);
+    DEBUG_ASSERT(m_cacheMissRows.isEmpty());
+    emitRowsChanged(std::move(staleRows));
+}
+
+void OverviewDelegate::slotOverviewReady(const QObject* pRequester, TrackId trackId) {
+    kLogger.info() << "slotOverviewReady()" << this << pRequester << trackId;
+
+    if (pRequester == this) {
+        emit overviewChanged(trackId);
+    }
+}
+
+void OverviewDelegate::slotOverviewChanged(TrackId trackId) {
+    kLogger.info() << "slotOverviewChanged()" << trackId;
+
+    emit overviewChanged(trackId);
+}
+
+void OverviewDelegate::paintItem(QPainter* painter,
+        const QStyleOptionViewItem& option,
+        const QModelIndex& index) const {
+    ScopedTimer t(QStringLiteral("OverviewDelegate::paintItem"));
+
+    paintItemBackground(painter, option, index);
+
+    TrackId trackId(m_pTrackModel->getTrackId(index));
+
+    const double scaleFactor = qobject_cast<QWidget*>(parent())->devicePixelRatioF();
+
+    // QPixmap pixmap = , option.rect.size() * scaleFactor
+    QImage image = m_pCache->getCachedOverviewImage(trackId, m_signalColors);
+    if (image.isNull()) {
+        // Cache miss
+        if (m_inhibitLazyLoading) {
+            // We are requesting cache-only covers and got a cache
+            // miss. Record this row so that when we switch to requesting
+            // non-cache we can request an update.
+            m_cacheMissRows.append(index.row());
+        } else {
+            m_pCache->requestOverview(trackId,
+                    m_signalColors,
+                    this,
+                    option.rect.size() * scaleFactor);
+        }
+    } else {
+        // Cache hit
+        // pixmap.setDevicePixelRatio(scaleFactor);
+        // painter->drawPixmap(option.rect, pixmap);
+        painter->drawImage(option.rect, image);
+    }
+}

--- a/src/library/tabledelegates/overviewdelegate.h
+++ b/src/library/tabledelegates/overviewdelegate.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <QPainter>
+#include <QStyledItemDelegate>
+#include <QTableView>
+
+#include "library/tabledelegates/tableitemdelegate.h"
+#include "track/trackid.h"
+#include "waveform/renderers/waveformsignalcolors.h"
+
+class OverviewCache;
+class TrackModel;
+
+class OverviewDelegate : public TableItemDelegate {
+    Q_OBJECT
+
+  public:
+    explicit OverviewDelegate(QTableView* parent);
+    ~OverviewDelegate() override = default;
+
+    void paintItem(QPainter* painter,
+            const QStyleOptionViewItem& option,
+            const QModelIndex& index) const final;
+
+  signals:
+    void overviewChanged(const TrackId trackId);
+
+    // Sent when rows need to be refreshed
+    void rowsChanged(const QList<int>& rows);
+
+  public slots:
+    // Advise the delegate to temporarily inhibit lazy loading
+    // of cover images and to only display those cover images
+    // that have already been cached. Otherwise only the solid
+    // (background) color is painted.
+    //
+    // It is useful to handle cases when the user scroll down
+    // very fast or when they hold an arrow key. In this case
+    // it is NOT desirable to start multiple expensive file
+    // system operations in worker threads for loading and
+    // scaling cover images that are not even displayed after
+    // scrolling beyond them.
+    void slotInhibitLazyLoading(bool inhibitLazyLoading);
+
+  private slots:
+    void slotOverviewReady(const QObject* pRequester, TrackId trackId);
+
+    void slotOverviewChanged(TrackId trackId);
+
+  protected:
+    TrackModel* const m_pTrackModel;
+
+  private:
+    void emitRowsChanged(QList<int>&& rows);
+
+    OverviewCache* const m_pCache;
+    bool m_inhibitLazyLoading;
+
+    // We need to record rows in paint() (which is const) so
+    // these are marked mutable.
+    mutable QList<int> m_cacheMissRows;
+
+    WaveformSignalColors m_signalColors;
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,7 +47,7 @@ const QString kScaleFactorKey = QStringLiteral("ScaleFactor");
 // Profiling at 100% HiDPI zoom on Windows, that with 20MByte,
 // the SVG rendering happens sometimes during normal operation.
 // An indicator that the QPixmapCache was too small.
-constexpr int kPixmapCacheLimitAt100PercentZoom = 32 * 1024; // 32 MByte
+constexpr int kPixmapCacheLimitAt100PercentZoom = 128 * 1024; // 128 MByte
 
 int runMixxx(MixxxApplication* pApp, const CmdlineArgs& args) {
     CmdlineArgs::Instance().parseForUserFeedback();

--- a/src/preferences/dialog/dlgprefwaveform.h
+++ b/src/preferences/dialog/dlgprefwaveform.h
@@ -74,7 +74,6 @@ class DlgPrefWaveform : public DlgPreferencePage, public Ui::DlgPrefWaveformDlg 
     void updateWaveformAcceleration(
             WaveformWidgetType::Type type, WaveformWidgetBackend backend);
 
-    std::unique_ptr<ControlPushButton> m_pTypeControl;
     std::unique_ptr<ControlObject> m_pOverviewMinuteMarkersControl;
 
     UserSettingsPointer m_pConfig;

--- a/src/preferences/waveformoverviewsettings.h
+++ b/src/preferences/waveformoverviewsettings.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "preferences/usersettings.h"
+#include "waveform/overviews/overviewtype.h"
+
+namespace {
+const ConfigKey kOverviewTypeCfgKey(
+        QStringLiteral("[Waveform]"), QStringLiteral("WaveformOverviewType"));
+const ConfigKey kOverviewNormalizedCfgKey(
+        QStringLiteral("[Waveform]"), QStringLiteral("OverviewNormalized"));
+} // namespace
+
+class WaveformOverviewSettings {
+  public:
+    WaveformOverviewSettings(UserSettingsPointer pConfig)
+            : m_pConfig(pConfig) {
+    }
+
+    mixxx::OverviewType getOverviewType() const {
+        return m_pConfig->getValue<mixxx::OverviewType>(
+                kOverviewTypeCfgKey, mixxx::OverviewType::RGB);
+    }
+
+    void setOverviewType(mixxx::OverviewType type) {
+        m_pConfig->setValue(kOverviewTypeCfgKey, type);
+    }
+
+    bool isOverviewNormalized() const {
+        return m_pConfig->getValue<bool>(kOverviewNormalizedCfgKey);
+    }
+
+    void setOverviewNormalized(bool normalize) {
+        m_pConfig->setValue<bool>(kOverviewNormalizedCfgKey, normalize);
+    }
+
+  private:
+    UserSettingsPointer m_pConfig;
+};

--- a/src/waveform/overviews/overviewcache.cpp
+++ b/src/waveform/overviews/overviewcache.cpp
@@ -1,0 +1,369 @@
+#include "waveform/overviews/overviewcache.h"
+
+#include <QFutureWatcher>
+#include <QPixmapCache>
+#include <QSqlDatabase>
+#include <QtConcurrentRun>
+#include <QtSql>
+
+#include "library/dao/analysisdao.h"
+#include "mixer/playermanager.h"
+#include "moc_overviewcache.cpp"
+#include "preferences/waveformoverviewsettings.h"
+#include "track/globaltrackcache.h"
+#include "util/db/dbconnectionpooled.h"
+#include "util/db/dbconnectionpooler.h"
+#include "util/logger.h"
+#include "util/timer.h"
+#include "waveform/overviews/overviewrenderthread.h"
+#include "waveform/waveformfactory.h"
+
+namespace {
+
+mixxx::Logger kLogger("OverviewCache");
+
+/*
+QString pixmapCacheKey(TrackId trackId, QSize size) {
+    // return QString("Overview_%1").arg(trackId.toInt());
+    // return QString("Overview_%1_%2").arg(trackId.toInt()).arg(width);
+    return QString("Overview_%1_%2_%3")
+            .arg(trackId.toString())
+            .arg(size.width())
+            .arg(size.height());
+}
+
+QString colorToHex(const QColor& color) {
+    return QString::number(color.rgb(), 16);
+}
+
+QString formCacheKey(TrackId trackId, mixxx::OverviewType waveformType, WaveformSignalColors wsc) {
+    switch (waveformType) {
+    case mixxx::OverviewType::Filtered:
+        return QString("%1_Filtered_%2_%3_%4")
+                .arg(trackId.toString())
+                .arg(wsc.getLowColor().rgb(), 0, 16)
+                .arg(wsc.getMidColor().rgb(), 0, 16)
+                .arg(wsc.getHighColor().rgb(), 0, 16);
+    case mixxx::OverviewType::HSV:
+        return QString("%1_HSV_%2").arg(trackId.toString()).arg(wsc.getLowColor().rgb(), 0, 16);
+    case mixxx::OverviewType::RGB:
+    default:
+        return QString("%1_RGB_%2_%3_%4")
+                .arg(trackId.toString())
+                .arg(wsc.getRgbLowColor().rgb(), 0, 16)
+                .arg(wsc.getRgbMidColor().rgb(), 0, 16)
+                .arg(wsc.getRgbHighColor().rgb(), 0, 16);
+    }
+}
+*/
+
+QString formImageCacheKey(mixxx::OverviewType waveformType, WaveformSignalColors wsc) {
+    switch (waveformType) {
+    case mixxx::OverviewType::Filtered:
+        return QString("Filtered_%2_%3_%4")
+                .arg(wsc.getLowColor().rgb(), 0, 16)
+                .arg(wsc.getMidColor().rgb(), 0, 16)
+                .arg(wsc.getHighColor().rgb(), 0, 16);
+    case mixxx::OverviewType::HSV:
+        return QString("HSV_%2").arg(wsc.getLowColor().rgb(), 0, 16);
+    case mixxx::OverviewType::RGB:
+    default:
+        return QString("RGB_%2_%3_%4")
+                .arg(wsc.getRgbLowColor().rgb(), 0, 16)
+                .arg(wsc.getRgbMidColor().rgb(), 0, 16)
+                .arg(wsc.getRgbHighColor().rgb(), 0, 16);
+    }
+}
+
+// The transformation mode when scaling images
+const Qt::TransformationMode kTransformationMode = Qt::SmoothTransformation;
+
+inline QImage resizeImageSize(const QImage& image, QSize size) {
+    return image.scaled(size, Qt::IgnoreAspectRatio, kTransformationMode);
+}
+
+} // anonymous namespace
+
+OverviewCache::OverviewCache(UserSettingsPointer pConfig,
+        mixxx::DbConnectionPoolPtr pDbConnectionPool,
+        std::shared_ptr<PlayerManager> pPlayerManager)
+        : m_pConfig(pConfig),
+          m_pDbConnectionPool(std::move(pDbConnectionPool)),
+          m_renderThread(pDbConnectionPool, pConfig),
+          m_overviewCache(50) {
+    WaveformOverviewSettings overviewSettings(m_pConfig);
+    m_type = overviewSettings.getOverviewType();
+    m_overviewNormalized = overviewSettings.isOverviewNormalized();
+
+    connect(pPlayerManager.get(),
+            &PlayerManager::trackAnalyzerProgress,
+            this,
+            &OverviewCache::onTrackAnalyzerProgress);
+
+    connect(&m_renderThread,
+            &OverviewRenderThread::overviewRendered,
+            this,
+            &OverviewCache::overviewRendered);
+
+    m_renderThread.suspend();
+    // m_renderThread.resume();
+    m_renderThread.start();
+}
+
+void OverviewCache::setOverviewType(mixxx::OverviewType type) {
+    kLogger.info() << "setOverviewType" << type;
+
+    if (type == m_type) {
+        return;
+    }
+
+    m_type = type;
+    m_overviewCache.clear();
+
+    emit overviewsChanged(m_overviewCache.keys());
+}
+
+void OverviewCache::setOverviewNormalized(bool normalized) {
+    kLogger.info() << "setOverviewNormalized" << normalized;
+
+    if (normalized == m_overviewNormalized) {
+        return;
+    }
+
+    m_overviewNormalized = normalized;
+}
+
+void OverviewCache::onTrackAnalyzerProgress(TrackId trackId, AnalyzerProgress analyzerProgress) {
+    kLogger.info() << "onTrackAnalyzerProgress" << trackId << analyzerProgress;
+
+    m_tracksWithoutWaveform.remove(trackId);
+
+    /*
+    if (m_overviewCache.contains(trackId)) {
+        TrackPointer pTrack = GlobalTrackCacheLocker().lookupTrackById(trackId);
+        if (pTrack) {
+            ConstWaveformPointer pWaveform = pTrack->getWaveform();
+            if (pWaveform) {
+                OverviewCacheItem* pItem = m_overviewCache[trackId];
+                if (pItem != nullptr) {
+                    for (auto& item : pItem->images) {
+                        OverviewRenderThread::drawNextPixmapPart(item.second,
+                                pWaveform,
+                                m_type,
+                                item.first,
+                                pItem->completion);
+                    }
+                }
+            }
+        }
+    }
+    */
+}
+
+QImage OverviewCache::getCachedOverviewImage(
+        const TrackId trackId, const WaveformSignalColors signalColors) const {
+    if (!trackId.isValid()) {
+        return QImage();
+    }
+
+    OverviewCacheItem* pItem = m_overviewCache[trackId];
+    if (pItem != nullptr) {
+        QString imageCacheKey = formImageCacheKey(m_type, signalColors);
+        if (pItem->images.contains(imageCacheKey)) {
+            // TODO: Resize
+            // return QPixmap::fromImage();
+            return pItem->images[imageCacheKey].second;
+        }
+    }
+
+    /*
+    QImage image =
+    if (!image.isNull()) {
+        return QPixmap::fromImage(image);
+    }
+    */
+
+    // QString cacheKey = pixmapCacheKey(trackId, desiredSize);
+
+    /*if (m_tracksCurrentlyAnalyzed.contains(trackId)) {
+        QPixmapCache::remove(cacheKey);
+        return QPixmap();
+    }*/
+
+    /*
+    QPixmap pixmap;
+    if (!QPixmapCache::find(cacheKey, &pixmap)) {
+        return QPixmap();
+    }
+
+    return pixmap;
+    */
+
+    return QImage();
+}
+
+void OverviewCache::requestOverview(const TrackId trackId,
+        const WaveformSignalColors signalColors,
+        const QObject* pRequester,
+        const QSize desiredSize) {
+    ScopedTimer t(QStringLiteral("OverviewCache::requestOverview"));
+
+    kLogger.info() << "requestOverview()" << trackId << pRequester << desiredSize;
+
+    if (!trackId.isValid()) {
+        return;
+    }
+
+    if (m_currentlyRendering.contains(trackId)) {
+        return;
+    }
+
+    if (m_tracksWithoutWaveform.contains(trackId)) {
+        return;
+    }
+
+    m_currentlyRendering.insert(trackId);
+
+    // m_renderThread.scheduleRender(trackId, m_type, signalColors);
+
+    // The watcher will be deleted in overviewPrepared()
+    QFutureWatcher<FutureResult>* watcher = new QFutureWatcher<FutureResult>(this);
+    QFuture<FutureResult> future = QtConcurrent::run(
+            &OverviewCache::prepareOverview,
+            m_pConfig,
+            m_pDbConnectionPool,
+            trackId,
+            m_type,
+            signalColors,
+            pRequester,
+            desiredSize);
+    connect(watcher,
+            &QFutureWatcher<FutureResult>::finished,
+            this,
+            &OverviewCache::overviewPrepared);
+    watcher->setFuture(future);
+}
+
+// static
+ConstWaveformPointer OverviewCache::loadWaveform(const UserSettingsPointer pConfig,
+        const mixxx::DbConnectionPoolPtr pDbConnectionPool,
+        const TrackId trackId) {
+    TrackPointer pTrack = GlobalTrackCacheLocker().lookupTrackById(trackId);
+    if (pTrack) {
+        ConstWaveformPointer pWaveform = pTrack->getWaveform();
+        if (pWaveform) {
+            return pWaveform;
+        }
+    }
+
+    mixxx::DbConnectionPooler dbConnectionPooler(pDbConnectionPool);
+
+    AnalysisDao analysisDao(pConfig);
+    analysisDao.initialize(mixxx::DbConnectionPooled(pDbConnectionPool));
+
+    QList<AnalysisDao::AnalysisInfo> analyses = analysisDao.getAnalysesForTrackByType(
+            trackId, AnalysisDao::AnalysisType::TYPE_WAVESUMMARY);
+    if (analyses.isEmpty()) {
+        kLogger.info() << "Track" << trackId << "has no WAVESUMMARY analysis";
+        return ConstWaveformPointer();
+    }
+
+    return ConstWaveformPointer(WaveformFactory::loadWaveformFromAnalysis(analyses.first()));
+}
+
+// static
+OverviewCache::FutureResult OverviewCache::prepareOverview(
+        const UserSettingsPointer pConfig,
+        const mixxx::DbConnectionPoolPtr pDbConnectionPool,
+        const TrackId trackId,
+        const mixxx::OverviewType type,
+        const WaveformSignalColors signalColors,
+        const QObject* pRequester,
+        const QSize desiredSize) {
+    ScopedTimer t(QStringLiteral("OverviewCache::prepareOverview"));
+
+    kLogger.info() << "prepareOverview()" << trackId << type << pRequester << desiredSize;
+
+    RenderResult res;
+
+    ConstWaveformPointer pLoadedTrackWaveformSummary =
+            loadWaveform(pConfig, pDbConnectionPool, trackId);
+    if (pLoadedTrackWaveformSummary.isNull()) {
+        kLogger.info() << "Analysis for track" << trackId << "could not be loaded";
+    } else {
+        res = OverviewRenderThread::render(
+                pLoadedTrackWaveformSummary, type, signalColors);
+    }
+
+    FutureResult result;
+    result.trackId = trackId;
+    result.overviewType = type;
+    result.signalColors = signalColors;
+    result.requester = pRequester;
+    result.image = res.image;
+    // result.resizedToSize = desiredSize;
+    result.completion = res.completion;
+    result.peak = res.waveformPeak;
+    return result;
+}
+
+// watcher
+void OverviewCache::overviewPrepared() {
+    FutureResult res;
+    {
+        QFutureWatcher<FutureResult>* pFutureWatcher =
+                static_cast<QFutureWatcher<FutureResult>*>(sender());
+        VERIFY_OR_DEBUG_ASSERT(pFutureWatcher) {
+            return;
+        }
+        res = pFutureWatcher->result();
+        pFutureWatcher->deleteLater();
+    }
+
+    kLogger.info() << "overviewPrepared" << res.trackId << res.image;
+
+    if (res.image.isNull()) {
+        m_tracksWithoutWaveform.insert(res.trackId);
+    } else {
+        if (m_overviewCache.contains(res.trackId)) {
+            OverviewCacheItem* pItem = m_overviewCache[res.trackId];
+            pItem->completion = res.completion;
+            QString imageCacheKey = formImageCacheKey(res.overviewType, res.signalColors);
+            pItem->images[imageCacheKey] = QPair(res.signalColors, res.image);
+        } else {
+            OverviewCacheItem* pItem = new OverviewCacheItem;
+            pItem->completion = res.completion;
+            QString imageCacheKey = formImageCacheKey(res.overviewType, res.signalColors);
+            pItem->images[imageCacheKey] = QPair(res.signalColors, res.image);
+            m_overviewCache.insert(res.trackId, pItem);
+        }
+
+        kLogger.info()
+                << "Emitting overviewReady() signal" << res.requester << res.trackId;
+        emit overviewReady(res.requester, res.trackId);
+    }
+
+    m_currentlyRendering.remove(res.trackId);
+}
+
+void OverviewCache::overviewRendered(TrackId trackId,
+        mixxx::OverviewType overviewType,
+        WaveformSignalColors signalColors,
+        QImage image,
+        int completion) {
+    if (m_overviewCache.contains(trackId)) {
+        OverviewCacheItem* pItem = m_overviewCache[trackId];
+        pItem->completion = completion;
+        QString imageCacheKey = formImageCacheKey(overviewType, signalColors);
+        pItem->images[imageCacheKey] = QPair(signalColors, image);
+    } else {
+        OverviewCacheItem* pItem = new OverviewCacheItem;
+        pItem->completion = completion;
+        QString imageCacheKey = formImageCacheKey(overviewType, signalColors);
+        pItem->images[imageCacheKey] = QPair(signalColors, image);
+        m_overviewCache.insert(trackId, pItem);
+    }
+
+    kLogger.info() << "Emitting overviewReady() signal" << trackId << overviewType << completion;
+    emit overviewChanged(trackId);
+}

--- a/src/waveform/overviews/overviewcache.h
+++ b/src/waveform/overviews/overviewcache.h
@@ -1,0 +1,114 @@
+#pragma once
+
+#include <QSqlDatabase>
+
+#include "analyzer/analyzerprogress.h"
+#include "preferences/usersettings.h"
+#include "track/track.h"
+#include "util/db/dbconnectionpool.h"
+#include "util/singleton.h"
+#include "waveform/overviews/overviewrenderthread.h"
+
+class AnalysisDao;
+class PlayerManager;
+
+struct OverviewCacheItem {
+    AnalyzerProgress analyzerProgress;
+    int completion;
+    QMap<QString, QPair<WaveformSignalColors, QImage>> images;
+};
+
+class OverviewCache : public QObject, public Singleton<OverviewCache> {
+    Q_OBJECT
+  public:
+    mixxx::OverviewType getOverviewType();
+    void setOverviewType(mixxx::OverviewType);
+
+    bool isOverviewNormalized();
+    void setOverviewNormalized(bool);
+
+    QPixmap getCachedOverviewPixmap(const TrackId trackId,
+            const WaveformSignalColors signalColors,
+            const QSize desiredSize) const;
+
+    QImage getCachedOverviewImage(const TrackId trackId,
+            const WaveformSignalColors signalColors) const;
+
+    void requestOverview(
+            const TrackId trackId,
+            const WaveformSignalColors signalColors,
+            const QObject* pRequester,
+            const QSize desiredSize);
+
+    struct FutureResult {
+        FutureResult()
+                : requester(nullptr) {
+        }
+
+        TrackId trackId;
+        mixxx::OverviewType overviewType;
+        WaveformSignalColors signalColors;
+        QImage image;
+        // QSize resizedToSize;
+        const QObject* requester;
+        int completion;
+        float peak;
+    };
+
+  public slots:
+    void overviewPrepared();
+
+    void overviewRendered(TrackId,
+            mixxx::OverviewType,
+            WaveformSignalColors,
+            QImage,
+            int completion);
+
+    void onTrackAnalyzerProgress(TrackId trackId, AnalyzerProgress analyzerProgress);
+
+  signals:
+    void overviewReady(const QObject* pRequester, TrackId trackId);
+
+    void overviewChanged(TrackId);
+
+    void overviewsChanged(const QList<TrackId>);
+
+  protected:
+    OverviewCache(UserSettingsPointer pConfig,
+            mixxx::DbConnectionPoolPtr pDbConnectionPool,
+            std::shared_ptr<PlayerManager> pPlayerManager);
+    virtual ~OverviewCache() override = default;
+    friend class Singleton<OverviewCache>;
+
+    static FutureResult prepareOverview(
+            UserSettingsPointer pConfig,
+            mixxx::DbConnectionPoolPtr pDbConnectionPool,
+            const TrackId trackId,
+            const mixxx::OverviewType type,
+            const WaveformSignalColors signalColors,
+            const QObject* pRequester,
+            const QSize desiredSize);
+
+    static ConstWaveformPointer loadWaveform(const UserSettingsPointer pConfig,
+            const mixxx::DbConnectionPoolPtr pDbConnectionPool,
+            const TrackId trackId);
+
+  private:
+    UserSettingsPointer m_pConfig;
+    mixxx::DbConnectionPoolPtr m_pDbConnectionPool;
+
+    std::unique_ptr<AnalysisDao> m_pAnalysisDao;
+
+    OverviewRenderThread m_renderThread;
+
+    QSet<TrackId> m_currentlyRendering;
+
+    QSet<TrackId> m_tracksWithoutWaveform;
+
+    QHash<TrackId, int> m_trackToAnalysisId;
+
+    QCache<TrackId, OverviewCacheItem> m_overviewCache;
+
+    mixxx::OverviewType m_type;
+    bool m_overviewNormalized;
+};

--- a/src/waveform/overviews/overviewrenderthread.cpp
+++ b/src/waveform/overviews/overviewrenderthread.cpp
@@ -1,0 +1,341 @@
+#include "waveform/overviews/overviewrenderthread.h"
+
+#include <QPainter>
+
+#include "library/dao/analysisdao.h"
+#include "moc_overviewrenderthread.cpp"
+#include "util/colorcomponents.h"
+#include "util/db/dbconnectionpooled.h"
+#include "util/db/dbconnectionpooler.h"
+#include "util/logger.h"
+#include "util/math.h"
+#include "util/timer.h"
+#include "waveform/overviews/overviewtype.h"
+#include "waveform/waveformfactory.h"
+
+mixxx::Logger kLogger("OverviewRenderThread");
+
+RenderTrackOverview::RenderTrackOverview(TrackId trackId,
+        mixxx::OverviewType type,
+        WaveformSignalColors signalColors)
+        : m_trackId(trackId),
+          m_type(type),
+          m_signalColors(signalColors) {
+}
+
+TrackId RenderTrackOverview::getTrackId() const {
+    return m_trackId;
+}
+
+mixxx::OverviewType RenderTrackOverview::getType() const {
+    return m_type;
+}
+
+WaveformSignalColors RenderTrackOverview::getSignalColors() const {
+    return m_signalColors;
+}
+
+OverviewRenderThread::OverviewRenderThread(mixxx::DbConnectionPoolPtr dbConnectionPool,
+        UserSettingsPointer pConfig)
+        : WorkerThread("OverviewRenderThread"),
+          m_dbConnectionPool(dbConnectionPool),
+          m_pConfig(pConfig),
+          m_nextTrack(2) {
+}
+
+bool OverviewRenderThread::scheduleRender(TrackId trackId,
+        mixxx::OverviewType overviewType,
+        WaveformSignalColors signalColors) {
+    kLogger.info() << "scheduleRender" << trackId << overviewType;
+
+    RenderTrackOverview rto(trackId, overviewType, signalColors);
+    if (m_nextTrack.try_emplace(rto)) {
+        // Ensure that the submitted track gets processed eventually
+        // by waking the worker thread up after adding a new task to
+        // its back queue! Otherwise the thread might not notice if
+        // it is currently idle and has fallen asleep.
+        wake();
+        return true;
+    }
+    return false;
+}
+
+void OverviewRenderThread::doRun() {
+    kLogger.info() << "doRun";
+
+    mixxx::DbConnectionPooler dbConnectionPooler;
+    dbConnectionPooler = mixxx::DbConnectionPooler(m_dbConnectionPool); // move assignment
+    if (!dbConnectionPooler.isPooling()) {
+        kLogger.warning() << "Failed to obtain database connection for overview render thread";
+        return;
+    }
+
+    AnalysisDao analysisDao(m_pConfig);
+    analysisDao.initialize(mixxx::DbConnectionPooled(m_dbConnectionPool));
+
+    while (awaitWorkItemsFetched()) {
+        TrackId trackId = m_currentTrack->getTrackId();
+        mixxx::OverviewType type = m_currentTrack->getType();
+        WaveformSignalColors signalColors = m_currentTrack->getSignalColors();
+
+        kLogger.info() << "Rendering overview for track" << trackId;
+
+        QList<AnalysisDao::AnalysisInfo> analyses =
+                analysisDao.getAnalysesForTrackByType(
+                        trackId, AnalysisDao::AnalysisType::TYPE_WAVESUMMARY);
+
+        if (!analyses.isEmpty()) {
+            ConstWaveformPointer pWaveform = ConstWaveformPointer(
+                    WaveformFactory::loadWaveformFromAnalysis(
+                            analyses.first()));
+
+            RenderResult result = render(pWaveform, type, signalColors);
+
+            // TODO: Save in cache.
+
+            // Emit signal that overview waveform is rendered
+            emit overviewRendered(trackId,
+                    type,
+                    signalColors,
+                    result.image,
+                    pWaveform->getCompletion());
+        }
+    }
+}
+
+WorkerThread::TryFetchWorkItemsResult OverviewRenderThread::tryFetchWorkItems() {
+    DEBUG_ASSERT(!m_currentTrack.has_value());
+    RenderTrackOverview* pFront = m_nextTrack.front();
+    if (pFront) {
+        m_currentTrack = *pFront;
+        m_nextTrack.pop();
+        kLogger.debug() << "Dequeued next track" << m_currentTrack->getTrackId();
+        return TryFetchWorkItemsResult::Ready;
+    } else {
+        return TryFetchWorkItemsResult::Idle;
+    }
+}
+
+// static
+RenderResult OverviewRenderThread::render(ConstWaveformPointer pWaveform,
+        mixxx::OverviewType type,
+        WaveformSignalColors signalColors) {
+    ScopedTimer t(QStringLiteral("WaveformOverviewRenderer::render"));
+
+    const int dataSize = pWaveform->getDataSize();
+    if (dataSize <= 0) {
+        return RenderResult();
+    }
+
+    QImage image(dataSize / 2, 2 * 255, QImage::Format_ARGB32_Premultiplied);
+    image.fill(QColor(0, 0, 0, 0).value());
+
+    float peak = drawNextPixmapPart(image, pWaveform, type, signalColors, 0);
+
+    RenderResult result;
+    result.image = image;
+    result.completion = pWaveform->getCompletion();
+    result.waveformPeak = peak;
+    return result;
+}
+
+// static
+float OverviewRenderThread::drawNextPixmapPart(QImage& image,
+        ConstWaveformPointer pWaveform,
+        mixxx::OverviewType type,
+        WaveformSignalColors signalColors,
+        const int actualCompletion) {
+    ScopedTimer t(QStringLiteral("WaveformOverviewRenderer::drawNextPixmapPart"));
+
+    QPainter painter(&image);
+    painter.translate(0.0, static_cast<double>(image.height()) / 2.0);
+
+    const int nextCompletion = pWaveform->getCompletion();
+
+    if (type == mixxx::OverviewType::Filtered) {
+        drawNextPixmapPartLMH(&painter, pWaveform, signalColors, actualCompletion, nextCompletion);
+    } else if (type == mixxx::OverviewType::HSV) {
+        drawNextPixmapPartHSV(&painter, pWaveform, signalColors, actualCompletion, nextCompletion);
+    } else { // mixxx::OverviewType::RGB:
+        drawNextPixmapPartRGB(&painter, pWaveform, signalColors, actualCompletion, nextCompletion);
+    }
+
+    float peak = -1.0f;
+    for (int i = 0; i < nextCompletion; i += 2) {
+        peak = math_max3(peak,
+                static_cast<float>(pWaveform->getAll(i)),
+                static_cast<float>(pWaveform->getAll(i + 1)));
+    }
+    return peak;
+}
+
+void OverviewRenderThread::drawNextPixmapPartHSV(QPainter* pPainter,
+        ConstWaveformPointer pWaveform,
+        WaveformSignalColors signalColors,
+        const int actualCompletion,
+        const int nextCompletion) {
+    ScopedTimer t(QStringLiteral("OverviewRenderThread::drawNextPixmapPartHSV"));
+
+    // Get HSV of low color.
+    float h, s, v;
+    getHsvF(signalColors.getLowColor(), &h, &s, &v);
+
+    QColor color;
+    float lo, hi, total;
+
+    unsigned char maxLow[2] = {0, 0};
+    unsigned char maxHigh[2] = {0, 0};
+    unsigned char maxMid[2] = {0, 0};
+    unsigned char maxAll[2] = {0, 0};
+
+    for (int currentCompletion = actualCompletion;
+            currentCompletion < nextCompletion;
+            currentCompletion += 2) {
+        maxAll[0] = pWaveform->getAll(currentCompletion);
+        maxAll[1] = pWaveform->getAll(currentCompletion + 1);
+        if (maxAll[0] || maxAll[1]) {
+            maxLow[0] = pWaveform->getLow(currentCompletion);
+            maxLow[1] = pWaveform->getLow(currentCompletion + 1);
+            maxMid[0] = pWaveform->getMid(currentCompletion);
+            maxMid[1] = pWaveform->getMid(currentCompletion + 1);
+            maxHigh[0] = pWaveform->getHigh(currentCompletion);
+            maxHigh[1] = pWaveform->getHigh(currentCompletion + 1);
+
+            total = (maxLow[0] + maxLow[1] + maxMid[0] + maxMid[1] +
+                            maxHigh[0] + maxHigh[1]) *
+                    1.2f;
+
+            // Prevent division by zero
+            if (total > 0) {
+                // Normalize low and high
+                // (mid not need, because it not change the color)
+                lo = (maxLow[0] + maxLow[1]) / total;
+                hi = (maxHigh[0] + maxHigh[1]) / total;
+            } else {
+                lo = hi = 0.0;
+            }
+
+            // Set color
+            color.setHsvF(h, 1.0f - hi, 1.0f - lo);
+
+            pPainter->setPen(color);
+            pPainter->drawLine(QPoint(currentCompletion / 2, -maxAll[0]),
+                    QPoint(currentCompletion / 2, maxAll[1]));
+        }
+    }
+}
+
+void OverviewRenderThread::drawNextPixmapPartLMH(QPainter* pPainter,
+        ConstWaveformPointer pWaveform,
+        WaveformSignalColors signalColors,
+        const int actualCompletion,
+        const int nextCompletion) {
+    ScopedTimer t(QStringLiteral("OverviewRenderThread::drawNextPixmapPartLMH"));
+
+    QColor lowColor = signalColors.getLowColor();
+    QPen lowColorPen(QBrush(lowColor), 1);
+
+    QColor midColor = signalColors.getMidColor();
+    QPen midColorPen(QBrush(midColor), 1);
+
+    QColor highColor = signalColors.getHighColor();
+    QPen highColorPen(QBrush(highColor), 1);
+
+    int currentCompletion = 0;
+    for (currentCompletion = actualCompletion;
+            currentCompletion < nextCompletion;
+            currentCompletion += 2) {
+        unsigned char lowNeg = pWaveform->getLow(currentCompletion);
+        unsigned char lowPos = pWaveform->getLow(currentCompletion + 1);
+        if (lowPos || lowNeg) {
+            pPainter->setPen(lowColorPen);
+            pPainter->drawLine(QPoint(currentCompletion / 2, -lowNeg),
+                    QPoint(currentCompletion / 2, lowPos));
+        }
+    }
+
+    for (currentCompletion = actualCompletion;
+            currentCompletion < nextCompletion;
+            currentCompletion += 2) {
+        pPainter->setPen(midColorPen);
+        pPainter->drawLine(QPoint(currentCompletion / 2,
+                                   -pWaveform->getMid(currentCompletion)),
+                QPoint(currentCompletion / 2,
+                        pWaveform->getMid(currentCompletion + 1)));
+    }
+
+    for (currentCompletion = actualCompletion;
+            currentCompletion < nextCompletion;
+            currentCompletion += 2) {
+        pPainter->setPen(highColorPen);
+        pPainter->drawLine(QPoint(currentCompletion / 2,
+                                   -pWaveform->getHigh(currentCompletion)),
+                QPoint(currentCompletion / 2,
+                        pWaveform->getHigh(currentCompletion + 1)));
+    }
+}
+
+void OverviewRenderThread::drawNextPixmapPartRGB(QPainter* pPainter,
+        ConstWaveformPointer pWaveform,
+        WaveformSignalColors signalColors,
+        const int actualCompletion,
+        const int nextCompletion) {
+    ScopedTimer t(QStringLiteral("OverviewRenderThread::drawNextPixmapPartRGB"));
+
+    QColor color;
+
+    float lowColor_r, lowColor_g, lowColor_b;
+    getRgbF(signalColors.getRgbLowColor(), &lowColor_r, &lowColor_g, &lowColor_b);
+
+    float midColor_r, midColor_g, midColor_b;
+    getRgbF(signalColors.getRgbMidColor(), &midColor_r, &midColor_g, &midColor_b);
+
+    float highColor_r, highColor_g, highColor_b;
+    getRgbF(signalColors.getRgbHighColor(), &highColor_r, &highColor_g, &highColor_b);
+
+    // int currentCompletion = 0;
+    for (int currentCompletion = actualCompletion;
+            currentCompletion < nextCompletion;
+            currentCompletion += 2) {
+        unsigned char left = pWaveform->getAll(currentCompletion);
+        unsigned char right = pWaveform->getAll(currentCompletion + 1);
+
+        // Retrieve "raw" LMH values from waveform
+        float low = static_cast<float>(pWaveform->getLow(currentCompletion));
+        float mid = static_cast<float>(pWaveform->getMid(currentCompletion));
+        float high = static_cast<float>(pWaveform->getHigh(currentCompletion));
+
+        // Do matrix multiplication
+        float red = low * lowColor_r + mid * midColor_r + high * highColor_r;
+        float green = low * lowColor_g + mid * midColor_g + high * highColor_g;
+        float blue = low * lowColor_b + mid * midColor_b + high * highColor_b;
+
+        // Normalize and draw
+        float max = math_max3(red, green, blue);
+        if (max > 0.0) {
+            color.setRgbF(red / max, green / max, blue / max);
+            pPainter->setPen(color);
+            pPainter->drawLine(QPointF(currentCompletion / 2, -left),
+                    QPointF(currentCompletion / 2, 0));
+        }
+
+        // Retrieve "raw" LMH values from waveform
+        low = static_cast<float>(pWaveform->getLow(currentCompletion + 1));
+        mid = static_cast<float>(pWaveform->getMid(currentCompletion + 1));
+        high = static_cast<float>(pWaveform->getHigh(currentCompletion + 1));
+
+        // Do matrix multiplication
+        red = low * lowColor_r + mid * midColor_r + high * highColor_r;
+        green = low * lowColor_g + mid * midColor_g + high * highColor_g;
+        blue = low * lowColor_b + mid * midColor_b + high * highColor_b;
+
+        // Normalize and draw
+        max = math_max3(red, green, blue);
+        if (max > 0.0) {
+            color.setRgbF(red / max, green / max, blue / max);
+            pPainter->setPen(color);
+            pPainter->drawLine(QPointF(currentCompletion / 2, 0),
+                    QPointF(currentCompletion / 2, right));
+        }
+    }
+}

--- a/src/waveform/overviews/overviewrenderthread.h
+++ b/src/waveform/overviews/overviewrenderthread.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <QCache>
+
+#include "control/controlproxy.h"
+#include "rigtorp/SPSCQueue.h"
+#include "util/db/dbconnectionpool.h"
+#include "util/singleton.h"
+#include "util/workerthread.h"
+#include "waveform/overviews/overviewtype.h"
+#include "waveform/renderers/waveformsignalcolors.h"
+#include "waveform/waveform.h"
+#include "widget/woverview.h"
+
+class RenderTrackOverview {
+  public:
+    explicit RenderTrackOverview(TrackId trackId,
+            mixxx::OverviewType type,
+            WaveformSignalColors signalColors);
+
+    TrackId getTrackId() const;
+
+    mixxx::OverviewType getType() const;
+
+    WaveformSignalColors getSignalColors() const;
+
+  private:
+    TrackId m_trackId;
+    mixxx::OverviewType m_type;
+    WaveformSignalColors m_signalColors;
+};
+
+struct RenderResult {
+    QImage image;
+    int completion;
+    float waveformPeak;
+};
+
+class OverviewRenderThread : public WorkerThread {
+    Q_OBJECT
+
+  public:
+    OverviewRenderThread(mixxx::DbConnectionPoolPtr dbConnectionPool, UserSettingsPointer pConfig);
+    ~OverviewRenderThread() override = default;
+
+    bool scheduleRender(TrackId, mixxx::OverviewType, WaveformSignalColors);
+
+    static RenderResult render(ConstWaveformPointer, mixxx::OverviewType, WaveformSignalColors);
+
+    static float drawNextPixmapPart(QImage& image,
+            ConstWaveformPointer pWaveform,
+            mixxx::OverviewType type,
+            WaveformSignalColors signalColors,
+            const int actualCompletion);
+
+  signals:
+    void overviewRendered(TrackId,
+            mixxx::OverviewType,
+            WaveformSignalColors,
+            QImage,
+            int completion);
+
+  protected:
+    void doRun() override;
+
+    TryFetchWorkItemsResult tryFetchWorkItems() override;
+
+  private:
+    static void drawNextPixmapPartHSV(QPainter* pPainter,
+            ConstWaveformPointer pWaveform,
+            WaveformSignalColors signalColors,
+            const int actualCompletion,
+            const int nextCompletion);
+    static void drawNextPixmapPartLMH(QPainter* pPainter,
+            ConstWaveformPointer pWaveform,
+            WaveformSignalColors signalColors,
+            const int actualCompletion,
+            const int nextCompletion);
+    static void drawNextPixmapPartRGB(QPainter* pPainter,
+            ConstWaveformPointer pWaveform,
+            WaveformSignalColors signalColors,
+            const int actualCompletion,
+            const int nextCompletion);
+
+    const mixxx::DbConnectionPoolPtr m_dbConnectionPool;
+    const UserSettingsPointer m_pConfig;
+
+    rigtorp::SPSCQueue<RenderTrackOverview> m_nextTrack;
+
+    std::optional<RenderTrackOverview> m_currentTrack;
+};

--- a/src/waveform/overviews/overviewtype.cpp
+++ b/src/waveform/overviews/overviewtype.cpp
@@ -1,0 +1,4 @@
+// just a stub so the MOC file can be included somewhere
+#include "overviewtype.h"
+
+#include "moc_overviewtype.cpp"

--- a/src/waveform/overviews/overviewtype.h
+++ b/src/waveform/overviews/overviewtype.h
@@ -1,0 +1,16 @@
+#pragma once
+
+// required for Qt-Macros
+#include <qobjectdefs.h>
+
+namespace mixxx {
+Q_NAMESPACE
+
+enum class OverviewType {
+    Filtered,
+    HSV,
+    RGB,
+};
+Q_ENUM_NS(OverviewType);
+
+} // namespace mixxx

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -97,7 +97,6 @@ WaveformWidgetFactory::WaveformWidgetFactory()
           m_endOfTrackWarningTime(30),
           m_defaultZoom(WaveformWidgetRenderer::s_waveformDefaultZoom),
           m_zoomSync(true),
-          m_overviewNormalized(false),
           m_untilMarkShowBeats(false),
           m_untilMarkShowTime(false),
           m_untilMarkAlign(Qt::AlignVCenter),
@@ -383,12 +382,14 @@ bool WaveformWidgetFactory::setConfig(UserSettingsPointer config) {
         }
     }
 
+    /*
     int overviewNormalized = m_config->getValueString(ConfigKey("[Waveform]","OverviewNormalized")).toInt(&ok);
     if (ok) {
         setOverviewNormalized(static_cast<bool>(overviewNormalized));
     } else {
         m_config->set(ConfigKey("[Waveform]","OverviewNormalized"), ConfigValue(m_overviewNormalized));
     }
+    */
 
     m_playMarkerPosition = m_config->getValue(ConfigKey("[Waveform]", "PlayMarkerPosition"),
             WaveformWidgetRenderer::s_defaultPlayMarkerPosition);
@@ -680,12 +681,14 @@ double WaveformWidgetFactory::getVisualGain(FilterIndex index) const {
     return m_visualGain[index];
 }
 
+/*
 void WaveformWidgetFactory::setOverviewNormalized(bool normalize) {
     m_overviewNormalized = normalize;
     if (m_config) {
         m_config->set(ConfigKey("[Waveform]","OverviewNormalized"), ConfigValue(m_overviewNormalized));
     }
 }
+*/
 
 void WaveformWidgetFactory::setPlayMarkerPosition(double position) {
     m_playMarkerPosition = position;

--- a/src/waveform/waveformwidgetfactory.h
+++ b/src/waveform/waveformwidgetfactory.h
@@ -194,9 +194,6 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
     void setVisualGain(FilterIndex index, double gain);
     double getVisualGain(FilterIndex index) const;
 
-    void setOverviewNormalized(bool normalize);
-    int isOverviewNormalized() const { return m_overviewNormalized;}
-
     const QVector<WaveformWidgetAbstractHandle>& getAvailableTypes() const {
         return m_waveformWidgetHandles;
     }
@@ -272,7 +269,6 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
     double m_defaultZoom;
     bool m_zoomSync;
     double m_visualGain[FilterCount];
-    bool m_overviewNormalized;
 
     bool m_untilMarkShowBeats;
     bool m_untilMarkShowTime;

--- a/src/widget/wlibrary.cpp
+++ b/src/widget/wlibrary.cpp
@@ -30,6 +30,8 @@ void WLibrary::setup(const QDomNode& node, const SkinContext& context) {
                     kDefaultTrackTableBackgroundColorOpacity),
             kMinTrackTableBackgroundColorOpacity,
             kMaxTrackTableBackgroundColorOpacity);
+
+    m_overviewSignalColors.setup(node, context);
 }
 
 bool WLibrary::registerView(const QString& name, QWidget* pView) {

--- a/src/widget/wlibrary.h
+++ b/src/widget/wlibrary.h
@@ -8,6 +8,7 @@
 #include "library/libraryview.h"
 #include "skin/legacy/skincontext.h"
 #include "util/compatibility/qmutex.h"
+#include "waveform/renderers/waveformsignalcolors.h"
 #include "widget/wbasewidget.h"
 
 class LibraryView;
@@ -55,6 +56,10 @@ class WLibrary : public QStackedWidget, public WBaseWidget {
         return m_bShowButtonText;
     }
 
+    WaveformSignalColors getOverviewSignalColors() const {
+        return m_overviewSignalColors;
+    }
+
   signals:
     FocusWidget setLibraryFocus(FocusWidget newFocus);
 
@@ -77,4 +82,6 @@ class WLibrary : public QStackedWidget, public WBaseWidget {
     QMap<QString, QWidget*> m_viewMap;
     double m_trackTableBackgroundColorOpacity;
     bool m_bShowButtonText;
+
+    WaveformSignalColors m_overviewSignalColors;
 };

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -23,8 +23,7 @@ class SkinContext;
 class WOverview : public WWidget, public TrackDropTarget {
     Q_OBJECT
   public:
-    WOverview(
-            const QString& group,
+    WOverview(const QString& group,
             PlayerManager* pPlayerManager,
             UserSettingsPointer pConfig,
             QWidget* parent = nullptr);
@@ -32,19 +31,11 @@ class WOverview : public WWidget, public TrackDropTarget {
     void setup(const QDomNode& node, const SkinContext& context);
     virtual void initWithTrack(TrackPointer pTrack);
 
-    enum class Type {
-        Filtered,
-        HSV,
-        RGB,
-    };
-    Q_ENUM(Type);
-
   public slots:
     void onConnectedControlChanged(double dParameter, double dValue) override;
     void slotTrackLoaded(TrackPointer pTrack);
     void slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack);
-    void onTrackAnalyzerProgress(TrackId trackId,
-            AnalyzerProgress analyzerProgress);
+    void onTrackAnalyzerProgress(TrackId trackId, AnalyzerProgress analyzerProgress);
 
   signals:
     void trackDropped(const QString& filename, const QString& group) override;
@@ -73,22 +64,12 @@ class WOverview : public WWidget, public TrackDropTarget {
     void slotWaveformSummaryUpdated();
     void slotCueMenuPopupAboutToHide();
 
-    void slotTypeControlChanged(double v);
     void slotMinuteMarkersChanged(bool v);
 
   private:
     // Append the waveform overview pixmap according to available data
     // in waveform
     bool drawNextPixmapPart();
-    void drawNextPixmapPartHSV(QPainter* pPainter,
-            ConstWaveformPointer pWaveform,
-            const int nextCompletion);
-    void drawNextPixmapPartLMH(QPainter* pPainter,
-            ConstWaveformPointer pWaveform,
-            const int nextCompletion);
-    void drawNextPixmapPartRGB(QPainter* pPainter,
-            ConstWaveformPointer pWaveform,
-            const int nextCompletion);
 
     void drawEndOfTrackBackground(QPainter* pPainter);
     void drawAxis(QPainter* pPainter);
@@ -142,7 +123,6 @@ class WOverview : public WWidget, public TrackDropTarget {
     const QString m_group;
     UserSettingsPointer m_pConfig;
 
-    Type m_type;
     int m_actualCompletion;
     bool m_pixmapDone;
     float m_waveformPeak;
@@ -189,7 +169,6 @@ class WOverview : public WWidget, public TrackDropTarget {
     PollingControlProxy m_trackSamplesControl;
     PollingControlProxy m_playpositionControl;
     parented_ptr<ControlProxy> m_pPassthroughControl;
-    parented_ptr<ControlProxy> m_pTypeControl;
     parented_ptr<ControlProxy> m_pMinuteMarkersControl;
 
     QPointF m_timeRulerPos;


### PR DESCRIPTION
@ronso0 This is my work so far. This is obviously still a work in progress, but I am sharing this so that you can take a look and so that we can discuss our next steps. After we make a plan, I will split this into several smaller commits and/or PRs.

Here is a summary of changes:

 - Move overview waveform drawing from `WOverview` into a new component called `OverviewRenderThread` (currently not used as a dedicated overview render thread)
 - Introduction of `OverviewCache` (used by both `WOverview` and `OverviewDelegate`)
 - Introduction of Overview column (mostly a copy of Cover art column)
 - Refactor of Overview waveform render settings and removal of `[Waveform], WaveformOverviewType` CO

Note: I wasn't able to render overviews in a dedicated thread. For some reason I cannot get a database connection inside of that thread.