### PR TITLE
fix(playlist): use completeBaseName as name when importing playlist

### DIFF
--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -450,10 +450,9 @@ void BasePlaylistFeature::slotImportPlaylist() {
     }
 
     // Update the import/export playlist directory
-    QString fileDirectory(playlistFile);
-    fileDirectory.truncate(playlistFile.lastIndexOf("/"));
+    QFileInfo fileDirectory(playlistFile);
     m_pConfig->set(kConfigKeyLastImportExportPlaylistDirectory,
-            ConfigValue(fileDirectory));
+            ConfigValue(fileDirectory.absoluteDir().canonicalPath()));
 
     slotImportPlaylistFile(playlistFile, playlistId);
 }
@@ -496,10 +495,9 @@ void BasePlaylistFeature::slotCreateImportPlaylist() {
     }
 
     // Set last import directory
-    QString fileDirectory(playlistFiles.first());
-    fileDirectory.truncate(playlistFiles.first().lastIndexOf("/"));
+    QFileInfo fileDirectory(playlistFiles.first());
     m_pConfig->set(kConfigKeyLastImportExportPlaylistDirectory,
-            ConfigValue(fileDirectory));
+            ConfigValue(fileDirectory.absoluteDir().canonicalPath()));
 
     int lastPlaylistId = kInvalidPlaylistId;
 
@@ -507,7 +505,7 @@ void BasePlaylistFeature::slotCreateImportPlaylist() {
     for (const QString& playlistFile : playlistFiles) {
         const QFileInfo fileInfo(playlistFile);
         // Get a valid name
-        const QString baseName = fileInfo.baseName();
+        const QString baseName = fileInfo.completeBaseName();
         QString name = baseName;
         // Check if there already is a playlist by that name. If yes, add
         // increasing suffix (1++) until we find an unused name.
@@ -559,10 +557,9 @@ void BasePlaylistFeature::slotExportPlaylist() {
     }
 
     // Update the import/export playlist directory
-    QString fileDirectory(fileLocation);
-    fileDirectory.truncate(fileLocation.lastIndexOf("/"));
+    QFileInfo fileDirectory(fileLocation);
     m_pConfig->set(kConfigKeyLastImportExportPlaylistDirectory,
-            ConfigValue(fileDirectory));
+            ConfigValue(fileDirectory.absoluteDir().canonicalPath()));
 
     // The user has picked a new directory via a file dialog. This means the
     // system sandboxer (if we are sandboxed) has granted us permission to this

--- a/src/library/trackset/crate/cratefeature.cpp
+++ b/src/library/trackset/crate/cratefeature.cpp
@@ -646,10 +646,9 @@ void CrateFeature::slotImportPlaylist() {
     }
 
     // Update the import/export crate directory
-    QString fileDirectory(playlistFile);
-    fileDirectory.truncate(playlistFile.lastIndexOf("/"));
+    QFileInfo fileDirectory(playlistFile);
     m_pConfig->set(kConfigKeyLastImportExportCrateDirectoryKey,
-            ConfigValue(fileDirectory));
+            ConfigValue(fileDirectory.absoluteDir().canonicalPath()));
 
     CrateId crateId = crateIdFromIndex(m_lastRightClickedIndex);
     Crate crate;
@@ -700,10 +699,9 @@ void CrateFeature::slotCreateImportCrate() {
     }
 
     // Set last import directory
-    QString fileDirectory(playlistFiles.first());
-    fileDirectory.truncate(playlistFiles.first().lastIndexOf("/"));
+    QFileInfo fileDirectory(playlistFiles.first());
     m_pConfig->set(kConfigKeyLastImportExportCrateDirectoryKey,
-            ConfigValue(fileDirectory));
+            ConfigValue(fileDirectory.absoluteDir().canonicalPath()));
 
     CrateId lastCrateId;
 
@@ -714,7 +712,7 @@ void CrateFeature::slotCreateImportCrate() {
         Crate crate;
 
         // Get a valid name
-        const QString baseName = fileInfo.baseName();
+        const QString baseName = fileInfo.completeBaseName();
         for (int i = 0;; ++i) {
             auto name = baseName;
             if (i > 0) {
@@ -792,10 +790,9 @@ void CrateFeature::slotExportPlaylist() {
         return;
     }
     // Update the import/export crate directory
-    QString fileDirectory(fileLocation);
-    fileDirectory.truncate(fileLocation.lastIndexOf("/"));
+    QFileInfo fileDirectory(fileLocation);
     m_pConfig->set(kConfigKeyLastImportExportCrateDirectoryKey,
-            ConfigValue(fileDirectory));
+            ConfigValue(fileDirectory.absoluteDir().canonicalPath()));
 
     // The user has picked a new directory via a file dialog. This means the
     // system sandboxer (if we are sandboxed) has granted us permission to this


### PR DESCRIPTION
Fixes playlist names being truncated if they contains a dot.

To reproduce the bug, import a playlist with `.` inside, for example `Mixxx 2.6 - STEM demo.m3u`. The playlist `Mixxx 2` will be created, instead of `Mixxx 2.6 - STEM demo`. 

This fixes the issue and replace unnecessary string manipulation, based of the UNIX file path separator 