### PR TITLE
Scaled svg cache

### DIFF
--- a/src/widget/paintable.cpp
+++ b/src/widget/paintable.cpp
@@ -237,8 +237,10 @@ void Paintable::drawInternal(const QRectF& targetRect, QPainter* pPainter,
                 m_pPixmap = std::make_unique<QPixmap>(m_pSvg->defaultSize());
                 m_pPixmap->setDevicePixelRatio(devicePixelRatio);
                 m_pPixmap->fill(Qt::transparent);
-                auto pixmapPainter = QPainter(m_pPixmap.get());
-                m_pSvg->render(&pixmapPainter);
+                { // QPainter Scope
+                    auto pixmapPainter = QPainter(m_pPixmap.get());
+                    m_pSvg->render(&pixmapPainter);
+                }
                 mayCorrectColors();
             }
             // The SVG renderer doesn't directly support tiling, so we render
@@ -253,9 +255,11 @@ void Paintable::drawInternal(const QRectF& targetRect, QPainter* pPainter,
                 m_pPixmap = std::make_unique<QPixmap>(targetRect.size().toSize());
                 m_pPixmap->setDevicePixelRatio(devicePixelRatio);
                 m_pPixmap->fill(Qt::transparent);
-                auto pixmapPainter = QPainter(m_pPixmap.get());
-                m_pSvg->setViewBox(sourceRect);
-                m_pSvg->render(&pixmapPainter);
+                { // QPainter Scope
+                    auto pixmapPainter = QPainter(m_pPixmap.get());
+                    m_pSvg->setViewBox(sourceRect);
+                    m_pSvg->render(&pixmapPainter);
+                }
                 mayCorrectColors();
                 m_lastSourceRect = sourceRect;
             }

--- a/src/widget/paintable.cpp
+++ b/src/widget/paintable.cpp
@@ -69,29 +69,7 @@ Paintable::Paintable(const PixmapSource& source, DrawMode mode, double scaleFact
         } else {
             return;
         }
-#ifdef __APPLE__
-        // Apple does Retina scaling behind the scenes, so we also pass a
-        // Paintable::FIXED image. On the other targets, it is better to
-        // cache the pixmap. We do not do this for TILE and color schemas.
-        // which can result in a correct but possibly blurry picture at a
-        // Retina display. This can be fixed when switching to QT5
-        if (mode == TILE || WPixmapStore::willCorrectColors()) {
-#else
-        if (mode == TILE || mode == Paintable::FIXED || WPixmapStore::willCorrectColors()) {
-#endif
-            // The SVG renderer doesn't directly support tiling, so we render
-            // it to a pixmap which will then get tiled.
-            QImage copy_buffer(pSvg->defaultSize() * scaleFactor, QImage::Format_ARGB32);
-            copy_buffer.fill(0x00000000);  // Transparent black.
-            QPainter painter(&copy_buffer);
-            pSvg->render(&painter);
-            WPixmapStore::correctImageColors(&copy_buffer);
-
-            m_pPixmap.reset(new QPixmap(copy_buffer.size()));
-            m_pPixmap->convertFromImage(copy_buffer);
-        } else {
-            m_pSvg = std::move(pSvg);
-        }
+        m_pSvg = std::move(pSvg);
     }
 }
 
