### PR TITLE
Don't set GL_BGRA if QT_OPENGL_ES_2

### DIFF
--- a/src/controllers/rendering/controllerrenderingengine.cpp
+++ b/src/controllers/rendering/controllerrenderingengine.cpp
@@ -78,7 +78,7 @@ ControllerRenderingEngine::ControllerRenderingEngine(
 #ifdef __EMSCRIPTEN__
             m_isValid = false;
             kLogger.critical() << "Reversed RGBA format is not supported in Emscripten/WebAssembly";
-#else
+#elif !defined(QT_OPENGL_ES_2)
             m_GLDataFormat = GL_BGRA;
 #endif
         } else {


### PR DESCRIPTION
Fix compilation with both QML and QT_OPENGL_ES_2 :

```
src/controllers/rendering/controllerrenderingengine.cpp:82:30: error: ‘GL_BGRA’ 
was not declared in this scope; did you mean ‘GL_RGBA’?
   82 |             m_GLDataFormat = GL_BGRA;
      |                              ^~~~~~~
      |                              GL_RGBA
```

Moreover, could a general option for GLES2, not only specific to IOS, be possible?