### PR TITLE
(fix) Controller Learning: correct skin control for mic/aux section

### DIFF
--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -1395,7 +1395,7 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
             tr("Show/hide the sampler section"),
             pGuiMenu);
     addControl("[Skin]",
-            "show_microphone",
+            "show_microphones",
             tr("Microphone & Auxiliary Show/Hide"),
             tr("Show/hide the microphone & auxiliary section"),
             pGuiMenu);

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -1396,7 +1396,10 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
             pGuiMenu);
     addControl("[Skin]",
             "show_microphones",
-            tr("Microphone & Auxiliary Show/Hide"),
+            // && prevents auto-detecting mnemonic /keyboard accelerator which
+            // would render to underlined whitespace here.
+            //: keep double & to prevent creation of keyboard accelerator
+            tr("Microphone && Auxiliary Show/Hide"),
             tr("Show/hide the microphone & auxiliary section"),
             pGuiMenu);
     addControl("[Skin]",

--- a/src/controllers/dlgcontrollerlearning.cpp
+++ b/src/controllers/dlgcontrollerlearning.cpp
@@ -484,6 +484,22 @@ void DlgControllerLearning::loadControl(const ConfigKey& key,
 }
 
 void DlgControllerLearning::controlPicked(const ConfigKey& control) {
+    if (!ControlObject::exists(control)) {
+        QMessageBox msg(QMessageBox::Warning,
+                VersionStore::applicationName(),
+                tr("The selected control does not exist.<br>"
+                   "This likely a bug. Please report it on the Mixxx bug "
+                   "tracker.<br>"
+                   "<a href='https://github.com/mixxxdj/mixxx/issues'>"
+                   "https://github.com/mixxxdj/mixxx/issues</a>"
+                   "<br><br>"
+                   "You tried to learn: %1,%2")
+                        .arg(control.group, control.item));
+        msg.setTextFormat(Qt::RichText);              // make the link clickable
+        msg.setWindowFlags(Qt::WindowStaysOnTopHint); // position it above the Learning dialog
+        msg.exec();
+        return;
+    }
     QString title = m_pControlPickerMenu->controlTitleForConfigKey(control);
     QString description = m_pControlPickerMenu->descriptionForConfigKey(control);
     loadControl(control, title, description);


### PR DESCRIPTION
reported in the forum https://mixxx.discourse.group/t/microphone-auxiliary-show-hide-not-working-in-2-5-0/31149

And on top
* a warning for non-existant controls, with a link to Mixxx issues
* prevent auto-mnemonic for single `&` in control title with `&&`