### PR TITLE
Fix crash due to concurrent access in MidiController

### DIFF
--- a/src/controllers/bulk/bulkcontroller.cpp
+++ b/src/controllers/bulk/bulkcontroller.cpp
@@ -283,8 +283,8 @@ void BulkController::send(const QList<int>& data, unsigned int length) {
 
 void BulkController::sendBytes(const QByteArray& data) {
     VERIFY_OR_DEBUG_ASSERT(!m_pMapping ||
-            m_pMapping->getDeviceDirection() &
-                    LegacyControllerMapping::DeviceDirection::Outgoing) {
+            (m_pMapping->getDeviceDirection() &
+                    LegacyControllerMapping::DeviceDirection::Outgoing)) {
         qDebug() << "The mapping for the bulk device" << getName()
                  << "doesn't require sending data. Ignoring sending request.";
         return;

--- a/src/controllers/controller.h
+++ b/src/controllers/controller.h
@@ -92,6 +92,7 @@ class Controller : public QObject {
         VERIFY_OR_DEBUG_ASSERT(pDowncastedMapping) {
             return nullptr;
         }
+        DEBUG_ASSERT(pMapping.use_count() == 2);
         return pDowncastedMapping;
     }
 

--- a/src/controllers/controllermanager.cpp
+++ b/src/controllers/controllermanager.cpp
@@ -186,6 +186,9 @@ void ControllerManager::slotShutdown() {
 }
 
 void ControllerManager::updateControllerList() {
+    static bool already_called = false; 
+    DEBUG_ASSERT(!already_called); 
+    already_called = true; 
     // NOTE: Currently this function is only called on startup. If hotplug is added, changes to the
     // controller list must be synchronized with dlgprefcontrollers to avoid dangling connections
     // and possible crashes.

--- a/src/controllers/controllermanager.cpp
+++ b/src/controllers/controllermanager.cpp
@@ -186,9 +186,12 @@ void ControllerManager::slotShutdown() {
 }
 
 void ControllerManager::updateControllerList() {
-    static bool already_called = false; 
-    DEBUG_ASSERT(!already_called); 
-    already_called = true; 
+    static bool already_called = false;
+    VERIFY_OR_DEBUG_ASSERT(!already_called) {
+        qWarning() << "skipping ControllerManager::updateControllerList() because is already called";
+        return;
+    }
+    already_called = true;
     // NOTE: Currently this function is only called on startup. If hotplug is added, changes to the
     // controller list must be synchronized with dlgprefcontrollers to avoid dangling connections
     // and possible crashes.

--- a/src/controllers/midi/midicontroller.cpp
+++ b/src/controllers/midi/midicontroller.cpp
@@ -690,9 +690,13 @@ QJSValue MidiController::makeInputHandler(int status, int midino, const QJSValue
 std::shared_ptr<LegacyMidiControllerMapping> MidiController::getSharedMapping() const {
 #ifdef __cpp_lib_atomic_shared_ptr
     // Used Spinlock
-    return m_pMapping.load(std::memory_order_relaxed);
+    std::shared_ptr<LegacyMidiControllerMapping> pMapping =
+            m_pMapping.load(std::memory_order_relaxed);
 #else
     // Uses Mutex
-    return std::atomic_load_explicit(&m_pMapping, std::memory_order_relaxed);
+    std::shared_ptr<LegacyMidiControllerMapping> pMapping =
+            std::atomic_load_explicit(&m_pMapping, std::memory_order_relaxed);
 #endif
+    DEBUG_ASSERT(!pMapping || pMapping.use_count() == 2);
+    return pMapping;
 }

--- a/src/controllers/midi/midicontroller.h
+++ b/src/controllers/midi/midicontroller.h
@@ -43,10 +43,11 @@ class MidiController : public Controller {
     virtual std::shared_ptr<LegacyControllerMapping> cloneMapping() override;
 
     bool isMappable() const override {
-        if (!m_pMapping) {
+        std::shared_ptr<LegacyMidiControllerMapping> pMapping = m_pMapping;
+        if (!pMapping) {
             return false;
         }
-        return m_pMapping->isMappable();
+        return pMapping->isMappable();
     }
 
     bool matchMapping(const MappingInfo& mapping) override;

--- a/src/controllers/midi/midicontroller.h
+++ b/src/controllers/midi/midicontroller.h
@@ -43,7 +43,7 @@ class MidiController : public Controller {
     virtual std::shared_ptr<LegacyControllerMapping> cloneMapping() override;
 
     bool isMappable() const override {
-        std::shared_ptr<LegacyMidiControllerMapping> pMapping = m_pMapping;
+        std::shared_ptr<LegacyMidiControllerMapping> pMapping = getSharedMapping();
         if (!pMapping) {
             return false;
         }
@@ -104,10 +104,17 @@ class MidiController : public Controller {
     void createOutputHandlers();
     void updateAllOutputs();
     void destroyOutputHandlers();
+    std::shared_ptr<LegacyMidiControllerMapping> getSharedMapping() const;
 
     QHash<uint16_t, MidiInputMapping> m_temporaryInputMappings;
     QList<MidiOutputHandler*> m_outputs;
+
+#ifdef __cpp_lib_atomic_shared_ptr
+    std::atomic<std::shared_ptr<LegacyMidiControllerMapping>> m_pMapping;
+#else
     std::shared_ptr<LegacyMidiControllerMapping> m_pMapping;
+#endif
+
     SoftTakeoverCtrl m_st;
     QList<QPair<MidiInputMapping, unsigned char>> m_fourteen_bit_queued_mappings;
 


### PR DESCRIPTION
This fixes #13940 
The fix is implemented by locks around m_pMapping and reference counting. 

The locks are either a mutex or a spin lock depending on the compiler support. 
I have applied them everywhere, because it is not obvious which threads are readers and writers. 

There is potential for further refactoring, because the Mapping is finally no longer shared when used. This is however out of scope of this band aid PR. 