### PR TITLE
Added device-specific wiki and forum links for Mixman DM2 (Windows) mapping

### DIFF
--- a/res/controllers/Mixman DM2 (Windows).midi.xml
+++ b/res/controllers/Mixman DM2 (Windows).midi.xml
@@ -5,6 +5,7 @@
     <author>Joe M.</author>
     <description>MIDI Mapping for Mixman DM2 (Windows)</description>
     <manual>mixman_dm2</manual>
+    <forums>https://mixxx.discourse.group/t/mixman-dm2-information/9800/14</forums>
   </info>
   <controller id="Mixman DM2 (Windows)" port="Port">
     <controls>


### PR DESCRIPTION
This PR adds device-specific wiki and forum links to the Mixman DM2 (Windows) mapping metadata.
These links help users find documentation and community support for this controller.

Fixes: #12556

Wiki: https://manual.mixxx.org/2.4/en/hardware/controllers/mixman_dm2
Forum: https://mixxx.discourse.group/t/mixman-dm2-information/9800/14

@daschuer  Please let me know if you have any feedback!
