### PR TITLE
slip waveformrenderer using rendergraph

### DIFF
--- a/src/waveform/renderers/allshader/waveformrendererslipmode.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererslipmode.cpp
@@ -89,7 +89,7 @@ bool WaveformRendererSlipMode::preprocessInner() {
                     2 * std::abs(elapsed - kBlinkingPeriodMillis / 2)) /
             kBlinkingPeriodMillis;
 
-    const float alpha = std::clamp(0.25 + 0.5 * blinkIntensity, 0.0, 1.0);
+    const float alpha = std::clamp(0.25f + 0.5f * blinkIntensity, 0.0f, 1.0f);
 
     const float posx1 = 0.f;
     const float posx2 = m_waveformRenderer->getLength();

--- a/src/waveform/renderers/allshader/waveformrendererslipmode.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererslipmode.cpp
@@ -45,26 +45,27 @@ bool WaveformRendererSlipMode::init() {
     m_timer.restart();
 
     m_pSlipModeControl.reset(new ControlProxy(
-            m_waveformRenderer->getGroup(), "slip_enabled"));
+            m_waveformRenderer->getGroup(), QStringLiteral("slip_enabled")));
 
     return true;
 }
 
 void WaveformRendererSlipMode::setup(const QDomNode& node, const SkinContext& skinContext) {
     const QString slipModeOutlineColorName =
-            skinContext.selectString(node, "SlipBorderOutlineColor");
+            skinContext.selectString(node, QStringLiteral("SlipBorderOutlineColor"));
+    ;
     if (!slipModeOutlineColorName.isNull()) {
         m_color = WSkinColor::getCorrectColor(QColor(slipModeOutlineColorName));
     } else {
         m_color = kDefaultColor;
     }
     const float slipBorderTopOutlineSize = skinContext.selectFloat(
-            node, "SlipBorderTopOutlineSize", m_slipBorderTopOutlineSize);
+            node, QStringLiteral("SlipBorderTopOutlineSize"), m_slipBorderTopOutlineSize);
     if (slipBorderTopOutlineSize >= 0) {
         m_slipBorderTopOutlineSize = slipBorderTopOutlineSize;
     }
     const float slipBorderBottomOutlineSize = skinContext.selectFloat(
-            node, "SlipBorderBottomOutlineSize", m_slipBorderBottomOutlineSize);
+            node, QStringLiteral("SlipBorderBottomOutlineSize"), m_slipBorderBottomOutlineSize);
     if (slipBorderBottomOutlineSize >= 0) {
         m_slipBorderBottomOutlineSize = slipBorderBottomOutlineSize;
     }

--- a/src/waveform/renderers/allshader/waveformrendererslipmode.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererslipmode.cpp
@@ -1,9 +1,14 @@
 #include "waveform/renderers/allshader/waveformrendererslipmode.h"
 
 #include <QDomNode>
+#include <QVector4D>
 #include <memory>
 
 #include "control/controlproxy.h"
+#include "rendergraph/geometry.h"
+#include "rendergraph/material/rgbamaterial.h"
+#include "rendergraph/vertexupdaters/rgbavertexupdater.h"
+#include "util/colorcomponents.h"
 #include "waveform/renderers/waveformwidgetrenderer.h"
 #include "waveform/waveformwidgetfactory.h"
 #include "widget/wskincolor.h"
@@ -11,106 +16,119 @@
 namespace {
 
 constexpr int kBlinkingPeriodMillis = 1600;
-// Position matrix passed to OpenGL when drawing the shader
-constexpr float positionArray[] = {-1.f, -1.f, 1.f, -1.f, -1.f, 1.f, 1.f, 1.f};
 
 // Used as default outline color in case no value is provided in the theme
-
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-constexpr
-#else
-const
-#endif
-        QColor kDefaultColor = QColor(224, 224, 224);
+constexpr QColor kDefaultColor = QColor(224, 224, 224);
 
 } // anonymous namespace
