### PR TITLE
DEBUG sidebar click

### DIFF
--- a/src/library/mixxxlibraryfeature.cpp
+++ b/src/library/mixxxlibraryfeature.cpp
@@ -184,7 +184,7 @@ void MixxxLibraryFeature::bindSidebarWidget(WLibrarySidebar* pSidebarWidget) {
 #endif
 
 void MixxxLibraryFeature::activate() {
-    //qDebug() << "MixxxLibraryFeature::activate()";
+    qDebug() << "MixxxLibraryFeature::activate()";
     emit saveModelState();
     emit showTrackModel(m_pLibraryTableModel);
     emit enableCoverArtDisplay(true);

--- a/src/library/sidebarmodel.cpp
+++ b/src/library/sidebarmodel.cpp
@@ -332,16 +332,31 @@ void SidebarModel::clicked(const QModelIndex& index) {
     // invoked immediately before. That doesn't matter,
     // because we stop any running timer before handling
     // this event.
+    qWarning() << "SidebarModel::clicked" << index;
     stopPressedUntilClickedTimer();
     if (index.isValid()) {
+        qWarning() << "  index valid";
         if (index.internalPointer() == this) {
-            m_sFeatures[index.row()]->activate();
+            LibraryFeature* pFeature = m_sFeatures[index.row()];
+            if (!pFeature) {
+                qWarning() << "  no assoc. LibraryFeature found !!";
+                return;
+            }
+            qWarning() << "  index is root of"
+                       << pFeature->title().toString()
+                       << "-> activate()";
+            pFeature->activate();
         } else {
             TreeItem* pTreeItem = static_cast<TreeItem*>(index.internalPointer());
             if (pTreeItem) {
+                qWarning() << "  found assoc. TreeItem*:" << pTreeItem->getLabel();
                 LibraryFeature* pFeature = pTreeItem->feature();
                 DEBUG_ASSERT(pFeature);
+                qWarning() << "  of feature" << pFeature->title().toString();
+                qWarning() << "  -> activate()";
                 pFeature->activateChild(index);
+            } else {
+                qWarning() << "  no assoc. TreeItem* found";
             }
         }
     }


### PR DESCRIPTION
trying to debug #14306 

Should print info like this when clicking
```
warning [Main] SidebarModel::clicked QModelIndex(0,0,0x55df747e0720,SidebarModel(0x55df7476f7a0))
warning [Main]   index valid
warning [Main]   found assoc. TreeItem*: "New Crate (0) 0:00"
warning [Main]   of feature "Crates"
warning [Main]   -> activate()
```

@yanus