### PR TITLE
Show All StemStreams of StemTracks In TrackTable -> Draft -> Let's have a discussion

### DIFF
--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -23,6 +23,26 @@ enum class StemChannel {
     All = First | Second | Third | Fourth
 };
 Q_DECLARE_FLAGS(StemChannelSelection, StemChannel);
+
+// Helper function to extract StemChannelSelection from a track title
+inline StemChannelSelection extractStemMaskFromTitle(const QString& title) {
+    qDebug() << "Extracting stem mask from title:" << title;
+    if (title.endsWith(" [Drums]")) {
+        return StemChannel::First;
+    } else if (title.endsWith(" [Bass]")) {
+        return StemChannel::Second;
+    } else if (title.endsWith(" [Other]")) {
+        return StemChannel::Third;
+    } else if (title.endsWith(" [Vocals]")) {
+        return StemChannel::Fourth;
+    } else if (title.endsWith(" [Pre-Mixed Stereo]")) {
+        return StemChannel::All;
+    } else {
+        // Default -> Stems working with controls
+        qDebug() << "No match found, returning default StemChannel::All";
+        return StemChannel::None;
+    }
+}
 #endif
 
 // Contains the information needed to process a buffer of audio

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -399,7 +399,8 @@ void BaseSqlTableModel::select() {
 
                     iCounter = rowInfos.size() - 1;
                     const RowInfo& rowInfo = rowInfos[iCounter];
-                    QVariant title = rowInfo.columnValues[ColumnCache::COLUMN_LIBRARYTABLE_TITLE];
+                    // QVariant title =
+                    // rowInfo.columnValues[ColumnCache::COLUMN_LIBRARYTABLE_TITLE];
                 }
             }
         }
