### PR TITLE
Twister: Add stems layer

### DIFF
--- a/res/controllers/DJ TechTools MIDI Fighter Twister.midi.xml
+++ b/res/controllers/DJ TechTools MIDI Fighter Twister.midi.xml
@@ -132,6 +132,34 @@
       <value color="#ff00ff" label="Fuscia">100</value>
       <value color="#a400c0" label="Purple">108</value>
     </option>
+    <option variable="stemFxOffColor" type="enum" label="Stem FX Kill Switch Off Color">
+      <description>The color of the activated stem FX kill switch.</description>
+      <value label="Firmware Default">0</value>
+      <value color="#0040f0" label="Blue">1</value>
+      <value color="#3ec8e6" label="Celeste">32</value>
+      <value color="#008080" label="Teal">40</value>
+      <value color="#2fb340" label="Green">50</value>
+      <value color="#3fff58" label="Lime">60</value>
+      <value color="#e9c600" label="Yellow">66</value>
+      <value color="#f07800" label="Orange">74</value>
+      <value color="#b90908" label="Red" default="true">85</value>
+      <value color="#ff00ff" label="Fuscia">100</value>
+      <value color="#a400c0" label="Purple">108</value>
+    </option>
+    <option variable="stemFxOnColor" type="enum" label="Stem FX Kill Switch On Color">
+      <description>The color of the active stem FX kill switch.</description>
+      <value label="Firmware Default">127</value>
+      <value color="#0040f0" label="Blue">1</value>
+      <value color="#3ec8e6" label="Celeste">32</value>
+      <value color="#008080" label="Teal">40</value>
+      <value color="#2fb340" label="Green" default="true">50</value>
+      <value color="#3fff58" label="Lime">60</value>
+      <value color="#e9c600" label="Yellow">66</value>
+      <value color="#f07800" label="Orange">74</value>
+      <value color="#b90908" label="Red">85</value>
+      <value color="#ff00ff" label="Fuscia">100</value>
+      <value color="#a400c0" label="Purple">108</value>
+    </option>
   </settings>
   <controller id="DJ TechTools MIDI Fighter Twister">
     <scriptfiles>
@@ -481,6 +509,26 @@
           <script-binding/>
         </options>
       </control>
+      <control>
+        <group>[Channel1_Stem]</group>
+        <key>MidiFighterTwister.controller.toggleDeck</key>
+        <description>Toggle the left side of the controller between decks 1 and 3.</description>
+        <status>0xB3</status>
+        <midino>0x14</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel2_Stem]</group>
+        <key>MidiFighterTwister.controller.toggleDeck</key>
+        <description>Toggle the right side of the controller between decks 2 and 4.</description>
+        <status>0xB3</status>
+        <midino>0x17</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
 
       <!-- Layer 2: Effects -->
       <control>
@@ -756,6 +804,349 @@
         <description>Shift button for layer 2.</description>
         <status>0xB3</status>
         <midino>0x13</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterTwister.controller.toggleShift</key>
