### PR TITLE
Export playlists to Engine DJ

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2840,7 +2840,7 @@ option(ENGINEPRIME "Support for library export to Denon Engine Prime" ON)
 if(ENGINEPRIME)
   # libdjinterop does not currently have a stable ABI, so we fetch sources for a specific tag, build here, and link
   # statically.  This situation should be reviewed once libdjinterop hits version 1.x.
-  set(LIBDJINTEROP_VERSION 0.24.3)
+  set(LIBDJINTEROP_VERSION 0.26.1)
   # Look whether an existing installation of libdjinterop matches the required version.
   find_package(DjInterop ${LIBDJINTEROP_VERSION} EXACT CONFIG)
   if(NOT DjInterop_FOUND)
@@ -2903,7 +2903,7 @@ if(ENGINEPRIME)
         "https://github.com/xsco/libdjinterop/archive/refs/tags/${LIBDJINTEROP_VERSION}.tar.gz"
         "https://launchpad.net/~xsco/+archive/ubuntu/djinterop/+sourcefiles/libdjinterop/${LIBDJINTEROP_VERSION}-0ubuntu1/libdjinterop_${LIBDJINTEROP_VERSION}.orig.tar.gz"
       URL_HASH
-        SHA256=df41fe39bed9d16d27a3649d237b68edd2cdb6fc71a82cae5cd746d4e4ef6578
+        SHA256=f4fbe728783c14acdc999b74ce3f03d680f9187e1ff676d6bf1233fdb64ae7b2
       DOWNLOAD_DIR "${CMAKE_CURRENT_BINARY_DIR}/downloads"
       DOWNLOAD_NAME "libdjinterop-${LIBDJINTEROP_VERSION}.tar.gz"
       INSTALL_DIR ${DJINTEROP_INSTALL_DIR}

--- a/res/controllers/Hercules-DJControl-Inpulse-500-script.js
+++ b/res/controllers/Hercules-DJControl-Inpulse-500-script.js
@@ -1152,7 +1152,7 @@ DJCi500.crossfader = function(channel, control, value, status, group) {
             }
             engine.setValue(group, "crossfader", result);
         } else {
-            engine.setValue(group, "crossfader", (value/64)-1);
+            engine.setParameter(group, "crossfader", script.absoluteLin(value, 0, 1, 0, 127));
         }
     }
 };

--- a/res/controllers/Traktor-Kontrol-S2-MK3-hid-scripts.js
+++ b/res/controllers/Traktor-Kontrol-S2-MK3-hid-scripts.js
@@ -347,7 +347,7 @@ TraktorS2MK3.padModeHandler = function(field) {
                 TraktorS2MK3.outputHandler(colorValue, field.group, "pad_" + i);
             }
             else {
-                TraktorS2MK3.outputHandler(0, field.group, "pad_" + i);
+                TraktorS2MK3.outputHandler(0, field.group, `pad_${  i}`);
             }
         }
     }
@@ -889,10 +889,10 @@ TraktorS2MK3.registerOutputPackets = function() {
     this.linkOutput("[Channel2]", "keylock", this.outputHandler);
 
     for (let i = 1; i <= 8; ++i) {
-        engine.makeConnection("[Channel1]", "hotcue_" + i + "_enabled", this.hotcueOutputHandler);
-        engine.makeConnection("[Channel2]", "hotcue_" + i + "_enabled", this.hotcueOutputHandler);
-        engine.makeConnection("[Channel1]", "hotcue_" + i + "_color", this.hotcueColorHandler);
-        engine.makeConnection("[Channel2]", "hotcue_" + i + "_color", this.hotcueColorHandler);
+        engine.makeConnection("[Channel1]", `hotcue_${  i  }_enabled`, this.hotcueOutputHandler);
+        engine.makeConnection("[Channel2]", `hotcue_${  i  }_enabled`, this.hotcueOutputHandler);
+        engine.makeConnection("[Channel1]", `hotcue_${  i  }_color`, this.hotcueColorHandler);
+        engine.makeConnection("[Channel2]", `hotcue_${  i  }_color`, this.hotcueColorHandler);
     }
 
     this.linkOutput("[Channel1]", "pfl", this.outputHandler);
@@ -977,9 +977,9 @@ TraktorS2MK3.hotcueOutputHandler = function(value, group, key) {
         const color = engine.getValue(group, colorKey);
         const padNum = key[7];
         if (value > 0) {
-            TraktorS2MK3.colorOutputHandler(color, group, "pad_" + padNum);
+            TraktorS2MK3.colorOutputHandler(color, group, `pad_${  padNum}`);
         } else {
-            TraktorS2MK3.outputHandler(0, group, "pad_" + padNum);
+            TraktorS2MK3.outputHandler(0, group, `pad_${  padNum}`);
         }
     }
 };
@@ -988,7 +988,7 @@ TraktorS2MK3.hotcueColorHandler = function(value, group, key) {
     // Light button LED only when we are in hotcue mode
     const padNum = key[7];
     if (TraktorS2MK3.padModeState[group] === 0) {
-        TraktorS2MK3.colorOutputHandler(value, group, "pad_" + padNum);
+        TraktorS2MK3.colorOutputHandler(value, group, `pad_${  padNum}`);
     }
 };
 

--- a/res/controllers/Traktor-Kontrol-S2-MK3-hid-scripts.js
+++ b/res/controllers/Traktor-Kontrol-S2-MK3-hid-scripts.js
@@ -346,6 +346,9 @@ TraktorS2MK3.padModeHandler = function(field) {
                 const colorValue = TraktorS2MK3.PadColorMap.getValueForNearestColor(color);
                 TraktorS2MK3.outputHandler(colorValue, field.group, "pad_" + i);
             }
+            else {
+                TraktorS2MK3.outputHandler(0, field.group, "pad_" + i);
+            }
         }
     }
 };
