### PR TITLE
chore: Fix pre-commit on F41 and update remaining dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,7 +73,7 @@ repos:
         files: \.m?[jt]s$
         types: [file]
         stages:
-          - commit
+          - pre-commit
           - manual
         additional_dependencies:
           - eslint@^8.48.0
@@ -89,7 +89,7 @@ repos:
         entry: python tools/clang_format.py
         require_serial: true
         stages:
-          - commit
+          - pre-commit
           - manual
         language: python
         additional_dependencies:
@@ -141,7 +141,7 @@ repos:
         types: [text]
         files: ^.*\.qss$
         stages:
-          - commit
+          - pre-commit
           - manual
       - id: changelog
         name: changelog

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,8 +76,8 @@ repos:
           - pre-commit
           - manual
         additional_dependencies:
-          - eslint@^8.48.0
-          - eslint-plugin-jsdoc@^v46.5.1
+          - eslint@^9.14.0
+          - eslint-plugin-jsdoc@^v50.4.3
           - "@typescript-eslint/eslint-plugin"
           - "@typescript-eslint/parser"
           - eslint-plugin-diff@^2.0.3
@@ -93,7 +93,7 @@ repos:
           - manual
         language: python
         additional_dependencies:
-          - clang-format==16.0.6
+          - clang-format==19.1.3
         files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|m|mm|proto|vert)$
   - repo: https://github.com/psf/black
     rev: 24.10.0
@@ -165,8 +165,8 @@ repos:
         pass_filenames: false
         language: python
         additional_dependencies:
-          - beautifulsoup4==4.11.1
-          - lxml==4.9.3
-          - Markdown==3.4.1
+          - beautifulsoup4==4.12.3
+          - lxml==5.3.0
+          - Markdown==3.7
         types: [text]
         files: ^(CHANGELOG\.md|res/linux/org\.mixxx\.Mixxx\.metainfo.xml)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ default_language_version:
   rust: 1.64.0
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: fix-byte-order-marker
         exclude: ^.*(\.cbproj|\.groupproj|\.props|\.sln|\.vcxproj|\.vcxproj.filters|UTF-8-BOM.txt)$
@@ -66,7 +66,7 @@ repos:
           ]
         exclude: ^(packaging/wix/LICENSE.rtf.in|src/dialog/dlgabout\.cpp|.*\.(?:pot?|(?<!d\.)ts|wxl|svg))$
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v9.8.0
+    rev: v9.14.0
     hooks:
       - id: eslint
         args: [--fix, --report-unused-disable-directives]
@@ -96,12 +96,12 @@ repos:
           - clang-format==16.0.6
         files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|m|mm|proto|vert)$
   - repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 24.10.0
     hooks:
       - id: black
         files: ^tools/.*$
   - repo: https://github.com/pycqa/flake8
-    rev: "7.1.0"
+    rev: "7.1.1"
     hooks:
       - id: flake8
         files: ^tools/.*$
@@ -111,11 +111,11 @@ repos:
     hooks:
       - id: shellcheck
   - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.13.0
+    rev: v0.14.0
     hooks:
       - id: markdownlint-cli2
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.29.1
+    rev: 0.29.4
     hooks:
       - id: check-github-workflows
   - repo: https://github.com/pre-commit/mirrors-prettier


### PR DESCRIPTION
Edit: this also updates the internal dependencies to be reasonably up-to-date enough to even successfully install. otherwise `lxml` doesn't compile on Fedora 41. Essentially without this PR, developing on Fedora is broken and thus we should merge this reasonably quickly. 

newer Pre-commit versions issue warnings about our config using outdated stage names. This fixes to be complaint to pre-commit v4.

> [WARNING] hook id `eslint` uses deprecated stage names (commit) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
