### PR TITLE
Use Windows System libraries with find_library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1755,7 +1755,6 @@ elseif (UNIX)
   set(MIXXX_INSTALL_LICENSEDIR "${CMAKE_INSTALL_DOCDIR}")
 endif()
 
-
 if(WIN32)
   target_compile_definitions(mixxx-lib PUBLIC __WINDOWS__)
 
@@ -1771,7 +1770,9 @@ if(WIN32)
   # shoutidjc/shout.h checks for WIN32 to see if we are on Windows.
   target_compile_definitions(mixxx-lib PUBLIC WIN32)
 
-  target_link_libraries(mixxx-lib PRIVATE comctl32 shell32)
+  find_library(COMCTL32_LIB comctl32 REQUIRED)
+  find_library(SHELL32_LIB shell32 REQUIRED)
+  target_link_libraries(mixxx-lib PRIVATE ${COMCTL32_LIB} ${SHELL32_LIB})
 
   if(MSVC)
     target_link_options(mixxx-lib PUBLIC /entry:mainCRTStartup)
@@ -3205,18 +3206,19 @@ elseif(UNIX AND NOT APPLE AND NOT EMSCRIPTEN)
   )
 elseif(WIN32)
   if(Qt_IS_STATIC)
-    target_link_libraries(mixxx-lib PRIVATE
+    set(
+      QT_STATIC_SYSTEM_LIBRARIES
       # Pulled from qt-4.8.2-source\mkspecs\win32-msvc2010\qmake.conf
       # QtCore
       kernel32
-      user32      # QtGui, QtOpenGL, libHSS1394
+      user32 # QtGui, QtOpenGL, libHSS1394
       shell32
       uuid
-      ole32       # QtGui,
-      advapi32    # QtGui, portaudio, portmidi
-      ws2_32      # QtGui, QtNetwork, libshout
+      ole32 # QtGui,
+      advapi32 # QtGui, portaudio, portmidi
+      ws2_32 # QtGui, QtNetwork, libshout
       # QtGui
-      gdi32       # QtOpenGL, libshout
+      gdi32 # QtOpenGL, libshout
       comdlg32
       oleaut32
       imm32
@@ -3225,19 +3227,21 @@ elseif(WIN32)
       # QtOpenGL
       glu32
       opengl32
-
       # QtNetwork openssl-linked
       crypt32
-
-      dwmapi      # qtwindows
-      iphlpapi    # qt5network
-      mpr         # qt5core
-      netapi32    # qt5core
-      userenv     # qt5core
-      uxtheme     # ?
-      version     # ?
-      wtsapi32    # ?
+      dwmapi # qtwindows
+      iphlpapi # qt5network
+      mpr # qt5core
+      netapi32 # qt5core
+      userenv # qt5core
+      uxtheme # ?
+      version # ?
+      wtsapi32 # ?
     )
+    foreach(LIB ${QT_STATIC_SYSTEM_LIBRARIES})
+      find_library(${LIB}_LIB ${LIB} REQUIRED)
+      target_link_libraries(mixxx-lib PRIVATE ${LIB}_LIB)
+    endforeach()
 
     find_library(QTFONTDATABASESUPPORT_LIBRARY Qt${QT_VERSION_MAJOR}FontDatabaseSupport)
     target_link_libraries(mixxx-lib PRIVATE "${QTFONTDATABASESUPPORT_LIBRARY}")


### PR DESCRIPTION
This aims to not require the VS 2022 shell after the build directory is configured. 

This shall avoid this error message: 

```
FAILED: mixxx.exe
C:\WINDOWS\system32\cmd.exe /C "cd . && "C:\Program Files\CMake\bin\cmake.exe" -E vs_link_exe --msvc-ver=1943 --intdir=CMakeFiles\mixxx.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100220~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100220~1.0\x64\mt.exe --manifests  -- C:\PROGRA~1\MIB055~1\2022\COMMUN~1\VC\Tools\MSVC\1443~1.348\bin\Hostx64\x64\link.exe /nologo @CMakeFiles\mixxx.rsp  /out:mixxx.exe /implib:mixxx.lib /pdb:mixxx.pdb /version:0.0 /machine:x64 /debug /INCREMENTAL:NO /subsystem:windows /OPT:REF /entry:mainCRTStartup /manifest && C:\WINDOWS\system32\cmd.exe /C "cd /D C:\GitHub\mixxx\build && C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -noprofile -executionpolicy Bypass -file C:/GitHub/mixxx/buildenv/mixxx-deps-2.5-x64-windows-c15790e/scripts/buildsystems/msbuild/applocal.ps1 -targetBinary C:/GitHub/mixxx/build/mixxx.exe -installedDir C:/GitHub/mixxx/buildenv/mixxx-deps-2.5-x64-windows-c15790e/installed/x64-windows/bin -OutVariable out && cd /D C:\GitHub\mixxx\build && "C:\Program Files\CMake\bin\cmake.exe" -DCOMPONENT=applocal -DCMAKE_INSTALL_PREFIX="C:/GitHub/mixxx/build" -P cmake_install.cmake""
LINK: command "C:\PROGRA~1\MIB055~1\2022\COMMUN~1\VC\Tools\MSVC\1443~1.348\bin\Hostx64\x64\link.exe /nologo @CMakeFiles\mixxx.rsp /out:mixxx.exe /implib:mixxx.lib /pdb:mixxx.pdb /version:0.0 /machine:x64 /debug /INCREMENTAL:NO /subsystem:windows /OPT:REF /entry:mainCRTStartup /manifest /MANIFEST:EMBED,ID=1" failed (exit code 1181) with the following output:
LINK : fatal error LNK1181: cannot open input file 'comctl32.lib'
ninja: build stopped: subcommand failed.
``

