### PR TITLE
Metronome: Fix noise when pausing track in in the middle of the click sound. 

### DIFF
--- a/src/effects/backends/builtin/metronomeeffect.cpp
+++ b/src/effects/backends/builtin/metronomeeffect.cpp
@@ -131,7 +131,10 @@ void MetronomeEffect::processChannel(
                 nextClickStart = bufferEnd - beatToBufferEnd;
             }
         } else {
-            // no transport, nothing to do.
+            // no transport, continue until the current click has been fully played
+            if (gs->m_framesSinceClickStart < clickSize) {
+                gs->m_framesSinceClickStart += engineParameters.framesPerBuffer();
+            }
             return;
         }
     } else {


### PR DESCRIPTION
Continue to play started metronome click even if track is paused.
This fixes repeating the same buffer over and over again causing loud noise.

https://github.com/mixxxdj/mixxx/issues/13727