### PR TITLE
Small grammar fix for comment in `BpmControl::slotUpdateRateSlider`

### DIFF
--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -1106,7 +1106,7 @@ void BpmControl::slotUpdateRateSlider(double value) {
         kLogger.trace() << getGroup() << "BpmControl::slotUpdateRateSlider"
                         << value;
     }
-    // Adjust rate slider position response to a change in rate range or m_pEngineBpm
+    // Adjust rate slider position in response to a change in rate range or m_pEngineBpm
 
     double localBpm = m_pLocalBpm->get();
     if (localBpm == 0.0) {


### PR DESCRIPTION
You can't get more minimal than updating just 3 characters. The title already contains more characters than the change itself :sweat_smile:

Anyway, this is just a leftover from another larger changeset that is currently being split up.