### PR TITLE
(fix/feat) Traktor Kontrol S4 Mk3: prevent sync lockup, add setting for tempo center snap

### DIFF
--- a/res/controllers/Traktor Kontrol S4 MK3.hid.xml
+++ b/res/controllers/Traktor Kontrol S4 MK3.hid.xml
@@ -171,6 +171,31 @@
             </option>
         </group>
 
+        <group label="Tempo Fader">
+            <option
+                variable="tempoCenterRangeMm"
+                type="real"
+                min="0.3"
+                max="5.0"
+                default="1.0"
+                label="Center Snap Region in Millimeter">
+                <description>
+                    Defines the center range in mm where the rate snaps to 0.
+                </description>
+            </option>
+            <option
+                variable="tempoCenterOffsetMm"
+                type="real"
+                min="-3.0"
+                max="3.0"
+                default="0.0"
+                label="Center Snap Offset in Millimeter">
+                <description>
+                    Shifts the center range in case it doesn't match the center marker.
+                </description>
+            </option>
+        </group>
+
         <group label="Alternative Mapping">
             <option
                 variable="useKeylockOnMaster"
@@ -385,6 +410,7 @@
                 </option>
             </row>
         </group>
+
         <group label="Library">
             <row orientation="vertical">
                 <option
@@ -550,6 +576,7 @@
                 </option>
             </row>
         </group>
+
         <group label="Jog wheel">
             <option
                 variable="loopWheelMoveFactor"
@@ -598,6 +625,7 @@
                 <description>Define how fast the jogwheel rotates at the default play rate. This will impact scratch sensitivity, motor speed and ring LED pace.</description>
             </option>
         </group>
+
         <group label="Haptic drive feature (BETA)">
             <option
                 variable="useMotors"

--- a/res/controllers/Traktor-Kontrol-S4-MK3.js
+++ b/res/controllers/Traktor-Kontrol-S4-MK3.js
@@ -1644,6 +1644,7 @@ class S4Mk3Deck extends Deck {
         });
         this.tempoFader = new Pot({
             inKey: "rate",
+            outKey: "rate",
             appliedValue: null,
 
             input: function(value) {
@@ -1663,19 +1664,18 @@ class S4Mk3Deck extends Deck {
 
                 if (receivingFirstValue) {
                     engine.softTakeover(this.group, this.inKey, true);
+                    // Forec-update LED.
+                    // Output connection is made and updated before input() can set this.appliedValue
+                    // (doesn't happen until getInputReport())
+                    this.outTrigger();
                 }
             },
-        });
-        this.tempoFaderLED = new Component({
-            outKey: "rate",
-            tempoFader: this.tempoFader,
             output: function(value) {
-                if (this.tempoFader.appliedValue === null) {
+                if (this.appliedValue === null) {
                     return;
                 }
 
-                const engineValue = engine.getValue(this.group, this.outKey);
-                const hardwareOffset = this.tempoFader.appliedValue - engineValue;
+                const hardwareOffset = this.appliedValue - value;
                 // Use LED to indicate softTakeover pickup position
                 if (hardwareOffset > 0) { // engine is faster
                     this.send(TempoFaderSoftTakeoverColorLow + Button.prototype.brightnessOn);
@@ -1686,7 +1686,7 @@ class S4Mk3Deck extends Deck {
                 }
 
                 // Fader is in sync with engine, set center LED on/off
-                if (engineValue === 0) {
+                if (value === 0) {
                     this.send(this.color + Button.prototype.brightnessOn);
                 } else {
                     this.send(0);
@@ -3021,7 +3021,6 @@ class S4MK3 {
                 deckButtonLeft: {inByte: 5, inBit: 2},
                 deckButtonRight: {inByte: 5, inBit: 3},
                 deckButtonOutputByteOffset: 12,
-                tempoFaderLED: {outByte: 11},
                 shiftButton: {inByte: 5, inBit: 1, outByte: 59},
                 leftEncoder: {inByte: 19, inBit: 0},
                 leftEncoderPress: {inByte: 6, inBit: 2},
@@ -3049,7 +3048,7 @@ class S4MK3 {
                     {inByte: 3, inBit: 1, outByte: 6},
                     {inByte: 3, inBit: 0, outByte: 7},
                 ],
-                tempoFader: {inByte: 12, inBit: 0, inBitLength: 16, inReport: this.inReports[2]},
+                tempoFader: {inByte: 12, inBit: 0, inBitLength: 16, inReport: this.inReports[2], outByte: 11},
                 wheelRelative: {inByte: 11, inBit: 0, inBitLength: 16, inReport: this.inReports[3]},
                 wheelAbsolute: {inByte: 15, inBit: 0, inBitLength: 16, inReport: this.inReports[3]},
                 wheelTouch: {inByte: 16, inBit: 4},
@@ -3072,7 +3071,6 @@ class S4MK3 {
                 deckButtonLeft: {inByte: 14, inBit: 2},
                 deckButtonRight: {inByte: 14, inBit: 3},
                 deckButtonOutputByteOffset: 35,
-                tempoFaderLED: {outByte: 34},
                 shiftButton: {inByte: 14, inBit: 1, outByte: 70},
                 leftEncoder: {inByte: 20, inBit: 4},
                 leftEncoderPress: {inByte: 15, inBit: 5},
@@ -3100,7 +3098,7 @@ class S4MK3 {
                     {inByte: 13, inBit: 1, outByte: 29},
                     {inByte: 13, inBit: 0, outByte: 30},
                 ],
-                tempoFader: {inByte: 10, inBit: 0, inBitLength: 16, inReport: this.inReports[2]},
+                tempoFader: {inByte: 10, inBit: 0, inBitLength: 16, inReport: this.inReports[2], outByte: 34},
                 wheelRelative: {inByte: 39, inBit: 0, inBitLength: 16, inReport: this.inReports[3]},
                 wheelAbsolute: {inByte: 43, inBit: 0, inBitLength: 16, inReport: this.inReports[3]},
                 wheelTouch: {inByte: 16, inBit: 5},


### PR DESCRIPTION
Fixes #14721 
Also the default center range was way to narrow for me, I never managed to hit it.
(maybe because the hotspot was in between the values the fader sends, these have a resolution of 8-9 on my device, ie. ~510 steps, **not** [max-min] steps (4096))

Tested extensively, no more sync lockup.

* Rate is now set only in input function, incl. center snap/reset
* center snap can be customized (set in mm, 0.5..5.0, default: 1)
* output function only sets the LED (center, offset high/low)
* made separate output `tempoFaderLED(rate)` part of the `tempoFader` component
(fixes issue with LED on startup)

@acolombier Do yo have a chance to compare this with the behavior in Traktor?
How wide is the center range there? Can it be customized?
1 mm works fine for me. Should the lowest value be even lower that .5?
_**edit**_ I made it .3 mm, see inline comment

**Note:**
With my device I noticed the (value) center is off by .8 mm compared to the label.
This is annyoing since when I move the fader, I aim for the cap mark to match the center label (not trail'n'error until the LED lights up).
I added a hidden var `TempoCenterValueOffset`.
I think adding yet another setting for this is too much (is it?), but we should mention it in the manual.