### PR TITLE
Usability/Keyboard: Make the star ratings in the tracks view editable via keyboard

### DIFF
--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -308,6 +308,8 @@ WLibrary QPlainTextEdit,
 WBeatSpinBox,
 /* Track label inline editor */
 WTrackPropertyEditor,
+#LibraryStarEditor[isKeyboardEditMode="true"],
+#LibraryStarEditor[isKeyboardEditMode="true"]::item,
 #LibraryBPMSpinBox {
   color: #ddd;
   background-color: #0f0f0f;
@@ -316,6 +318,8 @@ WTrackPropertyEditor,
 }
 WLibrary QLineEdit,
 WTrackPropertyEditor,
+#LibraryStarEditor[isKeyboardEditMode="true"],
+#LibraryStarEditor[isKeyboardEditMode="true"]::item,
 #LibraryBPMSpinBox {
   border: 1px solid #006596;
 }

--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -2377,6 +2377,8 @@ WLibrarySidebar {
 /* Table cell in edit mode */
 WLibrary QLineEdit,
 WLibrary QPlainTextEdit,
+#LibraryStarEditor[isKeyboardEditMode="true"],
+#LibraryStarEditor[isKeyboardEditMode="true"]::item,
 #LibraryBPMSpinBox,
 /* Track label inline editor in decks and samplers */
 WTrackPropertyEditor,

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -2974,6 +2974,8 @@ WSearchLineEdit,
 WTrackPropertyEditor,
 WLibrary QLineEdit,
 WLibrary QPlainTextEdit,
+#LibraryStarEditor[isKeyboardEditMode="true"],
+#LibraryStarEditor[isKeyboardEditMode="true"]::item,
 #spinBoxTransition,
 #spinBoxRecentDays,
 #LibraryBPMSpinBox {
@@ -3061,6 +3063,8 @@ WTrackTableView {
 /* Table cell in edit mode */
 WLibrary QLineEdit,
 WLibrary QPlainTextEdit,
+#LibraryStarEditor[isKeyboardEditMode="true"],
+#LibraryStarEditor[isKeyboardEditMode="true"]::item,
 #LibraryBPMSpinBox,
 /* Track label inline editor in decks and samplers */
 WTrackPropertyEditor {

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -622,6 +622,8 @@ WTrackTableView {
   WLibrary QPlainTextEdit,
   /* Track label inline editor in decks and samplers */
   WTrackPropertyEditor,
+  #LibraryStarEditor[isKeyboardEditMode="true"],
+  #LibraryStarEditor[isKeyboardEditMode="true"]::item,
   #LibraryBPMSpinBox {
     color: #ddd;
     background-color: #0f0f0f;
@@ -629,6 +631,8 @@ WTrackTableView {
     selection-background-color: #ccc;
   }
   WLibrary QLineEdit,
+  #LibraryStarEditor[isKeyboardEditMode="true"],
+  #LibraryStarEditor[isKeyboardEditMode="true"]::item,
   #LibraryBPMSpinBox {
     border: 1px solid #656d75;
   }

--- a/res/skins/Shade/style_dark.qss
+++ b/res/skins/Shade/style_dark.qss
@@ -242,6 +242,8 @@ WTrackTableView {
   WLibrary QPlainTextEdit,
   /* Track label inline editor in decks and samplers */
   WTrackPropertyEditor,
+  #LibraryStarEditor[isKeyboardEditMode="true"],
+  #LibraryStarEditor[isKeyboardEditMode="true"]::item,
   #LibraryBPMSpinBox {
     color: #ddd;
     background-color: #0f0f0f;

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -2754,6 +2754,8 @@ WTrackTableView {
   WLibrary QPlainTextEdit,
   /* Track label inline editor in decks and samplers */
   WTrackPropertyEditor,
+  #LibraryStarEditor[isKeyboardEditMode="true"],
+  #LibraryStarEditor[isKeyboardEditMode="true"]::item,
   #LibraryBPMSpinBox {
     color: #ddd;
     background-color: #0f0f0f;
@@ -2763,6 +2765,8 @@ WTrackTableView {
     border-style: solid;
   }
   WLibrary QLineEdit,
+  #LibraryStarEditor[isKeyboardEditMode="true"],
+  #LibraryStarEditor[isKeyboardEditMode="true"]::item,
   #LibraryBPMSpinBox {
     border-color: #555;
   }

--- a/src/library/tabledelegates/stardelegate.cpp
+++ b/src/library/tabledelegates/stardelegate.cpp
@@ -16,7 +16,7 @@ StarDelegate::StarDelegate(QTableView* pTableView)
     connect(pTableView, &QTableView::entered, this, &StarDelegate::cellEntered);
     connect(pTableView, &QTableView::viewportEntered, this, &StarDelegate::cursorNotOverAnyCell);
 
-    auto pTrackTableView = qobject_cast<WTrackTableView*>(pTableView);
+    auto* pTrackTableView = qobject_cast<WTrackTableView*>(pTableView);
     if (pTrackTableView) {
         connect(pTrackTableView,
                 &WTrackTableView::viewportLeaving,

--- a/src/library/tabledelegates/stardelegate.cpp
+++ b/src/library/tabledelegates/stardelegate.cpp
@@ -20,6 +20,10 @@ StarDelegate::StarDelegate(QTableView* pTableView)
                 &WTrackTableView::viewportLeaving,
                 this,
                 &StarDelegate::cursorNotOverAnyCell);
+        connect(pTrackTableView,
+                &WTrackTableView::editRequested,
+                this,
+                &StarDelegate::editRequested);
     }
 }
 
@@ -86,6 +90,23 @@ void StarDelegate::commitAndCloseEditor() {
     StarEditor* editor = qobject_cast<StarEditor*>(sender());
     emit commitData(editor);
     emit closeEditor(editor, QAbstractItemDelegate::SubmitModelCache);
+}
+
+void StarDelegate::editRequested(const QModelIndex& index,
+        QAbstractItemView::EditTrigger trigger,
+        QEvent* event) {
+    Q_UNUSED(event);
+
+    // This slot is called when an edit is requested for ANY cell on the
+    // QTableView but the code should only be executed on a column with a
+    // StarRating.
+    if (trigger == QAbstractItemView::EditTrigger::EditKeyPressed &&
+            m_isPersistentEditorOpen && index.data().canConvert<StarRating>() &&
+            m_currentEditedCellIndex == index) {
+        // Close the (implicit) persistent editor for the current cell,
+        // so that a new explicit editor can be opened instead.
+        closeCurrentPersistentRatingEditor();
+    }
 }
 
 void StarDelegate::cellEntered(const QModelIndex& index) {

--- a/src/library/tabledelegates/stardelegate.cpp
+++ b/src/library/tabledelegates/stardelegate.cpp
@@ -101,15 +101,14 @@ void StarDelegate::commitAndCloseEditor() {
     emit closeEditor(editor, QAbstractItemDelegate::SubmitModelCache);
 }
 
-void StarDelegate::closingEditor(QWidget* widget, QAbstractItemDelegate::EndEditHint hint) {
-    Q_UNUSED(hint);
+void StarDelegate::closingEditor(QWidget* pWidget, QAbstractItemDelegate::EndEditHint) {
 
-    auto* editor = qobject_cast<StarEditor*>(widget);
-    VERIFY_OR_DEBUG_ASSERT(editor) {
+    auto* pEditor = qobject_cast<StarEditor*>(pWidget);
+    VERIFY_OR_DEBUG_ASSERT(pEditor) {
         return;
     }
 
-    restorePersistentRatingEditor(editor->getModelIndex());
+    restorePersistentRatingEditor(pEditor->getModelIndex());
 }
 
 void StarDelegate::editRequested(const QModelIndex& index,

--- a/src/library/tabledelegates/stardelegate.cpp
+++ b/src/library/tabledelegates/stardelegate.cpp
@@ -113,8 +113,7 @@ void StarDelegate::closingEditor(QWidget* pWidget, QAbstractItemDelegate::EndEdi
 
 void StarDelegate::editRequested(const QModelIndex& index,
         QAbstractItemView::EditTrigger trigger,
-        QEvent* event) {
-    Q_UNUSED(event);
+        QEvent*) {
 
     // This slot is called when an edit is requested for ANY cell on the
     // QTableView but the code should only be executed on a column with a

--- a/src/library/tabledelegates/stardelegate.cpp
+++ b/src/library/tabledelegates/stardelegate.cpp
@@ -66,8 +66,15 @@ QWidget* StarDelegate::createEditor(QWidget* parent,
     // paint event which resets the pending (unsaved) rating anyway.
     setTextColor(newOption, index);
 
-    StarEditor* editor =
-            new StarEditor(parent, m_pTableView, index, newOption, m_focusBorderColor);
+    StarEditor* editor = new StarEditor(parent,
+            m_pTableView,
+            index,
+            newOption,
+            m_persistentEditorState != PersistentEditor_Opening);
+
+    editor->setObjectName("LibraryStarEditor");
+    editor->ensurePolished();
+
     connect(editor,
             &StarEditor::editingFinished,
             this,
@@ -156,6 +163,7 @@ void StarDelegate::openPersistentRatingEditor(const QModelIndex& index) {
     }
 
     m_persistentEditorState = PersistentEditor_NotOpen;
+    m_persistentEditorState = PersistentEditor_Opening;
     m_pTableView->openPersistentEditor(index);
     m_persistentEditorState = PersistentEditor_Open;
     m_currentEditedCellIndex = index;

--- a/src/library/tabledelegates/stardelegate.cpp
+++ b/src/library/tabledelegates/stardelegate.cpp
@@ -141,6 +141,14 @@ void StarDelegate::cursorNotOverAnyCell() {
 }
 
 void StarDelegate::openPersistentRatingEditor(const QModelIndex& index) {
+    // Qt6: Check whether a non-persistent editor exists at index.
+    // QTableView::closePersistentEditor() would also close
+    // a non-persistent editor, so we have to make sure to
+    // not call it if an editor already exists.
+    if (m_pTableView->indexWidget(index)) {
+        return;
+    }
+
     // Close the previously open persistent rating editor
     if (m_persistentEditorState == PersistentEditor_Open) {
         // Don't close other editors when hovering the stars cell!

--- a/src/library/tabledelegates/stardelegate.cpp
+++ b/src/library/tabledelegates/stardelegate.cpp
@@ -75,7 +75,7 @@ void StarDelegate::setModelData(QWidget* editor, QAbstractItemModel* model,
 void StarDelegate::commitAndCloseEditor() {
     StarEditor* editor = qobject_cast<StarEditor*>(sender());
     emit commitData(editor);
-    emit closeEditor(editor);
+    emit closeEditor(editor, QAbstractItemDelegate::SubmitModelCache);
 }
 
 void StarDelegate::cellEntered(const QModelIndex& index) {

--- a/src/library/tabledelegates/stardelegate.cpp
+++ b/src/library/tabledelegates/stardelegate.cpp
@@ -10,7 +10,8 @@
 
 StarDelegate::StarDelegate(QTableView* pTableView)
         : TableItemDelegate(pTableView),
-          m_isPersistentEditorOpen(false) {
+          m_persistentEditorState(PersistentEditor_NotOpen) {
+    connect(this, &QAbstractItemDelegate::closeEditor, this, &StarDelegate::closingEditor);
     connect(pTableView, &QTableView::entered, this, &StarDelegate::cellEntered);
     connect(pTableView, &QTableView::viewportEntered, this, &StarDelegate::cursorNotOverAnyCell);
 
@@ -92,6 +93,17 @@ void StarDelegate::commitAndCloseEditor() {
     emit closeEditor(editor, QAbstractItemDelegate::SubmitModelCache);
 }
 
+void StarDelegate::closingEditor(QWidget* widget, QAbstractItemDelegate::EndEditHint hint) {
+    Q_UNUSED(hint);
+
+    auto* editor = qobject_cast<StarEditor*>(widget);
+    VERIFY_OR_DEBUG_ASSERT(editor) {
+        return;
+    }
+
+    restorePersistentRatingEditor(editor->getModelIndex());
+}
+
 void StarDelegate::editRequested(const QModelIndex& index,
         QAbstractItemView::EditTrigger trigger,
         QEvent* event) {
@@ -101,11 +113,12 @@ void StarDelegate::editRequested(const QModelIndex& index,
     // QTableView but the code should only be executed on a column with a
     // StarRating.
     if (trigger == QAbstractItemView::EditTrigger::EditKeyPressed &&
-            m_isPersistentEditorOpen && index.data().canConvert<StarRating>() &&
+            m_persistentEditorState == PersistentEditor_Open &&
+            index.data().canConvert<StarRating>() &&
             m_currentEditedCellIndex == index) {
         // Close the (implicit) persistent editor for the current cell,
         // so that a new explicit editor can be opened instead.
-        closeCurrentPersistentRatingEditor();
+        closeCurrentPersistentRatingEditor(true);
     }
 }
 
@@ -116,32 +129,50 @@ void StarDelegate::cellEntered(const QModelIndex& index) {
     if (index.data().canConvert<StarRating>()) {
         openPersistentRatingEditor(index);
     } else {
-        closeCurrentPersistentRatingEditor();
+        closeCurrentPersistentRatingEditor(false);
     }
 }
 
 void StarDelegate::cursorNotOverAnyCell() {
     // Invoked when the mouse cursor is not over any specific cell,
     // or when the mouse cursor has left the table area
-    closeCurrentPersistentRatingEditor();
+    closeCurrentPersistentRatingEditor(false);
 }
 
 void StarDelegate::openPersistentRatingEditor(const QModelIndex& index) {
     // Close the previously open persistent rating editor
-    if (m_isPersistentEditorOpen) {
+    if (m_persistentEditorState == PersistentEditor_Open) {
         // Don't close other editors when hovering the stars cell!
         m_pTableView->closePersistentEditor(m_currentEditedCellIndex);
     }
 
+    m_persistentEditorState = PersistentEditor_NotOpen;
     m_pTableView->openPersistentEditor(index);
-    m_isPersistentEditorOpen = true;
+    m_persistentEditorState = PersistentEditor_Open;
     m_currentEditedCellIndex = index;
 }
 
-void StarDelegate::closeCurrentPersistentRatingEditor() {
-    if (m_isPersistentEditorOpen) {
-        m_isPersistentEditorOpen = false;
+void StarDelegate::closeCurrentPersistentRatingEditor(bool rememberForRestore) {
+    if (m_persistentEditorState == PersistentEditor_Open) {
         m_pTableView->closePersistentEditor(m_currentEditedCellIndex);
+    }
+
+    if (rememberForRestore &&
+            (m_persistentEditorState == PersistentEditor_Open ||
+                    m_persistentEditorState == PersistentEditor_ShouldRestore)) {
+        // Keep m_currentEditedCellIndex so the persistent editor
+        // can be restored when the currently active explicit editor
+        // is closed.
+        m_persistentEditorState = PersistentEditor_ShouldRestore;
+    } else {
+        m_persistentEditorState = PersistentEditor_NotOpen;
         m_currentEditedCellIndex = QPersistentModelIndex();
+    }
+}
+
+void StarDelegate::restorePersistentRatingEditor(const QModelIndex& index) {
+    if (m_persistentEditorState == PersistentEditor_ShouldRestore &&
+            index.isValid() && m_currentEditedCellIndex == index) {
+        openPersistentRatingEditor(m_currentEditedCellIndex);
     }
 }

--- a/src/library/tabledelegates/stardelegate.cpp
+++ b/src/library/tabledelegates/stardelegate.cpp
@@ -1,6 +1,7 @@
 #include "library/tabledelegates/stardelegate.h"
 
 #include <QTableView>
+#include <QTimer>
 
 #include "library/starrating.h"
 #include "library/tabledelegates/stareditor.h"
@@ -173,6 +174,19 @@ void StarDelegate::closeCurrentPersistentRatingEditor(bool rememberForRestore) {
 void StarDelegate::restorePersistentRatingEditor(const QModelIndex& index) {
     if (m_persistentEditorState == PersistentEditor_ShouldRestore &&
             index.isValid() && m_currentEditedCellIndex == index) {
+        // Avoid race conditions by deferring the restore until
+        // we have returned to the event loop, and the closing of
+        // the current editor has been finished. Otherwise,
+        // the internal state of QAbstractItemView may become
+        // inconsistent.
+        m_persistentEditorState = PersistentEditor_InDeferredRestore;
+        QTimer::singleShot(0, this, &StarDelegate::restorePersistentRatingEditorNow);
+    }
+}
+
+void StarDelegate::restorePersistentRatingEditorNow() {
+    if (m_persistentEditorState == PersistentEditor_InDeferredRestore &&
+            m_currentEditedCellIndex.isValid()) {
         openPersistentRatingEditor(m_currentEditedCellIndex);
     }
 }

--- a/src/library/tabledelegates/stardelegate.cpp
+++ b/src/library/tabledelegates/stardelegate.cpp
@@ -6,11 +6,21 @@
 #include "library/tabledelegates/stareditor.h"
 #include "library/tabledelegates/tableitemdelegate.h"
 #include "moc_stardelegate.cpp"
+#include "widget/wtracktableview.h"
 
 StarDelegate::StarDelegate(QTableView* pTableView)
         : TableItemDelegate(pTableView),
           m_isOneCellInEditMode(false) {
     connect(pTableView, &QTableView::entered, this, &StarDelegate::cellEntered);
+    connect(pTableView, &QTableView::viewportEntered, this, &StarDelegate::cursorNotOverAnyCell);
+
+    auto pTrackTableView = qobject_cast<WTrackTableView*>(pTableView);
+    if (pTrackTableView) {
+        connect(pTrackTableView,
+                &WTrackTableView::viewportLeaving,
+                this,
+                &StarDelegate::cursorNotOverAnyCell);
+    }
 }
 
 void StarDelegate::paintItem(
@@ -93,6 +103,16 @@ void StarDelegate::cellEntered(const QModelIndex& index) {
     } else if (m_isOneCellInEditMode) {
         m_isOneCellInEditMode = false;
         m_pTableView->closePersistentEditor(m_currentEditedCellIndex);
-        m_currentEditedCellIndex = QModelIndex();
+        m_currentEditedCellIndex = QPersistentModelIndex();
+    }
+}
+
+void StarDelegate::cursorNotOverAnyCell() {
+    // Invoked when the mouse cursor is not over any specific cell,
+    // or when the mouse cursor has left the table area
+    if (m_isOneCellInEditMode) {
+        m_isOneCellInEditMode = false;
+        m_pTableView->closePersistentEditor(m_currentEditedCellIndex);
+        m_currentEditedCellIndex = QPersistentModelIndex();
     }
 }

--- a/src/library/tabledelegates/stardelegate.cpp
+++ b/src/library/tabledelegates/stardelegate.cpp
@@ -10,7 +10,7 @@
 
 StarDelegate::StarDelegate(QTableView* pTableView)
         : TableItemDelegate(pTableView),
-          m_isOneCellInEditMode(false) {
+          m_isPersistentEditorOpen(false) {
     connect(pTableView, &QTableView::entered, this, &StarDelegate::cellEntered);
     connect(pTableView, &QTableView::viewportEntered, this, &StarDelegate::cursorNotOverAnyCell);
 
@@ -93,25 +93,33 @@ void StarDelegate::cellEntered(const QModelIndex& index) {
     // QTableView but the code should only be executed on a column with a
     // StarRating.
     if (index.data().canConvert<StarRating>()) {
-        if (m_isOneCellInEditMode) {
-            // Don't close other editors when hovering the stars cell!
-            m_pTableView->closePersistentEditor(m_currentEditedCellIndex);
-        }
-        m_pTableView->openPersistentEditor(index);
-        m_isOneCellInEditMode = true;
-        m_currentEditedCellIndex = index;
-    } else if (m_isOneCellInEditMode) {
-        m_isOneCellInEditMode = false;
-        m_pTableView->closePersistentEditor(m_currentEditedCellIndex);
-        m_currentEditedCellIndex = QPersistentModelIndex();
+        openPersistentRatingEditor(index);
+    } else {
+        closeCurrentPersistentRatingEditor();
     }
 }
 
 void StarDelegate::cursorNotOverAnyCell() {
     // Invoked when the mouse cursor is not over any specific cell,
     // or when the mouse cursor has left the table area
-    if (m_isOneCellInEditMode) {
-        m_isOneCellInEditMode = false;
+    closeCurrentPersistentRatingEditor();
+}
+
+void StarDelegate::openPersistentRatingEditor(const QModelIndex& index) {
+    // Close the previously open persistent rating editor
+    if (m_isPersistentEditorOpen) {
+        // Don't close other editors when hovering the stars cell!
+        m_pTableView->closePersistentEditor(m_currentEditedCellIndex);
+    }
+
+    m_pTableView->openPersistentEditor(index);
+    m_isPersistentEditorOpen = true;
+    m_currentEditedCellIndex = index;
+}
+
+void StarDelegate::closeCurrentPersistentRatingEditor() {
+    if (m_isPersistentEditorOpen) {
+        m_isPersistentEditorOpen = false;
         m_pTableView->closePersistentEditor(m_currentEditedCellIndex);
         m_currentEditedCellIndex = QPersistentModelIndex();
     }

--- a/src/library/tabledelegates/stardelegate.h
+++ b/src/library/tabledelegates/stardelegate.h
@@ -48,6 +48,7 @@ class StarDelegate : public TableItemDelegate {
 
     enum PersistentEditorState {
         PersistentEditor_NotOpen,
+        PersistentEditor_Opening,
         PersistentEditor_Open,
         PersistentEditor_ShouldRestore,
         PersistentEditor_InDeferredRestore

--- a/src/library/tabledelegates/stardelegate.h
+++ b/src/library/tabledelegates/stardelegate.h
@@ -39,6 +39,7 @@ class StarDelegate : public TableItemDelegate {
     void editRequested(const QModelIndex& index,
             QAbstractItemView::EditTrigger trigger,
             QEvent* event);
+    void restorePersistentRatingEditorNow();
 
   private:
     void openPersistentRatingEditor(const QModelIndex& index);
@@ -48,7 +49,8 @@ class StarDelegate : public TableItemDelegate {
     enum PersistentEditorState {
         PersistentEditor_NotOpen,
         PersistentEditor_Open,
-        PersistentEditor_ShouldRestore
+        PersistentEditor_ShouldRestore,
+        PersistentEditor_InDeferredRestore
     };
 
     QPersistentModelIndex m_currentEditedCellIndex;

--- a/src/library/tabledelegates/stardelegate.h
+++ b/src/library/tabledelegates/stardelegate.h
@@ -33,6 +33,7 @@ class StarDelegate : public TableItemDelegate {
 
   private slots:
     void commitAndCloseEditor();
+    void closingEditor(QWidget* widget, QAbstractItemDelegate::EndEditHint hint);
     void cellEntered(const QModelIndex& index);
     void cursorNotOverAnyCell();
     void editRequested(const QModelIndex& index,
@@ -41,7 +42,15 @@ class StarDelegate : public TableItemDelegate {
 
   private:
     void openPersistentRatingEditor(const QModelIndex& index);
-    void closeCurrentPersistentRatingEditor();
+    void closeCurrentPersistentRatingEditor(bool rememberForRestore);
+    void restorePersistentRatingEditor(const QModelIndex& index);
+
+    enum PersistentEditorState {
+        PersistentEditor_NotOpen,
+        PersistentEditor_Open,
+        PersistentEditor_ShouldRestore
+    };
+
     QPersistentModelIndex m_currentEditedCellIndex;
-    bool m_isPersistentEditorOpen;
+    PersistentEditorState m_persistentEditorState;
 };

--- a/src/library/tabledelegates/stardelegate.h
+++ b/src/library/tabledelegates/stardelegate.h
@@ -35,6 +35,9 @@ class StarDelegate : public TableItemDelegate {
     void commitAndCloseEditor();
     void cellEntered(const QModelIndex& index);
     void cursorNotOverAnyCell();
+    void editRequested(const QModelIndex& index,
+            QAbstractItemView::EditTrigger trigger,
+            QEvent* event);
 
   private:
     void openPersistentRatingEditor(const QModelIndex& index);

--- a/src/library/tabledelegates/stardelegate.h
+++ b/src/library/tabledelegates/stardelegate.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <QAbstractItemView>
+
 #include "library/tabledelegates/tableitemdelegate.h"
 
 class StarDelegate : public TableItemDelegate {
@@ -35,6 +37,8 @@ class StarDelegate : public TableItemDelegate {
     void cursorNotOverAnyCell();
 
   private:
+    void openPersistentRatingEditor(const QModelIndex& index);
+    void closeCurrentPersistentRatingEditor();
     QPersistentModelIndex m_currentEditedCellIndex;
-    bool m_isOneCellInEditMode;
+    bool m_isPersistentEditorOpen;
 };

--- a/src/library/tabledelegates/stardelegate.h
+++ b/src/library/tabledelegates/stardelegate.h
@@ -32,6 +32,7 @@ class StarDelegate : public TableItemDelegate {
   private slots:
     void commitAndCloseEditor();
     void cellEntered(const QModelIndex& index);
+    void cursorNotOverAnyCell();
 
   private:
     QPersistentModelIndex m_currentEditedCellIndex;

--- a/src/library/tabledelegates/stareditor.cpp
+++ b/src/library/tabledelegates/stareditor.cpp
@@ -40,9 +40,13 @@ QSize StarEditor::sizeHint() const {
 }
 
 void StarEditor::paintEvent(QPaintEvent*) {
-    // If a StarEditor is open, by definition the mouse is hovering over us.
-    m_styleOption.state |= QStyle::State_MouseOver;
     m_styleOption.rect = rect();
+
+    if (underMouse()) {
+        m_styleOption.state |= QStyle::State_MouseOver;
+    } else {
+        m_styleOption.state &= ~QStyle::State_MouseOver;
+    }
 
     QItemSelectionModel* selectionModel = m_pTableView->selectionModel();
     if (selectionModel) {

--- a/src/library/tabledelegates/stareditor.cpp
+++ b/src/library/tabledelegates/stareditor.cpp
@@ -23,13 +23,13 @@ StarEditor::StarEditor(QWidget* parent,
         QTableView* pTableView,
         const QModelIndex& index,
         const QStyleOptionViewItem& option,
-        const QColor& focusBorderColor)
+        bool isKeyboardEditMode)
         : QWidget(parent),
           m_pTableView(pTableView),
           m_index(index),
           m_styleOption(option),
-          m_focusBorderColor(focusBorderColor),
-          m_starCount(StarRating::kMinStarCount) {
+          m_starCount(StarRating::kMinStarCount),
+          m_isKeyboardEditMode(isKeyboardEditMode) {
     DEBUG_ASSERT(m_pTableView);
     setMouseTracking(true);
     installEventFilter(this);
@@ -72,23 +72,20 @@ void StarEditor::paintEvent(QPaintEvent*) {
     painter.setClipRect(m_styleOption.rect);
 
     // Draw standard item with the table view's style
-    QStyle* style = m_pTableView->style();
+    QStyle* style = this->style();
     if (style) {
-        style->drawControl(QStyle::CE_ItemViewItem, &m_styleOption, &painter, m_pTableView);
+        // Overwrite the background and stars rendered by the StarDelegate
+        style->drawPrimitive(QStyle::PE_PanelItemViewItem, &m_styleOption, &painter, this);
     }
 
+    painter.save();
     if (m_styleOption.state & QStyle::State_Selected) {
         painter.setBrush(m_styleOption.palette.highlightedText().color());
     } else {
         painter.setBrush(m_styleOption.palette.text().color());
     }
-
     m_starRating.paint(&painter, m_styleOption.rect);
-
-    // Draw a border if the color cell is selected
-    if (m_styleOption.state & QStyle::State_HasFocus) {
-        TableItemDelegate::drawBorder(&painter, m_focusBorderColor, m_styleOption.rect);
-    }
+    painter.restore();
 }
 
 bool StarEditor::eventFilter(QObject* obj, QEvent* event) {

--- a/src/library/tabledelegates/stareditor.cpp
+++ b/src/library/tabledelegates/stareditor.cpp
@@ -29,6 +29,7 @@ StarEditor::StarEditor(QWidget* parent,
           m_index(index),
           m_styleOption(option),
           m_starCount(StarRating::kMinStarCount),
+          m_starCountToSave(StarRating::kInvalidStarCount),
           m_isKeyboardEditMode(isKeyboardEditMode) {
     DEBUG_ASSERT(m_pTableView);
     setMouseTracking(true);
@@ -187,10 +188,23 @@ bool StarEditor::eventFilter(QObject* obj, QEvent* event) {
         // Note: it seems with Qt5 we do not reliably get a Leave event when
         // invoking the track menu via right click, so reset the rating now.
         // The event is forwarded to parent QTableView.
+        m_starCountToSave = StarRating::kInvalidStarCount;
         resetRating();
         break;
     }
+    case QEvent::MouseButtonPress: {
+        // Workaround: The MouseButtonPress can cause a focus change that might
+        // cause a database reload, which then overwrites m_starRating before
+        // the MouseButtonRelease event has a chance to commit the new value
+        // to the model.
+        m_starCountToSave = m_starRating.starCount();
+        break;
+    }
     case QEvent::MouseButtonRelease: {
+        if (m_starCountToSave != StarRating::kInvalidStarCount) {
+            m_starRating.setStarCount(m_starCountToSave);
+            m_starCountToSave = StarRating::kInvalidStarCount;
+        }
         emit editingFinished();
         break;
     }

--- a/src/library/tabledelegates/stareditor.cpp
+++ b/src/library/tabledelegates/stareditor.cpp
@@ -93,6 +93,98 @@ void StarEditor::paintEvent(QPaintEvent*) {
 
 bool StarEditor::eventFilter(QObject* obj, QEvent* event) {
     switch (event->type()) {
+    case QEvent::KeyPress: {
+        VERIFY_OR_DEBUG_ASSERT(m_isKeyboardEditMode) {
+            // Persistent editors (i.e. those opened using openPersistentEditor)
+            // should not receive keyboard events via their eventFilter, so we
+            // shouldn't normally arrive here - but if we do, just forward the events.
+            return false;
+        }
+
+        // Change rating when certain keys are pressed
+        // while we are in edit mode.
+        QKeyEvent* ke = static_cast<QKeyEvent*>(event);
+        int newRating = m_starRating.starCount();
+        switch (ke->key()) {
+        case Qt::Key_Up:
+        case Qt::Key_Down:
+        case Qt::Key_PageUp:
+        case Qt::Key_PageDown: {
+            // Allow handling of certain keyboard navigation events.
+            // This logic attempts to match the behavior for text editor cells.
+            return false;
+        }
+        case Qt::Key_Home:
+        case Qt::Key_End: {
+            // Only forward Home and End if the Ctrl key is pressed.
+            // This matches the behavior of normal text editor cells.
+            if (ke->modifiers() & Qt::ControlModifier) {
+                return false;
+            }
+            return true;
+        }
+        case Qt::Key_0: {
+            newRating = 0;
+            break;
+        }
+        case Qt::Key_1: {
+            newRating = 1;
+            break;
+        }
+        case Qt::Key_2: {
+            newRating = 2;
+            break;
+        }
+        case Qt::Key_3: {
+            newRating = 3;
+            break;
+        }
+        case Qt::Key_4: {
+            newRating = 4;
+            break;
+        }
+        case Qt::Key_5: {
+            newRating = 5;
+            break;
+        }
+        case Qt::Key_6: {
+            newRating = 6;
+            break;
+        }
+        case Qt::Key_7: {
+            newRating = 7;
+            break;
+        }
+        case Qt::Key_8: {
+            newRating = 8;
+            break;
+        }
+        case Qt::Key_9: {
+            newRating = 9;
+            break;
+        }
+        case Qt::Key_Right:
+        case Qt::Key_Plus: {
+            newRating++;
+            break;
+        }
+        case Qt::Key_Left:
+        case Qt::Key_Minus: {
+            newRating--;
+            break;
+        }
+        }
+        newRating = math_clamp(newRating, StarRating::kMinStarCount, m_starRating.maxStarCount());
+        if (newRating != m_starRating.starCount()) {
+            // Apply star rating if it changed
+            m_starRating.setStarCount(newRating);
+            m_starCount = newRating;
+            update();
+        }
+        // Prevent other keys from being handled as global keyboard shortcuts.
+        // This matches the behavior of the other edit controls.
+        return true;
+    }
     case QEvent::Leave:
     case QEvent::ContextMenu: {
         // Note: it seems with Qt5 we do not reliably get a Leave event when

--- a/src/library/tabledelegates/stareditor.h
+++ b/src/library/tabledelegates/stareditor.h
@@ -29,6 +29,10 @@ class StarEditor : public QWidget {
     }
     StarRating starRating() { return m_starRating; }
 
+    QModelIndex getModelIndex() {
+        return m_index;
+    }
+
   signals:
     void editingFinished();
 

--- a/src/library/tabledelegates/stareditor.h
+++ b/src/library/tabledelegates/stareditor.h
@@ -58,5 +58,6 @@ class StarEditor : public QWidget {
     QStyleOptionViewItem m_styleOption;
     StarRating m_starRating;
     int m_starCount;
+    int m_starCountToSave;
     bool m_isKeyboardEditMode;
 };

--- a/src/library/tabledelegates/stareditor.h
+++ b/src/library/tabledelegates/stareditor.h
@@ -11,12 +11,18 @@ class QTableView;
 
 class StarEditor : public QWidget {
     Q_OBJECT
+
+    // The isKeyboardEditMode property is used by the skin stylesheets
+    // to distinguish StarEditor widgets with keyboard edit focus
+    // from those without.
+    Q_PROPERTY(bool isKeyboardEditMode MEMBER m_isKeyboardEditMode)
+
   public:
     StarEditor(QWidget* parent,
             QTableView* pTableView,
             const QModelIndex& index,
             const QStyleOptionViewItem& option,
-            const QColor& focusBorderColor);
+            bool isKeyboardEditMode);
 
     QSize sizeHint() const override;
     void setStarRating(const StarRating& starRating) {
@@ -50,7 +56,7 @@ class StarEditor : public QWidget {
     QTableView* m_pTableView;
     QModelIndex m_index;
     QStyleOptionViewItem m_styleOption;
-    QColor m_focusBorderColor;
     StarRating m_starRating;
     int m_starCount;
+    bool m_isKeyboardEditMode;
 };

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -674,6 +674,11 @@ void WTrackTableView::onSearch(const QString& text) {
 void WTrackTableView::onShow() {
 }
 
+void WTrackTableView::leaveEvent(QEvent* pEvent) {
+    Q_UNUSED(pEvent);
+    emit viewportLeaving();
+}
+
 void WTrackTableView::mousePressEvent(QMouseEvent* pEvent) {
     DragAndDropHelper::mousePressed(pEvent);
     WLibraryTableView::mousePressEvent(pEvent);

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1457,6 +1457,16 @@ void WTrackTableView::editSelectedItem() {
     }
 }
 
+bool WTrackTableView::edit(const QModelIndex& index, EditTrigger trigger, QEvent* event) {
+    // Notify the StarDelegate that we want to open an editor, either due to
+    // the mouse hovering over a cell, or because the user pressed the edit key,
+    // to allow it to properly handle switching between these two edit modes.
+    //
+    // This behavior is unique to the StarDelegate.
+    emit editRequested(index, trigger, event);
+    return QAbstractItemView::edit(index, trigger, event);
+}
+
 void WTrackTableView::activateSelectedTrack() {
     const QModelIndexList indices = getSelectedRows();
     if (indices.isEmpty()) {

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -127,6 +127,9 @@ class WTrackTableView : public WLibraryTableView {
     void trackMissingColorChanged(QColor col);
     void dropIndicatorColorChanged(QColor col);
 
+    // Invoked when the mouse leaves this widget.
+    void viewportLeaving();
+
   public slots:
     void loadTrackModel(QAbstractItemModel* model, bool restoreState = false);
     void slotMouseDoubleClicked(const QModelIndex &);
@@ -174,6 +177,7 @@ class WTrackTableView : public WLibraryTableView {
     void selectionChanged(const QItemSelection &selected,
                           const QItemSelection &deselected) override;
 
+    void leaveEvent(QEvent* pEvent) override;
     void mousePressEvent(QMouseEvent* pEvent) override;
     // Mouse move event, implemented to hide the text and show an icon instead
     // when dragging.

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -129,6 +129,9 @@ class WTrackTableView : public WLibraryTableView {
 
     // Invoked when the mouse leaves this widget.
     void viewportLeaving();
+    void editRequested(const QModelIndex& index,
+            QAbstractItemView::EditTrigger trigger,
+            QEvent* event);
 
   public slots:
     void loadTrackModel(QAbstractItemModel* model, bool restoreState = false);
@@ -195,6 +198,8 @@ class WTrackTableView : public WLibraryTableView {
     void showTrackMenu(const QPoint pos, const QModelIndex& index);
 
     void hideOrRemoveSelectedTracks();
+
+    bool edit(const QModelIndex& index, EditTrigger trigger, QEvent* event) override;
 
     const UserSettingsPointer m_pConfig;
     Library* const m_pLibrary;


### PR DESCRIPTION
It is now possible to press ~~enter~~ the edit key (`F2`, or, once #13148 is merged, 'R` resp. the confiugured edit key) on a selected "star rating" to then change the rating via the keyboard (either left/right arrow keys or numbers). Changing the rating using the mouse is still possible, and should work & interact with the keyboard edits as expected.

![ezgif-6-299426cc3f](https://github.com/user-attachments/assets/42caef62-9a1e-4c31-831c-388178867c8a)

### But why is this PR so large?
The code for handling the actual keyboard edits is quite simple. Nearly all of the complexity relates to handling the interaction between editing via mouse hover, editing via keyboard and the assumptions of the Qt `QTableView` framework code.

**In short:** Cells in the `QTableView` can either be in "edit mode" or "display mode". Pressing the edit key should enter edit mode, canceling or committing the edit should leave edit mode. BUT: The cells should also automatically enter edit mode when the mouse hovers over the cell, and exit it when the mouse leaves the cell. The rating should also temporarily adapt to the position of the mouse when hovering over the cell. But what happens e.g. when the user presses the edit key while already hovering over the cell?

All in all, the desired (and hereby implemented) behavior boils down to the following state machine:

![image](https://github.com/user-attachments/assets/969d4991-20b3-4c93-b264-cf0b2a3f6fae)
[PlantUML Diagram](https://www.plantuml.com/plantuml/uml/jLN1ZjD03BtFLrZb0jMcz5oLQil20S4Y189BsyFGpEv6f9DgCYrQ8VwTYQTkKcTSs0LoYiT-p_Qp9xcilNP-jobLUF46tbV-TLxumjw2hc4GJ3ZO0vZ0gwBUblhUv1yrXho0gvrpnlgZ_SbNZjm7oYjjrwPiM90ociYQf5nQJhgqIThAtXHkq_96MoGc6ZcJEZ1VLxlQ82UIxmiTZmRmGm7mfjvONw6RTtUnjF6yzaLPmdpjYxrvPCi0l6cUDphan8-JX18ZxvT2Yz9GO3Ilgxt9CIm2q9OgIFGEyVsppOr31lMJXlFMt7-jjCldDayKGrxGDkyFxQMvBImdE2uGUk4RCPYuHqJvq64npK8s8ZgjU3X4_t3ObFoySfGlBTUVQCNpyuPvVlAt9M1OEZy5irRdpbNVW--3CtLjOfwuTvWDtOsqi8q1J5YfjxjGK6b2uDE0lJWDU0RzfKWl0wq0rqG4_4th_xFVv1x_-_qDiYw6AyXcdR-1KkqxP5dmTRSxfDdWNRBUEDNrD2pojPjWbQruIWxD5hckxqo-cabxhOHpLYwxZA5o-cA91DDZykpSfazWf6HtOCdELA5FWKnl9c9QFDL-UnDoqQ16R3wbkV4pQA4fHKZ7nHDZnk5PXOewlq22l3EQOm9aFDQwWSoIVo_2KXE4vi9Bu157xBOjXaha4DLNiytKMp35R9m76tHYWXmr5PS8Qv9MeryFarl0JJC95szfeYjvl6iqpZINTGRTJfhGqUh0vRlQrZ0JnjUlHUOwltiFBErtar2T71WTlgAAUkWSgKjZyzsc_0K0)

All commits have been extensively documented. If I may, I would recommend reviewing the commits in isolation.