### PR TITLE
Fix BPM rounding for the 3/2 case

### DIFF
--- a/src/test/beatstest.cpp
+++ b/src/test/beatstest.cpp
@@ -5,6 +5,7 @@
 
 #include "audio/types.h"
 #include "track/beats.h"
+#include "track/beatutils.h"
 #include "track/bpm.h"
 
 using namespace mixxx;
@@ -535,6 +536,37 @@ TEST(BeatsTest, ConstTempoFindPrevNextBeatWhenNotOnBeat) {
     kConstTempoBeats.findPrevNextBeats(position, &foundPrevBeat, &foundNextBeat, false);
     EXPECT_NEAR(previousBeat.value(), foundPrevBeat.value(), kMaxBeatError);
     EXPECT_NEAR(nextBeat.value(), foundNextBeat.value(), kMaxBeatError);
+}
+
+TEST(BeatsTest, roundBpm) {
+    // Integer Bpm
+    mixxx::Bpm roundBpm = BeatUtils::roundBpmWithinRange(
+            mixxx::Bpm(121.5), mixxx::Bpm(121.9), mixxx::Bpm(122.4));
+    EXPECT_NEAR(roundBpm.value(), 122.0, kMaxBeatError);
+
+    // Half Bpm
+    roundBpm = BeatUtils::roundBpmWithinRange(mixxx::Bpm(80.1), mixxx::Bpm(80.4), mixxx::Bpm(80.7));
+    EXPECT_NEAR(roundBpm.value(), 80.5, kMaxBeatError);
+
+    // High Half Bpm -> 1/3
+    roundBpm = BeatUtils::roundBpmWithinRange(
+            mixxx::Bpm(121.1), mixxx::Bpm(121.4), mixxx::Bpm(122.7));
+    EXPECT_NEAR(roundBpm.value(), 121.3333333333, kMaxBeatError);
+
+    // High Half Bpm -> 1/12
+    roundBpm = BeatUtils::roundBpmWithinRange(
+            mixxx::Bpm(121.4), mixxx::Bpm(121.46), mixxx::Bpm(122.6));
+    EXPECT_NEAR(roundBpm.value(), 121.5, kMaxBeatError);
+
+    // 2/3 Bpm
+    roundBpm = BeatUtils::roundBpmWithinRange(
+            mixxx::Bpm(186.276), mixxx::Bpm(186.621), mixxx::Bpm(186.967));
+    EXPECT_NEAR(roundBpm.value(), 186.666666666, kMaxBeatError);
+
+    // 1/12 Bpm
+    roundBpm = BeatUtils::roundBpmWithinRange(
+            mixxx::Bpm(186.01), mixxx::Bpm(186.1), mixxx::Bpm(186.18));
+    EXPECT_NEAR(roundBpm.value(), 186.0833333333333, kMaxBeatError);
 }
 
 } // namespace

--- a/src/track/beatutils.cpp
+++ b/src/track/beatutils.cpp
@@ -332,18 +332,24 @@ mixxx::Bpm BeatUtils::roundBpmWithinRange(
         return snapBpm;
     }
 
