### PR TITLE
HID: Display all Reports with it's Controls as tabs in the controller preferences

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2595,7 +2595,6 @@ if(BUILD_TESTING)
     src/test/colormapperjsproxy_test.cpp
     src/test/colorpalette_test.cpp
     src/test/configobject_test.cpp
-    src/test/controller_hid_reportdescriptor_test.cpp
     src/test/controller_mapping_validation_test.cpp
     src/test/controller_mapping_settings_test.cpp
     src/test/controllers/controller_columnid_regression_test.cpp
@@ -2705,6 +2704,13 @@ if(BUILD_TESTING)
   endif()
 
   add_executable(mixxx-test ${src-mixxx-test})
+
+  if(HID)
+    target_sources(
+      mixxx-test
+      PRIVATE src/test/controller_hid_reportdescriptor_test.cpp
+    )
+  endif()
 
   if(QML)
     target_sources(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2595,6 +2595,7 @@ if(BUILD_TESTING)
     src/test/colormapperjsproxy_test.cpp
     src/test/colorpalette_test.cpp
     src/test/configobject_test.cpp
+    src/test/controller_hid_reportdescriptor_test.cpp
     src/test/controller_mapping_validation_test.cpp
     src/test/controller_mapping_settings_test.cpp
     src/test/controllers/controller_columnid_regression_test.cpp
@@ -4825,12 +4826,14 @@ if(HID)
   target_sources(
     mixxx-lib
     PRIVATE
+      src/controllers/controllerhidreporttabsmanager.cpp
       src/controllers/hid/hidcontroller.cpp
       src/controllers/hid/hidiothread.cpp
       src/controllers/hid/hidioglobaloutputreportfifo.cpp
       src/controllers/hid/hidiooutputreport.cpp
       src/controllers/hid/hiddevice.cpp
       src/controllers/hid/hidenumerator.cpp
+      src/controllers/hid/hidreportdescriptor.cpp
       src/controllers/hid/hidusagetables.cpp
       src/controllers/hid/legacyhidcontrollermapping.cpp
       src/controllers/hid/legacyhidcontrollermappingfilehandler.cpp

--- a/src/controllers/controllerhidreporttabsmanager.cpp
+++ b/src/controllers/controllerhidreporttabsmanager.cpp
@@ -379,88 +379,88 @@ void ControllerHidReportTabsManager::populateHidReportTable(
     pTable->verticalHeader()->setVisible(false);
 
     int row = 0;
-    for (const auto& pControl : controls) {
+    for (const auto& control : controls) {
         // Column 0 - Byte Position
-        QTableWidgetItem* bytePositionItem = createReadOnlyItem(
+        QTableWidgetItem* pBytePositionItem = createReadOnlyItem(
                 QStringLiteral("0x%1").arg(
-                        QString::number(pControl.m_bytePosition, 16)
+                        QString::number(control.m_bytePosition, 16)
                                 .rightJustified(2, '0')
                                 .toUpper()),
                 true);
-        pTable->setItem(row, 0, bytePositionItem);
+        pTable->setItem(row, 0, pBytePositionItem);
         // Store custom data for the row in the first cell
-        bytePositionItem->setData(Qt::UserRole + 1,
-                QVariant::fromValue(&pControl));
+        pBytePositionItem->setData(Qt::UserRole + 1,
+                QVariant::fromValue(&control));
 
         // Column 1 - Bit Position
-        pTable->setItem(row, 1, createReadOnlyItem(QString::number(pControl.m_bitPosition), true));
+        pTable->setItem(row, 1, createReadOnlyItem(QString::number(control.m_bitPosition), true));
         // Column 2 - Bit Size
-        pTable->setItem(row, 2, createReadOnlyItem(QString::number(pControl.m_bitSize), true));
+        pTable->setItem(row, 2, createReadOnlyItem(QString::number(control.m_bitSize), true));
         // Column 3 - Logical Min
         pTable->setItem(row,
                 3,
                 createReadOnlyItem(
-                        QString::number(pControl.m_logicalMinimum), true));
+                        QString::number(control.m_logicalMinimum), true));
         // Column 4 - Logical Max
         pTable->setItem(row,
                 4,
                 createReadOnlyItem(
-                        QString::number(pControl.m_logicalMaximum), true));
+                        QString::number(control.m_logicalMaximum), true));
         // Column 5 - Value
         pTable->setItem(row,
                 5,
-                createValueItem(reportType, pControl.m_logicalMinimum, pControl.m_logicalMaximum));
+                createValueItem(reportType, control.m_logicalMinimum, control.m_logicalMaximum));
         // Column 6 - Physical Min
         pTable->setItem(row,
                 6,
                 createReadOnlyItem(
-                        QString::number(pControl.m_physicalMinimum), true));
+                        QString::number(control.m_physicalMinimum), true));
         // Column 7 - Physical Max
         pTable->setItem(row,
                 7,
                 createReadOnlyItem(
-                        QString::number(pControl.m_physicalMaximum), true));
+                        QString::number(control.m_physicalMaximum), true));
         // Column 8 - Unit Scaling
         pTable->setItem(row,
                 8,
-                createReadOnlyItem(pControl.m_unitExponent != 0
+                createReadOnlyItem(control.m_unitExponent != 0
                                 ? QStringLiteral("10^%1").arg(
-                                          pControl.m_unitExponent)
+                                          control.m_unitExponent)
                                 : QString(),
                         true));
         // Column 9 - Unit
         pTable->setItem(row,
                 9,
                 createReadOnlyItem(hid::reportDescriptor::getScaledUnitString(
-                        pControl.m_unit)));
+                        control.m_unit)));
         // Column 10 - Abs/Rel
         pTable->setItem(row,
                 10,
-                createReadOnlyItem(pControl.m_flags.absolute_relative
+                createReadOnlyItem(control.m_flags.absolute_relative
                                 ? tr("Relative")
                                 : tr("Absolute")));
         // Column 11 - Wrap
         pTable->setItem(row,
                 11,
-                createReadOnlyItem(pControl.m_flags.no_wrap_wrap
+                createReadOnlyItem(control.m_flags.no_wrap_wrap
                                 ? tr("Wrap")
                                 : tr("No Wrap")));
         // Column 12 - Linear
         pTable->setItem(row,
                 12,
-                createReadOnlyItem(pControl.m_flags.linear_non_linear
+                createReadOnlyItem(control.m_flags.linear_non_linear
                                 ? tr("Non Linear")
                                 : tr("Linear")));
         // Column 13 - Preferred
         pTable->setItem(row,
                 13,
-                createReadOnlyItem(pControl.m_flags.preferred_no_preferred
+                createReadOnlyItem(control.m_flags.preferred_no_preferred
                                 ? tr("No Preferred")
                                 : tr("Preferred")));
         // Column 14 - Null
         pTable->setItem(row,
                 14,
-                createReadOnlyItem(pControl.m_flags.no_null_null
+                createReadOnlyItem(control.m_flags.no_null_null
                                 ? tr("Null")
                                 : tr("No Null")));
 
@@ -469,7 +469,7 @@ void ControllerHidReportTabsManager::populateHidReportTable(
         if (volatileIndex != -1) {
             pTable->setItem(row,
                     volatileIndex,
-                    createReadOnlyItem(pControl.m_flags.non_volatile_volatile
+                    createReadOnlyItem(control.m_flags.non_volatile_volatile
                                     ? tr("Volatile")
                                     : tr("Non Volatile")));
         }
@@ -477,8 +477,8 @@ void ControllerHidReportTabsManager::populateHidReportTable(
         // Usage Page / Usage
         int usagePageIdx = showVolatileColumn ? 16 : 15;
         int usageDescIdx = showVolatileColumn ? 17 : 16;
-        uint16_t usagePage = static_cast<uint16_t>((pControl.m_usage & 0xFFFF0000) >> 16);
-        uint16_t usage = static_cast<uint16_t>(pControl.m_usage & 0x0000FFFF);
+        uint16_t usagePage = static_cast<uint16_t>((control.m_usage & 0xFFFF0000) >> 16);
+        uint16_t usage = static_cast<uint16_t>(control.m_usage & 0x0000FFFF);
 
         pTable->setItem(row,
                 usagePageIdx,

--- a/src/controllers/controllerhidreporttabsmanager.cpp
+++ b/src/controllers/controllerhidreporttabsmanager.cpp
@@ -146,6 +146,10 @@ void ControllerHidReportTabsManager::createHidReportTab(QTabWidget* pParentRepor
             if (reportType == hid::reportDescriptor::HidReportType::Input) {
                 // Store the pTable pointer associated with the reportId
                 m_reportIdToTableMap[reportId] = pTable;
+                // Ensure that the table entry gets deleted when the table is destroyed
+                connect(pTable, &QObject::destroyed, this, [this, reportId]() {
+                    m_reportIdToTableMap.erase(reportId);
+                });
             }
 
             // Connect the signal for the reportId
@@ -196,6 +200,10 @@ void ControllerHidReportTabsManager::slotProcessInputReport(
         return;
     }
     QTableWidget* pTable = it->second;
+
+    VERIFY_OR_DEBUG_ASSERT(pTable) {
+        return;
+    }
 
     auto reportDescriptor = m_pHidController->getReportDescriptor();
     if (!reportDescriptor) {

--- a/src/controllers/controllerhidreporttabsmanager.cpp
+++ b/src/controllers/controllerhidreporttabsmanager.cpp
@@ -134,8 +134,8 @@ void ControllerHidReportTabsManager::updateTableWithReportData(
 
     // Process the report data and update the table
     for (int row = 0; row < pTable->rowCount(); ++row) {
-        auto* item = pTable->item(row, 5); // Value column is at index 5
-        if (item) {
+        auto* pItem = pTable->item(row, 5); // Value column is at index 5
+        if (pItem) {
             // Retrieve custom data from the first cell
             QVariant customData = pTable->item(row, 0)->data(Qt::UserRole + 1);
             if (customData.isValid()) {
@@ -144,7 +144,7 @@ void ControllerHidReportTabsManager::updateTableWithReportData(
                 int64_t controlValue =
                         hid::reportDescriptor::extractLogicalValue(
                                 reportData, *pControl);
-                item->setText(QString::number(controlValue));
+                pItem->setText(QString::number(controlValue));
             }
         }
     }
@@ -234,15 +234,15 @@ void ControllerHidReportTabsManager::slotSendReport(QTableWidget* pTable,
 
     // Iterate through each row in the table
     for (int row = 0; row < pTable->rowCount(); ++row) {
-        auto* item = pTable->item(row, 5); // Value column is at index 5
-        if (item) {
+        auto* pItem = pTable->item(row, 5); // Value column is at index 5
+        if (pItem) {
             // Retrieve custom data from the first cell
             QVariant customData = pTable->item(row, 0)->data(Qt::UserRole + 1);
             if (customData.isValid()) {
                 const auto* pControl = customData.value<const hid::reportDescriptor::Control*>();
                 // Set the control value in the reportData
                 bool success = hid::reportDescriptor::applyLogicalValue(
-                        reportData, *pControl, item->text().toLongLong());
+                        reportData, *pControl, pItem->text().toLongLong());
                 if (!success) {
                     qWarning() << "Failed to set control value for row" << row;
                     continue;
@@ -329,10 +329,11 @@ void ControllerHidReportTabsManager::populateHidReportTable(
     int row = 0;
     for (const auto& pControl : controls) {
         // Column 0 - Byte Position
-        auto* bytePositionItem = createReadOnlyItem(QStringLiteral("0x%1").arg(QString::number(
-                                                            pControl.m_bytePosition, 16)
-                                                                    .rightJustified(2, '0')
-                                                                    .toUpper()),
+        QTableWidgetItem* bytePositionItem = createReadOnlyItem(
+                QStringLiteral("0x%1").arg(
+                        QString::number(pControl.m_bytePosition, 16)
+                                .rightJustified(2, '0')
+                                .toUpper()),
                 true);
         pTable->setItem(row, 0, bytePositionItem);
         // Store custom data for the row in the first cell

--- a/src/controllers/controllerhidreporttabsmanager.cpp
+++ b/src/controllers/controllerhidreporttabsmanager.cpp
@@ -139,7 +139,7 @@ void ControllerHidReportTabsManager::updateTableWithReportData(
             // Retrieve custom data from the first cell
             QVariant customData = pTable->item(row, 0)->data(Qt::UserRole + 1);
             if (customData.isValid()) {
-                auto pControl =
+                const auto* pControl =
                         static_cast<const hid::reportDescriptor::Control*>(
                                 customData.value<const void*>());
                 // Use the custom data as needed
@@ -165,7 +165,7 @@ void ControllerHidReportTabsManager::slotProcessInputReport(
     QTableWidget* pTable = it->second;
 
     const auto& reportDescriptor = *m_pHidController->getReportDescriptor();
-    auto pReport = reportDescriptor.getReport(
+    const auto* pReport = reportDescriptor.getReport(
             hid::reportDescriptor::HidReportType::Input, reportId);
     if (pReport) {
         updateTableWithReportData(pTable, data);
@@ -226,7 +226,7 @@ void ControllerHidReportTabsManager::slotSendReport(QTableWidget* pTable,
 
     const auto& reportDescriptor = *m_pHidController->getReportDescriptor();
 
-    auto pReport = reportDescriptor.getReport(reportType, reportId);
+    const auto* pReport = reportDescriptor.getReport(reportType, reportId);
     VERIFY_OR_DEBUG_ASSERT(pReport) {
         return;
     }
@@ -241,9 +241,9 @@ void ControllerHidReportTabsManager::slotSendReport(QTableWidget* pTable,
             // Retrieve custom data from the first cell
             QVariant customData = pTable->item(row, 0)->data(Qt::UserRole + 1);
             if (customData.isValid()) {
-                auto pControl =
-                        reinterpret_cast<hid::reportDescriptor::Control*>(
-                                customData.value<void*>());
+                const auto* pControl =
+                        static_cast<const hid::reportDescriptor::Control*>(
+                                customData.value<const void*>());
                 // Set the control value in the reportData
                 bool success = hid::reportDescriptor::applyLogicalValue(
                         reportData, *pControl, item->text().toLongLong());

--- a/src/controllers/controllerhidreporttabsmanager.cpp
+++ b/src/controllers/controllerhidreporttabsmanager.cpp
@@ -66,15 +66,14 @@ void ControllerHidReportTabsManager::createReportTypeTabs() {
 
 void ControllerHidReportTabsManager::createHidReportTab(QTabWidget* pParentReportTypeTab,
         hid::reportDescriptor::HidReportType reportType) {
-    const auto& reportDescriptorTemp = m_pHidController->getReportDescriptor();
-    if (!reportDescriptorTemp.has_value()) {
+    auto reportDescriptor = m_pHidController->getReportDescriptor();
+    if (!reportDescriptor) {
         return;
     }
-    const auto& reportDescriptor = *reportDescriptorTemp;
 
     QMetaEnum metaEnum = QMetaEnum::fromType<hid::reportDescriptor::HidReportType>();
 
-    for (const auto& reportInfo : reportDescriptor.getListOfReports()) {
+    for (const auto& reportInfo : reportDescriptor->getListOfReports()) {
         auto [index, type, reportId] = reportInfo;
         if (type == reportType) {
             // Report is a fixed HID term and shouldn't be translated
@@ -108,7 +107,7 @@ void ControllerHidReportTabsManager::createHidReportTab(QTabWidget* pParentRepor
             auto pTable = make_parented<QTableWidget>(pTabWidget);
             pLayout->addWidget(pTable);
 
-            auto reportOpt = reportDescriptor.getReport(reportType, reportId);
+            auto reportOpt = reportDescriptor->getReport(reportType, reportId);
             if (reportOpt) {
                 const auto& report = reportOpt->get();
                 // Show payload size
@@ -198,13 +197,12 @@ void ControllerHidReportTabsManager::slotProcessInputReport(
     }
     QTableWidget* pTable = it->second;
 
-    const auto& reportDescriptorTemp = m_pHidController->getReportDescriptor();
-    if (!reportDescriptorTemp.has_value()) {
+    auto reportDescriptor = m_pHidController->getReportDescriptor();
+    if (!reportDescriptor) {
         return;
     }
-    const auto& reportDescriptor = *reportDescriptorTemp;
 
-    auto reportOpt = reportDescriptor.getReport(
+    auto reportOpt = reportDescriptor->getReport(
             hid::reportDescriptor::HidReportType::Input, reportId);
     if (reportOpt) {
         updateTableWithReportData(pTable, data);
@@ -234,13 +232,12 @@ void ControllerHidReportTabsManager::slotReadReport(QTableWidget* pTable,
         return;
     }
 
-    const auto& reportDescriptorTemp = m_pHidController->getReportDescriptor();
-    if (!reportDescriptorTemp.has_value()) {
+    auto reportDescriptor = m_pHidController->getReportDescriptor();
+    if (!reportDescriptor) {
         return;
     }
-    const auto& reportDescriptor = *reportDescriptorTemp;
 
-    auto reportOpt = reportDescriptor.getReport(reportType, reportId);
+    auto reportOpt = reportDescriptor->getReport(reportType, reportId);
     VERIFY_OR_DEBUG_ASSERT(reportOpt) {
         return;
     }
@@ -272,13 +269,12 @@ void ControllerHidReportTabsManager::slotSendReport(QTableWidget* pTable,
         return;
     }
 
-    const auto& reportDescriptorTemp = m_pHidController->getReportDescriptor();
-    if (!reportDescriptorTemp.has_value()) {
+    auto reportDescriptor = m_pHidController->getReportDescriptor();
+    if (!reportDescriptor) {
         return;
     }
-    const auto& reportDescriptor = *reportDescriptorTemp;
 
-    auto reportOpt = reportDescriptor.getReport(reportType, reportId);
+    auto reportOpt = reportDescriptor->getReport(reportType, reportId);
     VERIFY_OR_DEBUG_ASSERT(reportOpt) {
         return;
     }

--- a/src/controllers/controllerhidreporttabsmanager.cpp
+++ b/src/controllers/controllerhidreporttabsmanager.cpp
@@ -49,6 +49,7 @@ void ControllerHidReportTabsManager::createHidReportTab(QTabWidget* pParentRepor
     for (const auto& reportInfo : reportDescriptor.getListOfReports()) {
         auto [index, type, reportId] = reportInfo;
         if (type == reportType) {
+            // Report is a fixed HID term and shouldn't be translated
             QString tabName = QStringLiteral("%1 Report 0x%2")
                                       .arg(metaEnum.valueToKey(static_cast<int>(
                                                    reportType)),
@@ -61,8 +62,8 @@ void ControllerHidReportTabsManager::createHidReportTab(QTabWidget* pParentRepor
             auto* pTopWidgetRow = new QHBoxLayout();
 
             // Create buttons
-            auto pReadButton = make_parented<QPushButton>(QStringLiteral("Read"), pTabWidget);
-            auto pSendButton = make_parented<QPushButton>(QStringLiteral("Send"), pTabWidget);
+            auto pReadButton = make_parented<QPushButton>(tr("Read"), pTabWidget);
+            auto pSendButton = make_parented<QPushButton>(tr("Send"), pTabWidget);
 
             // Adjust visibility/enable state based on the report type
             if (reportType == hid::reportDescriptor::HidReportType::Input) {
@@ -84,8 +85,10 @@ void ControllerHidReportTabsManager::createHidReportTab(QTabWidget* pParentRepor
                 // Show payload size
                 auto pSizeLabel = make_parented<QLabel>(pTabWidget);
                 pSizeLabel->setText(
-                        QStringLiteral("Payload Size: <b>%1 bytes</b>")
-                                .arg(pReport->getReportSize()));
+                        QStringLiteral("%1: <b>%2</b> %3")
+                                .arg(tr("Payload Size"))
+                                .arg(pReport->getReportSize())
+                                .arg(tr("bytes")));
                 pTopWidgetRow->insertWidget(0, pSizeLabel);
 
                 populateHidReportTable(pTable, *pReport, reportType);
@@ -280,25 +283,25 @@ void ControllerHidReportTabsManager::populateHidReportTable(
             reportType == hid::reportDescriptor::HidReportType::Output);
 
     // Set headers
-    QStringList headers = {QStringLiteral("Byte Position"),
-            QStringLiteral("Bit Position"),
-            QStringLiteral("Bit Size"),
-            QStringLiteral("Logical Min"),
-            QStringLiteral("Logical Max"),
-            QStringLiteral("Value"),
-            QStringLiteral("Physical Min"),
-            QStringLiteral("Physical Max"),
-            QStringLiteral("Unit Scaling"),
-            QStringLiteral("Unit"),
-            QStringLiteral("Abs/Rel"),
-            QStringLiteral("Wrap"),
-            QStringLiteral("Linear"),
-            QStringLiteral("Preferred"),
-            QStringLiteral("Null")};
+    QStringList headers = {tr("Byte Position"),
+            tr("Bit Position"),
+            tr("Bit Size"),
+            tr("Logical Min"),
+            tr("Logical Max"),
+            tr("Value"),
+            tr("Physical Min"),
+            tr("Physical Max"),
+            tr("Unit Scaling"),
+            tr("Unit"),
+            tr("Abs/Rel"),
+            tr("Wrap"),
+            tr("Linear"),
+            tr("Preferred"),
+            tr("Null")};
     if (showVolatileColumn) {
-        headers << QStringLiteral("Volatile");
+        headers << tr("Volatile");
     }
-    headers << QStringLiteral("Usage Page") << QStringLiteral("Usage");
+    headers << tr("Usage Page") << tr("Usage");
 
     pTable->setColumnCount(headers.size());
     pTable->setHorizontalHeaderLabels(headers);
@@ -387,32 +390,32 @@ void ControllerHidReportTabsManager::populateHidReportTable(
         pTable->setItem(row,
                 10,
                 createReadOnlyItem(pControl.m_flags.absolute_relative
-                                ? QStringLiteral("Relative")
-                                : QStringLiteral("Absolute")));
+                                ? tr("Relative")
+                                : tr("Absolute")));
         // Column 11 - Wrap
         pTable->setItem(row,
                 11,
                 createReadOnlyItem(pControl.m_flags.no_wrap_wrap
-                                ? QStringLiteral("Wrap")
-                                : QStringLiteral("No Wrap")));
+                                ? tr("Wrap")
+                                : tr("No Wrap")));
         // Column 12 - Linear
         pTable->setItem(row,
                 12,
                 createReadOnlyItem(pControl.m_flags.linear_non_linear
-                                ? QStringLiteral("Non Linear")
-                                : QStringLiteral("Linear")));
+                                ? tr("Non Linear")
+                                : tr("Linear")));
         // Column 13 - Preferred
         pTable->setItem(row,
                 13,
                 createReadOnlyItem(pControl.m_flags.preferred_no_preferred
-                                ? QStringLiteral("No Preferred")
-                                : QStringLiteral("Preferred")));
+                                ? tr("No Preferred")
+                                : tr("Preferred")));
         // Column 14 - Null
         pTable->setItem(row,
                 14,
                 createReadOnlyItem(pControl.m_flags.no_null_null
-                                ? QStringLiteral("Null")
-                                : QStringLiteral("No Null")));
+                                ? tr("Null")
+                                : tr("No Null")));
 
         // Volatile column (if present)
         int volatileIndex = (showVolatileColumn ? 15 : -1);
@@ -420,8 +423,8 @@ void ControllerHidReportTabsManager::populateHidReportTable(
             pTable->setItem(row,
                     volatileIndex,
                     createReadOnlyItem(pControl.m_flags.non_volatile_volatile
-                                    ? QStringLiteral("Volatile")
-                                    : QStringLiteral("Non Volatile")));
+                                    ? tr("Volatile")
+                                    : tr("Non Volatile")));
         }
 
         // Usage Page / Usage

--- a/src/controllers/controllerhidreporttabsmanager.cpp
+++ b/src/controllers/controllerhidreporttabsmanager.cpp
@@ -502,10 +502,12 @@ void ControllerHidReportTabsManager::populateHidReportTable(
     for (int colIdx = 0; colIdx < pTable->columnCount(); ++colIdx) {
         columnWidths[colIdx] = pTable->columnWidth(colIdx);
     }
-    // Set the width of the value column (5) to fit 11 digits (int32 minimum in decimal)
+    // Set the width of the "Value" column (5) to fit 11 digits (int32 minimum in decimal)
+    // This is the only column in the table with dynamic content, therefore we need to
+    // set the width with enough reserved space.
     QFontMetrics metrics(pTable->font());
     int width = metrics.horizontalAdvance(QStringLiteral("0").repeated(11));
-    columnWidths[5] = width;
+    columnWidths[5] = width; // The column "Value" is at index 5
     for (int colIdx = 0; colIdx < pTable->columnCount(); ++colIdx) {
         pTable->horizontalHeader()->setSectionResizeMode(colIdx, QHeaderView::Fixed);
         pTable->setColumnWidth(colIdx, columnWidths[colIdx]);

--- a/src/controllers/controllerhidreporttabsmanager.cpp
+++ b/src/controllers/controllerhidreporttabsmanager.cpp
@@ -18,19 +18,19 @@ ControllerHidReportTabsManager::ControllerHidReportTabsManager(
 }
 
 void ControllerHidReportTabsManager::createReportTypeTabs() {
-    auto reportTypeTabs = std::make_unique<QTabWidget>(m_pParentControllerTab);
+    auto reportTypeTabs = make_parented<QTabWidget>(m_pParentControllerTab);
 
     QMetaEnum metaEnum = QMetaEnum::fromType<hid::reportDescriptor::HidReportType>();
 
     for (int reportTypeIdx = 0; reportTypeIdx < metaEnum.keyCount(); ++reportTypeIdx) {
         auto reportType = static_cast<hid::reportDescriptor::HidReportType>(
                 metaEnum.value(reportTypeIdx));
-        auto reportTypeTab = std::make_unique<QTabWidget>(reportTypeTabs.get());
+        auto reportTypeTab = make_parented<QTabWidget>(reportTypeTabs.get());
         createHidReportTab(reportTypeTab.get(), reportType);
         if (reportTypeTab->count() > 0) {
             QString tabName = QStringLiteral("%1 Reports")
                                       .arg(metaEnum.key(reportTypeIdx));
-            m_pParentControllerTab->addTab(reportTypeTab.release(), tabName);
+            m_pParentControllerTab->addTab(std::move(reportTypeTab), tabName);
         }
     }
 }

--- a/src/controllers/controllerhidreporttabsmanager.cpp
+++ b/src/controllers/controllerhidreporttabsmanager.cpp
@@ -498,9 +498,10 @@ void ControllerHidReportTabsManager::populateHidReportTable(
     for (int colIdx = 0; colIdx < pTable->columnCount(); ++colIdx) {
         pTable->horizontalHeader()->setSectionResizeMode(colIdx, QHeaderView::ResizeToContents);
     }
-    QVector<int> columnWidths(pTable->columnCount());
+    QVector<int> columnWidths;
+    columnWidths.reserve(pTable->columnCount());
     for (int colIdx = 0; colIdx < pTable->columnCount(); ++colIdx) {
-        columnWidths[colIdx] = pTable->columnWidth(colIdx);
+        columnWidths.push_back(pTable->columnWidth(colIdx));
     }
     // Set the width of the "Value" column (5) to fit 11 digits (int32 minimum in decimal)
     // This is the only column in the table with dynamic content, therefore we need to

--- a/src/controllers/controllerhidreporttabsmanager.cpp
+++ b/src/controllers/controllerhidreporttabsmanager.cpp
@@ -79,7 +79,7 @@ void ControllerHidReportTabsManager::createHidReportTab(QTabWidget* pParentRepor
             auto* pTable = new QTableWidget(pTabWidget);
             pLayout->addWidget(pTable);
 
-            auto* pReport = reportDescriptor.getReport(reportType, reportId);
+            const auto* pReport = reportDescriptor.getReport(reportType, reportId);
             if (pReport) {
                 // Show payload size
                 auto* pSizeLabel = new QLabel(pTabWidget);
@@ -187,12 +187,6 @@ void ControllerHidReportTabsManager::slotReadReport(QTableWidget* pTable,
         return;
     }
 
-    const auto& reportDescriptor = *m_pHidController->getReportDescriptor();
-    auto pReport = reportDescriptor.getReport(reportType, reportId);
-    VERIFY_OR_DEBUG_ASSERT(pReport) {
-        return;
-    }
-
     QByteArray reportData;
     if (reportType == hid::reportDescriptor::HidReportType::Input) {
         reportData = pJsProxy->getInputReport(reportId);
@@ -202,6 +196,11 @@ void ControllerHidReportTabsManager::slotReadReport(QTableWidget* pTable,
         return;
     }
 
+    const auto& reportDescriptor = *m_pHidController->getReportDescriptor();
+    const auto* pReport = reportDescriptor.getReport(reportType, reportId);
+    VERIFY_OR_DEBUG_ASSERT(pReport) {
+        return;
+    }
     if (reportData.size() < pReport->getReportSize()) {
         qWarning() << "Failed to get report. Read only " << reportData.size()
                    << " instead of expected " << pReport->getReportSize()

--- a/src/controllers/controllerhidreporttabsmanager.cpp
+++ b/src/controllers/controllerhidreporttabsmanager.cpp
@@ -29,8 +29,7 @@ void ControllerHidReportTabsManager::createReportTypeTabs() {
         createHidReportTab(reportTypeTab.get(), reportType);
         if (reportTypeTab->count() > 0) {
             QString tabName = QStringLiteral("%1 Reports")
-                                      .arg(metaEnum.valueToKey(
-                                              static_cast<int>(reportType)));
+                                      .arg(metaEnum.key(reportTypeIdx));
             m_pParentControllerTab->addTab(reportTypeTab.release(), tabName);
         }
     }

--- a/src/controllers/controllerhidreporttabsmanager.cpp
+++ b/src/controllers/controllerhidreporttabsmanager.cpp
@@ -47,6 +47,9 @@ ControllerHidReportTabsManager::ControllerHidReportTabsManager(
 }
 
 void ControllerHidReportTabsManager::createReportTypeTabs() {
+    VERIFY_OR_DEBUG_ASSERT(m_pParentControllerTab) {
+        return;
+    }
     auto reportTypeTabs = make_parented<QTabWidget>(m_pParentControllerTab);
 
     QMetaEnum metaEnum = QMetaEnum::fromType<hid::reportDescriptor::HidReportType>();
@@ -66,6 +69,9 @@ void ControllerHidReportTabsManager::createReportTypeTabs() {
 
 void ControllerHidReportTabsManager::createHidReportTab(QTabWidget* pParentReportTypeTab,
         hid::reportDescriptor::HidReportType reportType) {
+    VERIFY_OR_DEBUG_ASSERT(m_pHidController) {
+        return;
+    }
     auto reportDescriptor = m_pHidController->getReportDescriptor();
     if (!reportDescriptor) {
         return;
@@ -154,10 +160,12 @@ void ControllerHidReportTabsManager::createHidReportTab(QTabWidget* pParentRepor
 
             // Connect the signal for the reportId
             HidIoThread* hidIoThread = m_pHidController->getHidIoThread();
-            connect(hidIoThread,
-                    &HidIoThread::reportReceived,
-                    this,
-                    &ControllerHidReportTabsManager::slotProcessInputReport);
+            if (hidIoThread) {
+                connect(hidIoThread,
+                        &HidIoThread::reportReceived,
+                        this,
+                        &ControllerHidReportTabsManager::slotProcessInputReport);
+            }
         }
     }
 }
@@ -193,6 +201,9 @@ void ControllerHidReportTabsManager::updateTableWithReportData(
 
 void ControllerHidReportTabsManager::slotProcessInputReport(
         quint8 reportId, const QByteArray& data) {
+    VERIFY_OR_DEBUG_ASSERT(m_pHidController) {
+        return;
+    }
     // Find the table associated with the reportId
     auto it = m_reportIdToTableMap.find(reportId);
     if (it == m_reportIdToTableMap.end()) {
@@ -220,6 +231,9 @@ void ControllerHidReportTabsManager::slotProcessInputReport(
 void ControllerHidReportTabsManager::slotReadReport(QTableWidget* pTable,
         quint8 reportId,
         hid::reportDescriptor::HidReportType reportType) {
+    VERIFY_OR_DEBUG_ASSERT(m_pHidController) {
+        return;
+    }
     if (!m_pHidController->isOpen()) {
         qWarning() << "HID controller is not open.";
         return;

--- a/src/controllers/controllerhidreporttabsmanager.cpp
+++ b/src/controllers/controllerhidreporttabsmanager.cpp
@@ -1,0 +1,488 @@
+#include "controllerhidreporttabsmanager.h"
+
+#include <QHBoxLayout>
+#include <QHeaderView>
+#include <QLabel>
+#include <QLineEdit>
+#include <QMetaEnum>
+#include <QPushButton>
+#include <QVBoxLayout>
+
+#include "controllers/hid/hidusagetables.h"
+#include "moc_controllerhidreporttabsmanager.cpp"
+
+ControllerHidReportTabsManager::ControllerHidReportTabsManager(
+        QTabWidget* parentTabWidget, HidController* hidController)
+        : m_pParentControllerTab(parentTabWidget),
+          m_pHidController(hidController) {
+}
+
+void ControllerHidReportTabsManager::createReportTypeTabs() {
+    auto reportTypeTabs = std::make_unique<QTabWidget>(m_pParentControllerTab);
+
+    QMetaEnum metaEnum = QMetaEnum::fromType<hid::reportDescriptor::HidReportType>();
+
+    for (int reportTypeIdx = 0; reportTypeIdx < metaEnum.keyCount(); ++reportTypeIdx) {
+        auto reportType = static_cast<hid::reportDescriptor::HidReportType>(
+                metaEnum.value(reportTypeIdx));
+        auto reportTypeTab = std::make_unique<QTabWidget>(reportTypeTabs.get());
+        createHidReportTab(reportTypeTab.get(), reportType);
+        if (reportTypeTab->count() > 0) {
+            QString tabName = QStringLiteral("%1 Reports")
+                                      .arg(metaEnum.valueToKey(
+                                              static_cast<int>(reportType)));
+            m_pParentControllerTab->addTab(reportTypeTab.release(), tabName);
+        }
+    }
+}
+
+void ControllerHidReportTabsManager::createHidReportTab(QTabWidget* parentReportTypeTab,
+        hid::reportDescriptor::HidReportType reportType) {
+    const auto& reportDescriptorTemp = m_pHidController->getReportDescriptor();
+    if (!reportDescriptorTemp.has_value()) {
+        return;
+    }
+    const auto& reportDescriptor = *reportDescriptorTemp;
+
+    QMetaEnum metaEnum = QMetaEnum::fromType<hid::reportDescriptor::HidReportType>();
+
+    for (const auto& reportInfo : reportDescriptor.getListOfReports()) {
+        auto [index, type, reportId] = reportInfo;
+        if (type == reportType) {
+            QString tabName = QStringLiteral("%1 Report 0x%2")
+                                      .arg(metaEnum.valueToKey(static_cast<int>(
+                                                   reportType)),
+                                              QString::number(reportId, 16)
+                                                      .rightJustified(2, '0')
+                                                      .toUpper());
+
+            auto* tabWidget = new QWidget(parentReportTypeTab);
+            auto* layout = new QVBoxLayout(tabWidget);
+            auto* topWidgetRow = new QHBoxLayout();
+
+            // Create buttons
+            auto* readButton = new QPushButton(QStringLiteral("Read"), tabWidget);
+            auto* sendButton = new QPushButton(QStringLiteral("Send"), tabWidget);
+
+            // Adjust visibility/enable state based on the report type
+            if (reportType == hid::reportDescriptor::HidReportType::Input) {
+                sendButton->hide();
+                readButton->hide();
+            } else if (reportType == hid::reportDescriptor::HidReportType::Output) {
+                readButton->hide();
+            }
+
+            topWidgetRow->addWidget(readButton);
+            topWidgetRow->addWidget(sendButton);
+            layout->addLayout(topWidgetRow);
+
+            auto* table = new QTableWidget(tabWidget);
+            layout->addWidget(table);
+
+            auto report = reportDescriptor.getReport(reportType, reportId);
+            if (report) {
+                // Show payload size
+                auto* sizeLabel = new QLabel(tabWidget);
+                sizeLabel->setText(
+                        QStringLiteral("Payload Size: <b>%1 bytes</b>")
+                                .arg(report->getReportSize()));
+                topWidgetRow->insertWidget(0, sizeLabel);
+
+                populateHidReportTable(table, *report, reportType);
+            }
+
+            if (reportType != hid::reportDescriptor::HidReportType::Output) {
+                connect(readButton,
+                        &QPushButton::clicked,
+                        this,
+                        [this, table, reportId, reportType]() {
+                            slotReadReport(table, reportId, reportType);
+                        });
+                // Read once on tab creation
+                slotReadReport(table, reportId, reportType);
+            }
+            if (reportType != hid::reportDescriptor::HidReportType::Input) {
+                connect(sendButton,
+                        &QPushButton::clicked,
+                        this,
+                        [this, table, reportId, reportType]() {
+                            slotSendReport(table, reportId, reportType);
+                        });
+            }
+
+            parentReportTypeTab->addTab(tabWidget, tabName);
+
+            if (reportType == hid::reportDescriptor::HidReportType::Input) {
+                // Store the table pointer associated with the reportId
+                m_reportIdToTableMap[reportId] = table;
+            }
+
+            // Connect the signal for the reportId
+            HidIoThread* hidIoThread = m_pHidController->getHidIoThread();
+            connect(hidIoThread,
+                    &HidIoThread::reportReceived,
+                    this,
+                    &ControllerHidReportTabsManager::slotProcessInputReport);
+        }
+    }
+}
+
+void ControllerHidReportTabsManager::updateTableWithReportData(
+        QTableWidget* table,
+        const QByteArray& reportData) {
+    // Temporarily disable updates to speed up processing
+    table->setUpdatesEnabled(false);
+
+    // Process the report data and update the table
+    for (int row = 0; row < table->rowCount(); ++row) {
+        auto* item = table->item(row, 5); // Value column is at index 5
+        if (item) {
+            // Retrieve custom data from the first cell
+            QVariant customData = table->item(row, 0)->data(Qt::UserRole + 1);
+            if (customData.isValid()) {
+                auto control =
+                        static_cast<const hid::reportDescriptor::Control*>(
+                                customData.value<const void*>());
+                // Use the custom data as needed
+                int64_t controlValue =
+                        hid::reportDescriptor::extractLogicalValue(
+                                reportData, *control);
+                item->setText(QString::number(controlValue));
+            }
+        }
+    }
+
+    table->setUpdatesEnabled(true);
+}
+
+void ControllerHidReportTabsManager::slotProcessInputReport(
+        quint8 reportId, const QByteArray& data) {
+    // Find the table associated with the reportId
+    auto it = m_reportIdToTableMap.find(reportId);
+    if (it == m_reportIdToTableMap.end()) {
+        qWarning() << "No table found for reportId" << reportId;
+        return;
+    }
+    QTableWidget* table = it->second;
+
+    const auto& reportDescriptor = *m_pHidController->getReportDescriptor();
+    auto report = reportDescriptor.getReport(hid::reportDescriptor::HidReportType::Input, reportId);
+    if (report) {
+        updateTableWithReportData(table, data);
+    }
+}
+
+void ControllerHidReportTabsManager::slotReadReport(QTableWidget* table,
+        quint8 reportId,
+        hid::reportDescriptor::HidReportType reportType) {
+    if (!m_pHidController->isOpen()) {
+        qWarning() << "HID controller is not open.";
+        return;
+    }
+
+    HidControllerJSProxy* jsProxy = static_cast<HidControllerJSProxy*>(m_pHidController->jsProxy());
+    VERIFY_OR_DEBUG_ASSERT(jsProxy) {
+        return;
+    }
+
+    const auto& reportDescriptor = *m_pHidController->getReportDescriptor();
+    auto report = reportDescriptor.getReport(reportType, reportId);
+    VERIFY_OR_DEBUG_ASSERT(report) {
+        return;
+    }
+
+    QByteArray reportData;
+    if (reportType == hid::reportDescriptor::HidReportType::Input) {
+        reportData = jsProxy->getInputReport(reportId);
+    } else if (reportType == hid::reportDescriptor::HidReportType::Feature) {
+        reportData = jsProxy->getFeatureReport(reportId);
+    } else {
+        return;
+    }
+
+    if (reportData.size() < report->getReportSize()) {
+        qWarning() << "Failed to get report. Read only " << reportData.size()
+                   << " instead of expected " << report->getReportSize()
+                   << " bytes.";
+        return;
+    }
+
+    updateTableWithReportData(table, reportData);
+}
+
+void ControllerHidReportTabsManager::slotSendReport(QTableWidget* table,
+        quint8 reportId,
+        hid::reportDescriptor::HidReportType reportType) {
+    if (!m_pHidController->isOpen()) {
+        qWarning() << "HID controller is not open.";
+        return;
+    }
+
+    HidControllerJSProxy* jsProxy = static_cast<HidControllerJSProxy*>(m_pHidController->jsProxy());
+    VERIFY_OR_DEBUG_ASSERT(jsProxy) {
+        return;
+    }
+
+    const auto& reportDescriptor = *m_pHidController->getReportDescriptor();
+
+    auto report = reportDescriptor.getReport(reportType, reportId);
+    VERIFY_OR_DEBUG_ASSERT(report) {
+        return;
+    }
+
+    // Create a QByteArray of the size of the report
+    QByteArray reportData(report->getReportSize(), 0);
+
+    // Iterate through each row in the table
+    for (int row = 0; row < table->rowCount(); ++row) {
+        auto* item = table->item(row, 5); // Value column is at index 5
+        if (item) {
+            // Retrieve custom data from the first cell
+            QVariant customData = table->item(row, 0)->data(Qt::UserRole + 1);
+            if (customData.isValid()) {
+                auto control =
+                        reinterpret_cast<hid::reportDescriptor::Control*>(
+                                customData.value<void*>());
+                // Set the control value in the reportData
+                bool success = hid::reportDescriptor::applyLogicalValue(
+                        reportData, *control, item->text().toLongLong());
+                if (!success) {
+                    qWarning() << "Failed to set control value for row" << row;
+                    continue;
+                }
+            }
+        }
+    }
+
+    // Send the reportData
+    if (reportType == hid::reportDescriptor::HidReportType::Feature) {
+        jsProxy->sendFeatureReport(reportId, reportData);
+    } else if (reportType == hid::reportDescriptor::HidReportType::Output) {
+        jsProxy->sendOutputReport(reportId, reportData);
+    }
+}
+
+void ControllerHidReportTabsManager::populateHidReportTable(
+        QTableWidget* table,
+        const hid::reportDescriptor::Report& report,
+        hid::reportDescriptor::HidReportType reportType) {
+    // Temporarily disable updates to speed up populating
+    table->setUpdatesEnabled(false);
+
+    // Reserve rows up-front
+    const auto& controls = report.getControls();
+    table->setRowCount(static_cast<int>(controls.size()));
+
+    // Set the delegate once if needed
+    if (reportType != hid::reportDescriptor::HidReportType::Input) {
+        table->setItemDelegateForColumn(5, new ValueItemDelegate(table));
+    }
+
+    bool showVolatileColumn = (reportType == hid::reportDescriptor::HidReportType::Feature ||
+            reportType == hid::reportDescriptor::HidReportType::Output);
+
+    // Set headers
+    QStringList headers = {QStringLiteral("Byte Position"),
+            QStringLiteral("Bit Position"),
+            QStringLiteral("Bit Size"),
+            QStringLiteral("Logical Min"),
+            QStringLiteral("Logical Max"),
+            QStringLiteral("Value"),
+            QStringLiteral("Physical Min"),
+            QStringLiteral("Physical Max"),
+            QStringLiteral("Unit Scaling"),
+            QStringLiteral("Unit"),
+            QStringLiteral("Abs/Rel"),
+            QStringLiteral("Wrap"),
+            QStringLiteral("Linear"),
+            QStringLiteral("Preferred"),
+            QStringLiteral("Null")};
+    if (showVolatileColumn) {
+        headers << QStringLiteral("Volatile");
+    }
+    headers << QStringLiteral("Usage Page") << QStringLiteral("Usage");
+
+    table->setColumnCount(headers.size());
+    table->setHorizontalHeaderLabels(headers);
+    table->verticalHeader()->setVisible(false);
+
+    // Helpers
+    auto createReadOnlyItem = [](const QString& text, bool rightAlign = false) {
+        auto* item = new QTableWidgetItem(text);
+        item->setFlags(item->flags() & ~Qt::ItemIsEditable);
+        if (rightAlign) {
+            item->setTextAlignment(Qt::AlignRight | Qt::AlignVCenter);
+        }
+        return item;
+    };
+    auto createValueItem = [reportType](int minVal, int maxVal) {
+        auto* item = new QTableWidgetItem;
+        QFont font = item->font();
+        font.setBold(true);
+        item->setFont(font);
+        if (reportType == hid::reportDescriptor::HidReportType::Input) {
+            item->setFlags(item->flags() & ~Qt::ItemIsEditable);
+        } else {
+            item->setFlags(item->flags() | Qt::ItemIsEditable);
+            item->setData(Qt::UserRole, QVariant::fromValue(QPair<int, int>(minVal, maxVal)));
+        }
+        return item;
+    };
+
+    int row = 0;
+    for (const auto& control : controls) {
+        // Column 0 - Byte Position
+        auto* bytePositionItem = createReadOnlyItem(QStringLiteral("0x%1").arg(QString::number(
+                                                            control.m_bytePosition, 16)
+                                                                    .rightJustified(2, '0')
+                                                                    .toUpper()),
+                true);
+        table->setItem(row, 0, bytePositionItem);
+        // Store custom data for the row in the first cell
+        bytePositionItem->setData(Qt::UserRole + 1,
+                QVariant::fromValue(reinterpret_cast<void*>(
+                        const_cast<hid::reportDescriptor::Control*>(
+                                &control))));
+
+        // Column 1 - Bit Position
+        table->setItem(row, 1, createReadOnlyItem(QString::number(control.m_bitPosition), true));
+        // Column 2 - Bit Size
+        table->setItem(row, 2, createReadOnlyItem(QString::number(control.m_bitSize), true));
+        // Column 3 - Logical Min
+        table->setItem(row, 3, createReadOnlyItem(QString::number(control.m_logicalMinimum), true));
+        // Column 4 - Logical Max
+        table->setItem(row, 4, createReadOnlyItem(QString::number(control.m_logicalMaximum), true));
+        // Column 5 - Value
+        table->setItem(row, 5, createValueItem(control.m_logicalMinimum, control.m_logicalMaximum));
+        // Column 6 - Physical Min
+        table->setItem(row,
+                6,
+                createReadOnlyItem(
+                        QString::number(control.m_physicalMinimum), true));
+        // Column 7 - Physical Max
+        table->setItem(row,
+                7,
+                createReadOnlyItem(
+                        QString::number(control.m_physicalMaximum), true));
+        // Column 8 - Unit Scaling
+        table->setItem(row,
+                8,
+                createReadOnlyItem(control.m_unitExponent != 0
+                                ? QStringLiteral("10^%1").arg(
+                                          control.m_unitExponent)
+                                : QString(),
+                        true));
+        // Column 9 - Unit
+        table->setItem(row,
+                9,
+                createReadOnlyItem(hid::reportDescriptor::getScaledUnitString(
+                        control.m_unit)));
+        // Column 10 - Abs/Rel
+        table->setItem(row,
+                10,
+                createReadOnlyItem(control.m_flags.absolute_relative
+                                ? QStringLiteral("Relative")
+                                : QStringLiteral("Absolute")));
+        // Column 11 - Wrap
+        table->setItem(row,
+                11,
+                createReadOnlyItem(control.m_flags.no_wrap_wrap
+                                ? QStringLiteral("Wrap")
+                                : QStringLiteral("No Wrap")));
+        // Column 12 - Linear
+        table->setItem(row,
+                12,
+                createReadOnlyItem(control.m_flags.linear_non_linear
+                                ? QStringLiteral("Non Linear")
+                                : QStringLiteral("Linear")));
+        // Column 13 - Preferred
+        table->setItem(row,
+                13,
+                createReadOnlyItem(control.m_flags.preferred_no_preferred
+                                ? QStringLiteral("No Preferred")
+                                : QStringLiteral("Preferred")));
+        // Column 14 - Null
+        table->setItem(row,
+                14,
+                createReadOnlyItem(control.m_flags.no_null_null
+                                ? QStringLiteral("Null")
+                                : QStringLiteral("No Null")));
+
+        // Volatile column (if present)
+        int volatileIndex = (showVolatileColumn ? 15 : -1);
+        if (volatileIndex != -1) {
+            table->setItem(row,
+                    volatileIndex,
+                    createReadOnlyItem(control.m_flags.non_volatile_volatile
+                                    ? QStringLiteral("Volatile")
+                                    : QStringLiteral("Non Volatile")));
+        }
+
+        // Usage Page / Usage
+        int usagePageIdx = showVolatileColumn ? 16 : 15;
+        int usageDescIdx = showVolatileColumn ? 17 : 16;
+        uint16_t usagePage = static_cast<uint16_t>((control.m_usage & 0xFFFF0000) >> 16);
+        uint16_t usage = static_cast<uint16_t>(control.m_usage & 0x0000FFFF);
+
+        table->setItem(row,
+                usagePageIdx,
+                createReadOnlyItem(
+                        mixxx::hid::HidUsageTables::getUsagePageDescription(
+                                usagePage)));
+        table->setItem(row,
+                usageDescIdx,
+                createReadOnlyItem(
+                        mixxx::hid::HidUsageTables::getUsageDescription(
+                                usagePage, usage)));
+
+        ++row;
+    }
+
+    // Resize columns to contents once, store width and set column width fixed for performance
+    for (int colIdx = 0; colIdx < table->columnCount(); ++colIdx) {
+        table->horizontalHeader()->setSectionResizeMode(colIdx, QHeaderView::ResizeToContents);
+    }
+    QVector<int> columnWidths(table->columnCount());
+    for (int colIdx = 0; colIdx < table->columnCount(); ++colIdx) {
+        columnWidths[colIdx] = table->columnWidth(colIdx);
+    }
+    // Set the width of the value column (5) to fit 11 digits (int32 minimum in decimal)
+    QFontMetrics metrics(table->font());
+    int width = metrics.horizontalAdvance(QStringLiteral("0").repeated(11));
+    columnWidths[5] = width;
+    for (int colIdx = 0; colIdx < table->columnCount(); ++colIdx) {
+        table->horizontalHeader()->setSectionResizeMode(colIdx, QHeaderView::Fixed);
+        table->setColumnWidth(colIdx, columnWidths[colIdx]);
+    }
+
+    table->setUpdatesEnabled(true);
+}
+
+QWidget* ValueItemDelegate::createEditor(QWidget* parent,
+        const QStyleOptionViewItem&,
+        const QModelIndex& index) const {
+    // Create a line edit restricted by (logical min, logical max)
+    auto dataRange = index.data(Qt::UserRole).value<QPair<int, int>>();
+    auto* editor = new QLineEdit(parent);
+    editor->setValidator(new QIntValidator(dataRange.first, dataRange.second, editor));
+    return editor;
+}
+
+void ValueItemDelegate::setModelData(QWidget* editor,
+        QAbstractItemModel* model,
+        const QModelIndex& index) const {
+    auto* lineEdit = qobject_cast<QLineEdit*>(editor);
+    if (!lineEdit) {
+        return;
+    }
+
+    // Confirm the text is an integer within the expected range
+    bool ok = false;
+    const int value = lineEdit->text().toInt(&ok);
+    if (ok) {
+        auto dataRange = index.data(Qt::UserRole).value<QPair<int, int>>();
+        if (value >= dataRange.first && value <= dataRange.second) {
+            model->setData(index, value, Qt::EditRole);
+        }
+    }
+}

--- a/src/controllers/controllerhidreporttabsmanager.cpp
+++ b/src/controllers/controllerhidreporttabsmanager.cpp
@@ -197,7 +197,12 @@ void ControllerHidReportTabsManager::slotProcessInputReport(
     }
     QTableWidget* pTable = it->second;
 
-    const auto& reportDescriptor = *m_pHidController->getReportDescriptor();
+    const auto& reportDescriptorTemp = m_pHidController->getReportDescriptor();
+    if (!reportDescriptorTemp.has_value()) {
+        return;
+    }
+    const auto& reportDescriptor = *reportDescriptorTemp;
+
     const auto* pReport = reportDescriptor.getReport(
             hid::reportDescriptor::HidReportType::Input, reportId);
     if (pReport) {
@@ -228,7 +233,12 @@ void ControllerHidReportTabsManager::slotReadReport(QTableWidget* pTable,
         return;
     }
 
-    const auto& reportDescriptor = *m_pHidController->getReportDescriptor();
+    const auto& reportDescriptorTemp = m_pHidController->getReportDescriptor();
+    if (!reportDescriptorTemp.has_value()) {
+        return;
+    }
+    const auto& reportDescriptor = *reportDescriptorTemp;
+
     const auto* pReport = reportDescriptor.getReport(reportType, reportId);
     VERIFY_OR_DEBUG_ASSERT(pReport) {
         return;
@@ -260,7 +270,11 @@ void ControllerHidReportTabsManager::slotSendReport(QTableWidget* pTable,
         return;
     }
 
-    const auto& reportDescriptor = *m_pHidController->getReportDescriptor();
+    const auto& reportDescriptorTemp = m_pHidController->getReportDescriptor();
+    if (!reportDescriptorTemp.has_value()) {
+        return;
+    }
+    const auto& reportDescriptor = *reportDescriptorTemp;
 
     const auto* pReport = reportDescriptor.getReport(reportType, reportId);
     VERIFY_OR_DEBUG_ASSERT(pReport) {

--- a/src/controllers/controllerhidreporttabsmanager.cpp
+++ b/src/controllers/controllerhidreporttabsmanager.cpp
@@ -139,9 +139,7 @@ void ControllerHidReportTabsManager::updateTableWithReportData(
             // Retrieve custom data from the first cell
             QVariant customData = pTable->item(row, 0)->data(Qt::UserRole + 1);
             if (customData.isValid()) {
-                const auto* pControl =
-                        static_cast<const hid::reportDescriptor::Control*>(
-                                customData.value<const void*>());
+                const auto* pControl = customData.value<const hid::reportDescriptor::Control*>();
                 // Use the custom data as needed
                 int64_t controlValue =
                         hid::reportDescriptor::extractLogicalValue(
@@ -241,9 +239,7 @@ void ControllerHidReportTabsManager::slotSendReport(QTableWidget* pTable,
             // Retrieve custom data from the first cell
             QVariant customData = pTable->item(row, 0)->data(Qt::UserRole + 1);
             if (customData.isValid()) {
-                const auto* pControl =
-                        static_cast<const hid::reportDescriptor::Control*>(
-                                customData.value<const void*>());
+                const auto* pControl = customData.value<const hid::reportDescriptor::Control*>();
                 // Set the control value in the reportData
                 bool success = hid::reportDescriptor::applyLogicalValue(
                         reportData, *pControl, item->text().toLongLong());
@@ -341,9 +337,7 @@ void ControllerHidReportTabsManager::populateHidReportTable(
         pTable->setItem(row, 0, bytePositionItem);
         // Store custom data for the row in the first cell
         bytePositionItem->setData(Qt::UserRole + 1,
-                QVariant::fromValue(reinterpret_cast<void*>(
-                        const_cast<hid::reportDescriptor::Control*>(
-                                &pControl))));
+                QVariant::fromValue(&pControl));
 
         // Column 1 - Bit Position
         pTable->setItem(row, 1, createReadOnlyItem(QString::number(pControl.m_bitPosition), true));

--- a/src/controllers/controllerhidreporttabsmanager.cpp
+++ b/src/controllers/controllerhidreporttabsmanager.cpp
@@ -12,9 +12,9 @@
 #include "moc_controllerhidreporttabsmanager.cpp"
 
 ControllerHidReportTabsManager::ControllerHidReportTabsManager(
-        QTabWidget* parentTabWidget, HidController* hidController)
-        : m_pParentControllerTab(parentTabWidget),
-          m_pHidController(hidController) {
+        QTabWidget* pParentTabWidget, HidController* pHidController)
+        : m_pParentControllerTab(pParentTabWidget),
+          m_pHidController(pHidController) {
 }
 
 void ControllerHidReportTabsManager::createReportTypeTabs() {
@@ -36,7 +36,7 @@ void ControllerHidReportTabsManager::createReportTypeTabs() {
     }
 }
 
-void ControllerHidReportTabsManager::createHidReportTab(QTabWidget* parentReportTypeTab,
+void ControllerHidReportTabsManager::createHidReportTab(QTabWidget* pParentReportTypeTab,
         hid::reportDescriptor::HidReportType reportType) {
     const auto& reportDescriptorTemp = m_pHidController->getReportDescriptor();
     if (!reportDescriptorTemp.has_value()) {
@@ -56,65 +56,65 @@ void ControllerHidReportTabsManager::createHidReportTab(QTabWidget* parentReport
                                                       .rightJustified(2, '0')
                                                       .toUpper());
 
-            auto* tabWidget = new QWidget(parentReportTypeTab);
-            auto* layout = new QVBoxLayout(tabWidget);
-            auto* topWidgetRow = new QHBoxLayout();
+            auto* pTabWidget = new QWidget(pParentReportTypeTab);
+            auto* pLayout = new QVBoxLayout(pTabWidget);
+            auto* pTopWidgetRow = new QHBoxLayout();
 
             // Create buttons
-            auto* readButton = new QPushButton(QStringLiteral("Read"), tabWidget);
-            auto* sendButton = new QPushButton(QStringLiteral("Send"), tabWidget);
+            auto* pReadButton = new QPushButton(QStringLiteral("Read"), pTabWidget);
+            auto* pSendButton = new QPushButton(QStringLiteral("Send"), pTabWidget);
 
             // Adjust visibility/enable state based on the report type
             if (reportType == hid::reportDescriptor::HidReportType::Input) {
-                sendButton->hide();
-                readButton->hide();
+                pSendButton->hide();
+                pReadButton->hide();
             } else if (reportType == hid::reportDescriptor::HidReportType::Output) {
-                readButton->hide();
+                pReadButton->hide();
             }
 
-            topWidgetRow->addWidget(readButton);
-            topWidgetRow->addWidget(sendButton);
-            layout->addLayout(topWidgetRow);
+            pTopWidgetRow->addWidget(pReadButton);
+            pTopWidgetRow->addWidget(pSendButton);
+            pLayout->addLayout(pTopWidgetRow);
 
-            auto* table = new QTableWidget(tabWidget);
-            layout->addWidget(table);
+            auto* pTable = new QTableWidget(pTabWidget);
+            pLayout->addWidget(pTable);
 
-            auto report = reportDescriptor.getReport(reportType, reportId);
-            if (report) {
+            auto* pReport = reportDescriptor.getReport(reportType, reportId);
+            if (pReport) {
                 // Show payload size
-                auto* sizeLabel = new QLabel(tabWidget);
-                sizeLabel->setText(
+                auto* pSizeLabel = new QLabel(pTabWidget);
+                pSizeLabel->setText(
                         QStringLiteral("Payload Size: <b>%1 bytes</b>")
-                                .arg(report->getReportSize()));
-                topWidgetRow->insertWidget(0, sizeLabel);
+                                .arg(pReport->getReportSize()));
+                pTopWidgetRow->insertWidget(0, pSizeLabel);
 
-                populateHidReportTable(table, *report, reportType);
+                populateHidReportTable(pTable, *pReport, reportType);
             }
 
             if (reportType != hid::reportDescriptor::HidReportType::Output) {
-                connect(readButton,
+                connect(pReadButton,
                         &QPushButton::clicked,
                         this,
-                        [this, table, reportId, reportType]() {
-                            slotReadReport(table, reportId, reportType);
+                        [this, pTable, reportId, reportType]() {
+                            slotReadReport(pTable, reportId, reportType);
                         });
                 // Read once on tab creation
-                slotReadReport(table, reportId, reportType);
+                slotReadReport(pTable, reportId, reportType);
             }
             if (reportType != hid::reportDescriptor::HidReportType::Input) {
-                connect(sendButton,
+                connect(pSendButton,
                         &QPushButton::clicked,
                         this,
-                        [this, table, reportId, reportType]() {
-                            slotSendReport(table, reportId, reportType);
+                        [this, pTable, reportId, reportType]() {
+                            slotSendReport(pTable, reportId, reportType);
                         });
             }
 
-            parentReportTypeTab->addTab(tabWidget, tabName);
+            pParentReportTypeTab->addTab(pTabWidget, tabName);
 
             if (reportType == hid::reportDescriptor::HidReportType::Input) {
-                // Store the table pointer associated with the reportId
-                m_reportIdToTableMap[reportId] = table;
+                // Store the pTable pointer associated with the reportId
+                m_reportIdToTableMap[reportId] = pTable;
             }
 
             // Connect the signal for the reportId
@@ -128,31 +128,31 @@ void ControllerHidReportTabsManager::createHidReportTab(QTabWidget* parentReport
 }
 
 void ControllerHidReportTabsManager::updateTableWithReportData(
-        QTableWidget* table,
+        QTableWidget* pTable,
         const QByteArray& reportData) {
     // Temporarily disable updates to speed up processing
-    table->setUpdatesEnabled(false);
+    pTable->setUpdatesEnabled(false);
 
     // Process the report data and update the table
-    for (int row = 0; row < table->rowCount(); ++row) {
-        auto* item = table->item(row, 5); // Value column is at index 5
+    for (int row = 0; row < pTable->rowCount(); ++row) {
+        auto* item = pTable->item(row, 5); // Value column is at index 5
         if (item) {
             // Retrieve custom data from the first cell
-            QVariant customData = table->item(row, 0)->data(Qt::UserRole + 1);
+            QVariant customData = pTable->item(row, 0)->data(Qt::UserRole + 1);
             if (customData.isValid()) {
-                auto control =
+                auto pControl =
                         static_cast<const hid::reportDescriptor::Control*>(
                                 customData.value<const void*>());
                 // Use the custom data as needed
                 int64_t controlValue =
                         hid::reportDescriptor::extractLogicalValue(
-                                reportData, *control);
+                                reportData, *pControl);
                 item->setText(QString::number(controlValue));
             }
         }
     }
 
-    table->setUpdatesEnabled(true);
+    pTable->setUpdatesEnabled(true);
 }
 
 void ControllerHidReportTabsManager::slotProcessInputReport(
@@ -163,16 +163,17 @@ void ControllerHidReportTabsManager::slotProcessInputReport(
         qWarning() << "No table found for reportId" << reportId;
         return;
     }
-    QTableWidget* table = it->second;
+    QTableWidget* pTable = it->second;
 
     const auto& reportDescriptor = *m_pHidController->getReportDescriptor();
-    auto report = reportDescriptor.getReport(hid::reportDescriptor::HidReportType::Input, reportId);
-    if (report) {
-        updateTableWithReportData(table, data);
+    auto pReport = reportDescriptor.getReport(
+            hid::reportDescriptor::HidReportType::Input, reportId);
+    if (pReport) {
+        updateTableWithReportData(pTable, data);
     }
 }
 
-void ControllerHidReportTabsManager::slotReadReport(QTableWidget* table,
+void ControllerHidReportTabsManager::slotReadReport(QTableWidget* pTable,
         quint8 reportId,
         hid::reportDescriptor::HidReportType reportType) {
     if (!m_pHidController->isOpen()) {
@@ -180,37 +181,38 @@ void ControllerHidReportTabsManager::slotReadReport(QTableWidget* table,
         return;
     }
 
-    HidControllerJSProxy* jsProxy = static_cast<HidControllerJSProxy*>(m_pHidController->jsProxy());
-    VERIFY_OR_DEBUG_ASSERT(jsProxy) {
+    HidControllerJSProxy* pJsProxy =
+            static_cast<HidControllerJSProxy*>(m_pHidController->jsProxy());
+    VERIFY_OR_DEBUG_ASSERT(pJsProxy) {
         return;
     }
 
     const auto& reportDescriptor = *m_pHidController->getReportDescriptor();
-    auto report = reportDescriptor.getReport(reportType, reportId);
-    VERIFY_OR_DEBUG_ASSERT(report) {
+    auto pReport = reportDescriptor.getReport(reportType, reportId);
+    VERIFY_OR_DEBUG_ASSERT(pReport) {
         return;
     }
 
     QByteArray reportData;
     if (reportType == hid::reportDescriptor::HidReportType::Input) {
-        reportData = jsProxy->getInputReport(reportId);
+        reportData = pJsProxy->getInputReport(reportId);
     } else if (reportType == hid::reportDescriptor::HidReportType::Feature) {
-        reportData = jsProxy->getFeatureReport(reportId);
+        reportData = pJsProxy->getFeatureReport(reportId);
     } else {
         return;
     }
 
-    if (reportData.size() < report->getReportSize()) {
+    if (reportData.size() < pReport->getReportSize()) {
         qWarning() << "Failed to get report. Read only " << reportData.size()
-                   << " instead of expected " << report->getReportSize()
+                   << " instead of expected " << pReport->getReportSize()
                    << " bytes.";
         return;
     }
 
-    updateTableWithReportData(table, reportData);
+    updateTableWithReportData(pTable, reportData);
 }
 
-void ControllerHidReportTabsManager::slotSendReport(QTableWidget* table,
+void ControllerHidReportTabsManager::slotSendReport(QTableWidget* pTable,
         quint8 reportId,
         hid::reportDescriptor::HidReportType reportType) {
     if (!m_pHidController->isOpen()) {
@@ -218,34 +220,35 @@ void ControllerHidReportTabsManager::slotSendReport(QTableWidget* table,
         return;
     }
 
-    HidControllerJSProxy* jsProxy = static_cast<HidControllerJSProxy*>(m_pHidController->jsProxy());
-    VERIFY_OR_DEBUG_ASSERT(jsProxy) {
+    HidControllerJSProxy* pJsProxy =
+            static_cast<HidControllerJSProxy*>(m_pHidController->jsProxy());
+    VERIFY_OR_DEBUG_ASSERT(pJsProxy) {
         return;
     }
 
     const auto& reportDescriptor = *m_pHidController->getReportDescriptor();
 
-    auto report = reportDescriptor.getReport(reportType, reportId);
-    VERIFY_OR_DEBUG_ASSERT(report) {
+    auto pReport = reportDescriptor.getReport(reportType, reportId);
+    VERIFY_OR_DEBUG_ASSERT(pReport) {
         return;
     }
 
     // Create a QByteArray of the size of the report
-    QByteArray reportData(report->getReportSize(), 0);
+    QByteArray reportData(pReport->getReportSize(), 0);
 
     // Iterate through each row in the table
-    for (int row = 0; row < table->rowCount(); ++row) {
-        auto* item = table->item(row, 5); // Value column is at index 5
+    for (int row = 0; row < pTable->rowCount(); ++row) {
+        auto* item = pTable->item(row, 5); // Value column is at index 5
         if (item) {
             // Retrieve custom data from the first cell
-            QVariant customData = table->item(row, 0)->data(Qt::UserRole + 1);
+            QVariant customData = pTable->item(row, 0)->data(Qt::UserRole + 1);
             if (customData.isValid()) {
-                auto control =
+                auto pControl =
                         reinterpret_cast<hid::reportDescriptor::Control*>(
                                 customData.value<void*>());
                 // Set the control value in the reportData
                 bool success = hid::reportDescriptor::applyLogicalValue(
-                        reportData, *control, item->text().toLongLong());
+                        reportData, *pControl, item->text().toLongLong());
                 if (!success) {
                     qWarning() << "Failed to set control value for row" << row;
                     continue;
@@ -256,26 +259,26 @@ void ControllerHidReportTabsManager::slotSendReport(QTableWidget* table,
 
     // Send the reportData
     if (reportType == hid::reportDescriptor::HidReportType::Feature) {
-        jsProxy->sendFeatureReport(reportId, reportData);
+        pJsProxy->sendFeatureReport(reportId, reportData);
     } else if (reportType == hid::reportDescriptor::HidReportType::Output) {
-        jsProxy->sendOutputReport(reportId, reportData);
+        pJsProxy->sendOutputReport(reportId, reportData);
     }
 }
 
 void ControllerHidReportTabsManager::populateHidReportTable(
-        QTableWidget* table,
-        const hid::reportDescriptor::Report& report,
+        QTableWidget* pTable,
+        const hid::reportDescriptor::Report& pReport,
         hid::reportDescriptor::HidReportType reportType) {
     // Temporarily disable updates to speed up populating
-    table->setUpdatesEnabled(false);
+    pTable->setUpdatesEnabled(false);
 
     // Reserve rows up-front
-    const auto& controls = report.getControls();
-    table->setRowCount(static_cast<int>(controls.size()));
+    const auto& controls = pReport.getControls();
+    pTable->setRowCount(static_cast<int>(controls.size()));
 
     // Set the delegate once if needed
     if (reportType != hid::reportDescriptor::HidReportType::Input) {
-        table->setItemDelegateForColumn(5, new ValueItemDelegate(table));
+        pTable->setItemDelegateForColumn(5, new ValueItemDelegate(pTable));
     }
 
     bool showVolatileColumn = (reportType == hid::reportDescriptor::HidReportType::Feature ||
@@ -302,9 +305,9 @@ void ControllerHidReportTabsManager::populateHidReportTable(
     }
     headers << QStringLiteral("Usage Page") << QStringLiteral("Usage");
 
-    table->setColumnCount(headers.size());
-    table->setHorizontalHeaderLabels(headers);
-    table->verticalHeader()->setVisible(false);
+    pTable->setColumnCount(headers.size());
+    pTable->setHorizontalHeaderLabels(headers);
+    pTable->verticalHeader()->setVisible(false);
 
     // Helpers
     auto createReadOnlyItem = [](const QString& text, bool rightAlign = false) {
@@ -330,90 +333,99 @@ void ControllerHidReportTabsManager::populateHidReportTable(
     };
 
     int row = 0;
-    for (const auto& control : controls) {
+    for (const auto& pControl : controls) {
         // Column 0 - Byte Position
         auto* bytePositionItem = createReadOnlyItem(QStringLiteral("0x%1").arg(QString::number(
-                                                            control.m_bytePosition, 16)
+                                                            pControl.m_bytePosition, 16)
                                                                     .rightJustified(2, '0')
                                                                     .toUpper()),
                 true);
-        table->setItem(row, 0, bytePositionItem);
+        pTable->setItem(row, 0, bytePositionItem);
         // Store custom data for the row in the first cell
         bytePositionItem->setData(Qt::UserRole + 1,
                 QVariant::fromValue(reinterpret_cast<void*>(
                         const_cast<hid::reportDescriptor::Control*>(
-                                &control))));
+                                &pControl))));
 
         // Column 1 - Bit Position
-        table->setItem(row, 1, createReadOnlyItem(QString::number(control.m_bitPosition), true));
+        pTable->setItem(row, 1, createReadOnlyItem(QString::number(pControl.m_bitPosition), true));
         // Column 2 - Bit Size
-        table->setItem(row, 2, createReadOnlyItem(QString::number(control.m_bitSize), true));
+        pTable->setItem(row, 2, createReadOnlyItem(QString::number(pControl.m_bitSize), true));
         // Column 3 - Logical Min
-        table->setItem(row, 3, createReadOnlyItem(QString::number(control.m_logicalMinimum), true));
+        pTable->setItem(row,
+                3,
+                createReadOnlyItem(
+                        QString::number(pControl.m_logicalMinimum), true));
         // Column 4 - Logical Max
-        table->setItem(row, 4, createReadOnlyItem(QString::number(control.m_logicalMaximum), true));
+        pTable->setItem(row,
+                4,
+                createReadOnlyItem(
+                        QString::number(pControl.m_logicalMaximum), true));
         // Column 5 - Value
-        table->setItem(row, 5, createValueItem(control.m_logicalMinimum, control.m_logicalMaximum));
+        pTable->setItem(row,
+                5,
+                createValueItem(
+                        pControl.m_logicalMinimum, pControl.m_logicalMaximum));
         // Column 6 - Physical Min
-        table->setItem(row,
+        pTable->setItem(row,
                 6,
                 createReadOnlyItem(
-                        QString::number(control.m_physicalMinimum), true));
+                        QString::number(pControl.m_physicalMinimum), true));
         // Column 7 - Physical Max
-        table->setItem(row,
+        pTable->setItem(row,
                 7,
                 createReadOnlyItem(
-                        QString::number(control.m_physicalMaximum), true));
+                        QString::number(pControl.m_physicalMaximum), true));
         // Column 8 - Unit Scaling
-        table->setItem(row,
+        pTable->setItem(row,
                 8,
-                createReadOnlyItem(control.m_unitExponent != 0
+                createReadOnlyItem(pControl.m_unitExponent != 0
                                 ? QStringLiteral("10^%1").arg(
-                                          control.m_unitExponent)
+                                          pControl.m_unitExponent)
                                 : QString(),
                         true));
         // Column 9 - Unit
-        table->setItem(row,
+        pTable->setItem(row,
                 9,
                 createReadOnlyItem(hid::reportDescriptor::getScaledUnitString(
-                        control.m_unit)));
+                        pControl.m_unit)));
         // Column 10 - Abs/Rel
-        table->setItem(row,
+        pTable->setItem(row,
                 10,
-                createReadOnlyItem(control.m_flags.absolute_relative
+                createReadOnlyItem(pControl.m_flags.absolute_relative
                                 ? QStringLiteral("Relative")
                                 : QStringLiteral("Absolute")));
         // Column 11 - Wrap
-        table->setItem(row,
+        pTable->setItem(row,
                 11,
-                createReadOnlyItem(control.m_flags.no_wrap_wrap
+                createReadOnlyItem(pControl.m_flags.no_wrap_wrap
                                 ? QStringLiteral("Wrap")
                                 : QStringLiteral("No Wrap")));
         // Column 12 - Linear
-        table->setItem(row,
+        pTable->setItem(row,
                 12,
-                createReadOnlyItem(control.m_flags.linear_non_linear
+                createReadOnlyItem(pControl.m_flags.linear_non_linear
                                 ? QStringLiteral("Non Linear")
                                 : QStringLiteral("Linear")));
         // Column 13 - Preferred
-        table->setItem(row,
+        pTable->setItem(row,
                 13,
-                createReadOnlyItem(control.m_flags.preferred_no_preferred
+                createReadOnlyItem(pControl.m_flags.preferred_no_preferred
                                 ? QStringLiteral("No Preferred")
                                 : QStringLiteral("Preferred")));
         // Column 14 - Null
-        table->setItem(row,
+        pTable->setItem(row,
                 14,
-                createReadOnlyItem(control.m_flags.no_null_null
+                createReadOnlyItem(pControl.m_flags.no_null_null
                                 ? QStringLiteral("Null")
                                 : QStringLiteral("No Null")));
 
         // Volatile column (if present)
         int volatileIndex = (showVolatileColumn ? 15 : -1);
         if (volatileIndex != -1) {
-            table->setItem(row,
+            pTable->setItem(row,
                     volatileIndex,
-                    createReadOnlyItem(control.m_flags.non_volatile_volatile
+                    createReadOnlyItem(pControl.m_flags.non_volatile_volatile
                                     ? QStringLiteral("Volatile")
                                     : QStringLiteral("Non Volatile")));
         }
@@ -421,15 +433,15 @@ void ControllerHidReportTabsManager::populateHidReportTable(
         // Usage Page / Usage
         int usagePageIdx = showVolatileColumn ? 16 : 15;
         int usageDescIdx = showVolatileColumn ? 17 : 16;
-        uint16_t usagePage = static_cast<uint16_t>((control.m_usage & 0xFFFF0000) >> 16);
-        uint16_t usage = static_cast<uint16_t>(control.m_usage & 0x0000FFFF);
+        uint16_t usagePage = static_cast<uint16_t>((pControl.m_usage & 0xFFFF0000) >> 16);
+        uint16_t usage = static_cast<uint16_t>(pControl.m_usage & 0x0000FFFF);
 
-        table->setItem(row,
+        pTable->setItem(row,
                 usagePageIdx,
                 createReadOnlyItem(
                         mixxx::hid::HidUsageTables::getUsagePageDescription(
                                 usagePage)));
-        table->setItem(row,
+        pTable->setItem(row,
                 usageDescIdx,
                 createReadOnlyItem(
                         mixxx::hid::HidUsageTables::getUsageDescription(
@@ -439,50 +451,50 @@ void ControllerHidReportTabsManager::populateHidReportTable(
     }
 
     // Resize columns to contents once, store width and set column width fixed for performance
-    for (int colIdx = 0; colIdx < table->columnCount(); ++colIdx) {
-        table->horizontalHeader()->setSectionResizeMode(colIdx, QHeaderView::ResizeToContents);
+    for (int colIdx = 0; colIdx < pTable->columnCount(); ++colIdx) {
+        pTable->horizontalHeader()->setSectionResizeMode(colIdx, QHeaderView::ResizeToContents);
     }
-    QVector<int> columnWidths(table->columnCount());
-    for (int colIdx = 0; colIdx < table->columnCount(); ++colIdx) {
-        columnWidths[colIdx] = table->columnWidth(colIdx);
+    QVector<int> columnWidths(pTable->columnCount());
+    for (int colIdx = 0; colIdx < pTable->columnCount(); ++colIdx) {
+        columnWidths[colIdx] = pTable->columnWidth(colIdx);
     }
     // Set the width of the value column (5) to fit 11 digits (int32 minimum in decimal)
-    QFontMetrics metrics(table->font());
+    QFontMetrics metrics(pTable->font());
     int width = metrics.horizontalAdvance(QStringLiteral("0").repeated(11));
     columnWidths[5] = width;
-    for (int colIdx = 0; colIdx < table->columnCount(); ++colIdx) {
-        table->horizontalHeader()->setSectionResizeMode(colIdx, QHeaderView::Fixed);
-        table->setColumnWidth(colIdx, columnWidths[colIdx]);
+    for (int colIdx = 0; colIdx < pTable->columnCount(); ++colIdx) {
+        pTable->horizontalHeader()->setSectionResizeMode(colIdx, QHeaderView::Fixed);
+        pTable->setColumnWidth(colIdx, columnWidths[colIdx]);
     }
 
-    table->setUpdatesEnabled(true);
+    pTable->setUpdatesEnabled(true);
 }
 
-QWidget* ValueItemDelegate::createEditor(QWidget* parent,
+QWidget* ValueItemDelegate::createEditor(QWidget* pParent,
         const QStyleOptionViewItem&,
         const QModelIndex& index) const {
     // Create a line edit restricted by (logical min, logical max)
     auto dataRange = index.data(Qt::UserRole).value<QPair<int, int>>();
-    auto* editor = new QLineEdit(parent);
-    editor->setValidator(new QIntValidator(dataRange.first, dataRange.second, editor));
-    return editor;
+    auto* pEditor = new QLineEdit(pParent);
+    pEditor->setValidator(new QIntValidator(dataRange.first, dataRange.second, pEditor));
+    return pEditor;
 }
 
-void ValueItemDelegate::setModelData(QWidget* editor,
-        QAbstractItemModel* model,
+void ValueItemDelegate::setModelData(QWidget* pEditor,
+        QAbstractItemModel* pModel,
         const QModelIndex& index) const {
-    auto* lineEdit = qobject_cast<QLineEdit*>(editor);
-    if (!lineEdit) {
+    auto* pLineEdit = qobject_cast<QLineEdit*>(pEditor);
+    if (!pLineEdit) {
         return;
     }
 
     // Confirm the text is an integer within the expected range
     bool ok = false;
-    const int value = lineEdit->text().toInt(&ok);
+    const int value = pLineEdit->text().toInt(&ok);
     if (ok) {
         auto dataRange = index.data(Qt::UserRole).value<QPair<int, int>>();
         if (value >= dataRange.first && value <= dataRange.second) {
-            model->setData(index, value, Qt::EditRole);
+            pModel->setData(index, value, Qt::EditRole);
         }
     }
 }

--- a/src/controllers/controllerhidreporttabsmanager.cpp
+++ b/src/controllers/controllerhidreporttabsmanager.cpp
@@ -144,6 +144,9 @@ void ControllerHidReportTabsManager::updateTableWithReportData(
             QVariant customData = pTable->item(row, 0)->data(Qt::UserRole + 1);
             if (customData.isValid()) {
                 const auto* pControl = customData.value<const hid::reportDescriptor::Control*>();
+                VERIFY_OR_DEBUG_ASSERT(pControl) {
+                    continue;
+                }
                 // Use the custom data as needed
                 int64_t controlValue =
                         hid::reportDescriptor::extractLogicalValue(
@@ -215,6 +218,9 @@ void ControllerHidReportTabsManager::slotReadReport(QTableWidget* pTable,
 void ControllerHidReportTabsManager::slotSendReport(QTableWidget* pTable,
         quint8 reportId,
         hid::reportDescriptor::HidReportType reportType) {
+    VERIFY_OR_DEBUG_ASSERT(m_pHidController) {
+        return;
+    }
     if (!m_pHidController->isOpen()) {
         qWarning() << "HID controller is not open.";
         return;
@@ -244,7 +250,9 @@ void ControllerHidReportTabsManager::slotSendReport(QTableWidget* pTable,
             QVariant customData = pTable->item(row, 0)->data(Qt::UserRole + 1);
             if (customData.isValid()) {
                 const auto* pControl = customData.value<const hid::reportDescriptor::Control*>();
-                // Set the control value in the reportData
+                VERIFY_OR_DEBUG_ASSERT(pControl) {
+                    continue;
+                }
                 bool success = hid::reportDescriptor::applyLogicalValue(
                         reportData, *pControl, pItem->text().toLongLong());
                 if (!success) {

--- a/src/controllers/controllerhidreporttabsmanager.h
+++ b/src/controllers/controllerhidreporttabsmanager.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <QStyledItemDelegate>
+#include <QTabWidget>
+#include <QTableWidget>
+#include <memory>
+
+#include "controllers/hid/hidcontroller.h"
+#include "controllers/hid/hidreportdescriptor.h"
+
+class ControllerHidReportTabsManager : public QObject {
+    Q_OBJECT
+
+  public:
+    ControllerHidReportTabsManager(QTabWidget* parentTabWidget, HidController* hidController);
+
+    void createReportTypeTabs();
+    void createHidReportTab(QTabWidget* parentTab, hid::reportDescriptor::HidReportType reportType);
+    void slotSendReport(QTableWidget* table,
+            quint8 reportId,
+            hid::reportDescriptor::HidReportType reportType);
+    void populateHidReportTable(QTableWidget* table,
+            const hid::reportDescriptor::Report& report,
+            hid::reportDescriptor::HidReportType reportType);
+
+  private slots:
+    void slotReadReport(QTableWidget* table,
+            quint8 reportId,
+            hid::reportDescriptor::HidReportType reportType);
+
+  public slots:
+    void slotProcessInputReport(quint8 reportId, const QByteArray& reportData);
+
+  private:
+    void updateTableWithReportData(QTableWidget* table, const QByteArray& reportData);
+    QTabWidget* m_pParentControllerTab;
+    HidController* m_pHidController;
+    std::unordered_map<quint8, QTableWidget*> m_reportIdToTableMap;
+};
+
+class ValueItemDelegate : public QStyledItemDelegate {
+  public:
+    using QStyledItemDelegate::QStyledItemDelegate;
+
+    QWidget* createEditor(QWidget* parent,
+            const QStyleOptionViewItem& option,
+            const QModelIndex& index) const override;
+
+    void setModelData(QWidget* editor,
+            QAbstractItemModel* model,
+            const QModelIndex& index) const override;
+};

--- a/src/controllers/controllerhidreporttabsmanager.h
+++ b/src/controllers/controllerhidreporttabsmanager.h
@@ -36,7 +36,7 @@ class ControllerHidReportTabsManager : public QObject {
     void updateTableWithReportData(QTableWidget* pTable, const QByteArray& reportData);
     QTabWidget* m_pParentControllerTab;
     HidController* m_pHidController;
-    std::unordered_map<quint8, QTableWidget*> m_reportIdToTableMap;
+    std::unordered_map<quint8, QPointer<QTableWidget>> m_reportIdToTableMap;
 };
 
 class ValueItemDelegate : public QStyledItemDelegate {

--- a/src/controllers/controllerhidreporttabsmanager.h
+++ b/src/controllers/controllerhidreporttabsmanager.h
@@ -12,19 +12,20 @@ class ControllerHidReportTabsManager : public QObject {
     Q_OBJECT
 
   public:
-    ControllerHidReportTabsManager(QTabWidget* parentTabWidget, HidController* hidController);
+    ControllerHidReportTabsManager(QTabWidget* pParentTabWidget, HidController* pHidController);
 
     void createReportTypeTabs();
-    void createHidReportTab(QTabWidget* parentTab, hid::reportDescriptor::HidReportType reportType);
-    void slotSendReport(QTableWidget* table,
+    void createHidReportTab(QTabWidget* pParentTab,
+            hid::reportDescriptor::HidReportType reportType);
+    void slotSendReport(QTableWidget* pTable,
             quint8 reportId,
             hid::reportDescriptor::HidReportType reportType);
-    void populateHidReportTable(QTableWidget* table,
+    void populateHidReportTable(QTableWidget* pTable,
             const hid::reportDescriptor::Report& report,
             hid::reportDescriptor::HidReportType reportType);
 
   private slots:
-    void slotReadReport(QTableWidget* table,
+    void slotReadReport(QTableWidget* pTable,
             quint8 reportId,
             hid::reportDescriptor::HidReportType reportType);
 
@@ -32,7 +33,7 @@ class ControllerHidReportTabsManager : public QObject {
     void slotProcessInputReport(quint8 reportId, const QByteArray& reportData);
 
   private:
-    void updateTableWithReportData(QTableWidget* table, const QByteArray& reportData);
+    void updateTableWithReportData(QTableWidget* pTable, const QByteArray& reportData);
     QTabWidget* m_pParentControllerTab;
     HidController* m_pHidController;
     std::unordered_map<quint8, QTableWidget*> m_reportIdToTableMap;
@@ -42,11 +43,11 @@ class ValueItemDelegate : public QStyledItemDelegate {
   public:
     using QStyledItemDelegate::QStyledItemDelegate;
 
-    QWidget* createEditor(QWidget* parent,
+    QWidget* createEditor(QWidget* pParent,
             const QStyleOptionViewItem& option,
             const QModelIndex& index) const override;
 
-    void setModelData(QWidget* editor,
-            QAbstractItemModel* model,
+    void setModelData(QWidget* pEditor,
+            QAbstractItemModel* pModel,
             const QModelIndex& index) const override;
 };

--- a/src/controllers/controllerhidreporttabsmanager.h
+++ b/src/controllers/controllerhidreporttabsmanager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QPointer>
 #include <QStyledItemDelegate>
 #include <QTabWidget>
 #include <QTableWidget>
@@ -34,8 +35,8 @@ class ControllerHidReportTabsManager : public QObject {
 
   private:
     void updateTableWithReportData(QTableWidget* pTable, const QByteArray& reportData);
-    QTabWidget* m_pParentControllerTab;
-    HidController* m_pHidController;
+    QPointer<QTabWidget> m_pParentControllerTab;
+    QPointer<HidController> m_pHidController;
     std::unordered_map<quint8, QPointer<QTableWidget>> m_reportIdToTableMap;
 };
 

--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -90,7 +90,8 @@ DlgPrefController::DlgPrefController(
           m_inputMappingsTabIndex(-1),
           m_outputMappingsTabIndex(-1),
           m_settingsTabIndex(-1),
-          m_screensTabIndex(-1) {
+          m_screensTabIndex(-1),
+          m_hidReportTabsManager(nullptr) {
     m_ui.setupUi(this);
     // Create text color for the file and wiki links
     createLinkColor();
@@ -194,6 +195,12 @@ DlgPrefController::DlgPrefController(
         m_ui.labelHidUsagePageValue->setVisible(true);
         m_ui.labelHidUsage->setVisible(true);
         m_ui.labelHidUsageValue->setVisible(true);
+
+        // Create HID report tabs
+        m_hidReportTabsManager =
+                std::make_unique<ControllerHidReportTabsManager>(
+                        m_ui.controllerTabs, hidController);
+        m_hidReportTabsManager->createReportTypeTabs();
     } else
 #endif
     {
@@ -1161,7 +1168,7 @@ void DlgPrefController::showMapping(std::shared_ptr<LegacyControllerMapping> pMa
     }
 #endif
 
-    // Inputs tab
+    // MIDI Inputs tab
     ControllerInputMappingTableModel* pInputModel =
             new ControllerInputMappingTableModel(this,
                     m_pControlPickerMenu,
@@ -1189,7 +1196,7 @@ void DlgPrefController::showMapping(std::shared_ptr<LegacyControllerMapping> pMa
     // Trigger search when the model was recreated after hitting Apply
     slotInputControlSearch();
 
-    // Outputs tab
+    // MIDI Outputs tab
     ControllerOutputMappingTableModel* pOutputModel =
             new ControllerOutputMappingTableModel(this,
                     m_pControlPickerMenu,

--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -190,7 +190,7 @@ DlgPrefController::DlgPrefController(
 
 #ifdef __HID__
     // Display HID UsagePage and Usage if the controller is an HidController
-    if (auto* hidController = dynamic_cast<HidController*>(m_pController)) {
+    if (auto* hidController = qobject_cast<HidController*>(m_pController)) {
         m_ui.labelHidUsagePageValue->setText(QStringLiteral("%1 (%2)")
                         .arg(formatHex(hidController->getUsagePage()),
                                 hidController->getUsagePageDescription()));

--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -92,6 +92,8 @@ DlgPrefController::DlgPrefController(
           m_settingsTabIndex(-1),
           m_screensTabIndex(-1),
           m_hidReportTabsManager(nullptr) {
+    qRegisterMetaType<const hid::reportDescriptor::Control*>();
+
     m_ui.setupUi(this);
     // Create text color for the file and wiki links
     createLinkColor();

--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -90,9 +90,14 @@ DlgPrefController::DlgPrefController(
           m_inputMappingsTabIndex(-1),
           m_outputMappingsTabIndex(-1),
           m_settingsTabIndex(-1),
-          m_screensTabIndex(-1),
+          m_screensTabIndex(-1)
+#ifdef __HID__
+          ,
           m_hidReportTabsManager(nullptr) {
     qRegisterMetaType<const hid::reportDescriptor::Control*>();
+#else
+{
+#endif
 
     m_ui.setupUi(this);
     // Create text color for the file and wiki links

--- a/src/controllers/dlgprefcontroller.h
+++ b/src/controllers/dlgprefcontroller.h
@@ -2,7 +2,9 @@
 
 #include <memory>
 
+#ifdef __HID__
 #include "controllers/controllerhidreporttabsmanager.h"
+#endif
 #include "controllers/controllermappinginfo.h"
 #include "controllers/midi/midimessage.h"
 #include "controllers/ui_dlgprefcontrollerdlg.h"
@@ -149,5 +151,7 @@ class DlgPrefController : public DlgPreferencePage {
     int m_screensTabIndex;        // Index of the screens tab
     QHash<QString, bool> m_settingsCollapsedStates;
 
+#ifdef __HID__
     std::unique_ptr<ControllerHidReportTabsManager> m_hidReportTabsManager;
+#endif
 };

--- a/src/controllers/dlgprefcontroller.h
+++ b/src/controllers/dlgprefcontroller.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include "controllers/controllerhidreporttabsmanager.h"
 #include "controllers/controllermappinginfo.h"
 #include "controllers/midi/midimessage.h"
 #include "controllers/ui_dlgprefcontrollerdlg.h"
@@ -147,4 +148,6 @@ class DlgPrefController : public DlgPreferencePage {
     int m_settingsTabIndex;       // Index of the settings tab
     int m_screensTabIndex;        // Index of the screens tab
     QHash<QString, bool> m_settingsCollapsedStates;
+
+    std::unique_ptr<ControllerHidReportTabsManager> m_hidReportTabsManager;
 };

--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -162,16 +162,22 @@ int HidController::open(const QString& resourcePath) {
         return -1;
     }
 
-    m_rawReportDescriptor = m_deviceInfo.fetchRawReportDescriptor(pHidDevice);
+    // When fetching the report descriptor, from m_deviceInfo or if not read yet from the device
+    const std::vector<uint8_t>& rawReportDescriptor =
+            m_deviceInfo.fetchRawReportDescriptor(pHidDevice);
 
-    if (m_rawReportDescriptor.has_value()) {
-        m_reportDescriptor = hid::reportDescriptor::HidReportDescriptor(
-                m_rawReportDescriptor->data(), m_rawReportDescriptor->size());
+    if (!rawReportDescriptor.empty()) {
+        m_reportDescriptor =
+                std::make_shared<hid::reportDescriptor::HidReportDescriptor>(
+                        rawReportDescriptor);
         m_reportDescriptor->parse();
-        m_deviceHasReportIds = m_reportDescriptor->isDeviceWithReportIds();
+        m_deviceUsesReportIds = m_reportDescriptor->isDeviceWithReportIds();
+    } else {
+        m_reportDescriptor.reset();
+        m_deviceUsesReportIds = std::nullopt;
     }
 
-    m_pHidIoThread = std::make_unique<HidIoThread>(pHidDevice, m_deviceInfo, m_deviceHasReportIds);
+    m_pHidIoThread = std::make_unique<HidIoThread>(pHidDevice, m_deviceInfo, m_deviceUsesReportIds);
     m_pHidIoThread->setObjectName(QStringLiteral("HidIoThread ") + getName());
 
     connect(m_pHidIoThread.get(),

--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -165,7 +165,7 @@ int HidController::open(const QString& resourcePath) {
     m_rawReportDescriptor = m_deviceInfo.fetchRawReportDescriptor(pHidDevice);
 
     if (m_rawReportDescriptor.has_value()) {
-        m_reportDescriptor = hid::reportDescriptor::HIDReportDescriptor(
+        m_reportDescriptor = hid::reportDescriptor::HidReportDescriptor(
                 m_rawReportDescriptor->data(), m_rawReportDescriptor->size());
         m_reportDescriptor->parse();
         m_deviceHasReportIds = m_reportDescriptor->isDeviceWithReportIds();

--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -162,7 +162,16 @@ int HidController::open(const QString& resourcePath) {
         return -1;
     }
 
-    m_pHidIoThread = std::make_unique<HidIoThread>(pHidDevice, m_deviceInfo);
+    m_rawReportDescriptor = m_deviceInfo.fetchRawReportDescriptor(pHidDevice);
+
+    if (m_rawReportDescriptor.has_value()) {
+        m_reportDescriptor = hid::reportDescriptor::HIDReportDescriptor(
+                m_rawReportDescriptor->data(), m_rawReportDescriptor->size());
+        m_reportDescriptor->parse();
+        m_deviceHasReportIds = m_reportDescriptor->isDeviceWithReportIds();
+    }
+
+    m_pHidIoThread = std::make_unique<HidIoThread>(pHidDevice, m_deviceInfo, m_deviceHasReportIds);
     m_pHidIoThread->setObjectName(QStringLiteral("HidIoThread ") + getName());
 
     connect(m_pHidIoThread.get(),

--- a/src/controllers/hid/hidcontroller.h
+++ b/src/controllers/hid/hidcontroller.h
@@ -72,7 +72,7 @@ class HidController final : public Controller {
         return m_deviceInfo.getUsageDescription();
     }
 
-    const std::optional<hid::reportDescriptor::HIDReportDescriptor>& getReportDescriptor() const {
+    const std::optional<hid::reportDescriptor::HidReportDescriptor>& getReportDescriptor() const {
         return m_reportDescriptor;
     }
 
@@ -100,7 +100,7 @@ class HidController final : public Controller {
     mixxx::hid::DeviceInfo m_deviceInfo;
     // These optional members are not set before opening the device
     std::optional<std::vector<uint8_t>> m_rawReportDescriptor;
-    std::optional<hid::reportDescriptor::HIDReportDescriptor> m_reportDescriptor;
+    std::optional<hid::reportDescriptor::HidReportDescriptor> m_reportDescriptor;
     std::optional<bool> m_deviceHasReportIds;
 
     std::unique_ptr<HidIoThread> m_pHidIoThread;

--- a/src/controllers/hid/hidcontroller.h
+++ b/src/controllers/hid/hidcontroller.h
@@ -3,6 +3,7 @@
 #include "controllers/controller.h"
 #include "controllers/hid/hiddevice.h"
 #include "controllers/hid/hidiothread.h"
+#include "controllers/hid/hidreportdescriptor.h"
 #include "controllers/hid/legacyhidcontrollermapping.h"
 
 /// HID controller backend
@@ -70,6 +71,15 @@ class HidController final : public Controller {
     QString getUsageDescription() const {
         return m_deviceInfo.getUsageDescription();
     }
+
+    const std::optional<hid::reportDescriptor::HIDReportDescriptor>& getReportDescriptor() const {
+        return m_reportDescriptor;
+    }
+
+    HidIoThread* getHidIoThread() const {
+        return m_pHidIoThread.get();
+    }
+
     bool isMappable() const override {
         if (!m_pMapping) {
             return false;
@@ -87,7 +97,11 @@ class HidController final : public Controller {
     // 0x0.
     bool sendBytes(const QByteArray& data) override;
 
-    const mixxx::hid::DeviceInfo m_deviceInfo;
+    mixxx::hid::DeviceInfo m_deviceInfo;
+    // These optional members are not set before opening the device
+    std::optional<std::vector<uint8_t>> m_rawReportDescriptor;
+    std::optional<hid::reportDescriptor::HIDReportDescriptor> m_reportDescriptor;
+    std::optional<bool> m_deviceHasReportIds;
 
     std::unique_ptr<HidIoThread> m_pHidIoThread;
     std::unique_ptr<LegacyHidControllerMapping> m_pMapping;

--- a/src/controllers/hid/hidcontroller.h
+++ b/src/controllers/hid/hidcontroller.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 #include "controllers/controller.h"
 #include "controllers/hid/hiddevice.h"
 #include "controllers/hid/hidiothread.h"
@@ -72,7 +74,7 @@ class HidController final : public Controller {
         return m_deviceInfo.getUsageDescription();
     }
 
-    const std::optional<hid::reportDescriptor::HidReportDescriptor>& getReportDescriptor() const {
+    std::shared_ptr<const hid::reportDescriptor::HidReportDescriptor> getReportDescriptor() const {
         return m_reportDescriptor;
     }
 
@@ -99,9 +101,8 @@ class HidController final : public Controller {
 
     mixxx::hid::DeviceInfo m_deviceInfo;
     // These optional members are not set before opening the device
-    std::optional<std::vector<uint8_t>> m_rawReportDescriptor;
-    std::optional<hid::reportDescriptor::HidReportDescriptor> m_reportDescriptor;
-    std::optional<bool> m_deviceHasReportIds;
+    std::shared_ptr<hid::reportDescriptor::HidReportDescriptor> m_reportDescriptor;
+    std::optional<bool> m_deviceUsesReportIds;
 
     std::unique_ptr<HidIoThread> m_pHidIoThread;
     std::unique_ptr<LegacyHidControllerMapping> m_pMapping;

--- a/src/controllers/hid/hiddevice.cpp
+++ b/src/controllers/hid/hiddevice.cpp
@@ -52,21 +52,27 @@ DeviceInfo::DeviceInfo(const hid_device_info& device_info)
                   m_serialNumberRaw.data(), m_serialNumberRaw.size())) {
 }
 
-std::optional<std::vector<uint8_t>> DeviceInfo::fetchRawReportDescriptor(hid_device* pHidDevice) {
-    if (!m_reportDescriptor) {
-        if (!pHidDevice) {
-            return std::nullopt;
-        }
-
-        uint8_t tempReportDescriptor[HID_API_MAX_REPORT_DESCRIPTOR_SIZE];
-        int descriptorSize = hid_get_report_descriptor(pHidDevice,
-                tempReportDescriptor,
-                HID_API_MAX_REPORT_DESCRIPTOR_SIZE);
-        if (descriptorSize > 0) {
-            m_reportDescriptor = std::vector<uint8_t>(tempReportDescriptor,
-                    tempReportDescriptor + descriptorSize);
-        }
+const std::vector<uint8_t>& DeviceInfo::fetchRawReportDescriptor(hid_device* pHidDevice) {
+    if (!pHidDevice) {
+        static const std::vector<uint8_t> emptyDescriptor;
+        return emptyDescriptor;
     }
+    if (!m_reportDescriptor.empty()) {
+        //
+        return m_reportDescriptor;
+    }
+
+    uint8_t tempReportDescriptor[HID_API_MAX_REPORT_DESCRIPTOR_SIZE];
+    int descriptorSize = hid_get_report_descriptor(pHidDevice,
+            tempReportDescriptor,
+            HID_API_MAX_REPORT_DESCRIPTOR_SIZE);
+    if (descriptorSize <= 0) {
+        static const std::vector<uint8_t> emptyDescriptor;
+        return emptyDescriptor;
+    }
+    m_reportDescriptor = std::vector<uint8_t>(tempReportDescriptor,
+            tempReportDescriptor + descriptorSize);
+
     return m_reportDescriptor;
 }
 

--- a/src/controllers/hid/hiddevice.cpp
+++ b/src/controllers/hid/hiddevice.cpp
@@ -52,9 +52,6 @@ DeviceInfo::DeviceInfo(const hid_device_info& device_info)
                   m_serialNumberRaw.data(), m_serialNumberRaw.size())) {
 }
 
-// We need an opened hid_device here,
-// but the lifetime of the data is as long as DeviceInfo exists,
-// means the reportDescriptor data remains valid after closing the hid_device
 std::optional<std::vector<uint8_t>> DeviceInfo::fetchRawReportDescriptor(hid_device* pHidDevice) {
     if (!m_reportDescriptor) {
         if (!pHidDevice) {

--- a/src/controllers/hid/hiddevice.h
+++ b/src/controllers/hid/hiddevice.h
@@ -108,7 +108,7 @@ class DeviceInfo final {
     // We need an opened hid_device here,
     // but the lifetime of the data is as long as DeviceInfo exists,
     // means the reportDescriptor data remains valid after closing the hid_device
-    std::optional<std::vector<uint8_t>> fetchRawReportDescriptor(hid_device* pHidDevice);
+    const std::vector<uint8_t>& fetchRawReportDescriptor(hid_device* pHidDevice);
 
     bool isValid() const {
         return !getProductString().isNull() && !getSerialNumber().isNull();
@@ -141,7 +141,7 @@ class DeviceInfo final {
     QString m_productString;
     QString m_serialNumber;
 
-    std::optional<std::vector<uint8_t>> m_reportDescriptor;
+    std::vector<uint8_t> m_reportDescriptor;
 };
 
 } // namespace hid

--- a/src/controllers/hid/hiddevice.h
+++ b/src/controllers/hid/hiddevice.h
@@ -1,8 +1,12 @@
 #pragma once
 
+#include <hidapi.h>
+
 #include <QObject>
 #include <QString>
+#include <optional>
 #include <string>
+#include <vector>
 
 #include "controllers/controller.h"
 #include "controllers/hid/hidusagetables.h"
@@ -101,6 +105,8 @@ class DeviceInfo final {
         return mixxx::hid::HidUsageTables::getUsageDescription(usage_page, usage);
     }
 
+    std::optional<std::vector<uint8_t>> fetchRawReportDescriptor(hid_device* pHidDevice);
+
     bool isValid() const {
         return !getProductString().isNull() && !getSerialNumber().isNull();
     }
@@ -131,6 +137,8 @@ class DeviceInfo final {
     QString m_manufacturerString;
     QString m_productString;
     QString m_serialNumber;
+
+    std::optional<std::vector<uint8_t>> m_reportDescriptor;
 };
 
 } // namespace hid

--- a/src/controllers/hid/hiddevice.h
+++ b/src/controllers/hid/hiddevice.h
@@ -105,6 +105,9 @@ class DeviceInfo final {
         return mixxx::hid::HidUsageTables::getUsageDescription(usage_page, usage);
     }
 
+    // We need an opened hid_device here,
+    // but the lifetime of the data is as long as DeviceInfo exists,
+    // means the reportDescriptor data remains valid after closing the hid_device
     std::optional<std::vector<uint8_t>> fetchRawReportDescriptor(hid_device* pHidDevice);
 
     bool isValid() const {

--- a/src/controllers/hid/hidiothread.cpp
+++ b/src/controllers/hid/hidiothread.cpp
@@ -29,7 +29,7 @@ QString loggingCategoryPrefix(const QString& deviceName) {
 
 HidIoThread::HidIoThread(hid_device* pHidDevice,
         const mixxx::hid::DeviceInfo& deviceInfo,
-        std::optional<bool> deviceHasReportIds)
+        std::optional<bool> deviceUsesReportIds)
         : QThread(),
           m_deviceInfo(deviceInfo),
           // Defining RuntimeLoggingCategories locally in this thread improves
@@ -43,7 +43,7 @@ HidIoThread::HidIoThread(hid_device* pHidDevice,
           m_lastPollSize(0),
           m_pollingBufferIndex(0),
           m_hidReadErrorLogged(false),
-          m_deviceHasReportIds(deviceHasReportIds),
+          m_deviceUsesReportIds(deviceUsesReportIds),
           m_globalOutputReportFifo(),
           m_runLoopSemaphore(1) {
     // Initializing isn't strictly necessary but is good practice.
@@ -155,8 +155,8 @@ void HidIoThread::processInputReport(int bytesRead) {
                          bytesRead),
             mixxx::Time::elapsed());
 
-    if (m_deviceHasReportIds.has_value() && bytesRead > 0) {
-        if (m_deviceHasReportIds.value()) {
+    if (m_deviceUsesReportIds.has_value() && bytesRead > 0) {
+        if (m_deviceUsesReportIds.value()) {
             // Extract the ReportId from the buffer
             quint8 reportId = pCurrentBuffer[0];
             emit reportReceived(reportId,

--- a/src/controllers/hid/hidiothread.cpp
+++ b/src/controllers/hid/hidiothread.cpp
@@ -27,11 +27,13 @@ QString loggingCategoryPrefix(const QString& deviceName) {
 }
 } // namespace
 
-HidIoThread::HidIoThread(
-        hid_device* pHidDevice, const mixxx::hid::DeviceInfo& deviceInfo)
+HidIoThread::HidIoThread(hid_device* pHidDevice,
+        const mixxx::hid::DeviceInfo& deviceInfo,
+        std::optional<bool> deviceHasReportIds)
         : QThread(),
           m_deviceInfo(deviceInfo),
-          // Defining RuntimeLoggingCategories locally in this thread improves runtime performance significiantly
+          // Defining RuntimeLoggingCategories locally in this thread improves
+          // runtime performance significantly
           m_logBase(loggingCategoryPrefix(deviceInfo.formatName())),
           m_logInput(loggingCategoryPrefix(deviceInfo.formatName()) +
                   QStringLiteral(".input")),
@@ -41,6 +43,7 @@ HidIoThread::HidIoThread(
           m_lastPollSize(0),
           m_pollingBufferIndex(0),
           m_hidReadErrorLogged(false),
+          m_deviceHasReportIds(deviceHasReportIds),
           m_globalOutputReportFifo(),
           m_runLoopSemaphore(1) {
     // Initializing isn't strictly necessary but is good practice.
@@ -151,6 +154,22 @@ void HidIoThread::processInputReport(int bytesRead) {
     emit receive(QByteArray(reinterpret_cast<const char*>(pCurrentBuffer),
                          bytesRead),
             mixxx::Time::elapsed());
+
+    if (m_deviceHasReportIds.has_value() && bytesRead > 0) {
+        if (m_deviceHasReportIds.value()) {
+            // Extract the ReportId from the buffer
+            quint8 reportId = pCurrentBuffer[0];
+            emit reportReceived(reportId,
+                    QByteArray(
+                            reinterpret_cast<const char*>(pCurrentBuffer + 1),
+                            bytesRead - 1));
+        } else {
+            quint8 reportId = 0;
+            emit reportReceived(reportId,
+                    QByteArray(reinterpret_cast<const char*>(pCurrentBuffer),
+                            bytesRead));
+        }
+    }
 }
 
 QByteArray HidIoThread::getInputReport(quint8 reportID) {

--- a/src/controllers/hid/hidiothread.h
+++ b/src/controllers/hid/hidiothread.h
@@ -24,7 +24,8 @@ class HidIoThread : public QThread {
     Q_OBJECT
   public:
     HidIoThread(hid_device* pDevice,
-            const mixxx::hid::DeviceInfo& deviceInfo);
+            const mixxx::hid::DeviceInfo& deviceInfo,
+            std::optional<bool> deviceHasReportIds);
     ~HidIoThread() override;
 
     void run() override;
@@ -52,6 +53,7 @@ class HidIoThread : public QThread {
   signals:
     /// Signals that a HID InputReport received by Interrupt triggered from HID device
     void receive(const QByteArray& data, mixxx::Duration timestamp);
+    void reportReceived(quint8 reportId, const QByteArray& data);
 
   private:
     bool sendNextCachedOutputReport();
@@ -80,6 +82,8 @@ class HidIoThread : public QThread {
     int m_lastPollSize;
     int m_pollingBufferIndex;
     bool m_hidReadErrorLogged;
+
+    std::optional<bool> m_deviceHasReportIds;
 
     /// Must be locked when a operation changes the size of the m_outputReports map,
     /// or when modify the m_outputReportIterator

--- a/src/controllers/hid/hidiothread.h
+++ b/src/controllers/hid/hidiothread.h
@@ -25,7 +25,7 @@ class HidIoThread : public QThread {
   public:
     HidIoThread(hid_device* pDevice,
             const mixxx::hid::DeviceInfo& deviceInfo,
-            std::optional<bool> deviceHasReportIds);
+            std::optional<bool> deviceUsesReportIds);
     ~HidIoThread() override;
 
     void run() override;
@@ -83,7 +83,7 @@ class HidIoThread : public QThread {
     int m_pollingBufferIndex;
     bool m_hidReadErrorLogged;
 
-    std::optional<bool> m_deviceHasReportIds;
+    std::optional<bool> m_deviceUsesReportIds;
 
     /// Must be locked when a operation changes the size of the m_outputReports map,
     /// or when modify the m_outputReportIterator

--- a/src/controllers/hid/hidreportdescriptor.cpp
+++ b/src/controllers/hid/hidreportdescriptor.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <optional>
 
 #include "moc_hidreportdescriptor.cpp"
 #include "util/assert.h"
@@ -177,14 +178,16 @@ void Report::increasePosition(unsigned int bitSize) {
 void Collection::addReport(const Report& report) {
     m_reports.push_back(report);
 }
-const Report* Collection::getReport(
+
+std::optional<std::reference_wrapper<const hid::reportDescriptor::Report>>
+Collection::getReport(
         const HidReportType& reportType, const uint8_t& reportId) const {
     for (const auto& report : m_reports) {
         if (report.m_reportType == reportType && report.m_reportId == reportId) {
-            return &report;
+            return report;
         }
     }
-    return nullptr;
+    return std::nullopt;
 }
 
 // HID Report Descriptor Parser
@@ -518,15 +521,16 @@ Collection HidReportDescriptor::parse() {
     return collection;
 }
 
-const Report* HidReportDescriptor::getReport(
+std::optional<std::reference_wrapper<const hid::reportDescriptor::Report>>
+HidReportDescriptor::getReport(
         const HidReportType& reportType, const uint8_t& reportId) const {
     for (const auto& collection : m_topLevelCollections) {
-        const Report* report = collection.getReport(reportType, reportId);
-        if (report != nullptr) {
+        auto report = collection.getReport(reportType, reportId);
+        if (report) {
             return report;
         }
     }
-    return nullptr;
+    return std::nullopt;
 }
 
 std::vector<std::tuple<size_t, HidReportType, uint8_t>>

--- a/src/controllers/hid/hidreportdescriptor.cpp
+++ b/src/controllers/hid/hidreportdescriptor.cpp
@@ -529,7 +529,7 @@ const Report* HidReportDescriptor::getReport(
     return nullptr;
 }
 
-const std::vector<std::tuple<size_t, HidReportType, uint8_t>>
+std::vector<std::tuple<size_t, HidReportType, uint8_t>>
 HidReportDescriptor::getListOfReports() const {
     std::vector<std::tuple<size_t, HidReportType, uint8_t>> orderedList;
     for (size_t i = 0; i < m_topLevelCollections.size(); ++i) {

--- a/src/controllers/hid/hidreportdescriptor.cpp
+++ b/src/controllers/hid/hidreportdescriptor.cpp
@@ -423,8 +423,7 @@ Collection HIDReportDescriptor::parse() {
                 physicalMaximum = globalItems.physicalMaximum;
             }
 
-            ControlFlags flags;
-            flags.payload = payload;
+            auto flags = std::bit_cast<ControlFlags>(payload);
 
             if (flags.data_constant == 1) {
                 // Constant value padding - Usually for byte alignment

--- a/src/controllers/hid/hidreportdescriptor.cpp
+++ b/src/controllers/hid/hidreportdescriptor.cpp
@@ -409,7 +409,8 @@ Collection HIDReportDescriptor::parse() {
                 pCurrentReport = std::make_unique<Report>(getReportType(tag), globalItems.reportId);
             }
 
-            int32_t physicalMinimum, physicalMaximum;
+            int32_t physicalMinimum;
+            int32_t physicalMaximum;
             if (globalItems.physicalMinimum == 0 && globalItems.physicalMaximum == 0) {
                 // According remark in chapter 6.2.2.7 of HID class definition 1.11
                 physicalMinimum = globalItems.logicalMinimum;

--- a/src/controllers/hid/hidreportdescriptor.cpp
+++ b/src/controllers/hid/hidreportdescriptor.cpp
@@ -91,8 +91,11 @@ QString getScaledUnitString(uint32_t unit) {
         const char* pPhysicalQuantity[5];
     };
 
+    // This table of physical units is derived from the unit item table
+    // in chapter 6.2.2.7 of HID class definition 1.11
+    // These official unit symbols are not translateable
     const UnitInfo unitInfos[] = {
-            {"", "cm", "radian", "inch", "degree"},
+            {"", "cm", "rad", "″", "°"},    // length/angle
             {"", "g", "g", "slug", "slug"}, // mass
             {"", "s", "s", "s", "s"},       // time
             {"", "K", "K", "°F", "°F"},     // temperature

--- a/src/controllers/hid/hidreportdescriptor.cpp
+++ b/src/controllers/hid/hidreportdescriptor.cpp
@@ -1,0 +1,541 @@
+#include "controllers/hid/hidreportdescriptor.h"
+
+#include <algorithm>
+#include <cstdint>
+
+#include "moc_hidreportdescriptor.cpp"
+#include "util/assert.h"
+
+namespace hid::reportDescriptor {
+
+/// Extracts the value of the specified control in logical scale,
+/// from the given report data
+int32_t extractLogicalValue(const QByteArray& reportData, const Control& control) {
+    VERIFY_OR_DEBUG_ASSERT(control.m_bitSize > 0 && control.m_bitSize <= 32) {
+        return control.m_logicalMinimum; // Safe value in allowed range
+    }
+
+    uint8_t numberOfBytesToCopy = ((control.m_bitPosition + control.m_bitSize - 1) / 8) + 1;
+
+    int64_t value = 0;
+    std::memcpy(&value, reportData.data() + control.m_bytePosition, numberOfBytesToCopy);
+
+    value >>= control.m_bitPosition;
+
+    bool isSigned = control.m_logicalMinimum < 0;
+    // Mask out the bits that are not part of the control
+    if (isSigned) {
+        bool isNegative = value & (1ULL << (control.m_bitSize - 1));
+        value &= (1ULL << (control.m_bitSize - 1)) - 1;
+        if (isNegative) {
+            value = ((1ULL << (control.m_bitSize - 1)) - value) * -1;
+        }
+    } else {
+        value &= (1ULL << control.m_bitSize) - 1;
+    }
+
+    return value;
+}
+
+/// Sets the bits in the report data of the specified control,
+/// to the given value in logical scale
+bool applyLogicalValue(QByteArray& reportData, const Control& control, int32_t controlValue) {
+    VERIFY_OR_DEBUG_ASSERT(control.m_bitSize > 0 && control.m_bitSize <= 32) {
+        return false;
+    }
+
+    if (control.m_flags.no_null_null) {
+        // Nullable controls allow any possible value in the bitrange
+        if (control.m_logicalMinimum < 0) {
+            if (controlValue < -std::pow(2, control.m_bitSize - 1) ||
+                    controlValue > std::pow(2, control.m_bitSize - 1) - 1) {
+                return false;
+            }
+        } else {
+            if (controlValue < 0 || controlValue > std::pow(2, control.m_bitSize)) {
+                return false;
+            }
+        }
+    } else {
+        // Non-Nullable controls only allow values in the logical range
+        if (controlValue < control.m_logicalMinimum || controlValue > control.m_logicalMaximum) {
+            return false;
+        }
+    }
+
+    uint64_t mask = ((1ULL << control.m_bitSize) - 1) << control.m_bitPosition;
+    uint64_t value = (static_cast<uint64_t>(controlValue) << control.m_bitPosition) & mask;
+
+    // Check if the value fits into the data (position + bitSize)
+    uint8_t lastByteToCopy = control.m_bytePosition +
+            (control.m_bitPosition + control.m_bitSize - 1) / 8;
+
+    if (lastByteToCopy >= reportData.size()) {
+        return false;
+    }
+
+    for (uint8_t byteIdx = control.m_bytePosition; byteIdx <= lastByteToCopy; ++byteIdx) {
+        // Clear the bits that are part of the control
+        reportData[byteIdx] &= ~static_cast<uint8_t>(mask & 0xFF);
+        // Set the new value
+        reportData[byteIdx] |= static_cast<uint8_t>(value & 0xFF);
+        mask >>= 8;
+        value >>= 8;
+    }
+
+    return true;
+}
+
+QString getScaledUnitString(uint32_t unit) {
+    struct UnitInfo {
+        const char* physicalQuantity[5];
+    };
+
+    const UnitInfo unitInfos[] = {
+            {"", "cm", "radian", "inch", "degree"},
+            {"", "g", "g", "slug", "slug"}, // mass
+            {"", "s", "s", "s", "s"},       // time
+            {"", "K", "K", "°F", "°F"},     // temperature
+            {"", "A", "A", "A", "A"},       // current
+            {"", "cd", "cd", "cd", "cd"}    // luminous intensity
+    };
+
+    int8_t exponents[] = {0, 1, 2, 3, 4, 5, 6, 7, -8, -7, -6, -5, -4, -3, -2, -1};
+
+    QString unitString;
+
+    auto appendQuantity = [&](int shift, const UnitInfo& unitInfo) {
+        int8_t value = (unit >> shift) & 0xF;
+        if (value != 0) {
+            if (!unitString.isEmpty()) {
+                unitString += "*";
+            }
+            unitString += unitInfo.physicalQuantity[(unit & 0xF)];
+            if (exponents[value] != 1) {
+                unitString += "^" + QString::number(exponents[value]);
+            }
+        }
+    };
+
+    for (int quantityIdx = 0; quantityIdx < 6; ++quantityIdx) {
+        appendQuantity(4 + quantityIdx * 4, unitInfos[quantityIdx]);
+    }
+
+    return unitString;
+}
+
+// Class for Controls
+
+Control::Control(const ControlFlags flags,
+        const uint32_t usage,
+        const int32_t logicalMinimum,
+        const int32_t logicalMaximum,
+        const int32_t physicalMinimum,
+        const int32_t physicalMaximum,
+        const int8_t unitExponent,
+        const uint32_t unit,
+        const uint16_t bytePosition,
+        const uint8_t bitPosition,
+        const uint8_t bitSize)
+        : m_flags(flags),
+          m_usage(usage),
+          m_logicalMinimum(logicalMinimum),
+          m_logicalMaximum(logicalMaximum),
+          m_physicalMinimum(physicalMinimum),
+          m_physicalMaximum(physicalMaximum),
+          m_unitExponent(unitExponent),
+          m_unit(unit),
+          m_bytePosition(bytePosition),
+          m_bitPosition(bitPosition),
+          m_bitSize(bitSize) {
+}
+
+Report::Report(const HidReportType& reportType, const uint8_t& reportId)
+        : m_reportType(reportType),
+          m_reportId(reportId),
+          m_lastBytePosition(0),
+          m_lastBitPosition(0) {
+}
+
+void Report::addControl(const Control& item) {
+    m_controls.push_back(item);
+}
+
+void Report::increasePosition(unsigned int bitSize) {
+    // Calculate the new bit position
+    m_lastBitPosition += bitSize;
+
+    // If the bit position exceeds 8 bits, adjust the byte position
+    m_lastBytePosition += m_lastBitPosition / 8;
+    m_lastBitPosition %= 8;
+}
+
+// Class for Collections
+void Collection::addReport(const Report& report) {
+    m_reports.push_back(report);
+}
+const Report* Collection::getReport(
+        const HidReportType& reportType, const uint8_t& reportId) const {
+    for (auto& report : m_reports) {
+        if (report.m_reportType == reportType && report.m_reportId == reportId) {
+            return &report;
+        }
+    }
+    return nullptr;
+}
+
+// HID Report Descriptor Parser
+HIDReportDescriptor::HIDReportDescriptor(const uint8_t* data, size_t length)
+        : m_data(data),
+          m_length(length),
+          m_pos(0),
+          m_deviceHasReportIds(kNotSet),
+          m_collectionLevel(0) {
+}
+
+std::pair<HidItemTag, HidItemSize> HIDReportDescriptor::readTag() {
+    uint8_t byte = m_data[m_pos++];
+
+    VERIFY_OR_DEBUG_ASSERT(byte !=
+            static_cast<uint8_t>(HidItemSize::LongItemKeyword)){
+            // Long items are only reserved for future use, they can't be used
+            // according to HID class definition 1.11
+    };
+
+    HidItemTag tag = static_cast<HidItemTag>(
+            byte & static_cast<uint8_t>(HidItemTag::AllTagBitsMask));
+    HidItemSize size = static_cast<HidItemSize>(
+            byte & static_cast<uint8_t>(HidItemSize::AllSizeBitsMask));
+
+    return {tag, size};
+}
+
+uint32_t HIDReportDescriptor::readPayload(HidItemSize payloadSize) {
+    uint32_t payload;
+
+    switch (payloadSize) {
+    case HidItemSize::ZeroBytePayload:
+        return 0;
+    case HidItemSize::OneBytePayload:
+        VERIFY_OR_DEBUG_ASSERT(m_pos + 1 <= m_length) {
+            return 0;
+        }
+        return m_data[m_pos++];
+    case HidItemSize::TwoBytePayload:
+        VERIFY_OR_DEBUG_ASSERT(m_pos + 2 <= m_length) {
+            return 0;
+        }
+        payload = m_data[m_pos++];
+        payload |= m_data[m_pos++] << 8;
+        return payload;
+    case HidItemSize::FourBytePayload:
+        VERIFY_OR_DEBUG_ASSERT(m_pos + 4 <= m_length) {
+            return 0;
+        }
+        payload = m_data[m_pos++];
+        payload |= m_data[m_pos++] << 8;
+        payload |= m_data[m_pos++] << 16;
+        payload |= m_data[m_pos++] << 24;
+        return payload;
+    default:
+        DEBUG_ASSERT(true);
+        return 0;
+    }
+}
+
+int32_t HIDReportDescriptor::getSignedValue(uint32_t payload, HidItemSize payloadSize) {
+    switch (payloadSize) {
+    case HidItemSize::ZeroBytePayload:
+        return 0;
+    case HidItemSize::OneBytePayload:
+        if (payload & 0x80) {                                  // Check if the sign bit is set
+            return static_cast<int32_t>(payload | 0xFFFFFF00); // Sign extend to 32 bits
+        }
+        return static_cast<int32_t>(payload);
+    case HidItemSize::TwoBytePayload:
+        if (payload & 0x8000) {                                // Check if the sign bit is set
+            return static_cast<int32_t>(payload | 0xFFFF0000); // Sign extend to 32 bits
+        }
+        return static_cast<int32_t>(payload);
+    case HidItemSize::FourBytePayload:
+        return static_cast<int32_t>(payload); // Already 32 bits, no need to sign extend
+    default:
+        DEBUG_ASSERT(true);
+        return 0;
+    }
+}
+
+uint32_t HIDReportDescriptor::getDecodedUsage(
+        uint16_t usagePage, uint32_t usage, HidItemSize usageSize) {
+    switch (usageSize) {
+    case HidItemSize::ZeroBytePayload:
+        return usagePage << 16;
+    case HidItemSize::OneBytePayload:
+    case HidItemSize::TwoBytePayload:
+        return (usagePage << 16) + usage;
+    case HidItemSize::FourBytePayload:
+        return usage; // Full 32bit usage superseds Usage Page
+    default:
+        DEBUG_ASSERT(true);
+        return usagePage << 16;
+    }
+}
+
+HidReportType HIDReportDescriptor::getReportType(HidItemTag tag) {
+    switch (tag) {
+    case HidItemTag::Input:
+        return HidReportType::Input;
+    case HidItemTag::Output:
+        return HidReportType::Output;
+        break;
+    case HidItemTag::Feature:
+        return HidReportType::Feature;
+    default:
+        DEBUG_ASSERT(true);
+        return HidReportType::Input; // Dummy value for error case
+    }
+}
+
+Collection HIDReportDescriptor::parse() {
+    Collection collection;                           // Top level collection
+    std::unique_ptr<Report> currentReport = nullptr; // Use a unique_ptr for currentReport
+
+    // Global item values
+    GlobalItems globalItems;
+
+    // Local item values
+    LocalItems localItems;
+
+    while (m_pos < m_length) {
+        auto [tag, size] = readTag();
+        auto payload = readPayload(size);
+
+        switch (tag) {
+        // Global Items
+        case HidItemTag::UsagePage:
+            globalItems.usagePage = payload;
+            break;
+        case HidItemTag::LogicalMinimum:
+            globalItems.logicalMinimum = getSignedValue(payload, size);
+            break;
+        case HidItemTag::LogicalMaximum:
+            globalItems.logicalMaximum = getSignedValue(payload, size);
+            break;
+        case HidItemTag::PhysicalMinimum:
+            globalItems.physicalMinimum = getSignedValue(payload, size);
+            break;
+        case HidItemTag::PhysicalMaximum:
+            globalItems.physicalMaximum = getSignedValue(payload, size);
+            break;
+        case HidItemTag::UnitExponent:
+            // HID class definition restricts the unit exponent range to -8 to +7
+            globalItems.unitExponent = static_cast<int8_t>(payload & 0x0F);
+            if (globalItems.unitExponent >= 8) {
+                globalItems.unitExponent -= 16;
+            }
+            break;
+        case HidItemTag::Unit:
+            globalItems.unit = payload;
+            break;
+        case HidItemTag::ReportSize:
+            globalItems.reportSize = payload;
+            break;
+        case HidItemTag::ReportId:
+            globalItems.reportId = static_cast<uint8_t>(payload);
+            break;
+        case HidItemTag::ReportCount:
+            globalItems.reportCount = payload;
+            break;
+        case HidItemTag::Push:
+            // Places a copy of the global item state table on the stack
+            globalItemsStack.push_back(globalItems);
+            break;
+        case HidItemTag::Pop:
+            // Replaces the item state table with the top structure from the stack
+            VERIFY_OR_DEBUG_ASSERT(!globalItemsStack.empty()) {
+                globalItems = globalItemsStack.back();
+                globalItemsStack.pop_back();
+            }
+            break;
+
+        // Local Items
+        case HidItemTag::Usage:
+            localItems.Usage.push_back(getDecodedUsage(globalItems.usagePage, payload, size));
+            break;
+        case HidItemTag::UsageMinimum:
+            localItems.UsageMinimum = getDecodedUsage(globalItems.usagePage, payload, size);
+            break;
+        case HidItemTag::UsageMaximum:
+            localItems.UsageMaximum = getDecodedUsage(globalItems.usagePage, payload, size);
+            break;
+        case HidItemTag::DesignatorIndex:
+            localItems.DesignatorIndex = payload;
+            break;
+        case HidItemTag::DesignatorMinimum:
+            localItems.DesignatorMinimum = payload;
+            break;
+        case HidItemTag::DesignatorMaximum:
+            localItems.DesignatorMaximum = payload;
+            break;
+        case HidItemTag::StringIndex:
+            localItems.StringIndex = payload;
+            break;
+        case HidItemTag::StringMinimum:
+            localItems.StringMinimum = payload;
+            break;
+        case HidItemTag::StringMaximum:
+            localItems.StringMaximum = payload;
+            break;
+        case HidItemTag::Delimiter:
+            localItems.Delimiter = payload;
+            break;
+
+        // Main Items
+        case HidItemTag::Input:
+        case HidItemTag::Output:
+        case HidItemTag::Feature: {
+            if (currentReport == nullptr) {
+                // First control of this device
+                if (globalItems.reportId == kNoReportId) {
+                    m_deviceHasReportIds = false;
+                } else {
+                    m_deviceHasReportIds = true;
+                }
+                currentReport = std::make_unique<Report>(getReportType(tag), globalItems.reportId);
+            } else if (currentReport->m_reportType != getReportType(tag) ||
+                    globalItems.reportId != currentReport->m_reportId) {
+                // First control of a new report
+                collection.addReport(*currentReport);
+                currentReport = std::make_unique<Report>(getReportType(tag), globalItems.reportId);
+            }
+
+            int32_t physicalMinimum, physicalMaximum;
+            if (globalItems.physicalMinimum == 0 && globalItems.physicalMaximum == 0) {
+                // According remark in chapter 6.2.2.7 of HID class definition 1.11
+                physicalMinimum = globalItems.logicalMinimum;
+                physicalMaximum = globalItems.logicalMaximum;
+            } else {
+                physicalMinimum = globalItems.physicalMinimum;
+                physicalMaximum = globalItems.physicalMaximum;
+            }
+
+            ControlFlags flags;
+            flags.payload = payload;
+
+            if (flags.data_constant == 1) {
+                // Constant value padding - Usually for byte alignment
+                currentReport->increasePosition(globalItems.reportSize * globalItems.reportCount);
+            } else if (flags.array_variable == 0) {
+                // Array (e.g. list of pressed keys of a computer keyboard)
+                // NOT IMPLEMENTED as not relevant for mapping wizard,
+                // but could be implemented by overloaded Control class
+                currentReport->increasePosition(globalItems.reportSize * globalItems.reportCount);
+            } else {
+                // Normal variable control
+                uint32_t usage = 0;
+                unsigned int numOfControls =
+                        (localItems.UsageMinimum != kNotSet &&
+                                localItems.UsageMaximum != kNotSet)
+                        ? localItems.UsageMaximum - localItems.UsageMinimum + 1
+                        : globalItems.reportCount;
+                for (unsigned int controlIdx = 0;
+                        controlIdx < numOfControls;
+                        controlIdx++) {
+                    if (localItems.UsageMinimum != kNotSet && localItems.UsageMaximum != kNotSet) {
+                        if (controlIdx == 0) {
+                            usage = localItems.UsageMinimum;
+                        } else if (usage < localItems.UsageMaximum) {
+                            usage++;
+                        }
+                    } else if (!localItems.Usage.empty()) {
+                        // If there are less usages than reportCount,
+                        // the last usage value is valid for the remaining
+                        usage = localItems.Usage.front();
+                        localItems.Usage.erase(localItems.Usage.begin());
+                    }
+                    auto [lastBytePos, lastBitPos] = currentReport->getLastPosition();
+
+                    Control control(flags,
+                            usage,
+                            globalItems.logicalMinimum,
+                            globalItems.logicalMaximum,
+                            physicalMinimum,
+                            physicalMaximum,
+                            globalItems.unitExponent,
+                            globalItems.unit,
+                            lastBytePos,
+                            lastBitPos,
+                            globalItems.reportSize);
+                    currentReport->addControl(control);
+                    currentReport->increasePosition(globalItems.reportSize);
+                }
+                currentReport->increasePosition(
+                        (globalItems.reportCount - numOfControls) *
+                        globalItems.reportSize);
+            }
+
+            localItems = LocalItems();
+            break;
+        }
+
+        case HidItemTag::Collection:
+            m_collectionLevel++;
+
+            // We only handle top-level-collections
+            // according to chapter 8.4 "Report Constraints" HID class definition 1.11
+            if (m_collectionLevel == 1) {
+                DEBUG_ASSERT(payload == static_cast<uint32_t>(CollectionType::Application));
+            }
+            // Local items are only valid for the actual control definition, reset them
+            localItems = LocalItems();
+            break;
+        case HidItemTag::EndCollection:
+            if (m_collectionLevel == 1) {
+                if (currentReport) {
+                    collection.addReport(*currentReport);
+                    currentReport.reset();
+                }
+                m_topLevelCollections.push_back(collection);
+                collection = Collection();
+            }
+            if (m_collectionLevel > 0) {
+                m_collectionLevel--;
+            }
+            break;
+
+        default:
+            DEBUG_ASSERT(true);
+            break;
+        }
+    }
+
+    if (currentReport) {
+        collection.addReport(*currentReport);
+    }
+
+    return collection;
+}
+
+const Report* HIDReportDescriptor::getReport(
+        const HidReportType& reportType, const uint8_t& reportId) const {
+    for (auto& collection : m_topLevelCollections) {
+        const Report* report = collection.getReport(reportType, reportId);
+        if (report != nullptr) {
+            return report;
+        }
+    }
+    return nullptr;
+}
+
+const std::vector<std::tuple<size_t, HidReportType, uint8_t>>
+HIDReportDescriptor::getListOfReports() const {
+    std::vector<std::tuple<size_t, HidReportType, uint8_t>> orderedList;
+    for (size_t i = 0; i < m_topLevelCollections.size(); ++i) {
+        for (const auto& report : m_topLevelCollections[i].getReports()) {
+            orderedList.emplace_back(i, report.m_reportType, report.m_reportId);
+        }
+    }
+    return orderedList;
+}
+
+} // namespace hid::reportDescriptor

--- a/src/controllers/hid/hidreportdescriptor.cpp
+++ b/src/controllers/hid/hidreportdescriptor.cpp
@@ -453,7 +453,6 @@ Collection HIDReportDescriptor::parse() {
                         usage = localItems.Usage.front();
                         localItems.Usage.erase(localItems.Usage.begin());
                     }
-                    auto [lastBytePos, lastBitPos] = pCurrentReport->getLastPosition();
 
                     Control control(flags,
                             usage,
@@ -463,8 +462,8 @@ Collection HIDReportDescriptor::parse() {
                             physicalMaximum,
                             globalItems.unitExponent,
                             globalItems.unit,
-                            lastBytePos,
-                            lastBitPos,
+                            pCurrentReport->getLastBytePosition(),
+                            pCurrentReport->getLastBitPosition(),
                             globalItems.reportSize);
                     pCurrentReport->addControl(control);
                     pCurrentReport->increasePosition(globalItems.reportSize);

--- a/src/controllers/hid/hidreportdescriptor.cpp
+++ b/src/controllers/hid/hidreportdescriptor.cpp
@@ -188,7 +188,7 @@ const Report* Collection::getReport(
 }
 
 // HID Report Descriptor Parser
-HIDReportDescriptor::HIDReportDescriptor(const uint8_t* pData, size_t length)
+HidReportDescriptor::HidReportDescriptor(const uint8_t* pData, size_t length)
         : m_pData(pData),
           m_length(length),
           m_pos(0),
@@ -196,7 +196,7 @@ HIDReportDescriptor::HIDReportDescriptor(const uint8_t* pData, size_t length)
           m_collectionLevel(0) {
 }
 
-std::pair<HidItemTag, HidItemSize> HIDReportDescriptor::readTag() {
+std::pair<HidItemTag, HidItemSize> HidReportDescriptor::readTag() {
     uint8_t byte = m_pData[m_pos++];
 
     VERIFY_OR_DEBUG_ASSERT(byte !=
@@ -213,7 +213,7 @@ std::pair<HidItemTag, HidItemSize> HIDReportDescriptor::readTag() {
     return {tag, size};
 }
 
-uint32_t HIDReportDescriptor::readPayload(HidItemSize payloadSize) {
+uint32_t HidReportDescriptor::readPayload(HidItemSize payloadSize) {
     uint32_t payload;
 
     switch (payloadSize) {
@@ -246,7 +246,7 @@ uint32_t HIDReportDescriptor::readPayload(HidItemSize payloadSize) {
     }
 }
 
-int32_t HIDReportDescriptor::getSignedValue(uint32_t payload, HidItemSize payloadSize) {
+int32_t HidReportDescriptor::getSignedValue(uint32_t payload, HidItemSize payloadSize) {
     switch (payloadSize) {
     case HidItemSize::ZeroBytePayload:
         return 0;
@@ -268,7 +268,7 @@ int32_t HIDReportDescriptor::getSignedValue(uint32_t payload, HidItemSize payloa
     }
 }
 
-uint32_t HIDReportDescriptor::getDecodedUsage(
+uint32_t HidReportDescriptor::getDecodedUsage(
         uint16_t usagePage, uint32_t usage, HidItemSize usageSize) {
     switch (usageSize) {
     case HidItemSize::ZeroBytePayload:
@@ -284,7 +284,7 @@ uint32_t HIDReportDescriptor::getDecodedUsage(
     }
 }
 
-HidReportType HIDReportDescriptor::getReportType(HidItemTag tag) {
+HidReportType HidReportDescriptor::getReportType(HidItemTag tag) {
     switch (tag) {
     case HidItemTag::Input:
         return HidReportType::Input;
@@ -299,7 +299,7 @@ HidReportType HIDReportDescriptor::getReportType(HidItemTag tag) {
     }
 }
 
-Collection HIDReportDescriptor::parse() {
+Collection HidReportDescriptor::parse() {
     Collection collection;                            // Top level collection
     std::unique_ptr<Report> pCurrentReport = nullptr; // Use a unique_ptr for pCurrentReport
 
@@ -518,7 +518,7 @@ Collection HIDReportDescriptor::parse() {
     return collection;
 }
 
-const Report* HIDReportDescriptor::getReport(
+const Report* HidReportDescriptor::getReport(
         const HidReportType& reportType, const uint8_t& reportId) const {
     for (const auto& collection : m_topLevelCollections) {
         const Report* report = collection.getReport(reportType, reportId);
@@ -530,7 +530,7 @@ const Report* HIDReportDescriptor::getReport(
 }
 
 const std::vector<std::tuple<size_t, HidReportType, uint8_t>>
-HIDReportDescriptor::getListOfReports() const {
+HidReportDescriptor::getListOfReports() const {
     std::vector<std::tuple<size_t, HidReportType, uint8_t>> orderedList;
     for (size_t i = 0; i < m_topLevelCollections.size(); ++i) {
         for (const auto& report : m_topLevelCollections[i].getReports()) {

--- a/src/controllers/hid/hidreportdescriptor.cpp
+++ b/src/controllers/hid/hidreportdescriptor.cpp
@@ -179,7 +179,7 @@ void Collection::addReport(const Report& report) {
 }
 const Report* Collection::getReport(
         const HidReportType& reportType, const uint8_t& reportId) const {
-    for (auto& report : m_reports) {
+    for (const auto& report : m_reports) {
         if (report.m_reportType == reportType && report.m_reportId == reportId) {
             return &report;
         }
@@ -520,7 +520,7 @@ Collection HIDReportDescriptor::parse() {
 
 const Report* HIDReportDescriptor::getReport(
         const HidReportType& reportType, const uint8_t& reportId) const {
-    for (auto& collection : m_topLevelCollections) {
+    for (const auto& collection : m_topLevelCollections) {
         const Report* report = collection.getReport(reportType, reportId);
         if (report != nullptr) {
             return report;

--- a/src/controllers/hid/hidreportdescriptor.h
+++ b/src/controllers/hid/hidreportdescriptor.h
@@ -4,6 +4,7 @@
 
 #include <QMetaType>
 #include <QString>
+#include <cstddef>
 #include <cstdint>
 #include <vector>
 
@@ -11,7 +12,7 @@ namespace hid::reportDescriptor {
 
 Q_NAMESPACE
 
-QString getScaledUnitString(uint32_t unit);
+QString getScaledUnitString(std::uint32_t unit);
 
 constexpr int kNotSet = -1;
 // Value used instead of the ReportID, if device don't have ReportIDs
@@ -26,7 +27,7 @@ Q_ENUM_NS(HidReportType)
 
 // clang-format off
 // Enum class for HID Item Tags (incl. the two type bits)
-enum class HidItemTag : uint8_t {
+enum class HidItemTag : std::uint8_t {
     // "Main Items" according to chapter 6.2.2.4 of HID class definition 1.11
     Input             = 0b1000'00'00,
     Output            = 0b1001'00'00,
@@ -73,7 +74,7 @@ enum class HidItemTag : uint8_t {
 };
 
 // Enum class for HID Item Sizes
-enum class HidItemSize : uint8_t {
+enum class HidItemSize : std::uint8_t {
     // "Short Items" sizes according to chapter 6.2.2.2 of HID class definition 1.11
     ZeroBytePayload   = 0b0000'00'00,
     OneBytePayload    = 0b0000'00'01,
@@ -88,7 +89,7 @@ enum class HidItemSize : uint8_t {
 };
 
 // Collection types according to chapter 6.2.2.6 of HID class definition 1.11
-enum class CollectionType : uint8_t {
+enum class CollectionType : std::uint8_t {
     Physical      = 0x00, // e.g. group of axes
     Application   = 0x01, // e.g. mouse or keyboard
     Logical       = 0x02, // interrelated data
@@ -102,63 +103,63 @@ enum class CollectionType : uint8_t {
 // clang-format on
 
 struct ControlFlags {
-    uint32_t data_constant : 1;          // Data (0) | Constant (1)
-    uint32_t array_variable : 1;         // Array (0) | Variable (1)
-    uint32_t absolute_relative : 1;      // Absolute (0) | Relative (1)
-    uint32_t no_wrap_wrap : 1;           // No Wrap (0) | Wrap (1)
-    uint32_t linear_non_linear : 1;      // Linear (0) | Non Linear (1)
-    uint32_t preferred_no_preferred : 1; // Preferred State (0) | No Preferred (1)
-    uint32_t no_null_null : 1;           // No Null position (0) | Null state(1)
-    uint32_t non_volatile_volatile : 1;  // Non Volatile (0) | Volatile (1)
-    uint32_t bit_field_buffered : 1;     // Bit Field (0) | Buffered Bytes (1)
-    uint32_t reserved : 23;
+    std::uint32_t data_constant : 1;          // Data (0) | Constant (1)
+    std::uint32_t array_variable : 1;         // Array (0) | Variable (1)
+    std::uint32_t absolute_relative : 1;      // Absolute (0) | Relative (1)
+    std::uint32_t no_wrap_wrap : 1;           // No Wrap (0) | Wrap (1)
+    std::uint32_t linear_non_linear : 1;      // Linear (0) | Non Linear (1)
+    std::uint32_t preferred_no_preferred : 1; // Preferred State (0) | No Preferred (1)
+    std::uint32_t no_null_null : 1;           // No Null position (0) | Null state(1)
+    std::uint32_t non_volatile_volatile : 1;  // Non Volatile (0) | Volatile (1)
+    std::uint32_t bit_field_buffered : 1;     // Bit Field (0) | Buffered Bytes (1)
+    std::uint32_t reserved : 23;
 };
 
 // Class representing a control described in the HID report descriptor
 class Control {
   public:
     Control(const ControlFlags flags,
-            const uint32_t usage,
-            const int32_t logicalMinimum,
-            const int32_t logicalMaximum,
-            const int32_t physicalMinimum,
-            const int32_t physicalMaximum,
-            const int8_t unitExponent,
-            const uint32_t unit,
-            const uint16_t bytePosition, // Position of the first byte in the report
-            const uint8_t bitPosition,   // Position of first bit in first byte
-            const uint8_t bitSize);
+            const std::uint32_t usage,
+            const std::int32_t logicalMinimum,
+            const std::int32_t logicalMaximum,
+            const std::int32_t physicalMinimum,
+            const std::int32_t physicalMaximum,
+            const std::int8_t unitExponent,
+            const std::uint32_t unit,
+            const std::uint16_t bytePosition, // Position of the first byte in the report
+            const std::uint8_t bitPosition,   // Position of first bit in first byte
+            const std::uint8_t bitSize);
 
     const ControlFlags m_flags;
 
-    const uint32_t m_usage;
-    const int32_t m_logicalMinimum;
-    const int32_t m_logicalMaximum;
-    const int32_t m_physicalMinimum;
-    const int32_t m_physicalMaximum;
-    const int8_t m_unitExponent;
-    const uint32_t m_unit;
-    const uint16_t m_bytePosition; // Position of the first byte in the report
-    const uint8_t m_bitPosition;   // Position of first bit in first byte
-    const uint8_t m_bitSize;
+    const std::uint32_t m_usage;
+    const std::int32_t m_logicalMinimum;
+    const std::int32_t m_logicalMaximum;
+    const std::int32_t m_physicalMinimum;
+    const std::int32_t m_physicalMaximum;
+    const std::int8_t m_unitExponent;
+    const std::uint32_t m_unit;
+    const std::uint16_t m_bytePosition; // Position of the first byte in the report
+    const std::uint8_t m_bitPosition;   // Position of first bit in first byte
+    const std::uint8_t m_bitSize;
 
   private:
 };
 
-int32_t extractLogicalValue(const QByteArray& data, const Control& control);
-bool applyLogicalValue(QByteArray& data, const Control& control, int32_t controlValue);
+std::int32_t extractLogicalValue(const QByteArray& data, const Control& control);
+bool applyLogicalValue(QByteArray& data, const Control& control, std::int32_t controlValue);
 
 // Class representing a report in the HID report descriptor
 class Report {
   public:
-    Report(const HidReportType& reportType, const uint8_t& reportId);
+    Report(const HidReportType& reportType, const std::uint8_t& reportId);
 
     void addControl(const Control& item);
     void increasePosition(unsigned int bitSize);
-    uint16_t getLastBytePosition() const {
+    std::uint16_t getLastBytePosition() const {
         return m_lastBytePosition;
     }
-    uint8_t getLastBitPosition() const {
+    std::uint8_t getLastBitPosition() const {
         return m_lastBitPosition;
     }
 
@@ -167,15 +168,15 @@ class Report {
     }
 
     const HidReportType m_reportType;
-    const uint8_t m_reportId;
-    uint16_t getReportSize() const {
+    const std::uint8_t m_reportId;
+    std::uint16_t getReportSize() const {
         return m_lastBytePosition;
     }
 
   private:
     std::vector<Control> m_controls;
-    uint16_t m_lastBytePosition;
-    uint8_t m_lastBitPosition; // Last bit position inside last byte
+    std::uint16_t m_lastBytePosition;
+    std::uint8_t m_lastBitPosition; // Last bit position inside last byte
 };
 
 // Class representing a collection of HID items
@@ -183,7 +184,7 @@ class Collection {
   public:
     Collection() = default;
     void addReport(const Report& report);
-    const Report* getReport(const HidReportType& reportType, const uint8_t& reportId) const;
+    const Report* getReport(const HidReportType& reportType, const std::uint8_t& reportId) const;
     const std::vector<Report>& getReports() const {
         return m_reports;
     }
@@ -195,55 +196,58 @@ class Collection {
 // Class for parsing HID report descriptors
 class HidReportDescriptor {
   public:
-    HidReportDescriptor(const uint8_t* pData, size_t length);
+    HidReportDescriptor(const std::uint8_t* pData, std::size_t length);
 
     bool isDeviceWithReportIds() const {
         return m_deviceHasReportIds;
     }
 
     Collection parse();
-    const Report* getReport(const HidReportType& reportType, const uint8_t& reportId) const;
-    const std::vector<std::tuple<size_t, HidReportType, uint8_t>> getListOfReports() const;
+    const Report* getReport(const HidReportType& reportType, const std::uint8_t& reportId) const;
+    const std::vector<std::tuple<std::size_t, HidReportType, std::uint8_t>>
+    getListOfReports() const;
 
   private:
     // Define the struct for global items
     struct GlobalItems {
-        int32_t logicalMinimum = 0;
-        int32_t logicalMaximum = 0;
-        int32_t physicalMinimum = 0;
-        int32_t physicalMaximum = 0;
-        uint32_t reportSize = 0;
-        uint32_t reportCount = 0;
-        uint32_t unit = 0;
-        int8_t unitExponent = 0;
-        uint8_t reportId = 0;
-        uint16_t usagePage = 0;
+        std::int32_t logicalMinimum = 0;
+        std::int32_t logicalMaximum = 0;
+        std::int32_t physicalMinimum = 0;
+        std::int32_t physicalMaximum = 0;
+        std::uint32_t reportSize = 0;
+        std::uint32_t reportCount = 0;
+        std::uint32_t unit = 0;
+        std::int8_t unitExponent = 0;
+        std::uint8_t reportId = 0;
+        std::uint16_t usagePage = 0;
     };
 
     struct LocalItems {
-        std::vector<int64_t> Usage;
-        int64_t UsageMinimum = kNotSet;
-        int64_t UsageMaximum = kNotSet;
-        int64_t DesignatorIndex = kNotSet;
-        int64_t DesignatorMinimum = kNotSet;
-        int64_t DesignatorMaximum = kNotSet;
-        int64_t StringIndex = kNotSet;
-        int64_t StringMinimum = kNotSet;
-        int64_t StringMaximum = kNotSet;
-        int64_t Delimiter = kNotSet;
+        std::vector<std::int64_t> Usage;
+        std::int64_t UsageMinimum = kNotSet;
+        std::int64_t UsageMaximum = kNotSet;
+        std::int64_t DesignatorIndex = kNotSet;
+        std::int64_t DesignatorMinimum = kNotSet;
+        std::int64_t DesignatorMaximum = kNotSet;
+        std::int64_t StringIndex = kNotSet;
+        std::int64_t StringMinimum = kNotSet;
+        std::int64_t StringMaximum = kNotSet;
+        std::int64_t Delimiter = kNotSet;
     };
 
     std::pair<HidItemTag, HidItemSize> readTag();
-    uint32_t readPayload(HidItemSize payloadSize);
+    std::uint32_t readPayload(HidItemSize payloadSize);
 
-    int32_t getSignedValue(uint32_t payload, HidItemSize payloadSize);
-    uint32_t getDecodedUsage(uint16_t usagePage, uint32_t usage, HidItemSize usageSize);
+    std::int32_t getSignedValue(std::uint32_t payload, HidItemSize payloadSize);
+    std::uint32_t getDecodedUsage(std::uint16_t usagePage,
+            std::uint32_t usage,
+            HidItemSize usageSize);
 
     HidReportType getReportType(HidItemTag tag);
 
-    const uint8_t* m_pData;
-    size_t m_length;
-    size_t m_pos;
+    const std::uint8_t* m_pData;
+    std::size_t m_length;
+    std::size_t m_pos;
 
     bool m_deviceHasReportIds;
 

--- a/src/controllers/hid/hidreportdescriptor.h
+++ b/src/controllers/hid/hidreportdescriptor.h
@@ -195,7 +195,7 @@ class Collection {
 // Class for parsing HID report descriptors
 class HIDReportDescriptor {
   public:
-    HIDReportDescriptor(const uint8_t* data, size_t length);
+    HIDReportDescriptor(const uint8_t* pData, size_t length);
 
     bool isDeviceWithReportIds() const {
         return m_deviceHasReportIds;
@@ -241,7 +241,7 @@ class HIDReportDescriptor {
 
     HidReportType getReportType(HidItemTag tag);
 
-    const uint8_t* m_data;
+    const uint8_t* m_pData;
     size_t m_length;
     size_t m_pos;
 

--- a/src/controllers/hid/hidreportdescriptor.h
+++ b/src/controllers/hid/hidreportdescriptor.h
@@ -101,20 +101,17 @@ enum class CollectionType : uint8_t {
 };
 // clang-format on
 
-union ControlFlags {
-    struct {
-        uint32_t data_constant : 1;          // Data (0) | Constant (1)
-        uint32_t array_variable : 1;         // Array (0) | Variable (1)
-        uint32_t absolute_relative : 1;      // Absolute (0) | Relative (1)
-        uint32_t no_wrap_wrap : 1;           // No Wrap (0) | Wrap (1)
-        uint32_t linear_non_linear : 1;      // Linear (0) | Non Linear (1)
-        uint32_t preferred_no_preferred : 1; // Preferred State (0) | No Preferred (1)
-        uint32_t no_null_null : 1;           // No Null position (0) | Null state(1)
-        uint32_t non_volatile_volatile : 1;  // Non Volatile (0) | Volatile (1)
-        uint32_t bit_field_buffered : 1;     // Bit Field (0) | Buffered Bytes (1)
-        uint32_t reserved : 23;
-    };
-    uint32_t payload;
+struct ControlFlags {
+    uint32_t data_constant : 1;          // Data (0) | Constant (1)
+    uint32_t array_variable : 1;         // Array (0) | Variable (1)
+    uint32_t absolute_relative : 1;      // Absolute (0) | Relative (1)
+    uint32_t no_wrap_wrap : 1;           // No Wrap (0) | Wrap (1)
+    uint32_t linear_non_linear : 1;      // Linear (0) | Non Linear (1)
+    uint32_t preferred_no_preferred : 1; // Preferred State (0) | No Preferred (1)
+    uint32_t no_null_null : 1;           // No Null position (0) | Null state(1)
+    uint32_t non_volatile_volatile : 1;  // Non Volatile (0) | Volatile (1)
+    uint32_t bit_field_buffered : 1;     // Bit Field (0) | Buffered Bytes (1)
+    uint32_t reserved : 23;
 };
 
 // Class representing a control described in the HID report descriptor

--- a/src/controllers/hid/hidreportdescriptor.h
+++ b/src/controllers/hid/hidreportdescriptor.h
@@ -1,0 +1,258 @@
+#pragma once
+
+#include <qobjectdefs.h>
+
+#include <QMetaType>
+#include <QString>
+#include <cstdint>
+#include <vector>
+
+namespace hid::reportDescriptor {
+
+Q_NAMESPACE
+
+QString getScaledUnitString(uint32_t unit);
+
+constexpr int kNotSet = -1;
+// Value used instead of the ReportID, if device don't have ReportIDs
+constexpr int kNoReportId = 0x00;
+
+enum class HidReportType {
+    Input,
+    Output,
+    Feature
+};
+Q_ENUM_NS(HidReportType)
+
+// clang-format off
+// Enum class for HID Item Tags (incl. the two type bits)
+enum class HidItemTag : uint8_t {
+    // "Main Items" according to chapter 6.2.2.4 of HID class definition 1.11
+    Input             = 0b1000'00'00,
+    Output            = 0b1001'00'00,
+    Feature           = 0b1011'00'00,
+
+    Collection        = 0b1010'00'00,
+    EndCollection     = 0b1100'00'00,
+
+    // "Global Items" according to chapter 6.2.2.7 of HID class definition 1.11
+    UsagePage         = 0b0000'01'00,
+
+    LogicalMinimum    = 0b0001'01'00,
+    LogicalMaximum    = 0b0010'01'00,
+    PhysicalMinimum   = 0b0011'01'00,
+    PhysicalMaximum   = 0b0100'01'00,
+
+    UnitExponent      = 0b0101'01'00,
+    Unit              = 0b0110'01'00,
+
+    ReportSize        = 0b0111'01'00,
+    ReportId          = 0b1000'01'00,
+    ReportCount       = 0b1001'01'00,
+
+    Push              = 0b1010'01'00,
+    Pop               = 0b1011'01'00,
+
+    // "Local Items" according to chapter 6.2.2.8 of HID class definition 1.11
+    Usage             = 0b0000'10'00,
+    UsageMinimum      = 0b0001'10'00,
+    UsageMaximum      = 0b0010'10'00,
+        
+    DesignatorIndex   = 0b0011'10'00,
+    DesignatorMinimum = 0b0100'10'00,
+    DesignatorMaximum = 0b0101'10'00,
+        
+    StringIndex       = 0b0111'10'00,
+    StringMinimum     = 0b1000'10'00,
+    StringMaximum     = 0b1001'10'00,
+        
+    Delimiter         = 0b1010'10'00,
+        
+
+    AllTagBitsMask    = 0b1111'11'00
+};
+
+// Enum class for HID Item Sizes
+enum class HidItemSize : uint8_t {
+    // "Short Items" sizes according to chapter 6.2.2.2 of HID class definition 1.11
+    ZeroBytePayload   = 0b0000'00'00,
+    OneBytePayload    = 0b0000'00'01,
+    TwoBytePayload    = 0b0000'00'10,
+    FourBytePayload   = 0b0000'00'11,
+
+    
+    // Special value for "Long Items" according to chapter 6.2.2.3 of HID class definition 1.11
+    LongItemKeyword   = 0b1111'11'10,
+
+    AllSizeBitsMask   = 0b0000'00'11
+};
+
+// Collection types according to chapter 6.2.2.6 of HID class definition 1.11
+enum class CollectionType : uint8_t {
+    Physical      = 0x00, // e.g. group of axes
+    Application   = 0x01, // e.g. mouse or keyboard
+    Logical       = 0x02, // interrelated data
+    Report        = 0x03,
+    NamedArray    = 0x04,
+    UsageSwitch   = 0x05,
+    UsageModifier = 0x06,
+    Reserved      = 0x07, // range of 0x07-0x7F
+    VendorDefined = 0x80  // range of 0x80-0xFF
+};
+// clang-format on
+
+union ControlFlags {
+    struct {
+        uint32_t data_constant : 1;          // Data (0) | Constant (1)
+        uint32_t array_variable : 1;         // Array (0) | Variable (1)
+        uint32_t absolute_relative : 1;      // Absolute (0) | Relative (1)
+        uint32_t no_wrap_wrap : 1;           // No Wrap (0) | Wrap (1)
+        uint32_t linear_non_linear : 1;      // Linear (0) | Non Linear (1)
+        uint32_t preferred_no_preferred : 1; // Preferred State (0) | No Preferred (1)
+        uint32_t no_null_null : 1;           // No Null position (0) | Null state(1)
+        uint32_t non_volatile_volatile : 1;  // Non Volatile (0) | Volatile (1)
+        uint32_t bit_field_buffered : 1;     // Bit Field (0) | Buffered Bytes (1)
+        uint32_t reserved : 23;
+    };
+    uint32_t payload;
+};
+
+// Class representing a control described in the HID report descriptor
+class Control {
+  public:
+    Control(const ControlFlags flags,
+            const uint32_t usage,
+            const int32_t logicalMinimum,
+            const int32_t logicalMaximum,
+            const int32_t physicalMinimum,
+            const int32_t physicalMaximum,
+            const int8_t unitExponent,
+            const uint32_t unit,
+            const uint16_t bytePosition, // Position of the first byte in the report
+            const uint8_t bitPosition,   // Position of first bit in first byte
+            const uint8_t bitSize);
+
+    const ControlFlags m_flags;
+
+    const uint32_t m_usage;
+    const int32_t m_logicalMinimum;
+    const int32_t m_logicalMaximum;
+    const int32_t m_physicalMinimum;
+    const int32_t m_physicalMaximum;
+    const int8_t m_unitExponent;
+    const uint32_t m_unit;
+    const uint16_t m_bytePosition; // Position of the first byte in the report
+    const uint8_t m_bitPosition;   // Position of first bit in first byte
+    const uint8_t m_bitSize;
+
+  private:
+};
+
+int32_t extractLogicalValue(const QByteArray& data, const Control& control);
+bool applyLogicalValue(QByteArray& data, const Control& control, int32_t controlValue);
+
+// Class representing a report in the HID report descriptor
+class Report {
+  public:
+    Report(const HidReportType& reportType, const uint8_t& reportId);
+
+    void addControl(const Control& item);
+    void increasePosition(unsigned int bitSize);
+    std::pair<uint16_t, uint8_t> getLastPosition() const {
+        return {m_lastBytePosition, m_lastBitPosition};
+    }
+
+    const std::vector<Control>& getControls() const {
+        return m_controls;
+    }
+
+    const HidReportType m_reportType;
+    const uint8_t m_reportId;
+    uint16_t getReportSize() const {
+        return m_lastBytePosition;
+    }
+
+  private:
+    std::vector<Control> m_controls;
+    uint16_t m_lastBytePosition;
+    uint8_t m_lastBitPosition; // Last bit position inside last byte
+};
+
+// Class representing a collection of HID items
+class Collection {
+  public:
+    Collection() = default;
+    void addReport(const Report& report);
+    const Report* getReport(const HidReportType& reportType, const uint8_t& reportId) const;
+    const std::vector<Report>& getReports() const {
+        return m_reports;
+    }
+
+  private:
+    std::vector<Report> m_reports;
+};
+
+// Class for parsing HID report descriptors
+class HIDReportDescriptor {
+  public:
+    HIDReportDescriptor(const uint8_t* data, size_t length);
+
+    bool isDeviceWithReportIds() const {
+        return m_deviceHasReportIds;
+    }
+
+    Collection parse();
+    const Report* getReport(const HidReportType& reportType, const uint8_t& reportId) const;
+    const std::vector<std::tuple<size_t, HidReportType, uint8_t>> getListOfReports() const;
+
+  private:
+    // Define the struct for global items
+    struct GlobalItems {
+        uint16_t usagePage = 0;
+        int32_t logicalMinimum = 0;
+        int32_t logicalMaximum = 0;
+        int32_t physicalMinimum = 0;
+        int32_t physicalMaximum = 0;
+        int8_t unitExponent = 0;
+        uint32_t unit = 0;
+        uint32_t reportSize = 0;
+        uint8_t reportId = 0;
+        uint32_t reportCount = 0;
+    };
+
+    struct LocalItems {
+        std::vector<int64_t> Usage;
+        int64_t UsageMinimum = kNotSet;
+        int64_t UsageMaximum = kNotSet;
+        int64_t DesignatorIndex = kNotSet;
+        int64_t DesignatorMinimum = kNotSet;
+        int64_t DesignatorMaximum = kNotSet;
+        int64_t StringIndex = kNotSet;
+        int64_t StringMinimum = kNotSet;
+        int64_t StringMaximum = kNotSet;
+        int64_t Delimiter = kNotSet;
+    };
+
+    std::pair<HidItemTag, HidItemSize> readTag();
+    uint32_t readPayload(HidItemSize payloadSize);
+
+    int32_t getSignedValue(uint32_t payload, HidItemSize payloadSize);
+    uint32_t getDecodedUsage(uint16_t usagePage, uint32_t usage, HidItemSize usageSize);
+
+    HidReportType getReportType(HidItemTag tag);
+
+    const uint8_t* m_data;
+    size_t m_length;
+    size_t m_pos;
+
+    bool m_deviceHasReportIds;
+
+    std::vector<GlobalItems> globalItemsStack;
+
+    unsigned int m_collectionLevel;
+    std::vector<Collection> m_topLevelCollections;
+};
+
+} // namespace hid::reportDescriptor
+
+Q_DECLARE_METATYPE(hid::reportDescriptor::Control);

--- a/src/controllers/hid/hidreportdescriptor.h
+++ b/src/controllers/hid/hidreportdescriptor.h
@@ -158,8 +158,11 @@ class Report {
 
     void addControl(const Control& item);
     void increasePosition(unsigned int bitSize);
-    std::pair<uint16_t, uint8_t> getLastPosition() const {
-        return {m_lastBytePosition, m_lastBitPosition};
+    uint16_t getLastBytePosition() const {
+        return m_lastBytePosition;
+    }
+    uint8_t getLastBitPosition() const {
+        return m_lastBitPosition;
     }
 
     const std::vector<Control>& getControls() const {

--- a/src/controllers/hid/hidreportdescriptor.h
+++ b/src/controllers/hid/hidreportdescriptor.h
@@ -193,9 +193,9 @@ class Collection {
 };
 
 // Class for parsing HID report descriptors
-class HIDReportDescriptor {
+class HidReportDescriptor {
   public:
-    HIDReportDescriptor(const uint8_t* pData, size_t length);
+    HidReportDescriptor(const uint8_t* pData, size_t length);
 
     bool isDeviceWithReportIds() const {
         return m_deviceHasReportIds;

--- a/src/controllers/hid/hidreportdescriptor.h
+++ b/src/controllers/hid/hidreportdescriptor.h
@@ -208,16 +208,16 @@ class HidReportDescriptor {
   private:
     // Define the struct for global items
     struct GlobalItems {
-        uint16_t usagePage = 0;
         int32_t logicalMinimum = 0;
         int32_t logicalMaximum = 0;
         int32_t physicalMinimum = 0;
         int32_t physicalMaximum = 0;
-        int8_t unitExponent = 0;
-        uint32_t unit = 0;
         uint32_t reportSize = 0;
-        uint8_t reportId = 0;
         uint32_t reportCount = 0;
+        uint32_t unit = 0;
+        int8_t unitExponent = 0;
+        uint8_t reportId = 0;
+        uint16_t usagePage = 0;
     };
 
     struct LocalItems {

--- a/src/controllers/hid/hidreportdescriptor.h
+++ b/src/controllers/hid/hidreportdescriptor.h
@@ -204,8 +204,7 @@ class HidReportDescriptor {
 
     Collection parse();
     const Report* getReport(const HidReportType& reportType, const std::uint8_t& reportId) const;
-    const std::vector<std::tuple<std::size_t, HidReportType, std::uint8_t>>
-    getListOfReports() const;
+    std::vector<std::tuple<std::size_t, HidReportType, std::uint8_t>> getListOfReports() const;
 
   private:
     // Define the struct for global items

--- a/src/controllers/hid/hidreportdescriptor.h
+++ b/src/controllers/hid/hidreportdescriptor.h
@@ -6,6 +6,8 @@
 #include <QString>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
+#include <optional>
 #include <vector>
 
 namespace hid::reportDescriptor {
@@ -184,7 +186,9 @@ class Collection {
   public:
     Collection() = default;
     void addReport(const Report& report);
-    const Report* getReport(const HidReportType& reportType, const std::uint8_t& reportId) const;
+    std::optional<std::reference_wrapper<const Report>> getReport(
+            const HidReportType& reportType,
+            const std::uint8_t& reportId) const;
     const std::vector<Report>& getReports() const {
         return m_reports;
     }
@@ -203,7 +207,9 @@ class HidReportDescriptor {
     }
 
     Collection parse();
-    const Report* getReport(const HidReportType& reportType, const std::uint8_t& reportId) const;
+    std::optional<std::reference_wrapper<const Report>> getReport(
+            const HidReportType& reportType,
+            const std::uint8_t& reportId) const;
     std::vector<std::tuple<std::size_t, HidReportType, std::uint8_t>> getListOfReports() const;
 
   private:

--- a/src/controllers/hid/hidreportdescriptor.h
+++ b/src/controllers/hid/hidreportdescriptor.h
@@ -200,10 +200,10 @@ class Collection {
 // Class for parsing HID report descriptors
 class HidReportDescriptor {
   public:
-    HidReportDescriptor(const std::uint8_t* pData, std::size_t length);
+    explicit HidReportDescriptor(const std::vector<uint8_t>& data);
 
     bool isDeviceWithReportIds() const {
-        return m_deviceHasReportIds;
+        return m_deviceUsesReportIds;
     }
 
     Collection parse();
@@ -250,11 +250,10 @@ class HidReportDescriptor {
 
     HidReportType getReportType(HidItemTag tag);
 
-    const std::uint8_t* m_pData;
-    std::size_t m_length;
+    const std::vector<uint8_t>& m_data;
     std::size_t m_pos;
 
-    bool m_deviceHasReportIds;
+    bool m_deviceUsesReportIds;
 
     std::vector<GlobalItems> globalItemsStack;
 

--- a/src/test/controller_hid_reportdescriptor_test.cpp
+++ b/src/test/controller_hid_reportdescriptor_test.cpp
@@ -63,64 +63,64 @@ TEST(HidReportDescriptorParserTest, ParseReportDescriptor) {
     ASSERT_EQ(controls.size(), 5);
 
     // Mouse Button 1
-    ASSERT_EQ(controls[0].m_usage, 0x0009'0001);
-    ASSERT_EQ(controls[0].m_logicalMinimum, 0);
-    ASSERT_EQ(controls[0].m_logicalMaximum, 1);
-    ASSERT_EQ(controls[0].m_physicalMinimum, 0);
-    ASSERT_EQ(controls[0].m_physicalMaximum, 1);
-    ASSERT_EQ(controls[0].m_unitExponent, 0);
-    ASSERT_EQ(controls[0].m_unit, 0);
-    ASSERT_EQ(controls[0].m_bytePosition, 0);
-    ASSERT_EQ(controls[0].m_bitPosition, 0);
-    ASSERT_EQ(controls[0].m_bitSize, 1);
+    EXPECT_EQ(controls[0].m_usage, 0x0009'0001);
+    EXPECT_EQ(controls[0].m_logicalMinimum, 0);
+    EXPECT_EQ(controls[0].m_logicalMaximum, 1);
+    EXPECT_EQ(controls[0].m_physicalMinimum, 0);
+    EXPECT_EQ(controls[0].m_physicalMaximum, 1);
+    EXPECT_EQ(controls[0].m_unitExponent, 0);
+    EXPECT_EQ(controls[0].m_unit, 0);
+    EXPECT_EQ(controls[0].m_bytePosition, 0);
+    EXPECT_EQ(controls[0].m_bitPosition, 0);
+    EXPECT_EQ(controls[0].m_bitSize, 1);
 
     // Mouse Button 2
-    ASSERT_EQ(controls[1].m_usage, 0x0009'0002);
-    ASSERT_EQ(controls[1].m_logicalMinimum, 0);
-    ASSERT_EQ(controls[1].m_logicalMaximum, 1);
-    ASSERT_EQ(controls[1].m_physicalMinimum, 0);
-    ASSERT_EQ(controls[1].m_physicalMaximum, 1);
-    ASSERT_EQ(controls[1].m_unitExponent, 0);
-    ASSERT_EQ(controls[1].m_unit, 0);
-    ASSERT_EQ(controls[1].m_bytePosition, 0);
-    ASSERT_EQ(controls[1].m_bitPosition, 1);
-    ASSERT_EQ(controls[1].m_bitSize, 1);
+    EXPECT_EQ(controls[1].m_usage, 0x0009'0002);
+    EXPECT_EQ(controls[1].m_logicalMinimum, 0);
+    EXPECT_EQ(controls[1].m_logicalMaximum, 1);
+    EXPECT_EQ(controls[1].m_physicalMinimum, 0);
+    EXPECT_EQ(controls[1].m_physicalMaximum, 1);
+    EXPECT_EQ(controls[1].m_unitExponent, 0);
+    EXPECT_EQ(controls[1].m_unit, 0);
+    EXPECT_EQ(controls[1].m_bytePosition, 0);
+    EXPECT_EQ(controls[1].m_bitPosition, 1);
+    EXPECT_EQ(controls[1].m_bitSize, 1);
 
     // Mouse Button 3
-    ASSERT_EQ(controls[2].m_usage, 0x0009'0003);
-    ASSERT_EQ(controls[2].m_logicalMinimum, 0);
-    ASSERT_EQ(controls[2].m_logicalMaximum, 1);
-    ASSERT_EQ(controls[2].m_physicalMinimum, 0);
-    ASSERT_EQ(controls[2].m_physicalMaximum, 1);
-    ASSERT_EQ(controls[2].m_unitExponent, 0);
-    ASSERT_EQ(controls[2].m_unit, 0);
-    ASSERT_EQ(controls[2].m_bytePosition, 0);
-    ASSERT_EQ(controls[2].m_bitPosition, 2);
-    ASSERT_EQ(controls[2].m_bitSize, 1);
+    EXPECT_EQ(controls[2].m_usage, 0x0009'0003);
+    EXPECT_EQ(controls[2].m_logicalMinimum, 0);
+    EXPECT_EQ(controls[2].m_logicalMaximum, 1);
+    EXPECT_EQ(controls[2].m_physicalMinimum, 0);
+    EXPECT_EQ(controls[2].m_physicalMaximum, 1);
+    EXPECT_EQ(controls[2].m_unitExponent, 0);
+    EXPECT_EQ(controls[2].m_unit, 0);
+    EXPECT_EQ(controls[2].m_bytePosition, 0);
+    EXPECT_EQ(controls[2].m_bitPosition, 2);
+    EXPECT_EQ(controls[2].m_bitSize, 1);
 
     // Mouse Movement X
-    ASSERT_EQ(controls[3].m_usage, 0x0001'0030);
-    ASSERT_EQ(controls[3].m_logicalMinimum, -127);
-    ASSERT_EQ(controls[3].m_logicalMaximum, 127);
-    ASSERT_EQ(controls[3].m_physicalMinimum, -127);
-    ASSERT_EQ(controls[3].m_physicalMaximum, 127);
-    ASSERT_EQ(controls[3].m_unitExponent, 0);
-    ASSERT_EQ(controls[3].m_unit, 0);
-    ASSERT_EQ(controls[3].m_bitSize, 8);
-    ASSERT_EQ(controls[3].m_bytePosition, 1);
-    ASSERT_EQ(controls[3].m_bitPosition, 0);
+    EXPECT_EQ(controls[3].m_usage, 0x0001'0030);
+    EXPECT_EQ(controls[3].m_logicalMinimum, -127);
+    EXPECT_EQ(controls[3].m_logicalMaximum, 127);
+    EXPECT_EQ(controls[3].m_physicalMinimum, -127);
+    EXPECT_EQ(controls[3].m_physicalMaximum, 127);
+    EXPECT_EQ(controls[3].m_unitExponent, 0);
+    EXPECT_EQ(controls[3].m_unit, 0);
+    EXPECT_EQ(controls[3].m_bitSize, 8);
+    EXPECT_EQ(controls[3].m_bytePosition, 1);
+    EXPECT_EQ(controls[3].m_bitPosition, 0);
 
     // Mouse Movement Y
-    ASSERT_EQ(controls[4].m_usage, 0x0001'0031);
-    ASSERT_EQ(controls[4].m_logicalMinimum, -127);
-    ASSERT_EQ(controls[4].m_logicalMaximum, 127);
-    ASSERT_EQ(controls[4].m_physicalMinimum, -127);
-    ASSERT_EQ(controls[4].m_physicalMaximum, 127);
-    ASSERT_EQ(controls[4].m_unitExponent, 0);
-    ASSERT_EQ(controls[4].m_unit, 0);
-    ASSERT_EQ(controls[4].m_bitSize, 8);
-    ASSERT_EQ(controls[4].m_bytePosition, 2);
-    ASSERT_EQ(controls[4].m_bitPosition, 0);
+    EXPECT_EQ(controls[4].m_usage, 0x0001'0031);
+    EXPECT_EQ(controls[4].m_logicalMinimum, -127);
+    EXPECT_EQ(controls[4].m_logicalMaximum, 127);
+    EXPECT_EQ(controls[4].m_physicalMinimum, -127);
+    EXPECT_EQ(controls[4].m_physicalMaximum, 127);
+    EXPECT_EQ(controls[4].m_unitExponent, 0);
+    EXPECT_EQ(controls[4].m_unit, 0);
+    EXPECT_EQ(controls[4].m_bitSize, 8);
+    EXPECT_EQ(controls[4].m_bytePosition, 2);
+    EXPECT_EQ(controls[4].m_bitPosition, 0);
 }
 
 TEST(HidReportDescriptorTest, ControlValue_1Bit) {

--- a/src/test/controller_hid_reportdescriptor_test.cpp
+++ b/src/test/controller_hid_reportdescriptor_test.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <limits>
+#include <vector>
 
 #include "controllers/hid/hidreportdescriptor.h"
 
@@ -40,14 +41,16 @@ uint8_t reportDescriptor[] = {
 // clang-format on
 
 TEST(HidReportDescriptorParserTest, ParseReportDescriptor) {
-    HidReportDescriptor parser(reportDescriptor, sizeof(reportDescriptor));
+    const std::vector<uint8_t> reportDescriptorVector(
+            reportDescriptor, reportDescriptor + sizeof(reportDescriptor));
+    HidReportDescriptor parser(reportDescriptorVector);
     Collection collection = parser.parse();
 
     // Use getListOfReports to get the list of reports
     auto reportsList = parser.getListOfReports();
     ASSERT_EQ(reportsList.size(), 1);
 
-    auto [collectionIdx, reportType, reportId] = reportsList[0];
+    auto& [collectionIdx, reportType, reportId] = reportsList[0];
     ASSERT_EQ(collectionIdx, 0);
 
     // Use getReport to get the report

--- a/src/test/controller_hid_reportdescriptor_test.cpp
+++ b/src/test/controller_hid_reportdescriptor_test.cpp
@@ -125,17 +125,17 @@ TEST(HidReportDescriptorParserTest, ParseReportDescriptor) {
 
 TEST(HIDReportDescriptorTest, ControlValue_1Bit) {
     auto reportData = QByteArray::fromHex("81'00'00'FF'01");
-    Control control({{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}, // Flags
-            0x0009'0001,                              // UsagePage/Usage
-            0,                                        // LogicalMinimum
-            1,                                        // LogicalMaximum
-            0,                                        // PhysicalMinimum
-            1,                                        // PhysicalMaximum
-            0,                                        // UnitExponent
-            0,                                        // Unit
-            3,                                        // BytePosition
-            0,                                        // BitPosition
-            1);                                       // BitSize
+    Control control({0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // Flags
+            0x0009'0001,                            // UsagePage/Usage
+            0,                                      // LogicalMinimum
+            1,                                      // LogicalMaximum
+            0,                                      // PhysicalMinimum
+            1,                                      // PhysicalMaximum
+            0,                                      // UnitExponent
+            0,                                      // Unit
+            3,                                      // BytePosition
+            0,                                      // BitPosition
+            1);                                     // BitSize
 
     int32_t value = extractLogicalValue(reportData, control);
     EXPECT_EQ(value, 0x1);
@@ -150,17 +150,17 @@ TEST(HIDReportDescriptorTest, ControlValue_1Bit) {
 
 TEST(HIDReportDescriptorTest, ControlValue_unsigned11Bits) {
     auto reportData = QByteArray::fromHex("81'30'46'00'01");
-    Control control({{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}, // Flags
-            0x0009'0001,                              // UsagePage/Usage
-            0,                                        // LogicalMinimum
-            2047,                                     // LogicalMaximum
-            0,                                        // PhysicalMinimum
-            2047,                                     // PhysicalMaximum
-            0,                                        // UnitExponent
-            0,                                        // Unit
-            1,                                        // BytePosition
-            2,                                        // BitPosition
-            11);                                      // BitSize
+    Control control({0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // Flags
+            0x0009'0001,                            // UsagePage/Usage
+            0,                                      // LogicalMinimum
+            2047,                                   // LogicalMaximum
+            0,                                      // PhysicalMinimum
+            2047,                                   // PhysicalMaximum
+            0,                                      // UnitExponent
+            0,                                      // Unit
+            1,                                      // BytePosition
+            2,                                      // BitPosition
+            11);                                    // BitSize
 
     int32_t value = extractLogicalValue(reportData, control);
     EXPECT_EQ(value, 0b001'1000'1100);
@@ -175,17 +175,17 @@ TEST(HIDReportDescriptorTest, ControlValue_unsigned11Bits) {
 
 TEST(HIDReportDescriptorTest, ControlValue_signed11Bits) {
     auto reportData = QByteArray::fromHex("AA'BB'CC'DD'EE");
-    Control control({{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}, // Flags
-            0x0009'0001,                              // UsagePage/Usage
-            -1000,                                    // LogicalMinimum
-            1000,                                     // LogicalMaximum
-            -10,                                      // PhysicalMinimum
-            10,                                       // PhysicalMaximum
-            0,                                        // UnitExponent
-            0,                                        // Unit
-            2,                                        // BytePosition
-            0,                                        // BitPosition
-            11);                                      // BitSize
+    Control control({0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // Flags
+            0x0009'0001,                            // UsagePage/Usage
+            -1000,                                  // LogicalMinimum
+            1000,                                   // LogicalMaximum
+            -10,                                    // PhysicalMinimum
+            10,                                     // PhysicalMaximum
+            0,                                      // UnitExponent
+            0,                                      // Unit
+            2,                                      // BytePosition
+            0,                                      // BitPosition
+            11);                                    // BitSize
 
     int32_t value = extractLogicalValue(reportData, control);
     EXPECT_EQ(value, -564);
@@ -207,17 +207,17 @@ TEST(HIDReportDescriptorTest, ControlValue_signed11Bits) {
 
 TEST(HIDReportDescriptorTest, ControlValue_unsigned32Bits) {
     auto reportData = QByteArray::fromHex("0A'21'43'65'B7");
-    Control control({{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}, // Flags
-            0x0009'0001,                              // UsagePage/Usage
-            0,                                        // LogicalMinimum
-            0x7FFFFFFF,                               // LogicalMaximum
-            0,                                        // PhysicalMinimum
-            0x7FFFFFFF,                               // PhysicalMaximum
-            0,                                        // UnitExponent
-            0,                                        // Unit
-            0,                                        // BytePosition
-            4,                                        // BitPosition
-            32);                                      // BitSize
+    Control control({0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // Flags
+            0x0009'0001,                            // UsagePage/Usage
+            0,                                      // LogicalMinimum
+            0x7FFFFFFF,                             // LogicalMaximum
+            0,                                      // PhysicalMinimum
+            0x7FFFFFFF,                             // PhysicalMaximum
+            0,                                      // UnitExponent
+            0,                                      // Unit
+            0,                                      // BytePosition
+            4,                                      // BitPosition
+            32);                                    // BitSize
 
     int32_t value = extractLogicalValue(reportData, control);
     EXPECT_EQ(value, 0x76'54'32'10);
@@ -232,17 +232,17 @@ TEST(HIDReportDescriptorTest, ControlValue_unsigned32Bits) {
 
 TEST(HIDReportDescriptorTest, ControlValue_signed32Bits) {
     auto reportData = QByteArray::fromHex("0A'21'43'65'B7");
-    Control control({{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}, // Flags
-            0x0009'0001,                              // UsagePage/Usage
-            std::numeric_limits<int32_t>::min(),      // LogicalMinimum
-            std::numeric_limits<int32_t>::max(),      // LogicalMaximum
-            10,                                       // PhysicalMinimum
-            10,                                       // PhysicalMaximum
-            0,                                        // UnitExponent
-            0,                                        // Unit
-            0,                                        // BytePosition
-            4,                                        // BitPosition
-            32);                                      // BitSize
+    Control control({0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // Flags
+            0x0009'0001,                            // UsagePage/Usage
+            std::numeric_limits<int32_t>::min(),    // LogicalMinimum
+            std::numeric_limits<int32_t>::max(),    // LogicalMaximum
+            10,                                     // PhysicalMinimum
+            10,                                     // PhysicalMaximum
+            0,                                      // UnitExponent
+            0,                                      // Unit
+            0,                                      // BytePosition
+            4,                                      // BitPosition
+            32);                                    // BitSize
 
     int32_t value = extractLogicalValue(reportData, control);
     EXPECT_EQ(value, 0x76'54'32'10);
@@ -264,17 +264,17 @@ TEST(HIDReportDescriptorTest, ControlValue_signed32Bits) {
 
 TEST(HIDReportDescriptorTest, SetControlValue_OutOfRange) {
     auto reportData = QByteArray::fromHex("81'00'00'00'01");
-    Control control({{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}, // Flags
-            0x0009'0001,                              // UsagePage/Usage
-            0,                                        // LogicalMinimum
-            2047,                                     // LogicalMaximum
-            0,                                        // PhysicalMinimum
-            2047,                                     // PhysicalMaximum
-            0,                                        // UnitExponent
-            0,                                        // Unit
-            0,                                        // BytePosition
-            0,                                        // BitPosition
-            11);                                      // BitSize
+    Control control({0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // Flags
+            0x0009'0001,                            // UsagePage/Usage
+            0,                                      // LogicalMinimum
+            2047,                                   // LogicalMaximum
+            0,                                      // PhysicalMinimum
+            2047,                                   // PhysicalMaximum
+            0,                                      // UnitExponent
+            0,                                      // Unit
+            0,                                      // BytePosition
+            0,                                      // BitPosition
+            11);                                    // BitSize
 
     bool result = applyLogicalValue(reportData, control, 3000);
     EXPECT_FALSE(result);

--- a/src/test/controller_hid_reportdescriptor_test.cpp
+++ b/src/test/controller_hid_reportdescriptor_test.cpp
@@ -51,15 +51,15 @@ TEST(HidReportDescriptorParserTest, ParseReportDescriptor) {
     ASSERT_EQ(collectionIdx, 0);
 
     // Use getReport to get the report
-    const Report* report = parser.getReport(reportType, reportId);
-    ASSERT_NE(report, nullptr);
+    const Report* pReport = parser.getReport(reportType, reportId);
+    ASSERT_NE(pReport, nullptr);
 
     // Validate Report fields
-    ASSERT_EQ(report->m_reportType, reportType);
-    ASSERT_EQ(report->m_reportId, reportId);
+    ASSERT_EQ(pReport->m_reportType, reportType);
+    ASSERT_EQ(pReport->m_reportId, reportId);
 
     // Validate all Control fields
-    const std::vector<Control>& controls = report->getControls();
+    const std::vector<Control>& controls = pReport->getControls();
     ASSERT_EQ(controls.size(), 5);
 
     // Mouse Button 1

--- a/src/test/controller_hid_reportdescriptor_test.cpp
+++ b/src/test/controller_hid_reportdescriptor_test.cpp
@@ -51,15 +51,17 @@ TEST(HidReportDescriptorParserTest, ParseReportDescriptor) {
     ASSERT_EQ(collectionIdx, 0);
 
     // Use getReport to get the report
-    const Report* pReport = parser.getReport(reportType, reportId);
-    ASSERT_NE(pReport, nullptr);
+    auto reportOpt = parser.getReport(reportType, reportId);
+    ASSERT_TRUE(reportOpt.has_value());
+
+    const auto& report = reportOpt->get();
 
     // Validate Report fields
-    ASSERT_EQ(pReport->m_reportType, reportType);
-    ASSERT_EQ(pReport->m_reportId, reportId);
+    ASSERT_EQ(report.m_reportType, reportType);
+    ASSERT_EQ(report.m_reportId, reportId);
 
     // Validate all Control fields
-    const std::vector<Control>& controls = pReport->getControls();
+    const std::vector<Control>& controls = report.getControls();
     ASSERT_EQ(controls.size(), 5);
 
     // Mouse Button 1

--- a/src/test/controller_hid_reportdescriptor_test.cpp
+++ b/src/test/controller_hid_reportdescriptor_test.cpp
@@ -40,7 +40,7 @@ uint8_t reportDescriptor[] = {
 // clang-format on
 
 TEST(HidReportDescriptorParserTest, ParseReportDescriptor) {
-    HIDReportDescriptor parser(reportDescriptor, sizeof(reportDescriptor));
+    HidReportDescriptor parser(reportDescriptor, sizeof(reportDescriptor));
     Collection collection = parser.parse();
 
     // Use getListOfReports to get the list of reports
@@ -123,7 +123,7 @@ TEST(HidReportDescriptorParserTest, ParseReportDescriptor) {
     ASSERT_EQ(controls[4].m_bitPosition, 0);
 }
 
-TEST(HIDReportDescriptorTest, ControlValue_1Bit) {
+TEST(HidReportDescriptorTest, ControlValue_1Bit) {
     auto reportData = QByteArray::fromHex("81'00'00'FF'01");
     Control control({0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // Flags
             0x0009'0001,                            // UsagePage/Usage
@@ -148,7 +148,7 @@ TEST(HIDReportDescriptorTest, ControlValue_1Bit) {
     EXPECT_EQ(value2, 0x0);
 }
 
-TEST(HIDReportDescriptorTest, ControlValue_unsigned11Bits) {
+TEST(HidReportDescriptorTest, ControlValue_unsigned11Bits) {
     auto reportData = QByteArray::fromHex("81'30'46'00'01");
     Control control({0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // Flags
             0x0009'0001,                            // UsagePage/Usage
@@ -173,7 +173,7 @@ TEST(HIDReportDescriptorTest, ControlValue_unsigned11Bits) {
     EXPECT_EQ(value2, 0b010'1010'1010);
 }
 
-TEST(HIDReportDescriptorTest, ControlValue_signed11Bits) {
+TEST(HidReportDescriptorTest, ControlValue_signed11Bits) {
     auto reportData = QByteArray::fromHex("AA'BB'CC'DD'EE");
     Control control({0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // Flags
             0x0009'0001,                            // UsagePage/Usage
@@ -205,7 +205,7 @@ TEST(HIDReportDescriptorTest, ControlValue_signed11Bits) {
     EXPECT_EQ(value3, -200);
 }
 
-TEST(HIDReportDescriptorTest, ControlValue_unsigned32Bits) {
+TEST(HidReportDescriptorTest, ControlValue_unsigned32Bits) {
     auto reportData = QByteArray::fromHex("0A'21'43'65'B7");
     Control control({0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // Flags
             0x0009'0001,                            // UsagePage/Usage
@@ -230,7 +230,7 @@ TEST(HIDReportDescriptorTest, ControlValue_unsigned32Bits) {
     EXPECT_EQ(value2, 0x01'23'45'67);
 }
 
-TEST(HIDReportDescriptorTest, ControlValue_signed32Bits) {
+TEST(HidReportDescriptorTest, ControlValue_signed32Bits) {
     auto reportData = QByteArray::fromHex("0A'21'43'65'B7");
     Control control({0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // Flags
             0x0009'0001,                            // UsagePage/Usage
@@ -262,7 +262,7 @@ TEST(HIDReportDescriptorTest, ControlValue_signed32Bits) {
     EXPECT_EQ(value3, std::numeric_limits<int32_t>::max());
 }
 
-TEST(HIDReportDescriptorTest, SetControlValue_OutOfRange) {
+TEST(HidReportDescriptorTest, SetControlValue_OutOfRange) {
     auto reportData = QByteArray::fromHex("81'00'00'00'01");
     Control control({0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, // Flags
             0x0009'0001,                            // UsagePage/Usage

--- a/src/test/controller_hid_reportdescriptor_test.cpp
+++ b/src/test/controller_hid_reportdescriptor_test.cpp
@@ -1,0 +1,281 @@
+#include <gtest/gtest.h>
+
+#include <limits>
+
+#include "controllers/hid/hidreportdescriptor.h"
+
+using namespace hid::reportDescriptor;
+
+// Example HID report descriptor data
+
+// clang-format off
+uint8_t reportDescriptor[] = {
+        0x05, 0x01, // Usage Page (Generic Desktop)
+        0x09, 0x02, // Usage (Mouse)
+        0xA1, 0x01, // Collection (Application)
+        0x09, 0x01,  // Usage (Pointer)
+        0xA1, 0x00,  // Collection (Physical)
+        0x05, 0x09,   // Usage Page (Button)
+        0x19, 0x01,   // Usage Minimum (1)
+        0x29, 0x03,   // Usage Maximum (3)
+        0x15, 0x00,   // Logical Minimum (0)
+        0x25, 0x01,   // Logical Maximum (1)
+        0x95, 0x03,   // Report Count (3)
+        0x75, 0x01,   // Report Size (1)
+        0x81, 0x02,   // Input (Data, Variable, Absolute)
+        0x95, 0x01,   // Report Count (1)
+        0x75, 0x05,   // Report Size (5)
+        0x81, 0x01,   // Input (Constant)
+        0x05, 0x01,   // Usage Page (Generic Desktop)
+        0x09, 0x30,   // Usage (X)
+        0x09, 0x31,   // Usage (Y)
+        0x15, 0x81,   // Logical Minimum (-127)
+        0x25, 0x7F,   // Logical Maximum (127)
+        0x75, 0x08,   // Report Size (8)
+        0x95, 0x02,   // Report Count (2)
+        0x81, 0x06,   // Input (Data, Variable, Relative)
+        0xC0,        // End Collection
+        0xC0        // End Collection
+};
+// clang-format on
+
+TEST(HidReportDescriptorParserTest, ParseReportDescriptor) {
+    HIDReportDescriptor parser(reportDescriptor, sizeof(reportDescriptor));
+    Collection collection = parser.parse();
+
+    // Use getListOfReports to get the list of reports
+    auto reportsList = parser.getListOfReports();
+    ASSERT_EQ(reportsList.size(), 1);
+
+    auto [collectionIdx, reportType, reportId] = reportsList[0];
+    ASSERT_EQ(collectionIdx, 0);
+
+    // Use getReport to get the report
+    const Report* report = parser.getReport(reportType, reportId);
+    ASSERT_NE(report, nullptr);
+
+    // Validate Report fields
+    ASSERT_EQ(report->m_reportType, reportType);
+    ASSERT_EQ(report->m_reportId, reportId);
+
+    // Validate all Control fields
+    const std::vector<Control>& controls = report->getControls();
+    ASSERT_EQ(controls.size(), 5);
+
+    // Mouse Button 1
+    ASSERT_EQ(controls[0].m_usage, 0x0009'0001);
+    ASSERT_EQ(controls[0].m_logicalMinimum, 0);
+    ASSERT_EQ(controls[0].m_logicalMaximum, 1);
+    ASSERT_EQ(controls[0].m_physicalMinimum, 0);
+    ASSERT_EQ(controls[0].m_physicalMaximum, 1);
+    ASSERT_EQ(controls[0].m_unitExponent, 0);
+    ASSERT_EQ(controls[0].m_unit, 0);
+    ASSERT_EQ(controls[0].m_bytePosition, 0);
+    ASSERT_EQ(controls[0].m_bitPosition, 0);
+    ASSERT_EQ(controls[0].m_bitSize, 1);
+
+    // Mouse Button 2
+    ASSERT_EQ(controls[1].m_usage, 0x0009'0002);
+    ASSERT_EQ(controls[1].m_logicalMinimum, 0);
+    ASSERT_EQ(controls[1].m_logicalMaximum, 1);
+    ASSERT_EQ(controls[1].m_physicalMinimum, 0);
+    ASSERT_EQ(controls[1].m_physicalMaximum, 1);
+    ASSERT_EQ(controls[1].m_unitExponent, 0);
+    ASSERT_EQ(controls[1].m_unit, 0);
+    ASSERT_EQ(controls[1].m_bytePosition, 0);
+    ASSERT_EQ(controls[1].m_bitPosition, 1);
+    ASSERT_EQ(controls[1].m_bitSize, 1);
+
+    // Mouse Button 3
+    ASSERT_EQ(controls[2].m_usage, 0x0009'0003);
+    ASSERT_EQ(controls[2].m_logicalMinimum, 0);
+    ASSERT_EQ(controls[2].m_logicalMaximum, 1);
+    ASSERT_EQ(controls[2].m_physicalMinimum, 0);
+    ASSERT_EQ(controls[2].m_physicalMaximum, 1);
+    ASSERT_EQ(controls[2].m_unitExponent, 0);
+    ASSERT_EQ(controls[2].m_unit, 0);
+    ASSERT_EQ(controls[2].m_bytePosition, 0);
+    ASSERT_EQ(controls[2].m_bitPosition, 2);
+    ASSERT_EQ(controls[2].m_bitSize, 1);
+
+    // Mouse Movement X
+    ASSERT_EQ(controls[3].m_usage, 0x0001'0030);
+    ASSERT_EQ(controls[3].m_logicalMinimum, -127);
+    ASSERT_EQ(controls[3].m_logicalMaximum, 127);
+    ASSERT_EQ(controls[3].m_physicalMinimum, -127);
+    ASSERT_EQ(controls[3].m_physicalMaximum, 127);
+    ASSERT_EQ(controls[3].m_unitExponent, 0);
+    ASSERT_EQ(controls[3].m_unit, 0);
+    ASSERT_EQ(controls[3].m_bitSize, 8);
+    ASSERT_EQ(controls[3].m_bytePosition, 1);
+    ASSERT_EQ(controls[3].m_bitPosition, 0);
+
+    // Mouse Movement Y
+    ASSERT_EQ(controls[4].m_usage, 0x0001'0031);
+    ASSERT_EQ(controls[4].m_logicalMinimum, -127);
+    ASSERT_EQ(controls[4].m_logicalMaximum, 127);
+    ASSERT_EQ(controls[4].m_physicalMinimum, -127);
+    ASSERT_EQ(controls[4].m_physicalMaximum, 127);
+    ASSERT_EQ(controls[4].m_unitExponent, 0);
+    ASSERT_EQ(controls[4].m_unit, 0);
+    ASSERT_EQ(controls[4].m_bitSize, 8);
+    ASSERT_EQ(controls[4].m_bytePosition, 2);
+    ASSERT_EQ(controls[4].m_bitPosition, 0);
+}
+
+TEST(HIDReportDescriptorTest, ControlValue_1Bit) {
+    auto reportData = QByteArray::fromHex("81'00'00'FF'01");
+    Control control({{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}, // Flags
+            0x0009'0001,                              // UsagePage/Usage
+            0,                                        // LogicalMinimum
+            1,                                        // LogicalMaximum
+            0,                                        // PhysicalMinimum
+            1,                                        // PhysicalMaximum
+            0,                                        // UnitExponent
+            0,                                        // Unit
+            3,                                        // BytePosition
+            0,                                        // BitPosition
+            1);                                       // BitSize
+
+    int32_t value = extractLogicalValue(reportData, control);
+    EXPECT_EQ(value, 0x1);
+
+    bool result = applyLogicalValue(reportData, control, 0);
+    EXPECT_TRUE(result);
+    EXPECT_EQ(reportData, QByteArray::fromHex("81'00'00'FE'01"));
+
+    int32_t value2 = extractLogicalValue(reportData, control);
+    EXPECT_EQ(value2, 0x0);
+}
+
+TEST(HIDReportDescriptorTest, ControlValue_unsigned11Bits) {
+    auto reportData = QByteArray::fromHex("81'30'46'00'01");
+    Control control({{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}, // Flags
+            0x0009'0001,                              // UsagePage/Usage
+            0,                                        // LogicalMinimum
+            2047,                                     // LogicalMaximum
+            0,                                        // PhysicalMinimum
+            2047,                                     // PhysicalMaximum
+            0,                                        // UnitExponent
+            0,                                        // Unit
+            1,                                        // BytePosition
+            2,                                        // BitPosition
+            11);                                      // BitSize
+
+    int32_t value = extractLogicalValue(reportData, control);
+    EXPECT_EQ(value, 0b001'1000'1100);
+
+    bool result = applyLogicalValue(reportData, control, 0b010'1010'1010);
+    EXPECT_TRUE(result);
+    EXPECT_EQ(reportData, QByteArray::fromHex("81'A8'4A'00'01"));
+
+    int32_t value2 = extractLogicalValue(reportData, control);
+    EXPECT_EQ(value2, 0b010'1010'1010);
+}
+
+TEST(HIDReportDescriptorTest, ControlValue_signed11Bits) {
+    auto reportData = QByteArray::fromHex("AA'BB'CC'DD'EE");
+    Control control({{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}, // Flags
+            0x0009'0001,                              // UsagePage/Usage
+            -1000,                                    // LogicalMinimum
+            1000,                                     // LogicalMaximum
+            -10,                                      // PhysicalMinimum
+            10,                                       // PhysicalMaximum
+            0,                                        // UnitExponent
+            0,                                        // Unit
+            2,                                        // BytePosition
+            0,                                        // BitPosition
+            11);                                      // BitSize
+
+    int32_t value = extractLogicalValue(reportData, control);
+    EXPECT_EQ(value, -564);
+
+    bool result = applyLogicalValue(reportData, control, +200);
+    EXPECT_TRUE(result);
+    EXPECT_EQ(reportData, QByteArray::fromHex("AA'BB'C8'D8'EE"));
+
+    int32_t value2 = extractLogicalValue(reportData, control);
+    EXPECT_EQ(value2, +200);
+
+    bool result2 = applyLogicalValue(reportData, control, -200);
+    EXPECT_TRUE(result2);
+    EXPECT_EQ(reportData, QByteArray::fromHex("AA'BB'38'DF'EE"));
+
+    int32_t value3 = extractLogicalValue(reportData, control);
+    EXPECT_EQ(value3, -200);
+}
+
+TEST(HIDReportDescriptorTest, ControlValue_unsigned32Bits) {
+    auto reportData = QByteArray::fromHex("0A'21'43'65'B7");
+    Control control({{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}, // Flags
+            0x0009'0001,                              // UsagePage/Usage
+            0,                                        // LogicalMinimum
+            0x7FFFFFFF,                               // LogicalMaximum
+            0,                                        // PhysicalMinimum
+            0x7FFFFFFF,                               // PhysicalMaximum
+            0,                                        // UnitExponent
+            0,                                        // Unit
+            0,                                        // BytePosition
+            4,                                        // BitPosition
+            32);                                      // BitSize
+
+    int32_t value = extractLogicalValue(reportData, control);
+    EXPECT_EQ(value, 0x76'54'32'10);
+
+    bool result = applyLogicalValue(reportData, control, 0x01'23'45'67);
+    EXPECT_TRUE(result);
+    EXPECT_EQ(reportData, QByteArray::fromHex("7A'56'34'12'B0"));
+
+    int32_t value2 = extractLogicalValue(reportData, control);
+    EXPECT_EQ(value2, 0x01'23'45'67);
+}
+
+TEST(HIDReportDescriptorTest, ControlValue_signed32Bits) {
+    auto reportData = QByteArray::fromHex("0A'21'43'65'B7");
+    Control control({{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}, // Flags
+            0x0009'0001,                              // UsagePage/Usage
+            std::numeric_limits<int32_t>::min(),      // LogicalMinimum
+            std::numeric_limits<int32_t>::max(),      // LogicalMaximum
+            10,                                       // PhysicalMinimum
+            10,                                       // PhysicalMaximum
+            0,                                        // UnitExponent
+            0,                                        // Unit
+            0,                                        // BytePosition
+            4,                                        // BitPosition
+            32);                                      // BitSize
+
+    int32_t value = extractLogicalValue(reportData, control);
+    EXPECT_EQ(value, 0x76'54'32'10);
+
+    bool result = applyLogicalValue(reportData, control, std::numeric_limits<int32_t>::min());
+    EXPECT_TRUE(result);
+    EXPECT_EQ(reportData, QByteArray::fromHex("0A'00'00'00'B8"));
+
+    int32_t value2 = extractLogicalValue(reportData, control);
+    EXPECT_EQ(value2, std::numeric_limits<int32_t>::min());
+
+    bool result2 = applyLogicalValue(reportData, control, std::numeric_limits<int32_t>::max());
+    EXPECT_TRUE(result2);
+    EXPECT_EQ(reportData, QByteArray::fromHex("FA'FF'FF'FF'B7"));
+
+    int32_t value3 = extractLogicalValue(reportData, control);
+    EXPECT_EQ(value3, std::numeric_limits<int32_t>::max());
+}
+
+TEST(HIDReportDescriptorTest, SetControlValue_OutOfRange) {
+    auto reportData = QByteArray::fromHex("81'00'00'00'01");
+    Control control({{0, 0, 0, 0, 0, 0, 0, 0, 0, 0}}, // Flags
+            0x0009'0001,                              // UsagePage/Usage
+            0,                                        // LogicalMinimum
+            2047,                                     // LogicalMaximum
+            0,                                        // PhysicalMinimum
+            2047,                                     // PhysicalMaximum
+            0,                                        // UnitExponent
+            0,                                        // Unit
+            0,                                        // BytePosition
+            0,                                        // BitPosition
+            11);                                      // BitSize
+
+    bool result = applyLogicalValue(reportData, control, 3000);
+    EXPECT_FALSE(result);
+}


### PR DESCRIPTION
Implemented HID report tabs, that show all controls and it's values(if accessible) defined in the HID Reports Descriptor

- Implemented HID Report Descriptor Parser
- Implemented `extractLogicallValue` for logical value extraction for both signed and unsigned controls.
- Added HID report tab GUI layout in the controller dialog with "Read" and "Send" buttons based on report type.
- Extended `HidIoThread` to emit `reportReceived` signal with report ID for improved tracking, and added logic for bytesRead in processInputReport

**How it works:**
Every HID device has a mandatory binary Report Descriptor stored in it's memory (if the Report Descriptor would be invalid, the Kernel driver would reject the device and neither hidapi nor Mixxx would ever see it). With this PR, we read this binary Report Descriptor when the HID device is opened and store it in the DeviceInfo. Then the new report desciptor parser in src/controllers/hid/hidreportdescriptor.cpp parses this binary data according https://www.usb.org/document-library/device-class-definition-hid-111 and generates a simplified hierachy of ReportDescriptor->Collection->Report->Control, each is one minimal class with mostly read-only properties.
When you open the the Controller-Preferences of a HID controller, this class hirachy is used to populate additional tabs for the reports containing a list of all controls defined in them. It also shows the actual of Controls in InputReports values (e.g. knob position) read from the device and you can set values to be send to the device in OutputReports.

**Limitations**
The following limitations needs to be addressed in follow-up PRs:

- Currently Mixxx requires any mapping assigned to open a HID device. This functionality requires the device to be opened at startup, but does not use any information from the mapping files.
- It is not always possible to read/send data to the device (especially keyboards and mouses are often exclusive locked by the operating system driver). With the implementation in this PR nothing happens in this cases, as displaying the error information in the GUI would require complex inter-thread communication.

https://github.com/user-attachments/assets/b1e015c9-71f0-4737-b87c-cfad18f79f84
