### PR TITLE
endoftrack waveformrenderer using rendergraph

### DIFF
--- a/src/waveform/renderers/allshader/waveformrendererendoftrack.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererendoftrack.cpp
@@ -51,7 +51,8 @@ bool WaveformRendererEndOfTrack::init() {
 
 void WaveformRendererEndOfTrack::setup(const QDomNode& node, const SkinContext& skinContext) {
     m_color = QColor(200, 25, 20);
-    const QString endOfTrackColorName = skinContext.selectString(node, QStringLiteral("EndOfTrackColor"));
+    const QString endOfTrackColorName =
+            skinContext.selectString(node, QStringLiteral("EndOfTrackColor"));
     if (!endOfTrackColorName.isNull()) {
         m_color = QColor(endOfTrackColorName);
         m_color = WSkinColor::getCorrectColor(m_color);

--- a/src/waveform/renderers/allshader/waveformrendererendoftrack.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererendoftrack.cpp
@@ -51,7 +51,7 @@ bool WaveformRendererEndOfTrack::init() {
 
 void WaveformRendererEndOfTrack::setup(const QDomNode& node, const SkinContext& skinContext) {
     m_color = QColor(200, 25, 20);
-    const QString endOfTrackColorName = skinContext.selectString(node, "EndOfTrackColor");
+    const QString endOfTrackColorName = skinContext.selectString(node, QStringLiteral("EndOfTrackColor"));
     if (!endOfTrackColorName.isNull()) {
         m_color = QColor(endOfTrackColorName);
         m_color = WSkinColor::getCorrectColor(m_color);

--- a/src/waveform/renderers/allshader/waveformrendererendoftrack.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererendoftrack.cpp
@@ -1,9 +1,14 @@
 #include "waveform/renderers/allshader/waveformrendererendoftrack.h"
 
 #include <QDomNode>
+#include <QVector4D>
 #include <memory>
 
 #include "control/controlproxy.h"
+#include "rendergraph/geometry.h"
+#include "rendergraph/material/rgbamaterial.h"
+#include "rendergraph/vertexupdaters/rgbavertexupdater.h"
+#include "util/colorcomponents.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
 #include "waveform/waveformwidgetfactory.h"
 #include "widget/wskincolor.h"
@@ -11,19 +16,26 @@
 namespace {
 
 constexpr int kBlinkingPeriodMillis = 1000;
-constexpr float positionArray[] = {-1.f, -1.f, 1.f, -1.f, -1.f, 1.f, 1.f, 1.f};
-constexpr float verticalGradientArray[] = {1.f, 1.f, -1.f, -1.f};
-constexpr float horizontalGradientArray[] = {-1.f, 1.f, -1.f, 1.f};
 
 } // anonymous namespace
+
+using namespace rendergraph;
 
 namespace allshader {
 
 WaveformRendererEndOfTrack::WaveformRendererEndOfTrack(
         WaveformWidgetRenderer* waveformWidget)
-        : WaveformRenderer(waveformWidget),
+        : ::WaveformRendererAbstract(waveformWidget),
           m_pEndOfTrackControl(nullptr),
           m_pTimeRemainingControl(nullptr) {
+    initForRectangles<RGBAMaterial>(0);
+    setUsePreprocess(true);
+}
+
+void WaveformRendererEndOfTrack::draw(QPainter* painter, QPaintEvent* event) {
+    Q_UNUSED(painter);
+    Q_UNUSED(event);
+    DEBUG_ASSERT(false);
 }
 
 bool WaveformRendererEndOfTrack::init() {
@@ -37,49 +49,25 @@ bool WaveformRendererEndOfTrack::init() {
     return true;
 }
 
-void WaveformRendererEndOfTrack::setup(const QDomNode& node, const SkinContext& context) {
+void WaveformRendererEndOfTrack::setup(const QDomNode& node, const SkinContext& skinContext) {
     m_color = QColor(200, 25, 20);
-    const QString endOfTrackColorName = context.selectString(node, "EndOfTrackColor");
+    const QString endOfTrackColorName = skinContext.selectString(node, "EndOfTrackColor");
     if (!endOfTrackColorName.isNull()) {
         m_color = QColor(endOfTrackColorName);
         m_color = WSkinColor::getCorrectColor(m_color);
     }
 }
 
-void WaveformRendererEndOfTrack::initializeGL() {
-    m_shader.init();
+void WaveformRendererEndOfTrack::preprocess() {
+    if (!preprocessInner()) {
+        geometry().allocate(0);
+        markDirtyGeometry();
+    }
 }
 
-void WaveformRendererEndOfTrack::fillWithGradient(QColor color) {
-    const int colorLocation = m_shader.colorLocation();
-    const int positionLocation = m_shader.positionLocation();
-    const int gradientLocation = m_shader.gradientLocation();
-
-    m_shader.bind();
-    m_shader.enableAttributeArray(positionLocation);
-    m_shader.enableAttributeArray(gradientLocation);
-
-    m_shader.setUniformValue(colorLocation, color);
-
-    m_shader.setAttributeArray(
-            positionLocation, GL_FLOAT, positionArray, 2);
-    m_shader.setAttributeArray(gradientLocation,
-            GL_FLOAT,
-            m_waveformRenderer->getOrientation() == Qt::Vertical
-                    ? verticalGradientArray
-                    : horizontalGradientArray,
-            1);
-
-    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
-
-    m_shader.disableAttributeArray(positionLocation);
-    m_shader.disableAttributeArray(gradientLocation);
-    m_shader.release();
-}
-
-void WaveformRendererEndOfTrack::paintGL() {
+bool WaveformRendererEndOfTrack::preprocessInner() {
     if (!m_pEndOfTrackControl->toBool()) {
-        return;
+        return false;
     }
 
     const int elapsed = m_timer.elapsed().toIntegerMillis() % kBlinkingPeriodMillis;
@@ -93,17 +81,32 @@ void WaveformRendererEndOfTrack::paintGL() {
     const double criticalIntensity = (remainingTimeTriggerSeconds - remainingTime) /
             remainingTimeTriggerSeconds;
 
-    const double alpha = criticalIntensity * blinkIntensity;
+    const double alpha = std::clamp(criticalIntensity * blinkIntensity, 0.0, 1.0);
 
-    if (alpha != 0.0) {
-        QColor color = m_color;
-        color.setAlphaF(static_cast<float>(alpha));
+    QSizeF size(m_waveformRenderer->getWidth(), m_waveformRenderer->getHeight());
+    float r, g, b, a;
+    getRgbF(m_color, &r, &g, &b, &a);
 
-        glEnable(GL_BLEND);
-        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    const float posx0 = 0.f;
+    const float posx1 = size.width() / 2.f;
+    const float posx2 = size.width();
+    const float posy1 = 0.f;
+    const float posy2 = size.height();
 
-        fillWithGradient(color);
-    }
+    float minAlpha = 0.5f * static_cast<float>(alpha);
+    float maxAlpha = 0.83f * static_cast<float>(alpha);
+
+    geometry().allocate(6 * 2);
+    RGBAVertexUpdater vertexUpdater{geometry().vertexDataAs<Geometry::RGBAColoredPoint2D>()};
+    vertexUpdater.addRectangleHGradient(
+            {posx0, posy1}, {posx1, posy2}, {r, g, b, minAlpha}, {r, g, b, minAlpha});
+    vertexUpdater.addRectangleHGradient(
+            {posx1, posy1}, {posx2, posy2}, {r, g, b, minAlpha}, {r, g, b, maxAlpha});
+
+    markDirtyGeometry();
+    markDirtyMaterial();
+
+    return true;
 }
 
 } // namespace allshader

--- a/src/waveform/renderers/allshader/waveformrendererendoftrack.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererendoftrack.cpp
@@ -90,10 +90,10 @@ bool WaveformRendererEndOfTrack::preprocessInner() {
     getRgbF(m_color, &r, &g, &b, &a);
 
     const float posx0 = 0.f;
-    const float posx1 = size.width() / 2.f;
-    const float posx2 = size.width();
+    const float posx1 = static_cast<float>(size.width()) / 2.f;
+    const float posx2 = static_cast<float>(size.width());
     const float posy1 = 0.f;
-    const float posy2 = size.height();
+    const float posy2 = static_cast<float>(size.height());
 
     float minAlpha = 0.5f * static_cast<float>(alpha);
     float maxAlpha = 0.83f * static_cast<float>(alpha);

--- a/src/waveform/renderers/allshader/waveformrendererendoftrack.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererendoftrack.cpp
@@ -72,7 +72,9 @@ bool WaveformRendererEndOfTrack::preprocessInner() {
 
     const int elapsed = m_timer.elapsed().toIntegerMillis() % kBlinkingPeriodMillis;
 
-    const double blinkIntensity = (double)(2 * abs(elapsed - kBlinkingPeriodMillis / 2)) /
+    const double blinkIntensity =
+            static_cast<double>(
+                    2 * std::abs(elapsed - kBlinkingPeriodMillis / 2)) /
             kBlinkingPeriodMillis;
 
     const double remainingTime = m_pTimeRemainingControl->get();

--- a/src/waveform/renderers/allshader/waveformrendererendoftrack.h
+++ b/src/waveform/renderers/allshader/waveformrendererendoftrack.h
@@ -3,11 +3,11 @@
 #include <QColor>
 #include <memory>
 
-#include "rendergraph/openglnode.h"
-#include "shaders/endoftrackshader.h"
+#include "rendergraph/geometrynode.h"
+#include "rendergraph/opacitynode.h"
 #include "util/class.h"
 #include "util/performancetimer.h"
-#include "waveform/renderers/allshader/waveformrenderer.h"
+#include "waveform/renderers/waveformrendererabstract.h"
 
 class ControlProxy;
 class QDomNode;
@@ -18,28 +18,30 @@ class WaveformRendererEndOfTrack;
 }
 
 class allshader::WaveformRendererEndOfTrack final
-        : public allshader::WaveformRenderer,
-          public rendergraph::OpenGLNode {
+        : public ::WaveformRendererAbstract,
+          public rendergraph::GeometryNode {
   public:
     explicit WaveformRendererEndOfTrack(
             WaveformWidgetRenderer* waveformWidget);
+
+    // Pure virtual from WaveformRendererAbstract, not used
+    void draw(QPainter* painter, QPaintEvent* event) override final;
 
     void setup(const QDomNode& node, const SkinContext& skinContext) override;
 
     bool init() override;
 
-    void initializeGL() override;
-    void paintGL() override;
+    // Virtual for rendergraph::Node
+    void preprocess() override;
 
   private:
-    void fillWithGradient(QColor color);
-
-    mixxx::EndOfTrackShader m_shader;
     std::unique_ptr<ControlProxy> m_pEndOfTrackControl;
     std::unique_ptr<ControlProxy> m_pTimeRemainingControl;
 
     QColor m_color;
     PerformanceTimer m_timer;
+
+    bool preprocessInner();
 
     DISALLOW_COPY_AND_ASSIGN(WaveformRendererEndOfTrack);
 };


### PR DESCRIPTION
Ports the endoftrack waveformrenderer to a rendergraph node. This can be reviewed and merged independently from the PRs for the other waveformrenderers.