### PR TITLE
Stem control test fix

### DIFF
--- a/src/test/stemcontrolobjecttest.cpp
+++ b/src/test/stemcontrolobjecttest.cpp
@@ -110,15 +110,18 @@ class StemControlTest : public BaseSignalPathTest {
                         TrackPointer pNewTrack) { pLoadedTrack = pNewTrack; });
         BaseSignalPathTest::loadTrack(pDeck, pTrack);
 
-        for (int i = 0; i < 2000; ++i) {
+        for (int i = 0; i < 10000; ++i) {
             if (pLoadedTrack == pTrack) {
                 break;
             }
             int maxtime = 1; // ms
             QCoreApplication::processEvents(QEventLoop::WaitForMoreEvents, maxtime);
-            // 1 ms for waiting 2 s at max
+            // 1 ms for waiting 10 s at max
         }
         QObject::disconnect(connection);
+        if (pLoadedTrack != pTrack) {
+            qWarning() << "Timeout: failed loading track" << pTrack->getLocation();
+        }
     }
 
     std::unique_ptr<PollingControlProxy> m_pPlay;

--- a/src/test/stemcontrolobjecttest.cpp
+++ b/src/test/stemcontrolobjecttest.cpp
@@ -106,7 +106,7 @@ class StemControlTest : public BaseSignalPathTest {
         TrackPointer pLoadedTrack;
         QMetaObject::Connection connection = QObject::connect(pDeck,
                 &BaseTrackPlayerImpl::newTrackLoaded,
-                [&pLoadedTrack](
+                [&pLoadedTrack]( // clazy:exclude=lambda-in-connect
                         TrackPointer pNewTrack) { pLoadedTrack = pNewTrack; });
         BaseSignalPathTest::loadTrack(pDeck, pTrack);
 


### PR DESCRIPTION
This implements waiting for the Deck::newTrackLoaded() signal. An alternative for https://github.com/mixxxdj/mixxx/pull/13936

In most cases the test continues after only 1 ms in the wait loop, but it may take way longer if the hardware is busy. 