### PR TITLE
Remove Qt5 workaround from controller mapping

### DIFF
--- a/res/controllers/Behringer-Extension-scripts.js
+++ b/res/controllers/Behringer-Extension-scripts.js
@@ -282,12 +282,12 @@
         isEnabled: function() { return this.id !== 0; },
         start: function() {
             this.reset();
-            this.id = engine.beginTimer(this.timeout, function() {
+            this.id = engine.beginTimer(this.timeout, () => {
                 if (this.oneShot) {
                     this.disable();
                 }
                 this.action.call(this.owner);
-            }.bind(this), this.oneShot); // .bind(this) is required instead of arrow function for Qt < 6.2.4 due to QTBUG-95677
+            }, this.oneShot);
         },
         reset: function() {
             if (this.isEnabled()) {


### PR DESCRIPTION
This PR removes a workaround for a bug in Qt5. See https://github.com/mixxxdj/mixxx/pull/14232#discussion_r1940949552 and #11473

Tested successfully with nightly release.