### PR TITLE
Fix destruction race

### DIFF
--- a/src/control/pollingcontrolproxy.h
+++ b/src/control/pollingcontrolproxy.h
@@ -10,8 +10,8 @@
 /// It is basically a PIMPL version of a ControlDoublePrivate Shared pointer
 class PollingControlProxy {
   public:
-    PollingControlProxy(ControlFlags flags = ControlFlag::None)
-            : PollingControlProxy(ConfigKey(), flags) {
+    PollingControlProxy()
+            : m_pControl(ControlDoublePrivate::getDefaultControl()) {
     }
 
     PollingControlProxy(const QString& g, const QString& i, ControlFlags flags = ControlFlag::None)

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -56,13 +56,13 @@ mixxx::Bpm averageBpmRoundedWithinRange(double averageLength, double rateRatio) 
 BpmControl::BpmControl(const QString& group,
         UserSettingsPointer pConfig)
         : EngineControl(group, pConfig),
-          m_pReverseButton(group, QStringLiteral("reverse")),
-          m_pQuantize(group, QStringLiteral("quantize")),
-          m_pNextBeat(group, QStringLiteral("beat_next")),
-          m_pPrevBeat(group, QStringLiteral("beat_prev")),
-          m_pLoopEnabled(group, QStringLiteral("loop_enabled")),
-          m_pLoopStartPosition(group, QStringLiteral("loop_start_position")),
-          m_pLoopEndPosition(group, QStringLiteral("loop_end_position")),
+          m_reverseButton(group, QStringLiteral("reverse")),
+          m_quantize(group, QStringLiteral("quantize")),
+          m_nextBeat(group, QStringLiteral("beat_next")),
+          m_prevBeat(group, QStringLiteral("beat_prev")),
+          m_loopEnabled(group, QStringLiteral("loop_enabled")),
+          m_loopStartPosition(group, QStringLiteral("loop_start_position")),
+          m_loopEndPosition(group, QStringLiteral("loop_end_position")),
           // Measures distance from last beat in percentage: 0.5 = half-beat away.
           m_pThisBeatDistance(group, QStringLiteral("beat_distance")),
           m_pSyncMode(group, QStringLiteral("sync_mode")),
@@ -503,17 +503,17 @@ double BpmControl::calcSyncedRate(double userTweak) {
 
     // If we are not quantized, or there are no beats, or we're leader,
     // or we're in reverse, just return the rate as-is.
-    if (!m_pQuantize.toBool() || !m_pBeats || m_pReverseButton.toBool()) {
+    if (!m_quantize.toBool() || !m_pBeats || m_reverseButton.toBool()) {
         m_resetSyncAdjustment = true;
         return rate + userTweak;
     }
 
     const auto prevBeatPosition =
             mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-                    m_pPrevBeat.get());
+                    m_prevBeat.get());
     const auto nextBeatPosition =
             mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-                    m_pNextBeat.get());
+                    m_nextBeat.get());
 
     if (!prevBeatPosition.isValid() || !nextBeatPosition.isValid()) {
         m_resetSyncAdjustment = true;
@@ -524,13 +524,13 @@ double BpmControl::calcSyncedRate(double userTweak) {
 
     // Now that we have our beat distance we can also check how large the
     // current loop is.  If we are in a <1 beat loop, don't worry about offset.
-    if (m_pLoopEnabled.toBool()) {
+    if (m_loopEnabled.toBool()) {
         const auto loopStartPosition =
                 mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-                        m_pLoopStartPosition.get());
+                        m_loopStartPosition.get());
         const auto loopEndPosition =
                 mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-                        m_pLoopEndPosition.get());
+                        m_loopEndPosition.get());
         // This should always be true when a loop is enabled, but we check it
         // anyway to prevent race conditions.
         if (loopStartPosition.isValid() && loopEndPosition.isValid()) {
@@ -639,10 +639,10 @@ double BpmControl::getBeatDistance(mixxx::audio::FramePos thisPosition) const {
     }
     mixxx::audio::FramePos prevBeatPosition =
             mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-                    m_pPrevBeat.get());
+                    m_prevBeat.get());
     mixxx::audio::FramePos nextBeatPosition =
             mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-                    m_pNextBeat.get());
+                    m_nextBeat.get());
 
     if (!prevBeatPosition.isValid() || !nextBeatPosition.isValid()) {
         return 0.0 - m_dUserOffset.getValue();
@@ -744,10 +744,10 @@ mixxx::audio::FramePos BpmControl::getNearestPositionInPhase(
     // Get the current position of this deck.
     mixxx::audio::FramePos thisPrevBeatPosition =
             mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-                    m_pPrevBeat.get());
+                    m_prevBeat.get());
     mixxx::audio::FramePos thisNextBeatPosition =
             mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-                    m_pNextBeat.get());
