### PR TITLE
Add case-insensitive parsing for Lancelot key notation

### DIFF
--- a/src/test/keyutilstest.cpp
+++ b/src/test/keyutilstest.cpp
@@ -32,6 +32,12 @@ TEST_F(KeyUtilsTest, LancelotNotation) {
     EXPECT_EQ(mixxx::track::io::key::C_SHARP_MINOR,
               KeyUtils::guessKeyFromText("12A"));
 
+    // Allow lower-case to be more flexible when parsing search queries
+    EXPECT_EQ(mixxx::track::io::key::C_MAJOR,
+            KeyUtils::guessKeyFromText("8b"));
+    EXPECT_EQ(mixxx::track::io::key::C_SHARP_MINOR,
+            KeyUtils::guessKeyFromText("12a"));
+
     // whitespace is ok
     EXPECT_EQ(mixxx::track::io::key::B_MINOR,
             KeyUtils::guessKeyFromText("\t10A  "));

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -27,7 +27,7 @@ const QRegularExpression s_openKeyRegex(QStringLiteral(
 // Lancelot notation, the numbers 1-12 followed by A (minor) or B(I) (major).
 // or "I", "L", "M", "D", "P", "C" for the advanced modes
 const QRegularExpression s_lancelotKeyRegex(
-        QStringLiteral("\\A(?:^\\s*0*(1[0-2]|[1-9])([ABILMDPCabilmdpc])\\s*$)\\z"));
+        QStringLiteral("\\A(?:^\\s*0*(1[0-2]|[1-9])([ABILMDPC])\\s*$)\\z"), QRegularExpression::CaseInsensitiveOption);
 constexpr std::string_view s_lancelotMajorModes = "BILMbilm";
 
 // a-g followed by any number of sharps or flats, optionally followed by

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -27,8 +27,8 @@ const QRegularExpression s_openKeyRegex(QStringLiteral(
 // Lancelot notation, the numbers 1-12 followed by A (minor) or B(I) (major).
 // or "I", "L", "M", "D", "P", "C" for the advanced modes
 const QRegularExpression s_lancelotKeyRegex(
-        QStringLiteral("\\A(?:^\\s*0*(1[0-2]|[1-9])([ABILMDPC])\\s*$)\\z"));
-constexpr std::string_view s_lancelotMajorModes = "BILM";
+        QStringLiteral("\\A(?:^\\s*0*(1[0-2]|[1-9])([ABILMDPCabilmdpc])\\s*$)\\z"));
+constexpr std::string_view s_lancelotMajorModes = "BILMbilm";
 
 // a-g followed by any number of sharps or flats, optionally followed by
 // a scale mode spec (m = minor, min, maj ..)

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -27,8 +27,9 @@ const QRegularExpression s_openKeyRegex(QStringLiteral(
 // Lancelot notation, the numbers 1-12 followed by A (minor) or B(I) (major).
 // or "I", "L", "M", "D", "P", "C" for the advanced modes
 const QRegularExpression s_lancelotKeyRegex(
-        QStringLiteral("\\A(?:^\\s*0*(1[0-2]|[1-9])([ABILMDPC])\\s*$)\\z"), QRegularExpression::CaseInsensitiveOption);
-constexpr std::string_view s_lancelotMajorModes = "BILMbilm";
+        QStringLiteral("\\A(?:^\\s*0*(1[0-2]|[1-9])([ABILMDPC])\\s*$)\\z"),
+        QRegularExpression::CaseInsensitiveOption);
+constexpr std::string_view s_lancelotMajorModes = "BILM";
 
 // a-g followed by any number of sharps or flats, optionally followed by
 // a scale mode spec (m = minor, min, maj ..)
@@ -460,8 +461,9 @@ ChromaticKey KeyUtils::guessKeyFromText(const QString& text) {
         int openKeyNumber = lancelotNumberToOpenKeyNumber(lancelotNumber);
 
         const QChar lancelotScaleMode = lancelotMatch.captured(2).at(0);
-        bool major = (s_lancelotMajorModes.find(lancelotScaleMode.toLatin1()) != std::string::npos);
-
+        bool major = (s_lancelotMajorModes.find(
+                              lancelotScaleMode.toUpper().toLatin1()) !=
+                std::string::npos);
         return openKeyNumberToKey(openKeyNumber, major);
     }
 


### PR DESCRIPTION
When a user types in `key:5a` into the search field, the intent is most likely to search for `key:5A` instead of doing a text-only search.

The only case where case-insensitive parsing is ambigous is for the `d/m` (OpenKey) and `D/M` (Lancelot) suffixes, where lowercase will imply OpenKey, and uppercase will imply Lancelot (due to the order in which `guessKeyFromText` checks for matches with the different notations).