### PR TITLE
Streamlining SQL's -> SetlogFeature

### DIFF
--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -234,7 +234,7 @@ QModelIndex SetlogFeature::constructChildModel(int selectedId) {
     // Setup the sidebar playlist model
     QSqlDatabase database =
             m_pLibrary->trackCollectionManager()->internalCollection()->database();
-    // Line to start CI
+
     QString queryString = QStringLiteral(
             "CREATE TEMPORARY VIEW IF NOT EXISTS %1 AS "
             "SELECT "

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -234,7 +234,7 @@ QModelIndex SetlogFeature::constructChildModel(int selectedId) {
     // Setup the sidebar playlist model
     QSqlDatabase database =
             m_pLibrary->trackCollectionManager()->internalCollection()->database();
-
+    // Line to start CI
     QString queryString = QStringLiteral(
             "CREATE TEMPORARY VIEW IF NOT EXISTS %1 AS "
             "SELECT "


### PR DESCRIPTION

In these series of PR's I want to streamline / cleane up all SQL-Queries
-> use database.field structure for all fieldnames
-> no more 'written' names but use database & fieldnames as defined in trackschema
-> order of tables

1st: start with Playlists (Search particular HistoryList = Playlist)
2nd join other tables PlaylistTracks & Library
