### PR TITLE
Use GUI config for Traktor Kontrol S3 settings

### DIFF
--- a/res/controllers/Traktor Kontrol S3.hid.xml
+++ b/res/controllers/Traktor Kontrol S3.hid.xml
@@ -6,6 +6,7 @@
     <description>HID Mapping for Traktor Kontrol S3</description>
     <wiki>https://github.com/mixxxdj/mixxx/wiki/Native-Instruments-Traktor-Kontrol-S3</wiki>
     <forums>https://mixxx.discourse.group/t/native-instruments-traktor-s3-mapping/18502/4</forums>
+    <manual>native_instruments_traktor_kontrol_s3</manual>
     <devices>
       <product protocol="hid" vendor_id="0x17cc" product_id="0x1900" usage_page="0xff01" usage="0x1" interface_number="0x3" />
     </devices>
@@ -16,4 +17,163 @@
       <file filename="Traktor-Kontrol-S3-hid-scripts.js" functionprefix="TraktorS3" />
     </scriptfiles>
   </controller>
+  <settings>
+    <option variable="fxMode" type="enum"
+      label="Effect section layout">
+      <value label="Quick Effect" default="true">QUICK_EFFECT</value>
+      <value label="Advanced Mode">ADVANCED</value>
+      <description>
+        Quick effect mode matches the intended use of the S3's FX mixing section,
+        while advanced mode gives detailed control over the individual FX
+        sections.
+      </description>
+    </option>
+    <option variable="fxResetOnStart"
+      type="boolean"
+      label="Reset FX chain on startup"
+      default="true">
+      <description>
+        When enabled, reset all channels to the default FX chain on startup.
+        Otherwise, preserve the last used value.
+      </description>
+    </option>
+    <option variable="fxUseChannelColors"
+      type="boolean"
+      label="Use channel colors for FX enable buttons"
+      default="true">
+      <description>
+        When enabled, the FX Enable buttons will use the channel colors when the
+        filter effect is selected. Disabling this
+        will use the Filter button's orange color instead.
+      </description>
+    </option>
+    <option variable="pitchMode" type="enum"
+      label="Pitch Slider Mode">
+      <value label="Absolute" default="true">PITCH_ABSOLUTE</value>
+      <value label="Relative">PITCH_RELATIVE</value>
+      <description>
+        Absolute mode is a normal pitch slider. Relative mode lets you hold
+        shift to move the slider without affecting pitch so that you can
+        continue to move it up or down more than the physical slider length
+        would allow.
+      </description>
+    </option>
+    <option variable="samplerModePressAndHold"
+      type="boolean"
+      label="Stop samplers when button is released"
+      default="false">
+      <description>
+        When enabled, samplers will stop playing as soon as the button is
+        released.
+      </description>
+    </option>
+    <option variable="jogDefaultOn"
+      type="boolean"
+      label="Enable scratch mode on start"
+      default="true">
+      <description>
+        When enabled, enable the jog button (scratch mode) on startup.
+      </description>
+    </option>
+    <option variable="sixteenSamplers"
+      type="boolean"
+      label="Use deck 2 for samplers 9-16"
+      default="false">
+      <description>
+        When enabled the samplers on deck 2 are 9-16 instead of 1-8.
+      </description>
+    </option>
+    <option variable="chan1Color" type="enum"
+      label="Channel 1 Color">
+      <value label="Red">RED</value>
+      <value label="Carrot" default="true">CARROT</value>
+      <value label="Orange">ORANGE</value>
+      <value label="Honey">HONEY</value>
+      <value label="Yellow">YELLOW</value>
+      <value label="Lime">LIME</value>
+      <value label="Green">GREEN</value>
+      <value label="Aqua">AQUA</value>
+      <value label="Celeste">CELESTE</value>
+      <value label="Sky">SKY</value>
+      <value label="Blue">BLUE</value>
+      <value label="Purple">PURPLE</value>
+      <value label="Fuchsia">FUCHSIA</value>
+      <value label="Magenta">MAGENTA</value>
+      <value label="Azalea">AZALEA</value>
+      <value label="Salmon">SALMON</value>
+      <value label="White">WHITE</value>
+      <description>
+        Sets the color of buttons on the channel.
+      </description>
+    </option>
+    <option variable="chan2Color" type="enum"
+      label="Channel 2 Color">
+      <value label="Red">RED</value>
+      <value label="Carrot" default="true">CARROT</value>
+      <value label="Orange">ORANGE</value>
+      <value label="Honey">HONEY</value>
+      <value label="Yellow">YELLOW</value>
+      <value label="Lime">LIME</value>
+      <value label="Green">GREEN</value>
+      <value label="Aqua">AQUA</value>
+      <value label="Celeste">CELESTE</value>
+      <value label="Sky">SKY</value>
+      <value label="Blue">BLUE</value>
+      <value label="Purple">PURPLE</value>
+      <value label="Fuchsia">FUCHSIA</value>
+      <value label="Magenta">MAGENTA</value>
+      <value label="Azalea">AZALEA</value>
+      <value label="Salmon">SALMON</value>
+      <value label="White">WHITE</value>
+      <description>
+        Sets the color of buttons on the channel.
+      </description>
+    </option>
+    <option variable="chan3Color" type="enum"
+      label="Channel 3 Color">
+      <value label="Red">RED</value>
+      <value label="Carrot">CARROT</value>
+      <value label="Orange">ORANGE</value>
+      <value label="Honey">HONEY</value>
+      <value label="Yellow">YELLOW</value>
+      <value label="Lime">LIME</value>
+      <value label="Green">GREEN</value>
+      <value label="Aqua">AQUA</value>
+      <value label="Celeste">CELESTE</value>
+      <value label="Sky">SKY</value>
+      <value label="Blue" default="true">BLUE</value>
+      <value label="Purple">PURPLE</value>
+      <value label="Fuchsia">FUCHSIA</value>
+      <value label="Magenta">MAGENTA</value>
+      <value label="Azalea">AZALEA</value>
+      <value label="Salmon">SALMON</value>
+      <value label="White">WHITE</value>
+      <description>
+        Sets the color of buttons on the channel.
+      </description>
+    </option>
+    <option variable="chan4Color" type="enum"
+      label="Channel 4 Color">
+      <value label="Red">RED</value>
+      <value label="Carrot">CARROT</value>
+      <value label="Orange">ORANGE</value>
+      <value label="Honey">HONEY</value>
+      <value label="Yellow">YELLOW</value>
+      <value label="Lime">LIME</value>
+      <value label="Green">GREEN</value>
+      <value label="Aqua">AQUA</value>
+      <value label="Celeste">CELESTE</value>
+      <value label="Sky">SKY</value>
+      <value label="Blue" default="true">BLUE</value>
+      <value label="Purple">PURPLE</value>
+      <value label="Fuchsia">FUCHSIA</value>
+      <value label="Magenta">MAGENTA</value>
+      <value label="Azalea">AZALEA</value>
+      <value label="Salmon">SALMON</value>
+      <value label="White">WHITE</value>
+      <description>
+        Sets the color of buttons on the channel.
+      </description>
+    </option>
+</settings>
 </MixxxControllerPreset>

