### PR TITLE
Improve debug output in case of failing soundsource test

### DIFF
--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -125,9 +125,39 @@ class SoundSourceProxyTest : public MixxxTest, SoundSourceProviderRegistration {
             const CSAMPLE* expected,
             const CSAMPLE* actual,
             const char* errorMessage) {
-        for (SINT i = 0; i < size; ++i) {
-            EXPECT_NEAR(expected[i], actual[i], kMaxDecodingError)
-                    << "i=" << i << " " << errorMessage;
+        int error_count = 0;
+        SINT first = 0;
+        SINT last = 0;
+        SINT i = 0;
+        for (; i < size; ++i) {
+            if (std::abs(expected[i] - actual[i]) > kMaxDecodingError) {
+                error_count = 1;
+                first = i;
+                EXPECT_NEAR(expected[i], actual[i], kMaxDecodingError)
+                        << "i=" << i << " " << errorMessage;
+                break;
+            }
+        }
+        if (error_count == 1) {
+            std::ostringstream csv;
+            csv << std::setprecision(std::numeric_limits<CSAMPLE>::max_digits10);
+
+            csv << "sep=,\nexpected,actual,error\n"; // CSV header
+
+            for (SINT i = 0; i < size; ++i) {
+                csv << expected[i] << "," << actual[i];
+                if (std::abs(expected[i] - actual[i]) > kMaxDecodingError) {
+                    csv << ",1\n";
+                    error_count++;
+                    last = i;
+                } else {
+                    csv << ",0\n";
+                }
+            }
+            std::cout << "CSV debug output with " << error_count
+                      << " errors in the range " << first << " to " << last
+                      << ":\n"
+                      << csv.str();
         }
     }
 

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -129,11 +129,18 @@ class SoundSourceProxyTest : public MixxxTest, SoundSourceProviderRegistration {
         SINT first = 0;
         SINT last = 0;
         SINT i = 0;
-        for (; i < size; ++i) {
+        for (; i < size - 1; i += 2) {
             if (std::abs(expected[i] - actual[i]) > kMaxDecodingError) {
                 error_count = 1;
                 first = i;
                 EXPECT_NEAR(expected[i], actual[i], kMaxDecodingError)
+                        << "i=" << i << " " << errorMessage;
+                break;
+            }
+            if (std::abs(expected[i + 1] - actual[i + 1]) > kMaxDecodingError) {
+                error_count = 1;
+                first = i;
+                EXPECT_NEAR(expected[i + 1], actual[i + 1], kMaxDecodingError)
                         << "i=" << i << " " << errorMessage;
                 break;
             }
@@ -142,11 +149,14 @@ class SoundSourceProxyTest : public MixxxTest, SoundSourceProviderRegistration {
             std::ostringstream csv;
             csv << std::setprecision(std::numeric_limits<CSAMPLE>::max_digits10);
 
-            csv << "sep=,\nexpected,actual,error\n"; // CSV header
+            csv << "sep=,\nexpected left,expected right,actual left, actual "
+                   "right, error\n"; // CSV header
 
-            for (SINT i = 0; i < size; ++i) {
-                csv << expected[i] << "," << actual[i];
-                if (std::abs(expected[i] - actual[i]) > kMaxDecodingError) {
+            for (SINT i = 0; i < size - 1; i += 2) {
+                csv << expected[i] << "," << expected[i + 1] << "," << actual[i]
+                    << "," << actual[i + 1];
+                if (std::abs(expected[i] - actual[i]) > kMaxDecodingError ||
+                        std::abs(expected[i + 1] - actual[i + 1]) > kMaxDecodingError) {
                     csv << ",1\n";
                     error_count++;
                     last = i;
@@ -155,7 +165,7 @@ class SoundSourceProxyTest : public MixxxTest, SoundSourceProviderRegistration {
                 }
             }
             std::cout << "CSV debug output with " << error_count
-                      << " errors in the range " << first << " to " << last
+                      << " errors in the range " << first / 2 << " to " << last / 2
                       << ":\n"
                       << csv.str();
         }

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -129,18 +129,11 @@ class SoundSourceProxyTest : public MixxxTest, SoundSourceProviderRegistration {
         SINT first = 0;
         SINT last = 0;
         SINT i = 0;
-        for (; i < size - 1; i += 2) {
+        for (; i < size; ++i) {
             if (std::abs(expected[i] - actual[i]) > kMaxDecodingError) {
                 error_count = 1;
                 first = i;
                 EXPECT_NEAR(expected[i], actual[i], kMaxDecodingError)
-                        << "i=" << i << " " << errorMessage;
-                break;
-            }
-            if (std::abs(expected[i + 1] - actual[i + 1]) > kMaxDecodingError) {
-                error_count = 1;
-                first = i;
-                EXPECT_NEAR(expected[i + 1], actual[i + 1], kMaxDecodingError)
                         << "i=" << i << " " << errorMessage;
                 break;
             }

--- a/src/util/indexrange.cpp
+++ b/src/util/indexrange.cpp
@@ -104,7 +104,7 @@ std::optional<IndexRange> intersect2(IndexRange lhs, IndexRange rhs) {
 }
 
 std::ostream& operator<<(std::ostream& os, IndexRange arg) {
-    return os << '[' << arg.start() << " -> " << arg.end() << ')';
+    return os << '[' << arg.start() << " -> " << arg.end() << ']';
 }
 
 QDebug operator<<(QDebug dbg, IndexRange arg) {


### PR DESCRIPTION
Instead of a never ending list of Google Test failures, this outputs only the first issue per challenge and than gives a brief statistics about the rest of the buffer plus all samples in csv format.

This is hopefully the right tool to decide about decoder seek qualities. 

The visualization can than look like this using LibreOffice: 

![grafik](https://github.com/user-attachments/assets/cbe04988-52d4-4f2e-9001-894476856bfd)
