### PR TITLE
feat: store tracklist as tag comment on recording

### DIFF
--- a/src/encoder/encoder.cpp
+++ b/src/encoder/encoder.cpp
@@ -155,3 +155,22 @@ EncoderRecordingSettingsPointer EncoderFactory::getEncoderRecordingSettings(Enco
         return std::make_shared<EncoderWaveSettings>(pConfig, ENCODING_WAVE);
     }
 }
+
+void Encoder::addToTracklist(const QString& artist,
+        const QString& title,
+        std::chrono::seconds timestamp) {
+    auto recordedDurationSeconds = timestamp.count();
+    m_trackList.append(QStringLiteral("%1:%2:%3: %4 - %5")
+                    .arg(QString::number(recordedDurationSeconds / (60 * 60))
+                                    .rightJustified(2, '0'), // hours
+                            QString::number((recordedDurationSeconds / 60) % 60)
+                                    .rightJustified(2, '0'), // minutes
+                            QString::number(recordedDurationSeconds % 60)
+                                    .rightJustified(2, '0'),
+                            artist.trimmed().isEmpty()
+                                    ? QObject::tr("(Unknown Artist)")
+                                    : artist,
+                            title.trimmed().isEmpty()
+                                    ? QObject::tr("(Unknown Title)")
+                                    : title));
+}

--- a/src/encoder/encoder.h
+++ b/src/encoder/encoder.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <memory>
 
 #include "encoder/encoderrecordingsettings.h"
@@ -33,11 +34,25 @@ class Encoder {
     virtual void encodeBuffer(const CSAMPLE* samples, const std::size_t bufferSize) = 0;
     // Adds metadata to the encoded audio, i.e., the ID3 tag. Currently only used
     // by EngineRecord, ShoutConnection does something different.
-    virtual void updateMetaData(const QString& artist, const QString& title, const QString& album) = 0;
+    virtual void updateMetaData(const QString& artist,
+            const QString& title,
+            const QString& album,
+            std::chrono::seconds timestamp = {}) = 0;
     // called at the end when encoding is finished
     virtual void flush() = 0;
     // Setup the encoder with the specific settings
     virtual void setEncoderSettings(const EncoderSettings& settings) = 0;
+
+  protected:
+    void addToTracklist(const QString& artist,
+            const QString& title,
+            std::chrono::seconds timestamp);
+    const QStringList& getTrackList() const {
+        return m_trackList;
+    }
+
+  private:
+    QStringList m_trackList;
 };
 
 typedef std::shared_ptr<Encoder> EncoderPointer;

--- a/src/encoder/encoderfdkaac.cpp
+++ b/src/encoder/encoderfdkaac.cpp
@@ -440,9 +440,10 @@ void EncoderFdkAac::processFIFO() {
     }
 }
 
