### PR TITLE
Prevent deadlock with BULK transfert and reduce log noise

### DIFF
--- a/src/controllers/bulk/bulkcontroller.cpp
+++ b/src/controllers/bulk/bulkcontroller.cpp
@@ -299,11 +299,12 @@ void BulkController::sendBytes(const QByteArray& data) {
             (unsigned char*)data.constData(),
             data.size(),
             &transferred,
-            0);
+            5000 // Send timeout in milliseconds
+    );
     if (ret < 0) {
         qCWarning(m_logOutput) << "Unable to send data to" << getName()
                                << "serial #" << m_sUID << "-" << libusb_error_name(ret);
-    } else {
+    } else if (CmdlineArgs::Instance().getControllerDebug()) {
         qCDebug(m_logOutput) << transferred << "bytes sent to" << getName()
                              << "serial #" << m_sUID;
     }


### PR DESCRIPTION
- Set a timeout (currently 5sec) to prevent deadlock (occurred with the S4Mk3, as the device seems to have froze, leading to the Mixxx controller thread to starve.)
- Make success log message only displayed when using `--controller-debug`