### PR TITLE
Beat detection: rfc sharping

### DIFF
--- a/lib/qm-dsp/dsp/tempotracking/TempoTrackV2.cpp
+++ b/lib/qm-dsp/dsp/tempotracking/TempoTrackV2.cpp
@@ -138,31 +138,32 @@ TempoTrackV2::calculateBeatPeriod(const vector<double> &df,
         }
     }
 
-    // beat tracking frame size (roughly 6 seconds) and hop (1.5 seconds)
+    // Beat tracking window length (roughly 6 seconds) and hop size (1.5 seconds)
     int winlen = 512;
-    int step = 128;
+    int hopsize = 128;
 
-    // matrix to store output of comb filter bank, increment column of matrix at each frame
+    // Matrix to store output of comb filter bank
     d_mat_t rcfmat;
-    int col_counter = -1;
     int df_len = int(df.size());
 
-    // main loop for beat period calculation
-    for (int i = 0; i+winlen < df_len; i+=step) {
+    // Loop over the onset detection function in overlapping windows.
+    for (int i = 0; i + winlen < df_len; i += hopsize) {
         
-        // get dfframe
+        // Extact a window from df
         d_vec_t dfframe(winlen);
-        for (int k=0; k < winlen; k++) {
-            dfframe[k] = df[i+k];
+        for (int k = 0; k < winlen; k++) {
+            dfframe[k] = df[i + k];
         }
-        // get rcf vector for current frame
-        d_vec_t rcf(wv_len);
-        get_rcf(dfframe,wv,rcf);
 
-        rcfmat.push_back( d_vec_t() ); // adds a new column
-        col_counter++;
+        // Apply the resonator comb filter (RCF) bank to the window
+        // The result is a vector of filter responses for different periods.
+        d_vec_t rcf(wv_len);
+        get_rcf(dfframe, wv, rcf);
+
+        // Append the result to rcfmat as a new column 
+        rcfmat.push_back(d_vec_t());
         for (int j = 0; j < wv_len; j++) {
-            rcfmat[col_counter].push_back( rcf[j] );
+            rcfmat.back().push_back(rcf[j]);
         }
     }
 

--- a/lib/qm-dsp/dsp/tempotracking/TempoTrackV2.cpp
+++ b/lib/qm-dsp/dsp/tempotracking/TempoTrackV2.cpp
@@ -213,19 +213,44 @@ TempoTrackV2::get_rcf(const d_vec_t &dfframe_in, const d_vec_t &wv, d_vec_t &rcf
         }
     }
 
-    // apply adaptive threshold to rcf
-    MathUtilities::adaptiveThreshold(rcf);
+    // Apply a threshold to rcf to remove the noise floor which is in the wv shape.
 
-    double rcfsum =0.;
+    // Significant phases with percussion instruments have values in the 1000 - 10000 region
+    // Tracks with piano or guitar only have short regions we can use in the range of 20 - 35
+    // vocal and ambient beatless regions are < 5 and considered as detection noise.
+    // An artificial offset of 100 makes these low value peaks less significant in the
+    // following normalization step. They do no longer stand out, so that the following viterbi step
+    // keeps the tempo from a previous more significant region until another significant
+    // region is reached. This also avoids to get hooked to a different harmonics phase (int multiplier)
+    // after a bridge in electronic tracks.
+
+    double rcfsum1 = 0.;
     for (int i = 0; i < rcf_len; i++) {
-        rcf[i] += EPS ;
-        rcfsum += rcf[i];
+        rcfsum1 += rcf[i];
+    }
+
+    for (int i = 0; i < rcf_len; i++) {
+        rcf[i] -= wv[i] * rcfsum1;
+        if (rcf[i] < 0) {
+            rcf[i] = 0;
+        }
+        rcf[i] += 100; // determined experimentally (see above)
     }
 
     // normalise rcf to sum to unity
+    double rcfsum =0.;
     for (int i = 0; i < rcf_len; i++) {
-        rcf[i] /= (rcfsum + EPS);
+        rcfsum += rcf[i];
     }
+
+    for (int i = 0; i < rcf_len; i++) {
+        rcf[i] /= rcfsum;
+    }
+
+    // for (int i = 0; i < rcf_len; i++) {
+    //     std::cerr << " " << rcf[i];
+    //}
+    //std::cerr << std::endl;
 }
 
 void

