### PR TITLE
PitchBendControl: Extract PitchBendControl from RateControl.

### DIFF
--- a/src/engine/controls/pitchbendcontrol.cpp
+++ b/src/engine/controls/pitchbendcontrol.cpp
@@ -1,0 +1,199 @@
+#include "engine/controls/pitchbendcontrol.h"
+
+#include <QtDebug>
+
+#include "control/controlobject.h"
+#include "control/controlpushbutton.h"
+#include "engine/controls/enginecontrol.h"
+#include "moc_pitchbendcontrol.cpp"
+
+namespace {
+constexpr int kRateSensitivityMin = 100;
+constexpr int kRateSensitivityMax = 2500;
+} // namespace
+
+// Static default values for rate buttons (percents)
+ControlValueAtomic<double> PitchBendControl::m_dTemporaryRateChangeCoarse;
+ControlValueAtomic<double> PitchBendControl::m_dTemporaryRateChangeFine;
+int PitchBendControl::m_iRateRampSensitivity;
+PitchBendControl::RampMode PitchBendControl::m_eRateRampMode;
+
+PitchBendControl::PitchBendControl(const QString& group,
+        UserSettingsPointer pConfig)
+        : EngineControl(group, pConfig),
+          m_bTempStarted(false),
+          m_tempRateRatio(0.0),
+          m_dRateTempRampChange(0.0) {
+    // We need the sample rate so we can guesstimate something close
+    // what latency is.
+    m_pSampleRate = ControlObject::getControl(
+            ConfigKey(QStringLiteral("[App]"), QStringLiteral("samplerate")));
+
+    // Temporary rate-change buttons
+    m_pButtonRateTempDown =
+            new ControlPushButton(ConfigKey(group, "rate_temp_down"));
+    m_pButtonRateTempDownSmall =
+            new ControlPushButton(ConfigKey(group, "rate_temp_down_small"));
+    m_pButtonRateTempUp =
+            new ControlPushButton(ConfigKey(group, "rate_temp_up"));
+    m_pButtonRateTempUpSmall =
+            new ControlPushButton(ConfigKey(group, "rate_temp_up_small"));
+
+    //     // Update Internal Settings
+    //     // Set Pitchbend Mode
+    //     m_eRateRampMode = static_cast<RampMode>(
+    //         getConfig()->getValue(ConfigKey("[Controls]","RateRamp"),
+    //                               static_cast<int>(RampMode::Stepping)));
+
+    //     // Set the Sensitivity
+    //     m_iRateRampSensitivity =
+    //             getConfig()->getValueString(ConfigKey("[Controls]","RateRampSensitivity")).toInt();
+}
+
+PitchBendControl::~PitchBendControl() {
+    delete m_pButtonRateTempDown;
+    delete m_pButtonRateTempDownSmall;
+    delete m_pButtonRateTempUp;
+    delete m_pButtonRateTempUpSmall;
+}
+
+// static
+void PitchBendControl::setRateRampMode(RampMode mode) {
+    m_eRateRampMode = mode;
+}
+
+// static
+RateControl::RampMode PitchBendControl::getRateRampMode() {
+    return m_eRateRampMode;
+}
+
+// static
+void PitchBendControl::setRateRampSensitivity(int sense) {
+    // Reverse the actual sensitivity value passed.
+    // That way the gui works in an intuitive manner.
+    sense = kRateSensitivityMax - sense + kRateSensitivityMin;
+    if (sense < kRateSensitivityMin) {
+        m_iRateRampSensitivity = kRateSensitivityMin;
+    } else if (sense > kRateSensitivityMax) {
+        m_iRateRampSensitivity = kRateSensitivityMax;
+    } else {
+        m_iRateRampSensitivity = sense;
+    }
+}
+
+// static
+void PitchBendControl::setTemporaryRateChangeCoarseAmount(double v) {
+    m_dTemporaryRateChangeCoarse.setValue(v);
+}
+
+// static
+void PitchBendControl::setTemporaryRateChangeFineAmount(double v) {
+    m_dTemporaryRateChangeFine.setValue(v);
+}
+
+// static
+double PitchBendControl::getTemporaryRateChangeCoarseAmount() {
+    return m_dTemporaryRateChangeCoarse.getValue();
+}
+
+// static
+double PitchBendControl::getTemporaryRateChangeFineAmount() {
+    return m_dTemporaryRateChangeFine.getValue();
+}
+
+double PitchBendControl::getTempRate() {
+    // qDebug() << m_tempRateRatio;
+    return m_tempRateRatio;
+}
+
+void PitchBendControl::setRateTemp(double v) {
+    m_tempRateRatio = v;
+    if (m_tempRateRatio < -1.0) {
+        m_tempRateRatio = -1.0;
+    } else if (m_tempRateRatio > 1.0) {
+        m_tempRateRatio = 1.0;
+    } else if (util_isnan(m_tempRateRatio)) {
+        m_tempRateRatio = 0;
+    }
+}
+
+void PitchBendControl::addRateTemp(double v) {
+    setRateTemp(m_tempRateRatio + v);
+}
+
+void PitchBendControl::subRateTemp(double v) {
+    setRateTemp(m_tempRateRatio - v);
+}
+
+void PitchBendControl::resetRateTemp(void) {
+    setRateTemp(0.0);
+}
+
+void PitchBendControl::processTempRate(const std::size_t bufferSamples, const double rateRange) {
+    // Code to handle temporary rate change buttons.
+    // We support two behaviors, the standard ramped pitch bending
+    // and pitch shift stepping, which is the old behavior.
+
+    RampDirection rampDirection = RampDirection::None;
+    if (m_pButtonRateTempUp->toBool()) {
+        rampDirection = RampDirection::Up;
+    } else if (m_pButtonRateTempDown->toBool()) {
+        rampDirection = RampDirection::Down;
+    } else if (m_pButtonRateTempUpSmall->toBool()) {
+        rampDirection = RampDirection::UpSmall;
+    } else if (m_pButtonRateTempDownSmall->toBool()) {
+        rampDirection = RampDirection::DownSmall;
+    }
+
+    if (rampDirection != RampDirection::None) {
+        if (m_eRateRampMode == RampMode::Stepping) {
+            if (!m_bTempStarted) {
+                m_bTempStarted = true;
+                // old temporary pitch shift behavior
+                double change = m_dTemporaryRateChangeCoarse.getValue() / 100.0;
+                double csmall = m_dTemporaryRateChangeFine.getValue() / 100.0;
+
+                switch (rampDirection) {
+                case RampDirection::Up:
+                    setRateTemp(change);
+                    break;
+                case RampDirection::Down:
+                    setRateTemp(-change);
+                    break;
+                case RampDirection::UpSmall:
+                    setRateTemp(csmall);
+                    break;
+                case RampDirection::DownSmall:
+                    setRateTemp(-csmall);
+                    break;
+                case RampDirection::None:
+                default:
+                    DEBUG_ASSERT(false);
+                }
+            }
+        } else if (m_eRateRampMode == RampMode::Linear) {
+            if (!m_bTempStarted) {
+                m_bTempStarted = true;
+                double latrate = bufferSamples / m_pSampleRate->get();
+                m_dRateTempRampChange = latrate / (m_iRateRampSensitivity / 100.0);
+            }
+
+            switch (rampDirection) {
+            case RampDirection::Up:
+            case RampDirection::UpSmall:
+                addRateTemp(m_dRateTempRampChange * rateRange);
+                break;
+            case RampDirection::Down:
+            case RampDirection::DownSmall:
+                subRateTemp(m_dRateTempRampChange * rateRange);
+                break;
+            case RampDirection::None:
+            default:
+                DEBUG_ASSERT(false);
+            }
+        }
+    } else if (m_bTempStarted) {
+        m_bTempStarted = false;
+        resetRateTemp();
+    }
+}

