### PR TITLE
Add support for Arturia KeyLab Mk1

### DIFF
--- a/res/controllers/Arturia-KeyLab-Mk1-scripts.js
+++ b/res/controllers/Arturia-KeyLab-Mk1-scripts.js
@@ -279,9 +279,6 @@ var KeyLabMk1;
             this.inKey = `${this.cueBaseName}_activate`;
         }
         shift() {
-            // TODO: this class was copied from the Traktor Kontrol S4 Mk3
-            // mapping, but we don't have a shift button. Should this be made a
-            // long press action instead?
             this.inKey = `${this.cueBaseName}_clear`;
         }
     }
@@ -532,6 +529,13 @@ var KeyLabMk1;
             }
         }
 
+        switchLayer(layerNum, pads) {
+            this.applyLayer({pads: pads}, true);
+            this.radioGroup.forEach((btn, idx) => {
+                btn.output(idx === layerNum ? LedState.on : LedState.off);
+            });
+        }
+
         defaultLayer(group) {
             const pads = [
                 new IntroOutroButton({
@@ -580,10 +584,7 @@ var KeyLabMk1;
                     },
                 });
             }
-            this.applyLayer({pads: pads}, true);
-            this.radioGroup.forEach((btn, idx) => {
-                btn.output(idx === 0 ? LedState.on : LedState.off);
-            });
+            this.switchLayer(0, pads);
         }
 
         hotcueLayer(group) {
@@ -596,7 +597,6 @@ var KeyLabMk1;
                     blinkState: false,
                     blinkTimer: 0,
                     output: function(value) {
-                        // TODO: dedup with output function in defaultLayer.
                         if (value === 2) {
                             if (this.blinkTimer === 0) {
                                 this.blinkTimer = engine.beginTimer(250, () => {
@@ -614,10 +614,7 @@ var KeyLabMk1;
                     },
                 });
             }
-            this.applyLayer({pads: pads}, true);
-            this.radioGroup.forEach((btn, idx) => {
-                btn.output(idx === 1 ? LedState.on : LedState.off);
-            });
+            this.switchLayer(1, pads);
         }
 
         samplerLayer() {
@@ -671,20 +668,14 @@ var KeyLabMk1;
                     },
                 });
             }
-            this.applyLayer({"pads": pads}, true);
-            this.radioGroup.forEach((btn, idx) => {
-                btn.output(idx === 2 ? LedState.on : LedState.off);
-            });
+            this.switchLayer(2, pads);
         }
 
         disabledLayer() {
             for (let i = 0; i < 16; i++) {
                 delayLED(this.padNum(i) + 0x4c)(LedState.off);
             }
-            this.applyLayer({pads: Array(16).fill(new components.Button())});
-            this.radioGroup.forEach((btn) => {
-                btn.output(LedState.off);
-            });
+            this.switchLayer(undefined, Array(16).fill(new components.Button()));
         }
 
         input(channel, control, value, status, group) {

--- a/res/controllers/Arturia-KeyLab-Mk1-scripts.js
+++ b/res/controllers/Arturia-KeyLab-Mk1-scripts.js
@@ -69,83 +69,122 @@ var KeyLabMk1;
     // Menu items that can be controlled with the parameter and value encoders.
     const menu = [{
         name: "Key",
-        inKey: "key",
-        max: 24,
-        pressInKey: "reset_key",
-        outputValue: (value) => {
-            return keyNums[script.posMod(value - 1, keyNums.length)];
+        rotate: {
+            inKey: "key",
+            max: 24,
+            outputValue: (value) => {
+                return keyNums[script.posMod(value - 1, keyNums.length)];
+            },
+        },
+        press: {
+            inKey: "reset_key",
         },
     }, {
         name: "Beatloop",
-        inKey: "beatloop_size",
-        pressInKey: "beatloop_activate",
+        rotate: {
+            inKey: "beatloop_size",
+        },
+        press: {
+            inKey: "beatloop_activate",
+        },
     }, {
         name: "Beatjump",
-        inKey: "beatjump_size",
+        rotate: {
+            inKey: "beatjump_size",
+        },
     }, {
         name: "Library",
         params: [{
             name: "Search",
-            relative: true,
-            group: "[Library]",
-            inKey: "search_history_selector",
-            pressInKey: "clear_search",
+            rotate: {
+                group: "[Library]",
+                relative: true,
+                inKey: "search_history_selector",
+            },
+            press: {
+                group: "[Library]",
+                inKey: "clear_search",
+            },
         }, {
             name: "Focus",
-            min: 0,
-            max: 6,
-            group: "[Library]",
-            inKey: "focused_widget",
+            rotate: {
+                min: 0,
+                max: 6,
+                group: "[Library]",
+                inKey: "focused_widget",
+            },
         }, {
             name: "Scroll",
-            relative: true,
-            group: "[Library]",
-            inKey: "MoveVertical",
-            pressInKey: "GoToItem",
+            rotate: {
+                group: "[Library]",
+                relative: true,
+                inKey: "MoveVertical",
+            },
+            press: {
+                group: "[Library]",
+                inKey: "GoToItem",
+            },
         }, {
             name: "Sort",
-            min: 1,
-            max: 31,
-            group: "[Library]",
-            inKey: "sort_column_toggle",
-            pressInKey: "sort_order",
-            pressType: components.Button.prototype.types.toggle,
-            outputValue: (value) => {
-                return sortCols[(((value - 1) % sortCols.length) + sortCols.length) % sortCols.length];
+            rotate: {
+                group: "[Library]",
+                min: 1,
+                max: 31,
+                inKey: "sort_column_toggle",
+                outputValue: (value) => {
+                    return sortCols[(((value - 1) % sortCols.length) + sortCols.length) % sortCols.length];
+                },
+            },
+            press: {
+                group: "[Library]",
+                type: components.Button.prototype.types.toggle,
+                inKey: "sort_order",
             },
         }, {
             name: "Maximize",
-            group: "[Skin]",
-            pressType: components.Button.prototype.types.toggle,
-            pressInKey: "show_maximized_library",
+            press: {
+                group: "[Skin]",
+                type: components.Button.prototype.types.toggle,
+                inKey: "show_maximized_library",
+            },
         }, {
             name: "Font Size",
-            relative: true,
-            group: "[Library]",
-            inKey: "font_size_knob",
+            rotate: {
+                group: "[Library]",
+                relative: true,
+                inKey: "font_size_knob",
+            },
         }],
     }, {
         name: "Skin",
         params: [{
             name: "Effect Rack",
-            group: "[Skin]",
-            pressInKey: "show_effectrack",
-            pressType: components.Button.prototype.types.toggle,
+            press: {
+                group: "[Skin]",
+                type: components.Button.prototype.types.toggle,
+                inKey: "show_effectrack",
+            },
         }, {
             name: "Coverart",
-            group: "[Skin]",
-            pressInKey: "show_library_coverart",
-            pressType: components.Button.prototype.types.toggle,
+            press: {
+                group: "[Skin]",
+                type: components.Button.prototype.types.toggle,
+                inKey: "show_library_coverart",
+            },
         }, {
             name: "Samplers",
-            group: "[Skin]",
-            pressInKey: "show_samplers",
-            pressType: components.Button.prototype.types.toggle,
+            press: {
+                group: "[Skin]",
+                type: components.Button.prototype.types.toggle,
+                inKey: "show_samplers",
+            },
         }, {
             name: "Vinyl Control",
-            group: "[Skin]",
-            pressInKey: "show_vinylcontrol",
-            pressType: components.Button.prototype.types.toggle,
+            press: {
+                group: "[Skin]",
+                type: components.Button.prototype.types.toggle,
+                inKey: "show_vinylcontrol",
+            },
         }],
     }];
 
@@ -155,19 +194,29 @@ var KeyLabMk1;
             name: `FX${i + 1}`,
             params: [{
                 name: `FX${i + 1} Preset`,
-                group: `[EffectRack1_EffectUnit${i + 1}]`,
-                inKey: "chain_preset_selector",
-                relative: true,
-                pressInKey: "group_[Channel1]_enable",
-                pressType: components.Button.prototype.types.toggle,
+                rotate: {
+                    group: `[EffectRack1_EffectUnit${i + 1}]`,
+                    inKey: "chain_preset_selector",
+                    relative: true,
+                },
+                press: {
+                    group: `[EffectRack1_EffectUnit${i + 1}]`,
+                    inKey: "group_[Channel1]_enable",
+                    type: components.Button.prototype.types.toggle,
+                },
             }, {
                 name: `FX${i + 1} Focus`,
-                group: `[EffectRack1_EffectUnit${i + 1}]`,
-                min: 1,
-                max: engine.getValue(`[EffectRack1_EffectUnit${i + 1}]`, "num_effectslots"),
-                inKey: "focused_effect",
-                pressInKey: "show_focus",
-                pressType: components.Button.prototype.types.toggle,
+                rotate: {
+                    group: `[EffectRack1_EffectUnit${i + 1}]`,
+                    min: 1,
+                    max: engine.getValue(`[EffectRack1_EffectUnit${i + 1}]`, "num_effectslots"),
+                    inKey: "focused_effect",
+                },
+                press: {
+                    group: `[EffectRack1_EffectUnit${i + 1}]`,
+                    type: components.Button.prototype.types.toggle,
+                    inKey: "show_focus",
+                },
             }],
         });
     }
@@ -495,34 +544,49 @@ var KeyLabMk1;
                 group: "[Channel1]",
                 midi: [0xB0, 0x70], // Param encoder
                 selectedParam: 0,
