### PR TITLE
(fix) Traktor Kontrol S4 Mk3: correct wheel timestamp wrap-around

### DIFF
--- a/res/controllers/Traktor-Kontrol-S4-MK3.js
+++ b/res/controllers/Traktor-Kontrol-S4-MK3.js
@@ -2454,7 +2454,7 @@ class S4Mk3Deck extends Deck {
                 let [oldValue, oldTimestamp, speed] = this.oldValue;
 
                 if (timestamp < oldTimestamp) {
-                    oldTimestamp -= wheelRelativeMax;
+                    oldTimestamp -= wheelTimerMax;
                 }
 
                 let diff = value - oldValue;


### PR DESCRIPTION
just a copy/paste error I guess