### PR TITLE
(fix) Tracks: copy fix Ctrl+C

### DIFF
--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1151,9 +1151,14 @@ void WTrackTableView::keyPressEvent(QKeyEvent* event) {
             moveSelectedTracks(event);
             return;
         }
-        if (event->key() == Qt::Key_Escape) {
-            clearSelection();
-            setCurrentIndex(QModelIndex());
+        if (event->modifiers().testFlag(Qt::ControlModifier) &&
+                event->modifiers().testFlag(Qt::ShiftModifier) &&
+                event->key() == Qt::Key_C) {
+            // copy the cell content as native QKeySequence::Copy would
+            QKeyEvent ke =
+                    QKeyEvent{QEvent::KeyPress, Qt::Key_C, Qt::ControlModifier};
+            QTableView::keyPressEvent(&ke);
+            return;
         }
     }
     QTableView::keyPressEvent(event);

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1116,21 +1116,28 @@ void WTrackTableView::keyPressEvent(QKeyEvent* event) {
         break;
     }
     TrackModel* pTrackModel = getTrackModel();
-    if (pTrackModel && !pTrackModel->isLocked()) {
-        if (event->matches(QKeySequence::Delete) || event->key() == Qt::Key_Backspace) {
-            removeSelectedTracks();
-            return;
+    if (pTrackModel) {
+        if (!pTrackModel->isLocked()) {
+            if (event->matches(QKeySequence::Delete) || event->key() == Qt::Key_Backspace) {
+                removeSelectedTracks();
+                return;
+            }
+            if (event->matches(QKeySequence::Cut)) {
+                cutSelectedTracks();
+                return;
+            }
+            if (event->matches(QKeySequence::Paste)) {
+                pasteTracks(currentIndex());
+                return;
+            }
+            if (event->key() == Qt::Key_Escape) {
+                clearSelection();
+                setCurrentIndex(QModelIndex());
+            }
         }
-        if (event->matches(QKeySequence::Cut)) {
-            cutSelectedTracks();
-            return;
-        }
+
         if (event->matches(QKeySequence::Copy)) {
             copySelectedTracks();
-            return;
-        }
-        if (event->matches(QKeySequence::Paste)) {
-            pasteTracks(currentIndex());
             return;
         }
         if (event->modifiers().testFlag(Qt::AltModifier) &&


### PR DESCRIPTION
fixes #14065 
* **Ctrl+Shift+C** copies the content of the selected cell(s)
* (Ctrl+C copies the selected track(s) as before)

small fixup:
allow Copy Track also in locked track models