### PR TITLE
(POC) LateNight: allow to show 4 decks in a row

### DIFF
--- a/res/skins/LateNight/decks/decks_left.xml
+++ b/res/skins/LateNight/decks/decks_left.xml
@@ -25,5 +25,41 @@
       </WidgetGroup>
 
     </Children>
+    <Connection>
+      <ConfigKey>[Skin],show_4decks_row</ConfigKey>
+      <BindProperty>visible</BindProperty>
+      <Transform><Not/></Transform>
+    </Connection>
+  </WidgetGroup>
+
+  <WidgetGroup>
+    <ObjectName>DecksLeft</ObjectName>
+    <Layout>horizontal</Layout>
+    <SizePolicy>me,min</SizePolicy>
+    <Children>
+
+      <WidgetGroup>
+        <Layout>vertical</Layout>
+        <SizePolicy>me,min</SizePolicy>
+        <Children>
+          <SingletonContainer>
+            <ObjectName>Deck3_Src</ObjectName>
+          </SingletonContainer>
+        </Children>
+        <Connection>
+          <ConfigKey>[Skin],show_4decks</ConfigKey>
+          <BindProperty>visible</BindProperty>
+        </Connection>
+      </WidgetGroup>
+
+      <SingletonContainer>
+        <ObjectName>Deck1_Src</ObjectName>
+      </SingletonContainer>
+
+    </Children>
+    <Connection>
+      <ConfigKey>[Skin],show_4decks_row</ConfigKey>
+      <BindProperty>visible</BindProperty>
+    </Connection>
   </WidgetGroup>
 </Template>

--- a/res/skins/LateNight/decks/decks_left_mini.xml
+++ b/res/skins/LateNight/decks/decks_left_mini.xml
@@ -25,5 +25,41 @@
       </WidgetGroup>
 
     </Children>
+    <Connection>
+      <ConfigKey>[Skin],show_4decks_row</ConfigKey>
+      <BindProperty>visible</BindProperty>
+      <Transform><Not/></Transform>
+    </Connection>
+  </WidgetGroup>
+
+  <WidgetGroup>
+    <ObjectName>DecksLeft</ObjectName>
+    <Layout>horizontal</Layout>
+    <SizePolicy>me,min</SizePolicy>
+    <Children>
+
+      <WidgetGroup>
+        <Layout>vertical</Layout>
+        <SizePolicy>me,min</SizePolicy>
+        <Children>
+          <SingletonContainer>
+            <ObjectName>Deck3_Mini</ObjectName>
+          </SingletonContainer>
+        </Children>
+        <Connection>
+          <ConfigKey>[Skin],show_4decks</ConfigKey>
+          <BindProperty>visible</BindProperty>
+        </Connection>
+      </WidgetGroup>
+
+      <SingletonContainer>
+        <ObjectName>Deck1_Mini</ObjectName>
+      </SingletonContainer>
+
+    </Children>
+    <Connection>
+      <ConfigKey>[Skin],show_4decks_row</ConfigKey>
+      <BindProperty>visible</BindProperty>
+    </Connection>
   </WidgetGroup>
 </Template>

--- a/res/skins/LateNight/decks/decks_right.xml
+++ b/res/skins/LateNight/decks/decks_right.xml
@@ -1,7 +1,7 @@
 <Template>
   <SetVariable name="Type">deck</SetVariable>
   <WidgetGroup>
-    <ObjectName>DecksRight</ObjectName>
+    <ObjectName>DecksLeft</ObjectName>
     <Layout>vertical</Layout>
     <SizePolicy>me,min</SizePolicy>
     <Children>
@@ -25,5 +25,41 @@
       </WidgetGroup>
 
     </Children>
+    <Connection>
+      <ConfigKey>[Skin],show_4decks_row</ConfigKey>
+      <BindProperty>visible</BindProperty>
+      <Transform><Not/></Transform>
+    </Connection>
+  </WidgetGroup>
+
+  <WidgetGroup>
+    <ObjectName>DecksLeft</ObjectName>
+    <Layout>horizontal</Layout>
+    <SizePolicy>me,min</SizePolicy>
+    <Children>
+
+      <SingletonContainer>
+        <ObjectName>Deck2_Src</ObjectName>
+      </SingletonContainer>
+
+      <WidgetGroup>
+        <Layout>vertical</Layout>
+        <SizePolicy>me,min</SizePolicy>
+        <Children>
+          <SingletonContainer>
+            <ObjectName>Deck4_Src</ObjectName>
+          </SingletonContainer>
+        </Children>
+        <Connection>
+          <ConfigKey>[Skin],show_4decks</ConfigKey>
+          <BindProperty>visible</BindProperty>
+        </Connection>
+      </WidgetGroup>
+
+    </Children>
+    <Connection>
+      <ConfigKey>[Skin],show_4decks_row</ConfigKey>
+      <BindProperty>visible</BindProperty>
+    </Connection>
   </WidgetGroup>
 </Template>

--- a/res/skins/LateNight/decks/decks_right_mini.xml
+++ b/res/skins/LateNight/decks/decks_right_mini.xml
@@ -1,7 +1,7 @@
 <Template>
   <SetVariable name="Type">deck</SetVariable>
   <WidgetGroup>
-    <ObjectName>DecksRight</ObjectName>
+    <ObjectName>DecksLeft</ObjectName>
     <Layout>vertical</Layout>
     <SizePolicy>me,min</SizePolicy>
     <Children>
@@ -25,5 +25,41 @@
       </WidgetGroup>
 
     </Children>
-  </WidgetGroup><!-- DecksRight -->
+    <Connection>
+      <ConfigKey>[Skin],show_4decks_row</ConfigKey>
+      <BindProperty>visible</BindProperty>
+      <Transform><Not/></Transform>
+    </Connection>
+  </WidgetGroup>
+
+  <WidgetGroup>
+    <ObjectName>DecksLeft</ObjectName>
+    <Layout>horizontal</Layout>
+    <SizePolicy>me,min</SizePolicy>
+    <Children>
+
+      <SingletonContainer>
+        <ObjectName>Deck2_Mini</ObjectName>
+      </SingletonContainer>
+
+      <WidgetGroup>
+        <Layout>vertical</Layout>
+        <SizePolicy>me,min</SizePolicy>
+        <Children>
+          <SingletonContainer>
+            <ObjectName>Deck4_Mini</ObjectName>
+          </SingletonContainer>
+        </Children>
+        <Connection>
+          <ConfigKey>[Skin],show_4decks</ConfigKey>
+          <BindProperty>visible</BindProperty>
+        </Connection>
+      </WidgetGroup>
+
+    </Children>
+    <Connection>
+      <ConfigKey>[Skin],show_4decks_row</ConfigKey>
+      <BindProperty>visible</BindProperty>
+    </Connection>
+  </WidgetGroup>
 </Template>

--- a/res/skins/LateNight/decks/row_5_transportLoopJump.xml
+++ b/res/skins/LateNight/decks/row_5_transportLoopJump.xml
@@ -107,7 +107,7 @@
 
           <WidgetGroup><!-- HotCues -->
             <Layout>vertical</Layout>
-            <SizePolicy>max,min</SizePolicy>
+            <SizePolicy>max,max</SizePolicy>
             <Children>
               <WidgetGroup><!-- HotCues 1-2 / 1-4 -->
                 <Layout>horizontal</Layout>

--- a/res/skins/LateNight/mixer.xml
+++ b/res/skins/LateNight/mixer.xml
@@ -15,10 +15,22 @@
           <WidgetGroup>
             <ObjectName>MixerDecks</ObjectName>
             <SizePolicy>max,min</SizePolicy>
-            <Layout>vertical</Layout>
+            <!-- <Layout>vertical</Layout> -->
+            <Layout>horizontal</Layout>
             <Children>
               <Template src="skins:LateNight/mixer/mixer_2decks.xml"/>
-              <Template src="skins:LateNight/mixer/mixer_4decks.xml"/>
+              <WidgetGroup>
+                <SizePolicy>max,min</SizePolicy>
+                <Layout>horizontal</Layout>
+                <Children>
+                  <Template src="skins:LateNight/mixer/mixer_4decks_stacked.xml"/>
+                  <Template src="skins:LateNight/mixer/mixer_4decks_row.xml"/>
+                </Children>
+                <Connection>
+                  <ConfigKey persist="true">[Skin],show_4decks</ConfigKey>
+                  <BindProperty>visible</BindProperty>
+                </Connection>
+              </WidgetGroup>
             </Children>
             <Connection>
               <ConfigKey persist="true">[Skin],show_main_head_mixer</ConfigKey>

--- a/res/skins/LateNight/mixer/channel_4decks.xml
+++ b/res/skins/LateNight/mixer/channel_4decks.xml
@@ -9,7 +9,7 @@
   <SetVariable name="ArcThickness"><Variable name="ArcThicknessBig"/></SetVariable>
 
   <WidgetGroup>
-    <ObjectName>MixerChannel_4Decks</ObjectName>
+    <ObjectName><Variable name="ObjectName"/></ObjectName>
     <Layout>vertical</Layout>
     <SizePolicy>min,min</SizePolicy>
     <Children>
@@ -19,6 +19,8 @@
         <Layout>horizontal</Layout>
         <SizePolicy>min,max</SizePolicy>
         <Children>
+          <!-- AlignRight doesn't seem to work anymore with Qt6?? -->
+          <WidgetGroup><Size>0me,0min</Size></WidgetGroup>
           <Template src="skins:LateNight/controls/knob.xml">
             <SetVariable name="Size">40f,34f</SetVariable>
             <SetVariable name="KnobColor">orange</SetVariable>
@@ -64,11 +66,9 @@
         <MaximumSize>,18</MaximumSize>
         <Layout>vertical</Layout>
         <Children>
-          <EffectChainPresetSelector>
-            <ObjectName>QuickEffectSelectorLeft</ObjectName>
-            <Size>40min,18f</Size>
-            <EffectUnitGroup>[QuickEffectRack1_<Variable name="Group"/>]</EffectUnitGroup>
-          </EffectChainPresetSelector>
+          <SingletonContainer>
+            <ObjectName>QuickEffectSelector<Variable name="ChanNum"/>_Singleton</ObjectName>
+          </SingletonContainer>
         </Children>
         <Connection>
           <ConfigKey persist="true">[Skin],show_eq_knobs</ConfigKey>
@@ -77,17 +77,14 @@
       </WidgetGroup>
 
       <WidgetGroup>
-        <ObjectName>PflBox_4Decks</ObjectName>
+        <ObjectName>PflBox_4Decks_Stacked</ObjectName>
         <Layout>horizontal</Layout>
         <SizePolicy>min,min</SizePolicy>
         <Children>
-          <Template src="skins:LateNight/controls/button_2state.xml">
-            <SetVariable name="TooltipId">pfl</SetVariable>
-            <SetVariable name="ObjectName">PflButton</SetVariable>
-            <SetVariable name="Size">26,26</SetVariable>
-            <SetVariable name="BtnSize">square</SetVariable>
-            <SetVariable name="ConfigKey"><Variable name="Group"/>,pfl</SetVariable>
-          </Template>
+          <WidgetGroup><Size>0me,0f</Size></WidgetGroup>
+          <SingletonContainer>
+            <ObjectName>PflButton<Variable name="ChanNum"/></ObjectName>
+          </SingletonContainer>
         </Children>
       </WidgetGroup>
 
@@ -106,31 +103,19 @@
                 <ObjectName>VuMeterChannel<Variable name="ChanNum"/></ObjectName>
               </SingletonContainer>
             </Children>
-          </WidgetGroup>
+          </WidgetGroup><!-- VuMeterChannel_4Decks -->
 
-          <SliderComposed><!-- Volume -->
-            <TooltipId>channel_volume</TooltipId>
-            <Size>42f,107f</Size>
-            <Handle scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="SliderScheme"/>/sliders/knob_volume_deck.svg</Handle>
-            <Slider scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="SliderScheme"/>/sliders/slider_volume_deck.svg</Slider>
-            <Horizontal>false</Horizontal>
-            <BarColor><Variable name="BarColorVolume"/></BarColor>
-            <BarWidth><Variable name="BarWidth"/></BarWidth>
-            <BarMargins><Variable name="BarMarginVolume"/></BarMargins>
-            <BarRoundCaps>true</BarRoundCaps>
-            <BarAxisPos>21.0</BarAxisPos>
-            <Connection>
-              <ConfigKey><Variable name="Group"/>,volume</ConfigKey>
-            </Connection>
-          </SliderComposed>
+          <SingletonContainer>
+            <ObjectName>VolumeSlider<Variable name="ChanNum"/></ObjectName>
+          </SingletonContainer>
 
         </Children>
       </WidgetGroup><!-- VuAndSlider_4Decks -->
 
       <WidgetGroup>
-        <ObjectName>CrossfaderSwitch_4Decks</ObjectName>
+        <ObjectName>CrossfaderSwitch_4Decks_Stacked</ObjectName>
         <Layout>vertical</Layout>
-        <SizePolicy>min,min</SizePolicy>
+        <SizePolicy>me,min</SizePolicy>
         <Children>
           <Template src="skins:LateNight/controls/button_xfader_deck.xml"/>
         </Children>

--- a/res/skins/LateNight/mixer/channel_left.xml
+++ b/res/skins/LateNight/mixer/channel_left.xml
@@ -1,6 +1,3 @@
-<!--  This layout is only used for channel 1.  It can switch between a standard
-vertical layout and a side-by-side layout for two-deck mode -->
-
 <Template>
   <SetVariable name="Group">[Channel<Variable name="ChanNum"/>]</SetVariable>
   <SetVariable name="EqFxUnit">[EqualizerRack1_<Variable name="Group"/>]</SetVariable>
@@ -12,88 +9,117 @@ vertical layout and a side-by-side layout for two-deck mode -->
   <SetVariable name="ArcThickness"><Variable name="ArcThicknessBig"/></SetVariable>
 
   <WidgetGroup>
-    <ObjectName>MixerChannel_2Decks</ObjectName>
-    <Layout>horizontal</Layout>
+    <ObjectName><Variable name="ObjectName"/></ObjectName>
+    <Layout>vertical</Layout>
     <SizePolicy>min,min</SizePolicy>
     <Children>
 
-      <WidgetGroup><!-- EQs -->
-        <Layout>vertical</Layout>
-        <ObjectName>MixerChannel_2Decks_Left</ObjectName>
+      <!-- spacer to center channel controls without crossfader without
+          stretching them -->
+      <WidgetGroup><SizePolicy>min,e</SizePolicy></WidgetGroup>
+
+      <WidgetGroup><!-- EQs + Gain/Volume -->
+        <Layout>horizontal</Layout>
         <SizePolicy>min,min</SizePolicy>
         <Children>
 
-          <!-- In case an EQ/non-EQ effect has less than 3 knobs we need
-               center those vertically. This spacer and the one below knob 3
-               push Gain and QuickEffect etc. to the top/bottom -->
-          <WidgetGroup><Size>1min,0me</Size></WidgetGroup>
+          <WidgetGroup><!-- EQs -->
+            <Layout>vertical</Layout>
+            <SizePolicy>min,min</SizePolicy>
+            <Children>
 
-          <Template src="skins:LateNight/mixer/eq_knob_left.xml">
-            <SetVariable name="EqParameter">3</SetVariable>
-            <SetVariable name="EqRange">High</SetVariable>
-          </Template>
+              <!-- In case an EQ/non-EQ effect has less than 3 knobs we need
+                   center those vertically. This spacer and the one below knob 3
+                   push Gain and QuickEffect etc. to the top/bottom -->
+              <WidgetGroup><Size>1min,0me</Size></WidgetGroup>
 
-          <WidgetGroup><Size>1min,2f</Size></WidgetGroup>
+              <Template src="skins:LateNight/mixer/eq_knob_left.xml">
+                <SetVariable name="EqParameter">3</SetVariable>
+                <SetVariable name="EqRange">High</SetVariable>
+              </Template>
 
