### PR TITLE
fix: broken CI due to deprecated `QCheckBox::checkStateChanged`

### DIFF
--- a/src/preferences/dialog/dlgprefrecord.cpp
+++ b/src/preferences/dialog/dlgprefrecord.cpp
@@ -126,7 +126,11 @@ DlgPrefRecord::DlgPrefRecord(QWidget* parent, UserSettingsPointer pConfig)
             &DlgPrefRecord::slotSliderCompression);
 
     connect(CheckBoxRecordCueFile,
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+            &QCheckBox::checkStateChanged,
+#else
             &QCheckBox::stateChanged,
+#endif
             this,
             &DlgPrefRecord::slotToggleCueEnabled);
 }


### PR DESCRIPTION
As reported in https://github.com/mixxxdj/mixxx/pull/13365#issuecomment-3009261898

Lets see if this passes.