### PR TITLE
Overview scale options

### DIFF
--- a/src/library/overviewcache.cpp
+++ b/src/library/overviewcache.cpp
@@ -37,41 +37,7 @@ inline QImage resizeImageSize(const QImage& image, QSize size) {
 OverviewCache::OverviewCache(UserSettingsPointer pConfig,
         mixxx::DbConnectionPoolPtr pDbConnectionPool)
         : m_pConfig(pConfig),
-          m_pDbConnectionPool(std::move(pDbConnectionPool)),
-          m_clearingCache(false),
-          m_stopClearing(false) {
-}
-
-void OverviewCache::onNormalizeOrVisualGainChanged() {
-    // Clear the cache and emit changed signal so OverviewDelegate requests
-    // new pixmaps.
-    // Prevent interferences of repeated calls when Normalize or VisualGainAll
-    // are changed in quick succession.
-    if (m_clearingCache) {
-        m_stopClearing = true;
-    }
-    m_clearingCache = true;
-
-    QMultiHashIterator<TrackId, QString> it(m_cacheKeysByTrackId);
-    QSet<TrackId> ids;
-    while (it.hasNext()) {
-        if (m_stopClearing) {
-            m_stopClearing = false;
-            return;
-        }
-        it.next();
-        TrackId id = it.key();
-        ids.insert(id);
-        const auto cacheKey = it.value();
-        QPixmapCache::remove(cacheKey);
-    }
-
-    m_cacheKeysByTrackId.clear();
-    m_clearingCache = false;
-
-    for (const auto trackId : ids) {
-        emit overviewChanged(trackId);
-    }
+          m_pDbConnectionPool(std::move(pDbConnectionPool)) {
 }
 
 void OverviewCache::onTrackAnalysisProgress(TrackId trackId, AnalyzerProgress analyzerProgress) {

--- a/src/library/overviewcache.h
+++ b/src/library/overviewcache.h
@@ -41,7 +41,6 @@ class OverviewCache : public QObject, public Singleton<OverviewCache> {
     };
 
   public slots:
-    void onNormalizeOrVisualGainChanged();
     void overviewPrepared();
     void onTrackAnalysisProgress(TrackId trackId, AnalyzerProgress analyzerProgress);
 
@@ -75,6 +74,4 @@ class OverviewCache : public QObject, public Singleton<OverviewCache> {
     QSet<TrackId> m_currentlyLoading;
     QSet<TrackId> m_tracksWithoutOverview;
     QMultiHash<TrackId, QString> m_cacheKeysByTrackId;
-    bool m_clearingCache;
-    bool m_stopClearing;
 };

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -301,7 +301,7 @@ void MixxxMainWindow::initialize() {
             pOverviewCache,
             &OverviewCache::onNormalizeOrVisualGainChanged);
     connect(WaveformWidgetFactory::instance(),
-            &WaveformWidgetFactory::overviewNormalizeChanged,
+            &WaveformWidgetFactory::overviewScalingChanged,
             pOverviewCache,
             &OverviewCache::onNormalizeOrVisualGainChanged);
 

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -40,7 +40,6 @@
 #include "library/export/libraryexporter.h"
 #endif
 #include "library/library_prefs.h"
-#include "library/overviewcache.h"
 #include "library/trackcollectionmanager.h"
 #include "mixer/playerinfo.h"
 #include "mixer/playermanager.h"
@@ -292,18 +291,6 @@ void MixxxMainWindow::initialize() {
     WaveformWidgetFactory::createInstance(); // takes a long time
     WaveformWidgetFactory::instance()->setConfig(m_pCoreServices->getSettings());
     WaveformWidgetFactory::instance()->startVSync(m_pGuiTick, m_pVisualsManager, false);
-    // Connect OverviewCache so we can clear and re-render overviews in the library
-    // when "OverviewNormalized" or "VisualGain_0" (all) have been changed in the
-    // preferences.
-    auto* pOverviewCache = OverviewCache::instance();
-    connect(WaveformWidgetFactory::instance(),
-            &WaveformWidgetFactory::visualGainChanged,
-            pOverviewCache,
-            &OverviewCache::onNormalizeOrVisualGainChanged);
-    connect(WaveformWidgetFactory::instance(),
-            &WaveformWidgetFactory::overviewScalingChanged,
-            pOverviewCache,
-            &OverviewCache::onNormalizeOrVisualGainChanged);
 
     connect(this,
             &MixxxMainWindow::skinLoaded,

--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -13,8 +13,13 @@
 #include "waveform/waveformwidgetfactory.h"
 
 namespace {
-const ConfigKey kOverviewTypeCfgKey(QStringLiteral("[Waveform]"),
+const QString kWaveformGroup(QStringLiteral("[Waveform]"));
+const ConfigKey kOverviewTypeCfgKey(kWaveformGroup,
         QStringLiteral("WaveformOverviewType"));
+const ConfigKey kWaveformOptionsKey(kWaveformGroup,
+        QStringLiteral("waveform_options"));
+const ConfigKey kHardwareAccelerationKey(kWaveformGroup,
+        QStringLiteral("use_hardware_acceleration"));
 } // namespace
 
 DlgPrefWaveform::DlgPrefWaveform(
@@ -72,8 +77,7 @@ DlgPrefWaveform::DlgPrefWaveform(
     }
 
     m_pOverviewMinuteMarkersControl = std::make_unique<ControlObject>(
-            ConfigKey(QStringLiteral("[Waveform]"),
-                    QStringLiteral("draw_overview_minute_markers")));
+            ConfigKey(kWaveformGroup, QStringLiteral("draw_overview_minute_markers")));
     m_pOverviewMinuteMarkersControl->setReadOnly();
 
     // Populate untilMark options
@@ -239,7 +243,7 @@ DlgPrefWaveform::~DlgPrefWaveform() {
 void DlgPrefWaveform::slotSetWaveformOptions(
         allshader::WaveformRendererSignalBase::Option option, bool enabled) {
     allshader::WaveformRendererSignalBase::Options currentOption = m_pConfig->getValue(
-            ConfigKey("[Waveform]", "waveform_options"),
+            kWaveformOptionsKey,
             allshader::WaveformRendererSignalBase::Option::None);
     m_pConfig->setValue<int>(ConfigKey("[Waveform]", "waveform_options"),
             enabled ? currentOption |
@@ -261,7 +265,7 @@ void DlgPrefWaveform::slotUpdate() {
         openGlStatusData->setText(factory->getOpenGLVersion());
         useAccelerationCheckBox->setEnabled(true);
         isAccelerationEnabled = m_pConfig->getValue(
-                                        ConfigKey("[Waveform]", "use_hardware_acceleration"),
+                                        kHardwareAccelerationKey,
                                         factory->preferredBackend()) !=
                 WaveformWidgetBackend::None;
         useAccelerationCheckBox->setChecked(isAccelerationEnabled);
@@ -281,10 +285,10 @@ void DlgPrefWaveform::slotUpdate() {
     useWaveformCheckBox->setChecked(useWaveform);
 
     allshader::WaveformRendererSignalBase::Options currentOptions = m_pConfig->getValue(
-            ConfigKey("[Waveform]", "waveform_options"),
+            kWaveformOptionsKey,
             allshader::WaveformRendererSignalBase::Option::None);
     WaveformWidgetBackend backend = m_pConfig->getValue(
-            ConfigKey("[Waveform]", "use_hardware_acceleration"),
+            kHardwareAccelerationKey,
             factory->preferredBackend());
     updateWaveformAcceleration(factory->getType(), backend);
     updateWaveformTypeOptions(useWaveform, backend, currentOptions);
@@ -332,7 +336,7 @@ void DlgPrefWaveform::slotUpdate() {
     }
 
     bool drawOverviewMinuteMarkers = m_pConfig->getValue(
-            ConfigKey("[Waveform]", "draw_overview_minute_markers"), true);
+            ConfigKey(kWaveformGroup, QStringLiteral("draw_overview_minute_markers")), true);
     overviewMinuteMarkersCheckBox->setChecked(drawOverviewMinuteMarkers);
     m_pOverviewMinuteMarkersControl->forceSet(drawOverviewMinuteMarkers);
 
@@ -367,10 +371,9 @@ void DlgPrefWaveform::slotResetToDefaults() {
             allshader::WaveformRendererSignalBase::Option::None);
 
     // Restore waveform backend and option setting instantly
-    m_pConfig->setValue(ConfigKey("[Waveform]", "waveform_options"),
+    m_pConfig->setValue(kWaveformOptionsKey,
             allshader::WaveformRendererSignalBase::Option::None);
-    m_pConfig->setValue(ConfigKey("[Waveform]", "use_hardware_acceleration"),
-            defaultBackend);
+    m_pConfig->setValue(kHardwareAccelerationKey, defaultBackend);
     factory->setWidgetTypeFromHandle(
             factory->findHandleIndexFromType(
                     WaveformWidgetFactory::defaultType()),
@@ -430,14 +433,12 @@ void DlgPrefWaveform::slotSetWaveformType(int index) {
     auto* factory = WaveformWidgetFactory::instance();
     factory->setWidgetTypeFromHandle(factory->findHandleIndexFromType(type));
 
-    auto backend = m_pConfig->getValue(
-            ConfigKey("[Waveform]", "use_hardware_acceleration"),
-            factory->preferredBackend());
+    auto backend = m_pConfig->getValue(kHardwareAccelerationKey, factory->preferredBackend());
     useAccelerationCheckBox->setChecked(backend !=
             WaveformWidgetBackend::None);
 
     allshader::WaveformRendererSignalBase::Options currentOptions = m_pConfig->getValue(
-            ConfigKey("[Waveform]", "waveform_options"),
+            kWaveformOptionsKey,
             allshader::WaveformRendererSignalBase::Option::None);
     updateWaveformAcceleration(type, backend);
     updateWaveformTypeOptions(true, backend, currentOptions);
@@ -469,14 +470,12 @@ void DlgPrefWaveform::slotSetWaveformAcceleration(bool checked) {
 #endif
                 ;
     }
-    m_pConfig->setValue(
-            ConfigKey("[Waveform]", "use_hardware_acceleration"),
-            backend);
+    m_pConfig->setValue(kHardwareAccelerationKey, backend);
     auto type = static_cast<WaveformWidgetType::Type>(waveformTypeComboBox->currentData().toInt());
     auto* factory = WaveformWidgetFactory::instance();
     factory->setWidgetTypeFromHandle(factory->findHandleIndexFromType(type), true);
     allshader::WaveformRendererSignalBase::Options currentOptions = m_pConfig->getValue(
-            ConfigKey("[Waveform]", "waveform_options"),
+            kWaveformOptionsKey,
             allshader::WaveformRendererSignalBase::Option::None);
     updateWaveformTypeOptions(true, backend, currentOptions);
     updateEnableUntilMark();
@@ -554,8 +553,7 @@ void DlgPrefWaveform::updateEnableUntilMark() {
     WaveformWidgetFactory* factory = WaveformWidgetFactory::instance();
     const bool enabled =
             WaveformWidgetFactory::instance()->widgetTypeSupportsUntilMark() &&
-            m_pConfig->getValue(
-                    ConfigKey("[Waveform]", "use_hardware_acceleration"),
+            m_pConfig->getValue(kHardwareAccelerationKey,
                     factory->preferredBackend()) !=
                     WaveformWidgetBackend::None;
 #endif
@@ -635,7 +633,9 @@ void DlgPrefWaveform::slotSetNormalizeOverview(bool normalize) {
 }
 
 void DlgPrefWaveform::slotSetOverviewMinuteMarkers(bool draw) {
-    m_pConfig->setValue(ConfigKey("[Waveform]", "draw_overview_minute_markers"), draw);
+    m_pConfig->setValue(ConfigKey(kWaveformGroup,
+                                QStringLiteral("draw_overview_minute_markers")),
+            draw);
     m_pOverviewMinuteMarkersControl->forceSet(draw);
 }
 
@@ -656,7 +656,7 @@ void DlgPrefWaveform::slotClearCachedWaveforms() {
 void DlgPrefWaveform::slotSetBeatGridAlpha(int alpha) {
     // TODO(xxx) For consistency set this in WaveformWidgetFactory like
     // the other waveform controls.
-    m_pConfig->setValue(ConfigKey("[Waveform]", "beatGridAlpha"), alpha);
+    m_pConfig->setValue(ConfigKey(kWaveformGroup, QStringLiteral("beatGridAlpha")), alpha);
     WaveformWidgetFactory::instance()->setDisplayBeatGridAlpha(alpha);
 }
 
@@ -693,6 +693,7 @@ void DlgPrefWaveform::slotSetUntilMarkTextHeightLimit(int index) {
 void DlgPrefWaveform::slotStemOpacity(float value) {
     WaveformWidgetFactory::instance()->setStemOpacity(value);
 }
+
 void DlgPrefWaveform::slotStemReorderOnChange(bool value) {
     WaveformWidgetFactory::instance()->setStemReorderOnChange(value);
 }

--- a/src/preferences/dialog/dlgprefwaveform.h
+++ b/src/preferences/dialog/dlgprefwaveform.h
@@ -45,15 +45,12 @@ class DlgPrefWaveform : public DlgPreferencePage, public Ui::DlgPrefWaveformDlg 
         slotSetWaveformOptions(allshader::WaveformRendererSignalBase::Option::HighDetail, checked);
     }
 #endif
-    void slotSetWaveformOverviewType();
     void slotSetDefaultZoom(int index);
     void slotSetZoomSynchronization(bool checked);
     void slotSetVisualGainAll(double gain);
     void slotSetVisualGainLow(double gain);
     void slotSetVisualGainMid(double gain);
     void slotSetVisualGainHigh(double gain);
-    void slotSetNormalizeOverview(bool normalize);
-    void slotSetOverviewMinuteMarkers(bool minuteMarkers);
     void slotWaveformMeasured(float frameRate, int droppedFrames);
     void slotClearCachedWaveforms();
     void slotSetBeatGridAlpha(int alpha);
@@ -66,6 +63,10 @@ class DlgPrefWaveform : public DlgPreferencePage, public Ui::DlgPrefWaveformDlg 
     void slotStemOpacity(float value);
     void slotStemReorderOnChange(bool value);
     void slotStemOutlineOpacity(float value);
+    // overview options
+    void slotSetWaveformOverviewType();
+    void slotSetOverviewMinuteMarkers(bool minuteMarkers);
+    void slotSetOverviewScaling();
 
   private:
     void initWaveformControl();

--- a/src/preferences/dialog/dlgprefwaveformdlg.ui
+++ b/src/preferences/dialog/dlgprefwaveformdlg.ui
@@ -710,18 +710,41 @@ Select from different types of displays for the waveform overview, which differ 
      </item>
 
      <item row="1" column="1" colspan="4">
-      <widget class="QCheckBox" name="normalizeOverviewCheckBox">
-       <property name="text">
-        <string>Normalize waveform overview</string>
-       </property>
-      </widget>
-     </item>
-
-     <item row="2" column="1" colspan="4">
       <widget class="QCheckBox" name="overviewMinuteMarkersCheckBox">
        <property name="text">
         <string>Show minute markers on waveform overview</string>
        </property>
+      </widget>
+     </item>
+
+     <item row="2" column="0">
+      <widget class="QLabel" name="overview_gain_label">
+       <property name="toolTip">
+        <string extracomment="Select a gain mode for the waveform overview."/>
+       </property>
+       <property name="text">
+        <string>Gain</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1" colspan="4">
+      <widget class="QRadioButton" name="overview_scale_normalize">
+       <property name="text">
+        <string>Normalize to peak</string>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">overview_scale_options</string>
+       </attribute>
+      </widget>
+     </item>
+     <item row="3" column="1" colspan="4">
+      <widget class="QRadioButton" name="overview_scale_allReplayGain">
+       <property name="text">
+        <string extracomment="'Global' refers to the 'Global' visual gain in the scrolling waveform settings">Use Waveform "Global" gain and ReplayGain (if enabled)</string>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">overview_scale_options</string>
+       </attribute>
       </widget>
      </item>
 
@@ -868,12 +891,16 @@ Select from different types of displays for the waveform overview, which differ 
   <tabstop>untilMarkTextPointSizeSpinBox</tabstop>
   <tabstop>untilMarkTextHeightLimitComboBox</tabstop>
   <tabstop>waveformOverviewComboBox</tabstop>
-  <tabstop>normalizeOverviewCheckBox</tabstop>
   <tabstop>overviewMinuteMarkersCheckBox</tabstop>
+  <tabstop>overview_scale_normalize</tabstop>
+  <tabstop>overview_scale_allReplayGain</tabstop>
   <tabstop>enableWaveformCaching</tabstop>
   <tabstop>enableWaveformGenerationWithAnalysis</tabstop>
   <tabstop>clearCachedWaveforms</tabstop>
  </tabstops>
+ <buttongroups>
+  <buttongroup name="overview_scale_options"/>
+ </buttongroups>
  <resources/>
  <connections/>
 </ui>

--- a/src/waveform/renderers/waveformoverviewrenderer.cpp
+++ b/src/waveform/renderers/waveformoverviewrenderer.cpp
@@ -6,7 +6,6 @@
 #include "util/math.h"
 #include "util/timer.h"
 #include "waveform/renderers/waveformsignalcolors.h"
-#include "waveform/waveformwidgetfactory.h"
 
 namespace waveformOverviewRenderer {
 
@@ -57,17 +56,9 @@ QImage render(ConstWaveformPointer pWaveform,
                 static_cast<float>(pWaveform->getAll(i + 1)));
     }
     // Normalize
-    WaveformWidgetFactory* widgetFactory = WaveformWidgetFactory::instance();
     float diffGain = 0;
-    bool normalize = widgetFactory->isOverviewNormalized();
-    if (normalize && peak > 1) {
+    if (peak > 1) {
         diffGain = 255 - peak - 1;
-    } else {
-        const auto visualGain = static_cast<float>(
-                widgetFactory->getVisualGain(BandIndex::AllBand));
-        // TODO Scale it like the decks' overviews, ie. consider
-        // ReplayGain config
-        diffGain = 255.0f - (255.0f / visualGain);
     }
 
     const int topLeft = static_cast<int>(mono ? diffGain * 2 : diffGain);

--- a/src/waveform/renderers/waveformoverviewrenderer.cpp
+++ b/src/waveform/renderers/waveformoverviewrenderer.cpp
@@ -65,6 +65,8 @@ QImage render(ConstWaveformPointer pWaveform,
     } else {
         const auto visualGain = static_cast<float>(
                 widgetFactory->getVisualGain(BandIndex::AllBand));
+        // TODO Scale it like the decks' overviews, ie. consider
+        // ReplayGain config
         diffGain = 255.0f - (255.0f / visualGain);
     }
 

--- a/src/waveform/renderers/waveformoverviewrenderer.h
+++ b/src/waveform/renderers/waveformoverviewrenderer.h
@@ -9,9 +9,8 @@ class QPainter;
 class WaveformSignalColors;
 
 namespace waveformOverviewRenderer {
-/// This returns the normalized, fullsize, "mono" image
-/// for the library's overview column, scaled vertically
-/// depending on Normalized preference.
+/// This returns the normalized fullsize image
+/// for the library's overview column.
 QImage render(ConstWaveformPointer pWaveform,
         mixxx::OverviewType type,
         const WaveformSignalColors& signalColors,

--- a/src/waveform/renderers/waveformoverviewrenderer.h
+++ b/src/waveform/renderers/waveformoverviewrenderer.h
@@ -9,11 +9,16 @@ class QPainter;
 class WaveformSignalColors;
 
 namespace waveformOverviewRenderer {
+/// This returns the normalized, fullsize, "mono" image
+/// for the library's overview column, scaled vertically
+/// depending on Normalized preference.
 QImage render(ConstWaveformPointer pWaveform,
         mixxx::OverviewType type,
         const WaveformSignalColors& signalColors,
         bool mono = false);
-/// These paint methods allow "mono" rendering (mono-mixdown, bottom-aligned).
+
+/// These paint methods return the fullsize image
+/// They allow "mono" rendering (mono-mixdown, bottom-aligned).
 /// Note: Don't use mono = true with WOverview, it's not adjusted yet! It does some
 /// additional scaling for normalization which will atm cut off the bottom part.
 void drawWaveformPartRGB(

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -716,6 +716,9 @@ void WaveformWidgetFactory::setVisualGain(BandIndex index, double gain) {
             m_visualGain[BandIndex::Low],
             m_visualGain[BandIndex::Mid],
             m_visualGain[BandIndex::High]);
+    if (index == BandIndex::AllBand && !m_overviewNormalized) {
+        emit overviewScalingChanged();
+    }
 }
 
 double WaveformWidgetFactory::getVisualGain(BandIndex index) const {
@@ -728,7 +731,7 @@ void WaveformWidgetFactory::setOverviewNormalized(bool normalize) {
         m_config->set(ConfigKey(kWaveformGroup, QStringLiteral("OverviewNormalized")),
                 ConfigValue(m_overviewNormalized));
     }
-    emit overviewNormalizeChanged();
+    emit overviewScalingChanged();
 }
 
 void WaveformWidgetFactory::setPlayMarkerPosition(double position) {

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -1044,14 +1044,7 @@ WaveformWidgetAbstract* WaveformWidgetFactory::createAllshaderWaveformWidget(
 
 WaveformWidgetAbstract* WaveformWidgetFactory::createFilteredWaveformWidget(
         WWaveformViewer* viewer) {
-    // On the UI, hardware acceleration is a boolean (0 => software rendering, 1
-    // => hardware acceleration), but in the setting, we keep the granularity so
-    // in case of issue when we release, we can communicate workaround on
-    // editing the INI file to target a specific rendering backend. If no
-    // complains come back, we can convert this safely to a backend eventually.
-    WaveformWidgetBackend backend = m_config->getValue(
-            kHardwareAccelerationKey,
-            preferredBackend());
+    WaveformWidgetBackend backend = getBackendFromConfig();
 
     switch (backend) {
 #ifdef MIXXX_USE_QOPENGL
@@ -1065,14 +1058,7 @@ WaveformWidgetAbstract* WaveformWidgetFactory::createFilteredWaveformWidget(
 }
 
 WaveformWidgetAbstract* WaveformWidgetFactory::createHSVWaveformWidget(WWaveformViewer* viewer) {
-    // On the UI, hardware acceleration is a boolean (0 => software rendering, 1
-    // => hardware acceleration), but in the setting, we keep the granularity so
-    // in case of issue when we release, we can communicate workaround on
-    // editing the INI file to target a specific rendering backend. If no
-    // complains come back, we can convert this safely to a backend eventually.
-    WaveformWidgetBackend backend = m_config->getValue(
-            kHardwareAccelerationKey,
-            preferredBackend());
+    WaveformWidgetBackend backend = getBackendFromConfig();
 
     switch (backend) {
 #ifdef MIXXX_USE_QOPENGL
@@ -1085,14 +1071,7 @@ WaveformWidgetAbstract* WaveformWidgetFactory::createHSVWaveformWidget(WWaveform
 }
 
 WaveformWidgetAbstract* WaveformWidgetFactory::createRGBWaveformWidget(WWaveformViewer* viewer) {
-    // On the UI, hardware acceleration is a boolean (0 => software rendering, 1
-    // => hardware acceleration), but in the setting, we keep the granularity so
-    // in case of issue when we release, we can communicate workaround on
-    // editing the INI file to target a specific rendering backend. If no
-    // complains come back, we can convert this safely to a backend eventually.
-    WaveformWidgetBackend backend = m_config->getValue(
-            kHardwareAccelerationKey,
-            preferredBackend());
+    WaveformWidgetBackend backend = getBackendFromConfig();
 
     switch (backend) {
 #ifdef MIXXX_USE_QOPENGL
@@ -1107,14 +1086,7 @@ WaveformWidgetAbstract* WaveformWidgetFactory::createRGBWaveformWidget(WWaveform
 WaveformWidgetAbstract* WaveformWidgetFactory::createStackedWaveformWidget(
         WWaveformViewer* viewer) {
 #ifdef MIXXX_USE_QOPENGL
-    // On the UI, hardware acceleration is a boolean (0 => software rendering, 1
-    // => hardware acceleration), but in the setting, we keep the granularity so
-    // in case of issue when we release, we can communicate workaround on
-    // editing the INI file to target a specific rendering backend. If no
-    // complains come back, we can convert this safely to a backend eventually.
-    WaveformWidgetBackend backend = m_config->getValue(
-            kHardwareAccelerationKey,
-            preferredBackend());
+    WaveformWidgetBackend backend = getBackendFromConfig();
     switch (backend) {
     case WaveformWidgetBackend::AllShader:
         return createAllshaderWaveformWidget(WaveformWidgetType::Type::Stacked, viewer);
@@ -1125,14 +1097,7 @@ WaveformWidgetAbstract* WaveformWidgetFactory::createStackedWaveformWidget(
 }
 
 WaveformWidgetAbstract* WaveformWidgetFactory::createSimpleWaveformWidget(WWaveformViewer* viewer) {
-    // On the UI, hardware acceleration is a boolean (0 => software rendering, 1
-    // => hardware acceleration), but in the setting, we keep the granularity so
-    // in case of issue when we release, we can communicate workaround on
-    // editing the INI file to target a specific rendering backend. If no
-    // complains come back, we can convert this safely to a backend eventually.
-    WaveformWidgetBackend backend = m_config->getValue(
-            kHardwareAccelerationKey,
-            preferredBackend());
+    WaveformWidgetBackend backend = getBackendFromConfig();
 
     switch (backend) {
 #ifdef MIXXX_USE_QOPENGL
@@ -1271,6 +1236,17 @@ int WaveformWidgetFactory::findHandleIndexFromType(WaveformWidgetType::Type type
         }
     }
     return -1;
+}
+
+WaveformWidgetBackend WaveformWidgetFactory::getBackendFromConfig() const {
+    // On the UI, hardware acceleration is a boolean (0 => software rendering, 1
+    // => hardware acceleration), but in the setting, we keep the granularity so
+    // in case of issue when we release, we can communicate workaround on
+    // editing the INI file to target a specific rendering backend. If no
+    // complains come back, we can convert this safely to a backend eventually.
+    return m_config->getValue(
+            ConfigKey(QStringLiteral("[Waveform]"), QStringLiteral("use_hardware_acceleration")),
+            preferredBackend());
 }
 
 WaveformWidgetBackend WaveformWidgetFactory::preferredBackend() const {

--- a/src/waveform/waveformwidgetfactory.h
+++ b/src/waveform/waveformwidgetfactory.h
@@ -130,6 +130,7 @@ class WaveformWidgetFactory : public QObject,
 
     bool isOpenGlShaderAvailable() const { return m_openGLShaderAvailable;}
 
+    WaveformWidgetBackend getBackendFromConfig() const;
     WaveformWidgetBackend preferredBackend() const;
     static WaveformWidgetType::Type defaultType() {
         return WaveformWidgetType::RGB;
@@ -228,6 +229,7 @@ class WaveformWidgetFactory : public QObject,
     double getPlayMarkerPosition() const { return m_playMarkerPosition; }
 
     void notifyZoomChange(WWaveformViewer *viewer);
+
   signals:
     void waveformUpdateTick();
     void waveformMeasured(float frameRate, int droppedFrames);

--- a/src/waveform/waveformwidgetfactory.h
+++ b/src/waveform/waveformwidgetfactory.h
@@ -120,7 +120,7 @@ class WaveformWidgetFactory : public QObject,
 
     void setFrameRate(int frameRate);
     int getFrameRate() const { return m_frameRate;}
-//    bool getVSync() const { return m_vSyncType;}
+    // bool getVSync() const { return m_vSyncType;}
     void setEndOfTrackWarningTime(int endTime);
     int getEndOfTrackWarningTime() const { return m_endOfTrackWarningTime;}
 
@@ -238,7 +238,7 @@ class WaveformWidgetFactory : public QObject,
     void renderVuMeters(VSyncThread*);
     void swapVuMeters();
 
-    void overviewNormalizeChanged();
+    void overviewScalingChanged();
     void visualGainChanged(double allChannelGain, double lowGain, double midGain, double highGain);
 
     void untilMarkShowBeatsChanged(bool value);

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -33,6 +33,9 @@ constexpr int kDragOutsideLimitX = 100;
 constexpr int kDragOutsideLimitY = 50;
 } // anonymous namespace
 
+// for mixxx::OverviewType
+using namespace mixxx;
+
 WOverview::WOverview(
         const QString& group,
         PlayerManager* pPlayerManager,
@@ -41,7 +44,7 @@ WOverview::WOverview(
         : WWidget(parent),
           m_group(group),
           m_pConfig(pConfig),
-          m_type(mixxx::OverviewType::RGB),
+          m_type(OverviewType::RGB),
           m_actualCompletion(0),
           m_pixmapDone(false),
           m_waveformPeak(-1.0),
@@ -443,8 +446,8 @@ void WOverview::onPassthroughChange(double v) {
 
 void WOverview::slotTypeControlChanged(double v) {
     // Assert that v is in enum range to prevent UB.
-    DEBUG_ASSERT(v >= 0 && v < QMetaEnum::fromType<mixxx::OverviewType>().keyCount());
-    mixxx::OverviewType type = static_cast<mixxx::OverviewType>(static_cast<int>(v));
+    DEBUG_ASSERT(v >= 0 && v < QMetaEnum::fromType<OverviewType>().keyCount());
+    OverviewType type = static_cast<OverviewType>(static_cast<int>(v));
     if (type == m_type) {
         return;
     }
@@ -1422,21 +1425,21 @@ bool WOverview::drawNextPixmapPart() {
                 static_cast<float>(pWaveform->getAll(currentCompletion + 1)));
     }
 
-    if (m_type == mixxx::OverviewType::Filtered) {
+    if (m_type == OverviewType::Filtered) {
         waveformOverviewRenderer::drawWaveformPartLMH(
                 &painter,
                 pWaveform,
                 &m_actualCompletion,
                 nextCompletion,
                 m_signalColors);
-    } else if (m_type == mixxx::OverviewType::HSV) {
+    } else if (m_type == OverviewType::HSV) {
         waveformOverviewRenderer::drawWaveformPartHSV(
                 &painter,
                 pWaveform,
                 &m_actualCompletion,
                 nextCompletion,
                 m_signalColors);
-    } else { // mixxx::OverviewType::RGB:
+    } else { // OverviewType::RGB:
         waveformOverviewRenderer::drawWaveformPartRGB(
                 &painter,
                 pWaveform,

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -736,42 +736,44 @@ void WOverview::drawAxis(QPainter* pPainter) {
 }
 
 void WOverview::drawWaveformPixmap(QPainter* pPainter) {
-    if (!m_waveformSourceImage.isNull()) {
-        WaveformWidgetFactory* pWidgetFactory = WaveformWidgetFactory::instance();
-        float diffGain;
-        bool normalize = pWidgetFactory->isOverviewNormalized();
-        if (normalize && m_pixmapDone && m_waveformPeak > 1) {
-            diffGain = 255 - m_waveformPeak - 1;
-        } else {
-            DEBUG_ASSERT(m_pCurrentTrack);
-            const auto replayGain = m_pCurrentTrack->getReplayGain();
-            const auto visualGain = static_cast<float>(
-                    pWidgetFactory->getVisualGain(BandIndex::AllBand) *
-                    (replayGain.hasRatio()
-                                    ? replayGain.getRatio()
-                                    : 1.0));
-            diffGain = 255.0f - (255.0f / visualGain);
-        }
-
-        if (m_diffGain != diffGain || m_waveformImageScaled.isNull()) {
-            QRect sourceRect(0,
-                    static_cast<int>(diffGain),
-                    m_waveformSourceImage.width(),
-                    m_waveformSourceImage.height() -
-                            2 * static_cast<int>(diffGain));
-            QImage croppedImage = m_waveformSourceImage.copy(sourceRect);
-            if (m_orientation == Qt::Vertical) {
-                // Rotate pixmap
-                croppedImage = croppedImage.transformed(QTransform(0, 1, 1, 0, 0, 0));
-            }
-            m_waveformImageScaled = croppedImage.scaled(size() * m_devicePixelRatio,
-                    Qt::IgnoreAspectRatio,
-                    Qt::SmoothTransformation);
-            m_diffGain = diffGain;
-        }
-
-        pPainter->drawImage(rect(), m_waveformImageScaled);
+    if (m_waveformSourceImage.isNull()) {
+        return;
     }
+
+    WaveformWidgetFactory* pWidgetFactory = WaveformWidgetFactory::instance();
+    float diffGain;
+    bool normalize = pWidgetFactory->isOverviewNormalized();
+    if (normalize && m_pixmapDone && m_waveformPeak > 1) {
+        diffGain = 255 - m_waveformPeak - 1;
+    } else {
+        DEBUG_ASSERT(m_pCurrentTrack);
+        const auto replayGain = m_pCurrentTrack->getReplayGain();
+        const auto visualGain = static_cast<float>(
+                pWidgetFactory->getVisualGain(BandIndex::AllBand) *
+                (replayGain.hasRatio()
+                                ? replayGain.getRatio()
+                                : 1.0));
+        diffGain = 255.0f - (255.0f / visualGain);
+    }
+
+    if (m_diffGain != diffGain || m_waveformImageScaled.isNull()) {
+        const QRect sourceRect(0,
+                static_cast<int>(diffGain),
+                m_waveformSourceImage.width(),
+                m_waveformSourceImage.height() -
+                        2 * static_cast<int>(diffGain));
+        QImage croppedImage = m_waveformSourceImage.copy(sourceRect);
+        if (m_orientation == Qt::Vertical) {
+            // Rotate pixmap
+            croppedImage = croppedImage.transformed(QTransform(0, 1, 1, 0, 0, 0));
+        }
+        m_waveformImageScaled = croppedImage.scaled(size() * m_devicePixelRatio,
+                Qt::IgnoreAspectRatio,
+                Qt::SmoothTransformation);
+        m_diffGain = diffGain;
+    }
+
+    pPainter->drawImage(rect(), m_waveformImageScaled);
 }
 
 void WOverview::drawMinuteMarkers(QPainter* pPainter) {

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -69,7 +69,7 @@ class WOverview : public WWidget, public TrackDropTarget {
 
     void slotTypeControlChanged(double v);
     void slotMinuteMarkersChanged(bool v);
-    void slotNormalizeOrVisualGainChanged();
+    void slotScalingChanged();
 
   private:
     // Append the waveform overview pixmap according to available data
@@ -196,7 +196,11 @@ class WOverview : public WWidget, public TrackDropTarget {
     parented_ptr<ControlProxy> m_pPassthroughControl;
     parented_ptr<ControlProxy> m_pTypeControl;
     parented_ptr<ControlProxy> m_pMinuteMarkersControl;
+    // Controls to trigger update of amplitude scaling
     parented_ptr<ControlProxy> m_pReplayGain;
+    parented_ptr<ControlProxy> m_pReplayGainEnabled;
+    parented_ptr<ControlProxy> m_pReplayGainBoost;
+    parented_ptr<ControlProxy> m_pReplayGainDefaultBoost;
 
     QPointF m_timeRulerPos;
     WaveformMarkLabel m_timeRulerPositionLabel;


### PR DESCRIPTION
Fixup for #14309 as the new ReplayGain scaling was considered a regression for certain use case(s).
https://github.com/mixxxdj/mixxx/pull/14309#issuecomment-2673055066

This replaces the overview 'Normalize' checkbox with two options
* Normalize to peak
* Use Waveform "Global" gain and ReplayGain (if enabled)

The second option uses the same gains/factors as the scrolling waveforms, meaning it uses settings in the Waveforms and Normalization pages.
Making 'not normalize' an explicit option hopefully clarifies the situation.

The overviews in the library are now always normalized.
_____
<sub>Initial concept so the conversation here can be understood</sub>
~~This adds 3 overview gain modes~~
* ~~File gain (what we had before this PR with 'Normalize' unchecked) + factor spinbox~~
* ~~Normalize to peak~~
* ~~waveform "All" gain + ReplayGain~~