### PR TITLE
fix: use generic way to get the group on stem waveform renderer

### DIFF
--- a/src/waveform/renderers/allshader/waveformrendererstem.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererstem.cpp
@@ -31,9 +31,8 @@ void WaveformRendererStem::onSetup(const QDomNode&) {
 }
 
 bool WaveformRendererStem::init() {
-    auto group = m_pEQEnabled->getKey().group;
     for (int stemIdx = 0; stemIdx < mixxx::kMaxSupportedStems; stemIdx++) {
-        QString stemGroup = EngineDeck::getGroupForStem(group, stemIdx);
+        QString stemGroup = EngineDeck::getGroupForStem(m_waveformRenderer->getGroup(), stemIdx);
         m_pStemGain.emplace_back(
                 std::make_unique<PollingControlProxy>(stemGroup,
                         QStringLiteral("volume")));


### PR DESCRIPTION
Not sure how this one slipped through  - since the new stem rendergraph support, `WaveformRendererStem::init` may run while `m_pEQEnabled` is still null, leading to a crash. Using the correct way to get the group in renderer fixes the issue