### PR TITLE
fix: trigger QML waveform slot at init

### DIFF
--- a/src/qml/qmlplayerproxy.cpp
+++ b/src/qml/qmlplayerproxy.cpp
@@ -145,6 +145,7 @@ void QmlPlayerProxy::slotTrackLoaded(TrackPointer pTrack) {
 #ifdef __STEM__
         slotStemsChanged();
 #endif
+        slotWaveformChanged();
     }
     emit trackChanged();
     emit trackLoaded();


### PR DESCRIPTION
This fix the bug where the waveform isn't displayed when loading QML with a track already loaded (can be reproduced by loading a track, and trigger a QML reload with a `touch` on any used QMl file, e.g `res/qml/main.qml`)