### PR TITLE
qmlwaveform: Fix moc in Qt 6.9.0

### DIFF
--- a/src/qml/qmlwaveformoverview.h
+++ b/src/qml/qmlwaveformoverview.h
@@ -58,7 +58,11 @@ class QmlWaveformOverview : public QQuickPaintedItem {
   signals:
     void playerChanged();
     void channelsChanged(mixxx::qml::QmlWaveformOverview::Channels channels);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+    void rendererChanged(Renderer renderer);
+#else
     void rendererChanged(mixxx::qml::QmlWaveformOverview::Renderer renderer);
+#endif
     void colorHighChanged(const QColor& color);
     void colorMidChanged(const QColor& color);
     void colorLowChanged(const QColor& color);

--- a/src/qml/qmlwaveformrenderer.h
+++ b/src/qml/qmlwaveformrenderer.h
@@ -397,7 +397,11 @@ class QmlWaveformRendererMark
   signals:
     void playMarkerColorChanged(const QColor&);
     void playMarkerBackgroundChanged(const QColor&);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+    void defaultMarkChanged(QmlWaveformMark*);
+#else
     void defaultMarkChanged(mixxx::qml::QmlWaveformMark*);
+#endif
 
   private:
     QColor m_playMarkerColor;


### PR DESCRIPTION
This PR addresses issue #14122 

Building mixxx on Arch Linux broke with the update to Qt `6.9.0`.

Moc is unable to generate signal calls correctly and the build fails with:
```
In file included from src/qml/qmlwaveformoverview.cpp:4:
build-2.5.0-release/mixxx-qml-lib_autogen/include/moc_qmlwaveformoverview.cpp: In static member function ‘static void mixxx::qml::QmlWaveformOverview::qt_static_metacall(QObject*, QMetaObject::Call, int, void**)’:
build-2.5.0-release/mixxx-qml-lib_autogen/include/moc_qmlwaveformoverview.cpp:237:43: error: no matching function for call to ‘mixxx::qml::QmlWaveformOverview::rendererChanged()’
  237 |                 Q_EMIT _t->rendererChanged();
      |                        ~~~~~~~~~~~~~~~~~~~^~
In file included from src/qml/qmlwaveformoverview.cpp:1:
src/qml/qmlwaveformoverview.h:61:10: note: candidate: ‘void mixxx::qml::QmlWaveformOverview::rendererChanged(Renderer)’
   61 |     void rendererChanged(mixxx::qml::QmlWaveformOverview::Renderer renderer);
      |          ^~~~~~~~~~~~~~~
src/qml/qmlwaveformoverview.h:61:10: note:   candidate expects 1 argument, 0 provided
make[2]: *** [CMakeFiles/mixxx-qml-lib.dir/build.make:557: CMakeFiles/mixxx-qml-lib.dir/src/qml/qmlwaveformoverview.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1654: CMakeFiles/mixxx-qml-lib.dir/all] Error 2
make: *** [Makefile:166: all] Error 2

```

This does not happen when scope qualifiers are removed from the parameter class types. They can be resolved since they are local anyway. Not sure why the absolute qualification was done previously.

This is also arguably a regression in moc, since it does work with `mixxx::qml::QmlWaveformOverview::Channels` in `channelsChanged`.

The patch removes scope annotations for class parameters in the `rendererChanged` and `defaultMarkChanged` signals.

I did not test this patch with Qt 6.8.

