### PR TITLE
2.5.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2367,8 +2367,7 @@ announcements. First, if you are using Windows, you will have to uninstall any
 old versions of Mixxx before you can install 2.1. How to uninstall Mixxx
 varies on different versions of Windows:
 
-* Windows Vista, 7, and 8: [Start > Control Panel > Programs > Uninstall a
-  Program](https://support.microsoft.com/en-us/help/2601726)
+* Windows Vista, 7, and 8: Start > Control Panel > Programs > Uninstall a Program
 * Windows 10: [Start > Control Panel > Programs > Programs And Features >
   look for Mixxx > Uninstall](https://support.microsoft.com/en-gb/help/4028054/windows-repair-or-remove-programs-in-windows-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,21 @@
 * Behringer DDM4000 & BCR2000: Update mappings to 2.5
   [#14232](https://github.com/mixxxdj/mixxx/pull/14232)
   [#14349](https://github.com/mixxxdj/mixxx/pull/14349)
-* Hercules Inpulse 300: add toneplay, slicer, and beatmatch functionalities
+* Hercules DJControl Inpulse 300: add toneplay, slicer, and beatmatch functionalities
   [#14051](https://github.com/mixxxdj/mixxx/pull/14051)
   [#14057](https://github.com/mixxxdj/mixxx/pull/14057)
-* M-Vave SMC-Mixer: Add controller mapping [#14411](https://github.com/mixxxdj/mixxx/pull/14411)
+* Hercules DJControl Inpulse 500: New mapping
+  [#14491](https://github.com/mixxxdj/mixxx/pull/14491)
+  [#14510](https://github.com/mixxxdj/mixxx/pull/14510)
+* Hercules DJ Console Mk1: Fix pitch bend buttons [#14447](https://github.com/mixxxdj/mixxx/pull/14447)
+* M-Vave SMC-Mixer: Add controller mapping
+  [#14411](https://github.com/mixxxdj/mixxx/pull/14411)
+  [#14448](https://github.com/mixxxdj/mixxx/pull/14448)
+  [#14457](https://github.com/mixxxdj/mixxx/pull/14457)
+  [#14458](https://github.com/mixxxdj/mixxx/pull/14458)
+* M-Vave SMK-25 II: Piano keyboard mapping
+  [#14412](https://github.com/mixxxdj/mixxx/pull/14412)
+  [#14484](https://github.com/mixxxdj/mixxx/pull/14484)
 * Numark NS6II: New mapping [#11075](https://github.com/mixxxdj/mixxx/pull/11075)
 * Numark Platinum FX: New mapping [#12872](https://github.com/mixxxdj/mixxx/pull/12872)
 * Pioneer-DDJ-SB3: Fixes slip mode and adds missing knob controls [#11307](https://github.com/mixxxdj/mixxx/pull/11307)
@@ -63,6 +74,7 @@
 * Fix for `TypeError` in `midi-components-0.0.js`
   [#14203](https://github.com/mixxxdj/mixxx/pull/14203)
   [#14197](https://github.com/mixxxdj/mixxx/issues/14197)
+* Fix crash due to concurrent access in MidiController [#14159](https://github.com/mixxxdj/mixxx/pull/14159)
 
 ### Skins
 
@@ -103,10 +115,13 @@
 * History: Don't allow joining with locked previous playlist
   [#14401](https://github.com/mixxxdj/mixxx/pull/14401)
   [#14399](https://github.com/mixxxdj/mixxx/issues/14399)
+* Track info dialog: fixed cover label (max) size [#14418](https://github.com/mixxxdj/mixxx/pull/14418)
 * Track Menu: Reset `eject` after moving track file to trash [#14402](https://github.com/mixxxdj/mixxx/pull/14402)
 * Fix AutoDJ "Remove Crate" action
   [#14426](https://github.com/mixxxdj/mixxx/pull/14426)
   [#14425](https://github.com/mixxxdj/mixxx/issues/14425)
+* Fix scrolling issue with coverart columns visible [#13719](https://github.com/mixxxdj/mixxx/pull/13719)
+* Developer Tools: multi-word search, no Tab navigation in controls table [#14474](https://github.com/mixxxdj/mixxx/pull/14474)
 
 ### Other Fixes
 
@@ -149,6 +164,8 @@
   [#14269](https://github.com/mixxxdj/mixxx/pull/14269)
 * Fix and improve "missing env" error message [#14321](https://github.com/mixxxdj/mixxx/pull/14321)
 * Qt6.8: Ensure Mixxx uses "windowsvista" Qt style on Windows [#14228](https://github.com/mixxxdj/mixxx/pull/14228)
+* Raise macOS target version to 11 (Qt6.5 requirement). [#14440](https://github.com/mixxxdj/mixxx/pull/14440)
+* Fail early when building on WSL [#14481](https://github.com/mixxxdj/mixxx/pull/14481)
 
 ## [2.5.0](https://github.com/mixxxdj/mixxx/issues?q=milestone%3A2.5.0) (2024-12-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * Behringer DDM4000 & BCR2000: Update mappings to 2.5
   [#14232](https://github.com/mixxxdj/mixxx/pull/14232)
   [#14349](https://github.com/mixxxdj/mixxx/pull/14349)
+* DJ TechTools MIDI Fighter Spectra: Add controller mapping
+  [#14559](https://github.com/mixxxdj/mixxx/pull/14559)
 * Hercules DJControl Inpulse 300: add toneplay, slicer, and beatmatch functionalities
   [#14051](https://github.com/mixxxdj/mixxx/pull/14051)
   [#14057](https://github.com/mixxxdj/mixxx/pull/14057)
@@ -22,6 +24,7 @@
 * M-Vave SMK-25 II: Piano keyboard mapping
   [#14412](https://github.com/mixxxdj/mixxx/pull/14412)
   [#14484](https://github.com/mixxxdj/mixxx/pull/14484)
+* Numark Mixtrack Platinum: Fix VU Meters [#14575](https://github.com/mixxxdj/mixxx/pull/14575)
 * Numark NS6II: New mapping [#11075](https://github.com/mixxxdj/mixxx/pull/11075)
 * Numark Platinum FX: New mapping [#12872](https://github.com/mixxxdj/mixxx/pull/12872)
 * Pioneer-DDJ-SB3: Fixes slip mode and adds missing knob controls [#11307](https://github.com/mixxxdj/mixxx/pull/11307)
@@ -38,6 +41,9 @@
   [#14028](https://github.com/mixxxdj/mixxx/pull/14028)
   [#13995](https://github.com/mixxxdj/mixxx/issues/13995)
 * Traktor Kontrol S3: Use pitch absolute mode as described in the manual [#14123](https://github.com/mixxxdj/mixxx/pull/14123)
+* Stanton SCS.1m/d; Keith McMillen QuNeo; EKS Otus: use `playposition` instead of non-existent `visual_playposition`
+  [#14609](https://github.com/mixxxdj/mixxx/pull/14609)
+  [#14603](https://github.com/mixxxdj/mixxx/issues/14603)
 
 ### Controller Backend
 
@@ -91,6 +97,10 @@
 * Key Wheel: Move to View menu and make it a floating tool window
   [#14256](https://github.com/mixxxdj/mixxx/pull/14256)
   [#14239](https://github.com/mixxxdj/mixxx/pull/14239)
+* Center effect parameter names [#14598](https://github.com/mixxxdj/mixxx/pull/14598)
+* Track menu: highlight row when hovering checkbox
+  [#14636](https://github.com/mixxxdj/mixxx/pull/14636)
+  [#14680](https://github.com/mixxxdj/mixxx/pull/14680)
 
 ### Library
 
@@ -120,8 +130,23 @@
 * Fix AutoDJ "Remove Crate" action
   [#14426](https://github.com/mixxxdj/mixxx/pull/14426)
   [#14425](https://github.com/mixxxdj/mixxx/issues/14425)
-* Fix scrolling issue with coverart columns visible [#13719](https://github.com/mixxxdj/mixxx/pull/13719)
+* Fix scrolling issue with coverart columns visible
+  [#13719](https://github.com/mixxxdj/mixxx/pull/13719)
+  [#14631](https://github.com/mixxxdj/mixxx/pull/14631)
 * Developer Tools: multi-word search, no Tab navigation in controls table [#14474](https://github.com/mixxxdj/mixxx/pull/14474)
+* Analyze feature: respect New / All selection when searching
+  [#14660](https://github.com/mixxxdj/mixxx/pull/14660)
+  [#14659](https://github.com/mixxxdj/mixxx/issues/14659)
+* Stop populating Computer library feature when Mixxx should close [#14573](https://github.com/mixxxdj/mixxx/pull/14573)
+* Tracks: apply played/missing text color also to selected tracks [#13583](https://github.com/mixxxdj/mixxx/pull/13583)
+* Tracks: `show_track_menu` at index position [#14385](https://github.com/mixxxdj/mixxx/pull/14385)
+* Search related menu: improve checkbox click UX [#14637](https://github.com/mixxxdj/mixxx/pull/14637)
+* Avoid false missing tracks due to db inconsistency
+  [#14615](https://github.com/mixxxdj/mixxx/pull/14615)
+  [#14513](https://github.com/mixxxdj/mixxx/issues/14513)
+* Fix automatic trimming of search bar text
+  [#14497](https://github.com/mixxxdj/mixxx/pull/14497)
+  [#14486](https://github.com/mixxxdj/mixxx/issues/14486)
 
 ### Other Fixes
 
@@ -139,6 +164,12 @@
 * Allow seeking to a hotcue during waveform scratching
   [#14357](https://github.com/mixxxdj/mixxx/pull/14357)
   [#13981](https://github.com/mixxxdj/mixxx/issues/13981)
+* Reset saved loop when toggling off after switching cue type
+  [#14661](https://github.com/mixxxdj/mixxx/pull/14661)
+  [#14657](https://github.com/mixxxdj/mixxx/issues/14657)
+* Fix leaks from fid_design()
+  [#14567](https://github.com/mixxxdj/mixxx/pull/14567)
+  [#9470](https://github.com/mixxxdj/mixxx/issues/9470)
 
 ### Target support
 
@@ -150,6 +181,8 @@
   [#14071](https://github.com/mixxxdj/mixxx/issues/14071)
   [#14200](https://github.com/mixxxdj/mixxx/pull/14200)
   [#14204](https://github.com/mixxxdj/mixxx/pull/14204)
+  [#14440](https://github.com/mixxxdj/mixxx/pull/14440)
+  [#14518](https://github.com/mixxxdj/mixxx/pull/14518)
 * Welcome Ubuntu Plucky Puffin; Good bye Mantic Minotaur
   [#14148](https://github.com/mixxxdj/mixxx/pull/14148)
   [#14158](https://github.com/mixxxdj/mixxx/pull/14158)
@@ -163,9 +196,13 @@
 * Allow building without tests-tools via new CMake options BUILD_TESTING and BUILD_BENCH
   [#14269](https://github.com/mixxxdj/mixxx/pull/14269)
 * Fix and improve "missing env" error message [#14321](https://github.com/mixxxdj/mixxx/pull/14321)
-* Qt6.8: Ensure Mixxx uses "windowsvista" Qt style on Windows [#14228](https://github.com/mixxxdj/mixxx/pull/14228)
-* Raise macOS target version to 11 (Qt6.5 requirement). [#14440](https://github.com/mixxxdj/mixxx/pull/14440)
+* Qt 6.8: Ensure Mixxx uses "windowsvista" Qt style on Windows [#14228](https://github.com/mixxxdj/mixxx/pull/14228)
+* Raise macOS target version to 11 (Qt 6.5 requirement). [#14440](https://github.com/mixxxdj/mixxx/pull/14440)
 * Fail early when building on WSL [#14481](https://github.com/mixxxdj/mixxx/pull/14481)
+* Remove useless udev rule [#14630](https://github.com/mixxxdj/mixxx/pull/14630)
+* Handle new " / " from taglib 2.0
+  [#12854](https://github.com/mixxxdj/mixxx/pull/12854)
+  [#12790](https://github.com/mixxxdj/mixxx/issues/12790)
 
 ## [2.5.0](https://github.com/mixxxdj/mixxx/issues?q=milestone%3A2.5.0) (2024-12-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,9 @@
   [#14172](https://github.com/mixxxdj/mixxx/pull/14172)
   [#14289](https://github.com/mixxxdj/mixxx/pull/14289)
 * Fix writing metadata via symlink [#13711](https://github.com/mixxxdj/mixxx/pull/13711)
-* Library menu: change "Engine DJ Prime" to "Engine DJ" [#14248](https://github.com/mixxxdj/mixxx/pull/14248)
+* Library menu: change "Engine DJ Prime" to "Engine DJ"
+  [#14248](https://github.com/mixxxdj/mixxx/pull/14248)
+  [#14682](https://github.com/mixxxdj/mixxx/pull/14682)
 * Fix file extension handling during playlist export [#14381](https://github.com/mixxxdj/mixxx/pull/14381)
 * Fix manual key metadata editing in track properties dialog
   [#14022](https://github.com/mixxxdj/mixxx/pull/14022)
@@ -147,6 +149,9 @@
 * Fix automatic trimming of search bar text
   [#14497](https://github.com/mixxxdj/mixxx/pull/14497)
   [#14486](https://github.com/mixxxdj/mixxx/issues/14486)
+* Avoid crash after removing Quick Link
+  [#14556](https://github.com/mixxxdj/mixxx/pull/14556)
+  [#8270](https://github.com/mixxxdj/mixxx/issues/8270)
 
 ### Other Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,9 +84,10 @@
 
 ### Skins
 
-* Deere (64 samplers): Bring back library in regular view
+* Deere/LateNight (64 samplers): Bring back library in regular view
   [#14101](https://github.com/mixxxdj/mixxx/pull/14101)
   [#14097](https://github.com/mixxxdj/mixxx/issues/14097)
+  [#14700](https://github.com/mixxxdj/mixxx/issues/14700)
 * Fix crash when hiding waveforms in Deere
   [#14170](https://github.com/mixxxdj/mixxx/pull/14170)
 * Waveform Overview: Abort play pos dragging if cursor is released outside the valid area

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,7 +222,7 @@ elseif(APPLE)
   endif()
 endif()
 
-project(mixxx VERSION 2.5.0)
+project(mixxx VERSION 2.5.1)
 enable_language(C CXX)
 # Work around missing version suffixes support https://gitlab.kitware.com/cmake/cmake/-/issues/16716
 set(MIXXX_VERSION_PRERELEASE "") # set to "alpha" "beta" or ""

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 Mixxx 2.5.0, Digital DJ'ing software.
-Copyright (C) 2001-2024 Mixxx Development Team
+Copyright (C) 2001-2025 Mixxx Development Team
 
 Mixxx is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/cmake/modules/FindChromaprint.cmake
+++ b/cmake/modules/FindChromaprint.cmake
@@ -1,8 +1,3 @@
-# This file is part of Mixxx, Digital DJ'ing software.
-# Copyright (C) 2001-2024 Mixxx Development Team
-# Distributed under the GNU General Public Licence (GPL) version 2 or any later
-# later version. See the LICENSE file for details.
-
 #[=======================================================================[.rst:
 FindChromaprint
 ---------------

--- a/cmake/modules/FindDjInterop.cmake
+++ b/cmake/modules/FindDjInterop.cmake
@@ -1,8 +1,3 @@
-# This file is part of Mixxx, Digital DJ'ing software.
-# Copyright (C) 2001-2024 Mixxx Development Team
-# Distributed under the GNU General Public Licence (GPL) version 2 or any later
-# later version. See the LICENSE file for details.
-
 #[=======================================================================[.rst:
 FindDjInterop
 ---------------

--- a/cmake/modules/FindEbur128.cmake
+++ b/cmake/modules/FindEbur128.cmake
@@ -1,8 +1,3 @@
-# This file is part of Mixxx, Digital DJ'ing software.
-# Copyright (C) 2001-2024 Mixxx Development Team
-# Distributed under the GNU General Public Licence (GPL) version 2 or any later
-# later version. See the LICENSE file for details.
-
 #[=======================================================================[.rst:
 FindEbur128
 -----------

--- a/cmake/modules/FindFLAC.cmake
+++ b/cmake/modules/FindFLAC.cmake
@@ -1,8 +1,3 @@
-# This file is part of Mixxx, Digital DJ'ing software.
-# Copyright (C) 2001-2024 Mixxx Development Team
-# Distributed under the GNU General Public Licence (GPL) version 2 or any later
-# later version. See the LICENSE file for details.
-
 #[=======================================================================[.rst:
 FindFLAC
 --------

--- a/cmake/modules/FindG72X.cmake
+++ b/cmake/modules/FindG72X.cmake
@@ -1,8 +1,3 @@
-# This file is part of Mixxx, Digital DJ'ing software.
-# Copyright (C) 2001-2024 Mixxx Development Team
-# Distributed under the GNU General Public Licence (GPL) version 2 or any later
-# later version. See the LICENSE file for details.
-
 #[=======================================================================[.rst:
 FindG72X
 --------

--- a/cmake/modules/FindGPerfTools.cmake
+++ b/cmake/modules/FindGPerfTools.cmake
@@ -1,8 +1,3 @@
-# This file is part of Mixxx, Digital DJ'ing software.
-# Copyright (C) 2001-2024 Mixxx Development Team
-# Distributed under the GNU General Public Licence (GPL) version 2 or any later
-# later version. See the LICENSE file for details.
-
 #[=======================================================================[.rst:
 FindGPerfTools
 --------------

--- a/cmake/modules/FindHSS1394.cmake
+++ b/cmake/modules/FindHSS1394.cmake
@@ -1,8 +1,3 @@
-# This file is part of Mixxx, Digital DJ'ing software.
-# Copyright (C) 2001-2024 Mixxx Development Team
-# Distributed under the GNU General Public Licence (GPL) version 2 or any later
-# later version. See the LICENSE file for details.
-
 #[=======================================================================[.rst:
 FindHSS1394
 -----------

--- a/cmake/modules/FindID3Tag.cmake
+++ b/cmake/modules/FindID3Tag.cmake
@@ -1,8 +1,3 @@
-# This file is part of Mixxx, Digital DJ'ing software.
-# Copyright (C) 2001-2024 Mixxx Development Team
-# Distributed under the GNU General Public Licence (GPL) version 2 or any later
-# later version. See the LICENSE file for details.
-
 #[=======================================================================[.rst:
 FindID3Tag
 ----------

--- a/cmake/modules/FindKeyFinder.cmake
+++ b/cmake/modules/FindKeyFinder.cmake
@@ -1,8 +1,3 @@
-# This file is part of Mixxx, Digital DJ'ing software.
-# Copyright (C) 2001-2024 Mixxx Development Team
-# Distributed under the GNU General Public Licence (GPL) version 2 or any later
-# later version. See the LICENSE file for details.
-
 #[=======================================================================[.rst:
 FindKeyFinder
 --------

--- a/cmake/modules/FindLibUSB.cmake
+++ b/cmake/modules/FindLibUSB.cmake
@@ -1,8 +1,3 @@
-# This file is part of Mixxx, Digital DJ'ing software.
-# Copyright (C) 2001-2024 Mixxx Development Team
-# Distributed under the GNU General Public Licence (GPL) version 2 or any later
-# later version. See the LICENSE file for details.
-
 #[=======================================================================[.rst:
 FindLibUSB
 ----------

--- a/cmake/modules/FindLibudev.cmake
+++ b/cmake/modules/FindLibudev.cmake
@@ -1,8 +1,3 @@
-# This file is part of Mixxx, Digital DJ'ing software.
-# Copyright (C) 2001-2024 Mixxx Development Team
-# Distributed under the GNU General Public Licence (GPL) version 2 or any later
-# later version. See the LICENSE file for details.
-
 #[=======================================================================[.rst:
 FindLibudev
 --------

--- a/cmake/modules/FindMAD.cmake
+++ b/cmake/modules/FindMAD.cmake
@@ -1,8 +1,3 @@
-# This file is part of Mixxx, Digital DJ'ing software.
-# Copyright (C) 2001-2024 Mixxx Development Team
-# Distributed under the GNU General Public Licence (GPL) version 2 or any later
-# later version. See the LICENSE file for details.
-
 #[=======================================================================[.rst:
 FindMAD
 -------

--- a/cmake/modules/FindMP4.cmake
+++ b/cmake/modules/FindMP4.cmake
@@ -1,8 +1,3 @@
-# This file is part of Mixxx, Digital DJ'ing software.
-# Copyright (C) 2001-2024 Mixxx Development Team
-# Distributed under the GNU General Public Licence (GPL) version 2 or any later
-# later version. See the LICENSE file for details.
-
 #[=======================================================================[.rst:
 FindMP4
 -------

--- a/cmake/modules/FindMP4v2.cmake
+++ b/cmake/modules/FindMP4v2.cmake
@@ -1,8 +1,3 @@
-# This file is part of Mixxx, Digital DJ'ing software.
-# Copyright (C) 2001-2024 Mixxx Development Team
-# Distributed under the GNU General Public Licence (GPL) version 2 or any later
-# later version. See the LICENSE file for details.
-
 #[=======================================================================[.rst:
 FindMP4v2
 ---------

--- a/cmake/modules/FindModplug.cmake
+++ b/cmake/modules/FindModplug.cmake
@@ -1,8 +1,3 @@
-# This file is part of Mixxx, Digital DJ'ing software.
-# Copyright (C) 2001-2024 Mixxx Development Team
-# Distributed under the GNU General Public Licence (GPL) version 2 or any later
-# later version. See the LICENSE file for details.
-
 #[=======================================================================[.rst:
 FindModplug
 -----------

--- a/cmake/modules/FindOgg.cmake
+++ b/cmake/modules/FindOgg.cmake
@@ -1,8 +1,3 @@
-# This file is part of Mixxx, Digital DJ'ing software.
-# Copyright (C) 2001-2024 Mixxx Development Team
-# Distributed under the GNU General Public Licence (GPL) version 2 or any later
-# later version. See the LICENSE file for details.
-
 #[=======================================================================[.rst:
 FindOgg
 -------

--- a/cmake/modules/FindOpus.cmake
+++ b/cmake/modules/FindOpus.cmake
@@ -1,8 +1,3 @@
-# This file is part of Mixxx, Digital DJ'ing software.
-# Copyright (C) 2001-2024 Mixxx Development Team
-# Distributed under the GNU General Public Licence (GPL) version 2 or any later
-# later version. See the LICENSE file for details.
-
 #[=======================================================================[.rst:
 FindOpus
 --------

--- a/cmake/modules/FindOpusFile.cmake
+++ b/cmake/modules/FindOpusFile.cmake
@@ -1,8 +1,3 @@
-# This file is part of Mixxx, Digital DJ'ing software.
-# Copyright (C) 2001-2024 Mixxx Development Team
-# Distributed under the GNU General Public Licence (GPL) version 2 or any later
-# later version. See the LICENSE file for details.
-
 #[=======================================================================[.rst:
 FindOpus
 --------

--- a/cmake/modules/FindPortAudio.cmake
+++ b/cmake/modules/FindPortAudio.cmake
@@ -1,8 +1,3 @@
-# This file is part of Mixxx, Digital DJ'ing software.
-# Copyright (C) 2001-2024 Mixxx Development Team
-# Distributed under the GNU General Public Licence (GPL) version 2 or any later
-# later version. See the LICENSE file for details.
-
 #[=======================================================================[.rst:
 FindPortAudio
 --------

--- a/cmake/modules/FindPortMidi.cmake
+++ b/cmake/modules/FindPortMidi.cmake
@@ -1,8 +1,3 @@
-# This file is part of Mixxx, Digital DJ'ing software.
-# Copyright (C) 2001-2024 Mixxx Development Team
-# Distributed under the GNU General Public Licence (GPL) version 2 or any later
-# later version. See the LICENSE file for details.
-
 #[=======================================================================[.rst:
 FindPortMidi
 ---------------

--- a/cmake/modules/FindShoutidjc.cmake
+++ b/cmake/modules/FindShoutidjc.cmake
@@ -1,8 +1,3 @@
-# This file is part of Mixxx, Digital DJ'ing software.
-# Copyright (C) 2001-2024 Mixxx Development Team
-# Distributed under the GNU General Public Licence (GPL) version 2 or any later
-# later version. See the LICENSE file for details.
-
 #[=======================================================================[.rst:
 FindShoutidjc
 ---------

--- a/cmake/modules/FindSleef.cmake
+++ b/cmake/modules/FindSleef.cmake
@@ -1,8 +1,3 @@
-# This file is part of Mixxx, Digital DJ'ing software.
-# Copyright (C) 2001-2024 Mixxx Development Team
-# Distributed under the GNU General Public Licence (GPL) version 2 or any later
-# later version. See the LICENSE file for details.
-
 #[=======================================================================[.rst:
 FindSleef
 --------------

--- a/cmake/modules/FindSndFile.cmake
+++ b/cmake/modules/FindSndFile.cmake
@@ -1,8 +1,3 @@
-# This file is part of Mixxx, Digital DJ'ing software.
-# Copyright (C) 2001-2024 Mixxx Development Team
-# Distributed under the GNU General Public Licence (GPL) version 2 or any later
-# later version. See the LICENSE file for details.
-
 #[=======================================================================[.rst:
 FindSndFile
 -----------

--- a/cmake/modules/FindSoundTouch.cmake
+++ b/cmake/modules/FindSoundTouch.cmake
@@ -1,8 +1,3 @@
-# This file is part of Mixxx, Digital DJ'ing software.
-# Copyright (C) 2001-2024 Mixxx Development Team
-# Distributed under the GNU General Public Licence (GPL) version 2 or any later
-# later version. See the LICENSE file for details.
-
 #[=======================================================================[.rst:
 FindSoundTouch
 --------------

--- a/cmake/modules/FindTagLib.cmake
+++ b/cmake/modules/FindTagLib.cmake
@@ -1,8 +1,3 @@
-# This file is part of Mixxx, Digital DJ'ing software.
-# Copyright (C) 2001-2024 Mixxx Development Team
-# Distributed under the GNU General Public Licence (GPL) version 2 or any later
-# later version. See the LICENSE file for details.
-
 #[=======================================================================[.rst:
 FindTagLib
 -----------

--- a/cmake/modules/FindUpower.cmake
+++ b/cmake/modules/FindUpower.cmake
@@ -1,8 +1,3 @@
-# This file is part of Mixxx, Digital DJ'ing software.
-# Copyright (C) 2001-2024 Mixxx Development Team
-# Distributed under the GNU General Public Licence (GPL) version 2 or any later
-# later version. See the LICENSE file for details.
-
 #[=======================================================================[.rst:
 FindUpower
 ----------

--- a/cmake/modules/FindVorbis.cmake
+++ b/cmake/modules/FindVorbis.cmake
@@ -1,8 +1,3 @@
-# This file is part of Mixxx, Digital DJ'ing software.
-# Copyright (C) 2001-2024 Mixxx Development Team
-# Distributed under the GNU General Public Licence (GPL) version 2 or any later
-# later version. See the LICENSE file for details.
-
 #[=======================================================================[.rst:
 FindVorbis
 ----------

--- a/cmake/modules/Findhidapi.cmake
+++ b/cmake/modules/Findhidapi.cmake
@@ -1,8 +1,3 @@
-# This file is part of Mixxx, Digital DJ'ing software.
-# Copyright (C) 2001-2024 Mixxx Development Team
-# Distributed under the GNU General Public Licence (GPL) version 2 or any later
-# later version. See the LICENSE file for details.
-
 #[=======================================================================[.rst:
 Findhidapi
 ----------

--- a/cmake/modules/Findlilv.cmake
+++ b/cmake/modules/Findlilv.cmake
@@ -1,8 +1,3 @@
-# This file is part of Mixxx, Digital DJ'ing software.
-# Copyright (C) 2001-2024 Mixxx Development Team
-# Distributed under the GNU General Public Licence (GPL) version 2 or any later
-# later version. See the LICENSE file for details.
-
 #[=======================================================================[.rst:
 Findlilv
 --------

--- a/cmake/modules/Findmp3lame.cmake
+++ b/cmake/modules/Findmp3lame.cmake
@@ -1,8 +1,3 @@
-# This file is part of Mixxx, Digital DJ'ing software.
-# Copyright (C) 2001-2024 Mixxx Development Team
-# Distributed under the GNU General Public Licence (GPL) version 2 or any later
-# later version. See the LICENSE file for details.
-
 #[=======================================================================[.rst:
 Findmp3lame
 -----------

--- a/cmake/modules/Findrubberband.cmake
+++ b/cmake/modules/Findrubberband.cmake
@@ -1,8 +1,3 @@
-# This file is part of Mixxx, Digital DJ'ing software.
-# Copyright (C) 2001-2024 Mixxx Development Team
-# Distributed under the GNU General Public Licence (GPL) version 2 or any later
-# later version. See the LICENSE file for details.
-
 #[=======================================================================[.rst:
 Findrubberband
 --------------

--- a/cmake/modules/Findserd.cmake
+++ b/cmake/modules/Findserd.cmake
@@ -1,8 +1,3 @@
-# This file is part of Mixxx, Digital DJ'ing software.
-# Copyright (C) 2001-2025 Mixxx Development Team
-# Distributed under the GNU General Public Licence (GPL) version 2 or any later
-# later version. See the LICENSE file for details.
-
 #[=======================================================================[.rst:
 Findserd
 --------

--- a/cmake/modules/Findsord.cmake
+++ b/cmake/modules/Findsord.cmake
@@ -1,8 +1,3 @@
-# This file is part of Mixxx, Digital DJ'ing software.
-# Copyright (C) 2001-2025 Mixxx Development Team
-# Distributed under the GNU General Public Licence (GPL) version 2 or any later
-# later version. See the LICENSE file for details.
-
 #[=======================================================================[.rst:
 Findsord
 --------

--- a/cmake/modules/Findwavpack.cmake
+++ b/cmake/modules/Findwavpack.cmake
@@ -1,8 +1,3 @@
-# This file is part of Mixxx, Digital DJ'ing software.
-# Copyright (C) 2001-2024 Mixxx Development Team
-# Distributed under the GNU General Public Licence (GPL) version 2 or any later
-# later version. See the LICENSE file for details.
-
 #[=======================================================================[.rst:
 Findwavpack
 -----------

--- a/cmake/modules/Findzix.cmake
+++ b/cmake/modules/Findzix.cmake
@@ -1,8 +1,3 @@
-# This file is part of Mixxx, Digital DJ'ing software.
-# Copyright (C) 2001-2025 Mixxx Development Team
-# Distributed under the GNU General Public Licence (GPL) version 2 or any later
-# later version. See the LICENSE file for details.
-
 #[=======================================================================[.rst:
 Findzix
 --------

--- a/packaging/debian/copyright
+++ b/packaging/debian/copyright
@@ -6,7 +6,7 @@ Source: https://downloads.mixxx.org/
 
 Files: *
 Copyright:
- 2001-2024 Mixxx development team
+ 2001-2025 Mixxx development team
 License: GPL-2+
 
 License: GPL-2+

--- a/packaging/wix/LICENSE.rtf.in
+++ b/packaging/wix/LICENSE.rtf.in
@@ -2,7 +2,7 @@
 {\colortbl ;\red0\green0\blue255;}
 {\*\generator Riched20 10.0.14393}\viewkind4\uc1
 \pard\qj\ul\b\f0\fs22\lang1036 Mixxx @CMAKE_PROJECT_VERSION@, Digital DJ'ing software.\ulnone\b0\fs24\par
-\fs22 Copyright (C) 2001-2024 Mixxx Development Team\par
+\fs22 Copyright (C) 2001-2025 Mixxx Development Team\par
 \par
 Promotional tracks are copyright their respective owners and\par
 distributed with permission.\par

--- a/res/linux/org.mixxx.Mixxx.metainfo.xml
+++ b/res/linux/org.mixxx.Mixxx.metainfo.xml
@@ -96,7 +96,7 @@
   Do not edit it manually.
   -->
   <releases>
-    <release version="2.5.1" type="development" date="2025-03-24" timestamp="1742856467">
+    <release version="2.5.1" type="development" date="2025-03-20" timestamp="1742453738">
       <description>
  <p>
   Controller Mappings
@@ -106,6 +106,10 @@
    Behringer DDM4000 &amp; BCR2000: Update mappings to 2.5
    #14232
    #14349
+  </li>
+  <li>
+   DJ TechTools MIDI Fighter Spectra: Add controller mapping
+   #14559
   </li>
   <li>
    Hercules DJControl Inpulse 300: add toneplay, slicer, and beatmatch functionalities
@@ -132,6 +136,10 @@
    M-Vave SMK-25 II: Piano keyboard mapping
    #14412
    #14484
+  </li>
+  <li>
+   Numark Mixtrack Platinum: Fix VU Meters
+   #14575
   </li>
   <li>
    Numark NS6II: New mapping
@@ -168,6 +176,14 @@
   <li>
    Traktor Kontrol S3: Use pitch absolute mode as described in the manual
    #14123
+  </li>
+  <li>
+   Stanton SCS.1m/d; Keith McMillen QuNeo; EKS Otus: use
+   playposition
+   instead of non-existent
+   visual_playposition
+   #14609
+   #14603
   </li>
  </ul>
  <p>
@@ -288,6 +304,15 @@
    #14256
    #14239
   </li>
+  <li>
+   Center effect parameter names
+   #14598
+  </li>
+  <li>
+   Track menu: highlight row when hovering checkbox
+   #14636
+   #14680
+  </li>
  </ul>
  <p>
   Library
@@ -357,10 +382,44 @@
   <li>
    Fix scrolling issue with coverart columns visible
    #13719
+   #14631
   </li>
   <li>
    Developer Tools: multi-word search, no Tab navigation in controls table
    #14474
+  </li>
+  <li>
+   Analyze feature: respect New / All selection when searching
+   #14660
+   #14659
+  </li>
+  <li>
+   Stop populating Computer library feature when Mixxx should close
+   #14573
+  </li>
+  <li>
+   Tracks: apply played/missing text color also to selected tracks
+   #13583
+  </li>
+  <li>
+   Tracks:
+   show_track_menu
+   at index position
+   #14385
+  </li>
+  <li>
+   Search related menu: improve checkbox click UX
+   #14637
+  </li>
+  <li>
+   Avoid false missing tracks due to db inconsistency
+   #14615
+   #14513
+  </li>
+  <li>
+   Fix automatic trimming of search bar text
+   #14497
+   #14486
   </li>
  </ul>
  <p>
@@ -402,6 +461,16 @@
    #14357
    #13981
   </li>
+  <li>
+   Reset saved loop when toggling off after switching cue type
+   #14661
+   #14657
+  </li>
+  <li>
+   Fix leaks from fid_design()
+   #14567
+   #9470
+  </li>
  </ul>
  <p>
   Target support
@@ -418,6 +487,8 @@
    #14071
    #14200
    #14204
+   #14440
+   #14518
   </li>
   <li>
    Welcome Ubuntu Plucky Puffin; Good bye Mantic Minotaur
@@ -447,16 +518,25 @@
    #14321
   </li>
   <li>
-   Qt6.8: Ensure Mixxx uses "windowsvista" Qt style on Windows
+   Qt 6.8: Ensure Mixxx uses "windowsvista" Qt style on Windows
    #14228
   </li>
   <li>
-   Raise macOS target version to 11 (Qt6.5 requirement).
+   Raise macOS target version to 11 (Qt 6.5 requirement).
    #14440
   </li>
   <li>
    Fail early when building on WSL
    #14481
+  </li>
+  <li>
+   Remove useless udev rule
+   #14630
+  </li>
+  <li>
+   Handle new " / " from taglib 2.0
+   #12854
+   #12790
   </li>
  </ul>
 </description>

--- a/res/linux/org.mixxx.Mixxx.metainfo.xml
+++ b/res/linux/org.mixxx.Mixxx.metainfo.xml
@@ -96,7 +96,7 @@
   Do not edit it manually.
   -->
   <releases>
-    <release version="2.5.1" type="development" date="2025-03-03" timestamp="1741001174">
+    <release version="2.5.1" type="development" date="2025-03-24" timestamp="1742856467">
       <description>
  <p>
   Controller Mappings
@@ -108,13 +108,30 @@
    #14349
   </li>
   <li>
-   Hercules Inpulse 300: add toneplay, slicer, and beatmatch functionalities
+   Hercules DJControl Inpulse 300: add toneplay, slicer, and beatmatch functionalities
    #14051
    #14057
   </li>
   <li>
+   Hercules DJControl Inpulse 500: New mapping
+   #14491
+   #14510
+  </li>
+  <li>
+   Hercules DJ Console Mk1: Fix pitch bend buttons
+   #14447
+  </li>
+  <li>
    M-Vave SMC-Mixer: Add controller mapping
    #14411
+   #14448
+   #14457
+   #14458
+  </li>
+  <li>
+   M-Vave SMK-25 II: Piano keyboard mapping
+   #14412
+   #14484
   </li>
   <li>
    Numark NS6II: New mapping
@@ -235,6 +252,10 @@
    #14203
    #14197
   </li>
+  <li>
+   Fix crash due to concurrent access in MidiController
+   #14159
+  </li>
  </ul>
  <p>
   Skins
@@ -319,6 +340,10 @@
    #14399
   </li>
   <li>
+   Track info dialog: fixed cover label (max) size
+   #14418
+  </li>
+  <li>
    Track Menu: Reset
    eject
    after moving track file to trash
@@ -328,6 +353,14 @@
    Fix AutoDJ "Remove Crate" action
    #14426
    #14425
+  </li>
+  <li>
+   Fix scrolling issue with coverart columns visible
+   #13719
+  </li>
+  <li>
+   Developer Tools: multi-word search, no Tab navigation in controls table
+   #14474
   </li>
  </ul>
  <p>
@@ -416,6 +449,14 @@
   <li>
    Qt6.8: Ensure Mixxx uses "windowsvista" Qt style on Windows
    #14228
+  </li>
+  <li>
+   Raise macOS target version to 11 (Qt6.5 requirement).
+   #14440
+  </li>
+  <li>
+   Fail early when building on WSL
+   #14481
   </li>
  </ul>
 </description>

--- a/res/linux/org.mixxx.Mixxx.metainfo.xml
+++ b/res/linux/org.mixxx.Mixxx.metainfo.xml
@@ -96,7 +96,7 @@
   Do not edit it manually.
   -->
   <releases>
-    <release version="2.5.1" type="development" date="2025-03-20" timestamp="1742453738">
+    <release version="2.5.1" type="development" date="2025-04-25" timestamp="1745598227">
       <description>
  <p>
   Controller Mappings
@@ -6136,9 +6136,7 @@ varies on different versions of Windows:
  </p>
  <ul>
   <li>
-   Windows Vista, 7, and 8:
-   Start &gt; Control Panel &gt; Programs &gt; Uninstall a
-  Program
+   Windows Vista, 7, and 8: Start &gt; Control Panel &gt; Programs &gt; Uninstall a Program
   </li>
   <li>
    Windows 10:

--- a/res/linux/org.mixxx.Mixxx.metainfo.xml
+++ b/res/linux/org.mixxx.Mixxx.metainfo.xml
@@ -96,7 +96,7 @@
   Do not edit it manually.
   -->
   <releases>
-    <release version="2.5.1" type="development" date="2025-04-25" timestamp="1745598227">
+    <release version="2.5.1" type="development" date="2025-04-25" timestamp="1745604613">
       <description>
  <p>
   Controller Mappings
@@ -347,6 +347,7 @@
   <li>
    Library menu: change "Engine DJ Prime" to "Engine DJ"
    #14248
+   #14682
   </li>
   <li>
    Fix file extension handling during playlist export
@@ -420,6 +421,11 @@
    Fix automatic trimming of search bar text
    #14497
    #14486
+  </li>
+  <li>
+   Avoid crash after removing Quick Link
+   #14556
+   #8270
   </li>
  </ul>
  <p>

--- a/res/linux/org.mixxx.Mixxx.metainfo.xml
+++ b/res/linux/org.mixxx.Mixxx.metainfo.xml
@@ -96,7 +96,7 @@
   Do not edit it manually.
   -->
   <releases>
-    <release version="2.5.1" type="development" date="2025-04-25" timestamp="1745604613">
+    <release version="2.5.1" type="development" date="2025-04-26" timestamp="1745670165">
       <description>
  <p>
   Controller Mappings
@@ -278,9 +278,10 @@
  </p>
  <ul>
   <li>
-   Deere (64 samplers): Bring back library in regular view
+   Deere/LateNight (64 samplers): Bring back library in regular view
    #14101
    #14097
+   #14700
   </li>
   <li>
    Fix crash when hiding waveforms in Deere

--- a/res/skins/LateNight (64 Samplers)/skin.xml
+++ b/res/skins/LateNight (64 Samplers)/skin.xml
@@ -454,7 +454,7 @@
 
                     <WidgetGroup>
                       <Layout>vertical</Layout>
-                      <SizePolicy>me,max</SizePolicy>
+                      <SizePolicy>me,min</SizePolicy>
                       <Children>
                         <Template src="skins:LateNight/waveforms_container.xml"/>
                       </Children>


### PR DESCRIPTION
This is the release PR for the Mixxx version 2.5.1
It contains some important bug-fixes and mapping updates. 

These are my personal highlights: 

* Fix scrolling issue with coverart columns visible #13719
* Deere (64 samplers): Bring back library in regular view #14101 #14097
* Fix crash when hiding waveforms in Deere #14170
* Fix MusicBrainz lookup on Windows and macOS #14216 
* Fix sporadic deadlocks when closing Mixxx or changing sound devices #14208 #14055

I am also happy about these big effort involved publishing a new version after 3 Month. 
Thank you to all contributiors. 

@Eve00000 Next step is preparing a brief blog post. 
Will you find time for this. I am curious about the style you will select. 
