### PR TITLE
Qt 6.8 ready

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2798,6 +2798,8 @@ if(QML)
   if(QT_VERSION VERSION_GREATER 6.6)
     list(APPEND QT_EXTRA_COMPONENTS "QuickControls2Basic")
     list(APPEND QT_EXTRA_COMPONENTS "QuickControls2BasicStyleImpl")
+    list(APPEND QT_EXTRA_COMPONENTS "QuickControls2Fusion")
+    list(APPEND QT_EXTRA_COMPONENTS "QuickControls2FusionStyleImpl")
   endif()
 endif()
 find_package(Qt${QT_VERSION_MAJOR}
@@ -3051,6 +3053,8 @@ else()
           IMPORTED_RUNTIME_ARTIFACTS
             Qt${QT_VERSION_MAJOR}::QuickControls2Basic
             Qt${QT_VERSION_MAJOR}::QuickControls2BasicStyleImpl
+            Qt${QT_VERSION_MAJOR}::QuickControls2Fusion
+            Qt${QT_VERSION_MAJOR}::QuickControls2FusionStyleImpl
             DESTINATION
             "${MIXXX_INSTALL_DATADIR}"
             COMPONENT

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3063,6 +3063,14 @@ else()
             COMPONENT
             applocal
         )
+      else()
+        install(
+          IMPORTED_RUNTIME_ARTIFACTS
+            Qt${QT_VERSION_MAJOR}::QuickControls2
+            DESTINATION
+            "${MIXXX_INSTALL_DATADIR}"
+            COMPONENT
+            applocal)
       endif()
 
       if(QT_VERSION VERSION_LESS 6.8)
@@ -3086,6 +3094,14 @@ else()
         Qt${QT_VERSION_MAJOR}::QuickShapesPrivate
         DESTINATION "${MIXXX_INSTALL_DATADIR}"
         COMPONENT applocal)
