### PR TITLE
Tooltips: always show if Ctrl key is pressed

### DIFF
--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -1250,8 +1250,9 @@ void MixxxMainWindow::tryParseAndSetDefaultStyleSheet() {
 
 /// Catch ToolTip and WindowStateChange events
 bool MixxxMainWindow::eventFilter(QObject* obj, QEvent* event) {
-    if (event->type() == QEvent::ToolTip) {
-        // always show tooltips in the preferences window
+    // Always show tooltips if Ctrl is held down
+    if (event->type() == QEvent::ToolTip &&
+            !QApplication::keyboardModifiers().testFlag(Qt::ControlModifier)) {
         QWidget* activeWindow = QApplication::activeWindow();
         if (activeWindow &&
                 QLatin1String(activeWindow->metaObject()->className()) !=


### PR DESCRIPTION
I don't have tooltips enabled because I usually don't need them.
Though, sometimes I _do_ need them to check hotkeys but else I don't want them to get in the way.

So with this, if you have tooltips disabled you can press `Ctrl` and hover a widget (or some library item) they'll be shown..