### PR TITLE
(fix) use canonical path to load font file

### DIFF
--- a/src/util/font.cpp
+++ b/src/util/font.cpp
@@ -67,16 +67,16 @@ void FontUtils::initializeFonts(const QString& resourcePath) {
         return;
     }
 
-    const QList<QString> files = fontsDir.entryList(
+    const QFileInfoList files = fontsDir.entryInfoList(
             QDir::NoDotAndDotDot | QDir::Files | QDir::Readable);
-    for (const QString& path : files) {
+    for (const QFileInfo& file : files) {
         // Skip text files (e.g. license files). For all others we let Qt tell
         // us whether the font format is supported since there is no way to
         // check other than adding.
-        if (path.endsWith(QStringLiteral(".txt"), Qt::CaseInsensitive)) {
+        if (file.suffix().toLower() == QStringLiteral("txt")) {
             continue;
         }
 
-        addFont(path);
+        addFont(file.canonicalFilePath());
     }
 }


### PR DESCRIPTION
For some reason I get these warnings with main, but not with 2.5
```
warning [Main] Failed to add font: "OpenSans-Bold.ttf"
warning [Main] Failed to add font: "OpenSans-Regular.ttf"
warning [Main] Failed to add font: "OpenSans-Semibold.ttf"
warning [Main] Failed to add font: "Ubuntu-B.ttf"
warning [Main] Failed to add font: "Ubuntu-R.ttf"
```

Fixed by using the files' canonical paths.