### PR TITLE
Remove boilerplate and duplication in controller setting definition

### DIFF
--- a/src/controllers/legacycontrollersettings.cpp
+++ b/src/controllers/legacycontrollersettings.cpp
@@ -1,7 +1,5 @@
 #include "controllers/legacycontrollersettings.h"
 
-#include <util/assert.h>
-
 #include <QBoxLayout>
 #include <QCheckBox>
 #include <QColorDialog>
@@ -17,6 +15,8 @@
 #include <QStringLiteral>
 
 #include "moc_legacycontrollersettings.cpp"
+#include "util/assert.h"
+#include "util/parented_ptr.h"
 
 namespace {
 
@@ -66,10 +66,12 @@ LegacyControllerSettingBuilder::LegacyControllerSettingBuilder() {
 }
 
 AbstractLegacyControllerSetting::AbstractLegacyControllerSetting(const QDomElement& element) {
-    m_variableName = element.attribute("variable").trimmed();
-    m_label = replaceMarkupStyleStr(element.attribute("label", m_variableName).trimmed());
+    m_variableName = element.attribute(QStringLiteral("variable")).trimmed();
+    m_label = replaceMarkupStyleStr(
+            element.attribute(QStringLiteral("label"), m_variableName)
+                    .trimmed());
 
-    QDomElement description = element.firstChildElement("description");
+    QDomElement description = element.firstChildElement(QStringLiteral("description"));
     if (!description.isNull()) {
         m_description = replaceMarkupStyleStr(description.text().trimmed());
     }
@@ -106,7 +108,7 @@ QWidget* AbstractLegacyControllerSetting::buildWidget(QWidget* pParent,
     pLabelWidget->setText(label());
 
     if (!description().isEmpty()) {
-        pRoot->setToolTip(QString("<p>%1</p>").arg(description()));
+        pRoot->setToolTip(QStringLiteral("<p>%1</p>").arg(description()));
     }
 
     pLayout->addWidget(pLabelWidget);
@@ -122,8 +124,8 @@ QWidget* AbstractLegacyControllerSetting::buildWidget(QWidget* pParent,
 
 LegacyControllerBooleanSetting::LegacyControllerBooleanSetting(
         const QDomElement& element)
-        : AbstractLegacyControllerSetting(element) {
-    m_defaultValue = parseValue(element.attribute("default"));
+        : LegacyControllerSettingMixin(element) {
+    m_defaultValue = parseValue(element.attribute(QStringLiteral("default")));
     m_savedValue = m_defaultValue;
     m_editedValue = m_defaultValue;
 }
@@ -143,7 +145,7 @@ QWidget* LegacyControllerBooleanSetting::buildInputWidget(QWidget* pParent) {
     }
 
     if (!description().isEmpty()) {
-        pCheckBox->setToolTip(QString("<p>%1</p>").arg(description()));
+        pCheckBox->setToolTip(QStringLiteral("<p>%1</p>").arg(description()));
     }
 
     connect(this, &AbstractLegacyControllerSetting::valueReset, pCheckBox, [this, pCheckBox]() {
@@ -177,9 +179,9 @@ QWidget* LegacyControllerBooleanSetting::buildInputWidget(QWidget* pParent) {
 }
 
 bool LegacyControllerBooleanSetting::match(const QDomElement& element) {
-    return element.hasAttribute("type") &&
-            QString::compare(element.attribute("type"),
-                    "boolean",
+    return element.hasAttribute(QStringLiteral("type")) &&
+            QString::compare(element.attribute(QStringLiteral("type")),
+                    QStringLiteral("boolean"),
                     Qt::CaseInsensitive) == 0;
 }
 
@@ -228,22 +230,23 @@ QWidget* LegacyControllerRealSetting::buildInputWidget(QWidget* pParent) {
 
 LegacyControllerEnumSetting::LegacyControllerEnumSetting(
         const QDomElement& element)
-        : AbstractLegacyControllerSetting(element), m_options(), m_defaultValue(0) {
+        : LegacyControllerSettingMixin(element, 0),
+          m_options() {
     size_t pos = 0;
-    for (QDomElement value = element.firstChildElement("value");
+    for (QDomElement value = element.firstChildElement(QStringLiteral("value"));
             !value.isNull();
-            value = value.nextSiblingElement("value")) {
+            value = value.nextSiblingElement(QStringLiteral("value"))) {
         QString val = value.text();
-        QColor color = QColor(value.attribute("color"));
+        QColor color = QColor(value.attribute(QStringLiteral("color")));
         // TODO: Remove once we mandate GCC 10/Clang 16
 #if defined(__cpp_aggregate_paren_init) &&       \
         __cpp_aggregate_paren_init >= 201902L && \
         !defined(_MSC_VER) // FIXME: Bug in MSVC preventing the use of this feature
-        m_options.emplace_back(val, value.attribute("label", val), color);
+        m_options.emplace_back(val, value.attribute(QStringLiteral("label"), val), color);
 #else
-        m_options.emplace_back(Item{val, value.attribute("label", val), color});
+        m_options.emplace_back(Item{val, value.attribute(QStringLiteral("label"), val), color});
 #endif
-        if (value.hasAttribute("default")) {
+        if (value.hasAttribute(QStringLiteral("default"))) {
             m_defaultValue = pos;
         }
         pos++;
@@ -305,12 +308,8 @@ QWidget* LegacyControllerEnumSetting::buildInputWidget(QWidget* pParent) {
 
 LegacyControllerColorSetting::LegacyControllerColorSetting(
         const QDomElement& element)
-        : AbstractLegacyControllerSetting(element),
-          m_defaultValue(QColor(element.attribute("default"))),
-          m_savedValue(m_defaultValue),
-          m_editedValue(m_defaultValue) {
-    reset();
-    save();
+        : LegacyControllerSettingMixin(element,
+                  QColor(element.attribute(QStringLiteral("default")))) {
 }
 
 LegacyControllerColorSetting::~LegacyControllerColorSetting() = default;
@@ -371,13 +370,9 @@ QWidget* LegacyControllerColorSetting::buildInputWidget(QWidget* pParent) {
 
 LegacyControllerFileSetting::LegacyControllerFileSetting(
         const QDomElement& element)
-        : AbstractLegacyControllerSetting(element),
-          m_fileFilter(element.attribute("pattern")),
-          m_defaultValue(QFileInfo(element.attribute("default"))),
-          m_savedValue(m_defaultValue),
-          m_editedValue(m_defaultValue) {
-    reset();
-    save();
+        : LegacyControllerSettingMixin(element,
+                  QFileInfo(element.attribute(QStringLiteral("default")))),
+          m_fileFilter(element.attribute(QStringLiteral("pattern"))) {
 }
 LegacyControllerFileSetting::~LegacyControllerFileSetting() = default;
 

--- a/src/controllers/legacycontrollersettings.h
+++ b/src/controllers/legacycontrollersettings.h
@@ -8,7 +8,6 @@
 
 #include "controllers/legacycontrollersettingsfactory.h"
 #include "controllers/legacycontrollersettingslayout.h"
-#include "util/parented_ptr.h"
 
 namespace {
 template<class T>
@@ -127,9 +126,56 @@ class AbstractLegacyControllerSetting : public QObject {
     QString m_description;
 };
 
+/// @brief Base setting class generic
+/// @tparam T The type of value this setting type is holding
+template<class T>
+class LegacyControllerSettingMixin : public AbstractLegacyControllerSetting {
+  public:
+    bool isDefault() const override {
+        return m_savedValue == m_defaultValue;
+    }
+    bool isDirty() const override {
+        return m_savedValue != m_editedValue;
+    }
+
+    void save() override {
+        m_savedValue = m_editedValue;
+    }
+
+    void reset() override {
+        m_editedValue = m_defaultValue;
+        emit valueReset();
+    }
+
+  protected:
+    LegacyControllerSettingMixin(const QDomElement& element)
+            : AbstractLegacyControllerSetting(element) {
+    }
+    LegacyControllerSettingMixin(const QDomElement& element,
+            T defaultValue)
+            : AbstractLegacyControllerSetting(element),
+              m_savedValue(defaultValue),
+              m_defaultValue(defaultValue),
+              m_editedValue(defaultValue) {
+        reset();
+        save();
+    }
+    LegacyControllerSettingMixin(const QDomElement& element,
+            T currentValue,
+            T defaultValue)
+            : AbstractLegacyControllerSetting(element),
+              m_savedValue(currentValue),
+              m_defaultValue(defaultValue) {
+    }
+
+    T m_savedValue;
+    T m_defaultValue;
+    T m_editedValue;
+};
+
 class LegacyControllerBooleanSetting
         : public LegacyControllerSettingFactory<LegacyControllerBooleanSetting>,
-          public AbstractLegacyControllerSetting {
+          public LegacyControllerSettingMixin<bool> {
   public:
     LegacyControllerBooleanSetting(const QDomElement& element);
 
@@ -148,25 +194,11 @@ class LegacyControllerBooleanSetting
         return m_savedValue ? "true" : "false";
     }
     void parse(const QString& in, bool* ok = nullptr) override {
-        if (ok != nullptr)
+        if (ok != nullptr) {
             *ok = true;
+        }
         m_savedValue = parseValue(in);
         m_editedValue = m_savedValue;
-    }
-    bool isDefault() const override {
-        return m_savedValue == m_defaultValue;
-    }
-    bool isDirty() const override {
-        return m_savedValue != m_editedValue;
-    }
-
-    virtual void save() override {
-        m_savedValue = m_editedValue;
-    }
-
-    virtual void reset() override {
-        m_editedValue = m_defaultValue;
-        emit valueReset();
     }
 
     static AbstractLegacyControllerSetting* createFrom(const QDomElement& element) {
@@ -175,25 +207,13 @@ class LegacyControllerBooleanSetting
     static bool match(const QDomElement& element);
 
   protected:
-    LegacyControllerBooleanSetting(const QDomElement& element,
-            bool currentValue,
-            bool defaultValue)
-            : AbstractLegacyControllerSetting(element),
-              m_savedValue(currentValue),
-              m_defaultValue(defaultValue) {
-    }
-
     bool parseValue(const QString& in) {
         return QString::compare(in, "true", Qt::CaseInsensitive) == 0 || in == "1";
     }
 
-    virtual QWidget* buildInputWidget(QWidget* parent) override;
+    QWidget* buildInputWidget(QWidget* parent) override;
 
   private:
-    bool m_savedValue;
-    bool m_defaultValue;
-    bool m_editedValue;
-
     FRIEND_TEST(LegacyControllerMappingSettingsTest, booleanSettingEditing);
 };
 
@@ -213,10 +233,17 @@ class LegacyControllerNumberSetting
                           ValueSerializer,
                           ValueDeserializer,
                           InputWidget>>,
-          public AbstractLegacyControllerSetting {
+          public LegacyControllerSettingMixin<SettingType> {
   public:
+    using LegacyControllerSettingMixin<SettingType>::m_savedValue;
+    using LegacyControllerSettingMixin<SettingType>::m_defaultValue;
+    using LegacyControllerSettingMixin<SettingType>::m_editedValue;
+    using LegacyControllerSettingMixin<SettingType>::save;
+    using LegacyControllerSettingMixin<SettingType>::reset;
+    using LegacyControllerSettingMixin<SettingType>::connect;
+    using LegacyControllerSettingMixin<SettingType>::changed;
     LegacyControllerNumberSetting(const QDomElement& element)
-            : AbstractLegacyControllerSetting(element) {
+            : LegacyControllerSettingMixin<SettingType>(element) {
         bool isOk = false;
         m_minValue = ValueDeserializer(element.attribute("min"), &isOk);
         if (!isOk) {
@@ -258,22 +285,6 @@ class LegacyControllerNumberSetting
         m_editedValue = m_savedValue;
     }
 
-    bool isDefault() const override {
-        return m_savedValue == m_defaultValue;
-    }
-    bool isDirty() const override {
-        return m_savedValue != m_editedValue;
-    }
-
-    virtual void save() override {
-        m_savedValue = m_editedValue;
-    }
-
-    virtual void reset() override {
-        m_editedValue = m_defaultValue;
-        emit valueReset();
-    }
-
     /// @brief Whether of not this setting definition and its current state are
     /// valid. Validity scope includes default/current/dirty value within range
     /// and a strictly positive step, strictly less than max..
@@ -298,24 +309,20 @@ class LegacyControllerNumberSetting
             SettingType minValue,
             SettingType maxValue,
             SettingType stepValue)
-            : AbstractLegacyControllerSetting(element),
-              m_savedValue(currentValue),
-              m_defaultValue(defaultValue),
+            : LegacyControllerSettingMixin<SettingType>(element,
+                      currentValue,
+                      defaultValue),
               m_minValue(minValue),
               m_maxValue(maxValue),
               m_stepValue(stepValue) {
     }
 
-    virtual QWidget* buildInputWidget(QWidget* parent) override;
+    QWidget* buildInputWidget(QWidget* parent) override;
 
   private:
-    SettingType m_savedValue;
-    SettingType m_defaultValue;
     SettingType m_minValue;
     SettingType m_maxValue;
     SettingType m_stepValue;
-
-    SettingType m_editedValue;
 
     FRIEND_TEST(LegacyControllerMappingSettingsTest, integerSettingEditing);
     FRIEND_TEST(LegacyControllerMappingSettingsTest, doubleSettingEditing);
@@ -369,7 +376,7 @@ class LegacyControllerRealSetting : public LegacyControllerNumberSetting<double,
 
 class LegacyControllerEnumSetting
         : public LegacyControllerSettingFactory<LegacyControllerEnumSetting>,
-          public AbstractLegacyControllerSetting {
+          public LegacyControllerSettingMixin<size_t> {
   public:
     struct Item {
         QString value;
@@ -393,21 +400,6 @@ class LegacyControllerEnumSetting
         return m_options.value(static_cast<int>(m_savedValue)).value;
     }
     void parse(const QString& in, bool* ok) override;
-    bool isDefault() const override {
-        return m_savedValue == m_defaultValue;
-    }
-    bool isDirty() const override {
-        return m_savedValue != m_editedValue;
-    }
-
-    virtual void save() override {
-        m_savedValue = m_editedValue;
-    }
-
-    virtual void reset() override {
-        m_editedValue = m_defaultValue;
-        emit valueReset();
-    }
 
     /// @brief Whether or not this setting definition and its current state are
     /// valid. Validity scope includes a known default/current/dirty option.
@@ -429,21 +421,15 @@ class LegacyControllerEnumSetting
             const QList<Item>& options,
             size_t currentValue,
             size_t defaultValue)
-            : AbstractLegacyControllerSetting(element),
-              m_options(options),
-              m_savedValue(currentValue),
-              m_defaultValue(defaultValue) {
+            : LegacyControllerSettingMixin(element, currentValue, defaultValue),
+              m_options(options) {
     }
 
-    virtual QWidget* buildInputWidget(QWidget* parent) override;
+    QWidget* buildInputWidget(QWidget* parent) override;
 
   private:
     // We use a QList instead of QHash here because we want to keep the natural order
     QList<Item> m_options;
-    size_t m_savedValue;
-    size_t m_defaultValue;
-
-    size_t m_editedValue;
 
     FRIEND_TEST(LegacyControllerMappingSettingsTest, enumSettingEditing);
     FRIEND_TEST(ControllerS4MK3SettingTest, ensureLibrarySettingValueAndEnumEquals);
@@ -451,7 +437,7 @@ class LegacyControllerEnumSetting
 
 class LegacyControllerColorSetting
         : public LegacyControllerSettingFactory<LegacyControllerColorSetting>,
-          public AbstractLegacyControllerSetting {
+          public LegacyControllerSettingMixin<QColor> {
   public:
     LegacyControllerColorSetting(const QDomElement& element);
 
@@ -465,21 +451,6 @@ class LegacyControllerColorSetting
         return m_savedValue.name(QColor::HexRgb);
     }
     void parse(const QString& in, bool* ok) override;
-    bool isDefault() const override {
-        return m_savedValue == m_defaultValue;
-    }
-    bool isDirty() const override {
-        return m_savedValue != m_editedValue;
-    }
-
-    virtual void save() override {
-        m_savedValue = m_editedValue;
-    }
-
-    virtual void reset() override {
-        m_editedValue = m_defaultValue;
-        emit valueReset();
-    }
 
     /// @brief Whether or not this setting definition and its current state are
     /// valid. Validity scope includes a known default/current/dirty option.
@@ -504,18 +475,12 @@ class LegacyControllerColorSetting
     LegacyControllerColorSetting(const QDomElement& element,
             QColor currentValue,
             QColor defaultValue)
-            : AbstractLegacyControllerSetting(element),
-              m_defaultValue(defaultValue),
-              m_savedValue(currentValue) {
+            : LegacyControllerSettingMixin(element,
+                      defaultValue,
+                      currentValue) {
     }
 
-    virtual QWidget* buildInputWidget(QWidget* parent) override;
-
-  private:
-    QColor m_defaultValue;
-    QColor m_savedValue;
-
-    QColor m_editedValue;
+    QWidget* buildInputWidget(QWidget* parent) override;
 
     FRIEND_TEST(ControllerS4MK3SettingTest, ensureLibrarySettingValueAndEnumEquals);
     FRIEND_TEST(LegacyControllerMappingSettingsTest, enumSettingEditing);
@@ -523,7 +488,7 @@ class LegacyControllerColorSetting
 
 class LegacyControllerFileSetting
         : public LegacyControllerSettingFactory<LegacyControllerFileSetting>,
-          public AbstractLegacyControllerSetting {
+          public LegacyControllerSettingMixin<QFileInfo> {
   public:
     LegacyControllerFileSetting(const QDomElement& element);
 
@@ -537,21 +502,6 @@ class LegacyControllerFileSetting
         return m_savedValue.absoluteFilePath();
     }
     void parse(const QString& in, bool* ok) override;
-    bool isDefault() const override {
-        return m_savedValue == m_defaultValue;
-    }
-    bool isDirty() const override {
-        return m_savedValue != m_editedValue;
-    }
-
-    virtual void save() override {
-        m_savedValue = m_editedValue;
-    }
-
-    virtual void reset() override {
-        m_editedValue = m_defaultValue;
-        emit valueReset();
-    }
 
     /// @brief Whether or not this setting definition and its current state are
     /// valid. Validity scope includes a known default/current/dirty option.
@@ -575,19 +525,15 @@ class LegacyControllerFileSetting
     LegacyControllerFileSetting(const QDomElement& element,
             const QFileInfo& currentValue,
             const QFileInfo& defaultValue)
-            : AbstractLegacyControllerSetting(element),
-              m_defaultValue(defaultValue),
-              m_savedValue(currentValue) {
+            : LegacyControllerSettingMixin(element,
+                      defaultValue,
+                      currentValue) {
     }
 
     QWidget* buildInputWidget(QWidget* parent) override;
 
   private:
     QString m_fileFilter;
-    QFileInfo m_defaultValue;
-    QFileInfo m_savedValue;
-
-    QFileInfo m_editedValue;
 
     FRIEND_TEST(LegacyControllerMappingSettingsTest, enumSettingEditing);
     FRIEND_TEST(ControllerS4MK3SettingTest, ensureLibrarySettingValueAndEnumEquals);

--- a/src/controllers/legacycontrollersettingsfactory.h
+++ b/src/controllers/legacycontrollersettingsfactory.h
@@ -2,8 +2,6 @@
 
 #include <QDomElement>
 
-#include "controllers/legacycontrollersettingsfactory.h"
-
 class AbstractLegacyControllerSetting;
 
 /// @brief This class defines an interface that a controller setting type must

--- a/src/test/controller_mapping_settings_test.cpp
+++ b/src/test/controller_mapping_settings_test.cpp
@@ -33,33 +33,31 @@ const char* const kValidEnumOption = "<value label=\"%1\">%2</value>";
 
 TEST_F(LegacyControllerMappingSettingsTest, booleanSettingParsing) {
     QDomDocument doc;
-    doc.setContent(QString(kValidBoolean).arg("false").toLatin1());
+    {
+        doc.setContent(QString(kValidBoolean).arg("false").toLatin1());
 
-    EXPECT_TRUE(LegacyControllerBooleanSetting::match(doc.documentElement()));
-    LegacyControllerBooleanSetting* setting = (LegacyControllerBooleanSetting*)
-            LegacyControllerBooleanSetting::createFrom(doc.documentElement());
-    EXPECT_TRUE(setting->valid()) << "Unable to create a boolean setting";
+        EXPECT_TRUE(LegacyControllerBooleanSetting::match(doc.documentElement()));
+        LegacyControllerBooleanSetting setting(doc.documentElement());
+        EXPECT_TRUE(setting.valid()) << "Unable to create a boolean setting";
 
-    EXPECT_EQ(setting->variableName(), "myToggle1");
-    EXPECT_EQ(setting->label(), "Test label");
-    EXPECT_EQ(setting->description(), "Test description");
+        EXPECT_EQ(setting.variableName(), "myToggle1");
+        EXPECT_EQ(setting.label(), "Test label");
+        EXPECT_EQ(setting.description(), "Test description");
 
-    EXPECT_FALSE(setting->isDirty());
-    EXPECT_TRUE(setting->isDefault());
-    EXPECT_EQ(setting->stringify(), "false");
-    EXPECT_TRUE(setting->valid());
+        EXPECT_FALSE(setting.isDirty());
+        EXPECT_TRUE(setting.isDefault());
+        EXPECT_EQ(setting.stringify(), "false");
+        EXPECT_TRUE(setting.valid());
+    }
 
-    delete setting;
+    {
+        doc.setContent(QString(kValidBoolean).arg("true").toLatin1());
 
-    doc.setContent(QString(kValidBoolean).arg("true").toLatin1());
+        LegacyControllerBooleanSetting setting(doc.documentElement());
+        EXPECT_TRUE(setting.valid()) << "Unable to create a boolean setting";
 
-    setting = (LegacyControllerBooleanSetting*)
-            LegacyControllerBooleanSetting::createFrom(doc.documentElement());
-    EXPECT_TRUE(setting->valid()) << "Unable to create a boolean setting";
-
-    EXPECT_EQ(setting->stringify(), "true");
-
-    delete setting;
+        EXPECT_EQ(setting.stringify(), "true");
+    }
 }
 
 TEST_F(LegacyControllerMappingSettingsTest, booleanSettingEditing) {
@@ -68,99 +66,89 @@ TEST_F(LegacyControllerMappingSettingsTest, booleanSettingEditing) {
             QByteArray("<option variable=\"myToggle1\" type=\"boolean\" "
                        "default=\"false\" label=\"Test label\"/>"));
 
-    LegacyControllerBooleanSetting* setting = (LegacyControllerBooleanSetting*)
-            LegacyControllerBooleanSetting::createFrom(doc.documentElement());
-    EXPECT_TRUE(setting->valid()) << "Unable to create a boolean setting";
+    LegacyControllerBooleanSetting setting(doc.documentElement());
+    EXPECT_TRUE(setting.valid()) << "Unable to create a boolean setting";
 
-    setting->m_editedValue = true;
-    EXPECT_TRUE(setting->isDirty());
-    setting->save();
-    EXPECT_FALSE(setting->isDirty());
-    EXPECT_EQ(setting->m_savedValue, true);
+    setting.m_editedValue = true;
+    EXPECT_TRUE(setting.isDirty());
+    setting.save();
+    EXPECT_FALSE(setting.isDirty());
+    EXPECT_EQ(setting.m_savedValue, true);
 
     bool ok;
-    setting->parse("true", &ok);
+    setting.parse("true", &ok);
     EXPECT_TRUE(ok);
-    EXPECT_FALSE(setting->isDirty());
-    EXPECT_EQ(setting->stringify(), "true");
-    EXPECT_TRUE(setting->value().isBool());
-    EXPECT_TRUE(setting->value().toBool());
-    EXPECT_FALSE(setting->isDefault());
-    setting->parse("1", &ok);
+    EXPECT_FALSE(setting.isDirty());
+    EXPECT_EQ(setting.stringify(), "true");
+    EXPECT_TRUE(setting.value().isBool());
+    EXPECT_TRUE(setting.value().toBool());
+    EXPECT_FALSE(setting.isDefault());
+    setting.parse("1", &ok);
     EXPECT_TRUE(ok);
-    setting->parse("0", &ok);
+    setting.parse("0", &ok);
     EXPECT_TRUE(ok);
-    EXPECT_FALSE(setting->isDirty());
-    EXPECT_EQ(setting->stringify(), "false");
-    setting->parse("TRUE", &ok);
+    EXPECT_FALSE(setting.isDirty());
+    EXPECT_EQ(setting.stringify(), "false");
+    setting.parse("TRUE", &ok);
     EXPECT_TRUE(ok);
-    EXPECT_EQ(setting->stringify(), "true");
-    EXPECT_TRUE(setting->value().isBool());
-    EXPECT_TRUE(setting->value().toBool());
-    setting->reset();
-    EXPECT_TRUE(setting->isDirty());
-    setting->save();
-    EXPECT_EQ(setting->stringify(), "false");
-    EXPECT_TRUE(setting->isDefault());
+    EXPECT_EQ(setting.stringify(), "true");
+    EXPECT_TRUE(setting.value().isBool());
+    EXPECT_TRUE(setting.value().toBool());
+    setting.reset();
+    EXPECT_TRUE(setting.isDirty());
+    setting.save();
+    EXPECT_EQ(setting.stringify(), "false");
+    EXPECT_TRUE(setting.isDefault());
 
-    EXPECT_TRUE(setting->value().isBool());
-    EXPECT_FALSE(setting->value().toBool());
+    EXPECT_TRUE(setting.value().isBool());
+    EXPECT_FALSE(setting.value().toBool());
 }
 
 TEST_F(LegacyControllerMappingSettingsTest, integerSettingParsing) {
     QDomDocument doc;
-    doc.setContent(QString(kValidInteger).arg("42", "1", "99", "1").toLatin1());
+    {
+        doc.setContent(QString(kValidInteger).arg("42", "1", "99", "1").toLatin1());
 
-    EXPECT_TRUE(LegacyControllerIntegerSetting::match(doc.documentElement()));
-    LegacyControllerIntegerSetting* setting = (LegacyControllerIntegerSetting*)
-            LegacyControllerIntegerSetting::createFrom(doc.documentElement());
-    EXPECT_TRUE(setting->valid()) << "Unable to create an integer setting";
+        EXPECT_TRUE(LegacyControllerIntegerSetting::match(doc.documentElement()));
+        LegacyControllerIntegerSetting setting(doc.documentElement());
+        EXPECT_TRUE(setting.valid()) << "Unable to create an integer setting";
 
-    EXPECT_EQ(setting->variableName(), "myInteger1");
-    EXPECT_EQ(setting->label(), "Test label");
-    EXPECT_EQ(setting->description(), "Test description");
+        EXPECT_EQ(setting.variableName(), "myInteger1");
+        EXPECT_EQ(setting.label(), "Test label");
+        EXPECT_EQ(setting.description(), "Test description");
 
-    EXPECT_FALSE(setting->isDirty());
-    EXPECT_TRUE(setting->isDefault());
-    EXPECT_EQ(setting->stringify(), "42");
-    EXPECT_TRUE(setting->valid());
-
-    delete setting;
-
-    doc.setContent(QString(kValidInteger).arg("18", "1", "99", "1").toLatin1());
-    setting = (LegacyControllerIntegerSetting*)
-            LegacyControllerIntegerSetting::createFrom(doc.documentElement());
-    EXPECT_TRUE(setting->valid()) << "Unable to create an integer setting";
-    EXPECT_EQ(setting->stringify(), "18");
-    EXPECT_TRUE(setting->valid());
-
-    delete setting;
-
-    // Invalid if default is out of range
-    doc.setContent(QString(kValidInteger).arg("10", "20", "30", "1").toLatin1());
-    setting = (LegacyControllerIntegerSetting*)
-            LegacyControllerIntegerSetting::createFrom(doc.documentElement());
-    EXPECT_EQ(setting->stringify(), "10");
-    EXPECT_FALSE(setting->valid());
-
-    delete setting;
-
-    doc.setContent(QString(kValidInteger).arg("10", "1", "5", "1").toLatin1());
-    setting = (LegacyControllerIntegerSetting*)
-            LegacyControllerIntegerSetting::createFrom(doc.documentElement());
-    EXPECT_EQ(setting->stringify(), "10");
-    EXPECT_FALSE(setting->valid());
-
-    delete setting;
-
-    // Invalid if step is zero
-    doc.setContent(QString(kValidInteger).arg("10", "0", "30", "0").toLatin1());
-    setting = (LegacyControllerIntegerSetting*)
-            LegacyControllerIntegerSetting::createFrom(doc.documentElement());
-    EXPECT_EQ(setting->stringify(), "10");
-    EXPECT_FALSE(setting->valid());
-
-    delete setting;
+        EXPECT_FALSE(setting.isDirty());
+        EXPECT_TRUE(setting.isDefault());
+        EXPECT_EQ(setting.stringify(), "42");
+        EXPECT_TRUE(setting.valid());
+    }
+    {
+        doc.setContent(QString(kValidInteger).arg("18", "1", "99", "1").toLatin1());
+        LegacyControllerIntegerSetting setting(doc.documentElement());
+        EXPECT_TRUE(setting.valid()) << "Unable to create an integer setting";
+        EXPECT_EQ(setting.stringify(), "18");
+        EXPECT_TRUE(setting.valid());
+    }
+    {
+        // Invalid if default is out of range
+        doc.setContent(QString(kValidInteger).arg("10", "20", "30", "1").toLatin1());
+        LegacyControllerIntegerSetting setting(doc.documentElement());
+        EXPECT_EQ(setting.stringify(), "10");
+        EXPECT_FALSE(setting.valid());
+    }
+    {
+        doc.setContent(QString(kValidInteger).arg("10", "1", "5", "1").toLatin1());
+        LegacyControllerIntegerSetting setting(doc.documentElement());
+        EXPECT_EQ(setting.stringify(), "10");
+        EXPECT_FALSE(setting.valid());
+    }
+    {
+        // Invalid if step is zero
+        doc.setContent(QString(kValidInteger).arg("10", "0", "30", "0").toLatin1());
+        LegacyControllerIntegerSetting setting(doc.documentElement());
+        EXPECT_EQ(setting.stringify(), "10");
+        EXPECT_FALSE(setting.valid());
+    }
 }
 
 TEST_F(LegacyControllerMappingSettingsTest, integerSettingEditing) {
@@ -168,99 +156,89 @@ TEST_F(LegacyControllerMappingSettingsTest, integerSettingEditing) {
     doc.setContent(
             QByteArray("<option variable=\"myInteger1\" type=\"integer\" label=\"Test label\"/>"));
 
-    LegacyControllerIntegerSetting* setting = (LegacyControllerIntegerSetting*)
-            LegacyControllerIntegerSetting::createFrom(doc.documentElement());
-    EXPECT_TRUE(setting->valid()) << "Unable to create an integer setting";
+    LegacyControllerIntegerSetting setting(doc.documentElement());
+    EXPECT_TRUE(setting.valid()) << "Unable to create an integer setting";
 
-    setting->m_editedValue = true;
-    EXPECT_TRUE(setting->isDirty());
-    setting->save();
-    EXPECT_FALSE(setting->isDirty());
-    EXPECT_EQ(setting->m_savedValue, true);
+    setting.m_editedValue = true;
+    EXPECT_TRUE(setting.isDirty());
+    setting.save();
+    EXPECT_FALSE(setting.isDirty());
+    EXPECT_EQ(setting.m_savedValue, true);
 
     bool ok;
-    setting->parse("42", &ok);
+    setting.parse("42", &ok);
     EXPECT_TRUE(ok);
-    EXPECT_FALSE(setting->isDirty());
-    EXPECT_EQ(setting->stringify(), "42");
-    EXPECT_TRUE(setting->value().isNumber());
-    EXPECT_EQ(setting->value().toInt(), 42);
-    EXPECT_FALSE(setting->isDefault());
-    setting->parse("-15", &ok);
+    EXPECT_FALSE(setting.isDirty());
+    EXPECT_EQ(setting.stringify(), "42");
+    EXPECT_TRUE(setting.value().isNumber());
+    EXPECT_EQ(setting.value().toInt(), 42);
+    EXPECT_FALSE(setting.isDefault());
+    setting.parse("-15", &ok);
     EXPECT_TRUE(ok);
-    setting->parse("0", &ok);
+    setting.parse("0", &ok);
     EXPECT_TRUE(ok);
-    EXPECT_FALSE(setting->isDirty());
-    EXPECT_EQ(setting->stringify(), "0");
-    setting->parse("30 ", &ok);
+    EXPECT_FALSE(setting.isDirty());
+    EXPECT_EQ(setting.stringify(), "0");
+    setting.parse("30 ", &ok);
     EXPECT_TRUE(ok);
-    EXPECT_EQ(setting->stringify(), "30");
-    EXPECT_TRUE(setting->value().isNumber());
-    EXPECT_EQ(setting->value().toInt(), 30);
-    setting->reset();
-    EXPECT_TRUE(setting->isDirty());
-    setting->save();
-    EXPECT_EQ(setting->stringify(), "0");
-    EXPECT_TRUE(setting->isDefault());
-    setting->parse("abc ", &ok);
+    EXPECT_EQ(setting.stringify(), "30");
+    EXPECT_TRUE(setting.value().isNumber());
+    EXPECT_EQ(setting.value().toInt(), 30);
+    setting.reset();
+    EXPECT_TRUE(setting.isDirty());
+    setting.save();
+    EXPECT_EQ(setting.stringify(), "0");
+    EXPECT_TRUE(setting.isDefault());
+    setting.parse("abc ", &ok);
     EXPECT_FALSE(ok);
-    EXPECT_TRUE(setting->value().isNumber());
-    EXPECT_EQ(setting->value().toInt(), 0);
+    EXPECT_TRUE(setting.value().isNumber());
+    EXPECT_EQ(setting.value().toInt(), 0);
 }
 
 TEST_F(LegacyControllerMappingSettingsTest, doubleSettingParsing) {
     QDomDocument doc;
-    doc.setContent(QString(kValidDouble).arg("42", "1", "99", "1").toLatin1());
+    {
+        doc.setContent(QString(kValidDouble).arg("42", "1", "99", "1").toLatin1());
 
-    EXPECT_TRUE(LegacyControllerRealSetting::match(doc.documentElement()));
-    LegacyControllerRealSetting* setting = (LegacyControllerRealSetting*)
-            LegacyControllerRealSetting::createFrom(doc.documentElement());
-    EXPECT_TRUE(setting->valid()) << "Unable to create a real setting";
+        EXPECT_TRUE(LegacyControllerRealSetting::match(doc.documentElement()));
+        LegacyControllerIntegerSetting setting(doc.documentElement());
+        EXPECT_TRUE(setting.valid()) << "Unable to create a real setting";
 
-    EXPECT_EQ(setting->variableName(), "myReal1");
-    EXPECT_EQ(setting->label(), "myReal1");
-    EXPECT_TRUE(setting->description().isEmpty());
+        EXPECT_EQ(setting.variableName(), "myReal1");
+        EXPECT_EQ(setting.label(), "myReal1");
+        EXPECT_TRUE(setting.description().isEmpty());
 
-    EXPECT_FALSE(setting->isDirty());
-    EXPECT_TRUE(setting->isDefault());
-    EXPECT_EQ(setting->stringify(), "42");
-    EXPECT_TRUE(setting->valid());
-
-    delete setting;
-
-    doc.setContent(QString(kValidInteger).arg("18", "1", "99", "1").toLatin1());
-    setting = (LegacyControllerRealSetting*)
-            LegacyControllerRealSetting::createFrom(doc.documentElement());
-    EXPECT_EQ(setting->stringify(), "18");
-    EXPECT_TRUE(setting->valid());
-
-    delete setting;
-
-    // Invalid if default is out of range
-    doc.setContent(QString(kValidInteger).arg("10", "20", "30", "1").toLatin1());
-    setting = (LegacyControllerRealSetting*)
-            LegacyControllerRealSetting::createFrom(doc.documentElement());
-    EXPECT_EQ(setting->stringify(), "10");
-    EXPECT_FALSE(setting->valid());
-
-    delete setting;
-
-    doc.setContent(QString(kValidInteger).arg("10", "1", "5", "1").toLatin1());
-    setting = (LegacyControllerRealSetting*)
-            LegacyControllerRealSetting::createFrom(doc.documentElement());
-    EXPECT_EQ(setting->stringify(), "10");
-    EXPECT_FALSE(setting->valid());
-
-    delete setting;
-
-    // Invalid if step is zero
-    doc.setContent(QString(kValidInteger).arg("10", "0", "30", "0").toLatin1());
-    setting = (LegacyControllerRealSetting*)
-            LegacyControllerRealSetting::createFrom(doc.documentElement());
-    EXPECT_EQ(setting->stringify(), "10");
-    EXPECT_FALSE(setting->valid());
-
-    delete setting;
+        EXPECT_FALSE(setting.isDirty());
+        EXPECT_TRUE(setting.isDefault());
+        EXPECT_EQ(setting.stringify(), "42");
+        EXPECT_TRUE(setting.valid());
+    }
+    {
+        doc.setContent(QString(kValidInteger).arg("18", "1", "99", "1").toLatin1());
+        LegacyControllerIntegerSetting setting(doc.documentElement());
+        EXPECT_EQ(setting.stringify(), "18");
+        EXPECT_TRUE(setting.valid());
+    }
+    {
+        // Invalid if default is out of range
+        doc.setContent(QString(kValidInteger).arg("10", "20", "30", "1").toLatin1());
+        LegacyControllerIntegerSetting setting(doc.documentElement());
+        EXPECT_EQ(setting.stringify(), "10");
+        EXPECT_FALSE(setting.valid());
+    }
+    {
+        doc.setContent(QString(kValidInteger).arg("10", "1", "5", "1").toLatin1());
+        LegacyControllerIntegerSetting setting(doc.documentElement());
+        EXPECT_EQ(setting.stringify(), "10");
+        EXPECT_FALSE(setting.valid());
+    }
+    {
+        // Invalid if step is zero
+        doc.setContent(QString(kValidInteger).arg("10", "0", "30", "0").toLatin1());
+        LegacyControllerIntegerSetting setting(doc.documentElement());
+        EXPECT_EQ(setting.stringify(), "10");
+        EXPECT_FALSE(setting.valid());
+    }
 }
 
 TEST_F(LegacyControllerMappingSettingsTest, doubleSettingEditing) {
@@ -268,77 +246,73 @@ TEST_F(LegacyControllerMappingSettingsTest, doubleSettingEditing) {
     doc.setContent(
             QByteArray("<option variable=\"myReal1\" type=\"real\" label=\"Test label\"/>"));
 
-    LegacyControllerRealSetting* setting = (LegacyControllerRealSetting*)
-            LegacyControllerRealSetting::createFrom(doc.documentElement());
-    EXPECT_TRUE(setting->valid()) << "Unable to create a double setting";
+    LegacyControllerRealSetting setting(doc.documentElement());
+    EXPECT_TRUE(setting.valid()) << "Unable to create a double setting";
 
-    setting->m_editedValue = 1.0;
-    EXPECT_TRUE(setting->isDirty());
-    setting->save();
-    EXPECT_FALSE(setting->isDirty());
-    EXPECT_EQ(setting->m_savedValue, true);
+    setting.m_editedValue = 1.0;
+    EXPECT_TRUE(setting.isDirty());
+    setting.save();
+    EXPECT_FALSE(setting.isDirty());
+    EXPECT_EQ(setting.m_savedValue, true);
 
     bool ok;
-    setting->parse("0.001", &ok);
+    setting.parse("0.001", &ok);
     EXPECT_TRUE(ok);
-    EXPECT_FALSE(setting->isDirty());
-    EXPECT_EQ(setting->stringify(), "0.001");
-    EXPECT_TRUE(setting->value().isNumber());
-    EXPECT_EQ(setting->value().toNumber(), 0.001);
-    EXPECT_FALSE(setting->isDefault());
-    setting->parse("-15", &ok);
+    EXPECT_FALSE(setting.isDirty());
+    EXPECT_EQ(setting.stringify(), "0.001");
+    EXPECT_TRUE(setting.value().isNumber());
+    EXPECT_EQ(setting.value().toNumber(), 0.001);
+    EXPECT_FALSE(setting.isDefault());
+    setting.parse("-15", &ok);
     EXPECT_TRUE(ok);
-    setting->parse("0", &ok);
+    setting.parse("0", &ok);
     EXPECT_TRUE(ok);
-    EXPECT_FALSE(setting->isDirty());
-    EXPECT_EQ(setting->stringify(), "0");
-    setting->parse("30.0 ", &ok);
+    EXPECT_FALSE(setting.isDirty());
+    EXPECT_EQ(setting.stringify(), "0");
+    setting.parse("30.0 ", &ok);
     EXPECT_TRUE(ok);
-    EXPECT_EQ(setting->stringify(), "30");
-    EXPECT_TRUE(setting->value().isNumber());
-    EXPECT_EQ(setting->value().toNumber(), 30.0);
-    setting->reset();
-    EXPECT_TRUE(setting->isDirty());
-    setting->save();
-    EXPECT_EQ(setting->stringify(), "0");
-    EXPECT_TRUE(setting->isDefault());
-    setting->parse("abc ", &ok);
+    EXPECT_EQ(setting.stringify(), "30");
+    EXPECT_TRUE(setting.value().isNumber());
+    EXPECT_EQ(setting.value().toNumber(), 30.0);
+    setting.reset();
+    EXPECT_TRUE(setting.isDirty());
+    setting.save();
+    EXPECT_EQ(setting.stringify(), "0");
+    EXPECT_TRUE(setting.isDefault());
+    setting.parse("abc ", &ok);
     EXPECT_FALSE(ok);
-    EXPECT_TRUE(setting->value().isNumber());
-    EXPECT_EQ(setting->value().toNumber(), .0);
+    EXPECT_TRUE(setting.value().isNumber());
+    EXPECT_EQ(setting.value().toNumber(), .0);
 }
 
 TEST_F(LegacyControllerMappingSettingsTest, enumSettingParsing) {
     QDomDocument doc;
-    doc.setContent(QString(kValidEnum)
-                           .arg(QList({QString(kValidEnumOption)
-                                                      .arg("My option label",
-                                                              "myOptionValue")})
-                                           .join(""))
-                           .toLatin1());
+    {
+        doc.setContent(QString(kValidEnum)
+                        .arg(QList({QString(kValidEnumOption)
+                                                   .arg("My option label",
+                                                           "myOptionValue")})
+                                        .join(""))
+                        .toLatin1());
 
-    EXPECT_TRUE(LegacyControllerEnumSetting::match(doc.documentElement()));
-    LegacyControllerEnumSetting* setting = (LegacyControllerEnumSetting*)
-            LegacyControllerEnumSetting::createFrom(doc.documentElement());
-    EXPECT_TRUE(setting->valid()) << "Unable to create an enum setting";
+        EXPECT_TRUE(LegacyControllerEnumSetting::match(doc.documentElement()));
+        LegacyControllerEnumSetting setting(doc.documentElement());
+        EXPECT_TRUE(setting.valid()) << "Unable to create an enum setting";
 
-    EXPECT_EQ(setting->variableName(), "myEnum1");
-    EXPECT_EQ(setting->label(), "Test label");
-    EXPECT_EQ(setting->description(), "Test description");
+        EXPECT_EQ(setting.variableName(), "myEnum1");
+        EXPECT_EQ(setting.label(), "Test label");
+        EXPECT_EQ(setting.description(), "Test description");
 
-    EXPECT_FALSE(setting->isDirty());
-    EXPECT_TRUE(setting->isDefault());
-    EXPECT_EQ(setting->stringify(), "myOptionValue");
-    EXPECT_TRUE(setting->valid());
-
-    delete setting;
-
-    doc.setContent(QString(kValidEnum).arg("").toLatin1());
-    setting = (LegacyControllerEnumSetting*)
-            LegacyControllerEnumSetting::createFrom(doc.documentElement());
-    EXPECT_FALSE(setting->valid());
-
-    delete setting;
+        EXPECT_FALSE(setting.isDirty());
+        EXPECT_TRUE(setting.isDefault());
+        EXPECT_EQ(setting.stringify(), "myOptionValue");
+        EXPECT_TRUE(setting.valid());
+    }
+    {
+        doc.setContent(QString(kValidEnum).arg("").toLatin1());
+        LegacyControllerEnumSetting setting(doc.documentElement());
+        EXPECT_FALSE(setting.valid());
+    }
 }
 
 TEST_F(LegacyControllerMappingSettingsTest, enumSettingEditing) {
@@ -359,36 +333,35 @@ TEST_F(LegacyControllerMappingSettingsTest, enumSettingEditing) {
                            .toLatin1());
 
     EXPECT_TRUE(LegacyControllerEnumSetting::match(doc.documentElement()));
-    LegacyControllerEnumSetting* setting = (LegacyControllerEnumSetting*)
-            LegacyControllerEnumSetting::createFrom(doc.documentElement());
-    EXPECT_TRUE(setting->valid()) << "Unable to create an enum setting";
+    LegacyControllerEnumSetting setting(doc.documentElement());
+    EXPECT_TRUE(setting.valid()) << "Unable to create an enum setting";
 
-    setting->m_editedValue = 2;
-    EXPECT_TRUE(setting->isDirty());
-    setting->save();
-    EXPECT_FALSE(setting->isDirty());
-    EXPECT_EQ(setting->m_savedValue, 2);
-    EXPECT_EQ(setting->stringify(), "myOptionValue3");
-    EXPECT_TRUE(setting->value().isString());
-    EXPECT_EQ(setting->value().toString(), "myOptionValue3");
+    setting.m_editedValue = 2;
+    EXPECT_TRUE(setting.isDirty());
+    setting.save();
+    EXPECT_FALSE(setting.isDirty());
+    EXPECT_EQ(setting.m_savedValue, 2);
+    EXPECT_EQ(setting.stringify(), "myOptionValue3");
+    EXPECT_TRUE(setting.value().isString());
+    EXPECT_EQ(setting.value().toString(), "myOptionValue3");
 
     bool ok;
-    setting->parse("myOptionValue2", &ok);
+    setting.parse("myOptionValue2", &ok);
     EXPECT_TRUE(ok);
-    EXPECT_FALSE(setting->isDirty());
-    EXPECT_EQ(setting->stringify(), "myOptionValue2");
-    EXPECT_TRUE(setting->value().isString());
-    EXPECT_EQ(setting->value().toString(), "myOptionValue2");
-    EXPECT_FALSE(setting->isDefault());
-    setting->reset();
-    EXPECT_TRUE(setting->isDirty());
-    setting->save();
-    EXPECT_EQ(setting->stringify(), "myOptionValue1");
-    EXPECT_TRUE(setting->isDefault());
-    setting->parse("abc ", &ok);
+    EXPECT_FALSE(setting.isDirty());
+    EXPECT_EQ(setting.stringify(), "myOptionValue2");
+    EXPECT_TRUE(setting.value().isString());
+    EXPECT_EQ(setting.value().toString(), "myOptionValue2");
+    EXPECT_FALSE(setting.isDefault());
+    setting.reset();
+    EXPECT_TRUE(setting.isDirty());
+    setting.save();
+    EXPECT_EQ(setting.stringify(), "myOptionValue1");
+    EXPECT_TRUE(setting.isDefault());
+    setting.parse("abc ", &ok);
     EXPECT_FALSE(ok);
-    EXPECT_TRUE(setting->value().isString());
-    EXPECT_EQ(setting->value().toString(), "myOptionValue1");
+    EXPECT_TRUE(setting.value().isString());
+    EXPECT_EQ(setting.value().toString(), "myOptionValue1");
 }
 
 class LegacyDummyMapping : public LegacyControllerMapping {


### PR DESCRIPTION
As discussed in #13669, this PR introduced a refactor of the setting definition with a generic to remove code duplication and the needed boilerplate when introduced new setting type.