### PR TITLE
[DEBUG] Crash after tablet event

### DIFF
--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -1386,9 +1386,21 @@ bool MixxxMainWindow::eventFilter(QObject* obj, QEvent* event) {
                 emit fullScreenChanged(isFullScreen());
             }
         }
+    } else if (event->type() == QEvent::TabletMove ||
+            event->type() == QEvent::TabletPress ||
+            event->type() == QEvent::TabletRelease ||
+            event->type() == QEvent::TabletTrackingChange ||
+            event->type() == QEvent::TabletEnterProximity ||
+            event->type() == QEvent::TabletLeaveProximity) {
+        qWarning() << "Event filter:" << event;
     }
     // standard event processing
     return QMainWindow::eventFilter(obj, event);
+}
+
+void MixxxMainWindow::tabletEvent(QTabletEvent* event) {
+    qWarning() << "QTabletEvent:" << event;
+    QMainWindow::tabletEvent(event);
 }
 
 void MixxxMainWindow::closeEvent(QCloseEvent *event) {

--- a/src/mixxxmainwindow.h
+++ b/src/mixxxmainwindow.h
@@ -99,6 +99,7 @@ class MixxxMainWindow : public QMainWindow {
   protected:
     /// Event filter to block certain events (eg. tooltips if tooltips are disabled)
     bool eventFilter(QObject *obj, QEvent *event) override;
+    void tabletEvent(QTabletEvent* event) override;
     void closeEvent(QCloseEvent *event) override;
 
   private:


### PR DESCRIPTION
This should help finding the tablet event that causes the crash reported in #15087

Actually (IIUC) only these tablet events are useful in Mixxx
* QEvent::TabletMove
* QEvent::TabletPress
* QEvent::TabletRelease

and we could per se filter all other events like TabletTrackingChange, TabletEnterProximity and TabletLeaveProximity.

@somethingdiabolical Please test.