### PR TITLE
create Vinyl Control controls and proxies only for main decks

### DIFF
--- a/src/engine/controls/cuecontrol.cpp
+++ b/src/engine/controls/cuecontrol.cpp
@@ -4,6 +4,7 @@
 #include "control/controlobject.h"
 #include "control/controlpushbutton.h"
 #include "engine/enginebuffer.h"
+#include "mixer/playermanager.h"
 #include "moc_cuecontrol.cpp"
 #include "preferences/colorpalettesettings.h"
 #include "track/track.h"
@@ -198,8 +199,12 @@ void CueControl::createControls() {
     m_pOutroEndActivate = std::make_unique<ControlPushButton>(
             ConfigKey(m_group, "outro_end_activate"));
 
-    m_pVinylControlEnabled = std::make_unique<ControlProxy>(m_group, "vinylcontrol_enabled");
-    m_pVinylControlMode = std::make_unique<ControlProxy>(m_group, "vinylcontrol_mode");
+    if (PlayerManager::isDeckGroup(m_group)) {
+        m_pVinylControlEnabled = std::make_unique<ControlProxy>(
+                m_group, "vinylcontrol_enabled");
+        m_pVinylControlMode = std::make_unique<ControlProxy>(
+                m_group, "vinylcontrol_mode");
+    }
 
     m_pHotcueFocus = std::make_unique<ControlObject>(ConfigKey(m_group, "hotcue_focus"));
     setHotcueFocusIndex(Cue::kNoHotCue);
@@ -557,8 +562,8 @@ void CueControl::trackLoaded(TrackPointer pNewTrack) {
     switch (seekOnLoadMode) {
     case SeekOnLoadMode::Beginning:
         // This allows users to load tracks and have the needle-drop be maintained.
-        if (!(m_pVinylControlEnabled->toBool() &&
-                    m_pVinylControlMode->get() == MIXXX_VCMODE_ABSOLUTE)) {
+        if (!(m_pVinylControlEnabled && m_pVinylControlEnabled->toBool() &&
+                    m_pVinylControlMode && m_pVinylControlMode->get() == MIXXX_VCMODE_ABSOLUTE)) {
             seekOnLoad(mixxx::audio::kStartFramePos);
         }
         return;

--- a/src/engine/controls/ratecontrol.cpp
+++ b/src/engine/controls/ratecontrol.cpp
@@ -10,6 +10,7 @@
 #include "engine/controls/bpmcontrol.h"
 #include "engine/controls/enginecontrol.h"
 #include "engine/positionscratchcontroller.h"
+#include "mixer/playermanager.h"
 #include "moc_ratecontrol.cpp"
 #include "util/rotary.h"
 #include "vinylcontrol/defs_vinylcontrol.h"
@@ -99,13 +100,6 @@ RateControl::RateControl(const QString& group, UserSettingsPointer pConfig)
                   ConfigKey(group, QStringLiteral("jog")))),
           // FIXME: The filter length should be dependent on sample rate/block size or something
           m_pJogFilter(std::make_unique<Rotary>(25)),
-          // Vinyl control
-          m_pVCEnabled(ControlObject::getControl(ConfigKey(
-                  getGroup(), QStringLiteral("vinylcontrol_enabled")))),
-          m_pVCScratching(ControlObject::getControl(ConfigKey(
-                  getGroup(), QStringLiteral("vinylcontrol_scratching")))),
-          m_pVCMode(ControlObject::getControl(
-                  ConfigKey(getGroup(), QStringLiteral("vinylcontrol_mode")))),
           m_syncMode(group, QStringLiteral("sync_mode")),
           m_slipEnabled(group, QStringLiteral("slip_enabled")),
           m_wrapAroundCount(0),
@@ -114,6 +108,18 @@ RateControl::RateControl(const QString& group, UserSettingsPointer pConfig)
           m_bTempStarted(false),
           m_tempRateRatio(0.0),
           m_dRateTempRampChange(0.0) {
+    // Vinyl control COs are only created for main decks
+    if (PlayerManager::isDeckGroup(getGroup())) {
+        m_pVCEnabled = ControlObject::getControl(
+                ConfigKey(getGroup(), QStringLiteral("vinylcontrol_enabled")),
+                ControlFlag::NoAssertIfMissing);
+        m_pVCScratching = ControlObject::getControl(
+                ConfigKey(getGroup(), QStringLiteral("vinylcontrol_scratching")),
+                ControlFlag::NoAssertIfMissing);
+        m_pVCMode = ControlObject::getControl(
+                ConfigKey(getGroup(), QStringLiteral("vinylcontrol_mode")),
+                ControlFlag::NoAssertIfMissing);
+    }
     // This is the resulting rate ratio that can be used for display or calculations.
     // The track original rate ratio is 1.
     connect(m_pRateRatio.get(),
@@ -419,7 +425,7 @@ double RateControl::calculateSpeed(double baserate,
         }
 
         if (bVinylControlEnabled) {
-            if (m_pVCScratching->toBool()) {
+            if (m_pVCScratching && m_pVCScratching->toBool()) {
                 *pReportScratching = true;
             }
             rate = speed;

--- a/src/engine/controls/vinylcontrolcontrol.cpp
+++ b/src/engine/controls/vinylcontrolcontrol.cpp
@@ -1,6 +1,5 @@
 #include "engine/controls/vinylcontrolcontrol.h"
 
-#include "control/controlobject.h"
 #include "control/controlpushbutton.h"
 #include "moc_vinylcontrolcontrol.cpp"
 #include "track/track.h"
@@ -8,14 +7,17 @@
 
 VinylControlControl::VinylControlControl(const QString& group, UserSettingsPointer pConfig)
         : EngineControl(group, pConfig),
-          m_inputConfigured(group, QStringLiteral("input_configured")),
+          m_playEnabled(ConfigKey(group, QStringLiteral("play"))),
+          m_inputConfigured(ConfigKey(group, QStringLiteral("input_configured"))),
           m_bSeekRequested(false) {
-    m_pControlVinylStatus = new ControlObject(ConfigKey(group, "vinylcontrol_status"));
-    m_pControlVinylSpeedType = new ControlObject(ConfigKey(group, "vinylcontrol_speed_type"));
+    m_pControlVinylStatus = std::make_unique<ControlObject>(
+            ConfigKey(group, QStringLiteral("vinylcontrol_status")), this);
+    m_pControlVinylSpeedType = std::make_unique<ControlObject>(
+            ConfigKey(group, QStringLiteral("vinylcontrol_speed_type")), this);
 
     //Convert the ConfigKey's value into a double for the CO (for fast reads).
-    QString strVinylSpeedType = pConfig->getValueString(ConfigKey(group,
-                                                      "vinylcontrol_speed_type"));
+    const QString strVinylSpeedType = pConfig->getValueString(ConfigKey(group,
+            QStringLiteral("vinylcontrol_speed_type")));
     if (strVinylSpeedType == MIXXX_VINYL_SPEED_33) {
         m_pControlVinylSpeedType->set(MIXXX_VINYL_SPEED_33_NUM);
     } else if (strVinylSpeedType == MIXXX_VINYL_SPEED_45) {
@@ -24,46 +26,50 @@ VinylControlControl::VinylControlControl(const QString& group, UserSettingsPoint
         m_pControlVinylSpeedType->set(MIXXX_VINYL_SPEED_33_NUM);
     }
 
-    m_pControlVinylSeek = new ControlObject(ConfigKey(group, "vinylcontrol_seek"));
-    connect(m_pControlVinylSeek, &ControlObject::valueChanged,
-            this, &VinylControlControl::slotControlVinylSeek,
+    m_pControlVinylSeek = std::make_unique<ControlObject>(
+            ConfigKey(group, QStringLiteral("vinylcontrol_seek")), this);
+    connect(m_pControlVinylSeek.get(),
+            &ControlObject::valueChanged,
+            this,
+            &VinylControlControl::slotControlVinylSeek,
             Qt::DirectConnection);
 
-    m_pControlVinylRate = new ControlObject(ConfigKey(group, "vinylcontrol_rate"));
-    m_pControlVinylScratching = new ControlPushButton(ConfigKey(group, "vinylcontrol_scratching"));
+    // Most of these controls are only created here so they are available
+    // for ControlProxies in other engine units
+    m_pControlVinylRate = std::make_unique<ControlObject>(
+            ConfigKey(group, QStringLiteral("vinylcontrol_rate")), this);
+
+    m_pControlVinylScratching = std::make_unique<ControlPushButton>(
+            ConfigKey(group, QStringLiteral("vinylcontrol_scratching")), this);
     m_pControlVinylScratching->set(0);
     m_pControlVinylScratching->setButtonMode(mixxx::control::ButtonMode::Toggle);
-    m_pControlVinylEnabled = new ControlPushButton(ConfigKey(group, "vinylcontrol_enabled"));
+
+    m_pControlVinylEnabled = std::make_unique<ControlPushButton>(
+            ConfigKey(group, QStringLiteral("vinylcontrol_enabled")), this);
     m_pControlVinylEnabled->set(0);
     m_pControlVinylEnabled->setButtonMode(mixxx::control::ButtonMode::Toggle);
     m_pControlVinylEnabled->connectValueChangeRequest(
             this,
             &VinylControlControl::slotControlEnabledChangeRequest);
-    m_pControlVinylWantEnabled = new ControlPushButton(ConfigKey(group, "vinylcontrol_wantenabled"));
+
+    m_pControlVinylWantEnabled = std::make_unique<ControlPushButton>(
+            ConfigKey(group, QStringLiteral("vinylcontrol_wantenabled")), this);
     m_pControlVinylWantEnabled->set(0);
     m_pControlVinylWantEnabled->setButtonMode(mixxx::control::ButtonMode::Toggle);
-    m_pControlVinylMode = new ControlPushButton(ConfigKey(group, "vinylcontrol_mode"));
+
+    m_pControlVinylMode = std::make_unique<ControlPushButton>(
+            ConfigKey(group, QStringLiteral("vinylcontrol_mode")), this);
     m_pControlVinylMode->setBehavior(mixxx::control::ButtonMode::Toggle, 3);
-    m_pControlVinylCueing = new ControlPushButton(ConfigKey(group, "vinylcontrol_cueing"));
+
+    m_pControlVinylCueing = std::make_unique<ControlPushButton>(
+            ConfigKey(group, QStringLiteral("vinylcontrol_cueing")), this);
     m_pControlVinylCueing->setBehavior(mixxx::control::ButtonMode::Toggle, 3);
-    m_pControlVinylSignalEnabled = new ControlPushButton(ConfigKey(group, "vinylcontrol_signal_enabled"));
+
+    m_pControlVinylSignalEnabled = std::make_unique<ControlPushButton>(
+            ConfigKey(group, QStringLiteral("vinylcontrol_signal_enabled")),
+            this);
     m_pControlVinylSignalEnabled->set(1);
     m_pControlVinylSignalEnabled->setButtonMode(mixxx::control::ButtonMode::Toggle);
-
-    m_pPlayEnabled = new ControlProxy(group, "play", this);
-}
-
-VinylControlControl::~VinylControlControl() {
-    delete m_pControlVinylRate;
-    delete m_pControlVinylSignalEnabled;
-    delete m_pControlVinylCueing;
-    delete m_pControlVinylMode;
-    delete m_pControlVinylWantEnabled;
-    delete m_pControlVinylEnabled;
-    delete m_pControlVinylScratching;
-    delete m_pControlVinylSeek;
-    delete m_pControlVinylSpeedType;
-    delete m_pControlVinylStatus;
 }
 
 void VinylControlControl::trackLoaded(TrackPointer pNewTrack) {
@@ -81,12 +87,12 @@ void VinylControlControl::slotControlEnabledChangeRequest(double v) {
 }
 
 void VinylControlControl::notifySeekQueued() {
-    // m_bRequested is set and unset in a single execution path,
+    // m_bSeekRequested is set and unset in a single execution path,
     // so there are no issues with signals/slots causing timing
     // issues.
     if (m_pControlVinylMode->get() == MIXXX_VCMODE_ABSOLUTE &&
-        m_pPlayEnabled->get() > 0.0 &&
-        !m_bSeekRequested) {
+            m_playEnabled.get() > 0.0 &&
+            !m_bSeekRequested) {
         m_pControlVinylMode->set(MIXXX_VCMODE_RELATIVE);
     }
 }
@@ -177,12 +183,10 @@ void VinylControlControl::slotControlVinylSeek(double fractionalPos) {
     m_bSeekRequested = false;
 }
 
-bool VinylControlControl::isEnabled()
-{
+bool VinylControlControl::isEnabled() {
     return m_pControlVinylEnabled->toBool();
 }
 
-bool VinylControlControl::isScratching()
-{
+bool VinylControlControl::isScratching() {
     return m_pControlVinylScratching->toBool();
 }

--- a/src/engine/controls/vinylcontrolcontrol.h
+++ b/src/engine/controls/vinylcontrolcontrol.h
@@ -7,13 +7,11 @@
 
 class ControlObject;
 class ControlPushButton;
-class ControlProxy;
 
 class VinylControlControl : public EngineControl {
     Q_OBJECT
   public:
     VinylControlControl(const QString& group, UserSettingsPointer pConfig);
-    virtual ~VinylControlControl();
 
     // If the engine asks for a seek, we may need to disable absolute mode.
     void notifySeekQueued();
@@ -29,17 +27,17 @@ class VinylControlControl : public EngineControl {
     void slotControlVinylSeek(double fractionalPos);
 
   private:
-    ControlObject* m_pControlVinylRate;
-    ControlObject* m_pControlVinylSeek;
-    ControlObject* m_pControlVinylSpeedType;
-    ControlObject* m_pControlVinylStatus;
-    ControlPushButton* m_pControlVinylScratching;
-    ControlPushButton* m_pControlVinylMode;
-    ControlPushButton* m_pControlVinylEnabled;
-    ControlPushButton* m_pControlVinylWantEnabled;
-    ControlPushButton* m_pControlVinylCueing;
-    ControlPushButton* m_pControlVinylSignalEnabled;
-    ControlProxy* m_pPlayEnabled;
+    std::unique_ptr<ControlObject> m_pControlVinylRate;
+    std::unique_ptr<ControlObject> m_pControlVinylSeek;
+    std::unique_ptr<ControlObject> m_pControlVinylSpeedType;
+    std::unique_ptr<ControlObject> m_pControlVinylStatus;
+    std::unique_ptr<ControlPushButton> m_pControlVinylScratching;
+    std::unique_ptr<ControlPushButton> m_pControlVinylMode;
+    std::unique_ptr<ControlPushButton> m_pControlVinylEnabled;
+    std::unique_ptr<ControlPushButton> m_pControlVinylWantEnabled;
+    std::unique_ptr<ControlPushButton> m_pControlVinylCueing;
+    std::unique_ptr<ControlPushButton> m_pControlVinylSignalEnabled;
+    PollingControlProxy m_playEnabled;
     PollingControlProxy m_inputConfigured;
 
     TrackPointer m_pTrack; // is written from an engine worker thread

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -22,6 +22,7 @@
 #include "engine/readaheadmanager.h"
 #include "engine/sync/enginesync.h"
 #include "engine/sync/synccontrol.h"
+#include "mixer/playermanager.h"
 #include "moc_enginebuffer.cpp"
 #include "preferences/usersettings.h"
 #include "track/track.h"
@@ -198,13 +199,15 @@ EngineBuffer::EngineBuffer(const QString& group,
     m_pSyncControl = new SyncControl(group, pConfig, pChannel, m_pEngineSync);
 
 #ifdef __VINYLCONTROL__
-    m_pVinylControlControl = new VinylControlControl(group, pConfig);
-    connect(m_pVinylControlControl,
-            &VinylControlControl::noVinylControlInputConfigured,
-            this,
-            // signal-to-signal
-            &EngineBuffer::noVinylControlInputConfigured);
-    addControl(m_pVinylControlControl);
+    if (PlayerManager::isDeckGroup(group)) {
+        m_pVinylControlControl = new VinylControlControl(group, pConfig);
+        connect(m_pVinylControlControl,
+                &VinylControlControl::noVinylControlInputConfigured,
+                this,
+                // signal-to-signal
+                &EngineBuffer::noVinylControlInputConfigured);
+        addControl(m_pVinylControlControl);
+    }
 #endif
 
     // Create the Rate Controller

--- a/src/engine/sync/synccontrol.cpp
+++ b/src/engine/sync/synccontrol.cpp
@@ -8,6 +8,7 @@
 #include "engine/enginebuffer.h"
 #include "engine/enginemixer.h"
 #include "engine/sync/enginesync.h"
+#include "mixer/playermanager.h"
 #include "moc_synccontrol.cpp"
 #include "track/track.h"
 #include "util/assert.h"
@@ -123,15 +124,18 @@ void SyncControl::setEngineControls(RateControl* pRateControl,
     m_pSyncPhaseButton = new ControlProxy(getGroup(), "beatsync_phase", this);
 
 #ifdef __VINYLCONTROL__
-    m_pVCEnabled = new ControlProxy(
-            getGroup(), "vinylcontrol_enabled", this);
+    // Vinyl control COs are only created for main decks
+    if (PlayerManager::isDeckGroup(getGroup())) {
+        m_pVCEnabled = new ControlProxy(
+                getGroup(), "vinylcontrol_enabled", this);
+        // TODO Remove, ControlProxy asserts that the control exists
+        // Throw a hissy fit if somebody moved us such that the vinylcontrol_enabled
+        // control doesn't exist yet. This will blow up immediately, won't go unnoticed.
+        DEBUG_ASSERT(m_pVCEnabled->valid());
 
-    // Throw a hissy fit if somebody moved us such that the vinylcontrol_enabled
-    // control doesn't exist yet. This will blow up immediately, won't go unnoticed.
-    DEBUG_ASSERT(m_pVCEnabled->valid());
-
-    m_pVCEnabled->connectValueChanged(
-            this, &SyncControl::slotVinylControlChanged, Qt::DirectConnection);
+        m_pVCEnabled->connectValueChanged(
+                this, &SyncControl::slotVinylControlChanged, Qt::DirectConnection);
+    }
 #endif
 }
 

--- a/src/widget/wspinnybase.cpp
+++ b/src/widget/wspinnybase.cpp
@@ -562,24 +562,22 @@ void WSpinnyBase::mousePressEvent(QMouseEvent* e) {
         m_iStartMouseX = x;
         m_iStartMouseY = y;
 
-        if (e->button() == Qt::LeftButton || e->button() == Qt::RightButton) {
-            QApplication::setOverrideCursor(QCursor(Qt::ClosedHandCursor));
+        QApplication::setOverrideCursor(QCursor(Qt::ClosedHandCursor));
 
-            // Coordinates from center of widget
-            double c_x = x - width() / 2;
-            double c_y = y - height() / 2;
-            double theta = (180.0 / M_PI) * atan2(c_x, -c_y);
-            m_dPrevTheta = theta;
-            m_iFullRotations = calculateFullRotations(m_pPlayPos.get());
-            theta += m_iFullRotations * 360.0;
-            m_dInitialPos = calculatePositionFromAngle(theta) * m_pTrackSamples.get();
+        // Coordinates from center of widget
+        double c_x = x - width() / 2;
+        double c_y = y - height() / 2;
+        double theta = (180.0 / M_PI) * atan2(c_x, -c_y);
+        m_dPrevTheta = theta;
+        m_iFullRotations = calculateFullRotations(m_pPlayPos.get());
+        theta += m_iFullRotations * 360.0;
+        m_dInitialPos = calculatePositionFromAngle(theta) * m_pTrackSamples.get();
 
-            m_pScratchPos.set(0);
-            m_pScratchToggle.set(1.0);
+        m_pScratchPos.set(0);
+        m_pScratchToggle.set(1.0);
 
-            // Trigger a mouse move to immediately line up the vinyl with the cursor
-            mouseMoveEvent(e);
-        }
+        // Trigger a mouse move to immediately line up the vinyl with the cursor
+        mouseMoveEvent(e);
     } else {
         if (!m_loadedCover.isNull()) {
             m_pDlgCoverArt->init(m_pLoadedTrack);

--- a/src/widget/wspinnybase.cpp
+++ b/src/widget/wspinnybase.cpp
@@ -8,6 +8,7 @@
 #include "library/coverartutils.h"
 #include "library/dlgcoverartfullsize.h"
 #include "mixer/basetrackplayer.h"
+#include "mixer/playermanager.h"
 #include "moc_wspinnybase.cpp"
 #include "skin/legacy/skincontext.h"
 #include "track/track.h"
@@ -194,30 +195,32 @@ void WSpinnyBase::setup(const QDomNode& node,
     m_pSlipEnabled->connectValueChanged(this, &WSpinnyBase::updateSlipEnabled);
 
 #ifdef __VINYLCONTROL__
-    m_pVinylControlSpeedType = make_parented<ControlProxy>(
-            m_group, "vinylcontrol_speed_type", this, ControlFlag::NoAssertIfMissing);
-    // Initialize the rotational speed.
-    updateVinylControlSpeed(m_pVinylControlSpeedType->get());
-    // Match the vinyl control's set RPM so that the spinny widget rotates at
-    // the same speed as your physical decks, if you're using vinyl control.
-    m_pVinylControlSpeedType->connectValueChanged(this,
-            &WSpinnyBase::updateVinylControlSpeed);
+    if (PlayerManager::isDeckGroup(m_group)) {
+        m_pVinylControlSpeedType = make_parented<ControlProxy>(
+                m_group, "vinylcontrol_speed_type", this, ControlFlag::NoAssertIfMissing);
+        // Initialize the rotational speed.
+        updateVinylControlSpeed(m_pVinylControlSpeedType->get());
+        // Match the vinyl control's set RPM so that the spinny widget rotates at
+        // the same speed as your physical decks, if you're using vinyl control.
+        m_pVinylControlSpeedType->connectValueChanged(this,
+                &WSpinnyBase::updateVinylControlSpeed);
 
-    m_pVinylControlEnabled = make_parented<ControlProxy>(
-            m_group, "vinylcontrol_enabled", this, ControlFlag::NoAssertIfMissing);
-    updateVinylControlEnabled(m_pVinylControlEnabled->get());
-    m_pVinylControlEnabled->connectValueChanged(this,
-            &WSpinnyBase::updateVinylControlEnabled);
+        m_pVinylControlEnabled = make_parented<ControlProxy>(
+                m_group, "vinylcontrol_enabled", this, ControlFlag::NoAssertIfMissing);
+        updateVinylControlEnabled(m_pVinylControlEnabled->get());
+        m_pVinylControlEnabled->connectValueChanged(this,
+                &WSpinnyBase::updateVinylControlEnabled);
 
-    m_pSignalEnabled = make_parented<ControlProxy>(
-            m_group, "vinylcontrol_signal_enabled", this, ControlFlag::NoAssertIfMissing);
-    updateVinylControlSignalEnabled(m_pSignalEnabled->get());
-    m_pSignalEnabled->connectValueChanged(this,
-            &WSpinnyBase::updateVinylControlSignalEnabled);
-#else
-    // if no vinyl control, just call it 33
-    this->updateVinylControlSpeed(33.0);
+        m_pSignalEnabled = make_parented<ControlProxy>(
+                m_group, "vinylcontrol_signal_enabled", this, ControlFlag::NoAssertIfMissing);
+        updateVinylControlSignalEnabled(m_pSignalEnabled->get());
+        m_pSignalEnabled->connectValueChanged(this,
+                &WSpinnyBase::updateVinylControlSignalEnabled);
+        return;
+    }
 #endif
+    // if no vinyl control, just call it 33
+    updateVinylControlSpeed(33.0);
 }
 
 void WSpinnyBase::setLoadedCover(const QPixmap& pixmap) {

--- a/src/widget/wspinnybase.cpp
+++ b/src/widget/wspinnybase.cpp
@@ -29,12 +29,12 @@ WSpinnyBase::WSpinnyBase(
           WBaseWidget(this),
           m_group(group),
           m_pConfig(pConfig),
-          m_pPlayPos(nullptr),
-          m_pVisualPlayPos(nullptr),
-          m_pTrackSamples(nullptr),
-          m_pTrackSampleRate(nullptr),
-          m_pScratchToggle(nullptr),
-          m_pScratchPos(nullptr),
+          m_pVisualPlayPos(VisualPlayPosition::getVisualPlayPosition(m_group)),
+          m_pPlayPos(PollingControlProxy(m_group, QStringLiteral("playposition"))),
+          m_pTrackSamples(PollingControlProxy(m_group, QStringLiteral("track_samples"))),
+          m_pTrackSampleRate(PollingControlProxy(m_group, QStringLiteral("track_samplerate"))),
+          m_pScratchToggle(PollingControlProxy(m_group, QStringLiteral("scratch_position_enable"))),
+          m_pScratchPos(PollingControlProxy(m_group, QStringLiteral("scratch_position"))),
           m_pVinylControlSpeedType(nullptr),
           m_pVinylControlEnabled(nullptr),
           m_pSignalEnabled(nullptr),
@@ -61,8 +61,8 @@ WSpinnyBase::WSpinnyBase(
           m_bClampFailedWarning(false),
           m_bGhostPlayback(false),
           m_pPlayer(pPlayer),
-          m_pCoverMenu(new WCoverArtMenu(this)),
-          m_pDlgCoverArt(new DlgCoverArtFullSize(this, pPlayer, m_pCoverMenu)) {
+          m_pCoverMenu(make_parented<WCoverArtMenu>(this)),
+          m_pDlgCoverArt(make_parented<DlgCoverArtFullSize>(this, pPlayer, m_pCoverMenu)) {
 #ifdef __VINYLCONTROL__
     m_pVCManager = pVCMan;
 #else
@@ -167,7 +167,7 @@ void WSpinnyBase::setup(const QDomNode& node,
 
     // Dynamic skin option, set in WSpinnyBase's <ShowCoverControl> node.
     if (showCoverConfigKey.isValid()) {
-        m_pShowCoverProxy = new ControlProxy(
+        m_pShowCoverProxy = make_parented<ControlProxy>(
                 showCoverConfigKey, this);
         m_pShowCoverProxy->connectValueChanged(
                 this,
@@ -189,46 +189,31 @@ void WSpinnyBase::setup(const QDomNode& node,
     m_bDrawVinylSignalQuality = false;
 #endif
 
-    m_pPlayPos = new ControlProxy(
-            m_group, "playposition", this, ControlFlag::NoAssertIfMissing);
-    m_pVisualPlayPos = VisualPlayPosition::getVisualPlayPosition(m_group);
-    m_pTrackSamples = new ControlProxy(
-            m_group, "track_samples", this, ControlFlag::NoAssertIfMissing);
-    m_pTrackSampleRate = new ControlProxy(
-            m_group, "track_samplerate", this, ControlFlag::NoAssertIfMissing);
-
-    m_pScratchToggle = new ControlProxy(
-            m_group, "scratch_position_enable", this, ControlFlag::NoAssertIfMissing);
-    m_pScratchPos = new ControlProxy(
-            m_group, "scratch_position", this, ControlFlag::NoAssertIfMissing);
-
-    m_pSlipEnabled = new ControlProxy(
+    m_pSlipEnabled = make_parented<ControlProxy>(
             m_group, "slip_enabled", this, ControlFlag::NoAssertIfMissing);
     m_pSlipEnabled->connectValueChanged(this, &WSpinnyBase::updateSlipEnabled);
 
 #ifdef __VINYLCONTROL__
-    m_pVinylControlSpeedType = new ControlProxy(
+    m_pVinylControlSpeedType = make_parented<ControlProxy>(
             m_group, "vinylcontrol_speed_type", this, ControlFlag::NoAssertIfMissing);
     // Initialize the rotational speed.
     updateVinylControlSpeed(m_pVinylControlSpeedType->get());
-
-    m_pVinylControlEnabled = new ControlProxy(
-            m_group, "vinylcontrol_enabled", this, ControlFlag::NoAssertIfMissing);
-    updateVinylControlEnabled(m_pVinylControlEnabled->get());
-    m_pVinylControlEnabled->connectValueChanged(this,
-            &WSpinnyBase::updateVinylControlEnabled);
-
-    m_pSignalEnabled = new ControlProxy(
-            m_group, "vinylcontrol_signal_enabled", this, ControlFlag::NoAssertIfMissing);
-    updateVinylControlSignalEnabled(m_pSignalEnabled->get());
-    m_pSignalEnabled->connectValueChanged(this,
-            &WSpinnyBase::updateVinylControlSignalEnabled);
-
     // Match the vinyl control's set RPM so that the spinny widget rotates at
     // the same speed as your physical decks, if you're using vinyl control.
     m_pVinylControlSpeedType->connectValueChanged(this,
             &WSpinnyBase::updateVinylControlSpeed);
 
+    m_pVinylControlEnabled = make_parented<ControlProxy>(
+            m_group, "vinylcontrol_enabled", this, ControlFlag::NoAssertIfMissing);
+    updateVinylControlEnabled(m_pVinylControlEnabled->get());
+    m_pVinylControlEnabled->connectValueChanged(this,
+            &WSpinnyBase::updateVinylControlEnabled);
+
+    m_pSignalEnabled = make_parented<ControlProxy>(
+            m_group, "vinylcontrol_signal_enabled", this, ControlFlag::NoAssertIfMissing);
+    updateVinylControlSignalEnabled(m_pSignalEnabled->get());
+    m_pSignalEnabled->connectValueChanged(this,
+            &WSpinnyBase::updateVinylControlSignalEnabled);
 #else
     // if no vinyl control, just call it 33
     this->updateVinylControlSpeed(33.0);
@@ -387,8 +372,8 @@ void WSpinnyBase::resizeEvent(QResizeEvent* event) {
    in our polar coordinate system.
    Returns an angle clamped between -180 and 180 degrees. */
 double WSpinnyBase::calculateAngle(double playpos) {
-    double trackFrames = m_pTrackSamples->get() / 2;
-    double trackSampleRate = m_pTrackSampleRate->get();
+    double trackFrames = m_pTrackSamples.get() / 2;
+    double trackSampleRate = m_pTrackSampleRate.get();
     if (util_isnan(playpos) || util_isnan(trackFrames) || util_isnan(trackSampleRate) ||
             trackFrames <= 0 || trackSampleRate <= 0) {
         return 0.0;
@@ -437,8 +422,8 @@ int WSpinnyBase::calculateFullRotations(double playpos) {
         return 0;
     }
     // Convert playpos to seconds.
-    double t = playpos * (m_pTrackSamples->get() / 2 / // Stereo audio!
-                                 m_pTrackSampleRate->get());
+    double t = playpos * (m_pTrackSamples.get() / 2 / // Stereo audio!
+                                 m_pTrackSampleRate.get());
 
     // 33 RPM is approx. 0.5 rotations per second.
     // qDebug() << t;
@@ -456,8 +441,8 @@ double WSpinnyBase::calculatePositionFromAngle(double angle) {
     // 33 RPM is approx. 0.5 rotations per second.
     double t = angle / (360.0 * m_dRotationsPerSecond); // time in seconds
 
-    double trackFrames = m_pTrackSamples->get() / 2;
-    double trackSampleRate = m_pTrackSampleRate->get();
+    double trackFrames = m_pTrackSamples.get() / 2;
+    double trackSampleRate = m_pTrackSampleRate.get();
     if (util_isnan(trackFrames) || util_isnan(trackSampleRate) ||
             trackFrames <= 0 || trackSampleRate <= 0) {
         return 0.0;
@@ -542,8 +527,8 @@ void WSpinnyBase::mouseMoveEvent(QMouseEvent* e) {
     if ((e->buttons() & Qt::LeftButton) || (e->buttons() & Qt::RightButton)) {
         // Convert deltaTheta into a percentage of song length.
         double absPos = calculatePositionFromAngle(theta);
-        double absPosInSamples = absPos * m_pTrackSamples->get();
-        m_pScratchPos->set(absPosInSamples - m_dInitialPos);
+        double absPosInSamples = absPos * m_pTrackSamples.get();
+        m_pScratchPos.set(absPosInSamples - m_dInitialPos);
     } else if (e->buttons() & Qt::MiddleButton) {
     } else if (e->buttons() & Qt::NoButton) {
         setCursor(QCursor(Qt::OpenHandCursor));
@@ -585,12 +570,12 @@ void WSpinnyBase::mousePressEvent(QMouseEvent* e) {
             double c_y = y - height() / 2;
             double theta = (180.0 / M_PI) * atan2(c_x, -c_y);
             m_dPrevTheta = theta;
-            m_iFullRotations = calculateFullRotations(m_pPlayPos->get());
+            m_iFullRotations = calculateFullRotations(m_pPlayPos.get());
             theta += m_iFullRotations * 360.0;
-            m_dInitialPos = calculatePositionFromAngle(theta) * m_pTrackSamples->get();
+            m_dInitialPos = calculatePositionFromAngle(theta) * m_pTrackSamples.get();
 
-            m_pScratchPos->set(0);
-            m_pScratchToggle->set(1.0);
+            m_pScratchPos.set(0);
+            m_pScratchToggle.set(1.0);
 
             // Trigger a mouse move to immediately line up the vinyl with the cursor
             mouseMoveEvent(e);
@@ -611,7 +596,7 @@ void WSpinnyBase::mousePressEvent(QMouseEvent* e) {
 void WSpinnyBase::mouseReleaseEvent(QMouseEvent* e) {
     if (e->button() == Qt::LeftButton || e->button() == Qt::RightButton) {
         QApplication::restoreOverrideCursor();
-        m_pScratchToggle->set(0.0);
+        m_pScratchToggle.set(0.0);
         m_iFullRotations = 0;
     }
 }

--- a/src/widget/wspinnybase.h
+++ b/src/widget/wspinnybase.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include "control/pollingcontrolproxy.h"
 #include "preferences/usersettings.h"
 #include "track/track_decl.h"
+#include "util/parented_ptr.h"
 #include "vinylcontrol/vinylsignalquality.h"
 #include "widget/trackdroptarget.h"
 #include "widget/wbasewidget.h"
@@ -106,17 +108,18 @@ class WSpinnyBase : public WGLWidget,
     QImage m_fgImageScaled;
     std::shared_ptr<QImage> m_pGhostImage;
     QImage m_ghostImageScaled;
-    ControlProxy* m_pPlayPos;
+
     QSharedPointer<VisualPlayPosition> m_pVisualPlayPos;
-    ControlProxy* m_pTrackSamples;
-    ControlProxy* m_pTrackSampleRate;
-    ControlProxy* m_pScratchToggle;
-    ControlProxy* m_pScratchPos;
-    ControlProxy* m_pVinylControlSpeedType;
-    ControlProxy* m_pVinylControlEnabled;
-    ControlProxy* m_pSignalEnabled;
-    ControlProxy* m_pSlipEnabled;
-    ControlProxy* m_pShowCoverProxy;
+    PollingControlProxy m_pPlayPos;
+    PollingControlProxy m_pTrackSamples;
+    PollingControlProxy m_pTrackSampleRate;
+    PollingControlProxy m_pScratchToggle;
+    PollingControlProxy m_pScratchPos;
+    parented_ptr<ControlProxy> m_pVinylControlSpeedType;
+    parented_ptr<ControlProxy> m_pVinylControlEnabled;
+    parented_ptr<ControlProxy> m_pSignalEnabled;
+    parented_ptr<ControlProxy> m_pSlipEnabled;
+    parented_ptr<ControlProxy> m_pShowCoverProxy;
 
     TrackPointer m_pLoadedTrack;
     QPixmap m_loadedCover;
@@ -149,6 +152,6 @@ class WSpinnyBase : public WGLWidget,
     bool m_bGhostPlayback;
 
     BaseTrackPlayer* m_pPlayer;
-    WCoverArtMenu* m_pCoverMenu;
-    DlgCoverArtFullSize* m_pDlgCoverArt;
+    parented_ptr<WCoverArtMenu> m_pCoverMenu;
+    parented_ptr<DlgCoverArtFullSize> m_pDlgCoverArt;
 };


### PR DESCRIPTION
and not for preview deck and 4-64 samplers.

based on the 2.6 version of #15168

extra: migration to parented_ptr / unique_ptr and PollingControlProxy in WSpinnyBase and VinylControl
(couldn't resist, can move this to a separate PR if you want)