### PR TITLE
Fix missing forum and wiki links in Mixman DM2 (Windows) mapping

### DIFF
--- a/res/controllers/Mixman DM2 (Windows).midi.xml
+++ b/res/controllers/Mixman DM2 (Windows).midi.xml
@@ -5,6 +5,8 @@
     <author>Joe M.</author>
     <description>MIDI Mapping for Mixman DM2 (Windows)</description>
     <manual>mixman_dm2</manual>
+    <forum>https://mixxx.discourse.group/</forum>
+    <wiki>https://github.com/mixxxdj/mixxx/wiki</wiki>
   </info>
   <controller id="Mixman DM2 (Windows)" port="Port">
     <controls>


### PR DESCRIPTION
This PR resolves issue #12556 by adding missing forum and wiki links in the  Mixman DM2 (Windows).midi.xml file.

Changes Made:
Added the official Mixxx forum link: https://mixxx.discourse.group/
Added the Mixxx wiki link: https://github.com/mixxxdj/mixxx/wiki