### PR TITLE
show effect knob parameter value when clicking knob

### DIFF
--- a/src/control/controleffectknob.cpp
+++ b/src/control/controleffectknob.cpp
@@ -5,7 +5,9 @@
 #include "util/math.h"
 
 ControlEffectKnob::ControlEffectKnob(const ConfigKey& key, double dMinValue, double dMaxValue)
-        : ControlPotmeter(key, dMinValue, dMaxValue) {
+        // Set `ingnoreNoOps` false so clicking a WEffectParameterKnobComposed
+        // triggers the associated WEffectParameterNameBase to show the value.
+        : ControlPotmeter(key, dMinValue, dMaxValue, false, false) {
 }
 
 void ControlEffectKnob::setBehaviour(EffectManifestParameter::ValueScaler type,

--- a/src/effects/effectknobparameterslot.cpp
+++ b/src/effects/effectknobparameterslot.cpp
@@ -231,3 +231,9 @@ void EffectKnobParameterSlot::syncSofttakeover() {
 double EffectKnobParameterSlot::getValueParameter() const {
     return m_pControlValue->getParameter();
 }
+
+bool EffectKnobParameterSlot::isLinkedToMetaKnob() const {
+    auto linkType = static_cast<EffectManifestParameter::LinkType>(
+            static_cast<int>(m_pControlLinkType->get()));
+    return linkType != EffectManifestParameter::LinkType::None;
+}

--- a/src/effects/effectknobparameterslot.h
+++ b/src/effects/effectknobparameterslot.h
@@ -39,6 +39,8 @@ class EffectKnobParameterSlot : public EffectParameterSlotBase {
 
     void setParameter(double value) override;
 
+    bool isLinkedToMetaKnob() const;
+
   private slots:
     // Solely for handling control changes
     void slotLinkTypeChanging(double v);

--- a/src/widget/knobeventhandler.h
+++ b/src/widget/knobeventhandler.h
@@ -67,7 +67,7 @@ class KnobEventHandler {
                 m_bRightButtonPressed = true;
                 break;
             case Qt::LeftButton:
-            case Qt::MiddleButton:
+            case Qt::MiddleButton: {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
                 m_startPos = e->globalPosition().toPoint();
 #else
@@ -77,7 +77,15 @@ class KnobEventHandler {
                 // Somehow using Qt::BlankCursor does not work on Windows
                 // https://mixxx.org/forums/viewtopic.php?p=40298#p40298
                 pWidget->setCursor(m_blankCursor);
+                // Re-set the current value so the ControlObject emits valueChanged.
+                // This works only if `ignoreNoOps` is false for the underlying
+                // ControlPotmeter. Currently only used by ControlEffectKnob
+                // to make clicking a WEffectParameterKnobComposed trigger the
+                // associated WEffectParameterNameBase to show the current value.
+                double currValue = pWidget->getControlParameter();
+                pWidget->setControlParameterDown(currValue);
                 break;
+            }
             default:
                 break;
         }

--- a/src/widget/weffectparameternamebase.cpp
+++ b/src/widget/weffectparameternamebase.cpp
@@ -20,8 +20,8 @@ WEffectParameterNameBase::WEffectParameterNameBase(
         QWidget* pParent, EffectsManager* pEffectsManager)
         : WLabel(pParent),
           m_pEffectsManager(pEffectsManager),
-          m_widthHint(0),
-          m_parameterUpdated(false) {
+          m_parameterUpdated(false),
+          m_widthHint(0) {
     setAcceptDrops(true);
     setCursor(Qt::OpenHandCursor);
     parameterUpdated();
@@ -97,9 +97,14 @@ void WEffectParameterNameBase::parameterUpdated() {
                           metrics.size(0, m_text).width()) +
             2 * frameWidth();
     setText(m_text);
-    // valueChanged() is also emitted after a new parameter has been loaded.
+    // valueChanged() is also emitted after a new parameter has been loaded if
+    // that is linked to the Meta knob.
     // We set a flag in order to not show the value in that case.
-    if (isVisible()) {
+    // Though only suppress it for those knobs! For unlinked knobs it would
+    // prevent showing the value on first click.
+    EffectKnobParameterSlot* paramKnob =
+            qobject_cast<EffectKnobParameterSlot*>(m_pParameterSlot.data());
+    if (isVisible() && paramKnob && paramKnob->isLinkedToMetaKnob()) {
         m_parameterUpdated = true;
     }
 }

--- a/src/widget/weffectparameternamebase.cpp
+++ b/src/widget/weffectparameternamebase.cpp
@@ -20,7 +20,8 @@ WEffectParameterNameBase::WEffectParameterNameBase(
         QWidget* pParent, EffectsManager* pEffectsManager)
         : WLabel(pParent),
           m_pEffectsManager(pEffectsManager),
-          m_widthHint(0) {
+          m_widthHint(0),
+          m_parameterUpdated(false) {
     setAcceptDrops(true);
     setCursor(Qt::OpenHandCursor);
     parameterUpdated();
@@ -40,8 +41,13 @@ void WEffectParameterNameBase::setEffectParameterSlot(
                 this,
                 &WEffectParameterNameBase::parameterUpdated);
         if (qobject_cast<EffectKnobParameterSlot*>(m_pParameterSlot.data())) {
-            // Make connection to show parameter value instead of name briefly
-            // after value has changed.
+            // If this is a knob parameter, make a connection to briefly show
+            // the parameter value instead of the name after value has changed.
+            // 'valueChanged' is also emitted when changed indirectly by the
+            // linked Meta knob.
+            // Note: actually we need the (final) implementation of showNewValue()
+            // only in WEffectKnobParameterName but for easy maintenance we keep
+            // it here in the base class.
             connect(m_pParameterSlot.data(),
                     &EffectParameterSlotBase::valueChanged,
                     this,
@@ -91,12 +97,14 @@ void WEffectParameterNameBase::parameterUpdated() {
                           metrics.size(0, m_text).width()) +
             2 * frameWidth();
     setText(m_text);
-    m_parameterUpdated = true;
+    // valueChanged() is also emitted after a new parameter has been loaded.
+    // We set a flag in order to not show the value in that case.
+    if (isVisible()) {
+        m_parameterUpdated = true;
+    }
 }
 
 void WEffectParameterNameBase::showNewValue(double newValue) {
-    // Don't show the value for a newly loaded parameter. 'valueChanged' is emitted
-    // if this parameter is linked to the Meta knob
     if (m_parameterUpdated) {
         m_parameterUpdated = false;
         return;


### PR DESCRIPTION
Fixes #14374 

Click the knob to show the parameter value in the parameter name label, like when turning the knob.
Enabled by constructing the parameter CO with `ignoreNoOps` = false and re-setting the current value on click.

This is still sort of a hack, but it's a minimal invasive and robust solution, compared to trying to connect the knob and label widgets as proposed in #14596.

We could also re-apply the current value in a new `ControlParameterWidgetConnection` function (get parameter, set parameter), but it makes no difference, except that we have more code to maintain. The test commit is d217c2e278

___
**edit** Oh, looks like this is still missing the fix to make it work on first click after changing the effect or swapping parameters (ie. after skin load). Will amend that soonish.