### PR TITLE
fix(controllers): fix crossfader cut on Traktor Kontrol Z1

### DIFF
--- a/res/controllers/Traktor-Kontrol-Z1-scripts.js
+++ b/res/controllers/Traktor-Kontrol-Z1-scripts.js
@@ -5,6 +5,8 @@
 // Author: djantti
 //
 
+// eslint definitions
+/* global controller, HIDController, HIDPacket */
 class TraktorZ1Class {
     constructor() {
         this.controller = new HIDController();

--- a/res/controllers/Traktor-Kontrol-Z1-scripts.js
+++ b/res/controllers/Traktor-Kontrol-Z1-scripts.js
@@ -19,6 +19,7 @@ class TraktorZ1Class {
         this.vuRightConnection = {};
         this.vuMeterThresholds = {"vu-30": (1 / 7), "vu-15": (2 / 7), "vu-6": (3 / 7), "vu-3": (4 / 7), "vu0": (5 / 7), "vu3": (6 / 7), "vu6": (7 / 7)};
 
+        // Calibration data
         this.rawCalibration = {};
         this.calibration = null;
     }
@@ -73,7 +74,7 @@ class TraktorZ1Class {
         this.registerInputScaler(InputReport0x01, "[Channel2]", "volume", 0x19, 0xFFFF, this.parameterHandler.bind(this));
 
         // Crossfader
-        this.registerInputScaler(InputReport0x01, "[Master]", "crossfader", 0x1B, 0xFFFF, this.parameterHandler.bind(this));
+        this.registerInputScaler(InputReport0x01, "[Master]", "crossfader", 0x1B, 0xFFFF, this.crossfaderHandler.bind(this));
 
         this.controller.registerInputPacket(InputReport0x01);
     }
@@ -238,15 +239,16 @@ class TraktorZ1Class {
     }
 
     parameterHandler(field) {
-        let value = field.value / 4095;
+        engine.setParameter(field.group, field.name, field.value / 4095);
+    }
+
+    crossfaderHandler(field) {
         // Crossfader value don't reach boundaries and need to use calibration values
         // Also apply extra safe margins
         const safeMargins = 5;
-        if (field.name === "crossfader") {
-            const min = this.calibration.crossfader.min;
-            const max = this.calibration.crossfader.max;
-            value = script.absoluteLin(field.value, 0, 1, min + safeMargins, max - safeMargins);
-        }
+        const min = this.calibration.crossfader.min;
+        const max = this.calibration.crossfader.max;
+        const value = script.absoluteLin(field.value, 0, 1, min + safeMargins, max - safeMargins);
         engine.setParameter(field.group, field.name, value);
     }
 

--- a/res/controllers/Traktor-Kontrol-Z1-scripts.js
+++ b/res/controllers/Traktor-Kontrol-Z1-scripts.js
@@ -206,7 +206,13 @@ class TraktorZ1Class {
     }
 
     parameterHandler(field) {
-        engine.setParameter(field.group, field.name, field.value / 4095);
+        let value = field.value / 4095;
+        // Crossfader value don't reach boundaries and need safe margins
+        // min: 36 - max: 4083
+        if (field.name === "crossfader") {
+            value = (field.value - 36) / 4047;
+        }
+        engine.setParameter(field.group, field.name, value);
     }
 
     outputHandler(value, group, key) {


### PR DESCRIPTION
# Problem
When the crossfader curve is set to scratching in the settings, the physical crossfader of the Traktor Kontrol Z1 doesn't cut the sound of the corresponding deck.

# Cause
In theory, the crossfader value range is from 0 to 4095, but in practice, it never reaches the boundaries. On my unit, the minimum safe value is 36 (32 at the lowest) and the maximum safe value is 4083 (4087 at the highest).

# Approach
When setting the crossfader parameter value, we should apply those safe "margins" to ensure that the crossfader will always cut the sound.

Update: We now get the crossfader calibration values using `controller.getFeatureReport()` and apply them to the value to set. We also apply extra safe "margins" (5 on a total range of 4096) to compensate the value returned by the hardware, which can fluctuate a little bit on some crossfader movement (it doesn't always reach the calibrated value everytime).

# Steps to reproduce
- Plug the Traktor Kontrol Z1 to the computer
- Open Mixxx
- In the Controllers settings, set the existing Traktor Kontrol Z1 HID mapping
- In the Mixer settings, set the crossfader curve to scratching (slider completely on the right)
- Load and play two songs on decks 1 and 2 respectively
- On the Traktor Kontrol Z1, put the physical crossfader completely on the left
- Notice the song on deck 2 can still be heard
- On the Traktor Kontrol Z1, put the physical crossfader completely on the right
- Notice the song on deck 1 can still be heard

# Linked issue
[https://github.com/mixxxdj/mixxx/issues/14450](https://github.com/mixxxdj/mixxx/issues/14450)