### PR TITLE
ci(2.5): remove unused VCPKG_DEFAULT_HOST_TRIPLET flags from build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,32 +3,9 @@
 name: Build
 
 on:
-  workflow_call:
-    inputs:
-      publish:
-        type: boolean
-        default: false
-    secrets:
-      azure_client_id:
-        required: false
-      azure_client_secret:
-        required: false
-      azure_tenant_id:
-        required: false
-      downloads_hostgator_dot_mixxx_dot_org_key:
-        required: false
-      downloads_hostgator_dot_mixxx_dot_org_key_password:
-        required: false
-      macos_codesign_certificate_p12_base64:
-        required: false
-      macos_codesign_certificate_password:
-        required: false
-      macos_notarization_app_specific_password:
-        required: false
-      netlify_build_hook:
-        required: false
-      rryan_at_mixxx_dot_org_gpg_private_key:
-        required: false
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
 
 permissions:
   contents: read #  to fetch code (actions/checkout)
@@ -39,6 +16,30 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - name: Ubuntu 24.04
+            os: ubuntu-24.04
+            cmake_args: >-
+              -DQT6=ON
+              -DQML=ON
+              -DBULK=ON
+              -DFFMPEG=ON
+              -DLOCALECOMPARE=ON
+              -DMAD=ON
+              -DMODPLUG=ON
+              -DWAVPACK=ON
+              -DINSTALL_USER_UDEV_RULES=OFF
+            ctest_args: []
+            compiler_cache: ccache
+            compiler_cache_path: /home/runner/.cache/ccache
+            compiler_cache_id: qt6
+            cpack_generator: DEB
+            buildenv_basepath: /home/runner/buildenv
+            buildenv_script: tools/debian_buildenv.sh
+            artifacts_name: Ubuntu 24.04 Qt6 DEB
+            artifacts_path: build/*.deb
+            artifacts_slug: ubuntu-jammy
+            qt_qpa_platform: offscreen
+
           - name: Ubuntu 22.04
             os: ubuntu-22.04
             cmake_args: >-
@@ -58,7 +59,7 @@ jobs:
             cpack_generator: DEB
             buildenv_basepath: /home/runner/buildenv
             buildenv_script: tools/debian_buildenv.sh
-            artifacts_name: Ubuntu 22.04 Qt6 DEB
+            artifacts_name: Ubuntu 24.04 Qt6 DEB
             artifacts_path: build/*.deb
             artifacts_slug: ubuntu-jammy
             qt_qpa_platform: offscreen
@@ -71,9 +72,9 @@ jobs:
               -DMACOS_BUNDLE=ON
               -DMODPLUG=ON
               -DQT6=ON
+              -DQML=OFF
               -DWAVPACK=ON
               -DVCPKG_TARGET_TRIPLET=x64-osx-min1100-release
-              -DVCPKG_DEFAULT_HOST_TRIPLET=x64-osx-min1100-release
             # TODO: Fix this broken test on macOS
             ctest_args: --exclude-regex DirectoryDAOTest.relocateDirectory
             cpack_generator: DragNDrop
@@ -95,9 +96,9 @@ jobs:
               -DMACOS_BUNDLE=ON
               -DMODPLUG=ON
               -DQT6=ON
+              -DQML=ON
               -DWAVPACK=ON
               -DVCPKG_TARGET_TRIPLET=arm64-osx-min1100-release
-              -DVCPKG_DEFAULT_HOST_TRIPLET=x64-osx-min1100-release
             # TODO: Fix this broken test on macOS
             crosscompile: true
             cpack_generator: DragNDrop
@@ -110,24 +111,22 @@ jobs:
             artifacts_path: build/*.dmg
             artifacts_slug: macos-macosarm
             qt_qpa_platform: offscreen
-          - name: Windows 2022 (MSVC)
+          - name: Windows 2022 x64
             os: windows-2022
-            # TODO: Re-enable FFmpeg after licensing issues have been clarified
             # Attention: If you change the cmake_args for the Windows CI build,
             #            also adjust the for the local Windows build setup in
             #            ./tools/windows_buildenv.bat
             cmake_args: >-
               -DBULK=ON
-              -DFFMPEG=OFF
               -DHSS1394=ON
               -DLOCALECOMPARE=ON
               -DMAD=ON
               -DMEDIAFOUNDATION=ON
               -DMODPLUG=ON
               -DQT6=ON
+              -DQML=ON
               -DWAVPACK=ON
               -DVCPKG_TARGET_TRIPLET=x64-windows-release
-              -DVCPKG_DEFAULT_HOST_TRIPLET=x64-windows-release
             cc: cl
             cxx: cl
             # TODO: Fix these broken tests on Windows
@@ -135,15 +134,44 @@ jobs:
             cpack_generator: WIX
             buildenv_basepath: C:\buildenv
             buildenv_script: tools/windows_buildenv.bat
-            artifacts_name: Windows Installer
+            artifacts_name: Windows x64 Installer
             artifacts_path: build/*.msi
             artifacts_slug: windows-win64
             qt_qpa_platform: windows
+            arch: x64
+          - name: Windows 11 ARM64
+            os: windows-11-arm
+            # Attention: If you change the cmake_args for the Windows CI build,
+            #            also adjust the for the local Windows build setup in
+            #            ./tools/windows_buildenv.bat
+            cmake_args: >-
+              -DBULK=ON
+              -DHSS1394=ON
+              -DLOCALECOMPARE=ON
+              -DMAD=ON
+              -DMEDIAFOUNDATION=ON
+              -DMODPLUG=ON
+              -DQT6=ON
+              -DQML=ON
+              -DWAVPACK=ON
+              -DVCPKG_TARGET_TRIPLET=arm64-windows-release
+            cc: cl
+            cxx: cl
+            # TODO: Fix these broken tests on Windows
+            ctest_args: --exclude-regex '^AutoDJProcessorTest.*$'
+            cpack_generator: WIX
+            buildenv_basepath: C:\buildenv
+            buildenv_script: tools/windows_buildenv.bat
+            artifacts_name: Windows ARM64 Installer
+            artifacts_path: build/*.msi
+            artifacts_slug: windows-winarm
+            qt_qpa_platform: windows
+            arch: arm64
 
     env:
       # macOS codesigning
-      MACOS_CODESIGN_CERTIFICATE_P12_BASE64: ${{ secrets.macos_codesign_certificate_p12_base64 }}
-      MACOS_CODESIGN_CERTIFICATE_PASSWORD: ${{ secrets.macos_codesign_certificate_password }}
+      MACOS_CODESIGN_CERTIFICATE_P12_BASE64: ${{ secrets.MACOS_CODESIGN_CERTIFICATE_P12_BASE64 }}
+      MACOS_CODESIGN_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CODESIGN_CERTIFICATE_PASSWORD }}
 
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.name }}
@@ -152,6 +180,7 @@ jobs:
       artifact-macos-macosintel: ${{ steps.prepare_deploy.outputs.artifact-macos-macosintel }}
       artifact-macos-macosarm: ${{ steps.prepare_deploy.outputs.artifact-macos-macosarm }}
       artifact-windows-win64: ${{ steps.prepare_deploy.outputs.artifact-windows-win64 }}
+      artifact-windows-winarm: ${{ steps.prepare_deploy.outputs.artifact-windows-winarm }}
     steps:
       - name: "Check out repository"
         uses: actions/checkout@v4.2.2
@@ -172,7 +201,7 @@ jobs:
 
       - name: "[macOS] Set up cmake"
         uses: jwlawson/actions-setup-cmake@v2.0
-        # Ubuntu 22.04 should use the CMake version from the repos.
+        # Ubuntu 24.04 should use the CMake version from the repos.
         if: runner.os == 'macOS'
         with:
           # This should always match the minimum required version in
@@ -181,8 +210,9 @@ jobs:
 
       - name: "[Windows] Set up cmake"
         uses: jwlawson/actions-setup-cmake@v2.0
-        # Ubuntu 22.04 should use the CMake version from the repos.
-        if: runner.os == 'Windows'
+        # Ubuntu 24.04 should use the CMake version from the repos.
+        # On windows-11-arm this action installs the x64 version which has unwanted side effects
+        if: matrix.os == 'windows-2022'
         with:
           # This is a workaround for a SSL false positive in cmake 3.26.4
           # When downloading the manual. 3.21 is required for installing the
@@ -192,6 +222,18 @@ jobs:
       - name: "[Windows] Set up MSVC Developer Command Prompt"
         if: runner.os == 'Windows'
         uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.arch }}
+
+      - name: "[Windows 11 ARM64] Install ARM64 CMake"
+        if: matrix.os == 'windows-11-arm'
+        run: |
+          Invoke-WebRequest -Uri https://github.com/Kitware/CMake/releases/download/v3.30.1/cmake-3.30.1-windows-arm64.zip -OutFile cmake-arm64.zip
+          Expand-Archive cmake-arm64.zip -DestinationPath $env:USERPROFILE\cmake
+          $cmakePath = "$env:USERPROFILE\cmake\cmake-3.30.1-windows-arm64\bin"
+          $cmakePath | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          $env:Path += ";$cmakePath"
+          cmake --version
 
       - name: "[macOS] install ccache and make"
         if: runner.os == 'macOS'
@@ -336,13 +378,13 @@ jobs:
 
       - name: "[Windows] Sign executables"
         env:
-          azure_tenant_id: ${{ secrets.azure_tenant_id }}
-        if: runner.os == 'Windows' && env.azure_tenant_id
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+        if: runner.os == 'Windows' && env.AZURE_TENANT_ID
         uses: azure/trusted-signing-action@v0.5.1
         with:
-          azure-tenant-id: ${{ secrets.azure_tenant_id }}
-          azure-client-id: ${{ secrets.azure_client_id }}
-          azure-client-secret: ${{ secrets.azure_client_secret }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
           endpoint: https://weu.codesigning.azure.net/
           trusted-signing-account-name: mixxx
           certificate-profile-name: mixxx
@@ -353,7 +395,16 @@ jobs:
           timestamp-digest: SHA256
           timeout: 600
 
+      - name: "[Windows 11 ARM64] Install WiX Toolset3"
+        if: matrix.os == 'windows-11-arm'
+        run: |
+          choco install wixtoolset
+          Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
+          refreshenv
+          echo "WIX=$env:WIX" >> $env:GITHUB_ENV
+
       - name: "Package"
+        id: package
         if: matrix.cpack_generator != null
         # Use retry loop to work around a race condition on macOS causing
         # 'Resource busy' errors with 'hdiutil'. See
@@ -361,21 +412,28 @@ jobs:
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 30
-          max_attempts: 12
+          max_attempts: ${{ runner.os == 'macOS' && 12 || 1 }}
           retry_wait_seconds: 1
           command: |
             cd build
             cpack -G ${{ matrix.cpack_generator }} -V
 
+      - name: Upload failed packaging logs
+        if: always() && steps.package.outcome == 'failure' && runner.os == 'windows'
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs-packages-wix
+          path: D:/a/mixxx/mixxx/build/_CPack_Packages/win64/WIX/wix.log
+
       - name: "[Ubuntu] Import PPA GPG key"
         if: startsWith(matrix.os, 'ubuntu') && env.RRYAN_AT_MIXXX_DOT_ORG_GPG_PRIVATE_KEY != null
-        run: gpg --import <(echo "${{ secrets.rryan_at_mixxx_dot_org_gpg_private_key }}")
+        run: gpg --import <(echo "${{ secrets.RRYAN_AT_MIXXX_DOT_ORG_GPG_PRIVATE_KEY }}")
         env:
-          RRYAN_AT_MIXXX_DOT_ORG_GPG_PRIVATE_KEY: ${{ secrets.rryan_at_mixxx_dot_org_gpg_private_key }}
+          RRYAN_AT_MIXXX_DOT_ORG_GPG_PRIVATE_KEY: ${{ secrets.RRYAN_AT_MIXXX_DOT_ORG_GPG_PRIVATE_KEY }}
 
       - name: "Package for PPA"
         # No need to do the PPA build for both Ubuntu versions
-        if: matrix.name == 'Ubuntu 22.04'
+        if: matrix.name == 'Ubuntu 24.04'
         run: |
           if [[ "${{ github.ref }}" == "refs/heads/main" ]] && [[ "${{ github.repository }}" == "mixxxdj/mixxx" ]]; then
             CPACK_ARGS="-D DEB_UPLOAD_PPA=ppa:mixxx/nightlies"
@@ -395,18 +453,18 @@ jobs:
         run: packaging/macos/sign_notarize_staple.sh build/*.dmg
         env:
           APPLE_ID_USERNAME: daschuer@mixxx.org
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.macos_notarization_app_specific_password }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.MACOS_NOTARIZATION_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: JBLRSP95FC
 
       - name: "[Windows] Sign installer"
         env:
-          azure_tenant_id: ${{ secrets.azure_tenant_id }}
-        if: runner.os == 'Windows' && env.azure_tenant_id
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+        if: runner.os == 'Windows' && env.AZURE_TENANT_ID
         uses: azure/trusted-signing-action@v0.5.1
         with:
-          azure-tenant-id: ${{ secrets.azure_tenant_id }}
-          azure-client-id: ${{ secrets.azure_client_id }}
-          azure-client-secret: ${{ secrets.azure_client_secret }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
           endpoint: https://weu.codesigning.azure.net/
           trusted-signing-account-name: mixxx
           certificate-profile-name: mixxx
@@ -422,7 +480,7 @@ jobs:
         # also generates metadata for file artifact and write it to the job
         # output using the artifacts_slug value.
         id: prepare_deploy
-        if: inputs.publish && matrix.artifacts_path != null
+        if: github.event_name == 'push' && matrix.artifacts_path != null
         shell: bash
         run: >
           if [[ "${GITHUB_REF}" =~ ^refs/tags/.* ]];
@@ -438,45 +496,29 @@ jobs:
           --dest-url 'https://downloads.mixxx.org'
           ${{ matrix.artifacts_path }}
 
-      # Warning: do not move this step before restoring caches or it will break caching due to
-      # https://github.com/actions/cache/issues/531
       - name: "[Windows] Install rsync and openssh"
         env:
-          SSH_PRIVATE_KEY: ${{ secrets.downloads_hostgator_dot_mixxx_dot_org_key }}
-        if: runner.os == 'Windows' && inputs.publish && env.SSH_PRIVATE_KEY != null
+          SSH_PRIVATE_KEY: ${{ secrets.DOWNLOADS_HOSTGATOR_DOT_MIXXX_DOT_ORG_KEY }}
+        if: runner.os == 'Windows' && github.event_name == 'push' && env.SSH_PRIVATE_KEY != null
         run: |
-          $Env:PATH="c:\msys64\usr\bin;$Env:PATH"
+          if (Test-Path "C:\msys64\usr\bin") {
+            $msysPath="C:\msys64"
+          } else {
+            choco install msys2 -y
+            $msysPath="C:\tools\msys64"
+          }
+          $Env:PATH="$msysPath\usr\bin;$Env:PATH"
           pacman -S --noconfirm coreutils bash rsync openssh
-          # Unfortunately, mixing executables from msys64 and mingw (i.e. Git
-          # Bash) does not work properly and leads to errors like these:
-          #
-          #     0 [main] python3 (5248) C:\msys64\usr\bin\python3.exe: *** fatal error - cygheap base mismatch detected - 0x180347408/0x180352408.
-          #
-          # Even when prepending the MSYS2 binary directory to %PATH%, GitHub
-          # Actions will still pick the Git Bash executable over the MSYS2 one
-          # when using `shell: bash`. Since it's not feasible to set `shell` to
-          # an absolute path in a cross-platform build workflow, we overwrite the
-          # git bash executable with the MSYS2 one.
-          #
-          # Also see related issue:
-          # https://github.com/actions/virtual-environments/issues/594
           Copy-Item -Path "C:\msys64\usr\bin\bash.exe" -Destination "C:\Program Files\Git\bin\bash.exe" -Force
-          # By default, MSYS2 uses an
-          # /etc/profile file that changes
-          # the current working directory
-          # when bash is started. We don't
-          # want this behavior,so we just
-          # delete it.
           Remove-Item -Path "C:\msys64\etc\profile"
-          # Add MSYS2's tools to %PATH%.
           Add-Content -Path "$Env:GITHUB_ENV" -Value "PATH=$Env:PATH"
 
       - name: "Set up SSH Agent"
-        if: inputs.publish && env.SSH_PRIVATE_KEY != null
+        if: github.event_name == 'push' && env.SSH_PRIVATE_KEY != null
         shell: bash
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-          SSH_PRIVATE_KEY: ${{ secrets.downloads_hostgator_dot_mixxx_dot_org_key }}
+          SSH_PRIVATE_KEY: ${{ secrets.DOWNLOADS_HOSTGATOR_DOT_MIXXX_DOT_ORG_KEY }}
           SSH_HOST: downloads-hostgator.mixxx.org
         run: |
           ssh-agent -a $SSH_AUTH_SOCK > /dev/null
@@ -487,7 +529,7 @@ jobs:
 
       - name: "[macOS/Windows] Upload build to downloads.mixxx.org"
         # skip deploying Ubuntu builds to downloads.mixxx.org because these are deployed to the PPA
-        if: runner.os != 'Linux' && inputs.publish && env.SSH_AUTH_SOCK != null
+        if: runner.os != 'Linux' && github.event_name == 'push' && env.SSH_AUTH_SOCK != null
         shell: bash --login -eo pipefail "{0}"
         run: rsync --verbose --recursive --checksum --times --delay-updates "deploy/" "${SSH_USER}@${SSH_HOST}:${DESTDIR}/"
         env:
@@ -495,8 +537,7 @@ jobs:
           SSH_HOST: downloads-hostgator.mixxx.org
           SSH_USER: mixxx
 
-      # Workaround for https://github.com/actions/cache/issues/531
-      - name: Use system tar & zstd from Chocolatey for caching
+      - name: "Use system tar & zstd from Chocolatey for caching"
         if: runner.os == 'Windows'
         shell: bash
         run: |
@@ -513,10 +554,6 @@ jobs:
     name: "Update manifest file on download server"
     runs-on: ubuntu-latest
     needs: build
-    # Always run this job, even if one or more jobs from the `build` jobs
-    # fail to allow partial updates of the manifest.
-    # Don't run it on forks that do not have access to our external
-    # infrastructure, though.
     if: always() && github.repository == 'mixxxdj/mixxx'
     steps:
       - name: "Check out repository"
@@ -525,15 +562,12 @@ jobs:
           fetch-depth: 0
 
       - name: "Ensure that all tags are fetched"
-        # Works around an issue where not the latest tag is not fetched when the
-        # workflow is triggered by a tag push event.
-        # Possibly related: actions/checkout#290
         run: git fetch origin --force --tags
 
       - name: "Collect Artifacts Metadata & Write Manifest"
         # Retrieve the metadata from the matrix job's outputs, merge them into a
         # single JSON document and then deploy to the server.
-        if: inputs.publish && env.SSH_PASSWORD != null
+        if: github.event_name == 'push' && env.SSH_PASSWORD != null
         run: >
           if [[ "${GITHUB_REF}" =~ ^refs/tags/.* ]];
           then
@@ -548,33 +582,17 @@ jobs:
           --dest-url 'https://downloads.mixxx.org'
         env:
           JOB_DATA: ${{ toJSON(needs.build) }}
-          SSH_PASSWORD: ${{ secrets.downloads_hostgator_dot_mixxx_dot_org_key_password }}
+          SSH_PASSWORD: ${{ secrets.DOWNLOADS_HOSTGATOR_DOT_MIXXX_DOT_ORG_KEY_PASSWORD }}
 
       - name: "Set up SSH Agent"
-        if: inputs.publish && env.SSH_PRIVATE_KEY != null  && env.MANIFEST_DIRTY != null && env.MANIFEST_DIRTY != '0'
+        if: github.event_name == 'push' && env.SSH_PRIVATE_KEY != null  && env.MANIFEST_DIRTY != null && env.MANIFEST_DIRTY != '0'
         shell: bash
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-          SSH_PRIVATE_KEY: ${{ secrets.downloads_hostgator_dot_mixxx_dot_org_key }}
+          SSH_PRIVATE_KEY: ${{ secrets.DOWNLOADS_HOSTGATOR_DOT_MIXXX_DOT_ORG_KEY }}
           SSH_HOST: downloads-hostgator.mixxx.org
         run: |
           ssh-agent -a $SSH_AUTH_SOCK > /dev/null
           ssh-add - <<< "${SSH_PRIVATE_KEY}"
           mkdir -p "${HOME}/.ssh"
-          ssh-keyscan "${SSH_HOST}" >> "${HOME}/.ssh/known_hosts"
-          echo "SSH_AUTH_SOCK=${SSH_AUTH_SOCK}" >> "${GITHUB_ENV}"
-
-      - name: "Deploy Manifest"
-        if: inputs.publish && env.SSH_AUTH_SOCK != null
-        shell: bash
-        run: rsync --verbose --recursive --checksum --times --delay-updates "deploy/" "${SSH_USER}@${SSH_HOST}:${DESTDIR}/"
-        env:
-          DESTDIR: public_html/downloads
-          SSH_HOST: downloads-hostgator.mixxx.org
-          SSH_USER: mixxx
-
-      - name: "Trigger Netlify build"
-        if: env.NETLIFY_BUILD_HOOK != null && env.MANIFEST_DIRTY != null && env.MANIFEST_DIRTY != '0'
-        run: curl -X POST -d '{}' ${{ env.NETLIFY_BUILD_HOOK }}
-        env:
-          NETLIFY_BUILD_HOOK: ${{ secrets.netlify_build_hook }}
+          ssh-keyscan "${SSH_HOST}" >> "${HOME}/.ssh/known_hosts"`


### PR DESCRIPTION
This PR removes all occurrences of the obsolete **-DVCPKG_DEFAULT_HOST_TRIPLET=…** lines from our **.github/workflows/build.yml** on the **2.5** branch. Those flags were never actually consumed by CMake, and were triggering “Manually‑specified variables were not used” warnings in CI.

Fixes issue: https://github.com/mixxxdj/mixxx/issues/15022