### PR TITLE
Fix WiX error log file generation in GitHub workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -401,8 +401,8 @@ jobs:
         if: always() && steps.package.outcome == 'failure' && runner.os == 'windows'
         uses: actions/upload-artifact@v4
         with:
-          name: logs-packages-wix
-          path: D:/a/mixxx/mixxx/build/_CPack_Packages/win64/WIX/wix.log
+          name: ${{ matrix.os }}-logs-packages-wix
+          path: ${{ github.workspace }}/build/_CPack_Packages/win64/WIX/wix.log
 
       - name: "[Ubuntu] Import PPA GPG key"
         if: startsWith(matrix.os, 'ubuntu') && env.RRYAN_AT_MIXXX_DOT_ORG_GPG_PRIVATE_KEY != null


### PR DESCRIPTION
Files of both architectures collide (only happens, if both have errors)
The absolute path did not match to the arm64 runner