### PR TITLE
Add support for the MIDI Fighter Spectra

### DIFF
--- a/res/controllers/DJ TechTools MIDI Fighter Spectra.midi.xml
+++ b/res/controllers/DJ TechTools MIDI Fighter Spectra.midi.xml
@@ -1,0 +1,855 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MixxxControllerPreset mixxxVersion="" schemaVersion="1">
+  <info>
+    <name>DJ TechTools MIDI Fighter Spectra</name>
+    <author>Sam Whited</author>
+    <description>Multi-layer mappings for the Spectra.</description>
+    <manual>dj_techtools_midi_fighter_spectra</manual>
+    <forums>https://mixxx.discourse.group/t/dj-techtools-midi-fighter-spectra/31554</forums>
+    <devices>
+      <product protocol="midi" vendor_id="0x2580" product_id="0x0006"/>
+    </devices>
+  </info>
+  <settings>
+    <option variable="defaultLayer" type="enum" default="true" label="Default Layer">
+      <description>
+        Select the default layer.
+      </description>
+      <value label="EQ/Quick Effect Kill Switch" default="true">eq</value>
+      <value label="Hotcues">hotcues</value>
+      <value label="Samplers">samplers</value>
+    </option>
+    <option variable="groundEffectLed" type="enum" default="true" label="Ground Effect LEDs">
+      <description>
+        Allows configuring the behavior of the ground effect LEDs.
+      </description>
+      <value label="Off">off</value>
+      <value label="Pulse on Track Ending" default="true">end_of_track</value>
+      <value label="Blink on Beat">beat_active</value>
+    </option>
+    <group label="Button Lighting">
+      <row orientation="vertical">
+        <option variable="deckSelectedColor" type="enum" label="Selected Deck Color">
+          <description>The color of the selected deck button.</description>
+          <value label="Off">1</value>
+          <value label="Firmware Controlled">127</value>
+          <value label="Red">18</value>
+          <value label="Dim Red">19</value>
+          <value label="Orange">30</value>
+          <value label="Dim Orange">43</value>
+          <value label="Yellow">42</value>
+          <value label="Dim Yellow">43</value>
+          <value label="Lime">54</value>
+          <value label="Dim Lime">55</value>
+          <value label="Green">66</value>
+          <value label="Dim Green">67</value>
+          <value label="Celeste">78</value>
+          <value label="Dim Celeste">79</value>
+          <value label="Blue">90</value>
+          <value label="Dim Blue">91</value>
+          <value label="Purple">102</value>
+          <value label="Dim Purple">103</value>
+          <value label="Pink" default="true">114</value>
+          <value label="Dim Pink">115</value>
+          <value label="White">121</value>
+        </option>
+        <option variable="deckUnselectedColor" type="enum" label="Inactive Deck Color">
+          <description>The color of the non-active deck selection buttons.</description>
+          <value label="Off">1</value>
+          <value label="Firmware Controlled">127</value>
+          <value label="Red">18</value>
+          <value label="Dim Red">19</value>
+          <value label="Orange">30</value>
+          <value label="Dim Orange">43</value>
+          <value label="Yellow">42</value>
+          <value label="Dim Yellow">43</value>
+          <value label="Lime">54</value>
+          <value label="Dim Lime">55</value>
+          <value label="Green">66</value>
+          <value label="Dim Green">67</value>
+          <value label="Celeste">78</value>
+          <value label="Dim Celeste">79</value>
+          <value label="Blue">90</value>
+          <value label="Dim Blue">91</value>
+          <value label="Purple">102</value>
+          <value label="Dim Purple">103</value>
+          <value label="Pink">114</value>
+          <value label="Dim Pink" default="true">115</value>
+          <value label="White">121</value>
+        </option>
+        <option variable="introOutroColor" type="enum" label="Set intro/outro">
+          <description>The color of the intro or outro buttons when set.</description>
+          <value label="Off">1</value>
+          <value label="Firmware Controlled">127</value>
+          <value label="Red">18</value>
+          <value label="Dim Red">19</value>
+          <value label="Orange">30</value>
+          <value label="Dim Orange">43</value>
+          <value label="Yellow">42</value>
+          <value label="Dim Yellow">43</value>
+          <value label="Lime">54</value>
+          <value label="Dim Lime">55</value>
+          <value label="Green">66</value>
+          <value label="Dim Green">67</value>
+          <value label="Celeste">78</value>
+          <value label="Dim Celeste">79</value>
+          <value label="Blue" default="true">90</value>
+          <value label="Dim Blue">91</value>
+          <value label="Purple">102</value>
+          <value label="Dim Purple">103</value>
+          <value label="Pink">114</value>
+          <value label="Dim Pink">115</value>
+          <value label="White">121</value>
+        </option>
+        <option variable="unsetIntroOutroColor" type="enum" label="Unset intro/outro">
+          <description>The color of the intro or outro buttons when unset.</description>
+          <value label="Off" default="true">1</value>
+          <value label="Firmware Controlled">127</value>
+          <value label="Red">18</value>
+          <value label="Dim Red">19</value>
+          <value label="Orange">30</value>
+          <value label="Dim Orange">43</value>
+          <value label="Yellow">42</value>
+          <value label="Dim Yellow">43</value>
+          <value label="Lime">54</value>
+          <value label="Dim Lime">55</value>
+          <value label="Green">66</value>
+          <value label="Dim Green">67</value>
+          <value label="Celeste">78</value>
+          <value label="Dim Celeste">79</value>
+          <value label="Blue">90</value>
+          <value label="Dim Blue" default="true">91</value>
+          <value label="Purple">102</value>
+          <value label="Dim Purple">103</value>
+          <value label="Pink">114</value>
+          <value label="Dim Pink">115</value>
+          <value label="White">121</value>
+        </option>
+        <option variable="eqOffColor" type="enum" label="EQ Kill Switch On Color">
+          <description>The color of the activated EQ kill switch.</description>
+          <value label="Off">1</value>
+          <value label="Firmware Controlled">127</value>
+          <value label="Red" default="true">18</value>
+          <value label="Dim Red">19</value>
+          <value label="Orange">30</value>
+          <value label="Dim Orange">43</value>
+          <value label="Yellow">42</value>
+          <value label="Dim Yellow">43</value>
+          <value label="Lime">54</value>
+          <value label="Dim Lime">55</value>
+          <value label="Green">66</value>
+          <value label="Dim Green">67</value>
+          <value label="Celeste">78</value>
+          <value label="Dim Celeste">79</value>
+          <value label="Blue">90</value>
+          <value label="Dim Blue">91</value>
+          <value label="Purple">102</value>
+          <value label="Dim Purple">103</value>
+          <value label="Pink">114</value>
+          <value label="Dim Pink">115</value>
+          <value label="White">121</value>
+        </option>
+        <option variable="eqOnColor" type="enum" label="EQ Kill Switch Off Color">
+          <description>The color of the inactive EQ kill switch.</description>
+          <value label="Off" default="true">1</value>
+          <value label="Firmware Controlled">127</value>
+          <value label="Red">18</value>
+          <value label="Dim Red">19</value>
+          <value label="Orange">30</value>
+          <value label="Dim Orange">43</value>
+          <value label="Yellow">42</value>
+          <value label="Dim Yellow">43</value>
+          <value label="Lime">54</value>
+          <value label="Dim Lime">55</value>
+          <value label="Green">66</value>
+          <value label="Dim Green">67</value>
+          <value label="Celeste">78</value>
+          <value label="Dim Celeste">79</value>
+          <value label="Blue">90</value>
+          <value label="Dim Blue">91</value>
+          <value label="Purple">102</value>
+          <value label="Dim Purple">103</value>
+          <value label="Pink">114</value>
+          <value label="Dim Pink">115</value>
+          <value label="White">121</value>
+        </option>
+        <option variable="superOffColor" type="enum" label="Quick Effect Switch On Color">
+          <description>The color of the activated quick effect kill switch.</description>
+          <value label="Off">1</value>
+          <value label="Firmware Controlled">127</value>
+          <value label="Red">18</value>
+          <value label="Dim Red">19</value>
+          <value label="Orange">30</value>
+          <value label="Dim Orange">43</value>
+          <value label="Yellow">42</value>
+          <value label="Dim Yellow">43</value>
+          <value label="Lime">54</value>
+          <value label="Dim Lime">55</value>
+          <value label="Green" default="true">66</value>
+          <value label="Dim Green">67</value>
+          <value label="Celeste">78</value>
+          <value label="Dim Celeste">79</value>
+          <value label="Blue">90</value>
+          <value label="Dim Blue">91</value>
+          <value label="Purple">102</value>
+          <value label="Dim Purple">103</value>
+          <value label="Pink">114</value>
+          <value label="Dim Pink">115</value>
+          <value label="White">121</value>
+        </option>
+        <option variable="superOnColor" type="enum" label="Quick Effect Switch Off Color">
+          <description>The color of the inactive quick effect kill switch.</description>
+          <value label="Off" default="true">1</value>
+          <value label="Firmware Controlled">127</value>
+          <value label="Red">18</value>
+          <value label="Dim Red">19</value>
+          <value label="Orange">30</value>
+          <value label="Dim Orange">43</value>
+          <value label="Yellow">42</value>
+          <value label="Dim Yellow">43</value>
+          <value label="Lime">54</value>
+          <value label="Dim Lime">55</value>
+          <value label="Green">66</value>
+          <value label="Dim Green">67</value>
+          <value label="Celeste">78</value>
+          <value label="Dim Celeste">79</value>
+          <value label="Blue">90</value>
+          <value label="Dim Blue">91</value>
+          <value label="Purple">102</value>
+          <value label="Dim Purple">103</value>
+          <value label="Pink">114</value>
+          <value label="Dim Pink">115</value>
+          <value label="White">121</value>
+        </option>
+        <option variable="samplerLoadedColor" type="enum" label="Loaded Sampler Color">
+          <description>The color of a sampler button with a loaded sound.</description>
+          <value label="Off">1</value>
+          <value label="Firmware Controlled">127</value>
+          <value label="Red">18</value>
+          <value label="Dim Red">19</value>
+          <value label="Orange">30</value>
+          <value label="Dim Orange">43</value>
+          <value label="Yellow">42</value>
+          <value label="Dim Yellow">43</value>
+          <value label="Lime">54</value>
+          <value label="Dim Lime">55</value>
+          <value label="Green">66</value>
+          <value label="Dim Green">67</value>
+          <value label="Celeste">78</value>
+          <value label="Dim Celeste">79</value>
+          <value label="Blue">90</value>
+          <value label="Dim Blue">91</value>
+          <value label="Purple" default="true">102</value>
+          <value label="Dim Purple">103</value>
+          <value label="Pink">114</value>
+          <value label="Dim Pink">115</value>
+          <value label="White">121</value>
+        </option>
+        <option variable="samplerEmptyColor" type="enum" label="Empty Sampler Color">
+          <description>The color of a sampler button with no loaded sound.</description>
+          <value label="Off">1</value>
+          <value label="Firmware Controlled">127</value>
+          <value label="Red">18</value>
+          <value label="Dim Red">19</value>
+          <value label="Orange">30</value>
+          <value label="Dim Orange">43</value>
+          <value label="Yellow">42</value>
+          <value label="Dim Yellow">43</value>
+          <value label="Lime">54</value>
+          <value label="Dim Lime">55</value>
+          <value label="Green">66</value>
+          <value label="Dim Green">67</value>
+          <value label="Celeste">78</value>
+          <value label="Dim Celeste">79</value>
+          <value label="Blue">90</value>
+          <value label="Dim Blue">91</value>
+          <value label="Purple">102</value>
+          <value label="Dim Purple" default="true">103</value>
+          <value label="Pink">114</value>
+          <value label="Dim Pink">115</value>
+          <value label="White">121</value>
+        </option>
+      </row>
+    </group>
+  </settings>
+  <controller id="dj-techtools-midi-fighter-spectra">
+    <scriptfiles>
+      <file filename="midi-components-0.0.js" functionprefix=""/>
+      <file functionprefix="MidiFighterSpectra" filename="DJ TechTools-MIDI Fighter Spectra-scripts.js"/>
+    </scriptfiles>
+    <controls>
+      <!-- Layer 1: EQ -->
+      <!-- High Cutoff -->
+      <control>
+        <group>[Channel3]</group>
+        <key>MidiFighterSpectra.controller.eqLayer[0].input</key>
+        <description>High cutoff.</description>
+        <status>0x92</status>
+        <midino>0x30</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterSpectra.controller.eqLayer[1].input</key>
+        <description>High cutoff.</description>
+        <status>0x92</status>
+        <midino>0x31</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>MidiFighterSpectra.controller.eqLayer[2].input</key>
+        <description>High cutoff.</description>
+        <status>0x92</status>
+        <midino>0x32</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>MidiFighterSpectra.controller.eqLayer[3].input</key>
+        <description>High cutoff.</description>
+        <status>0x92</status>
+        <midino>0x33</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <!-- Mid Cutoff -->
+      <control>
+        <group>[Channel3]</group>
+        <key>MidiFighterSpectra.controller.eqLayer[4].input</key>
+        <description>Mid cutoff.</description>
+        <status>0x92</status>
+        <midino>0x2C</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterSpectra.controller.eqLayer[5].input</key>
+        <description>Mid cutoff.</description>
+        <status>0x92</status>
+        <midino>0x2D</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>MidiFighterSpectra.controller.eqLayer[6].input</key>
+        <description>Mid cutoff.</description>
+        <status>0x92</status>
+        <midino>0x2E</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>MidiFighterSpectra.controller.eqLayer[7].input</key>
+        <description>Mid cutoff.</description>
+        <status>0x92</status>
+        <midino>0x2F</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <!-- Low Cutoff -->
+      <control>
+        <group>[Channel3]</group>
+        <key>MidiFighterSpectra.controller.eqLayer[8].input</key>
+        <description>Low cutoff.</description>
+        <status>0x92</status>
+        <midino>0x28</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterSpectra.controller.eqLayer[9].input</key>
+        <description>Low cutoff.</description>
+        <status>0x92</status>
+        <midino>0x29</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>MidiFighterSpectra.controller.eqLayer[10].input</key>
+        <description>Low cutoff.</description>
+        <status>0x92</status>
+        <midino>0x2A</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>MidiFighterSpectra.controller.eqLayer[11].input</key>
+        <description>Low cutoff.</description>
+        <status>0x92</status>
+        <midino>0x2B</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <!-- Super Cutoff -->
+      <control>
+        <group>[Channel3]</group>
+        <key>MidiFighterSpectra.controller.eqLayer[12].input</key>
+        <description>Quick effect cutoff.</description>
+        <status>0x92</status>
+        <midino>0x24</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterSpectra.controller.eqLayer[13].input</key>
+        <description>Quick effect cutoff.</description>
+        <status>0x92</status>
+        <midino>0x25</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>MidiFighterSpectra.controller.eqLayer[14].input</key>
+        <description>Quick effect cutoff.</description>
+        <status>0x92</status>
+        <midino>0x26</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>MidiFighterSpectra.controller.eqLayer[15].input</key>
+        <description>Quick effect cutoff.</description>
+        <status>0x92</status>
+        <midino>0x27</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <!-- Layer 2: Cues -->
+      <!-- Intro/outro markers -->
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterSpectra.controller.activeDeck.cueLayer[0].input</key>
+        <description>Set intro start marker.</description>
+        <status>0x92</status>
+        <midino>0x40</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterSpectra.controller.activeDeck.cueLayer[1].input</key>
+        <description>Set intro end marker.</description>
+        <status>0x92</status>
+        <midino>0x41</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterSpectra.controller.activeDeck.cueLayer[2].input</key>
+        <description>Set outro start marker.</description>
+        <status>0x92</status>
+        <midino>0x42</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterSpectra.controller.activeDeck.cueLayer[3].input</key>
+        <description>Set outro end marker.</description>
+        <status>0x92</status>
+        <midino>0x43</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <!-- Hotcues -->
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterSpectra.controller.activeDeck.cueLayer[4].input</key>
+        <description>Set/activate hotcue 1.</description>
+        <status>0x92</status>
+        <midino>0x3C</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterSpectra.controller.activeDeck.cueLayer[5].input</key>
+        <description>Set/activate hotcue 2.</description>
+        <status>0x92</status>
+        <midino>0x3D</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterSpectra.controller.activeDeck.cueLayer[6].input</key>
+        <description>Set/activate hotcue 3.</description>
+        <status>0x92</status>
+        <midino>0x3E</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterSpectra.controller.activeDeck.cueLayer[7].input</key>
+        <description>Set/activate hotcue 4.</description>
+        <status>0x92</status>
+        <midino>0x3F</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterSpectra.controller.activeDeck.cueLayer[8].input</key>
+        <description>Set/activate hotcue 5.</description>
+        <status>0x92</status>
+        <midino>0x38</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterSpectra.controller.activeDeck.cueLayer[9].input</key>
+        <description>Set/activate hotcue 6.</description>
+        <status>0x92</status>
+        <midino>0x39</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterSpectra.controller.activeDeck.cueLayer[10].input</key>
+        <description>Set/activate hotcue 7.</description>
+        <status>0x92</status>
+        <midino>0x3A</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterSpectra.controller.activeDeck.cueLayer[11].input</key>
+        <description>Set/activate hotcue 8.</description>
+        <status>0x92</status>
+        <midino>0x3B</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <!-- Hotcue release -->
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterSpectra.controller.activeDeck.cueLayer[4].input</key>
+        <description>Release hotcue 1.</description>
+        <status>0x82</status>
+        <midino>0x3C</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterSpectra.controller.activeDeck.cueLayer[5].input</key>
+        <description>Release hotcue 2.</description>
+        <status>0x82</status>
+        <midino>0x3D</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterSpectra.controller.activeDeck.cueLayer[6].input</key>
+        <description>Release hotcue 3.</description>
+        <status>0x82</status>
+        <midino>0x3E</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterSpectra.controller.activeDeck.cueLayer[7].input</key>
+        <description>Release hotcue 4.</description>
+        <status>0x82</status>
+        <midino>0x3F</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterSpectra.controller.activeDeck.cueLayer[8].input</key>
+        <description>Release hotcue 5.</description>
+        <status>0x82</status>
+        <midino>0x38</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterSpectra.controller.activeDeck.cueLayer[9].input</key>
+        <description>Release hotcue 6.</description>
+        <status>0x82</status>
+        <midino>0x39</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterSpectra.controller.activeDeck.cueLayer[10].input</key>
+        <description>Release hotcue 7.</description>
+        <status>0x82</status>
+        <midino>0x3A</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterSpectra.controller.activeDeck.cueLayer[11].input</key>
+        <description>Release hotcue 8.</description>
+        <status>0x82</status>
+        <midino>0x3B</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <!-- Deck Selection -->
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterSpectra.controller.selectCueDeck.input</key>
+        <description>Select deck 1.</description>
+        <status>0x92</status>
+        <midino>0x34</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>MidiFighterSpectra.controller.selectCueDeck.input</key>
+        <description>Select deck 2.</description>
+        <status>0x92</status>
+        <midino>0x35</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>MidiFighterSpectra.controller.selectCueDeck.input</key>
+        <description>Select deck 3.</description>
+        <status>0x92</status>
+        <midino>0x36</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>MidiFighterSpectra.controller.selectCueDeck.input</key>
+        <description>Select deck 4.</description>
+        <status>0x92</status>
+        <midino>0x37</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <!-- Layer 3: Samplers -->
+      <control>
+        <group>[Sampler1]</group>
+        <key>MidiFighterSpectra.controller.samplerLayer[0].input</key>
+        <description>Load or play sampler.</description>
+        <status>0x92</status>
+        <midino>0x50</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler2]</group>
+        <key>MidiFighterSpectra.controller.samplerLayer[1].input</key>
+        <description>Load or play sampler.</description>
+        <status>0x92</status>
+        <midino>0x51</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler3]</group>
+        <key>MidiFighterSpectra.controller.samplerLayer[2].input</key>
+        <description>Load or play sampler.</description>
+        <status>0x92</status>
+        <midino>0x52</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler4]</group>
+        <key>MidiFighterSpectra.controller.samplerLayer[3].input</key>
+        <description>Load or play sampler.</description>
+        <status>0x92</status>
+        <midino>0x53</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler5]</group>
+        <key>MidiFighterSpectra.controller.samplerLayer[4].input</key>
+        <description>Load or play sampler.</description>
+        <status>0x92</status>
+        <midino>0x4C</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler6]</group>
+        <key>MidiFighterSpectra.controller.samplerLayer[5].input</key>
+        <description>Load or play sampler.</description>
+        <status>0x92</status>
+        <midino>0x4D</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler7]</group>
+        <key>MidiFighterSpectra.controller.samplerLayer[6].input</key>
+        <description>Load or play sampler.</description>
+        <status>0x92</status>
+        <midino>0x4E</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler8]</group>
+        <key>MidiFighterSpectra.controller.samplerLayer[7].input</key>
+        <description>Load or play sampler.</description>
+        <status>0x92</status>
+        <midino>0x4F</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler9]</group>
+        <key>MidiFighterSpectra.controller.samplerLayer[8].input</key>
+        <description>Load or play sampler.</description>
+        <status>0x92</status>
+        <midino>0x48</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler10]</group>
+        <key>MidiFighterSpectra.controller.samplerLayer[9].input</key>
+        <description>Load or play sampler.</description>
+        <status>0x92</status>
+        <midino>0x49</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler11]</group>
+        <key>MidiFighterSpectra.controller.samplerLayer[10].input</key>
+        <description>Load or play sampler.</description>
+        <status>0x92</status>
+        <midino>0x4A</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler12]</group>
+        <key>MidiFighterSpectra.controller.samplerLayer[11].input</key>
+        <description>Load or play sampler.</description>
+        <status>0x92</status>
+        <midino>0x4B</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler13]</group>
+        <key>MidiFighterSpectra.controller.samplerLayer[12].input</key>
+        <description>Load or play sampler.</description>
+        <status>0x92</status>
+        <midino>0x44</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler14]</group>
+        <key>MidiFighterSpectra.controller.samplerLayer[13].input</key>
+        <description>Load or play sampler.</description>
+        <status>0x92</status>
+        <midino>0x45</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler15]</group>
+        <key>MidiFighterSpectra.controller.samplerLayer[14].input</key>
+        <description>Load or play sampler.</description>
+        <status>0x92</status>
+        <midino>0x46</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Sampler16]</group>
+        <key>MidiFighterSpectra.controller.samplerLayer[15].input</key>
+        <description>Load or play sampler.</description>
+        <status>0x92</status>
+        <midino>0x47</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+    </controls>
+    <outputs/>
+  </controller>
+</MixxxControllerPreset>