--- a/src/engine/controls/pitchbendcontrol.h
+++ b/src/engine/controls/pitchbendcontrol.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <QObject>
+
+#include "control/controlobject.h"
+#include "engine/controls/enginecontrol.h"
+#include "engine/sync/syncable.h"
+#include "preferences/usersettings.h"
+
+class ControlObject;
+class ControlPushButton;
+
+// PitchBendControl is an EngineControl that is in charge of managing the rate of
+// playback of a given channel of audio in the Mixxx engine. Using input from
+// various controls, RateControl will calculate the current rate.
+class PitchBendControl : public EngineControl {
+    Q_OBJECT
+  public:
+    PitchBendControl(const QString& group, UserSettingsPointer pConfig);
+    PitchBendControl();
+
+    // Enumerations which hold the state of the pitchbend buttons.
+    // These enumerations can be used like a bitmask.
+    enum class RampDirection {
+        None,      // No buttons are held down
+        Down,      // Down button is being held
+        Up,        // Up button is being held
+        DownSmall, // DownSmall button is being held
+        UpSmall,   // UpSmall button is being held
+    };
+
+    enum class RampMode {
+        Stepping = 0, // pitch takes a temporary step up/down a certain amount
+        Linear = 1    // pitch moves up/down in a progressively linear fashion
+    };
+
+    // Set rate change when temp rate button is pressed
+    static void setTemporaryRateChangeCoarseAmount(double v);
+    static double getTemporaryRateChangeCoarseAmount();
+
+    // Set rate change when temp rate small button is pressed
+    static void setTemporaryRateChangeFineAmount(double v);
+    static double getTemporaryRateChangeFineAmount();
+
+    // Set Rate Ramp Mode
+    static void setRateRampMode(RampMode mode);
+    static RampMode getRateRampMode();
+
+    // Set Rate Ramp Sensitivity
+    static void setRateRampSensitivity(int);
+    static int getRateRampSensitivity();
+
+    // Invoked by RateControl::calculateSpeed
+    void processTempRate(const std::size_t bufferSamples, const double rateRange);
+
+    // Get the 'Raw' Temp Rate
+    double getTempRate(void);
+
+  private:
+    // Set rate change of the temporary pitch rate
+    void setRateTemp(double v);
+    // Add a value to the temporary pitch rate
+    void addRateTemp(double v);
+    // Subtract a value from the temporary pitch rate
+    void subRateTemp(double v);
+    // Reset the temporary pitch rate
+    void resetRateTemp(void);
+
+    // Values used when temp rate buttons are pressed
+    static ControlValueAtomic<double> m_dTemporaryRateChangeCoarse;
+    static ControlValueAtomic<double> m_dTemporaryRateChangeFine;
+
+    ControlPushButton* m_pButtonRateTempDown;
+    ControlPushButton* m_pButtonRateTempDownSmall;
+    ControlPushButton* m_pButtonRateTempUp;
+    ControlPushButton* m_pButtonRateTempUpSmall;
+
+    ControlObject* m_pSampleRate;
+
+    // This is true if we've already started to ramp the rate
+    bool m_bTempStarted;
+    // Set the Temporary Rate Change Mode
+    static RampMode m_eRateRampMode;
+    // The Rate Temp Sensitivity, the higher it is the slower it gets
+    static int m_iRateRampSensitivity;
+    // Temporary pitchrate, added to the permanent rate for calculateRate
+    double m_tempRateRatio;
+    // Speed for temporary rate change
+    double m_dRateTempRampChange;
+};

