### PR TITLE
Adding RadioLanewayCrossfade transition

### DIFF
--- a/src/analyzer/analyzersilence.cpp
+++ b/src/analyzer/analyzersilence.cpp
@@ -115,8 +115,7 @@ SINT AnalyzerSilence::findFirstFadeOutChunk(std::span<const CSAMPLE> samples) {
     // -1 is required, because the distance from the fist sample index (0) to crend() is 1,
     SINT ret = std::distance(
                        first_fade_out_sound(samples.rbegin(), samples.rend()),
-                       samples.rend()) -
-            1;
+                       samples.rend()) - 1;
     if (ret == -1) {
         ret = samples.size();
     }
@@ -126,9 +125,6 @@ SINT AnalyzerSilence::findFirstFadeOutChunk(std::span<const CSAMPLE> samples) {
 // static
 SINT AnalyzerSilence::findLastFadeInChunk(std::span<const CSAMPLE> samples) {
     SINT ret = std::distance(samples.begin(), last_fade_in_sound(samples.begin(), samples.end()));
-    //    if (ret == samples.size()) {
-    //        ret = 0;
-    //    }
     return ret;
 }
 

--- a/src/analyzer/analyzersilence.cpp
+++ b/src/analyzer/analyzersilence.cpp
@@ -115,7 +115,8 @@ SINT AnalyzerSilence::findFirstFadeOutChunk(std::span<const CSAMPLE> samples) {
     // -1 is required, because the distance from the fist sample index (0) to crend() is 1,
     SINT ret = std::distance(
                        first_fade_out_sound(samples.rbegin(), samples.rend()),
-                       samples.rend()) - 1;
+                       samples.rend()) -
+            1;
     if (ret == -1) {
         ret = samples.size();
     }

--- a/src/analyzer/analyzersilence.cpp
+++ b/src/analyzer/analyzersilence.cpp
@@ -119,11 +119,6 @@ SINT AnalyzerSilence::findFirstFadeOutChunk(std::span<const CSAMPLE> samples) {
                                      kFadeOutThreshold),
                        samples.rend()) -
             1;
-    // if we don't find it (track only partially loaded - and/or pathological)
-    // give us the track size.
-    if (ret == -1) {
-        ret = samples.size();
-    }
     return ret;
 }
 