+        <description>Shift button for layer 3.</description>
+        <status>0xB3</status>
+        <midino>0x16</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>MidiFighterTwister.controller.toggleShift</key>
+        <description>Shift button for layer 3.</description>
+        <status>0xB3</status>
+        <midino>0x19</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+
+      <!-- Layer 3: Stems -->
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterTwister.controller.leftStemDeck.volume[0].input</key>
+        <description>Stem 1 volume.</description>
+        <status>0xB0</status>
+        <midino>0x20</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterTwister.controller.leftStemDeck.volume[1].input</key>
+        <description>Stem 2 volume.</description>
+        <status>0xB0</status>
+        <midino>0x24</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterTwister.controller.leftStemDeck.volume[2].input</key>
+        <description>Stem 3 volume.</description>
+        <status>0xB0</status>
+        <midino>0x28</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterTwister.controller.leftStemDeck.volume[3].input</key>
+        <description>Stem 4 volume.</description>
+        <status>0xB0</status>
+        <midino>0x2C</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterTwister.controller.leftStemDeck.mute[0].input</key>
+        <description>Stem 1 mute.</description>
+        <status>0xB1</status>
+        <midino>0x20</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterTwister.controller.leftStemDeck.mute[1].input</key>
+        <description>Stem 2 mute.</description>
+        <status>0xB1</status>
+        <midino>0x24</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterTwister.controller.leftStemDeck.mute[2].input</key>
+        <description>Stem 3 mute.</description>
+        <status>0xB1</status>
+        <midino>0x28</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterTwister.controller.leftStemDeck.mute[3].input</key>
+        <description>Stem 4 mute.</description>
+        <status>0xB1</status>
+        <midino>0x2C</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterTwister.controller.leftStemDeck.effect[0].input</key>
+        <description>Stem 1 FX.</description>
+        <status>0xB0</status>
+        <midino>0x21</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterTwister.controller.leftStemDeck.effect[1].input</key>
+        <description>Stem 2 FX.</description>
+        <status>0xB0</status>
+        <midino>0x25</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterTwister.controller.leftStemDeck.effect[2].input</key>
+        <description>Stem 3 FX.</description>
+        <status>0xB0</status>
+        <midino>0x29</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterTwister.controller.leftStemDeck.effect[3].input</key>
+        <description>Stem 4 FX.</description>
+        <status>0xB0</status>
+        <midino>0x2D</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterTwister.controller.leftStemDeck.effectReset[0].input</key>
+        <description>Stem 1 FX reset.</description>
+        <status>0xB1</status>
+        <midino>0x21</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterTwister.controller.leftStemDeck.effectReset[1].input</key>
+        <description>Stem 2 FX reset.</description>
+        <status>0xB1</status>
+        <midino>0x25</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterTwister.controller.leftStemDeck.effectReset[2].input</key>
+        <description>Stem 3 FX reset.</description>
+        <status>0xB1</status>
+        <midino>0x29</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>MidiFighterTwister.controller.leftStemDeck.effectReset[3].input</key>
+        <description>Stem 4 FX reset.</description>
+        <status>0xB1</status>
+        <midino>0x2D</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+
+      <control>
+        <group>[Channel2]</group>
+        <key>MidiFighterTwister.controller.rightStemDeck.volume[0].input</key>
+        <description>Stem 1 volume.</description>
+        <status>0xB0</status>
+        <midino>0x23</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>MidiFighterTwister.controller.rightStemDeck.volume[1].input</key>
+        <description>Stem 2 volume.</description>
+        <status>0xB0</status>
+        <midino>0x27</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>MidiFighterTwister.controller.rightStemDeck.volume[2].input</key>
+        <description>Stem 3 volume.</description>
+        <status>0xB0</status>
+        <midino>0x2B</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>MidiFighterTwister.controller.rightStemDeck.volume[3].input</key>
+        <description>Stem 4 volume.</description>
+        <status>0xB0</status>
+        <midino>0x2F</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>MidiFighterTwister.controller.rightStemDeck.mute[0].input</key>
+        <description>Stem 1 mute.</description>
+        <status>0xB1</status>
+        <midino>0x23</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>MidiFighterTwister.controller.rightStemDeck.mute[1].input</key>
+        <description>Stem 2 mute.</description>
+        <status>0xB1</status>
+        <midino>0x27</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>MidiFighterTwister.controller.rightStemDeck.mute[2].input</key>
+        <description>Stem 3 mute.</description>
+        <status>0xB1</status>
+        <midino>0x2B</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>MidiFighterTwister.controller.rightStemDeck.mute[3].input</key>
+        <description>Stem 4 mute.</description>
+        <status>0xB1</status>
+        <midino>0x2F</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>MidiFighterTwister.controller.rightStemDeck.effect[0].input</key>
+        <description>Stem 1 FX.</description>
+        <status>0xB0</status>
+        <midino>0x22</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>MidiFighterTwister.controller.rightStemDeck.effect[1].input</key>
+        <description>Stem 2 FX.</description>
+        <status>0xB0</status>
+        <midino>0x26</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>MidiFighterTwister.controller.rightStemDeck.effect[2].input</key>
+        <description>Stem 3 FX.</description>
+        <status>0xB0</status>
+        <midino>0x2A</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>MidiFighterTwister.controller.rightStemDeck.effect[3].input</key>
+        <description>Stem 4 FX.</description>
+        <status>0xB0</status>
+        <midino>0x2E</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>MidiFighterTwister.controller.rightStemDeck.effectReset[0].input</key>
+        <description>Stem 1 FX reset.</description>
+        <status>0xB1</status>
+        <midino>0x22</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>MidiFighterTwister.controller.rightStemDeck.effectReset[1].input</key>
+        <description>Stem 2 FX reset.</description>
+        <status>0xB1</status>
+        <midino>0x26</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>MidiFighterTwister.controller.rightStemDeck.effectReset[2].input</key>
+        <description>Stem 3 FX reset.</description>
+        <status>0xB1</status>
+        <midino>0x2A</midino>
+        <options>
+          <script-binding/>
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>MidiFighterTwister.controller.rightStemDeck.effectReset[3].input</key>
+        <description>Stem 4 FX reset.</description>
+        <status>0xB1</status>
+        <midino>0x2E</midino>
         <options>
           <script-binding/>
         </options>

