### PR TITLE
Track Info Dialog: Improve keyboard usability & resize behavior

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1752,6 +1752,7 @@ add_library(
   src/widget/paintable.cpp
   src/widget/wanalysislibrarytableview.cpp
   src/widget/wbasewidget.cpp
+  src/widget/wbasicpushbutton.cpp
   src/widget/wbattery.cpp
   src/widget/wbeatspinbox.cpp
   src/widget/wbpmeditor.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1790,6 +1790,7 @@ add_library(
   src/widget/wlibrarytextbrowser.cpp
   src/widget/wmainmenubar.cpp
   src/widget/wmenucheckbox.cpp
+  src/widget/wmultilinetextedit.cpp
   src/widget/wnumber.cpp
   src/widget/wnumberdb.cpp
   src/widget/wnumberpos.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1758,6 +1758,7 @@ add_library(
   src/widget/wcollapsiblegroupbox.cpp
   src/widget/wcolorpicker.cpp
   src/widget/wcolorpickeraction.cpp
+  src/widget/wcolorpickeractionmenu.cpp
   src/widget/wcombobox.cpp
   src/widget/wcoverart.cpp
   src/widget/wcoverartlabel.cpp

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -281,10 +281,6 @@ void DlgTrackInfo::init() {
             &DlgTrackInfo::slotOpenInFileBrowser);
 
     // Cover art
-    m_pWCoverArtLabel->setToolTip(
-            tr("Left-click to show larger preview") + "\n" +
-            tr("Right-click for more options"));
-
     CoverArtCache* pCache = CoverArtCache::instance();
     if (pCache) {
         connect(pCache,

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -82,6 +82,7 @@ void DlgTrackInfo::init() {
     m_propertyWidgets.insert("key", txtKey);
     m_propertyWidgets.insert("grouping", txtGrouping);
     m_propertyWidgets.insert("comment", txtComment);
+    m_propertyWidgets.insert("color", btnColorPicker);
 
     coverLayout->setAlignment(Qt::AlignRight | Qt::AlignTop);
     coverLayout->setSpacing(0);

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -83,9 +83,6 @@ void DlgTrackInfo::init() {
     m_propertyWidgets.insert("grouping", txtGrouping);
     m_propertyWidgets.insert("comment", txtComment);
 
-    coverLayout->setAlignment(Qt::AlignRight | Qt::AlignTop);
-    coverLayout->setSpacing(0);
-    coverLayout->setContentsMargins(0, 0, 0, 0);
     coverLayout->insertWidget(0, m_pWCoverArtLabel.get());
 
     starsLayout->setAlignment(Qt::AlignRight | Qt::AlignVCenter);

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -21,6 +21,7 @@
 #include "util/datetime.h"
 #include "util/desktophelper.h"
 #include "util/duration.h"
+#include "widget/wcolorpickeractionmenu.h"
 #include "widget/wcoverartlabel.h"
 #include "widget/wcoverartmenu.h"
 #include "widget/wstarrating.h"
@@ -52,7 +53,7 @@ DlgTrackInfo::DlgTrackInfo(
           m_pWCoverArtMenu(make_parented<WCoverArtMenu>(this)),
           m_pWCoverArtLabel(make_parented<WCoverArtLabel>(this, m_pWCoverArtMenu)),
           m_pWStarRating(make_parented<WStarRating>(this)),
-          m_pColorPicker(make_parented<WColorPickerAction>(
+          m_pColorPicker(make_parented<WColorPickerActionMenu>(
                   WColorPicker::Option::AllowNoColor |
                           // TODO(xxx) remove this once the preferences are themed via QSS
                           WColorPicker::Option::NoExtStyleSheet,
@@ -60,6 +61,13 @@ DlgTrackInfo::DlgTrackInfo(
                   this)),
           m_widgetSizesFixed(false) {
     init();
+}
+
+DlgTrackInfo::~DlgTrackInfo() {
+    // ~parented_ptr() needs the definition of the wrapped type
+    // upon deletion! Otherwise the behavior is undefined.
+    // The wrapped types of some parented_ptr members are only
+    // forward declared in the header file.
 }
 
 void DlgTrackInfo::init() {
@@ -308,12 +316,10 @@ void DlgTrackInfo::init() {
             &DlgTrackInfo::slotRatingChanged);
 
     btnColorPicker->setStyle(QStyleFactory::create(QStringLiteral("fusion")));
-    QMenu* pColorPickerMenu = new QMenu(this);
-    pColorPickerMenu->addAction(m_pColorPicker);
-    btnColorPicker->setMenu(pColorPickerMenu);
+    btnColorPicker->setMenu(m_pColorPicker.get());
 
     connect(m_pColorPicker.get(),
-            &WColorPickerAction::colorPicked,
+            &WColorPickerActionMenu::colorPicked,
             this,
             [this](const mixxx::RgbColor::optional_t& newColor) {
                 trackColorDialogSetColor(newColor);

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -341,6 +341,59 @@ void DlgTrackInfo::init() {
                 trackColorDialogSetColor(newColor);
                 m_trackRecord.setColor(newColor);
             });
+
+    tabWidget->installEventFilter(this);
+    txtTrackName->installEventFilter(this);
+    txtArtist->installEventFilter(this);
+    txtAlbum->installEventFilter(this);
+    txtAlbumArtist->installEventFilter(this);
+    txtComposer->installEventFilter(this);
+    txtGenre->installEventFilter(this);
+    txtGrouping->installEventFilter(this);
+    txtYear->installEventFilter(this);
+    txtKey->installEventFilter(this);
+    txtTrackNumber->installEventFilter(this);
+    txtDuration->installEventFilter(this);
+    txtBpm->installEventFilter(this);
+    txtDateAdded->installEventFilter(this);
+    txtDateLastPlayed->installEventFilter(this);
+    txtType->installEventFilter(this);
+    txtBpm->installEventFilter(this);
+    txtBitrate->installEventFilter(this);
+    txtSamplerate->installEventFilter(this);
+    txtReplayGain->installEventFilter(this);
+    txtLocation->installEventFilter(this);
+}
+
+bool DlgTrackInfo::eventFilter(QObject* pObj, QEvent* pEvent) {
+    if (pEvent->type() == QEvent::KeyPress) {
+        auto* pKeyEvent = static_cast<QKeyEvent*>(pEvent);
+
+        const bool noModifiersPressed = !(pKeyEvent->modifiers() &
+                (Qt::ControlModifier | Qt::AltModifier |
+                        Qt::ShiftModifier | Qt::MetaModifier));
+
+        if (!noModifiersPressed) {
+            return false;
+        }
+
+        if (pObj == this || qobject_cast<QLabel*>(pObj) ||
+                qobject_cast<QLineEdit*>(pObj) ||
+                qobject_cast<QTabWidget*>(pObj))
+
+            if (pKeyEvent->key() == Qt::Key_Up) {
+                if (focusPreviousChild()) {
+                    pEvent->accept();
+                    return true;
+                }
+            } else if (pKeyEvent->key() == Qt::Key_Down) {
+                if (focusNextChild()) {
+                    pEvent->accept();
+                    return true;
+                }
+            }
+    }
+    return false;
 }
 
 void DlgTrackInfo::slotApply() {

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -356,9 +356,14 @@ void DlgTrackInfo::slotPrevDlgTagFetcher() {
     loadPrevTrack();
 }
 
+QModelIndex DlgTrackInfo::getPrevNextTrack(bool next) {
+    return m_currentTrackIndex.sibling(
+            m_currentTrackIndex.row() + (next ? 1 : -1),
+            m_currentTrackIndex.column());
+}
+
 void DlgTrackInfo::loadNextTrack() {
-    auto nextRow = m_currentTrackIndex.sibling(
-            m_currentTrackIndex.row() + 1, m_currentTrackIndex.column());
+    auto nextRow = getPrevNextTrack(true);
     if (nextRow.isValid()) {
         loadTrack(nextRow);
         emit next();
@@ -366,8 +371,7 @@ void DlgTrackInfo::loadNextTrack() {
 }
 
 void DlgTrackInfo::loadPrevTrack() {
-    QModelIndex prevRow = m_currentTrackIndex.sibling(
-            m_currentTrackIndex.row() - 1, m_currentTrackIndex.column());
+    auto prevRow = getPrevNextTrack(false);
     if (prevRow.isValid()) {
         loadTrack(prevRow);
         emit previous();
@@ -557,6 +561,9 @@ void DlgTrackInfo::loadTrack(const QModelIndex& index) {
         return;
     }
     m_currentTrackIndex = index;
+    btnPrev->setEnabled(getPrevNextTrack(false).isValid());
+    btnNext->setEnabled(getPrevNextTrack(true).isValid());
+
     loadTrackInternal(pTrack);
     if (m_pDlgTagFetcher && m_pDlgTagFetcher->isVisible()) {
         m_pDlgTagFetcher->loadTrack(m_currentTrackIndex);

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -312,10 +312,6 @@ void DlgTrackInfo::init() {
     pColorPickerMenu->addAction(m_pColorPicker);
     btnColorPicker->setMenu(pColorPickerMenu);
 
-    connect(btnColorPicker,
-            &QPushButton::clicked,
-            this,
-            &DlgTrackInfo::slotColorButtonClicked);
     connect(m_pColorPicker.get(),
             &WColorPickerAction::colorPicked,
             this,
@@ -612,13 +608,6 @@ void DlgTrackInfo::slotOpenInFileBrowser() {
         return;
     }
     mixxx::DesktopHelper::openInFileBrowser(QStringList(m_pLoadedTrack->getLocation()));
-}
-
-void DlgTrackInfo::slotColorButtonClicked() {
-    if (!m_pLoadedTrack) {
-        return;
-    }
-    btnColorPicker->showMenu();
 }
 
 void DlgTrackInfo::trackColorDialogSetColor(const mixxx::RgbColor::optional_t& newColor) {

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -1,5 +1,6 @@
 #include "library/dlgtrackinfo.h"
 
+#include <QShortcut>
 #include <QSignalBlocker>
 #include <QStyleFactory>
 #include <QtDebug>
@@ -104,6 +105,18 @@ void DlgTrackInfo::init() {
                 &QPushButton::clicked,
                 this,
                 &DlgTrackInfo::slotPrevButton);
+
+        QShortcut* nextShortcut = new QShortcut(QKeySequence("Alt+Right"), this);
+        QShortcut* prevShortcut = new QShortcut(QKeySequence("Alt+Left"), this);
+
+        connect(nextShortcut,
+                &QShortcut::activated,
+                btnNext,
+                [this] { btnNext->animateClick(); });
+        connect(prevShortcut,
+                &QShortcut::activated,
+                btnPrev,
+                [this] { btnPrev->animateClick(); });
     } else {
         btnNext->hide();
         btnPrev->hide();

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -95,6 +95,11 @@ void DlgTrackInfo::init() {
     // This is necessary to pass on mouseMove events to WStarRating
     m_pWStarRating->setMouseTracking(true);
 
+    // Workaround: Align the baseline of the "Comments" label
+    // with the baseline of the text inside the comments field
+    const int topMargin = txtComment->frameWidth() + int(txtComment->document()->documentMargin());
+    lblTrackComment->setContentsMargins(0, topMargin, 0, 0);
+
     if (m_pTrackModel) {
         connect(btnNext,
                 &QPushButton::clicked,

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -379,6 +379,7 @@ void DlgTrackInfo::loadNextTrack() {
     auto nextRow = getPrevNextTrack(true);
     if (nextRow.isValid()) {
         loadTrack(nextRow);
+        refocusCurrentWidget();
         emit next();
     }
 }
@@ -387,7 +388,23 @@ void DlgTrackInfo::loadPrevTrack() {
     auto prevRow = getPrevNextTrack(false);
     if (prevRow.isValid()) {
         loadTrack(prevRow);
+        refocusCurrentWidget();
         emit previous();
+    }
+}
+
+/// Simulate moving the focus out of and then back into the currently
+/// focused widget to trigger behaviors like the "Select all on focus"
+/// for QLineEdit.
+///
+/// This is done when moving to the previous/next track, because,
+/// logically, the user has moved to a new dialog, even though we
+/// reuse the current dialog instance internally.
+void DlgTrackInfo::refocusCurrentWidget() {
+    QWidget* focusedWidget = QApplication::focusWidget();
+    if (focusedWidget && isAncestorOf(focusedWidget)) {
+        focusedWidget->clearFocus();
+        focusedWidget->setFocus(Qt::ShortcutFocusReason);
     }
 }
 

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -393,6 +393,19 @@ bool DlgTrackInfo::eventFilter(QObject* pObj, QEvent* pEvent) {
                 }
             }
     }
+    if (pEvent->type() == QEvent::FocusIn) {
+        auto* pFocusEvent = static_cast<QFocusEvent*>(pEvent);
+
+        if (pFocusEvent->reason() == Qt::TabFocusReason ||
+                pFocusEvent->reason() == Qt::BacktabFocusReason ||
+                pFocusEvent->reason() == Qt::ShortcutFocusReason) {
+            auto* pLabel = qobject_cast<QLabel*>(pObj);
+            if (pLabel && !pLabel->hasSelectedText()) {
+                pLabel->setSelection(0, pLabel->text().size());
+                return false;
+            }
+        }
+    }
     return false;
 }
 
@@ -674,7 +687,7 @@ void DlgTrackInfo::focusField(const QString& property) {
             // If we shall focus the BPM spinbox, switch to BPM tab
             tabWidget->setCurrentIndex(tabWidget->indexOf(tabBPM));
         }
-        it.value()->setFocus();
+        it.value()->setFocus(Qt::ShortcutFocusReason);
     }
 }
 

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -431,36 +431,30 @@ void DlgTrackInfo::replaceTrackRecord(
 }
 
 void DlgTrackInfo::updateTrackMetadataFields() {
+    const auto metadata = m_trackRecord.getMetadata();
+    const auto trackInfo = metadata.getTrackInfo();
+    const auto albumInfo = metadata.getAlbumInfo();
+    const auto signalInfo = metadata.getStreamInfo().getSignalInfo();
+
     // Editable fields
-    txtTitle->setText(
-            m_trackRecord.getMetadata().getTrackInfo().getTitle());
-    txtArtist->setText(
-            m_trackRecord.getMetadata().getTrackInfo().getArtist());
-    txtAlbum->setText(
-            m_trackRecord.getMetadata().getAlbumInfo().getTitle());
-    txtAlbumArtist->setText(
-            m_trackRecord.getMetadata().getAlbumInfo().getArtist());
-    txtGenre->setText(
-            m_trackRecord.getMetadata().getTrackInfo().getGenre());
-    txtComposer->setText(
-            m_trackRecord.getMetadata().getTrackInfo().getComposer());
-    txtGrouping->setText(
-            m_trackRecord.getMetadata().getTrackInfo().getGrouping());
-    txtYear->setText(
-            m_trackRecord.getMetadata().getTrackInfo().getYear());
-    txtTrackNumber->setText(
-            m_trackRecord.getMetadata().getTrackInfo().getTrackNumber());
-    txtComment->setPlainText(
-            m_trackRecord.getMetadata().getTrackInfo().getComment());
-    txtBpm->setText(
-            m_trackRecord.getMetadata().getTrackInfo().getBpmText());
+    txtTitle->setText(trackInfo.getTitle());
+    txtArtist->setText(trackInfo.getArtist());
+    txtAlbum->setText(albumInfo.getTitle());
+    txtAlbumArtist->setText(albumInfo.getArtist());
+    txtGenre->setText(trackInfo.getGenre());
+    txtComposer->setText(trackInfo.getComposer());
+    txtGrouping->setText(trackInfo.getGrouping());
+    txtYear->setText(trackInfo.getYear());
+    txtTrackNumber->setText(trackInfo.getTrackNumber());
+    txtComment->setPlainText(trackInfo.getComment());
+    txtBpm->setText(trackInfo.getBpmText());
     displayKeyText();
     displayTuningFields();
 
     // Non-editable fields
     txtDuration->setText(
-            m_trackRecord.getMetadata().getDurationText(mixxx::Duration::Precision::SECONDS));
-    QString bitrate = m_trackRecord.getMetadata().getBitrateText();
+            metadata.getDurationText(mixxx::Duration::Precision::SECONDS));
+    QString bitrate = metadata.getBitrateText();
     if (bitrate.isEmpty()) {
         txtBitrate->clear();
     } else {
@@ -468,9 +462,9 @@ void DlgTrackInfo::updateTrackMetadataFields() {
     }
     txtReplayGain->setText(
             mixxx::ReplayGain::ratioToString(
-                    m_trackRecord.getMetadata().getTrackInfo().getReplayGain().getRatio()));
+                    trackInfo.getReplayGain().getRatio()));
 
-    auto samplerate = m_trackRecord.getMetadata().getStreamInfo().getSignalInfo().getSampleRate();
+    auto samplerate = signalInfo.getSampleRate();
     if (samplerate.isValid()) {
         txtSamplerate->setText(QString::number(samplerate.value()) + " Hz");
     } else {

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -451,6 +451,18 @@ void DlgTrackInfo::updateTrackMetadataFields() {
     displayKeyText();
     displayTuningFields();
 
+    // Set cursor / scroll position of editable fields (only relevant
+    // when the content's width is larger than the width of the QLineEdit)
+    txtTitle->setCursorPosition(0);
+    txtArtist->setCursorPosition(0);
+    txtAlbum->setCursorPosition(0);
+    txtAlbumArtist->setCursorPosition(0);
+    txtGenre->setCursorPosition(0);
+    txtComposer->setCursorPosition(0);
+    txtGrouping->setCursorPosition(0);
+    txtYear->setCursorPosition(0);
+    txtTrackNumber->setCursorPosition(0);
+
     // Non-editable fields
     txtDuration->setText(
             metadata.getDurationText(mixxx::Duration::Precision::SECONDS));

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -281,6 +281,10 @@ void DlgTrackInfo::init() {
             &DlgTrackInfo::slotOpenInFileBrowser);
 
     // Cover art
+    m_pWCoverArtLabel->setToolTip(
+            tr("Left-click to show larger preview") + "\n" +
+            tr("Right-click for more options"));
+
     CoverArtCache* pCache = CoverArtCache::instance();
     if (pCache) {
         connect(pCache,

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -33,6 +33,9 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
             const TrackModel* trackModel = nullptr);
     ~DlgTrackInfo() override;
 
+  protected:
+    bool eventFilter(QObject* pObj, QEvent* pEvent) override;
+
   public slots:
     // Not thread safe. Only invoke via AutoConnection or QueuedConnection, not
     // directly!

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -79,7 +79,6 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
 
     void slotTrackChanged(TrackId trackId);
     void slotOpenInFileBrowser();
-    void slotColorButtonClicked();
 
     void slotCoverFound(
             const QObject* pRequester,

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -12,10 +12,9 @@
 #include "track/trackrecord.h"
 #include "util/parented_ptr.h"
 #include "util/tapfilter.h"
-#include "widget/wcolorpickeraction.h"
 
 class TrackModel;
-class WColorPickerAction;
+class WColorPickerActionMenu;
 class WStarRating;
 class WCoverArtMenu;
 class WCoverArtLabel;
@@ -32,7 +31,7 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     explicit DlgTrackInfo(
             UserSettingsPointer pUserSettings,
             const TrackModel* trackModel = nullptr);
-    ~DlgTrackInfo() override = default;
+    ~DlgTrackInfo() override;
 
   public slots:
     // Not thread safe. Only invoke via AutoConnection or QueuedConnection, not
@@ -140,7 +139,7 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     parented_ptr<WCoverArtMenu> m_pWCoverArtMenu;
     parented_ptr<WCoverArtLabel> m_pWCoverArtLabel;
     parented_ptr<WStarRating> m_pWStarRating;
-    parented_ptr<WColorPickerAction> m_pColorPicker;
+    parented_ptr<WColorPickerActionMenu> m_pColorPicker;
 
     std::unique_ptr<DlgTagFetcher> m_pDlgTagFetcher;
 

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -89,6 +89,7 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     void slotReloadCoverArt();
 
   private:
+    QModelIndex getPrevNextTrack(bool next);
     void loadNextTrack();
     void loadPrevTrack();
     void loadTrackInternal(const TrackPointer& pTrack);

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -120,18 +120,14 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     void updateBpmScaleButtonLabels();
 
     const UserSettingsPointer m_pUserSettings;
-
     const TrackModel* const m_pTrackModel;
 
     TrackPointer m_pLoadedTrack;
-
     QModelIndex m_currentTrackIndex;
-
     mixxx::TrackRecord m_trackRecord;
 
     mixxx::BeatsPointer m_pBeatsClone;
     bool m_trackHasBeatMap;
-
     bool m_bpmLocked;
     TapFilter m_tapFilter;
     mixxx::Bpm m_lastTapedBpm;

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -92,6 +92,7 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     QModelIndex getPrevNextTrack(bool next);
     void loadNextTrack();
     void loadPrevTrack();
+    void refocusCurrentWidget();
     void loadTrackInternal(const TrackPointer& pTrack);
     void reloadTrackBeats(const Track& track);
     void trackColorDialogSetColor(const mixxx::RgbColor::optional_t& color);

--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -49,9 +49,8 @@
       </attribute>
       <layout class="QVBoxLayout" name="summary_layout" stretch="1,0,0">
        <item>
-        <widget class="QGroupBox" name="groupBox">
+        <widget class="QGroupBox" name="metadata_groupBox">
          <layout class="QGridLayout" name="tags_layout" columnstretch="0,10,0,2">
-
           <item row="0" column="0">
            <widget class="QLabel" name="lblTitle">
             <property name="sizePolicy">
@@ -528,7 +527,7 @@
           </item>
 
           <item row="11" column="0" colspan="4">
-           <layout class="QHBoxLayout" name="meatdata_buttons_layout">
+           <layout class="QHBoxLayout" name="metadata_buttons_layout">
             <item>
              <widget class="QPushButton" name="btnImportMetadataFromMusicBrainz">
               <property name="text">

--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -214,7 +214,16 @@
           </item>
 
           <item row="3" column="2" colspan="2">
-           <widget class="QWidget" name="verticalWidgetStars" native="true">
+           <widget class="WStarRating" name="starRating">
+            <property name="mouseTracking">
+             <bool>true</bool>
+            </property>
+            <property name="upDownChangesFocus">
+             <bool>true</bool>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::StrongFocus</enum>
+            </property>
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
               <horstretch>0</horstretch>

--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -1132,9 +1132,9 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
   <tabstop>txtKey</tabstop>
   <tabstop>spinTuning</tabstop>
   <tabstop>txtComment</tabstop>
-  <tabstop>btnColorPicker</tabstop>
   <tabstop>btnImportMetadataFromMusicBrainz</tabstop>
   <tabstop>btnImportMetadataFromFile</tabstop>
+  <tabstop>btnColorPicker</tabstop>
   <tabstop>btnOpenFileBrowser</tabstop>
   <tabstop>spinBpm</tabstop>
   <tabstop>bpmConst</tabstop>

--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -102,8 +102,14 @@
              <property name="spacing">
               <number>0</number>
              </property>
+             <property name="margin">
+              <number>0</number>
+             </property>
              <property name="sizeConstraint">
               <enum>QLayout::SetDefaultConstraint</enum>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignVCenter</set>
              </property>
             </layout>
            </widget>

--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -1175,13 +1175,14 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
   <tabstop>txtAlbum</tabstop>
   <tabstop>txtAlbumArtist</tabstop>
   <tabstop>txtComposer</tabstop>
-  <tabstop>txtYear</tabstop>
   <tabstop>txtGenre</tabstop>
-  <tabstop>txtTrackNumber</tabstop>
   <tabstop>txtGrouping</tabstop>
+  <tabstop>txtComment</tabstop>
+  <tabstop>starRating</tabstop>
+  <tabstop>txtYear</tabstop>
+  <tabstop>txtTrackNumber</tabstop>
   <tabstop>txtKey</tabstop>
   <tabstop>spinTuning</tabstop>
-  <tabstop>txtComment</tabstop>
   <tabstop>btnImportMetadataFromMusicBrainz</tabstop>
   <tabstop>btnImportMetadataFromFile</tabstop>
   <tabstop>btnColorPicker</tabstop>

--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -485,9 +485,21 @@
            </widget>
           </item>
           <item row="8" column="1" colspan="3">
-           <widget class="QPlainTextEdit" name="txtComment">
+           <widget class="WMultiLineTextEdit" name="txtComment">
             <property name="tabChangesFocus">
              <bool>true</bool>
+            </property>
+            <property name="horizontalScrollBarPolicy">
+             <enum>Qt::ScrollBarAlwaysOff</enum>
+            </property>
+            <property name="verticalScrollBarPolicy">
+             <enum>Qt::ScrollBarAsNeeded</enum>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
             </property>
            </widget>
           </item>
@@ -505,7 +517,7 @@
           <item row="9" column="1" colspan="3">
            <widget class="QPushButton" name="btnColorPicker">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
@@ -1118,6 +1130,13 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+ <customwidgets>
+  <customwidget>
+   <class>WMultiLineTextEdit</class>
+   <extends>QLineEdit</extends>
+   <header>widget/wmultilinetextedit.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>tabWidget</tabstop>
   <tabstop>txtTitle</tabstop>

--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -494,6 +494,9 @@
             <property name="tabChangesFocus">
              <bool>true</bool>
             </property>
+            <property name="upDownChangesFocus">
+             <bool>true</bool>
+            </property>
             <property name="horizontalScrollBarPolicy">
              <enum>Qt::ScrollBarAlwaysOff</enum>
             </property>

--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -698,6 +698,9 @@
             <property name="text">
              <string/>
             </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
            </widget>
           </item>
 

--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -530,16 +530,34 @@
           <item row="11" column="0" colspan="4">
            <layout class="QHBoxLayout" name="meatdata_buttons_layout">
             <item>
-             <widget class="QPushButton" name="btnImportMetadataFromMusicBrainz">
+             <widget class="WBasicPushButton" name="btnImportMetadataFromMusicBrainz">
               <property name="text">
                <string>Import Metadata from MusicBrainz</string>
+              </property>
+              <property name="elideMode">
+                <enum>Qt::ElideLeft</enum>
+               </property>
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
               </property>
              </widget>
             </item>
             <item>
-             <widget class="QPushButton" name="btnImportMetadataFromFile">
+             <widget class="WBasicPushButton" name="btnImportMetadataFromFile">
               <property name="text">
                <string>Re-Import Metadata from file</string>
+              </property>
+              <property name="elideMode">
+               <enum>Qt::ElideLeft</enum>
+              </property>
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
               </property>
              </widget>
             </item>
@@ -973,7 +991,7 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
         </widget>
        </item>
        <item>
-        <widget class="QPushButton" name="bpmClear">
+        <widget class="WBasicPushButton" name="bpmClear">
          <property name="text">
           <string>Clear BPM and Beatgrid</string>
          </property>
@@ -1118,6 +1136,13 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+ <customwidgets>
+  <customwidget>
+   <class>WBasicPushButton</class>
+   <extends>QPushButton</extends>
+   <header>widget/wbasicpushbutton.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>tabWidget</tabstop>
   <tabstop>txtTitle</tabstop>

--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -631,15 +631,15 @@
            </widget>
           </item>
 
-          <item row="0" column="2">
-           <widget class="QLabel" name="lblType">
+          <item row="1" column="0">
+           <widget class="QLabel" name="lblBpm">
             <property name="text">
-             <string>Filetype:</string>
+             <string>BPM:</string>
             </property>
            </widget>
           </item>
-          <item row="0" column="3">
-           <widget class="QLabel" name="txtType">
+          <item row="1" column="1">
+           <widget class="QLabel" name="txtBpm">
             <property name="font">
              <font>
               <weight>75</weight>
@@ -655,15 +655,63 @@
            </widget>
           </item>
 
-          <item row="1" column="0">
-           <widget class="QLabel" name="lblBpm">
+          <item row="2" column="0">
+           <widget class="QLabel" name="lblDateAdded">
             <property name="text">
-             <string>BPM:</string>
+             <string>Date added:</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
-           <widget class="QLabel" name="txtBpm">
+          <item row="2" column="1">
+           <widget class="QLabel" name="txtDateAdded">
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+
+          <item row="3" column="0">
+           <widget class="QLabel" name="lblReplayGain">
+            <property name="text">
+             <string>ReplayGain:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QLabel" name="txtReplayGain">
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+
+          <item row="0" column="2">
+           <widget class="QLabel" name="lblType">
+            <property name="text">
+             <string>Filetype:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="3">
+           <widget class="QLabel" name="txtType">
             <property name="font">
              <font>
               <weight>75</weight>
@@ -703,30 +751,6 @@
            </widget>
           </item>
 
-          <item row="2" column="0">
-           <widget class="QLabel" name="lblReplayGain">
-            <property name="text">
-             <string>ReplayGain:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QLabel" name="txtReplayGain">
-            <property name="font">
-             <font>
-              <weight>75</weight>
-              <bold>true</bold>
-             </font>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-            <property name="textInteractionFlags">
-             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-            </property>
-           </widget>
-          </item>
-
           <item row="2" column="2">
            <widget class="QLabel" name="lblSamplerate">
             <property name="text">
@@ -736,30 +760,6 @@
           </item>
           <item row="2" column="3">
            <widget class="QLabel" name="txtSamplerate">
-            <property name="font">
-             <font>
-              <weight>75</weight>
-              <bold>true</bold>
-             </font>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-            <property name="textInteractionFlags">
-             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-            </property>
-           </widget>
-          </item>
-
-          <item row="3" column="0">
-           <widget class="QLabel" name="lblDateAdded">
-            <property name="text">
-             <string>Date added:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QLabel" name="txtDateAdded">
             <property name="font">
              <font>
               <weight>75</weight>
@@ -1198,6 +1198,15 @@ Often results in higher quality beatgrids, but will not do well on tracks that h
   <tabstop>btnImportMetadataFromMusicBrainz</tabstop>
   <tabstop>btnImportMetadataFromFile</tabstop>
   <tabstop>btnColorPicker</tabstop>
+  <tabstop>txtDuration</tabstop>
+  <tabstop>txtBpm</tabstop>
+  <tabstop>txtDateAdded</tabstop>
+  <tabstop>txtReplayGain</tabstop>
+  <tabstop>txtType</tabstop>
+  <tabstop>txtBitrate</tabstop>
+  <tabstop>txtSamplerate</tabstop>
+  <tabstop>txtFileSize</tabstop>
+  <tabstop>txtLocation</tabstop>
   <tabstop>btnOpenFileBrowser</tabstop>
   <tabstop>spinBpm</tabstop>
   <tabstop>bpmConst</tabstop>

--- a/src/library/dlgtrackinfomulti.ui
+++ b/src/library/dlgtrackinfomulti.ui
@@ -444,7 +444,7 @@
       </item>
 
       <item row="11" column="0" colspan="4">
-       <widget class="QPushButton" name="btnImportMetadataFromFile">
+       <widget class="WBasicPushButton" name="btnImportMetadataFromFile">
         <property name="text">
          <string>Re-Import Metadata from files</string>
         </property>
@@ -721,6 +721,13 @@
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+ <customwidgets>
+  <customwidget>
+   <class>WBasicPushButton</class>
+   <extends>QPushButton</extends>
+   <header>widget/wbasicpushbutton.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>txtTitle</tabstop>
   <tabstop>txtArtist</tabstop>

--- a/src/widget/wbasicpushbutton.cpp
+++ b/src/widget/wbasicpushbutton.cpp
@@ -1,0 +1,68 @@
+#include "widget/wbasicpushbutton.h"
+
+#include <QPaintEvent>
+#include <QStyleOption>
+#include <QStylePainter>
+
+#include "moc_wbasicpushbutton.cpp"
+
+namespace {
+void elideButtonLabelIfNeeded(QStyleOptionButton& option,
+        QStyle* style,
+        QWidget* widget,
+        Qt::TextElideMode elideMode) {
+    if (elideMode == Qt::ElideNone) {
+        return;
+    }
+
+    // Calculate how much space we have left for the text
+    QSize textSize = style->subElementRect(QStyle::SE_PushButtonContents, &option, widget).size();
+
+    if (option.features & QStyleOptionButton::HasMenu) {
+        int indicatorSize = style->pixelMetric(QStyle::PM_MenuButtonIndicator, &option, widget);
+        textSize.setWidth(textSize.width() - indicatorSize);
+    }
+
+    if (!option.icon.isNull()) {
+        int iconSpacing = 4; // ### 4 is currently hardcoded in QPushButton::sizeHint()
+        textSize.setWidth(textSize.width() - option.iconSize.width() - iconSpacing);
+    }
+
+    // Replace overflowing text with ellipsis ("...")
+    option.text = option.fontMetrics.elidedText(option.text, elideMode, textSize.width());
+}
+} // namespace
+
+WBasicPushButton::WBasicPushButton(QWidget* pParent)
+        : QPushButton(pParent),
+          m_elideMode(Qt::ElideNone) {
+}
+
+void WBasicPushButton::setElideMode(Qt::TextElideMode elideMode) {
+    if (elideMode != m_elideMode) {
+        m_elideMode = elideMode;
+        updateGeometry();
+    }
+}
+
+QSize WBasicPushButton::minimumSizeHint() const {
+    QSize fullSize = sizeHint();
+
+    if (m_elideMode == Qt::ElideNone) {
+        // Elision of overflowing text is disabled,
+        // so this button cannot be collapsed beyond
+        // its default size.
+        return fullSize;
+    } else {
+        // Elision of overflowing text is enabled.
+        return QSize(0, fullSize.height());
+    }
+}
+
+void WBasicPushButton::paintEvent(QPaintEvent* /*unused*/) {
+    QStylePainter p(this);
+    QStyleOptionButton option;
+    initStyleOption(&option);
+    elideButtonLabelIfNeeded(option, p.style(), this, m_elideMode);
+    p.drawControl(QStyle::CE_PushButton, option);
+}

--- a/src/widget/wbasicpushbutton.cpp
+++ b/src/widget/wbasicpushbutton.cpp
@@ -3,6 +3,7 @@
 #include <QPaintEvent>
 #include <QStyleOption>
 #include <QStylePainter>
+#include <QToolTip>
 
 #include "moc_wbasicpushbutton.cpp"
 
@@ -65,4 +66,48 @@ void WBasicPushButton::paintEvent(QPaintEvent* /*unused*/) {
     initStyleOption(&option);
     elideButtonLabelIfNeeded(option, p.style(), this, m_elideMode);
     p.drawControl(QStyle::CE_PushButton, option);
+}
+
+QString WBasicPushButton::buildToolTip() const {
+    // Show the button label as a tooltip when the label text
+    // is partially hidden due to the button's size
+    const QString txtToolTip = toolTip();
+    if (!txtToolTip.isEmpty()) {
+        return txtToolTip;
+    }
+
+    const QString txtLabel = text();
+    const QSize currentSize = size();
+    const QSize fullSize = sizeHint();
+
+    if ((currentSize.height() < fullSize.height() ||
+                currentSize.width() < fullSize.width()) &&
+            !txtLabel.isEmpty()) {
+        // The label text is not fully visible,
+        // so show it as a tooltip
+        return txtLabel;
+    }
+
+    return QString();
+}
+
+bool WBasicPushButton::event(QEvent* e) {
+    switch (e->type()) {
+    case QEvent::ToolTip: {
+        const QString toolTipToShow = buildToolTip();
+        if (!toolTipToShow.isEmpty()) {
+            QToolTip::showText(static_cast<QHelpEvent*>(e)->globalPos(),
+                    toolTipToShow,
+                    this,
+                    QRect(),
+                    toolTipDuration());
+        } else {
+            e->ignore();
+        }
+        return true;
+    }
+    default: {
+        return QPushButton::event(e);
+    }
+    }
 }

--- a/src/widget/wbasicpushbutton.h
+++ b/src/widget/wbasicpushbutton.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <QPushButton>
+
+/// Subclass of QPushButton that replaces a portion of the button label
+/// with an ellipsis (according to Qt::TextElideMode) when the text would
+/// otherwise overflow the available space.
+///
+/// See WPushButton when you need to connect to a ControlObject.
+class WBasicPushButton : public QPushButton {
+    Q_OBJECT
+    Q_PROPERTY(Qt::TextElideMode elideMode READ elideMode WRITE setElideMode);
+
+  public:
+    explicit WBasicPushButton(QWidget* pParent = nullptr);
+
+    void setElideMode(Qt::TextElideMode elideMode);
+    Qt::TextElideMode elideMode() const {
+        return m_elideMode;
+    };
+
+    QSize minimumSizeHint() const override;
+
+  protected:
+    void paintEvent(QPaintEvent* e) override;
+
+    Qt::TextElideMode m_elideMode;
+};

--- a/src/widget/wbasicpushbutton.h
+++ b/src/widget/wbasicpushbutton.h
@@ -22,6 +22,8 @@ class WBasicPushButton : public QPushButton {
     QSize minimumSizeHint() const override;
 
   protected:
+    QString buildToolTip() const;
+    bool event(QEvent* e) override;
     void paintEvent(QPaintEvent* e) override;
 
     Qt::TextElideMode m_elideMode;

--- a/src/widget/wcolorpicker.cpp
+++ b/src/widget/wcolorpicker.cpp
@@ -29,7 +29,7 @@ inline int idealColumnCount(int numItems) {
             break;
         }
         if (remainder > numColumnsRemainder) {
-            numColumnsRemainder = numColumnsCandidate;
+            numColumnsRemainder = remainder;
             numColumns = numColumnsCandidate;
         }
     }

--- a/src/widget/wcolorpicker.cpp
+++ b/src/widget/wcolorpicker.cpp
@@ -2,11 +2,13 @@
 
 #include <QColorDialog>
 #include <QGridLayout>
+#include <QKeyEvent>
 #include <QPushButton>
 #include <QStyle>
 #include <QStyleFactory>
 
 #include "moc_wcolorpicker.cpp"
+#include "util/optional.h"
 #include "util/parented_ptr.h"
 
 namespace {
@@ -35,6 +37,109 @@ inline int idealColumnCount(int numItems) {
     }
 
     return numColumns;
+}
+
+WColorGridButton::WColorGridButton(const mixxx::RgbColor::optional_t& color,
+        int row,
+        int column,
+        QWidget* parent)
+        : QPushButton(parent),
+          m_color(color),
+          m_row(row),
+          m_column(column) {
+    if (color) {
+        // Set the background color of the button.
+        // This can't be overridden in skin stylesheets.
+        setStyleSheet(
+                QStringLiteral("QPushButton { background-color: %1; }")
+                        .arg(mixxx::RgbColor::toQString(color.value())));
+        setToolTip(mixxx::RgbColor::toQString(color.value()));
+    } else {
+        setProperty("noColor", true);
+        setToolTip(tr("No color"));
+    }
+
+    setCheckable(true);
+
+    // Without this the button might shrink when setting the checkmark icon,
+    // both here or via external stylesheets.
+    setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding));
+}
+
+void WColorGridButton::keyPressEvent(QKeyEvent* event) {
+    if (handleNavigation(event)) {
+        // Already handled completely
+    } else if (event->key() == Qt::Key_Return) {
+        // Key_Return should act the same as Key_Space
+        setDown(true);
+    } else {
+        QPushButton::keyPressEvent(event);
+    }
+}
+
+void WColorGridButton::keyReleaseEvent(QKeyEvent* event) {
+    if (event->key() == Qt::Key_Return && !event->isAutoRepeat() && isDown()) {
+        click();
+    } else {
+        QPushButton::keyReleaseEvent(event);
+    }
+}
+
+bool WColorGridButton::handleNavigation(QKeyEvent* event) {
+    QWidget* pParent = qobject_cast<QWidget*>(parent());
+    if (!pParent) {
+        return false;
+    }
+
+    QGridLayout* pGridLayout = qobject_cast<QGridLayout*>(pParent->layout());
+    if (!pGridLayout) {
+        return false;
+    }
+
+    const int maxRow = pGridLayout->rowCount() - 1;
+    const int maxColumn = pGridLayout->columnCount() - 1;
+    int newRow = m_row;
+    int newColumn = m_column;
+
+    switch (event->key()) {
+    case Qt::Key_Up: {
+        newRow = qBound(0, newRow - 1, maxRow);
+        break;
+    }
+    case Qt::Key_Down: {
+        newRow = qBound(0, newRow + 1, maxRow);
+        break;
+    }
+    case Qt::Key_Left: {
+        newColumn = qBound(0, newColumn - 1, maxColumn);
+        break;
+    }
+    case Qt::Key_Right: {
+        newColumn = qBound(0, newColumn + 1, maxColumn);
+        break;
+    }
+    default: {
+        return false;
+    }
+    }
+
+    // Show the keyboard focus frame (if not yet visible)
+    window()->setAttribute(Qt::WA_KeyboardFocusChange);
+
+    QLayoutItem* pNewItem = pGridLayout->itemAtPosition(newRow, newColumn);
+    if (!pNewItem) {
+        // May happen when itemCount < (rowCount * columnCount),
+        // i.e. when some cells in the grid are empty.
+        return false;
+    }
+
+    QWidget* pNewFocus = pNewItem->widget();
+    if (!pNewFocus) {
+        return false;
+    }
+
+    pNewFocus->setFocus();
+    return true;
 }
 
 WColorPicker::WColorPicker(Options options, const ColorPalette& palette, QWidget* parent)
@@ -138,21 +243,11 @@ void WColorPicker::addColorButtons() {
 }
 
 void WColorPicker::addColorButton(mixxx::RgbColor color, QGridLayout* pLayout, int row, int column) {
-    parented_ptr<QPushButton> pButton = make_parented<QPushButton>("", this);
+    auto pButton = make_parented<WColorGridButton>(color, row, column, this);
     if (m_pStyle) {
         pButton->setStyle(m_pStyle);
     }
-
-    // Set the background color of the button. This can't be overridden in skin stylesheets.
-    pButton->setStyleSheet(
-            QString("QPushButton { background-color: %1; }").arg(mixxx::RgbColor::toQString(color)));
-    pButton->setToolTip(mixxx::RgbColor::toQString(color));
-    pButton->setCheckable(true);
-    // Without this the button might shrink when setting the checkmark icon,
-    // both here or via external stylesheets.
-    pButton->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding));
     m_colorButtons.append(pButton);
-
     connect(pButton,
             &QPushButton::clicked,
             this,
@@ -163,25 +258,21 @@ void WColorPicker::addColorButton(mixxx::RgbColor color, QGridLayout* pLayout, i
 }
 
 void WColorPicker::addNoColorButton(QGridLayout* pLayout, int row, int column) {
-    QPushButton* pButton = m_pNoColorButton;
-    if (!pButton) {
-        pButton = make_parented<QPushButton>("", this);
-        if (m_pStyle) {
-            pButton->setStyle(m_pStyle);
-        }
-
-        pButton->setProperty("noColor", true);
-        pButton->setToolTip(tr("No color"));
-        pButton->setCheckable(true);
-        pButton->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding));
-        connect(pButton,
-                &QPushButton::clicked,
-                this,
-                [this]() {
-                    emit colorPicked(std::nullopt);
-                });
-        m_pNoColorButton = pButton;
+    VERIFY_OR_DEBUG_ASSERT(!m_pNoColorButton) {
+        return;
     }
+
+    auto pButton = make_parented<WColorGridButton>(std::nullopt, row, column, this);
+    if (m_pStyle) {
+        pButton->setStyle(m_pStyle);
+    }
+    connect(pButton,
+            &QPushButton::clicked,
+            this,
+            [this]() {
+                emit colorPicked(std::nullopt);
+            });
+    m_pNoColorButton = pButton;
     pLayout->addWidget(pButton, row, column);
 }
 

--- a/src/widget/wcolorpicker.cpp
+++ b/src/widget/wcolorpicker.cpp
@@ -350,3 +350,22 @@ void WColorPicker::setColorPalette(const ColorPalette& palette) {
 void WColorPicker::slotColorPicked(const mixxx::RgbColor::optional_t& color) {
     setSelectedColor(color);
 }
+
+void WColorPicker::setInitialFocus() {
+    QGridLayout* pLayout = qobject_cast<QGridLayout*>(layout());
+    VERIFY_OR_DEBUG_ASSERT(pLayout) {
+        qWarning() << "Color Picker has no layout!";
+        return;
+    }
+
+    // Focus the top left button when the color picker
+    // popup is opened, so that keyboard navigation
+    // can be used.
+    auto* topLeftItem = pLayout->itemAtPosition(0, 0);
+    if (topLeftItem) {
+        auto* topLeftWidget = topLeftItem->widget();
+        if (topLeftWidget) {
+            topLeftWidget->setFocus();
+        }
+    }
+}

--- a/src/widget/wcolorpicker.h
+++ b/src/widget/wcolorpicker.h
@@ -53,6 +53,7 @@ class WColorPicker : public QWidget {
     void resetSelectedColor();
     void setSelectedColor(const mixxx::RgbColor::optional_t& color);
     void setColorPalette(const ColorPalette& palette);
+    void setInitialFocus();
 
   signals:
     void colorPicked(const mixxx::RgbColor::optional_t& color);

--- a/src/widget/wcolorpicker.h
+++ b/src/widget/wcolorpicker.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <QMenu>
+#include <QPushButton>
 #include <QStyle>
 #include <QWidget>
 
@@ -7,7 +9,28 @@
 #include "util/parented_ptr.h"
 
 class QGridLayout;
-class QPushButton;
+class WColorPicker;
+
+/// Customized button used internally by WColorPicker
+class WColorGridButton : public QPushButton {
+    Q_OBJECT
+  public:
+    WColorGridButton(const mixxx::RgbColor::optional_t& color,
+            int row,
+            int column,
+            QWidget* parent = nullptr);
+
+  protected:
+    void keyPressEvent(QKeyEvent* event) override;
+    void keyReleaseEvent(QKeyEvent* event) override;
+
+  private:
+    bool handleNavigation(QKeyEvent* event);
+
+    mixxx::RgbColor::optional_t m_color;
+    int m_row;
+    int m_column;
+};
 
 class WColorPicker : public QWidget {
     Q_OBJECT

--- a/src/widget/wcolorpickeraction.cpp
+++ b/src/widget/wcolorpickeraction.cpp
@@ -37,3 +37,7 @@ void WColorPickerAction::setColorPalette(const ColorPalette& palette) {
     }
     pWidget->adjustSize();
 }
+
+void WColorPickerAction::setInitialFocus() {
+    m_pColorPicker->setInitialFocus();
+}

--- a/src/widget/wcolorpickeraction.h
+++ b/src/widget/wcolorpickeraction.h
@@ -15,6 +15,7 @@ class WColorPickerAction : public QWidgetAction {
 
     void resetSelectedColor();
     void setSelectedColor(const mixxx::RgbColor::optional_t& color);
+    void setInitialFocus();
 
     /// Set a new color palette for the underlying color picker.
     ///

--- a/src/widget/wcolorpickeractionmenu.cpp
+++ b/src/widget/wcolorpickeractionmenu.cpp
@@ -18,6 +18,7 @@ WColorPickerActionMenu::WColorPickerActionMenu(
             &WColorPickerActionMenu::colorPicked);
 
     addAction(m_pColorPickerAction.get());
+    m_pColorPickerAction->setInitialFocus();
 }
 
 void WColorPickerActionMenu::setColorPalette(const ColorPalette& palette) {

--- a/src/widget/wcolorpickeractionmenu.cpp
+++ b/src/widget/wcolorpickeractionmenu.cpp
@@ -1,0 +1,40 @@
+#include "widget/wcolorpickeractionmenu.h"
+
+#include <QKeyEvent>
+
+#include "moc_wcolorpickeractionmenu.cpp"
+#include "widget/wcolorpickeraction.h"
+
+WColorPickerActionMenu::WColorPickerActionMenu(
+        WColorPicker::Options options,
+        const ColorPalette& palette,
+        QWidget* parent)
+        : QMenu(parent),
+          m_pColorPickerAction(
+                  make_parented<WColorPickerAction>(options, palette, this)) {
+    connect(m_pColorPickerAction.get(),
+            &WColorPickerAction::colorPicked,
+            this,
+            &WColorPickerActionMenu::colorPicked);
+
+    addAction(m_pColorPickerAction.get());
+}
+
+void WColorPickerActionMenu::setColorPalette(const ColorPalette& palette) {
+    m_pColorPickerAction->setColorPalette(palette);
+    updateGeometry();
+}
+
+void WColorPickerActionMenu::setSelectedColor(const mixxx::RgbColor::optional_t& color) {
+    m_pColorPickerAction->setSelectedColor(color);
+}
+
+void WColorPickerActionMenu::resetSelectedColor() {
+    m_pColorPickerAction->resetSelectedColor();
+}
+
+bool WColorPickerActionMenu::focusNextPrevChild(bool next) {
+    // Override the behavior of QMenu::focusNextPrevChild
+    // which would convert this into a keyPressEvent()
+    return QWidget::focusNextPrevChild(next);
+}

--- a/src/widget/wcolorpickeractionmenu.h
+++ b/src/widget/wcolorpickeractionmenu.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <QMenu>
+
+#include "util/color/colorpalette.h"
+#include "util/color/rgbcolor.h"
+#include "widget/wcolorpicker.h"
+
+class WColorPickerAction;
+
+class WColorPickerActionMenu : public QMenu {
+    Q_OBJECT
+  public:
+    explicit WColorPickerActionMenu(
+            WColorPicker::Options options,
+            const ColorPalette& palette,
+            QWidget* parent = nullptr);
+
+    /// Set a new color palette for the underlying color picker.
+    void setColorPalette(const ColorPalette& palette);
+    void setSelectedColor(const mixxx::RgbColor::optional_t& color);
+    void resetSelectedColor();
+
+  signals:
+    void colorPicked(const mixxx::RgbColor::optional_t& color);
+
+  protected:
+    bool focusNextPrevChild(bool next) override;
+
+  private:
+    parented_ptr<WColorPickerAction> m_pColorPickerAction;
+};

--- a/src/widget/wcoverartlabel.cpp
+++ b/src/widget/wcoverartlabel.cpp
@@ -48,6 +48,12 @@ WCoverArtLabel::WCoverArtLabel(QWidget* pParent, WCoverArtMenu* pCoverMenu)
     setFrameShape(QFrame::Box);
     setAlignment(Qt::AlignCenter);
     setPixmapAndResize(m_defaultCover);
+
+    if (m_pCoverMenu != nullptr) {
+        setToolTip(
+                tr("Left-click to show larger preview") + "\n" +
+                tr("Right-click for more options"));
+    }
 }
 
 WCoverArtLabel::~WCoverArtLabel() = default;

--- a/src/widget/wmultilinetextedit.cpp
+++ b/src/widget/wmultilinetextedit.cpp
@@ -9,7 +9,8 @@
 #include "wmultilinetextedit.h"
 
 WMultiLineTextEdit::WMultiLineTextEdit(QWidget* parent)
-        : QPlainTextEdit(parent) {
+        : QPlainTextEdit(parent),
+          m_upDownChangesFocus(false) {
     // The added viewportMargin is required to ensure the inner
     // content of the text editor does not accidentally overwrite
     // the focus frame of the whole control. The documentMargin is

--- a/src/widget/wmultilinetextedit.cpp
+++ b/src/widget/wmultilinetextedit.cpp
@@ -1,0 +1,27 @@
+#include "widget/wmultilinetextedit.h"
+
+#include <QSizeF>
+
+#include "moc_wmultilinetextedit.cpp"
+
+WMultiLineTextEdit::WMultiLineTextEdit(QWidget* parent)
+        : QPlainTextEdit(parent) {
+}
+
+QSize WMultiLineTextEdit::minimumSizeHint() const {
+    const int minLines = 2;
+    return sizeHintImpl(minLines);
+}
+
+QSize WMultiLineTextEdit::sizeHint() const {
+    const int minLines = 2;
+    return sizeHintImpl(minLines);
+}
+
+QSize WMultiLineTextEdit::sizeHintImpl(const int minLines) const {
+    const auto w = 0.0;
+    const auto h = 2 * frameWidth() + 2 * document()->documentMargin() +
+            QFontMetrics(font()).lineSpacing() * minLines;
+
+    return QSizeF(w, h).toSize();
+}

--- a/src/widget/wmultilinetextedit.cpp
+++ b/src/widget/wmultilinetextedit.cpp
@@ -1,11 +1,22 @@
 #include "widget/wmultilinetextedit.h"
 
 #include <QSizeF>
+#include <QStyle>
+#include <QStyleOption>
+#include <QStylePainter>
 
 #include "moc_wmultilinetextedit.cpp"
+#include "wmultilinetextedit.h"
 
 WMultiLineTextEdit::WMultiLineTextEdit(QWidget* parent)
         : QPlainTextEdit(parent) {
+    // The added viewportMargin is required to ensure the inner
+    // content of the text editor does not accidentally overwrite
+    // the focus frame of the whole control. The documentMargin is
+    // reduced by an equal amount so the total amount of padding
+    // stays the same.
+    setViewportMargins(4, 4, 4, 4);
+    document()->setDocumentMargin(0);
 }
 
 QSize WMultiLineTextEdit::minimumSizeHint() const {
@@ -24,4 +35,61 @@ QSize WMultiLineTextEdit::sizeHintImpl(const int minLines) const {
             QFontMetrics(font()).lineSpacing() * minLines;
 
     return QSizeF(w, h).toSize();
+}
+
+bool WMultiLineTextEdit::event(QEvent* e) {
+    switch (e->type()) {
+    case QEvent::Paint: {
+        QStylePainter p(this);
+        QStyleOptionFrame option;
+        initStyleOption(&option);
+        if (isReadOnly()) {
+            option.state |= QStyle::State_ReadOnly;
+        }
+        style()->drawPrimitive(QStyle::PE_PanelLineEdit, &option, &p, this);
+        return true;
+    }
+    default: {
+        return QPlainTextEdit::event(e);
+    }
+    }
+}
+
+void WMultiLineTextEdit::keyPressEvent(QKeyEvent* event) {
+    const bool isUp = event->key() == Qt::Key_Up;
+    const bool isDown = event->key() == Qt::Key_Down;
+
+    // Do not interpret as navigation if any modifier key is pressed
+    const bool anyModifiersPressed = event->modifiers() &
+            (Qt::ControlModifier | Qt::AltModifier |
+                    Qt::ShiftModifier | Qt::MetaModifier);
+
+    // Holding down a key to scroll all the way to the
+    // top or bottom of the text edit should not cause
+    // the focus to leave the text edit control.
+    const bool isAutoRepeat = event->isAutoRepeat();
+
+    if (!m_upDownChangesFocus || !(isUp || isDown) ||
+            isAutoRepeat || anyModifiersPressed) {
+        QPlainTextEdit::keyPressEvent(event);
+    } else {
+        // Up/Down should only cause a focus change when the edge
+        // of the text box has been reached i.e. when the text
+        // cursor position didn't change due to the keypress.
+        auto oldCursor = textCursor();
+        QPlainTextEdit::keyPressEvent(event);
+        auto newCursor = textCursor();
+
+        const bool cursorHasNotChanged = oldCursor.position() == newCursor.position() &&
+                oldCursor.anchor() == newCursor.anchor();
+
+        if (cursorHasNotChanged && isUp && focusPreviousChild()) {
+            event->accept();
+            return;
+        }
+        if (cursorHasNotChanged && isDown && focusNextChild()) {
+            event->accept();
+            return;
+        }
+    }
 }

--- a/src/widget/wmultilinetextedit.h
+++ b/src/widget/wmultilinetextedit.h
@@ -14,6 +14,10 @@ class WMultiLineTextEdit : public QPlainTextEdit {
     QSize minimumSizeHint() const override;
     QSize sizeHint() const override;
 
+  protected:
+    bool event(QEvent* e) override;
+    void keyPressEvent(QKeyEvent* event) override;
+
   private:
     QSize sizeHintImpl(const int minLines) const;
 };

--- a/src/widget/wmultilinetextedit.h
+++ b/src/widget/wmultilinetextedit.h
@@ -8,9 +8,21 @@
 /// Used for DlgTrackInfo/~Multi and similar dialogs.
 class WMultiLineTextEdit : public QPlainTextEdit {
     Q_OBJECT
+    Q_PROPERTY(bool upDownChangesFocus READ upDownChangesFocus WRITE setUpDownChangesFocus)
 
   public:
     WMultiLineTextEdit(QWidget* parent = nullptr);
+
+    /// Sets whether to change focus to the next/previous sibling control
+    /// when the Up/Down arrow keys are pressed while the cursor is at
+    /// the very end or very start of the control.
+    void setUpDownChangesFocus(bool enable) {
+        m_upDownChangesFocus = enable;
+    }
+    bool upDownChangesFocus() const {
+        return m_upDownChangesFocus;
+    }
+
     QSize minimumSizeHint() const override;
     QSize sizeHint() const override;
 
@@ -20,4 +32,5 @@ class WMultiLineTextEdit : public QPlainTextEdit {
 
   private:
     QSize sizeHintImpl(const int minLines) const;
+    bool m_upDownChangesFocus;
 };

--- a/src/widget/wmultilinetextedit.h
+++ b/src/widget/wmultilinetextedit.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <QPlainTextEdit>
+
+/// An implementation of QPlainTextTedit with a more sensible minimum
+/// size of 2 text lines.
+///
+/// Used for DlgTrackInfo/~Multi and similar dialogs.
+class WMultiLineTextEdit : public QPlainTextEdit {
+    Q_OBJECT
+
+  public:
+    WMultiLineTextEdit(QWidget* parent = nullptr);
+    QSize minimumSizeHint() const override;
+    QSize sizeHint() const override;
+
+  private:
+    QSize sizeHintImpl(const int minLines) const;
+};

--- a/src/widget/wstarrating.cpp
+++ b/src/widget/wstarrating.cpp
@@ -11,6 +11,8 @@ class QWidgets;
 
 WStarRating::WStarRating(QWidget* pParent)
         : WWidget(pParent),
+          m_upDownChangesFocus(false),
+          m_focusedViaKeyboard(false),
           m_starCount(0),
           m_visualStarRating(m_starCount) {
 }
@@ -49,7 +51,75 @@ void WStarRating::paintEvent(QPaintEvent * /*unused*/) {
     painter.setBrush(option.palette.text());
     painter.drawPrimitive(QStyle::PE_Widget, option);
 
+    if (focusPolicy() != Qt::NoFocus &&
+            (option.state & QStyle::State_HasFocus) &&
+            (option.state & QStyle::State_KeyboardFocusChange)) {
+        painter.setBrush(option.palette.highlight().color());
+    } else {
+        painter.setBrush(option.palette.text().color());
+    }
+
     m_visualStarRating.paint(&painter, m_contentRect);
+}
+
+void WStarRating::keyPressEvent(QKeyEvent* event) {
+    // Change rating when certain keys are pressed
+    QKeyEvent* ke = static_cast<QKeyEvent*>(event);
+    int newRating = m_visualStarRating.starCount();
+    switch (ke->key()) {
+    case Qt::Key_0:
+    case Qt::Key_1:
+    case Qt::Key_2:
+    case Qt::Key_3:
+    case Qt::Key_4:
+    case Qt::Key_5:
+    case Qt::Key_6:
+    case Qt::Key_7:
+    case Qt::Key_8:
+    case Qt::Key_9: {
+        bool ok = false;
+        int keyInt = ke->text().toInt(&ok);
+        if (ok) {
+            newRating = keyInt;
+        }
+        break;
+    }
+    case Qt::Key_Right:
+    case Qt::Key_Plus: {
+        newRating++;
+        break;
+    }
+    case Qt::Key_Left:
+    case Qt::Key_Minus: {
+        newRating--;
+        break;
+    }
+    case Qt::Key_Up: {
+        if (m_upDownChangesFocus && focusPreviousChild()) {
+            event->accept();
+        } else {
+            event->ignore();
+        }
+        return;
+    }
+    case Qt::Key_Down: {
+        if (m_upDownChangesFocus && focusNextChild()) {
+            event->accept();
+        } else {
+            event->ignore();
+        }
+        return;
+    }
+    default: {
+        event->ignore();
+        return;
+    }
+    }
+    bool shouldUpdateVisual = !m_focusedViaKeyboard;
+    m_focusedViaKeyboard = true;
+    newRating = math_clamp(newRating, StarRating::kMinStarCount, m_visualStarRating.maxStarCount());
+    updateVisualRating(newRating, shouldUpdateVisual);
+    m_starCount = newRating;
 }
 
 void WStarRating::mouseMoveEvent(QMouseEvent *event) {

--- a/src/widget/wstarrating.h
+++ b/src/widget/wstarrating.h
@@ -8,10 +8,23 @@ class SkinContext;
 
 class WStarRating : public WWidget {
     Q_OBJECT
+    Q_PROPERTY(bool upDownChangesFocus READ upDownChangesFocus WRITE setUpDownChangesFocus)
+
   public:
     WStarRating(QWidget* pParent);
 
     virtual void setup(const QDomNode& node, const SkinContext& context);
+
+    /// Sets whether to change focus to the next/previous sibling control
+    /// when the Up/Down arrow keys are pressed while the cursor is at
+    /// the very end or very start of the control.
+    void setUpDownChangesFocus(bool enable) {
+        m_upDownChangesFocus = enable;
+    }
+    bool upDownChangesFocus() const {
+        return m_upDownChangesFocus;
+    }
+
     QSize sizeHint() const override;
 
   public slots:
@@ -28,6 +41,9 @@ class WStarRating : public WWidget {
     void fillDebugTooltip(QStringList* debug) override;
 
   private:
+    bool m_upDownChangesFocus;
+    bool m_focusedViaKeyboard;
+
     int m_starCount;
 
     StarRating m_visualStarRating;


### PR DESCRIPTION
This PR bundles a number of keyboard usability improvements and general polish for the track info dialog.
It combines a number of small changes that are functionally independent and could be split off into their own PRs if necessary, but would likely produce merge conflicts due to most of them affecting the same set of files.

- In short, the track info dialog and all of its controls (except for the cover art image) are now easily accessible and usable via the keyboard, tab order matches visual order and small screens/large font sizes are handled more gracefully.

- The visual look is only changed minimally (the border style of the comments field now matches the other text fields & the "Import metadata" buttons display an ellipsis when collapsed below their minimum text width & a few pixel-level alignments, see below for details).

> _**PS:** If you want to quickly try it out without having to build it yourself, you can use the `io.github.cr7pt0gr4ph7.Mixxx` Flatpak published at [`cr7pt0gr4ph7/mixxx-flatpak`](https://github.com/cr7pt0gr4ph7/mixxx-flatpak) that includes this and a few other changes. Parallel installation is possible, i.e. any existing official or Flatpak installation of Mixxx will not be affected:_
> ```
> sudo flatpak remote-add --if-not-exists mixxx-flatpak https://cr7pt0gr4ph7.github.io/mixxx-flatpak/default.flatpakrepo
> sudo flatpak install io.github.cr7pt0gr4ph7.Mixxx
> ```

(As a sidenote, the changes from #13632 have been integrated).

## Summary

The Git history has been rewritten to group related commits together into the following changesets (presented in the chronological order of their Git history):

### Add "Last Played" field (2 commits)

Because, why not? This was the only piece of metadata that was available as a column but not shown in the track info dialog. There's space in the layout for it, so let's just add it.

Will be shown as `-` when not present in the track's metadata.

### General Cleanup (6 commits)

These should all (hopefully) be uncontentious:

- Fix alignment of the labels for "Comments" and "Grouping" by moving them a few pixels.
- Make text in the "Bitrate" field selectable, like the other read-only fields.
- Just a bit of miscellanceous cleanup:
  - Give the `QGroupBox`es speaking names instead of auto-generated ones
  - Use variables to avoid code duplication in `updateTrackMetatdataFields`
  - Use empty lines to logically group related fields in `dlgtrackinfo.h`.

### Edit star rating via keyboard (5 commits)

The star rating widget was focusable, but it was not possible to use the keyboard to actually change the rating.

- Pressing the `0`, `1`, ..., `9` key now sets the rating. The result will be clamped to the range `0..maxStarCount` (Reason: The existing code internally allows for a `maxStarCount` other than `5`).
- Pressing the `+` or `Right` key increments the rating.
- Pressing the `-` or `Left` key increments the rating.

As a sidenote, editing the star rating cells in the library table view was suffienctly different to be split into the separate PR #13717.

### Improve track list navigation (3 commits)

Navigation within a list of tracks has been improved by adding keyboard shortcuts (`Alt+Left`/`Alt+Right`[^1] [^2]) and conditionally enabling/disabling the prev/next buttons. Focus is kept within the currently focused editor when moving to another track, but any "on focus" behaviours (like selecting all text in a QLineEdit) for the current control are re-triggered.

[^1]: Sidenote: `Alt+Left`/`Right` was choosen because `Ctrl+Left`/`Right` and `Left`/`Right` already have a meaning within the text edit widgets.

[^2]: Sidenote: `Alt+Up`/`Down` can be added if desired.

**Future work:** It is currently not explained (or visually indicated) to the user that navigating to the previous/next track cancels changes made to the current track (like `Escape` or `Cancel` would do).

### Resize behaviour (5 commits)

- Avoid the minimum size of `WMultiLineTextEdit` (the "Comments" field) jumping to a larger size when the dialog is resized by the user.

- Text edit widgets: Show the start of the contained text (e.g. the album title) by default instead of the end when the text's length exceeds the widgets width.

- Allow the `Import metadata from MusicBrainz` and `Re-import metadata from file` to be collapsed to smaller widths by displaying an ellipsis (`...`).

### Keyboard navigation using `Up`/`Down` (6 commits)

Add `Up`/`Down` as an alternative to `Tab`/`Shift+Tab` for moving focus within the track info dialog to make the keyboard experience a bit more seamless.

- **Exception:** For the "Comments" control, focus only moves out of the text editor when the cursor is at the very start or end of the content when you start to hold down the corresponding arrow key, i.e. when you are at the start of the "Comments" field and hold down `Down` to move the cursor to the very end, focus does not leave the "Comments" field until you release the `Down` key and then press it again.

- **Exception:** For the BPM spinner on the second tab, `Up` and `Down` retain their original behavior (Note: haven't found a good way to differentiate between the different user intentions here)

### Edit color picker via keyboard (3 commits)

The color picker popover could be triggered, but not controlled, via the keyboard.

- `Space` or `Enter` on the color picker button triggers the popover and moves focus into the popover.
- `Tab`/`Shift+Tab` and `Up`/`Down`/`Left`/`Right` can be used to navigate within the color picker popover when it is open.
- Pressing `Esc` closes the color picker popover without making a selection.
- Pressing `Enter` or `Space` selects the focused color and closes the color picker popover.

### Tooltip for cover art image (1 commit)

Added a compact tooltip to the cover art image to indicate the available interactions (left click/right click).

### Merge & additional cleanup (2 commits)

- Merge `mixxxdj/mixxx:main` and resolve merge conflicts caused by #13632.
- Fix small misspelling `meatdata_buttons_layout` -> `metadata_buttons_layout`
- Fix code style issues in `wcolorpicker.cpp`