### PR TITLE
Solves problem with special characters in path to stems

### DIFF
--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -290,7 +290,7 @@ AVFormatContext* SoundSourceFFmpeg::openInputFile(
     // Open input file and allocate/initialize AVFormatContext
     const int avformat_open_input_result =
             avformat_open_input(
-                    &pavInputFormatContext, fileName.toLocal8Bit().constData(), nullptr, nullptr);
+                    &pavInputFormatContext, fileName.toUtf8().constData(), nullptr, nullptr);
     if (avformat_open_input_result != 0) {
         DEBUG_ASSERT(avformat_open_input_result < 0);
         kLogger.warning().noquote()


### PR DESCRIPTION
This change solves the problem when special charactersare in the name of the directories containing stems. In my case ' •'
See issue #13783.