### PR TITLE
Library: make scan report optional (opt-out)

### DIFF
--- a/src/library/library_prefs.cpp
+++ b/src/library/library_prefs.cpp
@@ -18,6 +18,11 @@ const ConfigKey mixxx::library::prefs::kRescanOnStartupConfigKey =
                 mixxx::library::prefs::kConfigGroup,
                 QStringLiteral("RescanOnStartup")};
 
+const ConfigKey mixxx::library::prefs::kShowScanSummaryConfigKey =
+        ConfigKey{
+                mixxx::library::prefs::kConfigGroup,
+                QStringLiteral("show_library_scan_summary")};
+
 const ConfigKey mixxx::library::prefs::kKeyNotationConfigKey =
         ConfigKey{
                 mixxx::library::prefs::kConfigGroup,

--- a/src/library/library_prefs.h
+++ b/src/library/library_prefs.h
@@ -14,6 +14,8 @@ extern const QString kConfigGroup;
 
 extern const ConfigKey kRescanOnStartupConfigKey;
 
+extern const ConfigKey kShowScanSummaryConfigKey;
+
 extern const ConfigKey kKeyNotationConfigKey;
 
 extern const ConfigKey kTrackDoubleClickActionConfigKey;

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -39,6 +39,7 @@
 #ifdef __ENGINEPRIME__
 #include "library/export/libraryexporter.h"
 #endif
+#include "library/library_prefs.h"
 #include "library/overviewcache.h"
 #include "library/trackcollectionmanager.h"
 #include "mixer/playerinfo.h"
@@ -1217,6 +1218,11 @@ void MixxxMainWindow::slotHelpAbout() {
 }
 
 void MixxxMainWindow::slotLibraryScanSummaryDlg(const LibraryScanResultSummary& result) {
+    if (!m_pCoreServices->getSettings()->getValue<bool>(
+                mixxx::library::prefs::kShowScanSummaryConfigKey, true)) {
+        return;
+    }
+
     // Don't show the report dialog when the scan is run during startup and no
     // noteworthy changes have been detected.
     if (result.autoscan &&

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -277,6 +277,8 @@ void DlgPrefLibrary::slotUpdate() {
     populateDirList();
     checkBox_library_scan->setChecked(m_pConfig->getValue(
             kRescanOnStartupConfigKey, false));
+    checkBox_library_scan_summary->setChecked(m_pConfig->getValue(
+            kShowScanSummaryConfigKey, true));
 
     spinbox_history_track_duplicate_distance->setValue(m_pConfig->getValue(
             kHistoryTrackDuplicateDistanceConfigKey,
@@ -508,6 +510,9 @@ void DlgPrefLibrary::slotSeratoMetadataExportClicked(bool checked) {
 void DlgPrefLibrary::slotApply() {
     m_pConfig->set(kRescanOnStartupConfigKey,
             ConfigValue((int)checkBox_library_scan->isChecked()));
+
+    m_pConfig->set(kShowScanSummaryConfigKey,
+            ConfigValue((int)checkBox_library_scan_summary->isChecked()));
 
     m_pConfig->set(kHistoryTrackDuplicateDistanceConfigKey,
             ConfigValue(spinbox_history_track_duplicate_distance->value()));

--- a/src/preferences/dialog/dlgpreflibrarydlg.ui
+++ b/src/preferences/dialog/dlgpreflibrarydlg.ui
@@ -89,6 +89,17 @@
        </widget>
       </item>
 
+      <item row="4" column="0" colspan="2">
+       <widget class="QCheckBox" name="checkBox_library_scan_summary">
+        <property name="text">
+         <string>Show scan summary dialog</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+
      </layout>
     </widget>
    </item>
@@ -671,6 +682,7 @@
   <tabstop>pushButton_relocate_dir</tabstop>
   <tabstop>pushButton_remove_dir</tabstop>
   <tabstop>checkBox_library_scan</tabstop>
+  <tabstop>checkBox_library_scan_summary</tabstop>
   <tabstop>checkBox_sync_track_metadata</tabstop>
   <tabstop>checkBox_serato_metadata_export</tabstop>
   <tabstop>checkBox_use_relative_path</tabstop>


### PR DESCRIPTION
Closes #15085

Bit late for 2.6 with the new tr strings, but since the always-on dialog has been reported not desired / annoying this may still slip in.