### PR TITLE
fix running mixxx-test directly

### DIFF
--- a/src/test/librarytest.cpp
+++ b/src/test/librarytest.cpp
@@ -37,6 +37,10 @@ LibraryTest::LibraryTest()
     CoverArtCache::createInstance();
 }
 
+LibraryTest::~LibraryTest() {
+    CoverArtCache::destroy();
+}
+
 TrackPointer LibraryTest::getOrAddTrackByLocation(
         const QString& trackLocation) const {
     return m_pTrackCollectionManager->getOrAddTrack(

--- a/src/test/librarytest.h
+++ b/src/test/librarytest.h
@@ -14,7 +14,7 @@
 class LibraryTest : public MixxxDbTest, SoundSourceProviderRegistration {
   protected:
     LibraryTest();
-    ~LibraryTest() override = default;
+    ~LibraryTest() override;
 
     TrackCollectionManager* trackCollectionManager() const {
         return m_pTrackCollectionManager.get();

--- a/src/test/playermanagertest.cpp
+++ b/src/test/playermanagertest.cpp
@@ -107,6 +107,7 @@ class PlayerManagerTest : public MixxxDbTest, SoundSourceProviderRegistration {
         m_pEffectsManager.reset();
         m_pTrackCollectionManager.reset();
         m_pControlIndicatorTimer.reset();
+        CoverArtCache::destroy();
     }
 
   protected:


### PR DESCRIPTION
Some test where failing if you run mixxx-test directly instead of using ctest. This PR fixes this. 