### PR TITLE
Don't rename secrets when passing them to reusable workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,25 +9,25 @@ on:
         type: boolean
         default: false
     secrets:
-      azure_client_id:
+      AZURE_CLIENT_ID:
         required: false
-      azure_client_secret:
+      AZURE_CLIENT_SECRET:
         required: false
-      azure_tenant_id:
+      AZURE_TENANT_ID:
         required: false
-      downloads_hostgator_dot_mixxx_dot_org_key:
+      DOWNLOADS_HOSTGATOR_DOT_MIXXX_DOT_ORG_KEY:
         required: false
-      downloads_hostgator_dot_mixxx_dot_org_key_password:
+      DOWNLOADS_HOSTGATOR_DOT_MIXXX_DOT_ORG_KEY_PASSWORD:
         required: false
-      macos_codesign_certificate_p12_base64:
+      MACOS_CODESIGN_CERTIFICATE_P12_BASE64:
         required: false
-      macos_codesign_certificate_password:
+      MACOS_CODESIGN_CERTIFICATE_PASSWORD:
         required: false
-      macos_notarization_app_specific_password:
+      MACOS_NOTARIZATION_APP_SPECIFIC_PASSWORD:
         required: false
-      netlify_build_hook:
+      NETLIFY_BUILD_HOOK:
         required: false
-      rryan_at_mixxx_dot_org_gpg_private_key:
+      RRYAN_AT_MIXXX_DOT_ORG_GPG_PRIVATE_KEY:
         required: false
 
 permissions:
@@ -139,8 +139,8 @@ jobs:
 
     env:
       # macOS codesigning
-      MACOS_CODESIGN_CERTIFICATE_P12_BASE64: ${{ secrets.macos_codesign_certificate_p12_base64 }}
-      MACOS_CODESIGN_CERTIFICATE_PASSWORD: ${{ secrets.macos_codesign_certificate_password }}
+      MACOS_CODESIGN_CERTIFICATE_P12_BASE64: ${{ secrets.MACOS_CODESIGN_CERTIFICATE_P12_BASE64 }}
+      MACOS_CODESIGN_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CODESIGN_CERTIFICATE_PASSWORD }}
 
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.name }}
@@ -333,13 +333,13 @@ jobs:
 
       - name: "[Windows] Sign executables"
         env:
-          azure_tenant_id: ${{ secrets.azure_tenant_id }}
-        if: runner.os == 'Windows' && env.azure_tenant_id
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+        if: runner.os == 'Windows' && env.AZURE_TENANT_ID
         uses: azure/trusted-signing-action@v0.5.1
         with:
