### PR TITLE
Fix loading the wrong track via drag and drop and fix wrong DEBUG_ASSERT

### DIFF
--- a/src/track/globaltrackcache.cpp
+++ b/src/track/globaltrackcache.cpp
@@ -487,6 +487,8 @@ TrackPointer GlobalTrackCache::lookupByRef(
                     << "cached =" << cachedTrackRef;
         }
     }
+    // Lookup failed, either because the TrackRef did not specify an id or canonical location,
+    // or because the database contains multiple tracks with that canonical location.
     return {};
 }
 


### PR DESCRIPTION
This fixes handling with duplicated tracks https://github.com/mixxxdj/mixxx/issues/13706. Now an attempt for caching two tracks with different locations referencing the same file are reliably detected and rejected the situation is reported as warning, and does no longer violates assertions. 

This has been tested on Ubuntu focal using a symlink 
`ln -s track.mp3 symlink.mp3`

The related issues showing the empty property page and overwriting thee symlink https://github.com/mixxxdj/mixxx/issues/13707 are still pending, work is in progress. 
