### PR TITLE
(fix) Track menu: avoid crash and UX issues with track nullptr

### DIFF
--- a/src/library/dlgtagfetcher.cpp
+++ b/src/library/dlgtagfetcher.cpp
@@ -246,30 +246,31 @@ void DlgTagFetcher::slotPrev() {
 }
 
 void DlgTagFetcher::loadTrack(const TrackPointer& pTrack) {
+    tags->clear();
+    m_data = Data();
     if (m_pTrack) {
-        tags->clear();
         disconnect(m_pTrack.get(),
                 &Track::changed,
                 this,
                 &DlgTagFetcher::slotTrackChanged);
-        m_data = Data();
     }
-    tags->clear();
 
     m_pWFetchedCoverArtLabel->setCoverArt(CoverInfo{}, QPixmap{});
 
     m_coverCache.clear();
-
-    m_pTrack = pTrack;
-    if (!m_pTrack) {
-        return;
-    }
 
     btnRetry->setDisabled(true);
     btnApply->setDisabled(true);
     checkBoxTags->setDisabled(true);
     checkBoxCover->setDisabled(true);
     statusMessage->setVisible(false);
+
+    m_pTrack = pTrack;
+    if (!m_pTrack) {
+        loadingProgressBar->setVisible(false);
+        return;
+    }
+
     loadingProgressBar->setVisible(true);
     loadingProgressBar->setValue(kMinimumValueOfQProgressBar);
     addDivider(tr("Original tags"), tags);

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -623,6 +623,8 @@ void DlgTrackInfo::saveTrack() {
 void DlgTrackInfo::clear() {
     const QSignalBlocker signalBlocker(this);
 
+    setWindowTitle(QString());
+
     if (m_pLoadedTrack) {
         disconnect(m_pLoadedTrack.get(),
                 &Track::changed,

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -215,6 +215,10 @@ void WTrackMenu::createMenus() {
                     m_pSearchRelatedMenu->clear();
                     const auto pTrack = getFirstTrackPointer();
                     if (pTrack) {
+                        // Ensure it's enabled, else we can't add actions.
+                        VERIFY_OR_DEBUG_ASSERT(m_pSearchRelatedMenu->isEnabled()) {
+                            m_pSearchRelatedMenu->setEnabled(true);
+                        }
                         m_pSearchRelatedMenu->addActionsForTrack(*pTrack);
                     }
                     m_pSearchRelatedMenu->setEnabled(
@@ -828,6 +832,19 @@ void WTrackMenu::updateMenus() {
 
     // Gray out some stuff if multiple songs were selected.
     const bool singleTrackSelected = getTrackCount() == 1;
+
+    if (featureIsEnabled(Feature::SearchRelated)) {
+        // Enable only if we have one valid track pointer.
+        // this prevents the cursor getting stuck on this menu in case it gets
+        // disabled when encountering a track nullptr in lambda function
+        // connected to aboutToShow() signal (see createMenus()).
+        // Note: track nullptr can happen when TrackDAO returns nullptr because
+        // the selected track references a file referenced by another cached track.
+        DEBUG_ASSERT(m_pSearchRelatedMenu);
+        const auto pTrack = getFirstTrackPointer();
+        m_pSearchRelatedMenu->setEnabled(pTrack != nullptr);
+        // TODO Only enable for single track?
+    }
 
     if (featureIsEnabled(Feature::LoadTo)) {
         int iNumDecks = static_cast<int>(m_pNumDecks.get());

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -849,6 +849,7 @@ void WTrackMenu::updateMenus() {
     if (featureIsEnabled(Feature::LoadTo)) {
         int iNumDecks = static_cast<int>(m_pNumDecks.get());
         m_pDeckMenu->clear();
+        // TODO Only enable for single track?
         if (iNumDecks > 0) {
             for (int i = 1; i <= iNumDecks; ++i) {
                 // PlayerManager::groupForDeck is 0-indexed.
@@ -964,6 +965,7 @@ void WTrackMenu::updateMenus() {
         bool anyBpmLocked;
         bool anyBpmNotLocked;
         std::tie(anyBpmLocked, anyBpmNotLocked) = getTrackBpmLockStates();
+        // TODO Disable menu if anyBpmLocked == anyBpmNotLocked ??
         if (featureIsEnabled(Feature::Reset)) {
             m_pClearBeatsAction->setEnabled(!anyBpmLocked);
         }
@@ -2355,6 +2357,10 @@ void WTrackMenu::slotShowDlgTrackInfo() {
                 }
             });
     // Method getFirstTrackPointer() is not applicable here!
+    // DlgTrackInfo relies on a track model for certain operations,
+    // for example show/hide the Next/Prev buttons.
+    // It can be loaded with either an index (must have a model),
+    // or a TrackPointer (must NOT have a model then).
     if (m_pTrackModel) {
         m_pDlgTrackInfo->loadTrack(m_trackIndexList.at(0));
     } else {

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -847,10 +847,11 @@ void WTrackMenu::updateMenus() {
     }
 
     if (featureIsEnabled(Feature::LoadTo)) {
+        // Enable menus only for single track
         int iNumDecks = static_cast<int>(m_pNumDecks.get());
         m_pDeckMenu->clear();
-        // TODO Only enable for single track?
-        if (iNumDecks > 0) {
+        m_pDeckMenu->setEnabled(singleTrackSelected);
+        if (singleTrackSelected && iNumDecks > 0) {
             for (int i = 1; i <= iNumDecks; ++i) {
                 // PlayerManager::groupForDeck is 0-indexed.
                 QString deckGroup = PlayerManager::groupForDeck(i - 1);
@@ -885,8 +886,9 @@ void WTrackMenu::updateMenus() {
 
         int iNumSamplers = static_cast<int>(m_pNumSamplers.get());
         const int maxSamplersPerMenu = 16;
-        if (iNumSamplers > 0) {
-            m_pSamplerMenu->clear();
+        m_pSamplerMenu->clear();
+        m_pSamplerMenu->setEnabled(singleTrackSelected);
+        if (singleTrackSelected && iNumSamplers > 0) {
             QMenu* pMenu = m_pSamplerMenu;
             int samplersInMenu = 0;
             for (int i = 1; i <= iNumSamplers; ++i) {
@@ -965,7 +967,6 @@ void WTrackMenu::updateMenus() {
         bool anyBpmLocked;
         bool anyBpmNotLocked;
         std::tie(anyBpmLocked, anyBpmNotLocked) = getTrackBpmLockStates();
-        // TODO Disable menu if anyBpmLocked == anyBpmNotLocked ??
         if (featureIsEnabled(Feature::Reset)) {
             m_pClearBeatsAction->setEnabled(!anyBpmLocked);
         }

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -722,11 +722,9 @@ std::pair<bool, bool> WTrackMenu::getTrackBpmLockStates() const {
                 break;
             }
         }
-    } else {
-        if (m_pTrack) {
-            anyBpmLocked = m_pTrack->isBpmLocked();
-            anyBpmNotLocked = !anyBpmLocked;
-        }
+    } else if (m_pTrack) {
+        anyBpmLocked = m_pTrack->isBpmLocked();
+        anyBpmNotLocked = !anyBpmLocked;
     }
     return std::pair<bool, bool>(anyBpmLocked, anyBpmNotLocked);
 }
@@ -815,8 +813,11 @@ CoverInfo WTrackMenu::getCoverInfoOfLastTrack() const {
                         .data()
                         .toString();
         return coverInfo;
-    } else {
+    } else if (m_pTrack) {
         return m_pTrack->getCoverInfoWithLocation();
+    } else {
+        // No track, no track model
+        return CoverInfo();
     }
 }
 
@@ -968,13 +969,15 @@ void WTrackMenu::updateMenus() {
                 } else if (m_pTrack) {
                     pTrack = m_pTrack;
                 }
-                const double bpm = pTrack->getBpm();
-                appendBpmPreviewtoBpmAction(m_pBpmDoubleAction, bpm);
-                appendBpmPreviewtoBpmAction(m_pBpmHalveAction, bpm);
-                appendBpmPreviewtoBpmAction(m_pBpmTwoThirdsAction, bpm);
-                appendBpmPreviewtoBpmAction(m_pBpmThreeFourthsAction, bpm);
-                appendBpmPreviewtoBpmAction(m_pBpmFourThirdsAction, bpm);
-                appendBpmPreviewtoBpmAction(m_pBpmThreeHalvesAction, bpm);
+                if (pTrack) {
+                    const double bpm = pTrack->getBpm();
+                    appendBpmPreviewtoBpmAction(m_pBpmDoubleAction, bpm);
+                    appendBpmPreviewtoBpmAction(m_pBpmHalveAction, bpm);
+                    appendBpmPreviewtoBpmAction(m_pBpmTwoThirdsAction, bpm);
+                    appendBpmPreviewtoBpmAction(m_pBpmThreeFourthsAction, bpm);
+                    appendBpmPreviewtoBpmAction(m_pBpmFourThirdsAction, bpm);
+                    appendBpmPreviewtoBpmAction(m_pBpmThreeHalvesAction, bpm);
+                }
             }
         }
     }


### PR DESCRIPTION
This is just a quick fix to avoid a crash when trying to open the track menu or Track Properties with Ctrl+P
**when the selection contains a duplicate track**. (a track that references the same file as another track)
Note: fixin the UX inconsistencies (see below) is a lot more work, probably requires some not so trivial refactoring.

No idea how I got that duplicate file, but it's awful show stopper.
The general question is how to provide helpful info to the user so they can resolve the situation themselves (without having to edit the database manually).

The menu and Track Properties can now be opened (Track Props is empty) but at least it doesn't crash anymore (in release builds / with DEBUG_ASSERTIONS_FATAL = OFF).


**Note for testing:**
In case you manage to create a duplicate track, you need to disable this DEBUG_ASSERT in TrackDAO inorder to proceed
https://github.com/mixxxdj/mixxx/blob/f5890a89bf1db266cfaaa166e31085aadfe1a1ca/src/library/dao/trackdao.cpp#L1440
FWIW I couldn't duplicate a track with DB Browser for SQlite, it prevents that:
`Error changing data: UNIQUE constraint failed: track_locations.location`

____
Uff, the UX when encountering such a duplicate is very inconsistent, and I think a 'normal' user (DEBUG_ASSERTIONS_FATAL = OFF) does not get enough information to resolve the situation:
1. Track Properties can be opened, but it's empty
2. when opening Track Properties for another track in the table, then hit a dupe track when using Next/Prev, the fields are cleared but the window title is not
3. MusicBrainz dialog can be opened but displays ~20% progress and "Tags can be applied"
4. otoh, the track menu can be opened ~~and most (all?) actions work~~ _was confused due to ¹_
disabled: Find On Web
works: Add to Auto DJ, Add to Playlist/Crate (though sidebar items are not set bold)
not working: BPM, Color, ...
Search Related:
    * is disabled when hovering/selecting it, cursor is stuck there, menu can only be closed by pressing Esc twice
    * remains disabled for regular tracks afterwards (wrong order of populate and setEnabled())
5. when loading the track by dragging it to a deck (loaded by ref/url), the 'original' track¹ is loaded
6. otoh neither double-click in Tracks nor the keyboard shortcuts Shift+Left/Right work (loaded via TrackPointer, but [`WTrackTableView::loadSelectedTrackToGroup`](https://github.com/mixxxdj/mixxx/blob/f5890a89bf1db266cfaaa166e31085aadfe1a1ca/src/widget/wtracktableview.cpp#L1035) aborts due to nullptr)
7. track color is displayed in Tracks but in decks it's the color of the 'original' track?

¹ ~~GlobalTrackCache/TrackDAO throw the warning for the newer track.~~
No, it depends on which track has been cached first. So the dupe can be different in each session.
