### PR TITLE
add `WSettingsCheckBoxLabel` to replace the click eventFilter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1580,6 +1580,7 @@ add_library(
   src/widget/wscrollable.cpp
   src/widget/wsearchlineedit.cpp
   src/widget/wsearchrelatedtracksmenu.cpp
+  src/widget/wsettingscheckboxlabel.cpp
   src/widget/wsingletoncontainer.cpp
   src/widget/wsizeawarestack.cpp
   src/widget/wskincolor.cpp

--- a/src/controllers/legacycontrollersettings.h
+++ b/src/controllers/legacycontrollersettings.h
@@ -214,17 +214,6 @@ class LegacyControllerBooleanSetting
 
     QWidget* buildInputWidget(QWidget* parent) override;
 
-  private:
-    class ToggleCheckboxEventFilter : public QObject {
-      public:
-        ToggleCheckboxEventFilter(QObject* pParent)
-                : QObject(pParent) {
-        }
-        bool eventFilter(QObject* pObj, QEvent* pEvent) override;
-    };
-
-    parented_ptr<ToggleCheckboxEventFilter> m_pToggleCheckboxEventFilter;
-
     FRIEND_TEST(LegacyControllerMappingSettingsTest, booleanSettingEditing);
 };
 

--- a/src/widget/wsettingscheckboxlabel.cpp
+++ b/src/widget/wsettingscheckboxlabel.cpp
@@ -1,0 +1,17 @@
+#include "widget/wsettingscheckboxlabel.h"
+
+#include <QCheckBox>
+#include <QMouseEvent>
+
+#include "moc_wsettingscheckboxlabel.cpp"
+
+void WSettingsCheckBoxLabel::mousePressEvent(QMouseEvent* pEvent) {
+    if (pEvent->buttons().testFlag(Qt::LeftButton)) {
+        QCheckBox* pCB = qobject_cast<QCheckBox*>(buddy());
+        if (pCB) {
+            pCB->toggle();
+            pCB->setFocus(Qt::MouseFocusReason);
+        }
+    }
+    QLabel::mousePressEvent(pEvent);
+}

--- a/src/widget/wsettingscheckboxlabel.h
+++ b/src/widget/wsettingscheckboxlabel.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <QLabel>
+
+/// This is a QLabel for use in controller settings.
+/// It is expected to have a QCheckBox buddy assigned. If so, left-click on the
+/// label will toggle the checkbox and set focus on it.
+class WSettingsCheckBoxLabel : public QLabel {
+    Q_OBJECT
+  public:
+    explicit WSettingsCheckBoxLabel(QWidget* pParent = nullptr,
+            Qt::WindowFlags flags = Qt::WindowFlags())
+            : QLabel(pParent, flags) {
+
+              };
+    explicit WSettingsCheckBoxLabel(const QString& text,
+            QWidget* pParent = nullptr,
+            Qt::WindowFlags flags = Qt::WindowFlags())
+            : QLabel(text, pParent, flags) {
+              };
+
+  protected:
+    void mousePressEvent(QMouseEvent* pEvent) override;
+};


### PR DESCRIPTION
Replaces the [susceptible](https://github.com/mixxxdj/mixxx/pull/14327#issuecomment-2661658447) and complicated `ToggleCheckboxEventFilter` we use to achieve the clickable QCheckBox label with a rather simple custom QLabel where we only override the mouse press and toggle the QcheckBox buddy.
(as proposed in #13979, didn't do it then because it was much easier to copypasta the eventFilter stuff)

I don't spot a difference UX-wise.
Please test!