-          <Template src="skins:LateNight/mixer/eq_knob_left.xml">
-            <SetVariable name="EqParameter">2</SetVariable>
-            <SetVariable name="EqRange">Mid</SetVariable>
-          </Template>
+              <WidgetGroup><Size>1min,2f</Size></WidgetGroup>
 
-          <WidgetGroup><Size>1min,2f</Size></WidgetGroup>
+              <Template src="skins:LateNight/mixer/eq_knob_left.xml">
+                <SetVariable name="EqParameter">2</SetVariable>
+                <SetVariable name="EqRange">Mid</SetVariable>
+              </Template>
 
-          <Template src="skins:LateNight/mixer/eq_knob_left.xml">
-            <SetVariable name="EqParameter">1</SetVariable>
-            <SetVariable name="EqRange">Low</SetVariable>
-          </Template>
+              <WidgetGroup><Size>1min,2f</Size></WidgetGroup>
 
-          <WidgetGroup><Size>1min,2me</Size></WidgetGroup>
+              <Template src="skins:LateNight/mixer/eq_knob_left.xml">
+                <SetVariable name="EqParameter">1</SetVariable>
+                <SetVariable name="EqRange">Low</SetVariable>
+              </Template>
 
+              <WidgetGroup><Size>1min,2me</Size></WidgetGroup>
 
-          <Template src="skins:LateNight/mixer/quick_effect_knob_left.xml"/>
+              <Template src="skins:LateNight/mixer/quick_effect_knob_left.xml"/>
 
-          <WidgetGroup><Size>1min,3f</Size></WidgetGroup>
+            </Children>
+            <Connection>
+              <ConfigKey>[Skin],show_eq_knobs</ConfigKey>
+              <BindProperty>visible</BindProperty>
+            </Connection>
+          </WidgetGroup><!-- EQs -->
+
+          <WidgetGroup>
+            <ObjectName>VolumeGain2Decks</ObjectName>
+            <Layout>vertical</Layout>
+            <SizePolicy>max,min</SizePolicy>
+            <Children>
+
+              <Template src="skins:LateNight/controls/knob.xml">
+                <SetVariable name="ObjectName">GainKnob</SetVariable>
+                <SetVariable name="Size">40f,34f</SetVariable>
+                <SetVariable name="KnobColor">orange</SetVariable>
+                <SetVariable name="ArcColor"><Variable name="ArcColorGain"/></SetVariable>
+                <SetVariable name="Control">pregain</SetVariable>
+                <SetVariable name="TooltipId">pregain</SetVariable>
+              </Template>
+
+              <WidgetGroup><Size>1min,0me</Size></WidgetGroup>
+
+              <SingletonContainer>
+                <ObjectName>VolumeSlider<Variable name="ChanNum"/></ObjectName>
+              </SingletonContainer>
+
+            </Children>
+          </WidgetGroup><!-- VolumeGain2Decks -->
         </Children>
-        <Connection>
-          <ConfigKey>[Skin],show_eq_knobs</ConfigKey>
-          <BindProperty>visible</BindProperty>
-        </Connection>
-      </WidgetGroup><!-- /EQs -->
+      </WidgetGroup><!-- EQs + Gain/Volume -->
 
       <WidgetGroup>
-        <ObjectName>VolumeGain2Decks</ObjectName>
-        <Layout>vertical</Layout>
-        <SizePolicy>me,min</SizePolicy>
+        <Layout>horizontal</Layout>
+        <SizePolicy>i,min</SizePolicy>
         <Children>
-          <Template src="skins:LateNight/controls/knob.xml">
-            <SetVariable name="Size">40f,34f</SetVariable>
-            <SetVariable name="KnobColor">orange</SetVariable>
-            <SetVariable name="ArcColor"><Variable name="ArcColorGain"/></SetVariable>
-            <SetVariable name="Control">pregain</SetVariable>
-            <SetVariable name="TooltipId">pregain</SetVariable>
-          </Template>
-
-          <WidgetGroup><Size>1min,4f</Size></WidgetGroup>
-
-          <SliderComposed><!-- Volume -->
-            <TooltipId>channel_volume</TooltipId>
-            <Size>42f,107f</Size>
-            <Handle scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="SliderScheme"/>/sliders/knob_volume_deck.svg</Handle>
-            <Slider scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="SliderScheme"/>/sliders/slider_volume_deck.svg</Slider>
-            <Horizontal>false</Horizontal>
-            <BarColor><Variable name="BarColorVolume"/></BarColor>
-            <BarWidth><Variable name="BarWidth"/></BarWidth>
-            <BarMargins><Variable name="BarMarginVolume"/></BarMargins>
-            <BarRoundCaps>true</BarRoundCaps>
-            <BarAxisPos>21.0</BarAxisPos>
+          <WidgetGroup>
+            <Layout>horizontal</Layout>
+            <SizePolicy>me,min</SizePolicy>
+            <MinimumSize>40,18</MinimumSize>
+            <MaximumSize>,18</MaximumSize>
+            <Children>
+              <SingletonContainer>
+                <ObjectName>QuickEffectSelector<Variable name="ChanNum"/>_Singleton</ObjectName>
+              </SingletonContainer>
+            </Children>
             <Connection>
-              <ConfigKey><Variable name="Group"/>,volume</ConfigKey>
+              <ConfigKey persist="true">[Skin],show_eq_knobs</ConfigKey>
+              <BindProperty>visible</BindProperty>
             </Connection>
-          </SliderComposed>
-
-          <WidgetGroup><Size>1min,0me</Size></WidgetGroup>
+          </WidgetGroup>
+          <Template src="skins:LateNight/mixer/spacer_4decks_eq_vu.xml">
+            <SetVariable name="Height">18f</SetVariable>
+          </Template>
         </Children>
-      </WidgetGroup><!-- VolumeGain2Decks -->
+        <Connection>
+          <ConfigKey persist="true">[Skin],show_4decks</ConfigKey>
+          <BindProperty>visible</BindProperty>
+        </Connection>
+      </WidgetGroup>
+
+      <WidgetGroup><SizePolicy>min,e</SizePolicy></WidgetGroup>
+
     </Children>
-  </WidgetGroup><!-- MixerChannel_2Decks -->
+  </WidgetGroup>
 </Template>

--- a/res/skins/LateNight/mixer/channel_right.xml
+++ b/res/skins/LateNight/mixer/channel_right.xml
@@ -1,6 +1,3 @@
-<!--  This layout is only used for channel 2.  It can switch between a standard
-vertical layout and a reversed side-by-side layout for two-deck mode -->
-
 <Template>
   <SetVariable name="Group">[Channel<Variable name="ChanNum"/>]</SetVariable>
   <SetVariable name="EqFxUnit">[EqualizerRack1_<Variable name="Group"/>]</SetVariable>
@@ -11,89 +8,119 @@ vertical layout and a reversed side-by-side layout for two-deck mode -->
   <SetVariable name="ArcRadius"><Variable name="ArcRadiusBig"/></SetVariable>
   <SetVariable name="ArcThickness"><Variable name="ArcThicknessBig"/></SetVariable>
 
-
   <WidgetGroup>
-    <ObjectName>MixerChannel_2Decks</ObjectName>
-    <Layout>horizontal</Layout>
+    <ObjectName><Variable name="ObjectName"/></ObjectName>
+    <Layout>vertical</Layout>
     <SizePolicy>min,min</SizePolicy>
     <Children>
 
-      <WidgetGroup>
-        <ObjectName>VolumeGain2Decks</ObjectName>
-        <Layout>vertical</Layout>
-        <SizePolicy>me,min</SizePolicy>
-        <Children>
-          <Template src="skins:LateNight/controls/knob.xml">
-            <SetVariable name="Size">40f,34f</SetVariable>
-            <SetVariable name="KnobColor">orange</SetVariable>
-            <SetVariable name="ArcColor"><Variable name="ArcColorGain"/></SetVariable>
-            <SetVariable name="Control">pregain</SetVariable>
-            <SetVariable name="TooltipId">pregain</SetVariable>
-          </Template>
+      <!-- spacer to center channel controls without crossfader without
+          stretching them -->
+      <WidgetGroup><SizePolicy>min,e</SizePolicy></WidgetGroup>
 
-          <WidgetGroup><Size>1min,4f</Size></WidgetGroup>
-
-          <SliderComposed><!-- Volume -->
-            <TooltipId>channel_volume</TooltipId>
-            <Size>42f,107f</Size>
-            <Handle scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="SliderScheme"/>/sliders/knob_volume_deck.svg</Handle>
-            <Slider scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="SliderScheme"/>/sliders/slider_volume_deck.svg</Slider>
-            <Horizontal>false</Horizontal>
-            <BarColor><Variable name="BarColorVolume"/></BarColor>
-            <BarWidth><Variable name="BarWidth"/></BarWidth>
-            <BarMargins><Variable name="BarMarginVolume"/></BarMargins>
-            <BarRoundCaps>true</BarRoundCaps>
-            <BarAxisPos>21.0</BarAxisPos>
-            <Connection>
-              <ConfigKey><Variable name="Group"/>,volume</ConfigKey>
-            </Connection>
-          </SliderComposed>
-
-          <WidgetGroup><Size>1min,0me</Size></WidgetGroup>
-        </Children>
-      </WidgetGroup><!-- VolumeGain2Decks -->
-
-      <WidgetGroup>
-        <ObjectName>MixerChannel_2Decks_Right</ObjectName>
+      <WidgetGroup><!-- EQs + Gain/Volume -->
+        <Layout>horizontal</Layout>
         <SizePolicy>min,min</SizePolicy>
-        <Layout>vertical</Layout>
         <Children>
 
-          <!-- In case an EQ/non-EQ effect has less than 3 knobs we need
-               center those vertically. This spacer and the one below knob 3
-               push Gain and QuickEffect etc. to the top/bottom -->
-          <WidgetGroup><Size>1min,0me</Size></WidgetGroup>
+          <WidgetGroup>
+            <ObjectName>VolumeGain2Decks</ObjectName>
+            <Layout>vertical</Layout>
+            <SizePolicy>max,min</SizePolicy>
+            <Children>
 
-          <Template src="skins:LateNight/mixer/eq_knob_right.xml">
-            <SetVariable name="EqParameter">3</SetVariable>
-            <SetVariable name="EqRange">High</SetVariable>
+              <Template src="skins:LateNight/controls/knob.xml">
+                <SetVariable name="ObjectName">GainKnob</SetVariable>
+                <SetVariable name="Size">40f,34f</SetVariable>
+                <SetVariable name="KnobColor">orange</SetVariable>
+                <SetVariable name="ArcColor"><Variable name="ArcColorGain"/></SetVariable>
+                <SetVariable name="Control">pregain</SetVariable>
+                <SetVariable name="TooltipId">pregain</SetVariable>
+              </Template>
+
+              <WidgetGroup><Size>1min,0me</Size></WidgetGroup>
+
+              <SingletonContainer>
+                <ObjectName>VolumeSlider<Variable name="ChanNum"/></ObjectName>
+              </SingletonContainer>
+
+            </Children>
+          </WidgetGroup><!-- VolumeGain2Decks -->
+
+          <WidgetGroup><!-- EQs -->
+            <Layout>vertical</Layout>
+            <SizePolicy>min,min</SizePolicy>
+            <Children>
+
+              <!-- In case an EQ/non-EQ effect has less than 3 knobs we need
+                   center those vertically. This spacer and the one below knob 3
+                   push Gain and QuickEffect etc. to the top/bottom -->
+              <WidgetGroup><Size>1min,0me</Size></WidgetGroup>
+
+              <Template src="skins:LateNight/mixer/eq_knob_right.xml">
+                <SetVariable name="EqParameter">3</SetVariable>
+                <SetVariable name="EqRange">High</SetVariable>
+              </Template>
+
+              <WidgetGroup><Size>1min,2f</Size></WidgetGroup>
+
+              <Template src="skins:LateNight/mixer/eq_knob_right.xml">
+                <SetVariable name="EqParameter">2</SetVariable>
+                <SetVariable name="EqRange">Mid</SetVariable>
+              </Template>
+
+              <WidgetGroup><Size>1min,2f</Size></WidgetGroup>
+
+              <Template src="skins:LateNight/mixer/eq_knob_right.xml">
+                <SetVariable name="EqParameter">1</SetVariable>
+                <SetVariable name="EqRange">Low</SetVariable>
+              </Template>
+
+              <WidgetGroup><Size>1min,2me</Size></WidgetGroup>
+
+              <Template src="skins:LateNight/mixer/quick_effect_knob_right.xml"/>
+
+            </Children>
+            <Connection>
+              <ConfigKey>[Skin],show_eq_knobs</ConfigKey>
+              <BindProperty>visible</BindProperty>
+            </Connection>
+          </WidgetGroup><!-- EQs -->
+        </Children>
+      </WidgetGroup><!-- EQs + Gain/Volume -->
+
+      <WidgetGroup>
+        <Layout>horizontal</Layout>
+        <SizePolicy>i,min</SizePolicy>
+        <Children>
+          <WidgetGroup>
+            <Layout>horizontal</Layout>
+            <SizePolicy>me,min</SizePolicy>
+            <MinimumSize>40,18</MinimumSize>
+            <MaximumSize>,18</MaximumSize>
+            <Children>
+              <SingletonContainer>
+                <ObjectName>QuickEffectSelector<Variable name="ChanNum"/>_Singleton</ObjectName>
+              </SingletonContainer>
+            </Children>
+            <Connection>
+              <ConfigKey persist="true">[Skin],show_eq_knobs</ConfigKey>
+              <BindProperty>visible</BindProperty>
+            </Connection>
+          </WidgetGroup>
+
+          <Template src="skins:LateNight/mixer/spacer_4decks_eq_vu.xml">
+            <SetVariable name="Height">18f</SetVariable>
           </Template>
 
-          <WidgetGroup><Size>1min,2f</Size></WidgetGroup>
-
-          <Template src="skins:LateNight/mixer/eq_knob_right.xml">
-            <SetVariable name="EqParameter">2</SetVariable>
-            <SetVariable name="EqRange">Mid</SetVariable>
-          </Template>
-
-          <WidgetGroup><Size>1min,2f</Size></WidgetGroup>
-
-          <Template src="skins:LateNight/mixer/eq_knob_right.xml">
-            <SetVariable name="EqParameter">1</SetVariable>
-            <SetVariable name="EqRange">Low</SetVariable>
-          </Template>
-
-          <WidgetGroup><Size>1min,2me</Size></WidgetGroup>
-
-          <Template src="skins:LateNight/mixer/quick_effect_knob_right.xml"/>
-
-          <WidgetGroup><Size>0min,3f</Size></WidgetGroup>
         </Children>
         <Connection>
-          <ConfigKey>[Skin],show_eq_knobs</ConfigKey>
+          <ConfigKey persist="true">[Skin],show_4decks</ConfigKey>
           <BindProperty>visible</BindProperty>
         </Connection>
-      </WidgetGroup><!-- MixerChannel_2Decks_Right -->
+      </WidgetGroup>
+
+      <WidgetGroup><SizePolicy>min,e</SizePolicy></WidgetGroup>
 
     </Children>
   </WidgetGroup>

--- a/res/skins/LateNight/mixer/eq_knob_4decks.xml
+++ b/res/skins/LateNight/mixer/eq_knob_4decks.xml
@@ -6,128 +6,120 @@
     <Layout>horizontal</Layout>
     <SizePolicy>min,min</SizePolicy>
     <Children>
+
+      <WidgetGroup><Size>4f,0min</Size></WidgetGroup>
+
       <WidgetGroup>
-        <ObjectName>ChannelMixer_KnobContainer</ObjectName>
+        <ObjectName>AlignRight</ObjectName>
         <Layout>horizontal</Layout>
         <SizePolicy>min,min</SizePolicy>
         <Children>
