### PR TITLE
[POC] stem selection menu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -780,6 +780,8 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/dialog/dlgkeywheel.ui
   src/dialog/dlgreplacecuecolor.cpp
   src/dialog/dlgreplacecuecolordlg.ui
+  src/dialog/dlgstemselect.cpp
+  src/dialog/dlgstemselect.ui
   src/effects/backends/builtin/autopaneffect.cpp
   src/effects/backends/builtin/balanceeffect.cpp
   src/effects/backends/builtin/bessel4lvmixeqeffect.cpp

--- a/src/dialog/dlgstemselect.cpp
+++ b/src/dialog/dlgstemselect.cpp
@@ -1,0 +1,173 @@
+#include "dialog/dlgstemselect.h"
+
+#include <QDir>
+#include <QKeyEvent>
+#include <QMouseEvent>
+#include <QSvgRenderer>
+
+#include "control/controlobject.h"
+#include "library/coverartcache.h"
+#include "library/library_prefs.h"
+#include "moc_dlgstemselect.cpp"
+#include "track/track.h"
+#include "widget/wcoverartlabel.h"
+
+namespace {
+
+} // namespace
+
+DlgStemSelect::DlgStemSelect(QWidget* parent)
+        : QDialog(parent) {
+    setupUi(this);
+
+    // setWindowFlags(Qt::Popup);
+    // setAttribute(Qt::WA_StyledBackground);
+
+    m_pWCoverArtLabel = make_parented<WCoverArtLabel>(this);
+
+    // Cover art
+    CoverArtCache* pCache = CoverArtCache::instance();
+    if (pCache) {
+        connect(pCache,
+                &CoverArtCache::coverFound,
+                this,
+                &DlgStemSelect::slotCoverFound);
+    }
+
+    coverLayout->setAlignment(Qt::AlignRight | Qt::AlignTop);
+    coverLayout->setSpacing(0);
+    coverLayout->setContentsMargins(0, 0, 0, 0);
+    coverLayout->insertWidget(0, m_pWCoverArtLabel.get());
+
+    installEventFilter(this);
+
+    connect(buttonAbort,
+            &QAbstractButton::clicked,
+            this,
+            &QDialog::accept);
+
+    connect(radioButtonStem,
+            &QRadioButton::toggled,
+            this,
+            &DlgStemSelect::slotStemMixToggled);
+    connect(radioButtonStereo,
+            &QRadioButton::toggled,
+            this,
+            &DlgStemSelect::slotStemMixToggled);
+
+    connect(checkBoxStem1,
+            &QCheckBox::stateChanged,
+            this,
+            &DlgStemSelect::slotStemChecked);
+    connect(checkBoxStem2,
+            &QCheckBox::stateChanged,
+            this,
+            &DlgStemSelect::slotStemChecked);
+    connect(checkBoxStem3,
+            &QCheckBox::stateChanged,
+            this,
+            &DlgStemSelect::slotStemChecked);
+    connect(checkBoxStem4,
+            &QCheckBox::stateChanged,
+            this,
+            &DlgStemSelect::slotStemChecked);
+}
+
+bool DlgStemSelect::eventFilter(QObject* obj, QEvent* event) {
+    if (event->type() == QEvent::KeyPress) {
+        QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
+        if (keyEvent->key() == Qt::Key_Tab) {
+            return true;
+        } else if (keyEvent->key() == Qt::Key_Backtab) {
+            return true;
+        }
+    } else if (event->type() == QEvent::MouseButtonPress) {
+        // QMouseEvent* mouseEvent = static_cast<QMouseEvent*>(event);
+        // return true;
+    }
+    // standard event processing
+    return QDialog::eventFilter(obj, event);
+}
+
+void DlgStemSelect::show(TrackPointer pTrack) {
+    m_pTrack = pTrack;
+
+    DEBUG_ASSERT(pTrack->hasStem());
+
+    QString colorStyle;
+    auto stemInfoList = pTrack->getStemInfo();
+    for (int stemIdx = 0; stemIdx < stemInfoList.count(); stemIdx++) {
+        switch (stemIdx) {
+        case 0:
+            checkBoxStem1->setText(stemInfoList.at(stemIdx).getLabel());
+            colorStyle =
+                    QString("QCheckBox { color: %1; }")
+                            .arg(stemInfoList.at(stemIdx).getColor().name());
+            checkBoxStem1->setStyleSheet(colorStyle);
+            break;
+        case 1:
+            checkBoxStem2->setText(stemInfoList.at(stemIdx).getLabel());
+            colorStyle =
+                    QString("QCheckBox { color: %1; }")
+                            .arg(stemInfoList.at(stemIdx).getColor().name());
+            checkBoxStem2->setStyleSheet(colorStyle);
+            break;
+        case 2:
+            checkBoxStem3->setText(stemInfoList.at(stemIdx).getLabel());
+            colorStyle =
+                    QString("QCheckBox { color: %1; }")
+                            .arg(stemInfoList.at(stemIdx).getColor().name());
+            checkBoxStem3->setStyleSheet(colorStyle);
+            break;
+        case 3:
+            checkBoxStem4->setText(stemInfoList.at(stemIdx).getLabel());
+            colorStyle =
+                    QString("QCheckBox { color: %1; }")
+                            .arg(stemInfoList.at(stemIdx).getColor().name());
+            checkBoxStem4->setStyleSheet(colorStyle);
+            break;
+        }
+    }
+
+    m_pWCoverArtLabel->loadTrack(pTrack);
+
+    const auto coverInfo = CoverInfo(
+            m_pTrack->getCoverInfo(),
+            m_pTrack->getLocation());
+    m_pWCoverArtLabel->setCoverArt(coverInfo, QPixmap());
+    // Executed concurrently
+    CoverArtCache::requestCover(this, coverInfo);
+
+    QDialog::show();
+}
+
+void DlgStemSelect::slotStemMixToggled(bool checked) {
+    if (checked) {
+        checkBoxStem1->setChecked(false);
+        checkBoxStem2->setChecked(false);
+        checkBoxStem3->setChecked(false);
+        checkBoxStem4->setChecked(false);
+    }
+}
+
+void DlgStemSelect::slotStemChecked(int state) {
+    if (state == Qt::Checked) {
+        blockSignals(true);
+        buttonGroup->setExclusive(false);
+        radioButtonStem->setChecked(false);
+        radioButtonStereo->setChecked(false);
+        buttonGroup->setExclusive(true);
+        blockSignals(false);
+    }
+}
+
+void DlgStemSelect::slotCoverFound(
+        const QObject* pRequester,
+        const CoverInfo& coverInfo,
+        const QPixmap& pixmap) {
+    if (pRequester == this &&
+            m_pTrack &&
+            m_pTrack->getLocation() == coverInfo.trackLocation) {
+        m_pWCoverArtLabel->setCoverArt(coverInfo, pixmap);
+    }
+}

