### PR TITLE
Add M-Vave SMK-25 II piano keyboard mapping

### DIFF
--- a/res/controllers/MVave-SMK-25-II-scripts.js
+++ b/res/controllers/MVave-SMK-25-II-scripts.js
@@ -206,42 +206,43 @@ var SMK25II;
         switch (data[3]) {
         case 0x60: {
             const knob = SMK25II.controller.activeDeck.gainKnob;
+            knob.input(undefined, undefined, data[5], undefined, undefined);
             knob.inSetParameter(knob.inValueScale(data[5]));
             break;
         }
         case 0x61: {
             const knob = SMK25II.controller.activeDeck.highKnob;
-            knob.inSetParameter(knob.inValueScale(data[5]));
+            knob.input(undefined, undefined, data[5], undefined, undefined);
             break;
         }
         case 0x62: {
             const knob = SMK25II.controller.activeDeck.midKnob;
-            knob.inSetParameter(knob.inValueScale(data[5]));
+            knob.input(undefined, undefined, data[5], undefined, undefined);
             break;
         }
         case 0x63: {
             const knob = SMK25II.controller.activeDeck.lowKnob;
-            knob.inSetParameter(knob.inValueScale(data[5]));
+            knob.input(undefined, undefined, data[5], undefined, undefined);
             break;
         }
         case 0x64: {
             const knob = SMK25II.controller.activeDeck.effectKnob;
-            knob.inSetParameter(knob.inValueScale(data[5]));
+            knob.input(undefined, undefined, data[5], undefined, undefined);
             break;
         }
         case 0x65: {
             const knob = SMK25II.controller.xfadeKnob;
-            knob.inSetParameter(knob.inValueScale(data[5]));
+            knob.input(undefined, undefined, data[5], undefined, undefined);
             break;
         }
         case 0x66: {
             const knob = SMK25II.controller.headGainKnob;
-            knob.inSetParameter(knob.inValueScale(data[5]));
+            knob.input(undefined, undefined, data[5], undefined, undefined);
             break;
         }
         case 0x67: {
             const knob = SMK25II.controller.gainKnob;
-            knob.inSetParameter(knob.inValueScale(data[5]));
+            knob.input(undefined, undefined, data[5], undefined, undefined);
             break;
         }
         }

--- a/res/controllers/MVave-SMK-25-II-scripts.js
+++ b/res/controllers/MVave-SMK-25-II-scripts.js
@@ -138,12 +138,7 @@ var SMK25II;
         }
     }
 
