### PR TITLE
Fail verbose when Chromaprint is missing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2377,7 +2377,11 @@ if(WIN32)
 endif()
 
 # Chromaprint
-find_package(Chromaprint REQUIRED)
+find_package(Chromaprint)
+if(NOT Chromaprint_FOUND)
+  # Fail verbose, because with Qt Creator, the verbose error message for Qt is bypassed.
+  FATAL_ERROR_MISSING_ENV()
+endif()
 target_link_libraries(mixxx-lib PRIVATE Chromaprint::Chromaprint)
 
 # Locale Aware Compare for SQLite


### PR DESCRIPTION
because with Qt Creator, the verbose error message for Qt is bypassed.