--- a/src/engine/controls/ratecontrol.cpp
+++ b/src/engine/controls/ratecontrol.cpp
@@ -15,11 +15,6 @@
 #include "util/rotary.h"
 #include "vinylcontrol/defs_vinylcontrol.h"
 
-namespace {
-constexpr int kRateSensitivityMin = 100;
-constexpr int kRateSensitivityMax = 2500;
-} // namespace
-
 // Static default values for rate buttons (percents)
 ControlValueAtomic<double> RateControl::m_dPermanentRateChangeCoarse;
 ControlValueAtomic<double> RateControl::m_dPermanentRateChangeFine;

--- a/src/engine/controls/ratecontrol.h
+++ b/src/engine/controls/ratecontrol.h
@@ -6,6 +6,7 @@
 #include "engine/controls/enginecontrol.h"
 #include "engine/sync/syncable.h"
 
+class PitchBendControl;
 class BpmControl;
 class Rotary;
 class ControlTTRotary;
@@ -24,22 +25,8 @@ public:
   RateControl(const QString& group, UserSettingsPointer pConfig);
   ~RateControl() override;
 
-  // Enumerations which hold the state of the pitchbend buttons.
-  // These enumerations can be used like a bitmask.
-  enum class RampDirection {
-      None,      // No buttons are held down
-      Down,      // Down button is being held
-      Up,        // Up button is being held
-      DownSmall, // DownSmall button is being held
-      UpSmall,   // UpSmall button is being held
-  };
-
-  enum class RampMode {
-      Stepping = 0, // pitch takes a temporary step up/down a certain amount
-      Linear = 1    // pitch moves up/down in a progressively linear fashion
-  };
-
-  void setBpmControl(BpmControl* bpmcontrol);
+  void setPitchBendControl(PitchBendControl* pitchBendControl);
+  void setBpmControl(BpmControl* bpmControl);
 
   // Returns the current engine rate.  "reportScratching" is used to tell
   // the caller that the user is currently scratching, and this is used to
