### PR TITLE
(fix) Track Info: show key text as in tracks table

### DIFF
--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -744,7 +744,12 @@ mixxx::UpdateResult DlgTrackInfo::updateKeyText() {
 }
 
 void DlgTrackInfo::displayKeyText() {
-    const QString keyText = KeyUtils::keyToString(m_trackRecord.getKeys().getGlobalKey());
+    QString keyText;
+    if (m_pLoadedTrack) {
+        keyText = KeyUtils::keyFromKeyTextAndIdValues(
+                m_pLoadedTrack->getKeyText(),
+                m_pLoadedTrack->getKey());
+    }
     txtKey->setText(keyText);
 }
 

--- a/src/library/dlgtrackinfomulti.cpp
+++ b/src/library/dlgtrackinfomulti.cpp
@@ -386,7 +386,11 @@ void DlgTrackInfoMulti::updateTrackMetadataFields() {
         composers.insert(rec.getMetadata().getTrackInfo().getComposer());
         grouping.insert(rec.getMetadata().getTrackInfo().getGrouping());
         years.insert(rec.getMetadata().getTrackInfo().getYear());
-        keys.insert(KeyUtils::keyToString(rec.getKeys().getGlobalKey()));
+        auto pTrack = getTrackFromSetById(rec.getId());
+        DEBUG_ASSERT(pTrack);
+        keys.insert(KeyUtils::keyFromKeyTextAndIdValues(
+                pTrack->getKeyText(),
+                pTrack->getKey()));
         nums.insert(rec.getMetadata().getTrackInfo().getTrackNumber());
         comments.insert(rec.getMetadata().getTrackInfo().getComment());
 


### PR DESCRIPTION
Fixes #14019 butit feels like this is just a workaround.
(I didn't look into the Track / TrackRecord details)

Seems like TrackRecord doesn't hold the key text from the database, whereas `BaseTrackCache::getTrackValueForColumn()` takes the Track's key text.

quoting my findings from https://github.com/mixxxdj/mixxx/pull/14011#issuecomment-2542653733 again:
**Max Graef - Jazz 104**, FLAC

 | | |
 |---|---|
 database |  ---
 file metadata|     8B
| | |
  Tracks | 8B
  Deck | 8B
 Track Properties dialog |    ---
 -> Re-import from file |8B


Based on #14011, so it's only the last commit.