### PR TITLE
limit play marker hints text height to 1/3rd or full waveform height (2.5)

### DIFF
--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -73,6 +73,9 @@ DlgPrefWaveform::DlgPrefWaveform(
     untilMarkAlignComboBox->addItem(tr("Center"));
     untilMarkAlignComboBox->addItem(tr("Bottom"));
 
+    untilMarkTextHeightLimitComboBox->addItem(tr("1/3rd of waveform viewer"));
+    untilMarkTextHeightLimitComboBox->addItem(tr("Full waveform viewer height"));
+
     // The GUI is not fully setup so connecting signals before calling
     // slotUpdate can generate rebootMixxxView calls.
     // TODO(XXX): Improve this awkwardness.
@@ -179,6 +182,10 @@ DlgPrefWaveform::DlgPrefWaveform(
             QOverload<int>::of(&QSpinBox::valueChanged),
             this,
             &DlgPrefWaveform::slotSetUntilMarkTextPointSize);
+    connect(untilMarkTextHeightLimitComboBox,
+            QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this,
+            &DlgPrefWaveform::slotSetUntilMarkTextHeightLimit);
 
     setScrollSafeGuardForAllInputWidgets(this);
 }
@@ -225,6 +232,9 @@ void DlgPrefWaveform::slotUpdate() {
             WaveformWidgetFactory::toUntilMarkAlignIndex(
                     factory->getUntilMarkAlign()));
     untilMarkTextPointSizeSpinBox->setValue(factory->getUntilMarkTextPointSize());
+    untilMarkTextHeightLimitComboBox->setCurrentIndex(
+            WaveformWidgetFactory::toUntilMarkTextHeightLimitIndex(
+                    factory->getUntilMarkTextHeightLimit()));
 
     WOverview::Type cfgOverviewType =
             m_pConfig->getValue<WOverview::Type>(kOverviewTypeCfgKey, WOverview::Type::RGB);
@@ -320,6 +330,7 @@ void DlgPrefWaveform::updateEnableUntilMark() {
     untilMarkAlignComboBox->setEnabled(enabled);
     untilMarkTextPointSizeLabel->setEnabled(enabled);
     untilMarkTextPointSizeSpinBox->setEnabled(enabled);
+    untilMarkTextHeightLimitComboBox->setEnabled(enabled);
     requiresGLSLLabel->setVisible(!enabled);
 }
 
