### PR TITLE
Make QmlPlayerProxy read-only

### DIFF
--- a/src/qml/qmlplayerproxy.cpp
+++ b/src/qml/qmlplayerproxy.cpp
@@ -15,15 +15,6 @@
         return pTrack->GETTER();                     \
     }
 
-#define PROPERTY_IMPL(TYPE, NAME, GETTER, SETTER)    \
-    PROPERTY_IMPL_GETTER(TYPE, NAME, GETTER)         \
-    void QmlPlayerProxy::SETTER(const TYPE& value) { \
-        const TrackPointer pTrack = m_pCurrentTrack; \
-        if (pTrack != nullptr) {                     \
-            pTrack->SETTER(value);                   \
-        }                                            \
-    }
-
 namespace mixxx {
 namespace qml {
 
@@ -339,18 +330,18 @@ bool QmlPlayerProxy::isLoaded() const {
     return m_pCurrentTrack != nullptr;
 }
 
-PROPERTY_IMPL(QString, artist, getArtist, setArtist)
-PROPERTY_IMPL(QString, title, getTitle, setTitle)
-PROPERTY_IMPL(QString, album, getAlbum, setAlbum)
-PROPERTY_IMPL(QString, albumArtist, getAlbumArtist, setAlbumArtist)
+PROPERTY_IMPL_GETTER(QString, artist, getArtist)
+PROPERTY_IMPL_GETTER(QString, title, getTitle)
+PROPERTY_IMPL_GETTER(QString, album, getAlbum)
+PROPERTY_IMPL_GETTER(QString, albumArtist, getAlbumArtist)
 PROPERTY_IMPL_GETTER(QString, genre, getGenre)
-PROPERTY_IMPL(QString, composer, getComposer, setComposer)
-PROPERTY_IMPL(QString, grouping, getGrouping, setGrouping)
-PROPERTY_IMPL(QString, year, getYear, setYear)
-PROPERTY_IMPL(QString, trackNumber, getTrackNumber, setTrackNumber)
-PROPERTY_IMPL(QString, trackTotal, getTrackTotal, setTrackTotal)
-PROPERTY_IMPL(QString, comment, getComment, setComment)
-PROPERTY_IMPL(QString, keyText, getKeyText, setKeyText)
+PROPERTY_IMPL_GETTER(QString, composer, getComposer)
+PROPERTY_IMPL_GETTER(QString, grouping, getGrouping)
+PROPERTY_IMPL_GETTER(QString, year, getYear)
+PROPERTY_IMPL_GETTER(QString, trackNumber, getTrackNumber)
+PROPERTY_IMPL_GETTER(QString, trackTotal, getTrackTotal)
+PROPERTY_IMPL_GETTER(QString, comment, getComment)
+PROPERTY_IMPL_GETTER(QString, keyText, getKeyText)
 
 QColor QmlPlayerProxy::getColor() const {
     const TrackPointer pTrack = m_pCurrentTrack;
@@ -358,14 +349,6 @@ QColor QmlPlayerProxy::getColor() const {
         return QColor();
     }
     return RgbColor::toQColor(pTrack->getColor());
-}
-
-void QmlPlayerProxy::setColor(const QColor& value) {
-    const TrackPointer pTrack = m_pTrackPlayer->getLoadedTrack();
-    if (pTrack != nullptr) {
-        std::optional<RgbColor> color = RgbColor::fromQColor(value);
-        pTrack->setColor(color);
-    }
 }
 
 QUrl QmlPlayerProxy::getCoverArtUrl() const {

--- a/src/qml/qmlplayerproxy.h
+++ b/src/qml/qmlplayerproxy.h
@@ -20,21 +20,19 @@ namespace qml {
 class QmlPlayerProxy : public QObject {
     Q_OBJECT
     Q_PROPERTY(bool isLoaded READ isLoaded NOTIFY trackChanged)
-    Q_PROPERTY(QString artist READ getArtist WRITE setArtist NOTIFY artistChanged)
-    Q_PROPERTY(QString title READ getTitle WRITE setTitle NOTIFY titleChanged)
-    Q_PROPERTY(QString album READ getAlbum WRITE setAlbum NOTIFY albumChanged)
-    Q_PROPERTY(QString albumArtist READ getAlbumArtist WRITE setAlbumArtist
-                    NOTIFY albumArtistChanged)
+    Q_PROPERTY(QString artist READ getArtist NOTIFY artistChanged)
+    Q_PROPERTY(QString title READ getTitle NOTIFY titleChanged)
+    Q_PROPERTY(QString album READ getAlbum NOTIFY albumChanged)
+    Q_PROPERTY(QString albumArtist READ getAlbumArtist NOTIFY albumArtistChanged)
     Q_PROPERTY(QString genre READ getGenre STORED false NOTIFY genreChanged)
-    Q_PROPERTY(QString composer READ getComposer WRITE setComposer NOTIFY composerChanged)
-    Q_PROPERTY(QString grouping READ getGrouping WRITE setGrouping NOTIFY groupingChanged)
-    Q_PROPERTY(QString year READ getYear WRITE setYear NOTIFY yearChanged)
-    Q_PROPERTY(QString trackNumber READ getTrackNumber WRITE setTrackNumber
-                    NOTIFY trackNumberChanged)
-    Q_PROPERTY(QString trackTotal READ getTrackTotal WRITE setTrackTotal NOTIFY trackTotalChanged)
-    Q_PROPERTY(QString comment READ getComment WRITE setComment NOTIFY commentChanged)
-    Q_PROPERTY(QString keyText READ getKeyText WRITE setKeyText NOTIFY keyTextChanged)
-    Q_PROPERTY(QColor color READ getColor WRITE setColor NOTIFY colorChanged)
+    Q_PROPERTY(QString composer READ getComposer NOTIFY composerChanged)
+    Q_PROPERTY(QString grouping READ getGrouping NOTIFY groupingChanged)
+    Q_PROPERTY(QString year READ getYear NOTIFY yearChanged)
+    Q_PROPERTY(QString trackNumber READ getTrackNumber NOTIFY trackNumberChanged)
+    Q_PROPERTY(QString trackTotal READ getTrackTotal NOTIFY trackTotalChanged)
+    Q_PROPERTY(QString comment READ getComment NOTIFY commentChanged)
+    Q_PROPERTY(QString keyText READ getKeyText NOTIFY keyTextChanged)
+    Q_PROPERTY(QColor color READ getColor NOTIFY colorChanged)
     Q_PROPERTY(QUrl coverArtUrl READ getCoverArtUrl NOTIFY coverArtUrlChanged)
     Q_PROPERTY(QUrl trackLocationUrl READ getTrackLocationUrl NOTIFY trackLocationUrlChanged)
     QML_NAMED_ELEMENT(Player)
@@ -103,19 +101,6 @@ class QmlPlayerProxy : public QObject {
 #ifdef __STEM__
     void slotStemsChanged();
 #endif
-
-    void setArtist(const QString& artist);
-    void setTitle(const QString& title);
-    void setAlbum(const QString& album);
-    void setAlbumArtist(const QString& albumArtist);
-    void setComposer(const QString& composer);
-    void setGrouping(const QString& grouping);
-    void setYear(const QString& year);
-    void setTrackNumber(const QString& trackNumber);
-    void setTrackTotal(const QString& trackTotal);
-    void setComment(const QString& comment);
-    void setKeyText(const QString& keyText);
-    void setColor(const QColor& color);
 
   signals:
     void trackLoading();


### PR DESCRIPTION
Per discussion on Zulip, this PR disable setters in `QmlPlayerProxy` for now.