### PR TITLE
[GSoC 2025 Antonio Giordano] Integrate Multi-Genre editing into DlgTrackInfo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1589,6 +1589,7 @@ add_library(
   src/widget/weffectpushbutton.cpp
   src/widget/weffectselector.cpp
   src/widget/wfindonwebmenu.cpp
+  src/widget/wgenretaginput.cpp
   src/widget/whotcuebutton.cpp
   src/widget/wimagestore.cpp
   src/widget/wkey.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1224,6 +1224,7 @@ add_library(
   src/library/dao/analysisdao.cpp
   src/library/dao/autodjcratesdao.cpp
   src/library/dao/cuedao.cpp
+  src/library/dao/genredao.cpp
   src/library/dao/directorydao.cpp
   src/library/dao/libraryhashdao.cpp
   src/library/dao/playlistdao.cpp

--- a/src/library/dao/genredao.cpp
+++ b/src/library/dao/genredao.cpp
@@ -1,0 +1,145 @@
+#include "library/dao/genredao.h"
+
+#include <QDebug>
+#include <QSqlDatabase>
+#include <QSqlError>
+#include <QSqlQuery>
+#include <QSqlRecord>
+#include <QVariant>
+#include <QtDebug>
+
+#include "library/queryutil.h"
+#include "moc_genredao.cpp"
+#include "util/db/dbconnection.h"
+
+GenreDao::GenreDao(QObject* parent)
+        : QObject(parent) {
+}
+
+void GenreDao::initialize(const QSqlDatabase& database) {
+    DAO::initialize(database);
+    loadGenres2QVL(m_genreData);
+}
+
+void GenreDao::loadGenres2QVL(QVariantList& genreData) {
+    genreData.clear();
+    QSqlQuery query(m_database);
+    query.prepare("SELECT id, name FROM genres ORDER BY name ASC");
+
+    if (query.exec()) {
+        while (query.next()) {
+            QVariantMap entry;
+            entry["id"] = query.value("id").toInt();
+            entry["name"] = query.value("name").toString();
+            genreData.append(entry);
+        }
+        qDebug() << "GenreDao::loadGenres2QVL loaded" << genreData.size() << "genres";
+    } else {
+        qWarning() << "GenreDao::loadGenres2QVL failed:" << query.lastError();
+    }
+}
+
+QString GenreDao::getDisplayGenreNameForGenreID(const QString& rawGenre) const {
+    return rawGenre;
+}
+
+QMap<QString, QString> GenreDao::getAllGenres() {
+    QMap<QString, QString> genreMap;
+    QSqlQuery query(m_database);
+    query.prepare("SELECT id, name FROM genres");
+
+    if (query.exec()) {
+        while (query.next()) {
+            int id = query.value("id").toInt();
+            QString name = query.value("name").toString();
+            genreMap.insert(QString::number(id), name);
+        }
+    } else {
+        qWarning() << "GenreDao::getAllGenres failed:" << query.lastError();
+    }
+
+    return genreMap;
+}
+
+QStringList GenreDao::getAllGenreNames() const {
+    QStringList names;
+    for (const QVariant& entry : m_genreData) {
+        QVariantMap map = entry.toMap();
+        names << map["name"].toString();
+    }
+    return names;
+}
+
+QStringList GenreDao::getGenresForTrack(TrackId trackId) const {
+    QStringList genres;
+    QSqlQuery query(m_database);
+    query.prepare(
+            "SELECT g.name FROM genres g "
+            "JOIN genre_tracks gt ON g.id = gt.genre_id "
+            "WHERE gt.track_id = ? ORDER BY g.name");
+    query.bindValue(0, trackId.toVariant());
+
+    if (query.exec()) {
+        while (query.next()) {
+            genres << query.value(0).toString();
+        }
+    }
+
+    return genres;
+}
+
+bool GenreDao::setGenresForTrack(TrackId trackId, const QStringList& genreNames) {
+    if (!m_database.transaction()) {
+        return false;
+    }
+
+    QSqlQuery deleteQuery(m_database);
+    deleteQuery.prepare("DELETE FROM genre_tracks WHERE track_id = ?");
+    deleteQuery.bindValue(0, trackId.toVariant());
+
+    if (!deleteQuery.exec()) {
+        m_database.rollback();
+        return false;
+    }
+
+    for (const QString& genreName : genreNames) {
+        if (genreName.trimmed().isEmpty()) {
+            continue;
+        }
+
+        int genreId = createGenre(genreName.trimmed());
+        if (genreId > 0) {
+            QSqlQuery insertQuery(m_database);
+            insertQuery.prepare("INSERT INTO genre_tracks (track_id, genre_id) VALUES (?, ?)");
+            insertQuery.bindValue(0, trackId.toVariant());
+            insertQuery.bindValue(1, genreId);
+
+            if (!insertQuery.exec()) {
+                m_database.rollback();
+                return false;
+            }
+        }
+    }
+
+    return m_database.commit();
+}
+
+int GenreDao::createGenre(const QString& genreName) {
+    QSqlQuery checkQuery(m_database);
+    checkQuery.prepare("SELECT id FROM genres WHERE name = ? COLLATE NOCASE");
+    checkQuery.bindValue(0, genreName);
+
+    if (checkQuery.exec() && checkQuery.next()) {
+        return checkQuery.value(0).toInt();
+    }
+
+    QSqlQuery insertQuery(m_database);
+    insertQuery.prepare("INSERT INTO genres (name) VALUES (?)");
+    insertQuery.bindValue(0, genreName);
+
+    if (insertQuery.exec()) {
+        return insertQuery.lastInsertId().toInt();
+    }
+
+    return -1;
+}

--- a/src/library/dao/genredao.h
+++ b/src/library/dao/genredao.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <QMap>
+#include <QRegularExpression>
+#include <QString>
+#include <QVariantList>
+
+#include "library/dao/dao.h"
+#include "preferences/usersettings.h"
+#include "track/trackid.h"
+#include "util/class.h"
+
+class QSqlDatabase;
+
+class GenreDao : public QObject, public virtual DAO {
+    Q_OBJECT
+  public:
+    explicit GenreDao(QObject* parent = nullptr);
+    ~GenreDao() override = default;
+
+    void initialize(const QSqlDatabase& database) override;
+    void loadGenres2QVL(QVariantList& genreData);
+    QString getDisplayGenreNameForGenreID(const QString& rawGenre) const;
+    QMap<QString, QString> getAllGenres();
+
+    QStringList getAllGenreNames() const;
+    QStringList getGenresForTrack(TrackId trackId) const;
+    bool setGenresForTrack(TrackId trackId, const QStringList& genreNames);
+    int createGenre(const QString& genreName);
+
+  private:
+    QVariantList m_genreData;
+
+    DISALLOW_COPY_AND_ASSIGN(GenreDao);
+};

--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -14,6 +14,7 @@
 #include "library/coverartutils.h"
 #include "library/dao/analysisdao.h"
 #include "library/dao/cuedao.h"
+#include "library/dao/genredao.h"
 #include "library/dao/libraryhashdao.h"
 #include "library/dao/playlistdao.h"
 #include "library/dao/trackschema.h"
@@ -89,13 +90,15 @@ QSet<QString> collectTrackLocations(FwdSqlQuery& query) {
 } // anonymous namespace
 
 TrackDAO::TrackDAO(CueDAO& cueDao,
-                   PlaylistDAO& playlistDao,
-                   AnalysisDao& analysisDao,
-                   LibraryHashDAO& libraryHashDao,
-                   UserSettingsPointer pConfig)
+        PlaylistDAO& playlistDao,
+        AnalysisDao& analysisDao,
+        GenreDao& genreDao,
+        LibraryHashDAO& libraryHashDao,
+        UserSettingsPointer pConfig)
         : m_cueDao(cueDao),
           m_playlistDao(playlistDao),
           m_analysisDao(analysisDao),
+          m_genreDao(genreDao),
           m_libraryHashDao(libraryHashDao),
           m_pConfig(pConfig),
           m_trackLocationIdColumn(UndefinedRecordIndex),

--- a/src/library/dao/trackdao.h
+++ b/src/library/dao/trackdao.h
@@ -17,6 +17,7 @@ class PlaylistDAO;
 class AnalysisDao;
 class CueDAO;
 class LibraryHashDAO;
+class GenreDao;
 
 namespace mixxx {
 class FileInfo;
@@ -41,6 +42,7 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
             CueDAO& cueDao,
             PlaylistDAO& playlistDao,
             AnalysisDao& analysisDao,
+            GenreDao& genreDao,
             LibraryHashDAO& libraryHashDao,
             UserSettingsPointer pConfig);
     ~TrackDAO() override;
@@ -202,6 +204,7 @@ class TrackDAO : public QObject, public virtual DAO, public virtual GlobalTrackC
     CueDAO& m_cueDao;
     PlaylistDAO& m_playlistDao;
     AnalysisDao& m_analysisDao;
+    GenreDao& m_genreDao;
     LibraryHashDAO& m_libraryHashDao;
 
     const UserSettingsPointer m_pConfig;

--- a/src/library/dlgtrackinfo.h
+++ b/src/library/dlgtrackinfo.h
@@ -13,6 +13,7 @@
 #include "util/parented_ptr.h"
 #include "util/tapfilter.h"
 #include "widget/wcolorpickeraction.h"
+#include "widget/wgenretaginput.h"
 
 class TrackModel;
 class WColorPickerAction;
@@ -20,6 +21,7 @@ class WStarRating;
 class WCoverArtMenu;
 class WCoverArtLabel;
 class DlgTagFetcher;
+class TrackCollection;
 
 /// A dialog box to display and edit track properties.
 /// Use TrackPointer to load a track into the dialog or
@@ -40,6 +42,7 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     void loadTrack(TrackPointer pTrack);
     void loadTrack(const QModelIndex& index);
     void focusField(const QString& property);
+    void setTrackCollection(TrackCollection* pTrackCollection);
 
   signals:
     void next();
@@ -83,6 +86,7 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
             const QPixmap& pixmap);
     void slotCoverInfoSelected(const CoverInfoRelative& coverInfo);
     void slotReloadCoverArt();
