### PR TITLE
signal waveformrenderers using rendergraph

### DIFF
--- a/src/waveform/renderers/allshader/waveformrendererfiltered.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererfiltered.cpp
@@ -1,10 +1,13 @@
 #include "waveform/renderers/allshader/waveformrendererfiltered.h"
 
+#include "rendergraph/material/rgbmaterial.h"
+#include "rendergraph/vertexupdaters/rgbvertexupdater.h"
 #include "track/track.h"
 #include "util/math.h"
-#include "waveform/renderers/allshader/matrixforwidgetgeometry.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
 #include "waveform/waveform.h"
+
+using namespace rendergraph;
 
 namespace allshader {
 
@@ -12,45 +15,56 @@ WaveformRendererFiltered::WaveformRendererFiltered(
         WaveformWidgetRenderer* waveformWidget, bool bRgbStacked)
         : WaveformRendererSignalBase(waveformWidget),
           m_bRgbStacked(bRgbStacked) {
+    initForRectangles<RGBMaterial>(0);
+    setUsePreprocess(true);
 }
 
 void WaveformRendererFiltered::onSetup(const QDomNode&) {
 }
 
-void WaveformRendererFiltered::initializeGL() {
-    m_shader.init();
+void WaveformRendererFiltered::preprocess() {
+    if (!preprocessInner()) {
+        if (geometry().vertexCount() != 0) {
+            geometry().allocate(0);
+            markDirtyGeometry();
+        }
+    }
 }
 
-void WaveformRendererFiltered::paintGL() {
+bool WaveformRendererFiltered::preprocessInner() {
     TrackPointer pTrack = m_waveformRenderer->getTrackInfo();
+
     if (!pTrack) {
-        return;
+        return false;
     }
 
     ConstWaveformPointer waveform = pTrack->getWaveform();
     if (waveform.isNull()) {
-        return;
+        return false;
     }
 
     const int dataSize = waveform->getDataSize();
     if (dataSize <= 1) {
-        return;
+        return false;
     }
 
     const WaveformData* data = waveform->data();
     if (data == nullptr) {
-        return;
+        return false;
     }
 #ifdef __STEM__
     auto stemInfo = pTrack->getStemInfo();
     // If this track is a stem track, skip the rendering
     if (!stemInfo.isEmpty() && waveform->hasStem()) {
-        return;
+        return false;
     }
 #endif
 
     const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
-    const int length = static_cast<int>(m_waveformRenderer->getLength() * devicePixelRatio);
+    const int length = static_cast<int>(m_waveformRenderer->getLength());
+    const int pixelLength = static_cast<int>(m_waveformRenderer->getLength() * devicePixelRatio);
+    const float invDevicePixelRatio = 1.f / devicePixelRatio;
+    const float halfPixelSize = 0.5 / devicePixelRatio;
 
     // See waveformrenderersimple.cpp for a detailed explanation of the frame and index calculation
     const int visualFramesSize = dataSize / 2;
@@ -61,14 +75,14 @@ void WaveformRendererFiltered::paintGL() {
 
     // Represents the # of visual frames per horizontal pixel.
     const double visualIncrementPerPixel =
-            (lastVisualFrame - firstVisualFrame) / static_cast<double>(length);
+            (lastVisualFrame - firstVisualFrame) / static_cast<double>(pixelLength);
 
     // Per-band gain from the EQ knobs.
-    float allGain{1.0};
+    float allGain(1.0);
     float bandGain[3] = {1.0, 1.0, 1.0};
     getGains(&allGain, true, &bandGain[0], &bandGain[1], &bandGain[2]);
 
-    const float breadth = static_cast<float>(m_waveformRenderer->getBreadth()) * devicePixelRatio;
+    const float breadth = static_cast<float>(m_waveformRenderer->getBreadth());
     const float halfBreadth = breadth / 2.0f;
 
     const float heightFactor = allGain * halfBreadth / m_maxValue;
@@ -79,28 +93,55 @@ void WaveformRendererFiltered::paintGL() {
 
     const int numVerticesPerLine = 6; // 2 triangles
 
-    int reserved[4];
-    // low, mid, high
-    for (int bandIndex = 0; bandIndex < 3; bandIndex++) {
-        m_vertices[bandIndex].clear();
-        reserved[bandIndex] = numVerticesPerLine * length;
-        m_vertices[bandIndex].reserve(reserved[bandIndex]);
+    // low, mid, high + horizontal axis
+    int reserved = numVerticesPerLine * (pixelLength * 3 + 1);
+
+    geometry().setDrawingMode(Geometry::DrawingMode::Triangles);
+    geometry().allocate(reserved);
+    markDirtyGeometry();
+
+    QVector3D rgb[3];
+    if (m_bRgbStacked) {
+        rgb[0] = QVector3D(static_cast<float>(m_rgbLowColor_r),
+                static_cast<float>(m_rgbLowColor_g),
+                static_cast<float>(m_rgbLowColor_b));
+        rgb[1] = QVector3D(static_cast<float>(m_rgbMidColor_r),
+                static_cast<float>(m_rgbMidColor_g),
+                static_cast<float>(m_rgbMidColor_b));
+        rgb[2] = QVector3D(static_cast<float>(m_rgbHighColor_r),
+                static_cast<float>(m_rgbHighColor_g),
+                static_cast<float>(m_rgbHighColor_b));
+    } else {
+        rgb[0] = QVector3D(static_cast<float>(m_lowColor_r),
+                static_cast<float>(m_lowColor_g),
+                static_cast<float>(m_lowColor_b));
+        rgb[1] = QVector3D(static_cast<float>(m_midColor_r),
+                static_cast<float>(m_midColor_g),
+                static_cast<float>(m_midColor_b));
+        rgb[2] = QVector3D(static_cast<float>(m_highColor_r),
+                static_cast<float>(m_highColor_g),
+                static_cast<float>(m_highColor_b));
     }
 
-    // the horizontal line
-    reserved[3] = numVerticesPerLine;
-    m_vertices[3].clear();
-    m_vertices[3].reserve(reserved[3]);
+    RGBVertexUpdater axisVertexUpdater{geometry().vertexDataAs<Geometry::RGBColoredPoint2D>()};
+    axisVertexUpdater.addRectangle({0.f,
+                                           halfBreadth - 0.5f},
+            {static_cast<float>(length),
+                    halfBreadth + 0.5f},
+            {static_cast<float>(m_axesColor_r),
+                    static_cast<float>(m_axesColor_g),
+                    static_cast<float>(m_axesColor_b)});
 
-    m_vertices[3].addRectangle(
-            0.f,
-            halfBreadth - 0.5f * devicePixelRatio,
-            static_cast<float>(length),
-            halfBreadth + 0.5f * devicePixelRatio);
-
+    RGBVertexUpdater vertexUpdater[3]{
+            {geometry().vertexDataAs<Geometry::RGBColoredPoint2D>() +
+                    numVerticesPerLine},
+            {geometry().vertexDataAs<Geometry::RGBColoredPoint2D>() +
+                    numVerticesPerLine * (1 + pixelLength)},
+            {geometry().vertexDataAs<Geometry::RGBColoredPoint2D>() +
+                    numVerticesPerLine * (1 + pixelLength * 2)}};
     const double maxSamplingRange = visualIncrementPerPixel / 2.0;
 
-    for (int pos = 0; pos < length; ++pos) {
+    for (int pos = 0; pos < pixelLength; ++pos) {
         const int visualFrameStart = std::lround(xVisualFrame - maxSamplingRange);
         const int visualFrameStop = std::lround(xVisualFrame + maxSamplingRange);
 
@@ -108,90 +149,51 @@ void WaveformRendererFiltered::paintGL() {
         const int visualIndexStop =
                 std::min(std::max(visualFrameStop, visualFrameStart + 1) * 2, dataSize - 1);
 
-        const float fpos = static_cast<float>(pos);
+        const float fpos = static_cast<float>(pos) * invDevicePixelRatio;
 
         // 3 bands, 2 channels
         float max[3][2]{};
+        uchar u8max[3][2]{};
+        for (int chn = 0; chn < 2; chn++) {
+            for (int i = visualIndexStart + chn; i < visualIndexStop + chn; i += 2) {
+                const WaveformData& waveformData = data[i];
 
-        for (int i = visualIndexStart; i < visualIndexStop; i += 2) {
-            for (int chn = 0; chn < 2; chn++) {
-                const WaveformData& waveformData = data[i + chn];
-                const float filteredLow = static_cast<float>(waveformData.filtered.low);
-                const float filteredMid = static_cast<float>(waveformData.filtered.mid);
-                const float filteredHigh = static_cast<float>(waveformData.filtered.high);
-
-                max[0][chn] = math_max(max[0][chn], filteredLow);
-                max[1][chn] = math_max(max[1][chn], filteredMid);
-                max[2][chn] = math_max(max[2][chn], filteredHigh);
+                u8max[0][chn] = math_max(u8max[0][chn], waveformData.filtered.low);
+                u8max[1][chn] = math_max(u8max[1][chn], waveformData.filtered.mid);
+                u8max[2][chn] = math_max(u8max[2][chn], waveformData.filtered.high);
             }
+            // Cast to float
+            max[0][chn] = static_cast<float>(u8max[0][chn]);
+            max[1][chn] = static_cast<float>(u8max[1][chn]);
+            max[2][chn] = static_cast<float>(u8max[2][chn]);
         }
+
+        // TODO: this can be optimized by using one geometrynode per band
+        // + one for the horizontal axis, and uniform color materials,
+        // instead of passing constant color as vertex.
 
         for (int bandIndex = 0; bandIndex < 3; bandIndex++) {
             max[bandIndex][0] *= bandGain[bandIndex];
             max[bandIndex][1] *= bandGain[bandIndex];
 
-            // lines are thin rectangles
-            m_vertices[bandIndex].addRectangle(
-                    fpos - 0.5f,
-                    halfBreadth - heightFactor * max[bandIndex][0],
-                    fpos + 0.5f,
-                    halfBreadth + heightFactor * max[bandIndex][1]);
+            vertexUpdater[bandIndex].addRectangle(
+                    {fpos - halfPixelSize,
+                            halfBreadth - heightFactor * max[bandIndex][0]},
+                    {fpos + halfPixelSize,
+                            halfBreadth + heightFactor * max[bandIndex][1]},
+                    {rgb[bandIndex]});
         }
 
         xVisualFrame += visualIncrementPerPixel;
     }
 
-    const QMatrix4x4 matrix = matrixForWidgetGeometry(m_waveformRenderer, true);
+    DEBUG_ASSERT(reserved ==
+            vertexUpdater[0].index() + vertexUpdater[1].index() +
+                    vertexUpdater[2].index());
 
-    const int matrixLocation = m_shader.matrixLocation();
-    const int colorLocation = m_shader.colorLocation();
-    const int positionLocation = m_shader.positionLocation();
+    markDirtyMaterial();
 
-    m_shader.bind();
-    m_shader.enableAttributeArray(positionLocation);
-
-    m_shader.setUniformValue(matrixLocation, matrix);
-
-    QColor colors[4];
-    if (m_bRgbStacked) {
-        colors[0].setRgbF(static_cast<float>(m_rgbLowColor_r),
-                static_cast<float>(m_rgbLowColor_g),
-                static_cast<float>(m_rgbLowColor_b));
-        colors[1].setRgbF(static_cast<float>(m_rgbMidColor_r),
-                static_cast<float>(m_rgbMidColor_g),
-                static_cast<float>(m_rgbMidColor_b));
-        colors[2].setRgbF(static_cast<float>(m_rgbHighColor_r),
-                static_cast<float>(m_rgbHighColor_g),
-                static_cast<float>(m_rgbHighColor_b));
-    } else {
-        colors[0].setRgbF(static_cast<float>(m_lowColor_r),
-                static_cast<float>(m_lowColor_g),
-                static_cast<float>(m_lowColor_b));
-        colors[1].setRgbF(static_cast<float>(m_midColor_r),
-                static_cast<float>(m_midColor_g),
-                static_cast<float>(m_midColor_b));
-        colors[2].setRgbF(static_cast<float>(m_highColor_r),
-                static_cast<float>(m_highColor_g),
-                static_cast<float>(m_highColor_b));
-    }
-    colors[3].setRgbF(static_cast<float>(m_axesColor_r),
-            static_cast<float>(m_axesColor_g),
-            static_cast<float>(m_axesColor_b),
-            static_cast<float>(m_axesColor_a));
-
-    // 3 bands + 1 extra for the horizontal line
-
-    for (int i = 0; i < 4; i++) {
-        DEBUG_ASSERT(reserved[i] == m_vertices[i].size());
-        m_shader.setUniformValue(colorLocation, colors[i]);
-        m_shader.setAttributeArray(
-                positionLocation, GL_FLOAT, m_vertices[i].constData(), 2);
-
-        glDrawArrays(GL_TRIANGLES, 0, m_vertices[i].size());
-    }
-
-    m_shader.disableAttributeArray(positionLocation);
-    m_shader.release();
+    return true;
 }
 
 } // namespace allshader

--- a/src/waveform/renderers/allshader/waveformrendererfiltered.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererfiltered.cpp
@@ -64,7 +64,7 @@ bool WaveformRendererFiltered::preprocessInner() {
     const int length = static_cast<int>(m_waveformRenderer->getLength());
     const int pixelLength = static_cast<int>(m_waveformRenderer->getLength() * devicePixelRatio);
     const float invDevicePixelRatio = 1.f / devicePixelRatio;
-    const float halfPixelSize = 0.5 / devicePixelRatio;
+    const float halfPixelSize = 0.5f / devicePixelRatio;
 
     // See waveformrenderersimple.cpp for a detailed explanation of the frame and index calculation
     const int visualFramesSize = dataSize / 2;

--- a/src/waveform/renderers/allshader/waveformrendererfiltered.h
+++ b/src/waveform/renderers/allshader/waveformrendererfiltered.h
@@ -1,9 +1,7 @@
 #pragma once
 
-#include "rendergraph/openglnode.h"
-#include "shaders/unicolorshader.h"
+#include "rendergraph/geometrynode.h"
 #include "util/class.h"
-#include "waveform/renderers/allshader/vertexdata.h"
 #include "waveform/renderers/allshader/waveformrenderersignalbase.h"
 
 namespace allshader {
@@ -12,20 +10,19 @@ class WaveformRendererFiltered;
 
 class allshader::WaveformRendererFiltered final
         : public allshader::WaveformRendererSignalBase,
-          public rendergraph::OpenGLNode {
+          public rendergraph::GeometryNode {
   public:
     explicit WaveformRendererFiltered(WaveformWidgetRenderer* waveformWidget, bool rgbStacked);
 
-    // override ::WaveformRendererSignalBase
+    // Pure virtual from WaveformRendererSignalBase, not used
     void onSetup(const QDomNode& node) override;
 
-    void initializeGL() override;
-    void paintGL() override;
+    // Virtuals for rendergraph::Node
+    void preprocess() override;
 
   private:
     const bool m_bRgbStacked;
-    mixxx::UnicolorShader m_shader;
-    VertexData m_vertices[4];
+    bool preprocessInner();
 
     DISALLOW_COPY_AND_ASSIGN(WaveformRendererFiltered);
 };

--- a/src/waveform/renderers/allshader/waveformrendererhsv.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererhsv.cpp
@@ -1,56 +1,69 @@
 #include "waveform/renderers/allshader/waveformrendererhsv.h"
 
+#include "rendergraph/material/rgbmaterial.h"
+#include "rendergraph/vertexupdaters/rgbvertexupdater.h"
 #include "track/track.h"
 #include "util/colorcomponents.h"
 #include "util/math.h"
-#include "waveform/renderers/allshader/matrixforwidgetgeometry.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
 #include "waveform/waveform.h"
 
+using namespace rendergraph;
+
 namespace allshader {
 
-WaveformRendererHSV::WaveformRendererHSV(
-        WaveformWidgetRenderer* waveformWidget)
+WaveformRendererHSV::WaveformRendererHSV(WaveformWidgetRenderer* waveformWidget)
         : WaveformRendererSignalBase(waveformWidget) {
+    initForRectangles<RGBMaterial>(0);
+    setUsePreprocess(true);
 }
 
 void WaveformRendererHSV::onSetup(const QDomNode&) {
 }
 
-void WaveformRendererHSV::initializeGL() {
-    m_shader.init();
+void WaveformRendererHSV::preprocess() {
+    if (!preprocessInner()) {
+        if (geometry().vertexCount() != 0) {
+            geometry().allocate(0);
+            markDirtyGeometry();
+        }
+    }
 }
 
-void WaveformRendererHSV::paintGL() {
+bool WaveformRendererHSV::preprocessInner() {
     TrackPointer pTrack = m_waveformRenderer->getTrackInfo();
+
     if (!pTrack) {
-        return;
+        return false;
     }
 
     ConstWaveformPointer waveform = pTrack->getWaveform();
     if (waveform.isNull()) {
-        return;
+        return false;
     }
 
     const int dataSize = waveform->getDataSize();
     if (dataSize <= 1) {
-        return;
+        return false;
     }
 
     const WaveformData* data = waveform->data();
     if (data == nullptr) {
-        return;
+        return false;
     }
 #ifdef __STEM__
     auto stemInfo = pTrack->getStemInfo();
     // If this track is a stem track, skip the rendering
     if (!stemInfo.isEmpty() && waveform->hasStem()) {
-        return;
+        return false;
     }
 #endif
 
     const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
-    const int length = static_cast<int>(m_waveformRenderer->getLength() * devicePixelRatio);
+    const int length = static_cast<int>(m_waveformRenderer->getLength());
+    const int pixelLength = static_cast<int>(m_waveformRenderer->getLength() * devicePixelRatio);
+    const float invDevicePixelRatio = 1.f / devicePixelRatio;
+    const float halfPixelSize = 0.5 / devicePixelRatio;
 
     // See waveformrenderersimple.cpp for a detailed explanation of the frame and index calculation
     const int visualFramesSize = dataSize / 2;
@@ -61,7 +74,7 @@ void WaveformRendererHSV::paintGL() {
 
     // Represents the # of visual frames per horizontal pixel.
     const double visualIncrementPerPixel =
-            (lastVisualFrame - firstVisualFrame) / static_cast<double>(length);
+            (lastVisualFrame - firstVisualFrame) / static_cast<double>(pixelLength);
 
     float allGain(1.0);
     getGains(&allGain, false, nullptr, nullptr, nullptr);
@@ -70,7 +83,7 @@ void WaveformRendererHSV::paintGL() {
     float h, s, v;
     getHsvF(m_pColors->getLowColor(), &h, &s, &v);
 
-    const float breadth = static_cast<float>(m_waveformRenderer->getBreadth()) * devicePixelRatio;
+    const float breadth = static_cast<float>(m_waveformRenderer->getBreadth());
     const float halfBreadth = breadth / 2.0f;
 
     const float heightFactor = allGain * halfBreadth / m_maxValue;
@@ -81,25 +94,24 @@ void WaveformRendererHSV::paintGL() {
 
     const int numVerticesPerLine = 6; // 2 triangles
 
-    const int reserved = numVerticesPerLine * (length + 1);
+    const int reserved = numVerticesPerLine * (pixelLength + 1);
 
-    m_vertices.clear();
-    m_vertices.reserve(reserved);
-    m_colors.clear();
-    m_colors.reserve(reserved);
+    geometry().setDrawingMode(Geometry::DrawingMode::Triangles);
+    geometry().allocate(reserved);
+    markDirtyGeometry();
 
-    m_vertices.addRectangle(0.f,
-            halfBreadth - 0.5f * devicePixelRatio,
-            static_cast<float>(length),
-            halfBreadth + 0.5f * devicePixelRatio);
-    m_colors.addForRectangle(
-            static_cast<float>(m_axesColor_r),
-            static_cast<float>(m_axesColor_g),
-            static_cast<float>(m_axesColor_b));
+    RGBVertexUpdater vertexUpdater{geometry().vertexDataAs<Geometry::RGBColoredPoint2D>()};
+    vertexUpdater.addRectangle({0.f,
+                                       halfBreadth - 0.5f},
+            {static_cast<float>(length),
+                    halfBreadth + 0.5f},
+            {static_cast<float>(m_axesColor_r),
+                    static_cast<float>(m_axesColor_g),
+                    static_cast<float>(m_axesColor_b)});
 
     const double maxSamplingRange = visualIncrementPerPixel / 2.0;
 
-    for (int pos = 0; pos < length; ++pos) {
+    for (int pos = 0; pos < pixelLength; ++pos) {
         const int visualFrameStart = std::lround(xVisualFrame - maxSamplingRange);
         const int visualFrameStop = std::lround(xVisualFrame + maxSamplingRange);
 
@@ -107,7 +119,7 @@ void WaveformRendererHSV::paintGL() {
         const int visualIndexStop =
                 std::min(std::max(visualFrameStop, visualFrameStart + 1) * 2, dataSize - 1);
 
-        const float fpos = static_cast<float>(pos);
+        const float fpos = static_cast<float>(pos) * invDevicePixelRatio;
 
         // per channel
         float maxLow[2]{};
@@ -161,45 +173,24 @@ void WaveformRendererHSV::paintGL() {
         QColor color;
         color.setHsvF(h, 1.0f - hi, 1.0f - lo);
 
-        // lines are thin rectangles
+        // Lines are thin rectangles
         // maxAll[0] is for left channel, maxAll[1] is for right channel
-        m_vertices.addRectangle(fpos - 0.5f,
-                halfBreadth - heightFactor * maxAll[0],
-                fpos + 0.5f,
-                halfBreadth + heightFactor * maxAll[1]);
-        m_colors.addForRectangle(
-                static_cast<float>(color.redF()),
-                static_cast<float>(color.greenF()),
-                static_cast<float>(color.blueF()));
+        vertexUpdater.addRectangle({fpos - halfPixelSize,
+                                           halfBreadth - heightFactor * maxAll[0]},
+                {fpos + halfPixelSize,
+                        halfBreadth + heightFactor * maxAll[1]},
+                {static_cast<float>(color.redF()),
+                        static_cast<float>(color.greenF()),
+                        static_cast<float>(color.blueF())});
 
         xVisualFrame += visualIncrementPerPixel;
     }
 
-    DEBUG_ASSERT(reserved == m_vertices.size());
-    DEBUG_ASSERT(reserved == m_colors.size());
+    DEBUG_ASSERT(reserved == vertexUpdater.index());
 
-    const QMatrix4x4 matrix = matrixForWidgetGeometry(m_waveformRenderer, true);
+    markDirtyMaterial();
 
-    const int matrixLocation = m_shader.matrixLocation();
-    const int positionLocation = m_shader.positionLocation();
-    const int colorLocation = m_shader.colorLocation();
-
-    m_shader.bind();
-    m_shader.enableAttributeArray(positionLocation);
-    m_shader.enableAttributeArray(colorLocation);
-
-    m_shader.setUniformValue(matrixLocation, matrix);
-
-    m_shader.setAttributeArray(
-            positionLocation, GL_FLOAT, m_vertices.constData(), 2);
-    m_shader.setAttributeArray(
-            colorLocation, GL_FLOAT, m_colors.constData(), 3);
-
-    glDrawArrays(GL_TRIANGLES, 0, m_vertices.size());
-
-    m_shader.disableAttributeArray(positionLocation);
-    m_shader.disableAttributeArray(colorLocation);
-    m_shader.release();
+    return true;
 }
 
 } // namespace allshader

--- a/src/waveform/renderers/allshader/waveformrendererhsv.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererhsv.cpp
@@ -63,7 +63,7 @@ bool WaveformRendererHSV::preprocessInner() {
     const int length = static_cast<int>(m_waveformRenderer->getLength());
     const int pixelLength = static_cast<int>(m_waveformRenderer->getLength() * devicePixelRatio);
     const float invDevicePixelRatio = 1.f / devicePixelRatio;
-    const float halfPixelSize = 0.5 / devicePixelRatio;
+    const float halfPixelSize = 0.5f / devicePixelRatio;
 
     // See waveformrenderersimple.cpp for a detailed explanation of the frame and index calculation
     const int visualFramesSize = dataSize / 2;

--- a/src/waveform/renderers/allshader/waveformrendererhsv.h
+++ b/src/waveform/renderers/allshader/waveformrendererhsv.h
@@ -1,10 +1,7 @@
 #pragma once
 
-#include "rendergraph/openglnode.h"
-#include "shaders/rgbshader.h"
+#include "rendergraph/geometrynode.h"
 #include "util/class.h"
-#include "waveform/renderers/allshader/rgbdata.h"
-#include "waveform/renderers/allshader/vertexdata.h"
 #include "waveform/renderers/allshader/waveformrenderersignalbase.h"
 
 namespace allshader {
@@ -13,20 +10,18 @@ class WaveformRendererHSV;
 
 class allshader::WaveformRendererHSV final
         : public allshader::WaveformRendererSignalBase,
-          public rendergraph::OpenGLNode {
+          public rendergraph::GeometryNode {
   public:
     explicit WaveformRendererHSV(WaveformWidgetRenderer* waveformWidget);
 
-    // override ::WaveformRendererSignalBase
+    // Pure virtual from WaveformRendererSignalBase, not used
     void onSetup(const QDomNode& node) override;
 
-    void initializeGL() override;
-    void paintGL() override;
+    // Virtuals for rendergraph::Node
+    void preprocess() override;
 
   private:
-    mixxx::RGBShader m_shader;
-    VertexData m_vertices;
-    RGBData m_colors;
+    bool preprocessInner();
 
     DISALLOW_COPY_AND_ASSIGN(WaveformRendererHSV);
 };

--- a/src/waveform/renderers/allshader/waveformrendererrgb.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererrgb.cpp
@@ -75,7 +75,7 @@ bool WaveformRendererRGB::preprocessInner() {
     const int length = static_cast<int>(m_waveformRenderer->getLength());
     const int pixelLength = static_cast<int>(m_waveformRenderer->getLength() * devicePixelRatio);
     const float invDevicePixelRatio = 1.f / devicePixelRatio;
-    const float halfPixelSize = 0.5 / devicePixelRatio;
+    const float halfPixelSize = 0.5f / devicePixelRatio;
 
     // See waveformrenderersimple.cpp for a detailed explanation of the frame and index calculation
     const int visualFramesSize = dataSize / 2;

--- a/src/waveform/renderers/allshader/waveformrendererrgb.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererrgb.cpp
@@ -1,10 +1,13 @@
 #include "waveform/renderers/allshader/waveformrendererrgb.h"
 
+#include "rendergraph/material/rgbmaterial.h"
+#include "rendergraph/vertexupdaters/rgbvertexupdater.h"
 #include "track/track.h"
 #include "util/math.h"
-#include "waveform/renderers/allshader/matrixforwidgetgeometry.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
 #include "waveform/waveform.h"
+
+using namespace rendergraph;
 
 namespace allshader {
 
@@ -20,19 +23,27 @@ WaveformRendererRGB::WaveformRendererRGB(WaveformWidgetRenderer* waveformWidget,
         : WaveformRendererSignalBase(waveformWidget),
           m_isSlipRenderer(type == ::WaveformRendererAbstract::Slip),
           m_options(options) {
+    initForRectangles<RGBMaterial>(0);
+    setUsePreprocess(true);
 }
 
 void WaveformRendererRGB::onSetup(const QDomNode&) {
 }
 
-void WaveformRendererRGB::initializeGL() {
-    m_shader.init();
+void WaveformRendererRGB::preprocess() {
+    if (!preprocessInner()) {
+        if (geometry().vertexCount() != 0) {
+            geometry().allocate(0);
+            markDirtyGeometry();
+        }
+    }
 }
 
-void WaveformRendererRGB::paintGL() {
+bool WaveformRendererRGB::preprocessInner() {
     TrackPointer pTrack = m_waveformRenderer->getTrackInfo();
+
     if (!pTrack || (m_isSlipRenderer && !m_waveformRenderer->isSlipActive())) {
-        return;
+        return false;
     }
 
     auto positionType = m_isSlipRenderer ? ::WaveformRendererAbstract::Slip
@@ -40,28 +51,31 @@ void WaveformRendererRGB::paintGL() {
 
     ConstWaveformPointer waveform = pTrack->getWaveform();
     if (waveform.isNull()) {
-        return;
+        return false;
     }
 
     const int dataSize = waveform->getDataSize();
     if (dataSize <= 1) {
-        return;
+        return false;
     }
 
     const WaveformData* data = waveform->data();
     if (data == nullptr) {
-        return;
+        return false;
     }
 #ifdef __STEM__
     auto stemInfo = pTrack->getStemInfo();
     // If this track is a stem track, skip the rendering
     if (!stemInfo.isEmpty() && waveform->hasStem()) {
-        return;
+        return false;
     }
 #endif
 
     const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
-    const int length = static_cast<int>(m_waveformRenderer->getLength() * devicePixelRatio);
+    const int length = static_cast<int>(m_waveformRenderer->getLength());
+    const int pixelLength = static_cast<int>(m_waveformRenderer->getLength() * devicePixelRatio);
+    const float invDevicePixelRatio = 1.f / devicePixelRatio;
+    const float halfPixelSize = 0.5 / devicePixelRatio;
 
     // See waveformrenderersimple.cpp for a detailed explanation of the frame and index calculation
     const int visualFramesSize = dataSize / 2;
@@ -72,14 +86,14 @@ void WaveformRendererRGB::paintGL() {
 
     // Represents the # of visual frames per horizontal pixel.
     const double visualIncrementPerPixel =
-            (lastVisualFrame - firstVisualFrame) / static_cast<double>(length);
+            (lastVisualFrame - firstVisualFrame) / static_cast<double>(pixelLength);
 
     // Per-band gain from the EQ knobs.
     float allGain(1.0), lowGain(1.0), midGain(1.0), highGain(1.0);
     // applyCompensation = false, as we scale to match filtered.all
     getGains(&allGain, false, &lowGain, &midGain, &highGain);
 
-    const float breadth = static_cast<float>(m_waveformRenderer->getBreadth()) * devicePixelRatio;
+    const float breadth = static_cast<float>(m_waveformRenderer->getBreadth());
     const float halfBreadth = breadth / 2.0f;
 
     const float heightFactorAbs = allGain * halfBreadth / m_maxValue;
@@ -104,25 +118,24 @@ void WaveformRendererRGB::paintGL() {
 
     const int reserved = numVerticesPerLine *
             // Slip rendere only render a single channel, so the vertices count doesn't change
-            ((splitLeftRight && !m_isSlipRenderer ? length * 2 : length) + 1);
+            ((splitLeftRight && !m_isSlipRenderer ? pixelLength * 2 : pixelLength) + 1);
 
-    m_vertices.clear();
-    m_vertices.reserve(reserved);
-    m_colors.clear();
-    m_colors.reserve(reserved);
+    geometry().setDrawingMode(Geometry::DrawingMode::Triangles);
+    geometry().allocate(reserved);
+    markDirtyGeometry();
 
-    m_vertices.addRectangle(0.f,
-            halfBreadth - 0.5f * devicePixelRatio,
-            static_cast<float>(length),
-            m_isSlipRenderer ? halfBreadth : halfBreadth + 0.5f * devicePixelRatio);
-    m_colors.addForRectangle(
-            static_cast<float>(m_axesColor_r),
-            static_cast<float>(m_axesColor_g),
-            static_cast<float>(m_axesColor_b));
+    RGBVertexUpdater vertexUpdater{geometry().vertexDataAs<Geometry::RGBColoredPoint2D>()};
+    vertexUpdater.addRectangle({0.f,
+                                       halfBreadth - 0.5f},
+            {static_cast<float>(length),
+                    m_isSlipRenderer ? halfBreadth : halfBreadth + 0.5f},
+            {static_cast<float>(m_axesColor_r),
+                    static_cast<float>(m_axesColor_g),
+                    static_cast<float>(m_axesColor_b)});
 
     const double maxSamplingRange = visualIncrementPerPixel / 2.0;
 
-    for (int pos = 0; pos < length; ++pos) {
+    for (int pos = 0; pos < pixelLength; ++pos) {
         const int visualFrameStart = std::lround(xVisualFrame - maxSamplingRange);
         const int visualFrameStop = std::lround(xVisualFrame + maxSamplingRange);
 
@@ -130,7 +143,7 @@ void WaveformRendererRGB::paintGL() {
         const int visualIndexStop =
                 std::min(std::max(visualFrameStop, visualFrameStart + 1) * 2, dataSize - 1);
 
-        const float fpos = static_cast<float>(pos);
+        const float fpos = static_cast<float>(pos) * invDevicePixelRatio;
 
         // Find the max values for low, mid, high and all in the waveform data.
         // - Max of left and right
@@ -213,51 +226,36 @@ void WaveformRendererRGB::paintGL() {
 
             // Lines are thin rectangles
             if (!splitLeftRight) {
-                m_vertices.addRectangle(fpos - 0.5f,
-                        halfBreadth - heightFactorAbs * maxAllChn[0],
-                        fpos + 0.5f,
-                        m_isSlipRenderer
-                                ? halfBreadth
-                                : halfBreadth + heightFactorAbs * maxAllChn[1]);
+                vertexUpdater.addRectangle({fpos - halfPixelSize,
+                                                   halfBreadth - heightFactorAbs * maxAllChn[0]},
+                        {fpos + halfPixelSize,
+                                m_isSlipRenderer
+                                        ? halfBreadth
+                                        : halfBreadth + heightFactorAbs * maxAllChn[1]},
+                        {red,
+                                green,
+                                blue});
             } else {
                 // note: heightFactor is the same for left and right,
                 // but negative for left (chn 0) and positive for right (chn 1)
-                m_vertices.addRectangle(fpos - 0.5f,
-                        halfBreadth,
-                        fpos + 0.5f,
-                        halfBreadth + heightFactor[chn] * maxAllChn[chn]);
+                vertexUpdater.addRectangle({fpos - halfPixelSize,
+                                                   halfBreadth},
+                        {fpos + halfPixelSize,
+                                halfBreadth + heightFactor[chn] * maxAllChn[chn]},
+                        {red,
+                                green,
+                                blue});
             }
-            m_colors.addForRectangle(red, green, blue);
         }
 
         xVisualFrame += visualIncrementPerPixel;
     }
 
-    DEBUG_ASSERT(reserved == m_vertices.size());
-    DEBUG_ASSERT(reserved == m_colors.size());
+    DEBUG_ASSERT(reserved == vertexUpdater.index());
 
-    const QMatrix4x4 matrix = matrixForWidgetGeometry(m_waveformRenderer, true);
+    markDirtyMaterial();
 
-    const int matrixLocation = m_shader.matrixLocation();
-    const int positionLocation = m_shader.positionLocation();
-    const int colorLocation = m_shader.colorLocation();
-
-    m_shader.bind();
-    m_shader.enableAttributeArray(positionLocation);
-    m_shader.enableAttributeArray(colorLocation);
-
-    m_shader.setUniformValue(matrixLocation, matrix);
-
-    m_shader.setAttributeArray(
-            positionLocation, GL_FLOAT, m_vertices.constData(), 2);
-    m_shader.setAttributeArray(
-            colorLocation, GL_FLOAT, m_colors.constData(), 3);
-
-    glDrawArrays(GL_TRIANGLES, 0, m_vertices.size());
-
-    m_shader.disableAttributeArray(positionLocation);
-    m_shader.disableAttributeArray(colorLocation);
-    m_shader.release();
+    return true;
 }
 
 } // namespace allshader

--- a/src/waveform/renderers/allshader/waveformrendererrgb.h
+++ b/src/waveform/renderers/allshader/waveformrendererrgb.h
@@ -1,10 +1,7 @@
 #pragma once
 
-#include "rendergraph/openglnode.h"
-#include "shaders/rgbshader.h"
+#include "rendergraph/geometrynode.h"
 #include "util/class.h"
-#include "waveform/renderers/allshader/rgbdata.h"
-#include "waveform/renderers/allshader/vertexdata.h"
 #include "waveform/renderers/allshader/waveformrenderersignalbase.h"
 
 namespace allshader {
@@ -13,30 +10,28 @@ class WaveformRendererRGB;
 
 class allshader::WaveformRendererRGB final
         : public allshader::WaveformRendererSignalBase,
-          public rendergraph::OpenGLNode {
+          public rendergraph::GeometryNode {
   public:
     explicit WaveformRendererRGB(WaveformWidgetRenderer* waveformWidget,
             ::WaveformRendererAbstract::PositionSource type =
                     ::WaveformRendererAbstract::Play,
             WaveformRendererSignalBase::Options options = WaveformRendererSignalBase::Option::None);
 
-    // override ::WaveformRendererSignalBase
+    // Pure virtual from WaveformRendererSignalBase, not used
     void onSetup(const QDomNode& node) override;
-
-    void initializeGL() override;
-    void paintGL() override;
 
     bool supportsSlip() const override {
         return true;
     }
 
-  private:
-    mixxx::RGBShader m_shader;
-    VertexData m_vertices;
-    RGBData m_colors;
+    // Virtuals for rendergraph::Node
+    void preprocess() override;
 
+  private:
     bool m_isSlipRenderer;
     WaveformRendererSignalBase::Options m_options;
+
+    bool preprocessInner();
 
     DISALLOW_COPY_AND_ASSIGN(WaveformRendererRGB);
 };

--- a/src/waveform/renderers/allshader/waveformrenderersimple.cpp
+++ b/src/waveform/renderers/allshader/waveformrenderersimple.cpp
@@ -1,172 +1,162 @@
 #include "waveform/renderers/allshader/waveformrenderersimple.h"
 
+#include "rendergraph/material/rgbmaterial.h"
+#include "rendergraph/vertexupdaters/rgbvertexupdater.h"
 #include "track/track.h"
 #include "util/math.h"
-#include "waveform/renderers/allshader/matrixforwidgetgeometry.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
 #include "waveform/waveform.h"
 
+using namespace rendergraph;
+
 namespace allshader {
 
-WaveformRendererSimple::WaveformRendererSimple(
-        WaveformWidgetRenderer* waveformWidget)
+WaveformRendererSimple::WaveformRendererSimple(WaveformWidgetRenderer* waveformWidget)
         : WaveformRendererSignalBase(waveformWidget) {
+    initForRectangles<RGBMaterial>(0);
+    setUsePreprocess(true);
 }
 
 void WaveformRendererSimple::onSetup(const QDomNode&) {
 }
 
-void WaveformRendererSimple::initializeGL() {
-    m_shader.init();
+void WaveformRendererSimple::preprocess() {
+    if (!preprocessInner()) {
+        if (geometry().vertexCount() != 0) {
+            geometry().allocate(0);
+            markDirtyGeometry();
+        }
+    }
 }
 
-void WaveformRendererSimple::paintGL() {
+bool WaveformRendererSimple::preprocessInner() {
     TrackPointer pTrack = m_waveformRenderer->getTrackInfo();
+
     if (!pTrack) {
-        return;
+        return false;
     }
 
     ConstWaveformPointer waveform = pTrack->getWaveform();
     if (waveform.isNull()) {
-        return;
+        return false;
     }
 
     const int dataSize = waveform->getDataSize();
     if (dataSize <= 1) {
-        return;
+        return false;
     }
 
     const WaveformData* data = waveform->data();
     if (data == nullptr) {
-        return;
+        return false;
     }
+#ifdef __STEM__
+    auto stemInfo = pTrack->getStemInfo();
+    // If this track is a stem track, skip the rendering
+    if (!stemInfo.isEmpty() && waveform->hasStem()) {
+        return false;
+    }
+#endif
 
     const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
-    const int length = static_cast<int>(m_waveformRenderer->getLength() * devicePixelRatio);
+    const int length = static_cast<int>(m_waveformRenderer->getLength());
+    const int pixelLength = static_cast<int>(m_waveformRenderer->getLength() * devicePixelRatio);
+    const float invDevicePixelRatio = 1.f / devicePixelRatio;
+    const float halfPixelSize = 0.5 / devicePixelRatio;
 
     // Note that waveform refers to the visual waveform, not to audio samples.
     //
     // WaveformData* data contains the L and R waveform values interleaved. In the calculations
     // below, 'frame' refers to the index of such an L-R pair.
     const int visualFramesSize = dataSize / 2;
-
     // Calculate the first and last frame to draw, from the normalized display position
     const double firstVisualFrame =
             m_waveformRenderer->getFirstDisplayedPosition() * visualFramesSize;
     const double lastVisualFrame =
             m_waveformRenderer->getLastDisplayedPosition() * visualFramesSize;
 
-    // Calculate the number of visual frames per horizontal pixel.
+    // Represents the # of visual frames per horizontal pixel.
     const double visualIncrementPerPixel =
-            (lastVisualFrame - firstVisualFrame) / static_cast<double>(length);
+            (lastVisualFrame - firstVisualFrame) / static_cast<double>(pixelLength);
 
     // Per-band gain from the EQ knobs.
     float allGain{1.0};
     float bandGain[3] = {1.0, 1.0, 1.0};
     getGains(&allGain, false, &bandGain[0], &bandGain[1], &bandGain[2]);
 
-    const float breadth = static_cast<float>(m_waveformRenderer->getBreadth()) * devicePixelRatio;
+    const float breadth = static_cast<float>(m_waveformRenderer->getBreadth());
     const float halfBreadth = breadth / 2.0f;
 
     const float heightFactor = allGain * halfBreadth / m_maxValue;
 
-    // Effective visual frame for x, which we will increment for each pixel advanced
+    // Effective visual frame for x
     double xVisualFrame = qRound(firstVisualFrame / visualIncrementPerPixel) *
             visualIncrementPerPixel;
 
     const int numVerticesPerLine = 6; // 2 triangles
 
-    int reserved[2];
+    const int reserved = numVerticesPerLine * (pixelLength + 1);
 
-    reserved[0] = numVerticesPerLine * length;
-    m_vertices[0].clear();
-    m_vertices[0].reserve(reserved[0]);
+    geometry().setDrawingMode(Geometry::DrawingMode::Triangles);
+    geometry().allocate(reserved);
+    markDirtyGeometry();
 
-    // the horizontal line
-    reserved[1] = numVerticesPerLine;
-    m_vertices[1].clear();
-    m_vertices[1].reserve(reserved[1]);
+    RGBVertexUpdater vertexUpdater{geometry().vertexDataAs<Geometry::RGBColoredPoint2D>()};
+    vertexUpdater.addRectangle({0.f,
+                                       halfBreadth - 0.5f},
+            {static_cast<float>(length),
+                    halfBreadth + 0.5f},
+            {static_cast<float>(m_axesColor_r),
+                    static_cast<float>(m_axesColor_g),
+                    static_cast<float>(m_axesColor_b)});
 
-    m_vertices[1].addRectangle(
-            0.f,
-            halfBreadth - 0.5f * devicePixelRatio,
-            static_cast<float>(length),
-            halfBreadth + 0.5f * devicePixelRatio);
-
-    // We will iterate over a range of waveform data, centered around xVisualFrame
     const double maxSamplingRange = visualIncrementPerPixel / 2.0;
 
-    for (int pos = 0; pos < length; ++pos) {
-        // Calculate the start and end of the range of waveform data, centered around xVisualFrame
+    const QVector3D signalColor{static_cast<float>(m_signalColor_r),
+            static_cast<float>(m_signalColor_g),
+            static_cast<float>(m_signalColor_b)};
+
+    for (int pos = 0; pos < pixelLength; ++pos) {
         const int visualFrameStart = std::lround(xVisualFrame - maxSamplingRange);
         const int visualFrameStop = std::lround(xVisualFrame + maxSamplingRange);
 
-        // Calculate the actual (deinterleaved) indices.
-        //
-        // Make sure we stay inside data at the lower boundary
         const int visualIndexStart = std::max(visualFrameStart * 2, 0);
-        // and at the upper boundary.
-        // Note: * dataSize - 1, because below we add chn = 1
-        //       * visualFrameStart + 1, because we want to have at least 1 value
         const int visualIndexStop =
                 std::min(std::max(visualFrameStop, visualFrameStart + 1) * 2, dataSize - 1);
 
-        // 2 channels
-        float max[2]{};
+        const float fpos = static_cast<float>(pos) * invDevicePixelRatio;
 
+        // - Per channel
+        uchar u8maxAllChn[2]{};
         for (int chn = 0; chn < 2; chn++) {
             // data is interleaved left / right
             for (int i = visualIndexStart + chn; i < visualIndexStop + chn; i += 2) {
                 const WaveformData& waveformData = data[i];
-                const float filteredAll = static_cast<float>(waveformData.filtered.all);
 
-                max[chn] = math_max(max[chn], filteredAll);
+                u8maxAllChn[chn] = math_max(u8maxAllChn[chn], waveformData.filtered.all);
             }
         }
+        float maxAllChn[2]{static_cast<float>(u8maxAllChn[0]), static_cast<float>(u8maxAllChn[1])};
 
-        const float fpos = static_cast<float>(pos);
+        // TODO: use two geometrynodes, with uniform material,
+        // one for the axis, one for the signal
 
-        // lines are thin rectangles
-        m_vertices[0].addRectangle(
-                fpos - 0.5f,
-                halfBreadth - heightFactor * max[0],
-                fpos + 0.5f,
-                halfBreadth + heightFactor * max[1]);
+        // note: heightFactor is the same for left and right,
+        // but negative for left (chn 0) and positive for right (chn 1)
+        vertexUpdater.addRectangle({fpos - halfPixelSize,
+                                           halfBreadth - heightFactor * maxAllChn[0]},
+                {fpos + halfPixelSize,
+                        halfBreadth + heightFactor * maxAllChn[0]},
+                signalColor);
 
         xVisualFrame += visualIncrementPerPixel;
     }
 
-    const QMatrix4x4 matrix = matrixForWidgetGeometry(m_waveformRenderer, true);
+    DEBUG_ASSERT(reserved == vertexUpdater.index());
 
-    const int matrixLocation = m_shader.matrixLocation();
-    const int colorLocation = m_shader.colorLocation();
-    const int positionLocation = m_shader.positionLocation();
+    markDirtyMaterial();
 
-    m_shader.bind();
-    m_shader.enableAttributeArray(positionLocation);
-
-    m_shader.setUniformValue(matrixLocation, matrix);
-
-    QColor colors[2];
-    colors[0].setRgbF(static_cast<float>(m_signalColor_r),
-            static_cast<float>(m_signalColor_g),
-            static_cast<float>(m_signalColor_b));
-    colors[1].setRgbF(static_cast<float>(m_axesColor_r),
-            static_cast<float>(m_axesColor_g),
-            static_cast<float>(m_axesColor_b),
-            static_cast<float>(m_axesColor_a));
-
-    for (int i = 0; i < 2; i++) {
-        DEBUG_ASSERT(reserved[i] == m_vertices[i].size());
-        m_shader.setUniformValue(colorLocation, colors[i]);
-        m_shader.setAttributeArray(
-                positionLocation, GL_FLOAT, m_vertices[i].constData(), 2);
-
-        glDrawArrays(GL_TRIANGLES, 0, m_vertices[i].size());
-    }
-
-    m_shader.disableAttributeArray(positionLocation);
-    m_shader.release();
+    return true;
 }
 
 } // namespace allshader

--- a/src/waveform/renderers/allshader/waveformrenderersimple.cpp
+++ b/src/waveform/renderers/allshader/waveformrenderersimple.cpp
@@ -62,7 +62,7 @@ bool WaveformRendererSimple::preprocessInner() {
     const int length = static_cast<int>(m_waveformRenderer->getLength());
     const int pixelLength = static_cast<int>(m_waveformRenderer->getLength() * devicePixelRatio);
     const float invDevicePixelRatio = 1.f / devicePixelRatio;
-    const float halfPixelSize = 0.5 / devicePixelRatio;
+    const float halfPixelSize = 0.5f / devicePixelRatio;
 
     // Note that waveform refers to the visual waveform, not to audio samples.
     //

--- a/src/waveform/renderers/allshader/waveformrenderersimple.h
+++ b/src/waveform/renderers/allshader/waveformrenderersimple.h
@@ -1,9 +1,7 @@
 #pragma once
 
-#include "rendergraph/openglnode.h"
-#include "shaders/unicolorshader.h"
+#include "rendergraph/geometrynode.h"
 #include "util/class.h"
-#include "waveform/renderers/allshader/vertexdata.h"
 #include "waveform/renderers/allshader/waveformrenderersignalbase.h"
 
 namespace allshader {
@@ -12,19 +10,18 @@ class WaveformRendererSimple;
 
 class allshader::WaveformRendererSimple final
         : public allshader::WaveformRendererSignalBase,
-          public rendergraph::OpenGLNode {
+          public rendergraph::GeometryNode {
   public:
     explicit WaveformRendererSimple(WaveformWidgetRenderer* waveformWidget);
 
-    // override ::WaveformRendererSignalBase
+    // Pure virtual from WaveformRendererSignalBase, not used
     void onSetup(const QDomNode& node) override;
 
-    void initializeGL() override;
-    void paintGL() override;
+    // Virtuals for rendergraph::Node
+    void preprocess() override;
 
   private:
-    mixxx::UnicolorShader m_shader;
-    VertexData m_vertices[2];
+    bool preprocessInner();
 
     DISALLOW_COPY_AND_ASSIGN(WaveformRendererSimple);
 };


### PR DESCRIPTION
Ports the signal waveformrenderers to rendergraph nodes. This can be reviewed and merged independently from the PRs for the other waveformrenderers.