### PR TITLE
qsscheck.py -> added utf-8 in open()

### DIFF
--- a/tools/qsscheck.py
+++ b/tools/qsscheck.py
@@ -242,13 +242,13 @@ def get_global_names(mixxx_path):
             ext = os.path.splitext(fname)[1]
             if ext in (".h", ".cpp"):
                 fpath = os.path.join(root, fname)
-                with open(fpath, mode="r") as f:
+                with open(fpath, mode="r", encoding="utf-8") as f:
                     for line in f:
                         classnames.update(set(RE_CPP_CLASSNAME.findall(line)))
                         objectnames.update(set(RE_CPP_OBJNAME.findall(line)))
             elif ext == ".ui":
                 fpath = os.path.join(root, fname)
-                with open(fpath, mode="r") as f:
+                with open(fpath, mode="r", encoding="utf-8") as f:
                     objectnames.update(set(RE_UI_OBJNAME.findall(f.read())))
     return classnames, objectnames
 
@@ -266,7 +266,7 @@ def get_skin_objectnames(skin_path):
                 continue
 
             fpath = os.path.join(root, fname)
-            with open(fpath, mode="r") as f:
+            with open(fpath, mode="r", encoding="utf-8") as f:
                 for line in f:
                     yield from RE_XML_OBJNAME.findall(line)
                     yield from RE_XML_OBJNAME_SETVAR.findall(line)


### PR DESCRIPTION
these changes solve a 1st error in pre-commit after changing a qss. Error like 
Traceback (most recent call last):
  File "D:\mixxx-git\mixxx\tools\qsscheck.py", line 435, in <module>
    sys.exit(main())
             ^^^^^^
  File "D:\mixxx-git\mixxx\tools\qsscheck.py", line 428, in main
    for message in check_skins(mixxx_path, skins, args.ignore.split(",")):
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\mixxx-git\mixxx\tools\qsscheck.py", line 322, in check_skins
    classnames, objectnames = get_global_names(mixxx_path)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\mixxx-git\mixxx\tools\qsscheck.py", line 252, in get_global_names
    objectnames.update(set(RE_UI_OBJNAME.findall(f.read())))
                                                 ^^^^^^^^
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.12_3.12.2544.0_x64__qbz5n2kfra8p0\Lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 10957: character maps to <undefined>