### PR TITLE
Fix talkover ducking bug

### DIFF
--- a/src/engine/enginemixer.cpp
+++ b/src/engine/enginemixer.cpp
@@ -40,6 +40,7 @@ EngineMixer::EngineMixer(
           m_boothGainOld(0.0),
           m_headphoneMainGainOld(0.0),
           m_headphoneGainOld(1.0),
+          m_duckingGainOld(1.0),
           m_balleftOld(1.0),
           m_balrightOld(1.0),
           m_numMicsConfigured(0),
@@ -530,12 +531,8 @@ void EngineMixer::process(const int iBufferSize) {
 
     // Make the mix for each crossfader orientation output bus.
     // m_mainGain takes care of applying the attenuation from
-    // channel volume faders, crossfader, and talkover ducking.
-    // Talkover is mixed in later according to the configured MicMonitorMode
-    m_mainGain.setGains(crossfaderLeftGain,
-            1.0f,
-            crossfaderRightGain,
-            m_pTalkoverDucking->getGain(iFrames));
+    // channel volume faders and crossfader.
+    m_mainGain.setGains(crossfaderLeftGain, 1.0f, crossfaderRightGain);
 
     for (int o = EngineChannel::LEFT; o <= EngineChannel::RIGHT; o++) {
         ChannelMixer::applyEffectsInPlaceAndMixChannels(m_mainGain,
@@ -608,6 +605,13 @@ void EngineMixer::process(const int iBufferSize) {
             // buffers within the same callback.
             applyMainEffects(iBufferSize);
 
+            // Apply talkover ducking gain after applying effects in order to
+            // avoid ducking neutralization by some effects (e.g. compressor or
+            // AGC)
+            CSAMPLE_GAIN duckingGain = m_pTalkoverDucking->getGain(iFrames);
+            SampleUtil::applyRampingGain(m_main.data(), m_duckingGainOld, duckingGain, iBufferSize);
+            m_duckingGainOld = duckingGain;
+
             if (headphoneEnabled) {
                 processHeadphones(mainMixGainInHeadphones, iBufferSize);
             }
@@ -647,6 +651,13 @@ void EngineMixer::process(const int iBufferSize) {
             // within the same callback. For consistency between the MicMonitorModes,
             // process main effects here before mixing in talkover.
             applyMainEffects(iBufferSize);
+
+            // Apply talkover ducking gain after applying effects in order to
+            // avoid ducking neutralization by some effects (e.g. compressor or
+            // AGC)
+            CSAMPLE_GAIN duckingGain = m_pTalkoverDucking->getGain(iFrames);
+            SampleUtil::applyRampingGain(m_main.data(), m_duckingGainOld, duckingGain, iBufferSize);
+            m_duckingGainOld = duckingGain;
 
             if (headphoneEnabled) {
                 processHeadphones(mainMixGainInHeadphones, iBufferSize);
@@ -705,6 +716,13 @@ void EngineMixer::process(const int iBufferSize) {
             // record/broadcast signal so the record/broadcast signal is the same
             // as what is heard on the main & booth outputs.
             applyMainEffects(iBufferSize);
+
+            // Apply talkover ducking gain after applying effects in order to
+            // avoid ducking neutralization by some effects (e.g. compressor or
+            // AGC)
+            CSAMPLE_GAIN duckingGain = m_pTalkoverDucking->getGain(iFrames);
+            SampleUtil::applyRampingGain(m_main.data(), m_duckingGainOld, duckingGain, iBufferSize);
+            m_duckingGainOld = duckingGain;
 
             if (headphoneEnabled) {
                 processHeadphones(mainMixGainInHeadphones, iBufferSize);

--- a/src/engine/enginemixer.h
+++ b/src/engine/enginemixer.h
@@ -155,8 +155,7 @@ class EngineMixer : public QObject, public AudioSource {
         OrientationVolumeGainCalculator()
                 : m_dLeftGain(1.0),
                   m_dCenterGain(1.0),
-                  m_dRightGain(1.0),
-                  m_dTalkoverDuckingGain(1.0) {
+                  m_dRightGain(1.0) {
         }
 
         inline CSAMPLE_GAIN getGain(ChannelInfo* pChannelInfo) const override {
@@ -167,24 +166,21 @@ class EngineMixer : public QObject, public AudioSource {
                     m_dLeftGain,
                     m_dCenterGain,
                     m_dRightGain);
-            return channelVolume * orientationGain * m_dTalkoverDuckingGain;
+            return channelVolume * orientationGain;
         }
 
         inline void setGains(CSAMPLE_GAIN leftGain,
                 CSAMPLE_GAIN centerGain,
-                CSAMPLE_GAIN rightGain,
-                CSAMPLE_GAIN talkoverDuckingGain) {
+                CSAMPLE_GAIN rightGain) {
             m_dLeftGain = leftGain;
             m_dCenterGain = centerGain;
             m_dRightGain = rightGain;
-            m_dTalkoverDuckingGain = talkoverDuckingGain;
         }
 
       private:
         CSAMPLE_GAIN m_dLeftGain;
         CSAMPLE_GAIN m_dCenterGain;
         CSAMPLE_GAIN m_dRightGain;
-        CSAMPLE_GAIN m_dTalkoverDuckingGain;
     };
 
     enum class MicMonitorMode {
@@ -329,6 +325,7 @@ class EngineMixer : public QObject, public AudioSource {
     CSAMPLE_GAIN m_boothGainOld;
     CSAMPLE_GAIN m_headphoneMainGainOld;
     CSAMPLE_GAIN m_headphoneGainOld;
+    CSAMPLE_GAIN m_duckingGainOld;
     CSAMPLE_GAIN m_balleftOld;
     CSAMPLE_GAIN m_balrightOld;
     std::atomic<unsigned int> m_numMicsConfigured;


### PR DESCRIPTION
This is a small fix for microphone talkover ducking bug. The idea is just to apply ducking after applying effects in order to avoid ducking neutralization by some of the effects (for example compressor).
Fixes #12451 