### PR TITLE
(fix) skins: center rate range labels (Qt6 regression)

### DIFF
--- a/res/skins/Tango/decks/rate_pitch_key.xml
+++ b/res/skins/Tango/decks/rate_pitch_key.xml
@@ -180,6 +180,7 @@ Variables:
 
               <!-- Pitch range indicators: prefix / spacer / range number -->
               <WidgetGroup>
+                <ObjectName>RateDisplayBox</ObjectName>
                 <SizePolicy>me,me</SizePolicy>
                 <Layout>vertical</Layout>
                 <Size>50f,-1me</Size>
@@ -195,8 +196,9 @@ Variables:
                         <Channel><Variable name="chanNum" /></Channel>
                         <Position>Top</Position>
                         <Display>prefix</Display>
-                        <SizePolicy>me,min</SizePolicy>
+                        <SizePolicy>min,min</SizePolicy>
                       </RateRange>
+                      <WidgetGroup><Size>0me,0me</Size></WidgetGroup>
                       <RateRange>
                         <TooltipId>rate_range_display</TooltipId>
                         <ObjectName>RateDisplayTopRate</ObjectName>
@@ -222,8 +224,9 @@ Variables:
                         <Position>Bottom</Position>
                         <Align>Bottom</Align>
                         <Display>prefix</Display>
-                        <SizePolicy>me,min</SizePolicy>
+                        <SizePolicy>min,min</SizePolicy>
                       </RateRange>
+                      <WidgetGroup><Size>0me,0me</Size></WidgetGroup>
                       <RateRange>
                         <TooltipId>rate_range_display</TooltipId>
                         <ObjectName>RateDisplayBottomRate</ObjectName>

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -1312,6 +1312,10 @@ WBeatSpinBox,
         image: url(skin:/../Tango/buttons/btn_key_down_hover.svg) no-repeat center center;
       }
 
+#RateDisplayBox {
+  padding: 0 3px 0 5px;
+}
+
 
 /* ################################################################
 ####### Deck Colors ##################################################
@@ -3210,11 +3214,4 @@ WEffectChainPresetSelector::indicator::unchecked:selected,
 
 WRateRange {
     font-size: 11px;
-}
-
-#RateDisplayTopPrefix,
-#RateDisplayBottomPrefix,
-#RateDisplayTopRate,
-#RateDisplayBottomRate {
-    qproperty-alignment: 'AlignHCenter';
 }

--- a/src/widget/wraterange.cpp
+++ b/src/widget/wraterange.cpp
@@ -31,6 +31,7 @@ void WRateRange::setup(const QDomNode& node, const SkinContext& context) {
     } else {
         m_nodeDisplay = DisplayType::Default;
     }
+    setAlignment(Qt::AlignCenter);
 
     // Initialize the widget (overrides the base class initial value).
     const double range = m_pRateRangeControl->get();


### PR DESCRIPTION
Fixes a Qt6 regression:
the numbers were left-aligned, in LateNight they overlap the slider background.
It's not possible anymore to correct this with a stylesheet like this
```css
#RateRangeText {
  qproperty-alignment: AlignRight;
  text-align: right;
}
```

Fix was necessary in LateNight and Tango.

Fixed 'center' is okay for official skins. If we need more customization we can add a parser for an `Align` node.

| 2.4 | 2.5 | this PR |
|-|-|-|
![image](https://github.com/user-attachments/assets/99b8f95b-4578-482e-a1be-9c8549ebe7ae) | ![image](https://github.com/user-attachments/assets/d6e0e89e-5661-412e-a937-48eede2ba982) | ![image](https://github.com/user-attachments/assets/ead20a37-1f22-453f-92b0-84db6d2aae2a)


