### PR TITLE
(fix) Tracks: prevent reorder with Alt keys when model (playlist) is locked

### DIFF
--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -698,7 +698,7 @@ void WTrackTableView::mouseMoveEvent(QMouseEvent* pEvent) {
 // Drag enter event, happens when a dragged item hovers over the track table view
 void WTrackTableView::dragEnterEvent(QDragEnterEvent * event) {
     auto* pTrackModel = getTrackModel();
-    if (!pTrackModel || !event->mimeData()->hasUrls()) {
+    if (!pTrackModel || pTrackModel->isLocked() || !event->mimeData()->hasUrls()) {
         event->ignore();
         return;
     }
@@ -720,25 +720,22 @@ void WTrackTableView::dragEnterEvent(QDragEnterEvent * event) {
 // Without it, the following drop is ignored.
 void WTrackTableView::dragMoveEvent(QDragMoveEvent * event) {
     auto* pTrackModel = getTrackModel();
-    if (!pTrackModel) {
+    if (!pTrackModel || pTrackModel->isLocked() || event->mimeData()->hasUrls()) {
+        event->ignore();
         return;
     }
     // Needed to allow auto-scrolling
     WLibraryTableView::dragMoveEvent(event);
 
     //qDebug() << "dragMoveEvent" << event->mimeData()->formats();
-    if (pTrackModel && event->mimeData()->hasUrls()) {
-        if (event->source() == this) {
-            if (pTrackModel->hasCapabilities(TrackModel::Capability::Reorder)) {
-                event->acceptProposedAction();
-            } else {
-                event->ignore();
-            }
-        } else {
+    if (event->source() == this) {
+        if (pTrackModel->hasCapabilities(TrackModel::Capability::Reorder)) {
             event->acceptProposedAction();
+        } else {
+            event->ignore();
         }
     } else {
-        event->ignore();
+        event->acceptProposedAction();
     }
 }
 
@@ -747,7 +744,7 @@ void WTrackTableView::dropEvent(QDropEvent * event) {
     TrackModel* pTrackModel = getTrackModel();
     // We only do things to the TrackModel in this method so if we don't have
     // one we should just bail.
-    if (!pTrackModel) {
+    if (!pTrackModel || pTrackModel->isLocked() || !event->mimeData()->hasUrls()) {
         event->ignore();
         return;
     }
@@ -755,11 +752,6 @@ void WTrackTableView::dropEvent(QDropEvent * event) {
     QItemSelectionModel* pSelectionModel = selectionModel();
     VERIFY_OR_DEBUG_ASSERT(pSelectionModel != nullptr) {
         qWarning() << "No selection model available";
-        event->ignore();
-        return;
-    }
-
-    if (!event->mimeData()->hasUrls() || pTrackModel->isLocked()) {
         event->ignore();
         return;
     }
@@ -1080,6 +1072,11 @@ void WTrackTableView::moveRows(QList<int> selectedRowsIn, int destRow) {
 }
 
 void WTrackTableView::moveSelectedTracks(QKeyEvent* event) {
+    TrackModel* pTrackModel = getTrackModel();
+    if (!pTrackModel || pTrackModel->isLocked()) {
+        return;
+    }
+
     QList<int> selectedRows = getSelectedRowNumbers();
     if (selectedRows.isEmpty()) {
         return;

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1199,23 +1199,25 @@ void WTrackTableView::keyPressEvent(QKeyEvent* event) {
                 clearSelection();
                 setCurrentIndex(QModelIndex());
             }
+
+            if (event->modifiers().testFlag(Qt::AltModifier) &&
+                    (event->key() == Qt::Key_Up ||
+                            event->key() == Qt::Key_Down ||
+                            event->key() == Qt::Key_PageUp ||
+                            event->key() == Qt::Key_PageDown ||
+                            event->key() == Qt::Key_Home ||
+                            event->key() == Qt::Key_End) &&
+                    pTrackModel->hasCapabilities(TrackModel::Capability::Reorder)) {
+                moveSelectedTracks(event);
+                return;
+            }
         }
 
         if (event->matches(QKeySequence::Copy)) {
             copySelectedTracks();
             return;
         }
-        if (event->modifiers().testFlag(Qt::AltModifier) &&
-                (event->key() == Qt::Key_Up ||
-                        event->key() == Qt::Key_Down ||
-                        event->key() == Qt::Key_PageUp ||
-                        event->key() == Qt::Key_PageDown ||
-                        event->key() == Qt::Key_Home ||
-                        event->key() == Qt::Key_End) &&
-                pTrackModel->hasCapabilities(TrackModel::Capability::Reorder)) {
-            moveSelectedTracks(event);
-            return;
-        }
+
         if (event->modifiers().testFlag(Qt::ControlModifier) &&
                 event->modifiers().testFlag(Qt::ShiftModifier) &&
                 event->key() == Qt::Key_C) {


### PR DESCRIPTION
1) prevent reorder of locked model with Alt keys
2) unify some DnD test, add some so the cursor correctly reflects ignore/accept