### PR TITLE
MixxxApplication: Only log opaque pointer after notify

### DIFF
--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -201,21 +201,12 @@ bool MixxxApplication::notify(QObject* pTarget, QEvent* pEvent) {
 
     if (m_isDeveloper &&
             time.elapsed() > kEventNotifyExecTimeWarningThreshold) {
-        QDebug debug = qDebug();
-        debug << "Processing"
-              << pEvent->type()
-              << "for object";
-        if (pEvent->type() == QEvent::DeferredDelete ||
-                pEvent->type() == QEvent::ChildRemoved) {
-            // pTarget can be already dangling in case of DeferredDelete
-            debug << static_cast<void*>(pTarget); // will print dangling address
-        } else {
-            debug << pTarget // will print address, class and object name
-                  << "running in thread:"
-                  << pTarget->thread()->objectName();
-        }
-        debug << "took"
-              << time.elapsed().debugMillisWithUnit();
+        qDebug() << "Processing"
+                 << pEvent->type()
+                 << "for object"
+                 << static_cast<void*>(pTarget) // may be a dangling pointer in some cases
+                 << "took"
+                 << time.elapsed().debugMillisWithUnit();
     }
 
     return ret;


### PR DESCRIPTION
As an addendum to #13900, `QEvent::Timer` seems to be another event type where a dangling pointer could come up (the screenshot includes some more logging which I've removed again):

![Screenshot 2024-11-19 at 18 46 45](https://github.com/user-attachments/assets/9198969c-8529-4bde-abd6-0ef493391905)

Since the target pointer could be dangling for any event point, this PR takes the safer road by only logging the opaque pointer after the notify call.