### PR TITLE
2.5.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,7 +208,7 @@ endif()
 project(mixxx VERSION 2.5.0)
 enable_language(C CXX)
 # Work around missing version suffixes support https://gitlab.kitware.com/cmake/cmake/-/issues/16716
-set(MIXXX_VERSION_PRERELEASE "beta") # set to "alpha" "beta" or ""
+set(MIXXX_VERSION_PRERELEASE "") # set to "alpha" "beta" or ""
 
 set(CMAKE_PROJECT_HOMEPAGE_URL "https://www.mixxx.org")
 set(CMAKE_PROJECT_DESCRIPTION "Mixxx is Free DJ software that gives you everything you need to perform live mixes.")

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Mixxx 2.5-beta, Digital DJ'ing software.
+Mixxx 2.5.0, Digital DJ'ing software.
 Copyright (C) 2001-2024 Mixxx Development Team
 
 Mixxx is free software; you can redistribute it and/or modify

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,9 @@
+mixxx (2.4.2-1~focal) focal; urgency=medium
+
+  * Build of 2.4.2
+
+ -- RJ Skerry-Ryan <rryan@mixxx.org>  Tue, 26 Nov 2024 23:29:32 +0000
+
 mixxx (2.4.1-1~focal) focal; urgency=medium
 
   * Build of 2.4.1


### PR DESCRIPTION
This is the version bump PR to release 2.5.0 finally. 
We can do smoke testing before or after merge. 
