### PR TITLE
Log Test fixes and refactoring. 

### DIFF
--- a/src/test/controller_mapping_file_handler_test.cpp
+++ b/src/test/controller_mapping_file_handler_test.cpp
@@ -926,6 +926,7 @@ TEST_F(LegacyControllerMappingFileHandlerTest, screenMappingExtraIntPropertiesDe
                         </screens>
                 </controller>
                 )EOF"));
+    ASSERT_ALL_EXPECTED_MSG();
 
     mapping = std::make_shared<MockLegacyControllerMapping>();
     // This file always gets added
@@ -946,6 +947,7 @@ TEST_F(LegacyControllerMappingFileHandlerTest, screenMappingExtraIntPropertiesDe
             doc.documentElement(),
             mapping,
             QDir());
+    ASSERT_ALL_EXPECTED_MSG();
 }
 
 TEST_F(LegacyControllerMappingFileHandlerTest, canParseHybridMapping) {

--- a/src/test/controller_mapping_file_handler_test.cpp
+++ b/src/test/controller_mapping_file_handler_test.cpp
@@ -22,7 +22,6 @@ class LegacyControllerMappingFileHandlerTest
     void SetUp() override {
         mixxx::Time::setTestMode(true);
         mixxx::Time::addTestTime(10ms);
-        SETUP_LOG_CAPTURE();
     }
 
     void TearDown() override {
@@ -43,6 +42,9 @@ class LegacyControllerMappingFileHandlerTest
             const QDir&) {
         return QFileInfo(QDir("/dummy/path/").absoluteFilePath(filename));
     }
+
+  private:
+    LogCaptureGuard m_logCaptureGuard;
 };
 
 class MockLegacyControllerMapping : public LegacyControllerMapping {

--- a/src/test/controllerrenderingengine_test.cpp
+++ b/src/test/controllerrenderingengine_test.cpp
@@ -19,12 +19,14 @@ class ControllerRenderingEngineTest : public MixxxTest {
     void SetUp() override {
         mixxx::Time::setTestMode(true);
         mixxx::Time::addTestTime(10ms);
-        SETUP_LOG_CAPTURE();
     }
 
     QList<QImage::Format> supportedPixelFormat() const {
         return LegacyControllerMappingFileHandler::kSupportedPixelFormat.values();
     }
+
+  private:
+    LogCaptureGuard m_logCaptureGuard;
 };
 
 class MockRenderingEngine : public ControllerRenderingEngine {

--- a/src/test/controllerscriptenginelegacy_test.cpp
+++ b/src/test/controllerscriptenginelegacy_test.cpp
@@ -781,7 +781,7 @@ class MockScreenRender : public ControllerRenderingEngine {
 };
 
 TEST_F(ControllerScriptEngineLegacyTest, screenWontSentRawDataIfNotConfigured) {
-    SETUP_LOG_CAPTURE();
+    LogCaptureGuard logCaptureGuard;
     LegacyControllerMapping::ScreenInfo dummyScreen{
             "",                                                    // identifier
             QSize(0, 0),                                           // size
@@ -816,7 +816,7 @@ TEST_F(ControllerScriptEngineLegacyTest, screenWontSentRawDataIfNotConfigured) {
 }
 
 TEST_F(ControllerScriptEngineLegacyTest, screenWillSentRawDataIfConfigured) {
-    SETUP_LOG_CAPTURE();
+    LogCaptureGuard logCaptureGuard;
     LegacyControllerMapping::ScreenInfo dummyScreen{
             "",                                                    // identifier
             QSize(0, 0),                                           // size

--- a/src/test/helpers/log_test.cpp
+++ b/src/test/helpers/log_test.cpp
@@ -34,3 +34,11 @@ void logCapture(QtMsgType msgType, const QMessageLogContext&, const QString& msg
     strm << msgTypeStr;
     FAIL() << errMsg.toStdString();
 }
+
+LogCaptureGuard::LogCaptureGuard()
+        : m_oldHandler(qInstallMessageHandler(logCapture)) {
+}
+
+LogCaptureGuard::~LogCaptureGuard() {
+    qInstallMessageHandler(m_oldHandler);
+}

--- a/src/test/helpers/log_test.cpp
+++ b/src/test/helpers/log_test.cpp
@@ -12,11 +12,25 @@ void logCapture(QtMsgType msgType, const QMessageLogContext&, const QString& msg
             return;
         }
     }
+
     // Unexpected info or debug message aren't considered as a failure
-    if (msgType < QtMsgType::QtWarningMsg)
+    QString msgTypeStr;
+    switch (msgType) {
+    case QtDebugMsg:
+    case QtInfoMsg:
         return;
+    case QtWarningMsg:
+        msgTypeStr = QStringLiteral("Warning: ") + msg;
+        break;
+    case QtCriticalMsg:
+        msgTypeStr = QStringLiteral("Critical:") + msg;
+        break;
+    case QtFatalMsg:
+        msgTypeStr = QStringLiteral("Fatal:") + msg;
+        break;
+    }
     QString errMsg("Got an unexpected log message: \n\t");
     QDebug strm(&errMsg);
-    strm << msgType << msg;
+    strm << msgTypeStr;
     FAIL() << errMsg.toStdString();
 }

--- a/src/test/helpers/log_test.cpp
+++ b/src/test/helpers/log_test.cpp
@@ -27,10 +27,10 @@ void logCapture(QtMsgType msgType, const QMessageLogContext& context, const QStr
         msgTypeStr = QStringLiteral("Warning: ") + msg;
         break;
     case QtCriticalMsg:
-        msgTypeStr = QStringLiteral("Critical:") + msg;
+        msgTypeStr = QStringLiteral("Critical: ") + msg;
         break;
     case QtFatalMsg:
-        msgTypeStr = QStringLiteral("Fatal:") + msg;
+        msgTypeStr = QStringLiteral("Fatal: ") + msg;
         break;
     }
     QString errMsg("Got an unexpected log message: \n\t");
@@ -74,10 +74,10 @@ QString LogCaptureGuard::clearExpectedGetMsg() {
                 msgTypeStr = QStringLiteral("Warning: ");
                 break;
             case QtCriticalMsg:
-                msgTypeStr = QStringLiteral("Critical:");
+                msgTypeStr = QStringLiteral("Critical: ");
                 break;
             case QtFatalMsg:
-                msgTypeStr = QStringLiteral("Fatal:");
+                msgTypeStr = QStringLiteral("Fatal: ");
                 break;
             }
             strm << "\t" << msgTypeStr + std::get<QRegularExpression>(msg).pattern() << "\n";

--- a/src/test/helpers/log_test.cpp
+++ b/src/test/helpers/log_test.cpp
@@ -46,6 +46,7 @@ LogCaptureGuard::LogCaptureGuard() {
 }
 
 LogCaptureGuard::~LogCaptureGuard() {
+    s_logMessagesExpected.clear();
     qInstallMessageHandler(s_oldHandler);
 }
 

--- a/src/test/helpers/log_test.cpp
+++ b/src/test/helpers/log_test.cpp
@@ -61,26 +61,26 @@ QString LogCaptureGuard::clearExpectedGetMsg() {
     if (!s_logMessagesExpected.isEmpty()) {
         QDebug strm(&errMsg);
         strm << s_logMessagesExpected.size() << "expected log messages didn't occur: \n";
-        for (const auto& msg : std::as_const(s_logMessagesExpected)) {
+        for (const auto& [type, regex] : std::as_const(s_logMessagesExpected)) {
             QString msgTypeStr;
-            switch (std::get<QtMsgType>(msg)) {
+            switch (type) {
             case QtDebugMsg:
-                msgTypeStr = QStringLiteral("Warning: ");
+                msgTypeStr = QStringLiteral("Warning: ") + regex.pattern();
                 break;
             case QtInfoMsg:
-                msgTypeStr = QStringLiteral("Warning: ");
+                msgTypeStr = QStringLiteral("Warning: ") + regex.pattern();
                 break;
             case QtWarningMsg:
-                msgTypeStr = QStringLiteral("Warning: ");
+                msgTypeStr = QStringLiteral("Warning: ") + regex.pattern();
                 break;
             case QtCriticalMsg:
-                msgTypeStr = QStringLiteral("Critical: ");
+                msgTypeStr = QStringLiteral("Critical: ") + regex.pattern();
                 break;
             case QtFatalMsg:
-                msgTypeStr = QStringLiteral("Fatal: ");
+                msgTypeStr = QStringLiteral("Fatal: ") + regex.pattern();
                 break;
             }
-            strm << "\t" << msgTypeStr + std::get<QRegularExpression>(msg).pattern() << "\n";
+            strm << "\t" << msgTypeStr << "\n";
         }
         s_logMessagesExpected.clear();
     }

--- a/src/test/helpers/log_test.cpp
+++ b/src/test/helpers/log_test.cpp
@@ -5,8 +5,16 @@ namespace {
 QList<std::tuple<QtMsgType, QRegularExpression>> s_logMessagesExpected;
 QtMessageHandler s_oldHandler;
 
-void logCapture(QtMsgType msgType, const QMessageLogContext& context, const QString& msg) {
+void callOldHandler(QtMsgType msgType, const QMessageLogContext& context, const QString& msg) {
+    // QtMessageHandler is a typedef for a pointer to a function
     s_oldHandler(msgType, context, msg);
+}
+
+void logCapture(QtMsgType msgType, const QMessageLogContext& context, const QString& msg) {
+    // First log msg as usual
+    callOldHandler(msgType, context, msg);
+
+    // Return without failing if the msg has been expected
     for (int i = 0; i < s_logMessagesExpected.size(); i++) {
         if (std::get<QtMsgType>(s_logMessagesExpected[i]) == msgType &&
                 std::get<QRegularExpression>(s_logMessagesExpected[i])

--- a/src/test/helpers/log_test.cpp
+++ b/src/test/helpers/log_test.cpp
@@ -61,7 +61,25 @@ QString LogCaptureGuard::clearExpectedGetMsg() {
         QDebug strm(&errMsg);
         strm << s_logMessagesExpected.size() << "expected log messages didn't occur: \n";
         for (const auto& msg : std::as_const(s_logMessagesExpected)) {
-            strm << "\t" << std::get<QtMsgType>(msg) << std::get<QRegularExpression>(msg) << "\n";
+            QString msgTypeStr;
+            switch (std::get<QtMsgType>(msg)) {
+            case QtDebugMsg:
+                msgTypeStr = QStringLiteral("Warning: ");
+                break;
+            case QtInfoMsg:
+                msgTypeStr = QStringLiteral("Warning: ");
+                break;
+            case QtWarningMsg:
+                msgTypeStr = QStringLiteral("Warning: ");
+                break;
+            case QtCriticalMsg:
+                msgTypeStr = QStringLiteral("Critical:");
+                break;
+            case QtFatalMsg:
+                msgTypeStr = QStringLiteral("Fatal:");
+                break;
+            }
+            strm << "\t" << msgTypeStr + std::get<QRegularExpression>(msg).pattern() << "\n";
         }
         s_logMessagesExpected.clear();
     }

--- a/src/test/helpers/log_test.h
+++ b/src/test/helpers/log_test.h
@@ -26,3 +26,12 @@
 
 extern QList<std::tuple<QtMsgType, QRegularExpression>> logMessagesExpected;
 void logCapture(QtMsgType msgType, const QMessageLogContext&, const QString& msg);
+
+class LogCaptureGuard {
+  public:
+    LogCaptureGuard();
+    ~LogCaptureGuard();
+
+  private:
+    QtMessageHandler m_oldHandler;
+};

--- a/src/test/helpers/log_test.h
+++ b/src/test/helpers/log_test.h
@@ -7,31 +7,21 @@
 #include <QRegularExpression>
 #include <tuple>
 
-#define SETUP_LOG_CAPTURE() \
-    qInstallMessageHandler(logCapture)
+#define ASSERT_ALL_EXPECTED_MSG()                                \
+    {                                                            \
+        QString errMsg = LogCaptureGuard::clearExpectedGetMsg(); \
+        if (!errMsg.isEmpty()) {                                 \
+            FAIL() << errMsg.toStdString();                      \
+        }                                                        \
+    }
 
-#define ASSERT_ALL_EXPECTED_MSG()                                                                  \
-    if (!logMessagesExpected.isEmpty()) {                                                          \
-        QString errMsg;                                                                            \
-        QDebug strm(&errMsg);                                                                      \
-        strm << logMessagesExpected.size() << "expected log messages didn't occur: \n";            \
-        for (const auto& msg : std::as_const(logMessagesExpected))                                 \
-            strm << "\t" << std::get<QtMsgType>(msg) << std::get<QRegularExpression>(msg) << "\n"; \
-        FAIL() << errMsg.toStdString();                                                            \
-    } else                                                                                         \
-        logMessagesExpected.clear();
-
-#define EXPECT_LOG_MSG(type, exp) \
-    logMessagesExpected.push_back(std::make_tuple(type, QRegularExpression(exp)))
-
-extern QList<std::tuple<QtMsgType, QRegularExpression>> logMessagesExpected;
-void logCapture(QtMsgType msgType, const QMessageLogContext&, const QString& msg);
+#define EXPECT_LOG_MSG(type, exp) LogCaptureGuard::expect(type, exp)
 
 class LogCaptureGuard {
   public:
     LogCaptureGuard();
     ~LogCaptureGuard();
 
-  private:
-    QtMessageHandler m_oldHandler;
+    static void expect(QtMsgType type, const QString& exp);
+    static QString clearExpectedGetMsg();
 };


### PR DESCRIPTION
This fixes failing test when running mixxx-test directly. 

In addition the improves the log test a bit. 

* LogCaptureGuard for scoped handling of QtMessageHandler.
* Hide global variables 
* improve error messages 
* Don't expect Info messages 
* Fix clear of expected messages