### PR TITLE
(fix) DlgTrackInfo/~Multi: use configured notation for key display

### DIFF
--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -744,7 +744,7 @@ mixxx::UpdateResult DlgTrackInfo::updateKeyText() {
 }
 
 void DlgTrackInfo::displayKeyText() {
-    const QString keyText = m_trackRecord.getMetadata().getTrackInfo().getKeyText();
+    const QString keyText = KeyUtils::keyToString(m_trackRecord.getKeys().getGlobalKey());
     txtKey->setText(keyText);
 }
 

--- a/src/library/dlgtrackinfomulti.cpp
+++ b/src/library/dlgtrackinfomulti.cpp
@@ -386,7 +386,7 @@ void DlgTrackInfoMulti::updateTrackMetadataFields() {
         composers.insert(rec.getMetadata().getTrackInfo().getComposer());
         grouping.insert(rec.getMetadata().getTrackInfo().getGrouping());
         years.insert(rec.getMetadata().getTrackInfo().getYear());
-        keys.insert(rec.getMetadata().getTrackInfo().getKeyText());
+        keys.insert(KeyUtils::keyToString(rec.getKeys().getGlobalKey()));
         nums.insert(rec.getMetadata().getTrackInfo().getTrackNumber());
         comments.insert(rec.getMetadata().getTrackInfo().getComment());
 

--- a/src/preferences/dialog/dlgprefkey.cpp
+++ b/src/preferences/dialog/dlgprefkey.cpp
@@ -105,10 +105,10 @@ void DlgPrefKey::loadSettings() {
     m_bFastAnalysisEnabled = m_keySettings.getFastAnalysis();
     m_bReanalyzeEnabled = m_keySettings.getReanalyzeWhenSettingsChange();
 
-    QString notation_name = m_keySettings.getKeyNotation();
-    KeyUtils::KeyNotation notation_type;
+    KeyUtils::KeyNotation notation_type =
+            KeyUtils::keyNotationFromString(m_keySettings.getKeyNotation());
     QMap<mixxx::track::io::key::ChromaticKey, QString> notation;
-    if (notation_name == KEY_NOTATION_CUSTOM) {
+    if (notation_type == KeyUtils::KeyNotation::Custom) {
         radioNotationCustom->setChecked(true);
         // Read the custom notation from the config and store it in a temp QMap
         for (auto it = m_keyLineEdits.constBegin();
@@ -116,20 +116,15 @@ void DlgPrefKey::loadSettings() {
             it.value()->setText(m_keySettings.getCustomKeyNotation(it.key()));
             notation[it.key()] = it.value()->text();
         }
-        notation_type = KeyUtils::KeyNotation::Custom;
     } else {
-        if (notation_name == KEY_NOTATION_LANCELOT) {
+        if (notation_type == KeyUtils::KeyNotation::Lancelot) {
             radioNotationLancelot->setChecked(true);
-            notation_type = KeyUtils::KeyNotation::Lancelot;
-        } else if (notation_name == KEY_NOTATION_LANCELOT_AND_TRADITIONAL) {
+        } else if (notation_type == KeyUtils::KeyNotation::LancelotAndTraditional) {
             radioNotationLancelotAndTraditional->setChecked(true);
-            notation_type = KeyUtils::KeyNotation::LancelotAndTraditional;
-        } else if (notation_name == KEY_NOTATION_TRADITIONAL) {
+        } else if (notation_type == KeyUtils::KeyNotation::Traditional) {
             radioNotationTraditional->setChecked(true);
-            notation_type = KeyUtils::KeyNotation::Traditional;
-        } else if (notation_name == KEY_NOTATION_OPEN_KEY_AND_TRADITIONAL) {
+        } else if (notation_type == KeyUtils::KeyNotation::OpenKeyAndTraditional) {
             radioNotationOpenKeyAndTraditional->setChecked(true);
-            notation_type = KeyUtils::KeyNotation::OpenKeyAndTraditional;
         } else { // KEY_NOTATION_OPEN_KEY and unknown names
             radioNotationOpenKey->setChecked(true);
             notation_type = KeyUtils::KeyNotation::OpenKey;

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -5,6 +5,7 @@
 #include <QRegularExpression>
 #include <QtDebug>
 
+#include "preferences/keydetectionsettings.h"
 #include "util/compatibility/qmutex.h"
 
 using mixxx::track::io::key::ChromaticKey;
@@ -536,6 +537,24 @@ KeyUtils::KeyNotation KeyUtils::keyNotationFromNumericValue(double value) {
         return KeyNotation::Invalid;
     }
     return static_cast<KeyNotation>(value_floored);
+}
+
+KeyUtils::KeyNotation KeyUtils::keyNotationFromString(const QString& notationName) {
+    if (notationName == KEY_NOTATION_CUSTOM) {
+        return KeyUtils::KeyNotation::Custom;
+    } else if (notationName == KEY_NOTATION_OPEN_KEY) {
+        return KeyUtils::KeyNotation::OpenKey;
+    } else if (notationName == KEY_NOTATION_LANCELOT) {
+        return KeyUtils::KeyNotation::Lancelot;
+    } else if (notationName == KEY_NOTATION_TRADITIONAL) {
+        return KeyUtils::KeyNotation::Traditional;
+    } else if (notationName == KEY_NOTATION_OPEN_KEY_AND_TRADITIONAL) {
+        return KeyUtils::KeyNotation::OpenKeyAndTraditional;
+    } else if (notationName == KEY_NOTATION_LANCELOT_AND_TRADITIONAL) {
+        return KeyUtils::KeyNotation::LancelotAndTraditional;
+    } else {
+        return KeyUtils::KeyNotation::Invalid;
+    }
 }
 
 // static

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -356,8 +356,7 @@ QString KeyUtils::keyToString(ChromaticKey key,
                               KeyNotation notation) {
     if (!ChromaticKey_IsValid(key) ||
         key == mixxx::track::io::key::INVALID) {
-        // TODO(rryan): Maybe just the empty string?
-        return "INVALID";
+        return {};
     }
 
     if (notation == KeyNotation::Custom) {

--- a/src/track/keyutils.h
+++ b/src/track/keyutils.h
@@ -66,6 +66,7 @@ class KeyUtils {
 
     static mixxx::track::io::key::ChromaticKey keyFromNumericValue(double value);
     static KeyNotation keyNotationFromNumericValue(double value);
+    static KeyNotation keyNotationFromString(const QString& notationName);
 
     static double keyToNumericValue(mixxx::track::io::key::ChromaticKey key);
 

--- a/src/track/keyutils.h
+++ b/src/track/keyutils.h
@@ -43,7 +43,7 @@ class KeyUtils {
                 key < mixxx::track::io::key::C_MINOR;
     }
 
-    // Returns the tonic, 0-indexed.
+    /// Returns the tonic, 0-indexed.
     static inline int keyToTonic(mixxx::track::io::key::ChromaticKey key) {
         if (key == mixxx::track::io::key::INVALID) {
             return mixxx::track::io::key::INVALID;
@@ -51,14 +51,14 @@ class KeyUtils {
         return static_cast<int>(key) - (keyIsMajor(key) ? 1 : 13);
     }
 
-    // Takes a 0-indexed tonic and whether it is major/minor and produces a key.
+    /// Takes a 0-indexed tonic and whether it is major/minor and produces a key.
     static inline mixxx::track::io::key::ChromaticKey tonicToKey(int tonic, bool major) {
         return static_cast<mixxx::track::io::key::ChromaticKey>(
             tonic + (major ? 1 : 13));
     }
 
     static QString keyToString(mixxx::track::io::key::ChromaticKey key,
-                               KeyNotation notation = KeyNotation::Custom);
+            KeyNotation notation = KeyNotation::Custom);
 
     static QString formatGlobalKey(
             const Keys& keys,
@@ -86,8 +86,8 @@ class KeyUtils {
     static int shortestStepsToCompatibleKey(mixxx::track::io::key::ChromaticKey key,
                                             mixxx::track::io::key::ChromaticKey target_key);
 
-    // Returns a list of keys that are harmonically compatible with key using
-    // the Circle of Fifths (including the key itself).
+    /// Returns a list of keys that are harmonically compatible with key using
+    /// the Circle of Fifths (including the key itself).
     static QList<mixxx::track::io::key::ChromaticKey> getCompatibleKeys(
         mixxx::track::io::key::ChromaticKey key);
 
@@ -101,7 +101,7 @@ class KeyUtils {
     static void setNotation(
         const QMap<mixxx::track::io::key::ChromaticKey, QString>& notation);
 
-    // Returns pow(2, octaveChange)
+    /// Returns pow(2, octaveChange)
     static inline double octaveChangeToPowerOf2(const double& octaveChange) {
         // Some libraries (e.g. SoundTouch) calculate pow(2, octaveChange)
         // using this identity:


### PR DESCRIPTION
Previously, Track Properties did show the key text stored in the track, not the corresponding key of the notation selected in Key preferences. Furthermore, when selecting such a key literal text of  a different notation in DlgTrackInfoMulti, that string was always converted to 'Traditional' notation (select 5A, get Cm).

This fixes Track Properties and uses the new helper function in Key preferences.