### PR TITLE
[2.5] clang-format: Indent Objective-C blocks with 4 spaces

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -41,6 +41,7 @@ StatementMacros:
   - QT_REQUIRE_VERSION
 ---
 Language: ObjC
+ObjCBlockIndentWidth: 4
 # We exclude Objective-C(++) from the second line-wrapping pass in tools/clang_format.py
 # since this pass only applies C++ rules and therefore include the ColumnLimit in the
 # 'main' clang-format config here.


### PR DESCRIPTION
Cherry-pick of https://github.com/mixxxdj/mixxx/pull/13503 to 2.5 (which would be useful to have to avoid having diverging code formatting).