### PR TITLE
Effects: Add support for GUIs and reference implementation for Audio Unit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1878,7 +1878,10 @@ if(APPLE)
     )
     target_link_libraries(
       mixxx-lib
-      PRIVATE "-weak_framework AudioToolbox" "-weak_framework AVFAudio"
+      PRIVATE
+        "-weak_framework AudioToolbox"
+        "-weak_framework AVFAudio"
+        "-weak_framework CoreAudioKit"
     )
     target_compile_definitions(mixxx-lib PUBLIC __AU_EFFECTS__)
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1875,6 +1875,7 @@ if(APPLE)
         src/effects/backends/audiounit/audiounitmanager.mm
         src/effects/backends/audiounit/audiouniteffectprocessor.mm
         src/effects/backends/audiounit/audiounitmanifest.mm
+        src/effects/backends/audiounit/dlgaudiounit.mm
     )
     target_link_libraries(
       mixxx-lib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1073,6 +1073,7 @@ add_library(
   src/effects/chains/pergroupeffectchain.cpp
   src/effects/chains/quickeffectchain.cpp
   src/effects/chains/standardeffectchain.cpp
+  src/effects/dlgeffect.cpp
   src/effects/effectbuttonparameterslot.cpp
   src/effects/effectchain.cpp
   src/effects/effectchainmixmode.cpp

--- a/res/skins/LateNight/fx/slot_controls.xml
+++ b/res/skins/LateNight/fx/slot_controls.xml
@@ -31,13 +31,23 @@
 
           <Template src="skins:LateNight/fx/focus_button.xml"/>
 
-          <Template src="skins:LateNight/controls/button_2state.xml">
-            <SetVariable name="TooltipId">EffectSlot_uiShown</SetVariable>
-            <SetVariable name="ObjectName">FxUiButton</SetVariable>
-            <SetVariable name="BtnSize">square</SetVariable>
-            <SetVariable name="Size">26f,26f</SetVariable>
-            <SetVariable name="ConfigKey">[<Variable name="FxRack_FxUnit_FxNum"/>],uiShown</SetVariable>
-          </Template>
+          <WidgetGroup>
+            <Layout>vertical</Layout>
+            <SizePolicy>min,min</SizePolicy>
+            <Children>
+              <Template src="skins:LateNight/controls/button_2state.xml">
+                <SetVariable name="TooltipId">EffectSlot_uiShown</SetVariable>
+                <SetVariable name="ObjectName">FxUiButton</SetVariable>
+                <SetVariable name="BtnSize">square</SetVariable>
+                <SetVariable name="Size">26f,26f</SetVariable>
+                <SetVariable name="ConfigKey">[<Variable name="FxRack_FxUnit_FxNum"/>],uiShown</SetVariable>
+              </Template>
+            </Children>
+            <Connection>
+              <ConfigKey persist="true">[Skin],show_effectuibuttons</ConfigKey>
+              <BindProperty>visible</BindProperty>
+            </Connection>
+          </WidgetGroup>
 
           <Template src="skins:LateNight/controls/button_2state.xml">
             <SetVariable name="TooltipId">EffectSlot_enabled</SetVariable>

--- a/res/skins/LateNight/fx/slot_controls.xml
+++ b/res/skins/LateNight/fx/slot_controls.xml
@@ -31,6 +31,14 @@
 
           <Template src="skins:LateNight/fx/focus_button.xml"/>
 
+          <Template src="skins:LateNight/controls/button_2state.xml">
+            <SetVariable name="TooltipId">EffectSlot_enabled</SetVariable>
+            <SetVariable name="ObjectName">FxToggleButton</SetVariable>
+            <SetVariable name="BtnSize">square</SetVariable>
+            <SetVariable name="Size">26f,26f</SetVariable>
+            <SetVariable name="ConfigKey">[<Variable name="FxRack_FxUnit_FxNum"/>],enabled</SetVariable>
+          </Template>
+
           <WidgetGroup>
             <Layout>vertical</Layout>
             <SizePolicy>min,min</SizePolicy>
@@ -58,14 +66,6 @@
               <BindProperty>visible</BindProperty>
             </Connection>
           </WidgetGroup>
-
-          <Template src="skins:LateNight/controls/button_2state.xml">
-            <SetVariable name="TooltipId">EffectSlot_enabled</SetVariable>
-            <SetVariable name="ObjectName">FxToggleButton</SetVariable>
-            <SetVariable name="BtnSize">square</SetVariable>
-            <SetVariable name="Size">26f,26f</SetVariable>
-            <SetVariable name="ConfigKey">[<Variable name="FxRack_FxUnit_FxNum"/>],enabled</SetVariable>
-          </Template>
 
           <Template src="skins:LateNight/fx/meta_knob.xml"/>
 

--- a/res/skins/LateNight/fx/slot_controls.xml
+++ b/res/skins/LateNight/fx/slot_controls.xml
@@ -32,6 +32,14 @@
           <Template src="skins:LateNight/fx/focus_button.xml"/>
 
           <Template src="skins:LateNight/controls/button_2state.xml">
+            <SetVariable name="TooltipId">EffectSlot_uiShown</SetVariable>
+            <SetVariable name="ObjectName">FxUiButton</SetVariable>
+            <SetVariable name="BtnSize">square</SetVariable>
+            <SetVariable name="Size">26f,26f</SetVariable>
+            <SetVariable name="ConfigKey">[<Variable name="FxRack_FxUnit_FxNum"/>],uiShown</SetVariable>
+          </Template>
+
+          <Template src="skins:LateNight/controls/button_2state.xml">
             <SetVariable name="TooltipId">EffectSlot_enabled</SetVariable>
             <SetVariable name="ObjectName">FxToggleButton</SetVariable>
             <SetVariable name="BtnSize">square</SetVariable>

--- a/res/skins/LateNight/fx/slot_controls.xml
+++ b/res/skins/LateNight/fx/slot_controls.xml
@@ -35,13 +35,23 @@
             <Layout>vertical</Layout>
             <SizePolicy>min,min</SizePolicy>
             <Children>
-              <Template src="skins:LateNight/controls/button_2state.xml">
-                <SetVariable name="TooltipId">EffectSlot_ui_shown</SetVariable>
-                <SetVariable name="ObjectName">FxUiButton</SetVariable>
-                <SetVariable name="BtnSize">square</SetVariable>
-                <SetVariable name="Size">26f,26f</SetVariable>
-                <SetVariable name="ConfigKey">[<Variable name="FxRack_FxUnit_FxNum"/>],ui_shown</SetVariable>
-              </Template>
+              <WidgetGroup>
+                <Layout>vertical</Layout>
+                <SizePolicy>min,min</SizePolicy>
+                <Children>
+                  <Template src="skins:LateNight/controls/button_2state.xml">
+                    <SetVariable name="TooltipId">EffectSlot_ui_shown</SetVariable>
+                    <SetVariable name="ObjectName">FxUiButton</SetVariable>
+                    <SetVariable name="BtnSize">square</SetVariable>
+                    <SetVariable name="Size">26f,26f</SetVariable>
+                    <SetVariable name="ConfigKey">[<Variable name="FxRack_FxUnit_FxNum"/>],ui_shown</SetVariable>
+                  </Template>
+                </Children>
+                <Connection>
+                  <ConfigKey persist="true">[<Variable name="FxRack_FxUnit_FxNum"/>],uibutton_shown</ConfigKey>
+                  <BindProperty>visible</BindProperty>
+                </Connection>
+              </WidgetGroup>
             </Children>
             <Connection>
               <ConfigKey persist="true">[Skin],show_effectuibuttons</ConfigKey>

--- a/res/skins/LateNight/fx/slot_controls.xml
+++ b/res/skins/LateNight/fx/slot_controls.xml
@@ -36,11 +36,11 @@
             <SizePolicy>min,min</SizePolicy>
             <Children>
               <Template src="skins:LateNight/controls/button_2state.xml">
-                <SetVariable name="TooltipId">EffectSlot_uiShown</SetVariable>
+                <SetVariable name="TooltipId">EffectSlot_ui_shown</SetVariable>
                 <SetVariable name="ObjectName">FxUiButton</SetVariable>
                 <SetVariable name="BtnSize">square</SetVariable>
                 <SetVariable name="Size">26f,26f</SetVariable>
-                <SetVariable name="ConfigKey">[<Variable name="FxRack_FxUnit_FxNum"/>],uiShown</SetVariable>
+                <SetVariable name="ConfigKey">[<Variable name="FxRack_FxUnit_FxNum"/>],ui_shown</SetVariable>
               </Template>
             </Children>
             <Connection>

--- a/res/skins/LateNight/palemoon/buttons/btn__fx_ui.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__fx_ui.svg
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="44"
+   height="44"
+   version="1.1"
+   viewBox="0 0 22 22"
+   id="svg4"
+   sodipodi:docname="btn__fx_ui.svg"
+   inkscape:version="1.4 (e7c3feb1, 2024-10-09)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="namedview4"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="4.7045455"
+     inkscape:cx="-11.797101"
+     inkscape:cy="7.6521739"
+     inkscape:window-width="1824"
+     inkscape:window-height="977"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4" />
+  <g
+     transform="matrix(0.881636,0,0,0.882853,1.4147372,5.2834623)"
+     fill="#918273"
+     stroke-width="1.13347"
+     id="g4"
+     style="stroke-width:6.30494304;stroke-dasharray:none">
+    <rect
+       style="fill:#918273;fill-opacity:1;stroke:#000000;stroke-width:1.36866853;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       id="rect5"
+       width="15.188016"
+       height="15.167079"
+       x="3.2781239"
+       y="-1.1084664" />
+    <ellipse
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:4.23432;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       id="path5"
+       cx="6.2788553"
+       cy="1.7373904"
+       rx="1.0548562"
+       ry="1.0534021" />
+    <ellipse
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:4.23432;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       id="path5-9"
+       cx="8.8360825"
+       cy="1.7373904"
+       rx="1.0548562"
+       ry="1.0534021" />
+    <ellipse
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:4.23432;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       id="path5-9-6"
+       cx="11.39331"
+       cy="1.7373904"
+       rx="1.0548562"
+       ry="1.0534021" />
+  </g>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__fx_ui_active.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__fx_ui_active.svg
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="44"
+   height="44"
+   version="1.1"
+   viewBox="0 0 22 22"
+   id="svg4"
+   sodipodi:docname="btn__fx_ui_active.svg"
+   inkscape:version="1.4 (e7c3feb1, 2024-10-09)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="namedview4"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="4.7045455"
+     inkscape:cx="-11.690821"
+     inkscape:cy="7.6521738"
+     inkscape:window-width="1824"
+     inkscape:window-height="977"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4" />
+  <g
+     transform="matrix(0.881636,0,0,0.882853,1.4147372,5.2834623)"
+     fill="#918273"
+     stroke-width="1.13347"
+     id="g4"
+     style="stroke-width:6.30494304;stroke-dasharray:none;fill:#000000;fill-opacity:1">
+    <path
+       id="rect5-7"
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.2546;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       d="M 3.9115282 -0.47593546 L 3.9115282 13.426082 L 17.832735 13.426082 L 17.832735 -0.47593546 L 3.9115282 -0.47593546 z M 6.2786208 0.68440954 A 1.0548562 1.0534021 0 0 1 7.3342311 1.7374586 A 1.0548562 1.0534021 0 0 1 6.2786208 2.7905076 A 1.0548562 1.0534021 0 0 1 5.2241181 1.7374586 A 1.0548562 1.0534021 0 0 1 6.2786208 0.68440954 z M 8.8362328 0.68440954 A 1.0548562 1.0534021 0 0 1 9.8907354 1.7374586 A 1.0548562 1.0534021 0 0 1 8.8362328 2.7905076 A 1.0548562 1.0534021 0 0 1 7.7817301 1.7374586 A 1.0548562 1.0534021 0 0 1 8.8362328 0.68440954 z M 11.393845 0.68440954 A 1.0548562 1.0534021 0 0 1 12.448347 1.7374586 A 1.0548562 1.0534021 0 0 1 11.393845 2.7905076 A 1.0548562 1.0534021 0 0 1 10.338234 1.7374586 A 1.0548562 1.0534021 0 0 1 11.393845 0.68440954 z " />
+  </g>
+</svg>

--- a/res/skins/LateNight/skin.xml
+++ b/res/skins/LateNight/skin.xml
@@ -82,6 +82,7 @@
     <!-- Effects -->
       <attribute persist="true" config_key="[Skin],show_effectrack">1</attribute>
       <attribute persist="true" config_key="[Skin],show_4effectunits">0</attribute>
+      <attribute persist="true" config_key="[Skin],show_effectuibuttons">1</attribute>
       <attribute persist="true" config_key="[Skin],show_superknobs">0</attribute>
     <!-- Samplers -->
       <attribute persist="true" config_key="[Skin],show_samplers">0</attribute>

--- a/res/skins/LateNight/skin_settings.xml
+++ b/res/skins/LateNight/skin_settings.xml
@@ -375,7 +375,7 @@ Description:
                 <Children>
                   <WidgetGroup>
                     <Layout>horizontal</Layout>
-                    <Size>200min,1min</Size>
+                    <Size>180min,1min</Size>
                     <Children>
                       <Template src="skins:LateNight/helpers/skin_settings_labelbutton_2state.xml">
                         <SetVariable name="Text">Effect Units</SetVariable>

--- a/res/skins/LateNight/skin_settings.xml
+++ b/res/skins/LateNight/skin_settings.xml
@@ -375,7 +375,7 @@ Description:
                 <Children>
                   <WidgetGroup>
                     <Layout>horizontal</Layout>
-                    <Size>180min,1min</Size>
+                    <Size>200min,1min</Size>
                     <Children>
                       <Template src="skins:LateNight/helpers/skin_settings_labelbutton_2state.xml">
                         <SetVariable name="Text">Effect Units</SetVariable>
@@ -428,10 +428,22 @@ Description:
                         <SetVariable name="Setting">[Skin],show_effectrack</SetVariable>
                       </Template>
 
-                      <Template src="skins:LateNight/helpers/skin_settings_button_2state.xml">
-                        <SetVariable name="Text">Super Knobs</SetVariable>
-                        <SetVariable name="Setting">[Skin],show_superknobs</SetVariable>
-                      </Template>
+                      <WidgetGroup>
+                        <ObjectName>SkinSettingsCategory</ObjectName>
+                        <SizePolicy>me,min</SizePolicy>
+                        <Layout>vertical</Layout>
+                        <Children>
+                          <Template src="skins:LateNight/helpers/skin_settings_button_2state.xml">
+                            <SetVariable name="Text">Effect UI Buttons</SetVariable>
+                            <SetVariable name="Setting">[Skin],show_effectuibuttons</SetVariable>
+                          </Template>
+
+                          <Template src="skins:LateNight/helpers/skin_settings_button_2state.xml">
+                            <SetVariable name="Text">Super Knobs</SetVariable>
+                            <SetVariable name="Setting">[Skin],show_superknobs</SetVariable>
+                          </Template>
+                        </Children>
+                      </WidgetGroup>
                     </Children>
                   </WidgetGroup>
                 </Children>

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -1602,6 +1602,7 @@ WPushButton#LoopActivate[displayValue="0"],
 #EQKillButtonBox WPushButton[displayValue="0"],
 WPushButton#StemMuteButton[displayValue="0"],
 WPushButton#QuickEffectButton[displayValue="0"],
+WPushButton#FxUiButton[displayValue="0"],
 WPushButton#FxToggleButton[displayValue="0"],
 #MicAuxUnit WPushButton[displayValue="0"],
 #MicDuckingContainer WPushButton[displayValue="0"],
@@ -1723,6 +1724,8 @@ QPushButton#pushButtonRecording:checked,
 }
 
 /* Green for Fx toggles, QuickEffect + Fx12 */
+#FxUnit1 #FxUiButton[displayValue="1"],
+#FxUnit2 #FxUiButton[displayValue="1"],
 #FxUnit1 #FxToggleButton[displayValue="1"],
 #FxUnit2 #FxToggleButton[displayValue="1"],
 WPushButton#VinylStatus[displayValue="1"], /* enabled, OK */
@@ -1736,6 +1739,8 @@ WPushButton#VinylStatus[displayValue="1"], /* enabled, OK */
     background-color: #236b00;
   }
 /* Blue for Fx buttons 3/4 */
