### PR TITLE
slotTranslateBeatsHalf: Move beatgrid half beat

### DIFF
--- a/res/skins/Deere/deck_text_row.xml
+++ b/res/skins/Deere/deck_text_row.xml
@@ -141,7 +141,7 @@
                       </Template>
 
                       <Template src="skin:left_right_1state_button_optional.xml">
-                        <SetVariable name="TooltipId">beats_translate_earlier</SetVariable>
+                        <SetVariable name="TooltipId">beats_translate_earlier_move_half_beat</SetVariable>
                         <SetVariable name="ObjectName">BeatsTranslateEarlierButton</SetVariable>
                         <SetVariable name="state_0_pressed">icon/ic_beats_translate_earlier_48px.svg</SetVariable>
                         <SetVariable name="state_0_unpressed">icon/ic_beats_translate_earlier_48px.svg</SetVariable>
@@ -150,7 +150,7 @@
                       </Template>
 
                       <Template src="skin:left_right_1state_button_optional.xml">
-                        <SetVariable name="TooltipId">beats_translate_later</SetVariable>
+                        <SetVariable name="TooltipId">beats_translate_later_move_half_beat</SetVariable>
                         <SetVariable name="ObjectName">BeatsTranslateLaterButton</SetVariable>
                         <SetVariable name="state_0_pressed">icon/ic_beats_translate_later_48px.svg</SetVariable>
                         <SetVariable name="state_0_unpressed">icon/ic_beats_translate_later_48px.svg</SetVariable>

--- a/res/skins/Deere/deck_text_row.xml
+++ b/res/skins/Deere/deck_text_row.xml
@@ -146,6 +146,7 @@
                         <SetVariable name="state_0_pressed">icon/ic_beats_translate_earlier_48px.svg</SetVariable>
                         <SetVariable name="state_0_unpressed">icon/ic_beats_translate_earlier_48px.svg</SetVariable>
                         <SetVariable name="left_connection_control"><Variable name="group"/>,beats_translate_earlier</SetVariable>
+                        <SetVariable name="right_connection_control"><Variable name="group"/>,beats_translate_half</SetVariable>
                       </Template>
 
                       <Template src="skin:left_right_1state_button_optional.xml">
@@ -154,6 +155,7 @@
                         <SetVariable name="state_0_pressed">icon/ic_beats_translate_later_48px.svg</SetVariable>
                         <SetVariable name="state_0_unpressed">icon/ic_beats_translate_later_48px.svg</SetVariable>
                         <SetVariable name="left_connection_control"><Variable name="group"/>,beats_translate_later</SetVariable>
+                        <SetVariable name="right_connection_control"><Variable name="group"/>,beats_translate_half</SetVariable>
                       </Template>
 
                       <Template src="skin:left_right_1state_button_optional.xml">

--- a/res/skins/LateNight/waveform.xml
+++ b/res/skins/LateNight/waveform.xml
@@ -284,11 +284,12 @@
                 <Layout>vertical</Layout>
                 <Size>26f,52f</Size>
                 <Children>
-                  <Template src="skins:LateNight/controls/button_1state_optional.xml">
+                  <Template src="skins:LateNight/controls/button_1state_right_optional.xml">
                     <SetVariable name="TooltipId">beats_translate_earlier</SetVariable>
                     <SetVariable name="ObjectName">BeatsEarlier</SetVariable>
                     <SetVariable name="Size">26f,26f</SetVariable>
                     <SetVariable name="ConfigKey"><Variable name="Group"/>,beats_translate_earlier</SetVariable>
+                    <SetVariable name="ConfigKeyRight"><Variable name="Group"/>,beats_translate_half</SetVariable>
                   </Template>
                   <Template src="skins:LateNight/controls/button_1state_optional.xml">
                     <SetVariable name="TooltipId">beats_adjust_faster</SetVariable>
@@ -303,12 +304,13 @@
                 <Layout>vertical</Layout>
                 <Size>26f,52f</Size>
                 <Children>
-                  <Template src="skins:LateNight/controls/button_1state_optional.xml">
+                  <Template src="skins:LateNight/controls/button_1state_right_optional.xml">
                     <SetVariable name="TooltipId">beats_translate_later</SetVariable>
                     <SetVariable name="ObjectName">BeatsLater</SetVariable>
                     <SetVariable name="Size">26f,26f</SetVariable>
                     <SetVariable name="BtnSize">grid</SetVariable>
                     <SetVariable name="ConfigKey"><Variable name="Group"/>,beats_translate_later</SetVariable>
