### PR TITLE
[GSoC Genre-DAO] Implement Genre-DAO for Multiple Genres 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1221,6 +1221,7 @@ add_library(
   src/library/coverart.cpp
   src/library/coverartcache.cpp
   src/library/coverartutils.cpp
+  src/library/dao/genredao.cpp
   src/library/dao/analysisdao.cpp
   src/library/dao/autodjcratesdao.cpp
   src/library/dao/cuedao.cpp

--- a/src/library/dao/genre.h
+++ b/src/library/dao/genre.h
@@ -1,0 +1,20 @@
+#ifndef GENRE_H
+#define GENRE_H
+
+#include <QString>
+
+#include "util/db/dbid.h"
+
+// Represents a single genre entity from the database.
+// This struct is used to pass genre data between the DAO and other Mixxx parts.
+struct Genre {
+    DbId id = DbId_Invalid;
+    QString name;
+
+    // Overload operator== for easy comparison, e.g. in QList::contains()
+    bool operator==(const Genre& other) const {
+        return id == other.id;
+    }
+};
+
+#endif

--- a/src/library/dao/genre.h
+++ b/src/library/dao/genre.h
@@ -1,20 +1,31 @@
-#ifndef GENRE_H
-#define GENRE_H
+#pragma once
 
+#include <QMetaType>
 #include <QString>
 
 #include "util/db/dbid.h"
 
-// Represents a single genre entity from the database.
-// This struct is used to pass genre data between the DAO and other Mixxx parts.
 struct Genre {
-    DbId id = DbId_Invalid;
+    DbId id;
     QString name;
 
-    // Overload operator== for easy comparison, e.g. in QList::contains()
+    Genre() = default;
+    Genre(DbId genreId, const QString& genreName)
+            : id(genreId),
+              name(genreName) {
+    }
+
+    bool isValid() const {
+        return id.isValid() && !name.isEmpty();
+    }
+
     bool operator==(const Genre& other) const {
-        return id == other.id;
+        return id == other.id && name == other.name;
+    }
+
+    bool operator!=(const Genre& other) const {
+        return !(*this == other);
     }
 };
 
-#endif
+Q_DECLARE_METATYPE(Genre)

--- a/src/library/dao/genre.h
+++ b/src/library/dao/genre.h
@@ -29,3 +29,6 @@ struct Genre {
 };
 
 Q_DECLARE_METATYPE(Genre)
+
+// Allows printing a list of Genres directly to a QDebug stream.
+QDebug operator<<(QDebug dbg, const QList<Genre>& genres);

--- a/src/library/dao/genredao.cpp
+++ b/src/library/dao/genredao.cpp
@@ -1,0 +1,185 @@
+#include "library/dao/genredao.h"
+
+#include "library/dao/trackschema.h"
+#include "util/db/dbconnection.h"
+#include "util/db/sqlite.h" // Include the SQLite header for SQuery
+#include "util/db/sqltransaction.h"
+#include "util/logger.h"
+
+namespace {
+mixxx::Logger kLogger("GenreDAO");
+}
+
+GenreDAO::GenreDAO(DbConnection* dbConnection)
+        : DAO(dbConnection) {
+}
+
+DbId GenreDAO::addGenre(const QString& name) {
+    const QString trimmedName = name.trimmed();
+    if (trimmedName.isEmpty()) {
+        return DbId_Invalid;
+    }
+
+    Genre existingGenre = getGenreByName(trimmedName);
+    if (existingGenre.id != DbId_Invalid) {
+        return existingGenre.id;
+    }
+
+    QSqlQuery query = SQuery(m_pDb);
+    query.prepare(QString("INSERT INTO %1 (%2) VALUES (:name)")
+                    .arg(mixxx::trackschema::TableGenres,
+                            mixxx::trackschema::GenresName));
+    query.bindValue(":name", trimmedName);
+
+    if (!exec(query)) {
+        LOG_FAILED_QUERY(query) << "Failed to insert new genre:" << trimmedName;
+        return DbId_Invalid;
+    }
+    return query.lastInsertId().toLongLong();
+}
+
+Genre GenreDAO::getGenreByName(const QString& name) {
+    QSqlQuery query = SQuery(m_pDb);
+    query.prepare(QString("SELECT %1, %2 FROM %3 WHERE %2 = :name")
+                    .arg(mixxx::trackschema::GenresId,
+                            mixxx::trackschema::GenresName,
+                            mixxx::trackschema::TableGenres));
+    query.bindValue(":name", name);
+
+    if (!exec(query)) {
+        LOG_FAILED_QUERY(query) << "Failed to get genre by name:" << name;
+        return Genre();
+    }
+    if (!query.next()) {
+        return Genre(); // Not found, return invalid genre
+    }
+    return Genre{query.value(0).toLongLong(), query.value(1).toString()};
+}
+
+Genre GenreDAO::getGenreById(DbId id) {
+    if (id == DbId_Invalid) {
+        return Genre();
+    }
+    QSqlQuery query = SQuery(m_pDb);
+    query.prepare(QString("SELECT %1, %2 FROM %3 WHERE %1 = :id")
+                    .arg(mixxx::trackschema::GenresId,
+                            mixxx::trackschema::GenresName,
+                            mixxx::trackschema::TableGenres));
+    query.bindValue(":id", id);
+
+    if (!exec(query) || !query.next()) {
+        return Genre();
+    }
+    return Genre{query.value(0).toLongLong(), query.value(1).toString()};
+}
+
+QList<Genre> GenreDAO::getGenresForTrack(DbId trackId) {
+    QList<Genre> genres;
+    if (trackId == DbId_Invalid) {
+        return genres;
+    }
+
+    QSqlQuery query = SQuery(m_pDb);
+    query.prepare(QString(
+            "SELECT g.%1, g.%2 FROM %3 g "
+            "JOIN %4 gt ON g.%1 = gt.%5 "
+            "WHERE gt.%6 = :trackId "
+            "ORDER BY g.%2")
+                    .arg(mixxx::trackschema::GenresId,
+                            mixxx::trackschema::GenresName,
+                            mixxx::trackschema::TableGenres,
+                            mixxx::trackschema::TableGenreTracks,
+                            mixxx::trackschema::GenreTracksGenreId,
+                            mixxx::trackschema::GenreTracksTrackId));
+    query.bindValue(":trackId", trackId);
+
+    if (!exec(query)) {
+        LOG_FAILED_QUERY(query) << "Failed to get genres for track id:" << trackId;
+        return genres;
+    }
+
+    while (query.next()) {
+        genres.append(Genre{query.value(0).toLongLong(), query.value(1).toString()});
+    }
+    return genres;
+}
+
+bool GenreDAO::setGenresForTrack(DbId trackId, const QList<DbId>& genreIds) {
+    if (trackId == DbId_Invalid) {
+        return false;
+    }
+
+    SqlTransaction transaction(m_pDb);
+    if (!transaction.begin()) {
+        kLogger.warning() << "Failed to begin transaction for setGenresForTrack";
+        return false;
+    }
+
+    // 1. Delete all existing genre associations for this track.
+    QSqlQuery deleteQuery = SQuery(m_pDb);
+    deleteQuery.prepare(QString("DELETE FROM %1 WHERE %2 = :trackId")
+                    .arg(mixxx::trackschema::TableGenreTracks,
+                            mixxx::trackschema::GenreTracksTrackId));
+    deleteQuery.bindValue(":trackId", trackId);
+    if (!exec(deleteQuery)) {
+        transaction.rollback();
+        return false;
+    }
+
+    // 2. Insert the new associations.
+    if (!genreIds.isEmpty()) {
+        QSqlQuery insertQuery = SQuery(m_pDb);
+        insertQuery.prepare(QString("INSERT INTO %1 (%2, %3) VALUES (:trackId, :genreId)")
+                        .arg(mixxx::trackschema::TableGenreTracks,
+                                mixxx::trackschema::GenreTracksTrackId,
+                                mixxx::trackschema::GenreTracksGenreId));
+
+        for (const DbId genreId : genreIds) {
+            if (genreId != DbId_Invalid) {
+                insertQuery.bindValue(":trackId", trackId);
+                insertQuery.bindValue(":genreId", genreId);
+                if (!exec(insertQuery)) {
+                    transaction.rollback();
+                    return false;
+                }
+            }
+        }
+    }
+
+    return transaction.commit();
+}
+
+QList<Genre> GenreDAO::getAllGenres() {
+    QList<Genre> genres;
+    // Using a direct query as shorthand is not available/needed.
+    QSqlQuery query = SQuery(m_pDb);
+    query.prepare(QString("SELECT %1, %2 FROM %3 ORDER BY %2")
+                    .arg(mixxx::trackschema::GenresId,
+                            mixxx::trackschema::GenresName,
+                            mixxx::trackschema::TableGenres));
+
+    if (!exec(query)) {
+        LOG_FAILED_QUERY(query) << "Failed to get all genres";
+        return genres;
+    }
+
+    while (query.next()) {
+        genres.append(Genre{query.value(0).toLongLong(), query.value(1).toString()});
+    }
+    return genres;
+}
+
+int GenreDAO::deleteUnusedGenres() {
+    const QString sql = QString("DELETE FROM %1 WHERE %2 NOT IN (SELECT DISTINCT %3 FROM %4)")
+                                .arg(mixxx::trackschema::TableGenres,
+                                        mixxx::trackschema::GenresId,
+                                        mixxx::trackschema::GenreTracksGenreId,
+                                        mixxx::trackschema::TableGenreTracks);
+
+    QSqlQuery query = SQuery(m_pDb);
+    if (!query.exec(sql)) {
+        LOG_FAILED_QUERY(query) << "Failed to delete unused genres";
+        return -1;
+    }
+    return query.numRowsAffected();
+}

--- a/src/library/dao/genredao.cpp
+++ b/src/library/dao/genredao.cpp
@@ -19,7 +19,7 @@ GenreDAO::GenreDAO()
         : DAO() {
 }
 
-DbId GenreDAO::addGenre(const QString& name) {
+DbId GenreDAO::getOrCreateGenre(const QString& name) {
     const QString trimmedName = name.trimmed();
     if (trimmedName.isEmpty()) {
         return DbId();

--- a/src/library/dao/genredao.cpp
+++ b/src/library/dao/genredao.cpp
@@ -1,8 +1,12 @@
 #include "library/dao/genredao.h"
 
+#include <QSqlError>
+#include <QSqlQuery>
+#include <QVariant>
+
 #include "library/dao/trackschema.h"
 #include "util/db/dbconnection.h"
-#include "util/db/sqlite.h" // Include the SQLite header for SQuery
+#include "util/db/sqlite.h" // For SQuery and LOG_FAILED_QUERY
 #include "util/db/sqltransaction.h"
 #include "util/logger.h"
 
@@ -10,30 +14,31 @@ namespace {
 mixxx::Logger kLogger("GenreDAO");
 }
 
+// base DAO constructor
 GenreDAO::GenreDAO(DbConnection* dbConnection)
-        : DAO(dbConnection) {
+        : DAO() {
+    setDb(dbConnection);
 }
 
 DbId GenreDAO::addGenre(const QString& name) {
     const QString trimmedName = name.trimmed();
     if (trimmedName.isEmpty()) {
-        return DbId_Invalid;
+        return invalidId();
     }
 
     Genre existingGenre = getGenreByName(trimmedName);
-    if (existingGenre.id != DbId_Invalid) {
+    if (existingGenre.id != invalidId()) {
         return existingGenre.id;
     }
 
     QSqlQuery query = SQuery(m_pDb);
     query.prepare(QString("INSERT INTO %1 (%2) VALUES (:name)")
-                    .arg(mixxx::trackschema::TableGenres,
-                            mixxx::trackschema::GenresName));
+                    .arg(TableGenres, GenresName));
     query.bindValue(":name", trimmedName);
 
-    if (!exec(query)) {
+    if (!query.exec()) {
         LOG_FAILED_QUERY(query) << "Failed to insert new genre:" << trimmedName;
-        return DbId_Invalid;
+        return invalidId();
     }
     return query.lastInsertId().toLongLong();
 }
@@ -41,33 +46,28 @@ DbId GenreDAO::addGenre(const QString& name) {
 Genre GenreDAO::getGenreByName(const QString& name) {
     QSqlQuery query = SQuery(m_pDb);
     query.prepare(QString("SELECT %1, %2 FROM %3 WHERE %2 = :name")
-                    .arg(mixxx::trackschema::GenresId,
-                            mixxx::trackschema::GenresName,
-                            mixxx::trackschema::TableGenres));
+                    .arg(GenresId, GenresName, TableGenres));
     query.bindValue(":name", name);
 
-    if (!exec(query)) {
-        LOG_FAILED_QUERY(query) << "Failed to get genre by name:" << name;
+    if (!query.exec() || !query.next()) {
+        if (query.lastError().type() != QSqlError::NoError) {
+            LOG_FAILED_QUERY(query) << "Failed to get genre by name:" << name;
+        }
         return Genre();
-    }
-    if (!query.next()) {
-        return Genre(); // Not found, return invalid genre
     }
     return Genre{query.value(0).toLongLong(), query.value(1).toString()};
 }
 
 Genre GenreDAO::getGenreById(DbId id) {
-    if (id == DbId_Invalid) {
+    if (id == invalidId()) {
         return Genre();
     }
     QSqlQuery query = SQuery(m_pDb);
     query.prepare(QString("SELECT %1, %2 FROM %3 WHERE %1 = :id")
-                    .arg(mixxx::trackschema::GenresId,
-                            mixxx::trackschema::GenresName,
-                            mixxx::trackschema::TableGenres));
-    query.bindValue(":id", id);
+                    .arg(GenresId, GenresName, TableGenres));
+    query.bindValue(":id", QVariant::fromValue(id));
 
-    if (!exec(query) || !query.next()) {
+    if (!query.exec() || !query.next()) {
         return Genre();
     }
     return Genre{query.value(0).toLongLong(), query.value(1).toString()};
@@ -75,25 +75,25 @@ Genre GenreDAO::getGenreById(DbId id) {
 
 QList<Genre> GenreDAO::getGenresForTrack(DbId trackId) {
     QList<Genre> genres;
-    if (trackId == DbId_Invalid) {
+    if (trackId == invalidId()) {
         return genres;
     }
 
     QSqlQuery query = SQuery(m_pDb);
-    query.prepare(QString(
-            "SELECT g.%1, g.%2 FROM %3 g "
-            "JOIN %4 gt ON g.%1 = gt.%5 "
-            "WHERE gt.%6 = :trackId "
-            "ORDER BY g.%2")
-                    .arg(mixxx::trackschema::GenresId,
-                            mixxx::trackschema::GenresName,
-                            mixxx::trackschema::TableGenres,
-                            mixxx::trackschema::TableGenreTracks,
-                            mixxx::trackschema::GenreTracksGenreId,
-                            mixxx::trackschema::GenreTracksTrackId));
-    query.bindValue(":trackId", trackId);
+    query.prepare(
+            QString("SELECT g.%1, g.%2 FROM %3 AS g "
+                    "JOIN %4 AS gt ON g.%1 = gt.%5 "
+                    "WHERE gt.%6 = :trackId "
+                    "ORDER BY g.%2")
+                    .arg(GenresId,
+                            GenresName,
+                            TableGenres,
+                            TableGenreTracks,
+                            GenreTracksGenreId,
+                            GenreTracksTrackId));
+    query.bindValue(":trackId", QVariant::fromValue(trackId));
 
-    if (!exec(query)) {
+    if (!query.exec()) {
         LOG_FAILED_QUERY(query) << "Failed to get genres for track id:" << trackId;
         return genres;
     }
@@ -105,7 +105,7 @@ QList<Genre> GenreDAO::getGenresForTrack(DbId trackId) {
 }
 
 bool GenreDAO::setGenresForTrack(DbId trackId, const QList<DbId>& genreIds) {
-    if (trackId == DbId_Invalid) {
+    if (trackId == invalidId()) {
         return false;
     }
 
@@ -115,30 +115,27 @@ bool GenreDAO::setGenresForTrack(DbId trackId, const QList<DbId>& genreIds) {
         return false;
     }
 
-    // 1. Delete all existing genre associations for this track.
     QSqlQuery deleteQuery = SQuery(m_pDb);
     deleteQuery.prepare(QString("DELETE FROM %1 WHERE %2 = :trackId")
-                    .arg(mixxx::trackschema::TableGenreTracks,
-                            mixxx::trackschema::GenreTracksTrackId));
-    deleteQuery.bindValue(":trackId", trackId);
-    if (!exec(deleteQuery)) {
+                    .arg(TableGenreTracks, GenreTracksTrackId));
+    deleteQuery.bindValue(":trackId", QVariant::fromValue(trackId));
+    if (!deleteQuery.exec()) {
+        LOG_FAILED_QUERY(deleteQuery);
         transaction.rollback();
         return false;
     }
 
-    // 2. Insert the new associations.
     if (!genreIds.isEmpty()) {
         QSqlQuery insertQuery = SQuery(m_pDb);
         insertQuery.prepare(QString("INSERT INTO %1 (%2, %3) VALUES (:trackId, :genreId)")
-                        .arg(mixxx::trackschema::TableGenreTracks,
-                                mixxx::trackschema::GenreTracksTrackId,
-                                mixxx::trackschema::GenreTracksGenreId));
+                        .arg(TableGenreTracks, GenreTracksTrackId, GenreTracksGenreId));
 
         for (const DbId genreId : genreIds) {
-            if (genreId != DbId_Invalid) {
-                insertQuery.bindValue(":trackId", trackId);
-                insertQuery.bindValue(":genreId", genreId);
-                if (!exec(insertQuery)) {
+            if (genreId != invalidId()) {
+                insertQuery.bindValue(":trackId", QVariant::fromValue(trackId));
+                insertQuery.bindValue(":genreId", QVariant::fromValue(genreId));
+                if (!insertQuery.exec()) {
+                    LOG_FAILED_QUERY(insertQuery);
                     transaction.rollback();
                     return false;
                 }
@@ -151,14 +148,11 @@ bool GenreDAO::setGenresForTrack(DbId trackId, const QList<DbId>& genreIds) {
 
 QList<Genre> GenreDAO::getAllGenres() {
     QList<Genre> genres;
-    // Using a direct query as shorthand is not available/needed.
     QSqlQuery query = SQuery(m_pDb);
     query.prepare(QString("SELECT %1, %2 FROM %3 ORDER BY %2")
-                    .arg(mixxx::trackschema::GenresId,
-                            mixxx::trackschema::GenresName,
-                            mixxx::trackschema::TableGenres));
+                    .arg(GenresId, GenresName, TableGenres));
 
-    if (!exec(query)) {
+    if (!query.exec()) {
         LOG_FAILED_QUERY(query) << "Failed to get all genres";
         return genres;
     }
@@ -171,10 +165,7 @@ QList<Genre> GenreDAO::getAllGenres() {
 
 int GenreDAO::deleteUnusedGenres() {
     const QString sql = QString("DELETE FROM %1 WHERE %2 NOT IN (SELECT DISTINCT %3 FROM %4)")
-                                .arg(mixxx::trackschema::TableGenres,
-                                        mixxx::trackschema::GenresId,
-                                        mixxx::trackschema::GenreTracksGenreId,
-                                        mixxx::trackschema::TableGenreTracks);
+                                .arg(TableGenres, GenresId, GenreTracksGenreId, TableGenreTracks);
 
     QSqlQuery query = SQuery(m_pDb);
     if (!query.exec(sql)) {

--- a/src/library/dao/genredao.cpp
+++ b/src/library/dao/genredao.cpp
@@ -189,3 +189,17 @@ int GenreDAO::deleteUnusedGenres() {
 
     return query.numRowsAffected();
 }
+
+// QDebug stream operator for a list of Genre objects.
+QDebug operator<<(QDebug dbg, const QList<Genre>& genres) {
+    // This helper allows for clean debug output like: genres:("House", "Techno")
+    dbg.nospace() << "genres:(";
+    for (int i = 0; i < genres.size(); ++i) {
+        if (i > 0) {
+            dbg.nospace() << ", ";
+        }
+        dbg.nospace() << "\"" << genres.at(i).name << "\"";
+    }
+    dbg.nospace() << ")";
+    return dbg;
+}

--- a/src/library/dao/genredao.cpp
+++ b/src/library/dao/genredao.cpp
@@ -25,12 +25,6 @@ DbId GenreDAO::addGenre(const QString& name) {
         return DbId();
     }
 
-    // First Check if genre exists
-    Genre existingGenre = getGenreByName(trimmedName);
-    if (existingGenre.isValid()) {
-        return existingGenre.id;
-    }
-
     // Insert new genre
     QSqlQuery query(database());
     query.prepare(QString("INSERT INTO %1 (%2) VALUES (:name)")

--- a/src/library/dao/genredao.h
+++ b/src/library/dao/genredao.h
@@ -1,0 +1,41 @@
+#ifndef GENREDAO_H
+#define GENREDAO_H
+
+#include <QList>
+#include <QString>
+
+#include "library/dao/dao.h"
+#include "library/dao/genre.h"
+
+class DbConnection; // Forward Declaration to reduce compile dependencies
+
+// Data Access Object for all genre-related database operations.
+class GenreDAO final : public DAO {
+  public:
+    explicit GenreDAO(DbConnection* dbConnection);
+
+    // Adds a new genre to the 'genres' table if it doesn't exist.
+    // Returns the ID of the new or existing genre. On failure, returns DbId_Invalid.
+    DbId addGenre(const QString& name);
+
+    // Retrieves a genre by its name. Returns an invalid Genre if not found.
+    Genre getGenreByName(const QString& name);
+
+    // Retrieves a genre by its ID. Returns an invalid Genre if not found.
+    Genre getGenreById(DbId id);
+
+    // Retrieves a list of all genres associated with a specific track.
+    QList<Genre> getGenresForTrack(DbId trackId);
+
+    // Sets all genres for a specific track, replacing any existing associations.
+    bool setGenresForTrack(DbId trackId, const QList<DbId>& genreIds);
+
+    // Retrieves all genres from the database.
+    QList<Genre> getAllGenres();
+
+    // Deletes genres from the 'genres' table that are no longer associated with any tracks.
+    // Returns the number of rows deleted, or -1 on error.
+    int deleteUnusedGenres();
+};
+
+#endif

--- a/src/library/dao/genredao.h
+++ b/src/library/dao/genredao.h
@@ -15,7 +15,7 @@ class GenreDAO : public DAO {
     ~GenreDAO() override = default;
 
     /// Adds a new genre or returns the ID if it already exists
-    DbId addGenre(const QString& name);
+    DbId getOrCreateGenre(const QString& name);
 
     /// Search for a genre by name (case-insensitive)
     Genre getGenreByName(const QString& name);

--- a/src/library/dao/genredao.h
+++ b/src/library/dao/genredao.h
@@ -1,41 +1,38 @@
-#ifndef GENREDAO_H
-#define GENREDAO_H
+#pragma once
 
 #include <QList>
 #include <QString>
 
 #include "library/dao/dao.h"
 #include "library/dao/genre.h"
+#include "util/db/dbid.h"
 
-class DbConnection; // Forward Declaration to reduce compile dependencies
-
-// Data Access Object for all genre-related database operations.
-class GenreDAO final : public DAO {
+/// Data Access Object for managing music genres
+/// Supports multiple genres per track via normalized tables
+class GenreDAO : public DAO {
   public:
-    explicit GenreDAO(DbConnection* dbConnection);
+    explicit GenreDAO();
+    ~GenreDAO() override = default;
 
-    // Adds a new genre to the 'genres' table if it doesn't exist.
-    // Returns the ID of the new or existing genre. On failure, returns DbId_Invalid.
+    /// Adds a new genre or returns the ID if it already exists
     DbId addGenre(const QString& name);
 
-    // Retrieves a genre by its name. Returns an invalid Genre if not found.
+    /// Search for a genre by name (case-insensitive)
     Genre getGenreByName(const QString& name);
 
-    // Retrieves a genre by its ID. Returns an invalid Genre if not found.
+    /// Retrieve a genre by ID
     Genre getGenreById(DbId id);
 
-    // Retrieves a list of all genres associated with a specific track.
+    /// Gets all genres associated with a track
     QList<Genre> getGenresForTrack(DbId trackId);
 
-    // Sets all genres for a specific track, replacing any existing associations.
+    /// Set genres for a track (atomic operation)
+    /// Removes all existing associations and creates new ones
     bool setGenresForTrack(DbId trackId, const QList<DbId>& genreIds);
 
-    // Retrieves all genres from the database.
+    /// Gets all genres present in the database
     QList<Genre> getAllGenres();
 
-    // Deletes genres from the 'genres' table that are no longer associated with any tracks.
-    // Returns the number of rows deleted, or -1 on error.
+    /// Remove unused genres from any track
     int deleteUnusedGenres();
 };
-
-#endif

--- a/src/library/dao/trackschema.h
+++ b/src/library/dao/trackschema.h
@@ -78,15 +78,15 @@ const QString PLAYLISTTRACKSTABLE_DATETIMEADDED = QStringLiteral("pl_datetime_ad
 
 const QString REKORDBOX_ANALYZE_PATH = "analyze_path";
 
-// === Multi-Genre Support (Flat Model) ===
+// Tabella Genres
 const QString TableGenres = QStringLiteral("genres");
 const QString GenresId = QStringLiteral("id");
 const QString GenresName = QStringLiteral("name");
 
+// Tabella Genre-Tracks Junction
 const QString TableGenreTracks = QStringLiteral("genre_tracks");
 const QString GenreTracksTrackId = QStringLiteral("track_id");
 const QString GenreTracksGenreId = QStringLiteral("genre_id");
-// === END of Multi-Genre Support constants ===
 
 namespace mixxx {
 namespace trackschema {

--- a/src/library/dao/trackschema.h
+++ b/src/library/dao/trackschema.h
@@ -78,6 +78,16 @@ const QString PLAYLISTTRACKSTABLE_DATETIMEADDED = QStringLiteral("pl_datetime_ad
 
 const QString REKORDBOX_ANALYZE_PATH = "analyze_path";
 
+// === Multi-Genre Support (Flat Model) ===
+const QString TableGenres = QStringLiteral("genres");
+const QString GenresId = QStringLiteral("id");
+const QString GenresName = QStringLiteral("name");
+
+const QString TableGenreTracks = QStringLiteral("genre_tracks");
+const QString GenreTracksTrackId = QStringLiteral("track_id");
+const QString GenreTracksGenreId = QStringLiteral("genre_id");
+// === END of Multi-Genre Support constants ===
+
 namespace mixxx {
 namespace trackschema {
 // TableForColumn returns the name of the table that contains the named column.


### PR DESCRIPTION
This PR introduces the genre DAO schema for the [GSoC 2025 Multi-Genre Support project](https://github.com/mixxxdj/mixxx/issues/14897).

**Overview**
_Data Access Object (DAO) implementation for managing multiple genres per track, replacing the current single-field genre system with a normalized database architecture._
_Following the initial schema setup, this update adds the logic required to manage genres and track-genre associations through a clean, extensible data access layer (DAO) and Qt-compatible data structures._

**Phase 1.2 – Genre DAO & Data Model Layer**

**1.2.1 Database Schema Extensions (`trackschema.h`)**
Added constants for new database entities:
* `TableGenres`, `GenresId`, `GenresName` for the `genres` table
* `TableGenreTracks`, `GenreTracksTrackId`, `GenreTracksGenreId` for the `genre_tracks` junction table

**1.2.2 Genre Data Model (`genre.h` - NEW FILE)**
_A lightweight struct representing a genre with type-safe access._
* Introduce `Genre` struct
* Includes `isValid()` and comparison operators
* Registered as a Qt metatype with `Q_DECLARE_METATYPE(Genre)` for signal-slot compatibility

**1.2.3 Genre Data Model (`genredao.h` - NEW FILE)**
* CRUD operations: `addGenre()`, `getGenreById()`, `getGenreByName()`, `deleteUnusedGenres()`
* Track-genre associations: `getGenresForTrack()`, `setGenresForTrack()`
* Batch operations: `getAllGenres()` for UI population

**1.2.4 DAO Implementation (`genredao.cpp` - NEW FILE)**
* Implements proper parameter binding with `bindValue()` for type safety
* Includes comprehensive error handling with `LOG_FAILED_QUERY` 
* `setGenresForTrack()` method uses explicit database transactions (`QSqlDatabase::transaction()`)
* Atomic operations ensure data consistency during bulk updates
* "Get-or-create" pattern in `addGenre()` prevents duplicate entries
* Case-insensitive genre matching using `COLLATE NOCASE`

**1.2.5 Integration Layer (`trackcollectionmanager.h` - MODIFIED)**
* `updateTrackGenres()` - Replace all genres for a track
* `addTrackGenres()` - Add genres while preserving existing ones
* `removeTrackGenres()` - Remove specific genres from a track
* `getTrackGenres()` - Retrieve all genres for a track
* `getAllGenres()` - Get complete genre catalog
* `cleanupUnusedGenres()` - Database maintenance operation

**Context and Purpose**
These changes represent the second milestone in the GSoC roadmap, introducing the **backend logic** needed for storing and managing multi-genre data. 

This PR addresses **Task 1.2** in the main [GSoC tracking issue](https://github.com/mixxxdj/mixxx/issues/14897).