### PR TITLE
(fix) Hotcue sort: collect only cues with valid hotcue index

### DIFF
--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -998,9 +998,14 @@ void Track::setHotcueIndicesSortedByPosition(HotcueSortMode sortMode) {
     indices.reserve(m_cuePoints.size());
     positions.reserve(m_cuePoints.size());
     for (const CuePointer& pCue : std::as_const(m_cuePoints)) {
-        if (pCue->getType() != mixxx::CueType::HotCue &&
-                pCue->getType() != mixxx::CueType::Loop &&
-                pCue->getType() != mixxx::CueType::Jump) {
+        // We only want hotcues (regular, loop, jump) with a valid index.
+        // Note: Loop with index -1 is the temporary, unsaved loop.
+        // Also note that there may be orphaned hotcues with index -1.
+        // Remember to also run this check when setting the new indices.
+        if (pCue->getHotCue() == Cue::kNoHotCue ||
+                (pCue->getType() != mixxx::CueType::HotCue &&
+                        pCue->getType() != mixxx::CueType::Loop &&
+                        pCue->getType() != mixxx::CueType::Jump)) {
             continue;
         }
         const auto pos = pCue->getPosition();
@@ -1037,9 +1042,10 @@ void Track::setHotcueIndicesSortedByPosition(HotcueSortMode sortMode) {
 
     // Finally set new indices on hotcues
     for (CuePointer& pCue : m_cuePoints) {
-        if (pCue->getType() != mixxx::CueType::HotCue &&
-                pCue->getType() != mixxx::CueType::Loop &&
-                pCue->getType() != mixxx::CueType::Jump) {
+        if (pCue->getHotCue() == Cue::kNoHotCue ||
+                (pCue->getType() != mixxx::CueType::HotCue &&
+                        pCue->getType() != mixxx::CueType::Loop &&
+                        pCue->getType() != mixxx::CueType::Jump)) {
             continue;
         }
         int newIndex = posIndexHash.take(pCue->getPosition());


### PR DESCRIPTION
Fixup for #13808

Also check for valid hotcue index when collecting hotcues.
These create issues:
* `Loop` and index -1 is the temporary loop
* and there may be orphaned `Hotcue`s with invalid index

____
I noticed that sorting hotcues would magically create new hotcues and loopcues, some even at the same pos / close to existing (valid) hotcues. Checking the database, I have about 3000 of such cues.
Seems they have accumulated over the past ~10 years :shrug: 
