### PR TITLE
chore: disable QML pre-commit hooks to prevent further data loss

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -168,6 +168,8 @@ repos:
         language: system
         types: [text]
         files: ^.*\.qml$
+        stages:
+          - manual
       - id: metainfo
         name: metainfo
         description: Update AppStream metainfo releases from CHANGELOG.md.


### PR DESCRIPTION
As mentioned [here](https://github.com/mixxxdj/mixxx/issues/14604#issuecomment-2849385936), I have lost about 2 days worth of work when I jumped to help with the 2.6 release. (`git commit` of staged + `git reset` of test files - commit hooks failing leading to loosing all). Since it was days ago, I have no hope to recover this loss.

Needless to say that I am extremely frustrated right now. Since QML hooks is extremely unreliable and unstable, I suggest we disable it (make it manual) till further notice.

Relates to #14604 