-          <WidgetGroup><Size>4f,0min</Size></WidgetGroup>
 
-          <WidgetGroup>
-            <ObjectName>AlignRight</ObjectName>
-            <Layout>horizontal</Layout>
-            <SizePolicy>min,min</SizePolicy>
+          <WidgetGroup><!-- Kill button / placeholder -->
+            <ObjectName>EQKillButtonBox</ObjectName>
+            <Layout>vertical</Layout>
+            <Size>0min,34f</Size>
             <Children>
 
-              <WidgetGroup><!-- Kill button / placeholder -->
-                <ObjectName>EQKillButtonBox</ObjectName>
-                <Layout>vertical</Layout>
-                <Size>0min,34f</Size>
-                <Children>
+              <EffectPushButton>
+                <TooltipId>filter<Variable name="EqRange"/>Kill</TooltipId>
+                <ObjectName>EQKillButton_<Variable name="EqRange"/></ObjectName>
+                <Size>18f,18f</Size>
+                <NumberStates>2</NumberStates>
+                <EffectUnitGroup><Variable name="EqFxUnit"/></EffectUnitGroup>
+                <Effect>1</Effect>
+                <EffectButtonParameter><Variable name="EqParameter"/></EffectButtonParameter>
+                <State>
+                  <Number>0</Number>
+                  <Unpressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill.svg</Unpressed>
+                  <Pressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Pressed>
+                </State>
+                <State>
+                  <Number>1</Number>
+                  <Unpressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Unpressed>
+                  <Pressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Pressed>
+                </State>
+                <Connection>
+                  <ConfigKey><Variable name="EqEffect"/>,button_parameter<Variable name="EqParameter"/></ConfigKey>
+                  <ButtonState>LeftButton</ButtonState>
+                </Connection>
+                <Connection>
+                  <ConfigKey>[Skin],show_eq_kill_buttons</ConfigKey>
+                  <BindProperty>visible</BindProperty>
+                </Connection>
+              </EffectPushButton>
 
-                  <WidgetGroup><Size>0min,5f</Size></WidgetGroup>
-
-                  <EffectPushButton>
-                    <TooltipId>filter<Variable name="EqRange"/>Kill</TooltipId>
-                    <ObjectName>EQKillButton_<Variable name="EqRange"/></ObjectName>
-                    <Size>18f,18f</Size>
-                    <NumberStates>2</NumberStates>
-                    <EffectUnitGroup><Variable name="EqFxUnit"/></EffectUnitGroup>
-                    <Effect>1</Effect>
-                    <EffectButtonParameter><Variable name="EqParameter"/></EffectButtonParameter>
-                    <State>
-                      <Number>0</Number>
-                      <Unpressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill.svg</Unpressed>
-                      <Pressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Pressed>
-                    </State>
-                    <State>
-                      <Number>1</Number>
-                      <Unpressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Unpressed>
-                      <Pressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Pressed>
-                    </State>
-                    <Connection>
-                      <ConfigKey><Variable name="EqEffect"/>,button_parameter<Variable name="EqParameter"/></ConfigKey>
-                      <ButtonState>LeftButton</ButtonState>
-                    </Connection>
-                    <Connection>
-                      <ConfigKey>[Skin],show_eq_kill_buttons</ConfigKey>
-                      <BindProperty>visible</BindProperty>
-                    </Connection>
-                  </EffectPushButton>
-
-                  <!-- Placeholder when Kill buttons are hidden -->
-                  <WidgetGroup>
-                    <Size>18f,0f</Size>
-                    <Connection>
-                      <ConfigKey>[Skin],show_eq_kill_buttons</ConfigKey>
-                      <Transform><Not/></Transform>
-                      <BindProperty>visible</BindProperty>
-                    </Connection>
-                  </WidgetGroup>
-
-                </Children>
-              </WidgetGroup><!-- Kill button / placeholder -->
-
-              <WidgetGroup><!-- EQ knob + Kill status dot -->
-                <Size>40f,34f</Size>
-                <Children>
-                  <EffectParameterKnobComposed>
-                    <Pos>0,0</Pos>
-                    <Size>40f,34f</Size>
-                    <TooltipId>filter<Variable name="EqRange"/></TooltipId>
-                    <Knob>skins:LateNight/<Variable name="KnobScheme"/>/knobs/knob_indicator_regular_<Variable name="KnobColorEq"/>.svg</Knob>
-                    <BackPath>skins:LateNight/<Variable name="KnobScheme"/>/knobs/knob_bg_regular.svg</BackPath>
-                    <MinAngle><Variable name="PotiMinAngle"/></MinAngle>
-                    <MaxAngle><Variable name="PotiMaxAngle"/></MaxAngle>
-                    <ArcRadius><Variable name="ArcRadius"/></ArcRadius>
-                    <ArcThickness><Variable name="ArcThickness"/></ArcThickness>
-                    <ArcColor><Variable name="ArcColorEq"/></ArcColor>
-                    <ArcRoundCaps><Variable name="ArcRoundCaps"/></ArcRoundCaps>
-                    <KnobCenterYOffset>1.998</KnobCenterYOffset>
-                    <EffectUnitGroup><Variable name="EqFxUnit"/></EffectUnitGroup>
-                    <Effect>1</Effect>
-                    <EffectParameter><Variable name="EqParameter"/></EffectParameter>
-                    <Connection>
-                      <ConfigKey><Variable name="EqEffect"/>,parameter<Variable name="EqParameter"/></ConfigKey>
-                    </Connection>
-                  </EffectParameterKnobComposed>
-                  <PushButton>
-                    <TooltipId>filter<Variable name="EqRange"/>Kill</TooltipId>
-                    <ObjectName>EQKillDot</ObjectName>
-                    <Pos>0,27</Pos>
-                    <Size><Variable name="EqKillDotSize"/></Size>
-                    <NumberStates>2</NumberStates>
-                    <RightClickIsPushButton>false</RightClickIsPushButton>
-                    <State>
-                      <Number>0</Number>
-                    </State>
-                    <State>
-                      <Number>1</Number>
-                    </State>
-                    <Connection>
-                      <ConfigKey><Variable name="EqEffect"/>,button_parameter<Variable name="EqParameter"/></ConfigKey>
-                      <ButtonState>LeftButton</ButtonState>
-                    </Connection>
-                    <Connection>
-                      <ConfigKey>[Skin],show_eq_kill_buttons</ConfigKey>
-                      <Transform><Not/></Transform>
-                      <BindProperty>visible</BindProperty>
-                    </Connection>
-                  </PushButton>
-                </Children>
-              </WidgetGroup><!-- EQ knob + Kill status dot -->
-
-              <WidgetGroup><Size>2f,0min</Size></WidgetGroup>
+              <!-- Placeholder when Kill buttons are hidden -->
+              <WidgetGroup>
+                <Size>18f,0f</Size>
+                <Connection>
+                  <ConfigKey>[Skin],show_eq_kill_buttons</ConfigKey>
+                  <Transform><Not/></Transform>
+                  <BindProperty>visible</BindProperty>
+                </Connection>
+              </WidgetGroup>
 
             </Children>
-            <Connection>
-              <ConfigKey><Variable name="EqEffect"/>,parameter<Variable name="EqParameter"/>_loaded</ConfigKey>
-              <BindProperty>visible</BindProperty>
-            </Connection>
-          </WidgetGroup>
+          </WidgetGroup><!-- Kill button / placeholder -->
+
+          <WidgetGroup><!-- EQ knob + Kill status dot -->
+            <Size>40f,34f</Size>
+            <Children>
+              <EffectParameterKnobComposed>
+                <Pos>0,0</Pos>
+                <Size>40f,34f</Size>
+                <TooltipId>filter<Variable name="EqRange"/></TooltipId>
+                <Knob>skins:LateNight/<Variable name="KnobScheme"/>/knobs/knob_indicator_regular_<Variable name="KnobColorEq"/>.svg</Knob>
+                <BackPath>skins:LateNight/<Variable name="KnobScheme"/>/knobs/knob_bg_regular.svg</BackPath>
+                <MinAngle><Variable name="PotiMinAngle"/></MinAngle>
+                <MaxAngle><Variable name="PotiMaxAngle"/></MaxAngle>
+                <ArcRadius><Variable name="ArcRadius"/></ArcRadius>
+                <ArcThickness><Variable name="ArcThickness"/></ArcThickness>
+                <ArcColor><Variable name="ArcColorEq"/></ArcColor>
+                <ArcRoundCaps><Variable name="ArcRoundCaps"/></ArcRoundCaps>
+                <KnobCenterYOffset>1.998</KnobCenterYOffset>
+                <EffectUnitGroup><Variable name="EqFxUnit"/></EffectUnitGroup>
+                <Effect>1</Effect>
+                <EffectParameter><Variable name="EqParameter"/></EffectParameter>
+                <Connection>
+                  <ConfigKey><Variable name="EqEffect"/>,parameter<Variable name="EqParameter"/></ConfigKey>
+                </Connection>
+              </EffectParameterKnobComposed>
+              <PushButton>
+                <TooltipId>filter<Variable name="EqRange"/>Kill</TooltipId>
+                <ObjectName>EQKillDot</ObjectName>
+                <Pos>0,27</Pos>
+                <Size><Variable name="EqKillDotSize"/></Size>
+                <NumberStates>2</NumberStates>
+                <RightClickIsPushButton>false</RightClickIsPushButton>
+                <State>
+                  <Number>0</Number>
+                </State>
+                <State>
+                  <Number>1</Number>
+                </State>
+                <Connection>
+                  <ConfigKey><Variable name="EqEffect"/>,button_parameter<Variable name="EqParameter"/></ConfigKey>
+                  <ButtonState>LeftButton</ButtonState>
+                </Connection>
+                <Connection>
+                  <ConfigKey>[Skin],show_eq_kill_buttons</ConfigKey>
+                  <Transform><Not/></Transform>
+                  <BindProperty>visible</BindProperty>
+                </Connection>
+              </PushButton>
+            </Children>
+          </WidgetGroup><!-- EQ knob + Kill status dot -->
+
+          <WidgetGroup><Size>2f,0min</Size></WidgetGroup>
 
         </Children>
-      </WidgetGroup><!-- ChannelMixer_KnobContainer -->
+        <Connection>
+          <ConfigKey><Variable name="EqEffect"/>,parameter<Variable name="EqParameter"/>_loaded</ConfigKey>
+          <BindProperty>visible</BindProperty>
+        </Connection>
+      </WidgetGroup>
+
     </Children>
     <Connection>
       <ConfigKey>[Skin],show_eq_knobs</ConfigKey>

--- a/res/skins/LateNight/mixer/eq_knob_left.xml
+++ b/res/skins/LateNight/mixer/eq_knob_left.xml
@@ -7,98 +7,89 @@
     <Children>
 
       <WidgetGroup>
-        <ObjectName>ChannelMixer_KnobContainer</ObjectName>
-        <Layout>horizontal</Layout>
-        <SizePolicy>min,min</SizePolicy>
+        <ObjectName>EQKillButtonBox</ObjectName>
+        <Layout>vertical</Layout>
+        <Size>18f,34f</Size>
         <Children>
 
-          <WidgetGroup>
-            <ObjectName>EQKillButtonBox</ObjectName>
-            <Layout>vertical</Layout>
-            <Size>18f,34f</Size>
-            <Children>
-              <WidgetGroup><Size>0min,5f</Size></WidgetGroup>
-              <EffectPushButton>
-                <TooltipId>filter<Variable name="EqRange"/>Kill</TooltipId>
-                <ObjectName>EQKillButton_<Variable name="EqRange"/></ObjectName>
-                <Size>18f,18f</Size>
-                <NumberStates>2</NumberStates>
-                <EffectUnitGroup><Variable name="EqFxUnit"/></EffectUnitGroup>
-                <Effect>1</Effect>
-                <EffectButtonParameter><Variable name="EqParameter"/></EffectButtonParameter>
-                <State>
-                  <Number>0</Number>
-                  <Unpressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill.svg</Unpressed>
-                  <Pressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Pressed>
-                </State>
-                <State>
-                  <Number>1</Number>
-                  <Unpressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Unpressed>
-                  <Pressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Pressed>
-                </State>
-                <Connection>
-                  <ConfigKey><Variable name="EqEffect"/>,button_parameter<Variable name="EqParameter"/></ConfigKey>
-                  <ButtonState>LeftButton</ButtonState>
-                </Connection>
-              </EffectPushButton>
-            </Children>
+          <EffectPushButton>
+            <TooltipId>filter<Variable name="EqRange"/>Kill</TooltipId>
+            <ObjectName>EQKillButton_<Variable name="EqRange"/></ObjectName>
+            <Size>18f,18f</Size>
+            <NumberStates>2</NumberStates>
+            <EffectUnitGroup><Variable name="EqFxUnit"/></EffectUnitGroup>
+            <Effect>1</Effect>
+            <EffectButtonParameter><Variable name="EqParameter"/></EffectButtonParameter>
+            <State>
+              <Number>0</Number>
+              <Unpressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill.svg</Unpressed>
+              <Pressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Pressed>
+            </State>
+            <State>
+              <Number>1</Number>
+              <Unpressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Unpressed>
+              <Pressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Pressed>
+            </State>
+            <Connection>
+              <ConfigKey><Variable name="EqEffect"/>,button_parameter<Variable name="EqParameter"/></ConfigKey>
+              <ButtonState>LeftButton</ButtonState>
+            </Connection>
+          </EffectPushButton>
+        </Children>
+        <Connection>
+          <ConfigKey>[Skin],show_eq_kill_buttons</ConfigKey>
+          <BindProperty>visible</BindProperty>
+        </Connection>
+      </WidgetGroup><!-- EQKillButtonBox -->
+
+      <WidgetGroup><!-- EQ knob + Kill status dot -->
+        <Size>40f,34f</Size>
+        <Children>
+          <EffectParameterKnobComposed>
+            <Pos>0,0</Pos>
+            <Size>40f,34f</Size>
+            <TooltipId>filter<Variable name="EqRange"/></TooltipId>
+            <Knob>skins:LateNight/<Variable name="KnobScheme"/>/knobs/knob_indicator_regular_<Variable name="KnobColorEq"/>.svg</Knob>
+            <BackPath>skins:LateNight/<Variable name="KnobScheme"/>/knobs/knob_bg_regular.svg</BackPath>
+            <MinAngle><Variable name="PotiMinAngle"/></MinAngle>
+            <MaxAngle><Variable name="PotiMaxAngle"/></MaxAngle>
+            <ArcRadius><Variable name="ArcRadius"/></ArcRadius>
+            <ArcThickness><Variable name="ArcThickness"/></ArcThickness>
+            <ArcColor><Variable name="ArcColorEq"/></ArcColor>
+            <ArcRoundCaps><Variable name="ArcRoundCaps"/></ArcRoundCaps>
+            <KnobCenterYOffset>1.998</KnobCenterYOffset>
+            <EffectUnitGroup><Variable name="EqFxUnit"/></EffectUnitGroup>
+            <Effect>1</Effect>
+            <EffectParameter><Variable name="EqParameter"/></EffectParameter>
+            <Connection>
+              <ConfigKey><Variable name="EqEffect"/>,parameter<Variable name="EqParameter"/></ConfigKey>
+            </Connection>
+          </EffectParameterKnobComposed>
+          <PushButton>
+            <TooltipId>filter<Variable name="EqRange"/>Kill</TooltipId>
+            <ObjectName>EQKillDot</ObjectName>
+            <Pos>0,27</Pos>
+            <Size><Variable name="EqKillDotSize"/></Size>
+            <NumberStates>2</NumberStates>
+            <RightClickIsPushButton>false</RightClickIsPushButton>
+            <State>
+              <Number>0</Number>
+            </State>
+            <State>
+              <Number>1</Number>
+            </State>
+            <Connection>
+              <ConfigKey><Variable name="EqEffect"/>,button_parameter<Variable name="EqParameter"/></ConfigKey>
+              <ButtonState>LeftButton</ButtonState>
+            </Connection>
             <Connection>
               <ConfigKey>[Skin],show_eq_kill_buttons</ConfigKey>
