### PR TITLE
drop Hotcue onto Play button to latch `play`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1510,6 +1510,7 @@ add_library(
   src/widget/findonwebmenuservices/findonwebmenulastfm.cpp
   src/widget/findonwebmenuservices/findonwebmenusoundcloud.cpp
   src/widget/hexspinbox.cpp
+  src/widget/hotcuedrag.cpp
   src/widget/paintable.cpp
   src/widget/wanalysislibrarytableview.cpp
   src/widget/wbasewidget.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1554,6 +1554,7 @@ add_library(
   src/widget/wnumberrate.cpp
   src/widget/woverview.cpp
   src/widget/wpixmapstore.cpp
+  src/widget/wplaybutton.cpp
   src/widget/wpushbutton.cpp
   src/widget/wraterange.cpp
   src/widget/wstarratingaction.cpp

--- a/res/skins/Deere/deck_controls_row.xml
+++ b/res/skins/Deere/deck_controls_row.xml
@@ -38,7 +38,7 @@
             <Layout>stacked</Layout>
             <SizePolicy>me,me</SizePolicy>
             <Children>
-              <Template src="skin:left_right_display_2state_button.xml">
+              <Template src="skin:left_right_display_play_2state_button.xml">
                 <SetVariable name="TooltipId">play_cue_set</SetVariable>
                 <SetVariable name="ObjectName">PlayToggle</SetVariable>
                 <SetVariable name="MinimumSize"><Variable name="HorizontalStretchButtonMinimumSize"/></SetVariable>

--- a/res/skins/Deere/left_right_display_play_2state_button.xml
+++ b/res/skins/Deere/left_right_display_play_2state_button.xml
@@ -1,0 +1,65 @@
+<!DOCTYPE template>
+<!--
+  Description:
+    A button that has a left-click control, a right-click control, and a 2-state
+    display control.
+    Left-click control is one of the play controls.
+    HotcueButtons of the same player (engine, not necessarily same player in skin)
+    can be dropped onto it in order to latch play when previewing from hotcue.
+
+    Make sure to use one of the 'play' ToolTipIDs so the dnd behavior is discoverable.
+
+  Variables:
+    ObjectName: The object name.
+    Size: the button size.
+    state_X_text:
+    state_X_pressed:
+    state_X_unpressed:
+    LeftClickIsPushButton:  true / false
+                            Defines the button mode.
+                            true = PUSH button
+                            false = TOGGLE or TRIGGER, as automatically set by
+                            the control connected to the respective button.
+    RightClickIsPushButton: See above. true / false
+-->
+<Template>
+  <PlayButton>
+    <TooltipId><Variable name="TooltipId"/></TooltipId>
+    <ObjectName><Variable name="ObjectName"/></ObjectName>
+    <MinimumSize><Variable name="MinimumSize"/></MinimumSize>
+    <MaximumSize><Variable name="MaximumSize"/></MaximumSize>
+    <SizePolicy><Variable name="SizePolicy"/></SizePolicy>
+    <NumberStates>2</NumberStates>
+    <LeftClickIsPushButton><Variable name="LeftClickIsPushButton"/></LeftClickIsPushButton>
+    <RightClickIsPushButton><Variable name="RightClickIsPushButton"/></RightClickIsPushButton>
+    <Group><Variable name="group"/></Group>
+    <State>
+      <Number>0</Number>
+      <Text><Variable name="state_0_text"/></Text>
+      <Pressed scalemode="STRETCH_ASPECT"><Variable name="state_0_pressed"/></Pressed>
+      <Unpressed scalemode="STRETCH_ASPECT"><Variable name="state_0_unpressed"/></Unpressed>
+    </State>
+    <State>
+      <Number>1</Number>
+      <Text><Variable name="state_1_text"/></Text>
+      <Pressed scalemode="STRETCH_ASPECT"><Variable name="state_1_pressed"/></Pressed>
+      <Unpressed scalemode="STRETCH_ASPECT"><Variable name="state_1_unpressed"/></Unpressed>
+    </State>
+    <Connection>
+      <ConfigKey><Variable name="left_connection_control"/></ConfigKey>
+      <EmitOnPressAndRelease>true</EmitOnPressAndRelease>
+      <ButtonState>LeftButton</ButtonState>
+      <ConnectValueToWidget>false</ConnectValueToWidget>
+    </Connection>
+    <Connection>
+      <ConfigKey><Variable name="right_connection_control"/></ConfigKey>
+      <EmitOnPressAndRelease>true</EmitOnPressAndRelease>
+      <ButtonState>RightButton</ButtonState>
+      <ConnectValueToWidget>false</ConnectValueToWidget>
+    </Connection>
+    <Connection>
+      <ConfigKey><Variable name="display_connection_control"/></ConfigKey>
+      <ConnectValueFromWidget>false</ConnectValueFromWidget>
+    </Connection>
+  </PlayButton>
+</Template>

--- a/res/skins/LateNight/controls/button_play_2state_right_display.xml
+++ b/res/skins/LateNight/controls/button_play_2state_right_display.xml
@@ -1,0 +1,59 @@
+<!--
+Description:
+  A button that has click or display controls.
+  Left-click control is one of the play controls.
+  HotcueButtons of the same player (engine, not necessarily same player in skin)
+  can be dropped onto it in order to latch play when previewing from hotcue.
+
+  Make sure to use one of the 'play' ToolTipIDs so the dnd behavior is discoverable.
+
+Variables:
+  ObjectName        : object name
+  ToolTipID         : standard Tooltip from mixxx db
+    see: https://github.com/mixxxdj/mixxx/blob/main/src/skin/legacy/tooltips.cpp
+  Group             : BasePlayer group
+  Size              : button size
+  state_X_text      : label text for state X
+  state_X_pressed   : background graphic for pressed state X
+  state_X_unpressed : background graphic for unpressed state X
+  Align             : alignment of text
+  ConfigKey         : left-click control
+  ConfigKeyRight    : right-click control
+  ConfigKeyDisp     : display control
+-->
+<Template>
+  <PlayButton>
+    <TooltipId><Variable name="TooltipId"/></TooltipId>
+    <ObjectName><Variable name="ObjectName"/></ObjectName>
+    <Size><Variable name="Size"/></Size>
+    <NumberStates>2</NumberStates>
+    <RightClickIsPushButton>true</RightClickIsPushButton>
+    <Group><Variable name="Group"/></Group>
+    <State>
+      <Number>0</Number>
+      <Text><Variable name="state_0_text"/></Text>
+      <Alignment><Variable name="Align"/></Alignment>
+      <Unpressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_<Variable name="BtnSize"/>.svg</Unpressed>
+      <Pressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_<Variable name="BtnSize"/>_active.svg</Pressed>
+    </State>
+    <State>
+      <Number>1</Number>
+      <Text><Variable name="state_1_text"/></Text>
+      <Alignment><Variable name="Align"/></Alignment>
+      <Unpressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_<Variable name="BtnSize"/>_active.svg</Unpressed>
+      <Pressed scalemode="STRETCH">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn_<Variable name="BtnType"/>_<Variable name="BtnSize"/>_active.svg</Pressed>
+    </State>
+    <Connection>
+      <ConfigKey><Variable name="ConfigKey"/></ConfigKey>
+      <ButtonState>LeftButton</ButtonState>
+    </Connection>
+    <Connection>
+      <ConfigKey><Variable name="ConfigKeyRight"/></ConfigKey>
+      <ButtonState>RightButton</ButtonState>
+    </Connection>
+    <Connection>
+      <ConfigKey><Variable name="ConfigKeyDisp"/></ConfigKey>
+      <ConnectValueFromWidget>false</ConnectValueFromWidget>
+    </Connection>
+  </PlayButton>
+</Template>

--- a/res/skins/LateNight/decks/row_5_transportLoopJump.xml
+++ b/res/skins/LateNight/decks/row_5_transportLoopJump.xml
@@ -71,7 +71,7 @@
                 <Layout>stacked</Layout>
                 <Size>68f,26f</Size>
                 <Children>
-                  <Template src="skins:LateNight/controls/button_2state_right_display.xml">
+                  <Template src="skins:LateNight/controls/button_play_2state_right_display.xml">
                     <SetVariable name="TooltipId">play_cue_set</SetVariable>
                     <SetVariable name="ObjectName">PlayDeck</SetVariable>
                     <SetVariable name="Size">68f,26f</SetVariable>

--- a/res/skins/LateNight/samplers/sampler.xml
+++ b/res/skins/LateNight/samplers/sampler.xml
@@ -85,7 +85,7 @@
                         <Layout>stacked</Layout>
                         <SizePolicy>max,max</SizePolicy>
                         <Children>
-                          <Template src="skins:LateNight/controls/button_2state_right_display.xml">
+                          <Template src="skins:LateNight/controls/button_play_2state_right_display.xml">
                             <SetVariable name="TooltipId">cue_gotoandplay_cue_default</SetVariable>
                             <SetVariable name="ObjectName">PlaySampler</SetVariable>
                             <SetVariable name="Size">34f,34f</SetVariable>

--- a/res/skins/Shade/mixer_panel.xml
+++ b/res/skins/Shade/mixer_panel.xml
@@ -121,9 +121,10 @@
                 </Connection>
               </PushButton>
               <!-- Play -->
-              <PushButton>
+              <PlayButton>
                 <TooltipId>play_cue_set</TooltipId>
                 <Pos>11,200</Pos>
+                <Group>[Channel1]</Group>
                 <NumberStates>2</NumberStates>
                 <State>
                   <Number>0</Number>
@@ -147,7 +148,7 @@
                   <ConfigKey>[Channel1],play_latched</ConfigKey>
                   <ConnectValueFromWidget>false</ConnectValueFromWidget>
                 </Connection>
-              </PushButton>
+              </PlayButton>
 
               <!-- Play deck 2 -->
               <!-- Play indicator, blinks depending on Cue mode -->
@@ -185,9 +186,10 @@
                 </Connection>
               </PushButton>
               <!-- Play -->
-              <PushButton>
+              <PlayButton>
                 <TooltipId>play_cue_set</TooltipId>
                 <Pos>203,200</Pos>
+                <Group>[Channel2]</Group>
                 <NumberStates>2</NumberStates>
                 <State>
                   <Number>0</Number>
@@ -211,7 +213,7 @@
                   <ConfigKey>[Channel2],play_latched</ConfigKey>
                   <ConnectValueFromWidget>false</ConnectValueFromWidget>
                 </Connection>
-              </PushButton>
+              </PlayButton>
 
               <!--
               **********************************************

--- a/res/skins/Shade/sampler.xml
+++ b/res/skins/Shade/sampler.xml
@@ -131,8 +131,9 @@
                     </Connection>
                   </PushButton>
                   <!-- Play -->
-                  <PushButton>
+                  <PlayButton>
                     <TooltipId>cue_gotoandplay_cue_default</TooltipId>
+                    <Group><Variable name="group"/></Group>
                     <Pos>3,7</Pos>
                     <NumberStates>2</NumberStates>
                     <RightClickIsPushButton>true</RightClickIsPushButton>
@@ -156,7 +157,7 @@
                     <Connection>
                       <ConfigKey><Variable name="group"/>,play_latched</ConfigKey>
                     </Connection>
-                  </PushButton>
+                  </PlayButton>
                 </Children>
               </WidgetGroup>
 

--- a/res/skins/Tango/controls/button_play_2state_right_display.xml
+++ b/res/skins/Tango/controls/button_play_2state_right_display.xml
@@ -1,0 +1,58 @@
+<!--
+Description:
+  A button that has click or display controls.
+  Left-click control is one of the play controls.
+  HotcueButtons of the same player (engine, not necessarily same player in skin)
+  can be dropped onto it in order to latch play when previewing from hotcue.
+
+  Make sure to use one of the 'play' ToolTipIDs so the dnd behavior is discoverable.
+
+Variables:
+  ObjectName        : object name
+  ToolTipID         : standard Tooltip from mixxx db
+    see: https://github.com/mixxxdj/mixxx/blob/main/src/skin/legacy/tooltips.cpp
+  Size              : button size
+  state_X_text      : label text for state X
+  state_X_pressed   : background graphic for pressed state X
+  state_X_unpressed : background graphic for unpressed state X
+  Align             : alignment of text
+  ConfigKey         : left-click control
+  ConfigKeyRight    : right-click control
+  ConfigKeyDisp     : display control
+-->
+<Template>
+  <PlayButton>
+    <TooltipId><Variable name="TooltipId"/></TooltipId>
+    <ObjectName><Variable name="ObjectName"/></ObjectName>
+    <Size><Variable name="Size"/></Size>
+    <NumberStates>2</NumberStates>
+    <RightClickIsPushButton>true</RightClickIsPushButton>
+    <Group><Variable name="group"/></Group>
+    <State>
+      <Number>0</Number>
+      <Text><Variable name="state_0_text"/></Text>
+      <Alignment><Variable name="Align"/></Alignment>
+      <Pressed scalemode="STRETCH_ASPECT">skins:Tango/buttons/btn_<Variable name="state_0_icon"/></Pressed>
+      <Unpressed scalemode="STRETCH_ASPECT">skins:Tango/buttons/btn_<Variable name="state_0_icon"/></Unpressed>
+    </State>
+    <State>
+      <Number>1</Number>
+      <Text><Variable name="state_1_text"/></Text>
+      <Alignment><Variable name="Align"/></Alignment>
+      <Pressed scalemode="STRETCH_ASPECT">skins:Tango/buttons/btn_<Variable name="state_1_icon"/></Pressed>
+      <Unpressed scalemode="STRETCH_ASPECT">skins:Tango/buttons/btn_<Variable name="state_1_icon"/></Unpressed>
+    </State>
+    <Connection>
+      <ConfigKey><Variable name="ConfigKey"/></ConfigKey>
+      <ButtonState>LeftButton</ButtonState>
+    </Connection>
+    <Connection>
+      <ConfigKey><Variable name="ConfigKeyRight"/></ConfigKey>
+      <ButtonState>RightButton</ButtonState>
+    </Connection>
+    <Connection>
+      <ConfigKey><Variable name="ConfigKeyDisp"/></ConfigKey>
+      <ConnectValueFromWidget>false</ConnectValueFromWidget>
+    </Connection>
+  </PlayButton>
+</Template>

--- a/res/skins/Tango/decks/row_transport_left.xml
+++ b/res/skins/Tango/decks/row_transport_left.xml
@@ -222,7 +222,7 @@ Variables:
             <Size>50f,24f</Size>
             <Children>
               <!-- Play -->
-              <Template src="skins:Tango/controls/button_2state_right_display.xml">
+              <Template src="skins:Tango/controls/button_play_2state_right_display.xml">
                 <SetVariable name="ObjectName">PlayCue</SetVariable>
                 <SetVariable name="TooltipId">play_cue_set</SetVariable>
                 <SetVariable name="Size">50f,24f</SetVariable>

--- a/res/skins/Tango/decks/row_transport_right.xml
+++ b/res/skins/Tango/decks/row_transport_right.xml
@@ -24,7 +24,7 @@ Variables:
         <Size>50f,24f</Size>
         <Children>
           <!-- Play -->
-          <Template src="skins:Tango/controls/button_2state_right_display.xml">
+          <Template src="skins:Tango/controls/button_play_2state_right_display.xml">
             <SetVariable name="ObjectName">PlayCue</SetVariable>
             <SetVariable name="TooltipId">play_cue_set</SetVariable>
             <SetVariable name="Size">50f,24f</SetVariable>

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -63,6 +63,7 @@
 #include "widget/wnumberrate.h"
 #include "widget/woverview.h"
 #include "widget/wpixmapstore.h"
+#include "widget/wplaybutton.h"
 #include "widget/wpushbutton.h"
 #include "widget/wraterange.h"
 #include "widget/wrecordingduration.h"
@@ -536,6 +537,8 @@ QList<QWidget*> LegacySkinParser::parseNode(const QDomElement& node) {
         result = wrapWidget(parseStandardWidget<WSliderComposed>(node));
     } else if (nodeName == "PushButton") {
         result = wrapWidget(parseStandardWidget<WPushButton>(node));
+    } else if (nodeName == "PlayButton") {
+        result = wrapWidget(parsePlayButton(node));
     } else if (nodeName == "EffectPushButton") {
         result = wrapWidget(parseEffectPushButton(node));
     } else if (nodeName == "HotcueButton") {
@@ -1938,6 +1941,18 @@ QWidget* LegacySkinParser::parseHotcueButton(const QDomElement& element) {
             controlFromConfigKey(pWidget->getClearConfigKey(), false),
             ControlParameterWidgetConnection::EmitOption::EMIT_ON_PRESS_AND_RELEASE);
 
+    pWidget->Init();
+    return pWidget;
+}
+
+QWidget* LegacySkinParser::parsePlayButton(const QDomElement& element) {
+    QString group = lookupNodeGroup(element);
+    WPlayButton* pWidget = new WPlayButton(m_pParent, group);
+    commonWidgetSetup(element, pWidget);
+    pWidget->setup(element, *m_pContext);
+    pWidget->installEventFilter(m_pKeyboard);
+    pWidget->installEventFilter(
+            m_pControllerManager->getControllerLearningEventFilter());
     pWidget->Init();
     return pWidget;
 }

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -1917,7 +1917,7 @@ QString LegacySkinParser::getSharedGroupString(const QString& channelStr) {
 
 QWidget* LegacySkinParser::parseHotcueButton(const QDomElement& element) {
     QString group = lookupNodeGroup(element);
-    WHotcueButton* pWidget = new WHotcueButton(group, m_pParent);
+    WHotcueButton* pWidget = new WHotcueButton(m_pParent, group);
     commonWidgetSetup(element, pWidget);
     pWidget->setup(element, *m_pContext);
     pWidget->installEventFilter(m_pKeyboard);

--- a/src/skin/legacy/legacyskinparser.h
+++ b/src/skin/legacy/legacyskinparser.h
@@ -101,6 +101,7 @@ class LegacySkinParser : public QObject, public SkinParser {
     QWidget* parseEffectPushButton(const QDomElement& node);
     QWidget* parseEffectSelector(const QDomElement& node);
     QWidget* parseHotcueButton(const QDomElement& node);
+    QWidget* parsePlayButton(const QDomElement& node);
 
     // Legacy pre-1.12.0 skin support.
     QWidget* parseBackground(const QDomElement& node, QWidget* pOuterWidget, QWidget* pInnerWidget);

--- a/src/skin/legacy/tooltips.cpp
+++ b/src/skin/legacy/tooltips.cpp
@@ -534,8 +534,13 @@ void Tooltips::addStandardTooltips() {
     // Currently used for samplers
     add("play_start")
             << tr("Play/Pause")
-            << QString("%1: %2").arg(leftClick, tr("Starts playing from the beginning of the track."))
-            << QString("%1: %2").arg(rightClick, tr("Jumps to the beginning of the track and stops."));
+            << QString("%1: %2").arg(leftClick,
+                       tr("Starts playing from the beginning of the track."))
+            << QString("%1: %2").arg(rightClick,
+                       tr("Jumps to the beginning of the track and stops."))
+            << " " // add linebreak, '\n' would result in two linebreaks
+            << tr("Drag a Hotcue button here to continue playing after "
+                  "releasing the Hotcue.");
 
     QString whilePlaying = tr("(while playing)");
     QString whileStopped = tr("(while stopped)");
@@ -552,7 +557,10 @@ void Tooltips::addStandardTooltips() {
             << tr("Play/Pause")
             << QString("%1: %2").arg(leftClick, tr("Plays or pauses the track."))
             << QString("%1 %2: %3").arg(leftClick, whilePreviewing, latchingPlay)
-            << QString("%1: %2").arg(rightClick, cueSet);
+            << QString("%1: %2").arg(rightClick, cueSet)
+            << " " // add linebreak, '\n' would result in two linebreaks
+            << tr("Drag a Hotcue button here to continue playing after "
+                  "releasing the Hotcue.");
 
     // Currently used for minimal decks
     add("play_cue_default")
@@ -561,7 +569,10 @@ void Tooltips::addStandardTooltips() {
             << QString("%1 %2: %3").arg(rightClick, whilePlaying, cueWhilePlaying)
             << QString("%1 %2: %3").arg(rightClick, whileStopped, cueWhileStopped)
             << cueHint
-            << quantizeSnap;
+            << quantizeSnap
+            << " " // add linebreak, '\n' would result in two linebreaks
+            << tr("Drag a Hotcue button here to continue playing after "
+                  "releasing the Hotcue.");
     add("cue_default_cue_gotoandstop")
             << tr("Cue")
             << QString("%1 %2: %3").arg(leftClick, whilePlaying, cueWhilePlaying)
@@ -703,8 +714,10 @@ void Tooltips::addStandardTooltips() {
                   << tr("Drag this button onto another Hotcue button to move it "
                         "there (change its index). If the other hotcue is set, "
                         "the two are swapped.")
+                  << tr("Drag this button onto a Play button while previewing "
+                        "to continue playback after release.")
                   << tr("Dragging with Shift key pressed will not start previewing "
-                        "the hotcue");
+                        "the hotcue.");
 
     // Status displays and toggle buttons
     add("toggle_recording")

--- a/src/widget/hotcuedrag.cpp
+++ b/src/widget/hotcuedrag.cpp
@@ -1,0 +1,67 @@
+#include <widget/hotcuedrag.h>
+
+#include <QDragEnterEvent>
+#include <QMouseEvent>
+
+#include "mixer/playerinfo.h"
+#include "track/track.h"
+
+namespace mixxx {
+
+namespace hotcuedrag {
+
+/// Check if the event is a valid hotcue drag or drop event.
+/// Event must be a QDragEnterEvent or a QDropEvent.
+/// In case of QDropEvent, the HotcueDragInfo is extracted and the pointer
+/// data is used by the caller (WHotcueButton) to swap hotuces.
+template<typename T>
+bool isValidHotcueDragOrDropEvent(T* pEvent,
+        const QString& group,
+        QObject* pTarget = nullptr,
+        int ignoreHotcueIndex = Cue::kNoHotCue,
+        HotcueDragInfo* pDragData = nullptr) {
+    constexpr bool isDrag = std::same_as<QDragEnterEvent, T>;
+    // Allow source == target in the drag case so we get the drag cursor
+    // (i.e. not the 'drop rejected' cursor) when starting the drag and when
+    // dragging over the source later on.
+    // Same exception for hotcue index check below.
+    if (!isDrag && pEvent->source() == pTarget) {
+        return false;
+    }
+    TrackPointer pTrack = PlayerInfo::instance().getTrackInfo(group);
+    if (!pTrack) {
+        return false;
+    }
+    const QByteArray mimeDataBytes = pEvent->mimeData()->data(kDragMimeType);
+    if (mimeDataBytes.isEmpty()) {
+        return false;
+    }
+    const HotcueDragInfo dragData = HotcueDragInfo::fromByteArray(mimeDataBytes);
+    if (dragData.isValid() &&
+            (isDrag || dragData.hotcue != ignoreHotcueIndex) &&
+            dragData.trackId == pTrack->getId()) {
+        if (pDragData != nullptr) {
+            *pDragData = dragData;
+        }
+        return true;
+    }
+    return false;
+};
+
+bool isValidHotcueDragEvent(QDragEnterEvent* pEvent,
+        const QString& group,
+        int ignoreHotcueIndex) {
+    return isValidHotcueDragOrDropEvent(pEvent, group, nullptr, ignoreHotcueIndex);
+}
+
+bool isValidHotcueDropEvent(QDropEvent* pEvent,
+        const QString& group,
+        QObject* pTarget,
+        int ignoreHotcueIndex,
+        HotcueDragInfo* pDragData) {
+    return isValidHotcueDragOrDropEvent(pEvent, group, pTarget, ignoreHotcueIndex, pDragData);
+}
+
+} // namespace hotcuedrag
+
+} // namespace mixxx

--- a/src/widget/hotcuedrag.h
+++ b/src/widget/hotcuedrag.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <QBuffer>
+#include <QMimeData>
+#include <QString>
+
+#include "track/cue.h"
+#include "track/trackid.h"
+
+const QString kDragMimeType = QStringLiteral("hotcueDragInfo");
+
+class TrackId;
+class QDragEnterEvent;
+class QDropEvent;
+
+namespace mixxx {
+
+namespace hotcuedrag {
+
+struct HotcueDragInfo {
+    constexpr HotcueDragInfo() {};
+    constexpr HotcueDragInfo(TrackId id, int cue)
+            : trackId(id),
+              hotcue(cue) {};
+
+    static HotcueDragInfo fromByteArray(const QByteArray& bytes) {
+        QDataStream stream(bytes);
+        TrackId trackId;
+        int hotcue;
+        stream >> trackId >> hotcue;
+        return HotcueDragInfo(trackId, hotcue);
+    };
+
+    QByteArray toByteArray() const {
+        QByteArray bytes;
+        QDataStream dataStream(&bytes, QIODevice::WriteOnly);
+        dataStream << trackId << hotcue;
+        return bytes;
+    };
+
+    bool isValid() const {
+        return trackId.isValid() && hotcue != Cue::kNoHotCue;
+    }
+
+    TrackId trackId = TrackId();
+    int hotcue = Cue::kNoHotCue;
+};
+
+/// These check if the event is a valid hotcue drag or drop event.
+/// Event must be a QDragEnterEvent or a QDropEvent.
+/// In case of QDropEvent, the HotcueDragInfo is extracted from the QDrag and
+/// assigned to the passed pointer. It's used by the caller (WHotcueButton)
+/// to swap hotuces.
+bool isValidHotcueDragEvent(QDragEnterEvent* pEvent,
+        const QString& group,
+        int ignoreHotcueIndex = Cue::kNoHotCue);
+bool isValidHotcueDropEvent(QDropEvent* pEvent,
+        const QString& group,
+        QObject* pTarget,
+        int ignoreHotcueIndex = Cue::kNoHotCue,
+        HotcueDragInfo* pDragData = nullptr);
+
+} // namespace hotcuedrag
+
+} // namespace mixxx

--- a/src/widget/whotcuebutton.h
+++ b/src/widget/whotcuebutton.h
@@ -2,44 +2,14 @@
 
 #include <QString>
 
-#include "track/trackid.h"
 #include "util/parented_ptr.h"
 #include "widget/wcuemenupopup.h"
 #include "widget/wpushbutton.h"
 
 class WHotcueButton : public WPushButton {
     Q_OBJECT
-
-    struct HotcueDragInfo {
-        HotcueDragInfo(TrackId id, int cue)
-                : trackId(id),
-                  hotcue(cue) {};
-
-        static HotcueDragInfo fromByteArray(const QByteArray& bytes) {
-            QDataStream stream(bytes);
-            TrackId trackId;
-            int hotcue;
-            stream >> trackId >> hotcue;
-            return HotcueDragInfo(trackId, hotcue);
-        };
-
-        QByteArray toByteArray() {
-            QByteArray bytes;
-            QDataStream dataStream(&bytes, QIODevice::WriteOnly);
-            dataStream << trackId << hotcue;
-            return bytes;
-        };
-
-        bool isValid() {
-            return trackId.isValid() && hotcue != Cue::kNoHotCue;
-        }
-
-        TrackId trackId = TrackId();
-        int hotcue = Cue::kNoHotCue;
-    };
-
   public:
-    WHotcueButton(const QString& group, QWidget* pParent);
+    WHotcueButton(QWidget* pParent, const QString& group);
 
     void setup(const QDomNode& node, const SkinContext& context) override;
 
@@ -60,7 +30,6 @@ class WHotcueButton : public WPushButton {
     void mouseMoveEvent(QMouseEvent* pEvent) override;
     void dragEnterEvent(QDragEnterEvent* pEvent) override;
     void dropEvent(QDropEvent* pEvent) override;
-
     void restyleAndRepaint() override;
 
   private slots:

--- a/src/widget/wplaybutton.cpp
+++ b/src/widget/wplaybutton.cpp
@@ -1,0 +1,40 @@
+#include "widget/wplaybutton.h"
+
+#include <QMouseEvent>
+
+#include "control/controlobject.h"
+#include "moc_wplaybutton.cpp"
+#include "widget/hotcuedrag.h"
+
+using namespace mixxx::hotcuedrag;
+
+WPlayButton::WPlayButton(QWidget* pParent, const QString& group)
+        : WPushButton(pParent),
+          m_group(group) {
+    setAcceptDrops(true);
+}
+
+void WPlayButton::dragEnterEvent(QDragEnterEvent* pEvent) {
+    if (isValidHotcueDragEvent(pEvent, m_group)) {
+        pEvent->acceptProposedAction();
+    } else {
+        pEvent->ignore();
+    }
+}
+
+void WPlayButton::dropEvent(QDropEvent* pEvent) {
+    // Enable 'play' if we drop a hotcue here while we're
+    // previewing it but NOT playing.
+    // If not previewing this is no-op.
+    if (ControlObject::get(ConfigKey(m_group, QStringLiteral("play_latched"))) <= 0 &&
+            isValidHotcueDropEvent(pEvent, m_group, this)) {
+        // This seems counterintuitive but it's the same action that
+        // allows to latch `play` with keyboard or controllers while
+        // previewing a hotcue.
+        // See EngineBuffer::slotControlPlayRequest()
+        ControlObject::set(ConfigKey(m_group, QStringLiteral("play")), 0.0);
+        pEvent->accept();
+    } else {
+        pEvent->ignore();
+    }
+}

--- a/src/widget/wplaybutton.h
+++ b/src/widget/wplaybutton.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "widget/wpushbutton.h"
+
+struct HotcueDragInfo;
+
+class WPlayButton : public WPushButton {
+    Q_OBJECT
+  public:
+    WPlayButton(QWidget* pParent, const QString& group);
+
+  private:
+    void dragEnterEvent(QDragEnterEvent* pEvent) override;
+    void dropEvent(QDropEvent* pEvent) override;
+
+    QString m_group;
+};

--- a/src/widget/wpushbutton.h
+++ b/src/widget/wpushbutton.h
@@ -75,7 +75,6 @@ class WPushButton : public WWidget {
     void focusOutEvent(QFocusEvent* e) override;
     void fillDebugTooltip(QStringList* debug) override;
 
-  protected:
     virtual void restyleAndRepaint();
 
     // Associates a pixmap of a given state of the button with the widget


### PR DESCRIPTION
Finally implementing #9570

* (deck is stopped)
* click and hold Hotcue to preview / stutter-play
* "Oh, sounds good, I want to continue!"
* move cursor to initiate drag
* drop onto Play button
* = 'play' latched, playback continues on mouse release

Previously this was possible only if two buttons could be pressed simultaneously, ie. with controllers, with mouse and keyboard mapping or multitouch (screens).

### Note:
Only works with the new `PlayButton` (inherits WPushButton) which requires a valid `Group` set in xml (like WHotcueButton, `<Group>[Channel1]</Group>`) and can currently be tested with **LateNight** only (in decks that have hotcue buttons, so normal decks and samplers).

### TODO
- [ ] update all skins