### PR TITLE
bpm detect speedup

### DIFF
--- a/lib/qm-dsp/dsp/tempotracking/TempoTrackV2.cpp
+++ b/lib/qm-dsp/dsp/tempotracking/TempoTrackV2.cpp
@@ -315,13 +315,8 @@ TempoTrackV2::viterbi_decode(const d_mat_t &rcfmat, const d_vec_t &wv, d_vec_t &
     }
 
     i_vec_t bestpath(T);
-    d_vec_t tmp_vec(Q);
-    for (int i = 0; i < Q; i++) {
-        tmp_vec[i] = delta[T-1][i];
-    }
-
     // find starting point - best beat period for "last" frame
-    bestpath[T-1] = get_max_ind(tmp_vec);
+    bestpath[T-1] = get_max_ind(delta[T-1]);
 
     // backtrace through index of maximum values in psi
     for (int t=T-2; t>0 ;t--) {

--- a/lib/qm-dsp/dsp/tempotracking/TempoTrackV2.cpp
+++ b/lib/qm-dsp/dsp/tempotracking/TempoTrackV2.cpp
@@ -101,7 +101,6 @@ TempoTrackV2::filter_df(d_vec_t &df)
 void
 TempoTrackV2::calculateBeatPeriod(const vector<double> &df,
                                   vector<double> &beat_period,
-                                  vector<double> &tempi,
                                   double inputtempo, bool constraintempo)
 {
     // to follow matlab.. split into 512 sample frames with a 128 hop size
@@ -168,7 +167,7 @@ TempoTrackV2::calculateBeatPeriod(const vector<double> &df,
     }
 
     // now call viterbi decoding function
-    viterbi_decode(rcfmat,wv,beat_period,tempi);
+    viterbi_decode(rcfmat,wv,beat_period);
 }
 
 
@@ -228,7 +227,7 @@ TempoTrackV2::get_rcf(const d_vec_t &dfframe_in, const d_vec_t &wv, d_vec_t &rcf
 }
 
 void
-TempoTrackV2::viterbi_decode(const d_mat_t &rcfmat, const d_vec_t &wv, d_vec_t &beat_period, d_vec_t &tempi)
+TempoTrackV2::viterbi_decode(const d_mat_t &rcfmat, const d_vec_t &wv, d_vec_t &beat_period)
 {
     // following Kevin Murphy's Viterbi decoding to get best path of
     // beat periods through rfcmat
@@ -345,10 +344,6 @@ TempoTrackV2::viterbi_decode(const d_mat_t &rcfmat, const d_vec_t &wv, d_vec_t &
     // fill in the last values...
     for (int i = lastind; i < int(beat_period.size()); i++) {
         beat_period[i] = beat_period[lastind];
-    }
-
-    for (int i = 0; i < int(beat_period.size()); i++) {
-        tempi.push_back((60. * m_rate / m_increment)/beat_period[i]);
     }
 }
 

--- a/lib/qm-dsp/dsp/tempotracking/TempoTrackV2.h
+++ b/lib/qm-dsp/dsp/tempotracking/TempoTrackV2.h
@@ -39,9 +39,8 @@ public:
 
     // Returned beat periods are given in df increment units; inputtempo and tempi in bpm
     void calculateBeatPeriod(const std::vector<double> &df,
-                             std::vector<double> &beatPeriod,
-                             std::vector<double> &tempi) {
-        calculateBeatPeriod(df, beatPeriod, tempi, 120.0, false);
+                             std::vector<double> &beatPeriod) {
+        calculateBeatPeriod(df, beatPeriod, 120.0, false);
     }
 
     // Returned beat periods are given in df increment units; inputtempo and tempi in bpm
@@ -49,7 +48,6 @@ public:
     // Note, if inputtempo = 120 and constraintempo = false, then functionality is as it was before
     void calculateBeatPeriod(const std::vector<double> &df,
                              std::vector<double> &beatPeriod,
-                             std::vector<double> &tempi,
                              double inputtempo, bool constraintempo);
 
     // Returned beat positions are given in df increment units
@@ -80,8 +78,7 @@ private:
     double mean_array(const d_vec_t &dfin, int start, int end);
     void filter_df(d_vec_t &df);
     void get_rcf(const d_vec_t &dfframe, const d_vec_t &wv, d_vec_t &rcf);
-    void viterbi_decode(const d_mat_t &rcfmat, const d_vec_t &wv,
-                        d_vec_t &bp, d_vec_t &tempi);
+    void viterbi_decode(const d_mat_t &rcfmat, const d_vec_t &wv, d_vec_t &bp);
     double get_max_val(const d_vec_t &df);
     int get_max_ind(const d_vec_t &df);
     void normalise_vec(d_vec_t &df);

--- a/src/analyzer/plugins/analyzerqueenmarybeats.cpp
+++ b/src/analyzer/plugins/analyzerqueenmarybeats.cpp
@@ -84,7 +84,6 @@ bool AnalyzerQueenMaryBeats::finalize() {
 
     std::vector<double> df;
     std::vector<double> beatPeriod;
-    std::vector<double> tempi;
     const auto required_size = std::max(0, nonZeroCount - 2);
     df.reserve(required_size);
     beatPeriod.reserve(required_size);
@@ -97,7 +96,7 @@ bool AnalyzerQueenMaryBeats::finalize() {
     }
 
     TempoTrackV2 tt(m_sampleRate, m_stepSizeFrames);
-    tt.calculateBeatPeriod(df, beatPeriod, tempi);
+    tt.calculateBeatPeriod(df, beatPeriod);
 
     std::vector<double> beats;
     tt.calculateBeats(df, beatPeriod, beats);


### PR DESCRIPTION
Remove some unused vectors. They were confusing and consume unnecessarily CPU. 
This is bas for fixing another rounding issue. 