### PR TITLE
[POC] OSCQuery

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1296,6 +1296,7 @@ add_library(
   src/network/jsonwebtask.cpp
   src/network/networktask.cpp
   src/network/webtask.cpp
+  src/osc/query/oscquerydescription.cpp
   src/preferences/colorpaletteeditor.cpp
   src/preferences/colorpaletteeditor.cpp
   src/preferences/colorpaletteeditormodel.cpp

--- a/src/control/control.cpp
+++ b/src/control/control.cpp
@@ -2,6 +2,7 @@
 
 #include "control/controlobject.h"
 #include "moc_control.cpp"
+#include "osc/query/oscquerydescription.h"
 #include "util/mutex.h"
 #include "util/stat.h"
 
@@ -35,6 +36,9 @@ QHash<ConfigKey, QWeakPointer<ControlDoublePrivate>> s_qCOHash
 /// Hash of aliases between ConfigKeys. Solely used for looking up the first
 /// alias associated with a key.
 QHash<ConfigKey, ConfigKey> s_qCOAliasHash
+        GUARDED_BY(s_qCOHashMutex);
+
+OscQueryDescription s_oscQueryDecription
         GUARDED_BY(s_qCOHashMutex);
 
 /// is used instead of a nullptr, helps to omit null checks everywhere
@@ -213,6 +217,12 @@ QSharedPointer<ControlDoublePrivate> ControlDoublePrivate::getDefaultControl() {
         }
     }
     return defaultCO;
+}
+
+// static
+void ControlDoublePrivate::writeOscQueryDescription(QString& oscQueryFileName) {
+    const MMutexLocker locker(&s_qCOHashMutex);
+    s_oscQueryDecription.saveToFile(oscQueryFileName);
 }
 
 // static

