### PR TITLE
fix: DEBUG assert being hit in VinylControl ctor

### DIFF
--- a/src/vinylcontrol/vinylcontrol.cpp
+++ b/src/vinylcontrol/vinylcontrol.cpp
@@ -7,9 +7,12 @@
 VinylControl::VinylControl(UserSettingsPointer pConfig, const QString& group)
         : m_pConfig(pConfig),
           m_group(group),
+          m_passthroughEnabled(PollingControlProxy(m_group, QStringLiteral("passthrough"))),
+          m_scratchPositionEnabled(PollingControlProxy(
+                  m_group, QStringLiteral("scratch_position_enable"))),
           m_iLeadInTime(m_pConfig->getValueString(
                                          ConfigKey(group, "vinylcontrol_lead_in_time"))
-                                .toInt()),
+                          .toInt()),
           m_dVinylPosition(0.0),
           m_fTimecodeQuality(0.0f) {
     // Get Control objects
@@ -40,9 +43,6 @@ VinylControl::VinylControl(UserSettingsPointer pConfig, const QString& group)
     signalenabled = new ControlProxy(
             group, "vinylcontrol_signal_enabled", this);
     reverseButton = new ControlProxy(group, "reverse", this);
-    m_passthroughEnabled = PollingControlProxy(group, QStringLiteral("passthrough"));
-    m_scratchPositionEnabled = PollingControlProxy(
-            group, QStringLiteral("scratch_position_enable"));
 
     //Enabled or not -- load from saved value in case vinyl control is restarting
     m_bIsEnabled = wantenabled->get() > 0.0;


### PR DESCRIPTION
Move PollingControlProxy initializations to member initializer list to avoid double init and avoid debug asserting on the first (default) initialization.

Fixes #15167

May need care when merging to 2.6 (since the issue doesn't occur there, haven't investigated why).