### PR TITLE
Saved beat jumps -- two dedicated Jump toggles

### DIFF
--- a/res/qml/WaveformDisplay.qml
+++ b/res/qml/WaveformDisplay.qml
@@ -91,6 +91,7 @@ Item {
                 color: "#00d9ff"
                 textColor: "#1a1a1a"
                 text: " %1 "
+                endIcon: Qt.resolvedUrl("images/jump_%1.svg")
             }
 
             untilMark.showTime: true

--- a/res/qml/images/jump_backward.svg
+++ b/res/qml/images/jump_backward.svg
@@ -1,0 +1,1 @@
+../../skins/LateNight/palemoon/buttons/btn__beatjump_left.svg

--- a/res/qml/images/jump_forward.svg
+++ b/res/qml/images/jump_forward.svg
@@ -1,0 +1,1 @@
+../../skins/LateNight/palemoon/buttons/btn__beatjump_right.svg

--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -2435,6 +2435,18 @@ WEffectChainPresetSelector::indicator:unchecked:selected,
   outline: none;
 }
 
+#CueStandardButton {
+/* tall button, about the same height as cue number + label edit box */
+  width: 28px;
+  height: 46px;
+  /* make the icon slightly larger than default 16px */
+  qproperty-iconSize: 20px;
+  qproperty-icon: url(skin:/../Deere/icon/ic_loop_in_48px.svg);
+  background-color: #3B3B3B;
+  border-radius: 2px;
+  outline: none;
+}
+
 #CueSavedLoopButton {
 /* tall button, about the same height as cue number + label edit box */
   width: 28px;
@@ -2447,11 +2459,23 @@ WEffectChainPresetSelector::indicator:unchecked:selected,
   outline: none;
 }
 
-#CueDeleteButton:hover, #CueSavedLoopButton:hover {
+#CueSavedJumpButton {
+/* tall button, about the same height as cue number + label edit box */
+  width: 28px;
+  height: 46px;
+  /* make the icon slightly larger than default 16px */
+  qproperty-iconSize: 20px;
+  qproperty-icon: url(skin:/../Deere/icon/ic_beatjump_forward_48px.svg);
+  background-color: #3B3B3B;
+  border-radius: 2px;
+  outline: none;
+}
+
+#CueDeleteButton:hover, #CueStandardButton:hover, #CueSavedLoopButton:hover, #CueSavedJumpButton:hover {
   background-color: #4B4B4B;
 }
 
-#CueSavedLoopButton:checked {
+#CueDeleteButton:checked, #CueStandardButton:checked, #CueSavedLoopButton:checked, #CueSavedJumpButton:checked {
   background-color: #006596;
 }
 

--- a/res/skins/LateNight/palemoon/buttons/btn__1_jump_active.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__1_jump_active.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   height="48"
+   width="40"
+   sodipodi:docname="btn__1_jump_active.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   viewBox="0 0 20 24"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2544"
+     inkscape:window-height="1331"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="10.871075"
+     inkscape:cx="32.931426"
+     inkscape:cy="8.0948756"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <marker
+       style="overflow:visible"
+       id="marker1312"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path1310" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path886" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.2) translate(6,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path868" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(1.1) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path874" />
+    </marker>
+  </defs>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     x="5.8255696"
+     y="17.235025"
+     id="text1"><tspan
+       id="tspan1"
+       x="5.8255696"
+       y="17.235025"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.6667px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';fill:#000000;fill-opacity:1">1</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.69742"
+     x="4.2831869"
+     y="12.99669"
+     id="text836-5"
+     transform="scale(1.0526149,0.95001506)"><tspan
+       id="tspan834-8"
+       x="4.2831869"
+       y="12.99669"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans';fill:#000000;fill-opacity:1;stroke-width:1.69742">↷</tspan></text>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__1_jump_backward_active.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__1_jump_backward_active.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   height="48"
+   width="40"
+   sodipodi:docname="btn__7_jump_backward_active.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   viewBox="0 0 20 24"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2544"
+     inkscape:window-height="1331"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="8.8653513"
+     inkscape:cx="26.282094"
+     inkscape:cy="1.9175777"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <marker
+       style="overflow:visible"
+       id="marker1312"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path1310" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path886" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.2) translate(6,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path868" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(1.1) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path874" />
+    </marker>
+  </defs>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     x="5.8255696"
+     y="17.235025"
+     id="text1"><tspan
+       id="tspan1"
+       x="5.8255696"
+       y="17.235025"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.6667px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';fill:#000000;fill-opacity:1">1</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.69742"
+     x="0.48312664"
+     y="12.99669"
+     id="text836-5"
+     transform="scale(1.0526149,0.95001506)"><tspan
+       id="tspan834-8"
+       x="0.48312664"
+       y="12.99669"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans';fill:#000000;fill-opacity:1;stroke-width:1.69742">↶</tspan></text>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__1_jump_backward_set.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__1_jump_backward_set.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   height="48"
+   width="40"
+   sodipodi:docname="btn__1_jump_backward_set.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   viewBox="0 0 20 24"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2544"
+     inkscape:window-height="1331"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="8.8653513"
+     inkscape:cx="26.282094"
+     inkscape:cy="1.9175777"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <marker
+       style="overflow:visible"
+       id="marker1312"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path1310" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path886" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.2) translate(6,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path868" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(1.1) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path874" />
+    </marker>
+  </defs>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     x="5.8255696"
+     y="17.235025"
+     id="text1"><tspan
+       id="tspan1"
+       x="5.8255696"
+       y="17.235025"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.6667px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';fill:#000000;fill-opacity:1">1</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#5e5e5e;fill-opacity:1;stroke:none;stroke-width:1.69742"
+     x="0.48312664"
+     y="12.99669"
+     id="text836-5"
+     transform="scale(1.0526149,0.95001506)"><tspan
+       id="tspan834-8"
+       x="0.48312664"
+       y="12.99669"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans';fill:#5e5e5e;fill-opacity:1;stroke-width:1.69742">↶</tspan></text>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__1_jump_set.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__1_jump_set.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   height="48"
+   width="40"
+   sodipodi:docname="btn__1_jump_set.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   viewBox="0 0 20 24"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2544"
+     inkscape:window-height="1331"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="10.871075"
+     inkscape:cx="32.931426"
+     inkscape:cy="8.0948756"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <marker
+       style="overflow:visible"
+       id="marker1312"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path1310" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path886" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.2) translate(6,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path868" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(1.1) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path874" />
+    </marker>
+  </defs>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     x="5.8255696"
+     y="17.235025"
+     id="text1"><tspan
+       id="tspan1"
+       x="5.8255696"
+       y="17.235025"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.6667px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';fill:#000000;fill-opacity:1">1</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#5e5e5e;fill-opacity:1;stroke:none;stroke-width:1.69742"
+     x="4.2831869"
+     y="12.99669"
+     id="text836-5"
+     transform="scale(1.0526149,0.95001506)"><tspan
+       id="tspan834-8"
+       x="4.2831869"
+       y="12.99669"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans';fill:#5e5e5e;fill-opacity:1;stroke-width:1.69742">↷</tspan></text>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__2_jump_active.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__2_jump_active.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   height="48"
+   width="40"
+   sodipodi:docname="btn__2_jump_active.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   viewBox="0 0 20 24"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2544"
+     inkscape:window-height="1331"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="10.871075"
+     inkscape:cx="32.931426"
+     inkscape:cy="8.0948756"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <marker
+       style="overflow:visible"
+       id="marker1312"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path1310" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path886" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.2) translate(6,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path868" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(1.1) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path874" />
+    </marker>
+  </defs>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     x="5.8255696"
+     y="17.235025"
+     id="text1"><tspan
+       id="tspan1"
+       x="5.8255696"
+       y="17.235025"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.6667px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';fill:#000000;fill-opacity:1">2</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.69742"
+     x="4.2831869"
+     y="12.99669"
+     id="text836-5"
+     transform="scale(1.0526149,0.95001506)"><tspan
+       id="tspan834-8"
+       x="4.2831869"
+       y="12.99669"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans';fill:#000000;fill-opacity:1;stroke-width:1.69742">↷</tspan></text>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__2_jump_backward_active.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__2_jump_backward_active.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   height="48"
+   width="40"
+   sodipodi:docname="btn__7_jump_backward_active.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   viewBox="0 0 20 24"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2544"
+     inkscape:window-height="1331"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="8.8653513"
+     inkscape:cx="26.282094"
+     inkscape:cy="1.9175777"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <marker
+       style="overflow:visible"
+       id="marker1312"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path1310" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path886" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.2) translate(6,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path868" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(1.1) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path874" />
+    </marker>
+  </defs>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     x="5.8255696"
+     y="17.235025"
+     id="text1"><tspan
+       id="tspan1"
+       x="5.8255696"
+       y="17.235025"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.6667px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';fill:#000000;fill-opacity:1">2</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.69742"
+     x="0.48312664"
+     y="12.99669"
+     id="text836-5"
+     transform="scale(1.0526149,0.95001506)"><tspan
+       id="tspan834-8"
+       x="0.48312664"
+       y="12.99669"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans';fill:#000000;fill-opacity:1;stroke-width:1.69742">↶</tspan></text>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__2_jump_backward_set.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__2_jump_backward_set.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   height="48"
+   width="40"
+   sodipodi:docname="btn__7_jump_backward_active.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   viewBox="0 0 20 24"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2544"
+     inkscape:window-height="1331"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="8.8653513"
+     inkscape:cx="26.282094"
+     inkscape:cy="1.9175777"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <marker
+       style="overflow:visible"
+       id="marker1312"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path1310" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path886" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.2) translate(6,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path868" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(1.1) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path874" />
+    </marker>
+  </defs>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     x="5.8255696"
+     y="17.235025"
+     id="text1"><tspan
+       id="tspan1"
+       x="5.8255696"
+       y="17.235025"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.6667px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';fill:#000000;fill-opacity:1">2</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#5e5e5e;fill-opacity:1;stroke:none;stroke-width:1.69742"
+     x="0.48312664"
+     y="12.99669"
+     id="text836-5"
+     transform="scale(1.0526149,0.95001506)"><tspan
+       id="tspan834-8"
+       x="0.48312664"
+       y="12.99669"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans';fill:#5e5e5e;fill-opacity:1;stroke-width:1.69742">↶</tspan></text>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__2_jump_set.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__2_jump_set.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   height="48"
+   width="40"
+   sodipodi:docname="btn__1_jump_set.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   viewBox="0 0 20 24"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2544"
+     inkscape:window-height="1331"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="10.871075"
+     inkscape:cx="32.931426"
+     inkscape:cy="8.0948756"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <marker
+       style="overflow:visible"
+       id="marker1312"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path1310" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path886" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.2) translate(6,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path868" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(1.1) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path874" />
+    </marker>
+  </defs>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     x="5.8255696"
+     y="17.235025"
+     id="text1"><tspan
+       id="tspan1"
+       x="5.8255696"
+       y="17.235025"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.6667px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';fill:#000000;fill-opacity:1">2</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#5e5e5e;fill-opacity:1;stroke:none;stroke-width:1.69742"
+     x="4.2831869"
+     y="12.99669"
+     id="text836-5"
+     transform="scale(1.0526149,0.95001506)"><tspan
+       id="tspan834-8"
+       x="4.2831869"
+       y="12.99669"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans';fill:#5e5e5e;fill-opacity:1;stroke-width:1.69742">↷</tspan></text>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__3_jump_active.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__3_jump_active.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   height="48"
+   width="40"
+   sodipodi:docname="btn__3_jump_active.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   viewBox="0 0 20 24"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2544"
+     inkscape:window-height="1331"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="10.871075"
+     inkscape:cx="32.931426"
+     inkscape:cy="8.0948756"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <marker
+       style="overflow:visible"
+       id="marker1312"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path1310" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path886" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.2) translate(6,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path868" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(1.1) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path874" />
+    </marker>
+  </defs>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     x="5.8255696"
+     y="17.235025"
+     id="text1"><tspan
+       id="tspan1"
+       x="5.8255696"
+       y="17.235025"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.6667px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';fill:#000000;fill-opacity:1">3</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.69742"
+     x="4.2831869"
+     y="12.99669"
+     id="text836-5"
+     transform="scale(1.0526149,0.95001506)"><tspan
+       id="tspan834-8"
+       x="4.2831869"
+       y="12.99669"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans';fill:#000000;fill-opacity:1;stroke-width:1.69742">↷</tspan></text>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__3_jump_backward_active.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__3_jump_backward_active.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   height="48"
+   width="40"
+   sodipodi:docname="btn__7_jump_backward_active.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   viewBox="0 0 20 24"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2544"
+     inkscape:window-height="1331"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="8.8653513"
+     inkscape:cx="26.282094"
+     inkscape:cy="1.9175777"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <marker
+       style="overflow:visible"
+       id="marker1312"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path1310" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path886" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.2) translate(6,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path868" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(1.1) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path874" />
+    </marker>
+  </defs>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     x="5.8255696"
+     y="17.235025"
+     id="text1"><tspan
+       id="tspan1"
+       x="5.8255696"
+       y="17.235025"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.6667px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';fill:#000000;fill-opacity:1">3</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.69742"
+     x="0.48312664"
+     y="12.99669"
+     id="text836-5"
+     transform="scale(1.0526149,0.95001506)"><tspan
+       id="tspan834-8"
+       x="0.48312664"
+       y="12.99669"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans';fill:#000000;fill-opacity:1;stroke-width:1.69742">↶</tspan></text>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__3_jump_backward_set.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__3_jump_backward_set.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   height="48"
+   width="40"
+   sodipodi:docname="btn__7_jump_backward_active.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   viewBox="0 0 20 24"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2544"
+     inkscape:window-height="1331"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="8.8653513"
+     inkscape:cx="26.282094"
+     inkscape:cy="1.9175777"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <marker
+       style="overflow:visible"
+       id="marker1312"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path1310" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path886" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.2) translate(6,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path868" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(1.1) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path874" />
+    </marker>
+  </defs>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     x="5.8255696"
+     y="17.235025"
+     id="text1"><tspan
+       id="tspan1"
+       x="5.8255696"
+       y="17.235025"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.6667px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';fill:#000000;fill-opacity:1">3</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#5e5e5e;fill-opacity:1;stroke:none;stroke-width:1.69742"
+     x="0.48312664"
+     y="12.99669"
+     id="text836-5"
+     transform="scale(1.0526149,0.95001506)"><tspan
+       id="tspan834-8"
+       x="0.48312664"
+       y="12.99669"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans';fill:#5e5e5e;fill-opacity:1;stroke-width:1.69742">↶</tspan></text>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__3_jump_set.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__3_jump_set.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   height="48"
+   width="40"
+   sodipodi:docname="btn__1_jump_set.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   viewBox="0 0 20 24"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2544"
+     inkscape:window-height="1331"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="10.871075"
+     inkscape:cx="32.931426"
+     inkscape:cy="8.0948756"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <marker
+       style="overflow:visible"
+       id="marker1312"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path1310" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path886" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.2) translate(6,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path868" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(1.1) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path874" />
+    </marker>
+  </defs>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     x="5.8255696"
+     y="17.235025"
+     id="text1"><tspan
+       id="tspan1"
+       x="5.8255696"
+       y="17.235025"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.6667px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';fill:#000000;fill-opacity:1">3</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#5e5e5e;fill-opacity:1;stroke:none;stroke-width:1.69742"
+     x="4.2831869"
+     y="12.99669"
+     id="text836-5"
+     transform="scale(1.0526149,0.95001506)"><tspan
+       id="tspan834-8"
+       x="4.2831869"
+       y="12.99669"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans';fill:#5e5e5e;fill-opacity:1;stroke-width:1.69742">↷</tspan></text>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__4_jump_active.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__4_jump_active.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   height="48"
+   width="40"
+   sodipodi:docname="btn__4_jump_active.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   viewBox="0 0 20 24"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2544"
+     inkscape:window-height="1331"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="10.871075"
+     inkscape:cx="32.931426"
+     inkscape:cy="8.0948756"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <marker
+       style="overflow:visible"
+       id="marker1312"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path1310" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path886" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.2) translate(6,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path868" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(1.1) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path874" />
+    </marker>
+  </defs>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     x="5.8255696"
+     y="17.235025"
+     id="text1"><tspan
+       id="tspan1"
+       x="5.8255696"
+       y="17.235025"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.6667px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';fill:#000000;fill-opacity:1">4</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.69742"
+     x="4.2831869"
+     y="12.99669"
+     id="text836-5"
+     transform="scale(1.0526149,0.95001506)"><tspan
+       id="tspan834-8"
+       x="4.2831869"
+       y="12.99669"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans';fill:#000000;fill-opacity:1;stroke-width:1.69742">↷</tspan></text>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__4_jump_backward_active.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__4_jump_backward_active.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   height="48"
+   width="40"
+   sodipodi:docname="btn__7_jump_backward_active.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   viewBox="0 0 20 24"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2544"
+     inkscape:window-height="1331"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="8.8653513"
+     inkscape:cx="26.282094"
+     inkscape:cy="1.9175777"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <marker
+       style="overflow:visible"
+       id="marker1312"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path1310" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path886" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.2) translate(6,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path868" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(1.1) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path874" />
+    </marker>
+  </defs>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     x="5.8255696"
+     y="17.235025"
+     id="text1"><tspan
+       id="tspan1"
+       x="5.8255696"
+       y="17.235025"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.6667px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';fill:#000000;fill-opacity:1">4</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.69742"
+     x="0.48312664"
+     y="12.99669"
+     id="text836-5"
+     transform="scale(1.0526149,0.95001506)"><tspan
+       id="tspan834-8"
+       x="0.48312664"
+       y="12.99669"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans';fill:#000000;fill-opacity:1;stroke-width:1.69742">↶</tspan></text>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__4_jump_backward_set.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__4_jump_backward_set.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   height="48"
+   width="40"
+   sodipodi:docname="btn__7_jump_backward_active.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   viewBox="0 0 20 24"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2544"
+     inkscape:window-height="1331"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="8.8653513"
+     inkscape:cx="26.282094"
+     inkscape:cy="1.9175777"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <marker
+       style="overflow:visible"
+       id="marker1312"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path1310" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path886" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.2) translate(6,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path868" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(1.1) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path874" />
+    </marker>
+  </defs>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     x="5.8255696"
+     y="17.235025"
+     id="text1"><tspan
+       id="tspan1"
+       x="5.8255696"
+       y="17.235025"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.6667px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';fill:#000000;fill-opacity:1">4</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#5e5e5e;fill-opacity:1;stroke:none;stroke-width:1.69742"
+     x="0.48312664"
+     y="12.99669"
+     id="text836-5"
+     transform="scale(1.0526149,0.95001506)"><tspan
+       id="tspan834-8"
+       x="0.48312664"
+       y="12.99669"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans';fill:#5e5e5e;fill-opacity:1;stroke-width:1.69742">↶</tspan></text>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__4_jump_set.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__4_jump_set.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   height="48"
+   width="40"
+   sodipodi:docname="btn__1_jump_set.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   viewBox="0 0 20 24"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2544"
+     inkscape:window-height="1331"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="10.871075"
+     inkscape:cx="32.931426"
+     inkscape:cy="8.0948756"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <marker
+       style="overflow:visible"
+       id="marker1312"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path1310" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path886" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.2) translate(6,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path868" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(1.1) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path874" />
+    </marker>
+  </defs>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     x="5.8255696"
+     y="17.235025"
+     id="text1"><tspan
+       id="tspan1"
+       x="5.8255696"
+       y="17.235025"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.6667px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';fill:#000000;fill-opacity:1">4</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#5e5e5e;fill-opacity:1;stroke:none;stroke-width:1.69742"
+     x="4.2831869"
+     y="12.99669"
+     id="text836-5"
+     transform="scale(1.0526149,0.95001506)"><tspan
+       id="tspan834-8"
+       x="4.2831869"
+       y="12.99669"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans';fill:#5e5e5e;fill-opacity:1;stroke-width:1.69742">↷</tspan></text>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__5_jump_active.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__5_jump_active.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   height="48"
+   width="40"
+   sodipodi:docname="btn__5_jump_active.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   viewBox="0 0 20 24"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2544"
+     inkscape:window-height="1331"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="10.871075"
+     inkscape:cx="32.931426"
+     inkscape:cy="8.0948756"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <marker
+       style="overflow:visible"
+       id="marker1312"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path1310" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path886" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.2) translate(6,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path868" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(1.1) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path874" />
+    </marker>
+  </defs>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     x="5.8255696"
+     y="17.235025"
+     id="text1"><tspan
+       id="tspan1"
+       x="5.8255696"
+       y="17.235025"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.6667px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';fill:#000000;fill-opacity:1">5</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.69742"
+     x="4.2831869"
+     y="12.99669"
+     id="text836-5"
+     transform="scale(1.0526149,0.95001506)"><tspan
+       id="tspan834-8"
+       x="4.2831869"
+       y="12.99669"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans';fill:#000000;fill-opacity:1;stroke-width:1.69742">↷</tspan></text>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__5_jump_backward_active.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__5_jump_backward_active.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   height="48"
+   width="40"
+   sodipodi:docname="btn__7_jump_backward_active.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   viewBox="0 0 20 24"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2544"
+     inkscape:window-height="1331"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="8.8653513"
+     inkscape:cx="26.282094"
+     inkscape:cy="1.9175777"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <marker
+       style="overflow:visible"
+       id="marker1312"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path1310" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path886" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.2) translate(6,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path868" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(1.1) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path874" />
+    </marker>
+  </defs>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     x="5.8255696"
+     y="17.235025"
+     id="text1"><tspan
+       id="tspan1"
+       x="5.8255696"
+       y="17.235025"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.6667px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';fill:#000000;fill-opacity:1">5</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.69742"
+     x="0.48312664"
+     y="12.99669"
+     id="text836-5"
+     transform="scale(1.0526149,0.95001506)"><tspan
+       id="tspan834-8"
+       x="0.48312664"
+       y="12.99669"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans';fill:#000000;fill-opacity:1;stroke-width:1.69742">↶</tspan></text>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__5_jump_backward_set.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__5_jump_backward_set.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   height="48"
+   width="40"
+   sodipodi:docname="btn__7_jump_backward_active.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   viewBox="0 0 20 24"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2544"
+     inkscape:window-height="1331"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="8.8653513"
+     inkscape:cx="26.282094"
+     inkscape:cy="1.9175777"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <marker
+       style="overflow:visible"
+       id="marker1312"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path1310" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path886" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.2) translate(6,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path868" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(1.1) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path874" />
+    </marker>
+  </defs>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     x="5.8255696"
+     y="17.235025"
+     id="text1"><tspan
+       id="tspan1"
+       x="5.8255696"
+       y="17.235025"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.6667px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';fill:#000000;fill-opacity:1">5</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#5e5e5e;fill-opacity:1;stroke:none;stroke-width:1.69742"
+     x="0.48312664"
+     y="12.99669"
+     id="text836-5"
+     transform="scale(1.0526149,0.95001506)"><tspan
+       id="tspan834-8"
+       x="0.48312664"
+       y="12.99669"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans';fill:#5e5e5e;fill-opacity:1;stroke-width:1.69742">↶</tspan></text>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__5_jump_set.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__5_jump_set.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   height="48"
+   width="40"
+   sodipodi:docname="btn__1_jump_set.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   viewBox="0 0 20 24"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2544"
+     inkscape:window-height="1331"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="10.871075"
+     inkscape:cx="32.931426"
+     inkscape:cy="8.0948756"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <marker
+       style="overflow:visible"
+       id="marker1312"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path1310" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path886" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.2) translate(6,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path868" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(1.1) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path874" />
+    </marker>
+  </defs>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     x="5.8255696"
+     y="17.235025"
+     id="text1"><tspan
+       id="tspan1"
+       x="5.8255696"
+       y="17.235025"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.6667px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';fill:#000000;fill-opacity:1">5</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#5e5e5e;fill-opacity:1;stroke:none;stroke-width:1.69742"
+     x="4.2831869"
+     y="12.99669"
+     id="text836-5"
+     transform="scale(1.0526149,0.95001506)"><tspan
+       id="tspan834-8"
+       x="4.2831869"
+       y="12.99669"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans';fill:#5e5e5e;fill-opacity:1;stroke-width:1.69742">↷</tspan></text>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__6_jump_active.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__6_jump_active.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   height="48"
+   width="40"
+   sodipodi:docname="btn__6_jump_active.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   viewBox="0 0 20 24"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2544"
+     inkscape:window-height="1331"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="10.871075"
+     inkscape:cx="32.931426"
+     inkscape:cy="8.0948756"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <marker
+       style="overflow:visible"
+       id="marker1312"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path1310" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path886" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.2) translate(6,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path868" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(1.1) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path874" />
+    </marker>
+  </defs>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     x="5.8255696"
+     y="17.235025"
+     id="text1"><tspan
+       id="tspan1"
+       x="5.8255696"
+       y="17.235025"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.6667px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';fill:#000000;fill-opacity:1">6</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.69742"
+     x="4.2831869"
+     y="12.99669"
+     id="text836-5"
+     transform="scale(1.0526149,0.95001506)"><tspan
+       id="tspan834-8"
+       x="4.2831869"
+       y="12.99669"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans';fill:#000000;fill-opacity:1;stroke-width:1.69742">↷</tspan></text>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__6_jump_backward_active.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__6_jump_backward_active.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   height="48"
+   width="40"
+   sodipodi:docname="btn__7_jump_backward_active.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   viewBox="0 0 20 24"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2544"
+     inkscape:window-height="1331"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="8.8653513"
+     inkscape:cx="26.282094"
+     inkscape:cy="1.9175777"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <marker
+       style="overflow:visible"
+       id="marker1312"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path1310" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path886" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.2) translate(6,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path868" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(1.1) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path874" />
+    </marker>
+  </defs>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     x="5.8255696"
+     y="17.235025"
+     id="text1"><tspan
+       id="tspan1"
+       x="5.8255696"
+       y="17.235025"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.6667px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';fill:#000000;fill-opacity:1">6</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.69742"
+     x="0.48312664"
+     y="12.99669"
+     id="text836-5"
+     transform="scale(1.0526149,0.95001506)"><tspan
+       id="tspan834-8"
+       x="0.48312664"
+       y="12.99669"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans';fill:#000000;fill-opacity:1;stroke-width:1.69742">↶</tspan></text>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__6_jump_backward_set.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__6_jump_backward_set.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   height="48"
+   width="40"
+   sodipodi:docname="btn__6_jump_backward_set.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   viewBox="0 0 20 24"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2544"
+     inkscape:window-height="1331"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="8.8653513"
+     inkscape:cx="26.282094"
+     inkscape:cy="1.9175777"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <marker
+       style="overflow:visible"
+       id="marker1312"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path1310" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path886" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.2) translate(6,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path868" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(1.1) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path874" />
+    </marker>
+  </defs>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     x="5.8255696"
+     y="17.235025"
+     id="text1"><tspan
+       id="tspan1"
+       x="5.8255696"
+       y="17.235025"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.6667px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';fill:#000000;fill-opacity:1">6</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#5e5e5e;fill-opacity:1;stroke:none;stroke-width:1.69742"
+     x="0.48312664"
+     y="12.99669"
+     id="text836-5"
+     transform="scale(1.0526149,0.95001506)"><tspan
+       id="tspan834-8"
+       x="0.48312664"
+       y="12.99669"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans';fill:#5e5e5e;fill-opacity:1;stroke-width:1.69742">↶</tspan></text>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__6_jump_set.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__6_jump_set.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   height="48"
+   width="40"
+   sodipodi:docname="btn__1_jump_set.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   viewBox="0 0 20 24"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2544"
+     inkscape:window-height="1331"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="10.871075"
+     inkscape:cx="32.931426"
+     inkscape:cy="8.0948756"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <marker
+       style="overflow:visible"
+       id="marker1312"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path1310" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path886" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.2) translate(6,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path868" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(1.1) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path874" />
+    </marker>
+  </defs>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     x="5.8255696"
+     y="17.235025"
+     id="text1"><tspan
+       id="tspan1"
+       x="5.8255696"
+       y="17.235025"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.6667px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';fill:#000000;fill-opacity:1">6</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#5e5e5e;fill-opacity:1;stroke:none;stroke-width:1.69742"
+     x="4.2831869"
+     y="12.99669"
+     id="text836-5"
+     transform="scale(1.0526149,0.95001506)"><tspan
+       id="tspan834-8"
+       x="4.2831869"
+       y="12.99669"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans';fill:#5e5e5e;fill-opacity:1;stroke-width:1.69742">↷</tspan></text>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__7_jump_active.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__7_jump_active.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   height="48"
+   width="40"
+   sodipodi:docname="btn__7_jump_active.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   viewBox="0 0 20 24"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2544"
+     inkscape:window-height="1331"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="10.871075"
+     inkscape:cx="32.931426"
+     inkscape:cy="8.0948756"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <marker
+       style="overflow:visible"
+       id="marker1312"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path1310" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path886" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.2) translate(6,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path868" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(1.1) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path874" />
+    </marker>
+  </defs>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     x="5.8255696"
+     y="17.235025"
+     id="text1"><tspan
+       id="tspan1"
+       x="5.8255696"
+       y="17.235025"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.6667px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';fill:#000000;fill-opacity:1">7</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.69742"
+     x="4.2831869"
+     y="12.99669"
+     id="text836-5"
+     transform="scale(1.0526149,0.95001506)"><tspan
+       id="tspan834-8"
+       x="4.2831869"
+       y="12.99669"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans';fill:#000000;fill-opacity:1;stroke-width:1.69742">↷</tspan></text>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__7_jump_backward_active.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__7_jump_backward_active.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   height="48"
+   width="40"
+   sodipodi:docname="btn__7_jump_backward_active.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   viewBox="0 0 20 24"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2544"
+     inkscape:window-height="1331"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="8.8653513"
+     inkscape:cx="26.282094"
+     inkscape:cy="1.9175777"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <marker
+       style="overflow:visible"
+       id="marker1312"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path1310" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path886" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.2) translate(6,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path868" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(1.1) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path874" />
+    </marker>
+  </defs>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     x="5.8255696"
+     y="17.235025"
+     id="text1"><tspan
+       id="tspan1"
+       x="5.8255696"
+       y="17.235025"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.6667px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';fill:#000000;fill-opacity:1">7</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.69742"
+     x="0.48312664"
+     y="12.99669"
+     id="text836-5"
+     transform="scale(1.0526149,0.95001506)"><tspan
+       id="tspan834-8"
+       x="0.48312664"
+       y="12.99669"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans';fill:#000000;fill-opacity:1;stroke-width:1.69742">↶</tspan></text>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__7_jump_backward_set.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__7_jump_backward_set.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   height="48"
+   width="40"
+   sodipodi:docname="btn__7_jump_backward_active.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   viewBox="0 0 20 24"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2544"
+     inkscape:window-height="1331"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="8.8653513"
+     inkscape:cx="26.282094"
+     inkscape:cy="1.9175777"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <marker
+       style="overflow:visible"
+       id="marker1312"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path1310" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path886" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.2) translate(6,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path868" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(1.1) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path874" />
+    </marker>
+  </defs>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     x="5.8255696"
+     y="17.235025"
+     id="text1"><tspan
+       id="tspan1"
+       x="5.8255696"
+       y="17.235025"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.6667px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';fill:#000000;fill-opacity:1">7</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#5e5e5e;fill-opacity:1;stroke:none;stroke-width:1.69742"
+     x="0.48312664"
+     y="12.99669"
+     id="text836-5"
+     transform="scale(1.0526149,0.95001506)"><tspan
+       id="tspan834-8"
+       x="0.48312664"
+       y="12.99669"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans';fill:#5e5e5e;fill-opacity:1;stroke-width:1.69742">↶</tspan></text>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__7_jump_set.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__7_jump_set.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   height="48"
+   width="40"
+   sodipodi:docname="btn__1_jump_set.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   viewBox="0 0 20 24"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2544"
+     inkscape:window-height="1331"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="10.871075"
+     inkscape:cx="32.931426"
+     inkscape:cy="8.0948756"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <marker
+       style="overflow:visible"
+       id="marker1312"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path1310" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path886" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.2) translate(6,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path868" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(1.1) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path874" />
+    </marker>
+  </defs>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     x="5.8255696"
+     y="17.235025"
+     id="text1"><tspan
+       id="tspan1"
+       x="5.8255696"
+       y="17.235025"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.6667px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';fill:#000000;fill-opacity:1">7</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#5e5e5e;fill-opacity:1;stroke:none;stroke-width:1.69742"
+     x="4.2831869"
+     y="12.99669"
+     id="text836-5"
+     transform="scale(1.0526149,0.95001506)"><tspan
+       id="tspan834-8"
+       x="4.2831869"
+       y="12.99669"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans';fill:#5e5e5e;fill-opacity:1;stroke-width:1.69742">↷</tspan></text>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__8_jump_active.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__8_jump_active.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   height="48"
+   width="40"
+   sodipodi:docname="btn__8_jump_active.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   viewBox="0 0 20 24"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2544"
+     inkscape:window-height="1331"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="10.871075"
+     inkscape:cx="32.931426"
+     inkscape:cy="8.0948756"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <marker
+       style="overflow:visible"
+       id="marker1312"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path1310" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path886" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.2) translate(6,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path868" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(1.1) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path874" />
+    </marker>
+  </defs>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     x="5.8255696"
+     y="17.235025"
+     id="text1"><tspan
+       id="tspan1"
+       x="5.8255696"
+       y="17.235025"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.6667px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';fill:#000000;fill-opacity:1">8</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.69742"
+     x="4.2831869"
+     y="12.99669"
+     id="text836-5"
+     transform="scale(1.0526149,0.95001506)"><tspan
+       id="tspan834-8"
+       x="4.2831869"
+       y="12.99669"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans';fill:#000000;fill-opacity:1;stroke-width:1.69742">↷</tspan></text>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__8_jump_backward_active.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__8_jump_backward_active.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   height="48"
+   width="40"
+   sodipodi:docname="btn__8_jump_backward_active.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   viewBox="0 0 20 24"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2544"
+     inkscape:window-height="1331"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="8.8653513"
+     inkscape:cx="26.282094"
+     inkscape:cy="1.9175777"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <marker
+       style="overflow:visible"
+       id="marker1312"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path1310" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path886" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.2) translate(6,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path868" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(1.1) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path874" />
+    </marker>
+  </defs>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     x="5.8255696"
+     y="17.235025"
+     id="text1"><tspan
+       id="tspan1"
+       x="5.8255696"
+       y="17.235025"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.6667px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';fill:#000000;fill-opacity:1">8</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.69742"
+     x="0.48312664"
+     y="12.99669"
+     id="text836-5"
+     transform="scale(1.0526149,0.95001506)"><tspan
+       id="tspan834-8"
+       x="0.48312664"
+       y="12.99669"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans';fill:#000000;fill-opacity:1;stroke-width:1.69742">↶</tspan></text>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__8_jump_backward_set.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__8_jump_backward_set.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   height="48"
+   width="40"
+   sodipodi:docname="btn__8_jump_backward_active.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   viewBox="0 0 20 24"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2544"
+     inkscape:window-height="1331"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="8.8653513"
+     inkscape:cx="26.282094"
+     inkscape:cy="1.9175777"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <marker
+       style="overflow:visible"
+       id="marker1312"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path1310" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path886" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.2) translate(6,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path868" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(1.1) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path874" />
+    </marker>
+  </defs>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     x="5.8255696"
+     y="17.235025"
+     id="text1"><tspan
+       id="tspan1"
+       x="5.8255696"
+       y="17.235025"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.6667px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';fill:#000000;fill-opacity:1">8</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#5e5e5e;fill-opacity:1;stroke:none;stroke-width:1.69742"
+     x="0.48312664"
+     y="12.99669"
+     id="text836-5"
+     transform="scale(1.0526149,0.95001506)"><tspan
+       id="tspan834-8"
+       x="0.48312664"
+       y="12.99669"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans';fill:#5e5e5e;fill-opacity:1;stroke-width:1.69742">↶</tspan></text>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__8_jump_set.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__8_jump_set.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   height="48"
+   width="40"
+   sodipodi:docname="btn__1_jump_set.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   viewBox="0 0 20 24"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2544"
+     inkscape:window-height="1331"
+     id="namedview7"
+     showgrid="false"
+     inkscape:zoom="10.871075"
+     inkscape:cx="32.931426"
+     inkscape:cy="8.0948756"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <marker
+       style="overflow:visible"
+       id="marker1312"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path1310" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.3) translate(-2.3,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path886" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Sstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow1Sstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(0.2) translate(6,0)"
+         style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 0.0,0.0 L 5.0,-5.0 L -12.5,0.0 L 5.0,5.0 L 0.0,0.0 z "
+         id="path868" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Lstart"
+       refX="0.0"
+       refY="0.0"
+       orient="auto"
+       inkscape:stockid="Arrow2Lstart"
+       inkscape:isstock="true">
+      <path
+         transform="scale(1.1) translate(1,0)"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         id="path874" />
+    </marker>
+  </defs>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     x="5.8255696"
+     y="17.235025"
+     id="text1"><tspan
+       id="tspan1"
+       x="5.8255696"
+       y="17.235025"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.6667px;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';fill:#000000;fill-opacity:1">8</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:17.3333px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#5e5e5e;fill-opacity:1;stroke:none;stroke-width:1.69742"
+     x="4.2831869"
+     y="12.99669"
+     id="text836-5"
+     transform="scale(1.0526149,0.95001506)"><tspan
+       id="tspan834-8"
+       x="4.2831869"
+       y="12.99669"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:17.3333px;font-family:'Droid Sans';-inkscape-font-specification:'Droid Sans';fill:#5e5e5e;fill-opacity:1;stroke-width:1.69742">↷</tspan></text>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__jump_backward.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__jump_backward.svg
@@ -1,0 +1,1 @@
+btn__beatjump_left.svg

--- a/res/skins/LateNight/palemoon/buttons/btn__jump_forward.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__jump_forward.svg
@@ -1,0 +1,1 @@
+btn__beatjump_right.svg

--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -2106,8 +2106,29 @@ QPushButton#pushButtonRepeatPlaylist:!checked {
   }
 
 /* widgets in cue popup menu */
