### PR TITLE
Tracks: allow saving & loading columns layout

### DIFF
--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -3507,6 +3507,8 @@ WSearchLineEdit::item:selected,
 #MainMenu QMenu::item:disabled,
 WLibrarySidebar QMenu::item:disabled,
 WLibraryTextBrowser QMenu::item:disabled,
+WTrackTableViewHeader QMenu::item::disabled,
+WTrackTableViewHeader QMenu QCheckBox::disabled,
 WTrackMenu::item:disabled,
 WTrackMenu QMenu::item:disabled,
 WTrackMenu QMenu QCheckBox:disabled,
@@ -3551,7 +3553,9 @@ QPlainTextEdit QMenu::item:disabled {
     image: url(skins:LateNight/palemoon/buttons/btn__menu_checkbox_checked.svg);
     }
     #MainMenu QMenu::indicator:unchecked,
-    #MainMenu QMenu::indicator:unchecked:selected {
+    #MainMenu QMenu::indicator:unchecked:selected,
+    WTrackTableViewHeader QMenu QCheckBox::indicator:unchecked,
+    WTrackTableViewHeader QMenu QCheckBox::indicator:unchecked:selected {
       image: url(skins:LateNight/palemoon/buttons/btn__menu_checkbox.svg);
     }
 
@@ -3586,8 +3590,6 @@ QPlainTextEdit QMenu::item:disabled {
   selected, unchecked items would have a checkmark */
 WLibrarySidebar QMenu::indicator:unchecked,
 WLibrarySidebar QMenu::indicator:unchecked:selected,
-WTrackTableViewHeader QMenu QCheckBox::indicator:unchecked,
-WTrackTableViewHeader QMenu QCheckBox::indicator:unchecked:selected,
 WEffectSelector::indicator:unchecked,
 WEffectSelector::indicator:unchecked:selected,
 WEffectChainPresetSelector::indicator:unchecked,

--- a/res/skins/default.qss
+++ b/res/skins/default.qss
@@ -168,6 +168,10 @@ WLibrarySidebar QMenu::item {
 WLibrarySidebar QMenu::indicator {
   margin: 0em -0.1em 0em 0.3em;
 }
+WTrackTableViewHeader QMenu::item {
+  /* Indicator width is 0.7 + 0.3 margin-left + 0.25 text pad-left */
+  padding: 0.17em 0 0.17em 1.25em;
+}
 
 WLibrarySidebar QMenu::indicator,
 WTrackTableViewHeader QMenu QCheckBox::indicator,

--- a/src/library/browse/browsetablemodel.h
+++ b/src/library/browse/browsetablemodel.h
@@ -59,6 +59,9 @@ class BrowseTableModel final : public QStandardItemModel, public virtual TrackMo
     TrackPointer getTrack(const QModelIndex& index) const override;
     TrackPointer getTrackByRef(const TrackRef& trackRef) const override;
     TrackModel::Capabilities getCapabilities() const override;
+    bool canLoadTrackSetColumns() const override {
+        return false;
+    }
 
     QString getTrackLocation(const QModelIndex& index) const override;
     TrackId getTrackId(const QModelIndex& index) const override;

--- a/src/library/trackmodel.h
+++ b/src/library/trackmodel.h
@@ -201,6 +201,10 @@ class TrackModel {
     /*non-virtual*/ bool hasCapabilities(Capabilities caps) const {
         return (getCapabilities() & caps) == caps;
     }
+    // Return false via overrides in incompatible track models
+    virtual bool canLoadTrackSetColumns() const {
+        return true;
+    }
     virtual QString getModelSetting(const QString& name) {
         SettingsDAO settings(m_db);
         QString key = m_settingsNamespace + "." + name;
@@ -211,6 +215,15 @@ class TrackModel {
         SettingsDAO settings(m_db);
         QString key = m_settingsNamespace + "." + name;
         return settings.setValue(key, value);
+    }
+
+    QString getCommonHeaderState() {
+        SettingsDAO settings(m_db);
+        return settings.getValue("common_header_state_pb");
+    }
+    bool setCommonHeaderState(const QVariant& value) {
+        SettingsDAO settings(m_db);
+        return settings.setValue("common_header_state_pb", value);
     }
 
     virtual int defaultSortColumn() const {

--- a/src/widget/wtracktableviewheader.h
+++ b/src/widget/wtracktableviewheader.h
@@ -5,12 +5,15 @@
 #include <QMenu>
 
 #include "proto/headers.pb.h"
+#include "util/parented_ptr.h"
 
 class TrackModel;
 class QAction;
 class QCheckBox;
 class QContextMenuEvent;
 class QWidget;
+class QWidgetAction;
+class WMenuCheckBox;
 class WTrackTableViewHeader;
 
 // Thanks to StackOverflow http://stackoverflow.com/questions/1163030/qt-qtableview-and-horizontalheader-restorestate
@@ -65,9 +68,6 @@ class WTrackTableViewHeader : public QHeaderView {
     void saveHeaderState();
     void restoreHeaderState();
     void loadDefaultHeaderState();
-    // Try to load the saved common header state.
-    void loadCommonHeaderState();
-    void storeAsCommonHeaderState();
 
     // Returns false if the header state is not stored in the database (on first time usage)
     bool hasPersistedHeaderState();
@@ -101,13 +101,23 @@ class WTrackTableViewHeader : public QHeaderView {
   private:
     int hiddenCount();
     void updateMenu();
+    void updateCommonHeaderActions();
     bool shouldSyncWithCommonHeaderState();
+    // Try to load the saved common header state.
+    void loadCommonHeaderState();
+    void storeAsCommonHeaderState();
     TrackModel* getTrackModel();
 
     void setHeightForFont();
 
-    QMenu m_menu;
+    parented_ptr<QMenu> m_pMenu;
     QMap<int, QCheckBox*> m_columnCheckBoxes;
+
+    parented_ptr<QAction> m_pStoreAsCommontHeaderAction;
+    parented_ptr<QAction> m_pLoadCommonHeaderAction;
+    parented_ptr<WMenuCheckBox> m_pSyncCheckBox;
+    parented_ptr<QWidgetAction> m_pSyncAction;
+    parented_ptr<QAction> m_pShuffleAction;
 
     int m_preferredHeight;
     QMap<int, int> m_hiddenColumnSizes;

--- a/src/widget/wtracktableviewheader.h
+++ b/src/widget/wtracktableviewheader.h
@@ -16,7 +16,7 @@ class WTrackTableViewHeader;
 // Thanks to StackOverflow http://stackoverflow.com/questions/1163030/qt-qtableview-and-horizontalheader-restorestate
 // answer with this code snippet: http://codepad.org/2gPIMPYU
 class HeaderViewState {
-public:
+  public:
     HeaderViewState() {}
 
     // Populate the object based on the provided live view.
@@ -31,9 +31,10 @@ public:
 
     // Returns a serialized protobuf of the current state.
     QString saveState() const;
-    // Apply the state to the provided view.  The data in the object may be
+    // Apply the state to the provided view. The data in the object may be
     // changed if the header format has changed.
-    void restoreState(WTrackTableViewHeader* pHeaders);
+    // Don't sort if explicitly disabled, for example when cloning the Tracks header.
+    void restoreState(WTrackTableViewHeader* pHeaders, bool sort = true);
 
     // returns false if no headers are listed to be shown.
     bool healthy() const {
@@ -48,7 +49,7 @@ public:
         return false;
     }
 
-private:
+  private:
     mixxx::library::HeaderViewState m_view_state;
 };
 
@@ -64,6 +65,10 @@ class WTrackTableViewHeader : public QHeaderView {
     void saveHeaderState();
     void restoreHeaderState();
     void loadDefaultHeaderState();
+    // Try to load the saved common header state.
+    void loadCommonHeaderState();
+    void storeAsCommonHeaderState();
+
     // Returns false if the header state is not stored in the database (on first time usage)
     bool hasPersistedHeaderState();
 
@@ -91,10 +96,12 @@ class WTrackTableViewHeader : public QHeaderView {
 
   private slots:
     void showOrHideColumn(int);
+    void toggleSyncCommonHeaderState(bool checked);
 
   private:
     int hiddenCount();
-    void clearActions();
+    void updateMenu();
+    bool shouldSyncWithCommonHeaderState();
     TrackModel* getTrackModel();
 
     void setHeightForFont();

--- a/src/widget/wtracktableviewheader.h
+++ b/src/widget/wtracktableviewheader.h
@@ -37,7 +37,7 @@ class HeaderViewState {
     // Apply the state to the provided view. The data in the object may be
     // changed if the header format has changed.
     // Don't sort if explicitly disabled, for example when cloning the Tracks header.
-    void restoreState(WTrackTableViewHeader* pHeaders, bool sort = true);
+    void restoreState(WTrackTableViewHeader* pHeaders, bool restoreCommonState);
 
     // returns false if no headers are listed to be shown.
     bool healthy() const {
@@ -66,8 +66,6 @@ class WTrackTableViewHeader : public QHeaderView {
     void setModel(QAbstractItemModel* model) override;
 
     void saveHeaderState();
-    void restoreHeaderState();
-    void loadDefaultHeaderState();
 
     // Returns false if the header state is not stored in the database (on first time usage)
     bool hasPersistedHeaderState();
@@ -103,6 +101,8 @@ class WTrackTableViewHeader : public QHeaderView {
     void updateMenu();
     void updateCommonHeaderActions();
     bool shouldSyncWithCommonHeaderState();
+    void restoreHeaderState();
+    void loadDefaultHeaderState();
     // Try to load the saved common header state.
     void loadCommonHeaderState();
     void storeAsCommonHeaderState();


### PR DESCRIPTION
### Save & restore a custom columns layout
1.  adjust column layout in any of the internal features (haven't tested external ones like Traktor, iTunes etc.)
2. header menu -> "Save columns layout"
3. switch to another feature
4. header menu -> "Load saved columns layout"
5. layout is applied, current sorting persists

### Sync model's header with the custom layout
Tick the box and the saved layout will be loaded(so save first if you want the current layout to become the Sync layout!).
Every view where this is enabled will automatically load the saved layout, and adjustments in any of them will persist.
<img width="446" height="172" alt="image" src="https://github.com/user-attachments/assets/101c9f1a-0d75-4ff6-bf22-e698bec35abe" />

### Note / only limitation I noticed
Due to how the header is stored, it is not able to save model-specific columns (#, 'added to playlist').
For example if you store the layout in _Playlists_ with the _#_ column visible, that can not be shown in _Tracks_ or _Crates_. So when you switch from _Crates_ back to _Playlists_, it saves the  columns available in _Crates_ and the _#_ column will be gone in _Playlists_.

These functions are disabled in models that don't show/support the main library columns.
Currently this is only _Computer_ but there may be others, like the external views like Traktor, iTunes etc.
Please test!

Btw: works nicely with #14687 in **Computer** if library table model is used : )


Related:
#3063 https://github.com/mixxxdj/mixxx/pull/3063#issuecomment-774340023
#2046