+#FxUnit3 #FxUiButton[displayValue="1"],
+#FxUnit4 #FxUiButton[displayValue="1"],
 #FxUnit3 #FxToggleButton[displayValue="1"],
 #FxUnit4 #FxToggleButton[displayValue="1"]
 WBeatSpinBox::up-button:pressed,
@@ -2295,6 +2300,13 @@ WPushButton#PlayDeck[value="0"] {
   }
   #MixModeButton[value="1"] {
     image: url(skins:LateNight/palemoon/buttons/btn__fx_mixmode_d+w.svg) no-repeat center center;
+  }
+
+#FxUiButton[value="0"] {
+  image: url(skins:LateNight/palemoon/buttons/btn__fx_ui.svg) no-repeat center center;
+  }
+  #FxUiButton[value="1"] {
+    image: url(skins:LateNight/palemoon/buttons/btn__fx_ui_active.svg) no-repeat center center;
   }
 
 #FxToggleButton[value="0"] {

--- a/src/effects/backends/audiounit/audiouniteffectprocessor.h
+++ b/src/effects/backends/audiounit/audiouniteffectprocessor.h
@@ -4,8 +4,10 @@
 #import <AudioToolbox/AudioToolbox.h>
 #import <CoreAudioTypes/CoreAudioTypes.h>
 
+#include <QDialog>
 #include <QList>
 #include <atomic>
+#include <memory>
 
 #include "audio/types.h"
 #include "effects/backends/audiounit/audiounitmanager.h"
@@ -53,6 +55,8 @@ class AudioUnitEffectProcessor final : public EffectProcessorImpl<AudioUnitEffec
             const mixxx::EngineParameters& engineParameters,
             const EffectEnableState enableState,
             const GroupFeatureState& groupFeatures) override;
+
+    std::unique_ptr<QDialog> createUI() override;
 
   private:
     AudioUnitManagerPointer m_pManager;

--- a/src/effects/backends/audiounit/audiouniteffectprocessor.h
+++ b/src/effects/backends/audiounit/audiouniteffectprocessor.h
@@ -70,5 +70,5 @@ class AudioUnitEffectProcessor final : public EffectProcessorImpl<AudioUnitEffec
     void syncParameters();
     void syncStreamFormat(const mixxx::EngineParameters& engineParameters);
 
-    NSView* _Nullable createNativeUI(CGSize size);
+    NSView* _Nullable createNativeUI(CGSize size, QString& outError);
 };

--- a/src/effects/backends/audiounit/audiouniteffectprocessor.h
+++ b/src/effects/backends/audiounit/audiouniteffectprocessor.h
@@ -69,6 +69,4 @@ class AudioUnitEffectProcessor final : public EffectProcessorImpl<AudioUnitEffec
 
     void syncParameters();
     void syncStreamFormat(const mixxx::EngineParameters& engineParameters);
