### PR TITLE
add WMenuCheckBox, to be used in QWidgetAction in some menus

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1311,6 +1311,7 @@ add_library(mixxx-lib STATIC EXCLUDE_FROM_ALL
   src/widget/wlibrarytableview.cpp
   src/widget/wlibrarytextbrowser.cpp
   src/widget/wmainmenubar.cpp
+  src/widget/wmenucheckbox.cpp
   src/widget/wnumber.cpp
   src/widget/wnumberdb.cpp
   src/widget/wnumberpos.cpp

--- a/src/widget/weffectchainpresetbutton.cpp
+++ b/src/widget/weffectchainpresetbutton.cpp
@@ -1,6 +1,5 @@
 #include "widget/weffectchainpresetbutton.h"
 
-#include <QCheckBox>
 #include <QWidgetAction>
 
 #include "effects/effectparameter.h"
@@ -11,6 +10,7 @@
 #include "moc_weffectchainpresetbutton.cpp"
 #include "util/parented_ptr.h"
 #include "widget/effectwidgetutils.h"
+#include "widget/wmenucheckbox.h"
 
 WEffectChainPresetButton::WEffectChainPresetButton(QWidget* parent, EffectsManager* pEffectsManager)
         : QPushButton(parent),
@@ -138,7 +138,7 @@ void WEffectChainPresetButton::populateMenu() {
             const auto& hiddenParameters = pEffectSlot->getHiddenParameters().value(parameterType);
             for (const auto& parameters : {loadedParameters, hiddenParameters}) {
                 for (const auto& pParameter : parameters) {
-                    auto pCheckbox = make_parented<QCheckBox>(pEffectMenu);
+                    auto pCheckbox = make_parented<WMenuCheckBox>(pEffectMenu);
                     pCheckbox->setChecked(true);
                     pCheckbox->setText(pParameter->manifest()->name());
 #if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)

--- a/src/widget/wmenucheckbox.cpp
+++ b/src/widget/wmenucheckbox.cpp
@@ -1,0 +1,28 @@
+#include "widget/wmenucheckbox.h"
+
+#include <QMouseEvent>
+
+#include "moc_wmenucheckbox.cpp"
+
+WMenuCheckBox::WMenuCheckBox(QWidget* pParent)
+        : WMenuCheckBox(QString(), pParent) {
+}
+
+WMenuCheckBox::WMenuCheckBox(const QString& label, QWidget* pParent)
+        : QCheckBox(label, pParent) {
+    installEventFilter(this);
+}
+
+bool WMenuCheckBox::eventFilter(QObject* pObj, QEvent* pEvent) {
+    if (isEnabled() && pEvent->type() == QEvent::HoverEnter) {
+        setFocus(Qt::MouseFocusReason);
+    } else if (pEvent->type() == QEvent::HoverLeave) {
+        // Also explicitly clear focus. This is required when we have other
+        // Q[Widget]Actions in the same menu which have a 'selected' but no
+        // 'focus' property.
+        clearFocus();
+    } else if (pEvent->type() == QEvent::MouseButtonDblClick) {
+        return true;
+    }
+    return QCheckBox::eventFilter(pObj, pEvent);
+}

--- a/src/widget/wmenucheckbox.h
+++ b/src/widget/wmenucheckbox.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <QCheckBox>
+
+/// This is a custom QCheckBox fixing some bugs/quirks that occur when QCheckBox
+/// is packed into QWidgetAction for use in QMenu.
+/// 1. fixed hover behavior: get focused (highlighted) on hover, no matter
+/// where the pointer is. With original QCheckBox it'd only get focused
+/// when the pointer hovers the label or the [ ] indicator -- hovering the
+/// whitespace next to narrow labels had no effect.
+/// 2. block double-clicks: originally, in conjunction with QWidgetAction, those
+/// would first toggle the checkbox, then make the QWidgetAction emit the
+/// 'activated' signal and thereby close the menu unexpectedly.
+///
+/// Currently used in WTrackTableViewHeader menu, WTrackMenu's Crates menu and
+/// WSearchrelatedMenu.
+class WMenuCheckBox : public QCheckBox {
+    Q_OBJECT
+  public:
+    explicit WMenuCheckBox(QWidget* pParent = nullptr);
+    explicit WMenuCheckBox(const QString& label, QWidget* pParent = nullptr);
+
+    bool eventFilter(QObject* pObj, QEvent* pEvent) override;
+};

--- a/src/widget/wsearchrelatedtracksmenu.cpp
+++ b/src/widget/wsearchrelatedtracksmenu.cpp
@@ -361,14 +361,13 @@ void WSearchRelatedTracksMenu::addActionsForTrack(
 
     // Make the Search button a checkbox to simplify setting an icon via qss.
     // This is not possible with a QAction, and tedious with a QPushButton.
-    auto pCheckBox = make_parented<QCheckBox>(tr("&Search selected"), this);
+    // Use a custom QCheckBox with fixed hover behavior.
+    auto pCheckBox = make_parented<WMenuCheckBox>(tr("&Search selected"), this);
     pCheckBox->setObjectName("SearchSelectedAction");
     m_pSearchAction = make_parented<QWidgetAction>(this);
     m_pSearchAction->setDefaultWidget(pCheckBox.get());
     addAction(m_pSearchAction.get());
     m_pSearchAction->setDisabled(true);
-    // To fix the hover effect, see eventFilter() for details
-    m_pSearchAction->installEventFilter(this);
 
     // This is for Enter/Return key
     connect(m_pSearchAction.get(),
@@ -414,19 +413,6 @@ bool WSearchRelatedTracksMenu::eventFilter(QObject* pObj, QEvent* e) {
             }
             return true;
         }
-    } else if (e->type() == QEvent::HoverEnter && pObj != this) {
-        // The hover effect seems to be broken for widgets in QWidgetActions:
-        // hovering anything but the label or indicator won't highlight the
-        // entire row. Let's set focus manually.
-        QCheckBox* pBox = qobject_cast<QCheckBox*>(pObj);
-        if (pBox && pBox->isEnabled()) {
-            pBox->setFocus();
-        }
-    } else if (e->type() == QEvent::MouseButtonDblClick) {
-        // Another quirk: double-click does first un/tick the box, the second
-        // click however triggers the action.
-        // Let's just disable double-click, it has no benefit here.
-        return true;
     }
     return QObject::eventFilter(pObj, e);
 }

--- a/src/widget/wsearchrelatedtracksmenu.h
+++ b/src/widget/wsearchrelatedtracksmenu.h
@@ -1,19 +1,22 @@
 #pragma once
 
-#include <QCheckBox>
 #include <QMenu>
 
 #include "util/parented_ptr.h"
+#include "widget/wmenucheckbox.h"
 
 class Track;
 class QWidgetAction;
 
-class WSearchRelatedCheckBox : public QCheckBox {
+/// Extension of WMenuCheckBox with a vertical separator bar in between the
+/// label and the indicator box. This is supposed to clarify the different
+/// behavior of clicks in these two regions.
+class WSearchRelatedCheckBox : public WMenuCheckBox {
     Q_OBJECT
   public:
     explicit WSearchRelatedCheckBox(const QString& label,
             QWidget* pParent = nullptr)
-            : QCheckBox(label, pParent) {
+            : WMenuCheckBox(label, pParent) {
     }
 
     Q_PROPERTY(QColor separatorColor

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -46,6 +46,7 @@
 #include "widget/wcoverartlabel.h"
 #include "widget/wcoverartmenu.h"
 #include "widget/wfindonwebmenu.h"
+#include "widget/wmenucheckbox.h"
 #include "widget/wsearchrelatedtracksmenu.h"
 // WStarRating is required for DlgTrackInfo
 #include "widget/wstarrating.h"
@@ -1524,7 +1525,8 @@ void WTrackMenu::slotPopulateCrateMenu() {
     while (allCrates.populateNext(&crate)) {
         auto pAction = make_parented<QWidgetAction>(
                 m_pCrateMenu);
-        auto pCheckBox = make_parented<QCheckBox>(
+        // Use a custom QCheckBox with fixed hover behavior.
+        auto pCheckBox = make_parented<WMenuCheckBox>(
                 mixxx::escapeTextPropertyWithoutShortcuts(crate.getName()),
                 m_pCrateMenu);
         pCheckBox->setProperty("crateId", QVariant::fromValue(crate.getId()));
@@ -1545,10 +1547,6 @@ void WTrackMenu::slotPopulateCrateMenu() {
         //                    pCheckBox->palette().highlight().color().name()));
         pAction->setEnabled(!crate.isLocked());
         pAction->setDefaultWidget(pCheckBox.get());
-        // The hover effect seems to be broken for widgets in QWidgetActions:
-        // hovering anything but the label or indicator won't highlight the
-        // entire row. Let's set focus manually.
-        pCheckBox.get()->installEventFilter(this);
 
         if (crate.getTrackCount() == 0) {
             pCheckBox->setChecked(false);
@@ -1578,16 +1576,6 @@ void WTrackMenu::slotPopulateCrateMenu() {
     m_pCrateMenu->addAction(newCrateAction);
     connect(newCrateAction, &QAction::triggered, this, &WTrackMenu::addSelectionToNewCrate);
     m_bCrateMenuLoaded = true;
-}
-
-bool WTrackMenu::eventFilter(QObject* pObj, QEvent* e) {
-    if (e->type() == QEvent::HoverEnter && pObj != this) {
-        QCheckBox* pBox = qobject_cast<QCheckBox*>(pObj);
-        if (pBox) {
-            pBox->setFocus();
-        }
-    }
-    return QObject::eventFilter(pObj, e);
 }
 
 void WTrackMenu::updateSelectionCrates(QWidget* pWidget) {

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -113,8 +113,6 @@ class WTrackMenu : public QMenu {
     void slotRemoveFromDisk();
     const QString getDeckGroup() const;
 
-    bool eventFilter(QObject* pObj, QEvent* e) override;
-
   signals:
     void loadTrackToPlayer(TrackPointer pTrack, const QString& group, bool play = false);
     void trackMenuVisible(bool visible);

--- a/src/widget/wtracktableviewheader.cpp
+++ b/src/widget/wtracktableviewheader.cpp
@@ -8,6 +8,7 @@
 #include "moc_wtracktableviewheader.cpp"
 #include "util/math.h"
 #include "util/parented_ptr.h"
+#include "widget/wmenucheckbox.h"
 
 #define WTTVH_MINIMUM_SECTION_SIZE 20
 
@@ -164,7 +165,8 @@ void WTrackTableViewHeader::setModel(QAbstractItemModel* model) {
 
         QString title = model->headerData(i, orientation()).toString();
 
-        auto pCheckBox = make_parented<QCheckBox>(title, &m_menu);
+        // Custom QCheckBox with fixed hover behavior
+        auto pCheckBox = make_parented<WMenuCheckBox>(title, &m_menu);
         // Keep a map of checkboxes and columns
         m_columnCheckBoxes.insert(i, pCheckBox.get());
         connect(pCheckBox.get(),


### PR DESCRIPTION
Follow-up for #14636 

I moved the existing hover & double-click fixex a separate class (very minimal) which can now be used in any menu.
(fixes for quirks with QCheckBox in QWidgetAction in QMenus)

This allows to make the checkbox behavior consistent in
* Track menu -> Crates
* Track menu -> Search Related
* track table header menu
* effect chain preset menu