### PR TITLE
BPM/tempo editor widget

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1657,6 +1657,7 @@ add_library(
   src/widget/wbasewidget.cpp
   src/widget/wbattery.cpp
   src/widget/wbeatspinbox.cpp
+  src/widget/wbpmeditor.cpp
   src/widget/wcollapsiblegroupbox.cpp
   src/widget/wcolorpicker.cpp
   src/widget/wcolorpickeraction.cpp

--- a/res/skins/LateNight/classic/buttons/btn__bpm_select_edit.svg
+++ b/res/skins/LateNight/classic/buttons/btn__bpm_select_edit.svg
@@ -1,0 +1,5 @@
+<svg width="32" height="32" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <path d="m8 3.75v8.5" fill="none" stroke="#d2d2d1" stroke-width="1.5"/>
+  <path d="m5.5 3.75h5" fill="none" stroke="#d2d2d1" stroke-width="1.5"/>
+  <path d="m5.5 12.25h5" fill="none" stroke="#d2d2d1" stroke-width="1.5"/>
+</svg>

--- a/res/skins/LateNight/classic/buttons/btn__bpm_select_tap.svg
+++ b/res/skins/LateNight/classic/buttons/btn__bpm_select_tap.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <ellipse cx="8" cy="8" rx="5.3454823" ry="5.4031892" fill="none" stroke="#d2d2d1" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="0" stroke-width="1.5" style="paint-order:fill markers stroke"/>
+  <ellipse cx="8" cy="8" rx="1.8907727" ry="1.9140049" fill="#d2d2d1" style="paint-order:fill markers stroke"/>
+</svg>

--- a/res/skins/LateNight/classic/buttons/btn__bpm_spinbox_minus.svg
+++ b/res/skins/LateNight/classic/buttons/btn__bpm_spinbox_minus.svg
@@ -1,0 +1,14 @@
+<svg width="60" height="32" version="1.1" viewBox="0 0 30 16" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="a" x1="2" x2="24" y1="12" y2="12" gradientTransform="matrix(.69565215 0 0 1.3043477 -1.0434993 -29.347824)" gradientUnits="userSpaceOnUse">
+      <stop stop-opacity=".0047619" offset="0"/>
+      <stop stop-opacity="0" offset=".5"/>
+      <stop stop-opacity=".47451" offset="1"/>
+    </linearGradient>
+  </defs>
+  <rect width="30" height="16" fill="#262626" stroke-width=".500001" style="paint-order:fill markers stroke"/>
+  <path d="m10 7h9v3h-9z" fill="none" stroke="#000001" stroke-linecap="square" stroke-width="1.6"/>
+  <path d="m10 7h9v3h-9z" fill="#d2d2d1"/>
+  <path d="m0 0v1h29v15h1v-16h-1-29z" fill="#393939" style="paint-order:fill markers stroke"/>
+  <rect transform="rotate(90)" x="-2.5e-7" y="-30" width="15.999999" height="30" color="#000001" fill="url(#a)" stroke-width=".500001"/>
+</svg>

--- a/res/skins/LateNight/classic/buttons/btn__bpm_spinbox_minus_pressed.svg
+++ b/res/skins/LateNight/classic/buttons/btn__bpm_spinbox_minus_pressed.svg
@@ -1,0 +1,14 @@
+<svg width="60" height="32" version="1.1" viewBox="0 0 30 16" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="a" x1="2" x2="24" y1="12" y2="12" gradientTransform="matrix(1.3043478,0,0,1.3043478,-26.956559,-29.347825)" gradientUnits="userSpaceOnUse">
+      <stop stop-opacity=".0047619" offset="0"/>
+      <stop stop-opacity="0" offset=".5"/>
+      <stop stop-opacity=".47451" offset="1"/>
+    </linearGradient>
+  </defs>
+  <rect width="30" height="16" fill="#db0000" stroke-width=".500002" style="paint-order:fill markers stroke"/>
+  <path d="m10 7h9v3h-9z" fill="none" stroke="#000001" stroke-linecap="square" stroke-width="1.6"/>
+  <path d="m10 7h9v3h-9z" fill="#d2d2d1"/>
+  <path d="m0 0v1h29v15h1v-16h-1-29z" fill="#393939" style="paint-order:fill markers stroke"/>
+  <rect transform="matrix(0,-1,-1,0,0,0)" x="-25" y="-30.000002" width="30" height="30.000002" color="#000001" fill="url(#a)" stroke-width=".5"/>
+</svg>

--- a/res/skins/LateNight/classic/buttons/btn__bpm_spinbox_plus.svg
+++ b/res/skins/LateNight/classic/buttons/btn__bpm_spinbox_plus.svg
@@ -1,0 +1,16 @@
+<svg width="60" height="32" version="1.1" viewBox="0 0 30 16" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="a" x1="2" x2="24" y1="12" y2="12" gradientTransform="matrix(.69565215 0 0 1.3043477 -1.0434993 -29.347824)" gradientUnits="userSpaceOnUse">
+      <stop stop-opacity=".0047619" offset="0"/>
+      <stop stop-opacity="0" offset=".5"/>
+      <stop stop-opacity=".47451" offset="1"/>
+    </linearGradient>
+  </defs>
+  <rect width="30" height="16" fill="#262626" stroke-width=".500001" style="paint-order:fill markers stroke"/>
+  <path d="m11 7h3v-3h3v3h3v3h-3v3h-3v-3h-3z" fill="none" stroke="#000001" stroke-linecap="square" stroke-width="1.6"/>
+  <path d="m11 7h3v-3h3v3h3v3h-3v3h-3v-3h-3z" fill="#d2d2d1"/>
+  <rect width="30" height="1" fill="#242426" style="paint-order:fill markers stroke"/>
+  <rect width="1" height="16" style="paint-order:fill markers stroke"/>
+  <path d="m1 0v1 15h1v-15h28v-1h-29z" fill="#393939" style="paint-order:fill markers stroke"/>
+  <rect transform="rotate(90)" x="-2.5e-7" y="-30" width="15.999999" height="30" color="#000001" fill="url(#a)" stroke-width=".500001"/>
+</svg>

--- a/res/skins/LateNight/classic/buttons/btn__bpm_spinbox_plus_pressed.svg
+++ b/res/skins/LateNight/classic/buttons/btn__bpm_spinbox_plus_pressed.svg
@@ -1,0 +1,16 @@
+<svg width="60" height="32" version="1.1" viewBox="0 0 30 16" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="a" x1="2" x2="24" y1="12" y2="12" gradientTransform="matrix(1.3043478,0,0,1.3043478,-26.956559,-29.347825)" gradientUnits="userSpaceOnUse">
+      <stop stop-opacity=".0047619" offset="0"/>
+      <stop stop-opacity="0" offset=".5"/>
+      <stop stop-opacity=".47451" offset="1"/>
+    </linearGradient>
+  </defs>
+  <rect width="30" height="16" fill="#db0000" stroke-width=".500002" style="paint-order:fill markers stroke"/>
+  <path d="m11 7h3v-3h3v3h3v3h-3v3h-3v-3h-3z" fill="none" stroke="#000001" stroke-linecap="square" stroke-width="1.6"/>
+  <path d="m11 7h3v-3h3v3h3v3h-3v3h-3v-3h-3z" fill="#d2d2d1"/>
+  <rect width="30" height="1" fill="#242426" style="paint-order:fill markers stroke"/>
+  <rect width="1" height="16" style="paint-order:fill markers stroke"/>
+  <path d="m1 0v1 15h1v-15h28v-1h-29z" fill="#393939" style="paint-order:fill markers stroke"/>
+  <rect transform="matrix(0,-1,-1,0,0,0)" x="-25" y="-30.000002" width="30" height="30.000002" color="#000001" fill="url(#a)" stroke-width=".5"/>
+</svg>

--- a/res/skins/LateNight/classic/buttons/spinbox_down_pressed.svg
+++ b/res/skins/LateNight/classic/buttons/spinbox_down_pressed.svg
@@ -1,14 +1,14 @@
-<svg width="17" height="11" version="1.1" xmlns="http://www.w3.org/2000/svg">
-		<defs>
-				<linearGradient id="a" x1="2" x2="24" y1="12" y2="12" gradientTransform="matrix(1,0,0,1.6956521,-13.50003,-38.152173)" gradientUnits="userSpaceOnUse">
-						<stop stop-opacity=".0047619" offset="0"/>
-						<stop stop-opacity="0" offset=".5"/>
-						<stop stop-opacity=".47451" offset="1"/>
-				</linearGradient>
-		</defs>
-		<rect x="-3.4557388" y="-5.57377" width="20.455738" height="16.573771" rx="1.5" ry="1.5" fill="#db0000" style="paint-order:fill markers stroke"/>
-		<rect transform="rotate(90)" x="-12" y="-39" width="23" height="39" color="#000001" fill="url(#a)"/>
-		<path d="m9 7.9999994-3.4641429-6h6.9281999z" fill="none" stroke="#000001" stroke-width="1.6"/>
-		<path d="m9 7.9999994-3.4641429-6h6.9281999z" fill="#bfbfbe" stroke-width=".85714287"/>
-		<rect y="-13.007122" width="1" height="24.007122" fill="#333334" style="paint-order:fill markers stroke"/>
+<svg version="1.1" viewBox="0 0 17 11" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="a" x1="2" x2="24" y1="12" y2="12" gradientTransform="matrix(1,0,0,1.6956521,-18.50003,-38.152173)" gradientUnits="userSpaceOnUse">
+      <stop stop-opacity=".0047619" offset="0"/>
+      <stop stop-opacity="0" offset=".5"/>
+      <stop stop-opacity=".47451" offset="1"/>
+    </linearGradient>
+  </defs>
+  <rect x="-3.4557388" y="-5.57377" width="20.455738" height="16.573771" rx="1.5" ry="1.5" fill="#db0000" style="paint-order:fill markers stroke"/>
+  <path d="m9 7.9999994-3.4641429-6h6.9281999z" fill="none" stroke="#000001" stroke-width="1.6"/>
+  <path d="m9 7.9999994-3.4641429-6h6.9281999z" fill="#bfbfbe" stroke-width=".85714287"/>
+  <rect y="-13.007122" width="1" height="24.007122" fill="#333334" style="paint-order:fill markers stroke"/>
+  <rect transform="matrix(0,-1,-1,0,0,0)" x="-17" y="-39" width="23" height="39" color="#000001" fill="url(#a)"/>
 </svg>

--- a/res/skins/LateNight/classic/buttons/spinbox_up_pressed.svg
+++ b/res/skins/LateNight/classic/buttons/spinbox_up_pressed.svg
@@ -1,14 +1,14 @@
-<svg width="17" height="11" version="1.1" xmlns="http://www.w3.org/2000/svg">
-		<defs>
-				<linearGradient id="a" x1="2" x2="24" y1="12" y2="12" gradientTransform="matrix(1,0,0,1.6956521,-1.50003,-38.152173)" gradientUnits="userSpaceOnUse">
-						<stop stop-opacity=".0047619" offset="0"/>
-						<stop stop-opacity="0" offset=".5"/>
-						<stop stop-opacity=".47451" offset="1"/>
-				</linearGradient>
-		</defs>
-		<rect x="-3.4557376" width="20.455738" height="16.573771" rx="1.5" ry="1.5" fill="#db0000" style="paint-order:fill markers stroke"/>
-		<rect transform="rotate(90)" x="1.0817554e-18" y="-39" width="23" height="39" color="#000001" fill="url(#a)"/>
-		<path d="M 9.0050588,2.9999997 5.5409159,9 h 6.9282001 z" fill="none" stroke="#000001" stroke-width="1.6"/>
-		<path d="M 9.0050588,2.9999997 5.5409159,9 h 6.9282001 z" fill="#bfbfbe" stroke-width=".85714287"/>
-		<rect y="-13.007122" width="1" height="24.007122" fill="#333334" style="paint-order:fill markers stroke"/>
+<svg version="1.1" viewBox="0 0 17 11" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="a" x1="2" x2="24" y1="12" y2="12" gradientTransform="matrix(1,0,0,1.6956521,-18.50003,-38.152173)" gradientUnits="userSpaceOnUse">
+      <stop stop-opacity=".0047619" offset="0"/>
+      <stop stop-opacity="0" offset=".5"/>
+      <stop stop-opacity=".47451" offset="1"/>
+    </linearGradient>
+  </defs>
+  <rect x="-3.4557376" width="20.455738" height="16.573771" rx="1.5" ry="1.5" fill="#db0000" style="paint-order:fill markers stroke"/>
+  <path d="M 9.0050588,2.9999997 5.5409159,9 h 6.9282001 z" fill="none" stroke="#000001" stroke-width="1.6"/>
+  <path d="M 9.0050588,2.9999997 5.5409159,9 h 6.9282001 z" fill="#bfbfbe" stroke-width=".85714287"/>
+  <rect y="-13.007122" width="1" height="24.007122" fill="#333334" style="paint-order:fill markers stroke"/>
+  <rect transform="matrix(0,-1,-1,0,0,0)" x="-17" y="-39" width="23" height="39" color="#000001" fill="url(#a)"/>
 </svg>

--- a/res/skins/LateNight/decks/rate_controls.xml
+++ b/res/skins/LateNight/decks/rate_controls.xml
@@ -20,40 +20,32 @@
         <SizePolicy>min,me</SizePolicy>
         <Children>
 
-          <WidgetGroup><!-- BPM + rate + Tap overlay-->
-            <ObjectName>BpmRateTapContainer</ObjectName>
+          <!-- [BPM + rate + Tap overlay] + SyncBox -->
+          <!-- We want the BPM display/edit box to be aligned with the Sync controls.
+               Since size policies are hard to control with the stacked BPM display/edit layout,
+               we put this into a separate container. -->
+          <WidgetGroup>
+            <ObjectName>BpmTapSyncContainer</ObjectName>
             <Layout>vertical</Layout>
-            <SizePolicy>min,me</SizePolicy>
-            <MaximumSize>,46</MaximumSize>
+            <SizePolicy>min,min</SizePolicy>
             <Children>
+
               <WidgetGroup>
                 <ObjectName>BpmTapContainer</ObjectName>
-                <Layout>stacked</Layout>
-                <Size>57f,-1me</Size>
+                <!-- same width as total width of SyncBox children (40 + 22) -->
+                <Size>62f,42f</Size>
                 <Children>
-                  <!-- invisible Tempo/BPM tap button on top of BPM display -->
-                  <PushButton>
-                    <TooltipId>tempo_tap_bpm_tap_visual_bpm</TooltipId>
-                    <ObjectName>BpmTap</ObjectName>
-                    <Size>57f,-1me</Size>
-                    <NumberStates>1</NumberStates>
-                    <Connection>
-                      <ConfigKey><Variable name="Group"/>,tempo_tap</ConfigKey>
-                    </Connection>
-                    <Connection>
-                      <ConfigKey><Variable name="Group"/>,bpm_tap</ConfigKey>
-                      <ButtonState>RightButton</ButtonState>
-                    </Connection>
-                  </PushButton>
-                  <WidgetGroup><!-- BPM + rate -->
+                  <!-- BPM + rate -->
+                  <WidgetGroup>
                     <ObjectName>AlignCenter</ObjectName>
+                    <Pos>0,0</Pos>
                     <Layout>vertical</Layout>
-                    <Size>57f,-1me</Size>
+                    <Size>62f,-1me</Size>
                     <Children>
                       <Number>
                         <ObjectName>BpmText</ObjectName>
                         <TooltipId>visual_bpm</TooltipId>
-                        <Size>57f,22f</Size>
+                        <Size>62f,22f</Size>
                         <Alignment>center</Alignment>
                         <NumberOfDigits>2</NumberOfDigits>
                         <Connection>
@@ -69,43 +61,50 @@
                       </NumberRate>
                     </Children>
                   </WidgetGroup>
+                  <!-- invisible Tempo/BPM editor on top of BPM/rate displays -->
+                  <BpmEditor>
+                    <TooltipId>visual_bpm_edit</TooltipId>
+                    <Pos>0,0</Pos>
+                    <Size>62f,42f</Size>
+                    <Group><Variable name="Group"/></Group>
+                  </BpmEditor>
                 </Children>
-              </WidgetGroup>
-            </Children>
-          </WidgetGroup><!-- BpmRateTapContainer -->
+              </WidgetGroup><!-- BpmTapContainer -->
 
-          <WidgetGroup>
-            <ObjectName>SyncBox</ObjectName>
-            <Layout>horizontal</Layout>
-            <SizePolicy>min,min</SizePolicy>
-            <Children>
-              <PushButton>
-                <TooltipId>sync_enabled</TooltipId>
-                <ObjectName>SyncDeck</ObjectName>
-                <Size>40f,22f</Size>
-                <NumberStates>2</NumberStates>
-                <RightClickIsPushButton>true</RightClickIsPushButton>
-                <Connection>
-                  <ConfigKey><Variable name="Group"/>,sync_enabled</ConfigKey>
-                  <ButtonState>LeftButton</ButtonState>
-                </Connection>
-                <Connection>
-                  <ConfigKey><Variable name="Group"/>,sync_leader</ConfigKey>
-                  <ButtonState>RightButton</ButtonState>
-                </Connection>
-              </PushButton>
-              <PushButton>
-                <TooltipId>sync_leader</TooltipId>
-                <ObjectName>SyncLeader</ObjectName>
-                <Size>22f,22f</Size>
-                <NumberStates>3</NumberStates>
-                <Connection>
-                  <ConfigKey><Variable name="Group"/>,sync_leader</ConfigKey>
-                  <ButtonState>LeftButton</ButtonState>
-                </Connection>
-              </PushButton>
+              <WidgetGroup>
+                <ObjectName>SyncBox</ObjectName>
+                <Layout>horizontal</Layout>
+                <SizePolicy>min,min</SizePolicy>
+                <Children>
+                  <PushButton>
+                    <TooltipId>sync_enabled</TooltipId>
+                    <ObjectName>SyncDeck</ObjectName>
+                    <Size>40f,22f</Size>
+                    <NumberStates>2</NumberStates>
+                    <RightClickIsPushButton>true</RightClickIsPushButton>
+                    <Connection>
+                      <ConfigKey><Variable name="Group"/>,sync_enabled</ConfigKey>
+                      <ButtonState>LeftButton</ButtonState>
+                    </Connection>
+                    <Connection>
+                      <ConfigKey><Variable name="Group"/>,sync_leader</ConfigKey>
+                      <ButtonState>RightButton</ButtonState>
+                    </Connection>
+                  </PushButton>
+                  <PushButton>
+                    <TooltipId>sync_leader</TooltipId>
+                    <ObjectName>SyncLeader</ObjectName>
+                    <Size>22f,22f</Size>
+                    <NumberStates>3</NumberStates>
+                    <Connection>
+                      <ConfigKey><Variable name="Group"/>,sync_leader</ConfigKey>
+                      <ButtonState>LeftButton</ButtonState>
+                    </Connection>
+                  </PushButton>
+                </Children>
+              </WidgetGroup><!-- SyncBox -->
             </Children>
-          </WidgetGroup>
+          </WidgetGroup><!-- BpmTapSyncContainer -->
 
           <WidgetGroup><Size>0min,0me</Size></WidgetGroup>
 

--- a/res/skins/LateNight/decks/rate_controls_compact.xml
+++ b/res/skins/LateNight/decks/rate_controls_compact.xml
@@ -15,105 +15,171 @@
        </WidgetGroup>
 
       <WidgetGroup>
-        <ObjectName>BpmRateTapContainer</ObjectName>
+        <ObjectName>RateContainer</ObjectName>
         <Layout>vertical</Layout>
-        <SizePolicy>min,min</SizePolicy>
+        <SizePolicy>max,min</SizePolicy>
         <Children>
 
-          <WidgetGroup><!-- BPM + rate + Tap overlay-->
-            <ObjectName>BpmTapContainer</ObjectName>
-            <Layout>stacked</Layout>
-            <Size>60f,40f</Size>
+          <!-- [BPM + rate + Tap overlay] + SyncBox -->
+          <!-- We want the BPM display/edit box to be aligned with the Sync controls.
+               Since size policies are hard to control with the stacked BPM display/edit layout,
+               we put this into a separate container. -->
+          <WidgetGroup>
+            <ObjectName>BpmTapSyncContainer</ObjectName>
+            <Layout>vertical</Layout>
+            <SizePolicy>min,max</SizePolicy>
             <Children>
-              <!-- invisible Tempo/BPM tap button on top of BPM display -->
-              <PushButton>
-                <TooltipId>tempo_tap_bpm_tap_visual_bpm</TooltipId>
-                <ObjectName>BpmTap</ObjectName>
-                <SizePolicy>me,me</SizePolicy>
-                <NumberStates>1</NumberStates>
-                  <Connection>
-                    <ConfigKey><Variable name="Group"/>,tempo_tap</ConfigKey>
-                  </Connection>
-                  <Connection>
-                    <ConfigKey><Variable name="Group"/>,bpm_tap</ConfigKey>
-                    <ButtonState>RightButton</ButtonState>
-                  </Connection>
-              </PushButton>
-              <WidgetGroup><!-- BPM + rate -->
-                <ObjectName>AlignCenter</ObjectName>
-                <Layout>vertical</Layout>
-                <SizePolicy>me,me</SizePolicy>
-                <Children>
-                  <Number>
-                    <ObjectName>BpmText</ObjectName>
-                    <TooltipId>visual_bpm</TooltipId>
-                    <Size>-1me,22f</Size>
-                    <Alignment>center</Alignment>
-                    <NumberOfDigits>2</NumberOfDigits>
-                    <Connection>
-                      <ConfigKey><Variable name="Group"/>,visual_bpm</ConfigKey>
-                    </Connection>
-                  </Number>
-                  <NumberRate>
-                    <TooltipId>rate_display</TooltipId>
-                    <ObjectName>RateText</ObjectName>
-                    <Channel><Variable name="ChanNum" /></Channel>
-                    <Alignment>center</Alignment>
-                    <NumberOfDigits>2</NumberOfDigits>
-                  </NumberRate>
-                </Children>
-              </WidgetGroup><!-- BpmContainer + Tap overlay -->
-            </Children>
-          </WidgetGroup><!-- BpmContainer -->
 
-          <WidgetGroup><Size>0min,0me</Size></WidgetGroup>
+              <WidgetGroup>
+                <ObjectName>BpmTapContainer</ObjectName>
+                <!-- same width as total width of SyncBox children (40 + 22) -->
+                <Size>62f,42f</Size>
+                <Children>
+                  <!-- BPM + rate -->
+                  <WidgetGroup>
+                    <ObjectName>AlignCenter</ObjectName>
+                    <Pos>0,0</Pos>
+                    <Layout>vertical</Layout>
+                    <Size>62f,42f</Size>
+                    <Children>
+                      <Number>
+                        <ObjectName>BpmText</ObjectName>
+                        <TooltipId>visual_bpm</TooltipId>
+                        <Size>62f,22f</Size>
+                        <Alignment>center</Alignment>
+                        <NumberOfDigits>2</NumberOfDigits>
+                        <Connection>
+                          <ConfigKey><Variable name="Group"/>,visual_bpm</ConfigKey>
+                        </Connection>
+                      </Number>
+                      <NumberRate>
+                        <TooltipId>rate_display</TooltipId>
+                        <ObjectName>RateText</ObjectName>
+                        <Alignment>center</Alignment>
+                        <Channel><Variable name="ChanNum" /></Channel>
+                        <NumberOfDigits>2</NumberOfDigits>
+                      </NumberRate>
+                    </Children>
+                  </WidgetGroup>
+                  <!-- invisible Tempo/BPM editor on top of BPM/rate displays -->
+                  <BpmEditor>
+                    <TooltipId>visual_bpm_edit</TooltipId>
+                    <Pos>0,0</Pos>
+                    <Size>62f,42f</Size>
+                    <Group><Variable name="Group"/></Group>
+                  </BpmEditor>
+                </Children>
+              </WidgetGroup><!-- BpmTapContainer -->
+
+              <WidgetGroup>
+                <ObjectName>SyncBox</ObjectName>
+                <Layout>horizontal</Layout>
+                <SizePolicy>min,min</SizePolicy>
+                <Children>
+                  <PushButton>
+                    <TooltipId>sync_enabled</TooltipId>
+                    <ObjectName>SyncDeck</ObjectName>
+                    <Size>40f,22f</Size>
+                    <NumberStates>2</NumberStates>
+                    <RightClickIsPushButton>true</RightClickIsPushButton>
+                    <Connection>
+                      <ConfigKey><Variable name="Group"/>,sync_enabled</ConfigKey>
+                      <ButtonState>LeftButton</ButtonState>
+                    </Connection>
+                    <Connection>
+                      <ConfigKey><Variable name="Group"/>,sync_leader</ConfigKey>
+                      <ButtonState>RightButton</ButtonState>
+                    </Connection>
+                  </PushButton>
+                  <PushButton>
+                    <TooltipId>sync_leader</TooltipId>
+                    <ObjectName>SyncLeader</ObjectName>
+                    <Size>22f,22f</Size>
+                    <NumberStates>3</NumberStates>
+                    <Connection>
+                      <ConfigKey><Variable name="Group"/>,sync_leader</ConfigKey>
+                      <ButtonState>LeftButton</ButtonState>
+                    </Connection>
+                  </PushButton>
+                </Children>
+                <Connection>
+                  <ConfigKey persist="true">[LateNight],show_sync_button_compact</ConfigKey>
+                  <BindProperty>visible</BindProperty>
+                </Connection>
+              </WidgetGroup><!-- SyncBoxCompact -->
+            </Children>
+          </WidgetGroup><!-- BpmTapSyncContainer -->
+
+          <WidgetGroup><Size>0f,0me</Size></WidgetGroup>
 
           <WidgetGroup>
             <ObjectName>RateControls</ObjectName>
-            <SizePolicy>min,min</SizePolicy>
             <Layout>horizontal</Layout>
+            <SizePolicy>min,min</SizePolicy>
             <Children>
-              <!-- Rate controls with Sync button -->
-              <WidgetGroup>
-                <ObjectName>AlignCenter</ObjectName>
-                <SizePolicy>min,min</SizePolicy>
-                <Layout>vertical</Layout>
-                <Children>
-                  <WidgetGroup>
-                    <ObjectName>SyncBoxCompact</ObjectName>
-                    <Layout>horizontal</Layout>
-                    <SizePolicy>min,min</SizePolicy>
-                    <Children>
-                      <PushButton>
-                        <TooltipId>sync_enabled</TooltipId>
-                        <ObjectName>SyncDeck</ObjectName>
-                        <Size>40f,22f</Size>
-                        <NumberStates>2</NumberStates>
-                        <RightClickIsPushButton>true</RightClickIsPushButton>
-                        <Connection>
-                          <ConfigKey><Variable name="Group"/>,sync_enabled</ConfigKey>
-                          <ButtonState>LeftButton</ButtonState>
-                        </Connection>
-                        <Connection>
-                          <ConfigKey><Variable name="Group"/>,sync_leader</ConfigKey>
-                          <ButtonState>RightButton</ButtonState>
-                        </Connection>
-                      </PushButton>
-                      <PushButton>
-                        <TooltipId>sync_leader</TooltipId>
-                        <ObjectName>SyncLeader</ObjectName>
-                        <Size>22f,22f</Size>
-                        <NumberStates>3</NumberStates>
-                        <Connection>
-                          <ConfigKey><Variable name="Group"/>,sync_leader</ConfigKey>
-                          <ButtonState>LeftButton</ButtonState>
-                        </Connection>
-                      </PushButton>
-                    </Children>
-                  </WidgetGroup>
 
-                  <WidgetGroup><!-- Rate slider + range displays -->
-                    <ObjectName>RateSliderBoxCompactSync</ObjectName>
+              <WidgetStack currentpage="[LateNight],show_sync_button_compact" persist="true">
+                <ObjectName>RateStack<Variable name="Group"/></ObjectName>
+                <Children><!-- Rate slider + range displays with Sync button -->
+
+                  <WidgetGroup><!-- Rate controls (no Sync button) -->
+                    <ObjectName>RateSliderBoxCompact</ObjectName>
+                    <Size>59f,97f</Size>
+                    <Layout>stacked</Layout>
+                    <Children>
+                      <WidgetGroup><!-- Rate slider + center indicator -->
+                        <ObjectName></ObjectName>
+                        <Size>54f,97f</Size>
+                        <Children>
+                          <Label>
+                            <ObjectName>RateCenter</ObjectName>
+                            <Size>5f,5f</Size>
+                            <Pos>7,47</Pos>
+                            <Connection>
+                              <ConfigKey><Variable name="Group"/>,rate_set_default</ConfigKey>
+                              <BindProperty>highlight</BindProperty>
+                            </Connection>
+                          </Label>
+
+                          <SliderComposed>
+                            <ObjectName>RateSlider</ObjectName>
+                            <Size>40f,95f</Size>
+                            <Pos>10,2</Pos>
+                            <TooltipId>rate</TooltipId>
+                            <Handle scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="SliderScheme"/>/sliders/knob_pitch_deck.svg</Handle>
+                            <Slider scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="SliderScheme"/>/sliders/slider_pitch_deck_compact.svg</Slider>
+                            <Horizontal>false</Horizontal>
+                            <BarWidth><Variable name="BarWidth"/></BarWidth>
+                            <BarMargins><Variable name="BarMarginPitch"/></BarMargins>
+                            <BarColor><Variable name="BarColorPitch"/></BarColor>
+                            <BarRoundCaps>true</BarRoundCaps>
+                            <BarAxisPos>20.0</BarAxisPos>
+                            <BarUnipolar>false</BarUnipolar>
+                            <Connection>
+                              <ConfigKey><Variable name="Group"/>,rate</ConfigKey>
+                            </Connection>
+                          </SliderComposed>
+                        </Children>
+                      </WidgetGroup><!-- Rate slider + center indicator -->
+
+                      <WidgetGroup><!-- Rate range indicators -->
+                        <SizePolicy>min,me</SizePolicy>
+                        <Layout>vertical</Layout>
+                        <Children>
+                          <SingletonContainer>
+                            <ObjectName>RateRangeDisplayTop<Variable name="ChanNum"/></ObjectName>
+                          </SingletonContainer>
+                          <WidgetGroup><Size>0min,0me</Size></WidgetGroup>
+                          <SingletonContainer>
+                            <ObjectName>RateRangeDisplayBottom<Variable name="ChanNum"/></ObjectName>
+                          </SingletonContainer>
+                        </Children>
+                      </WidgetGroup><!-- Rate range indicators -->
+                    </Children>
+                  </WidgetGroup><!-- Rate controls (no Sync button) -->
+
+                  <WidgetGroup trigger="[LateNight],show_sync_button_compact" on_hide_select="0"><!-- Rate slider + range displays with Sync button -->
+                    <ObjectName>RateSliderBoxCompact</ObjectName>
                     <Layout>stacked</Layout>
                     <SizePolicy>max,me</SizePolicy>
                     <Children>
@@ -124,7 +190,7 @@
                           <Label>
                             <ObjectName>RateCenter</ObjectName>
                             <Size>5f,5f</Size>
-                            <Pos>2,39</Pos>
+                            <Pos>7,39</Pos>
                             <Connection>
                               <ConfigKey><Variable name="Group"/>,rate_set_default</ConfigKey>
                               <BindProperty>highlight</BindProperty>
@@ -133,7 +199,7 @@
                           <SliderComposed>
                             <ObjectName>RateSlider</ObjectName>
                             <Size>40f,79f</Size>
-                            <Pos>5,2</Pos>
+                            <Pos>10,2</Pos>
                             <TooltipId>rate</TooltipId>
                             <Handle scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="SliderScheme"/>/sliders/knob_pitch_deck.svg</Handle>
                             <Slider scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="SliderScheme"/>/sliders/slider_pitch_deck_compact_sync.svg</Slider>
@@ -165,78 +231,15 @@
                         </Children>
                       </WidgetGroup><!-- Rate range indicators -->
                     </Children>
-                  </WidgetGroup><!-- Rate slider + range displays -->
+                  </WidgetGroup>
+
                 </Children>
-                <Connection>
-                  <ConfigKey persist="true">[LateNight],show_sync_button_compact</ConfigKey>
-                  <BindProperty>visible</BindProperty>
-                </Connection>
-              </WidgetGroup><!-- Rate controls with Sync button -->
+              </WidgetStack>
 
-              <WidgetGroup><!-- Rate controls (no Sync button) -->
-                <ObjectName>RateSliderBoxCompact</ObjectName>
-                <SizePolicy>max,min</SizePolicy>
-                <Layout>stacked</Layout>
-                <Children>
-                  <WidgetGroup><!-- Rate slider + center indicator -->
-                    <ObjectName></ObjectName>
-                    <Size>54f,97f</Size>
-                    <Children>
-                      <Label>
-                        <ObjectName>RateCenter</ObjectName>
-                        <Size>5f,5f</Size>
-                        <Pos>2,47</Pos>
-                        <Connection>
-                          <ConfigKey><Variable name="Group"/>,rate_set_default</ConfigKey>
-                          <BindProperty>highlight</BindProperty>
-                        </Connection>
-                      </Label>
-
-                      <SliderComposed>
-                        <ObjectName>RateSlider</ObjectName>
-                        <Size>40f,95f</Size>
-                        <Pos>5,2</Pos>
-                        <TooltipId>rate</TooltipId>
-                        <Handle scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="SliderScheme"/>/sliders/knob_pitch_deck.svg</Handle>
-                        <Slider scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="SliderScheme"/>/sliders/slider_pitch_deck_compact.svg</Slider>
-                        <Horizontal>false</Horizontal>
-                        <BarWidth><Variable name="BarWidth"/></BarWidth>
-                        <BarMargins><Variable name="BarMarginPitch"/></BarMargins>
-                        <BarColor><Variable name="BarColorPitch"/></BarColor>
-                        <BarRoundCaps>true</BarRoundCaps>
-                        <BarAxisPos>20.0</BarAxisPos>
-                        <BarUnipolar>false</BarUnipolar>
-                        <Connection>
-                          <ConfigKey><Variable name="Group"/>,rate</ConfigKey>
-                        </Connection>
-                      </SliderComposed>
-                    </Children>
-                  </WidgetGroup><!-- Rate slider + center indicator -->
-
-                  <WidgetGroup><!-- Rate range indicators -->
-                    <SizePolicy>min,me</SizePolicy>
-                    <Layout>vertical</Layout>
-                    <Children>
-                      <SingletonContainer>
-                        <ObjectName>RateRangeDisplayTop<Variable name="ChanNum"/></ObjectName>
-                      </SingletonContainer>
-                      <WidgetGroup><Size>0min,0me</Size></WidgetGroup>
-                      <SingletonContainer>
-                        <ObjectName>RateRangeDisplayBottom<Variable name="ChanNum"/></ObjectName>
-                      </SingletonContainer>
-                    </Children>
-                  </WidgetGroup><!-- Rate range indicators -->
-                </Children>
-                <Connection>
-                  <ConfigKey persist="true">[LateNight],show_sync_button_compact</ConfigKey>
-                  <Transform><Not/></Transform>
-                  <BindProperty>visible</BindProperty>
-                </Connection>
-              </WidgetGroup><!-- Rate controls (no Sync button) -->
             </Children>
           </WidgetGroup><!-- RateControls -->
 
-          <WidgetGroup><Size>0min,0me</Size></WidgetGroup>
+          <WidgetGroup><Size>0f,0me</Size></WidgetGroup>
 
         </Children>
       </WidgetGroup>

--- a/res/skins/LateNight/palemoon/buttons/btn__bpm_select_edit.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__bpm_select_edit.svg
@@ -1,0 +1,5 @@
+<svg width="32" height="32" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <path d="m8 3.75v8.5" fill="none" stroke="#a89a8c" stroke-width="1.5"/>
+  <path d="m5.5 3.75h5" fill="none" stroke="#a89a8c" stroke-width="1.5"/>
+  <path d="m5.5 12.25h5" fill="none" stroke="#a89a8c" stroke-width="1.5"/>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__bpm_select_tap.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__bpm_select_tap.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+  <ellipse cx="8" cy="8" rx="5.3454823" ry="5.4031892" fill="none" stroke="#a89a8c" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="0" stroke-width="1.5" style="paint-order:fill markers stroke"/>
+  <ellipse cx="8" cy="8" rx="1.8907727" ry="1.9140049" fill="#a89a8c" style="paint-order:fill markers stroke"/>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__bpm_spinbox_minus.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__bpm_spinbox_minus.svg
@@ -1,0 +1,6 @@
+<svg width="60" height="32" version="1.1" viewBox="0 0 30 16" xmlns="http://www.w3.org/2000/svg">
+  <path d="m10 7h9v3h-9z" fill="none" stroke="#000001" stroke-linecap="square" stroke-linejoin="round" stroke-width="1.6"/>
+  <path d="m10 7h9v3h-9z" fill="#8e8276"/>
+  <rect x="29" y="1" width="1" height="15" fill="#1b1b1d" style="paint-order:fill markers stroke"/>
+  <rect width="30" height="1" fill="#242426" style="paint-order:fill markers stroke"/>
+</svg>

--- a/res/skins/LateNight/palemoon/buttons/btn__bpm_spinbox_plus.svg
+++ b/res/skins/LateNight/palemoon/buttons/btn__bpm_spinbox_plus.svg
@@ -1,0 +1,7 @@
+<svg width="60" height="32" version="1.1" viewBox="0 0 30 16" xmlns="http://www.w3.org/2000/svg">
+  <path d="m11 7h3v-3h3v3h3v3h-3v3h-3v-3h-3z" fill="none" stroke="#000001" stroke-linecap="square" stroke-linejoin="round" stroke-width="1.6"/>
+  <path d="m11 7h3v-3h3v3h3v3h-3v3h-3v-3h-3z" fill="#8e8276"/>
+  <rect width="30" height="1" fill="#242426" style="paint-order:fill markers stroke"/>
+  <rect width="1" height="16" style="paint-order:fill markers stroke"/>
+  <rect x="1" y="1" width="1" height="15" fill="#1b1b1d" style="paint-order:fill markers stroke"/>
+</svg>

--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -13,6 +13,7 @@ WTrackProperty,
 WRecordingDuration,
 QSpinBox,
 WBeatSpinBox,
+WBpmEditor QDoubleSpinBox,
 WCueMenuPopup,
 WCueMenuPopup QLabel,
 WCueMenuPopup QLineEdit,
@@ -476,14 +477,9 @@ WSpinny { /*
 #SyncBox {
   qproperty-layoutAlignment: 'AlignHCenter | AlignTop';
 }
-#BpmRateTapContainer {
-  margin: 1px;
-}
 
 #RateControls {
   qproperty-layoutAlignment: 'AlignHCenter | AlignBottom';
-}
-#RateSliderBoxCompactSync {
   margin-left: 5px;
 }
 
@@ -493,6 +489,18 @@ WTrackProperty[selected="false"] {
   border: 0px solid transparent;
   border-radius: 1px;
 }
+
+#BpmClickOverlay,
+#BpmTapButton,
+#BpmTapButton:focus {
+  background-color: transparent;
+}
+WBpmEditor,
+#BpmClickOverlay {
+  border: none;
+}
+
+
 /************** Decks  ********************************************************/
 
 

--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -88,11 +88,20 @@ WLibrary,
 WTrackProperty:hover,
 WTrackProperty:hover[selected="false"],
 WTrackProperty:hover[selected="true"],
-#BpmTapContainer:hover {
+#BpmTapContainer:hover,
+#BpmTapSelectButton,
+#BpmEditSelectButton {
   background-color: #151517;
   border-radius: 1px;
   }
-  #BpmTap[pressed="true"] {
+  #BpmTapSelectButton {
+    image: url(skins:LateNight/classic/buttons/btn__bpm_select_tap.svg) no-repeat center center;
+  }
+  #BpmEditSelectButton {
+    border-left: 0px;
+    image: url(skins:LateNight/classic/buttons/btn__bpm_select_edit.svg) no-repeat left top;
+  }
+  #BpmTapButton[pressed="true"] {
    border: 1px solid #7d350d;
   }
 
