### PR TITLE
fix: document libFLAC 1.5 `FLAC__STREAM_DECODER_ERROR_STATUS_MISSING_FRAME`

### DIFF
--- a/src/sources/soundsourceflac.cpp
+++ b/src/sources/soundsourceflac.cpp
@@ -586,6 +586,11 @@ void SoundSourceFLAC::flacError(FLAC__StreamDecoderErrorStatus status) {
         error = "STREAM_DECODER_ERROR_STATUS_BAD_METADATA";
         break;
 #endif
+#if FLAC_API_VERSION_CURRENT >= 15
+    case FLAC__STREAM_DECODER_ERROR_STATUS_MISSING_FRAME:
+        error = "STREAM_DECODER_ERROR_STATUS_MISSING_FRAME";
+        break;
+#endif
     }
     kLogger.warning()
             << "FLAC decoding error" << error


### PR DESCRIPTION
Just noticed this `-Wswitch` when compiling against libFLAC 1.5