### PR TITLE
feat: add file and color controller setting types

### DIFF
--- a/res/controllers/Dummy Device Screen.hid.xml
+++ b/res/controllers/Dummy Device Screen.hid.xml
@@ -39,6 +39,28 @@
                        The background used for empty decks
                    </description>
                </option>
+                <option
+                    variable="deckA"
+                    type="enum"
+                    label="Deck A">
+                    <value color="#FF0000" label="Red">red</value>
+                    <value color="#FF5E00" label="Carrot">carrot</value>
+                    <value color="#FF7800" label="Orange">orange</value>
+                    <value color="#FF9200" label="Honey">honey</value>
+                    <value color="#FFFF00" label="Yellow">yellow</value>
+                    <value color="#81FF00" label="Lime">lime</value>
+                    <value color="#00FF00" label="Green">green</value>
+                    <value color="#00FF49" label="Aqua">aqua</value>
+                    <value color="#00FFFF" label="Celeste">celeste</value>
+                    <value color="#0091FF" label="Sky">sky</value>
+                    <value color="#0000FF" label="Blue">blue</value>
+                    <value color="#FF00FF" label="Purple">purple</value>
+                    <value color="#FF0091" label="Fuscia">fuscia</value>
+                    <value color="#FF0079" label="Magenta">magenta</value>
+                    <value color="#FF477E" label="Azalea">azalea</value>
+                    <value color="#FF4761" label="Salmon">salmon</value>
+                    <value color="#FFFFFF" label="White">white</value>
+                </option>
             </row>
          </group>
     </settings>

--- a/res/controllers/Dummy Device Screen.hid.xml
+++ b/res/controllers/Dummy Device Screen.hid.xml
@@ -8,6 +8,40 @@
             <product protocol="hid" vendor_id="0xdead" product_id="0xbeaf" />
         </devices>
     </info>
+    <settings>
+        <group label="Cosmetic">
+            <row orientation="vertical">
+                <option
+                    variable="theme"
+                    type="enum"
+                    label="Theme use for the screen">
+                    <description>
+                        The theme used for the screens
+                    </description>
+                    <value label="Classic" default="true">stock</value>
+                    <value label="Advanced">advanced</value>
+                </option>
+               <option
+                   variable="idleBackground"
+                   type="file"
+                   pattern="Images (*.png *.gif *.jpg)"
+                   label="Idle deck background">
+                   <description>
+                       The background used for empty decks
+                   </description>
+               </option>
+               <option
+                   variable="accentColor"
+                   type="color"
+                   default="orange"
+                   label="Accent color">
+                   <description>
+                       The background used for empty decks
+                   </description>
+               </option>
+            </row>
+         </group>
+    </settings>
     <controller id="DummyDevice">
         <screens>
             <screen identifier="main" width="480" height="360" targetFps="20" pixelType="RBGA" splashoff="500" />

