### PR TITLE
(fix) Track menu: highlight row when hovering checkbox

### DIFF
--- a/src/widget/wsearchrelatedtracksmenu.cpp
+++ b/src/widget/wsearchrelatedtracksmenu.cpp
@@ -367,6 +367,8 @@ void WSearchRelatedTracksMenu::addActionsForTrack(
     m_pSearchAction->setDefaultWidget(pCheckBox.get());
     addAction(m_pSearchAction.get());
     m_pSearchAction->setDisabled(true);
+    // To fix the hover effect, see eventFilter() for details
+    m_pSearchAction->installEventFilter(this);
 
     // This is for Enter/Return key
     connect(m_pSearchAction.get(),
@@ -411,6 +413,14 @@ bool WSearchRelatedTracksMenu::eventFilter(QObject* pObj, QEvent* e) {
                 pBox->toggle();
             }
             return true;
+        }
+    } else if (e->type() == QEvent::HoverEnter && pObj != this) {
+        // The hover effect seems to be broken for widgets in QWidgetActions:
+        // hovering anything but the label or indicator won't highlight the
+        // entire row. Let's set focus manually.
+        QCheckBox* pBox = qobject_cast<QCheckBox*>(pObj);
+        if (pBox && pBox->isEnabled()) {
+            pBox->setFocus();
         }
     } else if (e->type() == QEvent::MouseButtonDblClick) {
         // Another quirk: double-click does first un/tick the box, the second

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -1545,6 +1545,10 @@ void WTrackMenu::slotPopulateCrateMenu() {
         //                    pCheckBox->palette().highlight().color().name()));
         pAction->setEnabled(!crate.isLocked());
         pAction->setDefaultWidget(pCheckBox.get());
+        // The hover effect seems to be broken for widgets in QWidgetActions:
+        // hovering anything but the label or indicator won't highlight the
+        // entire row. Let's set focus manually.
+        pCheckBox.get()->installEventFilter(this);
 
         if (crate.getTrackCount() == 0) {
             pCheckBox->setChecked(false);
@@ -1574,6 +1578,16 @@ void WTrackMenu::slotPopulateCrateMenu() {
     m_pCrateMenu->addAction(newCrateAction);
     connect(newCrateAction, &QAction::triggered, this, &WTrackMenu::addSelectionToNewCrate);
     m_bCrateMenuLoaded = true;
+}
+
+bool WTrackMenu::eventFilter(QObject* pObj, QEvent* e) {
+    if (e->type() == QEvent::HoverEnter && pObj != this) {
+        QCheckBox* pBox = qobject_cast<QCheckBox*>(pObj);
+        if (pBox) {
+            pBox->setFocus();
+        }
+    }
+    return QObject::eventFilter(pObj, e);
 }
 
 void WTrackMenu::updateSelectionCrates(QWidget* pWidget) {

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -113,6 +113,8 @@ class WTrackMenu : public QMenu {
     void slotRemoveFromDisk();
     const QString getDeckGroup() const;
 
+    bool eventFilter(QObject* pObj, QEvent* e) override;
+
   signals:
     void loadTrackToPlayer(TrackPointer pTrack, const QString& group, bool play = false);
     void trackMenuVisible(bool visible);


### PR DESCRIPTION
Previously, the checkbox rows in the crate menu and Search Related menu where highlighted only when the label or the indicator where hovered. (it would still respond to clicks, so this seems to be just a painting/focus issue)
![menu-hover](https://github.com/user-attachments/assets/635fd29a-dc5e-4485-9e00-0cf78e7d85a0)

### Fix
Focus the checkbox manually on **HoverEnter**
![menu-hover-fixed](https://github.com/user-attachments/assets/64308268-a542-4149-b726-7eea23cb0dde)

Note: the outcome is exactly the same as when selecting a checkbox with the keyboard, hence it does not interfere with `LibraryControl::getFocusedWidget()`.

### and
I also disabled double-click on the checkboxes. Apparently double-click first toggles the indicator, then triggers the action even though the event position is identical.