### PR TITLE
Raise macOS target version to 11 (Qt6.5 requirement).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,8 +197,8 @@ elseif(APPLE)
       set(CMAKE_SYSTEM_PROCESSOR arm64 CACHE STRING "The target system processor")
     else()
       if(QT6)
-        # Minimum macOS version supported by Qt 6
-        set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15 CACHE STRING "Minimum macOS version the build will be able to run on")
+        # Minimum macOS version supported by Qt 6.5
+        set(CMAKE_OSX_DEPLOYMENT_TARGET 11.0 CACHE STRING "Minimum macOS version the build will be able to run on")
       else()
         # Minimum macOS version supported by Qt 5.12
         set(CMAKE_OSX_DEPLOYMENT_TARGET 10.12 CACHE STRING "Minimum macOS version the build will be able to run on")


### PR DESCRIPTION
This fixes a linker warning: 
` ... was built for newer 'macOS' version (11.0) than being linked (10.15)`

Our vcpkg environment is at macOS 11 already becaus of this requirement.