### PR TITLE
Quick fix for #14197 (`TypeError` in `midi-components-0.0.js`)

### DIFF
--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -660,7 +660,7 @@
                 });
             }
 
-            script.deepMerge(this, newLayer);
+            _.merge(this, newLayer);
 
             if (reconnectComponents === true) {
                 this.forEachComponent(function(component) {


### PR DESCRIPTION
This PR contains a quick fix for isue 14197 which was introduced by issue 12779.