### PR TITLE
[POC] Add downbeats to waveform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1831,6 +1831,7 @@ if(QOPENGL)
       src/waveform/renderers/allshader/matrixforwidgetgeometry.cpp
       src/waveform/renderers/allshader/waveformrenderbackground.cpp
       src/waveform/renderers/allshader/waveformrenderbeat.cpp
+      src/waveform/renderers/allshader/waveformrenderdownbeat.cpp
       src/waveform/renderers/allshader/waveformrenderer.cpp
       src/waveform/renderers/allshader/waveformrendererendoftrack.cpp
       src/waveform/renderers/allshader/waveformrendererslipmode.cpp
@@ -3455,6 +3456,7 @@ if(QML)
       src/qml/qmlsettingparameter.cpp
       src/waveform/renderers/allshader/digitsrenderer.cpp
       src/waveform/renderers/allshader/waveformrenderbeat.cpp
+      src/waveform/renderers/allshader/waveformrenderdownbeat.cpp
       src/waveform/renderers/allshader/waveformrenderer.cpp
       src/waveform/renderers/allshader/waveformrendererendoftrack.cpp
       src/waveform/renderers/allshader/waveformrendererpreroll.cpp

--- a/res/skins/LateNight/palemoon/buttons/btn__backward_down_beats_marker.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__backward_down_beats_marker.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 0 24 24"
+   id="svg128"
+   sodipodi:docname="btn__backward_down_beats_marker.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs132" />
+  <sodipodi:namedview
+     id="namedview130"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     showgrid="false"
+     inkscape:zoom="31.782809"
+     inkscape:cx="12.978714"
+     inkscape:cy="12.113467"
+     inkscape:window-width="1920"
+     inkscape:window-height="1011"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg128" />
+  <g
+     fill="none"
+     stroke="#000000"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     stroke-width="1.6"
+     id="g116"
+     transform="matrix(-1,0,0,1,24.701086,0)">
+    <g
+       transform="translate(1,-10)"
+       id="g114">
+      <path
+         d="m 8,31 h 2 V 13 H 8 Z"
+         id="path106" />
+      <path
+         d="m 13,31 h 2 V 13 h -2 z"
+         id="path108" />
+      <path
+         d="m 18,31 h 2 V 13 h -2 z"
+         id="path110" />
+      <path
+         d="M 3,31 H 5 V 13 H 3 Z"
+         id="path112" />
+    </g>
+  </g>
+  <g
+     transform="matrix(-1,0,0,1,23.701086,-10)"
+     fill="#3f3d3d"
+     id="g126">
+    <path
+       d="m 8,31 h 2 V 13 H 8 Z"
+       id="path118" />
+    <path
+       d="m 13,31 h 2 V 13 h -2 z"
+       id="path120"
+       style="fill:#ff0000" />
+    <path
+       d="M 3,31 H 5 V 13 H 3 Z"
+       id="path122"
+       style="fill:#ff0000" />
+    <path
+       d="m 18,31 h 2 V 13 h -2 z"
+       id="path124" />
+  </g>
+  <path
+     d="M 8.6967185,6.2388508 V 10.687604 H 22.265535 v 2.965828 H 8.6967185 v 4.44875 l -7.306285,-5.931664 z"
+     fill="#928476"
+     id="path850"
+     style="fill:#928476;fill-opacity:1;stroke:#000000;stroke-width:1.353;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers" />
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__backward_down_beats_marker_active.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__backward_down_beats_marker_active.svg
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 0 24 24"
+   id="svg128"
+   sodipodi:docname="btn__backward_down_beats_marker_active.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs132" />
+  <sodipodi:namedview
+     id="namedview130"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     showgrid="false"
+     inkscape:zoom="20.857468"
+     inkscape:cx="11.195031"
+     inkscape:cy="14.479226"
+     inkscape:window-width="1920"
+     inkscape:window-height="1011"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg128" />
+  <g
+     fill="none"
+     stroke="#000000"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     stroke-width="1.6"
+     id="g116"
+     transform="matrix(-1,0,0,1,24.701086,0)">
+    <g
+       transform="translate(1,-10)"
+       id="g114" />
+  </g>
+  <g
+     transform="matrix(-1,0,0,1,23.701086,-10)"
+     fill="#3f3d3d"
+     id="g126"
+     style="fill:#000000">
+    <path
+       d="m 8,31 h 2 V 25 H 8 Z"
+       id="path118"
+       sodipodi:nodetypes="ccccc"
+       style="fill:#000000" />
+    <path
+       d="M 3,31 H 5 V 25 H 3 Z"
+       id="path122"
+       style="fill:#000000"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       d="m 18,31 h 2 v -4 h -2 z"
+       id="path124"
+       sodipodi:nodetypes="ccccc"
+       style="fill:#000000" />
+  </g>
+  <g
+     transform="matrix(-1,0,0,1,23.695685,-10.015571)"
+     fill="#3f3d3d"
+     id="g126-6"
+     style="fill:#000000">
+    <path
+       d="m 8,19 h 2 V 13 H 8 Z"
+       id="path118-2"
+       style="fill:#000000"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       d="m 13,19 h 1.104921 L 14.124739,15.505489 15,15.516636 V 13 h -2 z"
+       id="path120-9"
+       style="fill:#000000"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       d="m 12.887858,25.154872 h 1.104921 l 0.01982,3.494511 0.875261,-0.01115 v 2.516636 h -2 z"
+       id="path120-9-7"
+       style="fill:#000000"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       d="M 3,19 H 5 V 13 H 3 Z"
+       id="path122-1"
+       style="fill:#000000"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       d="m 18,17 h 2 v -4 h -2 z"
+       id="path124-2"
+       style="fill:#000000"
+       sodipodi:nodetypes="ccccc" />
+  </g>
+  <path
+     d="M 8.6967185,6.2388508 V 10.687604 H 22.265535 v 2.965828 H 8.6967185 v 4.44875 l -7.306285,-5.931664 z"
+     fill="#928476"
+     id="path850"
+     style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.653;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers" />
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__forward_down_beats_marker.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__forward_down_beats_marker.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 0 24 24"
+   id="svg128"
+   sodipodi:docname="btn__forward_down_beats_marker.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs132" />
+  <sodipodi:namedview
+     id="namedview130"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     showgrid="false"
+     inkscape:zoom="20.857468"
+     inkscape:cx="11.195031"
+     inkscape:cy="14.479226"
+     inkscape:window-width="1920"
+     inkscape:window-height="1011"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg128" />
+  <g
+     fill="none"
+     stroke="#000000"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     stroke-width="1.6"
+     id="g116"
+     transform="translate(-1.045069)">
+    <g
+       transform="translate(1,-10)"
+       id="g114">
+      <path
+         d="m 8,31 h 2 V 13 H 8 Z"
+         id="path106" />
+      <path
+         d="m 13,31 h 2 V 13 h -2 z"
+         id="path108" />
+      <path
+         d="m 18,31 h 2 V 13 h -2 z"
+         id="path110" />
+      <path
+         d="M 3,31 H 5 V 13 H 3 Z"
+         id="path112" />
+    </g>
+  </g>
+  <g
+     transform="translate(-0.04506903,-10)"
+     fill="#3f3d3d"
+     id="g126">
+    <path
+       d="m 8,31 h 2 V 13 H 8 Z"
+       id="path118" />
+    <path
+       d="m 13,31 h 2 V 13 h -2 z"
+       id="path120"
+       style="fill:#ff0000" />
+    <path
+       d="M 3,31 H 5 V 13 H 3 Z"
+       id="path122"
+       style="fill:#ff0000" />
+    <path
+       d="m 18,31 h 2 V 13 h -2 z"
+       id="path124" />
+  </g>
+  <path
+     d="M 14.959298,6.2388508 V 10.687604 H 1.390482 v 2.965828 h 13.568816 v 4.44875 l 7.306285,-5.931664 z"
+     fill="#928476"
+     id="path850"
+     style="fill:#928476;fill-opacity:1;stroke:#000000;stroke-width:1.653;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers" />
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__forward_down_beats_marker_active.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__forward_down_beats_marker_active.svg
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 0 24 24"
+   id="svg128"
+   sodipodi:docname="btn__forward_down_beats_marker_active.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs132" />
+  <sodipodi:namedview
+     id="namedview130"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     showgrid="false"
+     inkscape:zoom="20.857468"
+     inkscape:cx="11.195031"
+     inkscape:cy="14.479226"
+     inkscape:window-width="1920"
+     inkscape:window-height="1011"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg128" />
+  <g
+     fill="none"
+     stroke="#000000"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     stroke-width="1.6"
+     id="g116"
+     transform="translate(-1.0451175)">
+    <g
+       transform="translate(1,-10)"
+       id="g114" />
+  </g>
+  <g
+     transform="translate(-0.0451175,-10)"
+     fill="#3f3d3d"
+     id="g126"
+     style="fill:#000000">
+    <path
+       d="m 8,31 h 2 V 25 H 8 Z"
+       id="path118"
+       sodipodi:nodetypes="ccccc"
+       style="fill:#000000" />
+    <path
+       d="M 3,31 H 5 V 25 H 3 Z"
+       id="path122"
+       style="fill:#000000"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       d="m 18,31 h 2 v -4 h -2 z"
+       id="path124"
+       sodipodi:nodetypes="ccccc"
+       style="fill:#000000" />
+  </g>
+  <g
+     transform="translate(-0.0397165,-10.015571)"
+     fill="#3f3d3d"
+     id="g126-6"
+     style="fill:#000000">
+    <path
+       d="m 8,19 h 2 V 13 H 8 Z"
+       id="path118-2"
+       style="fill:#000000"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       d="m 13,19 h 1.104921 L 14.124739,15.505489 15,15.516636 V 13 h -2 z"
+       id="path120-9"
+       style="fill:#000000"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       d="m 12.887858,25.154872 h 1.104921 l 0.01982,3.494511 0.875261,-0.01115 v 2.516636 h -2 z"
+       id="path120-9-7"
+       style="fill:#000000"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       d="M 3,19 H 5 V 13 H 3 Z"
+       id="path122-1"
+       style="fill:#000000"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       d="m 18,17 h 2 v -4 h -2 z"
+       id="path124-2"
+       style="fill:#000000"
+       sodipodi:nodetypes="ccccc" />
+  </g>
+  <path
+     d="M 14.95925,6.2388508 V 10.687604 H 1.3904335 v 2.965828 H 14.95925 v 4.44875 l 7.306285,-5.931664 z"
+     fill="#928476"
+     id="path850"
+     style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.653;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers" />
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__hide_down_beats_marker.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__hide_down_beats_marker.svg
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 0 24 24"
+   id="svg128"
+   sodipodi:docname="btn__hide_down_beats_marker.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs132" />
+  <sodipodi:namedview
+     id="namedview130"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     showgrid="false"
+     inkscape:zoom="20.857468"
+     inkscape:cx="11.266948"
+     inkscape:cy="14.479226"
+     inkscape:window-width="1920"
+     inkscape:window-height="1011"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg128" />
+  <g
+     fill="none"
+     stroke="#000000"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     stroke-width="1.6"
+     id="g116"
+     transform="translate(-0.43658641)">
+    <g
+       transform="translate(1,-10)"
+       id="g114">
+      <path
+         d="m 8,31 h 2 V 13 H 8 Z"
+         id="path106" />
+      <path
+         d="m 13,31 h 2 V 13 h -2 z"
+         id="path108" />
+      <path
+         d="m 18,31 h 2 V 13 h -2 z"
+         id="path110" />
+      <path
+         d="M 3,31 H 5 V 13 H 3 Z"
+         id="path112" />
+    </g>
+  </g>
+  <g
+     transform="translate(0.56341356,-10)"
+     fill="#3f3d3d"
+     id="g126">
+    <path
+       d="m 8,31 h 2 V 13 H 8 Z"
+       id="path118" />
+    <path
+       d="m 13,31 h 2 V 13 h -2 z"
+       id="path120"
+       style="fill:#ff0000" />
+    <path
+       d="M 3,31 H 5 V 13 H 3 Z"
+       id="path122"
+       style="fill:#ff0000" />
+    <path
+       d="m 18,31 h 2 V 13 h -2 z"
+       id="path124" />
+  </g>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__show_down_beats_marker.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__show_down_beats_marker.svg
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   viewBox="0 0 24 24"
+   id="svg128"
+   sodipodi:docname="btn__show_down_beats_marker.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs132" />
+  <sodipodi:namedview
+     id="namedview130"
+     pagecolor="#505050"
+     bordercolor="#eeeeee"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#505050"
+     showgrid="false"
+     inkscape:zoom="20.857468"
+     inkscape:cx="11.266948"
+     inkscape:cy="14.479226"
+     inkscape:window-width="1920"
+     inkscape:window-height="1011"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg128" />
+  <g
+     fill="none"
+     stroke="#000000"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     stroke-width="1.6"
+     id="g116"
+     transform="translate(-0.43658641)">
+    <g
+       transform="translate(1,-10)"
+       id="g114">
+      <path
+         d="m 8,31 h 2 V 13 H 8 Z"
+         id="path106" />
+      <path
+         d="m 13,31 h 2 V 13 h -2 z"
+         id="path108" />
+      <path
+         d="m 18,31 h 2 V 13 h -2 z"
+         id="path110" />
+      <path
+         d="M 3,31 H 5 V 13 H 3 Z"
+         id="path112" />
+    </g>
+  </g>
+  <g
+     transform="translate(0.56341356,-10)"
+     fill="#3f3d3d"
+     id="g126">
+    <path
+       d="m 8,31 h 2 V 13 H 8 Z"
+       id="path118" />
+    <path
+       d="m 2.9898117,31.047918 h 2 v -18 h -2 z"
+       id="path118-2" />
+    <path
+       d="m 13.016571,31.067395 h 2 v -18 h -2 z"
+       id="path118-0" />
+    <path
+       d="m 18,31 h 2 V 13 h -2 z"
+       id="path124" />
+  </g>
+</svg>