@@ -886,10 +889,10 @@ TraktorS2MK3.registerOutputPackets = function() {
     this.linkOutput("[Channel2]", "keylock", this.outputHandler);
 
     for (let i = 1; i <= 8; ++i) {
-        TraktorS2MK3.controller.linkOutput("[Channel1]", "pad_" + i, "[Channel1]", "hotcue_" + i + "_enabled", this.hotcueOutputHandler);
-        TraktorS2MK3.controller.linkOutput("[Channel2]", "pad_" + i, "[Channel2]", "hotcue_" + i + "_enabled", this.hotcueOutputHandler);
-        TraktorS2MK3.controller.linkOutput("[Channel1]", "pad_" + i, "[Channel1]", "hotcue_" + i + "_color", this.hotcueColorHandler);
-        TraktorS2MK3.controller.linkOutput("[Channel2]", "pad_" + i, "[Channel2]", "hotcue_" + i + "_color", this.hotcueColorHandler);
+        engine.makeConnection("[Channel1]", "hotcue_" + i + "_enabled", this.hotcueOutputHandler);
+        engine.makeConnection("[Channel2]", "hotcue_" + i + "_enabled", this.hotcueOutputHandler);
+        engine.makeConnection("[Channel1]", "hotcue_" + i + "_color", this.hotcueColorHandler);
+        engine.makeConnection("[Channel2]", "hotcue_" + i + "_color", this.hotcueColorHandler);
     }
 
     this.linkOutput("[Channel1]", "pfl", this.outputHandler);
@@ -972,18 +975,20 @@ TraktorS2MK3.hotcueOutputHandler = function(value, group, key) {
     if (TraktorS2MK3.padModeState[group] === 0) {
         const colorKey = key.replace("_enabled", "_color");
         const color = engine.getValue(group, colorKey);
+        const padNum = key[7];
         if (value > 0) {
-            TraktorS2MK3.colorOutputHandler(color, group, key);
+            TraktorS2MK3.colorOutputHandler(color, group, "pad_" + padNum);
         } else {
-            TraktorS2MK3.outputHandler(0, group, key);
+            TraktorS2MK3.outputHandler(0, group, "pad_" + padNum);
         }
     }
 };
 
 TraktorS2MK3.hotcueColorHandler = function(value, group, key) {
     // Light button LED only when we are in hotcue mode
+    const padNum = key[7];
     if (TraktorS2MK3.padModeState[group] === 0) {
-        TraktorS2MK3.colorOutputHandler(value, group, key);
+        TraktorS2MK3.colorOutputHandler(value, group, "pad_" + padNum);
     }
 };
 

--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -1310,7 +1310,7 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
             tr("Microphone Ducking Mode"),
             tr("Toggle microphone ducking mode (OFF, AUTO, MANUAL)"),
             pMicrophoneMenu);
