### PR TITLE
Fix undefined behaviour of infinity()

### DIFF
--- a/src/test/durationutiltest.cpp
+++ b/src/test/durationutiltest.cpp
@@ -1,10 +1,10 @@
-#include <limits>
-
 #include <gtest/gtest.h>
 
-#include "util/duration.h"
-
 #include <QtDebug>
+#include <limits>
+
+#include "util/duration.h"
+#include "util/fpclassify.h"
 
 namespace {
 
@@ -115,7 +115,7 @@ TEST_F(DurationUtilTest, formatTime) {
     formatTime("24:00:00.000", 24 * 3600);
     formatTime("24:00:01.000", 24 * 3600 + 1);
     formatTime("25:00:01.000", 25 * 3600 + 1);
-    formatTime("?", std::numeric_limits<double>::infinity());
+    formatTime("?", util_double_infinity());
     formatTime("?", -1);
 }
 

--- a/src/test/frametest.cpp
+++ b/src/test/frametest.cpp
@@ -3,6 +3,7 @@
 #include <QDebug>
 
 #include "audio/frame.h"
+#include "util/fpclassify.h"
 
 class FrameTest : public testing::Test {
 };
@@ -18,7 +19,7 @@ TEST_F(FrameTest, TestFramePosValid) {
     // Denormals
     EXPECT_TRUE(mixxx::audio::FramePos(0.0).isValid());
     EXPECT_TRUE(mixxx::audio::FramePos(std::numeric_limits<double>::min() / 2.0).isValid());
-    EXPECT_FALSE(mixxx::audio::FramePos(std::numeric_limits<double>::infinity()).isValid());
+    EXPECT_FALSE(mixxx::audio::FramePos(util_double_infinity()).isValid());
     // NaN
     EXPECT_FALSE(mixxx::audio::FramePos().isValid());
     EXPECT_FALSE(mixxx::audio::FramePos(std::numeric_limits<double>::quiet_NaN()).isValid());
@@ -54,16 +55,12 @@ TEST_F(FrameTest, TestFramePosEquality) {
             mixxx::audio::FramePos(std::numeric_limits<
                     mixxx::audio::FramePos::value_t>::quiet_NaN()));
     EXPECT_EQ(mixxx::audio::FramePos(),
-            mixxx::audio::FramePos(std::numeric_limits<
-                    mixxx::audio::FramePos::value_t>::infinity()));
+            mixxx::audio::FramePos(util_double_infinity()));
     EXPECT_EQ(mixxx::audio::FramePos(),
-            mixxx::audio::FramePos(
-                    -std::numeric_limits<
-                            mixxx::audio::FramePos::value_t>::infinity()));
+            mixxx::audio::FramePos(-util_double_infinity()));
     EXPECT_EQ(mixxx::audio::FramePos(std::numeric_limits<
                       mixxx::audio::FramePos::value_t>::quiet_NaN()),
-            mixxx::audio::FramePos(std::numeric_limits<
-                    mixxx::audio::FramePos::value_t>::infinity()));
+            mixxx::audio::FramePos(util_double_infinity()));
 }
 
 TEST_F(FrameTest, LowerFrameBoundary) {

--- a/src/test/mathutiltest.cpp
+++ b/src/test/mathutiltest.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <QtDebug>
+#include <cstring>
 
 #include "util/denormalsarezero.h"
 #include "util/fpclassify.h"
@@ -91,15 +92,14 @@ TEST_F(MathUtilTest, Denormal) {
 
 TEST_F(MathUtilTest, DoubleValues) {
     // This verifies that the infinity value can be copied into -ffastmath code
-    if (std::numeric_limits<double>::is_iec559) {
-        union {
-            long long int_value;
-            double double_value;
-        } inf_union;
-        inf_union.double_value = util_double_infinity();
-        // IEC 559 (IEEE 754) Infinity
-        EXPECT_EQ(inf_union.int_value, 0x7FF0000000000000);
-    }
+
+    // All supported targets are using IEC559 floats
+    static_assert(std::numeric_limits<double>::is_iec559);
+    long long int_value;
+    double double_value = util_double_infinity();
+    std::memcpy(&int_value, &double_value, sizeof(double_value));
+    // IEC 559 (IEEE 754) Infinity
+    EXPECT_EQ(int_value, 0x7FF0000000000000);
 }
 
 }  // namespace

--- a/src/test/mathutiltest.cpp
+++ b/src/test/mathutiltest.cpp
@@ -1,9 +1,9 @@
 #include <gtest/gtest.h>
 
 #include <QtDebug>
-#include <limits>
 
 #include "util/denormalsarezero.h"
+#include "util/fpclassify.h"
 #include "util/math.h"
 
 namespace {
@@ -51,11 +51,11 @@ TEST_F(MathUtilTest, IsNaN) {
 TEST_F(MathUtilTest, IsInf) {
     // Test floats can be recognized as infinity.
     EXPECT_FALSE(util_isinf(0.0f));
-    EXPECT_TRUE(util_isinf(std::numeric_limits<float>::infinity()));
+    EXPECT_TRUE(util_isinf(util_float_infinity()));
 
     // Test doubles can be recognized as infinity.
     EXPECT_FALSE(util_isinf(0.0f));
-    EXPECT_TRUE(util_isinf(std::numeric_limits<double>::infinity()));
+    EXPECT_TRUE(util_isinf(util_double_infinity()));
 }
 
 TEST_F(MathUtilTest, Denormal) {

--- a/src/test/mathutiltest.cpp
+++ b/src/test/mathutiltest.cpp
@@ -89,5 +89,17 @@ TEST_F(MathUtilTest, Denormal) {
 #endif
 }
 
+TEST_F(MathUtilTest, DoubleValues) {
+    // This verifies that the infinity value can be copied into -ffastmath code
+    if (std::numeric_limits<double>::is_iec559) {
+        union {
+            long long int_value;
+            double double_value;
+        } inf_union;
+        inf_union.double_value = util_double_infinity();
+        // IEC 559 (IEEE 754) Infinity
+        EXPECT_EQ(inf_union.int_value, 0x7FF0000000000000);
+    }
+}
 
 }  // namespace

--- a/src/util/fpclassify.cpp
+++ b/src/util/fpclassify.cpp
@@ -8,6 +8,7 @@
 #endif
 
 #include <cmath>
+#include <limits>
 
 int util_fpclassify(float x) {
     return std::fpclassify(x);
@@ -47,4 +48,12 @@ int util_isnan(double x) {
 
 int util_isinf(double x) {
     return std::isinf(x);
+}
+
+float util_float_infinity() {
+    return std::numeric_limits<double>::infinity();
+}
+
+double util_double_infinity() {
+    return std::numeric_limits<double>::infinity();
 }

--- a/src/util/fpclassify.h
+++ b/src/util/fpclassify.h
@@ -25,5 +25,10 @@ int util_isnan(double x);
 int util_isinf(float x);
 int util_isinf(double x);
 
+// The following functions are only used in testing code.
+// Don't use them in other -ffast-math code to avoid undefined behavior in
+// floating-point arithmetic where the compiler assumes that arguments and
+// results are not NaNs or +-Infs. For checking external librarie's return
+// values use the appropiated function above.
 float util_float_infinity();
 double util_double_infinity();

--- a/src/util/fpclassify.h
+++ b/src/util/fpclassify.h
@@ -24,3 +24,6 @@ int util_isnan(double x);
 
 int util_isinf(float x);
 int util_isinf(double x);
+
+float util_float_infinity();
+double util_double_infinity();


### PR DESCRIPTION
This fixes the undefined behviour of of `std::numeric_limits<double>::infinity())` in `-ffastmath (-ffinite-math-only)` code. By moving it to fclassify.cpp which is compiled without this flags leading to defined behavior. It makes sure that the IEEE infinity is returned which is `0x7FF0000000000000`. 

Clang 18 warns about this as `use of infinity is undefined behavior due to the currently enabled floating-point options`. This warning may indicate a real issue in case of aggressive optimization. 

This solution not only mutes this warning as `-Wnan-infinity-disabled`. We have argued that we shall not use infinity at all, but we can't entirely prevent it because all UB does not mean infinity does not happen especially when we interact with non `-ffastmath` libraries.    

Fixes: #13780

The discussion around using inf() as invalid value in this is orthogonal. We have test in place that verify that it is working for now. I consider a refactoring of it as unnecessary regression risk, but will not block an attempt. Just let's merge this as a fix for UB.  
