### PR TITLE
Playlists: add 'Unlock all' and 'Delete all unlocked' menu actions

### DIFF
--- a/src/library/dao/playlistdao.cpp
+++ b/src/library/dao/playlistdao.cpp
@@ -253,6 +253,34 @@ bool PlaylistDAO::deletePlaylists(const QStringList& idStringList) {
     return true;
 }
 
+bool PlaylistDAO::deletePlaylistsByType(
+        PlaylistDAO::HiddenType type,
+        bool unlockedOnly) {
+    QString queryStr =
+            "SELECT id FROM Playlists "
+            "WHERE hidden = :type";
+    if (unlockedOnly) {
+        queryStr.append(" AND locked = 0");
+    }
+    QSqlQuery query(m_database);
+    query.prepare(queryStr);
+    query.bindValue(":type", static_cast<int>(type));
+    if (!query.exec()) {
+        LOG_FAILED_QUERY(query);
+        return false;
+    }
+
+    QStringList idStringList;
+    while (query.next()) {
+        idStringList.append(query.value(0).toString());
+    }
+    qInfo() << "Prepared deletion of" << idStringList.size()
+            << QString(unlockedOnly ? "unlocked" : QString())
+            << "playlists of type" << type;
+
+    return deletePlaylists(idStringList);
+}
+
 bool PlaylistDAO::deleteUnlockedPlaylists(QStringList&& idStringList) {
     if (idStringList.isEmpty()) {
         return false;
@@ -263,8 +291,8 @@ bool PlaylistDAO::deleteUnlockedPlaylists(QStringList&& idStringList) {
     QSqlQuery query(m_database);
     // select locked playlists
     query.prepare(QStringLiteral(
-            "SELECT id FROM Playlists WHERE id IN (%1) AND locked = 1")
-                          .arg(idString));
+            "SELECT id FROM Playlists WHERE id IN (:ids) AND locked = 1"));
+    query.bindValue(":ids", idString);
     if (!query.exec()) {
         LOG_FAILED_QUERY(query);
         return false;
@@ -333,6 +361,29 @@ bool PlaylistDAO::setPlaylistLocked(const int playlistId, const bool locked) {
     }
     emit lockChanged(QSet<int>{playlistId});
     return true;
+}
+
+int PlaylistDAO::setPlaylistsLockedByType(const HiddenType hidden, const bool lock) {
+    QSqlQuery query(m_database);
+    query.prepare(
+            mixxx::DbConnection::collateLexicographically(
+                    QString("SELECT id, name FROM Playlists "
+                            "WHERE hidden = %1 "
+                            "ORDER BY name")
+                            .arg(hidden)));
+
+    QSet<int> playlistIds;
+
+    if (!query.exec()) {
+        LOG_FAILED_QUERY(query);
+        return playlistIds.size();
+    }
+
+    while (query.next()) {
+        playlistIds.insert(query.value(0).toInt());
+    }
+
+    return setPlaylistsLocked(playlistIds, lock);
 }
 
 int PlaylistDAO::setPlaylistsLocked(const QSet<int>& playlistIds, const bool lock) {
@@ -480,6 +531,32 @@ QList<QPair<int, QString>> PlaylistDAO::getPlaylists(const HiddenType hidden) co
             mixxx::DbConnection::collateLexicographically(
                     QString("SELECT id, name FROM Playlists "
                             "WHERE hidden = %1 "
+                            "ORDER BY name")
+                            .arg(hidden)));
+
+    QList<QPair<int, QString>> playlists;
+
+    if (!query.exec()) {
+        LOG_FAILED_QUERY(query);
+        return playlists;
+    }
+
+    while (query.next()) {
+        const int id = query.value(0).toInt();
+        const QString name = query.value(1).toString();
+        playlists.append(qMakePair(id, name));
+    }
+    return playlists;
+}
+QList<QPair<int, QString>> PlaylistDAO::getUnlockedPlaylists(const HiddenType hidden) const {
+    // qDebug() << "PlaylistDAO::getPlaylists(hidden =" << hidden
+    //          << QThread::currentThread() << m_database.connectionName();
+
+    QSqlQuery query(m_database);
+    query.prepare(
+            mixxx::DbConnection::collateLexicographically(
+                    QString("SELECT id, name FROM Playlists "
+                            "WHERE hidden = %1 AND locked = 0 "
                             "ORDER BY name")
                             .arg(hidden)));
 

--- a/src/library/dao/playlistdao.h
+++ b/src/library/dao/playlistdao.h
@@ -42,6 +42,7 @@ class PlaylistDAO : public QObject, public virtual DAO {
     void deletePlaylist(const int playlistId);
     // Delete a set of playlists.
     bool deletePlaylists(const QStringList& idStringList);
+    bool deletePlaylistsByType(PlaylistDAO::HiddenType type, bool unlockedOnly = true);
     bool deleteUnlockedPlaylists(QStringList&& idStringList);
     /// Delete Playlists with fewer entries then "minNumberOfTracks"
     /// Needs to be called inside a transaction.
@@ -52,6 +53,7 @@ class PlaylistDAO : public QObject, public virtual DAO {
     void renamePlaylist(const int playlistId, const QString& newName);
     // Lock or unlock a playlist
     bool setPlaylistLocked(const int playlistId, const bool locked);
+    int setPlaylistsLockedByType(const HiddenType hidden, const bool lock);
     int setPlaylistsLocked(const QSet<int>& playlistIds, const bool lock);
     // Find out the state of a playlist lock
     bool isPlaylistLocked(const int playlistId) const;
@@ -63,6 +65,7 @@ class PlaylistDAO : public QObject, public virtual DAO {
     unsigned int playlistCount() const;
     // Get all playlist ids and names of a specific type
     QList<QPair<int, QString>> getPlaylists(const HiddenType hidden) const;
+    QList<QPair<int, QString>> getUnlockedPlaylists(const HiddenType hidden) const;
     // Find out the name of the playlist at the given Id
     QString getPlaylistName(const int playlistId) const;
     // Get the playlist id by its name

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -69,23 +69,23 @@ BasePlaylistFeature::BasePlaylistFeature(
 }
 
 void BasePlaylistFeature::initActions() {
-    m_pCreatePlaylistAction = new QAction(tr("Create New Playlist"), this);
+    m_pCreatePlaylistAction = make_parented<QAction>(tr("Create New Playlist"), this);
     connect(m_pCreatePlaylistAction,
             &QAction::triggered,
             this,
             &BasePlaylistFeature::slotCreatePlaylist);
 
-    m_pRenamePlaylistAction = new QAction(tr("Rename"), this);
+    m_pRenamePlaylistAction = make_parented<QAction>(tr("Rename"), this);
     connect(m_pRenamePlaylistAction,
             &QAction::triggered,
             this,
             &BasePlaylistFeature::slotRenamePlaylist);
-    m_pDuplicatePlaylistAction = new QAction(tr("Duplicate"), this);
+    m_pDuplicatePlaylistAction = make_parented<QAction>(tr("Duplicate"), this);
     connect(m_pDuplicatePlaylistAction,
             &QAction::triggered,
             this,
             &BasePlaylistFeature::slotDuplicatePlaylist);
-    m_pDeletePlaylistAction = new QAction(tr("Remove"), this);
+    m_pDeletePlaylistAction = make_parented<QAction>(tr("Remove"), this);
     const auto removeKeySequence =
             // TODO(XXX): Qt6 replace enum | with QKeyCombination
             QKeySequence(static_cast<int>(kHideRemoveShortcutModifier) |
@@ -95,50 +95,51 @@ void BasePlaylistFeature::initActions() {
             &QAction::triggered,
             this,
             &BasePlaylistFeature::slotDeletePlaylist);
-    m_pLockPlaylistAction = new QAction(tr("Lock"), this);
+    m_pLockPlaylistAction = make_parented<QAction>(tr("Lock"), this);
     connect(m_pLockPlaylistAction,
             &QAction::triggered,
             this,
             &BasePlaylistFeature::slotTogglePlaylistLock);
 
-    m_pAddToAutoDJAction = new QAction(tr("Add to Auto DJ Queue (bottom)"), this);
+    m_pAddToAutoDJAction = make_parented<QAction>(tr("Add to Auto DJ Queue (bottom)"), this);
     connect(m_pAddToAutoDJAction,
             &QAction::triggered,
             this,
             &BasePlaylistFeature::slotAddToAutoDJ);
-    m_pAddToAutoDJTopAction = new QAction(tr("Add to Auto DJ Queue (top)"), this);
+    m_pAddToAutoDJTopAction = make_parented<QAction>(tr("Add to Auto DJ Queue (top)"), this);
     connect(m_pAddToAutoDJTopAction,
             &QAction::triggered,
             this,
             &BasePlaylistFeature::slotAddToAutoDJTop);
-    m_pAddToAutoDJReplaceAction = new QAction(tr("Add to Auto DJ Queue (replace)"), this);
+    m_pAddToAutoDJReplaceAction =
+            make_parented<QAction>(tr("Add to Auto DJ Queue (replace)"), this);
     connect(m_pAddToAutoDJReplaceAction,
             &QAction::triggered,
             this,
             &BasePlaylistFeature::slotAddToAutoDJReplace);
 
-    m_pAnalyzePlaylistAction = new QAction(tr("Analyze entire Playlist"), this);
+    m_pAnalyzePlaylistAction = make_parented<QAction>(tr("Analyze entire Playlist"), this);
     connect(m_pAnalyzePlaylistAction,
             &QAction::triggered,
             this,
             &BasePlaylistFeature::slotAnalyzePlaylist);
 
-    m_pImportPlaylistAction = new QAction(tr("Import Playlist"), this);
+    m_pImportPlaylistAction = make_parented<QAction>(tr("Import Playlist"), this);
     connect(m_pImportPlaylistAction,
             &QAction::triggered,
             this,
             &BasePlaylistFeature::slotImportPlaylist);
-    m_pCreateImportPlaylistAction = new QAction(tr("Import Playlist"), this);
+    m_pCreateImportPlaylistAction = make_parented<QAction>(tr("Import Playlist"), this);
     connect(m_pCreateImportPlaylistAction,
             &QAction::triggered,
             this,
             &BasePlaylistFeature::slotCreateImportPlaylist);
-    m_pExportPlaylistAction = new QAction(tr("Export Playlist"), this);
+    m_pExportPlaylistAction = make_parented<QAction>(tr("Export Playlist"), this);
     connect(m_pExportPlaylistAction,
             &QAction::triggered,
             this,
             &BasePlaylistFeature::slotExportPlaylist);
-    m_pExportTrackFilesAction = new QAction(tr("Export Track Files"), this);
+    m_pExportTrackFilesAction = make_parented<QAction>(tr("Export Track Files"), this);
     connect(m_pExportTrackFilesAction,
             &QAction::triggered,
             this,

--- a/src/library/trackset/baseplaylistfeature.h
+++ b/src/library/trackset/baseplaylistfeature.h
@@ -8,6 +8,7 @@
 #include "library/dao/playlistdao.h"
 #include "library/trackset/basetracksetfeature.h"
 #include "track/trackid.h"
+#include "util/parented_ptr.h"
 
 class WLibrary;
 class KeyboardEventFilter;
@@ -101,19 +102,19 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
     QPointer<WLibrarySidebar> m_pSidebarWidget;
     QPointer<WLibrary> m_pLibraryWidget;
 
-    QAction* m_pCreatePlaylistAction;
-    QAction* m_pDeletePlaylistAction;
-    QAction* m_pAddToAutoDJAction;
-    QAction* m_pAddToAutoDJTopAction;
-    QAction* m_pAddToAutoDJReplaceAction;
-    QAction* m_pRenamePlaylistAction;
-    QAction* m_pLockPlaylistAction;
-    QAction* m_pImportPlaylistAction;
-    QAction* m_pCreateImportPlaylistAction;
-    QAction* m_pExportPlaylistAction;
-    QAction* m_pExportTrackFilesAction;
-    QAction* m_pDuplicatePlaylistAction;
-    QAction* m_pAnalyzePlaylistAction;
+    parented_ptr<QAction> m_pCreatePlaylistAction;
+    parented_ptr<QAction> m_pDeletePlaylistAction;
+    parented_ptr<QAction> m_pAddToAutoDJAction;
+    parented_ptr<QAction> m_pAddToAutoDJTopAction;
+    parented_ptr<QAction> m_pAddToAutoDJReplaceAction;
+    parented_ptr<QAction> m_pRenamePlaylistAction;
+    parented_ptr<QAction> m_pLockPlaylistAction;
+    parented_ptr<QAction> m_pImportPlaylistAction;
+    parented_ptr<QAction> m_pCreateImportPlaylistAction;
+    parented_ptr<QAction> m_pExportPlaylistAction;
+    parented_ptr<QAction> m_pExportTrackFilesAction;
+    parented_ptr<QAction> m_pDuplicatePlaylistAction;
+    parented_ptr<QAction> m_pAnalyzePlaylistAction;
 
     PlaylistTableModel* m_pPlaylistTableModel;
     QSet<int> m_playlistIdsOfSelectedTrack;

--- a/src/library/trackset/playlistfeature.cpp
+++ b/src/library/trackset/playlistfeature.cpp
@@ -33,11 +33,25 @@ PlaylistFeature::PlaylistFeature(Library* pLibrary, UserSettingsPointer pConfig)
     m_pSidebarModel->setRootItem(std::move(pRootItem));
     constructChildModel(kInvalidPlaylistId);
 
-    m_pShufflePlaylistAction = new QAction(tr("Shuffle Playlist"), this);
+    m_pShufflePlaylistAction = make_parented<QAction>(tr("Shuffle Playlist"), this);
     connect(m_pShufflePlaylistAction,
             &QAction::triggered,
             this,
             &PlaylistFeature::slotShufflePlaylist);
+
+    m_pUnlockPlaylistsAction =
+            make_parented<QAction>(tr("Unlock all playlists"), this);
+    connect(m_pUnlockPlaylistsAction,
+            &QAction::triggered,
+            this,
+            &PlaylistFeature::slotUnlockAllPlaylists);
+
+    m_pDeleteAllUnlockedPlaylistsAction =
+            make_parented<QAction>(tr("Delete all unlocked playlists"), this);
+    connect(m_pDeleteAllUnlockedPlaylistsAction,
+            &QAction::triggered,
+            this,
+            &PlaylistFeature::slotDeleteAllUnlockedPlaylists);
 }
 
 QVariant PlaylistFeature::title() {
@@ -48,6 +62,9 @@ void PlaylistFeature::onRightClick(const QPoint& globalPos) {
     m_lastRightClickedIndex = QModelIndex();
     QMenu menu(m_pSidebarWidget);
     menu.addAction(m_pCreatePlaylistAction);
+    menu.addSeparator();
+    menu.addAction(m_pUnlockPlaylistsAction);
+    menu.addAction(m_pDeleteAllUnlockedPlaylistsAction);
     menu.addSeparator();
     menu.addAction(m_pCreateImportPlaylistAction);
     menu.exec(globalPos);
@@ -231,6 +248,46 @@ void PlaylistFeature::slotShufflePlaylist() {
 
         pPlaylistTableModel->shuffleTracks(selection, QModelIndex());
     }
+}
+
+void PlaylistFeature::slotUnlockAllPlaylists() {
+    m_playlistDao.setPlaylistsLockedByType(PlaylistDAO::PLHT_NOT_HIDDEN, false);
+}
+
+void PlaylistFeature::slotDeleteAllUnlockedPlaylists() {
+    // Collect playlists to display the count
+    const QList<QPair<int, QString>> playlists =
+            m_playlistDao.getUnlockedPlaylists(PlaylistDAO::PLHT_NOT_HIDDEN);
+    if (playlists.size() <= 0) {
+        return;
+    }
+
+    QMessageBox::StandardButton btn = QMessageBox::question(nullptr,
+            tr("Confirm Deletion"),
+            tr("Do you really want to delete all unlocked playlists?"),
+            QMessageBox::Yes | QMessageBox::No,
+            QMessageBox::No);
+    if (btn != QMessageBox::Yes) {
+        return;
+    }
+
+    btn = QMessageBox::question(nullptr,
+            tr("Confirm Deletion"),
+            tr("Deleting %1 unlocked playlists.<br>"
+               "This operation can not be undone!")
+                    .arg(playlists.size()),
+            QMessageBox::Yes | QMessageBox::No,
+            QMessageBox::No);
+    if (btn != QMessageBox::Yes) {
+        return;
+    }
+
+    QStringList ids;
+    for (const auto& playlist : std::as_const(playlists)) {
+        ids << QString::number(playlist.first);
+    }
+
+    m_playlistDao.deleteUnlockedPlaylists(std::move(ids));
 }
 
 /// Purpose: When inserting or removing playlists,

--- a/src/library/trackset/playlistfeature.h
+++ b/src/library/trackset/playlistfeature.h
@@ -7,6 +7,7 @@
 
 #include "library/trackset/baseplaylistfeature.h"
 #include "preferences/usersettings.h"
+#include "util/parented_ptr.h"
 
 class TreeItem;
 class QPoint;
@@ -36,6 +37,8 @@ class PlaylistFeature : public BasePlaylistFeature {
     void slotPlaylistContentOrLockChanged(const QSet<int>& playlistIds) override;
     void slotPlaylistTableRenamed(int playlistId, const QString& newName) override;
     void slotShufflePlaylist();
+    void slotUnlockAllPlaylists();
+    void slotDeleteAllUnlockedPlaylists();
 
   protected:
     void decorateChild(TreeItem* pChild, int playlistId) override;
@@ -45,5 +48,7 @@ class PlaylistFeature : public BasePlaylistFeature {
   private:
     QString getRootViewHtml() const override;
 
-    QAction* m_pShufflePlaylistAction;
+    parented_ptr<QAction> m_pShufflePlaylistAction;
+    parented_ptr<QAction> m_pUnlockPlaylistsAction;
+    parented_ptr<QAction> m_pDeleteAllUnlockedPlaylistsAction;
 };


### PR DESCRIPTION
Another coffee break feature I found in my git stash.
Kind of fixes #8960 

This add two actions to the **Playlists** context menu (sidebar) like the one we already have in the History feature:
* Delete all playlists
* Delete all unlocked playlists

Both need to be confirmed twice.


~~Will do the same for crates soonish.~~