@@ -486,7 +487,7 @@ void BaseSqlTableModel::select() {
 TrackId BaseSqlTableModel::generateStemTrackId(
         const TrackId& parentTrackId,
         const QString& stemFileName) {
-    QString idString = QString("%1-%2").arg(parentTrackId.toString()).arg(stemFileName);
+    QString idString = QString("%1-%2").arg(parentTrackId.toString(), stemFileName);
     return TrackId(idString);
 }
 

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -398,7 +398,7 @@ void BaseSqlTableModel::select() {
                     // after modification: " << rowInfos.back().columnValues;
 
                     iCounter = rowInfos.size() - 1;
-                    const RowInfo& rowInfo = rowInfos[iCounter];
+                    // const RowInfo& rowInfo = rowInfos[iCounter];
                     // QVariant title =
                     // rowInfo.columnValues[ColumnCache::COLUMN_LIBRARYTABLE_TITLE];
                 }

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -13,6 +13,8 @@
 #include "moc_basesqltablemodel.cpp"
 #include "track/keyutils.h"
 #include "track/track.h"
+// EVE
+#include "track/steminfoimporter.h"
 #include "track/trackmetadata.h"
 #include "util/assert.h"
 #include "util/datetime.h"
@@ -221,6 +223,52 @@ void BaseSqlTableModel::select() {
     PerformanceTimer time;
     time.start();
 
+    ///////
+    //  qDebug() << "NO CACHE USED";
+
+    //  if (m_tableName.startsWith("crate")) {
+    //    // EVE drop view and rebuild it for Searchcrate
+    //    //        qDebug() << "[BASESQLTABLEMODEL] [SELECT] -> [SMARTIES] Drop
+    //    //        temp table " << m_tableName;
+    //    QString queryStringDropView = QString("DROP VIEW IF EXISTS %1 ").arg(m_tableName);
+    //    FwdSqlQuery(m_database, queryStringDropView).execPrepared();
+    //    //        qDebug() << "[BASESQLTABLEMODEL] [SELECT] -> [SMARTIES] REBUILD TEMP";
+    //    QStringList columns;
+    //    QString crateId = m_tableName;
+    //    crateId = crateId.replace("crate_", "");
+
+    //    columns << "library." + LIBRARYTABLE_ID
+    //            << "'' AS " + LIBRARYTABLE_PREVIEW
+    //            // For sorting the cover art column we give LIBRARYTABLE_COVERART
+    //            // the same value as the cover digest.
+    //            << LIBRARYTABLE_COVERART_DIGEST + " AS " + LIBRARYTABLE_COVERART
+    //            << "library." + LIBRARYTABLE_TITLE
+    //            << "library." + LIBRARYTABLE_FILETYPE
+    //            << "track_locations." + TRACKLOCATIONSTABLE_LOCATION;
+
+    //    QString queryString =
+    //            QString("CREATE TEMPORARY VIEW IF NOT EXISTS %1 AS "
+    //                    "SELECT %2 FROM %3 "
+    //                    "INNER JOIN track_locations "
+    //                    "ON library.location=track_locations.id "
+    //                    //"WHERE %4 IN (%5) "
+    //                    "WHERE %4 IN (SELECT %5 FROM %6 WHERE %7 = %8) "
+    //                    "AND %9=0")
+    //                    .arg(m_tableName,
+    //                            columns.join(","),
+    //                            LIBRARY_TABLE,
+    //                            "library." + LIBRARYTABLE_ID,
+    //                            "crate_tracks.track_id",
+    //                            "crate_tracks",
+    //                            "crate_tracks.crate_id",
+    //                            crateId,
+    //                            LIBRARYTABLE_MIXXXDELETED);
+    //    qDebug() << "Query String:" << queryString;
+    //    FwdSqlQuery(m_database, queryString).execPrepared();
+    //}
+
+    ///////
+
     // Prepare query for id and all columns not in m_trackSource
     QString queryString = QString("SELECT %1 FROM %2 %3")
                                   .arg(m_tableColumns.join(","), m_tableName, m_tableOrderBy);
@@ -254,6 +302,14 @@ void BaseSqlTableModel::select() {
     QSet<TrackId> trackIds;
     int idColumn = -1;
     int posColumn = -1;
+
+    QString fileType;
+    QString filePath;
+    QString trackTitle;
+    int fileTypeIndex;
+    int filePathIndex;
+    int titleIndex;
+    int iCounter;
     while (query.next()) {
         QSqlRecord sqlRecord = query.record();
 
@@ -288,6 +344,65 @@ void BaseSqlTableModel::select() {
             rowInfo.columnValues.push_back(sqlRecord.value(i));
         }
         rowInfos.push_back(rowInfo);
+
+        if (m_tableName.contains("crate")) {
+            // EVE
+            fileTypeIndex = fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_FILETYPE);
+            filePathIndex = fieldIndex(ColumnCache::COLUMN_TRACKLOCATIONSTABLE_LOCATION);
+            titleIndex = fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_TITLE);
+
+            if (fileTypeIndex != -1 && filePathIndex != -1) {
+                fileType = sqlRecord.value(fileTypeIndex).toString();
+                filePath = sqlRecord.value(filePathIndex).toString();
+                trackTitle = sqlRecord.value(titleIndex).toString();
+
+                // qDebug() << "[BaseSqlTableModel::select()] -> fileType: " << fileType;
+                // qDebug() << "[BaseSqlTableModel::select()] -> filePath: " << filePath;
+                // qDebug() << "[BaseSqlTableModel::select()] -> trackTitle: " << trackTitle;
+            } else {
+                // qDebug() << "[BaseSqlTableModel::select()] -> Invalid column indices!";
+            }
+
+            // if stem -> add stemtracks
+
+            if (fileType == "stem.mp4") {
+                // qDebug() << "[BaseSqlTableModel::select()] -> Stem -> filetype: " << fileType;
+                // Get the StemTracks
+                QList<StemRow> stemTracks = loadStemTracks(filePath);
+                for (int i = 0; i < stemTracks.size(); ++i) {
+                    const StemRow& stemTrack = stemTracks[i];
+
+                    // Copy current RowInfo -> put stemData in it
+                    // qDebug() << "[BaseSqlTableModel::select()] -> RowInfo: "
+                    // << rowInfo.columnValues;
+                    RowInfo stemRowInfo = rowInfo;
+                    // Row Number
+                    stemRowInfo.row = rowInfos.size();
+
+                    int titleIndex = fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_TITLE);
+                    if (titleIndex == -1) {
+                        // qDebug() << "[BaseSqlTableModel::select()] -> RowInfo
+                        // -> titleIndex: "Invalid title index!";
+                        continue;
+                    }
+                    QString newTitle = trackTitle + " [" + stemTrack.trackName + "]";
+                    stemRowInfo.columnValues[titleIndex] = QVariant(newTitle);
+                    // qDebug() << "[BaseSqlTableModel::select()] ->
+                    // stemRowInfo: "
+                    //          << "Original Title:" << trackTitle;
+                    //          << "New Title: " << newTitle;
+                    // qDebug() << "[BaseSqlTableModel::select()] -> Modified
+                    // columnValues:" << stemRowInfo.columnValues;
+                    rowInfos.push_back(stemRowInfo);
+                    // qDebug() << "[BaseSqlTableModel::select()] -> New RowInfo
+                    // after modification: " << rowInfos.back().columnValues;
+
+                    iCounter = rowInfos.size() - 1;
+                    const RowInfo& rowInfo = rowInfos[iCounter];
+                    QVariant title = rowInfo.columnValues[ColumnCache::COLUMN_LIBRARYTABLE_TITLE];
+                }
+            }
+        }
     }
 
     if (sDebug) {
@@ -352,16 +467,45 @@ void BaseSqlTableModel::select() {
         DEBUG_ASSERT(trackPosToRows.size() == rowInfos.size());
     }
 
-    // We're done! Issue the update signals and replace the main maps.
+    // qDebug() << "[BaseSqlTableModel::select()] -> RowInfo -> Rows before
+    // replacement:" << m_rowInfo.size(); We're done! Issue the update signals
+    // and replace the main maps.
     replaceRows(
             std::move(rowInfos),
             std::move(trackIdToRows),
             std::move(trackPosToRows));
     // Both rowInfo and trackIdToRows (might) have been moved and
     // must not be used afterwards!
+    // qDebug() << "[BaseSqlTableModel::select()] -> RowInfo: -> Rows after
+    // replacement:" << m_rowInfo.size();
 
     qDebug() << this << "select() returned" << m_rowInfo.size()
              << "results in" << time.elapsed().debugMillisWithUnit();
+}
+
+TrackId BaseSqlTableModel::generateStemTrackId(
+        const TrackId& parentTrackId,
+        const QString& stemFileName) {
+    QString idString = QString("%1-%2").arg(parentTrackId.toString()).arg(stemFileName);
+    return TrackId(idString);
+}
+
+QList<BaseSqlTableModel::StemRow> BaseSqlTableModel::loadStemTracks(const QString& filePath) {
+    QList<BaseSqlTableModel::StemRow> stemRows;
+    // qDebug() << "[BaseSqlTableModel::loadStemTracks] -> loadStemTracks for filepath" << filePath;
+    QStringList stemNames = {
+            //"Stem-Mixing",
+            "Pre-Mixed Stereo",
+            "Drums",
+            "Bass",
+            "Other",
+            "Vocals"};
+
+    for (const QString& stemName : stemNames) {
+        stemRows.append(StemRow(filePath, stemName, "stem.mp4"));
+    }
+
+    return stemRows;
 }
 
 void BaseSqlTableModel::setTable(QString tableName,
@@ -371,6 +515,8 @@ void BaseSqlTableModel::setTable(QString tableName,
     if (sDebug) {
         qDebug() << this << "setTable" << tableName << tableColumns << idColumn;
     }
+    qDebug() << "m_tableColumns" << m_tableColumns;
+
     m_tableName = std::move(tableName);
     m_idColumn = std::move(idColumn);
     m_tableColumns = std::move(tableColumns);
@@ -675,6 +821,9 @@ QVariant BaseSqlTableModel::rawValue(
         }
 
         const QVector<QVariant>& columnValues = rowInfo.columnValues;
+        // qDebug() << "[BaseSqlTableModel::rawValue] -> Returning value for row:" << row
+        //          << "column:" << column
+        //          << "value:" << columnValues.at(column);
         if (sDebug) {
             qDebug() << "Returning table-column value"
                      << columnValues.at(column)

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -309,7 +309,7 @@ void BaseSqlTableModel::select() {
     int fileTypeIndex;
     int filePathIndex;
     int titleIndex;
-    int iCounter;
+    // int iCounter;
     while (query.next()) {
         QSqlRecord sqlRecord = query.record();
 
@@ -397,7 +397,7 @@ void BaseSqlTableModel::select() {
                     // qDebug() << "[BaseSqlTableModel::select()] -> New RowInfo
                     // after modification: " << rowInfos.back().columnValues;
 
-                    iCounter = rowInfos.size() - 1;
+                    // iCounter = rowInfos.size() - 1;
                     // const RowInfo& rowInfo = rowInfos[iCounter];
                     // QVariant title =
                     // rowInfo.columnValues[ColumnCache::COLUMN_LIBRARYTABLE_TITLE];

--- a/src/library/basesqltablemodel.h
+++ b/src/library/basesqltablemodel.h
@@ -9,6 +9,8 @@
 #include "util/class.h"
 
 class TrackCollectionManager;
+class StemInfoImporter;
+struct StemRow;
 
 // BaseSqlTableModel is a custom-written SQL-backed table which aggressively
 // caches the contents of the table and supports lightweight updates.
@@ -20,6 +22,22 @@ class BaseSqlTableModel : public BaseTrackTableModel {
             TrackCollectionManager* pTrackCollectionManager,
             const char* settingsNamespace);
     ~BaseSqlTableModel() override;
+
+    struct StemRow {
+        QString filePath;
+        QString trackName;
+        QString trackType; // = StemTrack Name
+
+        StemRow(const QString& path, const QString& name, const QString& type)
+                : filePath(path),
+                  trackName(name),
+                  trackType(type) {
+        }
+    };
+
+    // EVE
+    QList<BaseSqlTableModel::StemRow> loadStemTracks(const QString& filePath);
+    TrackId generateStemTrackId(const TrackId& parentTrackId, const QString& stemFileName);
 
     // Returns true if the BaseSqlTableModel has been initialized. Calling data
     // access methods on a BaseSqlTableModel which is not initialized is likely
@@ -129,6 +147,8 @@ class BaseSqlTableModel : public BaseTrackTableModel {
         int row;
         QVector<QVariant> columnValues;
 
+        StemRow* stemRow = nullptr;
+
         int getPosition(int posCol) const {
             if (posCol < 0) {
                 return -1;
@@ -149,6 +169,11 @@ class BaseSqlTableModel : public BaseTrackTableModel {
                 return true;
             }
             return row < other.row;
+        }
+
+        // RowInfo has stem data?
+        bool hasStemData() const {
+            return stemRow != nullptr;
         }
     };
 

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -551,23 +551,53 @@ void Library::slotLoadTrack(TrackPointer pTrack) {
     emit loadTrack(pTrack);
 }
 
-void Library::slotLoadLocationToPlayer(const QString& location, const QString& group, bool play) {
+#ifdef __STEM__
+void Library::slotLoadLocationToPlayer(
+        const QString& location,
+        const QString& group,
+        mixxx::StemChannelSelection stemMask,
+        bool play) {
     auto trackRef = TrackRef::fromFilePath(location);
     TrackPointer pTrack = m_pTrackCollectionManager->getOrAddTrack(trackRef);
     if (pTrack) {
-#ifdef __STEM__
-        emit loadTrackToPlayer(pTrack, group, mixxx::StemChannelSelection(), play);
-#else
-        emit loadTrackToPlayer(pTrack, group, play);
-#endif
+        // qDebug() << "[Library::slotLoadLocationToPlayer] triggered";
+        // qDebug() << "[Library::slotLoadLocationToPlayer] -> sender() " <<
+        // sender(); qDebug() << "[Library::slotLoadLocationToPlayer] ->
+        // pNewTrack->getTitle(): " << pTrack->getTitle(); qDebug() <<
+        // "[Library::slotLoadLocationToPlayer] -> stemMask " << stemMask;
+        // qDebug() << "[Library::slotLoadLocationToPlayer] -> bPlay " << play;
+        // emit loadTrackToPlayer(pTrack, group, mixxx::StemChannelSelection(),
+        // play);
+        emit loadTrackToPlayer(pTrack, group, stemMask, play);
     }
 }
+#else
+void Library::slotLoadLocationToPlayer(
+        const QString& location,
+        const QString& group,
+        bool play) {
+    auto trackRef = TrackRef::fromFilePath(location);
+    TrackPointer pTrack = m_pTrackCollectionManager->getOrAddTrack(trackRef);
+    if (pTrack) {
+        emit loadTrackToPlayer(pTrack, group, play);
+    }
+}
+#endif
 
 #ifdef __STEM__
 void Library::slotLoadTrackToPlayer(TrackPointer pTrack,
         const QString& group,
         mixxx::StemChannelSelection stemMask,
         bool play) {
+    // qDebug() << "[Library::slotLoadTrackToPlayer] triggered";
+    // qDebug() << "[Library::slotLoadTrackToPlayer] -> sender() " << sender();
+    if (pTrack) {
+        // qDebug() << "[Library::slotLoadTrackToPlayer] ->
+        // pNewTrack->getTitle(): " << pTrack->getTitle();
+    }
+    // qDebug() << "[Library::slotLoadTrackToPlayer] -> stemMask " << stemMask;
+    // qDebug() << "[Library::slotLoadTrackToPlayer] -> bPlay " << play;
+
     emit loadTrackToPlayer(pTrack, group, stemMask, play);
 }
 #else

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -122,7 +122,15 @@ class Library: public QObject {
 #else
     void slotLoadTrackToPlayer(TrackPointer pTrack, const QString& group, bool play);
 #endif
+
+#ifdef __STEM__
+    void slotLoadLocationToPlayer(const QString& location,
+            const QString& group,
+            mixxx::StemChannelSelection stemMask,
+            bool play);
+#else
     void slotLoadLocationToPlayer(const QString& location, const QString& group, bool play);
+#endif
     void slotRefreshLibraryModels();
     void slotCreatePlaylist();
     void slotCreateCrate();

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -652,6 +652,7 @@ void LibraryControl::slotLoadSelectedTrackToGroup(const QString& group, bool pla
     WTrackTableView* pTrackTableView = m_pLibraryWidget->getCurrentTrackTableView();
     if (pTrackTableView) {
 #ifdef __STEM__
+        qDebug() << "LibraryControl::slotLoadSelectedTrackToGroup -> stemMask: " << stemMask;
         pTrackTableView->loadSelectedTrackToGroup(group, stemMask, play);
 #else
         pTrackTableView->loadSelectedTrackToGroup(group, play);

--- a/src/library/rowinfo.h
+++ b/src/library/rowinfo.h
@@ -1,0 +1,50 @@
+// rowinfo.h
+#pragma once
+#include <QColor>
+#include <QSqlRecord>
+#include <QString>
+
+class RowInfo {
+  public:
+    RowInfo()
+            : m_trackId(-1) {
+    }
+
+    const QString& getLabel() const {
+        return m_label;
+    }
+
+    void setLabel(const QString& label) {
+        m_label = label;
+    }
+
+    const QColor& getColor() const {
+        return m_color;
+    }
+
+    void setColor(const QColor& color) {
+        m_color = color;
+    }
+
+    int getTrackId() const {
+        return m_trackId;
+    }
+
+    void setTrackId(int trackId) {
+        m_trackId = trackId;
+    }
+
+    const QSqlRecord& getSqlRecord() const {
+        return m_sqlRecord;
+    }
+
+    void setSqlRecord(const QSqlRecord& sqlRecord) {
+        m_sqlRecord = sqlRecord;
+    }
+
+  private:
+    QString m_label;
+    QColor m_color;
+    int m_trackId;
+    QSqlRecord m_sqlRecord;
+};

--- a/src/library/trackset/crate/cratestorage.cpp
+++ b/src/library/trackset/crate/cratestorage.cpp
@@ -412,9 +412,9 @@ uint CrateStorage::countCrateTracks(CrateId crateId) const {
 //static
 QString CrateStorage::formatSubselectQueryForCrateTrackIds(CrateId crateId) {
     return QStringLiteral("SELECT %1 FROM %2 WHERE %3=%4")
-            .arg(CRATETRACKSTABLE_TRACKID,
+            .arg("crate_tracks." + CRATETRACKSTABLE_TRACKID,
                     CRATE_TRACKS_TABLE,
-                    CRATETRACKSTABLE_CRATEID,
+                    "crate_tracks." + CRATETRACKSTABLE_CRATEID,
                     crateId.toString());
 }
 

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -550,6 +550,15 @@ void BaseTrackPlayerImpl::disconnectLoadedTrack() {
 void BaseTrackPlayerImpl::slotLoadTrack(TrackPointer pNewTrack,
         mixxx::StemChannelSelection stemMask,
         bool bPlay) {
+    qDebug() << "BaseTrackPlayerImpl::slotLoadTrack -> sender() " << sender();
+    if (pNewTrack) {
+        qDebug() << "BaseTrackPlayerImpl::slotLoadTrack -> "
+                    "pNewTrack->getTitle(): "
+                 << pNewTrack->getTitle();
+    }
+    qDebug() << "BaseTrackPlayerImpl::slotLoadTrack -> stemMask " << stemMask;
+    qDebug() << "BaseTrackPlayerImpl::slotLoadTrack -> bPlay " << bPlay;
+
 #else
 void BaseTrackPlayerImpl::slotLoadTrack(TrackPointer pNewTrack,
         bool bPlay) {
@@ -560,7 +569,6 @@ void BaseTrackPlayerImpl::slotLoadTrack(TrackPointer pNewTrack,
     if (pNewTrack) {
         auto fileInfo = pNewTrack->getFileInfo();
         if (!Sandbox::askForAccess(&fileInfo)) {
-            // We don't have access.
             return;
         }
     }
@@ -577,6 +585,7 @@ void BaseTrackPlayerImpl::slotLoadTrack(TrackPointer pNewTrack,
     // Request a new track from EngineBuffer
     EngineBuffer* pEngineBuffer = m_pChannel->getEngineBuffer();
 #ifdef __STEM__
+    qDebug() << "BaseTrackPlayerImpl::slotLoadTrack -> stemMask" << stemMask;
     pEngineBuffer->loadTrack(pNewTrack,
             stemMask,
             bPlay,
@@ -621,6 +630,7 @@ void BaseTrackPlayerImpl::slotLoadFailed(TrackPointer pTrack, const QString& rea
 
 void BaseTrackPlayerImpl::slotTrackLoaded(TrackPointer pNewTrack,
                                           TrackPointer pOldTrack) {
+    qDebug() << "BaseTrackPlayerImpl::slotTrackLoaded triggered by sender" << sender();
     //qDebug() << "BaseTrackPlayerImpl::slotTrackLoaded" << pNewTrack.get() << pOldTrack.get();
     if (!pNewTrack &&
             pOldTrack &&
@@ -815,6 +825,7 @@ void BaseTrackPlayerImpl::slotLoadTrackFromSampler(double d) {
 }
 
 void BaseTrackPlayerImpl::loadTrackFromGroup(const QString& group) {
+    qDebug() << "BaseTrackPlayerImpl::loadTrackFromGroup triggered";
     EngineChannel* pChannel = m_pEngineMixer->getChannel(group);
     if (!pChannel) {
         return;

--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -676,6 +676,16 @@ void PlayerManager::slotLoadTrackToPlayer(TrackPointer pTrack,
         const QString& group,
         mixxx::StemChannelSelection stemMask,
         bool play) {
+    qDebug() << "[PlayerManager::slotLoadTrackToPlayer] triggered";
+    qDebug() << "[PlayerManager::slotLoadTrackToPlayer] -> sender() " << sender();
+    if (pTrack) {
+        qDebug() << "[PlayerManager::slotLoadTrackToPlayer] -> "
+                    "pNewTrack->getTitle(): "
+                 << pTrack->getTitle();
+    }
+    qDebug() << "[PlayerManager::slotLoadTrackToPlayer] -> stemMask " << stemMask;
+    qDebug() << "[PlayerManager::slotLoadTrackToPlayer] -> bPlay " << play;
+
 #else
 void PlayerManager::slotLoadTrackToPlayer(
         TrackPointer pTrack, const QString& group, bool play) {
@@ -740,15 +750,40 @@ void PlayerManager::slotLoadTrackToPlayer(
     m_lastLoadedPlayer = group;
 }
 
+#ifdef __STEM__
+void PlayerManager::slotLoadLocationToPlayer(
+        const QString& location,
+        const QString& group,
+        mixxx::StemChannelSelection stemMask = mixxx::StemChannel::All,
+        bool play = false) {
+#else
 void PlayerManager::slotLoadLocationToPlayer(
         const QString& location, const QString& group, bool play) {
-    // The library will get the track and then signal back to us to load the
-    // track via slotLoadTrackToPlayer.
+#endif
+
+// void PlayerManager::slotLoadLocationToPlayer(
+//         const QString& location, const QString& group, bool play) {
+//  The library will get the track and then signal back to us to load the
+//  track via slotLoadTrackToPlayer.
+#ifdef __STEM__
+    emit loadLocationToPlayer(location, group, stemMask, play);
+#else
     emit loadLocationToPlayer(location, group, play);
+#endif
 }
 
+#ifdef __STEM__
+void PlayerManager::slotLoadLocationToPlayerMaybePlay(
+        const QString& location, const QString& group, mixxx::StemChannelSelection stemMask) {
+    qDebug() << "[PlayerManager::slotLoadLocationToPlayerMaybePlay] triggered";
+    qDebug() << "[PlayerManager::slotLoadLocationToPlayerMaybePlay] -> sender() " << sender();
+    qDebug() << "[PlayerManager::slotLoadLocationToPlayerMaybePlay] -> location: " << location;
+    qDebug() << "[PlayerManager::slotLoadLocationToPlayerMaybePlay] -> stemMask " << stemMask;
+#else
 void PlayerManager::slotLoadLocationToPlayerMaybePlay(
         const QString& location, const QString& group) {
+#endif
+
     bool play = false;
     LoadWhenDeckPlaying loadWhenDeckPlaying = m_pConfig->getValue(
             kConfigKeyLoadWhenDeckPlaying, kDefaultLoadWhenDeckPlaying);
@@ -763,19 +798,44 @@ void PlayerManager::slotLoadLocationToPlayerMaybePlay(
         }
         break;
     }
+#ifdef __STEM__
+    slotLoadLocationToPlayer(location, group, stemMask, play);
+#else
     slotLoadLocationToPlayer(location, group, play);
+#endif
 }
 
 void PlayerManager::slotLoadToDeck(const QString& location, int deck) {
+#ifdef __STEM__
+    slotLoadLocationToPlayer(location,
+            groupForDeck(deck - 1),
+            mixxx::StemChannelSelection(),
+            false);
+#else
     slotLoadLocationToPlayer(location, groupForDeck(deck - 1), false);
+#endif
 }
 
 void PlayerManager::slotLoadToPreviewDeck(const QString& location, int previewDeck) {
+#ifdef __STEM__
+    slotLoadLocationToPlayer(location,
+            groupForPreviewDeck(previewDeck - 1),
+            mixxx::StemChannelSelection(),
+            false);
+#else
     slotLoadLocationToPlayer(location, groupForPreviewDeck(previewDeck - 1), false);
+#endif
 }
 
 void PlayerManager::slotLoadToSampler(const QString& location, int sampler) {
+#ifdef __STEM__
+    slotLoadLocationToPlayer(location,
+            groupForSampler(sampler - 1),
+            mixxx::StemChannelSelection(),
+            false);
+#else
     slotLoadLocationToPlayer(location, groupForSampler(sampler - 1), false);
+#endif
 }
 
 void PlayerManager::slotLoadTrackIntoNextAvailableDeck(TrackPointer pTrack) {
@@ -801,7 +861,11 @@ void PlayerManager::slotLoadLocationIntoNextAvailableDeck(const QString& locatio
         return;
     }
 
+#ifdef __STEM__
+    slotLoadLocationToPlayer(location, pDeck->getGroup(), mixxx::StemChannelSelection(), play);
+#else
     slotLoadLocationToPlayer(location, pDeck->getGroup(), play);
+#endif
 }
 
 void PlayerManager::slotLoadTrackIntoNextAvailableSampler(TrackPointer pTrack) {

--- a/src/mixer/playermanager.h
+++ b/src/mixer/playermanager.h
@@ -202,8 +202,19 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
 #else
     void slotLoadTrackToPlayer(TrackPointer pTrack, const QString& group, bool play);
 #endif
-    void slotLoadLocationToPlayer(const QString& location, const QString& group, bool play);
+#ifdef __STEM__
+    void slotLoadLocationToPlayer(const QString& location,
+            const QString& group,
+            mixxx::StemChannelSelection stemMask,
+            bool play);
+    void slotLoadLocationToPlayerMaybePlay(const QString& location,
+            const QString& group,
+            mixxx::StemChannelSelection stemMask = mixxx::StemChannel::All);
+#else
+    void slotLoadLocationToPlayer(
+            const QString& location, const QString& group, bool play);
     void slotLoadLocationToPlayerMaybePlay(const QString& location, const QString& group);
+#endif
 
     void slotCloneDeck(const QString& source_group, const QString& target_group);
 
@@ -237,7 +248,15 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
     void onTrackAnalysisFinished();
 
   signals:
+#ifdef __STEM__
+    void loadLocationToPlayer(
+            const QString& location,
+            const QString& group,
+            mixxx::StemChannelSelection stemMask = mixxx::StemChannel::All,
+            bool play = false);
+#else
     void loadLocationToPlayer(const QString& location, const QString& group, bool play);
+#endif
 
     // Emitted when the user tries to enable a microphone talkover control when
     // there is no input configured.

--- a/src/mixer/samplerbank.cpp
+++ b/src/mixer/samplerbank.cpp
@@ -219,7 +219,15 @@ bool SamplerBank::loadSamplerBankFromPath(const QString& samplerBankPath) {
 #endif
                                 false);
                     } else {
+//                        m_pPlayerManager->slotLoadLocationToPlayer(location, group, false);
+#ifdef __STEM__
+                        m_pPlayerManager->slotLoadLocationToPlayer(location,
+                                group,
+                                mixxx::StemChannelSelection(),
+                                false);
+#else
                         m_pPlayerManager->slotLoadLocationToPlayer(location, group, false);
+#endif
                     }
                 }
             }

--- a/src/qml/qmlplayermanagerproxy.cpp
+++ b/src/qml/qmlplayermanagerproxy.cpp
@@ -56,7 +56,12 @@ void QmlPlayerManagerProxy::loadLocationUrlIntoNextAvailableDeck(
 
 void QmlPlayerManagerProxy::loadLocationToPlayer(
         const QString& location, const QString& group, bool play) {
+//    m_pPlayerManager->slotLoadLocationToPlayer(location, group, play);
+#ifdef __STEM__
+    m_pPlayerManager->slotLoadLocationToPlayer(location, group, mixxx::StemChannel::All, play);
+#else
     m_pPlayerManager->slotLoadLocationToPlayer(location, group, play);
+#endif
 }
 
 // static

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -1047,9 +1047,13 @@ QWidget* LegacySkinParser::parseOverview(const QDomElement& node) {
             new WOverview(group, m_pPlayerManager, m_pConfig, m_pParent);
 
     connect(overviewWidget,
-            &WOverview::trackDropped,
+            &WOverview::emitTrackDropped,
             m_pPlayerManager,
             &PlayerManager::slotLoadLocationToPlayerMaybePlay);
+    // connect(overviewWidget,
+    //         &WOverview::trackDropped,
+    //         m_pPlayerManager,
+    //         &PlayerManager::slotLoadLocationToPlayerMaybePlay);
     connect(overviewWidget, &WOverview::cloneDeck,
             m_pPlayerManager, &PlayerManager::slotCloneDeck);
     // This signal stems from AnalysisFeature, and the overview can now
@@ -1121,9 +1125,14 @@ QWidget* LegacySkinParser::parseVisual(const QDomElement& node) {
             &WWaveformViewer::slotTrackUnloaded);
 
     connect(viewer,
-            &WWaveformViewer::trackDropped,
+            &WWaveformViewer::emitTrackDropped,
             m_pPlayerManager,
             &PlayerManager::slotLoadLocationToPlayerMaybePlay);
+
+    // connect(viewer,
+    //         &WWaveformViewer::trackDropped,
+    //         m_pPlayerManager,
+    //         &PlayerManager::slotLoadLocationToPlayerMaybePlay);
     connect(viewer, &WWaveformViewer::cloneDeck,
             m_pPlayerManager, &PlayerManager::slotCloneDeck);
 
@@ -1203,9 +1212,13 @@ QWidget* LegacySkinParser::parseTrackProperty(const QDomElement& node) {
             pTrackProperty,
             &WTrackProperty::slotLoadingTrack);
     connect(pTrackProperty,
-            &WTrackProperty::trackDropped,
+            &WTrackProperty::emitTrackDropped,
             m_pPlayerManager,
             &PlayerManager::slotLoadLocationToPlayerMaybePlay);
+    // connect(pTrackProperty,
+    //         &WTrackProperty::trackDropped,
+    //         m_pPlayerManager,
+    //         &PlayerManager::slotLoadLocationToPlayerMaybePlay);
     connect(pTrackProperty,
             &WTrackProperty::cloneDeck,
             m_pPlayerManager,
@@ -1247,9 +1260,13 @@ QWidget* LegacySkinParser::parseTrackWidgetGroup(const QDomElement& node) {
             pGroup,
             &WTrackWidgetGroup::slotLoadingTrack);
     connect(pGroup,
-            &WTrackWidgetGroup::trackDropped,
+            &WTrackWidgetGroup::emitTrackDropped,
             m_pPlayerManager,
             &PlayerManager::slotLoadLocationToPlayerMaybePlay);
+    // connect(pGroup,
+    //         &WTrackWidgetGroup::trackDropped,
+    //         m_pPlayerManager,
+    //         &PlayerManager::slotLoadLocationToPlayerMaybePlay);
     connect(pGroup,
             &WTrackWidgetGroup::cloneDeck,
             m_pPlayerManager,
@@ -1438,9 +1455,13 @@ QWidget* LegacySkinParser::parseSpinny(const QDomElement& node) {
             pSpinny,
             &WSpinnyBase::swap);
     connect(pSpinny,
-            &WSpinnyBase::trackDropped,
+            &WSpinnyBase::emitTrackDropped,
             m_pPlayerManager,
             &PlayerManager::slotLoadLocationToPlayerMaybePlay);
+    // connect(pSpinny,
+    //         &WSpinnyBase::trackDropped,
+    //         m_pPlayerManager,
+    //         &PlayerManager::slotLoadLocationToPlayerMaybePlay);
     connect(pSpinny, &WSpinnyBase::cloneDeck, m_pPlayerManager, &PlayerManager::slotCloneDeck);
 
     ControlObject* showCoverControl = controlFromConfigNode(node.toElement(), "ShowCoverControl");
@@ -1564,9 +1585,13 @@ QWidget* LegacySkinParser::parseCoverArt(const QDomElement& node) {
         connect(m_pLibrary, &Library::trackSelected, pCoverArt, &WCoverArt::slotLoadTrack);
     } else if (pPlayer != nullptr) {
         connect(pCoverArt,
-                &WCoverArt::trackDropped,
+                &WCoverArt::emitTrackDropped,
                 m_pPlayerManager,
                 &PlayerManager::slotLoadLocationToPlayerMaybePlay);
+        // connect(pCoverArt,
+        //         &WCoverArt::trackDropped,
+        //         m_pPlayerManager,
+        //         &PlayerManager::slotLoadLocationToPlayerMaybePlay);
         connect(pCoverArt, &WCoverArt::cloneDeck,
                 m_pPlayerManager, &PlayerManager::slotCloneDeck);
     }

--- a/src/util/dnd.cpp
+++ b/src/util/dnd.cpp
@@ -46,23 +46,93 @@ bool addFileToList(
     return true;
 }
 
+// EVE - OLD
+// QList<mixxx::FileInfo> dropEventFiles(
+//        const QMimeData& mimeData,
+//        const QString& sourceIdentifier,
+//        bool firstOnly,
+//        bool acceptPlaylists) {
+//    qDebug() << "dropEventFiles()" << mimeData.hasUrls() << mimeData.urls();
+//    qDebug() << "mimeData.hasText()" << mimeData.hasText() << mimeData.text();
+//
+//    if (!mimeData.hasUrls() ||
+//            (mimeData.hasText() && mimeData.text() == sourceIdentifier)) {
+//        return {};
+//    }
+//
+//    return DragAndDropHelper::supportedTracksFromUrls(
+//            mimeData.urls(),
+//            firstOnly,
+//            acceptPlaylists);
+//}
+
+#ifdef __STEM__
+QList<QPair<mixxx::FileInfo, mixxx::StemChannelSelection>> dropEventFiles(
+#else
 QList<mixxx::FileInfo> dropEventFiles(
+#endif
         const QMimeData& mimeData,
         const QString& sourceIdentifier,
         bool firstOnly,
         bool acceptPlaylists) {
-    qDebug() << "dropEventFiles()" << mimeData.hasUrls() << mimeData.urls();
-    qDebug() << "mimeData.hasText()" << mimeData.hasText() << mimeData.text();
+    qDebug() << "[dropEventFiles()] -> mimeData.hasUrls()" << mimeData.hasUrls() << mimeData.urls();
+    qDebug() << "[dropEventFiles()] -> mimeData.hasText()" << mimeData.hasText() << mimeData.text();
 
+    // NO URLS | text matches the source identifier -> empty list
     if (!mimeData.hasUrls() ||
             (mimeData.hasText() && mimeData.text() == sourceIdentifier)) {
         return {};
     }
 
-    return DragAndDropHelper::supportedTracksFromUrls(
+    // LIST -> supported tracks from URLs
+    auto trackList = DragAndDropHelper::supportedTracksFromUrls(
             mimeData.urls(),
             firstOnly,
             acceptPlaylists);
+
+#ifdef __STEM__
+    // Extract stemMask if available
+    mixxx::StemChannelSelection stemMask = mixxx::StemChannel::All; // Default: full track
+    qDebug() << "[dropEventFiles()] -> before if (mimeData...";
+
+    if (mimeData.hasFormat("application/x-mixxx-stem-mask")) {
+        QByteArray data = mimeData.data("application/x-mixxx-stem-mask");
+        QDataStream stream(&data, QIODevice::ReadOnly);
+
+        // Default
+        int stemValue = static_cast<int>(mixxx::StemChannel::All);
+        qDebug() << "[dropEventFiles()] -> stemValue before deserialization:" << stemValue;
+
+        // Deserialize the stem value
+        stream >> stemValue;
+        stemMask = static_cast<mixxx::StemChannelSelection>(stemValue);
+
+        if (stream.status() != QDataStream::Ok) {
+            qDebug() << "[dropEventFiles()] -> Failed to extract stem mask!";
+        } else {
+            qDebug() << "[dropEventFiles()] -> Successfully extracted stem mask:" << stemMask;
+        }
+    } else {
+        qDebug() << "[dropEventFiles()] -> No stem mask format found!";
+    }
+
+    // Check stemMask
+    if (stemMask == mixxx::StemChannel::All) {
+        qDebug() << "[dropEventFiles()] -> Default stem mask applied: All";
+    } else {
+        qDebug() << "[dropEventFiles()] -> Custom stem mask applied:" << stemMask;
+    }
+
+    // Result list & pair= track + stemMask
+    QList<QPair<mixxx::FileInfo, mixxx::StemChannelSelection>> result;
+    for (const auto& track : trackList) {
+        result.append(qMakePair(track, stemMask));
+    }
+    qDebug() << "[dropEventFiles()] -> stem-result:" << result;
+    return result;
+#else
+    return trackList;
+#endif
 }
 
 // Allow loading to a player if the player isn't playing
@@ -242,16 +312,63 @@ QDrag* DragAndDropHelper::dragTrack(
     return dragUrls(trackUrls, pDragSource, sourceIdentifier);
 }
 
-//static
+// EVE - OLD
+// static
+// QDrag* DragAndDropHelper::dragTrackLocations(
+//        const QList<QString>& locations,
+//        QWidget* pDragSource,
+//        const QString& sourceIdentifier) {
+//    QList<QUrl> trackUrls;
+//    foreach (QString location, locations) {
+//        trackUrls.append(mixxx::FileInfo(location).toQUrl());
+//    }
+//    return dragUrls(trackUrls, pDragSource, sourceIdentifier);
+//}
+
+// static
+#ifdef __STEM__
+QDrag* DragAndDropHelper::dragTrackLocations(
+        const QList<QString>& locations,
+        const QList<mixxx::StemChannelSelection>& stemMasks,
+        QWidget* pDragSource,
+        const QString& sourceIdentifier) {
+    qDebug() << "[DragAndDropHelper::dragTrackLocations] -> stemMasks " << stemMasks;
+#else
 QDrag* DragAndDropHelper::dragTrackLocations(
         const QList<QString>& locations,
         QWidget* pDragSource,
         const QString& sourceIdentifier) {
+#endif
     QList<QUrl> trackUrls;
-    foreach (QString location, locations) {
+    for (const QString& location : locations) {
         trackUrls.append(mixxx::FileInfo(location).toQUrl());
     }
-    return dragUrls(trackUrls, pDragSource, sourceIdentifier);
+
+    QMimeData* pMimeData = new QMimeData;
+    pMimeData->setUrls(trackUrls);
+
+#ifdef __STEM__
+    if (!stemMasks.isEmpty()) {
+        QByteArray stemMaskData;
+        QDataStream stream(&stemMaskData, QIODevice::WriteOnly);
+
+        // Serialize the list of stem masks to check
+        for (const mixxx::StemChannelSelection& mask : stemMasks) {
+            stream << mask;
+        }
+
+        // Add the serialized stem mask data to the MIME data
+        pMimeData->setData("application/x-mixxx-stem-mask", stemMaskData);
+        qDebug() << "[DragAndDropHelper::dragTrackLocations] -> Serialized "
+                    "stemMasks:"
+                 << stemMaskData.toHex();
+    }
+#endif
+
+    QDrag* pDrag = new QDrag(pDragSource);
+    pDrag->setMimeData(pMimeData);
+    Qt::DropAction dropAction = pDrag->exec(Qt::CopyAction | Qt::MoveAction);
+    return pDrag;
 }
 
 //static
@@ -268,7 +385,7 @@ void DragAndDropHelper::handleTrackDragEnterEvent(
     }
 }
 
-//static
+// static
 void DragAndDropHelper::handleTrackDropEvent(
         QDropEvent* pEvent,
         TrackDropTarget& target,
@@ -280,11 +397,22 @@ void DragAndDropHelper::handleTrackDropEvent(
             target.emitCloneDeck(pEvent->mimeData()->text(), group);
             return;
         } else {
+#ifdef __STEM__
+            const QList<QPair<mixxx::FileInfo, mixxx::StemChannelSelection>> files = dropEventFiles(
+                    *pEvent->mimeData(), group, true, false);
+            if (!files.isEmpty()) {
+                pEvent->accept();
+                qDebug() << "[DragAndDropHelper::handleTrackDropEvent] -> "
+                            "before emitTrackDropped files "
+                         << files;
+                target.emitTrackDropped(files.at(0).first.location(), group, files.at(0).second);
+#else
             const QList<mixxx::FileInfo> files = dropEventFiles(
                     *pEvent->mimeData(), group, true, false);
             if (!files.isEmpty()) {
                 pEvent->accept();
                 target.emitTrackDropped(files.at(0).location(), group);
+#endif
                 return;
             }
         }

--- a/src/util/dnd.cpp
+++ b/src/util/dnd.cpp
@@ -332,6 +332,7 @@ QDrag* DragAndDropHelper::dragTrackLocations(
         const QList<mixxx::StemChannelSelection>& stemMasks,
         QWidget* pDragSource,
         const QString& sourceIdentifier) {
+    Q_UNUSED(sourceIdentifier);
     qDebug() << "[DragAndDropHelper::dragTrackLocations] -> stemMasks " << stemMasks;
 #else
 QDrag* DragAndDropHelper::dragTrackLocations(
@@ -367,7 +368,8 @@ QDrag* DragAndDropHelper::dragTrackLocations(
 
     QDrag* pDrag = new QDrag(pDragSource);
     pDrag->setMimeData(pMimeData);
-    Qt::DropAction dropAction = pDrag->exec(Qt::CopyAction | Qt::MoveAction);
+    // Qt::DropAction dropAction = pDrag->exec(Qt::CopyAction | Qt::MoveAction);
+    pDrag->exec(Qt::CopyAction | Qt::MoveAction);
     return pDrag;
 }
 

--- a/src/util/dnd.cpp
+++ b/src/util/dnd.cpp
@@ -125,7 +125,7 @@ QList<mixxx::FileInfo> dropEventFiles(
 
     // Result list & pair= track + stemMask
     QList<QPair<mixxx::FileInfo, mixxx::StemChannelSelection>> result;
-    for (const auto& track : trackList) {
+    for (const auto& track : std::as_const(trackList)) {
         result.append(qMakePair(track, stemMask));
     }
     qDebug() << "[dropEventFiles()] -> stem-result:" << result;

--- a/src/util/dnd.h
+++ b/src/util/dnd.h
@@ -36,10 +36,18 @@ class DragAndDropHelper final {
             QWidget* pDragSource,
             const QString& sourceIdentifier);
 
+#ifdef __STEM__
+    static QDrag* dragTrackLocations(
+            const QList<QString>& locations,
+            const QList<mixxx::StemChannelSelection>& stemMasks,
+            QWidget* pDragSource,
+            const QString& sourceIdentifier);
+#else
     static QDrag* dragTrackLocations(
             const QList<QString>& locations,
             QWidget* pDragSource,
             const QString& sourceIdentifier);
+#endif
 
     static void handleTrackDragEnterEvent(
             QDragEnterEvent* pEvent,

--- a/src/waveform/renderers/waveformmark.cpp
+++ b/src/waveform/renderers/waveformmark.cpp
@@ -142,7 +142,8 @@ WaveformMark::WaveformMark(const QString& group,
     if (!color.isValid()) {
         // As a fallback, grab the color from the parent's AxesColor
         // color = signalColors.getAxesColor();
-        qDebug() << "Didn't get mark <Color>:" << color;
+        // EVE
+        // qDebug() << "Didn't get mark <Color>:" << color;
     } else {
         color = WSkinColor::getCorrectColor(color);
     }
@@ -152,7 +153,8 @@ WaveformMark::WaveformMark(const QString& group,
     if (!m_textColor.isValid()) {
         // Read the text color, otherwise use the parent's BgColor.
         m_textColor = signalColors.getBgColor();
-        qDebug() << "Didn't get mark <TextColor>, using parent's <BgColor>:" << m_textColor;
+        // EVE
+        //  qDebug() << "Didn't get mark <TextColor>, using parent's <BgColor>:" << m_textColor;
     }
 
     m_align = decodeAlignmentFlags(markAlign, Qt::AlignBottom | Qt::AlignHCenter);

--- a/src/widget/trackdroptarget.h
+++ b/src/widget/trackdroptarget.h
@@ -28,11 +28,11 @@ class TrackDropTarget {
         qDebug() << "[TrackDropTarget] -> emitTrackDropped -> filename "
                  << filename << " group: " << group
                  << " stemMask: " << stemMask;
-        emit trackDropped(filename, group, stemMask);
+        trackDropped(filename, group, stemMask);
     }
 #else
     void emitTrackDropped(const QString& filename, const QString& group) {
-        emit trackDropped(filename, group); // clazy:exclude=incorrect-emit
+        trackDropped(filename, group); // clazy:exclude=incorrect-emit
     }
 #endif
 

--- a/src/widget/trackdroptarget.h
+++ b/src/widget/trackdroptarget.h
@@ -3,6 +3,10 @@
 #include <QEvent>
 #include <QString>
 
+#ifdef __STEM__
+#include "engine/engine.h"
+#endif
+
 /// Mixin to mark a widget as a drop target for tracks.
 ///
 /// This class is *not* derived from QObject (inheriting from 2 QObject classes
@@ -17,9 +21,20 @@ class TrackDropTarget {
         emit cloneDeck(sourceGroup, targetGroup); // clazy:exclude=incorrect-emit
     }
 
+#ifdef __STEM__
+    void emitTrackDropped(const QString& filename,
+            const QString& group,
+            mixxx::StemChannelSelection stemMask = mixxx::StemChannel::All) {
+        qDebug() << "[TrackDropTarget] -> emitTrackDropped -> filename "
+                 << filename << " group: " << group
+                 << " stemMask: " << stemMask;
+        emit trackDropped(filename, group, stemMask);
+    }
+#else
     void emitTrackDropped(const QString& filename, const QString& group) {
         emit trackDropped(filename, group); // clazy:exclude=incorrect-emit
     }
+#endif
 
     virtual bool handleDragAndDropEventFromWindow(QEvent* pEvent) {
         pEvent->ignore();
@@ -27,6 +42,13 @@ class TrackDropTarget {
     }
 
   signals:
+#ifdef __STEM__
+    virtual void trackDropped(const QString& filename,
+            const QString& group,
+            mixxx::StemChannelSelection stemMask) = 0;
+#else
     virtual void trackDropped(const QString& filename, const QString& group) = 0;
+#endif
+
     virtual void cloneDeck(const QString& sourceGroup, const QString& targetGroup) = 0;
 };

--- a/src/widget/wcoverart.cpp
+++ b/src/widget/wcoverart.cpp
@@ -164,6 +164,7 @@ void WCoverArt::slotCoverFound(
 }
 
 void WCoverArt::slotLoadTrack(TrackPointer pTrack) {
+    // qDebug() << "[WCoverArt::slotTrackLoaded] triggered";
     if (m_loadedTrack) {
         disconnect(m_loadedTrack.get(),
                 &Track::coverArtUpdated,
@@ -306,3 +307,22 @@ bool WCoverArt::event(QEvent* pEvent) {
     }
     return QWidget::event(pEvent);
 }
+
+#ifdef __STEM__
+void WCoverArt::trackDropped(const QString& filename,
+        const QString& group,
+        mixxx::StemChannelSelection stemMask) {
+    // qDebug() << "[WCoverArt::trackDropped] -> File:" << filename << "Group:"
+    // << group << "StemMask:" << stemMask;
+
+    if (stemMask != mixxx::StemChannel::All) {
+        qDebug() << "[WCoverArt::trackDropped] -> Specific stem track selected.";
+    }
+    emit emitTrackDropped(filename, group, stemMask);
+}
+#else
+void WCoverArt::trackDropped(const QString& filename, const QString& group) {
+    // qDebug() << "[WCoverArt::trackDropped] ->  File:" << filename << "Group:" << group;
+    emit emitTrackDropped(filename, group);
+}
+#endif

--- a/src/widget/wcoverart.h
+++ b/src/widget/wcoverart.h
@@ -25,6 +25,14 @@ class WCoverArt : public QWidget, public WBaseWidget, public TrackDropTarget {
 
     void setup(const QDomNode& node, const SkinContext& context);
 
+#ifdef __STEM__
+    void trackDropped(const QString& filename,
+            const QString& group,
+            mixxx::StemChannelSelection stemMask) override;
+#else
+    void trackDropped(const QString& filename, const QString& group) override;
+#endif
+
   public slots:
     void slotLoadTrack(TrackPointer);
     void slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack);
@@ -32,7 +40,14 @@ class WCoverArt : public QWidget, public WBaseWidget, public TrackDropTarget {
     void slotEnable(bool);
 
   signals:
-    void trackDropped(const QString& filename, const QString& group) override;
+    // void trackDropped(const QString& filename, const QString& group) override;
+#ifdef __STEM__
+    void emitTrackDropped(const QString& filename,
+            const QString& group,
+            mixxx::StemChannelSelection stemMask);
+#else
+    void emitTrackDropped(const QString& filename, const QString& group);
+#endif
     void cloneDeck(const QString& sourceGroup, const QString& targetGroup) override;
 
   private slots:

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -345,6 +345,7 @@ void WOverview::onTrackAnalyzerProgress(TrackId trackId, AnalyzerProgress analyz
 }
 
 void WOverview::slotTrackLoaded(TrackPointer pTrack) {
+    // qDebug() << "[WOverview::slotTrackLoaded] triggered";
     Q_UNUSED(pTrack); // only used in DEBUG_ASSERT
     //qDebug() << "WOverview::slotTrackLoaded()" << m_pCurrentTrack.get() << pTrack.get();
     DEBUG_ASSERT(m_pCurrentTrack == pTrack);
@@ -1685,3 +1686,22 @@ void WOverview::dragEnterEvent(QDragEnterEvent* pEvent) {
 void WOverview::dropEvent(QDropEvent* pEvent) {
     DragAndDropHelper::handleTrackDropEvent(pEvent, *this, m_group, m_pConfig);
 }
+
+#ifdef __STEM__
+void WOverview::trackDropped(const QString& filename,
+        const QString& group,
+        mixxx::StemChannelSelection stemMask) {
+    // qDebug() << "[WOverview::trackDropped] -> File:" << filename << "Group:"
+    // << group << "StemMask:" << stemMask;
+
+    if (stemMask != mixxx::StemChannel::All) {
+        qDebug() << "[WOverview::trackDropped] -> Specific stem track selected.";
+    }
+    emit emitTrackDropped(filename, group, stemMask);
+}
+#else
+void WOverview::trackDropped(const QString& filename, const QString& group) {
+    // qDebug() << "[WOverview::trackDropped] ->File:" << filename << "Group:" << group;
+    emit emitTrackDropped(filename, group);
+}
+#endif

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -39,6 +39,14 @@ class WOverview : public WWidget, public TrackDropTarget {
     };
     Q_ENUM(Type);
 
+#ifdef __STEM__
+    void trackDropped(const QString& filename,
+            const QString& group,
+            mixxx::StemChannelSelection stemMask) override;
+#else
+    void trackDropped(const QString& filename, const QString& group) override;
+#endif
+
   public slots:
     void onConnectedControlChanged(double dParameter, double dValue) override;
     void slotTrackLoaded(TrackPointer pTrack);
@@ -47,7 +55,14 @@ class WOverview : public WWidget, public TrackDropTarget {
             AnalyzerProgress analyzerProgress);
 
   signals:
-    void trackDropped(const QString& filename, const QString& group) override;
+    // void trackDropped(const QString& filename, const QString& group) override;
+#ifdef __STEM__
+    void emitTrackDropped(const QString& filename,
+            const QString& group,
+            mixxx::StemChannelSelection stemMask);
+#else
+    void emitTrackDropped(const QString& filename, const QString& group);
+#endif
     void cloneDeck(const QString& sourceGroup, const QString& targetGroup) override;
 
   protected:

--- a/src/widget/wspinnybase.cpp
+++ b/src/widget/wspinnybase.cpp
@@ -241,6 +241,7 @@ void WSpinnyBase::setLoadedCover(const QPixmap& pixmap) {
 }
 
 void WSpinnyBase::slotLoadTrack(TrackPointer pTrack) {
+    // qDebug() << "[WSpinnyBase::slotTrackLoaded] triggered";
     if (m_pLoadedTrack) {
         disconnect(m_pLoadedTrack.get(),
                 &Track::coverArtUpdated,
@@ -664,3 +665,22 @@ void WSpinnyBase::dragEnterEvent(QDragEnterEvent* pEvent) {
 void WSpinnyBase::dropEvent(QDropEvent* pEvent) {
     DragAndDropHelper::handleTrackDropEvent(pEvent, *this, m_group, m_pConfig);
 }
+
+#ifdef __STEM__
+void WSpinnyBase::trackDropped(const QString& filename,
+        const QString& group,
+        mixxx::StemChannelSelection stemMask) {
+    // qDebug() << "[WSpinnyBase::trackDropped] -> File:" << filename <<
+    // "Group:" << group << "StemMask:" << stemMask;
+
+    if (stemMask != mixxx::StemChannel::All) {
+        qDebug() << "[WSpinnyBase::trackDropped] -> Specific stem track selected.";
+    }
+    emit emitTrackDropped(filename, group, stemMask);
+}
+#else
+void WSpinnyBase::trackDropped(const QString& filename, const QString& group) {
+    // qDebug() << "[WSpinnyBase::trackDropped] -> File:" << filename << "Group:" << group;
+    emit emitTrackDropped(filename, group);
+}
+#endif

--- a/src/widget/wspinnybase.h
+++ b/src/widget/wspinnybase.h
@@ -43,6 +43,14 @@ class WSpinnyBase : public WGLWidget,
     void dragEnterEvent(QDragEnterEvent* event) override;
     void dropEvent(QDropEvent* event) override;
 
+#ifdef __STEM__
+    void trackDropped(const QString& filename,
+            const QString& group,
+            mixxx::StemChannelSelection stemMask) override;
+#else
+    void trackDropped(const QString& filename, const QString& group) override;
+#endif
+
   public slots:
     void slotLoadTrack(TrackPointer);
     void slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack);
@@ -63,7 +71,14 @@ class WSpinnyBase : public WGLWidget,
     void slotTrackCoverArtUpdated();
 
   signals:
-    void trackDropped(const QString& filename, const QString& group) override;
+    // void trackDropped(const QString& filename, const QString& group) override;
+#ifdef __STEM__
+    void emitTrackDropped(const QString& filename,
+            const QString& group,
+            mixxx::StemChannelSelection stemMask);
+#else
+    void emitTrackDropped(const QString& filename, const QString& group);
+#endif
     void cloneDeck(const QString& sourceGroup, const QString& targetGroup) override;
 
   protected:

--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -70,6 +70,7 @@ void WTrackProperty::setup(const QDomNode& node, const SkinContext& context) {
 }
 
 void WTrackProperty::slotTrackLoaded(TrackPointer pTrack) {
+    // qDebug() << "[WTracjProperty::slotTrackLoaded] triggered";
     if (!pTrack) {
         return;
     }
@@ -378,3 +379,26 @@ bool WTrackPropertyEditor::eventFilter(QObject* pObj, QEvent* pEvent) {
     }
     return QLineEdit::eventFilter(pObj, pEvent);
 }
+
+#ifdef __STEM__
+void WTrackProperty::trackDropped(const QString& filename,
+        const QString& group,
+        mixxx::StemChannelSelection stemMask) {
+    // qDebug() << "[WTrackProperty::trackDropped] -> File:" << filename <<
+    // "Group:" << group << "StemMask:" << stemMask;
+
+    if (stemMask != mixxx::StemChannel::All) {
+        qDebug() << "[WTrackProperty::trackDropped] -> Specific stem track selected.";
+    }
+    // qDebug() << "WTrackProperty::trackDropped] -> sender() " << sender();
+    // qDebug() << "[WTrackProperty::trackDropped] -> filename: " << filename;
+    // qDebug() << "[WTrackProperty::trackDropped] -> group: " << group;
+    // qDebug() << "[WTrackProperty::trackDropped] -> stemMask " << stemMask;
+    emit emitTrackDropped(filename, group, stemMask);
+}
+#else
+void WTrackProperty::trackDropped(const QString& filename, const QString& group) {
+    // qDebug() << "[WTrackProperty::trackDropped] -> File:" << filename << "Group:" << group;
+    emit emitTrackDropped(filename, group);
+}
+#endif

--- a/src/widget/wtrackproperty.h
+++ b/src/widget/wtrackproperty.h
@@ -55,9 +55,24 @@ class WTrackProperty : public WLabel, public TrackDropTarget {
     }
 
     void setup(const QDomNode& node, const SkinContext& context) override;
+#ifdef __STEM__
+    void trackDropped(const QString& filename,
+            const QString& group,
+            mixxx::StemChannelSelection stemMask) override;
+#else
+    void trackDropped(const QString& filename, const QString& group) override;
+#endif
 
   signals:
-    void trackDropped(const QString& filename, const QString& group) override;
+    // void trackDropped(const QString& filename, const QString& group) override;
+#ifdef __STEM__
+    void emitTrackDropped(const QString& filename,
+            const QString& group,
+            mixxx::StemChannelSelection stemMask);
+#else
+    void emitTrackDropped(const QString& filename, const QString& group);
+#endif
+
     void cloneDeck(const QString& sourceGroup, const QString& targetGroup) override;
     void setAndConfirmTrackMenuControl(bool visible);
     void selectedStateChanged(bool state);

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -623,8 +623,9 @@ void WTrackTableView::mouseMoveEvent(QMouseEvent* pEvent) {
         // Iterate over selected rows and append each item's location url to a list.
         QList<QString> locations;
         const QModelIndexList indices = getSelectedRows();
+#ifdef __STEM__
         QList<mixxx::StemChannelSelection> stemMasks;
-
+#endif
         for (const QModelIndex& index : indices) {
             if (!index.isValid()) {
                 continue;

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -7,6 +7,7 @@
 #include <QUrl>
 
 #include "control/controlobject.h"
+#include "engine/engine.h"
 #include "library/dao/trackschema.h"
 #include "library/library.h"
 #include "library/library_prefs.h"

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -622,14 +622,42 @@ void WTrackTableView::mouseMoveEvent(QMouseEvent* pEvent) {
         // Iterate over selected rows and append each item's location url to a list.
         QList<QString> locations;
         const QModelIndexList indices = getSelectedRows();
+        QList<mixxx::StemChannelSelection> stemMasks;
 
         for (const QModelIndex& index : indices) {
             if (!index.isValid()) {
                 continue;
             }
             locations.append(pTrackModel->getTrackLocation(index));
+
+#ifdef __STEM__
+            // Cast the TrackModel to QAbstractItemModel
+            QAbstractItemModel* pModel = dynamic_cast<QAbstractItemModel*>(pTrackModel);
+            if (!pModel) {
+                qWarning() << "[WTrackTableView::mouseMoveEvent] -> Failed to "
+                              "cast TrackModel to QAbstractItemModel";
+                continue;
+            }
+            // Get actual title column index
+            int titleColumn = pTrackModel->fieldIndex("title");
+            QModelIndex titleIndex = index.siblingAtColumn(titleColumn);
+            QString modifiedTitle = pModel->data(titleIndex, Qt::DisplayRole).toString();
+            qDebug() << "[WTrackTableView::mouseMoveEvent] -> Corrected "
+                        "modifiedTitle:"
+                     << modifiedTitle;
+            // Extract the stemMask from the modified title
+            mixxx::StemChannelSelection stemMask = mixxx::extractStemMaskFromTitle(modifiedTitle);
+            stemMasks.append(stemMask);
+#endif
         }
+#ifdef __STEM__
+        qDebug() << "[WTrackTableView::mouseMoveEvent] -> stemMasks " << stemMasks;
+        // Start the drag operation with locations and stemMasks
+        DragAndDropHelper::dragTrackLocations(locations, stemMasks, this, "library");
+#else
+        // Start the drag operation with locations only
         DragAndDropHelper::dragTrackLocations(locations, this, "library");
+#endif
     }
 }
 
@@ -1322,6 +1350,7 @@ void WTrackTableView::activateSelectedTrack() {
 void WTrackTableView::loadSelectedTrackToGroup(const QString& group,
         mixxx::StemChannelSelection stemMask,
         bool play) {
+    qDebug() << "[WTrackTableView::loadSelectedTrackToGroup] -> stemMask: " << stemMask;
 #else
 void WTrackTableView::loadSelectedTrackToGroup(const QString& group,
         bool play) {
@@ -1360,6 +1389,27 @@ void WTrackTableView::loadSelectedTrackToGroup(const QString& group,
     TrackPointer pTrack;
     if (pTrackModel && (pTrack = pTrackModel->getTrack(index))) {
 #ifdef __STEM__
+        QAbstractItemModel* pModel = dynamic_cast<QAbstractItemModel*>(pTrackModel);
+        if (!pModel) {
+            qWarning() << "[WTrackTableView::loadSelectedTrackToGroup] -> "
+                          "Failed to cast TrackModel to QAbstractItemModel";
+            return;
+        }
+
+        QString modifiedTitle =
+                pModel->data(index, ColumnCache::COLUMN_LIBRARYTABLE_TITLE)
+                        .toString();
+        qDebug() << "[WTrackTableView::loadSelectedTrackToGroup] -> "
+                    "modifiedTitle: "
+                 << modifiedTitle;
+        mixxx::StemChannelSelection extractedStemMask =
+                mixxx::extractStemMaskFromTitle(modifiedTitle);
+
+        if (stemMask == mixxx::StemChannelSelection(mixxx::StemChannel::None)) {
+            stemMask = extractedStemMask;
+        }
+        qDebug() << "[WTrackTableView::loadSelectedTrackToGroup] -> stemMask: " << stemMask;
+
         DEBUG_ASSERT(!stemMask || pTrack->hasStem());
         emit loadTrackToPlayer(pTrack, group, stemMask, play);
 #else

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -43,11 +43,13 @@ class WTrackTableView : public WLibraryTableView {
     void editSelectedItem();
     void activateSelectedTrack();
 #ifdef __STEM__
-    void loadSelectedTrackToGroup(const QString& group,
+    void loadSelectedTrackToGroup(
+            const QString& group,
             mixxx::StemChannelSelection stemMask,
             bool play);
 #else
-    void loadSelectedTrackToGroup(const QString& group,
+    void loadSelectedTrackToGroup(
+            const QString& group,
             bool play);
 #endif
     void assignNextTrackColor() override;

--- a/src/widget/wtrackwidgetgroup.cpp
+++ b/src/widget/wtrackwidgetgroup.cpp
@@ -45,6 +45,7 @@ void WTrackWidgetGroup::setup(const QDomNode& node, const SkinContext& context) 
 }
 
 void WTrackWidgetGroup::slotTrackLoaded(TrackPointer pTrack) {
+    // qDebug() << "[WTrackWidgetGroup::slotTrackLoaded] triggered";
     if (!pTrack) {
         return;
     }
@@ -141,3 +142,22 @@ void WTrackWidgetGroup::ensureTrackMenuIsCreated() {
                         visible ? 1.0 : 0.0);
             });
 }
+
+#ifdef __STEM__
+void WTrackWidgetGroup::trackDropped(const QString& filename,
+        const QString& group,
+        mixxx::StemChannelSelection stemMask) {
+    // qDebug() << "[WTrackWidgetGroup::trackDropped] -> File:" << filename <<
+    // "Group:" << group << "StemMask:" << stemMask;
+
+    if (stemMask != mixxx::StemChannel::All) {
+        qDebug() << "[WTrackWidgetGroup::trackDropped] -> Specific stem track selected.";
+    }
+    emit emitTrackDropped(filename, group, stemMask);
+}
+#else
+void WTrackWidgetGroup::trackDropped(const QString& filename, const QString& group) {
+    // qDebug() << "[WTrackWidgetGroup::trackDropped] -> File:" << filename << "Group:" << group;
+    emit emitTrackDropped(filename, group);
+}
+#endif

--- a/src/widget/wtrackwidgetgroup.h
+++ b/src/widget/wtrackwidgetgroup.h
@@ -19,9 +19,23 @@ class WTrackWidgetGroup : public WWidgetGroup, public TrackDropTarget {
             bool isMainDeck);
     ~WTrackWidgetGroup() override;
     void setup(const QDomNode& node, const SkinContext& context) override;
+#ifdef __STEM__
+    void trackDropped(const QString& filename,
+            const QString& group,
+            mixxx::StemChannelSelection stemMask) override;
+#else
+    void trackDropped(const QString& filename, const QString& group) override;
+#endif
 
   signals:
-    void trackDropped(const QString& fileName, const QString& group) override;
+    // void trackDropped(const QString& fileName, const QString& group) override;
+#ifdef __STEM__
+    void emitTrackDropped(const QString& filename,
+            const QString& group,
+            mixxx::StemChannelSelection stemMask);
+#else
+    void emitTrackDropped(const QString& filename, const QString& group);
+#endif
     void cloneDeck(const QString& sourceGroup, const QString& targetGroup) override;
 
   public slots:

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -222,6 +222,7 @@ void WWaveformViewer::leaveEvent(QEvent*) {
 }
 
 void WWaveformViewer::slotTrackLoaded(TrackPointer track) {
+    // qDebug() << "[WWaveformViewer::slotTrackLoaded] triggered";
     if (m_waveformWidget) {
         m_waveformWidget->setTrack(track);
     }
@@ -354,3 +355,22 @@ void WWaveformViewer::unhighlightMark(WaveformMarkPointer pMark) {
 bool WWaveformViewer::isPlaying() const {
     return m_pPlayEnabled->toBool();
 }
+
+#ifdef __STEM__
+void WWaveformViewer::trackDropped(const QString& filename,
+        const QString& group,
+        mixxx::StemChannelSelection stemMask) {
+    // qDebug() << "[WWaveformViewer::trackDropped] -> File:" << filename <<
+    // "Group:" << group << "StemMask:" << stemMask;
+
+    if (stemMask != mixxx::StemChannel::All) {
+        qDebug() << "[WWaveformViewer::trackDropped] -> Specific stem track selected.";
+    }
+    emit emitTrackDropped(filename, group, stemMask);
+}
+#else
+void WWaveformViewer::trackDropped(const QString& filename, const QString& group) {
+    // qDebug() << "[WWaveformViewer::trackDropped] -> File:" << filename << "Group:" << group;
+    emit emitTrackDropped(filename, group);
+}
+#endif

--- a/src/widget/wwaveformviewer.h
+++ b/src/widget/wwaveformviewer.h
@@ -35,9 +35,23 @@ class WWaveformViewer : public WWidget, public TrackDropTarget {
     void mouseMoveEvent(QMouseEvent * /*unused*/) override;
     void mouseReleaseEvent(QMouseEvent * /*unused*/) override;
     void leaveEvent(QEvent* /*unused*/) override;
+#ifdef __STEM__
+    void trackDropped(const QString& filename,
+            const QString& group,
+            mixxx::StemChannelSelection stemMask) override;
+#else
+    void trackDropped(const QString& filename, const QString& group) override;
+#endif
 
   signals:
-    void trackDropped(const QString& filename, const QString& group) override;
+    // void trackDropped(const QString& filename, const QString& group) override;
+#ifdef __STEM__
+    void emitTrackDropped(const QString& filename,
+            const QString& group,
+            mixxx::StemChannelSelection stemMask);
+#else
+    void emitTrackDropped(const QString& filename, const QString& group);
+#endif
     void cloneDeck(const QString& sourceGroup, const QString& targetGroup) override;
     void passthroughChanged(double value);
 


### PR DESCRIPTION
This was running in my head, cracking my brains for a long time.
It started after the conversation with @daschuer  in PR #13934 "[POC] stem selection menu" in order to let OSC-Users load a stemTrack (stream in Stem).

My brain likes to have the different stemStreams listed in the trackTable.
So....

ATM this only works for stems in crates because I haven't changed the sql-query in other libraryFeatures.
How does this work?
-> library sidebar -> feature -> select -> select colums -> tempview -> call BaseSqlTableModel::select()

I added type & location to the columns that are added to the tempview
in BaseSqlTableModel::select()
* creation
-> when type is stem.mp4 (ALAC at the moment)
-> add 'virtual' tracks with same rowinfo as original + add info to title as [StemTypeSuffix]
            "Pre-Mixed Stereo" / "Drums" / "Bass" / "Other" / "Vocals"
-> these 'virtual' tracks stay always right under the original track in any sorting.
* playing
-> when dragging the 'virtual' track to a player
-> title gets read -> stemMask determined based on [StemTypeSuffix] stored in mimedata
-> trackload signals adapted to take stemMask
-> players recognize stemMask -> load the stemStream instead of full StemTrack or the Pre-Mixed Stereo Track.

Not worked on: 
-> displaying the title of the stemStream
-> cloning -> the full stem is cloned (maybe that's also what I like)
-> saving the stemStream in sampler (after restart the full stem is in the sampler)
-> it's possible I did changes that were not needed.

What do you think?
(at least it's out of my head & my brain)

![afbeelding](https://github.com/user-attachments/assets/352c1357-e191-496d-ba1d-f2fef67190df)

