### PR TITLE
vinyl control: remove too-slow settling of pitch display

### DIFF
--- a/src/vinylcontrol/vinylcontrolxwax.cpp
+++ b/src/vinylcontrol/vinylcontrolxwax.cpp
@@ -586,13 +586,10 @@ void VinylControlXwax::analyzeSamples(CSAMPLE* pSamples, size_t nFrames) {
                 // For large changes in pitch (start/stop, usually), immediately
                 // update the display.
                 m_dDisplayPitch = averagePitch;
-            } else if (fabs(pitch_difference) > 0.005) {
-                // For medium changes in pitch, take 4 callback loops to
+            } else {
+                // For other changes in pitch, take 4 callback loops to
                 // converge on the correct amount.
                 m_dDisplayPitch += pitch_difference * .25;
-            } else {
-                // For extremely small changes, converge very slowly.
-                m_dDisplayPitch += pitch_difference * .01;
             }
             // Don't show extremely high or low speeds in the UI.
             if (reportedPlayButton && !scratching->toBool() &&


### PR DESCRIPTION
The vinyl control pitch display pegged too hard to incorrect values, making it seem like Mixxx was playing back tracks at the wrong speed. Instead, quickly converge on the correct average pitch at the expense of noisy bpm display. None of this affects actual playback speed, which is always taken exactly from xwax's value.
    
  