### PR TITLE
Fix unnecessary painting in CoverArtDelegate

### DIFF
--- a/src/library/coverartdelegate.cpp
+++ b/src/library/coverartdelegate.cpp
@@ -136,7 +136,7 @@ void CoverArtDelegate::paintItem(
             // Cache miss
             if (m_inhibitLazyLoading) {
                 // We are requesting cache-only covers and got a cache
-                // miss. Maintain them in a list for later lookup
+                // miss. Record row in a list for later lookup.
                 if (!m_cacheMissRows.contains(index.row())) {
                     cleanCacheMissRows();
                     m_cacheMissRows.insert(index.row());

--- a/src/library/coverartdelegate.cpp
+++ b/src/library/coverartdelegate.cpp
@@ -85,7 +85,7 @@ void CoverArtDelegate::slotInhibitLazyLoading(
     const double scaleFactor = m_pTableView->devicePixelRatioF();
     const int width = static_cast<int>(m_pTableView->columnWidth(m_column) * scaleFactor);
 
-    for (int row : m_cacheMissRows) {
+    for (int row : std::as_const(m_cacheMissRows)) {
         QModelIndex index = m_pTableView->model()->index(row, m_column);
         CoverInfo coverInfo = m_pTrackModel->getCoverInfo(index);
         QRect rect = m_pTableView->visualRect(index);

--- a/src/library/coverartdelegate.cpp
+++ b/src/library/coverartdelegate.cpp
@@ -175,8 +175,8 @@ void CoverArtDelegate::paintItem(
 void CoverArtDelegate::cleanCacheMissRows() const {
     auto it = m_cacheMissRows.begin();
     while (it != m_cacheMissRows.end()) {
-        QModelIndex index = m_pTableView->model()->index(*it, m_column);
-        QRect rect = m_pTableView->visualRect(index);
+        const QModelIndex index = m_pTableView->model()->index(*it, m_column);
+        const QRect rect = m_pTableView->visualRect(index);
         if (!rect.intersects(m_pTableView->rect())) {
             // Cover image row is no longer shown. We keep the set
             // small which likely reuses the allocatd memory later

--- a/src/library/coverartdelegate.cpp
+++ b/src/library/coverartdelegate.cpp
@@ -182,6 +182,8 @@ void CoverArtDelegate::cleanCacheMissRows() const {
         QModelIndex index = m_pTableView->model()->index(*it, m_column);
         QRect rect = m_pTableView->visualRect(index);
         if (!rect.intersects(m_pTableView->rect())) {
+            // Cover image row is no longer shown. We keep the set
+            // small which likely reuses the allocatd memory later
             it = m_cacheMissRows.erase(it);
         } else {
             ++it;

--- a/src/library/coverartdelegate.cpp
+++ b/src/library/coverartdelegate.cpp
@@ -108,16 +108,16 @@ void CoverArtDelegate::paintItem(
         QPainter* painter,
         const QStyleOptionViewItem& option,
         const QModelIndex& index) const {
-    CoverInfo coverInfo = m_pTrackModel->getCoverInfo(index);
     VERIFY_OR_DEBUG_ASSERT(m_pTrackModel) {
         return;
     }
+    CoverInfo coverInfo = m_pTrackModel->getCoverInfo(index);
     bool drewPixmap = false;
     if (coverInfo.hasImage()) {
         VERIFY_OR_DEBUG_ASSERT(m_pCache) {
             return;
         }
-        const double scaleFactor = qobject_cast<QWidget*>(parent())->devicePixelRatioF();
+        const double scaleFactor = m_pTableView->devicePixelRatioF();
         QPixmap pixmap = CoverArtCache::getCachedCover(
                 coverInfo,
                 static_cast<int>(option.rect.width() * scaleFactor));

--- a/src/library/coverartdelegate.cpp
+++ b/src/library/coverartdelegate.cpp
@@ -103,8 +103,6 @@ void CoverArtDelegate::paintItem(
         QPainter* painter,
         const QStyleOptionViewItem& option,
         const QModelIndex& index) const {
-    paintItemBackground(painter, option, index);
-
     CoverInfo coverInfo = m_pTrackModel->getCoverInfo(index);
     VERIFY_OR_DEBUG_ASSERT(m_pTrackModel) {
         return;
@@ -157,8 +155,12 @@ void CoverArtDelegate::paintItem(
     // Since the background color is calculated from the cover art image
     // it is optional and may not always be available. The background
     // color may even be set manually without having a cover image.
-    if (!drewPixmap && coverInfo.color) {
-        painter->fillRect(option.rect, mixxx::RgbColor::toQColor(coverInfo.color));
+    if (!drewPixmap) {
+        if (coverInfo.color) {
+            painter->fillRect(option.rect, mixxx::RgbColor::toQColor(coverInfo.color));
+        } else {
+            paintItemBackground(painter, option, index);
+        }
     }
 
     // Draw a border if the cover art cell has focus

--- a/src/library/coverartdelegate.cpp
+++ b/src/library/coverartdelegate.cpp
@@ -76,7 +76,7 @@ void CoverArtDelegate::requestUncachedCover(
 void CoverArtDelegate::slotInhibitLazyLoading(
         bool inhibitLazyLoading) {
     m_inhibitLazyLoading = inhibitLazyLoading;
-    if (m_inhibitLazyLoading) {
+    if (m_inhibitLazyLoading || m_cacheMissRows.isEmpty()) {
         return;
     }
     VERIFY_OR_DEBUG_ASSERT(m_pTrackModel) {
@@ -86,10 +86,10 @@ void CoverArtDelegate::slotInhibitLazyLoading(
     const int width = static_cast<int>(m_pTableView->columnWidth(m_column) * scaleFactor);
 
     for (int row : std::as_const(m_cacheMissRows)) {
-        QModelIndex index = m_pTableView->model()->index(row, m_column);
-        CoverInfo coverInfo = m_pTrackModel->getCoverInfo(index);
-        QRect rect = m_pTableView->visualRect(index);
+        const QModelIndex index = m_pTableView->model()->index(row, m_column);
+        const QRect rect = m_pTableView->visualRect(index);
         if (rect.intersects(m_pTableView->rect())) {
+            const CoverInfo coverInfo = m_pTrackModel->getCoverInfo(index);
             requestUncachedCover(coverInfo, width, row);
         }
     }

--- a/src/library/coverartdelegate.h
+++ b/src/library/coverartdelegate.h
@@ -55,9 +55,11 @@ class CoverArtDelegate : public TableItemDelegate {
   private:
     void emitRowsChanged(
             QList<int>&& rows);
-    TrackPointer loadTrackByLocation(
-            const QString& trackLocation) const;
     void cleanCacheMissRows() const;
+    void requestUncachedCover(
+            const CoverInfo& coverInfo,
+            int width,
+            int row) const;
 
     CoverArtCache* const m_pCache;
     bool m_inhibitLazyLoading;

--- a/src/library/coverartdelegate.h
+++ b/src/library/coverartdelegate.h
@@ -55,15 +55,16 @@ class CoverArtDelegate : public TableItemDelegate {
   private:
     void emitRowsChanged(
             QList<int>&& rows);
-
     TrackPointer loadTrackByLocation(
             const QString& trackLocation) const;
+    void cleanCacheMissRows() const;
 
     CoverArtCache* const m_pCache;
     bool m_inhibitLazyLoading;
+    int m_column;
 
     // We need to record rows in paint() (which is const) so
     // these are marked mutable.
-    mutable QList<int> m_cacheMissRows;
+    mutable QSet<int> m_cacheMissRows;
     mutable QMultiHash<mixxx::cache_key_t, int> m_pendingCacheRows;
 };


### PR DESCRIPTION
I have created this during my my first attempt to fix the priority inversion #11128 when scrolling with cover arts column enabled. This is a bit of a speed up, but does not fix the actual problem. This will be part of the next PR #13719 