@@ -52,24 +39,12 @@ public:
           bool* pReportScratching,
           bool* pReportReverse);
 
-  // Set rate change when temp rate button is pressed
-  static void setTemporaryRateChangeCoarseAmount(double v);
-  static double getTemporaryRateChangeCoarseAmount();
-  // Set rate change when temp rate small button is pressed
-  static void setTemporaryRateChangeFineAmount(double v);
-  static double getTemporaryRateChangeFineAmount();
   // Set rate change when perm rate button is pressed
   static void setPermanentRateChangeCoarseAmount(double v);
   static double getPermanentRateChangeCoarseAmount();
   // Set rate change when perm rate small button is pressed
   static void setPermanentRateChangeFineAmount(double v);
   static double getPermanentRateChangeFineAmount();
-  // Set Rate Ramp Mode
-  static void setRateRampMode(RampMode mode);
-  static RampMode getRateRampMode();
-  // Set Rate Ramp Sensitivity
-  static void setRateRampSensitivity(int);
-  static int getRateRampSensitivity();
   bool isReverseButtonPressed();
   // ReadAheadManager::getNextSamples() notifies us each time the play position
   // wrapped around during one buffer process (beatloop or track repeat) so
@@ -90,32 +65,13 @@ public slots:
   void slotControlFastBack(double);
 
 private:
-  void processTempRate(const size_t bufferSamples);
   double getJogFactor() const;
   double getWheelFactor() const;
   SyncMode getSyncMode() const;
 
-  // Set rate change of the temporary pitch rate
-  void setRateTemp(double v);
-  // Add a value to the temporary pitch rate
-  void addRateTemp(double v);
-  // Subtract a value from the temporary pitch rate
-  void subRateTemp(double v);
-  // Reset the temporary pitch rate
-  void resetRateTemp(void);
-  // Get the 'Raw' Temp Rate
-  double getTempRate(void);
-
   // Values used when temp and perm rate buttons are pressed
-  static ControlValueAtomic<double> m_dTemporaryRateChangeCoarse;
-  static ControlValueAtomic<double> m_dTemporaryRateChangeFine;
   static ControlValueAtomic<double> m_dPermanentRateChangeCoarse;
   static ControlValueAtomic<double> m_dPermanentRateChangeFine;