-#CueDeleteButton,
+#CueDeleteButton {
+  qproperty-icon: url(skins:LateNight/classic/buttons/btn__delete.svg);
+  /* color buttons are 42x24 px.
+  To get the final size for the Delete button consider border width.
+  It's a tall button, about the same height as cue number + label edit box */
+  width: 24px;
+  height: 24px;
+  border-width: 2px;
+  border-image: url(skins:LateNight/classic/buttons/btn_embedded_library.svg) 2 2 2 2;
+  qproperty-iconSize: 18px;
+  /* has no effect
+  padding: 0px; */
+}
+#CueDeleteButton:hover {
+  background-color: #6c2e2e;
+}
+
+#CueDeleteButton[pressed="true"], #CueDeleteButton:pressed, #CueDeleteButton:clicked {
+  background-color: #dc4141 !important;
+}
+
 #CueSavedLoopButton {
+  qproperty-icon: url(skins:LateNight/classic/buttons/btn__loop.svg);
   /* color buttons are 42x24 px.
   To get the final size for the Delete button consider border width.
   It's a tall button, about the same height as cue number + label edit box */
@@ -2115,6 +2136,10 @@ QPushButton#pushButtonRepeatPlaylist:!checked {
   height: 42px;
   border-width: 2px;
   border-image: url(skins:LateNight/classic/buttons/btn_embedded_library.svg) 2 2 2 2;
+  /* make the icon slightly larger than default 16px */
+  qproperty-iconSize: 20px;
+  /* has no effect
+  padding: 0px; */
 }
 #CueDeleteButton {
   image: url(skins:LateNight/classic/buttons/btn__delete.svg);
@@ -2125,6 +2150,42 @@ QPushButton#pushButtonRepeatPlaylist:!checked {
 #CueDeleteButton:pressed,
 #CueSavedLoopButton:pressed,
 #CueSavedLoopButton:checked {
+  background-color: #db0000;
+  outline: none;
+  image: url(skins:LateNight/classic/buttons/btn__loop_active.svg);
+}
+
+#CueSavedJumpButton {
+  qproperty-icon: url(skins:LateNight/classic/buttons/btn__beatjump_right.svg);
+  /* color buttons are 42x24 px.
+  To get the final size for the Delete button consider border width.
+  It's a tall button, about the same height as cue number + label edit box */
+  width: 24px;
+  height: 42px;
+  border-width: 2px;
+  border-image: url(skins:LateNight/classic/buttons/btn_embedded_library.svg) 2 2 2 2;
+  /* make the icon slightly larger than default 16px */
+  qproperty-iconSize: 20px;
+  /* has no effect
+  padding: 0px; */
+}
+
+#CueStandardButton {
+  qproperty-icon: url(skins:LateNight/classic/buttons/btn__beats_hotcues_later.svg);
+  /* color buttons are 42x24 px.
+  To get the final size for the Delete button consider border width.
+  It's a tall button, about the same height as cue number + label edit box */
+  width: 24px;
+  height: 42px;
+  border-width: 2px;
+  border-image: url(skins:LateNight/classic/buttons/btn_embedded_library.svg) 2 2 2 2;
+  /* make the icon slightly larger than default 16px */
+  qproperty-iconSize: 20px;
+  /* has no effect
+  padding: 0px; */
+}
+#CueSavedJumpButton:pressed, WCueMenuPopup #CueSavedJumpButton:checked,
+  #CueStandardButton:pressed, WCueMenuPopup #CueStandardButton:checked {
   background-color: #db0000;
   outline: none;
 }

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -1488,7 +1488,9 @@ WEffectSelector:!editable,
 #fadeModeCombobox:!editable,
 #LibraryFeatureControls QPushButton:enabled,
 #CueDeleteButton,
-#CueSavedLoopButton {
+#CueStandardButton,
+#CueSavedLoopButton,
+#CueSavedJumpButton {
   outline: none;
   border-width: 2px;
   border-image: url(skins:LateNight/palemoon/buttons/btn_embedded_library.svg) 2 2 2 2;
@@ -1518,8 +1520,12 @@ WEffectSelector:!editable,
   WEffectSelector:!editable:on,
   #fadeModeCombobox:!editable:on,
   #CueDeleteButton[pressed="true"],
+  #CueStandardButton[pressed="true"],
+  #CueStandardButton:checked,
   #CueSavedLoopButton[pressed="true"],
-  #CueSavedLoopButton:checked {
+  #CueSavedLoopButton:checked,
+  #CueSavedJumpButton[pressed="true"],
+  #CueSavedJumpButton:checked {
     border-width: 2px;
     border-image: url(skins:LateNight/palemoon/buttons/btn_embedded_library_active.svg) 2 2 2 2;
   }
@@ -1653,7 +1659,9 @@ WBeatSpinBox::down-button {
   /* bright buttons in dimmed containers
   #BeatgridControls WPushButton[displayValue="0"], */
   #CueDeleteButton,
+  #CueStandardButton,
   #CueSavedLoopButton,
+  #CueSavedJumpButton,
   #SplitCue[displayValue="0"],
   #PlayPreview[displayValue="0"],
   /* library controls */
@@ -1709,9 +1717,12 @@ WPushButton#LoopAnchor[pressed="true"],
 #BeatjumpControls WPushButton[value="1"],
 #RateControls WPushButton[value="1"],
 #BeatgridControls WPushButton[pressed="true"]/*,
-#CueDeleteButton[pressed="true"],
+#CueStandardButton[pressed="true"],
+#CueStandardButton:checked,
 #CueSavedLoopButton[pressed="true"],
-#CueSavedLoopButton:checked*/ {
+#CueSavedLoopButton:checked,
+#CueSavedJumpButton[pressed="true"],
+#CueSavedJumpButton:checked*/ {
   background-color: #7d350d;
   }
 
@@ -1946,6 +1957,30 @@ WPushButton#PlayDeck[value="0"] {
   #Hotcue1 WPushButton[type="loop"][displayValue="2"][dark="true"] {
     image: url(skins:LateNight/palemoon/buttons/btn__1_loop.svg) no-repeat center center;
   }
+  #Hotcue1 WPushButton[type="jump"][displayValue="1"][direction="forward"][dark="false"][active="true"],
+  #Hotcue1 WPushButton[type="jump"][displayValue="2"][direction="forward"][dark="false"][active="true"],
+  #Hotcue1 WPushButton[type="jump"][displayValue="1"][direction="forward"][dark="true"][active="true"],
+  #Hotcue1 WPushButton[type="jump"][displayValue="2"][direction="forward"][dark="true"][active="true"] {
+    image: url(skins:LateNight/palemoon/buttons/btn__1_jump_active.svg) no-repeat center center;
+  }
+  #Hotcue1 WPushButton[type="jump"][displayValue="1"][direction="backward"][dark="false"][active="true"],
+  #Hotcue1 WPushButton[type="jump"][displayValue="2"][direction="backward"][dark="false"][active="true"],
+  #Hotcue1 WPushButton[type="jump"][displayValue="1"][direction="backward"][dark="true"][active="true"],
+  #Hotcue1 WPushButton[type="jump"][displayValue="2"][direction="backward"][dark="true"][active="true"] {
+    image: url(skins:LateNight/palemoon/buttons/btn__1_jump_backward_active.svg) no-repeat center center;
+  }
+  #Hotcue1 WPushButton[type="jump"][displayValue="1"][direction="forward"][dark="false"][active="false"],
+  #Hotcue1 WPushButton[type="jump"][displayValue="2"][direction="forward"][dark="false"][active="false"],
+  #Hotcue1 WPushButton[type="jump"][displayValue="1"][direction="forward"][dark="true"][active="false"],
+  #Hotcue1 WPushButton[type="jump"][displayValue="2"][direction="forward"][dark="true"][active="false"] {
+    image: url(skins:LateNight/palemoon/buttons/btn__1_jump_set.svg) no-repeat center center;
+  }
+  #Hotcue1 WPushButton[type="jump"][displayValue="1"][direction="backward"][dark="false"][active="false"],
+  #Hotcue1 WPushButton[type="jump"][displayValue="2"][direction="backward"][dark="false"][active="false"],
+  #Hotcue1 WPushButton[type="jump"][displayValue="1"][direction="backward"][dark="true"][active="false"],
+  #Hotcue1 WPushButton[type="jump"][displayValue="2"][direction="backward"][dark="true"][active="false"] {
+    image: url(skins:LateNight/palemoon/buttons/btn__1_jump_backward_set.svg) no-repeat center center;
+  }
 
 #Hotcue2 WPushButton[displayValue="0"] {
   image: url(skins:LateNight/palemoon/buttons/btn__2.svg) no-repeat center center;
@@ -1963,6 +1998,30 @@ WPushButton#PlayDeck[value="0"] {
   #Hotcue2 WPushButton[type="loop"][displayValue="1"][dark="true"],
   #Hotcue2 WPushButton[type="loop"][displayValue="2"][dark="true"] {
     image: url(skins:LateNight/palemoon/buttons/btn__2_loop.svg) no-repeat center center;
+  }
+  #Hotcue2 WPushButton[type="jump"][displayValue="1"][direction="forward"][dark="false"][active="true"],
+  #Hotcue2 WPushButton[type="jump"][displayValue="2"][direction="forward"][dark="false"][active="true"],
+  #Hotcue2 WPushButton[type="jump"][displayValue="1"][direction="forward"][dark="true"][active="true"],
+  #Hotcue2 WPushButton[type="jump"][displayValue="2"][direction="forward"][dark="true"][active="true"] {
+    image: url(skins:LateNight/palemoon/buttons/btn__2_jump_active.svg) no-repeat center center;
+  }
+  #Hotcue2 WPushButton[type="jump"][displayValue="1"][direction="backward"][dark="false"][active="true"],
+  #Hotcue2 WPushButton[type="jump"][displayValue="2"][direction="backward"][dark="false"][active="true"],
+  #Hotcue2 WPushButton[type="jump"][displayValue="1"][direction="backward"][dark="true"][active="true"],
+  #Hotcue2 WPushButton[type="jump"][displayValue="2"][direction="backward"][dark="true"][active="true"] {
+    image: url(skins:LateNight/palemoon/buttons/btn__2_jump_backward_active.svg) no-repeat center center;
+  }
+  #Hotcue2 WPushButton[type="jump"][displayValue="1"][direction="forward"][dark="false"][active="false"],
+  #Hotcue2 WPushButton[type="jump"][displayValue="2"][direction="forward"][dark="false"][active="false"],
+  #Hotcue2 WPushButton[type="jump"][displayValue="1"][direction="forward"][dark="true"][active="false"],
+  #Hotcue2 WPushButton[type="jump"][displayValue="2"][direction="forward"][dark="true"][active="false"] {
+    image: url(skins:LateNight/palemoon/buttons/btn__2_jump_set.svg) no-repeat center center;
+  }
+  #Hotcue2 WPushButton[type="jump"][displayValue="1"][direction="backward"][dark="false"][active="false"],
+  #Hotcue2 WPushButton[type="jump"][displayValue="2"][direction="backward"][dark="false"][active="false"],
+  #Hotcue2 WPushButton[type="jump"][displayValue="1"][direction="backward"][dark="true"][active="false"],
+  #Hotcue2 WPushButton[type="jump"][displayValue="2"][direction="backward"][dark="true"][active="false"] {
+    image: url(skins:LateNight/palemoon/buttons/btn__2_jump_backward_set.svg) no-repeat center center;
   }
 
 #Hotcue3 WPushButton[displayValue="0"] {
