### PR TITLE
[2.5] ci: Fix empty pathspec error in sync-branches workflow 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       RRYAN_AT_MIXXX_DOT_ORG_GPG_PRIVATE_KEY: ${{ secrets.RRYAN_AT_MIXXX_DOT_ORG_GPG_PRIVATE_KEY }}
 
   sync:
-    if: ${{ github.ref != 'refs/heads/main' }} && ${{ github.repository == 'mixxxdj/mixxx' }}
+    if: ${{ github.ref != 'refs/heads/main' && github.repository == 'mixxxdj/mixxx' }}
     uses: ./.github/workflows/sync_branches.yml
     secrets:
       MIXXX_BRANCH_SYNC_PAT: ${{ secrets.MIXXX_BRANCH_SYNC_PAT }}


### PR DESCRIPTION
This PR targets the 2.5 branch as requested by @daschuer.

It resolves the "empty string is not a valid pathspec" error in the sync-branches workflow.

The workflow was failing when triggered by a commit on a branch that is not a source key in the ACTIVE_VERSIONS map (e.g., the main branch). This caused the TO_BRANCH variable to be empty, leading to a crash when git checkout was called.

This fix adds a preliminary step to check if the triggering branch is a valid source. If not, the sync and merge steps are gracefully skipped.

Fixes https://github.com/mixxxdj/mixxx/issues/15098