@@ -287,16 +296,13 @@ WSearchLineEdit,
   }
 
 WBeatSpinBox,
+WBpmEditor QDoubleSpinBox,
 #spinBoxTransition  {
   selection-color: #000;
   selection-background-color: #d2d2d2;
   }
-  WBeatSpinBox:focus  {
-    selection-color: #000;
-    selection-background-color: #d2d2d2;
-  }
   WBeatSpinBox:focus,
-  #spinBoxTransition:focus {
+  WBpmEditor QDoubleSpinBox:focus  {
     background-color: #000;
   }
 
@@ -604,7 +610,7 @@ WLibrary {
 /************** RateControls ********************************************/
 
 #RateContainer {
-  padding: 4px 0px 0px 0px;
+  padding: 2px 0px 0px 0px;
   }
 
   #RateText {
@@ -612,8 +618,8 @@ WLibrary {
     margin: 0px;
   }
 
-  #SyncBox {
-    margin: 2px 1px 1px 2px;
+  #BpmTapSyncContainer {
+    margin: 0px 2px 1px 2px;
   }
 
   #RateControls {
@@ -627,12 +633,16 @@ WLibrary {
 
 /********************** Loop Controls / AutoDJ spinbox ************************/
 
+WBeatSpinBox,
+WBpmEditor QDoubleSpinBox,
+#spinBoxTransition {
+  background-color: #0f0f0f;
+  }
   WBeatSpinBox {
     border-width: 2px 19px 2px 2px;
     border-image: url(skins:LateNight/classic/buttons/spinbox_elevated_border.svg) 2 19 2 2;
     margin: 1px 0px 0px 1px;
     padding: 0px -17px 2px 1px;
-    background-color: #0f0f0f;
     }
     WBeatSpinBox:focus {
       border-image: url(skins:LateNight/classic/buttons/spinbox_elevated_border_focus.svg) 2 19 2 2;
@@ -645,7 +655,6 @@ WLibrary {
     height: 19px;
     padding: 0px -15px 0px 0px;
     margin: 0px 2px 3px 5px;
-    background-color: #0f0f0f;
     }
     #spinBoxTransition:focus {
       border-image: url(skins:LateNight/classic/buttons/spinbox_embedded_border_focus_orange.svg) 3 19 2 3;
@@ -693,6 +702,54 @@ WLibrary {
       #spinBoxTransition::down-button {
         margin: 0px -3px -1px 0px;
         }
+
+
+WBpmEditor {
+  padding: 0px;
+  margin: 0px;
+  border: none;
+}
+WBpmEditor QDoubleSpinBox,
+WBpmEditor QDoubleSpinBox:focus {
+  border-image: none;
+  border: 1px solid #d08e00;
+  border-radius: 2px;
+  margin: 0px;
+  /* top/bottom padding is required to make room for the buttons! */
+  padding: 2px 0px 16px 0px;
+  font-size: 14px/14px;
+}
+WBpmEditor QDoubleSpinBox QLineEdit {
+  text-align: center;
+}
+
+WBpmEditor QDoubleSpinBox::up-button,
+WBpmEditor QDoubleSpinBox::down-button {
+  subcontrol-origin: padding;
+  subcontrol-position: bottom;
+  position: absolute;
+  height: 16px;
+  width: 30px;
+  background-color: #171719;
+}
+WBpmEditor QDoubleSpinBox::up-button {
+  image: url(skins:LateNight/classic/buttons/btn__bpm_spinbox_plus.svg) no-repeat;
+  bottom: 0px;
+  left: 30px;
+  right: 0px;
+  }
+  WBpmEditor QDoubleSpinBox::up-button:pressed {
+    image: url(skins:LateNight/classic/buttons/btn__bpm_spinbox_plus_pressed.svg) no-repeat;
+  }
+WBpmEditor QDoubleSpinBox::down-button {
+  bottom: 0px;
+  left: 0px;
+  right: 30px;
+  image: url(skins:LateNight/classic/buttons/btn__bpm_spinbox_minus.svg) no-repeat;
+  }
+  WBpmEditor QDoubleSpinBox::down-button:pressed {
+    image: url(skins:LateNight/classic/buttons/btn__bpm_spinbox_minus_pressed.svg) no-repeat;
+  }
 
 
 
@@ -1208,7 +1265,9 @@ WSearchLineEdit QAbstractScrollArea,
 #fadeModeCombobox:!editable,
 #fadeModeCombobox:!editable:on,
 #fadeModeCombobox QAbstractScrollArea,
-WBeatSpinBox, #spinBoxTransition,
+WBeatSpinBox,
+#spinBoxTransition,
+WBpmEditor QDoubleSpinBox,
 #LibraryFeatureControls QLabel,
 #LibraryFeatureControls QRadioButton {
   color: #888;
@@ -1634,7 +1693,6 @@ QPushButton#pushButtonAnalyze:checked {
 WPushButton#PlayDeck[displayValue="0"],
 WPushButton#PlayDeckMini[displayValue="0"],
 WPushButton#PlaySampler[displayValue="0"],
-WPushButton#BpmTap[displayValue="0"],
 WPushButton#FxFocusButton[displayValue="0"],
 #SamplerSettings WPushButton[displayValue="0"],
 #SamplerSettingsMini WPushButton[displayValue="0"],
@@ -2242,13 +2300,23 @@ WLibrary QPlainTextEdit,
 #LibraryBPMSpinBox,
 /* Track label inline editor in decks and samplers */
 WTrackPropertyEditor,
-WTrackProperty[selected="true"] {
+WTrackProperty[selected="true"],
+#BpmTapSelectButton, #BpmEditSelectButton {
   color: #ddd;
   background-color: #0f0f0f;
   selection-color: #000;
   selection-background-color: #ccc;
   border: 1px solid #5E4507;
 }
+#BpmTapSelectButton {
+  border-right: 0px;
+}
+#BpmTapButton {
+  border: 1px solid #5E4507;
+  }
+  #BpmTapButton:pressed {
+    border: 1px solid #d08e00;
+  }
 
 /* Entire BPM cell */
 /* Lock icon at the left */

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -353,6 +353,8 @@ WTrackProperty:hover[selected="false"],
 WTrackProperty:hover[selected="true"],
 WTrackProperty[selected="true"],
 #BpmTapContainer:hover,
