### PR TITLE
(fix) Avoid engine freeze when loading a new track while scratching with waveform or spinny

### DIFF
--- a/src/engine/controls/ratecontrol.cpp
+++ b/src/engine/controls/ratecontrol.cpp
@@ -628,3 +628,10 @@ void RateControl::notifyWrapAround(mixxx::audio::FramePos triggerPos,
 void RateControl::notifySeek(mixxx::audio::FramePos position) {
     m_pScratchController->notifySeek(position);
 }
+
+void RateControl::resetPositionScratchController() {
+    // Resets the scratch state to avoid engine freeze due to insanley high rate
+    // reported on track load while scratching.
+    // https://github.com/mixxxdj/mixxx/issues/15082
+    m_pScratchController->reset();
+}

--- a/src/engine/controls/ratecontrol.h
+++ b/src/engine/controls/ratecontrol.h
@@ -77,6 +77,7 @@ public:
   void notifyWrapAround(mixxx::audio::FramePos triggerPos,
           mixxx::audio::FramePos targetPos);
   void notifySeek(mixxx::audio::FramePos position) override;
+  void resetPositionScratchController();
 
 public slots:
   void slotRateRangeChanged(double);

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -627,13 +627,19 @@ void EngineBuffer::ejectTrack() {
 
     if (pOldTrack) {
         notifyTrackLoaded(TrackPointer(), pOldTrack);
+    } else {
+        // When not invoking notifyTrackLoaded() call this separately
+        m_pRateControl->resetPositionScratchController();
     }
+
     m_iTrackLoading = 0;
     m_pChannelToCloneFrom = nullptr;
 }
 
 void EngineBuffer::notifyTrackLoaded(
         TrackPointer pNewTrack, TrackPointer pOldTrack) {
+    m_pRateControl->resetPositionScratchController();
+
     if (pOldTrack) {
         disconnect(
                 pOldTrack.get(),

--- a/src/engine/positionscratchcontroller.cpp
+++ b/src/engine/positionscratchcontroller.cpp
@@ -329,3 +329,13 @@ void PositionScratchController::notifySeek(mixxx::audio::FramePos position) {
     // distance traveled in m_samplePosDeltaSum
     m_seekSamplePos = newPos;
 }
+
+void PositionScratchController::reset() {
+    // Resets the scratch state to avoid engine freeze due to insanley high rate
+    // reported on track load while scratching.
+    // https://github.com/mixxxdj/mixxx/issues/15082
+    m_pScratchEnable->set(0.0);
+    m_isScratching = false;
+    m_inertiaEnabled = false;
+    m_rate = 0;
+}

--- a/src/engine/positionscratchcontroller.h
+++ b/src/engine/positionscratchcontroller.h
@@ -33,6 +33,7 @@ class PositionScratchController : public QObject {
         return m_rate;
     }
     void notifySeek(mixxx::audio::FramePos position);
+    void reset();
 
   private slots:
     void slotUpdateFilterParameters(double sampleRate);


### PR DESCRIPTION
Closes #15082 

As proposed there, reset PositionScratchController on track load:
* release `[ChannelN],scratch_position_enable`
* reset the flags `m_inertiaEnabled` and `m_isScratching`
* reset `m_rate`

### How to reproduce / confirm the fix:
* load a track
* left-click, move and hold its waveform or spinny to stop the track / start scratching
* load a track to this deck (Shift+Left or via controller)
* engine freeze (you click still do stuff in the GUI, eg. seek with in the overview but no sound anymore)
* closing Mixxx will close the main window but the process will not exit.

_____

Waveform and spinny would still show the drag cursor (hand) but moving it would not scratch.
Though this minor inconvenience is negligible IMO.