### PR TITLE
MixxxApplication: Handle nullptr targets in notify

### DIFF
--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -14,6 +14,7 @@
 #include "soundio/soundmanagerutil.h"
 #include "track/track.h"
 #include "track/trackref.h"
+#include "util/assert.h"
 #include "util/cache.h"
 #include "util/cmdlineargs.h"
 #include "util/color/rgbcolor.h"
@@ -198,6 +199,11 @@ bool MixxxApplication::notify(QObject* pTarget, QEvent* pEvent) {
     }
 
     bool ret = QApplication::notify(pTarget, pEvent);
+
+    VERIFY_OR_DEBUG_ASSERT(pTarget != nullptr) {
+        qWarning() << "Processed" << pEvent->type() << "for null pointer, this is probably a bug!";
+        return ret;
+    }
 
     if (m_isDeveloper &&
             time.elapsed() > kEventNotifyExecTimeWarningThreshold) {


### PR DESCRIPTION
This handles null `pTarget`s in `MixxxApplication::notify`'s debug logging.

I ran into some hard-to-debug corner cases where the target pointer was null and the event was already optimized out, so I believe handling this case should at least provide valuable information about the event through the log. Maybe it would even make sense to log this case via `qWarning()` or `qCritical()`.