### PR TITLE
beat waveformrenderer using rendergraph

### DIFF
--- a/src/waveform/renderers/allshader/waveformrenderbeat.cpp
+++ b/src/waveform/renderers/allshader/waveformrenderbeat.cpp
@@ -2,34 +2,49 @@
 
 #include <QDomNode>
 
+#include "rendergraph/geometry.h"
+#include "rendergraph/material/unicolormaterial.h"
+#include "rendergraph/vertexupdaters/vertexupdater.h"
 #include "skin/legacy/skincontext.h"
 #include "track/track.h"
-#include "waveform/renderers/allshader/matrixforwidgetgeometry.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
 #include "widget/wskincolor.h"
+
+using namespace rendergraph;
 
 namespace allshader {
 
 WaveformRenderBeat::WaveformRenderBeat(WaveformWidgetRenderer* waveformWidget,
         ::WaveformRendererAbstract::PositionSource type)
-        : WaveformRenderer(waveformWidget),
+        : ::WaveformRendererAbstract(waveformWidget),
           m_isSlipRenderer(type == ::WaveformRendererAbstract::Slip) {
+    initForRectangles<UniColorMaterial>(0);
+    setUsePreprocess(true);
 }
 
-void WaveformRenderBeat::initializeGL() {
-    m_shader.init();
-}
-
-void WaveformRenderBeat::setup(const QDomNode& node, const SkinContext& context) {
-    m_color = QColor(context.selectString(node, "BeatColor"));
+void WaveformRenderBeat::setup(const QDomNode& node, const SkinContext& skinContext) {
+    m_color = QColor(skinContext.selectString(node, "BeatColor"));
     m_color = WSkinColor::getCorrectColor(m_color).toRgb();
 }
 
-void WaveformRenderBeat::paintGL() {
-    TrackPointer trackInfo = m_waveformRenderer->getTrackInfo();
+void WaveformRenderBeat::draw(QPainter* painter, QPaintEvent* event) {
+    Q_UNUSED(painter);
+    Q_UNUSED(event);
+    DEBUG_ASSERT(false);
+}
+
+void WaveformRenderBeat::preprocess() {
+    if (!preprocessInner()) {
+        geometry().allocate(0);
+        markDirtyGeometry();
+    }
+}
+
+bool WaveformRenderBeat::preprocessInner() {
+    const TrackPointer trackInfo = m_waveformRenderer->getTrackInfo();
 
     if (!trackInfo || (m_isSlipRenderer && !m_waveformRenderer->isSlipActive())) {
-        return;
+        return false;
     }
 
     auto positionType = m_isSlipRenderer ? ::WaveformRendererAbstract::Slip
@@ -37,24 +52,21 @@ void WaveformRenderBeat::paintGL() {
 
     mixxx::BeatsPointer trackBeats = trackInfo->getBeats();
     if (!trackBeats) {
-        return;
+        return false;
     }
 
     int alpha = m_waveformRenderer->getBeatGridAlpha();
     if (alpha == 0) {
-        return;
+        return false;
     }
 
     const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
 
-    glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-
     m_color.setAlphaF(alpha / 100.0f);
 
     const double trackSamples = m_waveformRenderer->getTrackSamples();
-    if (trackSamples <= 0) {
-        return;
+    if (trackSamples <= 0.0) {
+        return false;
     }
 
     const double firstDisplayedPosition =
@@ -68,7 +80,7 @@ void WaveformRenderBeat::paintGL() {
             lastDisplayedPosition * trackSamples);
 
     if (!startPosition.isValid() || !endPosition.isValid()) {
-        return;
+        return false;
     }
 
     const float rendererBreadth = m_waveformRenderer->getBreadth();
@@ -87,8 +99,9 @@ void WaveformRenderBeat::paintGL() {
     }
 
     const int reserved = numBeatsInRange * numVerticesPerLine;
-    m_vertices.clear();
-    m_vertices.reserve(reserved);
+    geometry().allocate(reserved);
+
+    VertexUpdater vertexUpdater{geometry().vertexDataAs<Geometry::Point2D>()};
 
     for (auto it = trackBeats->iteratorFrom(startPosition);
             it != trackBeats->cend() && *it <= endPosition;
@@ -103,33 +116,17 @@ void WaveformRenderBeat::paintGL() {
         const float x1 = static_cast<float>(xBeatPoint);
         const float x2 = x1 + 1.f;
 
-        m_vertices.addRectangle(x1,
-                0.f,
-                x2,
-                m_isSlipRenderer ? rendererBreadth / 2 : rendererBreadth);
+        vertexUpdater.addRectangle({x1, 0.f},
+                {x2, m_isSlipRenderer ? rendererBreadth / 2 : rendererBreadth});
     }
+    markDirtyGeometry();
 
-    DEBUG_ASSERT(reserved == m_vertices.size());
+    DEBUG_ASSERT(reserved == vertexUpdater.index());
 
-    const int positionLocation = m_shader.positionLocation();
-    const int matrixLocation = m_shader.matrixLocation();
-    const int colorLocation = m_shader.colorLocation();
+    material().setUniform(1, m_color);
+    markDirtyMaterial();
 
-    m_shader.bind();
-    m_shader.enableAttributeArray(positionLocation);
-
-    const QMatrix4x4 matrix = matrixForWidgetGeometry(m_waveformRenderer, false);
-
-    m_shader.setAttributeArray(
-            positionLocation, GL_FLOAT, m_vertices.constData(), 2);
-
-    m_shader.setUniformValue(matrixLocation, matrix);
-    m_shader.setUniformValue(colorLocation, m_color);
-
-    glDrawArrays(GL_TRIANGLES, 0, m_vertices.size());
-
-    m_shader.disableAttributeArray(positionLocation);
-    m_shader.release();
+    return true;
 }
 
 } // namespace allshader

--- a/src/waveform/renderers/allshader/waveformrenderbeat.cpp
+++ b/src/waveform/renderers/allshader/waveformrenderbeat.cpp
@@ -23,7 +23,7 @@ WaveformRenderBeat::WaveformRenderBeat(WaveformWidgetRenderer* waveformWidget,
 }
 
 void WaveformRenderBeat::setup(const QDomNode& node, const SkinContext& skinContext) {
-    m_color = QColor(skinContext.selectString(node, "BeatColor"));
+    m_color = QColor(skinContext.selectString(node, QStringLiteral("BeatColor")));
     m_color = WSkinColor::getCorrectColor(m_color).toRgb();
 }
 

--- a/src/waveform/renderers/allshader/waveformrenderbeat.h
+++ b/src/waveform/renderers/allshader/waveformrenderbeat.h
@@ -1,12 +1,11 @@
 #pragma once
 
 #include <QColor>
+#include <memory>
 
-#include "rendergraph/openglnode.h"
-#include "shaders/unicolorshader.h"
+#include "rendergraph/geometrynode.h"
 #include "util/class.h"
-#include "waveform/renderers/allshader/vertexdata.h"
-#include "waveform/renderers/allshader/waveformrenderer.h"
+#include "waveform/renderers/waveformrendererabstract.h"
 
 class QDomNode;
 class SkinContext;
@@ -16,23 +15,26 @@ class WaveformRenderBeat;
 }
 
 class allshader::WaveformRenderBeat final
-        : public allshader::WaveformRenderer,
-          public rendergraph::OpenGLNode {
+        : public ::WaveformRendererAbstract,
+          public rendergraph::GeometryNode {
   public:
     explicit WaveformRenderBeat(WaveformWidgetRenderer* waveformWidget,
             ::WaveformRendererAbstract::PositionSource type =
                     ::WaveformRendererAbstract::Play);
 
+    // Pure virtual from WaveformRendererAbstract, not used
+    void draw(QPainter* painter, QPaintEvent* event) override final;
+
     void setup(const QDomNode& node, const SkinContext& skinContext) override;
-    void paintGL() override;
-    void initializeGL() override;
+
+    // Virtuals for rendergraph::Node
+    void preprocess() override;
 
   private:
-    mixxx::UnicolorShader m_shader;
     QColor m_color;
-    VertexData m_vertices;
-
     bool m_isSlipRenderer;
+
+    bool preprocessInner();
 
     DISALLOW_COPY_AND_ASSIGN(WaveformRenderBeat);
 };


### PR DESCRIPTION
Ports the beat waveformrenderer to a rendergraph node. This can be reviewed and merged independently from the PRs for the other waveformrenderers.