### PR TITLE
also show time / beats since last marker

### DIFF
--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -68,10 +68,10 @@ DlgPrefWaveform::DlgPrefWaveform(
         defaultZoomComboBox->addItem(QString::number(100 / static_cast<double>(i), 'f', 1) + " %");
     }
 
-    // Populate untilMark options
-    untilMarkAlignComboBox->addItem(tr("Top"));
-    untilMarkAlignComboBox->addItem(tr("Center"));
-    untilMarkAlignComboBox->addItem(tr("Bottom"));
+    // Populate distanceToMark options
+    distanceToMarkAlignComboBox->addItem(tr("Top"));
+    distanceToMarkAlignComboBox->addItem(tr("Center"));
+    distanceToMarkAlignComboBox->addItem(tr("Bottom"));
 
     // The GUI is not fully setup so connecting signals before calling
     // slotUpdate can generate rebootMixxxView calls.
@@ -163,6 +163,14 @@ DlgPrefWaveform::DlgPrefWaveform(
             &QSlider::valueChanged,
             this,
             &DlgPrefWaveform::slotSetPlayMarkerPosition);
+    connect(sinceMarkShowBeatsCheckBox,
+            &QCheckBox::toggled,
+            this,
+            &DlgPrefWaveform::slotSetSinceMarkShowBeats);
+    connect(sinceMarkShowTimeCheckBox,
+            &QCheckBox::toggled,
+            this,
+            &DlgPrefWaveform::slotSetSinceMarkShowTime);
     connect(untilMarkShowBeatsCheckBox,
             &QCheckBox::toggled,
             this,
@@ -171,14 +179,14 @@ DlgPrefWaveform::DlgPrefWaveform(
             &QCheckBox::toggled,
             this,
             &DlgPrefWaveform::slotSetUntilMarkShowTime);
-    connect(untilMarkAlignComboBox,
+    connect(distanceToMarkAlignComboBox,
             QOverload<int>::of(&QComboBox::currentIndexChanged),
             this,
-            &DlgPrefWaveform::slotSetUntilMarkAlign);
-    connect(untilMarkTextPointSizeSpinBox,
+            &DlgPrefWaveform::slotSetDistanceToMarkAlign);
+    connect(distanceToMarkTextPointSizeSpinBox,
             QOverload<int>::of(&QSpinBox::valueChanged),
             this,
-            &DlgPrefWaveform::slotSetUntilMarkTextPointSize);
+            &DlgPrefWaveform::slotSetDistanceToMarkTextPointSize);
 
     setScrollSafeGuardForAllInputWidgets(this);
 }
@@ -201,7 +209,7 @@ void DlgPrefWaveform::slotUpdate() {
         waveformTypeComboBox->setCurrentIndex(currentIndex);
     }
 
-    updateEnableUntilMark();
+    updateEnableDistanceToMark();
 
     frameRateSpinBox->setValue(factory->getFrameRate());
     frameRateSlider->setValue(factory->getFrameRate());