--- a/res/controllers/DJ TechTools MIDI Fighter Spectra.midi.xml
+++ b/res/controllers/DJ TechTools MIDI Fighter Spectra.midi.xml
@@ -27,6 +27,12 @@
       <value label="Pulse on Track Ending" default="true">end_of_track</value>
       <value label="Blink on Beat">beat_active</value>
     </option>
+    <option variable="pulseDeckSelect" type="boolean" default="true" label="Pulse Deck Select on Track Ending">
+      <description>
+        Pulse the appropriate deck selection button on the hotcue layer when the
+        track on that deck is ending.
+      </description>
+    </option>
     <group label="Button Lighting">
       <row orientation="vertical">
         <option variable="deckSelectedColor" type="enum" label="Selected Deck Color">

--- a/res/controllers/DJ TechTools-MIDI Fighter Spectra-scripts.js
+++ b/res/controllers/DJ TechTools-MIDI Fighter Spectra-scripts.js
@@ -1,0 +1,267 @@
+"use strict";
+
+// eslint-disable-next-line no-var
+var MidiFighterSpectra;
+(function(MidiFighterSpectra) {
+    const mapIndexToChannel = function(index) {
+        switch (Math.abs(index) % 4) {
+        case 0: return 3;
+        case 1: return 1;
+        case 2: return 2;
+        case 3: return 4;
+        }
+    };
+
+    class Deck extends components.Deck {
+        constructor() {
+            super([1, 2, 3, 4]);
+
+            this.cueLayer = [
+                // Intro/outro markers
+                new components.Button({
+                    group: "[Channel1]",
+                    midi: [0x92, 0x40],
+                    inKey: "intro_start_activate",
+                    outKey: "intro_start_enabled",
+                    on: engine.getSetting("introOutroColor"),
+                    off: engine.getSetting("unsetIntroOutroColor"),
+                }),
+                new components.Button({
+                    group: "[Channel1]",
+                    midi: [0x92, 0x41],
+                    inKey: "intro_end_activate",
+                    outKey: "intro_end_enabled",
+                    on: engine.getSetting("introOutroColor"),
+                    off: engine.getSetting("unsetIntroOutroColor"),
+                }),
+                new components.Button({
+                    group: "[Channel1]",
+                    midi: [0x92, 0x42],
+                    inKey: "outro_start_activate",
+                    outKey: "outro_start_enabled",
+                    on: engine.getSetting("introOutroColor"),
+                    off: engine.getSetting("unsetIntroOutroColor"),
+                }),
+                new components.Button({
+                    group: "[Channel1]",
+                    midi: [0x92, 0x43],
+                    inKey: "outro_end_activate",
+                    outKey: "outro_end_enabled",
+                    on: engine.getSetting("introOutroColor"),
+                    off: engine.getSetting("unsetIntroOutroColor"),
+                }),
+            ];
+            for (let i = 0; i < 8; i++) {
+                this.cueLayer[i + 4] = new components.HotcueButton({
+                    number: i + 1,
+                    group: "[Channel1]",
+                    midi: [0x92, [
+                        0x3C, 0x3D, 0x3E, 0x3F,
+                        0x38, 0x39, 0x3A, 0x3B
+                    ][i]],
+                    colorMapper: new ColorMapper({
+                        // These colors don't always appear to match what the
+                        // manual says they should be. The "bright" version of
+                        // the color is what the manual says should be the
+                        // "dull" version, and "white" is actually purple (and
+                        // the invalid value, 121, provided is actually white).
+                        0x000000: 1,   // Black (Off)
+                        0xC50A08: 19,  // Dim Red
+                        0xF07800: 31,  // Dim Orange
+                        0xF8D200: 43,  // Dim Yellow
+                        0xC4D82E: 55,  // Dim Lime
+                        0x32BE44: 67,  // Dim Green
+                        0x42D4F4: 79,  // Dim Bianchi/Celeste
+                        0x0044FF: 91,  // Dim Blue
+                        0xAF00CC: 103, // Dim Purple
+                        0xFCA6D7: 115, // Dim Pink
+                        0xF2F2FF: 122, // White
+                    }),
+                    input: function(channel, control, value, status, group) {
+                        // If this is a note release event, swap the value as if
+                        // this were a normal button release.
+                        if (status === 0x82) {
+                            value = value ? this.off : this.on;
+                            status = 0x92;
+                        }
+                        components.HotcueButton.prototype.input.bind(this)(channel, control, value, status, group);
+                    },
+                    outputColor: function(colorCode) {
+                        const enabled = engine.getValue(this.group, `hotcue_${this.number}_status`) === 2;
+                        // If the loop is enabled or the hotcue is previewing,
+                        // set the brighter variant of the closest color.
+                        if (enabled) {
+                            const nearestColorValue = this.colorMapper.getValueForNearestColor(colorCode);
+                            this.send(nearestColorValue - (enabled ? 1 : 0));
+                            return;
+                        }
+
+                        // otherwise set the "dim" variant.
+                        components.HotcueButton.prototype.outputColor.bind(this)(colorCode);
+                    },
+                });
+            }
+        }
+    }
+
+    class Controller extends components.ComponentContainer {
+        constructor() {
+            super({});
+
+            this.eqLayer = [];
+            for (let i = 0; i < 4; i++) {
+                this.eqLayer[i] = new components.Button({
+                    group: `[EqualizerRack1_[Channel${mapIndexToChannel(i)}]_Effect1]`,
+                    midi: [0x92, 0x30 + i],
+                    key: "button_parameter3",
+                    type: components.Button.prototype.types.toggle,
+                    off: engine.getSetting("eqOnColor"),
+                    on: engine.getSetting("eqOffColor"),
+                });
+                this.eqLayer[i + 4] = new components.Button({
+                    group: `[EqualizerRack1_[Channel${mapIndexToChannel(i)}]_Effect1]`,
+                    midi: [0x92, 0x2C + i],
+                    key: "button_parameter2",
+                    type: components.Button.prototype.types.toggle,
+                    off: engine.getSetting("eqOnColor"),
+                    on: engine.getSetting("eqOffColor"),
+                });
+                this.eqLayer[i + 8] = new components.Button({
+                    group: `[EqualizerRack1_[Channel${mapIndexToChannel(i)}]_Effect1]`,
+                    midi: [0x92, 0x28 + i],
+                    key: "button_parameter1",
+                    type: components.Button.prototype.types.toggle,
+                    off: engine.getSetting("eqOnColor"),
+                    on: engine.getSetting("eqOffColor"),
+                });
+                this.eqLayer[i + 12] = new components.Button({
+                    group: `[QuickEffectRack1_[Channel${mapIndexToChannel(i)}]]`,
+                    midi: [0x92, 0x24 + i],
+                    key: "enabled",
+                    type: components.Button.prototype.types.toggle,
+                    off: engine.getSetting("superOnColor"),
+                    on: engine.getSetting("superOffColor"),
+                });
+            }
+
+            this.samplerLayer = [];
+            for (let i = 0; i < 16; i++) {
+                this.samplerLayer[i] = new components.SamplerButton({
+                    number: i + 1,
+                    midi: [0x92, [
+                        0x50, 0x51, 0x52, 0x53,
+                        0x4C, 0x4D, 0x4E, 0x4F,
+                        0x48, 0x49, 0x4A, 0x4B,
+                        0x44, 0x45, 0x46, 0x47,
+                    ][i]],
+                    off: engine.getSetting("samplerEmptyColor"),
+                    on: engine.getSetting("samplerLoadedColor"),
+                });
+            }
+
+            this.activeDeck = new Deck();
+
+            // Layer selection. Since we're not connecting to any signals, just
+            // have one button and use its input function to set the LEDs.
+            this.selectCueDeck = new components.Button({
+                midi: [0x92, 0x34],
+                input: function(_channel, control, value, _status, group) {
+                    MidiFighterSpectra.controller.activeDeck.setCurrentDeck(group);
+                    this.output(value, group, control);
+                },
+                output: function(_value, _group, control) {
+                    for (let i = 0; i < 4; i++) {
+                        midi.sendShortMsg(this.midi[0], this.midi[1] + i, (control === this.midi[1] + i) ? this.on : this.off);
+                    }
+                },
+                on: engine.getSetting("deckSelectedColor"),
+                off: engine.getSetting("deckUnselectedColor"),
+            });
+            this.selectCueDeck.output(0x7F, "[Channel1]", 0x34);
+        }
+    }
+
+    // Functions for scaling a signed byte value to the scale expected to toggle
+    // an effect. Each value is a function except for "off", which always
+    const groundEffect = {
+        off: 18, // 18 is always off
+        on: function(value) { return (value / 127 * 15) + 19; }, // 19-33 brightness values
+        gate: function(value) { return (value / 127 * 7) + 34; }, // 34-41 sets the strobe rate
+        pulse: function(value) { return (value / 127 * 7) + 42; }, // 42-49 sets the pulse rate
+    };
+
+    MidiFighterSpectra.init = function() {
+        MidiFighterSpectra.controller = new Controller();
+
+        // Blink the ground effect LEDs when a track is ending.
+        MidiFighterSpectra.connections = [];
+        switch (engine.getSetting("groundEffectLed")) {
+        case "off":
+            break;
+        case "end_of_track":
+            MidiFighterSpectra.connections = MidiFighterSpectra.connections.concat([
+                engine.makeConnection("[Channel1]", "end_of_track", function(value) {
+                    midi.sendShortMsg(0x93, 0x13, (value === 0) ? groundEffect.off : groundEffect.pulse(75));
+                }),
+                engine.makeConnection("[Channel2]", "end_of_track", function(value) {
+                    midi.sendShortMsg(0x93, 0x11, (value === 0) ? groundEffect.off : groundEffect.pulse(75));
+                }),
+                engine.makeConnection("[Channel3]", "end_of_track", function(value) {
+                    midi.sendShortMsg(0x93, 0x12, (value === 0) ? groundEffect.off : groundEffect.pulse(75));
+                }),
+                engine.makeConnection("[Channel4]", "end_of_track", function(value) {
+                    midi.sendShortMsg(0x93, 0x10, (value === 0) ? groundEffect.off : groundEffect.pulse(75));
+                }),
+            ]);
+            break;
+        case "beat_active":
+            MidiFighterSpectra.connections = MidiFighterSpectra.connections.concat([
+                engine.makeConnection("[Channel1]", "beat_active", function(value) {
+                    midi.sendShortMsg(0x93, 0x13, (!value) ? groundEffect.off : groundEffect.on(127));
+                }),
+                engine.makeConnection("[Channel2]", "beat_active", function(value) {
+                    midi.sendShortMsg(0x93, 0x11, (!value) ? groundEffect.off : groundEffect.on(127));
+                }),
+                engine.makeConnection("[Channel3]", "beat_active", function(value) {
+                    midi.sendShortMsg(0x93, 0x12, (!value) ? groundEffect.off : groundEffect.on(127));
+                }),
+                engine.makeConnection("[Channel4]", "beat_active", function(value) {
+                    midi.sendShortMsg(0x93, 0x10, (!value) ? groundEffect.off : groundEffect.on(127));
+                }),
+            ]);
+            break;
+        };
+
+        // The manual says to send a C1-D#1 (ie. 0x18-0x1B), but it appears that
+        // you have to send 0x00-0x03 instead.
+        switch (engine.getSetting("defaultLayer")) {
+        case "eq":
+            midi.sendShortMsg(0x93, 0x00, 127);
+            break;
+        case "hotcues":
+            midi.sendShortMsg(0x93, 0x01, 127);
+            break;
+        case "samplers":
+            midi.sendShortMsg(0x93, 0x02, 127);
+            break;
+        }
+    };
+
+    MidiFighterSpectra.shutdown = function() {
+        MidiFighterSpectra.controller.shutdown();
+
+        for (const connection of MidiFighterSpectra.connections) {
+            connection.disconnect();
+        }
+
+        // Make sure we turn ground effect LEDs off when we shut down.
+        for (let i = 0x10; i <= 0x13; i++) {
+            midi.sendShortMsg(0x93, i, groundEffect.off);
+            midi.sendShortMsg(0x93, i, groundEffect.off);
+            midi.sendShortMsg(0x93, i, groundEffect.off);
+            midi.sendShortMsg(0x93, i, groundEffect.off);
+        }
+    };
+})(MidiFighterSpectra || (MidiFighterSpectra = {}));
+
+// vim:expandtab:tabstop=4:shiftwidth=4


### PR DESCRIPTION
This PR adds support for the [DJ TechTools MIDI Fighter Spectra](https://store.djtechtools.com/collections/midi-fighters-midi-fighter-accessories/products/midi-fighter-spectra)

Currently it has three layers:

- EQ/quick effect cutoff buttons
- Intro/outro, 8 hot cues, deck selection
- Samplers

There is one additional layer that's mapable and will be reserved for future use (see comments below).

The corresponding manual PR is here: mixxxdj/manual#746