### PR TITLE
Fix memory leak and use parented_ptr in WTrackMenu

### DIFF
--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -162,58 +162,64 @@ void WTrackMenu::popup(const QPoint& pos, QAction* at) {
 
 void WTrackMenu::createMenus() {
     if (featureIsEnabled(Feature::LoadTo)) {
-        m_pLoadToMenu = new QMenu(this);
+        m_pLoadToMenu = make_parented<QMenu>(this);
         m_pLoadToMenu->setTitle(tr("Load to"));
-        m_pDeckMenu = new QMenu(m_pLoadToMenu);
+        m_pDeckMenu = make_parented<QMenu>(m_pLoadToMenu);
         m_pDeckMenu->setTitle(tr("Deck"));
-        m_pSamplerMenu = new QMenu(m_pLoadToMenu);
+        m_pSamplerMenu = make_parented<QMenu>(m_pLoadToMenu);
         m_pSamplerMenu->setTitle(tr("Sampler"));
     }
 
     if (featureIsEnabled(Feature::Playlist)) {
-        m_pPlaylistMenu = new QMenu(this);
+        m_pPlaylistMenu = make_parented<QMenu>(this);
         m_pPlaylistMenu->setTitle(tr("Add to Playlist"));
         connect(m_pPlaylistMenu, &QMenu::aboutToShow, this, &WTrackMenu::slotPopulatePlaylistMenu);
     }
 
     if (featureIsEnabled(Feature::Crate)) {
-        m_pCrateMenu = new QMenu(this);
+        m_pCrateMenu = make_parented<QMenu>(this);
         m_pCrateMenu->setTitle(tr("Crates"));
         m_pCrateMenu->setObjectName("CratesMenu");
         connect(m_pCrateMenu, &QMenu::aboutToShow, this, &WTrackMenu::slotPopulateCrateMenu);
     }
 
     if (featureIsEnabled(Feature::Metadata)) {
-        m_pMetadataMenu = new QMenu(this);
+        m_pMetadataMenu = make_parented<QMenu>(this);
         m_pMetadataMenu->setTitle(tr("Metadata"));
 
-        m_pMetadataUpdateExternalCollectionsMenu = new QMenu(m_pMetadataMenu);
+        m_pMetadataUpdateExternalCollectionsMenu = make_parented<QMenu>(m_pMetadataMenu);
         m_pMetadataUpdateExternalCollectionsMenu->setTitle(tr("Update external collections"));
 
-        m_pCoverMenu = new WCoverArtMenu(m_pMetadataMenu);
+        m_pCoverMenu = make_parented<WCoverArtMenu>(m_pMetadataMenu);
         m_pCoverMenu->setTitle(tr("Cover Art"));
-        connect(m_pCoverMenu, &WCoverArtMenu::coverInfoSelected, this, &WTrackMenu::slotCoverInfoSelected);
-        connect(m_pCoverMenu, &WCoverArtMenu::reloadCoverArt, this, &WTrackMenu::slotReloadCoverArt);
+        connect(m_pCoverMenu.get(),
+                &WCoverArtMenu::coverInfoSelected,
+                this,
+                &WTrackMenu::slotCoverInfoSelected);
+        connect(m_pCoverMenu.get(),
+                &WCoverArtMenu::reloadCoverArt,
+                this,
+                &WTrackMenu::slotReloadCoverArt);
     }
 
     if (featureIsEnabled(Feature::BPM)) {
-        m_pBPMMenu = new QMenu(this);
+        m_pBPMMenu = make_parented<QMenu>(this);
         m_pBPMMenu->setTitle(tr("Adjust BPM"));
     }
 
     if (featureIsEnabled(Feature::Color)) {
-        m_pColorMenu = new QMenu(this);
+        m_pColorMenu = make_parented<QMenu>(this);
         m_pColorMenu->setTitle(tr("Select Color"));
     }
 
     if (featureIsEnabled(Feature::Reset)) {
-        m_pClearMetadataMenu = new QMenu(this);
+        m_pClearMetadataMenu = make_parented<QMenu>(this);
         //: Reset metadata in right click track context menu in library
         m_pClearMetadataMenu->setTitle(tr("Clear"));
     }
 
     if (featureIsEnabled(Feature::Analyze)) {
-        m_pAnalyzeMenu = new QMenu(this);
+        m_pAnalyzeMenu = make_parented<QMenu>(this);
         m_pAnalyzeMenu->setTitle(tr("Analyze"));
     }
 
@@ -274,7 +280,7 @@ void WTrackMenu::createMenus() {
         // permanently delete files, put the action into a submenu for safety
         // reasons and display different messages in the delete dialogs.
 #if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
-        m_pRemoveFromDiskMenu = new QMenu(this);
+        m_pRemoveFromDiskMenu = make_parented<QMenu>(this);
         m_pRemoveFromDiskMenu->setTitle(tr("Delete Track Files"));
 #endif
     }

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -417,13 +417,13 @@ void WTrackMenu::createActions() {
         for (auto* const pExternalTrackCollection :
                 m_pLibrary->trackCollectionManager()->externalCollections()) {
             UpdateExternalTrackCollection updateInExternalTrackCollection;
-            updateInExternalTrackCollection.externalTrackCollection = pExternalTrackCollection;
-            updateInExternalTrackCollection.action = new QAction(
+            updateInExternalTrackCollection.pExternalTrackCollection = pExternalTrackCollection;
+            updateInExternalTrackCollection.pAction = make_parented<QAction>(
                     pExternalTrackCollection->name(), m_pMetadataMenu);
-            updateInExternalTrackCollection.action->setToolTip(
+            updateInExternalTrackCollection.pAction->setToolTip(
                     pExternalTrackCollection->description());
             m_updateInExternalTrackCollections += updateInExternalTrackCollection;
-            connect(updateInExternalTrackCollection.action,
+            connect(updateInExternalTrackCollection.pAction,
                     &QAction::triggered,
                     this,
                     [this, pExternalTrackCollection] {
@@ -661,7 +661,7 @@ void WTrackMenu::setupActions() {
         for (const auto& updateInExternalTrackCollection :
                 std::as_const(m_updateInExternalTrackCollections)) {
             m_pMetadataUpdateExternalCollectionsMenu->addAction(
-                    updateInExternalTrackCollection.action);
+                    updateInExternalTrackCollection.pAction);
         }
         if (!m_pMetadataUpdateExternalCollectionsMenu->isEmpty()) {
             m_pMetadataMenu->addMenu(m_pMetadataUpdateExternalCollectionsMenu);
@@ -673,9 +673,9 @@ void WTrackMenu::setupActions() {
                     [this] {
                         for (const auto& updateInExternalTrackCollection :
                                 std::as_const(m_updateInExternalTrackCollections)) {
-                            updateInExternalTrackCollection.action->setEnabled(
+                            updateInExternalTrackCollection.pAction->setEnabled(
                                     updateInExternalTrackCollection
-                                            .externalTrackCollection
+                                            .pExternalTrackCollection
                                             ->isConnected());
                         }
                     });
@@ -954,7 +954,7 @@ void WTrackMenu::updateMenus() {
                 bool deckEnabled =
                         (!deckPlaying || allowLoadTrackIntoPlayingDeck) &&
                         singleTrackSelected;
-                QAction* pAction = new QAction(tr("Deck %1").arg(i), this);
+                auto pAction = make_parented<QAction>(tr("Deck %1").arg(i), this);
                 pAction->setEnabled(deckEnabled);
                 m_pDeckMenu->addAction(pAction);
                 connect(pAction, &QAction::triggered, this, [this, deckGroup] { loadSelectionToGroup(deckGroup); });
@@ -973,7 +973,7 @@ void WTrackMenu::updateMenus() {
                     samplersInMenu = 0;
                     int limit = iNumSamplers > i + 15 ? i + 15 : iNumSamplers;
                     const QString label = samplerTrString(i) + QStringLiteral("- %1").arg(limit);
-                    pMenu = new QMenu(label, m_pSamplerMenu);
+                    pMenu = make_parented<QMenu>(label, m_pSamplerMenu);
                     m_pSamplerMenu->addMenu(pMenu);
                 }
                 samplersInMenu++;
@@ -982,7 +982,7 @@ void WTrackMenu::updateMenus() {
                 bool samplerPlaying = ControlObject::get(
                                               ConfigKey(samplerGroup, "play")) > 0.0;
                 bool samplerEnabled = !samplerPlaying && singleTrackSelected;
-                QAction* pAction = new QAction(samplerTrString(i), pMenu);
+                auto pAction = make_parented<QAction>(samplerTrString(i), pMenu);
                 pAction->setEnabled(samplerEnabled);
                 pMenu->addAction(pAction);
                 connect(pAction,
@@ -1431,7 +1431,7 @@ void WTrackMenu::slotPopulatePlaylistMenu() {
         // No leak because making the menu the parent means they will be
         // auto-deleted
         int plId = id;
-        auto* pAction = new QAction(
+        auto pAction = make_parented<QAction>(
                 mixxx::escapeTextPropertyWithoutShortcuts(name),
                 m_pPlaylistMenu);
         bool locked = playlistDao.isPlaylistLocked(plId);
@@ -1445,7 +1445,7 @@ void WTrackMenu::slotPopulatePlaylistMenu() {
                 });
     }
     m_pPlaylistMenu->addSeparator();
-    QAction* newPlaylistAction = new QAction(tr("Create New Playlist"), m_pPlaylistMenu);
+    auto newPlaylistAction = make_parented<QAction>(tr("Create New Playlist"), m_pPlaylistMenu);
     m_pPlaylistMenu->addAction(newPlaylistAction);
     connect(newPlaylistAction, &QAction::triggered, this, [this] { addSelectionToPlaylist(-1); });
     m_bPlaylistMenuLoaded = true;

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -293,18 +293,18 @@ void WTrackMenu::createActions() {
                     kHideRemoveShortcutKey);
 
     if (featureIsEnabled(Feature::AutoDJ)) {
-        m_pAutoDJBottomAct = new QAction(tr("Add to Auto DJ Queue (bottom)"), this);
+        m_pAutoDJBottomAct = make_parented<QAction>(tr("Add to Auto DJ Queue (bottom)"), this);
         connect(m_pAutoDJBottomAct, &QAction::triggered, this, &WTrackMenu::slotAddToAutoDJBottom);
 
-        m_pAutoDJTopAct = new QAction(tr("Add to Auto DJ Queue (top)"), this);
+        m_pAutoDJTopAct = make_parented<QAction>(tr("Add to Auto DJ Queue (top)"), this);
         connect(m_pAutoDJTopAct, &QAction::triggered, this, &WTrackMenu::slotAddToAutoDJTop);
 
-        m_pAutoDJReplaceAct = new QAction(tr("Add to Auto DJ Queue (replace)"), this);
+        m_pAutoDJReplaceAct = make_parented<QAction>(tr("Add to Auto DJ Queue (replace)"), this);
         connect(m_pAutoDJReplaceAct, &QAction::triggered, this, &WTrackMenu::slotAddToAutoDJReplace);
     }
 
     if (featureIsEnabled(Feature::LoadTo)) {
-        m_pAddToPreviewDeck = new QAction(tr("Preview Deck"), m_pLoadToMenu);
+        m_pAddToPreviewDeck = make_parented<QAction>(tr("Preview Deck"), m_pLoadToMenu);
         // currently there is only one preview deck so just map it here.
         QString previewDeckGroup = PlayerManager::groupForPreviewDeck(0);
         connect(m_pAddToPreviewDeck, &QAction::triggered, this, [this, previewDeckGroup] { loadSelectionToGroup(previewDeckGroup); });
@@ -313,21 +313,21 @@ void WTrackMenu::createActions() {
     if (featureIsEnabled(Feature::Remove)) {
         // Keyboard shortcuts are set here just to have them displayed in the menu.
         // Actual keypress is handled in WTrackTableView::keyPressEvent().
-        m_pRemoveAct = new QAction(tr("Remove"), this);
+        m_pRemoveAct = make_parented<QAction>(tr("Remove"), this);
         m_pRemoveAct->setShortcut(hideRemoveKeySequence);
         connect(m_pRemoveAct, &QAction::triggered, this, &WTrackMenu::slotRemove);
 
-        m_pRemovePlaylistAct = new QAction(tr("Remove from Playlist"), this);
+        m_pRemovePlaylistAct = make_parented<QAction>(tr("Remove from Playlist"), this);
         m_pRemovePlaylistAct->setShortcut(hideRemoveKeySequence);
         connect(m_pRemovePlaylistAct, &QAction::triggered, this, &WTrackMenu::slotRemove);
 
-        m_pRemoveCrateAct = new QAction(tr("Remove from Crate"), this);
+        m_pRemoveCrateAct = make_parented<QAction>(tr("Remove from Crate"), this);
         m_pRemoveCrateAct->setShortcut(hideRemoveKeySequence);
         connect(m_pRemoveCrateAct, &QAction::triggered, this, &WTrackMenu::slotRemove);
     }
 
     if (featureIsEnabled(Feature::HideUnhidePurge)) {
-        m_pHideAct = new QAction(tr("Hide from Library"), this);
+        m_pHideAct = make_parented<QAction>(tr("Hide from Library"), this);
         // This is just for having the shortcut displayed next to the action in the menu.
         // The actual keypress is handled in WTrackTableView::keyPressEvent().
         // Note: don't show the hotkey for more than one action
@@ -336,18 +336,19 @@ void WTrackMenu::createActions() {
         }
         connect(m_pHideAct, &QAction::triggered, this, &WTrackMenu::slotHide);
 
-        m_pUnhideAct = new QAction(tr("Unhide from Library"), this);
+        m_pUnhideAct = make_parented<QAction>(tr("Unhide from Library"), this);
         connect(m_pUnhideAct, &QAction::triggered, this, &WTrackMenu::slotUnhide);
 
-        m_pPurgeAct = new QAction(tr("Purge from Library"), this);
+        m_pPurgeAct = make_parented<QAction>(tr("Purge from Library"), this);
         connect(m_pPurgeAct, &QAction::triggered, this, &WTrackMenu::slotPurge);
     }
 
     if (featureIsEnabled(Feature::RemoveFromDisk)) {
 #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
-        m_pRemoveFromDiskAct = new QAction(tr("Move Track File(s) to Trash"), this);
+        m_pRemoveFromDiskAct = make_parented<QAction>(tr("Move Track File(s) to Trash"), this);
 #else
-        m_pRemoveFromDiskAct = new QAction(tr("Delete Files from Disk"), m_pRemoveFromDiskMenu);
+        m_pRemoveFromDiskAct = make_parented<QAction>(
+                tr("Delete Files from Disk"), m_pRemoveFromDiskMenu);
 #endif
         connect(m_pRemoveFromDiskAct,
                 &QAction::triggered,
@@ -356,7 +357,7 @@ void WTrackMenu::createActions() {
     }
 
     if (featureIsEnabled(Feature::Metadata)) {
-        m_pStarRatingAction = new WStarRatingAction(this);
+        m_pStarRatingAction = make_parented<WStarRatingAction>(this);
         m_pStarRatingAction->setObjectName("RatingAction");
         connect(m_pStarRatingAction,
                 &WStarRatingAction::ratingSet,
@@ -365,7 +366,7 @@ void WTrackMenu::createActions() {
     }
 
     if (featureIsEnabled(Feature::Properties)) {
-        m_pPropertiesAct = new QAction(tr("Properties"), this);
+        m_pPropertiesAct = make_parented<QAction>(tr("Properties"), this);
         // This is just for having the shortcut displayed next to the action
         // when the menu is invoked from the tracks table.
         // The keypress is caught in WTrackTableView::keyPressEvent
@@ -380,32 +381,32 @@ void WTrackMenu::createActions() {
     }
 
     if (featureIsEnabled(Feature::FileBrowser)) {
-        m_pFileBrowserAct = new QAction(tr("Open in File Browser"), this);
+        m_pFileBrowserAct = make_parented<QAction>(tr("Open in File Browser"), this);
         connect(m_pFileBrowserAct, &QAction::triggered, this, &WTrackMenu::slotOpenInFileBrowser);
     }
 
     if (featureIsEnabled(Feature::SelectInLibrary)) {
-        m_pSelectInLibraryAct = new QAction(tr("Select in Library"), this);
+        m_pSelectInLibraryAct = make_parented<QAction>(tr("Select in Library"), this);
         connect(m_pSelectInLibraryAct, &QAction::triggered, this, &WTrackMenu::slotSelectInLibrary);
     }
 
     if (featureIsEnabled(Feature::Metadata)) {
         m_pImportMetadataFromFileAct =
-                new QAction(tr("Import From File Tags"), m_pMetadataMenu);
+                make_parented<QAction>(tr("Import From File Tags"), m_pMetadataMenu);
         connect(m_pImportMetadataFromFileAct,
                 &QAction::triggered,
                 this,
                 &WTrackMenu::slotImportMetadataFromFileTags);
 
         m_pImportMetadataFromMusicBrainzAct =
-                new QAction(tr("Import From MusicBrainz"), m_pMetadataMenu);
+                make_parented<QAction>(tr("Import From MusicBrainz"), m_pMetadataMenu);
         connect(m_pImportMetadataFromMusicBrainzAct,
                 &QAction::triggered,
                 this,
                 &WTrackMenu::slotShowDlgTagFetcher);
 
         m_pExportMetadataAct =
-                new QAction(tr("Export To File Tags"), m_pMetadataMenu);
+                make_parented<QAction>(tr("Export To File Tags"), m_pMetadataMenu);
         connect(m_pExportMetadataAct,
                 &QAction::triggered,
                 this,
@@ -433,64 +434,64 @@ void WTrackMenu::createActions() {
 
     if (featureIsEnabled(Feature::Reset)) {
         // Clear metadata actions
-        m_pClearBeatsAction = new QAction(tr("BPM and Beatgrid"), m_pClearMetadataMenu);
+        m_pClearBeatsAction = make_parented<QAction>(tr("BPM and Beatgrid"), m_pClearMetadataMenu);
         connect(m_pClearBeatsAction, &QAction::triggered, this, &WTrackMenu::slotClearBeats);
 
-        m_pClearPlayCountAction = new QAction(tr("Play Count"), m_pClearMetadataMenu);
+        m_pClearPlayCountAction = make_parented<QAction>(tr("Play Count"), m_pClearMetadataMenu);
         connect(m_pClearPlayCountAction, &QAction::triggered, this, &WTrackMenu::slotClearPlayCount);
 
-        m_pClearRatingAction = new QAction(tr("Rating"), m_pClearMetadataMenu);
+        m_pClearRatingAction = make_parented<QAction>(tr("Rating"), m_pClearMetadataMenu);
         connect(m_pClearRatingAction, &QAction::triggered, this, &WTrackMenu::slotClearRating);
 
-        m_pClearMainCueAction = new QAction(tr("Cue Point"), m_pClearMetadataMenu);
+        m_pClearMainCueAction = make_parented<QAction>(tr("Cue Point"), m_pClearMetadataMenu);
         connect(m_pClearMainCueAction, &QAction::triggered, this, &WTrackMenu::slotResetMainCue);
 
-        m_pClearHotCuesAction = new QAction(tr("Hotcues"), m_pClearMetadataMenu);
+        m_pClearHotCuesAction = make_parented<QAction>(tr("Hotcues"), m_pClearMetadataMenu);
         connect(m_pClearHotCuesAction, &QAction::triggered, this, &WTrackMenu::slotClearHotCues);
 
-        m_pClearIntroCueAction = new QAction(tr("Intro"), m_pClearMetadataMenu);
+        m_pClearIntroCueAction = make_parented<QAction>(tr("Intro"), m_pClearMetadataMenu);
         connect(m_pClearIntroCueAction, &QAction::triggered, this, &WTrackMenu::slotResetIntroCue);
 
-        m_pClearOutroCueAction = new QAction(tr("Outro"), m_pClearMetadataMenu);
+        m_pClearOutroCueAction = make_parented<QAction>(tr("Outro"), m_pClearMetadataMenu);
         connect(m_pClearOutroCueAction, &QAction::triggered, this, &WTrackMenu::slotResetOutroCue);
 
-        m_pClearLoopsAction = new QAction(tr("Loops"), m_pClearMetadataMenu);
+        m_pClearLoopsAction = make_parented<QAction>(tr("Loops"), m_pClearMetadataMenu);
         connect(m_pClearLoopsAction, &QAction::triggered, this, &WTrackMenu::slotClearLoops);
 
-        m_pClearKeyAction = new QAction(tr("Key"), m_pClearMetadataMenu);
+        m_pClearKeyAction = make_parented<QAction>(tr("Key"), m_pClearMetadataMenu);
         connect(m_pClearKeyAction, &QAction::triggered, this, &WTrackMenu::slotClearKey);
 
-        m_pClearReplayGainAction = new QAction(tr("ReplayGain"), m_pClearMetadataMenu);
+        m_pClearReplayGainAction = make_parented<QAction>(tr("ReplayGain"), m_pClearMetadataMenu);
         connect(m_pClearReplayGainAction, &QAction::triggered, this, &WTrackMenu::slotClearReplayGain);
 
-        m_pClearWaveformAction = new QAction(tr("Waveform"), m_pClearMetadataMenu);
+        m_pClearWaveformAction = make_parented<QAction>(tr("Waveform"), m_pClearMetadataMenu);
         connect(m_pClearWaveformAction, &QAction::triggered, this, &WTrackMenu::slotClearWaveform);
 
-        m_pClearCommentAction = new QAction(tr("Comment"), m_pClearMetadataMenu);
+        m_pClearCommentAction = make_parented<QAction>(tr("Comment"), m_pClearMetadataMenu);
         connect(m_pClearCommentAction, &QAction::triggered, this, &WTrackMenu::slotClearComment);
 
-        m_pClearAllMetadataAction = new QAction(tr("All"), m_pClearMetadataMenu);
+        m_pClearAllMetadataAction = make_parented<QAction>(tr("All"), m_pClearMetadataMenu);
         connect(m_pClearAllMetadataAction, &QAction::triggered, this, &WTrackMenu::slotClearAllMetadata);
     }
 
     if (featureIsEnabled(Feature::BPM)) {
-        m_pBpmLockAction = new QAction(tr("Lock BPM"), m_pBPMMenu);
-        m_pBpmUnlockAction = new QAction(tr("Unlock BPM"), m_pBPMMenu);
+        m_pBpmLockAction = make_parented<QAction>(tr("Lock BPM"), m_pBPMMenu);
+        m_pBpmUnlockAction = make_parented<QAction>(tr("Unlock BPM"), m_pBPMMenu);
         connect(m_pBpmLockAction, &QAction::triggered, this, &WTrackMenu::slotLockBpm);
         connect(m_pBpmUnlockAction, &QAction::triggered, this, &WTrackMenu::slotUnlockBpm);
 
         //BPM edit actions
-        m_pBpmDoubleAction = new QAction(tr("Double BPM"), m_pBPMMenu);
+        m_pBpmDoubleAction = make_parented<QAction>(tr("Double BPM"), m_pBPMMenu);
         storeActionTextAndScaleInProperties(m_pBpmDoubleAction, 2.0);
-        m_pBpmHalveAction = new QAction(tr("Halve BPM"), m_pBPMMenu);
+        m_pBpmHalveAction = make_parented<QAction>(tr("Halve BPM"), m_pBPMMenu);
         storeActionTextAndScaleInProperties(m_pBpmHalveAction, 0.5);
-        m_pBpmTwoThirdsAction = new QAction(tr("2/3 BPM"), m_pBPMMenu);
+        m_pBpmTwoThirdsAction = make_parented<QAction>(tr("2/3 BPM"), m_pBPMMenu);
         storeActionTextAndScaleInProperties(m_pBpmTwoThirdsAction, 2.0 / 3.0);
-        m_pBpmThreeFourthsAction = new QAction(tr("3/4 BPM"), m_pBPMMenu);
+        m_pBpmThreeFourthsAction = make_parented<QAction>(tr("3/4 BPM"), m_pBPMMenu);
         storeActionTextAndScaleInProperties(m_pBpmThreeFourthsAction, 3.0 / 4.0);
-        m_pBpmFourThirdsAction = new QAction(tr("4/3 BPM"), m_pBPMMenu);
+        m_pBpmFourThirdsAction = make_parented<QAction>(tr("4/3 BPM"), m_pBPMMenu);
         storeActionTextAndScaleInProperties(m_pBpmFourThirdsAction, 4.0 / 3.0);
-        m_pBpmThreeHalvesAction = new QAction(tr("3/2 BPM"), m_pBPMMenu);
+        m_pBpmThreeHalvesAction = make_parented<QAction>(tr("3/2 BPM"), m_pBPMMenu);
         storeActionTextAndScaleInProperties(m_pBpmThreeHalvesAction, 3.0 / 2.0);
 
         connect(m_pBpmDoubleAction, &QAction::triggered, this, [this] {
@@ -512,13 +513,13 @@ void WTrackMenu::createActions() {
             slotScaleBpm(mixxx::Beats::BpmScale::ThreeHalves);
         });
 
-        m_pBpmResetAction = new QAction(tr("Clear BPM and Beatgrid"), m_pBPMMenu);
+        m_pBpmResetAction = make_parented<QAction>(tr("Clear BPM and Beatgrid"), m_pBPMMenu);
         connect(m_pBpmResetAction,
                 &QAction::triggered,
                 this,
                 &WTrackMenu::slotClearBeats);
 
-        m_pBpmUndoAction = new QAction(tr("Undo last BPM/beats change"), m_pBPMMenu);
+        m_pBpmUndoAction = make_parented<QAction>(tr("Undo last BPM/beats change"), m_pBPMMenu);
         connect(m_pBpmUndoAction,
                 &QAction::triggered,
                 this,
@@ -526,19 +527,19 @@ void WTrackMenu::createActions() {
     }
 
     if (featureIsEnabled(Feature::Analyze)) {
-        m_pAnalyzeAction = new QAction(tr("Analyze"), this);
+        m_pAnalyzeAction = make_parented<QAction>(tr("Analyze"), this);
         connect(m_pAnalyzeAction, &QAction::triggered, this, &WTrackMenu::slotAnalyze);
 
-        m_pReanalyzeAction = new QAction(tr("Reanalyze"), this);
+        m_pReanalyzeAction = make_parented<QAction>(tr("Reanalyze"), this);
         connect(m_pReanalyzeAction, &QAction::triggered, this, &WTrackMenu::slotReanalyze);
 
-        m_pReanalyzeConstBpmAction = new QAction(tr("Reanalyze (constant BPM)"), this);
+        m_pReanalyzeConstBpmAction = make_parented<QAction>(tr("Reanalyze (constant BPM)"), this);
         connect(m_pReanalyzeConstBpmAction,
                 &QAction::triggered,
                 this,
                 &WTrackMenu::slotReanalyzeWithFixedTempo);
 
-        m_pReanalyzeVarBpmAction = new QAction(tr("Reanalyze (variable BPM)"), this);
+        m_pReanalyzeVarBpmAction = make_parented<QAction>(tr("Reanalyze (variable BPM)"), this);
         connect(m_pReanalyzeVarBpmAction,
                 &QAction::triggered,
                 this,
@@ -549,8 +550,8 @@ void WTrackMenu::createActions() {
     // for WTrackmenu instantiated by WTrackProperty and other deck widgets, thus
     // don't create it if a track model is set.
     if (!m_pTrackModel && featureIsEnabled(Feature::UpdateReplayGainFromPregain)) {
-        m_pUpdateReplayGainAct =
-                new QAction(tr("Update ReplayGain from Deck Gain"), m_pClearMetadataMenu);
+        m_pUpdateReplayGainAct = make_parented<QAction>(
+                tr("Update ReplayGain from Deck Gain"), m_pClearMetadataMenu);
         connect(m_pUpdateReplayGainAct,
                 &QAction::triggered,
                 this,
@@ -559,7 +560,7 @@ void WTrackMenu::createActions() {
 
     if (featureIsEnabled(Feature::Color)) {
         ColorPaletteSettings colorPaletteSettings(m_pConfig);
-        m_pColorPickerAction = new WColorPickerAction(WColorPicker::Option::AllowNoColor,
+        m_pColorPickerAction = make_parented<WColorPickerAction>(WColorPicker::Option::AllowNoColor,
                 colorPaletteSettings.getTrackColorPalette(),
                 m_pColorMenu);
         m_pColorPickerAction->setObjectName("TrackColorPickerAction");

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -274,77 +274,77 @@ class WTrackMenu : public QMenu {
 #endif
 
     // Update ReplayGain from Track
-    QAction* m_pUpdateReplayGainAct{};
+    parented_ptr<QAction> m_pUpdateReplayGainAct;
 
     // Reload Track Metadata Action:
-    QAction* m_pImportMetadataFromFileAct{};
-    QAction* m_pImportMetadataFromMusicBrainzAct{};
+    parented_ptr<QAction> m_pImportMetadataFromFileAct;
+    parented_ptr<QAction> m_pImportMetadataFromMusicBrainzAct;
 
     // Save Track Metadata Action:
-    QAction* m_pExportMetadataAct{};
+    parented_ptr<QAction> m_pExportMetadataAct;
 
     // Load Track to PreviewDeck
-    QAction* m_pAddToPreviewDeck{};
+    parented_ptr<QAction> m_pAddToPreviewDeck;
 
     // Send to Auto-DJ Action
-    QAction* m_pAutoDJBottomAct{};
-    QAction* m_pAutoDJTopAct{};
-    QAction* m_pAutoDJReplaceAct{};
+    parented_ptr<QAction> m_pAutoDJBottomAct;
+    parented_ptr<QAction> m_pAutoDJTopAct;
+    parented_ptr<QAction> m_pAutoDJReplaceAct;
 
     // Remove from table
-    QAction* m_pRemoveAct{};
-    QAction* m_pRemovePlaylistAct{};
-    QAction* m_pRemoveCrateAct{};
-    QAction* m_pHideAct{};
-    QAction* m_pUnhideAct{};
-    QAction* m_pPurgeAct{};
-    QAction* m_pRemoveFromDiskAct{};
+    parented_ptr<QAction> m_pRemoveAct;
+    parented_ptr<QAction> m_pRemovePlaylistAct;
+    parented_ptr<QAction> m_pRemoveCrateAct;
+    parented_ptr<QAction> m_pHideAct;
+    parented_ptr<QAction> m_pUnhideAct;
+    parented_ptr<QAction> m_pPurgeAct;
+    parented_ptr<QAction> m_pRemoveFromDiskAct;
 
     // Show track-editor action
-    QAction* m_pPropertiesAct{};
+    parented_ptr<QAction> m_pPropertiesAct;
 
     // Open file in default file browser
-    QAction* m_pFileBrowserAct{};
+    parented_ptr<QAction> m_pFileBrowserAct;
 
     // Select track in library
-    QAction* m_pSelectInLibraryAct{};
+    parented_ptr<QAction> m_pSelectInLibraryAct;
 
     // BPM feature
-    QAction* m_pBpmLockAction{};
-    QAction* m_pBpmUnlockAction{};
-    QAction* m_pBpmDoubleAction{};
-    QAction* m_pBpmHalveAction{};
-    QAction* m_pBpmTwoThirdsAction{};
-    QAction* m_pBpmThreeFourthsAction{};
-    QAction* m_pBpmFourThirdsAction{};
-    QAction* m_pBpmThreeHalvesAction{};
-    QAction* m_pBpmResetAction{};
-    QAction* m_pBpmUndoAction{};
+    parented_ptr<QAction> m_pBpmLockAction;
+    parented_ptr<QAction> m_pBpmUnlockAction;
+    parented_ptr<QAction> m_pBpmDoubleAction;
+    parented_ptr<QAction> m_pBpmHalveAction;
+    parented_ptr<QAction> m_pBpmTwoThirdsAction;
+    parented_ptr<QAction> m_pBpmThreeFourthsAction;
+    parented_ptr<QAction> m_pBpmFourThirdsAction;
+    parented_ptr<QAction> m_pBpmThreeHalvesAction;
+    parented_ptr<QAction> m_pBpmResetAction;
+    parented_ptr<QAction> m_pBpmUndoAction;
 
     // Track rating and color
-    WStarRatingAction* m_pStarRatingAction{};
-    WColorPickerAction* m_pColorPickerAction{};
+    parented_ptr<WStarRatingAction> m_pStarRatingAction;
+    parented_ptr<WColorPickerAction> m_pColorPickerAction;
 
     // Analysis actions
-    QAction* m_pAnalyzeAction{};
-    QAction* m_pReanalyzeAction{};
-    QAction* m_pReanalyzeConstBpmAction{};
-    QAction* m_pReanalyzeVarBpmAction{};
+    parented_ptr<QAction> m_pAnalyzeAction;
+    parented_ptr<QAction> m_pReanalyzeAction;
+    parented_ptr<QAction> m_pReanalyzeConstBpmAction;
+    parented_ptr<QAction> m_pReanalyzeVarBpmAction;
 
     // Clear track metadata actions
-    QAction* m_pClearBeatsAction{};
-    QAction* m_pClearPlayCountAction{};
-    QAction* m_pClearRatingAction{};
-    QAction* m_pClearMainCueAction{};
-    QAction* m_pClearHotCuesAction{};
-    QAction* m_pClearIntroCueAction{};
-    QAction* m_pClearOutroCueAction{};
-    QAction* m_pClearLoopsAction{};
-    QAction* m_pClearWaveformAction{};
-    QAction* m_pClearCommentAction{};
-    QAction* m_pClearKeyAction{};
-    QAction* m_pClearReplayGainAction{};
-    QAction* m_pClearAllMetadataAction{};
+    parented_ptr<QAction> m_pClearBeatsAction;
+    parented_ptr<QAction> m_pClearPlayCountAction;
+    parented_ptr<QAction> m_pClearRatingAction;
+    parented_ptr<QAction> m_pClearMainCueAction;
+    parented_ptr<QAction> m_pClearHotCuesAction;
+    parented_ptr<QAction> m_pClearIntroCueAction;
+    parented_ptr<QAction> m_pClearOutroCueAction;
+    parented_ptr<QAction> m_pClearLoopsAction;
+    parented_ptr<QAction> m_pClearWaveformAction;
+    parented_ptr<QAction> m_pClearCommentAction;
+    parented_ptr<QAction> m_pClearKeyAction;
+    parented_ptr<QAction> m_pClearReplayGainAction;
+    parented_ptr<QAction> m_pClearAllMetadataAction;
 
     const UserSettingsPointer m_pConfig;
     Library* const m_pLibrary;

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -358,8 +358,8 @@ class WTrackMenu : public QMenu {
     std::unique_ptr<DlgTagFetcher> m_pDlgTagFetcher;
 
     struct UpdateExternalTrackCollection {
-        QPointer<ExternalTrackCollection> externalTrackCollection;
-        QAction* action{};
+        QPointer<ExternalTrackCollection> pExternalTrackCollection;
+        QAction* pAction{};
     };
 
     QList<UpdateExternalTrackCollection> m_updateInExternalTrackCollections;

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -255,18 +255,18 @@ class WTrackMenu : public QMenu {
     QString m_deckGroup;
 
     // Submenus
-    QMenu* m_pLoadToMenu{};
-    QMenu* m_pDeckMenu{};
-    QMenu* m_pSamplerMenu{};
-    QMenu* m_pPlaylistMenu{};
-    QMenu* m_pCrateMenu{};
-    QMenu* m_pMetadataMenu{};
-    QMenu* m_pMetadataUpdateExternalCollectionsMenu{};
-    QMenu* m_pClearMetadataMenu{};
-    QMenu* m_pAnalyzeMenu{};
-    QMenu* m_pBPMMenu{};
-    QMenu* m_pColorMenu{};
-    WCoverArtMenu* m_pCoverMenu{};
+    parented_ptr<QMenu> m_pLoadToMenu;
+    parented_ptr<QMenu> m_pDeckMenu;
+    parented_ptr<QMenu> m_pSamplerMenu;
+    parented_ptr<QMenu> m_pPlaylistMenu;
+    parented_ptr<QMenu> m_pCrateMenu;
+    parented_ptr<QMenu> m_pMetadataMenu;
+    parented_ptr<QMenu> m_pMetadataUpdateExternalCollectionsMenu;
+    parented_ptr<QMenu> m_pClearMetadataMenu;
+    parented_ptr<QMenu> m_pAnalyzeMenu;
+    parented_ptr<QMenu> m_pBPMMenu;
+    parented_ptr<QMenu> m_pColorMenu;
+    parented_ptr<WCoverArtMenu> m_pCoverMenu;
     parented_ptr<WSearchRelatedTracksMenu> m_pSearchRelatedMenu;
     parented_ptr<WFindOnWebMenu> m_pFindOnWebMenu;
 #if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)


### PR DESCRIPTION
The widgets of the delete dialog where not properly parented and causing a memory leak. 
I have now used partented_ptr for all QObject pointers. 

This was a by-catch searching for the crasher reported in: 
https://github.com/mixxxdj/mixxx/pull/13602