### PR TITLE
(fix) Traktor S4mk3: smooth xfader curve for Const Power mode

### DIFF
--- a/res/controllers/Traktor-Kontrol-S4-MK3.js
+++ b/res/controllers/Traktor-Kontrol-S4-MK3.js
@@ -1128,17 +1128,19 @@ class Mixer extends ComponentContainer {
                 switch (value) {
                 case 0x00:  // Picnic Bench / Fast Cut
                     engine.setValue("[Mixer Profile]", "xFaderMode", 0);
-                    engine.setValue("[Mixer Profile]", "xFaderCalibration", 0.9);
                     engine.setValue("[Mixer Profile]", "xFaderCurve", 7.0);
                     break;
                 case 0x01:  // Constant Power
                     engine.setValue("[Mixer Profile]", "xFaderMode", 1);
-                    engine.setValue("[Mixer Profile]", "xFaderCalibration", 0.3);
                     engine.setValue("[Mixer Profile]", "xFaderCurve", 0.6);
+                    // Constant power requires to set an appropriate calibration value
+                    // in order to get a smooth curve.
+                    // This is the output of EngineXfader::getPowerCalibration() for
+                    // the "xFaderCurve" 0.6 (pow(0.5, 1.0 / 0.6))
+                    engine.setValue("[Mixer Profile]", "xFaderCalibration", 0.31498);
                     break;
                 case 0x02: // Additive
                     engine.setValue("[Mixer Profile]", "xFaderMode", 0);
-                    engine.setValue("[Mixer Profile]", "xFaderCalibration", 0.4);
                     engine.setValue("[Mixer Profile]", "xFaderCurve", 0.9);
                 }
             },


### PR DESCRIPTION
and remove unused calibration values for Additive modes (see https://github.com/mixxxdj/mixxx/issues/13363#issuecomment-2632543950 for details)

before: (slow fade with rather sharp cut)
![image](https://github.com/user-attachments/assets/d4bcba9c-abe3-4faa-8092-07a841ec167b)


fix:
![image](https://github.com/user-attachments/assets/0a1d1636-8b55-4a33-9e21-bccfd6c3f22a)