+
+      if(QT_VERSION VERSION_LESS 6.4)
+        # From Qt 6.4 integrated in QuickControls2
+	    install(IMPORTED_RUNTIME_ARTIFACTS
+	      Qt${QT_VERSION_MAJOR}::QuickTemplates2
+	      DESTINATION "${MIXXX_INSTALL_DATADIR}"
+	      COMPONENT applocal)
+	  endif()
 
       install(IMPORTED_RUNTIME_ARTIFACTS
         Qt${QT_VERSION_MAJOR}::ShaderTools

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2793,13 +2793,16 @@ if(QML)
   list(APPEND QT_EXTRA_COMPONENTS "QuickShapesPrivate")
   list(APPEND QT_EXTRA_COMPONENTS "QuickTemplates2")
   list(APPEND QT_EXTRA_COMPONENTS "QuickWidgets")
-  list(APPEND QT_EXTRA_COMPONENTS "QmlWorkerScript")
   list(APPEND QT_EXTRA_COMPONENTS "ShaderTools")
-  if(QT_VERSION VERSION_GREATER 6.6)
+  if(QT_VERSION VERSION_GREATER_EQUAL 6.7)
     list(APPEND QT_EXTRA_COMPONENTS "QuickControls2Basic")
     list(APPEND QT_EXTRA_COMPONENTS "QuickControls2BasicStyleImpl")
     list(APPEND QT_EXTRA_COMPONENTS "QuickControls2Fusion")
     list(APPEND QT_EXTRA_COMPONENTS "QuickControls2FusionStyleImpl")
+  endif()
+  if(QT_VERSION VERSION_LESS 6.8)
+    # From Qt 6.8 integrated in Qml via QmlMeta
+    list(APPEND QT_EXTRA_COMPONENTS "QmlWorkerScript")
   endif()
 endif()
 find_package(Qt${QT_VERSION_MAJOR}
@@ -3048,13 +3051,25 @@ else()
         DESTINATION "${MIXXX_INSTALL_DATADIR}"
         COMPONENT applocal)
 
-      if(QT_VERSION VERSION_GREATER 6.6)
+      if(QT_VERSION VERSION_GREATER_EQUAL 6.7)
         install(
           IMPORTED_RUNTIME_ARTIFACTS
             Qt${QT_VERSION_MAJOR}::QuickControls2Basic
             Qt${QT_VERSION_MAJOR}::QuickControls2BasicStyleImpl
             Qt${QT_VERSION_MAJOR}::QuickControls2Fusion
             Qt${QT_VERSION_MAJOR}::QuickControls2FusionStyleImpl
+            DESTINATION
+            "${MIXXX_INSTALL_DATADIR}"
+            COMPONENT
+            applocal
+        )
+      endif()
+
+      if(QT_VERSION VERSION_LESS 6.8)
+        # From Qt 6.8 integrated in Qml via QmlMeta
+        install(
+          IMPORTED_RUNTIME_ARTIFACTS
+            Qt${QT_VERSION_MAJOR}::QmlWorkerScript
             DESTINATION
             "${MIXXX_INSTALL_DATADIR}"
             COMPONENT
@@ -3069,11 +3084,6 @@ else()
 
       install(IMPORTED_RUNTIME_ARTIFACTS
         Qt${QT_VERSION_MAJOR}::QuickShapesPrivate
-        DESTINATION "${MIXXX_INSTALL_DATADIR}"
-        COMPONENT applocal)
-
-      install(IMPORTED_RUNTIME_ARTIFACTS
-        Qt${QT_VERSION_MAJOR}::QmlWorkerScript
         DESTINATION "${MIXXX_INSTALL_DATADIR}"
         COMPONENT applocal)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3038,11 +3038,6 @@ else()
         COMPONENT applocal)
 
       install(IMPORTED_RUNTIME_ARTIFACTS
-        Qt${QT_VERSION_MAJOR}::QuickControls2
-        DESTINATION "${MIXXX_INSTALL_DATADIR}"
-        COMPONENT applocal)
-
-      install(IMPORTED_RUNTIME_ARTIFACTS
         Qt${QT_VERSION_MAJOR}::QuickControls2Impl
         DESTINATION "${MIXXX_INSTALL_DATADIR}"
         COMPONENT applocal)
@@ -3054,11 +3049,6 @@ else()
 
       install(IMPORTED_RUNTIME_ARTIFACTS
         Qt${QT_VERSION_MAJOR}::QuickShapesPrivate
-        DESTINATION "${MIXXX_INSTALL_DATADIR}"
-        COMPONENT applocal)
-
-      install(IMPORTED_RUNTIME_ARTIFACTS
-        Qt${QT_VERSION_MAJOR}::QuickTemplates2
         DESTINATION "${MIXXX_INSTALL_DATADIR}"
         COMPONENT applocal)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2795,6 +2795,10 @@ if(QML)
   list(APPEND QT_EXTRA_COMPONENTS "QuickWidgets")
   list(APPEND QT_EXTRA_COMPONENTS "QmlWorkerScript")
   list(APPEND QT_EXTRA_COMPONENTS "ShaderTools")
+  if(QT_VERSION VERSION_GREATER 6.6)
+    list(APPEND QT_EXTRA_COMPONENTS "QuickControls2Basic")
+    list(APPEND QT_EXTRA_COMPONENTS "QuickControls2BasicStyleImpl")
+  endif()
 endif()
 find_package(Qt${QT_VERSION_MAJOR}
   COMPONENTS
@@ -3041,6 +3045,18 @@ else()
         Qt${QT_VERSION_MAJOR}::QuickControls2Impl
         DESTINATION "${MIXXX_INSTALL_DATADIR}"
         COMPONENT applocal)
+
+      if(QT_VERSION VERSION_GREATER 6.6)
+        install(
+          IMPORTED_RUNTIME_ARTIFACTS
+            Qt${QT_VERSION_MAJOR}::QuickControls2Basic
+            Qt${QT_VERSION_MAJOR}::QuickControls2BasicStyleImpl
+            DESTINATION
+            "${MIXXX_INSTALL_DATADIR}"
+            COMPONENT
+            applocal
+        )
+      endif()
 
       install(IMPORTED_RUNTIME_ARTIFACTS
         Qt${QT_VERSION_MAJOR}::QuickLayouts


### PR DESCRIPTION
Qt > 6.6 has slightly different QML packaging. Adjust the installed packages on Windows and macOS. 
This is a spitted from https://github.com/daschuer/mixxx/tree/vcpkg_update_direct
to verify that it also builds with older Qt versions. 