### PR TITLE
fix(mapping): Denon MC7000 slicer mode TypeError

### DIFF
--- a/res/controllers/Denon-MC7000-scripts.js
+++ b/res/controllers/Denon-MC7000-scripts.js
@@ -1140,7 +1140,7 @@ MC7000.TrackPositionLEDs = function(value, group) {
     if (!MC7000.experimental) {
         return;
     }
-    if (MC7000.PADModeSlicer[deckIndex]) {
+    if (MC7000.PADMode[deckIndex] === "Slicer") {
         // only send new LED status when beatCountLED really changes
         if (MC7000.prevPadLED[deckIndex] !== beatCountLED) {
             // first set all LEDs to default color incl shifted


### PR DESCRIPTION
Fixes TypeError "Cannot read property '1' of undefined" when experimental slicer beat counter feature is enabled.

The error occurred because code was incorrectly attempting to access `MC7000.PADModeSlicer[deckIndex]` which doesn't exist, instead of using `MC7000.PADMode[deckIndex] === "Slicer"`.