### PR TITLE
QML: Improve waveform zoom exp

### DIFF
--- a/res/qml/WaveformDisplay.qml
+++ b/res/qml/WaveformDisplay.qml
@@ -10,6 +10,8 @@ Item {
     required property string group
     property bool splitStemTracks: false
 
+    readonly property string zoomGroup: Mixxx.Config.waveformZoomSynchronization() ? "[Channel1]" : group
+
     enum MouseStatus {
         Normal,
         Bending,
@@ -21,6 +23,13 @@ Item {
         group: root.group
         zoom: zoomControl.value
         backgroundColor: "#5e000000"
+
+        Behavior on zoom {
+            SmoothedAnimation {
+                duration: 500
+                velocity: -1
+            }
+        }
 
         Mixxx.WaveformRendererEndOfTrack {
             color: '#ff8872'
@@ -180,8 +189,14 @@ Item {
     Mixxx.ControlProxy {
         id: zoomControl
 
-        group: root.group
+        group: root.zoomGroup
         key: "waveform_zoom"
+
+        Component.onCompleted: {
+            if (group == root.group) {
+                value = Mixxx.Config.waveformDefaultZoom()
+            }
+        }
     }
 
     MouseArea {

--- a/src/qml/qmlconfigproxy.cpp
+++ b/src/qml/qmlconfigproxy.cpp
@@ -17,6 +17,12 @@ const QString kPreferencesGroup = QStringLiteral("[Preferences]");
 const QString kMultiSamplingKey = QStringLiteral("multi_sampling");
 const QString k3DHardwareAccelerationKey = QStringLiteral("force_hardware_acceleration");
 
+const QString kWaveformGroup = QStringLiteral("[Waveform]");
+const QString kWaveformZoomSynchronizationKey = QStringLiteral("ZoomSynchronization");
+const QString kWaveformDefaultZoomKey = QStringLiteral("DefaultZoom");
+const bool kWaveformZoomSynchronizationDefault = true;
+const double kWaveformDefaultZoomDefault = 3.0;
+
 } // namespace
 
 namespace mixxx {
@@ -51,6 +57,17 @@ bool QmlConfigProxy::useAcceleration() {
     }
     return m_pConfig->getValue<bool>(
             ConfigKey(kPreferencesGroup, k3DHardwareAccelerationKey));
+}
+
+bool QmlConfigProxy::waveformZoomSynchronization() {
+    return m_pConfig->getValue(
+            ConfigKey(kWaveformGroup, kWaveformZoomSynchronizationKey),
+            kWaveformZoomSynchronizationDefault);
+}
+double QmlConfigProxy::waveformDefaultZoom() {
+    return m_pConfig->getValue(
+            ConfigKey(kWaveformGroup, kWaveformDefaultZoomKey),
+            kWaveformDefaultZoomDefault);
 }
 
 // static

--- a/src/qml/qmlconfigproxy.h
+++ b/src/qml/qmlconfigproxy.h
@@ -25,6 +25,10 @@ class QmlConfigProxy : public QObject {
     Q_INVOKABLE int getMultiSamplingLevel();
     Q_INVOKABLE bool useAcceleration();
 
+    // Waveform settings
+    Q_INVOKABLE bool waveformZoomSynchronization();
+    Q_INVOKABLE double waveformDefaultZoom();
+
     static QmlConfigProxy* create(QQmlEngine* pQmlEngine, QJSEngine* pJsEngine);
     static inline void registerUserSettings(UserSettingsPointer pConfig) {
         s_pUserSettings = std::move(pConfig);


### PR DESCRIPTION
Depends on #14515

This small PR adds:
- Restore the default zoom upon startup, as previously performed by the [WaveformWidgetFactory](https://github.com/mixxxdj/mixxx/blob/917671b6139e3a038e14780ff9839f6650227398/src/waveform/waveformwidgetfactory.cpp#L356)
- Support for Zoom Sync (Note: setting change only applied upon UI reload - more work to be done on this in the future
- Zoom animation 