### PR TITLE
(fix) AutoDJ "Remove Crate" action, fix and add comments

### DIFF
--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -106,8 +106,11 @@ AutoDJFeature::AutoDJFeature(Library* pLibrary,
             &QAction::triggered,
             this,
             &AutoDJFeature::slotClearQueue);
-    // Create context-menu items to allow crates to be added to, and removed
-    // from, the auto-DJ queue.
+    // Create context menu item to allow crates to be removed from AutoDJ sources.
+    // onRightClickChild() gets the clicked crate's id form the sidebar model and
+    // assigns it to this action's data.
+    // In slotRemoveCrateFromAutoDj() we retrieve the CrateId data and finally
+    // remove the crate from sources in removeCrateFromAutoDj().
     m_pRemoveCrateFromAutoDjAction =
             make_parented<QAction>(tr("Remove Crate as Track Source"), this);
     m_pRemoveCrateFromAutoDjAction->setShortcut(removeKeySequence);
@@ -234,13 +237,13 @@ void AutoDJFeature::slotClearQueue() {
     clear();
 }
 
-// Add a crate to the auto-DJ queue.
+// Add a crate to the AutoDJ sources
 void AutoDJFeature::slotAddCrateToAutoDj(CrateId crateId) {
     m_pTrackCollection->updateAutoDjCrate(crateId, true);
 }
 
 void AutoDJFeature::slotRemoveCrateFromAutoDj() {
-    CrateId crateId(m_pRemoveCrateFromAutoDjAction->data().value<CrateId>());
+    CrateId crateId(m_pRemoveCrateFromAutoDjAction->data());
     removeCrateFromAutoDj(crateId);
 }
 


### PR DESCRIPTION
Fixes #14425 

FWIW the QAction's `data()` is for example `QVariant(int, 2)` and `data().value<CrateId>()` will always return `-1` :shrug: 