### PR TITLE
Enable R3 time-stretching with Rubberband 4.0.0 API version numbers

### DIFF
--- a/src/engine/bufferscalers/enginebufferscalerubberband.cpp
+++ b/src/engine/bufferscalers/enginebufferscalerubberband.cpp
@@ -11,7 +11,8 @@
 
 using RubberBand::RubberBandStretcher;
 
-#define RUBBERBANDV3 (RUBBERBAND_API_MAJOR_VERSION >= 2 && RUBBERBAND_API_MINOR_VERSION >= 7)
+#define RUBBERBANDV3 (RUBBERBAND_API_MAJOR_VERSION >= 3 || \
+        (RUBBERBAND_API_MAJOR_VERSION == 2 && RUBBERBAND_API_MINOR_VERSION >= 7))
 
 EngineBufferScaleRubberBand::EngineBufferScaleRubberBand(
         ReadAheadManager* pReadAheadManager)


### PR DESCRIPTION
This small PR enables R3 time-stretching when Mixxx is using Rubberband 4.0.0. Rubberband now defines API level numbers like this, so the current version check logic is not enough anymore.

```
#define RUBBERBAND_API_MAJOR_VERSION 3
#define RUBBERBAND_API_MINOR_VERSION 0
```

I've tested this patch with Rubberband 3.3.0 and 4.0.0 and and it seems to resolve the issue. Let me know if anything should be changed or further improved. Thanks!