### PR TITLE
(cleanup) remove obsolete focusOutEvent() from WPushButton

### DIFF
--- a/src/widget/wpushbutton.cpp
+++ b/src/widget/wpushbutton.cpp
@@ -460,18 +460,6 @@ bool WPushButton::event(QEvent* e) {
     return WWidget::event(e);
 }
 
-void WPushButton::focusOutEvent(QFocusEvent* e) {
-    qDebug() << "focusOutEvent" << e->reason();
-    if (m_bPressed && e->reason() != Qt::MouseFocusReason) {
-        // Since we support multi touch there is no reason to reset
-        // the pressed flag if the Primary touch point is moved to an
-        // other widget
-        m_bPressed = false;
-        restyleAndRepaint();
-    }
-    QWidget::focusOutEvent(e);
-}
-
 void WPushButton::mouseReleaseEvent(QMouseEvent * e) {
     const bool leftClick = e->button() == Qt::LeftButton;
     const bool rightClick = e->button() == Qt::RightButton;

--- a/src/widget/wpushbutton.h
+++ b/src/widget/wpushbutton.h
@@ -71,7 +71,6 @@ class WPushButton : public WWidget {
     void paintEvent(QPaintEvent* e) override;
     void mousePressEvent(QMouseEvent* e) override;
     void mouseReleaseEvent(QMouseEvent* e) override;
-    void focusOutEvent(QFocusEvent* e) override;
     void fillDebugTooltip(QStringList* debug) override;
 
   protected:


### PR DESCRIPTION
[Focus is disabled in setup()](https://github.com/mixxxdj/mixxx/blob/278806dfa0c77572c853e887838d5067be6d097c/src/widget/wpushbutton.cpp#L236) anyway and there is no WPushButton-derived WWidget that sets a different focus policy, so this is never called.
['pressed' and 'hovered' states are reset in event()](https://github.com/mixxxdj/mixxx/blob/278806dfa0c77572c853e887838d5067be6d097c/src/widget/wpushbutton.cpp#L433), eg. when switching to another window.
(I traced the events to verify)

So this is basically a fixup/cleanup for #2307 / #2460 