--- a/src/controllers/legacycontrollersettings.cpp
+++ b/src/controllers/legacycontrollersettings.cpp
@@ -256,8 +256,8 @@ void LegacyControllerEnumSetting::parse(const QString& in, bool* ok) {
     save();
 
     size_t pos = 0;
-    for (const auto& value : std::as_const(m_options)) {
-        if (std::get<0>(value) == in) {
+    for (const auto& item : std::as_const(m_options)) {
+        if (item.value == in) {
             if (ok != nullptr) {
                 *ok = true;
             }
@@ -272,8 +272,15 @@ void LegacyControllerEnumSetting::parse(const QString& in, bool* ok) {
 QWidget* LegacyControllerEnumSetting::buildInputWidget(QWidget* pParent) {
     auto* pComboBox = new QComboBox(pParent);
 
-    for (const auto& value : std::as_const(m_options)) {
-        pComboBox->addItem(std::get<1>(value));
+    for (const auto& item : std::as_const(m_options)) {
+        if (item.color.isValid()) {
+            QPixmap icon(24, 24);
+            QPainter painter(&icon);
+            painter.fillRect(0, 0, 24, 24, item.color);
+            pComboBox->addItem(QIcon(icon), item.label);
+        } else {
+            pComboBox->addItem(item.label);
+        }
     }
     pComboBox->setCurrentIndex(static_cast<int>(m_editedValue));
 

--- a/src/controllers/legacycontrollersettings.h
+++ b/src/controllers/legacycontrollersettings.h
@@ -184,7 +184,7 @@ class LegacyControllerBooleanSetting
     bool m_defaultValue;
     bool m_editedValue;
 
-    friend class LegacyControllerMappingSettingsTest_booleanSettingEditing_Test;
+    FRIEND_TEST(LegacyControllerMappingSettingsTest, booleanSettingEditing);
 };
 
 template<class SettingType>
@@ -301,8 +301,8 @@ class LegacyControllerNumberSetting
 
     SettingType m_editedValue;
 
-    friend class LegacyControllerMappingSettingsTest_integerSettingEditing_Test;
-    friend class LegacyControllerMappingSettingsTest_doubleSettingEditing_Test;
+    FRIEND_TEST(LegacyControllerMappingSettingsTest, integerSettingEditing);
+    FRIEND_TEST(LegacyControllerMappingSettingsTest, doubleSettingEditing);
 };
 
 template<class T>
@@ -429,8 +429,8 @@ class LegacyControllerEnumSetting
 
     size_t m_editedValue;
 
-    friend class LegacyControllerMappingSettingsTest_enumSettingEditing_Test;
-    friend class ControllerS4MK3SettingTest_ensureLibrarySettingValueAndEnumEquals;
+    FRIEND_TEST(LegacyControllerMappingSettingsTest, enumSettingEditing);
+    FRIEND_TEST(ControllerS4MK3SettingTest, ensureLibrarySettingValueAndEnumEquals);
 };
 
 class LegacyControllerColorSetting

--- a/src/controllers/legacycontrollersettings.h
+++ b/src/controllers/legacycontrollersettings.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <gtest/gtest_prod.h>
+
+#include <QColor>
+#include <QFileInfo>
 #include <QJSValue>
 
 #include "controllers/legacycontrollersettingsfactory.h"
@@ -421,6 +425,150 @@ class LegacyControllerEnumSetting
 
     friend class LegacyControllerMappingSettingsTest_enumSettingEditing_Test;
     friend class ControllerS4MK3SettingTest_ensureLibrarySettingValueAndEnumEquals;
+};
+
+class LegacyControllerColorSetting
+        : public LegacyControllerSettingFactory<LegacyControllerColorSetting>,
+          public AbstractLegacyControllerSetting {
+  public:
+    LegacyControllerColorSetting(const QDomElement& element);
+
+    ~LegacyControllerColorSetting() override;
+
+    QJSValue value() const override {
+        return QJSValue(stringify());
+    }
+
+    QString stringify() const override {
+        return m_savedValue.name(QColor::HexRgb);
+    }
+    void parse(const QString& in, bool* ok) override;
+    bool isDefault() const override {
+        return m_savedValue == m_defaultValue;
+    }
+    bool isDirty() const override {
+        return m_savedValue != m_editedValue;
+    }
+
+    virtual void save() override {
+        m_savedValue = m_editedValue;
+    }
+
+    virtual void reset() override {
+        m_editedValue = m_defaultValue;
+        emit valueReset();
+    }
+
+    /// @brief Whether or not this setting definition and its current state are
+    /// valid. Validity scope includes a known default/current/dirty option.
+    /// @return true if valid
+    bool valid() const override {
+        return AbstractLegacyControllerSetting::valid() &&
+                m_defaultValue.isValid() &&
+                m_savedValue.isValid();
+    }
+
+    static AbstractLegacyControllerSetting* createFrom(const QDomElement& element) {
+        return new LegacyControllerColorSetting(element);
+    }
+    static inline bool match(const QDomElement& element) {
+        return element.hasAttribute(QStringLiteral("type")) &&
+                QString::compare(element.attribute(QStringLiteral("type")),
+                        QStringLiteral("color"),
+                        Qt::CaseInsensitive) == 0;
+    }
+
+  protected:
+    LegacyControllerColorSetting(const QDomElement& element,
+            QColor currentValue,
+            QColor defaultValue)
+            : AbstractLegacyControllerSetting(element),
+              m_defaultValue(defaultValue),
+              m_savedValue(currentValue) {
+    }
+
+    virtual QWidget* buildInputWidget(QWidget* parent) override;
+
+  private:
+    QColor m_defaultValue;
+    QColor m_savedValue;
+
+    QColor m_editedValue;
+
+    FRIEND_TEST(ControllerS4MK3SettingTest, ensureLibrarySettingValueAndEnumEquals);
+    FRIEND_TEST(LegacyControllerMappingSettingsTest, enumSettingEditing);
+};
+
+class LegacyControllerFileSetting
+        : public LegacyControllerSettingFactory<LegacyControllerFileSetting>,
+          public AbstractLegacyControllerSetting {
+  public:
+    LegacyControllerFileSetting(const QDomElement& element);
+
+    virtual ~LegacyControllerFileSetting();
+
+    QJSValue value() const override {
+        return QJSValue(stringify());
+    }
+
+    QString stringify() const override {
+        return m_savedValue.absoluteFilePath();
+    }
+    void parse(const QString& in, bool* ok) override;
+    bool isDefault() const override {
+        return m_savedValue == m_defaultValue;
+    }
+    bool isDirty() const override {
+        return m_savedValue != m_editedValue;
+    }
+
+    virtual void save() override {
+        m_savedValue = m_editedValue;
+    }
+
+    virtual void reset() override {
+        m_editedValue = m_defaultValue;
+        emit valueReset();
+    }
+
+    /// @brief Whether or not this setting definition and its current state are
+    /// valid. Validity scope includes a known default/current/dirty option.
+    /// @return true if valid
+    bool valid() const override {
+        return AbstractLegacyControllerSetting::valid() &&
+                (m_defaultValue == m_savedValue || m_savedValue.exists());
+    }
+
+    static AbstractLegacyControllerSetting* createFrom(const QDomElement& element) {
+        return new LegacyControllerFileSetting(element);
+    }
+    static bool match(const QDomElement& element) {
+        return element.hasAttribute(QStringLiteral("type")) &&
+                QString::compare(element.attribute(QStringLiteral("type")),
+                        QStringLiteral("file"),
+                        Qt::CaseInsensitive) == 0;
+    }
+
+  protected:
+    LegacyControllerFileSetting(const QDomElement& element,
+            const QFileInfo& currentValue,
+            const QFileInfo& defaultValue)
+            : AbstractLegacyControllerSetting(element),
+              m_defaultValue(defaultValue),
+              m_savedValue(currentValue) {
+    }
+
+    QWidget* buildInputWidget(QWidget* parent) override;
+
+  private:
+    QString m_fileFilter;
+    QFileInfo m_defaultValue;
+    QFileInfo m_savedValue;
+
+    QFileInfo m_editedValue;
+
+    FRIEND_TEST(LegacyControllerMappingSettingsTest, enumSettingEditing);
+    FRIEND_TEST(ControllerS4MK3SettingTest, ensureLibrarySettingValueAndEnumEquals);
 };
 
 template<>

--- a/src/controllers/legacycontrollersettings.h
+++ b/src/controllers/legacycontrollersettings.h
@@ -355,6 +355,12 @@ class LegacyControllerEnumSetting
         : public LegacyControllerSettingFactory<LegacyControllerEnumSetting>,
           public AbstractLegacyControllerSetting {
   public:
+    struct Item {
+        QString value;
+        QString label;
+        QColor color;
+    };
+
     LegacyControllerEnumSetting(const QDomElement& element);
 
     virtual ~LegacyControllerEnumSetting() = default;
@@ -363,12 +369,12 @@ class LegacyControllerEnumSetting
         return QJSValue(stringify());
     }
 
-    const QList<std::tuple<QString, QString>>& options() const {
+    const QList<Item>& options() const {
         return m_options;
     }
 
     QString stringify() const override {
-        return std::get<0>(m_options.value(static_cast<int>(m_savedValue)));
+        return m_options.value(static_cast<int>(m_savedValue)).value;
     }
     void parse(const QString& in, bool* ok) override;
     bool isDefault() const override {
@@ -404,7 +410,7 @@ class LegacyControllerEnumSetting
 
   protected:
     LegacyControllerEnumSetting(const QDomElement& element,
-            const QList<std::tuple<QString, QString>>& options,
+            const QList<Item>& options,
             size_t currentValue,
             size_t defaultValue)
             : AbstractLegacyControllerSetting(element),
@@ -417,7 +423,7 @@ class LegacyControllerEnumSetting
 
   private:
     // We use a QList instead of QHash here because we want to keep the natural order
-    QList<std::tuple<QString, QString>> m_options;
+    QList<Item> m_options;
     size_t m_savedValue;
     size_t m_defaultValue;
 

--- a/src/test/controllers/controller_columnid_regression_test.cpp
+++ b/src/test/controllers/controller_columnid_regression_test.cpp
@@ -76,7 +76,7 @@ TEST_F(ControllerLibraryColumnIDRegressionTest, ensureS4MK3) {
         auto pEnum = std::dynamic_pointer_cast<LegacyControllerEnumSetting>(setting);
         EXPECT_TRUE(pEnum);
         for (const auto& opt : pEnum->options()) {
-            EXPECT_EQ(static_cast<int>(COLUMN_MAPPING[std::get<0>(opt)]), std::get<1>(opt).toInt());
+            EXPECT_EQ(static_cast<int>(COLUMN_MAPPING[opt.value]), opt.label.toInt());
         }
         count++;
     }


### PR DESCRIPTION
Add new controller setting type, particularly useful for screen mapping.

https://github.com/user-attachments/assets/af1e2df9-e273-4471-ac39-535bfbc4fbdd

TODO:
- [x] Unit test
- [x] Improved UI