### PR TITLE
(fix) Tracks view: reset Qt::WA_InputMethodEnabled right away

### DIFF
--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -84,6 +84,29 @@ WTrackTableView::~WTrackTableView() {
         pHeader->saveHeaderState();
     }
 }
+#ifdef __LINUX__
+void WTrackTableView::currentChanged(
+        const QModelIndex& current,
+        const QModelIndex& previous) {
+    // This override fixes https://github.com/mixxxdj/mixxx/pull/14734
+    // On Ubuntu-based distros it may happen that the InputMethod management
+    // isn't working correctly for some reason. When the focused cell in the
+    // tracks view is changed, QAbstractItemView::currentChanged()
+    // https://github.com/qt/qtbase/blob/82015992c853b50dac167da26b8b858ac4794c66/src/widgets/itemviews/qabstractitemview.cpp#L3823
+    // enables Qt::WA_InputMethodEnabled for editable columns/cells.
+    // Then, special keys are interpreted as QInputMethodEvent instead of
+    // QKeyEvent, which are therefore not filtered by KeyboardEventFilter and
+    // some keys of built-in keyboard mappings don't work.
+    // (de_DE, fr_FR, fr_CH and probably others).
+    // Reset Qt::WA_InputMethodEnabled right away if no editor is open
+    QTableView::currentChanged(current, previous);
+    if (state() != QTableView::EditingState) {
+        // Does not interfere with hovered Star delegate, the only editor that
+        // is opened on hover.
+        setAttribute(Qt::WA_InputMethodEnabled, false);
+    }
+}
+#endif
 
 void WTrackTableView::enableCachedOnly() {
     if (!m_loadCachedOnly) {

--- a/src/widget/wtracktableview.h
+++ b/src/widget/wtracktableview.h
@@ -29,6 +29,9 @@ class WTrackTableView : public WLibraryTableView {
             double backgroundColorOpacity,
             bool sorting);
     ~WTrackTableView() override;
+#ifdef __LINUX__
+    void currentChanged(const QModelIndex& current, const QModelIndex& previous) override;
+#endif
     void contextMenuEvent(QContextMenuEvent * event) override;
     QString columnNameOfIndex(const QModelIndex& index) const;
     void onSearch(const QString& text) override;


### PR DESCRIPTION
Fixes https://github.com/mixxxdj/mixxx/issues/14734

**TL;DR**
avoids that öäü keypresses are processed as QInputMethodEvent instead of QKeyEvent when the focus is on an editable table cell (no editor open).

**The issue:**
On current Ubuntu-based distros **edit** using Wayland[^1], it may happen that the InputMethod management isn't working correctly for some reason.
When the focused cell in the tracks view is changed, [QAbstractItemView::currentChanged()](https://github.com/qt/qtbase/blob/82015992c853b50dac167da26b8b858ac4794c66/src/widgets/itemviews/qabstractitemview.cpp#L3823) enables `Qt::WA_InputMethodEnabled` for **editable** columns/cells.
Then, special keys are interpreted as `QInputMethodEvent` instead of `QKeyEvent`, which are therefore not filtered by `KeyboardEventFilter` and some keys of built-in keyboard mappings don't work (de_DE, fr_FR, fr_CH and probably others).

**The fix**
Overrdie `currentChanged()`, reset `Qt::WA_InputMethodEnabled` right away.
I confirmed the fix in an Ubuntu 24.04 VM, but broader testing is required.
No issues spotted, text input in in-place editors works as before as they have the attribute set true by default.

According to the documentation, `Qt::WA_InputMethodEnabled` needs to be true for
a) (custom) text input widgets (default true)
b) complex input like composed keys (eg. first `¨`, then `o` to compose `ö`)
Neither of these are required for the table view, and IIRC the official mappings don't use the special composed keys.
![image](https://github.com/user-attachments/assets/d8647f43-c8ee-4783-b65e-9d763fb65e3d)



**TODO**
- [x] ~~test on Windows and macOS, add #ifdef __LINUX__ in case of issues~~ Linux only now
- [x] test with virtual keyboard (onscreen keyboard)
- [ ] test on Feadora, Arch ... 

[^1]: This was reported for these distro versions, all using Wayland by default
    * Kubuntu 24.04 [Mixxx forum: Keyboard shortcut “ö” stopped working (other umlauts affected, too)](https://mixxx.discourse.group/t/keyboard-shortcut-o-stopped-working-other-umlauts-affected-too/30470/14)
    * Linux Mint 21.3 #14734 
    * Ubuntu 24.04 (VM testing #14824)