### PR TITLE
Fix caluculation of m_resourcePath in the testing case

### DIFF
--- a/src/controllers/scripting/legacy/controllerscriptenginelegacy.h
+++ b/src/controllers/scripting/legacy/controllerscriptenginelegacy.h
@@ -125,7 +125,7 @@ class ControllerScriptEngineLegacy : public ControllerScriptEngineBase {
     std::unordered_map<QString, std::unique_ptr<mixxx::qml::QmlMixxxControllerScreen>> m_rootItems;
     QList<LegacyControllerMapping::QMLModuleInfo> m_modules;
     QList<LegacyControllerMapping::ScreenInfo> m_infoScreens;
-    QString m_resourcePath{QStringLiteral(".")};
+    QString m_resourcePath;
 #endif
     QList<QJSValue> m_incomingDataFunctions;
     QHash<QString, QJSValue> m_scriptWrappedFunctionCache;

--- a/src/test/controller_mapping_validation_test.cpp
+++ b/src/test/controller_mapping_validation_test.cpp
@@ -199,7 +199,7 @@ bool LegacyControllerMappingValidationTest::testLoadMapping(const MappingInfo& m
 
     FakeController controller;
     controller.setMapping(pMapping);
-    bool result = controller.applyMapping("./res");
+    bool result = controller.applyMapping(getTestDir().filePath(QStringLiteral("../../res")));
     controller.stopEngine();
     return result;
 }


### PR DESCRIPTION
It took me quite a while to figure that out. A related issue is that the path/line reported in the error message is wrong, because of a QML hack: 

https://github.com/mixxxdj/mixxx/blob/main/src/controllers/scripting/legacy/controllerscriptenginelegacy.cpp#L763-L765

The hack allows statements like this: 

`import "." as Skin`

instead of 

`import "../qml" as Skin`

I would prefer to remove the hack and use the later, which feels correct for me. 
