### PR TITLE
(fix) Track property editor: don't close when opening context menu

### DIFF
--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -365,8 +365,13 @@ bool WTrackPropertyEditor::eventFilter(QObject* pObj, QEvent* pEvent) {
     } else if (pEvent->type() == QEvent::FocusOut) {
         // Close and commit if any other widget gets focus
         if (isVisible()) {
-            hide();
-            emit commitEditorData(text());
+            QFocusEvent* fe = static_cast<QFocusEvent*>(pEvent);
+            // For any FocusOut, except when showing the QLineEdit's menu,
+            // we hide() and commit the current text.
+            if (fe->reason() != Qt::PopupFocusReason) {
+                hide();
+                emit commitEditorData(text());
+            }
         }
     }
     return QLineEdit::eventFilter(pObj, pEvent);


### PR DESCRIPTION
This slipped through in #11755
Currently the editor is closed on _every_ FocusOut event, but that's wrong if the QLineEdit's menu pops up.
That one seems to be the only event that has the reason `Qt::PopupFocusReason` so we can filter easily.