### PR TITLE
fix: prevent div by zero and use correct config key

### DIFF
--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -73,7 +73,7 @@ DlgPrefWaveform::DlgPrefWaveform(
 
     m_pOverviewMinuteMarkersControl = std::make_unique<ControlObject>(
             ConfigKey(QStringLiteral("[Waveform]"),
-                    QStringLiteral("DrawOverviewMinuteMarkers")));
+                    QStringLiteral("draw_overview_minute_markers")));
     m_pOverviewMinuteMarkersControl->setReadOnly();
 
     // Populate untilMark options
@@ -304,7 +304,7 @@ void DlgPrefWaveform::slotUpdate() {
     }
 
     bool drawOverviewMinuteMarkers = m_pConfig->getValue(
-            ConfigKey("[Waveform]", "DrawOverviewMinuteMarkers"), true);
+            ConfigKey("[Waveform]", "draw_overview_minute_markers"), true);
     overviewMinuteMarkersCheckBox->setChecked(drawOverviewMinuteMarkers);
     m_pOverviewMinuteMarkersControl->forceSet(drawOverviewMinuteMarkers);
 
@@ -575,7 +575,7 @@ void DlgPrefWaveform::slotSetNormalizeOverview(bool normalize) {
 }
 
 void DlgPrefWaveform::slotSetOverviewMinuteMarkers(bool draw) {
-    m_pConfig->setValue(ConfigKey("[Waveform]", "DrawOverviewMinuteMarkers"), draw);
+    m_pConfig->setValue(ConfigKey("[Waveform]", "draw_overview_minute_markers"), draw);
     m_pOverviewMinuteMarkersControl->forceSet(draw);
 }
 

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -88,7 +88,7 @@ WOverview::WOverview(
 
     m_pMinuteMarkersControl = make_parented<ControlProxy>(
             QStringLiteral("[Waveform]"),
-            QStringLiteral("DrawOverviewMinuteMarkers"),
+            QStringLiteral("draw_overview_minute_markers"),
             this);
     m_pMinuteMarkersControl->connectValueChanged(this, &WOverview::slotMinuteMarkersChanged);
     slotMinuteMarkersChanged(static_cast<bool>(m_pMinuteMarkersControl->get()));
@@ -722,6 +722,10 @@ void WOverview::drawMinuteMarkers(QPainter* pPainter) {
     }
 
     if (!static_cast<bool>(m_pMinuteMarkersControl->get())) {
+        return;
+    }
+
+    if (m_pRateRatioControl->get() == 0) {
         return;
     }
 
@@ -1599,9 +1603,14 @@ void WOverview::paintText(const QString& text, QPainter* pPainter) {
 }
 
 double WOverview::samplePositionToSeconds(double sample) {
+    double rate = m_pRateRatioControl->get();
+    VERIFY_OR_DEBUG_ASSERT(rate != 0.0) {
+        return 1;
+    }
+
     double trackTime = sample /
             (m_trackSampleRateControl.get() * mixxx::kEngineChannelOutputCount);
-    return trackTime / m_pRateRatioControl->get();
+    return trackTime / rate;
 }
 
 void WOverview::resizeEvent(QResizeEvent* pEvent) {


### PR DESCRIPTION
This fixes a regression introduced in #13401 where the UI would freeze if the rate control is reduce to zero.

This also adjust the config key to match the `snake_case`