+              <Transform><Not/></Transform>
               <BindProperty>visible</BindProperty>
             </Connection>
-          </WidgetGroup><!-- EQKillButtonBox -->
-
-          <WidgetGroup><!-- EQ knob + Kill status dot -->
-            <Size>40f,34f</Size>
-            <Children>
-              <EffectParameterKnobComposed>
-                <Pos>0,0</Pos>
-                <Size>40f,34f</Size>
-                <TooltipId>filter<Variable name="EqRange"/></TooltipId>
-                <Knob>skins:LateNight/<Variable name="KnobScheme"/>/knobs/knob_indicator_regular_<Variable name="KnobColorEq"/>.svg</Knob>
-                <BackPath>skins:LateNight/<Variable name="KnobScheme"/>/knobs/knob_bg_regular.svg</BackPath>
-                <MinAngle><Variable name="PotiMinAngle"/></MinAngle>
-                <MaxAngle><Variable name="PotiMaxAngle"/></MaxAngle>
-                <ArcRadius><Variable name="ArcRadius"/></ArcRadius>
-                <ArcThickness><Variable name="ArcThickness"/></ArcThickness>
-                <ArcColor><Variable name="ArcColorEq"/></ArcColor>
-                <ArcRoundCaps><Variable name="ArcRoundCaps"/></ArcRoundCaps>
-                <KnobCenterYOffset>1.998</KnobCenterYOffset>
-                <EffectUnitGroup><Variable name="EqFxUnit"/></EffectUnitGroup>
-                <Effect>1</Effect>
-                <EffectParameter><Variable name="EqParameter"/></EffectParameter>
-                <Connection>
-                  <ConfigKey><Variable name="EqEffect"/>,parameter<Variable name="EqParameter"/></ConfigKey>
-                </Connection>
-              </EffectParameterKnobComposed>
-              <PushButton>
-                <TooltipId>filter<Variable name="EqRange"/>Kill</TooltipId>
-                <ObjectName>EQKillDot</ObjectName>
-                <Pos>0,27</Pos>
-                <Size><Variable name="EqKillDotSize"/></Size>
-                <NumberStates>2</NumberStates>
-                <RightClickIsPushButton>false</RightClickIsPushButton>
-                <State>
-                  <Number>0</Number>
-                </State>
-                <State>
-                  <Number>1</Number>
-                </State>
-                <Connection>
-                  <ConfigKey><Variable name="EqEffect"/>,button_parameter<Variable name="EqParameter"/></ConfigKey>
-                  <ButtonState>LeftButton</ButtonState>
-                </Connection>
-                <Connection>
-                  <ConfigKey>[Skin],show_eq_kill_buttons</ConfigKey>
-                  <Transform><Not/></Transform>
-                  <BindProperty>visible</BindProperty>
-                </Connection>
-              </PushButton>
-            </Children>
-          </WidgetGroup><!-- EQ knob + Kill status dot -->
-
+          </PushButton>
         </Children>
-      </WidgetGroup><!-- ChannelMixer_KnobContainer -->
+      </WidgetGroup><!-- EQ knob + Kill status dot -->
 
     </Children>
     <Connection>

--- a/res/skins/LateNight/mixer/eq_knob_right.xml
+++ b/res/skins/LateNight/mixer/eq_knob_right.xml
@@ -3,104 +3,94 @@
 
   <WidgetGroup>
     <Layout>horizontal</Layout>
-    <Size>0min,34f</Size>
+    <SizePolicy>min,min</SizePolicy>
     <Children>
-      <WidgetGroup>
-        <ObjectName>ChannelMixer_KnobContainer</ObjectName>
-        <Layout>horizontal</Layout>
-        <SizePolicy>min,min</SizePolicy>
+
+      <WidgetGroup><!-- EQ knob + Kill status dot -->
+        <Size>40f,34f</Size>
         <Children>
-
-          <WidgetGroup><!-- EQ knob + Kill status dot -->
+          <EffectParameterKnobComposed>
+            <TooltipId>filter<Variable name="EqRange"/></TooltipId>
+            <Pos>0,0</Pos>
             <Size>40f,34f</Size>
-            <Children>
-              <EffectParameterKnobComposed>
-                <TooltipId>filter<Variable name="EqRange"/></TooltipId>
-                <Pos>0,0</Pos>
-                <Size>40f,34f</Size>
-                <Knob>skins:LateNight/<Variable name="KnobScheme"/>/knobs/knob_indicator_regular_<Variable name="KnobColorEq"/>.svg</Knob>
-                <BackPath>skins:LateNight/<Variable name="KnobScheme"/>/knobs/knob_bg_regular.svg</BackPath>
-                <MinAngle><Variable name="PotiMinAngle"/></MinAngle>
-                <MaxAngle><Variable name="PotiMaxAngle"/></MaxAngle>
-                <ArcRadius><Variable name="ArcRadius"/></ArcRadius>
-                <ArcThickness><Variable name="ArcThickness"/></ArcThickness>
-                <ArcColor><Variable name="ArcColorEq"/></ArcColor>
-                <ArcRoundCaps><Variable name="ArcRoundCaps"/></ArcRoundCaps>
-                <KnobCenterYOffset>1.998</KnobCenterYOffset>
-                <EffectUnitGroup><Variable name="EqFxUnit"/></EffectUnitGroup>
-                <Effect>1</Effect>
-                <EffectParameter><Variable name="EqParameter"/></EffectParameter>
-                <Connection>
-                  <ConfigKey><Variable name="EqEffect"/>,parameter<Variable name="EqParameter"/></ConfigKey>
-                </Connection>
-              </EffectParameterKnobComposed>
-              <PushButton>
-                <TooltipId>filter<Variable name="EqRange"/>Kill</TooltipId>
-                <ObjectName>EQKillDot</ObjectName>
-                <Pos>31,27</Pos>
-                <Size><Variable name="EqKillDotSize"/></Size>
-                <NumberStates>2</NumberStates>
-                <RightClickIsPushButton>false</RightClickIsPushButton>
-                <State>
-                  <Number>0</Number>
-                </State>
-                <State>
-                  <Number>1</Number>
-                </State>
-                <Connection>
-                  <ConfigKey><Variable name="EqEffect"/>,button_parameter<Variable name="EqParameter"/></ConfigKey>
-                  <ButtonState>LeftButton</ButtonState>
-                </Connection>
-                <Connection>
-                  <ConfigKey>[Skin],show_eq_kill_buttons</ConfigKey>
-                  <Transform><Not/></Transform>
-                  <BindProperty>visible</BindProperty>
-                </Connection>
-              </PushButton>
-            </Children>
-          </WidgetGroup><!-- EQ knob + Kill status dot -->
-
-          <WidgetGroup>
-            <ObjectName>EQKillButtonBox</ObjectName>
-            <Layout>vertical</Layout>
-            <Size>18f,34f</Size>
-            <Children>
-
-              <WidgetGroup><Size>0min,5f</Size></WidgetGroup>
-
-              <EffectPushButton>
-                <TooltipId>filter<Variable name="EqRange"/>Kill</TooltipId>
-                <ObjectName>EQKillButton_<Variable name="EqRange"/></ObjectName>
-                <Size>18f,18f</Size>
-                <NumberStates>2</NumberStates>
-                <EffectUnitGroup><Variable name="EqFxUnit"/></EffectUnitGroup>
-                <Effect>1</Effect>
-                <EffectButtonParameter><Variable name="EqParameter"/></EffectButtonParameter>
-                <State>
-                  <Number>0</Number>
-                  <Unpressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill.svg</Unpressed>
-                  <Pressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Pressed>
-                </State>
-                <State>
-                  <Number>1</Number>
-                  <Unpressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Unpressed>
-                  <Pressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Pressed>
-                </State>
-                <Connection>
-                  <ConfigKey><Variable name="EqEffect"/>,button_parameter<Variable name="EqParameter"/></ConfigKey>
-                  <ButtonState>LeftButton</ButtonState>
-                </Connection>
-              </EffectPushButton>
-
-            </Children>
+            <Knob>skins:LateNight/<Variable name="KnobScheme"/>/knobs/knob_indicator_regular_<Variable name="KnobColorEq"/>.svg</Knob>
+            <BackPath>skins:LateNight/<Variable name="KnobScheme"/>/knobs/knob_bg_regular.svg</BackPath>
+            <MinAngle><Variable name="PotiMinAngle"/></MinAngle>
+            <MaxAngle><Variable name="PotiMaxAngle"/></MaxAngle>
+            <ArcRadius><Variable name="ArcRadius"/></ArcRadius>
+            <ArcThickness><Variable name="ArcThickness"/></ArcThickness>
+            <ArcColor><Variable name="ArcColorEq"/></ArcColor>
+            <ArcRoundCaps><Variable name="ArcRoundCaps"/></ArcRoundCaps>
+            <KnobCenterYOffset>1.998</KnobCenterYOffset>
+            <EffectUnitGroup><Variable name="EqFxUnit"/></EffectUnitGroup>
+            <Effect>1</Effect>
+            <EffectParameter><Variable name="EqParameter"/></EffectParameter>
+            <Connection>
+              <ConfigKey><Variable name="EqEffect"/>,parameter<Variable name="EqParameter"/></ConfigKey>
+            </Connection>
+          </EffectParameterKnobComposed>
+          <PushButton>
+            <TooltipId>filter<Variable name="EqRange"/>Kill</TooltipId>
+            <ObjectName>EQKillDot</ObjectName>
+            <Pos>31,27</Pos>
+            <Size><Variable name="EqKillDotSize"/></Size>
+            <NumberStates>2</NumberStates>
+            <RightClickIsPushButton>false</RightClickIsPushButton>
+            <State>
+              <Number>0</Number>
+            </State>
+            <State>
+              <Number>1</Number>
+            </State>
+            <Connection>
+              <ConfigKey><Variable name="EqEffect"/>,button_parameter<Variable name="EqParameter"/></ConfigKey>
+              <ButtonState>LeftButton</ButtonState>
+            </Connection>
             <Connection>
               <ConfigKey>[Skin],show_eq_kill_buttons</ConfigKey>
+              <Transform><Not/></Transform>
               <BindProperty>visible</BindProperty>
             </Connection>
-          </WidgetGroup><!-- EQKillButtonBox -->
+          </PushButton>
+        </Children>
+      </WidgetGroup><!-- EQ knob + Kill status dot -->
+
+      <WidgetGroup>
+        <ObjectName>EQKillButtonBox</ObjectName>
+        <Layout>vertical</Layout>
+        <Size>18f,34f</Size>
+        <Children>
+
+          <EffectPushButton>
+            <TooltipId>filter<Variable name="EqRange"/>Kill</TooltipId>
+            <ObjectName>EQKillButton_<Variable name="EqRange"/></ObjectName>
+            <Size>18f,18f</Size>
+            <NumberStates>2</NumberStates>
+            <EffectUnitGroup><Variable name="EqFxUnit"/></EffectUnitGroup>
+            <Effect>1</Effect>
+            <EffectButtonParameter><Variable name="EqParameter"/></EffectButtonParameter>
+            <State>
+              <Number>0</Number>
+              <Unpressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill.svg</Unpressed>
+              <Pressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Pressed>
+            </State>
+            <State>
+              <Number>1</Number>
+              <Unpressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Unpressed>
+              <Pressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_eqkill_active.svg</Pressed>
+            </State>
+            <Connection>
+              <ConfigKey><Variable name="EqEffect"/>,button_parameter<Variable name="EqParameter"/></ConfigKey>
+              <ButtonState>LeftButton</ButtonState>
+            </Connection>
+          </EffectPushButton>
 
         </Children>
-      </WidgetGroup><!-- ChannelMixer_KnobContainer -->
+        <Connection>
+          <ConfigKey>[Skin],show_eq_kill_buttons</ConfigKey>
+          <BindProperty>visible</BindProperty>
+        </Connection>
+      </WidgetGroup><!-- EQKillButtonBox -->
 
     </Children>
     <Connection>

--- a/res/skins/LateNight/mixer/mixer_2decks.xml
+++ b/res/skins/LateNight/mixer/mixer_2decks.xml
@@ -1,5 +1,6 @@
 <Template>
   <WidgetGroup>
+    <ObjectName>Mixer_2Decks</ObjectName>
     <Layout>vertical</Layout>
     <SizePolicy>max,min</SizePolicy>
     <Children>
@@ -10,11 +11,12 @@
 
       <WidgetGroup><!-- Channel controls -->
         <ObjectName>AlignHCenter</ObjectName>
-        <SizePolicy>min,min</SizePolicy>
+        <SizePolicy>min,max</SizePolicy>
         <Layout>horizontal</Layout>
         <Children>
 
           <Template src="skins:LateNight/mixer/channel_left.xml">
+            <SetVariable name="ObjectName">Mixer_2Decks_Ch1</SetVariable>
             <SetVariable name="ChanNum">1</SetVariable>
             <SetVariable name="xfaderLeft">default</SetVariable>
             <SetVariable name="xfaderRight">warning</SetVariable>
@@ -22,33 +24,23 @@
 
           <WidgetGroup><!-- Pfl + VU -->
             <Layout>vertical</Layout>
-            <SizePolicy>max,max</SizePolicy>
+            <SizePolicy>max,min</SizePolicy>
             <Children>
 
               <WidgetGroup>
-                <ObjectName></ObjectName>
+                <ObjectName>PflBox_2Decks</ObjectName>
                 <Layout>horizontal</Layout>
-                <Size>0min,26f</Size>
+                <SizePolicy>min,min</SizePolicy>
                 <Children>
-                  <Template src="skins:LateNight/controls/button_2state.xml">
-                    <SetVariable name="TooltipId">pfl</SetVariable>
-                    <SetVariable name="ObjectName">PflButton</SetVariable>
-                    <SetVariable name="Size">26f,26f</SetVariable>
-                    <SetVariable name="BtnSize">square</SetVariable>
-                    <SetVariable name="ConfigKey">[Channel1],pfl</SetVariable>
-                  </Template>
+                  <SingletonContainer>
+                    <ObjectName>PflButton1</ObjectName>
+                  </SingletonContainer>
                   <WidgetGroup><Size>3f,0min</Size></WidgetGroup>
-                  <Template src="skins:LateNight/controls/button_2state.xml">
-                    <SetVariable name="TooltipId">pfl</SetVariable>
-                    <SetVariable name="ObjectName">PflButton</SetVariable>
-                    <SetVariable name="Size">26f,26f</SetVariable>
-                    <SetVariable name="BtnSize">square</SetVariable>
-                    <SetVariable name="ConfigKey">[Channel2],pfl</SetVariable>
-                  </Template>
+                  <SingletonContainer>
+                    <ObjectName>PflButton2</ObjectName>
+                  </SingletonContainer>
                 </Children>
               </WidgetGroup>
-
-              <WidgetGroup><Size>1min,13f</Size></WidgetGroup>
 
               <WidgetGroup>
                 <ObjectName>VuMeterBoxFull</ObjectName>
@@ -68,10 +60,12 @@
                   </SingletonContainer>
                 </Children>
               </WidgetGroup>
+
             </Children>
           </WidgetGroup><!-- Pfl + VU -->
 
           <Template src="skins:LateNight/mixer/channel_right.xml">
+            <SetVariable name="ObjectName">Mixer_2Decks_Ch2</SetVariable>
             <SetVariable name="ChanNum">2</SetVariable>
             <SetVariable name="xfaderLeft">warning</SetVariable>
             <SetVariable name="xfaderRight">default</SetVariable>
@@ -81,7 +75,7 @@
       </WidgetGroup><!-- /Channel controls -->
 
       <WidgetGroup><!-- Crossfader + Channel1/2 assign switches -->