+                    <SetVariable name="ConfigKeyRight"><Variable name="Group"/>,beats_translate_half</SetVariable>
                   </Template>
                   <Template src="skins:LateNight/controls/button_1state_optional.xml">
                     <SetVariable name="TooltipId">beats_adjust_slower</SetVariable>

--- a/res/skins/LateNight/waveform.xml
+++ b/res/skins/LateNight/waveform.xml
@@ -285,7 +285,7 @@
                 <Size>26f,52f</Size>
                 <Children>
                   <Template src="skins:LateNight/controls/button_1state_right_optional.xml">
-                    <SetVariable name="TooltipId">beats_translate_earlier</SetVariable>
+                    <SetVariable name="TooltipId">beats_translate_earlier_move_half_beat</SetVariable>
                     <SetVariable name="ObjectName">BeatsEarlier</SetVariable>
                     <SetVariable name="Size">26f,26f</SetVariable>
                     <SetVariable name="ConfigKey"><Variable name="Group"/>,beats_translate_earlier</SetVariable>
@@ -305,7 +305,7 @@
                 <Size>26f,52f</Size>
                 <Children>
                   <Template src="skins:LateNight/controls/button_1state_right_optional.xml">
-                    <SetVariable name="TooltipId">beats_translate_later</SetVariable>
+                    <SetVariable name="TooltipId">beats_translate_later_move_half_beat</SetVariable>
                     <SetVariable name="ObjectName">BeatsLater</SetVariable>
                     <SetVariable name="Size">26f,26f</SetVariable>
                     <SetVariable name="BtnSize">grid</SetVariable>

--- a/res/skins/Tango/waveform.xml
+++ b/res/skins/Tango/waveform.xml
@@ -154,11 +154,12 @@ Variables:
                 <Layout>vertical</Layout>
                 <SizePolicy>f,f</SizePolicy>
                 <Children>
-                  <Template src="skins:Tango/controls/button_1state_optional.xml">
+                  <Template src="skins:Tango/controls/button_1state_right_optional.xml">
                     <SetVariable name="TooltipId">beats_translate_earlier</SetVariable>
                     <SetVariable name="ObjectName">BeatgridEarlier</SetVariable>
                     <SetVariable name="Size">28f,24f</SetVariable>
                     <SetVariable name="ConfigKey"><Variable name="Group"/>,beats_translate_earlier</SetVariable>
+                    <SetVariable name="ConfigKeyRight"><Variable name="Group"/>,beats_translate_half</SetVariable>
                   </Template>
 
                   <Template src="skins:Tango/controls/button_1state_optional.xml">
@@ -174,11 +175,12 @@ Variables:
                 <Layout>vertical</Layout>
                 <SizePolicy>f,f</SizePolicy>
                 <Children>
-                  <Template src="skins:Tango/controls/button_1state_optional.xml">
+                  <Template src="skins:Tango/controls/button_1state_right_optional.xml">
                     <SetVariable name="TooltipId">beats_translate_later</SetVariable>
                     <SetVariable name="ObjectName">BeatgridLater</SetVariable>
                     <SetVariable name="Size">28f,24f</SetVariable>
                     <SetVariable name="ConfigKey"><Variable name="Group"/>,beats_translate_later</SetVariable>
+                    <SetVariable name="ConfigKeyRight"><Variable name="Group"/>,beats_translate_half</SetVariable>
                   </Template>
 
                   <Template src="skins:Tango/controls/button_1state_optional.xml">

--- a/res/skins/Tango/waveform.xml
+++ b/res/skins/Tango/waveform.xml
@@ -155,7 +155,7 @@ Variables:
                 <SizePolicy>f,f</SizePolicy>
                 <Children>
                   <Template src="skins:Tango/controls/button_1state_right_optional.xml">
-                    <SetVariable name="TooltipId">beats_translate_earlier</SetVariable>
+                    <SetVariable name="TooltipId">beats_translate_earlier_move_half_beat</SetVariable>
                     <SetVariable name="ObjectName">BeatgridEarlier</SetVariable>
                     <SetVariable name="Size">28f,24f</SetVariable>
                     <SetVariable name="ConfigKey"><Variable name="Group"/>,beats_translate_earlier</SetVariable>
@@ -176,7 +176,7 @@ Variables:
                 <SizePolicy>f,f</SizePolicy>
                 <Children>
                   <Template src="skins:Tango/controls/button_1state_right_optional.xml">