-
-  ControlPushButton* m_pButtonRateTempDown;
-  ControlPushButton* m_pButtonRateTempDownSmall;
-  ControlPushButton* m_pButtonRateTempUp;
-  ControlPushButton* m_pButtonRateTempUpSmall;
 
   ControlPushButton* m_pButtonRatePermDown;
   ControlPushButton* m_pButtonRatePermDownSmall;
@@ -146,6 +102,9 @@ private:
 
   ControlObject* m_pSampleRate;
 
+  // For pitch bending
+  PitchBendControl* m_pPitchBendControl;
+
   // For Sync Lock
   BpmControl* m_pBpmControl;
 
@@ -156,18 +115,8 @@ private:
   mixxx::audio::FramePos m_jumpPos;
   mixxx::audio::FramePos m_targetPos;
 
-  // This is true if we've already started to ramp the rate
-  bool m_bTempStarted;
-  // Set the Temporary Rate Change Mode
-  static RampMode m_eRateRampMode;
-  // The Rate Temp Sensitivity, the higher it is the slower it gets
-  static int m_iRateRampSensitivity;
   // Factor applied to the deprecated "wheel" rate value.
   static const double kWheelMultiplier;
   // Factor applied to jogwheels when the track is paused to speed up seeking.
   static const double kPausedJogMultiplier;
-  // Temporary pitchrate, added to the permanent rate for calculateRate
-  double m_tempRateRatio;
-  // Speed for temporary rate change
-  double m_dRateTempRampChange;
 };

--- a/src/preferences/dialog/dlgprefdeck.cpp
+++ b/src/preferences/dialog/dlgprefdeck.cpp
@@ -5,6 +5,7 @@
 #include "control/controlobject.h"
 #include "control/controlproxy.h"
 #include "defs_urls.h"
+#include "engine/controls/pitchbendcontrol.h"
 #include "engine/controls/ratecontrol.h"
 #include "engine/sync/enginesync.h"
 #include "mixer/basetrackplayer.h"
@@ -16,7 +17,7 @@
 namespace {
 constexpr int kDefaultRateRangePercent = 8;
 constexpr double kRateDirectionInverted = -1;
-constexpr RateControl::RampMode kDefaultRampingMode = RateControl::RampMode::Stepping;
+constexpr PitchBendControl::RampMode kDefaultRampingMode = PitchBendControl::RampMode::Stepping;
 constexpr double kDefaultTemporaryRateChangeCoarse = 4.00; // percent
 constexpr double kDefaultTemporaryRateChangeFine = 2.00;
 constexpr double kDefaultPermanentRateChangeCoarse = 0.50;
@@ -366,10 +367,10 @@ DlgPrefDeck::DlgPrefDeck(QWidget* parent, UserSettingsPointer pConfig)
             &QRadioButton::toggled,
             this,
             &DlgPrefDeck::slotRateRampingModeLinearButton);