+#BpmTapSelectButton,
+#BpmEditSelectButton,
 #PlayPositionText:hover, #PlayPositionTextSmall:hover {
   background-color: #151517;
   }
@@ -360,10 +362,21 @@ WTrackProperty[selected="true"],
   WTrackProperty[selected="true"] {
     background-color: #181819;
   }
-  #BpmTap[pressed="true"],
-  WTrackProperty[selected="true"] {
+  WTrackProperty[selected="true"],
+  #BpmTapSelectButton,
+  #BpmEditSelectButton,
+  #BpmTapButton {
     border: 1px solid #7d350d;
-/*    border: 1px solid #888;*/
+  }
+  #BpmTapSelectButton {
+    border-right: 0px;
+    image: url(skins:LateNight/palemoon/buttons/btn__bpm_select_tap.svg) no-repeat center center;
+  }
+  #BpmEditSelectButton {
+    image: url(skins:LateNight/palemoon/buttons/btn__bpm_select_edit.svg) no-repeat left top;
+  }
+  #BpmTapButton:pressed {
+    border: 1px solid #257b82;
   }
 
 /* Disabled for now since the hover effect is stuck as soon as the
@@ -640,7 +653,7 @@ WTrackProperty[selected="true"],
 /************** RateControls ********************************************/
 
 #RateContainer {
