### PR TITLE
Continue after the maximum learning time is over

### DIFF
--- a/src/controllers/dlgcontrollerlearning.cpp
+++ b/src/controllers/dlgcontrollerlearning.cpp
@@ -321,7 +321,9 @@ void DlgControllerLearning::slotMessageReceived(unsigned char status,
     // timer.  That way the user won't just push buttons forever and wonder
     // why the wizard never advances.
     MidiOpCode opCode = MidiUtils::opCodeFromStatus(status);
-    if (opCode != MidiOpCode::ControlChange || progressBarWiggleFeedback->value() != 10) {
+    if (opCode != MidiOpCode::ControlChange &&
+            progressBarWiggleFeedback->value() !=
+                    progressBarWiggleFeedback->maximum()) {
         m_lastMessageTimer.start();
     }
 }


### PR DESCRIPTION
This is a band aid for a controller that repeatedly send the same message. I have implemented it for debugging the race condition in #14159 
In such a case the midi learn dialog was stuck. Now it continues after the progress bar is at maximum. 
Useful learning is however still not possible with such a hypothetical controller, because Mixxx will always pick the repeated message for learning. At least the GUI behaves as expected. 