--- a/lib/qm-dsp/dsp/tempotracking/TempoTrackV2.cpp
+++ b/lib/qm-dsp/dsp/tempotracking/TempoTrackV2.cpp
@@ -141,23 +141,25 @@ TempoTrackV2::calculateBeatPeriod(const vector<double> &df,
     // Beat tracking window length (roughly 6 seconds) and hop size (1.5 seconds)
     int winlen = 512;
     int hopsize = 128;
-
+    
+    int df_len = int(df.size());
+    
     // Matrix to store output of comb filter bank
     d_mat_t rcfmat;
-    int df_len = int(df.size());
+    rcfmat.reserve(df_len / hopsize + 1);
+    d_vec_t dfframe(winlen);
+    d_vec_t rcf(wv_len);
 
     // Loop over the onset detection function in overlapping windows.
     for (int i = 0; i + winlen < df_len; i += hopsize) {
         
         // Extact a window from df
-        d_vec_t dfframe(winlen);
         for (int k = 0; k < winlen; k++) {
             dfframe[k] = df[i + k];
         }
 
         // Apply the resonator comb filter (RCF) bank to the window
         // The result is a vector of filter responses for different periods.
-        d_vec_t rcf(wv_len);
         get_rcf(dfframe, wv, rcf);
 
         // Append the result to rcfmat as a new column 

--- a/src/analyzer/plugins/analyzerqueenmarybeats.cpp
+++ b/src/analyzer/plugins/analyzerqueenmarybeats.cpp
@@ -77,22 +77,21 @@ bool AnalyzerQueenMaryBeats::processSamples(const CSAMPLE* pIn, SINT iLen) {
 bool AnalyzerQueenMaryBeats::finalize() {
     m_helper.finalize();
 
-    int nonZeroCount = static_cast<int>(m_detectionResults.size());
+    std::size_t nonZeroCount = m_detectionResults.size();
     while (nonZeroCount > 0 && m_detectionResults.at(nonZeroCount - 1) <= 0.0) {
         --nonZeroCount;
     }
 
+    std::size_t required_size = std::max(static_cast<std::size_t>(0), nonZeroCount - 2);
+
     std::vector<double> df;
-    std::vector<double> beatPeriod;
-    const auto required_size = std::max(0, nonZeroCount - 2);
     df.reserve(required_size);
-    beatPeriod.reserve(required_size);
+    auto beatPeriod = std::vector<double>(required_size);
 
     // skip first 2 results as it might have detect noise as onset
     // that's how vamp does and seems works best this way
-    for (int i = 2; i < nonZeroCount; ++i) {
+    for (std::size_t i = 2; i < nonZeroCount; ++i) {
         df.push_back(m_detectionResults.at(i));
-        beatPeriod.push_back(0.0);
     }
 
     TempoTrackV2 tt(m_sampleRate, m_stepSizeFrames);
@@ -102,7 +101,7 @@ bool AnalyzerQueenMaryBeats::finalize() {
     tt.calculateBeats(df, beatPeriod, beats);
 
     m_resultBeats.reserve(static_cast<int>(beats.size()));
-    for (size_t i = 0; i < beats.size(); ++i) {
+    for (std::size_t i = 0; i < beats.size(); ++i) {
         // we add the halve m_stepSizeFrames here, because the beat
         // is detected between the two samples.
         const auto result = mixxx::audio::FramePos(


### PR DESCRIPTION
This PR improved the beat detector by not trying to find beat periods in boatless, ambient or vocal regions. 
It is on top of https://github.com/mixxxdj/mixxx/pull/15076 The actual beat detection is still looking for beats in the range of the detected period. This will be fixed in a follow up PR.  

This is a significant improvement for tracks with bridges where the algorithm was not able to keep the phase and tempo before and after. So we should consider to bump the detector version at some point. This is only the second step of PRs more are in progress. Is this still a 2.6 bug fix? 

Here the results: 

[Balron - Neurosekanice](https://music.youtube.com/watch?v=5zz3LrRcVS0) a track with a problematic bridge 
Before: 
<img width="606" height="341" alt="grafik" src="https://github.com/user-attachments/assets/1e0e8c7f-4af6-43f0-ba40-1c08d0f7adf0" />
After: 
<img width="606" height="341" alt="grafik" src="https://github.com/user-attachments/assets/465280b8-8070-4fcb-b874-296699619b60" />
The tempo before and after the bridge is the same. During the beatless bridge there are still a tempo dip. This is the topic of a follow up PR. 

[Rachel Zegler - The Ballad of Lucy Gray Baird](https://music.youtube.com/watch?v=74LYZuxHom0) a guitar track without drums 
Before: 
<img width="606" height="341" alt="grafik" src="https://github.com/user-attachments/assets/0aa3f76a-38ac-4ab5-88ae-b6bb86ea97c4" />
After: 
<img width="606" height="341" alt="grafik" src="https://github.com/user-attachments/assets/0a8e8c98-fa26-45af-adf7-2558ec910c73" />
The detector no longer follows the vocals which are no actual beats. 

[Soffie - Für immer Frühling](https://music.youtube.com/watch?v=8AXCCi8puA4) a constant 140 bpm track with piano and vocal only regions. 
Before: 
<img width="606" height="341" alt="grafik" src="https://github.com/user-attachments/assets/c1ffe504-e409-4485-8bb0-4fea9a97ad71" />
After: 
<img width="606" height="341" alt="grafik" src="https://github.com/user-attachments/assets/1295d64f-6133-4720-b908-c4fed69d6b50" />
Result is way better but not perfect. especially there is a tempo dip at the beginning and gentle floating at the vocal only region. 

[Rudeejay & Da Brozz Vs ANGEMI - #Narcotic2k17 (RYGO Edit)](https://music.youtube.com/watch?v=6yX6ZSv3PTo) tempo changing track. 
Before: 
<img width="606" height="341" alt="grafik" src="https://github.com/user-attachments/assets/5c0b63a9-3c7a-4399-ab9c-7b5632eb269f" />
After: 
<img width="606" height="341" alt="grafik" src="https://github.com/user-attachments/assets/45e6eb3d-8efc-44dc-902e-bb0e50340bc5" />
This confirms that we don't have a regression in non problematic tracks or with tempo changes. The new version however eliminated the tempo dip at the end. 

 


 