### PR TITLE
EngineRecord: Fix recorded duration at start of recording

### DIFF
--- a/src/engine/sidechain/enginerecord.cpp
+++ b/src/engine/sidechain/enginerecord.cpp
@@ -146,6 +146,7 @@ void EngineRecord::process(const CSAMPLE* pBuffer, const int iBufferSize) {
             // clean frames counting and get current sample rate.
             m_frames = 0;
             m_sampleRate = mixxx::audio::SampleRate::fromDouble(m_sampleRateControl.get());
+            m_recordedDuration = 0;
 
             if (m_bCueIsEnabled) {
                 openCueFile();


### PR DESCRIPTION
### Fixes #13964 

This fixes the first timestamp of CUE sheets upon restarting the recording, see https://github.com/mixxxdj/mixxx/issues/13964#issuecomment-2513231487 for details.

In the medium-term this logic should probably be refactored to contain less duplication, but I'd consider it more important to get this bug fixed for 2.5 before looking at (potentially riskier) refactorings, which should probably also target `main` to get more testing.

(Hope it's okay that I added this to the 2.5.0 milestone, since it's a really trivial fix)