### PR TITLE
Labeler: Add `developer experience` issue label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -32,6 +32,14 @@ controller mappings:
       - any-glob-to-any-file:
           - res/controllers/**
 
+developer experience:
+  - changed-files:
+      - any-glob-to-any-file:
+          - CONTRIBUTING.md
+          - README.md
+          - .github/labeler.yml
+          - .pre-commit-config.yaml
+
 analyzer:
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -35,10 +35,13 @@ controller mappings:
 developer experience:
   - changed-files:
       - any-glob-to-any-file:
+          - .github/ISSUE_TEMPLATE/**
+          - .github/labeler.yml
+          - tools/**
+          - .pre-commit-config.yaml
+          - CODE_OF_CONDUCT.md
           - CONTRIBUTING.md
           - README.md
-          - .github/labeler.yml
-          - .pre-commit-config.yaml
 
 analyzer:
   - changed-files:


### PR DESCRIPTION
The `developer experience` issue label created by request in [#13827](https://github.com/mixxxdj/mixxx/issues/13827#issuecomment-2453422945) should also be handled by the automatic issue labeler.

---

I also have two related requests:
- [x] Can we rename **`developer-experience`** to **`developer experience`** to match the naming convention of the other issue labels?
- [x] Can someone fix the currently truncated description of the `developer experience` label to read: `Issues, bugs and PRs related to the development process, development environment & developer docs.`?