### PR TITLE
Beat detector: fix rounding issue in comb filter that considers the harmonics

### DIFF
--- a/lib/qm-dsp/dsp/tempotracking/TempoTrackV2.cpp
+++ b/lib/qm-dsp/dsp/tempotracking/TempoTrackV2.cpp
@@ -210,22 +210,28 @@ TempoTrackV2::get_rcf(const d_vec_t &dfframe_in, const d_vec_t &wv, d_vec_t &rcf
 
     rcf[0] = 0;
     for (int i = 1; i < rcf_len; i++) { // max beat period
+        // First interval
         rcf[i] = acf[i];
 
+        // Second interval. We use the two neigbours as half value only because they
+        // are between this and the pervious or next iteration. Summe of all is 1. 
         rcf[i] += acf[i * 2 - 1] / 4;
         rcf[i] += acf[i * 2] / 2;
         rcf[i] += acf[i * 2 + 1] / 4;
 
+        // Third interval. Neighbours fully belong to this interval 
         rcf[i] += acf[i * 3 - 1] / 3;
         rcf[i] += acf[i * 3] / 3;
         rcf[i] += acf[i * 3 + 1] / 3;
 
+        // Third interval. The outer neighbours are again on the border. 
         rcf[i] += acf[i * 4 - 2] / 8;
         rcf[i] += acf[i * 4 - 1] / 4;
         rcf[i] += acf[i * 4] / 4;
         rcf[i] += acf[i * 4 + 1] / 4;
         rcf[i] += acf[i * 4 + 2] / 8;
 
+        // Apply whigtening to prefered values around 120 bpm 
         rcf[i] *= wv[i];
     }
 


### PR DESCRIPTION
During my beat detection test I had the phenomena that the phases pins where ~0.5 steps off. This leads occasionally to wrong rounding results. 

The reason is is an off-by one issue in the comb filter of the autocorrelation result where harmonics are considered slightly off. 

Before: 
* 43
* 86 87 88
* 129 130 131 132 133
* 172 173 174 175 176 177 178 

Now
* 43
* 85 86 87
* 128 129 130
* 170 171 172 173 174 
