### PR TITLE
Overview: abort play pos dragging if cursor is relased outside the valid area

### DIFF
--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -407,11 +407,16 @@ void WOverview::onRateRatioChange(double v) {
 void WOverview::onPassthroughChange(double v) {
     m_bPassthroughEnabled = static_cast<bool>(v);
 
-    if (!m_bPassthroughEnabled) {
+    if (m_bPassthroughEnabled) {
+        // Abort play position dragging
+        m_bLeftClickDragging = false;
+        m_bTimeRulerActive = false;
+        m_iPickupPos = m_iPlayPos;
+    } else {
         slotWaveformSummaryUpdated();
     }
 
-    // Always call this to trigger a repaint even if not track is loaded
+    // Always call this to trigger a repaint even if no track is loaded
     update();
 }
 

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -474,17 +474,9 @@ void WOverview::receiveCuesUpdated() {
 void WOverview::mouseMoveEvent(QMouseEvent* e) {
     if (m_bLeftClickDragging) {
         if (m_orientation == Qt::Horizontal) {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-            m_iPickupPos = math_clamp(static_cast<int>(e->position().x()), 0, width() - 1);
-#else
-            m_iPickupPos = math_clamp(e->x(), 0, width() - 1);
-#endif
+            m_iPickupPos = math_clamp(e->pos().x(), 0, width() - 1);
         } else {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-            m_iPickupPos = math_clamp(static_cast<int>(e->position().y()), 0, height() - 1);
-#else
-            m_iPickupPos = math_clamp(e->y(), 0, height() - 1);
-#endif
+            m_iPickupPos = math_clamp(e->pos().y(), 0, height() - 1);
         }
     }
 
@@ -541,17 +533,9 @@ void WOverview::mousePressEvent(QMouseEvent* e) {
     }
     if (e->button() == Qt::LeftButton) {
         if (m_orientation == Qt::Horizontal) {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-            m_iPickupPos = math_clamp(static_cast<int>(e->position().x()), 0, width() - 1);
-#else
-            m_iPickupPos = math_clamp(e->x(), 0, width() - 1);
-#endif
+            m_iPickupPos = math_clamp(e->pos().x(), 0, width() - 1);
         } else {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-            m_iPickupPos = math_clamp(static_cast<int>(e->position().y()), 0, height() - 1);
-#else
-            m_iPickupPos = math_clamp(e->y(), 0, height() - 1);
-#endif
+            m_iPickupPos = math_clamp(e->pos().y(), 0, height() - 1);
         }
 
         if (m_pHoveredMark != nullptr) {

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -122,6 +122,15 @@ class WOverview : public WWidget, public TrackDropTarget {
         return m_orientation == Qt::Horizontal ? height() : width();
     }
 
+    inline bool isPosInAllowedPosDragZone(const QPoint pos) {
+        const QRect dragZone = rect().marginsAdded(QMargins(
+                m_dragMarginH,
+                m_dragMarginV,
+                m_dragMarginH,
+                m_dragMarginV));
+        return dragZone.contains(pos);
+    }
+
     ConstWaveformPointer getWaveform() const {
         return m_pWaveform;
     }
@@ -162,6 +171,8 @@ class WOverview : public WWidget, public TrackDropTarget {
     int m_iPlayPos;
     bool m_bTimeRulerActive;
     Qt::Orientation m_orientation;
+    int m_dragMarginH;
+    int m_dragMarginV;
     int m_iLabelFontSize;
 
     // Coefficient value-position linear transposition
@@ -213,5 +224,4 @@ class WOverview : public WWidget, public TrackDropTarget {
     std::vector<WaveformMarkRange> m_markRanges;
     WaveformMarkLabel m_cuePositionLabel;
     WaveformMarkLabel m_cueTimeDistanceLabel;
-
 };


### PR DESCRIPTION
This is an attempt to fix #13732 = simplify aborting accidental position drag

Dragging the play position is allowed only in the valid zone:
overview **+-100 px** vertically and **+-50 px** horizontally

If the cursor leaves the valid area while dragging:
show a warning cursor
remove the time ruler, restore regular play pos painting

Dragging is aborted only if the **release event** happens outside.

![overview-drag-abort](https://github.com/user-attachments/assets/cbbe184a-1473-4d29-b19a-8c34674a4bce)

Also includes a fix: abort play pos dragging if passthrough is enabled while dragging

### TODO
- [ ] check if devicePixeRatio is relevant here
- [ ] make 100% sure that the cursor is reset in all possible  situations