### PR TITLE
ci(2.5): remove all VCPKG_DEFAULT_HOST_TRIPLET entries from build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,6 @@ jobs:
               -DQT6=ON
               -DWAVPACK=ON
               -DVCPKG_TARGET_TRIPLET=x64-osx-min1100-release
-              -DVCPKG_DEFAULT_HOST_TRIPLET=x64-osx-min1100-release
             # TODO: Fix this broken test on macOS
             ctest_args: --exclude-regex DirectoryDAOTest.relocateDirectory
             cpack_generator: DragNDrop
@@ -97,7 +96,6 @@ jobs:
               -DQT6=ON
               -DWAVPACK=ON
               -DVCPKG_TARGET_TRIPLET=arm64-osx-min1100-release
-              -DVCPKG_DEFAULT_HOST_TRIPLET=x64-osx-min1100-release
             # TODO: Fix this broken test on macOS
             crosscompile: true
             cpack_generator: DragNDrop
@@ -127,7 +125,6 @@ jobs:
               -DQT6=ON
               -DWAVPACK=ON
               -DVCPKG_TARGET_TRIPLET=x64-windows-release
-              -DVCPKG_DEFAULT_HOST_TRIPLET=x64-windows-release
             cc: cl
             cxx: cl
             # TODO: Fix these broken tests on Windows


### PR DESCRIPTION
This PR removes the unused `-DVCPKG_DEFAULT_HOST_TRIPLET` flags from the `.github/workflows/build.yml` file.

These flags were previously set in the CMake arguments, but are no longer used by the Mixxx build system. They were triggering CMake warnings like:

Manually-specified variables were not used by the project:
VCPKG_DEFAULT_HOST_TRIPLET


Removing them simplifies the workflow configuration and eliminates unnecessary warnings during CI runs.

Fixes: #15022
@daschuer Kindly review this.