-    // Probe the reasonable multipliers for 0.5
-    const double roundBpmWidth = maxBpm - minBpm;
-    if (roundBpmWidth > 0.5) {
-        // 0.5 BPM are only reasonable if the double value is not insane
-        // or the 2/3 value is not too small.
-        if (centerBpm < mixxx::Bpm(85.0)) {
-            // this cane be actually up to 175 BPM
-            // allow halve BPM values
-            return mixxx::Bpm(round(centerBpm.value() * 2) / 2);
-        } else if (centerBpm > mixxx::Bpm(127.0)) {
-            // optimize for 2/3 going down to 85
-            return mixxx::Bpm(round(centerBpm.value() / 3 * 2) * 3 / 2);
+    // 0.5 BPM are only reasonable if the double value is not insane
+    // else other factors below are more typical
+    if (centerBpm < mixxx::Bpm(85.0)) {
+        // this cane be actually up to 175 BPM
+        // allow halve BPM values
+        snapBpm = mixxx::Bpm(round(centerBpm.value() * 2) / 2);
+        if (snapBpm > minBpm && snapBpm < maxBpm) {
+            // Success
+            return snapBpm;
+        }
+    }
+
+    if (centerBpm > mixxx::Bpm(127.0)) {
+        // optimize for 2/3 going down to 85
+        // else other factors below are more typical
+        snapBpm = mixxx::Bpm(round(centerBpm.value() / 3 * 2) * 3 / 2);
+        if (snapBpm > minBpm && snapBpm < maxBpm) {
+            return snapBpm;
         }
     }
 

--- a/src/track/beatutils.cpp
+++ b/src/track/beatutils.cpp
@@ -353,20 +353,23 @@ mixxx::Bpm BeatUtils::roundBpmWithinRange(
         }
     }
 
-    if (roundBpmWidth > 1.0 / 12) {
-        // this covers all sorts of 1/2 2/3 and 3/4 multiplier
-        return mixxx::Bpm(round(centerBpm.value() * 12) / 12);
-    } else {
-        // We are here if we have more that ~75 beats and ~30 s
-        // try to snap to a 1/12 Bpm
-        snapBpm = mixxx::Bpm(round(centerBpm.value() * 12) / 12);
-        if (snapBpm > minBpm && snapBpm < maxBpm) {
-            // Success
-            return snapBpm;
-        }
-        // else give up and use the original BPM value.
+    // try to snap to a 1/3 Bpm
+    // This covers all sorts of 3/2 and 3/4 multiplier
+    snapBpm = mixxx::Bpm(round(centerBpm.value() * 3) / 3);
+    if (snapBpm > minBpm && snapBpm < maxBpm) {
+        // Success
+        return snapBpm;
     }
 
+    // try to snap to a 1/12 Bpm
+    // This covers all other sorts of typical multiplier
+    snapBpm = mixxx::Bpm(round(centerBpm.value() * 12) / 12);
+    if (snapBpm > minBpm && snapBpm < maxBpm) {
+        // Success
+        return snapBpm;
+    }
+
+    // else give up and use the original BPM value.
     return centerBpm;
 }
 

--- a/src/track/beatutils.cpp
+++ b/src/track/beatutils.cpp
@@ -335,7 +335,7 @@ mixxx::Bpm BeatUtils::roundBpmWithinRange(
     // 0.5 BPM are only reasonable if the double value is not insane
     // else other factors below are more typical
     if (centerBpm < mixxx::Bpm(85.0)) {
-        // this cane be actually up to 175 BPM
+        // this can be actually up to 175 BPM
         // allow halve BPM values
         snapBpm = mixxx::Bpm(round(centerBpm.value() * 2) / 2);
         if (snapBpm > minBpm && snapBpm < maxBpm) {
@@ -354,7 +354,7 @@ mixxx::Bpm BeatUtils::roundBpmWithinRange(
     }
 
     // try to snap to a 1/3 Bpm
-    // This covers all sorts of 3/2 and 3/4 multiplier
+    // This covers all sorts of 3/2 and 3/4 multipliers
     snapBpm = mixxx::Bpm(round(centerBpm.value() * 3) / 3);
     if (snapBpm > minBpm && snapBpm < maxBpm) {
         // Success
@@ -362,7 +362,7 @@ mixxx::Bpm BeatUtils::roundBpmWithinRange(
     }
 
     // try to snap to a 1/12 Bpm
-    // This covers all other sorts of typical multiplier
+    // This covers all other sorts of typical multipliers
     snapBpm = mixxx::Bpm(round(centerBpm.value() * 12) / 12);
     if (snapBpm > minBpm && snapBpm < maxBpm) {
         // Success

--- a/src/track/beatutils.h
+++ b/src/track/beatutils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QVector>
+#include <optional>
 
 #include "audio/frame.h"
 #include "track/bpm.h"
@@ -36,6 +37,11 @@ class BeatUtils {
             const QVector<mixxx::audio::FramePos>& beats);
 
     static QVector<mixxx::audio::FramePos> getBeats(const QVector<ConstRegion>& constantRegions);
+
+    static std::optional<mixxx::Bpm> trySnap(mixxx::Bpm minBpm,
+            mixxx::Bpm centerBpm,
+            mixxx::Bpm maxBpm,
+            double fraction);
 
     static mixxx::Bpm roundBpmWithinRange(
             mixxx::Bpm minBpm, mixxx::Bpm centerBpm, mixxx::Bpm maxBpm);


### PR DESCRIPTION
During testing with tracks with changing BPMs from QM, in notices that BeatUtils::roundBpmWithinRange() returns out of range values in the 3/2 case. 

This is fixed. There should be no notable issue, because rounding currently applied to the whole track and the code in question is only relevant for short tracks portions. However it needs to be fixed for further rounding improvements. 
