### PR TITLE
Fix 14326

### DIFF
--- a/src/controllers/legacycontrollersettings.cpp
+++ b/src/controllers/legacycontrollersettings.cpp
@@ -155,7 +155,8 @@ QWidget* LegacyControllerBooleanSetting::buildInputWidget(QWidget* pParent) {
     // We want to format the checkbox label with html styles. This is not possible
     // so we attach a separate QLabel and, in order to get a clickable label like
     // with QCheckBox, we associate the label with the checkbox (buddy).
-    // When the label is clicked we toggle the checkbox in eventFilter().
+    // When the label is clicked we toggle the checkbox in the function
+    // eventFilter() of helper class ToggleCheckboxEventFilter.
     auto pLabelWidget = make_parented<QLabel>(pWidget);
     pLabelWidget->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Maximum);
     pLabelWidget->setText(label());
@@ -187,6 +188,11 @@ bool LegacyControllerBooleanSetting::match(const QDomElement& element) {
 
 bool LegacyControllerBooleanSetting::ToggleCheckboxEventFilter::eventFilter(
         QObject* pObj, QEvent* pEvent) {
+    // eventFilter was a method of LegacyControllerBooleanSetting, but this
+    // doesn't work, as LegacyControllerBooleanSetting is created from a
+    // different thread, and Qt cannot filter events for objects in a
+    // different thread.
+
     QLabel* pLabel = qobject_cast<QLabel*>(pObj);
     if (pLabel && pEvent->type() == QEvent::MouseButtonPress) {
         QCheckBox* pCheckBox = qobject_cast<QCheckBox*>(pLabel->buddy());

--- a/src/controllers/legacycontrollersettings.cpp
+++ b/src/controllers/legacycontrollersettings.cpp
@@ -115,7 +115,6 @@ QWidget* AbstractLegacyControllerSetting::buildWidget(QWidget* pParent,
 LegacyControllerBooleanSetting::LegacyControllerBooleanSetting(
         const QDomElement& element)
         : AbstractLegacyControllerSetting(element) {
-    m_pToggleCheckboxEventFilter = nullptr;
     m_defaultValue = parseValue(element.attribute("default"));
     m_savedValue = m_defaultValue;
     m_editedValue = m_defaultValue;
@@ -162,9 +161,9 @@ QWidget* LegacyControllerBooleanSetting::buildInputWidget(QWidget* pParent) {
     pLabelWidget->setText(label());
     pLabelWidget->setBuddy(pCheckBox);
     if (!m_pToggleCheckboxEventFilter) {
-        m_pToggleCheckboxEventFilter = new ToggleCheckboxEventFilter(pWidget);
+        m_pToggleCheckboxEventFilter = make_parented<ToggleCheckboxEventFilter>(pWidget);
     }
-    pLabelWidget->installEventFilter(m_pToggleCheckboxEventFilter);
+    pLabelWidget->installEventFilter(m_pToggleCheckboxEventFilter.get());
 
     QBoxLayout* pLayout = new QHBoxLayout();
 

--- a/src/controllers/legacycontrollersettings.cpp
+++ b/src/controllers/legacycontrollersettings.cpp
@@ -115,6 +115,7 @@ QWidget* AbstractLegacyControllerSetting::buildWidget(QWidget* pParent,
 LegacyControllerBooleanSetting::LegacyControllerBooleanSetting(
         const QDomElement& element)
         : AbstractLegacyControllerSetting(element) {
+    m_pToggleCheckboxEventFilter = nullptr;
     m_defaultValue = parseValue(element.attribute("default"));
     m_savedValue = m_defaultValue;
     m_editedValue = m_defaultValue;
@@ -159,7 +160,10 @@ QWidget* LegacyControllerBooleanSetting::buildInputWidget(QWidget* pParent) {
     pLabelWidget->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Maximum);
     pLabelWidget->setText(label());
     pLabelWidget->setBuddy(pCheckBox);
-    pLabelWidget->installEventFilter(this);
+    if (!m_pToggleCheckboxEventFilter) {
+        m_pToggleCheckboxEventFilter = new ToggleCheckboxEventFilter(pWidget);
+    }
+    pLabelWidget->installEventFilter(m_pToggleCheckboxEventFilter);
 
     QBoxLayout* pLayout = new QHBoxLayout();
 
@@ -181,7 +185,8 @@ bool LegacyControllerBooleanSetting::match(const QDomElement& element) {
                     Qt::CaseInsensitive) == 0;
 }
 
-bool LegacyControllerBooleanSetting::eventFilter(QObject* pObj, QEvent* pEvent) {
+bool LegacyControllerBooleanSetting::ToggleCheckboxEventFilter::eventFilter(
+        QObject* pObj, QEvent* pEvent) {
     QLabel* pLabel = qobject_cast<QLabel*>(pObj);
     if (pLabel && pEvent->type() == QEvent::MouseButtonPress) {
         QCheckBox* pCheckBox = qobject_cast<QCheckBox*>(pLabel->buddy());

--- a/src/controllers/legacycontrollersettings.h
+++ b/src/controllers/legacycontrollersettings.h
@@ -136,8 +136,6 @@ class LegacyControllerBooleanSetting
                     LegacyControllerSettingsLayoutContainer::HORIZONTAL)
             override;
 
-    bool eventFilter(QObject* pObj, QEvent* pEvent) override;
-
     QJSValue value() const override {
         return QJSValue(m_savedValue);
     }
@@ -188,6 +186,15 @@ class LegacyControllerBooleanSetting
     virtual QWidget* buildInputWidget(QWidget* parent) override;
 
   private:
+    class ToggleCheckboxEventFilter : public QObject {
+      public:
+        ToggleCheckboxEventFilter(QObject* pParent)
+                : QObject(pParent) {
+        }
+        bool eventFilter(QObject* pObj, QEvent* pEvent) override;
+    };
+
+    ToggleCheckboxEventFilter* m_pToggleCheckboxEventFilter;
     bool m_savedValue;
     bool m_defaultValue;
     bool m_editedValue;

--- a/src/controllers/legacycontrollersettings.h
+++ b/src/controllers/legacycontrollersettings.h
@@ -194,7 +194,7 @@ class LegacyControllerBooleanSetting
         bool eventFilter(QObject* pObj, QEvent* pEvent) override;
     };
 
-    ToggleCheckboxEventFilter* m_pToggleCheckboxEventFilter;
+    parented_ptr<ToggleCheckboxEventFilter> m_pToggleCheckboxEventFilter;
     bool m_savedValue;
     bool m_defaultValue;
     bool m_editedValue;


### PR DESCRIPTION
Fixes #14326

installEventFilter was using an object created in a different thread than the main thread. this is illegal. Fixed by using a helper class with the eventFilter method, which is instantiated in the main thread.


