### PR TITLE
(fix) DeveloperTools: restore searchbar shortcut Ctrl+F

### DIFF
--- a/src/dialog/dlgdevelopertools.cpp
+++ b/src/dialog/dlgdevelopertools.cpp
@@ -2,6 +2,7 @@
 
 #include <QDateTime>
 #include <QDir>
+#include <QKeyEvent>
 
 #include "control/control.h"
 #include "moc_dlgdevelopertools.cpp"
@@ -66,6 +67,9 @@ DlgDeveloperTools::DlgDeveloperTools(QWidget* pParent,
 
     // Delete this dialog when its closed. We don't want any persistence.
     setAttribute(Qt::WA_DeleteOnClose);
+
+    // Just to catch Ctrl+F to focus searchbar
+    installEventFilter(this);
 }
 
 void DlgDeveloperTools::timerEvent(QTimerEvent* pEvent) {
@@ -144,4 +148,20 @@ void DlgDeveloperTools::slotLogSearch() {
     QString textToFind = logSearch->text();
     m_logCursor = logTextView->document()->find(textToFind, m_logCursor);
     logTextView->setTextCursor(m_logCursor);
+}
+
+bool DlgDeveloperTools::eventFilter(QObject* pObj, QEvent* pEvent) {
+    if (pEvent->type() == QEvent::ShortcutOverride) {
+        QKeyEvent* pKE = static_cast<QKeyEvent*>(pEvent);
+        VERIFY_OR_DEBUG_ASSERT(pKE) {
+            return QDialog::eventFilter(pObj, pEvent);
+        }
+
+        if (pKE->key() == Qt::Key_F && (pKE->modifiers() & Qt::ControlModifier)) {
+            controlSearch->setFocus(Qt::ShortcutFocusReason);
+            pEvent->accept();
+            return true;
+        }
+    }
+    return QDialog::eventFilter(pObj, pEvent);
 }

--- a/src/dialog/dlgdevelopertools.h
+++ b/src/dialog/dlgdevelopertools.h
@@ -14,6 +14,8 @@ class DlgDeveloperTools : public QDialog, public Ui::DlgDeveloperTools {
   public:
     DlgDeveloperTools(QWidget* pParent, UserSettingsPointer pConfig);
 
+    bool eventFilter(QObject* pObj, QEvent* pEvent) override;
+
   protected:
     void timerEvent(QTimerEvent* pTimerEvent) override;
 


### PR DESCRIPTION
`Ctrl`+`F` was previously set by WSearchLineEdit, which is used in skins and Developer Tools.
Since #13200 it's a global shortcut set in WMainMenuBar, which breaks it for Developer Tools.

This restores it in Developer Tools via `ShortcutOverride` event filter.