### PR TITLE
CMakeLists: Disable `QTlsBackendOpenSSLPlugin` on iOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3468,9 +3468,16 @@ if(Qt_IS_STATIC)
       Qt${QT_VERSION_MAJOR}::QSvgPlugin
       # sqldrivers
       Qt${QT_VERSION_MAJOR}::QSQLiteDriverPlugin
-      # network plugins
-      Qt${QT_VERSION_MAJOR}::QTlsBackendOpenSSLPlugin
   )
+
+  if(NOT IOS)
+    target_link_libraries(
+      mixxx-lib
+      PRIVATE
+        # network plugins
+        Qt${QT_VERSION_MAJOR}::QTlsBackendOpenSSLPlugin
+    )
+  endif()
 
   if(EMSCRIPTEN)
     target_link_libraries(
@@ -3567,14 +3574,16 @@ else()
         applocal
     )
 
-    install(
-      IMPORTED_RUNTIME_ARTIFACTS
-        Qt${QT_VERSION_MAJOR}::QTlsBackendOpenSSLPlugin
-        DESTINATION
-        "${MIXXX_INSTALL_DATADIR}/tls"
-        COMPONENT
-        applocal
-    )
+    if(NOT IOS)
+      install(
+        IMPORTED_RUNTIME_ARTIFACTS
+          Qt${QT_VERSION_MAJOR}::QTlsBackendOpenSSLPlugin
+          DESTINATION
+          "${MIXXX_INSTALL_DATADIR}/tls"
+          COMPONENT
+          applocal
+      )
+    endif()
 
     if(QML)
       install(

--- a/src/mixxxapplication.cpp
+++ b/src/mixxxapplication.cpp
@@ -50,7 +50,9 @@ Q_IMPORT_PLUGIN(QMinimalIntegrationPlugin)
 #endif
 
 Q_IMPORT_PLUGIN(QSQLiteDriverPlugin)
+#if !defined(Q_OS_IOS)
 Q_IMPORT_PLUGIN(QTlsBackendOpenSSL)
+#endif
 Q_IMPORT_PLUGIN(QSvgPlugin)
 Q_IMPORT_PLUGIN(QICOPlugin)
 Q_IMPORT_PLUGIN(QJpegPlugin)


### PR DESCRIPTION
The current iOS Qt 6 build (as of https://github.com/fwcd/vcpkg/commit/57ce3aded1b447dbb618f76a0cfc9bfe1c52775e) doesn't seem to support this plugin:

```
CMake Error at CMakeLists.txt:3464 (target_link_libraries):
  Target "mixxx-lib" links to:

    Qt6::QTlsBackendOpenSSLPlugin

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.



-- Generating done (0.9s)
CMake Generate step failed.  Build files cannot be regenerated correctly.
```

Hence this PR disables it when targeting iOS.