### PR TITLE
Fix: white-noise-improve-usability (#11868)

### DIFF
--- a/src/effects/backends/builtin/whitenoiseeffect.cpp
+++ b/src/effects/backends/builtin/whitenoiseeffect.cpp
@@ -1,11 +1,13 @@
 #include "effects/backends/builtin/whitenoiseeffect.h"
 
+#include "control/controlproxy.h"
 #include "effects/backends/effectmanifest.h"
 #include "engine/effects/engineeffectparameter.h"
 #include "util/rampingvalue.h"
 
 namespace {
 const QString dryWetParameterId = QStringLiteral("dry_wet");
+const QString gainParameterId = QStringLiteral("gain");
 } // anonymous namespace
 
 // static
@@ -33,12 +35,23 @@ EffectManifestPointer WhiteNoiseEffect::getManifest() {
     drywet->setDefaultLinkType(EffectManifestParameter::LinkType::Linked);
     drywet->setRange(0, 1, 1);
 
+    // This is gain parameter
+    EffectManifestParameterPointer gain = pManifest->addParameter();
+    gain->setId(gainParameterId);
+    gain->setName(QObject::tr("Gain"));
+    gain->setDescription(QObject::tr("Gain for white noise"));
+    gain->setValueScaler(EffectManifestParameter::ValueScaler::Linear);
+    gain->setUnitsHint(EffectManifestParameter::UnitsHint::Unknown);
+    gain->setDefaultLinkType(EffectManifestParameter::LinkType::None);
+    gain->setRange(0, 1, 1);
+
     return pManifest;
 }
 
 void WhiteNoiseEffect::loadEngineEffectParameters(
         const QMap<QString, EngineEffectParameterPointer>& parameters) {
     m_pDryWetParameter = parameters.value(dryWetParameterId);
+    m_pGainParameter = parameters.value(gainParameterId);
 }
 
 void WhiteNoiseEffect::processChannel(
@@ -52,21 +65,41 @@ void WhiteNoiseEffect::processChannel(
 
     WhiteNoiseGroupState& gs = *pState;
 
+    // Get dry/wet control value and set up ramping
     CSAMPLE drywet = static_cast<CSAMPLE>(m_pDryWetParameter->value());
     RampingValue<CSAMPLE_GAIN> drywet_ramping_value(
             drywet, gs.previous_drywet, engineParameters.framesPerBuffer());
 
+    // Generate white noise
     std::uniform_real_distribution<> r_distributor(0.0, 1.0);
-
-    for (SINT i = 0; i < engineParameters.samplesPerBuffer(); i++) {
-        CSAMPLE_GAIN drywet_ramped = drywet_ramping_value.getNth(i);
-
-        float noise = static_cast<float>(
-                r_distributor(gs.gen));
-
-        pOutput[i] = pInput[i] * (1 - drywet_ramped) + noise * drywet_ramped;
+    const auto bufferSize = engineParameters.samplesPerBuffer();
+    for (unsigned int i = 0; i < bufferSize; ++i) {
+        float noise = static_cast<float>(r_distributor(gs.gen));
+        // Apply silence threshold to the generated noise
+        if (std::abs(noise) < 0.0078f) {
+            noise = 0.0f;
+        }
+        gs.m_noiseBuffer[i] = noise;
     }
 
+    // Apply high-pass and low-pass filtering to the noise
+    gs.m_highpass.process(gs.m_noiseBuffer.data(), gs.m_filteredBuffer.data(), bufferSize);
+    gs.m_lowpass.process(gs.m_filteredBuffer.data(), gs.m_filteredBuffer.data(), bufferSize);
+
+    // Get the master gain value
+    CSAMPLE gain = static_cast<CSAMPLE>(m_pGainParameter->value());
+
+    // Mix dry and wet signals, apply gain and ramp the dry/wet effect
+    for (unsigned int i = 0; i < bufferSize; ++i) {
+        CSAMPLE_GAIN drywet_ramped = drywet_ramping_value.getNth(i);
+
+        // Apply the dry/wet control and gain to the output signal
+        pOutput[i] = (pInput[i] * (1 - drywet_ramped) +
+                             gs.m_filteredBuffer[i] * drywet_ramped) *
+                gain;
+    }
+
+    // Store the current drywet value for the next buffer
     if (enableState == EffectEnableState::Disabling) {
         gs.previous_drywet = 0;
     } else {

--- a/src/effects/backends/builtin/whitenoiseeffect.h
+++ b/src/effects/backends/builtin/whitenoiseeffect.h
@@ -3,21 +3,32 @@
 #include <random>
 
 #include "effects/backends/effectprocessor.h"
+#include "engine/filters/enginefilterbiquad1.h"
 #include "util/class.h"
+#include "util/samplebuffer.h"
 #include "util/types.h"
 
 class WhiteNoiseGroupState final : public EffectState {
   public:
-    WhiteNoiseGroupState(const mixxx::EngineParameters& engineParameters)
-            : EffectState(engineParameters),
+    WhiteNoiseGroupState(const mixxx::EngineParameters& bufferParameters)
+            : EffectState(bufferParameters),
               previous_drywet(0.0),
-              gen(rs()) {
+              gen(rs()),
+              m_highpass(bufferParameters.sampleRate(), 20.0, 0.707, false),
+              m_lowpass(bufferParameters.sampleRate(), 20000.0, 0.707, false),
+              m_noiseBuffer(bufferParameters.samplesPerBuffer()),
+              m_filteredBuffer(bufferParameters.samplesPerBuffer()) {
     }
-    ~WhiteNoiseGroupState() override = default;
 
     CSAMPLE_GAIN previous_drywet;
     std::random_device rs;
     std::mt19937 gen;
+
+    EngineFilterBiquad1High m_highpass;
+    EngineFilterBiquad1Low m_lowpass;
+
+    mixxx::SampleBuffer m_noiseBuffer;
+    mixxx::SampleBuffer m_filteredBuffer;
 };
 
 class WhiteNoiseEffect : public EffectProcessorImpl<WhiteNoiseGroupState> {
@@ -41,6 +52,7 @@ class WhiteNoiseEffect : public EffectProcessorImpl<WhiteNoiseGroupState> {
 
   private:
     EngineEffectParameterPointer m_pDryWetParameter;
+    EngineEffectParameterPointer m_pGainParameter;
 
     DISALLOW_COPY_AND_ASSIGN(WhiteNoiseEffect);
 };


### PR DESCRIPTION
Fix: Improve usability of White Noise effect #11868 
- Added a Gain (Gain knob) parameter
- Applied silence under 0.0078
- Implemented filtered white noise using high-pass and low-pass biquad filters (cutting frequencies below 20 Hz and above 20,000 Hz)
- Mapped the Meta knob to control only Dry/Wet, not Gain

If you spot anything that could be improved or if my approach seems off, I’d really appreciate your suggestions!