### PR TITLE
Fix pitch bend buttons and rate/volume knob on Hercules DJ Console Mk1

### DIFF
--- a/res/controllers/Hercules DJ Console Mk1.hid.xml
+++ b/res/controllers/Hercules DJ Console Mk1.hid.xml
@@ -7,6 +7,23 @@
         <forums>http://www.mixxx.org/forums/viewtopic.php?f=7&amp;t=4081</forums>
         <manual>hercules_dj_console_mk1</manual>
     </info>
+    <settings>
+        <group label="Backwards Compatibility">
+            <row orientation="vertical">
+                <option
+                    variable="pitchBendAsJogWheel"
+                    type="boolean"
+                    default="false"
+                    label="Use the pitch bend buttons as jog wheels">
+                    <description>
+                      This will change the pitch bend buttons to behave like the
+                      jog wheels, scratching when the track is paused or seeking
+                      when the track is playing.
+                    </description>
+                </option>
+            </row>
+        </group>
+    </settings>
     <controller id="Hercules DJ Console Mk1 HID">
         <scriptfiles>
             <file filename="Hercules-DJ-Console-Mk1-hid-scripts.js" functionprefix="HerculesMk1Hid"/>

--- a/res/controllers/Hercules DJ Console Mk1.hid.xml
+++ b/res/controllers/Hercules DJ Console Mk1.hid.xml
@@ -21,6 +21,16 @@
                       when the track is playing.
                     </description>
                 </option>
+                <option
+                    variable="gainAsTempo"
+                    type="boolean"
+                    default="false"
+                    label="Use the gain encoder for setting the tempo">
+                    <description>
+                      This will change the gain encoder to modify the tempo
+                      instead.
+                    </description>
+                </option>
             </row>
         </group>
     </settings>

--- a/res/controllers/Hercules-DJ-Console-Mk1-hid-scripts.js
+++ b/res/controllers/Hercules-DJ-Console-Mk1-hid-scripts.js
@@ -84,20 +84,26 @@ HerculesMk1Hid.init = function() {
     //
 
     c.capture("pitchbend_down", "all", function(g, e, v) {
-        if (engine.getValue(g, "play") == 0) {
-            engine.setValue(g, "back", v > 0 ? 1 : 0);
-        }
-        else if (v > 0) {
-            engine.setValue(g, "jog", -3);
+        if (engine.getSetting("pitchBendAsJogWheel")) {
+            if (!engine.getValue(g, "play")) {
+                engine.setValue(g, "back", v > 0 ? 1 : 0);
+            } else if (v > 0) {
+                engine.setValue(g, "jog", -3);
+            }
+        } else {
+            engine.setParameter(g, "pitch_down", v > 0);
         }
     });
 
     c.capture("pitchbend_up", "all", function(g, e, v) {
-        if (engine.getValue(g, "play") == 0) {
-            engine.setValue(g, "fwd", v > 0 ? 1 : 0);
-        }
-        else if (v > 0) {
-            engine.setValue(g, "jog", 3);
+        if (engine.getSetting("pitchBendAsJogWheel")) {
+            if (!engine.getValue(g, "play")) {
+                engine.setValue(g, "fwd", v > 0 ? 1 : 0);
+            } else if (v > 0) {
+                engine.setValue(g, "jog", 3);
+            }
+        } else {
+            engine.setParameter(g, "pitch_up", v > 0);
         }
     });
 

--- a/res/controllers/Hercules-DJ-Console-Mk1-hid-scripts.js
+++ b/res/controllers/Hercules-DJ-Console-Mk1-hid-scripts.js
@@ -151,13 +151,18 @@ HerculesMk1Hid.init = function() {
     */
 
     //
-    // tempo encoder
+    // volume/tempo encoder
     //
 
-    c.capture("rate", "all", function(g, e, v, ctrl) {
-        var rate = engine.getValue(g, "rate") + ctrl.relative / c.tempo_scaling;
-        if (rate > 1) rate = 1; else if (rate < -1) rate = -1;
-        engine.setValue(g, e, rate);
+    c.capture("pregain", "all", function(g, e, v, ctrl) {
+        if (engine.getSetting("gainAsTempo")) {
+            let rate = engine.getValue(g, "rate") + ctrl.relative / c.tempo_scaling;
+            if (rate > 1) { rate = 1; } else if (rate < -1) { rate = -1; }
+            engine.setValue(g, "rate", rate);
+        } else {
+            const gain = engine.getValue(g, e) + ctrl.relative / 10;
+            engine.setValue(g, e, gain);
+        }
     });
 
     //
@@ -390,7 +395,7 @@ HerculesMk1Hid.define_hid_format = function() {
     c.add_control(pid, "filterMid", "[Channel1]", "fader", 9, 0xff)
     c.add_control(pid, "filterHigh", "[Channel1]", "fader", 10, 0xff)
     c.add_control(pid, "volume", "[Channel1]", "fader", 12, 0xff)
-    c.add_control(pid, "rate", "[Channel1]", "encoder", 14, 0xff)
+    c.add_control(pid, "pregain", "[Channel1]", "encoder", 14, 0xff);
     c.add_control(pid, "jog", "[Channel1]", "encoder", 16, 0xff)
     c.add_control(pid, "layer_select", "[Channel1]", "button", 1, 0x40)
     c.add_control(pid, "layer_btn1", "[Channel1]", "button", 2, 0x40)
@@ -413,7 +418,7 @@ HerculesMk1Hid.define_hid_format = function() {
     c.add_control(pid, "filterMid", "[Channel2]", "fader", 6, 0xff)
     c.add_control(pid, "filterHigh", "[Channel2]", "fader", 7, 0xff)
     c.add_control(pid, "volume", "[Channel2]", "fader", 13, 0xff)
-    c.add_control(pid, "rate", "[Channel2]", "encoder", 15, 0xff)
+    c.add_control(pid, "pregain", "[Channel2]", "encoder", 15, 0xff);
     c.add_control(pid, "jog", "[Channel2]", "encoder", 17, 0xff)
     c.add_control(pid, "layer_select", "[Channel2]", "button", 1, 0x01)
     c.add_control(pid, "layer_btn1", "[Channel2]", "button", 2, 0x80)

--- a/res/controllers/Hercules-DJ-Console-Mk1-hid-scripts.js
+++ b/res/controllers/Hercules-DJ-Console-Mk1-hid-scripts.js
@@ -91,7 +91,7 @@ HerculesMk1Hid.init = function() {
                 engine.setValue(g, "jog", -3);
             }
         } else {
-            engine.setParameter(g, "pitch_down", v > 0);
+            engine.setParameter(g, "pitch_down", v > 0 ? 1 : 0);
         }
     });
 
@@ -103,7 +103,7 @@ HerculesMk1Hid.init = function() {
                 engine.setValue(g, "jog", 3);
             }
         } else {
-            engine.setParameter(g, "pitch_up", v > 0);
+            engine.setParameter(g, "pitch_up", v > 0 ? 1 : 0);
         }
     });
 


### PR DESCRIPTION
Previously the pitch bend buttons were mapped the same way as the jog wheels, however this is identical to the jog wheels right below them and felt a bit useless. This patch maps the buttons to their original purpose, bumping the pitch up or down, and adds a setting that allows reverting to the previous behavior for backwards compatibility.

I only have one of these temporarily and won't be able to do long term maintenance on this controller, but if there are any other changes that need to be made or tested I have one for the next day or two.