### PR TITLE
(fix/feat) Traktor Kontrol S4 Mk3: tempo offset per deck

### DIFF
--- a/res/controllers/Traktor Kontrol S4 MK3.hid.xml
+++ b/res/controllers/Traktor Kontrol S4 MK3.hid.xml
@@ -183,17 +183,30 @@
                     Defines the center range in mm where the rate snaps to 0.
                 </description>
             </option>
-            <option
-                variable="tempoCenterOffsetMm"
-                type="real"
-                min="-3.0"
-                max="3.0"
-                default="0.0"
-                label="Center Snap Offset in Millimeter">
-                <description>
-                    Shifts the center range in case it doesn't match the center marker.
-                </description>
-            </option>
+            <row orientation="vertical">
+                <option
+                    variable="tempoCenterOffsetMmLeft"
+                    type="real"
+                    min="-3.0"
+                    max="3.0"
+                    default="0.0"
+                    label="Center Snap Offset in Millimeter (Left Deck)">
+                    <description>
+                        Shifts the center range in case it doesn't match the center marker.
+                    </description>
+                </option>
+                <option
+                    variable="tempoCenterOffsetMmRight"
+                    type="real"
+                    min="-3.0"
+                    max="3.0"
+                    default="0.0"
+                    label="Center Snap Offset in Millimeter (Right Deck)">
+                    <description>
+                        Shifts the center range in case it doesn't match the center marker.
+                    </description>
+                </option>
+            </row>
         </group>
 
         <group label="Alternative Mapping">

--- a/res/controllers/Traktor-Kontrol-S4-MK3.js
+++ b/res/controllers/Traktor-Kontrol-S4-MK3.js
@@ -82,9 +82,12 @@ const TempoFaderTicksPerMm = 4096 / 77; // 53.1948..
 const TempoCenterRangeTicks = TempoFaderTicksPerMm * TempoCenterRangeMm;
 // Value center may be off the labeled center.
 // Use this setting to compensate per device.
-const TempoCenterValueOffset = (engine.getSetting("tempoCenterOffsetMm") || 0.0) * TempoFaderTicksPerMm;
-const TempoCenterUpper = (4096 / 2) + (TempoCenterRangeTicks / 2) + TempoCenterValueOffset;
-const TempoCenterLower = (4096 / 2) - (TempoCenterRangeTicks / 2) + TempoCenterValueOffset;
+const TempoCenterValueOffsetLeft = (engine.getSetting("tempoCenterOffsetMmLeft") || 0.0) * TempoFaderTicksPerMm;
+const TempoCenterValueOffsetRright = (engine.getSetting("tempoCenterOffsetMmRight") || 0.0) * TempoFaderTicksPerMm;
+const TempoCenterUpperLeft = (4096 / 2) + (TempoCenterRangeTicks / 2) + TempoCenterValueOffsetLeft;
+const TempoCenterLowerLeft = (4096 / 2) - (TempoCenterRangeTicks / 2) + TempoCenterValueOffsetLeft;
+const TempoCenterUpperRight = (4096 / 2) + (TempoCenterRangeTicks / 2) + TempoCenterValueOffsetRright;
+const TempoCenterLowerRight = (4096 / 2) - (TempoCenterRangeTicks / 2) + TempoCenterValueOffsetRright;
 
 // Define whether or not to keep LED that have only one color (reverse, flux, play, shift) dimmed if they are inactive.
 // 'true' will keep them dimmed, 'false' will turn them off. Default: true
