### PR TITLE
(fix) Tooltips: keep linebreak before kbd shortcut tooltips

### DIFF
--- a/src/widget/wbasewidget.h
+++ b/src/widget/wbasewidget.h
@@ -5,6 +5,8 @@
 #include <memory>
 #include <vector>
 
+#include "util/string.h"
+
 class ControlWidgetPropertyConnection;
 class ControlParameterWidgetConnection;
 
@@ -26,17 +28,17 @@ class WBaseWidget {
     }
 
     void appendBaseTooltip(const QString& tooltip) {
-        m_baseTooltip.append(tooltip.trimmed());
+        m_baseTooltip.append(mixxx::removeTrailingWhitespaces(tooltip));
         m_pWidget->setToolTip(m_baseTooltip);
     }
 
     void prependBaseTooltip(const QString& tooltip) {
-        m_baseTooltip.prepend(tooltip.trimmed());
+        m_baseTooltip.prepend(mixxx::removeTrailingWhitespaces(tooltip));
         m_pWidget->setToolTip(m_baseTooltip);
     }
 
     void setBaseTooltip(const QString& tooltip) {
-        m_baseTooltip = tooltip.trimmed();
+        m_baseTooltip = mixxx::removeTrailingWhitespaces(tooltip);
         m_pWidget->setToolTip(m_baseTooltip);
     }
 


### PR DESCRIPTION
fixup for #13952 
Keyboard shortcuts were trimmed [QString::trimmed() removes both leading and trailing whitespace, this includes the ASCII characters '\t', '\n', '\v', '\f', '\r'](https://doc.qt.io/qt-6/qstring.html#trimmed)

use `mixxx::removeTrailingWhitespaces()` helper instead.

before:
![Screenshot_2025-05-08_11-41-53](https://github.com/user-attachments/assets/626b0479-dfe7-4d0c-9d5a-a7868fef4682)

after:
![Screenshot_2025-05-08_11-38-54](https://github.com/user-attachments/assets/24f297b2-a3a2-4e7d-96f5-12d5bab2f3d4)
