### PR TITLE
chore(waveform): migrate option to global namespace

### DIFF
--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -225,10 +225,10 @@ DlgPrefWaveform::~DlgPrefWaveform() {
 }
 
 void DlgPrefWaveform::slotSetWaveformOptions(
-        allshader::WaveformRendererSignalBase::Option option, bool enabled) {
-    allshader::WaveformRendererSignalBase::Options currentOption = m_pConfig->getValue(
+        WaveformRendererSignalBase::Option option, bool enabled) {
+    WaveformRendererSignalBase::Options currentOption = m_pConfig->getValue(
             ConfigKey("[Waveform]", "waveform_options"),
-            allshader::WaveformRendererSignalBase::Option::None);
+            WaveformRendererSignalBase::Option::None);
     m_pConfig->setValue<int>(ConfigKey("[Waveform]", "waveform_options"),
             enabled ? currentOption |
                             option
@@ -268,9 +268,9 @@ void DlgPrefWaveform::slotUpdate() {
     bool useWaveform = factory->getType() != WaveformWidgetType::Empty;
     useWaveformCheckBox->setChecked(useWaveform);
 
-    allshader::WaveformRendererSignalBase::Options currentOptions = m_pConfig->getValue(
+    WaveformRendererSignalBase::Options currentOptions = m_pConfig->getValue(
             ConfigKey("[Waveform]", "waveform_options"),
-            allshader::WaveformRendererSignalBase::Option::None);
+            WaveformRendererSignalBase::Option::None);
     WaveformWidgetBackend backend = m_pConfig->getValue(
             ConfigKey("[Waveform]", "use_hardware_acceleration"),
             factory->preferredBackend());
@@ -348,11 +348,11 @@ void DlgPrefWaveform::slotResetToDefaults() {
     updateWaveformAcceleration(WaveformWidgetFactory::defaultType(), defaultBackend);
     updateWaveformTypeOptions(true,
             defaultBackend,
-            allshader::WaveformRendererSignalBase::Option::None);
+            WaveformRendererSignalBase::Option::None);
 
     // Restore waveform backend and option setting instantly
     m_pConfig->setValue(ConfigKey("[Waveform]", "waveform_options"),
-            allshader::WaveformRendererSignalBase::Option::None);
+            WaveformRendererSignalBase::Option::None);
     m_pConfig->setValue(ConfigKey("[Waveform]", "use_hardware_acceleration"),
             defaultBackend);
     factory->setWidgetTypeFromHandle(
@@ -420,9 +420,9 @@ void DlgPrefWaveform::slotSetWaveformType(int index) {
     useAccelerationCheckBox->setChecked(backend !=
             WaveformWidgetBackend::None);
 
-    allshader::WaveformRendererSignalBase::Options currentOptions = m_pConfig->getValue(
+    WaveformRendererSignalBase::Options currentOptions = m_pConfig->getValue(
             ConfigKey("[Waveform]", "waveform_options"),
-            allshader::WaveformRendererSignalBase::Option::None);
+            WaveformRendererSignalBase::Option::None);
     updateWaveformAcceleration(type, backend);
     updateWaveformTypeOptions(true, backend, currentOptions);
     updateEnableUntilMark();
@@ -459,9 +459,9 @@ void DlgPrefWaveform::slotSetWaveformAcceleration(bool checked) {
     auto type = static_cast<WaveformWidgetType::Type>(waveformTypeComboBox->currentData().toInt());
     auto* factory = WaveformWidgetFactory::instance();
     factory->setWidgetTypeFromHandle(factory->findHandleIndexFromType(type), true);
-    allshader::WaveformRendererSignalBase::Options currentOptions = m_pConfig->getValue(
+    WaveformRendererSignalBase::Options currentOptions = m_pConfig->getValue(
             ConfigKey("[Waveform]", "waveform_options"),
-            allshader::WaveformRendererSignalBase::Option::None);
+            WaveformRendererSignalBase::Option::None);
     updateWaveformTypeOptions(true, backend, currentOptions);
     updateEnableUntilMark();
 }
@@ -495,14 +495,14 @@ void DlgPrefWaveform::updateWaveformAcceleration(
 
 void DlgPrefWaveform::updateWaveformTypeOptions(bool useWaveform,
         WaveformWidgetBackend backend,
-        allshader::WaveformRendererSignalBase::Options currentOptions) {
+        WaveformRendererSignalBase::Options currentOptions) {
     splitLeftRightCheckBox->blockSignals(true);
     highDetailCheckBox->blockSignals(true);
 
 #ifdef MIXXX_USE_QOPENGL
     WaveformWidgetFactory* factory = WaveformWidgetFactory::instance();
-    allshader::WaveformRendererSignalBase::Options supportedOption =
-            allshader::WaveformRendererSignalBase::Option::None;
+    WaveformRendererSignalBase::Options supportedOption =
+            WaveformRendererSignalBase::Option::None;
 
     auto type = static_cast<WaveformWidgetType::Type>(waveformTypeComboBox->currentData().toInt());
     int handleIdx = factory->findHandleIndexFromType(type);
@@ -513,15 +513,15 @@ void DlgPrefWaveform::updateWaveformTypeOptions(bool useWaveform,
 
     splitLeftRightCheckBox->setEnabled(useWaveform &&
             supportedOption &
-                    allshader::WaveformRendererSignalBase::Option::SplitStereoSignal);
+                    WaveformRendererSignalBase::Option::SplitStereoSignal);
     highDetailCheckBox->setEnabled(useWaveform &&
             supportedOption &
-                    allshader::WaveformRendererSignalBase::Option::HighDetail);
+                    WaveformRendererSignalBase::Option::HighDetail);
     splitLeftRightCheckBox->setChecked(splitLeftRightCheckBox->isEnabled() &&
             currentOptions &
-                    allshader::WaveformRendererSignalBase::Option::SplitStereoSignal);
+                    WaveformRendererSignalBase::Option::SplitStereoSignal);
     highDetailCheckBox->setChecked(highDetailCheckBox->isEnabled() &&
-            currentOptions & allshader::WaveformRendererSignalBase::Option::HighDetail);
+            currentOptions & WaveformRendererSignalBase::Option::HighDetail);
 #else
     splitLeftRightCheckBox->setVisible(false);
     highDetailCheckBox->setVisible(false);

--- a/src/preferences/dialog/dlgprefwaveform.h
+++ b/src/preferences/dialog/dlgprefwaveform.h
@@ -35,14 +35,14 @@ class DlgPrefWaveform : public DlgPreferencePage, public Ui::DlgPrefWaveformDlg 
     void slotSetWaveformEnabled(bool checked);
     void slotSetWaveformAcceleration(bool checked);
 #ifdef MIXXX_USE_QOPENGL
-    void slotSetWaveformOptions(allshader::WaveformRendererSignalBase::Option option, bool enabled);
+    void slotSetWaveformOptions(WaveformRendererSignalBase::Option option, bool enabled);
     void slotSetWaveformOptionSplitStereoSignal(bool checked) {
-        slotSetWaveformOptions(allshader::WaveformRendererSignalBase::Option::
+        slotSetWaveformOptions(WaveformRendererSignalBase::Option::
                                        SplitStereoSignal,
                 checked);
     }
     void slotSetWaveformOptionHighDetail(bool checked) {
-        slotSetWaveformOptions(allshader::WaveformRendererSignalBase::Option::HighDetail, checked);
+        slotSetWaveformOptions(WaveformRendererSignalBase::Option::HighDetail, checked);
     }
 #endif
     void slotSetWaveformOverviewType();
@@ -71,7 +71,7 @@ class DlgPrefWaveform : public DlgPreferencePage, public Ui::DlgPrefWaveformDlg 
     void updateEnableUntilMark();
     void updateWaveformTypeOptions(bool useWaveform,
             WaveformWidgetBackend backend,
-            allshader::WaveformRendererSignalBase::Options currentOption);
+            WaveformRendererSignalBase::Options currentOption);
     void updateWaveformAcceleration(
             WaveformWidgetType::Type type, WaveformWidgetBackend backend);
     void updateWaveformGeneralOptionsEnabled();

--- a/src/preferences/upgrade.cpp
+++ b/src/preferences/upgrade.cpp
@@ -37,7 +37,7 @@ namespace {
 // mapping to proactively move users to the new all-shader waveform types
 std::tuple<WaveformWidgetType::Type,
         WaveformWidgetBackend,
-        allshader::WaveformRendererSignalBase::Options>
+        WaveformRendererSignalBase::Options>
 upgradeToAllShaders(int unsafeWaveformType,
         int unsafeWaveformBackend,
         int unsafeWaveformOption) {
@@ -45,10 +45,10 @@ upgradeToAllShaders(int unsafeWaveformType,
     using WWT = WaveformWidgetType;
 
     if (static_cast<int>(WaveformWidgetBackend::AllShader) == unsafeWaveformBackend) {
-        allshader::WaveformRendererSignalBase::Options waveformOption =
-                static_cast<allshader::WaveformRendererSignalBase::Options>(
+        WaveformRendererSignalBase::Options waveformOption =
+                static_cast<WaveformRendererSignalBase::Options>(
                         unsafeWaveformOption) &
-                allshader::WaveformRendererSignalBase::Option::AllOptionsCombined;
+                WaveformRendererSignalBase::Option::AllOptionsCombined;
         switch (unsafeWaveformType) {
         case WWT::Simple:
         case WWT::Filtered:
@@ -67,8 +67,8 @@ upgradeToAllShaders(int unsafeWaveformType,
     }
 
     // Reset the options
-    allshader::WaveformRendererSignalBase::Options waveformOption =
-            allshader::WaveformRendererSignalBase::Option::None;
+    WaveformRendererSignalBase::Options waveformOption =
+            WaveformRendererSignalBase::Option::None;
     WaveformWidgetType::Type waveformType =
             static_cast<WaveformWidgetType::Type>(unsafeWaveformType);
     WaveformWidgetBackend waveformBackend = WaveformWidgetBackend::AllShader;
@@ -97,7 +97,7 @@ upgradeToAllShaders(int unsafeWaveformType,
     // Filtered waveforms
     case WWT::Filtered: // GLSLFilteredWaveform
     case 22:            // AllShaderTexturedFiltered
-        waveformOption = allshader::WaveformRendererSignalBase::Option::HighDetail;
+        waveformOption = WaveformRendererSignalBase::Option::HighDetail;
         [[fallthrough]];
     case 2:  // SoftwareWaveform
     case 4:  // QtWaveform
@@ -116,7 +116,7 @@ upgradeToAllShaders(int unsafeWaveformType,
     // Stacked waveform
     case 24:           // AllShaderTexturedStacked
     case WWT::Stacked: // GLSLRGBStackedWaveform
-        waveformOption = allshader::WaveformRendererSignalBase::Option::HighDetail;
+        waveformOption = WaveformRendererSignalBase::Option::HighDetail;
         [[fallthrough]];
     case 26: // AllShaderRGBStackedWaveform
         waveformType = WaveformWidgetType::Stacked;
@@ -127,8 +127,8 @@ upgradeToAllShaders(int unsafeWaveformType,
     case 23: // AllShaderTexturedRGB
     case 12: // GLSLRGBWaveform
         waveformOption = unsafeWaveformType == 18
-                ? allshader::WaveformRendererSignalBase::Option::SplitStereoSignal
-                : allshader::WaveformRendererSignalBase::Option::HighDetail;
+                ? WaveformRendererSignalBase::Option::SplitStereoSignal
+                : WaveformRendererSignalBase::Option::HighDetail;
         [[fallthrough]];
     default:
         waveformType = WaveformWidgetFactory::defaultType();

--- a/src/qml/qmlwaveformrenderer.cpp
+++ b/src/qml/qmlwaveformrenderer.cpp
@@ -22,9 +22,9 @@ namespace mixxx {
 namespace qml {
 
 QmlWaveformRendererMark::QmlWaveformRendererMark()
-        : m_defaultMark(nullptr),
-          m_untilMark(std::make_unique<QmlWaveformUntilMark>()),
-          m_playMarkerPosition(0.5) {
+        : m_playMarkerPosition(0.5),
+          m_defaultMark(nullptr),
+          m_untilMark(std::make_unique<QmlWaveformUntilMark>()) {
 }
 
 QmlWaveformRendererFactory::Renderer QmlWaveformRendererEndOfTrack::create(
@@ -118,7 +118,7 @@ QmlWaveformRendererFactory::Renderer QmlWaveformRendererRGB::create(
 QmlWaveformRendererFactory::Renderer QmlWaveformRendererFiltered::create(
         WaveformWidgetRenderer* waveformWidget) const {
     auto pRenderer = std::make_unique<allshader::WaveformRendererFiltered>(
-            waveformWidget, m_ignoreStem);
+            waveformWidget, m_ignoreStem, m_options);
 
     setup(pRenderer.get());
     return QmlWaveformRendererFactory::Renderer{pRenderer.get(), std::move(pRenderer)};
@@ -127,7 +127,7 @@ QmlWaveformRendererFactory::Renderer QmlWaveformRendererFiltered::create(
 QmlWaveformRendererFactory::Renderer QmlWaveformRendererHSV::create(
         WaveformWidgetRenderer* waveformWidget) const {
     auto pRenderer = std::make_unique<allshader::WaveformRendererHSV>(
-            waveformWidget);
+            waveformWidget, m_options);
 
     pRenderer->setAxesColor(m_axesColor);
     pRenderer->setColor(m_color);
@@ -170,7 +170,7 @@ QmlWaveformRendererFactory::Renderer QmlWaveformRendererHSV::create(
 QmlWaveformRendererFactory::Renderer QmlWaveformRendererSimple::create(
         WaveformWidgetRenderer* waveformWidget) const {
     auto pRenderer = std::make_unique<allshader::WaveformRendererSimple>(
-            waveformWidget);
+            waveformWidget, m_options);
 
     pRenderer->setAxesColor(m_axesColor);
     pRenderer->setColor(m_color);

--- a/src/qml/qmlwaveformrenderer.h
+++ b/src/qml/qmlwaveformrenderer.h
@@ -85,7 +85,7 @@ class QmlWaveformRendererPreroll
     ::WaveformRendererAbstract::PositionSource m_position{::WaveformRendererAbstract::Play};
 };
 
-typedef allshader::WaveformRendererSignalBase::Options WaveformRendererSignalBaseOptions;
+typedef WaveformRendererSignalBase::Options WaveformRendererSignalBaseOptions;
 class QmlWaveformRendererSignal
         : public QmlWaveformRendererFactory {
     Q_OBJECT
@@ -139,7 +139,7 @@ class QmlWaveformRendererSignal
 
     ::WaveformRendererAbstract::PositionSource m_position{::WaveformRendererAbstract::Play};
     WaveformRendererSignalBaseOptions m_options{
-            allshader::WaveformRendererSignalBase::Option::None};
+            WaveformRendererSignalBase::Option::None};
 };
 
 class QmlWaveformRendererRGB
@@ -175,6 +175,8 @@ class QmlWaveformRendererHSV
     Q_PROPERTY(double gainLow MEMBER m_gainLow NOTIFY gainLowChanged REQUIRED)
     Q_PROPERTY(double gainMid MEMBER m_gainMid NOTIFY gainMidChanged REQUIRED)
     Q_PROPERTY(double gainHigh MEMBER m_gainHigh NOTIFY gainHighChanged REQUIRED)
+    Q_PROPERTY(WaveformRendererSignalBaseOptions options MEMBER
+                    m_options NOTIFY optionsChanged)
     QML_NAMED_ELEMENT(WaveformRendererHSV)
 
   public:
@@ -187,6 +189,11 @@ class QmlWaveformRendererHSV
     void gainLowChanged(double);
     void gainMidChanged(double);
     void gainHighChanged(double);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+    void optionsChanged(WaveformRendererSignalBaseOptions);
+#else
+    void optionsChanged(mixxx::qml::WaveformRendererSignalBaseOptions);
+#endif
 
   private:
     QColor m_axesColor;
@@ -198,6 +205,8 @@ class QmlWaveformRendererHSV
     double m_gainHigh;
 
     bool m_ignoreStem{false};
+    WaveformRendererSignalBaseOptions m_options{
+            WaveformRendererSignalBase::Option::None};
 };
 
 class QmlWaveformRendererSimple
@@ -207,6 +216,8 @@ class QmlWaveformRendererSimple
     Q_PROPERTY(QColor axesColor MEMBER m_axesColor NOTIFY axesColorChanged REQUIRED)
     Q_PROPERTY(QColor color MEMBER m_color NOTIFY colorChanged REQUIRED)
     Q_PROPERTY(double gain MEMBER m_gain NOTIFY gainChanged REQUIRED)
+    Q_PROPERTY(WaveformRendererSignalBaseOptions options MEMBER
+                    m_options NOTIFY optionsChanged)
     QML_NAMED_ELEMENT(WaveformRendererSimple)
 
   public:
@@ -216,12 +227,19 @@ class QmlWaveformRendererSimple
     void colorChanged(const QColor&);
     void ignoreStemChanged(bool);
     void gainChanged(double);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
+    void optionsChanged(WaveformRendererSignalBaseOptions);
+#else
+    void optionsChanged(mixxx::qml::WaveformRendererSignalBaseOptions);
+#endif
 
   private:
     QColor m_axesColor;
     QColor m_color;
     double m_gain;
     bool m_ignoreStem{false};
+    WaveformRendererSignalBaseOptions m_options{
+            WaveformRendererSignalBase::Option::None};
 };
 
 class QmlWaveformRendererBeat

--- a/src/test/waveform_upgrade_test.cpp
+++ b/src/test/waveform_upgrade_test.cpp
@@ -23,7 +23,7 @@ TEST_F(UpgradeTest, useCorrectWaveformType) {
         int oldTypeId;
         WaveformWidgetType::Type expectedType;
         WaveformWidgetBackend expectedBackend;
-        allshader::WaveformRendererSignalBase::Options expectedOptions;
+        WaveformRendererSignalBase::Options expectedOptions;
     };
 
     QList<test_case> testCases = {
@@ -31,132 +31,132 @@ TEST_F(UpgradeTest, useCorrectWaveformType) {
                     0,
                     WaveformWidgetType::Empty,
                     WaveformWidgetBackend::None,
-                    allshader::WaveformRendererSignalBase::Option::None},
+                    WaveformRendererSignalBase::Option::None},
             test_case{"SoftwareWaveform",
                     2, //  Filtered
                     WaveformWidgetType::Filtered,
                     WaveformWidgetBackend::AllShader,
-                    allshader::WaveformRendererSignalBase::Option::None},
+                    WaveformRendererSignalBase::Option::None},
             test_case{"QtSimpleWaveform",
                     3, //  Simple Qt
                     WaveformWidgetType::Simple,
                     WaveformWidgetBackend::AllShader,
-                    allshader::WaveformRendererSignalBase::Option::None},
+                    WaveformRendererSignalBase::Option::None},
             test_case{"QtWaveform",
                     4, //  Filtered Qt
                     WaveformWidgetType::Filtered,
                     WaveformWidgetBackend::AllShader,
-                    allshader::WaveformRendererSignalBase::Option::None},
+                    WaveformRendererSignalBase::Option::None},
             test_case{"GLSimpleWaveform",
                     5, //  Simple GL
                     WaveformWidgetType::Simple,
                     WaveformWidgetBackend::AllShader,
-                    allshader::WaveformRendererSignalBase::Option::None},
+                    WaveformRendererSignalBase::Option::None},
             test_case{"GLFilteredWaveform",
                     6, //  Filtered GL
                     WaveformWidgetType::Filtered,
                     WaveformWidgetBackend::AllShader,
-                    allshader::WaveformRendererSignalBase::Option::None},
+                    WaveformRendererSignalBase::Option::None},
             test_case{"GLSLFilteredWaveform",
                     7, //  Filtered GLSL
                     WaveformWidgetType::Filtered,
                     WaveformWidgetBackend::AllShader,
-                    allshader::WaveformRendererSignalBase::Option::HighDetail},
+                    WaveformRendererSignalBase::Option::HighDetail},
             test_case{"HSVWaveform",
                     8, //  HSV
                     WaveformWidgetType::HSV,
                     WaveformWidgetBackend::AllShader,
-                    allshader::WaveformRendererSignalBase::Option::None},
+                    WaveformRendererSignalBase::Option::None},
             test_case{"GLVSyncTest",
                     9, //  VSync GL
                     WaveformWidgetType::VSyncTest,
                     WaveformWidgetBackend::None,
-                    allshader::WaveformRendererSignalBase::Option::None},
+                    WaveformRendererSignalBase::Option::None},
             test_case{"RGBWaveform",
                     10, // RGB
                     WaveformWidgetType::RGB,
                     WaveformWidgetBackend::AllShader,
-                    allshader::WaveformRendererSignalBase::Option::None},
+                    WaveformRendererSignalBase::Option::None},
             test_case{"GLRGBWaveform",
                     11, // RGB GL
                     WaveformWidgetType::RGB,
                     WaveformWidgetBackend::AllShader,
-                    allshader::WaveformRendererSignalBase::Option::None},
+                    WaveformRendererSignalBase::Option::None},
             test_case{"GLSLRGBWaveform",
                     12, // RGB GLSL
                     WaveformWidgetType::RGB,
                     WaveformWidgetBackend::AllShader,
-                    allshader::WaveformRendererSignalBase::Option::HighDetail},
+                    WaveformRendererSignalBase::Option::HighDetail},
             test_case{"QtVSyncTest",
                     13, // VSync Qt
                     WaveformWidgetType::VSyncTest,
                     WaveformWidgetBackend::None,
-                    allshader::WaveformRendererSignalBase::Option::None},
+                    WaveformRendererSignalBase::Option::None},
             test_case{"QtHSVWaveform",
                     14, // HSV Qt
                     WaveformWidgetType::HSV,
                     WaveformWidgetBackend::AllShader,
-                    allshader::WaveformRendererSignalBase::Option::None},
+                    WaveformRendererSignalBase::Option::None},
             test_case{"QtRGBWaveform",
                     15, // RGB Qt
                     WaveformWidgetType::RGB,
                     WaveformWidgetBackend::AllShader,
-                    allshader::WaveformRendererSignalBase::Option::None},
+                    WaveformRendererSignalBase::Option::None},
             test_case{"GLSLRGBStackedWaveform",
                     16, // RGB Stacked
                     WaveformWidgetType::Stacked,
                     WaveformWidgetBackend::AllShader,
-                    allshader::WaveformRendererSignalBase::Option::HighDetail},
+                    WaveformRendererSignalBase::Option::HighDetail},
             test_case{"AllShaderRGBWaveform",
                     17, // RGB (all-shaders)
                     WaveformWidgetType::RGB,
                     WaveformWidgetBackend::AllShader,
-                    allshader::WaveformRendererSignalBase::Option::None},
+                    WaveformRendererSignalBase::Option::None},
             test_case{"AllShaderLRRGBWaveform",
                     18, // L/R RGB (all-shaders)
                     WaveformWidgetType::RGB,
                     WaveformWidgetBackend::AllShader,
-                    allshader::WaveformRendererSignalBase::Option::SplitStereoSignal},
+                    WaveformRendererSignalBase::Option::SplitStereoSignal},
             test_case{"AllShaderFilteredWaveform",
                     19, // Filtered (all-shaders)
                     WaveformWidgetType::Filtered,
                     WaveformWidgetBackend::AllShader,
-                    allshader::WaveformRendererSignalBase::Option::None},
+                    WaveformRendererSignalBase::Option::None},
             test_case{"AllShaderSimpleWaveform",
                     20, // Simple (all-shaders)
                     WaveformWidgetType::Simple,
                     WaveformWidgetBackend::AllShader,
-                    allshader::WaveformRendererSignalBase::Option::None},
+                    WaveformRendererSignalBase::Option::None},
             test_case{"AllShaderHSVWaveform",
                     21, // HSV (all-shaders)
                     WaveformWidgetType::HSV,
                     WaveformWidgetBackend::AllShader,
-                    allshader::WaveformRendererSignalBase::Option::None},
+                    WaveformRendererSignalBase::Option::None},
             test_case{"AllShaderTexturedFiltered",
                     22, // Filtered (textured) (all-shaders)
                     WaveformWidgetType::Filtered,
                     WaveformWidgetBackend::AllShader,
-                    allshader::WaveformRendererSignalBase::Option::HighDetail},
+                    WaveformRendererSignalBase::Option::HighDetail},
             test_case{"AllShaderTexturedRGB",
                     23, // RGB (textured) (all-shaders)
                     WaveformWidgetType::RGB,
                     WaveformWidgetBackend::AllShader,
-                    allshader::WaveformRendererSignalBase::Option::HighDetail},
+                    WaveformRendererSignalBase::Option::HighDetail},
             test_case{"AllShaderTexturedStacked",
                     24, // Stacked (textured) (all-shaders)
                     WaveformWidgetType::Stacked,
                     WaveformWidgetBackend::AllShader,
-                    allshader::WaveformRendererSignalBase::Option::HighDetail},
+                    WaveformRendererSignalBase::Option::HighDetail},
             test_case{"AllShaderRGBStackedWaveform",
                     26, // Stacked (all-shaders)
                     WaveformWidgetType::Stacked,
                     WaveformWidgetBackend::AllShader,
-                    allshader::WaveformRendererSignalBase::Option::None},
+                    WaveformRendererSignalBase::Option::None},
             test_case{"Count_WaveformwidgetType",
                     27, //    Also used as invalid value
                     WaveformWidgetType::RGB,
                     WaveformWidgetBackend::AllShader,
-                    allshader::WaveformRendererSignalBase::Option::None}};
+                    WaveformRendererSignalBase::Option::None}};
 
     for (const auto& testCase : testCases) {
         int waveformType = testCase.oldTypeId;

--- a/src/waveform/renderers/allshader/waveformrendererfiltered.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererfiltered.cpp
@@ -13,8 +13,9 @@ namespace allshader {
 
 WaveformRendererFiltered::WaveformRendererFiltered(
         WaveformWidgetRenderer* waveformWidget,
-        bool bRgbStacked)
-        : WaveformRendererSignalBase(waveformWidget),
+        bool bRgbStacked,
+        ::WaveformRendererSignalBase::Options options)
+        : WaveformRendererSignalBase(waveformWidget, options),
           m_bRgbStacked(bRgbStacked) {
     initForRectangles<RGBMaterial>(0);
     setUsePreprocess(true);

--- a/src/waveform/renderers/allshader/waveformrendererfiltered.h
+++ b/src/waveform/renderers/allshader/waveformrendererfiltered.h
@@ -13,7 +13,8 @@ class allshader::WaveformRendererFiltered final
           public rendergraph::GeometryNode {
   public:
     explicit WaveformRendererFiltered(WaveformWidgetRenderer* waveformWidget,
-            bool rgbStacked);
+            bool rgbStacked,
+            ::WaveformRendererSignalBase::Options options);
 
     // Pure virtual from WaveformRendererSignalBase, not used
     void onSetup(const QDomNode& node) override;

--- a/src/waveform/renderers/allshader/waveformrendererhsv.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererhsv.cpp
@@ -12,8 +12,9 @@ using namespace rendergraph;
 
 namespace allshader {
 
-WaveformRendererHSV::WaveformRendererHSV(WaveformWidgetRenderer* waveformWidget)
-        : WaveformRendererSignalBase(waveformWidget) {
+WaveformRendererHSV::WaveformRendererHSV(WaveformWidgetRenderer* waveformWidget,
+        ::WaveformRendererSignalBase::Options options)
+        : WaveformRendererSignalBase(waveformWidget, options) {
     initForRectangles<RGBMaterial>(0);
     setUsePreprocess(true);
 }

--- a/src/waveform/renderers/allshader/waveformrendererhsv.h
+++ b/src/waveform/renderers/allshader/waveformrendererhsv.h
@@ -12,7 +12,8 @@ class allshader::WaveformRendererHSV final
         : public allshader::WaveformRendererSignalBase,
           public rendergraph::GeometryNode {
   public:
-    explicit WaveformRendererHSV(WaveformWidgetRenderer* waveformWidget);
+    explicit WaveformRendererHSV(WaveformWidgetRenderer* waveformWidget,
+            ::WaveformRendererSignalBase::Options options);
 
     // Pure virtual from WaveformRendererSignalBase, not used
     void onSetup(const QDomNode& node) override;

--- a/src/waveform/renderers/allshader/waveformrendererrgb.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererrgb.cpp
@@ -20,8 +20,8 @@ inline float math_pow2(float x) {
 
 WaveformRendererRGB::WaveformRendererRGB(WaveformWidgetRenderer* waveformWidget,
         ::WaveformRendererAbstract::PositionSource type,
-        WaveformRendererSignalBase::Options options)
-        : WaveformRendererSignalBase(waveformWidget),
+        ::WaveformRendererSignalBase::Options options)
+        : WaveformRendererSignalBase(waveformWidget, options),
           m_isSlipRenderer(type == ::WaveformRendererAbstract::Slip),
           m_options(options) {
     initForRectangles<RGBMaterial>(0);
@@ -99,7 +99,7 @@ bool WaveformRendererRGB::preprocessInner() {
 
     const float heightFactorAbs = allGain * halfBreadth / m_maxValue;
     const float heightFactor[2] = {-heightFactorAbs, heightFactorAbs};
-    const bool splitLeftRight = m_options & WaveformRendererSignalBase::Option::SplitStereoSignal;
+    const bool splitLeftRight = m_options & ::WaveformRendererSignalBase::Option::SplitStereoSignal;
 
     const float low_r = static_cast<float>(m_rgbLowColor_r);
     const float mid_r = static_cast<float>(m_rgbMidColor_r);

--- a/src/waveform/renderers/allshader/waveformrendererrgb.h
+++ b/src/waveform/renderers/allshader/waveformrendererrgb.h
@@ -15,7 +15,8 @@ class allshader::WaveformRendererRGB final
     explicit WaveformRendererRGB(WaveformWidgetRenderer* waveformWidget,
             ::WaveformRendererAbstract::PositionSource type =
                     ::WaveformRendererAbstract::Play,
-            WaveformRendererSignalBase::Options options = WaveformRendererSignalBase::Option::None);
+            ::WaveformRendererSignalBase::Options options =
+                    ::WaveformRendererSignalBase::Option::None);
 
     // Pure virtual from WaveformRendererSignalBase, not used
     void onSetup(const QDomNode& node) override;
@@ -29,7 +30,7 @@ class allshader::WaveformRendererRGB final
 
   private:
     bool m_isSlipRenderer;
-    WaveformRendererSignalBase::Options m_options;
+    ::WaveformRendererSignalBase::Options m_options;
 
     bool preprocessInner();
 

--- a/src/waveform/renderers/allshader/waveformrenderersignalbase.cpp
+++ b/src/waveform/renderers/allshader/waveformrenderersignalbase.cpp
@@ -5,8 +5,8 @@
 namespace allshader {
 
 WaveformRendererSignalBase::WaveformRendererSignalBase(
-        WaveformWidgetRenderer* waveformWidget)
-        : ::WaveformRendererSignalBase(waveformWidget),
+        WaveformWidgetRenderer* waveformWidget, ::WaveformRendererSignalBase::Options options)
+        : ::WaveformRendererSignalBase(waveformWidget, options),
           m_ignoreStem(false) {
 }
 

--- a/src/waveform/renderers/allshader/waveformrenderersignalbase.h
+++ b/src/waveform/renderers/allshader/waveformrenderersignalbase.h
@@ -15,19 +15,12 @@ class WaveformRendererSignalBase;
 
 class allshader::WaveformRendererSignalBase : public ::WaveformRendererSignalBase {
   public:
-    enum class Option {
-        None = 0b0,
-        SplitStereoSignal = 0b1,
-        HighDetail = 0b10,
-        AllOptionsCombined = SplitStereoSignal | HighDetail,
-    };
-    Q_DECLARE_FLAGS(Options, Option)
-
     void draw(QPainter* painter, QPaintEvent* event) override final;
 
     static constexpr float m_maxValue{static_cast<float>(std::numeric_limits<uint8_t>::max())};
 
-    explicit WaveformRendererSignalBase(WaveformWidgetRenderer* waveformWidget);
+    explicit WaveformRendererSignalBase(WaveformWidgetRenderer* waveformWidget,
+            ::WaveformRendererSignalBase::Options options);
 
     virtual bool supportsSlip() const {
         return false;

--- a/src/waveform/renderers/allshader/waveformrenderersimple.cpp
+++ b/src/waveform/renderers/allshader/waveformrenderersimple.cpp
@@ -12,8 +12,8 @@ using namespace rendergraph;
 namespace allshader {
 
 WaveformRendererSimple::WaveformRendererSimple(
-        WaveformWidgetRenderer* waveformWidget)
-        : WaveformRendererSignalBase(waveformWidget) {
+        WaveformWidgetRenderer* waveformWidget, ::WaveformRendererSignalBase::Options options)
+        : WaveformRendererSignalBase(waveformWidget, options) {
     initForRectangles<RGBMaterial>(0);
     setUsePreprocess(true);
 }

--- a/src/waveform/renderers/allshader/waveformrenderersimple.h
+++ b/src/waveform/renderers/allshader/waveformrenderersimple.h
@@ -12,7 +12,8 @@ class allshader::WaveformRendererSimple final
         : public allshader::WaveformRendererSignalBase,
           public rendergraph::GeometryNode {
   public:
-    explicit WaveformRendererSimple(WaveformWidgetRenderer* waveformWidget);
+    explicit WaveformRendererSimple(WaveformWidgetRenderer* waveformWidget,
+            ::WaveformRendererSignalBase::Options options);
 
     // Pure virtual from WaveformRendererSignalBase, not used
     void onSetup(const QDomNode& node) override;

--- a/src/waveform/renderers/allshader/waveformrendererstem.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererstem.cpp
@@ -31,8 +31,9 @@ namespace allshader {
 
 WaveformRendererStem::WaveformRendererStem(
         WaveformWidgetRenderer* waveformWidget,
-        ::WaveformRendererAbstract::PositionSource type)
-        : WaveformRendererSignalBase(waveformWidget),
+        ::WaveformRendererAbstract::PositionSource type,
+        ::WaveformRendererSignalBase::Options options)
+        : WaveformRendererSignalBase(waveformWidget, options),
           m_isSlipRenderer(type == ::WaveformRendererAbstract::Slip),
           m_splitStemTracks(false) {
     initForRectangles<RGBAMaterial>(0);

--- a/src/waveform/renderers/allshader/waveformrendererstem.h
+++ b/src/waveform/renderers/allshader/waveformrendererstem.h
@@ -19,7 +19,9 @@ class allshader::WaveformRendererStem final
   public:
     explicit WaveformRendererStem(WaveformWidgetRenderer* waveformWidget,
             ::WaveformRendererAbstract::PositionSource type =
-                    ::WaveformRendererAbstract::Play);
+                    ::WaveformRendererAbstract::Play,
+            ::WaveformRendererSignalBase::Options options =
+                    ::WaveformRendererSignalBase::Option::None);
 
     // Pure virtual from WaveformRendererSignalBase, not used
     void onSetup(const QDomNode& node) override;

--- a/src/waveform/renderers/allshader/waveformrenderertextured.cpp
+++ b/src/waveform/renderers/allshader/waveformrenderertextured.cpp
@@ -31,8 +31,8 @@ WaveformRendererTextured::WaveformRendererTextured(
         WaveformWidgetRenderer* waveformWidget,
         ::WaveformWidgetType::Type t,
         ::WaveformRendererAbstract::PositionSource type,
-        WaveformRendererSignalBase::Options options)
-        : WaveformRendererSignalBase(waveformWidget),
+        ::WaveformRendererSignalBase::Options options)
+        : WaveformRendererSignalBase(waveformWidget, options),
           m_unitQuadListId(-1),
           m_textureId(0),
           m_textureRenderedWaveformCompletion(0),
@@ -380,7 +380,7 @@ void WaveformRendererTextured::paintGL() {
 
         if (m_type == ::WaveformWidgetType::RGB) {
             m_frameShaderProgram->setUniformValue("splitStereoSignal",
-                    m_options & WaveformRendererSignalBase::Option::SplitStereoSignal);
+                    m_options & ::WaveformRendererSignalBase::Option::SplitStereoSignal);
         }
 
         m_frameShaderProgram->setUniformValue("axesColor",

--- a/src/waveform/renderers/allshader/waveformrenderertextured.h
+++ b/src/waveform/renderers/allshader/waveformrenderertextured.h
@@ -24,8 +24,8 @@ class allshader::WaveformRendererTextured final : public allshader::WaveformRend
             WaveformWidgetType::Type t,
             ::WaveformRendererAbstract::PositionSource type =
                     ::WaveformRendererAbstract::Play,
-            WaveformRendererSignalBase::Options options =
-                    WaveformRendererSignalBase::Option::None);
+            ::WaveformRendererSignalBase::Options options =
+                    ::WaveformRendererSignalBase::Option::None);
     ~WaveformRendererTextured() override;
 
     // override ::WaveformRendererSignalBase
@@ -72,7 +72,7 @@ class allshader::WaveformRendererTextured final : public allshader::WaveformRend
 
     // shaders
     bool m_isSlipRenderer;
-    WaveformRendererSignalBase::Options m_options;
+    ::WaveformRendererSignalBase::Options m_options;
     bool m_shadersValid;
     WaveformWidgetType::Type m_type;
     const QString m_pFragShader;

--- a/src/waveform/renderers/deprecated/glwaveformrenderersignal.h
+++ b/src/waveform/renderers/deprecated/glwaveformrenderersignal.h
@@ -12,8 +12,9 @@
 /// QPainter API which Qt translates to OpenGL under the hood.
 class GLWaveformRendererSignal : public WaveformRendererSignalBase, public GLWaveformRenderer {
   public:
-    GLWaveformRendererSignal(WaveformWidgetRenderer* waveformWidgetRenderer)
-            : WaveformRendererSignalBase(waveformWidgetRenderer) {
+    GLWaveformRendererSignal(WaveformWidgetRenderer* waveformWidgetRenderer,
+            ::WaveformRendererSignalBase::Options options)
+            : WaveformRendererSignalBase(waveformWidgetRenderer, options) {
     }
 };
 

--- a/src/waveform/renderers/glvsynctestrenderer.cpp
+++ b/src/waveform/renderers/glvsynctestrenderer.cpp
@@ -7,7 +7,8 @@
 
 GLVSyncTestRenderer::GLVSyncTestRenderer(
         WaveformWidgetRenderer* waveformWidgetRenderer)
-        : GLWaveformRendererSignal(waveformWidgetRenderer),
+        : GLWaveformRendererSignal(waveformWidgetRenderer,
+                  WaveformRendererSignalBase::Option::None),
           m_drawcount(0) {
 }
 

--- a/src/waveform/renderers/qtvsynctestrenderer.cpp
+++ b/src/waveform/renderers/qtvsynctestrenderer.cpp
@@ -9,8 +9,9 @@
 
 QtVSyncTestRenderer::QtVSyncTestRenderer(
         WaveformWidgetRenderer* waveformWidgetRenderer)
-    : WaveformRendererSignalBase(waveformWidgetRenderer),
-      m_drawcount(0) {
+        : WaveformRendererSignalBase(waveformWidgetRenderer,
+                  ::WaveformRendererSignalBase::Option::None),
+          m_drawcount(0) {
 }
 
 QtVSyncTestRenderer::~QtVSyncTestRenderer() {

--- a/src/waveform/renderers/qtwaveformrendererfilteredsignal.cpp
+++ b/src/waveform/renderers/qtwaveformrendererfilteredsignal.cpp
@@ -12,8 +12,9 @@
 #include <QLinearGradient>
 
 QtWaveformRendererFilteredSignal::QtWaveformRendererFilteredSignal(
-        WaveformWidgetRenderer* waveformWidgetRenderer)
-    : WaveformRendererSignalBase(waveformWidgetRenderer) {
+        WaveformWidgetRenderer* waveformWidgetRenderer,
+        ::WaveformRendererSignalBase::Options options)
+        : WaveformRendererSignalBase(waveformWidgetRenderer, options) {
 }
 
 QtWaveformRendererFilteredSignal::~QtWaveformRendererFilteredSignal() {

--- a/src/waveform/renderers/qtwaveformrendererfilteredsignal.h
+++ b/src/waveform/renderers/qtwaveformrendererfilteredsignal.h
@@ -9,7 +9,9 @@ class ControlObject;
 
 class QtWaveformRendererFilteredSignal : public WaveformRendererSignalBase {
   public:
-    explicit QtWaveformRendererFilteredSignal(WaveformWidgetRenderer* waveformWidgetRenderer);
+    explicit QtWaveformRendererFilteredSignal(
+            WaveformWidgetRenderer* waveformWidgetRenderer,
+            ::WaveformRendererSignalBase::Options options);
     virtual ~QtWaveformRendererFilteredSignal();
 
     virtual void onSetup(const QDomNode &node);

--- a/src/waveform/renderers/waveformrendererfilteredsignal.cpp
+++ b/src/waveform/renderers/waveformrendererfilteredsignal.cpp
@@ -7,8 +7,9 @@
 #include "util/painterscope.h"
 
 WaveformRendererFilteredSignal::WaveformRendererFilteredSignal(
-        WaveformWidgetRenderer* waveformWidgetRenderer)
-    : WaveformRendererSignalBase(waveformWidgetRenderer) {
+        WaveformWidgetRenderer* waveformWidgetRenderer,
+        ::WaveformRendererSignalBase::Options options)
+        : WaveformRendererSignalBase(waveformWidgetRenderer, options) {
 }
 
 WaveformRendererFilteredSignal::~WaveformRendererFilteredSignal() {

--- a/src/waveform/renderers/waveformrendererfilteredsignal.h
+++ b/src/waveform/renderers/waveformrendererfilteredsignal.h
@@ -9,7 +9,7 @@
 class WaveformRendererFilteredSignal : public WaveformRendererSignalBase {
   public:
     explicit WaveformRendererFilteredSignal(
-        WaveformWidgetRenderer* waveformWidget);
+            WaveformWidgetRenderer* waveformWidget, ::WaveformRendererSignalBase::Options options);
     virtual ~WaveformRendererFilteredSignal();
 
     virtual void onSetup(const QDomNode& node);

--- a/src/waveform/renderers/waveformrendererhsv.cpp
+++ b/src/waveform/renderers/waveformrendererhsv.cpp
@@ -8,8 +8,9 @@
 #include "waveformwidgetrenderer.h"
 
 WaveformRendererHSV::WaveformRendererHSV(
-        WaveformWidgetRenderer* waveformWidgetRenderer)
-    : WaveformRendererSignalBase(waveformWidgetRenderer) {
+        WaveformWidgetRenderer* waveformWidgetRenderer,
+        ::WaveformRendererSignalBase::Options options)
+        : WaveformRendererSignalBase(waveformWidgetRenderer, options) {
 }
 
 WaveformRendererHSV::~WaveformRendererHSV() {

--- a/src/waveform/renderers/waveformrendererhsv.h
+++ b/src/waveform/renderers/waveformrendererhsv.h
@@ -6,7 +6,7 @@
 class WaveformRendererHSV : public WaveformRendererSignalBase {
   public:
     explicit WaveformRendererHSV(
-        WaveformWidgetRenderer* waveformWidget);
+            WaveformWidgetRenderer* waveformWidget, ::WaveformRendererSignalBase::Options options);
     virtual ~WaveformRendererHSV();
 
     virtual void onSetup(const QDomNode& node);

--- a/src/waveform/renderers/waveformrendererrgb.cpp
+++ b/src/waveform/renderers/waveformrendererrgb.cpp
@@ -6,8 +6,9 @@
 #include "util/painterscope.h"
 
 WaveformRendererRGB::WaveformRendererRGB(
-        WaveformWidgetRenderer* waveformWidgetRenderer)
-        : WaveformRendererSignalBase(waveformWidgetRenderer) {
+        WaveformWidgetRenderer* waveformWidgetRenderer,
+        ::WaveformRendererSignalBase::Options options)
+        : WaveformRendererSignalBase(waveformWidgetRenderer, options) {
 }
 
 WaveformRendererRGB::~WaveformRendererRGB() {

--- a/src/waveform/renderers/waveformrendererrgb.h
+++ b/src/waveform/renderers/waveformrendererrgb.h
@@ -6,7 +6,7 @@
 class WaveformRendererRGB : public WaveformRendererSignalBase {
   public:
     explicit WaveformRendererRGB(
-        WaveformWidgetRenderer* waveformWidget);
+            WaveformWidgetRenderer* waveformWidget, ::WaveformRendererSignalBase::Options options);
     virtual ~WaveformRendererRGB();
 
     virtual void onSetup(const QDomNode& node);

--- a/src/waveform/renderers/waveformrenderersignalbase.cpp
+++ b/src/waveform/renderers/waveformrenderersignalbase.cpp
@@ -12,7 +12,7 @@ const QString kEffectGroupFormat = QStringLiteral("[EqualizerRack1_%1_Effect1]")
 } // namespace
 
 WaveformRendererSignalBase::WaveformRendererSignalBase(
-        WaveformWidgetRenderer* waveformWidgetRenderer)
+        WaveformWidgetRenderer* waveformWidgetRenderer, Options)
         : WaveformRendererAbstract(waveformWidgetRenderer),
           m_pEQEnabled(nullptr),
           m_pLowFilterControlObject(nullptr),

--- a/src/waveform/renderers/waveformrenderersignalbase.h
+++ b/src/waveform/renderers/waveformrenderersignalbase.h
@@ -14,8 +14,16 @@ class WaveformSignalColors;
 class WaveformRendererSignalBase : public QObject, public WaveformRendererAbstract {
     Q_OBJECT
   public:
+    enum class Option {
+        None = 0b0,
+        SplitStereoSignal = 0b1,
+        HighDetail = 0b10,
+        AllOptionsCombined = SplitStereoSignal | HighDetail,
+    };
+    Q_DECLARE_FLAGS(Options, Option)
+
     explicit WaveformRendererSignalBase(
-            WaveformWidgetRenderer* waveformWidgetRenderer);
+            WaveformWidgetRenderer* waveformWidgetRenderer, Options options);
     virtual ~WaveformRendererSignalBase();
 
     virtual bool init();

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -1,5 +1,6 @@
 #include "waveform/waveformwidgetfactory.h"
 
+#include "waveform/renderers/waveformrendererabstract.h"
 #include "waveform/waveform.h"
 
 #ifdef MIXXX_USE_QOPENGL
@@ -931,7 +932,7 @@ void WaveformWidgetFactory::evaluateWidgets() {
     m_waveformWidgetHandles.clear();
     QHash<WaveformWidgetType::Type, QList<WaveformWidgetBackend>> collectedHandles;
     QHash<WaveformWidgetType::Type,
-            allshader::WaveformRendererSignalBase::Options>
+            WaveformRendererSignalBase::Options>
             supportedOptions;
     for (WaveformWidgetType::Type type : WaveformWidgetType::kValues) {
         switch (type) {
@@ -995,22 +996,21 @@ void WaveformWidgetFactory::evaluateWidgets() {
         m_waveformWidgetHandles.push_back(WaveformWidgetAbstractHandle(type, backends
 #ifdef MIXXX_USE_QOPENGL
                 ,
-                supportedOptions.value(type, allshader::WaveformRendererSignalBase::Option::None)
+                supportedOptions.value(type, WaveformRendererSignalBase::Option::None)
 #endif
                         ));
     }
 }
 
 WaveformWidgetAbstract* WaveformWidgetFactory::createAllshaderWaveformWidget(
-        WaveformWidgetType::Type type, WWaveformViewer* viewer) {
-    allshader::WaveformRendererSignalBase::Options options =
-            m_config->getValue(ConfigKey("[Waveform]", "waveform_options"),
-                    allshader::WaveformRendererSignalBase::Option::None);
+        WaveformWidgetType::Type type,
+        WWaveformViewer* viewer,
+        WaveformRendererSignalBase::Options options) {
     return new allshader::WaveformWidget(viewer, type, viewer->getGroup(), options);
 }
 
 WaveformWidgetAbstract* WaveformWidgetFactory::createFilteredWaveformWidget(
-        WWaveformViewer* viewer) {
+        WWaveformViewer* viewer, WaveformRendererSignalBase::Options options) {
     // On the UI, hardware acceleration is a boolean (0 => software rendering, 1
     // => hardware acceleration), but in the setting, we keep the granularity so
     // in case of issue when we release, we can communicate workaround on
@@ -1023,15 +1023,16 @@ WaveformWidgetAbstract* WaveformWidgetFactory::createFilteredWaveformWidget(
     switch (backend) {
 #ifdef MIXXX_USE_QOPENGL
     case WaveformWidgetBackend::AllShader: {
-        return createAllshaderWaveformWidget(WaveformWidgetType::Type::Filtered, viewer);
+        return createAllshaderWaveformWidget(WaveformWidgetType::Type::Filtered, viewer, options);
     }
 #endif
     default:
-        return new SoftwareWaveformWidget(viewer->getGroup(), viewer);
+        return new SoftwareWaveformWidget(viewer->getGroup(), viewer, options);
     }
 }
 
-WaveformWidgetAbstract* WaveformWidgetFactory::createHSVWaveformWidget(WWaveformViewer* viewer) {
+WaveformWidgetAbstract* WaveformWidgetFactory::createHSVWaveformWidget(
+        WWaveformViewer* viewer, WaveformRendererSignalBase::Options options) {
     // On the UI, hardware acceleration is a boolean (0 => software rendering, 1
     // => hardware acceleration), but in the setting, we keep the granularity so
     // in case of issue when we release, we can communicate workaround on
@@ -1044,14 +1045,15 @@ WaveformWidgetAbstract* WaveformWidgetFactory::createHSVWaveformWidget(WWaveform
     switch (backend) {
 #ifdef MIXXX_USE_QOPENGL
     case WaveformWidgetBackend::AllShader:
-        return createAllshaderWaveformWidget(WaveformWidgetType::HSV, viewer);
+        return createAllshaderWaveformWidget(WaveformWidgetType::HSV, viewer, options);
 #endif
     default:
-        return new HSVWaveformWidget(viewer->getGroup(), viewer);
+        return new HSVWaveformWidget(viewer->getGroup(), viewer, options);
     }
 }
 
-WaveformWidgetAbstract* WaveformWidgetFactory::createRGBWaveformWidget(WWaveformViewer* viewer) {
+WaveformWidgetAbstract* WaveformWidgetFactory::createRGBWaveformWidget(
+        WWaveformViewer* viewer, WaveformRendererSignalBase::Options options) {
     // On the UI, hardware acceleration is a boolean (0 => software rendering, 1
     // => hardware acceleration), but in the setting, we keep the granularity so
     // in case of issue when we release, we can communicate workaround on
@@ -1064,15 +1066,15 @@ WaveformWidgetAbstract* WaveformWidgetFactory::createRGBWaveformWidget(WWaveform
     switch (backend) {
 #ifdef MIXXX_USE_QOPENGL
     case WaveformWidgetBackend::AllShader:
-        return createAllshaderWaveformWidget(WaveformWidgetType::Type::RGB, viewer);
+        return createAllshaderWaveformWidget(WaveformWidgetType::Type::RGB, viewer, options);
 #endif
     default:
-        return new RGBWaveformWidget(viewer->getGroup(), viewer);
+        return new RGBWaveformWidget(viewer->getGroup(), viewer, options);
     }
 }
 
 WaveformWidgetAbstract* WaveformWidgetFactory::createStackedWaveformWidget(
-        WWaveformViewer* viewer) {
+        WWaveformViewer* viewer, WaveformRendererSignalBase::Options options) {
 #ifdef MIXXX_USE_QOPENGL
     // On the UI, hardware acceleration is a boolean (0 => software rendering, 1
     // => hardware acceleration), but in the setting, we keep the granularity so
@@ -1084,14 +1086,15 @@ WaveformWidgetAbstract* WaveformWidgetFactory::createStackedWaveformWidget(
             preferredBackend());
     switch (backend) {
     case WaveformWidgetBackend::AllShader:
-        return createAllshaderWaveformWidget(WaveformWidgetType::Type::Stacked, viewer);
+        return createAllshaderWaveformWidget(WaveformWidgetType::Type::Stacked, viewer, options);
 #endif
     default:
         return new EmptyWaveformWidget(viewer->getGroup(), viewer);
     }
 }
 
-WaveformWidgetAbstract* WaveformWidgetFactory::createSimpleWaveformWidget(WWaveformViewer* viewer) {
+WaveformWidgetAbstract* WaveformWidgetFactory::createSimpleWaveformWidget(
+        WWaveformViewer* viewer, WaveformRendererSignalBase::Options options) {
     // On the UI, hardware acceleration is a boolean (0 => software rendering, 1
     // => hardware acceleration), but in the setting, we keep the granularity so
     // in case of issue when we release, we can communicate workaround on
@@ -1104,7 +1107,7 @@ WaveformWidgetAbstract* WaveformWidgetFactory::createSimpleWaveformWidget(WWavef
     switch (backend) {
 #ifdef MIXXX_USE_QOPENGL
     case WaveformWidgetBackend::AllShader:
-        return createAllshaderWaveformWidget(WaveformWidgetType::Type::Simple, viewer);
+        return createAllshaderWaveformWidget(WaveformWidgetType::Type::Simple, viewer, options);
 #endif
     default:
         return new EmptyWaveformWidget(viewer->getGroup(), viewer);
@@ -1128,24 +1131,28 @@ WaveformWidgetAbstract* WaveformWidgetFactory::createWaveformWidget(
             type = WaveformWidgetType::Empty;
         }
 
+        WaveformRendererSignalBase::Options options =
+                m_config->getValue(ConfigKey("[Waveform]", "waveform_options"),
+                        WaveformRendererSignalBase::Option::None);
+
         switch (type) {
         case WaveformWidgetType::Simple:
-            widget = createSimpleWaveformWidget(viewer);
+            widget = createSimpleWaveformWidget(viewer, options);
             break;
         case WaveformWidgetType::Filtered:
-            widget = createFilteredWaveformWidget(viewer);
+            widget = createFilteredWaveformWidget(viewer, options);
             break;
         case WaveformWidgetType::HSV:
-            widget = createHSVWaveformWidget(viewer);
+            widget = createHSVWaveformWidget(viewer, options);
             break;
         case WaveformWidgetType::VSyncTest:
             widget = createVSyncTestWaveformWidget(viewer);
             break;
         case WaveformWidgetType::RGB:
-            widget = createRGBWaveformWidget(viewer);
+            widget = createRGBWaveformWidget(viewer, options);
             break;
         case WaveformWidgetType::Stacked:
-            widget = createStackedWaveformWidget(viewer);
+            widget = createStackedWaveformWidget(viewer, options);
             break;
         default:
             widget = new EmptyWaveformWidget(viewer->getGroup(), viewer);

--- a/src/waveform/waveformwidgetfactory.h
+++ b/src/waveform/waveformwidgetfactory.h
@@ -10,6 +10,7 @@
 #include "util/performancetimer.h"
 #include "util/singleton.h"
 #include "waveform/renderers/allshader/waveformrenderersignalbase.h"
+#include "waveform/renderers/waveformrenderersignalbase.h"
 #include "waveform/widgets/waveformwidgettype.h"
 #include "waveform/widgets/waveformwidgetvars.h"
 
@@ -61,11 +62,11 @@ class WaveformWidgetAbstractHandle {
     }
 
 #ifdef MIXXX_USE_QOPENGL
-    allshader::WaveformRendererSignalBase::Options supportedOptions(
+    WaveformRendererSignalBase::Options supportedOptions(
             WaveformWidgetBackend backend) const {
         return backend == WaveformWidgetBackend::AllShader
                 ? m_supportedOption
-                : allshader::WaveformRendererSignalBase::Option::None;
+                : WaveformRendererSignalBase::Option::None;
     }
 #endif
 
@@ -76,7 +77,7 @@ class WaveformWidgetAbstractHandle {
     QList<WaveformWidgetBackend> m_backends;
 #ifdef MIXXX_USE_QOPENGL
     // Only relevant for Allshader (accelerated) backend. Other backends don't implement options
-    allshader::WaveformRendererSignalBase::Options m_supportedOption;
+    WaveformRendererSignalBase::Options m_supportedOption;
 #endif
 
     friend class WaveformWidgetFactory;
@@ -260,7 +261,9 @@ class WaveformWidgetFactory : public QObject,
     template<typename WaveformT>
     QString buildWidgetDisplayName() const;
     WaveformWidgetAbstract* createAllshaderWaveformWidget(
-            WaveformWidgetType::Type type, WWaveformViewer* viewer);
+            WaveformWidgetType::Type type,
+            WWaveformViewer* viewer,
+            WaveformRendererSignalBase::Options option);
     WaveformWidgetAbstract* createWaveformWidget(WaveformWidgetType::Type type, WWaveformViewer* viewer);
     int findIndexOf(WWaveformViewer* viewer) const;
 
@@ -303,11 +306,17 @@ class WaveformWidgetFactory : public QObject,
     VisualsManager* m_pVisualsManager;  // not owned
 
     // TODO(#13245): Migrate the following methods to smart pointer.
-    WaveformWidgetAbstract* createFilteredWaveformWidget(WWaveformViewer* viewer);
-    WaveformWidgetAbstract* createHSVWaveformWidget(WWaveformViewer* viewer);
-    WaveformWidgetAbstract* createRGBWaveformWidget(WWaveformViewer* viewer);
-    WaveformWidgetAbstract* createStackedWaveformWidget(WWaveformViewer* viewer);
-    WaveformWidgetAbstract* createSimpleWaveformWidget(WWaveformViewer* viewer);
+    WaveformWidgetAbstract* createFilteredWaveformWidget(
+            WWaveformViewer* viewer,
+            WaveformRendererSignalBase::Options option);
+    WaveformWidgetAbstract* createHSVWaveformWidget(WWaveformViewer* viewer,
+            WaveformRendererSignalBase::Options option);
+    WaveformWidgetAbstract* createRGBWaveformWidget(WWaveformViewer* viewer,
+            WaveformRendererSignalBase::Options option);
+    WaveformWidgetAbstract* createStackedWaveformWidget(WWaveformViewer* viewer,
+            WaveformRendererSignalBase::Options option);
+    WaveformWidgetAbstract* createSimpleWaveformWidget(WWaveformViewer* viewer,
+            WaveformRendererSignalBase::Options option);
     WaveformWidgetAbstract* createVSyncTestWaveformWidget(WWaveformViewer* viewer);
 
     //Debug

--- a/src/waveform/widgets/allshader/waveformwidget.cpp
+++ b/src/waveform/widgets/allshader/waveformwidget.cpp
@@ -25,7 +25,7 @@ namespace allshader {
 WaveformWidget::WaveformWidget(QWidget* parent,
         WaveformWidgetType::Type type,
         const QString& group,
-        WaveformRendererSignalBase::Options options)
+        ::WaveformRendererSignalBase::Options options)
         : WGLWidget(parent),
           WaveformWidgetAbstract(group),
           m_pWaveformRendererSignal(nullptr) {
@@ -101,10 +101,10 @@ WaveformWidget::~WaveformWidget() {
 
 std::unique_ptr<WaveformRendererSignalBase>
 WaveformWidget::addWaveformSignalRenderer(WaveformWidgetType::Type type,
-        WaveformRendererSignalBase::Options options,
+        ::WaveformRendererSignalBase::Options options,
         ::WaveformRendererAbstract::PositionSource positionSource) {
 #ifndef QT_OPENGL_ES_2
-    if (options & WaveformRendererSignalBase::Option::HighDetail) {
+    if (options & ::WaveformRendererSignalBase::Option::HighDetail) {
         switch (type) {
         case ::WaveformWidgetType::RGB:
         case ::WaveformWidgetType::Filtered:
@@ -119,16 +119,16 @@ WaveformWidget::addWaveformSignalRenderer(WaveformWidgetType::Type type,
 
     switch (type) {
     case ::WaveformWidgetType::Simple:
-        return addWaveformSignalRenderer<WaveformRendererSimple>();
+        return addWaveformSignalRenderer<WaveformRendererSimple>(options);
     case ::WaveformWidgetType::RGB:
         return addWaveformSignalRenderer<WaveformRendererRGB>(positionSource, options);
     case ::WaveformWidgetType::HSV:
-        return addWaveformSignalRenderer<WaveformRendererHSV>();
+        return addWaveformSignalRenderer<WaveformRendererHSV>(options);
     case ::WaveformWidgetType::Filtered:
-        return addWaveformSignalRenderer<WaveformRendererFiltered>(false);
+        return addWaveformSignalRenderer<WaveformRendererFiltered>(false, options);
     case ::WaveformWidgetType::Stacked:
         return addWaveformSignalRenderer<WaveformRendererFiltered>(
-                true); // true for RGB Stacked
+                true, options); // true for RGB Stacked
     default:
         break;
     }
@@ -198,16 +198,16 @@ void WaveformWidget::leaveEvent(QEvent* pEvent) {
 /* static */
 WaveformRendererSignalBase::Options WaveformWidget::supportedOptions(
         WaveformWidgetType::Type type) {
-    WaveformRendererSignalBase::Options options = WaveformRendererSignalBase::Option::None;
+    ::WaveformRendererSignalBase::Options options = ::WaveformRendererSignalBase::Option::None;
     switch (type) {
     case WaveformWidgetType::Type::RGB:
-        options = WaveformRendererSignalBase::Option::AllOptionsCombined;
+        options = ::WaveformRendererSignalBase::Option::AllOptionsCombined;
         break;
     case WaveformWidgetType::Type::Filtered:
-        options = WaveformRendererSignalBase::Option::HighDetail;
+        options = ::WaveformRendererSignalBase::Option::HighDetail;
         break;
     case WaveformWidgetType::Type::Stacked:
-        options = WaveformRendererSignalBase::Option::HighDetail;
+        options = ::WaveformRendererSignalBase::Option::HighDetail;
         break;
     default:
         break;

--- a/src/waveform/widgets/allshader/waveformwidget.h
+++ b/src/waveform/widgets/allshader/waveformwidget.h
@@ -20,7 +20,7 @@ class allshader::WaveformWidget final : public ::WGLWidget,
     explicit WaveformWidget(QWidget* parent,
             WaveformWidgetType::Type type,
             const QString& group,
-            WaveformRendererSignalBase::Options options);
+            ::WaveformRendererSignalBase::Options options);
     ~WaveformWidget() override;
 
     WaveformWidgetType::Type getType() const override {
@@ -40,7 +40,7 @@ class allshader::WaveformWidget final : public ::WGLWidget,
         return this;
     }
     static WaveformWidgetVars vars();
-    static WaveformRendererSignalBase::Options supportedOptions(WaveformWidgetType::Type type);
+    static ::WaveformRendererSignalBase::Options supportedOptions(WaveformWidgetType::Type type);
 
   private:
     void castToQWidget() override;
@@ -61,7 +61,7 @@ class allshader::WaveformWidget final : public ::WGLWidget,
 
     std::unique_ptr<allshader::WaveformRendererSignalBase> addWaveformSignalRenderer(
             WaveformWidgetType::Type type,
-            WaveformRendererSignalBase::Options options,
+            ::WaveformRendererSignalBase::Options options,
             ::WaveformRendererAbstract::PositionSource positionSource);
 
     WaveformWidgetType::Type m_type;

--- a/src/waveform/widgets/hsvwaveformwidget.cpp
+++ b/src/waveform/widgets/hsvwaveformwidget.cpp
@@ -11,13 +11,15 @@
 #include "waveform/renderers/waveformrendermark.h"
 #include "waveform/renderers/waveformrendermarkrange.h"
 
-HSVWaveformWidget::HSVWaveformWidget(const QString& group, QWidget* parent)
+HSVWaveformWidget::HSVWaveformWidget(const QString& group,
+        QWidget* parent,
+        ::WaveformRendererSignalBase::Options options)
         : NonGLWaveformWidgetAbstract(group, parent) {
     addRenderer<WaveformRenderBackground>();
     addRenderer<WaveformRendererEndOfTrack>();
     addRenderer<WaveformRendererPreroll>();
     addRenderer<WaveformRenderMarkRange>();
-    addRenderer<WaveformRendererHSV>();
+    addRenderer<WaveformRendererHSV>(options);
     addRenderer<WaveformRenderBeat>();
     addRenderer<WaveformRenderMark>();
 

--- a/src/waveform/widgets/hsvwaveformwidget.h
+++ b/src/waveform/widgets/hsvwaveformwidget.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "nonglwaveformwidgetabstract.h"
+#include "waveform/renderers/waveformrenderersignalbase.h"
 
 class QWidget;
 
@@ -28,6 +29,8 @@ class HSVWaveformWidget : public NonGLWaveformWidgetAbstract {
     virtual void paintEvent(QPaintEvent* event);
 
   private:
-    HSVWaveformWidget(const QString& group, QWidget* parent);
+    HSVWaveformWidget(const QString& group,
+            QWidget* parent,
+            WaveformRendererSignalBase::Options options);
     friend class WaveformWidgetFactory;
 };

--- a/src/waveform/widgets/rgbwaveformwidget.cpp
+++ b/src/waveform/widgets/rgbwaveformwidget.cpp
@@ -11,13 +11,15 @@
 #include "waveform/renderers/waveformrendermark.h"
 #include "waveform/renderers/waveformrendermarkrange.h"
 
-RGBWaveformWidget::RGBWaveformWidget(const QString& group, QWidget* parent)
+RGBWaveformWidget::RGBWaveformWidget(const QString& group,
+        QWidget* parent,
+        WaveformRendererSignalBase::Options options)
         : NonGLWaveformWidgetAbstract(group, parent) {
     addRenderer<WaveformRenderBackground>();
     addRenderer<WaveformRendererEndOfTrack>();
     addRenderer<WaveformRendererPreroll>();
     addRenderer<WaveformRenderMarkRange>();
-    addRenderer<WaveformRendererRGB>();
+    addRenderer<WaveformRendererRGB>(options);
     addRenderer<WaveformRenderBeat>();
     addRenderer<WaveformRenderMark>();
 

--- a/src/waveform/widgets/rgbwaveformwidget.h
+++ b/src/waveform/widgets/rgbwaveformwidget.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "nonglwaveformwidgetabstract.h"
+#include "waveform/renderers/waveformrenderersignalbase.h"
 
 class QWidget;
 
@@ -28,6 +29,8 @@ class RGBWaveformWidget : public NonGLWaveformWidgetAbstract {
     virtual void paintEvent(QPaintEvent* event);
 
   private:
-    RGBWaveformWidget(const QString& group, QWidget* parent);
+    RGBWaveformWidget(const QString& group,
+            QWidget* parent,
+            WaveformRendererSignalBase::Options options);
     friend class WaveformWidgetFactory;
 };

--- a/src/waveform/widgets/softwarewaveformwidget.cpp
+++ b/src/waveform/widgets/softwarewaveformwidget.cpp
@@ -11,13 +11,15 @@
 #include "waveform/renderers/waveformrendermark.h"
 #include "waveform/renderers/waveformrendermarkrange.h"
 
-SoftwareWaveformWidget::SoftwareWaveformWidget(const QString& group, QWidget* parent)
+SoftwareWaveformWidget::SoftwareWaveformWidget(const QString& group,
+        QWidget* parent,
+        WaveformRendererSignalBase::Options options)
         : NonGLWaveformWidgetAbstract(group, parent) {
     addRenderer<WaveformRenderBackground>();
     addRenderer<WaveformRendererEndOfTrack>();
     addRenderer<WaveformRendererPreroll>();
     addRenderer<WaveformRenderMarkRange>();
-    addRenderer<WaveformRendererFilteredSignal>();
+    addRenderer<WaveformRendererFilteredSignal>(options);
     addRenderer<WaveformRenderBeat>();
     addRenderer<WaveformRenderMark>();
 

--- a/src/waveform/widgets/softwarewaveformwidget.h
+++ b/src/waveform/widgets/softwarewaveformwidget.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "nonglwaveformwidgetabstract.h"
+#include "waveform/renderers/waveformrenderersignalbase.h"
 
 class QWidget;
 
@@ -29,6 +30,8 @@ class SoftwareWaveformWidget : public NonGLWaveformWidgetAbstract {
     virtual void paintEvent(QPaintEvent* event);
 
   private:
-    SoftwareWaveformWidget(const QString& groupp, QWidget* parent);
+    SoftwareWaveformWidget(const QString& groupp,
+            QWidget* parent,
+            WaveformRendererSignalBase::Options options);
     friend class WaveformWidgetFactory;
 };


### PR DESCRIPTION
This migration allows #14998 to leverage Waveform options instead of using bare config+WaveformFactory