### PR TITLE
fix beat sync in flanger effect

### DIFF
--- a/src/effects/backends/builtin/flangereffect.cpp
+++ b/src/effects/backends/builtin/flangereffect.cpp
@@ -133,8 +133,8 @@ void FlangerEffect::processChannel(
     // When the period is changed, the position of the sound shouldn't
     // so time need to be recalculated
     if (pState->previousPeriodFrames != -1.0) {
-        pState->lfoFrames *= static_cast<unsigned int>(
-                lfoPeriodFrames / pState->previousPeriodFrames);
+        pState->lfoFrames = static_cast<unsigned int>(
+                lfoPeriodFrames / pState->previousPeriodFrames * pState->lfoFrames);
     }
     pState->previousPeriodFrames = lfoPeriodFrames;
 


### PR DESCRIPTION
 the LFO sometimes jumps out of beat sync because of a rounding problem 