### PR TITLE
AudioUnitManager: Wrap every instance in a shared pointer

### DIFF
--- a/src/effects/backends/audiounit/audiouniteffectprocessor.h
+++ b/src/effects/backends/audiounit/audiouniteffectprocessor.h
@@ -55,7 +55,7 @@ class AudioUnitEffectProcessor final : public EffectProcessorImpl<AudioUnitEffec
             const GroupFeatureState& groupFeatures) override;
 
   private:
-    AudioUnitManagerPointer m_manager;
+    AudioUnitManagerPointer m_pManager;
 
     QList<EngineEffectParameterPointer> m_parameters;
     QList<AudioUnitParameterValue> m_lastValues;

--- a/src/effects/backends/audiounit/audiouniteffectprocessor.h
+++ b/src/effects/backends/audiounit/audiouniteffectprocessor.h
@@ -55,7 +55,7 @@ class AudioUnitEffectProcessor final : public EffectProcessorImpl<AudioUnitEffec
             const GroupFeatureState& groupFeatures) override;
 
   private:
-    AudioUnitManager m_manager;
+    AudioUnitManagerPointer m_manager;
 
     QList<EngineEffectParameterPointer> m_parameters;
     QList<AudioUnitParameterValue> m_lastValues;

--- a/src/effects/backends/audiounit/audiouniteffectprocessor.mm
+++ b/src/effects/backends/audiounit/audiouniteffectprocessor.mm
@@ -142,7 +142,7 @@ void AudioUnitEffectGroupState::render(AudioUnit _Nonnull audioUnit,
 
 AudioUnitEffectProcessor::AudioUnitEffectProcessor(
         AVAudioUnitComponent* _Nullable component)
-        : m_manager(AudioUnitManager::create(component)) {
+        : m_pManager(AudioUnitManager::create(component)) {
 }
 
 void AudioUnitEffectProcessor::loadEngineEffectParameters(
@@ -157,7 +157,7 @@ void AudioUnitEffectProcessor::processChannel(
         const mixxx::EngineParameters& engineParameters,
         const EffectEnableState,
         const GroupFeatureState&) {
-    AudioUnit _Nullable audioUnit = m_manager->getAudioUnit();
+    AudioUnit _Nullable audioUnit = m_pManager->getAudioUnit();
     if (!audioUnit) {
         qWarning()
                 << "Cannot process channel before Audio Unit is instantiated";
@@ -175,7 +175,7 @@ void AudioUnitEffectProcessor::processChannel(
 }
 
 void AudioUnitEffectProcessor::syncParameters() {
-    AudioUnit _Nullable audioUnit = m_manager->getAudioUnit();
+    AudioUnit _Nullable audioUnit = m_pManager->getAudioUnit();
     DEBUG_ASSERT(audioUnit != nil);
 
     m_lastValues.reserve(m_parameters.size());
@@ -210,7 +210,7 @@ void AudioUnitEffectProcessor::syncParameters() {
 
 void AudioUnitEffectProcessor::syncStreamFormat(
         const mixxx::EngineParameters& parameters) {
-    AudioUnit _Nullable audioUnit = m_manager->getAudioUnit();
+    AudioUnit _Nullable audioUnit = m_pManager->getAudioUnit();
     DEBUG_ASSERT(audioUnit != nil);
 
     if (parameters.sampleRate() != m_lastSampleRate ||

--- a/src/effects/backends/audiounit/audiouniteffectprocessor.mm
+++ b/src/effects/backends/audiounit/audiouniteffectprocessor.mm
@@ -142,7 +142,7 @@ void AudioUnitEffectGroupState::render(AudioUnit _Nonnull audioUnit,
 
 AudioUnitEffectProcessor::AudioUnitEffectProcessor(
         AVAudioUnitComponent* _Nullable component)
-        : m_manager(component) {
+        : m_manager(AudioUnitManager::create(component)) {
 }
 
 void AudioUnitEffectProcessor::loadEngineEffectParameters(
@@ -157,7 +157,7 @@ void AudioUnitEffectProcessor::processChannel(
         const mixxx::EngineParameters& engineParameters,
         const EffectEnableState,
         const GroupFeatureState&) {
-    AudioUnit _Nullable audioUnit = m_manager.getAudioUnit();
+    AudioUnit _Nullable audioUnit = m_manager->getAudioUnit();
     if (!audioUnit) {
         qWarning()
                 << "Cannot process channel before Audio Unit is instantiated";
@@ -175,7 +175,7 @@ void AudioUnitEffectProcessor::processChannel(
 }
 
 void AudioUnitEffectProcessor::syncParameters() {
-    AudioUnit _Nullable audioUnit = m_manager.getAudioUnit();
+    AudioUnit _Nullable audioUnit = m_manager->getAudioUnit();
     DEBUG_ASSERT(audioUnit != nil);
 
     m_lastValues.reserve(m_parameters.size());
@@ -210,7 +210,7 @@ void AudioUnitEffectProcessor::syncParameters() {
 
 void AudioUnitEffectProcessor::syncStreamFormat(
         const mixxx::EngineParameters& parameters) {
-    AudioUnit _Nullable audioUnit = m_manager.getAudioUnit();
+    AudioUnit _Nullable audioUnit = m_manager->getAudioUnit();
     DEBUG_ASSERT(audioUnit != nil);
 
     if (parameters.sampleRate() != m_lastSampleRate ||

--- a/src/effects/backends/audiounit/audiounitmanager.h
+++ b/src/effects/backends/audiounit/audiounitmanager.h
@@ -4,6 +4,7 @@
 #import <AudioToolbox/AudioToolbox.h>
 #import <CoreAudioTypes/CoreAudioTypes.h>
 
+#include <QSharedPointer>
 #include <QString>
 
 enum AudioUnitInstantiationType {
@@ -12,16 +13,21 @@ enum AudioUnitInstantiationType {
     AsyncOutOfProcess,
 };
 
+class AudioUnitManager;
+typedef QSharedPointer<AudioUnitManager> AudioUnitManagerPointer;
+
 /// A RAII wrapper around an `AudioUnit`.
 class AudioUnitManager {
   public:
-    AudioUnitManager(AVAudioUnitComponent* _Nullable component = nil,
-            AudioUnitInstantiationType instantiationType =
-                    AudioUnitInstantiationType::AsyncOutOfProcess);
     ~AudioUnitManager();
 
     AudioUnitManager(const AudioUnitManager&) = delete;
     AudioUnitManager& operator=(const AudioUnitManager&) = delete;
+
+    static AudioUnitManagerPointer create(
+            AVAudioUnitComponent* _Nullable component = nil,
+            AudioUnitInstantiationType instantiationType =
+                    AudioUnitInstantiationType::AsyncOutOfProcess);
 
     /// Fetches the audio unit if already instantiated.
     ///
@@ -35,8 +41,13 @@ class AudioUnitManager {
     std::atomic<bool> m_isInstantiated;
     AudioUnit _Nullable m_audioUnit;
 
-    void instantiateAudioUnitAsync(AVAudioUnitComponent* _Nonnull component, bool inProcess);
-    void instantiateAudioUnitSync(AVAudioUnitComponent* _Nonnull component);
+    AudioUnitManager(AVAudioUnitComponent* _Nullable component);
+
+    static void instantiateAudioUnitAsync(AudioUnitManagerPointer manager,
+            AVAudioUnitComponent* _Nonnull component,
+            bool inProcess);
+    static void instantiateAudioUnitSync(AudioUnitManagerPointer manager,
+            AVAudioUnitComponent* _Nonnull component);
 
     void initializeWith(AudioUnit _Nullable audioUnit);
 };

--- a/src/effects/backends/audiounit/audiounitmanager.h
+++ b/src/effects/backends/audiounit/audiounitmanager.h
@@ -24,6 +24,11 @@ class AudioUnitManager {
     AudioUnitManager(const AudioUnitManager&) = delete;
     AudioUnitManager& operator=(const AudioUnitManager&) = delete;
 
+    /// Creates a new `AudioUnitManager`, wrapped in a shared pointer. This
+    /// form of instantiation is enforced, since asynchronously instantiated
+    /// audio units may capture a pointer to the manager instance (that would be
+    /// unsafe if the manager is deinitialized to early, since the callback
+    /// would be left with a dangling pointer).
     static AudioUnitManagerPointer create(
             AVAudioUnitComponent* _Nullable component = nil,
             AudioUnitInstantiationType instantiationType =

--- a/src/effects/backends/audiounit/audiounitmanager.h
+++ b/src/effects/backends/audiounit/audiounitmanager.h
@@ -46,10 +46,10 @@ class AudioUnitManager {
 
     AudioUnitManager(AVAudioUnitComponent* _Nullable component);
 
-    static void instantiateAudioUnitAsync(AudioUnitManagerPointer manager,
+    static void instantiateAudioUnitAsync(AudioUnitManagerPointer pManager,
             AVAudioUnitComponent* _Nonnull component,
             bool inProcess);
-    static void instantiateAudioUnitSync(AudioUnitManagerPointer manager,
+    static void instantiateAudioUnitSync(AudioUnitManagerPointer pManager,
             AVAudioUnitComponent* _Nonnull component);
 
     void initializeWith(AudioUnit _Nullable audioUnit);

--- a/src/effects/backends/audiounit/audiounitmanager.h
+++ b/src/effects/backends/audiounit/audiounitmanager.h
@@ -28,7 +28,7 @@ class AudioUnitManager {
     /// Non-blocking and thread-safe, since this method is intended to (also) be
     /// called in a real-time context, e.g. from an audio thread, where we don't
     /// want to e.g. block on a mutex.
-    AudioUnit _Nullable getAudioUnit();
+    AudioUnit _Nullable getAudioUnit() const;
 
   private:
     QString m_name;

--- a/src/effects/backends/audiounit/audiounitmanager.h
+++ b/src/effects/backends/audiounit/audiounitmanager.h
@@ -4,17 +4,15 @@
 #import <AudioToolbox/AudioToolbox.h>
 #import <CoreAudioTypes/CoreAudioTypes.h>
 
-#include <QSharedPointer>
 #include <QString>
+
+#include "effects/backends/audiounit/audiounitmanagerpointer.h"
 
 enum AudioUnitInstantiationType {
     Sync,
     AsyncInProcess,
     AsyncOutOfProcess,
 };
-
-class AudioUnitManager;
-typedef QSharedPointer<AudioUnitManager> AudioUnitManagerPointer;
 
 /// A RAII wrapper around an `AudioUnit`.
 class AudioUnitManager {

--- a/src/effects/backends/audiounit/audiounitmanager.h
+++ b/src/effects/backends/audiounit/audiounitmanager.h
@@ -38,5 +38,5 @@ class AudioUnitManager {
     void instantiateAudioUnitAsync(AVAudioUnitComponent* _Nonnull component, bool inProcess);
     void instantiateAudioUnitSync(AVAudioUnitComponent* _Nonnull component);
 
-    void initializeWith(AudioUnit _Nonnull audioUnit);
+    void initializeWith(AudioUnit _Nullable audioUnit);
 };

--- a/src/effects/backends/audiounit/audiounitmanager.mm
+++ b/src/effects/backends/audiounit/audiounitmanager.mm
@@ -72,11 +72,6 @@ void AudioUnitManager::instantiateAudioUnitAsync(
             return;
         }
 
-        VERIFY_OR_DEBUG_ASSERT(audioUnit != nil) {
-            qWarning() << "Could not instantiate Audio Unit" << m_name << "...but the error is noErr, what's going on?";
-            return;
-        }
-
         initializeWith(audioUnit);
     });
     // clang-format on
@@ -96,7 +91,14 @@ void AudioUnitManager::instantiateAudioUnitSync(
     initializeWith(audioUnit);
 }
 
-void AudioUnitManager::initializeWith(AudioUnit _Nonnull audioUnit) {
+void AudioUnitManager::initializeWith(AudioUnit _Nullable audioUnit) {
+    VERIFY_OR_DEBUG_ASSERT(audioUnit != nil) {
+        qWarning() << "Instantiated Audio Unit" << m_name
+                   << " is null, despite not erroring on initialization, "
+                      "something's wrong";
+        return;
+    }
+
     VERIFY_OR_DEBUG_ASSERT(!m_isInstantiated.load()) {
         qWarning() << "Audio Unit" << m_name
                    << "cannot be initialized after already having been "

--- a/src/effects/backends/audiounit/audiounitmanager.mm
+++ b/src/effects/backends/audiounit/audiounitmanager.mm
@@ -38,7 +38,7 @@ AudioUnitManager::~AudioUnitManager() {
     }
 }
 
-AudioUnit _Nullable AudioUnitManager::getAudioUnit() {
+AudioUnit _Nullable AudioUnitManager::getAudioUnit() const {
     // We need to load this atomic flag to ensure that we don't get a partial
     // read of the audio unit pointer (probably extremely uncommon, but not
     // impossible: https://belkadan.com/blog/2023/10/Implicity-Atomic)

--- a/src/effects/backends/audiounit/audiounitmanagerpointer.h
+++ b/src/effects/backends/audiounit/audiounitmanagerpointer.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <QSharedPointer>
+
+class AudioUnitManager;
+typedef QSharedPointer<AudioUnitManager> AudioUnitManagerPointer;

--- a/src/effects/backends/audiounit/audiounitmanifest.mm
+++ b/src/effects/backends/audiounit/audiounitmanifest.mm
@@ -19,10 +19,10 @@ AudioUnitManifest::AudioUnitManifest(
     setAuthor(QString::fromNSString([component manufacturerName]));
 
     // Instantiate audio unit (in-process) to load parameters
-    AudioUnitManagerPointer manager = AudioUnitManager::create(
+    AudioUnitManagerPointer pManager = AudioUnitManager::create(
             component, AudioUnitInstantiationType::Sync);
 
-    AudioUnit audioUnit = manager->getAudioUnit();
+    AudioUnit audioUnit = pManager->getAudioUnit();
 
     if (audioUnit) {
         // Fetch number of parameters

--- a/src/effects/backends/audiounit/audiounitmanifest.mm
+++ b/src/effects/backends/audiounit/audiounitmanifest.mm
@@ -18,10 +18,11 @@ AudioUnitManifest::AudioUnitManifest(
     setDescription(QString::fromNSString([component typeName]));
     setAuthor(QString::fromNSString([component manufacturerName]));
 
-    // Try instantiating the unit in-process to fetch its properties quickly
+    // Instantiate audio unit (in-process) to load parameters
+    AudioUnitManagerPointer manager = AudioUnitManager::create(
+            component, AudioUnitInstantiationType::Sync);
 
-    AudioUnitManager manager{component, AudioUnitInstantiationType::Sync};
-    AudioUnit audioUnit = manager.getAudioUnit();
+    AudioUnit audioUnit = manager->getAudioUnit();
 
     if (audioUnit) {
         // Fetch number of parameters


### PR DESCRIPTION
This is a small patch I extracted from #13887 (and rebased to 2.5), which fixes a dangling pointer issue when Audio Units are instantiated asynchronously.

The issue is that the async initialization callback captures the `AudioUnitManager` instance, which is unsafe if the instance doesn't outlive the callback. The solution is to simply wrap the `AudioUnitManager` in a `QSharedPointer`, which ensures that the callback keeps the manager instance alive for as long as necessary. See https://github.com/mixxxdj/mixxx/pull/13887#issuecomment-2501814755 for further rationale.

I consider it relatively safe to merge this for 2.5 since it doesn't change anything about the instantiation logic itself (Audio Units are still instantiated synchronously to read the parameters and asynchronously once activated). The migration to make everything asynchronous will then be deferred to 2.6 via #13887.