### PR TITLE
(fix) track menu: reset `eject` after moving track file to trash

### DIFF
--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -2416,6 +2416,7 @@ void WTrackMenu::slotRemoveFromDisk() {
     for (const QString& group : groups) {
         ControlObject::set(ConfigKey(group, "stop"), 1.0);
         ControlObject::set(ConfigKey(group, "eject"), 1.0);
+        ControlObject::set(ConfigKey(group, "eject"), 0.0);
     }
 
     // Set up and initiate the track batch operation


### PR DESCRIPTION
I was wondering why eject remained pressed after moving a track file to thrash, and I suspected the S4 mapping because I just noticed it with that.

A simple reset does the trick.