### PR TITLE
(fix) Track Info dialog: restore column stretching

### DIFF
--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -50,7 +50,7 @@
       <layout class="QVBoxLayout" name="summary_layout">
        <item>
         <widget class="QGroupBox" name="groupBox">
-         <layout class="QGridLayout" name="tags_layout">
+         <layout class="QGridLayout" name="tags_layout" columnstretch="0,10,0,2">
 
           <item row="0" column="0">
            <widget class="QLabel" name="lblTitle">


### PR DESCRIPTION
probably got lost during merge of 2.5

currently
![currently](https://github.com/user-attachments/assets/2cb45ba9-c01c-4822-a681-fadaacb2a801)

fixed
![fixed](https://github.com/user-attachments/assets/dd959f6c-e061-48f9-8841-5b3178d70601)
