### PR TITLE
Fix for loading MP4 files with Unicode filenames on windows.

### DIFF
--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -290,7 +290,7 @@ AVFormatContext* SoundSourceFFmpeg::openInputFile(
     // Open input file and allocate/initialize AVFormatContext
     const int avformat_open_input_result =
             avformat_open_input(
-                    &pavInputFormatContext, fileName.toLocal8Bit().constData(), nullptr, nullptr);
+                    &pavInputFormatContext, fileName.toUtf8().constData(), nullptr, nullptr);
     if (avformat_open_input_result != 0) {
         DEBUG_ASSERT(avformat_open_input_result < 0);
         kLogger.warning().noquote()


### PR DESCRIPTION
Attempt to load a MP4 format file when on Windows that has Unicode files names will result in (specifically Tiësto - The Business):

Exception thrown at 0x00007FF87292EF09 (avformat-60.dll) in mixxx.exe: 0xC0000005: Access violation reading location 0x0000000000000000.

The function call here expects UTF8 encoding. Using toLocal8Bit will make UTF8 on linux but not on Windows. Use toUtf8 instead.