-        <ObjectName>CrossfaderAndSwitches2Decks</ObjectName>
+        <!-- <ObjectName>CrossfaderAndSwitches2Decks</ObjectName> -->
         <Layout>horizontal</Layout>
         <Children>
 
@@ -97,11 +91,9 @@
                 <MaximumSize>,18</MaximumSize>
                 <Layout>vertical</Layout>
                 <Children>
-                  <EffectChainPresetSelector>
-                    <ObjectName>QuickEffectSelectorLeft</ObjectName>
-                    <Size>40me,18f</Size>
-                    <EffectUnitGroup>[QuickEffectRack1_[Channel1]]</EffectUnitGroup>
-                  </EffectChainPresetSelector>
+                  <SingletonContainer>
+                    <ObjectName>QuickEffectSelector1_Singleton</ObjectName>
+                  </SingletonContainer>
                 </Children>
                 <Connection>
                   <ConfigKey persist="true">[Skin],show_eq_knobs</ConfigKey>
@@ -112,66 +104,26 @@
               <!-- xfader switch -->
               <WidgetGroup>
                 <Layout>horizontal</Layout>
-                <SizePolicy>min,min</SizePolicy>
+                <SizePolicy>min,me</SizePolicy>
                 <Children>
-                  <!-- center xfader buttons below EQ knobs -->
-                  <WidgetGroup>
-                    <Layout>horizontal</Layout>
-                    <SizePolicy>min,min</SizePolicy>
-                    <Children>
-                      <WidgetGroup><Size>2f,0min</Size></WidgetGroup>
-                      <WidgetGroup>
-                        <Size>18f,0min</Size>
-                        <Connection>
-                          <ConfigKey persist="true">[Skin],show_eq_kill_buttons</ConfigKey>
-                          <BindProperty>visible</BindProperty>
-                        </Connection>
-                      </WidgetGroup>
-                    </Children>
-                    <Connection>
-                      <ConfigKey persist="true">[Skin],show_eq_knobs</ConfigKey>
-                      <BindProperty>visible</BindProperty>
-                    </Connection>
-                  </WidgetGroup><!-- spacer -->
-
-                  <WidgetGroup>
-                    <Layout>vertical</Layout>
-                    <SizePolicy>min,min</SizePolicy>
-                    <Children>
-                      <WidgetGroup><Size>min,2f</Size></WidgetGroup>
-                      <Template src="skins:LateNight/controls/button_xfader_deck.xml">
-                        <SetVariable name="Group">[Channel1]</SetVariable>
-                        <SetVariable name="xfaderLeft">default</SetVariable>
-                        <SetVariable name="xfaderRight">warning</SetVariable>
-                      </Template>
-                    </Children>
-                    <Connection>
-                      <ConfigKey persist="true">[Skin],show_xfader</ConfigKey>
-                      <BindProperty>visible</BindProperty>
-                    </Connection>
-                  </WidgetGroup>
-
-                  <WidgetGroup><Size>0me,0min</Size></WidgetGroup>
+                  <Template src="skins:LateNight/controls/button_xfader_deck.xml">
+                    <SetVariable name="Group">[Channel1]</SetVariable>
+                    <SetVariable name="xfaderLeft">default</SetVariable>
+                    <SetVariable name="xfaderRight">warning</SetVariable>
+                  </Template>
                 </Children>
               </WidgetGroup><!-- xfader switch -->
 
             </Children>
           </WidgetGroup><!-- Channel 1 Quick effect selector + xFader switch -->
 
-          <!--  Regular crossfader for
-                * 2 decks with EQ knobs visible
-                * 4 decks
-                Narrow crossfader for
-                * 2 decks with EQ knobs hidden -->
-          <WidgetGroup>
-            <ObjectName>CrossfaderContainer</ObjectName>
+          <WidgetGroup><!-- CrossfaderContainer -->
             <Layout>horizontal</Layout>
             <SizePolicy>max,min</SizePolicy>
             <Children>
 
-              <WidgetGroup><!-- with EQ knobs -->
+              <WidgetGroup>
                 <Layout>horizontal</Layout>
-                <SizePolicy>max,min</SizePolicy>
                 <Children>
                   <SingletonContainer>
                     <ObjectName>CrossfaderSingleton</ObjectName>
@@ -183,35 +135,21 @@
                 </Connection>
               </WidgetGroup>
 
-
-              <SliderComposed><!-- without EQ knobs -->
-                <TooltipId>crossfader</TooltipId>
-                <Size>85f,40f</Size>
-                <Handle scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="SliderScheme"/>/sliders/knob_crossfader.svg</Handle>
-                <Slider scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="SliderScheme"/>/sliders/slider_crossfader_small.svg</Slider>
-                <Horizontal>true</Horizontal>
-                <BarColor><Variable name="BarColorCrossfader"/></BarColor>
-                <BarWidth><Variable name="BarWidth"/></BarWidth>
-                <BarMargins><Variable name="BarMarginCrossfader"/></BarMargins>
-                <BarMargins><Variable name="BarMarginVolume"/></BarMargins>
-                <BarRoundCaps>true</BarRoundCaps>
-                <BarAxisPos>19.0</BarAxisPos>
-                <BarUnipolar>false</BarUnipolar>
-                <Connection>
-                  <ConfigKey>[Master],crossfader</ConfigKey>
-                </Connection>
+              <WidgetGroup>
+                <Layout>horizontal</Layout>
+                <Children>
+                  <SingletonContainer>
+                    <ObjectName>CrossfaderNarrowSingleton</ObjectName>
+                  </SingletonContainer>
+                </Children>
                 <Connection>
                   <ConfigKey persist="true">[Skin],show_eq_knobs</ConfigKey>
-                  <BindProperty>visible</BindProperty>
                   <Transform><Not/></Transform>
+                  <BindProperty>visible</BindProperty>
                 </Connection>
-              </SliderComposed>
+              </WidgetGroup>
 
             </Children>
-            <Connection>
-              <ConfigKey persist="true">[Skin],show_xfader</ConfigKey>
-              <BindProperty>visible</BindProperty>
-            </Connection>
           </WidgetGroup><!-- CrossfaderContainer -->
 
           <!-- Channel 2 Quick effect selector + xFader switch -->
@@ -227,11 +165,9 @@
                 <MaximumSize>,18</MaximumSize>
                 <Layout>vertical</Layout>
                 <Children>
-                  <EffectChainPresetSelector>
-                    <ObjectName>QuickEffectSelectorRight</ObjectName>
-                    <Size>40me,18f</Size>
-                    <EffectUnitGroup>[QuickEffectRack1_[Channel2]]</EffectUnitGroup>
-                  </EffectChainPresetSelector>
+                  <SingletonContainer>
+                    <ObjectName>QuickEffectSelector2_Singleton</ObjectName>
+                  </SingletonContainer>
                 </Children>
                 <Connection>
                   <ConfigKey persist="true">[Skin],show_eq_knobs</ConfigKey>
@@ -244,44 +180,11 @@
                 <Layout>horizontal</Layout>
                 <SizePolicy>min,me</SizePolicy>
                 <Children>
-                  <WidgetGroup><Size>0me,0min</Size></WidgetGroup>
-
-                  <WidgetGroup>
-                    <Layout>vertical</Layout>
-                    <SizePolicy>min,min</SizePolicy>
-                    <Children>
-                      <WidgetGroup><Size>min,2f</Size></WidgetGroup>
-                      <Template src="skins:LateNight/controls/button_xfader_deck.xml">
-                        <SetVariable name="Group">[Channel2]</SetVariable>
-                        <SetVariable name="xfaderLeft">warning</SetVariable>
-                        <SetVariable name="xfaderRight">default</SetVariable>
-                      </Template>
-                    </Children>
-                    <Connection>
-                      <ConfigKey persist="true">[Skin],show_xfader</ConfigKey>
-                      <BindProperty>visible</BindProperty>
-                    </Connection>
-                  </WidgetGroup>
-
-                  <!-- center xfader buttons below EQ knobs -->
-                  <WidgetGroup>
-                    <Layout>horizontal</Layout>
-                    <SizePolicy>min,min</SizePolicy>
-                    <Children>
-                      <WidgetGroup><Size>2f,0min</Size></WidgetGroup>
-                      <WidgetGroup>
-                        <Size>18f,0min</Size>
-                        <Connection>
-                          <ConfigKey persist="true">[Skin],show_eq_kill_buttons</ConfigKey>
-                          <BindProperty>visible</BindProperty>
-                        </Connection>
-                      </WidgetGroup>
-                    </Children>
-                    <Connection>
-                      <ConfigKey persist="true">[Skin],show_eq_knobs</ConfigKey>
-                      <BindProperty>visible</BindProperty>
-                    </Connection>
-                  </WidgetGroup><!-- spacer -->
+                  <Template src="skins:LateNight/controls/button_xfader_deck.xml">
+                    <SetVariable name="Group">[Channel2]</SetVariable>
+                    <SetVariable name="xfaderLeft">warning</SetVariable>
+                    <SetVariable name="xfaderRight">default</SetVariable>
+                  </Template>
                 </Children>
               </WidgetGroup><!-- xfader switch -->
 
@@ -289,6 +192,10 @@
           </WidgetGroup><!-- Channel 2 Quick effect selector + xFader switch -->
 
         </Children>
+        <Connection>
+          <ConfigKey persist="true">[Skin],show_xfader</ConfigKey>
+          <BindProperty>visible</BindProperty>
+        </Connection>
       </WidgetGroup><!-- /Crossfader + Channel1/2 assign switches -->
 
       <!-- spacer to center channel controls without crossfader without

