### PR TITLE
fix: prevent crash when no app windows have the focus

### DIFF
--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -1039,10 +1039,10 @@ void LibraryControl::slotGoToItem(double v) {
         // press & release Space (QAbstractButton::clicked() is emitted on release)
         QKeyEvent pressSpace = QKeyEvent{QEvent::KeyPress, Qt::Key_Space, Qt::NoModifier};
         QKeyEvent releaseSpace = QKeyEvent{QEvent::KeyRelease, Qt::Key_Space, Qt::NoModifier};
-        auto window = QApplication::focusWindow();
-        if (window) {
-            QApplication::sendEvent(window, &pressSpace);
-            QApplication::sendEvent(window, &releaseSpace);
+        auto* pWindow = QApplication::focusWindow();
+        if (pWindow) {
+            QApplication::sendEvent(pWindow, &pressSpace);
+            QApplication::sendEvent(pWindow, &releaseSpace);
         }
         return;
     }
@@ -1057,9 +1057,9 @@ void LibraryControl::slotGoToItem(double v) {
         // If Unknown is some other 'untrained' or unresponsive widget
         // GoToItem is inappropriate and we can't do much about that.
         QKeyEvent event = QKeyEvent{QEvent::KeyPress, Qt::Key_Return, Qt::NoModifier};
-        auto window = QApplication::focusWindow();
-        if (window) {
-            QApplication::sendEvent(window, &event);
+        auto* pWindow = QApplication::focusWindow();
+        if (pWindow) {
+            QApplication::sendEvent(pWindow, &event);
         }
         return;
     }

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -1039,8 +1039,11 @@ void LibraryControl::slotGoToItem(double v) {
         // press & release Space (QAbstractButton::clicked() is emitted on release)
         QKeyEvent pressSpace = QKeyEvent{QEvent::KeyPress, Qt::Key_Space, Qt::NoModifier};
         QKeyEvent releaseSpace = QKeyEvent{QEvent::KeyRelease, Qt::Key_Space, Qt::NoModifier};
-        QApplication::sendEvent(QApplication::focusWindow(), &pressSpace);
-        QApplication::sendEvent(QApplication::focusWindow(), &releaseSpace);
+        auto window = QApplication::focusWindow();
+        if (window) {
+            QApplication::sendEvent(window, &pressSpace);
+            QApplication::sendEvent(window, &releaseSpace);
+        }
         return;
     }
     case FocusWidget::ContextMenu:
@@ -1054,7 +1057,10 @@ void LibraryControl::slotGoToItem(double v) {
         // If Unknown is some other 'untrained' or unresponsive widget
         // GoToItem is inappropriate and we can't do much about that.
         QKeyEvent event = QKeyEvent{QEvent::KeyPress, Qt::Key_Return, Qt::NoModifier};
-        QApplication::sendEvent(QApplication::focusWindow(), &event);
+        auto window = QApplication::focusWindow();
+        if (window) {
+            QApplication::sendEvent(window, &event);
+        }
         return;
     }
     case FocusWidget::Searchbar:


### PR DESCRIPTION
This crash occurs when using the `GoToItem` while a window is open in Mixxx (eg. settings) and was last to have focus, but the Mixxx application doesn't have the focus anymore 