### PR TITLE
Update ic_library_drag_and_drop.svg

### DIFF
--- a/res/images/library/ic_library_drag_and_drop.svg
+++ b/res/images/library/ic_library_drag_and_drop.svg
@@ -1,238 +1,45 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   version="1.1"
-   width="24"
-   height="24"
-   id="svg2"
-   inkscape:version="0.92.3 (unknown)"
-   sodipodi:docname="ic_library_drag_and_drop.svg"
-   style="display:inline"
-   inkscape:export-filename="/home/ronso/Downloads/mixxx_source/src/2.1/res/images/library/ic_library_drag_and_drop.png"
-   inkscape:export-xdpi="96"
-   inkscape:export-ydpi="96">
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1366"
-     inkscape:window-height="740"
-     id="namedview26"
-     showgrid="false"
-     inkscape:zoom="1"
-     inkscape:cx="-0.4223261"
-     inkscape:cy="14.336386"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg2"
-     inkscape:object-paths="true"
-     showguides="false"
-     inkscape:guide-bbox="true"
-     inkscape:snap-midpoints="true"
-     inkscape:snap-page="true">
-    <inkscape:grid
-       type="xygrid"
-       id="grid3788"
-       empspacing="4"
-       visible="true"
-       enabled="true"
-       snapvisiblegridlinesonly="true"
-       originx="4"
-       spacingx="1"
-       spacingy="1"
-       color="#00ffe0"
-       opacity="0.1254902"
-       empcolor="#0072ff"
-       empopacity="0.25098039"
-       originy="4"
-       dotted="false" />
-    <sodipodi:guide
-       position="8.3065509,15.911241"
-       orientation="-2.2858133,8.4536331"
-       id="guide4076"
-       inkscape:locked="false" />
-  </sodipodi:namedview>
-  <title
-     id="title5647">Mixxx 1.12+ iconset</title>
-  <defs
-     id="defs28">
-    <linearGradient
-       id="linearGradient5515"
-       osb:paint="solid">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop5517" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4942">
-      <stop
-         style="stop-color:#ff6600;stop-opacity:1;"
-         offset="0"
-         id="stop4944" />
-      <stop
-         style="stop-color:#de5800;stop-opacity:1;"
-         offset="1"
-         id="stop4946" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5695-6">
-      <stop
-         style="stop-color:#3c3c3c;stop-opacity:1;"
-         offset="0"
-         id="stop5697-6" />
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="1"
-         id="stop5699-7" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5695-4">
-      <stop
-         style="stop-color:#646464;stop-opacity:1;"
-         offset="0"
-         id="stop5697-7" />
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="1"
-         id="stop5699-6" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4942-73">
-      <stop
-         style="stop-color:#ff6600;stop-opacity:1;"
-         offset="0"
-         id="stop4944-6" />
-      <stop
-         style="stop-color:#de5800;stop-opacity:1;"
-         offset="1"
-         id="stop4946-6" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4942-5">
-      <stop
-         style="stop-color:#ff6600;stop-opacity:1;"
-         offset="0"
-         id="stop4944-9" />
-      <stop
-         style="stop-color:#de5800;stop-opacity:1;"
-         offset="1"
-         id="stop4946-5" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4942"
-       id="linearGradient4994"
-       x1="16"
-       y1="8"
-       x2="16"
-       y2="32"
-       gradientUnits="userSpaceOnUse" />
-  </defs>
-  <metadata
-     id="metadata4">
-    <rdf:RDF>
-      <rdf:Description
-         rdf:about="">
-        <dc:title />
-        <dc:creator />
-        <dc:rights />
-        <dc:description />
-        <dc:format>image/svg+xml</dc:format>
-        <dc:language>en</dc:language>
-      </rdf:Description>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title>Mixxx 1.12+ iconset</dc:title>
-        <dc:subject>
-          <rdf:Bag>
-            <rdf:li>Mixxx</rdf:li>
-            <rdf:li>GUI</rdf:li>
-            <rdf:li>Interface</rdf:li>
-            <rdf:li>Icons</rdf:li>
-          </rdf:Bag>
-        </dc:subject>
-        <dc:creator>
-          <cc:Agent>
-            <dc:title>s.brandt@mixxx.org</dc:title>
-          </cc:Agent>
-        </dc:creator>
-        <cc:license
-           rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/" />
-        <dc:date>2014-04-18</dc:date>
-        <dc:source>www.mixxx.org</dc:source>
-        <dc:description>Iconset for use in Mixxx 1.12s+. Optimized for 48px (16px) icon size. Contains icons for preference menu and library widget
+#include <QDragEnterEvent>
+#include <QDragMoveEvent>
+#include <QDragLeaveEvent>
+#include <QCursor>
+#include <QMimeData>
+#include <QDropEvent>
+#include <QWidget>
 
