### PR TITLE
(fix) Controller preferences: make Enabled checkbox clickable again

### DIFF
--- a/src/controllers/dlgprefcontrollerdlg.ui
+++ b/src/controllers/dlgprefcontrollerdlg.ui
@@ -65,30 +65,34 @@
     </widget>
    </item>
    <item row="1" column="0">
-    <widget class="QCheckBox" name="chkEnabledDevice">
-     <property name="text">
-      <string>Enabled</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="labelLoadMapping">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Load Mapping:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-     <property name="buddy">
-      <cstring>comboBoxMapping</cstring>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="layoutEnabledAndLoadLabel">
+     <item>
+      <widget class="QCheckBox" name="chkEnabledDevice">
+       <property name="text">
+        <string>Enabled</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="labelLoadMapping">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Load Mapping:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+       <property name="buddy">
+        <cstring>comboBoxMapping</cstring>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item row="1" column="1">
     <widget class="QComboBox" name="comboBoxMapping">


### PR DESCRIPTION
Since #14006 both the Enabled checkbox and the 'Load mapping:' label are in the same cell of the QGridLayout.
The issue is: click events don't reach the checkbox anymore.

This can be fixed by putting the checkbox **after** the label in the ui file (ie. on top of the label, see first commit), but the better fix is to put both in a **QHBoxLayout** (fixup commit) since that also prevents checkbox / label overlap.

Is this actually an issue for anyone else? I'm building with Qt 6.2.3
If yes, does the first fix work you? (just curious, the QHBoxLayout should be merged)