--- a/res/skins/LateNight/skin.xml
+++ b/res/skins/LateNight/skin.xml
@@ -198,6 +198,7 @@
 
       <SetVariable name="AxesColor">#999</SetVariable>
       <SetVariable name="BeatColor">#999</SetVariable>
+      <SetVariable name="DownbeatColor">#f00</SetVariable>
       <SetVariable name="PlayPosColor">#00c6ff</SetVariable>
       <SetVariable name="CueColor">#ff7a01</SetVariable>
       <SetVariable name="LoopColor">#00b400</SetVariable>
@@ -333,6 +334,7 @@
       <SetVariable name="SignalLowColor">red</SetVariable>
       <SetVariable name="AxesColor">#ffffff</SetVariable>
       <SetVariable name="BeatColor">#ffffff</SetVariable>
+      <SetVariable name="DownbeatColor">#00c8ff</SetVariable>
       <SetVariable name="PlayPosColor">#00c8ff</SetVariable>
       <SetVariable name="CueColor">#ff001c</SetVariable>
       <SetVariable name="LoopColor">#00ff00</SetVariable>

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -2310,10 +2310,10 @@ WPushButton#PlayDeck[value="0"] {
   #FxFocusButton[value="1"] {
     image: url(skins:LateNight/palemoon/buttons/btn__fx_focus_active.svg) no-repeat center center;
   }
