### PR TITLE
Add mapIndexToChannel and inverse common function

### DIFF
--- a/res/controllers/DJ TechTools-MIDI Fighter Spectra-scripts.js
+++ b/res/controllers/DJ TechTools-MIDI Fighter Spectra-scripts.js
@@ -3,15 +3,6 @@
 // eslint-disable-next-line no-var
 var MidiFighterSpectra;
 (function(MidiFighterSpectra) {
-    const mapIndexToChannel = function(index) {
-        switch (Math.abs(index) % 4) {
-        case 0: return 3;
-        case 1: return 1;
-        case 2: return 2;
-        case 3: return 4;
-        }
-    };
-
     class Deck extends components.Deck {
         constructor() {
             super([1, 2, 3, 4]);
@@ -111,7 +102,7 @@ var MidiFighterSpectra;
             this.eqLayer = [];
             for (let i = 0; i < 4; i++) {
                 this.eqLayer[i] = new components.Button({
-                    group: `[EqualizerRack1_[Channel${mapIndexToChannel(i)}]_Effect1]`,
+                    group: `[EqualizerRack1_[Channel${script.mapIndexToChannel(i)}]_Effect1]`,
                     midi: [0x92, 0x30 + i],
                     key: "button_parameter3",
                     type: components.Button.prototype.types.toggle,
@@ -119,7 +110,7 @@ var MidiFighterSpectra;
                     on: engine.getSetting("eqOffColor"),
                 });
                 this.eqLayer[i + 4] = new components.Button({
-                    group: `[EqualizerRack1_[Channel${mapIndexToChannel(i)}]_Effect1]`,
+                    group: `[EqualizerRack1_[Channel${script.mapIndexToChannel(i)}]_Effect1]`,
                     midi: [0x92, 0x2C + i],
                     key: "button_parameter2",
                     type: components.Button.prototype.types.toggle,
@@ -127,7 +118,7 @@ var MidiFighterSpectra;
                     on: engine.getSetting("eqOffColor"),
                 });
                 this.eqLayer[i + 8] = new components.Button({
-                    group: `[EqualizerRack1_[Channel${mapIndexToChannel(i)}]_Effect1]`,
+                    group: `[EqualizerRack1_[Channel${script.mapIndexToChannel(i)}]_Effect1]`,
                     midi: [0x92, 0x28 + i],
                     key: "button_parameter1",
                     type: components.Button.prototype.types.toggle,
@@ -135,7 +126,7 @@ var MidiFighterSpectra;
                     on: engine.getSetting("eqOffColor"),
                 });
                 this.eqLayer[i + 12] = new components.Button({
-                    group: `[QuickEffectRack1_[Channel${mapIndexToChannel(i)}]]`,
+                    group: `[QuickEffectRack1_[Channel${script.mapIndexToChannel(i)}]]`,
                     midi: [0x92, 0x24 + i],
                     key: "enabled",
                     type: components.Button.prototype.types.toggle,

--- a/res/controllers/MVave-SMC-Mixer-scripts.js
+++ b/res/controllers/MVave-SMC-Mixer-scripts.js
@@ -3,15 +3,6 @@
 // eslint-disable-next-line no-var
 var SMCMixer;
 (function(SMCMixer) {
-    const mapIndexToChannel = function(index) {
-        switch (Math.abs(index) % 4) {
-        case 0: return 3;
-        case 1: return 1;
-        case 2: return 2;
-        case 3: return 4;
-        }
-    };
-
     class Deck extends components.Deck {
         constructor() {
             super([1, 2, 3, 4]);
@@ -133,7 +124,7 @@ var SMCMixer;
     class EqRack extends components.ComponentContainer {
         constructor(index) {
             super({});
-            const channel = mapIndexToChannel(index);
+            const channel = script.mapIndexToChannel(index);
             this.knob = new Encoder({
                 group: `[Channel${channel}]`,
                 midi: [0xB0, 0x10 + index],
@@ -218,7 +209,7 @@ var SMCMixer;
             this.pflButtons = new Array(4);
             this.faders = new Array(8);
             for (let i = 0; i < 4; i++) {
-                const channel = mapIndexToChannel(i);
+                const channel = script.mapIndexToChannel(i);
                 const group = `[Channel${channel}]`;
                 this.eqButtons[i] = new EqRack(i);
                 this.slipButtons[i] = new components.Button({

--- a/res/controllers/common-controller-scripts.js
+++ b/res/controllers/common-controller-scripts.js
@@ -210,6 +210,30 @@ script.deckFromGroup = function(group) {
     return parseInt(deck);
 };
 
+// Maps an 0-indexed offset to a channel.
+// ie. the deck ordering sequence 3, 1, 2, 4.
+script.mapIndexToChannel = function(idx) {
+    switch (Math.abs(idx) % 4) {
+    case 0: return 3;
+    case 1: return 1;
+    case 2: return 2;
+    case 3: return 4;
+    }
+};
+
+// The inverse of mapIndexToChannel: given a channel, returns the 0-indexed
+// offset.
+script.mapChannelToIndex = function(channel) {
+    switch (channel) {
+    case 3: return 0;
+    case 1: return 1;
+    case 2: return 2;
+    case 4: return 3;
+    default:
+        throw Error("invalid channel, expected 3, 1, 2, or 4");
+    }
+};
+
 /* -------- ------------------------------------------------------
      script.bindConnections
    Purpose: Binds multiple controls at once. See an example in Pioneer-DDJ-SB-scripts.js


### PR DESCRIPTION
I've found myself adding these functions to every mapping I've written, mostly to go between the fader on the controller to the deck it should control. They're not exactly complicated, and copy/pasting them is easy  enough, but it seems like a common enough operation that it would be a good candidate to exist in the `scripts` namespace alongside other common stuff like extracting the deck number from the channel name? Thought I'd submit them and see either way, if this isn't desirable no worries.