### PR TITLE
Preferences: show 'real' xfader configuration

### DIFF
--- a/src/preferences/dialog/dlgprefmixer.cpp
+++ b/src/preferences/dialog/dlgprefmixer.cpp
@@ -41,14 +41,12 @@ const ConfigKey kLowEqFreqKey = ConfigKey(kMixerProfile, kLowEqFrequency);
 const ConfigKey kLowEqFreqPreciseKey =
         ConfigKey(kMixerProfile, QStringLiteral("LoEQFrequencyPrecise"));
 
-const QString kXfaderCalibration = QStringLiteral("xFaderCalibration");
-
 const ConfigKey kXfaderModeKey = ConfigKey(EngineXfader::kXfaderConfigKey,
         QStringLiteral("xFaderMode"));
 const ConfigKey kXfaderCurveKey = ConfigKey(EngineXfader::kXfaderConfigKey,
         QStringLiteral("xFaderCurve"));
 const ConfigKey kXfaderCalibrationKey = ConfigKey(EngineXfader::kXfaderConfigKey,
-        kXfaderCalibration);
+        QStringLiteral("xFaderCalibration"));
 const ConfigKey kXfaderReverseKey = ConfigKey(EngineXfader::kXfaderConfigKey,
         QStringLiteral("xFaderReverse"));
 
