### PR TITLE
Tracks: allow searching for track id

### DIFF
--- a/src/library/searchquery.cpp
+++ b/src/library/searchquery.cpp
@@ -77,6 +77,8 @@ QVariant getTrackValueForColumn(const TrackPointer& pTrack, const QString& colum
         return static_cast<int>(pTrack->getKey());
     } else if (column == LIBRARYTABLE_BPM_LOCK) {
         return pTrack->isBpmLocked();
+    } else if (column == LIBRARYTABLE_ID) {
+        return pTrack->getId().toVariant();
     }
 
     return QVariant();

--- a/src/library/searchqueryparser.cpp
+++ b/src/library/searchqueryparser.cpp
@@ -86,7 +86,8 @@ SearchQueryParser::SearchQueryParser(TrackCollection* pTrackCollection, QStringL
     m_numericFilters << "track"
                      << "played"
                      << "rating"
-                     << "bitrate";
+                     << "bitrate"
+                     << "id";
     m_specialFilters << "year"
                      << "key"
                      << "bpm"
@@ -117,6 +118,7 @@ SearchQueryParser::SearchQueryParser(TrackCollection* pTrackCollection, QStringL
     m_fieldToSqlColumns["location"] << "location";
     m_fieldToSqlColumns["type"] << "filetype";
     m_fieldToSqlColumns["datetime_added"] << "datetime_added";
+    m_fieldToSqlColumns["id"] << "id";
 
     m_textFilterMatcher = QRegularExpression(QString("^-?(%1):(.*)$").arg(m_textFilters.join("|")));
     m_numericFilterMatcher = QRegularExpression(


### PR DESCRIPTION
Just a little helper for debugging.

Initially this was --developer only, but why restrict it? I think it might be helpful for (remote) debugging.
Wdyt?