@@ -402,6 +413,11 @@ void DlgPrefWaveform::slotSetUntilMarkAlign(int index) {
 
 void DlgPrefWaveform::slotSetUntilMarkTextPointSize(int value) {
     WaveformWidgetFactory::instance()->setUntilMarkTextPointSize(value);
+}
+
+void DlgPrefWaveform::slotSetUntilMarkTextHeightLimit(int index) {
+    WaveformWidgetFactory::instance()->setUntilMarkTextHeightLimit(
+            WaveformWidgetFactory::toUntilMarkTextHeightLimit(index));
 }
 
 void DlgPrefWaveform::calculateCachedWaveformDiskUsage() {

--- a/src/preferences/dialog/dlgprefwaveform.h
+++ b/src/preferences/dialog/dlgprefwaveform.h
@@ -43,6 +43,7 @@ class DlgPrefWaveform : public DlgPreferencePage, public Ui::DlgPrefWaveformDlg 
     void slotSetUntilMarkShowTime(bool checked);
     void slotSetUntilMarkAlign(int index);
     void slotSetUntilMarkTextPointSize(int value);
+    void slotSetUntilMarkTextHeightLimit(int index);
 
   private:
     void initWaveformControl();

--- a/src/preferences/dialog/dlgprefwaveformdlg.ui
+++ b/src/preferences/dialog/dlgprefwaveformdlg.ui
@@ -468,67 +468,87 @@ Select from different types of displays for the waveform, which differ primarily
        </property>
       </widget>
      </item>
-     <item row="11" column="1">
-      <widget class="QCheckBox" name="untilMarkShowBeatsCheckBox">
-       <property name="text">
-        <string>Beats until next marker</string>
-       </property>
-      </widget>
-     </item>
-     <item row="12" column="1">
-      <widget class="QCheckBox" name="untilMarkShowTimeCheckBox">
-       <property name="text">
-        <string>Time until next marker</string>
-       </property>
-      </widget>
-     </item>
-     <item row="11" column="2">
-      <widget class="QLabel" name="untilMarkAlignLabel">
-       <property name="text">
-        <string>Placement</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-       </property>
-       <property name="buddy">
-        <cstring>untilMarkAlignComboBox</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="12" column="2">
-      <widget class="QComboBox" name="untilMarkAlignComboBox"/>
-     </item>
-     <item row="11" column="3">
-      <widget class="QLabel" name="untilMarkTextPointSizeLabel">
-       <property name="text">
-        <string>Font size</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-       </property>
-       <property name="buddy">
-        <cstring>untilMarkTextPointSizeSpinBox</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="12" column="3">
-      <widget class="QSpinBox" name="untilMarkTextPointSizeSpinBox">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="suffix">
-        <string> pt</string>
-       </property>
-       <property name="minimum">
-        <number>10</number>
-       </property>
-       <property name="maximum">
-        <number>50</number>
-       </property>
-       <property name="value">
-        <number>30</number>
-       </property>
-      </widget>
+     <item row="11" column="1" colspan="3">
+      <layout class="QGridLayout" name="gridLayout_4">
+       <item row="0" column="0">
+        <widget class="QCheckBox" name="untilMarkShowBeatsCheckBox">
+         <property name="text">
+          <string>Beats until next marker</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLabel" name="untilMarkAlignLabel">
+         <property name="text">
+          <string>Placement</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+         <property name="buddy">
+          <cstring>untilMarkAlignComboBox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="2">
+        <widget class="QLabel" name="untilMarkTextPointSizeLabel">
+         <property name="text">
+          <string>Preferred font size</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+         <property name="buddy">
+          <cstring>untilMarkTextPointSizeSpinBox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="3">
+        <widget class="QLabel" name="untilMarkTextHeightLimitLabel">
+         <property name="text">
+          <string>Text height limit</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+         <property name="buddy">
+          <cstring>untilMarkTextHeightLimitComboBox</cstring>
+         </property>
+        </widget>
+       </item>
+        <item row="1" column="0">
+        <widget class="QCheckBox" name="untilMarkShowTimeCheckBox">
+         <property name="text">
+          <string>Time until next marker</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QComboBox" name="untilMarkAlignComboBox"/>
+       </item>
+       <item row="1" column="2">
+        <widget class="QSpinBox" name="untilMarkTextPointSizeSpinBox">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="suffix">
+          <string> pt</string>
+         </property>
+         <property name="minimum">
+          <number>10</number>
+         </property>
+         <property name="maximum">
+          <number>100</number>
+         </property>
+         <property name="value">
+          <number>30</number>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="3">
+        <widget class="QComboBox" name="untilMarkTextHeightLimitComboBox"/>
+       </item>
+      </layout>
      </item>
      <item row="14" column="1" colspan="2">
       <widget class="QLabel" name="requiresGLSLLabel">

--- a/src/waveform/renderers/allshader/waveformrendermark.cpp
+++ b/src/waveform/renderers/allshader/waveformrendermark.cpp
@@ -85,8 +85,14 @@ void allshader::WaveformRenderMark::initializeGL() {
     updatePlayPosMarkTexture();
     const auto untilMarkTextPointSize =
             WaveformWidgetFactory::instance()->getUntilMarkTextPointSize();
+    const auto untilMarkTextHeightLimit =
+            WaveformWidgetFactory::instance()
+                    ->getUntilMarkTextHeightLimit(); // proportion of waveform
+                                                     // height
+    const auto untilMarkMaxHeightForText = getMaxHeightForText(untilMarkTextHeightLimit);
+
     m_digitsRenderer.updateTexture(untilMarkTextPointSize,
-            getMaxHeightForText(),
+            untilMarkMaxHeightForText,
             m_waveformRenderer->getDevicePixelRatio());
 }
 
@@ -319,8 +325,14 @@ void allshader::WaveformRenderMark::drawUntilMark(const QMatrix4x4& matrix, floa
 
     const auto untilMarkTextPointSize =
             WaveformWidgetFactory::instance()->getUntilMarkTextPointSize();
+    const auto untilMarkTextHeightLimit =
+            WaveformWidgetFactory::instance()
+                    ->getUntilMarkTextHeightLimit(); // proportion of waveform
+                                                     // height
+    const auto untilMarkMaxHeightForText = getMaxHeightForText(untilMarkTextHeightLimit);
+
     m_digitsRenderer.updateTexture(untilMarkTextPointSize,
-            getMaxHeightForText(),
+            untilMarkMaxHeightForText,
             m_waveformRenderer->getDevicePixelRatio());
 
     if (m_timeUntilMark == 0.0) {
@@ -333,7 +345,8 @@ void allshader::WaveformRenderMark::drawUntilMark(const QMatrix4x4& matrix, floa
             ? m_waveformRenderer->getBreadth() - ch
             : m_waveformRenderer->getBreadth() / 2.f;
 
-    bool multiLine = untilMarkShowBeats && untilMarkShowTime && ch * 2.f < getMaxHeightForText();
+    bool multiLine = untilMarkShowBeats && untilMarkShowTime &&
+            ch * 2.f < untilMarkMaxHeightForText;
 
     if (multiLine) {
         if (untilMarkAlign != Qt::AlignTop) {
@@ -513,6 +526,6 @@ void allshader::WaveformRenderMark::updateUntilMark(
                     (endPosition - playPosition));
 }
 
-float allshader::WaveformRenderMark::getMaxHeightForText() const {
-    return m_waveformRenderer->getBreadth() / 3;
+float allshader::WaveformRenderMark::getMaxHeightForText(float proportion) const {
+    return std::roundf(m_waveformRenderer->getBreadth() * proportion);
 }

--- a/src/waveform/renderers/allshader/waveformrendermark.h
+++ b/src/waveform/renderers/allshader/waveformrendermark.h
@@ -54,7 +54,7 @@ class allshader::WaveformRenderMark : public ::WaveformRenderMarkBase,
     void drawTexture(const QMatrix4x4& matrix, float x, float y, QOpenGLTexture* texture);
     void updateUntilMark(double playPosition, double markerPosition);
     void drawUntilMark(const QMatrix4x4& matrix, float x);
-    float getMaxHeightForText() const;
+    float getMaxHeightForText(float proportion) const;
 
     mixxx::RGBAShader m_rgbaShader;
     mixxx::TextureShader m_textureShader;

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -139,6 +139,7 @@ WaveformWidgetFactory::WaveformWidgetFactory()
           m_untilMarkShowTime(false),
           m_untilMarkAlign(Qt::AlignVCenter),
           m_untilMarkTextPointSize(24),
+          m_untilMarkTextHeightLimit(toUntilMarkTextHeightLimit(0)),
           m_openGlAvailable(false),
           m_openGlesAvailable(false),
           m_openGLShaderAvailable(false),
@@ -458,6 +459,9 @@ bool WaveformWidgetFactory::setConfig(UserSettingsPointer config) {
     setUntilMarkTextPointSize(
             m_config->getValue(ConfigKey("[Waveform]", "UntilMarkTextPointSize"),
                     m_untilMarkTextPointSize));
+    setUntilMarkTextHeightLimit(toUntilMarkTextHeightLimit(
+            m_config->getValue(ConfigKey("[Waveform]", "UntilMarkTextHeightLimit"),
+                    toUntilMarkTextHeightLimitIndex(m_untilMarkTextHeightLimit))));
 
     return true;
 }
@@ -1410,6 +1414,14 @@ void WaveformWidgetFactory::setUntilMarkTextPointSize(int value) {
     }
 }
 
+void WaveformWidgetFactory::setUntilMarkTextHeightLimit(float value) {
+    m_untilMarkTextHeightLimit = value;
+    if (m_config) {
+        m_config->setValue(ConfigKey("[Waveform]", "UntilMarkTextHeightLimit"),
+                toUntilMarkTextHeightLimitIndex(m_untilMarkTextHeightLimit));
+    }
+}
+
 // static
 Qt::Alignment WaveformWidgetFactory::toUntilMarkAlign(int index) {
     switch (index) {
@@ -1437,4 +1449,26 @@ int WaveformWidgetFactory::toUntilMarkAlignIndex(Qt::Alignment align) {
     }
     assert(false);
     return 1;
+}
+// static
+float WaveformWidgetFactory::toUntilMarkTextHeightLimit(int index) {
+    switch (index) {
+    case 0:
+        return 0.333f;
+    case 1:
+        return 1.f;
+    }
+    assert(false);
+    return 0.33f;
+}
+// static
+int WaveformWidgetFactory::toUntilMarkTextHeightLimitIndex(float value) {
+    if (value == 0.333f) {
+        return 0;
+    }
+    if (value == 1.f) {
+        return 1;
+    }
+    assert(false);
+    return 0;
 }

--- a/src/waveform/waveformwidgetfactory.h
+++ b/src/waveform/waveformwidgetfactory.h
@@ -102,6 +102,7 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
     void setUntilMarkShowTime(bool value);
     void setUntilMarkAlign(Qt::Alignment align);
     void setUntilMarkTextPointSize(int value);
+    void setUntilMarkTextHeightLimit(float value);
 
     bool getUntilMarkShowBeats() const {
         return m_untilMarkShowBeats;
@@ -115,9 +116,13 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
     int getUntilMarkTextPointSize() const {
         return m_untilMarkTextPointSize;
     }
-
+    float getUntilMarkTextHeightLimit() const {
+        return m_untilMarkTextHeightLimit;
+    }
     static Qt::Alignment toUntilMarkAlign(int index);
     static int toUntilMarkAlignIndex(Qt::Alignment align);
+    static float toUntilMarkTextHeightLimit(int index);
+    static int toUntilMarkTextHeightLimitIndex(float value);
 
     /// Returns the desired surface format for the OpenGLWindow
     static QSurfaceFormat getSurfaceFormat(UserSettingsPointer config = nullptr);
@@ -224,6 +229,7 @@ class WaveformWidgetFactory : public QObject, public Singleton<WaveformWidgetFac
     bool m_untilMarkShowTime;
     Qt::Alignment m_untilMarkAlign;
     int m_untilMarkTextPointSize;
+    float m_untilMarkTextHeightLimit;
 
     bool m_openGlAvailable;
     bool m_openGlesAvailable;


### PR DESCRIPTION
This is a cherry-pick of the changes of https://github.com/mixxxdj/mixxx/pull/13465 for 2.5.

The text height of the Play marker hints (beats and time until next marker) was limited to a third of the waveform viewer. Increasing the font size beyond that had no effect, until the waveform viewer was made higher.

This was confusing to the user and could be interpreted as a bug. Also, this limit of 1/3rd was arbitrary and not obvious. See this comment from Eve:

https://mixxx.zulipchat.com/#narrow/stream/109171-development/topic/.28RFC.29.20show.20beats.20until.20next.20marker/near/449084479

To make the mechanism more clear, I have renamed "Font size" to "Preferred font size" and added a combobox "Text height limit" with options "1/3rd on waveform viewer" and "Full waveform viewer".