--- a/res/skins/LateNight/mixer/mixer_4decks_row.xml
+++ b/res/skins/LateNight/mixer/mixer_4decks_row.xml
@@ -1,0 +1,316 @@
+<Template>
+  <WidgetGroup>
+    <ObjectName>Mixer_4Decks_Row</ObjectName>
+    <Layout>vertical</Layout>
+    <SizePolicy>max,min</SizePolicy>
+    <Children>
+
+      <WidgetGroup><!-- Channel controls + Main VU -->
+        <ObjectName>AlignHCenter</ObjectName>
+        <SizePolicy>min,min</SizePolicy>
+        <Layout>horizontal</Layout>
+        <Children>
+
+          <Template src="skins:LateNight/mixer/channel_left.xml">
+            <SetVariable name="ObjectName">Mixer_4Decks_Row_Ch3</SetVariable>
+            <SetVariable name="ChanNum">3</SetVariable>
+            <SetVariable name="xfaderLeft">default</SetVariable>
+            <SetVariable name="xfaderRight">warning</SetVariable>
+          </Template><!-- Channel3 -->
+
+          <WidgetGroup><!-- Pfl + VU 3 -->
+            <Layout>vertical</Layout>
+            <SizePolicy>max,min</SizePolicy>
+            <Children>
+              <!-- spacer to center channel controls without crossfader
+                  without stretching the mixer -->
+              <WidgetGroup><SizePolicy>min,e</SizePolicy></WidgetGroup>
+
+              <WidgetGroup>
+                <ObjectName>PflBox_4Decks_Row</ObjectName>
+                <Layout>horizontal</Layout>
+                <SizePolicy>min,min</SizePolicy>
+                <Children>
+                  <SingletonContainer>
+                    <ObjectName>PflButton3</ObjectName>
+                  </SingletonContainer>
+                </Children>
+              </WidgetGroup><!-- PflBox_4Decks_Row -->
+
+              <WidgetGroup>
+                <ObjectName>VuMeterBoxFull</ObjectName>
+                <Layout>horizontal</Layout>
+                <SizePolicy>min,min</SizePolicy>
+                <Children>
+                  <WidgetGroup><Size>7f,0min</Size></WidgetGroup>
+                  <SingletonContainer>
+                    <ObjectName>VuMeterChannel3</ObjectName>
+                  </SingletonContainer>
+                  <WidgetGroup><Size>7f,0min</Size></WidgetGroup>
+                </Children>
+              </WidgetGroup><!-- VuMeterBoxFull -->
+
+              <Template src="skins:LateNight/mixer/spacer_4decks_eq_vu.xml">
+                <SetVariable name="Height">18f</SetVariable>
+              </Template>
+
+              <WidgetGroup><SizePolicy>min,e</SizePolicy></WidgetGroup>
+            </Children>
+          </WidgetGroup><!-- Pfl + VU 3 -->
+
+          <WidgetGroup>
+            <ObjectName>Mixer4Decks_ChannelSeparator</ObjectName>
+            <Layout>horizontal</Layout>
+            <SizePolicy>min,me</SizePolicy>
+            <Children/>
+            <!-- this is sized and styled in css -->
+          </WidgetGroup><!-- Mixer4Decks_ChannelSeparator -->
+
+          <Template src="skins:LateNight/mixer/channel_left.xml">
+            <SetVariable name="ObjectName">Mixer_4Decks_Row_Ch1</SetVariable>
+            <SetVariable name="ChanNum">1</SetVariable>
+            <SetVariable name="xfaderLeft">default</SetVariable>
+            <SetVariable name="xfaderRight">warning</SetVariable>
+          </Template><!-- Channel1 -->
+
+          <WidgetGroup><!-- Pfl + VU 1/2 + Main -->
+            <Layout>vertical</Layout>
+            <SizePolicy>max,min</SizePolicy>
+            <Children>
+              <WidgetGroup><SizePolicy>min,e</SizePolicy></WidgetGroup>
+
+              <WidgetGroup>
+                <ObjectName>PflBox_4Decks_Row</ObjectName>
+                <Layout>horizontal</Layout>
+                <SizePolicy>min,min</SizePolicy>
+                <Children>
+                  <SingletonContainer>
+                    <ObjectName>PflButton1</ObjectName>
+                  </SingletonContainer>
+                  <WidgetGroup><Size>3f,0min</Size></WidgetGroup>
+                  <SingletonContainer>
+                    <ObjectName>PflButton2</ObjectName>
+                  </SingletonContainer>
+                </Children>
+              </WidgetGroup><!-- PflBox_4Decks_Row -->
+
+              <WidgetGroup>
+                <ObjectName>VuMeterBoxFull</ObjectName>
+                <Layout>horizontal</Layout>
+                <SizePolicy>min,min</SizePolicy>
+                <Children>
+                  <SingletonContainer>
+                    <ObjectName>VuMeterChannel1</ObjectName>
+                  </SingletonContainer>
+                  <WidgetGroup><Size>7f,0min</Size></WidgetGroup>
+                  <SingletonContainer>
+                    <ObjectName>VuMeterMain_Dark</ObjectName>
+                  </SingletonContainer>
+                  <WidgetGroup><Size>7f,0min</Size></WidgetGroup>
+                  <SingletonContainer>
+                    <ObjectName>VuMeterChannel2</ObjectName>
+                  </SingletonContainer>
+                </Children>
+              </WidgetGroup><!-- VuMeterBoxFull -->
+
+              <Template src="skins:LateNight/mixer/spacer_4decks_eq_vu.xml">
+                <SetVariable name="Height">18f</SetVariable>
+              </Template>
+
+              <WidgetGroup><SizePolicy>min,e</SizePolicy></WidgetGroup>
+            </Children>
+          </WidgetGroup><!-- Pfl + VU 1/2 + Main -->
+
+          <Template src="skins:LateNight/mixer/channel_right.xml">
+            <SetVariable name="ObjectName">Mixer_4Decks_Row_Ch2</SetVariable>
+            <SetVariable name="ChanNum">2</SetVariable>
+            <SetVariable name="xfaderLeft">warning</SetVariable>
+            <SetVariable name="xfaderRight">default</SetVariable>
+          </Template><!-- Channel2 -->
+
+          <WidgetGroup>
+            <ObjectName>Mixer4Decks_ChannelSeparator</ObjectName>
+            <Layout>horizontal</Layout>
+            <SizePolicy>min,me</SizePolicy>
+            <Children/>
+            <!-- this is sized and styled in css -->
+          </WidgetGroup><!-- Mixer4Decks_ChannelSeparator -->
+
+          <WidgetGroup><!-- Pfl + VU 4 -->
+            <Layout>vertical</Layout>
+            <SizePolicy>max,min</SizePolicy>
+            <Children>
+              <WidgetGroup><SizePolicy>min,e</SizePolicy></WidgetGroup>
+
+              <WidgetGroup>
+                <ObjectName>PflBox_4Decks_Row</ObjectName>
+                <Layout>horizontal</Layout>
+                <SizePolicy>min,min</SizePolicy>
+                <Children>
+                  <SingletonContainer>
+                    <ObjectName>PflButton4</ObjectName>
+                  </SingletonContainer>
+                </Children>
+              </WidgetGroup><!-- PflBox_4Decks_Row -->
+
+              <WidgetGroup>
+                <ObjectName>VuMeterBoxFull</ObjectName>
+                <Layout>horizontal</Layout>
+                <SizePolicy>min,min</SizePolicy>
+                <Children>
+                  <WidgetGroup><Size>7f,0min</Size></WidgetGroup>
+                  <SingletonContainer>
+                    <ObjectName>VuMeterChannel4</ObjectName>
+                  </SingletonContainer>
+                  <WidgetGroup><Size>7f,0min</Size></WidgetGroup>
+                </Children>
+              </WidgetGroup><!-- VuMeterBoxFull -->
+
+              <Template src="skins:LateNight/mixer/spacer_4decks_eq_vu.xml">
+                <SetVariable name="Height">18f</SetVariable>
+              </Template>
+
+              <WidgetGroup><SizePolicy>min,e</SizePolicy></WidgetGroup>
+            </Children>
+          </WidgetGroup><!-- Pfl + VU 4 -->
+
+          <Template src="skins:LateNight/mixer/channel_right.xml">
+            <SetVariable name="ObjectName">Mixer_4Decks_Row_Ch4</SetVariable>
+            <SetVariable name="ChanNum">4</SetVariable>
+            <SetVariable name="xfaderLeft">warning</SetVariable>
+            <SetVariable name="xfaderRight">default</SetVariable>
+          </Template><!-- Channel4 -->
+
+        </Children>
+      </WidgetGroup><!-- Channel controls + Main VU -->
+
+      <WidgetGroup>
+        <ObjectName>Mixer4Decks_SeparatorH</ObjectName>
+        <Layout>horizontal</Layout>
+        <SizePolicy>min,me</SizePolicy>
+        <Children/>
+        <!-- this is sized and styled in css -->
+        <Connection>
+          <ConfigKey persist="true">[Skin],show_xfader</ConfigKey>
+          <BindProperty>visible</BindProperty>
+        </Connection>
+      </WidgetGroup><!-- Mixer4Decks_SeparatorH -->
+
+      <!-- TODO align xfader switches somehow with channels above -->
+      <WidgetGroup><!-- Crossfader + Channel3/1/2/4 assign switches -->
+        <ObjectName>CrossfaderAndSwitches4Decks</ObjectName>
+        <Layout>horizontal</Layout>
+        <SizePolicy>min,min</SizePolicy>
+        <Children>
+
+          <WidgetGroup><Size>0me,0min</Size></WidgetGroup>
+
+          <WidgetGroup><!-- Channel 3 xFader switch -->
+            <Layout>horizontal</Layout>
+            <SizePolicy>max,min</SizePolicy>
+            <Children>
+              <Template src="skins:LateNight/controls/button_xfader_deck.xml">
+                <SetVariable name="Group">[Channel3]</SetVariable>
+                <SetVariable name="xfaderLeft">default</SetVariable>
+                <SetVariable name="xfaderRight">warning</SetVariable>
+              </Template>
+            </Children>
+          </WidgetGroup><!-- Channel 3 xFader switch -->
+
+          <WidgetGroup><Size>0me,0min</Size></WidgetGroup>
+          <WidgetGroup><Size>0me,0min</Size></WidgetGroup>
+
+          <WidgetGroup><!-- Channel 1 xFader switch -->
+            <Layout>horizontal</Layout>
+            <SizePolicy>max,min</SizePolicy>
+            <Children>
+              <Template src="skins:LateNight/controls/button_xfader_deck.xml">
+                <SetVariable name="Group">[Channel1]</SetVariable>
+                <SetVariable name="xfaderLeft">default</SetVariable>
+                <SetVariable name="xfaderRight">warning</SetVariable>
+              </Template>
+            </Children>
+          </WidgetGroup><!-- Channel 1 xFader switch -->
+
+          <WidgetGroup><Size>5f,0min</Size></WidgetGroup>
+
+          <WidgetGroup><!-- CrossfaderContainer -->
+            <Layout>horizontal</Layout>
+            <SizePolicy>max,min</SizePolicy>
+            <Children>
+
+              <WidgetGroup>
+                <Layout>horizontal</Layout>
+                <Children>
+                  <SingletonContainer>
+                    <ObjectName>CrossfaderSingleton</ObjectName>
+                  </SingletonContainer>
+                </Children>
+                <Connection>
+                  <ConfigKey persist="true">[Skin],show_eq_knobs</ConfigKey>
+                  <BindProperty>visible</BindProperty>
+                </Connection>
+              </WidgetGroup>
+
+              <WidgetGroup>
+                <Layout>horizontal</Layout>
+                <Children>
+                  <SingletonContainer>
+                    <ObjectName>CrossfaderNarrowSingleton</ObjectName>
+                  </SingletonContainer>
+                </Children>
+                <Connection>
+                  <ConfigKey persist="true">[Skin],show_eq_knobs</ConfigKey>
+                  <Transform><Not/></Transform>
+                  <BindProperty>visible</BindProperty>
+                </Connection>
+              </WidgetGroup>
+
+            </Children>
+          </WidgetGroup><!-- CrossfaderContainer -->
+
+          <WidgetGroup><Size>5f,0min</Size></WidgetGroup>
+
+          <WidgetGroup><!-- Channel 2 xFader switch -->
+            <Layout>horizontal</Layout>
+            <SizePolicy>max,me</SizePolicy>
+            <Children>
+              <Template src="skins:LateNight/controls/button_xfader_deck.xml">
+                <SetVariable name="Group">[Channel2]</SetVariable>
+                <SetVariable name="xfaderLeft">warning</SetVariable>
+                <SetVariable name="xfaderRight">default</SetVariable>
+              </Template>
+            </Children>
+          </WidgetGroup><!-- Channel 2 xFader switch -->
+
+          <WidgetGroup><Size>0me,0min</Size></WidgetGroup>
+          <WidgetGroup><Size>0me,0min</Size></WidgetGroup>
+
+          <WidgetGroup><!-- Channel 4 xFader switch -->
+            <Layout>horizontal</Layout>
+            <SizePolicy>max,me</SizePolicy>
+            <Children>
+              <Template src="skins:LateNight/controls/button_xfader_deck.xml">
+                <SetVariable name="Group">[Channel4]</SetVariable>
+                <SetVariable name="xfaderLeft">warning</SetVariable>
+                <SetVariable name="xfaderRight">default</SetVariable>
+              </Template>
+            </Children>
+          </WidgetGroup><!-- Channel 4 xFader switch -->
+
+          <WidgetGroup><Size>0me,0min</Size></WidgetGroup>
+
+        </Children>
+        <Connection>
+          <ConfigKey persist="true">[Skin],show_xfader</ConfigKey>
+          <BindProperty>visible</BindProperty>
+        </Connection>
+      </WidgetGroup><!-- /Crossfader + Channel3/1/2/4 assign switches -->
+
+    </Children>
+    <Connection>
+      <ConfigKey persist="true">[Skin],show_4decks_row</ConfigKey>
+      <BindProperty>visible</BindProperty>
+    </Connection>
+  </WidgetGroup><!-- MixerDecks -->
+</Template>

--- a/res/skins/LateNight/mixer/mixer_4decks_stacked.xml
+++ b/res/skins/LateNight/mixer/mixer_4decks_stacked.xml
@@ -1,8 +1,13 @@
 <Template>
   <WidgetGroup>
+    <ObjectName>Mixer_4Decks_Stacked</ObjectName>
     <Layout>vertical</Layout>
     <SizePolicy>max,min</SizePolicy>
     <Children>
+
+      <!-- spacer to center channel controls without crossfader
+          without stretching the mixer -->
+      <WidgetGroup><SizePolicy>min,e</SizePolicy></WidgetGroup>
 
       <WidgetGroup><!-- Channel controls -->
         <ObjectName>AlignHCenter</ObjectName>
@@ -11,24 +16,28 @@
         <Children>
 
           <Template src="skins:LateNight/mixer/channel_4decks.xml">
+            <SetVariable name="ObjectName">Mixer_4Decks_Stacked_Ch3</SetVariable>
             <SetVariable name="ChanNum">3</SetVariable>
             <SetVariable name="xfaderLeft">default</SetVariable>
             <SetVariable name="xfaderRight">warning</SetVariable>
           </Template>
 
           <Template src="skins:LateNight/mixer/channel_4decks.xml">
+            <SetVariable name="ObjectName">Mixer_4Decks_Stacked_Ch1</SetVariable>
             <SetVariable name="ChanNum">1</SetVariable>
             <SetVariable name="xfaderLeft">default</SetVariable>
             <SetVariable name="xfaderRight">warning</SetVariable>
           </Template>
 
           <Template src="skins:LateNight/mixer/channel_4decks.xml">
+            <SetVariable name="ObjectName">Mixer_4Decks_Stacked_Ch2</SetVariable>
             <SetVariable name="ChanNum">2</SetVariable>
             <SetVariable name="xfaderLeft">warning</SetVariable>
             <SetVariable name="xfaderRight">default</SetVariable>
           </Template>
 
           <Template src="skins:LateNight/mixer/channel_4decks.xml">
+            <SetVariable name="ObjectName">Mixer_4Decks_Stacked_Ch4</SetVariable>
             <SetVariable name="ChanNum">4</SetVariable>
             <SetVariable name="xfaderLeft">warning</SetVariable>
             <SetVariable name="xfaderRight">default</SetVariable>
@@ -41,41 +50,27 @@
 
       <WidgetGroup><SizePolicy>min,e</SizePolicy></WidgetGroup>
 
-      <WidgetGroup>
-        <ObjectName>CrossfaderAndSwitches2Decks</ObjectName>
+      <WidgetGroup><!-- CrossfaderContainer -->
         <Layout>horizontal</Layout>
+        <SizePolicy>min,min</SizePolicy>
         <Children>
-
-          <WidgetGroup><Size>0me,0min</Size></WidgetGroup>
-
-          <WidgetGroup>
-            <ObjectName>CrossfaderContainer</ObjectName>
-            <Layout>horizontal</Layout>
-            <SizePolicy>min,min</SizePolicy>
-            <Children>
-              <SingletonContainer>
-                <ObjectName>CrossfaderSingleton</ObjectName>
-              </SingletonContainer>
-            </Children>
-          </WidgetGroup><!-- CrossfaderContainer -->
-
-          <WidgetGroup><Size>0me,0min</Size></WidgetGroup>
-
+          <SingletonContainer>
+            <ObjectName>CrossfaderSingleton</ObjectName>
+          </SingletonContainer>
         </Children>
         <Connection>
           <ConfigKey persist="true">[Skin],show_xfader</ConfigKey>
           <BindProperty>visible</BindProperty>
         </Connection>
-      </WidgetGroup><!-- CrossfaderAndSwitches2Decks -->
+      </WidgetGroup><!-- CrossfaderContainer -->
 
-      <!-- spacer to center channel controls without crossfader
-          without stretching the mixer -->
       <WidgetGroup><SizePolicy>min,e</SizePolicy></WidgetGroup>
 
     </Children>
     <Connection>
-      <ConfigKey persist="true">[Skin],show_4decks</ConfigKey>
+      <ConfigKey persist="true">[Skin],show_4decks_row</ConfigKey>
       <BindProperty>visible</BindProperty>
+      <Transform><Not/></Transform>
     </Connection>
   </WidgetGroup>
 </Template>

--- a/res/skins/LateNight/mixer/mixer_main_headphone.xml
+++ b/res/skins/LateNight/mixer/mixer_main_headphone.xml
@@ -135,30 +135,41 @@
                 <Layout>vertical</Layout>
                 <SizePolicy>min,min</SizePolicy>
                 <Children>
-
                   <WidgetGroup>
-                    <MinimumSize>0,10</MinimumSize>
-                    <MaximumSize>,10</MaximumSize>
-                    <SizePolicy>min,me</SizePolicy>
-                  </WidgetGroup>
-
-                  <WidgetGroup>
-                    <ObjectName>VuMeterMain_4Decks</ObjectName>
-                    <Layout>horizontal</Layout>
-                    <SizePolicy>max,max</SizePolicy>
+                    <Layout>vertical</Layout>
+                    <SizePolicy>min,min</SizePolicy>
                     <Children>
-                      <SingletonContainer>
-                        <ObjectName>VuMeterMain_Light</ObjectName>
-                      </SingletonContainer>
+
+                      <WidgetGroup>
+                        <MinimumSize>0,10</MinimumSize>
+                        <MaximumSize>,10</MaximumSize>
+                        <SizePolicy>min,me</SizePolicy>
+                      </WidgetGroup>
+
+                      <WidgetGroup>
+                        <ObjectName>VuMeterMain_4Decks</ObjectName>
+                        <Layout>horizontal</Layout>
+                        <SizePolicy>max,max</SizePolicy>
+                        <Children>
+                          <SingletonContainer>
+                            <ObjectName>VuMeterMain_Light</ObjectName>
+                          </SingletonContainer>
+                        </Children>
+                      </WidgetGroup><!-- VuMeterMain_4Decks -->
+
+                      <WidgetGroup>
+                        <MinimumSize>0,20</MinimumSize>
+                        <MaximumSize>,20</MaximumSize>
+                        <SizePolicy>min,me</SizePolicy>
+                      </WidgetGroup>
+
                     </Children>
-                  </WidgetGroup><!-- VuMeterMain_4Decks -->
-
-                  <WidgetGroup>
-                    <MinimumSize>0,20</MinimumSize>
-                    <MaximumSize>,20</MaximumSize>
-                    <SizePolicy>min,me</SizePolicy>
+                    <Connection>
+                      <ConfigKey persist="true">[Skin],show_4decks_row</ConfigKey>
+                      <BindProperty>visible</BindProperty>
+                      <Transform><Not/></Transform>
+                    </Connection>
                   </WidgetGroup>
-
                 </Children>
                 <Connection>
                   <ConfigKey persist="true">[Skin],show_4decks</ConfigKey>

--- a/res/skins/LateNight/mixer/singletons.xml
+++ b/res/skins/LateNight/mixer/singletons.xml
@@ -3,48 +3,79 @@
   <SetVariable name="ChannelType">channel</SetVariable>
   <SetVariable name="VuSize">deck</SetVariable>
   <SetVariable name="VuColor">dark</SetVariable>
+  <SetVariable name="BtnType"><Variable name="TopRegion_BtnType"/></SetVariable>
 
   <SingletonDefinition>
     <ObjectName>CrossfaderSingleton</ObjectName>
     <Children>
+      <!-- WidgetGroup around slider to draw a style border
+      around it when AutoDJ is enabled. Note that it doesn't
+      work without the extra outer WidgetGroup (highlight in SliderComposed) -->
       <WidgetGroup>
-        <Size>115f,40f</Size>
+        <ObjectName>CrossfaderContainer</ObjectName>
+        <SizePolicy>f,f</SizePolicy>
+        <Layout>horizontal</Layout>
+        <Connection>
+          <ConfigKey>[AutoDJ],enabled</ConfigKey>
+          <BindProperty>highlight</BindProperty>
+        </Connection>
         <Children>
