### PR TITLE
Fix 4 steps browsing issue with Numark Mixtrack Platinium FX controller

### DIFF
--- a/res/controllers/Numark-Mixtrack-Platinum-FX-scripts.js
+++ b/res/controllers/Numark-Mixtrack-Platinum-FX-scripts.js
@@ -1548,10 +1548,10 @@ MixtrackPlatinumFX.Browse = function() {
                     engine.stopTimer(this.speedTimer);
                     this.speedTimer = 0;
                 }
-                this.speedTimer = engine.beginTimer(100, function() {
+                this.speedTimer = engine.beginTimer(100, (function() {
                     this.speed=0;
                     this.speedTimer = 0;
-                }, true);
+                }).bind(this), true);
                 this.speed++;
                 direction = (value > 0x40) ? value - 0x80 : value;
                 if (MixtrackPlatinumFX.shifted) {


### PR DESCRIPTION
After 3 browsing steps, the browsing is locked at 4 steps per controller's steps.

### Where the bug comes from
When the function in beginTimer is called (line 1556), this parent object is no longer the Encoder but... what ever it is (at this time I don't really know).
So, when we want to reset the speed to 0, it resets the speed attribute of the beginTimer's inside object and not the Encoder object.

### How did I fix it
I just binded the Encoder object to the beginTimer's function argument.