-
-    NSView* _Nullable createNativeUI(CGSize size, QString& outError);
 };

--- a/src/effects/backends/audiounit/audiouniteffectprocessor.h
+++ b/src/effects/backends/audiounit/audiouniteffectprocessor.h
@@ -5,7 +5,6 @@
 #import <AudioToolbox/AudioToolbox.h>
 #import <CoreAudioTypes/CoreAudioTypes.h>
 
-#include <QDialog>
 #include <QList>
 #include <atomic>
 #include <memory>
@@ -13,6 +12,7 @@
 #include "audio/types.h"
 #include "effects/backends/audiounit/audiounitmanager.h"
 #include "effects/backends/effectprocessor.h"
+#include "effects/dlgeffect.h"
 #include "engine/engine.h"
 
 class AudioUnitEffectGroupState final : public EffectState {
@@ -57,7 +57,7 @@ class AudioUnitEffectProcessor final : public EffectProcessorImpl<AudioUnitEffec
             const EffectEnableState enableState,
             const GroupFeatureState& groupFeatures) override;
 
-    std::unique_ptr<QDialog> createUI() override;
+    std::unique_ptr<DlgEffect> createUI() override;
 
   private:
     AudioUnitManagerPointer m_pManager;

--- a/src/effects/backends/audiounit/audiouniteffectprocessor.h
+++ b/src/effects/backends/audiounit/audiouniteffectprocessor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #import <AVFAudio/AVFAudio.h>
+#import <AppKit/AppKit.h>
 #import <AudioToolbox/AudioToolbox.h>
 #import <CoreAudioTypes/CoreAudioTypes.h>
 
@@ -68,4 +69,6 @@ class AudioUnitEffectProcessor final : public EffectProcessorImpl<AudioUnitEffec
 
     void syncParameters();
     void syncStreamFormat(const mixxx::EngineParameters& engineParameters);
+
+    NSView* _Nullable createNativeUI(CGSize size);
 };

--- a/src/effects/backends/audiounit/audiouniteffectprocessor.mm
+++ b/src/effects/backends/audiounit/audiouniteffectprocessor.mm
@@ -259,6 +259,6 @@ void AudioUnitEffectProcessor::syncStreamFormat(
     }
 }
 
-std::unique_ptr<QDialog> AudioUnitEffectProcessor::createUI() {
+std::unique_ptr<DlgEffect> AudioUnitEffectProcessor::createUI() {
     return std::make_unique<DlgAudioUnit>(m_pManager);
 }

--- a/src/effects/backends/audiounit/audiouniteffectprocessor.mm
+++ b/src/effects/backends/audiounit/audiouniteffectprocessor.mm
@@ -334,6 +334,11 @@ NSView* _Nullable AudioUnitEffectProcessor::createNativeUI(
         return nil;
     }
 
+    if (cocoaViewInfo == nil) {
+        outError = "Could not fetch Cocoa view info for Audio Unit " + name;
+        return nil;
+    }
+
     NSURL* viewBundleLocation =
             (__bridge NSURL*)cocoaViewInfo->mCocoaAUViewBundleLocation;
     if (viewBundleLocation == nil) {

--- a/src/effects/backends/audiounit/audiouniteffectprocessor.mm
+++ b/src/effects/backends/audiounit/audiouniteffectprocessor.mm
@@ -270,6 +270,13 @@ std::unique_ptr<QDialog> AudioUnitEffectProcessor::createUI() {
     NSView* dialogView =
             (__bridge NSView*)reinterpret_cast<void*>(dialog->winId());
 
+    // Style effect UI as a floating, but non-modal, HUD window
+    NSWindow* dialogWindow = [dialogView window];
+    [dialogWindow setStyleMask:NSWindowStyleMaskTitled |
+            NSWindowStyleMaskClosable | NSWindowStyleMaskResizable |
+            NSWindowStyleMaskHUDWindow];
+    [dialogWindow setLevel:NSFloatingWindowLevel];
+
     QString error = "Could not load UI of Audio Unit";
     NSView* audioUnitView = createNativeUI(dialog->size().toCGSize(), error);
 

--- a/src/effects/backends/audiounit/audiouniteffectprocessor.mm
+++ b/src/effects/backends/audiounit/audiouniteffectprocessor.mm
@@ -1,4 +1,5 @@
 #import <AVFAudio/AVFAudio.h>
+#import <AppKit/AppKit.h>
 #import <AudioToolbox/AudioToolbox.h>
 #import <CoreAudioTypes/CoreAudioBaseTypes.h>
 #include <CoreAudioTypes/CoreAudioTypes.h>
@@ -250,4 +251,21 @@ void AudioUnitEffectProcessor::syncStreamFormat(
             }
         }
     }
+}
+
+std::unique_ptr<QDialog> AudioUnitEffectProcessor::createUI() {
+    std::unique_ptr<QDialog> dialog = std::make_unique<QDialog>();
+
+    // See
+    // https://lists.qt-project.org/pipermail/interest/2014-January/010655.html
+    // for why we need this slightly convoluted cast to obtain the native view
+    NSView* view = (__bridge NSView*)reinterpret_cast<void*>(dialog->winId());
+
+    // Set up a demo view
+    NSTextField* text =
+            [[NSTextField alloc] initWithFrame:NSMakeRect(10, 10, 200, 200)];
+    text.stringValue = @"Test 123";
+    [view addSubview:text];
+
+    return dialog;
 }

--- a/src/effects/backends/audiounit/audiouniteffectprocessor.mm
+++ b/src/effects/backends/audiounit/audiouniteffectprocessor.mm
@@ -274,7 +274,7 @@ std::unique_ptr<QDialog> AudioUnitEffectProcessor::createUI() {
     NSWindow* dialogWindow = [dialogView window];
     [dialogWindow setStyleMask:NSWindowStyleMaskTitled |
             NSWindowStyleMaskClosable | NSWindowStyleMaskResizable |
-            NSWindowStyleMaskHUDWindow];
+            NSWindowStyleMaskUtilityWindow | NSWindowStyleMaskHUDWindow];
     [dialogWindow setLevel:NSFloatingWindowLevel];
 
     QString error = "Could not load UI of Audio Unit";

