### PR TITLE
Revert "(fix) allow seeking (eg. to hotcue) while scratching with the waveform"

### DIFF
--- a/src/engine/controls/ratecontrol.cpp
+++ b/src/engine/controls/ratecontrol.cpp
@@ -628,7 +628,3 @@ void RateControl::notifyWrapAround(mixxx::audio::FramePos triggerPos,
     m_jumpPos = triggerPos;
     m_targetPos = targetPos;
 }
-
-void RateControl::notifySeek(mixxx::audio::FramePos position) {
-    m_pScratchController->notifySeek(position);
-}

--- a/src/engine/controls/ratecontrol.h
+++ b/src/engine/controls/ratecontrol.h
@@ -88,7 +88,6 @@ public slots:
   void slotControlRatePermUpSmall(double);
   void slotControlFastForward(double);
   void slotControlFastBack(double);
-  void notifySeek(mixxx::audio::FramePos position) override;
 
 private:
   void processTempRate(const int bufferSamples);

--- a/src/engine/positionscratchcontroller.cpp
+++ b/src/engine/positionscratchcontroller.cpp
@@ -300,7 +300,7 @@ double PositionScratchController::getRate() {
 
 void PositionScratchController::notifySeek(mixxx::audio::FramePos position) {
     DEBUG_ASSERT(position.isValid());
-    // Scratching continues after seek due to calculating the relative
-    // distance traveled in m_samplePosDeltaSum
+    // scratching continues after seek due to calculating the relative distance traveled
+    // in m_samplePosDeltaSum
     m_prevSamplePos = position.toEngineSamplePos();
 }


### PR DESCRIPTION
This reverts #14024 
That waveform scratch bug described there has been around for long without complaints, so no big deal to revert the 'fix' in order to proceed with 2.5

Bit of a pity that  I just got used to controller scratching with `scratch_position` and need to find a workaround now. Maybe simply disable scratching before the seek, then reenable it immediatly.