### PR TITLE
(feat) show popup with Xfader curve when curve parameters changed (eg. by script)

### DIFF
--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -451,6 +451,9 @@ void MixxxMainWindow::initialize() {
         qDebug("Enabling Auto DJ from CLI flag.");
         ControlObject::set(ConfigKey("[AutoDJ]", "enabled"), 1.0);
     }
+
+    // Show xfader curve popup with current state (set by controller or loaded from config
+    emit m_pPrefDlg->showXfaderPopupPersist();
 }
 
 MixxxMainWindow::~MixxxMainWindow() {

--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -180,11 +180,16 @@ DlgPreferences::DlgPreferences(
             tr("Decks"),
             "ic_preferences_decks.svg");
 
+    auto* pDlgPrefMixer = new DlgPrefMixer(this, pEffectsManager, m_pConfig);
     addPageWidget(PreferencesPage(
-                          new DlgPrefMixer(this, pEffectsManager, m_pConfig),
+                          pDlgPrefMixer,
                           new QTreeWidgetItem(contentsTreeWidget, QTreeWidgetItem::Type)),
             tr("Mixer"),
             "ic_preferences_crossfader.svg");
+    connect(this,
+            &DlgPreferences::showXfaderPopupPersist,
+            pDlgPrefMixer,
+            &DlgPrefMixer::slotShowXfaderPopupPersist);
 
     addPageWidget(PreferencesPage(
                           new DlgPrefEffects(this, m_pConfig, pEffectsManager),

--- a/src/preferences/dialog/dlgpreferences.h
+++ b/src/preferences/dialog/dlgpreferences.h
@@ -67,6 +67,7 @@ class DlgPreferences : public QDialog, public Ui::DlgPreferencesDlg {
             std::optional<mixxx::preferences::SoundHardwareTab> tab =
                     std::nullopt);
     void slotButtonPressed(QAbstractButton* pButton);
+
   signals:
     void closeDlg();
     void showDlg();
@@ -81,6 +82,8 @@ class DlgPreferences : public QDialog, public Ui::DlgPreferencesDlg {
     void reloadUserInterface();
     void tooltipModeChanged(mixxx::preferences::Tooltips tooltipMode);
     void menuBarAutoHideChanged();
+
+    void showXfaderPopupPersist();
 
   protected:
     bool eventFilter(QObject*, QEvent*);

--- a/src/preferences/dialog/dlgprefmixer.cpp
+++ b/src/preferences/dialog/dlgprefmixer.cpp
@@ -102,14 +102,16 @@ void DlgXfaderCurve::setScene(QGraphicsScene* pScene) {
     adjustSize();
 }
 
-void DlgXfaderCurve::show() {
+void DlgXfaderCurve::show(bool autoHide) {
     if (graphicsViewXfader->scene() == nullptr) {
         return;
     }
     // This saves us from resetting pressed on close.
     m_mousePressed = false;
     QDialog::show();
-    m_hideTimer.start();
+    if (autoHide) {
+        m_hideTimer.start();
+    }
 
     if (m_moved) {
         return;
@@ -1111,13 +1113,20 @@ void DlgPrefMixer::drawXfaderDisplay() {
     graphicsViewXfader->repaint();
 
     if (!isVisible() && !m_initializing && !m_updatingGui) {
-        // show popup with xfader curve
-        if (m_pDlgXfaderCurve.get() == nullptr) {
-            m_pDlgXfaderCurve = make_parented<DlgXfaderCurve>(this);
-            m_pDlgXfaderCurve->setScene(m_pxfScene);
-        }
-        m_pDlgXfaderCurve->show();
+        showXfaderCurvePopup();
     }
+}
+
+void DlgPrefMixer::showXfaderCurvePopup(bool autoHide) {
+    if (m_pDlgXfaderCurve.get() == nullptr) {
+        m_pDlgXfaderCurve = make_parented<DlgXfaderCurve>(this);
+        m_pDlgXfaderCurve->setScene(m_pxfScene);
+    }
+    m_pDlgXfaderCurve->show(autoHide);
+}
+
+void DlgPrefMixer::slotShowXfaderPopupPersist() {
+    showXfaderCurvePopup(false);
 }
 
 void DlgPrefMixer::slotXFaderReverseBoxToggled() {

--- a/src/preferences/dialog/dlgprefmixer.cpp
+++ b/src/preferences/dialog/dlgprefmixer.cpp
@@ -1,8 +1,11 @@
 #include "preferences/dialog/dlgprefmixer.h"
 
 #include <QButtonGroup>
+#include <QGraphicsView>
+#include <QMouseEvent>
 #include <QPainterPath>
 #include <QStandardItemModel>
+#include <QStyle>
 
 #include "control/controlobject.h"
 #include "control/controlproxy.h"
@@ -19,6 +22,7 @@
 #include "util/make_const_iterator.h"
 #include "util/math.h"
 #include "util/rescaler.h"
+#include "util/widgethelper.h"
 
 namespace {
 const QString kEffectForGroupPrefix = QStringLiteral("EffectForGroup_");
@@ -65,6 +69,126 @@ bool isMainEQ(EffectManifest* pManifest) {
 }
 } // anonymous namespace
 
+DlgXfaderCurve::DlgXfaderCurve(QWidget* pParent)
+        : QDialog(pParent),
+          m_mousePressed(false),
+          m_moved(false) {
+    setupUi(this);
+    setWindowTitle(tr("Crossfader Curve"));
+    // Prohibit resize
+    layout()->setSizeConstraint(QLayout::SetFixedSize);
+
+    // Timer to allow dragging the window with longpress
+    m_clickTimer.setSingleShot(true);
+    m_clickTimer.setInterval(500);
+
+    // Hide the window 3 seconds after showing or last mouse interaction
+    m_hideTimer.setSingleShot(true);
+    m_hideTimer.setInterval(3000);
+    m_hideTimer.callOnTimeout(this, [this]() { close(); });
+
+    graphicsViewXfader->setRenderHint(QPainter::Antialiasing);
+
+    // Install event filter for dragging with left mouse button and close on click.
+    // Tracking the mouse on the transparent overlay widget is much easier than
+    // dealing with the complex QGraphicsView/QGraphicsScene mouse event handling.
+    // Leave mousetracking() off to receive mouse moves only when a button is pressed.
+    mouseCatcher->installEventFilter(this);
+}
+
+void DlgXfaderCurve::setScene(QGraphicsScene* pScene) {
+    graphicsViewXfader->setScene(pScene);
+    layout()->update();
+    adjustSize();
+}
+
+void DlgXfaderCurve::show() {
+    if (graphicsViewXfader->scene() == nullptr) {
+        return;
+    }
+    // This saves us from resetting pressed on close.
+    m_mousePressed = false;
+    QDialog::show();
+    m_hideTimer.start();
+
+    if (m_moved) {
+        return;
+    }
+
+    QWidget* centerOverWidget = parentWidget();
+    VERIFY_OR_DEBUG_ASSERT(centerOverWidget) {
+        qWarning() << "DlgXfaderCurve does not have a parent widget";
+        centerOverWidget = this;
+    }
+
+    const QScreen* const pScreen = mixxx::widgethelper::getScreen(*centerOverWidget);
+    QRect screenGeometry;
+    VERIFY_OR_DEBUG_ASSERT(pScreen) {
+        qWarning() << "Assuming screen size of 800x600px.";
+        screenGeometry = QRect(0, 0, 800, 600);
+    }
+    else {
+        screenGeometry = pScreen->geometry();
+    }
+
+    // Center the window
+    setGeometry(QStyle::alignedRect(
+            Qt::LeftToRight,
+            Qt::AlignCenter,
+            size(),
+            screenGeometry));
+}
+
+bool DlgXfaderCurve::eventFilter(QObject* pObj, QEvent* pEvent) {
+    switch (pEvent->type()) {
+    case QEvent::MouseButtonPress: {
+        QMouseEvent* pME = static_cast<QMouseEvent*>(pEvent);
+        if (!pME->buttons().testFlag(Qt::LeftButton)) {
+            break;
+        }
+
+        m_mousePressed = true;
+        m_clickTimer.start();
+        m_hideTimer.start();
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        const QPoint eventPosition = pME->globalPosition().toPoint();
+#else
+        const QPoint eventPosition = pME->globalPos();
+#endif
+        m_dragStartPosition = eventPosition - frameGeometry().topLeft();
+        break;
+    }
+    case QEvent::MouseMove: {
+        if (m_mousePressed) {
+            QMouseEvent* pME = static_cast<QMouseEvent*>(pEvent);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+            const QPoint eventPosition = pME->globalPosition().toPoint();
+#else
+            const QPoint eventPosition = pME->globalPos();
+#endif
+            move(eventPosition - m_dragStartPosition);
+            m_moved = true;
+        }
+        break;
+    }
+    case QEvent::MouseButtonRelease: {
+        m_mousePressed = false;
+        if (m_clickTimer.isActive()) {
+            // short press
+            close();
+            break;
+        }
+        // long press
+        m_hideTimer.stop();
+        m_hideTimer.start();
+        break;
+    }
+    default:
+        break;
+    }
+    return QDialog::eventFilter(pObj, pEvent);
+}
+
 DlgPrefMixer::DlgPrefMixer(
         QWidget* pParent,
         std::shared_ptr<EffectsManager> pEffectsManager,
@@ -100,6 +224,7 @@ DlgPrefMixer::DlgPrefMixer(
 #endif
           m_eqBypass(false),
           m_initializing(true),
+          m_updatingGui(false),
           m_updatingMainEQ(false),
           m_applyingDeckEQs(false),
           m_applyingQuickEffects(false) {
@@ -769,6 +894,7 @@ void DlgPrefMixer::storeEqShelves() {
 }
 
 void DlgPrefMixer::slotUpdate() {
+    m_updatingGui = true;
     slotUpdateXFader();
 
     // EQs & QuickEffects //////////////////////////////////////////////////////
@@ -833,6 +959,7 @@ void DlgPrefMixer::slotUpdate() {
     }
 
     updateMainEQ();
+    m_updatingGui = false;
 }
 
 void DlgPrefMixer::slotUpdateXFader() {
@@ -893,14 +1020,16 @@ void DlgPrefMixer::updateXFaderWidgets() {
 
 void DlgPrefMixer::drawXfaderDisplay() {
     // Initialize or clear scene
+    int sizeX = graphicsViewXfader->width() - 2;
+    int sizeY = graphicsViewXfader->height() - 2;
     if (m_pxfScene) {
         m_pxfScene->clear();
     } else {
         m_pxfScene = make_parented<QGraphicsScene>(this);
         // The size of the QGraphicsView doesn't change so we need to do this only once
         graphicsViewXfader->setLineWidth(1); // frame width
-        int sizeX = graphicsViewXfader->width() - 2;
-        int sizeY = graphicsViewXfader->height() - 2;
+        // int sizeX = graphicsViewXfader->width() - 2;
+        // int sizeY = graphicsViewXfader->height() - 2;
         m_pxfScene->setSceneRect(0, 0, sizeX, sizeY);
         m_pxfScene->setBackgroundBrush(Qt::black);
         graphicsViewXfader->setRenderHints(QPainter::Antialiasing);
@@ -980,6 +1109,15 @@ void DlgPrefMixer::drawXfaderDisplay() {
 
     graphicsViewXfader->show();
     graphicsViewXfader->repaint();
+
+    if (!isVisible() && !m_initializing && !m_updatingGui) {
+        // show popup with xfader curve
+        if (m_pDlgXfaderCurve.get() == nullptr) {
+            m_pDlgXfaderCurve = make_parented<DlgXfaderCurve>(this);
+            m_pDlgXfaderCurve->setScene(m_pxfScene);
+        }
+        m_pDlgXfaderCurve->show();
+    }
 }
 
 void DlgPrefMixer::slotXFaderReverseBoxToggled() {

--- a/src/preferences/dialog/dlgprefmixer.cpp
+++ b/src/preferences/dialog/dlgprefmixer.cpp
@@ -113,6 +113,8 @@ void DlgXfaderCurve::show(bool autoHide) {
         m_hideTimer.start();
     }
 
+    // If we've already moved the window we don't center it on the screen again
+    // in order to keep the previous position.
     if (m_moved) {
         return;
     }
@@ -126,7 +128,8 @@ void DlgXfaderCurve::show(bool autoHide) {
     const QScreen* const pScreen = mixxx::widgethelper::getScreen(*centerOverWidget);
     QRect screenGeometry;
     VERIFY_OR_DEBUG_ASSERT(pScreen) {
-        qWarning() << "Assuming screen size of 800x600px.";
+        qWarning() << "DlgXfaderCurve: No screen could be found. "
+                      "Assuming screen size of 800x600px.";
         screenGeometry = QRect(0, 0, 800, 600);
     }
     else {
@@ -1030,8 +1033,6 @@ void DlgPrefMixer::drawXfaderDisplay() {
         m_pxfScene = make_parented<QGraphicsScene>(this);
         // The size of the QGraphicsView doesn't change so we need to do this only once
         graphicsViewXfader->setLineWidth(1); // frame width
-        // int sizeX = graphicsViewXfader->width() - 2;
-        // int sizeY = graphicsViewXfader->height() - 2;
         m_pxfScene->setSceneRect(0, 0, sizeX, sizeY);
         m_pxfScene->setBackgroundBrush(Qt::black);
         graphicsViewXfader->setRenderHints(QPainter::Antialiasing);
@@ -1119,6 +1120,9 @@ void DlgPrefMixer::drawXfaderDisplay() {
 
 void DlgPrefMixer::showXfaderCurvePopup(bool autoHide) {
     if (m_pDlgXfaderCurve.get() == nullptr) {
+        VERIFY_OR_DEBUG_ASSERT(m_pxfScene) {
+            return;
+        }
         m_pDlgXfaderCurve = make_parented<DlgXfaderCurve>(this);
         m_pDlgXfaderCurve->setScene(m_pxfScene);
     }

--- a/src/preferences/dialog/dlgprefmixer.h
+++ b/src/preferences/dialog/dlgprefmixer.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <QPoint>
+#include <QTimer>
 #include <memory>
 
 #include "control/controlproxy.h"
@@ -7,6 +9,7 @@
 #include "effects/defs.h"
 #include "preferences/dialog/dlgpreferencepage.h"
 #include "preferences/dialog/ui_dlgprefmixerdlg.h"
+#include "preferences/dialog/ui_dlgxfadercurve.h"
 #include "preferences/usersettings.h"
 #include "util/parented_ptr.h"
 
@@ -14,13 +17,33 @@ class QComboBox;
 class QWidget;
 class EffectsManager;
 
+class DlgXfaderCurve : public QDialog, public Ui::DlgXfaderCurve {
+    Q_OBJECT
+
+  public:
+    explicit DlgXfaderCurve(QWidget* pParent);
+
+    void setScene(QGraphicsScene* pScene);
+    void show();
+
+  protected:
+    bool eventFilter(QObject* pObj, QEvent* pEvent) override;
+
+  private:
+    QTimer m_hideTimer;
+    QTimer m_clickTimer;
+    QPoint m_dragStartPosition;
+    bool m_mousePressed;
+    bool m_moved;
+};
+
 class DlgPrefMixer : public DlgPreferencePage, public Ui::DlgPrefMixerDlg {
     Q_OBJECT
   public:
     DlgPrefMixer(
-            QWidget* parent,
+            QWidget* pParent,
             std::shared_ptr<EffectsManager> pEffectsManager,
-            UserSettingsPointer _config);
+            UserSettingsPointer pConfig);
 
     QUrl helpUrl() const override;
 
@@ -105,6 +128,10 @@ class DlgPrefMixer : public DlgPreferencePage, public Ui::DlgPrefMixerDlg {
     bool m_xFaderReverse;
     parented_ptr<QGraphicsScene> m_pxfScene;
 
+    // the xfader curve popup
+    parented_ptr<QWidget> m_pCurvePopup;
+    parented_ptr<DlgXfaderCurve> m_pDlgXfaderCurve;
+
     PollingControlProxy m_COLoFreq;
     PollingControlProxy m_COHiFreq;
     double m_lowEqFreq, m_highEqFreq;
@@ -134,6 +161,7 @@ class DlgPrefMixer : public DlgPreferencePage, public Ui::DlgPrefMixerDlg {
     bool m_eqBypass;
 
     bool m_initializing;
+    bool m_updatingGui;
     bool m_updatingMainEQ;
     bool m_applyingDeckEQs;
     bool m_applyingQuickEffects;

--- a/src/preferences/dialog/dlgprefmixer.h
+++ b/src/preferences/dialog/dlgprefmixer.h
@@ -24,7 +24,7 @@ class DlgXfaderCurve : public QDialog, public Ui::DlgXfaderCurve {
     explicit DlgXfaderCurve(QWidget* pParent);
 
     void setScene(QGraphicsScene* pScene);
-    void show();
+    void show(bool autoHide = true);
 
   protected:
     bool eventFilter(QObject* pObj, QEvent* pEvent) override;
@@ -52,6 +52,8 @@ class DlgPrefMixer : public DlgPreferencePage, public Ui::DlgPrefMixerDlg {
     /// Update the widgets with values from config / EffectsManager
     void slotUpdate() override;
     void slotResetToDefaults() override;
+
+    void slotShowXfaderPopupPersist();
 
   private slots:
     /// Create EQ & QuickEffect selectors and deck label for each added deck
@@ -93,6 +95,7 @@ class DlgPrefMixer : public DlgPreferencePage, public Ui::DlgPrefMixerDlg {
 
   private:
     void drawXfaderDisplay();
+    void showXfaderCurvePopup(bool autoHide = true);
 
     void setDefaultShelves();
     double getEqFreq(int value, int minimum, int maximum);

--- a/src/preferences/dialog/dlgxfadercurve.ui
+++ b/src/preferences/dialog/dlgxfadercurve.ui
@@ -63,6 +63,8 @@
      </widget>
     </item>
 
+    <!-- invisible overlay that makes catching mouse events much easier than
+         with the complex QGraphicsView/QGraphicsScene mouse event handling-->
     <item row="0" column="0">
      <widget class="QWidget" name="mouseCatcher">
       <property name="sizePolicy">

--- a/src/preferences/dialog/dlgxfadercurve.ui
+++ b/src/preferences/dialog/dlgxfadercurve.ui
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DlgXfaderCurve</class>
+ <widget class="QDialog" name="DlgXfaderCurve">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>300</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>100</width>
+    <height>80</height>
+   </size>
+  </property>
+  <!-- <layout class="QVBoxLayout" name="verticalLayout"> -->
+  <layout class="QGridLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+
+    <item row="0" column="0">
+     <widget class="QGraphicsView" name="graphicsViewXfader">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="verticalScrollBarPolicy">
+       <enum>Qt::ScrollBarAlwaysOff</enum>
+      </property>
+      <property name="horizontalScrollBarPolicy">
+       <enum>Qt::ScrollBarAlwaysOff</enum>
+      </property>
+      <property name="fixedSize">
+       <size>
+        <width>123</width>
+        <height>83</height>
+       </size>
+      </property>
+     </widget>
+    </item>
+
+    <item row="0" column="0">
+     <widget class="QWidget" name="mouseCatcher">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="fixedSize">
+       <size>
+        <width>123</width>
+        <height>83</height>
+       </size>
+      </property>
+     </widget>
+    </item>
+
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Just a little helper to verify the xfader curve when setting it with a controller's switch
![xfader-popup](https://github.com/user-attachments/assets/4077fe29-2c2f-491b-8af7-e0db3d9e64dc)

* reuses the graphic from Mixer preferences
* shown centered on screen, can be dragged elsewhere (position is restored on next show)
* hide after 3 sec (after show or last dnd click) (make it 1.5 - 2 sec)
* close on click

If someone wants to test it without controller, here's a mapping for Vir-MIDI or MIDI Through
https://gist.github.com/ronso0/ae7a6f3fc2b28e43f16bf50bfb84e62e

### TODO
- [ ] make this optional

### TODO (custom)
- [ ] show when GUI is ready, no auto-hide then? so it's not missed?