@@ -253,7 +231,19 @@ void Paintable::drawInternal(const QRectF& targetRect, QPainter* pPainter,
     //          << targetRect << sourceRect;
     if (m_pSvg) {
         if (m_drawMode == TILE) {
-            qWarning() << "Tiled SVG should have been rendered to pixmap!";
+            if (!m_pPixmap) {
+                // qDebug() << "Paintable cache miss";
+                qreal devicePixelRatio = pPainter->device()->devicePixelRatio();
+                m_pPixmap = std::make_unique<QPixmap>(m_pSvg->defaultSize());
+                m_pPixmap->setDevicePixelRatio(devicePixelRatio);
+                m_pPixmap->fill(Qt::transparent);
+                auto pixmapPainter = QPainter(m_pPixmap.get());
+                m_pSvg->render(&pixmapPainter);
+                mayCorrectColors();
+            }
+            // The SVG renderer doesn't directly support tiling, so we render
+            // it to a pixmap which will then get tiled.
+            pPainter->drawTiledPixmap(targetRect, *m_pPixmap);
         } else {
             if (!m_pPixmap ||
                     m_pPixmap->size() != targetRect.size().toSize() ||
@@ -266,6 +256,7 @@ void Paintable::drawInternal(const QRectF& targetRect, QPainter* pPainter,
                 auto pixmapPainter = QPainter(m_pPixmap.get());
                 m_pSvg->setViewBox(sourceRect);
                 m_pSvg->render(&pixmapPainter);
+                mayCorrectColors();
                 m_lastSourceRect = sourceRect;
             }
             pPainter->drawPixmap(targetRect.topLeft(), *m_pPixmap);
@@ -307,5 +298,13 @@ QString Paintable::getAltFileName(const QString& fileName) {
         return newFileName;
     } else {
         return fileName;
+    }
+}
+
+void Paintable::mayCorrectColors() {
+    if (WPixmapStore::willCorrectColors()) {
+        QImage image = m_pPixmap->toImage();
+        WPixmapStore::correctImageColors(&image);
+        m_pPixmap->convertFromImage(image);
     }
 }

--- a/src/widget/paintable.cpp
+++ b/src/widget/paintable.cpp
@@ -234,7 +234,7 @@ void Paintable::drawInternal(const QRectF& targetRect, QPainter* pPainter,
             if (!m_pPixmap) {
                 // qDebug() << "Paintable cache miss";
                 qreal devicePixelRatio = pPainter->device()->devicePixelRatio();
-                m_pPixmap = std::make_unique<QPixmap>(m_pSvg->defaultSize());
+                m_pPixmap = std::make_unique<QPixmap>(m_pSvg->defaultSize() * devicePixelRatio);
                 m_pPixmap->setDevicePixelRatio(devicePixelRatio);
                 m_pPixmap->fill(Qt::transparent);
                 { // QPainter Scope
@@ -252,12 +252,18 @@ void Paintable::drawInternal(const QRectF& targetRect, QPainter* pPainter,
                     m_lastSourceRect != sourceRect) {
                 // qDebug() << "Paintable cache miss";
                 qreal devicePixelRatio = pPainter->device()->devicePixelRatio();
-                m_pPixmap = std::make_unique<QPixmap>(targetRect.size().toSize());
+                m_pPixmap = std::make_unique<QPixmap>(
+                        targetRect.size().toSize() * devicePixelRatio);
                 m_pPixmap->setDevicePixelRatio(devicePixelRatio);
                 m_pPixmap->fill(Qt::transparent);
                 { // QPainter Scope
                     auto pixmapPainter = QPainter(m_pPixmap.get());
-                    m_pSvg->setViewBox(sourceRect);
+                    QRectF deviceSourceRect = QRectF(
+                            sourceRect.x() * devicePixelRatio,
+                            sourceRect.y() * devicePixelRatio,
+                            sourceRect.width() * devicePixelRatio,
+                            sourceRect.height() * devicePixelRatio);
+                    m_pSvg->setViewBox(deviceSourceRect);
                     m_pSvg->render(&pixmapPainter);
                 }
                 mayCorrectColors();

--- a/src/widget/paintable.h
+++ b/src/widget/paintable.h
@@ -53,6 +53,7 @@ class Paintable {
   private:
     void drawInternal(const QRectF& targetRect, QPainter* pPainter,
                       const QRectF& sourceRect);
+    void mayCorrectColors();
 
     std::unique_ptr<QPixmap> m_pPixmap;
     std::unique_ptr<QSvgRenderer> m_pSvg;

--- a/src/widget/paintable.h
+++ b/src/widget/paintable.h
@@ -57,4 +57,5 @@ class Paintable {
     std::unique_ptr<QPixmap> m_pPixmap;
     std::unique_ptr<QSvgRenderer> m_pSvg;
     DrawMode m_drawMode;
+    QRectF m_lastSourceRect;
 };


### PR DESCRIPTION
This is on top of https://github.com/mixxxdj/mixxx/pull/13678

It is used to demonstrates a scaled SVG cache. 

@JoergAtGithub Can you benchmark that on your side. With manual testing I do not notice an improvement.
There are currently test debug messages, to trace how it works. they need to be removed before benchmarking.

When we have confirmed, I will streamline the whole class to properly consider the device pixel ratio everywhere.  