### PR TITLE
Fix for Hercules DJControl Inpulse 500 controller mapping

### DIFF
--- a/res/controllers/Hercules-DJControl-Inpulse-500-script.js
+++ b/res/controllers/Hercules-DJControl-Inpulse-500-script.js
@@ -1152,7 +1152,7 @@ DJCi500.crossfader = function(channel, control, value, status, group) {
             }
             engine.setValue(group, "crossfader", result);
         } else {
-            engine.setValue(group, "crossfader", (value/64)-1);
+            engine.setValue(group, "crossfader", ((value*2)/127)-1);
         }
     }
 };


### PR DESCRIPTION
The crossfader was not reaching 100% to the right end, only 98.43%.