### PR TITLE
Tracks table: show ReplayGain with max. 2 decimals, full precision in tooltip

### DIFF
--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -69,6 +69,8 @@ const QStringList kDefaultTableColumns = {
         LIBRARYTABLE_YEAR,
 };
 
+constexpr int kReplayGainPrecision = 2;
+
 inline QSqlDatabase cloneDatabase(
         const QSqlDatabase& prototype) {
     const auto connectionName =
@@ -898,7 +900,11 @@ QVariant BaseTrackTableModel::roleValue(
                     return QVariant();
                 }
             }
-            return mixxx::ReplayGain::ratioToString(rgRatio);
+            if (role == Qt::ToolTipRole || role == kDataExportRole) {
+                return mixxx::ReplayGain::ratioToString(rgRatio);
+            } else {
+                return mixxx::ReplayGain::ratioToString(rgRatio, kReplayGainPrecision);
+            }
         }
         case ColumnCache::COLUMN_LIBRARYTABLE_CHANNELS:
             // Not yet supported

--- a/src/track/replaygain.cpp
+++ b/src/track/replaygain.cpp
@@ -90,9 +90,13 @@ double ReplayGain::ratioFromString(const QString& dbGain, bool* pValid) {
     return kRatioUndefined;
 }
 
-QString ReplayGain::ratioToString(double ratio) {
+QString ReplayGain::ratioToString(double ratio, std::optional<int> precision) {
     if (isValidRatio(ratio)) {
-        return QString::number(ratio2db(ratio)) + kGainSuffix;
+        if (precision.has_value() && precision.value() >= 0) {
+            return QString::number(ratio2db(ratio), 'f', precision.value()) + kGainSuffix;
+        } else {
+            return QString::number(ratio2db(ratio)) + kGainSuffix;
+        }
     } else {
         return QString();
     }

--- a/src/track/replaygain.h
+++ b/src/track/replaygain.h
@@ -64,7 +64,8 @@ public:
     // Parsing and formatting of gain values according to the
     // ReplayGain 1.0/2.0 specification.
     static double ratioFromString(const QString& dBGain, bool* pValid = 0);
-    static QString ratioToString(double ratio);
+    static QString ratioToString(double ratio,
+            std::optional<int> precision = std::nullopt);
 
     static double normalizeRatio(double ratio);
 


### PR DESCRIPTION
Fixes #14867 
![image](https://github.com/user-attachments/assets/9d20e322-0c3a-454f-b2e3-ca1aa30eb251)
