### PR TITLE
CmdlineArgs: Add `--rescan-library` for rescanning on startup

### DIFF
--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -406,8 +406,8 @@ void CoreServices::initialize(QApplication* pApp) {
     m_pControllerManager = std::make_shared<ControllerManager>(pConfig);
 
     // Scan the library for new files and directories
-    bool rescan = pConfig->getValue<bool>(
-            library::prefs::kRescanOnStartupConfigKey);
+    bool rescan = m_cmdlineArgs.getRescanLibrary() ||
+            pConfig->getValue<bool>(library::prefs::kRescanOnStartupConfigKey);
     // rescan the library if we get a new plugin
     QList<QString> prev_plugins_list =
             pConfig->getValueString(

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -49,6 +49,7 @@ bool calcUseColorsAuto() {
 CmdlineArgs::CmdlineArgs()
         : m_startInFullscreen(false), // Initialize vars
           m_startAutoDJ(false),
+          m_rescanLibrary(false),
           m_controllerDebug(false),
           m_controllerAbortOnWarning(false),
           m_developer(false),
@@ -186,6 +187,12 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
                                       "Starts Auto DJ when Mixxx is launched.")
                             : QString());
     parser.addOption(startAutoDJ);
+
+    const QCommandLineOption rescanLibrary(QStringLiteral("rescan-library"),
+            forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
+                                      "Rescans the library when Mixxx is launched.")
+                            : QString());
+    parser.addOption(rescanLibrary);
 
     // An option with a value
     const QCommandLineOption settingsPath(QStringLiteral("settings-path"),
@@ -389,6 +396,10 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
 
     if (parser.isSet(startAutoDJ)) {
         m_startAutoDJ = true;
+    }
+
+    if (parser.isSet(rescanLibrary)) {
+        m_rescanLibrary = true;
     }
 
     if (parser.isSet(settingsPath)) {

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -33,6 +33,9 @@ class CmdlineArgs final {
     bool getStartAutoDJ() const {
         return m_startAutoDJ;
     }
+    bool getRescanLibrary() const {
+        return m_rescanLibrary;
+    }
     bool getControllerDebug() const {
         return m_controllerDebug;
     }
@@ -89,6 +92,7 @@ class CmdlineArgs final {
     QList<QString> m_musicFiles;    // List of files to load into players at startup
     bool m_startInFullscreen;       // Start in fullscreen mode
     bool m_startAutoDJ;
+    bool m_rescanLibrary;
     bool m_controllerDebug;
     bool m_controllerPreviewScreens;
     bool m_controllerAbortOnWarning; // Controller Engine will be stricter


### PR DESCRIPTION
This adds a small convenience flag for rescanning the library on startup without changing the settings.