### PR TITLE
(fix) skin reload: store new color scheme

### DIFF
--- a/src/preferences/dialog/dlgprefinterface.cpp
+++ b/src/preferences/dialog/dlgprefinterface.cpp
@@ -513,6 +513,7 @@ void DlgPrefInterface::slotApply() {
         emit reloadUserInterface();
         // Allow switching skins multiple times without closing the dialog
         m_skinNameOnUpdate = m_pSkin->name();
+        m_colorSchemeOnUpdate = m_colorScheme;
     }
 }
 


### PR DESCRIPTION
It wasn't stored, so Apply/Okay did not reload the skin with the new scheme.

I thought we already fixed that earlier, but it simply slipped through in #11853 