### PR TITLE
Update mapping for Stanton-DJC-4: Auto DJ

### DIFF
--- a/res/controllers/Stanton-DJC-4.midi.xml
+++ b/res/controllers/Stanton-DJC-4.midi.xml
@@ -2662,18 +2662,18 @@
         <status>0x90</status>
         <midino>0x5A</midino>
         <options>
-            <normal/>
+          <normal/>
         </options>
-    </control>
+      </control>
     <control>
-        <group>[AutoDJ]</group>
-        <key>fade_now</key>
-        <description>AutoDJ fade to next track</description>
-        <status>0x90</status>
-        <midino>0x28</midino>
-        <options>
-            <normal/>
-        </options>
+      <group>[AutoDJ]</group>
+      <key>fade_now</key>
+      <description>AutoDJ fade to next track</description>
+      <status>0x90</status>
+      <midino>0x28</midino>
+      <options>
+        <normal/>
+      </options>
     </control>
     </controls>
     <outputs>

--- a/res/controllers/Stanton-DJC-4.midi.xml
+++ b/res/controllers/Stanton-DJC-4.midi.xml
@@ -2655,6 +2655,26 @@
           <normal />
         </options>
       </control>
+      <control>
+        <group>[AutoDJ]</group>
+        <key>enabled</key>
+        <description>Toggle AutoDJ enable</description>
+        <status>0x90</status>
+        <midino>0x5A</midino>
+        <options>
+            <normal/>
+        </options>
+    </control>
+    <control>
+        <group>[AutoDJ]</group>
+        <key>fade_now</key>
+        <description>AutoDJ fade to next track</description>
+        <status>0x90</status>
+        <midino>0x28</midino>
+        <options>
+            <normal/>
+        </options>
+    </control>
     </controls>
     <outputs>
       <output>


### PR DESCRIPTION
Added:

AutoDJ enable/disable -> shift + TX/FX press (above VU meters) 
AutoDJ fade to next track -> TX/FX press

[Manual PR](https://github.com/mixxxdj/manual/pull/698)