### PR TITLE
(fix) DlgControllerLearning: make control box completer usable

### DIFF
--- a/src/controllers/dlgcontrollerlearning.cpp
+++ b/src/controllers/dlgcontrollerlearning.cpp
@@ -74,6 +74,9 @@ DlgControllerLearning::DlgControllerLearning(QWidget* parent,
 
     comboBoxChosenControl->completer()->setCompletionMode(
         QCompleter::PopupCompletion);
+    comboBoxChosenControl->completer()->setCaseSensitivity(Qt::CaseInsensitive);
+    comboBoxChosenControl->completer()->setFilterMode(Qt::MatchContains);
+
     populateComboBox();
     connect(comboBoxChosenControl,
             QOverload<int>::of(&QComboBox::currentIndexChanged),
@@ -152,6 +155,7 @@ void DlgControllerLearning::populateComboBox() {
     comboBoxChosenControl->clear();
     // Add a blank item so the lineedit is initially empty
     comboBoxChosenControl->addItem("", QVariant::fromValue(ConfigKey()));
+    // Note: changes here might break the completer, so remember to test that
     QList<NamedControl> sorted_controls;
     for (const ConfigKey& key : m_pControlPickerMenu->controlsAvailable()) {
         sorted_controls.push_back(NamedControl(

--- a/src/controllers/dlgcontrollerlearning.cpp
+++ b/src/controllers/dlgcontrollerlearning.cpp
@@ -150,17 +150,16 @@ DlgControllerLearning::DlgControllerLearning(QWidget* parent,
 void DlgControllerLearning::populateComboBox() {
     // Sort all of the controls and add them to the combo box
     comboBoxChosenControl->clear();
+    // Add a blank item so the lineedit is initially empty
     comboBoxChosenControl->addItem("", QVariant::fromValue(ConfigKey()));
     QList<NamedControl> sorted_controls;
-    foreach (ConfigKey key, m_pControlPickerMenu->controlsAvailable()) {
-        sorted_controls.push_back(
-                NamedControl(m_pControlPickerMenu->controlTitleForConfigKey(key),
-                        key));
+    for (const ConfigKey& key : m_pControlPickerMenu->controlsAvailable()) {
+        sorted_controls.push_back(NamedControl(
+                m_pControlPickerMenu->controlTitleForConfigKey(key),
+                key));
     }
-    std::sort(sorted_controls.begin(), sorted_controls.end(),
-          namedControlComparator);
-    foreach(NamedControl control, sorted_controls)
-    {
+    std::sort(sorted_controls.begin(), sorted_controls.end(), namedControlComparator);
+    for (const NamedControl& control : std::as_const(sorted_controls)) {
         comboBoxChosenControl->addItem(control.first,
                                        QVariant::fromValue(control.second));
     }


### PR DESCRIPTION
The implementation was complete but not very usable because some defaults were used.
* use `MatchContains` (default is `Qt::MatchStartsWith`
* set case-insensitive (default is `Qt::CaseSensitive`)

:tada: 