### PR TITLE
Support the Icon P1-Nano controller

### DIFF
--- a/res/controllers/Icon-P1Nano-scripts.js
+++ b/res/controllers/Icon-P1Nano-scripts.js
@@ -106,9 +106,12 @@ var P1Nano;
     };
 
     const fmtSeconds = function(value, ext=false) {
-        const minutes = Math.floor(value / 60).toString().padStart(2, 0);
-        const seconds = Math.floor(value - minutes * 60).toString().padStart(2, 0);
-        const ms = Math.floor(((value - (minutes * 60) - seconds) % 1) * 60).toString().padStart(2, 0);
+        const minutes = Math.floor(value / 60).toString()
+            .padStart(2, 0);
+        const seconds = Math.floor(value - minutes * 60).toString()
+            .padStart(2, 0);
+        const ms = Math.floor(((value - (minutes * 60) - seconds) % 1) * 60).toString()
+            .padStart(2, 0);
 
         // Don't list hours, chances are most DJ songs aren't that long.
         let out = `${minutes}.${seconds}`;

--- a/res/controllers/Icon-P1Nano-scripts.js
+++ b/res/controllers/Icon-P1Nano-scripts.js
@@ -106,19 +106,19 @@ var P1Nano;
     };
 
     const fmtSeconds = function(value, ext=false) {
-        const minutes = Math.floor(value / 60);
-        const seconds = Math.floor(value - minutes * 60);
-        const ms = Math.floor(((value - (minutes * 60) - seconds) % 1) * 60);
+        const minutes = Math.floor(value / 60).toString().padStart(2, 0);
+        const seconds = Math.floor(value - minutes * 60).toString().padStart(2, 0);
+        const ms = Math.floor(((value - (minutes * 60) - seconds) % 1) * 60).toString().padStart(2, 0);
 
         // Don't list hours, chances are most DJ songs aren't that long.
-        let out = `${minutes.toString().padStart(2, 0)  }.${  seconds.toString().padStart(2, 0)}`;
+        let out = `${minutes}.${seconds}`;
         if (ext) {
             // Note that this is *different* from what Mixxx displays (the
             // fractional part) because we use '.' as a separator to save space
             // on the display so if we did "00.00.01" (as opposed to "00:00.01")
             // you can't tell that the last part is a fractional part (and not
             // milliseconds).
-            out += `.${  ms.toString().padStart(2, 0)}`;
+            out += `.${ms}`;
         }
         return out;
     };

