### PR TITLE
README: add link to OS-specific build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ To build Mixxx, run
 There should now be a `mixxx` executable in the current directory that you can
 run. Alternatively, can generate a package using `cpack`.
 
+Detailed build instructions for each target OS can be found [on the wiki](https://github.com/mixxxdj/mixxx/wiki#compile-mixxx-from-source-code)
+
 ## Documentation
 
 For help using Mixxx, there are a variety of options:


### PR DESCRIPTION
Adds a quick link to https://github.com/mixxxdj/mixxx/wiki#compile-mixxx-from-source-code with detailed build instructions which are currently hard to find, unless you find your way via **Documentation** -> **Wiki** -> scroll down to **Developer Documentation** -> **Compile Mixxx From Source Code**