### PR TITLE
Preferences Effects: left/right key in effect lists trigger hide/unhide

### DIFF
--- a/src/preferences/dialog/dlgprefeffects.cpp
+++ b/src/preferences/dialog/dlgprefeffects.cpp
@@ -269,6 +269,7 @@ void DlgPrefEffects::slotHideUnhideEffect() {
         return;
     }
 
+    // We emulate a drag drop to move the effect
     QMimeData* mimeData = new QMimeData;
     mimeData->setText(pManifest->uniqueId());
     // Append the selected effect to the target list
@@ -282,7 +283,11 @@ void DlgPrefEffects::slotHideUnhideEffect() {
     if (!pSourceModel->removeRows(selIdx.row(), 1, selIdx.parent())) {
         // If removing failed, undo add to target list
         pTargetModel->removeRows(pMovedEffect.row(), 1, pMovedEffect.parent());
+        return;
     }
+    // Make sure the Type column is stretched to accommodate "Built-in" in case
+    // the view was last updated with LV2 effects only.
+    pTargetList->resizeColumnToContents(0);
 }
 
 void DlgPrefEffects::slotChainPresetSelectionChanged(const QItemSelection& selected) {

--- a/src/preferences/dialog/dlgprefeffects.cpp
+++ b/src/preferences/dialog/dlgprefeffects.cpp
@@ -402,8 +402,8 @@ void DlgPrefEffects::slotDeletePreset() {
     }
 }
 
-bool DlgPrefEffects::eventFilter(QObject* object, QEvent* event) {
-    if (event->type() == QEvent::FocusIn) {
+bool DlgPrefEffects::eventFilter(QObject* pObj, QEvent* pEvent) {
+    if (pEvent->type() == QEvent::FocusIn) {
         // Allow selection only in either of the effects/chains lists at a time
         // to clarify which effect/chain the info below refers to.
         // The method to update the info box for the new selection is the same
@@ -411,11 +411,11 @@ bool DlgPrefEffects::eventFilter(QObject* object, QEvent* event) {
         // * clear selection in adjacent view
         // * restore previous selection (select first item if none was selected)
         //   which updates the info box via 'currentRowChanged' signals
-        auto* pChainList = qobject_cast<QListView*>(object);
-        auto* pEffectList = qobject_cast<QTableView*>(object);
+        auto* pChainList = qobject_cast<QListView*>(pObj);
+        auto* pEffectList = qobject_cast<QTableView*>(pObj);
         // Restore previous selection only if focus was changed with keyboard.
         // For mouse clicks, that procedure would select the wrong index.
-        QFocusEvent* focEv = static_cast<QFocusEvent*>(event);
+        QFocusEvent* focEv = static_cast<QFocusEvent*>(pEvent);
         bool keyboardFocusIn = false;
         if (focEv->reason() == Qt::TabFocusReason ||
                 focEv->reason() == Qt::BacktabFocusReason) {
@@ -447,8 +447,21 @@ bool DlgPrefEffects::eventFilter(QObject* object, QEvent* event) {
                 pEffectList->selectRow(currIndex.row());
             }
         }
+    } else if (pEvent->type() == QEvent::KeyPress &&
+            m_pFocusedEffectList &&
+            pObj == m_pFocusedEffectList) {
+        // Left/Right key in focused effect list trigger Hide/Unhide:
+        // only Right is allowed in the left view, only Left in the right view,
+        // matching the enabled state of the GUI buttons.
+        QKeyEvent* pKE = static_cast<QKeyEvent*>(pEvent);
+        if ((pKE->key() == Qt::Key_Left &&
+                    m_pFocusedEffectList == hiddenEffectsTableView) ||
+                (pKE->key() == Qt::Key_Right &&
+                        m_pFocusedEffectList == visibleEffectsTableView)) {
+            slotHideUnhideEffect();
+        }
     }
-    return DlgPreferencePage::eventFilter(object, event);
+    return DlgPreferencePage::eventFilter(pObj, pEvent);
 }
 
 QListView* DlgPrefEffects::unfocusedChainList() {

--- a/src/preferences/dialog/dlgprefeffects.h
+++ b/src/preferences/dialog/dlgprefeffects.h
@@ -41,7 +41,8 @@ class DlgPrefEffects : public DlgPreferencePage, public Ui::DlgPrefEffectsDlg {
     void loadChainPresetLists();
     void saveChainPresetLists();
 
-    bool eventFilter(QObject* pChainList, QEvent* event) override;
+    /// Handles FocusIn and KeyPress events in chain preset lists
+    bool eventFilter(QObject* pObj, QEvent* pEvent) override;
     QListView* m_pFocusedChainList;
     QListView* unfocusedChainList();
     QTableView* m_pFocusedEffectList;

--- a/src/preferences/dialog/dlgprefeffectsdlg.ui
+++ b/src/preferences/dialog/dlgprefeffectsdlg.ui
@@ -590,9 +590,9 @@
   <tabstop>chainListView</tabstop>
   <tabstop>quickEffectListView</tabstop>
   <tabstop>visibleEffectsTableView</tabstop>
+  <tabstop>hiddenEffectsTableView</tabstop>
   <tabstop>hideButton</tabstop>
   <tabstop>unhideButton</tabstop>
-  <tabstop>hiddenEffectsTableView</tabstop>
   <tabstop>chainPresetImportButton</tabstop>
   <tabstop>chainPresetExportButton</tabstop>
   <tabstop>chainPresetRenameButton</tabstop>


### PR DESCRIPTION
Followup for #13329
Fixes #10580 

Or should this rather be Alt + Left/Right, like the track move hotkeys?