### PR TITLE
[fix] Fix automatic trimming of search bar text

### DIFF
--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -543,7 +543,8 @@ void WSearchLineEdit::slotTriggerSearch() {
 /// saves the current query as selection
 void WSearchLineEdit::slotSaveSearch() {
     m_saveTimer.stop();
-    QString cText = currentText().trimmed();
+    // Keep original text for UI, potentially with trailing spaces
+    QString cText = currentText();
     int cIndex = findCurrentTextIndex();
 #if ENABLE_TRACE_LOG
     kLogger.trace()
@@ -562,13 +563,16 @@ void WSearchLineEdit::slotSaveSearch() {
     }
     if (cIndex > 0 || cIndex == -1) {
         // If the query doesn't exist yet or was not at top, insert it at the top
-        insertItem(0, cText);
+        insertItem(0, cText.trimmed());
     }
     setCurrentIndex(0);
 
     while (count() > kMaxSearchEntries) {
         removeItem(kMaxSearchEntries);
     }
+
+    // Set the text without spaces for UI
+    setTextBlockSignals(cText);
 }
 
 void WSearchLineEdit::slotMoveSelectedHistory(int steps) {

--- a/src/widget/wsearchlineedit.h
+++ b/src/widget/wsearchlineedit.h
@@ -94,7 +94,7 @@ class WSearchLineEdit : public QComboBox, public WBaseWidget {
     bool hasSelectedText() const;
 
     inline int findCurrentTextIndex() {
-        return findData(currentText(), Qt::DisplayRole);
+        return findData(currentText().trimmed(), Qt::DisplayRole);
     }
 
     QString getSearchText() const;


### PR DESCRIPTION


https://github.com/user-attachments/assets/7ea62478-1a1f-47b6-befe-eab3788b1a63

As described in issue #14486, the search bar trims leading and trailing spaces in user's current text input after the auto-save timeout. 
This PR fixes the issue by removing the problematic `trimmed()` call.