### PR TITLE
2.6-beta band-aid: Disable QML to fix link failure avoid undefined behaviour

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,13 +227,14 @@ endif()
 include(CMakeDependentOption)
 
 option(QT6 "Build with Qt6" ON)
-cmake_dependent_option(
-  QML
-  "Build with QML"
-  ON
-  "QT6"
-  OFF
-)
+
+# Because of multiple concurrent definition of symbols caused by the rendergraph
+# compile definition we need to disable QML by default. This avoids the risk of
+# undefined behaviour in a stable build.
+# See: https://github.com/mixxxdj/mixxx/issues/14766
+# Once this is fixed we can revert the commit introducing this.
+option(QML "Build with QML" OFF)
+
 option(QOPENGL "Use QOpenGLWindow based widget instead of QGLWidget" ON)
 
 if(QOPENGL)


### PR DESCRIPTION
Because of multiple concurrent definition of symbols caused by the render graph compile definition, we can't provide 2.6-beta build for all Ubuntu versions on our PPA. 
This is a emergency band aid, to provide beta testers with builds until the root cause is fixed. 

See: 
https://github.com/mixxxdj/mixxx/issues/14766
https://github.com/mixxxdj/mixxx/issues/14771

Hopefully we fix the issue fast that we can revert this PR 