### PR TITLE
CMake find modules required for the new vcpkg environment 

### DIFF
--- a/cmake/modules/Findlilv.cmake
+++ b/cmake/modules/Findlilv.cmake
@@ -94,7 +94,10 @@ if(lilv_FOUND)
     )
     is_static_library(lilv_IS_STATIC lilv::lilv)
     if(lilv_IS_STATIC)
-      find_package(sord REQUIRED)
+      find_package(sord CONFIG)
+      if(NOT sord_FOUND)
+        find_package(sord REQUIRED)
+      endif()
       set_property(
         TARGET lilv::lilv
         APPEND

--- a/cmake/modules/Findlilv.cmake
+++ b/cmake/modules/Findlilv.cmake
@@ -50,7 +50,8 @@ if(PkgConfig_FOUND)
   pkg_check_modules(PC_lilv QUIET lilv-0 lv2)
 endif()
 
-find_path(lilv_INCLUDE_DIR
+find_path(
+  lilv_INCLUDE_DIR
   NAMES lilv/lilv.h
   PATH_SUFFIXES lilv-0
   HINTS ${PC_lilv_INCLUDE_DIRS}
@@ -58,7 +59,8 @@ find_path(lilv_INCLUDE_DIR
 )
 mark_as_advanced(lilv_INCLUDE_DIR)
 
-find_library(lilv_LIBRARY
+find_library(
+  lilv_LIBRARY
   NAMES lilv-0 lilv
   HINTS ${PC_lilv_LIBRARY_DIRS}
   DOC "lilv library"
@@ -83,7 +85,8 @@ if(lilv_FOUND)
 
   if(NOT TARGET lilv::lilv)
     add_library(lilv::lilv UNKNOWN IMPORTED)
-    set_target_properties(lilv::lilv
+    set_target_properties(
+      lilv::lilv
       PROPERTIES
         IMPORTED_LOCATION "${lilv_LIBRARY}"
         INTERFACE_COMPILE_OPTIONS "${PC_lilv_CFLAGS_OTHER}"
@@ -91,9 +94,11 @@ if(lilv_FOUND)
     )
     is_static_library(lilv_IS_STATIC lilv::lilv)
     if(lilv_IS_STATIC)
-      find_package(sord CONFIG REQUIRED)
-      set_property(TARGET lilv::lilv APPEND PROPERTY INTERFACE_LINK_LIBRARIES
-          sord::sord
+      find_package(sord REQUIRED)
+      set_property(
+        TARGET lilv::lilv
+        APPEND
+        PROPERTY INTERFACE_LINK_LIBRARIES sord::sord
       )
     endif()
   endif()

--- a/cmake/modules/Findserd.cmake
+++ b/cmake/modules/Findserd.cmake
@@ -1,0 +1,95 @@
+# This file is part of Mixxx, Digital DJ'ing software.
+# Copyright (C) 2001-2025 Mixxx Development Team
+# Distributed under the GNU General Public Licence (GPL) version 2 or any later
+# later version. See the LICENSE file for details.
+
+#[=======================================================================[.rst:
+Findserd
+--------
+
+Finds the serd library and its development headers.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module provides the following imported targets, if found:
+
+``serd::serd``
+  The serd library
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This will define the following variables:
+
+``serd_FOUND``
+  True if the system has the serd library.
+``serd_INCLUDE_DIRS``
+  Include directories needed to use serd.
+``serd_LIBRARIES``
+  Libraries needed to link to serd.
+``serd_DEFINITIONS``
+  Compile definitions needed to use serd.
+
+Cache Variables
+^^^^^^^^^^^^^^^
+
+The following cache variables may also be set:
+
+``serd_INCLUDE_DIR``
+  The directory containing ``serd/serd.h``.
+``serd_LIBRARY``
+  The path to the serd library.
+
+#]=======================================================================]
+
+include(IsStaticLibrary)
+
+find_package(PkgConfig QUIET)
+if(PkgConfig_FOUND)
+  pkg_check_modules(PC_serd QUIET serd-0)
+endif()
+
+find_path(
+  serd_INCLUDE_DIR
+  NAMES serd/serd.h
+  HINTS ${PC_serd_INCLUDE_DIRS}
+  DOC "serd include directory"
+)
+mark_as_advanced(serd_INCLUDE_DIR)
+
+find_library(
+  serd_LIBRARY
+  NAMES serd-0
+  HINTS ${PC_serd_LIBRARY_DIRS}
+  DOC "serd library"
+)
+mark_as_advanced(serd_LIBRARY)
+
+if(DEFINED PC_serd_VERSION AND NOT PC_serd_VERSION STREQUAL "")
+  set(serd_VERSION "${PC_serd_VERSION}")
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  serd
+  REQUIRED_VARS serd_LIBRARY serd_INCLUDE_DIR
+  VERSION_VAR serd_VERSION
+)
+
+if(serd_FOUND)
+  set(serd_LIBRARIES "${serd_LIBRARY}")
+  set(serd_INCLUDE_DIRS "${serd_INCLUDE_DIR}")
+  set(serd_DEFINITIONS ${PC_serd_CFLAGS_OTHER})
+
+  if(NOT TARGET serd::serd)
+    add_library(serd::serd UNKNOWN IMPORTED)
+    set_target_properties(
+      serd::serd
+      PROPERTIES
+        IMPORTED_LOCATION "${serd_LIBRARY}"
+        INTERFACE_COMPILE_OPTIONS "${PC_serd_CFLAGS_OTHER}"
+        INTERFACE_INCLUDE_DIRECTORIES "${serd_INCLUDE_DIR}"
+    )
+  endif()
+endif()

--- a/cmake/modules/Findsord.cmake
+++ b/cmake/modules/Findsord.cmake
@@ -94,10 +94,11 @@ if(sord_FOUND)
     is_static_library(sord_IS_STATIC sord::sord)
     if(sord_IS_STATIC)
       find_package(serd REQUIRED)
+      find_package(zix REQUIRED)
       set_property(
         TARGET sord::sord
         APPEND
-        PROPERTY INTERFACE_LINK_LIBRARIES serd::serd
+        PROPERTY INTERFACE_LINK_LIBRARIES serd::serd zix::zix
       )
     endif()
   endif()

--- a/cmake/modules/Findsord.cmake
+++ b/cmake/modules/Findsord.cmake
@@ -1,0 +1,95 @@
+# This file is part of Mixxx, Digital DJ'ing software.
+# Copyright (C) 2001-2025 Mixxx Development Team
+# Distributed under the GNU General Public Licence (GPL) version 2 or any later
+# later version. See the LICENSE file for details.
+
+#[=======================================================================[.rst:
+Findsord
+--------
+
+Finds the sord library and its development headers.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module provides the following imported targets, if found:
+
+``sord::sord``
+  The sord library
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This will define the following variables:
+
+``sord_FOUND``
+  True if the system has the sord library.
+``sord_INCLUDE_DIRS``
+  Include directories needed to use sord.
+``sord_LIBRARIES``
+  Libraries needed to link to sord.
+``sord_DEFINITIONS``
+  Compile definitions needed to use sord.
+
+Cache Variables
+^^^^^^^^^^^^^^^
+
+The following cache variables may also be set:
+
+``sord_INCLUDE_DIR``
+  The directory containing ``sord/sord.h``.
+``sord_LIBRARY``
+  The path to the sord library.
+
+#]=======================================================================]
+
+include(IsStaticLibrary)
+
+find_package(PkgConfig QUIET)
+if(PkgConfig_FOUND)
+  pkg_check_modules(PC_sord QUIET sord-0)
+endif()
+
+find_path(
+  sord_INCLUDE_DIR
+  NAMES sord/sord.h
+  HINTS ${PC_sord_INCLUDE_DIRS}
+  DOC "sord include directory"
+)
+mark_as_advanced(sord_INCLUDE_DIR)
+
+find_library(
+  sord_LIBRARY
+  NAMES sord-0
+  HINTS ${PC_sord_LIBRARY_DIRS}
+  DOC "sord library"
+)
+mark_as_advanced(sord_LIBRARY)
+
+if(DEFINED PC_sord_VERSION AND NOT PC_sord_VERSION STREQUAL "")
+  set(sord_VERSION "${PC_sord_VERSION}")
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  sord
+  REQUIRED_VARS sord_LIBRARY sord_INCLUDE_DIR
+  VERSION_VAR sord_VERSION
+)
+
+if(sord_FOUND)
+  set(sord_LIBRARIES "${sord_LIBRARY}")
+  set(sord_INCLUDE_DIRS "${sord_INCLUDE_DIR}")
+  set(sord_DEFINITIONS ${PC_sord_CFLAGS_OTHER})
+
+  if(NOT TARGET sord::sord)
+    add_library(sord::sord UNKNOWN IMPORTED)
+    set_target_properties(
+      sord::sord
+      PROPERTIES
+        IMPORTED_LOCATION "${sord_LIBRARY}"
+        INTERFACE_COMPILE_OPTIONS "${PC_sord_CFLAGS_OTHER}"
+        INTERFACE_INCLUDE_DIRECTORIES "${sord_INCLUDE_DIR}"
+    )
+  endif()
+endif()

--- a/cmake/modules/Findsord.cmake
+++ b/cmake/modules/Findsord.cmake
@@ -91,5 +91,14 @@ if(sord_FOUND)
         INTERFACE_COMPILE_OPTIONS "${PC_sord_CFLAGS_OTHER}"
         INTERFACE_INCLUDE_DIRECTORIES "${sord_INCLUDE_DIR}"
     )
+    is_static_library(sord_IS_STATIC sord::sord)
+    if(sord_IS_STATIC)
+      find_package(serd REQUIRED)
+      set_property(
+        TARGET sord::sord
+        APPEND
+        PROPERTY INTERFACE_LINK_LIBRARIES serd::serd
+      )
+    endif()
   endif()
 endif()

--- a/cmake/modules/Findsord.cmake
+++ b/cmake/modules/Findsord.cmake
@@ -94,12 +94,19 @@ if(sord_FOUND)
     is_static_library(sord_IS_STATIC sord::sord)
     if(sord_IS_STATIC)
       find_package(serd REQUIRED)
-      find_package(zix REQUIRED)
       set_property(
         TARGET sord::sord
         APPEND
-        PROPERTY INTERFACE_LINK_LIBRARIES serd::serd zix::zix
+        PROPERTY INTERFACE_LINK_LIBRARIES serd::serd
       )
+      if(sord_VERSION VERSION_GREATER_EQUAL "0.16.16")
+        find_package(zix REQUIRED)
+        set_property(
+          TARGET sord::sord
+          APPEND
+          PROPERTY INTERFACE_LINK_LIBRARIES zix::zix
+        )
+      endif()
     endif()
   endif()
 endif()

--- a/cmake/modules/Findzix.cmake
+++ b/cmake/modules/Findzix.cmake
@@ -1,0 +1,95 @@
+# This file is part of Mixxx, Digital DJ'ing software.
+# Copyright (C) 2001-2025 Mixxx Development Team
+# Distributed under the GNU General Public Licence (GPL) version 2 or any later
+# later version. See the LICENSE file for details.
+
+#[=======================================================================[.rst:
+Findzix
+--------
+
+Finds the zix library and its development headers.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module provides the following imported targets, if found:
+
+``zix::zix``
+  The zix library
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This will define the following variables:
+
+``zix_FOUND``
+  True if the system has the zix library.
+``zix_INCLUDE_DIRS``
+  Include directories needed to use zix.
+``zix_LIBRARIES``
+  Libraries needed to link to zix.
+``zix_DEFINITIONS``
+  Compile definitions needed to use zix.
+
+Cache Variables
+^^^^^^^^^^^^^^^
+
+The following cache variables may also be set:
+
+``zix_INCLUDE_DIR``
+  The directory containing ``zix/zix.h``.
+``zix_LIBRARY``
+  The path to the zix library.
+
+#]=======================================================================]
+
+include(IsStaticLibrary)
+
+find_package(PkgConfig QUIET)
+if(PkgConfig_FOUND)
+  pkg_check_modules(PC_zix QUIET zix-0)
+endif()
+
+find_path(
+  zix_INCLUDE_DIR
+  NAMES zix/zix.h
+  HINTS ${PC_zix_INCLUDE_DIRS}
+  DOC "zix include directory"
+)
+mark_as_advanced(zix_INCLUDE_DIR)
+
+find_library(
+  zix_LIBRARY
+  NAMES zix-0
+  HINTS ${PC_zix_LIBRARY_DIRS}
+  DOC "zix library"
+)
+mark_as_advanced(zix_LIBRARY)
+
+if(DEFINED PC_zix_VERSION AND NOT PC_zix_VERSION STREQUAL "")
+  set(zix_VERSION "${PC_zix_VERSION}")
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  zix
+  REQUIRED_VARS zix_LIBRARY zix_INCLUDE_DIR
+  VERSION_VAR zix_VERSION
+)
+
+if(zix_FOUND)
+  set(zix_LIBRARIES "${zix_LIBRARY}")
+  set(zix_INCLUDE_DIRS "${zix_INCLUDE_DIR}")
+  set(zix_DEFINITIONS ${PC_zix_CFLAGS_OTHER})
+
+  if(NOT TARGET zix::zix)
+    add_library(zix::zix UNKNOWN IMPORTED)
+    set_target_properties(
+      zix::zix
+      PROPERTIES
+        IMPORTED_LOCATION "${zix_LIBRARY}"
+        INTERFACE_COMPILE_OPTIONS "${PC_zix_CFLAGS_OTHER}"
+        INTERFACE_INCLUDE_DIRECTORIES "${zix_INCLUDE_DIR}"
+    )
+  endif()
+endif()


### PR DESCRIPTION
Some find modules are no longer provided by the recent upstream VCPKG environment. 
This fixes the issue.