### PR TITLE
libdjinterop 0.22.1, support for Engine 4.0.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2261,7 +2261,7 @@ option(ENGINEPRIME "Support for library export to Denon Engine Prime" ON)
 if(ENGINEPRIME)
   # libdjinterop does not currently have a stable ABI, so we fetch sources for a specific tag, build here, and link
   # statically.  This situation should be reviewed once libdjinterop hits version 1.x.
-  set(LIBDJINTEROP_VERSION 0.21.0)
+  set(LIBDJINTEROP_VERSION 0.22.1)
   # Look whether an existing installation of libdjinterop matches the required version.
   find_package(DjInterop  ${LIBDJINTEROP_VERSION} EXACT CONFIG)
   if(NOT DjInterop_FOUND)
@@ -2293,11 +2293,18 @@ if(ENGINEPRIME)
     # For offline builds download the archive file from the URL and
     # copy it into DOWNLOAD_DIR under DOWNLOAD_NAME prior to starting
     # the configuration.
+    #
+    # If you want to test (locally) an experimental fork/branch of libdjinterop,
+    # you can comment out URL and URL_HASH and use GIT_REPOSITORY instead:
+    #
+    # GIT_REPOSITORY "https://github.com/abcd/your-fork-of-libdjinterop"
+    # GIT_TAG "origin/name-of-your-branch"
+    #
     ExternalProject_Add(libdjinterop
       URL
         "https://github.com/xsco/libdjinterop/archive/refs/tags/${LIBDJINTEROP_VERSION}.tar.gz"
         "https://launchpad.net/~xsco/+archive/ubuntu/djinterop/+sourcefiles/libdjinterop/${LIBDJINTEROP_VERSION}-0ubuntu1/libdjinterop_${LIBDJINTEROP_VERSION}.orig.tar.gz"
-      URL_HASH SHA256=160d4e09b25e859816a6b664058e7c6bc5cd889adeb188a9721c2b65d2133641
+      URL_HASH SHA256=e811158d42c3864f5b682bcf76e0af78278050439d82d14d592dd0a391da6b20
       DOWNLOAD_DIR "${CMAKE_CURRENT_BINARY_DIR}/downloads"
       DOWNLOAD_NAME "libdjinterop-${LIBDJINTEROP_VERSION}.tar.gz"
       INSTALL_DIR ${DJINTEROP_INSTALL_DIR}

--- a/src/library/export/engineprimeexportjob.cpp
+++ b/src/library/export/engineprimeexportjob.cpp
@@ -13,7 +13,6 @@
 #include "library/trackset/crate/crate.h"
 #include "moc_engineprimeexportjob.cpp"
 #include "track/track.h"
-#include "util/optional.h"
 #include "util/thread_affinity.h"
 #include "waveform/waveformfactory.h"
 
@@ -184,7 +183,7 @@ void exportMetadata(
 
     snapshot.track_number = pTrack->getTrackNumber().toInt();
     if (snapshot.track_number == 0) {
-        snapshot.track_number = djinterop::stdx::nullopt;
+        snapshot.track_number = std::nullopt;
     }
 
     snapshot.duration = std::chrono::milliseconds{


### PR DESCRIPTION
Latest version of libdjinterop adds support for Engine 4.0.0/4.0.1.

Fixes #13695 