### PR TITLE
(fix) avoid crash after removing Quick Link

### DIFF
--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -358,7 +358,8 @@ void BrowseFeature::onRightClickChild(const QPoint& globalPos, const QModelIndex
     menu.addAction(m_pAddtoLibraryAction);
     menu.addAction(m_pRefreshDirTreeAction);
     menu.exec(globalPos);
-    onLazyChildExpandation(index);
+    // Don't invoke onLazyChildExpandation(index) now! It might cause a crash
+    // after quick link removal, see comment function for details.
 }
 
 namespace {
@@ -421,6 +422,9 @@ void BrowseFeature::onLazyChildExpandation(const QModelIndex& index) {
     // After migration to Qt5 the implementation of all LibraryFeatures
     // should be revisited, because I consider these checks only as a
     // temporary workaround.
+    // NOTE(ronso0) Still relevant with 2.5.0 and Qt6. These checks don't seem
+    // to suffice, it would crash after removing a quick link.
+    // Just don't call this after right-clicking a quick link.
     if (!index.isValid()) {
         return;
     }

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -24,6 +24,8 @@ const QString kViewName = QStringLiteral("BROWSEHOME");
 
 const QString kQuickLinksSeparator = QStringLiteral("-+-");
 
+const ConfigKey kQuickLinksCfgKey = ConfigKey("[Browse]", "QuickLinks");
+
 #if defined(__LINUX__)
 const QStringList removableDriveRootPaths() {
     QStringList paths;
@@ -514,16 +516,20 @@ QString BrowseFeature::getRootViewHtml() const {
 }
 
 void BrowseFeature::saveQuickLinks() {
-    m_pConfig->set(ConfigKey("[Browse]","QuickLinks"),ConfigValue(
-        m_quickLinkList.join(kQuickLinksSeparator)));
+    m_pConfig->setValue<QString>(kQuickLinksCfgKey,
+            m_quickLinkList.join(kQuickLinksSeparator));
 }
 
 void BrowseFeature::loadQuickLinks() {
-    if (m_pConfig->getValueString(ConfigKey("[Browse]","QuickLinks")).isEmpty()) {
+    if (!m_pConfig->exists(kQuickLinksCfgKey)) {
+        // New profile, create default Quick Links
         m_quickLinkList = getDefaultQuickLinks();
     } else {
-        m_quickLinkList = m_pConfig->getValueString(
-            ConfigKey("[Browse]","QuickLinks")).split(kQuickLinksSeparator);
+        const QString quickLinks = m_pConfig->getValueString(
+                kQuickLinksCfgKey);
+        if (!quickLinks.isEmpty()) {
+            m_quickLinkList = quickLinks.split(kQuickLinksSeparator);
+        }
     }
 }
 

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -345,25 +345,16 @@ void BrowseFeature::onRightClickChild(const QPoint& globalPos, const QModelIndex
 
     QMenu menu(m_pSidebarWidget);
 
-    if (pItem->parent()->getData().toString() == QUICK_LINK_NODE) {
-        // This is a QuickLink
+    if (pItem->parent()->getData().toString() == QUICK_LINK_NODE ||
+            m_quickLinkList.contains(path)) {
+        // This is a QuickLink or path is in the Quick Link list
         menu.addAction(m_pRemoveQuickLinkAction);
-        menu.addAction(m_pRefreshDirTreeAction);
-        menu.exec(globalPos);
-        onLazyChildExpandation(index);
-        return;
+    } else {
+        menu.addAction(m_pAddQuickLinkAction);
     }
 
-    if (m_quickLinkList.contains(path)) {
-        // Path is in the Quick Link list
-        menu.addAction(m_pRemoveQuickLinkAction);
-        menu.addAction(m_pRefreshDirTreeAction);
-        menu.exec(globalPos);
-        onLazyChildExpandation(index);
-        return;
-    }
-
-    menu.addAction(m_pAddQuickLinkAction);
+    // TODO Check if we already watch this path or a parent and don't show or
+    // disable this action.
     menu.addAction(m_pAddtoLibraryAction);
     menu.addAction(m_pRefreshDirTreeAction);
     menu.exec(globalPos);

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -52,6 +52,18 @@ BrowseFeature::BrowseFeature(
             &BrowseTableModel::restoreModelState,
             this,
             &LibraryFeature::restoreModelState);
+    connect(m_pSidebarModel,
+            &QAbstractItemModel::rowsAboutToBeRemoved,
+            this,
+            &BrowseFeature::invalidateRightClickIndex);
+    connect(m_pSidebarModel,
+            &QAbstractItemModel::rowsAboutToBeInserted,
+            this,
+            &BrowseFeature::invalidateRightClickIndex);
+    connect(m_pSidebarModel,
+            &QAbstractItemModel::modelAboutToBeReset,
+            this,
+            &BrowseFeature::invalidateRightClickIndex);
 
     m_pAddQuickLinkAction = new QAction(tr("Add to Quick Links"),this);
     connect(m_pAddQuickLinkAction,
@@ -600,4 +612,8 @@ QString BrowseFeature::getLastRightClickedPath() const {
         return {};
     }
     return pItem->getData().toString();
+}
+
+void BrowseFeature::invalidateRightClickIndex() {
+    m_lastRightClickedIndex = QModelIndex();
 }

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -162,6 +162,7 @@ void BrowseFeature::slotAddQuickLink() {
     }
 
     QVariant vpath = m_pLastRightClickedItem->getData();
+    m_pLastRightClickedItem = nullptr;
     QString spath = vpath.toString();
     QString name = extractNameFromPath(spath);
 
@@ -181,6 +182,7 @@ void BrowseFeature::slotAddToLibrary() {
         return;
     }
     QString spath = m_pLastRightClickedItem->getData().toString();
+    m_pLastRightClickedItem = nullptr;
     if (!m_pLibrary->requestAddDir(spath)) {
         return;
     }
@@ -223,7 +225,6 @@ void BrowseFeature::slotRemoveQuickLink() {
         return;
     }
 
-    m_pLastRightClickedItem = nullptr;
     QModelIndex parent = m_pSidebarModel->index(m_pQuickLinkItem->parentRow(), 0);
     m_pSidebarModel->removeRow(index, parent);
 
@@ -321,7 +322,7 @@ void BrowseFeature::onRightClickChild(const QPoint& globalPos, const QModelIndex
         return;
     }
 
-    // Make sure that this is reset when TreeItems are deleted in onLazyChildExpandation()
+    // Make sure that this is reset after use
     m_pLastRightClickedItem = pItem;
 
     QMenu menu(m_pSidebarWidget);
@@ -429,7 +430,6 @@ void BrowseFeature::onLazyChildExpandation(const QModelIndex& index) {
         return;
     }
 
-    m_pLastRightClickedItem = nullptr;
     // Before we populate the subtree, we need to delete old subtrees
     m_pSidebarModel->removeRows(0, pItem->childRows(), index);
 

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -246,17 +246,18 @@ void BrowseFeature::slotRefreshDirectoryTree() {
     if (!m_pLastRightClickedItem) {
         return;
     }
+    if (!m_pLastRightClickedIndex.isValid()) {
+        return;
+    }
 
-    const auto* pItem = m_pLastRightClickedItem;
+    const auto data = m_pLastRightClickedItem->getData();
     m_pLastRightClickedItem = nullptr;
-    const auto data = pItem->getData();
     DEBUG_ASSERT(data.isValid() && data.canConvert<QString>());
     const QString path = data.toString();
     m_pSidebarModel->removeChildDirsFromCache(QStringList{path});
 
     // Update child items
-    const QModelIndex index = m_pSidebarModel->index(pItem->parentRow(), 0);
-    onLazyChildExpandation(index);
+    onLazyChildExpandation(m_pLastRightClickedIndex);
 }
 
 TreeItemModel* BrowseFeature::sidebarModel() const {
@@ -342,6 +343,7 @@ void BrowseFeature::onRightClickChild(const QPoint& globalPos, const QModelIndex
 
     // Make sure that this is reset after use
     m_pLastRightClickedItem = pItem;
+    m_pLastRightClickedIndex = index;
 
     QMenu menu(m_pSidebarWidget);
 

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -275,11 +275,11 @@ void BrowseFeature::activate() {
 // Note: This is executed whenever you single click on an child item
 // Single clicks will not populate sub folders
 void BrowseFeature::activateChild(const QModelIndex& index) {
-    TreeItem *item = static_cast<TreeItem*>(index.internalPointer());
-    qDebug() << "BrowseFeature::activateChild " << item->getLabel() << " "
-             << item->getData().toString();
+    TreeItem* pItem = static_cast<TreeItem*>(index.internalPointer());
+    qDebug() << "BrowseFeature::activateChild " << pItem->getLabel() << " "
+             << pItem->getData().toString();
 
-    QString path = item->getData().toString();
+    QString path = pItem->getData().toString();
     if (path == QUICK_LINK_NODE || path == DEVICE_NODE) {
         emit saveModelState();
         // Clear the tracks view
@@ -310,23 +310,23 @@ void BrowseFeature::activateChild(const QModelIndex& index) {
 }
 
 void BrowseFeature::onRightClickChild(const QPoint& globalPos, const QModelIndex& index) {
-    TreeItem *item = static_cast<TreeItem*>(index.internalPointer());
-    if (!item) {
+    TreeItem* pItem = static_cast<TreeItem*>(index.internalPointer());
+    if (!pItem) {
         return;
     }
 
-    QString path = item->getData().toString();
+    QString path = pItem->getData().toString();
 
     if (path == QUICK_LINK_NODE || path == DEVICE_NODE) {
         return;
     }
 
     // Make sure that this is reset when TreeItems are deleted in onLazyChildExpandation()
-    m_pLastRightClickedItem = item;
+    m_pLastRightClickedItem = pItem;
 
     QMenu menu(m_pSidebarWidget);
 
-    if (item->parent()->getData().toString() == QUICK_LINK_NODE) {
+    if (pItem->parent()->getData().toString() == QUICK_LINK_NODE) {
         // This is a QuickLink
         menu.addAction(m_pRemoveQuickLinkAction);
         menu.addAction(m_pRefreshDirTreeAction);
@@ -414,15 +414,15 @@ void BrowseFeature::onLazyChildExpandation(const QModelIndex& index) {
     if (!index.isValid()) {
         return;
     }
-    TreeItem *item = static_cast<TreeItem*>(index.internalPointer());
-    if (!(item && item->getData().isValid())) {
+    TreeItem* pItem = static_cast<TreeItem*>(index.internalPointer());
+    if (!(pItem && pItem->getData().isValid())) {
         return;
     }
 
-    qDebug() << "BrowseFeature::onLazyChildExpandation " << item->getLabel()
-             << " " << item->getData();
+    qDebug() << "BrowseFeature::onLazyChildExpandation " << pItem->getLabel()
+             << " " << pItem->getData();
 
-    QString path = item->getData().toString();
+    QString path = pItem->getData().toString();
 
     // If the item is a built-in node, e.g., 'QuickLink' return
     if (path.isEmpty() || path == QUICK_LINK_NODE) {
@@ -431,7 +431,7 @@ void BrowseFeature::onLazyChildExpandation(const QModelIndex& index) {
 
     m_pLastRightClickedItem = nullptr;
     // Before we populate the subtree, we need to delete old subtrees
-    m_pSidebarModel->removeRows(0, item->childRows(), index);
+    m_pSidebarModel->removeRows(0, pItem->childRows(), index);
 
     // List of subfolders or drive letters
     std::vector<std::unique_ptr<TreeItem>> folders;

--- a/src/library/browse/browsefeature.h
+++ b/src/library/browse/browsefeature.h
@@ -77,6 +77,7 @@ class BrowseFeature : public LibraryFeature {
     // Caution: Make sure this is reset whenever the library tree is updated,
     // so that the internalPointer() does not become dangling
     TreeItem* m_pLastRightClickedItem;
+    QModelIndex m_pLastRightClickedIndex;
     TreeItem* m_pQuickLinkItem;
     QStringList m_quickLinkList;
     QPointer<WLibrarySidebar> m_pSidebarWidget;

--- a/src/library/browse/browsefeature.h
+++ b/src/library/browse/browsefeature.h
@@ -63,6 +63,7 @@ class BrowseFeature : public LibraryFeature {
     std::vector<std::unique_ptr<TreeItem>> getChildDirectoryItems(const QString& path) const;
     void saveQuickLinks();
     void loadQuickLinks();
+    QString getLastRightClickedPath() const;
 
     TrackCollection* const m_pTrackCollection;
 
@@ -76,8 +77,7 @@ class BrowseFeature : public LibraryFeature {
 
     // Caution: Make sure this is reset whenever the library tree is updated,
     // so that the internalPointer() does not become dangling
-    TreeItem* m_pLastRightClickedItem;
-    QModelIndex m_pLastRightClickedIndex;
+    QModelIndex m_lastRightClickedIndex;
     TreeItem* m_pQuickLinkItem;
     QStringList m_quickLinkList;
     QPointer<WLibrarySidebar> m_pSidebarWidget;

--- a/src/library/browse/browsefeature.h
+++ b/src/library/browse/browsefeature.h
@@ -50,6 +50,7 @@ class BrowseFeature : public LibraryFeature {
     void onLazyChildExpandation(const QModelIndex& index) override;
     void slotLibraryScanStarted();
     void slotLibraryScanFinished();
+    void invalidateRightClickIndex();
 
   signals:
     void setRootIndex(const QModelIndex&);

--- a/src/library/browse/foldertreemodel.cpp
+++ b/src/library/browse/foldertreemodel.cpp
@@ -28,21 +28,25 @@ FolderTreeModel::~FolderTreeModel() {
 // Note that BrowseFeature inserts folder trees dynamically and rowCount()
 // is only called if necessary.
 bool FolderTreeModel::hasChildren(const QModelIndex& parent) const {
-    TreeItem *item = static_cast<TreeItem*>(parent.internalPointer());
-    // Usually the child count is 0 because we do lazy initialization
-    // However, for, buid-in items such as 'Quick Links' there exist
-    // child items at init time
-    if (item->getData().toString() == QUICK_LINK_NODE) {
-        return true;
+    TreeItem* pItem = static_cast<TreeItem*>(parent.internalPointer());
+    VERIFY_OR_DEBUG_ASSERT(pItem) {
+        return false;
     }
-    //Can only happen on Windows
-    if (item->getData().toString() == DEVICE_NODE) {
+    // For Quick Link node we simply return the row count.
+    // That way we always have the real (uncached) state.
+    if (pItem->getData().toString() == QUICK_LINK_NODE) {
+        return rowCount(parent) > 0;
+    }
+    // For the 'Removable Devices' node we always return true so WLibrarySidebar
+    // thinks the node is expandable and any attempt to expand it will invoke
+    // LibraryFeature::onLazyChildExpandation() and update the tree.
+    if (pItem->getData().toString() == DEVICE_NODE) {
         return true;
     }
 
     // In all other cases the getData() points to a folder
-    QString folder = item->getData().toString();
-    return directoryHasChildren(folder);
+    const QString path = pItem->getData().toString();
+    return directoryHasChildren(path);
 }
 
 bool FolderTreeModel::directoryHasChildren(const QString& path) const {

--- a/src/library/browse/foldertreemodel.cpp
+++ b/src/library/browse/foldertreemodel.cpp
@@ -102,7 +102,9 @@ bool FolderTreeModel::directoryHasChildren(const QString& path) const {
     // filesystems that do not fully implement readdir such as JFS.
     if (directory == nullptr || (unknown_count == total_count && total_count > 0)) {
         QDir dir(path);
-        QFileInfoList all = dir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
+        // Instead of costly entryInfoList() we use entryList() which doesn't
+        // create a QFileInfo cache (only if sort flag is not set!).
+        const QStringList all = dir.entryList(QDir::Dirs | QDir::NoDotAndDotDot);
         has_children = all.count() > 0;
     }
 #endif

--- a/src/library/treeitemmodel.cpp
+++ b/src/library/treeitemmodel.cpp
@@ -143,13 +143,13 @@ int TreeItemModel::rowCount(const QModelIndex& parent) const {
         return 0;
     }
 
-    TreeItem* parentItem;
+    TreeItem* pParentItem;
     if (parent.isValid()) {
-        parentItem = static_cast<TreeItem*>(parent.internalPointer());
+        pParentItem = static_cast<TreeItem*>(parent.internalPointer());
     } else {
-        parentItem = getRootItem();
+        pParentItem = getRootItem();
     }
-    return parentItem->childRows();
+    return pParentItem->childRows();
 }
 
 // Populates the model and notifies the view.


### PR DESCRIPTION
workaround for #8270, happening with Qt 6.2.3

(... and other minor fixes for BrowseFeature, please see individual commits)

Apparently, the checks for `item != nullptr` and `item->getData().isValid()` don't suffice.
The crash happens afterwards with `qDebug() << item->getLabel() << item->getData().toString()`, so apparently the item has been removed in the meantime.

Simply don't call `onLazyChildExpandation()` after the context menu was closed and a Quick Link might have been removed.
Tbh I don't understand reasoning to expand the item after the menu closed in the first place. Regardless if the menu is used or closed right away, this is basically expand on right-click.

I removed those calls entirely, simply to avoid any further surprises.
___
Another bug I noticed while working on #14514 is that "Refresh directory tree" doesn't work for items other than first-level child items (and probably never did :grimacing: since #12908).
Fixed by using the last right-clicked index, too, as we do in other library features.