### PR TITLE
test: improve flaky stem color test

### DIFF
--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -541,7 +541,6 @@ void EngineBuffer::slotTrackLoaded(TrackPointer pTrack,
 
     m_visualPlayPos->setInvalid();
     m_playPos = kInitialPlayPosition; // for execute seeks to 0.0
-    m_pCurrentTrack = pTrack;
 
     m_channelCount = trackChannelCount;
     if (m_channelCount > mixxx::audio::ChannelCount::stereo()) {
@@ -587,6 +586,7 @@ void EngineBuffer::slotTrackLoaded(TrackPointer pTrack,
         m_iSeekPhaseQueued = 0;
     }
 
+    m_pCurrentTrack = pTrack;
     // Start buffer processing after all EngineContols are up to date
     // with the current track e.g track is seeked to Cue
     m_iTrackLoading = 0;


### PR DESCRIPTION
This will improve the stability of the `StemControlTest.StemColor`, but slighlty slow the test run by adding a sleep. The alternative would be to add some extensive watch to the `CachingReader`, which is not worth the effort.

Previous benchmark to get some failure (*10 runs, sequentially*)

```sh
seq 10 | xargs -n 1 ctest --timeout 45 -R 'StemControlTest.StemColor'
```

Current benchmark without a single failure (*500 runs, on 20 workers, with 20 threads*)

```sh
seq 500 | xargs -P 20 -n 1 ctest --timeout 45 -R 'StemControlTest.StemColor'
```

Fixes #13924