### PR TITLE
(fix) Traktor S4mk3: set 4 decks, avoid CO warnings for decks 3/4, eg. VU meter

### DIFF
--- a/res/controllers/Traktor-Kontrol-S4-MK3.js
+++ b/res/controllers/Traktor-Kontrol-S4-MK3.js
@@ -2877,6 +2877,9 @@ class S4Mk3MixerColumn extends ComponentContainer {
 
 class S4MK3 {
     constructor() {
+        if (engine.getValue("[App]", "num_decks") < 4) {
+            engine.setValue("[App]", "num_decks", 4);
+        }
         if (engine.getValue("[App]", "num_samplers") < 16) {
             engine.setValue("[App]", "num_samplers", 16);
         }


### PR DESCRIPTION
same as for the samplers: ensure all deck COs we connect to exist