### PR TITLE
DlgLibraryExport : changed "export to engine prime" to "export to engine dj os"

### DIFF
--- a/src/library/export/dlglibraryexport.cpp
+++ b/src/library/export/dlglibraryexport.cpp
@@ -125,7 +125,7 @@ DlgLibraryExport::DlgLibraryExport(
     pLayout->addLayout(pButtonBarLayout, 3, 0, 1, 2);
 
     setLayout(pLayout);
-    setWindowTitle(tr("Export Library to Engine Prime"));
+    setWindowTitle(tr("Export Library to Engine OS"));
 
     show();
     raise();
@@ -164,7 +164,7 @@ void DlgLibraryExport::browseExportDirectory() {
             m_pConfig->getValue(ConfigKey("[Library]", kLastDirConfigItemName),
                     QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));
     const auto exportDirectory = QFileDialog::getExistingDirectory(
-            nullptr, tr("Export Library To"), lastExportDirectory);
+            nullptr, tr("Export Library To Engine DJ OS"), lastExportDirectory);
     if (exportDirectory.isEmpty()) {
         return;
     }

--- a/src/library/export/dlglibraryexport.cpp
+++ b/src/library/export/dlglibraryexport.cpp
@@ -125,7 +125,7 @@ DlgLibraryExport::DlgLibraryExport(
     pLayout->addLayout(pButtonBarLayout, 3, 0, 1, 2);
 
     setLayout(pLayout);
-    setWindowTitle(tr("Export Library to Engine OS"));
+    setWindowTitle(tr("Export Library to Engine DJ OS"));
 
     show();
     raise();
@@ -164,7 +164,7 @@ void DlgLibraryExport::browseExportDirectory() {
             m_pConfig->getValue(ConfigKey("[Library]", kLastDirConfigItemName),
                     QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));
     const auto exportDirectory = QFileDialog::getExistingDirectory(
-            nullptr, tr("Export Library To Engine DJ OS"), lastExportDirectory);
+            nullptr, tr("Export Library To"), lastExportDirectory);
     if (exportDirectory.isEmpty()) {
         return;
     }


### PR DESCRIPTION
Saw issue #14141 wanted to try and help create a more user friendly base.

In dlgllibraryexport.cpp (not .h, mistyped) i changed the window setting window title from "Export to Engine Prime" to what was suggested "Export to Engine DJ OS"

PS. I had messed up in the first commit so i was fixing up my changes as well.
![Screenshot 2025-02-18 at 3 50 07 PM](https://github.com/user-attachments/assets/3a6cd644-5777-4af7-bb61-4cd074eb2b71)
