### PR TITLE
Limit mixxx.log size

### DIFF
--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -54,6 +54,7 @@ CmdlineArgs::CmdlineArgs()
           m_parseForUserFeedbackRequired(false),
           m_logLevel(mixxx::kLogLevelDefault),
           m_logFlushLevel(mixxx::kLogFlushLevelDefault),
+          m_logMaxFileSize(mixxx::kLogMaxFileSizeDefault),
 // We are not ready to switch to XDG folders under Linux, so keeping $HOME/.mixxx as preferences folder. see #8090
 #ifdef MIXXX_SETTINGS_PATH
           m_settingsPath(QDir::homePath().append("/").append(MIXXX_SETTINGS_PATH)) {
@@ -286,6 +287,18 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
     parser.addOption(logFlushLevel);
     parser.addOption(logFlushLevelDeprecated);
 
+    const QCommandLineOption logMaxFileSize(QStringLiteral("log-max-file-size"),
+            forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
+                                      "Sets the maximum file size of the "
+                                      "mixxx.log file in bytes. "
+                                      "Use -1 for unlimited. The default is "
+                                      "100 MB as 1e5 or 100000000.")
+                            : QString(),
+            QStringLiteral("bytes"));
+    logFlushLevelDeprecated.setFlags(QCommandLineOption::HiddenFromHelp);
+    logFlushLevelDeprecated.setValueName(logFlushLevel.valueName());
+    parser.addOption(logMaxFileSize);
+
     QCommandLineOption debugAssertBreak(QStringLiteral("debug-assert-break"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
                                       "Breaks (SIGINT) Mixxx, if a DEBUG_ASSERT evaluates to "
@@ -406,6 +419,17 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
             fputs("\nlogFlushLevel wasn't 'trace', 'debug', 'info', 'warning', or 'critical'!\n"
                   "Mixxx will only flush output after a critical message.\n",
                     stdout);
+        }
+    }
+
+    if (parser.isSet(logMaxFileSize)) {
+        QString strLogMaxFileSize = parser.value(logMaxFileSize);
+        bool ok = false;
+        // We parse it as double to also support exponential notation
+        m_logMaxFileSize = static_cast<qint64>(strLogMaxFileSize.toDouble(&ok));
+        if (!ok) {
+            fputs("\nFailed to parse log-max-file-size.\n", stdout);
+            return false;
         }
     }
 

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -52,6 +52,9 @@ class CmdlineArgs final {
     bool getSettingsPathSet() const { return m_settingsPathSet; }
     mixxx::LogLevel getLogLevel() const { return m_logLevel; }
     mixxx::LogLevel getLogFlushLevel() const { return m_logFlushLevel; }
+    qint64 getLogMaxFileSize() const {
+        return m_logMaxFileSize;
+    }
     bool getTimelineEnabled() const { return !m_timelinePath.isEmpty(); }
     const QString& getLocale() const { return m_locale; }
     const QString& getSettingsPath() const { return m_settingsPath; }
@@ -91,6 +94,7 @@ class CmdlineArgs final {
     bool m_parseForUserFeedbackRequired;
     mixxx::LogLevel m_logLevel; // Level of stderr logging message verbosity
     mixxx::LogLevel m_logFlushLevel; // Level of mixx.log file flushing
+    qint64 m_logMaxFileSize;
     QString m_locale;
     QString m_settingsPath;
     QString m_resourcePath;

--- a/src/util/logging.h
+++ b/src/util/logging.h
@@ -22,6 +22,7 @@ Q_DECLARE_OPERATORS_FOR_FLAGS(LogFlags);
 
 /// Default log level for (console) logs.
 constexpr LogLevel kLogLevelDefault = LogLevel::Warning;
+constexpr qint64 kLogMaxFileSizeDefault = 100'000'000; // 100 MB
 
 /// Default log level for flushing the buffered log stream.
 /// This is required to ensure that all buffered messages have


### PR DESCRIPTION
This sets a limit to 100 MB to lint the issue reported here: 
https://github.com/mixxxdj/mixxx/issues/13660

The limit can be adjusted by the command line parameter --log-max-file-size