--- a/res/controllers/Icon-P1Nano-scripts.js
+++ b/res/controllers/Icon-P1Nano-scripts.js
@@ -1,0 +1,768 @@
+"use strict";
+
+// eslint-disable-next-line no-var
+var P1Nano;
+(function(P1Nano) {
+    const SysexHeader = [0xF0, 0x00, 0x02, 0x4E];
+    const MCUHeader = [0xF0, 0x00, 0x00, 0x66, 0x14];
+
+    // Print a number (and only a number) to the 10 digit seven segment display.
+    const printSevenSeg = function(num, offset=0) {
+        // Differences from the MCU spec:
+        // - This should support ASCII plus some special characters, but this
+        //   device only appears to support numbers (0x30–0x39) plus the dot
+        //   (set bit 6, ie. a bitmask of 0x40).
+        // - The assignment block (0x4B and 0x4A) of the display doesn't exist.
+        switch (typeof num) {
+        case "number":
+            num = num.toString().toInt();
+            break;
+        case "string":
+            num = num.toInt();
+            break;
+        }
+        const printNum = [];
+        for (const c of num) {
+            // Encode the characters for the display.
+            switch (c) {
+            case 0x2E: // "."
+                // If we encounter a dot ".", set bit 6 on the previous
+                // character (activating the 8th segment '.').
+                printNum[printNum.length - 1] |= 0x40;
+                break;
+            case 0x2D: // "-"
+                // Honestly not sure if this is a deliberately supported
+                // character or just a quirk of the incomplete
+                // implementation, but 0x3B appears to be just the middle
+                // segment of the display.
+                printNum.push(0x3B);
+                break;
+            default:
+                printNum.push(c);
+                break;
+            }
+        }
+
+        const displayLen = 10 - offset;
+
+        for (let i = 0; i < displayLen; i++) {
+            const cursor = 0x49 - i - offset;
+            if (i < printNum.length) {
+                midi.sendShortMsg(0xB0, cursor, printNum[i]);
+            } else {
+                // Clear the remainder of the screen.
+                midi.sendShortMsg(0xB0, cursor, 0x20);
+            }
+        }
+    };
+
+    const printScreenName = function(idx, name, row=0) {
+        const maxLen = 7;
+        if (name.length > maxLen) {
+            console.log(`Trimmed text longer than ${maxLen} bytes: "${name}"`);
+            name = name.slice(0, maxLen);
+        }
+        name = name.padEnd(7, " ");
+        midi.sendSysexMsg(MCUHeader
+            .concat([0x12, (idx * maxLen) + (row * 56)])
+            .concat(name.toInt())
+            .concat([0xF7]));
+    };
+
+    const printLCDDisplay = function(channelIndex, text, row=0) {
+        // The MCU spec indicates that a there should be a two rowsstrip of 55
+        // dot-matrix displays (and a 56 byte buffer with a newline character at
+        // the end of each line).
+        //
+        // However, each LCD screen can print 7 characters per line, but on
+        // every screen but the first one the second character gets skipped and
+        // a space is always printed instead.
+        // I can only assume this is a bug? Unclear.
+        // To work around this weirdness, treat the LCDs as supporting a max of
+        // 5 characters and prepend some padding to skip the first two.
+        //
+        // The first screen will accept 7 characters, but only prints 6.
+
+        const maxLen = 5;
+        if (text.length > maxLen) {
+            console.log(`Trimmed text longer than ${maxLen} bytes: "${text}"`);
+            text = text.slice(0, maxLen);
+        }
+        text = ` ${text}`;
+        // Also add some padding at the end to clear anything that was already
+        // printed to this row (if we're not taking up the full length already).
+        text += " ".repeat(7 - text.length);
+
+        // Who knows…  seems to line everything up nicely, but I have no idea
+        // what's going on with the offsets here.
+        const trim = channelIndex - 1;
+        const offset = (row * 56) + ((channelIndex % 8) * 7) - trim;
+        const payload = SysexHeader.concat([0x15, 0x13]);
+        payload.push(offset);
+        payload.push(...text.toInt());
+        payload.push(0xF7);
+
+        midi.sendSysexMsg(payload);
+    };
+
+    const fmtSeconds = function(value, ext=false) {
+        const minutes = Math.floor(value / 60);
+        const seconds = Math.floor(value - minutes * 60);
+        const ms = Math.floor(((value - (minutes * 60) - seconds) % 1) * 60);
+
+        // Don't list hours, chances are most DJ songs aren't that long.
+        let out = `${minutes.toString().padStart(2, 0)  }.${  seconds.toString().padStart(2, 0)}`;
+        if (ext) {
+            // Note that this is *different* from what Mixxx displays (the
+            // fractional part) because we use '.' as a separator to save space
+            // on the display so if we did "00.00.01" (as opposed to "00:00.01")
+            // you can't tell that the last part is a fractional part (and not
+            // milliseconds).
+            out += `.${  ms.toString().padStart(2, 0)}`;
+        }
+        return out;
+    };
+
+    // Displays the play position on the 7-segment display.
+    class PlayPosition extends components.Component {
+        constructor(params) {
+            super(Object.assign({
+                outKey: "playposition",
+                firstOut: false,
+            }, params));
+        }
+
+        shutdown() {
+            // Clear the display on shutdown.
+            printSevenSeg("");
+        }
+
+        output(value, _group, control) {
+            // If the display is disabled, clear whatever was on it before the
+            // first time we'd update it, then don't send any further updates.
+            if (engine.getSetting("disableTimeDisplay")) {
+                if (!this.firstOut) {
+                    printSevenSeg("");
+                    this.firstOut = true;
+                }
+                return;
+            }
+            const playPos = (control === "playposition") ? value : engine.getValue(this.group, this.outKey);
+            const dur = engine.getValue(this.group, "duration");
+            const showDur = control === "ShowDurationRemaining" ? value : engine.getValue("[Controls]", "ShowDurationRemaining");
+            let time = "";
+            switch (showDur) {
+            case 0:
+                // Showing elapsed time
+                time = fmtSeconds(playPos * dur, true);
+                break;
+            case 1:
+                // Showing remaining time
+                time = `-${  fmtSeconds(dur - (playPos * dur), true)}`;
+                break;
+            case 2:
+                // Showing both
+                time = `${fmtSeconds(playPos * dur)  } -${  fmtSeconds(dur - (playPos * dur))}`;
+                break;
+            }
+            printSevenSeg(time);
+        }
+
+        connect() {
+            if (undefined !== this.group &&
+                undefined !== this.outKey &&
+                undefined !== this.output &&
+                typeof this.output === "function") {
+                const conn = engine.makeConnection(this.group, this.outKey, this.output.bind(this));
+                this.connections.push(conn);
+            }
+            const conn2 = engine.makeConnection("[Controls]", "ShowDurationRemaining", this.output.bind(this));
+            if (conn2 !== undefined) {
+                this.connections.push(conn2);
+            }
+        }
+    }
+
+    class VuMeter extends components.Component {
+        constructor(options) {
+            super(Object.assign({
+                key: "vu_meter",
+                // The channel pressure message is used by default, however we
+                // may override this (eg. for the mains meter which uses 0xD1).
+                midi: [0xD0],
+                firstOut: false,
+            }, options));
+        }
+
+        connect() {
+            // If we're creating the main output vumeter, Mixxx had some bugs
+            // were the name of the control got changed. Try both and see which
+            // one binds so that we ensure support for both 2.5.0 and 2.5.1 (and
+            // hopefully other versions going forward).
+            if (this.group === "[Main]" && typeof this.output === "function") {
+                this.connections[0] = engine.makeConnection(this.group, this.outKey, this.output.bind(this));
+                if (this.connections[0] === undefined) {
+                    this.connections[0] = engine.makeConnection("[Master]", "VuMeter", this.output.bind(this));
+                }
+                return;
+            }
+            return components.Component.prototype.connect.call(this);
+        }
+        outValueScale(value) {
+            // TODO: 0xD is 100% (> 0 dB) while 0xC is clipping at 0 dB. If
+            // we're going to do this linear approximation should we scale to
+            // that instead?
+            return value * 0xD;
+        }
+        shutdown() {
+            midi.sendSysexMsg(SysexHeader
+                .concat([0x16, 0x14, this.midi[0], 0x00])
+                .concat([0xF7]));
+        }
+        output(value) {
+            // If the meter is disabled, clear whatever was on it before the
+            // first time we'd update it, then don't send any further updates.
+            if (engine.getSetting("disableVuMeters")) {
+                if (!this.firstOut) {
+                    this.shutdown();
+                    this.firstOut = true;
+                }
+                return;
+            }
+            let idx = 0;
+            if (this.group !== "[Master]" && this.group !== "[Main]") {
+                idx = script.deckFromGroup(this.group) - 1;
+            }
+            // Set the first nibble of the value to the number of the channel.
+            // The second nibble is the value of the meter in the range 0x0 (<
+            // -60 dB) through 0xD (> 0 dB).
+            midi.sendSysexMsg(SysexHeader
+                .concat([0x16, 0x14, this.midi[0], (idx << 4) | this.outValueScale(value)])
+                .concat([0xF7]));
+        }
+    }
+
+    class VelocityEncoder extends components.Encoder {
+        constructor(params) {
+            super(params);
+            if (this.screen === undefined || this.screen < 0 || this.screen > 7) {
+                throw Error("VelocityEncoder must specify a screen number between 0 and 7");
+            }
+            if (this.name === undefined) {
+                throw Error("VelocityEncoder missing 'name' field");
+            }
+            if (typeof this.name === "string") {
+                // Pad name out with spaces so that it "fills" the screen
+                // (replacing anything longer than the current name that would
+                // otherwise hang around on this line).
+                this.name = this.name.padEnd(7, " ");
+            }
+            printScreenName(this.screen, this.name, 1);
+        }
+        outValueScale(_value) {
+            // TODO: I'm extremely confused about what values this expects or
+            // why this is necessary, but somehow it works.
+            return this.outGetParameter() * 12;
+        }
+        inValueScale(value) {
+            if (value < 0x40) {
+                return this.inGetParameter() + (value / 100);
+            } else {
+                return this.inGetParameter() - ((value - 0x40) / 100);
+            }
+        }
+        output(value, _group, _control) {
+            this.send(this.outValueScale(value));
+            const groupNo = /\[Channel(\d+)\]/.exec(this.group);
+            if (groupNo) {
+                const selectedIndicator = this.selected ? "*" : "";
+                const deck = `Deck ${groupNo[1]}${selectedIndicator}`.padEnd(7, " ");
+                printScreenName(this.screen, deck);
+            } else {
+                printScreenName(this.screen, "Main".padEnd(7, " "));
+            }
+        }
+        input(channel, control, value, status, group) {
+            // If we're not shifted, just call the normal input function.
+            if (!this.isShifted) {
+                return components.Encoder.prototype.input.call(this, channel, control, value, status, group);
+            }
+
+            // If we are shifted, update the parameter that the knob changes.
+            const deckResult = /\[Channel(\d+)\]/.exec(this.group);
+            const deck = (deckResult && deckResult.length > 0) ? deckResult[1] : undefined;
+            const params = Object.freeze([
+                {group: `[Channel${deck}]`, key: "pregain", name: "Gain"},
+                {group: `[EqualizerRack1_[Channel${deck}]_Effect1]`, key: "parameter3", name: "High"},
+                {group: `[EqualizerRack1_[Channel${deck}]_Effect1]`, key: "parameter2", name: "Mid"},
+                {group: `[EqualizerRack1_[Channel${deck}]_Effect1]`, key: "parameter1", name: "Low"},
+                {group: `[QuickEffectRack1_[Channel${deck}]]`, key: "super1", name: "FX"},
+            ]);
+            for (let i = 0; i < params.length; i++) {
+                const param = params[i];
+                if (param.key === this.key) {
+                    const offset = value < 0x40 ? 1 : -1;
+                    const newParam = params[script.posMod(i + offset, params.length)];
+                    Object.assign(this, newParam);
+                    if (this.key !== undefined) {
+                        this.outKey = this.key;
+                        this.inKey = this.key;
+                    }
+                    printScreenName(this.screen, this.name, 1);
+                    if (typeof this.setKnobPressKey === "function") {
+                        this.setKnobPressKey(`${this.key}_set_default`, this.group);
+                    }
+                    break;
+                }
+            }
+        }
+        shift() {
+            this.disconnect();
+            this.isShifted = true;
+        }
+        unshift() {
+            this.isShifted = false;
+            this.connect();
+        }
+    }
+
+    class TouchScreen extends components.ComponentContainer {
+        constructor() {
+            super({});
+
+            // Only button from the default mapping that makes sense.
+            this.tapTempoButton = new components.Button({
+                group: "[Channel1]",
+                midi: [0x90, 0x55],
+                key: "bpm_tap",
+            });
+
+            // Buttons from the custom Mixxx mapping.
+            this.introStartBtn = new components.Button({
+                group: "[Channel1]",
+                inKey: "intro_start_activate",
+                midi: [0x91, 0x00],
+            });
+            this.introEndBtn = new components.Button({
+                group: "[Channel1]",
+                inKey: "intro_end_activate",
+                midi: [0x90, 0x40],
+            });
+            this.outroStartBtn = new components.Button({
+                group: "[Channel1]",
+                inKey: "outro_start_activate",
+                midi: [0x91, 0x02],
+            });
+            this.outroEndBtn = new components.Button({
+                group: "[Channel1]",
+                inKey: "outro_end_activate",
+                midi: [0x91, 0x03],
+            });
+
+            this.hotcues = [];
+            for (let i = 0; i < 12; i++) {
+                this.hotcues[i] = new components.HotcueButton({
+                    number: i + 1,
+                    midi: [0x92, i],
+                });
+            }
+
+            this.samplers = [];
+            for (let i = 0; i < 16; i++) {
+                this.samplers[i] = new components.SamplerButton({
+                    number: i + 1,
+                    midi: [0x93, i],
+                });
+            }
+        }
+    }
+
+    class Deck extends components.Deck {
+        constructor() {
+            super([1, 2, 3, 4]);
+
+            this.touchScreen = new TouchScreen();
+
+            this.jogWheel = new components.JogWheelBasic({
+                group: "[Channel1]",
+                deck: 1,
+                midi: [0xB0, 0x3C],
+                vinylMode: false,
+                wheelResolution: 21,
+                max: 0x48,
+                alpha: 1/8,
+            });
+
+            this.playPosition = new PlayPosition({
+                group: "[Channel1]",
+            });
+
+            // Transport buttons
+            this.playButton = new components.PlayButton({
+                group: "[Channel1]",
+                midi: [0x90, 0x5E],
+                type: components.Button.prototype.types.toggle,
+            });
+            this.cueButton = new components.CueButton({
+                group: "[Channel1]",
+                midi: [0x90, 0x5D],
+            });
+            this.backButton = new components.Button({
+                group: "[Channel1]",
+                midi: [0x90, 0x5B],
+                key: "beatjump_backward",
+            });
+            this.forwardButton = new components.Button({
+                group: "[Channel1]",
+                midi: [0x90, 0x5C],
+                key: "beatjump_forward",
+            });
+            this.loopButton = new components.Button({
+                group: "[Channel1]",
+                midi: [0x90, 0x56],
+                inKey: "beatloop_activate",
+                outKey: "loop_enabled",
+            });
+
+            this.setCurrentDeck("[Channel1]");
+        }
+
+        setCurrentDeck(newGroup) {
+            midi.sendShortMsg(0x90, 0x18 + (newGroup - 1), 0x7F);
+            components.Deck.prototype.setCurrentDeck.call(this, newGroup);
+        }
+    }
+
+    class Controller extends components.ComponentContainer {
+        constructor() {
+            super({});
+
+            this.activeDeck = new Deck();
+
+            this.knobPress = [
+                new components.Button({
+                    group: "[Channel1]",
+                    key: "pregain_set_default",
+                    midi: [0x90, 0x20],
+                }),
+                new components.Button({
+                    group: "[Channel2]",
+                    key: "pregain_set_default",
+                    midi: [0x90, 0x21],
+                }),
+                new components.Button({
+                    group: "[Channel3]",
+                    key: "pregain_set_default",
+                    midi: [0x90, 0x22],
+                }),
+                new components.Button({
+                    group: "[Channel4]",
+                    key: "pregain_set_default",
+                    midi: [0x90, 0x23],
+                }),
+            ];
+            const setKnobPressKey = function(_this, i) {
+                return (key, group) => {
+                    _this.knobPress[i].group = group;
+                    _this.knobPress[i].key = key;
+                    _this.knobPress[i].inKey = key;
+                    _this.knobPress[i].outKey = key;
+                    _this.knobPress[i].disconnect();
+                    _this.knobPress[i].connect();
+                    _this.knobPress[i].trigger();
+                };
+            };
+            this.knob = [
+                new VelocityEncoder({
+                    group: "[Channel1]",
+                    screen: 0,
+                    selected: true,
+                    key: "pregain",
+                    name: "Gain",
+                    midi: [0xB0, 0x10],
+                    setKnobPressKey: setKnobPressKey(this, 0),
+                }),
+                new VelocityEncoder({
+                    group: "[Channel2]",
+                    screen: 1,
+                    key: "pregain",
+                    name: "Gain",
+                    midi: [0xB0, 0x11],
+                    setKnobPressKey: setKnobPressKey(this, 1),
+                }),
+                new VelocityEncoder({
+                    group: "[Channel3]",
+                    screen: 2,
+                    key: "pregain",
+                    name: "Gain",
+                    midi: [0xB0, 0x12],
+                    setKnobPressKey: setKnobPressKey(this, 2),
+                }),
+                new VelocityEncoder({
+                    group: "[Channel4]",
+                    screen: 3,
+                    key: "pregain",
+                    name: "Gain",
+                    midi: [0xB0, 0x13],
+                    setKnobPressKey: setKnobPressKey(this, 3),
+                }),
+            ];
+
+            this.shiftButton = new components.Button({
+                group: "[Channel1]",
+                midi: [0x90, 0x32],
+                type: components.Button.prototype.types.toggle,
+                controller: this,
+                input: function(_channel, _control, value, _status, _group) {
+                    if (value === 0) {
+                        return;
+                    }
+                    if (this.controller.isShifted) {
+                        this.controller.unshift();
+                    } else {
+                        this.controller.shift();
+                    }
+                    midi.sendShortMsg(this.midi[0], this.midi[1], this.controller.isShifted ? 0x7F : 0x00);
+                },
+            });
+
+            // Transport buttons
+            this.recordButton = new components.Button({
+                group: "[Recording]",
+                midi: [0x90, 0x5F],
+                inKey: "toggle_recording",
+                outKey: "status",
+            });
+
+            // Jogwheel with navigation buttons selected
+            this.jogUp = new components.Button({
+                group: "[Library]",
+                midi: [0x90, 0x60],
+                inKey: "MoveUp",
+            });
+            this.jogDown = new components.Button({
+                group: "[Library]",
+                midi: [0x90, 0x60],
+                inKey: "MoveDown",
+            });
+            this.jogLeft = new components.Button({
+                group: "[Library]",
+                midi: [0x90, 0x62],
+                inKey: "MoveLeft",
+            });
+            this.jogRight = new components.Button({
+                group: "[Library]",
+                midi: [0x90, 0x63],
+                inKey: "MoveRight",
+            });
+            this.jogButton = new components.Button({
+                group: "[Library]",
+                midi: [0x90, 0x65],
+                inKey: "GoToItem",
+            });
+            this.focusMode = new components.Button({
+                group: "[Library]",
+                midi: [0x90, 0x64],
+                jogUp: this.jogUp,
+                jogDown: this.jogDown,
+                jogLeft: this.jogLeft,
+                jogRight: this.jogRight,
+                jogButton: this.jogButton,
+                input: function(_channel, _control, value, _status, _group) {
+                    if (value === 0) {
+                        return;
+                    }
+                    if (this.jogUp.inKey === "MoveUp") {
+                        // TODO: this is not a good control use for the
+                        // crossfader, maybe use one of the unused audio
+                        // channels so the actual fader can be used?
+                        this.jogLeft.inKey = "crossfader_down_small";
+                        this.jogRight.inKey = "crossfader_up_small";
+                        this.jogButton.inKey = "crossfader_set_default";
+                        this.jogLeft.group = "[Master]";
+                        this.jogRight.group = "[Master]";
+                        this.jogButton.group = "[Master]";
+                        this.jogUp.inKey = "MoveFocusBackward";
+                        this.jogDown.inKey = "MoveFocusForward";
+                    } else {
+                        this.jogLeft.inKey = "MoveLeft";
+                        this.jogRight.inKey = "MoveRight";
+                        this.jogButton.inKey = "GoToItem";
+                        this.jogLeft.group = "[Library]";
+                        this.jogRight.group = "[Library]";
+                        this.jogButton.group = "[Library]";
+                        this.jogUp.inKey = "MoveUp";
+                        this.jogDown.inKey = "MoveDown";
+                    }
+                },
+            });
+
+            this.trackColors = [];
+            this.vuMeters = [];
+            this.bpmMeters = [];
+            this.fader = [];
+            this.muteButton = [];
+            this.soloButton = [];
+            this.recordButton = [];
+            for (let i = 0; i < 4; i++) {
+                this.trackColors[i] = new components.Component({
+                    group: `[Channel${i + 1}]`,
+                    key: "track_color",
+                    output: function() {
+                        const cmd = [0xf0, 0x00, 0x02, 0x4e, 0x16, 0x14];
+                        for (let i = 0; i < 4; i++) {
+                            const trackColor = engine.getValue(`[Channel${i + 1}]`, this.key);
+                            if (trackColor === -1) {
+                                cmd.push(0x00, 0x00, 0x00);
+                            } else {
+                                const colorobj = colorCodeToObject(trackColor);
+                                // Scale the color to fit a valid MIDI message.
+                                for (const [key, val] of Object.entries(colorobj)) {
+                                    if (typeof val === "number") {
+                                        colorobj[key] = val / 0xFF * 0x7E;
+                                    }
+                                }
+                                cmd.push(colorobj.red, colorobj.green, colorobj.blue);
+                            }
+                        }
+                        for (let i = 0; i < 4; i++) {
+                            // Unused screens (there's no way to set an individual screen, you
+                            // have to set them all at once every time).
+                            cmd.push(0x00, 0x00, 0x00);
+                        }
+                        cmd.push(0xF7);
+                        midi.sendSysexMsg(cmd);
+                    },
+                });
+                this.vuMeters[i] = new VuMeter({
+                    group: `[Channel${i + 1}]`,
+                });
+                this.bpmMeters[i] = new components.Component({
+                    group: `[Channel${i + 1}]`,
+                    midi: [0x90, 0x10],
+                    outKey: "bpm",
+                    output: function(value) {
+                        if (value === 0) {
+                            printLCDDisplay(i, " ");
+                        } else {
+                            printLCDDisplay(i, value.toPrecision(4).toString());
+                        }
+                    },
+                });
+
+                this.muteButton[i] = new components.Button({
+                    group: `[Channel${i + 1}]`,
+                    midi: [0x90, 0x10 + i],
+                    key: "mute",
+                    type: components.Button.prototype.types.toggle,
+                });
+                this.soloButton[i] = new components.Button({
+                    group: `[Channel${i + 1}]`,
+                    midi: [0x90, 0x08 + i],
+                    key: "beats_translate_curpos",
+                });
+                this.recordButton[i] = new components.Button({
+                    group: `[Channel${i + 1}]`,
+                    midi: [0x90, i],
+                    inKey: "bpm_tap",
+                    outKey: (() => {
+                        if (engine.getSetting("enableBPMBlink")) {
+                            return "beat_active";
+                        }
+                        return undefined;
+                    })(),
+                });
+
+                // TODO: these are 14-bit, so using the default output means the
+                // resolution is less than the input, so the fader sometimes
+                // "jumps" after you move it to whatever the output value is
+                // telling it to be at.
+                this.fader[i] = new components.Encoder({
+                    group: `[Channel${i + 1}]`,
+                    key: "volume",
+                    midi: [0xE0 + i, 0x00],
+                    softTakeover: false,
+                    outValueScale: function(value) {
+                        // If we're shifted we're a rate fader, so scale the
+                        // -1..1 range to the normal 0 to max.
+                        if (this.inKey === "rate") {
+                            return ((value + 1) / 2) * this.max;
+                        }
+                        // Otherwise we have a normal range and can do the
+                        // normal thing.
+                        return components.Encoder.prototype.outValueScale.call(this, value);
+                    },
+                    shift: function() {
+                        this.key = "rate";
+                        this.inKey = "rate";
+                        this.outKey = "rate";
+                        this.disconnect();
+                        this.connect();
+                        this.trigger();
+                    },
+                    unshift: function() {
+                        this.key = "volume";
+                        this.inKey = "volume";
+                        this.outKey = "volume";
+                        this.disconnect();
+                        this.connect();
+                        this.trigger();
+                    },
+                });
+            }
+
+            this.fader.push(new components.Encoder({
+                group: "[Master]",
+                key: "gain",
+                midi: [0xE8, 0x00],
+                // The 0 mark of the fader (which we want to correspond to 0.5,
+                // the middle of the gain knob) is not actually the center of
+                // the physical fader, so set a mid point value, check if we're
+                // above or below the fake mid point, and scale appropriately.
+                // TODO: what is the actual 0 value on the fader? 0x62? 0x64?
+                mid: 0x63,
+                inValueScale: function(value) {
+                    if (value >= this.mid) {
+                        return (((value - this.mid) / (this.max - this.mid)) * 0.5) + 0.5;
+                    } else {
+                        return value / (this.mid + 1) / 2;
+                    }
+                },
+                outValueScale: function(value) {
+                    if (value > 1) {
+                        return (((value - 1) / (5 - 1)) * (this.max - this.mid)) + this.mid;
+                    } else {
+                        return value * this.mid;
+                    }
+                },
+            }));
+            this.vuMeters.push(new VuMeter({
+                group: "[Main]",
+                midi: [0xD1],
+            }));
+        }
+
+        deckSelectInput(_channel, _control, value, _status, group) {
+            if (value === 0x00) {
+                // No need to select the deck on press and then re-select it on
+                // release.
+                return;
+            }
+            this.activeDeck.setCurrentDeck(group);
+            const deck = script.deckFromGroup(group);
+            for (let i = 0; i < 4; i++) {
+                this.knob[i].selected = deck === (i + 1);
+                this.knob[i].trigger();
+            }
+        }
+    }
+
+    P1Nano.init = function() {
+        P1Nano.controller = new Controller();
+    };
+    P1Nano.shutdown = function() {
+        P1Nano.controller.shutdown();
+    };
+})(P1Nano || (P1Nano = {}));
+
+// vim:expandtab:shiftwidth=4:tabstop=4:backupcopy=yes

