### PR TITLE
add missing header, fixes compilation of 2.5 on macOS

### DIFF
--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -3,6 +3,7 @@
 #include <QChar>
 #include <QDir>
 #include <QFileInfo>
+#include <QThread>
 #include <QtDebug>
 
 #ifdef __SQLITE3__


### PR DESCRIPTION
compilation failed with 

/Users/maarten/git/mixxx/src/library/dao/trackdao.cpp:284:17: error: incomplete type 'QThread' named in nested name specifier
             << QThread::currentThread() << m_database.connectionName();
                ^~~~~~~~~
