### PR TITLE
Improve Stat output: convert ns to ms and add spacing for readability

### DIFF
--- a/src/util/stat.h
+++ b/src/util/stat.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <QMap>
-#include <QVector>
 #include <QString>
+#include <QVector>
 
 #include "util/experiment.h"
 
@@ -23,58 +23,58 @@ class Stat {
 
     static QString statTypeToString(StatType type) {
         switch (type) {
-            case UNSPECIFIED:
-                return "UNSPECIFIED";
-            case COUNTER:
-                return "COUNTER";
-            case DURATION_MSEC:
-                return "DURATION_MSEC";
-            case DURATION_NANOSEC:
-                return "DURATION_NANOSEC";
-            case DURATION_SEC:
-                return "DURATION_SEC";
-            case EVENT:
-                return "EVENT";
-            case EVENT_START:
-                return "START";
-            case EVENT_END:
-                return "END";
-            default:
-                return "UNKNOWN";
+        case UNSPECIFIED:
+            return "UNSPECIFIED";
+        case COUNTER:
+            return "COUNTER";
+        case DURATION_MSEC:
+            return "DURATION_MSEC";
+        case DURATION_NANOSEC:
+            return "DURATION_NANOSEC";
+        case DURATION_SEC:
+            return "DURATION_SEC";
+        case EVENT:
+            return "EVENT";
+        case EVENT_START:
+            return "START";
+        case EVENT_END:
+            return "END";
+        default:
+            return "UNKNOWN";
         }
     }
 
     // TODO make this an enum class for improved typesafety and issues with
     // ambiguous overloads.
     enum ComputeTypes {
-        NONE            = 0x0000,
+        NONE = 0x0000,
         // O(1) in time and space.
-        COUNT           = 0x0001,
+        COUNT = 0x0001,
         // O(1) in time and space
-        SUM             = 0x0002,
+        SUM = 0x0002,
         // O(1) in time and space.
-        AVERAGE         = 0x0004,
+        AVERAGE = 0x0004,
         // O(1) in time and space.
         SAMPLE_VARIANCE = 0x0008,
-        SAMPLE_MEDIAN   = 0x0010,
+        SAMPLE_MEDIAN = 0x0010,
         // O(1) in time and space.
-        MIN             = 0x0020,
+        MIN = 0x0020,
         // O(1) in time and space.
-        MAX             = 0x0040,
+        MAX = 0x0040,
         // O(1) in time, O(k) in space where k is # of distinct values.
         // Use carefully!
-        HISTOGRAM       = 0x0080,
+        HISTOGRAM = 0x0080,
         // O(1) in time, O(n) in space where n is the # of reports.
         // Use carefully!
-        VALUES          = 0x0100,
+        VALUES = 0x0100,
         // TODO, track average reports per second
         REPORTS_PER_SECOND = 0x0200,
         // TODO, track the time in between received reports.
         REPORT_TIME_DELTA = 0x0400,
         // Used for marking stats recorded in EXPERIMENT mode.
-        STATS_EXPERIMENT  = 0x0800,
+        STATS_EXPERIMENT = 0x0800,
         // Used for marking stats recorded in BASE mode.
-        STATS_BASE        = 0x1000,
+        STATS_BASE = 0x1000,
     };
     Q_DECLARE_FLAGS(ComputeFlags, ComputeTypes);
 
@@ -89,13 +89,13 @@ class Stat {
 
     static ComputeFlags experimentFlags(ComputeFlags flags) {
         switch (Experiment::mode()) {
-            case Experiment::EXPERIMENT:
-                return flags | STATS_EXPERIMENT;
-            case Experiment::BASE:
-                return flags | STATS_BASE;
-            default:
-            case Experiment::OFF:
-                return flags;
+        case Experiment::EXPERIMENT:
+            return flags | STATS_EXPERIMENT;
+        case Experiment::BASE:
+            return flags | STATS_BASE;
+        default:
+        case Experiment::OFF:
+            return flags;
         }
     }
 
@@ -120,23 +120,23 @@ class Stat {
     QMap<double, double> m_histogram;
 
     static bool track(QString tag,
-                      Stat::StatType type,
-                      Stat::ComputeFlags compute,
-                      double value);
+            Stat::StatType type,
+            Stat::ComputeFlags compute,
+            double value);
 
     // Disallow to use this class with implicit converted char strings.
     // This should not be uses to avoid unicode encoding and memory
     // allocation at every call. Use a static tag like this:
     // static const QString tag("TAG TEXT");
-    static bool track(const char *,
-                      Stat::StatType,
-                      Stat::ComputeFlags,
-                      double) = delete;
+    static bool track(const char*,
+            Stat::StatType,
+            Stat::ComputeFlags,
+            double) = delete;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(Stat::ComputeFlags);
 
-QDebug operator<<(QDebug dbg, const Stat &stat);
+QDebug operator<<(QDebug dbg, const Stat& stat);
 
 struct StatReport {
     QString tag;


### PR DESCRIPTION
This pull request improves the debug output of the Stat class by:

1) Converting all time values from nanoseconds (ns) to milliseconds (ms) for better human readability.

2) Adding spaces after commas in the output string to improve formatting and clarity.

3) Introduced a lambda helper to convert nanoseconds (ns) to milliseconds (ms) with 3 decimal places.

4) Updated values for sum, average, min, max, variance, stddev, and histogram bin keys.

5) Replaced QStringList::join(",") with join(", ") for better output formatting.

Closes [#14908](https://github.com/mixxxdj/mixxx/issues/14908)