### PR TITLE
open Sound preferences with sprecific I/O tab selected

### DIFF
--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -738,6 +738,7 @@ QDialog::DialogCode MixxxMainWindow::noOutputDlg(bool* continueClicked) {
 
             // This way of opening the dialog allows us to use it synchronously
             m_pPrefDlg->setWindowModality(Qt::ApplicationModal);
+            m_pPrefDlg->showSoundHardwarePage(mixxx::preferences::SoundHardwareTab::Output);
             m_pPrefDlg->exec();
             if (m_pPrefDlg->result() == QDialog::Accepted) {
                 return QDialog::Accepted;
@@ -1082,7 +1083,7 @@ void MixxxMainWindow::slotNoVinylControlInputConfigured() {
             QMessageBox::Cancel);
     if (btn == QMessageBox::Ok) {
         m_pPrefDlg->show();
-        m_pPrefDlg->showSoundHardwarePage();
+        m_pPrefDlg->showSoundHardwarePage(mixxx::preferences::SoundHardwareTab::Input);
     }
 }
 
@@ -1096,7 +1097,7 @@ void MixxxMainWindow::slotNoDeckPassthroughInputConfigured() {
             QMessageBox::Cancel);
     if (btn == QMessageBox::Ok) {
         m_pPrefDlg->show();
-        m_pPrefDlg->showSoundHardwarePage();
+        m_pPrefDlg->showSoundHardwarePage(mixxx::preferences::SoundHardwareTab::Input);
     }
 }
 
@@ -1110,7 +1111,7 @@ void MixxxMainWindow::slotNoMicrophoneInputConfigured() {
             QMessageBox::Cancel);
     if (btn == QMessageBox::Ok) {
         m_pPrefDlg->show();
-        m_pPrefDlg->showSoundHardwarePage();
+        m_pPrefDlg->showSoundHardwarePage(mixxx::preferences::SoundHardwareTab::Input);
     }
 }
 
@@ -1124,7 +1125,7 @@ void MixxxMainWindow::slotNoAuxiliaryInputConfigured() {
             QMessageBox::Cancel);
     if (btn == QMessageBox::Ok) {
         m_pPrefDlg->show();
-        m_pPrefDlg->showSoundHardwarePage();
+        m_pPrefDlg->showSoundHardwarePage(mixxx::preferences::SoundHardwareTab::Input);
     }
 }
 

--- a/src/preferences/constants.h
+++ b/src/preferences/constants.h
@@ -39,6 +39,12 @@ enum class MultiSamplingMode {
 };
 Q_ENUM_NS(MultiSamplingMode);
 
+enum class SoundHardwareTab {
+    Output,
+    Input
+};
+Q_ENUM_NS(SoundHardwareTab);
+
 } // namespace constants
 } // namespace preferences
 } // namespace mixxx

--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -97,9 +97,10 @@ DlgPreferences::DlgPreferences(
         m_iconsPath.setPath(":/images/preferences/dark/");
     }
 
-    // Construct widgets for use in tabs.
+    // Construct page widgets and associated sidebar items
+    m_pSoundDlg = std::make_unique<DlgPrefSound>(this, pSoundManager, m_pConfig);
     m_soundPage = PreferencesPage(
-            new DlgPrefSound(this, pSoundManager, m_pConfig),
+            m_pSoundDlg.get(),
             new QTreeWidgetItem(contentsTreeWidget, QTreeWidgetItem::Type));
     addPageWidget(m_soundPage,
             tr("Sound Hardware"),
@@ -301,9 +302,13 @@ void DlgPreferences::changePage(QTreeWidgetItem* pCurrent, QTreeWidgetItem* pPre
     }
 }
 
