### PR TITLE
Key metadata track properties edit fix

### DIFF
--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -732,13 +732,9 @@ void DlgTrackInfo::slotSpinBpmValueChanged(double value) {
 
 void DlgTrackInfo::updateKeyText() {
     const auto keyText = txtKey->text();
-    const auto updateResult =
-            m_trackRecord.updateGlobalKeyNormalizeText(
-                    keyText,
-                    mixxx::track::io::key::USER);
-    if (updateResult == mixxx::UpdateResult::Rejected) {
-        // Restore the current key text
-    }
+    m_trackRecord.updateGlobalKeyNormalizeText(
+            keyText,
+            mixxx::track::io::key::USER);
     displayKeyText();
 }
 

--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -610,7 +610,7 @@ void DlgTrackInfo::saveTrack() {
     // handlers manually to capture any changes. If the bpm or key was unchanged
     // or invalid then the change will be ignored/rejected.
     slotSpinBpmValueChanged(spinBpm->value());
-    static_cast<void>(updateKeyText()); // discard result
+    updateKeyText();
 
     // Update the cached track
     //
@@ -730,17 +730,16 @@ void DlgTrackInfo::slotSpinBpmValueChanged(double value) {
     updateSpinBpmFromBeats();
 }
 
-mixxx::UpdateResult DlgTrackInfo::updateKeyText() {
-    const auto keyText = txtKey->text().trimmed();
+void DlgTrackInfo::updateKeyText() {
+    const auto keyText = txtKey->text();
     const auto updateResult =
             m_trackRecord.updateGlobalKeyNormalizeText(
                     keyText,
                     mixxx::track::io::key::USER);
     if (updateResult == mixxx::UpdateResult::Rejected) {
         // Restore the current key text
-        displayKeyText();
     }
-    return updateResult;
+    displayKeyText();
 }
 
 void DlgTrackInfo::displayKeyText() {
@@ -749,10 +748,7 @@ void DlgTrackInfo::displayKeyText() {
 }
 
 void DlgTrackInfo::slotKeyTextChanged() {
-    if (updateKeyText() != mixxx::UpdateResult::Unchanged) {
-        // Ensure that the text field always reflects the actual value
-        displayKeyText();
-    }
+    updateKeyText();
 }
 
 void DlgTrackInfo::slotRatingChanged(int rating) {

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -90,7 +90,7 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     void clear();
     void init();
 
-    mixxx::UpdateResult updateKeyText();
+    void updateKeyText();
     void displayKeyText();
 
     void updateFromTrack(const Track& track);

--- a/src/library/dlgtrackinfomulti.cpp
+++ b/src/library/dlgtrackinfomulti.cpp
@@ -654,9 +654,9 @@ void DlgTrackInfoMulti::saveTracks() {
             rec.refMetadata().refTrackInfo().setYear(year);
         }
         if (!key.isNull()) {
-            static_cast<void>(rec.updateGlobalKeyNormalizeText(
+            rec.updateGlobalKeyNormalizeText(
                     key,
-                    mixxx::track::io::key::USER));
+                    mixxx::track::io::key::USER);
         }
         if (!num.isNull()) {
             rec.refMetadata().refTrackInfo().setTrackNumber(num);

--- a/src/library/dlgtrackinfomulti.cpp
+++ b/src/library/dlgtrackinfomulti.cpp
@@ -907,13 +907,13 @@ void DlgTrackInfoMulti::slotKeyTextChanged() {
 
     const QString newTextInput = txtKey->currentText().trimmed();
     QString newKeyText;
-    mixxx::track::io::key::ChromaticKey newKey =
-            KeyUtils::guessKeyFromText(newTextInput);
-    if (newKey != mixxx::track::io::key::INVALID) {
-        newKeyText = KeyUtils::keyToString(newKey);
-    } else if (newTextInput.isEmpty()) {
-        // Empty text is not a valid key but indicates we want to clear the key.
-        newKeyText = newTextInput;
+    // Empty text is not a valid key but indicates we want to clear the key.
+    if (!newTextInput.isEmpty()) {
+        mixxx::track::io::key::ChromaticKey newKey =
+                KeyUtils::guessKeyFromText(newTextInput);
+        if (newKey != mixxx::track::io::key::INVALID) {
+            newKeyText = KeyUtils::keyToString(newKey);
+        }
     }
 
     txtKey->blockSignals(true);

--- a/src/track/trackrecord.cpp
+++ b/src/track/trackrecord.cpp
@@ -38,7 +38,7 @@ UpdateResult TrackRecord::updateGlobalKeyNormalizeText(
     // Try to parse the input as a key.
     mixxx::track::io::key::ChromaticKey newKey =
             KeyUtils::guessKeyFromText(keyText);
-    if (newKey == mixxx::track::io::key::INVALID) {
+    if (newKey == mixxx::track::io::key::INVALID && !keyText.isEmpty()) {
         // revert if we can't guess a valid key from it
         return UpdateResult::Rejected;
     }
@@ -48,7 +48,14 @@ UpdateResult TrackRecord::updateGlobalKeyNormalizeText(
         return UpdateResult::Unchanged;
     }
 
-    Keys newKeys = KeyFactory::makeBasicKeys(newKey, keySource);
+    Keys newKeys;
+    if (keySource == mixxx::track::io::key::FILE_METADATA) {
+        newKeys = KeyFactory::makeBasicKeysKeepText(
+                keyText,
+                mixxx::track::io::key::FILE_METADATA);
+    } else {
+        newKeys = KeyFactory::makeBasicKeys(newKey, keySource);
+    }
     setKeys(newKeys);
     return UpdateResult::Updated;
 }

--- a/src/track/trackrecord.h
+++ b/src/track/trackrecord.h
@@ -16,17 +16,17 @@ class TrackDAO;
 namespace mixxx {
 
 /// Effect of updating a property with a new value.
-enum class [[nodiscard]] UpdateResult{
-        /// The value has been updated and changed.
-        Updated,
+enum class UpdateResult {
+    /// The value has been updated and changed.
+    Updated,
 
-        /// The value didn't change and has not been updated.
-        Unchanged,
+    /// The value didn't change and has not been updated.
+    Unchanged,
 
-        /// The provided value is invalid or insonsistent with
-        /// any existing value(s) and has been rejected, i.e.
-        /// the current value didn't change either.
-        Rejected,
+    /// The provided value is invalid or insonsistent with
+    /// any existing value(s) and has been rejected, i.e.
+    /// the current value didn't change either.
+    Rejected,
 };
 
 // Properties of tracks that are stored in the database.


### PR DESCRIPTION
This fixed reloading and deleting of key value in the Track properties dialog. 

These are the leftover commits form the key metadata handling PRs for #10890 
