### PR TITLE
Tracks: align ReplayGain right

### DIFF
--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -862,7 +862,8 @@ QVariant BaseTrackTableModel::roleValue(
         case ColumnCache::COLUMN_LIBRARYTABLE_BPM:
         case ColumnCache::COLUMN_LIBRARYTABLE_DURATION:
         case ColumnCache::COLUMN_LIBRARYTABLE_BITRATE:
-        case ColumnCache::COLUMN_LIBRARYTABLE_TRACKNUMBER: {
+        case ColumnCache::COLUMN_LIBRARYTABLE_TRACKNUMBER:
+        case ColumnCache::COLUMN_LIBRARYTABLE_REPLAYGAIN: {
             // We need to cast to int due to a bug similar to
             // https://bugreports.qt.io/browse/QTBUG-67582
             return static_cast<int>(Qt::AlignVCenter | Qt::AlignRight);


### PR DESCRIPTION
Fixes #14997 

Surprisingly, the numbers are aligned vertically even when a variable-width font is used (where 0 is wider that 1 for example).