### PR TITLE
(fix) Search related menu: improve checkbox click UX

### DIFF
--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -3152,6 +3152,10 @@ QPlainTextEdit QMenu::item:disabled {
     border-top: 1px solid #000;
     border-bottom: 1px solid #333;
   }
+  /* use the same color for the vertical separator in Search related menu */
+  WSearchRelatedCheckBox {
+    qproperty-separatorColor: #333;
+  }
 
   #MainMenu QMenu::right-arrow,
   WTrackMenu::right-arrow,

--- a/src/widget/wsearchrelatedtracksmenu.cpp
+++ b/src/widget/wsearchrelatedtracksmenu.cpp
@@ -409,6 +409,11 @@ bool WSearchRelatedTracksMenu::eventFilter(QObject* pObj, QEvent* e) {
             }
             return true;
         }
+    } else if (e->type() == QEvent::MouseButtonDblClick) {
+        // Another quirk: double-click does first un/tick the box, the second
+        // click however triggers the action.
+        // Let's just disable double-click, it has no benefit here.
+        return true;
     }
     return QObject::eventFilter(pObj, e);
 }

--- a/src/widget/wsearchrelatedtracksmenu.h
+++ b/src/widget/wsearchrelatedtracksmenu.h
@@ -1,11 +1,30 @@
 #pragma once
 
+#include <QCheckBox>
 #include <QMenu>
 
 #include "util/parented_ptr.h"
 
 class Track;
 class QWidgetAction;
+
+class WSearchRelatedCheckBox : public QCheckBox {
+    Q_OBJECT
+  public:
+    explicit WSearchRelatedCheckBox(const QString& label,
+            QWidget* pParent = nullptr)
+            : QCheckBox(label, pParent) {
+    }
+
+    Q_PROPERTY(QColor separatorColor
+                    MEMBER m_separatorColor
+                            DESIGNABLE true);
+
+    void paintEvent(QPaintEvent*) override;
+
+  private:
+    QColor m_separatorColor;
+};
 
 class WSearchRelatedTracksMenu : public QMenu {
     Q_OBJECT


### PR DESCRIPTION
This improves the click UX in the Search Related menu:

**1)** click issue discovered in #14627:
currently only clicks **exactly on the checkbox indicator** un/tick the box, so if the click is accidentally slightly off to the left/top/bottom the action is triggered and the menu is closed.
**Fix:** Check if the `x` of the click event is left or right of the label boundary:
left: assume **indictator** click -> toggle, keep menu open
right/at: assume **label** click -> trigger, close menu

**2)** draw a vertical separator in between checkbox and label.
This should clarify that clicking the two regions label / chechbox has different effect.
It's done in the `paintEvent()` of the new `WSearchRelatedCheckBox` (only that method is overriden)
It has a custom qproperty that allows setting color in qss like this
```
WSearchRelatedCheckBox {
  qproperty-separatorColor: #333;
}
```
If it's not set, the text color from the `Disabled` palette is used
![Search-related-checkbox-separator](https://github.com/user-attachments/assets/6d711155-0a00-4947-834e-a85da5e8a351)



Fixes #14627