### PR TITLE
CMake: Join project() with enable_language()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,8 +338,7 @@ elseif(APPLE)
   endif()
 endif()
 
-project(mixxx VERSION 2.6.0)
-enable_language(C CXX)
+project(mixxx VERSION 2.6.0 LANGUAGES C CXX)
 # Work around missing version suffixes support https://gitlab.kitware.com/cmake/cmake/-/issues/16716
 set(MIXXX_VERSION_PRERELEASE "alpha") # set to "alpha" "beta" or ""
 


### PR DESCRIPTION
This avoids a bit redundant work

Found when debugging: 
https://github.com/mixxxdj/mixxx/issues/14560

The actual issue is however a the missing ucrtbased.dll. The version without d is installed by default on windows.  
I will file aseparate PR for that. 