### PR TITLE
(fix) Controller preferences: fix broken overwrite dialog ('Save as..' not working)

### DIFF
--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -740,7 +740,8 @@ bool DlgPrefController::saveMapping() {
             if (overwriteCheckBox.checkState() == Qt::Checked) {
                 m_pOverwriteMappings.insert(m_pMapping->filePath(), true);
             }
-        } else if (overwriteMsgBox.close()) {
+        } else if (overwriteMsgBox.clickedButton() != pSaveAsNew) {
+            // Dialog was closed without clicking one of our buttons
             return false;
         }
     }


### PR DESCRIPTION
Fixes a very weird bug: (which could reproduce often but 100%)
* open preferences of a MIDI controller
* select a mapping, Apply
* change a comment (don't Learn as that flow is also broken, see #14253)
* Apply
* "Save changes?" click "Save As.."
* dialog flashes (is closed and pops up again instantly)
* click "Save As.." again
* dialog is closed
* changes are not saved

The condition `else if (msgbox->close())` is not working as expected. And don't understand why it was working in the first place because the dialog is closed already when we reach that condition.  (it must have worked at some point (Qt5??) otherwise we'd have noticed, right)

Replaced that with another `clickedButton()` check and it's now working reliably.