-    /**
-     *
-     * @param _id The controller ID
-     * @param _debugging Whether we've started in debugging mode.
-     */
-    SMK25II.init = function(_id, _debugging) {
+    SMK25II.init = function() {
         SMK25II.controller = new Controller();
     };
     SMK25II.shutdown = function() {
@@ -152,7 +147,7 @@ var SMK25II;
     const MMCHeader = [0xF0, 0x35, 0x59];
     /**
      *
-     * @param data
+     * @param data the full sysex message data.
      */
     function decodeButton(data) {
         // Hotcues
@@ -250,8 +245,8 @@ var SMK25II;
     }
     /**
      *
-     * @param data
-     * @param length
+     * @param data the sysex message data
+     * @param length the length of the data (no longer used)
      */
     function incomingData(data, length) {
         if (length < 6) {

--- a/res/controllers/MVave-SMK-25-II-scripts.js
+++ b/res/controllers/MVave-SMK-25-II-scripts.js
@@ -116,15 +116,19 @@ var SMK25II;
             this.deckLeftButton = new components.Button({
                 group: "[Channel1]",
                 midi: [0x90, 0x2E], // << Channel Left Button
-                inToggle: function() {
-                    SMK25II.controller.activeDeck.setCurrentDeck("[Channel1]");
+                input: function(_channel, _control, value, _status, _group) {
+                    if (value === 0x00) {
+                        SMK25II.controller.activeDeck.setCurrentDeck("[Channel1]");
+                    }
                 },
             });
             this.deckRightButton = new components.Button({
                 group: "[Channel2]",
                 midi: [0x90, 0x2F], // >> Channel Right button
-                inToggle: function() {
-                    SMK25II.controller.activeDeck.setCurrentDeck("[Channel2]");
+                input: function(_channel, _control, value, _status, _group) {
+                    if (value === 0x00) {
+                        SMK25II.controller.activeDeck.setCurrentDeck("[Channel2]");
+                    }
                 },
             });
             // Drum Pads
@@ -154,43 +158,52 @@ var SMK25II;
     const decodeButton = function(data) {
         // Hotcues
         if (data[4] !== undefined && data[4] >= 0x00 && data[4] <= 0x07) {
-            SMK25II.controller.activeDeck.hotcues[data[4]].inToggle();
+            // This controller appears to send the release message immediately
+            // even if you're still holding the button down.
+            const button = SMK25II.controller.activeDeck.hotcues[data[4]];
+            button.input(undefined, undefined, data[5], undefined, undefined);
             return;
         }
         // Other media buttons
         switch (data[4]) {
         case 0x5D: {
-            SMK25II.controller.activeDeck.cueButton.inToggle();
+            const button = SMK25II.controller.activeDeck.cueButton;
+            button.input(button.channel, undefined, data[5], undefined, undefined);
             break;
         }
         case 0x5E: {
-            if (data[5] === 0x00) {
-                SMK25II.controller.activeDeck.playButton.inToggle();
-            }
+					  const button = SMK25II.controller.activeDeck.playButton;
+					  button.input(undefined, undefined, data[5], undefined, undefined);
             break;
         }
         case 0x5B: {
-            SMK25II.controller.activeDeck.backButton.inToggle();
+            const button = SMK25II.controller.activeDeck.backButton;
+            button.input(undefined, undefined, data[5], undefined, undefined);
             break;
         }
         case 0x5C: {
-            SMK25II.controller.activeDeck.forwardButton.inToggle();
+            const button = SMK25II.controller.activeDeck.forwardButton;
+            button.input(undefined, undefined, data[5], undefined, undefined);
             break;
         }
         case 0x5F: {
-            SMK25II.controller.recordButton.inToggle();
+            const button = SMK25II.controller.recordButton;
+            button.input(undefined, undefined, data[5], undefined, undefined);
             break;
         }
         case 0x2E: {
-            SMK25II.controller.deckLeftButton.inToggle();
+            const button = SMK25II.controller.deckLeftButton;
+            button.input(undefined, undefined, data[5], undefined, undefined);
             break;
         }
         case 0x2F: {
-            SMK25II.controller.deckRightButton.inToggle();
+            const button = SMK25II.controller.deckRightButton;
+            button.input(undefined, undefined, data[5], undefined, undefined);
             break;
         }
         case 0x4C: {
-            SMK25II.controller.activeDeck.loopButton.inToggle();
+            const button = SMK25II.controller.activeDeck.loopButton;
+            button.input(undefined, undefined, data[5], undefined, undefined);
             break;
         }
         default:

--- a/res/controllers/MVave-SMK-25-II-scripts.js
+++ b/res/controllers/MVave-SMK-25-II-scripts.js
@@ -38,6 +38,10 @@ var SMK25II;
                 softTakeover: true,
             });
             // Hotcues
+            //
+            // Note:
+            // The color of the pads cannot be set, it is controlled by the
+            // firmware and depends on what layer we're on.
             this.hotcues = [];
             for (let i = 0; i < 8; i++) {
                 const hotcueButton = new components.HotcueButton({
@@ -172,8 +176,8 @@ var SMK25II;
             break;
         }
         case 0x5E: {
-					  const button = SMK25II.controller.activeDeck.playButton;
-					  button.input(undefined, undefined, data[5], undefined, undefined);
+            const button = SMK25II.controller.activeDeck.playButton;
+            button.input(undefined, undefined, data[5], undefined, undefined);
             break;
         }
         case 0x5B: {

--- a/res/controllers/MVave-SMK-25-II-scripts.js
+++ b/res/controllers/MVave-SMK-25-II-scripts.js
@@ -145,7 +145,7 @@ var SMK25II;
         SMK25II.controller.shutdown();
     };
 
-    const MMCHeader = [0xF0, 0x35, 0x59];
+    const SysexHeader = [0xF0, 0x35, 0x59];
 
     /**
      *
@@ -194,7 +194,7 @@ var SMK25II;
             break;
         }
         default:
-            console.log(`unrecognized MMC command: ${data[4]}`);
+            console.log(`unrecognized Sysex command: ${data[4]}`);
         }
     };
 
@@ -249,20 +249,20 @@ var SMK25II;
     /**
      *
      * @param data the sysex message data
-     * @param length the length of the data (no longer used)
+     * @param _length the length of the data (no longer used)
      */
-    SMK25II.incomingData = function(data, length) {
-        if (length < 6) {
+    SMK25II.incomingData = function(data, _length) {
+        if (data.length < 6) {
             console.log(`expected sysex packet of length 6, got ${length}`);
             return;
         }
-        for (let n = 0; n < MMCHeader.length; n++) {
-            if (data[n] !== MMCHeader[n]) {
+        for (let n = 0; n < SysexHeader.length; n++) {
+            if (data[n] !== SysexHeader[n]) {
                 console.log("unknown sysex packet");
                 return;
             }
         }
-        if (data[length - 1] !== 0xF7) {
+        if (data[data.length - 1] !== 0xF7) {
             console.log("sysex packet missing trailer");
             return;
         }

--- a/res/controllers/MVave-SMK-25-II-scripts.js
+++ b/res/controllers/MVave-SMK-25-II-scripts.js
@@ -1,0 +1,268 @@
+"use strict";
+var SMK25II;
+(function (SMK25II) {
+    class Deck extends components.Deck {
+        constructor() {
+            super([1, 2, 3, 4]);
+            // Knobs
+            this.gainKnob = new components.Pot({
+                group: "[Channel1]",
+                key: "pregain",
+                midi: [0xB0, 0x1E],
+                softTakeover: true,
+            });
+            this.highKnob = new components.Pot({
+                group: "[EqualizerRack1_[Channel1]_Effect1]",
+                midi: [0xB0, 0x1F],
+                key: "parameter3",
+                softTakeover: true,
+            });
+            this.midKnob = new components.Pot({
+                group: "[EqualizerRack1_[Channel1]_Effect1]",
+                midi: [0xB0, 0x20],
+                key: "parameter2",
+                softTakeover: true,
+            });
+            this.lowKnob = new components.Pot({
+                group: "[EqualizerRack1_[Channel1]_Effect1]",
+                midi: [0xB0, 0x21],
+                key: "parameter1",
+                softTakeover: true,
+            });
+            this.effectKnob = new components.Pot({
+                group: "[QuickEffectRack1_[Channel1]]",
+                midi: [0xB0, 0x22],
+                key: "super1",
+                softTakeover: true,
+            });
+            // Hotcues
+            this.hotcues = [];
+            for (let i = 0; i < 8; i++) {
+                const hotcueButton = new components.HotcueButton({
+                    number: i + 1,
+                    group: "[Channel1]",
+                    midi: [0x90, i],
+                    type: components.Button.prototype.types.push,
+                });
+                this.hotcues[i] = hotcueButton;
+            }
+            this.loopButton = new components.LoopToggleButton({
+                group: "[Channel1]",
+                midi: [0x90, 0x4C],
+            });
+            // Transport buttons
+            this.playButton = new components.PlayButton({
+                group: "[Channel1]",
+                midi: [0x90, 0x5E], // Play transport
+                type: components.Button.prototype.types.toggle,
+            });
+            this.cueButton = new components.CueButton({
+                group: "[Channel1]",
+                midi: [0x90, 0x5D], // Pause transport
+                type: components.Button.prototype.types.push,
+            });
+            this.backButton = new components.Button({
+                group: "[Channel1]",
+                midi: [0x90, 0x5B],
+                key: "beatjump_backward",
+            });
+            this.forwardButton = new components.Button({
+                group: "[Channel1]",
+                midi: [0x90, 0x5C],
+                key: "beatjump_forward",
+            });
+            // Faders
+            this.pitchStrip = new components.Pot({
+                group: "[Channel1]",
+                midi: [0xE0, 0xE0],
+                key: "rate",
+            });
+            this.modStrip = new components.Pot({
+                group: "[Channel1]",
+                midi: [0xB0, 0x01],
+                key: "volume",
+            });
+        }
+    }
+    SMK25II.Deck = Deck;
+
+    class Controller extends components.ComponentContainer {
+        constructor(id, debugging) {
+            super({});
+            this.id = id;
+            this.debugging = debugging;
+            this.activeDeck = new SMK25II.Deck();
+            this.gainKnob = new components.Encoder({
+                group: "[Master]",
+                midi: [0xB0, 0x25],
+                key: "gain",
+            });
+            this.headGainKnob = new components.Encoder({
+                group: "[Master]",
+                midi: [0xB0, 0x24],
+                key: "headGain",
+            });
+            this.xfadeKnob = new components.Encoder({
+                group: "[Master]",
+                midi: [0xB0, 0x23],
+                key: "crossfader",
+            });
+            this.recordButton = new components.Button({
+                group: "[Recording]",
+                midi: [0x90, 0x5F],
+                inKey: "toggle_recording",
+                outKey: "status",
+            });
+            // Deck Select
+            this.deckLeftButton = new components.Button({
+                group: "[Channel1]",
+                midi: [0x90, 0x2E], // << Channel Left Button
+                inToggle: function() {
+                    SMK25II.controller.activeDeck.setCurrentDeck("[Channel1]");
+                },
+            });
+            this.deckRightButton = new components.Button({
+                group: "[Channel2]",
+                midi: [0x90, 0x2F], // >> Channel Right button
+                inToggle: function() {
+                    SMK25II.controller.activeDeck.setCurrentDeck("[Channel2]");
+                },
+            });
+            // Drum Pads
+            this.samplers = [];
+            for (let i = 0; i < 16; i++) {
+                this.samplers[i] = new components.SamplerButton({
+                    number: i + 1,
+                    volumeByVelocity: true,
+                });
+            }
+        }
+    }
+    SMK25II.Controller = Controller;
+
+    function init(id, debugging) {
+        SMK25II.controller = new SMK25II.Controller(id, debugging);
+    }
+    SMK25II.init = init;
+    function shutdown() {
+        SMK25II.controller.shutdown();
+    }
+    SMK25II.shutdown = shutdown;
+    const MMCHeader = [0xF0, 0x35, 0x59];
+    function decodeButton(data) {
+        // Hotcues
+        if (data[4] !== undefined && data[4] >= 0x00 && data[4] <= 0x07) {
+            SMK25II.controller.activeDeck.hotcues[data[4]].inToggle();
+            return;
+        }
+        // Other media buttons
+        switch (data[4]) {
+            case 0x5D: {
+                SMK25II.controller.activeDeck.cueButton.inToggle();
+                break;
+            }
+            case 0x5E: {
+                if (data[5] === 0x00) {
+                    SMK25II.controller.activeDeck.playButton.inToggle();
+                }
+                break;
+            }
+            case 0x5B: {
+                SMK25II.controller.activeDeck.backButton.inToggle();
+                break;
+            }
+            case 0x5C: {
+                SMK25II.controller.activeDeck.forwardButton.inToggle();
+                break;
+            }
+            case 0x5F: {
+                SMK25II.controller.recordButton.inToggle();
+                break;
+            }
+            case 0x2E: {
+                SMK25II.controller.deckLeftButton.inToggle();
+                break;
+            }
+            case 0x2F: {
+                SMK25II.controller.deckRightButton.inToggle();
+                break;
+            }
+            case 0x4C: {
+                SMK25II.controller.activeDeck.loopButton.inToggle();
+                break;
+            }
+            default:
+                console.log(`unrecognized MMC command: ${data[4]}`);
+        }
+    }
+    function decodePots(data) {
+        switch (data[3]) {
+            case 0x60: {
+                const knob = SMK25II.controller.activeDeck.gainKnob;
+                knob.inSetParameter(knob.inValueScale(data[5]));
+                break;
+            }
+            case 0x61: {
+                const knob = SMK25II.controller.activeDeck.highKnob;
+                knob.inSetParameter(knob.inValueScale(data[5]));
+                break;
+            }
+            case 0x62: {
+                const knob = SMK25II.controller.activeDeck.midKnob;
+                knob.inSetParameter(knob.inValueScale(data[5]));
+                break;
+            }
+            case 0x63: {
+                const knob = SMK25II.controller.activeDeck.lowKnob;
+                knob.inSetParameter(knob.inValueScale(data[5]));
+                break;
+            }
+            case 0x64: {
+                const knob = SMK25II.controller.activeDeck.effectKnob;
+                knob.inSetParameter(knob.inValueScale(data[5]));
+                break;
+            }
+            case 0x65: {
+                const knob = SMK25II.controller.xfadeKnob;
+                knob.inSetParameter(knob.inValueScale(data[5]));
+                break;
+            }
+            case 0x66: {
+                const knob = SMK25II.controller.headGainKnob;
+                knob.inSetParameter(knob.inValueScale(data[5]));
+                break;
+            }
+            case 0x67: {
+                const knob = SMK25II.controller.gainKnob;
+                knob.inSetParameter(knob.inValueScale(data[5]));
+                break;
+            }
+        }
+    }
+    function incomingData(data, length) {
+        if (length < 6) {
+            console.log(`expected sysex packet of length 6, got ${length}`);
+            return;
+        }
+        for (let n = 0; n < MMCHeader.length; n++) {
+            if (data[n] !== MMCHeader[n]) {
+                console.log("unknown sysex packet");
+                return;
+            }
+        }
+        if (data[length - 1] !== 0xF7) {
+            console.log("sysex packet missing trailer");
+            return;
+        }
+        if (data[3] == 0x10) {
+            decodeButton(data);
+        }
+        else if (data[3] >= 0x60 && data[3] <= 0x67) {
+            decodePots(data);
+        }
+        else {
+            console.log(`unrecognized sysex byte: ${data[3]}`);
+        }
+    }
+    SMK25II.incomingData = incomingData;
+})(SMK25II || (SMK25II = {}));

--- a/res/controllers/MVave-SMK-25-II-scripts.js
+++ b/res/controllers/MVave-SMK-25-II-scripts.js
@@ -144,12 +144,14 @@ var SMK25II;
     SMK25II.shutdown = function() {
         SMK25II.controller.shutdown();
     };
+
     const MMCHeader = [0xF0, 0x35, 0x59];
+
     /**
      *
      * @param data the full sysex message data.
      */
-    function decodeButton(data) {
+    const decodeButton = function(data) {
         // Hotcues
         if (data[4] !== undefined && data[4] >= 0x00 && data[4] <= 0x07) {
             SMK25II.controller.activeDeck.hotcues[data[4]].inToggle();
@@ -194,12 +196,13 @@ var SMK25II;
         default:
             console.log(`unrecognized MMC command: ${data[4]}`);
         }
-    }
+    };
+
     /**
      *
-     * @param data
+     * @param data the full sysex message data.
      */
-    function decodePots(data) {
+    const decodePots = function(data) {
         switch (data[3]) {
         case 0x60: {
             const knob = SMK25II.controller.activeDeck.gainKnob;
@@ -242,13 +245,13 @@ var SMK25II;
             break;
         }
         }
-    }
+    };
     /**
      *
      * @param data the sysex message data
      * @param length the length of the data (no longer used)
      */
-    function incomingData(data, length) {
+    SMK25II.incomingData = function(data, length) {
         if (length < 6) {
             console.log(`expected sysex packet of length 6, got ${length}`);
             return;
@@ -263,13 +266,12 @@ var SMK25II;
             console.log("sysex packet missing trailer");
             return;
         }
-        if (data[3] == 0x10) {
+        if (data[3] === 0x10) {
             decodeButton(data);
         } else if (data[3] >= 0x60 && data[3] <= 0x67) {
             decodePots(data);
         } else {
             console.log(`unrecognized sysex byte: ${data[3]}`);
         }
-    }
-    SMK25II.incomingData = incomingData;
+    };
 })(SMK25II || (SMK25II = {}));

--- a/res/controllers/MVave-SMK-25-II-scripts.js
+++ b/res/controllers/MVave-SMK-25-II-scripts.js
@@ -1,8 +1,8 @@
 "use strict";
 
-
+// eslint-disable-next-line no-var
 var SMK25II;
-(function (SMK25II) {
+(function(SMK25II) {
     class Deck extends components.Deck {
         constructor() {
             super([1, 2, 3, 4]);
@@ -150,6 +150,10 @@ var SMK25II;
         SMK25II.controller.shutdown();
     };
     const MMCHeader = [0xF0, 0x35, 0x59];
+    /**
+     *
+     * @param data
+     */
     function decodeButton(data) {
         // Hotcues
         if (data[4] !== undefined && data[4] >= 0x00 && data[4] <= 0x07) {
@@ -158,88 +162,97 @@ var SMK25II;
         }
         // Other media buttons
         switch (data[4]) {
-            case 0x5D: {
-                SMK25II.controller.activeDeck.cueButton.inToggle();
-                break;
+        case 0x5D: {
+            SMK25II.controller.activeDeck.cueButton.inToggle();
+            break;
+        }
+        case 0x5E: {
+            if (data[5] === 0x00) {
+                SMK25II.controller.activeDeck.playButton.inToggle();
             }
-            case 0x5E: {
-                if (data[5] === 0x00) {
-                    SMK25II.controller.activeDeck.playButton.inToggle();
-                }
-                break;
-            }
-            case 0x5B: {
-                SMK25II.controller.activeDeck.backButton.inToggle();
-                break;
-            }
-            case 0x5C: {
-                SMK25II.controller.activeDeck.forwardButton.inToggle();
-                break;
-            }
-            case 0x5F: {
-                SMK25II.controller.recordButton.inToggle();
-                break;
-            }
-            case 0x2E: {
-                SMK25II.controller.deckLeftButton.inToggle();
-                break;
-            }
-            case 0x2F: {
-                SMK25II.controller.deckRightButton.inToggle();
-                break;
-            }
-            case 0x4C: {
-                SMK25II.controller.activeDeck.loopButton.inToggle();
-                break;
-            }
-            default:
-                console.log(`unrecognized MMC command: ${data[4]}`);
+            break;
+        }
+        case 0x5B: {
+            SMK25II.controller.activeDeck.backButton.inToggle();
+            break;
+        }
+        case 0x5C: {
+            SMK25II.controller.activeDeck.forwardButton.inToggle();
+            break;
+        }
+        case 0x5F: {
+            SMK25II.controller.recordButton.inToggle();
+            break;
+        }
+        case 0x2E: {
+            SMK25II.controller.deckLeftButton.inToggle();
+            break;
+        }
+        case 0x2F: {
+            SMK25II.controller.deckRightButton.inToggle();
+            break;
+        }
+        case 0x4C: {
+            SMK25II.controller.activeDeck.loopButton.inToggle();
+            break;
+        }
+        default:
+            console.log(`unrecognized MMC command: ${data[4]}`);
         }
     }
+    /**
+     *
+     * @param data
+     */
     function decodePots(data) {
         switch (data[3]) {
-            case 0x60: {
-                const knob = SMK25II.controller.activeDeck.gainKnob;
-                knob.inSetParameter(knob.inValueScale(data[5]));
-                break;
-            }
-            case 0x61: {
-                const knob = SMK25II.controller.activeDeck.highKnob;
-                knob.inSetParameter(knob.inValueScale(data[5]));
-                break;
-            }
-            case 0x62: {
-                const knob = SMK25II.controller.activeDeck.midKnob;
-                knob.inSetParameter(knob.inValueScale(data[5]));
-                break;
-            }
-            case 0x63: {
-                const knob = SMK25II.controller.activeDeck.lowKnob;
-                knob.inSetParameter(knob.inValueScale(data[5]));
-                break;
-            }
-            case 0x64: {
-                const knob = SMK25II.controller.activeDeck.effectKnob;
-                knob.inSetParameter(knob.inValueScale(data[5]));
-                break;
-            }
-            case 0x65: {
-                const knob = SMK25II.controller.xfadeKnob;
-                knob.inSetParameter(knob.inValueScale(data[5]));
-                break;
-            }
-            case 0x66: {
-                const knob = SMK25II.controller.headGainKnob;
-                knob.inSetParameter(knob.inValueScale(data[5]));
-                break;
-            }
-            case 0x67: {
-                const knob = SMK25II.controller.gainKnob;
-                knob.inSetParameter(knob.inValueScale(data[5]));
-                break;
-            }
+        case 0x60: {
+            const knob = SMK25II.controller.activeDeck.gainKnob;
+            knob.inSetParameter(knob.inValueScale(data[5]));
+            break;
+        }
+        case 0x61: {
+            const knob = SMK25II.controller.activeDeck.highKnob;
+            knob.inSetParameter(knob.inValueScale(data[5]));
+            break;
+        }
+        case 0x62: {
+            const knob = SMK25II.controller.activeDeck.midKnob;
+            knob.inSetParameter(knob.inValueScale(data[5]));
+            break;
+        }
+        case 0x63: {
+            const knob = SMK25II.controller.activeDeck.lowKnob;
+            knob.inSetParameter(knob.inValueScale(data[5]));
+            break;
+        }
+        case 0x64: {
+            const knob = SMK25II.controller.activeDeck.effectKnob;
+            knob.inSetParameter(knob.inValueScale(data[5]));
+            break;
+        }
+        case 0x65: {
+            const knob = SMK25II.controller.xfadeKnob;
+            knob.inSetParameter(knob.inValueScale(data[5]));
+            break;
+        }
+        case 0x66: {
+            const knob = SMK25II.controller.headGainKnob;
+            knob.inSetParameter(knob.inValueScale(data[5]));
+            break;
+        }
+        case 0x67: {
+            const knob = SMK25II.controller.gainKnob;
+            knob.inSetParameter(knob.inValueScale(data[5]));
+            break;
+        }
         }
     }
+    /**
+     *
+     * @param data
+     * @param length
+     */
     function incomingData(data, length) {
         if (length < 6) {
             console.log(`expected sysex packet of length 6, got ${length}`);

--- a/res/controllers/MVave-SMK-25-II-scripts.js
+++ b/res/controllers/MVave-SMK-25-II-scripts.js
@@ -220,7 +220,6 @@ var SMK25II;
         case 0x60: {
             const knob = SMK25II.controller.activeDeck.gainKnob;
             knob.input(undefined, undefined, data[5], undefined, undefined);
-            knob.inSetParameter(knob.inValueScale(data[5]));
             break;
         }
         case 0x61: {

--- a/res/controllers/MVave-SMK-25-II-scripts.js
+++ b/res/controllers/MVave-SMK-25-II-scripts.js
@@ -253,7 +253,7 @@ var SMK25II;
      */
     SMK25II.incomingData = function(data, _length) {
         if (data.length < 6) {
-            console.log(`expected sysex packet of length 6, got ${length}`);
+            console.log(`expected sysex packet of length 6, got ${data.length}`);
             return;
         }
         for (let n = 0; n < SysexHeader.length; n++) {

--- a/res/controllers/MVave-SMK-25-II-scripts.js
+++ b/res/controllers/MVave-SMK-25-II-scripts.js
@@ -1,4 +1,6 @@
 "use strict";
+
+
 var SMK25II;
 (function (SMK25II) {
     class Deck extends components.Deck {
@@ -84,14 +86,11 @@ var SMK25II;
             });
         }
     }
-    SMK25II.Deck = Deck;
 
     class Controller extends components.ComponentContainer {
-        constructor(id, debugging) {
+        constructor() {
             super({});
-            this.id = id;
-            this.debugging = debugging;
-            this.activeDeck = new SMK25II.Deck();
+            this.activeDeck = new Deck();
             this.gainKnob = new components.Encoder({
                 group: "[Master]",
                 midi: [0xB0, 0x25],
@@ -138,16 +137,18 @@ var SMK25II;
             }
         }
     }
-    SMK25II.Controller = Controller;
 
-    function init(id, debugging) {
-        SMK25II.controller = new SMK25II.Controller(id, debugging);
-    }
-    SMK25II.init = init;
-    function shutdown() {
+    /**
+     *
+     * @param _id The controller ID
+     * @param _debugging Whether we've started in debugging mode.
+     */
+    SMK25II.init = function(_id, _debugging) {
+        SMK25II.controller = new Controller();
+    };
+    SMK25II.shutdown = function() {
         SMK25II.controller.shutdown();
-    }
-    SMK25II.shutdown = shutdown;
+    };
     const MMCHeader = [0xF0, 0x35, 0x59];
     function decodeButton(data) {
         // Hotcues
@@ -256,11 +257,9 @@ var SMK25II;
         }
         if (data[3] == 0x10) {
             decodeButton(data);
-        }
-        else if (data[3] >= 0x60 && data[3] <= 0x67) {
+        } else if (data[3] >= 0x60 && data[3] <= 0x67) {
             decodePots(data);
-        }
-        else {
+        } else {
             console.log(`unrecognized sysex byte: ${data[3]}`);
         }
     }

--- a/res/controllers/MVave-SMK-25-II.midi.xml
+++ b/res/controllers/MVave-SMK-25-II.midi.xml
@@ -6,6 +6,10 @@
     <description>MIDI mapping for the M-Vave SMK-25 II piano keyboard.</description>
     <forums>https://mixxx.discourse.group/t/sinco-m-wave-smk-25-ii/31350</forums>
     <devices>
+      <!--
+        This vendor and product ID is shared between multiple controllers and is
+        not unique to this device.
+      -->
       <product protocol="midi" vendor_id="0x4353" product_id="0x4b4d"/>
     </devices>
   </info>

--- a/res/controllers/MVave-SMK-25-II.midi.xml
+++ b/res/controllers/MVave-SMK-25-II.midi.xml
@@ -1,0 +1,291 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MixxxControllerPreset mixxxVersion="2.5" schemaVersion="1">
+  <info>
+    <name>M-Vave SMK-25 II</name>
+    <author>Sam Whited</author>
+    <description>MIDI mapping for the M-Vave SMK-25 II piano keyboard.</description>
+    <forums>https://mixxx.discourse.group/t/sinco-m-wave-smk-25-ii/31350</forums>
+    <devices>
+      <product protocol="midi" vendor_id="0x4353" product_id="0x4b4d"/>
+    </devices>
+  </info>
+  <controller id="mvave-smk-25-ii">
+    <scriptfiles>
+      <file filename="midi-components-0.0.js" functionprefix=""/>
+      <file filename="MVave-SMK-25-II-scripts.js" functionprefix="SMK25II"/>
+    </scriptfiles>
+    <controls>
+      <control>
+        <group>[Master]</group>
+        <key>SMK25II.incomingData</key>
+        <description>Parser for incoming MMC messages.</description>
+        <status>0xF0</status>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>SMK25II.controller.activeDeck.pitchStrip.input</key>
+        <description>Pitch strip.</description>
+        <status>0xE0</status>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>SMK25II.controller.activeDeck.modStrip.input</key>
+        <description>Modulation strip.</description>
+        <status>0xB0</status>
+        <midino>0x01</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <!-- Encoders -->
+      <control>
+        <group>[Channel1]</group>
+        <key>SMK25II.controller.activeDeck.gainKnob.input</key>
+        <description>Encoder 1.</description>
+        <status>0xB0</status>
+        <midino>0x1E</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>SMK25II.controller.activeDeck.highKnob.input</key>
+        <description>Encoder 2.</description>
+        <status>0xB0</status>
+        <midino>0x1F</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>SMK25II.controller.activeDeck.midKnob.input</key>
+        <description>Encoder 3.</description>
+        <status>0xB0</status>
+        <midino>0x20</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>SMK25II.controller.activeDeck.lowKnob.input</key>
+        <description>Encoder 4.</description>
+        <status>0xB0</status>
+        <midino>0x21</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>SMK25II.controller.activeDeck.effectKnob.input</key>
+        <description>Encoder 5.</description>
+        <status>0xB0</status>
+        <midino>0x22</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>SMK25II.controller.xfadeKnob.input</key>
+        <description>Encoder 6.</description>
+        <status>0xB0</status>
+        <midino>0x23</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>SMK25II.controller.headGainKnob.input</key>
+        <description>Encoder 7.</description>
+        <status>0xB0</status>
+        <midino>0x24</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>SMK25II.controller.gainKnob.input</key>
+        <description>Encoder 8.</description>
+        <status>0xB0</status>
+        <midino>0x25</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <!-- Drum Pads -->
+      <control>
+        <group>[Sampler]</group>
+        <key>SMK25II.controller.samplers[0].input</key>
+        <description>Drum pad.</description>
+        <status>0x99</status>
+        <midino>0x28</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler]</group>
+        <key>SMK25II.controller.samplers[1].input</key>
+        <description>Drum pad.</description>
+        <status>0x99</status>
+        <midino>0x29</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler]</group>
+        <key>SMK25II.controller.samplers[2].input</key>
+        <description>Drum pad.</description>
+        <status>0x99</status>
+        <midino>0x2A</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler]</group>
+        <key>SMK25II.controller.samplers[3].input</key>
+        <description>Drum pad.</description>
+        <status>0x99</status>
+        <midino>0x2B</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler]</group>
+        <key>SMK25II.controller.samplers[4].input</key>
+        <description>Drum pad.</description>
+        <status>0x99</status>
+        <midino>0x30</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler]</group>
+        <key>SMK25II.controller.samplers[5].input</key>
+        <description>Drum pad.</description>
+        <status>0x99</status>
+        <midino>0x31</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler]</group>
+        <key>SMK25II.controller.samplers[6].input</key>
+        <description>Drum pad.</description>
+        <status>0x99</status>
+        <midino>0x32</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler]</group>
+        <key>SMK25II.controller.samplers[7].input</key>
+        <description>Drum pad.</description>
+        <status>0x99</status>
+        <midino>0x33</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler]</group>
+        <key>SMK25II.controller.samplers[8].input</key>
+        <description>Drum pad.</description>
+        <status>0x99</status>
+        <midino>0x24</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler]</group>
+        <key>SMK25II.controller.samplers[9].input</key>
+        <description>Drum pad.</description>
+        <status>0x99</status>
+        <midino>0x25</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler]</group>
+        <key>SMK25II.controller.samplers[10].input</key>
+        <description>Drum pad.</description>
+        <status>0x99</status>
+        <midino>0x26</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler]</group>
+        <key>SMK25II.controller.samplers[11].input</key>
+        <description>Drum pad.</description>
+        <status>0x99</status>
+        <midino>0x27</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler]</group>
+        <key>SMK25II.controller.samplers[12].input</key>
+        <description>Drum pad.</description>
+        <status>0x99</status>
+        <midino>0x2C</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler]</group>
+        <key>SMK25II.controller.samplers[13].input</key>
+        <description>Drum pad.</description>
+        <status>0x99</status>
+        <midino>0x2D</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler]</group>
+        <key>SMK25II.controller.samplers[14].input</key>
+        <description>Drum pad.</description>
+        <status>0x99</status>
+        <midino>0x2E</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler]</group>
+        <key>SMK25II.controller.samplers[15].input</key>
+        <description>Drum pad.</description>
+        <status>0x99</status>
+        <midino>0x2B</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+    </controls>
+    <outputs/>
+  </controller>
+</MixxxControllerPreset>


### PR DESCRIPTION
This patch adds support for the M-Vave SMK-25 II keyboard. I confirm that I have signed the CLA.

The corresponding manual PR is here: https://github.com/mixxxdj/manual/pull/728