### PR TITLE
Fix 14706

### DIFF
--- a/src/rendergraph/opengl/backend/basenode.cpp
+++ b/src/rendergraph/opengl/backend/basenode.cpp
@@ -21,6 +21,7 @@ BaseNode::~BaseNode() {
 /// for a more clear transfer of ownership. pChild is considered owned by
 /// this at this point.
 void BaseNode::appendChildNode(BaseNode* pChild) {
+    DEBUG_ASSERT(pChild != nullptr);
     if (m_pLastChild) {
         pChild->m_pPreviousSibling = m_pLastChild;
         m_pLastChild->m_pNextSibling = pChild;
@@ -42,14 +43,21 @@ void BaseNode::appendChildNode(BaseNode* pChild) {
 /// for a more clear transfer of ownership. Otherwise,
 /// deleting pChild is responsibility of the caller.
 void BaseNode::removeChildNode(BaseNode* pChild) {
+    DEBUG_ASSERT(pChild);
     if (pChild == m_pFirstChild) {
+        DEBUG_ASSERT(pChild->m_pPreviousSibling == nullptr);
         m_pFirstChild = pChild->m_pNextSibling;
     } else {
+        DEBUG_ASSERT(pChild->m_pPreviousSibling != nullptr);
         pChild->m_pPreviousSibling->m_pNextSibling = pChild->m_pNextSibling;
     }
 
     if (pChild == m_pLastChild) {
-        m_pLastChild = nullptr;
+        DEBUG_ASSERT(pChild->m_pNextSibling == nullptr);
+        m_pLastChild = pChild->m_pPreviousSibling;
+    } else {
+        DEBUG_ASSERT(pChild->m_pNextSibling != nullptr);
+        pChild->m_pNextSibling->m_pPreviousSibling = pChild->m_pPreviousSibling;
     }
 
     if (pChild->m_pEngine) {

--- a/src/waveform/renderers/allshader/waveformrendermark.cpp
+++ b/src/waveform/renderers/allshader/waveformrendermark.cpp
@@ -393,8 +393,9 @@ void allshader::WaveformRenderMark::update() {
 
     // Remove unused nodes
     while (pRangeChild) {
+        auto* pNextChild = static_cast<GeometryNode*>(pRangeChild->nextSibling());
         auto pNode = m_pRangeNodesParent->detachChildNode(pRangeChild);
-        pRangeChild = static_cast<GeometryNode*>(pRangeChild->nextSibling());
+        pRangeChild = pNextChild;
     }
 
     m_waveformRenderer->setMarkPositions(marksOnScreen);

--- a/src/waveform/renderers/allshader/waveformrendermarkrange.cpp
+++ b/src/waveform/renderers/allshader/waveformrendermarkrange.cpp
@@ -40,6 +40,7 @@ void WaveformRenderMarkRange::draw(QPainter* painter, QPaintEvent* event) {
 void WaveformRenderMarkRange::update() {
     GeometryNode* pChild = static_cast<GeometryNode*>(firstChild());
 
+    // Add or reuse child node for the active and visible mark ranges.
     for (const auto& markRange : m_markRanges) {
         // If the mark range is not active we should not draw it.
         if (!markRange.active()) {
@@ -72,6 +73,7 @@ void WaveformRenderMarkRange::update() {
         QColor color = markRange.enabled() ? markRange.m_activeColor : markRange.m_disabledColor;
         color.setAlphaF(0.3f);
 
+        // Append a new node if none left, or reuse an existing one.
         if (!pChild) {
             auto pNode = std::make_unique<GeometryNode>();
             pChild = pNode.get();
@@ -87,9 +89,11 @@ void WaveformRenderMarkRange::update() {
 
         pChild = static_cast<GeometryNode*>(pChild->nextSibling());
     }
+    // Remove all remaining nodes
     while (pChild) {
+        auto* pNextChild = static_cast<GeometryNode*>(pChild->nextSibling());
         auto pNode = detachChildNode(pChild);
-        pChild = static_cast<GeometryNode*>(pChild->nextSibling());
+        pChild = pNextChild;
     }
 }
 


### PR DESCRIPTION
This fixes bug #14706 . The actual fix is in the first commit, in the implementation of removeChildNode. The changes in waveformrendermark.cpp and waveformrendermarkrange.cpp fix a memory leak.

