### PR TITLE
Autorecord implementation

### DIFF
--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -430,6 +430,7 @@ void MixxxMainWindow::initialize() {
     if (CmdlineArgs::Instance().getStartAutoDJ()) {
         qDebug("Enabling Auto DJ from CLI flag.");
         ControlObject::set(ConfigKey("[AutoDJ]", "enabled"), 1.0);
+        ControlObject::set(ConfigKey("[Master],recording"), 1.0);
     }
 }
 


### PR DESCRIPTION
Hi,

ADDENUM: I did not realise I should have set the PR to 2.5.0 which my fork is set to. I then changed the base to 2.5.

Here is the initial PR for implementing a function that starts the mixxx recording automatically. The logic behind this is enforcing the record feature in light of so called "[red light fever](https://www.mixinglessons.com/5-steps-to-overcome-red-light-fever/)". My university music professor who is an accomplished guitarist and a trouble shooter for many big name bands described this in his amusing way ... "You are waiting to record in the studio and suddenly you are the most amazing guitar maestro ever !" ... "But the the red light comes and ... yep ... red light fever ... the maestro has departed :(".

I got exactly that the other day when I was doing some brilliant DJ Shadow like scratches with effects. Then I look to see if the record button was on. No it wasn't ! Had I simply forgotten ? Maybe. However the act of manually having to the hit button is not necessary with this auto record feature in order to get round any forgetting but also to avoid red light fever.

Cheers

