### PR TITLE
chore: add note about ConfigKey naming convention

### DIFF
--- a/src/preferences/configobject.h
+++ b/src/preferences/configobject.h
@@ -15,6 +15,8 @@
 
 // Class for the key for a specific configuration element. A key consists of a
 // group and an item.
+//
+// NOTE: new ConfigKey's item should use the `snake_case` formatting
 class ConfigKey final {
   public:
     ConfigKey() = default; // is required for qMetaTypeConstructHelper()

--- a/src/preferences/dialog/dlgprefcolors.cpp
+++ b/src/preferences/dialog/dlgprefcolors.cpp
@@ -22,7 +22,7 @@ const ConfigKey kAutoHotcueColorsConfigKey("[Controls]", "auto_hotcue_colors");
 const ConfigKey kAutoLoopColorsConfigKey("[Controls]", "auto_loop_colors");
 const ConfigKey kHotcueDefaultColorIndexConfigKey("[Controls]", "HotcueDefaultColorIndex");
 const ConfigKey kLoopDefaultColorIndexConfigKey("[Controls]", "LoopDefaultColorIndex");
-const ConfigKey kKeyColorsEnabledConfigKey("[Config]", "KeyColorsEnabled");
+const ConfigKey kKeyColorsEnabledConfigKey("[Config]", "key_colors_enabled");
 
 } // anonymous namespace
 

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -1566,7 +1566,7 @@ QWidget* LegacySkinParser::parseLibrary(const QDomElement& node) {
 
     const auto keyColorsEnabled =
             m_pConfig->getValue(
-                    ConfigKey("[Config]", "KeyColorsEnabled"),
+                    ConfigKey("[Config]", "key_colors_enabled"),
                     BaseTrackTableModel::kKeyColorsEnabledDefault);
     BaseTrackTableModel::setKeyColorsEnabled(keyColorsEnabled);
 


### PR DESCRIPTION
Let me know if you can see anywhere where it would be worth pointing out as well.