### PR TITLE
Add Browse FileSytem ChildItems Limit

### DIFF
--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -469,8 +469,20 @@ std::vector<std::unique_ptr<TreeItem>> BrowseFeature::getChildDirectoryItems(
     QFileInfoList all = dirAccess.info().toQDir().entryInfoList(
             QDir::Dirs | QDir::NoDotAndDotDot);
 
+    int count = 0;
+
     // loop through all the item and construct the children
     foreach (QFileInfo one, all) {
+        if (m_pConfig->getValue(
+                    ConfigKey("[Library]",
+                            "BrowseFilesystemLimitChildItemsEnabled"),
+                    true)) {
+            if (count >= m_pConfig->getValue<int>(ConfigKey("[Library]",
+                                 "BrowseFilesystemLimitChildItemsNumber"))) {
+                // Limit -> Stop adding items
+                break;
+            }
+        }
         // Skip folders that end with .app on OS X
 #if defined(__APPLE__)
         if (one.isDir() && one.fileName().endsWith(".app"))
@@ -482,6 +494,7 @@ std::vector<std::unique_ptr<TreeItem>> BrowseFeature::getChildDirectoryItems(
         items.push_back(std::make_unique<TreeItem>(
                 one.fileName(),
                 QVariant(one.absoluteFilePath() + QStringLiteral("/"))));
+        count++;
     }
 
     return items;

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -18,6 +18,9 @@
 #include "widget/wlibrarysidebar.h"
 #include "widget/wlibrarytextbrowser.h"
 
+bool s_browseLimitChildItemsEnabled;
+int s_browseLimitChildItemsNumber;
+
 namespace {
 
 const QString kViewName = QStringLiteral("BROWSEHOME");
@@ -147,6 +150,14 @@ BrowseFeature::BrowseFeature(
 
     // initialize the model
     m_pSidebarModel->setRootItem(std::move(pRootItem));
+
+    s_browseLimitChildItemsEnabled = pConfig->getValue<bool>(
+            ConfigKey("[Library]",
+                    "BrowseFilesystemLimitChildItemsEnabled"));
+    s_browseLimitChildItemsNumber = pConfig->getValue<int>(
+            ConfigKey("[Library]", "BrowseFilesystemLimitChildItemsNumber"));
+    qDebug() << "s_browseLimitChildItemsEnabled: " << s_browseLimitChildItemsEnabled;
+    qDebug() << "s_browseLimitChildItemsNumber: " << s_browseLimitChildItemsNumber;
 }
 
 BrowseFeature::~BrowseFeature() {
@@ -470,15 +481,25 @@ std::vector<std::unique_ptr<TreeItem>> BrowseFeature::getChildDirectoryItems(
             QDir::Dirs | QDir::NoDotAndDotDot);
 
     int count = 0;
+    qDebug() << "s_browseLimitChildItemsEnabled: " << s_browseLimitChildItemsEnabled;
+    qDebug() << "s_browseLimitChildItemsNumber: " << s_browseLimitChildItemsNumber;
 
     // loop through all the item and construct the children
-    foreach (QFileInfo one, all) {
-        if (m_pConfig->getValue(
-                    ConfigKey("[Library]",
-                            "BrowseFilesystemLimitChildItemsEnabled"),
-                    true)) {
-            if (count >= m_pConfig->getValue<int>(ConfigKey("[Library]",
-                                 "BrowseFilesystemLimitChildItemsNumber"))) {
+    // foreach (QFileInfo one, all) {
+
+    // if (m_pConfig->getValue(
+    //             ConfigKey("[Library]",
+    //                     "BrowseFilesystemLimitChildItemsEnabled"),
+    //             true)) {
+    //     if (count >= m_pConfig->getValue<int>(ConfigKey("[Library]",
+    //                          "BrowseFilesystemLimitChildItemsNumber"))) {
+    //         // Limit -> Stop adding items
+    //         break;
+    //     }
+    // }
+    for (const QFileInfo& one : all) {
+        if (s_browseLimitChildItemsEnabled) {
+            if (count >= s_browseLimitChildItemsNumber) {
                 // Limit -> Stop adding items
                 break;
             }

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -150,14 +150,13 @@ BrowseFeature::BrowseFeature(
 
     // initialize the model
     m_pSidebarModel->setRootItem(std::move(pRootItem));
-
+    // Vars to limit the created childitems in tree,
+    // for slow pc's or external sources withslow connection
     s_browseLimitChildItemsEnabled = pConfig->getValue<bool>(
             ConfigKey("[Library]",
                     "BrowseFilesystemLimitChildItemsEnabled"));
     s_browseLimitChildItemsNumber = pConfig->getValue<int>(
             ConfigKey("[Library]", "BrowseFilesystemLimitChildItemsNumber"));
-    qDebug() << "s_browseLimitChildItemsEnabled: " << s_browseLimitChildItemsEnabled;
-    qDebug() << "s_browseLimitChildItemsNumber: " << s_browseLimitChildItemsNumber;
 }
 
 BrowseFeature::~BrowseFeature() {
@@ -469,7 +468,6 @@ void BrowseFeature::onLazyChildExpandation(const QModelIndex& index) {
 std::vector<std::unique_ptr<TreeItem>> BrowseFeature::getChildDirectoryItems(
         const QString& path) const {
     std::vector<std::unique_ptr<TreeItem>> items;
-    // line to start CI
     if (path.isEmpty()) {
         return items;
     }
@@ -481,22 +479,10 @@ std::vector<std::unique_ptr<TreeItem>> BrowseFeature::getChildDirectoryItems(
             QDir::Dirs | QDir::NoDotAndDotDot);
 
     int count = 0;
-    qDebug() << "s_browseLimitChildItemsEnabled: " << s_browseLimitChildItemsEnabled;
-    qDebug() << "s_browseLimitChildItemsNumber: " << s_browseLimitChildItemsNumber;
 
     // loop through all the item and construct the children
     // foreach (QFileInfo one, all) {
 
-    // if (m_pConfig->getValue(
-    //             ConfigKey("[Library]",
-    //                     "BrowseFilesystemLimitChildItemsEnabled"),
-    //             true)) {
-    //     if (count >= m_pConfig->getValue<int>(ConfigKey("[Library]",
-    //                          "BrowseFilesystemLimitChildItemsNumber"))) {
-    //         // Limit -> Stop adding items
-    //         break;
-    //     }
-    // }
     for (const QFileInfo& one : all) {
         if (s_browseLimitChildItemsEnabled) {
             if (count >= s_browseLimitChildItemsNumber) {

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -458,7 +458,7 @@ void BrowseFeature::onLazyChildExpandation(const QModelIndex& index) {
 std::vector<std::unique_ptr<TreeItem>> BrowseFeature::getChildDirectoryItems(
         const QString& path) const {
     std::vector<std::unique_ptr<TreeItem>> items;
-
+    // line to start CI
     if (path.isEmpty()) {
         return items;
     }

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -271,7 +271,7 @@ void DlgPrefLibrary::slotResetToDefaults() {
     checkBox_show_itunes->setChecked(true);
     checkBox_show_traktor->setChecked(true);
     checkBox_show_rekordbox->setChecked(true);
-    checkBox_browsefilesystemlimitchilditemsenabled->setChecked(false);
+    checkBox_browsefilesystem_limit_childitems_enabled->setChecked(true);
 }
 
 void DlgPrefLibrary::slotUpdate() {
@@ -341,9 +341,9 @@ void DlgPrefLibrary::slotUpdate() {
         break;
     }
 
-    checkBox_browsefilesystemlimitchilditemsenabled->setChecked(m_pConfig->getValue(
-            ConfigKey("[Library]", "BrowseFilesystemLimitChildItemsEnabled"), false));
-    spinbox_browsefilesystemlimitchilditemsnumber->setValue(m_pConfig->getValue<int>(
+    checkBox_browsefilesystem_limit_childitems_enabled->setChecked(m_pConfig->getValue(
+            ConfigKey("[Library]", "BrowseFilesystemLimitChildItemsEnabled"), true));
+    spinbox_browsefilesystem_limit_childitems_number->setValue(m_pConfig->getValue<int>(
             ConfigKey("[Library]", "BrowseFilesystemLimitChildItemsNumber")));
 
     bool editMetadataSelectedClick = m_pConfig->getValue(
@@ -550,9 +550,9 @@ void DlgPrefLibrary::slotApply() {
             ConfigValue((int)checkBox_show_serato->isChecked()));
 
     m_pConfig->set(ConfigKey("[Library]", "BrowseFilesystemLimitChildItemsEnabled"),
-            ConfigValue((int)checkBox_browsefilesystemlimitchilditemsenabled->isChecked()));
+            ConfigValue((int)checkBox_browsefilesystem_limit_childitems_enabled->isChecked()));
     m_pConfig->set(ConfigKey("[Library]", "BrowseFilesystemLimitChildItemsNumber"),
-            ConfigValue(spinbox_browsefilesystemlimitchilditemsnumber->value()));
+            ConfigValue(spinbox_browsefilesystem_limit_childitems_number->value()));
 
     int coverartfetcherquality_status;
     if (radioButton_cover_art_fetcher_highest->isChecked()) {

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -271,6 +271,7 @@ void DlgPrefLibrary::slotResetToDefaults() {
     checkBox_show_itunes->setChecked(true);
     checkBox_show_traktor->setChecked(true);
     checkBox_show_rekordbox->setChecked(true);
+    checkBox_browsefilesystemlimitchilditemsenabled->setChecked(false);
 }
 
 void DlgPrefLibrary::slotUpdate() {
@@ -339,6 +340,11 @@ void DlgPrefLibrary::slotUpdate() {
         radioButton_cover_art_fetcher_lowest->setChecked(true);
         break;
     }
+
+    checkBox_browsefilesystemlimitchilditemsenabled->setChecked(m_pConfig->getValue(
+            ConfigKey("[Library]", "BrowseFilesystemLimitChildItemsEnabled"), false));
+    spinbox_browsefilesystemlimitchilditemsnumber->setValue(m_pConfig->getValue<int>(
+            ConfigKey("[Library]", "BrowseFilesystemLimitChildItemsNumber")));
 
     bool editMetadataSelectedClick = m_pConfig->getValue(
             kEditMetadataSelectedClickConfigKey,
@@ -542,6 +548,11 @@ void DlgPrefLibrary::slotApply() {
                 ConfigValue((int)checkBox_show_rekordbox->isChecked()));
     m_pConfig->set(ConfigKey("[Library]", "ShowSeratoLibrary"),
             ConfigValue((int)checkBox_show_serato->isChecked()));
+
+    m_pConfig->set(ConfigKey("[Library]", "BrowseFilesystemLimitChildItemsEnabled"),
+            ConfigValue((int)checkBox_browsefilesystemlimitchilditemsenabled->isChecked()));
+    m_pConfig->set(ConfigKey("[Library]", "BrowseFilesystemLimitChildItemsNumber"),
+            ConfigValue(spinbox_browsefilesystemlimitchilditemsnumber->value()));
 
     int coverartfetcherquality_status;
     if (radioButton_cover_art_fetcher_highest->isChecked()) {

--- a/src/preferences/dialog/dlgpreflibrarydlg.ui
+++ b/src/preferences/dialog/dlgpreflibrarydlg.ui
@@ -14,14 +14,12 @@
    <string notr="true">Library Preferences</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-
    <item>
     <widget class="QGroupBox" name="groupBox_MusicDirectories">
      <property name="title">
       <string>Music Directories</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_music_directories">
-
       <item row="0" column="0" rowspan="3">
        <widget class="QListView" name="dirList">
         <property name="editTriggers">
@@ -38,7 +36,6 @@
         </property>
        </widget>
       </item>
-
       <item row="0" column="1">
        <widget class="QPushButton" name="pushButton_add_dir">
         <property name="font">
@@ -52,7 +49,6 @@
         </property>
        </widget>
       </item>
-
       <item row="1" column="1">
        <widget class="QPushButton" name="pushButton_relocate_dir">
         <property name="toolTip">
@@ -63,7 +59,6 @@
         </property>
        </widget>
       </item>
-
       <item row="2" column="1">
        <widget class="QPushButton" name="pushButton_remove_dir">
         <property name="font">
@@ -77,7 +72,6 @@
         </property>
        </widget>
       </item>
-
       <item row="3" column="0" colspan="2">
        <widget class="QCheckBox" name="checkBox_library_scan">
         <property name="text">
@@ -88,11 +82,9 @@
         </property>
        </widget>
       </item>
-
      </layout>
     </widget>
    </item>
-
    <item>
     <widget class="QGroupBox" name="groupBox_AudioFileFormats">
      <property name="title">
@@ -115,7 +107,6 @@
      </layout>
     </widget>
    </item>
-
    <item>
     <widget class="QGroupBox" name="groupBox_AudioFileTags">
      <property name="title">
@@ -132,7 +123,6 @@
         </property>
        </widget>
       </item>
-
       <item row="1" column="0">
        <widget class="QCheckBox" name="checkBox_serato_metadata_export">
         <property name="toolTip">
@@ -143,7 +133,6 @@
         </property>
        </widget>
       </item>
-
       <item row="2" column="0" colspan="2">
        <widget class="QCheckBox" name="checkBox_use_relative_path">
         <property name="text">
@@ -154,14 +143,12 @@
      </layout>
     </widget>
    </item>
-
    <item>
     <widget class="QGroupBox" name="groupBox_TrackTableView">
      <property name="title">
       <string>Track Table View</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_track_table_view">
-
       <item row="1" column="0" colspan="3">
        <widget class="QCheckBox" name="checkBox_edit_metadata_selected_clicked">
         <property name="text">
@@ -169,18 +156,16 @@
         </property>
        </widget>
       </item>
-
       <item row="2" column="0" colspan="3">
        <widget class="QLabel" name="label_doubeClickAction">
         <property name="text">
          <string>Track Double-Click Action:</string>
         </property>
         <property name="alignment">
-         <set>Qt::AlignLeft|Qt::AlignVCenter</set>
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
         </property>
        </widget>
       </item>
-
       <item row="3" column="0" colspan="3">
        <widget class="QRadioButton" name="radioButton_dbclick_deck">
         <property name="text">
@@ -212,14 +197,13 @@
         </property>
        </widget>
       </item>
-
       <item row="7" column="0">
        <widget class="QLabel" name="label_rowHeight">
         <property name="text">
          <string>Library Row Height:</string>
         </property>
         <property name="alignment">
-         <set>Qt::AlignLeft|Qt::AlignVCenter</set>
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
         </property>
        </widget>
       </item>
@@ -239,14 +223,13 @@
         </property>
        </widget>
       </item>
-
       <item row="8" column="0">
        <widget class="QLabel" name="label_libraryFont">
         <property name="text">
          <string>Library Font:</string>
         </property>
         <property name="alignment">
-         <set>Qt::AlignLeft|Qt::AlignVCenter</set>
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
         </property>
        </widget>
       </item>
@@ -264,21 +247,19 @@
         </property>
        </widget>
       </item>
-
       <item row="9" column="0">
        <widget class="QLabel" name="label_bpm_precision">
         <property name="text">
          <string>BPM display precision:</string>
         </property>
         <property name="alignment">
-         <set>Qt::AlignLeft|Qt::AlignVCenter</set>
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
         </property>
        </widget>
       </item>
       <item row="9" column="1" colspan="2">
        <widget class="QSpinBox" name="spinbox_bpm_precision"/>
       </item>
-
       <item row="10" column="0" colspan="3">
        <widget class="QCheckBox" name="checkbox_played_track_color">
         <property name="text">
@@ -286,25 +267,22 @@
         </property>
        </widget>
       </item>
-
      </layout>
     </widget>
-   </item><!-- Track Table View -->
-
+   </item>
    <item>
     <widget class="QGroupBox" name="groupBox_Search">
      <property name="title">
       <string>Track Search</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_search">
-
       <item row="0" column="0">
        <widget class="QLabel" name="label_searchDebouncingTimeout">
         <property name="text">
          <string>Search-as-you-type timeout:</string>
         </property>
         <property name="alignment">
-         <set>Qt::AlignLeft|Qt::AlignVCenter</set>
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
         </property>
        </widget>
       </item>
@@ -315,7 +293,6 @@
         </property>
        </widget>
       </item>
-
       <item row="1" column="0" colspan="3">
        <widget class="QCheckBox" name="checkBox_enable_search_completions">
         <property name="text">
@@ -323,7 +300,6 @@
         </property>
        </widget>
       </item>
-
       <item row="2" column="0" colspan="3">
        <widget class="QCheckBox" name="checkBox_enable_search_history_shortcuts">
         <property name="text">
@@ -331,14 +307,13 @@
         </property>
        </widget>
       </item>
-
       <item row="3" column="0">
        <widget class="QLabel" name="label_searchBpmFuzzyRange">
         <property name="text">
          <string>Percentage of pitch slider range for 'fuzzy' BPM search:</string>
         </property>
         <property name="alignment">
-         <set>Qt::AlignLeft|Qt::AlignVCenter</set>
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
         </property>
         <property name="buddy">
          <cstring>comboBox_search_bpm_fuzzy_range</cstring>
@@ -358,25 +333,22 @@
         </property>
        </widget>
       </item>
-
      </layout>
     </widget>
-   </item><!-- Search box -->
-
+   </item>
    <item>
     <widget class="QGroupBox" name="groupBox_History">
      <property name="title">
       <string>Session History</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_history">
-
       <item row="1" column="0">
        <widget class="QLabel" name="label_history_track_duplicate_distance">
         <property name="text">
          <string>Track duplicate distance</string>
         </property>
         <property name="alignment">
-         <set>Qt::AlignLeft|Qt::AlignVCenter</set>
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
         </property>
         <property name="wordWrap">
          <bool>true</bool>
@@ -399,7 +371,6 @@
         </property>
        </widget>
       </item>
-
       <item row="2" column="0">
        <widget class="QLabel" name="label_history_cleanup">
         <property name="toolTip">
@@ -409,7 +380,7 @@
          <string>Delete history playlist with less than N tracks</string>
         </property>
         <property name="alignment">
-         <set>Qt::AlignLeft|Qt::AlignVCenter</set>
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
         </property>
        </widget>
       </item>
@@ -426,11 +397,76 @@
         </property>
        </widget>
       </item>
-
      </layout>
     </widget>
-   </item><!-- History -->
-
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_browsefilesystem">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>80</height>
+      </size>
+     </property>
+     <property name="title">
+      <string>Browse Filesystem</string>
+     </property>
+     <widget class="QCheckBox" name="checkBox_browsefilesystemlimitchilditemsenabled">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>40</y>
+        <width>200</width>
+        <height>17</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Limit max Childitems</string>
+      </property>
+      <property name="checked">
+       <bool>true</bool>
+      </property>
+     </widget>
+     <widget class="QLabel" name="checkBox_browsefilesystemlimitchilditemslabel">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>10</y>
+        <width>623</width>
+        <height>26</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>To prevent a long waiting time while Mixxx explores your filesystem, you can limit the Childitems (Subfolders)</string>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+     </widget>
+     <widget class="QSpinBox" name="spinbox_browsefilesystemlimitchilditemsnumber">
+      <property name="geometry">
+       <rect>
+        <x>230</x>
+        <y>40</y>
+        <width>403</width>
+        <height>20</height>
+       </rect>
+      </property>
+      <property name="toolTip">
+       <string>When playing a track again log it to the session history only if more than N other tracks have been played in the meantime</string>
+      </property>
+      <property name="minimum">
+       <number>100</number>
+      </property>
+      <property name="maximum">
+       <number>50000</number>
+      </property>
+      <property name="value">
+       <number>100</number>
+      </property>
+     </widget>
+    </widget>
+   </item>
    <item>
     <widget class="QGroupBox" name="groupBox_external_libraries">
      <property name="title">
@@ -523,7 +559,6 @@
      </layout>
     </widget>
    </item>
-
    <item>
     <widget class="QGroupBox" name="groupBox_cover_art_fetcher">
      <property name="title">
@@ -593,7 +628,6 @@
      </layout>
     </widget>
    </item>
-
    <item>
     <widget class="QGroupBox" name="groupBox_settingsDir">
      <property name="title">

--- a/src/preferences/dialog/dlgpreflibrarydlg.ui
+++ b/src/preferences/dialog/dlgpreflibrarydlg.ui
@@ -411,7 +411,7 @@
      <property name="title">
       <string>Browse Filesystem</string>
      </property>
-     <widget class="QCheckBox" name="checkBox_browsefilesystemlimitchilditemsenabled">
+     <widget class="QCheckBox" name="checkBox_browsefilesystem_limit_childitems_enabled">
       <property name="geometry">
        <rect>
         <x>10</x>
@@ -427,7 +427,7 @@
        <bool>true</bool>
       </property>
      </widget>
-     <widget class="QLabel" name="checkBox_browsefilesystemlimitchilditemslabel">
+     <widget class="QLabel" name="checkBox_browsefilesystem_limit_childitems_label">
       <property name="geometry">
        <rect>
         <x>10</x>
@@ -443,7 +443,7 @@
        <bool>true</bool>
       </property>
      </widget>
-     <widget class="QSpinBox" name="spinbox_browsefilesystemlimitchilditemsnumber">
+     <widget class="QSpinBox" name="spinbox_browsefilesystem_limit_childitems_number">
       <property name="geometry">
        <rect>
         <x>230</x>


### PR DESCRIPTION
This PR adds the possibility to define a max number of childitems that will be added in the Folder-TreeView.
Number can be set between 100 & 50.000. Standard not enabled.

Special for slow PC's or PC's connected to a slow external drive / nas, or users making a mistake causing Mixxx to 'hang"

-> usecase PR #14441 "Opening a directory with a large number of files in the sidebar freezes Mixxx "
