### PR TITLE
Fixed LED issue on Traktor S2 Mk3 mapping

### DIFF
--- a/res/controllers/Traktor-Kontrol-S2-MK3-hid-scripts.js
+++ b/res/controllers/Traktor-Kontrol-S2-MK3-hid-scripts.js
@@ -347,7 +347,7 @@ TraktorS2MK3.padModeHandler = function(field) {
                 TraktorS2MK3.outputHandler(colorValue, field.group, "pad_" + i);
             }
             else {
-                TraktorS2MK3.outputHandler(0, field.group, "pad_" + i);
+                TraktorS2MK3.outputHandler(0, field.group, `pad_${  i}`);
             }
         }
     }
@@ -889,10 +889,10 @@ TraktorS2MK3.registerOutputPackets = function() {
     this.linkOutput("[Channel2]", "keylock", this.outputHandler);
 
     for (let i = 1; i <= 8; ++i) {
-        engine.makeConnection("[Channel1]", "hotcue_" + i + "_enabled", this.hotcueOutputHandler);
-        engine.makeConnection("[Channel2]", "hotcue_" + i + "_enabled", this.hotcueOutputHandler);
-        engine.makeConnection("[Channel1]", "hotcue_" + i + "_color", this.hotcueColorHandler);
-        engine.makeConnection("[Channel2]", "hotcue_" + i + "_color", this.hotcueColorHandler);
+        engine.makeConnection("[Channel1]", `hotcue_${  i  }_enabled`, this.hotcueOutputHandler);
+        engine.makeConnection("[Channel2]", `hotcue_${  i  }_enabled`, this.hotcueOutputHandler);
+        engine.makeConnection("[Channel1]", `hotcue_${  i  }_color`, this.hotcueColorHandler);
+        engine.makeConnection("[Channel2]", `hotcue_${  i  }_color`, this.hotcueColorHandler);
     }
 
     this.linkOutput("[Channel1]", "pfl", this.outputHandler);
@@ -977,9 +977,9 @@ TraktorS2MK3.hotcueOutputHandler = function(value, group, key) {
         const color = engine.getValue(group, colorKey);
         const padNum = key[7];
         if (value > 0) {
-            TraktorS2MK3.colorOutputHandler(color, group, "pad_" + padNum);
+            TraktorS2MK3.colorOutputHandler(color, group, `pad_${  padNum}`);
         } else {
-            TraktorS2MK3.outputHandler(0, group, "pad_" + padNum);
+            TraktorS2MK3.outputHandler(0, group, `pad_${  padNum}`);
         }
     }
 };
@@ -988,7 +988,7 @@ TraktorS2MK3.hotcueColorHandler = function(value, group, key) {
     // Light button LED only when we are in hotcue mode
     const padNum = key[7];
     if (TraktorS2MK3.padModeState[group] === 0) {
-        TraktorS2MK3.colorOutputHandler(value, group, "pad_" + padNum);
+        TraktorS2MK3.colorOutputHandler(value, group, `pad_${  padNum}`);
     }
 };
 

--- a/res/controllers/Traktor-Kontrol-S2-MK3-hid-scripts.js
+++ b/res/controllers/Traktor-Kontrol-S2-MK3-hid-scripts.js
@@ -346,6 +346,9 @@ TraktorS2MK3.padModeHandler = function(field) {
                 const colorValue = TraktorS2MK3.PadColorMap.getValueForNearestColor(color);
                 TraktorS2MK3.outputHandler(colorValue, field.group, "pad_" + i);
             }
+            else {
+                TraktorS2MK3.outputHandler(0, field.group, "pad_" + i);
+            }
         }
     }
 };
