### PR TITLE
Fix writing global key text after analyzing to library and file metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2114,6 +2114,7 @@ add_executable(mixxx-test
   src/test/imageutils_test.cpp
   src/test/indexrange_test.cpp
   src/test/itunesxmlimportertest.cpp
+  src/test/keyfactorytest.cpp
   src/test/keyutilstest.cpp
   src/test/lcstest.cpp
   src/test/learningutilstest.cpp

--- a/src/test/keyfactorytest.cpp
+++ b/src/test/keyfactorytest.cpp
@@ -1,0 +1,27 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <QDebug>
+
+#include "track/keyfactory.h"
+
+using ::testing::UnorderedElementsAre;
+
+class KeyFactoryTest : public testing::Test {
+};
+
+TEST_F(KeyFactoryTest, MakePreferredKeys) {
+    KeyChangeList key_changes = {
+            {mixxx::track::io::key::B_MAJOR, 1.0},
+            {mixxx::track::io::key::B_MINOR, 2.0},
+            {mixxx::track::io::key::B_MAJOR, 3.0},
+    };
+    QHash<QString, QString> extraVersionInfo = {{QStringLiteral("a"), QStringLiteral("b")}};
+
+    Keys track_keys = KeyFactory::makePreferredKeys(
+            key_changes, extraVersionInfo, mixxx::audio::SampleRate(44100), 4.0);
+
+    EXPECT_EQ(track_keys.getGlobalKey(), mixxx::track::io::key::B_MAJOR);
+    EXPECT_EQ(track_keys.getGlobalKeyText().toStdString(), "B");
+    EXPECT_EQ(track_keys.getSubVersion().toStdString(), "a=b");
+}

--- a/src/track/keyfactory.cpp
+++ b/src/track/keyfactory.cpp
@@ -106,7 +106,14 @@ Keys KeyFactory::makePreferredKeys(
             pChange->set_key(it->first);
             pChange->set_frame_position(static_cast<int>(frame));
         }
-        key_map.set_global_key(KeyUtils::calculateGlobalKey(key_changes, totalFrames, sampleRate));
+
+        mixxx::track::io::key::ChromaticKey global_key =
+                KeyUtils::calculateGlobalKey(
+                        key_changes, totalFrames, sampleRate);
+        key_map.set_global_key(global_key);
+        QString global_key_text = KeyUtils::keyToString(
+                global_key, KeyUtils::KeyNotation::ID3v2);
+        key_map.set_global_key_text(global_key_text.toStdString());
         key_map.set_source(mixxx::track::io::key::ANALYZER);
         Keys keys(key_map);
         keys.setSubVersion(subVersion);


### PR DESCRIPTION
This fixes #13646 a regression since #11096

Thank you @uklotzde for finding this bug just in time before the 2.5-beta period ends.

 I have also added a unittest. 