### PR TITLE
AddSwapArtistTitleButton

### DIFF
--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -171,10 +171,14 @@ void DlgTrackInfo::init() {
             &TapFilter::tapped,
             this,
             &DlgTrackInfo::slotBpmTap);
-
+    // Swap Title - Artist
+    connect(btnSwapArtistTitle,
+            &QPushButton::clicked,
+            this,
+            &DlgTrackInfo::slotSwapArtistTitle);
     // Metadata fields
     connect(txtTitle,
-            &QLineEdit::editingFinished,
+            &QLineEdit::textChanged,
             this,
             [this]() {
                 txtTitle->setText(txtTitle->text().trimmed());
@@ -182,7 +186,7 @@ void DlgTrackInfo::init() {
                         txtTitle->text());
             });
     connect(txtArtist,
-            &QLineEdit::editingFinished,
+            &QLineEdit::textChanged,
             this,
             [this]() {
                 txtArtist->setText(txtArtist->text().trimmed());
@@ -302,6 +306,13 @@ void DlgTrackInfo::init() {
                 trackColorDialogSetColor(newColor);
                 m_trackRecord.setColor(newColor);
             });
+}
+
+void DlgTrackInfo::slotSwapArtistTitle() {
+    QString artist = txtArtist->text();
+    QString title = txtTitle->text();
+    txtArtist->setText(title);
+    txtTitle->setText(artist);
 }
 
 void DlgTrackInfo::slotApply() {

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -57,6 +57,7 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     void slotOk();
     void slotApply();
     void slotCancel();
+    void slotSwapArtistTitle();
 
     void slotBpmScale(mixxx::Beats::BpmScale bpmScale);
     void slotBpmClear();

--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -90,7 +90,7 @@
            </widget>
           </item>
 
-          <item row="0" column="2" rowspan="3" colspan="2">
+          <item row="0" column="2" rowspan="4" colspan="2">
            <widget class="QWidget" name="coverWidget" native="true">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -142,7 +142,18 @@
            </widget>
           </item>
 
-          <item row="2" column="0">
+          <item row="2" column="1">
+           <widget class="QPushButton" name="btnSwapArtistTitle">
+            <property name="text">
+             <string>Swap Artist - Title</string>
+            </property>
+            <property name="toolTip">
+             <string>Swap the Artist and Title (requires apply or OK)</string>
+            </property>
+           </widget>
+          </item>
+
+          <item row="3" column="0">
            <widget class="QLabel" name="lblAlbum">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -158,7 +169,7 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
+          <item row="3" column="1">
            <widget class="QLineEdit" name="txtAlbum">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -175,7 +186,7 @@
            </widget>
           </item>
 
-          <item row="3" column="0">
+          <item row="4" column="0">
            <widget class="QLabel" name="lblAlbumArtist">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -191,7 +202,7 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
+          <item row="4" column="1">
            <widget class="QLineEdit" name="txtAlbumArtist">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -208,7 +219,7 @@
            </widget>
           </item>
 
-          <item row="3" column="2" colspan="2">
+          <item row="4" column="2" colspan="2">
            <widget class="QWidget" name="verticalWidgetStars" native="true">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -227,7 +238,7 @@
            </widget>
           </item>
 
-          <item row="4" column="0">
+          <item row="5" column="0">
            <widget class="QLabel" name="lblComposer">
             <property name="text">
              <string>Composer</string>
@@ -237,7 +248,7 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="1">
+          <item row="5" column="1">
            <widget class="QLineEdit" name="txtComposer">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -254,7 +265,7 @@
            </widget>
           </item>
 
-          <item row="4" column="2">
+          <item row="5" column="2">
            <widget class="QLabel" name="lblYear">
             <property name="text">
              <string>Year</string>
@@ -264,7 +275,7 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="3">
+          <item row="5" column="3">
            <widget class="QLineEdit" name="txtYear">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -275,7 +286,7 @@
            </widget>
           </item>
 
-          <item row="5" column="0">
+          <item row="6" column="0">
            <widget class="QLabel" name="lblGenre">
             <property name="text">
              <string>Genre</string>
@@ -285,7 +296,7 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="1">
+          <item row="6" column="1">
            <widget class="QLineEdit" name="txtGenre">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -302,7 +313,7 @@
            </widget>
           </item>
 
-          <item row="5" column="2">
+          <item row="6" column="2">
            <widget class="QLabel" name="lblKey">
             <property name="text">
              <string>Key</string>
@@ -312,7 +323,7 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="3">
+          <item row="6" column="3">
            <widget class="QLineEdit" name="txtKey">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -329,7 +340,7 @@
            </widget>
           </item>
 
-          <item row="6" column="0">
+          <item row="7" column="0">
            <widget class="QLabel" name="lblGrouping">
             <property name="text">
              <string>Grouping</string>
@@ -339,7 +350,7 @@
             </property>
            </widget>
           </item>
-          <item row="6" column="1">
+          <item row="7" column="1">
            <widget class="QLineEdit" name="txtGrouping">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -356,7 +367,7 @@
            </widget>
           </item>
 
-          <item row="6" column="2">
+          <item row="7" column="2">
            <widget class="QLabel" name="lblTrackNumber">
             <property name="text">
              <string>Track #</string>
@@ -366,7 +377,7 @@
             </property>
            </widget>
           </item>
-          <item row="6" column="3">
+          <item row="7" column="3">
            <widget class="QLineEdit" name="txtTrackNumber">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -383,7 +394,7 @@
            </widget>
           </item>
 
-          <item row="7" column="0">
+          <item row="8" column="0">
            <widget class="QLabel" name="lblTrackComment">
             <property name="text">
              <string>Comments</string>
@@ -393,7 +404,7 @@
             </property>
            </widget>
           </item>
-          <item row="7" column="1" colspan="3">
+          <item row="8" column="1" colspan="3">
            <widget class="QPlainTextEdit" name="txtComment">
             <property name="tabChangesFocus">
              <bool>true</bool>
@@ -401,7 +412,7 @@
            </widget>
           </item>
 
-          <item row="8" column="0">
+          <item row="9" column="0">
            <widget class="QLabel" name="lblTrackColor">
             <property name="text">
              <string>Color</string>
@@ -411,7 +422,7 @@
             </property>
            </widget>
           </item>
-          <item row="8" column="1" colspan="3">
+          <item row="9" column="1" colspan="3">
            <widget class="QPushButton" name="btnColorPicker">
             <property name="sizePolicy">
              <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
@@ -421,7 +432,7 @@
             </property>
            </widget>
           </item>
-          <item row="9" column="0">
+          <item row="10" column="0">
            <spacer name="horizontalSpacer_5">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
@@ -434,7 +445,7 @@
             </property>
            </spacer>
           </item>
-          <item row="10" column="0" colspan="4">
+          <item row="11" column="0" colspan="4">
            <layout class="QHBoxLayout" name="meatdata_buttons_layout">
             <item>
              <widget class="QPushButton" name="btnImportMetadataFromMusicBrainz">

--- a/src/library/dlgtrackinfomulti.cpp
+++ b/src/library/dlgtrackinfomulti.cpp
@@ -172,6 +172,11 @@ void DlgTrackInfoMulti::init() {
             this,
             &DlgTrackInfoMulti::slotOpenInFileBrowser);
 
+    connect(btnSwapArtistTitle,
+            &QPushButton::clicked,
+            this,
+            &DlgTrackInfoMulti::slotSwapArtistTitle);
+
     QList<QComboBox*> valueComboBoxes;
     valueComboBoxes.append(txtArtist);
     valueComboBoxes.append(txtTitle);
@@ -290,6 +295,31 @@ void DlgTrackInfoMulti::init() {
             &WCoverArtMenu::reloadCoverArt,
             this,
             &DlgTrackInfoMulti::slotReloadCoverArt);
+}
+
+void DlgTrackInfoMulti::slotSwapArtistTitle() {
+    qDebug() << "[DlgTrackInfoMulti] -> slotSwapArtistTitle() called";
+    QString oldArtist, oldTitle;
+    if (m_trackRecords.isEmpty()) {
+        return;
+    }
+
+    for (auto& rec : m_trackRecords) {
+        oldTitle.clear();
+        oldArtist.clear();
+        oldArtist = rec.getMetadata().getTrackInfo().getArtist();
+        oldTitle = rec.getMetadata().getTrackInfo().getTitle();
+        rec.refMetadata().refTrackInfo().setArtist(oldTitle);
+        rec.refMetadata().refTrackInfo().setTitle(oldArtist);
+    }
+
+    disconnectTracksChanged();
+    for (const auto& rec : std::as_const(m_trackRecords)) {
+        auto pTrack = m_pLoadedTracks.value(rec.getId());
+        pTrack->replaceRecord(rec);
+    }
+    connectTracksChanged();
+    updateFromTracks();
 }
 
 void DlgTrackInfoMulti::slotApply() {

--- a/src/library/dlgtrackinfomulti.h
+++ b/src/library/dlgtrackinfomulti.h
@@ -68,6 +68,7 @@ class DlgTrackInfoMulti : public QDialog, public Ui::DlgTrackInfoMulti {
     void slotReloadCoverArt();
 
     void slotOpenInFileBrowser();
+    void slotSwapArtistTitle();
 
   private:
     void init();

--- a/src/library/dlgtrackinfomulti.ui
+++ b/src/library/dlgtrackinfomulti.ui
@@ -127,7 +127,18 @@
        </widget>
       </item>
 
-      <item row="2" column="0">
+      <item row="2" column="1">
+       <widget class="QPushButton" name="btnSwapArtistTitle">
+        <property name="text">
+         <string>Swap Artist - Title</string>
+        </property>
+        <property name="toolTip">
+         <string>Swap the Artists and Titles (instantly applied to all tracks)</string>
+        </property>
+       </widget>
+      </item>
+
+       <item row="3" column="0">
        <widget class="QLabel" name="lblAlbum">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -143,7 +154,7 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="3" column="1">
        <widget class="QComboBox" name="txtAlbum">
         <property name="sizePolicy">
          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -160,7 +171,7 @@
        </widget>
       </item>
 
-      <item row="3" column="0">
+      <item row="4" column="0">
        <widget class="QLabel" name="lblAlbumArtist">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -176,7 +187,7 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
+      <item row="4" column="1">
        <widget class="QComboBox" name="txtAlbumArtist">
         <property name="sizePolicy">
          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -193,7 +204,7 @@
        </widget>
       </item>
 
-      <item row="3" column="2" colspan="2">
+      <item row="4" column="2" colspan="2">
        <widget class="QWidget" name="starsWidget" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -212,7 +223,7 @@
        </widget>
       </item>
 
-      <item row="4" column="0">
+      <item row="5" column="0">
        <widget class="QLabel" name="lblComposer">
         <property name="text">
          <string>Composer</string>
@@ -222,7 +233,7 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="1">
+      <item row="5" column="1">
        <widget class="QComboBox" name="txtComposer">
         <property name="sizePolicy">
          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -239,7 +250,7 @@
        </widget>
       </item>
 
-      <item row="4" column="2">
+      <item row="5" column="2">
        <widget class="QLabel" name="lblYear">
         <property name="text">
          <string>Year</string>
@@ -249,7 +260,7 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="3">
+      <item row="5" column="3">
        <widget class="QComboBox" name="txtYear">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -260,7 +271,7 @@
        </widget>
       </item>
 
-      <item row="5" column="0">
+      <item row="6" column="0">
        <widget class="QLabel" name="lblGenre">
         <property name="text">
          <string>Genre</string>
@@ -270,7 +281,7 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="1">
+      <item row="6" column="1">
        <widget class="QComboBox" name="txtGenre">
         <property name="sizePolicy">
          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -287,7 +298,7 @@
        </widget>
       </item>
 
-      <item row="5" column="2">
+      <item row="6" column="2">
        <widget class="QLabel" name="lblKey">
         <property name="text">
          <string>Key</string>
@@ -297,7 +308,7 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="3">
+      <item row="6" column="3">
        <widget class="QComboBox" name="txtKey">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -314,7 +325,7 @@
        </widget>
       </item>
 
-      <item row="6" column="0">
+      <item row="7" column="0">
        <widget class="QLabel" name="lblGrouping">
         <property name="text">
          <string>Grouping</string>
@@ -324,7 +335,7 @@
         </property>
        </widget>
       </item>
-      <item row="6" column="1">
+      <item row="7" column="1">
        <widget class="QComboBox" name="txtGrouping">
         <property name="sizePolicy">
          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -341,7 +352,7 @@
        </widget>
       </item>
 
-      <item row="6" column="2">
+      <item row="7" column="2">
        <widget class="QLabel" name="lblTrackNumber">
         <property name="text">
          <string>Track #</string>
@@ -351,7 +362,7 @@
         </property>
        </widget>
       </item>
-      <item row="6" column="3">
+      <item row="7" column="3">
        <widget class="QComboBox" name="txtTrackNumber">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -368,7 +379,7 @@
        </widget>
       </item>
 
-      <item row="7" column="0">
+      <item row="8" column="0">
        <widget class="QLabel" name="lblTrackComment">
         <property name="text">
          <string>Comments</string>
@@ -378,7 +389,7 @@
         </property>
        </widget>
       </item>
-      <item row="7" column="1" colspan="3">
+      <item row="8" column="1" colspan="3">
        <widget class="QComboBox" name="txtCommentBox">
         <property name="sizePolicy">
          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -394,7 +405,7 @@
         </property>
        </widget>
       </item>
-      <item row="8" column="1" colspan="3">
+      <item row="9" column="1" colspan="3">
        <widget class="QPlainTextEdit" name="txtComment">
         <property name="sizePolicy">
          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -408,7 +419,7 @@
        </widget>
       </item>
 
-      <item row="9" column="0">
+      <item row="10" column="0">
        <widget class="QLabel" name="lblTrackColor">
         <property name="text">
          <string>Color</string>
@@ -418,7 +429,7 @@
         </property>
        </widget>
       </item>
-      <item row="9" column="1" colspan="3">
+      <item row="10" column="1" colspan="3">
        <widget class="QPushButton" name="btnColorPicker">
         <property name="sizePolicy">
          <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
@@ -429,7 +440,7 @@
        </widget>
       </item>
 
-      <item row="10" column="0">
+      <item row="11" column="0">
        <spacer name="spacerColorPicker">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
@@ -443,7 +454,7 @@
        </spacer>
       </item>
 
-      <item row="11" column="0" colspan="4">
+      <item row="12" column="0" colspan="4">
        <widget class="QPushButton" name="btnImportMetadataFromFile">
         <property name="text">
          <string>Re-Import Metadata from files</string>


### PR DESCRIPTION
This PR adds a button in DlgTrackInfo & DlgTrackInfoMulti to swap Artist & Title, to solve the feature reques in #15128.
-> in DlgTrackInfo the change needs an apply or OK
-> in DlgTrackInfoMutli the changes are applied directly.

<img width="560" height="232" alt="afbeelding" src="https://github.com/user-attachments/assets/62d6c1b3-512d-4c43-af0f-76fc51f67006" />

<img width="568" height="260" alt="afbeelding" src="https://github.com/user-attachments/assets/2331fb2b-9d40-4f0b-aa53-e61d62829b98" />
