### PR TITLE
MIDI learn control menu: add more cue controls for samplers

### DIFF
--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -494,21 +494,29 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
 
     // Cues
     QMenu* pCueMenu = addSubmenu(tr("Cues"));
-    addDeckControl("cue_default", tr("Cue"), tr("Cue button"), pCueMenu);
-    addDeckControl("cue_set", tr("Set Cue"), tr("Set cue point"), pCueMenu);
-    addDeckControl("cue_goto", tr("Go-To Cue"), tr("Go to cue point"), pCueMenu);
+    addDeckAndSamplerControl("cue_default", tr("Cue"), tr("Cue button"), pCueMenu);
+    addDeckAndSamplerControl("cue_set", tr("Set Cue"), tr("Set cue point"), pCueMenu);
+    addDeckAndSamplerControl(
+            "cue_goto", tr("Go-To Cue"), tr("Go to cue point"), pCueMenu);
     addDeckAndSamplerAndPreviewDeckControl("cue_gotoandplay",
             tr("Go-To Cue And Play"),
             tr("Go to cue point and play"),
             pCueMenu);
-    addDeckControl("cue_gotoandstop",
+    addDeckAndSamplerControl("cue_gotoandstop",
             tr("Go-To Cue And Stop"),
             tr("Go to cue point and stop"),
             pCueMenu);
-    addDeckControl("cue_preview", tr("Preview Cue"), tr("Preview from cue point"), pCueMenu);
-    addDeckControl("cue_cdj", tr("Cue (CDJ Mode)"), tr("Cue button (CDJ mode)"), pCueMenu);
-    addDeckControl("play_stutter", tr("Stutter Cue"), tr("Stutter cue"), pCueMenu);
-    addDeckControl("cue_play",
+    addDeckAndSamplerControl("cue_preview",
+            tr("Preview Cue"),
+            tr("Preview from cue point"),
+            pCueMenu);
+    addDeckAndSamplerControl("cue_cdj",
+            tr("Cue (CDJ Mode)"),
+            tr("Cue button (CDJ mode)"),
+            pCueMenu);
+    addDeckAndSamplerControl(
+            "play_stutter", tr("Stutter Cue"), tr("Stutter cue"), pCueMenu);
+    addDeckAndSamplerControl("cue_play",
             tr("CUP (Cue + Play)"),
             tr("Go to cue point and play after release"),
             pCueMenu);


### PR DESCRIPTION
Just noticed that not all cue controls are in the MIDI Learn control menu