### PR TITLE
Use std::shared_ptr in  controller settings to fix memory leak

### DIFF
--- a/src/controllers/legacycontrollermappingfilehandler.cpp
+++ b/src/controllers/legacycontrollermappingfilehandler.cpp
@@ -138,8 +138,8 @@ void LegacyControllerMappingFileHandler::parseMappingSettingsElement(
             element = element.nextSiblingElement()) {
         const QString& tagName = element.tagName().toLower();
         if (tagName == "option") {
-            std::shared_ptr<AbstractLegacyControllerSetting> pSetting(
-                    LegacyControllerSettingBuilder::build(element));
+            std::shared_ptr<AbstractLegacyControllerSetting> pSetting =
+                    LegacyControllerSettingBuilder::build(element);
             if (pSetting.get() == nullptr) {
                 qDebug() << "Ignoring unsupported controller setting in file"
                          << pMapping->filePath() << "at line"

--- a/src/controllers/legacycontrollersettings.h
+++ b/src/controllers/legacycontrollersettings.h
@@ -176,7 +176,8 @@ class LegacyControllerBooleanSetting
             bool defaultValue)
             : AbstractLegacyControllerSetting(element),
               m_savedValue(currentValue),
-              m_defaultValue(defaultValue) {
+              m_defaultValue(defaultValue),
+              m_editedValue(currentValue) {
     }
 
     bool parseValue(const QString& in) {
@@ -421,7 +422,8 @@ class LegacyControllerEnumSetting
             : AbstractLegacyControllerSetting(element),
               m_options(options),
               m_savedValue(currentValue),
-              m_defaultValue(defaultValue) {
+              m_defaultValue(defaultValue),
+              m_editedValue(currentValue) {
     }
 
     virtual QWidget* buildInputWidget(QWidget* parent) override;

--- a/src/controllers/legacycontrollersettings.h
+++ b/src/controllers/legacycontrollersettings.h
@@ -165,8 +165,8 @@ class LegacyControllerBooleanSetting
         emit valueReset();
     }
 
-    static AbstractLegacyControllerSetting* createFrom(const QDomElement& element) {
-        return new LegacyControllerBooleanSetting(element);
+    static std::shared_ptr<LegacyControllerBooleanSetting> createFrom(const QDomElement& element) {
+        return std::make_shared<LegacyControllerBooleanSetting>(element);
     }
     static bool match(const QDomElement& element);
 
@@ -281,8 +281,8 @@ class LegacyControllerNumberSetting
                 valid_range(m_minValue, m_maxValue, m_stepValue);
     }
 
-    static AbstractLegacyControllerSetting* createFrom(const QDomElement& element) {
-        return new LegacyControllerNumberSetting(element);
+    static std::shared_ptr<LegacyControllerNumberSetting> createFrom(const QDomElement& element) {
+        return std::make_shared<LegacyControllerNumberSetting>(element);
     }
     static bool match(const QDomElement& element);
 
@@ -352,8 +352,8 @@ class LegacyControllerRealSetting : public LegacyControllerNumberSetting<double,
         }
     }
 
-    static AbstractLegacyControllerSetting* createFrom(const QDomElement& element) {
-        return new LegacyControllerRealSetting(element);
+    static std::shared_ptr<LegacyControllerRealSetting> createFrom(const QDomElement& element) {
+        return std::make_shared<LegacyControllerRealSetting>(element);
     }
 
     QWidget* buildInputWidget(QWidget* parent) override;
@@ -408,8 +408,8 @@ class LegacyControllerEnumSetting
                 static_cast<int>(m_editedValue) < m_options.size();
     }
 
-    static AbstractLegacyControllerSetting* createFrom(const QDomElement& element) {
-        return new LegacyControllerEnumSetting(element);
+    static std::shared_ptr<LegacyControllerEnumSetting> createFrom(const QDomElement& element) {
+        return std::make_shared<LegacyControllerEnumSetting>(element);
     }
     static inline bool match(const QDomElement& element);
 

--- a/src/controllers/legacycontrollersettingsfactory.h
+++ b/src/controllers/legacycontrollersettingsfactory.h
@@ -42,7 +42,7 @@ class LegacyControllerSettingBuilder {
     /// @param element The XML element to parse to build the new setting
     /// @return an instance if a a supported setting has been found, null
     /// otherwise
-    static AbstractLegacyControllerSetting* build(const QDomElement& element) {
+    static std::shared_ptr<AbstractLegacyControllerSetting> build(const QDomElement& element) {
         for (const auto& settingType : std::as_const(instance()->m_supportedSettings)) {
             if (settingType.matcher(element)) {
                 return settingType.builder(element);
@@ -54,8 +54,8 @@ class LegacyControllerSettingBuilder {
 
   private:
     struct SupportedSetting {
-        bool (*matcher)(const QDomElement&);
-        AbstractLegacyControllerSetting* (*builder)(const QDomElement&);
+        std::function<bool(const QDomElement&)> matcher;
+        std::function<std::shared_ptr<AbstractLegacyControllerSetting>(const QDomElement&)> builder;
     };
 
     LegacyControllerSettingBuilder();

--- a/src/controllers/scripting/legacy/controllerscriptenginelegacy.cpp
+++ b/src/controllers/scripting/legacy/controllerscriptenginelegacy.cpp
@@ -91,12 +91,12 @@ QJSValue ControllerScriptEngineLegacy::wrapFunctionCode(
 }
 
 void ControllerScriptEngineLegacy::setScriptFiles(
-        const QList<LegacyControllerMapping::ScriptFileInfo>& scripts) {
+        QList<LegacyControllerMapping::ScriptFileInfo> scripts) {
     const QStringList paths = m_fileWatcher.files();
     if (!paths.isEmpty()) {
         m_fileWatcher.removePaths(paths);
     }
-    m_scriptFiles = scripts;
+    m_scriptFiles = std::move(scripts);
 }
 
 void ControllerScriptEngineLegacy::setSettings(

--- a/src/controllers/scripting/legacy/controllerscriptenginelegacy.h
+++ b/src/controllers/scripting/legacy/controllerscriptenginelegacy.h
@@ -30,8 +30,7 @@ class ControllerScriptEngineLegacy : public ControllerScriptEngineBase {
         return m_pJSEngine;
     }
 
-  public slots:
-    void setScriptFiles(const QList<LegacyControllerMapping::ScriptFileInfo>& scripts);
+    void setScriptFiles(QList<LegacyControllerMapping::ScriptFileInfo> scripts);
 
     /// @brief Set the list of customizable settings and their currently set
     /// value, ready to be used. This method will generate a JSValue from their

--- a/src/test/controller_mapping_settings_test.cpp
+++ b/src/test/controller_mapping_settings_test.cpp
@@ -36,30 +36,25 @@ TEST_F(LegacyControllerMappingSettingsTest, booleanSettingParsing) {
     doc.setContent(QString(kValidBoolean).arg("false").toLatin1());
 
     EXPECT_TRUE(LegacyControllerBooleanSetting::match(doc.documentElement()));
-    LegacyControllerBooleanSetting* setting = (LegacyControllerBooleanSetting*)
+    std::shared_ptr<LegacyControllerBooleanSetting> pSetting =
             LegacyControllerBooleanSetting::createFrom(doc.documentElement());
-    EXPECT_TRUE(setting->valid()) << "Unable to create a boolean setting";
+    EXPECT_TRUE(pSetting->valid()) << "Unable to create a boolean setting";
 
-    EXPECT_EQ(setting->variableName(), "myToggle1");
-    EXPECT_EQ(setting->label(), "Test label");
-    EXPECT_EQ(setting->description(), "Test description");
+    EXPECT_EQ(pSetting->variableName(), "myToggle1");
+    EXPECT_EQ(pSetting->label(), "Test label");
+    EXPECT_EQ(pSetting->description(), "Test description");
 
-    EXPECT_FALSE(setting->isDirty());
-    EXPECT_TRUE(setting->isDefault());
-    EXPECT_EQ(setting->stringify(), "false");
-    EXPECT_TRUE(setting->valid());
-
-    delete setting;
+    EXPECT_FALSE(pSetting->isDirty());
+    EXPECT_TRUE(pSetting->isDefault());
+    EXPECT_EQ(pSetting->stringify(), "false");
+    EXPECT_TRUE(pSetting->valid());
 
     doc.setContent(QString(kValidBoolean).arg("true").toLatin1());
 
-    setting = (LegacyControllerBooleanSetting*)
-            LegacyControllerBooleanSetting::createFrom(doc.documentElement());
-    EXPECT_TRUE(setting->valid()) << "Unable to create a boolean setting";
+    pSetting = LegacyControllerBooleanSetting::createFrom(doc.documentElement());
+    EXPECT_TRUE(pSetting->valid()) << "Unable to create a boolean setting";
 
-    EXPECT_EQ(setting->stringify(), "true");
-
-    delete setting;
+    EXPECT_EQ(pSetting->stringify(), "true");
 }
 
 TEST_F(LegacyControllerMappingSettingsTest, booleanSettingEditing) {
@@ -68,43 +63,43 @@ TEST_F(LegacyControllerMappingSettingsTest, booleanSettingEditing) {
             QByteArray("<option variable=\"myToggle1\" type=\"boolean\" "
                        "default=\"false\" label=\"Test label\"/>"));
 
-    LegacyControllerBooleanSetting* setting = (LegacyControllerBooleanSetting*)
+    std::shared_ptr<LegacyControllerBooleanSetting> pSetting =
             LegacyControllerBooleanSetting::createFrom(doc.documentElement());
-    EXPECT_TRUE(setting->valid()) << "Unable to create a boolean setting";
+    EXPECT_TRUE(pSetting->valid()) << "Unable to create a boolean setting";
 
-    setting->m_editedValue = true;
-    EXPECT_TRUE(setting->isDirty());
-    setting->save();
-    EXPECT_FALSE(setting->isDirty());
-    EXPECT_EQ(setting->m_savedValue, true);
+    pSetting->m_editedValue = true;
+    EXPECT_TRUE(pSetting->isDirty());
+    pSetting->save();
+    EXPECT_FALSE(pSetting->isDirty());
+    EXPECT_EQ(pSetting->m_savedValue, true);
 
     bool ok;
-    setting->parse("true", &ok);
+    pSetting->parse("true", &ok);
     EXPECT_TRUE(ok);
-    EXPECT_FALSE(setting->isDirty());
-    EXPECT_EQ(setting->stringify(), "true");
-    EXPECT_TRUE(setting->value().isBool());
-    EXPECT_TRUE(setting->value().toBool());
-    EXPECT_FALSE(setting->isDefault());
-    setting->parse("1", &ok);
+    EXPECT_FALSE(pSetting->isDirty());
+    EXPECT_EQ(pSetting->stringify(), "true");
+    EXPECT_TRUE(pSetting->value().isBool());
+    EXPECT_TRUE(pSetting->value().toBool());
+    EXPECT_FALSE(pSetting->isDefault());
+    pSetting->parse("1", &ok);
     EXPECT_TRUE(ok);
-    setting->parse("0", &ok);
+    pSetting->parse("0", &ok);
     EXPECT_TRUE(ok);
-    EXPECT_FALSE(setting->isDirty());
-    EXPECT_EQ(setting->stringify(), "false");
-    setting->parse("TRUE", &ok);
+    EXPECT_FALSE(pSetting->isDirty());
+    EXPECT_EQ(pSetting->stringify(), "false");
+    pSetting->parse("TRUE", &ok);
     EXPECT_TRUE(ok);
-    EXPECT_EQ(setting->stringify(), "true");
-    EXPECT_TRUE(setting->value().isBool());
-    EXPECT_TRUE(setting->value().toBool());
-    setting->reset();
-    EXPECT_TRUE(setting->isDirty());
-    setting->save();
-    EXPECT_EQ(setting->stringify(), "false");
-    EXPECT_TRUE(setting->isDefault());
+    EXPECT_EQ(pSetting->stringify(), "true");
+    EXPECT_TRUE(pSetting->value().isBool());
+    EXPECT_TRUE(pSetting->value().toBool());
+    pSetting->reset();
+    EXPECT_TRUE(pSetting->isDirty());
+    pSetting->save();
+    EXPECT_EQ(pSetting->stringify(), "false");
+    EXPECT_TRUE(pSetting->isDefault());
 
-    EXPECT_TRUE(setting->value().isBool());
-    EXPECT_FALSE(setting->value().toBool());
+    EXPECT_TRUE(pSetting->value().isBool());
+    EXPECT_FALSE(pSetting->value().toBool());
 }
 
 TEST_F(LegacyControllerMappingSettingsTest, integerSettingParsing) {
@@ -112,55 +107,41 @@ TEST_F(LegacyControllerMappingSettingsTest, integerSettingParsing) {
     doc.setContent(QString(kValidInteger).arg("42", "1", "99", "1").toLatin1());
 
     EXPECT_TRUE(LegacyControllerIntegerSetting::match(doc.documentElement()));
-    LegacyControllerIntegerSetting* setting = (LegacyControllerIntegerSetting*)
+    std::shared_ptr<LegacyControllerIntegerSetting> pSetting =
             LegacyControllerIntegerSetting::createFrom(doc.documentElement());
-    EXPECT_TRUE(setting->valid()) << "Unable to create an integer setting";
+    EXPECT_TRUE(pSetting->valid()) << "Unable to create an integer setting";
 
-    EXPECT_EQ(setting->variableName(), "myInteger1");
-    EXPECT_EQ(setting->label(), "Test label");
-    EXPECT_EQ(setting->description(), "Test description");
+    EXPECT_EQ(pSetting->variableName(), "myInteger1");
+    EXPECT_EQ(pSetting->label(), "Test label");
+    EXPECT_EQ(pSetting->description(), "Test description");
 
-    EXPECT_FALSE(setting->isDirty());
-    EXPECT_TRUE(setting->isDefault());
-    EXPECT_EQ(setting->stringify(), "42");
-    EXPECT_TRUE(setting->valid());
-
-    delete setting;
+    EXPECT_FALSE(pSetting->isDirty());
+    EXPECT_TRUE(pSetting->isDefault());
+    EXPECT_EQ(pSetting->stringify(), "42");
+    EXPECT_TRUE(pSetting->valid());
 
     doc.setContent(QString(kValidInteger).arg("18", "1", "99", "1").toLatin1());
-    setting = (LegacyControllerIntegerSetting*)
-            LegacyControllerIntegerSetting::createFrom(doc.documentElement());
-    EXPECT_TRUE(setting->valid()) << "Unable to create an integer setting";
-    EXPECT_EQ(setting->stringify(), "18");
-    EXPECT_TRUE(setting->valid());
-
-    delete setting;
+    pSetting = LegacyControllerIntegerSetting::createFrom(doc.documentElement());
+    EXPECT_TRUE(pSetting->valid()) << "Unable to create an integer setting";
+    EXPECT_EQ(pSetting->stringify(), "18");
+    EXPECT_TRUE(pSetting->valid());
 
     // Invalid if default is out of range
     doc.setContent(QString(kValidInteger).arg("10", "20", "30", "1").toLatin1());
-    setting = (LegacyControllerIntegerSetting*)
-            LegacyControllerIntegerSetting::createFrom(doc.documentElement());
-    EXPECT_EQ(setting->stringify(), "10");
-    EXPECT_FALSE(setting->valid());
-
-    delete setting;
+    pSetting = LegacyControllerIntegerSetting::createFrom(doc.documentElement());
+    EXPECT_EQ(pSetting->stringify(), "10");
+    EXPECT_FALSE(pSetting->valid());
 
     doc.setContent(QString(kValidInteger).arg("10", "1", "5", "1").toLatin1());
-    setting = (LegacyControllerIntegerSetting*)
-            LegacyControllerIntegerSetting::createFrom(doc.documentElement());
-    EXPECT_EQ(setting->stringify(), "10");
-    EXPECT_FALSE(setting->valid());
-
-    delete setting;
+    pSetting = LegacyControllerIntegerSetting::createFrom(doc.documentElement());
+    EXPECT_EQ(pSetting->stringify(), "10");
+    EXPECT_FALSE(pSetting->valid());
 
     // Invalid if step is zero
     doc.setContent(QString(kValidInteger).arg("10", "0", "30", "0").toLatin1());
-    setting = (LegacyControllerIntegerSetting*)
-            LegacyControllerIntegerSetting::createFrom(doc.documentElement());
-    EXPECT_EQ(setting->stringify(), "10");
-    EXPECT_FALSE(setting->valid());
-
-    delete setting;
+    pSetting = LegacyControllerIntegerSetting::createFrom(doc.documentElement());
+    EXPECT_EQ(pSetting->stringify(), "10");
+    EXPECT_FALSE(pSetting->valid());
 }
 
 TEST_F(LegacyControllerMappingSettingsTest, integerSettingEditing) {
@@ -168,44 +149,44 @@ TEST_F(LegacyControllerMappingSettingsTest, integerSettingEditing) {
     doc.setContent(
             QByteArray("<option variable=\"myInteger1\" type=\"integer\" label=\"Test label\"/>"));
 
-    LegacyControllerIntegerSetting* setting = (LegacyControllerIntegerSetting*)
+    std::shared_ptr<LegacyControllerIntegerSetting> pSetting =
             LegacyControllerIntegerSetting::createFrom(doc.documentElement());
-    EXPECT_TRUE(setting->valid()) << "Unable to create an integer setting";
+    EXPECT_TRUE(pSetting->valid()) << "Unable to create an integer setting";
 
-    setting->m_editedValue = true;
-    EXPECT_TRUE(setting->isDirty());
-    setting->save();
-    EXPECT_FALSE(setting->isDirty());
-    EXPECT_EQ(setting->m_savedValue, true);
+    pSetting->m_editedValue = true;
+    EXPECT_TRUE(pSetting->isDirty());
+    pSetting->save();
+    EXPECT_FALSE(pSetting->isDirty());
+    EXPECT_EQ(pSetting->m_savedValue, true);
 
     bool ok;
-    setting->parse("42", &ok);
+    pSetting->parse("42", &ok);
     EXPECT_TRUE(ok);
-    EXPECT_FALSE(setting->isDirty());
-    EXPECT_EQ(setting->stringify(), "42");
-    EXPECT_TRUE(setting->value().isNumber());
-    EXPECT_EQ(setting->value().toInt(), 42);
-    EXPECT_FALSE(setting->isDefault());
-    setting->parse("-15", &ok);
+    EXPECT_FALSE(pSetting->isDirty());
+    EXPECT_EQ(pSetting->stringify(), "42");
+    EXPECT_TRUE(pSetting->value().isNumber());
+    EXPECT_EQ(pSetting->value().toInt(), 42);
+    EXPECT_FALSE(pSetting->isDefault());
+    pSetting->parse("-15", &ok);
     EXPECT_TRUE(ok);
-    setting->parse("0", &ok);
+    pSetting->parse("0", &ok);
     EXPECT_TRUE(ok);
-    EXPECT_FALSE(setting->isDirty());
-    EXPECT_EQ(setting->stringify(), "0");
-    setting->parse("30 ", &ok);
+    EXPECT_FALSE(pSetting->isDirty());
+    EXPECT_EQ(pSetting->stringify(), "0");
+    pSetting->parse("30 ", &ok);
     EXPECT_TRUE(ok);
-    EXPECT_EQ(setting->stringify(), "30");
-    EXPECT_TRUE(setting->value().isNumber());
-    EXPECT_EQ(setting->value().toInt(), 30);
-    setting->reset();
-    EXPECT_TRUE(setting->isDirty());
-    setting->save();
-    EXPECT_EQ(setting->stringify(), "0");
-    EXPECT_TRUE(setting->isDefault());
-    setting->parse("abc ", &ok);
+    EXPECT_EQ(pSetting->stringify(), "30");
+    EXPECT_TRUE(pSetting->value().isNumber());
+    EXPECT_EQ(pSetting->value().toInt(), 30);
+    pSetting->reset();
+    EXPECT_TRUE(pSetting->isDirty());
+    pSetting->save();
+    EXPECT_EQ(pSetting->stringify(), "0");
+    EXPECT_TRUE(pSetting->isDefault());
+    pSetting->parse("abc ", &ok);
     EXPECT_FALSE(ok);
-    EXPECT_TRUE(setting->value().isNumber());
-    EXPECT_EQ(setting->value().toInt(), 0);
+    EXPECT_TRUE(pSetting->value().isNumber());
+    EXPECT_EQ(pSetting->value().toInt(), 0);
 }
 
 TEST_F(LegacyControllerMappingSettingsTest, doubleSettingParsing) {
@@ -213,54 +194,40 @@ TEST_F(LegacyControllerMappingSettingsTest, doubleSettingParsing) {
     doc.setContent(QString(kValidDouble).arg("42", "1", "99", "1").toLatin1());
 
     EXPECT_TRUE(LegacyControllerRealSetting::match(doc.documentElement()));
-    LegacyControllerRealSetting* setting = (LegacyControllerRealSetting*)
+    std::shared_ptr<LegacyControllerRealSetting> pSetting =
             LegacyControllerRealSetting::createFrom(doc.documentElement());
-    EXPECT_TRUE(setting->valid()) << "Unable to create a real setting";
+    EXPECT_TRUE(pSetting->valid()) << "Unable to create a real setting";
 
-    EXPECT_EQ(setting->variableName(), "myReal1");
-    EXPECT_EQ(setting->label(), "myReal1");
-    EXPECT_TRUE(setting->description().isEmpty());
+    EXPECT_EQ(pSetting->variableName(), "myReal1");
+    EXPECT_EQ(pSetting->label(), "myReal1");
+    EXPECT_TRUE(pSetting->description().isEmpty());
 
-    EXPECT_FALSE(setting->isDirty());
-    EXPECT_TRUE(setting->isDefault());
-    EXPECT_EQ(setting->stringify(), "42");
-    EXPECT_TRUE(setting->valid());
-
-    delete setting;
+    EXPECT_FALSE(pSetting->isDirty());
+    EXPECT_TRUE(pSetting->isDefault());
+    EXPECT_EQ(pSetting->stringify(), "42");
+    EXPECT_TRUE(pSetting->valid());
 
     doc.setContent(QString(kValidInteger).arg("18", "1", "99", "1").toLatin1());
-    setting = (LegacyControllerRealSetting*)
-            LegacyControllerRealSetting::createFrom(doc.documentElement());
-    EXPECT_EQ(setting->stringify(), "18");
-    EXPECT_TRUE(setting->valid());
-
-    delete setting;
+    pSetting = LegacyControllerRealSetting::createFrom(doc.documentElement());
+    EXPECT_EQ(pSetting->stringify(), "18");
+    EXPECT_TRUE(pSetting->valid());
 
     // Invalid if default is out of range
     doc.setContent(QString(kValidInteger).arg("10", "20", "30", "1").toLatin1());
-    setting = (LegacyControllerRealSetting*)
-            LegacyControllerRealSetting::createFrom(doc.documentElement());
-    EXPECT_EQ(setting->stringify(), "10");
-    EXPECT_FALSE(setting->valid());
-
-    delete setting;
+    pSetting = LegacyControllerRealSetting::createFrom(doc.documentElement());
+    EXPECT_EQ(pSetting->stringify(), "10");
+    EXPECT_FALSE(pSetting->valid());
 
     doc.setContent(QString(kValidInteger).arg("10", "1", "5", "1").toLatin1());
-    setting = (LegacyControllerRealSetting*)
-            LegacyControllerRealSetting::createFrom(doc.documentElement());
-    EXPECT_EQ(setting->stringify(), "10");
-    EXPECT_FALSE(setting->valid());
-
-    delete setting;
+    pSetting = LegacyControllerRealSetting::createFrom(doc.documentElement());
+    EXPECT_EQ(pSetting->stringify(), "10");
+    EXPECT_FALSE(pSetting->valid());
 
     // Invalid if step is zero
     doc.setContent(QString(kValidInteger).arg("10", "0", "30", "0").toLatin1());
-    setting = (LegacyControllerRealSetting*)
-            LegacyControllerRealSetting::createFrom(doc.documentElement());
-    EXPECT_EQ(setting->stringify(), "10");
-    EXPECT_FALSE(setting->valid());
-
-    delete setting;
+    pSetting = LegacyControllerRealSetting::createFrom(doc.documentElement());
+    EXPECT_EQ(pSetting->stringify(), "10");
+    EXPECT_FALSE(pSetting->valid());
 }
 
 TEST_F(LegacyControllerMappingSettingsTest, doubleSettingEditing) {
@@ -268,44 +235,44 @@ TEST_F(LegacyControllerMappingSettingsTest, doubleSettingEditing) {
     doc.setContent(
             QByteArray("<option variable=\"myReal1\" type=\"real\" label=\"Test label\"/>"));
 
-    LegacyControllerRealSetting* setting = (LegacyControllerRealSetting*)
+    std::shared_ptr<LegacyControllerRealSetting> pSetting =
             LegacyControllerRealSetting::createFrom(doc.documentElement());
-    EXPECT_TRUE(setting->valid()) << "Unable to create a double setting";
+    EXPECT_TRUE(pSetting->valid()) << "Unable to create a double setting";
 
-    setting->m_editedValue = 1.0;
-    EXPECT_TRUE(setting->isDirty());
-    setting->save();
-    EXPECT_FALSE(setting->isDirty());
-    EXPECT_EQ(setting->m_savedValue, true);
+    pSetting->m_editedValue = 1.0;
+    EXPECT_TRUE(pSetting->isDirty());
+    pSetting->save();
+    EXPECT_FALSE(pSetting->isDirty());
+    EXPECT_EQ(pSetting->m_savedValue, true);
 
     bool ok;
-    setting->parse("0.001", &ok);
+    pSetting->parse("0.001", &ok);
     EXPECT_TRUE(ok);
-    EXPECT_FALSE(setting->isDirty());
-    EXPECT_EQ(setting->stringify(), "0.001");
-    EXPECT_TRUE(setting->value().isNumber());
-    EXPECT_EQ(setting->value().toNumber(), 0.001);
-    EXPECT_FALSE(setting->isDefault());
-    setting->parse("-15", &ok);
+    EXPECT_FALSE(pSetting->isDirty());
+    EXPECT_EQ(pSetting->stringify(), "0.001");
+    EXPECT_TRUE(pSetting->value().isNumber());
+    EXPECT_EQ(pSetting->value().toNumber(), 0.001);
+    EXPECT_FALSE(pSetting->isDefault());
+    pSetting->parse("-15", &ok);
     EXPECT_TRUE(ok);
-    setting->parse("0", &ok);
+    pSetting->parse("0", &ok);
     EXPECT_TRUE(ok);
-    EXPECT_FALSE(setting->isDirty());
-    EXPECT_EQ(setting->stringify(), "0");
-    setting->parse("30.0 ", &ok);
+    EXPECT_FALSE(pSetting->isDirty());
+    EXPECT_EQ(pSetting->stringify(), "0");
+    pSetting->parse("30.0 ", &ok);
     EXPECT_TRUE(ok);
-    EXPECT_EQ(setting->stringify(), "30");
-    EXPECT_TRUE(setting->value().isNumber());
-    EXPECT_EQ(setting->value().toNumber(), 30.0);
-    setting->reset();
-    EXPECT_TRUE(setting->isDirty());
-    setting->save();
-    EXPECT_EQ(setting->stringify(), "0");
-    EXPECT_TRUE(setting->isDefault());
-    setting->parse("abc ", &ok);
+    EXPECT_EQ(pSetting->stringify(), "30");
+    EXPECT_TRUE(pSetting->value().isNumber());
+    EXPECT_EQ(pSetting->value().toNumber(), 30.0);
+    pSetting->reset();
+    EXPECT_TRUE(pSetting->isDirty());
+    pSetting->save();
+    EXPECT_EQ(pSetting->stringify(), "0");
+    EXPECT_TRUE(pSetting->isDefault());
+    pSetting->parse("abc ", &ok);
     EXPECT_FALSE(ok);
-    EXPECT_TRUE(setting->value().isNumber());
-    EXPECT_EQ(setting->value().toNumber(), .0);
+    EXPECT_TRUE(pSetting->value().isNumber());
+    EXPECT_EQ(pSetting->value().toNumber(), .0);
 }
 
 TEST_F(LegacyControllerMappingSettingsTest, enumSettingParsing) {
@@ -318,27 +285,22 @@ TEST_F(LegacyControllerMappingSettingsTest, enumSettingParsing) {
                            .toLatin1());
 
     EXPECT_TRUE(LegacyControllerEnumSetting::match(doc.documentElement()));
-    LegacyControllerEnumSetting* setting = (LegacyControllerEnumSetting*)
+    std::shared_ptr<LegacyControllerEnumSetting> pSetting =
             LegacyControllerEnumSetting::createFrom(doc.documentElement());
-    EXPECT_TRUE(setting->valid()) << "Unable to create an enum setting";
+    EXPECT_TRUE(pSetting->valid()) << "Unable to create an enum setting";
 
-    EXPECT_EQ(setting->variableName(), "myEnum1");
-    EXPECT_EQ(setting->label(), "Test label");
-    EXPECT_EQ(setting->description(), "Test description");
+    EXPECT_EQ(pSetting->variableName(), "myEnum1");
+    EXPECT_EQ(pSetting->label(), "Test label");
+    EXPECT_EQ(pSetting->description(), "Test description");
 
-    EXPECT_FALSE(setting->isDirty());
-    EXPECT_TRUE(setting->isDefault());
-    EXPECT_EQ(setting->stringify(), "myOptionValue");
-    EXPECT_TRUE(setting->valid());
-
-    delete setting;
+    EXPECT_FALSE(pSetting->isDirty());
+    EXPECT_TRUE(pSetting->isDefault());
+    EXPECT_EQ(pSetting->stringify(), "myOptionValue");
+    EXPECT_TRUE(pSetting->valid());
 
     doc.setContent(QString(kValidEnum).arg("").toLatin1());
-    setting = (LegacyControllerEnumSetting*)
-            LegacyControllerEnumSetting::createFrom(doc.documentElement());
-    EXPECT_FALSE(setting->valid());
-
-    delete setting;
+    pSetting = LegacyControllerEnumSetting::createFrom(doc.documentElement());
+    EXPECT_FALSE(pSetting->valid());
 }
 
 TEST_F(LegacyControllerMappingSettingsTest, enumSettingEditing) {
@@ -359,36 +321,36 @@ TEST_F(LegacyControllerMappingSettingsTest, enumSettingEditing) {
                            .toLatin1());
 
     EXPECT_TRUE(LegacyControllerEnumSetting::match(doc.documentElement()));
-    LegacyControllerEnumSetting* setting = (LegacyControllerEnumSetting*)
+    std::shared_ptr<LegacyControllerEnumSetting> pSetting =
             LegacyControllerEnumSetting::createFrom(doc.documentElement());
-    EXPECT_TRUE(setting->valid()) << "Unable to create an enum setting";
+    EXPECT_TRUE(pSetting->valid()) << "Unable to create an enum setting";
 
-    setting->m_editedValue = 2;
-    EXPECT_TRUE(setting->isDirty());
-    setting->save();
-    EXPECT_FALSE(setting->isDirty());
-    EXPECT_EQ(setting->m_savedValue, 2);
-    EXPECT_EQ(setting->stringify(), "myOptionValue3");
-    EXPECT_TRUE(setting->value().isString());
-    EXPECT_EQ(setting->value().toString(), "myOptionValue3");
+    pSetting->m_editedValue = 2;
+    EXPECT_TRUE(pSetting->isDirty());
+    pSetting->save();
+    EXPECT_FALSE(pSetting->isDirty());
+    EXPECT_EQ(pSetting->m_savedValue, 2);
+    EXPECT_EQ(pSetting->stringify(), "myOptionValue3");
+    EXPECT_TRUE(pSetting->value().isString());
+    EXPECT_EQ(pSetting->value().toString(), "myOptionValue3");
 
     bool ok;
-    setting->parse("myOptionValue2", &ok);
+    pSetting->parse("myOptionValue2", &ok);
     EXPECT_TRUE(ok);
-    EXPECT_FALSE(setting->isDirty());
-    EXPECT_EQ(setting->stringify(), "myOptionValue2");
-    EXPECT_TRUE(setting->value().isString());
-    EXPECT_EQ(setting->value().toString(), "myOptionValue2");
-    EXPECT_FALSE(setting->isDefault());
-    setting->reset();
-    EXPECT_TRUE(setting->isDirty());
-    setting->save();
-    EXPECT_EQ(setting->stringify(), "myOptionValue1");
-    EXPECT_TRUE(setting->isDefault());
-    setting->parse("abc ", &ok);
+    EXPECT_FALSE(pSetting->isDirty());
+    EXPECT_EQ(pSetting->stringify(), "myOptionValue2");
+    EXPECT_TRUE(pSetting->value().isString());
+    EXPECT_EQ(pSetting->value().toString(), "myOptionValue2");
+    EXPECT_FALSE(pSetting->isDefault());
+    pSetting->reset();
+    EXPECT_TRUE(pSetting->isDirty());
+    pSetting->save();
+    EXPECT_EQ(pSetting->stringify(), "myOptionValue1");
+    EXPECT_TRUE(pSetting->isDefault());
+    pSetting->parse("abc ", &ok);
     EXPECT_FALSE(ok);
-    EXPECT_TRUE(setting->value().isString());
-    EXPECT_EQ(setting->value().toString(), "myOptionValue1");
+    EXPECT_TRUE(pSetting->value().isString());
+    EXPECT_EQ(pSetting->value().toString(), "myOptionValue1");
 }
 
 class LegacyDummyMapping : public LegacyControllerMapping {


### PR DESCRIPTION
There are remaining objects not deleted in `controller_mapping_settings_test.cpp`

I have fixed it by using std::shared_ptr from the very beginning by std::make_shared. In Mixxx itself the objects are later managed by a std::shared_ptr anyway. 
In addition I have added two drive by fixes regarding move semantic and uninitialized variables. 