### PR TITLE
mark rendering improvements

### DIFF
--- a/src/util/roundtopixel.h
+++ b/src/util/roundtopixel.h
@@ -2,7 +2,7 @@
 
 #include <cmath>
 
-inline auto makeRoundToPixel(float devicePixelRatio) {
+inline auto createFunctionRoundToPixel(float devicePixelRatio) {
     return [devicePixelRatio](float pos) {
         return std::round(pos * devicePixelRatio) / devicePixelRatio;
     };

--- a/src/util/roundtopixel.h
+++ b/src/util/roundtopixel.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <cmath>
+
+inline auto makeRoundToPixel(float devicePixelRatio) {
+    return [devicePixelRatio](float pos) {
+        return std::round(pos * devicePixelRatio) / devicePixelRatio;
+    };
+}

--- a/src/waveform/renderers/allshader/digitsrenderer.cpp
+++ b/src/waveform/renderers/allshader/digitsrenderer.cpp
@@ -136,7 +136,8 @@ void allshader::DigitsRenderer::updateTexture(
         const QString text(indexToChar(i));
         xs[i] = totalTextWidth;
         qreal w = std::round(metrics.horizontalAdvance(text) *
-                          devicePixelRatio / devicePixelRatio) +
+                          devicePixelRatio) /
+                        devicePixelRatio +
                 space + space + 1.0;
         totalTextWidth += w;
         m_width[i] = static_cast<float>(w);

--- a/src/waveform/renderers/allshader/digitsrenderer.cpp
+++ b/src/waveform/renderers/allshader/digitsrenderer.cpp
@@ -131,7 +131,7 @@ void allshader::DigitsRenderer::updateTexture(
 
     const float y = maxTextHeight + space - 0.5f;
 
-    auto roundToPixel = makeRoundToPixel(devicePixelRatio);
+    auto roundToPixel = createFunctionRoundToPixel(devicePixelRatio);
 
     float totalTextWidth{};
     std::array<float, NUM_CHARS> xs;

--- a/src/waveform/renderers/allshader/waveformrendermark.cpp
+++ b/src/waveform/renderers/allshader/waveformrendermark.cpp
@@ -203,7 +203,7 @@ void allshader::WaveformRenderMark::paintGL() {
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
-    auto roundToPixel = makeRoundToPixel(devicePixelRatio);
+    auto roundToPixel = createFunctionRoundToPixel(devicePixelRatio);
 
     for (const auto& pMark : std::as_const(m_marks)) {
         pMark->setBreadth(slipActive ? m_waveformRenderer->getBreadth() / 2

--- a/src/waveform/renderers/allshader/waveformrendermark.cpp
+++ b/src/waveform/renderers/allshader/waveformrendermark.cpp
@@ -20,6 +20,19 @@
 // only to draw on a QImage. This is only done once when needed and the images are
 // then used as textures to be drawn with a GLSL shader.
 
+namespace {
+
+struct RoundToPixel {
+    const float m_devicePixelRatio;
+    RoundToPixel(float devicePixelRatio)
+            : m_devicePixelRatio{devicePixelRatio} {
+    }
+    // round to nearest pixel, taking into account the devicePixelRatio
+    float operator()(float pos) const {
+        return std::round(pos * m_devicePixelRatio) / m_devicePixelRatio;
+    }
+};
+
 class TextureGraphics : public WaveformMark::Graphics {
   public:
     TextureGraphics(const QImage& image) {
@@ -27,88 +40,24 @@ class TextureGraphics : public WaveformMark::Graphics {
     }
     QOpenGLTexture* texture() {
         return &m_texture;
-        void updateTexture(rendergraph::Context * pContext, const QImage& image) {
-            dynamic_cast<TextureMaterial&>(material())
-                    .setTexture(std::make_unique<Texture>(pContext, image));
-            m_textureWidth = image.width();
-            m_textureHeight = image.height();
-        }
-        void update(float x, float y, float devicePixelRatio) {
-            TexturedVertexUpdater vertexUpdater{
-                    geometry().vertexDataAs<Geometry::TexturedPoint2D>()};
-            vertexUpdater.addRectangle({x, y},
-                    {x + m_textureWidth / devicePixelRatio,
-                            y + m_textureHeight / devicePixelRatio},
-                    {0.f, 0.f},
-                    {1.f, 1.f});
-        }
-        float textureWidth() const {
-            return m_textureWidth;
-        }
-        float textureHeight() const {
-            return m_textureHeight;
-        }
-
-      public:
-        float m_textureWidth{};
-        float m_textureHeight{};
-    };
-
-    class WaveformMarkNodeGraphics : public WaveformMark::Graphics {
-      public:
-        WaveformMarkNodeGraphics(WaveformMark* pOwner,
-                rendergraph::Context* pContext,
-                const QImage& image)
-                : m_pNode(std::make_unique<WaveformMarkNode>(
-                          pOwner, pContext, image)) {
-        }
-        void updateTexture(rendergraph::Context* pContext, const QImage& image) {
-            waveformMarkNode()->updateTexture(pContext, image);
-        }
-        void update(float x, float y, float devicePixelRatio) {
-            waveformMarkNode()->update(x, y, devicePixelRatio);
-        }
-        float textureWidth() const {
-            return waveformMarkNode()->textureWidth();
-        }
-        float textureHeight() const {
-            return waveformMarkNode()->textureHeight();
-        }
-        void attachNode(std::unique_ptr<rendergraph::BaseNode> pNode) {
-            DEBUG_ASSERT(!m_pNode);
-            m_pNode = std::move(pNode);
-        }
-        std::unique_ptr<rendergraph::BaseNode> detachNode() {
-            return std::move(m_pNode);
-        }
-
-      private:
-        OpenGLTexture2D m_texture;
-    };
-
-    constexpr float kPlayPosWidth{11.f};
-    constexpr float kPlayPosOffset{-(kPlayPosWidth - 1.f) / 2.f};
-
-    QString timeSecToString(double timeSec) {
-        int hundredths = std::lround(timeSec * 100.0);
-        int seconds = hundredths / 100;
-        hundredths -= seconds * 100;
-        int minutes = seconds / 60;
-        seconds -= minutes * 60;
-
-        return QString::asprintf("%d:%02d.%02d", minutes, seconds, hundredths);
     }
 
-    struct RoundToPixel {
-        const float m_devicePixelRatio;
-        RoundToPixel(float devicePixelRatio)
-                : m_devicePixelRatio(devicePixelRatio) {
-        }
-        // round to nearest pixel, taking into account the devicePixelRatio
-        float operator()(float pos) const {
-            return std::round(pos * m_devicePixelRatio) / m_devicePixelRatio;
-        }
-    };
+  private:
+    OpenGLTexture2D m_texture;
+};
+
+constexpr float kPlayPosWidth{11.f};
+constexpr float kPlayPosOffset{-(kPlayPosWidth - 1.f) / 2.f};
+
+QString timeSecToString(double timeSec) {
+    int hundredths = std::lround(timeSec * 100.0);
+    int seconds = hundredths / 100;
+    hundredths -= seconds * 100;
+    int minutes = seconds / 60;
+    seconds -= minutes * 60;
+
+    return QString::asprintf("%d:%02d.%02d", minutes, seconds, hundredths);
+}
 
 } // namespace
 
@@ -307,14 +256,14 @@ void allshader::WaveformRenderMark::paintGL() {
         }
         const double sampleEndPosition = pMark->getSampleEndPosition();
 
-        const float markWidth = pMarkNodeGraphics->textureWidth() / devicePixelRatio;
+        const float markWidth = pTexture->width() / devicePixelRatio;
         const float drawOffset = currentMarkPos + pMark->getOffset();
 
         bool visible = false;
         // Check if the current point needs to be displayed.
         if (drawOffset > -markWidth &&
                 drawOffset < m_waveformRenderer->getLength()) {
-            pMarkNodeGraphics->update(
+            drawTexture(matrix,
                     roundToPixel(drawOffset),
                     !m_isSlipRenderer && slipActive
                             ? roundToPixel(m_waveformRenderer->getBreadth() / 2.f)
@@ -334,8 +283,8 @@ void allshader::WaveformRenderMark::paintGL() {
                 color.setAlphaF(0.4f);
 
                 drawMark(matrix,
-                        QRectF(QPointF(currentMarkPoint, 0),
-                                QPointF(currentMarkEndPoint,
+                        QRectF(QPointF(roundToPixel(currentMarkPos), 0),
+                                QPointF(roundToPixel(currentMarkEndPos),
                                         m_waveformRenderer
                                                 ->getBreadth())),
                         color);
@@ -353,15 +302,10 @@ void allshader::WaveformRenderMark::paintGL() {
 
     const float playMarkerPos = m_waveformRenderer->getPlayMarkerPosition() *
             m_waveformRenderer->getLength();
-    {
+    if (m_playPosMarkTexture.isStorageAllocated()) {
         const float drawOffset = roundToPixel(playMarkerPos + kPlayPosOffset);
-        TexturedVertexUpdater vertexUpdater{
-                m_pPlayPosNode->geometry()
-                        .vertexDataAs<Geometry::TexturedPoint2D>()};
-        vertexUpdater.addRectangle({drawOffset, 0.f},
-                {drawOffset + kPlayPosWidth, static_cast<float>(m_waveformRenderer->getBreadth())},
-                {0.f, 0.f},
-                {1.f, 1.f});
+
+        drawTexture(matrix, drawOffset, 0.f, &m_playPosMarkTexture);
     }
 
     if (WaveformWidgetFactory::instance()->getUntilMarkShowBeats() ||

--- a/src/waveform/renderers/allshader/waveformrendermark.cpp
+++ b/src/waveform/renderers/allshader/waveformrendermark.cpp
@@ -22,16 +22,11 @@
 
 namespace {
 
-struct RoundToPixel {
-    const float m_devicePixelRatio;
-    RoundToPixel(float devicePixelRatio)
-            : m_devicePixelRatio{devicePixelRatio} {
-    }
-    // round to nearest pixel, taking into account the devicePixelRatio
-    float operator()(float pos) const {
-        return std::round(pos * m_devicePixelRatio) / m_devicePixelRatio;
-    }
-};
+auto makeRoundToPixel(float devicePixelRatio) {
+    return [devicePixelRatio](float pos) {
+        return std::round(pos * devicePixelRatio) / devicePixelRatio;
+    };
+}
 
 class TextureGraphics : public WaveformMark::Graphics {
   public:
@@ -213,7 +208,7 @@ void allshader::WaveformRenderMark::paintGL() {
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
-    RoundToPixel roundToPixel{devicePixelRatio};
+    auto roundToPixel = makeRoundToPixel(devicePixelRatio);
 
     for (const auto& pMark : std::as_const(m_marks)) {
         pMark->setBreadth(slipActive ? m_waveformRenderer->getBreadth() / 2

--- a/src/waveform/renderers/allshader/waveformrendermark.cpp
+++ b/src/waveform/renderers/allshader/waveformrendermark.cpp
@@ -5,6 +5,7 @@
 
 #include "track/track.h"
 #include "util/colorcomponents.h"
+#include "util/roundtopixel.h"
 #include "waveform/renderers/allshader/matrixforwidgetgeometry.h"
 #include "waveform/renderers/allshader/rgbadata.h"
 #include "waveform/renderers/allshader/vertexdata.h"
@@ -21,12 +22,6 @@
 // then used as textures to be drawn with a GLSL shader.
 
 namespace {
-
-auto makeRoundToPixel(float devicePixelRatio) {
-    return [devicePixelRatio](float pos) {
-        return std::round(pos * devicePixelRatio) / devicePixelRatio;
-    };
-}
 
 class TextureGraphics : public WaveformMark::Graphics {
   public:

--- a/src/waveform/renderers/allshader/waveformrendermark.cpp
+++ b/src/waveform/renderers/allshader/waveformrendermark.cpp
@@ -295,8 +295,8 @@ void allshader::WaveformRenderMark::paintGL() {
     }
     m_waveformRenderer->setMarkPositions(marksOnScreen);
 
-    const float playMarkerPos = m_waveformRenderer->getPlayMarkerPosition() *
-            m_waveformRenderer->getLength();
+    const float playMarkerPos = static_cast<float>(m_waveformRenderer->getPlayMarkerPosition() *
+            m_waveformRenderer->getLength());
     if (m_playPosMarkTexture.isStorageAllocated()) {
         const float drawOffset = roundToPixel(playMarkerPos + kPlayPosOffset);
 

--- a/src/waveform/renderers/waveformmark.cpp
+++ b/src/waveform/renderers/waveformmark.cpp
@@ -376,14 +376,15 @@ QImage WaveformMark::generateImage(float devicePixelRatio) {
     painter.setWorldMatrixEnabled(false);
 
     const Qt::Alignment alignH = m_align & Qt::AlignHorizontal_Mask;
+    const float imgw = static_cast<float>(markerGeometry.m_imageSize.width());
     switch (alignH) {
     case Qt::AlignHCenter:
-        m_linePosition = markerGeometry.m_imageSize.width() / 2.f;
-        m_offset = -(markerGeometry.m_imageSize.width() - 1.f) / 2.f;
+        m_linePosition = imgw / 2.f;
+        m_offset = -(imgw - 1.f) / 2.f;
         break;
     case Qt::AlignLeft:
-        m_linePosition = markerGeometry.m_imageSize.width() - 1.5f;
-        m_offset = -markerGeometry.m_imageSize.width() + 2.f;
+        m_linePosition = imgw - 1.5f;
+        m_offset = -imgw + 2.f;
         break;
     case Qt::AlignRight:
     default:

--- a/src/waveform/renderers/waveformmark.cpp
+++ b/src/waveform/renderers/waveformmark.cpp
@@ -100,6 +100,7 @@ WaveformMark::WaveformMark(const QString& group,
         const WaveformSignalColors& signalColors,
         int hotCue)
         : m_linePosition{},
+          m_offset{},
           m_breadth{},
           m_level{},
           m_iPriority(priority),
@@ -278,6 +279,15 @@ struct MarkerGeometry {
         const Qt::Alignment alignH = align & Qt::AlignHorizontal_Mask;
         const Qt::Alignment alignV = align & Qt::AlignVertical_Mask;
         const bool alignHCenter{alignH == Qt::AlignHCenter};
+
+        // The image width is the label rect width + 1, so that the label rect
+        // left and right positions can be at an integer + 0.5. This is so that
+        // the label rect is drawn at an exact pixel positions.
+        //
+        // Likewise, the line position also has to fall on an integer + 0.5.
+        // When center aligning, the image width has to be odd, so that the
+        // center is an integer + 0.5. For the image width to be odd, to
+        // label rect width has to be even.
         const qreal widthRounding{alignHCenter ? 2.f : 1.f};
 
         m_labelRect = QRectF{0.f,
@@ -286,17 +296,9 @@ struct MarkerGeometry {
                         widthRounding,
                 std::ceil(capHeight + 2.f * margin)};
 
-        m_imageSize = QSizeF{alignHCenter ? m_labelRect.width() + 1.f
-                                          : 2.f * m_labelRect.width() + 1.f,
-                breadth};
+        m_imageSize = QSizeF{m_labelRect.width() + 1.f, breadth};
 
-        if (alignH == Qt::AlignHCenter) {
-            m_labelRect.moveLeft((m_imageSize.width() - m_labelRect.width()) / 2.f);
-        } else if (alignH == Qt::AlignRight) {
-            m_labelRect.moveRight(m_imageSize.width() - 0.5f);
-        } else {
-            m_labelRect.moveLeft(0.5f);
-        }
+        m_labelRect.moveLeft(0.5f);
 
         const float increment = overlappingMarkerIncrement(
                 static_cast<float>(m_labelRect.height()), breadth);
@@ -373,22 +375,39 @@ QImage WaveformMark::generateImage(float devicePixelRatio) {
 
     painter.setWorldMatrixEnabled(false);
 
-    // Draw marker lines
-    const auto hcenter = markerGeometry.m_imageSize.width() / 2.f;
-    m_linePosition = static_cast<float>(hcenter);
+    const Qt::Alignment alignH = m_align & Qt::AlignHorizontal_Mask;
+    switch (alignH) {
+    case Qt::AlignHCenter:
+        m_linePosition = markerGeometry.m_imageSize.width() / 2.f;
+        m_offset = -(markerGeometry.m_imageSize.width() - 1.f) / 2.f;
+        DEBUG_ASSERT(linePos - std::roundf(linePos) < 0.000001f);
+        break;
+    case Qt::AlignLeft:
+        m_linePosition = markerGeometry.m_imageSize.width() - 1.5f;
+        m_offset = -markerGeometry.m_imageSize.width() + 2.f;
+        break;
+    case Qt::AlignRight:
+    default:
+        m_linePosition = 1.5f;
+        m_offset = -1.f;
+        break;
+    }
+
+    // Note: linePos has to be at integer + 0.5 to draw correctly
+    const float linePos = m_linePosition;
 
     // Draw the center line
     painter.setPen(fillColor());
-    painter.drawLine(QLineF(hcenter, 0.f, hcenter, markerGeometry.m_imageSize.height()));
+    painter.drawLine(QLineF(linePos, 0.f, linePos, markerGeometry.m_imageSize.height()));
 
     painter.setPen(borderColor());
-    painter.drawLine(QLineF(hcenter - 1.f,
+    painter.drawLine(QLineF(linePos - 1.f,
             0.f,
-            hcenter - 1.f,
+            linePos - 1.f,
             markerGeometry.m_imageSize.height()));
-    painter.drawLine(QLineF(hcenter + 1.f,
+    painter.drawLine(QLineF(linePos + 1.f,
             0.f,
-            hcenter + 1.f,
+            linePos + 1.f,
             markerGeometry.m_imageSize.height()));
 
     if (useIcon || label.length() != 0) {

--- a/src/waveform/renderers/waveformmark.cpp
+++ b/src/waveform/renderers/waveformmark.cpp
@@ -380,7 +380,6 @@ QImage WaveformMark::generateImage(float devicePixelRatio) {
     case Qt::AlignHCenter:
         m_linePosition = markerGeometry.m_imageSize.width() / 2.f;
         m_offset = -(markerGeometry.m_imageSize.width() - 1.f) / 2.f;
-        DEBUG_ASSERT(linePos - std::roundf(linePos) < 0.000001f);
         break;
     case Qt::AlignLeft:
         m_linePosition = markerGeometry.m_imageSize.width() - 1.5f;
@@ -395,6 +394,8 @@ QImage WaveformMark::generateImage(float devicePixelRatio) {
 
     // Note: linePos has to be at integer + 0.5 to draw correctly
     const float linePos = m_linePosition;
+    [[maybe_unused]] const float epsilon = 1e-6f;
+    DEBUG_ASSERT(std::abs(linePos - std::floor(linePos) - 0.5) < epsilon);
 
     // Draw the center line
     painter.setPen(fillColor());

--- a/src/waveform/renderers/waveformmark.h
+++ b/src/waveform/renderers/waveformmark.h
@@ -37,6 +37,10 @@ class WaveformMark {
     WaveformMark(const WaveformMark&) = delete;
     WaveformMark& operator=(const WaveformMark&) = delete;
 
+    float getOffset() const {
+        return m_offset;
+    }
+
     int getHotCue() const {
         return m_iHotCue;
     };
@@ -158,6 +162,7 @@ class WaveformMark {
     QString m_iconPath;
 
     float m_linePosition;
+    float m_offset;
     float m_breadth;
 
     // When there are overlapping marks, level is increased for each overlapping mark,

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -37,17 +37,13 @@ void WaveformRenderMark::draw(QPainter* painter, QPaintEvent* /*event*/) {
                     m_waveformRenderer->transformSamplePositionInRendererWorld(samplePosition);
             const double sampleEndPosition = pMark->getSampleEndPosition();
             if (m_waveformRenderer->getOrientation() == Qt::Horizontal) {
-                // Pixmaps are expected to have the mark stroke at the center,
-                // and preferably have an odd width in order to have the stroke
-                // exactly at the sample position.
-                const int markHalfWidth =
-                        static_cast<int>(image.width() / 2.0 /
-                                m_waveformRenderer->getDevicePixelRatio());
-                const int drawOffset = static_cast<int>(currentMarkPoint) - markHalfWidth;
+                const int markWidth = std::lround(image.width() /
+                        m_waveformRenderer->getDevicePixelRatio());
+                const int drawOffset = std::lround(currentMarkPoint + pMark->getOffset());
 
                 bool visible = false;
                 // Check if the current point needs to be displayed.
-                if (currentMarkPoint > -markHalfWidth && currentMarkPoint < m_waveformRenderer->getWidth() + markHalfWidth) {
+                if (drawOffset > -markWidth && drawOffset < m_waveformRenderer->getWidth()) {
                     painter->drawImage(drawOffset, 0, image);
                     visible = true;
                 }
@@ -84,16 +80,13 @@ void WaveformRenderMark::draw(QPainter* painter, QPaintEvent* /*event*/) {
                                     pMark, drawOffset});
                 }
             } else {
-                const int markHalfHeight =
-                        static_cast<int>(image.height() / 2.0 /
-                                m_waveformRenderer->getDevicePixelRatio());
-                const int drawOffset = static_cast<int>(currentMarkPoint) - markHalfHeight;
+                const int markHeight = std::lroundf(image.height() /
+                        m_waveformRenderer->getDevicePixelRatio());
+                const int drawOffset = std::lroundf(currentMarkPoint + pMark->getOffset());
 
                 bool visible = false;
                 // Check if the current point needs to be displayed.
-                if (currentMarkPoint > -markHalfHeight &&
-                        currentMarkPoint < m_waveformRenderer->getHeight() +
-                                        markHalfHeight) {
+                if (drawOffset > -markHeight && drawOffset < m_waveformRenderer->getHeight()) {
                     painter->drawImage(0, drawOffset, image);
                     visible = true;
                 }

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -82,7 +82,9 @@ void WaveformRenderMark::draw(QPainter* painter, QPaintEvent* /*event*/) {
             } else {
                 const int markHeight = std::lroundf(image.height() /
                         m_waveformRenderer->getDevicePixelRatio());
-                const int drawOffset = std::lroundf(currentMarkPoint + pMark->getOffset());
+                const int drawOffset =
+                        std::lround(static_cast<float>(currentMarkPoint) +
+                                pMark->getOffset());
 
                 bool visible = false;
                 // Check if the current point needs to be displayed.

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -265,8 +265,8 @@ void WaveformWidgetRenderer::draw(QPainter* painter, QPaintEvent* event) {
 }
 
 void WaveformWidgetRenderer::drawPlayPosmarker(QPainter* painter) {
-    const int lineX = static_cast<int>(m_width * m_playMarkerPosition);
-    const int lineY = static_cast<int>(m_height * m_playMarkerPosition);
+    const int lineX = std::lround(m_width * m_playMarkerPosition);
+    const int lineY = std::lround(m_height * m_playMarkerPosition);
 
     // draw dim outlines to increase playpos/waveform contrast
     painter->setOpacity(0.5);


### PR DESCRIPTION
These changes were originally made in the rendergraph PR (and in code already using rendergraph):
https://github.com/mixxxdj/mixxx/pull/13599
but I am splitting that PR into multiple ones. This is a OpenGL backport of those changes, but it will result in a smaller delta once I have the PR for the rendergraph base waveform mark renderers.

The improvements here are:

- Not using empty space in the mark textures to align them. For left and right aligned markers, half the image would be fully transparent. With this PR only the space needed it uses, and the mark is drawn with an offset to align them to the marker position.

- Round drawing to pixels. With OpenGL this doesn't seem necessary, but with QML / Qt Scenegraph this causes artifacts in the rendering.
