### PR TITLE
Fix crash due to concurrent access in MidiController (Alternative)

### DIFF
--- a/src/controllers/bulk/bulkcontroller.cpp
+++ b/src/controllers/bulk/bulkcontroller.cpp
@@ -202,7 +202,6 @@ int BulkController::open() {
     }
 #endif
 
-    setOpen(true);
     startEngine();
 
     if (m_pReader != nullptr) {
@@ -223,7 +222,8 @@ int BulkController::open() {
         // audio directly, like when scratching
         m_pReader->start(QThread::HighPriority);
     }
-
+    applyMapping();
+    setOpen(true);
     return 0;
 }
 

--- a/src/controllers/bulk/bulkcontroller.cpp
+++ b/src/controllers/bulk/bulkcontroller.cpp
@@ -97,14 +97,8 @@ QString BulkController::mappingExtension() {
 }
 
 void BulkController::setMapping(std::shared_ptr<LegacyControllerMapping> pMapping) {
+    m_pMutableMapping = pMapping;
     m_pMapping = downcastAndClone<LegacyHidControllerMapping>(pMapping.get());
-}
-
-std::shared_ptr<LegacyControllerMapping> BulkController::cloneMapping() {
-    if (!m_pMapping) {
-        return nullptr;
-    }
-    return std::make_shared<LegacyHidControllerMapping>(*m_pMapping);
 }
 
 QList<LegacyControllerMapping::ScriptFileInfo> BulkController::getMappingScriptFiles() {

--- a/src/controllers/bulk/bulkcontroller.cpp
+++ b/src/controllers/bulk/bulkcontroller.cpp
@@ -107,6 +107,20 @@ std::shared_ptr<LegacyControllerMapping> BulkController::cloneMapping() {
     return std::make_shared<LegacyHidControllerMapping>(*m_pMapping);
 }
 
+QList<LegacyControllerMapping::ScriptFileInfo> BulkController::getMappingScriptFiles() {
+    if (!m_pMapping) {
+        return {};
+    }
+    return m_pMapping->getScriptFiles();
+}
+
+QList<std::shared_ptr<AbstractLegacyControllerSetting>> BulkController::getMappingSettings() {
+    if (!m_pMapping) {
+        return {};
+    }
+    return m_pMapping->getSettings();
+}
+
 bool BulkController::matchMapping(const MappingInfo& mapping) {
     const QList<ProductInfo>& products = mapping.getProducts();
     for (const auto& product : products) {

--- a/src/controllers/bulk/bulkcontroller.h
+++ b/src/controllers/bulk/bulkcontroller.h
@@ -44,6 +44,9 @@ class BulkController : public Controller {
     virtual std::shared_ptr<LegacyControllerMapping> cloneMapping() override;
     void setMapping(std::shared_ptr<LegacyControllerMapping> pMapping) override;
 
+    QList<LegacyControllerMapping::ScriptFileInfo> getMappingScriptFiles() override;
+    QList<std::shared_ptr<AbstractLegacyControllerSetting>> getMappingSettings() override;
+
     bool isMappable() const override {
         if (!m_pMapping) {
             return false;

--- a/src/controllers/bulk/bulkcontroller.h
+++ b/src/controllers/bulk/bulkcontroller.h
@@ -41,7 +41,6 @@ class BulkController : public Controller {
 
     QString mappingExtension() override;
 
-    virtual std::shared_ptr<LegacyControllerMapping> cloneMapping() override;
     void setMapping(std::shared_ptr<LegacyControllerMapping> pMapping) override;
 
     QList<LegacyControllerMapping::ScriptFileInfo> getMappingScriptFiles() override;

--- a/src/controllers/bulk/bulkcontroller.h
+++ b/src/controllers/bulk/bulkcontroller.h
@@ -56,11 +56,10 @@ class BulkController : public Controller {
   protected:
     void send(const QList<int>& data, unsigned int length) override;
 
-  private slots:
+  private:
     int open() override;
     int close() override;
 
-  private:
     // For devices which only support a single report, reportID must be set to
     // 0x0.
     void sendBytes(const QByteArray& data) override;

--- a/src/controllers/controller.cpp
+++ b/src/controllers/controller.cpp
@@ -70,8 +70,7 @@ bool Controller::applyMapping() {
         return false;
     }
 
-    const std::shared_ptr<LegacyControllerMapping> pMapping = cloneMapping();
-    QList<LegacyControllerMapping::ScriptFileInfo> scriptFiles = pMapping->getScriptFiles();
+    QList<LegacyControllerMapping::ScriptFileInfo> scriptFiles = getMappingScriptFiles();
     if (scriptFiles.isEmpty()) {
         qCWarning(m_logBase)
                 << "No script functions available! Did the XML file(s) load "
@@ -81,7 +80,7 @@ bool Controller::applyMapping() {
 
     m_pScriptEngineLegacy->setScriptFiles(scriptFiles);
 
-    m_pScriptEngineLegacy->setSettings(pMapping->getSettings());
+    m_pScriptEngineLegacy->setSettings(getMappingSettings());
     return m_pScriptEngineLegacy->initialize();
 }
 

--- a/src/controllers/controller.h
+++ b/src/controllers/controller.h
@@ -69,8 +69,6 @@ class Controller : public QObject {
     // function that is assumed to exist. (Sub-classes may want to reimplement
     // this if they have an alternate way of handling such data.)
     virtual void receive(const QByteArray& data, mixxx::Duration timestamp);
-
-    virtual bool applyMapping();
     virtual void slotBeforeEngineShutdown();
 
     // Puts the controller in and out of learning mode.
@@ -78,6 +76,8 @@ class Controller : public QObject {
     void stopLearning();
 
   protected:
+    virtual bool applyMapping();
+
     template<typename SpecificMappingType>
         requires(std::is_final_v<SpecificMappingType> == true)
     std::unique_ptr<SpecificMappingType> downcastAndClone(const LegacyControllerMapping* pMapping) {

--- a/src/controllers/controller.h
+++ b/src/controllers/controller.h
@@ -29,10 +29,12 @@ class Controller : public QObject {
     /// the controller (type.)
     virtual QString mappingExtension() = 0;
 
-    virtual std::shared_ptr<LegacyControllerMapping> cloneMapping() = 0;
-    /// WARNING: LegacyControllerMapping is not thread safe!
-    /// Clone the mapping before passing to setMapping for use in the controller polling thread.
     virtual void setMapping(std::shared_ptr<LegacyControllerMapping> pMapping) = 0;
+    std::shared_ptr<LegacyControllerMapping> getMapping() {
+        // return the unused mutable copy of the mapping, that can be edited in the GUI thread
+        // and than adopted again via setMapping()
+        return m_pMutableMapping;
+    }
 
     virtual QList<LegacyControllerMapping::ScriptFileInfo> getMappingScriptFiles() = 0;
     virtual QList<std::shared_ptr<AbstractLegacyControllerSetting>> getMappingSettings() = 0;
@@ -139,6 +141,7 @@ class Controller : public QObject {
     const RuntimeLoggingCategory m_logBase;
     const RuntimeLoggingCategory m_logInput;
     const RuntimeLoggingCategory m_logOutput;
+    std::shared_ptr<LegacyControllerMapping> m_pMutableMapping;
 
   private: // but used by ControllerManager
 

--- a/src/controllers/controller.h
+++ b/src/controllers/controller.h
@@ -3,6 +3,7 @@
 #include <QElapsedTimer>
 
 #include "controllers/controllermappinginfo.h"
+#include "controllers/legacycontrollermapping.h"
 #include "util/duration.h"
 #include "util/runtimeloggingcategory.h"
 
@@ -32,6 +33,9 @@ class Controller : public QObject {
     /// WARNING: LegacyControllerMapping is not thread safe!
     /// Clone the mapping before passing to setMapping for use in the controller polling thread.
     virtual void setMapping(std::shared_ptr<LegacyControllerMapping> pMapping) = 0;
+
+    virtual QList<LegacyControllerMapping::ScriptFileInfo> getMappingScriptFiles() = 0;
+    virtual QList<std::shared_ptr<AbstractLegacyControllerSetting>> getMappingSettings() = 0;
 
     inline bool isOpen() const {
         return m_bIsOpen;

--- a/src/controllers/controllermanager.cpp
+++ b/src/controllers/controllermanager.cpp
@@ -422,9 +422,9 @@ void ControllerManager::slotApplyMapping(Controller* pController,
         return;
     }
 
+    closeController(pController);
     ConfigKey key(kSettingsGroup, sanitizeDeviceName(pController->getName()));
     if (!pMapping) {
-        closeController(pController);
         // Unset the controller mapping for this controller
         pController->setMapping(nullptr);
         m_pConfig->remove(key);
@@ -447,7 +447,6 @@ void ControllerManager::slotApplyMapping(Controller* pController,
         openController(pController);
         emit mappingApplied(pController->isMappable());
     } else {
-        closeController(pController);
         emit mappingApplied(false);
     }
 }

--- a/src/controllers/controllermanager.cpp
+++ b/src/controllers/controllermanager.cpp
@@ -301,7 +301,6 @@ void ControllerManager::slotSetUpDevices() {
             qWarning() << "There was a problem opening" << name;
             continue;
         }
-        pController->applyMapping();
     }
 
     pollIfAnyControllersOpen();
@@ -394,8 +393,6 @@ void ControllerManager::openController(Controller* pController) {
     // If successfully opened the device, apply the mapping and save the
     // preference setting.
     if (result == 0) {
-        pController->applyMapping();
-
         // Update configuration to reflect controller is enabled.
         m_pConfig->setValue(
                 ConfigKey("[Controller]", sanitizeDeviceName(pController->getName())), 1);

--- a/src/controllers/controllermanager.h
+++ b/src/controllers/controllermanager.h
@@ -52,13 +52,9 @@ class ControllerManager : public QObject {
     void mappingApplied(bool applied);
 
   public slots:
-    void updateControllerList();
-
     void slotApplyMapping(Controller* pController,
             std::shared_ptr<LegacyControllerMapping> pMapping,
             bool bEnabled);
-    void openController(Controller* pController);
-    void closeController(Controller* pController);
 
   private slots:
     /// Perform initialization that should be delayed until the ControllerManager
@@ -70,12 +66,16 @@ class ControllerManager : public QObject {
     void slotSetUpDevices();
     void slotShutdown();
     /// Calls poll() on all devices that have isPolling() true.
-    void pollDevices();
+    void slotPollDevices();
+
+  private:
+    void updateControllerList();
     void startPolling();
     void stopPolling();
     void pollIfAnyControllersOpen();
+    void openController(Controller* pController);
+    void closeController(Controller* pController);
 
-  private:
     UserSettingsPointer m_pConfig;
     ControllerLearningEventFilter* m_pControllerLearningEventFilter;
     QTimer m_pollTimer;

--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -62,7 +62,7 @@ DlgPrefController::DlgPrefController(
     initTableView(m_ui.m_pOutputMappingTableView);
 
     std::shared_ptr<LegacyControllerMapping> pMapping = m_pController->getMapping();
-    slotShowMapping(pMapping);
+    showMapping(pMapping);
 
     m_ui.labelDeviceName->setText(m_pController->getName());
     QString category = m_pController->getCategory();
@@ -200,7 +200,7 @@ void DlgPrefController::showLearningWizard() {
         m_pMapping = std::make_shared<LegacyMidiControllerMapping>();
         emit applyMapping(m_pController, m_pMapping, true);
         // shortcut for creating and assigning required I/O table models
-        slotShowMapping(m_pMapping);
+        showMapping(m_pMapping);
     }
 
     // Note that DlgControllerLearning is set to delete itself on close using
@@ -689,7 +689,7 @@ void DlgPrefController::slotMappingSelected(int chosenIndex) {
         // the preset combobox.
         enumerateMappings(mappingFilePath);
     }
-    slotShowMapping(pMapping);
+    showMapping(pMapping);
 }
 
 bool DlgPrefController::saveMapping() {
@@ -857,7 +857,7 @@ void DlgPrefController::initTableView(QTableView* pTable) {
     pTable->setAlternatingRowColors(true);
 }
 
-void DlgPrefController::slotShowMapping(std::shared_ptr<LegacyControllerMapping> pMapping) {
+void DlgPrefController::showMapping(std::shared_ptr<LegacyControllerMapping> pMapping) {
     m_ui.labelLoadedMapping->setText(mappingName(pMapping));
     m_ui.labelLoadedMappingDescription->setText(mappingDescription(pMapping));
     m_ui.labelLoadedMappingAuthor->setText(mappingAuthor(pMapping));

--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -197,7 +197,7 @@ void DlgPrefController::showLearningWizard() {
     slotApply();
 
     if (!m_pMapping) {
-        m_pMapping = std::shared_ptr<LegacyControllerMapping>(new LegacyMidiControllerMapping());
+        m_pMapping = std::make_shared<LegacyMidiControllerMapping>();
         emit applyMapping(m_pController, m_pMapping, true);
         // shortcut for creating and assigning required I/O table models
         slotShowMapping(m_pMapping);

--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -61,7 +61,7 @@ DlgPrefController::DlgPrefController(
     initTableView(m_ui.m_pInputMappingTableView);
     initTableView(m_ui.m_pOutputMappingTableView);
 
-    std::shared_ptr<LegacyControllerMapping> pMapping = m_pController->cloneMapping();
+    std::shared_ptr<LegacyControllerMapping> pMapping = m_pController->getMapping();
     slotShowMapping(pMapping);
 
     m_ui.labelDeviceName->setText(m_pController->getName());

--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -103,7 +103,11 @@ DlgPrefController::DlgPrefController(
     connect(this,
             &DlgPrefController::applyMapping,
             m_pControllerManager.get(),
-            &ControllerManager::slotApplyMapping);
+            &ControllerManager::slotApplyMapping,
+            Qt::BlockingQueuedConnection);
+    // Wait until the mapping has been cloned in the controller thread
+    // and we can continue to edit our copy
+
     // Update GUI
     connect(m_pControllerManager.get(),
             &ControllerManager::mappingApplied,

--- a/src/controllers/dlgprefcontroller.h
+++ b/src/controllers/dlgprefcontroller.h
@@ -55,9 +55,6 @@ class DlgPrefController : public DlgPreferencePage {
   private slots:
     /// Called when the user selects another mapping in the combobox
     void slotMappingSelected(int index);
-    /// Used to selected the current mapping in the combobox and display the
-    /// mapping information.
-    void slotShowMapping(std::shared_ptr<LegacyControllerMapping> mapping);
     void slotInputControlSearch();
     void slotOutputControlSearch();
     /// Called when the Controller Learning Wizard is closed.
@@ -78,6 +75,9 @@ class DlgPrefController : public DlgPreferencePage {
     void midiInputMappingsLearned(const MidiInputMappings& mappings);
 
   private:
+    /// Used to selected the current mapping in the combobox and display the
+    /// mapping information.
+    void showMapping(std::shared_ptr<LegacyControllerMapping> mapping);
     QString mappingShortName(const std::shared_ptr<LegacyControllerMapping> pMapping) const;
     QString mappingName(const std::shared_ptr<LegacyControllerMapping> pMapping) const;
     QString mappingAuthor(const std::shared_ptr<LegacyControllerMapping> pMapping) const;

--- a/src/controllers/dlgprefcontrollers.cpp
+++ b/src/controllers/dlgprefcontrollers.cpp
@@ -197,8 +197,8 @@ void DlgPrefControllers::setupControllerWidgets() {
         connect(pController,
                 &Controller::openChanged,
                 this,
-                [this, &pControllerDlg](bool bOpen) {
-                    slotHighlightDevice(pControllerDlg, bOpen);
+                [this, pDlg = pControllerDlg.get()](bool bOpen) {
+                    slotHighlightDevice(pDlg, bOpen);
                 });
 
         QTreeWidgetItem* pControllerTreeItem = new QTreeWidgetItem(

--- a/src/controllers/dlgprefcontrollers.cpp
+++ b/src/controllers/dlgprefcontrollers.cpp
@@ -176,7 +176,7 @@ void DlgPrefControllers::setupControllerWidgets() {
     std::sort(controllerList.begin(), controllerList.end(), controllerCompare);
 
     for (auto* pController : std::as_const(controllerList)) {
-        DlgPrefController* pControllerDlg = new DlgPrefController(
+        auto pControllerDlg = make_parented<DlgPrefController>(
                 this, pController, m_pControllerManager, m_pConfig);
         connect(pControllerDlg,
                 &DlgPrefController::mappingStarted,
@@ -187,9 +187,9 @@ void DlgPrefControllers::setupControllerWidgets() {
                 m_pDlgPreferences,
                 &DlgPreferences::show);
         // Recreate the control picker menus when decks or samplers are added
-        m_pNumDecks->connectValueChanged(pControllerDlg,
+        m_pNumDecks->connectValueChanged(pControllerDlg.get(),
                 &DlgPrefController::slotRecreateControlPickerMenu);
-        m_pNumSamplers->connectValueChanged(pControllerDlg,
+        m_pNumSamplers->connectValueChanged(pControllerDlg.get(),
                 &DlgPrefController::slotRecreateControlPickerMenu);
 
         m_controllerPages.append(pControllerDlg);
@@ -197,7 +197,7 @@ void DlgPrefControllers::setupControllerWidgets() {
         connect(pController,
                 &Controller::openChanged,
                 this,
-                [this, pControllerDlg](bool bOpen) {
+                [this, &pControllerDlg](bool bOpen) {
                     slotHighlightDevice(pControllerDlg, bOpen);
                 });
 

--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -29,14 +29,8 @@ QString HidController::mappingExtension() {
 }
 
 void HidController::setMapping(std::shared_ptr<LegacyControllerMapping> pMapping) {
+    m_pMutableMapping = pMapping;
     m_pMapping = downcastAndClone<LegacyHidControllerMapping>(pMapping.get());
-}
-
-std::shared_ptr<LegacyControllerMapping> HidController::cloneMapping() {
-    if (!m_pMapping) {
-        return nullptr;
-    }
-    return std::make_shared<LegacyHidControllerMapping>(*m_pMapping);
 }
 
 QList<LegacyControllerMapping::ScriptFileInfo> HidController::getMappingScriptFiles() {

--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -39,6 +39,20 @@ std::shared_ptr<LegacyControllerMapping> HidController::cloneMapping() {
     return std::make_shared<LegacyHidControllerMapping>(*m_pMapping);
 }
 
+QList<LegacyControllerMapping::ScriptFileInfo> HidController::getMappingScriptFiles() {
+    if (!m_pMapping) {
+        return {};
+    }
+    return m_pMapping->getScriptFiles();
+}
+
+QList<std::shared_ptr<AbstractLegacyControllerSetting>> HidController::getMappingSettings() {
+    if (!m_pMapping) {
+        return {};
+    }
+    return m_pMapping->getSettings();
+}
+
 bool HidController::matchMapping(const MappingInfo& mapping) {
     const QList<ProductInfo>& products = mapping.getProducts();
     for (const auto& product : products) {

--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -101,8 +101,6 @@ int HidController::open() {
         return -1;
     }
 
-    setOpen(true);
-
     m_pHidIoThread = std::make_unique<HidIoThread>(pHidDevice, m_deviceInfo);
     m_pHidIoThread->setObjectName(QStringLiteral("HidIoThread ") + getName());
 
@@ -132,6 +130,8 @@ int HidController::open() {
         qWarning() << "HidIoThread wasn't in expected OutputActive state";
     }
 
+    applyMapping();
+    setOpen(true);
     return 0;
 }
 

--- a/src/controllers/hid/hidcontroller.h
+++ b/src/controllers/hid/hidcontroller.h
@@ -17,7 +17,6 @@ class HidController final : public Controller {
 
     QString mappingExtension() override;
 
-    std::shared_ptr<LegacyControllerMapping> cloneMapping() override;
     void setMapping(std::shared_ptr<LegacyControllerMapping> pMapping) override;
 
     QList<LegacyControllerMapping::ScriptFileInfo> getMappingScriptFiles() override;

--- a/src/controllers/hid/hidcontroller.h
+++ b/src/controllers/hid/hidcontroller.h
@@ -29,11 +29,10 @@ class HidController final : public Controller {
 
     bool matchMapping(const MappingInfo& mapping) override;
 
-  private slots:
+  private:
     int open() override;
     int close() override;
 
-  private:
     // For devices which only support a single report, reportID must be set to
     // 0x0.
     void sendBytes(const QByteArray& data) override;

--- a/src/controllers/hid/hidcontroller.h
+++ b/src/controllers/hid/hidcontroller.h
@@ -17,8 +17,11 @@ class HidController final : public Controller {
 
     QString mappingExtension() override;
 
-    virtual std::shared_ptr<LegacyControllerMapping> cloneMapping() override;
+    std::shared_ptr<LegacyControllerMapping> cloneMapping() override;
     void setMapping(std::shared_ptr<LegacyControllerMapping> pMapping) override;
+
+    QList<LegacyControllerMapping::ScriptFileInfo> getMappingScriptFiles() override;
+    QList<std::shared_ptr<AbstractLegacyControllerSetting>> getMappingSettings() override;
 
     bool isMappable() const override {
         if (!m_pMapping) {

--- a/src/controllers/midi/hss1394controller.cpp
+++ b/src/controllers/midi/hss1394controller.cpp
@@ -129,8 +129,9 @@ int Hss1394Controller::open() {
             qWarning() << "Unable to set SCS.1d platter timer period.";
     }
 
-    setOpen(true);
     startEngine();
+    applyMapping();
+    setOpen(true);
     return 0;
 }
 

--- a/src/controllers/midi/midicontroller.cpp
+++ b/src/controllers/midi/midicontroller.cpp
@@ -66,6 +66,20 @@ std::shared_ptr<LegacyControllerMapping> MidiController::cloneMapping() {
     return std::make_shared<LegacyMidiControllerMapping>(*m_pMapping);
 }
 
+QList<LegacyControllerMapping::ScriptFileInfo> MidiController::getMappingScriptFiles() {
+    if (!m_pMapping) {
+        return {};
+    }
+    return m_pMapping->getScriptFiles();
+}
+
+QList<std::shared_ptr<AbstractLegacyControllerSetting>> MidiController::getMappingSettings() {
+    if (!m_pMapping) {
+        return {};
+    }
+    return m_pMapping->getSettings();
+}
+
 int MidiController::close() {
     destroyOutputHandlers();
     return 0;

--- a/src/controllers/midi/midicontroller.cpp
+++ b/src/controllers/midi/midicontroller.cpp
@@ -56,14 +56,8 @@ QString MidiController::mappingExtension() {
 }
 
 void MidiController::setMapping(std::shared_ptr<LegacyControllerMapping> pMapping) {
+    m_pMutableMapping = pMapping;
     m_pMapping = downcastAndClone<LegacyMidiControllerMapping>(pMapping.get());
-}
-
-std::shared_ptr<LegacyControllerMapping> MidiController::cloneMapping() {
-    if (!m_pMapping) {
-        return nullptr;
-    }
-    return std::make_shared<LegacyMidiControllerMapping>(*m_pMapping);
 }
 
 QList<LegacyControllerMapping::ScriptFileInfo> MidiController::getMappingScriptFiles() {

--- a/src/controllers/midi/midicontroller.h
+++ b/src/controllers/midi/midicontroller.h
@@ -73,6 +73,9 @@ class MidiController : public Controller {
             unsigned char control,
             const QJSValue& scriptCode);
 
+    bool applyMapping() override;
+    int close() override;
+
   protected slots:
     virtual void receivedShortMessage(
             unsigned char status,
@@ -81,12 +84,9 @@ class MidiController : public Controller {
             mixxx::Duration timestamp);
     // For receiving System Exclusive messages
     void receive(const QByteArray& data, mixxx::Duration timestamp) override;
-    int close() override;
     void slotBeforeEngineShutdown() override;
 
   private slots:
-    bool applyMapping() override;
-
     void learnTemporaryInputMappings(const MidiInputMappings& mappings);
     void clearTemporaryInputMappings();
     void commitTemporaryInputMappings();

--- a/src/controllers/midi/midicontroller.h
+++ b/src/controllers/midi/midicontroller.h
@@ -41,7 +41,10 @@ class MidiController : public Controller {
     QString mappingExtension() override;
 
     void setMapping(std::shared_ptr<LegacyControllerMapping> pMapping) override;
-    virtual std::shared_ptr<LegacyControllerMapping> cloneMapping() override;
+    std::shared_ptr<LegacyControllerMapping> cloneMapping() override;
+
+    QList<LegacyControllerMapping::ScriptFileInfo> getMappingScriptFiles() override;
+    QList<std::shared_ptr<AbstractLegacyControllerSetting>> getMappingSettings() override;
 
     bool isMappable() const override {
         if (!m_pMapping) {

--- a/src/controllers/midi/midicontroller.h
+++ b/src/controllers/midi/midicontroller.h
@@ -41,7 +41,6 @@ class MidiController : public Controller {
     QString mappingExtension() override;
 
     void setMapping(std::shared_ptr<LegacyControllerMapping> pMapping) override;
-    std::shared_ptr<LegacyControllerMapping> cloneMapping() override;
 
     QList<LegacyControllerMapping::ScriptFileInfo> getMappingScriptFiles() override;
     QList<std::shared_ptr<AbstractLegacyControllerSetting>> getMappingSettings() override;

--- a/src/controllers/midi/portmidicontroller.cpp
+++ b/src/controllers/midi/portmidicontroller.cpp
@@ -78,9 +78,9 @@ int PortMidiController::open() {
             return -2;
         }
     }
-
-    setOpen(true);
     startEngine();
+    applyMapping();
+    setOpen(true);
     return 0;
 }
 

--- a/src/controllers/midi/portmidicontroller.h
+++ b/src/controllers/midi/portmidicontroller.h
@@ -56,8 +56,6 @@ class PortMidiController : public MidiController {
     ~PortMidiController() override;
 
   private slots:
-    int open() override;
-    int close() override;
     bool poll() override;
 
   protected:
@@ -66,6 +64,9 @@ class PortMidiController : public MidiController {
                       unsigned char byte2) override;
 
   private:
+    int open() override;
+    int close() override;
+
     // The sysex data must already contain the start byte 0xf0 and the end byte
     // 0xf7.
     void sendBytes(const QByteArray& data) override;

--- a/src/test/controller_mapping_validation_test.h
+++ b/src/test/controller_mapping_validation_test.h
@@ -93,15 +93,6 @@ class FakeController : public Controller {
         }
     }
 
-    virtual std::shared_ptr<LegacyControllerMapping> cloneMapping() override {
-        if (m_pMidiMapping) {
-            return std::make_shared<LegacyMidiControllerMapping>(*m_pMidiMapping);
-        } else if (m_pHidMapping) {
-            return std::make_shared<LegacyHidControllerMapping>(*m_pHidMapping);
-        }
-        return nullptr;
-    };
-
     QList<LegacyControllerMapping::ScriptFileInfo> getMappingScriptFiles() override {
         if (m_pMidiMapping) {
             return m_pMidiMapping->getScriptFiles();

--- a/src/test/controller_mapping_validation_test.h
+++ b/src/test/controller_mapping_validation_test.h
@@ -102,6 +102,24 @@ class FakeController : public Controller {
         return nullptr;
     };
 
+    QList<LegacyControllerMapping::ScriptFileInfo> getMappingScriptFiles() override {
+        if (m_pMidiMapping) {
+            return m_pMidiMapping->getScriptFiles();
+        } else if (m_pHidMapping) {
+            return m_pHidMapping->getScriptFiles();
+        }
+        return {};
+    }
+
+    QList<std::shared_ptr<AbstractLegacyControllerSetting>> getMappingSettings() override {
+        if (m_pMidiMapping) {
+            return m_pMidiMapping->getSettings();
+        } else if (m_pHidMapping) {
+            return m_pHidMapping->getSettings();
+        }
+        return {};
+    }
+
     bool isMappable() const override;
 
     bool matchMapping(const MappingInfo& mapping) override {

--- a/src/test/controller_mapping_validation_test.h
+++ b/src/test/controller_mapping_validation_test.h
@@ -120,7 +120,7 @@ class FakeController : public Controller {
         Q_UNUSED(data);
     }
 
-  private slots:
+  private:
     int open() override {
         return 0;
     }
@@ -129,7 +129,6 @@ class FakeController : public Controller {
         return 0;
     }
 
-  private:
     bool m_bMidiMapping;
     bool m_bHidMapping;
     std::shared_ptr<LegacyMidiControllerMapping> m_pMidiMapping;


### PR DESCRIPTION
This is an alternative to fix #13940

I have now "hopfully" managed to wrap my head around the issue. The issue was that the mapping has been cloned from the GUI thread while the Controller thread has applied JS created mappings. This creates a broken copy of the mapping that crashes Mixxx after it was applied back to the Controller thread.  

The solution here keeps now a clean mutable copy of the mapping for the GUI thread. The GUI thread waits until the controller thread has cloned the mapping during "Apply" this way we have sorted out all concurrent access to the mappings. 

This PR is unfortunately a big bigger than expected, because some related code and comments have not been maintained over the years and was misleading making the issue hard to understand. 
