### PR TITLE
Add missing qt6-declarative-private-dev and qt6-base-private-dev package

### DIFF
--- a/tools/debian_buildenv_qt6.sh
+++ b/tools/debian_buildenv_qt6.sh
@@ -100,6 +100,8 @@ case "$1" in
             protobuf-compiler \
             qtkeychain-qt6-dev \
             qt6-declarative-dev \
+            qt6-declarative-private-dev \
+            qt6-base-private-dev \
             "${PACKAGES_EXTRA[@]}"
         ;;
     *)


### PR DESCRIPTION
This fixes the failing Qt6 Ci in the 2.4 branch. 
I don't know how it worked before. 

This is the failing run: 
https://github.com/mixxxdj/mixxx/actions/runs/11846326785/job/33106335230