### PR TITLE
(fix) fix file dialog extension handler, playlist export

### DIFF
--- a/src/util/file.cpp
+++ b/src/util/file.cpp
@@ -4,6 +4,8 @@
 #include <QRegExp> // required for 'indexIn(QString &str, int pos)
 #include <QRegularExpression>
 
+#include "util/assert.h"
+
 namespace {
 
 const QRegularExpression kExtractExtensionRegex(R"(\(\*\.(.*)\)$)");
@@ -27,11 +29,13 @@ QString filePathWithSelectedExtension(const QString& fileLocationInput,
     // Extract 'ext' from QFileDialog file filter string 'Funky type (*.ext)'
     const auto extMatch = kExtractExtensionRegex.match(selectedFileFilter);
     const QString ext = extMatch.captured(1);
-    if (ext.isNull()) {
+    VERIFY_OR_DEBUG_ASSERT(!ext.isEmpty()) {
         return fileLocation;
     }
     const QFileInfo fileName(fileLocation);
-    if (!ext.isEmpty() && fileName.suffix() != ext) {
+    if (fileName.suffix().isEmpty()) {
+        fileLocation += QChar('.') + ext;
+    } else if (fileName.suffix() != ext) {
         // Check if fileLocation ends with any of the available extensions
         int pos = 0;
         // Extract all extensions from the filter list


### PR DESCRIPTION
Yet another workaround for QFileDialog not appending the selected extension if the filename doesn't end with it.
(follow-up for #11332)

Steps to reproduce:
* select playlist, open menu, clcik Export
* insert file name without extension
* select "m3u8" (default is m3u)
* Ok
* dialog returns /home/user/Music/name
* handler should turn it into /home/user/Music/name.m3u8
* 2.5 bug: /home/user/Musi.m3u8

Btw this util is also used by the sampler bank export, so should be reproducible with that, too.

Probably fixes #14362