--- a/src/dialog/dlgstemselect.h
+++ b/src/dialog/dlgstemselect.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <QDialog>
+
+#include "dialog/ui_dlgstemselect.h"
+#include "track/track_decl.h"
+#include "util/parented_ptr.h"
+
+class WCoverArtLabel;
+class CoverInfo;
+
+class DlgStemSelect : public QDialog, public Ui::DlgStemSelect {
+    Q_OBJECT
+
+  public:
+    explicit DlgStemSelect(QWidget* parent);
+    ~DlgStemSelect() = default;
+    void show(TrackPointer pTrack);
+
+  protected:
+    bool eventFilter(QObject* obj, QEvent* event) override;
+
+  private slots:
+    void slotStemMixToggled(bool checked);
+    void slotStemChecked(int state);
+    void slotCoverFound(
+            const QObject* pRequester,
+            const CoverInfo& coverInfo,
+            const QPixmap& pixmap);
+
+  private:
+    TrackPointer m_pTrack;
+    parented_ptr<WCoverArtLabel> m_pWCoverArtLabel;
+};

--- a/src/dialog/dlgstemselect.ui
+++ b/src/dialog/dlgstemselect.ui
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DlgStemSelect</class>
+ <widget class="QDialog" name="DlgStemSelect">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>393</width>
+    <height>264</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Select Stems</string>
+  </property>
+  <property name="layoutDirection">
+   <enum>Qt::LeftToRight</enum>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout_4">
+     <item>
+      <widget class="QRadioButton" name="radioButtonStem">
+       <property name="text">
+        <string>Stem deck mixing</string>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">buttonGroup</string>
+       </attribute>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="radioButtonStereo">
+       <property name="text">
+        <string>Pre-mixed stereo track</string>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">buttonGroup</string>
+       </attribute>
+      </widget>
+     </item>
+     <item>
+      <widget class="QFrame" name="frame">
+       <property name="frameShape">
+        <enum>QFrame::StyledPanel</enum>
+       </property>
+       <property name="frameShadow">
+        <enum>QFrame::Raised</enum>
+       </property>
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="1" column="0">
+         <widget class="QCheckBox" name="checkBoxStem2">
+          <property name="text">
+           <string>Stem 2</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QCheckBox" name="checkBoxStem1">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Stem 1</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QCheckBox" name="checkBoxStem3">
+          <property name="text">
+           <string>Stem 3</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QCheckBox" name="checkBoxStem4">
+          <property name="text">
+           <string>Stem 4</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1" rowspan="4">
+         <layout class="QVBoxLayout" name="coverLayout"/>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Or press the corresponding play button for loading</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QPushButton" name="buttonAbort">
+         <property name="text">
+          <string>Abort</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_4">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QPushButton" name="buttonLoadTo">
+         <property name="text">
+          <string>Load to...</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="buttonLoad">
+         <property name="text">
+          <string>Load</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+ <buttongroups>
+  <buttongroup name="buttonGroup"/>
+ </buttongroups>
+</ui>

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -7,6 +7,7 @@
 #include <QUrl>
 
 #include "control/controlobject.h"