-    addMicrophoneAndAuxControl("passthrough",
+    addMicrophoneAndAuxControl("main_mix",
             tr("Auxiliary On/Off"),
             tr("Auxiliary on/off"),
             pMicrophoneMenu,

--- a/src/library/dao/playlistdao.cpp
+++ b/src/library/dao/playlistdao.cpp
@@ -150,6 +150,26 @@ QList<TrackId> PlaylistDAO::getTrackIds(const int playlistId) const {
     return trackIds;
 }
 
+QList<TrackId> PlaylistDAO::getTrackIdsInPlaylistOrder(const int playlistId) const {
+    QList<TrackId> trackIds;
+
+    QSqlQuery query(m_database);
+    query.prepare(QStringLiteral(
+            "SELECT DISTINCT track_id FROM PlaylistTracks "
+            "WHERE playlist_id = :id ORDER BY position ASC"));
+    query.bindValue(":id", playlistId);
+    if (!query.exec()) {
+        LOG_FAILED_QUERY(query);
+        return trackIds;
+    }
+
+    const int trackIdColumn = query.record().indexOf("track_id");
+    while (query.next()) {
+        trackIds.append(TrackId(query.value(trackIdColumn)));
+    }
+    return trackIds;
+}
+
 int PlaylistDAO::getPlaylistIdFromName(const QString& name) const {
     //qDebug() << "PlaylistDAO::getPlaylistIdFromName" << QThread::currentThread() << m_database.connectionName();
 

--- a/src/library/dao/playlistdao.h
+++ b/src/library/dao/playlistdao.h
@@ -72,6 +72,7 @@ class PlaylistDAO : public QObject, public virtual DAO {
     // stored in the database.
     int getPlaylistId(const int index) const;
     QList<TrackId> getTrackIds(const int playlistId) const;
+    QList<TrackId> getTrackIdsInPlaylistOrder(const int playlistId) const;
     // Returns true if the playlist with playlistId is hidden
     bool isHidden(const int playlistId) const;
     // Returns the HiddenType of playlistId

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -1044,7 +1044,7 @@ QList<TrackRef> TrackDAO::getAllTrackRefs(const QDir& rootDir) const {
     }
 
     QList<TrackRef> trackRefs;
-    const int idColumn = query.record().indexOf(LIBRARYTABLE_MIXXXDELETED);
+    const int idColumn = query.record().indexOf(LIBRARYTABLE_ID);
     const int locationColumn = query.record().indexOf(LIBRARYTABLE_LOCATION);
     while (query.next()) {
         const auto trackId = TrackId(query.value(idColumn));

--- a/src/library/export/dlglibraryexport.h
+++ b/src/library/export/dlglibraryexport.h
@@ -34,11 +34,10 @@ class DlgLibraryExport : public QDialog {
             UserSettingsPointer pConfig,
             TrackCollectionManager* pTrackCollectionManager);
 
-    /// Set the specified crate to be selected for export on the dialog.  If no
-    /// crate is provided (i.e. `std::nullopt`), then the dialog will be ready
-    /// to export the whole library.  If an unknown crate is provided, then no
-    /// action is taken.
-    void setSelectedCrate(std::optional<CrateId> crateId);
+    /// Set the provided crate and playlist to be initially selected for export
+    /// on the dialog.  If an unknown crate or playlist is provided, then no
+    /// action is taken for that item.
+    void setInitialSelection(std::optional<CrateId> crateId, std::optional<int> playlistId);
 
     /// Refresh the contents of the dialog.
     void refresh();
@@ -60,8 +59,9 @@ class DlgLibraryExport : public QDialog {
     TrackCollectionManager* m_pTrackCollectionManager;
 
     parented_ptr<QRadioButton> m_pWholeLibraryRadio;
-    parented_ptr<QRadioButton> m_pCratesRadio;
+    parented_ptr<QRadioButton> m_pCratesAndPlaylistsRadio;
     parented_ptr<QListWidget> m_pCratesList;
+    parented_ptr<QListWidget> m_pPlaylistsList;
     parented_ptr<QLineEdit> m_pExportDirectoryTextField;
     parented_ptr<QComboBox> m_pVersionCombo;
     parented_ptr<QLabel> m_pExistingDatabaseLabel;

--- a/src/library/export/engineprimeexportjob.cpp
+++ b/src/library/export/engineprimeexportjob.cpp
@@ -22,7 +22,8 @@ namespace mixxx {
 
 namespace {
 
-const std::string kMixxxRootCrateName = "Mixxx";
+const std::string kMixxxRootCrateName = "Mixxx Crates";
+const std::string kMixxxRootPlaylistName = "Mixxx Playlists";
 
 constexpr int kMaxHotCues = 8;
 
@@ -168,7 +169,7 @@ bool tryGetBeatgrid(BeatsPointer pBeats,
 void exportMetadata(
         djinterop::database* pDatabase,
         const e::engine_schema& dbSchemaVersion,
-        QHash<TrackId, int64_t>* pMixxxToEnginePrimeTrackIdMap,
+        QHash<TrackId, std::optional<djinterop::track>>* pMixxxToExtTrackMap,
         TrackPointer pTrack,
         const Waveform* pWaveform,
         const QString& relativePath) {
@@ -300,24 +301,21 @@ void exportMetadata(
                 << "(" << pTrack->getFileInfo().fileName() << ")";
     }
 
-    int externalTrackId;
+    // Commit changes, and record the mapping from Mixxx track id to exported track.
     if (externalTrack) {
         externalTrack->update(snapshot);
-        externalTrackId = externalTrack->id();
+        pMixxxToExtTrackMap->insert(pTrack->getId(), *externalTrack);
     } else {
         auto newTrack = pDatabase->create_track(snapshot);
-        externalTrackId = newTrack.id();
+        pMixxxToExtTrackMap->insert(pTrack->getId(), newTrack);
     }
-
-    // Record the mapping from Mixxx track id to exported track id.
-    pMixxxToEnginePrimeTrackIdMap->insert(pTrack->getId(), externalTrackId);
 }
 
 void exportTrack(
         const QSharedPointer<EnginePrimeExportRequest> pRequest,
         djinterop::database* pDatabase,
         const e::engine_schema& dbSchemaVersion,
-        QHash<TrackId, int64_t>* pMixxxToEnginePrimeTrackIdMap,
+        QHash<TrackId, std::optional<djinterop::track>>* pMixxxToExtTrackMap,
         const TrackPointer pTrack,
         const Waveform* pWaveform) {
     // Only export supported file types.
@@ -334,29 +332,62 @@ void exportTrack(
     // Export meta-data.
     exportMetadata(pDatabase,
             dbSchemaVersion,
-            pMixxxToEnginePrimeTrackIdMap,
+            pMixxxToExtTrackMap,
             pTrack,
             pWaveform,
             musicFileRelativePath);
 }
 
 void exportCrate(
-        djinterop::crate* pExtRootCrate,
-        const QHash<TrackId, int64_t>& mixxxToEnginePrimeTrackIdMap,
+        djinterop::database* pDb,
+        djinterop::crate* pExtRootCrate, // May be nullptr
+        const QHash<TrackId, std::optional<djinterop::track>>& mixxxToExtTrackMap,
         const Crate& crate,
         const QList<TrackId>& trackIds) {
-    // Create a new crate as a sub-crate of the top-level Mixxx crate, if one
-    // does not already exist.
     auto crateName = crate.getName().toStdString();
-    const auto optionalExtCrate = pExtRootCrate->sub_crate_by_name(crateName);
+    const auto optionalExtCrate = pExtRootCrate != nullptr
+            ? pExtRootCrate->sub_crate_by_name(crateName)
+            : pDb->root_crate_by_name(crateName);
+
+    // Create a new crate if one does not already exist.
     auto extCrate = optionalExtCrate
             ? *optionalExtCrate
-            : pExtRootCrate->create_sub_crate(crateName);
+            : pExtRootCrate != nullptr
+            ? pExtRootCrate->create_sub_crate(crateName)
+            : pDb->create_root_crate(crateName);
 
     // Loop through all track ids in this crate and add.
+    // Adding to a crate is idempotent, i.e. it doesn't matter if the track is
+    // already in the crate.
     for (const auto& trackId : trackIds) {
-        const auto extTrackId = mixxxToEnginePrimeTrackIdMap[trackId];
-        extCrate.add_track(extTrackId);
+        const auto extTrack = *mixxxToExtTrackMap[trackId];
+        extCrate.add_track(extTrack);
+    }
+}
+
+void exportPlaylist(
+        djinterop::database* pDb,
+        djinterop::playlist* pExtRootPlaylist, // May be nullptr
+        const QHash<TrackId, std::optional<djinterop::track>>& mixxxToExtTrackMap,
+        const QString& playlistName,
+        const QList<TrackId>& trackIds) {
+    auto optionalExtPlaylist = pExtRootPlaylist != nullptr
+            ? pExtRootPlaylist->sub_playlist_by_name(playlistName.toStdString())
+            : pDb->root_playlist_by_name(playlistName.toStdString());
+
+    // Create a new playlist if one does not already exist.
+    auto extPlaylist = optionalExtPlaylist
+            ? *optionalExtPlaylist
+            : pExtRootPlaylist != nullptr
+            ? pExtRootPlaylist->create_sub_playlist(playlistName.toStdString())
+            : pDb->create_root_playlist(playlistName.toStdString());
+
+    // Loop through all track ids and add.  If the playlist already existed,
+    // clear out all prior entries.
+    extPlaylist.clear_tracks();
+    for (const auto& trackId : trackIds) {
+        const auto extTrack = *mixxxToExtTrackMap[trackId];
+        extPlaylist.add_track_back(extTrack);
     }
 }
 
@@ -382,13 +413,14 @@ EnginePrimeExportJob::EnginePrimeExportJob(
 // header with unique_ptr's of incomplete types.
 EnginePrimeExportJob::~EnginePrimeExportJob() = default;
 
-void EnginePrimeExportJob::loadIds(const QSet<CrateId>& crateIds) {
+void EnginePrimeExportJob::loadIds(const QSet<CrateId>& crateIds, const QSet<int>& playlistIds) {
     DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(m_pTrackCollectionManager);
 
-    if (crateIds.isEmpty()) {
-        // No explicit crate ids specified, meaning we want to export the
-        // whole library, plus all non-empty crates.  Start by building a list
-        // of unique track refs from all directories in the library.
+    if (crateIds.isEmpty() && playlistIds.isEmpty()) {
+        // No explicit crate or playlist ids specified, meaning we want to
+        // export the whole library, plus all non-empty crates.  Start by
+        // building a list of unique track refs from all directories in the
+        // library.
         qDebug() << "Loading all track refs and crate ids...";
         QSet<TrackRef> trackRefs;
         const auto dirInfos = m_pTrackCollectionManager->internalCollection()
@@ -409,6 +441,7 @@ void EnginePrimeExportJob::loadIds(const QSet<CrateId>& crateIds) {
 #else
         m_trackRefs = trackRefs.toList();
 #endif
+        qDebug() << "Identified" << m_trackRefs.size() << " tracks to export";
 
         // Convert a list of track refs to a list of track ids, and use that
         // to identify all crates that contain those tracks.
@@ -424,17 +457,36 @@ void EnginePrimeExportJob::loadIds(const QSet<CrateId>& crateIds) {
 #else
         m_crateIds = crateIdsOfTracks.toList();
 #endif
+        qDebug() << "Identified" << m_crateIds.size() << " crates to export";
+
+        // Just export all playlists.
+        m_playlistIdsAndNames = m_pTrackCollectionManager->internalCollection()
+                                        ->getPlaylistDAO()
+                                        .getPlaylists(PlaylistDAO::PLHT_NOT_HIDDEN);
+        qDebug() << "Identified" << m_playlistIdsAndNames.size() << " playlists to export";
     } else {
-        // Explicit crates have been specified to export.
-        qDebug() << "Loading track refs from" << crateIds.size() << "crate(s)";
+        // Explicit crates/playlists have been specified to export.
+        qDebug() << "Loading track refs from" << crateIds.size()
+                 << "crate(s) and" << playlistIds.size() << "playlist(s)";
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
         m_crateIds = QList<CrateId>{crateIds.begin(), crateIds.end()};
 #else
         m_crateIds = crateIds.toList();
 #endif
+        qDebug() << "Identified" << m_crateIds.size() << " crates to export";
 
-        // Identify track refs from the specified crates.
-        m_trackRefs.clear();
+        for (auto&& playlistIdAndName : m_pTrackCollectionManager
+                        ->internalCollection()
+                        ->getPlaylistDAO()
+                        .getPlaylists(PlaylistDAO::PLHT_NOT_HIDDEN)) {
+            if (playlistIds.contains(playlistIdAndName.first)) {
+                m_playlistIdsAndNames.append(playlistIdAndName);
+            }
+        }
+        qDebug() << "Identified" << m_playlistIdsAndNames.size() << " playlists to export";
+
+        // Identify track refs from the specified crates and playlists.
+        QSet<TrackRef> trackRefs;
         for (const auto& crateId : crateIds) {
             auto result = m_pTrackCollectionManager->internalCollection()
                                   ->crates()
@@ -444,9 +496,29 @@ void EnginePrimeExportJob::loadIds(const QSet<CrateId>& crateIds) {
                 const auto location = m_pTrackCollectionManager->internalCollection()
                                               ->getTrackDAO()
                                               .getTrackLocation(trackId);
-                m_trackRefs.append(TrackRef::fromFilePath(location, trackId));
+                trackRefs.insert(TrackRef::fromFilePath(location, trackId));
             }
         }
+
+        for (const auto& playlistId : playlistIds) {
+            const auto trackIds =
+                    m_pTrackCollectionManager->internalCollection()
+                            ->getPlaylistDAO()
+                            .getTrackIds(playlistId);
+            for (auto&& trackId : trackIds) {
+                const auto location = m_pTrackCollectionManager->internalCollection()
+                                              ->getTrackDAO()
+                                              .getTrackLocation(trackId);
+                trackRefs.insert(TrackRef::fromFilePath(location, trackId));
+            }
+        }
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+        m_trackRefs = QList<TrackRef>{trackRefs.begin(), trackRefs.end()};
+#else
+        m_trackRefs = trackRefs.toList();
+#endif
+        qDebug() << "Identified" << m_trackRefs.size() << " tracks to export";
     }
 }
 
@@ -454,7 +526,8 @@ void EnginePrimeExportJob::loadTrack(const TrackRef& trackRef) {
     DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(m_pTrackCollectionManager);
 
     // Load the track.
-    m_pLastLoadedTrack = m_pTrackCollectionManager->getOrAddTrack(trackRef);
+    qDebug() << "Loading track" << trackRef << "...";
+    m_pLastLoadedTrack = m_pTrackCollectionManager->getTrackByRef(trackRef);
 
     // Load high-resolution waveform from analysis info.
     auto& analysisDao = m_pTrackCollectionManager->internalCollection()->getAnalysisDAO();
@@ -473,6 +546,7 @@ void EnginePrimeExportJob::loadCrate(const CrateId& crateId) {
     DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(m_pTrackCollectionManager);
 
     // Load crate details.
+    qDebug() << "Loading crate" << crateId << "...";
     m_pTrackCollectionManager->internalCollection()->crates().readCrateById(
             crateId, &m_lastLoadedCrate);
 
@@ -486,22 +560,36 @@ void EnginePrimeExportJob::loadCrate(const CrateId& crateId) {
     }
 }
 
+void EnginePrimeExportJob::loadPlaylist(int playlistId, const QString& playlistName) {
+    DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(m_pTrackCollectionManager);
+
+    // Load playlist details.
+    qDebug() << "Loading playlist" << playlistId << "(" << playlistName << ")" << "...";
+    m_lastLoadedPlaylistId = playlistId;
+    m_lastLoadedPlaylistName = playlistName;
+    m_lastLoadedPlaylistTrackIds =
+            m_pTrackCollectionManager->internalCollection()
+                    ->getPlaylistDAO()
+                    .getTrackIdsInPlaylistOrder(playlistId);
+}
+
 void EnginePrimeExportJob::run() {
     // Crate music directory if it doesn't already exist.
     QDir().mkpath(m_pRequest->musicFilesDir.path());
 
-    // Load ids of tracks and crates to export.
+    // Load ids of tracks, crates, and playlists to export.
     // Note that loading must happen on the same thread as the track collection
     // manager, which is not the same as this method's worker thread.
     QMetaObject::invokeMethod(
             this,
             "loadIds",
             Qt::BlockingQueuedConnection,
-            Q_ARG(QSet<CrateId>, m_pRequest->crateIdsToExport));
+            Q_ARG(QSet<CrateId>, m_pRequest->crateIdsToExport),
+            Q_ARG(QSet<int>, m_pRequest->playlistIdsToExport));
 
     // Measure progress as one 'count' for each track, each crate, plus some
     // additional counts for various other operations.
-    int maxProgress = m_trackRefs.size() + m_crateIds.size() + 2;
+    int maxProgress = m_trackRefs.size() + m_crateIds.size() + m_playlistIdsAndNames.size() + 2;
     int currProgress = 0;
     emit jobMaximum(maxProgress);
     emit jobProgress(currProgress);
@@ -509,6 +597,8 @@ void EnginePrimeExportJob::run() {
     // Ensure that the database exists, creating an empty one if not.
     std::unique_ptr<djinterop::database> pDb;
     e::engine_schema dbSchemaVersion;
+    qDebug() << "Creating/loading Engine database at"
+             << m_pRequest->engineLibraryDbDir.path() << "...";
     try {
         bool created;
         pDb = std::make_unique<djinterop::database>(e::create_or_load_database(
@@ -530,8 +620,10 @@ void EnginePrimeExportJob::run() {
     ++currProgress;
     emit jobProgress(currProgress);
 
-    // We will build up a map from Mixxx track id to EL track id during export.
-    QHash<TrackId, int64_t> mixxxToEnginePrimeTrackIdMap;
+    // We will build up a map from Mixxx track id to external track during export.
+    // QHash<Key, T> requires that T is default-constructible, but this is not true for
+    // djinterop::track, so we wrap it in std::optional and ensure it is always set.
+    QHash<TrackId, std::optional<djinterop::track>> mixxxToExtTrackMap;
 
     for (const auto& trackRef : std::as_const(m_trackRefs)) {
         // Load each track.
@@ -556,7 +648,7 @@ void EnginePrimeExportJob::run() {
             exportTrack(m_pRequest,
                     pDb.get(),
                     dbSchemaVersion,
-                    &mixxxToEnginePrimeTrackIdMap,
+                    &mixxxToExtTrackMap,
                     m_pLastLoadedTrack,
                     m_pLastLoadedWaveform.get());
         } catch (std::exception& e) {
@@ -578,37 +670,58 @@ void EnginePrimeExportJob::run() {
         emit jobProgress(currProgress);
     }
 
-    // We will ensure that there is a special top-level crate representing the
-    // root of all Mixxx-exported items.  Mixxx tracks and crates will exist
-    // underneath this crate.
-    std::unique_ptr<djinterop::crate> pExtRootCrate;
-    try {
-        const auto optionalExtRootCrate = pDb->root_crate_by_name(kMixxxRootCrateName);
-        pExtRootCrate = std::make_unique<djinterop::crate>(optionalExtRootCrate
-                        ? *optionalExtRootCrate
-                        : pDb->create_root_crate(kMixxxRootCrateName));
-    } catch (std::exception& e) {
-        qWarning() << "Failed to create/identify root crate:" << e.what();
-        m_lastErrorMessage = e.what();
-        emit failed(m_lastErrorMessage);
-        return;
-    }
-
-    // Add each track to the root crate, even if it also belongs to others.
-    for (const TrackRef& trackRef : std::as_const(m_trackRefs)) {
-        if (!mixxxToEnginePrimeTrackIdMap.contains(trackRef.getId())) {
-            qInfo() << "Not adding track" << trackRef.getId()
-                    << "to any crates, as it was not exported";
-            continue;
+    // If the database type supports it, ensure that there is a special
+    // top-level crate representing the root of all Mixxx-exported items.
+    // Mixxx tracks and crates will exist underneath this crate.
+    //
+    // If the database type does not support nested crates, export
+    // everything at top level.
+    std::unique_ptr<djinterop::crate> pExtRootCrate{};
+    if (pDb->supports_feature(djinterop::feature::supports_nested_crates)) {
+        try {
+            const auto optionalExtRootCrate = pDb->root_crate_by_name(kMixxxRootCrateName);
+            pExtRootCrate = std::make_unique<djinterop::crate>(optionalExtRootCrate
+                            ? *optionalExtRootCrate
+                            : pDb->create_root_crate(kMixxxRootCrateName));
+        } catch (std::exception& e) {
+            qWarning() << "Failed to create/identify root crate:" << e.what();
+            m_lastErrorMessage = e.what();
+            emit failed(m_lastErrorMessage);
+            return;
         }
 
-        const auto extTrackId = mixxxToEnginePrimeTrackIdMap.value(
-                trackRef.getId());
+        // Add each track to the root crate, even if it also belongs to others.
+        // This allows someone browsing crates to see all Mixxx-exported tracks
+        // under the top-level Mixxx crate.
+        for (const TrackRef& trackRef : std::as_const(m_trackRefs)) {
+            if (!mixxxToExtTrackMap.contains(trackRef.getId())) {
+                qInfo() << "Not adding track" << trackRef.getId()
+                        << "to any crates, as it was not exported";
+                continue;
+            }
+
+            const auto extTrack = *mixxxToExtTrackMap.value(trackRef.getId());
+            try {
+                pExtRootCrate->add_track(extTrack);
+            } catch (std::exception& e) {
+                qWarning() << "Failed to add track" << trackRef.getId()
+                           << "to root crate:" << e.what();
+                m_lastErrorMessage = e.what();
+                emit failed(m_lastErrorMessage);
+                return;
+            }
+        }
+    }
+
+    std::unique_ptr<djinterop::playlist> pExtRootPlaylist{};
+    if (pDb->supports_feature(djinterop::feature::supports_nested_playlists)) {
         try {
-            pExtRootCrate->add_track(extTrackId);
+            const auto optionalExtRootPlaylist = pDb->root_playlist_by_name(kMixxxRootPlaylistName);
+            pExtRootPlaylist = std::make_unique<djinterop::playlist>(optionalExtRootPlaylist
+                            ? *optionalExtRootPlaylist
+                            : pDb->create_root_playlist(kMixxxRootPlaylistName));
         } catch (std::exception& e) {
-            qWarning() << "Failed to add track" << trackRef.getId()
-                       << "to root crate:" << e.what();
+            qWarning() << "Failed to create/identify root playlist:" << e.what();
             m_lastErrorMessage = e.what();
             emit failed(m_lastErrorMessage);
             return;
@@ -637,8 +750,9 @@ void EnginePrimeExportJob::run() {
         qInfo() << "Exporting crate" << m_lastLoadedCrate.getId().toString() << "...";
         try {
             exportCrate(
-                    pExtRootCrate.get(),
-                    mixxxToEnginePrimeTrackIdMap,
+                    pDb.get(),
+                    pExtRootCrate.get(), // May be nullptr
+                    mixxxToExtTrackMap,
                     m_lastLoadedCrate,
                     m_lastLoadedCrateTrackIds);
         } catch (std::exception& e) {
@@ -653,8 +767,48 @@ void EnginePrimeExportJob::run() {
         emit jobProgress(currProgress);
     }
 
-    qInfo() << "Engine DJ Export Job completed successfully";
-    emit completed(m_trackRefs.size(), m_crateIds.size());
+    // Export all Mixxx playlists
+    for (const auto& idAndName : m_playlistIdsAndNames) {
+        // Load the current crate.
+        // Note that loading must happen on the same thread as the track collection
+        // manager, which is not the same as this method's worker thread.
+        QMetaObject::invokeMethod(
+                this,
+                "loadPlaylist",
+                Qt::BlockingQueuedConnection,
+                Q_ARG(int, idAndName.first),
+                Q_ARG(QString, idAndName.second));
+
+        if (m_cancellationRequested.loadAcquire() != 0) {
+            qInfo() << "Cancelling export";
+            return;
+        }
+
+        qInfo() << "Exporting playlist" << m_lastLoadedPlaylistId << "/"
+                << m_lastLoadedPlaylistName << "...";
+        try {
+            exportPlaylist(
+                    pDb.get(),
+                    pExtRootPlaylist.get(), // May be nullptr
+                    mixxxToExtTrackMap,
+                    m_lastLoadedPlaylistName,
+                    m_lastLoadedPlaylistTrackIds);
+        } catch (std::exception& e) {
+            qWarning() << "Failed to add crate" << m_lastLoadedCrate.getId().toString()
+                       << ":" << e.what();
+            m_lastErrorMessage = e.what();
+            emit failed(m_lastErrorMessage);
+            return;
+        }
+
+        ++currProgress;
+        emit jobProgress(currProgress);
+    }
+
+    qInfo() << "Engine DJ Export Job completed successfully - Num tracks ="
+            << m_trackRefs.size() << ", num crates =" << m_crateIds.size()
+            << ", num playlists =" << m_playlistIdsAndNames.size();
+    emit completed(m_trackRefs.size(), m_crateIds.size(), m_playlistIdsAndNames.size());
 }
 
 void EnginePrimeExportJob::slotCancel() {

--- a/src/library/export/engineprimeexportjob.h
+++ b/src/library/export/engineprimeexportjob.h
@@ -45,7 +45,7 @@ class EnginePrimeExportJob : public QThread {
     void jobProgress(int progress);
 
     /// Inform of a completed export job.
-    void completed(int numTracksExported, int numCratesExported);
+    void completed(int numTracksExported, int numCratesExported, int numPlaylistsExported);
 
     /// Inform of a failed export job.
     void failed(const QString& message);
@@ -58,17 +58,23 @@ class EnginePrimeExportJob : public QThread {
     // These slots are used to load data from the Mixxx database on the main
     // thread of the application, which will be different to the worker thread
     // used by an instance of this class.
-    void loadIds(const QSet<CrateId>& crateIdsToExport);
+    void loadIds(const QSet<CrateId>& crateIds, const QSet<int>& playlistIds);
     void loadTrack(const TrackRef& trackRef);
     void loadCrate(const CrateId& crateId);
+    void loadPlaylist(int playlistId, const QString& playlistName);
 
   private:
     QList<TrackRef> m_trackRefs;
     QList<CrateId> m_crateIds;
+    QList<QPair<int, QString>> m_playlistIdsAndNames;
+
     TrackPointer m_pLastLoadedTrack;
     std::unique_ptr<Waveform> m_pLastLoadedWaveform;
     Crate m_lastLoadedCrate;
     QList<TrackId> m_lastLoadedCrateTrackIds;
+    int m_lastLoadedPlaylistId;
+    QString m_lastLoadedPlaylistName;
+    QList<TrackId> m_lastLoadedPlaylistTrackIds;
 
     QAtomicInteger<int> m_cancellationRequested;
 

--- a/src/library/export/engineprimeexportrequest.h
+++ b/src/library/export/engineprimeexportrequest.h
@@ -20,11 +20,17 @@ struct EnginePrimeExportRequest {
     /// Version of Engine Prime database schema to use when exporting.
     djinterop::engine::engine_schema exportSchemaVersion;
 
-    /// Set of crates to export, if `exportSelectedCrates` is set to true.
+    /// Set of crates to export.
     ///
-    /// An empty set here implies that the whole music library is to be
-    /// exported.
+    /// An empty set of crates AND playlists to export implies that the whole
+    /// music library is to be exported.
     QSet<CrateId> crateIdsToExport;
+
+    /// Set of playlists to export,
+    ///
+    /// An empty set of crates AND playlists to export implies that the whole
+    /// music library is to be exported.
+    QSet<int> playlistIdsToExport;
 };
 
 } // namespace mixxx

--- a/src/library/export/libraryexporter.cpp
+++ b/src/library/export/libraryexporter.cpp
@@ -17,8 +17,9 @@ LibraryExporter::LibraryExporter(QWidget* parent,
           m_pTrackCollectionManager{pTrackCollectionManager} {
 }
 
-void LibraryExporter::requestExportWithOptionalInitialCrate(
-        std::optional<CrateId> initialSelectedCrate) {
+void LibraryExporter::requestExportWithOptionalInitialSelection(
+        std::optional<CrateId> initialSelectedCrateId,
+        std::optional<int> initialSelectedPlaylistId) {
     if (!m_pDialog) {
         m_pDialog = make_parented<DlgLibraryExport>(
                 this, m_pConfig, m_pTrackCollectionManager);
@@ -35,7 +36,7 @@ void LibraryExporter::requestExportWithOptionalInitialCrate(
     }
 
     m_pDialog->refresh();
-    m_pDialog->setSelectedCrate(initialSelectedCrate);
+    m_pDialog->setInitialSelection(initialSelectedCrateId, initialSelectedPlaylistId);
 }
 
 void LibraryExporter::beginEnginePrimeExport(
@@ -53,12 +54,13 @@ void LibraryExporter::beginEnginePrimeExport(
     connect(pJobThread,
             &EnginePrimeExportJob::completed,
             this,
-            [](int numTracks, int numCrates) {
+            [](int numTracks, int numCrates, int numPlaylists) {
                 QMessageBox::information(nullptr,
                         tr("Export Completed"),
-                        QString{tr("Exported %1 track(s) and %2 crate(s).")}
+                        QString{tr("Exported %1 track(s), %2 crate(s), and %3 playlist(s).")}
                                 .arg(numTracks)
-                                .arg(numCrates));
+                                .arg(numCrates)
+                                .arg(numPlaylists));
             });
     connect(pJobThread,
             &EnginePrimeExportJob::failed,

--- a/src/library/export/libraryexporter.h
+++ b/src/library/export/libraryexporter.h
@@ -29,21 +29,28 @@ class LibraryExporter : public QWidget {
   public slots:
     /// Begin the process of a library export.
     void slotRequestExport() {
-        requestExportWithOptionalInitialCrate(std::nullopt);
+        requestExportWithOptionalInitialSelection(std::nullopt, std::nullopt);
     }
 
     /// Begin the process of a library export, with an initial crate set.
-    void slotRequestExportWithInitialCrate(CrateId initialSelectedCrate) {
-        requestExportWithOptionalInitialCrate(
-                std::make_optional(initialSelectedCrate));
+    void slotRequestExportWithInitialCrate(CrateId initialSelectedCrateId) {
+        requestExportWithOptionalInitialSelection(
+                std::make_optional(initialSelectedCrateId), std::nullopt);
+    }
+
+    /// Begin the process of a library export, with an initial playlist set.
+    void slotRequestExportWithInitialPlaylist(int initialSelectedPlaylistId) {
+        requestExportWithOptionalInitialSelection(
+                std::nullopt, std::make_optional(initialSelectedPlaylistId));
     }
 
   private slots:
     void beginEnginePrimeExport(QSharedPointer<mixxx::EnginePrimeExportRequest> pRequest);
 
   private:
-    void requestExportWithOptionalInitialCrate(
-            std::optional<CrateId> initialSelectedCrate);
+    void requestExportWithOptionalInitialSelection(
+            std::optional<CrateId> initialSelectedCrateId,
+            std::optional<int> initialSelectedPlaylistId);
 
     UserSettingsPointer m_pConfig;
     TrackCollectionManager* m_pTrackCollectionManager;

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -102,6 +102,18 @@ Library::Library(
 
     m_pPlaylistFeature = new PlaylistFeature(this, UserSettingsPointer(m_pConfig));
     addFeature(m_pPlaylistFeature);
+#ifdef __ENGINEPRIME__
+    connect(m_pPlaylistFeature,
+            &PlaylistFeature::exportAllPlaylists,
+            this,
+            &Library::exportLibrary, // signal-to-signal
+            Qt::DirectConnection);
+    connect(m_pPlaylistFeature,
+            &PlaylistFeature::exportPlaylist,
+            this,
+            &Library::exportPlaylist, // signal-to-signal
+            Qt::DirectConnection);
+#endif
 
     m_pCrateFeature = new CrateFeature(this, m_pConfig);
     addFeature(m_pCrateFeature);

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -156,6 +156,7 @@ class Library: public QObject {
 #ifdef __ENGINEPRIME__
     void exportLibrary();
     void exportCrate(CrateId crateId);
+    void exportPlaylist(int playlistId);
 #endif
     void saveModelState();
     void restoreModelState();

--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -143,6 +143,25 @@ void BasePlaylistFeature::initActions() {
             &QAction::triggered,
             this,
             &BasePlaylistFeature::slotExportTrackFiles);
+#ifdef __ENGINEPRIME__
+    // Note: "Engine DJ" is a product name and must not be translated.
+    m_pExportAllPlaylistsToEngineAction = new QAction(tr("Export to Engine DJ"), this);
+    connect(m_pExportAllPlaylistsToEngineAction,
+            &QAction::triggered,
+            this,
+            &BasePlaylistFeature::exportAllPlaylists);
+    // Note: "Engine DJ" is a product name and must not be translated.
+    m_pExportPlaylistToEngineAction = new QAction(tr("Export to Engine DJ"), this);
+    connect(m_pExportPlaylistToEngineAction,
+            &QAction::triggered,
+            this,
+            [this]() {
+                int playlistId = playlistIdFromIndex(m_lastRightClickedIndex);
+                if (playlistId != kInvalidPlaylistId) {
+                    emit exportPlaylist(playlistId);
+                }
+            });
+#endif
 }
 
 void BasePlaylistFeature::connectPlaylistDAO() {

--- a/src/library/trackset/baseplaylistfeature.h
+++ b/src/library/trackset/baseplaylistfeature.h
@@ -58,6 +58,12 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
     void renameItem(const QModelIndex& index) override;
     void deleteItem(const QModelIndex& index) override;
 
+#ifdef __ENGINEPRIME__
+  signals:
+    void exportAllPlaylists();
+    void exportPlaylist(int playlistId);
+#endif
+
   protected slots:
     virtual void slotDeletePlaylist();
     void slotDuplicatePlaylist();
@@ -114,6 +120,10 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
     QAction* m_pExportTrackFilesAction;
     QAction* m_pDuplicatePlaylistAction;
     QAction* m_pAnalyzePlaylistAction;
+#ifdef __ENGINEPRIME__
+    QAction* m_pExportAllPlaylistsToEngineAction;
+    QAction* m_pExportPlaylistToEngineAction;
+#endif
 
     PlaylistTableModel* m_pPlaylistTableModel;
     QSet<int> m_playlistIdsOfSelectedTrack;

--- a/src/library/trackset/playlistfeature.cpp
+++ b/src/library/trackset/playlistfeature.cpp
@@ -50,6 +50,10 @@ void PlaylistFeature::onRightClick(const QPoint& globalPos) {
     menu.addAction(m_pCreatePlaylistAction);
     menu.addSeparator();
     menu.addAction(m_pCreateImportPlaylistAction);
+#ifdef __ENGINEPRIME__
+    menu.addSeparator();
+    menu.addAction(m_pExportAllPlaylistsToEngineAction);
+#endif
     menu.exec(globalPos);
 }
 
@@ -86,6 +90,9 @@ void PlaylistFeature::onRightClickChild(
     menu.addAction(m_pImportPlaylistAction);
     menu.addAction(m_pExportPlaylistAction);
     menu.addAction(m_pExportTrackFilesAction);
+#ifdef __ENGINEPRIME__
+    menu.addAction(m_pExportPlaylistToEngineAction);
+#endif
     menu.exec(globalPos);
 }
 

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -203,6 +203,10 @@ void MixxxMainWindow::initialize() {
             &Library::exportCrate,
             m_pLibraryExporter.get(),
             &mixxx::LibraryExporter::slotRequestExportWithInitialCrate);
+    connect(m_pCoreServices->getLibrary().get(),
+            &Library::exportPlaylist,
+            m_pLibraryExporter.get(),
+            &mixxx::LibraryExporter::slotRequestExportWithInitialPlaylist);
 #endif
 
     // Turn on fullscreen mode

--- a/src/waveform/renderers/waveformwidgetrenderer.cpp
+++ b/src/waveform/renderers/waveformwidgetrenderer.cpp
@@ -383,10 +383,10 @@ void WaveformWidgetRenderer::setPassThroughEnabled(bool enabled) {
     if (!enabled) {
         return;
     }
-    // If passthrough is activated while no track has been loaded previously mark
-    // the renderer state dirty in order trigger the render process. This is only
-    // required for the background renderer since that's the only one that'll
-    // be processed if passtrhough is active.
+    // If passthrough is activated while no track has been loaded previously,
+    // mark the renderer state dirty in order trigger the render process.
+    // This is only required for the background renderer since that's the only
+    // one that'll be processed if passthrough is active.
     if (!m_rendererStack.isEmpty()) {
         m_rendererStack[0]->setDirty(true);
     }


### PR DESCRIPTION
This PR adds support for exporting playlists to Engine DJ (previously only crates were exported).

Brief overview of changes:

* Update to libdjinterop 0.26.1 - this is currently pushed to the [XSCO PPA](https://launchpad.net/~xsco/+archive/ubuntu/djinterop).
* A new list on the export dialog window showing playlists.  An ASCII-art visualisation of the layout is in the relevant source file to explain how the grid layout is used.
* There is now a Right Click -> Export to Engine DJ option on playlists in the left-hand tree.

Caveats:
* AFAIK the newest Engine schemas don't support having the same track in the same playlist multiple times.  Duplicates in a playlist will be removed if this happens during export.

I've tested locally on my SC5000s, but extra testing from the community is always welcomed!