### PR TITLE
Numark Mixtrack 3: update library controls

### DIFF
--- a/res/controllers/Numark-Mixtrack-3-scripts.js
+++ b/res/controllers/Numark-Mixtrack-3-scripts.js
@@ -4,25 +4,25 @@
  **********************************************************************/
 // TrackEndWarning: "true": when you reach the end of the track,
 // the jog wheel Button will flash. "false": No flash of Jog Wheel Button
-var TrackEndWarning = true;
+const TrackEndWarning = engine.getSetting("TrackEndWarning") === "true";
 
 //iCutEnabled: iCut mode will automatically cut your track with the cross fader
 // when SHIFT enabled and scratching with the jog wheel
-var iCutEnabled = true;
+const iCutEnabled = engine.getSetting("iCutEnabled") === "true";
 
 //activate PFL of deck on track load
-var smartPFL = true;
+const smartPFL = engine.getSetting("smartPFL") === "true";
 
 //Disable Play on Sync button Double Press
-var noPlayOnSyncDoublePress = false;
+const noPlayOnSyncDoublePress = engine.getSetting("noPlayOnSyncDoublePress") === "true";
 
 // Shift+Filter control behavior
 // true (default) - FX parameter 4 (when the FX is focused)
 // false - Channel Gain
-var ShiftFilterFX4 = true;
+const ShiftFilterFX4 = engine.getSetting("ShiftFilterFX4") === "true";
 
 // allow pitch bend with wheel when wheel is not active