+#include "dialog/dlgstemselect.h"
 #include "library/dao/trackschema.h"
 #include "library/library.h"
 #include "library/library_prefs.h"
@@ -1091,6 +1092,39 @@ void WTrackTableView::keyPressEvent(QKeyEvent* event) {
             hideOrRemoveSelectedTracks();
         }
         return;
+    }
+    case Qt::Key_Right: {
+#ifdef __STEM__
+        TrackModel* pTrackModel = getTrackModel();
+        if (!pTrackModel) {
+            break;
+        }
+        const QModelIndexList indices = getSelectedRows();
+        if (indices.isEmpty()) {
+            break;
+        }
+        TrackPointer pTrack = pTrackModel->getTrack(indices.first());
+        if (!pTrack) {
+            break;
+        }
+
+        if (!pTrack->hasStreamInfoFromSource()) {
+            // The stem metadata are loaded on stream info refresh, which occurs
+            // when the file gets loaded for the time in the session. If there is no
+            // stream info from source, when open the file, which lead to loading
+            // the stem manifest.
+            mixxx::AudioSource::OpenParams config;
+            config.setChannelCount(mixxx::kMaxEngineChannelInputCount);
+            SoundSourceProxy(pTrack).openAudioSource(config);
+        }
+        if (pTrack->hasStem()) {
+            if (!m_pDlgStemSelect) {
+                m_pDlgStemSelect = make_parented<DlgStemSelect>(this);
+            }
+            m_pDlgStemSelect->show(pTrack);
+        }
+        break;
+#endif // __STEM__
     }
     default:
         break;

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -18,6 +18,7 @@ class DlgTrackInfo;
 class ExternalTrackCollection;
 class Library;
 class WTrackMenu;
+class DlgStemSelect;
 
 class WTrackTableView : public WLibraryTableView {
     Q_OBJECT
@@ -168,6 +169,8 @@ class WTrackTableView : public WLibraryTableView {
 
     // Context menu container
     parented_ptr<WTrackMenu> m_pTrackMenu;
+
+    parented_ptr<DlgStemSelect> m_pDlgStemSelect;
 
     const double m_backgroundColorOpacity;
     QColor m_focusBorderColor;


### PR DESCRIPTION
![grafik](https://github.com/user-attachments/assets/70aad288-6201-418b-b307-7b8b69ab8f4e)

This is a prove of concept of a stem selection menu. 

It opens if you press "->" (cursor right) when a stem file is selected in the library. This is useful to use the library encoder to select a stem for loading to samplers. 
* Turn Library Encoder to select a Track 
* Shift + Turn, to open the selection menu. 
* Turn and push to select a stem 
* click the sampler button to load. 

Alternative you may also focus one of the buttons to load the stem. 

 