### PR TITLE
fix: prevent double free on DigitsRenderer

### DIFF
--- a/src/waveform/renderers/allshader/digitsrenderer.cpp
+++ b/src/waveform/renderers/allshader/digitsrenderer.cpp
@@ -169,12 +169,12 @@ void allshader::DigitsRenderer::updateTexture(
         blur->setBlurRadius(static_cast<qreal>(m_penWidth) / 3);
 
         QGraphicsScene scene;
-        QGraphicsPixmapItem item;
-        item.setPixmap(QPixmap::fromImage(image));
-        item.setGraphicsEffect(blur.release());
+        auto item = std::make_unique<QGraphicsPixmapItem>();
+        item->setPixmap(QPixmap::fromImage(image));
+        item->setGraphicsEffect(blur.release());
         image.fill(Qt::transparent);
         QPainter painter(&image);
-        scene.addItem(&item);
+        scene.addItem(item.release());
         scene.render(&painter, QRectF(), QRectF(0, 0, image.width(), image.height()));
     }
 


### PR DESCRIPTION
`QGraphicsScene` [takes ownership](https://doc.qt.io/qt-6/qgraphicsscene.html#addItem) of added item. 

```
==1380748==ERROR: AddressSanitizer: negative-size-param: (size=-8)
[Detaching after fork from child process 1381537]
    #0 0x5555564f552e in memmove (/home/antoine/dev/mixxx/build/mixxx+0xfa152e)
(BuildId: 13337f5a877adf2ebe4092a9766ba03163c8e15b) #1 0x7ffff5b50dc8 in
QGraphicsScene::~QGraphicsScene()
(/lib/x86_64-linux-gnu/libQt6Widgets.so.6+0x550dc8) (BuildId:
0306bb82622a98068b88cae599deb7f8e1178bb3) #2 0x5555585e1529 in
allshader_sg::DigitsRenderNode::updateTexture(rendergraph_sg::Context*, float,
float, float)
/home/antoine/dev/mixxx/src/waveform/renderers/allshader/digitsrenderer.cpp:185:5
    #3 0x5555585e9dc7 in allshader_sg::WaveformRenderMark::drawUntilMark(float)
/home/antoine/dev/mixxx/src/waveform/renderers/allshader/waveformrendermark.cpp:366:26
    #4 0x5555585e8f33 in allshader_sg::WaveformRenderMark::update()
/home/antoine/dev/mixxx/src/waveform/renderers/allshader/waveformrendermark.cpp:348:9
    #5 0x5555585da2fd in
mixxx::qml::QmlWaveformDisplay::updatePaintNode(QSGNode*,
QQuickItem::UpdatePaintNodeData*)
/home/antoine/dev/mixxx/src/qml/qmlwaveformdisplay.cpp:155:31 #6 0x7ffff50773a7
in QQuickWindowPrivate::updateDirtyNode(QQuickItem*)
(/lib/x86_64-linux-gnu/libQt6Quick.so.6+0x2773a7) (BuildId:
c92febc410525176d423dfbff4dcb58de37e54fa) #7 0x7ffff5077d1a in
QQuickWindowPrivate::updateDirtyNodes()
(/lib/x86_64-linux-gnu/libQt6Quick.so.6+0x277d1a) (BuildId:
c92febc410525176d423dfbff4dcb58de37e54fa) #8 0x7ffff5078ca8 in
QQuickWindowPrivate::syncSceneGraph()
(/lib/x86_64-linux-gnu/libQt6Quick.so.6+0x278ca8) (BuildId:
c92febc410525176d423dfbff4dcb58de37e54fa) #9 0x7ffff5012161 in
QQuickRenderControl::sync() (/lib/x86_64-linux-gnu/libQt6Quick.so.6+0x212161)
(BuildId: c92febc410525176d423dfbff4dcb58de37e54fa) #10 0x5555581257a9 in
ControllerRenderingEngine::renderFrame()
/home/antoine/dev/mixxx/src/controllers/rendering/controllerrenderingengine.cpp:305:9
    #11 0x7ffff17ba555  (/lib/x86_64-linux-gnu/libQt6Core.so.6+0x1ba555)
(BuildId: 10c2c7ccc13f5d4a41be5530fed7514a09239f8d) #12 0x7ffff17a062e in
QObject::event(QEvent*) (/lib/x86_64-linux-gnu/libQt6Core.so.6+0x1a062e)
(BuildId: 10c2c7ccc13f5d4a41be5530fed7514a09239f8d) #13 0x7ffff577fd35 in
QApplicationPrivate::notify_helper(QObject*, QEvent*)
(/lib/x86_64-linux-gnu/libQt6Widgets.so.6+0x17fd35) (BuildId:
0306bb82622a98068b88cae599deb7f8e1178bb3) #14 0x7ffff1753a57 in
QCoreApplication::notifyInternal2(QObject*, QEvent*)
(/lib/x86_64-linux-gnu/libQt6Core.so.6+0x153a57) (BuildId:
10c2c7ccc13f5d4a41be5530fed7514a09239f8d) #15 0x7ffff18bc202 in
QTimerInfoList::activateTimers()
(/lib/x86_64-linux-gnu/libQt6Core.so.6+0x2bc202) (BuildId:
10c2c7ccc13f5d4a41be5530fed7514a09239f8d) #16 0x7ffff197bbfb
(/lib/x86_64-linux-gnu/libQt6Core.so.6+0x37bbfb) (BuildId:
10c2c7ccc13f5d4a41be5530fed7514a09239f8d) #17 0x7ffff551bd3a in
g_main_context_dispatch (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x55d3a)
(BuildId: 224ac2a88b72bc8e2fe8566ee28fae789fc69241) #18 0x7ffff55712b7
(/lib/x86_64-linux-gnu/libglib-2.0.so.0+0xab2b7) (BuildId:
224ac2a88b72bc8e2fe8566ee28fae789fc69241) #19 0x7ffff55193e2 in
g_main_context_iteration (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x533e2)
(BuildId: 224ac2a88b72bc8e2fe8566ee28fae789fc69241) #20 0x7ffff197bead in
QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>)
(/lib/x86_64-linux-gnu/libQt6Core.so.6+0x37bead) (BuildId:
10c2c7ccc13f5d4a41be5530fed7514a09239f8d) #21 0x7ffff1760ada in
QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>)
(/lib/x86_64-linux-gnu/libQt6Core.so.6+0x160ada) (BuildId:
10c2c7ccc13f5d4a41be5530fed7514a09239f8d) #22 0x7ffff184dfdb in QThread::exec()
(/lib/x86_64-linux-gnu/libQt6Core.so.6+0x24dfdb) (BuildId:
10c2c7ccc13f5d4a41be5530fed7514a09239f8d) #23 0x7ffff18bdfce
(/lib/x86_64-linux-gnu/libQt6Core.so.6+0x2bdfce) (BuildId:
10c2c7ccc13f5d4a41be5530fed7514a09239f8d) #24 0x7ffff0e94ac2 in start_thread
nptl/./nptl/pthread_create.c:442:8 #25 0x7ffff0f2684f
misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:81

0x607004965708 is located 40 bytes inside of 66-byte region
[0x6070049656e0,0x607004965722) allocated by thread T185 (ControllerScree) here:
    #0 0x55555655ea46 in realloc (/home/antoine/dev/mixxx/build/mixxx+0x100aa46)
(BuildId: 13337f5a877adf2ebe4092a9766ba03163c8e15b) #1 0x7ffff185dd14 in
QArrayData::reallocateUnaligned(QArrayData*, void*, long long, long long,
QArrayData::AllocationOption) (/lib/x86_64-linux-gnu/libQt6Core.so.6+0x25dd14)
(BuildId: 10c2c7ccc13f5d4a41be5530fed7514a09239f8d)

Thread T199 (ControllerScree) created by T59 (Controller) here:
    #0 0x555556547a9c in pthread_create
(/home/antoine/dev/mixxx/build/mixxx+0xff3a9c) (BuildId:
13337f5a877adf2ebe4092a9766ba03163c8e15b) #1 0x7ffff18bd9dd in
QThread::start(QThread::Priority)
(/lib/x86_64-linux-gnu/libQt6Core.so.6+0x2bd9dd) (BuildId:
10c2c7ccc13f5d4a41be5530fed7514a09239f8d)

Thread T59 (Controller) created by T0 here:
    #0 0x555556547a9c in pthread_create
(/home/antoine/dev/mixxx/build/mixxx+0xff3a9c) (BuildId:
13337f5a877adf2ebe4092a9766ba03163c8e15b) #1 0x7ffff18bd9dd in
QThread::start(QThread::Priority)
(/lib/x86_64-linux-gnu/libQt6Core.so.6+0x2bd9dd) (BuildId:
10c2c7ccc13f5d4a41be5530fed7514a09239f8d)

Thread T185 (ControllerScree) created by T59 (Controller) here:
    #0 0x555556547a9c in pthread_create
(/home/antoine/dev/mixxx/build/mixxx+0xff3a9c) (BuildId:
13337f5a877adf2ebe4092a9766ba03163c8e15b) #1 0x7ffff18bd9dd in
QThread::start(QThread::Priority)
(/lib/x86_64-linux-gnu/libQt6Core.so.6+0x2bd9dd) (BuildId:
10c2c7ccc13f5d4a41be5530fed7514a09239f8d)

SUMMARY: AddressSanitizer: negative-size-param
(/home/antoine/dev/mixxx/build/mixxx+0xfa152e) (BuildId:
13337f5a877adf2ebe4092a9766ba03163c8e15b) in memmove
```