### PR TITLE
Tracks: confirm dialog for Auto DJ queue replace action

### DIFF
--- a/src/library/dao/playlistdao.cpp
+++ b/src/library/dao/playlistdao.cpp
@@ -170,6 +170,11 @@ QList<TrackId> PlaylistDAO::getTrackIdsInPlaylistOrder(const int playlistId) con
     return trackIds;
 }
 
+QList<TrackId> PlaylistDAO::getAutoDJTrackIds() const {
+    const int iAutoDJPlaylistId = getPlaylistIdFromName(AUTODJ_TABLE);
+    return getTrackIds(iAutoDJPlaylistId);
+}
+
 int PlaylistDAO::getPlaylistIdFromName(const QString& name) const {
     //qDebug() << "PlaylistDAO::getPlaylistIdFromName" << QThread::currentThread() << m_database.connectionName();
 

--- a/src/library/dao/playlistdao.h
+++ b/src/library/dao/playlistdao.h
@@ -76,6 +76,7 @@ class PlaylistDAO : public QObject, public virtual DAO {
     int getPlaylistId(const int index) const;
     QList<TrackId> getTrackIds(const int playlistId) const;
     QList<TrackId> getTrackIdsInPlaylistOrder(const int playlistId) const;
+    QList<TrackId> getAutoDJTrackIds() const;
     // Returns true if the playlist with playlistId is hidden
     bool isHidden(const int playlistId) const;
     // Returns the HiddenType of playlistId

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -402,6 +402,7 @@ class WTrackMenu : public QMenu {
     QString m_trackProperty;
 
     static bool s_showPurgeSuccessPopup;
+    static bool s_confirmForAutoDjReplace;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(WTrackMenu::Features)


### PR DESCRIPTION
Fixes #14956 

I'm targeting 2.6 because I consider this a UX fix.
If not appropriate due to the new tr strings, we can also postpone it to main.