### PR TITLE
BaseTrackTableModel: Fix column header mapping

### DIFF
--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -35,40 +35,6 @@ const mixxx::Logger kLogger("BaseTrackTableModel");
 constexpr double kRelativeHeightOfCoverartToolTip =
         0.165; // Height of the image for the cover art tooltip (Relative to the available screen size)
 
-// Mandatory columns that are either used directly or in delegates.
-const QStringList kDefaultTableColumns = {
-        LIBRARYTABLE_ALBUM,
-        LIBRARYTABLE_ALBUMARTIST,
-        LIBRARYTABLE_ARTIST,
-        LIBRARYTABLE_BPM,
-        LIBRARYTABLE_BPM_LOCK,
-        LIBRARYTABLE_BITRATE,
-        LIBRARYTABLE_CHANNELS,
-        LIBRARYTABLE_COLOR,
-        LIBRARYTABLE_COMMENT,
-        LIBRARYTABLE_COMPOSER,
-        LIBRARYTABLE_COVERART,
-        LIBRARYTABLE_DATETIMEADDED,
-        LIBRARYTABLE_DURATION,
-        LIBRARYTABLE_FILETYPE,
-        LIBRARYTABLE_GENRE,
-        LIBRARYTABLE_GROUPING,
-        LIBRARYTABLE_KEY,
-        LIBRARYTABLE_KEY_ID,
-        TRACKLOCATIONSTABLE_LOCATION,
-        TRACKLOCATIONSTABLE_FSDELETED,
-        LIBRARYTABLE_PLAYED,
-        LIBRARYTABLE_PREVIEW,
-        LIBRARYTABLE_RATING,
-        LIBRARYTABLE_REPLAYGAIN,
-        LIBRARYTABLE_SAMPLERATE,
-        LIBRARYTABLE_TIMESPLAYED,
-        LIBRARYTABLE_LAST_PLAYED_AT,
-        LIBRARYTABLE_TITLE,
-        LIBRARYTABLE_TRACKNUMBER,
-        LIBRARYTABLE_YEAR,
-};
-
 inline QSqlDatabase cloneDatabase(
         const QSqlDatabase& prototype) {
     const auto connectionName =
@@ -122,11 +88,6 @@ bool BaseTrackTableModel::s_bApplyPlayedTrackColor =
 
 void BaseTrackTableModel::setApplyPlayedTrackColor(bool apply) {
     s_bApplyPlayedTrackColor = apply;
-}
-
-//static
-QStringList BaseTrackTableModel::defaultTableColumns() {
-    return kDefaultTableColumns;
 }
 
 BaseTrackTableModel::BaseTrackTableModel(

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -121,23 +121,21 @@ BaseTrackTableModel::BaseTrackTableModel(
 void BaseTrackTableModel::initTableColumnsAndHeaderProperties(
         const QStringList& tableColumns) {
     m_columnCache.setColumns(tableColumns);
-    if (m_columnHeaders.size() < tableColumns.size()) {
-        m_columnHeaders.resize(tableColumns.size());
-        // Init the mapping of all columns, even for internal columns that are
-        // hidden/invisible. Otherwise mapColumn() would not return a valid result
-        // for those columns.
-        for (int columnValue = 0; columnValue < ColumnCache::NUM_COLUMNS; ++columnValue) {
-            const auto column = static_cast<ColumnCache::Column>(columnValue);
-            DEBUG_ASSERT(column != ColumnCache::COLUMN_LIBRARYTABLE_INVALID);
-            const int headerIndex = m_columnCache.fieldIndex(column);
-            if (headerIndex < 0) {
-                // Missing table column.
-                continue;
-            }
-            DEBUG_ASSERT(headerIndex < m_columnHeaders.size());
-            m_columnHeaders[headerIndex].column = column;
-            DEBUG_ASSERT(mapColumn(headerIndex) == column);
+    m_columnHeaders.resize(tableColumns.size());
+    // Init the mapping of all columns, even for internal columns that are
+    // hidden/invisible. Otherwise mapColumn() would not return a valid result
+    // for those columns.
+    for (int columnValue = 0; columnValue < ColumnCache::NUM_COLUMNS; ++columnValue) {
+        const auto column = static_cast<ColumnCache::Column>(columnValue);
+        DEBUG_ASSERT(column != ColumnCache::COLUMN_LIBRARYTABLE_INVALID);
+        const int headerIndex = m_columnCache.fieldIndex(column);
+        if (headerIndex < 0) {
+            // Missing table column.
+            continue;
         }
+        DEBUG_ASSERT(headerIndex < m_columnHeaders.size());
+        m_columnHeaders[headerIndex].column = column;
+        DEBUG_ASSERT(mapColumn(headerIndex) == column);
     }
     initHeaderProperties();
 }

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -159,8 +159,8 @@ BaseTrackTableModel::BaseTrackTableModel(
 
 void BaseTrackTableModel::initTableColumnsAndHeaderProperties(
         const QStringList& tableColumns) {
+    // This function might be invoked repeatedly and not only once during construction.
     m_columnCache.setColumns(tableColumns);
-    DEBUG_ASSERT(m_columnHeaders.isEmpty());
     m_columnHeaders.resize(tableColumns.size());
     // Init the mapping of all columns, even for internal columns that are
     // hidden/invisible. Otherwise mapColumn() would not return a valid result
@@ -174,7 +174,6 @@ void BaseTrackTableModel::initTableColumnsAndHeaderProperties(
             continue;
         }
         DEBUG_ASSERT(headerIndex < m_columnHeaders.size());
-        DEBUG_ASSERT(mapColumn(headerIndex) == ColumnCache::COLUMN_LIBRARYTABLE_INVALID);
         m_columnHeaders[headerIndex].column = column;
         DEBUG_ASSERT(mapColumn(headerIndex) == column);
     }

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -126,8 +126,14 @@ void BaseTrackTableModel::initTableColumnsAndHeaderProperties(
     m_columnHeaders.clear();
     m_columnHeaders.resize(tableColumns.size());
 
-    // Init the mapping of all columns, even for internal columns that are
-    // hidden/invisible. Otherwise mapColumn() would not return a valid result
+    // Init the header properties of selected/visible columns.
+    // This method might by overridden by derived classes.
+    initHeaderProperties();
+    // The derived class might have added column headers.
+    DEBUG_ASSERT(m_columnHeaders.size() >= tableColumns.size());
+
+    // Init the mapping of all remaining columns, even for internal columns that
+    // are hidden/invisible. Otherwise mapColumn() would not return a valid result
     // for those columns.
     for (int columnValue = 0; columnValue < ColumnCache::NUM_COLUMNS; ++columnValue) {
         const auto column = static_cast<ColumnCache::Column>(columnValue);
@@ -138,12 +144,15 @@ void BaseTrackTableModel::initTableColumnsAndHeaderProperties(
             continue;
         }
         DEBUG_ASSERT(headerIndex < m_columnHeaders.size());
-        m_columnHeaders[headerIndex].column = column;
+        if (m_columnHeaders[headerIndex].column == ColumnCache::COLUMN_LIBRARYTABLE_INVALID) {
+            // Invisible/hidden column.
+            m_columnHeaders[headerIndex].column = column;
+        } else {
+            // Already initialized by initHeaderProperties().
+            DEBUG_ASSERT(m_columnHeaders[headerIndex].column == column);
+        }
         DEBUG_ASSERT(mapColumn(headerIndex) == column);
     }
-
-    // Init the header properties of selected/visible columns.
-    initHeaderProperties();
 }
 
 void BaseTrackTableModel::initHeaderProperties() {

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -35,6 +35,7 @@ const mixxx::Logger kLogger("BaseTrackTableModel");
 constexpr double kRelativeHeightOfCoverartToolTip =
         0.165; // Height of the image for the cover art tooltip (Relative to the available screen size)
 
+// Mandatory columns that are either used directly or in delegates.
 const QStringList kDefaultTableColumns = {
         LIBRARYTABLE_ALBUM,
         LIBRARYTABLE_ALBUMARTIST,
@@ -53,7 +54,9 @@ const QStringList kDefaultTableColumns = {
         LIBRARYTABLE_GENRE,
         LIBRARYTABLE_GROUPING,
         LIBRARYTABLE_KEY,
+        LIBRARYTABLE_KEY_ID,
         TRACKLOCATIONSTABLE_LOCATION,
+        TRACKLOCATIONSTABLE_FSDELETED,
         LIBRARYTABLE_PLAYED,
         LIBRARYTABLE_PREVIEW,
         LIBRARYTABLE_RATING,

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -121,7 +121,11 @@ BaseTrackTableModel::BaseTrackTableModel(
 void BaseTrackTableModel::initTableColumnsAndHeaderProperties(
         const QStringList& tableColumns) {
     m_columnCache.setColumns(tableColumns);
+
+    // Reset the column headers.
+    m_columnHeaders.clear();
     m_columnHeaders.resize(tableColumns.size());
+
     // Init the mapping of all columns, even for internal columns that are
     // hidden/invisible. Otherwise mapColumn() would not return a valid result
     // for those columns.
@@ -137,6 +141,8 @@ void BaseTrackTableModel::initTableColumnsAndHeaderProperties(
         m_columnHeaders[headerIndex].column = column;
         DEBUG_ASSERT(mapColumn(headerIndex) == column);
     }
+
+    // Init the header properties of selected/visible columns.
     initHeaderProperties();
 }
 

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -126,10 +126,10 @@ void BaseTrackTableModel::initTableColumnsAndHeaderProperties(
         // Init the mapping of all columns, even for internal columns that are
         // hidden/invisible. Otherwise mapColumn() would not return a valid result
         // for those columns.
-        for (auto columnValue = 0; columnValue < ColumnCache::NUM_COLUMNS; ++columnValue) {
+        for (int columnValue = 0; columnValue < ColumnCache::NUM_COLUMNS; ++columnValue) {
             const auto column = static_cast<ColumnCache::Column>(columnValue);
             DEBUG_ASSERT(column != ColumnCache::COLUMN_LIBRARYTABLE_INVALID);
-            const auto headerIndex = m_columnCache.fieldIndex(column);
+            const int headerIndex = m_columnCache.fieldIndex(column);
             if (headerIndex < 0) {
                 // Missing table column.
                 continue;

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -120,23 +120,24 @@ BaseTrackTableModel::BaseTrackTableModel(
 
 void BaseTrackTableModel::initTableColumnsAndHeaderProperties(
         const QStringList& tableColumns) {
-    // This function might be invoked repeatedly and not only once during construction.
     m_columnCache.setColumns(tableColumns);
-    m_columnHeaders.resize(tableColumns.size());
-    // Init the mapping of all columns, even for internal columns that are
-    // hidden/invisible. Otherwise mapColumn() would not return a valid result
-    // for those columns.
-    for (auto columnValue = 0; columnValue < ColumnCache::NUM_COLUMNS; ++columnValue) {
-        const auto column = static_cast<ColumnCache::Column>(columnValue);
-        DEBUG_ASSERT(column != ColumnCache::COLUMN_LIBRARYTABLE_INVALID);
-        const auto headerIndex = m_columnCache.fieldIndex(column);
-        if (headerIndex < 0) {
-            // Missing table column.
-            continue;
+    if (m_columnHeaders.size() < tableColumns.size()) {
+        m_columnHeaders.resize(tableColumns.size());
+        // Init the mapping of all columns, even for internal columns that are
+        // hidden/invisible. Otherwise mapColumn() would not return a valid result
+        // for those columns.
+        for (auto columnValue = 0; columnValue < ColumnCache::NUM_COLUMNS; ++columnValue) {
+            const auto column = static_cast<ColumnCache::Column>(columnValue);
+            DEBUG_ASSERT(column != ColumnCache::COLUMN_LIBRARYTABLE_INVALID);
+            const auto headerIndex = m_columnCache.fieldIndex(column);
+            if (headerIndex < 0) {
+                // Missing table column.
+                continue;
+            }
+            DEBUG_ASSERT(headerIndex < m_columnHeaders.size());
+            m_columnHeaders[headerIndex].column = column;
+            DEBUG_ASSERT(mapColumn(headerIndex) == column);
         }
-        DEBUG_ASSERT(headerIndex < m_columnHeaders.size());
-        m_columnHeaders[headerIndex].column = column;
-        DEBUG_ASSERT(mapColumn(headerIndex) == column);
     }
     initHeaderProperties();
 }

--- a/src/library/basetracktablemodel.h
+++ b/src/library/basetracktablemodel.h
@@ -10,6 +10,15 @@
 
 class TrackCollectionManager;
 
+/// Base class for tabular track list views.
+///
+/// The abstract model behind `WTrackTableView`.
+///
+/// Closely coupled with `BaseSqlTableModel` from which it has been extracted once.
+///
+/// Serves as an extension point for integrating external track data into Mixxx.
+/// It allows to view track lists provided by external libraries using `WTrackTableView`
+/// without importing redundant data into the Mixxx database.
 class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
     Q_OBJECT
     DISALLOW_COPY_AND_ASSIGN(BaseTrackTableModel);

--- a/src/library/basetracktablemodel.h
+++ b/src/library/basetracktablemodel.h
@@ -283,8 +283,6 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
     };
     QVector<ColumnHeader> m_columnHeaders;
 
-    int countValidColumnHeaders() const;
-
     TrackId m_previewDeckTrackId;
 
     mutable QModelIndex m_toolTipIndex;

--- a/src/library/basetracktablemodel.h
+++ b/src/library/basetracktablemodel.h
@@ -112,12 +112,11 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
     static constexpr int defaultColumnWidth() {
         return 50;
     }
-    static QStringList defaultTableColumns();
 
     // Build a map from the column names to their indices
-    // used by fieldIndex(). This function has to be called
+    // used by fieldIndex().
     void initTableColumnsAndHeaderProperties(
-            const QStringList& tableColumns = defaultTableColumns());
+            const QStringList& tableColumns);
 
     QString columnNameForFieldIndex(int index) const {
         return m_columnCache.columnNameForFieldIndex(index);


### PR DESCRIPTION
Without these fixes `BaseTrackTableModel` doesn't work as expected when used as a base class, i.e. internal column values are undefined and visible columns are missing.

However `BaseSqlTableModel` doesn't seem to suffer from these deficiencies and inconsistencies in its base class.