### PR TITLE
resolveTrackIdsFromUrls directly, without going through supportedTracksFromUrls

### DIFF
--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -165,11 +165,35 @@ TrackId TrackDAO::getTrackIdByLocation(const QString& location) const {
 }
 
 QList<TrackId> TrackDAO::resolveTrackIds(
+        const QList<QUrl>& urls,
+        ResolveTrackIdFlags flags) {
+    QStringList pathList;
+    pathList.reserve(urls.size());
+    for (const auto& url : urls) {
+        const QString urlStr = url.isLocalFile() ? url.toLocalFile() : url.toString();
+        pathList << "(" + SqlStringFormatter::format(m_database, urlStr) + ")";
+    }
+
+    return resolveTrackIds(pathList, flags);
+}
+
+QList<TrackId> TrackDAO::resolveTrackIds(
         const QList<mixxx::FileInfo>& fileInfos,
         ResolveTrackIdFlags flags) {
-    QList<TrackId> trackIds;
-    trackIds.reserve(fileInfos.size());
+    QStringList pathList;
+    pathList.reserve(fileInfos.size());
+    for (const auto& fileInfo : fileInfos) {
+        pathList << "(" + SqlStringFormatter::format(m_database, fileInfo.location()) + ")";
+    }
 
+    return resolveTrackIds(pathList, flags);
+}
+
+QList<TrackId> TrackDAO::resolveTrackIds(
+        const QStringList& pathList,
+        ResolveTrackIdFlags flags) {
+    QList<TrackId> trackIds;
+    trackIds.reserve(pathList.size());
     // Create a temporary database of the paths of all the imported tracks.
     QSqlQuery query(m_database);
     query.prepare(
@@ -179,12 +203,6 @@ QList<TrackId> TrackDAO::resolveTrackIds(
         LOG_FAILED_QUERY(query);
         DEBUG_ASSERT(!"Failed query");
         return trackIds;
-    }
-
-    QStringList pathList;
-    pathList.reserve(fileInfos.size());
-    for (const auto& fileInfo : fileInfos) {
-        pathList << "(" + SqlStringFormatter::format(m_database, fileInfo.location()) + ")";
     }
 
     // Add all the track paths temporary to this database.
@@ -239,12 +257,12 @@ QList<TrackId> TrackDAO::resolveTrackIds(
         while (query.next()) {
             trackIds.append(TrackId(query.value(idColumn)));
         }
-        DEBUG_ASSERT(trackIds.size() <= fileInfos.size());
-        if (trackIds.size() < fileInfos.size()) {
+        DEBUG_ASSERT(trackIds.size() <= pathList.size());
+        if (trackIds.size() < pathList.size()) {
             qDebug() << "TrackDAO::getTrackIds(): Found only"
                      << trackIds.size()
                      << "of"
-                     << fileInfos.size()
+                     << pathList.size()
                      << "tracks in library";
         }
     } else {

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -48,6 +48,9 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     void finish();
 
     QList<TrackId> resolveTrackIds(
+            const QList<QUrl>& urls,
+            ResolveTrackIdFlags flags = ResolveTrackIdFlag::ResolveOnly);
+    QList<TrackId> resolveTrackIds(
             const QList<mixxx::FileInfo>& fileInfos,
             ResolveTrackIdFlags flags = ResolveTrackIdFlag::ResolveOnly);
 
@@ -128,6 +131,10 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     friend class LibraryScanner;
     friend class TrackCollection;
     friend class TrackAnalysisScheduler;
+
+    QList<TrackId> resolveTrackIds(
+            const QStringList& pathList,
+            ResolveTrackIdFlags flags = ResolveTrackIdFlag::ResolveOnly);
 
     TrackId getTrackIdByLocation(
             const QString& location) const;

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -221,6 +221,18 @@ DirectoryDAO::RelocateResult TrackCollection::relocateDirectory(
 }
 
 QList<TrackId> TrackCollection::resolveTrackIds(
+        const QList<QUrl>& urls,
+        TrackDAO::ResolveTrackIdFlags flags) {
+    QList<TrackId> trackIds = m_trackDao.resolveTrackIds(
+            urls,
+            flags);
+    if (flags & TrackDAO::ResolveTrackIdFlag::UnhideHidden) {
+        unhideTracks(trackIds);
+    }
+    return trackIds;
+}
+
+QList<TrackId> TrackCollection::resolveTrackIds(
         const QList<mixxx::FileInfo>& trackFiles,
         TrackDAO::ResolveTrackIdFlags flags) {
     QList<TrackId> trackIds = m_trackDao.resolveTrackIds(
@@ -235,8 +247,7 @@ QList<TrackId> TrackCollection::resolveTrackIds(
 QList<TrackId> TrackCollection::resolveTrackIdsFromUrls(
         const QList<QUrl>& urls,
         bool addMissing) {
-    QList<mixxx::FileInfo> files = DragAndDropHelper::supportedTracksFromUrls(urls, false, true);
-    if (files.isEmpty()) {
+    if (urls.isEmpty()) {
         return QList<TrackId>();
     }
 
@@ -245,7 +256,7 @@ QList<TrackId> TrackCollection::resolveTrackIdsFromUrls(
     if (addMissing) {
         flags |= TrackDAO::ResolveTrackIdFlag::AddMissing;
     }
-    return resolveTrackIds(files, flags);
+    return resolveTrackIds(urls, flags);
 }
 
 QList<TrackId> TrackCollection::resolveTrackIdsFromLocations(

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -132,6 +132,9 @@ class TrackCollection : public QObject,
     QList<TrackId> resolveTrackIds(
             const QList<mixxx::FileInfo>& trackFiles,
             TrackDAO::ResolveTrackIdFlags flags);
+    QList<TrackId> resolveTrackIds(
+            const QList<QUrl>& urls,
+            TrackDAO::ResolveTrackIdFlags flags);
     QList<TrackId> resolveTrackIdsFromUrls(
             const QList<QUrl>& urls,
             bool addMissing);


### PR DESCRIPTION
resolveTrackIdsFromUrls directly, without going through DragAndDropeHelper::supportedTracksFromUrls

Replaces https://github.com/mixxxdj/mixxx/pull/13146