+
+using namespace rendergraph;
 
 namespace allshader {
 
 WaveformRendererSlipMode::WaveformRendererSlipMode(
         WaveformWidgetRenderer* waveformWidget)
-        : WaveformRenderer(waveformWidget),
+        : ::WaveformRendererAbstract(waveformWidget),
           m_slipBorderTopOutlineSize(10.f),
           m_slipBorderBottomOutlineSize(10.f) {
+    initForRectangles<RGBAMaterial>(0);
+    setUsePreprocess(true);
+}
+
+void WaveformRendererSlipMode::draw(QPainter* painter, QPaintEvent* event) {
+    Q_UNUSED(painter);
+    Q_UNUSED(event);
+    DEBUG_ASSERT(false);
 }
 
 bool WaveformRendererSlipMode::init() {
     m_timer.restart();
 
-    m_pSlipMode = std::make_unique<ControlProxy>(
-            m_waveformRenderer->getGroup(), "slip_enabled");
+    m_pSlipModeControl.reset(new ControlProxy(
+            m_waveformRenderer->getGroup(), "slip_enabled"));
 
     return true;
 }
 
-void WaveformRendererSlipMode::setup(const QDomNode& node, const SkinContext& context) {
-    const QString slipModeOutlineColorName = context.selectString(node, "SlipBorderOutlineColor");
+void WaveformRendererSlipMode::setup(const QDomNode& node, const SkinContext& skinContext) {
+    const QString slipModeOutlineColorName =
+            skinContext.selectString(node, "SlipBorderOutlineColor");
     if (!slipModeOutlineColorName.isNull()) {
         m_color = WSkinColor::getCorrectColor(QColor(slipModeOutlineColorName));
     } else {
         m_color = kDefaultColor;
     }
-    const float slipBorderTopOutlineSize = context.selectFloat(
+    const float slipBorderTopOutlineSize = skinContext.selectFloat(
             node, "SlipBorderTopOutlineSize", m_slipBorderTopOutlineSize);
     if (slipBorderTopOutlineSize >= 0) {
         m_slipBorderTopOutlineSize = slipBorderTopOutlineSize;
     }
-    const float slipBorderBottomOutlineSize = context.selectFloat(
+    const float slipBorderBottomOutlineSize = skinContext.selectFloat(
             node, "SlipBorderBottomOutlineSize", m_slipBorderBottomOutlineSize);
     if (slipBorderBottomOutlineSize >= 0) {
         m_slipBorderBottomOutlineSize = slipBorderBottomOutlineSize;
     }
 }
 
-void WaveformRendererSlipMode::initializeGL() {
-    m_shader.init();
+void WaveformRendererSlipMode::preprocess() {
+    if (!preprocessInner()) {
+        geometry().allocate(0);
+        markDirtyGeometry();
+    }
 }
 
-void WaveformRendererSlipMode::paintGL() {
-    if (!m_pSlipMode->toBool() || !m_waveformRenderer->isSlipActive()) {
-        return;
+bool WaveformRendererSlipMode::preprocessInner() {
+    if (!m_pSlipModeControl->toBool() || !m_waveformRenderer->isSlipActive()) {
+        return false;
     }
 
     const int elapsed = m_timer.elapsed().toIntegerMillis() % kBlinkingPeriodMillis;
 
-    const double blinkIntensity =
-            static_cast<double>(2 * abs(elapsed - kBlinkingPeriodMillis / 2)) /
+    const float blinkIntensity =
+            static_cast<float>(
+                    2 * std::abs(elapsed - kBlinkingPeriodMillis / 2)) /
             kBlinkingPeriodMillis;
 
-    const double alpha = 0.25 + 0.5 * blinkIntensity;
+    const float alpha = std::clamp(0.25 + 0.5 * blinkIntensity, 0.0, 1.0);
 
-    if (alpha != 0.0) {
-        QColor color = m_color;
-        color.setAlphaF(static_cast<float>(alpha));
+    const float posx1 = 0.f;
+    const float posx2 = m_waveformRenderer->getLength();
+    const float posy1 = 0.f;
+    const float posy2 = m_waveformRenderer->getBreadth() / 2.f;
 
-        glEnable(GL_BLEND);
-        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    const float sideBorderOutlineSide = m_slipBorderTopOutlineSize;
 
-        const int colorLocation = m_shader.colorLocation();
-        const int borderLocation = m_shader.boarderLocation();
-        const int positionLocation = m_shader.positionLocation();
-        const int gradientLocation = m_shader.dimensionLocation();
+    const QVector4D bgColor{0.f, 0.f, 0.f, 1.f};
+    const QVector4D borderColor{m_color.redF(), m_color.greenF(), m_color.blueF(), alpha};
+    const QVector4D borderColor0{m_color.redF(), m_color.greenF(), m_color.blueF(), 0.f};
 
-        m_shader.bind();
-        m_shader.enableAttributeArray(positionLocation);
+    const int numVerticesPerLine = 6;            // 2 triangles
+    geometry().allocate(numVerticesPerLine * 5); // border on 4 sides + bgColor filler in center
 
-        m_shader.setUniformValue(colorLocation, color);
-        m_shader.setUniformValue(borderLocation,
-                m_slipBorderTopOutlineSize,
-                m_slipBorderBottomOutlineSize);
+    RGBAVertexUpdater vertexUpdater{geometry().vertexDataAs<Geometry::RGBAColoredPoint2D>()};
 
-        m_shader.setAttributeArray(
-                positionLocation, GL_FLOAT, positionArray, 2);
+    vertexUpdater.addRectangle(
+            {posx1, posy1},
+            {posx2, posy2},
+            bgColor);
 
-        m_shader.setUniformValue(gradientLocation,
-                static_cast<float>(m_waveformRenderer->getLength()) / 2,
-                static_cast<float>(m_waveformRenderer->getBreadth()) / 2);
+    vertexUpdater.addRectangle(
+            {posx1, posy1}, {posx2, posy1 + m_slipBorderTopOutlineSize}, borderColor);
+    vertexUpdater.addRectangle({posx1, posy1 + m_slipBorderTopOutlineSize},
+            {posx1 + sideBorderOutlineSide,
+                    posy2},
+            borderColor);
+    vertexUpdater.addRectangle({posx2 - sideBorderOutlineSide, posy1 + m_slipBorderTopOutlineSize},
+            {posx2, posy2},
+            borderColor);
+    vertexUpdater.addRectangleVGradient({posx1, posy2},
+            {posx2, posy2 + m_slipBorderBottomOutlineSize},
+            borderColor,
+            borderColor0);
+    markDirtyGeometry();
+    markDirtyMaterial();
 
-        glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
-
-        m_shader.disableAttributeArray(positionLocation);
-        m_shader.release();
-    }
+    return true;
 }
 
 } // namespace allshader

--- a/src/waveform/renderers/allshader/waveformrendererslipmode.h
+++ b/src/waveform/renderers/allshader/waveformrendererslipmode.h
@@ -3,11 +3,11 @@
 #include <QColor>
 #include <memory>
 
-#include "rendergraph/openglnode.h"
-#include "shaders/slipmodeshader.h"
+#include "rendergraph/geometrynode.h"
+#include "rendergraph/opacitynode.h"
 #include "util/class.h"
 #include "util/performancetimer.h"
-#include "waveform/renderers/allshader/waveformrenderer.h"
+#include "waveform/renderers/waveformrendererabstract.h"
 
 class ControlProxy;
 class QDomNode;
@@ -18,28 +18,32 @@ class WaveformRendererSlipMode;
 }
 
 class allshader::WaveformRendererSlipMode final
-        : public allshader::WaveformRenderer,
-          public rendergraph::OpenGLNode {
+        : public ::WaveformRendererAbstract,
+          public rendergraph::GeometryNode {
   public:
     explicit WaveformRendererSlipMode(
             WaveformWidgetRenderer* waveformWidget);
+
+    // Pure virtual from WaveformRendererAbstract, not used
+    void draw(QPainter* painter, QPaintEvent* event) override final;
 
     void setup(const QDomNode& node, const SkinContext& skinContext) override;
 
     bool init() override;
 
-    void initializeGL() override;
-    void paintGL() override;
+    // Virtual for rendergraph::Node
+    void preprocess() override;
 
   private:
-    mixxx::SlipModeShader m_shader;
-    std::unique_ptr<ControlProxy> m_pSlipMode;
+    std::unique_ptr<ControlProxy> m_pSlipModeControl;
 
     float m_slipBorderTopOutlineSize;
     float m_slipBorderBottomOutlineSize;
 
     QColor m_color;
     PerformanceTimer m_timer;
+
+    bool preprocessInner();
 
     DISALLOW_COPY_AND_ASSIGN(WaveformRendererSlipMode);
 };


### PR DESCRIPTION
Ports the slip waveformrenderer to a rendergraph node. This can be reviewed and merged independently from the PRs for the other waveformrenderers.