### PR TITLE
(fix) disable Properties shortcut in Computer feature views

### DIFF
--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -871,6 +871,12 @@ void WTrackTableView::keyPressEvent(QKeyEvent* event) {
         if (event->modifiers().testFlag(Qt::NoModifier)) {
             slotMouseDoubleClicked(currentIndex());
         } else if ((event->modifiers() & kPropertiesShortcutModifier)) {
+            TrackModel* pTrackModel = getTrackModel();
+            if (!pTrackModel ||
+                    !pTrackModel->hasCapabilities(
+                            TrackModel::Capability::EditMetadata)) {
+                return;
+            }
             const QModelIndexList indices = getSelectedRows();
             if (indices.length() == 1) {
                 m_pTrackMenu->loadTrackModelIndices(indices);


### PR DESCRIPTION
In Computer feature, 'Properties' is not added to the track menu, but Track Properties could still be invoked via hotkey.
We should disable that altogether in Computer because whatever is changed in Track Properties¹ is not shown in the (Computer) tracks view.

¹even though the selected track may already be in the library, if not will be added when loading the file to Track Properties