@@ -1982,6 +2041,30 @@ WPushButton#PlayDeck[value="0"] {
   #Hotcue3 WPushButton[type="loop"][displayValue="2"][dark="true"] {
     image: url(skins:LateNight/palemoon/buttons/btn__3_loop.svg) no-repeat center center;
   }
+  #Hotcue3 WPushButton[type="jump"][displayValue="1"][direction="forward"][dark="false"][active="true"],
+  #Hotcue3 WPushButton[type="jump"][displayValue="2"][direction="forward"][dark="false"][active="true"],
+  #Hotcue3 WPushButton[type="jump"][displayValue="1"][direction="forward"][dark="true"][active="true"],
+  #Hotcue3 WPushButton[type="jump"][displayValue="2"][direction="forward"][dark="true"][active="true"] {
+    image: url(skins:LateNight/palemoon/buttons/btn__3_jump_active.svg) no-repeat center center;
+  }
+  #Hotcue3 WPushButton[type="jump"][displayValue="1"][direction="backward"][dark="false"][active="true"],
+  #Hotcue3 WPushButton[type="jump"][displayValue="2"][direction="backward"][dark="false"][active="true"],
+  #Hotcue3 WPushButton[type="jump"][displayValue="1"][direction="backward"][dark="true"][active="true"],
+  #Hotcue3 WPushButton[type="jump"][displayValue="2"][direction="backward"][dark="true"][active="true"] {
+    image: url(skins:LateNight/palemoon/buttons/btn__3_jump_backward_active.svg) no-repeat center center;
+  }
+  #Hotcue3 WPushButton[type="jump"][displayValue="1"][direction="forward"][dark="false"][active="false"],
+  #Hotcue3 WPushButton[type="jump"][displayValue="2"][direction="forward"][dark="false"][active="false"],
+  #Hotcue3 WPushButton[type="jump"][displayValue="1"][direction="forward"][dark="true"][active="false"],
+  #Hotcue3 WPushButton[type="jump"][displayValue="2"][direction="forward"][dark="true"][active="false"] {
+    image: url(skins:LateNight/palemoon/buttons/btn__3_jump_set.svg) no-repeat center center;
+  }
+  #Hotcue3 WPushButton[type="jump"][displayValue="1"][direction="backward"][dark="false"][active="false"],
+  #Hotcue3 WPushButton[type="jump"][displayValue="2"][direction="backward"][dark="false"][active="false"],
+  #Hotcue3 WPushButton[type="jump"][displayValue="1"][direction="backward"][dark="true"][active="false"],
+  #Hotcue3 WPushButton[type="jump"][displayValue="2"][direction="backward"][dark="true"][active="false"] {
+    image: url(skins:LateNight/palemoon/buttons/btn__3_jump_backward_set.svg) no-repeat center center;
+  }
 
 #Hotcue4 WPushButton[displayValue="0"] {
   image: url(skins:LateNight/palemoon/buttons/btn__4.svg) no-repeat center center;
@@ -1999,6 +2082,30 @@ WPushButton#PlayDeck[value="0"] {
   #Hotcue4 WPushButton[type="loop"][displayValue="1"][dark="true"],
   #Hotcue4 WPushButton[type="loop"][displayValue="2"][dark="true"] {
     image: url(skins:LateNight/palemoon/buttons/btn__4_loop.svg) no-repeat center center;
+  }
+  #Hotcue4 WPushButton[type="jump"][displayValue="1"][direction="forward"][dark="false"][active="true"],
+  #Hotcue4 WPushButton[type="jump"][displayValue="2"][direction="forward"][dark="false"][active="true"],
+  #Hotcue4 WPushButton[type="jump"][displayValue="1"][direction="forward"][dark="true"][active="true"],
+  #Hotcue4 WPushButton[type="jump"][displayValue="2"][direction="forward"][dark="true"][active="true"] {
+    image: url(skins:LateNight/palemoon/buttons/btn__4_jump_active.svg) no-repeat center center;
+  }
+  #Hotcue4 WPushButton[type="jump"][displayValue="1"][direction="backward"][dark="false"][active="true"],
+  #Hotcue4 WPushButton[type="jump"][displayValue="2"][direction="backward"][dark="false"][active="true"],
+  #Hotcue4 WPushButton[type="jump"][displayValue="1"][direction="backward"][dark="true"][active="true"],
+  #Hotcue4 WPushButton[type="jump"][displayValue="2"][direction="backward"][dark="true"][active="true"] {
+    image: url(skins:LateNight/palemoon/buttons/btn__4_jump_backward_active.svg) no-repeat center center;
+  }
+  #Hotcue4 WPushButton[type="jump"][displayValue="1"][direction="forward"][dark="false"][active="false"],
+  #Hotcue4 WPushButton[type="jump"][displayValue="2"][direction="forward"][dark="false"][active="false"],
+  #Hotcue4 WPushButton[type="jump"][displayValue="1"][direction="forward"][dark="true"][active="false"],
+  #Hotcue4 WPushButton[type="jump"][displayValue="2"][direction="forward"][dark="true"][active="false"] {
+    image: url(skins:LateNight/palemoon/buttons/btn__4_jump_set.svg) no-repeat center center;
+  }
+  #Hotcue4 WPushButton[type="jump"][displayValue="1"][direction="backward"][dark="false"][active="false"],
+  #Hotcue4 WPushButton[type="jump"][displayValue="2"][direction="backward"][dark="false"][active="false"],
+  #Hotcue4 WPushButton[type="jump"][displayValue="1"][direction="backward"][dark="true"][active="false"],
+  #Hotcue4 WPushButton[type="jump"][displayValue="2"][direction="backward"][dark="true"][active="false"] {
+    image: url(skins:LateNight/palemoon/buttons/btn__4_jump_backward_set.svg) no-repeat center center;
   }
 
 #Hotcue5 WPushButton[displayValue="0"] {
@@ -2018,6 +2125,30 @@ WPushButton#PlayDeck[value="0"] {
   #Hotcue5 WPushButton[type="loop"][displayValue="2"][dark="true"] {
     image: url(skins:LateNight/palemoon/buttons/btn__5_loop.svg) no-repeat center center;
   }
+  #Hotcue5 WPushButton[type="jump"][displayValue="1"][direction="forward"][dark="false"][active="true"],
+  #Hotcue5 WPushButton[type="jump"][displayValue="2"][direction="forward"][dark="false"][active="true"],
+  #Hotcue5 WPushButton[type="jump"][displayValue="1"][direction="forward"][dark="true"][active="true"],
+  #Hotcue5 WPushButton[type="jump"][displayValue="2"][direction="forward"][dark="true"][active="true"] {
+    image: url(skins:LateNight/palemoon/buttons/btn__5_jump_active.svg) no-repeat center center;
+  }
+  #Hotcue5 WPushButton[type="jump"][displayValue="1"][direction="backward"][dark="false"][active="true"],
+  #Hotcue5 WPushButton[type="jump"][displayValue="2"][direction="backward"][dark="false"][active="true"],
+  #Hotcue5 WPushButton[type="jump"][displayValue="1"][direction="backward"][dark="true"][active="true"],
+  #Hotcue5 WPushButton[type="jump"][displayValue="2"][direction="backward"][dark="true"][active="true"] {
+    image: url(skins:LateNight/palemoon/buttons/btn__5_jump_backward_active.svg) no-repeat center center;
+  }
+  #Hotcue5 WPushButton[type="jump"][displayValue="1"][direction="forward"][dark="false"][active="false"],
+  #Hotcue5 WPushButton[type="jump"][displayValue="2"][direction="forward"][dark="false"][active="false"],
+  #Hotcue5 WPushButton[type="jump"][displayValue="1"][direction="forward"][dark="true"][active="false"],
+  #Hotcue5 WPushButton[type="jump"][displayValue="2"][direction="forward"][dark="true"][active="false"] {
+    image: url(skins:LateNight/palemoon/buttons/btn__5_jump_set.svg) no-repeat center center;
+  }
+  #Hotcue5 WPushButton[type="jump"][displayValue="1"][direction="backward"][dark="false"][active="false"],
+  #Hotcue5 WPushButton[type="jump"][displayValue="2"][direction="backward"][dark="false"][active="false"],
+  #Hotcue5 WPushButton[type="jump"][displayValue="1"][direction="backward"][dark="true"][active="false"],
+  #Hotcue5 WPushButton[type="jump"][displayValue="2"][direction="backward"][dark="true"][active="false"] {
+    image: url(skins:LateNight/palemoon/buttons/btn__5_jump_backward_set.svg) no-repeat center center;
+  }
 
 #Hotcue6 WPushButton[displayValue="0"] {
   image: url(skins:LateNight/palemoon/buttons/btn__6.svg) no-repeat center center;
@@ -2035,6 +2166,30 @@ WPushButton#PlayDeck[value="0"] {
   #Hotcue6 WPushButton[type="loop"][displayValue="1"][dark="true"],
   #Hotcue6 WPushButton[type="loop"][displayValue="2"][dark="true"] {
     image: url(skins:LateNight/palemoon/buttons/btn__6_loop.svg) no-repeat center center;
+  }
+  #Hotcue6 WPushButton[type="jump"][displayValue="1"][direction="forward"][dark="false"][active="true"],
+  #Hotcue6 WPushButton[type="jump"][displayValue="2"][direction="forward"][dark="false"][active="true"],
+  #Hotcue6 WPushButton[type="jump"][displayValue="1"][direction="forward"][dark="true"][active="true"],
+  #Hotcue6 WPushButton[type="jump"][displayValue="2"][direction="forward"][dark="true"][active="true"] {
+    image: url(skins:LateNight/palemoon/buttons/btn__6_jump_active.svg) no-repeat center center;
+  }
+  #Hotcue6 WPushButton[type="jump"][displayValue="1"][direction="backward"][dark="false"][active="true"],
+  #Hotcue6 WPushButton[type="jump"][displayValue="2"][direction="backward"][dark="false"][active="true"],
+  #Hotcue6 WPushButton[type="jump"][displayValue="1"][direction="backward"][dark="true"][active="true"],
+  #Hotcue6 WPushButton[type="jump"][displayValue="2"][direction="backward"][dark="true"][active="true"] {
+    image: url(skins:LateNight/palemoon/buttons/btn__6_jump_backward_active.svg) no-repeat center center;
+  }
+  #Hotcue6 WPushButton[type="jump"][displayValue="1"][direction="forward"][dark="false"][active="false"],
+  #Hotcue6 WPushButton[type="jump"][displayValue="2"][direction="forward"][dark="false"][active="false"],
+  #Hotcue6 WPushButton[type="jump"][displayValue="1"][direction="forward"][dark="true"][active="false"],
+  #Hotcue6 WPushButton[type="jump"][displayValue="2"][direction="forward"][dark="true"][active="false"] {
+    image: url(skins:LateNight/palemoon/buttons/btn__6_jump_set.svg) no-repeat center center;
+  }
+  #Hotcue6 WPushButton[type="jump"][displayValue="1"][direction="backward"][dark="false"][active="false"],
+  #Hotcue6 WPushButton[type="jump"][displayValue="2"][direction="backward"][dark="false"][active="false"],
+  #Hotcue6 WPushButton[type="jump"][displayValue="1"][direction="backward"][dark="true"][active="false"],
+  #Hotcue6 WPushButton[type="jump"][displayValue="2"][direction="backward"][dark="true"][active="false"] {
+    image: url(skins:LateNight/palemoon/buttons/btn__6_jump_backward_set.svg) no-repeat center center;
   }
 
 #Hotcue7 WPushButton[displayValue="0"] {
@@ -2054,6 +2209,30 @@ WPushButton#PlayDeck[value="0"] {
   #Hotcue7 WPushButton[type="loop"][displayValue="2"][dark="true"] {
     image: url(skins:LateNight/palemoon/buttons/btn__7_loop.svg) no-repeat center center;
   }
+  #Hotcue7 WPushButton[type="jump"][displayValue="1"][direction="forward"][dark="false"][active="true"],
+  #Hotcue7 WPushButton[type="jump"][displayValue="2"][direction="forward"][dark="false"][active="true"],
+  #Hotcue7 WPushButton[type="jump"][displayValue="1"][direction="forward"][dark="true"][active="true"],
+  #Hotcue7 WPushButton[type="jump"][displayValue="2"][direction="forward"][dark="true"][active="true"] {
+    image: url(skins:LateNight/palemoon/buttons/btn__7_jump_active.svg) no-repeat center center;
+  }
+  #Hotcue7 WPushButton[type="jump"][displayValue="1"][direction="backward"][dark="false"][active="true"],
+  #Hotcue7 WPushButton[type="jump"][displayValue="2"][direction="backward"][dark="false"][active="true"],
+  #Hotcue7 WPushButton[type="jump"][displayValue="1"][direction="backward"][dark="true"][active="true"],
+  #Hotcue7 WPushButton[type="jump"][displayValue="2"][direction="backward"][dark="true"][active="true"] {
+    image: url(skins:LateNight/palemoon/buttons/btn__7_jump_backward_active.svg) no-repeat center center;
+  }
+  #Hotcue7 WPushButton[type="jump"][displayValue="1"][direction="forward"][dark="false"][active="false"],
+  #Hotcue7 WPushButton[type="jump"][displayValue="2"][direction="forward"][dark="false"][active="false"],
+  #Hotcue7 WPushButton[type="jump"][displayValue="1"][direction="forward"][dark="true"][active="false"],
+  #Hotcue7 WPushButton[type="jump"][displayValue="2"][direction="forward"][dark="true"][active="false"] {
+    image: url(skins:LateNight/palemoon/buttons/btn__7_jump_set.svg) no-repeat center center;
+  }
+  #Hotcue7 WPushButton[type="jump"][displayValue="1"][direction="backward"][dark="false"][active="false"],
+  #Hotcue7 WPushButton[type="jump"][displayValue="2"][direction="backward"][dark="false"][active="false"],
+  #Hotcue7 WPushButton[type="jump"][displayValue="1"][direction="backward"][dark="true"][active="false"],
+  #Hotcue7 WPushButton[type="jump"][displayValue="2"][direction="backward"][dark="true"][active="false"] {
+    image: url(skins:LateNight/palemoon/buttons/btn__7_jump_backward_set.svg) no-repeat center center;
+  }
 
 #Hotcue8 WPushButton[displayValue="0"] {
   image: url(skins:LateNight/palemoon/buttons/btn__8.svg) no-repeat center center;
@@ -2071,6 +2250,30 @@ WPushButton#PlayDeck[value="0"] {
   #Hotcue8 WPushButton[type="loop"][displayValue="1"][dark="true"],
   #Hotcue8 WPushButton[type="loop"][displayValue="2"][dark="true"] {
     image: url(skins:LateNight/palemoon/buttons/btn__8_loop.svg) no-repeat center center;
+  }
+  #Hotcue8 WPushButton[type="jump"][displayValue="1"][direction="forward"][dark="false"][active="true"],
+  #Hotcue8 WPushButton[type="jump"][displayValue="2"][direction="forward"][dark="false"][active="true"],
+  #Hotcue8 WPushButton[type="jump"][displayValue="1"][direction="forward"][dark="true"][active="true"],
+  #Hotcue8 WPushButton[type="jump"][displayValue="2"][direction="forward"][dark="true"][active="true"] {
+    image: url(skins:LateNight/palemoon/buttons/btn__8_jump_active.svg) no-repeat center center;
+  }
+  #Hotcue8 WPushButton[type="jump"][displayValue="1"][direction="backward"][dark="false"][active="true"],
+  #Hotcue8 WPushButton[type="jump"][displayValue="2"][direction="backward"][dark="false"][active="true"],
+  #Hotcue8 WPushButton[type="jump"][displayValue="1"][direction="backward"][dark="true"][active="true"],
+  #Hotcue8 WPushButton[type="jump"][displayValue="2"][direction="backward"][dark="true"][active="true"] {
+    image: url(skins:LateNight/palemoon/buttons/btn__8_jump_backward_active.svg) no-repeat center center;
+  }
+  #Hotcue8 WPushButton[type="jump"][displayValue="1"][direction="forward"][dark="false"][active="false"],
+  #Hotcue8 WPushButton[type="jump"][displayValue="2"][direction="forward"][dark="false"][active="false"],
+  #Hotcue8 WPushButton[type="jump"][displayValue="1"][direction="forward"][dark="true"][active="false"],
+  #Hotcue8 WPushButton[type="jump"][displayValue="2"][direction="forward"][dark="true"][active="false"] {
+    image: url(skins:LateNight/palemoon/buttons/btn__8_jump_set.svg) no-repeat center center;
+  }
+  #Hotcue8 WPushButton[type="jump"][displayValue="1"][direction="backward"][dark="false"][active="false"],
+  #Hotcue8 WPushButton[type="jump"][displayValue="2"][direction="backward"][dark="false"][active="false"],
+  #Hotcue8 WPushButton[type="jump"][displayValue="1"][direction="backward"][dark="true"][active="false"],
+  #Hotcue8 WPushButton[type="jump"][displayValue="2"][direction="backward"][dark="true"][active="false"] {
+    image: url(skins:LateNight/palemoon/buttons/btn__8_jump_backward_set.svg) no-repeat center center;
   }
 
 #SpecialCueButton_intro_start WPushButton[displayValue="0"] {
@@ -2552,30 +2755,67 @@ QPushButton#pushButtonRepeatPlaylist:!checked {
 /* AutoDJ button icons */
 
 /* widgets in cue popup menu */
-WCueMenuPopup #CueDeleteButton,
-WCueMenuPopup #CueSavedLoopButton {
+WCueMenuPopup #CueDeleteButton {
+  icon: url(skins:LateNight/palemoon/buttons/btn__delete.svg);
+  width: 24px;
+  height: 24px;
+  icon-size: 18px;
+}
+WCueMenuPopup #CueStandardButton {
+  icon: url(skins:LateNight/palemoon/buttons/btn__beats_hotcues_later.svg);
   width: 24px;
   height: 42px;
+  /* make the icon slightly larger than default 16px */
+  icon-size: 24px;
 }
-WCueMenuPopup #CueDeleteButton {
-  /* Note: we can't use qproperty-icon here because it's evauated only once
-     and therefore won't style the checked state */
-  image: url(skins:LateNight/palemoon/buttons/btn__delete.svg);
-}
-  WCueMenuPopup #CueDeleteButton:pressed {
-    background-color: #b24c12;
-    outline: none;
-    image: url(skins:LateNight/palemoon/buttons/btn__delete_active.svg);
-  }
-
 WCueMenuPopup #CueSavedLoopButton {
-  image: url(skins:LateNight/palemoon/buttons/btn__loop.svg);
+  icon: url(skins:LateNight/palemoon/buttons/btn__loop.svg);
+  width: 24px;
+  height: 42px;
+  /* make the icon slightly larger than default 16px */
+  icon-size: 24px;
 }
-WCueMenuPopup #CueSavedLoopButton:pressed,
-WCueMenuPopup #CueSavedLoopButton:checked {
+WCueMenuPopup #CueSavedJumpButton {
+  width: 24px;
+  height: 42px;
+  /* make the icon slightly larger than default 16px */
+  icon-size: 24px;
+}
+WCueMenuPopup #CueSavedJumpButton[direction="forward"] {
+  icon: url(skins:LateNight/palemoon/buttons/btn__beatjump_right.svg);
+}
+WCueMenuPopup #CueSavedJumpButton[direction="backward"] {
+  icon: url(skins:LateNight/palemoon/buttons/btn__beatjump_left.svg);
+}
+
+#CueDeleteButton:hover {
+  background-color: #6c2e2e;
+}
+
+#CueDeleteButton[pressed="true"], #CueDeleteButton:pressed, #CueDeleteButton:clicked {
+  background-color: #dc4141 !important;
+  outline: none;
+}
+
+#CueSavedLoopButton:pressed, #CueSavedLoopButton:checked {
   background-color: #b24c12;
   outline: none;
-  image: url(skins:LateNight/palemoon/buttons/btn__loop_active.svg);
+  icon: url(skins:LateNight/palemoon/buttons/btn__loop_active.svg);
+}
+#CueSavedJumpButton:pressed, #CueSavedJumpButton:checked {
+  background-color: #b24c12;
+  outline: none;
+}
+#CueSavedJumpButton[direction="forward"]:pressed, #CueSavedJumpButton[direction="forward"]:checked {
+  icon: url(skins:LateNight/palemoon/buttons/btn__beatjump_right_active.svg);
+}
+#CueSavedJumpButton[direction="backward"]:pressed, #CueSavedJumpButton[direction="backward"]:checked {
+  icon: url(skins:LateNight/palemoon/buttons/btn__beatjump_left_active.svg);
+}
+#CueStandardButton:pressed, #CueStandardButton:checked {
+  background-color: #b24c12;
+  outline: none;
+  icon: url(skins:LateNight/palemoon/buttons/btn__beats_hotcues_later_active.svg);
 }
 
 WCueMenuPopup #CueLabelEdit {

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -1490,7 +1490,9 @@ WEffectSelector:!editable,
 #CueDeleteButton,
 #CueStandardButton,
 #CueSavedLoopButton,
-#CueSavedJumpButton {
+#CueSavedJumpButton,
+#CueSavedJumpButtonForward,
+#CueSavedJumpButtonBackward {
   outline: none;
   border-width: 2px;
   border-image: url(skins:LateNight/palemoon/buttons/btn_embedded_library.svg) 2 2 2 2;
@@ -1525,7 +1527,11 @@ WEffectSelector:!editable,
   #CueSavedLoopButton[pressed="true"],
   #CueSavedLoopButton:checked,
   #CueSavedJumpButton[pressed="true"],
-  #CueSavedJumpButton:checked {
+  #CueSavedJumpButton:checked,
+  #CueSavedJumpButtonForward[pressed="true"],
+  #CueSavedJumpButtonForward:checked,
+  #CueSavedJumpButtonBackward[pressed="true"],
+  #CueSavedJumpButtonBackward:checked {
     border-width: 2px;
     border-image: url(skins:LateNight/palemoon/buttons/btn_embedded_library_active.svg) 2 2 2 2;
   }
@@ -1662,6 +1668,8 @@ WBeatSpinBox::down-button {
   #CueStandardButton,
   #CueSavedLoopButton,
   #CueSavedJumpButton,
+  #CueSavedJumpButtonForward,
+  #CueSavedJumpButtonBackward,
   #SplitCue[displayValue="0"],
   #PlayPreview[displayValue="0"],
   /* library controls */
@@ -2755,37 +2763,19 @@ QPushButton#pushButtonRepeatPlaylist:!checked {
 /* AutoDJ button icons */
 
 /* widgets in cue popup menu */
-WCueMenuPopup #CueDeleteButton {
+#CueDeleteButton {
   icon: url(skins:LateNight/palemoon/buttons/btn__delete.svg);
   width: 24px;
   height: 24px;
   icon-size: 18px;
 }
-WCueMenuPopup #CueStandardButton {
-  icon: url(skins:LateNight/palemoon/buttons/btn__beats_hotcues_later.svg);
+#CueStandardButton,
+#CueSavedLoopButton,
+#CueSavedJumpButtonForward, #CueSavedJumpButtonBackward {
   width: 24px;
-  height: 42px;
+  height: 32px;
   /* make the icon slightly larger than default 16px */
   icon-size: 24px;
-}
-WCueMenuPopup #CueSavedLoopButton {
-  icon: url(skins:LateNight/palemoon/buttons/btn__loop.svg);
-  width: 24px;
-  height: 42px;
-  /* make the icon slightly larger than default 16px */
-  icon-size: 24px;
-}
-WCueMenuPopup #CueSavedJumpButton {
-  width: 24px;
-  height: 42px;
-  /* make the icon slightly larger than default 16px */
-  icon-size: 24px;
-}
-WCueMenuPopup #CueSavedJumpButton[direction="forward"] {
-  icon: url(skins:LateNight/palemoon/buttons/btn__beatjump_right.svg);
-}
-WCueMenuPopup #CueSavedJumpButton[direction="backward"] {
-  icon: url(skins:LateNight/palemoon/buttons/btn__beatjump_left.svg);
 }
 
 #CueDeleteButton:hover {
@@ -2797,26 +2787,41 @@ WCueMenuPopup #CueSavedJumpButton[direction="backward"] {
   outline: none;
 }
 
-#CueSavedLoopButton:pressed, #CueSavedLoopButton:checked {
+#CueStandardButton:pressed, #CueStandardButton:checked,
+#CueSavedLoopButton:pressed, #CueSavedLoopButton:checked,
+#CueSavedJumpButtonForward:pressed, #CueSavedJumpButtonForward:checked,
+#CueSavedJumpButtonBackward:pressed, #CueSavedJumpButtonBackward:checked {
   background-color: #b24c12;
   outline: none;
