### PR TITLE
build: add missing deps for RPM systems

### DIFF
--- a/tools/rpm_buildenv.sh
+++ b/tools/rpm_buildenv.sh
@@ -53,6 +53,7 @@ case "$1" in
             lilv-devel \
             mesa-libGL-devel \
             mesa-libGLU-devel \
+            mold \
             ninja-build \
             opus-devel \
             opusfile-devel \


### PR DESCRIPTION
Found couple of missing dependencies when installing on Fedora 41 using a Toolbox