### PR TITLE
wait for the portaudio finished callback to avoid sporadic deadlocks

### DIFF
--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -476,7 +476,7 @@ SoundDeviceStatus SoundDevicePortAudio::close() {
             // stream has become inactive.
             err = Pa_StopStream(pStream);
             if (err != paNoError) {
-                qWarning() << "PortAudio: Stop stream error:"
+                qWarning() << "PortAudio: Error while attempting to stop stream:"
                            << Pa_GetErrorText(err) << m_deviceId;
             }
         }

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -458,9 +458,12 @@ SoundDeviceStatus SoundDevicePortAudio::close() {
         // Make sure the stream is not stopped before we try stopping it.
         PaError err = Pa_IsStreamStopped(pStream);
         // 1 means the stream is stopped. 0 means active, negative means error
-        if (err < 0) {
+        // (PaUtil_ValidateStreamPointer() failing, when passing a nullptr or
+        // wrong pointer type)
+        VERIFY_OR_DEBUG_ASSERT(err >= 0) {
             qWarning() << "PortAudio: Pa_IsStreamStopped returned error:"
                        << Pa_GetErrorText(err) << m_deviceId;
+            return SoundDeviceStatus::Error;
         }
         if (err == 1) {
             qWarning() << "PortAudio: Stream already stopped";

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -461,7 +461,6 @@ SoundDeviceStatus SoundDevicePortAudio::close() {
         if (err < 0) {
             qWarning() << "PortAudio: Pa_IsStreamStopped returned error:"
                        << Pa_GetErrorText(err) << m_deviceId;
-            return SoundDeviceStatus::Error;
         }
         if (err == 1) {
             qWarning() << "PortAudio: Stream already stopped";
@@ -472,16 +471,12 @@ SoundDeviceStatus SoundDevicePortAudio::close() {
 
             // We can now safely call Pa_StopStream, which should not block as the
             // stream has become inactive.
-            err = Pa_StopStream(m_pStream);
+            err = Pa_StopStream(pStream);
             if (err != paNoError) {
                 qWarning() << "PortAudio: Stop stream error:"
                            << Pa_GetErrorText(err) << m_deviceId;
-                return SoundDeviceStatus::Error;
             }
         }
-
-        // We can now safely set m_pStream to null
-        m_pStream.store(nullptr, std::memory_order_release);
 
         // Close stream
         err = Pa_CloseStream(pStream);
@@ -490,6 +485,9 @@ SoundDeviceStatus SoundDevicePortAudio::close() {
                        << Pa_GetErrorText(err) << m_deviceId;
             return SoundDeviceStatus::Error;
         }
+
+        // We can now safely set m_pStream to null
+        m_pStream.store(nullptr, std::memory_order_release);
     }
 
     m_outputFifo.reset();

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -444,7 +444,7 @@ void SoundDevicePortAudio::makeStreamInactiveAndWait() {
         if (!m_finishedCV.wait_for(lock, std::chrono::seconds(1), [&] { return m_bFinished; })) {
             // The timeout should not be reached, because when the process
             // callback returns paAbort, the stream will finish as soon as possible.
-            // We have it as a last result in case inactivating the stream stalls.
+            // We have it as a last resort in case inactivating the stream stalls.
             qWarning() << "PortAudio: Timeout reached when waiting for PortAudio finish callback";
         }
     }

--- a/src/soundio/sounddeviceportaudio.h
+++ b/src/soundio/sounddeviceportaudio.h
@@ -3,6 +3,7 @@
 #include <portaudio.h>
 
 #include <QString>
+#include <condition_variable>
 #include <memory>
 
 #include "control/pollingcontrolproxy.h"
@@ -47,6 +48,9 @@ class SoundDevicePortAudio : public SoundDevice {
                         const PaStreamCallbackTimeInfo *timeInfo,
                         PaStreamCallbackFlags statusFlags);
 
+    // Callback called once the process callback returns paAbort.
+    void finishedCallback();
+
     mixxx::audio::SampleRate getDefaultSampleRate() const override {
         return m_deviceInfo ? mixxx::audio::SampleRate::fromDouble(
                                       m_deviceInfo->defaultSampleRate)
@@ -57,6 +61,9 @@ class SoundDevicePortAudio : public SoundDevice {
     void updateCallbackEntryToDacTime(
             SINT framesPerBuffer, const PaStreamCallbackTimeInfo* timeInfo);
     void updateAudioLatencyUsage(const SINT framesPerBuffer);
+
+    // Wait until finishedCallback has been called.
+    void waitForFinished();
 
     // PortAudio stream for this device.
     std::atomic<PaStream*> m_pStream;
@@ -85,4 +92,7 @@ class SoundDevicePortAudio : public SoundDevice {
     PerformanceTimer m_clkRefTimer;
     PaTime m_lastCallbackEntrytoDacSecs;
     std::atomic<int> m_callbackResult;
+    std::mutex m_finishedMutex;
+    std::condition_variable m_finishedCV;
+    bool m_bFinished;
 };

--- a/src/soundio/sounddeviceportaudio.h
+++ b/src/soundio/sounddeviceportaudio.h
@@ -62,8 +62,7 @@ class SoundDevicePortAudio : public SoundDevice {
             SINT framesPerBuffer, const PaStreamCallbackTimeInfo* timeInfo);
     void updateAudioLatencyUsage(const SINT framesPerBuffer);
 
-    // Wait until finishedCallback has been called.
-    void waitForFinished();
+    void makeStreamInactiveAndWait();
 
     // PortAudio stream for this device.
     std::atomic<PaStream*> m_pStream;


### PR DESCRIPTION
This fixes #14055 . I describe the issue in detail in the bug report.

The fix consists of using [Pa_SetStreamFinishedCallback](https://www.portaudio.com/docs/v19-doxydocs/portaudio_8h.html#aa11e7b06b2cde8621551f5d527965838) to set a callback to wait for the stream to finish before continuing the main thread.

I have tested this by starting and stopping the devices programmatically in a loop. After 5000 iterations I still haven't had a deadlock, so I am confident the issue is fixed (without the fix I would get a deadlock every ~50 iterations).

Btw, there was this warning in the code (I have removed it):
```
        // BIG FAT WARNING: Pa_AbortStream() will kill threads while they're
        // waiting on a mutex, which will leave the mutex in an screwy
        // state. Don't use it!
```

This might be the same problem as described in #14055, and it is possible that with this fix we could also use Pa_AbortStream, instead of using the paAbort return value from the callback. But I didn't want to change the code more than necessary, and only add the wait condition, which is simple and safe.