### PR TITLE
[VinylControl] Reduce sticker drift

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ exclude: ^(lib/|src/test/.*data/).*|res/controllers/lodash\.mixxx\.js|src/.*_(an
 minimum_pre_commit_version: 2.21.0
 default_language_version:
   python: python3
-  rust: 1.85.0
+  rust: 1.64.0
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ exclude: ^(lib/|src/test/.*data/).*|res/controllers/lodash\.mixxx\.js|src/.*_(an
 minimum_pre_commit_version: 2.21.0
 default_language_version:
   python: python3
-  rust: 1.64.0
+  rust: 1.85.0
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/src/vinylcontrol/vinylcontrol.cpp
+++ b/src/vinylcontrol/vinylcontrol.cpp
@@ -41,8 +41,7 @@ VinylControl::VinylControl(UserSettingsPointer pConfig, const QString& group)
             group, "vinylcontrol_signal_enabled", this);
     reverseButton = new ControlProxy(group, "reverse", this);
     m_passthroughEnabled = make_parented<PollingControlProxy>(group, "passthrough");
-    scratchPositionEnabled = make_parented<ControlProxy>(
-            group, QStringLiteral("scratch_position_enable"), this);
+    scratchPositionEnabled = make_parented<ControlProxy>(group, QStringLiteral("scratch_position_enable"), this);
 
     //Enabled or not -- load from saved value in case vinyl control is restarting
     m_bIsEnabled = wantenabled->get() > 0.0;

--- a/src/vinylcontrol/vinylcontrol.cpp
+++ b/src/vinylcontrol/vinylcontrol.cpp
@@ -40,10 +40,8 @@ VinylControl::VinylControl(UserSettingsPointer pConfig, const QString& group)
     signalenabled = new ControlProxy(
             group, "vinylcontrol_signal_enabled", this);
     reverseButton = new ControlProxy(group, "reverse", this);
-    m_passthroughEnabled = make_parented<ControlProxy>(
-            group, QStringLiteral("passthrough"), this);
-    m_scratchPositionEnabled = make_parented<ControlProxy>(
-            group, QStringLiteral("scratch_position_enable"), this);
+    m_passthroughEnabled = PollingControlProxy(group, QStringLiteral("passthrough"));
+    m_scratchPositionEnabled = PollingControlProxy(group, QStringLiteral("scratch_position_enable"));
 
     //Enabled or not -- load from saved value in case vinyl control is restarting
     m_bIsEnabled = wantenabled->get() > 0.0;

--- a/src/vinylcontrol/vinylcontrol.cpp
+++ b/src/vinylcontrol/vinylcontrol.cpp
@@ -40,8 +40,9 @@ VinylControl::VinylControl(UserSettingsPointer pConfig, const QString& group)
     signalenabled = new ControlProxy(
             group, "vinylcontrol_signal_enabled", this);
     reverseButton = new ControlProxy(group, "reverse", this);
-    m_passthroughEnabled = make_parented<ControlProxy>(group, "passthrough", this);
-    scratchPositionEnabled = make_parented<ControlProxy>(
+    m_passthroughEnabled = make_parented<ControlProxy>(
+            group, QStringLiteral("passthrough"), this);
+    m_scratchPositionEnabled = make_parented<ControlProxy>(
             group, QStringLiteral("scratch_position_enable"), this);
 
     //Enabled or not -- load from saved value in case vinyl control is restarting

--- a/src/vinylcontrol/vinylcontrol.cpp
+++ b/src/vinylcontrol/vinylcontrol.cpp
@@ -40,8 +40,9 @@ VinylControl::VinylControl(UserSettingsPointer pConfig, const QString& group)
     signalenabled = new ControlProxy(
             group, "vinylcontrol_signal_enabled", this);
     reverseButton = new ControlProxy(group, "reverse", this);
-    m_passthroughEnabled = make_parented<PollingControlProxy>(group, "passthrough");
-    scratchPositionEnabled = make_parented<ControlProxy>(group, QStringLiteral("scratch_position_enable"), this);
+    m_passthroughEnabled = make_parented<ControlProxy>(group, "passthrough", this);
+    scratchPositionEnabled = make_parented<ControlProxy>(
+            group, QStringLiteral("scratch_position_enable"), this);
 
     //Enabled or not -- load from saved value in case vinyl control is restarting
     m_bIsEnabled = wantenabled->get() > 0.0;

--- a/src/vinylcontrol/vinylcontrol.cpp
+++ b/src/vinylcontrol/vinylcontrol.cpp
@@ -41,7 +41,8 @@ VinylControl::VinylControl(UserSettingsPointer pConfig, const QString& group)
             group, "vinylcontrol_signal_enabled", this);
     reverseButton = new ControlProxy(group, "reverse", this);
     m_passthroughEnabled = make_parented<PollingControlProxy>(group, "passthrough");
-    scratchPositionEnabled = make_parented<ControlProxy>(group, QStringLiteral("scratch_position_enable"), this);
+    scratchPositionEnabled = make_parented<ControlProxy>(
+            group, QStringLiteral("scratch_position_enable"), this);
 
     //Enabled or not -- load from saved value in case vinyl control is restarting
     m_bIsEnabled = wantenabled->get() > 0.0;

--- a/src/vinylcontrol/vinylcontrol.cpp
+++ b/src/vinylcontrol/vinylcontrol.cpp
@@ -40,9 +40,8 @@ VinylControl::VinylControl(UserSettingsPointer pConfig, const QString& group)
     signalenabled = new ControlProxy(
             group, "vinylcontrol_signal_enabled", this);
     reverseButton = new ControlProxy(group, "reverse", this);
-    passthroughEnabled = make_parented<ControlProxy>(group, QStringLiteral("passthrough"), this);
-    scratchPositionEnabled = make_parented<ControlProxy>(
-            group, QStringLiteral("scratch_position_enable"), this);
+    m_passthroughEnabled = make_parented<PollingControlProxy>(group, "passthrough");
+    scratchPositionEnabled = make_parented<ControlProxy>(group, QStringLiteral("scratch_position_enable"), this);
 
     //Enabled or not -- load from saved value in case vinyl control is restarting
     m_bIsEnabled = wantenabled->get() > 0.0;

--- a/src/vinylcontrol/vinylcontrol.cpp
+++ b/src/vinylcontrol/vinylcontrol.cpp
@@ -41,7 +41,8 @@ VinylControl::VinylControl(UserSettingsPointer pConfig, const QString& group)
             group, "vinylcontrol_signal_enabled", this);
     reverseButton = new ControlProxy(group, "reverse", this);
     m_passthroughEnabled = PollingControlProxy(group, QStringLiteral("passthrough"));