-                params: [...menu],
+                params: menu,
                 activeDeck: this.activeDeck,
                 input: function(_channel, _control, value, _status, _group) {
                     if (value === 0x3F) {
-                        this.selectedParam = (((this.selectedParam - 1) % this.params.length) + this.params.length)
-                            % this.params.length;
+                        this.selectedParam = script.posMod(this.selectedParam - 1, this.params.length);
                     } else if (value === 0x41) {
-                        this.selectedParam = (((this.selectedParam + 1) % this.params.length) + this.params.length)
-                            % this.params.length;
+                        this.selectedParam = script.posMod(this.selectedParam + 1, this.params.length);
                     }
                     const param = this.params[this.selectedParam];
-                    if (param.group) {
-                        this.activeDeck.valueEncoder.group = param.group;
-                        this.activeDeck.valueButton.group = param.group;
-                    } else {
-                        this.activeDeck.valueEncoder.group = this.activeDeck.currentDeck;
-                        this.activeDeck.valueButton.group = this.activeDeck.currentDeck;
+
+                    // Assign defaults to the value encoder and button, and
+                    // deactivate them.
+                    Object.assign(this.activeDeck.valueEncoder, {
+                        name: param.name,
+                        group: this.activeDeck.currentDeck,
+                        relative: false,
+                        key: undefined,
+                        inKey: undefined,
+                        outKey: undefined,
+                        outputValue: undefined,
+                        min: undefined,
+                        max: undefined,
+                    });
+                    Object.assign(this.activeDeck.valueButton, {
+                        name: param.name,
+                        group: this.activeDeck.currentDeck,
+                        type: components.Button.prototype.types.push,
+                        key: undefined,
+                        inKey: undefined,
+                        outKey: undefined,
+                        outputValue: undefined,
+                        min: undefined,
+                        max: undefined,
+                    });
+
+                    // If the current menu has new actions for the buttons,
+                    // assign them.
+                    if (param.rotate) {
+                        Object.assign(this.activeDeck.valueEncoder, param.rotate);
                     }
-                    this.activeDeck.valueEncoder.name = param.name;
-                    this.activeDeck.valueButton.name = param.name;
-                    this.activeDeck.valueEncoder.inKey = param.inKey;
-                    this.activeDeck.valueEncoder.max = param.max;
-                    this.activeDeck.valueEncoder.min = param.min;
-                    this.activeDeck.valueEncoder.relative = param.relative || false;
-                    this.activeDeck.valueButton.inKey = param.pressInKey;
-                    this.activeDeck.valueButton.type = param.pressType || components.Button.prototype.types.push;
-                    this.activeDeck.valueEncoder.outputValue = param.outputValue;
-                    this.activeDeck.valueButton.outputValue = param.outputValue;
+                    if (param.press) {
+                        Object.assign(this.activeDeck.valueButton, param.press);
+                    }
 
                     writeDisplay(`${param.name}`);
                 },
@@ -543,7 +607,7 @@ var KeyLabMk1;
                         // and set old menu to that submenus back menu.
                         this.prevParams = this.encoder.params;
                         this.prevSelected = this.encoder.selectedParam;
-                        this.encoder.params = [...param.params];
+                        this.encoder.params = param.params;
                         // Always add a back button to the end of sub-menus.
                         this.encoder.params.push({name: "Back"});
                         if (param.selectedParam === undefined) {

--- a/res/controllers/Arturia-KeyLab-Mk1-scripts.js
+++ b/res/controllers/Arturia-KeyLab-Mk1-scripts.js
@@ -73,7 +73,7 @@ var KeyLabMk1;
         max: 24,
         pressInKey: "reset_key",
         outputValue: (value) => {
-            return keyNums[(((value - 1) % keyNums.length) + keyNums.length) % keyNums.length];
+            return keyNums[script.posMod(value - 1, keyNums.length)];
         },
     }, {
         name: "Beatloop",
@@ -222,11 +222,6 @@ var KeyLabMk1;
     };
 
     class Deck extends components.Deck {
-        currentDeckNum() {
-            const deckStr = script.channelRegEx.exec(this.currentDeck)[1];
-            return parseInt(deckStr);
-        }
-
         constructor(deckNumbers, midiChannel) {
             super(deckNumbers);
 
@@ -444,14 +439,14 @@ var KeyLabMk1;
                 return;
             }
 
-            let blink_state = false;
+            let blinkState = false;
             let velocity = 500;
             if (this.group === group) {
                 velocity = 250;
             }
             this.blinking = engine.beginTimer(velocity, () => {
-                blink_state = !blink_state;
-                setLED(this.midi[2], blink_state);
+                blinkState = !blinkState;
+                setLED(this.midi[2], blinkState);
             });
         }
 
@@ -475,7 +470,7 @@ var KeyLabMk1;
                 setLED(0x1E, Boolean(value));
                 setLED(0x1F, !value);
                 if (!noWrite) {
-                    const currentDeckNum = this.activeDeck.currentDeckNum();
+                    const currentDeckNum = script.deckFromGroup(this.activeDeck.currentDeck);
                     writeDisplay(`Deck ${currentDeckNum}`);
                 }
             };
@@ -655,7 +650,7 @@ var KeyLabMk1;
                     empty: 0x00,
                     loaded: 0x01,
                     blinking: 0,
-                    blink_state: false,
+                    blinkState: false,
 
                     send: function(value) {
                         switch (value) {
@@ -683,8 +678,8 @@ var KeyLabMk1;
                             // timers, one of which we forget to stop.
                             if (this.blinking === 0) {
                                 this.blinking = engine.beginTimer(250, () => {
-                                    this.blink_state = !this.blink_state;
-                                    setLED(this.midi[1] + 0x4c, this.blink_state);
+                                    this.blinkState = !this.blinkState;
+                                    setLED(this.midi[1] + 0x4c, this.blinkState);
                                 });
                             }
                             break;

--- a/res/controllers/Arturia-KeyLab-Mk1-scripts.js
+++ b/res/controllers/Arturia-KeyLab-Mk1-scripts.js
@@ -72,7 +72,7 @@ var KeyLabMk1;
         rotate: {
             inKey: "key",
             max: 24,
-            outputValue: (value) => {
+            outValueScale: (value) => {
                 return keyNums[script.posMod(value - 1, keyNums.length)];
             },
         },
@@ -131,7 +131,7 @@ var KeyLabMk1;
                 min: 1,
                 max: 31,
                 inKey: "sort_column_toggle",
-                outputValue: (value) => {
+                outValueScale: (value) => {
                     return sortCols[(((value - 1) % sortCols.length) + sortCols.length) % sortCols.length];
                 },
             },
@@ -399,8 +399,8 @@ var KeyLabMk1;
                     this.output(this.inGetParameter());
                 },
                 output: function(value) {
-                    if (this.outputValue) {
-                        const newVal = this.outputValue(value);
+                    if (this.outValueScale) {
+                        const newVal = this.outValueScale(value);
                         writeDisplay(`${this.name}: ${newVal}`);
                     }
                 },
@@ -425,8 +425,8 @@ var KeyLabMk1;
                     this.output(this.encoder.inGetParameter());
                 },
                 output: function(value) {
-                    if (this.outputValue) {
-                        const newVal = this.outputValue(value);
+                    if (this.outValueScale) {
+                        const newVal = this.outValueScale(value);
                         writeDisplay(`${this.name}: ${newVal}`);
                     }
                 },
@@ -810,7 +810,7 @@ var KeyLabMk1;
                         key: undefined,
                         inKey: undefined,
                         outKey: undefined,
-                        outputValue: undefined,
+                        outValueScale: undefined,
                         min: undefined,
                         max: undefined,
                     });
@@ -821,7 +821,7 @@ var KeyLabMk1;
                         key: undefined,
                         inKey: undefined,
                         outKey: undefined,
-                        outputValue: undefined,
+                        outValueScale: undefined,
                         min: undefined,
                         max: undefined,
                     });
@@ -967,7 +967,7 @@ var KeyLabMk1;
         }
         for (let n = 0; n < MMCHeader.length; n++) {
             if (data[n] !== MMCHeader[n]) {
-                console.log("unknown sysex packet");
+                console.log(`unknown sysex packet: ${data}`);
                 return;
             }
         }

--- a/res/controllers/Arturia-KeyLab-Mk1-scripts.js
+++ b/res/controllers/Arturia-KeyLab-Mk1-scripts.js
@@ -128,8 +128,8 @@ var KeyLabMk1;
             name: "Sort",
             rotate: {
                 group: "[Library]",
-                min: 1,
-                max: 31,
+                min: script.LIBRARY_COLUMNS.ARTIST,
+                max: script.LIBRARY_COLUMNS.LAST_PLAYED,
                 inKey: "sort_column_toggle",
                 outValueScale: (value) => {
                     return sortCols[(((value - 1) % sortCols.length) + sortCols.length) % sortCols.length];
@@ -367,33 +367,28 @@ var KeyLabMk1;
                         return;
                     }
                     const param = this.inGetParameter();
-                    if (value === 0x3F) {
-                        if (this.relative) {
-                            this.inSetParameter(-1);
-                            return;
-                        }
-                        const newParam = param - 1;
-                        if (
-                            this.min !== undefined && this.max !== undefined
-                            && newParam < this.min
-                        ) {
-                            this.inSetParameter(this.max);
-                        } else {
-                            this.inSetParameter(param - 1);
-                        }
-                    } else if (value === 0x41) {
+
+                    if (value & 0x40) {
                         if (this.relative) {
                             this.inSetParameter(1);
-                            return;
-                        }
-                        const newParam = param + 1;
-                        if (
-                            this.max !== undefined && this.min !== undefined
-                            && newParam > this.max
-                        ) {
-                            this.inSetParameter(this.min);
                         } else {
-                            this.inSetParameter(param + 1);
+                            const newParam = param + 1;
+                            if (this.max !== undefined && this.min !== undefined && newParam > this.max) {
+                                this.inSetParameter(this.min);
+                            } else {
+                                this.inSetParameter(newParam);
+                            }
+                        }
+                    } else {
+                        if (this.relative) {
+                            this.inSetParameter(-1);
+                        } else {
+                            const newParam = param - 1;
+                            if (this.max !== undefined && this.min !== undefined && newParam < this.min) {
+                                this.inSetParameter(this.max);
+                            } else {
+                                this.inSetParameter(newParam);
+                            }
                         }
                     }
                     this.output(this.inGetParameter());
@@ -1005,3 +1000,5 @@ var KeyLabMk1;
         }
     };
 })(KeyLabMk1 || (KeyLabMk1 = {}));