+                    m_nextBeat.get());
     mixxx::audio::FrameDiff_t thisBeatLengthFrames;
     if (!thisPrevBeatPosition.isValid() || !thisNextBeatPosition.isValid() ||
             thisPosition > thisNextBeatPosition ||
@@ -854,13 +854,13 @@ mixxx::audio::FramePos BpmControl::getNearestPositionInPhase(
     }
 
     // We might be seeking outside the loop.
-    const bool loopEnabled = m_pLoopEnabled.toBool();
+    const bool loopEnabled = m_loopEnabled.toBool();
     const auto loopStartPosition =
             mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-                    m_pLoopStartPosition.get());
+                    m_loopStartPosition.get());
     const auto loopEndPosition =
             mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-                    m_pLoopEndPosition.get());
+                    m_loopEndPosition.get());
 
     // Cases for sanity:
     //
@@ -939,10 +939,10 @@ mixxx::audio::FramePos BpmControl::getBeatMatchPosition(
     // Get the current position of this deck.
     mixxx::audio::FramePos thisPrevBeatPosition =
             mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-                    m_pPrevBeat.get());
+                    m_prevBeat.get());
     mixxx::audio::FramePos thisNextBeatPosition =
             mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-                    m_pNextBeat.get());
+                    m_nextBeat.get());
     mixxx::audio::FrameDiff_t thisBeatLengthFrames;
 
     // Look up the next beat and beat length for the new position
@@ -1062,13 +1062,13 @@ mixxx::audio::FramePos BpmControl::getBeatMatchPosition(
     }
 
     // We might be seeking outside the loop.
-    const bool loopEnabled = m_pLoopEnabled.toBool();
+    const bool loopEnabled = m_loopEnabled.toBool();
     const auto loopStartPosition =
             mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-                    m_pLoopStartPosition.get());
+                    m_loopStartPosition.get());
     const auto loopEndPosition =
             mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-                    m_pLoopEndPosition.get());
+                    m_loopEndPosition.get());
 
     // Cases for sanity:
     //
@@ -1311,10 +1311,10 @@ void BpmControl::collectFeatures(GroupFeatureState* pGroupFeatures, double speed
     // Get the current position of this deck.
     mixxx::audio::FramePos prevBeatPosition =
             mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-                    m_pPrevBeat.get());
