### PR TITLE
(fix) correct Hidden settings namespace

### DIFF
--- a/src/library/missing_hidden/hiddentablemodel.cpp
+++ b/src/library/missing_hidden/hiddentablemodel.cpp
@@ -13,7 +13,7 @@ const QString kModelName = "hidden:";
 
 HiddenTableModel::HiddenTableModel(QObject* parent,
         TrackCollectionManager* pTrackCollectionManager)
-        : BaseSqlTableModel(parent, pTrackCollectionManager, "mixxx.db.model.missing") {
+        : BaseSqlTableModel(parent, pTrackCollectionManager, "mixxx.db.model.hidden") {
     setTableModel();
 }
 


### PR DESCRIPTION
regression from #2365 
Apparently no one noticed because it's actually a feature if you like to sync the column layout ; )

Noticed in #14479 which may bring automatic column layout sync.