### PR TITLE
S4Mk2: use engine settings API for configuration

### DIFF
--- a/res/controllers/Traktor Kontrol S4 MK2.hid.xml
+++ b/res/controllers/Traktor Kontrol S4 MK2.hid.xml
@@ -15,4 +15,16 @@
             <file filename="Traktor-Kontrol-S4-MK2-hid-scripts.js" functionprefix="TraktorS4MK2"/>
         </scriptfiles>
     </controller>
+    <settings>
+      <option variable="remixSlotButtonAction" type="enum"
+              label="Action to trigger with remix slot buttons">
+        <value label="Samplers" default="true">SAMPLES</value>
+        <value label="Loop Rolls">LOOPROLLS</value>
+      </option>
+      <option variable="shiftCueButtonAction" type="enum"
+              label="The action to trigger when Shift+Cue is pressed">
+        <value label="Rewind to start of track" default="true">REWIND</value>
+        <value label="Reverse playback direction">REVERSEROLL</value>
+      </option>
+    </settings>
 </MixxxControllerPreset>

--- a/res/controllers/Traktor-Kontrol-S4-MK2-hid-scripts.js
+++ b/res/controllers/Traktor-Kontrol-S4-MK2-hid-scripts.js
@@ -13,28 +13,13 @@
 // * Find a use for snap / master / other unused buttons?
 
 
-// ==== Friendly User Configuration ====
-// The Remix Slot buttons can have two possible functions:
-// 1. Sample launchers: pressing the buttons activates sample players in Mixxx
-// 2. Loop Roll: Holding the buttons activates a short loop, and when the button is
-//    released playback will resume where the track would have been without the loop.
-// To choose sample launching, set the word in quotes below to SAMPLES, all caps.  For
-// rolls, change the word to LOOPROLLS (no space).
-RemixSlotButtonAction = "SAMPLES";
-// The Cue button, when Shift is also held, can have two possible functions:
-// 1. "REWIND": seeks to the very start of the track.
-// 2. "REVERSEROLL": performs a temporary reverse or "censor" effect, where the track
-//    is momentarily played in reverse until the button is released.
-ShiftCueButtonAction = "REWIND";
-
-
 TraktorS4MK2 = new function() {
     this.controller = new HIDController();
     // TODO: Decide if these should be part of this.controller instead.
     this.partial_packet = Object();
     this.divisor_map = Object();
-    this.RemixSlotButtonAction = RemixSlotButtonAction;
-    this.ShiftCueButtonAction = ShiftCueButtonAction;
+    this.RemixSlotButtonAction = engine.getSetting("remixSlotButtonAction");
+    this.ShiftCueButtonAction = engine.getSetting("shiftCueButtonAction");
 
     // When true, packets will not be sent to the controller.  Good for doing mass updates.
     this.controller.freeze_lights = false;


### PR DESCRIPTION
I got one of these to repair today and noticed while testing that the manual mentions that you have to rewrite the script to configure parts of this controller. Since Mixxx now has a settings API this is unnecessary, so I moved the config into settings to make it easier to change. I used an enum instead of a boolean because it makes it easier to add more options later and required the minimal code change. Also it's just nicer to read in the settings window (no giant description of what both values of the bool mean, it's in the drop down).

Corresponding manual PR: mixxxdj/manual#767