### PR TITLE
(fix) stop BrowseThread::populateModel() when Mixxx should close

### DIFF
--- a/src/library/browse/browsethread.cpp
+++ b/src/library/browse/browsethread.cpp
@@ -143,7 +143,7 @@ void BrowseThread::populateModel() {
 
     int row = 0;
     // Iterate over the files
-    while (fileIt.hasNext()) {
+    while (!m_bStopThread && fileIt.hasNext()) {
         // If a user quickly jumps through the folders
         // the current task becomes "dirty"
         m_path_mutex.lock();


### PR DESCRIPTION
Else Mixxx is still running (without main window) while the thread keeps running until all tracks have been parsed, which may take quite a while with large directories.

IIUC the database is locked until Mixxx has been closed?
So a quick restart while such a huge file list is being processed will cause issues, no?