--- a/res/controllers/Icon-P1Nano-scripts.js
+++ b/res/controllers/Icon-P1Nano-scripts.js
@@ -162,7 +162,7 @@ var P1Nano;
                 break;
             case 2:
                 // Showing both
-                time = `${fmtSeconds(playPos * dur)  } -${  fmtSeconds(dur - (playPos * dur))}`;
+                time = `${fmtSeconds(playPos * dur)} -${fmtSeconds(dur - (playPos * dur))}`;
                 break;
             }
             printSevenSeg(time);

--- a/res/controllers/Icon-P1Nano.midi.xml
+++ b/res/controllers/Icon-P1Nano.midi.xml
@@ -1,0 +1,808 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MixxxControllerPreset mixxxVersion="2.5" schemaVersion="1">
+  <info>
+    <name>Icon P1-Nano MIDI 1</name>
+    <author>Sam Whited</author>
+    <description>MIDI mapping for the Icon P1-Nano controller and D-5 display.</description>
+    <forums>https://mixxx.discourse.group/t/icon-pro-audio-p1-nano/31630</forums>
+    <manual>icon_p1_nano</manual>
+    <devices>
+      <product protocol="midi" vendor_id="0x1d03" product_id="0x0806"/>
+    </devices>
+  </info>
+  <settings>
+    <option default="false" variable="disableVuMeters" type="boolean" label="Disable VuMeters">
+      <description>Disables showing the vumeter</description>
+    </option>
+    <option default="false" variable="disableTimeDisplay" type="boolean" label="Disable Timecode Display">
+      <description>Disables the 7-segment timecode display</description>
+    </option>
+    <option default="false" variable="enableBPMBlink" type="boolean" label="Blink record arm button on beat">
+      <description>Blink the record arm LED on the beat</description>
+    </option>
+  </settings>
+  <controller id="icon-p1nano">
+    <scriptfiles>
+      <file filename="midi-components-0.0.js" functionprefix=""/>
+      <file filename="Icon-P1Nano-scripts.js" functionprefix="P1Nano"/>
+    </scriptfiles>
+    <controls>
+      <!-- Virtual faders -->
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.fader[0].input</key>
+        <description>Virtual fader 1.</description>
+        <status>0xE0</status>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>P1Nano.controller.fader[1].input</key>
+        <description>Virtual fader 2.</description>
+        <status>0xE1</status>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>P1Nano.controller.fader[2].input</key>
+        <description>Virtual fader 3.</description>
+        <status>0xE2</status>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>P1Nano.controller.fader[3].input</key>
+        <description>Virtual fader 4.</description>
+        <status>0xE3</status>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Master]</group>
+        <key>P1Nano.controller.fader[4].input</key>
+        <description>Virtual fader 9.</description>
+        <status>0xE8</status>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+
+      <!-- Knobs -->
+      <control>
+        <group>[Master]</group>
+        <key>P1Nano.controller.knob[0].input</key>
+        <description>Knob 1.</description>
+        <status>0xB0</status>
+        <midino>0x10</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Master]</group>
+        <key>P1Nano.controller.knob[1].input</key>
+        <description>Knob 2.</description>
+        <status>0xB0</status>
+        <midino>0x11</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Master]</group>
+        <key>P1Nano.controller.knob[2].input</key>
+        <description>Knob 3.</description>
+        <status>0xB0</status>
+        <midino>0x12</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Master]</group>
+        <key>P1Nano.controller.knob[3].input</key>
+        <description>Knob 4.</description>
+        <status>0xB0</status>
+        <midino>0x13</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.knobPress[0].input</key>
+        <description>Knob button 1.</description>
+        <status>0x90</status>
+        <midino>0x20</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.knobPress[1].input</key>
+        <description>Knob button 2.</description>
+        <status>0x90</status>
+        <midino>0x21</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.knobPress[2].input</key>
+        <description>Knob button 3.</description>
+        <status>0x90</status>
+        <midino>0x22</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.knobPress[3].input</key>
+        <description>Knob button 4.</description>
+        <status>0x90</status>
+        <midino>0x23</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+
+      <!-- Transport Buttons -->
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.loopButton.input</key>
+        <description>Loop transport button.</description>
+        <status>0x90</status>
+        <midino>0x56</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.backButton.input</key>
+        <description>Rewind transport button.</description>
+        <status>0x90</status>
+        <midino>0x5B</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.forwardButton.input</key>
+        <description>Fast forward transport button.</description>
+        <status>0x90</status>
+        <midino>0x5C</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.cueButton.input</key>
+        <description>Pause transport button (used for Cue).</description>
+        <status>0x90</status>
+        <midino>0x5D</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.playButton.input</key>
+        <description>Play transport button.</description>
+        <status>0x90</status>
+        <midino>0x5E</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Recording]</group>
+        <key>P1Nano.controller.recordButton.input</key>
+        <description>Record transport button.</description>
+        <status>0x90</status>
+        <midino>0x5F</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+
+      <!-- Deck Selection -->
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.deckSelectInput</key>
+        <description>Deck 3 (volume) selected on controller.</description>
+        <status>0x90</status>
+        <midino>0x18</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>P1Nano.controller.deckSelectInput</key>
+        <description>Deck 1 (volume) selected on controller.</description>
+        <status>0x90</status>
+        <midino>0x19</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>P1Nano.controller.deckSelectInput</key>
+        <description>Deck 2 (volume) selected on controller.</description>
+        <status>0x90</status>
+        <midino>0x1A</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>P1Nano.controller.deckSelectInput</key>
+        <description>Deck 4 (volume) selected on controller.</description>
+        <status>0x90</status>
+        <midino>0x1B</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+
+      <!-- Navigation -->
+      <control>
+        <group>[Library]</group>
+        <key>P1Nano.controller.jogUp.input</key>
+        <description>Jogwheel move mode up.</description>
+        <status>0x90</status>
+        <midino>0x60</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Library]</group>
+        <key>P1Nano.controller.jogDown.input</key>
+        <description>Jogwheel move mode down.</description>
+        <status>0x90</status>
+        <midino>0x61</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Library]</group>
+        <key>P1Nano.controller.jogLeft.input</key>
+        <description>Jogwheel move mode left.</description>
+        <status>0x90</status>
+        <midino>0x62</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Library]</group>
+        <key>P1Nano.controller.jogRight.input</key>
+        <description>Jogwheel move mode right.</description>
+        <status>0x90</status>
+        <midino>0x63</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Library]</group>
+        <key>P1Nano.controller.focusMode.input</key>
+        <description>Jogwheel focus/zoom side up/down or left/right button.</description>
+        <status>0x90</status>
+        <midino>0x64</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Library]</group>
+        <key>P1Nano.controller.jogButton.input</key>
+        <description>Jogwheel press.</description>
+        <status>0x90</status>
+        <midino>0x65</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+
+      <!-- Flip/shift button -->
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.shiftButton.input</key>
+        <description>Flip button.</description>
+        <status>0x90</status>
+        <midino>0x32</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+
+      <!-- Channel Mapped Buttons -->
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.muteButton[0].input</key>
+        <description>"M" button.</description>
+        <status>0x90</status>
+        <midino>0x10</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>P1Nano.controller.muteButton[1].input</key>
+        <description>"M" button.</description>
+        <status>0x90</status>
+        <midino>0x11</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>P1Nano.controller.muteButton[2].input</key>
+        <description>"M" button.</description>
+        <status>0x90</status>
+        <midino>0x12</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>P1Nano.controller.muteButton[3].input</key>
+        <description>"M" button.</description>
+        <status>0x90</status>
+        <midino>0x13</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.soloButton[0].input</key>
+        <description>"S" button.</description>
+        <status>0x90</status>
+        <midino>0x08</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>P1Nano.controller.soloButton[1].input</key>
+        <description>"S" button.</description>
+        <status>0x90</status>
+        <midino>0x09</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>P1Nano.controller.soloButton[2].input</key>
+        <description>"S" button.</description>
+        <status>0x90</status>
+        <midino>0x0A</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>P1Nano.controller.soloButton[3].input</key>
+        <description>"S" button.</description>
+        <status>0x90</status>
+        <midino>0x0B</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.recordButton[0].input</key>
+        <description>Record button.</description>
+        <status>0x90</status>
+        <midino>0x00</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>P1Nano.controller.recordButton[1].input</key>
+        <description>Record button.</description>
+        <status>0x90</status>
+        <midino>0x01</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel3]</group>
+        <key>P1Nano.controller.recordButton[2].input</key>
+        <description>Record button.</description>
+        <status>0x90</status>
+        <midino>0x02</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel4]</group>
+        <key>P1Nano.controller.recordButton[3].input</key>
+        <description>Record button.</description>
+        <status>0x90</status>
+        <midino>0x03</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.jogWheel.inputWheel</key>
+        <description>Jog wheel.</description>
+        <status>0xB0</status>
+        <midino>0x3C</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+
+      <!-- Touch Screen Buttons -->
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.tapTempoButton.input</key>
+        <description>Tap Tempo</description>
+        <status>0x90</status>
+        <midino>0x55</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+
+      <!-- Custom layer 1: intro, outro, hotcues -->
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.touchScreen.introStartBtn.input</key>
+        <description>Intro Start</description>
+        <status>0x91</status>
+        <midino>0x00</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.touchScreen.introEndBtn.input</key>
+        <description>Intro End</description>
+        <status>0x91</status>
+        <midino>0x01</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.touchScreen.outroStartBtn.input</key>
+        <description>Outro Start</description>
+        <status>0x91</status>
+        <midino>0x02</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.touchScreen.outroEndBtn.input</key>
+        <description>Outro End</description>
+        <status>0x91</status>
+        <midino>0x03</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.touchScreen.hotcues[0].input</key>
+        <description>Hotcue 1</description>
+        <status>0x92</status>
+        <midino>0x00</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.touchScreen.hotcues[1].input</key>
+        <description>Hotcue 2</description>
+        <status>0x92</status>
+        <midino>0x01</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.touchScreen.hotcues[2].input</key>
+        <description>Hotcue 3</description>
+        <status>0x92</status>
+        <midino>0x02</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.touchScreen.hotcues[3].input</key>
+        <description>Hotcue 4</description>
+        <status>0x92</status>
+        <midino>0x03</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.touchScreen.hotcues[4].input</key>
+        <description>Hotcue 5</description>
+        <status>0x92</status>
+        <midino>0x04</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.touchScreen.hotcues[5].input</key>
+        <description>Hotcue 6</description>
+        <status>0x92</status>
+        <midino>0x05</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.touchScreen.hotcues[6].input</key>
+        <description>Hotcue 7</description>
+        <status>0x92</status>
+        <midino>0x06</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.touchScreen.hotcues[7].input</key>
+        <description>Hotcue 8</description>
+        <status>0x92</status>
+        <midino>0x07</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.touchScreen.hotcues[8].input</key>
+        <description>Hotcue 9</description>
+        <status>0x92</status>
+        <midino>0x08</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.touchScreen.hotcues[9].input</key>
+        <description>Hotcue 10</description>
+        <status>0x92</status>
+        <midino>0x09</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.touchScreen.hotcues[10].input</key>
+        <description>Hotcue 11</description>
+        <status>0x92</status>
+        <midino>0x0A</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.touchScreen.hotcues[11].input</key>
+        <description>Hotcue 12</description>
+        <status>0x92</status>
+        <midino>0x0B</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+
+      <!-- Layer 2: samplers -->
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.touchScreen.samplers[0].input</key>
+        <description>Sampler 1</description>
+        <status>0x93</status>
+        <midino>0x00</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.touchScreen.samplers[1].input</key>
+        <description>Sampler 2</description>
+        <status>0x93</status>
+        <midino>0x01</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.touchScreen.samplers[2].input</key>
+        <description>Sampler 3</description>
+        <status>0x93</status>
+        <midino>0x02</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.touchScreen.samplers[3].input</key>
+        <description>Sampler 4</description>
+        <status>0x93</status>
+        <midino>0x03</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.touchScreen.samplers[4].input</key>
+        <description>Sampler 5</description>
+        <status>0x93</status>
+        <midino>0x04</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.touchScreen.samplers[5].input</key>
+        <description>Sampler 6</description>
+        <status>0x93</status>
+        <midino>0x05</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.touchScreen.samplers[6].input</key>
+        <description>Sampler 7</description>
+        <status>0x93</status>
+        <midino>0x06</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.touchScreen.samplers[7].input</key>
+        <description>Sampler 8</description>
+        <status>0x93</status>
+        <midino>0x07</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.touchScreen.samplers[8].input</key>
+        <description>Sampler 9</description>
+        <status>0x93</status>
+        <midino>0x08</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.touchScreen.samplers[9].input</key>
+        <description>Sampler 10</description>
+        <status>0x93</status>
+        <midino>0x09</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.touchScreen.samplers[10].input</key>
+        <description>Sampler 11</description>
+        <status>0x93</status>
+        <midino>0x0A</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.touchScreen.samplers[11].input</key>
+        <description>Sampler 12</description>
+        <status>0x93</status>
+        <midino>0x0B</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.touchScreen.samplers[12].input</key>
+        <description>Sampler 13</description>
+        <status>0x93</status>
+        <midino>0x0C</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.touchScreen.samplers[13].input</key>
+        <description>Sampler 14</description>
+        <status>0x93</status>
+        <midino>0x0D</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.touchScreen.samplers[14].input</key>
+        <description>Sampler 15</description>
+        <status>0x93</status>
+        <midino>0x0E</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>P1Nano.controller.activeDeck.touchScreen.samplers[15].input</key>
+        <description>Sampler 16</description>
+        <status>0x93</status>
+        <midino>0x0F</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+
+    </controls>
+    <outputs/>
+  </controller>
+</MixxxControllerPreset>