-  padding: 4px 0px 0px 0px;
+  padding: 2px 0px 0px 0px;
   }
 
   #RateText {
@@ -648,8 +661,8 @@ WTrackProperty[selected="true"],
     margin: 0px 2px 0px 0px;
   }
 
-#SyncBox {
-  margin: 2px 1px 1px 2px;
+#BpmTapSyncContainer {
+  margin: 0px 2px 1px 2px;
 }
 
 #RateControls {
@@ -659,11 +672,13 @@ WTrackProperty[selected="true"],
 
 /********************** Loop Controls / AutoDJ spinbox ************************/
 WBeatSpinBox,
+WBpmEditor QDoubleSpinBox,
 #spinBoxTransition {
   selection-color: #a7998b;
   selection-background-color: #111;
   }
   WBeatSpinBox:focus,
+  WBpmEditor QDoubleSpinBox:focus,
   #spinBoxTransition:focus,
   #LibraryBPMSpinBox:focus  {
     selection-color: #000;
@@ -675,6 +690,7 @@ WBeatSpinBox {
   border-width: 3px 19px 2px 3px;
   border-image: url(skins:LateNight/palemoon/buttons/btn_embedded_spinbox.svg) 3 19 2 3;
 }
+
 #spinBoxTransition {
   width: 24px;
   height: 19px;