-    m_bRateRamping = static_cast<RateControl::RampMode>(
+    m_bRateRamping = static_cast<PitchBendControl::RampMode>(
             m_pConfig->getValue(ConfigKey("[Controls]", "RateRamp"),
                     static_cast<int>(kDefaultRampingMode)));
-    if (m_bRateRamping == RateControl::RampMode::Linear) {
+    if (m_bRateRamping == PitchBendControl::RampMode::Linear) {
         radioButtonRateRampModeLinear->setChecked(true);
     } else {
         radioButtonRateRampModeStepping->setChecked(true);
@@ -407,8 +408,8 @@ DlgPrefDeck::DlgPrefDeck(QWidget* parent, UserSettingsPointer pConfig)
     spinBoxPermanentRateCoarse->setValue(m_dRatePermCoarse);
     spinBoxPermanentRateFine->setValue(m_dRatePermFine);
 
-    RateControl::setTemporaryRateChangeCoarseAmount(m_dRateTempCoarse);
-    RateControl::setTemporaryRateChangeFineAmount(m_dRateTempFine);
+    PitchBendControl::setTemporaryRateChangeCoarseAmount(m_dRateTempCoarse);
+    PitchBendControl::setTemporaryRateChangeFineAmount(m_dRateTempFine);
     RateControl::setPermanentRateChangeCoarseAmount(m_dRatePermCoarse);
     RateControl::setPermanentRateChangeFineAmount(m_dRatePermFine);
 
@@ -490,7 +491,7 @@ void DlgPrefDeck::slotUpdate() {
         checkBoxResetSpeed->setChecked(false);
     }
 
-    if (m_bRateRamping == RateControl::RampMode::Linear) {
+    if (m_bRateRamping == PitchBendControl::RampMode::Linear) {
         radioButtonRateRampModeLinear->setChecked(true);
     } else {
         radioButtonRateRampModeStepping->setChecked(true);
@@ -500,8 +501,8 @@ void DlgPrefDeck::slotUpdate() {
         m_pConfig->getValue(ConfigKey("[Controls]", "RateRampSensitivity"),
                             kDefaultRateRampSensitivity));
 
-    spinBoxTemporaryRateCoarse->setValue(RateControl::getTemporaryRateChangeCoarseAmount());
-    spinBoxTemporaryRateFine->setValue(RateControl::getTemporaryRateChangeFineAmount());
+    spinBoxTemporaryRateCoarse->setValue(PitchBendControl::getTemporaryRateChangeCoarseAmount());
+    spinBoxTemporaryRateFine->setValue(PitchBendControl::getTemporaryRateChangeFineAmount());
     spinBoxPermanentRateCoarse->setValue(RateControl::getPermanentRateChangeCoarseAmount());
     spinBoxPermanentRateFine->setValue(RateControl::getPermanentRateChangeFineAmount());
 }
@@ -654,9 +655,9 @@ void DlgPrefDeck::slotRateRampSensitivitySlider(int value) {
 
 void DlgPrefDeck::slotRateRampingModeLinearButton(bool checked) {
     if (checked) {
-        m_bRateRamping = RateControl::RampMode::Linear;
+        m_bRateRamping = PitchBendControl::RampMode::Linear;
     } else {
-        m_bRateRamping = RateControl::RampMode::Stepping;
+        m_bRateRamping = PitchBendControl::RampMode::Stepping;
     }
 }
 
@@ -749,14 +750,14 @@ void DlgPrefDeck::slotApply() {
         pControl->set(static_cast<double>(m_keyunlockMode));
     }
 
-    RateControl::setRateRampMode(m_bRateRamping);
+    PitchBendControl::setRateRampMode(m_bRateRamping);
     m_pConfig->setValue(ConfigKey("[Controls]", "RateRamp"), m_bRateRamping);
 
-    RateControl::setRateRampSensitivity(m_iRateRampSensitivity);
+    PitchBendControl::setRateRampSensitivity(m_iRateRampSensitivity);
     m_pConfig->setValue(ConfigKey("[Controls]", "RateRampSensitivity"), m_iRateRampSensitivity);
 
-    RateControl::setTemporaryRateChangeCoarseAmount(m_dRateTempCoarse);
-    RateControl::setTemporaryRateChangeFineAmount(m_dRateTempFine);
+    PitchBendControl::setTemporaryRateChangeCoarseAmount(m_dRateTempCoarse);
+    PitchBendControl::setTemporaryRateChangeFineAmount(m_dRateTempFine);
     RateControl::setPermanentRateChangeCoarseAmount(m_dRatePermCoarse);
     RateControl::setPermanentRateChangeFineAmount(m_dRatePermFine);
 


### PR DESCRIPTION
As part of an effort to make maintenance of the `EngineControl` code easier, this PR splits off the **pitch bending logic & controls** into its own class. This was easily possible because the pitch bending code did not have any dependencies on the other code inside `RateControl` anyway.


Apart from the changed classname and the slightly changed signature of `processTempRate`, the `PitchBendControl` code is a one-to-one copy of the corresponding existing code in `RateControl`.