### PR DESCRIPTION
This adds support for the [Icon Pro Audo P1-Nano](https://iconproaudio.com/product/p1-nano/) (and likely the larger P1-X/P1-M, though I can't test that) which (mostly) follows the [Mackie Control Protocol](https://github.com/NicoG60/TouchMCU/blob/main/doc/mackie_control_protocol.md) (MCU) spec. It may be worth having a generic "MCU Device" script at a later date, that other scripts like this one (with minimum proprietary features) could inherit from, or that would stand alone if your specific device wasn't supported. However, I don't have a way to test that since I only have one controller that uses MCU, so for now it's its own script.

![Graphic of the P1-Nano](https://github.com/user-attachments/assets/5b6222b1-a9b8-460c-8784-6224f1a7a8ab)

Associated manual PR: mixxxdj/manual#751

Potential future follow ups (or hit me up if you have ideas for some of these):

- Figure out how to set the text and MIDI configuration of the touch screen buttons
- Figure out if it's possible to enable the Trim and Off buttons without their proprietary software
- Figure out what to do with the Read/Write/Touch/Latch/Trim/Off buttons
- Let the user configure and use the other 4 faders for samplers, preview decks, aux inputs, mics, etc.
- Let the user configure what the 7-segment display is used for (eg. we might put BPM here)
- Use the blue/red LED under the jog wheel for something?
- Should we extract some of this into a generic "MCU Compatible Device" mapping that this mapping can inherit from and only add some proprietary bits on top?