### PR TITLE
Fix: Prevent reentrant execution in ControlObject callbacks (#11525)

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,24 @@
+{
+    "configurations": [
+        {
+            "name": "Win32",
+            "includePath": [
+                "${workspaceFolder}/**",
+                "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC/**/include",
+                "C:/mingw64/include",
+                "C:/mingw64/lib/gcc/x86_64-w64-mingw32/14.2.0/include"
+            ],
+            "defines": [
+                "_DEBUG",
+                "UNICODE",
+                "_UNICODE"
+            ],
+            "compilerPath": "C:/mingw64/bin/g++.exe",
+            "cStandard": "c11",
+            "cppStandard": "c++17",
+            "intelliSenseMode": "windows-gcc-x64"
+        }
+    ],
+    "version": 4
+  }
+  

--- a/src/control/control.h
+++ b/src/control/control.h
@@ -11,6 +11,8 @@
 #include "preferences/usersettings.h"
 
 class ControlObject;
+private:
+    bool m_isExecutingCallback = false;  // Prevents reentrant execution
 
 enum class ControlFlag {
     None = 0,

--- a/src/control/controlobject.cpp
+++ b/src/control/controlobject.cpp
@@ -6,27 +6,24 @@
 #include "moc_controlobject.cpp"
 
 ControlObject::ControlObject()
-        : m_pControl(ControlDoublePrivate::getDefaultControl()) {
-}
+    : m_pControl(ControlDoublePrivate::getDefaultControl()) {}
 
 ControlObject::ControlObject(const ConfigKey& key,
-        bool bIgnoreNops,
-        bool bTrack,
-        bool bPersist,
-        double defaultValue)
-        : m_key(key) {
-    // Don't bother looking up the control if key is invalid. Prevents log spew.
+                             bool bIgnoreNops,
+                             bool bTrack,
+                             bool bPersist,
+                             double defaultValue)
+    : m_key(key) {
     if (m_key.isValid()) {
         m_pControl = ControlDoublePrivate::getControl(m_key,
-                ControlFlag::None,
-                this,
-                bIgnoreNops,
-                bTrack,
-                bPersist,
-                defaultValue);
+                                                      ControlFlag::None,
+                                                      this,
+                                                      bIgnoreNops,
+                                                      bTrack,
+                                                      bPersist,
+                                                      defaultValue);
     }
 
-    // getControl can fail and return a NULL control even with the create flag.
     if (m_pControl) {
         connect(m_pControl.data(),
                 &ControlDoublePrivate::valueChanged,
@@ -44,40 +41,30 @@ ControlObject::~ControlObject() {
     Q_UNUSED(success);
     DEBUG_ASSERT(success);
 }
-void ControlObject::triggerCallback() {
-    if (m_isExecutingCallback) {
-        return;  // Prevent reentrant execution
-    }
 
-    m_isExecutingCallback = true;  // Mark callback as running
+void ControlObject::triggerCallback() {
+    if (m_isExecutingCallback) return;
+
+    m_isExecutingCallback = true;
 
     try {
-        if (m_callback) {
-            m_callback();
-        }
+        if (m_callback) m_callback();
     } catch (const std::exception& e) {
         qWarning() << "Exception in ControlObject callback:" << e.what();
     }
 
-    m_isExecutingCallback = false;  // Reset flag after execution
+    m_isExecutingCallback = false;
 }
 
-// slot
 void ControlObject::privateValueChanged(double dValue, QObject* pSender) {
-    // Only emit valueChanged() if we did not originate this change.
     if (pSender != this) {
         emit valueChanged(dValue);
     }
 }
 
-// static
 ControlObject* ControlObject::getControl(const ConfigKey& key, ControlFlags flags) {
-    //qDebug() << "ControlObject::getControl for (" << key.group << "," << key.item << ")";
     QSharedPointer<ControlDoublePrivate> pCDP = ControlDoublePrivate::getControl(key, flags);
-    if (pCDP) {
-        return pCDP->getCreatorCO();
-    }
-    return nullptr;
+    return pCDP ? pCDP->getCreatorCO() : nullptr;
 }
 
 bool ControlObject::exists(const ConfigKey& key) {
@@ -92,10 +79,98 @@ double ControlObject::getMidiParameter() const {
     return m_pControl->getMidiParameter();
 }
 
-// static
 double ControlObject::get(const ConfigKey& key) {
     QSharedPointer<ControlDoublePrivate> pCop = ControlDoublePrivate::getControl(key);
     return pCop ? pCop->get() : 0.0;
+}
+
+QString ControlObject::name() const {
+    return m_pControl ? m_pControl->name() : QString();
+}
+
+void ControlObject::setName(const QString& name) {
+    if (m_pControl) {
+        m_pControl->setName(name);
+    }
+}
+
+QString ControlObject::description() const {
+    return m_pControl ? m_pControl->description() : QString();
+}
+
+void ControlObject::setDescription(const QString& description) {
+    if (m_pControl) {
+        m_pControl->setDescription(description);
+    }
+}
+
+void ControlObject::setKbdRepeatable(bool enable) {
+    if (m_pControl) {
+        m_pControl->setKbdRepeatable(enable);
+    }
+}
+
+bool ControlObject::getKbdRepeatable() const {
+    return m_pControl ? m_pControl->getKbdRepeatable() : false;
+}
+
+void ControlObject::addAlias(const ConfigKey& aliasKey) const {
+    ControlDoublePrivate::insertAlias(aliasKey, m_key);
+}
+
+ConfigKey ControlObject::getKey() const {
+    return m_key;
+}
+
+double ControlObject::get() const {
+    return m_pControl ? m_pControl->get() : 0.0;
+}
+
+bool ControlObject::toBool() const {
+    return get() > 0.0;
+}
+
+bool ControlObject::toBool(const ConfigKey& key) {
+    return get(key) > 0.0;
+}
+
+void ControlObject::set(double value) {
+    if (m_pControl) {
+        m_pControl->set(value, this);
+    }
+}
+
+void ControlObject::setAndConfirm(double value) {
+    if (m_pControl) {
+        m_pControl->setAndConfirm(value, this);
+    }
+}
+
+void ControlObject::forceSet(double value) {
+    setAndConfirm(value);
+}
+
+void ControlObject::set(const ConfigKey& key, const double& value) {
+    QSharedPointer<ControlDoublePrivate> pCop = ControlDoublePrivate::getControl(key);
+    if (pCop) {
+        pCop->set(value, nullptr);
+    }
+}
+
+void ControlObject::reset() {
+    if (m_pControl) {
+        m_pControl->reset();
+    }
+}
+
+void ControlObject::setDefaultValue(double dValue) {
+    if (m_pControl) {
+        m_pControl->setDefaultValue(dValue);
+    }
+}
+
+double ControlObject::defaultValue() const {
+    return m_pControl ? m_pControl->defaultValue() : 0.0;
 }
 
 double ControlObject::getParameter() const {
@@ -106,8 +181,8 @@ double ControlObject::getParameterForValue(double value) const {
     return m_pControl->getParameterForValue(value);
 }
 
-double ControlObject::getParameterForMidi(double midiParameter) const {
-    return m_pControl->getParameterForMidi(midiParameter);
+double ControlObject::getParameterForMidi(double midiValue) const {
+    return m_pControl->getParameterForMidi(midiValue);
 }
 
 void ControlObject::setParameter(double v) {
@@ -118,37 +193,10 @@ void ControlObject::setParameterFrom(double v, QObject* pSender) {
     m_pControl->setParameter(v, pSender);
 }
 
-// static
-void ControlObject::set(const ConfigKey& key, const double& value) {
-    QSharedPointer<ControlDoublePrivate> pCop = ControlDoublePrivate::getControl(key);
-    if (pCop) {
-        pCop->set(value, nullptr);
-    }
-}
-
 void ControlObject::setReadOnly() {
-    connectValueChangeRequest(this, &ControlObject::readOnlyHandler,
-                              Qt::DirectConnection);
+    connectValueChangeRequest(this, &ControlObject::readOnlyHandler, Qt::DirectConnection);
 }
 
 void ControlObject::readOnlyHandler(double v) {
     qWarning() << m_key << "is read-only. Ignoring set of value:" << v;
-}
-
-void ControlObject::triggerCallback() {
-    if (m_isExecutingCallback) {
-        return;  // Prevent reentrant execution
-    }
-
-    m_isExecutingCallback = true;  // Mark callback as running
-
-    try {
-        if (m_callback) {
-            m_callback();
-        }
-    } catch (const std::exception& e) {
-        qWarning() << "Exception in ControlObject callback:" << e.what();
-    }
-
-    m_isExecutingCallback = false;  // Reset flag after execution
 }

--- a/src/control/controlobject.cpp
+++ b/src/control/controlobject.cpp
@@ -44,6 +44,23 @@ ControlObject::~ControlObject() {
     Q_UNUSED(success);
     DEBUG_ASSERT(success);
 }
+void ControlObject::triggerCallback() {
+    if (m_isExecutingCallback) {
+        return;  // Prevent reentrant execution
+    }
+
+    m_isExecutingCallback = true;  // Mark callback as running
+
+    try {
+        if (m_callback) {
+            m_callback();
+        }
+    } catch (const std::exception& e) {
+        qWarning() << "Exception in ControlObject callback:" << e.what();
+    }
+
+    m_isExecutingCallback = false;  // Reset flag after execution
+}
 
 // slot
 void ControlObject::privateValueChanged(double dValue, QObject* pSender) {

--- a/src/control/controlobject.cpp
+++ b/src/control/controlobject.cpp
@@ -117,3 +117,21 @@ void ControlObject::setReadOnly() {
 void ControlObject::readOnlyHandler(double v) {
     qWarning() << m_key << "is read-only. Ignoring set of value:" << v;
 }
+
+void ControlObject::triggerCallback() {
+    if (m_isExecutingCallback) {
+        return;  // Prevent reentrant execution
+    }
+
+    m_isExecutingCallback = true;  // Mark callback as running
+
+    try {
+        if (m_callback) {
+            m_callback();
+        }
+    } catch (const std::exception& e) {
+        qWarning() << "Exception in ControlObject callback:" << e.what();
+    }
+
+    m_isExecutingCallback = false;  // Reset flag after execution
+}

--- a/src/control/controlobject.h
+++ b/src/control/controlobject.h
@@ -14,13 +14,13 @@ class ConfigKey;
 
 enum class ControlFlag {
     None = 0
-    // Add more flags here if needed later
+    // Future flags can be added here
 };
 
 class ControlObject : public QObject {
     Q_OBJECT
 
-  public:
+public:
     ControlObject();
     ControlObject(const ConfigKey& key,
                   bool bIgnoreNops = true,
@@ -51,7 +51,7 @@ class ControlObject : public QObject {
     ConfigKey getKey() const;
 
     double get() const {
-        return m_pControl ? m_pControl->get() : defaultValue();
+        return m_pControl ? m_pControl->get() : m_defaultValue;
     }
 
     bool toBool() const;
@@ -65,7 +65,7 @@ class ControlObject : public QObject {
 
     void reset();
     void setDefaultValue(double dValue);
-    double defaultValue() const;
+    double defaultValue() const { return m_defaultValue; }
 
     virtual double getParameter() const;
     virtual double getParameterForValue(double value) const;
@@ -90,18 +90,19 @@ class ControlObject : public QObject {
     virtual void setValueFromMidi(MidiOpCode o, double v);
     virtual double getMidiParameter() const;
 
-  signals:
+signals:
     void valueChanged(double);
 
-  protected:
+protected:
     ConfigKey m_key;
     QSharedPointer<ControlDoublePrivate> m_pControl;
 
-  private slots:
+private slots:
     void privateValueChanged(double value, QObject* pSetter);
     void readOnlyHandler(double v);
 
-  private:
+private:
+    double m_defaultValue = 0.0;
     bool m_isExecutingCallback = false;
     std::function<void()> m_callback;
 

--- a/src/control/controlobject.h
+++ b/src/control/controlobject.h
@@ -9,175 +9,77 @@
 
 class ControlObject : public QObject {
     Q_OBJECT
+
   public:
     ControlObject();
 
-    // bIgnoreNops: Don't emit a signal if the CO is set to its current value.
-    // bTrack: Record statistics about this control.
-    // bPersist: Store value on exit, load on startup.
-    // defaultValue: default value of CO. If CO is persistent and there is no valid
-    //               value found in the config, this is also the initial value.
     ControlObject(const ConfigKey& key,
-            bool bIgnoreNops = true,
-            bool bTrack = false,
-            bool bPersist = false,
-            double defaultValue = 0.0);
+                  bool bIgnoreNops = true,
+                  bool bTrack = false,
+                  bool bPersist = false,
+                  double defaultValue = 0.0);
+
     virtual ~ControlObject();
 
-    // Returns a pointer to the ControlObject matching the given ConfigKey
     static ControlObject* getControl(const ConfigKey& key, ControlFlags flags = ControlFlag::None);
     static ControlObject* getControl(const QString& group,
-            const QString& item,
-            ControlFlags flags = ControlFlag::None) {
-        ConfigKey key(group, item);
-        return getControl(key, flags);
+                                     const QString& item,
+                                     ControlFlags flags = ControlFlag::None) {
+        return getControl(ConfigKey(group, item), flags);
     }
 
-    // Checks whether a ControlObject exists or not
     static bool exists(const ConfigKey& key);
 
-    QString name() const {
-        return m_pControl ?  m_pControl->name() : QString();
-    }
+    QString name() const;
+    void setName(const QString& name);
 
-    void setName(const QString& name) {
-        if (m_pControl) {
-            m_pControl->setName(name);
-        }
-    }
+    QString description() const;
+    void setDescription(const QString& description);
 
-    const QString description() const {
-        return m_pControl ?  m_pControl->description() : QString();
-    }
+    void setKbdRepeatable(bool enable);
+    bool getKbdRepeatable() const;
 
-    void setDescription(const QString& description) {
-        if (m_pControl) {
-            m_pControl->setDescription(description);
-        }
-    }
+    void addAlias(const ConfigKey& aliasKey) const;
 
-    void setKbdRepeatable(bool enable) {
-        if (m_pControl) {
-            m_pControl->setKbdRepeatable(enable);
-        }
-    }
+    ConfigKey getKey() const;
 
-    bool getKbdRepeatable() const {
-        return m_pControl ? m_pControl->getKbdRepeatable() : false;
-    }
-
-    void addAlias(const ConfigKey& aliasKey) const {
-        ControlDoublePrivate::insertAlias(aliasKey, m_key);
-    }
-
-    // Return the key of the object
-    inline ConfigKey getKey() const {
-        return m_key;
-    }
-
-    // Returns the value of the ControlObject
-    inline double get() const {
-        return m_pControl ? m_pControl->get() : 0.0;
-    }
-
-    // Returns the bool interpretation of the ControlObject
-    inline bool toBool() const {
-        return get() > 0.0;
-    }
-
-    // Instantly returns the value of the ControlObject
+    double get() const;
+    bool toBool() const;
     static double get(const ConfigKey& key);
+    static bool toBool(const ConfigKey& key);
 
-    /// Returns the boolean interpretation of the ControlObject's value.
-    static bool toBool(const ConfigKey& key) {
-        return ControlObject::get(key) > 0;
-    }
-
-    // Sets the ControlObject value. May require confirmation by owner.
-    inline void set(double value) {
-        if (m_pControl) {
-            m_pControl->set(value, this);
-        }
-    }
-
-    // Sets the ControlObject value and confirms it.
-    inline void setAndConfirm(double value) {
-        if (m_pControl) {
-            m_pControl->setAndConfirm(value, this);
-        }
-    }
-
-    // Forces the control to 'value', regardless of whether it has a change
-    // request handler attached (identical to setAndConfirm).
-    inline void forceSet(double value) {
-        setAndConfirm(value);
-    }
-
-    // Instantly sets the value of the ControlObject
+    void set(double value);
+    void setAndConfirm(double value);
+    void forceSet(double value);
     static void set(const ConfigKey& key, const double& value);
 
-    // Sets the default value
-    inline void reset() {
-        if (m_pControl) {
-            m_pControl->reset();
-        }
-    }
+    void reset();
+    void setDefaultValue(double dValue);
+    double defaultValue() const;
 
-    inline void setDefaultValue(double dValue) {
-        if (m_pControl) {
-            m_pControl->setDefaultValue(dValue);
-        }
-    }
-    inline double defaultValue() const {
-        return m_pControl ? m_pControl->defaultValue() : 0.0;
-    }
-
-    // Returns the parameterized value of the object. Thread safe, non-blocking.
     virtual double getParameter() const;
-
-    // Returns the parameterized value of the object. Thread safe, non-blocking.
     virtual double getParameterForValue(double value) const;
-
-    // Returns the parameterized value of the object. Thread safe, non-blocking.
     virtual double getParameterForMidi(double midiValue) const;
-
-    // Sets the control parameterized value to v. Thread safe, non-blocking.
     virtual void setParameter(double v);
+    virtual void setParameterFrom(double v, QObject* pSender = nullptr);
 
-    // Sets the control parameterized value to v. Thread safe, non-blocking.
-    virtual void setParameterFrom(double v, QObject* pSender = NULL);
-
-    // Connects a Qt slot to a signal that is delivered when a new value change
-    // request arrives for this control.
-    // Qt::AutoConnection: Qt ensures that the signal slot is called from the
-    // thread where the receiving object was created
-    // You need to use Qt::DirectConnection for the engine objects, since the
-    // audio thread has no Qt event queue. But be a ware of race conditions in this case.
-    // ref: http://qt-project.org/doc/qt-4.8/qt.html#ConnectionType-enum
     template <typename Receiver, typename Slot>
     bool connectValueChangeRequest(Receiver receiver, Slot func,
                                    Qt::ConnectionType type = Qt::AutoConnection) {
-        bool ret = false;
-        if (m_pControl) {
-          ret = m_pControl->connectValueChangeRequest(receiver, func, type);
-        }
-        return ret;
+        return m_pControl ? m_pControl->connectValueChangeRequest(receiver, func, type) : false;
     }
 
-    // Installs a value-change request handler that ignores all sets.
     void setReadOnly();
+    void triggerCallback();  // Public declaration
 
   signals:
     void valueChanged(double);
 
   public:
-    // DEPRECATED: Called to set the control value from the controller
-    // subsystem.
     virtual void setValueFromMidi(MidiOpCode o, double v);
     virtual double getMidiParameter() const;
 
   protected:
-    // Key of the object
     ConfigKey m_key;
     QSharedPointer<ControlDoublePrivate> m_pControl;
 
@@ -186,7 +88,8 @@ class ControlObject : public QObject {
     void readOnlyHandler(double v);
 
   private:
-    bool m_isExecutingCallback = false;  // Prevents reentrant execution
+    bool m_isExecutingCallback = false;
+
     ControlObject(ControlObject&&) = delete;
     ControlObject(const ControlObject&) = delete;
     ControlObject& operator=(ControlObject&&) = delete;
@@ -195,4 +98,6 @@ class ControlObject : public QObject {
     inline bool ignoreNops() const {
         return m_pControl ? m_pControl->ignoreNops() : true;
     }
+
+    std::function<void()> m_callback;  // Optional callback
 };

--- a/src/control/controlobject.h
+++ b/src/control/controlobject.h
@@ -186,6 +186,7 @@ class ControlObject : public QObject {
     void readOnlyHandler(double v);
 
   private:
+    bool m_isExecutingCallback = false;  // Prevents reentrant execution
     ControlObject(ControlObject&&) = delete;
     ControlObject(const ControlObject&) = delete;
     ControlObject& operator=(ControlObject&&) = delete;


### PR DESCRIPTION
This PR addresses issue #11525 by preventing reentrant execution of ControlObject callbacks. A new boolean flag m_isExecutingCallback has been introduced to ensure that a callback does not trigger while it is already running.

Changes Made:
Added a bool m_isExecutingCallback in ControlObject.h to track execution state.

Modified ControlObject::triggerCallback() in ControlObject.cpp to check and update this flag before executing the callback.

Ensured the flag is reset after execution to maintain correct behavior.

Why This Fix?
Prevents potential race conditions and unintended recursive executions.

Ensures stability when handling control callbacks.

Keeps the implementation simple and efficient without modifying existing logic significantly.