### PR TITLE
(fix) Waveform scratching: fix seeking to hotcue (reduced, alt. for #14059)

### DIFF
--- a/src/engine/positionscratchcontroller.cpp
+++ b/src/engine/positionscratchcontroller.cpp
@@ -280,8 +280,8 @@ void PositionScratchController::process(double currentSamplePos,
                 // qDebug() << m_rate << scratchTargetDelta << m_samplePosDeltaSum << m_dt;
             }
         } else {
-            // We were previously in scratch mode and are no longer in scratch
-            // mode. Disable everything, or optionally enable inertia mode if
+            // We quit scratch mode.
+            // Disable everything, or optionally enable inertia mode if
             // the previous rate was high enough to count as a 'throw'
             if (fabs(m_rate) > kThrowThreshold) {
                 m_inertiaEnabled = true;
@@ -291,8 +291,8 @@ void PositionScratchController::process(double currentSamplePos,
             //qDebug() << "disable";
         }
     } else if (scratchEnable) {
-        // We were not previously in scratch mode but now are in scratch
-        // mode. Enable scratching.
+        // We were not previously in scratch mode but now we are.
+        // Enable scratching.
         m_isScratching = true;
         m_inertiaEnabled = false;
         m_moveDelay = 0;
@@ -302,9 +302,15 @@ void PositionScratchController::process(double currentSamplePos,
         m_samplePosDeltaSum = -(releaseRate / m_p) * m_callsPerDt;
         m_pVelocityController->reset(-m_samplePosDeltaSum);
         m_pRateIIFilter->reset(-m_samplePosDeltaSum);
-        // The "scratch_position" CO contains relative traveled audio frames * 2
-        // Not necessarily the actual position in the track. We use this to calculate
-        // the traveled distance of the mouse compared to m_scratchStartPos.
+        // The "scratch_position" CO contains the distance traveled. We use this
+        // to calculate the traveled distance of the mouse compared to m_scratchStartPos.
+        // When it's set by WWaveformViewer::mousePressEvent or mouseMoveEvent,
+        // this is equal to traveled frames * 2 but usually unrelated to the
+        // the actual position in the track.
+        // Note that "scratch_position" can also be set by anyone, eg. by wheel
+        // functions of controller mappings. In such cases its value depends on
+        // the scaling of the original wheel position / wheel tick values and
+        // may be entirely unrelated to audio frames.
         m_scratchStartPos = m_pScratchPos->get();
         m_scratchPosSampleTime = 0;
         // qDebug() << "scratchEnable()" << currentSamplePos;

--- a/src/engine/positionscratchcontroller.cpp
+++ b/src/engine/positionscratchcontroller.cpp
@@ -152,12 +152,6 @@ void PositionScratchController::process(double currentSamplePos,
         mixxx::audio::FramePos target) {
     bool scratchEnable = m_pScratchEnable->get() != 0;
 
-    if (!m_isScratching && !scratchEnable) {
-        // We were not previously in scratch mode are still not in scratch
-        // mode. Do nothing
-        return;
-    }
-
     if (bufferSize != m_bufferSize) {
         m_bufferSize = bufferSize;
         slotUpdateFilterParameters(m_pMainSampleRate->get());
@@ -327,11 +321,6 @@ void PositionScratchController::process(double currentSamplePos,
 
 void PositionScratchController::notifySeek(mixxx::audio::FramePos position) {
     const double newPos = position.toEngineSamplePos();
-    if (!isEnabled()) {
-        // Not scratching, ignore
-        // Such a queued seek would cause a position jump when touching the waveform.
-        return;
-    }
     // Scratching continues after seek due to calculating the relative
     // distance traveled in m_samplePosDeltaSum
     m_seekSamplePos = newPos;

--- a/src/engine/positionscratchcontroller.cpp
+++ b/src/engine/positionscratchcontroller.cpp
@@ -150,7 +150,7 @@ void PositionScratchController::process(double currentSamplePos,
         int wrappedAround,
         mixxx::audio::FramePos trigger,
         mixxx::audio::FramePos target) {
-    bool scratchEnable = m_pScratchEnable->get() != 0;
+    bool scratchEnable = m_pScratchEnable->toBool();
 
     if (bufferSize != m_bufferSize) {
         m_bufferSize = bufferSize;

--- a/src/engine/positionscratchcontroller.h
+++ b/src/engine/positionscratchcontroller.h
@@ -53,7 +53,7 @@ class PositionScratchController : public QObject {
     double m_scratchStartPos;
     double m_rate;
     double m_moveDelay;
-    double m_mouseSampleTime;
+    double m_scratchPosSampleTime;
 
     int m_bufferSize;
 

--- a/src/engine/positionscratchcontroller.h
+++ b/src/engine/positionscratchcontroller.h
@@ -47,6 +47,7 @@ class PositionScratchController : public QObject {
     bool m_isScratching;
     bool m_inertiaEnabled;
     double m_prevSamplePos;
+    double m_seekSamplePos;
     double m_samplePosDeltaSum;
     double m_scratchTargetDelta;
     double m_scratchStartPos;

--- a/src/engine/positionscratchcontroller.h
+++ b/src/engine/positionscratchcontroller.h
@@ -58,6 +58,7 @@ class PositionScratchController : public QObject {
 
     double m_dt;
     double m_callsPerDt;
+    double m_callsToStop;
 
     double m_p;
     double m_d;

--- a/src/engine/readaheadmanager.cpp
+++ b/src/engine/readaheadmanager.cpp
@@ -283,22 +283,8 @@ double ReadAheadManager::getFilePlaypositionFromLog(
     }
 
     double filePlayposition = 0;
-    bool shouldNotifySeek = false;
     while (m_readAheadLog.size() > 0 && numConsumedSamples > 0) {
         ReadLogEntry& entry = m_readAheadLog.front();
-
-        // Notify EngineControls that we have taken a seek.
-        // Every new entry start with a seek
-        // (Not looping control)
-        if (shouldNotifySeek) {
-            if (m_pRateControl) {
-                const auto seekPosition =
-                        mixxx::audio::FramePos::fromEngineSamplePos(
-                                entry.virtualPlaypositionStart);
-                m_pRateControl->notifySeek(seekPosition);
-            }
-        }
-
         // Advance our idea of the current virtual playposition to this
         // ReadLogEntry's start position.
         filePlayposition = entry.advancePlayposition(&numConsumedSamples);
@@ -307,7 +293,6 @@ double ReadAheadManager::getFilePlaypositionFromLog(
             // This entry is empty now.
             m_readAheadLog.pop_front();
         }
-        shouldNotifySeek = true;
     }
 
     return filePlayposition;


### PR DESCRIPTION
This is #14059 without the member/slot refactoring, i.e. just the fixes + switch to parented_ptr etc.
I hope this lowers the barrier to get the fix into 2.5.1

Original description:
___
This is a first (still dirty) fix for #13981 

**TL;DR**
it's now possible to seek to hotcues while doing wave scratches.
Scratching at/across  loop boundaries (active) still works.


Recently I [compared the available methods for scratching with controllers](https://github.com/mixxxdj/mixxx/pull/14004), and while PositionScratchController (developed for waveform scratching) turned out to be the best (for me, no drift, smooth at low rates, nice spinback) I couldn't really use it as I want to because seeking to hotcues while scratching (holding the wheel, or turning very slowly) produced insanely high rates, and didn't stop at the cue pos.

Even though the bug is fixed I still consider this 'dirty' because I don't fully understand what was going wrong with the filters after seeking.