### PR TITLE
(fix/feat) fix Sound Hardware URL, add (?) linking to Sound APIs in the manual

### DIFF
--- a/src/defs_urls.h
+++ b/src/defs_urls.h
@@ -48,7 +48,7 @@
 #define MIXXX_MANUAL_CONTROLS_URL \
     MIXXX_MANUAL_URL "/chapters/advanced_topics.html#mixxx-controls"
 #define MIXXX_MANUAL_SOUND_URL \
-    MIXXX_MANUAL_URL "/chapters/preferences.html#sound-hardware"
+    MIXXX_MANUAL_URL "/chapters/preferences/sound_hardware.html"
 #define MIXXX_MANUAL_LIBRARY_URL \
     MIXXX_MANUAL_URL "/chapters/preferences.html#library"
 #define MIXXX_MANUAL_CUE_MODES_URL \

--- a/src/defs_urls.h
+++ b/src/defs_urls.h
@@ -61,6 +61,8 @@
     MIXXX_MANUAL_URL "/chapters/library.html#finding-tracks-search"
 #define MIXXX_MANUAL_MIC_MONITOR_MODES_URL \
     MIXXX_MANUAL_URL "/chapters/microphones"
+#define MIXXX_MANUAL_MIC_LATENCY_URL \
+    MIXXX_MANUAL_URL "/chapters/microphones#latency-compensation"
 #define MIXXX_MANUAL_BEATS_URL \
     MIXXX_MANUAL_URL "/chapters/preferences.html#beat-detection"
 #define MIXXX_MANUAL_KEY_URL \

--- a/src/defs_urls.h
+++ b/src/defs_urls.h
@@ -49,6 +49,8 @@
     MIXXX_MANUAL_URL "/chapters/advanced_topics.html#mixxx-controls"
 #define MIXXX_MANUAL_SOUND_URL \
     MIXXX_MANUAL_URL "/chapters/preferences/sound_hardware.html"
+#define MIXXX_MANUAL_SOUND_API_URL \
+    MIXXX_MANUAL_URL "/chapters/preferences/sound_hardware.html#sound-api"
 #define MIXXX_MANUAL_LIBRARY_URL \
     MIXXX_MANUAL_URL "/chapters/preferences.html#library"
 #define MIXXX_MANUAL_CUE_MODES_URL \

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -64,6 +64,11 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
             QOverload<int>::of(&QComboBox::currentIndexChanged),
             this,
             &DlgPrefSound::apiChanged);
+    apiLabel->setText(apiLabel->text() + QChar(' ') +
+            coloredLinkString(
+                    m_pLinkColor,
+                    QStringLiteral("(?)"),
+                    MIXXX_MANUAL_SOUND_API_URL));
 
     sampleRateComboBox->clear();
     const auto sampleRates = m_pSoundManager->getSampleRates();

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -270,6 +270,12 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
                     QStringLiteral("(?)"),
                     MIXXX_MANUAL_MIC_MONITOR_MODES_URL));
 
+    latencyCompensationLabel->setText(latencyCompensationLabel->text() + QChar(' ') +
+            coloredLinkString(
+                    m_pLinkColor,
+                    QStringLiteral("(?)"),
+                    MIXXX_MANUAL_MIC_LATENCY_URL));
+
     hardwareGuide->setText(
             tr("The %1 lists sound cards and controllers you may want to "
                "consider for using Mixxx.")

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -264,6 +264,12 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
 
     setScrollSafeGuardForAllInputWidgets(this);
 
+    micMonitorModeLabel->setText(micMonitorModeLabel->text() + QChar(' ') +
+            coloredLinkString(
+                    m_pLinkColor,
+                    QStringLiteral("(?)"),
+                    MIXXX_MANUAL_MIC_MONITOR_MODES_URL));
+
     hardwareGuide->setText(
             tr("The %1 lists sound cards and controllers you may want to "
                "consider for using Mixxx.")

--- a/src/preferences/dialog/dlgprefsounddlg.ui
+++ b/src/preferences/dialog/dlgprefsounddlg.ui
@@ -133,6 +133,9 @@
        <property name="text">
         <string>Microphone Latency Compensation</string>
        </property>
+       <property name="openExternalLinks">
+        <bool>true</bool>
+       </property>
       </widget>
      </item>
      <item row="9" column="1">

--- a/src/preferences/dialog/dlgprefsounddlg.ui
+++ b/src/preferences/dialog/dlgprefsounddlg.ui
@@ -123,6 +123,9 @@
        <property name="text">
         <string>Microphone Monitor Mode</string>
        </property>
+       <property name="openExternalLinks">
+        <bool>true</bool>
+       </property>
       </widget>
      </item>
      <item row="9" column="0">

--- a/src/preferences/dialog/dlgprefsounddlg.ui
+++ b/src/preferences/dialog/dlgprefsounddlg.ui
@@ -21,6 +21,9 @@
        <property name="text">
         <string>Sound API</string>
        </property>
+       <property name="openExternalLinks">
+        <bool>true</bool>
+       </property>
        <property name="buddy">
         <cstring>apiComboBox</cstring>
        </property>


### PR DESCRIPTION
Adds **(?)** links to the labels of
* Sound API
* Mic monitor mode
* Mic latency compensation