### PR TITLE
Detect arch and fail early if not supported when installing buildenv

### DIFF
--- a/tools/macos_buildenv.sh
+++ b/tools/macos_buildenv.sh
@@ -19,23 +19,32 @@ realpath() {
 THIS_SCRIPT_NAME=${BASH_SOURCE[0]}
 [ -z "$THIS_SCRIPT_NAME" ] && THIS_SCRIPT_NAME=$0
 
-if [ -n "${BUILDENV_ARM64}" ]; then
-    VCPKG_TARGET_TRIPLET="arm64-osx-min1100-release"
-    BUILDENV_BRANCH="2.5-rel"
-    BUILDENV_NAME="mixxx-deps-2.5-arm64-osx-min1100-release-40c29ff"
-    BUILDENV_SHA256="b76685e77f681baf8fdc5037297b0f16d323a405d09ce276d8844304530278e1"
-else
-    if [ -n "${BUILDENV_RELEASE}" ]; then
-        VCPKG_TARGET_TRIPLET="x64-osx-min1100-release"
+HOST_ARCH=$(uname -m)  # One of x86_64, arm64, i386, ppc or ppc64
+
+if [ "$HOST_ARCH" == "x86_64" ]; then
+    if [ -n "${BUILDENV_ARM64}" ]; then
+        VCPKG_TARGET_TRIPLET="arm64-osx-min1100-release"
         BUILDENV_BRANCH="2.5-rel"
-        BUILDENV_NAME="mixxx-deps-2.5-x64-osx-min1100-release-40c29ff"
-        BUILDENV_SHA256="a9b7dd2cb9ab00db6d05ac1f05aab933ed0ab2697f71db1a1bad70305befcf1b"
+        BUILDENV_NAME="mixxx-deps-2.5-arm64-osx-min1100-release-40c29ff"
+        BUILDENV_SHA256="b76685e77f681baf8fdc5037297b0f16d323a405d09ce276d8844304530278e1"
     else
-        VCPKG_TARGET_TRIPLET="x64-osx-min1100"
-        BUILDENV_BRANCH="2.5"
-        BUILDENV_NAME="mixxx-deps-2.5-x64-osx-min1100-c15790e"
-        BUILDENV_SHA256="0252293436efed1b043d5c6ee384a9502ca0ade712eff95b2c0d2199d94598bb"
+        if [ -n "${BUILDENV_RELEASE}" ]; then
+            VCPKG_TARGET_TRIPLET="x64-osx-min1100-release"
+            BUILDENV_BRANCH="2.5-rel"
+            BUILDENV_NAME="mixxx-deps-2.5-x64-osx-min1100-release-40c29ff"
+            BUILDENV_SHA256="a9b7dd2cb9ab00db6d05ac1f05aab933ed0ab2697f71db1a1bad70305befcf1b"
+        else
+            VCPKG_TARGET_TRIPLET="x64-osx-min1100"
+            BUILDENV_BRANCH="2.5"
+            BUILDENV_NAME="mixxx-deps-2.5-x64-osx-min1100-c15790e"
+            BUILDENV_SHA256="0252293436efed1b043d5c6ee384a9502ca0ade712eff95b2c0d2199d94598bb"
+        fi
     fi
+else
+    echo "ERROR: Unsupported architecture detected: $HOST_ARCH"
+    echo "Please refer to the following guide to manually build the vcpkg environment:"
+    echo "https://github.com/mixxxdj/mixxx/wiki/Compiling-dependencies-for-macOS-arm64"
+    exit 1
 fi
 
 MIXXX_ROOT="$(realpath "$(dirname "$THIS_SCRIPT_NAME")/..")"


### PR DESCRIPTION
In case the host architecture is not supported a link to 
https://github.com/mixxxdj/mixxx/wiki/Compiling-dependencies-for-macOS-arm64
is displayed that allows to build the environment at home. 