### PR TITLE
Search: add BPM lock filter `bpm:locked`

### DIFF
--- a/src/library/searchquery.h
+++ b/src/library/searchquery.h
@@ -205,6 +205,7 @@ class BpmFilterNode : public QueryNode {
         HalveDouble,       // bpm:120
         HalveDoubleStrict, // bpm:120.0
         Operator,          // bpm:<=120
+        Locked,            // bpm:locked
     };
 
     // Allows WSearchRelatedTracksMenu to construct the QAction title


### PR DESCRIPTION
Extends `BpmFilterNode` to check for `locked` arg:
`bpm:locked` / `-bpm:locked`

Fixes #14583 