-var PitchBendOnWheelOff = true;
+const PitchBendOnWheelOff = engine.getSetting("PitchBendOnWheelOff") === "true";
 
 /**************************
  *  scriptpause
@@ -1078,24 +1078,34 @@ NumarkMixtrack3.PlayButton = function(channel, control, value, status, group) {
 };
 
 NumarkMixtrack3.BrowseButton = function(channel, control, value, status, group) {
-    var shifted = (NumarkMixtrack3.decks.D1.shiftKey || NumarkMixtrack3.decks.
-        D2.shiftKey || NumarkMixtrack3.decks.D3.shiftKey || NumarkMixtrack3.decks.D4.shiftKey);
+    const shifted = (
+        NumarkMixtrack3.decks.D1.shiftKey || NumarkMixtrack3.decks.D2.shiftKey ||
+        NumarkMixtrack3.decks.D3.shiftKey || NumarkMixtrack3.decks.D4.shiftKey
+    );
 
     if (value === ON) {
-	    if (shifted) {
-	        // SHIFT + BROWSE push : directory mode -- > Open/Close selected side bar item
-	        engine.setValue("[Library]", "GoToItem", true);
-	    } else {
-	        // Browse push : maximize/minimize library view
-	        if (value === ON) {
-	            script.toggleControl("[Skin]", "show_maximized_library");
-	        }
-	    }
+        if (engine.getSetting("libraryMode") === "focus") {
+            if (shifted) {
+                // SHIFT + BROWSE push : maximize/minimize library view
+                script.toggleControl("[Skin]", "show_maximized_library");
+            } else {
+                // Browse push : expand sidebar item or load track when in track table
+                engine.setValue("[Library]", "GoToItem", true);
+            }
+        } else { // Classic mode
+            if (shifted) {
+                // SHIFT + BROWSE push : directory mode -- > Open/Close selected side bar item
+                engine.setValue("[Library]", "GoToItem", true);
+            } else {
+                // Browse push : maximize/minimize library view
+                script.toggleControl("[Skin]", "show_maximized_library");
+            }
+        }
     }
 };
 
 NumarkMixtrack3.BrowseKnob = function(channel, control, value, status, group) {
-    var shifted = (
+    const shifted = (
         NumarkMixtrack3.decks.D1.shiftKey || NumarkMixtrack3.decks.D2.shiftKey ||
         NumarkMixtrack3.decks.D3.shiftKey || NumarkMixtrack3.decks.D4.shiftKey
     );
@@ -1103,11 +1113,20 @@ NumarkMixtrack3.BrowseKnob = function(channel, control, value, status, group) {
     // value = 1 / 2 / 3 ... for positive //value = 1 / 2 / 3
     var nval = (value > 0x40 ? value - 0x80 : value);
 
-    // SHIFT+Turn BROWSE Knob : directory mode --> select Play List/Side bar item
-    if (shifted) {
-        engine.setValue("[Playlist]", "SelectPlaylist", nval);
-    } else {
-        engine.setValue("[Playlist]", "SelectTrackKnob", nval);
+    if (engine.getSetting("libraryMode") === "focus") {
+        // SHIFT+Turn BROWSE Knob : change focus between search, track table, and sidebar
+        if (shifted) {
+            engine.setValue("[Library]", "MoveFocus", nval);
+        } else {
+            engine.setValue("[Library]", "MoveVertical", nval);
+        }
+    } else { // Classic mode
+        // SHIFT+Turn BROWSE Knob : directory mode --> select Play List/Side bar item
+        if (shifted) {
+            engine.setValue("[Playlist]", "SelectPlaylist", nval);
+        } else {
+            engine.setValue("[Playlist]", "SelectTrackKnob", nval);
+        }
     }
 };
 

--- a/res/controllers/Numark-Mixtrack-3.midi.xml
+++ b/res/controllers/Numark-Mixtrack-3.midi.xml
@@ -8,6 +8,76 @@
         <forums>https://mixxx.discourse.group/t/mixtrack-pro-3/15165</forums>
         <wiki>http://www.mixxx.org/wiki/doku.php/numark_mixtrack_pro_3</wiki>
     </info>
+    <settings>
+        <option
+            variable="libraryMode"
+            label="Navigation mode"
+            type="enum">
+            <value label="Focus" default="true">focus</value>
+            <value label="Classic">classic</value>
+            <description>
+                In Focus mode the Browse encoder affects the library widget which currently has keyboard focus.
+                This requires the Mixxx window to have focus and allows to control the searchbar, too.
+
+                In Classic mode the Browse encoder can select items in the sidebar and tracks table only, but independent
+                of keyboard focus.
+            </description>
+        </option>
+        <option
+            variable="TrackEndWarning"
+            label="Track End Warning"
+            type="boolean"
+            default="true">
+            <description>
+                The jog wheel button flashes near the end of a track.
+            </description>
+        </option>
+        <option
+            variable="iCutEnabled"
+            label="Enable iCut Mode"
+            type="boolean"
+            default="true">
+            <description>
+                When enabled, scratching with SHIFT automatically cuts the track using the crossfader.
+            </description>
+        </option>
+        <option
+            variable="smartPFL"
+            label="Smart PFL on Track Load"
+            type="boolean"
+            default="true">
+            <description>
+                Automatically activates the deck’s PFL (headphone cue) when a track is loaded.
+            </description>
+        </option>
+        <option
+            variable="noPlayOnSyncDoublePress"
+            label="Disable Play on Sync Double-Press"
+            type="boolean"
+            default="false">
+            <description>
+                Prevents the Sync button from triggering Play when double-pressed.
+            </description>
+        </option>
+        <option
+            variable="ShiftFilterFX4"
+            label="Shift + Filter Controls FX4 (not Gain)"
+            type="boolean"
+            default="true">
+            <description>
+                When true, Shift + Filter adjusts FX parameter 4. When false, it controls channel gain.
+            </description>
+        </option>
+        <option
+            variable="PitchBendOnWheelOff"
+            label="Pitch-bend with Wheel when Scratch is Off"
+            type="boolean"
+            default="true">
+            <description>
+                Allows pitch-bend using the jog wheel even when scratch mode is disabled.
+            </description>
+        </option>
+    </settings>
     <controller id="Mixtrack3">
         <scriptfiles>
             <file functionprefix="NumarkMixtrack3" filename="Numark-Mixtrack-3-scripts.js" />


### PR DESCRIPTION
Improve Browse knob/button behaviour by allowing focus shift between search, sidebar, and track table with Shift+turn Browse.

Further discussion: mixxxdj#14165

**edit**(@ronso0)
> The below is what I've settled on and I think it works well and minimises usage of the Shift button to create a simpler mapping.

- Turn: scroll through focused library element
- Shift + turn: move focus between search/sidebar/track table
- Press: expand sidebar item or load track (depending on focus)
- Shift + press: minimise/maximise library