-          <!-- WidgetGroup around slider to draw a style border
-          around it when AutoDJ is enabled. Note that it doesn't
-          work without the extra outer WidgetGroup -->
-          <WidgetGroup>
+          <SliderComposed>
+            <TooltipId>crossfader</TooltipId>
             <Size>115f,40f</Size>
-            <ObjectName>CrossfaderContainer</ObjectName>
+            <Handle scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="SliderScheme"/>/sliders/knob_crossfader.svg</Handle>
+            <Slider visible="false" scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="SliderScheme"/>/sliders/slider_crossfader.svg</Slider>
+            <Horizontal>true</Horizontal>
+            <BarColor><Variable name="BarColorCrossfader"/></BarColor>
+            <BarWidth><Variable name="BarWidth"/></BarWidth>
+            <BarMargins><Variable name="BarMarginCrossfader"/></BarMargins>
+            <BarMargins><Variable name="BarMarginVolume"/></BarMargins>
+            <BarRoundCaps>true</BarRoundCaps>
+            <BarAxisPos>19.0</BarAxisPos>
+            <BarUnipolar>false</BarUnipolar>
             <Connection>
-              <ConfigKey>[AutoDJ],enabled</ConfigKey>
-              <BindProperty>highlight</BindProperty>
+              <ConfigKey>[Master],crossfader</ConfigKey>
             </Connection>
-            <Children>
-              <SliderComposed>
-                <TooltipId>crossfader</TooltipId>
-                <Size>115f,40f</Size>
-                <Handle scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="SliderScheme"/>/sliders/knob_crossfader.svg</Handle>
-                <Slider visible="false" scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="SliderScheme"/>/sliders/slider_crossfader.svg</Slider>
-                <Horizontal>true</Horizontal>
-                <BarColor><Variable name="BarColorCrossfader"/></BarColor>
-                <BarWidth><Variable name="BarWidth"/></BarWidth>
-                <BarMargins><Variable name="BarMarginCrossfader"/></BarMargins>
-                <BarMargins><Variable name="BarMarginVolume"/></BarMargins>
-                <BarRoundCaps>true</BarRoundCaps>
-                <BarAxisPos>19.0</BarAxisPos>
-                <BarUnipolar>false</BarUnipolar>
-                <Connection>
-                  <ConfigKey>[Master],crossfader</ConfigKey>
-                </Connection>
-              </SliderComposed>
-            </Children>
-          </WidgetGroup>
+          </SliderComposed>
         </Children>
       </WidgetGroup>
     </Children>
   </SingletonDefinition>
 
+  <SingletonDefinition>
+    <ObjectName>CrossfaderNarrowSingleton</ObjectName>
+    <Children>
+      <WidgetGroup>
+        <Size>85f,40f</Size>
+        <ObjectName>CrossfaderContainer</ObjectName>
+        <Connection>
+          <ConfigKey>[AutoDJ],enabled</ConfigKey>
+          <BindProperty>highlight</BindProperty>
+        </Connection>
+        <Children>
+          <SliderComposed>
+            <TooltipId>crossfader</TooltipId>
+            <Size>85f,40f</Size>
+            <Handle scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="SliderScheme"/>/sliders/knob_crossfader.svg</Handle>
+            <Slider scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="SliderScheme"/>/sliders/slider_crossfader_small.svg</Slider>
+            <Horizontal>true</Horizontal>
+            <BarColor><Variable name="BarColorCrossfader"/></BarColor>
+            <BarWidth><Variable name="BarWidth"/></BarWidth>
+            <BarMargins><Variable name="BarMarginCrossfader"/></BarMargins>
+            <BarMargins><Variable name="BarMarginVolume"/></BarMargins>
+            <BarRoundCaps>true</BarRoundCaps>
+            <BarAxisPos>19.0</BarAxisPos>
+            <BarUnipolar>false</BarUnipolar>
+            <Connection>
+              <ConfigKey>[Master],crossfader</ConfigKey>
+            </Connection>
+          </SliderComposed>
+        </Children>
+      </WidgetGroup>
+    </Children>
+  </SingletonDefinition>
+
+  <!-- VU meters -->
   <SingletonDefinition>
     <ObjectName>VuMeterChannel1</ObjectName>
     <Children>
@@ -124,6 +155,183 @@
           <Template src="skins:LateNight/mixer/vumeter_main.xml">
             <SetVariable name="VuColor">light</SetVariable>
           </Template>
+        </Children>
+      </WidgetGroup>
+    </Children>
+  </SingletonDefinition>
+
+  <!-- Pfl buttons -->
+  <SingletonDefinition>
+    <ObjectName>PflButton1</ObjectName>
+    <Children>
+      <WidgetGroup>
+        <Layout>horizontal</Layout>
+        <Children>
+          <Template src="skins:LateNight/controls/button_2state.xml">
+            <SetVariable name="TooltipId">pfl</SetVariable>
+            <SetVariable name="ObjectName">PflButton</SetVariable>
+            <SetVariable name="Size">26,26</SetVariable>
+            <SetVariable name="BtnSize">square</SetVariable>
+            <SetVariable name="ConfigKey">[Channel1],pfl</SetVariable>
+          </Template>
+        </Children>
+      </WidgetGroup>
+    </Children>
+  </SingletonDefinition>
+
+  <SingletonDefinition>
+    <ObjectName>PflButton2</ObjectName>
+    <Children>
+      <WidgetGroup>
+        <Layout>horizontal</Layout>
+        <Children>
+          <Template src="skins:LateNight/controls/button_2state.xml">
+            <SetVariable name="TooltipId">pfl</SetVariable>
+            <SetVariable name="ObjectName">PflButton</SetVariable>
+            <SetVariable name="Size">26,26</SetVariable>
+            <SetVariable name="BtnSize">square</SetVariable>
+            <SetVariable name="ConfigKey">[Channel2],pfl</SetVariable>
+          </Template>
+        </Children>
+      </WidgetGroup>
+    </Children>
+  </SingletonDefinition>
+
+  <SingletonDefinition>
+    <ObjectName>PflButton3</ObjectName>
+    <Children>
+      <WidgetGroup>
+        <Layout>horizontal</Layout>
+        <Children>
+          <Template src="skins:LateNight/controls/button_2state.xml">
+            <SetVariable name="TooltipId">pfl</SetVariable>
+            <SetVariable name="ObjectName">PflButton</SetVariable>
+            <SetVariable name="Size">26,26</SetVariable>
+            <SetVariable name="BtnSize">square</SetVariable>
+            <SetVariable name="ConfigKey">[Channel3],pfl</SetVariable>
+          </Template>
+        </Children>
+      </WidgetGroup>
+    </Children>
+  </SingletonDefinition>
+
+  <SingletonDefinition>
+    <ObjectName>PflButton4</ObjectName>
+    <Children>
+      <WidgetGroup>
+        <Layout>horizontal</Layout>
+        <Children>
+          <Template src="skins:LateNight/controls/button_2state.xml">
+            <SetVariable name="TooltipId">pfl</SetVariable>
+            <SetVariable name="ObjectName">PflButton</SetVariable>
+            <SetVariable name="Size">26,26</SetVariable>
+            <SetVariable name="BtnSize">square</SetVariable>
+            <SetVariable name="ConfigKey">[Channel4],pfl</SetVariable>
+          </Template>
+        </Children>
+      </WidgetGroup>
+    </Children>
+  </SingletonDefinition>
+
+  <!-- Volumen sliders -->
+  <SingletonDefinition>
+    <ObjectName>VolumeSlider1</ObjectName>
+    <Children>
+      <Template src="skins:LateNight/mixer/volume_slider.xml">
+        <SetVariable name="ChanNum">1</SetVariable>
+      </Template>
+    </Children>
+  </SingletonDefinition>
+
+  <SingletonDefinition>
+    <ObjectName>VolumeSlider2</ObjectName>
+    <Children>
+      <Template src="skins:LateNight/mixer/volume_slider.xml">
+        <SetVariable name="ChanNum">2</SetVariable>
+      </Template>
+    </Children>
+  </SingletonDefinition>
+
+  <SingletonDefinition>
+    <ObjectName>VolumeSlider3</ObjectName>
+    <Children>
+      <Template src="skins:LateNight/mixer/volume_slider.xml">
+        <SetVariable name="ChanNum">3</SetVariable>
+      </Template>
+    </Children>
+  </SingletonDefinition>
+
+  <SingletonDefinition>
+    <ObjectName>VolumeSlider4</ObjectName>
+    <Children>
+      <Template src="skins:LateNight/mixer/volume_slider.xml">
+        <SetVariable name="ChanNum">4</SetVariable>
+      </Template>
+    </Children>
+  </SingletonDefinition>
+
+  <!-- Quick Effect selectors -->
+  <!-- text alignment and position of the down arrow is done in css
+       via the parents' ObjectName -->
+  <SingletonDefinition>
+    <ObjectName>QuickEffectSelector1_Singleton</ObjectName>
+    <Children>
+      <WidgetGroup>
+        <Layout>horizontal</Layout>
+        <Children>
+          <EffectChainPresetSelector>
+            <ObjectName>QuickEffectSelector1</ObjectName>
+            <Size>40me,18f</Size>
+            <EffectUnitGroup>[QuickEffectRack1_[Channel1]]</EffectUnitGroup>
+          </EffectChainPresetSelector>
+        </Children>
+      </WidgetGroup>
+    </Children>
+  </SingletonDefinition>
+
+  <SingletonDefinition>
+    <ObjectName>QuickEffectSelector2_Singleton</ObjectName>
+    <Children>
+      <WidgetGroup>
+        <Layout>horizontal</Layout>
+        <Children>
+          <EffectChainPresetSelector>
+            <ObjectName>QuickEffectSelector2</ObjectName>
+            <Size>40me,18f</Size>
+            <EffectUnitGroup>[QuickEffectRack1_[Channel2]]</EffectUnitGroup>
+          </EffectChainPresetSelector>
+        </Children>
+      </WidgetGroup>
+    </Children>
+  </SingletonDefinition>
+
+  <SingletonDefinition>
+    <ObjectName>QuickEffectSelector3_Singleton</ObjectName>
+    <Children>
+      <WidgetGroup>
+        <Layout>horizontal</Layout>
+        <Children>
+          <EffectChainPresetSelector>
+            <ObjectName>QuickEffectSelector3</ObjectName>
+            <Size>40me,18f</Size>
+            <EffectUnitGroup>[QuickEffectRack1_[Channel3]]</EffectUnitGroup>
+          </EffectChainPresetSelector>
+        </Children>
+      </WidgetGroup>
+    </Children>
+  </SingletonDefinition>
+
+  <SingletonDefinition>
+    <ObjectName>QuickEffectSelector4_Singleton</ObjectName>
+    <Children>
+      <WidgetGroup>
+        <Layout>horizontal</Layout>
+        <Children>
+          <EffectChainPresetSelector>
+            <ObjectName>QuickEffectSelector4</ObjectName>
+            <Size>40me,18f</Size>
+            <EffectUnitGroup>[QuickEffectRack1_[Channel4]]</EffectUnitGroup>
+          </EffectChainPresetSelector>
         </Children>
       </WidgetGroup>
     </Children>

--- a/res/skins/LateNight/mixer/singletons_channel.xml
+++ b/res/skins/LateNight/mixer/singletons_channel.xml
@@ -1,0 +1,115 @@
+<!DOCTYPE template>
+<Template>
+  <SetVariable name="Group">[Channel<Variable name="ChanNum"/>]</SetVariable>
+  <SetVariable name="ChannelType">channel</SetVariable>
+  <SetVariable name="VuSize">deck</SetVariable>
+  <SetVariable name="VuColor">dark</SetVariable>
+  <SetVariable name="EqFxUnit">[EqualizerRack1_<Variable name="Group"/>]</SetVariable>
+  <SetVariable name="EqEffect">[EqualizerRack1_<Variable name="Group"/>_Effect1]</SetVariable>
+
+  <SetVariable name="KnobBg">regular</SetVariable>
+  <SetVariable name="KnobIndicator">regular</SetVariable>
+  <SetVariable name="ArcRadius"><Variable name="ArcRadiusBig"/></SetVariable>
+  <SetVariable name="ArcThickness"><Variable name="ArcThicknessBig"/></SetVariable>
+
+  <SingletonDefinition>
+    <ObjectName>VuMeterChannel<Variable name="ChanNum"/></ObjectName>
+    <Children>
+      <WidgetGroup>
+        <Layout>horizontal</Layout>
+        <Children>
+          <!-- AlignRight doesn't seem to work anymore with Qt6?? -->
+          <Template src="skins:LateNight/controls/knob.xml">
+            <SetVariable name="Size">40f,34f</SetVariable>
+            <SetVariable name="KnobColor">orange</SetVariable>
+            <SetVariable name="ArcColor"><Variable name="ArcColorGain"/></SetVariable>
+            <SetVariable name="Control">pregain</SetVariable>
+            <SetVariable name="TooltipId">pregain</SetVariable>
+          </Template>
+        </Children>
+      </WidgetGroup>
+    </Children>
+  </SingletonDefinition>
+
+  <SingletonDefinition>
+    <ObjectName>EqKnobHigh_4Decks_Ch<Variable name="ChanNum"/></ObjectName>
+    <Children>
+      <WidgetGroup>
+        <Layout>horizontal</Layout>
+        <Children>
+          <Template src="skins:LateNight/mixer/eq_knob_4decks.xml">
+            <SetVariable name="EqParameter">3</SetVariable>
+            <SetVariable name="EqRange">High</SetVariable>
+          </Template>
+        </Children>
+      </WidgetGroup>
+    </Children>
+  </SingletonDefinition>
+
+  <SingletonDefinition>
+    <ObjectName>EqKnobMid_4Decks_Ch<Variable name="ChanNum"/></ObjectName>
+    <Children>
+      <WidgetGroup>
+        <Layout>horizontal</Layout>
+        <Children>
+          <Template src="skins:LateNight/mixer/eq_knob_4decks.xml">
+            <SetVariable name="EqParameter">2</SetVariable>
+            <SetVariable name="EqRange">Mid</SetVariable>
+          </Template>
+        </Children>
+      </WidgetGroup>
+    </Children>
+  </SingletonDefinition>
+
+  <SingletonDefinition>
+    <ObjectName>EqKnobLow_4Decks_Ch<Variable name="ChanNum"/></ObjectName>
+    <Children>
+      <WidgetGroup>
+        <Layout>horizontal</Layout>
+        <Children>
+          <Template src="skins:LateNight/mixer/eq_knob_4decks.xml">
+            <SetVariable name="EqParameter">1</SetVariable>
+            <SetVariable name="EqRange">Low</SetVariable>
+          </Template>
+        </Children>
+      </WidgetGroup>
+    </Children>
+  </SingletonDefinition>
+
+  <SingletonDefinition>
+    <ObjectName>QuickEffectKnob_2Decks_Ch<Variable name="ChanNum"/></ObjectName>
+    <Children>
+      <WidgetGroup>
+        <Layout>horizontal</Layout>
+        <Children>
+          <Template src="skins:LateNight/mixer/quick_effect_knob_2decks.xml"/>
+        </Children>
+      </WidgetGroup>
+    </Children>
+  </SingletonDefinition>
+
+  <SingletonDefinition>
+    <ObjectName>QuickEffectKnob_4Decks<Variable name="ChanNum"/></ObjectName>
+    <Children>
+      <WidgetGroup>
+        <Layout>horizontal</Layout>
+        <Children>
+          <Template src="skins:LateNight/mixer/quick_effect_knob_4decks.xml"/>
+        </Children>
+      </WidgetGroup>
+    </Children>
+  </SingletonDefinition>
+
+  <SingletonDefinition>
+    <ObjectName>VuMeterChannel<Variable name="ChanNum"/></ObjectName>
+    <Children>
+      <WidgetGroup>
+        <Layout>horizontal</Layout>
+        <Children>
+          <Template src="skins:LateNight/mixer/vumeter_single.xml"/>
+        </Children>
+      </WidgetGroup>
+    </Children>
+  </SingletonDefinition>
+
+</Template>

