### PR TITLE
[GSoC-Genre] Integrate multi-genre model into core application logic 

### DIFF
--- a/src/library/trackcollectionmanager.cpp
+++ b/src/library/trackcollectionmanager.cpp
@@ -43,8 +43,8 @@ TrackCollectionManager::TrackCollectionManager(QObject* parent,
         : QObject(parent),
           m_pConfig(pConfig),
           m_pInternalCollection(createInternalTrackCollection(
-                  this, pConfig, deleteTrackForTestingFn)) m_pGenreDAO =
-                  std::make_unique<GenreDAO>(dbConnection.get());
+                  this, pConfig, deleteTrackForTestingFn)),
+          m_pGenreDAO = std::make_unique<GenreDAO>(dbConnection.get());
 {
     const QSqlDatabase dbConnection = mixxx::DbConnectionPooled(pDbConnectionPool);
 
@@ -622,7 +622,7 @@ bool TrackCollectionManager::updateTrackGenre(
 bool TrackCollectionManager::updateTrackMood(
         Track* pTrack,
         const QString& mood) const {
-    s return pTrack->updateMood(
+    return pTrack->updateMood(
             // TODO: Pass tagging config
             mood);
 }
@@ -638,9 +638,8 @@ bool TrackCollectionManager::updateTrackGenres(Track* pTrack, const QStringList&
     QList<DbId> genreIds;
     genreIds.reserve(genreNames.size());
 
-    // For each name, get its ID. If the genre doesn't exist, DAO will create it.
     for (const QString& name : genreNames) {
-        const DbId genreId = m_pGenreDAO->addGenre(name);
+        const DbId genreId = m_pGenreDAO->getOrCreateGenre(name);
         if (genreId.isValid()) {
             genreIds.append(genreId);
         }

--- a/src/library/trackcollectionmanager.cpp
+++ b/src/library/trackcollectionmanager.cpp
@@ -629,7 +629,8 @@ bool TrackCollectionManager::updateTrackMood(
 #endif // __EXTRA_METADATA__
 
 // Replaces all genres for a given track by providing a list of names.
-bool TrackCollectionManager::updateTrackGenres(Track* pTrack, const QStringList& genreNames) const {
+bool TrackCollectionManager::replaceAllTrackGenres(
+        Track* pTrack, const QStringList& genreNames) const {
     DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
     VERIFY_OR_DEBUG_ASSERT(pTrack) {
         return false;

--- a/src/library/trackcollectionmanager.h
+++ b/src/library/trackcollectionmanager.h
@@ -60,8 +60,7 @@ class TrackCollectionManager: public QObject,
     QList<TrackId> resolveTrackIdsFromLocations(
             const QList<QString>& locations) const;
 
-    // Replaces all genres for a given track.
-    bool updateTrackGenres(
+    bool replaceAllTrackGenres(
             Track* pTrack,
             const QStringList& genreNames) const;
 

--- a/src/library/trackcollectionmanager.h
+++ b/src/library/trackcollectionmanager.h
@@ -6,6 +6,8 @@
 #include <memory>
 
 #include "library/dao/directorydao.h"
+#include "library/dao/genre.h"    // For the Genre struct
+#include "library/dao/genredao.h" // For the GenreDAO class
 #include "preferences/usersettings.h"
 #include "track/globaltrackcache.h"
 #include "util/db/dbconnectionpool.h"
@@ -58,10 +60,17 @@ class TrackCollectionManager: public QObject,
     QList<TrackId> resolveTrackIdsFromLocations(
             const QList<QString>& locations) const;
 
-    bool updateTrackGenre(
+    // Replaces all genres for a given track.
+    bool updateTrackGenres(
             Track* pTrack,
-            const QString& genre) const;
-#if defined(__EXTRA_METADATA__)
+            const QStringList& genreNames) const;
+
+    // Retrieves all genres from the database.
+    QList<Genre> getAllGenres() const;
+
+    // Cleans unused genres from the database.
+    int cleanupUnusedGenres() const;
+
     bool updateTrackMood(
             Track* pTrack,
             const QString& mood) const;
@@ -132,4 +141,7 @@ class TrackCollectionManager: public QObject,
 
     // TODO: Extract and decouple LibraryScanner from TrackCollectionManager
     std::unique_ptr<LibraryScanner> m_pScanner;
+
+    // DAO for genre-related database operations.
+    std::unique_ptr<GenreDAO> m_pGenreDAO;
 };

--- a/src/track/trackinfo.cpp
+++ b/src/track/trackinfo.cpp
@@ -1,5 +1,6 @@
 #include "track/trackinfo.h"
 
+#include <QStringList>
 
 namespace mixxx {
 
@@ -56,7 +57,7 @@ bool TrackInfo::compareEq(
             (getEncoder() == trackInfo.getEncoder()) &&
             (getEncoderSettings() == trackInfo.getEncoderSettings()) &&
 #endif // __EXTRA_METADATA__
-            (getGenre() == trackInfo.getGenre()) &&
+            (m_genres == trackInfo.m_genres) &&
             (getGrouping() == trackInfo.getGrouping()) &&
 #if defined(__EXTRA_METADATA__)
             (getISRC() == trackInfo.getISRC()) &&
@@ -100,7 +101,7 @@ QDebug operator<<(QDebug dbg, const TrackInfo& arg) {
     arg.dbgEncoder(dbg);
     arg.dbgEncoderSettings(dbg);
 #endif // __EXTRA_METADATA__
-    arg.dbgGenre(dbg);
+    arg.dbgGenres(dbg);
     arg.dbgGrouping(dbg);
 #if defined(__EXTRA_METADATA__)
     arg.dbgISRC(dbg);
@@ -131,6 +132,36 @@ QDebug operator<<(QDebug dbg, const TrackInfo& arg) {
     arg.dbgYear(dbg);
     dbg << '}';
     return dbg;
+}
+
+// Returns the list of genres for this track.
+const QList<Genre>& TrackInfo::getGenres() const {
+    return m_genres;
+}
+
+// Returns a comma-separated string of genre names for simple display.
+QString TrackInfo::getGenresString() const {
+    QStringList genreNames;
+    // Reserve memory to optimize performance for tracks with many genres.
+    genreNames.reserve(m_genres.size());
+    for (const Genre& genre : m_genres) {
+        genreNames.append(genre.name);
+    }
+    // Joins the names with ", " for a readable format, e.g. "House, Techno".
+    return genreNames.join(", ");
+}
+
+// Sets the list of genres for this track.
+void TrackInfo::setGenres(const QList<Genre>& genres) {
+    if (m_genres != genres) {
+        m_genres = genres;
+    }
+}
+
+// Debug helper to print genre info, replacing the auto-generated dbgGenre.
+void TrackInfo::dbgGenres(QDebug& dbg) const {
+    dbg.nospace() << "," << Qt::endl
+                  << "  genres: " << getGenresString();
 }
 
 } // namespace mixxx

--- a/src/track/trackinfo.cpp
+++ b/src/track/trackinfo.cpp
@@ -101,7 +101,8 @@ QDebug operator<<(QDebug dbg, const TrackInfo& arg) {
     arg.dbgEncoder(dbg);
     arg.dbgEncoderSettings(dbg);
 #endif // __EXTRA_METADATA__
-    arg.dbgGenres(dbg);
+    dbg.nospace() << "," << Qt::endl
+                  << "  " << arg.getGenres();
     arg.dbgGrouping(dbg);
 #if defined(__EXTRA_METADATA__)
     arg.dbgISRC(dbg);
@@ -156,12 +157,6 @@ void TrackInfo::setGenres(const QList<Genre>& genres) {
     if (m_genres != genres) {
         m_genres = genres;
     }
-}
-
-// Debug helper to print genre info, replacing the auto-generated dbgGenre.
-void TrackInfo::dbgGenres(QDebug& dbg) const {
-    dbg.nospace() << "," << Qt::endl
-                  << "  genres: " << getGenresString();
 }
 
 } // namespace mixxx

--- a/src/track/trackinfo.cpp
+++ b/src/track/trackinfo.cpp
@@ -139,7 +139,7 @@ const QList<Genre>& TrackInfo::getGenres() const {
     return m_genres;
 }
 
-// Returns a comma-separated string of genre names for simple display.
+// Returns a string of genre names for simple display.
 QString TrackInfo::getGenresString() const {
     QStringList genreNames;
     // Reserve memory to optimize performance for tracks with many genres.
@@ -147,8 +147,8 @@ QString TrackInfo::getGenresString() const {
     for (const Genre& genre : m_genres) {
         genreNames.append(genre.name);
     }
-    // Joins the names with ", " for a readable format, e.g. "House, Techno".
-    return genreNames.join(", ");
+    // Joins the names with " / " for a readable format, e.g. "House, Techno".
+    return genreNames.join(" / ");
 }
 
 // Sets the list of genres for this track.

--- a/src/track/trackinfo.h
+++ b/src/track/trackinfo.h
@@ -25,7 +25,6 @@ class TrackInfo final {
     MIXXX_DECL_PROPERTY(QString, encoder, Encoder)
     MIXXX_DECL_PROPERTY(QString, encoderSettings, EncoderSettings)
 #endif // __EXTRA_METADATA__
-    MIXXX_DECL_PROPERTY(QString, genre, Genre)
     MIXXX_DECL_PROPERTY(QString, grouping, Grouping)
 #if defined(__EXTRA_METADATA__)
     MIXXX_DECL_PROPERTY(QString, isrc, ISRC)
@@ -54,6 +53,23 @@ class TrackInfo final {
     MIXXX_DECL_PROPERTY(QString, work, Work)
 #endif // __EXTRA_METADATA__
     MIXXX_DECL_PROPERTY(QString, year, Year) // = release date
+
+  private:
+    // Holds a list of genres associated with the track.
+    QList<Genre> m_genres;
+
+  public:
+    // Returns the list of genres for this track.
+    const QList<Genre>& getGenres() const;
+
+    // Returns a comma-separated string of genre names for simple display.
+    QString getGenresString() const;
+
+    // Sets the list of genres for this track.
+    void setGenres(const QList<Genre>& genres);
+
+    // Debug helper to print genre info.
+    void dbgGenres(QDebug& dbg) const;
 
   public:
     TrackInfo() = default;

--- a/src/track/trackinfo.h
+++ b/src/track/trackinfo.h
@@ -68,8 +68,6 @@ class TrackInfo final {
     // Sets the list of genres for this track.
     void setGenres(const QList<Genre>& genres);
 
-    // Debug helper to print genre info.
-    void dbgGenres(QDebug& dbg) const;
 
   public:
     TrackInfo() = default;


### PR DESCRIPTION
This PR introduces the User Interface Integration changes for the [GSoC 2025 Multi-Genre Support project](https://github.com/mixxxdj/mixxx/issues/14897.)

This Pull Request represents the second major phase of the GSoC Multi-Genre Support project. It serves as the critical bridge between the foundational database layer [PR#1](https://github.com/mixxxdj/mixxx/pull/14898) and [PR#2](https://github.com/mixxxdj/mixxx/pull/14989) and the future user interface components.

The primary objective of this PR is to refactor the core in-memory data structures and integrate the new `GenreDAO` into the main library management logic. This ensures that the application is fully capable of handling a list of genres for each track, preparing the ground for the upcoming UI implementation.

**Architectural Changes and Implementation Details**

**1. Data Model Refactoring (`TrackInfo`)**
The `TrackInfo` class, which acts as the in-memory data representation for a track, has been fundamentally upgraded to be multi-genre aware.

**From Single to Multiple**: The previous `MIXXX_DECL_PROPERTY` for a single `QString genre` has been removed. It is replaced by a private member `QList<Genre>`, allowing a `TrackInfo` object to hold a complete list of `Genre` structs.

**New Accessor Methods**: New public methods have been introduced to manage this list:
- `getGenres() const`: Provides read-only access to the list of Genre objects.
- `setGenres(const QList<Genre>&)`: Updates the track's genres in memory. This method includes logic to prevent unnecessary "dirty" states if the new list is identical to the existing one.
-`getGenresString() const`: A new convenience method has been added to return a simple, comma-separated `QString` of all genre names, designed for easy display in UI elements.

**Core Logic Adaptation**:  All internal logic within `TrackInfo` that previously relied on the single genre string, such as `compareEq` and the debug `operator<<`, has been updated to correctly handle the new `QList<Genre>` structure.

**2. Integration into the Logic Layer (`TrackCollectionManager`)**
To provide a centralized and clean point of interaction for the rest of the application, the new GenreDAO has been integrated into the TrackCollectionManager.

**DAO Lifecycle Management**: A `std::unique_ptr<GenreDAO> m_pGenreDAO` has been added to the `TrackCollectionManager` and is initialized in its constructor. 

**High-Level API Exposure**: A new suite of public methods has been added to `TrackCollectionManager` to abstract away the underlying database operations. These methods will be the primary entry point for UI components:
- `updateTrackGenres(Track*, const QStringList&)`: Provides a high-level function to save a list of genres for a track. It internally handles the logic of converting genre names to IDs before persisting the associations.
- `getAllGenres() const`: Directly exposes the DAO's functionality to fetch a complete, alphabetized list of all known genres, ready to be used by UI completers or dropdowns.
- `cleanupUnusedGenres() const`: Exposes the DAO's maintenance function to the application layer.