-                    <SetVariable name="TooltipId">beats_translate_later</SetVariable>
+                    <SetVariable name="TooltipId">beats_translate_later_move_half_beat</SetVariable>
                     <SetVariable name="ObjectName">BeatgridLater</SetVariable>
                     <SetVariable name="Size">28f,24f</SetVariable>
                     <SetVariable name="ConfigKey"><Variable name="Group"/>,beats_translate_later</SetVariable>

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -313,6 +313,10 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
             tr("Move Beatgrid"),
             tr("Adjust the beatgrid to the left or right"),
             pBpmMenu);
+    addDeckControl("beats_translate_half",
+            tr("Move Beatgrid Half a Beat"),
+            tr("Adjust the beatgrid by exactly one half beat"),
+            pBpmMenu);
     addDeckControl("beats_translate_curpos",
             tr("Adjust Beatgrid"),
             tr("Align beatgrid to current position"),

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -315,7 +315,8 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
             pBpmMenu);
     addDeckControl("beats_translate_half",
             tr("Move Beatgrid Half a Beat"),
-            tr("Adjust the beatgrid by exactly one half beat"),
+            tr("Adjust the beatgrid by exactly one half beat. Usable only for "
+               "tracks with constant tempo."),
             pBpmMenu);
     addDeckControl("beats_translate_curpos",
             tr("Adjust Beatgrid"),

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -331,12 +331,14 @@ void BpmControl::slotTranslateBeatsHalf(double v) {
         return;
     }
     const mixxx::BeatsPointer pBeats = pTrack->getBeats();
-    if (pBeats) {
-        const auto translatedBeats = pBeats->tryTranslateBeats(0.5);
-        if (translatedBeats) {
-            pTrack->trySetBeats(*translatedBeats);
-        }
+    if (!pBeats) {
+        return;
     }
+    const auto translatedBeats = pBeats->tryTranslateBeats(0.5);
+    if (!translatedBeats) {
+        return;
+    }
+    pTrack->trySetBeats(*translatedBeats);
 }
 
 void BpmControl::slotTranslateBeatsMove(double v) {

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -322,6 +322,7 @@ void BpmControl::slotTranslateBeatsLater(double v) {
     slotTranslateBeatsMove(1);
 }
 
+// slotTranslateBeatsHalf works only with constant BPM tracks
 void BpmControl::slotTranslateBeatsHalf(double v) {
     if (v <= 0) {
         return;

--- a/src/engine/controls/bpmcontrol.h
+++ b/src/engine/controls/bpmcontrol.h
@@ -102,6 +102,7 @@ class BpmControl : public EngineControl {
     void slotAdjustBeatsSlower(double);
     void slotTranslateBeatsEarlier(double);
     void slotTranslateBeatsLater(double);
+    void slotTranslateBeatsHalf(double);
     void slotTranslateBeatsMove(double);
 
     void slotBpmTap(double value);
@@ -149,6 +150,7 @@ class BpmControl : public EngineControl {
     std::unique_ptr<ControlPushButton> m_pAdjustBeatsSlower;
     std::unique_ptr<ControlPushButton> m_pTranslateBeatsEarlier;
     std::unique_ptr<ControlPushButton> m_pTranslateBeatsLater;
+    std::unique_ptr<ControlPushButton> m_pTranslateBeatsHalf;
     std::unique_ptr<ControlEncoder> m_pTranslateBeatsMove;
     std::unique_ptr<ControlPushButton> m_pBeatsUndo;
     std::unique_ptr<ControlObject> m_pBeatsUndoPossible;

--- a/src/skin/legacy/tooltips.cpp
+++ b/src/skin/legacy/tooltips.cpp
@@ -435,15 +435,33 @@ void Tooltips::addStandardTooltips() {
             << tr("Adjust BPM Up")
             << tr("When tapped, adjusts the average BPM up by a small amount.");
 
+    const QString beatsTranslateEarlierTitle = tr("Adjust Beats Earlier");
+    const QString beatsTranslateLaterTitle = tr("Adjust Beats Later");
+    const QString beatsTranslateEarlierDescription =
+            tr("When tapped, moves the beatgrid left by a small amount.");
+    const QString beatsTranslateLaterDescription =
+            tr("When tapped, moves the beatgrid right by a small amount.");
+    const QString moveHalfBeat =
+            tr("Adjust beatgrid by exactly one half beat. "
+               "Usable only on\ntracks with constant tempo");
+
     add("beats_translate_earlier")
-            << tr("Adjust Beats Earlier")
-            << QString("%1: %2").arg(leftClick, tr("When tapped, moves the beatgrid left by a small amount."))
-            << QString("%1: %2").arg(rightClick, tr("Adjust beatgrid by exactly one half beat."));
+            << beatsTranslateEarlierTitle
+            << beatsTranslateEarlierDescription;
 
     add("beats_translate_later")
-            << tr("Adjust Beats Later")
-            << QString("%1: %2").arg(leftClick, tr("When tapped, moves the beatgrid right by a small amount."))
-            << QString("%1: %2").arg(rightClick, tr("Adjust beatgrid by exactly one half beat."));
+            << beatsTranslateLaterTitle
+            << beatsTranslateLaterDescription;
+
+    add("beats_translate_earlier_move_half_beat")
+            << beatsTranslateEarlierTitle
+            << QString("%1: %2").arg(leftClick, beatsTranslateEarlierDescription)
+            << QString("%1: %2").arg(rightClick, moveHalfBeat);
+
+    add("beats_translate_later_move_half_beat")
+            << beatsTranslateLaterTitle
+            << QString("%1: %2").arg(leftClick, beatsTranslateLaterDescription)
+            << QString("%1: %2").arg(rightClick, moveHalfBeat);
 
     add("beats_translate_curpos")
             << tr("Adjust Beatgrid")

--- a/src/skin/legacy/tooltips.cpp
+++ b/src/skin/legacy/tooltips.cpp
@@ -437,11 +437,13 @@ void Tooltips::addStandardTooltips() {
 
     add("beats_translate_earlier")
             << tr("Adjust Beats Earlier")
-            << tr("When tapped, moves the beatgrid left by a small amount.");
+            << QString("%1: %2").arg(leftClick, tr("When tapped, moves the beatgrid left by a small amount."))
+            << QString("%1: %2").arg(rightClick, tr("Adjust beatgrid by exactly one half beat."));
 
     add("beats_translate_later")
             << tr("Adjust Beats Later")
-            << tr("When tapped, moves the beatgrid right by a small amount.");
+            << QString("%1: %2").arg(leftClick, tr("When tapped, moves the beatgrid right by a small amount."))
+            << QString("%1: %2").arg(rightClick, tr("Adjust beatgrid by exactly one half beat."));
 
     add("beats_translate_curpos")
             << tr("Adjust Beatgrid")

--- a/src/skin/legacy/tooltips.cpp
+++ b/src/skin/legacy/tooltips.cpp
@@ -443,7 +443,7 @@ void Tooltips::addStandardTooltips() {
             tr("When tapped, moves the beatgrid right by a small amount.");
     const QString moveHalfBeat =
             tr("Adjust beatgrid by exactly one half beat. "
-               "Usable only on\ntracks with constant tempo");
+               "Usable only on\ntracks with constant tempo.");
 
     add("beats_translate_earlier")
             << beatsTranslateEarlierTitle

--- a/src/track/beats.cpp
+++ b/src/track/beats.cpp
@@ -1,9 +1,7 @@
 #include "track/beats.h"
 
 #include <cmath>
-#include <cstddef>
 #include <iterator>
-#include <optional>
 #include <unordered_map>
 #include <vector>
 
@@ -26,7 +24,6 @@ constexpr double kEpsilon = 0.01;
 } // namespace
 
 namespace mixxx {
-using std::transform;
 
 mixxx::audio::FrameDiff_t Beats::ConstIterator::beatLengthFrames() const {
     if (m_it == m_beats->m_markers.cend()) {

--- a/src/track/beats.cpp
+++ b/src/track/beats.cpp
@@ -635,7 +635,7 @@ std::optional<BeatsPointer> Beats::tryTranslate(audio::FrameDiff_t offsetFrames)
 }
 
 std::optional<BeatsPointer> Beats::tryTranslateBeats(double xBeats) const {
-    if (!m_markers.empty()) {
+    if (!hasConstantTempo()) {
         return std::nullopt;
     }
     const mixxx::audio::FrameDiff_t lastOffsetFrames =

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -397,6 +397,13 @@ class Beats : private std::enable_shared_from_this<Beats> {
     /// failure.
     std::optional<BeatsPointer> tryTranslate(audio::FrameDiff_t offset) const;
 
+    /// Translate all beats based on scalar 'xBeats', e.g. half a beat if xBeats
+    /// is set to 0.5. Works only for tracks with constant BPM.
+    //
+    /// Returns a pointer to the modified beats object, or `nullopt` on
+    /// failure.
+    std::optional<BeatsPointer> tryTranslateBeats(double xBeats) const;
+
     /// Scale the position of every beat in the song by `scale`.
     //
     /// Returns a pointer to the modified beats object, or `nullopt` on

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -524,6 +524,15 @@ void WTrackMenu::createActions() {
                 &WTrackMenu::slotUndoBeatsChange);
     }
 
+    if (!m_pTrackModel && featureIsEnabled(Feature::BPM)) {
+        m_pTranslateBeatsHalf = make_parented<QAction>(tr("Shift Beatgrid Half Beat"), m_pBPMMenu);
+        storeActionTextAndScaleInProperties(m_pTranslateBeatsHalf, 2.0);
+
+        connect(m_pTranslateBeatsHalf, &QAction::triggered, this, [this] {
+            slotTranslateBeatsHalf();
+        });
+    }
+
     if (featureIsEnabled(Feature::Analyze)) {
         m_pAnalyzeAction = make_parented<QAction>(tr("Analyze"), this);
         connect(m_pAnalyzeAction, &QAction::triggered, this, &WTrackMenu::slotAnalyze);
@@ -624,6 +633,10 @@ void WTrackMenu::setupActions() {
         m_pBPMMenu->addAction(m_pBpmFourThirdsAction);
         m_pBPMMenu->addAction(m_pBpmThreeHalvesAction);
         m_pBPMMenu->addAction(m_pBpmDoubleAction);
+        if (m_pTranslateBeatsHalf) {
+            m_pBPMMenu->addSeparator();
+            m_pBPMMenu->addAction(m_pTranslateBeatsHalf);
+        }
         m_pBPMMenu->addSeparator();
         m_pBPMMenu->addAction(m_pBpmLockAction);
         m_pBPMMenu->addAction(m_pBpmUnlockAction);
@@ -1135,6 +1148,10 @@ void WTrackMenu::updateMenus() {
         m_pUpdateReplayGainAct->setEnabled(!m_deckGroup.isEmpty());
     }
 
+    if (m_pTranslateBeatsHalf) {
+        m_pTranslateBeatsHalf->setEnabled(!m_deckGroup.isEmpty());
+    }
+
     if (featureIsEnabled(Feature::Color)) {
         m_pColorPickerAction->setColorPalette(
                 ColorPaletteSettings(m_pConfig).getTrackColorPalette());
@@ -1406,6 +1423,24 @@ void WTrackMenu::slotUpdateReplayGainFromPregain() {
         return;
     }
     m_pTrack->adjustReplayGainFromPregain(gain);
+}
+
+void WTrackMenu::slotTranslateBeatsHalf() {
+    VERIFY_OR_DEBUG_ASSERT(m_pTrack) {
+        return;
+    }
+    VERIFY_OR_DEBUG_ASSERT(!m_deckGroup.isEmpty()) {
+        return;
+    }
+    const mixxx::BeatsPointer pBeats = m_pTrack->getBeats();
+    if (!pBeats) {
+        return;
+    }
+    const auto translatedBeats = pBeats->tryTranslateBeats(0.5);
+    if (!translatedBeats) {
+        return;
+    }
+    m_pTrack->trySetBeats(*translatedBeats);
 }
 
 void WTrackMenu::slotImportMetadataFromFileTags() {

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -1429,9 +1429,6 @@ void WTrackMenu::slotTranslateBeatsHalf() {
     VERIFY_OR_DEBUG_ASSERT(m_pTrack) {
         return;
     }
-    VERIFY_OR_DEBUG_ASSERT(!m_deckGroup.isEmpty()) {
-        return;
-    }
     const mixxx::BeatsPointer pBeats = m_pTrack->getBeats();
     if (!pBeats) {
         return;

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -165,6 +165,7 @@ class WTrackMenu : public QMenu {
     void slotUnlockBpm();
     void slotScaleBpm(mixxx::Beats::BpmScale scale);
     void slotUndoBeatsChange();
+    void slotTranslateBeatsHalf();
 
     // Info and metadata
     void slotUpdateReplayGainFromPregain();
@@ -340,6 +341,7 @@ class WTrackMenu : public QMenu {
     parented_ptr<QAction> m_pBpmThreeHalvesAction;
     parented_ptr<QAction> m_pBpmResetAction;
     parented_ptr<QAction> m_pBpmUndoAction;
+    parented_ptr<QAction> m_pTranslateBeatsHalf;
 
     // Track rating and color
     parented_ptr<WStarRatingAction> m_pStarRatingAction;


### PR DESCRIPTION
Function to translate beat grid half a beat.
Implementing this: [Move beat grid half beat #10811](https://github.com/mixxxdj/mixxx/issues/10811)

Invoked by right click on Adjust Beats buttons.

slotTranslateBeatsMove adjusted for precision and coherence:
Removed rounding of input, as it invoked imprecision when
moving beat grid half a bar.
Removed the division by number of channels of the frames,
as the framerate is independent of number of channels.