### PR TITLE
(fix) Traktor Kontrol S4 Mk3: revert QuickEffect preset offset

### DIFF
--- a/res/controllers/Traktor-Kontrol-S4-MK3.js
+++ b/res/controllers/Traktor-Kontrol-S4-MK3.js
@@ -1262,7 +1262,7 @@ class FXSelect extends Button {
         if (this.mixer.firstPressedFxSelector !== null) {
             for (const deck of [1, 2, 3, 4]) {
                 const presetNumber = this.mixer.calculatePresetNumber();
-                engine.setValue(`[QuickEffectRack1_[Channel${deck}]]`, "loaded_chain_preset", presetNumber + 1);
+                engine.setValue(`[QuickEffectRack1_[Channel${deck}]]`, "loaded_chain_preset", presetNumber);
             }
         }
         if (this.mixer.firstPressedFxSelector === this.number) {
@@ -1296,7 +1296,7 @@ class QuickEffectButton extends Button {
         } else {
             const presetNumber = this.mixer.calculatePresetNumber();
             this.color = QuickEffectPresetColors[presetNumber - 1];
-            engine.setValue(this.group, "loaded_chain_preset", presetNumber + 1);
+            engine.setValue(this.group, "loaded_chain_preset", presetNumber);
             this.mixer.firstPressedFxSelector = null;
             this.mixer.secondPressedFxSelector = null;
             this.mixer.resetFxSelectorColors();
@@ -1317,7 +1317,7 @@ class QuickEffectButton extends Button {
         }
     }
     presetLoaded(presetNumber) {
-        this.color = QuickEffectPresetColors[presetNumber - 2];
+        this.color = QuickEffectPresetColors[presetNumber - 1];
         this.outConnections[1].trigger();
     }
     outConnect() {


### PR DESCRIPTION
0 is now the empty item ---
1 is the first item etc.

To clarify:
previously [1] would select the 3rd item = preset 2
now [1] selects preset 1