--- a/res/skins/LateNight/mixer/spacer_4decks_eq_vu.xml
+++ b/res/skins/LateNight/mixer/spacer_4decks_eq_vu.xml
@@ -1,0 +1,27 @@
+<Template>
+  <WidgetGroup>
+    <Layout>horizontal</Layout>
+    <Size>0f,min</Size>
+    <Children>
+      <WidgetGroup>
+        <Layout>horizontal</Layout>
+        <Size>0f,<Variable name="Height"/></Size>
+        <Children/>
+        <Connection>
+          <ConfigKey persist="true">[Skin],show_eq_knobs</ConfigKey>
+          <BindProperty>visible</BindProperty>
+        </Connection>
+      </WidgetGroup>
+      <WidgetGroup>
+        <Layout>horizontal</Layout>
+        <Size>0f,<Variable name="Height"/></Size>
+        <Children/>
+        <Connection>
+          <ConfigKey persist="true">[Skin],show_xfader</ConfigKey>
+          <Transform><Not/></Transform>
+          <BindProperty>visible</BindProperty>
+        </Connection>
+      </WidgetGroup>
+    </Children>
+  </WidgetGroup>
+</Template>

--- a/res/skins/LateNight/mixer/volume_slider.xml
+++ b/res/skins/LateNight/mixer/volume_slider.xml
@@ -1,0 +1,22 @@
+<Template>
+  <WidgetGroup>
+    <Layout>horizontal</Layout>
+    <Children>
+      <SliderComposed>
+        <TooltipId>channel_volume</TooltipId>
+        <Size>42f,107f</Size>
+        <Handle scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="SliderScheme"/>/sliders/knob_volume_deck.svg</Handle>
+        <Slider scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="SliderScheme"/>/sliders/slider_volume_deck.svg</Slider>
+        <Horizontal>false</Horizontal>
+        <BarColor><Variable name="BarColorVolume"/></BarColor>
+        <BarWidth><Variable name="BarWidth"/></BarWidth>
+        <BarMargins><Variable name="BarMarginVolume"/></BarMargins>
+        <BarRoundCaps>true</BarRoundCaps>
+        <BarAxisPos>21.0</BarAxisPos>
+        <Connection>
+          <ConfigKey>[Channel<Variable name="ChanNum"/>],volume</ConfigKey>
+        </Connection>
+      </SliderComposed>
+    </Children>
+  </WidgetGroup>
+</Template>

--- a/res/skins/LateNight/skin.xml
+++ b/res/skins/LateNight/skin.xml
@@ -45,6 +45,7 @@
     <!-- Decks -->
       <!-- general -->
       <attribute persist="true" config_key="[Skin],show_4decks">0</attribute>
+      <attribute persist="true" config_key="[Skin],show_4decks_row">0</attribute>
       <attribute persist="true" config_key="[Skin],show_hotcues">1</attribute>
       <attribute persist="true" config_key="[Skin],show_8_hotcues">1</attribute>
       <attribute persist="true" config_key="[Skin],show_intro_outro_cues">1</attribute>
@@ -384,6 +385,23 @@
     </SingletonDefinition>
 
     <Template src="skins:LateNight/mixer/singletons.xml"/>
+
+    <!-- move to /mixer/singletons.xml -->
+    <!-- <Template src="skins:LateNight/mixer/singletons_channel.xml">
+      <SetVariable name="ChanNum">1</SetVariable>
+    </Template>
+
+    <Template src="skins:LateNight/mixer/singletons_channel.xml">
+      <SetVariable name="ChanNum">2</SetVariable>
+    </Template>
+
+    <Template src="skins:LateNight/mixer/singletons_channel.xml">
+      <SetVariable name="ChanNum">3</SetVariable>
+    </Template>
+
+    <Template src="skins:LateNight/mixer/singletons_channel.xml">
+      <SetVariable name="ChanNum">4</SetVariable>
+    </Template> -->
 
     <SingletonDefinition>
       <ObjectName>LibrarySingleton</ObjectName>

--- a/res/skins/LateNight/skin_settings.xml
+++ b/res/skins/LateNight/skin_settings.xml
@@ -22,7 +22,7 @@ Description:
       <WidgetGroup>
         <ObjectName>SkinSettings</ObjectName>
         <Layout>vertical</Layout>
-        <Size>240f,1me</Size>
+        <Size>263f,1me</Size>
         <Children>
 
           <!-- Decks -->
@@ -50,6 +50,23 @@ Description:
                 <SetVariable name="Width">25f</SetVariable>
               </Template>
               <WidgetGroup><Size>0me,0f</Size></WidgetGroup>
+            </Children>
+          </WidgetGroup>
+
+          <WidgetGroup><!-- 4 deck in horizontal layout -->
+            <ObjectName>SkinSettingsCategory</ObjectName>
+            <SizePolicy>me,f</SizePolicy>
+            <Layout>stacked</Layout>
+            <Children>
+              <!-- translucent cover when 2 decks are shown -->
+              <Template src="skins:LateNight/helpers/skin_settings_cover_inverted.xml">
+                <SetVariable name="Setting">[Skin],show_4decks</SetVariable>
+              </Template>
+              <Template src="skins:LateNight/helpers/skin_settings_button_2state.xml">
+                <SetVariable name="Text">4 Decks in a Row</SetVariable>
+                <SetVariable name="Setting">[Skin],show_4decks_row</SetVariable>
+                <SetVariable name="Width">190me</SetVariable>
+              </Template>
             </Children>
           </WidgetGroup>
 

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -554,11 +554,13 @@ WTrackProperty[selected="false"] {
     qproperty-layoutAlignment: 'AlignHCenter | AlignBottom';
     }
 
-#CrossfaderAndSwitches2Decks {
+#CrossfaderAndSwitches2Decks,
+#CrossfaderSwitches4Decks {
   qproperty-layoutAlignment: 'AlignHCenter';
-}
-#CrossfaderSwitch_4Decks {
-  qproperty-layoutAlignment: 'AlignRight';
+  }
+  #CrossfaderSwitch_4Decks_Stacked {
+    qproperty-layoutAlignment: 'AlignRight | AlignVCenter';
+    /* background-color: #456113; */
   }
   #CrossfaderContainer {
     qproperty-layoutAlignment: 'AlignHCenter | AlignBottom';
@@ -646,22 +648,45 @@ WEffectChainPresetSelector {
   }
 
   /* QuickEffect selector of left-hand decks and in 4-decks mixer
-    has it's down arrow on the left side, below the QuickEffect toggle */
-  WEffectChainPresetSelector#QuickEffectSelectorLeft {
-    padding: 0px -5px 0px -1px;
+    has it's down arrow on the left side, below the QuickEffect toggle,
+    and left-aligned text */
+  #Mixer_2Decks WEffectChainPresetSelector#QuickEffectSelector1,
+  #Mixer_4Decks_Stacked WEffectChainPresetSelector#QuickEffectSelector1,
+  #Mixer_4Decks_Stacked WEffectChainPresetSelector#QuickEffectSelector2,
+  #Mixer_4Decks_Stacked WEffectChainPresetSelector#QuickEffectSelector3,
+  #Mixer_4Decks_Stacked WEffectChainPresetSelector#QuickEffectSelector4,
+  #Mixer_4Decks_Row WEffectChainPresetSelector#QuickEffectSelector1,
+  #Mixer_4Decks_Row WEffectChainPresetSelector#QuickEffectSelector3 {
+    padding: 0px -3px 0px -1px;
     margin: 0px;
     text-align: left;
     }
-    WEffectChainPresetSelector#QuickEffectSelectorLeft::drop-down {
+    #Mixer_2Decks WEffectChainPresetSelector#QuickEffectSelector1::drop-down,
+    #Mixer_4Decks_Stacked WEffectChainPresetSelector#QuickEffectSelector1::drop-down,
+    #Mixer_4Decks_Stacked WEffectChainPresetSelector#QuickEffectSelector2::drop-down,
+    #Mixer_4Decks_Stacked WEffectChainPresetSelector#QuickEffectSelector3::drop-down,
+    #Mixer_4Decks_Stacked WEffectChainPresetSelector#QuickEffectSelector4::drop-down,
+    #Mixer_4Decks_Row WEffectChainPresetSelector#QuickEffectSelector1::drop-down,
+    #Mixer_4Decks_Row WEffectChainPresetSelector#QuickEffectSelector3::drop-down {
       subcontrol-origin: margin;
       subcontrol-position: left center;
     }
-  WEffectChainPresetSelector#QuickEffectSelectorRight {
-    padding: 0px -1px 0px -5px;
+  /* QuickEffect selector of right-hand decks,
+     down arrow on the right side, text right-aligned */
+  #Mixer_2Decks WEffectChainPresetSelector#QuickEffectSelector2 {
+    padding: 0px -1px 0px -3px;
     margin: 0px;
     text-align: right;
     }
-    WEffectChainPresetSelector#QuickEffectSelectorRight::drop-down {
+    #Mixer_4Decks_Row WEffectChainPresetSelector#QuickEffectSelector2,
+    #Mixer_4Decks_Row WEffectChainPresetSelector#QuickEffectSelector4 {
+      padding: 0px -1px 0px 0px;
+      margin: 0px;
+      text-align: right;
+    }
+    #Mixer_2Decks WEffectChainPresetSelector#QuickEffectSelector2::drop-down,
+    #Mixer_4Decks_Row WEffectChainPresetSelector#QuickEffectSelector2::drop-down,
+    #Mixer_4Decks_Row WEffectChainPresetSelector#QuickEffectSelector4::drop-down {
       subcontrol-origin: margin;
       subcontrol-position: right center;
     }
@@ -974,7 +999,7 @@ WLibrarySidebar {
 }
 
 #TEST1 {
-  background-color: #456113;
+  background-color: #134561;
 }
 
 #TEST2 {
@@ -986,7 +1011,7 @@ WLibrarySidebar {
 }
 
 #TEST4 {
-  background-color: #134561;
+  background-color: #345613;
 }
 
 #TEST33 {

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -273,6 +273,8 @@ WSearchLineEdit {
 #DeckRateSeparator,
 #DeckRateSeparatorCompact,
 #MainMixerSeparator,
+#Mixer4Decks_ChannelSeparator,
+#Mixer4Decks_SeparatorH,
 #MainHeadphoneSeparator,
 #FxMixerSeparatorCollapsed,
 #FxSlotSeparatorH,
@@ -287,6 +289,15 @@ WSearchLineEdit {
     min-width: 0px;
     max-width: 0px;
   }
+  #Mixer4Decks_ChannelSeparator {
+    min-width: 0px;
+    max-width: 0px;
+    /* 2 x 1px border + 2 + 2 margin */
+    /*min-width: 6px;
+    max-width: 6px;*/
+    margin: 0px 4px;
+  }
+  #Mixer4Decks_SeparatorH,
   #SkinSettingsSeparator {
     min-height: 0px;
     max-height: 0px;
@@ -298,6 +309,7 @@ WSearchLineEdit {
     min-width: 12px;
     max-width: 12px;
   }
+  #Mixer4Decks_ChannelSeparator,
   #DeckRateSeparator,
   #DeckRateSeparatorCompact,
   #FxMixerSeparatorCollapsed,
@@ -308,6 +320,10 @@ WSearchLineEdit {
   #MainMixerSeparator {
     border-left: 1px solid #0c0c0c;
     border-right: 1px solid #222;
+  }
+  #Mixer4Decks_SeparatorH {
+    border-top: 1px solid #0c0c0c;
+    border-bottom: 1px solid #333;
   }
   #FxSlotSeparatorH {
     border-top: 1px solid #0c0c0c;
@@ -715,37 +731,69 @@ WBeatSpinBox::down-button,
 
 /************** Mixer ***************************************************/
 
-#CrossfaderContainer[highlight="1"] {
-  border:  1px solid #b2421c;
+/* all mixer variants */
+#Mixer_2Decks,
+#Mixer_4Decks_Stacked,
+#Mixer_4Decks_Row {}
+
+#Mixer_4Decks_Stacked {
+  padding: 3px 0px 0px 2px;
 }
 
-#MixerDecks {
-  padding: 2px 5px 2px 5px;
+  #Mixer_2Decks_Ch1,
+  #Mixer_4Decks_Row_Ch3 {
+    /* Using padding here would braek center alignment in VolumeGain2Decks ... */
+    margin: 3px 0px 2px 5px;
   }
-  #MixerChannel_2Decks_Left {
-    margin: 0px 2px;
+  #Mixer_2Decks_Ch2,
+  #Mixer_4Decks_Row_Ch4 {
+    padding: 3px 5px 2px 0px;
   }
-  #MixerChannel_2Decks_Right {
-    margin: 0px 2px;
+  #Mixer_4Decks_Row_Ch1,
+  #Mixer_4Decks_Row_Ch2 {
+    margin: 3px 0px 2px 0px;
   }
+
+  #GainKnob {
+    qproperty-layoutAlignment: 'AlignHCenter | AlignTop';
+  }
+
   #VuAndSlider_4Decks {
     margin-right: 1px;
   }
-  #PflBox_4Decks {
-    margin: 3px 0px 0px 20px;
+  #PflBox_2Decks {
+    margin: 8px 0px 11px 0px;
+  }
+  #PflBox_4Decks_Row {
+    margin: 8px 0px 10px 0px;
+  }
+  #PflBox_4Decks_Stacked {
+    /* not applied */
+    /* qproperty-layoutAlignment: 'AlignRight | AlignTop';*/
+    margin: 2px 10px 0px 0px;
   }
 
-  #CrossfaderSwitch_4Decks {
-    margin: 0px 4px 3px 0px;
+  #EQKillButtonBox {
+    padding-top: 5px;
+  }
+
+  #VuMeterBoxFull {
+    margin: 0px 0px 9px 0px;
+  }
+
+#CrossfaderContainer[highlight="1"] {
+  border:  1px solid #b2421c;
   }
   #Crossfader {
     padding: 0px 0px 0px 1px;
   }
+  #CrossfaderSwitch_4Decks_Stacked {
+    margin: 0px 0px 0px 5px;
+  }
 
   #CrossfaderButtonContainer_Deck {
-    padding: 1px;
     margin: 0px 1px 1px 0px;
-    }
+  }
   #CrossfaderButtonContainer_Aux {
     padding: 1px;
     margin-left: 3px;

--- a/src/widget/wbasewidget.cpp
+++ b/src/widget/wbasewidget.cpp
@@ -146,8 +146,10 @@ void WBaseWidget::setControlParameterRightUp(double v) {
 }
 
 void WBaseWidget::updateTooltip() {
+    qWarning() << "updateTooltip";
     // If we are in developer mode, update the tooltip.
     if (CmdlineArgs::Instance().getDeveloper()) {
+        qWarning() << "--> dev";
         QStringList debug;
         fillDebugTooltip(&debug);
 
@@ -183,6 +185,7 @@ QString toDebugString(const QSizePolicy::Policy& policy) {
 }
 
 void WBaseWidget::fillDebugTooltip(QStringList* debug) {
+    qWarning() << "fillDebugTooltip";
     QSizePolicy policy = m_pWidget->sizePolicy();
     *debug << QString("ClassName: %1").arg(m_pWidget->metaObject()->className())
            << QString("ObjectName: %1").arg(m_pWidget->objectName())


### PR DESCRIPTION
A fun (two-) coffee break hack.
Looks okay, please test and let me know what you think.

![image](https://github.com/user-attachments/assets/8bbe33d3-0475-4907-b852-0d815170afd5)

### TODO
- [x] apply to mini decks, too (library maximized)
- [ ] adjust Classic theme