### PR TITLE
(fix) Controller: clear mapping pointer when unloading a mapping

### DIFF
--- a/src/controllers/controller.h
+++ b/src/controllers/controller.h
@@ -81,6 +81,10 @@ class Controller : public QObject {
     template<typename SpecificMappingType>
     std::shared_ptr<SpecificMappingType> downcastAndTakeOwnership(
             std::shared_ptr<LegacyControllerMapping>&& pMapping) {
+        // When unsetting a mapping (select 'No mapping') we receive a nullptr
+        if (pMapping == nullptr) {
+            return nullptr;
+        }
         // Controller cannot take ownership if pMapping is referenced elsewhere because
         // the controller polling thread needs exclusive accesses to the non-thread safe
         // LegacyControllerMapping.

--- a/src/controllers/controllermanager.cpp
+++ b/src/controllers/controllermanager.cpp
@@ -423,6 +423,7 @@ void ControllerManager::slotApplyMapping(Controller* pController,
     if (!pMapping) {
         closeController(pController);
         // Unset the controller mapping for this controller
+        pController->setMapping(nullptr);
         m_pConfig->remove(key);
         emit mappingApplied(false);
         return;


### PR DESCRIPTION
With #13842 I noticed that the controller's pMapping still points to the previously loaded mapping when loading 'No mapping'.
Is there any reason for that?