### PR TITLE
 #6164 Reload playlist sidebar when DB changes 

### DIFF
--- a/src/library/dao/playlistdao.h
+++ b/src/library/dao/playlistdao.h
@@ -3,6 +3,7 @@
 #include <QHash>
 #include <QObject>
 #include <QSet>
+#include <QMap>
 
 #include "library/dao/dao.h"
 #include "track/trackid.h"
@@ -61,6 +62,12 @@ class PlaylistDAO : public QObject, public virtual DAO {
     bool appendTrackToPlaylist(TrackId trackId, const int playlistId);
     // Find out how many playlists exist.
     unsigned int playlistCount() const;
+    
+ 
+    void loadAllPlaylists();  // Reload playlists from the database
+    QSet<int> getAllPlaylistIds() const;  // Return set of all playlist IDs
+
+
     // Get all playlist ids and names of a specific type
     QList<QPair<int, QString>> getPlaylists(const HiddenType hidden) const;
     // Find out the name of the playlist at the given Id
@@ -147,5 +154,9 @@ class PlaylistDAO : public QObject, public virtual DAO {
 
     QMultiHash<TrackId, int> m_playlistsTrackIsIn;
     AutoDJProcessor* m_pAutoDJProcessor;
+
+    // Internal cache for loaded playlists
+    QMap<int, QString> m_playlistIdNameMap;
+
     DISALLOW_COPY_AND_ASSIGN(PlaylistDAO);
 };

--- a/src/library/trackset/baseplaylistfeature.h
+++ b/src/library/trackset/baseplaylistfeature.h
@@ -4,10 +4,12 @@
 #include <QPointer>
 #include <QSet>
 #include <QString>
+#include <memory>
 
 #include "library/dao/playlistdao.h"
 #include "library/trackset/basetracksetfeature.h"
 #include "track/trackid.h"
+#include "util/autofilereloader.h"  // include for AutoFileReloader
 
 class WLibrary;
 class KeyboardEventFilter;
@@ -70,9 +72,9 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
     void slotImportPlaylistFile(const QString& playlistFile, int playlistId);
     void slotCreateImportPlaylist();
     void slotExportPlaylist();
-    // Copy all of the tracks in a playlist to a new directory.
     void slotExportTrackFiles();
     void slotAnalyzePlaylist();
+    void onDatabaseChanged();  // to handle DB file change
 
   protected:
     struct IdAndLabel {
@@ -82,17 +84,12 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
 
     virtual void updateChildModel(const QSet<int>& playlistIds);
     virtual void clearChildModel();
-
-    /// borrows pChild which must not be null, TODO: use gsl::not_null
     virtual void decorateChild(TreeItem* pChild, int playlistId) = 0;
     virtual void addToAutoDJ(PlaylistDAO::AutoDJSendLoc loc);
 
     int playlistIdFromIndex(const QModelIndex& index) const;
-    // Get the QModelIndex of a playlist based on its id.  Returns QModelIndex()
-    // on failure.
     QModelIndex indexFromPlaylistId(int playlistId);
     bool isChildIndexSelectedInSidebar(const QModelIndex& index);
-
     QString createPlaylistLabel(const QString& name, int count, int duration) const;
 
     PlaylistDAO& m_playlistDao;
@@ -131,6 +128,8 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
     void markTreeItem(TreeItem* pTreeItem);
     QString fetchPlaylistLabel(int playlistId);
 
-
     const bool m_keepHiddenTracks;
+
+    std::unique_ptr<AutoFileReloader> m_pDbReloader;  //  File watcher for DB
 };
+

--- a/src/library/trackset/playlistfeature.h
+++ b/src/library/trackset/playlistfeature.h
@@ -22,6 +22,8 @@ class PlaylistFeature : public BasePlaylistFeature {
 
     QVariant title() override;
 
+    void reloadPlaylists();//declaration
+
     bool dropAcceptChild(const QModelIndex& index,
             const QList<QUrl>& urls,
             QObject* pSource) override;
@@ -46,4 +48,6 @@ class PlaylistFeature : public BasePlaylistFeature {
     QString getRootViewHtml() const override;
 
     QAction* m_pShufflePlaylistAction;
+
+    QAction* m_pReloadPlaylistsAction;
 };


### PR DESCRIPTION
issue #6164
Integrated AutoFileReloader into BasePlaylistFeature to watch for external database changes.

Currently, renaming playlists updates immediately, but adding new playlists requires a manual reload.

Encountered and resolved a concurrency issue during development.

Please review my current implementation and suggest improvements or best practices to enhance reliability and maintainability.

![image](https://github.com/user-attachments/assets/bfbbb4c6-2c63-4cbf-88b5-2f3ea726ec21)

![image](https://github.com/user-attachments/assets/70abb6bb-21d3-4f07-9c36-7893102ed8a7)
