### PR TITLE
Library: center date values, right-align Track #

### DIFF
--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -1000,6 +1000,11 @@ QVariant BaseTrackTableModel::roleValue(
             // https://bugreports.qt.io/browse/QTBUG-67582
             return static_cast<int>(Qt::AlignVCenter | Qt::AlignRight);
         }
+        case ColumnCache::COLUMN_LIBRARYTABLE_DATETIMEADDED:
+        case ColumnCache::COLUMN_PLAYLISTTRACKSTABLE_DATETIMEADDED:
+        case ColumnCache::COLUMN_LIBRARYTABLE_LAST_PLAYED_AT: {
+            return static_cast<int>(Qt::AlignVCenter | Qt::AlignHCenter);
+        }
         default:
             return QVariant(); // default AlignLeft for all other columns
         }

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -995,7 +995,8 @@ QVariant BaseTrackTableModel::roleValue(
         switch (field) {
         case ColumnCache::COLUMN_LIBRARYTABLE_BPM:
         case ColumnCache::COLUMN_LIBRARYTABLE_DURATION:
-        case ColumnCache::COLUMN_LIBRARYTABLE_BITRATE: {
+        case ColumnCache::COLUMN_LIBRARYTABLE_BITRATE:
+        case ColumnCache::COLUMN_LIBRARYTABLE_TRACKNUMBER: {
             // We need to cast to int due to a bug similar to
             // https://bugreports.qt.io/browse/QTBUG-67582
             return static_cast<int>(Qt::AlignVCenter | Qt::AlignRight);


### PR DESCRIPTION
This allows to adjust the 'margin' to adjacent (left-/right-aligned) columns.

One more step to 'fix' #9369 