### PR TITLE
fix: exclude stem samples for QML waveform

### DIFF
--- a/src/qml/qmlplayerproxy.cpp
+++ b/src/qml/qmlplayerproxy.cpp
@@ -220,11 +220,7 @@ void QmlPlayerProxy::slotWaveformChanged() {
     // Make a copy of the waveform data, stripping the stems portion. Note that the datasize is
     // different from the texture size -- we want the full texture size so the upload works. See
     // m_data in waveform/waveform.h.
-    if (m_waveformData.size() == 0 ||
-            static_cast<int>(m_waveformData.size()) !=
-                    pWaveform->getTextureSize()) {
-        m_waveformData.resize(pWaveform->getTextureSize());
-    }
+    m_waveformData.resize(pWaveform->getTextureSize());
     for (int i = 0; i < pWaveform->getDataSize(); i++) {
         m_waveformData[i] = data[i].filtered;
     }

--- a/src/qml/qmlplayerproxy.h
+++ b/src/qml/qmlplayerproxy.h
@@ -12,6 +12,7 @@
 #include "qml/qmlstemsmodel.h"
 #include "track/cueinfo.h"
 #include "track/track.h"
+#include "waveform/waveform.h"
 
 namespace mixxx {
 namespace qml {
@@ -151,6 +152,7 @@ class QmlPlayerProxy : public QObject {
     void waveformTextureStrideChanged();
 
   private:
+    std::vector<WaveformFilteredData> m_waveformData;
     QImage m_waveformTexture;
     QPointer<BaseTrackPlayer> m_pTrackPlayer;
     TrackPointer m_pCurrentTrack;


### PR DESCRIPTION
Fixes the same issue than #13472 on QML