### PR TITLE
Add script.deburr to common-controller-scripts to convert UTF-8 string to pure Latin-1

### DIFF
--- a/res/controllers/common-controller-scripts.js
+++ b/res/controllers/common-controller-scripts.js
@@ -245,6 +245,89 @@ script.midiDebug = function(channel, control, value, status, group) {
         " status: 0x" + status.toString(16) + " group: " + group);
 };
 
+
+
+class StringDeburr {
+    constructor() {
+        this.regexLatin = /[\xc0-\xd6\xd8-\xf6\xf8-\xff\u0100-\u017f]/g;
+
+        this.regexComboMark = /[\u0300-\u036f\ufe20-\ufe2f\u20d0-\u20ff]/g;
+
+        this.deburredLetters = {
+            // Latin-1 Supplement block.
+            "\xc0": "A",  "\xc1": "A", "\xc2": "A", "\xc3": "A", "\xc4": "A", "\xc5": "A",
+            "\xe0": "a",  "\xe1": "a", "\xe2": "a", "\xe3": "a", "\xe4": "a", "\xe5": "a",
+            "\xc7": "C",  "\xe7": "c",
+            "\xd0": "D",  "\xf0": "d",
+            "\xc8": "E",  "\xc9": "E", "\xca": "E", "\xcb": "E",
+            "\xe8": "e",  "\xe9": "e", "\xea": "e", "\xeb": "e",
+            "\xcc": "I",  "\xcd": "I", "\xce": "I", "\xcf": "I",
+            "\xec": "i",  "\xed": "i", "\xee": "i", "\xef": "i",
+            "\xd1": "N",  "\xf1": "n",
+            "\xd2": "O",  "\xd3": "O", "\xd4": "O", "\xd5": "O", "\xd6": "O", "\xd8": "O",
+            "\xf2": "o",  "\xf3": "o", "\xf4": "o", "\xf5": "o", "\xf6": "o", "\xf8": "o",
+            "\xd9": "U",  "\xda": "U", "\xdb": "U", "\xdc": "U",
+            "\xf9": "u",  "\xfa": "u", "\xfb": "u", "\xfc": "u",
+            "\xdd": "Y",  "\xfd": "y", "\xff": "y",
+            "\xc6": "Ae", "\xe6": "ae",
+            "\xde": "Th", "\xfe": "th",
+            "\xdf": "ss",
+            // Latin Extended-A block.
+            "\u0100": "A",  "\u0102": "A", "\u0104": "A",
+            "\u0101": "a",  "\u0103": "a", "\u0105": "a",
+            "\u0106": "C",  "\u0108": "C", "\u010a": "C", "\u010c": "C",
+            "\u0107": "c",  "\u0109": "c", "\u010b": "c", "\u010d": "c",
+            "\u010e": "D",  "\u0110": "D", "\u010f": "d", "\u0111": "d",
+            "\u0112": "E",  "\u0114": "E", "\u0116": "E", "\u0118": "E", "\u011a": "E",
+            "\u0113": "e",  "\u0115": "e", "\u0117": "e", "\u0119": "e", "\u011b": "e",
+            "\u011c": "G",  "\u011e": "G", "\u0120": "G", "\u0122": "G",
+            "\u011d": "g",  "\u011f": "g", "\u0121": "g", "\u0123": "g",
+            "\u0124": "H",  "\u0126": "H", "\u0125": "h", "\u0127": "h",
+            "\u0128": "I",  "\u012a": "I", "\u012c": "I", "\u012e": "I", "\u0130": "I",
+            "\u0129": "i",  "\u012b": "i", "\u012d": "i", "\u012f": "i", "\u0131": "i",
+            "\u0134": "J",  "\u0135": "j",
+            "\u0136": "K",  "\u0137": "k", "\u0138": "k",
+            "\u0139": "L",  "\u013b": "L", "\u013d": "L", "\u013f": "L", "\u0141": "L",
+            "\u013a": "l",  "\u013c": "l", "\u013e": "l", "\u0140": "l", "\u0142": "l",
+            "\u0143": "N",  "\u0145": "N", "\u0147": "N", "\u014a": "N",
+            "\u0144": "n",  "\u0146": "n", "\u0148": "n", "\u014b": "n",
+            "\u014c": "O",  "\u014e": "O", "\u0150": "O",
+            "\u014d": "o",  "\u014f": "o", "\u0151": "o",
+            "\u0154": "R",  "\u0156": "R", "\u0158": "R",
+            "\u0155": "r",  "\u0157": "r", "\u0159": "r",
+            "\u015a": "S",  "\u015c": "S", "\u015e": "S", "\u0160": "S",
+            "\u015b": "s",  "\u015d": "s", "\u015f": "s", "\u0161": "s",
+            "\u0162": "T",  "\u0164": "T", "\u0166": "T",
+            "\u0163": "t",  "\u0165": "t", "\u0167": "t",
+            "\u0168": "U",  "\u016a": "U", "\u016c": "U", "\u016e": "U", "\u0170": "U", "\u0172": "U",
+            "\u0169": "u",  "\u016b": "u", "\u016d": "u", "\u016f": "u", "\u0171": "u", "\u0173": "u",
+            "\u0174": "W",  "\u0175": "w",
+            "\u0176": "Y",  "\u0177": "y", "\u0178": "Y",
+            "\u0179": "Z",  "\u017b": "Z", "\u017d": "Z",
+            "\u017a": "z",  "\u017c": "z", "\u017e": "z",
+            "\u0132": "IJ", "\u0133": "ij",
+            "\u0152": "Oe", "\u0153": "oe",
+            "\u0149": "'n", "\u017f": "s"
+        };
+    }
+
+    replacer(key) {
+        const replacement = this.deburredLetters[key];
+        return replacement === undefined ? "?" : replacement;
+    }
+
+    deburr(string) {
+        return `${string}`.replace(this.regexLatin, this.replacer).replace(this.regexComboMark, "");
+    }
+}
+/**
+ * String deburring convenience function adapted from Lodash's _.deburr
+ * @see https://lodash.com/docs/4.17.15#deburr
+ * @param {string} value
+ * @returns {string}
+ */
+script.deburr = new StringDeburr().deburr;
+
 // Returns the deck number of a "ChannelN" or "SamplerN" group
 script.deckFromGroup = function(group) {
     let deck = 0;
@@ -334,7 +417,6 @@ script.absoluteLin = function(value, low, high, min, max) {
         return ((((high - low) / (max - min)) * (value - min)) + low);
     }
 };
-
 /* -------- ------------------------------------------------------
      script.absoluteLinInverse
    Purpose: Maps a linear Mixxx control value (like balance: -1..1) to an absolute linear value


### PR DESCRIPTION
This is copied and adapted from Lodash's `_.deburr`. Useful to transform UTF-8 strings for display on old devices with screens that can only display Latin-1 letters.

But maybe an implementation using a C++ library may be more efficient?