### PR TITLE
Fix: Avoid controller warnings for DDM4000

### DIFF
--- a/res/controllers/Behringer-DDM4000-scripts.js
+++ b/res/controllers/Behringer-DDM4000-scripts.js
@@ -201,7 +201,6 @@ var DDM4000 = new behringer.extension.GenericMidiController({
 
             const ModeButton = function(options) {
                 options = options || {};
-                options.key = options.key || "mode";
                 options.longPressTimeout = options.longPressTimeout || DEFAULT_LONGPRESS_DURATION;
                 e.LongPressButton.call(this, options);
             };
@@ -254,8 +253,8 @@ var DDM4000 = new behringer.extension.GenericMidiController({
                             }
                         },
                         {type: c.Button, options: {midi: [note, 0x03],  inKey: null}}, // Mode
-                        {type: c.Button, options: {midi: [cc,   0x38], outKey: null}}, // Mode: Multi
-                        {type: c.Button, options: {midi: [cc,   0x37], outKey: null}}, // Mode: Single
+                        {type: c.Button, options: {midi: [cc,   0x38], outKey: undefined}}, // Mode: Multi
+                        {type: c.Button, options: {midi: [cc,   0x37], outKey: undefined}}, // Mode: Single
                     ],
                     equalizerUnit: { //        P3 / Low,        P2 / Mid,        P1 / High
                         midi: { // eslint-disable-next-line key-spacing
@@ -284,8 +283,8 @@ var DDM4000 = new behringer.extension.GenericMidiController({
                             }
                         },
                         {type: c.Button, options: {midi: [note, 0x07],  inKey: null}}, // Mode
-                        {type: c.Button, options: {midi: [cc,   0x42], outKey: null}}, // Mode: Multi
-                        {type: c.Button, options: {midi: [cc,   0x41], outKey: null}}, // Mode: Single
+                        {type: c.Button, options: {midi: [cc,   0x42], outKey: undefined}}, // Mode: Multi
+                        {type: c.Button, options: {midi: [cc,   0x41], outKey: undefined}}, // Mode: Single
                     ],
                     equalizerUnit: { //        P3 / Low,        P2 / Mid,        P1 / High
                         midi: { // eslint-disable-next-line key-spacing
@@ -401,11 +400,11 @@ var DDM4000 = new behringer.extension.GenericMidiController({
                         {options: {midi: [note, 0x2A],    key: null, sendShifted: true}}, // Crossfader: Bounce to MIDI Clock
                         {options: {midi: [note, 0x2B],  inKey: null}}, // Crossfader: Beat (Left)
                         {options: {midi: [note, 0x2C],  inKey: null}}, // Crossfader: Beat (Right)
-                        {options: {midi: [cc,   0x2B], outKey: null}}, // Crossfader: Beat 1
-                        {options: {midi: [cc,   0x2C], outKey: null}}, // Crossfader: Beat 2
-                        {options: {midi: [cc,   0x2D], outKey: null}}, // Crossfader: Beat 4
-                        {options: {midi: [cc,   0x2E], outKey: null}}, // Crossfader: Beat 8
-                        {options: {midi: [cc,   0x2F], outKey: null}}, // Crossfader: Beat 16
+                        {options: {midi: [cc,   0x2B], outKey: undefined}}, // Crossfader: Beat 1
+                        {options: {midi: [cc,   0x2C], outKey: undefined}}, // Crossfader: Beat 2
+                        {options: {midi: [cc,   0x2D], outKey: undefined}}, // Crossfader: Beat 4
+                        {options: {midi: [cc,   0x2E], outKey: undefined}}, // Crossfader: Beat 8
+                        {options: {midi: [cc,   0x2F], outKey: undefined}}, // Crossfader: Beat 16
                     ]
                 },
                 { // Sampler


### PR DESCRIPTION
This PR avoids warnings that are caused by the default mapping for the DDM4000 mixer.

### ModeButton
```
Warning [Controller] ControlDoublePrivate::getControl returning NULL for ( "[Sampler1]" , "mode" )
Warning [Controller] ControlDoublePrivate::getControl returning NULL for ( "[Sampler2]" , "mode" )
Warning [Controller] "script tried to connect to ControlObject ([Sampler1], mode) which is non-existent."
Warning [Controller] "script tried to connect to ControlObject ([Sampler2], mode) which is non-existent."
```

These warnings are caused by a custom [ModeButton](https://github.com/mixxxdj/mixxx/blob/ec635a4cd4cc62b82cc249a26848adc3a7809c16/res/controllers/Behringer-DDM4000-scripts.js#L204) that declares the key `mode` which does not (and did never) exist in Mixxx. The custom `ModeButton` component handles DDM4000-specific behavior completely in JS, there's no Mixxx key involved. Thus, removing the default key assignment is safe and appropriate.

### Explicit `null` outKeys
```
Warning [Controller] "script tried to connect to ControlObject ([Channel1], ) which is non-existent."
Warning [Controller] "script tried to connect to ControlObject ([Channel2], ) which is non-existent."
Warning [Controller] "script tried to connect to ControlObject ([Master], ) which is non-existent."
```

These are caused by explicit `null` values for an `outKey` (e.g. [here](https://github.com/mixxxdj/mixxx/blob/ec635a4cd4cc62b82cc249a26848adc3a7809c16/res/controllers/Behringer-DDM4000-scripts.js#L404)).

Why explicit `null`s? The behavior would be the same if the line would be removed completely.  But when I wrote this mapping, I chose `null` to make the file contain all keys the device supports, even if this mapping does not use all of them. An alternative would be to comment the line out, but I don't like commented code.

What I didn't realize is that [connect()](https://github.com/mixxxdj/mixxx/blob/ec635a4cd4cc62b82cc249a26848adc3a7809c16/res/controllers/midi-components-0.0.js#L124) expects only `undefined` and not `null` for a missing value.

After all, I prefer keeping the `outKey` declarations with explicit `undefined` value to a) keep the mapping complete, b) show that the components are outgoing only and c) avoid the warning.

(Another alternative would be making `connect()` `null`-aware, but I'd like to avoid the risk of changing such a central location.)