### PR TITLE
fix: don't connect to WaveformFactory on SceneGraph implem

### DIFF
--- a/src/waveform/renderers/allshader/waveformrendermark.cpp
+++ b/src/waveform/renderers/allshader/waveformrendermark.cpp
@@ -176,7 +176,7 @@ allshader::WaveformRenderMark::WaveformRenderMark(
         m_pPlayPosNode->initForRectangles<TextureMaterial>(1);
         appendChildNode(std::move(pNode));
     }
-
+#ifndef __SCENEGRAPH__
     auto* pWaveformWidgetFactory = WaveformWidgetFactory::instance();
     connect(pWaveformWidgetFactory,
             &WaveformWidgetFactory::untilMarkShowBeatsChanged,
@@ -198,6 +198,7 @@ allshader::WaveformRenderMark::WaveformRenderMark(
             &WaveformWidgetFactory::untilMarkTextHeightLimitChanged,
             this,
             &WaveformRenderMark::setUntilMarkTextHeightLimit);
+#endif
 }
 
 void allshader::WaveformRenderMark::draw(QPainter*, QPaintEvent*) {


### PR DESCRIPTION
Fix warnings related to a connect on a `nullptr`, since the WaveformFactory is not used on SceneGraph