### PR TITLE
[GSoC 2025 Antonio Giordano] Initial DB Schema for Multi-Genre Support

### DIFF
--- a/res/schema.xml
+++ b/res/schema.xml
@@ -585,42 +585,35 @@ reapplying those migrations.
     </sql>
   </revision>
   <revision version="40" min_compatible="3">
-  <description>
-    Multi-Genre Support (Flat Model):
-    - Adds a 'genres' table for a centralized, flat list of genre names.
-    - Adds a 'genre_tracks' junction table for many-to-many track-genre associations.
-    - Migrates existing single genres from 'library.genre' to the new tables.
-  </description>
-  <sql>
-    CREATE TABLE IF NOT EXISTS genres (
+ <sql>
+      CREATE TABLE IF NOT EXISTS genres (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
-      name TEXT NOT NULL COLLATE NOCASE
-    );
+      name TEXT NOT NULL COLLATE NOCASE,
+      name_level_1 TEXT DEFAULT NULL COLLATE NOCASE,
+      name_level_2 TEXT DEFAULT NULL COLLATE NOCASE,
+      name_level_3 TEXT DEFAULT NULL COLLATE NOCASE,
+      name_level_4 TEXT DEFAULT NULL COLLATE NOCASE,
+      name_level_5 TEXT DEFAULT NULL COLLATE NOCASE,
+      display_group TEXT DEFAULT NULL,
+      display_order INTEGER DEFAULT 0,
+      is_visible INTEGER DEFAULT 1,
+      is_model_defined INTEGER DEFAULT 0,
+      count integer DEFAULT 0,
+      show integer DEFAULT 1,
+      locked integer DEFAULT 0,
+      autodj_source integer DEFAULT 0
+      );
 
-    CREATE UNIQUE INDEX IF NOT EXISTS idx_genres_name_unique ON genres(name);
-
-    CREATE TABLE IF NOT EXISTS genre_tracks (
+      CREATE TABLE IF NOT EXISTS genre_tracks (
       track_id INTEGER NOT NULL,
       genre_id INTEGER NOT NULL,
       PRIMARY KEY (track_id, genre_id),
       FOREIGN KEY (track_id) REFERENCES library(id) ON DELETE CASCADE,
       FOREIGN KEY (genre_id) REFERENCES genres(id) ON DELETE CASCADE
-    );
+      );
 
-    CREATE INDEX IF NOT EXISTS idx_genre_tracks_track_id ON genre_tracks(track_id);
-    CREATE INDEX IF NOT EXISTS idx_genre_tracks_genre_id ON genre_tracks(genre_id);
-
-    INSERT INTO genres (name)
-    SELECT DISTINCT TRIM(genre)
-    FROM library
-    WHERE genre IS NOT NULL AND TRIM(genre) != '';
-
-    INSERT INTO genre_tracks (track_id, genre_id)
-    SELECT T.id, G.id
-    FROM library T
-    JOIN genres G ON TRIM(T.genre) = G.name COLLATE NOCASE
-    WHERE T.genre IS NOT NULL AND TRIM(T.genre) != '';
-  </sql>
+      CREATE INDEX IF NOT EXISTS idx_genre_tracks_genre_id ON genre_tracks(genre_id);
+</sql>
 </revision>
 
 </schema>

--- a/res/schema.xml
+++ b/res/schema.xml
@@ -585,49 +585,42 @@ reapplying those migrations.
     </sql>
   </revision>
   <revision version="40" min_compatible="3">
-    <description>
-      Multi-Genre Support:
-      - Adds 'genres' table for centralized, hiererarchical genre management.
-      - Adds 'track_genres' junction table for many-to-many track-genre links.
-      - Migrates existing single genre-from 'library.genre' to the new tables.
-    </description>
-    <sql>
-      CREATE TABLE IF NOT EXISTS genres (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        name TEXT NOT NULL COLLATE NOCASE,
-        parent_id INTEGER DEFAULT NULL,
-        is_active INTEGER DEFAULT 1,
-        display_order INTEGER DEFAULT 0,
-        original_name TEXT DEFAULT NULL,
-        notes TEXT DEFAULT NULL,
-        FOREIGN KEY (parent_id) REFERENCES genres(id) ON DELETE SET NULL ON UPDATE CASCADE
-      );
+  <description>
+    Multi-Genre Support (Flat Model):
+    - Adds a 'genres' table for a centralized, flat list of genre names.
+    - Adds a 'genre_tracks' junction table for many-to-many track-genre associations.
+    - Migrates existing single genres from 'library.genre' to the new tables.
+  </description>
+  <sql>
+    CREATE TABLE IF NOT EXISTS genres (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL COLLATE NOCASE
+    );
 