--- a/res/controllers/DJ TechTools-MIDI Fighter Twister-scripts.js
+++ b/res/controllers/DJ TechTools-MIDI Fighter Twister-scripts.js
@@ -151,18 +151,15 @@ var MidiFighterTwister;
                     group: `[QuickEffectRack1_[Channel${deckNums[0]}_Stem${i + 1}]]`,
                     midi: [0xB0, this.midiModifier(0x21 + (4 * i))],
                     key: "super1",
-                    inValueScale: function(value) {
-                        if (this.inKey === "loaded_chain_preset") {
-                            const val = (value/this.max) * engine.getParameter(this.group, "num_chain_presets");
-                            return val;
-                        }
-                        return components.Encoder.prototype.inValueScale(value);
-                    },
                     shift: function() {
                         this.inKey = "loaded_chain_preset";
                         this.outKey = "loaded_chain_preset";
                         this.on = engine.getSetting("stemFxOnColor");
                         this.off = engine.getSetting("stemFxOffColor");
+                        this.inValueScale = function(value) {
+                            const val = (value/this.max) * engine.getParameter(this.group, "num_chain_presets");
+                            return Math.trunc(val);
+                        };
                         this.disconnect();
                         this.connect();
                         this.trigger();
@@ -172,6 +169,9 @@ var MidiFighterTwister;
                         this.outKey = this.key;
                         this.on = components.Button.prototype.on;
                         this.off = components.Button.prototype.off;
+                        this.inValueScale = function(value) {
+                            return components.Encoder.prototype.inValueScale(value);
+                        };
                         this.disconnect();
                         this.connect();
                         this.trigger();

--- a/res/controllers/DJ TechTools-MIDI Fighter Twister-scripts.js
+++ b/res/controllers/DJ TechTools-MIDI Fighter Twister-scripts.js
@@ -54,6 +54,157 @@ var MidiFighterTwister;
     components.Button.prototype.on = engine.getSetting("defColor");
     components.Button.prototype.off = engine.getSetting("relColor");
 
+    class StemDeck extends components.Deck {
+        midiModifier(value) {
+            // All midi values are for the left deck, we only modify them if
+            // we're constructing the right hand deck.
+            if (this.deckNumbers[0] === 1) {
+                return value;
+            }
+
+            // Even controls (ie. the first row) are mirrored to the far right
+            // row, three rows over.
+            if (value % 2 === 0) {
+                return value + 3;
+            }
+            // Odd controls (ie. the second row) are mirrored to the other inner
+            // row, one row over.
+            return value + 1;
+        }
+
+        constructor(deckNums) {
+            super(deckNums);
+
+            this.volume = [];
+            this.mute = [];
+            this.effect = [];
+            this.effectEnabled = [];
+            this.effectVolume = [];
+            this.effectReset = [];
+            for (let i = 0; i < 4; i++) {
+                this.volume[i] = new components.Encoder({
+                    group: `[Channel${deckNums[0]}_Stem${i + 1}]`,
+                    midi: [0xB0, this.midiModifier(0x20 + (4 * i))],
+                    key: "volume",
+                });
+                // TODO: change these into mute or reset buttons based on a
+                // setting?
+                this.mute[i] = new components.Button({
+                    group: `[Channel${deckNums[0]}_Stem${i + 1}]`,
+                    midi: [0xB1, this.midiModifier(0x20 + (4 * i))],
+                    key: "mute",
+                    colorKey: "color",
+                    colorMapper: new ColorMapper({
+                        0x0040f0: 1,   // Blue
+                        0x3ec8e6: 32,  // Celeste
+                        0x008080: 40,  // Teal
+                        0x2fb340: 50,  // Green
+                        0x3fff58: 60,  // Lime
+                        0xe9c600: 66,  // Yellow
+                        0xf07800: 74,  // Orange
+                        0xfd4a4a: 85,  // Red (was being mapped to orange, perceptually closer to red)
+                        0xb90908: 85,  // Red
+                        0xff00ff: 100, // Fuscia
+                        0xa400c0: 108, // Purple
+                    }),
+                    type: components.Button.prototype.types.toggle,
+                    outValueScale: function(_value) {
+                        return this.colorMapper.getValueForNearestColor(engine.getParameter(this.group, this.colorKey));
+                    },
+                    shift: function() {
+                        this.inKey = "volume_set_default";
+                        this.outKey = "volume_set_default";
+                        this.type = components.Button.prototype.types.push;
+                        this.disconnect();
+                        this.connect();
+                        this.trigger();
+                    },
+                    unshift: function() {
+                        this.inKey = this.key;
+                        this.outKey = this.key;
+                        this.type = components.Button.prototype.types.toggle;
+                        this.disconnect();
+                        this.connect();
+                        this.trigger();
+                    },
+                    output: function(value, _group, _control) {
+                        if (value) {
+                            // Dim the LED
+                            midi.sendShortMsg(0xB2, this.midi[1], 35);
+                        } else {
+                            // Brighten the LED
+                            midi.sendShortMsg(0xB2, this.midi[1], 47);
+                        }
+                    },
+                    outputColor: function(colorCode) {
+                        const nearestColorValue = this.colorMapper.getValueForNearestColor(colorCode);
+                        this.send(nearestColorValue);
+                    },
+                    connect: function() {
+                        components.Button.prototype.connect.call(this);
+                        if (undefined !== this.group && this.colorKey !== undefined) {
+                            this.connections[1] = engine.makeConnection(this.group, this.colorKey, this.outputColor.bind(this));
+                        }
+                    },
+                });
+                this.effect[i] = new components.Encoder({
+                    group: `[QuickEffectRack1_[Channel${deckNums[0]}_Stem${i + 1}]]`,
+                    midi: [0xB0, this.midiModifier(0x21 + (4 * i))],
+                    key: "super1",
+                    inValueScale: function(value) {
+                        if (this.inKey === "loaded_chain_preset") {
+                            const val = (value/this.max) * engine.getParameter(this.group, "num_chain_presets");
+                            return val;
+                        }
+                        return components.Encoder.prototype.inValueScale(value);
+                    },
+                    shift: function() {
+                        this.inKey = "loaded_chain_preset";
+                        this.outKey = "loaded_chain_preset";
+                        this.on = engine.getSetting("stemFxOnColor");
+                        this.off = engine.getSetting("stemFxOffColor");
+                        this.disconnect();
+                        this.connect();
+                        this.trigger();
+                    },
+                    unshift: function() {
+                        this.inKey = this.key;
+                        this.outKey = this.key;
+                        this.on = components.Button.prototype.on;
+                        this.off = components.Button.prototype.off;
+                        this.disconnect();
+                        this.connect();
+                        this.trigger();
+                    },
+                });
+                this.effectReset[i] = new components.Button({
+                    group: `[QuickEffectRack1_[Channel${deckNums[0]}_Stem${i + 1}]]`,
+                    midi: [0xB1, this.midiModifier(0x21 + (4 * i))],
+                    key: "super1_set_default",
+                    type: components.Button.prototype.types.toggle,
+                    shift: function() {
+                        this.inKey = "enabled";
+                        this.outKey = "enabled";
+                        this.on = engine.getSetting("stemFxOnColor");
+                        this.off = engine.getSetting("stemFxOffColor");
+                        this.disconnect();
+                        this.connect();
+                        this.trigger();
+                    },
+                    unshift: function() {
+                        this.inKey = this.key;
+                        this.outKey = this.key;
+                        this.on = components.Button.prototype.on;
+                        this.off = components.Button.prototype.off;
+                        this.disconnect();
+                        this.connect();
+                        this.trigger();
+                    },
+                });
+            }
+        }
+    }
+
     class Deck extends components.Deck {
         midiModifier(value) {
             // All midi values are for the left deck, we only modify them if
@@ -197,10 +348,14 @@ var MidiFighterTwister;
         constructor() {
             super({});
 
+            // Layer 3 Controls (stems)
+            this.leftStemDeck = new StemDeck([1, 3]);
+            this.rightStemDeck = new StemDeck([2, 4]);
+
             this.leftDeck = new Deck([1, 3]);
             this.rightDeck = new Deck([2, 4]);
 
-            // Layer 1 Controls
+            // Layer 1 Controls (mixer)
 
             this.crossfaderKnob = new components.Encoder({
                 group: "[Master]",
@@ -267,7 +422,8 @@ var MidiFighterTwister;
                 },
             });
 
-            // Layer 2 Controls
+            // Layer 2 Controls (effects)
+
             this.fx = [];
             this.fx[0] = new components.EffectUnit([1, 3]);
             this.fx[0].enableButtons[1].midi = [0xB1, 0x11];
@@ -384,6 +540,12 @@ var MidiFighterTwister;
                 break;
             case "[Channel2]":
                 this.rightDeck.toggle();
+                break;
+            case "[Channel1_Stem]":
+                this.leftStemDeck.toggle();
+                break;
+            case "[Channel2_Stem]":
+                this.rightStemDeck.toggle();
                 break;
             default:
                 console.log(`invalid group: ${group}`);

--- a/res/controllers/DJ TechTools-MIDI Fighter Twister-scripts.js
+++ b/res/controllers/DJ TechTools-MIDI Fighter Twister-scripts.js
@@ -108,9 +108,6 @@ var MidiFighterTwister;
                         0xa400c0: 108, // Purple
                     }),
                     type: components.Button.prototype.types.toggle,
-                    outValueScale: function(_value) {
-                        return this.colorMapper.getValueForNearestColor(engine.getParameter(this.group, this.colorKey));
-                    },
                     shift: function() {
                         this.inKey = "volume_set_default";
                         this.outKey = "volume_set_default";


### PR DESCRIPTION
This adds stem controls to the MIDI Fighter Twister (which is, I suspect, what will make this a useful addon controller more than anything else). This is for 2.6, so no rush on this one really.

Manual PR: mixxxdj/manual#778