@@ -219,12 +227,14 @@ void DlgPrefWaveform::slotUpdate() {
     beatGridAlphaSpinBox->setValue(factory->getBeatGridAlpha());
     beatGridAlphaSlider->setValue(factory->getBeatGridAlpha());
 
+    sinceMarkShowBeatsCheckBox->setChecked(factory->getSinceMarkShowBeats());
+    sinceMarkShowTimeCheckBox->setChecked(factory->getSinceMarkShowTime());
     untilMarkShowBeatsCheckBox->setChecked(factory->getUntilMarkShowBeats());
     untilMarkShowTimeCheckBox->setChecked(factory->getUntilMarkShowTime());
-    untilMarkAlignComboBox->setCurrentIndex(
-            WaveformWidgetFactory::toUntilMarkAlignIndex(
-                    factory->getUntilMarkAlign()));
-    untilMarkTextPointSizeSpinBox->setValue(factory->getUntilMarkTextPointSize());
+    distanceToMarkAlignComboBox->setCurrentIndex(
+            WaveformWidgetFactory::toDistanceToMarkAlignIndex(
+                    factory->getDistanceToMarkAlign()));
+    distanceToMarkTextPointSizeSpinBox->setValue(factory->getDistanceToMarkTextPointSize());
 
     WOverview::Type cfgOverviewType =
             m_pConfig->getValue<WOverview::Type>(kOverviewTypeCfgKey, WOverview::Type::RGB);
@@ -309,17 +319,19 @@ void DlgPrefWaveform::slotSetWaveformType(int index) {
     int handleIndex = waveformTypeComboBox->itemData(index).toInt();
     WaveformWidgetFactory::instance()->setWidgetTypeFromHandle(handleIndex);
 
-    updateEnableUntilMark();
+    updateEnableDistanceToMark();
 }
 
-void DlgPrefWaveform::updateEnableUntilMark() {
-    const bool enabled = WaveformWidgetFactory::instance()->widgetTypeSupportsUntilMark();
+void DlgPrefWaveform::updateEnableDistanceToMark() {
+    const bool enabled = WaveformWidgetFactory::instance()->widgetTypeSupportsDistanceToMark();
+    sinceMarkShowBeatsCheckBox->setEnabled(enabled);
+    sinceMarkShowTimeCheckBox->setEnabled(enabled);
     untilMarkShowBeatsCheckBox->setEnabled(enabled);
     untilMarkShowTimeCheckBox->setEnabled(enabled);
-    untilMarkAlignLabel->setEnabled(enabled);
-    untilMarkAlignComboBox->setEnabled(enabled);
-    untilMarkTextPointSizeLabel->setEnabled(enabled);
-    untilMarkTextPointSizeSpinBox->setEnabled(enabled);
+    distanceToMarkAlignLabel->setEnabled(enabled);
+    distanceToMarkAlignComboBox->setEnabled(enabled);
+    distanceToMarkTextPointSizeLabel->setEnabled(enabled);
+    distanceToMarkTextPointSizeSpinBox->setEnabled(enabled);
     requiresGLSLLabel->setVisible(!enabled);
 }
 
@@ -387,6 +399,14 @@ void DlgPrefWaveform::slotSetPlayMarkerPosition(int position) {
     WaveformWidgetFactory::instance()->setPlayMarkerPosition(position / 100.0);
 }
 
+void DlgPrefWaveform::slotSetSinceMarkShowBeats(bool checked) {
+    WaveformWidgetFactory::instance()->setSinceMarkShowBeats(checked);
+}
+
+void DlgPrefWaveform::slotSetSinceMarkShowTime(bool checked) {
+    WaveformWidgetFactory::instance()->setSinceMarkShowTime(checked);
+}
+
 void DlgPrefWaveform::slotSetUntilMarkShowBeats(bool checked) {
     WaveformWidgetFactory::instance()->setUntilMarkShowBeats(checked);
 }
@@ -395,13 +415,13 @@ void DlgPrefWaveform::slotSetUntilMarkShowTime(bool checked) {
     WaveformWidgetFactory::instance()->setUntilMarkShowTime(checked);
 }
 
-void DlgPrefWaveform::slotSetUntilMarkAlign(int index) {
-    WaveformWidgetFactory::instance()->setUntilMarkAlign(
-            WaveformWidgetFactory::toUntilMarkAlign(index));
+void DlgPrefWaveform::slotSetDistanceToMarkAlign(int index) {
+    WaveformWidgetFactory::instance()->setDistanceToMarkAlign(
+            WaveformWidgetFactory::toDistanceToMarkAlign(index));
 }
 
-void DlgPrefWaveform::slotSetUntilMarkTextPointSize(int value) {
-    WaveformWidgetFactory::instance()->setUntilMarkTextPointSize(value);
+void DlgPrefWaveform::slotSetDistanceToMarkTextPointSize(int value) {
+    WaveformWidgetFactory::instance()->setDistanceToMarkTextPointSize(value);
 }
 
 void DlgPrefWaveform::calculateCachedWaveformDiskUsage() {

--- a/src/preferences/dialog/dlgprefwaveform.h
+++ b/src/preferences/dialog/dlgprefwaveform.h
@@ -39,16 +39,18 @@ class DlgPrefWaveform : public DlgPreferencePage, public Ui::DlgPrefWaveformDlg 
     void slotClearCachedWaveforms();
     void slotSetBeatGridAlpha(int alpha);
     void slotSetPlayMarkerPosition(int position);
+    void slotSetSinceMarkShowBeats(bool checked);
+    void slotSetSinceMarkShowTime(bool checked);
     void slotSetUntilMarkShowBeats(bool checked);
     void slotSetUntilMarkShowTime(bool checked);
-    void slotSetUntilMarkAlign(int index);
-    void slotSetUntilMarkTextPointSize(int value);
+    void slotSetDistanceToMarkAlign(int index);
+    void slotSetDistanceToMarkTextPointSize(int value);
 
   private:
     void initWaveformControl();
     void calculateCachedWaveformDiskUsage();
     void notifyRebootNecessary();
-    void updateEnableUntilMark();
+    void updateEnableDistanceToMark();
 
     std::unique_ptr<ControlPushButton> m_pTypeControl;
 

--- a/src/preferences/dialog/dlgprefwaveformdlg.ui
+++ b/src/preferences/dialog/dlgprefwaveformdlg.ui
@@ -459,7 +459,7 @@ Select from different types of displays for the waveform, which differ primarily
      </item>
 
      <item row="11" column="0">
-      <widget class="QLabel" name="untilMarkLabel">
+      <widget class="QLabel" name="distanceToMarkLabel">
        <property name="text">
         <string>Play marker hints</string>
        </property>
@@ -468,67 +468,85 @@ Select from different types of displays for the waveform, which differ primarily
        </property>
       </widget>
      </item>
-     <item row="11" column="1">
-      <widget class="QCheckBox" name="untilMarkShowBeatsCheckBox">
-       <property name="text">
-        <string>Beats until next marker</string>
-       </property>
-      </widget>
-     </item>
-     <item row="12" column="1">
-      <widget class="QCheckBox" name="untilMarkShowTimeCheckBox">
-       <property name="text">
-        <string>Time until next marker</string>
-       </property>
-      </widget>
-     </item>
-     <item row="11" column="2">
-      <widget class="QLabel" name="untilMarkAlignLabel">
-       <property name="text">
-        <string>Placement</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-       </property>
-       <property name="buddy">
-        <cstring>untilMarkAlignComboBox</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="12" column="2">
-      <widget class="QComboBox" name="untilMarkAlignComboBox"/>
-     </item>
-     <item row="11" column="3">
-      <widget class="QLabel" name="untilMarkTextPointSizeLabel">
-       <property name="text">
-        <string>Font size</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-       </property>
-       <property name="buddy">
-        <cstring>untilMarkTextPointSizeSpinBox</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="12" column="3">
-      <widget class="QSpinBox" name="untilMarkTextPointSizeSpinBox">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="suffix">
-        <string> pt</string>
-       </property>
-       <property name="minimum">
-        <number>10</number>
-       </property>
-       <property name="maximum">
-        <number>50</number>
-       </property>
-       <property name="value">
-        <number>30</number>
-       </property>
-      </widget>
+     <item row="11" column="1" colspan="3">
+      <layout class="QGridLayout" name="gridLayout_4">
+       <item row="0" column="0">
+        <widget class="QCheckBox" name="sinceMarkShowBeatsCheckBox">
+         <property name="text">
+          <string>Beats since previous marker</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QCheckBox" name="sinceMarkShowTimeCheckBox">
+         <property name="text">
+          <string>Time since previous marker</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QCheckBox" name="untilMarkShowBeatsCheckBox">
+         <property name="text">
+          <string>Beats until next marker</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QCheckBox" name="untilMarkShowTimeCheckBox">
+         <property name="text">
+          <string>Time until next marker</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="2">
+        <widget class="QLabel" name="distanceToMarkAlignLabel">
+         <property name="text">
+          <string>Placement</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+         <property name="buddy">
+          <cstring>distanceToMarkAlignComboBox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2">
+        <widget class="QComboBox" name="distanceToMarkAlignComboBox"/>
+       </item>
+       <item row="0" column="3">
+        <widget class="QLabel" name="distanceToMarkTextPointSizeLabel">
+         <property name="text">
+          <string>Font size</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+         <property name="buddy">
+          <cstring>distanceToMarkTextPointSizeSpinBox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="3">
+        <widget class="QSpinBox" name="distanceToMarkTextPointSizeSpinBox">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="suffix">
+          <string> pt</string>
+         </property>
+         <property name="minimum">
+          <number>10</number>
+         </property>
+         <property name="maximum">
+          <number>50</number>
+         </property>
+         <property name="value">
+          <number>30</number>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
      <item row="14" column="1" colspan="2">
       <widget class="QLabel" name="requiresGLSLLabel">

--- a/src/preferences/dialog/dlgprefwaveformdlg.ui
+++ b/src/preferences/dialog/dlgprefwaveformdlg.ui
@@ -548,7 +548,7 @@ Select from different types of displays for the waveform, which differ primarily
        </item>
       </layout>
      </item>
-     <item row="14" column="1" colspan="2">
+     <item row="12" column="1" colspan="2">
       <widget class="QLabel" name="requiresGLSLLabel">
        <property name="text">
         <string>This functionality requires a waveform type marked "(GLSL)".</string>
@@ -558,7 +558,7 @@ Select from different types of displays for the waveform, which differ primarily
        </property>
       </widget>
      </item>
-     <item row="15" column="0">
+     <item row="13" column="0">
       <widget class="QLabel" name="cachedWaveforms">
        <property name="text">
         <string>Caching</string>
@@ -568,7 +568,7 @@ Select from different types of displays for the waveform, which differ primarily
        </property>
       </widget>
      </item>
-     <item row="15" column="1" colspan="3">
+     <item row="13" column="1" colspan="3">
       <layout class="QGridLayout" name="cachingGridLayout">
        <item row="4" column="0">
         <widget class="QPushButton" name="clearCachedWaveforms">
@@ -620,7 +620,7 @@ Select from different types of displays for the waveform, which differ primarily
       </layout>
      </item>
 
-     <item row="17" column="0" colspan="4">
+     <item row="14" column="0" colspan="4">
       <widget class="QGroupBox" name="openGLStatus">
        <property name="title">
         <string>OpenGL status</string>

--- a/src/preferences/dialog/dlgprefwaveformdlg.ui
+++ b/src/preferences/dialog/dlgprefwaveformdlg.ui
@@ -464,7 +464,7 @@ Select from different types of displays for the waveform, which differ primarily
         <string>Play marker hints</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
        </property>
       </widget>
      </item>

--- a/src/waveform/renderers/allshader/digitsrenderer.cpp
+++ b/src/waveform/renderers/allshader/digitsrenderer.cpp
@@ -206,7 +206,6 @@ void allshader::DigitsRenderer::updateTexture(
 }
 
 float allshader::DigitsRenderer::textWidth(const QString& s) const {
-    const int n = s.length();
     const float space = static_cast<float>(m_penWidth) / 2;
     float x = 0;
 

--- a/src/waveform/renderers/allshader/digitsrenderer.cpp
+++ b/src/waveform/renderers/allshader/digitsrenderer.cpp
@@ -205,6 +205,21 @@ void allshader::DigitsRenderer::updateTexture(
     m_texture.setData(image);
 }
 
+float allshader::DigitsRenderer::textWidth(const QString& s) const {
+    const int n = s.length();
+    const float space = static_cast<float>(m_penWidth) / 2;
+    float x = 0;
+
+    for (QChar c : s) {
+        if (x != 0) {
+            x -= space;
+        }
+        int index = charToIndex(c);
+        x += m_width[index];
+    }
+    return x;
+}
+
 float allshader::DigitsRenderer::draw(const QMatrix4x4& matrix,
         float x,
         float y,

--- a/src/waveform/renderers/allshader/digitsrenderer.h
+++ b/src/waveform/renderers/allshader/digitsrenderer.h
@@ -21,6 +21,7 @@ class allshader::DigitsRenderer : public QOpenGLFunctions {
             float y,
             const QString& s);
     float height() const;
+    float textWidth(const QString& s) const;
 
   private:
     mixxx::TextureShader m_shader;

--- a/src/waveform/renderers/allshader/waveformrendermark.h
+++ b/src/waveform/renderers/allshader/waveformrendermark.h
@@ -4,6 +4,7 @@
 
 #include "shaders/rgbashader.h"
 #include "shaders/textureshader.h"
+#include "track/beats.h"
 #include "util/opengltexture2d.h"
 #include "waveform/renderers/allshader/digitsrenderer.h"
 #include "waveform/renderers/allshader/waveformrendererabstract.h"
@@ -40,6 +41,11 @@ class allshader::WaveformRenderMark : public ::WaveformRenderMarkBase,
     void resizeGL(int w, int h) override;
 
   private:
+    struct Distance {
+        int m_beats;
+        double m_time;
+    };
+
     void updateMarkImage(WaveformMarkPointer pMark) override;
 
     void updatePlayPosMarkTexture();
@@ -52,18 +58,25 @@ class allshader::WaveformRenderMark : public ::WaveformRenderMarkBase,
 
     void drawMark(const QMatrix4x4& matrix, const QRectF& rect, QColor color);
     void drawTexture(const QMatrix4x4& matrix, float x, float y, QOpenGLTexture* texture);
-    void updateUntilMark(double playPosition, double markerPosition);
-    void drawUntilMark(const QMatrix4x4& matrix, float x);
+    Distance distanceSinceMark(mixxx::BeatsPointer trackBeats,
+            mixxx::Beats::ConstIterator itCurrentBeat,
+            double playPosition,
+            double prevMarkPosition);
+    Distance distanceUntilMark(mixxx::BeatsPointer trackBeats,
+            mixxx::Beats::ConstIterator itCurrentBeat,
+            double playPosition,
+            double prevMarkPosition);
+    void drawDistance(const QMatrix4x4& matrix,
+            float x,
+            Qt::Alignment align,
+            const Distance& distance);
     float getMaxHeightForText() const;
 
     mixxx::RGBAShader m_rgbaShader;
     mixxx::TextureShader m_textureShader;
     OpenGLTexture2D m_playPosMarkTexture;
     DigitsRenderer m_digitsRenderer;
-    int m_beatsUntilMark;
-    double m_timeUntilMark;
-    double m_currentBeatPosition;
-    double m_nextBeatPosition;
+    std::unique_ptr<ControlProxy> m_pTimeElapsedControl;
     std::unique_ptr<ControlProxy> m_pTimeRemainingControl;
 
     bool m_isSlipRenderer;

--- a/src/waveform/renderers/allshader/waveformrendermark.h
+++ b/src/waveform/renderers/allshader/waveformrendermark.h
@@ -59,17 +59,17 @@ class allshader::WaveformRenderMark : public ::WaveformRenderMarkBase,
     void drawMark(const QMatrix4x4& matrix, const QRectF& rect, QColor color);
     void drawTexture(const QMatrix4x4& matrix, float x, float y, QOpenGLTexture* texture);
     Distance distanceSinceMark(mixxx::BeatsPointer trackBeats,
-            mixxx::Beats::ConstIterator itCurrentBeat,
             double playPosition,
             double prevMarkPosition);
     Distance distanceUntilMark(mixxx::BeatsPointer trackBeats,
-            mixxx::Beats::ConstIterator itCurrentBeat,
             double playPosition,
             double prevMarkPosition);
     void drawDistance(const QMatrix4x4& matrix,
             float x,
             Qt::Alignment align,
-            const Distance& distance);
+            const Distance& distance,
+            bool showDistanceBeats,
+            bool showDistanceTime);
     float getMaxHeightForText() const;
 
     mixxx::RGBAShader m_rgbaShader;

--- a/src/waveform/renderers/waveformmark.cpp
+++ b/src/waveform/renderers/waveformmark.cpp
@@ -67,9 +67,7 @@ float overlappingMarkerIncrement(const float labelRectHeight, const float breadt
     return std::max(minIncrement, fullIncrement - std::max(0.f, threshold - breadth));
 }
 
-#define FOO
-
-bool isShowUntilNextPositionControl(const QString& positionControl) {
+bool isShowUntilPositionControl(const QString& positionControl) {
     // To identify which markers are included in the beat/time until next marker
     // display, in addition to the hotcues
 #if QT_VERSION >= QT_VERSION_CHECK(6, 4, 0)
@@ -104,7 +102,7 @@ WaveformMark::WaveformMark(const QString& group,
           m_level{},
           m_iPriority(priority),
           m_iHotCue(hotCue),
-          m_showUntilNext{} {
+          m_showUntil{} {
     QString positionControl;
     QString endPositionControl;
     QString typeControl;
@@ -112,10 +110,10 @@ WaveformMark::WaveformMark(const QString& group,
         positionControl = "hotcue_" + QString::number(hotCue + 1) + "_position";
         endPositionControl = "hotcue_" + QString::number(hotCue + 1) + "_endposition";
         typeControl = "hotcue_" + QString::number(hotCue + 1) + "_type";
-        m_showUntilNext = true;
+        m_showUntil = true;
     } else {
         positionControl = context.selectString(node, "Control");
-        m_showUntilNext = isShowUntilNextPositionControl(positionControl);
+        m_showUntil = isShowUntilPositionControl(positionControl);
     }
 
     if (!positionControl.isEmpty()) {

--- a/src/waveform/renderers/waveformmark.h
+++ b/src/waveform/renderers/waveformmark.h
@@ -89,8 +89,8 @@ class WaveformMark {
         }
         return m_pVisibleCO->toBool();
     }
-    bool isShowUntilNext() const {
-        return m_showUntilNext;
+    bool isShowUntil() const {
+        return m_showUntil;
     }
 
     template<typename Receiver, typename Slot>
@@ -178,8 +178,8 @@ class WaveformMark {
     int m_iPriority;
     int m_iHotCue;
 
-    // Whether this marker is used in the show beats/time until next marker display.
-    bool m_showUntilNext;
+    // Whether this marker is used in the show beats/time until next / since prev marker display.
+    bool m_showUntil;
 
     QColor m_fillColor;
     QColor m_borderColor;

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -135,10 +135,12 @@ WaveformWidgetFactory::WaveformWidgetFactory()
           m_defaultZoom(WaveformWidgetRenderer::s_waveformDefaultZoom),
           m_zoomSync(true),
           m_overviewNormalized(false),
+          m_sinceMarkShowBeats(false),
+          m_sinceMarkShowTime(false),
           m_untilMarkShowBeats(false),
           m_untilMarkShowTime(false),
-          m_untilMarkAlign(Qt::AlignVCenter),
-          m_untilMarkTextPointSize(24),
+          m_distanceToMarkAlign(Qt::AlignVCenter),
+          m_distanceToMarkTextPointSize(24),
           m_openGlAvailable(false),
           m_openGlesAvailable(false),
           m_openGLShaderAvailable(false),
@@ -431,6 +433,27 @@ bool WaveformWidgetFactory::setConfig(UserSettingsPointer config) {
             WaveformWidgetRenderer::s_defaultPlayMarkerPosition);
     setPlayMarkerPosition(m_playMarkerPosition);
 
+    int sinceMarkShowBeats =
+            m_config->getValueString(
+                            ConfigKey("[Waveform]", "SinceMarkShowBeats"))
+                    .toInt(&ok);
+    if (ok) {
+        setSinceMarkShowBeats(static_cast<bool>(sinceMarkShowBeats));
+    } else {
+        m_config->set(ConfigKey("[Waveform]", "SinceMarkShowBeats"),
+                ConfigValue(m_sinceMarkShowBeats));
+    }
+    int sinceMarkShowTime =
+            m_config->getValueString(
+                            ConfigKey("[Waveform]", "SinceMarkShowTime"))
+                    .toInt(&ok);
+    if (ok) {
+        setSinceMarkShowTime(static_cast<bool>(sinceMarkShowTime));
+    } else {
+        m_config->set(ConfigKey("[Waveform]", "SinceMarkShowTime"),
+                ConfigValue(m_sinceMarkShowTime));
+    }
+
     int untilMarkShowBeats =
             m_config->getValueString(
                             ConfigKey("[Waveform]", "UntilMarkShowBeats"))
@@ -452,12 +475,12 @@ bool WaveformWidgetFactory::setConfig(UserSettingsPointer config) {
                 ConfigValue(m_untilMarkShowTime));
     }
 
-    setUntilMarkAlign(toUntilMarkAlign(
+    setDistanceToMarkAlign(toDistanceToMarkAlign(
             m_config->getValue(ConfigKey("[Waveform]", "UntilMarkAlign"),
-                    toUntilMarkAlignIndex(m_untilMarkAlign))));
-    setUntilMarkTextPointSize(
+                    toDistanceToMarkAlignIndex(m_distanceToMarkAlign))));
+    setDistanceToMarkTextPointSize(
             m_config->getValue(ConfigKey("[Waveform]", "UntilMarkTextPointSize"),
-                    m_untilMarkTextPointSize));
+                    m_distanceToMarkTextPointSize));
 
     return true;
 }
@@ -585,7 +608,7 @@ bool WaveformWidgetFactory::setWidgetType(
     return isAcceptable;
 }
 
-bool WaveformWidgetFactory::widgetTypeSupportsUntilMark() const {
+bool WaveformWidgetFactory::widgetTypeSupportsDistanceToMark() const {
     switch (m_configType) {
     case WaveformWidgetType::AllShaderRGBWaveform:
         return true;
@@ -1378,6 +1401,22 @@ QSurfaceFormat WaveformWidgetFactory::getSurfaceFormat(UserSettingsPointer confi
     return format;
 }
 
+void WaveformWidgetFactory::setSinceMarkShowBeats(bool value) {
+    m_sinceMarkShowBeats = value;
+    if (m_config) {
+        m_config->set(ConfigKey("[Waveform]", "SinceMarkShowBeats"),
+                ConfigValue(m_sinceMarkShowBeats));
+    }
+}
+
+void WaveformWidgetFactory::setSinceMarkShowTime(bool value) {
+    m_sinceMarkShowTime = value;
+    if (m_config) {
+        m_config->set(ConfigKey("[Waveform]", "SinceMarkShowTime"),
+                ConfigValue(m_sinceMarkShowTime));
+    }
+}
+
 void WaveformWidgetFactory::setUntilMarkShowBeats(bool value) {
     m_untilMarkShowBeats = value;
     if (m_config) {
@@ -1394,24 +1433,24 @@ void WaveformWidgetFactory::setUntilMarkShowTime(bool value) {
     }
 }
 
-void WaveformWidgetFactory::setUntilMarkAlign(Qt::Alignment align) {
-    m_untilMarkAlign = align;
+void WaveformWidgetFactory::setDistanceToMarkAlign(Qt::Alignment align) {
+    m_distanceToMarkAlign = align;
     if (m_config) {
         m_config->setValue(ConfigKey("[Waveform]", "UntilMarkAlign"),
-                toUntilMarkAlignIndex(m_untilMarkAlign));
+                toDistanceToMarkAlignIndex(m_distanceToMarkAlign));
     }
 }
 
-void WaveformWidgetFactory::setUntilMarkTextPointSize(int value) {
-    m_untilMarkTextPointSize = value;
+void WaveformWidgetFactory::setDistanceToMarkTextPointSize(int value) {
+    m_distanceToMarkTextPointSize = value;
     if (m_config) {
         m_config->setValue(ConfigKey("[Waveform]", "UntilMarkTextPointSize"),
-                m_untilMarkTextPointSize);
+                m_distanceToMarkTextPointSize);
     }
 }
 
 // static
-Qt::Alignment WaveformWidgetFactory::toUntilMarkAlign(int index) {
+Qt::Alignment WaveformWidgetFactory::toDistanceToMarkAlign(int index) {
     switch (index) {
     case 0:
         return Qt::AlignTop;
@@ -1424,7 +1463,7 @@ Qt::Alignment WaveformWidgetFactory::toUntilMarkAlign(int index) {
     return Qt::AlignVCenter;
 }
 // static
-int WaveformWidgetFactory::toUntilMarkAlignIndex(Qt::Alignment align) {
+int WaveformWidgetFactory::toDistanceToMarkAlignIndex(Qt::Alignment align) {
     switch (align) {
     case Qt::AlignTop:
         return 0;

--- a/src/waveform/waveformwidgetfactory.h
+++ b/src/waveform/waveformwidgetfactory.h
@@ -97,27 +97,35 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
         return findHandleIndexFromType(m_type);
     }
     int findHandleIndexFromType(WaveformWidgetType::Type type);
-    bool widgetTypeSupportsUntilMark() const;
+    bool widgetTypeSupportsDistanceToMark() const;
+    void setSinceMarkShowBeats(bool value);
+    void setSinceMarkShowTime(bool value);
     void setUntilMarkShowBeats(bool value);
     void setUntilMarkShowTime(bool value);
-    void setUntilMarkAlign(Qt::Alignment align);
-    void setUntilMarkTextPointSize(int value);
+    void setDistanceToMarkAlign(Qt::Alignment align);
+    void setDistanceToMarkTextPointSize(int value);
 
+    bool getSinceMarkShowBeats() const {
+        return m_sinceMarkShowBeats;
+    }
+    bool getSinceMarkShowTime() const {
+        return m_sinceMarkShowTime;
+    }
     bool getUntilMarkShowBeats() const {
         return m_untilMarkShowBeats;
     }
     bool getUntilMarkShowTime() const {
         return m_untilMarkShowTime;
     }
-    Qt::Alignment getUntilMarkAlign() const {
-        return m_untilMarkAlign;
+    Qt::Alignment getDistanceToMarkAlign() const {
+        return m_distanceToMarkAlign;
     }
-    int getUntilMarkTextPointSize() const {
-        return m_untilMarkTextPointSize;
+    int getDistanceToMarkTextPointSize() const {
+        return m_distanceToMarkTextPointSize;
     }
 
-    static Qt::Alignment toUntilMarkAlign(int index);
-    static int toUntilMarkAlignIndex(Qt::Alignment align);
+    static Qt::Alignment toDistanceToMarkAlign(int index);
+    static int toDistanceToMarkAlignIndex(Qt::Alignment align);
 
     /// Returns the desired surface format for the OpenGLWindow
     static QSurfaceFormat getSurfaceFormat(UserSettingsPointer config = nullptr);
@@ -220,10 +228,12 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
     double m_visualGain[FilterCount];
     bool m_overviewNormalized;
 
+    bool m_sinceMarkShowBeats;
+    bool m_sinceMarkShowTime;
     bool m_untilMarkShowBeats;
     bool m_untilMarkShowTime;
-    Qt::Alignment m_untilMarkAlign;
-    int m_untilMarkTextPointSize;
+    Qt::Alignment m_distanceToMarkAlign;
+    int m_distanceToMarkTextPointSize;
 
     bool m_openGlAvailable;
     bool m_openGlesAvailable;


### PR DESCRIPTION
Also show the time and beats since the last marker, in addition to the time and beats until the next.

Added preferences to show/hide beat/times since previous marker

This is ready for review. I improved the code quality of the related code in waveformrendermark.cpp a bit.

<img width="1028" alt="Screenshot 2024-11-03 at 18 36 58" src="https://github.com/user-attachments/assets/a57f0246-0a57-4375-822d-9cf8e8a2dd90">
<img width="619" alt="Screenshot 2024-11-03 at 18 29 51" src="https://github.com/user-attachments/assets/7719ba6b-d6cc-4efe-b82d-d0ccda11a0ca">
