### PR TITLE
Revert "chore: pin Node.JS pre-commit hooks to use LTS"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -114,7 +114,6 @@ repos:
     rev: v0.13.0
     hooks:
       - id: markdownlint-cli2
-        language_version: lts
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.29.1
     hooks:


### PR DESCRIPTION
This reverts 8961bba53d968a7343062587aed752cd20c3daab of #13785 

No issues here anymore (ie. my issue described [here](https://mixxx.zulipchat.com/#narrow/channel/247620-development-help/topic/pre-commit.20404.20for.20markdownlint-cli2)  are resolved)

Please test!