### PR TITLE
Add a MMutexLockerDebug to trace Multithreading

### DIFF
--- a/src/util/mutex.h
+++ b/src/util/mutex.h
@@ -60,6 +60,25 @@ class SCOPED_CAPABILITY MMutexLocker {
     QT_MUTEX_LOCKER m_locker;
 };
 
+class SCOPED_CAPABILITY MMutexLockerDebug {
+  public:
+    MMutexLockerDebug(MMutex* pMu, const QString& info = {})
+            : m_pMutex(pMu) {
+        if (!m_pMutex->tryLock()) {
+            qDebug() << "Mutex wait" << info;
+            m_pMutex->lock();
+        }
+        qDebug() << "Mutex locked" << info;
+    }
+    ~MMutexLockerDebug() {
+        m_pMutex->unlock();
+        qDebug() << "Mutex unlocked";
+    }
+
+  private:
+    MMutex* m_pMutex;
+};
+
 class SCOPED_CAPABILITY MWriteLocker {
   public:
     MWriteLocker(MReadWriteLock* mu) ACQUIRE(mu) : m_locker(&mu->m_lock) {}


### PR DESCRIPTION
I have created this to trace multi threading. It is not used, but might be useful for other contributors. Do we want to keep that in our source tree for future debugging? 