### PR TITLE
Herc dj control inpulse 500

### DIFF
--- a/res/controllers/Hercules-DJControl-Inpulse-500-script.js
+++ b/res/controllers/Hercules-DJControl-Inpulse-500-script.js
@@ -1152,7 +1152,7 @@ DJCi500.crossfader = function(channel, control, value, status, group) {
             }
             engine.setValue(group, "crossfader", result);
         } else {
-            engine.setValue(group, "crossfader", (value/64)-1);
+            engine.setParameter(group, "crossfader", script.absoluteLin(value, 0, 1, 0, 127));
         }
     }
 };


### PR DESCRIPTION
The previous formula assumes a range of 0–128 for the values provided by the controller.

The actual range is 0–127.  As a result, the crossfader did not reach 100% when moved all the way to the right, only reaching 98%. This made it impossible to switch to the next track in Auto DJ mode using the crossfader when the left deck was playing.

This fix also changes the method from engine.setValue to engine.setParameter, as suggested by Eve.