@@ -682,11 +698,11 @@ WBeatSpinBox {
   margin: 0px 2px 3px 5px;
   border-width: 3px 19px 2px 3px;
   border-image: url(skins:LateNight/palemoon/buttons/btn_embedded_spinbox_autodj.svg) 3 19 2 3;
-  }
-  WBeatSpinBox:focus,
-  #spinBoxTransition:focus {
-    border-image: url(skins:LateNight/palemoon/buttons/btn_embedded_spinbox_focus_blue.svg) 3 19 2 3;
-  }
+}
+WBeatSpinBox:focus,
+#spinBoxTransition:focus {
+  border-image: url(skins:LateNight/palemoon/buttons/btn_embedded_spinbox_focus_blue.svg) 3 19 2 3;
+}
 
 WBeatSpinBox::up-button,
 WBeatSpinBox::down-button,
@@ -694,34 +710,74 @@ WBeatSpinBox::down-button,
 #spinBoxTransition::down-button {
   subcontrol-origin: content;
   position: relative;
-  /* as with spinbox: border is added to size. */
-  width: 18px;
   padding: 0px;
+  width: 18px;
   }
+
   WBeatSpinBox::up-button,
   #spinBoxTransition::up-button {
-    height: 11px;
     subcontrol-position: top right;
     image: url(skins:LateNight/palemoon/buttons/btn__spinbox_up.svg) no-repeat;
