### PR TITLE
Find controller path when executing mixxx-test from the build directory

### DIFF
--- a/src/test/controller_mapping_validation_test.cpp
+++ b/src/test/controller_mapping_validation_test.cpp
@@ -108,8 +108,7 @@ bool FakeController::isMappable() const {
 }
 
 void LegacyControllerMappingValidationTest::SetUp() {
-    m_mappingPath = QDir::current();
-    m_mappingPath.cd("res/controllers");
+    m_mappingPath = getTestDir().filePath(QStringLiteral("../../res/controllers/"));
     m_pEnumerator.reset(new MappingInfoEnumerator(QList<QString>{m_mappingPath.absolutePath()}));
 }
 

--- a/src/test/controllers/controller_columnid_regression_test.cpp
+++ b/src/test/controllers/controller_columnid_regression_test.cpp
@@ -55,9 +55,12 @@ QHash<QString, TrackModel::SortColumnId>
 };
 
 TEST_F(ControllerLibraryColumnIDRegressionTest, ensureS4MK3) {
+    QDir systemMappingsPath = getTestDir().filePath(QStringLiteral("../../res/controllers/"));
     std::shared_ptr<LegacyControllerMapping> pMapping =
             LegacyControllerMappingFileHandler::loadMapping(
-                    QFileInfo("res/controllers/Traktor Kontrol S4 MK3.hid.xml"), QDir());
+                    QFileInfo(systemMappingsPath.filePath(
+                            QStringLiteral("Traktor Kontrol S4 MK3.hid.xml"))),
+                    systemMappingsPath);
     EXPECT_TRUE(pMapping);
     auto settings = pMapping->getSettings();
     EXPECT_TRUE(!settings.isEmpty());

--- a/src/test/trackmetadataexport_test.cpp
+++ b/src/test/trackmetadataexport_test.cpp
@@ -35,8 +35,7 @@ class GlobalTrackCacheHelper : public GlobalTrackCacheSaver {
 class TrackMetadataExportTest : public MixxxTest, private SoundSourceProviderRegistration {
   public:
     TrackMetadataExportTest()
-            : m_testDataDir(QDir::current().absoluteFilePath(
-                      "src/test/id3-test-data")) {
+            : m_testDataDir(getTestDir().absoluteFilePath(QStringLiteral("id3-test-data"))) {
     }
 
   protected:
@@ -51,7 +50,7 @@ TEST_F(TrackMetadataExportTest, keepWithespaceKey) {
     constexpr std::string_view kId3Key = "Bbm";
 
     // Generate a file name for exporting metadata
-    const QString exportTrackPath = m_exportTempDir.filePath(kEmptyFile);
+    const QString exportTrackPath = m_exportTempDir.filePath("keepWithespaceKey.mp3");
     mixxxtest::copyFile(m_testDataDir.absoluteFilePath(kEmptyFile), exportTrackPath);
     TrackPointer pTrack = Track::newTemporary(exportTrackPath);
 


### PR DESCRIPTION
Before it was required to call it from the project's root directory. 