### PR TITLE
Fix an offset issue in QM Beat detector

### DIFF
--- a/lib/qm-dsp/dsp/tempotracking/TempoTrackV2.cpp
+++ b/lib/qm-dsp/dsp/tempotracking/TempoTrackV2.cpp
@@ -109,7 +109,7 @@ TempoTrackV2::calculateBeatPeriod(const vector<double> &df,
     // then call viterbi decoding with weight vector and transition matrix
     // and get best path
 
-    int wv_len = 128;
+    const int wv_len = 128;
 
     // MEPD 28/11/12
     // the default value of inputtempo in the beat tracking plugin is 120
@@ -117,7 +117,7 @@ TempoTrackV2::calculateBeatPeriod(const vector<double> &df,
     // accordingly.
     // note: 60*44100/512 is a magic number
     // this might (will?) break if a user specifies a different frame rate for the onset detection function
-    double rayparam = (60*44100/512)/inputtempo;
+    const double rayparam = (60 * 44100 / 512.0) / inputtempo;
 
     // make rayleigh weighting curve
     d_vec_t wv(wv_len);
@@ -152,10 +152,21 @@ TempoTrackV2::calculateBeatPeriod(const vector<double> &df,
 
     // Loop over the onset detection function half a window padding on both ends
     for (int i = -winlen / 2; i < df_len - winlen / 2; i += hopsize) {
-        for (int k = 0; k < winlen; k++) {
-            int j = i + k;
-            dfframe[k] = (j >= 0 && j < df_len) ? df[j] : 0.0;
+        int k = 0;
+        int l = winlen;
+
+        if (i < 0) {
+            k = -i;
+            std::fill(dfframe.begin(), dfframe.begin() + k, 0.0);
         }
+
+        if (i + l > df_len) {
+            l = df_len - i;
+            std::fill(dfframe.begin() + l, dfframe.end(), 0.0);
+        }
+        
+        std::copy(df.begin() + i + k, df.begin() + i + l,
+                      dfframe.begin() + k);
 
         // Apply the resonator comb filter (RCF) bank to the window
         // The result is a vector of filter responses for different periods.

--- a/lib/qm-dsp/dsp/tempotracking/TempoTrackV2.cpp
+++ b/lib/qm-dsp/dsp/tempotracking/TempoTrackV2.cpp
@@ -138,31 +138,32 @@ TempoTrackV2::calculateBeatPeriod(const vector<double> &df,
         }
     }
 
-    // beat tracking frame size (roughly 6 seconds) and hop (1.5 seconds)
+    // Beat tracking window length (roughly 6 seconds) and hop size (1.5 seconds)
     int winlen = 512;
-    int step = 128;
+    int hopsize = 128;
 
-    // matrix to store output of comb filter bank, increment column of matrix at each frame
+    // Matrix to store output of comb filter bank
     d_mat_t rcfmat;
-    int col_counter = -1;
     int df_len = int(df.size());
 
-    // main loop for beat period calculation
-    for (int i = 0; i+winlen < df_len; i+=step) {
+    // Loop over the onset detection function in overlapping windows.
+    for (int i = 0; i + winlen < df_len; i += hopsize) {
         
-        // get dfframe
+        // Extact a window from df
         d_vec_t dfframe(winlen);
-        for (int k=0; k < winlen; k++) {
-            dfframe[k] = df[i+k];
+        for (int k = 0; k < winlen; k++) {
+            dfframe[k] = df[i + k];
         }
-        // get rcf vector for current frame
-        d_vec_t rcf(wv_len);
-        get_rcf(dfframe,wv,rcf);
 
-        rcfmat.push_back( d_vec_t() ); // adds a new column
-        col_counter++;
+        // Apply the resonator comb filter (RCF) bank to the window
+        // The result is a vector of filter responses for different periods.
+        d_vec_t rcf(wv_len);
+        get_rcf(dfframe, wv, rcf);
+
+        // Append the result to rcfmat as a new column 
+        rcfmat.push_back(d_vec_t());
         for (int j = 0; j < wv_len; j++) {
-            rcfmat[col_counter].push_back( rcf[j] );
+            rcfmat.back().push_back(rcf[j]);
         }
     }
 

--- a/lib/qm-dsp/dsp/tempotracking/TempoTrackV2.cpp
+++ b/lib/qm-dsp/dsp/tempotracking/TempoTrackV2.cpp
@@ -141,23 +141,25 @@ TempoTrackV2::calculateBeatPeriod(const vector<double> &df,
     // Beat tracking window length (roughly 6 seconds) and hop size (1.5 seconds)
     int winlen = 512;
     int hopsize = 128;
-
+    
+    int df_len = int(df.size());
+    
     // Matrix to store output of comb filter bank
     d_mat_t rcfmat;
-    int df_len = int(df.size());
+    rcfmat.reserve(df_len / hopsize + 1);
+    d_vec_t dfframe(winlen);
+    d_vec_t rcf(wv_len);
 
     // Loop over the onset detection function in overlapping windows.
     for (int i = 0; i + winlen < df_len; i += hopsize) {
         
         // Extact a window from df
-        d_vec_t dfframe(winlen);
         for (int k = 0; k < winlen; k++) {
             dfframe[k] = df[i + k];
         }
 
         // Apply the resonator comb filter (RCF) bank to the window
         // The result is a vector of filter responses for different periods.
-        d_vec_t rcf(wv_len);
         get_rcf(dfframe, wv, rcf);
 
         // Append the result to rcfmat as a new column 

--- a/src/analyzer/plugins/analyzerqueenmarybeats.cpp
+++ b/src/analyzer/plugins/analyzerqueenmarybeats.cpp
@@ -77,22 +77,21 @@ bool AnalyzerQueenMaryBeats::processSamples(const CSAMPLE* pIn, SINT iLen) {
 bool AnalyzerQueenMaryBeats::finalize() {
     m_helper.finalize();
 
-    int nonZeroCount = static_cast<int>(m_detectionResults.size());
+    std::size_t nonZeroCount = m_detectionResults.size();
     while (nonZeroCount > 0 && m_detectionResults.at(nonZeroCount - 1) <= 0.0) {
         --nonZeroCount;
     }
 
+    std::size_t required_size = std::max(static_cast<std::size_t>(0), nonZeroCount - 2);
+
     std::vector<double> df;
-    std::vector<double> beatPeriod;
-    const auto required_size = std::max(0, nonZeroCount - 2);
     df.reserve(required_size);
-    beatPeriod.reserve(required_size);
+    auto beatPeriod = std::vector<double>(required_size);
 
     // skip first 2 results as it might have detect noise as onset
     // that's how vamp does and seems works best this way
-    for (int i = 2; i < nonZeroCount; ++i) {
+    for (std::size_t i = 2; i < nonZeroCount; ++i) {
         df.push_back(m_detectionResults.at(i));
-        beatPeriod.push_back(0.0);
     }
 
     TempoTrackV2 tt(m_sampleRate, m_stepSizeFrames);
@@ -102,7 +101,7 @@ bool AnalyzerQueenMaryBeats::finalize() {
     tt.calculateBeats(df, beatPeriod, beats);
 
     m_resultBeats.reserve(static_cast<int>(beats.size()));
-    for (size_t i = 0; i < beats.size(); ++i) {
+    for (std::size_t i = 0; i < beats.size(); ++i) {
         // we add the halve m_stepSizeFrames here, because the beat
         // is detected between the two samples.
         const auto result = mixxx::audio::FramePos(


### PR DESCRIPTION
The QM Beat detector uses 6 s windows to find coarse bpm values which are used as plausibility region when searching beats later. This window is shiftet over the track using a hop size of 1.5 s. 

This PR fixes an issue that detection starts with the first full window, which produces the result for the 3 position, later treated as the first position. This causes that a tempo change is assumed up to 3 s to early when searching for beats. 
The same issue happens at the end. This was dubious "fixed" by copying the last result four times at the end. 

In this PR instead, we cleanly detect position 1 and 2 by padding the used onset vector with zeros. 

This issue has only a visible effect with tracks where two regions are detected like 80 bpm before the bridge and 160 after. This is of cause not the desired result either, but this fix helps to detect this situation reliable and fix it hopefully in a follow up PR  
