### PR TITLE
(fix) WOverview: also render analysis progress when triggered by WTrackMenu/AnalysisFeature

### DIFF
--- a/src/library/analysis/analysisfeature.cpp
+++ b/src/library/analysis/analysisfeature.cpp
@@ -156,6 +156,14 @@ void AnalysisFeature::analyzeTracks(const QList<AnalyzerScheduledTrack>& tracks)
                 &TrackAnalysisScheduler::finished,
                 this,
                 &AnalysisFeature::onTrackAnalysisSchedulerFinished);
+        // Forward the signal to be picked up by Library.
+        // Used by WOverview to render the re-analysis progress of loaded tracks.
+        // This is the equivalent to PlayerManager's progress signal fired for
+        // analysis triggered by loading a track.
+        connect(m_pTrackAnalysisScheduler.get(),
+                &TrackAnalysisScheduler::trackProgress,
+                this,
+                &AnalysisFeature::trackProgress);
 
         emit analysisActive(true);
     }

--- a/src/library/analysis/analysisfeature.h
+++ b/src/library/analysis/analysisfeature.h
@@ -34,6 +34,7 @@ class AnalysisFeature : public LibraryFeature {
 
   signals:
     void analysisActive(bool bActive);
+    void trackProgress(TrackId trackId, AnalyzerProgress progress);
 
   public slots:
     void activate() override;

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -162,6 +162,10 @@ Library::Library(
             &PlayerManager::trackAnalyzerIdle,
             this,
             &Library::onPlayerManagerTrackAnalyzerIdle);
+    connect(m_pAnalysisFeature,
+            &AnalysisFeature::trackProgress,
+            this,
+            &Library::onTrackAnalyzerProgress);
 
     // iTunes and Rhythmbox should be last until we no longer have an obnoxious
     // messagebox popup when you select them. (This forces you to reach for your

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -148,6 +148,8 @@ class Library: public QObject {
     void setTrackTableRowHeight(int rowHeight);
     void setSelectedClick(bool enable);
 
+    void onTrackAnalyzerProgress(TrackId trackId, AnalyzerProgress analyzerProgress);
+
   private slots:
       void onPlayerManagerTrackAnalyzerProgress(TrackId trackId, AnalyzerProgress analyzerProgress);
       void onPlayerManagerTrackAnalyzerIdle();

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -999,6 +999,13 @@ QWidget* LegacySkinParser::parseOverview(const QDomElement& node) {
             &PlayerManager::slotLoadLocationToPlayerMaybePlay);
     connect(overviewWidget, &WOverview::cloneDeck,
             m_pPlayerManager, &PlayerManager::slotCloneDeck);
+    // This signal stems from AnalysisFeature, and the overview can now
+    // render the analysis progress like when listening to Playermanager's
+    // analysis progress signal when loading a track.
+    connect(m_pLibrary,
+            &Library::onTrackAnalyzerProgress,
+            overviewWidget,
+            &WOverview::onTrackAnalyzerProgress);
 
     commonWidgetSetup(node, overviewWidget);
     overviewWidget->setup(node, *m_pContext);


### PR DESCRIPTION
Currently, the analysis progress is rendered in the overview widgets only for analysis triggered when loading a track.
Now it's also rendered when the loaded track is re-analyzed (after clearing the wavefom).

1. load a new track to a deck (or take an analyzed track all clear waveform, BPM, ReplayGain ..)
= analysis starts, in overview the analysis progress bar is drawn and waveform is rendered as data is being created
2. track menu -> Clear -> Waveform
3. re-analyze (via deck track menu, library track menu or find track in Analyze feature)
= no progress bar in overview, no feedback <-- **fixed**, same feedback as with 1.

by-catch of #14140 