### PR TITLE
Musicbrainz: Improved messages in case of empty results 

### DIFF
--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -481,15 +481,15 @@ void DlgTagFetcher::setPercentOfEachRecordings(int totalRecordingsFound) {
 
 void DlgTagFetcher::fetchTagFinished(
         TrackPointer pTrack,
-        const QList<mixxx::musicbrainz::TrackRelease>& guessedTrackReleases) {
+        const QList<mixxx::musicbrainz::TrackRelease>& guessedTrackReleases,
+        const QString& whyEmptyMessage) {
     VERIFY_OR_DEBUG_ASSERT(pTrack == m_pTrack) {
         return;
     }
     m_data.m_tags = guessedTrackReleases;
     if (guessedTrackReleases.size() == 0) {
         loadingProgressBar->setValue(kMaximumValueOfQProgressBar);
-        QString emptyMessage = tr("Could not find this track in the MusicBrainz database.");
-        loadingProgressBar->setFormat(emptyMessage);
+        loadingProgressBar->setFormat(whyEmptyMessage);
         return;
     } else {
         btnApply->setDisabled(true);

--- a/src/library/dlgtagfetcher.h
+++ b/src/library/dlgtagfetcher.h
@@ -41,7 +41,8 @@ class DlgTagFetcher : public QDialog, public Ui::DlgTagFetcher {
   private slots:
     void fetchTagFinished(
             TrackPointer pTrack,
-            const QList<mixxx::musicbrainz::TrackRelease>& guessedTrackReleases);
+            const QList<mixxx::musicbrainz::TrackRelease>& guessedTrackReleases,
+            const QString& whyEmptyMessage);
     void tagSelected();
     void showProgressOfConstantTask(const QString&);
     void setPercentOfEachRecordings(int totalRecordingsFound);

--- a/src/musicbrainz/tagfetcher.cpp
+++ b/src/musicbrainz/tagfetcher.cpp
@@ -116,7 +116,8 @@ void TagFetcher::slotFingerprintReady() {
     if (fingerprint.isEmpty()) {
         emit resultAvailable(
                 m_pTrack,
-                QList<mixxx::musicbrainz::TrackRelease>());
+                {},
+                tr("Reading track for fingerprinting failed."));
         return;
     }
 
@@ -165,7 +166,8 @@ void TagFetcher::slotAcoustIdTaskSucceeded(
 
         emit resultAvailable(
                 std::move(pTrack),
-                QList<mixxx::musicbrainz::TrackRelease>());
+                {},
+                tr("Could not identify track through Acoustid."));
         return;
     }
 
@@ -299,9 +301,15 @@ void TagFetcher::slotMusicBrainzTaskSucceeded(
     auto pTrack = m_pTrack;
     terminate();
 
+    QString whyEmptyMessage;
+    if (guessedTrackReleases.empty()) {
+        whyEmptyMessage = tr("Could not find this track in the MusicBrainz database.");
+    }
+
     emit resultAvailable(
             std::move(pTrack),
-            std::move(guessedTrackReleases));
+            std::move(guessedTrackReleases),
+            whyEmptyMessage);
 }
 
 void TagFetcher::startFetchCoverArtLinks(

--- a/src/musicbrainz/tagfetcher.cpp
+++ b/src/musicbrainz/tagfetcher.cpp
@@ -121,7 +121,7 @@ void TagFetcher::slotFingerprintReady() {
         return;
     }
 
-    emit fetchProgress(tr("Identifying track through Acoustid"));
+    emit fetchProgress(tr("Identifying track through AcoustID"));
     DEBUG_ASSERT(!m_pAcoustIdTask);
     m_pAcoustIdTask = make_parented<mixxx::AcoustIdLookupTask>(
             &m_network,
@@ -167,7 +167,7 @@ void TagFetcher::slotAcoustIdTaskSucceeded(
         emit resultAvailable(
                 std::move(pTrack),
                 {},
-                tr("Could not identify track through Acoustid."));
+                tr("Could not identify track through AcoustID."));
         return;
     }
 
@@ -301,15 +301,17 @@ void TagFetcher::slotMusicBrainzTaskSucceeded(
     auto pTrack = m_pTrack;
     terminate();
 
-    QString whyEmptyMessage;
     if (guessedTrackReleases.empty()) {
-        whyEmptyMessage = tr("Could not find this track in the MusicBrainz database.");
+        emit resultAvailable(
+                std::move(pTrack),
+                {},
+                tr("Could not find this track in the MusicBrainz database."));
+    } else {
+        emit resultAvailable(
+                std::move(pTrack),
+                std::move(guessedTrackReleases),
+                {});
     }
-
-    emit resultAvailable(
-            std::move(pTrack),
-            std::move(guessedTrackReleases),
-            whyEmptyMessage);
 }
 
 void TagFetcher::startFetchCoverArtLinks(

--- a/src/musicbrainz/tagfetcher.h
+++ b/src/musicbrainz/tagfetcher.h
@@ -47,7 +47,8 @@ class TagFetcher : public QObject {
   signals:
     void resultAvailable(
             TrackPointer pTrack,
-            const QList<mixxx::musicbrainz::TrackRelease>& guessedTrackReleases);
+            const QList<mixxx::musicbrainz::TrackRelease>& guessedTrackReleases,
+            const QString& whyEmptyMessage); // To explain why the result is empty
     void fetchProgress(
             const QString& message);
     void numberOfRecordingsFoundFromAcoustId(int totalNumberOfRecordings);


### PR DESCRIPTION
Allow to use different messages in case Musikbrainz lookup ends without results.
This fixes #13666

Since this PR moves a translatable text form on object to another we need an Transifex cycle to not loose the translation in the stable 2.4 branch.  