### PR TITLE
github labeler: add Dev Tools to `developer experience`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -42,6 +42,7 @@ developer experience:
           - CODE_OF_CONDUCT.md
           - CONTRIBUTING.md
           - README.md
+          - src/dialog/dlgdevelopertools*
 
 analyzer:
   - changed-files:


### PR DESCRIPTION
Btw can we backport the labeler patterns to 2.5?