-      CREATE TABLE IF NOT EXISTS genre_tracks (
-        track_id INTEGER NOT NULL,
-        genre_id INTEGER NOT NULL,
-        PRIMARY KEY (track_id, genre_id),
-        FOREIGN KEY (track_id) REFERENCES library(id) ON DELETE CASCADE,
-        FOREIGN KEY (genre_id) REFERENCES genres(id) ON DELETE CASCADE
-      );
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_genres_name_unique ON genres(name);
 
-      <!-- Indexes on track_id and genre_id -->
-      CREATE INDEX IF NOT EXISTS idx_genre_tracks_track_id ON genre_tracks(track_id);
-      CREATE INDEX IF NOT EXISTS idx_genre_tracks_genre_id ON genre_tracks(genre_id);
+    CREATE TABLE IF NOT EXISTS genre_tracks (
+      track_id INTEGER NOT NULL,
+      genre_id INTEGER NOT NULL,
+      PRIMARY KEY (track_id, genre_id),
+      FOREIGN KEY (track_id) REFERENCES library(id) ON DELETE CASCADE,
+      FOREIGN KEY (genre_id) REFERENCES genres(id) ON DELETE CASCADE
+    );
 
-      <!-- Migrate existing single genre from library.genre to genres table -->
-      INSERT INTO genres (name, original_name, parent_id, is_active, display_order)
-      SELECT DISTINCT TRIM(library.genre), TRIM(library.genre), NULL, 1, 0
-      FROM library
-      WHERE library.genre IS NOT NULL AND TRIM(library.genre) != '';
+    CREATE INDEX IF NOT EXISTS idx_genre_tracks_track_id ON genre_tracks(track_id);
+    CREATE INDEX IF NOT EXISTS idx_genre_tracks_genre_id ON genre_tracks(genre_id);
 
-      <!-- Links library tracks to their corresponding genre IDs in track_genres -->
-      INSERT INTO genre_tracks (track_id, genre_id)
-      SELECT T.id, G.id
-      FROM library T
-      JOIN genres G ON TRIM(T.genre) = G.name COLLATE NOCASE
-      WHERE T.genre IS NOT NULL AND TRIM(T.genre) != '';
-    </sql>
-  </revision>
+    INSERT INTO genres (name)
+    SELECT DISTINCT TRIM(genre)
+    FROM library
+    WHERE genre IS NOT NULL AND TRIM(genre) != '';
+
+    INSERT INTO genre_tracks (track_id, genre_id)
+    SELECT T.id, G.id
+    FROM library T
+    JOIN genres G ON TRIM(T.genre) = G.name COLLATE NOCASE
+    WHERE T.genre IS NOT NULL AND TRIM(T.genre) != '';
+  </sql>
+</revision>
 
 </schema>

--- a/res/schema.xml
+++ b/res/schema.xml
@@ -584,4 +584,50 @@ reapplying those migrations.
       UPDATE library SET filetype='aiff' WHERE filetype='aif';
     </sql>
   </revision>
+  <revision version="40" min_compatible="3">
+    <description>
+      Multi-Genre Support:
+      - Adds 'genres' table for centralized, hiererarchical genre management.
+      - Adds 'track_genres' junction table for many-to-many track-genre links.
+      - Migrates existing single genre-from 'library.genre' to the new tables.
+    </description>
+    <sql>
+      CREATE TABLE IF NOT EXISTS genres (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL COLLATE NOCASE,
+        parent_id INTEGER DEFAULT NULL,
+        is_active INTEGER DEFAULT 1,
+        display_order INTEGER DEFAULT 0,
+        original_name TEXT DEFAULT NULL,
+        notes TEXT DEFAULT NULL,
+        FOREIGN KEY (parent_id) REFERENCES genres(id) ON DELETE SET NULL ON UPDATE CASCADE
+      );
+
+      CREATE TABLE IF NOT EXISTS genre_tracks (
+        track_id INTEGER NOT NULL,
+        genre_id INTEGER NOT NULL,
+        PRIMARY KEY (track_id, genre_id),
+        FOREIGN KEY (track_id) REFERENCES library(id) ON DELETE CASCADE,
+        FOREIGN KEY (genre_id) REFERENCES genres(id) ON DELETE CASCADE
+      );
+
+      <!-- Indexes on track_id and genre_id -->
+      CREATE INDEX IF NOT EXISTS idx_genre_tracks_track_id ON genre_tracks(track_id);
+      CREATE INDEX IF NOT EXISTS idx_genre_tracks_genre_id ON genre_tracks(genre_id);
+
+      <!-- Migrate existing single genre from library.genre to genres table -->
+      INSERT INTO genres (name, original_name, parent_id, is_active, display_order)
+      SELECT DISTINCT TRIM(library.genre), TRIM(library.genre), NULL, 1, 0
+      FROM library
+      WHERE library.genre IS NOT NULL AND TRIM(library.genre) != '';
+
+      <!-- Links library tracks to their corresponding genre IDs in track_genres -->
+      INSERT INTO genre_tracks (track_id, genre_id)
+      SELECT T.id, G.id
+      FROM library T
+      JOIN genres G ON TRIM(T.genre) = G.name COLLATE NOCASE
+      WHERE T.genre IS NOT NULL AND TRIM(T.genre) != '';
+    </sql>
+  </revision>
+
 </schema>

