### PR TITLE
Add option to disable EQ gain influence on waveforms

### DIFF
--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -149,10 +149,10 @@ DlgPrefWaveform::DlgPrefWaveform(
             &QCheckBox::clicked,
             this,
             &DlgPrefWaveform::slotSetWaveformOptionHighDetail);
-    connect(disableEqGainCheckBox,
+    connect(visualizeEqGainCheckBox,
             &QCheckBox::clicked,
             this,
-            &DlgPrefWaveform::slotSetDisableEq);
+            &DlgPrefWaveform::slotSetVisualizeEq);
     connect(defaultZoomComboBox,
             QOverload<int>::of(&QComboBox::currentIndexChanged),
             this,
@@ -284,9 +284,9 @@ void DlgPrefWaveform::slotUpdate() {
     updateEnableUntilMark();
     updateWaveformGeneralOptionsEnabled();
 
-    bool disableEqGain = m_pConfig->getValue(
-            ConfigKey("[Waveform]", "disable_eq_gain"), false);
-    disableEqGainCheckBox->setChecked(disableEqGain);
+    bool visualizeEqGain = m_pConfig->getValue(
+            ConfigKey("[Waveform]", "visualize_eq_gain"), false);
+    visualizeEqGainCheckBox->setChecked(visualizeEqGain);
 
     frameRateSpinBox->setValue(factory->getFrameRate());
     frameRateSlider->setValue(factory->getFrameRate());
@@ -626,8 +626,8 @@ void DlgPrefWaveform::slotSetNormalizeOverview(bool normalize) {
     updateWaveformGainEnabled();
 }
 
-void DlgPrefWaveform::slotSetDisableEq(bool checked) {
-    WaveformWidgetFactory::instance()->setEqGainDisabled(checked);
+void DlgPrefWaveform::slotSetVisualizeEq(bool checked) {
+    WaveformWidgetFactory::instance()->setVisualizeEqGain(checked);
 }
 
 void DlgPrefWaveform::slotSetOverviewMinuteMarkers(bool draw) {

--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -285,7 +285,7 @@ void DlgPrefWaveform::slotUpdate() {
     updateWaveformGeneralOptionsEnabled();
 
     bool visualizeEqGain = m_pConfig->getValue(
-            ConfigKey("[Waveform]", "visualize_eq_gain"), false);
+            ConfigKey("[Waveform]", "visualize_eq_gain"), true);
     visualizeEqGainCheckBox->setChecked(visualizeEqGain);
 
     frameRateSpinBox->setValue(factory->getFrameRate());

--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -149,6 +149,10 @@ DlgPrefWaveform::DlgPrefWaveform(
             &QCheckBox::clicked,
             this,
             &DlgPrefWaveform::slotSetWaveformOptionHighDetail);
+    connect(disableEqGainCheckBox,
+            &QCheckBox::clicked,
+            this,
+            &DlgPrefWaveform::slotSetDisableEq);
     connect(defaultZoomComboBox,
             QOverload<int>::of(&QComboBox::currentIndexChanged),
             this,
@@ -279,6 +283,10 @@ void DlgPrefWaveform::slotUpdate() {
     waveformTypeComboBox->setEnabled(useWaveform);
     updateEnableUntilMark();
     updateWaveformGeneralOptionsEnabled();
+
+    bool disableEqGain = m_pConfig->getValue(
+            ConfigKey("[Waveform]", "disable_eq_gain"), false);
+    disableEqGainCheckBox->setChecked(disableEqGain);
 
     frameRateSpinBox->setValue(factory->getFrameRate());
     frameRateSlider->setValue(factory->getFrameRate());
@@ -616,6 +624,10 @@ void DlgPrefWaveform::slotSetVisualGainHigh(double gain) {
 void DlgPrefWaveform::slotSetNormalizeOverview(bool normalize) {
     WaveformWidgetFactory::instance()->setOverviewNormalized(normalize);
     updateWaveformGainEnabled();
+}
+
+void DlgPrefWaveform::slotSetDisableEq(bool checked) {
+    WaveformWidgetFactory::instance()->setEqGainDisabled(checked);
 }
 
 void DlgPrefWaveform::slotSetOverviewMinuteMarkers(bool draw) {

--- a/src/preferences/dialog/dlgprefwaveform.h
+++ b/src/preferences/dialog/dlgprefwaveform.h
@@ -45,6 +45,7 @@ class DlgPrefWaveform : public DlgPreferencePage, public Ui::DlgPrefWaveformDlg 
         slotSetWaveformOptions(allshader::WaveformRendererSignalBase::Option::HighDetail, checked);
     }
 #endif
+    void slotSetDisableEq(bool checked);
     void slotSetWaveformOverviewType();
     void slotSetDefaultZoom(int index);
     void slotSetZoomSynchronization(bool checked);

--- a/src/preferences/dialog/dlgprefwaveform.h
+++ b/src/preferences/dialog/dlgprefwaveform.h
@@ -45,7 +45,7 @@ class DlgPrefWaveform : public DlgPreferencePage, public Ui::DlgPrefWaveformDlg 
         slotSetWaveformOptions(allshader::WaveformRendererSignalBase::Option::HighDetail, checked);
     }
 #endif
-    void slotSetDisableEq(bool checked);
+    void slotSetVisualizeEq(bool checked);
     void slotSetWaveformOverviewType();
     void slotSetDefaultZoom(int index);
     void slotSetZoomSynchronization(bool checked);

--- a/src/preferences/dialog/dlgprefwaveformdlg.ui
+++ b/src/preferences/dialog/dlgprefwaveformdlg.ui
@@ -85,9 +85,9 @@ Select from different types of displays for the waveform, which differ primarily
         </widget>
       </item>
       <item>
-        <widget class="QCheckBox" name="disableEqGainCheckBox">
+        <widget class="QCheckBox" name="visualizeEqGainCheckBox">
           <property name="text">
-            <string>Disable EQ Gain in Waveform</string>
+            <string>Visualize EQ Gain</string>
           </property>
         </widget>
       </item>

--- a/src/preferences/dialog/dlgprefwaveformdlg.ui
+++ b/src/preferences/dialog/dlgprefwaveformdlg.ui
@@ -83,7 +83,14 @@ Select from different types of displays for the waveform, which differ primarily
           <string>High details</string>
          </property>
         </widget>
-       </item>
+      </item>
+      <item>
+        <widget class="QCheckBox" name="disableEqGainCheckBox">
+          <property name="text">
+            <string>Disable EQ Gain in Waveform</string>
+          </property>
+        </widget>
+      </item>
       </layout>
      </item>
 

--- a/src/waveform/renderers/waveformrenderersignalbase.cpp
+++ b/src/waveform/renderers/waveformrenderersignalbase.cpp
@@ -161,9 +161,11 @@ void WaveformRendererSignalBase::setup(const QDomNode& node,
             });
 
     connect(pWaveformFactory,
-            &WaveformWidgetFactory::eqGainDisabledChanged,
+            &WaveformWidgetFactory::visualizeEqGainChanged,
             this,
-            [this](bool disabled) { m_eqGainDisabled = disabled; });
+            [this](bool value) { m_visualizeEqGain = value; });
+
+    m_visualizeEqGain = pWaveformFactory->visualizeEqGain();
 
     setAllChannelVisualGain(pWaveformFactory->getVisualGain(BandIndex::AllBand));
     setLowVisualGain(pWaveformFactory->getVisualGain(BandIndex::Low));
@@ -188,7 +190,11 @@ void WaveformRendererSignalBase::getGains(float* pAllGain,
         CSAMPLE_GAIN lowVisualGain = 1.0, midVisualGain = 1.0, highVisualGain = 1.0;
 
         // Only adjust low/mid/high gains if EQs are enabled.
-        if (m_pEQEnabled && m_pEQEnabled->get() > 0.0) {
+        if (!m_visualizeEqGain) {
+            lowVisualGain = m_lowVisualGain;
+            midVisualGain = m_midVisualGain;
+            highVisualGain = m_highVisualGain;
+        } else if (m_pEQEnabled && m_pEQEnabled->get() > 0.0) {
             if (m_pLowFilterControlObject &&
                     m_pMidFilterControlObject &&
                     m_pHighFilterControlObject) {
@@ -212,12 +218,6 @@ void WaveformRendererSignalBase::getGains(float* pAllGain,
             if (m_pHighKillControlObject && m_pHighKillControlObject->get() > 0.0) {
                 highVisualGain = 0;
             }
-        }
-
-        if (m_eqGainDisabled) {
-            lowVisualGain = m_lowVisualGain;
-            midVisualGain = m_midVisualGain;
-            highVisualGain = m_highVisualGain;
         }
 
         if (pLowGain != nullptr) {

--- a/src/waveform/renderers/waveformrenderersignalbase.cpp
+++ b/src/waveform/renderers/waveformrenderersignalbase.cpp
@@ -160,6 +160,11 @@ void WaveformRendererSignalBase::setup(const QDomNode& node,
                 setHighVisualGain(highGain);
             });
 
+    connect(pWaveformFactory,
+            &WaveformWidgetFactory::eqGainDisabledChanged,
+            this,
+            [this](bool disabled) { m_eqGainDisabled = disabled; });
+
     setAllChannelVisualGain(pWaveformFactory->getVisualGain(BandIndex::AllBand));
     setLowVisualGain(pWaveformFactory->getVisualGain(BandIndex::Low));
     setMidVisualGain(pWaveformFactory->getVisualGain(BandIndex::Mid));
@@ -207,6 +212,12 @@ void WaveformRendererSignalBase::getGains(float* pAllGain,
             if (m_pHighKillControlObject && m_pHighKillControlObject->get() > 0.0) {
                 highVisualGain = 0;
             }
+        }
+
+        if (m_eqGainDisabled) {
+            lowVisualGain = m_lowVisualGain;
+            midVisualGain = m_midVisualGain;
+            highVisualGain = m_highVisualGain;
         }
 
         if (pLowGain != nullptr) {

--- a/src/waveform/renderers/waveformrenderersignalbase.h
+++ b/src/waveform/renderers/waveformrenderersignalbase.h
@@ -64,7 +64,7 @@ class WaveformRendererSignalBase : public QObject, public WaveformRendererAbstra
     CSAMPLE_GAIN m_midVisualGain;
     CSAMPLE_GAIN m_highVisualGain;
 
-    bool m_eqGainDisabled;
+    bool m_visualizeEqGain;
 
     float m_axesColor_r, m_axesColor_g, m_axesColor_b, m_axesColor_a;
     float m_signalColor_r, m_signalColor_g, m_signalColor_b;

--- a/src/waveform/renderers/waveformrenderersignalbase.h
+++ b/src/waveform/renderers/waveformrenderersignalbase.h
@@ -64,6 +64,8 @@ class WaveformRendererSignalBase : public QObject, public WaveformRendererAbstra
     CSAMPLE_GAIN m_midVisualGain;
     CSAMPLE_GAIN m_highVisualGain;
 
+    bool m_eqGainDisabled;
+
     float m_axesColor_r, m_axesColor_g, m_axesColor_b, m_axesColor_a;
     float m_signalColor_r, m_signalColor_g, m_signalColor_b;
     float m_signalColor_h, m_signalColor_s, m_signalColor_v;

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -363,6 +363,10 @@ bool WaveformWidgetFactory::setConfig(UserSettingsPointer config) {
     bool zoomSync = m_config->getValue(ConfigKey("[Waveform]", "ZoomSynchronization"), m_zoomSync);
     setZoomSync(zoomSync);
 
+    bool disableEqGain = m_config->getValue(
+            ConfigKey("[Waveform]", "disable_eq_gain"), m_eqGainDisabled);
+    setEqGainDisabled(disableEqGain);
+
     int beatGridAlpha = m_config->getValue(ConfigKey("[Waveform]", "beatGridAlpha"), m_beatGridAlpha);
     setDisplayBeatGridAlpha(beatGridAlpha);
 
@@ -662,6 +666,13 @@ void WaveformWidgetFactory::setZoomSync(bool sync) {
     for (const auto& holder : std::as_const(m_waveformWidgetHolders)) {
         holder.m_waveformViewer->setZoom(refZoom);
     }
+}
+
+void WaveformWidgetFactory::setEqGainDisabled(bool disabled) {
+    m_eqGainDisabled = disabled;
+    m_config->setValue(ConfigKey("[Waveform]", "disable_eq_gain"), disabled);
+
+    emit eqGainDisabledChanged(disabled);
 }
 
 void WaveformWidgetFactory::setDisplayBeatGridAlpha(int alpha) {

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -363,9 +363,9 @@ bool WaveformWidgetFactory::setConfig(UserSettingsPointer config) {
     bool zoomSync = m_config->getValue(ConfigKey("[Waveform]", "ZoomSynchronization"), m_zoomSync);
     setZoomSync(zoomSync);
 
-    bool disableEqGain = m_config->getValue(
-            ConfigKey("[Waveform]", "disable_eq_gain"), m_eqGainDisabled);
-    setEqGainDisabled(disableEqGain);
+    bool visualizeEqGain = m_config->getValue(
+            ConfigKey("[Waveform]", "visualize_eq_gain"), m_visualizeEqGain);
+    setVisualizeEqGain(visualizeEqGain);
 
     int beatGridAlpha = m_config->getValue(ConfigKey("[Waveform]", "beatGridAlpha"), m_beatGridAlpha);
     setDisplayBeatGridAlpha(beatGridAlpha);
@@ -668,11 +668,11 @@ void WaveformWidgetFactory::setZoomSync(bool sync) {
     }
 }
 
-void WaveformWidgetFactory::setEqGainDisabled(bool disabled) {
-    m_eqGainDisabled = disabled;
-    m_config->setValue(ConfigKey("[Waveform]", "disable_eq_gain"), disabled);
+void WaveformWidgetFactory::setVisualizeEqGain(bool value) {
+    m_visualizeEqGain = value;
+    m_config->setValue(ConfigKey("[Waveform]", "visualize_eq_gain"), value);
 
-    emit eqGainDisabledChanged(disabled);
+    emit visualizeEqGainChanged(value);
 }
 
 void WaveformWidgetFactory::setDisplayBeatGridAlpha(int alpha) {

--- a/src/waveform/waveformwidgetfactory.h
+++ b/src/waveform/waveformwidgetfactory.h
@@ -191,6 +191,11 @@ class WaveformWidgetFactory : public QObject,
     void setZoomSync(bool sync);
     int isZoomSync() const { return m_zoomSync;}
 
+    bool isEqGainDisabled() const {
+        return m_eqGainDisabled;
+    };
+    void setEqGainDisabled(bool disabled);
+
     void setDisplayBeatGridAlpha(int alpha);
     int getBeatGridAlpha() const { return m_beatGridAlpha; }
 
@@ -225,6 +230,7 @@ class WaveformWidgetFactory : public QObject,
 
     void overviewNormalizeChanged();
     void visualGainChanged(double allChannelGain, double lowGain, double midGain, double highGain);
+    void eqGainDisabledChanged(bool value);
 
     void untilMarkShowBeatsChanged(bool value);
     void untilMarkShowTimeChanged(bool value);
@@ -283,6 +289,7 @@ class WaveformWidgetFactory : public QObject,
     int m_endOfTrackWarningTime;
     double m_defaultZoom;
     bool m_zoomSync;
+    bool m_eqGainDisabled;
     double m_visualGain[BandCount];
     bool m_overviewNormalized;
 

--- a/src/waveform/waveformwidgetfactory.h
+++ b/src/waveform/waveformwidgetfactory.h
@@ -191,10 +191,10 @@ class WaveformWidgetFactory : public QObject,
     void setZoomSync(bool sync);
     int isZoomSync() const { return m_zoomSync;}
 
-    bool isEqGainDisabled() const {
-        return m_eqGainDisabled;
+    bool visualizeEqGain() const {
+        return m_visualizeEqGain;
     };
-    void setEqGainDisabled(bool disabled);
+    void setVisualizeEqGain(bool value);
 
     void setDisplayBeatGridAlpha(int alpha);
     int getBeatGridAlpha() const { return m_beatGridAlpha; }
@@ -230,7 +230,7 @@ class WaveformWidgetFactory : public QObject,
 
     void overviewNormalizeChanged();
     void visualGainChanged(double allChannelGain, double lowGain, double midGain, double highGain);
-    void eqGainDisabledChanged(bool value);
+    void visualizeEqGainChanged(bool value);
 
     void untilMarkShowBeatsChanged(bool value);
     void untilMarkShowTimeChanged(bool value);
@@ -289,7 +289,7 @@ class WaveformWidgetFactory : public QObject,
     int m_endOfTrackWarningTime;
     double m_defaultZoom;
     bool m_zoomSync;
-    bool m_eqGainDisabled;
+    bool m_visualizeEqGain;
     double m_visualGain[BandCount];
     bool m_overviewNormalized;
 


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/9754967d-45da-4d30-a1a5-40e82aebc748)

Adds a new option in Preferences > Waveforms to disable the visible effect of EQ gain knobs on waveform rendering. Visual gain remains applied independently.

[Feature request here](https://github.com/mixxxdj/mixxx/issues/14901)