+    height: 11px;
     }
     WBeatSpinBox::up-button {
       margin: -2px -1px 0px 0px;
-      }
+    }
     #spinBoxTransition::up-button {
       margin: -2px -3px 0px 0px;
-      }
+    }
+
   WBeatSpinBox::down-button,
   #spinBoxTransition::down-button {
-    height: 11px;
     subcontrol-position: bottom right;
     image: url(skins:LateNight/palemoon/buttons/btn__spinbox_down.svg) no-repeat;
+    height: 11px;
+    margin: 0px -1px -3px 0px;
     }
-    WBeatSpinBox::down-button {
-      margin: 0px -1px -3px 0px;
-      }
     #spinBoxTransition::down-button {
       margin: 0px -3px -1px 0px;
-      }
+    }
+
+WBpmEditor {
+  padding: 0px;
+  margin: 0px;
+  border: none;
+}
+WBpmEditor QDoubleSpinBox,
+WBpmEditor QDoubleSpinBox:focus {
+  border-image: none;
+  border: 1px solid #257b82;
+  border-radius: 2px;
+  margin: 0px;
+  /* top/bottom padding is required to make room for the buttons! */
+  padding: 2px 0px 16px 0px;
+  font-size: 14px/14px;
+}
+WBpmEditor QDoubleSpinBox QLineEdit {
+  text-align: center;
+}
+
+WBpmEditor QDoubleSpinBox::up-button,
+WBpmEditor QDoubleSpinBox::down-button {
+  subcontrol-origin: padding;
+  subcontrol-position: bottom;
+  position: absolute;
+  height: 16px;
+  width: 30px;
+  background-color: #171719;
+}
+WBpmEditor QDoubleSpinBox::up-button {
+  image: url(skins:LateNight/palemoon/buttons/btn__bpm_spinbox_plus.svg) no-repeat;
+  bottom: 0px;
+  left: 30px;
+  right: 0px;
+  }
+WBpmEditor QDoubleSpinBox::down-button {
+  bottom: 0px;
+  left: 0px;
+  right: 30px;
+  image: url(skins:LateNight/palemoon/buttons/btn__bpm_spinbox_minus.svg) no-repeat;
+}
 
 
 /************** Mixer ***************************************************/
@@ -1297,6 +1353,7 @@ WEffectChainPresetSelector:!editable:on,
   }
 
   WBeatSpinBox,
+  WBpmEditor QDoubleSpinBox,
   #spinBoxTransition {
     color: #a7998b;
   }
@@ -1493,8 +1550,6 @@ WEffectSelector:!editable,
   border-width: 2px;
   border-image: url(skins:LateNight/palemoon/buttons/btn_embedded_library.svg) 2 2 2 2;
   }
-  /*
-  WPushButton#BpmTap[displayValue="1"], */
   WPushButton#VinylStatus[displayValue="1"],
   WPushButton#VinylStatus[displayValue="2"],
   WPushButton#VinylStatus[displayValue="3"],
@@ -1607,7 +1662,8 @@ WPushButton#FxToggleButton[displayValue="0"],
 #MicDuckingContainer WPushButton[displayValue="0"],
 WBeatSpinBox,
 WBeatSpinBox::up-button,
-WBeatSpinBox::down-button {
+WBeatSpinBox::down-button,
+WBpmEditor QDoubleSpinBox {
   background-color: #121213;
   }
   /* dim buttons in top-level containers */
@@ -1737,7 +1793,9 @@ WPushButton#VinylStatus[displayValue="1"], /* enabled, OK */
   }
 /* Blue for Fx buttons 3/4 */
 #FxUnit3 #FxToggleButton[displayValue="1"],
-#FxUnit4 #FxToggleButton[displayValue="1"]
+#FxUnit4 #FxToggleButton[displayValue="1"],
+WBpmEditor QDoubleSpinBox::up-button:pressed,
+WBpmEditor QDoubleSpinBox::down-button:pressed,
 WBeatSpinBox::up-button:pressed,
 WBeatSpinBox::down-button:pressed,
 #spinBoxTransition::up-button:pressed,

