### PR TITLE
fix: run PR CI on non-release branches too

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,6 +1,12 @@
 name: Pull request
 
 on:
+  push:
+    # ignore release branches, as those are built
+    # using the release.yml workflow
+    branches-ignore:
+      - main
+      - "[0-9].[0-9]"
   pull_request:
     types:
       - opened
@@ -16,6 +22,7 @@ jobs:
     uses: ./.github/workflows/checks.yml
 
   git:
+    if: github.event_name == 'pull_request'
     uses: ./.github/workflows/git.yml
 
   build:


### PR DESCRIPTION
This may fix @JoergAtGithub's usecase as outlined in #15024. Please test. 