### PR TITLE
(fix) update cue & play indicators on paused decks when switching cue mode

### DIFF
--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -107,10 +107,10 @@ CueControl::CueControl(const QString& group,
     m_pBeatLoopActivate = make_parented<ControlProxy>(group, "beatloop_activate", this);
     m_pBeatLoopSize = make_parented<ControlProxy>(group, "beatloop_size", this);
 
-    m_pCuePoint = new ControlObject(ConfigKey(group, "cue_point"));
+    m_pCuePoint = std::make_unique<ControlObject>(ConfigKey(group, "cue_point"));
     m_pCuePoint->set(Cue::kNoPosition);
 
-    m_pCueMode = new ControlObject(ConfigKey(group, "cue_mode"));
+    m_pCueMode = std::make_unique<ControlObject>(ConfigKey(group, "cue_mode"));
 
     m_pPassthrough = make_parented<ControlProxy>(group, "passthrough", this);
     m_pPassthrough->connectValueChanged(this,
@@ -119,8 +119,6 @@ CueControl::CueControl(const QString& group,
 }
 
 CueControl::~CueControl() {
-    delete m_pCuePoint;
-    delete m_pCueMode;
     qDeleteAll(m_hotcueControls);
 }
 

--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -111,6 +111,10 @@ CueControl::CueControl(const QString& group,
     m_pCuePoint->set(Cue::kNoPosition);
 
     m_pCueMode = std::make_unique<ControlObject>(ConfigKey(group, "cue_mode"));
+    connect(m_pCueMode.get(),
+            &ControlObject::valueChanged,
+            this,
+            &CueControl::slotCueModeChanged);
 
     m_pPassthrough = make_parented<ControlProxy>(group, "passthrough", this);
     m_pPassthrough->connectValueChanged(this,
@@ -590,6 +594,16 @@ void CueControl::seekOnLoad(mixxx::audio::FramePos seekOnLoadPosition) {
     DEBUG_ASSERT(seekOnLoadPosition.isValid());
     seekExact(seekOnLoadPosition);
     m_usedSeekOnLoadPosition.setValue(seekOnLoadPosition);
+}
+
+void CueControl::slotCueModeChanged(double) {
+    // This will call updateIndicatorsAndModifyPlay() with the current play state
+    // and update cue/play indicators.
+    // This is required for updating the indicators when the cue mode was changed
+    // while the deck is paused.
+    if (m_pPlay && !m_pPlay->toBool()) {
+        getEngineBuffer()->verifyPlay();
+    }
 }
 
 void CueControl::cueUpdated() {

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -215,6 +215,7 @@ class CueControl : public EngineControl {
 
   private slots:
     void quantizeChanged(double v);
+    void slotCueModeChanged(double v);
 
     void cueUpdated();
     void trackAnalyzed();

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -308,8 +308,8 @@ class CueControl : public EngineControl {
     QList<HotcueControl*> m_hotcueControls;
 
     ControlObject* m_pTrackSamples;
-    ControlObject* m_pCuePoint;
-    ControlObject* m_pCueMode;
+    std::unique_ptr<ControlObject> m_pCuePoint;
+    std::unique_ptr<ControlObject> m_pCueMode;
     std::unique_ptr<ControlPushButton> m_pCueSet;
     std::unique_ptr<ControlPushButton> m_pCueClear;
     std::unique_ptr<ControlPushButton> m_pCueCDJ;

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -220,6 +220,8 @@ class EngineBuffer : public EngineObject {
     void seekAbs(mixxx::audio::FramePos);
     void seekExact(mixxx::audio::FramePos);
 
+    void verifyPlay();
+
   public slots:
     void slotControlPlayRequest(double);
     void slotControlPlayFromStart(double);
@@ -284,7 +286,6 @@ class EngineBuffer : public EngineObject {
         return m_previousBufferSeek;
     }
     bool updateIndicatorsAndModifyPlay(bool newPlay, bool oldPlay);
-    void verifyPlay();
     void notifyTrackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack);
     void processTrackLocked(CSAMPLE* pOutput,
             const int iBufferSize,


### PR DESCRIPTION
Fixes #9928 
`play_indicator` is not updated on paused decks when switching cue mode.

* `CueControl::updateIndicatorsAndModifyPlay()` is called when the playpos changed, so eg. when playing or after seeking.
It update `play_indicator`, amongst other things.
* `CueControl::updateIndicators()` otoh is called on every process()/postProcess(), ie. also when not playing, ie. the engine assumes it's not necessary to update `play_indicator`.
But it _is_ necessary when we change the cue mode while decks are paused.

For main decks this is just a minor inconvenience, because indicators are updated as soon as decks play or preview.
But for loaded samplers it's a bit annoying because usually the playpos / playstate is not changed there (ie. no indicator update until restart).

I'm targetting 2.5 even though this can very well wait for 2.6.
I can isolate the fix commit if desired.