### PR TITLE
Fix building with a CMake multi-config setup

### DIFF
--- a/src/util/moc_included_test.cpp
+++ b/src/util/moc_included_test.cpp
@@ -1,4 +1,12 @@
+#if __has_include("../mocs_compilation_Debug.cpp")
+#include "../mocs_compilation_Debug.cpp"
+#elif __has_include("../mocs_compilation_Release.cpp")
+#include "../mocs_compilation_Release.cpp"
+#elif __has_include("../mocs_compilation_RelWithDebInfo.cpp")
+#include "../mocs_compilation_RelWithDebInfo.cpp"
+#else
 #include "../mocs_compilation.cpp"
+#endif
 
 // QT_VERSION will be defined by any moc_<header_base>.cpp file included from mocs_compilation.cpp
 // It is empty in case all moc files are included, a requirement to speed up incremental builds.


### PR DESCRIPTION
In a multi-config setup the mocs_compilation.cpp has the CMAKE_BUILD_TYPE prefix. 
See: 
https://cmake.org/cmake/help/latest/prop_tgt/AUTOMOC.html#not-included-moc-output-files

For the purpose of the test it is sufficent to include one of them. 