### PR TITLE
Allow to change the channel order when using 4 decks

### DIFF
--- a/res/skins/LateNight/decks/decks_left.xml
+++ b/res/skins/LateNight/decks/decks_left.xml
@@ -15,7 +15,7 @@
         <SizePolicy>me,min</SizePolicy>
         <Children>
           <SingletonContainer>
-            <ObjectName>Deck3_Src</ObjectName>
+            <ObjectName>Deck2_Src</ObjectName>
           </SingletonContainer>
         </Children>
         <Connection>

--- a/res/skins/LateNight/decks/decks_left_mini.xml
+++ b/res/skins/LateNight/decks/decks_left_mini.xml
@@ -15,7 +15,7 @@
         <SizePolicy>me,min</SizePolicy>
         <Children>
           <SingletonContainer>
-            <ObjectName>Deck3_Mini</ObjectName>
+            <ObjectName>Deck2_Mini</ObjectName>
           </SingletonContainer>
         </Children>
         <Connection>

--- a/res/skins/LateNight/decks/decks_right.xml
+++ b/res/skins/LateNight/decks/decks_right.xml
@@ -7,7 +7,7 @@
     <Children>
 
       <SingletonContainer>
-        <ObjectName>Deck2_Src</ObjectName>
+        <ObjectName>Deck3_Src</ObjectName>
       </SingletonContainer>
 
       <WidgetGroup>

--- a/res/skins/LateNight/decks/decks_right_mini.xml
+++ b/res/skins/LateNight/decks/decks_right_mini.xml
@@ -7,7 +7,7 @@
     <Children>
 
       <SingletonContainer>
-        <ObjectName>Deck2_Mini</ObjectName>
+        <ObjectName>Deck3_Mini</ObjectName>
       </SingletonContainer>
 
       <WidgetGroup>

--- a/res/skins/LateNight/mixer/mixer_4decks.xml
+++ b/res/skins/LateNight/mixer/mixer_4decks.xml
@@ -11,12 +11,6 @@
         <Children>
 
           <Template src="skins:LateNight/mixer/channel_4decks.xml">
-            <SetVariable name="ChanNum">3</SetVariable>
-            <SetVariable name="xfaderLeft">default</SetVariable>
-            <SetVariable name="xfaderRight">warning</SetVariable>
-          </Template>
-
-          <Template src="skins:LateNight/mixer/channel_4decks.xml">
             <SetVariable name="ChanNum">1</SetVariable>
             <SetVariable name="xfaderLeft">default</SetVariable>
             <SetVariable name="xfaderRight">warning</SetVariable>
@@ -24,6 +18,12 @@
 
           <Template src="skins:LateNight/mixer/channel_4decks.xml">
             <SetVariable name="ChanNum">2</SetVariable>
+            <SetVariable name="xfaderLeft">default</SetVariable>
+            <SetVariable name="xfaderRight">warning</SetVariable>
+          </Template>
+
+          <Template src="skins:LateNight/mixer/channel_4decks.xml">
+            <SetVariable name="ChanNum">3</SetVariable>
             <SetVariable name="xfaderLeft">warning</SetVariable>
             <SetVariable name="xfaderRight">default</SetVariable>
           </Template>

--- a/res/skins/LateNight/waveforms_container.xml
+++ b/res/skins/LateNight/waveforms_container.xml
@@ -35,7 +35,7 @@
                 <SizePolicy>me,me</SizePolicy>
                 <Children>
                   <Template src="skins:LateNight/waveform.xml">
-                    <SetVariable name="ChanNum">3</SetVariable>
+                    <SetVariable name="ChanNum">1</SetVariable>
                     <SetVariable name="SignalColor"><Variable name="SignalColor_34"/></SetVariable>
                     <SetVariable name="BgColorWaveform"><Variable name="BgColorWaveform_34"/></SetVariable>
                     <SetVariable name="Highlight">[Skin],show_4decks</SetVariable>
@@ -52,7 +52,7 @@
                 <SizePolicy>me,me</SizePolicy>
                 <Children>
                   <Template src="skins:LateNight/waveform.xml">
-                    <SetVariable name="ChanNum">1</SetVariable>
+                    <SetVariable name="ChanNum">2</SetVariable>
                     <SetVariable name="SignalColor"><Variable name="SignalColor_12"/></SetVariable>
                     <SetVariable name="BgColorWaveform"><Variable name="BgColorWaveform_12"/></SetVariable>
                     <SetVariable name="Highlight">[Skin],show_4decks</SetVariable>
@@ -65,7 +65,7 @@
                 <SizePolicy>me,me</SizePolicy>
                 <Children>
                   <Template src="skins:LateNight/waveform.xml">
-                    <SetVariable name="ChanNum">2</SetVariable>
+                    <SetVariable name="ChanNum">3</SetVariable>
                     <SetVariable name="SignalColor"><Variable name="SignalColor_12"/></SetVariable>
                     <SetVariable name="BgColorWaveform"><Variable name="BgColorWaveform_12"/></SetVariable>
                     <SetVariable name="Highlight">[Skin],show_4decks</SetVariable>


### PR DESCRIPTION
#13977 
For now, there's only a PoC for the 1234 channel order mode static.

The fader are rearrange in logical order and I changed the position of the deck and the waveforms to match the new order of the fader.