### PR TITLE
make `passthrough` / `vinylcontrol_enabled`  exclusive

### DIFF
--- a/src/engine/channels/enginechannel.cpp
+++ b/src/engine/channels/enginechannel.cpp
@@ -17,42 +17,49 @@ EngineChannel::EngineChannel(const ChannelHandleAndGroup& handleGroup,
           m_sampleBuffer(nullptr),
           m_bIsPrimaryDeck(isPrimaryDeck),
           m_active(false),
+          m_pMainMix(std::make_unique<ControlPushButton>(
+                  ConfigKey(getGroup(), QStringLiteral("main_mix")))),
+          m_pPFL(std::make_unique<ControlPushButton>(
+                  ConfigKey(getGroup(), QStringLiteral("pfl")))),
+          // crossfader assignment is persistent
+          m_pOrientation(std::make_unique<ControlPushButton>(
+                  ConfigKey(getGroup(), QStringLiteral("orientation")),
+                  true,
+                  defaultOrientation)),
+          m_pOrientationLeft(std::make_unique<ControlPushButton>(
+                  ConfigKey(getGroup(), QStringLiteral("orientation_left")))),
+          m_pOrientationRight(std::make_unique<ControlPushButton>(
+                  ConfigKey(getGroup(), QStringLiteral("orientation_right")))),
+          m_pOrientationCenter(std::make_unique<ControlPushButton>(
+                  ConfigKey(getGroup(), QStringLiteral("orientation_center")))),
+          m_pTalkover(std::make_unique<ControlPushButton>(
+                  ConfigKey(getGroup(), QStringLiteral("talkover")))),
           m_bIsTalkoverChannel(isTalkoverChannel),
           m_channelIndex(-1) {
-    m_pPFL = new ControlPushButton(ConfigKey(getGroup(), "pfl"));
     m_pPFL->setButtonMode(mixxx::control::ButtonMode::Toggle);
-    m_pMainMix = new ControlPushButton(ConfigKey(getGroup(), "main_mix"));
     m_pMainMix->setButtonMode(mixxx::control::ButtonMode::PowerWindow);
     m_pMainMix->addAlias(ConfigKey(getGroup(), QStringLiteral("master")));
-    // crossfader assignment is persistent
-    m_pOrientation = new ControlPushButton(
-            ConfigKey(getGroup(), "orientation"), true, defaultOrientation);
     m_pOrientation->setBehavior(mixxx::control::ButtonMode::Toggle, 3);
-    m_pOrientationLeft = new ControlPushButton(ConfigKey(getGroup(), "orientation_left"));
-    connect(m_pOrientationLeft, &ControlObject::valueChanged,
-            this, &EngineChannel::slotOrientationLeft, Qt::DirectConnection);
-    m_pOrientationRight = new ControlPushButton(ConfigKey(getGroup(), "orientation_right"));
-    connect(m_pOrientationRight, &ControlObject::valueChanged,
-            this, &EngineChannel::slotOrientationRight, Qt::DirectConnection);
-    m_pOrientationCenter = new ControlPushButton(ConfigKey(getGroup(), "orientation_center"));
-    connect(m_pOrientationCenter, &ControlObject::valueChanged,
-            this, &EngineChannel::slotOrientationCenter, Qt::DirectConnection);
-    m_pTalkover = new ControlPushButton(ConfigKey(getGroup(), "talkover"));
+    connect(m_pOrientationLeft.get(),
+            &ControlObject::valueChanged,
+            this,
+            &EngineChannel::slotOrientationLeft,
+            Qt::DirectConnection);
+    connect(m_pOrientationRight.get(),
+            &ControlObject::valueChanged,
+            this,
+            &EngineChannel::slotOrientationRight,
+            Qt::DirectConnection);
+    connect(m_pOrientationCenter.get(),
+            &ControlObject::valueChanged,
+            this,
+            &EngineChannel::slotOrientationCenter,
+            Qt::DirectConnection);
     m_pTalkover->setButtonMode(mixxx::control::ButtonMode::PowerWindow);
 
     if (m_pEffectsManager != nullptr) {
         m_pEffectsManager->registerInputChannel(handleGroup);
     }
-}
-
-EngineChannel::~EngineChannel() {
-    delete m_pMainMix;
-    delete m_pPFL;
-    delete m_pOrientation;
-    delete m_pOrientationLeft;
-    delete m_pOrientationRight;
-    delete m_pOrientationCenter;
-    delete m_pTalkover;
 }
 
 void EngineChannel::setPfl(bool enabled) {

--- a/src/engine/channels/enginechannel.h
+++ b/src/engine/channels/enginechannel.h
@@ -29,7 +29,6 @@ class EngineChannel : public EngineObject {
             EffectsManager* pEffectsManager,
             bool isTalkoverChannel,
             bool isPrimaryDeck);
-    ~EngineChannel() override;
 
     virtual ChannelOrientation getOrientation() const;
 
@@ -77,7 +76,7 @@ class EngineChannel : public EngineObject {
 
   protected:
     const ChannelHandleAndGroup m_group;
-    EffectsManager* m_pEffectsManager;
+    EffectsManager* m_pEffectsManager; // std::shared_ptr ??
 
     EngineVuMeter m_vuMeter;
     PollingControlProxy m_sampleRate;
@@ -94,13 +93,13 @@ class EngineChannel : public EngineObject {
     void slotOrientationCenter(double v);
 
   private:
-    ControlPushButton* m_pMainMix;
-    ControlPushButton* m_pPFL;
-    ControlPushButton* m_pOrientation;
-    ControlPushButton* m_pOrientationLeft;
-    ControlPushButton* m_pOrientationRight;
-    ControlPushButton* m_pOrientationCenter;
-    ControlPushButton* m_pTalkover;
+    std::unique_ptr<ControlPushButton> m_pMainMix;
+    std::unique_ptr<ControlPushButton> m_pPFL;
+    std::unique_ptr<ControlPushButton> m_pOrientation;
+    std::unique_ptr<ControlPushButton> m_pOrientationLeft;
+    std::unique_ptr<ControlPushButton> m_pOrientationRight;
+    std::unique_ptr<ControlPushButton> m_pOrientationCenter;
+    std::unique_ptr<ControlPushButton> m_pTalkover;
     bool m_bIsTalkoverChannel;
     int m_channelIndex;
 };

--- a/src/engine/channels/enginedeck.cpp
+++ b/src/engine/channels/enginedeck.cpp
@@ -35,8 +35,10 @@ EngineDeck::EngineDeck(
                   /*isTalkoverChannel*/ false,
                   primaryDeck),
           m_pConfig(pConfig),
-          m_pInputConfigured(new ControlObject(ConfigKey(getGroup(), "input_configured"))),
-          m_pPassing(new ControlPushButton(ConfigKey(getGroup(), "passthrough"))) {
+          m_pInputConfigured(std::make_unique<ControlObject>(
+                  ConfigKey(getGroup(), "input_configured"))),
+          m_pPassing(std::make_unique<ControlPushButton>(
+                  ConfigKey(getGroup(), "passthrough"))) {
     m_pInputConfigured->setReadOnly();
     // Set up passthrough utilities and fields
     m_pPassing->setButtonMode(mixxx::control::ButtonMode::PowerWindow);
@@ -115,7 +117,6 @@ void EngineDeck::slotTrackLoaded(TrackPointer pNewTrack,
 #endif
 
 EngineDeck::~EngineDeck() {
-    delete m_pPassing;
     delete m_pBuffer;
     delete m_pPregain;
 }

--- a/src/engine/channels/enginedeck.h
+++ b/src/engine/channels/enginedeck.h
@@ -6,6 +6,7 @@
 #include "preferences/usersettings.h"
 #include "soundio/soundmanagerutil.h"
 #include "track/track_decl.h"
+#include "util/parented_ptr.h"
 #include "util/samplebuffer.h"
 
 class EnginePregain;
@@ -104,9 +105,9 @@ class EngineDeck : public EngineChannel, public AudioDestination {
     std::vector<std::unique_ptr<ControlPushButton>> m_stemMute;
 #endif
 
-    // Begin vinyl passthrough fields
-    QScopedPointer<ControlObject> m_pInputConfigured;
-    ControlPushButton* m_pPassing;
+    // Vinyl / passthrough controls
+    std::unique_ptr<ControlObject> m_pInputConfigured;
+    std::unique_ptr<ControlPushButton> m_pPassing;
     bool m_bPassthroughIsActive;
     bool m_bPassthroughWasActive;
 };

--- a/src/engine/channels/enginedeck.h
+++ b/src/engine/channels/enginedeck.h
@@ -14,6 +14,7 @@ class EngineBuffer;
 class EngineMixer;
 class ControlPushButton;
 class ControlPotmeter;
+class ControlProxy;
 
 class EngineDeck : public EngineChannel, public AudioDestination {
     Q_OBJECT
@@ -80,6 +81,7 @@ class EngineDeck : public EngineChannel, public AudioDestination {
   public slots:
     void slotPassthroughToggle(double v);
     void slotPassthroughChangeRequest(double v);
+    void slotVcEnabledChanged(double v);
 #ifdef __STEM__
     void slotTrackLoaded(TrackPointer pNewTrack, TrackPointer);
 #endif
@@ -108,6 +110,7 @@ class EngineDeck : public EngineChannel, public AudioDestination {
     // Vinyl / passthrough controls
     std::unique_ptr<ControlObject> m_pInputConfigured;
     std::unique_ptr<ControlPushButton> m_pPassing;
+    parented_ptr<ControlProxy> m_pVCEnabled;
     bool m_bPassthroughIsActive;
     bool m_bPassthroughWasActive;
 };


### PR DESCRIPTION
turn VC on -> passthrough off
turn passthrough on -> VC off

Passthrough stops the deck and then VC has nothing to do anyway.
And with passthrough it makes no sense to show the VC signal quality in the spinnies.
So basically this is just a small usability improvement with no harm. Or did I overlook something?

(one step to fix #14236)
