### PR TITLE
fix: Add `QT_VERSION_CHECK`ed `QCheckBox::checkStateChanged` handlers

### DIFF
--- a/src/controllers/dlgprefcontrollers.cpp
+++ b/src/controllers/dlgprefcontrollers.cpp
@@ -47,7 +47,11 @@ DlgPrefControllers::DlgPrefControllers(DlgPreferences* pPreferences,
 #ifdef __PORTMIDI__
     checkBox_midithrough->setChecked(m_pConfig->getValue(kMidiThroughCfgKey, false));
     connect(checkBox_midithrough,
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+            &QCheckBox::checkStateChanged,
+#else
             &QCheckBox::stateChanged,
+#endif
             this,
             &DlgPrefControllers::slotMidiThroughChanged);
     txt_midithrough->setTextFormat(Qt::RichText);
@@ -272,7 +276,13 @@ void DlgPrefControllers::slotHighlightDevice(DlgPrefController* pControllerDlg, 
 }
 
 #ifdef __PORTMIDI__
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+void DlgPrefControllers::slotMidiThroughChanged(Qt::CheckState state) {
+    m_pConfig->setValue(kMidiThroughCfgKey, state != Qt::Unchecked);
+}
+#else
 void DlgPrefControllers::slotMidiThroughChanged(bool checked) {
     m_pConfig->setValue(kMidiThroughCfgKey, checked);
 }
+#endif
 #endif

--- a/src/controllers/dlgprefcontrollers.h
+++ b/src/controllers/dlgprefcontrollers.h
@@ -42,7 +42,11 @@ class DlgPrefControllers : public DlgPreferencePage, public Ui::DlgPrefControlle
   private slots:
     void rescanControllers();
 #ifdef __PORTMIDI__
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+    void slotMidiThroughChanged(Qt::CheckState state);
+#else
     void slotMidiThroughChanged(bool checked);
+#endif
 #endif
     void slotHighlightDevice(DlgPrefController* dialog, bool enabled);
 

--- a/src/preferences/dialog/dlgprefcolors.cpp
+++ b/src/preferences/dialog/dlgprefcolors.cpp
@@ -75,7 +75,11 @@ DlgPrefColors::DlgPrefColors(
             &DlgPrefColors::slotReplaceCueColorClicked);
 
     connect(checkboxKeyColorsEnabled,
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+            &QCheckBox::checkStateChanged,
+#else
             &QCheckBox::stateChanged,
+#endif
             this,
             &DlgPrefColors::slotKeyColorsEnabled);
 
@@ -408,8 +412,13 @@ void DlgPrefColors::slotEditHotcuePaletteClicked() {
     openColorPaletteEditor(hotcueColorPaletteName, true);
 }
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+void DlgPrefColors::slotKeyColorsEnabled(Qt::CheckState state) {
+    m_bKeyColorsEnabled = state != Qt::Unchecked;
+#else
 void DlgPrefColors::slotKeyColorsEnabled(int i) {
     m_bKeyColorsEnabled = static_cast<bool>(i);
+#endif
     BaseTrackTableModel::setKeyColorsEnabled(m_bKeyColorsEnabled);
     m_pConfig->setValue(kKeyColorsEnabledConfigKey, checkboxKeyColorsEnabled->checkState());
 }

--- a/src/preferences/dialog/dlgprefcolors.h
+++ b/src/preferences/dialog/dlgprefcolors.h
@@ -40,7 +40,11 @@ class DlgPrefColors : public DlgPreferencePage, public Ui::DlgPrefColorsDlg {
     void slotReplaceCueColorClicked();
     void slotEditTrackPaletteClicked();
     void slotEditHotcuePaletteClicked();
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+    void slotKeyColorsEnabled(Qt::CheckState state);
+#else
     void slotKeyColorsEnabled(int i);
+#endif
 
   private:
     void openColorPaletteEditor(


### PR DESCRIPTION
These previously used the soon to be removed (Qt 6.9) `&QCheckBox::stateChanged` signal. These occurrences have now been replaced by the correct `QCheckBox::checkStateChanged` signal connections along with `QT_VERSION_CHECK`s so they're forwards and backwards compatible.