--- a/src/control/control.cpp
+++ b/src/control/control.cpp
@@ -86,6 +86,7 @@ ControlDoublePrivate::ControlDoublePrivate(
 ControlDoublePrivate::~ControlDoublePrivate() {
     s_qCOHashMutex.lock();
     //qDebug() << "ControlDoublePrivate::s_qCOHash.remove(" << m_key.group << "," << m_key.item << ")";
+    s_oscQueryDecription.removeControlKey(m_key);
     s_qCOHash.remove(m_key);
     s_qCOHashMutex.unlock();
 
@@ -191,6 +192,7 @@ QSharedPointer<ControlDoublePrivate> ControlDoublePrivate::getControl(
         const MMutexLocker locker(&s_qCOHashMutex);
         //qDebug() << "ControlDoublePrivate::s_qCOHash.insert(" << key.group << "," << key.item << ")";
         s_qCOHash.insert(key, pControl);
+        s_oscQueryDecription.insertControlKey(key);
         return pControl;
     }
 

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -59,6 +59,8 @@ class ControlDoublePrivate : public QObject {
             double defaultValue = kDefaultValue);
     static QSharedPointer<ControlDoublePrivate> getDefaultControl();
 
+    static void writeOscQueryDescription(QString& oscQueryFileName);
+
     // Returns a list of all existing instances.
     static QList<QSharedPointer<ControlDoublePrivate>> getAllInstances();
     // Clears all existing instances and returns them as a list.

--- a/src/dialog/dlgdevelopertools.cpp
+++ b/src/dialog/dlgdevelopertools.cpp
@@ -47,6 +47,10 @@ DlgDeveloperTools::DlgDeveloperTools(QWidget* pParent,
             &QPushButton::clicked,
             this,
             &DlgDeveloperTools::slotControlDump);
+    connect(oscQuerryDump,
+            &QPushButton::clicked,
+            this,
+            &DlgDeveloperTools::slotOscQuerryDump);
 
     // Set up the log search box
     connect(logSearch,
@@ -131,6 +135,12 @@ void DlgDeveloperTools::slotControlDump() {
             dumpFile.write(line.toLocal8Bit());
         }
     }
+}
+
+void DlgDeveloperTools::slotOscQuerryDump() {
+    QString oscQueryFileName = m_pConfig->getSettingsPath() +
+            "/oscquery.json";
+    ControlDoublePrivate::writeOscQueryDescription(oscQueryFileName);
 }
 
 void DlgDeveloperTools::slotLogSearch() {

--- a/src/dialog/dlgdevelopertools.h
+++ b/src/dialog/dlgdevelopertools.h
@@ -21,6 +21,7 @@ class DlgDeveloperTools : public QDialog, public Ui::DlgDeveloperTools {
     void slotControlSearch(const QString& search);
     void slotLogSearch();
     void slotControlDump();
+    void slotOscQuerryDump();
 
   private:
     UserSettingsPointer m_pConfig;

--- a/src/dialog/dlgdevelopertoolsdlg.ui
+++ b/src/dialog/dlgdevelopertoolsdlg.ui
@@ -78,6 +78,16 @@
          </attribute>
         </widget>
        </item>
+       <item row="0" column="2">
+        <widget class="QPushButton" name="oscQuerryDump">
+         <property name="toolTip">
+          <string>Dumps a OSCQuery description to settings path (e.g. ~/.mixxx)</string>
+         </property>
+         <property name="text">
+          <string>Dump OSCQuerry Description</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="logTab">

--- a/src/osc/query/oscquerydescription.cpp
+++ b/src/osc/query/oscquerydescription.cpp
@@ -176,10 +176,10 @@ bool OscQueryDescription::saveToFile(const QString& filePath) const {
 
 void OscQueryDescription::insertControlKey(const ConfigKey& key) {
     QString address = toOscAddress(key);
-    addAddress("/cop/" + address, "f", "3", "");
-    addAddress("/get/cop/" + address, "f", "3", "");
-    addAddress("/cov/" + address, "f", "3", "");
-    addAddress("/get/cov/" + address, "f", "3", "");
+    addAddress("/cop/" + address, "d", "3", "");
+    addAddress("/get/cop/" + address, "d", "3", "");
+    addAddress("/cov/" + address, "d", "3", "");
+    addAddress("/get/cov/" + address, "d", "3", "");
 }
 
 void OscQueryDescription::removeControlKey(const ConfigKey& key) {

--- a/src/osc/query/oscquerydescription.cpp
+++ b/src/osc/query/oscquerydescription.cpp
@@ -5,6 +5,8 @@
 #include <QJsonDocument>
 #include <QJsonValue>
 
+#include "preferences/configobject.h"
+
 namespace {
 
 template<typename T>
@@ -12,6 +14,15 @@ T take_back(std::vector<T>* pVec) {
     T last_element = std::move(pVec->back());
     pVec->pop_back();
     return last_element;
+}
+
+QString toOscAddress(const ConfigKey& key) {
+    QString groupWithoutBrackets = key.group.mid(1, key.group.size() - 2);
+    QString oscAddress = groupWithoutBrackets + QChar('/') + key.item;
+    oscAddress.replace(QChar('['), QChar('('));
+    oscAddress.replace(QChar(']'), QChar(')'));
+    oscAddress.replace(QChar('_'), QChar('/'));
+    return oscAddress;
 }
 
 } // namespace
@@ -161,4 +172,20 @@ bool OscQueryDescription::saveToFile(const QString& filePath) const {
     file.write(toJsonString().toUtf8());
     file.close();
     return true;
+}
+
+void OscQueryDescription::insertControlKey(const ConfigKey& key) {
+    QString address = toOscAddress(key);
+    addAddress("/cop/" + address, "f", "3", "");
+    addAddress("/get/cop/" + address, "f", "3", "");
+    addAddress("/cov/" + address, "f", "3", "");
+    addAddress("/get/cov/" + address, "f", "3", "");
+}
+
+void OscQueryDescription::removeControlKey(const ConfigKey& key) {
+    QString address = toOscAddress(key);
+    removeAddress("/cop/" + address);
+    removeAddress("/get/cop/" + address);
+    removeAddress("/cov/" + address);
+    removeAddress("/get/cov/" + address);
 }

--- a/src/osc/query/oscquerydescription.cpp
+++ b/src/osc/query/oscquerydescription.cpp
@@ -17,10 +17,9 @@ T take_back(std::vector<T>* pVec) {
 }
 
 QString toOscAddress(const ConfigKey& key) {
-    QString groupWithoutBrackets = key.group.mid(1, key.group.size() - 2);
-    QString oscAddress = groupWithoutBrackets + QChar('/') + key.item;
-    oscAddress.replace(QChar('['), QChar('('));
-    oscAddress.replace(QChar(']'), QChar(')'));
+    QString oscAddress = key.group + key.item;
+    oscAddress.remove(QChar('['));
+    oscAddress.remove(QChar(']'));
     oscAddress.replace(QChar('_'), QChar('/'));
     return oscAddress;
 }

--- a/src/osc/query/oscquerydescription.cpp
+++ b/src/osc/query/oscquerydescription.cpp
@@ -47,7 +47,7 @@ void OscQueryDescription::addAddress(
 
     // Create a list of QJsonObjects.
     // Note: QJsonObject is only temporary helper class for writing a QJsonValue
-    for (const auto& pathPart : pathParts) {
+    for (const auto& pathPart : std::as_const(pathParts)) {
         if (pathPart.isEmpty()) {
             continue;
         }
@@ -96,7 +96,7 @@ void OscQueryDescription::removeAddress(const QString& address) {
 
     // Create a list of QJsonObjects.
     // Note: QJsonObject is only temporary helper class for writing a QJsonValue
-    for (const auto& pathPart : pathParts) {
+    for (const auto& pathPart : std::as_const(pathParts)) {
         if (pathPart.isEmpty()) {
             continue;
         }

--- a/src/osc/query/oscquerydescription.cpp
+++ b/src/osc/query/oscquerydescription.cpp
@@ -29,6 +29,7 @@ void OscQueryDescription::addAddress(
         const QString& access,
         const QString& description) {
     QStringList pathParts = address.split('/');
+    QString fullPath;
 
     std::vector<QJsonObject> objects;
     objects.reserve(pathParts.size());
@@ -39,6 +40,7 @@ void OscQueryDescription::addAddress(
         if (pathPart.isEmpty()) {
             continue;
         }
+        fullPath += "/" + pathPart;
         if (objects.size()) {
             QJsonValueRef currentContent = objects.back()["CONTENTS"];
             if (currentContent.isObject()) {
@@ -54,7 +56,7 @@ void OscQueryDescription::addAddress(
         if (currentPart.isObject()) {
             objects.push_back(currentPart.toObject());
         } else {
-            objects.emplace_back(QJsonObject({{"ACCESS", "0"}}));
+            objects.emplace_back(QJsonObject({{"ACCESS", "0"}, {"FULL_PATH", fullPath}}));
         }
     }
 

--- a/src/osc/query/oscquerydescription.cpp
+++ b/src/osc/query/oscquerydescription.cpp
@@ -1,0 +1,93 @@
+#include "osc/query/oscquerydescription.h"
+
+#include <QDebug>
+#include <QFile>
+#include <QJsonDocument>
+#include <QJsonValue>
+
+namespace {
+
+template<typename T>
+T take_back(std::vector<T>* pVec) {
+    T last_element = std::move(pVec->back());
+    pVec->pop_back();
+    return last_element;
+}
+
+} // namespace
+
+OscQueryDescription::OscQueryDescription()
+        : m_rootObject({{"DESCRIPTION", "Mixxx OSC root node"},
+                  {"FULL_PATH", "/"},
+                  {"ACCESS", "0"},
+                  {"CONTENTS", QJsonObject()}}) {
+}
+
+void OscQueryDescription::addAddress(
+        const QString& address,
+        const QString& type,
+        const QString& access,
+        const QString& description) {
+    QStringList pathParts = address.split('/');
+
+    std::vector<QJsonObject> objects;
+    objects.reserve(pathParts.size());
+
+    // Create a list of QJsonObjects.
+    // Note: QJsonObject is only temporary helper class for writing a QJsonValue
+    for (const auto& pathPart : pathParts) {
+        if (pathPart.isEmpty()) {
+            continue;
+        }
+        if (objects.size()) {
+            QJsonValueRef currentContent = objects.back()["CONTENTS"];
+            if (currentContent.isObject()) {
+                objects.push_back(currentContent.toObject());
+            } else {
+                objects.emplace_back();
+            }
+        } else {
+            objects.push_back(m_rootObject["CONTENTS"].toObject());
+        }
+
+        QJsonValueRef currentPart = objects.back()[pathPart];
+        if (currentPart.isObject()) {
+            objects.push_back(currentPart.toObject());
+        } else {
+            objects.emplace_back(QJsonObject({{"ACCESS", "0"}}));
+        }
+    }
+
+    // populate
+    objects.back()["FULL_PATH"] = address;
+    objects.back()["TYPE"] = type;
+    objects.back()["ACCESS"] = access;
+    objects.back()["DESCRIPTION"] = description;
+
+    // recreate form the leaves
+    for (auto it = pathParts.crbegin(); it != pathParts.crend(); ++it) {
+        objects.back()[*it] = take_back(&objects);
+        if (objects.size() == 1) {
+            m_rootObject["CONTENTS"] = take_back(&objects);
+            break;
+        }
+        objects.back()["CONTENTS"] = take_back(&objects);
+    }
+}
+
+QString OscQueryDescription::toJsonString() const {
+    QJsonDocument doc(m_rootObject);
+    return doc.toJson(QJsonDocument::Indented);
+}
+
+bool OscQueryDescription::saveToFile(const QString& filePath) const {
+    QFile file(filePath);
+    if (!file.open(QIODevice::WriteOnly)) {
+        qWarning() << "Failed to open file for writing:" << filePath;
+        return false;
+    }
+
+    file.write(toJsonString().toUtf8());
+    file.close();
+    return true;
+}

--- a/src/osc/query/oscquerydescription.h
+++ b/src/osc/query/oscquerydescription.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <QJsonObject>
+
+class QString;
+class QVariant;
+
+class OscQueryDescription {
+  public:
+    OscQueryDescription();
+
+    void addAddress(
+            const QString& address,
+            const QString& type,
+            const QString& access,
+            const QString& description);
+
+    QString toJsonString() const;
+
+    bool saveToFile(const QString& filePath) const;
+
+  private:
+    QJsonObject m_rootObject;
+};

--- a/src/osc/query/oscquerydescription.h
+++ b/src/osc/query/oscquerydescription.h
@@ -4,6 +4,7 @@
 
 class QString;
 class QVariant;
+class ConfigKey;
 
 class OscQueryDescription {
   public:
@@ -16,6 +17,9 @@ class OscQueryDescription {
             const QString& description);
 
     void removeAddress(const QString& address);
+
+    void insertControlKey(const ConfigKey& key);
+    void removeControlKey(const ConfigKey& key);
 
     QString toJsonString() const;
 

--- a/src/osc/query/oscquerydescription.h
+++ b/src/osc/query/oscquerydescription.h
@@ -15,6 +15,8 @@ class OscQueryDescription {
             const QString& access,
             const QString& description);
 
+    void removeAddress(const QString& address);
+
     QString toJsonString() const;
 
     bool saveToFile(const QString& filePath) const;


### PR DESCRIPTION
This PR implements the a bit of the OSCQuery protocol into Mixxx. It finally allows to subscribe CO updates form remote. Somehow a mapping mechanism. See https://github.com/Vidvox/OSCQueryProposal

@Eve00000 and I have discussed this and came to the conclusion that we need two root namespaces: 
cop = Returns the parameter represenatation of a ControlObject (Controller Domain) 
cov = Returns the value presnetation of a ControlObject (Engine Domain) 

Both are duplicated as /get/cop and /get/cov to query the values from clients which do not have implemented the 
OSCQuery protocol 

This results for a compelex example to this OSC path: 
"/cop/EffectRack1/EffectUnit1/group/(Channel1Stem1)/enable"

This results in a nice tree of COs, however we put OSCQuery to the edge, because the resulting formatted JSON file is 233 MB. 

I have created a button in the developer menu to store the file in the Mixxx config folder as oscquerry.json. 

You can Open it with Firefox (after copy it to your download folder) to nicely collapse all and navigate. 
This is a good preview how it will work in client tools when selecting a Mixxx control. 

 




 