@@ -74,13 +72,12 @@ DlgPrefMixer::DlgPrefMixer(
         : DlgPreferencePage(pParent),
           m_pConfig(pConfig),
           m_xFaderMode(MIXXX_XFADER_ADDITIVE),
-          m_xFaderTransform(EngineXfader::kTransformDefault),
+          m_xFaderCurve(EngineXfader::kTransformDefault),
           m_xFaderCal(0.0),
           m_xfModeCO(make_parented<ControlProxy>(kXfaderModeKey, this)),
           m_xfCurveCO(make_parented<ControlProxy>(kXfaderCurveKey, this)),
           m_xfReverseCO(make_parented<ControlProxy>(kXfaderReverseKey, this)),
-          m_xfCalibrationCO(
-                  ConfigKey(EngineXfader::kXfaderConfigKey, kXfaderCalibration)),
+          m_xfCalibrationCO(make_parented<ControlProxy>(kXfaderCalibrationKey, this)),
           m_crossfader(QStringLiteral("[Master]"), QStringLiteral("crossfader")),
           m_xFaderReverse(false),
           m_COLoFreq(kLowEqFreqKey),
@@ -113,14 +110,30 @@ DlgPrefMixer::DlgPrefMixer(
     connect(SliderXFader,
             QOverload<int>::of(&QSlider::valueChanged),
             this,
-            &DlgPrefMixer::slotUpdateXFader);
-    connect(SliderXFader, &QSlider::sliderMoved, this, &DlgPrefMixer::slotUpdateXFader);
-    connect(SliderXFader, &QSlider::sliderReleased, this, &DlgPrefMixer::slotUpdateXFader);
-    connect(radioButtonAdditive, &QRadioButton::clicked, this, &DlgPrefMixer::slotUpdateXFader);
-    connect(radioButtonConstantPower,
-            &QRadioButton::clicked,
+            &DlgPrefMixer::slotXFaderSliderChanged);
+    connect(SliderXFader, &QSlider::sliderMoved, this, &DlgPrefMixer::slotXFaderSliderChanged);
+    connect(SliderXFader, &QSlider::sliderReleased, this, &DlgPrefMixer::slotXFaderSliderChanged);
+    connect(buttonGroupCrossfaderModes,
+            &QButtonGroup::buttonClicked,
             this,
-            &DlgPrefMixer::slotUpdateXFader);
+            &DlgPrefMixer::slotXFaderModeBoxToggled);
+    connect(checkBoxReverse,
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+            &QCheckBox::checkStateChanged,
+#else
+            &QCheckBox::stateChanged,
+#endif
+            this,
+            &DlgPrefMixer::slotXFaderReverseBoxToggled);
+
+    m_xfModeCO->connectValueChanged(
+            this, &DlgPrefMixer::slotXFaderModeControlChanged);
+    m_xfCurveCO->connectValueChanged(
+            this, &DlgPrefMixer::slotXFaderCurveControlChanged);
+    m_xfCalibrationCO->connectValueChanged(
+            this, &DlgPrefMixer::slotXFaderCalibrationControlChanged);
+    m_xfReverseCO->connectValueChanged(
+            this, &DlgPrefMixer::slotXFaderReverseControlChanged);
 
     // Don't allow the xfader graph getting keyboard focus
     graphicsViewXfader->setFocusPolicy(Qt::NoFocus);
@@ -135,33 +148,57 @@ DlgPrefMixer::DlgPrefMixer(
     connect(SliderLoEQ, &QSlider::sliderReleased, this, &DlgPrefMixer::slotLoEqSliderChanged);
 
     connect(CheckBoxEqAutoReset,
-            &QCheckBox::toggled,
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+            &QCheckBox::checkStateChanged,
+#else
+            &QCheckBox::stateChanged,
+#endif
             this,
             &DlgPrefMixer::slotEqAutoResetToggled);
     connect(CheckBoxGainAutoReset,
-            &QCheckBox::toggled,
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+            &QCheckBox::checkStateChanged,
+#else
+            &QCheckBox::stateChanged,
+#endif
             this,
             &DlgPrefMixer::slotGainAutoResetToggled);
 #ifdef __STEM__
     connect(CheckBoxStemAutoReset,
-            &QCheckBox::toggled,
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+            &QCheckBox::checkStateChanged,
+#else
+            &QCheckBox::stateChanged,
+#endif
             this,
             &DlgPrefMixer::slotStemAutoResetToggled);
 #else
     CheckBoxStemAutoReset->hide();
 #endif
     connect(CheckBoxBypass,
-            &QCheckBox::toggled,
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+            &QCheckBox::checkStateChanged,
+#else
+            &QCheckBox::stateChanged,
+#endif
             this,
             &DlgPrefMixer::slotBypassEqToggled);
 
     connect(CheckBoxEqOnly,
-            &QCheckBox::toggled,
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+            &QCheckBox::checkStateChanged,
+#else
+            &QCheckBox::stateChanged,
+#endif
             this,
             &DlgPrefMixer::slotEqOnlyToggled);
 
     connect(CheckBoxSingleEqEffect,
-            &QCheckBox::toggled,
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+            &QCheckBox::checkStateChanged,
+#else
+            &QCheckBox::stateChanged,
+#endif
             this,
             &DlgPrefMixer::slotSingleEqToggled);
 
@@ -709,17 +746,17 @@ void DlgPrefMixer::slotApply() {
 
 void DlgPrefMixer::applyXFader() {
     m_xfModeCO->set(m_xFaderMode);
-    m_xfCurveCO->set(m_xFaderTransform);
-    m_xfCalibrationCO.set(m_xFaderCal);
+    m_xfCurveCO->set(m_xFaderCurve);
+    m_xfCalibrationCO->set(m_xFaderCal);
     if (m_xFaderReverse != m_xfReverseCO->toBool()) {
         double position = m_crossfader.get();
         m_crossfader.set(0.0 - position);
     }
     m_xfReverseCO->set(m_xFaderReverse ? 1.0 : 0.0);
 
-    m_pConfig->set(kXfaderModeKey, ConfigValue(m_xFaderMode));
-    m_pConfig->set(kXfaderCurveKey, ConfigValue(QString::number(m_xFaderTransform)));
-    m_pConfig->set(kXfaderReverseKey, ConfigValue(m_xFaderReverse ? 1 : 0));
+    m_pConfig->setValue(kXfaderModeKey, m_xFaderMode);
+    m_pConfig->setValue(kXfaderCurveKey, m_xFaderCurve);
+    m_pConfig->setValue(kXfaderReverseKey, m_xFaderReverse);
 }
 
 void DlgPrefMixer::storeEqShelves() {
@@ -732,27 +769,6 @@ void DlgPrefMixer::storeEqShelves() {
 }
 
 void DlgPrefMixer::slotUpdate() {
-    // xfader //////////////////////////////////////////////////////////////////
-    m_xFaderTransform = m_pConfig->getValue(kXfaderCurveKey, EngineXfader::kTransformDefault);
-
-    // Range SliderXFader 0 .. 100
-    double sliderVal = RescalerUtils::oneByXToLinear(
-            m_xFaderTransform - EngineXfader::kTransformMin + 1,
-            EngineXfader::kTransformMax - EngineXfader::kTransformMin + 1,
-            SliderXFader->minimum(),
-            SliderXFader->maximum());
-    SliderXFader->setValue(static_cast<int>(std::round(sliderVal)));
-
-    m_xFaderMode = m_pConfig->getValueString(kXfaderModeKey).toInt();
-    if (m_xFaderMode == MIXXX_XFADER_CONSTPWR) {
-        radioButtonConstantPower->setChecked(true);
-    } else {
-        radioButtonAdditive->setChecked(true);
-    }
-
-    m_xFaderReverse = m_pConfig->getValueString(kXfaderReverseKey).toInt() == 1;
-    checkBoxReverse->setChecked(m_xFaderReverse);
-
     slotUpdateXFader();
 
     // EQs & QuickEffects //////////////////////////////////////////////////////
@@ -819,6 +835,62 @@ void DlgPrefMixer::slotUpdate() {
     updateMainEQ();
 }
 
+void DlgPrefMixer::slotUpdateXFader() {
+    // Read values from config only on first update if the xfader curve controls
+    // are still at their default values. This should detect if controller mappings
+    // (or skin attributes) have changed the xfader controls.
+    // Else and on later calls, always read the current state from controls.
+    if (m_initializing &&
+            m_xfCurveCO->get() == m_xfCurveCO->getDefault() &&
+            m_xfCalibrationCO->get() == m_xfCalibrationCO->getDefault() &&
+            m_xfModeCO->get() == m_xfModeCO->getDefault() &&
+            m_xfReverseCO->get() == m_xfReverseCO->getDefault()) {
+        m_xFaderCurve = m_pConfig->getValue(kXfaderCurveKey, EngineXfader::kTransformDefault);
+        // "xFaderCalibration" is not stored in the config and it's not expsoed
+        // with a slider here. Each time the slider is touched it's calculated
+        // to get us a smooth curve for ConstPower mode. And hos no effect for
+        // Additive mode.
+        // TODO This also means custom values set by controller mappings are
+        // wiped on shutdown.
+        m_xFaderCal = EngineXfader::getPowerCalibration(m_xFaderCurve);
+        m_xFaderMode = m_pConfig->getValue<int>(kXfaderModeKey);
+        m_xFaderReverse = m_pConfig->getValue<bool>(kXfaderReverseKey);
+    } else {
+        // Update xfader from controls
+        // deactivated for now. resolve dupe debug etc.
+        // slotXFaderControlChanged();
+        m_xFaderCurve = m_xfCurveCO->get();
+        m_xFaderCal = m_xfCalibrationCO->get();
+        m_xFaderMode = static_cast<int>(m_xfModeCO->get());
+        m_xFaderReverse = static_cast<bool>(m_xfReverseCO->get());
+    }
+
+    updateXFaderWidgets();
+}
+
+void DlgPrefMixer::updateXFaderWidgets() {
+    const QSignalBlocker signalBlocker(this);
+
+    // Range SliderXFader 0 .. 100
+    double sliderVal = RescalerUtils::oneByXToLinear(
+            m_xFaderCurve - EngineXfader::kTransformMin + 1,
+            EngineXfader::kTransformMax - EngineXfader::kTransformMin + 1,
+            SliderXFader->minimum(),
+            SliderXFader->maximum());
+    SliderXFader->setValue(static_cast<int>(std::round(sliderVal)));
+
+    // Same here
+    if (m_xFaderMode == MIXXX_XFADER_CONSTPWR) {
+        radioButtonConstantPower->setChecked(true);
+    } else {
+        radioButtonAdditive->setChecked(true);
+    }
+
+    checkBoxReverse->setChecked(m_xFaderReverse);
+
+    drawXfaderDisplay();
+}
+
 void DlgPrefMixer::drawXfaderDisplay() {
     // Initialize or clear scene
     if (m_pxfScene) {
@@ -880,10 +952,10 @@ void DlgPrefMixer::drawXfaderDisplay() {
     for (int x = 1; x <= pointCount + 1; x++) {
         CSAMPLE_GAIN gainL, gainR;
         EngineXfader::getXfadeGains((-1. + (xfadeStep * (x - 1))),
-                m_xFaderTransform,
+                m_xFaderCurve,
                 m_xFaderCal,
                 m_xFaderMode,
-                checkBoxReverse->isChecked(),
+                m_xFaderReverse,
                 &gainL,
                 &gainR);
 
@@ -910,26 +982,68 @@ void DlgPrefMixer::drawXfaderDisplay() {
     graphicsViewXfader->repaint();
 }
 
-void DlgPrefMixer::slotUpdateXFader() {
-    if (radioButtonAdditive->isChecked()) {
-        m_xFaderMode = MIXXX_XFADER_ADDITIVE;
-    } else {
-        m_xFaderMode = MIXXX_XFADER_CONSTPWR;
-    }
+void DlgPrefMixer::slotXFaderReverseBoxToggled() {
+    m_xFaderReverse = checkBoxReverse->isChecked();
+}
 
-    // m_xFaderTransform is in the range of 1 to 1000 while 50 % slider results
+void DlgPrefMixer::slotXFaderSliderChanged() {
+    // m_xFaderCurve is in the range of 1 to 1000 while 50 % slider results
     // to ~2, which represents a medium rounded fader curve.
-    double transform = RescalerUtils::linearToOneByX(
-                               SliderXFader->value(),
-                               SliderXFader->minimum(),
-                               SliderXFader->maximum(),
-                               EngineXfader::kTransformMax) -
+    double curve = RescalerUtils::linearToOneByX(
+                           SliderXFader->value(),
+                           SliderXFader->minimum(),
+                           SliderXFader->maximum(),
+                           EngineXfader::kTransformMax) -
             1 + EngineXfader::kTransformMin;
     // Round to 4 decimal places to avoid round-trip offsets with default 1.0
-    m_xFaderTransform = std::round(transform * 10000) / 10000;
-    m_xFaderCal = EngineXfader::getPowerCalibration(m_xFaderTransform);
+    m_xFaderCurve = std::round(curve * 10000) / 10000;
+    // If the curve has been changed in the GUI we fetch the engine value for
+    // calibration which gives us a smooth curve.
+    // This wipes any previous value set by controller mappings for example.
+    m_xFaderCal = EngineXfader::getPowerCalibration(m_xFaderCurve);
+    drawXfaderDisplay();
+}
+
+void DlgPrefMixer::slotXFaderModeBoxToggled() {
+    m_xFaderMode = radioButtonConstantPower->isChecked()
+            ? MIXXX_XFADER_CONSTPWR
+            : MIXXX_XFADER_ADDITIVE;
 
     drawXfaderDisplay();
+}
+
+void DlgPrefMixer::slotXFaderCurveControlChanged(double v) {
+    if (v == m_xFaderCurve) {
+        return;
+    }
+    m_xFaderCurve = v;
+    updateXFaderWidgets();
+}
+
+void DlgPrefMixer::slotXFaderCalibrationControlChanged(double v) {
+    if (v == m_xFaderCal) {
+        return;
+    }
+    m_xFaderCal = v;
+    updateXFaderWidgets();
+}
+
+void DlgPrefMixer::slotXFaderModeControlChanged(double v) {
+    int mode = static_cast<int>(v);
+    if (mode == m_xFaderMode) {
+        return;
+    }
+    m_xFaderMode = mode;
+    updateXFaderWidgets();
+}
+
+void DlgPrefMixer::slotXFaderReverseControlChanged(double v) {
+    bool reverse = v > 0;
+    if (reverse == m_xFaderReverse) {
+        return;
+    }
+    m_xFaderReverse = reverse;
+    updateXFaderWidgets();
 }
 
 void DlgPrefMixer::slotEqAutoResetToggled(bool checked) {

--- a/src/preferences/dialog/dlgprefmixer.h
+++ b/src/preferences/dialog/dlgprefmixer.h
@@ -49,6 +49,17 @@ class DlgPrefMixer : public DlgPreferencePage, public Ui::DlgPrefMixerDlg {
     void slotPopulateQuickEffectSelectors();
 
     void slotUpdateXFader();
+    void updateXFaderWidgets();
+
+    void slotXFaderReverseBoxToggled();
+    void slotXFaderModeBoxToggled();
+    void slotXFaderSliderChanged();
+
+    void slotXFaderCurveControlChanged(double v);
+    void slotXFaderCalibrationControlChanged(double v);
+    void slotXFaderModeControlChanged(double v);
+    void slotXFaderReverseControlChanged(double v);
+
     void slotHiEqSliderChanged();
     void slotLoEqSliderChanged();
 
@@ -83,12 +94,12 @@ class DlgPrefMixer : public DlgPreferencePage, public Ui::DlgPrefMixerDlg {
 
     // X-fader values
     int m_xFaderMode;
-    double m_xFaderTransform, m_xFaderCal;
+    double m_xFaderCurve, m_xFaderCal;
 
     parented_ptr<ControlProxy> m_xfModeCO;
     parented_ptr<ControlProxy> m_xfCurveCO;
     parented_ptr<ControlProxy> m_xfReverseCO;
-    PollingControlProxy m_xfCalibrationCO;
+    parented_ptr<ControlProxy> m_xfCalibrationCO;
     PollingControlProxy m_crossfader;
 
     bool m_xFaderReverse;

--- a/src/preferences/dialog/dlgprefmixer.h
+++ b/src/preferences/dialog/dlgprefmixer.h
@@ -26,10 +26,12 @@ class DlgPrefMixer : public DlgPreferencePage, public Ui::DlgPrefMixerDlg {
 
   public slots:
     void slotApply() override;
+    /// Update the widgets with values from config / EffectsManager
     void slotUpdate() override;
     void slotResetToDefaults() override;
 
   private slots:
+    /// Create EQ & QuickEffect selectors and deck label for each added deck
     void slotNumDecksChanged(double numDecks);
     void slotEQEffectSelectionChanged(int effectIndex);
     void slotQuickEffectSelectionChanged(int effectIndex);
@@ -41,8 +43,8 @@ class DlgPrefMixer : public DlgPreferencePage, public Ui::DlgPrefMixerDlg {
     void slotStemAutoResetToggled(bool checked);
 #endif
     void slotBypassEqToggled(bool checked);
-    // Create, populate and show/hide EQ & QuickEffect selectors, considering the
-    // number of decks and the 'Single EQ' checkbox
+    /// Create, populate and show/hide EQ & QuickEffect selectors, considering the
+    /// number of decks and the 'Single EQ' checkbox
     void slotPopulateDeckEqSelectors();
     void slotPopulateQuickEffectSelectors();
 
@@ -50,7 +52,7 @@ class DlgPrefMixer : public DlgPreferencePage, public Ui::DlgPrefMixerDlg {
     void slotHiEqSliderChanged();
     void slotLoEqSliderChanged();
 
-    // Update the Main EQ
+    /// Update the Main EQ
     void slotMainEQParameterSliderChanged(int value);
     void slotMainEQToDefault();
     void slotMainEqEffectChanged(int effectIndex);
@@ -62,6 +64,8 @@ class DlgPrefMixer : public DlgPreferencePage, public Ui::DlgPrefMixerDlg {
     double getEqFreq(int value, int minimum, int maximum);
     int getSliderPosition(double eqFreq, int minimum, int maximum);
     void validateEQShelves();
+
+    void applyXFader();
 
     void applyDeckEQs();
     void applyQuickEffects();
@@ -79,12 +83,12 @@ class DlgPrefMixer : public DlgPreferencePage, public Ui::DlgPrefMixerDlg {
 
     // X-fader values
     int m_xFaderMode;
-    double m_transform, m_cal;
+    double m_xFaderTransform, m_xFaderCal;
 
-    PollingControlProxy m_mode;
-    PollingControlProxy m_curve;
-    PollingControlProxy m_calibration;
-    PollingControlProxy m_reverse;
+    parented_ptr<ControlProxy> m_xfModeCO;
+    parented_ptr<ControlProxy> m_xfCurveCO;
+    parented_ptr<ControlProxy> m_xfReverseCO;
+    PollingControlProxy m_xfCalibrationCO;
     PollingControlProxy m_crossfader;
 
     bool m_xFaderReverse;

--- a/src/preferences/dialog/dlgprefmixerdlg.ui
+++ b/src/preferences/dialog/dlgprefmixerdlg.ui
@@ -22,7 +22,7 @@
   <layout class="QVBoxLayout" name="verticalLayout_2">
 
    <item>
-    <widget class="QGroupBox" name="groupBox">
+    <widget class="QGroupBox" name="groupBox_xfader">
      <property name="title">
       <string>Crossfader Curve</string>
      </property>


### PR DESCRIPTION
This makes the Mixer preferences load the xfader configuration
* from config on first load (if all xfader controls are still at their default values¹)
* from controls each following update

This means touching the usual 3-state switch or curve knob on a controller will update the xfader graphic immedtiately.

¹Since mappings are loaded before DlgPreferences is instantiated this is supposed to detect if mappings have already set the xfader config in their init(), either explicitly or received updates via inputReport request.

Will do another test soon with the S4 Mk3 mapping which requests a status report on startup to sync all controls.

If someone wants to test it without controller, here's a mapping for Vir-MIDI or MIDI Through
https://gist.github.com/ronso0/ae7a6f3fc2b28e43f16bf50bfb84e62e