### PR TITLE
(fix)/UX: Pref controllers: notify of pending changes when closing preferences

### DIFF
--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -521,6 +521,10 @@ void DlgPrefController::slotUpdate() {
     m_GuiInitialized = true;
 }
 
+void DlgPrefController::slotHide() {
+    slotUpdate();
+}
+
 void DlgPrefController::slotResetToDefaults() {
     if (m_pMapping) {
         m_pMapping->resetSettings();

--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -724,6 +724,14 @@ bool DlgPrefController::saveMapping() {
                 tr("Save As"), QMessageBox::AcceptRole);
         QPushButton* pOverwrite = overwriteMsgBox.addButton(
                 tr("Overwrite"), QMessageBox::AcceptRole);
+        // QMessageBox handles Esc or pressing the X window button only if there
+        // is a button with either RejectRole or NoRole, so let's add one.
+        // https://doc.qt.io/qt-6/qmessagebox.html#escapeButton
+        QPushButton* pCancel = overwriteMsgBox.addButton(QMessageBox::Cancel);
+        // Hide Cancel since we don't really need it (we have the X button),
+        // furthermore it'll likely be auto-positioned in between Save and Overwrite
+        // which is not optimal (rules for order depend on OS).
+        pCancel->hide();
         overwriteMsgBox.setDefaultButton(pSaveAsNew);
         overwriteMsgBox.exec();
 

--- a/src/controllers/dlgprefcontroller.h
+++ b/src/controllers/dlgprefcontroller.h
@@ -37,6 +37,9 @@ class DlgPrefController : public DlgPreferencePage {
     void slotUpdate() override;
     /// Called when the user clicks the global "Apply" button.
     void slotApply() override;
+    /// Called when the preferences are hidden, e.g. when closing the window
+    /// with the [X] button or keyboard shortcut
+    void slotHide() override;
     /// Called when the user clicks the global "Reset to Defaults" button.
     void slotResetToDefaults() override;
 


### PR DESCRIPTION
Fixes #14220 

On top a small UX fix for the standard QMessageBox behavior:
if there is no button with _RejectRole_ or _NoRole_, QMessageBox ignores the Esc key and pressing the X window button, i.e. dialog can not be closed.
See https://doc.qt.io/qt-6/qmessagebox.html#escapeButton
Workaround is to add a Cancel button and hide it. See commit for more info.

(workaround is currently to click "Save As", then cancel that dialog)