### PR TITLE
ci: stop previous build when a new one is requested

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,6 +8,10 @@ on:
       - reopened
       - edited
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit:
     uses: ./.github/workflows/pre-commit.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,9 @@ on:
       - "[0-9].[0-9]"
   workflow_dispatch:
 
-env:
-  # This variable stores the map of Mixxx branches that still being developed. The key is the branch receiving support and the value is the next version in line
-  # NOTE: this must be valid JSON!
-  ACTIVE_VERSIONS: |-
-    {"2.5": "2.6", "2.6": "main"}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   checks:


### PR DESCRIPTION
I often make a subsequent push as I realised I forgot something. Also, it happens that few merges happens quickly one after the other. Finally, with sync branch, it happens that the sync branch gets updated quickly after merge.

All of this trigger A LOT of build. To reduce the new of building something now obsolete, this change introduce concurrency group so we can cancel build when a new is pushed. Of course, one can always retrigger the old build if they needed the build artifact for whatever reason (e.g need the apple .dmg install file), but the whole workflow (4 platform buil ds+ 3 checks) will gets cancelled by default