### PR TITLE
Pref Sound: add manual link for Mic monitoring modes

### DIFF
--- a/src/defs_urls.h
+++ b/src/defs_urls.h
@@ -57,6 +57,8 @@
     MIXXX_MANUAL_URL "/chapters/djing_with_mixxx#sync-lock-with-dynamic-tempo"
 #define MIXXX_MANUAL_TRACK_SEARCH_URL \
     MIXXX_MANUAL_URL "/chapters/library.html#finding-tracks-search"
+#define MIXXX_MANUAL_MIC_MONITOR_MODES_URL \
+    MIXXX_MANUAL_URL "/chapters/microphones"
 #define MIXXX_MANUAL_BEATS_URL \
     MIXXX_MANUAL_URL "/chapters/preferences.html#beat-detection"
 #define MIXXX_MANUAL_KEY_URL \

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -876,7 +876,9 @@ void DlgPrefSound::checkLatencyCompensation() {
         micMonitorModeComboBox->setEnabled(true);
         if (configuredMicMonitorMode == EngineMixer::MicMonitorMode::DirectMonitor) {
             latencyCompensationSpinBox->setEnabled(true);
-            QString lineBreak("<br/>");
+            const QString lineBreak("<br/>");
+            const QString kMicMonitorHintTrString =
+                    tr("Refer to the Mixxx User Manual for details.");
             // TODO(Be): Make the "User Manual" text link to the manual.
             if (m_pLatencyCompensation->get() == 0.0) {
                 latencyCompensationWarningLabel->setText(kWarningIconHtmlString +
@@ -887,7 +889,10 @@ void DlgPrefSound::checkLatencyCompensation() {
                            "Microphone Latency Compensation to align "
                            "microphone timing.") +
                         lineBreak +
-                        tr("Refer to the Mixxx User Manual for details.") +
+                        coloredLinkString(
+                                m_pLinkColor,
+                                kMicMonitorHintTrString,
+                                MIXXX_MANUAL_MIC_MONITOR_MODES_URL) +
                         "</html>");
                 latencyCompensationWarningLabel->show();
             } else if (m_bLatencyChanged) {
@@ -897,7 +902,10 @@ void DlgPrefSound::checkLatencyCompensation() {
                            "for Microphone Latency Compensation to align "
                            "microphone timing.") +
                         lineBreak +
-                        tr("Refer to the Mixxx User Manual for details.") +
+                        coloredLinkString(
+                                m_pLinkColor,
+                                kMicMonitorHintTrString,
+                                MIXXX_MANUAL_MIC_MONITOR_MODES_URL) +
                         "</html>");
                 latencyCompensationWarningLabel->show();
             } else {


### PR DESCRIPTION
Just a shortcut to https://manual.mixxx.org/2.5/en/chapters/microphones#measuring-round-trip-latency
The message is unchanged, just the duplicate tr string is now a constant (I wonder how Transifex handles this..)
Looks like this now:
![image](https://github.com/user-attachments/assets/88133552-c3fe-44e0-80cd-10cefdeb22e5)
