### PR TITLE
ControllerScriptInterfaceLegacy: Windows 1252 fix

### DIFF
--- a/res/controllers/engine-api.d.ts
+++ b/res/controllers/engine-api.d.ts
@@ -314,7 +314,7 @@ declare namespace engine {
         UTF_32BE,       // UTF-32 for Big-Endian devices (MIPS, PPC)
         CentralEurope,  // Windows_1250 which includes all characters of ISO_8859_2
         Cyrillic,       // Windows_1251 which includes all characters of ISO_8859_5
-        Latin1,         // Windows_1252 which includes all characters of ISO_8859_1
+        WesternEurope,  // Windows_1252 which includes all characters of ISO_8859_1
         Greek,          // Windows_1253 which includes all characters of ISO_8859_7
         Turkish,        // Windows_1254 which includes all characters of ISO_8859_9
         Hebrew,         // Windows_1255 which includes all characters of ISO_8859_8
@@ -330,7 +330,8 @@ declare namespace engine {
         UCS2,           // Universal Character Set (2-Byte) ISO_10646
         SCSU,           // Standard Compression Scheme for Unicode
         BOCU_1,         // Binary Ordered Compression for Unicode
-        CESU_8          // Compatibility Encoding Scheme for UTF-16 (8-Bit)
+        CESU_8,         // Compatibility Encoding Scheme for UTF-16 (8-Bit)
+        Latin1          // ISO_8859_1, available on Qt < 6.5
     }
 
     /**

--- a/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
+++ b/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
@@ -1075,7 +1075,7 @@ QByteArray ControllerScriptInterfaceLegacy::convertCharset(
         return convertCharsetInternal(QLatin1String("windows-1250"), value);
     case Cyrillic:
         return convertCharsetInternal(QLatin1String("windows-1251"), value);
-    case Latin1:
+    case WesternEurope:
         return convertCharsetInternal(QLatin1String("windows-1252"), value);
     case Greek:
         return convertCharsetInternal(QLatin1String("windows-1253"), value);
@@ -1109,7 +1109,10 @@ QByteArray ControllerScriptInterfaceLegacy::convertCharset(
         return convertCharsetInternal(QLatin1String("BOCU-1"), value);
     case CESU_8:
         return convertCharsetInternal(QLatin1String("CESU-8"), value);
+    case Latin1:
+        return convertCharsetInternal(QLatin1String("ISO-8859-1"), value);
     }
+
     m_pScriptEngineLegacy->logOrThrowError(QStringLiteral("Unknown charset specified"));
     return QByteArray();
 }

--- a/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
+++ b/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
@@ -1060,67 +1060,66 @@ QByteArray ControllerScriptInterfaceLegacy::convertCharset(
     using enum Charset;
     switch (targetCharset) {
     case ASCII:
-        return convertCharsetInternal(QStringLiteral("US-ASCII"), value);
+        return convertCharsetInternal(QLatin1String("US-ASCII"), value);
     case UTF_8:
-        return convertCharsetInternal(QStringLiteral("UTF-8"), value);
+        return convertCharsetInternal(QLatin1String("UTF-8"), value);
     case UTF_16LE:
-        return convertCharsetInternal(QStringLiteral("UTF-16LE"), value);
+        return convertCharsetInternal(QLatin1String("UTF-16LE"), value);
     case UTF_16BE:
-        return convertCharsetInternal(QStringLiteral("UTF-16BE"), value);
+        return convertCharsetInternal(QLatin1String("UTF-16BE"), value);
     case UTF_32LE:
-        return convertCharsetInternal(QStringLiteral("UTF-32LE"), value);
+        return convertCharsetInternal(QLatin1String("UTF-32LE"), value);
     case UTF_32BE:
-        return convertCharsetInternal(QStringLiteral("UTF-32BE"), value);
+        return convertCharsetInternal(QLatin1String("UTF-32BE"), value);
     case CentralEurope:
-        return convertCharsetInternal(QStringLiteral("windows-1250"), value);
+        return convertCharsetInternal(QLatin1String("windows-1250"), value);
     case Cyrillic:
-        return convertCharsetInternal(QStringLiteral("windows-1251"), value);
+        return convertCharsetInternal(QLatin1String("windows-1251"), value);
     case Latin1:
-        return convertCharsetInternal(QStringLiteral("windows-1252"), value);
+        return convertCharsetInternal(QLatin1String("windows-1252"), value);
     case Greek:
-        return convertCharsetInternal(QStringLiteral("windows-1253"), value);
+        return convertCharsetInternal(QLatin1String("windows-1253"), value);
     case Turkish:
-        return convertCharsetInternal(QStringLiteral("windows-1254"), value);
+        return convertCharsetInternal(QLatin1String("windows-1254"), value);
     case Hebrew:
-        return convertCharsetInternal(QStringLiteral("windows-1255"), value);
+        return convertCharsetInternal(QLatin1String("windows-1255"), value);
     case Arabic:
-        return convertCharsetInternal(QStringLiteral("windows-1256"), value);
+        return convertCharsetInternal(QLatin1String("windows-1256"), value);
     case Baltic:
-        return convertCharsetInternal(QStringLiteral("windows-1257"), value);
+        return convertCharsetInternal(QLatin1String("windows-1257"), value);
     case Vietnamese:
-        return convertCharsetInternal(QStringLiteral("windows-1258"), value);
+        return convertCharsetInternal(QLatin1String("windows-1258"), value);
     case Latin9:
-        return convertCharsetInternal(QStringLiteral("ISO-8859-15"), value);
+        return convertCharsetInternal(QLatin1String("ISO-8859-15"), value);
     case Shift_JIS:
-        return convertCharsetInternal(QStringLiteral("Shift_JIS"), value);
+        return convertCharsetInternal(QLatin1String("Shift_JIS"), value);
     case EUC_JP:
-        return convertCharsetInternal(QStringLiteral("EUC-JP"), value);
+        return convertCharsetInternal(QLatin1String("EUC-JP"), value);
     case EUC_KR:
-        return convertCharsetInternal(QStringLiteral("EUC-KR"), value);
+        return convertCharsetInternal(QLatin1String("EUC-KR"), value);
     case Big5_HKSCS:
-        return convertCharsetInternal(QStringLiteral("Big5-HKSCS"), value);
+        return convertCharsetInternal(QLatin1String("Big5-HKSCS"), value);
     case KOI8_U:
-        return convertCharsetInternal(QStringLiteral("KOI8-U"), value);
+        return convertCharsetInternal(QLatin1String("KOI8-U"), value);
     case UCS2:
-        return convertCharsetInternal(QStringLiteral("ISO-10646-UCS-2"), value);
+        return convertCharsetInternal(QLatin1String("ISO-10646-UCS-2"), value);
     case SCSU:
-        return convertCharsetInternal(QStringLiteral("SCSU"), value);
+        return convertCharsetInternal(QLatin1String("SCSU"), value);
     case BOCU_1:
-        return convertCharsetInternal(QStringLiteral("BOCU-1"), value);
+        return convertCharsetInternal(QLatin1String("BOCU-1"), value);
     case CESU_8:
-        return convertCharsetInternal(QStringLiteral("CESU-8"), value);
+        return convertCharsetInternal(QLatin1String("CESU-8"), value);
     }
     m_pScriptEngineLegacy->logOrThrowError(QStringLiteral("Unknown charset specified"));
     return QByteArray();
 }
 
 QByteArray ControllerScriptInterfaceLegacy::convertCharsetInternal(
-        const QString& targetCharset, const QString& value) {
+        const QLatin1String& targetCharset, const QString& value) {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
     QAnyStringView encoderName = QAnyStringView(targetCharset);
 #else
-    QByteArray encoderNameArray = targetCharset.toUtf8();
-    const char* encoderName = encoderNameArray.constData();
+    const char* encoderName = targetCharset.data();
 #endif
     QStringEncoder fromUtf16 = QStringEncoder(encoderName);
     if (!fromUtf16.isValid()) {

--- a/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
+++ b/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
@@ -1118,7 +1118,7 @@ QByteArray ControllerScriptInterfaceLegacy::convertCharset(
 }
 
 QByteArray ControllerScriptInterfaceLegacy::convertCharsetInternal(
-        const QLatin1String& targetCharset, const QString& value) {
+        QLatin1String targetCharset, const QString& value) {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
     QAnyStringView encoderName = QAnyStringView(targetCharset);
 #else

--- a/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.h
+++ b/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.h
@@ -123,7 +123,7 @@ class ControllerScriptInterfaceLegacy : public QObject {
             const QJSValue& callback,
             bool skipSuperseded = false);
 
-    QByteArray convertCharsetInternal(const QLatin1String& targetCharset, const QString& value);
+    QByteArray convertCharsetInternal(QLatin1String targetCharset, const QString& value);
 
     QHash<ConfigKey, ControlObjectScript*> m_controlCache;
     ControlObjectScript* getControlObjectScript(const QString& group, const QString& name);

--- a/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.h
+++ b/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.h
@@ -122,7 +122,7 @@ class ControllerScriptInterfaceLegacy : public QObject {
             const QJSValue& callback,
             bool skipSuperseded = false);
 
-    QByteArray convertCharsetInternal(const QString& targetCharset, const QString& value);
+    QByteArray convertCharsetInternal(const QLatin1String& targetCharset, const QString& value);
 
     QHash<ConfigKey, ControlObjectScript*> m_controlCache;
     ControlObjectScript* getControlObjectScript(const QString& group, const QString& name);

--- a/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.h
+++ b/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.h
@@ -29,7 +29,7 @@ class ControllerScriptInterfaceLegacy : public QObject {
         UTF_32BE,
         CentralEurope,
         Cyrillic,
-        Latin1,
+        WesternEurope,
         Greek,
         Turkish,
         Hebrew,
@@ -45,7 +45,8 @@ class ControllerScriptInterfaceLegacy : public QObject {
         UCS2,
         SCSU,
         BOCU_1,
-        CESU_8
+        CESU_8,
+        Latin1
     };
     Q_ENUM(Charset)
 


### PR DESCRIPTION
Latin1 is not Windows Western Europe charset. The later contains ™ and some other characters. This PR introduces both, "windows-1252" and "ISO-8859-1"

In addition this has some refactoring regarding string handling and makes the test pass on Qt 6.2 (I have not updated my dev machine to maintain the 2.5 branch) 
