### PR TITLE
Remove useless udev rule

### DIFF
--- a/res/linux/mixxx-usb-uaccess.rules
+++ b/res/linux/mixxx-usb-uaccess.rules
@@ -56,6 +56,3 @@ KERNEL=="hidraw*", ATTRS{idVendor}=="054c", TAG+="uaccess"
 
 # Missing:
 # - American Musical Supply (AMS/Mixars)
-
-# Only some distribuions require the below
-KERNEL=="hiddev*", NAME="usb/%k", GROUP="uaccess"


### PR DESCRIPTION
The udev rule in question is a remnant of the old udev rules file (`mixxx.usb.rules`) which used `GROUP="users"` instead of `TAG+="uaccess"` (changed in [commit c9bb987](https://github.com/mixxxdj/mixxx/commit/c9bb987664fbcb12b522cbb0827c30f2b71fa13b)). 

It is rendered useless in the current uaccess scheme, but the commit author erroneously changed `GROUP="users"` to `GROUP="uaccess"` instead of removing the line.

It must be noted that there is no such thing as a `uaccess` group.

The udev rule in question produces the following harmless error message:
```
udevd: specified group 'uaccess' unknown
```  