-void DlgPreferences::showSoundHardwarePage() {
+void DlgPreferences::showSoundHardwarePage(
+        std::optional<mixxx::preferences::SoundHardwareTab> tab) {
     switchToPage(m_soundPage.pTreeItem->text(0), m_soundPage.pDlg);
     contentsTreeWidget->setCurrentItem(m_soundPage.pTreeItem);
+    if (tab.has_value()) {
+        m_pSoundDlg->selectIOTab(*tab);
+    }
 }
 
 bool DlgPreferences::eventFilter(QObject* o, QEvent* e) {

--- a/src/preferences/dialog/dlgpreferences.h
+++ b/src/preferences/dialog/dlgpreferences.h
@@ -14,12 +14,13 @@
 #include "preferences/settingsmanager.h"
 #include "preferences/usersettings.h"
 
-class SoundManager;
 class ControllerManager;
+class DlgPrefControllers;
+class DlgPrefSound;
 class EffectsManager;
 class Library;
+class SoundManager;
 class VinylControlManager;
-class DlgPrefControllers;
 
 namespace mixxx {
 class ScreensaverManager;
@@ -62,7 +63,9 @@ class DlgPreferences : public QDialog, public Ui::DlgPreferencesDlg {
 
   public slots:
     void changePage(QTreeWidgetItem* pCurrent, QTreeWidgetItem* pPrevious);
-    void showSoundHardwarePage();
+    void showSoundHardwarePage(
+            std::optional<mixxx::preferences::SoundHardwareTab> tab =
+                    std::nullopt);
     void slotButtonPressed(QAbstractButton* pButton);
   signals:
     void closeDlg();
@@ -97,6 +100,7 @@ class DlgPreferences : public QDialog, public Ui::DlgPreferencesDlg {
 
     QStringList m_geometry;
     UserSettingsPointer m_pConfig;
+    std::unique_ptr<DlgPrefSound> m_pSoundDlg;
     PreferencesPage m_soundPage;
     DlgPrefControllers* m_pControllersDlg;
 

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -383,6 +383,16 @@ QUrl DlgPrefSound::helpUrl() const {
     return QUrl(MIXXX_MANUAL_SOUND_URL);
 }
 
+void DlgPrefSound::selectIOTab(mixxx::preferences::SoundHardwareTab tab) {
+    switch (tab) {
+    case mixxx::preferences::SoundHardwareTab::Input:
+        ioTabs->setCurrentWidget(inputTab);
+        return;
+    case mixxx::preferences::SoundHardwareTab::Output:
+        ioTabs->setCurrentWidget(outputTab);
+        return;
+    }
+}
 /// Initializes (and creates) all the path items. Each path item widget allows
 /// the user to input a sound device name and channel number given a description
 /// of what will be done with that info. Inputs and outputs are grouped by tab,

--- a/src/preferences/dialog/dlgprefsound.h
+++ b/src/preferences/dialog/dlgprefsound.h
@@ -4,6 +4,7 @@
 
 #include "control/pollingcontrolproxy.h"
 #include "defs_urls.h"
+#include "preferences/constants.h"
 #include "preferences/dialog/dlgpreferencepage.h"
 #include "preferences/dialog/ui_dlgprefsounddlg.h"
 #include "preferences/usersettings.h"
@@ -12,13 +13,13 @@
 #include "soundio/soundmanagerconfig.h"
 #include "util/parented_ptr.h"
 
-class SoundManager;
-class PlayerManager;
 class ControlObject;
+class ControlProxy;
+class DlgPrefSoundItem;
+class PlayerManager;
 class SoundDevice;
 class SoundDeviceId;
-class DlgPrefSoundItem;
-class ControlProxy;
+class SoundManager;
 
 // TODO(bkgood) (n-decks) establish a signal/slot connection with a signal
 // on EngineMaster that emits every time a channel is added, and a slot here
@@ -30,6 +31,8 @@ class DlgPrefSound : public DlgPreferencePage, public Ui::DlgPrefSoundDlg  {
     DlgPrefSound(QWidget* parent,
             std::shared_ptr<SoundManager> soundManager,
             UserSettingsPointer pSettings);
+
+    void selectIOTab(mixxx::preferences::SoundHardwareTab tab);
 
     QUrl helpUrl() const override;
 


### PR DESCRIPTION
Just a little helper that saves one click when being redirected from skin to Sound preferences after agreeing to set up a Mic, Aux or VC / Passthrough device.