### PR TITLE
Waveforms: add slip waveform to Textured/'High details' type

### DIFF
--- a/src/waveform/renderers/allshader/waveformrenderertextured.cpp
+++ b/src/waveform/renderers/allshader/waveformrenderertextured.cpp
@@ -455,11 +455,19 @@ void WaveformRendererTextured::paintGL() {
 
         glBegin(GL_QUADS);
         {
-            glTexCoord2f(0.0, 0.0);
-            glVertex3f(firstVisualIndex, -1.0f, 0.0f);
+            if (m_isSlipRenderer && m_waveformRenderer->isSlipActive()) {
+                glTexCoord2f(0.0, 0.5);
+                glVertex3f(firstVisualIndex, 0.0f, 0.0f);
 
-            glTexCoord2f(1.0, 0.0);
-            glVertex3f(lastVisualIndex, -1.0f, 0.0f);
+                glTexCoord2f(1.0, 0.5);
+                glVertex3f(lastVisualIndex, 0.0f, 0.0f);
+            } else {
+                glTexCoord2f(0.0, 0.0);
+                glVertex3f(firstVisualIndex, -1.0f, 0.0f);
+
+                glTexCoord2f(1.0, 0.0);
+                glVertex3f(lastVisualIndex, -1.0f, 0.0f);
+            }
 
             glTexCoord2f(1.0, 1.0);
             glVertex3f(lastVisualIndex, 1.0f, 0.0f);

--- a/src/waveform/renderers/allshader/waveformrenderertextured.h
+++ b/src/waveform/renderers/allshader/waveformrenderertextured.h
@@ -38,6 +38,10 @@ class allshader::WaveformRendererTextured : public QObject,
     void paintGL() override;
     void resizeGL(int w, int h) override;
 
+    bool supportsSlip() const override {
+        return true;
+    }
+
     void onSetTrack() override;
 
   public slots:


### PR DESCRIPTION
I wanted this so I had a coffe and poked around a bit in the Textured renderer, and after a few quite funny results it looks... great :tada: 

No clue what I did here, it's probably not the most efficient way. It's still rendering the entire texture, no?
I have no intention to polish this, so anynone who's interested may push to my branch directly.

One piece to resolve #13499