### PR TITLE
Allow feedback on every release of a `powerWindow` button

### DIFF
--- a/res/controllers/Behringer-BCR2000-scripts.js
+++ b/res/controllers/Behringer-BCR2000-scripts.js
@@ -97,6 +97,7 @@ var BCR2000 = new behringer.extension.GenericMidiController({
                 ],
                 equalizerUnit: {
                     feedback: true,
+                    feedbackOnRelease: true,
                     midi: {
                         enabled: [cc, p.pushEncoderGroup2[0].button],
                         super1: [cc, p.pushEncoderGroup2[0].encoder],
@@ -192,6 +193,7 @@ var BCR2000 = new behringer.extension.GenericMidiController({
                 ],
                 equalizerUnit: {
                     feedback: true,
+                    feedbackOnRelease: true,
                     midi: {
                         enabled: [cc, p.pushEncoderGroup2[4].button],
                         super1: [cc, p.pushEncoderGroup2[4].encoder],
@@ -210,6 +212,7 @@ var BCR2000 = new behringer.extension.GenericMidiController({
             }],
             effectUnits: [{
                 feedback: true,
+                feedbackOnRelease: true,
                 unitNumbers: [1, 3],
                 midi: {
                     effectFocusButton: [cc, p.buttonRow2[0]],
@@ -228,6 +231,7 @@ var BCR2000 = new behringer.extension.GenericMidiController({
             },
             {
                 feedback: true,
+                feedbackOnRelease: true,
                 unitNumbers: [2, 4],
                 midi: {
                     effectFocusButton: [cc, p.buttonRow2[4]],

--- a/res/controllers/Behringer-Extension-scripts.js
+++ b/res/controllers/Behringer-Extension-scripts.js
@@ -1240,6 +1240,11 @@
      *     |     |  |            to the hardware controller on changes. The address of the MIDI
      *     |     |  |            message is taken from the `midi` property of the affected
      *     |     |  |            component.
+     *     |     |  +- feedbackOnRelease: Enable controller feedback on button release (boolean, optional)
+     *     |     |  |            When set to `true`, values of the buttons in this unit are sent
+     *     |     |  |            to the hardware controller on release, no matter if changed or not.
+     *     |     |  |            The address of the MIDI message is taken from the `midi` property of the
+     *     |     |  |            affected component.
      *     |     |  +- output: Additional output definitions (optional).
      *     |     |             The structure of this object is the same as the structure of
      *     |     |             `midi`. Every value change of a component contained in `output`
@@ -1252,6 +1257,7 @@
      *     |        |          `enabled: [0x90, 0x02]`
      *     |        |          `super1: [0xB0, 0x06]`
      *     |        +- feedback: As described for equalizer unit
+     *     |        +- feedbackOnRelease: As described for equalizer unit
      *     |        +- output: As described for equalizer unit
      *     |
      *     +- effectUnits: An array of effect unit definitions (may be empty or omitted)
@@ -1262,6 +1268,7 @@
      *     |     |          `effectFocusButton: [0xB0, 0x15]`
      *     |     |          `knobs: {1: [0xB0, 0x26], 2: [0xB0, 0x25], 3: [0xB0, 0x24]}`
      *     |     +- feedback: As described for equalizer unit
+     *     |     +- feedbackOnRelease: As described for equalizer unit
      *     |     +- output: As described for equalizer unit
      *     |     +- sendShiftedFor: Type of components that send shifted MIDI messages (optional)
      *     |                        When set, all components of this type within this effect unit
@@ -1545,6 +1552,16 @@
                             publisherStorage);
                     });
             }
+
+            /* Enable feedback on button release for configured components */
+            if (definition.feedbackOnRelease) {
+                implementation.forEachComponent(function(component) {
+                    if (component instanceof components.Button) {
+                        component.triggerOnRelease = true;
+                    }
+                });
+            }
+
             return implementation;
         },
 

--- a/res/controllers/Behringer-Extension-scripts.js
+++ b/res/controllers/Behringer-Extension-scripts.js
@@ -1519,10 +1519,10 @@
             if (definition.feedback) {
                 const triggers = rebindTriggers || [];
                 const createPublisher = this.createPublisher; // `this` is bound to implementation
-                implementation.forEachComponent(function(effectComponent) {
-                    if (effectComponent instanceof components.Pot) {
-                        const publisher = createPublisher(effectComponent, publisherStorage);
-                        const prototype = Object.getPrototypeOf(effectComponent);
+                implementation.forEachComponent(function(source) {
+                    if (source instanceof components.Pot) {
+                        const publisher = createPublisher(source, publisherStorage);
+                        const prototype = Object.getPrototypeOf(source);
                         triggers.forEach(function(functionName) {
                             const delegate = prototype[functionName];
                             if (typeof delegate === "function") {

--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -176,6 +176,7 @@
         // in any Buttons that act differently with short and long presses
         // to keep the timeouts uniform.
         longPressTimeout: 275,
+        triggerOnRelease: false,
         isPress: function(channel, control, value, _status) {
             return value > 0;
         },
@@ -197,6 +198,8 @@
                 } else {
                     if (this.isLongPressed) {
                         this.inToggle();
+                    } else if (this.triggerOnRelease === true) {
+                        this.trigger();
                     }
                     if (this.longPressTimer !== 0) {
                         engine.stopTimer(this.longPressTimer);

--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -198,7 +198,7 @@
                 } else {
                     if (this.isLongPressed) {
                         this.inToggle();
-                    } else if (this.triggerOnRelease === true) {
+                    } else if (this.triggerOnRelease) {
                         this.trigger();
                     }
                     if (this.longPressTimer !== 0) {


### PR DESCRIPTION
This PR addresses #14334 by adding an option to send the current state of a `Button` with type `powerWindow` to the controller on release even if the `Button` state did not change. The new behavior is hidden behind a new feature flag to keep backwards compatibility. Only when the options of a `Button` contain the new property `triggerOnRelease`, the current state is sent to the controller instead of doing nothing. Only buttons of type `powerWindow` are affected.

The implementation has been tested successfully on a Behringer BCR2000 controller.

The `Behringer-Extension-scripts.js` have been extended to apply the new behavior to effect units, quick effect units and equalizers if their configuration contains the newly introduced option `feedbackOnRelease`. These component containers contain buttons of type `powerWindow`.
