### PR TITLE
Track property editor: enforce I cursor, hide while typing

### DIFF
--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -362,6 +362,10 @@ bool WTrackPropertyEditor::eventFilter(QObject* pObj, QEvent* pEvent) {
             ControlObject::set(ConfigKey("[Library]", "refocus_prev_widget"), 1);
             return true;
         default:
+            // Hide mouse cursor while typing
+            // TODO Test if this now works on Windows, see comment in
+            // widget/knobeventhandler.h
+            setCursor(Qt::BlankCursor);
             break;
         }
     } else if (pEvent->type() == QEvent::FocusOut) {
@@ -375,6 +379,16 @@ bool WTrackPropertyEditor::eventFilter(QObject* pObj, QEvent* pEvent) {
                 emit commitEditorData(text());
             }
         }
+    } else if (pEvent->type() == QEvent::MouseMove ||
+            pEvent->type() == QEvent::MouseButtonPress ||
+            pEvent->type() == QEvent::Show ||
+            pEvent->type() == QEvent::Enter) {
+        // Some desktop environments show the I cursor initially
+        // but fall back to regular pointer on mouse move.
+        // Enforce I cursor while editing.
+        setCursor(Qt::IBeamCursor);
+    } else if (pEvent->type() == QEvent::Leave) {
+        unsetCursor();
     }
     return QLineEdit::eventFilter(pObj, pEvent);
 }


### PR DESCRIPTION
When I open the editor I sometimes see it changing the cursor to `I` but it reverts to regular pointer as soon as I move it.
Thing is the pointer gets in the way of editing.
Idk if this is a Qt bug (I'm on 6.2.3 with Ubuntu + X11 + xfce4)
or if we need to implement it manually.
FWIW it works as expected in the library editor delegates (except auto-hide of course)

* enforce `I` cursor in editor
* hide cursor while typing (restores `I` on mouse move) -> do we want it or is it too invasive?

### TODO
- [ ] test on Windows 10/11. There's a comment in [widget/knobeventhandler.h that says it didn't in earlier versions (in 2018)](https://github.com/mixxxdj/mixxx/blob/adda147643d830ef3069121c634e799b6ca963ed/src/widget/knobeventhandler.h#L77), details somewhere [here](https://mixxx.discourse.group/t/mixxx-2-2-beta-released/17512/38)