### PR TITLE
Fix Clazy v1.12 errors in 2.4

### DIFF
--- a/src/broadcast/broadcastmanager.cpp
+++ b/src/broadcast/broadcastmanager.cpp
@@ -42,8 +42,8 @@ BroadcastManager::BroadcastManager(SettingsManager* pSettingsManager,
     shout_init();
 
     // Initialize connections list from the current state of BroadcastSettings
-    QList<BroadcastProfilePtr> profiles = m_pBroadcastSettings->profiles();
-    for (const BroadcastProfilePtr& profile : std::as_const(profiles)) {
+    const QList<BroadcastProfilePtr> profiles = m_pBroadcastSettings->profiles();
+    for (const BroadcastProfilePtr& profile : profiles) {
         addConnection(profile);
     }
 
@@ -117,8 +117,8 @@ void BroadcastManager::slotControlEnabled(double v) {
     } else {
         m_pBroadcastEnabled->set(false);
         m_pStatusCO->forceSet(STATUSCO_UNCONNECTED);
-        QList<BroadcastProfilePtr> profiles = m_pBroadcastSettings->profiles();
-        for (BroadcastProfilePtr profile : std::as_const(profiles)) {
+        const QList<BroadcastProfilePtr> profiles = m_pBroadcastSettings->profiles();
+        for (BroadcastProfilePtr profile : profiles) {
             if (profile->connectionStatus() == BroadcastProfile::STATUS_FAILURE) {
                 profile->setConnectionStatus(BroadcastProfile::STATUS_UNCONNECTED);
             }
@@ -137,8 +137,8 @@ void BroadcastManager::slotProfileRemoved(BroadcastProfilePtr profile) {
 }
 
 void BroadcastManager::slotProfilesChanged() {
-    QVector<NetworkOutputStreamWorkerPtr> workers = m_pNetworkStream->outputWorkers();
-    for (const NetworkOutputStreamWorkerPtr& pWorker : std::as_const(workers)) {
+    const QVector<NetworkOutputStreamWorkerPtr> workers = m_pNetworkStream->outputWorkers();
+    for (const NetworkOutputStreamWorkerPtr& pWorker : workers) {
         ShoutConnectionPtr connection = qSharedPointerCast<ShoutConnection>(pWorker);
         if (connection) {
             BroadcastProfilePtr profile = connection->profile();
@@ -198,8 +198,8 @@ bool BroadcastManager::removeConnection(BroadcastProfilePtr profile) {
 }
 
 ShoutConnectionPtr BroadcastManager::findConnectionForProfile(BroadcastProfilePtr profile) {
-    QVector<NetworkOutputStreamWorkerPtr> workers = m_pNetworkStream->outputWorkers();
-    for (const NetworkOutputStreamWorkerPtr& pWorker : std::as_const(workers)) {
+    const QVector<NetworkOutputStreamWorkerPtr> workers = m_pNetworkStream->outputWorkers();
+    for (const NetworkOutputStreamWorkerPtr& pWorker : workers) {
         ShoutConnectionPtr connection = qSharedPointerCast<ShoutConnection>(pWorker);
         if (connection.isNull()) {
             continue;
@@ -219,8 +219,8 @@ void BroadcastManager::slotConnectionStatusChanged(int newState) {
         connectedCount = 0, failedCount = 0;
 
     // Collect status info
-    QList<BroadcastProfilePtr> profiles = m_pBroadcastSettings->profiles();
-    for (BroadcastProfilePtr profile : std::as_const(profiles)) {
+    const QList<BroadcastProfilePtr> profiles = m_pBroadcastSettings->profiles();
+    for (BroadcastProfilePtr profile : profiles) {
         if (!profile->getEnabled()) {
             continue;
         }

--- a/src/broadcast/broadcastmanager.cpp
+++ b/src/broadcast/broadcastmanager.cpp
@@ -43,7 +43,7 @@ BroadcastManager::BroadcastManager(SettingsManager* pSettingsManager,
 
     // Initialize connections list from the current state of BroadcastSettings
     QList<BroadcastProfilePtr> profiles = m_pBroadcastSettings->profiles();
-    for (const BroadcastProfilePtr& profile : profiles) {
+    for (const BroadcastProfilePtr& profile : std::as_const(profiles)) {
         addConnection(profile);
     }
 
@@ -98,7 +98,7 @@ void BroadcastManager::slotControlEnabled(double v) {
     if (v > 0.0) {
         bool atLeastOneEnabled = false;
         QList<BroadcastProfilePtr> profiles = m_pBroadcastSettings->profiles();
-        for (const BroadcastProfilePtr& profile : profiles) {
+        for (const BroadcastProfilePtr& profile : std::as_const(profiles)) {
             if (profile->getEnabled()) {
                 atLeastOneEnabled = true;
                 break;
@@ -118,10 +118,10 @@ void BroadcastManager::slotControlEnabled(double v) {
         m_pBroadcastEnabled->set(false);
         m_pStatusCO->forceSet(STATUSCO_UNCONNECTED);
         QList<BroadcastProfilePtr> profiles = m_pBroadcastSettings->profiles();
-        for(BroadcastProfilePtr profile : profiles) {
-           if (profile->connectionStatus() == BroadcastProfile::STATUS_FAILURE) {
-               profile->setConnectionStatus(BroadcastProfile::STATUS_UNCONNECTED);
-           }
+        for (BroadcastProfilePtr profile : std::as_const(profiles)) {
+            if (profile->connectionStatus() == BroadcastProfile::STATUS_FAILURE) {
+                profile->setConnectionStatus(BroadcastProfile::STATUS_UNCONNECTED);
+            }
         }
     }
 
@@ -138,7 +138,7 @@ void BroadcastManager::slotProfileRemoved(BroadcastProfilePtr profile) {
 
 void BroadcastManager::slotProfilesChanged() {
     QVector<NetworkOutputStreamWorkerPtr> workers = m_pNetworkStream->outputWorkers();
-    for (const NetworkOutputStreamWorkerPtr& pWorker : workers) {
+    for (const NetworkOutputStreamWorkerPtr& pWorker : std::as_const(workers)) {
         ShoutConnectionPtr connection = qSharedPointerCast<ShoutConnection>(pWorker);
         if (connection) {
             BroadcastProfilePtr profile = connection->profile();
@@ -199,7 +199,7 @@ bool BroadcastManager::removeConnection(BroadcastProfilePtr profile) {
 
 ShoutConnectionPtr BroadcastManager::findConnectionForProfile(BroadcastProfilePtr profile) {
     QVector<NetworkOutputStreamWorkerPtr> workers = m_pNetworkStream->outputWorkers();
-    for (const NetworkOutputStreamWorkerPtr& pWorker : workers) {
+    for (const NetworkOutputStreamWorkerPtr& pWorker : std::as_const(workers)) {
         ShoutConnectionPtr connection = qSharedPointerCast<ShoutConnection>(pWorker);
         if (connection.isNull()) {
             continue;
@@ -220,7 +220,7 @@ void BroadcastManager::slotConnectionStatusChanged(int newState) {
 
     // Collect status info
     QList<BroadcastProfilePtr> profiles = m_pBroadcastSettings->profiles();
-    for (BroadcastProfilePtr profile : profiles) {
+    for (BroadcastProfilePtr profile : std::as_const(profiles)) {
         if (!profile->getEnabled()) {
             continue;
         }

--- a/src/controllers/controllermanager.cpp
+++ b/src/controllers/controllermanager.cpp
@@ -237,10 +237,10 @@ void ControllerManager::slotSetUpDevices() {
     qDebug() << "ControllerManager: Setting up devices";
 
     updateControllerList();
-    QList<Controller*> deviceList = getControllerList(false, true);
+    const QList<Controller*> deviceList = getControllerList(false, true);
     QStringList mappingPaths(getMappingPaths(m_pConfig));
 
-    for (Controller* pController : std::as_const(deviceList)) {
+    for (Controller* pController : deviceList) {
         QString name = pController->getName();
 
         if (pController->isOpen()) {

--- a/src/controllers/controllermanager.cpp
+++ b/src/controllers/controllermanager.cpp
@@ -240,7 +240,7 @@ void ControllerManager::slotSetUpDevices() {
     QList<Controller*> deviceList = getControllerList(false, true);
     QStringList mappingPaths(getMappingPaths(m_pConfig));
 
-    for (Controller* pController : deviceList) {
+    for (Controller* pController : std::as_const(deviceList)) {
         QString name = pController->getName();
 
         if (pController->isOpen()) {

--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -483,7 +483,7 @@ MappingInfo DlgPrefController::enumerateMappingsFromEnumerator(
                 pMappingEnumerator->getMappingsByExtension(
                         m_pController->mappingExtension());
 
-        for (const MappingInfo& mapping : systemMappings) {
+        for (const MappingInfo& mapping : std::as_const(systemMappings)) {
             m_ui.comboBoxMapping->addItem(
                     icon, mapping.getName(), mapping.getPath());
             if (m_pController->matchMapping(mapping)) {

--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -479,11 +479,11 @@ MappingInfo DlgPrefController::enumerateMappingsFromEnumerator(
     // re-enumerate on the next open of the preferences.
     if (!pMappingEnumerator.isNull()) {
         // Get a list of mappings in alphabetical order
-        QList<MappingInfo> systemMappings =
+        const QList<MappingInfo> systemMappings =
                 pMappingEnumerator->getMappingsByExtension(
                         m_pController->mappingExtension());
 
-        for (const MappingInfo& mapping : std::as_const(systemMappings)) {
+        for (const MappingInfo& mapping : systemMappings) {
             m_ui.comboBoxMapping->addItem(
                     icon, mapping.getName(), mapping.getPath());
             if (m_pController->matchMapping(mapping)) {

--- a/src/controllers/dlgprefcontrollers.cpp
+++ b/src/controllers/dlgprefcontrollers.cpp
@@ -146,7 +146,7 @@ void DlgPrefControllers::destroyControllerWidgets() {
     // to keep this dialog and the controllermanager consistent.
     QList<Controller*> controllerList =
             m_pControllerManager->getControllerList(false, true);
-    for (auto* pController : controllerList) {
+    for (auto* pController : std::as_const(controllerList)) {
         pController->disconnect(this);
     }
     while (!m_controllerPages.isEmpty()) {
@@ -176,7 +176,7 @@ void DlgPrefControllers::setupControllerWidgets() {
 
     std::sort(controllerList.begin(), controllerList.end(), controllerCompare);
 
-    for (auto* pController : controllerList) {
+    for (auto* pController : std::as_const(controllerList)) {
         DlgPrefController* pControllerDlg = new DlgPrefController(
                 this, pController, m_pControllerManager, m_pConfig);
         connect(pControllerDlg,

--- a/src/controllers/midi/legacymidicontrollermappingfilehandler.cpp
+++ b/src/controllers/midi/legacymidicontrollermappingfilehandler.cpp
@@ -240,7 +240,7 @@ void LegacyMidiControllerMappingFileHandler::addControlsToDocument(
     // to remove duplicate keys or else we'll duplicate those values.
     auto sortedInputKeys = mapping.getInputMappings().uniqueKeys();
     std::sort(sortedInputKeys.begin(), sortedInputKeys.end());
-    for (const auto& key : sortedInputKeys) {
+    for (const auto& key : std::as_const(sortedInputKeys)) {
         for (auto it = mapping.getInputMappings().constFind(key);
                 it != mapping.getInputMappings().constEnd() && it.key() == key;
                 ++it) {
@@ -254,7 +254,7 @@ void LegacyMidiControllerMappingFileHandler::addControlsToDocument(
     QDomElement outputs = doc->createElement("outputs");
     auto sortedOutputKeys = mapping.getOutputMappings().uniqueKeys();
     std::sort(sortedOutputKeys.begin(), sortedOutputKeys.end());
-    for (const auto& key : sortedOutputKeys) {
+    for (const auto& key : std::as_const(sortedOutputKeys)) {
         for (auto it = mapping.getOutputMappings().constFind(key);
                 it != mapping.getOutputMappings().constEnd() && it.key() == key;
                 ++it) {

--- a/src/dialog/dlgreplacecuecolor.cpp
+++ b/src/dialog/dlgreplacecuecolor.cpp
@@ -310,8 +310,8 @@ void DlgReplaceCueColor::slotApply() {
     }
 
     // Flush cached tracks to database
-    QSet<TrackId> cachedTrackIds = GlobalTrackCacheLocker().getCachedTrackIds();
-    for (const TrackId& trackId : std::as_const(cachedTrackIds)) {
+    const QSet<TrackId> cachedTrackIds = GlobalTrackCacheLocker().getCachedTrackIds();
+    for (const TrackId& trackId : cachedTrackIds) {
         TrackPointer pTrack = GlobalTrackCacheLocker().lookupTrackById(trackId);
         if (pTrack) {
             m_pTrackCollectionManager->saveTrack(pTrack);

--- a/src/dialog/dlgreplacecuecolor.cpp
+++ b/src/dialog/dlgreplacecuecolor.cpp
@@ -311,7 +311,7 @@ void DlgReplaceCueColor::slotApply() {
 
     // Flush cached tracks to database
     QSet<TrackId> cachedTrackIds = GlobalTrackCacheLocker().getCachedTrackIds();
-    for (const TrackId& trackId : cachedTrackIds) {
+    for (const TrackId& trackId : std::as_const(cachedTrackIds)) {
         TrackPointer pTrack = GlobalTrackCacheLocker().lookupTrackById(trackId);
         if (pTrack) {
             m_pTrackCollectionManager->saveTrack(pTrack);

--- a/src/effects/effectslot.cpp
+++ b/src/effects/effectslot.cpp
@@ -332,8 +332,8 @@ void EffectSlot::loadEffectInner(const EffectManifestPointer pManifest,
                     continue;
                 }
 
-                for (const auto& pParameter :
-                        m_allParameters.value(parameterType)) {
+                const auto& allParameters = m_allParameters.value(parameterType);
+                for (const auto& pParameter : allParameters) {
                     if (pParameter->manifest()->id() == parameterPreset.id()) {
                         m_loadedParameters[parameterType].append(pParameter);
                         break;

--- a/src/effects/presets/effectpreset.cpp
+++ b/src/effects/presets/effectpreset.cpp
@@ -53,10 +53,12 @@ EffectPreset::EffectPreset(const EffectSlotPointer pEffectSlot)
     for (int parameterTypeId = 0; parameterTypeId < numTypes; ++parameterTypeId) {
         const EffectParameterType parameterType =
                 static_cast<EffectParameterType>(parameterTypeId);
-        for (const auto& pParameter : pEffectSlot->getLoadedParameters().value(parameterType)) {
+        const auto& loadedParameters = pEffectSlot->getLoadedParameters().value(parameterType);
+        for (const auto& pParameter : loadedParameters) {
             m_effectParameterPresets.append(EffectParameterPreset(pParameter, false));
         }
-        for (const auto& pParameter : pEffectSlot->getHiddenParameters().value(parameterType)) {
+        const auto& hiddenParameters = pEffectSlot->getHiddenParameters().value(parameterType);
+        for (const auto& pParameter : hiddenParameters) {
             m_effectParameterPresets.append(EffectParameterPreset(pParameter, true));
         }
     }

--- a/src/library/banshee/bansheefeature.cpp
+++ b/src/library/banshee/bansheefeature.cpp
@@ -90,8 +90,8 @@ void BansheeFeature::activate() {
         m_isActivated =  true;
 
         std::unique_ptr<TreeItem> pRootItem = TreeItem::newRoot(this);
-        QList<BansheeDbConnection::Playlist> playlists = m_connection.getPlaylists();
-        for (const BansheeDbConnection::Playlist& playlist : std::as_const(playlists)) {
+        const QList<BansheeDbConnection::Playlist> playlists = m_connection.getPlaylists();
+        for (const BansheeDbConnection::Playlist& playlist : playlists) {
             qDebug() << playlist.name;
             // append the playlist to the child model
             pRootItem->appendChild(playlist.name, playlist.playlistId);

--- a/src/library/banshee/bansheefeature.cpp
+++ b/src/library/banshee/bansheefeature.cpp
@@ -91,7 +91,7 @@ void BansheeFeature::activate() {
 
         std::unique_ptr<TreeItem> pRootItem = TreeItem::newRoot(this);
         QList<BansheeDbConnection::Playlist> playlists = m_connection.getPlaylists();
-        for (const BansheeDbConnection::Playlist& playlist: playlists) {
+        for (const BansheeDbConnection::Playlist& playlist : std::as_const(playlists)) {
             qDebug() << playlist.name;
             // append the playlist to the child model
             pRootItem->appendChild(playlist.name, playlist.playlistId);

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -132,7 +132,7 @@ void TrackDAO::finish() {
     // And mark the corresponding tracks in track_locations in the deleted
     // directories as deleted.
     // TODO(XXX) This doesn't handle sub-directories of deleted directories.
-    for (const auto& dir: deletedHashDirs) {
+    for (const auto& dir : std::as_const(deletedHashDirs)) {
         markTrackLocationsAsDeleted(m_database, dir);
     }
     transaction.commit();

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -124,7 +124,7 @@ void TrackDAO::finish() {
     // Do housekeeping on the LibraryHashes/track_locations tables.
     qDebug() << "Cleaning LibraryHashes/track_locations tables.";
     SqlTransaction transaction(m_database);
-    QStringList deletedHashDirs = m_libraryHashDao.getDeletedDirectories();
+    const QStringList deletedHashDirs = m_libraryHashDao.getDeletedDirectories();
 
     // Delete any LibraryHashes directories that have been marked as deleted.
     m_libraryHashDao.removeDeletedDirectoryHashes();
@@ -132,7 +132,7 @@ void TrackDAO::finish() {
     // And mark the corresponding tracks in track_locations in the deleted
     // directories as deleted.
     // TODO(XXX) This doesn't handle sub-directories of deleted directories.
-    for (const auto& dir : std::as_const(deletedHashDirs)) {
+    for (const auto& dir : deletedHashDirs) {
         markTrackLocationsAsDeleted(m_database, dir);
     }
     transaction.commit();

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -394,7 +394,7 @@ bool TrackCollection::purgeAllTracks(
     QList<TrackRef> trackRefs = m_trackDao.getAllTrackRefs(rootDir);
     QList<TrackId> trackIds;
     trackIds.reserve(trackRefs.size());
-    for (const auto& trackRef : trackRefs) {
+    for (const auto& trackRef : std::as_const(trackRefs)) {
         DEBUG_ASSERT(trackRef.hasId());
         trackIds.append(trackRef.getId());
     }

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -391,10 +391,10 @@ bool TrackCollection::purgeAllTracks(
         const QDir& rootDir) {
     DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
 
-    QList<TrackRef> trackRefs = m_trackDao.getAllTrackRefs(rootDir);
+    const QList<TrackRef> trackRefs = m_trackDao.getAllTrackRefs(rootDir);
     QList<TrackId> trackIds;
     trackIds.reserve(trackRefs.size());
-    for (const auto& trackRef : std::as_const(trackRefs)) {
+    for (const auto& trackRef : trackRefs) {
         DEBUG_ASSERT(trackRef.hasId());
         trackIds.append(trackRef.getId());
     }

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -679,7 +679,7 @@ void BasePlaylistFeature::slotAnalyzePlaylist() {
         if (playlistId >= 0) {
             QList<TrackId> ids = m_playlistDao.getTrackIds(playlistId);
             QList<AnalyzerScheduledTrack> tracks;
-            for (auto id : ids) {
+            for (auto id : std::as_const(ids)) {
                 tracks.append(id);
             }
             emit analyzeTracks(tracks);

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -677,9 +677,9 @@ void BasePlaylistFeature::slotAnalyzePlaylist() {
     if (m_lastRightClickedIndex.isValid()) {
         int playlistId = playlistIdFromIndex(m_lastRightClickedIndex);
         if (playlistId >= 0) {
-            QList<TrackId> ids = m_playlistDao.getTrackIds(playlistId);
+            const QList<TrackId> ids = m_playlistDao.getTrackIds(playlistId);
             QList<AnalyzerScheduledTrack> tracks;
-            for (auto id : std::as_const(ids)) {
+            for (auto id : ids) {
                 tracks.append(id);
             }
             emit analyzeTracks(tracks);

--- a/src/library/trackset/crate/cratefeature.cpp
+++ b/src/library/trackset/crate/cratefeature.cpp
@@ -707,7 +707,7 @@ void CrateFeature::slotCreateImportCrate() {
     CrateId lastCrateId;
 
     // For each selected file create a new crate
-    for (const QString& playlistFile : playlistFiles) {
+    for (const QString& playlistFile : std::as_const(playlistFiles)) {
         const QFileInfo fileInfo(playlistFile);
 
         Crate crate;

--- a/src/library/trackset/crate/cratefeature.cpp
+++ b/src/library/trackset/crate/cratefeature.cpp
@@ -693,7 +693,7 @@ void CrateFeature::slotImportPlaylistFile(const QString& playlistFile, CrateId c
 
 void CrateFeature::slotCreateImportCrate() {
     // Get file to read
-    QStringList playlistFiles = LibraryFeature::getPlaylistFiles();
+    const QStringList playlistFiles = LibraryFeature::getPlaylistFiles();
     if (playlistFiles.isEmpty()) {
         return;
     }
@@ -707,7 +707,7 @@ void CrateFeature::slotCreateImportCrate() {
     CrateId lastCrateId;
 
     // For each selected file create a new crate
-    for (const QString& playlistFile : std::as_const(playlistFiles)) {
+    for (const QString& playlistFile : playlistFiles) {
         const QFileInfo fileInfo(playlistFile);
 
         Crate crate;

--- a/src/musicbrainz/web/coverartarchiveimagetask.h
+++ b/src/musicbrainz/web/coverartarchiveimagetask.h
@@ -22,7 +22,7 @@ class CoverArtArchiveImageTask : public network::WebTask {
             const QByteArray& coverArtImageBytes);
 
     void failed(
-            const network::WebResponse& response,
+            const mixxx::network::WebResponse& response,
             int errorCode,
             const QString& errorMessage);
 

--- a/src/musicbrainz/web/musicbrainzrecordingstask.h
+++ b/src/musicbrainz/web/musicbrainzrecordingstask.h
@@ -24,9 +24,9 @@ class MusicBrainzRecordingsTask : public network::WebTask {
 
   signals:
     void succeeded(
-            const QList<musicbrainz::TrackRelease>& trackReleases);
+            const QList<mixxx::musicbrainz::TrackRelease>& trackReleases);
     void failed(
-            const network::WebResponse& response,
+            const mixxx::network::WebResponse& response,
             int errorCode,
             const QString& errorMessage);
     void currentRecordingFetchedFromMusicBrainz();

--- a/src/network/jsonwebtask.h
+++ b/src/network/jsonwebtask.h
@@ -78,7 +78,7 @@ class JsonWebTask : public WebTask {
 
   signals:
     void failed(
-            const network::JsonWebResponse& response);
+            const mixxx::network::JsonWebResponse& response);
 
   protected:
     // Customizable in derived classes

--- a/src/preferences/broadcastsettings.cpp
+++ b/src/preferences/broadcastsettings.cpp
@@ -31,7 +31,7 @@ void BroadcastSettings::loadProfiles() {
     }
 
     QStringList nameFilters("*.bcp.xml");
-    QFileInfoList files =
+    const QFileInfoList files =
             profilesFolder.entryInfoList(nameFilters, QDir::Files, QDir::Name);
 
     // If *.bcp.xml files exist in the profiles subfolder, those will be loaded
@@ -49,7 +49,7 @@ void BroadcastSettings::loadProfiles() {
         kLogger.info() << "Found" << files.size() << "profile(s)";
 
         // Load profiles from filesystem
-        for (const QFileInfo& fileInfo : std::as_const(files)) {
+        for (const QFileInfo& fileInfo : files) {
             BroadcastProfilePtr profile =
                     BroadcastProfile::loadFromFile(fileInfo.absoluteFilePath());
 

--- a/src/preferences/broadcastsettings.cpp
+++ b/src/preferences/broadcastsettings.cpp
@@ -49,7 +49,7 @@ void BroadcastSettings::loadProfiles() {
         kLogger.info() << "Found" << files.size() << "profile(s)";
 
         // Load profiles from filesystem
-        for (const QFileInfo& fileInfo : files) {
+        for (const QFileInfo& fileInfo : std::as_const(files)) {
             BroadcastProfilePtr profile =
                     BroadcastProfile::loadFromFile(fileInfo.absoluteFilePath());
 

--- a/src/preferences/colorpaletteeditor.cpp
+++ b/src/preferences/colorpaletteeditor.cpp
@@ -194,7 +194,7 @@ void ColorPaletteEditor::slotAddColor() {
 
 void ColorPaletteEditor::slotRemoveColor() {
     QModelIndexList selection = m_pTableView->selectionModel()->selectedRows();
-    for (const auto& index : selection) {
+    for (const auto& index : std::as_const(selection)) {
         //row selected
         int row = index.row();
         m_pModel->removeRow(row);

--- a/src/preferences/colorpaletteeditor.cpp
+++ b/src/preferences/colorpaletteeditor.cpp
@@ -193,8 +193,8 @@ void ColorPaletteEditor::slotAddColor() {
 }
 
 void ColorPaletteEditor::slotRemoveColor() {
-    QModelIndexList selection = m_pTableView->selectionModel()->selectedRows();
-    for (const auto& index : std::as_const(selection)) {
+    const QModelIndexList selection = m_pTableView->selectionModel()->selectedRows();
+    for (const auto& index : selection) {
         //row selected
         int row = index.row();
         m_pModel->removeRow(row);

--- a/src/soundio/sounddevicenetwork.cpp
+++ b/src/soundio/sounddevicenetwork.cpp
@@ -271,9 +271,9 @@ void SoundDeviceNetwork::writeProcess(SINT framesPerBuffer) {
     m_outputFifo->aquireReadRegions(readAvailable,
             &dataPtr1, &size1, &dataPtr2, &size2);
 
-    QVector<NetworkOutputStreamWorkerPtr> workers =
+    const QVector<NetworkOutputStreamWorkerPtr> workers =
             m_pNetworkStream->outputWorkers();
-    for (const auto& pWorker : std::as_const(workers)) {
+    for (const auto& pWorker : workers) {
         if (pWorker.isNull()) {
             continue;
         }

--- a/src/soundio/sounddevicenetwork.cpp
+++ b/src/soundio/sounddevicenetwork.cpp
@@ -273,7 +273,7 @@ void SoundDeviceNetwork::writeProcess(SINT framesPerBuffer) {
 
     QVector<NetworkOutputStreamWorkerPtr> workers =
             m_pNetworkStream->outputWorkers();
-    for (const auto& pWorker : workers) {
+    for (const auto& pWorker : std::as_const(workers)) {
         if (pWorker.isNull()) {
             continue;
         }

--- a/src/soundio/soundmanager.cpp
+++ b/src/soundio/soundmanager.cpp
@@ -483,7 +483,7 @@ SoundDeviceStatus SoundManager::setupDevices() {
 
     qDebug() << outputDevicesOpened << "output sound devices opened";
     qDebug() << inputDevicesOpened << "input sound devices opened";
-    for (const auto& device: devicesNotFound) {
+    for (const auto& device : std::as_const(devicesNotFound)) {
         qWarning() << device << "not found";
     }
 

--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -109,7 +109,7 @@ bool SoundManagerConfig::readFromDisk() {
         }
 
         int devicesMatchingByName = 0;
-        for (const auto& soundDevice : soundDevices) {
+        for (const auto& soundDevice : std::as_const(soundDevices)) {
             SoundDeviceId hardwareDeviceId = soundDevice->getDeviceId();
             if (hardwareDeviceId.name == deviceIdFromFile.name) {
                 devicesMatchingByName++;
@@ -127,7 +127,7 @@ bool SoundManagerConfig::readFromDisk() {
             // very reliable as persistent identifiers across restarts of Mixxx.
             // Set deviceIdFromFile's alsaHwDevice and portAudioIndex to match
             // the hardwareDeviceId so operator== works for SoundDeviceId.
-            for (const auto& soundDevice : soundDevices) {
+            for (const auto& soundDevice : std::as_const(soundDevices)) {
                 SoundDeviceId hardwareDeviceId = soundDevice->getDeviceId();
                 if (hardwareDeviceId.name == deviceIdFromFile.name) {
                     deviceIdFromFile.alsaHwDevice = hardwareDeviceId.alsaHwDevice;
@@ -146,7 +146,7 @@ bool SoundManagerConfig::readFromDisk() {
                 // multiple devices with the same name. This might be possible
                 // somehow with a udev rule matching device serial numbers, but
                 // I have not tested this.
-                for (const auto& soundDevice : soundDevices) {
+                for (const auto& soundDevice : std::as_const(soundDevices)) {
                     SoundDeviceId hardwareDeviceId = soundDevice->getDeviceId();
                     if (hardwareDeviceId.name == deviceIdFromFile.name
                             && hardwareDeviceId.alsaHwDevice == deviceIdFromFile.alsaHwDevice) {
@@ -156,7 +156,7 @@ bool SoundManagerConfig::readFromDisk() {
                 }
             } else {
                 // Check if the one of the matching devices has the configured in and output channels
-                for (const auto& soundDevice : soundDevices) {
+                for (const auto& soundDevice : std::as_const(soundDevices)) {
                     SoundDeviceId hardwareDeviceId = soundDevice->getDeviceId();
                     if (hardwareDeviceId.name == deviceIdFromFile.name &&
                             soundDevice->getNumOutputChannels() >=
@@ -515,7 +515,7 @@ void SoundManagerConfig::loadDefaults(SoundManager* soundManager, unsigned int f
         clearInputs();
         QList<SoundDevicePointer> outputDevices = soundManager->getDeviceList(m_api, true, false);
         if (!outputDevices.isEmpty()) {
-            for (const auto& pDevice: outputDevices) {
+            for (const auto& pDevice : std::as_const(outputDevices)) {
                 if (pDevice->getNumOutputChannels() < 2) {
                     continue;
                 }

--- a/src/soundio/soundmanagerconfig.cpp
+++ b/src/soundio/soundmanagerconfig.cpp
@@ -84,7 +84,8 @@ bool SoundManagerConfig::readFromDisk() {
     VERIFY_OR_DEBUG_ASSERT(m_pSoundManager != nullptr) {
         return false;
     }
-    QList<SoundDevicePointer> soundDevices = m_pSoundManager->getDeviceList(m_api, true, true);
+    const QList<SoundDevicePointer> soundDevices =
+            m_pSoundManager->getDeviceList(m_api, true, true);
 
     for (int i = 0; i < devElements.count(); ++i) {
         QDomElement devElement(devElements.at(i).toElement());
@@ -109,7 +110,7 @@ bool SoundManagerConfig::readFromDisk() {
         }
 
         int devicesMatchingByName = 0;
-        for (const auto& soundDevice : std::as_const(soundDevices)) {
+        for (const auto& soundDevice : soundDevices) {
             SoundDeviceId hardwareDeviceId = soundDevice->getDeviceId();
             if (hardwareDeviceId.name == deviceIdFromFile.name) {
                 devicesMatchingByName++;
@@ -127,7 +128,7 @@ bool SoundManagerConfig::readFromDisk() {
             // very reliable as persistent identifiers across restarts of Mixxx.
             // Set deviceIdFromFile's alsaHwDevice and portAudioIndex to match
             // the hardwareDeviceId so operator== works for SoundDeviceId.
-            for (const auto& soundDevice : std::as_const(soundDevices)) {
+            for (const auto& soundDevice : soundDevices) {
                 SoundDeviceId hardwareDeviceId = soundDevice->getDeviceId();
                 if (hardwareDeviceId.name == deviceIdFromFile.name) {
                     deviceIdFromFile.alsaHwDevice = hardwareDeviceId.alsaHwDevice;
@@ -146,7 +147,7 @@ bool SoundManagerConfig::readFromDisk() {
                 // multiple devices with the same name. This might be possible
                 // somehow with a udev rule matching device serial numbers, but
                 // I have not tested this.
-                for (const auto& soundDevice : std::as_const(soundDevices)) {
+                for (const auto& soundDevice : soundDevices) {
                     SoundDeviceId hardwareDeviceId = soundDevice->getDeviceId();
                     if (hardwareDeviceId.name == deviceIdFromFile.name
                             && hardwareDeviceId.alsaHwDevice == deviceIdFromFile.alsaHwDevice) {
@@ -156,7 +157,7 @@ bool SoundManagerConfig::readFromDisk() {
                 }
             } else {
                 // Check if the one of the matching devices has the configured in and output channels
-                for (const auto& soundDevice : std::as_const(soundDevices)) {
+                for (const auto& soundDevice : soundDevices) {
                     SoundDeviceId hardwareDeviceId = soundDevice->getDeviceId();
                     if (hardwareDeviceId.name == deviceIdFromFile.name &&
                             soundDevice->getNumOutputChannels() >=
@@ -513,9 +514,10 @@ void SoundManagerConfig::loadDefaults(SoundManager* soundManager, unsigned int f
     if (flags & SoundManagerConfig::DEVICES) {
         clearOutputs();
         clearInputs();
-        QList<SoundDevicePointer> outputDevices = soundManager->getDeviceList(m_api, true, false);
+        const QList<SoundDevicePointer> outputDevices =
+                soundManager->getDeviceList(m_api, true, false);
         if (!outputDevices.isEmpty()) {
-            for (const auto& pDevice : std::as_const(outputDevices)) {
+            for (const auto& pDevice : outputDevices) {
                 if (pDevice->getNumOutputChannels() < 2) {
                     continue;
                 }

--- a/src/test/seratobeatgridtest.cpp
+++ b/src/test/seratobeatgridtest.cpp
@@ -51,9 +51,9 @@ class SeratoBeatGridTest : public testing::Test {
         dir.setFilter(QDir::Files);
         dir.setNameFilters(QStringList() << "*.octet-stream");
 
-        QFileInfoList fileList = dir.entryInfoList();
+        const QFileInfoList fileList = dir.entryInfoList();
         EXPECT_FALSE(fileList.isEmpty());
-        for (const QFileInfo& fileInfo : std::as_const(fileList)) {
+        for (const QFileInfo& fileInfo : fileList) {
             qDebug() << "--- File:" << fileInfo.fileName();
             QFile file(dir.filePath(fileInfo.fileName()));
             bool openOk = file.open(QIODevice::ReadOnly);

--- a/src/test/seratobeatgridtest.cpp
+++ b/src/test/seratobeatgridtest.cpp
@@ -53,7 +53,7 @@ class SeratoBeatGridTest : public testing::Test {
 
         QFileInfoList fileList = dir.entryInfoList();
         EXPECT_FALSE(fileList.isEmpty());
-        for (const QFileInfo& fileInfo : fileList) {
+        for (const QFileInfo& fileInfo : std::as_const(fileList)) {
             qDebug() << "--- File:" << fileInfo.fileName();
             QFile file(dir.filePath(fileInfo.fileName()));
             bool openOk = file.open(QIODevice::ReadOnly);

--- a/src/test/seratomarkers2test.cpp
+++ b/src/test/seratomarkers2test.cpp
@@ -122,9 +122,9 @@ class SeratoMarkers2Test : public testing::Test {
         dir.setFilter(QDir::Files);
         dir.setNameFilters(QStringList() << "*.octet-stream");
 
-        QFileInfoList fileList = dir.entryInfoList();
+        const QFileInfoList fileList = dir.entryInfoList();
         EXPECT_FALSE(fileList.isEmpty());
-        for (const QFileInfo& fileInfo : std::as_const(fileList)) {
+        for (const QFileInfo& fileInfo : fileList) {
             qDebug() << "--- File:" << fileInfo.fileName();
             QFile file(dir.filePath(fileInfo.fileName()));
             bool openOk = file.open(QIODevice::ReadOnly);

--- a/src/test/seratomarkers2test.cpp
+++ b/src/test/seratomarkers2test.cpp
@@ -124,7 +124,7 @@ class SeratoMarkers2Test : public testing::Test {
 
         QFileInfoList fileList = dir.entryInfoList();
         EXPECT_FALSE(fileList.isEmpty());
-        for (const QFileInfo& fileInfo : fileList) {
+        for (const QFileInfo& fileInfo : std::as_const(fileList)) {
             qDebug() << "--- File:" << fileInfo.fileName();
             QFile file(dir.filePath(fileInfo.fileName()));
             bool openOk = file.open(QIODevice::ReadOnly);

--- a/src/test/seratomarkerstest.cpp
+++ b/src/test/seratomarkerstest.cpp
@@ -62,9 +62,9 @@ class SeratoMarkersTest : public testing::Test {
         dir.setFilter(QDir::Files);
         dir.setNameFilters(QStringList() << "*.octet-stream");
 
-        QFileInfoList fileList = dir.entryInfoList();
+        const QFileInfoList fileList = dir.entryInfoList();
         EXPECT_FALSE(fileList.isEmpty());
-        for (const QFileInfo& fileInfo : std::as_const(fileList)) {
+        for (const QFileInfo& fileInfo : fileList) {
             qDebug() << "--- File:" << fileInfo.fileName();
             QFile file(dir.filePath(fileInfo.fileName()));
             bool openOk = file.open(QIODevice::ReadOnly);

--- a/src/test/seratomarkerstest.cpp
+++ b/src/test/seratomarkerstest.cpp
@@ -64,7 +64,7 @@ class SeratoMarkersTest : public testing::Test {
 
         QFileInfoList fileList = dir.entryInfoList();
         EXPECT_FALSE(fileList.isEmpty());
-        for (const QFileInfo& fileInfo : fileList) {
+        for (const QFileInfo& fileInfo : std::as_const(fileList)) {
             qDebug() << "--- File:" << fileInfo.fileName();
             QFile file(dir.filePath(fileInfo.fileName()));
             bool openOk = file.open(QIODevice::ReadOnly);

--- a/src/waveform/renderers/waveformmark.cpp
+++ b/src/waveform/renderers/waveformmark.cpp
@@ -16,18 +16,18 @@ namespace {
 constexpr float lineHoverPadding = 5.0;
 
 Qt::Alignment decodeAlignmentFlags(const QString& alignString, Qt::Alignment defaultFlags) {
-    QStringList stringFlags = alignString.toLower()
-                                      .split('|',
+    const QStringList stringFlags = alignString.toLower()
+                                            .split('|',
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
-                                              Qt::SkipEmptyParts);
+                                                    Qt::SkipEmptyParts);
 #else
-                                              QString::SkipEmptyParts);
+                                                    QString::SkipEmptyParts);
 #endif
 
     Qt::Alignment hflags;
     Qt::Alignment vflags;
 
-    for (const auto& stringFlag : std::as_const(stringFlags)) {
+    for (const auto& stringFlag : stringFlags) {
         if (stringFlag == "center") {
             hflags |= Qt::AlignHCenter;
             vflags |= Qt::AlignVCenter;

--- a/src/waveform/renderers/waveformmark.cpp
+++ b/src/waveform/renderers/waveformmark.cpp
@@ -27,7 +27,7 @@ Qt::Alignment decodeAlignmentFlags(const QString& alignString, Qt::Alignment def
     Qt::Alignment hflags;
     Qt::Alignment vflags;
 
-    for (const auto& stringFlag : stringFlags) {
+    for (const auto& stringFlag : std::as_const(stringFlags)) {
         if (stringFlag == "center") {
             hflags |= Qt::AlignHCenter;
             vflags |= Qt::AlignVCenter;

--- a/src/waveform/renderers/waveformrendermarkbase.cpp
+++ b/src/waveform/renderers/waveformrendermarkbase.cpp
@@ -58,7 +58,7 @@ void WaveformRenderMarkBase::updateMarksFromCues() {
 
     const int dimBrightThreshold = m_waveformRenderer->getDimBrightThreshold();
     QList<CuePointer> loadedCues = pTrackInfo->getCuePoints();
-    for (const CuePointer& pCue : loadedCues) {
+    for (const CuePointer& pCue : std::as_const(loadedCues)) {
         const int hotCue = pCue->getHotCue();
         if (hotCue == Cue::kNoHotCue) {
             continue;

--- a/src/waveform/renderers/waveformrendermarkbase.cpp
+++ b/src/waveform/renderers/waveformrendermarkbase.cpp
@@ -57,8 +57,8 @@ void WaveformRenderMarkBase::updateMarksFromCues() {
     }
 
     const int dimBrightThreshold = m_waveformRenderer->getDimBrightThreshold();
-    QList<CuePointer> loadedCues = pTrackInfo->getCuePoints();
-    for (const CuePointer& pCue : std::as_const(loadedCues)) {
+    const QList<CuePointer> loadedCues = pTrackInfo->getCuePoints();
+    for (const CuePointer& pCue : loadedCues) {
         const int hotCue = pCue->getHotCue();
         if (hotCue == Cue::kNoHotCue) {
             continue;

--- a/src/widget/weffectchainpresetbutton.cpp
+++ b/src/widget/weffectchainpresetbutton.cpp
@@ -129,13 +129,13 @@ void WEffectChainPresetButton::populateMenu() {
                 effectSlotNumPrefix + pEffectSlot->getManifest()->displayName(),
                 m_pMenu);
 
-        const ParameterMap loadedParameters = pEffectSlot->getLoadedParameters();
-        const ParameterMap hiddenParameters = pEffectSlot->getHiddenParameters();
         int numTypes = static_cast<int>(EffectManifestParameter::ParameterType::NumTypes);
         for (int parameterTypeId = 0; parameterTypeId < numTypes; ++parameterTypeId) {
             const EffectManifestParameter::ParameterType parameterType =
                     static_cast<EffectManifestParameter::ParameterType>(parameterTypeId);
-            for (const auto& pParameter : loadedParameters.value(parameterType)) {
+
+            const auto& loadedParameters = pEffectSlot->getLoadedParameters().value(parameterType);
+            for (const auto& pParameter : loadedParameters) {
                 auto pCheckbox = make_parented<QCheckBox>(pEffectMenu);
                 pCheckbox->setChecked(true);
                 pCheckbox->setText(pParameter->manifest()->name());
@@ -154,7 +154,8 @@ void WEffectChainPresetButton::populateMenu() {
                 pEffectMenu->addAction(pAction.get());
             }
 
-            for (const auto& pParameter : hiddenParameters.value(parameterType)) {
+            const auto& hiddenParameters = pEffectSlot->getHiddenParameters().value(parameterType);
+            for (const auto& pParameter : hiddenParameters) {
                 auto pCheckbox = make_parented<QCheckBox>(pEffectMenu);
                 pCheckbox->setChecked(false);
                 pCheckbox->setText(pParameter->manifest()->name());

--- a/src/widget/whotcuebutton.cpp
+++ b/src/widget/whotcuebutton.cpp
@@ -108,7 +108,7 @@ void WHotcueButton::mousePressEvent(QMouseEvent* e) {
 
             CuePointer pHotCue;
             QList<CuePointer> cueList = pTrack->getCuePoints();
-            for (const auto& pCue : cueList) {
+            for (const auto& pCue : std::as_const(cueList)) {
                 if (pCue->getHotCue() == m_hotcue) {
                     pHotCue = pCue;
                     break;

--- a/src/widget/whotcuebutton.cpp
+++ b/src/widget/whotcuebutton.cpp
@@ -107,8 +107,8 @@ void WHotcueButton::mousePressEvent(QMouseEvent* e) {
             }
 
             CuePointer pHotCue;
-            QList<CuePointer> cueList = pTrack->getCuePoints();
-            for (const auto& pCue : std::as_const(cueList)) {
+            const QList<CuePointer> cueList = pTrack->getCuePoints();
+            for (const auto& pCue : cueList) {
                 if (pCue->getHotCue() == m_hotcue) {
                     pHotCue = pCue;
                     break;

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -538,7 +538,7 @@ void WOverview::mousePressEvent(QMouseEvent* e) {
             // WaveformMarks with Cues will need to be implemented.
             CuePointer pHoveredCue;
             QList<CuePointer> cueList = m_pCurrentTrack->getCuePoints();
-            for (const auto& pCue : cueList) {
+            for (const auto& pCue : std::as_const(cueList)) {
                 if (pCue->getHotCue() == m_pHoveredMark->getHotCue()) {
                     pHoveredCue = pCue;
                     break;

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -537,8 +537,8 @@ void WOverview::mousePressEvent(QMouseEvent* e) {
             // WOverview in the future, another way to associate
             // WaveformMarks with Cues will need to be implemented.
             CuePointer pHoveredCue;
-            QList<CuePointer> cueList = m_pCurrentTrack->getCuePoints();
-            for (const auto& pCue : std::as_const(cueList)) {
+            const QList<CuePointer> cueList = m_pCurrentTrack->getCuePoints();
+            for (const auto& pCue : cueList) {
                 if (pCue->getHotCue() == m_pHoveredMark->getHotCue()) {
                     pHoveredCue = pCue;
                     break;

--- a/src/widget/wsplitter.cpp
+++ b/src/widget/wsplitter.cpp
@@ -54,10 +54,10 @@ void WSplitter::setup(const QDomNode& node, const SkinContext& context) {
 
     // found some value for splitsizes?
     if (!sizesJoined.isEmpty()) {
-        QStringList sizesSplit = sizesJoined.split(",");
+        const QStringList sizesSplit = sizesJoined.split(",");
         QList<int> sizesList;
         ok = false;
-        for (const QString& sizeStr : std::as_const(sizesSplit)) {
+        for (const QString& sizeStr : sizesSplit) {
             sizesList.push_back(sizeStr.toInt(&ok));
             if (!ok) {
                 break;
@@ -75,10 +75,10 @@ void WSplitter::setup(const QDomNode& node, const SkinContext& context) {
     // Which children can be collapsed?
     QString collapsibleJoined;
     if (context.hasNodeSelectString(node, "Collapsible", &collapsibleJoined)) {
-        QStringList collapsibleSplit = collapsibleJoined.split(",");
+        const QStringList collapsibleSplit = collapsibleJoined.split(",");
         QList<bool> collapsibleList;
         ok = false;
-        for (const QString& collapsibleStr : std::as_const(collapsibleSplit)) {
+        for (const QString& collapsibleStr : collapsibleSplit) {
             collapsibleList.push_back(collapsibleStr.toInt(&ok)>0);
             if (!ok) {
                 break;

--- a/src/widget/wsplitter.cpp
+++ b/src/widget/wsplitter.cpp
@@ -57,7 +57,7 @@ void WSplitter::setup(const QDomNode& node, const SkinContext& context) {
         QStringList sizesSplit = sizesJoined.split(",");
         QList<int> sizesList;
         ok = false;
-        for (const QString& sizeStr : sizesSplit) {
+        for (const QString& sizeStr : std::as_const(sizesSplit)) {
             sizesList.push_back(sizeStr.toInt(&ok));
             if (!ok) {
                 break;
@@ -78,7 +78,7 @@ void WSplitter::setup(const QDomNode& node, const SkinContext& context) {
         QStringList collapsibleSplit = collapsibleJoined.split(",");
         QList<bool> collapsibleList;
         ok = false;
-        for (const QString& collapsibleStr : collapsibleSplit) {
+        for (const QString& collapsibleStr : std::as_const(collapsibleSplit)) {
             collapsibleList.push_back(collapsibleStr.toInt(&ok)>0);
             if (!ok) {
                 break;

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -1324,10 +1324,10 @@ void WTrackMenu::slotPopulatePlaylistMenu() {
     const PlaylistDAO& playlistDao = m_pLibrary->trackCollectionManager()
                                              ->internalCollection()
                                              ->getPlaylistDAO();
-    QList<QPair<int, QString>> playlists =
+    const QList<QPair<int, QString>> playlists =
             playlistDao.getPlaylists(PlaylistDAO::PLHT_NOT_HIDDEN);
 
-    for (const auto& [id, name] : std::as_const(playlists)) {
+    for (const auto& [id, name] : playlists) {
         // No leak because making the menu the parent means they will be
         // auto-deleted
         int plId = id;

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -1327,7 +1327,7 @@ void WTrackMenu::slotPopulatePlaylistMenu() {
     QList<QPair<int, QString>> playlists =
             playlistDao.getPlaylists(PlaylistDAO::PLHT_NOT_HIDDEN);
 
-    for (const auto& [id, name] : playlists) {
+    for (const auto& [id, name] : std::as_const(playlists)) {
         // No leak because making the menu the parent means they will be
         // auto-deleted
         int plId = id;


### PR DESCRIPTION
I ran Clazy v1.12 on our codebase, and got many errors of the following types:

- https://github.com/KDE/clazy/blob/master/docs/checks/README-range-loop-detach.md
- https://github.com/KDE/clazy/blob/master/docs/checks/README-fully-qualified-moc-types.md

This PR fixes them.
 