### PR TITLE
Fix fpclassify for gcc >= 14  with LTO and clang >= 19 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2645,6 +2645,9 @@ target_link_libraries(mixxx-lib PRIVATE FLAC::FLAC)
 # inlining It is compiled without optimization and allows to use these function
 # from -ffast-math optimized objects. The MSVC option /fp:fast does not suffer this issue
 add_library(FpClassify STATIC EXCLUDE_FROM_ALL src/util/fpclassify.cpp)
+# With gcc >= 14 and -flto some code is inlined to fast-math code and then
+# optimized away. Disable it explicit for all compiler just in case.
+set_target_properties(FpClassify PROPERTIES INTERPROCEDURAL_OPTIMIZATION OFF)
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_SIMULATE_ID MATCHES "MSVC")
   target_compile_options(FpClassify PRIVATE /fp:precise)

--- a/src/test/mathutiltest.cpp
+++ b/src/test/mathutiltest.cpp
@@ -98,8 +98,12 @@ TEST_F(MathUtilTest, DoubleValues) {
     long long int_value;
     double double_value = util_double_infinity();
     std::memcpy(&int_value, &double_value, sizeof(double_value));
-    // IEC 559 (IEEE 754) Infinity
-    EXPECT_EQ(int_value, 0x7FF0000000000000);
+    long long int_diff = int_value - 0x7FF0000000000000; // IEC 559 (IEEE 754) Infinity
+    EXPECT_EQ(int_diff, 0);
+    // Comparing directly does not work because the compiler (clang >= 19) may
+    // optimize the long long roundtrip away, compares as double and discards the
+    // comparison because of -ffastmath (clang >= 19)
+    // EXPECT_EQ(int_value, 0x7FF0000000000000);
 }
 
 }  // namespace


### PR DESCRIPTION
Fixes #14716