### PR TITLE
Update 2.5 to windows2022 runner image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,8 +85,8 @@ jobs:
             artifacts_path: build/*.dmg
             artifacts_slug: macos-macosarm
             qt_qpa_platform: offscreen
-          - name: Windows 2019 (MSVC)
-            os: windows-2019
+          - name: Windows 2022 (MSVC)
+            os: windows-2022
             # TODO: Re-enable FFmpeg after licensing issues have been clarified
             # Attention: If you change the cmake_args for the Windows CI build,
             #            also adjust the for the local Windows build setup in

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,6 +289,16 @@ if(MSVC)
   # Remove unreferenced code and data
   # Since c++11 they can safely be removed to speed up linking.
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:inline")
+
+  if(NOT DEFINED MSVC_TOOLSET_VERSION OR MSVC_TOOLSET_VERSION VERSION_LESS 143)
+    message(
+      FATAL_ERROR
+      "MSVC_TOOLSET_VERSION is ${MSVC_TOOLSET_VERSION}.\n"
+      "Mixxx requires the Microsoft Visual C++ Redistributable toolset of version 143 (VS2022) or greater, "
+      "as the VCPKG buildenv is built with this version.\n"
+      "Please use the Visual Studio 2022 toolset therefore!"
+    )
+  endif()
 endif()
 
 # Speed up builds on HDDs and prevent wearing of SDDs

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Read [CONTRIBUTING](CONTRIBUTING.md) for more information.
 
 ## Building Mixxx
 
-First, open a terminal (on Windows, use "x64 Native Tools Command Prompt for
-[VS 2019][visualstudio2019]"), download the mixxx
+First, open a terminal (on Windows, use "**x64 Native Tools Command Prompt for
+[VS 2022][visualstudio2022]**"), download the mixxx
 source code and navigate to it:
 
     $ git clone https://github.com/mixxxdj/mixxx.git
@@ -104,7 +104,7 @@ license.
 [blog]: https://mixxx.org/news/
 [manual]: https://manual.mixxx.org/
 [wiki]: https://github.com/mixxxdj/mixxx/wiki
-[visualstudio2019]: https://docs.microsoft.com/visualstudio/install/install-visual-studio?view=vs-2019
+[visualstudio2022]: https://docs.microsoft.com/visualstudio/install/install-visual-studio?view=vs-2022
 [easybugs]: https://github.com/mixxxdj/mixxx/issues?q=is%3Aopen+is%3Aissue+label%3Aeasy
 [creating skins]: https://mixxx.org/wiki/doku.php/Creating-Skins
 [help translate content]: https://www.transifex.com/projects/p/mixxxdj

--- a/src/test/soundproxy_test.cpp
+++ b/src/test/soundproxy_test.cpp
@@ -50,8 +50,13 @@ class SoundSourceProxyTest : public MixxxTest, SoundSourceProviderRegistration {
                 // was not correctly handled. The actual FFmpeg version
                 // that fixed this bug is unknown.
                 << "-itunes-12.3.0-aac.m4a"
+#ifndef __WINDOWS__
+                // These tests always fail on Windows11/Windows Server 2022,
+                // due to a bug in the MediaFoundation AAC decoder shipped with Windows.
+                // See https://bugs.mixxx.org/issues/11094
                 << "-itunes-12.7.0-aac.m4a"
                 << "-ffmpeg-aac.m4a"
+#endif
 #if defined(__FFMPEG__) || defined(__COREAUDIO__)
                 << "-itunes-12.7.0-alac.m4a"
 #endif


### PR DESCRIPTION
Fixes #15002 in 2.5 branch by cherry picking the commits from main.
A PR for mixxxdj/vcpkg is additional needed to fix this, but is not relevant until we update the buildenv for 2.5. This can be merged independent.