### PR TITLE
Controller settings: have clickable checkbox label (like QCheckBox)

### DIFF
--- a/src/controllers/legacycontrollersettings.h
+++ b/src/controllers/legacycontrollersettings.h
@@ -136,6 +136,8 @@ class LegacyControllerBooleanSetting
                     LegacyControllerSettingsLayoutContainer::HORIZONTAL)
             override;
 
+    bool eventFilter(QObject* pObj, QEvent* pEvent) override;
+
     QJSValue value() const override {
         return QJSValue(m_savedValue);
     }


### PR DESCRIPTION
From the preferences and basically any QCheckBox in Mixxx' dialogs I'm used to being able to click on the label to toggle the checkbox (big label area, small checkbox).

However, in the controller settings we have separate QCheckBoxes (empty label) and QLabels because QCheckBox doesn't support html/richtext for formatting its label, and label click doesn't toggle the box.

This PR fixes this.
Wrt implementation we could as well use a custom QCheckBox and override its `mousePressEvent()`, the solution with eventFilter() was just much easier/quicker.