### PR TITLE
(fix) adjust some skin controls, allow point-and-click mapping

### DIFF
--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -1389,23 +1389,23 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
 
     // Skin Controls
     QMenu* pGuiMenu = addSubmenu(tr("User Interface"));
-    addControl("[Samplers]",
+    addControl("[Skin]",
             "show_samplers",
             tr("Samplers Show/Hide"),
             tr("Show/hide the sampler section"),
             pGuiMenu);
-    addControl("[Microphone]",
+    addControl("[Skin]",
             "show_microphone",
             tr("Microphone & Auxiliary Show/Hide"),
             tr("Show/hide the microphone & auxiliary section"),
             pGuiMenu);
-    addControl("[PreviewDeck]",
-            "show_previewdeck",
+    addControl("[Skin]",
+            "show_previewdecks",
             tr("Preview Deck Show/Hide"),
             tr("Show/hide the preview deck"),
             pGuiMenu);
-    addControl("[EffectRack1]",
-            "show",
+    addControl("[Skin]",
+            "show_effectrack",
             tr("Effect Rack Show/Hide"),
             tr("Show/hide the effect rack"),
             pGuiMenu);


### PR DESCRIPTION
Now these can also be mapped by click in MIDI Learning Wizard