### PR TITLE
Streamlining SQL's -> PlaylistDAO

### DIFF
--- a/src/library/dao/playlistdao.cpp
+++ b/src/library/dao/playlistdao.cpp
@@ -12,8 +12,6 @@
 #include "util/make_const_iterator.h"
 #include "util/math.h"
 
-// Line to start CI
-
 PlaylistDAO::PlaylistDAO()
         : m_pAutoDJProcessor(nullptr) {
 }

--- a/src/library/dao/playlistdao.cpp
+++ b/src/library/dao/playlistdao.cpp
@@ -12,6 +12,8 @@
 #include "util/make_const_iterator.h"
 #include "util/math.h"
 
+// Line to start CI
+
 PlaylistDAO::PlaylistDAO()
         : m_pAutoDJProcessor(nullptr) {
 }

--- a/src/library/dao/trackschema.h
+++ b/src/library/dao/trackschema.h
@@ -67,7 +67,9 @@ const QString PLAYLISTTABLE_POSITION = QStringLiteral("position");
 const QString PLAYLISTTABLE_HIDDEN = QStringLiteral("hidden");
 const QString PLAYLISTTABLE_DATECREATED = QStringLiteral("date_created");
 const QString PLAYLISTTABLE_DATEMODIFIED = QStringLiteral("date_modified");
+const QString PLAYLISTTABLE_LOCKED = QStringLiteral("locked");
 
+const QString PLAYLISTTRACKSTABLE_ID = QStringLiteral("id");
 const QString PLAYLISTTRACKSTABLE_TRACKID = QStringLiteral("track_id");
 const QString PLAYLISTTRACKSTABLE_POSITION = QStringLiteral("position");
 const QString PLAYLISTTRACKSTABLE_PLAYLISTID = QStringLiteral("playlist_id");


### PR DESCRIPTION

In these series of PR's I want to streamline / cleane up all SQL-Queries
-> use database.field structure for all fieldnames (if more then 1 table is called in the query)
-> no more 'written' names but use database & fieldnames as defined in trackschema


