### PR TITLE
chore: pin Node.JS pre-commit hooks to use LTS

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -114,6 +114,7 @@ repos:
     rev: v0.13.0
     hooks:
       - id: markdownlint-cli2
+        language_version: lts
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.29.1
     hooks:


### PR DESCRIPTION
`nodeenv` (used  by `pre-commit` to install Node env for pre-commit hooks using JavaScript) default to install the latest Node.JS runtime. 
v23.0.0 was just released and it contains [a bug](https://github.com/nodejs/node/issues/55410) preventing `npm pack`. This works around the issue by pinning the LTS version instead. 