### PR TITLE
(fix) adjust Gain after adopting it as ReplayGain only in requesting player

### DIFF
--- a/src/mixer/baseplayer.h
+++ b/src/mixer/baseplayer.h
@@ -17,7 +17,5 @@ class BasePlayer : public QObject {
 
   protected:
     PlayerManager* m_pPlayerManager;
-
-  private:
     const QString m_group;
 };

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -798,19 +798,26 @@ void BaseTrackPlayerImpl::slotSetReplayGain(mixxx::ReplayGain replayGain) {
     }
 }
 
-void BaseTrackPlayerImpl::slotAdjustReplayGain(mixxx::ReplayGain replayGain) {
+void BaseTrackPlayerImpl::slotAdjustReplayGain(
+        mixxx::ReplayGain replayGain, const QString& requestingPlayerGroup) {
     const double factor = m_pReplayGain->get() / replayGain.getRatio();
     const double newPregain = m_pPreGain->get() * factor;
 
     // There is a very slight chance that there will be a buffer call in between these sets.
     // Therefore, we first adjust the control that is being lowered before the control
     // that is being raised.  Worst case, the volume goes down briefly before rectifying.
+    // Only reset Gain if this player requested the change, ie. avoid Gain change
+    // in other players this track is loaded to.
     if (factor < 1.0) {
-        m_pPreGain->set(newPregain);
+        if (requestingPlayerGroup == m_group) {
+            m_pPreGain->set(newPregain);
+        }
         setReplayGain(replayGain.getRatio());
     } else {
         setReplayGain(replayGain.getRatio());
-        m_pPreGain->set(newPregain);
+        if (requestingPlayerGroup == m_group) {
+            m_pPreGain->set(newPregain);
+        }
     }
 }
 
@@ -972,7 +979,7 @@ void BaseTrackPlayerImpl::slotUpdateReplayGainFromPregain(double pressed) {
     if (gain == 1.0) {
         return;
     }
-    m_pLoadedTrack->adjustReplayGainFromPregain(gain);
+    m_pLoadedTrack->adjustReplayGainFromPregain(gain, m_group);
 }
 
 void BaseTrackPlayerImpl::setReplayGain(double value) {

--- a/src/mixer/basetrackplayer.h
+++ b/src/mixer/basetrackplayer.h
@@ -102,7 +102,7 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
     void slotSetReplayGain(mixxx::ReplayGain replayGain);
     /// When the replaygain is adjusted, we modify the track pregain
     /// to compensate so there is no audible change in volume.
-    void slotAdjustReplayGain(mixxx::ReplayGain replayGain);
+    void slotAdjustReplayGain(mixxx::ReplayGain replayGain, const QString& requestingPlayerGroup);
     void slotSetTrackColor(const mixxx::RgbColor::optional_t& color);
     void slotTrackColorSelector(int steps);
 

--- a/src/test/replaygaintest.cpp
+++ b/src/test/replaygaintest.cpp
@@ -179,13 +179,12 @@ TEST_F(AdjustReplayGainTest, AdjustReplayGainUpdatesPregain) {
     ControlObject::getControl(ConfigKey(m_sGroup1, "pregain"))->set(1.2);
     ControlObject::getControl(ConfigKey(m_sGroup1, "update_replaygain_from_pregain"))->set(1.0);
 
-    // The pregain value is folded into the replaygain value, and all pregains for all decks that
-    // have the same track loaded are adjusted so that the audible volume of the track does not
-    // change.
+    // The pregain value is folded into the replaygain value, and pregains is reset
+    // for the deck where the adjust control was triggered so that the audible volume
+    // of the track does not change.
+    // Pregain should not change on other decks with this track loaded.
     EXPECT_DOUBLE_EQ(1.0, ControlObject::getControl(ConfigKey(m_sGroup1, "pregain"))->get());
-    EXPECT_NEAR(0.83333333,
-            ControlObject::getControl(ConfigKey(m_sGroup2, "pregain"))->get(),
-            .005);
+    EXPECT_DOUBLE_EQ(1.0, ControlObject::getControl(ConfigKey(m_sGroup2, "pregain"))->get());
     EXPECT_DOUBLE_EQ(1.2, ControlObject::getControl(ConfigKey(m_sGroup1, "replaygain"))->get());
     EXPECT_DOUBLE_EQ(1.2, ControlObject::getControl(ConfigKey(m_sGroup2, "replaygain"))->get());
     EXPECT_DOUBLE_EQ(1.2, pTrack->getReplayGain().getRatio());

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -362,13 +362,13 @@ void Track::setReplayGain(const mixxx::ReplayGain& replayGain) {
     }
 }
 
-void Track::adjustReplayGainFromPregain(double gain) {
+void Track::adjustReplayGainFromPregain(double gain, const QString& requestingPlayerGroup) {
     auto locked = lockMutex(&m_qMutex);
     mixxx::ReplayGain replayGain = m_record.getMetadata().getTrackInfo().getReplayGain();
     replayGain.setRatio(gain * replayGain.getRatio());
     if (compareAndSet(m_record.refMetadata().refTrackInfo().ptrReplayGain(), replayGain)) {
         markDirtyAndUnlock(&locked);
-        emit replayGainAdjusted(replayGain);
+        emit replayGainAdjusted(replayGain, requestingPlayerGroup);
     }
 }
 

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -152,7 +152,7 @@ class Track : public QObject {
 
     void setReplayGain(const mixxx::ReplayGain&);
     // Adjust ReplayGain by multiplying the given gain amount.
-    void adjustReplayGainFromPregain(double);
+    void adjustReplayGainFromPregain(double gain, const QString& requestingPlayerGroup);
     // Returns ReplayGain
     mixxx::ReplayGain getReplayGain() const;
 
@@ -445,7 +445,7 @@ class Track : public QObject {
     void replayGainUpdated(mixxx::ReplayGain replayGain);
     // This signal indicates that ReplayGain is being adjusted, and pregains should be
     // adjusted in the opposite direction to compensate (no audible change).
-    void replayGainAdjusted(const mixxx::ReplayGain&);
+    void replayGainAdjusted(const mixxx::ReplayGain&, const QString& requestingPlayerGroup);
     void colorUpdated(const mixxx::RgbColor::optional_t& color);
     void ratingUpdated(int rating);
     void cuesUpdated();

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -1358,7 +1358,7 @@ void WTrackMenu::slotUpdateReplayGainFromPregain() {
     if (gain == 1.0) {
         return;
     }
-    m_pTrack->adjustReplayGainFromPregain(gain);
+    m_pTrack->adjustReplayGainFromPregain(gain, m_deckGroup);
 }
 
 void WTrackMenu::slotImportMetadataFromFileTags() {


### PR DESCRIPTION
Fixes #14806

### The issue:
if a track's ReplayGain is adjusted, all players that have it loaded adjust the Gain knob so that the effective gain remains unchanged. I guess this is supposed to prevent sudden volume changes in case that track is being played in other decks, besides the one where the ReplayGain was adjusted. While this seems okay for main decks where the Gain knob is _usually_ visible, it has unpleasant side effects (samplers, preview deck, see #14806) and users have little chance to fix it.

I think we should drop this.
If users decide to adjust the ReplayGain while playing a track, they need to be aware of the effect.
And I guess this lesson is learned quickly ; )

### The fix:
Adjust gain only the requesting player.
The requesting player group string is passed around so that only the requester adjusts the Gain knob.

When invoked via CO, BaseTrackPlayer(Impl) could as well send a pointer to itself, but ReplayGain can also be adjusted via WTrackMenu which acts on the Track directly (and has and should have no knowledge about the actual player) I decided to use the group string.