### PR TITLE
(fix) Library > Analysis: enable Stop button when anaylzing crate/playlist

### DIFF
--- a/src/library/analysis/dlganalysis.cpp
+++ b/src/library/analysis/dlganalysis.cpp
@@ -154,6 +154,7 @@ void DlgAnalysis::slotAnalysisActive(bool bActive) {
     if (bActive) {
         pushButtonAnalyze->setChecked(true);
         pushButtonAnalyze->setText(tr("Stop Analysis"));
+        pushButtonAnalyze->setEnabled(true);
         labelProgress->setEnabled(true);
     } else {
         pushButtonAnalyze->setChecked(false);


### PR DESCRIPTION
I just noticed that when you select [crate] -> Analyse entire crate, the analysis can't be stopped because the Stop Analysis button is deactivated (until the table selection changes or Select All is clicked).