### PR TITLE
Rotary: Fix accidental quantization

### DIFF
--- a/src/test/rotary_test.cpp
+++ b/src/test/rotary_test.cpp
@@ -17,6 +17,13 @@ TEST(Rotary, basicOverflow) {
     EXPECT_EQ(rot.filter(-2), -2);
 }
 
+TEST(Rotary, noQuantization) {
+    Rotary rot(2);
+    EXPECT_EQ(rot.filter(0.25), 0.125);
+    EXPECT_EQ(rot.filter(0.0), 0.125);
+    EXPECT_EQ(rot.filter(0.0), 0.0);
+}
+
 TEST(Rotary, hugeFilterSequential) {
     static constexpr int size = 200;
     Rotary rot(size);

--- a/src/test/rotary_test.cpp
+++ b/src/test/rotary_test.cpp
@@ -19,9 +19,9 @@ TEST(Rotary, basicOverflow) {
 
 TEST(Rotary, noQuantization) {
     Rotary rot(2);
-    EXPECT_EQ(rot.filter(0.25), 0.125);
-    EXPECT_EQ(rot.filter(0.0), 0.125);
-    EXPECT_EQ(rot.filter(0.0), 0.0);
+    EXPECT_DOUBLE_EQ(rot.filter(0.25), 0.125);
+    EXPECT_DOUBLE_EQ(rot.filter(0.0), 0.125);
+    EXPECT_DOUBLE_EQ(rot.filter(0.0), 0.0);
 }
 
 TEST(Rotary, hugeFilterSequential) {

--- a/src/util/rotary.cpp
+++ b/src/util/rotary.cpp
@@ -17,7 +17,7 @@ void Rotary::append(double v) {
 double Rotary::calculate() const {
     return std::accumulate(std::cbegin(m_filterHistory),
                    std::cend(m_filterHistory),
-                   0) /
+                   0.0) /
             static_cast<double>(m_filterHistory.size());
 }
 


### PR DESCRIPTION
### Fixes #14095 

This fixes the issue where `std::accumulate` would accidentally get instantiated to `int` (and thus quantize the entire sum to integers), causing the rotary filter to get insensitive to small changes, as they'd just be zeroed out. I have added a unit test to verify this.

I presume the lesson learned is that we should be careful about blindly replacing loops with `std::accumulate` or the like.