--- a/res/controllers/Traktor-Kontrol-S3-hid-scripts.js
+++ b/res/controllers/Traktor-Kontrol-S3-hid-scripts.js
@@ -42,14 +42,14 @@ var TraktorS3 = {};
 // Disable this option to use the second, Mixxx-specific mode. See the readme at
 // https://manual.mixxx.org/latest/en/hardware/controllers/native_instruments_traktor_kontrol_s3.html
 // for more information on how to use these modes.
-TraktorS3.QuickEffectMode = true;
+TraktorS3.QuickEffectMode = engine.getSetting("fxMode") === "QUICK_EFFECT";
 // When enabled, set all channels to the first FX chain on startup. Otherwise
 // the quick FX chain assignments from the last Mixxx run are preserved.
-TraktorS3.QuickEffectModeDefaultToFilter = true;
+TraktorS3.QuickEffectModeDefaultToFilter = engine.getSetting("fxResetOnStart");
 // When enabled, the FX Enable buttons will use the colors set in
 // `TraktorS3.ChannelColors` when the filter effect is selected. Disabling this
 // will use the Filter button's orange color instead.
-TraktorS3.QuickEffectModeChannelColors = false;
+TraktorS3.QuickEffectModeChannelColors = engine.getSetting("fxUseChannelColors");
 
 // The pitch slider can operate either in absolute or relative mode.
 // In absolute mode:
@@ -64,32 +64,32 @@ TraktorS3.QuickEffectModeChannelColors = false;
 // * Hold shift to move the pitch slider without adjusting the rate
 // * Hold keylock and move the pitch slider to adjust musical pitch
 // * keylock will still toggle on, but on release, not press.
-TraktorS3.PitchSliderRelativeMode = false;
+TraktorS3.PitchSliderRelativeMode = engine.getSetting("pitchMode") === "PITCH_RELATIVE";
 
 // The Samplers can operate two ways.
 // With SamplerModePressAndHold = false, tapping a Sampler button will start the
 // sample playing.  Pressing the button again will stop playback.
 // With SamplerModePressAndHold = true, a Sample will play while you hold the
 // button down.  Letting go will stop playback.
-TraktorS3.SamplerModePressAndHold = false;
+TraktorS3.SamplerModePressAndHold = engine.getSetting("samplerModePressAndHold");
 
 // When this option is true, start up with the jog button lit, which means touching the job wheel
 // enables scratch mode.
-TraktorS3.JogDefaultOn = true;
+TraktorS3.JogDefaultOn = engine.getSetting("jogDefaultOn");
 
 // If true, the sampler buttons on Deck 1 are samplers 1-8 and the sampler buttons on Deck 2 are
 // 9-16.  If false, both decks are samplers 1-8.
-TraktorS3.SixteenSamplers = false;
+TraktorS3.SixteenSamplers = engine.getSetting("sixteenSamplers");
 
 // You can choose the colors you want for each channel. The list of colors is:
 // RED, CARROT, ORANGE, HONEY, YELLOW, LIME, GREEN, AQUA, CELESTE, SKY, BLUE,
 // PURPLE, FUCHSIA, MAGENTA, AZALEA, SALMON, WHITE
 // Some colors may look odd because of how they are encoded inside the controller.
 TraktorS3.ChannelColors = {
-    "[Channel1]": "CARROT",
-    "[Channel2]": "CARROT",
-    "[Channel3]": "BLUE",
-    "[Channel4]": "BLUE"
+    "[Channel1]": engine.getSetting("chan1Color"),
+    "[Channel2]": engine.getSetting("chan2Color"),
+    "[Channel3]": engine.getSetting("chan3Color"),
+    "[Channel4]": engine.getSetting("chan4Color")
 };
 
 // Each color has four brightnesses, so these values can be between 0 and 3.


### PR DESCRIPTION
Had an S3 Mk3 land on my desk today and wanted to be able to change some settings without messing with copying files around or having my package manager revert it on Mixxx upgrades or what not. This converts most of the settings for the Traktor Kontrol S3 to use the newer GUI settings.

Corresponding manual PR: mixxxdj/manual#775