### PR TITLE
Show wait cursor when re/loading a skin (not during startup)

### DIFF
--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -49,6 +49,7 @@
 #include "util/debug.h"
 #include "util/desktophelper.h"
 #include "util/sandbox.h"
+#include "util/scopedoverridecursor.h"
 #include "util/timer.h"
 #include "util/versionstore.h"
 #include "waveform/guitick.h"
@@ -1167,6 +1168,7 @@ void MixxxMainWindow::slotTooltipModeChanged(mixxx::preferences::Tooltips tt) {
 void MixxxMainWindow::rebootMixxxView() {
     qDebug() << "Now in rebootMixxxView...";
 
+    ScopedWaitCursor cursor;
     // safe geometry for later restoration
     const QRect initGeometry = geometry();
 


### PR DESCRIPTION
Often enough when reloading a skin during develpoment I wait and wonder if the Ctrl+Shift+R hotkey triggered a reload.

Now we see a wait cursor while the skin is being loaded, like when applying a sound config.
A dim translucent overlay while reloading would also be nice IMO.