### PR TITLE
(fix) prevent crash with null track pointer

### DIFF
--- a/src/library/dlgtrackinfomulti.cpp
+++ b/src/library/dlgtrackinfomulti.cpp
@@ -314,7 +314,10 @@ void DlgTrackInfoMulti::loadTracks(const QList<TrackPointer>& pTracks) {
         m_pLoadedTracks.clear();
     }
     for (const auto& pTrack : pTracks) {
-        m_pLoadedTracks.insert(pTrack.get()->getId(), pTrack);
+        if (pTrack.get()) {
+            m_pLoadedTracks.insert(pTrack.get()->getId(), pTrack);
+        }
+        // Skip unavailable tracks
     }
 
     updateFromTracks();

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -2564,8 +2564,12 @@ void WTrackMenu::slotShowDlgTrackInfo() {
                 });
         QList<TrackPointer> tracks;
         tracks.reserve(getTrackCount());
-        for (int i = 0; i < m_trackIndexList.size(); i++) {
-            tracks.append(m_pTrackModel->getTrack(m_trackIndexList.at(i)));
+        for (const auto& index : m_trackIndexList) {
+            const auto pTrack = m_pTrackModel->getTrack(index);
+            if (pTrack) {
+                tracks.append(pTrack);
+            }
+            // Skip unavailable tracks
         }
         m_pDlgTrackInfoMulti->loadTracks(tracks);
         m_pDlgTrackInfoMulti->show();


### PR DESCRIPTION
Null tracks may occur when the track cache returns nullptr due to duplicate locations.

The second check in `DlgTrackInfoMulti::loadTracks()` is just a safety net in case it's called from another place/unit than `WTrackMenu::slotShowDlgTrackInfo()`.