### PR TITLE
(fix) also exclude QEvent::Timer in MixxxApplication::notify()

### DIFF
--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -212,7 +212,8 @@ bool MixxxApplication::notify(QObject* pTarget, QEvent* pEvent) {
               << pEvent->type()
               << "for object";
         if (pEvent->type() == QEvent::DeferredDelete ||
-                pEvent->type() == QEvent::ChildRemoved) {
+                pEvent->type() == QEvent::ChildRemoved ||
+                pEvent->type() == QEvent::Timer) {
             // pTarget can be already dangling in case of DeferredDelete
             debug << static_cast<void*>(pTarget); // will print dangling address
         } else {


### PR DESCRIPTION
With #13653 I noticed that QEvent::Timer is also affected.