### PR TITLE
Reimplement fifo as a proper lock free SCSP ring buffer 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2108,6 +2108,7 @@ add_executable(mixxx-test
   src/test/enginemixertest.cpp
   src/test/enginemicrophonetest.cpp
   src/test/enginesynctest.cpp
+  src/test/fifotest.cpp
   src/test/fileinfo_test.cpp
   src/test/frametest.cpp
   src/test/globaltrackcache_test.cpp

--- a/src/test/fifotest.cpp
+++ b/src/test/fifotest.cpp
@@ -75,10 +75,19 @@ TEST_P(FifoTest, flushReadTest) {
 
     ASSERT_EQ(0, fifo.readAvailable());
     ASSERT_EQ(100, fifo.write(data.data(), 100));
-    ASSERT_EQ((param.offset + 50) % param.expectedBufferSize,
-            fifo.flushReadData(50));
-    ASSERT_EQ((param.offset + 100) % param.expectedBufferSize,
-            fifo.flushReadData(1000000));
+
+    int expected;
+    expected = (param.offset + 50) % param.expectedBufferSize;
+    if (expected < 0) {
+        expected += param.expectedBufferSize;
+    }
+    ASSERT_EQ(expected, fifo.flushReadData(50));
+
+    expected = (param.offset + 100) % param.expectedBufferSize;
+    if (expected < 0) {
+        expected += param.expectedBufferSize;
+    }
+    ASSERT_EQ(expected, fifo.flushReadData(1000000));
     ASSERT_EQ(param.expectedBufferSize, fifo.write(data.data(), 1000000));
     ASSERT_EQ(param.expectedBufferSize, fifo.readAvailable());
 }

--- a/src/test/fifotest.cpp
+++ b/src/test/fifotest.cpp
@@ -8,8 +8,8 @@
 namespace {
 
 struct Param {
-    std::size_t requestedBufferSize;
-    std::size_t expectedBufferSize;
+    int requestedBufferSize;
+    int expectedBufferSize;
     int offset;
 };
 
@@ -56,8 +56,8 @@ TEST_P(FifoTest, readAvailableTest) {
     ASSERT_EQ(100, fifo.readAvailable());
     ASSERT_EQ(50, fifo.read(data.data(), 50));
     ASSERT_EQ(50, fifo.readAvailable());
-    ASSERT_EQ(static_cast<int>(param.expectedBufferSize - 50), fifo.write(data.data(), 1000000));
-    ASSERT_EQ(static_cast<int>(param.expectedBufferSize), fifo.readAvailable());
+    ASSERT_EQ(param.expectedBufferSize - 50, fifo.write(data.data(), 1000000));
+    ASSERT_EQ(param.expectedBufferSize, fifo.readAvailable());
 }
 
 TEST_P(FifoTest, flushReadTest) {
@@ -75,12 +75,12 @@ TEST_P(FifoTest, flushReadTest) {
 
     ASSERT_EQ(0, fifo.readAvailable());
     ASSERT_EQ(100, fifo.write(data.data(), 100));
-    ASSERT_EQ(static_cast<int>((param.offset + 50) % param.expectedBufferSize),
+    ASSERT_EQ((param.offset + 50) % param.expectedBufferSize,
             fifo.flushReadData(50));
-    ASSERT_EQ(static_cast<int>((param.offset + 100) % param.expectedBufferSize),
+    ASSERT_EQ((param.offset + 100) % param.expectedBufferSize,
             fifo.flushReadData(1000000));
-    ASSERT_EQ(static_cast<int>(param.expectedBufferSize), fifo.write(data.data(), 1000000));
-    ASSERT_EQ(static_cast<int>(param.expectedBufferSize), fifo.readAvailable());
+    ASSERT_EQ(param.expectedBufferSize, fifo.write(data.data(), 1000000));
+    ASSERT_EQ(param.expectedBufferSize, fifo.readAvailable());
 }
 
 TEST_P(FifoTest, readWriteStressTest) {
@@ -104,7 +104,7 @@ TEST_P(FifoTest, readWriteStressTest) {
     std::random_device rd;
     std::mt19937 mt(rd());
     std::uniform_int_distribution<int> dist(
-            0, static_cast<int>(param.expectedBufferSize + param.expectedBufferSize / 10));
+            0, param.expectedBufferSize + param.expectedBufferSize / 10);
 
     while (k < 1000000) {
         int n = dist(mt);
@@ -112,10 +112,10 @@ TEST_P(FifoTest, readWriteStressTest) {
         for (int i = 0; i < m; i++) {
             wdata[i] = k++;
         }
-        ASSERT_EQ(static_cast<int>(m), fifo.write(wdata.data(), n));
+        ASSERT_EQ(m, fifo.write(wdata.data(), n));
         n = dist(mt);
         m = std::min(n, fifo.readAvailable());
-        ASSERT_EQ(static_cast<int>(m), fifo.read(rdata.data(), n));
+        ASSERT_EQ(m, fifo.read(rdata.data(), n));
         for (int i = 0; i < m; i++) {
             ASSERT_EQ(j++, rdata[i]);
         }
@@ -152,8 +152,8 @@ TEST_P(FifoTest, readWriteStressTestRegions) {
         ring_buffer_size_t size1;
         uint32_t* ptr2;
         ring_buffer_size_t size2;
-        ASSERT_EQ(static_cast<int>(m), fifo.aquireWriteRegions(n, &ptr1, &size1, &ptr2, &size2));
-        ASSERT_EQ(static_cast<int>(m), size1 + size2);
+        ASSERT_EQ(m, fifo.aquireWriteRegions(n, &ptr1, &size1, &ptr2, &size2));
+        ASSERT_EQ(m, size1 + size2);
         for (int i = 0; i < size1; i++) {
             ptr1[i] = k++;
         }
@@ -163,8 +163,8 @@ TEST_P(FifoTest, readWriteStressTestRegions) {
         fifo.releaseWriteRegions(m);
         n = dist(mt);
         m = std::min(n, fifo.readAvailable());
-        ASSERT_EQ(static_cast<int>(m), fifo.aquireReadRegions(n, &ptr1, &size1, &ptr2, &size2));
-        ASSERT_EQ(static_cast<int>(m), size1 + size2);
+        ASSERT_EQ(m, fifo.aquireReadRegions(n, &ptr1, &size1, &ptr2, &size2));
+        ASSERT_EQ(m, size1 + size2);
         for (int i = 0; i < size1; i++) {
             ASSERT_EQ(j++, ptr1[i]);
         }

--- a/src/test/fifotest.cpp
+++ b/src/test/fifotest.cpp
@@ -1,0 +1,191 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <random>
+
+#include "util/fifo.h"
+
+namespace {
+
+struct Param {
+    std::size_t requestedBufferSize;
+    std::size_t expectedBufferSize;
+    int offset;
+};
+
+class FifoTest : public testing::TestWithParam<Param> {
+};
+
+TEST_P(FifoTest, writeAvailableTest) {
+    const auto param = FifoTest::GetParam();
+    std::vector<float> data(param.requestedBufferSize);
+    FIFO<float> fifo(param.requestedBufferSize);
+    fifo.releaseReadRegions(param.offset >= 0
+                    ? param.offset
+                    : std::numeric_limits<std::size_t>::max() + param.offset +
+                            1);
+    fifo.releaseWriteRegions(param.offset >= 0
+                    ? param.offset
+                    : std::numeric_limits<std::size_t>::max() + param.offset +
+                            1);
+
+    ASSERT_EQ(param.expectedBufferSize, fifo.writeAvailable());
+    ASSERT_EQ(100, fifo.write(data.data(), 100));
+    ASSERT_EQ(param.expectedBufferSize - 100, fifo.writeAvailable());
+    ASSERT_EQ(50, fifo.read(data.data(), 50));
+    ASSERT_EQ(param.expectedBufferSize - 50, fifo.writeAvailable());
+    ASSERT_EQ(param.expectedBufferSize - 50, fifo.write(data.data(), 1000000));
+    ASSERT_EQ(0, fifo.writeAvailable());
+}
+
+TEST_P(FifoTest, readAvailableTest) {
+    const auto param = FifoTest::GetParam();
+    std::vector<float> data(param.requestedBufferSize);
+    FIFO<float> fifo(param.requestedBufferSize);
+    fifo.releaseReadRegions(param.offset >= 0
+                    ? param.offset
+                    : std::numeric_limits<std::size_t>::max() + param.offset +
+                            1);
+    fifo.releaseWriteRegions(param.offset >= 0
+                    ? param.offset
+                    : std::numeric_limits<std::size_t>::max() + param.offset +
+                            1);
+
+    ASSERT_EQ(0, fifo.readAvailable());
+    ASSERT_EQ(100, fifo.write(data.data(), 100));
+    ASSERT_EQ(100, fifo.readAvailable());
+    ASSERT_EQ(50, fifo.read(data.data(), 50));
+    ASSERT_EQ(50, fifo.readAvailable());
+    ASSERT_EQ(static_cast<int>(param.expectedBufferSize - 50), fifo.write(data.data(), 1000000));
+    ASSERT_EQ(static_cast<int>(param.expectedBufferSize), fifo.readAvailable());
+}
+
+TEST_P(FifoTest, flushReadTest) {
+    const auto param = FifoTest::GetParam();
+    std::vector<float> data(param.requestedBufferSize);
+    FIFO<float> fifo(param.requestedBufferSize);
+    fifo.releaseReadRegions(param.offset >= 0
+                    ? param.offset
+                    : std::numeric_limits<std::size_t>::max() + param.offset +
+                            1);
+    fifo.releaseWriteRegions(param.offset >= 0
+                    ? param.offset
+                    : std::numeric_limits<std::size_t>::max() + param.offset +
+                            1);
+
+    ASSERT_EQ(0, fifo.readAvailable());
+    ASSERT_EQ(100, fifo.write(data.data(), 100));
+    ASSERT_EQ(static_cast<int>((param.offset + 50) % param.expectedBufferSize),
+            fifo.flushReadData(50));
+    ASSERT_EQ(static_cast<int>((param.offset + 100) % param.expectedBufferSize),
+            fifo.flushReadData(1000000));
+    ASSERT_EQ(static_cast<int>(param.expectedBufferSize), fifo.write(data.data(), 1000000));
+    ASSERT_EQ(static_cast<int>(param.expectedBufferSize), fifo.readAvailable());
+}
+
+TEST_P(FifoTest, readWriteStressTest) {
+    const auto param = FifoTest::GetParam();
+    std::vector<uint32_t> data(param.expectedBufferSize);
+    FIFO<uint32_t> fifo(param.requestedBufferSize);
+    fifo.releaseReadRegions(param.offset >= 0
+                    ? param.offset
+                    : std::numeric_limits<std::size_t>::max() + param.offset +
+                            1);
+    fifo.releaseWriteRegions(param.offset >= 0
+                    ? param.offset
+                    : std::numeric_limits<std::size_t>::max() + param.offset +
+                            1);
+
+    std::vector<uint32_t> wdata(param.expectedBufferSize + param.expectedBufferSize / 10);
+    std::vector<uint32_t> rdata(param.expectedBufferSize + param.expectedBufferSize / 10);
+    uint32_t k = 0;
+    uint32_t j = 0;
+
+    std::random_device rd;
+    std::mt19937 mt(rd());
+    std::uniform_int_distribution<int> dist(
+            0, static_cast<int>(param.expectedBufferSize + param.expectedBufferSize / 10));
+
+    while (k < 1000000) {
+        int n = dist(mt);
+        int m = std::min(n, fifo.writeAvailable());
+        for (int i = 0; i < m; i++) {
+            wdata[i] = k++;
+        }
+        ASSERT_EQ(static_cast<int>(m), fifo.write(wdata.data(), n));
+        n = dist(mt);
+        m = std::min(n, fifo.readAvailable());
+        ASSERT_EQ(static_cast<int>(m), fifo.read(rdata.data(), n));
+        for (int i = 0; i < m; i++) {
+            ASSERT_EQ(j++, rdata[i]);
+        }
+    }
+}
+
+TEST_P(FifoTest, readWriteStressTestRegions) {
+    const auto param = FifoTest::GetParam();
+    std::vector<uint32_t> data(param.expectedBufferSize);
+    FIFO<uint32_t> fifo(param.requestedBufferSize);
+    fifo.releaseReadRegions(param.offset >= 0
+                    ? param.offset
+                    : std::numeric_limits<std::size_t>::max() + param.offset +
+                            1);
+    fifo.releaseWriteRegions(param.offset >= 0
+                    ? param.offset
+                    : std::numeric_limits<std::size_t>::max() + param.offset +
+                            1);
+
+    std::vector<uint32_t> wdata(param.expectedBufferSize + param.expectedBufferSize / 10);
+    std::vector<uint32_t> rdata(param.expectedBufferSize + param.expectedBufferSize / 10);
+    uint32_t k = 0;
+    uint32_t j = 0;
+
+    std::random_device rd;
+    std::mt19937 mt(rd());
+    std::uniform_int_distribution<int> dist(
+            0, param.expectedBufferSize + param.expectedBufferSize / 10);
+
+    while (k < 1000000) {
+        int n = dist(mt);
+        int m = std::min(n, fifo.writeAvailable());
+        uint32_t* ptr1;
+        ring_buffer_size_t size1;
+        uint32_t* ptr2;
+        ring_buffer_size_t size2;
+        ASSERT_EQ(static_cast<int>(m), fifo.aquireWriteRegions(n, &ptr1, &size1, &ptr2, &size2));
+        ASSERT_EQ(static_cast<int>(m), size1 + size2);
+        for (int i = 0; i < size1; i++) {
+            ptr1[i] = k++;
+        }
+        for (int i = 0; i < size2; i++) {
+            ptr2[i] = k++;
+        }
+        fifo.releaseWriteRegions(m);
+        n = dist(mt);
+        m = std::min(n, fifo.readAvailable());
+        ASSERT_EQ(static_cast<int>(m), fifo.aquireReadRegions(n, &ptr1, &size1, &ptr2, &size2));
+        ASSERT_EQ(static_cast<int>(m), size1 + size2);
+        for (int i = 0; i < size1; i++) {
+            ASSERT_EQ(j++, ptr1[i]);
+        }
+        for (int i = 0; i < size2; i++) {
+            ASSERT_EQ(j++, ptr2[i]);
+        }
+        fifo.releaseReadRegions(m);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(FifoTestSuite,
+        FifoTest,
+        testing::Values(
+                Param{1024, 1024, 0},
+                Param{1024, 1024, 1200},
+                Param{1024, 1024, -1200},
+                Param{65536, 65536, 0},
+                Param{65536, 65536, 1200},
+                Param{65536, 65536, -1200},
+                Param{1234, 2048, 0},
+                Param{1234, 2048, -1200},
+                Param{1234, 2048, 1200}));
+
+} // namespace

--- a/src/util/fifo.h
+++ b/src/util/fifo.h
@@ -1,69 +1,164 @@
 #pragma once
 
-#include "pa_ringbuffer.h"
+#include <cstddef>
 
 #include "util/class.h"
 #include "util/math.h"
 
+// Fast, trivial type only single producer single consumer ring buffer, lock and wait free.
+// Internal buffer size will be rounded up to a power of two.
+
+// Internally we use std::size_t, but the original API used int for the return values.
+// It would be better to use std::size_t also for the return values, but this breaks
+// Windows compilation and should be done in a follow-up PR.
+using ring_buffer_size_t = int;
+
 template <class DataType>
 class FIFO {
   public:
-    explicit FIFO(int size)
-            : m_data(roundUpToPowerOf2(size)) {
-        // If we can't represent the next higher power of 2 then bail.
-        if (m_data.size() == 0) {
-            return;
-        }
-        PaUtil_InitializeRingBuffer(&m_ringBuffer,
-                static_cast<ring_buffer_size_t>(sizeof(DataType)),
-                static_cast<ring_buffer_size_t>(m_data.size()),
-                m_data.data());
+    using size_type = std::size_t;
+
+    explicit FIFO(size_type size)
+            : m_size{roundUpToPowerOf2(static_cast<unsigned int>(size))},
+              m_mask{m_size - 1},
+              m_data(m_size),
+              m_writeIndex{0},
+              m_readIndex{0} {
     }
-    virtual ~FIFO() {
-    }
+
+    // Returns the number of values in the ringbuffer available for read
     int readAvailable() const {
-        return PaUtil_GetRingBufferReadAvailable(&m_ringBuffer);
+        const size_type readIndex = m_readIndex.load(std::memory_order_relaxed);
+        const size_type writeIndex = m_writeIndex.load(std::memory_order_acquire);
+        return static_cast<int>(writeIndex - readIndex);
     }
+    // Returns the space in the ringbuffer available for write
     int writeAvailable() const {
-        return PaUtil_GetRingBufferWriteAvailable(&m_ringBuffer);
+        const size_type readIndex = m_readIndex.load(std::memory_order_acquire);
+        const size_type writeIndex = m_writeIndex.load(std::memory_order_relaxed);
+        return static_cast<int>(m_size - (writeIndex - readIndex));
     }
-    int read(DataType* pData, int count) {
-        return PaUtil_ReadRingBuffer(&m_ringBuffer, pData, count);
+    // Read count values to the ring buffer. If less then count values are
+    // available, only read the available amount. The return value is the
+    // actual number of values read. If the read index reached the end of the
+    // ringbuffer, the remainder is read from the start.
+    int read(DataType* pData, size_type count) {
+        size_type readIndex = m_readIndex.load(std::memory_order_relaxed);
+        const size_type writeIndex = m_writeIndex.load(std::memory_order_acquire);
+        const size_type available = writeIndex - readIndex;
+        count = std::min(available, count);
+        readIndex = readIndex & m_mask;
+        const size_type n = std::min(m_size - readIndex, count);
+        std::copy(m_data.data() + readIndex, m_data.data() + readIndex + n, pData);
+        std::copy(m_data.data(), m_data.data() + count - n, pData + n);
+        m_readIndex.fetch_add(count, std::memory_order_release);
+        return static_cast<int>(count);
     }
-    int write(const DataType* pData, int count) {
-        return PaUtil_WriteRingBuffer(&m_ringBuffer, pData, count);
+    // Write count samples to the ring buffer. If space available is less then
+    // count, only write the available space amount. The return value is the
+    // actual number of values written. If the write index reached the end of the
+    // ringbuffer, the remainder is written to the start.
+    int write(const DataType* pData, size_type count) {
+        const size_type readIndex = m_readIndex.load(std::memory_order_acquire);
+        size_type writeIndex = m_writeIndex.load(std::memory_order_relaxed);
+        const size_type available = m_size - (writeIndex - readIndex);
+        count = std::min(available, count);
+        writeIndex = writeIndex & m_mask;
+        const size_type n = std::min(m_size - writeIndex, count);
+        std::copy(pData, pData + n, m_data.data() + writeIndex);
+        std::copy(pData + n, pData + count, m_data.data());
+        m_writeIndex.fetch_add(count, std::memory_order_release);
+        return static_cast<int>(count);
     }
-    void writeBlocking(const DataType* pData, int count) {
-        int written = 0;
+    void writeBlocking(const DataType* pData, size_type count) {
+        size_type written = 0;
         while (written < count) {
             written += write(pData + written, count - written);
         }
     }
-    int aquireWriteRegions(int count,
-            DataType** dataPtr1, ring_buffer_size_t* sizePtr1,
-            DataType** dataPtr2, ring_buffer_size_t* sizePtr2) {
-        return PaUtil_GetRingBufferWriteRegions(&m_ringBuffer, count,
-                (void**)dataPtr1, sizePtr1, (void**)dataPtr2, sizePtr2);
+    // Give direct access to the ring buffer at the read index
+    // to a region of count values. If less than count values
+    // are available, limit to the available amount.
+    // If the region surpasses the end of the ring buffer,
+    // the first region will be until the end, the second
+    // region will be the remainder from the start, otherwise
+    // the second region will be nullptr and size 0.
+    int aquireReadRegions(size_type count,
+            DataType** dataPtr1,
+            int* sizePtr1,
+            DataType** dataPtr2,
+            int* sizePtr2) {
+        size_type readIndex = m_readIndex.load(std::memory_order_relaxed);
+        const size_type writeIndex = m_writeIndex.load(std::memory_order_acquire);
+        const size_type available = writeIndex - readIndex;
+        count = std::min(available, count);
+        readIndex = readIndex & m_mask;
+        *sizePtr1 = static_cast<int>(std::min(m_size - readIndex, count));
+        *sizePtr2 = static_cast<int>(count) - *sizePtr1;
+        *dataPtr1 = m_data.data() + readIndex;
+        *dataPtr2 = *sizePtr2 == 0 ? nullptr : m_data.data();
+
+        return count;
     }
-    int releaseWriteRegions(int count) {
-        return PaUtil_AdvanceRingBufferWriteIndex(&m_ringBuffer, count);
+    // Advance the read index after aquireReadRegions. Count should
+    // be the return value of aquireReadRegions, which is the total
+    // region size acquired.
+    int releaseReadRegions(size_type count) {
+        const size_type readIndex = (m_readIndex.load(std::memory_order_relaxed) + count);
+        m_readIndex.store(readIndex, std::memory_order_release);
+        return static_cast<int>(readIndex & m_mask);
     }
-    int aquireReadRegions(int count,
-            DataType** dataPtr1, ring_buffer_size_t* sizePtr1,
-            DataType** dataPtr2, ring_buffer_size_t* sizePtr2) {
-        return PaUtil_GetRingBufferReadRegions(&m_ringBuffer, count,
-                (void**)dataPtr1, sizePtr1, (void**)dataPtr2, sizePtr2);
+    // Same as aquireReadRegions, for write operations
+    int aquireWriteRegions(size_type count,
+            DataType** dataPtr1,
+            int* sizePtr1,
+            DataType** dataPtr2,
+            int* sizePtr2) {
+        const size_type readIndex = m_readIndex.load(std::memory_order_acquire);
+        size_type writeIndex = m_writeIndex.load(std::memory_order_relaxed);
+        const size_type available = m_size - (writeIndex - readIndex);
+        count = std::min(available, count);
+        writeIndex = writeIndex & m_mask;
+        *sizePtr1 = static_cast<int>(std::min(m_size - writeIndex, count));
+        *sizePtr2 = static_cast<int>(count) - *sizePtr1;
+        *dataPtr1 = m_data.data() + writeIndex;
+        *dataPtr2 = *sizePtr2 == 0 ? nullptr : m_data.data();
+
+        return static_cast<int>(count);
     }
-    int releaseReadRegions(int count) {
-        return PaUtil_AdvanceRingBufferReadIndex(&m_ringBuffer, count);
+    // Same as releaseReadRegions, for write operations
+    int releaseWriteRegions(size_type count) {
+        const size_type writeIndex = (m_writeIndex.load(std::memory_order_relaxed) + count);
+        m_writeIndex.store(writeIndex, std::memory_order_release);
+        return static_cast<int>(writeIndex & m_mask);
     }
-    int flushReadData(int count) {
-        int flush = math_min(readAvailable(), count);
-        return PaUtil_AdvanceRingBufferReadIndex(&m_ringBuffer, flush);
+    // Advance the read index with count values, or maximum until the write index.
+    // Returns the new read index (wrapped inside the buffer size)
+    int flushReadData(size_type count) {
+        size_type readIndex = m_readIndex.load(std::memory_order_relaxed);
+        const size_type writeIndex = m_writeIndex.load(std::memory_order_acquire);
+        const size_type available = writeIndex - readIndex;
+        count = std::min(available, count);
+        readIndex += count;
+        m_readIndex.store(readIndex, std::memory_order_release);
+        return static_cast<int>(readIndex & m_mask);
     }
 
   private:
+    const size_type m_size;
+    const size_type m_mask;
     std::vector<DataType> m_data;
-    PaUtilRingBuffer m_ringBuffer;
+    std::atomic<size_type> m_writeIndex;
+    std::atomic<size_type> m_readIndex;
+    // The memory order have the atomic has to be guaranteed:
+    // - The read functions have to use memory_order_acquire to access the write
+    //   index, while the write functions, which modify the write index, have to
+    //   use memory_order_release. This is to ensure that the read function will
+    //   not see the write index before it has been modified.
+    // - Vice versa the read index has to be accessed with memory_order_acquire
+    //   in the write functions and changed with memory_order_release.
+    // - All other access can be memory_order_relaxed as no other operations on
+    //   the atomics take place in between the operations described above.
+
     DISALLOW_COPY_AND_ASSIGN(FIFO);
 };

--- a/src/util/fifo.h
+++ b/src/util/fifo.h
@@ -1,9 +1,88 @@
 #pragma once
 
+#include <atomic>
 #include <cstddef>
 
+#include "pa_ringbuffer.h"
 #include "util/class.h"
 #include "util/math.h"
+
+namespace PA {
+template<class DataType>
+class FIFO {
+  public:
+    explicit FIFO(int size)
+            : m_data(roundUpToPowerOf2(size)) {
+        // If we can't represent the next higher power of 2 then bail.
+        if (m_data.size() == 0) {
+            return;
+        }
+        PaUtil_InitializeRingBuffer(&m_ringBuffer,
+                static_cast<ring_buffer_size_t>(sizeof(DataType)),
+                static_cast<ring_buffer_size_t>(m_data.size()),
+                m_data.data());
+    }
+    virtual ~FIFO() {
+    }
+    int readAvailable() const {
+        return PaUtil_GetRingBufferReadAvailable(&m_ringBuffer);
+    }
+    int writeAvailable() const {
+        return PaUtil_GetRingBufferWriteAvailable(&m_ringBuffer);
+    }
+    int read(DataType* pData, int count) {
+        return PaUtil_ReadRingBuffer(&m_ringBuffer, pData, count);
+    }
+    int write(const DataType* pData, int count) {
+        return PaUtil_WriteRingBuffer(&m_ringBuffer, pData, count);
+    }
+    void writeBlocking(const DataType* pData, int count) {
+        int written = 0;
+        while (written < count) {
+            written += write(pData + written, count - written);
+        }
+    }
+    int aquireWriteRegions(int count,
+            DataType** dataPtr1,
+            ring_buffer_size_t* sizePtr1,
+            DataType** dataPtr2,
+            ring_buffer_size_t* sizePtr2) {
+        return PaUtil_GetRingBufferWriteRegions(&m_ringBuffer,
+                count,
+                (void**)dataPtr1,
+                sizePtr1,
+                (void**)dataPtr2,
+                sizePtr2);
+    }
+    int releaseWriteRegions(int count) {
+        return PaUtil_AdvanceRingBufferWriteIndex(&m_ringBuffer, count);
+    }
+    int aquireReadRegions(int count,
+            DataType** dataPtr1,
+            ring_buffer_size_t* sizePtr1,
+            DataType** dataPtr2,
+            ring_buffer_size_t* sizePtr2) {
+        return PaUtil_GetRingBufferReadRegions(&m_ringBuffer,
+                count,
+                (void**)dataPtr1,
+                sizePtr1,
+                (void**)dataPtr2,
+                sizePtr2);
+    }
+    int releaseReadRegions(int count) {
+        return PaUtil_AdvanceRingBufferReadIndex(&m_ringBuffer, count);
+    }
+    int flushReadData(int count) {
+        int flush = math_min(readAvailable(), count);
+        return PaUtil_AdvanceRingBufferReadIndex(&m_ringBuffer, flush);
+    }
+
+  private:
+    std::vector<DataType> m_data;
+    PaUtilRingBuffer m_ringBuffer;
+    DISALLOW_COPY_AND_ASSIGN(FIFO);
+};
+} // namespace PA
 
 // Fast, trivial type only single producer single consumer ring buffer, lock and wait free.
 // Internal buffer size will be rounded up to a power of two.
@@ -11,7 +90,7 @@
 // Internally we use std::size_t, but the original API used int for the return values.
 // It would be better to use std::size_t also for the return values, but this breaks
 // Windows compilation and should be done in a follow-up PR.
-using ring_buffer_size_t = int;
+// using ring_buffer_size_t = int;
 
 template <class DataType>
 class FIFO {

--- a/src/util/fifo.h
+++ b/src/util/fifo.h
@@ -98,7 +98,7 @@ class FIFO {
         *dataPtr1 = m_data.data() + readIndex;
         *dataPtr2 = *sizePtr2 == 0 ? nullptr : m_data.data();
 
-        return count;
+        return static_cast<int>(count);
     }
     // Advance the read index after aquireReadRegions. Count should
     // be the return value of aquireReadRegions, which is the total

--- a/src/util/fifo.h
+++ b/src/util/fifo.h
@@ -92,7 +92,7 @@ class FIFO {
 // Windows compilation and should be done in a follow-up PR.
 // using ring_buffer_size_t = int;
 
-template <class DataType>
+template<class DataType>
 class FIFO {
   public:
     using size_type = std::size_t;
@@ -164,9 +164,9 @@ class FIFO {
     // the second region will be nullptr and size 0.
     int aquireReadRegions(size_type count,
             DataType** dataPtr1,
-            int* sizePtr1,
+            ring_buffer_size_t* sizePtr1,
             DataType** dataPtr2,
-            int* sizePtr2) {
+            ring_buffer_size_t* sizePtr2) {
         size_type readIndex = m_readIndex.load(std::memory_order_relaxed);
         const size_type writeIndex = m_writeIndex.load(std::memory_order_acquire);
         const size_type available = writeIndex - readIndex;
@@ -190,9 +190,9 @@ class FIFO {
     // Same as aquireReadRegions, for write operations
     int aquireWriteRegions(size_type count,
             DataType** dataPtr1,
-            int* sizePtr1,
+            ring_buffer_size_t* sizePtr1,
             DataType** dataPtr2,
-            int* sizePtr2) {
+            ring_buffer_size_t* sizePtr2) {
         const size_type readIndex = m_readIndex.load(std::memory_order_acquire);
         size_type writeIndex = m_writeIndex.load(std::memory_order_relaxed);
         const size_type available = m_size - (writeIndex - readIndex);


### PR DESCRIPTION
Reimplement fifo as a proper lock free SCSP ring buffer with atomics for thread-safety instead of using PaUtilRingBuffer as a backend.

Added unit tests.

One might consider that the tsan warnings for PaUtilRingBuffer or not "serious" but they sure are ugly and spam my tsan logs.

Fixes #13864 #13863  #13866 #13868
