### PR TITLE
AudioUnitManager: Avoid undefined behavior by initializing `m_isInstantiated` to `false`

### DIFF
--- a/src/effects/backends/audiounit/audiounitmanager.mm
+++ b/src/effects/backends/audiounit/audiounitmanager.mm
@@ -8,7 +8,8 @@
 
 AudioUnitManager::AudioUnitManager(AVAudioUnitComponent* _Nullable component,
         AudioUnitInstantiationType instantiationType)
-        : m_name(QString::fromNSString([component name])) {
+        : m_name(QString::fromNSString([component name])),
+          m_isInstantiated(false) {
     // NOTE: The component can be null if the lookup failed in
     // `AudioUnitBackend::createProcessor`, in which case the effect simply acts
     // as an identity function on the audio. Same applies when


### PR DESCRIPTION
Turns out creating a `std::atomic<bool>` without initializing it is very likely undefined behavior, so we ought to initialize it.