+
+// vim:expandtab:shiftwidth=4:tabstop=4:backupcopy=yes

--- a/res/controllers/Arturia-KeyLab-Mk1-scripts.js
+++ b/res/controllers/Arturia-KeyLab-Mk1-scripts.js
@@ -232,11 +232,10 @@ var KeyLabMk1;
                 type: components.Button.prototype.types.push,
                 output: delayLED(0x58),
             });
-            this.stopButton = new components.Button({
+            this.stopButton = new components.CueButton({
                 group: "[Channel1]",
                 midi: [0xB0 + midiChannel, 0x01],
                 type: components.Button.prototype.types.push,
-                key: "start_stop",
                 output: delayLED(0x59),
             });
             this.loopButton = new components.LoopToggleButton({

--- a/res/controllers/Arturia-KeyLab-Mk1-scripts.js
+++ b/res/controllers/Arturia-KeyLab-Mk1-scripts.js
@@ -257,7 +257,9 @@ var KeyLabMk1;
         } else if (lines.length >= 2) {
             console.log(`KeyLab display overflow, got ${lines.length} lines want 2`);
         }
-        sendSysex(sysexPayload);
+        engine.beginTimer(engine.getSetting("output_delay"), () => {
+            sendSysex(sysexPayload);
+        }, true);
     };
 
     /*
@@ -463,10 +465,11 @@ var KeyLabMk1;
                 this.blinking = 0;
             }
             if (value === 0) {
-                // TODO: this needs to be a nowrite version.
-                this.output(
-                    this.activeDeck.currentDeck === "[Channel1]" || this.activeDeck.currentDeck === "[Channel3]",
-                );
+                if (typeof this.noWriteOutput === "function") {
+                    this.noWriteOutput(
+                        this.activeDeck.currentDeck === "[Channel1]" || this.activeDeck.currentDeck === "[Channel3]",
+                    );
+                }
                 return;
             }
 
@@ -782,11 +785,13 @@ var KeyLabMk1;
             this.deck1Button = new DeckButton([1, 3], this.activeDeck, {
                 group: "[Channel1]",
                 midi: [0xB0, 0x76, 0x1E], // "Sound"
+                noWriteOutput: this.setDeckOutput(true),
                 output: this.setDeckOutput(),
             });
             this.deck2Button = new DeckButton([2, 4], this.activeDeck, {
                 group: "[Channel2]",
                 midi: [0xB0, 0x77, 0x1F], // "Multi"
+                noWriteOutput: this.setDeckOutput(true),
                 output: this.setDeckOutput(),
             });
 

--- a/res/controllers/Arturia-KeyLab-Mk1-scripts.js
+++ b/res/controllers/Arturia-KeyLab-Mk1-scripts.js
@@ -1,0 +1,759 @@
+"use strict";
+
+// eslint-disable-next-line no-var
+var KeyLabMk1;
+(function(KeyLabMk1) {
+    // https://manual.mixxx.org/2.5/en/chapters/appendix/mixxx_controls#control-[ChannelN]-key
+    const keyNums = [
+        "C",
+        "Db",
+        "D",
+        "Eb",
+        "E",
+        "F",
+        "F#/Gb",
+        "G",
+        "Ab",
+        "A",
+        "Bb",
+        "B",
+        "Cm",
+        "C#m",
+        "Dm",
+        "D#m/Ebm",
+        "Em",
+        "Fm",
+        "F#m",
+        "Gm",
+        "G#m",
+        "Am",
+        "Bbm",
+        "Bm",
+    ];
+
+    // https://manual.mixxx.org/2.5/en/chapters/appendix/mixxx_controls#control-[Library]-sort_column
+    const sortCols = [
+        "Artist",
+        "Title",
+        "Album",
+        "Album Artist",
+        "Year",
+        "Genre",
+        "Composer",
+        "Grouping",
+        "Tracknumber",
+        "Filetype",
+        "Native Location",
+        "Comment",
+        "Duration",
+        "Bitrate",
+        "BPM",
+        "Replay Gain",
+        "Datetime Added",
+        "Times Played",
+        "Rating",
+        "Key",
+        "Preview",
+        "Cover Art",
+        "Position",
+        "Play ID",
+        "Location",
+        "Filename",
+        "Modified Time",
+        "Creation Time",
+        "Sample Rate",
+        "Track Color",
+        "Last Played",
+    ];
+
+    // Menu items that can be controlled with the parameter and value encoders.
+    const menu = [{
+        name: "Key",
+        inKey: "key",
+        max: 24,
+        pressInKey: "reset_key",
+        outputValue: (value) => {
+            return keyNums[(((value - 1) % keyNums.length) + keyNums.length) % keyNums.length];
+        },
+    }, {
+        name: "Beatloop",
+        inKey: "beatloop_size",
+        pressInKey: "beatloop_activate",
+    }, {
+        name: "Beatjump",
+        inKey: "beatjump_size",
+    }, {
+        name: "Library",
+        params: [{
+            name: "Search",
+            relative: true,
+            group: "[Library]",
+            inKey: "search_history_selector",
+            pressInKey: "clear_search",
+        }, {
+            name: "Focus",
+            min: 0,
+            max: 6,
+            group: "[Library]",
+            inKey: "focused_widget",
+        }, {
+            name: "Scroll",
+            relative: true,
+            group: "[Library]",
+            inKey: "MoveVertical",
+            pressInKey: "GoToItem",
+        }, {
+            name: "Sort",
+            min: 1,
+            max: 31,
+            group: "[Library]",
+            inKey: "sort_column_toggle",
+            pressInKey: "sort_order",
+            pressType: components.Button.prototype.types.toggle,
+            outputValue: (value) => {
+                return sortCols[(((value - 1) % sortCols.length) + sortCols.length) % sortCols.length];
+            },
+        }, {
+            name: "Maximize",
+            group: "[Skin]",
+            pressType: components.Button.prototype.types.toggle,
+            pressInKey: "show_maximized_library",
+        }, {
+            name: "Font Size",
+            relative: true,
+            group: "[Library]",
+            inKey: "font_size_knob",
+        }],
+    }, {
+        name: "Skin",
+        params: [{
+            name: "Effect Rack",
+            group: "[Skin]",
+            pressInKey: "show_effectrack",
+            pressType: components.Button.prototype.types.toggle,
+        }, {
+            name: "Coverart",
+            group: "[Skin]",
+            pressInKey: "show_library_coverart",
+            pressType: components.Button.prototype.types.toggle,
+        }, {
+            name: "Samplers",
+            group: "[Skin]",
+            pressInKey: "show_samplers",
+            pressType: components.Button.prototype.types.toggle,
+        }, {
+            name: "Vinyl Control",
+            group: "[Skin]",
+            pressInKey: "show_vinylcontrol",
+            pressType: components.Button.prototype.types.toggle,
+        }],
+    }];
+
+    // Add FX sub-menus to parameters.
+    for (let i = 0; i < 4; i++) {
+        menu.push({
+            name: `FX${i + 1}`,
+            params: [{
+                name: `FX${i + 1} Preset`,
+                group: `[EffectRack1_EffectUnit${i + 1}]`,
+                inKey: "chain_preset_selector",
+                relative: true,
+                pressInKey: "group_[Channel1]_enable",
+                pressType: components.Button.prototype.types.toggle,
+            }, {
+                name: `FX${i + 1} Focus`,
+                group: `[EffectRack1_EffectUnit${i + 1}]`,
+                min: 1,
+                max: engine.getValue(`[EffectRack1_EffectUnit${i + 1}]`, "num_effectslots"),
+                inKey: "focused_effect",
+                pressInKey: "show_focus",
+                pressType: components.Button.prototype.types.toggle,
+            }],
+        });
+    }
+
+    // Sysex messages for toggling various LEDs on the controller.
+    // See https://legacy-forum.arturia.com/index.php?topic=90496.0
+    const SysexHeader = [0xF0, 0x00, 0x20, 0x6B, 0x7F, 0x42];
+    const MMCHeader = [0xF0, 0x7F, 0x7F];
+
+    const sendSysex = function(payload) {
+        const sysexMessage = SysexHeader.concat(payload, [0xF7]);
+        midi.sendSysexMsg(sysexMessage, sysexMessage.length);
+    };
+
+    const setLED = function(num, val) {
+        const on = val ? LedState.on : LedState.off;
+        sendSysex([0x02, 0x00, 0x10, 0x00, 0x00].concat(num, on));
+    };
+
+    const delayLED = function(led) {
+        return (value) => {
+            engine.beginTimer(engine.getSetting("output_delay"), () => {
+                setLED(led, Boolean(value));
+            }, true);
+        };
+    };
+
+    // Write a message to the keylab's display.
+    // To write a message at all you'll need firmware 1.33 or later, so it's not
+    // recommended that these messages be depended upon.
+    const writeDisplay = function(msg) {
+        // flatMap and flat don't appear to exist or we could just map \n to '00
+        // 02'.
+        const lines = msg.split("\n");
+        let sysexPayload = [0x04, 0x00, 0x60, 0x01].concat(lines[0].toInt(), 0x00);
+        if (lines.length === 2) {
+            sysexPayload = sysexPayload.concat(0x02, lines[1].toInt(), 0x00);
+        } else if (lines.length >= 2) {
+            console.log(`KeyLab display overflow, got ${lines.length} lines want 2`);
+        }
+        sendSysex(sysexPayload);
+    };
+
+    // The drum pads by default are laid out in a grid starting from the bottom
+    // left (0x24), then going right and up.
+    // This makes the very first pad (what we're calling pad '0') in the top
+    // left 0x30, so do some math to invert the pads and get us to the correct
+    // values going right and down instead by subtracting 8 times the row the
+    // button is on.
+    const pad = function(n) {
+        return n + 0x30 - (Math.floor(n / 4) * 8);
+    };
+
+    class Deck extends components.Deck {
+        currentDeckNum() {
+            const deckStr = script.channelRegEx.exec(this.currentDeck)[1];
+            return parseInt(deckStr);
+        }
+
+        constructor(deckNumbers, midiChannel) {
+            super(deckNumbers);
+
+            // Transport buttons
+            this.playButton = new components.PlayButton({
+                group: "[Channel1]",
+                midi: [0xB0 + midiChannel, 0x02],
+                type: components.Button.prototype.types.push,
+                output: delayLED(0x58),
+            });
+            this.stopButton = new components.Button({
+                group: "[Channel1]",
+                midi: [0xB0 + midiChannel, 0x01],
+                type: components.Button.prototype.types.push,
+                key: "start_stop",
+                output: delayLED(0x59),
+            });
+            this.loopButton = new components.LoopToggleButton({
+                group: "[Channel1]",
+                midi: [0xB0 + midiChannel, 0x37],
+                inKey: "reloop_toggle",
+                outKey: "loop_enabled",
+                output: delayLED(0x5D),
+            });
+            this.backButton = new components.Button({
+                group: "[Channel1]",
+                midi: [0xB0 + midiChannel, 0x05],
+                key: "beatjump_backward",
+                output: delayLED(0x5B),
+            });
+            this.forwardButton = new components.Button({
+                group: "[Channel1]",
+                midi: [0xB0 + midiChannel, 0x04],
+                key: "beatjump_forward",
+                output: delayLED(0x5C),
+            });
+
+            // Snapshot/parameter edit buttons
+            this.cueButton = new components.CueButton({
+                group: "[Channel1]",
+                midi: [0xB0 + midiChannel, 0x1F], // Snapshot 10
+                type: components.Button.prototype.types.push,
+            });
+            this.hotcues = [];
+            for (let i = 0; i < 8; i++) {
+                this.hotcues[i] = new components.HotcueButton({
+                    number: i + 1,
+                    group: "[Channel1]",
+                    midi: [0xB0 + midiChannel, 0x16 + i], // Snapshot 1-8
+                    type: components.Button.prototype.types.push,
+                    blinkState: false,
+                    blinkTimer: 0,
+                    output: function(value) {
+                        if (value === 2) {
+                            if (this.blinkTimer === 0) {
+                                this.blinkTimer = engine.beginTimer(250, () => {
+                                    this.blinkState = !this.blinkState;
+                                    delayLED(0x12 + i)(this.blinkState ? 1 : 0);
+                                });
+                            }
+                        } else {
+                            if (this.blinkTimer) {
+                                engine.stopTimer(this.blinkTimer);
+                                this.blinkTimer = 0;
+                            }
+                            delayLED(0x12 + i)(value);
+                        }
+                    },
+                });
+            }
+
+            // Parameters
+            const softTakeover = engine.getSetting("soft_takeover");
+            this.pregainPot = new components.Pot({
+                group: "[Channel1]",
+                midi: [0xB0 + midiChannel, 0x4A],
+                key: "pregain",
+                softTakeover: softTakeover,
+            });
+            this.highFilterGainPot = new components.Pot({
+                group: "[EqualizerRack1_[Channel1]_Effect1]",
+                midi: [0xB0 + midiChannel, 0x47],
+                key: "parameter3",
+                softTakeover: softTakeover,
+            });
+            this.midFilterGainPot = new components.Pot({
+                group: "[EqualizerRack1_[Channel1]_Effect1]",
+                midi: [0xB0 + midiChannel, 0x4C],
+                key: "parameter2",
+                softTakeover: softTakeover,
+            });
+            this.lowFilterGainPot = new components.Pot({
+                group: "[EqualizerRack1_[Channel1]_Effect1]",
+                midi: [0xB0 + midiChannel, 0x4D],
+                key: "parameter1",
+                softTakeover: softTakeover,
+            });
+            this.quickEffectPot = new components.Pot({
+                group: "[QuickEffectRack1_[Channel1]]",
+                midi: [0xB0 + midiChannel, 0x5D],
+                key: "super1",
+                softTakeover: softTakeover,
+            });
+
+            // Other encoders
+            this.valueEncoder = new components.Encoder({
+                group: "[Channel1]",
+                midi: [0xB0 + midiChannel, 0x72], // Value encoder
+                input: function(_channel, _control, value, _status, _group) {
+                    if (!this.inKey) {
+                        // If we haven't selected a parameter yet, don't do
+                        // anything.
+                        return;
+                    }
+                    const param = this.inGetParameter();
+                    if (value === 0x3F) {
+                        if (this.relative) {
+                            this.inSetParameter(-1);
+                            return;
+                        }
+                        const newParam = param - 1;
+                        if (
+                            this.min !== undefined && this.max !== undefined
+                            && newParam < this.min
+                        ) {
+                            this.inSetParameter(this.max);
+                        } else {
+                            this.inSetParameter(param - 1);
+                        }
+                    } else if (value === 0x41) {
+                        if (this.relative) {
+                            this.inSetParameter(1);
+                            return;
+                        }
+                        const newParam = param + 1;
+                        if (
+                            this.max !== undefined && this.min !== undefined
+                            && newParam > this.max
+                        ) {
+                            this.inSetParameter(this.min);
+                        } else {
+                            this.inSetParameter(param + 1);
+                        }
+                    }
+                    this.output(this.inGetParameter());
+                },
+                output: function(value) {
+                    if (this.outputValue) {
+                        const newVal = this.outputValue(value);
+                        writeDisplay(`${this.name}: ${newVal}`);
+                    }
+                },
+            });
+
+            this.valueButton = new components.Button({
+                group: "[Channel1]",
+                midi: [0xB0, 0x73], // Value encoder push
+                encoder: this.valueEncoder,
+                activeDeck: this,
+                inGetValue: function() {
+                    if (!this.inKey) {
+                        return 0;
+                    }
+                    return engine.getValue(this.group, this.inKey.replace("[Channel1]", this.activeDeck.currentDeck));
+                },
+                inSetValue: function(value) {
+                    if (!this.inKey) {
+                        return;
+                    }
+                    engine.setValue(this.group, this.inKey.replace("[Channel1]", this.activeDeck.currentDeck), value);
+                    this.output(this.encoder.inGetParameter());
+                },
+                output: function(value) {
+                    if (this.outputValue) {
+                        const newVal = this.outputValue(value);
+                        writeDisplay(`${this.name}: ${newVal}`);
+                    }
+                },
+            });
+        }
+    }
+
+    // DeckButton is a power window button that toggles between two decks and
+    // blinks if a track is ending on either of them.
+    class DeckButton extends components.Button {
+        constructor(decks, activeDeck, options) {
+            options.type = components.Button.prototype.types.powerWindow;
+            options.outKey = "end_of_track";
+            options.decks = decks;
+            options.activeDeck = activeDeck;
+            super(options);
+
+            this.blinking = 0;
+        }
+
+        inToggle() {
+            if (this.isLongPressed) {
+                this.activeDeck.setCurrentDeck(`[Channel${this.decks[1]}]`);
+            } else {
+                this.activeDeck.setCurrentDeck(`[Channel${this.decks[0]}]`);
+            }
+            this.output(0x1F);
+        }
+
+        blink(value, group, _control) {
+            if (this.blinking) {
+                engine.stopTimer(this.blinking);
+                this.blinking = 0;
+            }
+            if (value === 0) {
+                // TODO: this needs to be a nowrite version.
+                this.output(
+                    this.activeDeck.currentDeck === "[Channel1]" || this.activeDeck.currentDeck === "[Channel3]",
+                );
+                return;
+            }
+
+            let blink_state = false;
+            let velocity = 500;
+            if (this.group === group) {
+                velocity = 250;
+            }
+            this.blinking = engine.beginTimer(velocity, () => {
+                blink_state = !blink_state;
+                setLED(this.midi[2], blink_state);
+            });
+        }
+
+        connect() {
+            this.connections[0] = engine.makeConnection(
+                `[Channel${this.decks[0]}]`,
+                this.outKey,
+                this.blink.bind(this),
+            );
+            this.connections[1] = engine.makeConnection(
+                `[Channel${this.decks[1]}]`,
+                this.outKey,
+                this.blink.bind(this),
+            );
+        }
+    }
+
+    class Controller extends components.ComponentContainer {
+        setDeckOutput(noWrite = false) {
+            return (value) => {
+                setLED(0x1E, Boolean(value));
+                setLED(0x1F, !value);
+                if (!noWrite) {
+                    const currentDeckNum = this.activeDeck.currentDeckNum();
+                    writeDisplay(`Deck ${currentDeckNum}`);
+                }
+            };
+        }
+        constructor(id) {
+            super({});
+
+            this.id = id;
+            this.activeDeck = new Deck([1, 2, 3, 4], 1);
+            this.deck1Button = new DeckButton([1, 3], this.activeDeck, {
+                group: "[Channel1]",
+                midi: [0xB0, 0x76, 0x1E], // "Sound"
+                output: this.setDeckOutput(),
+            });
+            this.deck2Button = new DeckButton([2, 4], this.activeDeck, {
+                group: "[Channel2]",
+                midi: [0xB0, 0x77, 0x1F], // "Multi"
+                output: this.setDeckOutput(),
+            });
+
+            // Deck parameter selector.
+            this.paramEncoder = new components.Encoder({
+                group: "[Channel1]",
+                midi: [0xB0, 0x70], // Param encoder
+                selectedParam: 0,
+                params: [...menu],
+                activeDeck: this.activeDeck,
+                input: function(_channel, _control, value, _status, _group) {
+                    if (value === 0x3F) {
+                        this.selectedParam = (((this.selectedParam - 1) % this.params.length) + this.params.length)
+                            % this.params.length;
+                    } else if (value === 0x41) {
+                        this.selectedParam = (((this.selectedParam + 1) % this.params.length) + this.params.length)
+                            % this.params.length;
+                    }
+                    const param = this.params[this.selectedParam];
+                    if (param.group) {
+                        this.activeDeck.valueEncoder.group = param.group;
+                        this.activeDeck.valueButton.group = param.group;
+                    } else {
+                        this.activeDeck.valueEncoder.group = this.activeDeck.currentDeck;
+                        this.activeDeck.valueButton.group = this.activeDeck.currentDeck;
+                    }
+                    this.activeDeck.valueEncoder.name = param.name;
+                    this.activeDeck.valueButton.name = param.name;
+                    this.activeDeck.valueEncoder.inKey = param.inKey;
+                    this.activeDeck.valueEncoder.max = param.max;
+                    this.activeDeck.valueEncoder.min = param.min;
+                    this.activeDeck.valueEncoder.relative = param.relative || false;
+                    this.activeDeck.valueButton.inKey = param.pressInKey;
+                    this.activeDeck.valueButton.type = param.pressType || components.Button.prototype.types.push;
+                    this.activeDeck.valueEncoder.outputValue = param.outputValue;
+                    this.activeDeck.valueButton.outputValue = param.outputValue;
+
+                    writeDisplay(`${param.name}`);
+                },
+            });
+            this.paramButton = new components.Button({
+                group: "[Channel1]",
+                midi: [0xB0, 0x71], // Param encoder button
+                encoder: this.paramEncoder,
+                prevSelected: 0,
+                prevParams: [],
+                input: function(channel, control, value, status, group) {
+                    if (value) {
+                        return;
+                    }
+                    const param = this.encoder.params[this.encoder.selectedParam];
+                    if (param.params) {
+                        // We're entering a submenu so set the new menu to the submenu
+                        // and set old menu to that submenus back menu.
+                        this.prevParams = this.encoder.params;
+                        this.prevSelected = this.encoder.selectedParam;
+                        this.encoder.params = [...param.params];
+                        // Always add a back button to the end of sub-menus.
+                        this.encoder.params.push({name: "Back"});
+                        if (param.selectedParam === undefined) {
+                            param.selectedParam = 0;
+                        }
+                        this.encoder.selectedParam = param.selectedParam;
+                        this.encoder.input(channel, control, 0, status, group);
+                    } else if (param.name === "Back") {
+                        // We hit the back button, go up a level.
+                        this.encoder.params = this.prevParams;
+                        this.encoder.selectedParam = this.prevSelected;
+                        this.encoder.input(channel, control, 0, status, group);
+                    }
+                },
+            });
+            this.recordButton = new components.Button({
+                group: "[Recording]",
+                midi: [0xB0, 0x06],
+                inKey: "toggle_recording",
+                outKey: "status",
+                output: delayLED(0x5A),
+            });
+            const softTakeover = engine.getSetting("soft_takeover");
+            // Faders
+            this.faders = new Array(9);
+            this.faders[0] = new components.Pot({
+                group: "[Channel3]",
+                midi: [0xB0, 0x49],
+                key: "volume",
+                softTakeover: softTakeover,
+            });
+            this.faders[1] = new components.Pot({
+                group: "[Channel1]",
+                midi: [0xB0, 0x4B],
+                key: "volume",
+                softTakeover: softTakeover,
+            });
+            this.faders[2] = new components.Pot({
+                group: "[Channel2]",
+                midi: [0xB0, 0x4F],
+                key: "volume",
+                softTakeover: softTakeover,
+            });
+            this.faders[3] = new components.Pot({
+                group: "[Channel4]",
+                midi: [0xB0, 0x48],
+                key: "volume",
+                softTakeover: softTakeover,
+            });
+            this.faders[4] = new components.Pot({
+                group: "[Channel3]",
+                midi: [0xB0, 0x50],
+                key: "rate",
+                softTakeover: softTakeover,
+            });
+            this.faders[5] = new components.Pot({
+                group: "[Channel1]",
+                midi: [0xB0, 0x51],
+                key: "rate",
+                softTakeover: softTakeover,
+            });
+            this.faders[6] = new components.Pot({
+                group: "[Channel2]",
+                midi: [0xB0, 0x52],
+                key: "rate",
+                softTakeover: softTakeover,
+            });
+            this.faders[7] = new components.Pot({
+                group: "[Channel4]",
+                midi: [0xB0, 0x53],
+                key: "rate",
+                softTakeover: softTakeover,
+            });
+            this.faders[8] = new components.Pot({
+                group: "[Master]",
+                midi: [0xB0, 0x55],
+                key: "crossfader",
+                softTakeover: softTakeover,
+            });
+            // Pots
+            this.mainGain = new components.Pot({
+                group: "[Master]",
+                midi: [0xB0, 0x07],
+                key: "gain",
+                softTakeover: softTakeover,
+            });
+            this.headGain = new components.Pot({
+                group: "[Master]",
+                midi: [0xB0, 0x00],
+                key: "headGain",
+                softTakeover: softTakeover,
+            });
+            // Drum pads
+            this.samplers = [];
+            for (let i = 0; i < 16; i++) {
+                this.samplers[i] = new components.SamplerButton({
+                    number: i + 1,
+                    midi: [0x99, pad(i)], // Drum pads.
+                    volumeByVelocity: true,
+                    // These numbers are made up magic constants that can be
+                    // checked in the "send" callback defined below.
+                    playing: 0x72,
+                    empty: 0x00,
+                    loaded: 0x01,
+                    blinking: 0,
+                    blink_state: false,
+
+                    send: function(value) {
+                        switch (value) {
+                        case this.empty: {
+                            if (this.blinking) {
+                                engine.stopTimer(this.blinking);
+                                this.blinking = 0;
+                            }
+                            delayLED(this.midi[1] + 0x4c)(LedState.off);
+                            break;
+                        }
+                        case this.loaded: {
+                            if (this.blinking) {
+                                engine.stopTimer(this.blinking);
+                                this.blinking = 0;
+                            }
+                            delayLED(this.midi[1] + 0x4c)(LedState.on);
+                            break;
+                        }
+                        case this.playing: {
+                            // Start the sampler blinking every 500ms if it's
+                            // playing.
+                            // If for some reason it's already blinking, do
+                            // nothing so we don't end up with multiple blink
+                            // timers, one of which we forget to stop.
+                            if (this.blinking === 0) {
+                                this.blinking = engine.beginTimer(250, () => {
+                                    this.blink_state = !this.blink_state;
+                                    setLED(this.midi[1] + 0x4c, this.blink_state);
+                                });
+                            }
+                            break;
+                        }
+                        }
+                    },
+                });
+
+                this.padsDisabled = engine.getSetting("pads_disabled");
+                if (this.padsDisabled) {
+                    delayLED(this.samplers[i].midi[1] + 0x4c)(LedState.off);
+                    this.samplers[i].input = () => {};
+                }
+            }
+        }
+    }
+
+    KeyLabMk1.init = function(id, _debugging) {
+        KeyLabMk1.controller = new Controller(id);
+        writeDisplay("Welcome to Mixxx");
+    };
+
+    KeyLabMk1.shutdown = function() {
+        KeyLabMk1.controller.shutdown();
+        writeDisplay("Goodbye!");
+    };
+
+    KeyLabMk1.incomingData = function(data, length) {
+        if (length < 6) {
+            console.log(`expected sysex packet of length 6, got ${length}`);
+            return;
+        }
+        for (let n = 0; n < MMCHeader.length; n++) {
+            if (data[n] !== MMCHeader[n]) {
+                console.log("unknown sysex packet");
+                return;
+            }
+        }
+        // We only handle MMC commands at the moment: ignore responses, device
+        // control, MIDI show control, etc.
+        if (data[3] !== 0x06) {
+            console.log(`unexpected MMC Sub-ID#1: ${data[3]}`);
+            return;
+        }
+        if (data[length - 1] !== 0xF7) {
+            console.log("sysex packet missing trailer");
+            return;
+        }
+        switch (data[4]) {
+        case 0x01: // stop
+            KeyLabMk1.controller.activeDeck.stopButton.inSetValue(0x7f);
+            break;
+        case 0x02: // play
+            KeyLabMk1.controller.activeDeck.playButton.inToggle();
+            break;
+        case 0x04: // fast forward
+            KeyLabMk1.controller.activeDeck.forwardButton.inSetValue(0x7f);
+            break;
+        case 0x05: // rewind
+            KeyLabMk1.controller.activeDeck.backButton.inSetValue(0x7f);
+            break;
+        case 0x06: // record
+            KeyLabMk1.controller.recordButton.inSetValue(0x7f);
+            break;
+        case 0x37: // loop (I believe this one is non-standard)
+            KeyLabMk1.controller.activeDeck.loopButton.inToggle();
+            break;
+        default:
+            console.log(`unrecognized MMC command: ${data[4]}`);
+        }
+    };
+})(KeyLabMk1 || (KeyLabMk1 = {}));

--- a/res/controllers/ArturiaKeyLab.midi.xml
+++ b/res/controllers/ArturiaKeyLab.midi.xml
@@ -1,0 +1,610 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MixxxControllerPreset mixxxVersion="" schemaVersion="1">
+  <info>
+    <name>Arturia KeyLab Mk 1</name>
+    <author>Sam Whited</author>
+    <description>MIDI mapping for the original Arturia KeyLab Mk 1</description>
+    <forums>https://mixxx.discourse.group/t/arturia-keylab-mk1/31080</forums>
+  </info>
+  <settings>
+    <group label="Pots">
+      <option variable="soft_takeover" type="boolean" default="true"
+              label="Soft Takover">
+        <description>
+          Enables soft takeover on all encoders and faders.
+        </description>
+      </option>
+    </group>
+    <group label="System">
+      <option variable="pads_disabled" type="boolean" default="false" label="Disable Pads">
+        <description>
+          Disables using the drum pads to load and play back samples.
+          Enable this if you want to use the drum pads with an external synth.
+        </description>
+      </option>
+      <option variable="output_delay" type="integer" min="0" default="100" label="Output Delay (ms)">
+        <description>
+          The delay in milliseconds before setting output LEDs or the screen.
+          This is needed because the keyboard sets its own LEDs for some buttons
+          and occasionally decides to show something on the screen in response
+          to a button press that may overwrite whatever we were trying to write.
+          If you notice the screen or buttons briefly flashing to the expected
+          value, then changing, increase this number.
+        </description>
+      </option>
+    </group>
+  </settings>
+  <controller id="ArturiaKeyLabMk1">
+    <scriptfiles>
+      <file filename="midi-components-0.0.js"/>
+      <file filename="Arturia-KeyLab-Mk1-scripts.js" functionprefix="KeyLabMk1"/>
+    </scriptfiles>
+    <controls>
+      <control>
+        <group>[Master]</group>
+        <key>KeyLabMk1.incomingData</key>
+        <description>Parser for incoming MMC messages.</description>
+        <status>0xF0</status>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Master]</group>
+        <key>KeyLabMk1.controller.mainGain.input</key>
+        <description>Volume encoder on bank 1 controls main gain.</description>
+        <status>0xB0</status>
+        <midino>0x07</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Master]</group>
+        <key>KeyLabMk1.controller.headGain.input</key>
+        <description>Volume encoder on bank 2 controls headphone gain.</description>
+        <status>0xB0</status>
+        <midino>0x00</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+
+      <!-- Transport buttons -->
+      <control>
+        <group>[Channel1]</group>
+        <key>KeyLabMk1.controller.activeDeck.stopButton.input</key>
+        <description>Stop active deck and seek to start.</description>
+        <status>0xB0</status>
+        <midino>0x01</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>KeyLabMk1.controller.activeDeck.playButton.input</key>
+        <description>Play/pause active deck.</description>
+        <status>0xB0</status>
+        <midino>0x02</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>KeyLabMk1.controller.activeDeck.forwardButton.input</key>
+        <description>Jump forward on the active deck.</description>
+        <status>0xB0</status>
+        <midino>0x04</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>KeyLabMk1.controller.activeDeck.backButton.input</key>
+        <description>Jump back on the active deck.</description>
+        <status>0xB0</status>
+        <midino>0x05</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Recording]</group>
+        <key>KeyLabMk1.controller.recordButton.input</key>
+        <description>Start/stop recording.</description>
+        <status>0xB0</status>
+        <midino>0x06</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>KeyLabMk1.controller.activeDeck.loopButton.input</key>
+        <status>0xB0</status>
+        <midino>0x37</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+
+      <!-- Snapshot / edit parameter buttons -->
+      <control>
+        <group>[Channel1]</group>
+        <key>KeyLabMk1.controller.activeDeck.hotcues[0].input</key>
+        <description>Set or jump to a hotcue.</description>
+        <status>0xB0</status>
+        <midino>0x16</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>KeyLabMk1.controller.activeDeck.hotcues[1].input</key>
+        <description>Set or jump to a hotcue.</description>
+        <status>0xB0</status>
+        <midino>0x17</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>KeyLabMk1.controller.activeDeck.hotcues[2].input</key>
+        <description>Set or jump to a hotcue.</description>
+        <status>0xB0</status>
+        <midino>0x18</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>KeyLabMk1.controller.activeDeck.hotcues[3].input</key>
+        <description>Set or jump to a hotcue.</description>
+        <status>0xB0</status>
+        <midino>0x19</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>KeyLabMk1.controller.activeDeck.hotcues[4].input</key>
+        <description>Set or jump to a hotcue.</description>
+        <status>0xB0</status>
+        <midino>0x1A</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>KeyLabMk1.controller.activeDeck.hotcues[5].input</key>
+        <description>Set or jump to a hotcue.</description>
+        <status>0xB0</status>
+        <midino>0x1B</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>KeyLabMk1.controller.activeDeck.hotcues[6].input</key>
+        <description>Set or jump to a hotcue.</description>
+        <status>0xB0</status>
+        <midino>0x1C</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>KeyLabMk1.controller.activeDeck.hotcues[7].input</key>
+        <description>Set or jump to a hotcue.</description>
+        <status>0xB0</status>
+        <midino>0x1D</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+
+      <control>
+        <group>[Channel1]</group>
+        <key>KeyLabMk1.controller.activeDeck.cueButton.input</key>
+        <description>Set or jump to the cue point.</description>
+        <status>0xB0</status>
+        <midino>0x1F</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+
+      <!-- Parameters -->
+      <control>
+        <group>[Channel1]</group>
+        <key>KeyLabMk1.controller.activeDeck.pregainPot.input</key>
+        <description>Sets the pregain on the active deck.</description>
+        <status>0xB0</status>
+        <midino>0x4A</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[EqualizerRack1_[Channel1]_Effect1]</group>
+        <key>KeyLabMk1.controller.activeDeck.highFilterGainPot.input</key>
+        <description>Sets the high filter gain on the active deck.</description>
+        <status>0xB0</status>
+        <midino>0x47</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[EqualizerRack1_[Channel1]_Effect1]</group>
+        <key>KeyLabMk1.controller.activeDeck.midFilterGainPot.input</key>
+        <description>Sets the mid filter gain on the active deck.</description>
+        <status>0xB0</status>
+        <midino>0x4C</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[EqualizerRack1_[Channel1]_Effect1]</group>
+        <key>KeyLabMk1.controller.activeDeck.lowFilterGainPot.input</key>
+        <description>Sets the low filter gain on the active deck.</description>
+        <status>0xB0</status>
+        <midino>0x4D</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[QuickEffectRack1_[Channel1]]</group>
+        <key>KeyLabMk1.controller.activeDeck.quickEffectPot.input</key>
+        <description>Adjusts the quick effect super knob on the active deck.</description>
+        <status>0xB0</status>
+        <midino>0x5D</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+
+      <!-- Other encoders -->
+      <control>
+        <group>[Channel1]</group>
+        <key>KeyLabMk1.controller.paramEncoder.input</key>
+        <description>Select a parameter to adjust with the value encoder.</description>
+        <status>0xB0</status>
+        <midino>0x70</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>KeyLabMk1.controller.paramButton.input</key>
+        <description>Enter a submenu on the parameter menu.</description>
+        <status>0xB0</status>
+        <midino>0x71</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>KeyLabMk1.controller.activeDeck.valueEncoder.input</key>
+        <description>Perform operation selected in the menu.</description>
+        <status>0xB0</status>
+        <midino>0x72</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>KeyLabMk1.controller.activeDeck.valueButton.input</key>
+        <description>Perform operation selected in the menu.</description>
+        <status>0xB0</status>
+        <midino>0x73</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+
+      <!-- Deck selection for transport buttons -->
+      <control>
+        <group>[Channel1]</group>
+        <key>KeyLabMk1.controller.deck1Button.input</key>
+        <description>Select Deck 1.</description>
+        <status>0xB0</status>
+        <midino>0x76</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>KeyLabMk1.controller.deck2Button.input</key>
+        <description>Select Deck 2.</description>
+        <status>0xB0</status>
+        <midino>0x77</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+
+      <!-- Volume Faders -->
+      <control>
+        <group>[Channel1]</group>
+        <key>KeyLabMk1.controller.faders[1].input</key>
+        <description>F2 controls the first deck.</description>
+        <status>0xB0</status>
+        <midino>0x4B</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>KeyLabMk1.controller.faders[2].input</key>
+        <description>F3 controls the second deck.</description>
+        <status>0xB0</status>
+        <midino>0x4F</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>KeyLabMk1.controller.faders[0].input</key>
+        <description>F1 controls the third deck.</description>
+        <status>0xB0</status>
+        <midino>0x49</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>KeyLabMk1.controller.faders[3].input</key>
+        <description>F4 controls the fourth deck.</description>
+        <status>0xB0</status>
+        <midino>0x48</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+
+      <!-- Beat Sync Faders -->
+      <control>
+        <group>[Channel1]</group>
+        <key>KeyLabMk1.controller.faders[5].input</key>
+        <description>F2 controls the first deck.</description>
+        <status>0xB0</status>
+        <midino>0x51</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>KeyLabMk1.controller.faders[6].input</key>
+        <description>F3 controls the second deck.</description>
+        <status>0xB0</status>
+        <midino>0x52</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>KeyLabMk1.controller.faders[4].input</key>
+        <description>F1 controls the third deck.</description>
+        <status>0xB0</status>
+        <midino>0x50</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>KeyLabMk1.controller.faders[7].input</key>
+        <description>F4 controls the fourth deck.</description>
+        <status>0xB0</status>
+        <midino>0x53</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+
+      <!-- Crossfader -->
+      <control>
+        <group>[Master]</group>
+        <key>KeyLabMk1.controller.faders[8].input</key>
+        <description>F9 controls the crossfade.</description>
+        <status>0xB0</status>
+        <midino>0x55</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+
+      <!-- Samplers -->
+      <!-- Pads row 1 -->
+      <control>
+        <group>[Sampler1]</group>
+        <key>KeyLabMk1.controller.samplers[0].input</key>
+        <description>Load or play from a sampler with velocity sensitive volume.</description>
+        <status>0x99</status>
+        <midino>0x30</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler2]</group>
+        <key>KeyLabMk1.controller.samplers[1].input</key>
+        <description>Load or play from a sampler with velocity sensitive volume.</description>
+        <status>0x99</status>
+        <midino>0x31</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler3]</group>
+        <key>KeyLabMk1.controller.samplers[2].input</key>
+        <description>Load or play from a sampler with velocity sensitive volume.</description>
+        <status>0x99</status>
+        <midino>0x32</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler4]</group>
+        <key>KeyLabMk1.controller.samplers[3].input</key>
+        <description>Load or play from a sampler with velocity sensitive volume.</description>
+        <status>0x99</status>
+        <midino>0x33</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+
+      <!-- Pads row 2 -->
+      <control>
+        <group>[Sampler5]</group>
+        <key>KeyLabMk1.controller.samplers[4].input</key>
+        <description>Load or play from a sampler with velocity sensitive volume.</description>
+        <status>0x99</status>
+        <midino>0x2c</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler6]</group>
+        <key>KeyLabMk1.controller.samplers[5].input</key>
+        <description>Load or play from a sampler with velocity sensitive volume.</description>
+        <status>0x99</status>
+        <midino>0x2d</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler7]</group>
+        <key>KeyLabMk1.controller.samplers[6].input</key>
+        <description>Load or play from a sampler with velocity sensitive volume.</description>
+        <status>0x99</status>
+        <midino>0x2e</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler8]</group>
+        <key>KeyLabMk1.controller.samplers[7].input</key>
+        <description>Load or play from a sampler with velocity sensitive volume.</description>
+        <status>0x99</status>
+        <midino>0x2f</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+
+      <!-- Pads row 3 -->
+      <control>
+        <group>[Sampler9]</group>
+        <key>KeyLabMk1.controller.samplers[8].input</key>
+        <description>Load or play from a sampler with velocity sensitive volume.</description>
+        <status>0x99</status>
+        <midino>0x28</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler10]</group>
+        <key>KeyLabMk1.controller.samplers[9].input</key>
+        <description>Load or play from a sampler with velocity sensitive volume.</description>
+        <status>0x99</status>
+        <midino>0x29</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler11]</group>
+        <key>KeyLabMk1.controller.samplers[10].input</key>
+        <description>Load or play from a sampler with velocity sensitive volume.</description>
+        <status>0x99</status>
+        <midino>0x2a</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler12]</group>
+        <key>KeyLabMk1.controller.samplers[11].input</key>
+        <description>Load or play from a sampler with velocity sensitive volume.</description>
+        <status>0x99</status>
+        <midino>0x2b</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+
+      <!-- Pads row 4 -->
+      <control>
+        <group>[Sampler13]</group>
+        <key>KeyLabMk1.controller.samplers[12].input</key>
+        <description>Load or play from a sampler with velocity sensitive volume.</description>
+        <status>0x99</status>
+        <midino>0x24</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler14]</group>
+        <key>KeyLabMk1.controller.samplers[13].input</key>
+        <description>Load or play from a sampler with velocity sensitive volume.</description>
+        <status>0x99</status>
+        <midino>0x25</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler15]</group>
+        <key>KeyLabMk1.controller.samplers[14].input</key>
+        <description>Load or play from a sampler with velocity sensitive volume.</description>
+        <status>0x99</status>
+        <midino>0x26</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler16]</group>
+        <key>KeyLabMk1.controller.samplers[15].input</key>
+        <description>Load or play from a sampler with velocity sensitive volume.</description>
+        <status>0x99</status>
+        <midino>0x27</midino>
+        <options>
+          <Script-Binding/>
+        </options>
+      </control>
+    </controls>
+    <outputs/>
+  </controller>
+</MixxxControllerPreset>

--- a/res/controllers/ArturiaKeyLab.midi.xml
+++ b/res/controllers/ArturiaKeyLab.midi.xml
@@ -148,8 +148,8 @@
       <!-- Snapshot / edit parameter buttons -->
       <control>
         <group>[Channel1]</group>
-        <key>KeyLabMk1.controller.activeDeck.snapshots[0].input</key>
-        <description>Set or jump to a hotcue.</description>
+        <key>KeyLabMk1.controller.activeDeck.padGrid.radioGroup[0].input</key>
+        <description>Select the default pad mode (intro/outro + hotcues).</description>
         <status>0xB0</status>
         <midino>0x16</midino>
         <options>
@@ -158,8 +158,8 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>KeyLabMk1.controller.activeDeck.snapshots[1].input</key>
-        <description>Set or jump to a hotcue.</description>
+        <key>KeyLabMk1.controller.activeDeck.padGrid.radioGroup[1].input</key>
+        <description>Set drum pads to be hotcues.</description>
         <status>0xB0</status>
         <midino>0x17</midino>
         <options>
@@ -168,71 +168,10 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>KeyLabMk1.controller.activeDeck.snapshots[2].input</key>
-        <description>Set or jump to a hotcue.</description>
+        <key>KeyLabMk1.controller.activeDeck.padGrid.radioGroup[2].input</key>
+        <description>Set drum pads to be samplers.</description>
         <status>0xB0</status>
         <midino>0x18</midino>
-        <options>
-          <Script-Binding/>
-        </options>
-      </control>
-      <control>
-        <group>[Channel1]</group>
-        <key>KeyLabMk1.controller.activeDeck.snapshots[3].input</key>
-        <description>Set or jump to a hotcue.</description>
-        <status>0xB0</status>
-        <midino>0x19</midino>
-        <options>
-          <Script-Binding/>
-        </options>
-      </control>
-      <control>
-        <group>[Channel1]</group>
-        <key>KeyLabMk1.controller.activeDeck.snapshots[4].input</key>
-        <description>Set or jump to a hotcue.</description>
-        <status>0xB0</status>
-        <midino>0x1A</midino>
-        <options>
-          <Script-Binding/>
-        </options>
-      </control>
-      <control>
-        <group>[Channel1]</group>
-        <key>KeyLabMk1.controller.activeDeck.snapshots[5].input</key>
-        <description>Set or jump to a hotcue.</description>
-        <status>0xB0</status>
-        <midino>0x1B</midino>
-        <options>
-          <Script-Binding/>
-        </options>
-      </control>
-      <control>
-        <group>[Channel1]</group>
-        <key>KeyLabMk1.controller.activeDeck.snapshots[6].input</key>
-        <description>Set or jump to a hotcue.</description>
-        <status>0xB0</status>
-        <midino>0x1C</midino>
-        <options>
-          <Script-Binding/>
-        </options>
-      </control>
-      <control>
-        <group>[Channel1]</group>
-        <key>KeyLabMk1.controller.activeDeck.snapshots[7].input</key>
-        <description>Set or jump to a hotcue.</description>
-        <status>0xB0</status>
-        <midino>0x1D</midino>
-        <options>
-          <Script-Binding/>
-        </options>
-      </control>
-
-      <control>
-        <group>[Channel1]</group>
-        <key>KeyLabMk1.controller.activeDeck.cueButton.input</key>
-        <description>Set or jump to the cue point.</description>
-        <status>0xB0</status>
-        <midino>0x1F</midino>
         <options>
           <Script-Binding/>
         </options>

--- a/res/controllers/ArturiaKeyLab.midi.xml
+++ b/res/controllers/ArturiaKeyLab.midi.xml
@@ -20,12 +20,6 @@
       </option>
     </group>
     <group label="System">
-      <option variable="pads_disabled" type="boolean" default="false" label="Disable Pads">
-        <description>
-          Disables using the drum pads to load and play back samples.
-          Enable this if you want to use the drum pads with an external synth.
-        </description>
-      </option>
       <option variable="output_delay" type="integer" min="0" default="100" label="Output Delay (ms)">
         <description>
           The delay in milliseconds before setting output LEDs or the screen.
@@ -34,6 +28,22 @@
           to a button press that may overwrite whatever we were trying to write.
           If you notice the screen or buttons briefly flashing to the expected
           value, then changing, increase this number.
+        </description>
+      </option>
+    </group>
+    <group label="Drum Pads">
+      <option variable="pads_disabled" type="boolean" default="false" label="Disable Pads">
+        <description>
+          Disables using the drum pads to load and play back samples.
+          Enable this if you want to use the drum pads with an external synth.
+        </description>
+      </option>
+      <option variable="defaultPadLayout" type="enum" label="Default Pad Layout">
+        <value label="Intro/Outro + 12 hotcues" default="true">default</value>
+        <value label="Hotcues">hotcue</value>
+        <value label="Sampler">sampler</value>
+        <description>
+          Define the default layout used for the pads.
         </description>
       </option>
     </group>
@@ -138,7 +148,7 @@
       <!-- Snapshot / edit parameter buttons -->
       <control>
         <group>[Channel1]</group>
-        <key>KeyLabMk1.controller.activeDeck.hotcues[0].input</key>
+        <key>KeyLabMk1.controller.activeDeck.snapshots[0].input</key>
         <description>Set or jump to a hotcue.</description>
         <status>0xB0</status>
         <midino>0x16</midino>
@@ -148,7 +158,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>KeyLabMk1.controller.activeDeck.hotcues[1].input</key>
+        <key>KeyLabMk1.controller.activeDeck.snapshots[1].input</key>
         <description>Set or jump to a hotcue.</description>
         <status>0xB0</status>
         <midino>0x17</midino>
@@ -158,7 +168,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>KeyLabMk1.controller.activeDeck.hotcues[2].input</key>
+        <key>KeyLabMk1.controller.activeDeck.snapshots[2].input</key>
         <description>Set or jump to a hotcue.</description>
         <status>0xB0</status>
         <midino>0x18</midino>
@@ -168,7 +178,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>KeyLabMk1.controller.activeDeck.hotcues[3].input</key>
+        <key>KeyLabMk1.controller.activeDeck.snapshots[3].input</key>
         <description>Set or jump to a hotcue.</description>
         <status>0xB0</status>
         <midino>0x19</midino>
@@ -178,7 +188,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>KeyLabMk1.controller.activeDeck.hotcues[4].input</key>
+        <key>KeyLabMk1.controller.activeDeck.snapshots[4].input</key>
         <description>Set or jump to a hotcue.</description>
         <status>0xB0</status>
         <midino>0x1A</midino>
@@ -188,7 +198,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>KeyLabMk1.controller.activeDeck.hotcues[5].input</key>
+        <key>KeyLabMk1.controller.activeDeck.snapshots[5].input</key>
         <description>Set or jump to a hotcue.</description>
         <status>0xB0</status>
         <midino>0x1B</midino>
@@ -198,7 +208,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>KeyLabMk1.controller.activeDeck.hotcues[6].input</key>
+        <key>KeyLabMk1.controller.activeDeck.snapshots[6].input</key>
         <description>Set or jump to a hotcue.</description>
         <status>0xB0</status>
         <midino>0x1C</midino>
@@ -208,7 +218,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>KeyLabMk1.controller.activeDeck.hotcues[7].input</key>
+        <key>KeyLabMk1.controller.activeDeck.snapshots[7].input</key>
         <description>Set or jump to a hotcue.</description>
         <status>0xB0</status>
         <midino>0x1D</midino>
@@ -440,12 +450,10 @@
         </options>
       </control>
 
-      <!-- Samplers -->
       <!-- Pads row 1 -->
       <control>
-        <group>[Sampler1]</group>
-        <key>KeyLabMk1.controller.samplers[0].input</key>
-        <description>Load or play from a sampler with velocity sensitive volume.</description>
+        <key>KeyLabMk1.controller.activeDeck.padGrid.input</key>
+        <description>Configurable samplers or hotcues.</description>
         <status>0x99</status>
         <midino>0x30</midino>
         <options>
@@ -453,9 +461,8 @@
         </options>
       </control>
       <control>
-        <group>[Sampler2]</group>
-        <key>KeyLabMk1.controller.samplers[1].input</key>
-        <description>Load or play from a sampler with velocity sensitive volume.</description>
+        <key>KeyLabMk1.controller.activeDeck.padGrid.input</key>
+        <description>Configurable samplers or hotcues.</description>
         <status>0x99</status>
         <midino>0x31</midino>
         <options>
@@ -463,9 +470,8 @@
         </options>
       </control>
       <control>
-        <group>[Sampler3]</group>
-        <key>KeyLabMk1.controller.samplers[2].input</key>
-        <description>Load or play from a sampler with velocity sensitive volume.</description>
+        <key>KeyLabMk1.controller.activeDeck.padGrid.input</key>
+        <description>Configurable samplers or hotcues.</description>
         <status>0x99</status>
         <midino>0x32</midino>
         <options>
@@ -473,9 +479,8 @@
         </options>
       </control>
       <control>
-        <group>[Sampler4]</group>
-        <key>KeyLabMk1.controller.samplers[3].input</key>
-        <description>Load or play from a sampler with velocity sensitive volume.</description>
+        <key>KeyLabMk1.controller.activeDeck.padGrid.input</key>
+        <description>Configurable samplers or hotcues.</description>
         <status>0x99</status>
         <midino>0x33</midino>
         <options>
@@ -485,9 +490,8 @@
 
       <!-- Pads row 2 -->
       <control>
-        <group>[Sampler5]</group>
-        <key>KeyLabMk1.controller.samplers[4].input</key>
-        <description>Load or play from a sampler with velocity sensitive volume.</description>
+        <key>KeyLabMk1.controller.activeDeck.padGrid.input</key>
+        <description>Configurable samplers or hotcues.</description>
         <status>0x99</status>
         <midino>0x2c</midino>
         <options>
@@ -495,9 +499,8 @@
         </options>
       </control>
       <control>
-        <group>[Sampler6]</group>
-        <key>KeyLabMk1.controller.samplers[5].input</key>
-        <description>Load or play from a sampler with velocity sensitive volume.</description>
+        <key>KeyLabMk1.controller.activeDeck.padGrid.input</key>
+        <description>Configurable samplers or hotcues.</description>
         <status>0x99</status>
         <midino>0x2d</midino>
         <options>
@@ -505,9 +508,8 @@
         </options>
       </control>
       <control>
-        <group>[Sampler7]</group>
-        <key>KeyLabMk1.controller.samplers[6].input</key>
-        <description>Load or play from a sampler with velocity sensitive volume.</description>
+        <key>KeyLabMk1.controller.activeDeck.padGrid.input</key>
+        <description>Configurable samplers or hotcues.</description>
         <status>0x99</status>
         <midino>0x2e</midino>
         <options>
@@ -515,9 +517,8 @@
         </options>
       </control>
       <control>
-        <group>[Sampler8]</group>
-        <key>KeyLabMk1.controller.samplers[7].input</key>
-        <description>Load or play from a sampler with velocity sensitive volume.</description>
+        <key>KeyLabMk1.controller.activeDeck.padGrid.input</key>
+        <description>Configurable samplers or hotcues.</description>
         <status>0x99</status>
         <midino>0x2f</midino>
         <options>
@@ -527,9 +528,8 @@
 
       <!-- Pads row 3 -->
       <control>
-        <group>[Sampler9]</group>
-        <key>KeyLabMk1.controller.samplers[8].input</key>
-        <description>Load or play from a sampler with velocity sensitive volume.</description>
+        <key>KeyLabMk1.controller.activeDeck.padGrid.input</key>
+        <description>Configurable samplers or hotcues.</description>
         <status>0x99</status>
         <midino>0x28</midino>
         <options>
@@ -537,9 +537,8 @@
         </options>
       </control>
       <control>
-        <group>[Sampler10]</group>
-        <key>KeyLabMk1.controller.samplers[9].input</key>
-        <description>Load or play from a sampler with velocity sensitive volume.</description>
+        <key>KeyLabMk1.controller.activeDeck.padGrid.input</key>
+        <description>Configurable samplers or hotcues.</description>
         <status>0x99</status>
         <midino>0x29</midino>
         <options>
@@ -547,9 +546,8 @@
         </options>
       </control>
       <control>
-        <group>[Sampler11]</group>
-        <key>KeyLabMk1.controller.samplers[10].input</key>
-        <description>Load or play from a sampler with velocity sensitive volume.</description>
+        <key>KeyLabMk1.controller.activeDeck.padGrid.input</key>
+        <description>Configurable samplers or hotcues.</description>
         <status>0x99</status>
         <midino>0x2a</midino>
         <options>
@@ -557,9 +555,8 @@
         </options>
       </control>
       <control>
-        <group>[Sampler12]</group>
-        <key>KeyLabMk1.controller.samplers[11].input</key>
-        <description>Load or play from a sampler with velocity sensitive volume.</description>
+        <key>KeyLabMk1.controller.activeDeck.padGrid.input</key>
+        <description>Configurable samplers or hotcues.</description>
         <status>0x99</status>
         <midino>0x2b</midino>
         <options>
@@ -569,9 +566,8 @@
 
       <!-- Pads row 4 -->
       <control>
-        <group>[Sampler13]</group>
-        <key>KeyLabMk1.controller.samplers[12].input</key>
-        <description>Load or play from a sampler with velocity sensitive volume.</description>
+        <key>KeyLabMk1.controller.activeDeck.padGrid.input</key>
+        <description>Configurable samplers or hotcues.</description>
         <status>0x99</status>
         <midino>0x24</midino>
         <options>
@@ -579,9 +575,8 @@
         </options>
       </control>
       <control>
-        <group>[Sampler14]</group>
-        <key>KeyLabMk1.controller.samplers[13].input</key>
-        <description>Load or play from a sampler with velocity sensitive volume.</description>
+        <key>KeyLabMk1.controller.activeDeck.padGrid.input</key>
+        <description>Configurable samplers or hotcues.</description>
         <status>0x99</status>
         <midino>0x25</midino>
         <options>
@@ -589,9 +584,8 @@
         </options>
       </control>
       <control>
-        <group>[Sampler15]</group>
-        <key>KeyLabMk1.controller.samplers[14].input</key>
-        <description>Load or play from a sampler with velocity sensitive volume.</description>
+        <key>KeyLabMk1.controller.activeDeck.padGrid.input</key>
+        <description>Configurable samplers or hotcues.</description>
         <status>0x99</status>
         <midino>0x26</midino>
         <options>
@@ -599,9 +593,8 @@
         </options>
       </control>
       <control>
-        <group>[Sampler16]</group>
-        <key>KeyLabMk1.controller.samplers[15].input</key>
-        <description>Load or play from a sampler with velocity sensitive volume.</description>
+        <key>KeyLabMk1.controller.activeDeck.padGrid.input</key>
+        <description>Configurable samplers or hotcues.</description>
         <status>0x99</status>
         <midino>0x27</midino>
         <options>

--- a/res/controllers/ArturiaKeyLab.midi.xml
+++ b/res/controllers/ArturiaKeyLab.midi.xml
@@ -5,6 +5,10 @@
     <author>Sam Whited</author>
     <description>MIDI mapping for the original Arturia KeyLab Mk 1</description>
     <forums>https://mixxx.discourse.group/t/arturia-keylab-mk1/31080</forums>
+    <manual>arturia_keylab_mk1</manual>
+    <devices>
+      <product protocol="midi" vendor_id="0x1c75" product_id="0x02cd" />
+    </devices>
   </info>
   <settings>
     <group label="Pots">


### PR DESCRIPTION
The corresponding manual PR is here:

https://github.com/mixxxdj/manual/pull/744

![Graphical depiction of the keylab to give a sense of where the controls are. A textual description is included in the readme for the downstream project and will be included in the Mixxx manual.](https://github.com/user-attachments/assets/eca72d68-a64d-4c4a-a5f2-e4c7fa51cd56)


A few things to note in particular:

  - The menu system is a bit complicated. I don't see a way around that, but maybe someone else will have a better idea.
  - Unsure what's actually useful to have in the on-screen menu or not. I threw in a few actions, but some may or may not be as useful as others and I'm open to tweaking those.
  - Sound and Multi feel weird as deck switching buttons, but nothing else really worked well.
  - Fader bank 2 is unused at the moment, so there's room to make a more comprehensive effects controlling system, but that may be for a later update to keep the complexity of this PR low. Open to ideas though.