### PR TITLE
vinyl control: remove track selection mode

### DIFF
--- a/src/vinylcontrol/vinylcontrolxwax.cpp
+++ b/src/vinylcontrol/vinylcontrolxwax.cpp
@@ -57,11 +57,6 @@ VinylControlXwax::VinylControlXwax(UserSettingsPointer pConfig, const QString& g
           m_pSteadySubtle(nullptr),
           m_pSteadyGross(nullptr),
           m_bCDControl(false),
-          m_bTrackSelectMode(false),
-          m_pControlTrackSelector(nullptr),
-          m_pControlTrackLoader(nullptr),
-          m_dLastTrackSelectPos(0.0),
-          m_dCurTrackSelectPos(0.0),
           m_dDriftAmt(0.0),
           m_initialRelativeDriftAmt(0.0),
           m_deltaRelativeDriftAmount(0.0),
@@ -271,7 +266,6 @@ void VinylControlXwax::analyzeSamples(CSAMPLE* pSamples, size_t nFrames) {
     double duration_inaccurate = duration->get();
     if (duration_inaccurate != m_dOldDurationInaccurate) {
         m_bForceResync = true;
-        m_bTrackSelectMode = false; //just in case
         m_dOldDurationInaccurate = duration_inaccurate;
         m_dOldDuration = trackSamples->get() / 2 / trackSampleRate->get();
 
@@ -370,61 +364,6 @@ void VinylControlXwax::analyzeSamples(CSAMPLE* pSamples, size_t nFrames) {
                 vinylStatus->set(VINYL_STATUS_WARNING);
             } else {
                 vinylStatus->set(VINYL_STATUS_DISABLED);
-            }
-        }
-    }
-
-    //check here for position > safe, and if no record end mode,
-    //then trigger track selection mode.  just pass position to it
-    //and ignore pitch
-
-    if (!m_bAtRecordEnd) {
-        if (m_iPosition != -1 && m_iPosition > static_cast<int>(m_uiSafeZone)) {
-            //only enable if pitch is steady, though.  Heavy scratching can
-            //produce crazy results and trigger this mode
-            if (m_bTrackSelectMode || checkSteadyPitch(dVinylPitch, filePosition) > 0.1) {
-                //until I can figure out how to detect "track 2" on serato CD,
-                //don't try track selection
-                if (!m_bCDControl) {
-                    if (!m_bTrackSelectMode) {
-                        qDebug() << "position greater than safe, select mode" << m_iPosition << m_uiSafeZone;
-                        m_bTrackSelectMode = true;
-                        togglePlayButton(false);
-                        resetSteadyPitch(0.0, 0.0);
-                        m_pVCRate->set(0.0);
-                    }
-                    doTrackSelection(true, dVinylPitch, m_iPosition);
-                }
-
-                //hm I wonder if track will keep playing while this happens?
-                //not sure what we want to do here...  probably enforce
-                //stopped deck.
-
-                //but if constant mode...  nah, force stop.
-                return;
-            }
-            //if it's not steady yet we process as normal
-        } else {
-            //so we're not unsafe.... but
-            //if no position, but we were in select mode, do select mode
-            if (m_iPosition == -1 && m_bTrackSelectMode) {
-                //qDebug() << "no position, but were in select mode";
-                doTrackSelection(false, dVinylPitch, m_iPosition);
-
-                //again, force stop?
-                return;
-            } else if (m_bTrackSelectMode) {
-                //qDebug() << "discontinuing select mode, selecting track";
-                if (m_pControlTrackLoader == nullptr) {
-                    m_pControlTrackLoader = new ControlProxy(
-                            m_group, "LoadSelectedTrack", this);
-                }
-
-                m_pControlTrackLoader->set(1.0);
-                m_pControlTrackLoader->set(0.0); // I think I have to do this...
-
-                // if position is known and safe then no track select mode
-                m_bTrackSelectMode = false;
             }
         }
     }
@@ -687,52 +626,6 @@ void VinylControlXwax::togglePlayButton(bool on) {
         playButton->set((float)on); //and we all float on all right
     }
 }
-
-void VinylControlXwax::doTrackSelection(bool valid_pos, double pitch, double position) {
-    //compare positions, fabricating if we don't have position data, and
-    //move the selector every so often
-    //track will be selected when the needle is moved back to play area
-    //track selection can be cancelled by loading a track manually
-
-    constexpr int SELECT_INTERVAL = 150;
-    constexpr double NOPOS_SPEED = 0.50;
-
-    if (m_pControlTrackSelector == nullptr) {
-        // this isn't done in the constructor because this object
-        // doesn't seem to be created yet
-        m_pControlTrackSelector = new ControlProxy(
-                "[Playlist]","SelectTrackKnob", this);
-    }
-
-    if (!valid_pos) {
-        if (fabs(pitch) > 0.1) {
-            //how to estimate how far the record has moved when we don't have a valid
-            //position and no mp3 track to compare with???  just add a bullshit amount?
-            m_dCurTrackSelectPos += pitch * NOPOS_SPEED; //MADE UP CONSTANT, needs to be based on frames per second I think
-        } else {
-            // too slow, do nothing
-            return;
-        }
-    } else {
-        // if we have valid pos, use it
-        m_dCurTrackSelectPos = position;
-    }
-
-
-    //we have position or at least record is moving, so check if we should
-    //change location
-
-    if (fabs(m_dCurTrackSelectPos - m_dLastTrackSelectPos) > 10.0 * 1000) {
-        //yeah probably not a valid value
-        //qDebug() << "large change in track position, resetting";
-        m_dLastTrackSelectPos = m_dCurTrackSelectPos;
-    } else if (fabs(m_dCurTrackSelectPos - m_dLastTrackSelectPos) > SELECT_INTERVAL) {
-        //only adjust by one at a time.  It's no help jumping around
-        m_pControlTrackSelector->set((int)(m_dCurTrackSelectPos - m_dLastTrackSelectPos) / fabs(m_dCurTrackSelectPos - m_dLastTrackSelectPos));
-        m_dLastTrackSelectPos = m_dCurTrackSelectPos;
-    }
-}
-
 
 void VinylControlXwax::resetSteadyPitch(double pitch, double time) {
     m_pSteadySubtle->reset(pitch, time);

--- a/src/vinylcontrol/vinylcontrolxwax.h
+++ b/src/vinylcontrol/vinylcontrolxwax.h
@@ -123,18 +123,6 @@ class VinylControlXwax : public VinylControl {
     // Whether the configured timecode is CD-based or not.
     bool m_bCDControl;
 
-    // Whether track select mode is enabled.
-    bool m_bTrackSelectMode;
-
-    // Controls for manipulating the library.
-    ControlProxy* m_pControlTrackSelector;
-    ControlProxy* m_pControlTrackLoader;
-
-    // The previous and current track select position. Used for track selection
-    // using the control region.
-    double m_dLastTrackSelectPos;
-    double m_dCurTrackSelectPos;
-
     // The drift between the vinyl position and the file position from the most
     // recent run of analyzeSamples.
     double m_dDriftAmt;


### PR DESCRIPTION
this was supported by Serato but is very confusing to people and not really needed.  Let's remove it.