### PR TITLE
Search: add filter shortcuts, eg. t|title, a|artist, cm|comment, y|year

### DIFF
--- a/src/library/searchqueryparser.cpp
+++ b/src/library/searchqueryparser.cpp
@@ -72,51 +72,70 @@ SearchQueryParser::SearchQueryParser(TrackCollection* pTrackCollection, QStringL
           m_searchCrates(false) {
     setSearchColumns(std::move(searchColumns));
 
-    m_textFilters << "artist"
-                  << "album_artist"
-                  << "album"
-                  << "title"
-                  << "genre"
-                  << "composer"
-                  << "grouping"
-                  << "comment"
-                  << "location"
-                  << "crate"
+    m_textFilters << "a" << "artist"
+                  << "aa" << "album_artist"
+                  << "al" << "album"
+                  << "t" << "title"
+                  << "g" << "genre"
+                  << "cp" << "composer"
+                  << "gr" << "grouping"
+                  << "cm" << "comment"
+                  << "lo" << "location"
+                  << "c" << "crate"
                   << "type";
-    m_numericFilters << "track"
-                     << "played"
-                     << "rating"
-                     << "bitrate"
+    m_numericFilters << "tr" << "track"
+                     << "pl" << "played"
+                     << "r" << "rating"
+                     << "br" << "bitrate"
                      << "id";
-    m_specialFilters << "year"
-                     << "key"
-                     << "bpm"
-                     << "duration"
-                     << "added"
+    m_specialFilters << "y" << "year"
+                     << "k" << "key"
+                     << "b" << "bpm"
+                     << "du" << "duration"
+                     << "ad" << "added"
                      << "dateadded"
                      << "datetime_added"
                      << "date_added";
 
+    m_fieldToSqlColumns["a"] << "artist" << "album_artist";
     m_fieldToSqlColumns["artist"] << "artist" << "album_artist";
+    m_fieldToSqlColumns["aa"] << "album_artist";
     m_fieldToSqlColumns["album_artist"] << "album_artist";
+    m_fieldToSqlColumns["al"] << "album";
     m_fieldToSqlColumns["album"] << "album";
+    m_fieldToSqlColumns["t"] << "title";
     m_fieldToSqlColumns["title"] << "title";
+    m_fieldToSqlColumns["g"] << "genre";
     m_fieldToSqlColumns["genre"] << "genre";
+    m_fieldToSqlColumns["cp"] << "composer";
     m_fieldToSqlColumns["composer"] << "composer";
+    m_fieldToSqlColumns["gr"] << "grouping";
     m_fieldToSqlColumns["grouping"] << "grouping";
+    m_fieldToSqlColumns["cm"] << "comment";
     m_fieldToSqlColumns["comment"] << "comment";
+    m_fieldToSqlColumns["y"] << "year";
     m_fieldToSqlColumns["year"] << "year";
+    m_fieldToSqlColumns["tr"] << "tracknumber";
     m_fieldToSqlColumns["track"] << "tracknumber";
+    m_fieldToSqlColumns["b"] << "bpm";
     m_fieldToSqlColumns["bpm"] << "bpm";
+    m_fieldToSqlColumns["br"] << "bitrate";
     m_fieldToSqlColumns["bitrate"] << "bitrate";
+    m_fieldToSqlColumns["du"] << "duration";
     m_fieldToSqlColumns["duration"] << "duration";
+    m_fieldToSqlColumns["k"] << "key";
     m_fieldToSqlColumns["key"] << "key";
     m_fieldToSqlColumns["key_id"] << "key_id";
+    m_fieldToSqlColumns["pl"] << "timesplayed";
     m_fieldToSqlColumns["played"] << "timesplayed";
+    m_fieldToSqlColumns["lpl"] << "last_played_at";
     m_fieldToSqlColumns["lastplayed"] << "last_played_at";
+    m_fieldToSqlColumns["r"] << "rating";
     m_fieldToSqlColumns["rating"] << "rating";
+    m_fieldToSqlColumns["loc"] << "location";
     m_fieldToSqlColumns["location"] << "location";
     m_fieldToSqlColumns["type"] << "filetype";
+    m_fieldToSqlColumns["ad"] << "datetime_added";
     m_fieldToSqlColumns["datetime_added"] << "datetime_added";
     m_fieldToSqlColumns["id"] << "id";
 


### PR DESCRIPTION
Closes #15101 

Current shortcuts:
a: artist
aa: album artist
ad: date added
al: album
b: bpm
cm: comment
cp: composer
du: duration
g: genre
gr: grouping
k: key
lo: location
r: rating
t: title
tr: track (number)
y: year

Shall we add more? Shall we add one for each filter (longer that 4 characters)?

Targeting 2.6 even though we're in beta since this is no-risk addition, and all we need to do is update the manual.
Unless of course you think we should mention this in the searchbar tooltip.