### PR TITLE
Remove tap beat mapping for DDJ-400 and DDJ-FLX4

### DIFF
--- a/res/controllers/Pioneer-DDJ-400.midi.xml
+++ b/res/controllers/Pioneer-DDJ-400.midi.xml
@@ -890,27 +890,6 @@
             </control>
 
             <control>
-                <description>CUE Channel +SHIFT - press - Adjust BPM to match tapped BPM</description>
-                <group>[Channel1]</group>
-                <key>bpm_tap</key>
-                <status>0x90</status>
-                <midino>0x68</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <description>CUE Channel +SHIFT - press - Adjust BPM to match tapped BPM</description>
-                <group>[Channel2]</group>
-                <key>bpm_tap</key>
-                <status>0x91</status>
-                <midino>0x68</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-
-            <control>
                 <description>HEADPHONES MIXING - rotate - Monitor Balance</description>
                 <group>[Master]</group>
                 <key>headMix</key>

--- a/res/controllers/Pioneer-DDJ-FLX4.midi.xml
+++ b/res/controllers/Pioneer-DDJ-FLX4.midi.xml
@@ -900,27 +900,6 @@
             </control>
 
             <control>
-                <description>CUE Channel +SHIFT - press - Adjust BPM to match tapped BPM</description>
-                <group>[Channel1]</group>
-                <key>bpm_tap</key>
-                <status>0x90</status>
-                <midino>0x68</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <description>CUE Channel +SHIFT - press - Adjust BPM to match tapped BPM</description>
-                <group>[Channel2]</group>
-                <key>bpm_tap</key>
-                <status>0x91</status>
-                <midino>0x68</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-
-            <control>
                 <description>HEADPHONES MIXING - rotate - Monitor Balance</description>
                 <group>[Master]</group>
                 <key>headMix</key>


### PR DESCRIPTION
The key combination was used for both toggle channel quantize and ajust channel BPM to match tapped BPM. After discussion with @jusko, beat tap being less useful, it's the one that should go.

This fixes #13813 

No documentation change is needed as the toggle quantize behavior that remains after this PR is the one that is already documented [here](https://github.com/mixxxdj/manual/blob/2.4/source/hardware/controllers/pioneer_ddj_400.rst?plain=1#L273) and [here](https://github.com/mixxxdj/manual/blob/2.4/source/hardware/controllers/pioneer_ddj_flx4.rst?plain=1#L264)