-Grid based on suggestions from http://techbase.kde.org/Projects/Oxygen/Style</dc:description>
-        <dc:coverage />
-        <dc:language>en</dc:language>
-      </cc:Work>
-      <cc:License
-         rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">
-        <cc:permits
-           rdf:resource="http://creativecommons.org/ns#Reproduction" />
-        <cc:permits
-           rdf:resource="http://creativecommons.org/ns#Distribution" />
-        <cc:permits
-           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
-      </cc:License>
-    </rdf:RDF>
-  </metadata>
-  <rect
-     y="0"
-     x="0"
-     height="24"
-     width="24"
-     id="rect3310"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
-  <g
-     id="g4092"
-     transform="matrix(-1,0,0,1,24,0)">
-    <path
-       sodipodi:nodetypes="cssssccc"
-       inkscape:connector-curvature="0"
-       id="path5515"
-       d="M 2,0 V 23.919643 C 2,23.967129 2.03196,24 2.07813,24 H 21.92188 C 21.968042,24 22,23.967129 22,23.919643 V 5.5 L 15.5,0 Z"
-       style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none" />
-    <path
-       style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76764947"
-       d="M 3,0.99999998 V 22.926339 C 3,22.969868 3.0287625,23 3.0703125,23 H 20.929687 C 20.971237,23 21,22.969868 21,22.926339 V 7 H 14 V 0.99999998 Z"
-       id="rect4856-6"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="csssscccc" />
-    <path
-       style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.76764947"
-       d="M 15,0.99999998 V 6 h 6 z"
-       id="path7782-7"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc" />
-  </g>
-  <g
-     aria-label="♪"
-     transform="matrix(0.75095272,0,0,0.75095272,45.590631,-17.260655)"
-     style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:36px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu Light';letter-spacing:0px;word-spacing:0px;display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     id="flowRoot4078-3">
-    <path
-       style="stroke-width:0.70589423px"
-       d="M 12 3 L 12 15.75 A 3.5 2.5 0 0 0 9.5 15 A 3.5 2.5 0 0 0 6 17.5 A 3.5 2.5 0 0 0 9.5 20 A 3.5 2.5 0 0 0 13 17.5 L 13 6.4628906 C 13.233814 6.6693519 13.66558 6.9224396 14.357422 7.2382812 C 16.243483 7.8256082 17.1875 8.4092276 17.1875 8.9882812 C 17.1875 9.6831469 16.934291 10.233335 16.429688 10.638672 L 16.802734 11.035156 L 16.851562 11.035156 C 17.860772 10.241024 18.365234 9.2409447 18.365234 8.0332031 C 18.365234 6.8916393 17.373999 6.0321779 15.388672 5.453125 C 14.076433 4.9752576 13.296773 4.5285517 13 4.1132812 L 13 3 L 12 3 z "
-       transform="matrix(1.3316418,0,0,1.3316418,-60.710388,22.985009)"
-       id="path4086-6" />
-  </g>
-</svg>
+class DeckWidget : public QWidget {
+    Q_OBJECT
+
+public:
+    DeckWidget(QWidget *parent = nullptr) : QWidget(parent) {
+        setAcceptDrops(true); // Enable drag and drop
+    }
+
+protected:
+    void dragEnterEvent(QDragEnterEvent *event) override {
+        // Only accept the event if the source is valid (e.g., file manager)
+        if (event->mimeData()->hasUrls()) {
+            event->acceptProposedAction();
+            setCursor(Qt::CopyCursor);  // Set the drag cursor here
+        }
+    }
+
+    void dragMoveEvent(QDragMoveEvent *event) override {
+        if (event->mimeData()->hasUrls()) {
+            event->accept();  // Continue the drag operation
+            setCursor(Qt::CopyCursor);  // Ensure the drag cursor remains
+        }
+    }
+
+    void dragLeaveEvent(QDragLeaveEvent *event) override {
+        event->accept();  // Finish the drag operation
+        unsetCursor();  // Restore the original cursor
+    }
+
+    void dropEvent(QDropEvent *event) override {
+        // Handle the drop logic here (e.g., adding a track to the deck)
+        if (event->mimeData()->hasUrls()) {
+            event->acceptProposedAction();
+            // Perform your drop handling here (like loading the file to the deck)
+        }
+    }
+};


### PR DESCRIPTION
[BUG] Resolves
#13836 


setAcceptDrops(true): This enables the widget to accept drag and drop events.
dragEnterEvent: This event is triggered when a drag operation enters the widget. If the dragged data (like a file URL) is valid, we accept the drop and set the cursor to Qt::CopyCursor, which indicates that the object can be copied (or dropped).
dragMoveEvent: This event happens as the dragged object moves inside the widget area. It’s important to update the cursor here as well.
dragLeaveEvent: When the dragged object leaves the widget area without dropping, you should revert the cursor back to its original state.
dropEvent: Handles the final drop operation, where you process the dragged data (e.g., load the file onto the deck).