-    m_scratchPositionEnabled = PollingControlProxy(group, QStringLiteral("scratch_position_enable"));
+    m_scratchPositionEnabled = PollingControlProxy(
+            group, QStringLiteral("scratch_position_enable"));
 
     //Enabled or not -- load from saved value in case vinyl control is restarting
     m_bIsEnabled = wantenabled->get() > 0.0;

--- a/src/vinylcontrol/vinylcontrol.cpp
+++ b/src/vinylcontrol/vinylcontrol.cpp
@@ -40,7 +40,7 @@ VinylControl::VinylControl(UserSettingsPointer pConfig, const QString& group)
     signalenabled = new ControlProxy(
             group, "vinylcontrol_signal_enabled", this);
     reverseButton = new ControlProxy(group, "reverse", this);
-    passthroughEnabled(group, QStringLiteral("passthrough"));
+    passthroughEnabled = make_parented<ControlProxy>(group, QStringLiteral("passthrough"));
 
     //Enabled or not -- load from saved value in case vinyl control is restarting
     m_bIsEnabled = wantenabled->get() > 0.0;

--- a/src/vinylcontrol/vinylcontrol.cpp
+++ b/src/vinylcontrol/vinylcontrol.cpp
@@ -40,7 +40,7 @@ VinylControl::VinylControl(UserSettingsPointer pConfig, const QString& group)
     signalenabled = new ControlProxy(
             group, "vinylcontrol_signal_enabled", this);
     reverseButton = new ControlProxy(group, "reverse", this);
-    passthroughEnabled = new ControlProxy(group, "passthrough", this);
+    passthroughEnabled(group, QStringLiteral("passthrough"));
 
     //Enabled or not -- load from saved value in case vinyl control is restarting
     m_bIsEnabled = wantenabled->get() > 0.0;