-          azure-tenant-id: ${{ secrets.azure_tenant_id }}
-          azure-client-id: ${{ secrets.azure_client_id }}
-          azure-client-secret: ${{ secrets.azure_client_secret }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
           endpoint: https://weu.codesigning.azure.net/
           trusted-signing-account-name: mixxx
           certificate-profile-name: mixxx
@@ -366,9 +366,9 @@ jobs:
 
       - name: "[Ubuntu] Import PPA GPG key"
         if: startsWith(matrix.os, 'ubuntu') && env.RRYAN_AT_MIXXX_DOT_ORG_GPG_PRIVATE_KEY != null
-        run: gpg --import <(echo "${{ secrets.rryan_at_mixxx_dot_org_gpg_private_key }}")
+        run: gpg --import <(echo "${{ secrets.RRYAN_AT_MIXXX_DOT_ORG_GPG_PRIVATE_KEY }}")
         env:
-          RRYAN_AT_MIXXX_DOT_ORG_GPG_PRIVATE_KEY: ${{ secrets.rryan_at_mixxx_dot_org_gpg_private_key }}
+          RRYAN_AT_MIXXX_DOT_ORG_GPG_PRIVATE_KEY: ${{ secrets.RRYAN_AT_MIXXX_DOT_ORG_GPG_PRIVATE_KEY }}
 
       - name: "Package for PPA"
         # No need to do the PPA build for both Ubuntu versions
@@ -392,18 +392,18 @@ jobs:
         run: packaging/macos/sign_notarize_staple.sh build/*.dmg
         env:
           APPLE_ID_USERNAME: daschuer@mixxx.org
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.macos_notarization_app_specific_password }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.MACOS_NOTARIZATION_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: JBLRSP95FC
 
       - name: "[Windows] Sign installer"
         env:
-          azure_tenant_id: ${{ secrets.azure_tenant_id }}
-        if: runner.os == 'Windows' && env.azure_tenant_id
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+        if: runner.os == 'Windows' && env.AZURE_TENANT_ID
         uses: azure/trusted-signing-action@v0.5.1
         with:
-          azure-tenant-id: ${{ secrets.azure_tenant_id }}
-          azure-client-id: ${{ secrets.azure_client_id }}
-          azure-client-secret: ${{ secrets.azure_client_secret }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
           endpoint: https://weu.codesigning.azure.net/
           trusted-signing-account-name: mixxx
           certificate-profile-name: mixxx
@@ -439,7 +439,7 @@ jobs:
       # https://github.com/actions/cache/issues/531
       - name: "[Windows] Install rsync and openssh"
         env:
-          SSH_PRIVATE_KEY: ${{ secrets.downloads_hostgator_dot_mixxx_dot_org_key }}
+          SSH_PRIVATE_KEY: ${{ secrets.DOWNLOADS_HOSTGATOR_DOT_MIXXX_DOT_ORG_KEY }}
         if: runner.os == 'Windows' && inputs.publish && env.SSH_PRIVATE_KEY != null
         run: |
           $Env:PATH="c:\msys64\usr\bin;$Env:PATH"
@@ -473,7 +473,7 @@ jobs:
         shell: bash
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-          SSH_PRIVATE_KEY: ${{ secrets.downloads_hostgator_dot_mixxx_dot_org_key }}
+          SSH_PRIVATE_KEY: ${{ secrets.DOWNLOADS_HOSTGATOR_DOT_MIXXX_DOT_ORG_KEY }}
           SSH_HOST: downloads-hostgator.mixxx.org
         run: |
           ssh-agent -a $SSH_AUTH_SOCK > /dev/null
@@ -545,14 +545,14 @@ jobs:
           --dest-url 'https://downloads.mixxx.org'
         env:
           JOB_DATA: ${{ toJSON(needs.build) }}
-          SSH_PASSWORD: ${{ secrets.downloads_hostgator_dot_mixxx_dot_org_key_password }}
+          SSH_PASSWORD: ${{ secrets.DOWNLOADS_HOSTGATOR_DOT_MIXXX_DOT_ORG_KEY_PASSWORD }}
 
       - name: "Set up SSH Agent"
         if: inputs.publish && env.SSH_PRIVATE_KEY != null  && env.MANIFEST_DIRTY != null && env.MANIFEST_DIRTY != '0'
         shell: bash
         env:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
-          SSH_PRIVATE_KEY: ${{ secrets.downloads_hostgator_dot_mixxx_dot_org_key }}
+          SSH_PRIVATE_KEY: ${{ secrets.DOWNLOADS_HOSTGATOR_DOT_MIXXX_DOT_ORG_KEY }}
           SSH_HOST: downloads-hostgator.mixxx.org
         run: |
           ssh-agent -a $SSH_AUTH_SOCK > /dev/null
@@ -574,4 +574,4 @@ jobs:
         if: env.NETLIFY_BUILD_HOOK != null && env.MANIFEST_DIRTY != null && env.MANIFEST_DIRTY != '0'
         run: curl -X POST -d '{}' ${{ env.NETLIFY_BUILD_HOOK }}
         env:
-          NETLIFY_BUILD_HOOK: ${{ secrets.netlify_build_hook }}
+          NETLIFY_BUILD_HOOK: ${{ secrets.NETLIFY_BUILD_HOOK }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,4 +41,4 @@ jobs:
     if: ${{ github.ref != 'refs/heads/main' }}
     uses: ./.github/workflows/sync_branches.yml
     secrets:
-      pat_token: ${{ secrets.MIXXX_BRANCH_SYNC_PAT }}
+      MIXXX_BRANCH_SYNC_PAT: ${{ secrets.MIXXX_BRANCH_SYNC_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,16 +26,16 @@ jobs:
     with:
       publish: true
     secrets:
-      azure_client_id: ${{ secrets.AZURE_CLIENT_ID }}
-      azure_client_secret: ${{ secrets.AZURE_CLIENT_SECRET }}
-      azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
-      downloads_hostgator_dot_mixxx_dot_org_key: ${{ secrets.DOWNLOADS_HOSTGATOR_DOT_MIXXX_DOT_ORG_KEY }}
-      downloads_hostgator_dot_mixxx_dot_org_key_password: ${{ secrets.DOWNLOADS_HOSTGATOR_DOT_MIXXX_DOT_ORG_KEY_PASSWORD }}
-      macos_codesign_certificate_p12_base64: ${{ secrets.MACOS_CODESIGN_CERTIFICATE_P12_BASE64 }}
-      macos_codesign_certificate_password: ${{ secrets.MACOS_CODESIGN_CERTIFICATE_PASSWORD }}
-      macos_notarization_app_specific_password: ${{ secrets.MACOS_NOTARIZATION_APP_SPECIFIC_PASSWORD }}
-      netlify_build_hook: ${{ secrets.NETLIFY_BUILD_HOOK }}
-      rryan_at_mixxx_dot_org_gpg_private_key: ${{ secrets.RRYAN_AT_MIXXX_DOT_ORG_GPG_PRIVATE_KEY }}
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      DOWNLOADS_HOSTGATOR_DOT_MIXXX_DOT_ORG_KEY: ${{ secrets.DOWNLOADS_HOSTGATOR_DOT_MIXXX_DOT_ORG_KEY }}
+      DOWNLOADS_HOSTGATOR_DOT_MIXXX_DOT_ORG_KEY_PASSWORD: ${{ secrets.DOWNLOADS_HOSTGATOR_DOT_MIXXX_DOT_ORG_KEY_PASSWORD }}
+      MACOS_CODESIGN_CERTIFICATE_P12_BASE64: ${{ secrets.MACOS_CODESIGN_CERTIFICATE_P12_BASE64 }}
+      MACOS_CODESIGN_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CODESIGN_CERTIFICATE_PASSWORD }}
+      MACOS_NOTARIZATION_APP_SPECIFIC_PASSWORD: ${{ secrets.MACOS_NOTARIZATION_APP_SPECIFIC_PASSWORD }}
+      NETLIFY_BUILD_HOOK: ${{ secrets.NETLIFY_BUILD_HOOK }}
+      RRYAN_AT_MIXXX_DOT_ORG_GPG_PRIVATE_KEY: ${{ secrets.RRYAN_AT_MIXXX_DOT_ORG_GPG_PRIVATE_KEY }}
 
   sync:
     if: ${{ github.ref != 'refs/heads/main' }}

--- a/.github/workflows/sync_branches.yml
+++ b/.github/workflows/sync_branches.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     secrets:
       # PAT setup with content:write and pull_request:write
-      pat_token:
+      MIXXX_BRANCH_SYNC_PAT:
         required: true
 
 permissions: {}
@@ -13,7 +13,8 @@ env:
   SYNC_COMMITTER_EMAIL: bot@mixxx.org
   SYNC_COMMITTER_NAME: Mixxx Bot
 
-  # This variable stores the map of Mixxx branches that still being developed. The key is the branch receiving support and the value is the next version in line
+  # This variable stores the map of Mixxx branches that still being developed.
+  # The key is the branch receiving support and the value is the next version in line
   # NOTE: this must be valid JSON!
   ACTIVE_VERSIONS: |-
     {"2.5": "2.6", "2.6": "main"}
@@ -41,7 +42,7 @@ jobs:
       - name: "Check out repository"
         uses: actions/checkout@v4.1.7
         with:
-          token: ${{ secrets.pat_token }}
+          token: ${{ secrets.MIXXX_BRANCH_SYNC_PAT }}
           fetch-depth: 0
           persist-credentials: true
 
@@ -99,7 +100,7 @@ jobs:
           FROM_BRANCH: ${{ github.ref_name }}
           TO_BRANCH: ${{ fromJSON(env.ACTIVE_VERSIONS)[github.ref_name] }}
           SYNC_BRANCH: sync-branch-${{ github.ref_name }}-to-${{ fromJSON(env.ACTIVE_VERSIONS)[github.ref_name] }}
-          GITHUB_TOKEN: ${{ secrets.pat_token }}
+          GITHUB_TOKEN: ${{ secrets.MIXXX_BRANCH_SYNC_PAT }}
           PULL_REQUEST_TITLE: Merge changes from `${{ github.ref_name  }}` into `${{ fromJSON(env.ACTIVE_VERSIONS)[github.ref_name] }}`
           PULL_REQUEST_BODY: |
             New content has landed in the `${{ github.ref_name  }}` branch, so let's merge the changes into `${{ fromJSON(env.ACTIVE_VERSIONS)[github.ref_name] }}`


### PR DESCRIPTION
This keeps workflows reusable workflows readable without following renaming in the caller. It also allows quickly using the work flow directly without renaming. It will be easier to maintain in case of renaming or adding secrets in the GitHub config.

Successfully tested here 
https://github.com/daschuer/mixxx/actions/runs/15956365499

(except sync/sync-branches which is an independent issue.) 