### PR TITLE
fix(library): Allow loading in-progress recordings

### DIFF
--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -41,11 +41,10 @@ const QStringList removableDriveRootPaths() {
 
 BrowseFeature::BrowseFeature(
         Library* pLibrary,
-        UserSettingsPointer pConfig,
-        RecordingManager* pRecordingManager)
+        UserSettingsPointer pConfig)
         : LibraryFeature(pLibrary, pConfig, QString("computer")),
           m_pTrackCollection(pLibrary->trackCollectionManager()->internalCollection()),
-          m_browseModel(this, pLibrary->trackCollectionManager(), pRecordingManager),
+          m_browseModel(this, pLibrary->trackCollectionManager()),
           m_proxyModel(&m_browseModel, true),
           m_pSidebarModel(new FolderTreeModel(this)) {
     connect(&m_browseModel,

--- a/src/library/browse/browsefeature.h
+++ b/src/library/browse/browsefeature.h
@@ -25,8 +25,7 @@ class BrowseFeature : public LibraryFeature {
     Q_OBJECT
   public:
     BrowseFeature(Library* pLibrary,
-            UserSettingsPointer pConfig,
-            RecordingManager* pRecordingManager);
+            UserSettingsPointer pConfig);
     ~BrowseFeature() override;
 
     QVariant title() override;

--- a/src/library/browse/browsetablemodel.cpp
+++ b/src/library/browse/browsetablemodel.cpp
@@ -42,13 +42,11 @@ void listAppendOrReplaceAt(QList<T>* pList, int index, const T& value) {
 } // anonymous namespace
 
 BrowseTableModel::BrowseTableModel(QObject* parent,
-        TrackCollectionManager* pTrackCollectionManager,
-        RecordingManager* pRecordingManager)
+        TrackCollectionManager* pTrackCollectionManager)
         : TrackModel(pTrackCollectionManager->internalCollection()->database(),
                   "mixxx.db.model.browse"),
           QStandardItemModel(parent),
           m_pTrackCollectionManager(pTrackCollectionManager),
-          m_pRecordingManager(pRecordingManager),
           m_previewDeckGroup(PlayerManager::groupForPreviewDeck(0)) {
     QStringList headerLabels;
     /// The order of the columns appended here must exactly match the ordering
@@ -219,14 +217,6 @@ TrackPointer BrowseTableModel::getTrack(const QModelIndex& index) const {
 }
 
 TrackPointer BrowseTableModel::getTrackByRef(const TrackRef& trackRef) const {
-    if (m_pRecordingManager->getRecordingLocation() == trackRef.getLocation()) {
-        QMessageBox::critical(nullptr,
-                tr("Mixxx Library"),
-                tr("Could not load the following file because it is in use by "
-                   "Mixxx or another application.") +
-                        "\n" + trackRef.getLocation());
-        return TrackPointer();
-    }
     // NOTE(uklotzde, 2015-12-08): Accessing tracks from the browse view
     // will implicitly add them to the library. Is this really what we
     // want here??

--- a/src/library/browse/browsetablemodel.h
+++ b/src/library/browse/browsetablemodel.h
@@ -50,7 +50,7 @@ class BrowseTableModel final : public QStandardItemModel, public virtual TrackMo
     Q_OBJECT
 
   public:
-    BrowseTableModel(QObject* parent, TrackCollectionManager* pTrackCollectionManager, RecordingManager* pRec);
+    BrowseTableModel(QObject* parent, TrackCollectionManager* pTrackCollectionManager);
     virtual ~BrowseTableModel();
 
     // initiate table population, store path
@@ -106,7 +106,6 @@ class BrowseTableModel final : public QStandardItemModel, public virtual TrackMo
     TrackCollectionManager* const m_pTrackCollectionManager;
 
     QList<int> m_searchColumns;
-    RecordingManager* m_pRecordingManager;
     BrowseThreadPointer m_pBrowseThread;
     QString m_currentDirectory;
     QString m_previewDeckGroup;

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -131,7 +131,7 @@ Library::Library(
 #endif
 
     m_pBrowseFeature = new BrowseFeature(
-            this, m_pConfig, pRecordingManager);
+            this, m_pConfig);
     connect(m_pBrowseFeature,
             &BrowseFeature::scanLibrary,
             m_pTrackCollectionManager,

--- a/src/library/recording/dlgrecording.cpp
+++ b/src/library/recording/dlgrecording.cpp
@@ -22,7 +22,7 @@ DlgRecording::DlgRecording(
                           pConfig,
                           pLibrary,
                           parent->getTrackTableBackgroundColorOpacity())),
-          m_browseModel(this, pLibrary->trackCollectionManager(), pRecordingManager),
+          m_browseModel(this, pLibrary->trackCollectionManager()),
           m_proxyModel(&m_browseModel, true),
           m_bytesRecordedStr("--"),
           m_durationRecordedStr("--:--"),


### PR DESCRIPTION
This change fixes an issue where an in-progress recording could not be loaded into a deck on the first attempt.

The error was caused by a premature check in `BrowseTableModel::getTrackByRef` that incorrectly blocked the loading of a track that was currently being recorded.

This fix removes the erroneous `if` block, allowing the call to proceed to `m_pTrackCollectionManager->getOrAddTrack`, which correctly handles the track and allows it to be loaded successfully.

This was tested locally by starting a recording and confirming the track can be dragged to a deck on the first attempt without any error dialogs.

Fixes #14723