-#ToggleDownbeatsMarker[value="0"] {
+#ToggleDownbeatsMarker[value="1"] {
   image: url(skin:/palemoon/buttons/btn__show_down_beats_marker.svg) no-repeat center center;
   }
-#ToggleDownbeatsMarker[value="1"] {
+#ToggleDownbeatsMarker[value="0"] {
     image: url(skin:/palemoon/buttons/btn__hide_down_beats_marker.svg) no-repeat center center;
   }
 #BeatsForwardDownBeatsMarker[displayValue="0"] {

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -2310,6 +2310,24 @@ WPushButton#PlayDeck[value="0"] {
   #FxFocusButton[value="1"] {
     image: url(skins:LateNight/palemoon/buttons/btn__fx_focus_active.svg) no-repeat center center;
   }
+#ToggleDownbeatsMarker[value="0"] {
+  image: url(skin:/palemoon/buttons/btn__show_down_beats_marker.svg) no-repeat center center;
+  }
+#ToggleDownbeatsMarker[value="1"] {
+    image: url(skin:/palemoon/buttons/btn__hide_down_beats_marker.svg) no-repeat center center;
+  }
+#BeatsForwardDownBeatsMarker[displayValue="0"] {
+  image: url(skin:/palemoon/buttons/btn__forward_down_beats_marker.svg) no-repeat center center;
+  }
+#BeatsForwardDownBeatsMarker[pressed="true"] {
+    image: url(skin:/palemoon/buttons/btn__forward_down_beats_marker_active.svg) no-repeat center center;
+  }
+#BeatsBackwardDownBeatsMarker[displayValue="0"] {
+  image: url(skin:/palemoon/buttons/btn__backward_down_beats_marker.svg) no-repeat center center;
+  }
+#BeatsBackwardDownBeatsMarker[pressed="true"] {
+    image: url(skin:/palemoon/buttons/btn__backward_down_beats_marker_active.svg) no-repeat center center;
+  }
 
 /* deck controls for decks 1-4 and samplers */
 #CurposButton12[displayValue="0"], #CurposButton34[displayValue="0"] {

--- a/res/skins/LateNight/waveform.xml
+++ b/res/skins/LateNight/waveform.xml
@@ -264,6 +264,39 @@
         <Children>
           <WidgetGroup><Size>0me,1me</Size></WidgetGroup>
 
+              <WidgetGroup><!-- downbeats forward & backward marker -->
+                <Layout>horizontal</Layout>
+            <SizePolicy>f,f</SizePolicy>
+                <Children>
+              <WidgetGroup><Size>1f,0min</Size></WidgetGroup>
+
+                  <PushButton>
+                    <TooltipId>toggle_downbeats_marker</TooltipId>
+                    <ObjectName>ToggleDownbeatsMarker</ObjectName>
+                    <Size>26f,26f</Size>
+                    <NumberStates>2</NumberStates>
+                    <RightClickIsPushButton>false</RightClickIsPushButton>
+                    <Connection>
+                      <ConfigKey><Variable name="Group"/>,toggle_downbeats_marker</ConfigKey>
+                      <ButtonState>LeftButton</ButtonState>
+                    </Connection>
+                  </PushButton>
+
+                  <Template src="skin:/controls/button_1state.xml">
+                    <SetVariable name="TooltipId">beats_backward_down_beats_marker</SetVariable>
+                    <SetVariable name="ObjectName">BeatsBackwardDownBeatsMarker</SetVariable>
+                    <SetVariable name="Size">26f,26f</SetVariable>
+                    <SetVariable name="ConfigKey"><Variable name="Group"/>,beats_backward_down_beats_marker</SetVariable>
+                  </Template>
+                  <Template src="skin:/controls/button_1state.xml">
+                    <SetVariable name="TooltipId">beats_forward_down_beats_marker</SetVariable>
+                    <SetVariable name="ObjectName">BeatsForwardDownBeatsMarker</SetVariable>
+                    <SetVariable name="Size">26f,26f</SetVariable>
+                    <SetVariable name="ConfigKey"><Variable name="Group"/>,beats_forward_down_beats_marker</SetVariable>
+                  </Template>
+                </Children>
+              </WidgetGroup><!-- /downbeats forward & backward marker -->
+
           <WidgetGroup><!-- beat grid & hotcue shift buttons row -->
             <Layout>horizontal</Layout>
             <SizePolicy>f,f</SizePolicy>

--- a/res/skins/LateNight/waveform.xml
+++ b/res/skins/LateNight/waveform.xml
@@ -140,6 +140,7 @@
             <SignalRGBMidColor></SignalRGBMidColor>
             <SignalRGBLowColor></SignalRGBLowColor>
             <BeatColor><Variable name="BeatColor"/></BeatColor>
