### PR TITLE
chore: replace deprecated `QImage::mirror` with `QImage::flip` from Qt6.9

### DIFF
--- a/src/controllers/rendering/controllerrenderingengine.cpp
+++ b/src/controllers/rendering/controllerrenderingengine.cpp
@@ -359,7 +359,11 @@ void ControllerRenderingEngine::renderFrame() {
         kLogger.debug() << "Couldn't release the FBO.";
     }
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+    fboImage.flip(Qt::Vertical);
+#else
     fboImage.mirror(false, true);
+#endif
 
     emit frameRendered(m_screenInfo, fboImage.copy(), timestamp);
 


### PR DESCRIPTION
`QImage::mirror` has been deprecated in Qt6.9