-void EncoderFdkAac::updateMetaData(
-        const QString& artist, const QString& title, const QString& album) {
-    (void)artist, (void)title, (void)album;
+void EncoderFdkAac::updateMetaData(const QString&,
+        const QString&,
+        const QString&,
+        std::chrono::seconds) {
 }
 
 void EncoderFdkAac::flush() {

--- a/src/encoder/encoderfdkaac.h
+++ b/src/encoder/encoderfdkaac.h
@@ -17,7 +17,10 @@ class EncoderFdkAac : public Encoder {
     int initEncoder(mixxx::audio::SampleRate sampleRate,
             QString* pUserErrorMessage) override;
     void encodeBuffer(const CSAMPLE* samples, const std::size_t bufferSize) override;
-    void updateMetaData(const QString& artist, const QString& title, const QString& album) override;
+    void updateMetaData(const QString& artist,
+            const QString& title,
+            const QString& album,
+            std::chrono::seconds timecode = {}) override;
     void flush() override;
     void setEncoderSettings(const EncoderSettings& settings) override;
 

--- a/src/encoder/encoderffmpegcore.cpp
+++ b/src/encoder/encoderffmpegcore.cpp
@@ -184,17 +184,10 @@ void EncoderFfmpegCore::encodeBuffer(const CSAMPLE* samples, const std::size_t b
     free(l_fNormalizedSamples);
 }
 
-// Originally called from enginebroadcast.cpp to update metadata information
-// when streaming, however, this causes pops
-//
-// Currently this method is used before init() once to save artist, title and album
-//
-void EncoderFfmpegCore::updateMetaData(const QString& artist, const QString& title, const QString& album) {
-    qDebug() << "ffmpegencodercore: UpdateMetadata: !" << artist << " - " << title <<
-             " - " << album;
-    m_strMetaDataTitle = title;
-    m_strMetaDataArtist = artist;
-    m_strMetaDataAlbum = album;
+void EncoderFfmpegCore::updateMetaData(const QString&,
+        const QString&,
+        const QString&,
+        std::chrono::seconds) {
 }
 
 int EncoderFfmpegCore::initEncoder(

--- a/src/encoder/encoderffmpegcore.h
+++ b/src/encoder/encoderffmpegcore.h
@@ -19,6 +19,7 @@ extern "C" {
 
 #include <QBuffer>
 #include <QByteArray>
+#include <QFile>
 #include <QLibrary>
 
 #include "encoder/encoder.h"
@@ -44,7 +45,10 @@ public:
     ~EncoderFfmpegCore();
     int initEncoder(mixxx::audio::SampleRate sampleRate, QString* pUserErrorMessage) override;
     void encodeBuffer(const CSAMPLE* samples, const std::size_t bufferSize) override;
-    void updateMetaData(const QString& artist, const QString& title, const QString& album) override;
+    void updateMetaData(const QString& artist,
+            const QString& title,
+            const QString& album,
+            std::chrono::seconds timecode = {}) override;
     void flush() override;
     void setEncoderSettings(const EncoderSettings& settings) override;
 protected:
@@ -70,9 +74,6 @@ private:
     EncoderCallback* m_pCallback;
     TrackPointer m_pMetaData;
 
-    QString m_strMetaDataTitle;
-    QString m_strMetaDataArtist;
-    QString m_strMetaDataAlbum;
     QFile m_pFile;
 
     QByteArray m_strReadByteArray;

--- a/src/encoder/encodermp3.h
+++ b/src/encoder/encodermp3.h
@@ -17,7 +17,10 @@ class EncoderMp3 final : public Encoder {
     int initEncoder(mixxx::audio::SampleRate sampleRate,
             QString* pUserErrorMessage) override;
     void encodeBuffer(const CSAMPLE* samples, const std::size_t bufferSize) override;
-    void updateMetaData(const QString& artist, const QString& title, const QString& album) override;
+    void updateMetaData(const QString& artist,
+            const QString& title,
+            const QString& album,
+            std::chrono::seconds timecode = {}) override;
     void flush() override;
     void setEncoderSettings(const EncoderSettings& settings) override;
 

--- a/src/encoder/encoderopus.cpp
+++ b/src/encoder/encoderopus.cpp
@@ -1,5 +1,7 @@
 #include "encoder/encoderopus.h"
 
+#include <qglobal.h>
+
 #include <QByteArray>
 #include <QMapIterator>
 #include <QRandomGenerator>
@@ -461,10 +463,17 @@ void EncoderOpus::writePage(ogg_packet* pPacket) {
     } while(!ogg_page_eos(&m_oggPage));
 }
 
-void EncoderOpus::updateMetaData(const QString& artist, const QString& title, const QString& album) {
-    m_opusComments.insert("ARTIST", artist);
-    m_opusComments.insert("TITLE", title);
-    m_opusComments.insert("ALBUM", album);
+void EncoderOpus::updateMetaData(const QString& artist,
+        const QString& title,
+        const QString& album,
+        std::chrono::seconds) {
+    // We assume all the base tags are added at the same time, so only check for ARTIST presence
+    if (!m_opusComments.contains("ARTIST")) {
+        m_opusComments.insert("ARTIST", artist);
+        m_opusComments.insert("TITLE", title);
+        m_opusComments.insert("ALBUM", album);
+    }
+    // Tracklist tag not supported in OPUS
 }
 
 void EncoderOpus::flush() {

--- a/src/encoder/encoderopus.h
+++ b/src/encoder/encoderopus.h
@@ -29,7 +29,10 @@ class EncoderOpus: public Encoder {
     int initEncoder(mixxx::audio::SampleRate sampleRate,
             QString* pUserErrorMessage) override;
     void encodeBuffer(const CSAMPLE* samples, const std::size_t bufferSize) override;
-    void updateMetaData(const QString& artist, const QString& title, const QString& album) override;
+    void updateMetaData(const QString& artist,
+            const QString& title,
+            const QString& album,
+            std::chrono::seconds timecode = {}) override;
     void flush() override;
     void setEncoderSettings(const EncoderSettings& settings) override;
 

--- a/src/encoder/encodervorbis.cpp
+++ b/src/encoder/encodervorbis.cpp
@@ -1,5 +1,6 @@
 #include "encoder/encodervorbis.h"
 
+#include <qglobal.h>
 #include <stdlib.h> // needed for random num gen
 #include <time.h>   // needed for random num gen
 #include <vorbis/vorbisenc.h>
@@ -31,6 +32,9 @@ EncoderVorbis::EncoderVorbis(EncoderCallback* pCallback)
 
 EncoderVorbis::~EncoderVorbis() {
     if (m_bStreamInitialized) {
+        QString trackList = m_trackList.join("\n");
+        vorbis_comment_add_tag(&m_vcomment, "COMMENT", trackList.toUtf8().constData());
+
         ogg_stream_clear(&m_oggs);
         vorbis_block_clear(&m_vblock);
         vorbis_dsp_clear(&m_vdsp);
@@ -161,10 +165,16 @@ void EncoderVorbis::encodeBuffer(const CSAMPLE* samples, const std::size_t buffe
  *
  * Currently this method is used before init() once to save artist, title and album
 */
-void EncoderVorbis::updateMetaData(const QString& artist, const QString& title, const QString& album) {
-    m_metaDataTitle = title;
-    m_metaDataArtist = artist;
-    m_metaDataAlbum = album;
+void EncoderVorbis::updateMetaData(const QString& artist,
+        const QString& title,
+        const QString& album,
+        std::chrono::seconds) {
+    if (!m_bStreamInitialized) {
+        m_metaDataTitle = title;
+        m_metaDataArtist = artist;
+        m_metaDataAlbum = album;
+    }
+    // Tracklist tag not supported in OGG
 }
 
 void EncoderVorbis::initStream() {

--- a/src/encoder/encodervorbis.h
+++ b/src/encoder/encodervorbis.h
@@ -21,7 +21,10 @@ class EncoderVorbis : public Encoder {
     int initEncoder(mixxx::audio::SampleRate sampleRate,
             QString* pUserErrorMessage) override;
     void encodeBuffer(const CSAMPLE* samples, const std::size_t bufferSize) override;
-    void updateMetaData(const QString& artist, const QString& title, const QString& album) override;
+    void updateMetaData(const QString& artist,
+            const QString& title,
+            const QString& album,
+            std::chrono::seconds timecode = {}) override;
     void flush() override;
     void setEncoderSettings(const EncoderSettings& settings) override;
 
@@ -51,4 +54,6 @@ class EncoderVorbis : public Encoder {
     int m_bitrate;
     int m_channels;
     QFile m_file;
+
+    QStringList m_trackList;
 };

--- a/src/encoder/encoderwave.h
+++ b/src/encoder/encoderwave.h
@@ -23,7 +23,10 @@ class EncoderWave : public Encoder {
     int initEncoder(mixxx::audio::SampleRate sampleRate,
             QString* pUserErrorMessage) override;
     void encodeBuffer(const CSAMPLE* samples, const std::size_t bufferSize) override;
-    void updateMetaData(const QString& artist, const QString& title, const QString& album) override;
+    void updateMetaData(const QString& artist,
+            const QString& title,
+            const QString& album,
+            std::chrono::seconds timecode = {}) override;
     void flush() override;
     void setEncoderSettings(const EncoderSettings& settings) override;
 

--- a/src/engine/sidechain/enginerecord.h
+++ b/src/engine/sidechain/enginerecord.h
@@ -86,5 +86,6 @@ class EngineRecord : public QObject, public EncoderCallback, public SideChainWor
     QString m_cueFileName;
     quint64 m_cueTrack;
     bool m_bCueIsEnabled;
+    bool m_bTracklistAsCommentEnabled;
     bool m_bCueUsesFileAnnotation;
 };

--- a/src/preferences/dialog/dlgprefrecord.cpp
+++ b/src/preferences/dialog/dlgprefrecord.cpp
@@ -12,6 +12,7 @@
 
 namespace {
 constexpr bool kDefaultCueEnabled = true;
+constexpr bool kDefaultTracklistAsComment = true;
 constexpr bool kDefaultCueFileAnnotationEnabled = false;
 } // anonymous namespace
 
@@ -84,6 +85,7 @@ DlgPrefRecord::DlgPrefRecord(QWidget* parent, UserSettingsPointer pConfig)
     // Setting miscellaneous
     CheckBoxRecordCueFile->setChecked(m_pConfig->getValue<bool>(
             ConfigKey(RECORDING_PREF_KEY, "CueEnabled"), kDefaultCueEnabled));
+    updateTracklistAsComment();
 
     CheckBoxUseCueFileAnnotation->setChecked(m_pConfig->getValue<bool>(
             ConfigKey(RECORDING_PREF_KEY, "cue_file_annotation_enabled"),
@@ -166,6 +168,7 @@ void DlgPrefRecord::slotApply() {
     saveMetaData();
     saveEncoding();
     saveUseCueFile();
+    saveTracklistAsComment();
     saveUseCueFileAnnotation();
     saveSplitSize();
     saveChannelMode(); // saving channel preference (Mono/Stereo) to the config
@@ -211,6 +214,7 @@ void DlgPrefRecord::slotUpdate() {
     // Setting miscellaneous
     CheckBoxRecordCueFile->setChecked(m_pConfig->getValue<bool>(
             ConfigKey(RECORDING_PREF_KEY, "CueEnabled"), kDefaultCueEnabled));
+    updateTracklistAsComment();
 
     slotToggleCueEnabled();
     loadChannelMode(); // Load recording channel mode (Mono/Stereo) to keep the
@@ -241,6 +245,7 @@ void DlgPrefRecord::slotResetToDefaults() {
 
     // Sets 'Create a CUE file' checkbox value
     CheckBoxRecordCueFile->setChecked(kDefaultCueEnabled);
+    updateTracklistAsComment();
 
     // Sets 'Enable File Annotation in CUE file' checkbox value
     CheckBoxUseCueFileAnnotation->setChecked(kDefaultCueFileAnnotationEnabled);
@@ -338,6 +343,8 @@ void DlgPrefRecord::setupEncoderUI() {
     if (m_selFormat.internalName == ENCODING_MP3) {
         updateTextQuality();
     }
+
+    updateTracklistAsComment();
 }
 
 // This is to load the recording channel mode (Mono/Stereo) from config
@@ -397,6 +404,19 @@ void DlgPrefRecord::updateTextCompression() {
                     m_selFormat, m_pConfig);
     int quality = settings->getCompressionValues().at(SliderCompression->value());
     TextCompression->setText(QString::number(quality));
+}
+
+void DlgPrefRecord::updateTracklistAsComment() {
+    CheckBoxTracklistAsComment->blockSignals(true);
+    if (m_selFormat.internalName == ENCODING_MP3 || m_selFormat.internalName == ENCODING_WAVE) {
+        CheckBoxTracklistAsComment->setEnabled(true);
+        CheckBoxTracklistAsComment->setChecked(m_pConfig->getValue(
+                ConfigKey(RECORDING_PREF_KEY, "tracklist_as_comment"), kDefaultTracklistAsComment));
+    } else {
+        CheckBoxTracklistAsComment->setEnabled(false);
+        CheckBoxTracklistAsComment->setChecked(false);
+    }
+    CheckBoxTracklistAsComment->blockSignals(true);
 }
 
 void DlgPrefRecord::slotGroupChanged() {
@@ -493,6 +513,11 @@ void DlgPrefRecord::slotToggleCueEnabled() {
 void DlgPrefRecord::saveUseCueFile() {
     m_pConfig->set(ConfigKey(RECORDING_PREF_KEY, "CueEnabled"),
             ConfigValue(CheckBoxRecordCueFile->isChecked()));
+}
+
+void DlgPrefRecord::saveTracklistAsComment() {
+    m_pConfig->setValue(ConfigKey(RECORDING_PREF_KEY, "tracklist_as_comment"),
+            CheckBoxTracklistAsComment->isChecked());
 }
 
 void DlgPrefRecord::saveUseCueFileAnnotation() {

--- a/src/preferences/dialog/dlgprefrecord.h
+++ b/src/preferences/dialog/dlgprefrecord.h
@@ -43,10 +43,12 @@ class DlgPrefRecord : public DlgPreferencePage, public Ui::DlgPrefRecordDlg  {
     void loadMetaData();
     void updateTextQuality();
     void updateTextCompression();
+    void updateTracklistAsComment();
     void saveRecordingFolder();
     void saveMetaData();
     void saveEncoding();
     void saveUseCueFile();
+    void saveTracklistAsComment();
     void saveUseCueFileAnnotation();
     void saveSplitSize();
     void loadChannelMode();

--- a/src/preferences/dialog/dlgprefrecorddlg.ui
+++ b/src/preferences/dialog/dlgprefrecorddlg.ui
@@ -169,6 +169,18 @@ information from filepaths (i.e. username)</string>
 
       <item row="1" column="0">
        <widget class="QLabel" name="LabelLossless">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="text">
          <string>Lossless</string>
         </property>
@@ -397,6 +409,16 @@ information from filepaths (i.e. username)</string>
       <item row="2" column="1">
        <widget class="QLineEdit" name="LineEditAlbum"/>
       </item>
+      <item row="4" column="0" colspan="2">
+       <widget class="QCheckBox" name="CheckBoxTracklistAsComment">
+        <property name="toolTip">
+         <string>Only supported for MP3 and WAV</string>
+        </property>
+        <property name="text">
+         <string>Store the tracklist as comment</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -429,6 +451,7 @@ information from filepaths (i.e. username)</string>
   <tabstop>LineEditTitle</tabstop>
   <tabstop>LineEditAuthor</tabstop>
   <tabstop>LineEditAlbum</tabstop>
+  <tabstop>CheckBoxTracklistAsComment</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
Closes #9134

Implemented for MP3 and Wave and tested with both.

`ffprobe` example with MP3
```
$ ffprobe ../2024-10-13_20h38m19s.mp3 
ffprobe [...]
   [...]
[mp3 @ 0x556661ba7b80] Skipping 339 bytes of junk at 813.
Input #0, mp3, from '/home/antoine/Music/Mixxx/Recordings/2024-10-13_20h38m19s.mp3':
  Metadata:
    encoder         : LAME 64bits version 3.100 (http://lame.sf.net)
    title           : Foo
    artist          : Bar
    album           : Baz
    comment         : 00:00:00: Twenty One Pilots - The Craving (single version)
                    : 00:00:09: Carnage - Psy Or Die
                    : 00:00:19: bbno$ - it boy
                    : 00:00:38: Armin van Buuren feat. Trevor Guthrie - This Is What It Feels Like
                    : 00:00:47: Armin van Buuren - Larger Than Life
                    : 00:01:06: Freestylers - Cracks - Flux Pavilion Remix
  Duration: 00:01:17.14, start: 0.023021, bitrate: 128 kb/s
  Stream #0:0: Audio: mp3, 48000 Hz, stereo, fltp, 128 kb/s
    Metadata:
      encoder         : LAME3.100

```

## Note on MP3

After a long day of learning MP3 spec, it would appears that our implementation was somewhat flawed. My understanding is that the `Xing` frame that contains various parameter about the MP3 frames is expect in the beginning of the file, however we currently overwrite the first frames with it, leading to data loss. Since a frame is < 100ms, this is not something you can easily hear.

Second point is, we currently only write IDv1 (automatically supported by lame) but this limits the comment to 30 bytes. In order to lift this limit (and reach the hard limit of 2**32), we need to write ID3v2, but those are expected as header (unlike ID3v1 which can be appended in the footer when flushing the file.

In an ideal world, we would want to shift the file content to fit the ID3 header + the Xing frame. Because this basically requires to tear down the whole `EncoderCallback` mecanism, this instead adds a static header of 10K, which will be filled with the header, leading to a hard limit for comment (limit which depends of the artist, title and album size, as well the Xing frame size.

Appreciate this is far from optimal, but hopefully we can find an acceptable trade-off