### PR TITLE
avoid data race on m_pStream

### DIFF
--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -94,7 +94,8 @@ SoundDevicePortAudio::SoundDevicePortAudio(UserSettingsPointer config,
           m_framesSinceAudioLatencyUsageUpdate(0),
           m_syncBuffers(2),
           m_invalidTimeInfoCount(0),
-          m_lastCallbackEntrytoDacSecs(0) {
+          m_lastCallbackEntrytoDacSecs(0),
+          m_streamState(StreamState::STOP) {
     // Setting parent class members:
     m_hostAPI = Pa_GetHostApiInfo(deviceInfo->hostApi)->name;
     m_sampleRate = mixxx::audio::SampleRate::fromDouble(deviceInfo->defaultSampleRate);
@@ -360,10 +361,16 @@ SoundDeviceStatus SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffer
 #endif
 
     // Start stream
+
+    // Tell the callback that we are starting but not ready yet.
+    // The callback will return paContinue but not access m_pStream
+    // yet.
+    m_streamState.store(StreamState::STARTING, std::memory_order_release);
     err = Pa_StartStream(pStream);
     if (err != paNoError) {
         qWarning() << "PortAudio: Start stream error:" << Pa_GetErrorText(err);
         m_lastError = QString::fromUtf8(Pa_GetErrorText(err));
+        m_streamState.store(StreamState::STOP, std::memory_order_release);
         err = Pa_CloseStream(pStream);
         if (err != paNoError) {
             qWarning() << "PortAudio: Close stream error:"
@@ -392,6 +399,9 @@ SoundDeviceStatus SoundDevicePortAudio::open(bool isClkRefDevice, int syncBuffer
         m_clkRefTimer.start();
     }
     m_pStream = pStream;
+    // Tell the callback m_pStream can be accessed
+    m_streamState.store(StreamState::READY, std::memory_order_release);
+
     return SoundDeviceStatus::Ok;
 }
 
@@ -401,8 +411,11 @@ bool SoundDevicePortAudio::isOpen() const {
 
 SoundDeviceStatus SoundDevicePortAudio::close() {
     //qDebug() << "SoundDevicePortAudio::close()" << m_deviceId;
+
+    // Tell the callback to return paAbort. This stops the stream as soon as possible.
+    // After stopping the stream using this technique, Pa_StopStream() still has to be called.
+    m_streamState.store(StreamState::STOP, std::memory_order_release);
     PaStream* pStream = m_pStream;
-    m_pStream = nullptr;
     if (pStream) {
         // Make sure the stream is not stopped before we try stopping it.
         PaError err = Pa_IsStreamStopped(pStream);
@@ -415,18 +428,30 @@ SoundDeviceStatus SoundDevicePortAudio::close() {
         if (err < 0) {
             qWarning() << "PortAudio: Stream already stopped:"
                        << Pa_GetErrorText(err) << m_deviceId;
+            m_pStream = nullptr;
             return SoundDeviceStatus::Error;
         }
 
-        //Stop the stream.
+        // Stop the stream. Since the start of this function we are returning
+        // paAbort from the callback. paAbort stops the stream as soon as possible.
+        // When stopping the stream using this technique, we still need to call
+        // Pa_StopStream() before starting the stream again.
+
         err = Pa_StopStream(pStream);
-        //PaError err = Pa_AbortStream(m_pStream); //Trying Pa_AbortStream instead, because StopStream seems to wait
-                                                   //until all the buffers have been flushed, which can take a
-                                                   //few (annoying) seconds when you're doing soundcard input.
-                                                   //(it flushes the input buffer, and then some, or something)
-                                                   //BIG FAT WARNING: Pa_AbortStream() will kill threads while they're
-                                                   //waiting on a mutex, which will leave the mutex in an screwy
-                                                   //state. Don't use it!
+        // We should now be able to safely set m_pStream to null
+        m_pStream = nullptr;
+
+        // Note: With the use of return value paAbort as described above,
+        // the comment below is not relevant anymore, but I am leaving it
+        // because of the BIG FAT WARNING, just in case.
+        //
+        // Trying Pa_AbortStream instead, because StopStream seems to wait
+        // until all the buffers have been flushed, which can take a
+        // few (annoying) seconds when you're doing soundcard input.
+        // (it flushes the input buffer, and then some, or something)
+        // BIG FAT WARNING: Pa_AbortStream() will kill threads while they're
+        // waiting on a mutex, which will leave the mutex in an screwy
+        // state. Don't use it!
 
         if (err != paNoError) {
             qWarning() << "PortAudio: Stop stream error:"
@@ -455,8 +480,14 @@ QString SoundDevicePortAudio::getError() const {
 }
 
 void SoundDevicePortAudio::readProcess(SINT framesPerBuffer) {
+    if (m_streamState.load(std::memory_order_acquire) != StreamState::READY) {
+        return;
+    }
     PaStream* pStream = m_pStream;
-    if (pStream && m_inputParams.channelCount && m_inputFifo) {
+    VERIFY_OR_DEBUG_ASSERT(pStream) {
+        return;
+    }
+    if (m_inputParams.channelCount && m_inputFifo) {
         int inChunkSize = framesPerBuffer * m_inputParams.channelCount;
         if (m_syncBuffers == 0) { // "Experimental (no delay)"
 
@@ -586,8 +617,13 @@ void SoundDevicePortAudio::readProcess(SINT framesPerBuffer) {
 }
 
 void SoundDevicePortAudio::writeProcess(SINT framesPerBuffer) {
+    if (m_streamState.load(std::memory_order_acquire) != StreamState::READY) {
+        return;
+    }
     PaStream* pStream = m_pStream;
-
+    VERIFY_OR_DEBUG_ASSERT(pStream) {
+        return;
+    }
     if (pStream && m_outputParams.channelCount && m_outputFifo) {
         int outChunkSize = framesPerBuffer * m_outputParams.channelCount;
         int writeAvailable = m_outputFifo->writeAvailable();
@@ -820,7 +856,9 @@ int SoundDevicePortAudio::callbackProcessDrift(
             //qDebug() << "callbackProcess read:" << (float)readAvailable / outChunkSize << "Buffer empty";
         }
     }
-    return paContinue;
+    return m_streamState.load(std::memory_order_acquire) == StreamState::STOP
+            ? paAbort
+            : paContinue;
 }
 
 int SoundDevicePortAudio::callbackProcess(const SINT framesPerBuffer,
@@ -872,7 +910,9 @@ int SoundDevicePortAudio::callbackProcess(const SINT framesPerBuffer,
             //qDebug() << "callbackProcess read:" << "Buffer empty";
         }
     }
-    return paContinue;
+    return m_streamState.load(std::memory_order_acquire) == StreamState::STOP
+            ? paAbort
+            : paContinue;
 }
 
 int SoundDevicePortAudio::callbackProcessClkRef(
@@ -1007,7 +1047,7 @@ int SoundDevicePortAudio::callbackProcessClkRef(
                     << "SoundDevicePortAudio::callbackProcess m_outputParams channel count is zero or less:"
                     << m_outputParams.channelCount;
             // Bail out.
-            return paContinue;
+            m_streamState.store(StreamState::STOP, std::memory_order_release);
         }
 
         composeOutputBuffer(out, framesPerBuffer, 0, m_outputParams.channelCount);
@@ -1017,7 +1057,9 @@ int SoundDevicePortAudio::callbackProcessClkRef(
 
     updateAudioLatencyUsage(framesPerBuffer);
 
-    return paContinue;
+    return m_streamState.load(std::memory_order_acquire) == StreamState::STOP
+            ? paAbort
+            : paContinue;
 }
 
 void SoundDevicePortAudio::updateCallbackEntryToDacTime(

--- a/src/soundio/sounddeviceportaudio.h
+++ b/src/soundio/sounddeviceportaudio.h
@@ -59,7 +59,7 @@ class SoundDevicePortAudio : public SoundDevice {
     void updateAudioLatencyUsage(const SINT framesPerBuffer);
 
     // PortAudio stream for this device.
-    PaStream* volatile m_pStream;
+    std::atomic<PaStream*> m_pStream;
     // Struct containing information about this device. Don't free() it, it
     // belongs to PortAudio.
     const PaDeviceInfo* m_deviceInfo;
@@ -84,12 +84,5 @@ class SoundDevicePortAudio : public SoundDevice {
     int m_invalidTimeInfoCount;
     PerformanceTimer m_clkRefTimer;
     PaTime m_lastCallbackEntrytoDacSecs;
-
-    enum class StreamState : int {
-        STOP,
-        STARTING,
-        READY
-    };
-
-    std::atomic<StreamState> m_streamState;
+    std::atomic<int> m_callbackResult;
 };

--- a/src/soundio/sounddeviceportaudio.h
+++ b/src/soundio/sounddeviceportaudio.h
@@ -84,4 +84,12 @@ class SoundDevicePortAudio : public SoundDevice {
     int m_invalidTimeInfoCount;
     PerformanceTimer m_clkRefTimer;
     PaTime m_lastCallbackEntrytoDacSecs;
+
+    enum class StreamState : int {
+        STOP,
+        STARTING,
+        READY
+    };
+
+    std::atomic<StreamState> m_streamState;
 };


### PR DESCRIPTION
This fixes several tsan warnings related with stopping / closing portaudio streams, including #13870.

Apart from access to a non-atomic variable m_pStream, the real problem here was that 
readProcess() writeProcess() would take a copy of m_pStream:

```
PaStream* pStream = m_pStream;
```

and close() would then call Pa_StopStream(m_pStream); Apparently stopping a stream and still accessing it in the callback leads to data races, at least on macOS.

Now, it the portaudio docs I read:

> [Pa_StopStream()](https://www.portaudio.com/docs/v19-doxydocs/portaudio_8h.html#af18dd60220251286c337631a855e38a0) is designed to make sure that the buffers you've processed in your callback are all played, which may cause some delay. Alternatively, you could call [Pa_AbortStream()](https://www.portaudio.com/docs/v19-doxydocs/portaudio_8h.html#a138e57abde4e833c457b64895f638a25). On some platforms, aborting the stream is much faster and may cause some data processed by your callback not to be played.
> Another way to stop the stream is to return either paComplete, or paAbort from your callback. paComplete ensures that the last buffer is played whereas paAbort stops the stream as soon as possible. If you stop the stream using this technique, you will need to call [Pa_StopStream()](https://www.portaudio.com/docs/v19-doxydocs/portaudio_8h.html#af18dd60220251286c337631a855e38a0) before starting the stream again.

So what I do: in close() I change the (atomic) return value for readProcess and writeProcess from paContinue to paAbort, which will stop the stream. Pa_StopStream can then safely be called and m_pStream set to null.

As a side effect this also addresses a comment in the code about a failed intent to use Pa_AbortStream instead of PaStopStream.

This works well on macOS and I have not seen any portaudio related tsan warnings anymore. But since the platform specific aspects of Portaudio it is important to ensure this works as expected on Windows and Linux.
