### PR TITLE
Denon MC7000: Add sampler options to mapping settings

### DIFF
--- a/res/controllers/Denon-MC7000-scripts.js
+++ b/res/controllers/Denon-MC7000-scripts.js
@@ -47,7 +47,7 @@ MC7000.needleSearchPlay = false;
 // select if the previous sampler shall stop before a new sampler starts
 // true: a running sampler will stop before the new sampler starts
 // false: all triggered samplers will play simultaneously
-MC7000.prevSamplerStop = true;
+MC7000.prevSamplerStop = engine.getSetting("prevSamplerStop") ?? true;
 
 // Quantity of Samplers used in mixxx possible values 16 and 32
 // To use 32 samplers instead of 16 you can set the user variable
@@ -55,7 +55,7 @@ MC7000.prevSamplerStop = true;
 // Deck 2 will trigger sampler 9 to 16, Deck 3 will trigger
 // sampler 17 to 24 and Deck 4 will trigger sampler 25 to 32.
 // Please note that your Mixxx skin needs to support more than 16 samplers.
-MC7000.SamplerQty = 16;
+MC7000.SamplerQty = parseInt(engine.getSetting("samplerQty") ?? "16");
 
 // Set Vinyl Mode on ("true") or off ("false") when MIXXX starts.
 // This sets the Jog Wheel touch detection / Vinyl Mode

--- a/res/controllers/Denon-MC7000.midi.xml
+++ b/res/controllers/Denon-MC7000.midi.xml
@@ -92,6 +92,33 @@
                 </option>
             </group>
         </group>
+        <group label="Samplers">
+            <option
+                variable="prevSamplerStop"
+                label="Auto-stop previous samplers when starting new sampler"
+                type="boolean"
+                default="true">
+                <description>
+                    Whether the previous sampler shall stop before a new sampler starts.
+                    When true, a running sampler will stop before the new sampler starts.
+                    When false, all triggered samplers will play simultaneously.
+                </description>
+            </option>
+            <option
+                variable="samplerQty"
+                type="enum"
+                label="Quantity">
+                <value label="16" default="true">16</value>
+                <value label="32">32</value>
+                <description>
+                    The number of samplers to use. When 32 samplers are used,
+                    deck 1 will trigger sampler 1 to 8, deck 2 will trigger
+                    sampler 9 to 16, deck 3 will trigger sampler 17 to 24 and
+                    deck 4 will trigger sampler 25 to 32. Please note that your
+                    Mixxx skin needs to support more than 16 samplers.
+                </description>
+            </option>
+        </group>
     </settings>
     <controller id="DENON MC7000">
         <scriptfiles>


### PR DESCRIPTION
Scratching another (minor) itch, this exposes a few sampler-related options from the Denon MC7000 mapping to the user:

<img width="1006" alt="Screenshot 2024-11-30 at 01 36 15" src="https://github.com/user-attachments/assets/35f3d837-27f5-4684-a90f-efed256560a5">

I ran into this while trying to figure out why playing a sample would automatically stop all other playing samples and found that it wasn't a Mixxx issue, but something from the mapping. Since changing the script is inconvenient, here's a PR to fix it.