### PR TITLE
DlgKeywheel: Make dialog a floating tool window

### DIFF
--- a/src/dialog/dlgkeywheel.ui
+++ b/src/dialog/dlgkeywheel.ui
@@ -19,6 +19,9 @@
   <property name="windowTitle">
    <string>Keywheel</string>
   </property>
+  <property name="windowFlags">
+   <set>Qt::Tool|Qt::WindowStaysOnTopHint</set>
+  </property>
   <property name="layoutDirection">
    <enum>Qt::LeftToRight</enum>
   </property>


### PR DESCRIPTION
#14239 got me thinking whether we could make the keywheel a floating dialog to make it a bit more useful, given that the keywheel is usually needed e.g. while browsing tracks. This is essentially the same style that the effect GUI dialogs proposed in #13888 use.


I've also added the tool modifier which gives it a slightly thinner window bar, at least on macOS, where this nicely follows the convention laid out by the OS color picker:

| Before | After | OS color picker (for comparison) |
| --- | --- | --- |
| <img src="https://github.com/user-attachments/assets/32f4b785-e62f-4d2c-b1f5-8923783292b7" width="220"> | <img src="https://github.com/user-attachments/assets/7256a641-287a-4b06-8fc5-44166748f2f4" width="200"> | <img src="https://github.com/user-attachments/assets/89c5f034-d82b-44aa-852b-087ded72d50c" width="150"> |
