### PR TITLE
HID: Avoid repeated error messages from hid_write()/hid_read()

### DIFF
--- a/src/controllers/hid/hidioglobaloutputreportfifo.cpp
+++ b/src/controllers/hid/hidioglobaloutputreportfifo.cpp
@@ -71,10 +71,15 @@ bool HidIoGlobalOutputReportFifo::sendNextReportDataset(QMutex* pHidDeviceAndPol
             reportToSend.size());
     if (result == -1) {
         if (!m_hidWriteErrorLogged) {
-            qCWarning(logOutput) << "Unable to send data to" << deviceInfo.formatName() << ":"
-                                 << mixxx::convertWCStringToQString(
-                                            hid_error(pHidDevice),
-                                            kMaxHidErrorMessageSize);
+            qCWarning(logOutput)
+                    << "Unable to send data to" << deviceInfo.formatName()
+                    << ":"
+                    << mixxx::convertWCStringToQString(
+                               hid_error(pHidDevice), kMaxHidErrorMessageSize)
+                    << "Note that, this message is only logged once and may "
+                       "not appear again until all hid_read errors have "
+                       "disappeared.";
+
             // Stop logging error messages if every hid_write() fails to avoid large log files
             m_hidWriteErrorLogged = true;
         }

--- a/src/controllers/hid/hidioglobaloutputreportfifo.h
+++ b/src/controllers/hid/hidioglobaloutputreportfifo.h
@@ -38,4 +38,5 @@ class HidIoGlobalOutputReportFifo {
   private:
     // Lockless FIFO queue
     rigtorp::SPSCQueue<QByteArray> m_fifoQueue;
+    bool m_hidWriteErrorLogged;
 };

--- a/src/controllers/hid/hidiooutputreport.cpp
+++ b/src/controllers/hid/hidiooutputreport.cpp
@@ -15,6 +15,7 @@ constexpr size_t kMaxHidErrorMessageSize = 512;
 HidIoOutputReport::HidIoOutputReport(
         const quint8& reportId, const unsigned int& reportDataSize)
         : m_reportId(reportId),
+          m_hidWriteErrorLogged(false),
           m_possiblyUnsentDataCached(false),
           m_lastCachedDataSize(0) {
     // First byte must always contain the ReportID - also after swapping, therefore initialize both arrays
@@ -121,10 +122,16 @@ bool HidIoOutputReport::sendCachedData(QMutex* pHidDeviceAndPollMutex,
             reinterpret_cast<const unsigned char*>(m_lastSentData.constData()),
             m_lastSentData.size());
     if (result == -1) {
-        qCWarning(logOutput) << "Unable to send data to device :"
-                             << mixxx::convertWCStringToQString(
-                                        hid_error(pHidDevice),
-                                        kMaxHidErrorMessageSize);
+        if (!m_hidWriteErrorLogged) {
+            qCWarning(logOutput) << "Unable to send data to device :"
+                                 << mixxx::convertWCStringToQString(
+                                            hid_error(pHidDevice),
+                                            kMaxHidErrorMessageSize);
+            // Stop logging error messages if every hid_write() fails to avoid large log files
+            m_hidWriteErrorLogged = true;
+        }
+    } else {
+        m_hidWriteErrorLogged = false;
     }
 
     hidDeviceLock.unlock();

--- a/src/controllers/hid/hidiooutputreport.cpp
+++ b/src/controllers/hid/hidiooutputreport.cpp
@@ -123,10 +123,14 @@ bool HidIoOutputReport::sendCachedData(QMutex* pHidDeviceAndPollMutex,
             m_lastSentData.size());
     if (result == -1) {
         if (!m_hidWriteErrorLogged) {
-            qCWarning(logOutput) << "Unable to send data to device :"
-                                 << mixxx::convertWCStringToQString(
-                                            hid_error(pHidDevice),
-                                            kMaxHidErrorMessageSize);
+            qCWarning(logOutput)
+                    << "Unable to send data to device :"
+                    << mixxx::convertWCStringToQString(
+                               hid_error(pHidDevice), kMaxHidErrorMessageSize)
+                    << "Note that, this message is only logged once and may "
+                       "not appear again until all hid_writee errors have "
+                       "disappeared.";
+
             // Stop logging error messages if every hid_write() fails to avoid large log files
             m_hidWriteErrorLogged = true;
         }

--- a/src/controllers/hid/hidiooutputreport.h
+++ b/src/controllers/hid/hidiooutputreport.h
@@ -25,6 +25,7 @@ class HidIoOutputReport {
   private:
     const quint8 m_reportId;
     QByteArray m_lastSentData;
+    bool m_hidWriteErrorLogged;
 
     /// Mutex must be locked when reading/writing m_cachedData
     /// or m_possiblyUnsentDataCached

--- a/src/controllers/hid/hidiothread.cpp
+++ b/src/controllers/hid/hidiothread.cpp
@@ -40,6 +40,7 @@ HidIoThread::HidIoThread(
           m_pHidDevice(pHidDevice),
           m_lastPollSize(0),
           m_pollingBufferIndex(0),
+          m_hidReadErrorLogged(false),
           m_globalOutputReportFifo(),
           m_runLoopSemaphore(1) {
     // Initializing isn't strictly necessary but is good practice.
@@ -99,16 +100,23 @@ void HidIoThread::pollBufferedInputReports() {
         int bytesRead = hid_read(m_pHidDevice, m_pPollData[m_pollingBufferIndex], kBufferSize);
         if (bytesRead < 0) {
             // -1 is the only error value according to hidapi documentation.
-            qCWarning(m_logOutput) << "Unable to read buffered HID InputReports from"
-                                   << m_deviceInfo.formatName() << ":"
-                                   << mixxx::convertWCStringToQString(
-                                              hid_error(m_pHidDevice),
-                                              kMaxHidErrorMessageSize);
             DEBUG_ASSERT(bytesRead == -1);
+            if (!m_hidReadErrorLogged) {
+                qCWarning(m_logOutput) << "Unable to read buffered HID InputReports from"
+                                       << m_deviceInfo.formatName() << ":"
+                                       << mixxx::convertWCStringToQString(
+                                                  hid_error(m_pHidDevice),
+                                                  kMaxHidErrorMessageSize);
+                // Stop logging error messages if every hid_read() fails to avoid large log files
+                m_hidReadErrorLogged = true;
+            }
             break;
-        } else if (bytesRead == 0) {
-            // No InputReports left to be read
-            break;
+        } else {
+            m_hidReadErrorLogged = false; // Allow to log new errors
+            if (bytesRead == 0) {
+                // No InputReports left to be read
+                break;
+            }
         }
         processInputReport(bytesRead);
     }

--- a/src/controllers/hid/hidiothread.cpp
+++ b/src/controllers/hid/hidiothread.cpp
@@ -102,11 +102,15 @@ void HidIoThread::pollBufferedInputReports() {
             // -1 is the only error value according to hidapi documentation.
             DEBUG_ASSERT(bytesRead == -1);
             if (!m_hidReadErrorLogged) {
-                qCWarning(m_logOutput) << "Unable to read buffered HID InputReports from"
-                                       << m_deviceInfo.formatName() << ":"
-                                       << mixxx::convertWCStringToQString(
-                                                  hid_error(m_pHidDevice),
-                                                  kMaxHidErrorMessageSize);
+                qCWarning(m_logOutput)
+                        << "Unable to read buffered HID InputReports from"
+                        << m_deviceInfo.formatName() << ":"
+                        << mixxx::convertWCStringToQString(
+                                   hid_error(m_pHidDevice),
+                                   kMaxHidErrorMessageSize)
+                        << "Note that, this message is only logged once and "
+                           "may not appear again until all hid_read errors "
+                           "have disappeared.";
                 // Stop logging error messages if every hid_read() fails to avoid large log files
                 m_hidReadErrorLogged = true;
             }

--- a/src/controllers/hid/hidiothread.h
+++ b/src/controllers/hid/hidiothread.h
@@ -79,6 +79,7 @@ class HidIoThread : public QThread {
     unsigned char m_pPollData[kNumBuffers][kBufferSize];
     int m_lastPollSize;
     int m_pollingBufferIndex;
+    bool m_hidReadErrorLogged;
 
     /// Must be locked when a operation changes the size of the m_outputReports map,
     /// or when modify the m_outputReportIterator


### PR DESCRIPTION
This is fixed the huge log file issue with #13660 for log spam in any disconnect case, without fixing the root cause in that particular case. 