### PR TITLE
[GSOC 2025 Antonio Giordano] Add GenreDAO and integrate Multi-Genre Support into TrackDAO and TrackCollection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1224,6 +1224,7 @@ add_library(
   src/library/dao/analysisdao.cpp
   src/library/dao/autodjcratesdao.cpp
   src/library/dao/cuedao.cpp
+  src/library/dao/genredao.cpp
   src/library/dao/directorydao.cpp
   src/library/dao/libraryhashdao.cpp
   src/library/dao/playlistdao.cpp

--- a/src/library/dao/genredao.cpp
+++ b/src/library/dao/genredao.cpp
@@ -1,0 +1,145 @@
+#include "library/dao/genredao.h"
+
+#include <QDebug>
+#include <QSqlDatabase>
+#include <QSqlError>
+#include <QSqlQuery>
+#include <QSqlRecord>
+#include <QVariant>
+#include <QtDebug>
+
+#include "library/queryutil.h"
+#include "moc_genredao.cpp"
+#include "util/db/dbconnection.h"
+
+GenreDao::GenreDao(QObject* parent)
+        : QObject(parent) {
+}
+
+void GenreDao::initialize(const QSqlDatabase& database) {
+    DAO::initialize(database);
+    loadGenres2QVL(m_genreData);
+}
+
+void GenreDao::loadGenres2QVL(QVariantList& genreData) {
+    genreData.clear();
+    QSqlQuery query(m_database);
+    query.prepare("SELECT id, name FROM genres ORDER BY name ASC");
+
+    if (query.exec()) {
+        while (query.next()) {
+            QVariantMap entry;
+            entry["id"] = query.value("id").toInt();
+            entry["name"] = query.value("name").toString();
+            genreData.append(entry);
+        }
+        qDebug() << "GenreDao::loadGenres2QVL loaded" << genreData.size() << "genres";
+    } else {
+        qWarning() << "GenreDao::loadGenres2QVL failed:" << query.lastError();
+    }
+}
+
+QString GenreDao::getDisplayGenreNameForGenreID(const QString& rawGenre) const {
+    return rawGenre;
+}
+
+QMap<QString, QString> GenreDao::getAllGenres() {
+    QMap<QString, QString> genreMap;
+    QSqlQuery query(m_database);
+    query.prepare("SELECT id, name FROM genres");
+
+    if (query.exec()) {
+        while (query.next()) {
+            int id = query.value("id").toInt();
+            QString name = query.value("name").toString();
+            genreMap.insert(QString::number(id), name);
+        }
+    } else {
+        qWarning() << "GenreDao::getAllGenres failed:" << query.lastError();
+    }
+
+    return genreMap;
+}
+
+QStringList GenreDao::getAllGenreNames() const {
+    QStringList names;
+    for (const QVariant& entry : m_genreData) {
+        QVariantMap map = entry.toMap();
+        names << map["name"].toString();
+    }
+    return names;
+}
+
+QStringList GenreDao::getGenresForTrack(TrackId trackId) const {
+    QStringList genres;
+    QSqlQuery query(m_database);
+    query.prepare(
+            "SELECT g.name FROM genres g "
+            "JOIN genre_tracks gt ON g.id = gt.genre_id "
+            "WHERE gt.track_id = ? ORDER BY g.name");
+    query.bindValue(0, trackId.toVariant());
+
+    if (query.exec()) {
+        while (query.next()) {
+            genres << query.value(0).toString();
+        }
+    }
+
+    return genres;
+}
+
+bool GenreDao::setGenresForTrack(TrackId trackId, const QStringList& genreNames) {
+    if (!m_database.transaction()) {
+        return false;
+    }
+
+    QSqlQuery deleteQuery(m_database);
+    deleteQuery.prepare("DELETE FROM genre_tracks WHERE track_id = ?");
+    deleteQuery.bindValue(0, trackId.toVariant());
+
+    if (!deleteQuery.exec()) {
+        m_database.rollback();
+        return false;
+    }
+
+    for (const QString& genreName : genreNames) {
+        if (genreName.trimmed().isEmpty()) {
+            continue;
+        }
+
+        int genreId = createGenre(genreName.trimmed());
+        if (genreId > 0) {
+            QSqlQuery insertQuery(m_database);
+            insertQuery.prepare("INSERT INTO genre_tracks (track_id, genre_id) VALUES (?, ?)");
+            insertQuery.bindValue(0, trackId.toVariant());
+            insertQuery.bindValue(1, genreId);
+
+            if (!insertQuery.exec()) {
+                m_database.rollback();
+                return false;
+            }
+        }
+    }
+
+    return m_database.commit();
+}
+
+int GenreDao::createGenre(const QString& genreName) {
+    QSqlQuery checkQuery(m_database);
+    checkQuery.prepare("SELECT id FROM genres WHERE name = ? COLLATE NOCASE");
+    checkQuery.bindValue(0, genreName);
+
+    if (checkQuery.exec() && checkQuery.next()) {
+        return checkQuery.value(0).toInt();
+    }
+
+    QSqlQuery insertQuery(m_database);
+    insertQuery.prepare("INSERT INTO genres (name) VALUES (?)");
+    insertQuery.bindValue(0, genreName);
+
+    if (insertQuery.exec()) {
+        return insertQuery.lastInsertId().toInt();
+    }
+
+    return -1;
+}

--- a/src/library/dao/genredao.h
+++ b/src/library/dao/genredao.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <QMap>
+#include <QRegularExpression>
+#include <QString>
+#include <QVariantList>
+
+#include "library/dao/dao.h"
+#include "preferences/usersettings.h"
+#include "track/trackid.h"
+#include "util/class.h"
+
+class QSqlDatabase;
+
+class GenreDao : public QObject, public virtual DAO {
+    Q_OBJECT
+  public:
+    explicit GenreDao(QObject* parent = nullptr);
+    ~GenreDao() override = default;
+
+    void initialize(const QSqlDatabase& database) override;
+    void loadGenres2QVL(QVariantList& genreData);
+    QString getDisplayGenreNameForGenreID(const QString& rawGenre) const;
+    QMap<QString, QString> getAllGenres();
+
+    QStringList getAllGenreNames() const;
+    QStringList getGenresForTrack(TrackId trackId) const;
+    bool setGenresForTrack(TrackId trackId, const QStringList& genreNames);
+    int createGenre(const QString& genreName);
+
+  private:
+    QVariantList m_genreData;
+
+    DISALLOW_COPY_AND_ASSIGN(GenreDao);
+};

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -14,6 +14,7 @@
 #include "library/coverartutils.h"
 #include "library/dao/analysisdao.h"
 #include "library/dao/cuedao.h"
+#include "library/dao/genredao.h"
 #include "library/dao/libraryhashdao.h"
 #include "library/dao/playlistdao.h"
 #include "library/dao/trackschema.h"
@@ -89,13 +90,15 @@ QSet<QString> collectTrackLocations(FwdSqlQuery& query) {
 } // anonymous namespace
 
 TrackDAO::TrackDAO(CueDAO& cueDao,
-                   PlaylistDAO& playlistDao,
-                   AnalysisDao& analysisDao,
-                   LibraryHashDAO& libraryHashDao,
-                   UserSettingsPointer pConfig)
+        PlaylistDAO& playlistDao,
+        AnalysisDao& analysisDao,
+        GenreDao& genreDao,
+        LibraryHashDAO& libraryHashDao,
+        UserSettingsPointer pConfig)
         : m_cueDao(cueDao),
           m_playlistDao(playlistDao),
           m_analysisDao(analysisDao),
