### PR TITLE
Tracks: add hotkey Shift+Del to purge and move track files to trash

### DIFF
--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1112,6 +1112,8 @@ void WTrackTableView::keyPressEvent(QKeyEvent* event) {
     case kHideRemoveShortcutKey: {
         if (event->modifiers() == kHideRemoveShortcutModifier) {
             hideOrRemoveSelectedTracks();
+        } else if (event->modifiers().testFlag(Qt::ShiftModifier)) {
+            slotDeleteTracksFromDisk();
         }
         return;
     }


### PR DESCRIPTION
Shortcut for quick cleanup. Faster than opening the menu with right-click, select Purge, hit Enter.
Shift + Del is also the "direct delete" shortcut in some file managers.

### TODO
- [ ] document hotkey in the manual https://manual.mixxx.org/2.5/en/chapters/appendix/keyboard_mapping_table#appendix-keyboard