### PR TITLE
add 'LoadTrackFromPreviewDeck' control

### DIFF
--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -191,6 +191,13 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(
             &ControlObject::valueChanged,
             this,
             &BaseTrackPlayerImpl::slotLoadTrackFromSampler);
+    m_pLoadTrackFromPreviewDeck = std::make_unique<ControlObject>(
+            ConfigKey(getGroup(), "LoadTrackFromPreviewDeck"),
+            false);
+    connect(m_pLoadTrackFromPreviewDeck.get(),
+            &ControlObject::valueChanged,
+            this,
+            &BaseTrackPlayerImpl::slotLoadTrackFromPreviewDeck);
 
     // Waveform controls
     // This acts somewhat like a ControlPotmeter, but the normal _up/_down methods
@@ -807,6 +814,11 @@ void BaseTrackPlayerImpl::slotCloneChannel(EngineChannel* pChannel) {
 void BaseTrackPlayerImpl::slotLoadTrackFromDeck(double d) {
     int deck = static_cast<int>(d);
     loadTrackFromGroup(PlayerManager::groupForDeck(deck - 1));
+}
+
+void BaseTrackPlayerImpl::slotLoadTrackFromPreviewDeck(double d) {
+    int deck = static_cast<int>(d);
+    loadTrackFromGroup(PlayerManager::groupForPreviewDeck(deck - 1));
 }
 
 void BaseTrackPlayerImpl::slotLoadTrackFromSampler(double d) {

--- a/src/mixer/basetrackplayer.h
+++ b/src/mixer/basetrackplayer.h
@@ -140,6 +140,7 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
     void loadTrackFromGroup(const QString& group);
     void slotLoadTrackFromDeck(double deck);
     void slotLoadTrackFromSampler(double sampler);
+    void slotLoadTrackFromPreviewDeck(double deck);
     void slotTrackColorChangeRequest(double value);
     /// Slot for change signals from up/down controls (relative values)
     void slotTrackRatingChangeRequestRelative(int change);
@@ -181,6 +182,7 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
     // Load track from other deck/sampler
     std::unique_ptr<ControlObject> m_pLoadTrackFromDeck;
     std::unique_ptr<ControlObject> m_pLoadTrackFromSampler;
+    std::unique_ptr<ControlObject> m_pLoadTrackFromPreviewDeck;
 
     // Track color control
     std::unique_ptr<ControlObject> m_pTrackColor;


### PR DESCRIPTION
to make the `LoadTrackFrom..` controls complete.

My use case is storing tracks in samplers while the track may not be visible in the library anymore but is still loaded in preview deck. Been missing this feature in my recent sessions with the Traktor S4 Mk3.