### PR TITLE
(fix) handle "vinylcontrol_enabled" change request in VinylControlControl

### DIFF
--- a/src/engine/controls/vinylcontrolcontrol.cpp
+++ b/src/engine/controls/vinylcontrolcontrol.cpp
@@ -8,6 +8,7 @@
 
 VinylControlControl::VinylControlControl(const QString& group, UserSettingsPointer pConfig)
         : EngineControl(group, pConfig),
+          m_inputConfigured(group, QStringLiteral("input_configured")),
           m_bSeekRequested(false) {
     m_pControlVinylStatus = new ControlObject(ConfigKey(group, "vinylcontrol_status"));
     m_pControlVinylSpeedType = new ControlObject(ConfigKey(group, "vinylcontrol_speed_type"));
@@ -35,6 +36,9 @@ VinylControlControl::VinylControlControl(const QString& group, UserSettingsPoint
     m_pControlVinylEnabled = new ControlPushButton(ConfigKey(group, "vinylcontrol_enabled"));
     m_pControlVinylEnabled->set(0);
     m_pControlVinylEnabled->setButtonMode(ControlPushButton::TOGGLE);
+    m_pControlVinylEnabled->connectValueChangeRequest(
+            this,
+            &VinylControlControl::slotControlEnabledChangeRequest);
     m_pControlVinylWantEnabled = new ControlPushButton(ConfigKey(group, "vinylcontrol_wantenabled"));
     m_pControlVinylWantEnabled->set(0);
     m_pControlVinylWantEnabled->setButtonMode(ControlPushButton::TOGGLE);
@@ -66,6 +70,16 @@ VinylControlControl::~VinylControlControl() {
 
 void VinylControlControl::trackLoaded(TrackPointer pNewTrack) {
     m_pTrack = pNewTrack;
+}
+
+void VinylControlControl::slotControlEnabledChangeRequest(double v) {
+    // Warn the user if they try to enable vinyl control on a player with no
+    // configured input.
+    if (v > 0 && !m_inputConfigured.toBool()) {
+        emit noVinylControlInputConfigured();
+    } else {
+        m_pControlVinylEnabled->setAndConfirm(v);
+    }
 }
 
 void VinylControlControl::notifySeekQueued() {

--- a/src/engine/controls/vinylcontrolcontrol.h
+++ b/src/engine/controls/vinylcontrolcontrol.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "control/pollingcontrolproxy.h"
 #include "engine/controls/enginecontrol.h"
 #include "preferences/usersettings.h"
 #include "track/track_decl.h"
@@ -20,7 +21,11 @@ class VinylControlControl : public EngineControl {
     bool isScratching();
     void trackLoaded(TrackPointer pNewTrack) override;
 
+  signals:
+    void noVinylControlInputConfigured();
+
   private slots:
+    void slotControlEnabledChangeRequest(double v);
     void slotControlVinylSeek(double fractionalPos);
 
   private:
@@ -35,6 +40,7 @@ class VinylControlControl : public EngineControl {
     ControlPushButton* m_pControlVinylCueing;
     ControlPushButton* m_pControlVinylSignalEnabled;
     ControlProxy* m_pPlayEnabled;
+    PollingControlProxy m_inputConfigured;
 
     TrackPointer m_pTrack; // is written from an engine worker thread
 

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -197,6 +197,11 @@ EngineBuffer::EngineBuffer(const QString& group,
 
 #ifdef __VINYLCONTROL__
     m_pVinylControlControl = new VinylControlControl(group, pConfig);
+    connect(m_pVinylControlControl,
+            &VinylControlControl::noVinylControlInputConfigured,
+            this,
+            // signal-to-signal
+            &EngineBuffer::noVinylControlInputConfigured);
     addControl(m_pVinylControlControl);
 #endif
 

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -235,6 +235,7 @@ class EngineBuffer : public EngineObject {
   signals:
     void trackLoaded(TrackPointer pNewTrack, TrackPointer pOldTrack);
     void trackLoadFailed(TrackPointer pTrack, const QString& reason);
+    void noVinylControlInputConfigured();
 
   private slots:
     void slotTrackLoading();

--- a/src/mixer/basetrackplayer.h
+++ b/src/mixer/basetrackplayer.h
@@ -122,7 +122,6 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
     void slotTrackColorChangeRequest(double value);
     /// Slot for change signals from up/down controls (relative values)
     void slotTrackRatingChangeRequestRelative(int change);
-    void slotVinylControlEnabled(double v);
     void slotWaveformZoomValueChangeRequest(double pressed);
     void slotWaveformZoomUp(double pressed);
     void slotWaveformZoomDown(double pressed);
@@ -211,7 +210,4 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
     parented_ptr<ControlProxy> m_pPreGain;
     parented_ptr<ControlProxy> m_pRateRatio;
     parented_ptr<ControlProxy> m_pPitchAdjust;
-    parented_ptr<ControlProxy> m_pInputConfigured;
-    parented_ptr<ControlProxy> m_pVinylControlEnabled;
-    parented_ptr<ControlProxy> m_pVinylControlStatus;
 };

--- a/src/widget/wspinnybase.cpp
+++ b/src/widget/wspinnybase.cpp
@@ -538,8 +538,7 @@ void WSpinnyBase::mouseMoveEvent(QMouseEvent* e) {
     // qDebug() << "c t:" << theta << "pt:" << m_dPrevTheta <<
     //             "icr" << m_iFullRotations;
 
-    if (((e->buttons() & Qt::LeftButton) || (e->buttons() & Qt::RightButton)) &&
-            !m_bVinylActive) {
+    if ((e->buttons() & Qt::LeftButton) || (e->buttons() & Qt::RightButton)) {
         // Convert deltaTheta into a percentage of song length.
         double absPos = calculatePositionFromAngle(theta);
         double absPosInSamples = absPos * m_pTrackSamples->get();
@@ -576,11 +575,6 @@ void WSpinnyBase::mousePressEvent(QMouseEvent* e) {
 
         m_iStartMouseX = x;
         m_iStartMouseY = y;
-
-        // don't do anything if vinyl control is active
-        if (m_bVinylActive) {
-            return;
-        }
 
         if (e->button() == Qt::LeftButton || e->button() == Qt::RightButton) {
             QApplication::setOverrideCursor(QCursor(Qt::ClosedHandCursor));


### PR DESCRIPTION
Closes #15165

Apparently, the `vinylcontrol_enabled` proxy in `BaseTrackPlayerImpl` causes issues with the same proxy in `WSpinnyBase`.
The former handles the change (request), ie. resets `vinylcontrol_enabled` to **0** if no VC input is configured.
And the proxy in `WSpinnyBase` receives the ON signal delayed, ie. on/off in reverse order. 🤔 :man_shrugging: 

**Symptoms** / order of events:
1. VC in deck1 / spinny is OFF
2. click VC toggle or press Ctrl+T
3. `BaseTrackPlayerImpl::slotVinylControlEnabled` receives **1**
-> no input -> resets to **0**
4. `WSpinnyBase::updateVinylControlEnabled` receives **0**
5. VC config dialog popsp up, cancel
6. `WSpinnyBase::updateVinylControlEnabled` receives **1**
-> mouse scratching is blocked!

### Fix
I moved the change request handling to `VinylControlControl` (where the `vinylcontrol_enabled` pushbutton is created) and reject if no input is cofigured. The proxies wouldn't get notified in that case -- problem ~~solved~~ avoided.

**Other ways to fix this:**
1. Spinnies just don't care about VC for scratching?
both spinnies and waveforms control `PositionScratchController` (and waveforms don't care about VC) and IIUC that is applied on top of VC in [`RateControl::calculateSpeed`](https://github.com/mixxxdj/mixxx/blob/dabe2136b0e17f8cd158725ff27080e09f93a613/src/engine/controls/ratecontrol.cpp#L463)
2. Spinny reads `vinylcontrol_enabled` on mouse press?
and rejects if no input is configured. See 1, there doesn't seem to be a fundamental issue with VC + mouse scratching.

In both cases we might still have the wrong `VC_enabled` bool in WSpinny, and that is also used to draw the signal plot, hence I prefer the current fix.

Would be cool if someone with VC would try to reproduce the bug.
FWIW I'd also apply the additional fix **1.**