+    void slotGenresChanged();
 
   private:
     void loadNextTrack();
@@ -96,6 +100,8 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
 
     void updateKeyText();
     void displayKeyText();
+
+    void setupGenreWidget();
 
     void updateFromTrack(const Track& track);
 
@@ -133,6 +139,8 @@ class DlgTrackInfo : public QDialog, public Ui::DlgTrackInfo {
     parented_ptr<WCoverArtLabel> m_pWCoverArtLabel;
     parented_ptr<WStarRating> m_pWStarRating;
     parented_ptr<WColorPickerAction> m_pColorPicker;
+    parented_ptr<WGenreTagInput> m_pGenreWidget;
+    TrackCollection* m_pTrackCollection;
 
     std::unique_ptr<DlgTagFetcher> m_pDlgTagFetcher;
 };

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -100,7 +100,7 @@ LibraryScanner::LibraryScanner(
         const UserSettingsPointer& pConfig)
         : m_pDbConnectionPool(std::move(pDbConnectionPool)),
           m_analysisDao(pConfig),
-          m_trackDao(m_cueDao, m_playlistDao, m_analysisDao, m_libraryHashDao, pConfig),
+          m_trackDao(m_cueDao, m_playlistDao, m_analysisDao, m_genreDao, m_libraryHashDao, pConfig),
           m_stateSema(1), // only one transaction is possible at a time
           m_state(IDLE),
           m_manualScan(true) {

--- a/src/library/scanner/libraryscanner.h
+++ b/src/library/scanner/libraryscanner.h
@@ -11,6 +11,7 @@
 #include "library/dao/analysisdao.h"
 #include "library/dao/cuedao.h"
 #include "library/dao/directorydao.h"
+#include "library/dao/genredao.h"
 #include "library/dao/libraryhashdao.h"
 #include "library/dao/playlistdao.h"
 #include "library/dao/trackdao.h"
@@ -111,6 +112,7 @@ class LibraryScanner : public QThread {
     PlaylistDAO m_playlistDao;
     DirectoryDAO m_directoryDao;
     AnalysisDao m_analysisDao;
+    GenreDao m_genreDao;
     TrackDAO m_trackDao;
 
     // Global scanner state for scan currently in progress.

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -23,7 +23,7 @@ TrackCollection::TrackCollection(
           m_trackDao(m_cueDao,
                   m_playlistDao,
                   m_analysisDao,
-                  m_genreDAO,
+                  m_genreDao,
                   m_libraryHashDao,
                   pConfig) {
     // Forward signals from TrackDAO

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -19,7 +19,7 @@ TrackCollection::TrackCollection(
         QObject* parent, const UserSettingsPointer& pConfig)
         : QObject(parent),
           m_analysisDao(pConfig),
-          m_genreDAO(this),
+          m_genreDao(this),
           m_trackDao(m_cueDao,
                   m_playlistDao,
                   m_analysisDao,

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -16,12 +16,16 @@ mixxx::Logger kLogger("TrackCollection");
 } // anonymous namespace
 
 TrackCollection::TrackCollection(
-        QObject* parent,
-        const UserSettingsPointer& pConfig)
+        QObject* parent, const UserSettingsPointer& pConfig)
         : QObject(parent),
           m_analysisDao(pConfig),
-          m_trackDao(m_cueDao, m_playlistDao,
-                     m_analysisDao, m_libraryHashDao, pConfig) {
+          m_genreDAO(this),
+          m_trackDao(m_cueDao,
+                  m_playlistDao,
+                  m_analysisDao,
+                  m_genreDAO,
+                  m_libraryHashDao,
+                  pConfig) {
     // Forward signals from TrackDAO
     connect(&m_trackDao,
             &TrackDAO::trackDirty,
@@ -76,6 +80,7 @@ void TrackCollection::connectDatabase(const QSqlDatabase& database) {
     m_cueDao.initialize(database);
     m_directoryDao.initialize(database);
     m_analysisDao.initialize(database);
+    m_genreDao.initialize(database);
     m_libraryHashDao.initialize(database);
     m_crates.connectDatabase(database);
 }

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -9,6 +9,7 @@
 #include "library/dao/analysisdao.h"
 #include "library/dao/cuedao.h"
 #include "library/dao/directorydao.h"
+#include "library/dao/genredao.h"
 #include "library/dao/libraryhashdao.h"
 #include "library/dao/playlistdao.h"
 #include "library/dao/trackdao.h"
@@ -22,7 +23,7 @@ class QDir;
 
 // Manages the internal database.
 class TrackCollection : public QObject,
-    public virtual /*implements*/ SqlStorage {
+                        public virtual /*implements*/ SqlStorage {
     Q_OBJECT
 
   public:
@@ -67,6 +68,10 @@ class TrackCollection : public QObject,
     AnalysisDao& getAnalysisDAO() {
         DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
         return m_analysisDao;
+    }
+    GenreDao& getGenreDao() {
+        DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);
+        return m_genreDao;
     }
 
     void connectTrackSource(QSharedPointer<BaseTrackCache> pTrackSource);
@@ -171,6 +176,7 @@ class TrackCollection : public QObject,
     CueDAO m_cueDao;
     DirectoryDAO m_directoryDao;
     AnalysisDao m_analysisDao;
+    GenreDao m_genreDAO;
     LibraryHashDAO m_libraryHashDao;
     TrackDAO m_trackDao;
 

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -176,7 +176,7 @@ class TrackCollection : public QObject,
     CueDAO m_cueDao;
     DirectoryDAO m_directoryDao;
     AnalysisDao m_analysisDao;
-    GenreDao m_genreDAO;
+    GenreDao m_genreDao;
     LibraryHashDAO m_libraryHashDao;
     TrackDAO m_trackDao;
 

--- a/src/widget/wgenretaginput.cpp
+++ b/src/widget/wgenretaginput.cpp
@@ -1,0 +1,639 @@
+#include "widget/wgenretaginput.h"
+
+#include <QApplication>
+#include <QDrag>
+#include <QDragEnterEvent>
+#include <QDropEvent>
+#include <QHBoxLayout>
+#include <QKeyEvent>
+#include <QLabel>
+#include <QLineEdit>
+#include <QMimeData>
+#include <QMouseEvent>
+#include <QPainter>
+#include <QPushButton>
+#include <QRegularExpression>
+#include <QScrollArea>
+#include <QStyle>
+#include <QStyleOption>
+#include <QVBoxLayout>
+
+#include "library/trackcollection.h"
+#include "moc_wgenretaginput.cpp"
+#include "track/track.h"
+#include "util/assert.h"
+
+namespace {
+const int kTagSpacing = 4;
+} // anonymous namespace
+
+WGenreTagInput::WGenreTagInput(QWidget* parent)
+        : QWidget(parent),
+          m_pTrackCollection(nullptr),
+          m_readOnly(false),
+          m_editMode(false),
+          m_pMainLayout(nullptr),
+          m_pScrollArea(nullptr),
+          m_pTagContainer(nullptr),
+          m_pTagLayout(nullptr),
+          m_pLineEdit(nullptr),
+          m_pAddButton(nullptr),
+          m_pDisplayLabel(nullptr),
+          m_pCompleter(nullptr),
+          m_pCompleterModel(nullptr),
+          m_isDragging(false) {
+    setupUI();
+    setFocusPolicy(Qt::ClickFocus);
+    setAttribute(Qt::WA_Hover, true);
+    setAcceptDrops(true);
+}
+
+void WGenreTagInput::setupUI() {
+    m_pMainLayout = new QHBoxLayout(this);
+    m_pMainLayout->setContentsMargins(2, 2, 2, 2);
+    m_pMainLayout->setSpacing(0);
+
+    // Display label for non-edit mode
+    m_pDisplayLabel = new QLabel(this);
+    m_pDisplayLabel->setWordWrap(false);
+    m_pDisplayLabel->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+    m_pDisplayLabel->setStyleSheet("QLabel { padding: 2px; background: transparent; }");
+    m_pDisplayLabel->setVisible(false);
+    m_pMainLayout->addWidget(m_pDisplayLabel);
+
+    // Scroll area for tags in edit mode
+    m_pScrollArea = new QScrollArea(this);
+    m_pScrollArea->setWidgetResizable(true);
+    m_pScrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    m_pScrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    m_pScrollArea->setFixedHeight(26);
+    m_pScrollArea->setVisible(true);
+    m_pScrollArea->setStyleSheet(
+            "QScrollArea { border: 1px solid #555; border-radius: 3px; "
+            "background-color: #2a2a2a; }"
+            "QScrollBar:horizontal { background-color: #3a3a3a; height: 8px; "
+            "border-radius: 4px; }"
+            "QScrollBar::handle:horizontal { background-color: #666; "
+            "border-radius: 4px; min-width: 20px; }"
+            "QScrollBar::handle:horizontal:hover { background-color: #888; }"
+            "QScrollBar::add-line:horizontal, QScrollBar::sub-line:horizontal "
+            "{ width: 0px; }");
+
+    // Container for genre tags
+    m_pTagContainer = new QWidget();
+    m_pTagLayout = new QHBoxLayout(m_pTagContainer);
+    m_pTagLayout->setContentsMargins(2, 2, 2, 2);
+    m_pTagLayout->setSpacing(kTagSpacing);
+    m_pTagLayout->addStretch();
+
+    m_pScrollArea->setWidget(m_pTagContainer);
+    m_pMainLayout->addWidget(m_pScrollArea);
+
+    // Line edit for adding new genres
+    m_pLineEdit = new QLineEdit(this);
+    m_pLineEdit->setPlaceholderText(tr("Add genre..."));
+    m_pLineEdit->setVisible(true);
+    m_pLineEdit->setFixedHeight(26);
+    m_pLineEdit->setMinimumWidth(80);
+    m_pLineEdit->setMaximumWidth(150);
+    m_pLineEdit->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    connect(m_pLineEdit, &QLineEdit::returnPressed, this, &WGenreTagInput::slotAddGenre);
+    connect(m_pLineEdit, &QLineEdit::editingFinished, this, &WGenreTagInput::slotLineEditFinished);
+    m_pMainLayout->addWidget(m_pLineEdit);
+
+    // Add button
+    m_pAddButton = new QPushButton("+", this);
+    m_pAddButton->setMaximumSize(24, 24);
+    m_pAddButton->setVisible(true);
+    connect(m_pAddButton, &QPushButton::clicked, this, &WGenreTagInput::slotAddGenre);
+    m_pMainLayout->addWidget(m_pAddButton);
+
+    m_editMode = true;
+    updateGenreTags();
+}
+
+void WGenreTagInput::setTrack(TrackPointer pTrack) {
+    if (m_pTrack) {
+        disconnect(m_pTrack.get(), nullptr, this, nullptr);
+    }
+
+    m_pTrack = pTrack;
+
+    if (!m_pTrack) {
+        clear();
+        return;
+    }
+
+    loadGenresFromTrack();
+}
+
+void WGenreTagInput::setTrackCollection(TrackCollection* pTrackCollection) {
+    qDebug() << "=== setTrackCollection() DEBUG ===";
+    qDebug() << "pTrackCollection:" << (pTrackCollection ? "OK" : "NULL");
+
+    m_pTrackCollection = pTrackCollection;
+
+    if (m_pTrackCollection) {
+        setupGenreCompleter();
+        qDebug() << "TrackCollection set successfully!";
+    }
+}
+
+void WGenreTagInput::setupGenreCompleter() {
+    if (!m_pTrackCollection)
+        return;
+
+    QStringList genreNames = m_pTrackCollection->getGenreDao().getAllGenreNames();
+
+    if (m_pCompleter) {
+        m_pCompleter->deleteLater();
+    }
+
+    m_pCompleter = new QCompleter(genreNames, this);
+    m_pCompleter->setCaseSensitivity(Qt::CaseInsensitive);
+    m_pCompleter->setFilterMode(Qt::MatchContains);
+    m_pCompleter->setCompletionMode(QCompleter::PopupCompletion);
+    m_pCompleter->setMaxVisibleItems(8);
+
+    if (m_pLineEdit) {
+        m_pLineEdit->setCompleter(m_pCompleter);
+    }
+
+    connect(m_pCompleter,
+            QOverload<const QString&>::of(&QCompleter::activated),
+            this,
+            &WGenreTagInput::slotCompleterActivated);
+
+    qDebug() << "WGenreTagInput::setupGenreCompleter completed with"
+             << genreNames.size() << "genres";
+}
+
+void WGenreTagInput::loadGenresFromTrack() {
+    if (!m_pTrack || !m_pTrackCollection) {
+        qDebug() << "WGenreTagInput::loadGenresFromTrack - missing track or collection";
+        return;
+    }
+
+    QStringList genres = m_pTrackCollection->getGenreDao().getGenresForTrack(m_pTrack->getId());
+    qDebug() << "WGenreTagInput::loadGenresFromTrack - loaded genres:" << genres;
+
+    setGenres(genres);
+}
+
+void WGenreTagInput::saveGenresToTrack() {
+    qDebug() << "=== saveGenresToTrack() DEBUG ===";
+    qDebug() << "m_pTrack:" << (m_pTrack ? "OK" : "NULL");
+    qDebug() << "m_pTrackCollection:" << (m_pTrackCollection ? "OK" : "NULL");
+
+    if (!m_pTrack || !m_pTrackCollection) {
+        qDebug() << "WGenreTagInput::saveGenresToTrack - missing track or collection";
+        return;
+    }
+
+    qDebug() << "WGenreTagInput::saveGenresToTrack - saving genres:" << m_genres;
+
+    // Save genres to the track in the collection
+    // This will update the track's genre information in the database.
+    // Ensure that the track ID is valid and the collection is set.
+    bool success = m_pTrackCollection->getGenreDao().setGenresForTrack(m_pTrack->getId(), m_genres);
+
+    if (success) {
+        emit genresChanged();
+        qDebug() << "WGenreTagInput::saveGenresToTrack - genres saved successfully";
+    } else {
+        qWarning() << "WGenreTagInput::saveGenresToTrack - failed to save genres";
+    }
+}
+
+QStringList WGenreTagInput::getGenres() const {
+    return m_genres;
+}
+
+void WGenreTagInput::setGenres(const QStringList& genres) {
+    qDebug() << "=== setGenres() Start with:" << genres;
+
+    if (!m_pDisplayLabel) {
+        qDebug() << "ERROR: m_pDisplayLabel is null!";
+        return;
+    }
+
+    qDebug() << "Assegning m_genres...";
+    m_genres = genres;
+
+    qDebug() << "Updating display label...";
+    if (genres.isEmpty()) {
+        m_pDisplayLabel->setText("No genres");
+    } else {
+        m_pDisplayLabel->setText(genres.join(", "));
+    }
+
+    qDebug() << "Calling updateGenreTags()...";
+    updateGenreTags();
+
+    qDebug() << "Emitting signal genresChanged()...";
+    emit genresChanged();
+
+    qDebug() << "=== setGenres() End ===";
+}
+
+void WGenreTagInput::setReadOnly(bool readOnly) {
+    m_readOnly = readOnly;
+
+    if (m_readOnly && m_editMode) {
+        exitEditMode();
+    }
+
+    if (m_pLineEdit) {
+        m_pLineEdit->setReadOnly(m_readOnly);
+    }
+
+    if (m_pAddButton) {
+        m_pAddButton->setVisible(!m_readOnly);
+    }
+
+    update();
+}
+
+bool WGenreTagInput::isReadOnly() const {
+    return m_readOnly;
+}
+
+void WGenreTagInput::setCompleterModel(QStringListModel* model) {
+    m_pCompleterModel = model;
+    if (m_pCompleterModel && m_pLineEdit) {
+        if (!m_pCompleter) {
+            m_pCompleter = new QCompleter(this);
+            m_pCompleter->setCaseSensitivity(Qt::CaseInsensitive);
+            m_pCompleter->setFilterMode(Qt::MatchStartsWith);
+            m_pCompleter->setCompletionMode(QCompleter::PopupCompletion);
+            m_pCompleter->setMaxVisibleItems(8);
+            connect(m_pCompleter,
+                    QOverload<const QString&>::of(&QCompleter::activated),
+                    this,
+                    &WGenreTagInput::slotCompleterActivated);
+        }
+        m_pCompleter->setModel(m_pCompleterModel);
+        m_pLineEdit->setCompleter(m_pCompleter);
+    }
+}
+
+void WGenreTagInput::addGenre(const QString& genre) {
+    qDebug() << "=== addGenre() Start with:" << genre;
+
+    const QString trimmed = genre.trimmed();
+    if (trimmed.isEmpty() || m_genres.contains(trimmed, Qt::CaseInsensitive)) {
+        qDebug() << "Genere empty or duplicated, exit..";
+        return;
+    }
+
+    qDebug() << "Creating genres list";
+    QStringList newGenres = m_genres;
+    newGenres.append(trimmed);
+
+    qDebug() << "New List:" << newGenres;
+    setGenres(newGenres);
+
+    qDebug() << "=== addGenre() End ===";
+}
+
+void WGenreTagInput::removeGenre(const QString& genre) {
+    qDebug() << "WGenreTagInput::removeGenre called with:" << genre;
+
+    QStringList newGenres = m_genres;
+    if (newGenres.removeOne(genre)) {
+        qDebug() << "Genre removed successfully. New list:" << newGenres;
+        setGenres(newGenres);
+
+        saveGenresToTrack();
+    } else {
+        qDebug() << "Warning: Genre not found in list:" << genre;
+    }
+}
+
+void WGenreTagInput::clear() {
+    setGenres(QStringList());
+}
+
+void WGenreTagInput::paintEvent(QPaintEvent* event) {
+    QStyleOption opt;
+    opt.initFrom(this);
+    QPainter painter(this);
+    style()->drawPrimitive(QStyle::PE_Widget, &opt, &painter, this);
+    QWidget::paintEvent(event);
+}
+
+void WGenreTagInput::mouseDoubleClickEvent(QMouseEvent* event) {
+    QWidget::mouseDoubleClickEvent(event);
+}
+
+void WGenreTagInput::keyPressEvent(QKeyEvent* event) {
+    QWidget::keyPressEvent(event);
+}
+
+void WGenreTagInput::focusInEvent(QFocusEvent* event) {
+    QWidget::focusInEvent(event);
+    update();
+}
+
+void WGenreTagInput::focusOutEvent(QFocusEvent* event) {
+    QWidget::focusOutEvent(event);
+    update();
+}
+
+void WGenreTagInput::mousePressEvent(QMouseEvent* event) {
+    if (event->button() == Qt::LeftButton) {
+        m_dragStartPosition = event->pos();
+        QWidget* clickedWidget = childAt(event->pos());
+        while (clickedWidget && clickedWidget != this) {
+            QString genre = clickedWidget->property("genre").toString();
+            if (!genre.isEmpty()) {
+                m_draggedGenre = genre;
+                break;
+            }
+            clickedWidget = clickedWidget->parentWidget();
+        }
+    }
+    QWidget::mousePressEvent(event);
+}
+
+void WGenreTagInput::mouseMoveEvent(QMouseEvent* event) {
+    if (!(event->buttons() & Qt::LeftButton) || m_draggedGenre.isEmpty() ||
+            (event->pos() - m_dragStartPosition).manhattanLength() <
+                    QApplication::startDragDistance()) {
+        QWidget::mouseMoveEvent(event);
+        return;
+    }
+
+    QDrag* drag = new QDrag(this);
+    QMimeData* mimeData = new QMimeData;
+    mimeData->setText("mixxx-genre:" + m_draggedGenre);
+    drag->setMimeData(mimeData);
+
+    QLabel tempLabel(m_draggedGenre);
+    tempLabel.setStyleSheet(
+            "QLabel { background-color: #3a3a3a; color: #ddd; padding: 4px; "
+            "border-radius: 3px; }");
+    tempLabel.adjustSize();
+    QPixmap pixmap = tempLabel.grab();
+    drag->setPixmap(pixmap);
+
+    m_isDragging = true;
+    drag->exec(Qt::MoveAction);
+    m_isDragging = false;
+    m_draggedGenre.clear();
+}
+
+void WGenreTagInput::dragEnterEvent(QDragEnterEvent* event) {
+    if (event->mimeData()->hasText() && event->mimeData()->text().startsWith("mixxx-genre:")) {
+        event->acceptProposedAction();
+    }
+}
+
+void WGenreTagInput::dragMoveEvent(QDragMoveEvent* event) {
+    if (event->mimeData()->hasText() && event->mimeData()->text().startsWith("mixxx-genre:")) {
+        event->acceptProposedAction();
+    }
+}
+
+void WGenreTagInput::dropEvent(QDropEvent* event) {
+    QString mimeText = event->mimeData()->text();
+    if (!mimeText.startsWith("mixxx-genre:")) {
+        return;
+    }
+
+    QString droppedGenre = mimeText.mid(12);
+    QPoint dropPos = event->position().toPoint();
+    int targetIndex = 0;
+
+    if (m_pScrollArea && m_pScrollArea->geometry().contains(dropPos)) {
+        QPoint containerPos = m_pTagContainer->mapFromParent(m_pScrollArea->mapFromParent(dropPos));
+        for (int i = 0; i < m_pTagLayout->count() - 1; ++i) {
+            if (QLayoutItem* item = m_pTagLayout->itemAt(i)) {
+                if (item->widget()) {
+                    if (containerPos.x() < item->widget()->geometry().center().x()) {
+                        targetIndex = i;
+                        break;
+                    }
+                    targetIndex = i + 1;
+                }
+            }
+        }
+    }
+
+    QStringList newGenres = m_genres;
+    int currentIndex = newGenres.indexOf(droppedGenre);
+    if (currentIndex != -1 && currentIndex != targetIndex) {
+        newGenres.removeAt(currentIndex);
+        if (targetIndex > currentIndex) {
+            targetIndex--;
+        }
+        if (targetIndex >= newGenres.size()) {
+            newGenres.append(droppedGenre);
+        } else {
+            newGenres.insert(targetIndex, droppedGenre);
+        }
+        setGenres(newGenres);
+
+        saveGenresToTrack();
+
+        emit genresChanged();
+    }
+    event->acceptProposedAction();
+}
+
+void WGenreTagInput::enterEditMode() {
+    if (m_editMode || m_readOnly) {
+        return;
+    }
+
+    m_editMode = true;
+    m_pDisplayLabel->setVisible(false);
+    m_pScrollArea->setVisible(true);
+    m_pLineEdit->setVisible(true);
+    m_pAddButton->setVisible(true);
+    updateGenreTags();
+    m_pLineEdit->setFocus();
+}
+
+void WGenreTagInput::exitEditMode() {
+    if (!m_editMode) {
+        return;
+    }
+
+    m_editMode = false;
+    m_pScrollArea->setVisible(false);
+    m_pLineEdit->setVisible(false);
+    m_pAddButton->setVisible(false);
+    m_pDisplayLabel->setVisible(true);
+    updateGenreTags();
+    emit editingFinished();
+}
+
+void WGenreTagInput::updateGenreTags() {
+    qDebug() << "=== updateGenreTags() Start ===";
+
+    if (!m_pTagLayout) {
+        qDebug() << "ERRORE: m_pTagLayout is null!";
+        return;
+    }
+
+    if (m_editMode) {
+        qDebug() << "Edit Mode: cleaning existing layout";
+
+        // Clean existing tags
+        while (QLayoutItem* item = m_pTagLayout->takeAt(0)) {
+            qDebug() << "Removing Item form layout...";
+            if (item->widget()) {
+                qDebug() << "Deleting widget...";
+                item->widget()->deleteLater();
+            }
+            delete item;
+        }
+
+        m_pTagLayout->addStretch();
+
+        qDebug() << "Adding new tag for" << m_genres.size() << "genres...";
+
+        // Add new tags for each genre
+        for (const QString& genre : m_genres) {
+            qDebug() << "Creating genre tag:" << genre;
+            QWidget* tagWidget = createGenreTag(genre);
+            if (tagWidget) {
+                qDebug() << "Tag created, adding to layout";
+                m_pTagLayout->insertWidget(m_pTagLayout->count() - 1, tagWidget);
+                qDebug() << "Tag added to layout";
+            } else {
+                qDebug() << "ERROR: createGenreTag returns nullptr!";
+            }
+        }
+    } else {
+        qDebug() << "display mode: updating label...";
+        if (m_pDisplayLabel) {
+            m_pDisplayLabel->setText(formatGenresForDisplay());
+        }
+    }
+
+    qDebug() << "=== updateGenreTags() End ===";
+}
+
+QString WGenreTagInput::formatGenresForDisplay() const {
+    if (m_genres.isEmpty()) {
+        return tr("No genres");
+    }
+    return m_genres.join(", ");
+}
+
+QWidget* WGenreTagInput::createGenreTag(const QString& genre) {
+    qDebug() << "=== createGenreTag() Start for:" << genre;
+
+    QWidget* tagWidget = new QWidget();
+    if (!tagWidget) {
+        qDebug() << "ERROR: Impossible to create tagWidget";
+        return nullptr;
+    }
+
+    tagWidget->setStyleSheet(
+            "QWidget { background-color: #3a3a3a; border: 1px solid #555; "
+            "border-radius: 3px; padding: 2px 6px; }"
+            "QWidget:hover { background-color: #4a4a4a; }");
+    tagWidget->setFixedHeight(22);
+    tagWidget->setProperty("genre", genre);
+
+    QHBoxLayout* layout = new QHBoxLayout(tagWidget);
+    if (!layout) {
+        qDebug() << "ERROR: Impossible to create layout!";
+        tagWidget->deleteLater();
+        return nullptr;
+    }
+
+    layout->setContentsMargins(4, 2, 4, 2);
+    layout->setSpacing(4);
+
+    QLabel* label = new QLabel(genre, tagWidget);
+    if (!label) {
+        qDebug() << "ERROR: Impossible to create label!";
+        tagWidget->deleteLater();
+        return nullptr;
+    }
+
+    label->setStyleSheet("QLabel { background: transparent; border: none; color: #ddd; }");
+    layout->addWidget(label);
+
+    QPushButton* removeButton = new QPushButton("×", tagWidget);
+    if (!removeButton) {
+        qDebug() << "ERROR: Impossible to create removeButton!";
+        tagWidget->deleteLater();
+        return nullptr;
+    }
+
+    removeButton->setMaximumSize(16, 16);
+    removeButton->setStyleSheet(
+            "QPushButton { background: transparent; border: none; color: #ccc; font-weight: bold; }"
+            "QPushButton:hover { color: #fff; background-color: #666; border-radius: 8px; }");
+
+    connect(removeButton, &QPushButton::clicked, this, [this, genre]() {
+        qDebug() << "Removing genre:" << genre;
+        removeGenre(genre);
+    });
+
+    layout->addWidget(removeButton);
+
+    qDebug() << "=== createGenreTag() End - tag created successfully ===";
+    return tagWidget;
+}
+
+void WGenreTagInput::slotTrackGenresChanged(const QStringList& genres) {
+    setGenres(genres);
+}
+
+void WGenreTagInput::slotAddGenre() {
+    qDebug() << "=== slotAddGenre() Starting ===";
+
+    if (!m_pLineEdit) {
+        qDebug() << "CRITICAL ERROR: m_pLineEdit is null!";
+        return;
+    }
+
+    QString text = m_pLineEdit->text().trimmed();
+    qDebug() << "Text form LineEdit:" << text;
+
+    if (!text.isEmpty()) {
+        qDebug() << "Calling addGenre()...";
+        addGenre(text);
+        qDebug() << "addGenre() completed, cleaning LineEdit...";
+        m_pLineEdit->clear();
+        qDebug() << "LineEdit cleared";
+
+        saveGenresToTrack();
+    }
+
+    qDebug() << "=== slotAddGenre() End ===";
+}
+
+void WGenreTagInput::slotRemoveGenre() {
+    QPushButton* button = qobject_cast<QPushButton*>(sender());
+    if (button) {
+        if (QWidget* tagWidget = button->parentWidget()) {
+            if (QLabel* label = tagWidget->findChild<QLabel*>()) {
+                removeGenre(label->text());
+            }
+        }
+    }
+}
+
+void WGenreTagInput::slotLineEditFinished() {
+    QString text = m_pLineEdit->text().trimmed();
+    if (!text.isEmpty()) {
+        addGenre(text);
+        m_pLineEdit->clear();
+
+        saveGenresToTrack();
+    }
+}
+
+void WGenreTagInput::slotCompleterActivated(const QString& text) {
+    addGenre(text);
+    m_pLineEdit->clear();
+
+    saveGenresToTrack();
+}

--- a/src/widget/wgenretaginput.cpp
+++ b/src/widget/wgenretaginput.cpp
@@ -495,7 +495,7 @@ void WGenreTagInput::updateGenreTags() {
         qDebug() << "Adding new tag for" << m_genres.size() << "genres...";
 
         // Add new tags for each genre
-        for (const QString& genre : m_genres) {
+        for (const QString& genre : std::as_const(m_genres)) {
             qDebug() << "Creating genre tag:" << genre;
             QWidget* tagWidget = createGenreTag(genre);
             if (tagWidget) {

--- a/src/widget/wgenretaginput.h
+++ b/src/widget/wgenretaginput.h
@@ -1,0 +1,116 @@
+#pragma once
+
+#include <QCompleter>
+#include <QDragEnterEvent>
+#include <QDropEvent>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QMouseEvent>
+#include <QPushButton>
+#include <QRegularExpression>
+#include <QScrollArea>
+#include <QStringList>
+#include <QStringListModel>
+#include <QWidget>
+
+#include "control/controlproxy.h"
+#include "track/track_decl.h"
+#include "util/parented_ptr.h"
+
+// Forward declarations
+class TrackCollection;
+class GenreDao;
+
+class WGenreTagInput : public QWidget {
+    Q_OBJECT
+
+  public:
+    explicit WGenreTagInput(QWidget* parent = nullptr);
+    ~WGenreTagInput() override = default;
+
+    void setTrack(TrackPointer pTrack);
+    QStringList getGenres() const;
+    void setGenres(const QStringList& genres);
+
+    // Enable/disable editing
+    void setReadOnly(bool readOnly);
+    bool isReadOnly() const;
+
+    // Autocomplete support
+    void setCompleterModel(QStringListModel* model);
+
+    // Database integration
+    void setTrackCollection(TrackCollection* pTrackCollection);
+    void loadGenresFromTrack();
+    void saveGenresToTrack();
+
+  public slots:
+    void addGenre(const QString& genre);
+    void removeGenre(const QString& genre);
+    void clear();
+
+  signals:
+    void genresChanged();
+    void editingFinished();
+
+  protected:
+    void paintEvent(QPaintEvent* event) override;
+    void mouseDoubleClickEvent(QMouseEvent* event) override;
+    void keyPressEvent(QKeyEvent* event) override;
+    void focusInEvent(QFocusEvent* event) override;
+    void focusOutEvent(QFocusEvent* event) override;
+
+    // Drag & Drop events
+    void mousePressEvent(QMouseEvent* event) override;
+    void mouseMoveEvent(QMouseEvent* event) override;
+    void dragEnterEvent(QDragEnterEvent* event) override;
+    void dragMoveEvent(QDragMoveEvent* event) override;
+    void dropEvent(QDropEvent* event) override;
+
+  private slots:
+    void slotTrackGenresChanged(const QStringList& genres);
+    void slotAddGenre();
+    void slotRemoveGenre();
+    void slotLineEditFinished();
+    void slotCompleterActivated(const QString& text);
+
+  private:
+    void setupUI();
+    void setupGenreCompleter();
+    void updateGenreTags();
+    void enterEditMode();
+    void exitEditMode();
+    QString formatGenresForDisplay() const;
+
+    QWidget* createGenreTag(const QString& genre);
+
+    TrackPointer m_pTrack;
+    QStringList m_genres;
+
+    // Database integration
+    TrackCollection* m_pTrackCollection;
+
+    bool m_readOnly;
+    bool m_editMode;
+
+    // UI components
+    QHBoxLayout* m_pMainLayout;
+    QScrollArea* m_pScrollArea;
+    QWidget* m_pTagContainer;
+    QHBoxLayout* m_pTagLayout;
+    QLineEdit* m_pLineEdit;
+    QPushButton* m_pAddButton;
+    QLabel* m_pDisplayLabel;
+
+    // Autocomplete
+    QCompleter* m_pCompleter;
+    QStringListModel* m_pCompleterModel;
+
+    // Drag & Drop state
+    QPoint m_dragStartPosition;
+    QString m_draggedGenre;
+    bool m_isDragging;
+
+    Q_DISABLE_COPY(WGenreTagInput)
+};

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -45,7 +45,8 @@
 #include "widget/wcolorpickeraction.h"
 #include "widget/wcoverartlabel.h"
 #include "widget/wcoverartmenu.h"
-#include "widget/wfindonwebmenu.h"
+#include "widget/wfindonwebmenu.h
+#include "widget/wgenretaginput.h"
 #include "widget/wmenucheckbox.h"
 #include "widget/wsearchrelatedtracksmenu.h"
 // WStarRating is required for DlgTrackInfo
@@ -2735,6 +2736,11 @@ void WTrackMenu::slotShowDlgTrackInfo() {
         m_pDlgTrackInfo = std::make_unique<DlgTrackInfo>(
                 m_pConfig,
                 m_pTrackModel);
+        if (m_pLibrary && m_pLibrary->trackCollectionManager()) {
+            TrackCollection* pTrackCollection =
+                    m_pLibrary->trackCollectionManager()->internalCollection();
+            m_pDlgTrackInfo->setTrackCollection(pTrackCollection);
+        }
         connect(m_pDlgTrackInfo.get(),
                 &QDialog::finished,
                 this,

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -45,7 +45,7 @@
 #include "widget/wcolorpickeraction.h"
 #include "widget/wcoverartlabel.h"
 #include "widget/wcoverartmenu.h"
-#include "widget/wfindonwebmenu.h
+#include "widget/wfindonwebmenu.h"
 #include "widget/wgenretaginput.h"
 #include "widget/wmenucheckbox.h"
 #include "widget/wsearchrelatedtracksmenu.h"


### PR DESCRIPTION
## Overview

This PR introduced **multi‑genre editing** to the single track editor dialog (`DlgTrackInfo`).

Previously, Mixxx supported only a single genre per track using a simple text field (`txtGenre`). 
With this PR, that limitation is removed: users can now manage **multiple genres** per track using a new tag‑based widget, while all changes are seamlessly persisted via the [new DAO](https://github.com/mixxxdj/mixxx/pull/15145).

## New Components

`src/widget/wgenretaginput.cpp` / `src/widget/wgenretaginput.h`
- Introduces `WGenreTagInput`, a brand‑new Qt widget purpose‑built for multi‑genre editing.

### KeyFeature:
- Displays each genre as a **tag** (pill‑style label) that can be individually removed.
- Provides a **line edit with autocompletion** to quickly add new genres from the existing database list.
- Supports **drag‑and‑drop** to reorder genres visually.
- Handles keyboard events for quick tag addition/removal.
- Emits a `genresChanged` signal whenever the genre list is modified, ensuring UI and backend remain in sync.

### Technical Details:
- Uses a scrollable area (`QScrollArea`) to gracefully handle tracks with many genres.
- Internally manages a list of `QLabel` + `QToolButton` combinations for tag rendering and deletion.

_Provides public methods:_
- `setGenres(const QStringList&)`
- `getGenres() const`
- `addGenre(const QString&)`
- `removeGenre(const QString&)`
- `clear()`

## Modifications to Existing Classes

`src/library/dlgtrackinfo.cpp` / `src/library/dlgtrackinfo.h`

### Widget Integration
- Replaces the legacy single‑line `txtGenre` field with the new `WGenreTagInput` widget.
- Adds `setupGenreWidget()` to construct and configure `WGenreTagInput` dynamically within the dialog layout.

### Data Synchronization

1. Updates `updateTrackMetadataFields()`:
- Hides the old `txtGenre` field (still present for compatibility).
- Populates the `WGenreTagInput` with all genres for the current track using `GenreDao`.
2. Implements `slotGenresChanged()`:
- Listens for tag changes and updates the `TrackRecord` with the concatenated list of genres.

### Database Connection
- Adds `setTrackCollection(TrackCollection*)`, linking the widget to `GenreDao` through `TrackCollection`.
- Ensures that when a track is loaded or saved, all associated genres are correctly retrieved and persisted.

`src/widget/wtrackmenu.cpp`
- Passes the `TrackCollection` to `DlgTrackInfo` when the track info dialog is opened, enabling the new widget to query and update genres.

## Why This Matters

This PR delivers the first visible UI impact of Mixxx’s multi‑genre architecture. Specifically:

1. **Removes the single‑genre limitation**: Tracks can now have multiple genres assigned, better matching real‑world music organization.
2. **Improves user experience**:
- Tag‑based interface feels modern and intuitive.
- Autocompletion helps maintain consistency and avoid duplicate genre entries.
- Drag‑and‑drop provides flexibility for personal genre ordering.

## Next Step
- Extend the same multi‑genre functionality to `DlgTrackInfoMulti`, enabling users to assign and edit multiple genres across multiple selected tracks at once.

Every steps of this project is tracked in the [GSOC 2025 Antonio Giordano Project Overview](https://github.com/mixxxdj/mixxx/issues/14897)