### PR TITLE
(fix) Waveforms: don't scratch on mousepress/move with empty waveform

### DIFF
--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -77,7 +77,7 @@ void WWaveformViewer::showEvent(QShowEvent* event) {
 }
 
 void WWaveformViewer::mousePressEvent(QMouseEvent* event) {
-    if (!m_waveformWidget) {
+    if (!m_waveformWidget || m_waveformWidget->getType() == WaveformWidgetType::EmptyWaveform) {
         return;
     }
 
@@ -128,7 +128,7 @@ void WWaveformViewer::mousePressEvent(QMouseEvent* event) {
 }
 
 void WWaveformViewer::mouseMoveEvent(QMouseEvent* event) {
-    if (!m_waveformWidget) {
+    if (!m_waveformWidget || m_waveformWidget->getType() == WaveformWidgetType::EmptyWaveform) {
         return;
     }
 


### PR DESCRIPTION
Fixes #15088 