### PR TITLE
Paintable: Fix some type roundtrips

### DIFF
--- a/src/widget/paintable.cpp
+++ b/src/widget/paintable.cpp
@@ -50,8 +50,7 @@ QString Paintable::DrawModeToString(DrawMode mode) {
 }
 
 Paintable::Paintable(const PixmapSource& source, DrawMode mode, double scaleFactor)
-        : m_drawMode(mode),
-          m_source(source) {
+        : m_drawMode(mode) {
     if (!source.isSVG()) {
         m_pPixmap.reset(WPixmapStore::getPixmapNoCache(source.getPath(), scaleFactor));
     } else {
@@ -97,7 +96,7 @@ Paintable::Paintable(const PixmapSource& source, DrawMode mode, double scaleFact
 }
 
 bool Paintable::isNull() const {
-    return m_source.isEmpty();
+    return !(m_pPixmap || m_pSvg);
 }
 
 QSize Paintable::size() const {

--- a/src/widget/paintable.cpp
+++ b/src/widget/paintable.cpp
@@ -246,21 +246,15 @@ void Paintable::drawCentered(const QRectF& targetRect, QPainter* pPainter,
 
 void Paintable::drawInternal(const QRectF& targetRect, QPainter* pPainter,
                              const QRectF& sourceRect) {
-    // qDebug() << "Paintable::drawInternal" << DrawModeToString(m_draw_mode)
+    // qDebug() << "Paintable::drawInternal" << DrawModeToString(m_drawMode)
     //          << targetRect << sourceRect;
     if (m_pPixmap) {
+        // Note: Qt rounds the target rect to device pixels internally
+        // using  roundInDeviceCoordinates()
         if (m_drawMode == TILE) {
-            // TODO(rryan): Using a source rectangle doesn't make much sense
-            // with tiling. Ignore the source rect and tile our natural size
-            // across the target rect. What's the right general behavior here?
-            // NOTE(rryan): We round our target/source rectangles to the nearest
-            // pixel for raster images.
-            pPainter->drawTiledPixmap(targetRect.toRect(), *m_pPixmap, QPoint(0,0));
+            pPainter->drawTiledPixmap(targetRect, *m_pPixmap);
         } else {
-            // NOTE(rryan): We round our target/source rectangles to the nearest
-            // pixel for raster images.
-            pPainter->drawPixmap(targetRect.toRect(), *m_pPixmap,
-                                 sourceRect.toRect());
+            pPainter->drawPixmap(targetRect, *m_pPixmap, sourceRect);
         }
     } else if (m_pSvg) {
         if (m_drawMode == TILE) {

--- a/src/widget/paintable.cpp
+++ b/src/widget/paintable.cpp
@@ -254,7 +254,15 @@ void Paintable::drawInternal(const QRectF& targetRect, QPainter* pPainter,
         if (m_drawMode == TILE) {
             pPainter->drawTiledPixmap(targetRect, *m_pPixmap);
         } else {
-            pPainter->drawPixmap(targetRect, *m_pPixmap, sourceRect);
+            if (static_cast<QRectF>(m_pPixmap->rect()) == sourceRect &&
+                    sourceRect.size() == targetRect.size()) {
+                // Copy the whole pixmap without scaling
+                pPainter->drawPixmap(targetRect.topLeft(), *m_pPixmap);
+            } else {
+                // qDebug() << "Drawing QPixmap scaled or chopped";
+                // With scaling or chopping
+                pPainter->drawPixmap(targetRect, *m_pPixmap, sourceRect);
+            }
         }
     } else if (m_pSvg) {
         if (m_drawMode == TILE) {

--- a/src/widget/paintable.h
+++ b/src/widget/paintable.h
@@ -57,5 +57,4 @@ class Paintable {
     std::unique_ptr<QPixmap> m_pPixmap;
     std::unique_ptr<QSvgRenderer> m_pSvg;
     DrawMode m_drawMode;
-    PixmapSource m_source;
 };

--- a/src/widget/paintable.h
+++ b/src/widget/paintable.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <QImage>
-#include <QScopedPointer>
 #include <QRectF>
 #include <QString>
+#include <memory>
 
 #include "skin/legacy/imgsource.h"
 #include "skin/legacy/pixmapsource.h"
@@ -54,8 +54,8 @@ class Paintable {
     void drawInternal(const QRectF& targetRect, QPainter* pPainter,
                       const QRectF& sourceRect);
 
-    QScopedPointer<QPixmap> m_pPixmap;
-    QScopedPointer<QSvgRenderer> m_pSvg;
+    std::unique_ptr<QPixmap> m_pPixmap;
+    std::unique_ptr<QSvgRenderer> m_pSvg;
     DrawMode m_drawMode;
     PixmapSource m_source;
 };


### PR DESCRIPTION
This was a by catch during debugging https://github.com/mixxxdj/mixxx/pull/12904
It can be the base for caching the scaled QPixmap 