### PR TITLE
Fix LED on M-Vave SMC-Mixer

### DIFF
--- a/res/controllers/MVave-SMC-Mixer-scripts.js
+++ b/res/controllers/MVave-SMC-Mixer-scripts.js
@@ -96,7 +96,7 @@ var SMCMixer;
             // anything less than the tolerance window, we consider them the
             // same. This way we're not constantly blinking the soft takeover
             // indicator because we didn't get the control matched up exactly.
-            this.toleranceWindow = 0.001;
+            this.toleranceWindow = 0.03;
         }
         input(_channel, _control, value, _status, _group) {
             const receivingFirstValue = this.hardwarePos === undefined;
@@ -105,7 +105,17 @@ var SMCMixer;
             if (receivingFirstValue) {
                 this.firstValueReceived = true;
                 this.connect();
+            }
+        }
+        connect() {
+            if (this.firstValueReceived && !this.relative && this.softTakeover) {
                 engine.softTakeover(this.group, this.inKey, true);
+            }
+            if (undefined !== this.group &&
+                undefined !== this.outKey &&
+                undefined !== this.output &&
+                typeof this.output === "function") {
+                this.connections[0] = engine.makeConnection(this.group, this.outKey, this.output.bind(this));
             }
         }
         output(value) {


### PR DESCRIPTION
Apparently we somehow broke the LED code on the M-Vave SMC-Mixer during the review the other day and I didn't notice.

The `component.Pot` that we override has itself overridden the default connect method to remove connecting the output. This seems like it might be a bug itself that should be fixed, as pots may also have LED ring lights around them or what not to indicate their position, but it's unclear to me if this is deliberate or not so I filed this patch instead of a bug report against the midi components library. I can also fix it there if you think that's best.