### PR TITLE
fix: sync rate using the current BPM instead of the file one

### DIFF
--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -278,7 +278,7 @@ void SyncControl::reinitLeaderParams(
         kLogger.trace() << "SyncControl::reinitLeaderParams" << getGroup()
                         << beatDistance << baseBpm << bpm;
     }
-    m_leaderBpmAdjustFactor = determineBpmMultiplier(fileBpm(), baseBpm);
+    m_leaderBpmAdjustFactor = determineBpmMultiplier(mixxx::Bpm(m_pBpm->get()), bpm);
     updateLeaderBpm(bpm);
     updateLeaderBeatDistance(beatDistance);
 }

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -284,7 +284,7 @@ void SyncControl::reinitLeaderParams(
 }
 
 double SyncControl::determineBpmMultiplier(mixxx::Bpm myBpm, mixxx::Bpm targetBpm) const {
-    if (!myBpm.isValid() || !targetBpm.isValid()) {
+    if (!myBpm.isValid() || !targetBpm.isValid() || myBpm.isNull() || targetBpm.isNull()) {
         return kBpmUnity;
     }
     double unityRatio = myBpm / targetBpm;

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -284,7 +284,7 @@ void SyncControl::reinitLeaderParams(
 }
 
 double SyncControl::determineBpmMultiplier(mixxx::Bpm myBpm, mixxx::Bpm targetBpm) const {
-    if (!myBpm.isValid() || !targetBpm.isValid() || myBpm.isNull() || targetBpm.isNull()) {
+    if (!myBpm.isValid() || !targetBpm.isValid()) {
         return kBpmUnity;
     }
     double unityRatio = myBpm / targetBpm;

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -3147,7 +3147,7 @@ TEST_F(EngineSyncTest, KeepCorrectFactorUponResync) {
 }
 
 // There is a race condition preventing this usecase to work.
-// https://github.com/mixxxdj/mixxx/issues/????
+// https://github.com/mixxxdj/mixxx/issues/13689
 TEST_F(EngineSyncTest, DISABLED_KeepCorrectFactorOnLoad) {
     /* Usecase
         - load track @ 174bpm in deck 1 and enable sync leader

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -671,10 +671,10 @@ TEST_F(EngineSyncTest, RateChangeTest) {
     EXPECT_DOUBLE_EQ(
             120.0, ControlObject::get(ConfigKey(m_sGroup2, "file_bpm")));
 
-    // rate slider for channel 2 should now be 1.6 = 160 * 1.2 / 120.
-    EXPECT_DOUBLE_EQ(getRateSliderValue(1.6),
+    EXPECT_DOUBLE_EQ(getRateSliderValue(0.8),
             ControlObject::get(ConfigKey(m_sGroup2, "rate")));
-    EXPECT_DOUBLE_EQ(192.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
+    // Leader is currently 192, BPM before sync is 120, so the closer sync should be 96
+    EXPECT_DOUBLE_EQ(96.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
 }
 
 TEST_F(EngineSyncTest, RateChangeTestWeirdOrder) {
@@ -2105,8 +2105,8 @@ TEST_F(EngineSyncTest, HalfDoubleEachOther) {
             ControlObject::getControl(ConfigKey(m_sGroup1, "bpm"))->get());
 
     // Threshold 1.414 sqrt(2);
-    // 150 / 105 = 1.43
-    // 105 / 75 = 1.40
+    // 150 / 144 = 1.04
+    // 144 / 75 = 1.92
     // expect 75 BPM
 
     mixxx::BeatsPointer pBeats1b = mixxx::Beats::fromConstTempo(
@@ -2120,7 +2120,7 @@ TEST_F(EngineSyncTest, HalfDoubleEachOther) {
     ControlObject::getControl(ConfigKey(m_sGroup2, "sync_enabled"))->set(1.0);
     ControlObject::getControl(ConfigKey(m_sGroup2, "sync_enabled"))->set(0.0);
 
-    EXPECT_DOUBLE_EQ(75.0,
+    EXPECT_DOUBLE_EQ(150,
             ControlObject::getControl(ConfigKey(m_sGroup2, "bpm"))->get());
 
     ControlObject::getControl(ConfigKey(m_sGroup1, "sync_enabled"))->set(1.0);

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -3114,3 +3114,34 @@ TEST_F(EngineSyncTest, BeatContextRounding) {
             ControlObject::get(ConfigKey(m_sGroup1, "playposition")),
             kMaxFloatingPointErrorHighPrecision);
 }
+
+TEST_F(EngineSyncTest, KeepCorrectFactorUponResync) {
+    /* Usecase
+        - load track @ 174bpm in deck 1
+        - load track @ 87 bpm in deck 2
+        - Sync deck 2 to 1, keep 87 BPM on deck 2
+        - adjust rate slider on deck 1 to 184bpm
+        - Sync deck 2 to 1, get 92 BPM on deck 2
+    */
+    m_pMixerDeck1->loadFakeTrack(false, 174.0);
+    m_pMixerDeck2->loadFakeTrack(false, 87.0);
+    ProcessBuffer();
+
+    EXPECT_DOUBLE_EQ(174.0, ControlObject::get(ConfigKey(m_sGroup1, "bpm")));
+    EXPECT_DOUBLE_EQ(87.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
+
+    ControlObject::set(ConfigKey(m_sGroup2, "sync_enabled"), 1.0);
+    ControlObject::set(ConfigKey(m_sGroup1, "sync_leader"), 1.0);
+    ProcessBuffer();
+
+    EXPECT_DOUBLE_EQ(174.0, ControlObject::get(ConfigKey(m_sGroup1, "bpm")));
+    EXPECT_DOUBLE_EQ(87.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")));
+
+    ControlObject::set(ConfigKey(m_sGroup1, "rate"), getRateSliderValue(184.0 / 174));
+    ProcessBuffer();
+    EXPECT_NEAR(184.0, ControlObject::get(ConfigKey(m_sGroup1, "bpm")), 0.001);
+    EXPECT_NEAR(92.0, ControlObject::get(ConfigKey(m_sGroup2, "bpm")), 0.001);
+    EXPECT_NEAR(getRateSliderValue(1.0574),
+            ControlObject::get(ConfigKey(m_sGroup2, "rate")),
+            0.005);
+}

--- a/src/track/bpm.h
+++ b/src/track/bpm.h
@@ -45,6 +45,10 @@ public:
         return isValidValue(m_value);
     }
 
+    bool isNull() const {
+        return m_value == kValueMin;
+    }
+
     /// Return the valid value.
     ///
     /// Triggers a debug assertion if the value is invalid

--- a/src/track/bpm.h
+++ b/src/track/bpm.h
@@ -45,10 +45,6 @@ public:
         return isValidValue(m_value);
     }
 
-    bool isNull() const {
-        return m_value == kValueMin;
-    }
-
     /// Return the valid value.
     ///
     /// Triggers a debug assertion if the value is invalid


### PR DESCRIPTION
Fixes #12738

It doesn't make much sense to use the original file BPM as it is irrelevant to the user. In case it is, they could always reset the fader to zero before syncing, in which case sync behaviour will have the same effect as today