### PR TITLE
Fix RubberBand segafult when changing audio setting

### DIFF
--- a/src/engine/bufferscalers/enginebufferscalerubberband.cpp
+++ b/src/engine/bufferscalers/enginebufferscalerubberband.cpp
@@ -97,7 +97,6 @@ void EngineBufferScaleRubberBand::onSignalChanged() {
     // TODO: Resetting the sample rate will cause internal
     // memory allocations that may block the real-time thread.
     // When is this function actually invoked??
-    m_rubberBand.clear();
     if (!getOutputSignal().isValid()) {
         return;
     }

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -334,6 +334,14 @@ void DlgPrefSound::slotApply() {
         ScopedWaitCursor cursor;
         const auto keylockEngine =
                 keylockComboBox->currentData().value<EngineBuffer::KeylockEngine>();
+
+        // Temporary set an empty config to force the audio thread to stop and
+        // stay off while we are swapping the keylock settings. This is
+        // necessary because the audio thread doesn't have any synchronisation
+        // mechanism due to its realtime nature and editing the RubberBand
+        // config while it is running leads to race conditions.
+        m_pSoundManager->closeActiveConfig();
+
         m_pKeylockEngine.set(static_cast<double>(keylockEngine));
         m_pSettings->set(kKeylockEngingeCfgkey,
                 ConfigValue(static_cast<int>(keylockEngine)));

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -553,22 +553,20 @@ SoundManagerConfig SoundManager::getConfig() const {
     return m_config;
 }
 
-SoundDeviceStatus SoundManager::setConfig(const SoundManagerConfig& config) {
-    SoundDeviceStatus status = SoundDeviceStatus::Ok;
-    m_config = config;
-    checkConfig();
-
+void SoundManager::closeActiveConfig() {
     // Close open devices. After this call we will not get any more
     // onDeviceOutputCallback() or pushBuffer() calls because all the
     // SoundDevices are closed. closeDevices() blocks and can take a while.
     const bool sleepAfterClosing = true;
     closeDevices(sleepAfterClosing);
+}
 
-    // certain parts of mixxx rely on this being here, for the time being, just
-    // letting those be -- bkgood
-    // Do this first so vinyl control gets the right samplerate -- Owen W.
-    m_pConfig->set(ConfigKey("[Soundcard]", "Samplerate"),
-            ConfigValue(static_cast<int>(m_config.getSampleRate().value())));
+SoundDeviceStatus SoundManager::setConfig(const SoundManagerConfig& config) {
+    SoundDeviceStatus status = SoundDeviceStatus::Ok;
+    m_config = config;
+    checkConfig();
+
+    closeActiveConfig();
 
     status = setupDevices();
     if (status == SoundDeviceStatus::Ok) {

--- a/src/soundio/soundmanager.h
+++ b/src/soundio/soundmanager.h
@@ -74,6 +74,7 @@ class SoundManager : public QObject {
     QList<QString> getHostAPIList() const;
     SoundManagerConfig getConfig() const;
     SoundDeviceStatus setConfig(const SoundManagerConfig& config);
+    void closeActiveConfig();
     void checkConfig();
 
     void onDeviceOutputCallback(const SINT iFramesPerBuffer);


### PR DESCRIPTION
Fix a bug introduced by #13143 which would lead to segfault when updating the audio output setting (eg. sample rate, buffer length)

This solution is not ideal as it will simply ensure that the main thread does't free the stretcher while the engine thread is still processing, but the other rubberband instance will still be swapped, leading to the swapped stem channel to be offset-ed by one, and creating a weird desync. 

I cannot found of a solution without introducing some heavy locking, which is a big no-go for the realtime thread. 

Just to summarise the problem 
- Edit the audio setting
- Trigger sent on `keylock_engine` CO (main thread)
- Slot `EngineBuffer::slotKeylockEngineChanged` is ran on main thread and cycle the RubberBand wrappers with new instances using the correct settings

Mainwhile:
- `RubberBandTask::waitReady` is likely blocked on the engine thread, waiting for buffer scaling 

Due to the realtime aspect, the engine thread doesn't have a QEventLoop which could have been useful to schedule to stretcher setup slot.

Happy to go with an alternative solution, if you have a suggestion! 