### PR TITLE
Fix UI freeze when analyzing many tracks. 

### DIFF
--- a/src/library/basetrackcache.cpp
+++ b/src/library/basetrackcache.cpp
@@ -191,10 +191,6 @@ bool BaseTrackCache::updateIndexWithQuery(const QString& queryString) {
         qDebug() << "updateIndexWithQuery issuing query:" << queryString;
     }
 
-    if (m_bIsCaching) {
-        resetRecentTrack();
-    }
-
     QSqlQuery query(m_database);
     // This causes a memory savings since QSqlCachedResult (what QtSQLite uses)
     // won't allocate a giant in-memory table that we won't use at all.
@@ -249,6 +245,9 @@ void BaseTrackCache::buildIndex() {
     // clear the table, and keep track of what IDs we see, then delete the ones
     // we don't see.
     m_trackInfo.clear();
+    if (m_bIsCaching) {
+        resetRecentTrack();
+    }
 
     if (!updateIndexWithQuery(queryString)) {
         qDebug() << "buildIndex failed!";

--- a/src/library/basetrackcache.cpp
+++ b/src/library/basetrackcache.cpp
@@ -542,8 +542,8 @@ void BaseTrackCache::filterAndSort(const QSet<TrackId>& trackIds,
     for (TrackId trackId : std::as_const(dirtyTracks)) {
         // Only get the track if it is in the cache. Tracks that
         // are not cached in memory cannot be dirty.
-        TrackPointer pTrack = getCachedTrack(trackId);
-
+        // Bypass getCachedTrack() to not invalidate m_recentTrackId
+        TrackPointer pTrack = GlobalTrackCacheLocker().lookupTrackById(trackId);
         if (!pTrack) {
             continue;
         }

--- a/src/library/basetrackcache.cpp
+++ b/src/library/basetrackcache.cpp
@@ -107,10 +107,6 @@ void BaseTrackCache::ensureCached(TrackId trackId) {
     updateTrackInIndex(trackId);
 }
 
-void BaseTrackCache::ensureCached(const QSet<TrackId>& trackIds) {
-    updateTracksInIndex(trackIds);
-}
-
 const TrackPointer& BaseTrackCache::getCachedTrack(TrackId trackId) const {
     DEBUG_ASSERT(m_bIsCaching);
     // Only refresh the recently used track if the identifiers

--- a/src/library/basetrackcache.cpp
+++ b/src/library/basetrackcache.cpp
@@ -111,7 +111,7 @@ void BaseTrackCache::ensureCached(const QSet<TrackId>& trackIds) {
     updateTracksInIndex(trackIds);
 }
 
-const TrackPointer& BaseTrackCache::getRecentTrack(TrackId trackId) const {
+const TrackPointer& BaseTrackCache::getCachedTrack(TrackId trackId) const {
     DEBUG_ASSERT(m_bIsCaching);
     // Only refresh the recently used track if the identifiers
     // don't match. Otherwise simply return the corresponding
@@ -121,11 +121,13 @@ const TrackPointer& BaseTrackCache::getRecentTrack(TrackId trackId) const {
         if (trackId.isValid()) {
             TrackPointer trackPtr =
                     GlobalTrackCacheLocker().lookupTrackById(trackId);
-            replaceRecentTrack(
-                    std::move(trackId),
-                    std::move(trackPtr));
-        } else {
-            resetRecentTrack();
+            if (!trackPtr) {
+                resetRecentTrack();
+            } else {
+                replaceRecentTrack(
+                        std::move(trackId),
+                        std::move(trackPtr));
+            }
         }
     }
     return m_recentTrackPtr;
@@ -140,50 +142,15 @@ void BaseTrackCache::replaceRecentTrack(TrackPointer pTrack) const {
 }
 
 void BaseTrackCache::replaceRecentTrack(TrackId trackId, TrackPointer pTrack) const {
-    DEBUG_ASSERT(m_bIsCaching);
+    // reset recent track first, because that may evict if from GlobalTrackCache cache
+    // causing updateIndexWithQuery() which resets the recent track again.
+    resetRecentTrack();
+    DEBUG_ASSERT(!pTrack || m_recentTrackId != pTrack->getId());
     m_recentTrackId = std::move(trackId);
-    if (m_recentTrackId.isValid()) {
-        if (pTrack) {
-            DEBUG_ASSERT(m_recentTrackId == pTrack->getId());
-
-            // NOTE(uklotzde, 2018-02-07, Fedora 27, GCC 7.3.1, optimize=native (-O3), Core i5-6440HQ)
-            // Using the move assignment operator here will sooner or later
-            // store a nullptr in m_recentTrackPtr even if both m_recentTrackPtr
-            // and pTrack contain a valid but different pointer before the
-            // assignment and the custom deleter is invoked on m_recentTrackPtr
-            // during the assignment. The issue does not occur when either
-            // changing the optimization level from 'native' to 'none' or
-            // when replacing the move assignment with a swap operation (see below).
-            //
-            // Fucked up by the optimizer:
-            // m_recentTrackPtr = std::move(pTrack);
-            //
-            // The workaround:
-            m_recentTrackPtr.swap(pTrack);
-            //
-            // The following debug assertion will be triggered eventually
-            // without the workaround in place when browsing and editing
-            // properties of tracks.
-            DEBUG_ASSERT(m_recentTrackPtr);
-
-            if (m_recentTrackPtr->isDirty()) {
-                m_dirtyTracks.insert(m_recentTrackId);
-            } else {
-                m_dirtyTracks.remove(m_recentTrackId);
-            }
-        } else {
-            // The track cannot be dirty if it is not present
-            m_recentTrackPtr.reset();
-            m_dirtyTracks.remove(m_recentTrackId);
-        }
-    } else {
-        DEBUG_ASSERT(!pTrack);
-        m_recentTrackPtr.reset();
-    }
+    m_recentTrackPtr = std::move(pTrack);
 }
 
 void BaseTrackCache::resetRecentTrack() const {
-    DEBUG_ASSERT(m_bIsCaching);
     m_recentTrackId = TrackId();
     m_recentTrackPtr.reset();
 }
@@ -210,7 +177,7 @@ bool BaseTrackCache::updateTrackInIndex(
             record[i] = getTrackValueForColumn(pTrack, i);
         }
         if (m_bIsCaching) {
-            replaceRecentTrack(std::move(trackId), pTrack);
+            replaceRecentTrack(trackId, pTrack);
         }
     } else {
         if (m_bIsCaching) {
@@ -444,7 +411,7 @@ QVariant BaseTrackCache::data(TrackId trackId, int column) const {
     }
 
     if (m_bIsCaching) {
-        TrackPointer pTrack = getRecentTrack(trackId);
+        TrackPointer pTrack = getCachedTrack(trackId);
         if (pTrack) {
             QVariant result = getTrackValueForColumn(pTrack, column);
             if (result.isValid()) {
@@ -575,7 +542,7 @@ void BaseTrackCache::filterAndSort(const QSet<TrackId>& trackIds,
     for (TrackId trackId : std::as_const(dirtyTracks)) {
         // Only get the track if it is in the cache. Tracks that
         // are not cached in memory cannot be dirty.
-        TrackPointer pTrack = getRecentTrack(trackId);
+        TrackPointer pTrack = getCachedTrack(trackId);
 
         if (!pTrack) {
             continue;

--- a/src/library/basetrackcache.h
+++ b/src/library/basetrackcache.h
@@ -73,7 +73,6 @@ class BaseTrackCache : public QObject {
                                QHash<TrackId, int>* trackToIndex);
     virtual bool isCached(TrackId trackId) const;
     virtual void ensureCached(TrackId trackId);
-    virtual void ensureCached(const QSet<TrackId>& trackIds);
 
   signals:
     void tracksChanged(const QSet<TrackId>& trackIds);

--- a/src/library/basetrackcache.h
+++ b/src/library/basetrackcache.h
@@ -87,7 +87,7 @@ class BaseTrackCache : public QObject {
     void slotTrackClean(TrackId trackId);
 
   private:
-    const TrackPointer& getRecentTrack(TrackId trackId) const;
+    const TrackPointer& getCachedTrack(TrackId trackId) const;
     void replaceRecentTrack(TrackPointer pTrack) const;
     void replaceRecentTrack(TrackId trackId, TrackPointer pTrack) const;
     void resetRecentTrack() const;

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -24,11 +24,6 @@ TrackCollection::TrackCollection(
                      m_analysisDao, m_libraryHashDao, pConfig) {
     // Forward signals from TrackDAO
     connect(&m_trackDao,
-            &TrackDAO::trackClean,
-            this,
-            &TrackCollection::trackClean,
-            /*signal-to-signal*/ Qt::DirectConnection);
-    connect(&m_trackDao,
             &TrackDAO::trackDirty,
             this,
             &TrackCollection::trackDirty,

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -90,7 +90,6 @@ class TrackCollection : public QObject,
     void scanTrackAdded(TrackPointer pTrack);
 
     // Forwarded signals from TrackDAO
-    void trackClean(TrackId trackId);
     void trackDirty(TrackId trackId);
     void tracksAdded(const QSet<TrackId>& trackIds);
     void tracksChanged(const QSet<TrackId>& trackIds);

--- a/src/sources/soundsourceproxy.cpp
+++ b/src/sources/soundsourceproxy.cpp
@@ -286,7 +286,7 @@ bool SoundSourceProxy::isUrlSupported(const QUrl& url) {
 bool SoundSourceProxy::isFileSupported(const mixxx::FileInfo& fileInfo) {
     const QString fileType =
             mixxx::SoundSource::getTypeFromFile(fileInfo.asQFileInfo());
-    qDebug() << "isFileSupported" << fileType;
+    // qDebug() << "isFileSupported" << fileType;
     return isFileTypeSupported(fileType);
 }
 

--- a/src/track/globaltrackcache.cpp
+++ b/src/track/globaltrackcache.cpp
@@ -776,8 +776,7 @@ TrackRef GlobalTrackCache::initTrackId(
     DEBUG_ASSERT(pDel);
 
     DEBUG_ASSERT(strongPtr == m_incompleteTrack);
-    m_incompleteTrack = nullptr;
-    m_isTrackCompleted.wakeAll();
+    discardIncompleteTrack();
 
     // Insert item by id
     DEBUG_ASSERT(m_tracksById.find(trackId) == m_tracksById.end());

--- a/src/track/serato/markers.cpp
+++ b/src/track/serato/markers.cpp
@@ -635,7 +635,7 @@ QByteArray SeratoMarkers::dumpMP4() const {
 }
 
 QList<CueInfo> SeratoMarkers::getCues() const {
-    qDebug() << "Reading cues from 'Serato Markers_' tag data...";
+    // qDebug() << "Reading cues from 'Serato Markers_' tag data...";
 
     QList<CueInfo> cueInfos;
     int cueIndex = 0;

--- a/src/track/serato/markers2.cpp
+++ b/src/track/serato/markers2.cpp
@@ -592,7 +592,7 @@ SeratoMarkers2EntryPointer SeratoMarkers2::findEntryByType(
 }
 
 QList<CueInfo> SeratoMarkers2::getCues() const {
-    qDebug() << "Reading cues from 'Serato Markers2' tag data...";
+    // qDebug() << "Reading cues from 'Serato Markers2' tag data...";
 
     QList<CueInfo> cueInfos;
 
@@ -795,7 +795,7 @@ QByteArray SeratoMarkers2::dumpFLAC() const {
 }
 
 std::optional<SeratoStoredTrackColor> SeratoMarkers2::getTrackColor() const {
-    kLogger.debug() << "Reading track color from 'Serato Markers2' tag data...";
+    // kLogger.debug() << "Reading track color from 'Serato Markers2' tag data...";
 
     for (const auto& pEntry : std::as_const(m_entries)) {
         VERIFY_OR_DEBUG_ASSERT(pEntry) {
@@ -845,7 +845,7 @@ void SeratoMarkers2::setTrackColor(SeratoStoredTrackColor color) {
 }
 
 bool SeratoMarkers2::isBpmLocked() const {
-    kLogger.debug() << "Reading bpmlock state from 'Serato Markers2' tag data...";
+    // kLogger.debug() << "Reading bpmlock state from 'Serato Markers2' tag data...";
 
     for (const auto& pEntry : std::as_const(m_entries)) {
         VERIFY_OR_DEBUG_ASSERT(pEntry) {

--- a/src/track/serato/tags.cpp
+++ b/src/track/serato/tags.cpp
@@ -280,7 +280,7 @@ QList<CueInfo> SeratoTags::getCueInfos() const {
     }
 
     const QList<CueInfo> cueInfos = cueMap.values();
-    qDebug() << "SeratoTags::getCueInfos()";
+    // qDebug() << "SeratoTags::getCueInfos()";
     for (const CueInfo& cueInfo : cueInfos) {
         qDebug() << cueInfo;
     }


### PR DESCRIPTION
This fixes #14563 a regression introduced in https://github.com/mixxxdj/mixxx/pull/13719 caused by an underlying issue with recursive calls to the track cache. 

I did some testing and backtrack analysis and can confirm the issue is now fixed. 