--- a/src/effects/backends/audiounit/audiouniteffectprocessor.mm
+++ b/src/effects/backends/audiounit/audiouniteffectprocessor.mm
@@ -282,6 +282,20 @@ std::unique_ptr<QDialog> AudioUnitEffectProcessor::createUI() {
 
     if (audioUnitView != nil) {
         [dialogView addSubview:audioUnitView];
+
+        // Automatically resize the dialog to fit the view after layout
+        [audioUnitView setPostsFrameChangedNotifications:YES];
+        [[NSNotificationCenter defaultCenter]
+                addObserverForName:NSViewFrameDidChangeNotification
+                            object:audioUnitView
+                             queue:[NSOperationQueue mainQueue]
+                        usingBlock:^(NSNotification* notification) {
+                            NSView* audioUnitView =
+                                    (NSView*)notification.object;
+                            NSWindow* dialogWindow = audioUnitView.window;
+                            CGSize size = audioUnitView.frame.size;
+                            [dialogWindow setContentSize:size];
+                        }];
     } else {
         qWarning() << error;
 

--- a/src/effects/backends/audiounit/audiouniteffectprocessor.mm
+++ b/src/effects/backends/audiounit/audiouniteffectprocessor.mm
@@ -1,7 +1,6 @@
 #import <AVFAudio/AVFAudio.h>
 #import <AppKit/AppKit.h>
 #import <AudioToolbox/AudioToolbox.h>
-#import <AudioUnit/AUCocoaUIView.h>
 #import <CoreAudioKit/CoreAudioKit.h>
 #import <CoreAudioTypes/CoreAudioBaseTypes.h>
 #import <CoreAudioTypes/CoreAudioTypes.h>
@@ -14,6 +13,8 @@
 #include <memory>
 
 #include "effects/backends/audiounit/audiouniteffectprocessor.h"
+#include "effects/backends/audiounit/audiounitmanager.h"
+#include "effects/backends/audiounit/dlgaudiounit.h"
 #include "engine/effects/engineeffectparameter.h"
 #include "engine/engine.h"
 #include "util/assert.h"
@@ -259,155 +260,5 @@ void AudioUnitEffectProcessor::syncStreamFormat(
 }
 
 std::unique_ptr<QDialog> AudioUnitEffectProcessor::createUI() {
-    QString name = m_manager.getName();
-
-    std::unique_ptr<QDialog> dialog = std::make_unique<QDialog>();
-    dialog->setWindowTitle(name);
-
-    // See
-    // https://lists.qt-project.org/pipermail/interest/2014-January/010655.html
-    // for why we need this slightly convoluted cast
-    NSView* dialogView =
-            (__bridge NSView*)reinterpret_cast<void*>(dialog->winId());
-
-    // Style effect UI as a floating, but non-modal, HUD window
-    NSWindow* dialogWindow = [dialogView window];
-    [dialogWindow setStyleMask:NSWindowStyleMaskTitled |
-            NSWindowStyleMaskClosable | NSWindowStyleMaskResizable |
-            NSWindowStyleMaskUtilityWindow | NSWindowStyleMaskHUDWindow];
-    [dialogWindow setLevel:NSFloatingWindowLevel];
-
-    QString error = "Could not load UI of Audio Unit";
-    NSView* audioUnitView = createNativeUI(dialog->size().toCGSize(), error);
-
-    if (audioUnitView != nil) {
-        [dialogView addSubview:audioUnitView];
-
-        // Automatically resize the dialog to fit the view after layout
-        [audioUnitView setPostsFrameChangedNotifications:YES];
-        [[NSNotificationCenter defaultCenter]
-                addObserverForName:NSViewFrameDidChangeNotification
-                            object:audioUnitView
-                             queue:[NSOperationQueue mainQueue]
-                        usingBlock:^(NSNotification* notification) {
-                            NSView* audioUnitView =
-                                    (NSView*)notification.object;
-                            NSWindow* dialogWindow = audioUnitView.window;
-                            CGSize size = audioUnitView.frame.size;
-                            [dialogWindow setContentSize:size];
-                        }];
-    } else {
-        qWarning() << error;
-
-        // Fall back to a generic UI if possible
-        AudioUnit _Nullable audioUnit = m_manager.getAudioUnit();
-        if (audioUnit != nil) {
-            AUGenericView* genericView =
-                    [[AUGenericView alloc] initWithAudioUnit:audioUnit];
-            genericView.showsExpertParameters = YES;
-            [dialogView addSubview:genericView];
-        }
-    }
-
-    return dialog;
-}
-
-NSView* _Nullable AudioUnitEffectProcessor::createNativeUI(
-        CGSize size, QString& outError) {
-    QString name = m_manager.getName();
-    qDebug() << "Loading UI of Audio Unit" << name << "with width" << size.width
-             << "and height" << size.height;
-
-    AudioUnit _Nullable audioUnit = m_manager.getAudioUnit();
-
-    if (audioUnit == nil) {
-        outError = "Cannot create UI of Audio Unit " + name +
-                " without an instance";
-        return nil;
-    }
-
-    // See
-    // https://developer.apple.com/library/archive/samplecode/CocoaAUHost/Listings/Source_CAUHWindowController_mm.html
-
-    uint32_t dataSize;
-
-    OSStatus infoStatus = AudioUnitGetPropertyInfo(audioUnit,
-            kAudioUnitProperty_CocoaUI,
-            kAudioUnitScope_Global,
-            0,
-            &dataSize,
-            nullptr);
-    if (infoStatus != noErr) {
-        outError = "No Cocoa UI available for Audio Unit " + name;
-        return nil;
-    }
-
-    uint32_t numberOfClasses =
-            (dataSize - sizeof(CFURLRef)) / sizeof(CFStringRef);
-    if (numberOfClasses == 0) {
-        outError = "No view classes available for Audio Unit " + name;
-        return nil;
-    }
-
-    std::unique_ptr<AudioUnitCocoaViewInfo[]> cocoaViewInfo =
-            std::make_unique<AudioUnitCocoaViewInfo[]>(numberOfClasses);
-
-    OSStatus status = AudioUnitGetProperty(audioUnit,
-            kAudioUnitProperty_CocoaUI,
-            kAudioUnitScope_Global,
-            0,
-            cocoaViewInfo.get(),
-            &dataSize);
-    if (status != noErr) {
-        outError = "Could not fetch Cocoa UI for Audio Unit " + name;
-        return nil;
-    }
-
-    NSURL* viewBundleLocation =
-            (__bridge NSURL*)cocoaViewInfo.get()->mCocoaAUViewBundleLocation;
-    if (viewBundleLocation == nil) {
-        outError = "Cannot create UI of Audio Unit " + name +
-                " without view bundle path";
-        return nil;
-    }
-
-    // We only use the first view as in the Cocoa AU host example linked earlier
-    NSString* factoryClassName =
-            (__bridge NSString*)cocoaViewInfo.get()->mCocoaAUViewClass[0];
-    ;
-    if (factoryClassName == nil) {
-        outError = "Cannot create UI of Audio Unit " + name +
-                " without factory class name";
-        return nil;
-    }
-
-    NSBundle* viewBundle = [NSBundle bundleWithURL:viewBundleLocation];
-    if (viewBundle == nil) {
-        outError = "Could not load view bundle of Audio Unit " + name;
-        return nil;
-    }
-
-    Class factoryClass = [viewBundle classNamed:factoryClassName];
-    if (factoryClass == nil) {
-        outError =
-                "Could not load view factory class from bundle of Audio Unit " +
-                name;
-        return nil;
-    }
-
-    id<AUCocoaUIBase> factoryInstance = [[factoryClass alloc] init];
-    if (factoryInstance == nil) {
-        outError =
-                "Could not instantiate factory for view of Audio Unit " + name;
-        return nil;
-    }
-
-    NSView* view = [factoryInstance uiViewForAudioUnit:audioUnit withSize:size];
-    if (view == nil) {
-        outError = "Could not instantiate view of Audio Unit " + name;
-        return nil;
-    }
-
-    qDebug() << "Successfully loaded UI of Audio Unit" << name;
-    return view;
+    return std::make_unique<DlgAudioUnit>(m_pManager);
 }

--- a/src/effects/backends/audiounit/audiounitmanager.h
+++ b/src/effects/backends/audiounit/audiounitmanager.h
@@ -45,6 +45,9 @@ class AudioUnitManager {
     /// the timeout was reached instead.
     bool waitForAudioUnit(int timeoutMs) const;
 
+    /// Fetches the audio unit's name.
+    QString getName() const;
+
   private:
     QString m_name;
     std::atomic<bool> m_isInstantiated;

--- a/src/effects/backends/audiounit/audiounitmanager.mm
+++ b/src/effects/backends/audiounit/audiounitmanager.mm
@@ -145,3 +145,7 @@ void AudioUnitManager::initializeWith(AudioUnit _Nullable audioUnit) {
     m_audioUnit = audioUnit;
     m_isInstantiated.store(true);
 }
+
+QString AudioUnitManager::getName() const {
+    return m_name;
+}

--- a/src/effects/backends/audiounit/audiounitmanifest.mm
+++ b/src/effects/backends/audiounit/audiounitmanifest.mm
@@ -19,6 +19,7 @@ AudioUnitManifest::AudioUnitManifest(
     setVersion(QString::fromNSString([component versionString]));
     setDescription(QString::fromNSString([component typeName]));
     setAuthor(QString::fromNSString([component manufacturerName]));
+    setHasUI([component hasCustomView]);
 
     // Instantiate audio unit (out-of-process) to load parameters
     AudioUnitManagerPointer pManager = AudioUnitManager::create(component);

--- a/src/effects/backends/audiounit/audiounitmanifest.mm
+++ b/src/effects/backends/audiounit/audiounitmanifest.mm
@@ -19,7 +19,11 @@ AudioUnitManifest::AudioUnitManifest(
     setVersion(QString::fromNSString([component versionString]));
     setDescription(QString::fromNSString([component typeName]));
     setAuthor(QString::fromNSString([component manufacturerName]));
-    setHasUI([component hasCustomView]);
+
+    // All audio units provide a UI (not just if [component hasCustomView] is
+    // set) since they provide a generic fallback UI, which may be useful for
+    // effects with many different parameters.
+    setHasUI(true);
 
     // Instantiate audio unit (out-of-process) to load parameters
     AudioUnitManagerPointer pManager = AudioUnitManager::create(component);

--- a/src/effects/backends/audiounit/dlgaudiounit.h
+++ b/src/effects/backends/audiounit/dlgaudiounit.h
@@ -9,4 +9,8 @@ class DlgAudioUnit : public DlgEffect {
 
   public:
     DlgAudioUnit(AudioUnitManagerPointer pManager);
+    virtual ~DlgAudioUnit();
+
+  private:
+    id m_resizeObserver;
 };

--- a/src/effects/backends/audiounit/dlgaudiounit.h
+++ b/src/effects/backends/audiounit/dlgaudiounit.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#include <QDialog>
-
 #include "effects/backends/audiounit/audiounitmanagerpointer.h"
+#include "effects/dlgeffect.h"
 
 /// A dialog hosting the UI of an Audio Unit.
-class DlgAudioUnit : public QDialog {
+class DlgAudioUnit : public DlgEffect {
     Q_OBJECT
 
   public:

--- a/src/effects/backends/audiounit/dlgaudiounit.h
+++ b/src/effects/backends/audiounit/dlgaudiounit.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <QDialog>
+
+#include "effects/backends/audiounit/audiounitmanagerpointer.h"
+
+/// A dialog hosting the UI of an Audio Unit.
+class DlgAudioUnit : public QDialog {
+    Q_OBJECT
+
+  public:
+    DlgAudioUnit(AudioUnitManagerPointer pManager);
+};

--- a/src/effects/backends/audiounit/dlgaudiounit.mm
+++ b/src/effects/backends/audiounit/dlgaudiounit.mm
@@ -131,8 +131,8 @@ DlgAudioUnit::DlgAudioUnit(AudioUnitManagerPointer pManager) {
     // Style effect UI as a floating, but non-modal, HUD window
     NSWindow* dialogWindow = [dialogView window];
     [dialogWindow setStyleMask:NSWindowStyleMaskTitled |
-            NSWindowStyleMaskClosable | NSWindowStyleMaskResizable |
-            NSWindowStyleMaskUtilityWindow | NSWindowStyleMaskHUDWindow];
+            NSWindowStyleMaskClosable | NSWindowStyleMaskUtilityWindow |
+            NSWindowStyleMaskHUDWindow];
     [dialogWindow setLevel:NSFloatingWindowLevel];
 
     QString error = "Could not load UI of Audio Unit";

--- a/src/effects/backends/audiounit/dlgaudiounit.mm
+++ b/src/effects/backends/audiounit/dlgaudiounit.mm
@@ -152,7 +152,7 @@ DlgAudioUnit::DlgAudioUnit(AudioUnitManagerPointer pManager) {
                             CGSize cgSize = audioUnitView.frame.size;
                             QSize qSize(static_cast<int>(cgSize.width),
                                     static_cast<int>(cgSize.height));
-                            setFixedSize(qSize);
+                            resize(qSize);
                         }];
     }
 }

--- a/src/effects/backends/audiounit/dlgaudiounit.mm
+++ b/src/effects/backends/audiounit/dlgaudiounit.mm
@@ -149,9 +149,10 @@ DlgAudioUnit::DlgAudioUnit(AudioUnitManagerPointer pManager) {
                         usingBlock:^(NSNotification* notification) {
                             NSView* audioUnitView =
                                     (NSView*)notification.object;
-                            CGSize size = audioUnitView.frame.size;
-                            resize(static_cast<int>(size.width),
-                                    static_cast<int>(size.height));
+                            CGSize cgSize = audioUnitView.frame.size;
+                            QSize qSize(static_cast<int>(cgSize.width),
+                                    static_cast<int>(cgSize.height));
+                            setFixedSize(qSize);
                         }];
     }
 }

--- a/src/effects/backends/audiounit/dlgaudiounit.mm
+++ b/src/effects/backends/audiounit/dlgaudiounit.mm
@@ -25,6 +25,13 @@ std::variant<NSView* _Nonnull, QString> createNativeUI(
     qDebug() << "Loading UI of Audio Unit" << name << "with width" << size.width
              << "and height" << size.height;
 
+    const int TIMEOUT_MS = 2000;
+    if (!pManager->waitForAudioUnit(TIMEOUT_MS)) {
+        return "Instantiating the UI took more than " +
+                QString::number(TIMEOUT_MS) +
+                "ms, try closing and reopening the UI!";
+    }
+
     AudioUnit _Nullable audioUnit = pManager->getAudioUnit();
 
     if (audioUnit == nil) {

--- a/src/effects/backends/audiounit/dlgaudiounit.mm
+++ b/src/effects/backends/audiounit/dlgaudiounit.mm
@@ -142,7 +142,7 @@ DlgAudioUnit::DlgAudioUnit(AudioUnitManagerPointer pManager) {
 
         // Automatically resize the dialog to fit the view after layout
         [audioUnitView setPostsFrameChangedNotifications:YES];
-        [[NSNotificationCenter defaultCenter]
+        m_resizeObserver = [[NSNotificationCenter defaultCenter]
                 addObserverForName:NSViewFrameDidChangeNotification
                             object:audioUnitView
                              queue:[NSOperationQueue mainQueue]
@@ -155,4 +155,8 @@ DlgAudioUnit::DlgAudioUnit(AudioUnitManagerPointer pManager) {
                             setFixedSize(qSize);
                         }];
     }
+}
+
+DlgAudioUnit::~DlgAudioUnit() {
+    [[NSNotificationCenter defaultCenter] removeObserver:m_resizeObserver];
 }

--- a/src/effects/backends/audiounit/dlgaudiounit.mm
+++ b/src/effects/backends/audiounit/dlgaudiounit.mm
@@ -1,0 +1,169 @@
+#import <AVFAudio/AVFAudio.h>
+#import <AppKit/AppKit.h>
+#import <AudioToolbox/AudioToolbox.h>
+#import <AudioUnit/AUCocoaUIView.h>
+#import <CoreAudioKit/CoreAudioKit.h>
+#import <CoreAudioTypes/CoreAudioBaseTypes.h>
+#import <CoreAudioTypes/CoreAudioTypes.h>
+
+#include "effects/backends/audiounit/audiounitmanager.h"
+#include "effects/backends/audiounit/dlgaudiounit.h"
+
+#include "moc_dlgaudiounit.cpp"
+
+#include <QString>
+#include <QtGlobal>
+
+namespace {
+
+NSView* _Nullable createNativeUI(
+        AudioUnitManagerPointer pManager, CGSize size, QString& outError) {
+    QString name = pManager->getName();
+    qDebug() << "Loading UI of Audio Unit" << name << "with width" << size.width
+             << "and height" << size.height;
+
+    AudioUnit _Nullable audioUnit = pManager->getAudioUnit();
+
+    if (audioUnit == nil) {
+        outError = "Cannot create UI of Audio Unit " + name +
+                " without an instance";
+        return nil;
+    }
+
+    // See
+    // https://developer.apple.com/library/archive/samplecode/CocoaAUHost/Listings/Source_CAUHWindowController_mm.html
+
+    uint32_t dataSize;
+
+    OSStatus infoStatus = AudioUnitGetPropertyInfo(audioUnit,
+            kAudioUnitProperty_CocoaUI,
+            kAudioUnitScope_Global,
+            0,
+            &dataSize,
+            nullptr);
+    if (infoStatus != noErr) {
+        outError = "No Cocoa UI available for Audio Unit " + name;
+        return nil;
+    }
+
+    uint32_t numberOfClasses =
+            (dataSize - sizeof(CFURLRef)) / sizeof(CFStringRef);
+    if (numberOfClasses == 0) {
+        outError = "No view classes available for Audio Unit " + name;
+        return nil;
+    }
+
+    std::unique_ptr<AudioUnitCocoaViewInfo[]> cocoaViewInfo =
+            std::make_unique<AudioUnitCocoaViewInfo[]>(numberOfClasses);
+
+    OSStatus status = AudioUnitGetProperty(audioUnit,
+            kAudioUnitProperty_CocoaUI,
+            kAudioUnitScope_Global,
+            0,
+            cocoaViewInfo.get(),
+            &dataSize);
+    if (status != noErr) {
+        outError = "Could not fetch Cocoa UI for Audio Unit " + name;
+        return nil;
+    }
+
+    NSURL* viewBundleLocation =
+            (__bridge NSURL*)cocoaViewInfo.get()->mCocoaAUViewBundleLocation;
+    if (viewBundleLocation == nil) {
+        outError = "Cannot create UI of Audio Unit " + name +
+                " without view bundle path";
+        return nil;
+    }
+
+    // We only use the first view as in the Cocoa AU host example linked earlier
+    NSString* factoryClassName =
+            (__bridge NSString*)cocoaViewInfo.get()->mCocoaAUViewClass[0];
+    ;
+    if (factoryClassName == nil) {
+        outError = "Cannot create UI of Audio Unit " + name +
+                " without factory class name";
+        return nil;
+    }
+
+    NSBundle* viewBundle = [NSBundle bundleWithURL:viewBundleLocation];
+    if (viewBundle == nil) {
+        outError = "Could not load view bundle of Audio Unit " + name;
+        return nil;
+    }
+
+    Class factoryClass = [viewBundle classNamed:factoryClassName];
+    if (factoryClass == nil) {
+        outError =
+                "Could not load view factory class from bundle of Audio Unit " +
+                name;
+        return nil;
+    }
+
+    id<AUCocoaUIBase> factoryInstance = [[factoryClass alloc] init];
+    if (factoryInstance == nil) {
+        outError =
+                "Could not instantiate factory for view of Audio Unit " + name;
+        return nil;
+    }
+
+    NSView* view = [factoryInstance uiViewForAudioUnit:audioUnit withSize:size];
+    if (view == nil) {
+        outError = "Could not instantiate view of Audio Unit " + name;
+        return nil;
+    }
+
+    qDebug() << "Successfully loaded UI of Audio Unit" << name;
+    return view;
+}
+
+}; // anonymous namespace
+
+DlgAudioUnit::DlgAudioUnit(AudioUnitManagerPointer pManager) {
+    QString name = pManager->getName();
+
+    setWindowTitle(name);
+
+    // See
+    // https://lists.qt-project.org/pipermail/interest/2014-January/010655.html
+    // for why we need this slightly convoluted cast
+    NSView* dialogView = (__bridge NSView*)reinterpret_cast<void*>(winId());
+
+    // Style effect UI as a floating, but non-modal, HUD window
+    NSWindow* dialogWindow = [dialogView window];
+    [dialogWindow setStyleMask:NSWindowStyleMaskTitled |
+            NSWindowStyleMaskClosable | NSWindowStyleMaskResizable |
+            NSWindowStyleMaskUtilityWindow | NSWindowStyleMaskHUDWindow];
+    [dialogWindow setLevel:NSFloatingWindowLevel];
+
+    QString error = "Could not load UI of Audio Unit";
+    NSView* audioUnitView = createNativeUI(pManager, size().toCGSize(), error);
+
+    if (audioUnitView != nil) {
+        [dialogView addSubview:audioUnitView];
+
+        // Automatically resize the dialog to fit the view after layout
+        [audioUnitView setPostsFrameChangedNotifications:YES];
+        [[NSNotificationCenter defaultCenter]
+                addObserverForName:NSViewFrameDidChangeNotification
+                            object:audioUnitView
+                             queue:[NSOperationQueue mainQueue]
+                        usingBlock:^(NSNotification* notification) {
+                            NSView* audioUnitView =
+                                    (NSView*)notification.object;
+                            NSWindow* dialogWindow = audioUnitView.window;
+                            CGSize size = audioUnitView.frame.size;
+                            [dialogWindow setContentSize:size];
+                        }];
+    } else {
+        qWarning() << error;
+
+        // Fall back to a generic UI if possible
+        AudioUnit _Nullable audioUnit = pManager->getAudioUnit();
+        if (audioUnit != nil) {
+            AUGenericView* genericView =
+                    [[AUGenericView alloc] initWithAudioUnit:audioUnit];
+            genericView.showsExpertParameters = YES;
+            [dialogView addSubview:genericView];
+        }
+    }
+}

--- a/src/effects/backends/effectmanifest.h
+++ b/src/effects/backends/effectmanifest.h
@@ -25,6 +25,7 @@ class EffectManifest {
   public:
     EffectManifest()
             : m_backendType(EffectBackendType::Unknown),
+              m_hasUI(false),
               m_isMixingEQ(false),
               m_isMainEQ(false),
               m_effectRampsFromDry(false),
@@ -93,6 +94,14 @@ class EffectManifest {
 
     const QString& description() const {
         return m_description;
+    }
+
+    const bool& hasUI() const {
+        return m_hasUI;
+    }
+
+    void setHasUI(const bool value) {
+        m_hasUI = value;
     }
 
     const bool& isMixingEQ() const {
@@ -180,6 +189,7 @@ class EffectManifest {
     QString m_author;
     QString m_version;
     QString m_description;
+    bool m_hasUI;
     /// This helps us at DlgPrefEQ's basic selection of Equalizers
     bool m_isMixingEQ;
     bool m_isMainEQ;

--- a/src/effects/backends/effectprocessor.h
+++ b/src/effects/backends/effectprocessor.h
@@ -115,7 +115,7 @@ class EffectProcessor {
     /// after processing all effects in the effects chain.
     virtual SINT getGroupDelayFrames() = 0;
 
-    /// Creates a dialog hosting plugin-specific UI, if supported.
+    /// Creates a dialog hosting effect-specific UI, if supported.
     virtual std::unique_ptr<DlgEffect> createUI() = 0;
 };
 

--- a/src/effects/backends/effectprocessor.h
+++ b/src/effects/backends/effectprocessor.h
@@ -1,9 +1,13 @@
 #pragma once
 
 #include <QDebug>
+#include <QDialog>
 #include <QHash>
+#include <QLabel>
 #include <QPair>
 #include <QString>
+#include <QVBoxLayout>
+#include <memory>
 
 #include "effects/defs.h"
 #include "engine/channelhandle.h"
@@ -110,6 +114,9 @@ class EffectProcessor {
     /// the dry signal is delayed to overlap with the output wet signal
     /// after processing all effects in the effects chain.
     virtual SINT getGroupDelayFrames() = 0;
+
+    /// Creates a dialog hosting plugin-specific UI, if supported.
+    virtual std::unique_ptr<QDialog> createUI() = 0;
 };
 
 /// EffectProcessorImpl manages a separate EffectState for every combination of
@@ -146,6 +153,20 @@ class EffectProcessorImpl : public EffectProcessor {
     /// can override this method and set actual number of frames for the effect delay.
     virtual SINT getGroupDelayFrames() override {
         return 0;
+    }
+
+    std::unique_ptr<QDialog> createUI() override {
+        QLabel* label = new QLabel();
+        label->setText("This effect has no UI");
+
+        QVBoxLayout* layout = new QVBoxLayout();
+        layout->addWidget(label);
+
+        std::unique_ptr<QDialog> dialog = std::make_unique<QDialog>();
+        dialog->setWindowTitle("No UI available");
+        dialog->setLayout(layout);
+
+        return dialog;
     }
 
     void process(const ChannelHandle& inputHandle,

--- a/src/effects/backends/effectprocessor.h
+++ b/src/effects/backends/effectprocessor.h
@@ -163,7 +163,6 @@ class EffectProcessorImpl : public EffectProcessor {
         layout->addWidget(label);
 
         std::unique_ptr<DlgEffect> dialog = std::make_unique<DlgEffect>();
-        dialog->setWindowTitle("No UI available");
         dialog->setLayout(layout);
 
         return dialog;

--- a/src/effects/backends/effectprocessor.h
+++ b/src/effects/backends/effectprocessor.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <QDebug>
-#include <QDialog>
 #include <QHash>
 #include <QLabel>
 #include <QPair>
@@ -10,6 +9,7 @@
 #include <memory>
 
 #include "effects/defs.h"
+#include "effects/dlgeffect.h"
 #include "engine/channelhandle.h"
 #include "engine/effects/groupfeaturestate.h"
 #include "engine/effects/message.h"
@@ -116,7 +116,7 @@ class EffectProcessor {
     virtual SINT getGroupDelayFrames() = 0;
 
     /// Creates a dialog hosting plugin-specific UI, if supported.
-    virtual std::unique_ptr<QDialog> createUI() = 0;
+    virtual std::unique_ptr<DlgEffect> createUI() = 0;
 };
 
 /// EffectProcessorImpl manages a separate EffectState for every combination of
@@ -155,14 +155,14 @@ class EffectProcessorImpl : public EffectProcessor {
         return 0;
     }
 
-    std::unique_ptr<QDialog> createUI() override {
+    std::unique_ptr<DlgEffect> createUI() override {
         QLabel* label = new QLabel();
         label->setText("This effect has no UI");
 
         QVBoxLayout* layout = new QVBoxLayout();
         layout->addWidget(label);
 
-        std::unique_ptr<QDialog> dialog = std::make_unique<QDialog>();
+        std::unique_ptr<DlgEffect> dialog = std::make_unique<DlgEffect>();
         dialog->setWindowTitle("No UI available");
         dialog->setLayout(layout);
 

--- a/src/effects/dlgeffect.cpp
+++ b/src/effects/dlgeffect.cpp
@@ -10,6 +10,9 @@ DlgEffect::DlgEffect(QWidget* customUI) {
     setCustomUI(customUI);
 }
 
+DlgEffect::~DlgEffect() {
+}
+
 void DlgEffect::setCustomUI(QWidget* customUI) {
     if (customUI != nullptr) {
         customUI->setParent(this);

--- a/src/effects/dlgeffect.cpp
+++ b/src/effects/dlgeffect.cpp
@@ -1,0 +1,7 @@
+#include "effects/dlgeffect.h"
+
+#include "moc_dlgeffect.cpp"
+
+DlgEffect::DlgEffect() {
+    // TODO
+}

--- a/src/effects/dlgeffect.cpp
+++ b/src/effects/dlgeffect.cpp
@@ -1,5 +1,7 @@
 #include "effects/dlgeffect.h"
 
+#include <QWidget>
+
 #include "moc_dlgeffect.cpp"
 
 DlgEffect::DlgEffect(QWidget* customUI) {

--- a/src/effects/dlgeffect.cpp
+++ b/src/effects/dlgeffect.cpp
@@ -3,6 +3,8 @@
 #include "moc_dlgeffect.cpp"
 
 DlgEffect::DlgEffect(QWidget* customUI) {
+    setWindowTitle("Effect");
+    setWindowFlags(Qt::Tool | Qt::WindowStaysOnTopHint);
     setCustomUI(customUI);
 }
 

--- a/src/effects/dlgeffect.cpp
+++ b/src/effects/dlgeffect.cpp
@@ -19,3 +19,8 @@ void DlgEffect::setCustomUI(QWidget* customUI) {
     }
     m_customUI = customUI;
 }
+
+void DlgEffect::closeEvent(QCloseEvent* e) {
+    Q_UNUSED(e);
+    emit closed();
+}

--- a/src/effects/dlgeffect.cpp
+++ b/src/effects/dlgeffect.cpp
@@ -2,6 +2,13 @@
 
 #include "moc_dlgeffect.cpp"
 
-DlgEffect::DlgEffect() {
-    // TODO
+DlgEffect::DlgEffect(QWidget* customUI) {
+    setCustomUI(customUI);
+}
+
+void DlgEffect::setCustomUI(QWidget* customUI) {
+    if (customUI != nullptr) {
+        customUI->setParent(this);
+    }
+    m_customUI = customUI;
 }

--- a/src/effects/dlgeffect.cpp
+++ b/src/effects/dlgeffect.cpp
@@ -4,7 +4,8 @@
 
 #include "moc_dlgeffect.cpp"
 
-DlgEffect::DlgEffect(QWidget* customUI) {
+DlgEffect::DlgEffect(QWidget* customUI)
+        : m_closesWithoutSignal(false) {
     setWindowTitle("Effect");
     setWindowFlags(Qt::Tool | Qt::WindowStaysOnTopHint);
     setCustomUI(customUI);
@@ -20,7 +21,13 @@ void DlgEffect::setCustomUI(QWidget* customUI) {
     m_customUI = customUI;
 }
 
+void DlgEffect::setClosesWithoutSignal(bool closesWithoutSignal) {
+    m_closesWithoutSignal = closesWithoutSignal;
+}
+
 void DlgEffect::closeEvent(QCloseEvent* e) {
     Q_UNUSED(e);
-    emit closed();
+    if (!m_closesWithoutSignal) {
+        emit closed();
+    }
 }

--- a/src/effects/dlgeffect.h
+++ b/src/effects/dlgeffect.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QCloseEvent>
 #include <QDialog>
 #include <QWidget>
 
@@ -11,6 +12,12 @@ class DlgEffect : public QDialog {
     virtual ~DlgEffect();
 
     void setCustomUI(QWidget* customUI);
+
+  signals:
+    void closed();
+
+  protected:
+    void closeEvent(QCloseEvent* e) override;
 
   private:
     QWidget* m_customUI;

--- a/src/effects/dlgeffect.h
+++ b/src/effects/dlgeffect.h
@@ -1,10 +1,16 @@
 #pragma once
 
 #include <QDialog>
+#include <QWidget>
 
 class DlgEffect : public QDialog {
     Q_OBJECT
 
   public:
-    DlgEffect();
+    DlgEffect(QWidget* customUI = nullptr);
+
+    void setCustomUI(QWidget* customUI);
+
+  private:
+    QWidget* m_customUI;
 };

--- a/src/effects/dlgeffect.h
+++ b/src/effects/dlgeffect.h
@@ -4,6 +4,11 @@
 #include <QDialog>
 #include <QWidget>
 
+/// A dialog hosting effect-specific UI. This is mainly intended for audio
+/// plugins (e.g. AU/LV2/VST/...) to display their UI, but may also be useful to
+/// other effect backends. While subclassing is recommended to customize the
+/// dialog as needed, e.g. with a custom window title, this class already
+/// styles the dialog and configures it to float above other windows.
 class DlgEffect : public QDialog {
     Q_OBJECT
 

--- a/src/effects/dlgeffect.h
+++ b/src/effects/dlgeffect.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <QDialog>
+
+class DlgEffect : public QDialog {
+    Q_OBJECT
+
+  public:
+    DlgEffect();
+};

--- a/src/effects/dlgeffect.h
+++ b/src/effects/dlgeffect.h
@@ -17,6 +17,7 @@ class DlgEffect : public QDialog {
     virtual ~DlgEffect();
 
     void setCustomUI(QWidget* customUI);
+    void setClosesWithoutSignal(bool closesWithoutSignal);
 
   signals:
     void closed();
@@ -26,4 +27,5 @@ class DlgEffect : public QDialog {
 
   private:
     QWidget* m_customUI;
+    bool m_closesWithoutSignal;
 };

--- a/src/effects/dlgeffect.h
+++ b/src/effects/dlgeffect.h
@@ -8,6 +8,7 @@ class DlgEffect : public QDialog {
 
   public:
     DlgEffect(QWidget* customUI = nullptr);
+    virtual ~DlgEffect();
 
     void setCustomUI(QWidget* customUI);
 

--- a/src/effects/effectslot.cpp
+++ b/src/effects/effectslot.cpp
@@ -74,6 +74,13 @@ EffectSlot::EffectSlot(const QString& group,
             this,
             &EffectSlot::updateEngineState);
 
+    m_pControlUIShown = std::make_unique<ControlPushButton>(ConfigKey(m_group, "ui_shown"));
+    m_pControlUIShown->setButtonMode(mixxx::control::ButtonMode::PowerWindow);
+    connect(m_pControlUIShown.get(),
+            &ControlObject::valueChanged,
+            this,
+            &EffectSlot::updateEffectUIShown);
+
     m_pControlNextEffect = std::make_unique<ControlPushButton>(
             ConfigKey(m_group, "next_effect"));
     connect(m_pControlNextEffect.get(),
@@ -193,6 +200,21 @@ void EffectSlot::updateEngineState() {
         for (auto const& pParameter : parameterList) {
             pParameter->updateEngineState();
         }
+    }
+}
+
+void EffectSlot::updateEffectUIShown() {
+    if (!m_pEngineEffect) {
+        return;
+    }
+
+    if (m_pControlUIShown->toBool()) {
+        if (!m_pEffectUI) {
+            m_pEffectUI = m_pEngineEffect->createUI();
+        }
+        m_pEffectUI->show();
+    } else {
+        m_pEffectUI = nullptr;
     }
 }
 

--- a/src/effects/effectslot.cpp
+++ b/src/effects/effectslot.cpp
@@ -79,7 +79,7 @@ EffectSlot::EffectSlot(const QString& group,
     connect(m_pControlUIShown.get(),
             &ControlObject::valueChanged,
             this,
-            &EffectSlot::updateEffectUIShown);
+            &EffectSlot::updateEffectUI);
 
     m_pControlNextEffect = std::make_unique<ControlPushButton>(
             ConfigKey(m_group, "next_effect"));
@@ -203,15 +203,17 @@ void EffectSlot::updateEngineState() {
     }
 }
 
-void EffectSlot::updateEffectUIShown() {
+void EffectSlot::updateEffectUI() {
     if (!m_pEngineEffect) {
         return;
     }
 
+    if (m_pEffectUI) {
+        m_pEffectUI->close();
+    }
+
     if (m_pControlUIShown->toBool()) {
-        if (!m_pEffectUI) {
-            m_pEffectUI = m_pEngineEffect->createUI();
-        }
+        m_pEffectUI = m_pEngineEffect->createUI();
         m_pEffectUI->show();
     } else {
         m_pEffectUI = nullptr;
@@ -388,6 +390,7 @@ void EffectSlot::loadEffectInner(const EffectManifestPointer pManifest,
 
     emit effectChanged();
     updateEngineState();
+    updateEffectUI();
 }
 
 void EffectSlot::unloadEffect() {

--- a/src/effects/effectslot.cpp
+++ b/src/effects/effectslot.cpp
@@ -1,6 +1,8 @@
 #include "effects/effectslot.h"
 
 #include <QDebug>
+#include <QPoint>
+#include <optional>
 
 #include "control/controlencoder.h"
 #include "control/controlpushbutton.h"
@@ -212,8 +214,13 @@ void EffectSlot::updateEffectUI() {
     }
 
     bool uiShown = m_pControlUIShown->toBool();
+    std::optional<QPoint> oldDlgPosition;
 
     if (m_pEffectUI) {
+        // Carry over the screen position of the dialog to keep the user's
+        // window layout when switching to another effect.
+        oldDlgPosition = m_pEffectUI->pos();
+
         // Prevent close from retriggering updateControlOnEffectUIClose if we
         // want to keep showing a UI (e.g. because the effect was switched).
         m_pEffectUI->setClosesWithoutSignal(uiShown);
@@ -227,6 +234,10 @@ void EffectSlot::updateEffectUI() {
                 &DlgEffect::closed,
                 this,
                 &EffectSlot::updateControlOnEffectUIClose);
+
+        if (oldDlgPosition.has_value()) {
+            m_pEffectUI->move(oldDlgPosition->x(), oldDlgPosition->y());
+        }
     } else {
         m_pEffectUI = nullptr;
     }

--- a/src/effects/effectslot.cpp
+++ b/src/effects/effectslot.cpp
@@ -83,6 +83,11 @@ EffectSlot::EffectSlot(const QString& group,
             this,
             &EffectSlot::updateEffectUI);
 
+    connect(this,
+            &EffectSlot::effectChanged,
+            this,
+            &EffectSlot::updateEffectUI);
+
     m_pControlUIButtonShown = std::make_unique<ControlObject>(ConfigKey(m_group, "uibutton_shown"));
     m_pControlUIButtonShown->set(false);
 
@@ -209,10 +214,6 @@ void EffectSlot::updateEngineState() {
 }
 
 void EffectSlot::updateEffectUI() {
-    if (!m_pEngineEffect) {
-        return;
-    }
-
     bool uiShown = m_pControlUIShown->toBool();
     std::optional<QPoint> oldDlgPosition;
 
@@ -227,7 +228,7 @@ void EffectSlot::updateEffectUI() {
         m_pEffectUI->close();
     }
 
-    if (uiShown) {
+    if (uiShown && m_pEngineEffect) {
         m_pEffectUI = m_pEngineEffect->createUI();
         m_pEffectUI->show();
         connect(&*m_pEffectUI,
@@ -418,7 +419,6 @@ void EffectSlot::loadEffectInner(const EffectManifestPointer pManifest,
 
     emit effectChanged();
     updateEngineState();
-    updateEffectUI();
 }
 
 void EffectSlot::unloadEffect() {

--- a/src/effects/effectslot.cpp
+++ b/src/effects/effectslot.cpp
@@ -81,6 +81,9 @@ EffectSlot::EffectSlot(const QString& group,
             this,
             &EffectSlot::updateEffectUI);
 
+    m_pControlUIButtonShown = std::make_unique<ControlObject>(ConfigKey(m_group, "uibutton_shown"));
+    m_pControlUIButtonShown->set(false);
+
     m_pControlNextEffect = std::make_unique<ControlPushButton>(
             ConfigKey(m_group, "next_effect"));
     connect(m_pControlNextEffect.get(),
@@ -328,6 +331,7 @@ void EffectSlot::loadEffectInner(const EffectManifestPointer pManifest,
     }
 
     m_pManifest = pManifest;
+    m_pControlUIButtonShown->set(m_pManifest->hasUI());
     addToEngine();
 
     // Create EffectParameters. Every parameter listed in the manifest must have

--- a/src/effects/effectslot.cpp
+++ b/src/effects/effectslot.cpp
@@ -208,16 +208,29 @@ void EffectSlot::updateEffectUI() {
         return;
     }
 
+    bool uiShown = m_pControlUIShown->toBool();
+
     if (m_pEffectUI) {
+        // Prevent close from retriggering updateControlOnEffectUIClose if we
+        // want to keep showing a UI (e.g. because the effect was switched).
+        m_pEffectUI->setClosesWithoutSignal(uiShown);
         m_pEffectUI->close();
     }
 
-    if (m_pControlUIShown->toBool()) {
+    if (uiShown) {
         m_pEffectUI = m_pEngineEffect->createUI();
         m_pEffectUI->show();
+        connect(&*m_pEffectUI,
+                &DlgEffect::closed,
+                this,
+                &EffectSlot::updateControlOnEffectUIClose);
     } else {
         m_pEffectUI = nullptr;
     }
+}
+
+void EffectSlot::updateControlOnEffectUIClose() {
+    m_pControlUIShown->set(false);
 }
 
 void EffectSlot::initalizeInputChannel(ChannelHandle inputChannel) {

--- a/src/effects/effectslot.cpp
+++ b/src/effects/effectslot.cpp
@@ -242,6 +242,8 @@ void EffectSlot::updateEffectUI() {
     } else {
         m_pEffectUI = nullptr;
     }
+
+    m_pControlUIButtonShown->set(m_pManifest ? m_pManifest->hasUI() : false);
 }
 
 void EffectSlot::updateControlOnEffectUIClose() {
@@ -343,7 +345,6 @@ void EffectSlot::loadEffectInner(const EffectManifestPointer pManifest,
     }
 
     m_pManifest = pManifest;
-    m_pControlUIButtonShown->set(m_pManifest->hasUI());
     addToEngine();
 
     // Create EffectParameters. Every parameter listed in the manifest must have

--- a/src/effects/effectslot.h
+++ b/src/effects/effectslot.h
@@ -142,7 +142,7 @@ class EffectSlot : public QObject {
 
   private slots:
     void updateEngineState();
-    void updateEffectUIShown();
+    void updateEffectUI();
     void visibleEffectsListChanged();
 
   private:

--- a/src/effects/effectslot.h
+++ b/src/effects/effectslot.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QDialog>
 #include <QObject>
 #include <QSharedPointer>
 #include <QString>
@@ -141,6 +142,7 @@ class EffectSlot : public QObject {
 
   private slots:
     void updateEngineState();
+    void updateEffectUIShown();
     void visibleEffectsListChanged();
 
   private:
@@ -182,12 +184,15 @@ class EffectSlot : public QObject {
     QHash<EffectParameterType, QSharedPointer<ControlObject>> m_pControlNumParameters;
     QHash<EffectParameterType, QSharedPointer<ControlObject>> m_pControlNumParameterSlots;
     std::unique_ptr<ControlPushButton> m_pControlEnabled;
+    std::unique_ptr<ControlPushButton> m_pControlUIShown;
     std::unique_ptr<ControlObject> m_pControlNextEffect;
     std::unique_ptr<ControlObject> m_pControlPrevEffect;
     std::unique_ptr<ControlObject> m_pControlLoadedEffect;
     std::unique_ptr<ControlEncoder> m_pControlEffectSelector;
     std::unique_ptr<ControlObject> m_pControlClear;
     std::unique_ptr<ControlPotmeter> m_pControlMetaParameter;
+
+    std::unique_ptr<QDialog> m_pEffectUI;
 
     SoftTakeover m_metaknobSoftTakeover;
 

--- a/src/effects/effectslot.h
+++ b/src/effects/effectslot.h
@@ -186,6 +186,7 @@ class EffectSlot : public QObject {
     QHash<EffectParameterType, QSharedPointer<ControlObject>> m_pControlNumParameterSlots;
     std::unique_ptr<ControlPushButton> m_pControlEnabled;
     std::unique_ptr<ControlPushButton> m_pControlUIShown;
+    std::unique_ptr<ControlObject> m_pControlUIButtonShown;
     std::unique_ptr<ControlObject> m_pControlNextEffect;
     std::unique_ptr<ControlObject> m_pControlPrevEffect;
     std::unique_ptr<ControlObject> m_pControlLoadedEffect;

--- a/src/effects/effectslot.h
+++ b/src/effects/effectslot.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <QDialog>
 #include <QObject>
 #include <QSharedPointer>
 #include <QString>
 
 #include "controllers/softtakeover.h"
 #include "effects/backends/effectmanifest.h"
+#include "effects/dlgeffect.h"
 #include "engine/channelhandle.h"
 #include "preferences/usersettings.h"
 #include "util/class.h"
@@ -192,7 +192,7 @@ class EffectSlot : public QObject {
     std::unique_ptr<ControlObject> m_pControlClear;
     std::unique_ptr<ControlPotmeter> m_pControlMetaParameter;
 
-    std::unique_ptr<QDialog> m_pEffectUI;
+    std::unique_ptr<DlgEffect> m_pEffectUI;
 
     SoftTakeover m_metaknobSoftTakeover;
 

--- a/src/effects/effectslot.h
+++ b/src/effects/effectslot.h
@@ -143,6 +143,7 @@ class EffectSlot : public QObject {
   private slots:
     void updateEngineState();
     void updateEffectUI();
+    void updateControlOnEffectUIClose();
     void visibleEffectsListChanged();
 
   private:

--- a/src/engine/effects/engineeffect.cpp
+++ b/src/engine/effects/engineeffect.cpp
@@ -225,3 +225,7 @@ bool EngineEffect::process(const ChannelHandle& inputHandle,
 
     return processingOccured;
 }
+
+std::unique_ptr<QDialog> EngineEffect::createUI() {
+    return m_pProcessor->createUI();
+}

--- a/src/engine/effects/engineeffect.cpp
+++ b/src/engine/effects/engineeffect.cpp
@@ -226,6 +226,6 @@ bool EngineEffect::process(const ChannelHandle& inputHandle,
     return processingOccured;
 }
 
-std::unique_ptr<QDialog> EngineEffect::createUI() {
+std::unique_ptr<DlgEffect> EngineEffect::createUI() {
     return m_pProcessor->createUI();
 }

--- a/src/engine/effects/engineeffect.h
+++ b/src/engine/effects/engineeffect.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QDialog>
 #include <QMap>
 #include <QSet>
 #include <QString>
@@ -58,6 +59,8 @@ class EngineEffect final : public EffectsRequestHandler {
     SINT getGroupDelayFrames() {
         return m_pProcessor->getGroupDelayFrames();
     }
+
+    std::unique_ptr<QDialog> createUI();
 
   private:
     QString debugString() const {

--- a/src/engine/effects/engineeffect.h
+++ b/src/engine/effects/engineeffect.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <QDialog>
 #include <QMap>
 #include <QSet>
 #include <QString>
@@ -13,6 +12,8 @@
 #include "engine/channelhandle.h"
 #include "engine/effects/message.h"
 #include "util/types.h"
+
+class QDialog;
 
 /// EngineEffect is a generic wrapper around an EffectProcessor which intermediates
 /// between an EffectSlot and the EffectProcessor. It implements the logic to handle

--- a/src/engine/effects/engineeffect.h
+++ b/src/engine/effects/engineeffect.h
@@ -13,7 +13,7 @@
 #include "engine/effects/message.h"
 #include "util/types.h"
 
-class QDialog;
+class DlgEffect;
 
 /// EngineEffect is a generic wrapper around an EffectProcessor which intermediates
 /// between an EffectSlot and the EffectProcessor. It implements the logic to handle
@@ -61,7 +61,7 @@ class EngineEffect final : public EffectsRequestHandler {
         return m_pProcessor->getGroupDelayFrames();
     }
 
-    std::unique_ptr<QDialog> createUI();
+    std::unique_ptr<DlgEffect> createUI();
 
   private:
     QString debugString() const {

--- a/src/skin/legacy/tooltips.cpp
+++ b/src/skin/legacy/tooltips.cpp
@@ -1093,7 +1093,7 @@ void Tooltips::addStandardTooltips() {
             << tr("Clear")
             << tr("Clear the current effect.");
 
-    add("EffectSlot_uiShown")
+    add("EffectSlot_ui_shown")
             << tr("Show Effect UI")
             << tr("Displays the UI for the given effect if available");
 

--- a/src/skin/legacy/tooltips.cpp
+++ b/src/skin/legacy/tooltips.cpp
@@ -1093,6 +1093,10 @@ void Tooltips::addStandardTooltips() {
             << tr("Clear")
             << tr("Clear the current effect.");
 
+    add("EffectSlot_uiShown")
+            << tr("Show Effect UI")
+            << tr("Displays the UI for the given effect if available");
+
     add("EffectSlot_enabled")
             << tr("Enable Effect")
             << tr("The effect unit must also be assigned to a deck or other sound source to hear the effect.");


### PR DESCRIPTION
### Based on #13887, fixes #13147

This PR adds a generic interface for effect backends for exposing GUIs in the form of `QDialog`s, along with a reference implementation for Audio Unit effects on macOS[^1]:

![image](https://github.com/user-attachments/assets/00a601ee-c7fd-40b8-a830-2dcfec303b8c)

Effect UIs are toggled via a new button, implemented in LateNight/Palemoon (the only skin for now) and shown for effects that provide a UI:

![image](https://github.com/user-attachments/assets/7df2f701-a629-4fac-b48f-19ac3aa79e6a)

![image](https://github.com/user-attachments/assets/0d75fbc7-a1f8-4ce5-ad8c-48a94f13eac8)

These can be hidden via the skin settings to reduce UI clutter, if not needed:

![image](https://github.com/user-attachments/assets/38ef3c0a-0725-49ac-af8e-fedbf62bdf9b)

### To do

- Generic implementation
  - [x] Add button for toggling effect UIs
  - [x] Add `DlgEffect` abstraction that sets up a generic effect UI (a floating dialog)
  - [x] Update the `ui_shown` control object when the window is closed manually
  - [x] Make sure that effect UIs are also closed upon closing the main window
  - [x] Figure out if we can gray out/hide the button for toggling the UI if the effect doesn't support UIs. `EffectManifest` now exposes a `hasUI` property, which may be helpful for that.
- Audio Unit implementation
  - [x] Host plugin views by loading them from the corresponding bundle
  - [x] Fall back to generic view if the plugin does not provide a custom UI
  - [x] Automatically size the dialog window correctly

### Potentially out-of-scope

- Fix sampling rate mismatch between Audio Unit plugins and Mixxx
  - See https://github.com/mixxxdj/mixxx/pull/13888#issuecomment-2477938796
- Update the parameter knobs on the Mixxx side after changing them from the GUI (the other direction already works and the effect also updates as intended from the GUI, this seems to be purely cosmetic)
- Sync tempo/beat with AU effects
  - Currently plugins that operate primarily in beat domain (such as ShaperBox) are not super useful, since they can't use the correct tempo (and their default tempo is almost always misaligned)
  - See e.g. https://forums.developer.apple.com/forums/thread/46085

Feedback welcome!

[^1]: Support for UIs of other effect backends like LV2 (or VST plugins once we implement #9019) could be added in future PRs as needed.