### PR TITLE
Tracks: use clicked column to focus property editor in Track Info dialog

### DIFF
--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -31,6 +31,7 @@ constexpr int kMinBpm = 30;
 // Maximum allowed interval between beats (calculated from kMinBpm).
 const mixxx::Duration kMaxInterval = mixxx::Duration::fromMillis(
         static_cast<qint64>(1000.0 * (60.0 / kMinBpm)));
+const QString kBpmPropertyName = QStringLiteral("bpm");
 
 } // namespace
 
@@ -70,7 +71,7 @@ void DlgTrackInfo::init() {
     m_propertyWidgets.insert("composer", txtComposer);
     m_propertyWidgets.insert("genre", txtGenre);
     m_propertyWidgets.insert("year", txtYear);
-    m_propertyWidgets.insert("bpm", spinBpm);
+    m_propertyWidgets.insert(kBpmPropertyName, spinBpm);
     m_propertyWidgets.insert("tracknumber", txtTrackNumber);
     m_propertyWidgets.insert("key", txtKey);
     m_propertyWidgets.insert("grouping", txtGrouping);
@@ -510,6 +511,9 @@ void DlgTrackInfo::focusField(const QString& property) {
     }
     auto it = m_propertyWidgets.constFind(property);
     if (it != m_propertyWidgets.constEnd()) {
+        if (property == kBpmPropertyName) {
+            tabWidget->setCurrentIndex(tabWidget->indexOf(tabBPM));
+        }
         it.value()->setFocus();
     }
 }

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -2546,6 +2546,7 @@ void WTrackMenu::slotShowDlgTrackInfo() {
                 [this]() {
                     if (m_pDlgTrackInfoMulti.get() == sender()) {
                         m_pDlgTrackInfoMulti.release()->deleteLater();
+                        setTrackPropertyName();
                     }
                 });
         QList<TrackPointer> tracks;
@@ -2555,6 +2556,7 @@ void WTrackMenu::slotShowDlgTrackInfo() {
         }
         m_pDlgTrackInfoMulti->loadTracks(tracks);
         m_pDlgTrackInfoMulti->show();
+        m_pDlgTrackInfoMulti->focusField(m_trackProperty);
     } else {
         // Use the single-track editor with Next/Prev buttons and DlgTagFetcher.
         // Create a fresh dialog on invocation.
@@ -2567,6 +2569,7 @@ void WTrackMenu::slotShowDlgTrackInfo() {
                 [this]() {
                     if (m_pDlgTrackInfo.get() == sender()) {
                         m_pDlgTrackInfo.release()->deleteLater();
+                        setTrackPropertyName();
                     }
                 });
         // Method getFirstTrackPointer() is not applicable here!
@@ -2580,28 +2583,7 @@ void WTrackMenu::slotShowDlgTrackInfo() {
             m_pDlgTrackInfo->loadTrack(m_pTrack);
         }
         m_pDlgTrackInfo->show();
-    }
-}
-
-void WTrackMenu::showDlgTrackInfo(const QString& property) {
-    if (isEmpty()) {
-        return;
-    }
-    slotShowDlgTrackInfo();
-    if (m_pTrackModel && getTrackCount() > 1) {
-        VERIFY_OR_DEBUG_ASSERT(m_pDlgTrackInfoMulti) {
-            return;
-        }
-        if (m_pDlgTrackInfoMulti->isVisible()) {
-            m_pDlgTrackInfoMulti->focusField(property);
-        }
-    } else {
-        VERIFY_OR_DEBUG_ASSERT(m_pDlgTrackInfo) {
-            return;
-        }
-        if (m_pDlgTrackInfo->isVisible()) {
-            m_pDlgTrackInfo->focusField(property);
-        }
+        m_pDlgTrackInfo->focusField(m_trackProperty);
     }
 }
 

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -2546,7 +2546,8 @@ void WTrackMenu::slotShowDlgTrackInfo() {
                 [this]() {
                     if (m_pDlgTrackInfoMulti.get() == sender()) {
                         m_pDlgTrackInfoMulti.release()->deleteLater();
-                        setTrackPropertyName();
+                        // clear the track property name
+                        m_trackProperty.clear();
                     }
                 });
         QList<TrackPointer> tracks;
