### PR TITLE
scenegraph is conditionned to QML=ON 

### DIFF
--- a/src/rendergraph/CMakeLists.txt
+++ b/src/rendergraph/CMakeLists.txt
@@ -39,5 +39,7 @@ set(
 )
 
 add_subdirectory(opengl)
-add_subdirectory(scenegraph)
+if(QML)
+  add_subdirectory(scenegraph)
+endif()
 add_subdirectory(shaders)


### PR DESCRIPTION
[src/rendergraph/scenegraph/](https://github.com/mixxxdj/mixxx/blob/2091886c53c3194130dd6a64cf71b76c665dd7e4/src/rendergraph/scenegraph/CMakeLists.txt#L27) links against Qt6::quick and is not conditionned to QML

I get an error otherwise : 
```
CMake Error at src/rendergraph/scenegraph/CMakeLists.txt:26 (target_link_libraries):
  Target "rendergraph_sg" links to:

    Qt6::Quick

  but the target was not found.  Possible reasons include:
 
    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.
```