### PR TITLE
Add device-specific manual and forum links for Mixman DM2 (Windows) mapping in the base:2.5 

### DIFF
--- a/res/controllers/Mixman DM2 (Windows).midi.xml
+++ b/res/controllers/Mixman DM2 (Windows).midi.xml
@@ -5,6 +5,7 @@
     <author>Joe M.</author>
     <description>MIDI Mapping for Mixman DM2 (Windows)</description>
     <manual>mixman_dm2</manual>
+    <forums>https://mixxx.discourse.group/t/mixman-dm2-information/9800/14</forums>
   </info>
   <controller id="Mixman DM2 (Windows)" port="Port">
     <controls>


### PR DESCRIPTION
I created this new PR to resolve the branch change conflicts from main to 2.5 that were there earlier.

Old PR link: https://github.com/mixxxdj/mixxx/pull/14863

This PR adds device-specific wiki and forum links to the Mixman DM2 (Windows) mapping metadata.
These links help users find documentation and community support for this controller.

Fixes: https://github.com/mixxxdj/mixxx/issues/12556