### PR TITLE
(fix) Overview waveform: add tooltip info about left-click dragging

### DIFF
--- a/src/skin/legacy/tooltips.cpp
+++ b/src/skin/legacy/tooltips.cpp
@@ -47,6 +47,8 @@ void Tooltips::addStandardTooltips() {
             << tr("Waveform Overview")
             << tr("Shows information about the track currently loaded in this deck.") << "\n"
             << tr("Left click to jump around in the track.")
+            << tr("Left click and hold allows to preview the position where the play head "
+                  "will jump to on release. Dragging can be aborted with right click.")
             << tr("Right click hotcues to edit their labels and colors.")
             << tr("Right click anywhere else to show the time at that point.")
             << dropTracksHere;

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -523,6 +523,7 @@ void WOverview::mousePressEvent(QMouseEvent* e) {
         }
     } else if (e->button() == Qt::RightButton) {
         if (m_bLeftClickDragging) {
+            // Abort dragging
             m_iPickupPos = m_iPlayPos;
             m_bLeftClickDragging = false;
             m_bTimeRulerActive = false;


### PR DESCRIPTION
This and info how to abort dragging was missing.
Noticed while checking #13732 