### PR TITLE
(fix) make Track Properties dialog fit small screens, scrollable

### DIFF
--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -1,5 +1,6 @@
 #include "library/dlgtrackinfo.h"
 
+#include <QScrollArea>
 #include <QSignalBlocker>
 #include <QStyleFactory>
 #include <QtDebug>
@@ -20,6 +21,8 @@
 #include "util/datetime.h"
 #include "util/desktophelper.h"
 #include "util/duration.h"
+#include "util/parented_ptr.h"
+#include "util/widgethelper.h"
 #include "widget/wcoverartlabel.h"
 #include "widget/wcoverartmenu.h"
 #include "widget/wstarrating.h"
@@ -883,6 +886,7 @@ void DlgTrackInfo::slotImportMetadataFromMusicBrainz() {
 void DlgTrackInfo::showEvent(QShowEvent* pEvent) {
     QDialog::showEvent(pEvent);
     adjustWidgetSizes();
+    maybeMakeDialogScrollable();
 }
 
 void DlgTrackInfo::resizeEvent(QResizeEvent* pEvent) {
@@ -930,4 +934,120 @@ void DlgTrackInfo::adjustWidgetSizes() {
     // use the triple the height of a QLineEdit because they are sized correctly.
     // The editor can expand vertically when the dialog is resized.
     txtComment->setMinimumHeight(txtTrackNumber->geometry().height() * 3);
+}
+
+void DlgTrackInfo::maybeMakeDialogScrollable() {
+    // If the dialog doesn't fit the screen (with some margin), make it scrollable
+    // by putting the Summary tab inside a QScrollArea (plus some magic);
+    const QScreen* const pScreen = mixxx::widgethelper::getScreen(*this);
+    QRect screenAvailableGeometry;
+    VERIFY_OR_DEBUG_ASSERT(pScreen) {
+        qWarning() << "Assuming screen size of 800x600px.";
+        screenAvailableGeometry = QRect(0, 0, 800, 600);
+    }
+    else {
+        screenAvailableGeometry = pScreen->availableGeometry();
+    }
+
+    const QRect geometry = frameGeometry();
+    int currHeight = geometry.height();
+    int top = geometry.top();
+#ifndef __WINDOWS__
+    // On Linux, when the window is shown for the first time by the window manager,
+    // Qt doesn't have information about the frame size, so the offset is zero.
+    // As such, the first time it opens the window does not include the offset.
+    // Assume window decoration is 30 px tall, the frame is 2 px wide and some margin.
+    // Even for taller decoration, this kind of works since the Cancel|Reset|Okay buttons
+    // would still be partly visible.
+    // FIXME: we could also assume the window decoration is about as tall as
+    // those button and simply subtract btnCancel->height().
+    constexpr int kDecorationHeight = 50;
+    currHeight += kDecorationHeight;
+    top -= kDecorationHeight;
+#endif
+
+    if (currHeight > screenAvailableGeometry.height()) {
+        int origWidth = frameGeometry().width();
+        parented_ptr<QScrollArea> pScrollArea = make_parented<QScrollArea>(tabWidget);
+        pScrollArea->setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContentsOnFirstShow);
+
+        // Store the Summary tab's title before we (implicitly) remove its tab via
+        // QScrollArea::setWidget().
+        const QString summaryTitle = tabWidget->tabText(tabWidget->indexOf(tabSummary));
+        pScrollArea->setWidget(tabSummary);
+
+        // With true, adjustSize() avoids the horizontal scrollbar, but the comment
+        // editor will grow taller than necessary (~5 lines).
+        // With false, the comment editor will be small (~2 lines), but adjustSize()
+        // won't avoid the horizontal scrollbar, even when we use the Summary tab's
+        // width for the QScrollArea's minimum width.
+        pScrollArea->setWidgetResizable(true);
+
+        // Some settings to get the same look as the regular layout/view:
+        // By default, the QScrollArea would use another palette. Disable that.
+        pScrollArea->viewport()->setAutoFillBackground(false);
+        pScrollArea->widget()->setAutoFillBackground(false);
+        // Also don't draw an extra border
+        pScrollArea->setFrameStyle(QFrame::NoFrame);
+        // Now the scrollbar doesn't have borders anymore (it relied on those of
+        // the QScrollArea it seems), but the borders of tabSummary do the trick.
+
+        // This doesn't hurt either, though the scrollbar still stands out
+        // a tiny bit at the top:
+        // set margins to 0 before computing the size hint so the minimum
+        // width below is based on the content's preferred size, not default
+        // margins.
+        pScrollArea->setContentsMargins(0, 0, 0, 0);
+        tabSummary->setContentsMargins(0, 0, 0, 0);
+
+        // Expand the QScrollArea so that we don't need the horizontal scrollbar.
+        // Use the size hint (preferred width) instead of the current width,
+        // because with long translations (e.g. French) the current width may
+        // be too narrow for the content to fit without a horizontal scrollbar.
+        pScrollArea->setMinimumWidth(tabSummary->sizeHint().width());
+
+        // Move the Summary tab into the QScrollArea
+        tabWidget->removeTab(tabWidget->indexOf(tabSummary));
+        tabWidget->insertTab(0, pScrollArea.get(), summaryTitle);
+        tabWidget->setCurrentIndex(0);
+
+        // For some reason the reparenting removes the size adjustment we applied
+        // to txtComment in adjustWidgetSizes(). Let's set a fixed...
+        txtComment->setFixedHeight(txtTrackNumber->geometry().height() * 3);
+
+        // Note: with this alone the dialog would be much smaller than necessary.
+        // Without this the dialog would fit the screen exactly, but some parts
+        // may still be occluded by taskbar or other (system) toolbars.
+        // Also, for some setGeometry() would not trigger a resize event, even
+        // though the dialog is reported to be visible. (noticed on Linux)
+        adjustSize();
+
+        // Now expand vertically to available screen height.
+        // And show horizontally centered (Note: for some reason frameGeometry().left()
+        // would not work reliably after adjustSize(), dialog would be moved to left side.
+        // Use the dialog's width after adjustSize() which accounts for the scroll
+        // area's minimum width (incl. long translations), but don't make it smaller
+        // than the original width and cap it at the available screen width.
+        int newWidth = math_min(
+                math_max(origWidth, frameGeometry().width()),
+                screenAvailableGeometry.width());
+        int newX = screenAvailableGeometry.left() +
+                screenAvailableGeometry.width() / 2 -
+                newWidth / 2;
+        int optHeight = screenAvailableGeometry.height();
+#ifndef __WINDOWS__
+        optHeight -= kDecorationHeight;
+#endif
+        setGeometry(
+                newX,
+                screenAvailableGeometry.top(),
+                newWidth,
+                optHeight);
+    } else if (geometry.bottom() > screenAvailableGeometry.bottom()) {
+        // Dialog fits the available space but is positioned too low and buttons
+        // are (partially) occluded by the taskbar
+        // Move it up.
+        int overlap = geometry.bottom() - screenAvailableGeometry.bottom();
+        move(geometry.x(), top - overlap);
+    }
 }

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -96,6 +96,7 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     void clear();
     void init();
     void adjustWidgetSizes();
+    void maybeMakeDialogScrollable();
 
     void updateKeyText();
     void displayKeyText();

--- a/src/library/dlgtrackinfomulti.cpp
+++ b/src/library/dlgtrackinfomulti.cpp
@@ -2,6 +2,8 @@
 
 #include <QLineEdit>
 #include <QListView>
+#include <QScrollArea>
+#include <QScrollBar>
 #include <QStyleFactory>
 #include <QtDebug>
 
@@ -18,8 +20,10 @@
 #include "util/datetime.h"
 #include "util/desktophelper.h"
 #include "util/duration.h"
+#include "util/parented_ptr.h"
 #include "util/string.h"
 #include "util/stringformat.h"
+#include "util/widgethelper.h"
 #include "widget/wcoverartlabel.h"
 #include "widget/wcoverartmenu.h"
 #include "widget/wstarrating.h"
@@ -618,6 +622,7 @@ void DlgTrackInfoMulti::addValuesToCommentBox(QSet<QString>& comments) {
 void DlgTrackInfoMulti::showEvent(QShowEvent* pEvent) {
     QDialog::showEvent(pEvent);
     adjustWidgetSizes();
+    maybeMakeDialogScrollable();
 }
 
 void DlgTrackInfoMulti::resizeEvent(QResizeEvent* pEvent) {
@@ -670,6 +675,140 @@ void DlgTrackInfoMulti::adjustWidgetSizes() {
     // use the triple the height of a QLineEdit because they are sized correctly.
     // The editor can expand vertically when the dialog is resized.
     txtComment->setMinimumHeight(txtTrackNumber->geometry().height() * 3);
+}
+
+void DlgTrackInfoMulti::maybeMakeDialogScrollable() {
+    // If the dialog doesn't fit the screen (with some margin), make it scrollable
+    // by moving the main layout for a widget which we use as main widget for a
+    // QScrollArea (plus some magic);
+    const QScreen* const pScreen = mixxx::widgethelper::getScreen(*this);
+    QRect screenAvailableGeometry;
+    VERIFY_OR_DEBUG_ASSERT(pScreen) {
+        qWarning() << "Assuming screen size of 800x600px.";
+        screenAvailableGeometry = QRect(0, 0, 800, 600);
+    }
+    else {
+        screenAvailableGeometry = pScreen->availableGeometry();
+    }
+
+    const QRect geometry = frameGeometry();
+    int currHeight = geometry.height();
+    int top = geometry.top();
+#ifndef __WINDOWS__
+    // On Linux, when the window is shown for the first time by the window manager,
+    // Qt doesn't have information about the frame size, so the offset is zero.
+    // As such, the first time it opens the window does not include the offset
+    // Assume window decoration is 30 px tall, the frame is 2 px wide and some margin.
+    // Even for taller decoration, this kind of works since the Cancel|Reset|Okay buttons
+    // would still be partly visible.
+    // Note: we could also assume the window decoration is about as tall as
+    // those button and simply subtract btnCancel->height().
+    constexpr int kDecorationHeight = 50;
+    currHeight += kDecorationHeight;
+    top -= kDecorationHeight;
+#endif
+
+    if (currHeight > screenAvailableGeometry.height()) {
+        // Before we handle widgets and layouts, store the original width
+        int origWidth = frameGeometry().width();
+
+        parented_ptr<QScrollArea> pScrollArea = make_parented<QScrollArea>(this);
+        pScrollArea->setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContentsOnFirstShow);
+        // pScrollArea->verticalScrollBar()->setStyleSheet(
+        //         "QScrollBar:vertical { border-left: 1px solid palette(mid); }");
+
+        QVBoxLayout* pScrollLayout = new QVBoxLayout(pScrollArea.get());
+        pScrollLayout->setObjectName("ScrollLayout");
+        pScrollLayout->setContentsMargins(0, 0, 0, 0);
+        pScrollLayout->setSpacing(0);
+
+        pScrollLayout->insertWidget(0, tags_groupBox);
+        pScrollLayout->insertWidget(1, properties_groupBox);
+
+        parented_ptr<QWidget> pScrollWidget = make_parented<QWidget>(this);
+        pScrollWidget->setLayout(pScrollLayout);
+        pScrollArea->setWidget(pScrollWidget);
+
+        main_layout->insertWidget(0, pScrollArea);
+
+        // With true, adjustSize() avoids the horizontal scrollbar, but the comment
+        // editor will grow taller than necessary (~5 lines).
+        // With false, the comment editor will be small (~2 lines), but adjustSize()
+        // won't avoid the horizontal scrollbar, even when we use the Summary tab's
+        // width for the QScrollArea's minimum width.
+        pScrollArea->setWidgetResizable(true);
+
+        // Some settings to get the same look as the regular layout/view:
+        // By default, the QScrollArea would use another palette. Disable that.
+        pScrollArea->viewport()->setAutoFillBackground(false);
+        pScrollArea->widget()->setAutoFillBackground(false);
+        // Also don't draw an extra border
+        pScrollArea->setFrameStyle(QFrame::NoFrame);
+        // Now the scrollbar doesn't have borders anymore (it relied on those of
+        // the QScrollArea it seems), so let's add some.
+        pScrollArea->verticalScrollBar()->setStyleSheet(
+                "QScrollBar {"
+                "  border-top: 1px solid palette(mid);"
+                "  border-bottom: 1px solid palette(mid);"
+                "  border-left: none;"
+                "  border-right: 1px solid palette(mid);"
+                "}");
+
+        // This doesn't hurt either, though the scrollbar still stands out
+        // a tiny bit at the top:
+        // set margins to 0 before computing the size hint so the minimum
+        // width below is based on the content's preferred size, not default
+        // margins.
+        pScrollArea->setContentsMargins(0, 0, 0, 0);
+        pScrollWidget->setContentsMargins(0, 0, 0, 0);
+
+        // Expand the QScrollArea so that we don't need the horizontal scrollbar.
+        // Use the size hint (preferred width) instead of the current width,
+        // because with long translations (e.g. French) the current width may
+        // be too narrow for the content to fit without a horizontal scrollbar.
+        pScrollArea->setMinimumWidth(pScrollWidget->sizeHint().width());
+        // This doesn't hurt either, though the scrollbar still stands out
+        // a tiny bit at the top.
+
+        // For some reason the reparenting removes the size adjustment we applied
+        // to txtComment in adjustWidgetSizes(). Let's set a fixed...
+        txtComment->setFixedHeight(txtTrackNumber->geometry().height() * 3);
+
+        // Note: with this alone the dialog would be much smaller than necessary.
+        // Without this the dialog would fit the screen exactly, but some parts
+        // may still be occluded by taskbar or other (system) toolbars.
+        // Also, for some reason, setGeometry() would not trigger a resize event,
+        // even though the dialog is reported to be visible. (noticed on Linux)
+        adjustSize();
+
+        // Now expand vertically to available screen height.
+        // And show horizontally centered (Note: for some reason frameGeometry().left()
+        // would not work reliably after adjustSize(), dialog would be moved to left side.
+        // Use the dialog's width after adjustSize() which accounts for the scroll
+        // area's minimum width (incl. long translations), but don't make it smaller
+        // than the original width and cap it at the available screen width.
+        int newWidth = math_min(
+                math_max(origWidth, frameGeometry().width()),
+                screenAvailableGeometry.width());
+        int newX = screenAvailableGeometry.left() +
+                screenAvailableGeometry.width() / 2 -
+                newWidth / 2;
+        int optHeight = screenAvailableGeometry.height();
+#ifndef __WINDOWS__
+        optHeight -= kDecorationHeight;
+#endif
+        setGeometry(
+                newX,
+                screenAvailableGeometry.top(),
+                newWidth,
+                optHeight);
+    } else if (geometry.bottom() > screenAvailableGeometry.bottom()) {
+        // Dialog fits the available space but is positioned too low and buttons
+        // are (partially) occluded by the taskbar
+        // Move it up.
+        int overlap = geometry.bottom() - screenAvailableGeometry.bottom();
+        move(geometry.x(), top - overlap);
+    }
 }
 
 void DlgTrackInfoMulti::saveTracks() {

--- a/src/library/dlgtrackinfomulti.h
+++ b/src/library/dlgtrackinfomulti.h
@@ -72,6 +72,7 @@ class DlgTrackInfoMulti : public QDialog, public Ui::DlgTrackInfoMulti {
   private:
     void init();
     void adjustWidgetSizes();
+    void maybeMakeDialogScrollable();
 
     void loadTracksInternal(const QList<TrackPointer>& pTracks);
     void saveTracks();


### PR DESCRIPTION
Resize the Track Properties dialog to fit small screens.
Fixes #14421 

If the dialog won't fit the screen vertically, the Summary tab widget is moved into a new tab with a QScrollArea.
Actually a straight-forward solution, but it still requires some tweaking to work around some Qt/QSizePolicy/QLayout quirks and get it fully right.
For the multi-track I simply :tm:  moved the main layout into a widget in the QScrollArea.

For big screens nothing changes.

Should look something like this
![single](https://github.com/user-attachments/assets/0627b334-a49b-4fba-a35b-4060db60391a)
![multi](https://github.com/user-attachments/assets/eb7b545b-9f6c-4991-ab95-42840d09394f)

### TODO
- [x] test if focused tag from focused tracks table column is still adopted