--- a/src/database/mixxxdb.cpp
+++ b/src/database/mixxxdb.cpp
@@ -12,7 +12,7 @@
 const QString MixxxDb::kDefaultSchemaFile(":/schema.xml");
 
 //static
-const int MixxxDb::kRequiredSchemaVersion = 39;
+const int MixxxDb::kRequiredSchemaVersion = 40;
 
 namespace {
 


### PR DESCRIPTION
### Overview

This PR introduces the foundational database schema changes for the [GSoC 2025 Multi-Genre Support project](https://github.com/mixxxdj/mixxx/issues/14897).

This initial PR focuses on establishing the simple schema to support multi-genre tagging with a flat (non-hierarchical) structure.
This provides a solid and testable foundation upon which future features will be built.

This PR modifies `res/schema.xml` and the corresponding database migration logic.

**Changes Details: Phase 1: Core Database & Logic**

**1.1 Database Schema Definition & Initial Migration**
_Essential data structure for associating multiple genres with a single track._

**1.1.1 `genres` table**
_This table acts as a centralized, unique list of genre names._
 * `id` (INTEGER PRIMARY KEY AUTOINCREMENT)
 * `name` (TEXT NOT NULL COLLATE NOCASE, UNIQUE)

**1.1.2  `genre_tracks` junction table**
_This table creates the many-to-many relationship between tracks and genres._
 * `track_id ` (INTEGER NOT NULL, FOREIGN KEY to library.id ON DELETE CASCADE)
 * `genre_id `(INTEGER NOT NULL, FOREIGN KEY to genres.id ON DELETE CASCADE)
 * Composite `PRIMARY KEY` (track_id, genre_id).

**1.1.3 Implement necessary indexes:** 
Adds indexes on genres(name), genre_tracks(track_id), and genre_tracks(genre_id) for performance.

**1.1.4 Increment the database schema version to 40.**

1.1.5 Implement the data migration script:
* Populates the new genres table with unique, trimmed genre names from the existing library.genre column.
* Populates the genre_tracks table by linking each track's ID to its corresponding new genre ID.

**Future Features to add**

**New `genres` table with the following columns:**
    * `id` (INTEGER PRIMARY KEY AUTOINCREMENT)
    * `name` (TEXT NOT NULL COLLATE NOCASE, UNIQUE)
    * `parent_id` (INTEGER DEFAULT NULL, FOREIGN KEY to `genres.id` ON DELETE SET NULL ON UPDATE CASCADE) - For hierarchical structure.
    * `is_active` (INTEGER DEFAULT 1) - To allow "disabling" genres.
    * `display_order` (INTEGER DEFAULT 0) - For custom sorting of sibling genres.
    * `original_name` (TEXT DEFAULT NULL) - To store the original name from a source if the user renames it.

**New `genre_tracks` junction table**
    * `track_id` (INTEGER NOT NULL, FOREIGN KEY to `library.id` ON DELETE CASCADE)
    * `genre_id` (INTEGER NOT NULL, FOREIGN KEY to `genres.id` ON DELETE CASCADE)
    * Composite `PRIMARY KEY (track_id, genre_id)`.

**Implement necessary indexes on the new tables for performance and uniqueness**
(`idx_genres_name_unique`, `idx_genres_parent_id`, `idx_genre_tracks_track_id`, `idx_genre_tracks_genre_id`).

**Implement a basic migration script to:**
    * Populate the `genres` table with unique, trimmed genre names from the existing `library.genre` column (as top-level, active genres, with `original_name` set).
    * Populate the `genre_tracks` table by linking `library.id` to the corresponding new `genres.id` based on a case-insensitive name match.

**Context and Purpose:**

These changes are the first step as outlined in the GSoC project proposal. They lay the database groundwork required for all future multi-genre functionalities, including hierarchical management, improved UI, and enhanced metadata handling.

This PR addresses **Task 1.1** in the main GSoC [tracking issue](https://github.com/mixxxdj/mixxx/issues/14897)

**Testing Done:**
* Verified successful schema creation from an empty database.
* Verified successful data migration from an existing database populated with various single-genre scenarios.
* Database structure and migrated data inspected with DB Browser for SQLite.

This PR focuses solely on the database schema and initial data migration. Subsequent PRs will address DAO changes, UI implementation, and other features.