### PR TITLE
Show translator file path in debug message 

### DIFF
--- a/src/util/translations.h
+++ b/src/util/translations.h
@@ -127,7 +127,7 @@ class Translations {
 
         qDebug() << "Loaded" << translation << "translations for locale"
                  << locale.name()
-                 << "from" << translationsPath;
+                 << "from" << pTranslator->filePath();
         pApp->installTranslator(pTranslator);
         return true;
     }


### PR DESCRIPTION
This helps to pick the correct file for translation in case a fallback is picked. 