--- a/src/vinylcontrol/vinylcontrol.cpp
+++ b/src/vinylcontrol/vinylcontrol.cpp
@@ -41,6 +41,7 @@ VinylControl::VinylControl(UserSettingsPointer pConfig, const QString& group)
             group, "vinylcontrol_signal_enabled", this);
     reverseButton = new ControlProxy(group, "reverse", this);
     passthroughEnabled = make_parented<ControlProxy>(group, QStringLiteral("passthrough"));
+    scratchPositionEnabled = make_parented<ControlProxy>(group, QStringLiteral("scratch_position_enable"));
 
     //Enabled or not -- load from saved value in case vinyl control is restarting
     m_bIsEnabled = wantenabled->get() > 0.0;

--- a/src/vinylcontrol/vinylcontrol.cpp
+++ b/src/vinylcontrol/vinylcontrol.cpp
@@ -40,6 +40,7 @@ VinylControl::VinylControl(UserSettingsPointer pConfig, const QString& group)
     signalenabled = new ControlProxy(
             group, "vinylcontrol_signal_enabled", this);
     reverseButton = new ControlProxy(group, "reverse", this);
+    passthroughEnabled = new ControlProxy(group, "passthrough", this);
 
     //Enabled or not -- load from saved value in case vinyl control is restarting
     m_bIsEnabled = wantenabled->get() > 0.0;

--- a/src/vinylcontrol/vinylcontrol.cpp
+++ b/src/vinylcontrol/vinylcontrol.cpp
@@ -40,9 +40,9 @@ VinylControl::VinylControl(UserSettingsPointer pConfig, const QString& group)
     signalenabled = new ControlProxy(
             group, "vinylcontrol_signal_enabled", this);
     reverseButton = new ControlProxy(group, "reverse", this);
-    passthroughEnabled = make_parented<ControlProxy>(group, QStringLiteral("passthrough"));
+    passthroughEnabled = make_parented<ControlProxy>(group, QStringLiteral("passthrough"), this);
     scratchPositionEnabled = make_parented<ControlProxy>(
-            group, QStringLiteral("scratch_position_enable"));
+            group, QStringLiteral("scratch_position_enable"), this);
 
     //Enabled or not -- load from saved value in case vinyl control is restarting
     m_bIsEnabled = wantenabled->get() > 0.0;

--- a/src/vinylcontrol/vinylcontrol.cpp
+++ b/src/vinylcontrol/vinylcontrol.cpp
@@ -41,7 +41,8 @@ VinylControl::VinylControl(UserSettingsPointer pConfig, const QString& group)
             group, "vinylcontrol_signal_enabled", this);
     reverseButton = new ControlProxy(group, "reverse", this);
     passthroughEnabled = make_parented<ControlProxy>(group, QStringLiteral("passthrough"));
-    scratchPositionEnabled = make_parented<ControlProxy>(group, QStringLiteral("scratch_position_enable"));
+    scratchPositionEnabled = make_parented<ControlProxy>(
+            group, QStringLiteral("scratch_position_enable"));
 
     //Enabled or not -- load from saved value in case vinyl control is restarting
     m_bIsEnabled = wantenabled->get() > 0.0;

--- a/src/vinylcontrol/vinylcontrol.h
+++ b/src/vinylcontrol/vinylcontrol.h
@@ -2,6 +2,7 @@
 
 #include <QString>
 
+#include "control/pollingcontrolproxy.h"
 #include "preferences/usersettings.h"
 #include "util/parented_ptr.h"
 #include "util/types.h"