@@ -886,10 +889,10 @@ TraktorS2MK3.registerOutputPackets = function() {
     this.linkOutput("[Channel2]", "keylock", this.outputHandler);
 
     for (let i = 1; i <= 8; ++i) {
-        TraktorS2MK3.controller.linkOutput("[Channel1]", "pad_" + i, "[Channel1]", "hotcue_" + i + "_enabled", this.hotcueOutputHandler);
-        TraktorS2MK3.controller.linkOutput("[Channel2]", "pad_" + i, "[Channel2]", "hotcue_" + i + "_enabled", this.hotcueOutputHandler);
-        TraktorS2MK3.controller.linkOutput("[Channel1]", "pad_" + i, "[Channel1]", "hotcue_" + i + "_color", this.hotcueColorHandler);
-        TraktorS2MK3.controller.linkOutput("[Channel2]", "pad_" + i, "[Channel2]", "hotcue_" + i + "_color", this.hotcueColorHandler);
+        engine.makeConnection("[Channel1]", "hotcue_" + i + "_enabled", this.hotcueOutputHandler);
+        engine.makeConnection("[Channel2]", "hotcue_" + i + "_enabled", this.hotcueOutputHandler);
+        engine.makeConnection("[Channel1]", "hotcue_" + i + "_color", this.hotcueColorHandler);
+        engine.makeConnection("[Channel2]", "hotcue_" + i + "_color", this.hotcueColorHandler);
     }
 
     this.linkOutput("[Channel1]", "pfl", this.outputHandler);
@@ -972,18 +975,20 @@ TraktorS2MK3.hotcueOutputHandler = function(value, group, key) {
     if (TraktorS2MK3.padModeState[group] === 0) {
         const colorKey = key.replace("_enabled", "_color");
         const color = engine.getValue(group, colorKey);
+        const padNum = key[7];
         if (value > 0) {
-            TraktorS2MK3.colorOutputHandler(color, group, key);
+            TraktorS2MK3.colorOutputHandler(color, group, "pad_" + padNum);
         } else {
-            TraktorS2MK3.outputHandler(0, group, key);
+            TraktorS2MK3.outputHandler(0, group, "pad_" + padNum);
         }
     }
 };
 
 TraktorS2MK3.hotcueColorHandler = function(value, group, key) {
     // Light button LED only when we are in hotcue mode
+    const padNum = key[7];
     if (TraktorS2MK3.padModeState[group] === 0) {
-        TraktorS2MK3.colorOutputHandler(value, group, key);
+        TraktorS2MK3.colorOutputHandler(value, group, "pad_" + padNum);
     }
 };
 


### PR DESCRIPTION
On the Mixxx forums, I fixed an issue with the Traktor S2 Mk3 mapping and then promised to make a PR about it...8 months ago. I finally remembered to do it today so here it is.

The issue was that the pad LEDs on the S2 wouldn't update whenever a hotcue was added or removed. I wrote about both the cause of the issue and my solution to the issue on the [Mixxx forums](https://mixxx.discourse.group/t/native-instruments-traktor-kontrol-s2-mk3/18147/45?u=boredguy1) (quoted below):

> At around line 970ish in the script, the function `TraktorS2MK3.hotcueOutputHandler` is being passed the wrong key values. The strings being passed to key are all something along the lines of `hotcue_X_enabled` when they should be something like `pad_X`. (This is also possibly what’s triggering the `Unknown field: [Channel1].hotcue_1_enabled` mentioned in the bug reports.)
> 
> A quick and dirty hack is to reformat the strings being passed in `TraktorS2MK3.hotcueOutputHandler` and `TraktorS2MK3.hotcueColorHandler` (which is what I did).
> 
> There is also a second issue that no one seems to have picked up on, which is that at line 890, the script attempts to connect `hotcue_X_enabled` and `hotcue_X_color`, but because only one callback can be connected at a time when using `linkOutput`, `hotcue_X_color` updates are ignored.
> 
> I just fixed this by replacing `linkOutput` with `engine.makeConnection`. (I think `linkOutput` is outdated anyway, I wasn’t able to find anything on it in the documentation.)

Fixes #11677
Fixes #12130