@@ -2569,7 +2570,8 @@ void WTrackMenu::slotShowDlgTrackInfo() {
                 [this]() {
                     if (m_pDlgTrackInfo.get() == sender()) {
                         m_pDlgTrackInfo.release()->deleteLater();
-                        setTrackPropertyName();
+                        // clear the track property name
+                        m_trackProperty.clear();
                     }
                 });
         // Method getFirstTrackPointer() is not applicable here!

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -99,12 +99,16 @@ class WTrackMenu : public QMenu {
 
     void loadTrack(
             const TrackPointer& pTrack, const QString& deckGroup);
+    /// Set the track property string which can be used to tell DlgTrackInfo/~Multi
+    /// to focus a specific metadata editor widget
+    void setTrackPropertyName(const QString& property = QString()) {
+        m_trackProperty = property;
+    }
 
     // WARNING: This function hides non-virtual QMenu::popup().
     // This has been done on purpose to ensure menu doesn't popup without loaded track(s).
     void popup(const QPoint& pos, QAction* at = nullptr);
     void slotShowDlgTrackInfo();
-    void showDlgTrackInfo(const QString& property = QString());
     // Library management
     void slotRemoveFromDisk();
     const QString getDeckGroup() const;
@@ -365,6 +369,8 @@ class WTrackMenu : public QMenu {
 
     Features m_eActiveFeatures;
     const Features m_eTrackModelFeatures;
+
+    QString m_trackProperty;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(WTrackMenu::Features)

--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -191,7 +191,8 @@ void WTrackProperty::mouseDoubleClickEvent(QMouseEvent* pEvent) {
     }
     ensureTrackMenuIsCreated();
     m_pTrackMenu->loadTrack(m_pCurrentTrack, m_group);
-    m_pTrackMenu->showDlgTrackInfo(m_displayProperty);
+    m_pTrackMenu->setTrackPropertyName(m_displayProperty);
+    m_pTrackMenu->slotShowDlgTrackInfo();
 }
 
 void WTrackProperty::dragEnterEvent(QDragEnterEvent* pEvent) {
@@ -208,6 +209,7 @@ void WTrackProperty::contextMenuEvent(QContextMenuEvent* pEvent) {
         ensureTrackMenuIsCreated();
         m_pTrackMenu->loadTrack(m_pCurrentTrack, m_group);
         // Show the right-click menu
+        m_pTrackMenu->setTrackPropertyName(m_displayProperty);
         m_pTrackMenu->popup(pEvent->globalPos());
         // Unset the hover state manually (stuck state is probably a Qt bug)
         // TODO(ronso0) Test whether this is still required with Qt6

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -532,12 +532,27 @@ void WTrackTableView::contextMenuEvent(QContextMenuEvent* event) {
     // TODO Also pass the index of the focused column so DlgTrackInfo/~Multi?
     // They could then focus the respective edit field.
     m_pTrackMenu->loadTrackModelIndices(indices);
+    const QModelIndex clickedIdx = indexAt(event->pos());
+    m_pTrackMenu->setTrackPropertyName(columnNameOfIndex(clickedIdx));
 
     saveCurrentIndex();
 
-    // Create the right-click menu
     m_pTrackMenu->popup(event->globalPos());
     // WTrackmenu emits restoreCurrentViewStateOrIndex() if required
+}
+
+QString WTrackTableView::columnNameOfIndex(const QModelIndex& index) const {
+    if (!index.isValid()) {
+        return {};
+    }
+    VERIFY_OR_DEBUG_ASSERT(model()) {
+        return {};
+    }
+    return model()->headerData(
+                          index.column(),
+                          Qt::Horizontal,
+                          TrackModel::kHeaderNameRole)
+            .toString();
 }
 
 void WTrackTableView::onSearch(const QString& text) {
@@ -1085,17 +1100,9 @@ void WTrackTableView::keyPressEvent(QKeyEvent* event) {
             // We use the column of the current index (last focus cell), even
             // it may not be part of the selection, we just assume it's in the
             // desired column.
-            const auto currIdx = currentIndex();
-            if (currIdx.isValid()) {
-                const QString columnName = model()->headerData(
-                                                          currIdx.column(),
-                                                          Qt::Horizontal,
-                                                          TrackModel::kHeaderNameRole)
-                                                   .toString();
-                m_pTrackMenu->showDlgTrackInfo(columnName);
-            } else {
-                m_pTrackMenu->slotShowDlgTrackInfo();
-            }
+            const QString columnName = columnNameOfIndex(currentIndex());
+            m_pTrackMenu->setTrackPropertyName(columnName);
+            m_pTrackMenu->slotShowDlgTrackInfo();
         }
         return;
     }

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -30,6 +30,7 @@ class WTrackTableView : public WLibraryTableView {
             bool sorting);
     ~WTrackTableView() override;
     void contextMenuEvent(QContextMenuEvent * event) override;
+    QString columnNameOfIndex(const QModelIndex& index) const;
     void onSearch(const QString& text) override;
     void onShow() override;
     bool hasFocus() const override;


### PR DESCRIPTION
follow-up for #13841 
and a small tweak for DlgTrackInfo (single track)