### PR TITLE
DEBUG kbd mapping: umlauts (de_DE locale) slip through while editable table cell is focused -- 2.6

### DIFF
--- a/src/controllers/keyboard/keyboardeventfilter.cpp
+++ b/src/controllers/keyboard/keyboardeventfilter.cpp
@@ -22,7 +22,7 @@ KeyboardEventFilter::KeyboardEventFilter(ConfigObject<ConfigValueKbd>* pKbdConfi
 KeyboardEventFilter::~KeyboardEventFilter() {
 }
 
-bool KeyboardEventFilter::eventFilter(QObject*, QEvent* e) {
+bool KeyboardEventFilter::eventFilter(QObject* obj, QEvent* e) {
     if (e->type() == QEvent::FocusOut) {
         // If we lose focus, we need to clear out the active key list
         // because we might not get Key Release events.
@@ -153,7 +153,9 @@ bool KeyboardEventFilter::eventFilter(QObject*, QEvent* e) {
     } else if (e->type() == QEvent::KeyboardLayoutChange) {
         // This event is not fired on ubunty natty, why?
         // TODO(XXX): find a way to support KeyboardLayoutChange Bug #997811
-        //qDebug() << "QEvent::KeyboardLayoutChange";
+        qWarning() << "  kbd filter: KeyboardLayoutChange event" << obj;
+    } else if (e->type() == QEvent::InputMethod) {
+        qWarning() << "  kbd filter: InputMethod event" << obj;
     }
     return false;
 }

--- a/src/controllers/keyboard/keyboardeventfilter.cpp
+++ b/src/controllers/keyboard/keyboardeventfilter.cpp
@@ -156,6 +156,13 @@ bool KeyboardEventFilter::eventFilter(QObject* obj, QEvent* e) {
         qWarning() << "  kbd filter: KeyboardLayoutChange event" << obj;
     } else if (e->type() == QEvent::InputMethod) {
         qWarning() << "  kbd filter: InputMethod event" << obj;
+        QInputMethodEvent* ime = static_cast<QInputMethodEvent*>(e);
+        qWarning() << "  --commitStr " << ime->commitString();
+        // ä Qt::Key_Adiaeresis
+        // ö Qt::Key_Odiaeresis
+        // ü Qt::Key_Udiaeresis
+        // ß Qt::Key_ssharp
+        qWarning() << "  --preeditStr" << ime->preeditString();
     }
     return false;
 }

--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -121,7 +121,13 @@ Bool __xErrorHandler(Display* display, XErrorEvent* event, xError* error) {
 inline QLocale inputLocale() {
     // Use the default config for local keyboard
     QInputMethod* pInputMethod = QGuiApplication::inputMethod();
-    return pInputMethod ? pInputMethod->locale() : QLocale(QLocale::English);
+    if (pInputMethod) {
+        qWarning() << "---CoreServices: use inputLocale" << pInputMethod->locale().name();
+        return pInputMethod->locale();
+    } else {
+        qWarning() << "---CoreServices: NO inputLocale, return English";
+        return QLocale(QLocale::English);
+    }
 }
 } // anonymous namespace
 

--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -542,6 +542,8 @@ void CoreServices::initializeKeyboard() {
         pConfig->set(ConfigKey("[Keyboard]", "Enabled"), ConfigValue(1));
     }
 
+    QLocale locale = inputLocale();
+
     // Read keyboard configuration and set kdbConfig object in WWidget
     // Check first in user's Mixxx directory
     QString userKeyboard = QDir(pConfig->getSettingsPath()).filePath("Custom.kbd.cfg");
@@ -554,7 +556,6 @@ void CoreServices::initializeKeyboard() {
         m_pKbdConfig = std::make_shared<ConfigObject<ConfigValueKbd>>(userKeyboard);
     } else {
         // Default to the locale for the main input method (e.g. keyboard).
-        QLocale locale = inputLocale();
 
         // check if a default keyboard exists
         QString defaultKeyboard = QString(resourcePath).append("keyboard/");

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -21,6 +21,34 @@
 
 namespace {
 const QString kAppGroup = QStringLiteral("[App]");
+
+QString focusWidgetStr(FocusWidget fw) {
+    switch (fw) {
+    case FocusWidget::None: {
+        return "None";
+    }
+    case FocusWidget::Searchbar: {
+        return "Searchbar";
+    }
+    case FocusWidget::Sidebar: {
+        return "Sidebar";
+    }
+    case FocusWidget::TracksTable: {
+        return "TracksTable";
+    }
+    case FocusWidget::ContextMenu: {
+        return "ContextMenu";
+    }
+    case FocusWidget::Dialog: {
+        return "Dialog";
+    }
+    case FocusWidget::Unknown: {
+        return "Unknown";
+    }
+    default:
+        return "---";
+    }
+}
 } // namespace
 
 LoadToGroupController::LoadToGroupController(LibraryControl* pParent, const QString& group)
@@ -1017,6 +1045,7 @@ void LibraryControl::slotFocusedWidgetChanged(QWidget* oldW, QWidget* newW) {
 void LibraryControl::updateFocusedWidgetControls() {
     m_focusedWidget = getFocusedWidget();
     // Update "[Library], focused_widget" control
+    qWarning().noquote() << "------- now focused:" << focusWidgetStr(m_focusedWidget);
     double newVal = static_cast<double>(m_focusedWidget);
     m_pFocusedWidgetCO->setAndConfirm(newVal);
 }

--- a/src/preferences/configobject.cpp
+++ b/src/preferences/configobject.cpp
@@ -351,10 +351,14 @@ template <class ValueType>
 QMultiHash<ValueType, ConfigKey> ConfigObject<ValueType>::transpose() const {
     QReadLocker lock(&m_valuesLock);
 
+    qWarning() << "   .";
+    qWarning() << "   ConfigObject::transpose, values:";
     QMultiHash<ValueType, ConfigKey> transposedHash;
     for (auto it = m_values.constBegin(); it != m_values.constEnd(); ++it) {
+        qWarning().noquote() << "   " << it.value().value << it.key();
         transposedHash.insert(it.value(), it.key());
     }
+    qWarning() << "   .";
     return transposedHash;
 }
 

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -78,6 +78,18 @@ WTrackTableView::WTrackTableView(QWidget* pParent,
     setInputMethodHints(Qt::ImhNone);
 }
 
+void WTrackTableView::currentChanged(
+        const QModelIndex& current,
+        const QModelIndex& previous) {
+    QTableView::currentChanged(current, previous);
+    // Reset Qt::WA_InputMethodEnabled right away if no editor is open
+    if (state() != QTableView::EditingState) {
+        // how would currentChanged be called anyway when an editor is open?
+        // Star delegate hovered?
+        setAttribute(Qt::WA_InputMethodEnabled, false);
+    }
+}
+
 WTrackTableView::~WTrackTableView() {
     WTrackTableViewHeader* pHeader =
             qobject_cast<WTrackTableViewHeader*>(horizontalHeader());

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1355,8 +1355,12 @@ void WTrackTableView::hideOrRemoveSelectedTracks() {
 /// If applicable, requests that the selected field/item be edited
 /// Does nothing otherwise.
 void WTrackTableView::editSelectedItem() {
+    qWarning() << "----WTTV editSelItem";
     if (state() != EditingState) {
+        qWarning() << "----edit";
         edit(currentIndex(), EditKeyPressed, nullptr);
+    } else {
+        qWarning() << "----!return";
     }
 }
 

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -74,6 +74,8 @@ WTrackTableView::WTrackTableView(QWidget* pParent,
             &WTrackTableView::scrollValueChanged,
             this,
             &WTrackTableView::slotScrollValueChanged);
+
+    setInputMethodHints(Qt::ImhNone);
 }
 
 WTrackTableView::~WTrackTableView() {

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1117,6 +1117,7 @@ void WTrackTableView::moveSelectedTracks(QKeyEvent* event) {
 }
 
 void WTrackTableView::keyPressEvent(QKeyEvent* event) {
+    qWarning() << "     WTrackTableView keypress:" << QKeySequence(event->key()).toString();
     switch (event->key()) {
     case kPropertiesShortcutKey: {
         // Return invokes the double-click action.
@@ -1207,7 +1208,13 @@ void WTrackTableView::keyPressEvent(QKeyEvent* event) {
             return;
         }
     }
+    qWarning() << "     --> passed to QTableView";
     QTableView::keyPressEvent(event);
+}
+
+void WTrackTableView::keyboardSearch(const QString& search) {
+    qWarning() << "     --> kbd search" << search;
+    QTableView::keyboardSearch(search);
 }
 
 void WTrackTableView::resizeEvent(QResizeEvent* event) {

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -39,6 +39,7 @@ class WTrackTableView : public WLibraryTableView {
     void setFocus() override;
     void pasteFromSidebar() override;
     void keyPressEvent(QKeyEvent* event) override;
+    void keyboardSearch(const QString& search) override;
     void resizeEvent(QResizeEvent* event) override;
     void editSelectedItem();
     void activateSelectedTrack();

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -33,6 +33,9 @@ class WTrackTableView : public WLibraryTableView {
     ~WTrackTableView() override;
     // can't use, it's not virtual in QWidget
     // void setAttribute(Qt::WidgetAttribute attribute, bool on = true) override;
+
+    void currentChanged(const QModelIndex& current, const QModelIndex& previous) override;
+
     void contextMenuEvent(QContextMenuEvent * event) override;
     QString columnNameOfIndex(const QModelIndex& index) const;
     void onSearch(const QString& text) override;

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -31,6 +31,8 @@ class WTrackTableView : public WLibraryTableView {
             Library* pLibrary,
             double backgroundColorOpacity);
     ~WTrackTableView() override;
+    // can't use, it's not virtual in QWidget
+    // void setAttribute(Qt::WidgetAttribute attribute, bool on = true) override;
     void contextMenuEvent(QContextMenuEvent * event) override;
     QString columnNameOfIndex(const QModelIndex& index) const;
     void onSearch(const QString& text) override;


### PR DESCRIPTION
same as #13795, based on 2.6
____
This adds some logging in order to debug the umlaut issue reported here
* [Mixxx forum: Keyboard shortcut “ö” stopped working (other umlauts affected, too)](https://mixxx.discourse.group/t/keyboard-shortcut-o-stopped-working-other-umlauts-affected-too/30470/14)
* [#14734 2.6 - Key "ö" doesn't trigger shortcut in table view, searches in column instead](https://github.com/mixxxdj/mixxx/pull/14734)

Happens with Qt5 and Qt6 and german locale.

### Symptoms:
In the tracks view, certain special characters (äöüß) don't trigger the controls set in the kbd mapping if the focus is on editable cells (even if `selectedClick` is disabled).
keyboardSearch() is called instead.
In the treeview the same shortcuts work.

I don't understand how these keys can slip through `KeyboardEventFilter::eventFilter`.
IIUC QKeyEvents are processed like this:
1. KeyboardEventFilter is installed on every single WTrackTableView during skin construction
2. KeyboardEventFilter::eventFilter
   * checks if it's not modifier-only and if there is a mapping for the key
   * if yes: key event is consumed, control is triggered
3. else WTrackTableView::keyPressEvent() is called
   * if it's a special key handled by us, respective function is called and consumes the key event
   * else QTableView::keyPressEvent() is called which might call
4. QAbstractItemView::keyboardSearch(text) if the QKeyEvent::text() is not empty

### More findings:
* `selectedClick` On/Off has no effect ("Edit metadata when clicking selected items")
* locale is detected correctly, de_DE.kbd-cfg is loaded