### PR TITLE
(fix/Qt6) Skins: center effect parameter names

### DIFF
--- a/res/skins/Deere/effect_parameter_button.xml
+++ b/res/skins/Deere/effect_parameter_button.xml
@@ -44,6 +44,7 @@
             <MinimumSize>34,15</MinimumSize>
             <MaximumSize>58,15</MaximumSize>
             <SizePolicy>me,f</SizePolicy>
+            <Alignment>center</Alignment>
             <Elide>right</Elide>
             <ObjectName>EffectButtonLabel</ObjectName>
             <EffectRack><Variable name="EffectRack"/></EffectRack>

--- a/res/skins/Deere/effect_parameter_knob.xml
+++ b/res/skins/Deere/effect_parameter_knob.xml
@@ -46,6 +46,7 @@
         <EffectUnit><Variable name="EffectUnit"/></EffectUnit>
         <Effect><Variable name="Effect"/></Effect>
         <EffectParameter><Variable name="EffectParameter"/></EffectParameter>
+        <Alignment>center</Alignment>
         <Elide>right</Elide>
       </EffectParameterName>
 

--- a/res/skins/LateNight/fx/parameter_button.xml
+++ b/res/skins/LateNight/fx/parameter_button.xml
@@ -61,6 +61,7 @@
         <Effect><Variable name="FxNum"/></Effect>
         <EffectButtonParameter><Variable name="FxParameter"/></EffectButtonParameter>
         <Alignment>center</Alignment>
+        <Elide>right</Elide>
       </EffectButtonParameterName>
 
     </Children>

--- a/res/skins/LateNight/fx/parameter_knob.xml
+++ b/res/skins/LateNight/fx/parameter_knob.xml
@@ -54,6 +54,7 @@
         <EffectUnit><Variable name="FxUnit"/></EffectUnit>
         <Effect><Variable name="FxNum"/></Effect>
         <EffectParameter><Variable name="FxParameter"/></EffectParameter>
+        <Alignment>center</Alignment>
         <Elide>right</Elide>
       </EffectParameterName>
 

--- a/res/skins/Tango/fx/parameter_knob.xml
+++ b/res/skins/Tango/fx/parameter_knob.xml
@@ -60,6 +60,7 @@ Variables:
             <EffectUnit><Variable name="FxUnit"/></EffectUnit>
             <Effect><Variable name="FxNum"/></Effect>
             <EffectParameter><Variable name="FxParameter"/></EffectParameter>
+            <Alignment>center</Alignment>
             <Elide>right</Elide>
           </EffectParameterName>
         </Children>


### PR DESCRIPTION
Knob parameter names are left-aligned with Qt6
Apparently `QLabel{text-align: center;}` doesn't work anymore, or is broken by setting `Elide`, idk.

**edit** I see this with Qt 6.2.3, which I know is outdated. But IIRC Alignment wasn't working with Qt5 that's why we used `text-align` in qss instead.