### PR TITLE
(fix) Controller mapping info: avoid cropped description text

### DIFF
--- a/src/controllers/dlgprefcontrollerdlg.ui
+++ b/src/controllers/dlgprefcontrollerdlg.ui
@@ -312,7 +312,7 @@
           <item row="2" column="1">
            <widget class="QLabel" name="labelLoadedMappingDescription">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Minimum">
+             <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>


### PR DESCRIPTION
Quick fix for #14117 
(interestingly it was the horizontal size policy that finally made the difference :man_shrugging: )
![image](https://github.com/user-attachments/assets/2218f3fd-0d9c-4280-99ab-e975dc6a1270)

when merging to main just drop the 2.5 change.