-  icon: url(skins:LateNight/palemoon/buttons/btn__loop_active.svg);
 }
-#CueSavedJumpButton:pressed, #CueSavedJumpButton:checked {
-  background-color: #b24c12;
-  outline: none;
-}
-#CueSavedJumpButton[direction="forward"]:pressed, #CueSavedJumpButton[direction="forward"]:checked {
-  icon: url(skins:LateNight/palemoon/buttons/btn__beatjump_right_active.svg);
-}
-#CueSavedJumpButton[direction="backward"]:pressed, #CueSavedJumpButton[direction="backward"]:checked {
-  icon: url(skins:LateNight/palemoon/buttons/btn__beatjump_left_active.svg);
-}
-#CueStandardButton:pressed, #CueStandardButton:checked {
-  background-color: #b24c12;
-  outline: none;
-  icon: url(skins:LateNight/palemoon/buttons/btn__beats_hotcues_later_active.svg);
-}
+
+#CueStandardButton {
+  icon: url(skins:LateNight/palemoon/buttons/btn__beats_hotcues_later.svg);
+  }
+  #CueStandardButton:pressed, #CueStandardButton:checked {
+    icon: url(skins:LateNight/palemoon/buttons/btn__beats_hotcues_later_active.svg);
+  }
+
+#CueSavedLoopButton {
+  icon: url(skins:LateNight/palemoon/buttons/btn__loop.svg);
+  }
+  #CueSavedLoopButton:pressed, #CueSavedLoopButton:checked {
+    icon: url(skins:LateNight/palemoon/buttons/btn__loop_active.svg);
+  }
+
+#CueSavedJumpButtonForward {
+  icon: url(skins:LateNight/palemoon/buttons/btn__beatjump_right.svg);
+  }
+  #CueSavedJumpButtonForward:pressed, #CueSavedJumpButtonForward:checked {
+    icon: url(skins:LateNight/palemoon/buttons/btn__beatjump_right_active.svg);
+  }
+#CueSavedJumpButtonBackward {
+  icon: url(skins:LateNight/palemoon/buttons/btn__beatjump_left.svg);
+  }
+  #CueSavedJumpButtonBackward:pressed, #CueSavedJumpButtonBackward:checked {
+    icon: url(skins:LateNight/palemoon/buttons/btn__beatjump_left_active.svg);
+  }
+
 
 WCueMenuPopup #CueLabelEdit {
   /*border: 1px solid #c2b3a5;*/

--- a/res/skins/LateNight/waveform.xml
+++ b/res/skins/LateNight/waveform.xml
@@ -158,6 +158,8 @@
               <Align>bottom|right</Align>
               <Color>#FF0000</Color>
               <TextColor>#FFFFFF</TextColor>
+              <EndIcon>skins:LateNight/palemoon/buttons/btn__jump_%1.svg</EndIcon>
+              <DisabledOpacity>0.25</DisabledOpacity>
               <Text> %1 </Text>
             </DefaultMark>
             <!-- Cue -->

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -440,6 +440,20 @@ WCueMenuPopup QLabel {
   qproperty-iconSize: 20px;
   outline: none;
 }
+#CueStandardButton {
+  /* set any border to allow styles for other properties as well */
+  border: 1px solid #060613;
+/* To get the final size for the Delete button consider border width.
+  tall button, about the same height as cue number + label edit box */
+  width: 24px;
+  height: 43px;
+  padding: 0px;
+  background-color: #aab2b7;
+  qproperty-icon: url(skin:/btn/btn_vinylcontrol.png);
+  /* make the icon slightly larger than default 16px */
+  qproperty-iconSize: 20px;
+  outline: none;
+}
 #CueSavedLoopButton {
   /* set any border to allow styles for other properties as well */
   border: 1px solid #060613;
@@ -449,12 +463,28 @@ WCueMenuPopup QLabel {
   height: 43px;
   padding: 0px;
   background-color: #aab2b7;
-  qproperty-icon: url(skin:/btn/btn_hotcue_loop.png);
+  qproperty-icon: url(skin:/btn/btn_repeat.png);
   /* make the icon slightly larger than default 16px */
   qproperty-iconSize: 20px;
   outline: none;
 }
-#CueSavedLoopButton:pressed, #CueSavedLoopButton:checked {
+#CueSavedJumpButton {
+  /* set any border to allow styles for other properties as well */
+  border: 1px solid #060613;
+/* To get the final size for the Delete button consider border width.
+  tall button, about the same height as cue number + label edit box */
+  width: 24px;
+  height: 43px;
+  padding: 0px;
+  background-color: #aab2b7;
+  qproperty-icon: url(skin:/btn/btn_slip.png);
+  /* make the icon slightly larger than default 16px */
+  qproperty-iconSize: 20px;
+  outline: none;
+}
+#CueStandardButton:pressed, #CueStandardButton:checked,
+  #CueSavedLoopButton:pressed, #CueSavedLoopButton:checked,
+  #CueSavedJumpButton:pressed, #CueSavedJumpButton:checked {
   background-color: #F90562;
 }
 #CueLabelEdit {

--- a/res/skins/Shade/style.qss
+++ b/res/skins/Shade/style.qss
@@ -468,23 +468,8 @@ WCueMenuPopup QLabel {
   qproperty-iconSize: 20px;
   outline: none;
 }
-#CueSavedJumpButton {
-  /* set any border to allow styles for other properties as well */
-  border: 1px solid #060613;
-/* To get the final size for the Delete button consider border width.
-  tall button, about the same height as cue number + label edit box */
-  width: 24px;
-  height: 43px;
-  padding: 0px;
-  background-color: #aab2b7;
-  qproperty-icon: url(skin:/btn/btn_slip.png);
-  /* make the icon slightly larger than default 16px */
-  qproperty-iconSize: 20px;
-  outline: none;
-}
 #CueStandardButton:pressed, #CueStandardButton:checked,
-  #CueSavedLoopButton:pressed, #CueSavedLoopButton:checked,
-  #CueSavedJumpButton:pressed, #CueSavedJumpButton:checked {
+  #CueSavedLoopButton:pressed, #CueSavedLoopButton:checked {
   background-color: #F90562;
 }
 #CueLabelEdit {

--- a/res/skins/Shade/style_dark.qss
+++ b/res/skins/Shade/style_dark.qss
@@ -153,7 +153,9 @@ WEffectSelector::indicator:unchecked:selected,
 #CueDeleteButton {
   background-color: #8a8a8a;
 }
-#CueSavedLoopButton:pressed, #CueSavedLoopButton:checked {
+#CueStandardButton:pressed, #CueStandardButton:checked,
+  #CueSavedLoopButton:pressed, #CueSavedLoopButton:checked,
+  #CueSavedJumpButton:pressed, #CueSavedJumpButton:checked {
   background-color: #b79d00;
 }
 #CueLabelEdit {

--- a/res/skins/Shade/style_dark.qss
+++ b/res/skins/Shade/style_dark.qss
@@ -154,8 +154,7 @@ WEffectSelector::indicator:unchecked:selected,
   background-color: #8a8a8a;
 }
 #CueStandardButton:pressed, #CueStandardButton:checked,
-  #CueSavedLoopButton:pressed, #CueSavedLoopButton:checked,
-  #CueSavedJumpButton:pressed, #CueSavedJumpButton:checked {
+  #CueSavedLoopButton:pressed, #CueSavedLoopButton:checked {
   background-color: #b79d00;
 }
 #CueLabelEdit {

--- a/res/skins/Shade/style_summer_sunset.qss
+++ b/res/skins/Shade/style_summer_sunset.qss
@@ -144,13 +144,14 @@ WEffectSelector::indicator:unchecked:selected,
 	border: 0px solid #f8ba54;
 }
 
-#CueDeleteButton {
+#CueStandardButton,
+  #CueSavedLoopButton,
+  #CueSavedJumpButton {
   background-color: #cdbb5d;
 }
-#CueSavedLoopButton {
-  background-color: #cdbb5d;
-}
-#CueSavedLoopButton:pressed, #CueSavedLoopButton:checked {
+#CueStandardButton:pressed, #CueStandardButton:checked,
+  #CueSavedLoopButton:pressed, #CueSavedLoopButton:checked,
+  #CueSavedJumpButton:pressed, #CueSavedJumpButton:checked {
   background-color: #54fd05;
 }
 #CueLabelEdit {

--- a/res/skins/Shade/style_summer_sunset.qss
+++ b/res/skins/Shade/style_summer_sunset.qss
@@ -145,13 +145,11 @@ WEffectSelector::indicator:unchecked:selected,
 }
 
 #CueStandardButton,
-  #CueSavedLoopButton,
-  #CueSavedJumpButton {
+#CueSavedLoopButton {
   background-color: #cdbb5d;
 }
 #CueStandardButton:pressed, #CueStandardButton:checked,
-  #CueSavedLoopButton:pressed, #CueSavedLoopButton:checked,
-  #CueSavedJumpButton:pressed, #CueSavedJumpButton:checked {
+#CueSavedLoopButton:pressed, #CueSavedLoopButton:checked {
   background-color: #54fd05;
 }
 #CueLabelEdit {

--- a/res/skins/Tango/style.qss
+++ b/res/skins/Tango/style.qss
@@ -2479,7 +2479,35 @@ WSearchRelatedTracksMenu #SearchSelectedAction::indicator {
   }
 
 /* widgets in cue popup menu */
-#CueDeleteButton,
+#CueDeleteButton {
+  /* color buttons are 42x24 px.
+  To get the final size for the Delete button consider border width.
+  tall button, about the same height as cue number + label edit box */
+  width: 26px;
+  height: 26px;
+  border: 1px solid #666;
+  background-color: #333;
+  border-radius: 2px;
+  qproperty-icon: url(skin:/../Tango/buttons/btn_delete.svg);
+  /* make the icon slightly larger than default 16px */
+  qproperty-iconSize: 16px;
+}
+#CueStandardButton {
+  /* color buttons are 42x24 px.
+  To get the final size for the Delete button consider border width.
+  tall button, about the same height as cue number + label edit box */
+  width: 26px;
+  height: 44px;
+  border: 1px solid #666;
+  background-color: #333;
+  border-radius: 2px;
+  qproperty-icon: url(skin:/../Tango/buttons/btn_hotcues_later.svg);
+  /* make the icon slightly larger than default 16px */
+  qproperty-iconSize: 20px;
+}
+#CueStandardButton:checked {
+  background-color: #ff7b00;
+}
 #CueSavedLoopButton {
   /* color buttons are 42x24 px.
   To get the final size for the Delete button consider border width.
@@ -2489,7 +2517,31 @@ WSearchRelatedTracksMenu #SearchSelectedAction::indicator {
   border: 1px solid #666;
   background-color: #333;
   border-radius: 2px;
-  }
+  qproperty-icon: url(skin:/../Tango/buttons/btn_loop_beatjump_off.svg);
+  /* make the icon slightly larger than default 16px */
+  qproperty-iconSize: 20px;
+}
+#CueSavedLoopButton:checked {
+  background-color: #ff7b00;
+  qproperty-icon: url(skin:/../Tango/buttons/btn_loop_beatjump_on.svg);
+}
+#CueSavedJumpButton {
+  /* color buttons are 42x24 px.
+  To get the final size for the Delete button consider border width.
+  tall button, about the same height as cue number + label edit box */
+  width: 26px;
+  height: 44px;
+  border: 1px solid #666;
+  background-color: #333;
+  border-radius: 2px;
+  qproperty-icon: url(skin:/../Tango/buttons/btn_beatjump_forward.svg);
+  /* make the icon slightly larger than default 16px */
+  qproperty-iconSize: 20px;
+}
+#CueSavedJumpButton:checked {
+  qproperty-icon: url(skin:/../Tango/buttons/btn_beatjump_forward_pressed.svg);
+  background-color: #ff7b00;
+}
   #CueDeleteButton {
     /* Note: we can't use qproperty-icon here because it's evauated only once
        and therefore won't style the checked state */

--- a/res/skins/default.qss
+++ b/res/skins/default.qss
@@ -34,7 +34,7 @@ QPushButton#LibraryBPMButton:!checked {
 
 /* Add default icons for cue menu buttons */
 WCueMenuPopup #CueDeleteButton {
