### PR TITLE
Show effect knob values on click ( Feature: #14374 )

### DIFF
--- a/src/effects/backends/effectmanifestparameter.h
+++ b/src/effects/backends/effectmanifestparameter.h
@@ -340,6 +340,23 @@ class EffectManifestParameter {
         return m_steps;
     }
 
+    /// Converts a raw parameter value into a readable string with units (e.g., "0.25" → "250 ms").
+    /// Handles formatting for integral/toggle vs. continuous values.
+    /// Used by UI components like knobs and labels to show user-friendly tooltips.
+    QString valueToString(double value) const {
+        // Clamp value between allowed min and max
+        double clamped = std::clamp(value, m_minimum, m_maximum);
+
+        QString unit = m_unitString.isEmpty() ? QString() : QStringLiteral(" ") + m_unitString;
+
+        // Format based on scaler type
+        if (m_valueScaler == ValueScaler::Toggle || m_valueScaler == ValueScaler::Integral) {
+            return QString::number(static_cast<int>(clamped)) + unit;
+        } else {
+            return QString::number(clamped, 'f', 2) + unit;
+        }
+    }
+
   private:
     void setParameterType(const ParameterType parameterType) {
         m_parameterType = parameterType;

--- a/src/effects/effectparameterslotbase.h
+++ b/src/effects/effectparameterslotbase.h
@@ -4,7 +4,9 @@
 #include <QString>
 #include <optional>
 
+#include "effects/backends/effectmanifest.h"
 #include "effects/backends/effectmanifestparameter.h"
+#include "effects/effectparameter.h"
 #include "util/class.h"
 
 class ControlObject;
@@ -24,6 +26,16 @@ class EffectParameterSlotBase : public QObject {
     EffectParameterSlotBase(const QString& group,
             const unsigned int iParameterSlotNumber,
             const EffectParameterType parameterType);
+
+    // Returns the current value of the associated effect parameter, if loaded.
+    // Used for displaying meaningful values in the UI (e.g., in tooltips).
+    // Returns 0.0 if no parameter is currently loaded.
+    double currentParameterValue() const {
+        if (m_pEffectParameter) {
+            return m_pEffectParameter->getValue();
+        }
+        return 0.0;
+    }
 
     ~EffectParameterSlotBase() override;
 

--- a/src/widget/weffectknobparametername.cpp
+++ b/src/widget/weffectknobparametername.cpp
@@ -2,6 +2,24 @@
 
 #include "moc_weffectknobparametername.cpp"
 #include "widget/effectwidgetutils.h"
+#include "widget/weffectparameterknobcomposed.h" // Included the knob widget header to allow linking with the label.
+
+// Helper function to get a sibling widget of a specific type (e.g., knob <-> label)
+// within the same parent container. This allows the label and knob to find each other.
+template<typename T>
+T* getSiblingOfType(QWidget* pWidget) {
+    if (!pWidget || !pWidget->parentWidget()) {
+        return nullptr;
+    }
+
+    const auto children = pWidget->parentWidget()->findChildren<T*>();
+    for (T* pChild : children) {
+        if (pChild != pWidget) {
+            return pChild;
+        }
+    }
+    return nullptr;
+}
 
 WEffectKnobParameterName::WEffectKnobParameterName(
         QWidget* pParent, EffectsManager* pEffectsManager)
@@ -25,4 +43,12 @@ void WEffectKnobParameterName::setup(const QDomNode& node, const SkinContext& co
                                "effect parameter"));
     }
     setEffectParameterSlot(m_pParameterSlot);
+
+    // Our new connection to the knob.
+    // Attempt to find the sibling knob associated with this label, and connect them.
+    // This allows the knob to access the label for tooltip fallback text.
+    WEffectParameterKnobComposed* pKnob = getSiblingOfType<WEffectParameterKnobComposed>(this);
+    if (pKnob) {
+        pKnob->setLabelPointer(this);
+    }
 }

--- a/src/widget/weffectparameterknobcomposed.cpp
+++ b/src/widget/weffectparameterknobcomposed.cpp
@@ -4,6 +4,11 @@
 #include "effects/presets/effectchainpreset.h"
 #include "moc_weffectparameterknobcomposed.cpp"
 #include "widget/effectwidgetutils.h"
