### PR TITLE
(feat) Computer feature: use library data model if selected path is watched by library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1456,6 +1456,7 @@ add_library(
   src/library/searchqueryparser.cpp
   src/library/serato/seratofeature.cpp
   src/library/serato/seratoplaylistmodel.cpp
+  src/library/sidebaritemdelegate.cpp
   src/library/sidebarmodel.cpp
   src/library/starrating.cpp
   src/library/tabledelegates/bpmdelegate.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1384,6 +1384,7 @@ add_library(
   src/library/basetrackcache.cpp
   src/library/basetracktablemodel.cpp
   src/library/browse/browsefeature.cpp
+  src/library/browse/browselibrarytablemodel.cpp
   src/library/browse/browsetablemodel.cpp
   src/library/browse/browsethread.cpp
   src/library/browse/foldertreemodel.cpp

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -2996,6 +2996,7 @@ WLibrarySidebar {
 }
 WLibrarySidebar {
   outline: none;
+  qproperty-watchedPathColor: #00ffff;
 }
 /* Selected rows in Tree and Tracks table */
 WLibrarySidebar::item:selected,

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -204,11 +204,11 @@ void BrowseFeature::slotAddToLibrary() {
     }
 
     if (!m_pLibrary->requestAddDir(path)) {
+        // Return if adding failed due to missing/unreadable/SQL error,
+        // or if the directory is already watched.
         return;
     }
 
-    // TODO Check if this really added a new directory. Ignore if it's a child
-    // of an already watched directory. Notify if it failed for another reason.
     QMessageBox msgBox;
     msgBox.setIcon(QMessageBox::Warning);
     // strings are dupes from DlgPrefLibrary

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -213,9 +213,16 @@ void BrowseFeature::slotAddToLibrary() {
     msgBox.setIcon(QMessageBox::Warning);
     // strings are dupes from DlgPrefLibrary
     msgBox.setWindowTitle(tr("Music Directory Added"));
-    msgBox.setText(tr("You added one or more music directories. The tracks in "
-                      "these directories won't be available until you rescan "
-                      "your library. Would you like to rescan now?"));
+    QString msgText = tr(
+            "You added one or more music directories. The tracks in "
+            "these directories won't be available until you rescan "
+            "your library. Would you like to rescan now?");
+    msgText.append(QStringLiteral("\n\n"));
+    msgText.append(tr(
+            "If yes, you also need to click the directory again after the"
+            "scan in order to switch from the current file tag view to the "
+            "library view for this directory."));
+    msgBox.setText(msgText);
     QPushButton* scanButton = msgBox.addButton(
         tr("Scan"), QMessageBox::AcceptRole);
     msgBox.addButton(QMessageBox::Cancel);

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -169,7 +169,8 @@ BrowseFeature::BrowseFeature(Library* pLibrary,
     for (const QString& quickLinkPath : std::as_const(m_quickLinkList)) {
         QString name = extractNameFromPath(quickLinkPath);
         qDebug() << "Appending Quick Link: " << name << "---" << quickLinkPath;
-        m_pQuickLinkItem->appendChild(name, quickLinkPath);
+        auto pItem = createPathTreeItem(name, quickLinkPath);
+        m_pQuickLinkItem->insertChild(m_pQuickLinkItem->childRows(), std::move(pItem));
     }
 
     // initialize the model
@@ -189,13 +190,14 @@ void BrowseFeature::slotAddQuickLink() {
         return;
     }
 
-    const QString name = extractNameFromPath(path);
-
     const QModelIndex parent = m_pSidebarModel->index(m_pQuickLinkItem->parentRow(), 0);
     std::vector<std::unique_ptr<TreeItem>> rows;
     // TODO() Use here std::span to get around the heap allocation of
     // std::vector for a single element.
-    rows.push_back(std::make_unique<TreeItem>(name, path));
+    const QString name = extractNameFromPath(path);
+    qDebug() << "Appending Quick Link: " << name << "---" << path;
+    auto pItem = createPathTreeItem(name, path);
+    rows.emplace_back(std::move(pItem));
     m_pSidebarModel->insertTreeItemRows(std::move(rows), m_pQuickLinkItem->childRows(), parent);
 
     m_quickLinkList.append(path);
@@ -401,16 +403,15 @@ void BrowseFeature::onRightClickChild(const QPoint& globalPos, const QModelIndex
         menu.addAction(m_pAddQuickLinkAction);
     }
 
-    if (!isPathWatched(path)) {
+    if (!pItem->isWatchedLibraryPath()) {
         menu.addAction(m_pAddtoLibraryAction);
     }
     menu.addAction(m_pRefreshDirTreeAction);
     menu.exec(globalPos);
 }
 
-namespace {
 // Get the list of devices (under "Removable Devices" section).
-std::vector<std::unique_ptr<TreeItem>> createRemovableDevices() {
+std::vector<std::unique_ptr<TreeItem>> BrowseFeature::createRemovableDevices() const {
     std::vector<std::unique_ptr<TreeItem>> ret;
 #if defined(__WINDOWS__)
     // Repopulate drive list
@@ -447,14 +448,13 @@ std::vector<std::unique_ptr<TreeItem>> createRemovableDevices() {
         if (removableDriveRootPaths().contains(device.absoluteFilePath())) {
             continue;
         }
-        ret.push_back(std::make_unique<TreeItem>(
-                device.fileName(),
-                QVariant(device.filePath() + QStringLiteral("/"))));
+        const QString path = device.filePath() + QStringLiteral("/");
+        auto pNewItem = createPathTreeItem(device.fileName(), path, false);
+        ret.emplace_back(std::move(pNewItem));
     }
 #endif
     return ret;
 }
-} // namespace
 
 // This is called whenever you double click or use the triangle symbol to expand
 // the subtree. The method will read the subfolders.
@@ -513,7 +513,8 @@ void BrowseFeature::onLazyChildExpandation(const QModelIndex& index) {
 #endif
         folders = createRemovableDevices();
     } else {
-        folders = getChildDirectoryItems(path);
+        bool isWatched = pItem->isWatchedLibraryPath();
+        folders = getChildDirectoryItems(path, isWatched);
     }
 
     if (!folders.empty()) {
@@ -522,7 +523,8 @@ void BrowseFeature::onLazyChildExpandation(const QModelIndex& index) {
 }
 
 std::vector<std::unique_ptr<TreeItem>> BrowseFeature::getChildDirectoryItems(
-        const QString& path) const {
+        const QString& path,
+        bool isWatched) const {
     std::vector<std::unique_ptr<TreeItem>> items;
 
     if (path.isEmpty()) {
@@ -530,37 +532,53 @@ std::vector<std::unique_ptr<TreeItem>> BrowseFeature::getChildDirectoryItems(
     }
     // we assume that the path refers to a folder in the file system
     // populate children
-    const auto dirAccess = mixxx::FileAccess(mixxx::FileInfo(path));
-
-    QFileInfoList all = dirAccess.info().toQDir().entryInfoList(
-            QDir::Dirs | QDir::NoDotAndDotDot);
+    const QDir dir(path);
+    const QFileInfoList all = dir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
 
     // loop through all the item and construct the children
-    foreach (QFileInfo one, all) {
+    for (const auto& one : all) {
         // Skip folders that end with .app on OS X
 #if defined(__APPLE__)
         if (one.isDir() && one.fileName().endsWith(".app"))
             continue;
 #endif
-        // We here create new items for the sidebar models
-        // Once the items are added to the TreeItemModel,
-        // the models takes ownership of them and ensures their deletion
-        items.push_back(std::make_unique<TreeItem>(
-                one.fileName(),
-                QVariant(one.absoluteFilePath() + QStringLiteral("/"))));
+        // We here create new items for the sidebar models.
+        // Once the items are added to the TreeItemModel, the model takes
+        // ownership of them and ensures their deletion.
+        // Note: use absolutePath(), not canonicalPath().
+        const QString chPath = one.absoluteFilePath() + QStringLiteral("/");
+        auto pNewItem = createPathTreeItem(one.fileName(), chPath, isWatched);
+        items.emplace_back(std::move(pNewItem));
     }
 
     return items;
 }
 
+std::unique_ptr<TreeItem> BrowseFeature::createPathTreeItem(
+        const QString& name,
+        const QString& path,
+        bool parentIsWatched) const {
+    auto pItem = std::make_unique<TreeItem>(name, path);
+    pItem->setIsWatchedLibraryPath(parentIsWatched
+                    ? true
+                    : isPathWatched(path));
+    return pItem;
+}
+
+/// Check if the path is a (child of a) library root dir
 bool BrowseFeature::isPathWatched(const QString& path) const {
+    if (path.isEmpty() || path == QUICK_LINK_NODE || path == DEVICE_NODE) {
+        return false;
+    }
+
     const auto dir = mixxx::FileInfo(path);
-    VERIFY_OR_DEBUG_ASSERT(dir.exists() && dir.isDir()) {
+    if (!dir.exists() || !dir.isDir()) {
         qWarning() << "Failed to check" << dir.location();
         qWarning() << "Directory does not exist, is inaccessible or is not a directory";
         return false;
     }
-    VERIFY_OR_DEBUG_ASSERT(dir.isReadable()) {
+    // NOTE Don't assert dir.isreadable(), this may be the linux root directory
+    if (!dir.isReadable()) {
         qWarning() << "Aborting to check" << dir.location();
         qWarning() << "Directory can not be read";
         return false;

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -22,6 +22,7 @@
 #include "library/treeitem.h"
 #include "moc_browsefeature.cpp"
 #include "util/cmdlineargs.h"
+#include "util/performancetimer.h"
 #include "widget/wlibrary.h"
 #include "widget/wlibrarysidebar.h"
 #include "widget/wlibrarytextbrowser.h"
@@ -314,21 +315,27 @@ void BrowseFeature::slotRefreshDirectoryTree() {
 }
 
 void BrowseFeature::slotLibraryDirectoriesChanged() {
+    qWarning() << "#";
+    qWarning() << "# slotLibraryDirectoriesChanged ##############################";
     // Let a worker thread update the symlink map
     if (m_future_watcher.isRunning()) {
         // Cancel the current run.
         // No need for m_future_watcher.waitForFinished(),
         // updateSymlinkMap() will abort/return early if
         // the auto-generated QPromise::isCanceled()
+        qWarning() << "# task already/still running, cancel it";
         m_future_watcher.cancel();
     }
+    qWarning() << "# set up QFuture";
     // Run
     const auto rootDirs =
             m_pTrackCollection->getDirectoryDAO().loadAllDirectories(true /* ignore missing */);
     m_future = QtConcurrent::run(&BrowseFeature::updateSymlinkMap,
             this,
             rootDirs);
+    qWarning() << "# run";
     m_future_watcher.setFuture(m_future);
+    qWarning() << "#";
 }
 
 void BrowseFeature::updateSymlinkMap(
@@ -383,17 +390,29 @@ void BrowseFeature::updateSymlinkMap(
     QThread* thisThread = QThread::currentThread();
     thisThread->setPriority(QThread::LowPriority);
 
+    qWarning() << "     .";
+    qWarning() << "     .";
+    qWarning() << "     .";
+    qWarning() << "     BrowseFeature::updateSymlinkList";
+    qWarning() << "     .";
+
+    PerformanceTimer timer;
+    timer.start();
+
     QMap<QString, QString> symLinksMap;
 
     for (const auto& rootDir : rootDirs) {
         if (promise.isCanceled()) {
             return;
         }
+        qWarning() << "     insert root dir" << rootDir.location();
         symLinksMap.insert(rootDir.location(), rootDir.location());
+        qWarning() << "              target" << rootDir.canonicalLocation();
         if (rootDir.location() != rootDir.canonicalLocation()) {
             // some path segment is a symlink
             symLinksMap.insert(rootDir.canonicalLocation(), rootDir.location());
         }
+        qWarning() << "       .";
         // Scan all subdirectories
         QDirIterator it(rootDir.location(),
                 QDir::Dirs | QDir::NoDotAndDotDot,
@@ -405,12 +424,25 @@ void BrowseFeature::updateSymlinkMap(
             it.next();
             mixxx::FileInfo dirInfo(it.fileInfo());
             if (dirInfo.canonicalLocation().isEmpty()) {
+                qWarning() << "     > skip invalid symlink (target empty)" << dirInfo.location();
                 continue;
             }
+            qWarning() << "     > insert" << dirInfo.location();
+            qWarning() << "       target" << dirInfo.canonicalLocation();
             symLinksMap.insert(dirInfo.location(), dirInfo.location());
             symLinksMap.insert(dirInfo.canonicalLocation(), dirInfo.location());
         }
     }
+    const auto elapsed = timer.elapsed();
+    // Takes ~800 ms for ~3000 directories on a decent SSD
+    int elapsedMs = elapsed.toIntegerMillis();
+    int elapsedNs = elapsed.toIntegerNanos();
+    qWarning() << "     .";
+    qWarning() << "     collecting" << symLinksMap.size() << "dirs";
+    qWarning() << "     took" << elapsedMs << "ms (" << elapsedNs << "ns)";
+    qWarning() << "     .";
+    qWarning() << "     .";
+    qWarning() << "     .";
     promise.addResult(symLinksMap);
 }
 
@@ -426,6 +458,9 @@ void BrowseFeature::onSymLinkMapUpdated() {
 void BrowseFeature::slotUpdateAllTreeItemsIsWatchedPath() {
     // Update ALL items
     // Iterate over top-level items and update each recursively
+    qWarning() << "     ~";
+    qWarning() << "     ~ slotUpdateAllTreeItemsIsWatchedPath";
+    qWarning() << "     ~ num rows:" << m_pSidebarModel->rowCount();
     for (int row = 0; row < m_pSidebarModel->rowCount(); ++row) {
         const QModelIndex index = m_pSidebarModel->index(row, 0);
         TreeItem* pTreeItem = m_pSidebarModel->getItem(index);
@@ -435,30 +470,44 @@ void BrowseFeature::slotUpdateAllTreeItemsIsWatchedPath() {
         updateItemIsWatchedPathRecursively(pTreeItem);
     }
 
+    qWarning() << "     ~ items updated";
     VERIFY_OR_DEBUG_ASSERT(m_pSidebarWidget) {
         return;
     }
 
+    qWarning() << "     ~ maybe switch model of the currently selected item";
     m_pSidebarWidget->update();
     // If `isWatched` of the currently selected path doesn't match
     // the used model anymore, update it.
     const auto& selectedIndex = m_pSidebarWidget->selectedIndex();
+    qWarning() << "     ~ selectedIndex:" << selectedIndex;
+    qWarning() << "     ~ sidebar model:" << m_pSidebarModel.get();
     if (selectedIndex.model() != m_pSidebarModel.get()) {
         // Index does not belong to our sidebar model, ignore
+        qWarning() << "     ~ !! index does not belong to our sidebar model";
         return;
     }
     auto* pSelectedItem = m_pSidebarModel->getItem(selectedIndex);
     if (!pSelectedItem) {
+        qWarning() << "     ~ !! NO selected item found, return";
         return;
     }
     const QString path = pSelectedItem->getData().toString();
     if (path.isEmpty() || path == QUICK_LINK_NODE || path == DEVICE_NODE) {
+        qWarning() << "     ~ !! item is root/QuickLink/Devices item, return";
         return;
     }
+    qWarning() << "     ~ found selected item";
+    qWarning() << "     ~ selected item:" << pSelectedItem->getLabel();
     bool watched = pSelectedItem->isWatchedLibraryPath();
     bool usingLibraryView =
             static_cast<BrowseLibraryTableModel*>(m_pCurrentTrackModel) != nullptr;
     if (watched != usingLibraryView) {
+        if (watched) {
+            qWarning() << "     ~ switch to library model";
+        } else {
+            qWarning() << "     ~ switch to file model";
+        }
         activateChild(selectedIndex);
     }
 }
@@ -476,6 +525,7 @@ void BrowseFeature::updateItemIsWatchedPathRecursively(TreeItem* pItem) {
         return;
     }
 
+    qWarning() << "     ~ maybe update" << path;
     if (isPathWatched(path)) {
         pItem->updateIsWatchedLibraryPathRecursively(true);
     } else {
@@ -546,6 +596,7 @@ void BrowseFeature::activateChild(const QModelIndex& index) {
         return;
     }
 
+    qDebug() << "--> orig path:" << path;
 
     emit saveModelState();
 
@@ -558,13 +609,18 @@ void BrowseFeature::activateChild(const QModelIndex& index) {
         // filter tracks by directory (recursive)
         // Resolve path, ie. figure if it's symlink'ed in some library directory.
         // If yes, use the un-resolved path to set the directory filter
+        qWarning() << "--> use TRACK view";
+        qWarning() << "--> unresolve path";
         const QString unresolvedPath = maybeUnResolveSymlink(std::move(path));
+        qWarning() << "--> setPath" << unresolvedPath;
         m_pLibraryModel->setPath(std::move(unresolvedPath));
+        qWarning() << "--> setSearch" << currSearch;
         m_pLibraryModel->search(currSearch);
         m_pCurrentTrackModel = m_pLibraryModel;
         emit showTrackModel(m_pLibraryModel);
         emit enableCoverArtDisplay(true);
     } else {
+        qWarning() << "--> use FILE view";
         // use BrowseTableModel
         // Open a security token for this path and if we do not have access, ask
         // for it.
@@ -756,6 +812,7 @@ std::vector<std::unique_ptr<TreeItem>> BrowseFeature::getChildDirectoryItems(
         // Once the items are added to the TreeItemModel, the model takes
         // ownership of them and ensures their deletion.
         // Note: use absolutePath(), not canonicalPath().
+        // TODO Explain. See getDefaultQuickLinks() for explanation.
         const QString chPath = one.absoluteFilePath() + QStringLiteral("/");
         auto pNewItem = createPathTreeItem(one.fileName(), chPath, isWatched);
         items.emplace_back(std::move(pNewItem));
@@ -778,11 +835,13 @@ std::unique_ptr<TreeItem> BrowseFeature::createPathTreeItem(
 /// Check if the path is a (child of a) library root dir
 bool BrowseFeature::isPathWatched(const QString& path) const {
     if (path.isEmpty() || path == QUICK_LINK_NODE || path == DEVICE_NODE) {
+        qWarning() << "     ~ isPathWatched: false (is Quick Links or Devices)" << path;
         return false;
     }
 
     const auto dir = mixxx::FileInfo(path);
     if (!dir.exists() || !dir.isDir()) {
+        qWarning() << "     ~ isPathWatched" << path;
         qWarning() << "Failed to check" << dir.location();
         qWarning() << "Directory does not exist, is inaccessible or is not a directory";
         return false;
@@ -805,21 +864,32 @@ bool BrowseFeature::isPathWatched(const QString& path) const {
     const QMap<QString, QString>::const_iterator itcan =
             m_trackDirSymlinksMap.constFind(dirCanLoc);
     if (itcan != m_trackDirSymlinksMap.constEnd()) {
+        qWarning() << "     ~ isPathWatched YES" << path;
+        if (dir.location() != itcan.value()) {
+            qWarning() << "    resolved to" << itcan.value();
+        }
         return true;
     }
+
+    qWarning() << "     ~ isPathWatched NO " << path;
     return false;
 }
 
 QString BrowseFeature::maybeUnResolveSymlink(const QString& path) const {
     // Check if path is a resolved path of a library (sub)directory.
     // See updateSymlinkMap() for details.
+    qWarning() << "### maybeUnResolveSymlink" << path;
     mixxx::FileInfo dir(path);
+    qWarning() << "###     canonicalLocation" << dir.canonicalLocation();
+    qWarning() << "###     dir symlink list:" << m_trackDirSymlinksMap.size();
     const QMap<QString, QString>::const_iterator it =
             m_trackDirSymlinksMap.constFind(dir.canonicalLocation());
     if (it == m_trackDirSymlinksMap.constEnd()) {
+        qWarning() << "### path NOT found";
         return path;
     }
 
+    qWarning() << "### found, resolved to" << it.value();
     // location() misses the trailing '/' but we need it only for the file view
     return it.value();
 }

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -316,30 +316,28 @@ void BrowseFeature::activateChild(const QModelIndex& index) {
     }
     if (path == QUICK_LINK_NODE || path == DEVICE_NODE) {
         emit saveModelState();
-        // Clear the tracks view
-        m_pBrowseModel->setPath({});
-    } else {
-        // Open a security token for this path and if we do not have access, ask
-        // for it.
-        auto dirInfo = mixxx::FileInfo(path);
-        auto dirAccess = mixxx::FileAccess(dirInfo);
-        if (!dirAccess.isReadable()) {
-            if (Sandbox::askForAccess(&dirInfo)) {
-                // Re-create to get a new token.
-                dirAccess = mixxx::FileAccess(dirInfo);
-            } else {
-                // TODO(rryan): Activate an info page about sandboxing?
-                return;
-            }
-        }
-        emit saveModelState();
-        m_pBrowseModel->setPath(std::move(dirAccess));
+        // Nothing to see here, show the Computer root view
+        activate();
+        return;
     }
+
+    // Open a security token for this path and if we do not have access, ask
+    // for it.
+    auto dirInfo = mixxx::FileInfo(path);
+    auto dirAccess = mixxx::FileAccess(dirInfo);
+    if (!dirAccess.isReadable()) {
+        if (Sandbox::askForAccess(&dirInfo)) {
+            // Re-create to get a new token.
+            dirAccess = mixxx::FileAccess(dirInfo);
+        } else {
+            // TODO(rryan): Activate an info page about sandboxing?
+            return;
+        }
+    }
+    emit saveModelState();
+    m_pBrowseModel->setPath(std::move(dirAccess));
     emit showTrackModel(m_pProxyModel.get());
     // Search is restored in Library::slotShowTrackModel, disable it where it's useless
-    if (path == QUICK_LINK_NODE || path == DEVICE_NODE) {
-        emit disableSearch();
-    }
     emit enableCoverArtDisplay(false);
 }
 

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -9,6 +9,7 @@
 #include <QStringList>
 #include <memory>
 
+#include "library/browse/browselibrarytablemodel.h"
 #include "library/browse/browsetablemodel.h"
 #include "library/browse/foldertreemodel.h"
 #include "library/library.h"
@@ -48,16 +49,20 @@ BrowseFeature::BrowseFeature(Library* pLibrary,
         : LibraryFeature(pLibrary, pConfig, QString("computer")),
           m_pTrackCollection(
                   pLibrary->trackCollectionManager()->internalCollection()),
-          m_pBrowseModel(make_parented<BrowseTableModel>(
+          m_pFileModel(make_parented<BrowseTableModel>(
                   this, pLibrary->trackCollectionManager(), pRecordingManager)),
           m_pProxyModel(std::make_unique<ProxyTrackModel>(
-                  m_pBrowseModel, true /* handle search */)),
+                  m_pFileModel, true /* handle search */)),
+          m_pLibraryModel(make_parented<BrowseLibraryTableModel>(this,
+                  pLibrary->trackCollectionManager(),
+                  "mixxx.db.model.browseLibrary")),
+          m_pCurrentTrackModel(nullptr),
           m_pSidebarModel(make_parented<FolderTreeModel>(this)) {
-    connect(m_pBrowseModel,
+    connect(m_pFileModel,
             &BrowseTableModel::saveModelState,
             this,
             &LibraryFeature::saveModelState);
-    connect(m_pBrowseModel,
+    connect(m_pFileModel,
             &BrowseTableModel::restoreModelState,
             this,
             &LibraryFeature::restoreModelState);
@@ -297,8 +302,19 @@ void BrowseFeature::activate() {
     emit enableCoverArtDisplay(false);
 }
 
-// Note: This is executed whenever you single click on an child item
-// Single clicks will not populate sub folders
+/// This is executed whenever you single-click on a child item.
+/// The track view is then populated with tracks from that directory.
+/// Two different views (models) are used, depending on whether the directory
+/// is a (child of a) library directory or not:
+/// 1. not a library dir: file view
+///    This view shows the audio tags of the track files each time the directory item
+///    is activated, regardless if individual (or all) tracks have been added to the
+///    library. Population is usually slow and doesn't have all library columns.
+/// 2. a library dir: track (library) view
+///    Displays metadata from the library (database) like in other features,
+///    has all columns and capabilities of Tracks.
+///
+/// Note: single clicks will not expand or populate sub directories.
 void BrowseFeature::activateChild(const QModelIndex& index) {
     if (!index.isValid()) {
         return;
@@ -321,24 +337,42 @@ void BrowseFeature::activateChild(const QModelIndex& index) {
         return;
     }
 
-    // Open a security token for this path and if we do not have access, ask
-    // for it.
-    auto dirInfo = mixxx::FileInfo(path);
-    auto dirAccess = mixxx::FileAccess(dirInfo);
-    if (!dirAccess.isReadable()) {
-        if (Sandbox::askForAccess(&dirInfo)) {
-            // Re-create to get a new token.
-            dirAccess = mixxx::FileAccess(dirInfo);
-        } else {
-            // TODO(rryan): Activate an info page about sandboxing?
-            return;
-        }
-    }
+
     emit saveModelState();
-    m_pBrowseModel->setPath(std::move(dirAccess));
-    emit showTrackModel(m_pProxyModel.get());
-    // Search is restored in Library::slotShowTrackModel, disable it where it's useless
-    emit enableCoverArtDisplay(false);
+
+    const QString currSearch = getCurrentSearch();
+    // TODO sync sort column, if possible
+    // * get sort column from current model
+    // * if we switch the model, set sort column
+    if (isPathWatched(path)) {
+        // use LibraryTableModel
+        // filter tracks by directory (recursive)
+        m_pLibraryModel->setPath(std::move(path));
+        m_pLibraryModel->search(currSearch);
+        m_pCurrentTrackModel = m_pLibraryModel;
+        emit showTrackModel(m_pLibraryModel);
+        emit enableCoverArtDisplay(true);
+    } else {
+        // use BrowseTableModel
+        // Open a security token for this path and if we do not have access, ask
+        // for it.
+        auto dirInfo = mixxx::FileInfo(path);
+        mixxx::FileAccess dirAccess = mixxx::FileAccess(dirInfo);
+        if (!dirAccess.isReadable()) {
+            if (Sandbox::askForAccess(&dirInfo)) {
+                // Re-create to get a new token.
+                dirAccess = mixxx::FileAccess(dirInfo);
+            } else {
+                // TODO(rryan): Activate an info page about sandboxing?
+                return;
+            }
+        }
+        m_pFileModel->setPath(std::move(dirAccess));
+        m_pProxyModel->search(currSearch);
+        m_pCurrentTrackModel = m_pProxyModel.get();
+        emit showTrackModel(m_pProxyModel.get());
+        emit enableCoverArtDisplay(false);
+    }
 }
 
 void BrowseFeature::onRightClickChild(const QPoint& globalPos, const QModelIndex& index) {
@@ -367,9 +401,9 @@ void BrowseFeature::onRightClickChild(const QPoint& globalPos, const QModelIndex
         menu.addAction(m_pAddQuickLinkAction);
     }
 
-    // TODO Check if we already watch this path or a parent and don't show or
-    // disable this action.
-    menu.addAction(m_pAddtoLibraryAction);
+    if (!isPathWatched(path)) {
+        menu.addAction(m_pAddtoLibraryAction);
+    }
     menu.addAction(m_pRefreshDirTreeAction);
     menu.exec(globalPos);
 }
@@ -519,6 +553,35 @@ std::vector<std::unique_ptr<TreeItem>> BrowseFeature::getChildDirectoryItems(
     return items;
 }
 
+bool BrowseFeature::isPathWatched(const QString& path) const {
+    const auto dir = mixxx::FileInfo(path);
+    VERIFY_OR_DEBUG_ASSERT(dir.exists() && dir.isDir()) {
+        qWarning() << "Failed to check" << dir.location();
+        qWarning() << "Directory does not exist, is inaccessible or is not a directory";
+        return false;
+    }
+    VERIFY_OR_DEBUG_ASSERT(dir.isReadable()) {
+        qWarning() << "Aborting to check" << dir.location();
+        qWarning() << "Directory can not be read";
+        return false;
+    }
+    const auto newCanonicalLocation = dir.canonicalLocation();
+    DEBUG_ASSERT(!newCanonicalLocation.isEmpty());
+    const auto rootDirs =
+            m_pTrackCollection->getDirectoryDAO().loadAllDirectories(true /* ignore missing */);
+    for (auto&& oldDir : rootDirs) {
+        const auto oldCanonicalLocation = oldDir.canonicalLocation();
+        DEBUG_ASSERT(!oldCanonicalLocation.isEmpty());
+        if (mixxx::FileInfo::isRootSubCanonicalLocation(
+                    oldCanonicalLocation,
+                    newCanonicalLocation)) {
+            // New dir is a child of an existing dir, return
+            return true;
+        }
+    }
+    return false;
+}
+
 QString BrowseFeature::getRootViewHtml() const {
     const QString browseTitle = tr("Computer");
     const QString browseSummary = tr(
@@ -625,8 +688,12 @@ QStringList BrowseFeature::getDefaultQuickLinks() const {
     return result;
 }
 
+QString BrowseFeature::getCurrentSearch() const {
+    return m_pCurrentTrackModel != nullptr ? m_pCurrentTrackModel->currentSearch() : QString();
+}
+
 void BrowseFeature::releaseBrowseThread() {
-    m_pBrowseModel->releaseBrowseThread();
+    m_pFileModel->releaseBrowseThread();
 }
 
 QString BrowseFeature::getLastRightClickedPath() const {

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -1,23 +1,27 @@
 #include "library/browse/browsefeature.h"
 
 #include <QAction>
+#include <QDirIterator>
 #include <QFileInfo>
 #include <QMenu>
 #include <QPushButton>
 #include <QSortFilterProxyModel>
 #include <QStandardPaths>
 #include <QStringList>
+#include <QtConcurrentRun>
 #include <memory>
 
 #include "library/browse/browselibrarytablemodel.h"
 #include "library/browse/browsetablemodel.h"
 #include "library/browse/foldertreemodel.h"
 #include "library/library.h"
+#include "library/library_prefs.h"
 #include "library/proxytrackmodel.h"
 #include "library/trackcollection.h"
 #include "library/trackcollectionmanager.h"
 #include "library/treeitem.h"
 #include "moc_browsefeature.cpp"
+#include "util/cmdlineargs.h"
 #include "widget/wlibrary.h"
 #include "widget/wlibrarysidebar.h"
 #include "widget/wlibrarytextbrowser.h"
@@ -175,6 +179,34 @@ BrowseFeature::BrowseFeature(Library* pLibrary,
 
     // initialize the model
     m_pSidebarModel->setRootItem(std::move(pRootItem));
+
+    // Prepare everything for creating the symlink map of track directories.
+    // For reason and details updateSymlinkMap().
+    // This is called by slotLibraryDirectoriesChanged() and then all items'
+    // `isWatchedLibraryPath` flags are updated accordingly.
+    connect(&m_future_watcher,
+            &QFutureWatcher<QMap<QString, QString>>::finished,
+            this,
+            &BrowseFeature::onSymLinkMapUpdated);
+    // We don't need to update now if we rescan on startup or scheduled a scan via
+    // command line; in both cases it's triggered by CoreServices after the library
+    // has been constructed, and we're listening to the libraryScanFinished() signal below.
+    bool rescan = CmdlineArgs::Instance().getRescanLibrary() ||
+            pConfig->getValue<bool>(mixxx::library::prefs::kRescanOnStartupConfigKey);
+    if (!rescan) {
+        slotLibraryDirectoriesChanged();
+    }
+
+    // Update symlink map after library scan and when library
+    // directories have been changed in the preferences.
+    connect(pLibrary,
+            &Library::trackDirectoriesUpdated,
+            this,
+            &BrowseFeature::slotLibraryDirectoriesChanged);
+    connect(pLibrary->trackCollectionManager(),
+            &TrackCollectionManager::libraryScanFinished,
+            this,
+            &BrowseFeature::slotLibraryDirectoriesChanged);
 }
 
 BrowseFeature::~BrowseFeature() {
@@ -281,6 +313,179 @@ void BrowseFeature::slotRefreshDirectoryTree() {
     onLazyChildExpandation(m_lastRightClickedIndex);
 }
 
+void BrowseFeature::slotLibraryDirectoriesChanged() {
+    // Let a worker thread update the symlink map
+    if (m_future_watcher.isRunning()) {
+        // Cancel the current run.
+        // No need for m_future_watcher.waitForFinished(),
+        // updateSymlinkMap() will abort/return early if
+        // the auto-generated QPromise::isCanceled()
+        m_future_watcher.cancel();
+    }
+    // Run
+    const auto rootDirs =
+            m_pTrackCollection->getDirectoryDAO().loadAllDirectories(true /* ignore missing */);
+    m_future = QtConcurrent::run(&BrowseFeature::updateSymlinkMap,
+            this,
+            rootDirs);
+    m_future_watcher.setFuture(m_future);
+}
+
+void BrowseFeature::updateSymlinkMap(
+        QPromise<QMap<QString, QString>>& promise,
+        const QList<mixxx::FileInfo>& rootDirs) {
+    // Create the map of all symlink'ed track (sub)directories.
+    // It's reverse, ie. <target, symlink>
+    //
+    // The purpose:
+    // "Unresolve" clicked symlink target paths to their respective canonical
+    // paths stored in the library.
+    //
+    // Let's say we have a library directory /home/user/Music which is a symlink
+    // to /mnt/SSD/music.
+    // In the tree this directory can be in multiple places, for example
+    //   QuickLinks -> Music
+    //   mnt -> SSD -> music
+    // When selecting either of those, we want the correct directory filter
+    // (/home/user/Music) for the library model to show all contained tracks.
+    //
+    // However, Library directories and track locations are stored as canonical
+    // locations and items in the Quick Links and drive nodes all have the
+    // resolved path. So, when selecting /mnt/SSD/music, the directory filter
+    // would not yield any results as only tracks in /home/user/Music are in the
+    // library.
+    //
+    // This reverse target/symlink map allows us to get the correct library
+    // (sub)directory for a given symlink target.
+    //
+    // NOTE: we could also use this map when creating new tree items paths
+    // so we work with the canonical library location right away and save the
+    // unresolve step on click.
+    // BUT in case library directories are removed/relocated we'd not only have
+    // to update the items' `isPathWatched` flag but also their path (item data)
+    //
+    // Also check symlik'ed directories, inside or outside library directories,
+    // that are effectively inside library dirs. Example
+    // /home/ is a library dir. Cases covered:
+    // /home/Abc links to /mnt/Abc
+    // /mnt/Cba links to /home/Abc
+    // /mnt/Bca links to /mnt/Abc
+
+    VERIFY_OR_DEBUG_ASSERT_THIS_QOBJECT_THREAD_ANTI_AFFINITY() {
+        // Must only be run in separate thread via QFutureWatcher and
+        // QtConcurrent::run()
+        return;
+    }
+
+    // There's no need for high prio. Also, it may be triggered on startup when
+    // a scheduled library scan finished. At that point we don't want to
+    // push back other threads.
+    QThread* thisThread = QThread::currentThread();
+    thisThread->setPriority(QThread::LowPriority);
+
+    QMap<QString, QString> symLinksMap;
+
+    for (const auto& rootDir : rootDirs) {
+        if (promise.isCanceled()) {
+            return;
+        }
+        symLinksMap.insert(rootDir.location(), rootDir.location());
+        if (rootDir.location() != rootDir.canonicalLocation()) {
+            // some path segment is a symlink
+            symLinksMap.insert(rootDir.canonicalLocation(), rootDir.location());
+        }
+        // Scan all subdirectories
+        QDirIterator it(rootDir.location(),
+                QDir::Dirs | QDir::NoDotAndDotDot,
+                QDirIterator::Subdirectories | QDirIterator::FollowSymlinks);
+        while (it.hasNext()) {
+            if (promise.isCanceled()) {
+                return;
+            }
+            it.next();
+            mixxx::FileInfo dirInfo(it.fileInfo());
+            if (dirInfo.canonicalLocation().isEmpty()) {
+                continue;
+            }
+            symLinksMap.insert(dirInfo.location(), dirInfo.location());
+            symLinksMap.insert(dirInfo.canonicalLocation(), dirInfo.location());
+        }
+    }
+    promise.addResult(symLinksMap);
+}
+
+void BrowseFeature::onSymLinkMapUpdated() {
+    m_mutex.lock();
+    // Swap the symlink map
+    m_trackDirSymlinksMap = m_future_watcher.result();
+    m_mutex.unlock();
+
+    slotUpdateAllTreeItemsIsWatchedPath();
+}
+
+void BrowseFeature::slotUpdateAllTreeItemsIsWatchedPath() {
+    // Update ALL items
+    // Iterate over top-level items and update each recursively
+    for (int row = 0; row < m_pSidebarModel->rowCount(); ++row) {
+        const QModelIndex index = m_pSidebarModel->index(row, 0);
+        TreeItem* pTreeItem = m_pSidebarModel->getItem(index);
+        VERIFY_OR_DEBUG_ASSERT(pTreeItem) {
+            continue;
+        }
+        updateItemIsWatchedPathRecursively(pTreeItem);
+    }
+
+    VERIFY_OR_DEBUG_ASSERT(m_pSidebarWidget) {
+        return;
+    }
+
+    m_pSidebarWidget->update();
+    // If `isWatched` of the currently selected path doesn't match
+    // the used model anymore, update it.
+    const auto& selectedIndex = m_pSidebarWidget->selectedIndex();
+    if (selectedIndex.model() != m_pSidebarModel.get()) {
+        // Index does not belong to our sidebar model, ignore
+        return;
+    }
+    auto* pSelectedItem = m_pSidebarModel->getItem(selectedIndex);
+    if (!pSelectedItem) {
+        return;
+    }
+    const QString path = pSelectedItem->getData().toString();
+    if (path.isEmpty() || path == QUICK_LINK_NODE || path == DEVICE_NODE) {
+        return;
+    }
+    bool watched = pSelectedItem->isWatchedLibraryPath();
+    bool usingLibraryView =
+            static_cast<BrowseLibraryTableModel*>(m_pCurrentTrackModel) != nullptr;
+    if (watched != usingLibraryView) {
+        activateChild(selectedIndex);
+    }
+}
+
+void BrowseFeature::updateItemIsWatchedPathRecursively(TreeItem* pItem) {
+    VERIFY_OR_DEBUG_ASSERT(pItem) {
+        return;
+    }
+    const auto itemData = pItem->getData();
+    VERIFY_OR_DEBUG_ASSERT(itemData.isValid() && itemData.canConvert<QString>()) {
+        return;
+    }
+    const QString path = itemData.toString();
+    if (path.isEmpty()) {
+        return;
+    }
+
+    if (isPathWatched(path)) {
+        pItem->updateIsWatchedLibraryPathRecursively(true);
+    } else {
+        pItem->setIsWatchedLibraryPath(false);
+        for (auto* pChild : std::as_const(pItem->children())) {
+            updateItemIsWatchedPathRecursively(pChild);
+        }
+    }
+}
+
 TreeItemModel* BrowseFeature::sidebarModel() const {
     return m_pSidebarModel;
 }
@@ -294,7 +499,7 @@ void BrowseFeature::bindLibraryWidget(WLibrary* libraryWidget,
 }
 
 void BrowseFeature::bindSidebarWidget(WLibrarySidebar* pSidebarWidget) {
-    // store the sidebar widget pointer for later use in onRightClickChild
+    // store the sidebar widget pointer for later use
     m_pSidebarWidget = pSidebarWidget;
 }
 
@@ -315,6 +520,8 @@ void BrowseFeature::activate() {
 /// 2. a library dir: track (library) view
 ///    Displays metadata from the library (database) like in other features,
 ///    has all columns and capabilities of Tracks.
+///    Note: this also applies if a library (sub)directory is a symlink and we
+///    clicked the symlink target (which may be outside the library dir).
 ///
 /// Note: single clicks will not expand or populate sub directories.
 void BrowseFeature::activateChild(const QModelIndex& index) {
@@ -349,7 +556,10 @@ void BrowseFeature::activateChild(const QModelIndex& index) {
     if (isPathWatched(path)) {
         // use LibraryTableModel
         // filter tracks by directory (recursive)
-        m_pLibraryModel->setPath(std::move(path));
+        // Resolve path, ie. figure if it's symlink'ed in some library directory.
+        // If yes, use the un-resolved path to set the directory filter
+        const QString unresolvedPath = maybeUnResolveSymlink(std::move(path));
+        m_pLibraryModel->setPath(std::move(unresolvedPath));
         m_pLibraryModel->search(currSearch);
         m_pCurrentTrackModel = m_pLibraryModel;
         emit showTrackModel(m_pLibraryModel);
@@ -583,21 +793,35 @@ bool BrowseFeature::isPathWatched(const QString& path) const {
         qWarning() << "Directory can not be read";
         return false;
     }
-    const auto newCanonicalLocation = dir.canonicalLocation();
-    DEBUG_ASSERT(!newCanonicalLocation.isEmpty());
-    const auto rootDirs =
-            m_pTrackCollection->getDirectoryDAO().loadAllDirectories(true /* ignore missing */);
-    for (auto&& oldDir : rootDirs) {
-        const auto oldCanonicalLocation = oldDir.canonicalLocation();
-        DEBUG_ASSERT(!oldCanonicalLocation.isEmpty());
-        if (mixxx::FileInfo::isRootSubCanonicalLocation(
-                    oldCanonicalLocation,
-                    newCanonicalLocation)) {
-            // New dir is a child of an existing dir, return
-            return true;
-        }
+
+    const auto dirCanLoc = dir.canonicalLocation();
+    VERIFY_OR_DEBUG_ASSERT(!dirCanLoc.isEmpty()) {
+        return false;
+    }
+
+    // Check if we have the path in the symlinks map.
+    // Returns true if this is a symlink or target.
+    // Includes library root dirs.
+    const QMap<QString, QString>::const_iterator itcan =
+            m_trackDirSymlinksMap.constFind(dirCanLoc);
+    if (itcan != m_trackDirSymlinksMap.constEnd()) {
+        return true;
     }
     return false;
+}
+
+QString BrowseFeature::maybeUnResolveSymlink(const QString& path) const {
+    // Check if path is a resolved path of a library (sub)directory.
+    // See updateSymlinkMap() for details.
+    mixxx::FileInfo dir(path);
+    const QMap<QString, QString>::const_iterator it =
+            m_trackDirSymlinksMap.constFind(dir.canonicalLocation());
+    if (it == m_trackDirSymlinksMap.constEnd()) {
+        return path;
+    }
+
+    // location() misses the trailing '/' but we need it only for the file view
+    return it.value();
 }
 
 QString BrowseFeature::getRootViewHtml() const {

--- a/src/library/browse/browsefeature.h
+++ b/src/library/browse/browsefeature.h
@@ -62,7 +62,13 @@ class BrowseFeature : public LibraryFeature {
     QString extractNameFromPath(const QString& spath);
     bool isPathWatched(const QString& path) const;
     QStringList getDefaultQuickLinks() const;
-    std::vector<std::unique_ptr<TreeItem>> getChildDirectoryItems(const QString& path) const;
+    std::vector<std::unique_ptr<TreeItem>> createRemovableDevices() const;
+    std::vector<std::unique_ptr<TreeItem>> getChildDirectoryItems(
+            const QString& path,
+            bool isWatched) const;
+    std::unique_ptr<TreeItem> createPathTreeItem(const QString& name,
+            const QString& path,
+            bool parentIsWatched = false) const;
     void saveQuickLinks();
     void loadQuickLinks();
     QString getLastRightClickedPath() const;

--- a/src/library/browse/browsefeature.h
+++ b/src/library/browse/browsefeature.h
@@ -2,24 +2,22 @@
 
 #include <QObject>
 #include <QPointer>
-#include <QSortFilterProxyModel>
 #include <QString>
-#include <QStringListModel>
-#include <QVariant>
 
-#include "library/browse/browsetablemodel.h"
 #include "library/libraryfeature.h"
-#include "library/proxytrackmodel.h"
 #include "preferences/usersettings.h"
+#include "util/parented_ptr.h"
 
 #define QUICK_LINK_NODE "::mixxx_quick_lnk_node::"
 #define DEVICE_NODE "::mixxx_device_node::"
 
+class BrowseTableModel;
+class ProxyTrackModel;
+class FolderTreeModel;
 class Library;
+class RecordingManager;
 class TrackCollection;
 class WLibrarySidebar;
-class QModelIndex;
-class FolderTreeModel;
 
 class BrowseFeature : public LibraryFeature {
     Q_OBJECT
@@ -68,13 +66,13 @@ class BrowseFeature : public LibraryFeature {
 
     TrackCollection* const m_pTrackCollection;
 
-    BrowseTableModel m_browseModel;
-    ProxyTrackModel m_proxyModel;
-    FolderTreeModel* m_pSidebarModel;
-    QAction* m_pAddQuickLinkAction;
-    QAction* m_pRemoveQuickLinkAction;
-    QAction* m_pAddtoLibraryAction;
-    QAction* m_pRefreshDirTreeAction;
+    parented_ptr<BrowseTableModel> m_pBrowseModel;
+    std::unique_ptr<ProxyTrackModel> m_pProxyModel;
+    parented_ptr<FolderTreeModel> m_pSidebarModel;
+    parented_ptr<QAction> m_pAddQuickLinkAction;
+    parented_ptr<QAction> m_pRemoveQuickLinkAction;
+    parented_ptr<QAction> m_pAddtoLibraryAction;
+    parented_ptr<QAction> m_pRefreshDirTreeAction;
 
     // Caution: Make sure this is reset whenever the library tree is updated,
     // so that the internalPointer() does not become dangling

--- a/src/library/browse/browsefeature.h
+++ b/src/library/browse/browsefeature.h
@@ -12,11 +12,13 @@
 #define DEVICE_NODE "::mixxx_device_node::"
 
 class BrowseTableModel;
+class BrowseLibraryTableModel;
 class ProxyTrackModel;
 class FolderTreeModel;
 class Library;
 class RecordingManager;
 class TrackCollection;
+class TrackModel;
 class WLibrarySidebar;
 
 class BrowseFeature : public LibraryFeature {
@@ -58,16 +60,21 @@ class BrowseFeature : public LibraryFeature {
   private:
     QString getRootViewHtml() const;
     QString extractNameFromPath(const QString& spath);
+    bool isPathWatched(const QString& path) const;
     QStringList getDefaultQuickLinks() const;
     std::vector<std::unique_ptr<TreeItem>> getChildDirectoryItems(const QString& path) const;
     void saveQuickLinks();
     void loadQuickLinks();
     QString getLastRightClickedPath() const;
 
+    QString getCurrentSearch() const;
+
     TrackCollection* const m_pTrackCollection;
 
-    parented_ptr<BrowseTableModel> m_pBrowseModel;
+    parented_ptr<BrowseTableModel> m_pFileModel;
     std::unique_ptr<ProxyTrackModel> m_pProxyModel;
+    parented_ptr<BrowseLibraryTableModel> m_pLibraryModel;
+    TrackModel* m_pCurrentTrackModel;
     parented_ptr<FolderTreeModel> m_pSidebarModel;
     parented_ptr<QAction> m_pAddQuickLinkAction;
     parented_ptr<QAction> m_pRemoveQuickLinkAction;

--- a/src/library/browse/browsefeature.h
+++ b/src/library/browse/browsefeature.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <QFuture>
+#include <QFutureWatcher>
 #include <QObject>
 #include <QPointer>
 #include <QString>
@@ -57,10 +59,22 @@ class BrowseFeature : public LibraryFeature {
     void requestAddDir(const QString&);
     void scanLibrary();
 
+  private slots:
+    void slotLibraryDirectoriesChanged();
+    void onSymLinkMapUpdated();
+
   private:
     QString getRootViewHtml() const;
     QString extractNameFromPath(const QString& spath);
     bool isPathWatched(const QString& path) const;
+    QString maybeUnResolveSymlink(const QString& path) const;
+
+    void updateSymlinkMap(
+            QPromise<QMap<QString, QString>>& promise,
+            const QList<mixxx::FileInfo>& rootDirs);
+    void slotUpdateAllTreeItemsIsWatchedPath();
+    void updateItemIsWatchedPathRecursively(TreeItem* pItem);
+
     QStringList getDefaultQuickLinks() const;
     std::vector<std::unique_ptr<TreeItem>> createRemovableDevices() const;
     std::vector<std::unique_ptr<TreeItem>> getChildDirectoryItems(
@@ -93,4 +107,10 @@ class BrowseFeature : public LibraryFeature {
     TreeItem* m_pQuickLinkItem;
     QStringList m_quickLinkList;
     QPointer<WLibrarySidebar> m_pSidebarWidget;
+
+    QMap<QString, QString> m_trackDirSymlinksMap;
+
+    QFutureWatcher<QMap<QString, QString>> m_future_watcher;
+    QFuture<QMap<QString, QString>> m_future;
+    QMutex m_mutex;
 };

--- a/src/library/browse/browselibrarytablemodel.cpp
+++ b/src/library/browse/browselibrarytablemodel.cpp
@@ -27,6 +27,8 @@ void BrowseLibraryTableModel::setPath(QString path) {
     // Note(ronso0) For now I'm using recursive mode since that is what almost
     // all my b2b DJs expected (coming from Serato or VDJ).
     // FIXME Default to strict mode and add strict/recursive toggle?
+    const QString newDirFilter = QStringLiteral("dir:\"%1\"").arg(path);
+    qWarning().noquote() << "--> new dirFilter:" << newDirFilter;
     setExtraFilter(QStringLiteral("dir:\"%1\"").arg(path));
 }
 

--- a/src/library/browse/browselibrarytablemodel.cpp
+++ b/src/library/browse/browselibrarytablemodel.cpp
@@ -1,0 +1,45 @@
+#include "library/browse/browselibrarytablemodel.h"
+
+#include "moc_browselibrarytablemodel.cpp"
+
+namespace {
+
+const QString kTableName = QStringLiteral("browse_library_view");
+// Track filter: missing tracks
+const QString kTrackFilter = QStringLiteral("(mixxx_deleted=0 AND fs_deleted=0)");
+
+} // anonymous namespace
+
+BrowseLibraryTableModel::BrowseLibraryTableModel(
+        QObject* pParent,
+        TrackCollectionManager* pTrackCollectionManager,
+        const char* settingsNamespace)
+        : LibraryTableModel(pParent, pTrackCollectionManager, settingsNamespace) {
+}
+
+void BrowseLibraryTableModel::setPath(QString path) {
+    while (path.endsWith('/')) {
+        path.chop(1);
+    }
+    // Note: depending on operator we get strict or recursive search:
+    // dir:=path -> strict
+    // dir:path  -> recursive
+    // Note(ronso0) For now I'm using recursive mode since that is what almost
+    // all my b2b DJs expected (coming from Serato or VDJ).
+    // FIXME Default to strict mode and add strict/recursive toggle?
+    setExtraFilter(QStringLiteral("dir:\"%1\"").arg(path));
+}
+
+TrackModel::Capabilities BrowseLibraryTableModel::getCapabilities() const {
+    return Capability::AddToTrackSet |
+            Capability::AddToAutoDJ |
+            Capability::EditMetadata |
+            Capability::LoadToDeck |
+            Capability::LoadToSampler |
+            Capability::LoadToPreviewDeck |
+            Capability::ResetPlayed |
+            Capability::RemoveFromDisk |
+            Capability::Analyze |
+            Capability::Properties |
+            Capability::Sorting;
+}

--- a/src/library/browse/browselibrarytablemodel.h
+++ b/src/library/browse/browselibrarytablemodel.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "library/librarytablemodel.h"
+
+class BrowseLibraryTableModel : public LibraryTableModel {
+    Q_OBJECT
+  public:
+    BrowseLibraryTableModel(
+            QObject* pParent,
+            TrackCollectionManager* pTrackCollectionManager,
+            const char* settingsNamespace);
+    ~BrowseLibraryTableModel() override = default;
+
+    void setPath(QString path);
+    int addTracks(const QModelIndex&, const QList<QString>&) final {
+        return 0;
+    };
+
+    Capabilities getCapabilities() const final;
+
+  private:
+    QString m_directoryFilter;
+};

--- a/src/library/browse/browsetablemodel.cpp
+++ b/src/library/browse/browsetablemodel.cpp
@@ -45,7 +45,7 @@ BrowseTableModel::BrowseTableModel(QObject* parent,
         TrackCollectionManager* pTrackCollectionManager,
         RecordingManager* pRecordingManager)
         : TrackModel(pTrackCollectionManager->internalCollection()->database(),
-                  "mixxx.db.model.browse"),
+                  "mixxx.db.model.browseFiles"),
           QStandardItemModel(parent),
           m_pTrackCollectionManager(pTrackCollectionManager),
           m_pRecordingManager(pRecordingManager),

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -660,6 +660,7 @@ bool Library::requestAddDir(const QString& dir) {
         return false;
     }
 
+    emit trackDirectoriesUpdated();
     return true;
 }
 
@@ -697,6 +698,7 @@ bool Library::requestRemoveDir(const QString& dir, LibraryRemovalType removalTyp
         DEBUG_ASSERT(!"unreachable");
     }
 
+    emit trackDirectoriesUpdated();
     return true;
 }
 
@@ -704,6 +706,7 @@ bool Library::requestRelocateDir(const QString& oldDir, const QString& newDir) {
     DirectoryDAO::RelocateResult result =
             m_pTrackCollectionManager->relocateDirectory(oldDir, newDir);
     if (result == DirectoryDAO::RelocateResult::Ok) {
+        emit trackDirectoriesUpdated();
         return true;
     }
 

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -179,6 +179,8 @@ class Library: public QObject {
 
     void onTrackAnalyzerProgress(TrackId trackId, AnalyzerProgress analyzerProgress);
 
+    void trackDirectoriesUpdated();
+
   private slots:
       void onPlayerManagerTrackAnalyzerProgress(TrackId trackId, AnalyzerProgress analyzerProgress);
       void onPlayerManagerTrackAnalyzerIdle();

--- a/src/library/librarytablemodel.cpp
+++ b/src/library/librarytablemodel.cpp
@@ -5,8 +5,15 @@
 #include "library/trackcollection.h"
 #include "library/trackcollectionmanager.h"
 #include "mixer/playerinfo.h"
-#include "mixer/playermanager.h"
 #include "moc_librarytablemodel.cpp"
+
+namespace {
+
+const QString kTableName = QStringLiteral("library_view");
+// Track filter: exclude hidden and missing tracks
+const QString kTrackFilter = QStringLiteral("(mixxx_deleted=0 AND fs_deleted=0)");
+
+} // anonymous namespace
 
 LibraryTableModel::LibraryTableModel(QObject* parent,
         TrackCollectionManager* pTrackCollectionManager,
@@ -19,8 +26,6 @@ LibraryTableModel::~LibraryTableModel() {
 }
 
 void LibraryTableModel::setTableModel() {
-    const QString tableName("library_view");
-
     QStringList columns;
     columns << "library." + LIBRARYTABLE_ID
             << "'' AS " + LIBRARYTABLE_PREVIEW
@@ -29,13 +34,17 @@ void LibraryTableModel::setTableModel() {
             << LIBRARYTABLE_COVERART_DIGEST + " AS " + LIBRARYTABLE_COVERART;
 
     QSqlQuery query(m_database);
-    query.prepare(
-            "CREATE TEMPORARY VIEW IF NOT EXISTS " + tableName +
-            " AS SELECT " + columns.join(",") +
+    const QString queryString = QStringLiteral(
+            "CREATE TEMPORARY VIEW IF NOT EXISTS %1"
+            " AS SELECT %2"
             " FROM library "
             "INNER JOIN track_locations "
             "ON library.location=track_locations.id "
-            "WHERE (mixxx_deleted=0 AND fs_deleted=0)");
+            "WHERE %3")
+                                        .arg(kTableName,
+                                                columns.join(","),
+                                                kTrackFilter);
+    query.prepare(queryString);
     if (!query.exec()) {
         LOG_FAILED_QUERY(query);
     }
@@ -44,7 +53,7 @@ void LibraryTableModel::setTableModel() {
     tableColumns << LIBRARYTABLE_ID;
     tableColumns << LIBRARYTABLE_PREVIEW;
     tableColumns << LIBRARYTABLE_COVERART;
-    setTable(tableName,
+    setTable(kTableName,
             LIBRARYTABLE_ID,
             std::move(tableColumns),
             m_pTrackCollectionManager->internalCollection()->getTrackSource());
@@ -92,6 +101,10 @@ bool LibraryTableModel::isColumnInternal(int column) {
 }
 
 TrackModel::Capabilities LibraryTableModel::getCapabilities() const {
+    // Note(ronso0) When adding capabilities, also check getCapabilities() in
+    // BrowseLibraryTableModel which builds on this class.
+    // For example BrowseLibraryTableModel does not accept drops and does not
+    // allow to hide tracks (it always shows ALL tracks).
     return Capability::ReceiveDrops |
             Capability::AddToTrackSet |
             Capability::AddToAutoDJ |

--- a/src/library/librarytablemodel.h
+++ b/src/library/librarytablemodel.h
@@ -14,8 +14,8 @@ class LibraryTableModel : public BaseSqlTableModel {
     bool isColumnInternal(int column) final;
     // Takes a list of locations and add the tracks to the library. Returns the
     // number of successful additions.
-    int addTracks(const QModelIndex& index, const QList<QString>& locations) final;
-    TrackModel::Capabilities getCapabilities() const final;
+    int addTracks(const QModelIndex& index, const QList<QString>& locations) override;
+    TrackModel::Capabilities getCapabilities() const override;
 
     void select() override;
 

--- a/src/library/sidebaritemdelegate.cpp
+++ b/src/library/sidebaritemdelegate.cpp
@@ -1,0 +1,37 @@
+#include "library/sidebaritemdelegate.h"
+
+#include <QPainter>
+#include <QStyle>
+
+#include "library/sidebarmodel.h"
+#include "moc_sidebaritemdelegate.cpp"
+#include "util/assert.h"
+#include "widget/wlibrarysidebar.h"
+
+SidebarItemDelegate::SidebarItemDelegate(
+        WLibrarySidebar* pSidebarWidget,
+        SidebarModel* pSidebarModel)
+        : QStyledItemDelegate(pSidebarWidget),
+          m_pSidebarModel(pSidebarModel) {
+    DEBUG_ASSERT(m_pSidebarModel);
+}
+
+void SidebarItemDelegate::paint(
+        QPainter* pPainter,
+        const QStyleOptionViewItem& option,
+        const QModelIndex& index) const {
+    QStyledItemDelegate::paint(pPainter, option, index);
+
+    // If the (path) item is a watched path, draw an indicator on top of the qss style.
+    // The bounding rect of the dot is half the x-height of the current font.
+    int wh = option.fontMetrics.xHeight() / 2;
+    if (m_pSidebarModel->indexIsWatchedPathItem(index)) {
+        pPainter->setRenderHint(QPainter::Antialiasing);
+        pPainter->setBrush(QBrush(m_watchedPathColor));
+        pPainter->drawEllipse( // x, y, w, h
+                option.rect.x(),
+                option.rect.y() + 1,
+                wh,
+                wh);
+    }
+}

--- a/src/library/sidebaritemdelegate.h
+++ b/src/library/sidebaritemdelegate.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <QColor>
+#include <QStyledItemDelegate>
+
+class SidebarModel;
+class WLibrarySidebar;
+
+class SidebarItemDelegate : public QStyledItemDelegate {
+    Q_OBJECT
+  public:
+    explicit SidebarItemDelegate(
+            WLibrarySidebar* pSidebarwidget,
+            SidebarModel* pSidebarModel);
+    ~SidebarItemDelegate() override = default;
+
+    void paint(
+            QPainter* pPainter,
+            const QStyleOptionViewItem& option,
+            const QModelIndex& index) const override;
+
+    void setWatchedPathColor(const QColor& color) {
+        if (color.isValid()) {
+            m_watchedPathColor = color;
+        }
+    }
+
+  private:
+    SidebarModel* m_pSidebarModel;
+    QColor m_watchedPathColor;
+};

--- a/src/library/sidebarmodel.cpp
+++ b/src/library/sidebarmodel.cpp
@@ -614,3 +614,17 @@ void SidebarModel::slotFeatureSelect(LibraryFeature* pFeature,
     }
     emit selectIndex(ind, scrollTo);
 }
+
+bool SidebarModel::indexIsWatchedPathItem(const QModelIndex& index) const {
+    if (!index.isValid()) {
+        return false;
+    }
+    if (index.internalPointer() == this) {
+        return false;
+    }
+    TreeItem* pTreeItem = static_cast<TreeItem*>(index.internalPointer());
+    if (!pTreeItem) {
+        return false;
+    }
+    return pTreeItem->isWatchedLibraryPath();
+}

--- a/src/library/sidebarmodel.h
+++ b/src/library/sidebarmodel.h
@@ -49,6 +49,9 @@ class SidebarModel : public QAbstractItemModel {
 
     void clear(const QModelIndex& index);
     void paste(const QModelIndex& index);
+
+    bool indexIsWatchedPathItem(const QModelIndex& index) const;
+
   public slots:
     void pressed(const QModelIndex& index);
     void clicked(const QModelIndex& index);

--- a/src/library/treeitem.cpp
+++ b/src/library/treeitem.cpp
@@ -31,11 +31,12 @@ TreeItem::TreeItem(
         LibraryFeature* pFeature,
         QString label,
         QVariant data)
-    : m_pFeature(pFeature),
-      m_pParent(nullptr),
-      m_label(std::move(label)),
-      m_data(std::move(data)),
-      m_bold(false) {
+        : m_pFeature(pFeature),
+          m_pParent(nullptr),
+          m_label(std::move(label)),
+          m_data(std::move(data)),
+          m_bold(false),
+          m_isWatched(false) {
 }
 
 TreeItem::~TreeItem() {

--- a/src/library/treeitem.cpp
+++ b/src/library/treeitem.cpp
@@ -84,6 +84,14 @@ void TreeItem::initFeatureRecursively(LibraryFeature* pFeature) {
     }
 }
 
+void TreeItem::updateIsWatchedLibraryPathRecursively(bool watched) {
+    setIsWatchedLibraryPath(watched);
+    for (auto* pChild : std::as_const(m_children)) {
+        pChild->setIsWatchedLibraryPath(watched);
+        pChild->updateIsWatchedLibraryPathRecursively(watched);
+    }
+}
+
 TreeItem* TreeItem::appendChild(
         QString label,
         QVariant data) {

--- a/src/library/treeitem.h
+++ b/src/library/treeitem.h
@@ -132,6 +132,7 @@ class TreeItem final {
     bool isWatchedLibraryPath() {
         return m_isWatched;
     }
+    void updateIsWatchedLibraryPathRecursively(bool watched);
 
   private:
     explicit TreeItem(

--- a/src/library/treeitem.h
+++ b/src/library/treeitem.h
@@ -125,6 +125,13 @@ class TreeItem final {
     bool isBold() const {
         return m_bold;
     }
+    // This is set/used only by BrowseFeature
+    void setIsWatchedLibraryPath(bool watched) {
+        m_isWatched = watched;
+    }
+    bool isWatchedLibraryPath() {
+        return m_isWatched;
+    }
 
   private:
     explicit TreeItem(
@@ -147,4 +154,5 @@ class TreeItem final {
     QVariant m_data;
     QIcon m_icon;
     bool m_bold;
+    bool m_isWatched;
 };

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -5,16 +5,27 @@
 #include <QtDebug>
 
 #include "library/library_prefs.h"
+#include "library/sidebaritemdelegate.h"
 #include "library/sidebarmodel.h"
 #include "moc_wlibrarysidebar.cpp"
 #include "util/defs.h"
 #include "util/dnd.h"
 
+namespace {
+
+// color for the 'watched path' indicator (cyan)
+const QColor kDefaultWatchedPathColor = QColor("#00ffff"); // clazy:exclude=qcolor-from-literal
+
+} // anonymous namespace
+
 WLibrarySidebar::WLibrarySidebar(QWidget* parent)
         : QTreeView(parent),
           WBaseWidget(this),
+          m_pSidebarModel(nullptr),
+          m_pItemDelegate(nullptr),
           m_hoverExpandDelay(mixxx::library::prefs::kSidebarHoverExpandDelayDefault),
-          m_lastDragMoveAccepted(false) {
+          m_lastDragMoveAccepted(false),
+          m_watchedPathColor(kDefaultWatchedPathColor) {
     qRegisterMetaType<FocusWidget>("FocusWidget");
     //Set some properties
     setHeaderHidden(true);
@@ -29,6 +40,24 @@ WLibrarySidebar::WLibrarySidebar(QWidget* parent)
     header()->setStretchLastSection(false);
     header()->setSectionResizeMode(QHeaderView::ResizeToContents);
     header()->setHorizontalScrollMode(QAbstractItemView::ScrollPerPixel);
+}
+
+void WLibrarySidebar::setModel(QAbstractItemModel* pModel) {
+    SidebarModel* pSidebarModel = qobject_cast<SidebarModel*>(pModel);
+    DEBUG_ASSERT(pSidebarModel);
+    m_pSidebarModel = pSidebarModel;
+    QTreeView::setModel(pSidebarModel);
+    // Create the delegate for painting the bookmark indicator
+    DEBUG_ASSERT(m_pItemDelegate == nullptr);
+    m_pItemDelegate = new SidebarItemDelegate(this, pSidebarModel);
+    setItemDelegateForColumn(0, m_pItemDelegate);
+    m_pItemDelegate->setWatchedPathColor(m_watchedPathColor);
+    // Color can be set in qss via qproperty-watchedPathColor which happens
+    // when the stylesheet is applied. Push it to delegate.
+    connect(this,
+            &WLibrarySidebar::watchedPathColorChanged,
+            m_pItemDelegate,
+            &SidebarItemDelegate::setWatchedPathColor);
 }
 
 void WLibrarySidebar::contextMenuEvent(QContextMenuEvent* pEvent) {
@@ -116,13 +145,7 @@ void WLibrarySidebar::dragMoveEvent(QDragMoveEvent* pEvent) {
         return;
     }
 
-    SidebarModel* pSidebarModel = qobject_cast<SidebarModel*>(model());
-    VERIFY_OR_DEBUG_ASSERT(pSidebarModel) {
-        m_lastDragMoveAccepted = false;
-        pEvent->ignore();
-        return;
-    }
-    if (pSidebarModel->dragMoveAccept(index, urls)) {
+    if (m_pSidebarModel->dragMoveAccept(index, urls)) {
         m_lastDragMoveAccepted = true;
         pEvent->acceptProposedAction();
     } else {
@@ -162,15 +185,6 @@ void WLibrarySidebar::dropEvent(QDropEvent* pEvent) {
         pEvent->ignore();
         return;
     }
-    // Drag-and-drop from an external application (eg. a file manager) or the
-    // track table widget onto the sidebar.
-    // Reset the selected items (if you had anything highlighted, it clears it)
-    // this->selectionModel()->clear();
-    SidebarModel* pSidebarModel = qobject_cast<SidebarModel*>(model());
-    VERIFY_OR_DEBUG_ASSERT(pSidebarModel) {
-        pEvent->ignore();
-        return;
-    }
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     QPoint pos = pEvent->position().toPoint();
 #else
@@ -181,7 +195,7 @@ void WLibrarySidebar::dropEvent(QDropEvent* pEvent) {
     // pEvent->source() will return NULL if something is dropped from
     // a different application
     const QList<QUrl> urls = pEvent->mimeData()->urls();
-    if (pSidebarModel->dropAccept(destIndex, urls, pEvent->source())) {
+    if (m_pSidebarModel->dropAccept(destIndex, urls, pEvent->source())) {
         pEvent->acceptProposedAction();
     } else {
         pEvent->ignore();
@@ -226,17 +240,14 @@ void WLibrarySidebar::toggleSelectedItem() {
 }
 
 bool WLibrarySidebar::isLeafNodeSelected() {
-    QModelIndex index = selectedIndex();
-    if (index.isValid()) {
-        if(!index.model()->hasChildren(index)) {
-            return true;
-        }
-        const SidebarModel* pSidebarModel = qobject_cast<const SidebarModel*>(index.model());
-        if (pSidebarModel) {
-            return pSidebarModel->hasTrackTable(index);
-        }
+    const QModelIndex index = selectedIndex();
+    if (!index.isValid()) {
+        return false;
     }
-    return false;
+    if (!index.model()->hasChildren(index)) {
+        return true;
+    }
+    return m_pSidebarModel->hasTrackTable(index);
 }
 
 bool WLibrarySidebar::isChildIndexSelected(const QModelIndex& index) {
@@ -245,12 +256,7 @@ bool WLibrarySidebar::isChildIndexSelected(const QModelIndex& index) {
     if (!selIndex.isValid()) {
         return false;
     }
-    SidebarModel* pSidebarModel = qobject_cast<SidebarModel*>(model());
-    VERIFY_OR_DEBUG_ASSERT(pSidebarModel) {
-        // qDebug() << " >> model() is not SidebarModel";
-        return false;
-    }
-    QModelIndex translated = pSidebarModel->translateChildIndex(index);
+    QModelIndex translated = m_pSidebarModel->translateChildIndex(index);
     if (!translated.isValid()) {
         // qDebug() << " >> index can't be translated";
         return false;
@@ -264,11 +270,7 @@ bool WLibrarySidebar::isFeatureRootIndexSelected(LibraryFeature* pFeature) {
     if (!selIndex.isValid()) {
         return false;
     }
-    SidebarModel* pSidebarModel = qobject_cast<SidebarModel*>(model());
-    VERIFY_OR_DEBUG_ASSERT(pSidebarModel) {
-        return false;
-    }
-    const QModelIndex rootIndex = pSidebarModel->getFeatureRootIndex(pFeature);
+    const QModelIndex rootIndex = m_pSidebarModel->getFeatureRootIndex(pFeature);
     return rootIndex == selIndex;
 }
 
@@ -277,11 +279,9 @@ bool WLibrarySidebar::isFeatureRootIndexSelected(LibraryFeature* pFeature) {
 void WLibrarySidebar::keyPressEvent(QKeyEvent* pEvent) {
     // TODO(XXX) Should first keyEvent ensure previous item has focus? I.e. if the selected
     // item is not focused, require second press to perform the desired action.
-
-    SidebarModel* pSidebarModel = qobject_cast<SidebarModel*>(model());
-    QModelIndex selIndex = selectedIndex();
-    if (pSidebarModel && selIndex.isValid() && pEvent->matches(QKeySequence::Paste)) {
-        pSidebarModel->paste(selIndex);
+    const QModelIndex selIndex = selectedIndex();
+    if (selIndex.isValid() && pEvent->matches(QKeySequence::Paste)) {
+        m_pSidebarModel->paste(selIndex);
         return;
     }
 
@@ -408,18 +408,13 @@ void WLibrarySidebar::selectIndex(const QModelIndex& index, bool scrollToIndex) 
 
 /// Selects a child index from a feature and ensures visibility
 void WLibrarySidebar::selectChildIndex(const QModelIndex& index, bool selectItem) {
-    SidebarModel* pSidebarModel = qobject_cast<SidebarModel*>(model());
-    VERIFY_OR_DEBUG_ASSERT(pSidebarModel) {
-        qDebug() << "model() is not SidebarModel";
-        return;
-    }
-    QModelIndex translated = pSidebarModel->translateChildIndex(index);
+    const QModelIndex translated = m_pSidebarModel->translateChildIndex(index);
     if (!translated.isValid()) {
         return;
     }
 
     if (selectItem) {
-        auto* pModel = new QItemSelectionModel(pSidebarModel);
+        auto* pModel = new QItemSelectionModel(m_pSidebarModel);
         pModel->select(translated, QItemSelectionModel::Select);
         if (selectionModel()) {
             selectionModel()->deleteLater();
@@ -436,7 +431,7 @@ void WLibrarySidebar::selectChildIndex(const QModelIndex& index, bool selectItem
     scrollTo(translated, EnsureVisible);
 }
 
-QModelIndex WLibrarySidebar::selectedIndex() {
+QModelIndex WLibrarySidebar::selectedIndex() const {
     QModelIndexList selectedIndices = selectionModel()->selectedRows();
     if (selectedIndices.isEmpty()) {
         return QModelIndex();

--- a/src/widget/wlibrarysidebar.h
+++ b/src/widget/wlibrarysidebar.h
@@ -8,12 +8,21 @@
 #include "widget/wbasewidget.h"
 
 class LibraryFeature;
+class SidebarItemDelegate;
+class SidebarModel;
 class QPoint;
 
 class WLibrarySidebar : public QTreeView, public WBaseWidget {
     Q_OBJECT
   public:
     explicit WLibrarySidebar(QWidget* parent = nullptr);
+
+    Q_PROPERTY(QColor watchedPathColor
+                    MEMBER m_watchedPathColor
+                            NOTIFY watchedPathColorChanged
+                                    DESIGNABLE true);
+
+    void setModel(QAbstractItemModel* pModel) override;
 
     void contextMenuEvent(QContextMenuEvent* pEvent) override;
     void dragMoveEvent(QDragMoveEvent* pEvent) override;
@@ -27,6 +36,7 @@ class WLibrarySidebar : public QTreeView, public WBaseWidget {
     void toggleSelectedItem();
     void renameSelectedItem();
     bool isLeafNodeSelected();
+    QModelIndex selectedIndex() const;
     bool isChildIndexSelected(const QModelIndex& index);
     bool isFeatureRootIndexSelected(LibraryFeature* pFeature);
 
@@ -42,19 +52,22 @@ class WLibrarySidebar : public QTreeView, public WBaseWidget {
     void deleteItem(const QModelIndex&);
     FocusWidget setLibraryFocus(FocusWidget newFocus,
             Qt::FocusReason focusReason = Qt::OtherFocusReason);
+    void watchedPathColorChanged(QColor m_watchedPathColor);
 
   protected:
     bool event(QEvent* pEvent) override;
 
   private:
     void focusSelectedIndex();
-    QModelIndex selectedIndex();
 
     void toggleDragHoverPropertyAndUpdateStyle(bool enabled);
     void resetHoverIndexAndDragMoveResult();
 
+    SidebarModel* m_pSidebarModel;
+    SidebarItemDelegate* m_pItemDelegate;
     QBasicTimer m_expandTimer;
     int m_hoverExpandDelay;
     QModelIndex m_hoverIndex;
     bool m_lastDragMoveAccepted;
+    QColor m_watchedPathColor;
 };


### PR DESCRIPTION
Fixes #14683 
Related: #11026 #9897

### TL:DR
If the selected path is watched by library, we show it like the other track views (Tracks, Crates, ..).
This gives us the same the view (colums) and editing capabilities.
Watched paths are currently marked with an ~~orange~~ **cyan dot**:
![image](https://github.com/user-attachments/assets/6d039b59-746f-451e-ac42-f3a9956950c9)


This is really handy if you want to browse your library by path!
Supposed to enhance the **Sidebar Bookmarks** use case #14508.

### Details
If the path is watched, we use an alternative model (derived from `LibraryTableModel`, uses track data).
Luckily, LibraryTableModel already allows to use an extra search filter (not visible in the searchbox) which allows to filter tracks by directory. (such a filter is also used in _Analyze_ view)
Since BrowseFeature tells the library to load its model on click, switching between the file / track model works flawlessly.

This also introduces `SidebarItemDelegate` to do the painting.

**Note**:
The header is different for the file / track views (eg. the file view does not have the rating column), but the views can be made somewhat similar by adjusting the headers once.

- [x] adopt search query when switching between file / track model
- [x] add subtle decoration if path item is watched (probably with sidebar delegate from #14508)
- [ ] cache `isWatchedPath` property to avoid string comparison when expanding the tree?
- [ ] don't rebuild child tree if watched path is expanded? (update on demand with "Refresh directory tree")
try to adopt solution from #14508
- [x] update TreeItems' `isWatchedPath` flag when directories have been added to or removed from library
- [ ] also switch view model in that case, if current view is affected?

### TODO
- [ ] ~~use ibrary view in Recording, too~~ postponed, will happen as followup
- [x] verify all commits build
- [x] test on Linux
- [ ] test on Windows
- [ ] test on macOS
- [ ] test with watched network shares on all OS
- [ ] make it work with #14479, ie.