-  image: url(:/images/ic_delete.svg);
+  icon: url(:/images/ic_delete.svg);
 }
 
 WColorPicker QPushButton[noColor="true"] {

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -169,6 +169,7 @@ class HotcueControl : public QObject {
     std::unique_ptr<ControlObject> m_hotcueEndPosition;
     std::unique_ptr<ControlObject> m_pHotcueStatus;
     std::unique_ptr<ControlObject> m_hotcueType;
+    std::unique_ptr<ControlObject> m_hotcueDirection;
     std::unique_ptr<ControlObject> m_hotcueColor;
     // Hotcue button controls
     std::unique_ptr<ControlPushButton> m_hotcueSet;
@@ -196,6 +197,15 @@ class CueControl : public EngineControl {
     CueControl(const QString& group,
             UserSettingsPointer pConfig);
     ~CueControl() override;
+
+    void notifySeek(mixxx::audio::FramePos position) override;
+
+    /// nextTrigger returns the sample at which the engine will be triggered to
+    /// take a jump. This is only used for active saved jumps.
+    virtual mixxx::audio::FramePos nextTrigger(bool reverse,
+            mixxx::audio::FramePos currentPosition,
+            mixxx::audio::FramePos* pTargetPosition,
+            mixxx::audio::FrameDiff_t lookAheadFrames);
 
     void hintReader(gsl::not_null<HintVector*> pHintList) override;
     bool updateIndicatorsAndModifyPlay(bool newPlay, bool oldPlay, bool playPossible);
@@ -296,6 +306,10 @@ class CueControl : public EngineControl {
     int getHotcueFocusIndex() const;
     mixxx::RgbColor colorFromConfig(const ConfigKey& configKey);
 
+    void jumpTo(mixxx::audio::FramePos currentPosition,
+            mixxx::audio::FramePos source,
+            mixxx::audio::FramePos target);
+
     UserSettingsPointer m_pConfig;
     ColorPaletteSettings m_colorPaletteSettings;
     QAtomicInt m_currentlyPreviewingIndex;
@@ -370,6 +384,7 @@ class CueControl : public EngineControl {
     std::unique_ptr<ControlPushButton> m_pSortHotcuesByPosCompress;
 
     QAtomicPointer<HotcueControl> m_pCurrentSavedLoopControl;
+    QAtomicPointer<HotcueControl> m_pCurrentSavedJumpControl;
 
     // Tells us which controls map to which hotcue
     QMap<QObject*, int> m_controlMap;

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -251,7 +251,8 @@ EngineBuffer::EngineBuffer(const QString& group,
             Qt::DirectConnection);
 
     m_pReadAheadManager = new ReadAheadManager(m_pReader,
-                                               m_pLoopingControl);
+            m_pLoopingControl,
+            m_pCueControl);
     m_pReadAheadManager->addRateControl(m_pRateControl);
 
     m_pKeylockEngine = new ControlProxy(kAppGroup, QStringLiteral("keylock_engine"), this);

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -114,6 +114,9 @@ class EngineBuffer : public EngineObject {
     mixxx::audio::ChannelCount getChannelCount() const {
         return m_channelCount;
     }
+    mixxx::audio::FramePos getPlayPos() const {
+        return m_playPos;
+    }
     bool getScratching() const;
     bool isReverse() const;
     /// Returns current bpm value (not thread-safe)

--- a/src/engine/readaheadmanager.cpp
+++ b/src/engine/readaheadmanager.cpp
@@ -1,6 +1,8 @@
 #include "engine/readaheadmanager.h"
 
+#include "audio/frame.h"
 #include "engine/cachingreader/cachingreader.h"
+#include "engine/controls/cuecontrol.h"
 #include "engine/controls/loopingcontrol.h"
 #include "engine/controls/ratecontrol.h"
 #include "util/defs.h"
@@ -8,6 +10,7 @@
 
 ReadAheadManager::ReadAheadManager()
         : m_pLoopingControl(nullptr),
+          m_pCueControl(nullptr),
           m_pRateControl(nullptr),
           m_currentPosition(0),
           m_pReader(nullptr),
@@ -17,14 +20,17 @@ ReadAheadManager::ReadAheadManager()
 }
 
 ReadAheadManager::ReadAheadManager(CachingReader* pReader,
-        LoopingControl* pLoopingControl)
+        LoopingControl* pLoopingControl,
+        CueControl* pCueControl)
         : m_pLoopingControl(pLoopingControl),
+          m_pCueControl(pCueControl),
           m_pRateControl(nullptr),
           m_currentPosition(0),
           m_pReader(pReader),
           m_pCrossFadeBuffer(SampleUtil::alloc(MAX_BUFFER_LEN)),
           m_cacheMissHappened(false) {
     DEBUG_ASSERT(m_pLoopingControl != nullptr);
+    DEBUG_ASSERT(m_pCueControl != nullptr);
     DEBUG_ASSERT(m_pReader != nullptr);
 }
 
@@ -54,27 +60,73 @@ SINT ReadAheadManager::getNextSamples(double dRate,
                             m_currentPosition, channelCount),
                     &targetPosition);
     const double loop_trigger = loopTriggerPosition.toSamplePosMaybeInvalid(channelCount);
-    const double target = targetPosition.toSamplePosMaybeInvalid(channelCount);
+    double target = targetPosition.toSamplePosMaybeInvalid(channelCount);
 
-    SINT preloop_samples = 0;
-    double samplesToLoopTrigger = 0.0;
+    SINT preseek_samples = 0;
+    double samplesToSeekTrigger = 0.0;
 
     bool reachedTrigger = false;
 
+    // By default, we are reading as many sampler as requested
     SINT samples_from_reader = requested_samples;
     if (loop_trigger != kNoTrigger) {
-        samplesToLoopTrigger = in_reverse ?
-                m_currentPosition - loop_trigger :
-                loop_trigger - m_currentPosition;
-        if (samplesToLoopTrigger >= 0.0) {
+        samplesToSeekTrigger = in_reverse ? m_currentPosition - loop_trigger
+                                          : loop_trigger - m_currentPosition;
+        if (samplesToSeekTrigger >= 0.0) {
             // We can only read whole frames from the reader.
             // Use ceil here, to be sure to reach the loop trigger.
-            preloop_samples = SampleUtil::ceilPlayPosToFrameStart(
-                    samplesToLoopTrigger, channelCount);
+            preseek_samples = SampleUtil::ceilPlayPosToFrameStart(
+                    samplesToSeekTrigger, channelCount);
             // clamp requested samples from the caller to the loop trigger point
-            if (preloop_samples <= requested_samples) {
+            if (preseek_samples <= requested_samples) {
                 reachedTrigger = true;
-                samples_from_reader = preloop_samples;
+                samples_from_reader = preseek_samples;
+            }
+        }
+    }
+
+    mixxx::audio::FramePos jumpTargetPosition;
+    // A saved jump cue will only limit the amount we can read in one shot.
+    const mixxx::audio::FramePos jumpTriggerPosition =
+            m_pCueControl->nextTrigger(in_reverse,
+                    mixxx::audio::FramePos::fromSamplePosMaybeInvalid(
+                            m_currentPosition, channelCount),
+                    &jumpTargetPosition,
+                    static_cast<mixxx::audio::FrameDiff_t>(requested_samples / channelCount));
+    double jump_trigger = jumpTriggerPosition.toSamplePosMaybeInvalid(channelCount);
+
+    // If there is both a loop and saved jump that are armed, and they both
+    // cancel each other (Loop from A -> B, jump from A -> B), we no-op the jump
+    // to prevent an infinite silent play loop
+    if (jump_trigger != kNoTrigger && loop_trigger != kNoTrigger &&
+            jumpTriggerPosition == targetPosition &&
+            loopTriggerPosition == jumpTargetPosition) {
+        jump_trigger = kNoTrigger;
+    }
+
+    SINT prejump_samples = 0;
+    double samplesToJumpTrigger = 0.0;
+
+    if (jump_trigger != kNoTrigger) {
+        samplesToJumpTrigger = in_reverse ? m_currentPosition - jump_trigger
+                                          : jump_trigger - m_currentPosition;
+        if (samplesToJumpTrigger >= 0.0) {
+            // We can only read whole frames from the reader.
+            // Use ceil here, to be sure to reach the jump trigger.
+            prejump_samples = SampleUtil::ceilPlayPosToFrameStart(
+                    samplesToJumpTrigger, channelCount);
+            // clamp requested samples from the caller to the jump trigger point
+            if (prejump_samples <= requested_samples) {
+                reachedTrigger = true;
+                // A loop end may be before the jump. If the jump is first, this
+                // should be our new target
+                if (loop_trigger == kNoTrigger || prejump_samples < preseek_samples) {
+                    samples_from_reader = prejump_samples;
+                    preseek_samples = prejump_samples;
+                    samplesToSeekTrigger = samplesToJumpTrigger;
+                    target = jumpTargetPosition.toSamplePosMaybeInvalid(channelCount);
+                    targetPosition = jumpTargetPosition;
+                }
             }
         }
     }
@@ -123,15 +175,18 @@ SINT ReadAheadManager::getNextSamples(double dRate,
     if (reachedTrigger) {
         DEBUG_ASSERT(target != kNoTrigger);
         if (m_pRateControl) {
-            m_pRateControl->notifyWrapAround(loopTriggerPosition, targetPosition);
+            m_pRateControl->notifyWrapAround(loopTriggerPosition.isValid()
+                            ? loopTriggerPosition
+                            : jumpTriggerPosition,
+                    targetPosition);
         }
         // TODO probably also useful for hotcue_X_indicator in CueControl::updateIndicators()
 
         // Jump to other end of loop or track.
         m_currentPosition = target;
-        if (preloop_samples > 0) {
+        if (preseek_samples > 0) {
             // we are up to one frame ahead of the loop trigger
-            double overshoot = preloop_samples - samplesToLoopTrigger;
+            double overshoot = preseek_samples - samplesToSeekTrigger;
             // start the loop later accordingly to be sure the loop length is as desired
             // e.g. exactly one bar.
             m_currentPosition += overshoot;
@@ -147,32 +202,32 @@ SINT ReadAheadManager::getNextSamples(double dRate,
             // Average preloop_samples = 2.2
         }
 
-        // start reading before the loop start point, to crossfade these samples
+        // start reading before the loop start point or the saved jump, to crossfade these samples
         // with the samples we need to the loop end
-        int loop_read_position = SampleUtil::roundPlayPosToFrameStart(
+        int seek_read_position = SampleUtil::roundPlayPosToFrameStart(
                 m_currentPosition +
-                        (in_reverse ? preloop_samples : -preloop_samples),
+                        (in_reverse ? preseek_samples : -preseek_samples),
                 channelCount);
 
         int crossFadeStart = 0;
         int crossFadeSamples = samples_from_reader;
-        if (loop_read_position < 0) {
+        if (seek_read_position < 0) {
             // we start in the pre-role without suitable samples for crossfading
-            crossFadeStart = -loop_read_position;
+            crossFadeStart = -seek_read_position;
             crossFadeSamples -= crossFadeStart;
         } else {
             int trackSamples = static_cast<int>(
                     m_pLoopingControl->getTrackFrame().toSamplePos(
                             channelCount));
-            if (loop_read_position > trackSamples) {
+            if (seek_read_position > trackSamples) {
                 // looping in reverse overlapping post-roll without samples
-                crossFadeStart = loop_read_position - trackSamples;
+                crossFadeStart = seek_read_position - trackSamples;
                 crossFadeSamples -= crossFadeStart;
             }
         }
 
         if (crossFadeSamples > 0) {
-            const auto readResult = m_pReader->read(loop_read_position +
+            const auto readResult = m_pReader->read(seek_read_position +
                             (in_reverse ? crossFadeStart : -crossFadeStart),
                     crossFadeSamples,
                     in_reverse,

--- a/src/engine/readaheadmanager.h
+++ b/src/engine/readaheadmanager.h
@@ -9,6 +9,7 @@
 #include "util/types.h"
 
 class LoopingControl;
+class CueControl;
 class RateControl;
 
 /// ReadAheadManager is a tool for keeping track of the engine's current position
@@ -23,7 +24,9 @@ class RateControl;
 class ReadAheadManager {
   public:
     ReadAheadManager(); // Only for testing: ReadAheadManagerMock
-    ReadAheadManager(CachingReader* pReader, LoopingControl* pLoopingControl);
+    ReadAheadManager(CachingReader* reader,
+            LoopingControl* pLoopingControl,
+            CueControl* pCueControl);
     virtual ~ReadAheadManager();
 
     /// Call this method to fill buffer with requested_samples out of the
@@ -122,6 +125,7 @@ class ReadAheadManager {
                          double virtualPlaypositionEndNonInclusive);
 
     LoopingControl* m_pLoopingControl;
+    CueControl* m_pCueControl;
     RateControl* m_pRateControl;
     std::list<ReadLogEntry> m_readAheadLog;
     double m_currentPosition; // In absolute samples

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -1334,28 +1334,38 @@ void MixxxMainWindow::tryParseAndSetDefaultStyleSheet() {
 
 /// Catch ToolTip and WindowStateChange events
 bool MixxxMainWindow::eventFilter(QObject* obj, QEvent* event) {
-    // Always show tooltips if Ctrl is held down
-    if (event->type() == QEvent::ToolTip &&
-            !QApplication::keyboardModifiers().testFlag(Qt::ControlModifier)) {
+    if (event->type() == QEvent::ToolTip) {
+        // Always show tooltips if Ctrl is held down
+        if (QApplication::keyboardModifiers().testFlag(Qt::ControlModifier)) {
+            return QMainWindow::eventFilter(obj, event);
+        }
+        // Always show tooltips for cue type buttons in the Cue menu
+        if (QLatin1String(obj->metaObject()->className()) == "CueMenuPushButton") {
+            return QMainWindow::eventFilter(obj, event);
+        }
+        // Always show tooltips in Preferences
         QWidget* activeWindow = QApplication::activeWindow();
         if (activeWindow &&
-                QLatin1String(activeWindow->metaObject()->className()) !=
+                QLatin1String(activeWindow->metaObject()->className()) ==
                         "DlgPreferences") {
-            // return true for no tool tips
-            switch (m_toolTipsCfg) {
-            case mixxx::preferences::Tooltips::OnlyInLibrary:
-                if (dynamic_cast<WBaseWidget*>(obj) != nullptr) {
-                    return true;
-                }
-                break;
-            case mixxx::preferences::Tooltips::On:
-                break;
-            case mixxx::preferences::Tooltips::Off:
-                return true;
-            default:
-                DEBUG_ASSERT(!"m_toolTipsCfg value unknown");
+            return QMainWindow::eventFilter(obj, event);
+        }
+
+        // For all other we follow the tooltip sett8ing.
+        // Return true for no tool tips
+        switch (m_toolTipsCfg) {
+        case mixxx::preferences::Tooltips::OnlyInLibrary:
+            if (dynamic_cast<WBaseWidget*>(obj) != nullptr) {
                 return true;
             }
+            break;
+        case mixxx::preferences::Tooltips::On:
+            break;
+        case mixxx::preferences::Tooltips::Off:
+            return true;
+        default:
+            DEBUG_ASSERT(!"m_toolTipsCfg value unknown");
+            return true;
         }
     } else if (event->type() == QEvent::WindowStateChange) {
 #ifndef __APPLE__

--- a/src/preferences/dialog/dlgprefcolors.cpp
+++ b/src/preferences/dialog/dlgprefcolors.cpp
@@ -17,12 +17,15 @@ namespace {
 
 constexpr int kHotcueDefaultColorIndex = -1;
 constexpr int kLoopDefaultColorIndex = -1;
+constexpr int kJumpDefaultColorIndex = -1;
 constexpr QSize kPalettePreviewSize = QSize(108, 16);
 const ConfigKey kAutoHotcueColorsConfigKey("[Controls]", "auto_hotcue_colors");
 const ConfigKey kAutoLoopColorsConfigKey("[Controls]", "auto_loop_colors");
+const ConfigKey kAutoJumpColorsConfigKey("[Controls]", "auto_jump_colors");
 const ConfigKey kHotcueDefaultColorIndexConfigKey("[Controls]", "HotcueDefaultColorIndex");
 const ConfigKey kLoopDefaultColorIndexConfigKey("[Controls]", "LoopDefaultColorIndex");
 const ConfigKey kKeyColorsEnabledConfigKey("[Config]", "key_colors_enabled");
+const ConfigKey kJumpDefaultColorIndexConfigKey("[Controls]", "jump_default_color_index");
 
 } // anonymous namespace
 
@@ -184,6 +187,24 @@ void DlgPrefColors::slotUpdate() {
         comboBoxLoopDefaultColor->setCurrentIndex(
                 loopDefaultColorIndex + 1);
     }
+
+    bool autoJumpColors = m_pConfig->getValue(kAutoJumpColorsConfigKey, false);
+    if (autoJumpColors) {
+        comboBoxJumpDefaultColor->setCurrentIndex(0);
+    } else {
+        int jumpDefaultColorIndex = m_pConfig->getValue(
+                kJumpDefaultColorIndexConfigKey, kJumpDefaultColorIndex);
+        if (jumpDefaultColorIndex < 0 ||
+                jumpDefaultColorIndex >= hotcuePalette.size()) {
+            jumpDefaultColorIndex =
+                    hotcuePalette.size() - 3; // default to third last color
+            if (jumpDefaultColorIndex < 0) {
+                jumpDefaultColorIndex = 0;
+            }
+        }
+        comboBoxJumpDefaultColor->setCurrentIndex(
+                jumpDefaultColorIndex + 1);
+    }
 }
 
 // Set the default values for all the widgets
@@ -206,6 +227,8 @@ void DlgPrefColors::slotResetToDefaults() {
     comboBoxLoopDefaultColor->setCurrentIndex(
             mixxx::PredefinedColorPalettes::kDefaultTrackColorPalette.size() - 1);
     checkboxKeyColorsEnabled->setChecked(BaseTrackTableModel::kKeyColorsEnabledDefault);
+    comboBoxJumpDefaultColor->setCurrentIndex(
+            mixxx::PredefinedColorPalettes::kDefaultTrackColorPalette.size() - 2);
 }
 
 // Apply and save any changes made in the dialog
@@ -275,6 +298,15 @@ void DlgPrefColors::slotApply() {
     }
 
     m_pConfig->setValue(kKeyColorsEnabledConfigKey, checkboxKeyColorsEnabled->checkState());
+    int jumpColorIndex = comboBoxJumpDefaultColor->currentIndex();
+
+    if (jumpColorIndex > 0) {
+        m_pConfig->setValue(kAutoJumpColorsConfigKey, false);
+        m_pConfig->setValue(kJumpDefaultColorIndexConfigKey, jumpColorIndex - 1);
+    } else {
+        m_pConfig->setValue(kAutoJumpColorsConfigKey, true);
+        m_pConfig->setValue(kJumpDefaultColorIndexConfigKey, -1);
+    }
 }
 
 void DlgPrefColors::slotReplaceCueColorClicked() {
@@ -357,6 +389,9 @@ void DlgPrefColors::slotHotcuePaletteIndexChanged(int paletteIndex) {
     int defaultLoopColor = comboBoxLoopDefaultColor->currentIndex();
     comboBoxLoopDefaultColor->clear();
 
+    int defaultJumpColor = comboBoxJumpDefaultColor->currentIndex();
+    comboBoxJumpDefaultColor->clear();
+
     QIcon paletteIcon = drawHotcueColorByPaletteIcon(paletteName);
 
     comboBoxHotcueDefaultColor->addItem(tr("By hotcue number"), -1);
@@ -364,6 +399,9 @@ void DlgPrefColors::slotHotcuePaletteIndexChanged(int paletteIndex) {
 
     comboBoxLoopDefaultColor->addItem(tr("By hotcue number"), -1);
     comboBoxLoopDefaultColor->setItemIcon(0, paletteIcon);
+
+    comboBoxJumpDefaultColor->addItem(tr("By hotcue number"), -1);
+    comboBoxJumpDefaultColor->setItemIcon(0, paletteIcon);
 
     QPixmap pixmap(16, 16);
     for (int i = 0; i < palette.size(); ++i) {
@@ -378,6 +416,9 @@ void DlgPrefColors::slotHotcuePaletteIndexChanged(int paletteIndex) {
 
         comboBoxLoopDefaultColor->addItem(item, i);
         comboBoxLoopDefaultColor->setItemIcon(i + 1, icon);
+
+        comboBoxJumpDefaultColor->addItem(item, i);
+        comboBoxJumpDefaultColor->setItemIcon(i + 1, icon);
     }
 
     if (comboBoxHotcueDefaultColor->count() > defaultHotcueColor) {
@@ -392,6 +433,13 @@ void DlgPrefColors::slotHotcuePaletteIndexChanged(int paletteIndex) {
     } else {
         comboBoxLoopDefaultColor->setCurrentIndex(
                 comboBoxLoopDefaultColor->count() - 1);
+    }
+
+    if (comboBoxJumpDefaultColor->count() > defaultJumpColor) {
+        comboBoxJumpDefaultColor->setCurrentIndex(defaultJumpColor);
+    } else {
+        comboBoxJumpDefaultColor->setCurrentIndex(
+                comboBoxJumpDefaultColor->count() - 1);
     }
 }
 
@@ -453,18 +501,28 @@ void DlgPrefColors::trackPaletteUpdated(const QString& trackColors) {
     QString hotcueColors = comboBoxHotcueColors->currentData().toString();
     int defaultHotcueColor = comboBoxHotcueDefaultColor->currentIndex();
     int defaultLoopColor = comboBoxLoopDefaultColor->currentIndex();
+    int defaultJumpColor = comboBoxJumpDefaultColor->currentIndex();
 
     slotUpdate();
-    restoreComboBoxes(hotcueColors, trackColors, defaultHotcueColor, defaultLoopColor);
+    restoreComboBoxes(hotcueColors,
+            trackColors,
+            defaultHotcueColor,
+            defaultLoopColor,
+            defaultJumpColor);
 }
 
 void DlgPrefColors::hotcuePaletteUpdated(const QString& hotcueColors) {
     QString trackColors = comboBoxTrackColors->currentData().toString();
     int defaultHotcueColor = comboBoxHotcueDefaultColor->currentIndex();
     int defaultLoopColor = comboBoxLoopDefaultColor->currentIndex();
+    int defaultJumpColor = comboBoxJumpDefaultColor->currentIndex();
 
     slotUpdate();
-    restoreComboBoxes(hotcueColors, trackColors, defaultHotcueColor, defaultLoopColor);
+    restoreComboBoxes(hotcueColors,
+            trackColors,
+            defaultHotcueColor,
+            defaultLoopColor,
+            defaultJumpColor);
 }
 
 void DlgPrefColors::palettesUpdated() {
@@ -472,16 +530,22 @@ void DlgPrefColors::palettesUpdated() {
     QString trackColors = comboBoxTrackColors->currentData().toString();
     int defaultHotcueColor = comboBoxHotcueDefaultColor->currentIndex();
     int defaultLoopColor = comboBoxLoopDefaultColor->currentIndex();
+    int defaultJumpColor = comboBoxJumpDefaultColor->currentIndex();
 
     slotUpdate();
-    restoreComboBoxes(hotcueColors, trackColors, defaultHotcueColor, defaultLoopColor);
+    restoreComboBoxes(hotcueColors,
+            trackColors,
+            defaultHotcueColor,
+            defaultLoopColor,
+            defaultJumpColor);
 }
 
 void DlgPrefColors::restoreComboBoxes(
         const QString& hotcueColors,
         const QString& trackColors,
         int defaultHotcueColor,
-        int defaultLoopColor) {
+        int defaultLoopColor,
+        int defaultJumpColor) {
     comboBoxHotcueColors->setCurrentText(QCoreApplication::translate(
             "PredefinedColorPalettes", qPrintable(hotcueColors)));
     comboBoxTrackColors->setCurrentText(QCoreApplication::translate(
@@ -497,5 +561,11 @@ void DlgPrefColors::restoreComboBoxes(
     } else {
         comboBoxLoopDefaultColor->setCurrentIndex(
                 comboBoxLoopDefaultColor->count() - 1);
+    }
+    if (comboBoxJumpDefaultColor->count() > defaultJumpColor) {
+        comboBoxJumpDefaultColor->setCurrentIndex(defaultJumpColor);
+    } else {
+        comboBoxJumpDefaultColor->setCurrentIndex(
+                comboBoxJumpDefaultColor->count() - 2);
     }
 }

--- a/src/preferences/dialog/dlgprefcolors.h
+++ b/src/preferences/dialog/dlgprefcolors.h
@@ -56,7 +56,8 @@ class DlgPrefColors : public DlgPreferencePage, public Ui::DlgPrefColorsDlg {
             const QString& hotcueColors,
             const QString& trackColors,
             int defaultHotcueColor,
-            int defaultLoopColor);
+            int defaultLoopColor,
+            int defaultJumpColor);
 
     const UserSettingsPointer m_pConfig;
     ColorPaletteSettings m_colorPaletteSettings;

--- a/src/preferences/dialog/dlgprefcolorsdlg.ui
+++ b/src/preferences/dialog/dlgprefcolorsdlg.ui
@@ -100,7 +100,18 @@
      <widget class="QComboBox" name="comboBoxLoopDefaultColor"/>
     </item>
 
-    <item row="4" column="0" colspan="2">
+    <item row="4" column="0">
+     <widget class="QLabel" name="labelJumpDefaultColor">
+      <property name="text">
+       <string>Jump default color</string>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="1">
+     <widget class="QComboBox" name="comboBoxJumpDefaultColor"/>
+    </item>
+
+    <item row="5" column="0" colspan="2">
      <widget class="QCheckBox" name="checkboxKeyColorsEnabled">
       <property name="toolTip">
        <string>When key colors are enabled, Mixxx will display a color hint
@@ -112,14 +123,14 @@ associated with each key.</string>
      </widget>
     </item>
 
-    <item row="5" column="0">
+    <item row="6" column="0">
      <widget class="QLabel" name="labelKeyColors">
       <property name="text">
        <string>Key palette</string>
       </property>
      </widget>
     </item>
-    <item row="5" column="1">
+    <item row="6" column="1">
      <widget class="QComboBox" name="comboBoxKeyColors">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -130,7 +141,7 @@ associated with each key.</string>
      </widget>
     </item>
 
-    <item row="6" column="0" colspan="2">
+    <item row="7" column="0" colspan="2">
      <spacer>
       <property name="orientation">
        <enum>Qt::Vertical</enum>
@@ -153,6 +164,7 @@ associated with each key.</string>
   <tabstop>comboBoxHotcueColors</tabstop>
   <tabstop>pushButtonEditHotcuePalette</tabstop>
   <tabstop>comboBoxHotcueDefaultColor</tabstop>
+  <tabstop>comboBoxJumpDefaultColor</tabstop>
   <tabstop>pushButtonReplaceCueColor</tabstop>
   <tabstop>checkboxKeyColorsEnabled</tabstop>
  </tabstops>

--- a/src/qml/qmlwaveformrenderer.cpp
+++ b/src/qml/qmlwaveformrenderer.cpp
@@ -1,5 +1,10 @@
 #include "qml/qmlwaveformrenderer.h"
 
+#include <qapplication.h>
+#include <qfileinfo.h>
+#include <qglobal.h>
+#include <qlist.h>
+
 #include <memory>
 
 #include "moc_qmlwaveformrenderer.cpp"
@@ -207,14 +212,43 @@ QmlWaveformRendererFactory::Renderer QmlWaveformRendererMark::create(
                 pMark->textColor(),
                 pMark->align(),
                 pMark->text(),
-                pMark->pixmap(),
-                pMark->icon(),
+                pMark->pixmap().toLocalFile(),
+                pMark->icon().toLocalFile(),
                 pMark->color(),
-                priority)));
+                priority,
+                Cue::kNoHotCue,
+                {},
+                pMark->endPixmap().toLocalFile(),
+                pMark->endIcon().toLocalFile(),
+                pMark->disabledOpacity(),
+                pMark->enabledOpacity())));
         priority--;
     }
     const auto* pMark = defaultMark();
     if (pMark != nullptr) {
+        const QString pixmap = pMark->pixmap().toLocalFile();
+        const QString endPixmap = pMark->endPixmap().toLocalFile();
+        const QString icon = pMark->icon().toLocalFile();
+        const QString endIcon = pMark->endIcon().toLocalFile();
+        // FIXME: the following checks should be done on the WaveformMarker
+        // setter (depends of #14515)
+        if (!QFileInfo::exists(pixmap)) {
+            qmlEngine(this)->throwError(tr("Cannot find the marker pixmap") + " \"" + pixmap + '"');
+        }
+
+        if (!endPixmap.isEmpty() && !QFileInfo(endPixmap).exists()) {
+            qmlEngine(this)->throwError(tr("Cannot find the marker endPixmap") +
+                    " \"" + endPixmap + '"');
+        }
+
+        if (!icon.isEmpty() && !QFileInfo(icon).exists()) {
+            qmlEngine(this)->throwError(tr("Cannot find the marker icon") + " \"" + icon + '"');
+        }
+
+        if (!endIcon.isEmpty() && !QFileInfo(endIcon).exists()) {
+            qmlEngine(this)->throwError(tr("Cannot find the marker endIcon") +
+                    " \"" + endIcon + '"');
+        }
         pRenderer->setDefaultMark(
                 waveformWidget->getGroup(),
                 WaveformMarkSet::DefaultMarkerStyle{
@@ -223,9 +257,13 @@ QmlWaveformRendererFactory::Renderer QmlWaveformRendererMark::create(
                         pMark->textColor(),
                         pMark->align(),
                         pMark->text(),
-                        pMark->pixmap(),
-                        pMark->icon(),
+                        pixmap,
+                        endPixmap,
+                        icon,
+                        endIcon,
                         pMark->color(),
+                        pMark->enabledOpacity(),
+                        pMark->disabledOpacity(),
                 });
     }
     return QmlWaveformRendererFactory::Renderer{pRenderer.get(), std::move(pRenderer)};

--- a/src/qml/qmlwaveformrenderer.h
+++ b/src/qml/qmlwaveformrenderer.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <qqmlcontext.h>
+
 #include <QObject>
 #include <QQmlEngine>
 
@@ -218,8 +220,10 @@ class QmlWaveformMark : public QObject {
     Q_PROPERTY(QString textColor MEMBER m_textColor NOTIFY textColorChanged)
     Q_PROPERTY(QString align MEMBER m_align NOTIFY alignChanged)
     Q_PROPERTY(QString text MEMBER m_text NOTIFY textChanged)
-    Q_PROPERTY(QString pixmap MEMBER m_pixmap NOTIFY pixmapChanged)
-    Q_PROPERTY(QString icon MEMBER m_icon NOTIFY iconChanged)
+    Q_PROPERTY(QUrl pixmap MEMBER m_pixmap NOTIFY pixmapChanged)
+    Q_PROPERTY(QUrl icon MEMBER m_icon NOTIFY iconChanged)
+    Q_PROPERTY(QUrl endPixmap MEMBER m_endPixmap NOTIFY endPixmapChanged)
+    Q_PROPERTY(QUrl endIcon MEMBER m_endIcon NOTIFY endIconChanged)
     QML_NAMED_ELEMENT(WaveformMark)
   public:
     QString control() const {
@@ -240,11 +244,23 @@ class QmlWaveformMark : public QObject {
     QString text() const {
         return m_text;
     }
-    QString pixmap() const {
+    QUrl pixmap() const {
         return m_pixmap;
     }
-    QString icon() const {
+    QUrl icon() const {
         return m_icon;
+    }
+    QUrl endPixmap() const {
+        return m_endPixmap;
+    }
+    QUrl endIcon() const {
+        return m_endIcon;
+    }
+    float disabledOpacity() const {
+        return m_disabledOpacity;
+    }
+    float enabledOpacity() const {
+        return m_enabledOpacity;
     }
 
   signals:
@@ -254,8 +270,12 @@ class QmlWaveformMark : public QObject {
     void textColorChanged(QString textColor);
     void alignChanged(QString align);
     void textChanged(QString text);
-    void pixmapChanged(QString pixmap);
-    void iconChanged(QString icon);
+    void pixmapChanged(QUrl pixmap);
+    void iconChanged(QUrl icon);
+    void endPixmapChanged(QUrl pixmap);
+    void endIconChanged(QUrl icon);
+    void disabledOpacityChanged(float opacity);
+    void enabledOpacityChanged(float opacity);
 
   private:
     QString m_control;
@@ -264,8 +284,12 @@ class QmlWaveformMark : public QObject {
     QString m_textColor;
     QString m_align;
     QString m_text;
-    QString m_pixmap;
-    QString m_icon;
+    QUrl m_pixmap;
+    QUrl m_icon;
+    QUrl m_endPixmap;
+    QUrl m_endIcon;
+    float m_disabledOpacity;
+    float m_enabledOpacity;
 };
 
 class QmlWaveformUntilMark : public QObject {

--- a/src/rendergraph/common/rendergraph/material/texturematerial.cpp
+++ b/src/rendergraph/common/rendergraph/material/texturematerial.cpp
@@ -18,7 +18,7 @@ TextureMaterial::TextureMaterial()
 }
 
 /* static */ const UniformSet& TextureMaterial::uniforms() {
-    static UniformSet set = makeUniformSet<QMatrix4x4>({"ubuf.matrix"});
+    static UniformSet set = makeUniformSet<QMatrix4x4, float>({"ubuf.matrix", "ubuf.alpha"});
     return set;
 }
 

--- a/src/rendergraph/shaders/texture.frag
+++ b/src/rendergraph/shaders/texture.frag
@@ -1,9 +1,18 @@
 #version 440
 
+layout(std140, binding = 0) uniform buf {
+    mat4 matrix;
+    float alpha;
+}
+ubuf;
+
 layout(binding = 1) uniform sampler2D texture1;
 layout(location = 0) in vec2 vTexcoord;
 layout(location = 0) out vec4 fragColor;
 
 void main() {
     fragColor = texture(texture1, vTexcoord);
+    if (ubuf.alpha > 0.0) {
+        fragColor *= ubuf.alpha;
+    }
 }

--- a/src/rendergraph/shaders/texture.frag.gl
+++ b/src/rendergraph/shaders/texture.frag.gl
@@ -1,6 +1,14 @@
 #version 120
 //// GENERATED - EDITS WILL BE OVERWRITTEN
 
+struct buf
+{
+    mat4 matrix;
+    float alpha;
+};
+
+uniform buf ubuf;
+
 uniform sampler2D texture1;
 
 varying vec2 vTexcoord;
@@ -8,4 +16,8 @@ varying vec2 vTexcoord;
 void main()
 {
     gl_FragData[0] = texture2D(texture1, vTexcoord);
+    if (ubuf.alpha > 0.0)
+    {
+        gl_FragData[0] *= ubuf.alpha;
+    }
 }

--- a/src/rendergraph/shaders/texture.vert
+++ b/src/rendergraph/shaders/texture.vert
@@ -2,6 +2,7 @@
 
 layout(std140, binding = 0) uniform buf {
     mat4 matrix;
+    float alpha;
 }
 ubuf;
 

--- a/src/rendergraph/shaders/texture.vert.gl
+++ b/src/rendergraph/shaders/texture.vert.gl
@@ -4,6 +4,7 @@
 struct buf
 {
     mat4 matrix;
+    float alpha;
 };
 
 uniform buf ubuf;

--- a/src/shaders/textureshader.cpp
+++ b/src/shaders/textureshader.cpp
@@ -16,11 +16,13 @@ void main()
 )--");
 
     QString fragmentShaderCode = QStringLiteral(R"--(
+#version 120
 uniform sampler2D texture;
 varying highp vec2 vTexcoord;
+uniform float alpha;
 void main()
 {
-    gl_FragColor = texture2D(texture, vTexcoord);
+    gl_FragColor = texture2D(texture, vTexcoord) * vec4(1.0, 1.0, 1.0, alpha > .0 ? alpha : 1.0);
 }
 )--");
 

--- a/src/test/readaheadmanager_test.cpp
+++ b/src/test/readaheadmanager_test.cpp
@@ -1,12 +1,14 @@
+#include "engine/readaheadmanager.h"
+
 #include <gtest/gtest.h>
 
-#include <QtDebug>
 #include <QScopedPointer>
+#include <QtDebug>
 
-#include "engine/cachingreader/cachingreader.h"
 #include "control/controlobject.h"
+#include "engine/cachingreader/cachingreader.h"
+#include "engine/controls/cuecontrol.h"
 #include "engine/controls/loopingcontrol.h"
-#include "engine/readaheadmanager.h"
 #include "test/mixxxtest.h"
 #include "util/assert.h"
 #include "util/defs.h"
@@ -41,14 +43,11 @@ class StubLoopControl : public LoopingControl {
             : LoopingControl(kGroup, UserSettingsPointer()) {
     }
 
-    void pushTriggerReturnValue(double value) {
+    void pushValues(double trigger, double target) {
         m_triggerReturnValues.push_back(
-                mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(value));
-    }
-
-    void pushTargetReturnValue(double value) {
+                mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(trigger));
         m_targetReturnValues.push_back(
-                mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(value));
+                mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(target));
     }
 
     mixxx::audio::FramePos nextTrigger(bool reverse,
@@ -68,6 +67,35 @@ class StubLoopControl : public LoopingControl {
     QList<mixxx::audio::FramePos> m_targetReturnValues;
 };
 
+class StubCueControl : public CueControl {
+  public:
+    StubCueControl()
+            : CueControl(kGroup, UserSettingsPointer()) {
+    }
+
+    void pushValues(double trigger, double target) {
+        m_triggerReturnValues.push_back(
+                mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(trigger));
+
+        m_targetReturnValues.push_back(
+                mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(target));
+    }
+
+    mixxx::audio::FramePos nextTrigger(bool,
+            mixxx::audio::FramePos,
+            mixxx::audio::FramePos* pTargetPosition,
+            mixxx::audio::FrameDiff_t) override {
+        RELEASE_ASSERT(!m_targetReturnValues.isEmpty());
+        *pTargetPosition = m_targetReturnValues.takeFirst();
+        RELEASE_ASSERT(!m_triggerReturnValues.isEmpty());
+        return m_triggerReturnValues.takeFirst();
+    }
+
+  protected:
+    QList<mixxx::audio::FramePos> m_triggerReturnValues;
+    QList<mixxx::audio::FramePos> m_targetReturnValues;
+};
+
 class ReadAheadManagerTest : public MixxxTest {
   public:
     ReadAheadManagerTest()
@@ -75,6 +103,12 @@ class ReadAheadManagerTest : public MixxxTest {
               m_beatNextCO(ConfigKey(kGroup, "beat_next")),
               m_beatPrevCO(ConfigKey(kGroup, "beat_prev")),
               m_playCO(ConfigKey(kGroup, "play")),
+              m_stopCO(ConfigKey(kGroup, "stop")),
+              m_vinylControlCO(ConfigKey(kGroup, "vinylcontrol_enabled")),
+              m_vinylControlModeCO(ConfigKey(kGroup, "vinylcontrol_mode")),
+              m_passthroughCO(ConfigKey(kGroup, "passthrough")),
+              m_indicator250msCO(ConfigKey("[App]", "indicator_250ms")),
+              m_indicator500msCO(ConfigKey("[App]", "indicator_500ms")),
               m_quantizeCO(ConfigKey(kGroup, "quantize")),
               m_repeatCO(ConfigKey(kGroup, "repeat")),
               m_slipEnabledCO(ConfigKey(kGroup, "slip_enabled")),
@@ -87,17 +121,26 @@ class ReadAheadManagerTest : public MixxxTest {
         SampleUtil::clear(m_pBuffer, MAX_BUFFER_LEN);
         m_pReader.reset(new StubReader());
         m_pLoopControl.reset(new StubLoopControl());
+        m_pCueControl.reset(new StubCueControl());
         m_pReadAheadManager.reset(new ReadAheadManager(m_pReader.data(),
-                                                       m_pLoopControl.data()));
+                m_pLoopControl.data(),
+                m_pCueControl.data()));
     }
 
     QScopedPointer<StubReader> m_pReader;
     QScopedPointer<StubLoopControl> m_pLoopControl;
+    QScopedPointer<StubCueControl> m_pCueControl;
     QScopedPointer<ReadAheadManager> m_pReadAheadManager;
     ControlObject m_beatClosestCO;
     ControlObject m_beatNextCO;
     ControlObject m_beatPrevCO;
     ControlObject m_playCO;
+    ControlObject m_stopCO;
+    ControlObject m_vinylControlCO;
+    ControlObject m_vinylControlModeCO;
+    ControlObject m_passthroughCO;
+    ControlObject m_indicator250msCO;
+    ControlObject m_indicator500msCO;
     ControlObject m_quantizeCO;
     ControlObject m_repeatCO;
     ControlObject m_slipEnabledCO;
@@ -105,24 +148,68 @@ class ReadAheadManagerTest : public MixxxTest {
     CSAMPLE* m_pBuffer;
 };
 
+TEST_F(ReadAheadManagerTest, SavedJump) {
+    m_pReadAheadManager->notifySeek(0.5);
+
+    for (int i = 0; i < 2; i++) {
+        m_pLoopControl->pushValues(kNoTrigger, kNoTrigger);
+    }
+
+    m_pCueControl->pushValues(20, 6);
+    m_pCueControl->pushValues(kNoTrigger, kNoTrigger);
+
+    EXPECT_EQ(20,
+            m_pReadAheadManager->getNextSamples(
+                    1.0, m_pBuffer, 30, mixxx::audio::ChannelCount::stereo()));
+    EXPECT_NEAR(6.5, m_pReadAheadManager->getPlaypos(), 1);
+    EXPECT_EQ(80,
+            m_pReadAheadManager->getNextSamples(
+                    1.0, m_pBuffer, 80, mixxx::audio::ChannelCount::stereo()));
+
+    EXPECT_NEAR(86.5, m_pReadAheadManager->getPlaypos(), 1);
+}
+
+TEST_F(ReadAheadManagerTest, TriggerOnJumpOrLoop) {
+    m_pReadAheadManager->notifySeek(0);
+
+    // The jump trigger is located before the loop end
+    m_pLoopControl->pushValues(50, 10);
+    m_pCueControl->pushValues(40, 20);
+
+    EXPECT_EQ(40,
+            m_pReadAheadManager->getNextSamples(
+                    1.0, m_pBuffer, 100, mixxx::audio::ChannelCount::stereo()));
+    EXPECT_NEAR(20, m_pReadAheadManager->getPlaypos(), 1);
+
+    m_pReadAheadManager->notifySeek(0);
+
+    // The jump trigger is located after the loop end
+    m_pLoopControl->pushValues(50, 40);
+    m_pCueControl->pushValues(60, 30);
+
+    EXPECT_EQ(50,
+            m_pReadAheadManager->getNextSamples(
+                    1.0, m_pBuffer, 100, mixxx::audio::ChannelCount::stereo()));
+    EXPECT_NEAR(40, m_pReadAheadManager->getPlaypos(), 1);
+}
+
 TEST_F(ReadAheadManagerTest, FractionalFrameLoop) {
     // If we are in reverse, a loop is enabled, and the current playposition
     // is before of the loop, we should seek to the out point of the loop.
     m_pReadAheadManager->notifySeek(0.5);
-    // Trigger value means, the sample that triggers the loop (loop in)
-    m_pLoopControl->pushTriggerReturnValue(20.2);
-    m_pLoopControl->pushTriggerReturnValue(20.2);
-    m_pLoopControl->pushTriggerReturnValue(20.2);
-    m_pLoopControl->pushTriggerReturnValue(20.2);
-    m_pLoopControl->pushTriggerReturnValue(20.2);
-    m_pLoopControl->pushTriggerReturnValue(20.2);
-    // Process value is the sample we should seek to.
-    m_pLoopControl->pushTargetReturnValue(3.3);
-    m_pLoopControl->pushTargetReturnValue(3.3);
-    m_pLoopControl->pushTargetReturnValue(3.3);
-    m_pLoopControl->pushTargetReturnValue(3.3);
-    m_pLoopControl->pushTargetReturnValue(3.3);
-    m_pLoopControl->pushTargetReturnValue(kNoTrigger);
+    // Trigger value means, the sample that triggers the loop (loop in) and the
+    // sample we should seek to.
+    m_pLoopControl->pushValues(20.2, 3.3);
+    m_pLoopControl->pushValues(20.2, 3.3);
+    m_pLoopControl->pushValues(20.2, 3.3);
+    m_pLoopControl->pushValues(20.2, 3.3);
+    m_pLoopControl->pushValues(20.2, 3.3);
+    m_pLoopControl->pushValues(20.2, kNoTrigger);
+
+    for (int i = 0; i < 6; i++) {
+        m_pCueControl->pushValues(kNoTrigger, kNoTrigger);
+    }
+
     // read from start to loop trigger, overshoot 0.3
     EXPECT_EQ(20,
             m_pReadAheadManager->getNextSamples(

--- a/src/waveform/renderers/allshader/waveformrendermark.cpp
+++ b/src/waveform/renderers/allshader/waveformrendermark.cpp
@@ -12,6 +12,7 @@
 #include "rendergraph/vertexupdaters/rgbavertexupdater.h"
 #include "rendergraph/vertexupdaters/texturedvertexupdater.h"
 #include "track/track.h"
+#include "util/assert.h"
 #include "util/colorcomponents.h"
 #include "util/roundtopixel.h"
 #include "waveform/renderers/allshader/digitsrenderer.h"
@@ -34,9 +35,14 @@ namespace {
 class WaveformMarkNode : public rendergraph::GeometryNode {
   public:
     WaveformMark* m_pOwner{};
+    bool m_isEndMark{false};
 
-    WaveformMarkNode(WaveformMark* pOwner, rendergraph::Context* pContext, const QImage& image)
-            : m_pOwner(pOwner) {
+    WaveformMarkNode(WaveformMark* pOwner,
+            bool isEndMark,
+            rendergraph::Context* pContext,
+            const QImage& image)
+            : m_pOwner(pOwner),
+              m_isEndMark(isEndMark) {
         initForRectangles<TextureMaterial>(1);
         updateTexture(pContext, image);
     }
@@ -68,6 +74,10 @@ class WaveformMarkNode : public rendergraph::GeometryNode {
         return m_textureHeight;
     }
 
+    void setAlpha(float alpha) {
+        material().setUniform(1, alpha);
+    }
+
   public:
     float m_textureWidth{};
     float m_textureHeight{};
@@ -76,10 +86,11 @@ class WaveformMarkNode : public rendergraph::GeometryNode {
 class WaveformMarkNodeGraphics : public WaveformMark::Graphics {
   public:
     WaveformMarkNodeGraphics(WaveformMark* pOwner,
+            bool isEndMark,
             rendergraph::Context* pContext,
             const QImage& image)
             : m_pNode(std::make_unique<WaveformMarkNode>(
-                      pOwner, pContext, image)) {
+                      pOwner, isEndMark, pContext, image)) {
     }
     void updateTexture(rendergraph::Context* pContext, const QImage& image) {
         waveformMarkNode()->updateTexture(pContext, image);
@@ -92,6 +103,9 @@ class WaveformMarkNodeGraphics : public WaveformMark::Graphics {
     }
     float textureHeight() const {
         return waveformMarkNode()->textureHeight();
+    }
+    void setAlpha(float alpha) {
+        waveformMarkNode()->setAlpha(alpha);
     }
     void attachNode(std::unique_ptr<rendergraph::BaseNode> pNode) {
         DEBUG_ASSERT(!m_pNode);
@@ -278,8 +292,10 @@ void allshader::WaveformRenderMark::update() {
         WaveformMarkNode* pWaveformMarkNode = static_cast<WaveformMarkNode*>(pNode.get());
         // Determine its WaveformMark
         auto* pMark = pWaveformMarkNode->m_pOwner;
-        auto* pGraphics = static_cast<WaveformMarkNodeGraphics*>(pMark->m_pGraphics.get());
-        // Store the node with the WaveformMark
+        auto* pGraphics = static_cast<WaveformMarkNodeGraphics*>(
+                pWaveformMarkNode->m_isEndMark ? pMark->m_pEndGraphics.get()
+                                               : pMark->m_pGraphics.get());
+        // Store the nodes with the WaveformMark
         pGraphics->attachNode(std::move(pNode));
     }
 
@@ -322,13 +338,19 @@ void allshader::WaveformRenderMark::update() {
 
         auto* pMarkGraphics = pMark->m_pGraphics.get();
         auto* pMarkNodeGraphics = static_cast<WaveformMarkNodeGraphics*>(pMarkGraphics);
-        if (!pMarkGraphics) { // is this even possible?
+        if (!pMarkNodeGraphics) { // is this even possible?
             continue;
         }
 
         const float currentMarkPos = static_cast<float>(
                 m_waveformRenderer->transformSamplePositionInRendererWorld(
                         samplePosition, positionType));
+        auto* pMarkEndGraphics = pMark->m_pEndGraphics.get();
+        auto* pMarkEndNodeGraphics = static_cast<WaveformMarkNodeGraphics*>(pMarkEndGraphics);
+        VERIFY_OR_DEBUG_ASSERT(pMarkEndNodeGraphics) {
+            continue;
+        }
+
         if (pMark->isShowUntilNext() &&
                 samplePosition >= playPosition + 1.0 &&
                 samplePosition < nextMarkPosition) {
@@ -358,30 +380,47 @@ void allshader::WaveformRenderMark::update() {
 
         // Check if the range needs to be displayed.
         if (samplePosition != sampleEndPosition && sampleEndPosition != Cue::kNoPosition) {
-            DEBUG_ASSERT(samplePosition < sampleEndPosition);
             const float currentMarkEndPos = static_cast<float>(
                     m_waveformRenderer->transformSamplePositionInRendererWorld(
                             sampleEndPosition, positionType));
+
             if (visible || currentMarkEndPos > 0.f) {
-                QColor color = pMark->fillColor();
-                color.setAlphaF(0.4f);
+                if (pMark->isLoop()) {
+                    // Reuse, or create new when needed
+                    if (!pRangeChild) {
+                        auto pNode = std::make_unique<GeometryNode>();
+                        pNode->initForRectangles<RGBAMaterial>(2);
+                        pRangeChild = pNode.get();
+                        m_pRangeNodesParent->appendChildNode(std::move(pNode));
+                    }
 
-                // Reuse, or create new when needed
-                if (!pRangeChild) {
-                    auto pNode = std::make_unique<GeometryNode>();
-                    pNode->initForRectangles<RGBAMaterial>(2);
-                    pRangeChild = pNode.get();
-                    m_pRangeNodesParent->appendChildNode(std::move(pNode));
+                    QColor color = pMark->fillColor();
+                    color.setAlphaF(0.4f);
+                    updateRangeNode(pRangeChild,
+                            QRectF(QPointF(roundToPixel(currentMarkPos),
+                                           !m_isSlipRenderer && slipActive
+                                                   ? roundToPixel(
+                                                             m_waveformRenderer
+                                                                     ->getBreadth() /
+                                                             2)
+                                                   : 0.f),
+                                    QPointF(roundToPixel(currentMarkEndPos),
+                                            roundToPixel(m_waveformRenderer
+                                                            ->getBreadth()))),
+                            color);
+                    pRangeChild = static_cast<GeometryNode*>(pRangeChild->nextSibling());
+                } else {
+                    pMarkEndNodeGraphics->update(
+                            roundToPixel(currentMarkEndPos - markWidth / 2.f),
+                            !m_isSlipRenderer && slipActive
+                                    ? roundToPixel(m_waveformRenderer->getBreadth() / 2)
+                                    : 0,
+                            devicePixelRatio);
+                    pMarkEndNodeGraphics->setAlpha(static_cast<float>(pMark->opacity()));
+                    // transfer back to m_pMarkNodesParent children, for rendering
+                    m_pMarkNodesParent->appendChildNode(pMarkEndNodeGraphics->detachNode());
                 }
-
-                updateRangeNode(pRangeChild,
-                        QRectF(QPointF(roundToPixel(currentMarkPos), 0.f),
-                                QPointF(roundToPixel(currentMarkEndPos),
-                                        roundToPixel(m_waveformRenderer->getBreadth()))),
-                        color);
-
                 visible = true;
-                pRangeChild = static_cast<GeometryNode*>(pRangeChild->nextSibling());
             }
         }
 
@@ -560,6 +599,7 @@ void allshader::WaveformRenderMark::updateMarkImage(WaveformMarkPointer pMark) {
     if (!pMark->m_pGraphics) {
         pMark->m_pGraphics =
                 std::make_unique<WaveformMarkNodeGraphics>(pMark.get(),
+                        false,
                         m_waveformRenderer->getContext(),
                         pMark->generateImage(
                                 m_waveformRenderer->getDevicePixelRatio()));
@@ -567,6 +607,21 @@ void allshader::WaveformRenderMark::updateMarkImage(WaveformMarkPointer pMark) {
         auto* pGraphics = static_cast<WaveformMarkNodeGraphics*>(pMark->m_pGraphics.get());
         pGraphics->updateTexture(m_waveformRenderer->getContext(),
                 pMark->generateImage(
+                        m_waveformRenderer->getDevicePixelRatio()));
+    }
+}
+void allshader::WaveformRenderMark::updateEndMarkImage(WaveformMarkPointer pMark) {
+    if (!pMark->m_pEndGraphics) {
+        pMark->m_pEndGraphics =
+                std::make_unique<WaveformMarkNodeGraphics>(pMark.get(),
+                        true,
+                        m_waveformRenderer->getContext(),
+                        pMark->generateEndImage(
+                                m_waveformRenderer->getDevicePixelRatio()));
+    } else {
+        auto* pGraphics = static_cast<WaveformMarkNodeGraphics*>(pMark->m_pEndGraphics.get());
+        pGraphics->updateTexture(m_waveformRenderer->getContext(),
+                pMark->generateEndImage(
                         m_waveformRenderer->getDevicePixelRatio()));
     }
 }

--- a/src/waveform/renderers/allshader/waveformrendermark.h
+++ b/src/waveform/renderers/allshader/waveformrendermark.h
@@ -62,6 +62,7 @@ class allshader::WaveformRenderMark : public ::WaveformRenderMarkBase,
 
   private:
     void updateMarkImage(WaveformMarkPointer pMark) override;
+    void updateEndMarkImage(WaveformMarkPointer pMark) override;
 
     void updatePlayPosMarkTexture(rendergraph::Context* pContext);
 

--- a/src/waveform/renderers/waveformmark.cpp
+++ b/src/waveform/renderers/waveformmark.cpp
@@ -2,6 +2,8 @@
 
 #include <QOpenGLTexture>
 #include <QPainterPath>
+#include <QStringLiteral>
+#include <QSvgRenderer>
 #include <QtDebug>
 
 #include "skin/legacy/skincontext.h"
@@ -93,7 +95,8 @@ bool isShowUntilNextPositionControl(const QString& positionControl) {
 
 } // anonymous namespace
 
-WaveformMark::WaveformMark(const QString& group,
+WaveformMark::WaveformMark(
+        const QString& group,
         QString positionControl,
         const QString& visibilityControl,
         const QString& textColor,
@@ -104,22 +107,34 @@ WaveformMark::WaveformMark(const QString& group,
         QColor color,
         int priority,
         int hotCue,
-        const WaveformSignalColors& signalColors)
+        const WaveformSignalColors& signalColors,
+        const QString& endPixmapPath,
+        const QString& endIconPath,
+        float disabledOpacity,
+        float enabledOpacity)
         : m_textColor(textColor),
           m_pixmapPath(pixmapPath),
+          m_endPixmapPath(endPixmapPath),
           m_iconPath(iconPath),
+          m_endIconPath(endIconPath),
+          m_enabledOpacity(enabledOpacity),
+          m_disabledOpacity(disabledOpacity),
           m_linePosition{},
           m_breadth{},
           m_level{},
+          m_typeCO{},
+          m_statusCO{},
           m_iPriority(priority),
           m_iHotCue(hotCue),
           m_showUntilNext{} {
     QString endPositionControl;
     QString typeControl;
+    QString statusControl;
     if (hotCue != Cue::kNoHotCue) {
         QString hotcueNumber = QString::number(hotCue + 1);
         positionControl = QStringLiteral("hotcue_%1_position").arg(hotcueNumber);
         endPositionControl = QStringLiteral("hotcue_%1_endposition").arg(hotcueNumber);
+        statusControl = QStringLiteral("hotcue_%1_status").arg(hotcueNumber);
         typeControl = QStringLiteral("hotcue_%1_type").arg(hotcueNumber);
         m_showUntilNext = true;
     } else {
@@ -131,7 +146,8 @@ WaveformMark::WaveformMark(const QString& group,
     }
     if (!endPositionControl.isEmpty()) {
         m_pEndPositionCO = std::make_unique<ControlProxy>(group, endPositionControl);
-        m_pTypeCO = std::make_unique<ControlProxy>(group, typeControl);
+        m_statusCO = std::make_unique<ControlProxy>(group, statusControl);
+        m_typeCO = std::make_unique<ControlProxy>(group, typeControl);
     }
 
     if (!visibilityControl.isEmpty()) {
@@ -179,10 +195,12 @@ WaveformMark::WaveformMark(const QString& group,
     QString positionControl;
     QString endPositionControl;
     QString typeControl;
+    QString statusControl;
     if (hotCue != Cue::kNoHotCue) {
         positionControl = "hotcue_" + QString::number(hotCue + 1) + "_position";
         endPositionControl = "hotcue_" + QString::number(hotCue + 1) + "_endposition";
         typeControl = "hotcue_" + QString::number(hotCue + 1) + "_type";
+        statusControl = "hotcue_" + QString::number(hotCue + 1) + "_status";
         m_showUntilNext = true;
     } else {
         positionControl = context.selectString(node, "Control");
@@ -194,7 +212,8 @@ WaveformMark::WaveformMark(const QString& group,
     }
     if (!endPositionControl.isEmpty()) {
         m_pEndPositionCO = std::make_unique<ControlProxy>(group, endPositionControl);
-        m_pTypeCO = std::make_unique<ControlProxy>(group, typeControl);
+        m_typeCO = std::make_unique<ControlProxy>(group, typeControl);
+        m_statusCO = std::make_unique<ControlProxy>(group, statusControl);
     }
 
     QString visibilityControl = context.selectString(node, "VisibilityControl");
@@ -234,10 +253,23 @@ WaveformMark::WaveformMark(const QString& group,
         m_pixmapPath = context.makeSkinPath(m_pixmapPath);
     }
 
+    m_endPixmapPath = context.selectString(node, "EndPixmap");
+    if (!m_endPixmapPath.isEmpty()) {
+        m_endPixmapPath = context.makeSkinPath(m_endPixmapPath);
+    }
+
     m_iconPath = context.selectString(node, "Icon");
     if (!m_iconPath.isEmpty()) {
         m_iconPath = context.makeSkinPath(m_iconPath);
     }
+
+    m_endIconPath = context.selectString(node, "EndIcon");
+    if (!m_endIconPath.isEmpty()) {
+        m_endIconPath = context.makeSkinPath(m_endIconPath);
+    }
+
+    m_enabledOpacity = context.selectDouble(node, "EnabledOpacity", 1);
+    m_disabledOpacity = context.selectDouble(node, "DisabledOpacity", 0.5);
 }
 
 WaveformMark::~WaveformMark() = default;
@@ -406,9 +438,11 @@ class MarkerGeometry {
     QSizeF m_imageSize;
 };
 
-QImage WaveformMark::generateImage(float devicePixelRatio) {
-    DEBUG_ASSERT(needsImageUpdate());
-
+QImage WaveformMark::performImageGeneration(float devicePixelRatio,
+        const QString& pixmapPath,
+        const QString& text,
+        WaveformMarkLabel* labelMark,
+        const QString& iconPath) {
     if (m_breadth == 0.0f) {
         return {};
     }
@@ -416,8 +450,8 @@ QImage WaveformMark::generateImage(float devicePixelRatio) {
     // Load the pixmap from file.
     // If that succeeds loading the text and stroke is skipped.
 
-    if (!m_pixmapPath.isEmpty()) {
-        QString path = m_pixmapPath;
+    if (!pixmapPath.isEmpty()) {
+        QString path = pixmapPath;
         // Use devicePixelRatio to properly scale the image
         QImage image = *WImageStore::getImage(path, devicePixelRatio);
         // If loading the image didn't fail, then we're done. Otherwise fall
@@ -448,23 +482,36 @@ QImage WaveformMark::generateImage(float devicePixelRatio) {
             return image;
         }
     }
-
-    QString label = m_text;
-
-    // Determine mark text.
-    if (getHotCue() >= 0) {
-        if (!label.isEmpty()) {
-            label.prepend(": ");
-        }
-        label.prepend(QString::number(getHotCue() + 1));
-    }
-
-    const bool useIcon = m_iconPath != "";
+    const bool useIcon = iconPath != "";
 
     // Determine drawing geometries
-    const MarkerGeometry markerGeometry{label, useIcon, m_align, m_breadth, m_level};
+    const MarkerGeometry markerGeometry{text, useIcon, m_align, m_breadth, m_level};
 
-    m_label.setAreaRect(markerGeometry.labelRect());
+    float linePos;
+    if (labelMark) {
+        labelMark->setAreaRect(markerGeometry.labelRect());
+
+        const Qt::Alignment alignH = m_align & Qt::AlignHorizontal_Mask;
+        const float imgw = static_cast<float>(markerGeometry.imageSize().width());
+        switch (alignH) {
+        case Qt::AlignHCenter:
+            m_linePosition = imgw / 2.f;
+            m_offset = -(imgw - 1.f) / 2.f;
+            break;
+        case Qt::AlignLeft:
+            m_linePosition = imgw - 1.5f;
+            m_offset = -imgw + 2.f;
+            break;
+        case Qt::AlignRight:
+        default:
+            m_linePosition = 1.5f;
+            m_offset = -1.f;
+            break;
+        }
+        linePos = m_linePosition;
+    } else {
+        linePos = static_cast<float>(markerGeometry.imageSize().width()) / 2.f;
+    }
 
     const QSize size{markerGeometry.getImageSize(devicePixelRatio)};
 
@@ -489,26 +536,7 @@ QImage WaveformMark::generateImage(float devicePixelRatio) {
 
     painter.setWorldMatrixEnabled(false);
 
-    const Qt::Alignment alignH = m_align & Qt::AlignHorizontal_Mask;
-    const float imgw = static_cast<float>(markerGeometry.imageSize().width());
-    switch (alignH) {
-    case Qt::AlignHCenter:
-        m_linePosition = imgw / 2.f;
-        m_offset = -(imgw - 1.f) / 2.f;
-        break;
-    case Qt::AlignLeft:
-        m_linePosition = imgw - 1.5f;
-        m_offset = -imgw + 2.f;
-        break;
-    case Qt::AlignRight:
-    default:
-        m_linePosition = 1.5f;
-        m_offset = -1.f;
-        break;
-    }
-
     // Note: linePos has to be at integer + 0.5 to draw correctly
-    const float linePos = m_linePosition;
     [[maybe_unused]] const float epsilon = 1e-6f;
     DEBUG_ASSERT(std::abs(linePos - std::floor(linePos) - 0.5) < epsilon);
 
@@ -526,7 +554,7 @@ QImage WaveformMark::generateImage(float devicePixelRatio) {
             linePos + 1.f,
             markerGeometry.imageSize().height()));
 
-    if (useIcon || label.length() != 0) {
+    if (useIcon || text.length() != 0) {
         painter.setPen(borderColor());
 
         // Draw the label rounded rect with border
@@ -535,7 +563,7 @@ QImage WaveformMark::generateImage(float devicePixelRatio) {
         painter.fillPath(path, fillColor());
         painter.drawPath(path);
 
-        // Center m_contentRect.width() and m_contentRect.height() inside m_labelRect
+        // Center m_contentRect.width() and m_contentRect.height() inside labelRectMarl
         // and apply the offset x,y so the text ends up in the centered width,height.
         QPointF pos(markerGeometry.labelRect().x() +
                         (markerGeometry.labelRect().width() -
@@ -549,7 +577,7 @@ QImage WaveformMark::generateImage(float devicePixelRatio) {
                         markerGeometry.contentRect().y());
 
         if (useIcon) {
-            QSvgRenderer svgRenderer(m_iconPath);
+            QSvgRenderer svgRenderer(iconPath);
             svgRenderer.render(&painter, QRectF(pos, markerGeometry.contentRect().size()));
         } else {
             // Draw the text
@@ -557,11 +585,42 @@ QImage WaveformMark::generateImage(float devicePixelRatio) {
             painter.setPen(labelColor());
             painter.setFont(markerGeometry.font());
 
-            painter.drawText(pos, label);
+            painter.drawText(pos, text);
         }
     }
 
     painter.end();
 
     return image;
+}
+
+QImage WaveformMark::generateImage(float devicePixelRatio) {
+    DEBUG_ASSERT(needsImageUpdate());
+
+    QString label = m_text;
+
+    // Determine mark text.
+    if (getHotCue() >= 0) {
+        if (!label.isEmpty()) {
+            label.prepend(": ");
+        }
+        label.prepend(QString::number(getHotCue() + 1));
+    }
+
+    return performImageGeneration(devicePixelRatio, m_pixmapPath, label, &m_label, m_iconPath);
+}
+
+QImage WaveformMark::generateEndImage(float devicePixelRatio) {
+    assert(needsEndImageUpdate());
+
+    QString direction = QStringLiteral("forward");
+
+    if (isJump() && getSampleEndPosition() > getSamplePosition()) {
+        direction = QStringLiteral("backward");
+    }
+    return performImageGeneration(devicePixelRatio,
+            m_endPixmapPath,
+            "",
+            nullptr,
+            m_endIconPath.contains("%1") ? m_endIconPath.arg(direction) : m_endIconPath);
 }

--- a/src/waveform/renderers/waveformmark.h
+++ b/src/waveform/renderers/waveformmark.h
@@ -1,9 +1,12 @@
 #pragma once
 #include <QDomNode>
+#include <QHash>
 #include <QImage>
 #include <memory>
 
 #include "control/controlproxy.h"
+#include "control/pollingcontrolproxy.h"
+#include "engine/controls/cuecontrol.h"
 #include "track/cue.h"
 #include "waveform/renderers/waveformsignalcolors.h"
 #include "waveform/waveformmarklabel.h"
@@ -44,7 +47,11 @@ class WaveformMark {
             QColor color,
             int priority,
             int hotCue = Cue::kNoHotCue,
-            const WaveformSignalColors& signalColors = {});
+            const WaveformSignalColors& signalColors = {},
+            const QString& endPixmapPath = {},
+            const QString& endIconPath = {},
+            float disabledOpacity = 1.0f,
+            float enabledOpacity = 1.0f);
     ~WaveformMark();
 
     // Disable copying
@@ -61,6 +68,12 @@ class WaveformMark {
     int getPriority() const {
         return m_iPriority;
     };
+    mixxx::CueType getType() const {
+        if (!m_typeCO) {
+            return mixxx::CueType::Invalid;
+        }
+        return static_cast<mixxx::CueType>(m_typeCO->get());
+    }
 
     // The m_pPositionCO related function
     bool isValid() const {
@@ -77,18 +90,44 @@ class WaveformMark {
             m_pEndPositionCO->connectValueChanged(receiver, slot, Qt::AutoConnection);
         }
     };
+    template<typename Receiver, typename Slot>
+    void connectTypeChanged(Receiver receiver, Slot slot) const {
+        if (m_typeCO) {
+            m_typeCO->connectValueChanged(receiver, slot, Qt::AutoConnection);
+        }
+    };
+    template<typename Receiver, typename Slot>
+    void connectStatusChanged(Receiver receiver, Slot slot) const {
+        if (m_statusCO) {
+            m_statusCO->connectValueChanged(receiver, slot, Qt::AutoConnection);
+        }
+    };
+
     double getSamplePosition() const {
         return m_pPositionCO->get();
+    }
+    bool isJump() const {
+        return m_typeCO &&
+                static_cast<mixxx::CueType>(m_typeCO->get()) ==
+                mixxx::CueType::Jump;
+    }
+    bool isLoop() const {
+        return m_typeCO &&
+                static_cast<mixxx::CueType>(m_typeCO->get()) ==
+                mixxx::CueType::Loop;
+    }
+    bool isStandard() const {
+        // A Waveform mark should always have either `isJump`, `isLoop` or
+        // `isNormal` returning true!
+        return !isLoop() && !isJump();
     }
     double getSampleEndPosition() const {
         if (!m_pEndPositionCO ||
                 // A hotcue may have an end position although it isn't a saved
-                // loop anymore. This happens when the user changes the cue
+                // loop or jump anymore. This happens when the user changes the cue
                 // type. However, we persist the end position if the user wants
                 // to restore the cue to a saved loop
-                (m_pTypeCO &&
-                        static_cast<mixxx::CueType>(m_pTypeCO->get()) !=
-                                mixxx::CueType::Loop)) {
+                isStandard()) {
             return Cue::kNoPosition;
         }
         return m_pEndPositionCO->get();
@@ -106,6 +145,13 @@ class WaveformMark {
             return true;
         }
         return m_pVisibleCO->toBool();
+    }
+    // A cue is always considered active if it isn't a saved loop or a saved
+    // jump (a.k.a a "standard" cue)
+    bool isActive() const {
+        return !m_statusCO ||
+                static_cast<HotcueControl::Status>(m_statusCO->get()) ==
+                HotcueControl::Status::Active;
     }
     bool isShowUntilNext() const {
         return m_showUntilNext;
@@ -138,14 +184,25 @@ class WaveformMark {
         return m_labelColor;
     }
 
+    double opacity() const {
+        return isActive() ? m_enabledOpacity : m_disabledOpacity;
+    }
+
     void setNeedsImageUpdate() {
         if (m_pGraphics) {
             m_pGraphics->m_obsolete = true;
+        }
+        if (m_pEndGraphics) {
+            m_pEndGraphics->m_obsolete = true;
         }
     }
 
     bool needsImageUpdate() const {
         return !m_pGraphics || m_pGraphics->m_obsolete;
+    }
+
+    bool needsEndImageUpdate() const {
+        return !m_pEndGraphics || m_pEndGraphics->m_obsolete;
     }
 
     void setBreadth(float breadth) {
@@ -168,12 +225,18 @@ class WaveformMark {
     bool contains(QPoint point, Qt::Orientation orientation) const;
 
     QImage generateImage(float devicePixelRatio);
+    QImage generateEndImage(float devicePixelRatio);
 
     QColor m_textColor;
     QString m_text;
     Qt::Alignment m_align;
     QString m_pixmapPath;
+    QString m_endPixmapPath;
     QString m_iconPath;
+    QString m_endIconPath;
+
+    double m_enabledOpacity;
+    double m_disabledOpacity;
 
     float m_linePosition;
     float m_offset;
@@ -187,12 +250,20 @@ class WaveformMark {
     WaveformMarkLabel m_label;
 
   private:
+    QImage performImageGeneration(float devicePixelRatio,
+            const QString& pixmapPath,
+            const QString& text,
+            WaveformMarkLabel* labelMark,
+            const QString& iconPath);
+
     std::unique_ptr<ControlProxy> m_pPositionCO;
     std::unique_ptr<ControlProxy> m_pEndPositionCO;
-    std::unique_ptr<ControlProxy> m_pTypeCO;
     std::unique_ptr<ControlProxy> m_pVisibleCO;
+    std::unique_ptr<ControlProxy> m_typeCO;
+    std::unique_ptr<ControlProxy> m_statusCO;
 
     std::unique_ptr<Graphics> m_pGraphics;
+    std::unique_ptr<Graphics> m_pEndGraphics;
 
     int m_iPriority;
     int m_iHotCue;

--- a/src/waveform/renderers/waveformmarkset.cpp
+++ b/src/waveform/renderers/waveformmarkset.cpp
@@ -68,7 +68,6 @@ void WaveformMarkSet::setDefault(const QString& group,
         const DefaultMarkerStyle& model,
         const WaveformSignalColors& signalColors) {
     m_pDefaultMark = WaveformMarkPointer::create(
-
             group,
             model.positionControl,
             model.visibilityControl,
@@ -84,7 +83,6 @@ void WaveformMarkSet::setDefault(const QString& group,
     for (int i = 0; i < NUM_HOT_CUES; ++i) {
         if (m_hotCueMarks.value(i).isNull()) {
             auto pMark = WaveformMarkPointer::create(
-
                     group,
                     model.positionControl,
                     model.visibilityControl,
@@ -96,7 +94,11 @@ void WaveformMarkSet::setDefault(const QString& group,
                     model.color,
                     i,
                     i,
-                    signalColors);
+                    signalColors,
+                    model.endPixmapPath,
+                    model.endIconPath,
+                    model.enabledOpacity,
+                    model.disabledOpacity);
             m_marks.push_front(pMark);
             m_hotCueMarks.insert(pMark->getHotCue(), pMark);
         }

--- a/src/waveform/renderers/waveformmarkset.h
+++ b/src/waveform/renderers/waveformmarkset.h
@@ -18,8 +18,12 @@ class WaveformMarkSet {
         QString markAlign;
         QString text;
         QString pixmapPath;
+        QString endPixmapPath;
         QString iconPath;
+        QString endIconPath;
         QColor color;
+        float enabledOpacity;
+        float disabledOpacity;
     };
 
     WaveformMarkSet();
@@ -52,6 +56,24 @@ class WaveformMarkSet {
         for (const auto& pMark : std::as_const(m_marks)) {
             if (pMark->hasVisible()) {
                 pMark->connectVisibleChanged(receiver, slot);
+            }
+        }
+    }
+
+    template<typename Receiver, typename Slot>
+    void connectTypeChanged(Receiver receiver, Slot slot) const {
+        for (const auto& pMark : std::as_const(m_marks)) {
+            if (pMark->isValid()) {
+                pMark->connectTypeChanged(receiver, slot);
+            }
+        }
+    }
+
+    template<typename Receiver, typename Slot>
+    void connectStatusChanged(Receiver receiver, Slot slot) const {
+        for (const auto& pMark : std::as_const(m_marks)) {
+            if (pMark->isValid()) {
+                pMark->connectStatusChanged(receiver, slot);
             }
         }
     }

--- a/src/waveform/renderers/waveformrendermark.cpp
+++ b/src/waveform/renderers/waveformrendermark.cpp
@@ -140,3 +140,13 @@ void WaveformRenderMark::updateMarkImage(WaveformMarkPointer pMark) {
                         .transformed(QTransform().rotate(90)));
     }
 }
+void WaveformRenderMark::updateEndMarkImage(WaveformMarkPointer pMark) {
+    if (m_waveformRenderer->getOrientation() == Qt::Horizontal) {
+        pMark->m_pEndGraphics = std::make_unique<ImageGraphics>(
+                pMark->generateEndImage(m_waveformRenderer->getDevicePixelRatio()));
+    } else {
+        pMark->m_pEndGraphics = std::make_unique<ImageGraphics>(
+                pMark->generateEndImage(m_waveformRenderer->getDevicePixelRatio())
+                        .transformed(QTransform().rotate(90)));
+    }
+}

--- a/src/waveform/renderers/waveformrendermark.h
+++ b/src/waveform/renderers/waveformrendermark.h
@@ -10,6 +10,7 @@ class WaveformRenderMark : public WaveformRenderMarkBase {
 
   private:
     void updateMarkImage(WaveformMarkPointer pMark) override;
+    void updateEndMarkImage(WaveformMarkPointer pMark) override;
 
     DISALLOW_COPY_AND_ASSIGN(WaveformRenderMark);
 };

--- a/src/waveform/renderers/waveformrendermarkbase.cpp
+++ b/src/waveform/renderers/waveformrendermarkbase.cpp
@@ -20,6 +20,8 @@ bool WaveformRenderMarkBase::init() {
     m_marks.connectSamplePositionChanged(this, &WaveformRenderMarkBase::onMarkChanged);
     m_marks.connectSampleEndPositionChanged(this, &WaveformRenderMarkBase::onMarkChanged);
     m_marks.connectVisibleChanged(this, &WaveformRenderMarkBase::onMarkChanged);
+    m_marks.connectTypeChanged(this, &WaveformRenderMarkBase::onMarkChanged);
+    m_marks.connectStatusChanged(this, &WaveformRenderMarkBase::onMarkChanged);
     return true;
 }
 
@@ -79,6 +81,9 @@ void WaveformRenderMarkBase::updateMarksFromCues() {
         QColor newColor = mixxx::RgbColor::toQColor(pCue->getColor());
         pMark->setText(newLabel);
         pMark->setBaseColor(newColor, dimBrightThreshold);
+        if (pMark->isJump()) {
+            pMark->setNeedsImageUpdate();
+        }
     }
 
     updateMarks();
@@ -95,6 +100,9 @@ void WaveformRenderMarkBase::updateMarkImages() {
     for (const auto& pMark : m_marks) {
         if (pMark->needsImageUpdate()) {
             updateMarkImage(pMark);
+        }
+        if (pMark->needsEndImageUpdate()) {
+            updateEndMarkImage(pMark);
         }
     }
 }

--- a/src/waveform/renderers/waveformrendermarkbase.h
+++ b/src/waveform/renderers/waveformrendermarkbase.h
@@ -60,6 +60,7 @@ class WaveformRenderMarkBase : public QObject, public WaveformRendererAbstract {
 
   private:
     virtual void updateMarkImage(WaveformMarkPointer pMark) = 0;
+    virtual void updateEndMarkImage(WaveformMarkPointer pMark) = 0;
 
     DISALLOW_COPY_AND_ASSIGN(WaveformRenderMarkBase);
 };

--- a/src/widget/wcuemenupopup.cpp
+++ b/src/widget/wcuemenupopup.cpp
@@ -461,12 +461,6 @@ void WCueMenuPopup::slotSavedJumpCueManual() {
         return;
     }
     auto cueStartEnd = m_pCue->getStartAndEndPosition();
-    // If we are changing the cue type from a loop, we need to permute the position
-    if (m_pCue->getType() == mixxx::CueType::Loop) {
-        auto endPosition = cueStartEnd.endPosition;
-        cueStartEnd.endPosition = cueStartEnd.startPosition;
-        cueStartEnd.startPosition = endPosition;
-    }
     auto newPosition = getCurrentPlayPositionWithQuantize();
     if (!newPosition.has_value() || newPosition == cueStartEnd.startPosition) {
         return;

--- a/src/widget/wcuemenupopup.cpp
+++ b/src/widget/wcuemenupopup.cpp
@@ -267,11 +267,26 @@ void WCueMenuPopup::slotUpdate() {
         m_pStandardCue->setChecked(m_pCue->getType() == mixxx::CueType::HotCue);
         m_pSavedLoopCue->setChecked(m_pCue->getType() == mixxx::CueType::Loop);
         m_pSavedJumpCue->setChecked(m_pCue->getType() == mixxx::CueType::Jump);
-        m_pSavedJumpCue->setProperty("direction",
-                m_pCue->getType() != mixxx::CueType::Jump ||
-                                m_pCue->getPosition() > m_pCue->getEndPosition()
-                        ? "forward"
-                        : "backward");
+        QString direction;
+        if (m_pCue->getType() == mixxx::CueType::HotCue) {
+            // Use forward/backward icon if the playposition is before/after
+            // the hotcue position
+            auto cueStartEnd = m_pCue->getStartAndEndPosition();
+            auto newPosition = getCurrentPlayPositionWithQuantize();
+            if (!newPosition.has_value() || newPosition < cueStartEnd.startPosition) {
+                direction = "forward";
+            } else {
+                direction = "backward";
+            }
+        } else {
+            // Use forward icon if this is a saved loop, or forward/back if this
+            // already is a jump cue
+            direction = m_pCue->getType() != mixxx::CueType::Jump ||
+                            m_pCue->getPosition() > m_pCue->getEndPosition()
+                    ? "forward"
+                    : "backward";
+        }
+        m_pSavedJumpCue->setProperty("direction", direction);
         m_pSavedJumpCue->style()->polish(m_pSavedJumpCue.get());
         m_pSavedJumpCue->repaint();
     } else {

--- a/src/widget/wcuemenupopup.cpp
+++ b/src/widget/wcuemenupopup.cpp
@@ -140,20 +140,23 @@ WCueMenuPopup::WCueMenuPopup(UserSettingsPointer pConfig, QWidget* parent)
 
     m_pSavedJumpCue = std::make_unique<CueMenuPushButton>(this);
     m_pSavedJumpCue->setToolTip(
-            //: \n is a linebreak. Try to not to extend the translation beyond the length
-            //: of the longest source line so the tooltip remains compact.
-            tr("Turn this cue into a saved jump, to the current play position \n"
-               "or that minus the current beatjump size") +
+            //: \n is a linebreak. Try to not to extend the translation beyond
+            //: the length of the longest source line so the tooltip remains
+            //: compact.
+            tr("Turn this cue into a saved jump.") + "\n\n" +
+            tr("Left-click: If this is a hotcue, use the current play position "
+               "as jump position\n"
+               "if no previous jump position is known.\n"
+               "If this is saved loop, use the start as jump position and the "
+               "end as cue/target position.\n"
+               "If this is already a jump cue, swap the jump position and the "
+               "cue/target position.") +
             "\n\n" +
-            tr("Left-click: Toggle this cue type to saved beatjump, using \n"
-               "the current play position if not previous jump position was "
-               "known. \nIf "
-               "a previous jump position exists, it will "
-               "swap the jump position and the cue/target position."
-               "\nThe cue type will remain unchanged if the jump position cannot be figured out.") +
+            tr("Right-click: use current play position as the jump position") +
             "\n\n" +
-            tr("Right-click: Set the current play position as the jump \n"
-               "destination and make the cue a saved jump if not"));
+            tr("The cue type will remain unchanged if the play position is at "
+               "the cue position\n"
+               "or jump position cannot be figured out."));
     m_pSavedJumpCue->setObjectName("CueSavedJumpButton");
     m_pSavedJumpCue->setCheckable(true);
     connect(m_pSavedJumpCue.get(),

--- a/src/widget/wcuemenupopup.cpp
+++ b/src/widget/wcuemenupopup.cpp
@@ -2,12 +2,21 @@
 
 #include <QHBoxLayout>
 #include <QVBoxLayout>
+#include <optional>
 
 #include "control/controlobject.h"
 #include "moc_wcuemenupopup.cpp"
 #include "track/track.h"
 
-void CueTypePushButton::mousePressEvent(QMouseEvent* e) {
+namespace {
+const ConfigKey kHotcueDefaultColorIndexConfigKey("[Controls]", "HotcueDefaultColorIndex");
+const ConfigKey kLoopDefaultColorIndexConfigKey("[Controls]", "LoopDefaultColorIndex");
+const ConfigKey kJumpDefaultColorIndexConfigKey("[Controls]", "jump_default_color_index");
+
+constexpr mixxx::audio::FrameDiff_t kMinimumAudibleLoopSizeFrames = 150;
+} // namespace
+
+void CueMenuPushButton::mousePressEvent(QMouseEvent* e) {
     if (e->type() == QEvent::MouseButtonPress && e->button() == Qt::RightButton) {
         emit rightClicked();
         return;
@@ -15,8 +24,50 @@ void CueTypePushButton::mousePressEvent(QMouseEvent* e) {
     QPushButton::mousePressEvent(e);
 }
 
+void WCueMenuPopup::updateTypeAndColorIfDefault(mixxx::CueType newType) {
+    auto hotcueColorPalette =
+            m_colorPaletteSettings.getHotcueColorPalette();
+    int colorIndex;
+    switch (m_pCue->getType()) {
+    default:
+        colorIndex = m_pConfig->getValue(kHotcueDefaultColorIndexConfigKey, -1);
+        break;
+    case mixxx::CueType::Loop:
+        colorIndex = m_pConfig->getValue(kLoopDefaultColorIndexConfigKey, -1);
+        break;
+    case mixxx::CueType::Jump:
+        colorIndex = m_pConfig->getValue(kJumpDefaultColorIndexConfigKey, -1);
+        break;
+    }
+    auto defaultColor =
+            (colorIndex < 0 || colorIndex >= hotcueColorPalette.size())
+            ? hotcueColorPalette.defaultColor()
+            : hotcueColorPalette.at(colorIndex);
+    m_pCue->setType(newType);
+    if (m_pCue->getColor() != defaultColor) {
+        return;
+    }
+    switch (newType) {
+    default:
+        colorIndex = m_pConfig->getValue(kHotcueDefaultColorIndexConfigKey, -1);
+        break;
+    case mixxx::CueType::Loop:
+        colorIndex = m_pConfig->getValue(kLoopDefaultColorIndexConfigKey, -1);
+        break;
+    case mixxx::CueType::Jump:
+        colorIndex = m_pConfig->getValue(kJumpDefaultColorIndexConfigKey, -1);
+        break;
+    }
+    if (colorIndex < 0 || colorIndex >= hotcueColorPalette.size()) {
+        m_pCue->setColor(hotcueColorPalette.defaultColor());
+    } else {
+        m_pCue->setColor(hotcueColorPalette.at(colorIndex));
+    }
+}
+
 WCueMenuPopup::WCueMenuPopup(UserSettingsPointer pConfig, QWidget* parent)
         : QWidget(parent),
+          m_pConfig(pConfig),
           m_colorPaletteSettings(ColorPaletteSettings(pConfig)),
           m_pBeatLoopSize(ControlFlag::AllowMissingOrInvalid),
           m_pPlayPos(ControlFlag::AllowMissingOrInvalid),
@@ -54,14 +105,24 @@ WCueMenuPopup::WCueMenuPopup(UserSettingsPointer pConfig, QWidget* parent)
             this,
             &WCueMenuPopup::slotChangeCueColor);
 
-    m_pDeleteCue = std::make_unique<QPushButton>("", this);
+    m_pDeleteCue = std::make_unique<CueMenuPushButton>(this);
     m_pDeleteCue->setToolTip(tr("Delete this cue"));
     m_pDeleteCue->setObjectName("CueDeleteButton");
     connect(m_pDeleteCue.get(), &QPushButton::clicked, this, &WCueMenuPopup::slotDeleteCue);
 
-    m_pSavedLoopCue = std::make_unique<CueTypePushButton>(this);
+    m_pStandardCue = std::make_unique<CueMenuPushButton>(this);
+    m_pStandardCue->setToolTip(
+            tr("Turn this cue into a regular hotcue"));
+    m_pStandardCue->setObjectName("CueStandardButton");
+    m_pStandardCue->setCheckable(true);
+    connect(m_pStandardCue.get(),
+            &CueMenuPushButton::clicked,
+            this,
+            &WCueMenuPopup::slotStandardCue);
+
+    m_pSavedLoopCue = std::make_unique<CueMenuPushButton>(this);
     m_pSavedLoopCue->setToolTip(
-            tr("Toggle this cue type between normal cue and saved loop") +
+            tr("Turn this cue into a saved loop") +
             "\n\n" +
             tr("Left-click: Use the old size or the current beatloop size as the loop size") +
             "\n" +
@@ -69,13 +130,40 @@ WCueMenuPopup::WCueMenuPopup(UserSettingsPointer pConfig, QWidget* parent)
     m_pSavedLoopCue->setObjectName("CueSavedLoopButton");
     m_pSavedLoopCue->setCheckable(true);
     connect(m_pSavedLoopCue.get(),
-            &CueTypePushButton::clicked,
+            &CueMenuPushButton::clicked,
             this,
             &WCueMenuPopup::slotSavedLoopCueAuto);
     connect(m_pSavedLoopCue.get(),
-            &CueTypePushButton::rightClicked,
+            &CueMenuPushButton::rightClicked,
             this,
             &WCueMenuPopup::slotSavedLoopCueManual);
+
+    m_pSavedJumpCue = std::make_unique<CueMenuPushButton>(this);
+    m_pSavedJumpCue->setToolTip(
+            //: \n is a linebreak. Try to not to extend the translation beyond the length
+            //: of the longest source line so the tooltip remains compact.
+            tr("Turn this cue into a saved jump, to the current play position \n"
+               "or that minus the current beatjump size") +
+            "\n\n" +
+            tr("Left-click: Toggle this cue type to saved beatjump, using \n"
+               "the current play position if not previous jump position was "
+               "known. \nIf "
+               "a previous jump position exists, it will "
+               "swap the jump position and the cue/target position."
+               "\nThe cue type will remain unchanged if the jump position cannot be figured out.") +
+            "\n\n" +
+            tr("Right-click: Set the current play position as the jump \n"
+               "destination and make the cue a saved jump if not"));
+    m_pSavedJumpCue->setObjectName("CueSavedJumpButton");
+    m_pSavedJumpCue->setCheckable(true);
+    connect(m_pSavedJumpCue.get(),
+            &CueMenuPushButton::clicked,
+            this,
+            &WCueMenuPopup::slotSavedJumpCueAuto);
+    connect(m_pSavedJumpCue.get(),
+            &CueMenuPushButton::rightClicked,
+            this,
+            &WCueMenuPopup::slotSavedJumpCueManual);
 
     QHBoxLayout* pLabelLayout = new QHBoxLayout();
     pLabelLayout->addWidget(m_pCueNumber.get());
@@ -89,8 +177,11 @@ WCueMenuPopup::WCueMenuPopup(UserSettingsPointer pConfig, QWidget* parent)
 
     QVBoxLayout* pRightLayout = new QVBoxLayout();
     pRightLayout->addWidget(m_pDeleteCue.get());
+    pRightLayout->addWidget(m_pStandardCue.get());
     pRightLayout->addStretch(1);
     pRightLayout->addWidget(m_pSavedLoopCue.get());
+    pRightLayout->addStretch(1);
+    pRightLayout->addWidget(m_pSavedJumpCue.get());
 
     QHBoxLayout* pMainLayout = new QHBoxLayout();
     pMainLayout->addLayout(pLeftLayout);
@@ -144,20 +235,42 @@ void WCueMenuPopup::slotUpdate() {
         Cue::StartAndEndPositions pos = m_pCue->getStartAndEndPosition();
         if (pos.startPosition.isValid()) {
             double startPositionSeconds = pos.startPosition.value() / m_pTrack->getSampleRate();
-            positionText = mixxx::Duration::formatTime(startPositionSeconds, mixxx::Duration::Precision::CENTISECONDS);
+            QString startPositionText =
+                    mixxx::Duration::formatTime(startPositionSeconds,
+                            mixxx::Duration::Precision::CENTISECONDS);
             if (pos.endPosition.isValid() && m_pCue->getType() != mixxx::CueType::HotCue) {
                 double endPositionSeconds = pos.endPosition.value() / m_pTrack->getSampleRate();
-                positionText = QString("%1 - %2").arg(
-                    positionText,
-                    mixxx::Duration::formatTime(endPositionSeconds, mixxx::Duration::Precision::CENTISECONDS)
-                );
+                QString endPositionText = mixxx::Duration::formatTime(
+                        endPositionSeconds,
+                        mixxx::Duration::Precision::
+                                CENTISECONDS);
+                if (m_pCue->getType() == mixxx::CueType::Jump) {
+                    std::swap(startPositionText, endPositionText);
+                }
+                positionText =
+                        QString("%1 %2 %3")
+                                .arg(startPositionText,
+                                        m_pCue->getType() ==
+                                                        mixxx::CueType::Loop
+                                                ? "-"
+                                                : "->",
+                                        endPositionText);
             }
         }
         m_pCuePosition->setText(positionText);
 
         m_pEditLabel->setText(m_pCue->getLabel());
         m_pColorPicker->setSelectedColor(m_pCue->getColor());
+        m_pStandardCue->setChecked(m_pCue->getType() == mixxx::CueType::HotCue);
         m_pSavedLoopCue->setChecked(m_pCue->getType() == mixxx::CueType::Loop);
+        m_pSavedJumpCue->setChecked(m_pCue->getType() == mixxx::CueType::Jump);
+        m_pSavedJumpCue->setProperty("direction",
+                m_pCue->getType() != mixxx::CueType::Jump ||
+                                m_pCue->getPosition() > m_pCue->getEndPosition()
+                        ? "forward"
+                        : "backward");
+        m_pSavedJumpCue->style()->polish(m_pSavedJumpCue.get());
+        m_pSavedJumpCue->repaint();
     } else {
         m_pTrack.reset();
         m_pCue.reset();
@@ -198,6 +311,19 @@ void WCueMenuPopup::slotDeleteCue() {
     hide();
 }
 
+void WCueMenuPopup::slotStandardCue() {
+    VERIFY_OR_DEBUG_ASSERT(m_pCue != nullptr) {
+        return;
+    }
+    VERIFY_OR_DEBUG_ASSERT(m_pTrack != nullptr) {
+        return;
+    }
+    if (m_pCue->getType() != mixxx::CueType::HotCue) {
+        updateTypeAndColorIfDefault(mixxx::CueType::HotCue);
+    }
+    slotUpdate();
+}
+
 void WCueMenuPopup::slotSavedLoopCueAuto() {
     VERIFY_OR_DEBUG_ASSERT(m_pCue != nullptr) {
         return;
@@ -208,27 +334,47 @@ void WCueMenuPopup::slotSavedLoopCueAuto() {
     VERIFY_OR_DEBUG_ASSERT(m_pBeatLoopSize.valid()) {
         return;
     }
-    if (m_pCue->getType() == mixxx::CueType::Loop) {
-        m_pCue->setType(mixxx::CueType::HotCue);
-    } else {
-        auto cueStartEnd = m_pCue->getStartAndEndPosition();
-        if (!cueStartEnd.endPosition.isValid() ||
-                cueStartEnd.endPosition <= cueStartEnd.startPosition) {
-            double beatloopSize = m_pBeatLoopSize.get();
-            const mixxx::BeatsPointer pBeats = m_pTrack->getBeats();
-            if (beatloopSize <= 0 || !pBeats) {
-                return;
-            }
-            auto position = pBeats->findNBeatsFromPosition(
-                    cueStartEnd.startPosition, beatloopSize);
-            if (position <= m_pCue->getPosition()) {
-                return;
-            }
-            m_pCue->setEndPosition(position);
+    auto cueStartEnd = m_pCue->getStartAndEndPosition();
+    // If we are changing the cue type from a jump, we need to permute the positions
+    if (m_pCue->getType() == mixxx::CueType::Jump) {
+        auto endPosition = cueStartEnd.endPosition;
+        if (cueStartEnd.endPosition < cueStartEnd.startPosition) {
+            // Only swap value if this is a forward jump
+            cueStartEnd.endPosition = cueStartEnd.startPosition;
+            cueStartEnd.startPosition = endPosition;
         }
-        m_pCue->setType(mixxx::CueType::Loop);
+        m_pCue->setStartAndEndPosition(cueStartEnd.startPosition, cueStartEnd.endPosition);
     }
+    if (!cueStartEnd.endPosition.isValid() ||
+            cueStartEnd.endPosition <= cueStartEnd.startPosition) {
+        double beatloopSize = m_pBeatLoopSize.get();
+        const mixxx::BeatsPointer pBeats = m_pTrack->getBeats();
+        if (beatloopSize <= 0 || !pBeats) {
+            return;
+        }
+        auto position = pBeats->findNBeatsFromPosition(
+                cueStartEnd.startPosition, beatloopSize);
+        if (position <= m_pCue->getPosition()) {
+            return;
+        }
+        m_pCue->setEndPosition(position);
+    }
+    updateTypeAndColorIfDefault(mixxx::CueType::Loop);
     slotUpdate();
+}
+
+std::optional<mixxx::audio::FramePos> WCueMenuPopup::getCurrentPlayPositionWithQuantize() const {
+    const mixxx::BeatsPointer pBeats = m_pTrack->getBeats();
+    auto position = mixxx::audio::FramePos::fromEngineSamplePos(
+            m_pPlayPos.get() * m_pTrackSample.get());
+    if (m_pQuantizeEnabled.toBool() && pBeats) {
+        mixxx::audio::FramePos nextBeatPosition, prevBeatPosition;
+        pBeats->findPrevNextBeats(position, &prevBeatPosition, &nextBeatPosition, false);
+        return (nextBeatPosition - position > position - prevBeatPosition)
+                ? prevBeatPosition
+                : nextBeatPosition;
+    }
+    return position;
 }
 
 void WCueMenuPopup::slotSavedLoopCueManual() {
@@ -238,24 +384,78 @@ void WCueMenuPopup::slotSavedLoopCueManual() {
     VERIFY_OR_DEBUG_ASSERT(m_pTrack != nullptr) {
         return;
     }
-    VERIFY_OR_DEBUG_ASSERT(m_pBeatLoopSize.valid()) {
+    // If we are changing the cue type from a jump, we need to permute the
+    // positions if it wasn't going backward
+    if (m_pCue->getType() == mixxx::CueType::Jump &&
+            m_pCue->getPosition() > m_pCue->getEndPosition()) {
+        auto cueStartEnd = m_pCue->getStartAndEndPosition();
+        auto endPosition = cueStartEnd.endPosition;
+        cueStartEnd.endPosition = cueStartEnd.startPosition;
+        cueStartEnd.startPosition = endPosition;
+        m_pCue->setStartAndEndPosition(cueStartEnd.startPosition, cueStartEnd.endPosition);
+    }
+    auto newPosition = getCurrentPlayPositionWithQuantize();
+    if (!newPosition.has_value() || newPosition <= m_pCue->getPosition()) {
         return;
     }
-    const mixxx::BeatsPointer pBeats = m_pTrack->getBeats();
-    auto position = mixxx::audio::FramePos::fromEngineSamplePos(
-            m_pPlayPos.get() * m_pTrackSample.get());
-    if (m_pQuantizeEnabled.toBool() && pBeats) {
-        mixxx::audio::FramePos nextBeatPosition, prevBeatPosition;
-        pBeats->findPrevNextBeats(position, &prevBeatPosition, &nextBeatPosition, false);
-        position = (nextBeatPosition - position > position - prevBeatPosition)
-                ? prevBeatPosition
-                : nextBeatPosition;
-    }
-    if (position <= m_pCue->getPosition()) {
+    m_pCue->setEndPosition(newPosition.value());
+    updateTypeAndColorIfDefault(mixxx::CueType::Loop);
+    slotUpdate();
+}
+
+void WCueMenuPopup::slotSavedJumpCueAuto() {
+    VERIFY_OR_DEBUG_ASSERT(m_pCue != nullptr) {
+        slotUpdate();
         return;
     }
-    m_pCue->setEndPosition(position);
-    m_pCue->setType(mixxx::CueType::Loop);
+    VERIFY_OR_DEBUG_ASSERT(m_pTrack != nullptr) {
+        slotUpdate();
+        return;
+    }
+    auto cueStartEnd = m_pCue->getStartAndEndPosition();
+    // If we are changing the cue type from a loop, we need to permute the position
+    // Also, if the type is already a jump, we swap to the to/from point
+    if (m_pCue->getType() == mixxx::CueType::Loop || m_pCue->getType() == mixxx::CueType::Jump) {
+        auto endPosition = cueStartEnd.endPosition;
+        cueStartEnd.endPosition = cueStartEnd.startPosition;
+        cueStartEnd.startPosition = endPosition;
+    }
+    if (!cueStartEnd.endPosition.isValid()) {
+        auto newPosition = getCurrentPlayPositionWithQuantize();
+        if (!newPosition.has_value() ||
+                std::abs(newPosition.value() - cueStartEnd.startPosition) <=
+                        kMinimumAudibleLoopSizeFrames) {
+            slotUpdate();
+            return;
+        }
+        cueStartEnd.endPosition = newPosition.value();
+    }
+    m_pCue->setStartAndEndPosition(cueStartEnd.startPosition, cueStartEnd.endPosition);
+    updateTypeAndColorIfDefault(mixxx::CueType::Jump);
+    slotUpdate();
+}
+
+void WCueMenuPopup::slotSavedJumpCueManual() {
+    VERIFY_OR_DEBUG_ASSERT(m_pCue != nullptr) {
+        return;
+    }
+    VERIFY_OR_DEBUG_ASSERT(m_pTrack != nullptr) {
+        return;
+    }
+    auto cueStartEnd = m_pCue->getStartAndEndPosition();
+    // If we are changing the cue type from a loop, we need to permute the position
+    if (m_pCue->getType() == mixxx::CueType::Loop) {
+        auto endPosition = cueStartEnd.endPosition;
+        cueStartEnd.endPosition = cueStartEnd.startPosition;
+        cueStartEnd.startPosition = endPosition;
+    }
+    auto newPosition = getCurrentPlayPositionWithQuantize();
+    if (!newPosition.has_value() || newPosition == cueStartEnd.startPosition) {
+        return;
+    }
+    cueStartEnd.endPosition = newPosition.value();
+    m_pCue->setStartAndEndPosition(cueStartEnd.startPosition, cueStartEnd.endPosition);
+    updateTypeAndColorIfDefault(mixxx::CueType::Jump);
     slotUpdate();
 }
 

--- a/src/widget/wcuemenupopup.h
+++ b/src/widget/wcuemenupopup.h
@@ -15,10 +15,10 @@
 class ControlProxy;
 
 // Custom PushButton which emit a custom signal when right-clicked
-class CueTypePushButton : public QPushButton {
+class CueMenuPushButton : public QPushButton {
     Q_OBJECT
   public:
-    explicit CueTypePushButton(QWidget* parent = 0)
+    explicit CueMenuPushButton(QWidget* parent = 0)
             : QPushButton(parent) {
     }
 
@@ -64,6 +64,9 @@ class WCueMenuPopup : public QWidget {
     void slotEditLabel();
     void slotDeleteCue();
     void slotUpdate();
+    void slotStandardCue();
+    void slotSavedJumpCueManual();
+    void slotSavedJumpCueAuto();
     /// This slot is called when the saved loop button is being left pressed,
     /// which effectively toggle the cue loop between standard cue and saved
     /// loop. If the cue was never a saved loop, it will use the current
@@ -77,6 +80,10 @@ class WCueMenuPopup : public QWidget {
     void slotChangeCueColor(mixxx::RgbColor::optional_t color);
 
   private:
+    void updateTypeAndColorIfDefault(mixxx::CueType newType);
+    std::optional<mixxx::audio::FramePos> getCurrentPlayPositionWithQuantize() const;
+
+    UserSettingsPointer m_pConfig;
     ColorPaletteSettings m_colorPaletteSettings;
     PollingControlProxy m_pBeatLoopSize;
     PollingControlProxy m_pPlayPos;
@@ -89,8 +96,10 @@ class WCueMenuPopup : public QWidget {
     std::unique_ptr<QLabel> m_pCuePosition;
     std::unique_ptr<QLineEdit> m_pEditLabel;
     std::unique_ptr<WColorPicker> m_pColorPicker;
-    std::unique_ptr<QPushButton> m_pDeleteCue;
-    std::unique_ptr<CueTypePushButton> m_pSavedLoopCue;
+    std::unique_ptr<CueMenuPushButton> m_pDeleteCue;
+    std::unique_ptr<CueMenuPushButton> m_pStandardCue;
+    std::unique_ptr<CueMenuPushButton> m_pSavedLoopCue;
+    std::unique_ptr<CueMenuPushButton> m_pSavedJumpCue;
 
   protected:
     void closeEvent(QCloseEvent* event) override;

--- a/src/widget/wcuemenupopup.h
+++ b/src/widget/wcuemenupopup.h
@@ -65,8 +65,6 @@ class WCueMenuPopup : public QWidget {
     void slotDeleteCue();
     void slotUpdate();
     void slotStandardCue();
-    void slotSavedJumpCueManual();
-    void slotSavedJumpCueAuto();
     /// This slot is called when the saved loop button is being left pressed,
     /// which effectively toggle the cue loop between standard cue and saved
     /// loop. If the cue was never a saved loop, it will use the current
@@ -77,6 +75,13 @@ class WCueMenuPopup : public QWidget {
     /// which effectively makes the cue a saved loop and use the current play
     /// position as loop end
     void slotSavedLoopCueManual();
+    void slotSavedJumpCueForwardAuto();
+    void slotSavedJumpCueForwardManual();
+    void savedJumpCueForwardFromPositions(mixxx::audio::FramePos pos1, mixxx::audio::FramePos pos2);
+    void slotSavedJumpCueBackwardAuto();
+    void slotSavedJumpCueBackwardManual();
+    void savedJumpCueBackwardFromPositions(
+            mixxx::audio::FramePos pos1, mixxx::audio::FramePos pos2);
     void slotChangeCueColor(mixxx::RgbColor::optional_t color);
 
   private:
@@ -99,7 +104,8 @@ class WCueMenuPopup : public QWidget {
     std::unique_ptr<CueMenuPushButton> m_pDeleteCue;
     std::unique_ptr<CueMenuPushButton> m_pStandardCue;
     std::unique_ptr<CueMenuPushButton> m_pSavedLoopCue;
-    std::unique_ptr<CueMenuPushButton> m_pSavedJumpCue;
+    std::unique_ptr<CueMenuPushButton> m_pSavedJumpCueForward;
+    std::unique_ptr<CueMenuPushButton> m_pSavedJumpCueBackward;
 
   protected:
     void closeEvent(QCloseEvent* event) override;

--- a/src/widget/whotcuebutton.h
+++ b/src/widget/whotcuebutton.h
@@ -23,6 +23,10 @@ class WHotcueButton : public WPushButton {
     Q_PROPERTY(bool light MEMBER m_bCueColorIsLight);
     Q_PROPERTY(bool dark MEMBER m_bCueColorIsDark);
     Q_PROPERTY(QString type MEMBER m_type);
+    Q_PROPERTY(QString direction MEMBER m_direction);
+    Q_PROPERTY(bool active READ isActive);
+
+    bool isActive() const;
 
   protected:
     void mousePressEvent(QMouseEvent* pEvent) override;
@@ -35,6 +39,7 @@ class WHotcueButton : public WPushButton {
   private slots:
     void slotColorChanged(double color);
     void slotTypeChanged(double type);
+    void slotUpdateDirection(double = 0);
 
   private:
     ConfigKey createConfigKey(const QString& name);
@@ -45,11 +50,16 @@ class WHotcueButton : public WPushButton {
     bool m_hoverCueColor;
     parented_ptr<ControlProxy> m_pCoColor;
     parented_ptr<ControlProxy> m_pCoType;
+    parented_ptr<ControlProxy> m_pCoDirection;
+    parented_ptr<ControlProxy> m_pCoPosition;
+    parented_ptr<ControlProxy> m_pCoEndPosition;
+    parented_ptr<ControlProxy> m_pCoActive;
     parented_ptr<WCueMenuPopup> m_pCueMenuPopup;
     int m_cueColorDimThreshold;
     bool m_bCueColorDimmed;
     bool m_bCueColorIsLight;
     bool m_bCueColorIsDark;
     QString m_type;
+    QString m_direction;
     QMargins m_dndRectMargins;
 };

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -186,6 +186,8 @@ void WOverview::setup(const QDomNode& node, const SkinContext& context) {
     m_marks.connectSamplePositionChanged(this, &WOverview::onMarkChanged);
     m_marks.connectSampleEndPositionChanged(this, &WOverview::onMarkChanged);
     m_marks.connectVisibleChanged(this, &WOverview::onMarkChanged);
+    m_marks.connectTypeChanged(this, &WOverview::onMarkChanged);
+    m_marks.connectStatusChanged(this, &WOverview::onMarkChanged);
 
     QDomNode child = node.firstChild();
     while (!child.isNull()) {
@@ -475,7 +477,8 @@ void WOverview::updateCues(const QList<CuePointer> &loadedCues) {
 
             int hotcueNumber = currentCue->getHotCue();
             if ((currentCue->getType() == mixxx::CueType::HotCue ||
-                        currentCue->getType() == mixxx::CueType::Loop) &&
+                        currentCue->getType() == mixxx::CueType::Loop ||
+                        currentCue->getType() == mixxx::CueType::Jump) &&
                     hotcueNumber != Cue::kNoHotCue) {
                 // Prepend the hotcue number to hotcues' labels
                 QString newLabel = currentCue->getLabel();
@@ -971,6 +974,7 @@ void WOverview::drawMarks(QPainter* pPainter, const float offset, const float ga
                 offset + static_cast<float>(samplePosition) * gain,
                 0.0f,
                 static_cast<float>(width()));
+        float markStartPosition = markPosition;
         pMark->m_linePosition = markPosition;
 
         QLineF line;
@@ -986,15 +990,22 @@ void WOverview::drawMarks(QPainter* pPainter, const float offset, const float ga
         QRectF rect;
         double sampleEndPosition = pMark->getSampleEndPosition();
         if (sampleEndPosition > 0) {
-            const float markEndPosition = math_clamp(
+            float markEndPosition = math_clamp(
                     offset + static_cast<float>(sampleEndPosition) * gain,
                     0.0f,
                     static_cast<float>(width()));
 
+            // If it's a Jump cue, end is later than start for a forward jump,
+            // so swap positions in this case to get a valid rect for
+            // painting the range.
+            if (pMark->isJump() &&
+                    markEndPosition < markStartPosition) {
+                std::swap(markStartPosition, markEndPosition);
+            }
             if (m_orientation == Qt::Horizontal) {
-                rect.setCoords(markPosition, 0, markEndPosition, height());
+                rect.setCoords(markStartPosition, 0, markEndPosition, height());
             } else {
-                rect.setCoords(0, markPosition, width(), markEndPosition);
+                rect.setCoords(0, markStartPosition, width(), markEndPosition);
             }
         }
 
@@ -1005,9 +1016,18 @@ void WOverview::drawMarks(QPainter* pPainter, const float offset, const float ga
         pPainter->drawLine(line);
 
         if (rect.isValid()) {
-            QColor loopColor = pMark->fillColor();
-            loopColor.setAlphaF(0.5f);
-            pPainter->fillRect(rect, loopColor);
+            QColor rangeColor = pMark->fillColor();
+            // Less opacity for inactive jump cues to not unnecessarily obstruct
+            // the waveform image.
+            // TODO Use played color for forward jumps to clarify we'll skip that region?
+            if (pMark->getType() == mixxx::CueType::Jump && pMark->isActive()) {
+                rangeColor.setAlphaF(0.5f);
+            } else {
+                rangeColor.setAlphaF(0.2f);
+            }
+            // TODO Instead of uniform painting, use different types of gradients
+            // loops, jump, intro/outro
+            pPainter->fillRect(rect, rangeColor);
         }
 
         if (!pMark->m_text.isEmpty()) {


### PR DESCRIPTION
Alternative proposal to #13216
styled only in LateNight PaleMoon!


Now there are two Jump toggles: forward & backward.

![image](https://github.com/user-attachments/assets/b892876c-7ecb-4681-976a-fb3453f140d0)

On **left click**, each one tries to create a Jumpcue from either
* Hotcue: hotcue position / previous "end" position (if this was a Loop or Jump earlier)
if there is no valid "end" pos, the current position is used
* Loopcue: use start / end
* Jumpcue: swap jump/target position

**Right click** always tries to use the current position. (must be different from the cue position)

* roundtrip between Hotcue / Loopcue / Jumpcue should always work
Hotcue -> Loopcue -> Hotcue -> Jumpcue should pick the loop start/end, depending on the direction
* cue type buttons must always reflect the actual cue type (= match Hotcue button icon)