### PR TITLE
Improved comments in enginecontrol and use of std::size_t for bufferSize accross the codebase

### DIFF
--- a/.codespellignorelines
+++ b/.codespellignorelines
@@ -4,24 +4,24 @@
                  pInOut, pInOut,
         CSAMPLE* pInOut,
     CSAMPLE* pInOut,
-void EnginePregain::process(CSAMPLE* pInOut, const int iBufferSize) {
-void EngineDelay::process(CSAMPLE* pInOut, const int iBufferSize) {
+void EnginePregain::process(CSAMPLE* pInOut, const std::size_t bufferSize) {
+void EngineDelay::process(CSAMPLE* pInOut, const std::size_t bufferSize) {
         pInOut[i] = (CSAMPLE) processSample(fbuf1, (double) pInOut[i]);
         pInOut[i + 1] = (CSAMPLE) processSample(fbuf2, (double) pInOut[i + 1]);
             m_pDelayBuffer[m_iDelayPos] = pInOut[i];
             pInOut[i] = m_pDelayBuffer[iDelaySourcePos];
-        SampleUtil::applyRampingGain(&pInOut[0], m_fPrevGain, 0, iBufferSize / 2);
-        SampleUtil::applyRampingGain(&pInOut[iBufferSize / 2], 0, totalGain, iBufferSize / 2);
-        SampleUtil::applyRampingGain(pInOut, m_fPrevGain, totalGain, iBufferSize);
-        SampleUtil::applyGain(pInOut, totalGain, iBufferSize);
-    void process(CSAMPLE* pInOut, const int iBufferSize) override;
-    void process(CSAMPLE* pInOut, const int iBufferSize);
-    virtual void process(CSAMPLE* pInOut, const int iBufferSize);
+        SampleUtil::applyRampingGain(&pInOut[0], m_fPrevGain, 0, bufferSize / 2);
+        SampleUtil::applyRampingGain(&pInOut[bufferSize / 2], 0, totalGain, bufferSize / 2);
+        SampleUtil::applyRampingGain(pInOut, m_fPrevGain, totalGain, bufferSize);
+        SampleUtil::applyGain(pInOut, totalGain, bufferSize);
+    void process(CSAMPLE* pInOut, const std::size_t bufferSize) override;
+    void process(CSAMPLE* pInOut, const std::size_t bufferSize);
+    virtual void process(CSAMPLE* pInOut, const std::size_t bufferSize);
                 "CSAMPLE_GAIN gain%(i)din, CSAMPLE_GAIN gain%(i)dout"
                 "gain%(i)dout == CSAMPLE_GAIN_ZERO) {"
                     "pSrc%(i)d, gain%(i)din, gain%(i)dout" % {"i": j}
                 "(gain%(i)dout - gain%(i)din) / (iNumSamples / 2);"
-    MOCK_METHOD(void, process, (CSAMPLE * pInOut, const int iBufferSize), (override));
+    MOCK_METHOD(void, process, (CSAMPLE * pInOut, const std::size_t bufferSize), (override));
     const QString kName3 = QStringLiteral("I'm blue, da ba dee");
     float m_k2vg; // IIF factor
     float m_k2vgNew; // IIF factor
@@ -71,6 +71,6 @@ void EngineEffectsDelay::process(CSAMPLE* pInOut,
     // Source: FIPS 180-4 Secure Hash Standard (SHS)
         // ALAC/CAF has been added in version 1.0.26
         QStringLiteral("caf"),
-void EngineFilter::process(CSAMPLE* pInOut, const int iBufferSize)
+void EngineFilter::process(CSAMPLE* pInOut, const size_t bufferSize)
     // Note(RRyan/Max Linke):
     // https://github.com/codders/libshout/blob/a17fb84671d3732317b0353d7281cc47e2df6cf6/src/timing/timing.c

--- a/src/encoder/encoder.h
+++ b/src/encoder/encoder.h
@@ -29,7 +29,7 @@ class Encoder {
 
     virtual int initEncoder(mixxx::audio::SampleRate sampleRate, QString* pUserErrorMessage) = 0;
     // encodes the provided buffer of audio.
-    virtual void encodeBuffer(const CSAMPLE *samples, const int size) = 0;
+    virtual void encodeBuffer(const CSAMPLE* samples, const std::size_t bufferSize) = 0;
     // Adds metadata to the encoded audio, i.e., the ID3 tag. Currently only used
     // by EngineRecord, ShoutConnection does something different.
     virtual void updateMetaData(const QString& artist, const QString& title, const QString& album) = 0;

--- a/src/encoder/encoderfdkaac.cpp
+++ b/src/encoder/encoderfdkaac.cpp
@@ -351,11 +351,11 @@ int EncoderFdkAac::initEncoder(mixxx::audio::SampleRate sampleRate, QString* pUs
     return 0;
 }
 
-void EncoderFdkAac::encodeBuffer(const CSAMPLE* samples, const int sampleCount) {
+void EncoderFdkAac::encodeBuffer(const CSAMPLE* samples, const std::size_t bufferSize) {
     if (!m_pInputFifo) {
         return;
     }
-    int writeCount = sampleCount;
+    int writeCount = static_cast<int>(bufferSize);
     int writeAvailable = m_pInputFifo->writeAvailable();
     if (writeCount > writeAvailable) {
         kLogger.warning() << "FIFO buffer too small, losing samples!"

--- a/src/encoder/encoderfdkaac.h
+++ b/src/encoder/encoderfdkaac.h
@@ -15,7 +15,7 @@ class EncoderFdkAac : public Encoder {
     virtual ~EncoderFdkAac();
 
     int initEncoder(mixxx::audio::SampleRate sampleRate, QString* pUserErrorMessage) override;
-    void encodeBuffer(const CSAMPLE* samples, const int sampleCount) override;
+    void encodeBuffer(const CSAMPLE* samples, const std::size_t bufferSize) override;
     void updateMetaData(const QString& artist, const QString& title, const QString& album) override;
     void flush() override;
     void setEncoderSettings(const EncoderSettings& settings) override;

--- a/src/encoder/encoderffmpegcore.cpp
+++ b/src/encoder/encoderffmpegcore.cpp
@@ -99,7 +99,7 @@ int EncoderFfmpegCore::getSerial() {
     return l_iSerial;
 }
 
-void EncoderFfmpegCore::encodeBuffer(const CSAMPLE *samples, const int size) {
+void EncoderFfmpegCore::encodeBuffer(const CSAMPLE* samples, const std::size_t bufferSize) {
     unsigned char *l_strBuffer = NULL;
     int l_iBufferLen = 0;
     //int l_iAudioCpyLen = m_iAudioInputFrameSize *

--- a/src/encoder/encoderffmpegcore.h
+++ b/src/encoder/encoderffmpegcore.h
@@ -43,7 +43,7 @@ public:
 #endif
     ~EncoderFfmpegCore();
     int initEncoder(mixxx::audio::SampleRate sampleRate, QString* pUserErrorMessage) override;
-    void encodeBuffer(const CSAMPLE *samples, const int size) override;
+    void encodeBuffer(const CSAMPLE* samples, const std::size_t bufferSize) override;
     void updateMetaData(const QString& artist, const QString& title, const QString& album) override;
     void flush() override;
     void setEncoderSettings(const EncoderSettings& settings) override;

--- a/src/encoder/encodermp3.cpp
+++ b/src/encoder/encodermp3.cpp
@@ -81,32 +81,32 @@ void EncoderMp3::setEncoderSettings(const EncoderSettings& settings) {
     }
 }
 
-int EncoderMp3::bufferOutGrow(int size) {
-    if (m_bufferOutSize >= size) {
+int EncoderMp3::bufferOutGrow(std::size_t bufferSize) {
+    if (m_bufferOutSize >= bufferSize) {
         return 0;
     }
 
-    m_bufferOut = (unsigned char *)realloc(m_bufferOut, size);
+    m_bufferOut = (unsigned char*)realloc(m_bufferOut, bufferSize);
     if (m_bufferOut == nullptr) {
         return -1;
     }
 
-    m_bufferOutSize = size;
+    m_bufferOutSize = bufferSize;
     return 0;
 }
 
-int EncoderMp3::bufferInGrow(int size) {
-    if (m_bufferInSize >= size) {
+int EncoderMp3::bufferInGrow(std::size_t bufferSize) {
+    if (m_bufferInSize >= bufferSize) {
         return 0;
     }
 
-    m_bufferIn[0] = (float *)realloc(m_bufferIn[0], size * sizeof(float));
-    m_bufferIn[1] = (float *)realloc(m_bufferIn[1], size * sizeof(float));
+    m_bufferIn[0] = (float*)realloc(m_bufferIn[0], bufferSize * sizeof(float));
+    m_bufferIn[1] = (float*)realloc(m_bufferIn[1], bufferSize * sizeof(float));
     if ((m_bufferIn[0] == nullptr) || (m_bufferIn[1] == nullptr)) {
         return -1;
     }
 
-    m_bufferInSize = size;
+    m_bufferInSize = bufferSize;
     return 0;
 }
 
@@ -117,7 +117,7 @@ void EncoderMp3::flush() {
         return;
     }
     // Flush also writes ID3 tags.
-    int rc = lame_encode_flush(m_lameFlags, m_bufferOut, m_bufferOutSize);
+    int rc = lame_encode_flush(m_lameFlags, m_bufferOut, static_cast<int>(m_bufferOutSize));
     if (rc < 0) {
         return;
     }
@@ -127,39 +127,42 @@ void EncoderMp3::flush() {
     // `lame_get_lametag_frame` returns the number of bytes copied into buffer,
     // or the required buffer size, if the provided buffer is too small.
     // Function failed, if the return value is larger than `m_bufferOutSize`!
-    int numBytes = static_cast<int>(
-            lame_get_lametag_frame(m_lameFlags, m_bufferOut, m_bufferOutSize));
+    std::size_t numBytes =
+            lame_get_lametag_frame(m_lameFlags, m_bufferOut, m_bufferOutSize);
     if (numBytes > m_bufferOutSize) {
         bufferOutGrow(numBytes);
-        numBytes = static_cast<int>(lame_get_lametag_frame(
-                m_lameFlags, m_bufferOut, m_bufferOutSize));
+        numBytes = lame_get_lametag_frame(
+                m_lameFlags, m_bufferOut, m_bufferOutSize);
     }
     // Write the lame/xing header.
     m_pCallback->seek(0);
-    m_pCallback->write(nullptr, m_bufferOut, 0, numBytes);
+    m_pCallback->write(nullptr, m_bufferOut, 0, static_cast<int>(numBytes));
 }
 
-void EncoderMp3::encodeBuffer(const CSAMPLE *samples, const int size) {
+void EncoderMp3::encodeBuffer(const CSAMPLE* samples, const std::size_t bufferSize) {
     if (m_lameFlags == nullptr) {
         return;
     }
-    int outsize = 0;
+    std::size_t outsize = 0;
     int rc = 0;
 
-    outsize = (int)((1.25 * size + 7200) + 1);
+    outsize = (int)((1.25 * bufferSize + 7200) + 1);
     bufferOutGrow(outsize);
 
-    bufferInGrow(size);
+    bufferInGrow(bufferSize);
 
     // Deinterleave samples. We use normalized floats in the engine [-1.0, 1.0]
     // but LAME expects samples in the range [SHRT_MIN, SHRT_MAX].
-    for (int i = 0; i < size/2; ++i) {
+    for (std::size_t i = 0; i < bufferSize / 2; ++i) {
         m_bufferIn[0][i] = samples[i*2] * SHRT_MAX;
         m_bufferIn[1][i] = samples[i*2+1] * SHRT_MAX;
     }
-
-    rc = lame_encode_buffer_float(m_lameFlags, m_bufferIn[0], m_bufferIn[1],
-                                  size/2, m_bufferOut, m_bufferOutSize);
+    rc = lame_encode_buffer_float(m_lameFlags,
+            m_bufferIn[0],
+            m_bufferIn[1],
+            static_cast<int>(bufferSize / 2),
+            m_bufferOut,
+            static_cast<int>(m_bufferOutSize));
     if (rc < 0) {
         return;
     }
@@ -168,7 +171,7 @@ void EncoderMp3::encodeBuffer(const CSAMPLE *samples, const int size) {
 }
 
 void EncoderMp3::initStream() {
-    m_bufferOutSize = (int)((1.25 * 20000 + 7200) + 1);
+    m_bufferOutSize = (size_t)((1.25 * 20000 + 7200) + 1);
     m_bufferOut = (unsigned char *)malloc(m_bufferOutSize);
 
     m_bufferIn[0] = (float *)malloc(m_bufferOutSize * sizeof(float));

--- a/src/encoder/encodermp3.h
+++ b/src/encoder/encodermp3.h
@@ -15,15 +15,15 @@ class EncoderMp3 final : public Encoder {
     ~EncoderMp3() override;
 
     int initEncoder(mixxx::audio::SampleRate sampleRate, QString* pUserErrorMessage) override;
-    void encodeBuffer(const CSAMPLE *samples, const int size) override;
+    void encodeBuffer(const CSAMPLE* samples, const std::size_t bufferSize) override;
     void updateMetaData(const QString& artist, const QString& title, const QString& album) override;
     void flush() override;
     void setEncoderSettings(const EncoderSettings& settings) override;
 
   private:
     void initStream();
-    int bufferOutGrow(int size);
-    int bufferInGrow(int size);
+    int bufferOutGrow(std::size_t bufferSize);
+    int bufferInGrow(std::size_t bufferSize);
 
     lame_t m_lameFlags;
     QString m_metaDataTitle;
@@ -35,9 +35,9 @@ class EncoderMp3 final : public Encoder {
     vbr_mode m_encoding_mode;
     MPEG_mode_e m_stereo_mode;
     unsigned char *m_bufferOut;
-    int m_bufferOutSize;
+    std::size_t m_bufferOutSize;
     float* m_bufferIn[2];
-    int m_bufferInSize;
+    std::size_t m_bufferInSize;
 
     EncoderCallback* m_pCallback;
 };

--- a/src/encoder/encoderopus.cpp
+++ b/src/encoder/encoderopus.cpp
@@ -368,12 +368,12 @@ void EncoderOpus::pushTagsPacket() {
     }
 }
 
-void EncoderOpus::encodeBuffer(const CSAMPLE *samples, const int size) {
+void EncoderOpus::encodeBuffer(const CSAMPLE* samples, const std::size_t bufferSize) {
     if (!m_pOpus) {
         return;
     }
 
-    int writeRequired = size;
+    int writeRequired = static_cast<int>(bufferSize);
     int writeAvailable = m_fifoBuffer.writeAvailable();
     if (writeRequired > writeAvailable) {
         kLogger.warning() << "FIFO buffer too small, losing samples!"

--- a/src/encoder/encoderopus.h
+++ b/src/encoder/encoderopus.h
@@ -27,7 +27,7 @@ class EncoderOpus: public Encoder {
     ~EncoderOpus() override;
 
     int initEncoder(mixxx::audio::SampleRate sampleRate, QString* pUserErrorMessage) override;
-    void encodeBuffer(const CSAMPLE *samples, const int size) override;
+    void encodeBuffer(const CSAMPLE* samples, const std::size_t bufferSize) override;
     void updateMetaData(const QString& artist, const QString& title, const QString& album) override;
     void flush() override;
     void setEncoderSettings(const EncoderSettings& settings) override;

--- a/src/encoder/encodersndfileflac.cpp
+++ b/src/encoder/encodersndfileflac.cpp
@@ -58,10 +58,10 @@ void EncoderSndfileFlac::setEncoderSettings(const EncoderSettings& settings)
     m_compression = static_cast<double>(settings.getCompression()) / 8.0;
 }
 
-void EncoderSndfileFlac::encodeBuffer(const CSAMPLE* pBuffer, const int iBufferSize) {
+void EncoderSndfileFlac::encodeBuffer(const CSAMPLE* pBuffer, const std::size_t bufferSize) {
     if (m_pClampBuffer) {
-        SINT numSamplesLeft = iBufferSize;
-        while (numSamplesLeft > 0) {
+            SINT numSamplesLeft = bufferSize;
+            while (numSamplesLeft > 0) {
             const SINT numSamplesToWrite = math_min(numSamplesLeft, kEncBufferSize);
             convertFloat32ToIntFormat(m_pClampBuffer.get(),
                     pBuffer,
@@ -70,9 +70,9 @@ void EncoderSndfileFlac::encodeBuffer(const CSAMPLE* pBuffer, const int iBufferS
             sf_write_int(m_pSndfile, m_pClampBuffer.get(), numSamplesToWrite);
             pBuffer += numSamplesToWrite;
             numSamplesLeft -= numSamplesToWrite;
-        }
+            }
     } else {
-        sf_write_float(m_pSndfile, pBuffer, iBufferSize);
+            sf_write_float(m_pSndfile, pBuffer, bufferSize);
     }
 }
 

--- a/src/encoder/encodersndfileflac.cpp
+++ b/src/encoder/encodersndfileflac.cpp
@@ -60,8 +60,8 @@ void EncoderSndfileFlac::setEncoderSettings(const EncoderSettings& settings)
 
 void EncoderSndfileFlac::encodeBuffer(const CSAMPLE* pBuffer, const std::size_t bufferSize) {
     if (m_pClampBuffer) {
-            SINT numSamplesLeft = bufferSize;
-            while (numSamplesLeft > 0) {
+        SINT numSamplesLeft = bufferSize;
+        while (numSamplesLeft > 0) {
             const SINT numSamplesToWrite = math_min(numSamplesLeft, kEncBufferSize);
             convertFloat32ToIntFormat(m_pClampBuffer.get(),
                     pBuffer,
@@ -70,9 +70,9 @@ void EncoderSndfileFlac::encodeBuffer(const CSAMPLE* pBuffer, const std::size_t 
             sf_write_int(m_pSndfile, m_pClampBuffer.get(), numSamplesToWrite);
             pBuffer += numSamplesToWrite;
             numSamplesLeft -= numSamplesToWrite;
-            }
+        }
     } else {
-            sf_write_float(m_pSndfile, pBuffer, bufferSize);
+        sf_write_float(m_pSndfile, pBuffer, bufferSize);
     }
 }
 

--- a/src/encoder/encodersndfileflac.h
+++ b/src/encoder/encodersndfileflac.h
@@ -19,7 +19,7 @@ class EncoderSndfileFlac : public EncoderWave {
     ~EncoderSndfileFlac() override = default;
 
     void setEncoderSettings(const EncoderSettings& settings) override;
-    void encodeBuffer(const CSAMPLE* samples, const int size) override;
+    void encodeBuffer(const CSAMPLE* samples, const std::size_t bufferSize) override;
 
   protected:
     void initStream() override;

--- a/src/encoder/encodervorbis.cpp
+++ b/src/encoder/encodervorbis.cpp
@@ -133,25 +133,25 @@ void EncoderVorbis::writePage() {
     }
 }
 
-void EncoderVorbis::encodeBuffer(const CSAMPLE *samples, const int size) {
-    float **buffer = vorbis_analysis_buffer(&m_vdsp, size);
+void EncoderVorbis::encodeBuffer(const CSAMPLE* samples, const std::size_t bufferSize) {
+    float** buffer = vorbis_analysis_buffer(&m_vdsp, static_cast<int>(bufferSize));
 
     // Deinterleave samples. We use normalized floats in the engine [-1.0, 1.0]
     // and libvorbis expects samples in the range [-1.0, 1.0] so no conversion
     // is required.
     if (m_channels == 2) {
-        for (int i = 0; i < size/2; ++i) {
+        for (std::size_t i = 0; i < bufferSize / 2; ++i) {
             buffer[0][i] = samples[i*2];
             buffer[1][i] = samples[i*2+1];
         }
     }
     else {
-        for (int i = 0; i < size/2; ++i) {
+        for (std::size_t i = 0; i < bufferSize / 2; ++i) {
             buffer[0][i] = (samples[i*2] + samples[i*2+1]) / 2.f;
         }
     }
     /** encodes audio **/
-    vorbis_analysis_wrote(&m_vdsp, size/2);
+    vorbis_analysis_wrote(&m_vdsp, static_cast<int>(bufferSize) / 2);
     /** writes the OGG page and sends it to file or stream **/
     writePage();
 }

--- a/src/encoder/encodervorbis.h
+++ b/src/encoder/encodervorbis.h
@@ -19,7 +19,7 @@ class EncoderVorbis : public Encoder {
     ~EncoderVorbis() override;
 
     int initEncoder(mixxx::audio::SampleRate sampleRate, QString* pUserErrorMessage) override;
-    void encodeBuffer(const CSAMPLE *samples, const int size) override;
+    void encodeBuffer(const CSAMPLE* samples, const std::size_t bufferSize) override;
     void updateMetaData(const QString& artist, const QString& title, const QString& album) override;
     void flush() override;
     void setEncoderSettings(const EncoderSettings& settings) override;

--- a/src/encoder/encoderwave.cpp
+++ b/src/encoder/encoderwave.cpp
@@ -136,9 +136,8 @@ void EncoderWave::flush() {
     sf_write_sync(m_pSndfile);
 }
 
-
-void EncoderWave::encodeBuffer(const CSAMPLE *pBuffer, const int iBufferSize) {
-    sf_write_float(m_pSndfile, pBuffer, iBufferSize);
+void EncoderWave::encodeBuffer(const CSAMPLE* pBuffer, const std::size_t bufferSize) {
+    sf_write_float(m_pSndfile, pBuffer, bufferSize);
 }
 
 /* Originally called from enginebroadcast.cpp to update metadata information

--- a/src/encoder/encoderwave.h
+++ b/src/encoder/encoderwave.h
@@ -21,7 +21,7 @@ class EncoderWave : public Encoder {
     ~EncoderWave() override;
 
     int initEncoder(mixxx::audio::SampleRate sampleRate, QString* pUserErrorMessage) override;
-    void encodeBuffer(const CSAMPLE *samples, const int size) override;
+    void encodeBuffer(const CSAMPLE* samples, const std::size_t bufferSize) override;
     void updateMetaData(const QString& artist, const QString& title, const QString& album) override;
     void flush() override;
     void setEncoderSettings(const EncoderSettings& settings) override;

--- a/src/engine/channelmixer.cpp
+++ b/src/engine/channelmixer.cpp
@@ -10,7 +10,7 @@ void ChannelMixer::applyEffectsAndMixChannels(const EngineMixer::GainCalculator&
         QVarLengthArray<EngineMixer::GainCache, kPreallocatedChannels>* channelGainCache,
         CSAMPLE* pOutput,
         const ChannelHandle& outputHandle,
-        unsigned int iBufferSize,
+        std::size_t bufferSize,
         mixxx::audio::SampleRate sampleRate,
         EngineEffectsManager* pEngineEffectsManager) {
     // Signal flow overview:
@@ -22,7 +22,7 @@ void ChannelMixer::applyEffectsAndMixChannels(const EngineMixer::GainCalculator&
     //     C) Processes effects on the temporary buffer
     //     D) Mixes the temporary buffer into pOutput
     // The original channel input buffers are not modified.
-    SampleUtil::clear(pOutput, iBufferSize);
+    SampleUtil::clear(pOutput, bufferSize);
     ScopedTimer t(QStringLiteral("EngineMixer::applyEffectsAndMixChannels"));
     for (auto* pChannelInfo : activeChannels) {
         EngineMixer::GainCache& gainCache = (*channelGainCache)[pChannelInfo->m_index];
@@ -42,7 +42,7 @@ void ChannelMixer::applyEffectsAndMixChannels(const EngineMixer::GainCalculator&
                 outputHandle,
                 pChannelInfo->m_pBuffer.data(),
                 pOutput,
-                iBufferSize,
+                bufferSize,
                 sampleRate,
                 pChannelInfo->m_features,
                 oldGain,
@@ -59,7 +59,7 @@ void ChannelMixer::applyEffectsInPlaceAndMixChannels(
                 channelGainCache,
         CSAMPLE* pOutput,
         const ChannelHandle& outputHandle,
-        unsigned int iBufferSize,
+        std::size_t bufferSize,
         mixxx::audio::SampleRate sampleRate,
         EngineEffectsManager* pEngineEffectsManager) {
     // Signal flow overview:
@@ -69,7 +69,7 @@ void ChannelMixer::applyEffectsInPlaceAndMixChannels(
     //    B) Applies effects to the buffer, modifying the original input buffer
     // 4. Mix the channel buffers together to make pOutput, overwriting the pOutput buffer from the last engine callback
     ScopedTimer t(QStringLiteral("EngineMixer::applyEffectsInPlaceAndMixChannels"));
-    SampleUtil::clear(pOutput, iBufferSize);
+    SampleUtil::clear(pOutput, bufferSize);
     for (auto* pChannelInfo : activeChannels) {
         EngineMixer::GainCache& gainCache = (*channelGainCache)[pChannelInfo->m_index];
         CSAMPLE_GAIN oldGain = gainCache.m_gain;
@@ -87,12 +87,12 @@ void ChannelMixer::applyEffectsInPlaceAndMixChannels(
         pEngineEffectsManager->processPostFaderInPlace(pChannelInfo->m_handle,
                 outputHandle,
                 pChannelInfo->m_pBuffer.data(),
-                iBufferSize,
+                bufferSize,
                 sampleRate,
                 pChannelInfo->m_features,
                 oldGain,
                 newGain,
                 fadeout);
-        SampleUtil::add(pOutput, pChannelInfo->m_pBuffer.data(), iBufferSize);
+        SampleUtil::add(pOutput, pChannelInfo->m_pBuffer.data(), bufferSize);
     }
 }

--- a/src/engine/channelmixer.h
+++ b/src/engine/channelmixer.h
@@ -19,7 +19,7 @@ class ChannelMixer {
                     channelGainCache,
             CSAMPLE* pOutput,
             const ChannelHandle& outputHandle,
-            unsigned int iBufferSize,
+            std::size_t bufferSize,
             mixxx::audio::SampleRate sampleRate,
             EngineEffectsManager* pEngineEffectsManager);
     // This does modify the input channel buffers, then mixes them to make the output buffer.
@@ -31,7 +31,7 @@ class ChannelMixer {
                     channelGainCache,
             CSAMPLE* pOutput,
             const ChannelHandle& outputHandle,
-            unsigned int iBufferSize,
+            std::size_t bufferSize,
             mixxx::audio::SampleRate sampleRate,
             EngineEffectsManager* pEngineEffectsManager);
 };

--- a/src/engine/channels/engineaux.cpp
+++ b/src/engine/channels/engineaux.cpp
@@ -69,26 +69,26 @@ void EngineAux::receiveBuffer(
     m_sampleBuffer = pBuffer;
 }
 
-void EngineAux::process(CSAMPLE* pOut, const int iBufferSize) {
+void EngineAux::process(CSAMPLE* pOut, const std::size_t bufferSize) {
     const CSAMPLE* sampleBuffer = m_sampleBuffer; // save pointer on stack
     CSAMPLE_GAIN pregain = static_cast<CSAMPLE_GAIN>(m_pPregain->get());
     if (sampleBuffer) {
-        SampleUtil::copyWithGain(pOut, sampleBuffer, pregain, iBufferSize);
+        SampleUtil::copyWithGain(pOut, sampleBuffer, pregain, bufferSize);
         EngineEffectsManager* pEngineEffectsManager = m_pEffectsManager->getEngineEffectsManager();
         if (pEngineEffectsManager != nullptr) {
             pEngineEffectsManager->processPreFaderInPlace(m_group.handle(),
                     m_pEffectsManager->getMainHandle(),
                     pOut,
-                    iBufferSize,
+                    bufferSize,
                     mixxx::audio::SampleRate::fromDouble(m_sampleRate.get()));
         }
         m_sampleBuffer = nullptr;
     } else {
-        SampleUtil::clear(pOut, iBufferSize);
+        SampleUtil::clear(pOut, bufferSize);
     }
 
     // Update VU meter
-    m_vuMeter.process(pOut, iBufferSize);
+    m_vuMeter.process(pOut, bufferSize);
 }
 
 void EngineAux::collectFeatures(GroupFeatureState* pGroupFeatures) const {

--- a/src/engine/channels/engineaux.h
+++ b/src/engine/channels/engineaux.h
@@ -18,7 +18,7 @@ class EngineAux : public EngineChannel, public AudioDestination {
     ActiveState updateActiveState() override;
 
     /// Called by EngineMixer whenever is requesting a new buffer of audio.
-    void process(CSAMPLE* pOutput, const int iBufferSize) override;
+    void process(CSAMPLE* pOutput, const std::size_t bufferSize) override;
     void collectFeatures(GroupFeatureState* pGroupFeatures) const override;
 
     /// This is called by SoundManager whenever there are new samples from the

--- a/src/engine/channels/enginechannel.h
+++ b/src/engine/channels/enginechannel.h
@@ -66,8 +66,8 @@ class EngineChannel : public EngineObject {
     virtual void postProcessLocalBpm() {
     }
 
-    virtual void postProcess(const int iBufferSize) {
-        Q_UNUSED(iBufferSize)
+    virtual void postProcess(const std::size_t bufferSize) {
+        Q_UNUSED(bufferSize)
     }
 
     // TODO(XXX) This hack needs to be removed.

--- a/src/engine/channels/enginedeck.cpp
+++ b/src/engine/channels/enginedeck.cpp
@@ -131,17 +131,17 @@ void EngineDeck::addStemHandle(const ChannelHandleAndGroup& stemHandleGroup) {
     }
 }
 
-void EngineDeck::processStem(CSAMPLE* pOut, const int iBufferSize) {
+void EngineDeck::processStem(CSAMPLE* pOut, const std::size_t bufferSize) {
     mixxx::audio::ChannelCount chCount = m_pBuffer->getChannelCount();
     VERIFY_OR_DEBUG_ASSERT(m_stems.size() <= chCount &&
             m_stemMute.size() <= chCount && m_stemGain.size() <= chCount) {
         return;
     };
     mixxx::audio::SampleRate sampleRate = mixxx::audio::SampleRate::fromDouble(m_sampleRate.get());
-    int stemCount = chCount / mixxx::kEngineChannelOutputCount;
-    int numFrames = iBufferSize / mixxx::kEngineChannelOutputCount;
-    auto allChannelBufferSize = iBufferSize * stemCount;
-    if (m_stemBuffer.size() < allChannelBufferSize) {
+    unsigned int stemCount = chCount / mixxx::kEngineChannelOutputCount;
+    SINT numFrames = bufferSize / mixxx::kEngineChannelOutputCount;
+    std::size_t allChannelBufferSize = bufferSize * stemCount;
+    if (m_stemBuffer.size() < static_cast<SINT>(allChannelBufferSize)) {
         m_stemBuffer = mixxx::SampleBuffer(allChannelBufferSize);
     }
     m_pBuffer->process(m_stemBuffer.data(), allChannelBufferSize);
@@ -164,7 +164,7 @@ void EngineDeck::processStem(CSAMPLE* pOut, const int iBufferSize) {
     // effect manager so we can also apply the individual stem quick FX
     GroupFeatureState featureState;
     collectFeatures(&featureState);
-    for (int stemIdx = 0; stemIdx < stemCount;
+    for (size_t stemIdx = 0; stemIdx < stemCount;
             stemIdx++) {
         int chOffset = stemIdx * mixxx::audio::ChannelCount::stereo();
         float stemGain = m_stemMute[stemIdx]->toBool()
@@ -181,7 +181,7 @@ void EngineDeck::processStem(CSAMPLE* pOut, const int iBufferSize) {
         pEngineEffectsManager->processPostFaderInPlace(m_stems[stemIdx].handle(),
                 m_pEffectsManager->getMainHandle(),
                 pOut,
-                iBufferSize,
+                bufferSize,
                 sampleRate,
                 featureState,
                 m_stemsGainCache[stemIdx],
@@ -226,18 +226,18 @@ void EngineDeck::cloneStemState(const EngineDeck* deckToClone) {
 }
 #endif
 
-void EngineDeck::process(CSAMPLE* pOut, const int iBufferSize) {
+void EngineDeck::process(CSAMPLE* pOut, const std::size_t bufferSize) {
     // Feed the incoming audio through if passthrough is active
     const CSAMPLE* sampleBuffer = m_sampleBuffer; // save pointer on stack
     if (isPassthroughActive() && sampleBuffer) {
-        SampleUtil::copy(pOut, sampleBuffer, iBufferSize);
+        SampleUtil::copy(pOut, sampleBuffer, bufferSize);
         m_bPassthroughWasActive = true;
         m_sampleBuffer = nullptr;
         m_pPregain->setSpeedAndScratching(1, false);
     } else {
         // If passthrough is no longer enabled, zero out the buffer
         if (m_bPassthroughWasActive) {
-            SampleUtil::clear(pOut, iBufferSize);
+            SampleUtil::clear(pOut, bufferSize);
             m_bPassthroughWasActive = false;
             return;
         }
@@ -247,11 +247,11 @@ void EngineDeck::process(CSAMPLE* pOut, const int iBufferSize) {
         if (m_pBuffer->getChannelCount() <= mixxx::kEngineChannelOutputCount) {
             // Process a single mono or stereo channel
 #endif
-            m_pBuffer->process(pOut, iBufferSize);
+            m_pBuffer->process(pOut, bufferSize);
 #ifdef __STEM__
         } else {
             // Process multiple stereo channels (stems) and mix them together
-            processStem(pOut, iBufferSize);
+            processStem(pOut, bufferSize);
         }
 #endif
         m_pPregain->setSpeedAndScratching(m_pBuffer->getSpeed(), m_pBuffer->getScratching());
@@ -259,19 +259,19 @@ void EngineDeck::process(CSAMPLE* pOut, const int iBufferSize) {
     }
 
     // Apply pregain
-    m_pPregain->process(pOut, iBufferSize);
+    m_pPregain->process(pOut, bufferSize);
 
     EngineEffectsManager* pEngineEffectsManager = m_pEffectsManager->getEngineEffectsManager();
     if (pEngineEffectsManager != nullptr) {
         pEngineEffectsManager->processPreFaderInPlace(m_group.handle(),
                 m_pEffectsManager->getMainHandle(),
                 pOut,
-                iBufferSize,
+                bufferSize,
                 mixxx::audio::SampleRate::fromDouble(m_sampleRate.get()));
     }
 
     // Update VU meter
-    m_vuMeter.process(pOut, iBufferSize);
+    m_vuMeter.process(pOut, bufferSize);
 }
 
 void EngineDeck::collectFeatures(GroupFeatureState* pGroupFeatures) const {
@@ -284,8 +284,8 @@ void EngineDeck::postProcessLocalBpm() {
     m_pBuffer->postProcessLocalBpm();
 }
 
-void EngineDeck::postProcess(const int iBufferSize) {
-    m_pBuffer->postProcess(iBufferSize);
+void EngineDeck::postProcess(const std::size_t bufferSize) {
+    m_pBuffer->postProcess(bufferSize);
 }
 
 EngineBuffer* EngineDeck::getEngineBuffer() {

--- a/src/engine/channels/enginedeck.cpp
+++ b/src/engine/channels/enginedeck.cpp
@@ -164,7 +164,7 @@ void EngineDeck::processStem(CSAMPLE* pOut, const std::size_t bufferSize) {
     // effect manager so we can also apply the individual stem quick FX
     GroupFeatureState featureState;
     collectFeatures(&featureState);
-    for (size_t stemIdx = 0; stemIdx < stemCount;
+    for (std::size_t stemIdx = 0; stemIdx < stemCount;
             stemIdx++) {
         int chOffset = stemIdx * mixxx::audio::ChannelCount::stereo();
         float stemGain = m_stemMute[stemIdx]->toBool()

--- a/src/engine/channels/enginedeck.h
+++ b/src/engine/channels/enginedeck.h
@@ -26,7 +26,7 @@ class EngineDeck : public EngineChannel, public AudioDestination {
             bool primaryDeck);
     ~EngineDeck() override;
 
-    void process(CSAMPLE* pOutput, const int iBufferSize) override;
+    void process(CSAMPLE* pOutput, const std::size_t bufferSize) override;
     void collectFeatures(GroupFeatureState* pGroupFeatures) const override;
 
     // postProcessLocalBpm() is called on all decks to update the localBpm after
@@ -38,7 +38,7 @@ class EngineDeck : public EngineChannel, public AudioDestination {
 
     // Update beat distances, sync modes, and other values that are only known
     // after all other processing is done.
-    void postProcess(const int iBufferSize) override;
+    void postProcess(const std::size_t bufferSize) override;
 
     // TODO(XXX) This hack needs to be removed.
     EngineBuffer* getEngineBuffer() override;
@@ -86,7 +86,7 @@ class EngineDeck : public EngineChannel, public AudioDestination {
   private:
 #ifdef __STEM__
     // Process multiple channels and mix them together into the passed buffer
-    void processStem(CSAMPLE* pOutput, const int iBufferSize);
+    void processStem(CSAMPLE* pOutput, const std::size_t bufferSize);
 #endif
 
     std::vector<ChannelHandleAndGroup> m_stems;

--- a/src/engine/channels/enginemicrophone.cpp
+++ b/src/engine/channels/enginemicrophone.cpp
@@ -68,28 +68,28 @@ void EngineMicrophone::receiveBuffer(
     m_sampleBuffer = pBuffer;
 }
 
-void EngineMicrophone::process(CSAMPLE* pOut, const int iBufferSize) {
+void EngineMicrophone::process(CSAMPLE* pOut, const std::size_t bufferSize) {
     // If configured read into the output buffer.
     // Otherwise, skip the appropriate number of samples to throw them away.
     const CSAMPLE* sampleBuffer = m_sampleBuffer; // save pointer on stack
     CSAMPLE_GAIN pregain = static_cast<CSAMPLE_GAIN>(m_pPregain->get());
     if (sampleBuffer) {
-        SampleUtil::copyWithGain(pOut, sampleBuffer, pregain, iBufferSize);
+        SampleUtil::copyWithGain(pOut, sampleBuffer, pregain, bufferSize);
         EngineEffectsManager* pEngineEffectsManager = m_pEffectsManager->getEngineEffectsManager();
         if (pEngineEffectsManager != nullptr) {
             pEngineEffectsManager->processPreFaderInPlace(m_group.handle(),
                     m_pEffectsManager->getMainHandle(),
                     pOut,
-                    iBufferSize,
+                    bufferSize,
                     mixxx::audio::SampleRate::fromDouble(m_sampleRate.get()));
         }
     } else {
-        SampleUtil::clear(pOut, iBufferSize);
+        SampleUtil::clear(pOut, bufferSize);
     }
     m_sampleBuffer = nullptr;
 
     // Update VU meter
-    m_vuMeter.process(pOut, iBufferSize);
+    m_vuMeter.process(pOut, bufferSize);
 }
 
 void EngineMicrophone::collectFeatures(GroupFeatureState* pGroupFeatures) const {

--- a/src/engine/channels/enginemicrophone.h
+++ b/src/engine/channels/enginemicrophone.h
@@ -19,7 +19,7 @@ class EngineMicrophone : public EngineChannel, public AudioDestination {
     ActiveState updateActiveState() override;
 
     // Called by EngineMixer whenever is requesting a new buffer of audio.
-    void process(CSAMPLE* pOutput, const int iBufferSize) override;
+    void process(CSAMPLE* pOutput, const std::size_t bufferSize) override;
     void collectFeatures(GroupFeatureState* pGroupFeatures) const override;
 
     // This is called by SoundManager whenever there are new samples from the

--- a/src/engine/controls/enginecontrol.cpp
+++ b/src/engine/controls/enginecontrol.cpp
@@ -19,12 +19,12 @@ EngineControl::EngineControl(const QString& group,
 EngineControl::~EngineControl() {
 }
 
-void EngineControl::process(const double dRate,
+void EngineControl::process(const double rate,
         mixxx::audio::FramePos currentPosition,
-        const int iBufferSize) {
-    Q_UNUSED(dRate);
+        const std::size_t bufferSize) {
+    Q_UNUSED(rate);
     Q_UNUSED(currentPosition);
-    Q_UNUSED(iBufferSize);
+    Q_UNUSED(bufferSize);
 }
 
 void EngineControl::trackLoaded(TrackPointer pNewTrack) {

--- a/src/engine/controls/enginecontrol.h
+++ b/src/engine/controls/enginecontrol.h
@@ -52,9 +52,9 @@ class EngineControl : public QObject {
     /// See the above comments for information about guarantees that hold during this call.
     /// An EngineControl can perform any upkeep operations necessary here.
     /// @param dRate current playback rate in audio frames per second
-    virtual void process(const double dRate,
+    virtual void process(const double rate,
             mixxx::audio::FramePos currentPosition,
-            const int iBufferSize);
+            const std::size_t bufferSize);
 
     /// hintReader allows the EngineControl to provide hints to the reader
     /// to indicate that the given portion of a song

--- a/src/engine/controls/enginecontrol.h
+++ b/src/engine/controls/enginecontrol.h
@@ -48,17 +48,17 @@ class EngineControl : public QObject {
             UserSettingsPointer pConfig);
     ~EngineControl() override;
 
-    // Called by EngineBuffer::process every latency period. See the above
-    // comments for information about guarantees that hold during this call. An
-    // EngineControl can perform any upkeep operations that are necessary during
-    // this call.
+    /// Called by EngineBuffer::process every latency period.
+    /// See the above comments for information about guarantees that hold during this call.
+    /// An EngineControl can perform any upkeep operations necessary here.
+    /// @param dRate current playback rate in audio frames per second
     virtual void process(const double dRate,
             mixxx::audio::FramePos currentPosition,
             const int iBufferSize);
 
-    // hintReader allows the EngineControl to provide hints to the reader to
-    // indicate that the given portion of a song is a potential imminent seek
-    // target.
+    /// hintReader allows the EngineControl to provide hints to the reader
+    /// to indicate that the given portion of a song
+    /// is a potential imminent seek target.
     virtual void hintReader(gsl::not_null<HintVector*> pHintList);
 
     virtual void setEngineMixer(EngineMixer* pEngineMixer);
@@ -73,7 +73,7 @@ class EngineControl : public QObject {
             mixxx::audio::FramePos endPosition,
             bool enabled);
 
-    // Called to collect player features for effects processing.
+    /// Collect player features for effects processing.
     virtual void collectFeatureState(GroupFeatureState* pGroupFeatures) const {
         Q_UNUSED(pGroupFeatures);
     }
@@ -103,9 +103,10 @@ class EngineControl : public QObject {
     }
     void seek(double fractionalPosition);
     void seekAbs(mixxx::audio::FramePos position);
-    // Seek to an exact sample and don't allow quantizing adjustment.
-    void seekExact(mixxx::audio::FramePos position);
-    // Returns an EngineBuffer to target for syncing. Returns nullptr if none found
+    /// Seek to an exact frame, no quantizing
+    /// virtual only for tests!
+    virtual void seekExact(mixxx::audio::FramePos position);
+    /// Return an EngineBuffer to target for syncing. Returns nullptr if none found.
     EngineBuffer* pickSyncTarget();
 
     UserSettingsPointer getConfig();

--- a/src/engine/controls/loopingcontrol.cpp
+++ b/src/engine/controls/loopingcontrol.cpp
@@ -361,10 +361,10 @@ void LoopingControl::slotLoopDouble(double pressed) {
     m_pCOBeatLoopSize->set(m_pCOBeatLoopSize->get() * 2.0);
 }
 
-void LoopingControl::process(const double dRate,
+void LoopingControl::process(const double rate,
         mixxx::audio::FramePos currentPosition,
-        const int iBufferSize) {
-    Q_UNUSED(iBufferSize);
+        const std::size_t bufferSize) {
+    Q_UNUSED(bufferSize);
 
     const auto previousPosition = m_currentPosition.getValue();
 
@@ -385,7 +385,7 @@ void LoopingControl::process(const double dRate,
                     // should be moved with it
                     const auto targetPosition =
                             adjustedPositionInsideAdjustedLoop(currentPosition,
-                                    dRate < 0, // reverse
+                                    rate < 0, // reverse
                                     m_oldLoopInfo.startPosition,
                                     m_oldLoopInfo.endPosition,
                                     loopInfo.startPosition,

--- a/src/engine/controls/loopingcontrol.h
+++ b/src/engine/controls/loopingcontrol.h
@@ -28,9 +28,9 @@ class LoopingControl : public EngineControl {
     // process() updates the internal state of the LoopingControl to reflect the
     // correct current sample. If a loop should be taken LoopingControl returns
     // the sample that should be seeked to. Otherwise it returns currentPosition.
-    void process(const double dRate,
+    void process(const double rate,
             mixxx::audio::FramePos currentPosition,
-            const int iBufferSize) override;
+            const std::size_t bufferSize) override;
 
     // nextTrigger returns the sample at which the engine will be triggered to
     // take a loop, given the value of currentPosition and the playback direction.

--- a/src/engine/controls/ratecontrol.cpp
+++ b/src/engine/controls/ratecontrol.cpp
@@ -394,14 +394,16 @@ SyncMode RateControl::getSyncMode() const {
     return syncModeFromDouble(m_pSyncMode->get());
 }
 
-double RateControl::calculateSpeed(double baserate, double speed, bool paused,
-                                   int iSamplesPerBuffer,
-                                   bool* pReportScratching,
-                                   bool* pReportReverse) {
+double RateControl::calculateSpeed(double baserate,
+        double speed,
+        bool paused,
+        std::size_t samplesPerBuffer,
+        bool* pReportScratching,
+        bool* pReportReverse) {
     *pReportScratching = false;
     *pReportReverse = false;
 
-    processTempRate(iSamplesPerBuffer);
+    processTempRate(samplesPerBuffer);
 
     double rate;
     const double searching = m_pRateSearch->get();
@@ -466,7 +468,7 @@ double RateControl::calculateSpeed(double baserate, double speed, bool paused,
         // (beatloop or track repeat) so it can correctly interpret the sample position delta.
         m_pScratchController->process(currentSample,
                 rate,
-                iSamplesPerBuffer,
+                samplesPerBuffer,
                 baserate,
                 m_wrapAroundCount,
                 m_jumpPos,
@@ -510,7 +512,7 @@ double RateControl::calculateSpeed(double baserate, double speed, bool paused,
     return rate;
 }
 
-void RateControl::processTempRate(const int bufferSamples) {
+void RateControl::processTempRate(const std::size_t bufferSamples) {
     // Code to handle temporary rate change buttons.
     // We support two behaviors, the standard ramped pitch bending
     // and pitch shift stepping, which is the old behavior.

--- a/src/engine/controls/ratecontrol.h
+++ b/src/engine/controls/ratecontrol.h
@@ -48,7 +48,7 @@ public:
           double baserate,
           double speed,
           bool paused,
-          int iSamplesPerBuffer,
+          std::size_t samplesPerBuffer,
           bool* pReportScratching,
           bool* pReportReverse);
 
@@ -90,7 +90,7 @@ public slots:
   void slotControlFastBack(double);
 
 private:
-  void processTempRate(const int bufferSamples);
+  void processTempRate(const size_t bufferSamples);
   double getJogFactor() const;
   double getWheelFactor() const;
   SyncMode getSyncMode() const;

--- a/src/engine/effects/engineeffect.cpp
+++ b/src/engine/effects/engineeffect.cpp
@@ -127,7 +127,7 @@ bool EngineEffect::process(const ChannelHandle& inputHandle,
         const ChannelHandle& outputHandle,
         const CSAMPLE* pInput,
         CSAMPLE* pOutput,
-        const unsigned int numSamples,
+        const std::size_t numSamples,
         const mixxx::audio::SampleRate sampleRate,
         const EffectEnableState chainEnableState,
         const GroupFeatureState& groupFeatures) {

--- a/src/engine/effects/engineeffect.h
+++ b/src/engine/effects/engineeffect.h
@@ -42,7 +42,7 @@ class EngineEffect final : public EffectsRequestHandler {
             const ChannelHandle& outputHandle,
             const CSAMPLE* pInput,
             CSAMPLE* pOutput,
-            const unsigned int numSamples,
+            const std::size_t numSamples,
             const mixxx::audio::SampleRate sampleRate,
             const EffectEnableState chainEnableState,
             const GroupFeatureState& groupFeatures);

--- a/src/engine/effects/engineeffectchain.cpp
+++ b/src/engine/effects/engineeffectchain.cpp
@@ -175,7 +175,7 @@ bool EngineEffectChain::process(const ChannelHandle& inputHandle,
         const ChannelHandle& outputHandle,
         CSAMPLE* pIn,
         CSAMPLE* pOut,
-        const unsigned int numSamples,
+        const std::size_t numSamples,
         const mixxx::audio::SampleRate sampleRate,
         const GroupFeatureState& groupFeatures,
         bool fadeout) {
@@ -287,7 +287,7 @@ bool EngineEffectChain::process(const ChannelHandle& inputHandle,
                         pIntermediateInput,
                         lastCallbackMixKnob,
                         currentMixKnob,
-                        numSamples);
+                        static_cast<int>(numSamples));
             } else {
                 // Dry+Wet mode: output = input + (wet * mix knob)
                 SampleUtil::copy2WithRampingGain(
@@ -298,7 +298,7 @@ bool EngineEffectChain::process(const ChannelHandle& inputHandle,
                         pIntermediateInput,
                         lastCallbackMixKnob,
                         currentMixKnob,
-                        numSamples);
+                        static_cast<int>(numSamples));
             }
         }
     }

--- a/src/engine/effects/engineeffectchain.h
+++ b/src/engine/effects/engineeffectchain.h
@@ -40,7 +40,7 @@ class EngineEffectChain final : public EffectsRequestHandler {
             const ChannelHandle& outputHandle,
             CSAMPLE* pIn,
             CSAMPLE* pOut,
-            const unsigned int numSamples,
+            const std::size_t numSamples,
             const mixxx::audio::SampleRate sampleRate,
             const GroupFeatureState& groupFeatures,
             bool fadeout);

--- a/src/engine/effects/engineeffectsdelay.cpp
+++ b/src/engine/effects/engineeffectsdelay.cpp
@@ -17,9 +17,9 @@ EngineEffectsDelay::~EngineEffectsDelay() {
 }
 
 void EngineEffectsDelay::process(CSAMPLE* pInOut,
-        const int iBufferSize) {
+        const std::size_t bufferSize) {
     if (m_prevDelaySamples == 0 && m_currentDelaySamples == 0) {
-        for (int i = 0; i < iBufferSize; ++i) {
+        for (std::size_t i = 0; i < bufferSize; ++i) {
             // Put samples into delay buffer.
             m_pDelayBuffer[m_delayBufferWritePos] = pInOut[i];
             m_delayBufferWritePos = (m_delayBufferWritePos + 1) % kDelayBufferSize;
@@ -38,7 +38,7 @@ void EngineEffectsDelay::process(CSAMPLE* pInOut,
             kDelayBufferSize;
 
     if (m_prevDelaySamples == m_currentDelaySamples) {
-        for (int i = 0; i < iBufferSize; ++i) {
+        for (std::size_t i = 0; i < bufferSize; ++i) {
             // Put samples into delay buffer.
             m_pDelayBuffer[m_delayBufferWritePos] = pInOut[i];
             m_delayBufferWritePos = (m_delayBufferWritePos + 1) % kDelayBufferSize;
@@ -59,9 +59,10 @@ void EngineEffectsDelay::process(CSAMPLE* pInOut,
                 (m_delayBufferWritePos + kDelayBufferSize - m_prevDelaySamples) %
                 kDelayBufferSize;
 
-        const RampingValue<CSAMPLE_GAIN> delayChangeRamped(0.0f, 1.0f, iBufferSize);
+        const RampingValue<CSAMPLE_GAIN> delayChangeRamped(
+                0.0f, 1.0f, static_cast<int>(bufferSize));
 
-        for (int i = 0; i < iBufferSize; ++i) {
+        for (std::size_t i = 0; i < bufferSize; ++i) {
             // Put samples into delay buffer.
             m_pDelayBuffer[m_delayBufferWritePos] = pInOut[i];
             m_delayBufferWritePos = (m_delayBufferWritePos + 1) % kDelayBufferSize;
@@ -70,7 +71,7 @@ void EngineEffectsDelay::process(CSAMPLE* pInOut,
             // and with the use of ramping (cross-fading),
             // calculate the result sample value
             // and put it into the dest buffer.
-            CSAMPLE_GAIN crossMix = delayChangeRamped.getNth(i);
+            CSAMPLE_GAIN crossMix = delayChangeRamped.getNth(static_cast<int>(i));
 
             pInOut[i] = m_pDelayBuffer[oldDelaySourcePos] * (1.0f - crossMix);
             pInOut[i] += m_pDelayBuffer[delaySourcePos] * crossMix;

--- a/src/engine/effects/engineeffectsdelay.h
+++ b/src/engine/effects/engineeffectsdelay.h
@@ -71,7 +71,7 @@ class EngineEffectsDelay final : public EngineObject {
     /// as actual and the output buffer is filled using cross-fading
     /// of the presumed output buffer for the previous delay value
     /// and of the output buffer created using the new delay value.
-    void process(CSAMPLE* pInOut, const int iBufferSize) override;
+    void process(CSAMPLE* pInOut, const std::size_t bufferSize) override;
 
   private:
     SINT m_currentDelaySamples;

--- a/src/engine/effects/engineeffectsmanager.cpp
+++ b/src/engine/effects/engineeffectsmanager.cpp
@@ -95,7 +95,7 @@ void EngineEffectsManager::onCallbackStart() {
 void EngineEffectsManager::processPreFaderInPlace(const ChannelHandle& inputHandle,
         const ChannelHandle& outputHandle,
         CSAMPLE* pInOut,
-        unsigned int numSamples,
+        std::size_t numSamples,
         mixxx::audio::SampleRate sampleRate) {
     // Feature state is gathered after prefader effects processing.
     // This is okay because the equalizer effects do not make use of it.
@@ -114,7 +114,7 @@ void EngineEffectsManager::processPostFaderInPlace(
         const ChannelHandle& inputHandle,
         const ChannelHandle& outputHandle,
         CSAMPLE* pInOut,
-        unsigned int numSamples,
+        std::size_t numSamples,
         mixxx::audio::SampleRate sampleRate,
         const GroupFeatureState& groupFeatures,
         CSAMPLE_GAIN oldGain,
@@ -138,7 +138,7 @@ void EngineEffectsManager::processPostFaderAndMix(
         const ChannelHandle& outputHandle,
         CSAMPLE* pIn,
         CSAMPLE* pOut,
-        unsigned int numSamples,
+        std::size_t numSamples,
         mixxx::audio::SampleRate sampleRate,
         const GroupFeatureState& groupFeatures,
         CSAMPLE_GAIN oldGain,
@@ -163,7 +163,7 @@ void EngineEffectsManager::processInner(
         const ChannelHandle& outputHandle,
         CSAMPLE* pIn,
         CSAMPLE* pOut,
-        unsigned int numSamples,
+        std::size_t numSamples,
         mixxx::audio::SampleRate sampleRate,
         const GroupFeatureState& groupFeatures,
         CSAMPLE_GAIN oldGain,

--- a/src/engine/effects/engineeffectsmanager.h
+++ b/src/engine/effects/engineeffectsmanager.h
@@ -32,7 +32,7 @@ class EngineEffectsManager final : public EffectsRequestHandler {
             const ChannelHandle& inputHandle,
             const ChannelHandle& outputHandle,
             CSAMPLE* pInOut,
-            unsigned int numSamples,
+            std::size_t numSamples,
             mixxx::audio::SampleRate sampleRate);
 
     /// Process the postfader EngineEffectChains on the pInOut buffer, modifying
@@ -41,7 +41,7 @@ class EngineEffectsManager final : public EffectsRequestHandler {
             const ChannelHandle& inputHandle,
             const ChannelHandle& outputHandle,
             CSAMPLE* pInOut,
-            unsigned int numSamples,
+            std::size_t numSamples,
             mixxx::audio::SampleRate sampleRate,
             const GroupFeatureState& groupFeatures,
             CSAMPLE_GAIN oldGain = CSAMPLE_GAIN_ONE,
@@ -58,7 +58,7 @@ class EngineEffectsManager final : public EffectsRequestHandler {
             const ChannelHandle& outputHandle,
             CSAMPLE* pIn,
             CSAMPLE* pOut,
-            unsigned int numSamples,
+            std::size_t numSamples,
             mixxx::audio::SampleRate sampleRate,
             const GroupFeatureState& groupFeatures,
             CSAMPLE_GAIN oldGain = CSAMPLE_GAIN_ONE,
@@ -89,7 +89,7 @@ class EngineEffectsManager final : public EffectsRequestHandler {
             const ChannelHandle& outputHandle,
             CSAMPLE* pIn,
             CSAMPLE* pOut,
-            unsigned int numSamples,
+            std::size_t numSamples,
             mixxx::audio::SampleRate sampleRate,
             const GroupFeatureState& groupFeatures,
             CSAMPLE_GAIN oldGain = CSAMPLE_GAIN_ONE,

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -95,7 +95,7 @@ EngineBuffer::EngineBuffer(const QString& group,
           m_pCrossfadeBuffer(SampleUtil::alloc(
                   kMaxEngineFrames * mixxx::kMaxEngineChannelInputCount)),
           m_bCrossfadeReady(false),
-          m_iLastBufferSize(0) {
+          m_lastBufferSize(0) {
     // This should be a static assertion, but isValid() is not constexpr.
     DEBUG_ASSERT(kInitialPlayPosition.isValid());
 
@@ -331,7 +331,7 @@ void EngineBuffer::bindWorkers(EngineWorkerScheduler* pWorkerScheduler) {
 }
 
 void EngineBuffer::enableIndependentPitchTempoScaling(bool bEnable,
-                                                      const int iBufferSize) {
+        const std::size_t bufferSize) {
     // MUST ACQUIRE THE PAUSE MUTEX BEFORE CALLING THIS METHOD
 
     // When no time-stretching or pitch-shifting is needed we use our own linear
@@ -348,7 +348,7 @@ void EngineBuffer::enableIndependentPitchTempoScaling(bool bEnable,
             // Crossfade if we are not paused.
             // If we start from zero a ramping gain is
             // applied later
-            readToCrossfadeBuffer(iBufferSize);
+            readToCrossfadeBuffer(bufferSize);
         }
         m_pScale = keylock_scale;
         m_pScale->clear();
@@ -357,7 +357,7 @@ void EngineBuffer::enableIndependentPitchTempoScaling(bool bEnable,
         if (m_speed_old != 0.0) {
             // Crossfade if we are not paused
             // (for slow speeds below 0.1 the vinyl_scale is used)
-            readToCrossfadeBuffer(iBufferSize);
+            readToCrossfadeBuffer(bufferSize);
         }
         m_pScale = vinyl_scale;
         m_pScale->clear();
@@ -447,11 +447,11 @@ void EngineBuffer::requestSyncMode(SyncMode mode) {
     }
 }
 
-void EngineBuffer::readToCrossfadeBuffer(const int iBufferSize) {
+void EngineBuffer::readToCrossfadeBuffer(const std::size_t bufferSize) {
     if (!m_bCrossfadeReady) {
         // Read buffer, as if there where no parameter change
         // (Must be called only once per callback)
-        m_pScale->scaleBuffer(m_pCrossfadeBuffer, iBufferSize);
+        m_pScale->scaleBuffer(m_pCrossfadeBuffer, bufferSize);
         // Restore the original position that was lost due to scaleBuffer() above
         m_pReadAheadManager->notifySeek(m_playPos.toSamplePos(m_channelCount));
         m_bCrossfadeReady = true;
@@ -470,14 +470,14 @@ void EngineBuffer::setNewPlaypos(mixxx::audio::FramePos position) {
     if (m_rate_old != 0.0) {
         // Before seeking, read extra buffer for crossfading
         // this also sets m_pReadAheadManager to newpos
-        readToCrossfadeBuffer(m_iLastBufferSize);
+        readToCrossfadeBuffer(m_lastBufferSize);
     } else {
         m_pReadAheadManager->notifySeek(m_playPos.toSamplePos(m_channelCount));
     }
     m_pScale->clear();
 
     // Ensures that the playpos slider gets updated in next process call
-    m_iSamplesSinceLastIndicatorUpdate = 1000000;
+    m_samplesSinceLastIndicatorUpdate = 1000000;
 
     // Must hold the engineLock while using m_engineControls
     for (const auto& pControl : std::as_const(m_engineControls)) {
@@ -864,7 +864,7 @@ void EngineBuffer::slotKeylockEngineChanged(double dIndex) {
 }
 
 void EngineBuffer::processTrackLocked(
-        CSAMPLE* pOutput, const int iBufferSize, mixxx::audio::SampleRate sampleRate) {
+        CSAMPLE* pOutput, const std::size_t bufferSize, mixxx::audio::SampleRate sampleRate) {
     ScopedTimer t(QStringLiteral("EngineBuffer::process_pauselock"));
 
     m_trackSampleRateOld = mixxx::audio::SampleRate::fromDouble(m_pTrackSampleRate->get());
@@ -892,7 +892,7 @@ void EngineBuffer::processTrackLocked(
     bool is_reverse = false;
 
     // Update the slipped position and seek to it if slip mode was disabled.
-    processSlip(iBufferSize);
+    processSlip(bufferSize);
 
     // Note: This may affect the m_playPos, play, scaler and crossfade buffer
     processSeek(paused);
@@ -901,12 +901,12 @@ void EngineBuffer::processTrackLocked(
     // (1.0 being normal rate. 2.0 plays at 2x speed -- 2 track seconds
     // pass for every 1 real second). Depending on whether
     // keylock is enabled, this is applied to either the rate or the tempo.
-    int outputBufferSize = iBufferSize;
+    std::size_t outputBufferSize = bufferSize;
     int stereoPairCount = m_channelCount / mixxx::audio::ChannelCount::stereo();
     // The speed is calculated out of the buffer size for the stereo channel
     // output, after mixing multi channel (stem) together
     if (stereoPairCount > 1) {
-        outputBufferSize = iBufferSize / stereoPairCount;
+        outputBufferSize = bufferSize / stereoPairCount;
     }
     double speed = m_pRateControl->calculateSpeed(
             baseSampleRate,
@@ -970,10 +970,10 @@ void EngineBuffer::processTrackLocked(
     if (speed != 0.0) {
         // Do not switch scaler when we have no transport
         enableIndependentPitchTempoScaling(useIndependentPitchAndTempoScaling,
-                iBufferSize);
+                bufferSize);
     } else if (m_speed_old != 0 && !is_scratching) {
         // we are stopping, collect samples for fade out
-        readToCrossfadeBuffer(iBufferSize);
+        readToCrossfadeBuffer(bufferSize);
         // Clear the scaler information
         m_pScale->clear();
     }
@@ -1034,7 +1034,7 @@ void EngineBuffer::processTrackLocked(
                        m_reverse_old != is_reverse)) { // no pitch change when reversing
             //XXX: Trying to force RAMAN to read from correct
             //     playpos when rate changes direction - Albert
-            readToCrossfadeBuffer(iBufferSize);
+            readToCrossfadeBuffer(bufferSize);
             // Clear the scaler information
             m_pScale->clear();
         }
@@ -1095,7 +1095,7 @@ void EngineBuffer::processTrackLocked(
     // If the buffer is not paused, then scale the audio.
     if (!bCurBufferPaused) {
         // Perform scaling of Reader buffer into buffer.
-        const double framesRead = m_pScale->scaleBuffer(pOutput, iBufferSize);
+        const double framesRead = m_pScale->scaleBuffer(pOutput, bufferSize);
 
         // TODO(XXX): The result framesRead might not be an integer value.
         // Converting to samples here does not make sense. All positional
@@ -1121,7 +1121,7 @@ void EngineBuffer::processTrackLocked(
             // Bring pOutput with the new parameters in and fade out the old one,
             // stored with the old parameters in m_pCrossfadeBuffer
             SampleUtil::linearCrossfadeBuffersIn(
-                    pOutput, m_pCrossfadeBuffer, iBufferSize, m_channelCount);
+                    pOutput, m_pCrossfadeBuffer, bufferSize, m_channelCount);
         }
         // Note: we do not fade here if we pass the end or the start of
         // the track in reverse direction
@@ -1134,19 +1134,19 @@ void EngineBuffer::processTrackLocked(
         if (m_bCrossfadeReady) {
             // We don't ramp here, since EnginePregain handles fades
             // from and to speed == 0
-            SampleUtil::copy(pOutput, m_pCrossfadeBuffer, iBufferSize);
+            SampleUtil::copy(pOutput, m_pCrossfadeBuffer, bufferSize);
         } else {
-            SampleUtil::clear(pOutput, iBufferSize);
+            SampleUtil::clear(pOutput, bufferSize);
         }
     }
 
-    m_actual_speed = (m_playPos - playpos_old) / (iBufferSize / 2);
+    m_actual_speed = (m_playPos - playpos_old) / (bufferSize / 2);
     // qDebug() << "Ramped Speed" << m_actual_speed / m_speed_old;
 
     for (const auto& pControl : std::as_const(m_engineControls)) {
         // m_playPos is already updated here and points to the end of the played buffer
         pControl->setFrameInfo(m_playPos, trackEndPosition, m_trackSampleRateOld);
-        pControl->process(rate, m_playPos, iBufferSize);
+        pControl->process(rate, m_playPos, bufferSize);
     }
 
     m_scratching_old = is_scratching;
@@ -1178,9 +1178,9 @@ void EngineBuffer::processTrackLocked(
     hintReader(rate);
 }
 
-void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
+void EngineBuffer::process(CSAMPLE* pOutput, const std::size_t bufferSize) {
     // Bail if we receive a buffer size with incomplete sample frames. Assert in debug builds.
-    VERIFY_OR_DEBUG_ASSERT((iBufferSize % m_channelCount) == 0) {
+    VERIFY_OR_DEBUG_ASSERT((bufferSize % m_channelCount) == 0) {
         return;
     }
     m_pReader->process();
@@ -1207,7 +1207,7 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
 
     bool hasStableTrack = m_pTrackLoaded->toBool() && m_iTrackLoading.loadAcquire() == 0;
     if (hasStableTrack && m_pause.tryLock()) {
-        processTrackLocked(pOutput, iBufferSize, m_sampleRate);
+        processTrackLocked(pOutput, bufferSize, m_sampleRate);
         // release the pauselock
         m_pause.unlock();
     } else {
@@ -1227,7 +1227,7 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
         // is handled. For now we apply a rectangular Gain change here which
         // may click.
 
-        SampleUtil::clear(pOutput, iBufferSize);
+        SampleUtil::clear(pOutput, bufferSize);
 
         m_rate_old = 0;
         m_speed_old = 0;
@@ -1236,18 +1236,18 @@ void EngineBuffer::process(CSAMPLE* pOutput, const int iBufferSize) {
     }
 
 #ifdef __SCALER_DEBUG__
-    for (int i=0; i<iBufferSize; i+=2) {
+    for (std::size_t i = 0; i < bufferSize; i += 2) {
         writer << pOutput[i] << "\n";
     }
 #endif
 
     m_pSyncControl->updateAudible();
 
-    m_iLastBufferSize = iBufferSize;
+    m_lastBufferSize = bufferSize;
     m_bCrossfadeReady = false;
 }
 
-void EngineBuffer::processSlip(int iBufferSize) {
+void EngineBuffer::processSlip(std::size_t bufferSize) {
     // Do a single read from m_bSlipEnabled so we don't run in to race conditions.
     bool enabled = m_pSlipButton->toBool();
     if (enabled != m_bSlipEnabledProcessing) {
@@ -1264,15 +1264,15 @@ void EngineBuffer::processSlip(int iBufferSize) {
 
     // Increment slip position even if it was just toggled -- this ensures the position is correct.
     if (enabled) {
-        // `iBufferSize` originates from `SoundManager::onDeviceOutputCallback`
+        // `bufferSize` originates from `SoundManager::onDeviceOutputCallback`
         // and is always a multiple of channel count, so we can safely use integer division
         // to find the number of frames per buffer here.
         //
-        // TODO: Check if we can replace `iBufferSize` with the number of
+        // TODO: Check if we can replace `bufferSize` with the number of
         // frames per buffer in most engine method signatures to avoid this
         // back and forth calculations.
-        const int bufferFrameCount = iBufferSize / m_channelCount;
-        DEBUG_ASSERT(bufferFrameCount * m_channelCount == iBufferSize);
+        const std::size_t bufferFrameCount = bufferSize / m_channelCount;
+        DEBUG_ASSERT(bufferFrameCount * m_channelCount == bufferSize);
         const mixxx::audio::FrameDiff_t slipDelta =
                 static_cast<mixxx::audio::FrameDiff_t>(bufferFrameCount) * m_dSlipRate;
         // Simulate looping if a regular loop is active
@@ -1402,7 +1402,7 @@ void EngineBuffer::postProcessLocalBpm() {
     m_pBpmControl->updateLocalBpm();
 }
 
-void EngineBuffer::postProcess(const int iBufferSize) {
+void EngineBuffer::postProcess(const std::size_t bufferSize) {
     // The order of events here is very delicate.  It's necessary to update
     // some values before others, because the later updates may require
     // values from the first update. Do not make calls here that could affect
@@ -1433,7 +1433,7 @@ void EngineBuffer::postProcess(const int iBufferSize) {
 
     // Update all the indicators that EngineBuffer publishes to allow
     // external parts of Mixxx to observe its status.
-    updateIndicators(m_speed_old, iBufferSize);
+    updateIndicators(m_speed_old, bufferSize);
 }
 
 mixxx::audio::FramePos EngineBuffer::queuedSeekPosition() const {
@@ -1445,7 +1445,7 @@ mixxx::audio::FramePos EngineBuffer::queuedSeekPosition() const {
     return queuedSeek.position;
 }
 
-void EngineBuffer::updateIndicators(double speed, int iBufferSize) {
+void EngineBuffer::updateIndicators(double speed, std::size_t bufferSize) {
     if (!m_playPos.isValid() ||
             !m_trackSampleRateOld.isValid() ||
             m_pPassthroughEnabled->toBool()) {
@@ -1459,7 +1459,7 @@ void EngineBuffer::updateIndicators(double speed, int iBufferSize) {
     }
 
     // Increase samplesCalculated by the buffer size
-    m_iSamplesSinceLastIndicatorUpdate += iBufferSize;
+    m_samplesSinceLastIndicatorUpdate += bufferSize;
 
     const double fFractionalPlaypos = fractionalPlayposFromAbsolute(m_playPos);
     const double fFractionalSlipPos = fractionalPlayposFromAbsolute(m_slipPos);
@@ -1490,7 +1490,7 @@ void EngineBuffer::updateIndicators(double speed, int iBufferSize) {
 
     // Update indicators that are only updated after every
     // sampleRate/kiUpdateRate samples processed.  (e.g. playposSlider)
-    if (m_iSamplesSinceLastIndicatorUpdate >
+    if (m_samplesSinceLastIndicatorUpdate >
             (mixxx::kEngineChannelOutputCount * m_pSampleRate->get() /
                     kPlaypositionUpdateRate)) {
         m_playposSlider->set(fFractionalPlaypos);
@@ -1502,7 +1502,7 @@ void EngineBuffer::updateIndicators(double speed, int iBufferSize) {
     m_visualPlayPos->set(
             fFractionalPlaypos,
             speed * m_baserate_old,
-            static_cast<int>(iBufferSize) /
+            static_cast<int>(bufferSize) /
                     m_trackEndPositionOld.toEngineSamplePos(),
             fFractionalSlipPos,
             effectiveSlipRate,
@@ -1513,7 +1513,7 @@ void EngineBuffer::updateIndicators(double speed, int iBufferSize) {
             fFractionalLoopStartPos,
             fFractionalLoopEndPos,
             tempoTrackSeconds,
-            iBufferSize / mixxx::kEngineChannelOutputCount / m_sampleRate.toDouble() * 1000000.0);
+            bufferSize / mixxx::kEngineChannelOutputCount / m_sampleRate.toDouble() * 1000000.0);
 
     // TODO: Especially with long audio buffers, jitter is visible. This can be fixed by moving the
     // ClockControl::updateIndicators into the waveform update loop which is synced with the display refresh rate.

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -136,10 +136,10 @@ class EngineBuffer : public EngineObject {
     void requestSyncMode(SyncMode mode);
 
     // The process methods all run in the audio callback.
-    void process(CSAMPLE* pOut, const int iBufferSize) override;
-    void processSlip(int iBufferSize);
+    void process(CSAMPLE* pOut, const std::size_t bufferSize) override;
+    void processSlip(std::size_t bufferSize);
     void postProcessLocalBpm();
-    void postProcess(const int iBufferSize);
+    void postProcess(const std::size_t bufferSize);
 
     /// Returns the seek position iff a seek is currently queued but not yet
     /// processed. If no seek was queued, and invalid frame position is returned.
@@ -262,9 +262,9 @@ class EngineBuffer : public EngineObject {
     void addControl(EngineControl* pControl);
 
     void enableIndependentPitchTempoScaling(bool bEnable,
-                                            const int iBufferSize);
+            const std::size_t bufferSize);
 
-    void updateIndicators(double rate, int iBufferSize);
+    void updateIndicators(double rate, std::size_t bufferSize);
 
     void hintReader(const double rate);
 
@@ -276,7 +276,7 @@ class EngineBuffer : public EngineObject {
     // Read one buffer from the current scaler into the crossfade buffer.  Used
     // for transitioning from one scaler to another, or reseeking a scaler
     // to prevent pops.
-    void readToCrossfadeBuffer(const int iBufferSize);
+    void readToCrossfadeBuffer(const std::size_t bufferSize);
 
     // Reset buffer playpos and set file playpos.
     void setNewPlaypos(mixxx::audio::FramePos playpos);
@@ -292,7 +292,7 @@ class EngineBuffer : public EngineObject {
     void verifyPlay();
     void notifyTrackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack);
     void processTrackLocked(CSAMPLE* pOutput,
-            const int iBufferSize,
+            const std::size_t bufferSize,
             mixxx::audio::SampleRate sampleRate);
 
     // Holds the name of the control group
@@ -379,7 +379,7 @@ class EngineBuffer : public EngineObject {
     // during seek and loading of a new track
     QMutex m_pause;
     // Used in update of playpos slider
-    int m_iSamplesSinceLastIndicatorUpdate;
+    std::size_t m_samplesSinceLastIndicatorUpdate;
 
     // The location where the track would have been had slip not been engaged
     mixxx::audio::FramePos m_slipPos;
@@ -481,7 +481,7 @@ class EngineBuffer : public EngineObject {
     // to eliminate clicks and pops.
     CSAMPLE* m_pCrossfadeBuffer;
     bool m_bCrossfadeReady;
-    int m_iLastBufferSize;
+    std::size_t m_lastBufferSize;
 
     QSharedPointer<VisualPlayPosition> m_visualPlayPos;
 };

--- a/src/engine/enginedelay.cpp
+++ b/src/engine/enginedelay.cpp
@@ -50,7 +50,7 @@ void EngineDelay::slotDelayChanged() {
     }
 }
 
-void EngineDelay::process(CSAMPLE* pInputOutput, const int iBufferSize) {
+void EngineDelay::process(CSAMPLE* pInputOutput, const std::size_t bufferSize) {
     if (m_iDelay > 0) {
         // The "+ kiMaxDelay" addition ensures positive values for the modulo calculation.
         // From a mathematical point of view, this addition can be removed. Anyway,
@@ -66,7 +66,7 @@ void EngineDelay::process(CSAMPLE* pInputOutput, const int iBufferSize) {
             return;
         }
 
-        for (int i = 0; i < iBufferSize; ++i) {
+        for (std::size_t i = 0; i < bufferSize; ++i) {
             // put sample into delay buffer:
             m_delayBuffer[m_iDelayPos] = pInputOutput[i];
             m_iDelayPos = (m_iDelayPos + 1) % kiMaxDelay;

--- a/src/engine/enginedelay.h
+++ b/src/engine/enginedelay.h
@@ -13,7 +13,7 @@ class EngineDelay : public EngineObject {
     EngineDelay(const ConfigKey& delayControl, bool bPersist = true);
     ~EngineDelay() override;
 
-    void process(CSAMPLE* pInOut, const int iBufferSize) override;
+    void process(CSAMPLE* pInOut, const std::size_t bufferSize) override;
 
     void setDelay(double newDelay);
 

--- a/src/engine/enginemixer.cpp
+++ b/src/engine/enginemixer.cpp
@@ -229,9 +229,9 @@ std::span<const CSAMPLE> EngineMixer::getSidechainBuffer() const {
     return m_sidechainMix.span();
 }
 
-void EngineMixer::processChannels(int iBufferSize) {
+void EngineMixer::processChannels(std::size_t bufferSize) {
     // Update internal sync lock rate.
-    m_pEngineSync->onCallbackStart(m_sampleRate, iBufferSize);
+    m_pEngineSync->onCallbackStart(m_sampleRate, bufferSize);
 
     m_activeBusChannels[EngineChannel::LEFT].clear();
     m_activeBusChannels[EngineChannel::CENTER].clear();
@@ -321,8 +321,8 @@ void EngineMixer::processChannels(int iBufferSize) {
     for (int i = activeChannelsStartIndex; i < m_activeChannels.size(); ++i) {
         ChannelInfo* pChannelInfo = m_activeChannels[i];
         auto& pChannel = pChannelInfo->m_pChannel;
-        DEBUG_ASSERT(pChannelInfo->m_pBuffer.size() >= iBufferSize);
-        pChannel->process(pChannelInfo->m_pBuffer.data(), iBufferSize);
+        DEBUG_ASSERT(pChannelInfo->m_pBuffer.size() >= static_cast<SINT>(bufferSize));
+        pChannel->process(pChannelInfo->m_pBuffer.data(), bufferSize);
 
         // Collect metadata for effects
         if (m_pEngineEffectsManager) {
@@ -336,7 +336,7 @@ void EngineMixer::processChannels(int iBufferSize) {
     // Note, because we call this on the internal clock first,
     // it will have an up-to-date beatDistance, whereas the other
     // Syncables will not.
-    m_pEngineSync->onCallbackEnd(m_sampleRate, iBufferSize);
+    m_pEngineSync->onCallbackEnd(m_sampleRate, bufferSize);
 
     // After all engines have been processed, trigger updates of local bpm values
     // which may have changed based on track position
@@ -352,13 +352,13 @@ void EngineMixer::processChannels(int iBufferSize) {
     // if the sync target was processed before or after the sync origin.
     std::for_each(m_activeChannels.cbegin() + activeChannelsStartIndex,
             m_activeChannels.cend(),
-            [iBufferSize](const auto& pChannelInfo) {
-                pChannelInfo->m_pChannel->postProcess(iBufferSize);
+            [bufferSize](const auto& pChannelInfo) {
+                pChannelInfo->m_pChannel->postProcess(bufferSize);
             });
 }
 
-void EngineMixer::process(const int iBufferSize) {
-    DEBUG_ASSERT(iBufferSize <= static_cast<int>(kMaxEngineSamples));
+void EngineMixer::process(const std::size_t bufferSize) {
+    DEBUG_ASSERT(bufferSize <= static_cast<int>(kMaxEngineSamples));
 
     static bool haveSetName = false;
     if (!haveSetName) {
@@ -374,14 +374,14 @@ void EngineMixer::process(const int iBufferSize) {
     m_sampleRate = mixxx::audio::SampleRate::fromDouble(m_pSampleRate->get());
     // TODO: remove assumption of stereo buffer
     constexpr unsigned int kChannels = 2;
-    const unsigned int iFrames = iBufferSize / kChannels;
+    const unsigned int iFrames = static_cast<unsigned int>(bufferSize) / kChannels;
 
     if (m_pEngineEffectsManager) {
         m_pEngineEffectsManager->onCallbackStart();
     }
 
     // Prepare all channels for output
-    processChannels(iBufferSize);
+    processChannels(bufferSize);
 
     // Compute headphone mix
     // Head phone left/right mix
@@ -408,7 +408,7 @@ void EngineMixer::process(const int iBufferSize) {
                 &m_channelHeadphoneGainCache,
                 m_head.data(),
                 m_headphoneHandle.handle(),
-                iBufferSize,
+                bufferSize,
                 m_sampleRate,
                 m_pEngineEffectsManager);
 
@@ -428,7 +428,7 @@ void EngineMixer::process(const int iBufferSize) {
                     m_headphoneHandle.handle(),
                     m_headphoneHandle.handle(),
                     m_head.data(),
-                    iBufferSize,
+                    bufferSize,
                     m_sampleRate,
                     headphoneFeatures);
         }
@@ -442,7 +442,7 @@ void EngineMixer::process(const int iBufferSize) {
             &m_channelTalkoverGainCache,
             m_talkover.data(),
             m_mainHandle.handle(),
-            iBufferSize,
+            bufferSize,
             m_sampleRate,
             m_pEngineEffectsManager);
 
@@ -454,7 +454,7 @@ void EngineMixer::process(const int iBufferSize) {
                 m_busTalkoverHandle.handle(),
                 m_mainHandle.handle(),
                 m_talkover.data(),
-                iBufferSize,
+                bufferSize,
                 m_sampleRate,
                 busFeatures,
                 CSAMPLE_GAIN_ONE,
@@ -467,7 +467,7 @@ void EngineMixer::process(const int iBufferSize) {
         m_pTalkoverDucking->setAboveThreshold(false);
         break;
     case EngineTalkoverDucking::AUTO:
-        m_pTalkoverDucking->processKey(m_talkover.data(), iBufferSize);
+        m_pTalkoverDucking->processKey(m_talkover.data(), bufferSize);
         break;
     case EngineTalkoverDucking::MANUAL:
         m_pTalkoverDucking->setAboveThreshold(!m_activeTalkoverChannels.isEmpty());
@@ -502,7 +502,7 @@ void EngineMixer::process(const int iBufferSize) {
                                          // follows an orientation switch
                 m_outputBusBuffers[o].data(),
                 m_mainHandle.handle(),
-                iBufferSize,
+                bufferSize,
                 m_sampleRate,
                 m_pEngineEffectsManager);
     }
@@ -513,7 +513,7 @@ void EngineMixer::process(const int iBufferSize) {
                 m_busCrossfaderLeftHandle.handle(),
                 m_mainHandle.handle(),
                 m_outputBusBuffers[EngineChannel::LEFT].data(),
-                iBufferSize,
+                bufferSize,
                 m_sampleRate,
                 busFeatures,
                 CSAMPLE_GAIN_ONE,
@@ -523,7 +523,7 @@ void EngineMixer::process(const int iBufferSize) {
                 m_busCrossfaderCenterHandle.handle(),
                 m_mainHandle.handle(),
                 m_outputBusBuffers[EngineChannel::CENTER].data(),
-                iBufferSize,
+                bufferSize,
                 m_sampleRate,
                 busFeatures,
                 CSAMPLE_GAIN_ONE,
@@ -533,7 +533,7 @@ void EngineMixer::process(const int iBufferSize) {
                 m_busCrossfaderRightHandle.handle(),
                 m_mainHandle.handle(),
                 m_outputBusBuffers[EngineChannel::RIGHT].data(),
-                iBufferSize,
+                bufferSize,
                 m_sampleRate,
                 busFeatures,
                 CSAMPLE_GAIN_ONE,
@@ -550,7 +550,7 @@ void EngineMixer::process(const int iBufferSize) {
                 1.0,
                 m_outputBusBuffers[EngineChannel::RIGHT].data(),
                 1.0,
-                iBufferSize);
+                static_cast<int>(bufferSize));
 
         MicMonitorMode configuredMicMonitorMode = static_cast<MicMonitorMode>(
             static_cast<int>(m_pMicMonitorMode->get()));
@@ -564,10 +564,10 @@ void EngineMixer::process(const int iBufferSize) {
             // to both the main and booth in that case will require refactoring
             // the effects system to be able to process the same effects on multiple
             // buffers within the same callback.
-            applyMainEffects(iBufferSize);
+            applyMainEffects(bufferSize);
 
             if (headphoneEnabled) {
-                processHeadphones(mainMixGainInHeadphones, iBufferSize);
+                processHeadphones(mainMixGainInHeadphones, bufferSize);
             }
 
             // Copy main mix to booth output with booth gain before mixing
@@ -579,23 +579,23 @@ void EngineMixer::process(const int iBufferSize) {
                         m_main.data(),
                         m_boothGainOld,
                         boothGain,
-                        iBufferSize);
+                        bufferSize);
                 m_boothGainOld = boothGain;
             }
 
             // Mix talkover into main mix
             if (m_numMicsConfigured > 0) {
-                SampleUtil::add(m_main.data(), m_talkover.data(), iBufferSize);
+                SampleUtil::add(m_main.data(), m_talkover.data(), bufferSize);
             }
 
             // Apply main gain
             CSAMPLE_GAIN mainGain = static_cast<CSAMPLE_GAIN>(m_pMainGain->get());
-            SampleUtil::applyRampingGain(m_main.data(), m_mainGainOld, mainGain, iBufferSize);
+            SampleUtil::applyRampingGain(m_main.data(), m_mainGainOld, mainGain, bufferSize);
             m_mainGainOld = mainGain;
 
             // Record/broadcast signal is the same as the main output
             if (sidechainMixRequired()) {
-                m_sidechainMix.copy(m_main, iBufferSize);
+                m_sidechainMix.copy(m_main, bufferSize);
             }
         } else if (configuredMicMonitorMode == MicMonitorMode::MainAndBooth) {
             // Process main channel effects
@@ -604,15 +604,15 @@ void EngineMixer::process(const int iBufferSize) {
             // to be able to process the same effects on different buffers
             // within the same callback. For consistency between the MicMonitorModes,
             // process main effects here before mixing in talkover.
-            applyMainEffects(iBufferSize);
+            applyMainEffects(bufferSize);
 
             if (headphoneEnabled) {
-                processHeadphones(mainMixGainInHeadphones, iBufferSize);
+                processHeadphones(mainMixGainInHeadphones, bufferSize);
             }
 
             // Mix talkover with main
             if (m_numMicsConfigured > 0) {
-                SampleUtil::add(m_main.data(), m_talkover.data(), iBufferSize);
+                SampleUtil::add(m_main.data(), m_talkover.data(), bufferSize);
             }
 
             // Copy main mix (with talkover mixed in) to booth output with booth gain
@@ -623,7 +623,7 @@ void EngineMixer::process(const int iBufferSize) {
                         m_main.data(),
                         m_boothGainOld,
                         boothGain,
-                        iBufferSize);
+                        bufferSize);
                 m_boothGainOld = boothGain;
             }
 
@@ -633,12 +633,12 @@ void EngineMixer::process(const int iBufferSize) {
                     m_main.data(),
                     m_mainGainOld,
                     mainGain,
-                    iBufferSize);
+                    bufferSize);
             m_mainGainOld = mainGain;
 
             // Record/broadcast signal is the same as the main output
             if (sidechainMixRequired()) {
-                m_sidechainMix.copy(m_main, iBufferSize);
+                m_sidechainMix.copy(m_main, bufferSize);
             }
         } else if (configuredMicMonitorMode == MicMonitorMode::DirectMonitor) {
             // Skip mixing talkover with the main and booth outputs
@@ -654,7 +654,7 @@ void EngineMixer::process(const int iBufferSize) {
                         m_main.data(),
                         m_boothGainOld,
                         boothGain,
-                        iBufferSize);
+                        bufferSize);
                 m_boothGainOld = boothGain;
             }
 
@@ -662,10 +662,10 @@ void EngineMixer::process(const int iBufferSize) {
             // NOTE(Be): This should occur before mixing in talkover for the
             // record/broadcast signal so the record/broadcast signal is the same
             // as what is heard on the main & booth outputs.
-            applyMainEffects(iBufferSize);
+            applyMainEffects(bufferSize);
 
             if (headphoneEnabled) {
-                processHeadphones(mainMixGainInHeadphones, iBufferSize);
+                processHeadphones(mainMixGainInHeadphones, bufferSize);
             }
 
             // Apply main gain
@@ -674,10 +674,10 @@ void EngineMixer::process(const int iBufferSize) {
                     m_main.data(),
                     m_mainGainOld,
                     mainGain,
-                    iBufferSize);
+                    bufferSize);
             m_mainGainOld = mainGain;
             if (sidechainMixRequired()) {
-                m_sidechainMix.copy(m_main, iBufferSize);
+                m_sidechainMix.copy(m_main, bufferSize);
 
                 if (m_numMicsConfigured > 0) {
                     // The talkover signal Mixxx receives is delayed by the round trip latency.
@@ -698,8 +698,8 @@ void EngineMixer::process(const int iBufferSize) {
 
                     // Copy the main mix to a separate buffer before delaying it
                     // to avoid delaying the main output.
-                    m_pLatencyCompensationDelay->process(m_sidechainMix.data(), iBufferSize);
-                    SampleUtil::add(m_sidechainMix.data(), m_talkover.data(), iBufferSize);
+                    m_pLatencyCompensationDelay->process(m_sidechainMix.data(), bufferSize);
+                    SampleUtil::add(m_sidechainMix.data(), m_talkover.data(), bufferSize);
                 }
             }
         }
@@ -724,7 +724,7 @@ void EngineMixer::process(const int iBufferSize) {
                     m_mainOutputHandle.handle(),
                     m_mainHandle.handle(),
                     m_main.data(),
-                    iBufferSize,
+                    bufferSize,
                     m_sampleRate,
                     mainFeatures);
         }
@@ -745,7 +745,7 @@ void EngineMixer::process(const int iBufferSize) {
                 balright,
                 m_balleftOld,
                 m_balrightOld,
-                iBufferSize);
+                bufferSize);
 
         m_balleftOld = balleft;
         m_balrightOld = balright;
@@ -753,24 +753,24 @@ void EngineMixer::process(const int iBufferSize) {
         // Update VU meter (it does not return anything). Needs to be here so that
         // main balance and talkover is reflected in the VU meter.
         if (m_pVumeter != nullptr) {
-            m_pVumeter->process(m_main.data(), iBufferSize);
+            m_pVumeter->process(m_main.data(), bufferSize);
         }
     }
 
     if (m_pMainMonoMixdown->toBool()) {
-        SampleUtil::mixStereoToMono(m_main.data(), iBufferSize);
+        SampleUtil::mixStereoToMono(m_main.data(), bufferSize);
     }
 
     if (mainEnabled) {
-        m_pMainDelay->process(m_main.data(), iBufferSize);
+        m_pMainDelay->process(m_main.data(), bufferSize);
     } else {
-        m_main.clear(iBufferSize);
+        m_main.clear(bufferSize);
     }
     if (headphoneEnabled) {
-        m_pHeadDelay->process(m_head.data(), iBufferSize);
+        m_pHeadDelay->process(m_head.data(), bufferSize);
     }
     if (boothEnabled) {
-        m_pBoothDelay->process(m_booth.data(), iBufferSize);
+        m_pBoothDelay->process(m_booth.data(), bufferSize);
     }
 
     // We're close to the end of the callback. Wake up the engine worker
@@ -778,7 +778,7 @@ void EngineMixer::process(const int iBufferSize) {
     m_pWorkerScheduler->runWorkers();
 }
 
-void EngineMixer::applyMainEffects(int bufferSize) {
+void EngineMixer::applyMainEffects(std::size_t bufferSize) {
     // Apply main effects
     if (m_pEngineEffectsManager) {
         GroupFeatureState mainFeatures;
@@ -797,14 +797,14 @@ void EngineMixer::applyMainEffects(int bufferSize) {
 
 void EngineMixer::processHeadphones(
         const CSAMPLE_GAIN mainMixGainInHeadphones,
-        int iBufferSize) {
+        std::size_t bufferSize) {
     // Add main mix to headphones
     SampleUtil::addWithRampingGain(
             m_head.data(),
             m_main.data(),
             m_headphoneMainGainOld,
             mainMixGainInHeadphones,
-            iBufferSize);
+            bufferSize);
     m_headphoneMainGainOld = mainMixGainInHeadphones;
 
     // If Head Split is enabled, replace the left channel of the pfl buffer
@@ -815,7 +815,7 @@ void EngineMixer::processHeadphones(
         // with all compilers, except clang >= 14.
         auto* const ph = m_head.data();
         auto* const pm = m_main.data();
-        for (SINT i = 0; i + 1 < iBufferSize; i += 2) {
+        for (std::size_t i = 0; i + 1 < bufferSize; i += 2) {
             ph[i] = (ph[i] + ph[i + 1]) / 2;
             ph[i + 1] = (pm[i] + pm[i + 1]) / 2;
         }
@@ -827,7 +827,7 @@ void EngineMixer::processHeadphones(
             m_head.data(),
             m_headphoneGainOld,
             headphoneGain,
-            iBufferSize);
+            bufferSize);
     m_headphoneGainOld = headphoneGain;
 }
 

--- a/src/engine/enginemixer.h
+++ b/src/engine/enginemixer.h
@@ -68,7 +68,7 @@ class EngineMixer : public QObject, public AudioSource {
     void onInputConnected(const AudioInput& input);
     void onInputDisconnected(const AudioInput& input);
 
-    void process(const int iBufferSize);
+    void process(const std::size_t bufferSize);
 
     // Add an EngineChannel to the mixing engine. This is not thread safe --
     // only call it before the engine has started mixing.
@@ -257,13 +257,13 @@ class EngineMixer : public QObject, public AudioSource {
     // m_activeBusChannels, m_activeHeadphoneChannels, and
     // m_activeTalkoverChannels with each channel that is active for the
     // respective output.
-    void processChannels(int iBufferSize);
+    void processChannels(std::size_t bufferSize);
 
     ChannelHandleFactoryPointer m_pChannelHandleFactory;
-    void applyMainEffects(int bufferSize);
+    void applyMainEffects(std::size_t bufferSize);
     void processHeadphones(
             const CSAMPLE_GAIN mainMixGainInHeadphones,
-            int iBufferSize);
+            std::size_t bufferSize);
     bool sidechainMixRequired() const;
 
     // non-owning. lifetime bound to EffectsManager

--- a/src/engine/engineobject.h
+++ b/src/engine/engineobject.h
@@ -12,7 +12,7 @@ class EngineObject : public QObject {
     EngineObject();
     ~EngineObject() override;
     virtual void process(CSAMPLE* pInOut,
-                         const int iBufferSize) = 0;
+            const std::size_t bufferSize) = 0;
 
     // Sub-classes re-implement and populate GroupFeatureState with the features
     // they extract.
@@ -27,6 +27,5 @@ class EngineObjectConstIn : public QObject {
     EngineObjectConstIn();
     ~EngineObjectConstIn() override;
 
-    virtual void process(const CSAMPLE* pIn, CSAMPLE* pOut,
-                         const int iBufferSize) = 0;
+    virtual void process(const CSAMPLE* pIn, CSAMPLE* pOut, const std::size_t bufferSize) = 0;
 };

--- a/src/engine/enginepregain.cpp
+++ b/src/engine/enginepregain.cpp
@@ -64,7 +64,7 @@ void EnginePregain::setSpeedAndScratching(double speed, bool scratching) {
     m_scratching = scratching;
 }
 
-void EnginePregain::process(CSAMPLE* pInOut, const int iBufferSize) {
+void EnginePregain::process(CSAMPLE* pInOut, const std::size_t bufferSize) {
     const auto fReplayGain = static_cast<CSAMPLE_GAIN>(m_pCOReplayGain->get());
     CSAMPLE_GAIN fReplayGainCorrection;
     if (!s_pEnableReplayGain->toBool() || m_pPassthroughEnabled->toBool()) {
@@ -148,16 +148,16 @@ void EnginePregain::process(CSAMPLE* pInOut, const int iBufferSize) {
 
     if ((m_dSpeed * m_dOldSpeed < 0) && m_scratching) {
         // direction changed, go though zero if scratching
-        SampleUtil::applyRampingGain(&pInOut[0], m_fPrevGain, 0, iBufferSize / 2);
-        SampleUtil::applyRampingGain(&pInOut[iBufferSize / 2], 0, totalGain, iBufferSize / 2);
+        SampleUtil::applyRampingGain(&pInOut[0], m_fPrevGain, 0, bufferSize / 2);
+        SampleUtil::applyRampingGain(&pInOut[bufferSize / 2], 0, totalGain, bufferSize / 2);
     } else if (totalGain != m_fPrevGain) {
         // Prevent sound wave discontinuities by interpolating from old to new gain
         // if not stopped or starting
         // This handles also the ramping of play (from speed 0) and pause (to speed 0)
-        SampleUtil::applyRampingGain(pInOut, m_fPrevGain, totalGain, iBufferSize);
+        SampleUtil::applyRampingGain(pInOut, m_fPrevGain, totalGain, bufferSize);
     } else {
         // SampleUtil deals with aliased buffers and gains of 1 or 0.
-        SampleUtil::applyGain(pInOut, totalGain, iBufferSize);
+        SampleUtil::applyGain(pInOut, totalGain, bufferSize);
     }
     m_fPrevGain = totalGain;
 }

--- a/src/engine/enginepregain.h
+++ b/src/engine/enginepregain.h
@@ -23,7 +23,7 @@ class EnginePregain : public EngineObject {
     // reversed without a ramp to zero.
     void setSpeedAndScratching(double speed, bool scratching);
 
-    void process(CSAMPLE* pInOut, const int iBufferSize) override;
+    void process(CSAMPLE* pInOut, const std::size_t bufferSize) override;
 
     void collectFeatures(GroupFeatureState* pGroupFeatures) const override;
 

--- a/src/engine/enginesidechaincompressor.cpp
+++ b/src/engine/enginesidechaincompressor.cpp
@@ -42,9 +42,9 @@ void EngineSideChainCompressor::setAboveThreshold(bool value) {
     m_bAboveThreshold = value;
 }
 
-void EngineSideChainCompressor::processKey(const CSAMPLE* pIn, const int iBufferSize) {
+void EngineSideChainCompressor::processKey(const CSAMPLE* pIn, const std::size_t bufferSize) {
     m_bAboveThreshold = false;
-    for (int i = 0; i + 1 < iBufferSize; i += 2) {
+    for (std::size_t i = 0; i + 1 < bufferSize; i += 2) {
         CSAMPLE val = (pIn[i] + pIn[i + 1]) / 2;
         if (val > m_threshold) {
             m_bAboveThreshold = true;

--- a/src/engine/enginesidechaincompressor.h
+++ b/src/engine/enginesidechaincompressor.h
@@ -48,7 +48,7 @@ class EngineSideChainCompressor {
     // multiple times for multiple keys, however they will not be summed together
     // so compression will not be triggered unless at least one buffer would
     // have triggered alone.
-    void processKey(const CSAMPLE* pIn, const int iBufferSize);
+    void processKey(const CSAMPLE* pIn, const std::size_t bufferSize);
 
     // Calculates a new gain value based on the current compression ratio
     // over the given number of frames and whether the current input is above threshold.

--- a/src/engine/enginevumeter.cpp
+++ b/src/engine/enginevumeter.cpp
@@ -36,17 +36,19 @@ EngineVuMeter::EngineVuMeter(const QString& group, const QString& legacyGroup)
             reset();
 }
 
-void EngineVuMeter::process(CSAMPLE* pIn, const int iBufferSize) {
+void EngineVuMeter::process(CSAMPLE* pIn, const std::size_t bufferSize) {
     CSAMPLE fVolSumL, fVolSumR;
 
     const auto sampleRate = mixxx::audio::SampleRate::fromDouble(m_sampleRate.get());
 
     SampleUtil::CLIP_STATUS clipped = SampleUtil::sumAbsPerChannel(&fVolSumL,
-            &fVolSumR, pIn, iBufferSize);
+            &fVolSumR,
+            pIn,
+            bufferSize);
     m_fRMSvolumeSumL += fVolSumL;
     m_fRMSvolumeSumR += fVolSumR;
 
-    m_samplesCalculated += static_cast<unsigned int>(iBufferSize / 2);
+    m_samplesCalculated += static_cast<unsigned int>(bufferSize / 2);
 
     // Are we ready to update the VU meter?:
     if (m_samplesCalculated > (sampleRate / kVuUpdateRate)) {
@@ -81,7 +83,7 @@ void EngineVuMeter::process(CSAMPLE* pIn, const int iBufferSize) {
 
     if (clipped & SampleUtil::CLIPPING_LEFT) {
         m_peakIndicatorLeft.set(1.0);
-        m_peakDurationL = kPeakDuration * sampleRate / iBufferSize / 2000;
+        m_peakDurationL = static_cast<int>(kPeakDuration * sampleRate / bufferSize / 2000);
     } else if (m_peakDurationL <= 0) {
         m_peakIndicatorLeft.set(0.0);
     } else {
@@ -90,7 +92,7 @@ void EngineVuMeter::process(CSAMPLE* pIn, const int iBufferSize) {
 
     if (clipped & SampleUtil::CLIPPING_RIGHT) {
         m_peakIndicatorRight.set(1.0);
-        m_peakDurationR = kPeakDuration * sampleRate / iBufferSize / 2000;
+        m_peakDurationR = static_cast<int>(kPeakDuration * sampleRate / bufferSize / 2000);
     } else if (m_peakDurationR <= 0) {
         m_peakIndicatorRight.set(0.0);
     } else {

--- a/src/engine/enginevumeter.h
+++ b/src/engine/enginevumeter.h
@@ -9,7 +9,7 @@ class EngineVuMeter : public EngineObject {
   public:
     EngineVuMeter(const QString& group, const QString& legacyGroup = QString());
 
-    virtual void process(CSAMPLE* pInOut, const int iBufferSize);
+    virtual void process(CSAMPLE* pInOut, const std::size_t bufferSize);
 
     void reset();
 

--- a/src/engine/filters/enginefilterdelay.h
+++ b/src/engine/filters/enginefilterdelay.h
@@ -45,8 +45,7 @@ class EngineFilterDelay : public EngineObjectConstIn {
         m_delaySamples = delaySamples;
     }
 
-    virtual void process(const CSAMPLE* pIn, CSAMPLE* pOutput,
-                         const int iBufferSize) {
+    virtual void process(const CSAMPLE* pIn, CSAMPLE* pOutput, const std::size_t bufferSize) {
         if (m_oldDelaySamples == m_delaySamples) {
             // The "+ SIZE" addition ensures positive values for the modulo calculation.
             // From a mathematical point of view, this addition can be removed. Anyway,
@@ -55,7 +54,7 @@ class EngineFilterDelay : public EngineObjectConstIn {
             // (but in math the result value is positive).
             int delaySourcePos = (m_delayPos + SIZE - m_delaySamples) % SIZE;
 
-            for (int i = 0; i < iBufferSize; ++i) {
+            for (std::size_t i = 0; i < bufferSize; ++i) {
                 // put sample into delay buffer:
                 m_buf[m_delayPos] = pIn[i];
                 m_delayPos = (m_delayPos + 1) % SIZE;
@@ -70,19 +69,19 @@ class EngineFilterDelay : public EngineObjectConstIn {
             // from the cpp point of view, the modulo operator for negative values
             // (for example, x % y, where x is a negative value) produces negative results
             // (but in math the result value is positive).
-            int delaySourcePos = (m_delayPos + SIZE - m_delaySamples + iBufferSize / 2) % SIZE;
+            int delaySourcePos = (m_delayPos + SIZE - m_delaySamples + bufferSize / 2) % SIZE;
             int oldDelaySourcePos = (m_delayPos + SIZE - m_oldDelaySamples) % SIZE;
 
             double cross_mix = 0.0;
-            double cross_inc = 2 / static_cast<double>(iBufferSize);
+            double cross_inc = 2 / static_cast<double>(bufferSize);
 
-            for (int i = 0; i < iBufferSize; ++i) {
+            for (std::size_t i = 0; i < bufferSize; ++i) {
                 // put sample into delay buffer:
                 m_buf[m_delayPos] = pIn[i];
                 m_delayPos = (m_delayPos + 1) % SIZE;
 
                 // Take delayed sample from delay buffer and copy it to dest buffer:
-                if (i < iBufferSize / 2) {
+                if (i < bufferSize / 2) {
                     // only ramp the second half of the buffer, because we do
                     // the same in the IIR filter to wait for settling
                     pOutput[i] = m_buf[oldDelaySourcePos];
@@ -99,15 +98,13 @@ class EngineFilterDelay : public EngineObjectConstIn {
         m_doStart = false;
     }
 
-
     // this is can be used instead off a final process() call before pause
     // It fades to dry or 0 according to the m_startFromDry parameter
     // it is an alternative for using pauseFillter() calls
-    void processAndPauseFilter(const CSAMPLE* pIn, CSAMPLE* pOutput,
-                       const int iBufferSize) {
+    void processAndPauseFilter(const CSAMPLE* pIn, CSAMPLE* pOutput, const std::size_t bufferSize) {
         int oldDelay = m_delaySamples;
         m_delaySamples = 0;
-        process(pIn, pOutput, iBufferSize);
+        process(pIn, pOutput, bufferSize);
         m_delaySamples = oldDelay;
         pauseFilter();
     }

--- a/src/engine/filters/enginefilteriir.h
+++ b/src/engine/filters/enginefilteriir.h
@@ -67,18 +67,18 @@ class EngineFilterIIR : public EngineFilterIIRBase {
     void processAndPauseFilter(
             const CSAMPLE* pIn,
             CSAMPLE* pOutput,
-            int iBufferSize) {
-        process(pIn, pOutput, iBufferSize);
+            std::size_t bufferSize) {
+        process(pIn, pOutput, bufferSize);
         if (m_startFromDry) {
             SampleUtil::linearCrossfadeBuffersOut(
                     pOutput, // fade out filtered
                     pIn,     // fade in dry
-                    iBufferSize,
+                    bufferSize,
                     mixxx::kEngineChannelOutputCount);
         } else {
             SampleUtil::applyRampingGain(
                     pOutput, 1.0, 0, // fade out filtered
-                    iBufferSize);
+                    bufferSize);
         }
         pauseFilterInner();
     }
@@ -94,7 +94,7 @@ class EngineFilterIIR : public EngineFilterIIRBase {
     }
 
     void setCoefs(const char* spec,
-            size_t bufsize,
+            std::size_t bufsize,
             double sampleRate,
             double freq0,
             double freq1 = 0,
@@ -232,24 +232,23 @@ class EngineFilterIIR : public EngineFilterIIRBase {
         m_doStart = false;
     }
 
-    virtual void process(const CSAMPLE* pIn, CSAMPLE* pOutput,
-                         const int iBufferSize) {
+    virtual void process(const CSAMPLE* pIn, CSAMPLE* pOutput, const std::size_t bufferSize) {
         if (!m_doRamping) {
-            for (int i = 0; i < iBufferSize; i += 2) {
+            for (std::size_t i = 0; i < bufferSize; i += 2) {
                 pOutput[i] = static_cast<CSAMPLE>(processSample(m_coef, m_buf1, pIn[i]));
                 pOutput[i + 1] = static_cast<CSAMPLE>(processSample(m_coef, m_buf2, pIn[i + 1]));
             }
         } else {
             double cross_mix = 0.0;
-            double cross_inc = 4.0 / static_cast<double>(iBufferSize);
-            for (int i = 0; i < iBufferSize; i += 2) {
+            double cross_inc = 4.0 / static_cast<double>(bufferSize);
+            for (std::size_t i = 0; i < bufferSize; i += 2) {
                 // Do a linear cross fade between the output of the old
                 // Filter and the new filter.
                 // The new filter is settled for Input = 0 and it sees
                 // all frequencies of the rectangular start impulse.
                 // Since the group delay, after which the start impulse
                 // has passed is unknown here, we just what the half
-                // iBufferSize until we use the samples of the new filter.
+                // bufferSize until we use the samples of the new filter.
                 // In one of the previous version we have faded the Input
                 // of the new filter but it turns out that this produces
                 // a gain drop due to the filter delay which is more
@@ -272,7 +271,7 @@ class EngineFilterIIR : public EngineFilterIIRBase {
                 double new1 = static_cast<CSAMPLE>(processSample(m_coef, m_buf1, pIn[i]));
                 double new2 = static_cast<CSAMPLE>(processSample(m_coef, m_buf2, pIn[i + 1]));
 
-                if (i < iBufferSize / 2) {
+                if (i < bufferSize / 2) {
                     pOutput[i] = static_cast<CSAMPLE>(old1);
                     pOutput[i + 1] = static_cast<CSAMPLE>(old2);
                 } else {

--- a/src/engine/filters/enginefiltermoogladder4.h
+++ b/src/engine/filters/enginefiltermoogladder4.h
@@ -117,20 +117,19 @@ class EngineFilterMoogLadderBase : public EngineObjectConstIn {
     // it is an alternative for using pauseFillter() calls
     void processAndPauseFilter(const CSAMPLE* M_RESTRICT pIn,
             CSAMPLE* M_RESTRICT pOutput,
-            const int iBufferSize) {
-        process(pIn, pOutput, iBufferSize);
+            const std::size_t bufferSize) {
+        process(pIn, pOutput, bufferSize);
         SampleUtil::linearCrossfadeBuffersOut(
                 pOutput, // fade out filtered
                 pIn,     // fade in dry
-                iBufferSize,
+                bufferSize,
                 mixxx::kEngineChannelOutputCount);
         initBuffers();
     }
 
-    virtual void process(const CSAMPLE* pIn, CSAMPLE* pOutput,
-                         const int iBufferSize) {
+    virtual void process(const CSAMPLE* pIn, CSAMPLE* pOutput, const std::size_t bufferSize) {
         if (!m_doRamping) {
-            for (int i = 0; i < iBufferSize; i += 2) {
+            for (std::size_t i = 0; i < bufferSize; i += 2) {
                 pOutput[i] = processSample(pIn[i], &m_buf[0]);
                 pOutput[i+1] = processSample(pIn[i+1], &m_buf[1]);
             }
@@ -139,9 +138,9 @@ class EngineFilterMoogLadderBase : public EngineObjectConstIn {
             float startKacr = m_kacr;
             float startK2vg = m_k2vg;
             double cross_mix = 0.0;
-            double cross_inc = 2.0 / static_cast<double>(iBufferSize);
+            double cross_inc = 2.0 / static_cast<double>(bufferSize);
 
-            for (int i = 0; i < iBufferSize; i += 2) {
+            for (std::size_t i = 0; i < bufferSize; i += 2) {
                 cross_mix += cross_inc;
                 m_postGain = static_cast<float>(m_postGainNew * cross_mix +
                         startPostGain * (1.0 - cross_mix));
@@ -156,15 +155,15 @@ class EngineFilterMoogLadderBase : public EngineObjectConstIn {
             m_kacr = m_kacrNew;
             m_k2vg = m_k2vgNew;
             double cross_mix = 0.0;
-            double cross_inc = 4.0 / static_cast<double>(iBufferSize);
-            for (int i = 0; i < iBufferSize; i += 2) {
+            double cross_inc = 4.0 / static_cast<double>(bufferSize);
+            for (std::size_t i = 0; i < bufferSize; i += 2) {
                 // Do a linear cross fade between the output of the old
                 // Filter and the new filter.
                 // The new filter is settled for Input = 0 and it sees
                 // all frequencies of the rectangular start impulse.
                 // Since the group delay, after which the start impulse
                 // has passed is unknown here, we just what the half
-                // iBufferSize until we use the samples of the new filter.
+                // bufferSize until we use the samples of the new filter.
                 // In one of the previous version we have faded the Input
                 // of the new filter but it turns out that this produces
                 // a gain drop due to the filter delay which is more
@@ -174,7 +173,7 @@ class EngineFilterMoogLadderBase : public EngineObjectConstIn {
                 double new1 = processSample(pIn[i], &m_buf[0]);
                 double new2 = processSample(pIn[i+1], &m_buf[1]);
 
-                if (i < iBufferSize / 2) {
+                if (i < bufferSize / 2) {
                     pOutput[i] = old1;
                     pOutput[i + 1] = old2;
                 } else {

--- a/src/engine/filters/enginefilterpan.h
+++ b/src/engine/filters/enginefilterpan.h
@@ -37,8 +37,7 @@ class EngineFilterPan : public EngineObjectConstIn {
         }
     }
 
-    virtual void process(const CSAMPLE* pIn, CSAMPLE* pOutput,
-                         const int iBufferSize) {
+    virtual void process(const CSAMPLE* pIn, CSAMPLE* pOutput, const std::size_t bufferSize) {
         int delayLeftSourceFrame;
         int delayRightSourceFrame;
         if (m_leftDelayFrames > 0) {
@@ -51,12 +50,12 @@ class EngineFilterPan : public EngineObjectConstIn {
 
         VERIFY_OR_DEBUG_ASSERT(delayLeftSourceFrame >= 0 &&
                                 delayRightSourceFrame >= 0) {
-            SampleUtil::copy(pOutput, pIn, iBufferSize);
+            SampleUtil::copy(pOutput, pIn, bufferSize);
             return;
         }
 
         if (!m_doRamping) {
-            for (int i = 0; i < iBufferSize / 2; ++i) {
+            for (std::size_t i = 0; i < bufferSize / 2; ++i) {
                 // put sample into delay buffer:
                 m_buf[m_delayFrame * 2] = pIn[i * 2];
                 m_buf[m_delayFrame * 2 + 1] = pIn[i * 2 + 1];
@@ -81,14 +80,14 @@ class EngineFilterPan : public EngineObjectConstIn {
 
             VERIFY_OR_DEBUG_ASSERT(delayOldLeftSourceFrame >= 0 &&
                                     delayOldRightSourceFrame >= 0) {
-                SampleUtil::copy(pOutput, pIn, iBufferSize);
+                SampleUtil::copy(pOutput, pIn, bufferSize);
                 return;
             }
 
             double cross_mix = 0.0;
-            double cross_inc = 2 / static_cast<double>(iBufferSize);
+            double cross_inc = 2 / static_cast<double>(bufferSize);
 
-            for (int i = 0; i < iBufferSize / 2; ++i) {
+            for (std::size_t i = 0; i < bufferSize / 2; ++i) {
                 // put sample into delay buffer:
                 m_buf[m_delayFrame * 2] = pIn[i * 2];
                 m_buf[m_delayFrame * 2 + 1] = pIn[i * 2 + 1];

--- a/src/engine/positionscratchcontroller.cpp
+++ b/src/engine/positionscratchcontroller.cpp
@@ -92,7 +92,7 @@ PositionScratchController::~PositionScratchController() {
 
 void PositionScratchController::process(double currentSamplePos,
         double releaseRate,
-        int iBufferSize,
+        std::size_t bufferSize,
         double baseSampleRate,
         int wrappedAround,
         mixxx::audio::FramePos trigger,
@@ -106,7 +106,7 @@ void PositionScratchController::process(double currentSamplePos,
     }
 
     // The latency or time difference between process calls.
-    const double dt = static_cast<double>(iBufferSize) / m_pMainSampleRate->get() / 2;
+    const double dt = static_cast<double>(bufferSize) / m_pMainSampleRate->get() / 2;
 
     // Sample Mouse with fixed timing intervals to iron out significant jitters
     // that are added on the way from mouse to engine thread
@@ -200,7 +200,7 @@ void PositionScratchController::process(double currentSamplePos,
             // Measure the total distance traveled since last frame and add
             // it to the running total. This is required to scratch within loop
             // boundaries. And normalize to one buffer
-            m_samplePosDeltaSum += (sampleDelta) / (iBufferSize * baseSampleRate);
+            m_samplePosDeltaSum += (sampleDelta) / (bufferSize * baseSampleRate);
 
             // Continue with the last rate if we do not have a new
             // Mouse position
@@ -208,7 +208,7 @@ void PositionScratchController::process(double currentSamplePos,
                 // Set the scratch target to the current set position
                 // and normalize to one buffer
                 double scratchTargetDelta = (scratchPosition - m_scratchStartPos) /
-                        (iBufferSize * baseSampleRate);
+                        (bufferSize * baseSampleRate);
 
                 bool calcRate = true;
 

--- a/src/engine/positionscratchcontroller.h
+++ b/src/engine/positionscratchcontroller.h
@@ -17,7 +17,7 @@ class PositionScratchController : public QObject {
 
     void process(double currentSample,
             double releaseRate,
-            int iBufferSize,
+            std::size_t bufferSize,
             double baseSampleRate,
             int wrappedAround,
             mixxx::audio::FramePos trigger,

--- a/src/engine/sidechain/enginerecord.cpp
+++ b/src/engine/sidechain/enginerecord.cpp
@@ -107,7 +107,7 @@ bool EngineRecord::metaDataHasChanged()
     return true;
 }
 
-void EngineRecord::process(const CSAMPLE* pBuffer, const int iBufferSize) {
+void EngineRecord::process(const CSAMPLE* pBuffer, const std::size_t bufferSize) {
     const auto recordingStatus = static_cast<int>(m_pRecReady->get());
     static const QString tag("EngineRecord recording");
 
@@ -199,7 +199,7 @@ void EngineRecord::process(const CSAMPLE* pBuffer, const int iBufferSize) {
     if (m_pRecReady->get() == RECORD_ON) {
         // Compress audio. Encoder will call method 'write()' below to
         // write a file stream and emit bytesRecorded.
-        m_pEncoder->encodeBuffer(pBuffer, iBufferSize);
+        m_pEncoder->encodeBuffer(pBuffer, bufferSize);
 
         //Writing cueLine before updating the time counter since we prefer to be ahead
         //rather than late.
@@ -210,7 +210,7 @@ void EngineRecord::process(const CSAMPLE* pBuffer, const int iBufferSize) {
         }
 
         // update frames counting and recorded duration (seconds)
-        m_frames += iBufferSize / 2;
+        m_frames += bufferSize / 2;
         unsigned long lastDuration = m_recordedDuration;
         m_recordedDuration = m_frames / m_sampleRate;
 

--- a/src/engine/sidechain/enginerecord.h
+++ b/src/engine/sidechain/enginerecord.h
@@ -19,7 +19,7 @@ class EngineRecord : public QObject, public EncoderCallback, public SideChainWor
     EngineRecord(UserSettingsPointer pConfig);
     ~EngineRecord() override;
 
-    void process(const CSAMPLE* pBuffer, const int iBufferSize) override;
+    void process(const CSAMPLE* pBuffer, const std::size_t bufferSize) override;
     void shutdown() override {}
 
     // writes compressed audio to file

--- a/src/engine/sidechain/networkoutputstreamworker.h
+++ b/src/engine/sidechain/networkoutputstreamworker.h
@@ -48,7 +48,7 @@ class NetworkOutputStreamWorker {
     NetworkOutputStreamWorker();
     virtual ~NetworkOutputStreamWorker() = default;
 
-    virtual void process(const CSAMPLE* pBuffer, const int iBufferSize) = 0;
+    virtual void process(const CSAMPLE* pBuffer, const std::size_t bufferSize) = 0;
     virtual void shutdown() = 0;
 
     virtual void outputAvailable();

--- a/src/engine/sidechain/shoutconnection.cpp
+++ b/src/engine/sidechain/shoutconnection.cpp
@@ -700,7 +700,7 @@ int ShoutConnection::filelen() {
     return 0;
 }
 
-bool ShoutConnection::writeSingle(const unsigned char* data, size_t len) {
+bool ShoutConnection::writeSingle(const unsigned char* data, std::size_t len) {
     setFunctionCode(8);
     int ret = shout_send_raw(m_pShout, data, len);
     if (ret == SHOUTERR_BUSY) {
@@ -725,7 +725,7 @@ bool ShoutConnection::writeSingle(const unsigned char* data, size_t len) {
     return true;
 }
 
-void ShoutConnection::process(const CSAMPLE* pBuffer, const int iBufferSize) {
+void ShoutConnection::process(const CSAMPLE* pBuffer, const std::size_t bufferSize) {
     setFunctionCode(4);
     if (!m_pProfile->getEnabled()) {
         return;
@@ -744,9 +744,9 @@ void ShoutConnection::process(const CSAMPLE* pBuffer, const int iBufferSize) {
     const EncoderPointer pEncoder = m_encoder;
 
     // If we are connected, encode the samples.
-    if (iBufferSize > 0 && pEncoder) {
+    if (bufferSize > 0 && pEncoder) {
         setFunctionCode(6);
-        pEncoder->encodeBuffer(pBuffer, iBufferSize);
+        pEncoder->encodeBuffer(pBuffer, bufferSize);
         // the encoded frames are received by the write() callback.
     }
 

--- a/src/engine/sidechain/shoutconnection.h
+++ b/src/engine/sidechain/shoutconnection.h
@@ -33,7 +33,7 @@ class ShoutConnection
 
     // This is called by the Engine implementation for each sample. Encode and
     // send the stream, as well as check for metadata changes.
-    void process(const CSAMPLE* pBuffer, const int iBufferSize) override;
+    void process(const CSAMPLE* pBuffer, const std::size_t bufferSize) override;
 
     void shutdown() override {
     }

--- a/src/engine/sidechain/sidechainworker.h
+++ b/src/engine/sidechain/sidechainworker.h
@@ -6,6 +6,6 @@ class SideChainWorker {
   public:
     SideChainWorker() { }
     virtual ~SideChainWorker() = default;
-    virtual void process(const CSAMPLE* pBuffer, const int iBufferSize) = 0;
+    virtual void process(const CSAMPLE* pBuffer, const std::size_t bufferSize) = 0;
     virtual void shutdown() = 0;
 };

--- a/src/engine/sync/enginesync.cpp
+++ b/src/engine/sync/enginesync.cpp
@@ -585,11 +585,11 @@ void EngineSync::addSyncableDeck(Syncable* pSyncable) {
     m_syncables.append(pSyncable);
 }
 
-void EngineSync::onCallbackStart(mixxx::audio::SampleRate sampleRate, int bufferSize) {
+void EngineSync::onCallbackStart(mixxx::audio::SampleRate sampleRate, std::size_t bufferSize) {
     m_pInternalClock->onCallbackStart(sampleRate, bufferSize);
 }
 
-void EngineSync::onCallbackEnd(mixxx::audio::SampleRate sampleRate, int bufferSize) {
+void EngineSync::onCallbackEnd(mixxx::audio::SampleRate sampleRate, std::size_t bufferSize) {
     m_pInternalClock->onCallbackEnd(sampleRate, bufferSize);
 }
 

--- a/src/engine/sync/enginesync.h
+++ b/src/engine/sync/enginesync.h
@@ -71,8 +71,8 @@ class EngineSync : public SyncableListener {
 
     void addSyncableDeck(Syncable* pSyncable);
     EngineChannel* getLeaderChannel() const;
-    void onCallbackStart(mixxx::audio::SampleRate sampleRate, int bufferSize);
-    void onCallbackEnd(mixxx::audio::SampleRate sampleRate, int bufferSize);
+    void onCallbackStart(mixxx::audio::SampleRate sampleRate, std::size_t bufferSize);
+    void onCallbackEnd(mixxx::audio::SampleRate sampleRate, std::size_t bufferSize);
 
   private:
     /// Iterate over decks, and based on sync and play status, pick a new Leader, or return the

--- a/src/engine/sync/internalclock.cpp
+++ b/src/engine/sync/internalclock.cpp
@@ -210,13 +210,13 @@ void InternalClock::updateBeatLength(mixxx::audio::SampleRate sampleRate, mixxx:
     updateLeaderBeatDistance(oldBeatDistance);
 }
 
-void InternalClock::onCallbackStart(mixxx::audio::SampleRate sampleRate, int bufferSize) {
+void InternalClock::onCallbackStart(mixxx::audio::SampleRate sampleRate, std::size_t bufferSize) {
     Q_UNUSED(sampleRate)
     Q_UNUSED(bufferSize)
     m_pEngineSync->notifyInstantaneousBpmChanged(this, getBpm());
 }
 
-void InternalClock::onCallbackEnd(mixxx::audio::SampleRate sampleRate, int bufferSize) {
+void InternalClock::onCallbackEnd(mixxx::audio::SampleRate sampleRate, std::size_t bufferSize) {
     updateBeatLength(sampleRate, getBpm());
 
     // stereo samples, so divide by 2

--- a/src/engine/sync/internalclock.h
+++ b/src/engine/sync/internalclock.h
@@ -61,8 +61,8 @@ class InternalClock : public QObject, public Clock, public Syncable {
     void updateInstantaneousBpm(mixxx::Bpm bpm) override;
     void reinitLeaderParams(double beatDistance, mixxx::Bpm baseBpm, mixxx::Bpm bpm) override;
 
-    void onCallbackStart(mixxx::audio::SampleRate sampleRate, int bufferSize);
-    void onCallbackEnd(mixxx::audio::SampleRate sampleRate, int bufferSize);
+    void onCallbackStart(mixxx::audio::SampleRate sampleRate, std::size_t bufferSize);
+    void onCallbackEnd(mixxx::audio::SampleRate sampleRate, std::size_t bufferSize);
 
   private slots:
     void slotBpmChanged(double bpm);

--- a/src/sources/soundsourcestem.cpp
+++ b/src/sources/soundsourcestem.cpp
@@ -388,8 +388,8 @@ SoundSource::OpenResult SoundSourceSTEM::tryOpen(
         // No special channel format request
         m_requestedChannelCount = mixxx::audio::ChannelCount::stem();
         initChannelCountOnce(
-                mixxx::audio::ChannelCount::stereo() *
-                m_pStereoStreams.size());
+                static_cast<int>(mixxx::audio::ChannelCount::stereo() *
+                        m_pStereoStreams.size()));
     }
 
     initSampleRateOnce(m_pStereoStreams.front()->getSignalInfo().getSampleRate());
@@ -431,16 +431,17 @@ ReadableSampleFrames SoundSourceSTEM::readSampleFramesClamped(
             SampleBuffer::ReadableSlice(
                     globalSampleFrames.writableData(),
                     globalSampleFrames.writableLength()));
-    int stemCount = m_pStereoStreams.size();
+    std::size_t stemCount = m_pStereoStreams.size();
     CSAMPLE* pBuffer = globalSampleFrames.writableData();
 
     if (m_requestedChannelCount == mixxx::audio::ChannelCount::stereo()) {
         SampleUtil::clear(pBuffer, globalSampleFrames.writableLength());
     } else {
-        DEBUG_ASSERT(stemSampleLength * stemCount == globalSampleFrames.writableLength());
+        DEBUG_ASSERT(stemSampleLength * static_cast<SINT>(stemCount) ==
+                globalSampleFrames.writableLength());
     }
 
-    for (int streamIdx = 0; streamIdx < stemCount; streamIdx++) {
+    for (std::size_t streamIdx = 0; streamIdx < stemCount; streamIdx++) {
         WritableSampleFrames currentStemFrame = WritableSampleFrames(
                 globalSampleFrames.frameIndexRange(),
                 SampleBuffer::WritableSlice(

--- a/src/test/enginemixertest.cpp
+++ b/src/test/enginemixertest.cpp
@@ -31,18 +31,18 @@ class EngineChannelMock : public EngineChannel {
                       /*isPrimarydeck*/ true) {
     }
 
-    void applyVolume(CSAMPLE* pBuff, const int iBufferSize) {
+    void applyVolume(CSAMPLE* pBuff, const std::size_t bufferSize) {
         Q_UNUSED(pBuff);
-        Q_UNUSED(iBufferSize);
+        Q_UNUSED(bufferSize);
     }
 
     MOCK_METHOD(ActiveState, updateActiveState, (), (override));
     MOCK_METHOD(bool, isActive, (), (override));
     MOCK_METHOD(bool, isMainMixEnabled, (), (override, const));
     MOCK_METHOD(bool, isPflEnabled, (), (override, const));
-    MOCK_METHOD(void, process, (CSAMPLE * pInOut, const int iBufferSize), (override));
+    MOCK_METHOD(void, process, (CSAMPLE * pInOut, const std::size_t bufferSize), (override));
     MOCK_METHOD(void, collectFeatures, (GroupFeatureState * pGroupFeatures), (override, const));
-    MOCK_METHOD(void, postProcess, (const int iBufferSize), (override));
+    MOCK_METHOD(void, postProcess, (const std::size_t bufferSize), (override));
 };
 
 class EngineMixerTest


### PR DESCRIPTION
This is a spin-off of https://github.com/mixxxdj/mixxx/pull/13172#discussion_r1824896186 to keep the changes not related to Macros out of that PR.