### PR TITLE
(fix) reset saved loop when toggling off after switching cue type

### DIFF
--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -2379,6 +2379,11 @@ void CueControl::slotLoopEnabledChanged(bool enabled) {
         return;
     }
 
+    if (pSavedLoopControl->getType() != mixxx::CueType::Loop) {
+        slotLoopReset();
+        return;
+    }
+
     DEBUG_ASSERT(pSavedLoopControl->getStatus() != HotcueControl::Status::Empty);
     DEBUG_ASSERT(pSavedLoopControl->getCue() &&
             pSavedLoopControl->getCue()->getPosition() ==
@@ -2403,7 +2408,8 @@ void CueControl::slotLoopUpdated(mixxx::audio::FramePos startPosition,
         return;
     }
 
-    if (pSavedLoopControl->getStatus() != HotcueControl::Status::Active) {
+    if (pSavedLoopControl->getStatus() != HotcueControl::Status::Active ||
+            pSavedLoopControl->getType() != mixxx::CueType::Loop) {
         slotLoopReset();
         return;
     }
@@ -2720,6 +2726,12 @@ void HotcueControl::setPosition(mixxx::audio::FramePos position) {
 
 void HotcueControl::setEndPosition(mixxx::audio::FramePos endPosition) {
     m_hotcueEndPosition->set(endPosition.toEngineSamplePosMaybeInvalid());
+}
+
+mixxx::CueType HotcueControl::getType() const {
+    // Cast to int before casting to the int-based enum class because MSVC will
+    // throw a hissy fit otherwise.
+    return static_cast<mixxx::CueType>(static_cast<int>(m_hotcueType->get()));
 }
 
 void HotcueControl::setType(mixxx::CueType type) {

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -91,6 +91,7 @@ class HotcueControl : public QObject {
     mixxx::audio::FramePos getEndPosition() const;
     void setEndPosition(mixxx::audio::FramePos endPosition);
 
+    mixxx::CueType getType() const;
     void setType(mixxx::CueType type);
 
     void setStatus(HotcueControl::Status status);


### PR DESCRIPTION
Fixes #14657 

Partial backport of a7874047327d3cea418924b114892c9aef519387 from #13216 