+//// Included this headers for QToolTip, label access, and manifest for dynamic tooltip display.
+#include <QToolTip>
+
+#include "effects/backends/effectmanifestparameter.h"
+#include "widget/weffectknobparametername.h"
 
 void WEffectParameterKnobComposed::setup(const QDomNode& node, const SkinContext& context) {
     WKnobComposed::setup(node, context);
@@ -34,5 +39,31 @@ void WEffectParameterKnobComposed::parameterUpdated() {
         // The knob should be hidden by the skin when the parameterX_loaded ControlObject
         // indicates no parameter is loaded, so this tooltip should never be shown.
         setBaseTooltip("");
+    }
+}
+
+// Override mousePressEvent to show a tooltip with the parameter name and its
+// current value (with correct unit). Falls back to label text if unavailable.
+void WEffectParameterKnobComposed::mousePressEvent(QMouseEvent* e) {
+    WKnobComposed::mousePressEvent(e);
+
+    if (m_pEffectParameterSlot && m_pEffectParameterSlot->isLoaded()) {
+        EffectManifestParameterPointer pManifest = m_pEffectParameterSlot->getManifest();
+        if (pManifest) {
+            QString name = pManifest->name();
+            double value = m_pEffectParameterSlot->currentParameterValue();
+            QString valueStr = pManifest->valueToString(value);
+
+            QString tooltip = QString("%1: %2").arg(name, valueStr);
+            QToolTip::showText(e->globalPosition().toPoint(), tooltip, this);
+            return;
+        }
+    }
+    // fallback: show label
+    if (m_pLabel) {
+        QString labelText = m_pLabel->text();
+        if (!labelText.isEmpty()) {
+            QToolTip::showText(e->globalPosition().toPoint(), labelText, this);
+        }
     }
 }

--- a/src/widget/weffectparameterknobcomposed.h
+++ b/src/widget/weffectparameterknobcomposed.h
@@ -1,9 +1,12 @@
 #pragma once
 
 #include "effects/defs.h"
+#include "widget/weffectknobparametername.h" // Forward declaration for label widget to avoid circular dependency.
 #include "widget/wknobcomposed.h"
 
 class EffectsManager;
+class WEffectKnobParameterName; // Forward declare WEffectKnobParameterName to
+                                // allow usage in setLabelPointer().
 
 // This is used for effect parameter knobs with dynamic
 // tooltips, if the knob value is displayed by rotating a
@@ -22,10 +25,21 @@ class WEffectParameterKnobComposed : public WKnobComposed {
 
     void setup(const QDomNode& node, const SkinContext& context) override;
 
+    // Connecting the knob with its label.
+    // Allow linking a label widget to this knob so it can be used as a fallback
+    // in the tooltip when parameter info is unavailable.
+    void setLabelPointer(WEffectKnobParameterName* pLabel) {
+        m_pLabel = pLabel;
+    }
+    void mousePressEvent(QMouseEvent* e) override;
   private slots:
     void parameterUpdated();
 
   private:
     EffectsManager* m_pEffectsManager;
     EffectParameterSlotBasePointer m_pEffectParameterSlot;
+    WEffectKnobParameterName* m_pLabel =
+            nullptr; // Pointer to associated label. Pointer to the associated
+                     // label widget (if available). Used for fallback tooltip
+                     // when parameter data is missing.
 };


### PR DESCRIPTION
Fixes #14374 
Related to #11041 

-Shows knob name and realtime parameter value in tooltips on click (before move).
-Added valueToString function to format knob value with units -Linked tooltip display between WEffectParameterKnobComposed and WEffectKnobParameterName.
-Caches and updates knob tooltip dynamically based on internal state.
Considered this : https://github.com/mixxxdj/mixxx/issues/14374#issuecomment-2765801236
This is my first contribution to Mixxx. I’d really appreciate any feedback or suggestions to improve the implementation.
![Screenshot (1318)](https://github.com/user-attachments/assets/1a075d0e-e07d-4c2c-bf12-d7ce83932af9)
![Screenshot (1319)](https://github.com/user-attachments/assets/8332a94c-13d2-43b0-b366-97ac40e40c25)
![Screenshot (1317)](https://github.com/user-attachments/assets/eb92df59-abb5-450d-8249-88d8054e38d2)