### PR TITLE
allow to set threshold for MixxxApp::notify() event warning

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,6 +39,7 @@ constexpr int kParseCmdlineArgsErrorExitCode = 2;
 constexpr char kScaleFactorEnvVar[] = "QT_SCALE_FACTOR";
 const QString kConfigGroup = QStringLiteral("[Config]");
 const QString kScaleFactorKey = QStringLiteral("ScaleFactor");
+const QString kNotifyMaxDbgTimeKey = QStringLiteral("notify_max_dbg_time");
 
 // The default initial QPixmapCache limit is 10MB.
 // But this is used for all CoverArts in all used sizes and
@@ -243,6 +244,14 @@ int main(int argc, char * argv[]) {
         qWarning() << "Qt style for Windows is not set to 'windowsvista'. GUI might look broken!";
     }
 #endif
+
+    auto config = ConfigObject<ConfigValue>(
+            QDir(args.getSettingsPath()).filePath(MIXXX_SETTINGS_FILE),
+            QString(),
+            QString());
+    int notifywarningThreshold = config.getValue<int>(
+            ConfigKey(kConfigGroup, kNotifyMaxDbgTimeKey), 10);
+    app.setNotifyWarningThreshold(notifywarningThreshold);
 
 #ifdef Q_OS_MACOS
     // TODO: At this point it is too late to provide the same settings path to all components

--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -87,7 +87,7 @@ class QMouseEventEditable : public QMouseEvent {
 // processed through the event queue every 16.6ms, to ensure smooth rendering.
 // Exceeding this processing time can lead to visible delays, therefore 10ms is a
 // reasonable threshold.
-constexpr mixxx::Duration kEventNotifyExecTimeWarningThreshold = mixxx::Duration::fromMillis(10);
+constexpr int kDefaultEventNotifyExecTimeWarningThreshold = 10;
 
 } // anonymous namespace
 
@@ -95,7 +95,9 @@ MixxxApplication::MixxxApplication(int& argc, char** argv)
         : QApplication(argc, argv),
           m_rightPressedButtons(0),
           m_pTouchShift(nullptr),
-          m_isDeveloper(CmdlineArgs::Instance().getDeveloper()) {
+          m_isDeveloper(CmdlineArgs::Instance().getDeveloper()),
+          m_eventNotifyExecTimeWarningThreshold(
+                  mixxx::Duration::fromMillis(kDefaultEventNotifyExecTimeWarningThreshold)) {
     registerMetaTypes();
 
     // Increase the size of the global thread pool to at least
@@ -145,6 +147,12 @@ void MixxxApplication::registerMetaTypes() {
     qRegisterMetaType<mixxx::audio::FramePos>("mixxx::audio::FramePos");
     qRegisterMetaType<std::optional<mixxx::RgbColor>>("std::optional<mixxx::RgbColor>");
     qRegisterMetaType<mixxx::FileInfo>("mixxx::FileInfo");
+}
+
+void MixxxApplication::setNotifyWarningThreshold(int threshold) {
+    if (threshold > kDefaultEventNotifyExecTimeWarningThreshold) {
+        m_eventNotifyExecTimeWarningThreshold = mixxx::Duration::fromMillis(threshold);
+    }
 }
 
 bool MixxxApplication::notify(QObject* pTarget, QEvent* pEvent) {
@@ -212,7 +220,7 @@ bool MixxxApplication::notify(QObject* pTarget, QEvent* pEvent) {
     }
 
     if (m_isDeveloper &&
-            time.elapsed() > kEventNotifyExecTimeWarningThreshold) {
+            time.elapsed() > m_eventNotifyExecTimeWarningThreshold) {
         QDebug debug = qDebug();
         debug << "Processing"
               << pEvent->type()

--- a/src/mixxxapplication.h
+++ b/src/mixxxapplication.h
@@ -2,6 +2,8 @@
 
 #include <QApplication>
 
+#include "util/duration.h"
+
 class ControlProxy;
 
 class MixxxApplication : public QApplication {
@@ -12,6 +14,8 @@ class MixxxApplication : public QApplication {
 
     bool notify(QObject*, QEvent*) override;
 
+    void setNotifyWarningThreshold(int threshold);
+
   private:
     bool touchIsRightButton();
     void registerMetaTypes();
@@ -19,4 +23,5 @@ class MixxxApplication : public QApplication {
     int m_rightPressedButtons;
     ControlProxy* m_pTouchShift;
     bool m_isDeveloper;
+    mixxx::Duration m_eventNotifyExecTimeWarningThreshold;
 };


### PR DESCRIPTION
**edit** The settings key is `[Config],notify_max_dbg_time`.

At least on my machine there's so many events that take longer than 10 millis, and I want to reduce log spam.
There are probably more elegant ways to accomplish this, ie. keep `MixxxApplication` clean, like avoid adding a method and no new includes in its header. If you agree this is worth being implemented, please suggest better ways.