### PR TITLE
AudioUnitBackend: Initialize parameters concurrently and load music effects too

### DIFF
--- a/src/effects/backends/audiounit/audiounitbackend.mm
+++ b/src/effects/backends/audiounit/audiounitbackend.mm
@@ -126,11 +126,11 @@ class AudioUnitBackend : public EffectsBackend {
             });
         }
 
-        int64_t timeoutMs = 10000;
+        const int64_t TIMEOUT_MS = 6000;
 
         qDebug() << "Waiting for audio unit manifests to be loaded...";
         if (dispatch_group_wait(group,
-                    dispatch_time(DISPATCH_TIME_NOW, timeoutMs * 1000000)) ==
+                    dispatch_time(DISPATCH_TIME_NOW, TIMEOUT_MS * 1000000)) ==
                 0) {
             qDebug() << "Successfully loaded audio unit manifests";
         } else {

--- a/src/effects/backends/audiounit/audiounitmanager.h
+++ b/src/effects/backends/audiounit/audiounitmanager.h
@@ -48,6 +48,7 @@ class AudioUnitManager {
   private:
     QString m_name;
     std::atomic<bool> m_isInstantiated;
+    dispatch_group_t _Nonnull m_instantiationGroup;
     AudioUnit _Nullable m_audioUnit;
 
     AudioUnitManager(AVAudioUnitComponent* _Nullable component);

--- a/src/effects/backends/audiounit/audiounitmanager.h
+++ b/src/effects/backends/audiounit/audiounitmanager.h
@@ -43,7 +43,7 @@ class AudioUnitManager {
     ///
     /// Returns true if the audio unit was instantiated successfully and false if
     /// the timeout was reached instead.
-    bool waitForAudioUnit(int timeoutMs);
+    bool waitForAudioUnit(int timeoutMs) const;
 
   private:
     QString m_name;

--- a/src/effects/backends/audiounit/audiounitmanager.h
+++ b/src/effects/backends/audiounit/audiounitmanager.h
@@ -39,6 +39,12 @@ class AudioUnitManager {
     /// want to e.g. block on a mutex.
     AudioUnit _Nullable getAudioUnit() const;
 
+    /// Blocks until the audio unit has been instantiated.
+    ///
+    /// Returns true if the audio unit was instantiated successfully and false if
+    /// the timeout was reached instead.
+    bool waitForAudioUnit(int timeoutMs);
+
   private:
     QString m_name;
     std::atomic<bool> m_isInstantiated;

--- a/src/effects/backends/audiounit/audiounitmanager.mm
+++ b/src/effects/backends/audiounit/audiounitmanager.mm
@@ -58,7 +58,7 @@ AudioUnit _Nullable AudioUnitManager::getAudioUnit() const {
     return m_audioUnit;
 }
 
-bool AudioUnitManager::waitForAudioUnit(int timeoutMs) {
+bool AudioUnitManager::waitForAudioUnit(int timeoutMs) const {
     // NOTE: We use a sleep loop here since both a QWaitCondition and GCD
     // DispatchGroup-based implementation seem to result in spurious crashes.
     // See https://github.com/mixxxdj/mixxx/pull/13887#issuecomment-2486459443

--- a/src/effects/backends/audiounit/audiounitmanifest.mm
+++ b/src/effects/backends/audiounit/audiounitmanifest.mm
@@ -23,7 +23,7 @@ AudioUnitManifest::AudioUnitManifest(
     // Instantiate audio unit (out-of-process) to load parameters
     AudioUnitManagerPointer pManager = AudioUnitManager::create(component);
 
-    const int TIMEOUT_MS = 5000;
+    const int TIMEOUT_MS = 2000;
 
     QElapsedTimer timer;
     timer.start();

--- a/src/effects/backends/audiounit/audiounitmanifest.mm
+++ b/src/effects/backends/audiounit/audiounitmanifest.mm
@@ -24,19 +24,12 @@ AudioUnitManifest::AudioUnitManifest(
     AudioUnitManagerPointer pManager = AudioUnitManager::create(component);
 
     const int TIMEOUT_MS = 2000;
-
-    QElapsedTimer timer;
-    timer.start();
-
-    while (pManager->getAudioUnit() == nil) {
-        if (timer.elapsed() > TIMEOUT_MS) {
-            qWarning() << name() << "took more than" << TIMEOUT_MS
-                       << "ms to initialize, skipping manifest initialization "
-                          "for this effect. This means this effect will not "
-                          "display any parameters and likely not be useful!";
-            return;
-        }
-        QThread::msleep(10);
+    if (!pManager->waitForAudioUnit(TIMEOUT_MS)) {
+        qWarning() << name() << "took more than" << TIMEOUT_MS
+                   << "ms to initialize, skipping manifest initialization "
+                      "for this effect. This means this effect will not "
+                      "display any parameters and likely not be useful!";
+        return;
     }
 
     AudioUnit audioUnit = pManager->getAudioUnit();


### PR DESCRIPTION
### Based on #13945 

This addresses a todo note in the `AudioUnitBackend` implementation:

https://github.com/mixxxdj/mixxx/blob/028e3ff4ee0ca464c7c47faa89a1c12a3e99b4e9/src/effects/backends/audiounit/audiounitbackend.mm#L81-L82

With this PR, Audio Units plugins are now instantiated concurrently and out-of-process during the initial load. This has a few advantages over the current approach of instantiating everything synchronously:

- It's faster. Since all effect manifests are to be loaded synchronously while Mixxx is starting up, doing this concurrently for all plugins potentially improves startup time.
- It's more robust. Currently a bad plugin implementation could crash Mixxx during startup. By doing this out-of-process and adding a timeout, an unstable plugin shouldn't prevent Mixxx from starting up properly.

Additionally, we now load plugins of the category `kAudioUnitType_MusicEffect` (in addition to `kAudioUnitType_Effect`), which are MIDI controllable, but otherwise function just like regular effects. This is useful, since it lets Mixxx discover plugins like ShaperBox, which are marked as music effects.