### PR TITLE
(fix) allow seeking (eg. to hotcue) while scratching with the waveform

### DIFF
--- a/src/engine/controls/ratecontrol.cpp
+++ b/src/engine/controls/ratecontrol.cpp
@@ -628,3 +628,7 @@ void RateControl::notifyWrapAround(mixxx::audio::FramePos triggerPos,
     m_jumpPos = triggerPos;
     m_targetPos = targetPos;
 }
+
+void RateControl::notifySeek(mixxx::audio::FramePos position) {
+    m_pScratchController->notifySeek(position);
+}

--- a/src/engine/controls/ratecontrol.h
+++ b/src/engine/controls/ratecontrol.h
@@ -88,6 +88,7 @@ public slots:
   void slotControlRatePermUpSmall(double);
   void slotControlFastForward(double);
   void slotControlFastBack(double);
+  void notifySeek(mixxx::audio::FramePos position) override;
 
 private:
   void processTempRate(const int bufferSamples);

--- a/src/engine/positionscratchcontroller.cpp
+++ b/src/engine/positionscratchcontroller.cpp
@@ -300,7 +300,7 @@ double PositionScratchController::getRate() {
 
 void PositionScratchController::notifySeek(mixxx::audio::FramePos position) {
     DEBUG_ASSERT(position.isValid());
-    // scratching continues after seek due to calculating the relative distance traveled
-    // in m_samplePosDeltaSum
+    // Scratching continues after seek due to calculating the relative
+    // distance traveled in m_samplePosDeltaSum
     m_prevSamplePos = position.toEngineSamplePos();
 }


### PR DESCRIPTION
1. scratch with the mouse on waveform, eg. spinback (mouse button still pressed)
2. press hotcue in order to seek to it
= player seeks to hotcue and stays there

Previously this was not possible because the seek position was not propagated, and the player would forward/rewind back to the position where we stopped the track with insane speed.
(well, it worked if PositionScratchController didn't register a movement, ie. if the mouse has been pressed but not moved)