@@ -159,14 +154,14 @@ bool AnalyzerSilence::processSamples(const CSAMPLE* pIn, SINT count) {
     }
     if (m_fadeThresholdFadeInEnd >= 0) {
         const SINT lasttSampleBeforeFadeOut = findFirstFadeOutChunk(samples);
-        if (lasttSampleBeforeFadeOut < (count - 1)) {
+        if (lasttSampleBeforeFadeOut >= 0) {
             m_fadeThresholdFadeOutStart = m_framesProcessed +
                     (lasttSampleBeforeFadeOut / m_channelCount) + 1;
         }
     }
     if (m_fadeThresholdFadeOutStart >= 0) {
         const SINT lastSoundSample = findLastSoundInChunk(samples);
-        if (lastSoundSample < (count - 1)) { // not only sound or silence
+        if (lastSoundSample >= 0) {
             m_signalEnd = m_framesProcessed + (lastSoundSample / m_channelCount) + 1;
         }
     }

--- a/src/analyzer/analyzersilence.cpp
+++ b/src/analyzer/analyzersilence.cpp
@@ -12,12 +12,34 @@ constexpr CSAMPLE kSilenceThreshold = 0.001f; // -60 dB
 // TODO: Change the above line to:
 //constexpr CSAMPLE kSilenceThreshold = db2ratio(-60.0f);
 
+// These are in dBV expressed as Volts RMS (which seems, sensibly,
+// the way Mixxx works).
+// Don't change these to const as they are used only to feed the
+// fade thresholds which are consts below themselves while we work
+// out which one is best, and you'll just be adding to exe size.
+#define N_10DB_FADEOUT_THRESHOLD 0.3162f
+#define N_12DB_FADEOUT_THRESHOLD 0.2511f
+#define N_15DB_FADEOUT_THRESHOLD 0.1778f
+#define N_18DB_FADEOUT_THRESHOLD 0.1259f
+#define N_20DB_FADEOUT_THRESHOLD 0.1f
+#define N_24DB_FADEOUT_THRESHOLD 0.0631f
+#define N_25DB_FADEOUT_THRESHOLD 0.0562f
+#define N_27DB_FADEOUT_THRESHOLD 0.0447f
+#define N_30DB_FADEOUT_THRESHOLD 0.0316f
+#define N_40DB_FADEOUT_THRESHOLD 0.01f
+
+constexpr CSAMPLE kFadeInThreshold = N_27DB_FADEOUT_THRESHOLD;
+constexpr CSAMPLE kFadeOutThreshold = N_12DB_FADEOUT_THRESHOLD;
+
+
 bool shouldAnalyze(TrackPointer pTrack) {
     CuePointer pIntroCue = pTrack->findCueByType(mixxx::CueType::Intro);
     CuePointer pOutroCue = pTrack->findCueByType(mixxx::CueType::Outro);
     CuePointer pN60dBSound = pTrack->findCueByType(mixxx::CueType::N60dBSound);
+    CuePointer pFadeIn = pTrack->findCueByType(mixxx::CueType::FadeIn);
+    CuePointer pFadeOut = pTrack->findCueByType(mixxx::CueType::FadeOut);
 
-    if (!pIntroCue || !pOutroCue || !pN60dBSound || pN60dBSound->getLengthFrames() <= 0) {
+    if (!pFadeIn || !pFadeOut || !pIntroCue || !pOutroCue || !pN60dBSound || pN60dBSound->getLengthFrames() <= 0) {
         return true;
     }
     return false;
@@ -30,13 +52,29 @@ Iterator first_sound(Iterator begin, Iterator end) {
     });
 }
 
+template<typename ForwardIterator>
+ForwardIterator last_fade_in_sound(ForwardIterator begin, ForwardIterator end) {
+    return std::find_if(begin, end, [](const auto elem) {
+        return fabs(elem) >= kFadeInThreshold;
+    });
+}
+
+template<typename Iterator>
+Iterator first_fade_out_sound(Iterator begin, Iterator end) {
+    return std::find_if(begin, end, [](const auto elem) {
+        return fabs(elem) >= kFadeOutThreshold;
+    });
+}
+
 } // anonymous namespace
 
 AnalyzerSilence::AnalyzerSilence(UserSettingsPointer pConfig)
         : m_pConfig(pConfig),
           m_framesProcessed(0),
           m_signalStart(-1),
-          m_signalEnd(-1) {
+          m_signalEnd(-1),
+          m_fadeThresholdFadeInEnd(-1),
+          m_fadeThresholdFadeOutStart(-1) {
 }
 
 bool AnalyzerSilence::initialize(const AnalyzerTrack& track,
@@ -53,6 +91,8 @@ bool AnalyzerSilence::initialize(const AnalyzerTrack& track,
     m_framesProcessed = 0;
     m_signalStart = -1;
     m_signalEnd = -1;
+    m_fadeThresholdFadeInEnd = -1;
+    m_fadeThresholdFadeOutStart = -1;
     m_channelCount = channelCount;
 
     return true;
@@ -67,6 +107,25 @@ SINT AnalyzerSilence::findFirstSoundInChunk(std::span<const CSAMPLE> samples) {
 SINT AnalyzerSilence::findLastSoundInChunk(std::span<const CSAMPLE> samples) {
     // -1 is required, because the distance from the fist sample index (0) to crend() is 1,
     SINT ret = std::distance(first_sound(samples.rbegin(), samples.rend()), samples.rend()) - 1;
+    return ret;
+}
+
+// static
+SINT AnalyzerSilence::findFirstFadeOutChunk(std::span<const CSAMPLE> samples) {
+    // -1 is required, because the distance from the fist sample index (0) to crend() is 1,
+    SINT ret = std::distance(first_fade_out_sound(samples.rbegin(), samples.rend()), samples.rend()) - 1;
+    if (ret == -1) {
+        ret = samples.size();
+    }
+    return ret;
+}
+
+// static
+SINT AnalyzerSilence::findLastFadeInChunk(std::span<const CSAMPLE> samples) {
+    SINT ret = std::distance(samples.begin(), last_fade_in_sound(samples.begin(), samples.end()));
+    //    if (ret == samples.size()) {
+    //        ret = 0;
+    //    }
     return ret;
 }
 
@@ -93,10 +152,23 @@ bool AnalyzerSilence::processSamples(const CSAMPLE* pIn, SINT count) {
             m_signalStart = m_framesProcessed + firstSoundSample / m_channelCount;
         }
     }
-    if (m_signalStart >= 0) {
+
+    if (m_fadeThresholdFadeInEnd < 0) {
+        const SINT lastSampleOfFadeIn = findLastFadeInChunk(samples);
+        if (lastSampleOfFadeIn < count) {
+            m_fadeThresholdFadeInEnd = m_framesProcessed + (lastSampleOfFadeIn / m_channelCount);
+        }
+    }
+    if (m_fadeThresholdFadeInEnd >= 0) {
+        const SINT lasttSampleBeforeFadeOut = findFirstFadeOutChunk(samples);
+        if (lasttSampleBeforeFadeOut < (count - 1)) {
+            m_fadeThresholdFadeOutStart = m_framesProcessed + (lasttSampleBeforeFadeOut / m_channelCount) + 1;
+        }
+    }
+    if (m_fadeThresholdFadeOutStart >= 0) {
         const SINT lastSoundSample = findLastSoundInChunk(samples);
-        if (lastSoundSample >= 0) {
-            m_signalEnd = m_framesProcessed + lastSoundSample / m_channelCount + 1;
+        if (lastSoundSample < (count - 1)) { // not only sound or silence
+            m_signalEnd = m_framesProcessed + (lastSoundSample / m_channelCount) + 1;
         }
     }
 
@@ -136,6 +208,36 @@ void AnalyzerSilence::storeResults(TrackPointer pTrack) {
 
     setupMainAndIntroCue(pTrack.get(), firstSoundPosition, m_pConfig.data());
     setupOutroCue(pTrack.get(), lastSoundPosition);
+
+    if (m_fadeThresholdFadeInEnd < 0) {
+        m_fadeThresholdFadeInEnd = 0;
+    }
+    if (m_fadeThresholdFadeOutStart < 0) {
+        m_fadeThresholdFadeOutStart = m_framesProcessed;
+    }
+    const auto fadeInEndPosition = mixxx::audio::FramePos(m_fadeThresholdFadeInEnd);
+    CuePointer pFadeIn = pTrack->findCueByType(mixxx::CueType::FadeIn);
+    if (pFadeIn == nullptr) {
+        pFadeIn = pTrack->createAndAddCue(
+                mixxx::CueType::FadeIn,
+                Cue::kNoHotCue,
+                firstSoundPosition,
+                fadeInEndPosition);
+    } else {
+        pFadeIn->setStartAndEndPosition(firstSoundPosition, fadeInEndPosition);
+    }
+
+    const auto fadeOutStartPosition = mixxx::audio::FramePos(m_fadeThresholdFadeOutStart);
+    CuePointer pFadeOut = pTrack->findCueByType(mixxx::CueType::FadeOut);
+    if (pFadeOut == nullptr) {
+        pFadeOut = pTrack->createAndAddCue(
+                mixxx::CueType::FadeOut,
+                Cue::kNoHotCue,
+                fadeOutStartPosition,
+                lastSoundPosition);
+    } else {
+        pFadeOut->setStartAndEndPosition(fadeOutStartPosition, lastSoundPosition);
+    }
 }
 
 // static

--- a/src/analyzer/analyzersilence.cpp
+++ b/src/analyzer/analyzersilence.cpp
@@ -12,24 +12,22 @@ constexpr CSAMPLE kSilenceThreshold = 0.001f; // -60 dB
 // TODO: Change the above line to:
 // constexpr CSAMPLE kSilenceThreshold = db2ratio(-60.0f);
 
-// These are in dBV expressed as Volts RMS (which seems, sensibly,
-// the way Mixxx works).
-// Don't change these to const as they are used only to feed the
-// fade thresholds which are consts below themselves while we work
-// out which one is best, and you'll just be adding to exe size.
-#define N_10DB_FADE_THRESHOLD 0.3162f
-#define N_12DB_FADE_THRESHOLD 0.2511f
-#define N_15DB_FADE_THRESHOLD 0.1778f
-#define N_18DB_FADE_THRESHOLD 0.1259f
-#define N_20DB_FADE_THRESHOLD 0.1f
-#define N_24DB_FADE_THRESHOLD 0.0631f
-#define N_25DB_FADE_THRESHOLD 0.0562f
-#define N_27DB_FADE_THRESHOLD 0.0447f
-#define N_30DB_FADE_THRESHOLD 0.0316f
-#define N_40DB_FADE_THRESHOLD 0.01f
+// This comment can be deleted for full release.
+// Some other values in case. These are in dBV expressed as Volts RMS 
+// (which seems, sensibly, the way Mixxx works).
+// N_10DB_FADE_THRESHOLD 0.3162f
+// N_12DB_FADE_THRESHOLD 0.2511f
+// N_15DB_FADE_THRESHOLD 0.1778f
+// N_18DB_FADE_THRESHOLD 0.1259f
+// N_20DB_FADE_THRESHOLD 0.1f
+// N_24DB_FADE_THRESHOLD 0.0631f
+// N_25DB_FADE_THRESHOLD 0.0562f
+// N_27DB_FADE_THRESHOLD 0.0447f
+// N_30DB_FADE_THRESHOLD 0.0316f
+// N_40DB_FADE_THRESHOLD 0.01f
 
-constexpr CSAMPLE kFadeInThreshold = N_27DB_FADE_THRESHOLD;
-constexpr CSAMPLE kFadeOutThreshold = N_12DB_FADE_THRESHOLD;
+constexpr CSAMPLE kFadeInThreshold = 0.0447f;
+constexpr CSAMPLE kFadeOutThreshold = 0.2511f;
 
 bool shouldAnalyze(TrackPointer pTrack) {
     CuePointer pIntroCue = pTrack->findCueByType(mixxx::CueType::Intro);
@@ -103,7 +101,7 @@ SINT AnalyzerSilence::findLastSoundInChunk(std::span<const CSAMPLE> samples) {
     return ret;
 }
 
-// Find the number of first sound sample where the sound is above kFadeInThreshold (-27db)
+// Find the index of first sound sample where the sound is above kFadeInThreshold (-27db)
 SINT AnalyzerSilence::findLastFadeInChunk(std::span<const CSAMPLE> samples) {
     SINT ret = std::distance(samples.begin(),
             find_first_above_threshold(
@@ -111,7 +109,7 @@ SINT AnalyzerSilence::findLastFadeInChunk(std::span<const CSAMPLE> samples) {
     return ret;
 }
 
-// Find the number of last sound sample where the sound is above kFadeOutThreshold (-12db)
+// Find the index of last sound sample where the sound is above kFadeOutThreshold (-12db)
 SINT AnalyzerSilence::findFirstFadeOutChunk(std::span<const CSAMPLE> samples) {
     // Note we are searching backwards from the end here.
     SINT ret = std::distance(find_first_above_threshold(samples.rbegin(),

--- a/src/analyzer/analyzersilence.cpp
+++ b/src/analyzer/analyzersilence.cpp
@@ -106,11 +106,13 @@ SINT AnalyzerSilence::findLastFadeInChunk(std::span<const CSAMPLE> samples) {
 // Find the number of last sound sample where the sound is above kFadeOutThreshold (-12db)
 SINT AnalyzerSilence::findFirstFadeOutChunk(std::span<const CSAMPLE> samples) {
     // Note we are searching backwards from the end here.
-    SINT ret = std::distance(
-                       find_first_above_threshold(samples.rbegin(), samples.rend(), kFadeOutThreshold),
+    SINT ret = std::distance(find_first_above_threshold(samples.rbegin(),
+                                     samples.rend(),
+                                     kFadeOutThreshold),
                        samples.rend()) -
             1;
-    // if we don't find it (track only partially loaded - and/or pathological) give us the track size.
+    // if we don't find it (track only partially loaded - and/or pathological)
+    // give us the track size.
     if (ret == -1) {
         ret = samples.size();
     }

--- a/src/analyzer/analyzersilence.cpp
+++ b/src/analyzer/analyzersilence.cpp
@@ -13,7 +13,7 @@ constexpr CSAMPLE kSilenceThreshold = 0.001f; // -60 dB
 // constexpr CSAMPLE kSilenceThreshold = db2ratio(-60.0f);
 
 // This comment can be deleted for full release.
-// Some other values in case. These are in dBV expressed as Volts RMS 
+// Some other values in case. These are in dBV expressed as Volts RMS
 // (which seems, sensibly, the way Mixxx works).
 // N_10DB_FADE_THRESHOLD 0.3162f
 // N_12DB_FADE_THRESHOLD 0.2511f

--- a/src/analyzer/analyzersilence.cpp
+++ b/src/analyzer/analyzersilence.cpp
@@ -87,19 +87,27 @@ bool AnalyzerSilence::initialize(const AnalyzerTrack& track,
 
 // static
 SINT AnalyzerSilence::findFirstSoundInChunk(std::span<const CSAMPLE> samples) {
-    return std::distance(samples.begin(), find_first_above_threshold(samples.begin(), samples.end(), kSilenceThreshold));
+    return std::distance(samples.begin(),
+            find_first_above_threshold(
+                    samples.begin(), samples.end(), kSilenceThreshold));
 }
 
 // static
 SINT AnalyzerSilence::findLastSoundInChunk(std::span<const CSAMPLE> samples) {
     // -1 is required, because the distance from the fist sample index (0) to crend() is 1,
-    SINT ret = std::distance(find_first_above_threshold(samples.rbegin(), samples.rend(), kSilenceThreshold), samples.rend()) - 1;
+    SINT ret = std::distance(find_first_above_threshold(samples.rbegin(),
+                                     samples.rend(),
+                                     kSilenceThreshold),
+                       samples.rend()) -
+            1;
     return ret;
 }
 
 // Find the number of first sound sample where the sound is above kFadeInThreshold (-27db)
 SINT AnalyzerSilence::findLastFadeInChunk(std::span<const CSAMPLE> samples) {
-    SINT ret = std::distance(samples.begin(), find_first_above_threshold(samples.begin(), samples.end(), kFadeInThreshold));
+    SINT ret = std::distance(samples.begin(),
+            find_first_above_threshold(
+                    samples.begin(), samples.end(), kFadeInThreshold));
     return ret;
 }
 

--- a/src/analyzer/analyzersilence.cpp
+++ b/src/analyzer/analyzersilence.cpp
@@ -26,8 +26,8 @@ constexpr CSAMPLE kSilenceThreshold = 0.001f; // -60 dB
 // N_30DB_FADE_THRESHOLD 0.0316f
 // N_40DB_FADE_THRESHOLD 0.01f
 
-constexpr CSAMPLE kFadeInThreshold = 0.0447f;
-constexpr CSAMPLE kFadeOutThreshold = 0.2511f;
+constexpr CSAMPLE kFadeInThreshold = 0.0447f;  // -27 dBV
+constexpr CSAMPLE kFadeOutThreshold = 0.2511f; // -12 dBV
 
 bool shouldAnalyze(TrackPointer pTrack) {
     CuePointer pIntroCue = pTrack->findCueByType(mixxx::CueType::Intro);

--- a/src/analyzer/analyzersilence.cpp
+++ b/src/analyzer/analyzersilence.cpp
@@ -38,7 +38,8 @@ bool shouldAnalyze(TrackPointer pTrack) {
     CuePointer pFadeIn = pTrack->findCueByType(mixxx::CueType::FadeIn);
     CuePointer pFadeOut = pTrack->findCueByType(mixxx::CueType::FadeOut);
 
-    if (!pFadeIn || !pFadeOut || !pIntroCue || !pOutroCue || !pN60dBSound || pN60dBSound->getLengthFrames() <= 0) {
+    if (!pFadeIn || !pFadeOut || !pIntroCue || !pOutroCue || !pN60dBSound ||
+            pN60dBSound->getLengthFrames() <= 0) {
         return true;
     }
     return false;
@@ -112,7 +113,10 @@ SINT AnalyzerSilence::findLastSoundInChunk(std::span<const CSAMPLE> samples) {
 // static
 SINT AnalyzerSilence::findFirstFadeOutChunk(std::span<const CSAMPLE> samples) {
     // -1 is required, because the distance from the fist sample index (0) to crend() is 1,
-    SINT ret = std::distance(first_fade_out_sound(samples.rbegin(), samples.rend()), samples.rend()) - 1;
+    SINT ret = std::distance(
+                       first_fade_out_sound(samples.rbegin(), samples.rend()),
+                       samples.rend()) -
+            1;
     if (ret == -1) {
         ret = samples.size();
     }
@@ -161,7 +165,8 @@ bool AnalyzerSilence::processSamples(const CSAMPLE* pIn, SINT count) {
     if (m_fadeThresholdFadeInEnd >= 0) {
         const SINT lasttSampleBeforeFadeOut = findFirstFadeOutChunk(samples);
         if (lasttSampleBeforeFadeOut < (count - 1)) {
-            m_fadeThresholdFadeOutStart = m_framesProcessed + (lasttSampleBeforeFadeOut / m_channelCount) + 1;
+            m_fadeThresholdFadeOutStart = m_framesProcessed +
+                    (lasttSampleBeforeFadeOut / m_channelCount) + 1;
         }
     }
     if (m_fadeThresholdFadeOutStart >= 0) {

--- a/src/analyzer/analyzersilence.cpp
+++ b/src/analyzer/analyzersilence.cpp
@@ -10,7 +10,7 @@ namespace {
 // verify that the track samples have not changed since the last analysis
 constexpr CSAMPLE kSilenceThreshold = 0.001f; // -60 dB
 // TODO: Change the above line to:
-//constexpr CSAMPLE kSilenceThreshold = db2ratio(-60.0f);
+// constexpr CSAMPLE kSilenceThreshold = db2ratio(-60.0f);
 
 // These are in dBV expressed as Volts RMS (which seems, sensibly,
 // the way Mixxx works).
@@ -30,7 +30,6 @@ constexpr CSAMPLE kSilenceThreshold = 0.001f; // -60 dB
 
 constexpr CSAMPLE kFadeInThreshold = N_27DB_FADEOUT_THRESHOLD;
 constexpr CSAMPLE kFadeOutThreshold = N_12DB_FADEOUT_THRESHOLD;
-
 
 bool shouldAnalyze(TrackPointer pTrack) {
     CuePointer pIntroCue = pTrack->findCueByType(mixxx::CueType::Intro);

--- a/src/analyzer/analyzersilence.h
+++ b/src/analyzer/analyzersilence.h
@@ -35,12 +35,11 @@ class AnalyzerSilence : public Analyzer {
     static void setupOutroCue(Track* pTrack, mixxx::audio::FramePos lastSoundPosition);
 
     /// returns the index of the first sample in the buffer that is above the
-    /// fade out threshold (e.g. -20 dB) or samples.size() if no sample is found
-    /// TODO CHeck if 'samples.size()' is actually meaningful in this context.
+    /// fade in threshold (e.g. -27 dB).
     static SINT findLastFadeInChunk(std::span<const CSAMPLE> samples);
 
-    /// returns the index of the last sample in the buffer that is above that is
-    /// above the fade out threshold (e.g. -20 dB) or samples.size() if no
+    /// returns the index of the last sample in the buffer that is
+    /// above the fade out threshold (e.g. -12 dB) or samples.size() if no
     /// sample is found
     static SINT findFirstFadeOutChunk(std::span<const CSAMPLE> samples);
 

--- a/src/analyzer/analyzersilence.h
+++ b/src/analyzer/analyzersilence.h
@@ -34,13 +34,13 @@ class AnalyzerSilence : public Analyzer {
             UserSettings* pConfig);
     static void setupOutroCue(Track* pTrack, mixxx::audio::FramePos lastSoundPosition);
 
-    /// returns the index of the first sample in the buffer that is above the 
+    /// returns the index of the first sample in the buffer that is above the
     /// fade out threshold (e.g. -20 dB) or samples.size() if no sample is found
     /// TODO CHeck if 'samples.size()' is actually meaningful in this context.
     static SINT findLastFadeInChunk(std::span<const CSAMPLE> samples);
 
-    /// returns the index of the last sample in the buffer that is above that is 
-    /// above the fade out threshold (e.g. -20 dB) or samples.size() if no 
+    /// returns the index of the last sample in the buffer that is above that is
+    /// above the fade out threshold (e.g. -20 dB) or samples.size() if no
     /// sample is found
     static SINT findFirstFadeOutChunk(std::span<const CSAMPLE> samples);
 

--- a/src/analyzer/analyzersilence.h
+++ b/src/analyzer/analyzersilence.h
@@ -34,13 +34,14 @@ class AnalyzerSilence : public Analyzer {
             UserSettings* pConfig);
     static void setupOutroCue(Track* pTrack, mixxx::audio::FramePos lastSoundPosition);
 
-    /// returns the index of the first sample in the buffer that is above the fade out threshold (e.g. -20 dB)
-    /// or samples.size() if no sample is found
+    /// returns the index of the first sample in the buffer that is above the 
+    /// fade out threshold (e.g. -20 dB) or samples.size() if no sample is found
     /// TODO CHeck if 'samples.size()' is actually meaningful in this context.
     static SINT findLastFadeInChunk(std::span<const CSAMPLE> samples);
 
-    /// returns the index of the last sample in the buffer that is above that is above the fade out threshold (e.g. -20 dB)
-    /// or samples.size() if no sample is found
+    /// returns the index of the last sample in the buffer that is above that is 
+    /// above the fade out threshold (e.g. -20 dB) or samples.size() if no 
+    /// sample is found
     static SINT findFirstFadeOutChunk(std::span<const CSAMPLE> samples);
 
     /// returns the index of the first sample in the buffer that is above -60 dB

--- a/src/analyzer/analyzersilence.h
+++ b/src/analyzer/analyzersilence.h
@@ -34,6 +34,15 @@ class AnalyzerSilence : public Analyzer {
             UserSettings* pConfig);
     static void setupOutroCue(Track* pTrack, mixxx::audio::FramePos lastSoundPosition);
 
+    /// returns the index of the first sample in the buffer that is above the fade out threshold (e.g. -20 dB)
+    /// or samples.size() if no sample is found
+    /// TODO CHeck if 'samples.size()' is actually meaningful in this context.
+    static SINT findLastFadeInChunk(std::span<const CSAMPLE> samples);
+
+    /// returns the index of the last sample in the buffer that is above that is above the fade out threshold (e.g. -20 dB)
+    /// or samples.size() if no sample is found
+    static SINT findFirstFadeOutChunk(std::span<const CSAMPLE> samples);
+
     /// returns the index of the first sample in the buffer that is above -60 dB
     /// or samples.size() if no sample is found
     static SINT findFirstSoundInChunk(std::span<const CSAMPLE> samples);
@@ -56,4 +65,6 @@ class AnalyzerSilence : public Analyzer {
     SINT m_framesProcessed;
     SINT m_signalStart;
     SINT m_signalEnd;
+    SINT m_fadeThresholdFadeInEnd;
+    SINT m_fadeThresholdFadeOutStart;
 };

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -1691,7 +1691,7 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
         }
 
         // Note as we get here pFromDeck->playNextPos == fromDeckEndPosition.
-        // We use this default to make sure that playNextPos is alway greater than
+        // We use this default to make sure that playNextPos is always greater than
         // pFromDeck->fadeBeginPos unless we really intend to start early.
 
         // If we have a long(ish) fade in then let's start the next track early.
@@ -1732,7 +1732,8 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
             } else {
                 // This is the general case where we want to do a fadeout when
                 // after (sound level last goes below) Cue:FadOut start.
-                // and we start early while for (the sound level starts below) the duration Cue:FadIn end.
+                // and we start early while for (the sound level starts below)
+                // the duration Cue:FadIn end.
                 pFromDeck->fadeEndPos = fadeOutEnd;
             }
         } else {

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -1731,9 +1731,9 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
                 }
             } else {
                 // This is the general case where we want to do a fadeout when
-                // after (sound level last goes below) Cue:FadOut start.
-                // and we start early while for (the sound level starts below)
-                // the duration Cue:FadIn end.
+                // after (sound level last goes below) Cue:FadOut start
+                // and/or we start early until (the sound level is above) 
+                // Cue:FadeIn end.
                 pFromDeck->fadeEndPos = fadeOutEnd;
             }
         } else {

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -1732,7 +1732,7 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
             } else {
                 // This is the general case where we want to do a fadeout when
                 // after (sound level last goes below) Cue:FadOut start
-                // and/or we start early until (the sound level is above) 
+                // and/or we start early until (the sound level is above)
                 // Cue:FadeIn end.
                 pFromDeck->fadeEndPos = fadeOutEnd;
             }

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -44,12 +44,9 @@ DeckAttributes::DeckAttributes(int index,
           m_sampleRate(group, "track_samplerate"),
           m_rateRatio(group, "rate_ratio"),
           m_pPlayer(pPlayer) {
-    connect(m_pPlayer, &BaseTrackPlayer::newTrackLoaded,
-            this, &DeckAttributes::slotTrackLoaded);
-    connect(m_pPlayer, &BaseTrackPlayer::loadingTrack,
-            this, &DeckAttributes::slotLoadingTrack);
-    connect(m_pPlayer, &BaseTrackPlayer::playerEmpty,
-            this, &DeckAttributes::slotPlayerEmpty);
+    connect(m_pPlayer, &BaseTrackPlayer::newTrackLoaded, this, &DeckAttributes::slotTrackLoaded);
+    connect(m_pPlayer, &BaseTrackPlayer::loadingTrack, this, &DeckAttributes::slotLoadingTrack);
+    connect(m_pPlayer, &BaseTrackPlayer::playerEmpty, this, &DeckAttributes::slotPlayerEmpty);
     m_playPos.connectValueChanged(this, &DeckAttributes::slotPlayPosChanged);
     m_play.connectValueChanged(this, &DeckAttributes::slotPlayChanged);
     m_introStartPos.connectValueChanged(this, &DeckAttributes::slotIntroStartPositionChanged);
@@ -91,7 +88,7 @@ void DeckAttributes::slotTrackLoaded(TrackPointer pTrack) {
 }
 
 void DeckAttributes::slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack) {
-    //qDebug() << "DeckAttributes::slotLoadingTrack";
+    // qDebug() << "DeckAttributes::slotLoadingTrack";
     emit loadingTrack(this, pNewTrack, pOldTrack);
 }
 
@@ -134,8 +131,7 @@ AutoDJProcessor::AutoDJProcessor(
 
     m_pSkipNext = new ControlPushButton(
             ConfigKey("[AutoDJ]", "skip_next"));
-    connect(m_pSkipNext, &ControlObject::valueChanged,
-            this, &AutoDJProcessor::controlSkipNext);
+    connect(m_pSkipNext, &ControlObject::valueChanged, this, &AutoDJProcessor::controlSkipNext);
 
     m_pAddRandomTrack = new ControlPushButton(
             ConfigKey("[AutoDJ]", "add_random_track"));
@@ -146,8 +142,7 @@ AutoDJProcessor::AutoDJProcessor(
 
     m_pFadeNow = new ControlPushButton(
             ConfigKey("[AutoDJ]", "fade_now"));
-    connect(m_pFadeNow, &ControlObject::valueChanged,
-            this, &AutoDJProcessor::controlFadeNow);
+    connect(m_pFadeNow, &ControlObject::valueChanged, this, &AutoDJProcessor::controlFadeNow);
 
     m_pEnabledAutoDJ = new ControlPushButton(
             ConfigKey("[AutoDJ]", "enabled"));
@@ -368,7 +363,7 @@ AutoDJProcessor::AutoDJError AutoDJProcessor::skipNext() {
         TrackId leftId = pLeftDeck->getLoadedTrack()->getId();
         TrackId rightId = pRightDeck->getLoadedTrack()->getId();
         if (nextId == leftId || nextId == rightId) {
-        // One of the playing tracks is still on top of playlist, remove second item
+            // One of the playing tracks is still on top of playlist, remove second item
             m_pAutoDJTableModel->removeTrack(m_pAutoDJTableModel->index(1, 0));
         } else {
             m_pAutoDJTableModel->removeTrack(m_pAutoDJTableModel->index(0, 0));
@@ -675,7 +670,7 @@ void AutoDJProcessor::crossfaderChanged(double value) {
 }
 
 void AutoDJProcessor::playerPositionChanged(DeckAttributes* pAttributes,
-                                            double thisPlayPosition) {
+        double thisPlayPosition) {
     // qDebug() << "player" << pAttributes->group << "PositionChanged(" << value << ")";
     if (m_eState == ADJ_DISABLED) {
         // nothing to do
@@ -839,8 +834,8 @@ void AutoDJProcessor::playerPositionChanged(DeckAttributes* pAttributes,
     // - transition into fading mode, play the other deck and fade to it.
     // - check if fading is done and stop the deck
     // - update the crossfader
-    if ((thisPlayPosition >= thisDeck->fadeBeginPos) && 
-        thisDeck->isFromDeck && !otherDeck->loading) {
+    if ((thisPlayPosition >= thisDeck->fadeBeginPos) &&
+            thisDeck->isFromDeck && !otherDeck->loading) {
         if (m_eState == ADJ_IDLE) {
             if (thisDeckPlaying || thisPlayPosition >= 1.0) {
                 // Set the state as FADING.
@@ -934,7 +929,8 @@ TrackPointer AutoDJProcessor::getNextTrackFromQueue() {
     bool randomQueueEnabled = m_pConfig->getValue<bool>(
             ConfigKey("[Auto DJ]", "EnableRandomQueue"));
     int minAutoDJCrateTracks = m_pConfig->getValueString(
-            ConfigKey(kConfigKey, "RandomQueueMinimumAllowed")).toInt();
+                                                ConfigKey(kConfigKey, "RandomQueueMinimumAllowed"))
+                                       .toInt();
     int tracksToAdd = minAutoDJCrateTracks - m_pAutoDJTableModel->rowCount();
     // In case we start off with < minimum tracks
     if (randomQueueEnabled && (tracksToAdd > 0)) {
@@ -943,7 +939,7 @@ TrackPointer AutoDJProcessor::getNextTrackFromQueue() {
 
     while (true) {
         TrackPointer nextTrack = m_pAutoDJTableModel->getTrack(
-            m_pAutoDJTableModel->index(0, 0));
+                m_pAutoDJTableModel->index(0, 0));
 
         if (nextTrack) {
             if (nextTrack->getFileInfo().checkFileExists()) {
@@ -1022,9 +1018,11 @@ bool AutoDJProcessor::removeTrackFromTopOfQueue(TrackPointer pTrack) {
 
 void AutoDJProcessor::maybeFillRandomTracks() {
     int minAutoDJCrateTracks = m_pConfig->getValueString(
-            ConfigKey(kConfigKey, "RandomQueueMinimumAllowed")).toInt();
+                                                ConfigKey(kConfigKey, "RandomQueueMinimumAllowed"))
+                                       .toInt();
     bool randomQueueEnabled = (((m_pConfig->getValueString(
-            ConfigKey("[Auto DJ]", "EnableRandomQueue")).toInt())) == 1);
+                                                  ConfigKey("[Auto DJ]", "EnableRandomQueue"))
+                                               .toInt())) == 1);
 
     int tracksToAdd = minAutoDJCrateTracks - m_pAutoDJTableModel->rowCount();
     if (randomQueueEnabled && (tracksToAdd > 0)) {
@@ -1370,13 +1368,13 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
     const double fromDeckEndPosition = getEndSecond(pFromDeck);
     const double toDeckEndPosition = getEndSecond(pToDeck);
     // Make sure playNextPos is higher than fadeBeginPos by default
-    pFromDeck->playNextPos = fromDeckEndPosition; 
+    pFromDeck->playNextPos = fromDeckEndPosition;
     // Since the end position is measured in seconds from 0:00 it is also
     // the track duration. Use this alias for better readability.
     const double fromDeckDuration = fromDeckEndPosition;
     const double toDeckDuration = toDeckEndPosition;
     // Make sure playNextPos is higher than fadeBeginPos by default
-    pToDeck->playNextPos = toDeckEndPosition; 
+    pToDeck->playNextPos = toDeckEndPosition;
 
     VERIFY_OR_DEBUG_ASSERT(fromDeckDuration >= kMinimumTrackDurationSec) {
         // Track has no duration or too short. This should not happen, because short
@@ -1661,7 +1659,7 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
         // we have a pathologically long fade in...
         // it might be the track... it might be the db...
         // ... but this happens on most calculateTransition save the last:
-        // There are  multiple calls to calculateTransition it seems that fadeInEnd 
+        // There are  multiple calls to calculateTransition it seems that fadeInEnd
         // collects spurious data about the fade in position
         // until the lat call (is pDeck->rateRatio() correct all the time?).
         // Placing this here seems to prevent anything weird happening for a short
@@ -1669,7 +1667,6 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
         if (fadeInEnd > (fromDeckEndPosition / 1.2)) {
             fadeInEnd = fadeInStart;
         }
-
 
         // If we are still early (it might be a very short current track) then
         // the FadeInLength is likely to end up as 0 which on a short track
@@ -1763,7 +1760,7 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
             startPoint = toDeckPositionSeconds;
         }
         useFixedFadeTime(pFromDeck, pToDeck, fromDeckPosition, fromDeckEndPosition, startPoint);
-        }
+    }
     }
 
     // These are expected to be a fraction of the track length.
@@ -1897,7 +1894,8 @@ void AutoDJProcessor::playerTrackLoaded(DeckAttributes* pDeck, TrackPointer pTra
 }
 
 void AutoDJProcessor::playerLoadingTrack(DeckAttributes* pDeck,
-        TrackPointer pNewTrack, TrackPointer pOldTrack) {
+        TrackPointer pNewTrack,
+        TrackPointer pOldTrack) {
     if constexpr (sDebug) {
         qDebug() << this << "playerLoadingTrack" << pDeck->group
                  << "new:" << (pNewTrack ? pNewTrack->getLocation() : "(null)")
@@ -1983,7 +1981,7 @@ void AutoDJProcessor::setTransitionTime(int time) {
 
     // Update the transition time first.
     m_pConfig->set(ConfigKey(kConfigKey, kTransitionPreferenceName),
-                   ConfigValue(time));
+            ConfigValue(time));
     m_transitionTime = time;
 
     // Then re-calculate fade thresholds for the decks.

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -434,8 +434,8 @@ AutoDJProcessor::AutoDJError AutoDJProcessor::toggleAutoDJ(bool enable) {
             }
         }
 
-        TrackPointer nextTrack = getNextTrackFromQueue();
-        if (!nextTrack) {
+        TrackPointer pNextTrack = getNextTrackFromQueue();
+        if (!pNextTrack) {
             qDebug() << "Queue is empty now, disable Auto DJ";
             m_pEnabledAutoDJ->setAndConfirm(0.0);
             emitAutoDJStateChanged(m_eState);
@@ -558,7 +558,7 @@ AutoDJProcessor::AutoDJError AutoDJProcessor::toggleAutoDJ(bool enable) {
             // Load track into the left deck and play. Once it starts playing,
             // we will receive a playerPositionChanged update for deck 1 which
             // will load a track into the right deck and switch to IDLE mode.
-            emitLoadTrackToPlayer(nextTrack, pLeftDeck->group, true);
+            emitLoadTrackToPlayer(pNextTrack, pLeftDeck->group, true);
         } else {
             // One of the two decks is playing. Switch into IDLE mode and wait
             // until the playing deck crosses posThreshold to start fading.
@@ -566,12 +566,12 @@ AutoDJProcessor::AutoDJError AutoDJProcessor::toggleAutoDJ(bool enable) {
             m_isNowStartingEarly = false;
             if (leftDeckPlaying) {
                 // Load track into the right deck.
-                emitLoadTrackToPlayer(nextTrack, pRightDeck->group, false);
+                emitLoadTrackToPlayer(pNextTrack, pRightDeck->group, false);
                 // Move crossfader to the left.
                 setCrossfader(-1.0);
             } else {
                 // Load track into the left deck.
-                emitLoadTrackToPlayer(nextTrack, pLeftDeck->group, false);
+                emitLoadTrackToPlayer(pNextTrack, pLeftDeck->group, false);
                 // Move crossfader to the right.
                 setCrossfader(1.0);
             }
@@ -938,12 +938,12 @@ TrackPointer AutoDJProcessor::getNextTrackFromQueue() {
     }
 
     while (true) {
-        TrackPointer nextTrack = m_pAutoDJTableModel->getTrack(
+        TrackPointer pNextTrack = m_pAutoDJTableModel->getTrack(
                 m_pAutoDJTableModel->index(0, 0));
 
-        if (nextTrack) {
-            if (nextTrack->getFileInfo().checkFileExists()) {
-                return nextTrack;
+        if (pNextTrack) {
+            if (pNextTrack->getFileInfo().checkFileExists()) {
+                return pNextTrack;
             } else {
                 // Remove missing song from auto DJ playlist.
                 m_pAutoDJTableModel->removeTrack(
@@ -951,25 +951,25 @@ TrackPointer AutoDJProcessor::getNextTrackFromQueue() {
             }
         } else {
             // We're out of tracks. Return the null TrackPointer.
-            return nextTrack;
+            return pNextTrack;
         }
     }
 }
 
 bool AutoDJProcessor::loadNextTrackFromQueue(const DeckAttributes& deck, bool play) {
-    TrackPointer nextTrack = getNextTrackFromQueue();
+    TrackPointer pNextTrack = getNextTrackFromQueue();
 
     // We ran out of tracks in the queue.
-    if (!nextTrack) {
+    if (!pNextTrack) {
         // Disable AutoDJ.
         toggleAutoDJ(false);
 
-        // And eject track (nextTrack is null) as "End of auto DJ warning"
-        emitLoadTrackToPlayer(nextTrack, deck.group, false);
+        // And eject track (pNextTrack is null) as "End of auto DJ warning"
+        emitLoadTrackToPlayer(pNextTrack, deck.group, false);
         return false;
     }
 
-    emitLoadTrackToPlayer(nextTrack, deck.group, play);
+    emitLoadTrackToPlayer(pNextTrack, deck.group, play);
     return true;
 }
 

--- a/src/library/autodj/autodjprocessor.h
+++ b/src/library/autodj/autodjprocessor.h
@@ -118,6 +118,7 @@ class DeckAttributes : public QObject {
     int index;
     QString group;
     double startPos;     // Set in toDeck nature
+    double playNextPos;  // Needed for Radio Laneway Crossfade
     double fadeBeginPos; // set in fromDeck nature
     double fadeEndPos;   // set in fromDeck nature
     bool isFromDeck;
@@ -164,7 +165,8 @@ class AutoDJProcessor : public QObject {
         FadeAtOutroStart,
         FixedFullTrack,
         FixedSkipSilence,
-        FixedStartCenterSkipSilence
+        FixedStartCenterSkipSilence,
+        RadioLanewayCrossfade
     };
 
     AutoDJProcessor(QObject* pParent,
@@ -254,6 +256,9 @@ class AutoDJProcessor : public QObject {
     double getFirstSoundSecond(DeckAttributes* pDeck);
     double getLastSoundSecond(DeckAttributes* pDeck);
     double getEndSecond(DeckAttributes* pDeck);
+    double getMainCueSecond(DeckAttributes* pDeck);
+    double getFadeInSecond(DeckAttributes* pDeck);
+    double getFadeOutSecond(DeckAttributes* pDeck);
     double framePositionToSeconds(mixxx::audio::FramePos position, DeckAttributes* pDeck);
 
     TrackPointer getNextTrackFromQueue();
@@ -284,6 +289,7 @@ class AutoDJProcessor : public QObject {
     PlaylistTableModel* m_pAutoDJTableModel;
 
     AutoDJState m_eState;
+    bool m_isNowStartingEarly;
     double m_transitionProgress;
     double m_transitionTime; // the desired value set by the user
     TransitionMode m_transitionMode;

--- a/src/library/autodj/dlgautodj.cpp
+++ b/src/library/autodj/dlgautodj.cpp
@@ -150,7 +150,13 @@ DlgAutoDJ::DlgAutoDJ(WLibrary* parent,
             "\n"
             "Skip Silence Start Full Volume:\n"
             "The same as Skip Silence, but starting transitions with a centered\n"
-            "crossfader, so that the intro starts at full volume.\n");
+            "crossfader, so that the intro starts at full volume.\n"
+            "Radio Laneway Crossfade:\n"
+            "Starts the next track at full volume.  Starts the crossfade when the\n" 
+            "volume last falls below -12Db or at the spin box setting which ever\n" 
+            "is lower, and potentially starts the next earlier if it starts below\n"
+            "-27Db.\n");
+
 
     pushButtonFadeNow->setToolTip(fadeBtnTooltip);
     pushButtonSkipNext->setToolTip(skipBtnTooltip);
@@ -185,6 +191,8 @@ DlgAutoDJ::DlgAutoDJ(WLibrary* parent,
             static_cast<int>(AutoDJProcessor::TransitionMode::FixedSkipSilence));
     fadeModeCombobox->addItem(tr("Skip Silence Start Full Volume"),
             static_cast<int>(AutoDJProcessor::TransitionMode::FixedStartCenterSkipSilence));
+    fadeModeCombobox->addItem(tr("Radio Laneway Crossfade"),
+            static_cast<int>(AutoDJProcessor::TransitionMode::RadioLanewayCrossfade));
     fadeModeCombobox->setCurrentIndex(
             fadeModeCombobox->findData(static_cast<int>(m_pAutoDJProcessor->getTransitionMode())));
     connect(fadeModeCombobox,

--- a/src/library/autodj/dlgautodj.cpp
+++ b/src/library/autodj/dlgautodj.cpp
@@ -152,11 +152,12 @@ DlgAutoDJ::DlgAutoDJ(WLibrary* parent,
             "Skip Silence Start Full Volume:\n"
             "The same as Skip Silence, but starting transitions with a centered\n"
             "crossfader, so that the intro starts at full volume.\n"
+            "\n"
             "Radio Laneway Crossfade:\n"
             "Starts the next track at full volume.  Starts the crossfade when the\n"
             "volume last falls below -12Db or at the spin box setting which ever\n"
             "is lower, and potentially starts the next earlier if it starts below\n"
-            "-27Db.\n");
+            "-27Db.");
 
     pushButtonFadeNow->setToolTip(fadeBtnTooltip);
     pushButtonSkipNext->setToolTip(skipBtnTooltip);

--- a/src/library/autodj/dlgautodj.cpp
+++ b/src/library/autodj/dlgautodj.cpp
@@ -71,8 +71,7 @@ DlgAutoDJ::DlgAutoDJ(WLibrary* parent,
 
     QBoxLayout* box = qobject_cast<QBoxLayout*>(layout());
     VERIFY_OR_DEBUG_ASSERT(box) { // Assumes the form layout is a QVBox/QHBoxLayout!
-    }
-    else {
+    } else {
         box->removeWidget(m_pTrackTablePlaceholder);
         m_pTrackTablePlaceholder->hide();
         box->insertWidget(1, m_pTrackTableView);

--- a/src/library/autodj/dlgautodj.cpp
+++ b/src/library/autodj/dlgautodj.cpp
@@ -71,7 +71,8 @@ DlgAutoDJ::DlgAutoDJ(WLibrary* parent,
 
     QBoxLayout* box = qobject_cast<QBoxLayout*>(layout());
     VERIFY_OR_DEBUG_ASSERT(box) { // Assumes the form layout is a QVBox/QHBoxLayout!
-    } else {
+    }
+    else {
         box->removeWidget(m_pTrackTablePlaceholder);
         m_pTrackTablePlaceholder->hide();
         box->insertWidget(1, m_pTrackTableView);

--- a/src/library/autodj/dlgautodj.cpp
+++ b/src/library/autodj/dlgautodj.cpp
@@ -70,8 +70,9 @@ DlgAutoDJ::DlgAutoDJ(WLibrary* parent,
             &WTrackTableView::setSelectedClick);
 
     QBoxLayout* box = qobject_cast<QBoxLayout*>(layout());
-    VERIFY_OR_DEBUG_ASSERT(box) { //Assumes the form layout is a QVBox/QHBoxLayout!
-    } else {
+    VERIFY_OR_DEBUG_ASSERT(box) { // Assumes the form layout is a QVBox/QHBoxLayout!
+    }
+    else {
         box->removeWidget(m_pTrackTablePlaceholder);
         m_pTrackTablePlaceholder->hide();
         box->insertWidget(1, m_pTrackTableView);
@@ -82,7 +83,7 @@ DlgAutoDJ::DlgAutoDJ(WLibrary* parent,
     m_pTrackTableView->loadTrackModel(m_pAutoDJTableModel);
 
     // Do not set this because it disables auto-scrolling
-    //m_pTrackTableView->setDragDropMode(QAbstractItemView::InternalMove);
+    // m_pTrackTableView->setDragDropMode(QAbstractItemView::InternalMove);
 
     connect(pushButtonAutoDJ,
             &QPushButton::clicked,
@@ -152,11 +153,10 @@ DlgAutoDJ::DlgAutoDJ(WLibrary* parent,
             "The same as Skip Silence, but starting transitions with a centered\n"
             "crossfader, so that the intro starts at full volume.\n"
             "Radio Laneway Crossfade:\n"
-            "Starts the next track at full volume.  Starts the crossfade when the\n" 
-            "volume last falls below -12Db or at the spin box setting which ever\n" 
+            "Starts the next track at full volume.  Starts the crossfade when the\n"
+            "volume last falls below -12Db or at the spin box setting which ever\n"
             "is lower, and potentially starts the next earlier if it starts below\n"
             "-27Db.\n");
-
 
     pushButtonFadeNow->setToolTip(fadeBtnTooltip);
     pushButtonSkipNext->setToolTip(skipBtnTooltip);

--- a/src/track/cueinfo.cpp
+++ b/src/track/cueinfo.cpp
@@ -23,6 +23,8 @@ void assertEndPosition(
     case CueType::Intro:
     case CueType::Outro:
     case CueType::Invalid:
+    case CueType::FadeIn:
+    case CueType::FadeOut:
         break;
     case CueType::Beat: // unused
     default:

--- a/src/track/cueinfo.cpp
+++ b/src/track/cueinfo.cpp
@@ -148,6 +148,12 @@ QDebug operator<<(QDebug debug, const CueType& cueType) {
     case CueType::N60dBSound:
         debug << "CueType::N60dBSound";
         break;
+    case CueType::FadeIn:
+        debug << "CueType::FadeIn";
+        break;
+    case CueType::FadeOut:
+        debug << "CueType::FadeOut";
+        break;
     }
     return debug;
 }

--- a/src/track/cueinfo.h
+++ b/src/track/cueinfo.h
@@ -19,10 +19,9 @@ enum class CueType {
     Outro = 7,
     N60dBSound = 8, // range that covers beginning and end of audible
                     // sound; not shown to user
-                    // sound; not shown to user
     FadeIn = 9,     // First time sound reaches a certain level
                     // (cf analyzersilence.cpp);  not shown to user
-    FadeOut = 10   // Last time sound reaches a certain level 
+    FadeOut = 10    // Last time sound reaches a certain level
                     // (cf analyzersilence.cpp);  not shown to user
 };
 

--- a/src/track/cueinfo.h
+++ b/src/track/cueinfo.h
@@ -19,6 +19,11 @@ enum class CueType {
     Outro = 7,
     N60dBSound = 8, // range that covers beginning and end of audible
                     // sound; not shown to user
+                    // sound; not shown to user
+    FadeIn = 9,     // First time sound reaches a certain level
+                    // (cf analyzersilence.cpp);  not shown to user
+    FadeOut = 10   // Last time sound reaches a certain level 
+                    // (cf analyzersilence.cpp);  not shown to user
 };
 
 enum class CueFlag {

--- a/src/track/cueinfo.h
+++ b/src/track/cueinfo.h
@@ -19,10 +19,14 @@ enum class CueType {
     Outro = 7,
     N60dBSound = 8, // range that covers beginning and end of audible
                     // sound; not shown to user
-    FadeIn = 9,     // First time sound reaches a certain level
-                    // (cf analyzersilence.cpp);  not shown to user
-    FadeOut = 10    // Last time sound reaches a certain level
-                    // (cf analyzersilence.cpp);  not shown to user
+    FadeIn = 9,     // Range from start of track to the first sample in
+                    // the track where the sound volume was above the
+                    // kFadeInThreshold (cf analyzersilence.cpp);
+                    // not shown to user
+    FadeOut = 10    // Range from the last sample in the track where
+                    // the sound volume was above the kFadeOutThreshold
+                    // to the end of the track (cf analyzersilence.cpp);
+                    // not shown to user
 };
 
 enum class CueFlag {

--- a/src/track/cueinfo.h
+++ b/src/track/cueinfo.h
@@ -19,7 +19,7 @@ enum class CueType {
     Outro = 7,
     N60dBSound = 8, // range that covers beginning and end of audible
                     // sound; not shown to user
-    FadeIn = 9,     // Range from start of track to the first sample in
+    FadeIn = 9,     // Range from the start of track to the first sample in
                     // the track where the sound volume was above the
                     // kFadeInThreshold (cf analyzersilence.cpp);
                     // not shown to user

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -2156,6 +2156,10 @@ class ResetWaveformTrackPointerOperation : public mixxx::TrackPointerOperation {
         // same reasons that apply for reanalyze of the waveforms applies also
         // for the AudibleSound cue.
         pTrack->removeCuesOfType(mixxx::CueType::N60dBSound);
+        // FIX/TODO:
+        // Assumed this Should also apply?
+        pTrack->removeCuesOfType(mixxx::CueType::FadeIn);
+        pTrack->removeCuesOfType(mixxx::CueType::FadeOut);
     }
 
     AnalysisDao& m_analysisDao;


### PR DESCRIPTION
RadioLanewayCrossfade transition.
See AutoDj: New transition mode 'Radio Laneway'  https://github.com/mixxxdj/mixxx/issues/13716.

This transition mode is designed for social functions, especially playing popular music, and is intended to sound like a commercial radio station. For this purpose, it is vastly superior to existing transmission modes, and for cold endings especially, it consistently performs better than most people I suspect (well, me at least!).

This adds two new Cues, FadeIn and FadeOut. (cf analyzersilence.cpp pN60dBSound and kSilenceThreshold.) The FadeIn range is the time from the Main cue point (or first sound if the MainCue is not set) to the first time a track reaches kFadeInThreshold which is set to -27 dBV (or 0.0447f). The distance between these is the fadeInLength. The FadeOut range is from the last time a track was at kFadeOutThreshold which is set to -12 dBV (or 0.2511f), to the last sound. The distance between these is the fadeOutLength. The values are selected based on "sounding good" while reducing the chance of pathological times for fade-ins or outs.  Note that tracks always start a full volume (cf. TransitionMode::FixedStartCenterSkipSilence https://github.com/mixxxdj/mixxx/pull/13628).

This transition mode does the following:

1. If a playing (from) track has reached the FadeOut cue start, then a crossfade starting center is initiated, with the transmission time taking the fadeOutLength, or value from the spin box (fixed value), whichever is smaller. This fits most cases and provides a smooth crossfade on tracks with a fadeout, and excellent timing when a track has a sharp or cold ending.

2. If the next (to) track has a fadeInLength greater than 0.25 seconds then the next (to) track starts a fadeInLength value (playNextPos) earlier than the current (from) deck fadeOutStart. This covers the case where we have a slow fade-in of a song, for example, when Boston's "More Than A Feeling", comes next after a song with a cold (stab) end, removing the perception of a gap, while preserving the cold ending. (In this example it is about 3 seconds earlier, though the new track is not perceptible during a cold ending). Note that the crossfader holds in the center while the next (to) track starts, and starts moving the fader once fadeOutStart is reached. If the fadeOutLength + playNextPos difference is greater than the spin box, then revert to item 1 above using (fixed value) calculated from fadeOutLength.
 
3. If the next (to) track has a duration of less than 15 seconds then this track is likely a jingle or sample. In this case, the fadeInLength is 0 and the fadeOutLength is 1. This way we have a fast neat transition while maximizing the time for the next track to load.
