### PR TITLE
Added Linux Mint Codenames to debian_buildenv.sh

### DIFF
--- a/tools/debian_buildenv.sh
+++ b/tools/debian_buildenv.sh
@@ -12,7 +12,7 @@ case "$1" in
     setup)
         source /etc/lsb-release 2>/dev/null
         case "${DISTRIB_CODENAME}" in
-            focal|jammy|bullseye) # <= Ubuntu 22.04.5 LTS
+            focal|jammy|bullseye|victoria|vera|vanessa|virginia) # <= Ubuntu 22.04.5 LTS
                 PACKAGES_EXTRA=(
                     libqt6shadertools6-dev
                 )


### PR DESCRIPTION
We see here the "DISTRIB_CODENAME=vanessa" for the Ubuntu Jammy based Linux Mint 
https://forums.linuxmint.com/viewtopic.php?t=385892

Here is a list of other dot releases: 
https://linuxmint.com/download_all.php