+                    m_prevBeat.get());
     mixxx::audio::FramePos nextBeatPosition =
             mixxx::audio::FramePos::fromEngineSamplePosMaybeInvalid(
-                    m_pNextBeat.get());
+                    m_nextBeat.get());
     mixxx::audio::FrameDiff_t beatLengthFrames;
     double beatFraction;
     if (getBeatContextNoLookup(info.currentPosition,

--- a/src/engine/controls/bpmcontrol.h
+++ b/src/engine/controls/bpmcontrol.h
@@ -131,18 +131,18 @@ class BpmControl : public EngineControl {
     friend class SyncControl;
 
     // ControlObjects that come from EngineBuffer
-    PollingControlProxy m_pReverseButton;
+    PollingControlProxy m_reverseButton;
     std::unique_ptr<ControlProxy> m_pRateRatio;
-    PollingControlProxy m_pQuantize;
+    PollingControlProxy m_quantize;
 
     // ControlObjects that come from QuantizeControl
-    PollingControlProxy m_pNextBeat;
-    PollingControlProxy m_pPrevBeat;
+    PollingControlProxy m_nextBeat;
+    PollingControlProxy m_prevBeat;
 
     // ControlObjects that come from LoopingControl
-    PollingControlProxy m_pLoopEnabled;
-    PollingControlProxy m_pLoopStartPosition;
-    PollingControlProxy m_pLoopEndPosition;
+    PollingControlProxy m_loopEnabled;
+    PollingControlProxy m_loopStartPosition;
+    PollingControlProxy m_loopEndPosition;
 
     // The average bpm around the current playposition;
     std::unique_ptr<ControlObject> m_pLocalBpm;

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -184,9 +184,9 @@ EngineBuffer::EngineBuffer(const QString& group,
     // Quantization Controller for enabling and disabling the
     // quantization (alignment) of loop in/out positions and (hot)cues with
     // beats.
-    QuantizeControl* quantize_control = new QuantizeControl(group, pConfig);
-    addControl(quantize_control);
-    m_pQuantize = ControlObject::getControl(ConfigKey(group, "quantize"));
+    QuantizeControl* pQuantize_control = new QuantizeControl(group, pConfig);
+    addControl(pQuantize_control);
+    m_quantize = PollingControlProxy(ConfigKey(group, "quantize"));
 
     // Create the Loop Controller
     m_pLoopingControl = new LoopingControl(group, pConfig);
@@ -787,7 +787,7 @@ void EngineBuffer::slotControlPlayRequest(double v) {
     bool verifiedPlay = updateIndicatorsAndModifyPlay(v > 0.0, oldPlay);
 
     if (!oldPlay && verifiedPlay) {
-        if (m_pQuantize->toBool()
+        if (m_quantize.toBool()
 #ifdef __VINYLCONTROL__
                 && m_pVinylControlControl && !m_pVinylControlControl->isEnabled()
 #endif
@@ -1159,7 +1159,7 @@ void EngineBuffer::processTrackLocked(
     // Ife it's really desired, should this be moved to looping control in order
     // to set the sync'ed playposition right away and fill the wrap-around buffer
     // with correct samples from the sync'ed loop in / track start position?
-    if (m_pRepeat->toBool() && m_pQuantize->toBool() &&
+    if (m_pRepeat->toBool() && m_quantize.toBool() &&
             (m_playPos > playpos_old) == backwards) {
         // TODO() The resulting seek is processed in the following callback
         // That is to late
@@ -1341,7 +1341,7 @@ void EngineBuffer::processSeek(bool paused) {
             position = m_playPos;
             break;
         case SEEK_STANDARD:
-            if (m_pQuantize->toBool()) {
+            if (m_quantize.toBool()) {
                 seekType |= SEEK_PHASE;
             }
             // new position was already set above

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -292,6 +292,9 @@ EngineBuffer::~EngineBuffer() {
     //close the writer
     df.close();
 #endif
+
+    qDeleteAll(m_engineControls.rbegin(), m_engineControls.rend());
+
     delete m_pReadAheadManager;
     delete m_pReader;
 
@@ -322,8 +325,6 @@ EngineBuffer::~EngineBuffer() {
     delete m_pReplayGain;
 
     SampleUtil::free(m_pCrossfadeBuffer);
-
-    qDeleteAll(m_engineControls);
 }
 
 void EngineBuffer::bindWorkers(EngineWorkerScheduler* pWorkerScheduler) {

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -9,6 +9,7 @@
 #include "audio/frame.h"
 #include "audio/types.h"
 #include "control/controlvalue.h"
+#include "control/pollingcontrolproxy.h"
 #include "engine/cachingreader/cachingreader.h"
 #include "engine/engineobject.h"
 #include "engine/slipmodestate.h"
@@ -410,7 +411,7 @@ class EngineBuffer : public EngineObject {
 
     ControlPushButton* m_pSlipButton;
 
-    ControlObject* m_pQuantize;
+    PollingControlProxy m_quantize;
     ControlPotmeter* m_playposSlider;
     ControlProxy* m_pSampleRate;
     ControlProxy* m_pKeylockEngine;

--- a/src/test/readaheadmanager_test.cpp
+++ b/src/test/readaheadmanager_test.cpp
@@ -91,9 +91,6 @@ class ReadAheadManagerTest : public MixxxTest {
                                                        m_pLoopControl.data()));
     }
 
-    QScopedPointer<StubReader> m_pReader;
-    QScopedPointer<StubLoopControl> m_pLoopControl;
-    QScopedPointer<ReadAheadManager> m_pReadAheadManager;
     ControlObject m_beatClosestCO;
     ControlObject m_beatNextCO;
     ControlObject m_beatPrevCO;
@@ -103,6 +100,9 @@ class ReadAheadManagerTest : public MixxxTest {
     ControlObject m_slipEnabledCO;
     ControlObject m_trackSamplesCO;
     CSAMPLE* m_pBuffer;
+    QScopedPointer<StubReader> m_pReader;
+    QScopedPointer<StubLoopControl> m_pLoopControl;
+    QScopedPointer<ReadAheadManager> m_pReadAheadManager;
 };
 
 TEST_F(ReadAheadManagerTest, FractionalFrameLoop) {

--- a/src/widget/wcuemenupopup.cpp
+++ b/src/widget/wcuemenupopup.cpp
@@ -17,11 +17,7 @@ void CueTypePushButton::mousePressEvent(QMouseEvent* e) {
 
 WCueMenuPopup::WCueMenuPopup(UserSettingsPointer pConfig, QWidget* parent)
         : QWidget(parent),
-          m_colorPaletteSettings(ColorPaletteSettings(pConfig)),
-          m_pBeatLoopSize(ControlFlag::AllowMissingOrInvalid),
-          m_pPlayPos(ControlFlag::AllowMissingOrInvalid),
-          m_pTrackSample(ControlFlag::AllowMissingOrInvalid),
-          m_pQuantizeEnabled(ControlFlag::AllowMissingOrInvalid) {
+          m_colorPaletteSettings(ColorPaletteSettings(pConfig)) {
     QWidget::hide();
     setWindowFlags(Qt::Popup);
     setAttribute(Qt::WA_StyledBackground);


### PR DESCRIPTION
This fixes a few race conditions that causing a dangling pointer. This has been discovered when introducing the borrowable_ptr in main, where such situation causing a dead lock. With luck this fixes a hard to reproduce crash during shutdown, that's why I have decided to backport this to the 2.5 branch. 