@@ -425,7 +428,7 @@ class ComponentContainer extends Component {
 
 /* eslint no-redeclare: "off" */
 class Deck extends ComponentContainer {
-    constructor(decks, colors) {
+    constructor(decks, colors, settings) {
         super();
         if (typeof decks === "number") {
             this.group = Deck.groupForNumber(decks);
@@ -443,6 +446,7 @@ class Deck extends ComponentContainer {
             }
             this.color = colors[0];
         }
+        this.settings = settings;
         this.secondDeckModes = null;
     }
     toggleDeck() {
@@ -1582,8 +1586,8 @@ class S4Mk3EffectUnit extends ComponentContainer {
 }
 
 class S4Mk3Deck extends Deck {
-    constructor(decks, colors, effectUnit, mixer, inReports, outReport, io) {
-        super(decks, colors);
+    constructor(decks, colors, settings, effectUnit, mixer, inReports, outReport, io) {
+        super(decks, colors, settings);
 
         this.playButton = new PlayButton({
             output: InactiveLightsAlwaysBacklit ? undefined : Button.prototype.uncoloredOutput
@@ -1643,19 +1647,21 @@ class S4Mk3Deck extends Deck {
             } : undefined,
         });
         this.tempoFader = new Pot({
+            deck: this,
             inKey: "rate",
             outKey: "rate",
             appliedValue: null,
-
+            tempoCenterUpper: this.settings.tempoCenterUpper,
+            tempoCenterLower: this.settings.tempoCenterLower,
             input: function(value) {
                 const receivingFirstValue = this.appliedValue === null;
 
-                if (value < TempoCenterLower) {
+                if (value < this.tempoCenterLower) {
                     // scale input for lower range
-                    this.appliedValue = script.absoluteLin(value, -1, 0, 0, TempoCenterLower);
-                } else if (value > TempoCenterUpper) {
+                    this.appliedValue = script.absoluteLin(value, -1, 0, 0, this.tempoCenterLower);
+                } else if (value > this.tempoCenterUpper) {
                     // scale input for upper range
-                    this.appliedValue = script.absoluteLin(value, 0, 1, TempoCenterUpper, 4096);
+                    this.appliedValue = script.absoluteLin(value, 0, 1, this.tempoCenterUpper, 4096);
                 } else {
                     // reset rate in center region
                     this.appliedValue = 0;
@@ -3006,7 +3012,10 @@ class S4MK3 {
         // so every single components' IO needs to be specified individually
         // for both decks.
         this.leftDeck = new S4Mk3Deck(
-            [1, 3], [DeckColors[0], DeckColors[2]], this.effectUnit1, this.mixer,
+            [1, 3], [DeckColors[0], DeckColors[2]], {
+                tempoCenterLower: TempoCenterLowerLeft,
+                tempoCenterUpper: TempoCenterUpperLeft,
+            }, this.effectUnit1, this.mixer,
             this.inReports, this.outReports[128],
             {
                 playButton: {inByte: 4, inBit: 0, outByte: 55},
@@ -3056,7 +3065,10 @@ class S4MK3 {
         );
 
         this.rightDeck = new S4Mk3Deck(
-            [2, 4], [DeckColors[1], DeckColors[3]], this.effectUnit2, this.mixer,
+            [2, 4], [DeckColors[1], DeckColors[3]], {
+                tempoCenterLower: TempoCenterLowerRight,
+                tempoCenterUpper: TempoCenterUpperRight,
+            }, this.effectUnit2, this.mixer,
             this.inReports, this.outReports[128],
             {
                 playButton: {inByte: 12, inBit: 0, outByte: 66},

--- a/res/controllers/Traktor-Kontrol-S4-MK3.js
+++ b/res/controllers/Traktor-Kontrol-S4-MK3.js
@@ -82,7 +82,7 @@ const TempoFaderTicksPerMm = 4096 / 77; // 53.1948..
 const TempoCenterRangeTicks = TempoFaderTicksPerMm * TempoCenterRangeMm;
 // Value center may be off the labeled center.
 // Use this setting to compensate per device.
-const TempoCenterValueOffset = engine.getSetting("tempoCenterOffsetMm") || 0.0;
+const TempoCenterValueOffset = (engine.getSetting("tempoCenterOffsetMm") || 0.0) * TempoFaderTicksPerMm;
 const TempoCenterUpper = (4096 / 2) + (TempoCenterRangeTicks / 2) + TempoCenterValueOffset;
 const TempoCenterLower = (4096 / 2) - (TempoCenterRangeTicks / 2) + TempoCenterValueOffset;
 


### PR DESCRIPTION
1st is a fixup for #14721 (tempo center offset was missing factor _ticks/mm_)

2nd allows to set the offset per side