### PR TITLE
Traktor S3: Fix hotcue color output

### DIFF
--- a/res/controllers/Traktor Kontrol S3.hid.xml
+++ b/res/controllers/Traktor Kontrol S3.hid.xml
@@ -4,8 +4,7 @@
     <name>Traktor Kontrol S3</name>
     <author>Owen Williams</author>
     <description>HID Mapping for Traktor Kontrol S3</description>
-    <wiki>https://github.com/mixxxdj/mixxx/wiki/Native-Instruments-Traktor-Kontrol-S3</wiki>
-    <forums>https://mixxx.discourse.group/t/native-instruments-traktor-s3-mapping/18502/4</forums>
+    <forums>https://mixxx.discourse.group/t/native-instruments-traktor-s3-mapping/18502</forums>
     <manual>native_instruments_traktor_kontrol_s3</manual>
     <devices>
       <product protocol="hid" vendor_id="0x17cc" product_id="0x1900" usage_page="0xff01" usage="0x1" interface_number="0x3" />
@@ -18,6 +17,28 @@
     </scriptfiles>
   </controller>
   <settings>
+    <option variable="ledDimValue" type="enum"
+      label="Dim LED Level">
+      <value label="Off">0</value>
+      <value label="Low" default="true">1</value>
+      <value label="Mid">2</value>
+      <value label="High">3</value>
+      <description>
+        Sets the brightness of the LEDs when they are on in a dim mode.
+        High does not work when using bus power and will appear the same as mid.
+      </description>
+    </option>
+    <option variable="ledBrightValue" type="enum"
+      label="Bright LED Level">
+      <value label="Off">0</value>
+      <value label="Low">1</value>
+      <value label="Mid">2</value>
+      <value label="High" default="true">3</value>
+      <description>
+        Sets the brightness of the LEDs when they are set to bright mode.
+        High does not work when using bus power and will appear the same as mid.
+      </description>
+    </option>
     <option variable="fxMode" type="enum"
       label="Effect section layout">
       <value label="Quick Effect" default="true">QUICK_EFFECT</value>

--- a/res/controllers/Traktor-Kontrol-S3-hid-scripts.js
+++ b/res/controllers/Traktor-Kontrol-S3-hid-scripts.js
@@ -2,8 +2,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////////
 //
-// Traktor Kontrol S3 HID controller script v2.00
-// Last modification: January 2023
+// Traktor Kontrol S3 HID controller script
 // Authors: Owen Williams, Robbert van der Helm
 // https://manual.mixxx.org/latest/en/hardware/controllers/native_instruments_traktor_kontrol_s3.html
 //
@@ -93,8 +92,8 @@ TraktorS3.ChannelColors = {
 };
 
 // Each color has four brightnesses, so these values can be between 0 and 3.
-TraktorS3.LEDDimValue = 0x00;
-TraktorS3.LEDBrightValue = 0x02;
+TraktorS3.LEDDimValue = parseInt(engine.getSetting("ledDimValue"), 10) || 0x01;
+TraktorS3.LEDBrightValue = parseInt(engine.getSetting("ledBrightValue"), 10) || 0x03;
 
 // By default the jog wheel's behavior when rotating it matches 33 1/3 rpm
 // vinyl. Changing this value to 2.0 causes a single rotation of the platter to
@@ -1522,14 +1521,14 @@ TraktorS3.Deck = class {
     }
 
     lightHotcue(number) {
-        const loaded = engine.getValue(this.activeChannel, "hotcue_" + number + "_status");
-        const active = engine.getValue(this.activeChannel, "hotcue_" + number + "_activate");
-        let ledValue = this.controller.hid.LEDColors.WHITE;
-        if (loaded) {
+        const hotCueStatus = engine.getValue(this.activeChannel, `hotcue_${  number  }_status`);
+        let ledValue = this.controller.hid.LEDColors.OFF;
+        // If hotcue is set, change the color.
+        if (hotCueStatus) {
             ledValue = this.colorForHotcue(number);
-            ledValue += TraktorS3.LEDDimValue;
         }
-        if (active) {
+        // If hotcue is active, make it brighter.
+        if (hotCueStatus === 2) {
             ledValue += TraktorS3.LEDBrightValue;
         } else {
             ledValue += TraktorS3.LEDDimValue;


### PR DESCRIPTION
Currently the hotcue buttons aren't working in the way they were intended to work (I think?). The default for non-active cues is "off" (the lowest brightness level), meaning that no hotcue is ever shown. When you *press* the button you briefly get the color of the hotcue because the hotcue activate control was being monitored. Instead, always monitor the hotcue status and go between dim and bright based on that. This also changes the defaults to the dimmest level that's not off and the brightest level (which is the same as the second brightest level if you're using bus power).

This also moves the LED brightness levels into settings to make it easier to change them later.

I've also opened issues for several tangentially related other problems I've found with this controller while trying to get this fixed, but for now this was the only one where the problem seemed obvious to me. For the other issues see #15057, #15058, and #15059.