### PR TITLE
Tracks: focus the editing field in the track properties that corresponds to the focused column

### DIFF
--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -440,19 +440,6 @@
               </property>
              </widget>
             </item>
-            <item row="0" column="0">
-             <spacer name="horizontalSpacer_5">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>10</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
            </layout>
           </item>
          </layout>

--- a/src/library/dlgtrackinfomulti.cpp
+++ b/src/library/dlgtrackinfomulti.cpp
@@ -125,6 +125,22 @@ void DlgTrackInfoMulti::init() {
     setupUi(this);
     setWindowIcon(QIcon(MIXXX_ICON_PATH));
 
+    // Store tag edit widget pointers to allow focusing a specific widgets when
+    // this is opened by double-clicking a WTrackProperty label.
+    // Associate with property strings taken from library/dao/trackdao.h
+    m_propertyWidgets.insert("artist", txtArtist);
+    m_propertyWidgets.insert("title", txtTitle);
+    m_propertyWidgets.insert("titleInfo", txtTitle);
+    m_propertyWidgets.insert("album", txtAlbum);
+    m_propertyWidgets.insert("album_artist", txtAlbumArtist);
+    m_propertyWidgets.insert("composer", txtComposer);
+    m_propertyWidgets.insert("genre", txtGenre);
+    m_propertyWidgets.insert("year", txtYear);
+    m_propertyWidgets.insert("tracknumber", txtTrackNumber);
+    m_propertyWidgets.insert("key", txtKey);
+    m_propertyWidgets.insert("grouping", txtGrouping);
+    m_propertyWidgets.insert("comment", txtComment);
+
     // QDialog buttons
     connect(btnApply,
             &QPushButton::clicked,
@@ -306,6 +322,16 @@ void DlgTrackInfoMulti::loadTracks(const QList<TrackPointer>& pTracks) {
     // Listen to all tracks' changed() signal so we don't need to listen to
     // individual signals such as cuesUpdates, coverArtUpdated(), etc.
     connectTracksChanged();
+}
+
+void DlgTrackInfoMulti::focusField(const QString& property) {
+    if (property.isEmpty()) {
+        return;
+    }
+    auto it = m_propertyWidgets.constFind(property);
+    if (it != m_propertyWidgets.constEnd()) {
+        it.value()->setFocus();
+    }
 }
 
 void DlgTrackInfoMulti::updateFromTracks() {

--- a/src/library/dlgtrackinfomulti.h
+++ b/src/library/dlgtrackinfomulti.h
@@ -29,6 +29,7 @@ class DlgTrackInfoMulti : public QDialog, public Ui::DlgTrackInfoMulti {
     ~DlgTrackInfoMulti() override = default;
 
     void loadTracks(const QList<TrackPointer>& pTracks);
+    void focusField(const QString& property);
 
     /// We need this to set the max width of the comment QComboBox which has
     /// issues with long lines / multi-line content. See init() for details.
@@ -106,6 +107,8 @@ class DlgTrackInfoMulti : public QDialog, public Ui::DlgTrackInfoMulti {
 
     QHash<TrackId, TrackPointer> m_pLoadedTracks;
     QList<mixxx::TrackRecord> m_trackRecords;
+
+    QHash<QString, QWidget*> m_propertyWidgets;
 
     parented_ptr<WCoverArtMenu> m_pWCoverArtMenu;
     parented_ptr<WCoverArtLabel> m_pWCoverArtLabel;

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -2588,8 +2588,20 @@ void WTrackMenu::showDlgTrackInfo(const QString& property) {
         return;
     }
     slotShowDlgTrackInfo();
-    if (m_pDlgTrackInfo->isVisible()) {
-        m_pDlgTrackInfo->focusField(property);
+    if (m_pTrackModel && getTrackCount() > 1) {
+        VERIFY_OR_DEBUG_ASSERT(m_pDlgTrackInfoMulti) {
+            return;
+        }
+        if (m_pDlgTrackInfoMulti->isVisible()) {
+            m_pDlgTrackInfoMulti->focusField(property);
+        }
+    } else {
+        VERIFY_OR_DEBUG_ASSERT(m_pDlgTrackInfo) {
+            return;
+        }
+        if (m_pDlgTrackInfo->isVisible()) {
+            m_pDlgTrackInfo->focusField(property);
+        }
     }
 }
 

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1079,10 +1079,23 @@ void WTrackTableView::keyPressEvent(QKeyEvent* event) {
             if (indices.isEmpty()) {
                 return;
             }
-            // TODO Also pass the index of the focused column so DlgTrackInfo/~Multi
-            // can focus the respective edit field.
             m_pTrackMenu->loadTrackModelIndices(indices);
-            m_pTrackMenu->slotShowDlgTrackInfo();
+            // Pass the name of the focused column to DlgTrackInfo/~Multi
+            // so they can focus the respective edit field.
+            // We use the column of the current index (last focus cell), even
+            // it may not be part of the selection, we just assume it's in the
+            // desired column.
+            const auto currIdx = currentIndex();
+            if (currIdx.isValid()) {
+                const QString columnName = model()->headerData(
+                                                          currIdx.column(),
+                                                          Qt::Horizontal,
+                                                          TrackModel::kHeaderNameRole)
+                                                   .toString();
+                m_pTrackMenu->showDlgTrackInfo(columnName);
+            } else {
+                m_pTrackMenu->slotShowDlgTrackInfo();
+            }
         }
         return;
     }


### PR DESCRIPTION
Just a small helper for the editing workflow.
(it's just the equivalent to the flow with the track labels in decks, see
https://github.com/mixxxdj/mixxx/blob/938cc311cd1a5f8e691691f6bbe044d8392548f6/src/widget/wtrackproperty.cpp#L187-L195)
* in the tracks table the 'Comment' column is focused
* hit Ctrl+Enter to open Track Properties (one or more tracks)
* Track Properties opens and keyboard focus is on the Comment field