### PR TITLE
fix: make `hotcue_focus_color_next`/`_prev` COs `ControlPushButton`s

### DIFF
--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -201,9 +201,9 @@ void CueControl::createControls() {
 
     m_pHotcueFocus = std::make_unique<ControlObject>(ConfigKey(m_group, "hotcue_focus"));
     setHotcueFocusIndex(Cue::kNoHotCue);
-    m_pHotcueFocusColorPrev = std::make_unique<ControlObject>(
+    m_pHotcueFocusColorPrev = std::make_unique<ControlPushButton>(
             ConfigKey(m_group, "hotcue_focus_color_prev"));
-    m_pHotcueFocusColorNext = std::make_unique<ControlObject>(
+    m_pHotcueFocusColorNext = std::make_unique<ControlPushButton>(
             ConfigKey(m_group, "hotcue_focus_color_next"));
 
     // Create hotcue controls

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -352,8 +352,8 @@ class CueControl : public EngineControl {
     std::unique_ptr<ControlProxy> m_pVinylControlMode;
 
     std::unique_ptr<ControlObject> m_pHotcueFocus;
-    std::unique_ptr<ControlObject> m_pHotcueFocusColorNext;
-    std::unique_ptr<ControlObject> m_pHotcueFocusColorPrev;
+    std::unique_ptr<ControlPushButton> m_pHotcueFocusColorNext;
+    std::unique_ptr<ControlPushButton> m_pHotcueFocusColorPrev;
 
     parented_ptr<ControlProxy> m_pPassthrough;
 


### PR DESCRIPTION
This fixes two issues:
1. The Control is not accessible via the controller mapping XML
2. The Control ignores nops, leading to confusing why `engine.setValue(group, ..., 1)` was only working on the first press (which is a confusion that comes up because this is not the case for other button-like controls, since those are implemented using `ControlPushButton`).

Both issues [were raised on Zulip](https://mixxx.zulipchat.com/#narrow/stream/113295-controller-mapping/topic/Problem.20with.20hotcue_focus_color_next.20and.20_prev). 