### PR TITLE
Qt6.8: Ensure Mixxx uses "windowsvista" Qt style on Windows

### DIFF
--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -350,6 +350,15 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
     parser.addOption(debugAssertBreak);
     parser.addOption(debugAssertBreakDeprecated);
 
+    const QCommandLineOption styleOption(QStringLiteral("style"),
+            forUserFeedback
+                    ? QCoreApplication::translate("CmdlineArgs",
+                              "Sets the application GUI style. Possible values "
+                              "depend on your system configuration.")
+                    : QString(),
+            QStringLiteral("style"));
+    parser.addOption(styleOption);
+
     const QCommandLineOption helpOption = parser.addHelpOption();
     const QCommandLineOption versionOption = parser.addVersionOption();
 
@@ -487,6 +496,10 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
         m_useColors = false;
     } else if (parser.value(color).compare(QLatin1String("auto"), Qt::CaseInsensitive) != 0) {
         fputs("Unknown argument for for color.\n", stdout);
+    }
+
+    if (parser.isSet(styleOption)) {
+        m_styleName = parser.value(styleOption);
     }
 
     return true;

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -11,6 +11,7 @@
 #include <QCoreApplication>
 #include <QProcessEnvironment>
 #include <QStandardPaths>
+#include <QStyleFactory>
 #include <QtGlobal>
 
 #include "config.h"
@@ -353,8 +354,8 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
     const QCommandLineOption styleOption(QStringLiteral("style"),
             forUserFeedback
                     ? QCoreApplication::translate("CmdlineArgs",
-                              "Sets the application GUI style. Possible values "
-                              "depend on your system configuration.")
+                              "Overrides the default application GUI style. Possible values: %1")
+                              .arg(QStyleFactory::keys().join(QStringLiteral(", ")))
                     : QString(),
             QStringLiteral("style"));
     parser.addOption(styleOption);

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -71,6 +71,10 @@ class CmdlineArgs final {
     const QString& getResourcePath() const { return m_resourcePath; }
     const QString& getTimelinePath() const { return m_timelinePath; }
 
+    const QString& getStyle() const {
+        return m_styleName;
+    }
+
     void setScaleFactor(double scaleFactor) {
         m_scaleFactor = scaleFactor;
     }
@@ -110,4 +114,5 @@ class CmdlineArgs final {
     QString m_settingsPath;
     QString m_resourcePath;
     QString m_timelinePath;
+    QString m_styleName;
 };


### PR DESCRIPTION
- Ensure Mixxx uses "windowsvista" Qt style on Windows, as our skinning looks inconsistent with Qt's "windows" or "windows11" styles
- Add logging of the selected style on all platforms