+          m_genreDao(genreDao),
           m_libraryHashDao(libraryHashDao),
           m_pConfig(pConfig),
           m_trackLocationIdColumn(UndefinedRecordIndex),

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -17,6 +17,7 @@ class PlaylistDAO;
 class AnalysisDao;
 class CueDAO;
 class LibraryHashDAO;
+class GenreDao;
 
 namespace mixxx {
 class FileInfo;
@@ -41,6 +42,7 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
             CueDAO& cueDao,
             PlaylistDAO& playlistDao,
             AnalysisDao& analysisDao,
+            GenreDao& genreDao,
             LibraryHashDAO& libraryHashDao,
             UserSettingsPointer pConfig);
     ~TrackDAO() override;
@@ -202,6 +204,7 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     CueDAO& m_cueDao;
     PlaylistDAO& m_playlistDao;
     AnalysisDao& m_analysisDao;
+    GenreDao& m_genreDao;
     LibraryHashDAO& m_libraryHashDao;
 
     const UserSettingsPointer m_pConfig;

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -100,7 +100,7 @@ LibraryScanner::LibraryScanner(
         const UserSettingsPointer& pConfig)
         : m_pDbConnectionPool(std::move(pDbConnectionPool)),
           m_analysisDao(pConfig),
-          m_trackDao(m_cueDao, m_playlistDao, m_analysisDao, m_libraryHashDao, pConfig),
+          m_trackDao(m_cueDao, m_playlistDao, m_analysisDao, m_genreDao, m_libraryHashDao, pConfig),
           m_stateSema(1), // only one transaction is possible at a time
           m_state(IDLE),
           m_manualScan(true) {

--- a/src/library/scanner/libraryscanner.h
+++ b/src/library/scanner/libraryscanner.h
@@ -11,6 +11,7 @@
 #include "library/dao/analysisdao.h"
 #include "library/dao/cuedao.h"
 #include "library/dao/directorydao.h"
+#include "library/dao/genredao.h"
 #include "library/dao/libraryhashdao.h"
 #include "library/dao/playlistdao.h"
 #include "library/dao/trackdao.h"
@@ -111,6 +112,7 @@ class LibraryScanner : public QThread {
     PlaylistDAO m_playlistDao;
     DirectoryDAO m_directoryDao;
     AnalysisDao m_analysisDao;
+    GenreDao m_genreDao;
     TrackDAO m_trackDao;
 
     // Global scanner state for scan currently in progress.

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -23,7 +23,7 @@ TrackCollection::TrackCollection(
           m_trackDao(m_cueDao,
                   m_playlistDao,
                   m_analysisDao,
-                  m_genreDAO,
+                  m_genreDao,
                   m_libraryHashDao,
                   pConfig) {
     // Forward signals from TrackDAO

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -19,7 +19,7 @@ TrackCollection::TrackCollection(
         QObject* parent, const UserSettingsPointer& pConfig)
         : QObject(parent),
           m_analysisDao(pConfig),
-          m_genreDAO(this),
+          m_genreDao(this),
           m_trackDao(m_cueDao,
                   m_playlistDao,
                   m_analysisDao,

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -16,12 +16,16 @@ mixxx::Logger kLogger("TrackCollection");
 } // anonymous namespace
 
 TrackCollection::TrackCollection(
-        QObject* parent,
-        const UserSettingsPointer& pConfig)
+        QObject* parent, const UserSettingsPointer& pConfig)
         : QObject(parent),
           m_analysisDao(pConfig),
-          m_trackDao(m_cueDao, m_playlistDao,
-                     m_analysisDao, m_libraryHashDao, pConfig) {
+          m_genreDAO(this),
+          m_trackDao(m_cueDao,
+                  m_playlistDao,
+                  m_analysisDao,
+                  m_genreDAO,
+                  m_libraryHashDao,
+                  pConfig) {
     // Forward signals from TrackDAO
     connect(&m_trackDao,
             &TrackDAO::trackDirty,
@@ -76,6 +80,7 @@ void TrackCollection::connectDatabase(const QSqlDatabase& database) {
     m_cueDao.initialize(database);
     m_directoryDao.initialize(database);
     m_analysisDao.initialize(database);
+    m_genreDao.initialize(database);
     m_libraryHashDao.initialize(database);
     m_crates.connectDatabase(database);
 }

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -9,6 +9,7 @@
 #include "library/dao/analysisdao.h"
 #include "library/dao/cuedao.h"
 #include "library/dao/directorydao.h"
+#include "library/dao/genredao.h"
 #include "library/dao/libraryhashdao.h"
 #include "library/dao/playlistdao.h"
 #include "library/dao/trackdao.h"
@@ -22,7 +23,7 @@ class QDir;
 
 // Manages the internal database.
 class TrackCollection : public QObject,
-    public virtual /*implements*/ SqlStorage {
+                        public virtual /*implements*/ SqlStorage {
     Q_OBJECT
 
   public:
@@ -67,6 +68,10 @@ class TrackCollection : public QObject,
     AnalysisDao& getAnalysisDAO() {
         DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
         return m_analysisDao;
+    }
+    GenreDao& getGenreDao() {
+        DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
+        return m_genreDao;
     }
 
     void connectTrackSource(QSharedPointer<BaseTrackCache> pTrackSource);
@@ -171,6 +176,7 @@ class TrackCollection : public QObject,
     CueDAO m_cueDao;
     DirectoryDAO m_directoryDao;
     AnalysisDao m_analysisDao;
+    GenreDao m_genreDAO;
     LibraryHashDAO m_libraryHashDao;
     TrackDAO m_trackDao;
 

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -176,7 +176,7 @@ class TrackCollection : public QObject,
     CueDAO m_cueDao;
     DirectoryDAO m_directoryDao;
     AnalysisDao m_analysisDao;
-    GenreDao m_genreDAO;
+    GenreDao m_genreDao;
     LibraryHashDAO m_libraryHashDao;
     TrackDAO m_trackDao;
 


### PR DESCRIPTION
## Overview

This pull request introduces the core infrastructure for **multi‑genre support** in Mixxx by adding a dedicated `GenreDao` and integrating it into the existing data access layer.

## New Components

`src/library/dao/genredao.cpp` / `src/library/dao/genredao.h`
Adds a new GenreDao class, responsible for managing all genre‑related database operations.

### Implements
- `initialize()` loads all existing genres into memory for quick access.
- `getAllGenres()` / `getAllGenreNames()` retrieves all genres and their names.
- `getGenresForTrack()` fetches all genres associated with a specific track.
- `setGenresForTrack()` updates the genres of a track by removing old associations and inserting the new ones provided.
- `createGenre()` ensures that a genre exists in the database, creating it if necessary.

## Modifications to Existing Classes

`src/library/dao/trackdao.cpp` /  `trackdao.h`
- `TrackDAO` now takes a reference to `GenreDao` in its constructor.
- Adds a private member `GenreDao& m_genreDao`, allowing `TrackDAO` to query and update genre information directly.

`src/library/trackcollection.cpp` / `trackcollection.h`
- Declares a new member `GenreDao m_genreDao` inside `TrackCollection`.
- Passes `m_genreDao` to `TrackDAO` to enable genre management when tracks are loaded or updated.
- Initializes `m_genreDao` when the database connection is established.
- Adds a `getGenreDao()` accessor to expose GenreDao to other components 

`src/library/libraryscanner.cpp` / `libraryscanner.h`
- Declares a new member `GenreDao m_genreDao` inside `TrackCollection`.
- Passes `m_genreDao` to `TrackDAO` so that tracks can query and update their genres.

## Why This Matters
This PR establishes the backend groundwork for multi‑genre tagging in Mixxx. 
By centralizing genre operations within `GenreDao`, the codebase gains:
- A **single source of truth** for genre management, avoiding duplication of logic across the codebase.
- Cleaner and more maintainable database code, isolating genre logic from other DAOs.
- A strong foundation for **future UI enhancements**, such as multi‑genre editing in both single‑track and multi‑track dialogs.
- Easier scalability for future features like **bulk genre editing**, improved search/filtering, or syncing with external metadata services.

## Next Steps
- Integrate the new `GenreDao` into `DlgTrackInfo` to enable multi‑genre editing for individual tracks.
- Extend support to `DlgTrackInfoMulti` to allow consistent multi‑genre editing across multiple selected tracks.

Every steps of this project is tracked in the [GSOC 2025 Antonio Giordano Project Overview](https://github.com/mixxxdj/mixxx/issues/14897)