### PR TITLE
Controllers: allow to enable MIDI Through Port in non-developer sessions

### DIFF
--- a/src/controllers/controllermanager.cpp
+++ b/src/controllers/controllermanager.cpp
@@ -34,7 +34,8 @@
 // Poll every 1ms (where possible) for good controller response
 #ifdef __LINUX__
 // Many Linux distros ship with the system tick set to 250Hz so 1ms timer
-// reportedly causes CPU hosage. See Bug #990992 rryan 6/2012
+// reportedly causes CPU hosage. See https://github.com/mixxxdj/mixxx/issues/6383
+// rryan 6/2012
 const mixxx::Duration ControllerManager::kPollInterval = mixxx::Duration::fromMillis(5);
 #else
 const mixxx::Duration ControllerManager::kPollInterval = mixxx::Duration::fromMillis(1);
@@ -153,7 +154,7 @@ void ControllerManager::slotInitialize() {
     // Instantiate all enumerators. Enumerators can take a long time to
     // construct since they interact with host MIDI APIs.
 #ifdef __PORTMIDI__
-    m_enumerators.append(new PortMidiEnumerator());
+    m_enumerators.append(new PortMidiEnumerator(m_pConfig));
 #endif
 #ifdef __HSS1394__
     m_enumerators.append(new Hss1394Enumerator(m_pConfig));

--- a/src/controllers/defs_controllers.h
+++ b/src/controllers/defs_controllers.h
@@ -26,3 +26,9 @@ inline QString userMappingsPath(UserSettingsPointer pConfig) {
 #define MIDI_MAPPING_EXTENSION ".midi.xml"
 #define BULK_MAPPING_EXTENSION ".bulk.xml"
 #define XML_SCHEMA_VERSION "1"
+
+#ifdef __PORTMIDI__
+const auto kMidiThroughPortPrefix = QLatin1String("MIDI Through Port");
+const ConfigKey kMidiThroughCfgKey =
+        ConfigKey(QStringLiteral("[Controller]"), QStringLiteral("midi_through_enabled"));
+#endif

--- a/src/controllers/dlgprefcontrollers.cpp
+++ b/src/controllers/dlgprefcontrollers.cpp
@@ -44,6 +44,28 @@ DlgPrefControllers::DlgPrefControllers(DlgPreferences* pPreferences,
             this,
             &DlgPrefControllers::rescanControllers);
 
+#ifdef __PORTMIDI__
+    checkBox_midithrough->setChecked(m_pConfig->getValue(kMidiThroughCfgKey, false));
+    connect(checkBox_midithrough,
+            &QCheckBox::stateChanged,
+            this,
+            &DlgPrefControllers::slotMidiThroughChanged);
+    txt_midithrough->setTextFormat(Qt::RichText);
+    //: text enclosed in <b> is bold, <br/> is a linebreak
+    //: %1 is the placehodler for 'MIDI Through Port'
+    txt_midithrough->setText(tr(
+            "%1 is a virtual controller that allows to use e.g. the 'MIDI for light' "
+            "mapping.<br/>"
+            "You need to restart Mixxx in order to enable it.<br/>"
+            "<b>Note:</b> mappings meant for physical controllers can cause issues and "
+            "even render the Mixxx GUI unresponsive when being loaded to %1.")
+                    .arg(kMidiThroughPortPrefix));
+#else
+    line_midithrough->hide();
+    checkBox_midithrough->hide();
+    txt_midithrough->hide();
+#endif
+
     // Setting the description text here instead of in the ui file allows to paste
     // a formatted link (text color is a more readable blend of text color and original link color).
     txtMappingsOverview->setText(tr(
@@ -234,3 +256,9 @@ void DlgPrefControllers::slotHighlightDevice(DlgPrefController* pControllerDlg, 
     temp.setBold(enabled);
     pControllerTreeItem->setFont(0, temp);
 }
+
+#ifdef __PORTMIDI__
+void DlgPrefControllers::slotMidiThroughChanged(bool checked) {
+    m_pConfig->setValue(kMidiThroughCfgKey, checked);
+}
+#endif

--- a/src/controllers/dlgprefcontrollers.h
+++ b/src/controllers/dlgprefcontrollers.h
@@ -41,6 +41,9 @@ class DlgPrefControllers : public DlgPreferencePage, public Ui::DlgPrefControlle
 
   private slots:
     void rescanControllers();
+#ifdef __PORTMIDI__
+    void slotMidiThroughChanged(bool checked);
+#endif
     void slotHighlightDevice(DlgPrefController* dialog, bool enabled);
 
   private:

--- a/src/controllers/dlgprefcontrollersdlg.ui
+++ b/src/controllers/dlgprefcontrollersdlg.ui
@@ -13,7 +13,7 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
    <item row="0" column="0">
-    <widget class="QGroupBox" name="groupBox_2">
+    <widget class="QGroupBox" name="groupBox_overview">
      <property name="title">
       <string>Controllers</string>
      </property>
@@ -69,11 +69,56 @@
         </property>
        </widget>
       </item>
+
+      <item>
+       <widget class="Line" name="line_midithrough">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+
+      <item>
+       <widget class="QCheckBox" name="checkBox_midithrough">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Enable MIDI Through Port</string>
+        </property>
+       </widget>
+      </item>
+
+      <item>
+       <widget class="QLabel" name="txt_midithrough">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Ignored" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>10</height>
+         </size>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
    <item row="1" column="0">
-    <widget class="QGroupBox" name="groupBox">
+    <widget class="QGroupBox" name="groupBox_mappings">
      <property name="title">
       <string>Mappings</string>
      </property>
@@ -178,6 +223,10 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  checkBox_midithrough
+  btnOpenUserMappings
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/controllers/midi/portmidienumerator.h
+++ b/src/controllers/midi/portmidienumerator.h
@@ -1,18 +1,20 @@
 #pragma once
 
 #include "controllers/midi/midienumerator.h"
+#include "preferences/usersettings.h"
 
 /// This class handles discovery and enumeration of DJ controllers that appear under the PortMIDI cross-platform API.
 class PortMidiEnumerator : public MidiEnumerator {
     Q_OBJECT
   public:
-    PortMidiEnumerator();
+    PortMidiEnumerator(UserSettingsPointer pConfig);
     ~PortMidiEnumerator() override;
 
     QList<Controller*> queryDevices() override;
 
   private:
     QList<Controller*> m_devices;
+    UserSettingsPointer m_pConfig;
 };
 
 // For testing.


### PR DESCRIPTION
Fixes #8356
Replaces #4148 

Enabling requires restart.
Setting is stored in config as `[Controller] midi_through_enabled`

The description is just a proposal.
In a followup we may replace it with brief description and a link to to-be-written manual chapter.

![image](https://github.com/user-attachments/assets/fff2d8dd-8652-4a05-b2f2-6aa84bcab98c)
