### PR TITLE
Code cleanup in SidebarModel and WLibrarySidebar

### DIFF
--- a/src/library/sidebarmodel.cpp
+++ b/src/library/sidebarmodel.cpp
@@ -18,7 +18,7 @@ namespace {
 constexpr int kPressedUntilClickedTimeoutMillis = 300;
 
 /// Enables additional debugging output.
-constexpr bool sDebug = false;
+constexpr bool kDebug = false;
 
 } // anonymous namespace
 
@@ -104,7 +104,7 @@ void SidebarModel::activateDefaultSelection() {
 
 QModelIndex SidebarModel::index(int row, int column,
                                 const QModelIndex& parent) const {
-    if constexpr (sDebug) {
+    if constexpr (kDebug) {
         qDebug() << "SidebarModel::index row=" << row
                  << "column=" << column << "parent=" << parent;
     }
@@ -143,7 +143,7 @@ QModelIndex SidebarModel::index(int row, int column,
 }
 
 QModelIndex SidebarModel::getFeatureRootIndex(LibraryFeature* pFeature) {
-    if constexpr (sDebug) {
+    if constexpr (kDebug) {
         qDebug() << "SidebarModel::getFeatureRootIndex for" << pFeature->title().toString();
     }
     QModelIndex ind;
@@ -175,7 +175,7 @@ void SidebarModel::paste(const QModelIndex& index) {
 }
 
 QModelIndex SidebarModel::parent(const QModelIndex& index) const {
-    if constexpr (sDebug) {
+    if constexpr (kDebug) {
         qDebug() << "SidebarModel::parent index=" << index;
     }
     if (index.isValid()) {
@@ -217,7 +217,7 @@ QModelIndex SidebarModel::parent(const QModelIndex& index) const {
 }
 
 int SidebarModel::rowCount(const QModelIndex& parent) const {
-    if constexpr (sDebug) {
+    if constexpr (kDebug) {
         qDebug() << "SidebarModel::rowCount parent=" << parent;
     }
     if (parent.isValid()) {
@@ -237,7 +237,7 @@ int SidebarModel::rowCount(const QModelIndex& parent) const {
 
 int SidebarModel::columnCount(const QModelIndex& parent) const {
     Q_UNUSED(parent);
-    if constexpr (sDebug) {
+    if constexpr (kDebug) {
         qDebug() << "SidebarModel::columnCount parent=" << parent;
     }
     // TODO(rryan) will we ever have columns? I don't think so.
@@ -261,7 +261,7 @@ bool SidebarModel::hasChildren(const QModelIndex& parent) const {
 }
 
 QVariant SidebarModel::data(const QModelIndex& index, int role) const {
-    if constexpr (sDebug) {
+    if constexpr (kDebug) {
         qDebug("SidebarModel::data() row=%d column=%d pointer=%p, role=%d",
                 index.row(),
                 index.column(),
@@ -437,7 +437,7 @@ void SidebarModel::deleteItem(const QModelIndex& index) {
 }
 
 bool SidebarModel::dropAccept(const QModelIndex& index, const QList<QUrl>& urls, QObject* pSource) {
-    if constexpr (sDebug) {
+    if constexpr (kDebug) {
         qDebug() << "SidebarModel::dropAccept() index=" << index << urls;
     }
     bool result = false;
@@ -463,7 +463,7 @@ bool SidebarModel::hasTrackTable(const QModelIndex& index) const {
 }
 
 bool SidebarModel::dragMoveAccept(const QModelIndex& index, const QUrl& url) const {
-    if constexpr (sDebug) {
+    if constexpr (kDebug) {
         qDebug() << "SidebarModel::dragMoveAccept() index=" << index << url;
     }
     bool result = false;

--- a/src/library/sidebarmodel.cpp
+++ b/src/library/sidebarmodel.cpp
@@ -262,7 +262,7 @@ bool SidebarModel::hasChildren(const QModelIndex& parent) const {
 
 QVariant SidebarModel::data(const QModelIndex& index, int role) const {
     if constexpr (sDebug) {
-        qDebug("SidebarModel::data() row=%d column=%d pointer=%8x, role=%d",
+        qDebug("SidebarModel::data() row=%d column=%d pointer=%p, role=%d",
                 index.row(),
                 index.column(),
                 index.internalPointer(),

--- a/src/library/sidebarmodel.cpp
+++ b/src/library/sidebarmodel.cpp
@@ -17,6 +17,9 @@ namespace {
 /// been chosen as a compromise between usability and responsiveness.
 constexpr int kPressedUntilClickedTimeoutMillis = 300;
 
+/// Enables additional debugging output.
+constexpr bool sDebug = false;
+
 } // anonymous namespace
 
 SidebarModel::SidebarModel(
@@ -101,8 +104,11 @@ void SidebarModel::activateDefaultSelection() {
 
 QModelIndex SidebarModel::index(int row, int column,
                                 const QModelIndex& parent) const {
-    // qDebug() << "SidebarModel::index row=" << row
-      //       << "column=" << column << "parent=" << parent.getData();
+    if constexpr (sDebug) {
+        qDebug() << "SidebarModel::index row=" << row
+                 << "column=" << column << "parent=" << parent;
+    }
+
     if (parent.isValid()) {
         /* If we have selected the root of a library feature at position 'row'
          * its internal pointer is the current sidebar object model
@@ -137,7 +143,9 @@ QModelIndex SidebarModel::index(int row, int column,
 }
 
 QModelIndex SidebarModel::getFeatureRootIndex(LibraryFeature* pFeature) {
-    // qDebug() << "SidebarModel::getFeatureRootIndex for" << pFeature->title().toString();
+    if constexpr (sDebug) {
+        qDebug() << "SidebarModel::getFeatureRootIndex for" << pFeature->title().toString();
+    }
     QModelIndex ind;
     for (int i = 0; i < m_sFeatures.size(); ++i) {
         if (m_sFeatures[i] == pFeature) {
@@ -167,7 +175,9 @@ void SidebarModel::paste(const QModelIndex& index) {
 }
 
 QModelIndex SidebarModel::parent(const QModelIndex& index) const {
-    //qDebug() << "SidebarModel::parent index=" << index.getData();
+    if constexpr (sDebug) {
+        qDebug() << "SidebarModel::parent index=" << index;
+    }
     if (index.isValid()) {
         // If we have selected the root of a library feature
         // its internal pointer is the current sidebar object model
@@ -207,7 +217,9 @@ QModelIndex SidebarModel::parent(const QModelIndex& index) const {
 }
 
 int SidebarModel::rowCount(const QModelIndex& parent) const {
-    //qDebug() << "SidebarModel::rowCount parent=" << parent.getData();
+    if constexpr (sDebug) {
+        qDebug() << "SidebarModel::rowCount parent=" << parent;
+    }
     if (parent.isValid()) {
         if (parent.internalPointer() == this) {
             return m_sFeatures[parent.row()]->sidebarModel()->rowCount();
@@ -225,7 +237,9 @@ int SidebarModel::rowCount(const QModelIndex& parent) const {
 
 int SidebarModel::columnCount(const QModelIndex& parent) const {
     Q_UNUSED(parent);
-    //qDebug() << "SidebarModel::columnCount parent=" << parent;
+    if constexpr (sDebug) {
+        qDebug() << "SidebarModel::columnCount parent=" << parent;
+    }
     // TODO(rryan) will we ever have columns? I don't think so.
     return 1;
 }
@@ -247,8 +261,14 @@ bool SidebarModel::hasChildren(const QModelIndex& parent) const {
 }
 
 QVariant SidebarModel::data(const QModelIndex& index, int role) const {
-    // qDebug("SidebarModel::data row=%d column=%d pointer=%8x, role=%d",
-    //        index.row(), index.column(), index.internalPointer(), role);
+    if constexpr (sDebug) {
+        qDebug("SidebarModel::data() row=%d column=%d pointer=%8x, role=%d",
+                index.row(),
+                index.column(),
+                index.internalPointer(),
+                role);
+    }
+
     if (!index.isValid()) {
         return QVariant();
     }
@@ -417,7 +437,9 @@ void SidebarModel::deleteItem(const QModelIndex& index) {
 }
 
 bool SidebarModel::dropAccept(const QModelIndex& index, const QList<QUrl>& urls, QObject* pSource) {
-    //qDebug() << "SidebarModel::dropAccept() index=" << index << url;
+    if constexpr (sDebug) {
+        qDebug() << "SidebarModel::dropAccept() index=" << index << urls;
+    }
     bool result = false;
     if (index.isValid()) {
         if (index.internalPointer() == this) {
@@ -440,8 +462,10 @@ bool SidebarModel::hasTrackTable(const QModelIndex& index) const {
     return false;
 }
 
-bool SidebarModel::dragMoveAccept(const QModelIndex& index, const QUrl& url) {
-    //qDebug() << "SidebarModel::dragMoveAccept() index=" << index << url;
+bool SidebarModel::dragMoveAccept(const QModelIndex& index, const QUrl& url) const {
+    if constexpr (sDebug) {
+        qDebug() << "SidebarModel::dragMoveAccept() index=" << index << url;
+    }
     bool result = false;
 
     if (index.isValid()) {

--- a/src/library/sidebarmodel.h
+++ b/src/library/sidebarmodel.h
@@ -39,7 +39,7 @@ class SidebarModel : public QAbstractItemModel {
     QVariant data(const QModelIndex& index,
                   int role = Qt::DisplayRole) const override;
     bool dropAccept(const QModelIndex& index, const QList<QUrl>& urls, QObject* pSource);
-    bool dragMoveAccept(const QModelIndex& index, const QUrl& url);
+    bool dragMoveAccept(const QModelIndex& index, const QUrl& url) const;
     bool hasChildren(const QModelIndex& parent = QModelIndex()) const override;
     bool hasTrackTable(const QModelIndex& index) const;
     QModelIndex translateChildIndex(const QModelIndex& index) {

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -43,7 +43,7 @@ void WLibrarySidebar::contextMenuEvent(QContextMenuEvent *event) {
     //}
 }
 
-// Drag enter event, happens when a dragged item enters the track sources view
+/// Drag enter event, happens when a dragged item enters the track sources view
 void WLibrarySidebar::dragEnterEvent(QDragEnterEvent * event) {
     qDebug() << "WLibrarySidebar::dragEnterEvent" << event->mimeData()->formats();
     if (event->mimeData()->hasUrls()) {
@@ -62,7 +62,7 @@ void WLibrarySidebar::dragEnterEvent(QDragEnterEvent * event) {
     //QTreeView::dragEnterEvent(event);
 }
 
-// Drag move event, happens when a dragged item hovers over the track sources view...
+/// Drag move event, happens when a dragged item hovers over the track sources view...
 void WLibrarySidebar::dragMoveEvent(QDragMoveEvent * event) {
     //qDebug() << "dragMoveEvent" << event->mimeData()->formats();
     // Start a timer to auto-expand sections the user hovers on.

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -66,11 +66,7 @@ void WLibrarySidebar::dragEnterEvent(QDragEnterEvent * event) {
 void WLibrarySidebar::dragMoveEvent(QDragMoveEvent * event) {
     //qDebug() << "dragMoveEvent" << event->mimeData()->formats();
     // Start a timer to auto-expand sections the user hovers on.
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     QPoint pos = event->position().toPoint();
-#else
-    QPoint pos = event->pos();
-#endif
     QModelIndex index = indexAt(pos);
     if (m_hoverIndex != index) {
         m_expandTimer.stop();
@@ -93,11 +89,7 @@ void WLibrarySidebar::dragMoveEvent(QDragMoveEvent * event) {
             if (sidebarModel) {
                 accepted = false;
                 for (const QUrl& url : urls) {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
                     QPoint pos = event->position().toPoint();
-#else
-                    QPoint pos = event->pos();
-#endif
                     QModelIndex destIndex = indexAt(pos);
                     if (sidebarModel->dragMoveAccept(destIndex, url)) {
                         // We only need one URL to be valid for us
@@ -152,13 +144,9 @@ void WLibrarySidebar::dropEvent(QDropEvent * event) {
             //eg. dragging a track from Windows Explorer onto the sidebar
             SidebarModel* sidebarModel = qobject_cast<SidebarModel*>(model());
             if (sidebarModel) {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
                 QPoint pos = event->position().toPoint();
-#else
-                QPoint pos = event->pos();
-#endif
-
                 QModelIndex destIndex = indexAt(pos);
+
                 // event->source() will return NULL if something is dropped from
                 // a different application
                 const QList<QUrl> urls = event->mimeData()->urls();

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -66,7 +66,11 @@ void WLibrarySidebar::dragEnterEvent(QDragEnterEvent * event) {
 void WLibrarySidebar::dragMoveEvent(QDragMoveEvent * event) {
     //qDebug() << "dragMoveEvent" << event->mimeData()->formats();
     // Start a timer to auto-expand sections the user hovers on.
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     QPoint pos = event->position().toPoint();
+#else
+    QPoint pos = event->pos();
+#endif
     QModelIndex index = indexAt(pos);
     if (m_hoverIndex != index) {
         m_expandTimer.stop();
@@ -89,7 +93,11 @@ void WLibrarySidebar::dragMoveEvent(QDragMoveEvent * event) {
             if (sidebarModel) {
                 accepted = false;
                 for (const QUrl& url : urls) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
                     QPoint pos = event->position().toPoint();
+#else
+                    QPoint pos = event->pos();
+#endif
                     QModelIndex destIndex = indexAt(pos);
                     if (sidebarModel->dragMoveAccept(destIndex, url)) {
                         // We only need one URL to be valid for us
@@ -146,9 +154,13 @@ void WLibrarySidebar::dropEvent(QDropEvent * event) {
             //eg. dragging a track from Windows Explorer onto the sidebar
             SidebarModel* sidebarModel = qobject_cast<SidebarModel*>(model());
             if (sidebarModel) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
                 QPoint pos = event->position().toPoint();
-                QModelIndex destIndex = indexAt(pos);
+#else
+                QPoint pos = event->pos();
+#endif
 
+                QModelIndex destIndex = indexAt(pos);
                 // event->source() will return NULL if something is dropped from
                 // a different application
                 const QList<QUrl> urls = event->mimeData()->urls();

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -94,10 +94,12 @@ void WLibrarySidebar::dragMoveEvent(QDragMoveEvent * event) {
                     if (sidebarModel->dragMoveAccept(destIndex, url)) {
                         // We only need one URL to be valid for us
                         // to accept the whole drag...
-                        // consider we have a long list of valid files, checking all will
-                        // take a lot of time that stales Mixxx and this makes the drop feature useless
-                        // Eg. you may have tried to drag two MP3's and an EXE, the drop is accepted here,
-                        // but the EXE is sorted out later after dropping
+                        // Consider that we might have a long list of files,
+                        // checking all will take a lot of time that stalls
+                        // Mixxx and this makes the drop feature useless.
+                        // E.g. you may have tried to drag two MP3's and an EXE,
+                        // the drop is accepted here, but the EXE is filtered
+                        // out later after dropping
                         accepted = true;
                         break;
                     }


### PR DESCRIPTION
Just a few small code format cleanups split off from a larger PR series for implementing crate folders.

- SidebarModel: Hide debug logging behind a `constexpr` flag instead of comments & use correct `printf` format for `void*` pointer (to avoid clazy warning/error)
- WLibrarySidebar: Remove `#ifdef`'d code for pre-Qt6 versions, adjust linebreaks in comment for readability, add `const` to declaration of `dragMoveAccept` to match the definition