### PR TITLE
Cache miss: log cleanup and debug

### DIFF
--- a/src/engine/readaheadmanager.cpp
+++ b/src/engine/readaheadmanager.cpp
@@ -12,7 +12,7 @@ ReadAheadManager::ReadAheadManager()
           m_currentPosition(0),
           m_pReader(nullptr),
           m_pCrossFadeBuffer(SampleUtil::alloc(MAX_BUFFER_LEN)),
-          m_cacheMissHappened(false) {
+          m_cacheMissCount(0) {
     // For testing only: ReadAheadManagerMock
 }
 
@@ -23,7 +23,7 @@ ReadAheadManager::ReadAheadManager(CachingReader* pReader,
           m_currentPosition(0),
           m_pReader(pReader),
           m_pCrossFadeBuffer(SampleUtil::alloc(MAX_BUFFER_LEN)),
-          m_cacheMissHappened(false) {
+          m_cacheMissCount(0) {
     DEBUG_ASSERT(m_pLoopingControl != nullptr);
     DEBUG_ASSERT(m_pReader != nullptr);
 }
@@ -93,8 +93,8 @@ SINT ReadAheadManager::getNextSamples(double dRate, CSAMPLE* pOutput,
         SampleUtil::clear(pOutput, samples_from_reader);
         // Set the cache miss flag to decide when to apply ramping
         // after the following read attempts.
-        m_cacheMissHappened = true;
-    } else if (m_cacheMissHappened) {
+        m_cacheMissCount++;
+    } else if (m_cacheMissCount > 0) {
         // Previous read was a cache miss, but now we got something back.
         // Apply ramping gain, because the last buffer has unwanted silence
         // and new samples without fading are causing a pop.
@@ -103,7 +103,7 @@ SINT ReadAheadManager::getNextSamples(double dRate, CSAMPLE* pOutput,
                 CSAMPLE_GAIN_ONE,
                 samples_from_reader);
         // Reset the cache miss flag, because we are now back on track.
-        m_cacheMissHappened = false;
+        m_cacheMissCount = 0;
     }
 
     // Increment or decrement current read-ahead position
@@ -179,7 +179,7 @@ SINT ReadAheadManager::getNextSamples(double dRate, CSAMPLE* pOutput,
                 SampleUtil::clear(m_pCrossFadeBuffer, samples_from_reader);
                 // Set the cache miss flag to decide when to apply ramping
                 // after the following read attempts.
-                m_cacheMissHappened = true;
+                m_cacheMissCount++;
             }
 
             // do crossfade from the current buffer into the new loop beginning
@@ -209,16 +209,8 @@ void ReadAheadManager::addRateControl(RateControl* pRateControl) {
 // Not thread-save, call from engine thread only
 void ReadAheadManager::notifySeek(double seekPosition) {
     m_currentPosition = seekPosition;
-    m_cacheMissHappened = false;
+    m_cacheMissCount = 0;
     m_readAheadLog.clear();
-
-    // TODO(XXX) notifySeek on the engine controls. EngineBuffer currently does
-    // a fine job of this so it isn't really necessary but eventually I think
-    // RAMAN should do this job. rryan 11/2011
-
-    // foreach (EngineControl* pControl, m_sEngineControls) {
-    //     pControl->notifySeek(iSeekPosition);
-    // }
 }
 
 void ReadAheadManager::hintReader(double dRate, gsl::not_null<HintVector*> pHintList) {

--- a/src/engine/readaheadmanager.cpp
+++ b/src/engine/readaheadmanager.cpp
@@ -12,7 +12,8 @@ ReadAheadManager::ReadAheadManager()
           m_currentPosition(0),
           m_pReader(nullptr),
           m_pCrossFadeBuffer(SampleUtil::alloc(MAX_BUFFER_LEN)),
-          m_cacheMissCount(0) {
+          m_cacheMissCount(0),
+          m_cacheMissExpected(false) {
     // For testing only: ReadAheadManagerMock
 }
 
@@ -23,7 +24,8 @@ ReadAheadManager::ReadAheadManager(CachingReader* pReader,
           m_currentPosition(0),
           m_pReader(pReader),
           m_pCrossFadeBuffer(SampleUtil::alloc(MAX_BUFFER_LEN)),
-          m_cacheMissCount(0) {
+          m_cacheMissCount(0),
+          m_cacheMissExpected(false) {
     DEBUG_ASSERT(m_pLoopingControl != nullptr);
     DEBUG_ASSERT(m_pReader != nullptr);
 }
@@ -103,7 +105,11 @@ SINT ReadAheadManager::getNextSamples(double dRate, CSAMPLE* pOutput,
                 CSAMPLE_GAIN_ONE,
                 samples_from_reader);
         // Reset the cache miss flag, because we are now back on track.
+        if (!m_cacheMissExpected) {
+            qDebug() << "ReadAheadManager: continue after number cache misses:" << m_cacheMissCount;
+        }
         m_cacheMissCount = 0;
+        m_cacheMissExpected = false;
     }
 
     // Increment or decrement current read-ahead position
@@ -210,6 +216,7 @@ void ReadAheadManager::addRateControl(RateControl* pRateControl) {
 void ReadAheadManager::notifySeek(double seekPosition) {
     m_currentPosition = seekPosition;
     m_cacheMissCount = 0;
+    m_cacheMissExpected = true;
     m_readAheadLog.clear();
 }
 

--- a/src/engine/readaheadmanager.h
+++ b/src/engine/readaheadmanager.h
@@ -123,5 +123,5 @@ class ReadAheadManager {
     double m_currentPosition;
     CachingReader* m_pReader;
     CSAMPLE* m_pCrossFadeBuffer;
-    bool m_cacheMissHappened;
+    int m_cacheMissCount;
 };

--- a/src/engine/readaheadmanager.h
+++ b/src/engine/readaheadmanager.h
@@ -124,4 +124,5 @@ class ReadAheadManager {
     CachingReader* m_pReader;
     CSAMPLE* m_pCrossFadeBuffer;
     int m_cacheMissCount;
+    bool m_cacheMissExpected;
 };

--- a/src/sources/soundsourcemp3.cpp
+++ b/src/sources/soundsourcemp3.cpp
@@ -506,9 +506,9 @@ void SoundSourceMp3::close() {
 
 void SoundSourceMp3::restartDecoding(
         const SeekFrameType& seekFrame) {
-    if (kLogger.debugEnabled()) {
-        kLogger.info() << "restartDecoding for frame" << seekFrame.frameIndex << "@"
-                       << (seekFrame.pInputData - m_pFileData);
+    if (kLogger.traceEnabled()) {
+        kLogger.trace() << "restartDecoding for frame" << seekFrame.frameIndex << "@"
+                        << (seekFrame.pInputData - m_pFileData);
     }
 
     // Discard decoded output
@@ -696,16 +696,16 @@ ReadableSampleFrames SoundSourceMp3::readSampleFramesClamped(
                         // Don't bother the user with warnings from recoverable
                         // errors while skipping decoded samples or that even
                         // might occur for files that are perfectly ok.
-                        if (kLogger.debugEnabled()) {
-                            kLogger.debug()
+                        if (kLogger.traceEnabled()) {
+                            kLogger.trace()
                                     << "Recoverable MP3 frame decoding error:"
                                     << mad_stream_errorstr(&m_madStream);
                         }
                     } else if (m_madStream.error == MAD_ERROR_BADDATAPTR &&
                             m_curFrameIndex == firstFrameIndex) {
                         // This is expected after starting decoding with an offset
-                        if (kLogger.debugEnabled()) {
-                            kLogger.debug()
+                        if (kLogger.traceEnabled()) {
+                            kLogger.trace()
                                     << "Recoverable MP3 frame decoding error:"
                                     << mad_stream_errorstr(&m_madStream);
                         }


### PR DESCRIPTION
This PR removes expected error messages from the mixxx.log and introduces a new logging message in case we pick up decoding after unexpected cache misses. 
Since this is logging form the engine thread which is locking, we can't not log every cache miss itself to not make the issue worse in cases is is barely bearable.  

This is an attempt to debug: https://github.com/mixxxdj/mixxx/issues/14785