### PR TITLE
fix(mapping): Denon MC7000 crossfader curve using wrong parameter

### DIFF
--- a/res/controllers/Denon-MC7000-scripts.js
+++ b/res/controllers/Denon-MC7000-scripts.js
@@ -1041,7 +1041,7 @@ MC7000.parameterButtonRightShifted = function(channel, control, value, status, g
 };
 
 // Set Crossfader Curve
-MC7000.crossFaderCurve = function(control, value) {
+MC7000.crossFaderCurve = function(channel, control, value) {
     script.crossfaderCurve(value);
 };
 


### PR DESCRIPTION
Fixes crossfader curve function to use the proper MIDI parameter for value.

The function was using the second parameter (control=0x09) instead of the third parameter (value=0-127), causing the crossfader curve to always be set to 9 regardless of actual knob position.