### PR TITLE
(DEBUG) S4 Mk3: compare scratch functions `engine.scratch..` vs `engine.setValue(group, "scratch2..")`

### DIFF
--- a/res/controllers/Traktor Kontrol S4 MK3.hid.xml
+++ b/res/controllers/Traktor Kontrol S4 MK3.hid.xml
@@ -10,6 +10,25 @@
         </devices>
     </info>
     <settings>
+        <group label="TEST scratch options">
+            <row orientation="vertical">
+                <option
+                    variable="scratchMode"
+                    type="enum"
+                    label="Scratch mode">
+                    <value label="scratch2">scratch2</value>
+                    <value label="scratchTick">scratchTick</value>
+                    <value label="wheelPos">wheelPos</value>
+                </option>
+                <option
+                    variable="scratchSyncToWheelLED"
+                    type="boolean"
+                    default="false"
+                    label="Sync scratch speed with wheel LED speed">
+                </option>
+            </row>
+        </group>
+
         <group label="Deck Lighting">
             <row orientation="vertical">
                 <option

--- a/res/controllers/Traktor-Kontrol-S4-MK3.js
+++ b/res/controllers/Traktor-Kontrol-S4-MK3.js
@@ -170,6 +170,23 @@ const BeatJumps = [
 // the motor if enable. Recommended value are 33 + 1/3 or 45.
 // Default: 33 + 1/3
 const BaseRevolutionsPerMinute = engine.getSetting("baseRevolutionsPerMinute") || 33 + 1/3;
+const ScratchSyncToWheelLED = !!engine.getSetting("scratchSyncToWheelLED");
+
+const scratchModes = {
+    scratch2: 0,
+    scratchTick: 1,
+    wheelPos: 2,
+    wheelPosNew: 3,
+};
+const ScratchMode = scratchModes[engine.getSetting("scratchMode")] || scratchModes.scratch2;
+// Parameters for scratchTick mode
+// alpha and beta are the recommended start values from
+// https://github.com/mixxxdj/mixxx/wiki/midi%20scripting#scratching-and-jog-wheels
+const ScratchAlpha = 1.0/8;
+const ScratchBeta = ScratchAlpha/32;
+const ScratchTicksPerRev = ScratchSyncToWheelLED ? 2150 : 6750;
+const ScratchSpeedFactor = ScratchSyncToWheelLED ? 2.14 : 1;
+const HotcuePressStopsScratching = !!engine.getSetting("hotcuePressStopsScratching");
 
 // Define whether or not to use motors.
 // This is a BETA feature! Please use at your own risk. Setting this off means that below settings are inactive
@@ -634,7 +651,7 @@ class Deck extends ComponentContainer {
 
         this.selectedStem.fill(false);
 
-        engine.setValue(this.group, "scratch2_enable", false);
+        this.deck.wheelTouch.toggleScratching(false);
         this.group = newGroup;
         this.color = this.groupsToColors[newGroup];
 
@@ -644,7 +661,7 @@ class Deck extends ComponentContainer {
 
             if (this.wheelMode === wheelModes.motor) {
                 engine.beginTimer(MotorWindUpMilliseconds, () => {
-                    engine.setValue(newGroup, "scratch2_enable", true);
+                    this.deck.wheelTouch.toggleScratching(true);
                 }, true);
             }
         }
@@ -867,9 +884,9 @@ class CueButton extends PushButton {
         } else {
             engine.setValue(this.group, this.inKey, pressed);
             if (this.deck.wheelMode === wheelModes.motor) {
-                engine.setValue(this.group, "scratch2_enable", false);
+                this.deck.wheelTouch.toggleScratching(false);
                 engine.beginTimer(MotorWindDownMilliseconds, () => {
-                    engine.setValue(this.group, "scratch2_enable", true);
+                    this.deck.wheelTouch.toggleScratching(true);
                 }, true);
             }
         }
@@ -936,7 +953,7 @@ class HotcueButton extends PushButton {
             engine.setValue(this.deck.libraryPlayButton.group, this.inKey, pressed);
         } else {
             if (this.deck.wheelMode === wheelModes.vinyl && !this.deck.wheelTouch.touched) {
-                engine.setValue(this.group, "scratch2_enable", false);
+                this.deck.wheelTouch.toggleScratching(false);
             }
             engine.setValue(this.group, this.inKey, pressed);
             if (this.shifted) {
@@ -2127,7 +2144,7 @@ class S4Mk3Deck extends Deck {
                         // Else, we enter/exit the loop in wheel mode
                     } else if (this.previousWheelMode === null) {
                         this.deck.fluxButton.loopModeOff();
-                        engine.setValue(this.group, "scratch2_enable", false);
+                        this.deck.wheelTouch.toggleScratching(false);
                         this.previousWheelMode = this.deck.wheelMode;
                         this.deck.wheelMode = wheelModes.loopIn;
 
@@ -2177,7 +2194,7 @@ class S4Mk3Deck extends Deck {
             onShortRelease: function() {
                 if (!this.shifted) {
                     engine.setValue(this.group, this.key, false);
-                    engine.setValue(this.group, "scratch2_enable", false);
+                    this.deck.wheelTouch.toggleScratching(false);
                 }
             },
             loopModeOff: function(skipRestore) {
@@ -2211,7 +2228,7 @@ class S4Mk3Deck extends Deck {
                         // Else, we enter/exit the loop in wheel mode
                     } else if (this.previousWheelMode === null) {
                         this.deck.reverseButton.loopModeOff();
-                        engine.setValue(this.group, "scratch2_enable", false);
+                        this.deck.wheelTouch.toggleScratching(false);
                         this.previousWheelMode = this.deck.wheelMode;
                         this.deck.wheelMode = wheelModes.loopOut;
                         if (this.loopModeConnection === null) {
@@ -2957,12 +2974,12 @@ class S4Mk3Deck extends Deck {
                 this.deck.fluxButton.loopModeOff(true);
                 if (this.deck.wheelMode === wheelModes.motor) {
                     this.deck.wheelMode = wheelModes.vinyl;
-                    engine.setValue(this.group, "scratch2_enable", false);
+                    this.deck.wheelTouch.toggleScratching(false);
                 } else {
                     this.deck.wheelMode = wheelModes.motor;
                     const group = this.group;
                     engine.beginTimer(MotorWindUpMilliseconds, () => {
-                        engine.setValue(group, "scratch2_enable", true);
+                        this.deck.wheelTouch.toggleScratching(false);
                     }, true);
                 }
                 this.outTrigger();
@@ -2984,7 +3001,7 @@ class S4Mk3Deck extends Deck {
                 } else {
                     this.deck.wheelMode = wheelModes.vinyl;
                 }
-                engine.setValue(this.group, "scratch2_enable", false);
+                this.deck.wheelTouch.toggleScratching(false);
                 this.outTrigger();
             },
             outTrigger: function() {
@@ -3000,12 +3017,14 @@ class S4Mk3Deck extends Deck {
         this.wheelTouch = new Button({
             touched: false,
             deck: this,
+            wheelPos: 0,
+            speed: 0,
             input: function(touched) {
                 this.touched = touched;
                 if (this.deck.wheelMode === wheelModes.vinyl || this.deck.wheelMode === wheelModes.motor) {
                     if (touched) {
-                        engine.setValue(this.group, "scratch2_enable", true);
-                    } else {
+                        this.toggleScratching(true);
+                    } else { // release
                         this.stopScratchWhenOver();
                     }
                 }
@@ -3015,14 +3034,54 @@ class S4Mk3Deck extends Deck {
                     return;
                 }
 
-                if (engine.getValue(this.group, "play") &&
-                    engine.getValue(this.group, "scratch2") < 1.5 * baseRevolutionsPerSecond &&
-                    engine.getValue(this.group, "scratch2") > 0) {
-                    engine.setValue(this.group, "scratch2_enable", false);
-                } else if (engine.getValue(this.group, "scratch2") === 0) {
-                    engine.setValue(this.group, "scratch2_enable", false);
-                } else {
-                    engine.beginTimer(100, this.stopScratchWhenOver.bind(this), true);
+                switch (ScratchMode) {
+                case scratchModes.wheelPos:
+                    if (Math.abs(this.speed) < 0.0000001) {
+                        this.toggleScratching(false);
+                    } else {
+                        engine.beginTimer(100, this.stopScratchWhenOver.bind(this), true);
+                    }
+                    break;
+                case scratchModes.scratchTick:
+                case scratchModes.scratch2:
+                default:
+                    if (engine.getValue(this.group, "play") &&
+                        engine.getValue(this.group, "scratch2") < 1.5 * baseRevolutionsPerSecond &&
+                        engine.getValue(this.group, "scratch2") > 0) {
+                        this.toggleScratching(false);
+                    } else if (engine.getValue(this.group, "scratch2") === 0) {
+                        this.toggleScratching(false);
+                    } else {
+                        engine.beginTimer(100, this.stopScratchWhenOver.bind(this), true);
+                    }
+                    break;
+                }
+            },
+            toggleScratching: function(enable) {
+                switch (ScratchMode) {
+                case scratchModes.scratchTick:
+                    if (enable) {
+                        engine.scratchEnable(this.deck.currentDeckNumber,
+                            ScratchTicksPerRev,
+                            BaseRevolutionsPerMinute,
+                            ScratchAlpha,
+                            ScratchBeta); // ramping true by default
+                    } else {
+                        engine.scratchDisable(this.deck.currentDeckNumber);
+                    }
+                    break;
+                case scratchModes.wheelPos:
+                    if (enable) {
+                        engine.setValue(this.group, "scratch_position", this.wheelPos);
+                        engine.setValue(this.group, "scratch_position_enable", 1);
+                    } else {
+                        engine.setValue(this.group, "scratch_position_enable", 0);
+                    }
+                    break;
+                case scratchModes.scratch2:
+                default:
+                    engine.setValue(this.group, "scratch2_enable", enable);
+                    break;
                 }
             }
         });
@@ -3039,20 +3098,33 @@ class S4Mk3Deck extends Deck {
             input: function(value, timestamp) {
                 if (this.oldValue === null) {
                     // This is to avoid the issue where the first time, we diff with 0, leading to the absolute value
-                    this.oldValue = [value, timestamp, 0];
+                    this.oldValue = [value, timestamp, 0, 0];
                     return;
                 }
-                let [oldValue, oldTimestamp, speed] = this.oldValue;
+                /* eslint prefer-const: "off" */
+                let [oldValue, oldTimestamp, speed, oldPos] = this.oldValue;
 
+                // Log value right-aligned
+                // const maxLength = wheelRelativeMax.toString().length;
+                // const valueStr = value.toString().padStart(maxLength, " ");
+                // if (this.deck.currentDeckNumber === 1) {
+                //     console.warn(`value: ${valueStr}`);
+                //}
+
+                // check if the internal timer wrapped around
                 if (timestamp < oldTimestamp) {
                     oldTimestamp -= wheelTimerMax;
                 }
 
                 let diff = value - oldValue;
+                // Check if the value wrapped around.
+                // It's not impossible a human made ~11 revs since the last call...
                 if (diff > wheelRelativeMax / 2) {
                     oldValue += wheelRelativeMax;
+                    diff -= wheelRelativeMax;
                 } else if (diff < -wheelRelativeMax / 2) {
                     oldValue -= wheelRelativeMax;
+                    diff += wheelRelativeMax;
                 }
 
                 const currentSpeed = (value - oldValue)/(timestamp - oldTimestamp);
@@ -3061,11 +3133,18 @@ class S4Mk3Deck extends Deck {
                 } else {
                     speed = currentSpeed;
                 }
-                this.oldValue = [value, timestamp, speed];
-                this.speed = wheelAbsoluteMax*speed*10;
 
+                this.speed = wheelAbsoluteMax * speed * 10 * ScratchSpeedFactor * 2.14;
+
+                const newPos = oldPos + diff * 55;
+                this.deck.wheelTouch.wheelPos = newPos;
+                this.deck.wheelTouch.speed = speed;
+
+                this.oldValue = [value, timestamp, speed, newPos];
+
+                const scratch2 = engine.getValue(this.group, "scratch2");
                 if (this.speed === 0 &&
-                    engine.getValue(this.group, "scratch2") === 0 &&
+                    scratch2 === 0 &&
                     engine.getValue(this.group, "jog") === 0 &&
                     this.deck.wheelMode !== wheelModes.motor) {
                     return;
@@ -3099,8 +3178,19 @@ class S4Mk3Deck extends Deck {
                     }
                     break;
                 case wheelModes.vinyl:
-                    if (this.deck.wheelTouch.touched || engine.getValue(this.group, "scratch2") !== 0) {
+                    if (ScratchMode === scratchModes.scratchTick &&
+                            engine.isScratching(this.deck.currentDeckNumber)) {
+                        if (diff !== 0) {
+                            engine.scratchTick(this.deck.currentDeckNumber, diff);
+                        }
+                    } else if (ScratchMode === scratchModes.scratch2 &&
+                            (this.deck.wheelTouch.touched || scratch2 !== 0)) {
                         engine.setValue(this.group, "scratch2", this.speed);
+                    } else if (ScratchMode === scratchModes.wheelPos &&
+                            // (this.deck.wheelTouch.touched || scratch2 !== 0)) {
+                            (this.deck.wheelTouch.touched ||
+                                engine.getValue(this.group, "scratch_position_enable") > 0)) {
+                        engine.setValue(this.group, "scratch_position", newPos);
                     } else {
                         engine.setValue(this.group, "jog", this.speed);
                     }
@@ -3347,10 +3437,10 @@ class S4Mk3MotorManager {
         }
 
         if (this.isBlockedByUser()) {
-            engine.setValue(this.deck.group, "scratch2_enable", true);
+            this.deck.wheelTouch.toggleScratching(true);
             this.currentMaxWheelForce = this.zeroSpeedForce + parseInt(this.baseFactor * expectedSpeed);
         } else if (expectedSpeed && this.userHold === 0 && !this.deck.wheelTouch.touched) {
-            engine.setValue(this.deck.group, "scratch2_enable", false);
+            this.deck.wheelTouch.toggleScratching(true);
             this.currentMaxWheelForce = MaxWheelForce;
         }
 


### PR DESCRIPTION
Helper to fix/debug #14000 

This adds two options for scratching:
* 3 scratch modes:
   curr: `engine.setValue(group, "scratch2..)`
   alt1: `engine.scratchEnable()`/`engine.scratchTick()` 
   alt2: `scratch_position_enable` / `scratch_position` (currently used for waveform scratching)
* sync scratch speed with wheel LED speed (~2x as fast as the current scratch speed)

With the alternative methods (scratchTick, wheelPos) scratching sounds pretty smooth **at low speeds**, while with the current implementation it's rather just noise (no buffer underruns, really just how wheel ticks are filtered & emitted)

**Another notable difference:**
with the `scratchTick()` method the track is very slowly drifting backwards when doing many (40+) fast + short back & forth scratches¹.

### My results:
**curr: `scratch2`:** 
* noisy at low speeds
* small drift for fast back'n'forth scratches¹
* no notable drift for one-direction scratches
(some revs forth, then same backwards, should land at the same position)

**alt1: `scratchTick`:**
* smooth sound at all speeds
* drifts backwards  for fast back'n'forth scratches¹
* no notable drift for one-direction scratches

**alt2: `scratchPos`:**
* bit noisy at very low speeds
* **no drift** whatsoever!

### Bottom line:
So, to get the best of both methods, could we use the alt. method for very slow scratches?
~~I'll test that soon.~~
**edit** No, I won't. I'm using `scratchPos` and it suits my needs. Sounds good a mid/high speeds, no drift.

Or fix the filtering for the current method?
I have no clue how..