### PR TITLE
chore(ci): prevent double-run and use composite workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,7 @@
 name: Build
 
 on:
-  push:
-  pull_request:
-    types: [opened, synchronize, reopened, edited]
+  workflow_call:
 
 permissions:
   contents: read #  to fetch code (actions/checkout)

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -3,12 +3,7 @@
 name: Changelog
 
 on:
-  push:
-    branches:
-      - "main"
-      - "[0-9].[0-9]"
-    paths:
-      - "CHANGELOG.md"
+  workflow_call:
 
 permissions: {}
 jobs:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,9 +3,7 @@
 name: build-checks
 
 on:
-  push:
-  pull_request:
-    types: [opened, synchronize, reopened, edited]
+  workflow_call:
 
 permissions:
   contents: read #  to fetch code (actions/checkout)

--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -1,6 +1,7 @@
 name: Git Checks
 
-on: [pull_request]
+on:
+  workflow_call:
 
 jobs:
   block-fixup:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,8 +3,7 @@
 name: pre-commit
 
 on:
-  push:
-  pull_request:
+  workflow_call:
 
 permissions:
   contents: read #  to fetch code (actions/checkout)

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,36 @@
+name: Pull request
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+
+jobs:
+  pre-commit:
+    uses: ./.github/workflows/pre-commit.yml
+
+  checks:
+    uses: ./.github/workflows/checks.yml
+
+  git:
+    uses: ./.github/workflows/git.yml
+
+  build:
+    uses: ./.github/workflows/build.yml
+
+  # This task is used as a probe for auto merge
+  # In the future, it could also be used to perform a status update (e.g once the whole CI is passing + is ready for review, add a specific label such as `need review`)
+  ready:
+    name: Ready to merge
+    needs:
+      - pre-commit
+      - checks
+      - git
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ready to go
+        run: "exit 0"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+      - "[0-9].[0-9]"
+  workflow_dispatch:
+
+jobs:
+  checks:
+    uses: ./.github/workflows/checks.yml
+
+  changelog:
+    uses: ./.github/workflows/changelog.yml
+
+  build:
+    uses: ./.github/workflows/build.yml
+
+  sync:
+    if: ${{ github.ref != 'refs/heads/main' }}
+    uses: ./.github/workflows/sync_branch.yml

--- a/.github/workflows/sync_branches.yml
+++ b/.github/workflows/sync_branches.yml
@@ -1,9 +1,6 @@
 name: Sync Branches
 on:
-  push:
-    branches:
-      - "2.5"
-      - "2.6"
+  workflow_call:
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
Fixes the double run on CI and consolidate our workflow in a single run. Note that this will allow introducing dependencies in the future and eventually help reducing the CI minute consumption