### PR TITLE
Fix borrowable_ptr

### DIFF
--- a/src/test/borrowabletest.cpp
+++ b/src/test/borrowabletest.cpp
@@ -43,6 +43,7 @@ TEST_F(BorrowableTest, TwoThreads) {
             int* p2 = borrowed1.get();
             qDebug() << "future2 a" << (p1 ? *p1 : 0) << (p2 ? *p2 : 0);
         }
+        // Force a task change to main to check for a fixed deadlock.
         QThread::usleep(1);
         for (int k = 0; k < 2; ++k) {
             borrowed_ptr borrowed1 = borrowable.borrow();

--- a/src/test/borrowabletest.cpp
+++ b/src/test/borrowabletest.cpp
@@ -22,7 +22,6 @@ TEST_F(BorrowableTest, SingleThread) {
 
 TEST_F(BorrowableTest, TwoThreads) {
     int i = 1;
-    int j = 2;
 
     auto borrowable = borrowable_ptr(&i);
 
@@ -42,7 +41,15 @@ TEST_F(BorrowableTest, TwoThreads) {
             borrowed_ptr borrowed2 = borrowable.borrow();
             int* p1 = borrowed1.get();
             int* p2 = borrowed1.get();
-            qDebug() << "future2" << (p1 ? *p1 : 0) << (p2 ? *p2 : 0);
+            qDebug() << "future2 a" << (p1 ? *p1 : 0) << (p2 ? *p2 : 0);
+        }
+        QThread::usleep(1);
+        for (int k = 0; k < 2; ++k) {
+            borrowed_ptr borrowed1 = borrowable.borrow();
+            borrowed_ptr borrowed2 = borrowable.borrow();
+            int* p1 = borrowed1.get();
+            int* p2 = borrowed1.get();
+            qDebug() << "future2 b" << (p1 ? *p1 : 0) << (p2 ? *p2 : 0);
         }
     });
 
@@ -51,8 +58,7 @@ TEST_F(BorrowableTest, TwoThreads) {
         qDebug() << "main";
     }
 
-    // replace borrowable object
-    borrowable = borrowable_ptr(&j);
+    borrowable.reset();
 
     // Wait for both tasks to complete
     future1.waitForFinished();

--- a/src/test/borrowabletest.cpp
+++ b/src/test/borrowabletest.cpp
@@ -30,7 +30,7 @@ TEST_F(BorrowableTest, TwoThreads) {
             borrowed_ptr borrowed1 = borrowable.borrow();
             borrowed_ptr borrowed2 = borrowable.borrow();
             int* p1 = borrowed1.get();
-            int* p2 = borrowed1.get();
+            int* p2 = borrowed2.get();
             qDebug() << "future1" << (p1 ? *p1 : 0) << (p2 ? *p2 : 0);
         }
     });
@@ -40,7 +40,7 @@ TEST_F(BorrowableTest, TwoThreads) {
             borrowed_ptr borrowed1 = borrowable.borrow();
             borrowed_ptr borrowed2 = borrowable.borrow();
             int* p1 = borrowed1.get();
-            int* p2 = borrowed1.get();
+            int* p2 = borrowed2.get();
             qDebug() << "future2 a" << (p1 ? *p1 : 0) << (p2 ? *p2 : 0);
         }
         // Force a task change to main to check for a fixed deadlock.
@@ -49,7 +49,7 @@ TEST_F(BorrowableTest, TwoThreads) {
             borrowed_ptr borrowed1 = borrowable.borrow();
             borrowed_ptr borrowed2 = borrowable.borrow();
             int* p1 = borrowed1.get();
-            int* p2 = borrowed1.get();
+            int* p2 = borrowed2.get();
             qDebug() << "future2 b" << (p1 ? *p1 : 0) << (p2 ? *p2 : 0);
         }
     });

--- a/src/util/borrowable_ptr.h
+++ b/src/util/borrowable_ptr.h
@@ -136,4 +136,6 @@ class borrowable_ptr {
     std::shared_ptr<Tp> m_sharedPtr; ///< Non-owning private shared pointer to the managed object.
     // must not be changed after construction, because changing shared pointers is not thread safe.
     const std::weak_ptr<Tp> m_weakPtr; ///< Non-owning shared pointer for sharing,
+
+    Q_DISABLE_COPY_MOVE(borrowable_ptr)
 };

--- a/src/util/borrowable_ptr.h
+++ b/src/util/borrowable_ptr.h
@@ -108,7 +108,6 @@ class borrowable_ptr {
 
     ~borrowable_ptr() {
         reset();
-        // m_mutex.unlock();
     }
 
     // @brief Borrow a strong reference to the managed object.


### PR DESCRIPTION
Use an immutable std::weak_ptr for creating borrowed_ptr to avoid a race condition with reset(). Also remove copy constructor, because writing the shared_ptr itself is not thread safe.

Shall fix https://github.com/mixxxdj/mixxx/issues/14828

Thanks to @Hapsa21 for pointing giving the hints in #14906

