### PR TITLE
(fix) menubar: don't show 'hide' dialog when switching skins

### DIFF
--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -99,6 +99,7 @@ MixxxMainWindow::MixxxMainWindow(std::shared_ptr<mixxx::CoreServices> pCoreServi
 #ifdef __LINUX__
           m_supportsGlobalMenuBar(supportsGlobalMenu()),
 #endif
+          m_inRebootMixxxView(false),
           m_pDeveloperToolsDlg(nullptr),
           m_pPrefDlg(nullptr),
           m_toolTipsCfg(mixxx::preferences::Tooltips::On) {
@@ -1159,6 +1160,7 @@ void MixxxMainWindow::slotTooltipModeChanged(mixxx::preferences::Tooltips tt) {
 
 void MixxxMainWindow::rebootMixxxView() {
     qDebug() << "Now in rebootMixxxView...";
+    m_inRebootMixxxView = true;
 
     ScopedWaitCursor cursor;
     // safe geometry for later restoration
@@ -1192,6 +1194,7 @@ void MixxxMainWindow::rebootMixxxView() {
         QMessageBox::critical(this,
                               tr("Error in skin file"),
                               tr("The selected skin cannot be loaded."));
+        m_inRebootMixxxView = false;
         // m_pWidgetParent is NULL, we can't continue.
         return;
     }
@@ -1220,6 +1223,7 @@ void MixxxMainWindow::rebootMixxxView() {
         setGeometry(initGeometry);
     }
 
+    m_inRebootMixxxView = false;
     qDebug() << "rebootMixxxView DONE";
 }
 
@@ -1310,7 +1314,9 @@ bool MixxxMainWindow::eventFilter(QObject* obj, QEvent* event) {
             if (!m_supportsGlobalMenuBar || isFullScreenNow)
 #endif
             {
-                alwaysHideMenuBarDlg();
+                if (!m_inRebootMixxxView) {
+                    alwaysHideMenuBarDlg();
+                }
                 slotUpdateMenuBarAltKeyConnection();
             }
 #endif

--- a/src/mixxxmainwindow.h
+++ b/src/mixxxmainwindow.h
@@ -137,6 +137,7 @@ class MixxxMainWindow : public QMainWindow {
 #ifdef __LINUX__
     const bool m_supportsGlobalMenuBar;
 #endif
+    bool m_inRebootMixxxView;
 
     DlgDeveloperTools* m_pDeveloperToolsDlg;
 


### PR DESCRIPTION
don't show the dialog when switching skins while fullscreen.
furthermore, the hide dialog would block the preferences (wait cursor).

reported in https://github.com/mixxxdj/mixxx/issues/14094#issuecomment-2567461150
