### PR TITLE
Optimized tooltip generation in WBaseWidget

### DIFF
--- a/src/widget/wbasewidget.cpp
+++ b/src/widget/wbasewidget.cpp
@@ -139,20 +139,16 @@ void WBaseWidget::setControlParameterRightUp(double v) {
 }
 
 void WBaseWidget::updateTooltip() {
-    // Remove leading and trailing whitespace/line breaks from the tooltip.
-    QString base = baseTooltip().trimmed();
-
     // If we are in developer mode, expand the tooltip.
     if (CmdlineArgs::Instance().getDeveloper()) {
         QStringList debug;
         fillDebugTooltip(&debug);
 
+        QString base = baseTooltip();
         if (!base.isEmpty()) {
             debug.append(QStringLiteral("Tooltip: \"%1\"").arg(base));
         }
         m_pWidget->setToolTip(debug.join(QChar('\n')));
-    } else {
-        m_pWidget->setToolTip(base);
     }
 }
 

--- a/src/widget/wbasewidget.cpp
+++ b/src/widget/wbasewidget.cpp
@@ -150,7 +150,7 @@ void WBaseWidget::updateTooltip() {
         if (!base.isEmpty()) {
             debug.append(QStringLiteral("Tooltip: \"%1\"").arg(base));
         }
-        m_pWidget->setToolTip(debug.join(QStringLiteral("\n")));
+        m_pWidget->setToolTip(debug.join(QChar('\n')));
     } else {
         m_pWidget->setToolTip(base);
     }

--- a/src/widget/wbasewidget.cpp
+++ b/src/widget/wbasewidget.cpp
@@ -154,24 +154,7 @@ void WBaseWidget::updateTooltip() {
 
 template<>
 QString toDebugString(const QSizePolicy::Policy& policy) {
-    switch (policy) {
-    case QSizePolicy::Fixed:
-        return QStringLiteral("Fixed");
-    case QSizePolicy::Minimum:
-        return QStringLiteral("Minimum");
-    case QSizePolicy::Maximum:
-        return QStringLiteral("Maximum");
-    case QSizePolicy::Preferred:
-        return QStringLiteral("Preferred");
-    case QSizePolicy::Expanding:
-        return QStringLiteral("Expanding");
-    case QSizePolicy::MinimumExpanding:
-        return QStringLiteral("MinimumExpanding");
-    case QSizePolicy::Ignored:
-        return QStringLiteral("Ignored");
-    default:
-        return QVariant::fromValue(policy).toString();
-    }
+    return QVariant::fromValue(policy).toString();
 }
 
 void WBaseWidget::fillDebugTooltip(QStringList* debug) {

--- a/src/widget/wbasewidget.cpp
+++ b/src/widget/wbasewidget.cpp
@@ -174,7 +174,7 @@ QString toDebugString(const QSizePolicy::Policy& policy) {
     case QSizePolicy::Ignored:
         return QStringLiteral("Ignored");
     default:
-        return QString::number(static_cast<int>(policy));
+        return QVariant::fromValue(policy).toString();
     }
 }
 

--- a/src/widget/wbasewidget.cpp
+++ b/src/widget/wbasewidget.cpp
@@ -146,56 +146,61 @@ void WBaseWidget::updateTooltip() {
 
         QString base = baseTooltip();
         if (!base.isEmpty()) {
-            debug.append(QString("Tooltip: \"%1\"").arg(base));
+            debug.append(QStringLiteral("Tooltip: \"%1\"").arg(base));
         }
-        m_pWidget->setToolTip(debug.join("\n"));
+        m_pWidget->setToolTip(debug.join(QStringLiteral("\n")));
     }
 }
 
