### PR TITLE
VersionStore: Fix ARM64 platform string

### DIFF
--- a/src/util/versionstore.cpp
+++ b/src/util/versionstore.cpp
@@ -113,7 +113,7 @@ QString VersionStore::applicationName() {
 #elif defined(IA64)
 #define PLATFORM_STR "IA64"
 #elif defined(__aarch64__)
-#define PLATFORM_STR "IA64"
+#define PLATFORM_STR "ARM64"
 #elif defined(__arm__) || defined(__thumb__) || defined(_ARM) || \
         defined(_M_ARM) || defined(_M_ARMT) || defined(__arm)
 #define PLATFORM_STR "ARM"


### PR DESCRIPTION
### Fixes #14086 

This fixes a small regression introduced in #13687, which inadvertently changed the version string to "IA64" for arm64.