### PR TITLE
Fix broken Windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1710,7 +1710,6 @@ set(
   src/util/runtimeloggingcategory.h
   src/util/safelywritablefile.h
   src/util/sample.h
-  src/util/sample_autogen.h
   src/util/samplebuffer.h
   src/util/sandbox.h
   src/util/scopedoverridecursor.h


### PR DESCRIPTION
Removed src/util/sample_autogen.h from CMakeLists.txt to fix broken PCH build.
This is a regression introduced by #13988.