--- a/src/skin/legacy/legacyskinparser.h
+++ b/src/skin/legacy/legacyskinparser.h
@@ -80,7 +80,7 @@ class LegacySkinParser : public QObject, public SkinParser {
 #ifdef __STEM__
     QWidget* parseStemLabelWidget(const QDomElement& element);
 #endif
-
+    QWidget* parseBpmEditor(const QDomElement& node);
     QWidget* parseText(const QDomElement& node);
     QWidget* parseTrackProperty(const QDomElement& node);
     QWidget* parseStarRating(const QDomElement& node);

--- a/src/skin/legacy/tooltips.cpp
+++ b/src/skin/legacy/tooltips.cpp
@@ -401,12 +401,16 @@ void Tooltips::addStandardTooltips() {
             << tr("Holds the gain of the low EQ to zero while active.")
             << eqKillLatch;
 
-    QString tempoDisplay = tr("Displays the tempo of the loaded track in BPM (beats per minute).");
+    const QString tempoDisplay =
+            tr("Displays the tempo of the loaded track in BPM (beats per "
+               "minute).");
     // TODO Clarify this refers to 'file BPM', not playback rate?
-    QString bpmTapButton = tr("When tapped repeatedly, adjusts the BPM to match the tapped BPM.");
-    QString tempoTapButton =
+    const QString bpmTapButton = tr(
+            "When tapped repeatedly, adjusts the BPM to match the tapped BPM.");
+    const QString tempoTapButton =
             tr("When tapped repeatedly, adjusts the tempo to match the tapped "
                "BPM.");
+    const QString bpmTempoEdit = tr("Click to open the tempo/BPM editor");
     add("visual_bpm")
             << tr("Tempo")
             << tempoDisplay;
@@ -416,6 +420,9 @@ void Tooltips::addStandardTooltips() {
             << tr("Key")
             << tr("Displays the current musical key of the loaded track after pitch shifting.");
 
+    add("visual_bpm_edit")
+            << tempoDisplay
+            << bpmTempoEdit;
     add("bpm_tap")
             << tr("BPM Tap")
             << bpmTapButton;
@@ -426,6 +433,10 @@ void Tooltips::addStandardTooltips() {
             << tr("Rate Tap and BPM Tap")
             << QString("%1: %2").arg(leftClick, tempoTapButton)
             << QString("%1: %2").arg(rightClick, bpmTapButton);
+    add("tempo_edit")
+            << tr("Set Tempo")
+            << tr("Set the desired tempo in BPM. If the track currently has no BPM detected, "
+                  "set the desired tempo in percent.");
 
     add("beats_adjust_slower")
             << tr("Adjust BPM Down")

--- a/src/widget/wbpmeditor.cpp
+++ b/src/widget/wbpmeditor.cpp
@@ -1,0 +1,326 @@
+#include <widget/wbpmeditor.h>
+
+#include <QHBoxLayout>
+#include <QMouseEvent>
+#include <QStackedLayout>
+
+#include "control/controlobject.h"
+#include "moc_wbpmeditor.cpp"
+#include "skin/legacy/skincontext.h"
+
+namespace {
+// Intervals for the hide timer
+// Use same timeout as the WTrackProperty select timer for consistency
+const int kHoverLeaveTimeout = 2000;
+const int kInactiveTimeout = 5000;
+
+// Property name for the BPM/rate spinbox
+const char* kOrigVal("originalValue");
+const double kBpmStepSize = 1.0;
+const double kRateStepSize = 0.01; // +- 1 %
+
+} // anonymous namespace
+
+void TapPushButton::mousePressEvent(QMouseEvent* e) {
+    if (e->type() == QEvent::MouseButtonPress && e->button() == Qt::RightButton) {
+        emit rightClicked();
+        return;
+    }
+    QPushButton::mousePressEvent(e);
+}
+
+void BpmSpinBox::stepBy(int steps) {
+    QDoubleSpinBox::stepBy(steps);
+    emit stepped(steps);
+}
+
+WBpmEditor::WBpmEditor(const QString& group, QWidget* pParent)
+        : WWidget(pParent),
+          m_tempoTapCO(group, QStringLiteral("tempo_tap")),
+          m_bpmTapCO(group, QStringLiteral("bpm_tap")),
+          // FIXME make it a ControlProxy to quit editor when track is unloaded so we
+          // don't accidentally set the file BPM while 'somehow' the track is swapped?
+          m_trackLoadedCO(group, QStringLiteral("track_loaded")),
+          m_bpmCO(group, QStringLiteral("bpm")),
+          m_fileBpmCO(group, QStringLiteral("file_bpm")),
+          m_rateRatioCO(group, QStringLiteral("rate_ratio")),
+          m_pClickOverlay(nullptr),
+          m_pSelectWidget(nullptr),
+          m_pTapSelectButton(nullptr),
+          m_pEditSelectButton(nullptr),
+          m_pTapButton(nullptr),
+          m_pEditBox(nullptr),
+          m_spinboxDecimals(2) {
+    setContentsMargins(0, 0, 0, 0);
+    setFocusPolicy(Qt::NoFocus);
+    // Setup the layout with the mode selectors (Tap|Edit), tap button and
+    // tempo editor. Only one of these widgets can be visible.
+    m_pClickOverlay = make_parented<QPushButton>(this);
+    m_pClickOverlay->setObjectName(QStringLiteral("BpmClickOverlay"));
+    m_pClickOverlay->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    m_pClickOverlay->setFocusPolicy(Qt::NoFocus);
+    m_pClickOverlay->installEventFilter(this);
+    connect(m_pClickOverlay.get(),
+            &QPushButton::clicked,
+            this,
+            [this]() { switchMode(Mode::Select); });
+
+    m_pTapSelectButton = make_parented<QPushButton>(this);
+    m_pTapSelectButton->setObjectName(QStringLiteral("BpmTapSelectButton"));
+    m_pTapSelectButton->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    m_pTapSelectButton->setFocusPolicy(Qt::NoFocus);
+    m_pTapSelectButton->installEventFilter(this);
+    connect(m_pTapSelectButton.get(),
+            &QPushButton::clicked,
+            this,
+            [this]() { switchMode(Mode::Tap); });
+
+    m_pEditSelectButton = make_parented<QPushButton>(this);
+    m_pEditSelectButton->setObjectName(QStringLiteral("BpmEditSelectButton"));
+    m_pEditSelectButton->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    m_pEditSelectButton->setFocusPolicy(Qt::NoFocus);
+    m_pEditSelectButton->installEventFilter(this);
+    connect(m_pEditSelectButton.get(),
+            &QPushButton::clicked,
+            this,
+            [this]() { switchMode(Mode::Edit); });
+
+    m_pSelectWidget = make_parented<QWidget>(this);
+    m_pSelectWidget->installEventFilter(this);
+    m_pSelectWidget->setFocusPolicy(Qt::NoFocus);
+    auto pSelectLayout = std::make_unique<QHBoxLayout>();
+    pSelectLayout->setAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
+    pSelectLayout->setContentsMargins(0, 0, 0, 0);
+    pSelectLayout->setSpacing(0);
+    pSelectLayout->setSizeConstraint(QLayout::SetNoConstraint);
+    pSelectLayout->addWidget(m_pTapSelectButton.get());
+    pSelectLayout->addWidget(m_pEditSelectButton.get());
+    pSelectLayout->update();
+    pSelectLayout->activate();
+    m_pSelectWidget->setLayout(pSelectLayout.release());
+
+    m_pTapButton = make_parented<TapPushButton>(this);
+    m_pTapButton->setObjectName(QStringLiteral("BpmTapButton"));
+    m_pTapButton->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    connect(m_pTapButton.get(),
+            &QPushButton::clicked,
+            this,
+            [this]() {
+                // Tap engine BPM
+                m_hideTimer.start(kInactiveTimeout);
+                m_tempoTapCO.set(1.0);
+                m_tempoTapCO.set(0.0);
+            });
+    connect(m_pTapButton.get(),
+            &TapPushButton::rightClicked,
+            this,
+            [this]() {
+                // Tap file BPM
+                m_hideTimer.start(kInactiveTimeout);
+                m_bpmTapCO.set(1.0);
+                m_bpmTapCO.set(0.0);
+            });
+
+    m_pEditBox = make_parented<BpmSpinBox>(this);
+    m_pEditBox->setObjectName(QStringLiteral("EditBox"));
+    m_pEditBox->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    m_pEditBox->setLineeditAlignment(Qt::AlignHCenter | Qt::AlignTop);
+    // Step size, min and max are set when the spinbox is set up in switchMode().
+    // Stepping via Up/Down or scroll wheel is applied immediately.
+    connect(m_pEditBox.get(),
+            &BpmSpinBox::stepped,
+            this,
+            &WBpmEditor::applySpinboxSteps);
+    // Use the event filter to catch Enter/Return presses to apply manually
+    // entered values and close the editor, as well as Esc to quit.
+    m_pEditBox->installEventFilter(this);
+    // Note: don't connect to &QDoubleSpinBox::editingFinished as that would call
+    // the apply slot twice: first when Enter is pressed and again when the spinbox
+    // is hidden (FocusOut/hide event when the current widget is switched).
+
+    m_pModeLayout = make_parented<QStackedLayout>(this);
+    m_pModeLayout->setAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
+    m_pModeLayout->setContentsMargins(0, 0, 0, 0);
+    m_pModeLayout->setSpacing(0);
+    m_pModeLayout->setSizeConstraint(QLayout::SetNoConstraint);
+    m_pModeLayout->addWidget(m_pClickOverlay.get());
+    m_pModeLayout->addWidget(m_pSelectWidget.get());
+    m_pModeLayout->addWidget(m_pTapButton.get());
+    m_pModeLayout->addWidget(m_pEditBox.get());
+    m_pModeLayout->setCurrentWidget(m_pClickOverlay.get());
+    setLayout(m_pModeLayout.get());
+    layout()->update();
+    layout()->activate();
+
+    // The hide timer is started when switching to Select mode, in Tap mode when
+    // the cursor leaves the Tap button or after N seconds of inactivity.
+    m_hideTimer.setSingleShot(true);
+    m_hideTimer.callOnTimeout(this, [this]() { switchMode(Mode::Listen); });
+    installEventFilter(this);
+}
+
+void WBpmEditor::setup(const QDomNode& node, const SkinContext& context) {
+    Q_UNUSED(context);
+
+    // Number of digits after the decimal.
+    context.hasNodeSelectInt(node, "NumberOfDigits", &m_spinboxDecimals);
+    m_pEditBox->setDecimals(m_spinboxDecimals);
+
+    // TODO Check if we need to set the scale factor for the spinbox
+    // double scaleFactor = context.getScaleFactor();
+    // setScaleFactor(scaleFactor);
+    // m_pEditBox->setsc >setScaleFactor(scaleFactor);
+}
+
+void WBpmEditor::setTapButtonTooltip(const QString& tooltip) {
+    m_pTapSelectButton.get()->setToolTip(tooltip);
+    m_pTapButton.get()->setToolTip(tooltip);
+}
+
+void WBpmEditor::setEditButtonTooltip(const QString& tooltip) {
+    m_pEditSelectButton.get()->setToolTip(tooltip);
+    m_pEditBox.get()->setToolTip(tooltip);
+}
+
+bool WBpmEditor::eventFilter(QObject* pObj, QEvent* pEvent) {
+    if (pObj == m_pEditBox.get() && pEvent->type() == QEvent::KeyPress) {
+        // Esc will close & reset.
+        // Any other keypress is forwarded.
+        QKeyEvent* keyEvent = static_cast<QKeyEvent*>(pEvent);
+        if (keyEvent->key() == Qt::Key_Escape) {
+            switchMode(Mode::Listen);
+            return true;
+        } else if (keyEvent->key() == Qt::Key_Enter ||
+                keyEvent->key() == Qt::Key_Return) {
+            applySpinboxValueAndQuit();
+        }
+    } else if (pEvent->type() == QEvent::HoverEnter) {
+        m_hideTimer.stop();
+    } else if (pEvent->type() == QEvent::HoverLeave &&
+            pObj != m_pEditBox.get()) {
+        // Don't auto-quit the spinbox when while it focus
+        m_hideTimer.start(kHoverLeaveTimeout);
+    } else if (pEvent->type() == QEvent::FocusOut) {
+        // Only the spinbox can have focus - quit and discard pending changes
+        switchMode(Mode::Listen);
+    }
+    return QWidget::eventFilter(pObj, pEvent);
+}
+
+void WBpmEditor::startEditMode() {
+    double fileBpm = m_fileBpmCO.get();
+    // The `rateRange` ControlPotmeter allows 1-400 %.
+    // For rate % these are the limits, for BPM the lower limit is 1 (to keep
+    // the track playing)
+    if (fileBpm == 0.0) { // Rate mode
+        // Track has currently no BPM so we'll control the rate.
+        // Note that this might change while we edit the rate, so we set
+        // the '%' suffix (and we'll use it to detect BPM/rate mode when
+        // committing the new value).
+        // Also, clamp like rateRange.
+        double currRate = m_rateRatioCO.get();
+        m_pEditBox->setSuffix(" %");
+        m_pEditBox->setMinimum(1);
+        m_pEditBox->setMaximum(400);
+        m_pEditBox->setSingleStep(kRateStepSize);
+        m_pEditBox->setValue(currRate * 100);
+        // The value may be cropped/rounded if the decimals don't fit in the box.
+        // Store the rounded value for comparison when committing
+        m_pEditBox->setProperty(kOrigVal, m_pEditBox->value());
+    } else { // BPM mode
+        double currBpm = m_bpmCO.get();
+        m_pEditBox->setSuffix("");
+        m_pEditBox->setMinimum(1);
+        m_pEditBox->setMaximum(fileBpm * 4);
+        m_pEditBox->setSingleStep(kBpmStepSize);
+        m_pEditBox->setValue(currBpm);
+        // The value may be cropped/rounded if the decimals don't fit in the box.
+        // Store the rounded value for comparison when attempting to apply typed values.
+        m_pEditBox->setProperty(kOrigVal, m_pEditBox->value());
+    }
+
+    m_pModeLayout->setCurrentWidget(m_pEditBox.get());
+    m_pEditBox->setFocus();
+    m_pEditBox->selectAll();
+}
+
+void WBpmEditor::applySpinboxSteps(int steps) {
+    // This ignores the spinbox value after Up/Down steps and applies +- steps
+    // sto the COs directly.
+    // The purpose is to allow us to return to the initial BPM/rate, eg. center,
+    // with Up/Down steps (without intermediate manual changes).
+    // With default QDoubleSpinBox behavior this does not work due to rounding.
+
+    if (m_pEditBox->suffix().isEmpty()) {
+        // No suffix means we're in BPM mode
+        double newValue = m_bpmCO.get() + (steps * kBpmStepSize);
+        m_bpmCO.set(newValue);
+        m_pEditBox->setValue(newValue);
+    } else {
+        // Rate mode
+        double newValue = m_rateRatioCO.get() + (steps * kRateStepSize);
+        m_rateRatioCO.set(newValue);
+        m_pEditBox->setValue(newValue * 100);
+    }
+    m_pEditBox->setProperty(kOrigVal, m_pEditBox->value());
+}
+
+void WBpmEditor::applySpinboxValueAndQuit() {
+    // Filter no-op: avoid shifting rate/BPM due to rounding when the
+    // original value has more decimals than the spinbox can display
+    const QVariant origValueVar = m_pEditBox->property(kOrigVal);
+    VERIFY_OR_DEBUG_ASSERT(origValueVar.isValid() && origValueVar.canConvert<double>()) {
+        // Something went wrong during spinbox setup, quit.
+        // This property is cleared when switching to Listen mode.
+        switchMode(Mode::Listen);
+        return;
+    }
+
+    double origValue = origValueVar.toDouble();
+    double newValue = m_pEditBox->value();
+
+    // Note: this comparison should suffice, no need for epsilon check to
+    // account for floating point imprecision, eg. like this
+    // fabs(newValue - origValue) < (1 / pow(10, m_spinboxDecimals))
+    if (newValue == origValue) {
+        switchMode(Mode::Listen);
+        return;
+    }
+
+    if (m_pEditBox->suffix().isEmpty()) {
+        // No suffix means we're in BPM mode
+        m_bpmCO.set(newValue);
+    } else {
+        // Rate mode
+        m_rateRatioCO.set(newValue / 100);
+    }
+
+    switchMode(Mode::Listen);
+}
+
+void WBpmEditor::switchMode(Mode mode) {
+    m_hideTimer.stop();
+    if (!m_trackLoadedCO.toBool()) {
+        mode = Mode::Listen;
+    }
+    switch (mode) {
+    case Mode::Select:
+        m_pModeLayout->setCurrentWidget(m_pSelectWidget.get());
+        return;
+    case Mode::Tap:
+        m_pModeLayout->setCurrentWidget(m_pTapButton.get());
+        return;
+    case Mode::Edit: {
+        startEditMode();
+        return;
+    }
+    case Mode::Listen:
+    default:
+        m_pEditBox->setProperty(kOrigVal, QVariant());
+        m_pModeLayout->setCurrentWidget(m_pClickOverlay.get());
+        ControlObject::set(ConfigKey(QStringLiteral("[Library]"),
+                                   QStringLiteral("refocus_prev_widget")),
+                1);
+        return;
+    }
+}

--- a/src/widget/wbpmeditor.h
+++ b/src/widget/wbpmeditor.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <QDoubleSpinBox>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QTimer>
+
+#include "control/pollingcontrolproxy.h"
+#include "util/parented_ptr.h"
+#include "widget/wwidget.h"
+
+class QPushButton;
+class QDoubleSpinBox;
+class QStackedLayout;
+class SkinContext;
+
+// Custom PushButton which emits a custom signal when right-clicked
+class TapPushButton : public QPushButton {
+    Q_OBJECT
+  public:
+    explicit TapPushButton(QWidget* parent = 0)
+            : QPushButton(parent) {
+    }
+
+  protected:
+    void mousePressEvent(QMouseEvent* e) override;
+
+  signals:
+    void rightClicked();
+};
+
+class BpmSpinBox : public QDoubleSpinBox {
+    Q_OBJECT
+  public:
+    explicit BpmSpinBox(QWidget* pParent = 0)
+            : QDoubleSpinBox(pParent) {
+    }
+
+    void setLineeditAlignment(QFlags<enum Qt::AlignmentFlag> flags) {
+        lineEdit()->setAlignment(flags);
+    }
+  signals:
+    void stepped(int steps);
+
+  private:
+    void stepBy(int steps) override;
+};
+
+class WBpmEditor : public WWidget {
+    Q_OBJECT
+  public:
+    explicit WBpmEditor(const QString& group, QWidget* pParent = nullptr);
+
+    void setup(const QDomNode& node, const SkinContext& context);
+
+    enum class Mode {
+        Listen,
+        Select,
+        Tap,
+        Edit,
+    };
+
+    void setTapButtonTooltip(const QString& tooltip);
+    void setEditButtonTooltip(const QString& tooltip);
+
+  private slots:
+    void switchMode(Mode mode);
+
+  private:
+    bool eventFilter(QObject* pObj, QEvent* pEvent) override;
+    void startEditMode();
+    void applySpinboxSteps(int steps);
+    void applySpinboxValueAndQuit();
+
+    PollingControlProxy m_tempoTapCO;
+    PollingControlProxy m_bpmTapCO;
+    PollingControlProxy m_trackLoadedCO;
+    PollingControlProxy m_bpmCO;
+    PollingControlProxy m_fileBpmCO;
+    PollingControlProxy m_rateRatioCO;
+
+    parented_ptr<QStackedLayout> m_pModeLayout;
+    parented_ptr<QPushButton> m_pClickOverlay;
+    parented_ptr<QWidget> m_pSelectWidget;
+    parented_ptr<QPushButton> m_pTapSelectButton;
+    parented_ptr<QPushButton> m_pEditSelectButton;
+    parented_ptr<TapPushButton> m_pTapButton;
+    parented_ptr<BpmSpinBox> m_pEditBox;
+
+    QTimer m_hideTimer;
+
+    int m_spinboxDecimals;
+};


### PR DESCRIPTION
Closes #12086 and #14611 

Combines the current BPM display/tap stack with a spinbox for tempo.
The Select mode is auto-quit 2 s after the pointer leaves the widget, for Tap mode this happens after 5 s of inactivity.

* **initial state:** invisible overlay with hover effect
* **click:** activate 'select' mode, show Tap and Edit button
* **Tap:** enable tap button
left-click: tap tempo
right-click: tap track BPM
* **Edit:** shows tempo spinbox
enter desired tempo, apply with Enter. Cancel with Esc and when another widget gets keyboard focus.

![bpm-combo-widget](https://github.com/user-attachments/assets/b6b15512-4898-44bc-ad50-1c6238983819)




___

For now this is available  only in LateNight, styled only in PaleMoon.
I'll keep testing it and polish every now and then.

Some more ideas, regarding UX and more functions:
* do we just want to enter numbers or strings like "nnn %" or "3/4" (for polyrhythm sync)?
* should the spinbox/lineedit update when the BPM change?

### TODO
- [ ] style in LateNight Classic
- [ ] Test with touch devices?