### PR TITLE
Track Info Multi: add comment Find/Replace/Insert controls

### DIFF
--- a/src/library/dlgtrackinfomulti.h
+++ b/src/library/dlgtrackinfomulti.h
@@ -67,6 +67,8 @@ class DlgTrackInfoMulti : public QDialog, public Ui::DlgTrackInfoMulti {
     void slotCoverInfoSelected(const CoverInfoRelative& coverInfo);
     void slotReloadCoverArt();
 
+    void slotCommentEditModeChanged(QAbstractButton* pBtn);
+
     void slotOpenInFileBrowser();
 
   private:

--- a/src/library/dlgtrackinfomulti.ui
+++ b/src/library/dlgtrackinfomulti.ui
@@ -394,6 +394,44 @@
         </property>
        </widget>
       </item>
+      <item row="8" column="0">
+       <layout class="QVBoxLayout" name="comment_edit_mode_layout">
+        <item>
+         <widget class="QRadioButton" name="btnCommentSelect">
+          <property name="text">
+           <string>Select</string>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">commentEditModeGroup</string>
+          </attribute>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="btnCommentReplace">
+          <property name="text">
+           <string>Find/Replace</string>
+          </property>
+          <attribute name="buttonGroup">
+           <string notr="true">commentEditModeGroup</string>
+          </attribute>
+         </widget>
+        </item>
+        <item row="2" column="0" colspan="2">
+          <spacer name="spacerCommentEditSpacer2">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </spacer>
+         </item>
+       </layout>
+      </item>
+
       <item row="8" column="1" colspan="3">
        <widget class="QPlainTextEdit" name="txtComment">
         <property name="sizePolicy">
@@ -405,6 +443,78 @@
         <property name="tabChangesFocus">
          <bool>true</bool>
         </property>
+       </widget>
+      </item>
+
+      <item row="8" column="1" colspan="3">
+       <widget class="QWidget" name="commentFindReplaceBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <layout class="QGridLayout" name="comment_edit_fields_layout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="labelCommentFind">
+           <property name="text">
+            <string>Find</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLineEdit" name="txtCommentFind">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="labelCommentReplace">
+           <property name="text">
+            <string>Replace / Insert</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLineEdit" name="txtCommentReplace">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0" colspan="2">
+          <spacer name="spacerCommentEditSpacer2">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </spacer>
+         </item>
+        </layout>
        </widget>
       </item>
 
@@ -421,7 +531,7 @@
       <item row="9" column="1" colspan="3">
        <widget class="QPushButton" name="btnColorPicker">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
@@ -744,6 +854,10 @@
   <tabstop>txtGenre</tabstop>
   <tabstop>txtGrouping</tabstop>
   <tabstop>txtCommentBox</tabstop>
+  <tabstop>btnCommentSelect</tabstop>
+  <tabstop>btnCommentReplace</tabstop>
+  <tabstop>txtCommentFind</tabstop>
+  <tabstop>txtCommentReplace</tabstop>
   <tabstop>txtComment</tabstop>
   <tabstop>txtYear</tabstop>
   <tabstop>txtKey</tabstop>
@@ -755,5 +869,8 @@
   <tabstop>btnOK</tabstop>
  </tabstops>
  <resources/>
+ <buttongroups>
+  <buttongroup name="commentEditModeGroup"/>
+ </buttongroups>
  <connections/>
 </ui>


### PR DESCRIPTION
Just wanted to share my implementation of a simple find/replace dialog for the multi-tack Track Info dialog.
It's mainly supposed to help with how I use comments usage/workflow:
first line of the track comment is always a row of tags, like genre, and some other hints, which I can easily edit in the decks (only first line is shown in that editor).
Now I can mass-replace tags, eg. classic -> klassik, tekno -> techno

**Select** uses the current implementation with the combobox and text editor.
**Find/replace** switches to the Find & Replace mask and replaces the first occurence of the text
Just one special feature ( which could actually be the 3rd mode "Insert"):
if the **Find** field is empty, the replace string (+ whitespace) is inserted before the comment.

I'll probably tweak standard find/replace to parse only the first line of the comment to not accidentally mess up my Bandcamp album/track links in line 3.

![image](https://github.com/user-attachments/assets/0d8cbd9d-bd08-46df-9dd1-810c37167c4c)

If there is interest I'll make it ready to be merged.
