### PR TITLE
fix: handle `script.deckFromGroup(undefined)` gracefully

### DIFF
--- a/res/controllers/common-controller-scripts.js
+++ b/res/controllers/common-controller-scripts.js
@@ -248,6 +248,9 @@ script.midiDebug = function(channel, control, value, status, group) {
 // Returns the deck number of a "ChannelN" or "SamplerN" group
 script.deckFromGroup = function(group) {
     let deck = 0;
+    if (group === undefined) {
+        return undefined;
+    }
     if (group.substring(2, 8) === "hannel") {
         // Extract deck number from the group text
         deck = group.substring(8, group.length - 1);


### PR DESCRIPTION
This fixes an exception occuring since #13425 where constructing a `components.JogWheelBasic` with only a `deck` number with a matching `group` would result an exception (since `script.deckFromGroup` would call `substring` on `undefined`).

CC @christophehenry 