### PR TITLE
FFmpeg: Use internal aac decoder. If not available give a hint.

### DIFF
--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -582,7 +582,8 @@ SoundSource::OpenResult SoundSourceFFmpeg::tryOpen(
 
     if (pDecoder->id == AV_CODEC_ID_AAC ||
             pDecoder->id == AV_CODEC_ID_AAC_LATM) {
-        if (std::strcmp(pDecoder->name, "aac") != 0) {
+        // We only allow AAC decoders that pass our seeking tests
+        if (std::strcmp(pDecoder->name, "aac") != 0 && std::strcmp(pDecoder->name, "aac_at") != 0) {
             pAacDecoder = avcodec_find_decoder_by_name("aac");
             if (pAacDecoder) {
                 pDecoder = pAacDecoder;

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -599,6 +599,8 @@ SoundSource::OpenResult SoundSourceFFmpeg::tryOpen(
         }
     }
 
+    kLogger.debug() << "using decoder:" << pDecoder->long_name;
+
     // Select audio stream for decoding
     AVStream* pavStream = m_pavInputFormatContext->streams[av_find_best_stream_result];
     DEBUG_ASSERT(pavStream != nullptr);

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -593,7 +593,9 @@ SoundSource::OpenResult SoundSourceFFmpeg::tryOpen(
                            "build."
                         << "To enable AAC support, please install an FFmpeg "
                            "version with the internal aac decoder enabled."
-                        << "Note: AAC decoding may be subject to patent "
+                           "Note 1: The libfdk_aac decoder is no working properly "
+                           "with Mixxx, FFmpeg's internal AAC decoder does."
+                        << "Note 2: AAC decoding may be subject to patent "
                            "restrictions, depending on your country.";
             }
         }

--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -548,9 +548,11 @@ SoundSource::OpenResult SoundSourceFFmpeg::tryOpen(
     // Find the best stream
 #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(59, 0, 100) // FFmpeg 5.0
     const AVCodec* pDecoder = nullptr;
+    const AVCodec* pAacDecoder = nullptr;
 #else
     // https://github.com/FFmpeg/FFmpeg/blob/dd17c86aa11feae2b86de054dd0679cc5f88ebab/doc/APIchanges#L175
     AVCodec* pDecoder = nullptr;
+    AVCodec* pAacDecoder = nullptr;
 #endif
     const int av_find_best_stream_result = av_find_best_stream(
             m_pavInputFormatContext,
@@ -577,6 +579,24 @@ SoundSource::OpenResult SoundSourceFFmpeg::tryOpen(
         return SoundSource::OpenResult::Aborted;
     }
     DEBUG_ASSERT(pDecoder);
+
+    if (pDecoder->id == AV_CODEC_ID_AAC ||
+            pDecoder->id == AV_CODEC_ID_AAC_LATM) {
+        if (std::strcmp(pDecoder->name, "aac") != 0) {
+            pAacDecoder = avcodec_find_decoder_by_name("aac");
+            if (pAacDecoder) {
+                pDecoder = pAacDecoder;
+            } else {
+                kLogger.warning()
+                        << "Internal aac decoder not found in your FFmpeg "
+                           "build."
+                        << "To enable AAC support, please install an FFmpeg "
+                           "version with the internal aac decoder enabled."
+                        << "Note: AAC decoding may be subject to patent "
+                           "restrictions, depending on your country.";
+            }
+        }
+    }
 
     // Select audio stream for decoding
     AVStream* pavStream = m_pavInputFormatContext->streams[av_find_best_stream_result];

--- a/src/sources/soundsourcestem.cpp
+++ b/src/sources/soundsourcestem.cpp
@@ -115,6 +115,8 @@ SoundSource::OpenResult SoundSourceSingleSTEM::tryOpen(
 
     DEBUG_ASSERT(pDecoder);
 
+    kLogger.debug() << "using FFmpeg decoder:" << pDecoder->long_name;
+
     // Select the main mix stream for decoding
     AVStream* pavStream = selectedAudioStream;
     DEBUG_ASSERT(pavStream != nullptr);

--- a/src/sources/soundsourcestem.cpp
+++ b/src/sources/soundsourcestem.cpp
@@ -128,7 +128,9 @@ SoundSource::OpenResult SoundSourceSingleSTEM::tryOpen(
                            "build."
                         << "To enable AAC support, please install an FFmpeg "
                            "version with the internal aac decoder enabled."
-                        << "Note: AAC decoding may be subject to patent "
+                           "Note 1: The libfdk_aac decoder is no working properly "
+                           "with Mixxx, FFmpeg's internal AAC decoder does."
+                        << "Note 2: AAC decoding may be subject to patent "
                            "restrictions, depending on your country.";
             }
         }

--- a/src/sources/soundsourcestem.cpp
+++ b/src/sources/soundsourcestem.cpp
@@ -115,6 +115,25 @@ SoundSource::OpenResult SoundSourceSingleSTEM::tryOpen(
 
     DEBUG_ASSERT(pDecoder);
 
+    if (pDecoder->id == AV_CODEC_ID_AAC ||
+            pDecoder->id == AV_CODEC_ID_AAC_LATM) {
+        // We only allow AAC decoders that pass our seeking tests
+        if (std::strcmp(pDecoder->name, "aac") != 0 && std::strcmp(pDecoder->name, "aac_at") != 0) {
+            const AVCodec* pAacDecoder = avcodec_find_decoder_by_name("aac");
+            if (pAacDecoder) {
+                pDecoder = pAacDecoder;
+            } else {
+                kLogger.warning()
+                        << "Internal aac decoder not found in your FFmpeg "
+                           "build."
+                        << "To enable AAC support, please install an FFmpeg "
+                           "version with the internal aac decoder enabled."
+                        << "Note: AAC decoding may be subject to patent "
+                           "restrictions, depending on your country.";
+            }
+        }
+    }
+
     kLogger.debug() << "using FFmpeg decoder:" << pDecoder->long_name;
 
     // Select the main mix stream for decoding


### PR DESCRIPTION
User the known working internal aac encoder with ffmpeg. 
If it is not available give a hint how to fix it. 

This will help to not collect wrong metadata or suffer form audible artifacts with other aac codecs. 
Once we have succeeding tests with others we can enable them one by one. 

See also https://github.com/mixxxdj/mixxx/issues/14624