### PR TITLE
add controls to order Hotcues by position

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2461,6 +2461,7 @@ if(BUILD_TESTING)
     src/test/frametest.cpp
     src/test/globaltrackcache_test.cpp
     src/test/hotcuecontrol_test.cpp
+    src/test/hotcueorderbyposition_test.cpp
     src/test/imageutils_test.cpp
     src/test/indexrange_test.cpp
     src/test/itunesxmlimportertest.cpp

--- a/src/audio/frame.h
+++ b/src/audio/frame.h
@@ -5,6 +5,7 @@
 #include <limits>
 
 #include "engine/engine.h"
+#include "util/compatibility/qhash.h"
 #include "util/fpclassify.h"
 
 namespace mixxx {
@@ -246,6 +247,12 @@ inline bool operator!=(FramePos frame1, FramePos frame2) {
 }
 
 QDebug operator<<(QDebug dbg, FramePos arg);
+
+inline qhash_seed_t qHash(
+        FramePos pos,
+        qhash_seed_t seed = 0) {
+    return static_cast<qhash_seed_t>(pos.value(), seed);
+}
 
 constexpr FramePos kInvalidFramePos = FramePos(FramePos::kInvalidValue);
 constexpr FramePos kStartFramePos = FramePos(FramePos::kStartValue);

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -515,20 +515,6 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
 
     // Hotcues
     QMenu* pHotcueMainMenu = addSubmenu(tr("Hotcues"));
-    QString hotcueActivateTitle = tr("Hotcue %1");
-    QString hotcueClearTitle = tr("Clear Hotcue %1");
-    QString hotcueSetTitle = tr("Set Hotcue %1");
-    QString hotcueGotoTitle = tr("Jump To Hotcue %1");
-    QString hotcueGotoAndStopTitle = tr("Jump To Hotcue %1 And Stop");
-    QString hotcueGotoAndPlayTitle = tr("Jump To Hotcue %1 And Play");
-    QString hotcuePreviewTitle = tr("Preview Hotcue %1");
-    QString hotcueActivateDescription = tr("Set, preview from or jump to hotcue %1");
-    QString hotcueClearDescription = tr("Clear hotcue %1");
-    QString hotcueSetDescription = tr("Set hotcue %1");
-    QString hotcueGotoDescription = tr("Jump to hotcue %1");
-    QString hotcueGotoAndStopDescription = tr("Jump to hotcue %1 and stop");
-    QString hotcueGotoAndPlayDescription = tr("Jump to hotcue %1 and play");
-    QString hotcuePreviewDescription = tr("Preview from hotcue %1");
     addDeckControl("shift_cues_earlier",
             tr("Shift cue points earlier"),
             tr("Shift cue points 10 milliseconds earlier"),
@@ -545,6 +531,29 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
             tr("Shift cue points later (fine)"),
             tr("Shift cue points 1 millisecond later"),
             pHotcueMainMenu);
+    addDeckControl("sort_hotcues",
+            tr("Sort hotcues by position"),
+            tr("Sort hotcues by position"),
+            pHotcueMainMenu);
+    addDeckControl("sort_hotcues_remove_offsets",
+            tr("Sort hotcues by position (remove offsets)"),
+            tr("Sort hotcues by position (remove offsets)"),
+            pHotcueMainMenu);
+
+    const QString hotcueActivateTitle = tr("Hotcue %1");
+    const QString hotcueClearTitle = tr("Clear Hotcue %1");
+    const QString hotcueSetTitle = tr("Set Hotcue %1");
+    const QString hotcueGotoTitle = tr("Jump To Hotcue %1");
+    const QString hotcueGotoAndStopTitle = tr("Jump To Hotcue %1 And Stop");
+    const QString hotcueGotoAndPlayTitle = tr("Jump To Hotcue %1 And Play");
+    const QString hotcuePreviewTitle = tr("Preview Hotcue %1");
+    const QString hotcueActivateDescription = tr("Set, preview from or jump to hotcue %1");
+    const QString hotcueClearDescription = tr("Clear hotcue %1");
+    const QString hotcueSetDescription = tr("Set hotcue %1");
+    const QString hotcueGotoDescription = tr("Jump to hotcue %1");
+    const QString hotcueGotoAndStopDescription = tr("Jump to hotcue %1 and stop");
+    const QString hotcueGotoAndPlayDescription = tr("Jump to hotcue %1 and play");
+    const QString hotcuePreviewDescription = tr("Preview from hotcue %1");
     // add menus for hotcues 1-16.
     // though, keep the menu small put additional hotcues in a separate menu,
     // but don't create that submenu for less than 4 additional hotcues.

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -128,6 +128,20 @@ CueControl::CueControl(const QString& group,
     m_pPassthrough->connectValueChanged(this,
             &CueControl::passthroughChanged,
             Qt::DirectConnection);
+
+    m_pSortHotcuesByPos = std::make_unique<ControlPushButton>(ConfigKey(group, "sort_hotcues"));
+    connect(m_pSortHotcuesByPos.get(),
+            &ControlObject::valueChanged,
+            this,
+            &CueControl::setHotcueIndicesSortedByPosition,
+            Qt::DirectConnection);
+    m_pSortHotcuesByPosCompress = std::make_unique<ControlPushButton>(
+            ConfigKey(group, "sort_hotcues_remove_offsets"));
+    connect(m_pSortHotcuesByPosCompress.get(),
+            &ControlObject::valueChanged,
+            this,
+            &CueControl::setHotcueIndicesSortedByPositionCompress,
+            Qt::DirectConnection);
 }
 
 CueControl::~CueControl() {
@@ -445,6 +459,18 @@ void CueControl::passthroughChanged(double enabled) {
     } else {
         // Reconnect all controls when deck returns to regular mode.
         connectControls();
+    }
+}
+
+void CueControl::setHotcueIndicesSortedByPosition(double v) {
+    if (v > 0 && m_pLoadedTrack) {
+        m_pLoadedTrack->setHotcueIndicesSortedByPosition(HotcueSortMode::KeepOffsets);
+    }
+}
+
+void CueControl::setHotcueIndicesSortedByPositionCompress(double v) {
+    if (v > 0 && m_pLoadedTrack) {
+        m_pLoadedTrack->setHotcueIndicesSortedByPosition(HotcueSortMode::RemoveOffsets);
     }
 }
 

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -240,6 +240,9 @@ class CueControl : public EngineControl {
 
     void passthroughChanged(double v);
 
+    void setHotcueIndicesSortedByPosition(double v);
+    void setHotcueIndicesSortedByPositionCompress(double v);
+
     void cueSet(double v);
     void cueClear(double v);
     void cueGoto(double v);
@@ -361,6 +364,9 @@ class CueControl : public EngineControl {
     std::unique_ptr<ControlPushButton> m_pHotcueFocusColorPrev;
 
     parented_ptr<ControlProxy> m_pPassthrough;
+
+    std::unique_ptr<ControlPushButton> m_pSortHotcuesByPos;
+    std::unique_ptr<ControlPushButton> m_pSortHotcuesByPosCompress;
 
     QAtomicPointer<HotcueControl> m_pCurrentSavedLoopControl;
 

--- a/src/test/hotcueorderbyposition_test.cpp
+++ b/src/test/hotcueorderbyposition_test.cpp
@@ -1,0 +1,80 @@
+// #include "library/coverart.h"
+// #include "sources/soundsourceproxy.h"
+// #include "test/soundsourceproviderregistration.h"
+#include "test/mixxxtest.h"
+#include "track/cue.h"
+#include "track/track.h"
+
+// Test for updating track metadata and cover art from files.
+class TrackHotcueOrderByPosTest : public MixxxTest {
+  protected:
+    static TrackPointer newTestTrack() {
+        return Track::newTemporary(
+                QDir(MixxxTest::getOrInitTestDir().filePath(QStringLiteral("track-test-data"))),
+                "THOBP.mp3");
+    }
+};
+
+TEST_F(TrackHotcueOrderByPosTest, orderHotcuesKeepOffsets) {
+    auto pTrack = newTestTrack();
+    pTrack->markClean();
+
+    // create hotcues with ascending position but unordered indices
+    CuePointer pHotcue1 = pTrack->createAndAddCue(mixxx::CueType::HotCue,
+            2,
+            mixxx::audio::FramePos(100),
+            mixxx::audio::kInvalidFramePos);
+    CuePointer pHotcue2 = pTrack->createAndAddCue(mixxx::CueType::HotCue,
+            1,
+            mixxx::audio::FramePos(200),
+            mixxx::audio::kInvalidFramePos);
+    CuePointer pHotcue3 = pTrack->createAndAddCue(mixxx::CueType::HotCue,
+            7,
+            mixxx::audio::FramePos(300),
+            mixxx::audio::kInvalidFramePos,
+            mixxx::PredefinedColorPalettes::kDefaultCueColor);
+    CuePointer pHotcue4 = pTrack->createAndAddCue(mixxx::CueType::HotCue,
+            5,
+            mixxx::audio::FramePos(400),
+            mixxx::audio::kInvalidFramePos);
+
+    pTrack->setHotcueIndicesSortedByPosition(HotcueSortMode::KeepOffsets);
+
+    // Hotcues indices by position should now be 1 2 5 7
+    EXPECT_EQ(pHotcue1->getHotCue(), 1);
+    EXPECT_EQ(pHotcue2->getHotCue(), 2);
+    EXPECT_EQ(pHotcue3->getHotCue(), 5);
+    EXPECT_EQ(pHotcue4->getHotCue(), 7);
+}
+
+TEST_F(TrackHotcueOrderByPosTest, orderHotcuesRemoveOffsets) {
+    auto pTrack = newTestTrack();
+    pTrack->markClean();
+
+    // create hotcues with ascending position but unordered indices
+    CuePointer pHotcue1 = pTrack->createAndAddCue(mixxx::CueType::HotCue,
+            2,
+            mixxx::audio::FramePos(100),
+            mixxx::audio::kInvalidFramePos);
+    CuePointer pHotcue2 = pTrack->createAndAddCue(mixxx::CueType::HotCue,
+            1,
+            mixxx::audio::FramePos(200),
+            mixxx::audio::kInvalidFramePos);
+    CuePointer pHotcue3 = pTrack->createAndAddCue(mixxx::CueType::HotCue,
+            7,
+            mixxx::audio::FramePos(300),
+            mixxx::audio::kInvalidFramePos,
+            mixxx::PredefinedColorPalettes::kDefaultCueColor);
+    CuePointer pHotcue4 = pTrack->createAndAddCue(mixxx::CueType::HotCue,
+            5,
+            mixxx::audio::FramePos(400),
+            mixxx::audio::kInvalidFramePos);
+
+    pTrack->setHotcueIndicesSortedByPosition(HotcueSortMode::RemoveOffsets);
+
+    // Hotcues indices by position should now be 0 1 2 3
+    EXPECT_EQ(pHotcue1->getHotCue(), 0);
+    EXPECT_EQ(pHotcue2->getHotCue(), 1);
+    EXPECT_EQ(pHotcue3->getHotCue(), 2);
+    EXPECT_EQ(pHotcue4->getHotCue(), 3);
+}

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -296,6 +296,11 @@ class Track : public QObject {
     void setMainCuePosition(mixxx::audio::FramePos position);
     /// Shift all cues by a constant offset
     void shiftCuePositionsMillis(mixxx::audio::FrameDiff_t milliseconds);
+    /// Set hoctues' indices sorted by their frame position.
+    /// If compress is true, indices are consecutive and start at 0.
+    /// Set false to sort only, ie. keep empty hotcues before and in between.
+    void setHotcueIndicesSortedByPosition(HotcueSortMode sortMode);
+
     // Call when analysis is done.
     void analysisFinished();
 

--- a/src/track/track_decl.h
+++ b/src/track/track_decl.h
@@ -28,6 +28,11 @@ enum class ExportTrackMetadataResult {
     Skipped,
 };
 
+enum class HotcueSortMode {
+    KeepOffsets,
+    RemoveOffsets,
+};
+
 // key for control to open/close the decks' track menus
 const QString kShowTrackMenuKey = QStringLiteral("show_track_menu");
 

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -217,6 +217,9 @@ void WTrackMenu::createMenus() {
         m_pColorMenu->setTitle(tr("Select Color"));
     }
 
+    m_pHotcueMenu = make_parented<QMenu>(this);
+    m_pHotcueMenu->setTitle(tr("Hotcues"));
+
     if (featureIsEnabled(Feature::Reset)) {
         m_pClearMetadataMenu = make_parented<QMenu>(this);
         //: Reset metadata in right click track context menu in library
@@ -470,6 +473,23 @@ void WTrackMenu::createActions() {
 
         m_pClearAllMetadataAction = make_parented<QAction>(tr("All"), m_pClearMetadataMenu);
         connect(m_pClearAllMetadataAction, &QAction::triggered, this, &WTrackMenu::slotClearAllMetadata);
+
+        m_pSortHotcuesByPositionCompressAction = make_parented<QAction>(
+                tr("Sort hotcues by position (remove offsets)"), m_pHotcueMenu);
+        connect(m_pSortHotcuesByPositionCompressAction,
+                &QAction::triggered,
+                this,
+                [this]() {
+                    slotSortHotcuesByPosition(HotcueSortMode::RemoveOffsets);
+                });
+        m_pSortHotcuesByPositionAction = make_parented<QAction>(
+                tr("Sort hotcues by position"), m_pHotcueMenu);
+        connect(m_pSortHotcuesByPositionAction,
+                &QAction::triggered,
+                this,
+                [this]() {
+                    slotSortHotcuesByPosition(HotcueSortMode::KeepOffsets);
+                });
     }
 
     if (featureIsEnabled(Feature::BPM)) {
@@ -570,6 +590,7 @@ void WTrackMenu::createActions() {
 }
 
 void WTrackMenu::setupActions() {
+    addSeparator();
     if (featureIsEnabled(Feature::SearchRelated)) {
         addMenu(m_pSearchRelatedMenu);
     }
@@ -675,8 +696,13 @@ void WTrackMenu::setupActions() {
         if (featureIsEnabled(Feature::FindOnWeb)) {
             m_pMetadataMenu->addMenu(m_pFindOnWebMenu);
         }
+
         addSeparator();
         addMenu(m_pMetadataMenu);
+
+        m_pHotcueMenu->addAction(m_pSortHotcuesByPositionCompressAction);
+        m_pHotcueMenu->addAction(m_pSortHotcuesByPositionAction);
+        addMenu(m_pHotcueMenu);
     }
 
     if (featureIsEnabled(Feature::Reset)) {
@@ -692,6 +718,7 @@ void WTrackMenu::setupActions() {
         m_pClearMetadataMenu->addAction(m_pClearKeyAction);
         m_pClearMetadataMenu->addAction(m_pClearReplayGainAction);
         m_pClearMetadataMenu->addAction(m_pClearWaveformAction);
+        m_pClearMetadataMenu->addSeparator();
         m_pClearMetadataMenu->addSeparator();
         m_pClearMetadataMenu->addAction(m_pClearAllMetadataAction);
         addMenu(m_pClearMetadataMenu);
@@ -2118,6 +2145,19 @@ class ResetOutroTrackPointerOperation : public mixxx::TrackPointerOperation {
     }
 };
 
+class SortHotcuesByPositionTrackPointerOperation : public mixxx::TrackPointerOperation {
+  public:
+    explicit SortHotcuesByPositionTrackPointerOperation(HotcueSortMode sortMode)
+            : m_sortMode(sortMode) {
+    }
+
+  private:
+    void doApply(const TrackPointer& pTrack) const override {
+        pTrack->setHotcueIndicesSortedByPosition(m_sortMode);
+    }
+    HotcueSortMode m_sortMode;
+};
+
 } // anonymous namespace
 
 void WTrackMenu::slotResetMainCue() {
@@ -2165,6 +2205,27 @@ void WTrackMenu::slotClearHotCues() {
             tr("Removing hot cues from %n track(s)", "", getTrackCount());
     const auto trackOperator =
             RemoveCuesOfTypeTrackPointerOperation(mixxx::CueType::HotCue);
+    applyTrackPointerOperation(
+            progressLabelText,
+            &trackOperator);
+}
+
+void WTrackMenu::slotSortHotcuesByPosition(HotcueSortMode sortMode) {
+    QString progressLabelText;
+    switch (sortMode) {
+    case HotcueSortMode::RemoveOffsets:
+        progressLabelText = tr(
+                "Sorting hotcues of %n track(s) by position (remove offsets)",
+                "",
+                getTrackCount());
+        break;
+    case HotcueSortMode::KeepOffsets:
+        progressLabelText =
+                tr("Sorting hotcues of %n track(s) by position", "", getTrackCount());
+        break;
+    }
+    const auto trackOperator =
+            SortHotcuesByPositionTrackPointerOperation(sortMode);
     applyTrackPointerOperation(
             progressLabelText,
             &trackOperator);

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -12,6 +12,7 @@
 #include "library/trackprocessing.h"
 #include "preferences/usersettings.h"
 #include "track/beats.h"
+#include "track/track_decl.h"
 #include "track/trackref.h"
 #include "util/color/rgbcolor.h"
 #include "util/parented_ptr.h"
@@ -166,6 +167,9 @@ class WTrackMenu : public QMenu {
     void slotScaleBpm(mixxx::Beats::BpmScale scale);
     void slotUndoBeatsChange();
 
+    // Hotcues
+    void slotSortHotcuesByPosition(HotcueSortMode sortMode);
+
     // Info and metadata
     void slotUpdateReplayGainFromPregain();
     void slotShowDlgTagFetcher();
@@ -285,6 +289,7 @@ class WTrackMenu : public QMenu {
     parented_ptr<QMenu> m_pCrateMenu;
     parented_ptr<QMenu> m_pMetadataMenu;
     parented_ptr<QMenu> m_pMetadataUpdateExternalCollectionsMenu;
+    parented_ptr<QMenu> m_pHotcueMenu;
     parented_ptr<QMenu> m_pClearMetadataMenu;
     parented_ptr<QMenu> m_pAnalyzeMenu;
     parented_ptr<QMenu> m_pBPMMenu;
@@ -365,6 +370,8 @@ class WTrackMenu : public QMenu {
     parented_ptr<QAction> m_pClearKeyAction;
     parented_ptr<QAction> m_pClearReplayGainAction;
     parented_ptr<QAction> m_pClearAllMetadataAction;
+    parented_ptr<QAction> m_pSortHotcuesByPositionAction{};
+    parented_ptr<QAction> m_pSortHotcuesByPositionCompressAction{};
 
     const UserSettingsPointer m_pConfig;
     Library* const m_pLibrary;


### PR DESCRIPTION
This is a small helper for my hotcue workflow, see below.

**TL;DR:**
Adds two controls to order hotcues by position in the track:
6 4 5 2 ==> 2 4 5 6
(only index is changed, see static hotcue colors in the waveform)
* `sort_hotcues` just reorder (keeps unset cues)
![hotcues-sort-75](https://github.com/user-attachments/assets/06fe3e92-913d-4c55-bc97-ae7354485f2a)

* `sort_hotcues_remove_offsets` reorder and compress: hotcues start at 1, remove unset cues
![hotcues-sort-compress-75](https://github.com/user-attachments/assets/eba9a657-a624-4431-b2b3-12c68783341d)

### TODO
- [x] add tests
- [x] include loop cues and jump cues
- [x] move actions to 'Hotcue' menu (track menu)

There's no a 'Hotcues' menu with these two actions:
![hotcues-menu](https://github.com/user-attachments/assets/8050c513-9b4a-4086-87f7-6b524e7343bc)


**Background:**
I usually set 1 at the start/first sound, 2 at the first beat (ifi t's not 1 already), 3 left empty for some interesting spot in long intros, 4 first phrase for mixing (main) beat etc.
So sometimes it turns out I don't need 2 & 3 but need some extra cues in between 4 - 8.
Or I need extra cues before 4.
Being able to rearrange cues with #13394 is great, but might be cumbersome, especially when I'm in a hurry during (live) preparation

Draft until #13394 has been merged and there's some agreement how to proceed here.