+            <DownbeatColor><Variable name="DownbeatColor"/></DownbeatColor>
             <AxesColor><Variable name="AxesColor"/></AxesColor>
             <BeatHighlightColor></BeatHighlightColor>
             <PlayPosColor><Variable name="PlayPosColor"/></PlayPosColor>

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -265,10 +265,49 @@ BpmControl::BpmControl(const QString& group,
     m_pBeatsUndoPossible = std::make_unique<ControlObject>(
             ConfigKey(group, "beats_undo_possible"));
     m_pBeatsUndoPossible->setReadOnly();
+
+    m_pBeatsForwardDownBeatsMarker = std::make_unique<ControlPushButton>(
+            ConfigKey(group, "beats_forward_down_beats_marker"), false);
+    m_pBeatsForwardDownBeatsMarker->setKbdRepeatable(true);
+    connect(m_pBeatsForwardDownBeatsMarker.get(),
+            &ControlObject::valueChanged,
+            this,
+            &BpmControl::slotForwardDownBeatsMarker,
+            Qt::DirectConnection);
+
+    m_pBeatsBackwardDownBeatsMarker = std::make_unique<ControlPushButton>(
+            ConfigKey(group, "beats_backward_down_beats_marker"), false);
+    m_pBeatsBackwardDownBeatsMarker->setKbdRepeatable(true);
+    connect(m_pBeatsBackwardDownBeatsMarker.get(),
+            &ControlObject::valueChanged,
+            this,
+            &BpmControl::slotBackwardDownBeatsMarker,
+            Qt::DirectConnection);
 }
 
 mixxx::Bpm BpmControl::getBpm() const {
     return mixxx::Bpm(m_pEngineBpm->get());
+}
+
+void BpmControl::slotForwardDownBeatsMarker(double v) {
+    if (v <= 0) {
+        return;
+    }
+    const TrackPointer pTrack = getEngineBuffer()->getLoadedTrack();
+    int downbeatOffset = pTrack->getDownbeatOffset();
+    downbeatOffset == 7 ? downbeatOffset = 0 : ++downbeatOffset;
+    pTrack->setDownbeatOffset(downbeatOffset);
+}
+
+void BpmControl::slotBackwardDownBeatsMarker(double v) {
+    if (v <= 0) {
+        return;
+    }
+    const TrackPointer pTrack = getEngineBuffer()->getLoadedTrack();
+    int downbeatOffset = pTrack->getDownbeatOffset();
+    if (downbeatOffset == 0)
+        downbeatOffset = 8;
+    pTrack->setDownbeatOffset(--downbeatOffset);
 }
 
 void BpmControl::adjustBeatsBpm(double deltaBpm) {

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -294,6 +294,8 @@ void BpmControl::slotForwardDownBeatsMarker(double v) {
         return;
     }
     const TrackPointer pTrack = getEngineBuffer()->getLoadedTrack();
+    if (!pTrack)
+        return;
     int downbeatOffset = pTrack->getDownbeatOffset();
     downbeatOffset == 7 ? downbeatOffset = 0 : ++downbeatOffset;
     pTrack->setDownbeatOffset(downbeatOffset);
@@ -304,6 +306,8 @@ void BpmControl::slotBackwardDownBeatsMarker(double v) {
         return;
     }
     const TrackPointer pTrack = getEngineBuffer()->getLoadedTrack();
+    if (!pTrack)
+        return;
     int downbeatOffset = pTrack->getDownbeatOffset();
     if (downbeatOffset == 0)
         downbeatOffset = 8;

--- a/src/engine/controls/bpmcontrol.h
+++ b/src/engine/controls/bpmcontrol.h
@@ -116,6 +116,8 @@ class BpmControl : public EngineControl {
     void slotBeatsTranslateMatchAlignment(double);
     void slotToggleBpmLock(double);
     void slotBeatsUndoAdjustment(double value);
+    void slotForwardDownBeatsMarker(double);
+    void slotBackwardDownBeatsMarker(double);
 
   private:
     SyncMode getSyncMode() const {
@@ -163,6 +165,9 @@ class BpmControl : public EngineControl {
     std::unique_ptr<ControlPushButton> m_pBeatsDouble;
 
     std::unique_ptr<ControlPushButton> m_pBpmLock;
+
+    std::unique_ptr<ControlPushButton> m_pBeatsForwardDownBeatsMarker;
+    std::unique_ptr<ControlPushButton> m_pBeatsBackwardDownBeatsMarker;
 
     // The current effective BPM of the engine
     std::unique_ptr<ControlLinPotmeter> m_pEngineBpm;

--- a/src/proto/beats.proto
+++ b/src/proto/beats.proto
@@ -28,4 +28,5 @@ message BeatMap {
 message BeatGrid {
   optional Bpm bpm = 1;
   optional Beat first_beat = 2;
+  optional int32 downbeats_offset = 3;
 }

--- a/src/test/beatstest.cpp
+++ b/src/test/beatstest.cpp
@@ -21,7 +21,8 @@ const auto kConstTempoBeats = Beats(
         kStartPosition,
         kBpm,
         kSampleRate,
-        QString());
+        QString(),
+        0);
 
 // Create beats with 8 beats at 120 BPM, then 16 beats at 60 Bpm, followed by 120 BPM.
 const auto kNonConstTempoBeats = Beats(
@@ -32,7 +33,8 @@ const auto kNonConstTempoBeats = Beats(
         kStartPosition + 8 * kSampleRate.value() / 2 + 16 * kSampleRate.value(),
         kBpm,
         kSampleRate,
-        QString());
+        QString(),
+        0);
 
 TEST(BeatsTest, ConstTempoGetBpmInRange) {
     EXPECT_DOUBLE_EQ(kBpm.value(),

--- a/src/track/beats.cpp
+++ b/src/track/beats.cpp
@@ -172,7 +172,7 @@ mixxx::BeatsPointer Beats::fromConstTempo(
         mixxx::audio::FramePos lastMarkerPosition,
         mixxx::Bpm lastMarkerBpm,
         const QString& subVersion,
-        const u_int8_t downbeatsOffset) {
+        const int downbeatsOffset) {
     VERIFY_OR_DEBUG_ASSERT(sampleRate.isValid() &&
             lastMarkerPosition.isValid() && lastMarkerBpm.isValid()) {
         return nullptr;
@@ -190,7 +190,7 @@ mixxx::BeatsPointer Beats::fromBeatPositions(
         mixxx::audio::SampleRate sampleRate,
         const QVector<audio::FramePos>& beatPositions,
         const QString& subVersion,
-        const u_int8_t downbeatsOffset) {
+        const int downbeatsOffset) {
     VERIFY_OR_DEBUG_ASSERT(sampleRate.isValid() && beatPositions.size() >= 2) {
         return nullptr;
     }
@@ -258,7 +258,7 @@ mixxx::BeatsPointer Beats::fromBeatMarkers(
         const audio::FramePos lastMarkerPosition,
         const Bpm lastMarkerBpm,
         const QString& subVersion,
-        const u_int8_t downbeatsOffset) {
+        const int downbeatsOffset) {
     return BeatsPointer(new Beats(markers,
             lastMarkerPosition,
             lastMarkerBpm,
@@ -319,7 +319,7 @@ mixxx::BeatsPointer Beats::fromBeatGridByteArray(
         bpm = mixxx::Bpm(pBlob->bpm);
     }
 
-    u_int8_t downbeatsOffset = grid.has_downbeats_offset() ? grid.downbeats_offset() : 0;
+    int downbeatsOffset = grid.has_downbeats_offset() ? grid.downbeats_offset() : 0;
 
     if (position.isValid() && bpm.isValid()) {
         return fromConstTempo(sampleRate, position, bpm, subVersion, downbeatsOffset);
@@ -722,7 +722,7 @@ std::optional<BeatsPointer> Beats::trySetBpm(mixxx::Bpm bpm) const {
     return BeatsPointer(new Beats({}, *it, bpm, m_sampleRate, m_subVersion, m_downbeatsOffset));
 }
 
-std::optional<BeatsPointer> Beats::trySetDownbeatsOffset(u_int8_t offset) const {
+std::optional<BeatsPointer> Beats::trySetDownbeatsOffset(int offset) const {
     return BeatsPointer(new Beats(m_markers,
             m_lastMarkerPosition,
             m_lastMarkerBpm,
@@ -731,7 +731,7 @@ std::optional<BeatsPointer> Beats::trySetDownbeatsOffset(u_int8_t offset) const 
             offset));
 }
 
-u_int8_t Beats::getDownbeatsOffset() const {
+int Beats::getDownbeatsOffset() const {
     return m_downbeatsOffset;
 }
 

--- a/src/track/beats.cpp
+++ b/src/track/beats.cpp
@@ -171,19 +171,26 @@ mixxx::BeatsPointer Beats::fromConstTempo(
         mixxx::audio::SampleRate sampleRate,
         mixxx::audio::FramePos lastMarkerPosition,
         mixxx::Bpm lastMarkerBpm,
-        const QString& subVersion) {
+        const QString& subVersion,
+        const u_int8_t downbeatsOffset) {
     VERIFY_OR_DEBUG_ASSERT(sampleRate.isValid() &&
             lastMarkerPosition.isValid() && lastMarkerBpm.isValid()) {
         return nullptr;
     }
-    return BeatsPointer(new Beats({}, lastMarkerPosition, lastMarkerBpm, sampleRate, subVersion));
+    return BeatsPointer(new Beats({},
+            lastMarkerPosition,
+            lastMarkerBpm,
+            sampleRate,
+            subVersion,
+            downbeatsOffset));
 }
 
 // static
 mixxx::BeatsPointer Beats::fromBeatPositions(
         mixxx::audio::SampleRate sampleRate,
         const QVector<audio::FramePos>& beatPositions,
-        const QString& subVersion) {
+        const QString& subVersion,
+        const u_int8_t downbeatsOffset) {
     VERIFY_OR_DEBUG_ASSERT(sampleRate.isValid() && beatPositions.size() >= 2) {
         return nullptr;
     }
@@ -240,7 +247,8 @@ mixxx::BeatsPointer Beats::fromBeatPositions(
             markerPosition.toLowerFrameBoundary(),
             bpm,
             sampleRate,
-            subVersion));
+            subVersion,
+            downbeatsOffset));
 }
 
 // static
@@ -249,12 +257,14 @@ mixxx::BeatsPointer Beats::fromBeatMarkers(
         const std::vector<BeatMarker>& markers,
         const audio::FramePos lastMarkerPosition,
         const Bpm lastMarkerBpm,
-        const QString& subVersion) {
+        const QString& subVersion,
+        const u_int8_t downbeatsOffset) {
     return BeatsPointer(new Beats(markers,
             lastMarkerPosition,
             lastMarkerBpm,
             sampleRate,
-            subVersion));
+            subVersion,
+            downbeatsOffset));
 }
 
 // static
@@ -309,8 +319,10 @@ mixxx::BeatsPointer Beats::fromBeatGridByteArray(
         bpm = mixxx::Bpm(pBlob->bpm);
     }
 
+    u_int8_t downbeatsOffset = grid.has_downbeats_offset() ? grid.downbeats_offset() : 0;
+
     if (position.isValid() && bpm.isValid()) {
-        return fromConstTempo(sampleRate, position, bpm, subVersion);
+        return fromConstTempo(sampleRate, position, bpm, subVersion, downbeatsOffset);
     }
 
     // Failed to parse the beatgrid.
@@ -362,7 +374,7 @@ QByteArray Beats::toBeatGridByteArray() const {
             static_cast<google::protobuf::int32>(
                     m_lastMarkerPosition.toLowerFrameBoundary().value()));
     grid.mutable_bpm()->set_bpm(m_lastMarkerBpm.value());
-
+    grid.set_downbeats_offset(m_downbeatsOffset);
     std::string output;
     grid.SerializeToString(&output);
     return QByteArray(output.data(), static_cast<int>(output.length()));
@@ -635,7 +647,8 @@ std::optional<BeatsPointer> Beats::tryTranslate(audio::FrameDiff_t offsetFrames)
             lastMarkerPosition.toLowerFrameBoundary(),
             m_lastMarkerBpm,
             m_sampleRate,
-            m_subVersion));
+            m_subVersion,
+            m_downbeatsOffset));
 }
 
 std::optional<BeatsPointer> Beats::tryTranslateBeats(double xBeats) const {
@@ -649,7 +662,8 @@ std::optional<BeatsPointer> Beats::tryTranslateBeats(double xBeats) const {
             lastMarkerPosition.toLowerFrameBoundary(),
             m_lastMarkerBpm,
             m_sampleRate,
-            m_subVersion));
+            m_subVersion,
+            m_downbeatsOffset));
 }
 
 std::optional<BeatsPointer> Beats::tryScale(BpmScale scale) const {
@@ -699,12 +713,26 @@ std::optional<BeatsPointer> Beats::tryScale(BpmScale scale) const {
             m_lastMarkerPosition,
             lastMarkerBpm,
             m_sampleRate,
-            m_subVersion));
+            m_subVersion,
+            m_downbeatsOffset));
 }
 
 std::optional<BeatsPointer> Beats::trySetBpm(mixxx::Bpm bpm) const {
     const auto it = cfirstmarker();
-    return BeatsPointer(new Beats({}, *it, bpm, m_sampleRate, m_subVersion));
+    return BeatsPointer(new Beats({}, *it, bpm, m_sampleRate, m_subVersion, m_downbeatsOffset));
+}
+
+std::optional<BeatsPointer> Beats::trySetDownbeatsOffset(u_int8_t offset) const {
+    return BeatsPointer(new Beats(m_markers,
+            m_lastMarkerPosition,
+            m_lastMarkerBpm,
+            m_sampleRate,
+            m_subVersion,
+            offset));
+}
+
+u_int8_t Beats::getDownbeatsOffset() const {
+    return m_downbeatsOffset;
 }
 
 bool Beats::isValid() const {

--- a/src/track/beats.cpp
+++ b/src/track/beats.cpp
@@ -38,6 +38,10 @@ mixxx::audio::FrameDiff_t Beats::ConstIterator::beatLengthFrames() const {
     return (nextMarkerPosition - m_it->position()) / m_it->beatsTillNextMarker();
 }
 
+int Beats::ConstIterator::beatOffset() const {
+    return m_beatOffset;
+}
+
 Beats::ConstIterator Beats::ConstIterator::operator+=(Beats::ConstIterator::difference_type n) {
     if (n == 0) {
         return *this;

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -457,7 +457,7 @@ class Beats : private std::enable_shared_from_this<Beats> {
     // The sub-version of this beatgrid.
     const QString m_subVersion;
 
-    const int m_downbeatsOffset;
+    const int m_downbeatsOffset = 0;
 };
 
 } // namespace mixxx

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -143,6 +143,8 @@ class Beats : private std::enable_shared_from_this<Beats> {
             return !(lhs == rhs);
         }
 
+        int beatOffset() const;
+
       private:
         void updateValue();
 

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -159,12 +159,14 @@ class Beats : private std::enable_shared_from_this<Beats> {
             mixxx::audio::FramePos lastMarkerPosition,
             mixxx::Bpm lastMarkerBpm,
             mixxx::audio::SampleRate sampleRate,
-            const QString& subVersion)
+            const QString& subVersion,
+            const u_int8_t downbeatsOffset)
             : m_markers(std::move(markers)),
               m_lastMarkerPosition(lastMarkerPosition),
               m_lastMarkerBpm(lastMarkerBpm),
               m_sampleRate(sampleRate),
-              m_subVersion(subVersion) {
+              m_subVersion(subVersion),
+              m_downbeatsOffset(downbeatsOffset) {
         DEBUG_ASSERT(m_lastMarkerPosition.isValid());
         DEBUG_ASSERT(!m_lastMarkerPosition.isFractional());
         DEBUG_ASSERT(m_lastMarkerBpm.isValid());
@@ -174,12 +176,14 @@ class Beats : private std::enable_shared_from_this<Beats> {
     Beats(mixxx::audio::FramePos lastMarkerPosition,
             mixxx::Bpm lastMarkerBpm,
             mixxx::audio::SampleRate sampleRate,
-            const QString& subVersion)
+            const QString& subVersion,
+            const u_int8_t downbeatsOffset)
             : Beats(std::vector<BeatMarker>(),
                       lastMarkerPosition,
                       lastMarkerBpm,
                       sampleRate,
-                      subVersion) {
+                      subVersion,
+                      downbeatsOffset) {
     }
 
     ~Beats() = default;
@@ -251,19 +255,22 @@ class Beats : private std::enable_shared_from_this<Beats> {
             audio::SampleRate sampleRate,
             audio::FramePos position,
             Bpm bpm,
-            const QString& subVersion = QString());
+            const QString& subVersion = QString(),
+            const u_int8_t downbeatsOffset = 0);
 
     static mixxx::BeatsPointer fromBeatPositions(
             audio::SampleRate sampleRate,
             const QVector<audio::FramePos>& beatPositions,
-            const QString& subVersion = QString());
+            const QString& subVersion = QString(),
+            const u_int8_t downbeatsOffset = 0);
 
     static mixxx::BeatsPointer fromBeatMarkers(
             audio::SampleRate sampleRate,
             const std::vector<BeatMarker>& beatMarker,
             const audio::FramePos lastMarkerPosition,
             const Bpm lastMarkerBpm,
-            const QString& subVersion = QString());
+            const QString& subVersion = QString(),
+            const u_int8_t downbeatsOffset = 0);
 
     enum class BpmScale {
         Double,
@@ -295,6 +302,8 @@ class Beats : private std::enable_shared_from_this<Beats> {
     QString getSubVersion() const {
         return m_subVersion;
     }
+
+    u_int8_t getDownbeatsOffset() const;
 
     ////////////////////////////////////////////////////////////////////////////
     // Beat calculations
@@ -418,6 +427,8 @@ class Beats : private std::enable_shared_from_this<Beats> {
     /// failure.
     std::optional<BeatsPointer> trySetBpm(mixxx::Bpm bpm) const;
 
+    std::optional<BeatsPointer> trySetDownbeatsOffset(u_int8_t offset) const;
+
   protected:
     /// Type tag for making public constructors of derived classes inaccessible.
     ///
@@ -445,6 +456,8 @@ class Beats : private std::enable_shared_from_this<Beats> {
 
     // The sub-version of this beatgrid.
     const QString m_subVersion;
+
+    const u_int8_t m_downbeatsOffset;
 };
 
 } // namespace mixxx

--- a/src/track/beats.h
+++ b/src/track/beats.h
@@ -160,7 +160,7 @@ class Beats : private std::enable_shared_from_this<Beats> {
             mixxx::Bpm lastMarkerBpm,
             mixxx::audio::SampleRate sampleRate,
             const QString& subVersion,
-            const u_int8_t downbeatsOffset)
+            const int downbeatsOffset)
             : m_markers(std::move(markers)),
               m_lastMarkerPosition(lastMarkerPosition),
               m_lastMarkerBpm(lastMarkerBpm),
@@ -177,7 +177,7 @@ class Beats : private std::enable_shared_from_this<Beats> {
             mixxx::Bpm lastMarkerBpm,
             mixxx::audio::SampleRate sampleRate,
             const QString& subVersion,
-            const u_int8_t downbeatsOffset)
+            const int downbeatsOffset)
             : Beats(std::vector<BeatMarker>(),
                       lastMarkerPosition,
                       lastMarkerBpm,
@@ -256,13 +256,13 @@ class Beats : private std::enable_shared_from_this<Beats> {
             audio::FramePos position,
             Bpm bpm,
             const QString& subVersion = QString(),
-            const u_int8_t downbeatsOffset = 0);
+            const int downbeatsOffset = 0);
 
     static mixxx::BeatsPointer fromBeatPositions(
             audio::SampleRate sampleRate,
             const QVector<audio::FramePos>& beatPositions,
             const QString& subVersion = QString(),
-            const u_int8_t downbeatsOffset = 0);
+            const int downbeatsOffset = 0);
 
     static mixxx::BeatsPointer fromBeatMarkers(
             audio::SampleRate sampleRate,
@@ -270,7 +270,7 @@ class Beats : private std::enable_shared_from_this<Beats> {
             const audio::FramePos lastMarkerPosition,
             const Bpm lastMarkerBpm,
             const QString& subVersion = QString(),
-            const u_int8_t downbeatsOffset = 0);
+            const int downbeatsOffset = 0);
 
     enum class BpmScale {
         Double,
@@ -303,7 +303,7 @@ class Beats : private std::enable_shared_from_this<Beats> {
         return m_subVersion;
     }
 
-    u_int8_t getDownbeatsOffset() const;
+    int getDownbeatsOffset() const;
 
     ////////////////////////////////////////////////////////////////////////////
     // Beat calculations
@@ -427,7 +427,7 @@ class Beats : private std::enable_shared_from_this<Beats> {
     /// failure.
     std::optional<BeatsPointer> trySetBpm(mixxx::Bpm bpm) const;
 
-    std::optional<BeatsPointer> trySetDownbeatsOffset(u_int8_t offset) const;
+    std::optional<BeatsPointer> trySetDownbeatsOffset(int offset) const;
 
   protected:
     /// Type tag for making public constructors of derived classes inaccessible.
@@ -457,7 +457,7 @@ class Beats : private std::enable_shared_from_this<Beats> {
     // The sub-version of this beatgrid.
     const QString m_subVersion;
 
-    const u_int8_t m_downbeatsOffset;
+    const int m_downbeatsOffset;
 };
 
 } // namespace mixxx

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -517,7 +517,7 @@ void Track::afterBeatsAndBpmUpdated(
     emitBeatsAndBpmUpdated();
 }
 
-void Track::setDownbeatOffset(u_int8_t offset) {
+void Track::setDownbeatOffset(int offset) {
     m_downbeat_offset = offset;
     const auto newBeats = m_pBeats->trySetDownbeatsOffset(offset);
     if (newBeats) {

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -454,6 +454,7 @@ bool Track::setBeatsWhileLocked(mixxx::BeatsPointer pBeats) {
     }
 
     m_pBeats = std::move(pBeats);
+    m_downbeat_offset = m_pBeats->getDownbeatsOffset();
     m_record.refMetadata().refTrackInfo().setBpm(getBeatsPointerBpm(m_pBeats, getDuration()));
     return true;
 }
@@ -514,6 +515,14 @@ void Track::afterBeatsAndBpmUpdated(
 
     markDirtyAndUnlock(pLock);
     emitBeatsAndBpmUpdated();
+}
+
+void Track::setDownbeatOffset(u_int8_t offset) {
+    m_downbeat_offset = offset;
+    const auto newBeats = m_pBeats->trySetDownbeatsOffset(offset);
+    if (newBeats) {
+        trySetBeats(*newBeats);
+    }
 }
 
 void Track::emitBeatsAndBpmUpdated() {

--- a/src/track/track.cpp
+++ b/src/track/track.cpp
@@ -454,7 +454,9 @@ bool Track::setBeatsWhileLocked(mixxx::BeatsPointer pBeats) {
     }
 
     m_pBeats = std::move(pBeats);
-    m_downbeat_offset = m_pBeats->getDownbeatsOffset();
+    if (m_pBeats) {
+        m_downbeat_offset = m_pBeats->getDownbeatsOffset();
+    }
     m_record.refMetadata().refTrackInfo().setBpm(getBeatsPointerBpm(m_pBeats, getDuration()));
     return true;
 }

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -338,6 +338,14 @@ class Track : public QObject {
     void swapHotcues(int a, int b);
     void setCuePoints(const QList<CuePointer>& cuePoints);
 
+    int getDownbeatOffset() const {
+        return m_downbeat_offset;
+    }
+
+    void setDownbeatOffset(int offset) {
+        m_downbeat_offset = offset;
+    }
+
 #ifdef __STEM__
     QList<StemInfo> getStemInfo() const {
         const QMutexLocker lock(&m_qMutex);
@@ -605,6 +613,8 @@ class Track : public QObject {
 
     // The list of cue points for the track
     QList<CuePointer> m_cuePoints;
+
+    int m_downbeat_offset = 0; // offset in bars
 
 #ifdef __STEM__
     // The list of stem info

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -338,13 +338,11 @@ class Track : public QObject {
     void swapHotcues(int a, int b);
     void setCuePoints(const QList<CuePointer>& cuePoints);
 
-    int getDownbeatOffset() const {
+    u_int8_t getDownbeatOffset() const {
         return m_downbeat_offset;
     }
 
-    void setDownbeatOffset(int offset) {
-        m_downbeat_offset = offset;
-    }
+    void setDownbeatOffset(u_int8_t offset);
 
 #ifdef __STEM__
     QList<StemInfo> getStemInfo() const {

--- a/src/track/track.h
+++ b/src/track/track.h
@@ -338,11 +338,11 @@ class Track : public QObject {
     void swapHotcues(int a, int b);
     void setCuePoints(const QList<CuePointer>& cuePoints);
 
-    u_int8_t getDownbeatOffset() const {
+    int getDownbeatOffset() const {
         return m_downbeat_offset;
     }
 
-    void setDownbeatOffset(u_int8_t offset);
+    void setDownbeatOffset(int offset);
 
 #ifdef __STEM__
     QList<StemInfo> getStemInfo() const {

--- a/src/waveform/renderers/allshader/waveformrenderdownbeat.cpp
+++ b/src/waveform/renderers/allshader/waveformrenderdownbeat.cpp
@@ -1,0 +1,142 @@
+#include "waveform/renderers/allshader/waveformrenderdownbeat.h"
+
+#include <QDomNode>
+
+#include "moc_waveformrenderdownbeat.cpp"
+#include "rendergraph/geometry.h"
+#include "rendergraph/material/unicolormaterial.h"
+#include "rendergraph/vertexupdaters/vertexupdater.h"
+#include "skin/legacy/skincontext.h"
+#include "track/track.h"
+#include "waveform/renderers/waveformwidgetrenderer.h"
+#include "widget/wskincolor.h"
+
+using namespace rendergraph;
+
+namespace allshader {
+
+WaveformRenderDownBeat::WaveformRenderDownBeat(WaveformWidgetRenderer* waveformWidget,
+        ::WaveformRendererAbstract::PositionSource type)
+        : ::WaveformRendererAbstract(waveformWidget),
+          m_isSlipRenderer(type == ::WaveformRendererAbstract::Slip) {
+    initForRectangles<UniColorMaterial>(0);
+    setUsePreprocess(true);
+}
+
+void WaveformRenderDownBeat::setup(const QDomNode& node, const SkinContext& skinContext) {
+    m_color = QColor(255, 0, 0);
+    m_color = WSkinColor::getCorrectColor(m_color).toRgb();
+}
+
+void WaveformRenderDownBeat::draw(QPainter* painter, QPaintEvent* event) {
+    Q_UNUSED(painter);
+    Q_UNUSED(event);
+    DEBUG_ASSERT(false);
+}
+
+void WaveformRenderDownBeat::preprocess() {
+    if (!preprocessInner()) {
+        geometry().allocate(0);
+        markDirtyGeometry();
+    }
+}
+
+bool WaveformRenderDownBeat::preprocessInner() {
+    const TrackPointer trackInfo = m_waveformRenderer->getTrackInfo();
+
+    if (!trackInfo || (m_isSlipRenderer && !m_waveformRenderer->isSlipActive())) {
+        return false;
+    }
+
+    auto positionType = m_isSlipRenderer ? ::WaveformRendererAbstract::Slip
+                                         : ::WaveformRendererAbstract::Play;
+
+    mixxx::BeatsPointer trackBeats = trackInfo->getBeats();
+    if (!trackBeats) {
+        return false;
+    }
+
+    int alpha = m_waveformRenderer->getBeatGridAlpha();
+    if (alpha == 0) {
+        return false;
+    }
+
+    const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
+
+    m_color.setAlphaF(alpha / 100.0f);
+
+    const double trackSamples = m_waveformRenderer->getTrackSamples();
+    if (trackSamples <= 0.0) {
+        return false;
+    }
+
+    const double firstDisplayedPosition =
+            m_waveformRenderer->getFirstDisplayedPosition(positionType);
+    const double lastDisplayedPosition =
+            m_waveformRenderer->getLastDisplayedPosition(positionType);
+
+    const auto startPosition = mixxx::audio::FramePos::fromEngineSamplePos(
+            firstDisplayedPosition * trackSamples);
+    const auto endPosition = mixxx::audio::FramePos::fromEngineSamplePos(
+            lastDisplayedPosition * trackSamples);
+
+    if (!startPosition.isValid() || !endPosition.isValid()) {
+        return false;
+    }
+
+    const float rendererBreadth = m_waveformRenderer->getBreadth();
+
+    const int numVerticesPerLine = 6; // 2 triangles
+
+    int downbeatOffset = trackInfo->getDownbeatOffset();
+
+    int numDownbeatsInRange = 0;
+    for (auto it = trackBeats->iteratorFrom(startPosition);
+            it != trackBeats->cend() && *it <= endPosition;
+            ++it) {
+        if ((it.beatOffset() - downbeatOffset) % 4 != 0) {
+            continue;
+        }
+        numDownbeatsInRange++;
+    }
+
+    const int reserved = (numDownbeatsInRange * 3) + (numDownbeatsInRange * numVerticesPerLine);
+    geometry().allocate(reserved);
+
+    VertexUpdater vertexUpdater{geometry().vertexDataAs<Geometry::Point2D>()};
+
+    for (auto it = trackBeats->iteratorFrom(startPosition);
+            it != trackBeats->cend() && *it <= endPosition;
+            ++it) {
+        if ((it.beatOffset() - downbeatOffset) % 4 != 0) {
+            continue;
+        }
+        double beatPosition = it->toEngineSamplePos();
+        double xBeatPoint =
+                m_waveformRenderer->transformSamplePositionInRendererWorld(
+                        beatPosition, positionType);
+
+        xBeatPoint = qRound(xBeatPoint * devicePixelRatio) / devicePixelRatio;
+
+        const float x1 = static_cast<float>(xBeatPoint) + 0.f;
+        const float x2 = x1 + 1.f;
+
+        vertexUpdater.addRectangle({x1, 0.f},
+                {x2, m_isSlipRenderer ? rendererBreadth / 2 : rendererBreadth});
+        if ((it.beatOffset() - downbeatOffset) % 8 == 0) {
+            vertexUpdater.addTriangle({x1 - 4.f, 0.f}, {x2 + 4.f, 0.f}, {x1, 6.f});
+        } else {
+            vertexUpdater.addTriangle({0.f, 0.f}, {0.f, 0.f}, {0.f, 0.f});
+        }
+    }
+    markDirtyGeometry();
+
+    DEBUG_ASSERT(reserved == vertexUpdater.index());
+
+    material().setUniform(1, m_color);
+    markDirtyMaterial();
+
+    return true;
+}
+
+} // namespace allshader

--- a/src/waveform/renderers/allshader/waveformrenderdownbeat.cpp
+++ b/src/waveform/renderers/allshader/waveformrenderdownbeat.cpp
@@ -24,7 +24,7 @@ WaveformRenderDownBeat::WaveformRenderDownBeat(WaveformWidgetRenderer* waveformW
 }
 
 void WaveformRenderDownBeat::setup(const QDomNode& node, const SkinContext& skinContext) {
-    m_color = QColor(255, 0, 0);
+    m_color = QColor(skinContext.selectString(node, QStringLiteral("DownbeatColor")));
     m_color = WSkinColor::getCorrectColor(m_color).toRgb();
 }
 

--- a/src/waveform/renderers/allshader/waveformrenderdownbeat.h
+++ b/src/waveform/renderers/allshader/waveformrenderdownbeat.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <QColor>
+
+#include "rendergraph/geometrynode.h"
+#include "util/class.h"
+#include "waveform/renderers/waveformrendererabstract.h"
+
+class QDomNode;
+class SkinContext;
+
+namespace allshader {
+class WaveformRenderDownBeat;
+} // namespace allshader
+
+class allshader::WaveformRenderDownBeat final
+        : public QObject,
+          public ::WaveformRendererAbstract,
+          public rendergraph::GeometryNode {
+    Q_OBJECT
+  public:
+    explicit WaveformRenderDownBeat(WaveformWidgetRenderer* waveformWidget,
+            ::WaveformRendererAbstract::PositionSource type =
+                    ::WaveformRendererAbstract::Play);
+
+    // Pure virtual from WaveformRendererAbstract, not used
+    void draw(QPainter* painter, QPaintEvent* event) override final;
+
+    void setup(const QDomNode& node, const SkinContext& skinContext) override;
+
+    // Virtuals for rendergraph::Nodeocktoggle
+    void preprocess() override;
+
+  public slots:
+    void setColor(const QColor& color) {
+        m_color = color;
+    }
+
+  private:
+    QColor m_color;
+    bool m_isSlipRenderer;
+
+    bool preprocessInner();
+
+    DISALLOW_COPY_AND_ASSIGN(WaveformRenderDownBeat);
+};

--- a/src/waveform/widgets/allshader/waveformwidget.cpp
+++ b/src/waveform/widgets/allshader/waveformwidget.cpp
@@ -6,6 +6,7 @@
 
 #include "waveform/renderers/allshader/waveformrenderbackground.h"
 #include "waveform/renderers/allshader/waveformrenderbeat.h"
+#include "waveform/renderers/allshader/waveformrenderdownbeat.h"
 #include "waveform/renderers/allshader/waveformrendererendoftrack.h"
 #include "waveform/renderers/allshader/waveformrendererfiltered.h"
 #include "waveform/renderers/allshader/waveformrendererhsv.h"
@@ -56,6 +57,7 @@ WaveformWidget::WaveformWidget(QWidget* parent,
         pOpacityNode->appendChildNode(std::unique_ptr<rendergraph::BaseNode>(pNode));
     }
     pOpacityNode->appendChildNode(addRendererNode<WaveformRenderBeat>());
+    pOpacityNode->appendChildNode(addRendererNode<WaveformRenderDownBeat>());
     m_pWaveformRenderMark = pOpacityNode->appendChildNode(addRendererNode<WaveformRenderMark>());
 
     // if the added signal renderer supports slip, we add it again, now for

--- a/src/waveform/widgets/allshader/waveformwidget.h
+++ b/src/waveform/widgets/allshader/waveformwidget.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "control/controlobject.h"
 #include "rendergraph/engine.h"
 #include "rendergraph/opacitynode.h"
 #include "waveform/renderers/allshader/waveformrenderersignalbase.h"
@@ -41,12 +42,12 @@ class allshader::WaveformWidget final : public ::WGLWidget,
     }
     static WaveformWidgetVars vars();
     static WaveformRendererSignalBase::Options supportedOptions(WaveformWidgetType::Type type);
-
   private:
     void castToQWidget() override;
     void paintEvent(QPaintEvent* event) override;
     void wheelEvent(QWheelEvent* event) override;
     void leaveEvent(QEvent* event) override;
+    void toggleDownBeatVisibility();
 
     template<class T_Renderer, typename... Args>
     inline std::unique_ptr<T_Renderer> addRendererNode(Args&&... args) {
@@ -71,5 +72,7 @@ class allshader::WaveformWidget final : public ::WGLWidget,
     WaveformRenderMarkRange* m_pWaveformRenderMarkRange;
     WaveformRendererSignalBase* m_pWaveformRendererSignal;
 
+    rendergraph::OpacityNode* m_pDownBeatOpacityNode;
+    float m_downBeatOpacity = 0.0f;
     DISALLOW_COPY_AND_ASSIGN(WaveformWidget);
 };


### PR DESCRIPTION
#### Current UI:
![current_2deck](https://github.com/user-attachments/assets/73d76f2d-31e7-4ccd-97e0-973227e6e71e)

#### Modified UI:
![downbeat_2deck](https://github.com/user-attachments/assets/5d27caa6-0d57-44bd-833d-90321abfbf84)

#### There are 3 new buttons: 
- toggle downbeats visibility 
- move downbeats forward 
- move downbeats backward.

## Information, Implementation details and doubts

_First of all, when reviewing take in consideration that I am mainly Javascript developer. Just tired of getting the down beat wrong, then I faced c++ here. And this implementation already solve almost all my use cases._

__The main concept here is the creation of a new `waveformrenderdownbeat` class, this is basically a copy of `waveformrenderbeat` but only rendering the down beats. Doing this way is less disruptive and is not messing with old code.__

- It shows 4 and 8 beats differently, 8ths are generated with little triangle on top.

- There is a new skin parameter for setting the downbeat color.

- This will work only on 4/4 songs right now.

- This will only work with [x] use acceleration

- It needs a way to store the downbeatoffset after user move it.

__

 - I needed to get the absolute position of the beats, to do that I exposed `m_beatOffset` from `beats.cpp`. Is there already other way to do this?
- I am adding the downbeat into waveformwidget.cpp. To control visibility I am just toggling the opacity. There is maybe a quicker anyway to do? Directly removing it instead?

