### PR TITLE
Add manual link to M-Vave mappings

### DIFF
--- a/res/controllers/MVave-SMC-Mixer.midi.xml
+++ b/res/controllers/MVave-SMC-Mixer.midi.xml
@@ -5,6 +5,7 @@
     <author>Sam Whited</author>
     <description>MIDI mapping for the M-Vave SMC-Mixer.</description>
     <forums>https://mixxx.discourse.group/t/m-wave-sinco-smc-mixer-radio-broadcast-mapping/30366</forums>
+    <manual>mvave_smc_mixer</manual>
     <devices>
       <!--
         This vendor and product ID is shared between multiple controllers and is

--- a/res/controllers/MVave-SMK-25-II.midi.xml
+++ b/res/controllers/MVave-SMK-25-II.midi.xml
@@ -5,6 +5,7 @@
     <author>Sam Whited</author>
     <description>MIDI mapping for the M-Vave SMK-25 II piano keyboard.</description>
     <forums>https://mixxx.discourse.group/t/sinco-m-wave-smk-25-ii/31350</forums>
+    <manual>mvave_smk-25-ii</manual>
     <devices>
       <!--
         This vendor and product ID is shared between multiple controllers and is


### PR DESCRIPTION
Just noticed that some of the mappings link to the manual in the Mixxx interface and added a link for the M-Vave mappings. Sorry I missed this on the initial submission!