### PR TITLE
WOverview: remove unused coefficients

### DIFF
--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -51,8 +51,7 @@ WOverview::WOverview(
           m_bTimeRulerActive(false),
           m_orientation(Qt::Horizontal),
           m_iLabelFontSize(10),
-          m_a(1.0),
-          m_b(0.0),
+          m_maxPixelPos(1.0),
           m_analyzerProgress(kAnalyzerProgressUnknown),
           m_trackLoaded(false),
           m_pHoveredMark(nullptr),
@@ -1634,19 +1633,7 @@ double WOverview::samplePositionToSeconds(double sample) {
 
 void WOverview::resizeEvent(QResizeEvent* pEvent) {
     Q_UNUSED(pEvent);
-    // Play-position potmeters range from 0 to 1 but they allow out-of-range
-    // sets. This is to give VC access to the pre-roll area.
-    constexpr double kMaxPlayposRange = 1.0;
-    constexpr double kMinPlayposRange = 0.0;
-
-    // Values of zero and one in normalized space.
-    const double zero = (0.0 - kMinPlayposRange) / (kMaxPlayposRange - kMinPlayposRange);
-    const double one = (1.0 - kMinPlayposRange) / (kMaxPlayposRange - kMinPlayposRange);
-
-    // These coefficients convert between widget space and normalized value
-    // space.
-    m_a = (length() - 1) / (one - zero);
-    m_b = zero * m_a;
+    m_maxPixelPos = length() - 1;
 
     m_devicePixelRatio = devicePixelRatioF();
 

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -108,10 +108,10 @@ class WOverview : public WWidget, public TrackDropTarget {
     void paintText(const QString& text, QPainter* pPainter);
     double samplePositionToSeconds(double sample);
     inline int valueToPosition(double value) const {
-        return static_cast<int>(m_a * value - m_b);
+        return static_cast<int>(m_maxPixelPos * value);
     }
     inline double positionToValue(int position) const {
-        return (static_cast<double>(position) + m_b) / m_a;
+        return static_cast<double>(position) / m_maxPixelPos;
     }
 
     void updateCues(const QList<CuePointer> &loadedCues);
@@ -166,9 +166,8 @@ class WOverview : public WWidget, public TrackDropTarget {
     Qt::Orientation m_orientation;
     int m_iLabelFontSize;
 
-    // Coefficient value-position linear transposition
-    double m_a;
-    double m_b;
+    // Coefficient for linear value <-> position  transposition
+    double m_maxPixelPos;
 
     AnalyzerProgress m_analyzerProgress;
     bool m_trackLoaded;


### PR DESCRIPTION
Unused. (well, they are used but... ; )

I didn't dig through the file history to figure what that was supposed to do :man_shrugging: 
I hope `m_maxPixelPos` is descriptive, else feel free to propose another name.