### PR TITLE
(fix/UX) set scrollSafeGuard also for controller settings widgets

### DIFF
--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -861,7 +861,12 @@ void DlgPrefController::slotShowMapping(std::shared_ptr<LegacyControllerMapping>
             }
         }
 
-        m_ui.groupBoxSettings->setVisible(!settings.isEmpty());
+        if (settings.isEmpty()) {
+            m_ui.groupBoxSettings->setVisible(false);
+        } else {
+            m_ui.groupBoxSettings->setVisible(true);
+            setScrollSafeGuardForAllInputWidgets(m_ui.groupBoxSettings);
+        }
     }
 
     // If there is still settings that may be saved and no new mapping selected

--- a/src/preferences/dialog/dlgpreferencepage.cpp
+++ b/src/preferences/dialog/dlgpreferencepage.cpp
@@ -21,39 +21,16 @@ QUrl DlgPreferencePage::helpUrl() const {
     return QUrl();
 }
 
-void DlgPreferencePage::setScrollSafeGuardForAllInputWidgets(QObject* obj) {
+void DlgPreferencePage::setScrollSafeGuardForAllInputWidgets(QObject* pObj) {
     // Set the focus policy to for scrollable input widgets and connect them
-    // to the custom event filter
-    for (auto* ch : obj->children()) {
-        // children() does not descend into QGroupBox,
-        // so we need to do it manually
-        QGroupBox* gBox = qobject_cast<QGroupBox*>(ch);
-        if (gBox) {
-            setScrollSafeGuardForAllInputWidgets(gBox);
-            continue;
-        }
-
-        QComboBox* combo = qobject_cast<QComboBox*>(ch);
-        if (combo) {
-            setScrollSafeGuard(combo);
-            continue;
-        }
-        QSpinBox* spin = qobject_cast<QSpinBox*>(ch);
-        if (spin) {
-            setScrollSafeGuard(spin);
-            continue;
-        }
-        QDoubleSpinBox* spinDouble = qobject_cast<QDoubleSpinBox*>(ch);
-        if (spinDouble) {
-            setScrollSafeGuard(spinDouble);
-            continue;
-        }
-        QSlider* slider = qobject_cast<QSlider*>(ch);
-        if (slider) {
-            setScrollSafeGuard(slider);
-            continue;
-        }
-    }
+    // to the custom event filter.
+    // Note: finding all relevant widgets with pObj->findchildren<Type*>
+    // is much faster than with
+    // for (auto* ch : pObj->children()) { qobject_cast<Type*>(ch); }
+    setScrollSafeGuardForChildrenOfType<QComboBox>(pObj);
+    setScrollSafeGuardForChildrenOfType<QSpinBox>(pObj);
+    setScrollSafeGuardForChildrenOfType<QDoubleSpinBox>(pObj);
+    setScrollSafeGuardForChildrenOfType<QSlider>(pObj);
 }
 
 void DlgPreferencePage::setScrollSafeGuard(QWidget* pWidget) {
@@ -61,22 +38,30 @@ void DlgPreferencePage::setScrollSafeGuard(QWidget* pWidget) {
     pWidget->installEventFilter(this);
 }
 
-bool DlgPreferencePage::eventFilter(QObject* obj, QEvent* e) {
-    if (e->type() == QEvent::Wheel) {
-        // Reject scrolling only if widget is unfocused.
+template<typename T>
+void DlgPreferencePage::setScrollSafeGuardForChildrenOfType(QObject* pObj) {
+    QList<T*> children = pObj->findChildren<T*>();
+    for (T* pChild : children) {
+        setScrollSafeGuard(pChild);
+    }
+}
+
+bool DlgPreferencePage::eventFilter(QObject* pObj, QEvent* pEvent) {
+    if (pEvent->type() == QEvent::Wheel) {
+        // Reject scrolling if widget is not focused.
         // Object to widget cast is needed to check the focus state.
-        QComboBox* combo = qobject_cast<QComboBox*>(obj);
-        QSpinBox* spin = qobject_cast<QSpinBox*>(obj);
-        QDoubleSpinBox* spinDbl = qobject_cast<QDoubleSpinBox*>(obj);
-        QSlider* slider = qobject_cast<QSlider*>(obj);
+        QComboBox* combo = qobject_cast<QComboBox*>(pObj);
+        QSpinBox* spin = qobject_cast<QSpinBox*>(pObj);
+        QDoubleSpinBox* spinDbl = qobject_cast<QDoubleSpinBox*>(pObj);
+        QSlider* slider = qobject_cast<QSlider*>(pObj);
         if ((combo && !combo->hasFocus()) ||
                 (spin && !spin->hasFocus()) ||
                 (spinDbl && !spinDbl->hasFocus()) ||
                 (slider && !slider->hasFocus())) {
-            QApplication::sendEvent(qobject_cast<QObject*>(layout()), e);
-            // QApplication::sendEvent(layout()->parent(), e); ??
+            QApplication::sendEvent(qobject_cast<QObject*>(layout()), pEvent);
+            // QApplication::sendEvent(layout()->parent(), pEvent); ??
             return true;
         }
     }
-    return QObject::eventFilter(obj, e);
+    return QObject::eventFilter(pObj, pEvent);
 }

--- a/src/preferences/dialog/dlgpreferencepage.cpp
+++ b/src/preferences/dialog/dlgpreferencepage.cpp
@@ -58,8 +58,11 @@ bool DlgPreferencePage::eventFilter(QObject* pObj, QEvent* pEvent) {
                 (spin && !spin->hasFocus()) ||
                 (spinDbl && !spinDbl->hasFocus()) ||
                 (slider && !slider->hasFocus())) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            QApplication::sendEvent(layout()->parent(), pEvent);
+#else
             QApplication::sendEvent(qobject_cast<QObject*>(layout()), pEvent);
-            // QApplication::sendEvent(layout()->parent(), pEvent); ??
+#endif
             return true;
         }
     }

--- a/src/preferences/dialog/dlgpreferencepage.h
+++ b/src/preferences/dialog/dlgpreferencepage.h
@@ -28,13 +28,13 @@ class DlgPreferencePage : public QWidget {
             "</html> ")
                                                    .arg(kWarningIconPath);
 
-    void setScrollSafeGuardForAllInputWidgets(QObject* obj);
+    void setScrollSafeGuardForAllInputWidgets(QObject* pObj);
     /// Avoid undesired value changes when scrolling a preferences page while
     /// the pointer is above an input widget (QSpinBox, QComboBox, QSlider):
     /// * set the focus policy to Qt::StrongFocus (focusable by click & tab key)
     /// * forward wheel events to the top-level layout
     void setScrollSafeGuard(QWidget* pWidget);
-    bool eventFilter(QObject* obj, QEvent* e);
+    bool eventFilter(QObject* pObj, QEvent* pEvent);
 
     QColor m_pLinkColor;
 
@@ -77,4 +77,8 @@ class DlgPreferencePage : public QWidget {
                 palette().text().color())
                                .name();
     }
+
+  private:
+    template<typename T>
+    void setScrollSafeGuardForChildrenOfType(QObject* pObj);
 };


### PR DESCRIPTION
... like for all other input widgets in the preferences.

Didn't work right away because the [current way to 'safe' all child input widgets](https://github.com/mixxxdj/mixxx/blob/d18764a9258f1400f7d9922df6ba7210e4c5d18d/src/preferences/dialog/dlgpreferencepage.cpp#L24-L27) via `QObject::children()` + `qobject_cast<Type*>(QObject*)` requires Q_OBJECT for all setting widget sub-classes (not just the base class).
However "Template classes not supported by Q_OBJECT"...

I'm pedantic but I'm also lazy so I didn't try to fix the Q_OBJECT stuff (no clue where to start anyway..) but found another way (which is also much faster¹ : ) -> first commit.

Works beautifully.
Fixing the scroll guard for Qt6 en passant.

¹<sub>for example Library preferences: ~200 μs vs. ~700 μs</sub> 