### PR TITLE
Fix check for unrelated decks playing when starting Auto DJ

### DIFF
--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -401,6 +401,9 @@ AutoDJProcessor::AutoDJError AutoDJProcessor::toggleAutoDJ(bool enable) {
         // TODO: This is a total bandaid for making Auto DJ work with four decks.
         // We should design a nicer way to handle this.
         for (const auto& pDeck : std::as_const(m_decks)) {
+            VERIFY_OR_DEBUG_ASSERT(pDeck) {
+                continue;
+            }
             if (pDeck == pLeftDeck) {
                 continue;
             }

--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -398,14 +398,20 @@ AutoDJProcessor::AutoDJError AutoDJProcessor::toggleAutoDJ(bool enable) {
             return ADJ_BOTH_DECKS_PLAYING;
         }
 
-        // TODO: This is a total bandaid for making Auto DJ work with decks 3
-        // and 4.  We should design a nicer way to handle this.
-        for (int i = 2; i < m_decks.length(); ++i) {
-            if (m_decks[i] && m_decks[i]->isPlaying()) {
+        // TODO: This is a total bandaid for making Auto DJ work with four decks.
+        // We should design a nicer way to handle this.
+        for (const auto& pDeck : std::as_const(m_decks)) {
+            if (pDeck == pLeftDeck) {
+                continue;
+            }
+            if (pDeck == pRightDeck) {
+                continue;
+            }
+            if (pDeck->isPlaying()) {
                 // Keep the current state.
                 emitAutoDJStateChanged(m_eState);
-                emit autoDJError(ADJ_DECKS_3_4_PLAYING);
-                return ADJ_DECKS_3_4_PLAYING;
+                emit autoDJError(ADJ_UNUSED_DECK_PLAYING);
+                return ADJ_UNUSED_DECK_PLAYING;
             }
         }
 

--- a/src/library/autodj/autodjprocessor.h
+++ b/src/library/autodj/autodjprocessor.h
@@ -155,7 +155,7 @@ class AutoDJProcessor : public QObject {
         ADJ_IS_INACTIVE,
         ADJ_QUEUE_EMPTY,
         ADJ_BOTH_DECKS_PLAYING,
-        ADJ_DECKS_3_4_PLAYING,
+        ADJ_UNUSED_DECK_PLAYING,
         ADJ_NOT_TWO_DECKS
     };
 

--- a/src/library/autodj/dlgautodj.cpp
+++ b/src/library/autodj/dlgautodj.cpp
@@ -297,10 +297,10 @@ void DlgAutoDJ::autoDJError(AutoDJProcessor::AutoDJError error) {
                 tr("One deck must be stopped to enable Auto DJ mode."),
                 QMessageBox::Ok);
         break;
-    case AutoDJProcessor::ADJ_DECKS_3_4_PLAYING:
+    case AutoDJProcessor::ADJ_UNUSED_DECK_PLAYING:
         QMessageBox::warning(nullptr,
                 tr("Auto DJ"),
-                tr("Decks 3 and 4 must be stopped to enable Auto DJ mode."),
+                tr("Decks not used for Auto DJ must be stopped to enable Auto DJ mode."),
                 QMessageBox::Ok);
         break;
     case AutoDJProcessor::ADJ_OK:

--- a/src/test/autodjprocessor_test.cpp
+++ b/src/test/autodjprocessor_test.cpp
@@ -589,12 +589,12 @@ TEST_F(AutoDJProcessorTest, DecksPlayingWarning) {
 TEST_F(AutoDJProcessorTest, Decks34PlayingWarning) {
     deck3.play.set(1);
     AutoDJProcessor::AutoDJError err = pProcessor->toggleAutoDJ(true);
-    EXPECT_EQ(AutoDJProcessor::ADJ_DECKS_3_4_PLAYING, err);
+    EXPECT_EQ(AutoDJProcessor::ADJ_UNUSED_DECK_PLAYING, err);
 
     deck3.play.set(0);
     deck4.play.set(1);
     err = pProcessor->toggleAutoDJ(true);
-    EXPECT_EQ(AutoDJProcessor::ADJ_DECKS_3_4_PLAYING, err);
+    EXPECT_EQ(AutoDJProcessor::ADJ_UNUSED_DECK_PLAYING, err);
 }
 
 TEST_F(AutoDJProcessorTest, QueueEmpty) {


### PR DESCRIPTION
This fixes #13734

Unfortunately this breaks string freeze. So we have the choice for keeping the check 2.4 broken for the uncommon case of using deck 3 or 4 for Auto DJ, but with a translated error or fix the check introducing an English error message.

What do you think. Let's adjust the merge target accordingly. 