### PR TITLE
fix clang-tidy complain

### DIFF
--- a/src/widget/wtrackstemmenu.cpp
+++ b/src/widget/wtrackstemmenu.cpp
@@ -12,7 +12,7 @@ const QList<mixxx::StemChannel> stemTracks = {
         mixxx::StemChannel::Third,
         mixxx::StemChannel::Fourth,
 };
-}
+} // namespace
 
 WTrackStemMenu::WTrackStemMenu(const QString& label,
         QWidget* parent,


### PR DESCRIPTION
This fixes 
`anonymous namespace not terminated with a closing comment [google-readability-namespace-comments]`