### PR TITLE
Hercules DJ Control Starlight: Add EffectChain superknob control

### DIFF
--- a/res/controllers/Hercules DJControl Starlight.midi.xml
+++ b/res/controllers/Hercules DJControl Starlight.midi.xml
@@ -445,6 +445,17 @@
                 <key>super1</key>
                 <description>SHIFT + Filter</description>
                 <status>0xb4</status>
+                <midino>0x01</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            
+            <control>
+                <group>[EffectRack1_EffectUnit1]</group>
+                <key>super1</key>
+                <description>SHIFT + Bass</description>
+                <status>0xb4</status>
                 <midino>0x02</midino>
                 <options>
                     <normal/>
@@ -717,6 +728,17 @@
                 <group>[EffectRack1_EffectUnit2]</group>
                 <key>super1</key>
                 <description>SHIFT + Filter</description>
+                <status>0xb5</status>
+                <midino>0x01</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+
+            <control>
+                <group>[EffectRack1_EffectUnit2]</group>
+                <key>super1</key>
+                <description>SHIFT + Bass</description>
                 <status>0xb5</status>
                 <midino>0x02</midino>
                 <options>

--- a/res/controllers/Hercules DJControl Starlight.midi.xml
+++ b/res/controllers/Hercules DJControl Starlight.midi.xml
@@ -441,6 +441,17 @@
 
         // FX
             <control>
+                <group>[EffectRack1_EffectUnit1]</group>
+                <key>super1</key>
+                <description>SHIFT + Filter</description>
+                <status>0xb4</status>
+                <midino>0x02</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            
+            <control>
                 <group>[EffectRack1_EffectUnit1_Effect1]</group>
                 <key>enabled</key>
                 <description>(Pad 1)</description>
@@ -702,6 +713,17 @@
             </control>
 
         // FX
+            <control>
+                <group>[EffectRack1_EffectUnit2]</group>
+                <key>super1</key>
+                <description>SHIFT + Filter</description>
+                <status>0xb5</status>
+                <midino>0x02</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            
             <control>
                 <group>[EffectRack1_EffectUnit2_Effect1]</group>
                 <key>enabled</key>

--- a/res/controllers/Hercules DJControl Starlight.midi.xml
+++ b/res/controllers/Hercules DJControl Starlight.midi.xml
@@ -450,7 +450,7 @@
                     <normal/>
                 </options>
             </control>
-            
+
             <control>
                 <group>[EffectRack1_EffectUnit1]</group>
                 <key>super1</key>
@@ -461,7 +461,7 @@
                     <normal/>
                 </options>
             </control>
-            
+
             <control>
                 <group>[EffectRack1_EffectUnit1_Effect1]</group>
                 <key>enabled</key>
@@ -745,7 +745,7 @@
                     <normal/>
                 </options>
             </control>
-            
+
             <control>
                 <group>[EffectRack1_EffectUnit2_Effect1]</group>
                 <key>enabled</key>


### PR DESCRIPTION
This adds controls for moving the metaknobs of all effects in the chain by holding the SHIFT button and turning the Bass/Filter knob.