-template <>
+template<>
 QString toDebugString(const QSizePolicy::Policy& policy) {
     switch (policy) {
-        case QSizePolicy::Fixed:
-            return "Fixed";
-        case QSizePolicy::Minimum:
-            return "Minimum";
-        case QSizePolicy::Maximum:
-            return "Maximum";
-        case QSizePolicy::Preferred:
-            return "Preferred";
-        case QSizePolicy::Expanding:
-            return "Expanding";
-        case QSizePolicy::MinimumExpanding:
-            return "MinimumExpanding";
-        case QSizePolicy::Ignored:
-            return "Ignored";
-        default:
-            break;
+    case QSizePolicy::Fixed:
+        return QStringLiteral("Fixed");
+    case QSizePolicy::Minimum:
+        return QStringLiteral("Minimum");
+    case QSizePolicy::Maximum:
+        return QStringLiteral("Maximum");
+    case QSizePolicy::Preferred:
+        return QStringLiteral("Preferred");
+    case QSizePolicy::Expanding:
+        return QStringLiteral("Expanding");
+    case QSizePolicy::MinimumExpanding:
+        return QStringLiteral("MinimumExpanding");
+    case QSizePolicy::Ignored:
+        return QStringLiteral("Ignored");
+    default:
+        return QString::number(static_cast<int>(policy));
     }
-    return QString::number(static_cast<int>(policy));
 }
 
 void WBaseWidget::fillDebugTooltip(QStringList* debug) {
     QSizePolicy policy = m_pWidget->sizePolicy();
-    *debug << QString("ClassName: %1").arg(m_pWidget->metaObject()->className())
-           << QString("ObjectName: %1").arg(m_pWidget->objectName())
-           << QString("Position: %1").arg(toDebugString(m_pWidget->pos()))
-           << QString("SizePolicy: %1,%2").arg(toDebugString(policy.horizontalPolicy()),
-                                               toDebugString(policy.verticalPolicy()))
-           << QString("Size: %1").arg(toDebugString(m_pWidget->size()))
-           << QString("SizeHint: %1").arg(toDebugString(m_pWidget->sizeHint()))
-           << QString("MinimumSizeHint: %1").arg(toDebugString(m_pWidget->minimumSizeHint()));
+    *debug << QStringLiteral("ClassName: %1")
+                      .arg(m_pWidget->metaObject()->className())
+           << QStringLiteral("ObjectName: %1").arg(m_pWidget->objectName())
+           << QStringLiteral("Position: %1")
+                      .arg(toDebugString(m_pWidget->pos()))
+           << QStringLiteral("SizePolicy: %1,%2")
+                      .arg(toDebugString(policy.horizontalPolicy()),
+                              toDebugString(policy.verticalPolicy()))
+           << QStringLiteral("Size: %1").arg(toDebugString(m_pWidget->size()))
+           << QStringLiteral("SizeHint: %1")
+                      .arg(toDebugString(m_pWidget->sizeHint()))
+           << QStringLiteral("MinimumSizeHint: %1")
+                      .arg(toDebugString(m_pWidget->minimumSizeHint()));
 
-    for (const auto& pControlConnection : std::as_const(m_leftConnections)) {
-        *debug << QString("LeftConnection: %1").arg(pControlConnection->toDebugString());
+    for (const auto& pControlConnection : m_leftConnections) {
+        *debug << QStringLiteral("LeftConnection: %1").arg(pControlConnection->toDebugString());
     }
-    for (const auto& pControlConnection : std::as_const(m_rightConnections)) {
-        *debug << QString("RightConnection: %1").arg(pControlConnection->toDebugString());
+    for (const auto& pControlConnection : m_rightConnections) {
+        *debug << QStringLiteral("RightConnection: %1").arg(pControlConnection->toDebugString());
     }
-    for (const auto& pControlConnection : std::as_const(m_connections)) {
-        *debug << QString("Connection: %1").arg(pControlConnection->toDebugString());
+    for (const auto& pControlConnection : m_connections) {
+        *debug << QStringLiteral("Connection: %1").arg(pControlConnection->toDebugString());
     }
     if (m_pDisplayConnection) {
-        *debug << QString("DisplayConnection: %1").arg(m_pDisplayConnection->toDebugString());
+        *debug << QStringLiteral("DisplayConnection: %1")
+                          .arg(m_pDisplayConnection->toDebugString());
     }
 }

--- a/src/widget/wbasewidget.cpp
+++ b/src/widget/wbasewidget.cpp
@@ -139,16 +139,20 @@ void WBaseWidget::setControlParameterRightUp(double v) {
 }
 
 void WBaseWidget::updateTooltip() {
-    // If we are in developer mode, update the tooltip.
+    // Remove leading and trailing whitespace/line breaks from the tooltip.
+    QString base = baseTooltip().trimmed();
+
+    // If we are in developer mode, expand the tooltip.
     if (CmdlineArgs::Instance().getDeveloper()) {
         QStringList debug;
         fillDebugTooltip(&debug);
 
-        QString base = baseTooltip();
         if (!base.isEmpty()) {
             debug.append(QStringLiteral("Tooltip: \"%1\"").arg(base));
         }
         m_pWidget->setToolTip(debug.join(QStringLiteral("\n")));
+    } else {
+        m_pWidget->setToolTip(base);
     }
 }
 

--- a/src/widget/wbasewidget.h
+++ b/src/widget/wbasewidget.h
@@ -26,18 +26,18 @@ class WBaseWidget {
     }
 
     void appendBaseTooltip(const QString& tooltip) {
-        m_baseTooltip.append(tooltip);
+        m_baseTooltip.append(tooltip.trimmed());
         m_pWidget->setToolTip(m_baseTooltip);
     }
 
     void prependBaseTooltip(const QString& tooltip) {
-        m_baseTooltip.prepend(tooltip);
+        m_baseTooltip.prepend(tooltip.trimmed());
         m_pWidget->setToolTip(m_baseTooltip);
     }
 
     void setBaseTooltip(const QString& tooltip) {
-        m_baseTooltip = tooltip;
-        m_pWidget->setToolTip(tooltip);
+        m_baseTooltip = tooltip.trimmed();
+        m_pWidget->setToolTip(m_baseTooltip);
     }
 
     QString baseTooltip() const {

--- a/src/widget/wbasewidget.h
+++ b/src/widget/wbasewidget.h
@@ -21,7 +21,7 @@ class WBaseWidget {
 
     virtual void Init();
 
-    QWidget* toQWidget() {
+    QWidget* toQWidget() const {
         return m_pWidget;
     }
 


### PR DESCRIPTION
Code cleanup. Main change is that empty lines at the end of the tooltips are no longer printed.