### PR TITLE
Use [Channel1_Stem1] pattern for Stem COs. Improve speed a bit.

### DIFF
--- a/res/qml/EqColumn.qml
+++ b/res/qml/EqColumn.qml
@@ -19,7 +19,7 @@ Column {
     }
 
     function stemGroup(group, index) {
-        return `${group.substr(0, group.length-1)}Stem${index + 1}]`
+        return `${group.substr(0, group.length-1)}_Stem${index + 1}]`
     }
 
     Row {

--- a/res/skins/LateNight/stem_channel.xml
+++ b/res/skins/LateNight/stem_channel.xml
@@ -1,5 +1,5 @@
 <Template>
-  <SetVariable name="StemGroup">[Channel<Variable name="ChanNum"/>Stem<Variable name="StemNum"/>]</SetVariable>
+  <SetVariable name="StemGroup">[Channel<Variable name="ChanNum"/>_Stem<Variable name="StemNum"/>]</SetVariable>
 
 	<WidgetGroup>
 		<ObjectName>StemChannel_ControlContainer</ObjectName>

--- a/src/engine/channels/enginedeck.cpp
+++ b/src/engine/channels/enginedeck.cpp
@@ -1,5 +1,7 @@
 #include "engine/channels/enginedeck.h"
 
+#include <QStringView>
+
 #include "control/controlpushbutton.h"
 #include "effects/effectsmanager.h"
 #include "engine/controls/bpmcontrol.h"
@@ -355,10 +357,8 @@ void EngineDeck::slotPassthroughChangeRequest(double v) {
 
 #ifdef __STEM__
 // static
-QString EngineDeck::getGroupForStem(const QString& deckGroup, int stemIdx) {
-    DEBUG_ASSERT(deckGroup.endsWith("]"));
-    QString groupForStem = deckGroup;
-    groupForStem[deckGroup.size() - 1] = QChar('_');
-    return groupForStem + QStringLiteral("Stem") + QString::number(stemIdx + 1) + QChar(']');
+QString EngineDeck::getGroupForStem(QStringView deckGroup, int stemIdx) {
+    DEBUG_ASSERT(deckGroup.endsWith(QChar(']')) && stemIdx < 4);
+    return deckGroup.chopped(1) + QStringLiteral("_Stem") + QChar('1' + stemIdx) + QChar(']');
 }
 #endif

--- a/src/engine/channels/enginedeck.cpp
+++ b/src/engine/channels/enginedeck.cpp
@@ -13,17 +13,6 @@
 #include "util/assert.h"
 #include "util/sample.h"
 
-#ifdef __STEM__
-namespace {
-QString getGroupForStem(const QString& deckGroup, int stemIdx) {
-    DEBUG_ASSERT(deckGroup.endsWith("]"));
-    return QStringLiteral("%1Stem%2]")
-            .arg(deckGroup.left(deckGroup.size() - 1),
-                    QString::number(stemIdx));
-}
-} // anonymous namespace
-#endif
-
 EngineDeck::EngineDeck(
         const ChannelHandleAndGroup& handleGroup,
         UserSettingsPointer pConfig,
@@ -77,14 +66,14 @@ EngineDeck::EngineDeck(
     m_stemMute.reserve(mixxx::kMaxSupportedStems);
     for (int stemIdx = 0; stemIdx < mixxx::kMaxSupportedStems; stemIdx++) {
         m_stemGain.emplace_back(std::make_unique<ControlPotmeter>(
-                ConfigKey(getGroupForStem(getGroup(), stemIdx + 1), QStringLiteral("volume"))));
+                ConfigKey(getGroupForStem(getGroup(), stemIdx), QStringLiteral("volume"))));
         // The default value is ignored and override with the medium value by
         // ControlPotmeter. This is likely a bug but fixing might have a
         // disruptive impact, so setting the default explicitly
         m_stemGain.back()->set(1.0);
         m_stemGain.back()->setDefaultValue(1.0);
         auto pMuteButton = std::make_unique<ControlPushButton>(
-                ConfigKey(getGroupForStem(getGroup(), stemIdx + 1), QStringLiteral("mute")));
+                ConfigKey(getGroupForStem(getGroup(), stemIdx), QStringLiteral("mute")));
         pMuteButton->setButtonMode(mixxx::control::ButtonMode::PowerWindow);
         m_stemMute.push_back(std::move(pMuteButton));
     }
@@ -363,3 +352,13 @@ void EngineDeck::slotPassthroughChangeRequest(double v) {
         emit noPassthroughInputConfigured();
     }
 }
+
+#ifdef __STEM__
+// static
+QString EngineDeck::getGroupForStem(const QString& deckGroup, int stemIdx) {
+    DEBUG_ASSERT(deckGroup.endsWith("]"));
+    QString groupForStem = deckGroup;
+    groupForStem[deckGroup.size() - 1] = QChar('_');
+    return groupForStem + QStringLiteral("Stem") + QString::number(stemIdx + 1) + QChar(']');
+}
+#endif

--- a/src/engine/channels/enginedeck.h
+++ b/src/engine/channels/enginedeck.h
@@ -71,7 +71,7 @@ class EngineDeck : public EngineChannel, public AudioDestination {
     // of stem track
     void cloneStemState(const EngineDeck* deckToClone);
     void addStemHandle(const ChannelHandleAndGroup& stemHandleGroup);
-    static QString getGroupForStem(const QString& deckGroup, int stemIdx);
+    static QString getGroupForStem(QStringView deckGroup, int stemIdx);
 #endif
 
   signals:

--- a/src/engine/channels/enginedeck.h
+++ b/src/engine/channels/enginedeck.h
@@ -71,6 +71,7 @@ class EngineDeck : public EngineChannel, public AudioDestination {
     // of stem track
     void cloneStemState(const EngineDeck* deckToClone);
     void addStemHandle(const ChannelHandleAndGroup& stemHandleGroup);
+    static QString getGroupForStem(const QString& deckGroup, int stemIdx);
 #endif
 
   signals:

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -288,10 +288,8 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(
 #ifdef __STEM__
     m_pStemColors.reserve(mixxx::kMaxSupportedStems);
     QString group = getGroup();
-    for (int stemIdx = 1; stemIdx <= mixxx::kMaxSupportedStems; stemIdx++) {
-        QString stemGroup = QStringLiteral("%1Stem%2]")
-                                    .arg(group.left(group.size() - 1),
-                                            QString::number(stemIdx));
+    for (int stemIdx = 0; stemIdx < mixxx::kMaxSupportedStems; stemIdx++) {
+        QString stemGroup = EngineDeck::getGroupForStem(group, stemIdx);
         m_pStemColors.emplace_back(std::make_unique<ControlObject>(
                 ConfigKey(stemGroup, QStringLiteral("color"))));
         m_pStemColors.back()->set(kNoTrackColor);

--- a/src/mixer/playermanager.h
+++ b/src/mixer/playermanager.h
@@ -145,13 +145,13 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
     // Returns the group for the ith sampler where i is zero indexed
     static QString groupForSampler(int i) {
         DEBUG_ASSERT(i >= 0);
-        return QStringLiteral("[Sampler") + QString::number(i + 1) + ']';
+        return QStringLiteral("[Sampler") + QString::number(i + 1) + QChar(']');
     }
 
     // Returns the group for the ith deck where i is zero indexed
     static QString groupForDeck(int i) {
         DEBUG_ASSERT(i >= 0);
-        return QStringLiteral("[Channel") + QString::number(i + 1) + ']';
+        return QStringLiteral("[Channel") + QString::number(i + 1) + QChar(']');
     }
 
 #ifdef __STEM__
@@ -159,14 +159,14 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
     static QString groupForDeckStem(int i, int j) {
         DEBUG_ASSERT(i >= 0);
         return QStringLiteral("[Channel") + QString::number(i + 1) +
-                QStringLiteral("Stem") + QString::number(j + 1) + ']';
+                QStringLiteral("_Stem") + QString::number(j + 1) + QChar(']');
     }
 #endif
 
     // Returns the group for the ith PreviewDeck where i is zero indexed
     static QString groupForPreviewDeck(int i) {
         DEBUG_ASSERT(i >= 0);
-        return QStringLiteral("[PreviewDeck") + QString::number(i + 1) + ']';
+        return QStringLiteral("[PreviewDeck") + QString::number(i + 1) + QChar(']');
     }
 
     // Returns the group for the ith Microphone where i is zero indexed
@@ -176,7 +176,7 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
         // the group [Microphone]. For backwards compatibility we keep it that
         // way.
         if (i > 0) {
-            return QStringLiteral("[Microphone") + QString::number(i + 1) + ']';
+            return QStringLiteral("[Microphone") + QString::number(i + 1) + QChar(']');
         } else {
             return QStringLiteral("[Microphone]");
         }
@@ -185,7 +185,7 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
     // Returns the group for the ith Auxiliary where i is zero indexed
     static QString groupForAuxiliary(int i) {
         DEBUG_ASSERT(i >= 0);
-        return QStringLiteral("[Auxiliary") + QString::number(i + 1) + ']';
+        return QStringLiteral("[Auxiliary") + QString::number(i + 1) + QChar(']');
     }
 
     static QAtomicPointer<ControlProxy> m_pCOPNumDecks;

--- a/src/mixer/playermanager.h
+++ b/src/mixer/playermanager.h
@@ -155,11 +155,11 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
     }
 
 #ifdef __STEM__
-    // Returns the group for the ith deck and jth stem where i and j is zero indexed
-    static QString groupForDeckStem(int i, int j) {
-        DEBUG_ASSERT(i >= 0);
-        return QStringLiteral("[Channel") + QString::number(i + 1) +
-                QStringLiteral("_Stem") + QString::number(j + 1) + QChar(']');
+    // Returns the group for the deck and stem where deckIndex and stemInde are zero based
+    static QString groupForDeckStem(int deckIdx, int stemIdx) {
+        DEBUG_ASSERT(deckIdx >= 0 && stemIdx >= 0 && stemIdx < 4);
+        return QStringLiteral("[Channel") + QString::number(deckIdx + 1) +
+                QStringLiteral("_Stem") + QChar('1' + stemIdx) + QChar(']');
     }
 #endif
 

--- a/src/test/stemcontrolobjecttest.cpp
+++ b/src/test/stemcontrolobjecttest.cpp
@@ -12,9 +12,9 @@ class StemControlTest : public BaseSignalPathTest {
   protected:
     QString getGroupForStem(const QString& deckGroup, int stemIdx) {
         DEBUG_ASSERT(deckGroup.endsWith("]"));
-        return QStringLiteral("%1Stem%2]")
-                .arg(deckGroup.left(deckGroup.size() - 1),
-                        QString::number(stemIdx));
+        QString groupForStem = deckGroup;
+        groupForStem[deckGroup.size() - 1] = QChar('_');
+        return groupForStem + QStringLiteral("Stem") + QString::number(stemIdx) + QChar(']');
     }
     QString getFxGroupForStem(const QString& deckGroup, int stemIdx) {
         return QStringLiteral("[QuickEffectRack1_%1]")

--- a/src/test/stemcontrolobjecttest.cpp
+++ b/src/test/stemcontrolobjecttest.cpp
@@ -10,15 +10,13 @@
 
 class StemControlTest : public BaseSignalPathTest {
   protected:
-    QString getGroupForStem(const QString& deckGroup, int stemIdx) {
-        DEBUG_ASSERT(deckGroup.endsWith("]"));
-        QString groupForStem = deckGroup;
-        groupForStem[deckGroup.size() - 1] = QChar('_');
-        return groupForStem + QStringLiteral("Stem") + QString::number(stemIdx) + QChar(']');
+    QString getGroupForStem(QStringView deckGroup, int stemNr) {
+        DEBUG_ASSERT(deckGroup.endsWith(QChar(']')) && stemNr <= 4);
+        return deckGroup.chopped(1) + QStringLiteral("_Stem") + QChar('0' + stemNr) + QChar(']');
     }
-    QString getFxGroupForStem(const QString& deckGroup, int stemIdx) {
+    QString getFxGroupForStem(const QString& deckGroup, int stemNr) {
         return QStringLiteral("[QuickEffectRack1_%1]")
-                .arg(getGroupForStem(deckGroup, stemIdx));
+                .arg(getGroupForStem(deckGroup, stemNr));
     }
 
     void SetUp() override {

--- a/src/waveform/renderers/allshader/waveformrendererstem.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererstem.cpp
@@ -28,16 +28,16 @@ void WaveformRendererStem::initializeGL() {
     m_shader.init();
     m_textureShader.init();
     auto group = m_pEQEnabled->getKey().group;
+    DEBUG_ASSERT(group.endsWith("]"));
+    group[group.size() - 1] = QChar('_');
     for (int stemIdx = 1; stemIdx <= mixxx::kMaxSupportedStems; stemIdx++) {
-        DEBUG_ASSERT(group.endsWith("]"));
-        QString stemGroup = QStringLiteral("%1Stem%2]")
-                                    .arg(group.left(group.size() - 1),
-                                            QString::number(stemIdx));
+        QString stemGroup = group + QStringLiteral("Stem") + QString::number(stemIdx) + QChar(']');
         m_pStemGain.emplace_back(
                 std::make_unique<ControlProxy>(stemGroup,
                         QStringLiteral("volume")));
-        m_pStemMute.emplace_back(std::make_unique<ControlProxy>(
-                stemGroup, QStringLiteral("mute")));
+        m_pStemMute.emplace_back(
+                std::make_unique<ControlProxy>(stemGroup,
+                        QStringLiteral("mute")));
     }
 }
 

--- a/src/waveform/renderers/allshader/waveformrendererstem.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererstem.cpp
@@ -4,6 +4,7 @@
 #include <QImage>
 #include <QOpenGLTexture>
 
+#include "engine/channels/enginedeck.h"
 #include "engine/engine.h"
 #include "track/track.h"
 #include "util/math.h"
@@ -28,10 +29,8 @@ void WaveformRendererStem::initializeGL() {
     m_shader.init();
     m_textureShader.init();
     auto group = m_pEQEnabled->getKey().group;
-    DEBUG_ASSERT(group.endsWith("]"));
-    group[group.size() - 1] = QChar('_');
-    for (int stemIdx = 1; stemIdx <= mixxx::kMaxSupportedStems; stemIdx++) {
-        QString stemGroup = group + QStringLiteral("Stem") + QString::number(stemIdx) + QChar(']');
+    for (int stemIdx = 0; stemIdx < mixxx::kMaxSupportedStems; stemIdx++) {
+        QString stemGroup = EngineDeck::getGroupForStem(group, stemIdx);
         m_pStemGain.emplace_back(
                 std::make_unique<ControlProxy>(stemGroup,
                         QStringLiteral("volume")));


### PR DESCRIPTION
Fixes #14240 for a consistent rule how indexed groups are build.  