### PR TITLE
use atomic to fix tsan detected data race condition of blink value in control indicator

### DIFF
--- a/src/control/controlindicator.h
+++ b/src/control/controlindicator.h
@@ -35,7 +35,7 @@ class ControlIndicator : public ControlObject {
     };
 
   private:
-    enum BlinkValue m_blinkValue;
+    std::atomic<BlinkValue> m_blinkValue;
     parented_ptr<ControlProxy> m_pCOIndicator250millis;
     parented_ptr<ControlProxy> m_pCOIndicator500millis;
 };


### PR DESCRIPTION
Fixes #13874