@@ -67,7 +68,7 @@ class VinylControl : public QObject {
     ControlProxy* signalenabled;
     // When the user has pressed the "reverse" button.
     ControlProxy* reverseButton;
-    parented_ptr<ControlProxy> passthroughEnabled;
+    parented_ptr<PollingControlProxy> m_passthroughEnabled;
     parented_ptr<ControlProxy> scratchPositionEnabled;
 
     // The lead-in time...

--- a/src/vinylcontrol/vinylcontrol.h
+++ b/src/vinylcontrol/vinylcontrol.h
@@ -2,6 +2,7 @@
 
 #include <QString>
 
+#include "control/pollingcontrolproxy.h"
 #include "preferences/usersettings.h"
 #include "util/parented_ptr.h"
 #include "util/types.h"
@@ -67,8 +68,8 @@ class VinylControl : public QObject {
     ControlProxy* signalenabled;
     // When the user has pressed the "reverse" button.
     ControlProxy* reverseButton;
-    parented_ptr<ControlProxy> m_passthroughEnabled;
-    parented_ptr<ControlProxy> m_scratchPositionEnabled;
+    PollingControlProxy m_passthroughEnabled;
+    PollingControlProxy m_scratchPositionEnabled;
 
     // The lead-in time...
     int m_iLeadInTime;

--- a/src/vinylcontrol/vinylcontrol.h
+++ b/src/vinylcontrol/vinylcontrol.h
@@ -2,7 +2,6 @@
 
 #include <QString>
 
-#include "control/pollingcontrolproxy.h"
 #include "preferences/usersettings.h"
 #include "util/parented_ptr.h"
 #include "util/types.h"
@@ -68,7 +67,7 @@ class VinylControl : public QObject {
     ControlProxy* signalenabled;
     // When the user has pressed the "reverse" button.
     ControlProxy* reverseButton;
-    parented_ptr<PollingControlProxy> m_passthroughEnabled;
+    parented_ptr<ControlProxy> m_passthroughEnabled;
     parented_ptr<ControlProxy> scratchPositionEnabled;
 
     // The lead-in time...

--- a/src/vinylcontrol/vinylcontrol.h
+++ b/src/vinylcontrol/vinylcontrol.h
@@ -68,7 +68,7 @@ class VinylControl : public QObject {
     // When the user has pressed the "reverse" button.
     ControlProxy* reverseButton;
     parented_ptr<ControlProxy> m_passthroughEnabled;
-    parented_ptr<ControlProxy> scratchPositionEnabled;
+    parented_ptr<ControlProxy> m_scratchPositionEnabled;
 
     // The lead-in time...
     int m_iLeadInTime;

--- a/src/vinylcontrol/vinylcontrol.h
+++ b/src/vinylcontrol/vinylcontrol.h
@@ -3,6 +3,7 @@
 #include <QString>
 
 #include "preferences/usersettings.h"
+#include "util/parented_ptr.h"
 #include "util/types.h"
 
 class PollingControlProxy;
@@ -66,7 +67,7 @@ class VinylControl : public QObject {
     ControlProxy* signalenabled;
     // When the user has pressed the "reverse" button.
     ControlProxy* reverseButton;
-    PollingControlProxy* passthroughEnabled;
+    parented_ptr<ControlProxy> passthroughEnabled;
 
     // The lead-in time...
     int m_iLeadInTime;

--- a/src/vinylcontrol/vinylcontrol.h
+++ b/src/vinylcontrol/vinylcontrol.h
@@ -68,6 +68,7 @@ class VinylControl : public QObject {
     // When the user has pressed the "reverse" button.
     ControlProxy* reverseButton;
     parented_ptr<ControlProxy> passthroughEnabled;
+    parented_ptr<ControlProxy> scratchPositionEnabled;
 
     // The lead-in time...
     int m_iLeadInTime;

--- a/src/vinylcontrol/vinylcontrol.h
+++ b/src/vinylcontrol/vinylcontrol.h
@@ -2,9 +2,10 @@
 
 #include <QString>
 
-#include "util/types.h"
 #include "preferences/usersettings.h"
+#include "util/types.h"
 
+class PollingControlProxy;
 class ControlProxy;
 struct VinylSignalQualityReport;
 
@@ -65,7 +66,7 @@ class VinylControl : public QObject {
     ControlProxy* signalenabled;
     // When the user has pressed the "reverse" button.
     ControlProxy* reverseButton;
-    ControlProxy* passthroughEnabled;
+    PollingControlProxy* passthroughEnabled;
 
     // The lead-in time...
     int m_iLeadInTime;

--- a/src/vinylcontrol/vinylcontrol.h
+++ b/src/vinylcontrol/vinylcontrol.h
@@ -65,6 +65,7 @@ class VinylControl : public QObject {
     ControlProxy* signalenabled;
     // When the user has pressed the "reverse" button.
     ControlProxy* reverseButton;
+    ControlProxy* passthroughEnabled;
 
     // The lead-in time...
     int m_iLeadInTime;

--- a/src/vinylcontrol/vinylcontrolxwax.cpp
+++ b/src/vinylcontrol/vinylcontrolxwax.cpp
@@ -673,7 +673,7 @@ double VinylControlXwax::calcDeltaRelativeDriftAmount(double deltaFilePos) {
     // when passthrough is enabled or is playing in reverse
     if (fabs(m_deltaRelativeDriftAmount) > 1.5 ||
             fabs(deltaFilePos) > 0.03 || // TODO: thresholds to adjust probably
-            m_passthroughEnabled->get() || reverseButton->toBool() ||
+            m_passthroughEnabled->toBool() || reverseButton->toBool() ||
             scratchPositionEnabled->toBool()) {
         m_relativedDriftAmtMem = m_dDriftAmt;
     }

--- a/src/vinylcontrol/vinylcontrolxwax.cpp
+++ b/src/vinylcontrol/vinylcontrolxwax.cpp
@@ -673,7 +673,7 @@ double VinylControlXwax::calcDeltaRelativeDriftAmount(double deltaFilePos) {
     // when passthrough is enabled or is playing in reverse
     if (fabs(m_deltaRelativeDriftAmount) > 1.5 ||
             fabs(deltaFilePos) > 0.03 || // TODO: thresholds to adjust probably
-            passthroughEnabled->toBool() || reverseButton->toBool() ||
+            m_passthroughEnabled->get() || reverseButton->toBool() ||
             scratchPositionEnabled->toBool()) {
         m_relativedDriftAmtMem = m_dDriftAmt;
     }

--- a/src/vinylcontrol/vinylcontrolxwax.cpp
+++ b/src/vinylcontrol/vinylcontrolxwax.cpp
@@ -63,7 +63,7 @@ VinylControlXwax::VinylControlXwax(UserSettingsPointer pConfig, const QString& g
           m_dLastTrackSelectPos(0.0),
           m_dCurTrackSelectPos(0.0),
           m_dDriftAmt(0.0),
-          m_relativedDriftAmtMem(0.0),
+          m_relativeDriftAmtMem(0.0),
           m_deltaRelativeDriftAmount(0.0),
           m_dUiUpdateTime(-1.0) {
     // TODO(rryan): Should probably live in VinylControlManager since it's not
@@ -524,14 +524,14 @@ void VinylControlXwax::analyzeSamples(CSAMPLE* pSamples, size_t nFrames) {
             // Calculate how much the vinyl's position has drifted from it's timecode and compensate for it.
             // (This is caused by the manufacturing process of the vinyl.)
             if (m_iVCMode == MIXXX_VCMODE_ABSOLUTE &&
-                    fabs(m_dDriftAmt) > 0.03 && fabs(m_dDriftAmt) < 5.0) {
+                    std::fabs(m_dDriftAmt) > 0.03 && std::fabs(m_dDriftAmt) < 5.0) {
                 dDriftControl = m_dDriftAmt * .01;
             } else {
                 // Apply relative drift control
                 if (m_iVCMode == MIXXX_VCMODE_RELATIVE) {
-                    if (fabs(m_deltaRelativeDriftAmount) > 0.006 &&
-                            fabs(m_deltaRelativeDriftAmount) < 1.0 &&
-                            fabs(m_deltaFilePos) < 0.03) {
+                    if (std::fabs(m_deltaRelativeDriftAmount) > 0.006 &&
+                            std::fabs(m_deltaRelativeDriftAmount) < 1.0 &&
+                            std::fabs(m_deltaFilePos) < 0.03) {
                         dDriftControl = m_deltaRelativeDriftAmount * 0.3;
                     }
                 } else {
@@ -671,14 +671,14 @@ void VinylControlXwax::analyzeSamples(CSAMPLE* pSamples, size_t nFrames) {
 double VinylControlXwax::calcDeltaRelativeDriftAmount(double deltaFilePos) {
     // Reset m_relativeDriftAmtMem in case of needle drop, file position change (hotcue, loop etc.),
     // when passthrough is enabled or is playing in reverse
-    if (fabs(m_deltaRelativeDriftAmount) > 1.5 ||
-            fabs(deltaFilePos) > 0.03 || // TODO: thresholds to adjust probably
+    if (std::fabs(m_deltaRelativeDriftAmount) > 1.5 ||
+            std::fabs(deltaFilePos) > 0.03 || // TODO: thresholds to adjust probably
             m_passthroughEnabled->toBool() || reverseButton->toBool() ||
-            scratchPositionEnabled->toBool()) {
-        m_relativedDriftAmtMem = m_dDriftAmt;
+            m_scratchPositionEnabled->toBool()) {
+        m_relativeDriftAmtMem = m_dDriftAmt;
     }
 
-    return m_dDriftAmt - m_relativedDriftAmtMem;
+    return m_dDriftAmt - m_relativeDriftAmtMem;
 }
 
 void VinylControlXwax::enableRecordEndMode() {

--- a/src/vinylcontrol/vinylcontrolxwax.cpp
+++ b/src/vinylcontrol/vinylcontrolxwax.cpp
@@ -63,7 +63,7 @@ VinylControlXwax::VinylControlXwax(UserSettingsPointer pConfig, const QString& g
           m_dLastTrackSelectPos(0.0),
           m_dCurTrackSelectPos(0.0),
           m_dDriftAmt(0.0),
-          m_relativeDriftAmtMem(0.0),
+          m_initialRelativeDriftAmt(0.0),
           m_deltaRelativeDriftAmount(0.0),
           m_dUiUpdateTime(-1.0) {
     // TODO(rryan): Should probably live in VinylControlManager since it's not
@@ -675,10 +675,10 @@ double VinylControlXwax::calcDeltaRelativeDriftAmount(double deltaFilePos) {
             std::fabs(deltaFilePos) > 0.03 || // TODO: thresholds to adjust probably
             m_passthroughEnabled->toBool() || reverseButton->toBool() ||
             m_scratchPositionEnabled->toBool()) {
-        m_relativeDriftAmtMem = m_dDriftAmt;
+        m_initialRelativeDriftAmt = m_dDriftAmt;
     }
 
-    return m_dDriftAmt - m_relativeDriftAmtMem;
+    return m_dDriftAmt - m_initialRelativeDriftAmt;
 }
 
 void VinylControlXwax::enableRecordEndMode() {

--- a/src/vinylcontrol/vinylcontrolxwax.cpp
+++ b/src/vinylcontrol/vinylcontrolxwax.cpp
@@ -673,8 +673,8 @@ double VinylControlXwax::calcDeltaRelativeDriftAmount(double deltaFilePos) {
     // when passthrough is enabled or is playing in reverse
     if (std::fabs(m_deltaRelativeDriftAmount) > 1.5 ||
             std::fabs(deltaFilePos) > 0.03 || // TODO: thresholds to adjust probably
-            m_passthroughEnabled->toBool() || reverseButton->toBool() ||
-            m_scratchPositionEnabled->toBool()) {
+            m_passthroughEnabled.toBool() || reverseButton->toBool() ||
+            m_scratchPositionEnabled.toBool()) {
         m_initialRelativeDriftAmt = m_dDriftAmt;
     }
 

--- a/src/vinylcontrol/vinylcontrolxwax.cpp
+++ b/src/vinylcontrol/vinylcontrolxwax.cpp
@@ -46,6 +46,7 @@ VinylControlXwax::VinylControlXwax(UserSettingsPointer pConfig, const QString& g
           m_iVCMode(static_cast<int>(mode->get())),
           m_iOldVCMode(MIXXX_VCMODE_ABSOLUTE),
           m_dOldFilePos(0.0),
+          m_deltaFilePos(0.0),
           m_dOldDuration(0.0),
           m_dOldDurationInaccurate(-1.0),
           m_bWasReversed(false),
@@ -64,7 +65,6 @@ VinylControlXwax::VinylControlXwax(UserSettingsPointer pConfig, const QString& g
           m_dDriftAmt(0.0),
           m_relativedDriftAmtMem(0.0),
           m_deltaRelativeDriftAmount(0.0),
-          m_deltaFilePos(0.0),
           m_dUiUpdateTime(-1.0) {
     // TODO(rryan): Should probably live in VinylControlManager since it's not
     // specific to a VC deck.

--- a/src/vinylcontrol/vinylcontrolxwax.cpp
+++ b/src/vinylcontrol/vinylcontrolxwax.cpp
@@ -672,7 +672,7 @@ double VinylControlXwax::calcDeltaRelativeDriftAmount(double deltaFilePos) {
     // Reset m_relativeDriftAmtMem in case of needle drop, file position change (hotcue, loop etc.),
     // when passthrough is enabled or is playing in reverse
     if (fabs(m_deltaRelativeDriftAmount) > 1.5 || fabs(deltaFilePos) > 0.03 ||  // TODO: thresholds to adjust probably
-        passthroughEnabled->toBool() || reverseButton->toBool()) {
+        passthroughEnabled->toBool() || reverseButton->toBool() || scratchPositionEnabled->toBool()) {
         m_relativedDriftAmtMem = m_dDriftAmt;
     }
 

--- a/src/vinylcontrol/vinylcontrolxwax.cpp
+++ b/src/vinylcontrol/vinylcontrolxwax.cpp
@@ -530,8 +530,8 @@ void VinylControlXwax::analyzeSamples(CSAMPLE* pSamples, size_t nFrames) {
                 // Apply relative drift control
                 if (m_iVCMode == MIXXX_VCMODE_RELATIVE) {
                     if (fabs(m_deltaRelativeDriftAmount) > 0.006 &&
-                        fabs(m_deltaRelativeDriftAmount) < 1.0 &&
-                        fabs(m_deltaFilePos) < 0.03) {
+                            fabs(m_deltaRelativeDriftAmount) < 1.0 &&
+                            fabs(m_deltaFilePos) < 0.03) {
                         dDriftControl = m_deltaRelativeDriftAmount * 0.3;
                     }
                 } else {
@@ -671,8 +671,10 @@ void VinylControlXwax::analyzeSamples(CSAMPLE* pSamples, size_t nFrames) {
 double VinylControlXwax::calcDeltaRelativeDriftAmount(double deltaFilePos) {
     // Reset m_relativeDriftAmtMem in case of needle drop, file position change (hotcue, loop etc.),
     // when passthrough is enabled or is playing in reverse
-    if (fabs(m_deltaRelativeDriftAmount) > 1.5 || fabs(deltaFilePos) > 0.03 ||  // TODO: thresholds to adjust probably
-        passthroughEnabled->toBool() || reverseButton->toBool() || scratchPositionEnabled->toBool()) {
+    if (fabs(m_deltaRelativeDriftAmount) > 1.5 ||
+            fabs(deltaFilePos) > 0.03 || // TODO: thresholds to adjust probably
+            passthroughEnabled->toBool() || reverseButton->toBool() ||
+            scratchPositionEnabled->toBool()) {
         m_relativedDriftAmtMem = m_dDriftAmt;
     }
 

--- a/src/vinylcontrol/vinylcontrolxwax.cpp
+++ b/src/vinylcontrol/vinylcontrolxwax.cpp
@@ -582,7 +582,7 @@ void VinylControlXwax::analyzeSamples(CSAMPLE* pSamples, size_t nFrames) {
             averagePitch = dVinylPitch;
         }
 
-        m_pVCRate->set(averagePitch + dDriftControl);
+        m_pVCRate->set(dVinylPitch + dDriftControl);
         if (uiUpdateTime(filePosition)) {
             double true_pitch = averagePitch + dDriftControl;
             double pitch_difference = true_pitch - m_dDisplayPitch;

--- a/src/vinylcontrol/vinylcontrolxwax.cpp
+++ b/src/vinylcontrol/vinylcontrolxwax.cpp
@@ -516,7 +516,7 @@ void VinylControlXwax::analyzeSamples(CSAMPLE* pSamples, size_t nFrames) {
             // Calculate how much the vinyl's position has drifted from it's timecode and compensate for it.
             // (This is caused by the manufacturing process of the vinyl.)
             if (m_iVCMode == MIXXX_VCMODE_ABSOLUTE &&
-                    fabs(m_dDriftAmt) > 0.1 && fabs(m_dDriftAmt) < 5.0) {
+                    fabs(m_dDriftAmt) > 0.03 && fabs(m_dDriftAmt) < 5.0) {
                 dDriftControl = m_dDriftAmt * .01;
             } else {
                 dDriftControl = 0.0;

--- a/src/vinylcontrol/vinylcontrolxwax.h
+++ b/src/vinylcontrol/vinylcontrolxwax.h
@@ -138,7 +138,7 @@ class VinylControlXwax : public VinylControl {
     // The drift between the vinyl position and the file position from the most
     // recent run of analyzeSamples.
     double m_dDriftAmt;
-    double m_relativedDriftAmtMem;
+    double m_relativeDriftAmtMem;
     double m_deltaRelativeDriftAmount;
 
     // Records the time of the last UI update. Used to prevent hammering the GUI

--- a/src/vinylcontrol/vinylcontrolxwax.h
+++ b/src/vinylcontrol/vinylcontrolxwax.h
@@ -138,7 +138,7 @@ class VinylControlXwax : public VinylControl {
     // The drift between the vinyl position and the file position from the most
     // recent run of analyzeSamples.
     double m_dDriftAmt;
-    double m_relativeDriftAmtMem;
+    double m_initialRelativeDriftAmt;
     double m_deltaRelativeDriftAmount;
 
     // Records the time of the last UI update. Used to prevent hammering the GUI

--- a/src/vinylcontrol/vinylcontrolxwax.h
+++ b/src/vinylcontrol/vinylcontrolxwax.h
@@ -43,7 +43,7 @@ class VinylControlXwax : public VinylControl {
     void doTrackSelection(bool valid_pos, double pitch, double position);
     void resetSteadyPitch(double pitch, double time);
     double checkSteadyPitch(double pitch, double time);
-    void checkDeltaRelativeDriftAmount(double filePosition);
+    double calcDeltaRelativeDriftAmount(double deltaFilePosition);
     void enableRecordEndMode();
     void disableRecordEndMode();
     void enableConstantMode();
@@ -139,7 +139,6 @@ class VinylControlXwax : public VinylControl {
     // recent run of analyzeSamples.
     double m_dDriftAmt;
     double m_relativedDriftAmtMem;
-    bool m_relativedDriftAmtSet;
     double m_deltaRelativeDriftAmount;
 
     // Records the time of the last UI update. Used to prevent hammering the GUI

--- a/src/vinylcontrol/vinylcontrolxwax.h
+++ b/src/vinylcontrol/vinylcontrolxwax.h
@@ -43,6 +43,7 @@ class VinylControlXwax : public VinylControl {
     void doTrackSelection(bool valid_pos, double pitch, double position);
     void resetSteadyPitch(double pitch, double time);
     double checkSteadyPitch(double pitch, double time);
+    void checkDeltaRelativeDriftAmount(double filePosition);
     void enableRecordEndMode();
     void disableRecordEndMode();
     void enableConstantMode();
@@ -87,6 +88,8 @@ class VinylControlXwax : public VinylControl {
 
     // The file position from the last run of analyzeSamples.
     double m_dOldFilePos;
+    // The delta file position in relative mode
+    double m_deltaFilePos;
 
     // The loaded track duration from the last run of analyzeSamples.
     double m_dOldDuration;
@@ -135,6 +138,9 @@ class VinylControlXwax : public VinylControl {
     // The drift between the vinyl position and the file position from the most
     // recent run of analyzeSamples.
     double m_dDriftAmt;
+    double m_relativedDriftAmtMem;
+    bool m_relativedDriftAmtSet;
+    double m_deltaRelativeDriftAmount;
 
     // Records the time of the last UI update. Used to prevent hammering the GUI
     // with updates.


### PR DESCRIPTION
# Goal
This PR aims at reducing the sticker drift, especially in relative mode.

# Approach
In relative mode, we keep track of the absolute vinyl position and compute the drift amount delta to progressively change the VC Rate speed via the existing `dDriftControl` property, until the drift is back to 0 (or close to 0 at least).
This `m_relativedDriftAmtMem` variable is reset in case of a needle drop, a file position change (by using cue points, loops, mouse click etc.), if it's playing in reverse, if passthrough is enabled or scratch position is enabled (via waveform scratch for instance).

# How to test
- Using Serato vinyls in Relative mode, try different scratching patterns and ensure the sticker drift is not increasing.

# Related issues
- https://github.com/mixxxdj/mixxx/issues/8944
- https://github.com/mixxxdj/mixxx/issues/8927

Feedback is very welcome!