### PR TITLE
Pitch filter improvement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4899,6 +4899,7 @@ if(VINYLCONTROL)
       lib/xwax/lut_mk2.c
       lib/xwax/filters.c
       lib/xwax/delayline.c
+      lib/xwax/pitch_kalman.c
   )
   target_include_directories(mixxx-xwax SYSTEM PUBLIC lib/xwax)
   target_link_libraries(mixxx-lib PRIVATE mixxx-xwax)

--- a/lib/xwax/pitch_kalman.c
+++ b/lib/xwax/pitch_kalman.c
@@ -1,0 +1,236 @@
+#include <math.h>
+
+#include "pitch_kalman.h"
+
+enum { x = 0, v = 1 }; /* Matrix indices: x = position and v = velocity */
+
+static inline double pow2(double val)
+{
+    return (val * val);
+}
+
+static inline double pow3(double val)
+{
+    return (val * val * val);
+}
+
+/*
+ * Initialize the filter with dt, the coefficients and thresholds for
+ * the different mode switches
+ *
+ * q: acceleration noise spectral density (tune up if motion is more jittery)
+ * r: variance of dx measurement (tune up if observations are noisier)
+ */
+
+void pitch_kalman_init(struct pitch_kalman* p, double dt,
+        struct kalman_coeffs stable, struct kalman_coeffs medium, struct kalman_coeffs reactive,
+        double medium_threshold, double reactive_threshold)
+{
+    if (!p || medium_threshold > reactive_threshold) {
+        errno = EINVAL;
+        perror(__func__);
+        return;
+    }
+
+    /* Sampling interval */
+
+    p->dt = dt;
+
+    /* State space (position and velocity)*/
+
+    p->Xk[x] = 0.0;
+    p->Xk[v] = 0.0;
+
+    /*
+     * Start with large uncertainty so the filter trusts early measurements.
+     *
+     * NOTE: P[v][x] is unused and therefore not initialized
+     */
+
+    p->P[x][x] = 1e6;
+    p->P[x][v] = 0.0;
+    p->P[v][v] = 1e6;
+
+    /* Fixed thresholds for the mode switches */
+
+    p->reactive_threshold = reactive_threshold;
+    p->medium_threshold = medium_threshold;
+
+    /* Q and R for the different modes */
+
+    p->stable = stable;
+    p->medium = medium;
+    p->reactive = reactive;
+
+    /* Initialize as reactive */
+
+    kalman_tune_sensitivity(p, &p->reactive);
+}
+
+/*
+ * Feed one observation: in the last dt seconds, position moved by dx
+ */
+
+void pitch_kalman_update(struct pitch_kalman* p, double dx)
+{
+    if (!p) {
+        errno = EINVAL;
+        perror(__func__);
+        return;
+    }
+
+    /* Sampling interval */
+
+    const double dt = p->dt;
+    /*
+
+     * =================== Prediction step =====================
+     *
+     * State transition for constant-velocity model:
+     *   F = [ 1  dt
+     *         0  1 ]
+     *
+     * Discretizing, the process noise covariance is:
+     *   Q = q x [ dt^3/3  dt^2/2
+     *             dt^2/2  dt     ]
+     *
+     * Here p->coeffs->Q is 'q', the acceleration noise variance.
+     *
+     * Q[v][x] is not needed for the computations, therefore we put 0.0.
+     */
+
+    const double F[2][2] = { { 1.0,   dt },
+                             { 0.0,  1.0 }};
+
+    const double Q[2][2] = { { p->coeffs->Q * (pow3(dt) / 3.0),  p->coeffs->Q * (pow2(dt) / 2.0) },
+                             {                             0.0,  p->coeffs->Q * dt               }};
+
+    /* Predict state */
+
+    const double X_pred[2] = { p->Xk[x] + p->Xk[v] * dt, p->Xk[v] };
+
+    /*
+     * Predict covariance: P_pred = F x P x F^T + Q
+     * For 2×2 P and F, expand each term explicitly:
+     *
+     *   P00_pred = F00 * (F00 * P00 + F01 * P01) + F01 * (F00 * P01 + F01 * P11) + Q00
+     *   P01_pred = F10 * (F00 * P00 + F01 * P01) + F11 * (F00 * P01 + F01 * P11) + Q01
+     *   P11_pred = F10 * (F10 * P00 + F11 * P01) + F11 * (F10 * P01 + F11 * P11) + Q11
+     *
+     * This preserves symmetry while avoiding full matrix multiplication.
+     */
+
+    const double P[2][2] = { {p->P[x][x], p->P[x][v]},
+                             {       0.0, p->P[v][v]} };
+
+    double P_pred[2][2];
+
+    P_pred[x][x] = F[x][x] * (F[x][x] * P[x][x] + F[x][v] * P[x][v]) +
+                   F[x][v] * (F[x][x] * P[x][v] + F[x][v] * P[v][v]) + Q[x][x];
+
+    P_pred[x][v] = F[v][x] * (F[x][x] * P[x][x] + F[x][v] * P[x][v]) +
+                   F[v][v] * (F[x][x] * P[x][v] + F[x][v] * P[v][v]) + Q[x][v];
+
+    P_pred[v][v] = F[v][x] * (F[v][x] * P[x][x] + F[v][v] * P[x][v]) +
+                   F[v][v] * (F[v][x] * P[x][v] + F[v][v] * P[v][v]) + Q[v][v];
+
+    /*
+     * =================== Update step =======================
+     *
+     *   Measurement model: z = Hx + noise
+     *   Here H = [1 0], so z = x + noise
+     *
+     *   Innovation (residual): y = z - H * X_pred[x]
+     *   Since Hx = 1, Hv = 0, this reduces to: y = dx - X_pred[x]
+     */
+
+    const double y = dx - X_pred[x];
+
+    /*
+     * Toggle mode switches for stable playback and scratching. When the
+     * innovation quantity hits a certain treshold the filter sensitivity
+     * is tuned.
+     *
+     * The innovation is similar to the residual in the alpha-beta filter,
+     * calculated as
+     *
+     *          residual = measurement - prediction
+     *
+     * It represents how much the actual measurement deviates from the
+     * predicted value.
+     *
+     * NOTE: The innovation is a noisy quantity. The switches have been worked
+     *       out to ensure proper playback. If we should ever decide to use a
+     *       continuous curve instead of hard switches, we should probably
+     *       smooth the innovation before.
+     */
+
+    const double y_abs = fabs(y);
+
+    if (y_abs > p->reactive_threshold)
+        kalman_tune_sensitivity(p, &p->reactive);
+    else if (y_abs > p->medium_threshold && y_abs < p->reactive_threshold)
+        kalman_tune_sensitivity(p, &p->medium);
+    else
+        kalman_tune_sensitivity(p, &p->stable);
+
+    /* Ensure reactivity and quick decay after standstill */
+
+    if (fabs(p->Xk[v]) < 5e-2)
+        kalman_tune_sensitivity(p, &p->reactive);
+
+    /*
+     * Innovation covariance: S = H * P_pred * H^T + R
+     * With H = [1 0], this reduces to: S = P_pred[x][x] + R
+     */
+
+    const double S = P_pred[x][x] + p->coeffs->R;
+
+    /*
+     * Kalman gain: K = P_pred * H^T * S^-1
+     *
+     * With H = [1 0]:
+     *   K[x] = P_pred[x][x] / S
+     *   K[v] = P_pred[x][v] / S
+     */
+
+    const double invS = 1.0 / S;
+    const double K[2] = {P_pred[x][x] * invS, P_pred[x][v] * invS};
+
+    /*
+     * Update state:
+     *
+     * X_upd[x] = X_pred[x] + K[x] * y
+     * X_upd[v] = X_pred[v] + K[v] * y
+     */
+
+    double X_upd[2] = {X_pred[x] + K[x] * y, X_pred[v] + K[v] * y};
+
+    /*
+     * Update covariance: P = (I - K H) * P_pred
+     *
+     * H = [1 0], so:
+     *
+     *   I - K x H = [ 1-K[x]  0
+     *                  -K[v]  1 ]
+     */
+
+    double P_upd[2][2];
+
+    P_upd[x][x] = (1.0 - K[x]) * P_pred[x][x];
+    P_upd[x][v] = (1.0 - K[x]) * P_pred[x][v]; /* equals P_upd[x] */
+    P_upd[v][v] = P_pred[v][v] - K[v] * P_pred[x][v];
+
+    /* Keep the same “relative position” convention as the Alpha-Beta filter */
+
+    X_upd[x] -= dx;
+
+    /* Store updated state and covariance */
+
+    p->Xk[x] = X_upd[x];
+    p->Xk[v] = X_upd[v];
+
+    p->P[x][x] = P_upd[x][x];
+    p->P[x][v] = P_upd[x][v];
+    p->P[v][v] = P_upd[v][v];
+}

--- a/lib/xwax/pitch_kalman.h
+++ b/lib/xwax/pitch_kalman.h
@@ -1,0 +1,112 @@
+/*
+ * Kalman filter pitch estimator with sensitivity mode switches
+ *
+ * Model: Constant velocity (x, v) with acceleration process noise
+ *
+ * State:
+ *   x : Position (s) relative to the predicted trajectory
+ *   v : Velocity (dimensionless) relative to the carrier frequency of the timecode (normalized)
+ *
+ * Assumption: We steadily advance with a constant velocity
+ *
+ *   dx: The displacement of the position by which we advanced (s).
+ *       When crossing a zero this is 1/4 of cycle of the sinusoid
+ *       (π/2) quantized to the resolution of the timecode.
+ *
+ *       When not crossing a zero, a displacement of 0.0 is passed,
+ *       which signifies no movement and lets the velocity decay slowly
+ *       until the next zero crossing is encountered.
+ *
+ * Observation:
+ *   z = dx (new measurement after the interval dt)
+ *
+ * Modes:
+ *   stable  : Low Q and high R for stable playback
+ *   medium  : Medium values for slight pitch changes
+ *   reactive: High Q and low R for high reactivity (scratching)
+ */
+
+#ifndef PITCH_KALMAN_H
+#define PITCH_KALMAN_H
+
+#include <errno.h>
+#include <stdio.h>
+
+/* Struct for the Kalman filter coefficients R and Q */
+
+struct kalman_coeffs {
+    double Q;
+    double R;
+};
+
+#define KALMAN_COEFFS(q_arg, r_arg) \
+    (struct kalman_coeffs) {.Q = (q_arg), .R = (r_arg)}
+
+struct pitch_kalman {
+    /*
+     * NOTE: In discrete time dt is usually denoted as Ts = 1/Fs,
+     * but xwax uses the continuous notation.
+     */
+
+    double dt; /* Sampling interval: (s) */
+
+    double Xk[2]; /* Position and velocity state space */
+
+    /* Covariance P (2x2, symmetric) */
+
+    double P[2][2];
+
+    /* Tresholds of the innovation quantity for the mode switches */
+
+    double reactive_threshold, medium_threshold;
+
+    /* Currently used coefficients*/
+
+    struct kalman_coeffs* coeffs;
+
+    /* Stable, medium reactive coefficients for the mode switch */
+
+    struct kalman_coeffs stable;
+    struct kalman_coeffs medium;
+    struct kalman_coeffs reactive;
+};
+
+void pitch_kalman_init(struct pitch_kalman* p, double dt, struct kalman_coeffs stable,
+        struct kalman_coeffs medium, struct kalman_coeffs reactive,
+        double medium_threshold, double reactive_threshold);
+void pitch_kalman_update(struct pitch_kalman* p, double dx);
+
+/*
+ * Retune noise sensitivity without resetting state
+ */
+
+static inline void kalman_tune_sensitivity(struct pitch_kalman* p, struct kalman_coeffs* coeffs)
+{
+    if (!p || !coeffs) {
+        errno = EINVAL;
+        perror(__func__);
+        return;
+    }
+
+    p->coeffs = coeffs;
+}
+
+
+/*
+ * Get the current pitch (velocity estimate)
+ */
+
+static inline double pitch_kalman_current(const struct pitch_kalman* p)
+{
+    if (!p) {
+        errno = EINVAL;
+        perror(__func__);
+        return 0.0;
+    }
+
+    /* Return the velocity Xk[v] relative to carrier frequency of the timecode (normalized) */
+
+    return p->Xk[1];
+}
+
+#endif /* PITCH_KALMAN_H */

--- a/lib/xwax/timecoder.c
+++ b/lib/xwax/timecoder.c
@@ -416,7 +416,7 @@ static void init_channel(struct timecode_def *def, struct timecoder_channel *ch)
  */
 
 void timecoder_init(struct timecoder *tc, struct timecode_def *def,
-                    double speed, unsigned int sample_rate, bool phono)
+                    double speed, unsigned int sample_rate, bool phono, bool pitch_estimator)
 {
     assert(def != NULL);
 
@@ -438,7 +438,7 @@ void timecoder_init(struct timecoder *tc, struct timecode_def *def,
     init_channel(tc->def, &tc->primary);
     init_channel(tc->def, &tc->secondary);
 
-    tc->use_legacy_pitch_filter = false; /* Switch for pitch filter type */
+    tc->use_legacy_pitch_filter = pitch_estimator; /* Switch for pitch filter type */
 
     if (tc->use_legacy_pitch_filter) {
         pitch_init(&tc->pitch, tc->dt);

--- a/lib/xwax/timecoder.c
+++ b/lib/xwax/timecoder.c
@@ -19,6 +19,8 @@
 
 #include <assert.h>
 #include <limits.h>
+#include <pitch.h>
+#include <pitch_kalman.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -435,7 +437,19 @@ void timecoder_init(struct timecoder *tc, struct timecode_def *def,
     tc->forwards = 1;
     init_channel(tc->def, &tc->primary);
     init_channel(tc->def, &tc->secondary);
-    pitch_init(&tc->pitch, tc->dt);
+
+    tc->use_legacy_pitch_filter = false; /* Switch for pitch filter type */
+
+    if (tc->use_legacy_pitch_filter) {
+        pitch_init(&tc->pitch, tc->dt);
+    } else {
+        pitch_kalman_init(&tc->pitch_kalman, tc->dt,
+                KALMAN_COEFFS(1e-8, 10.0), /* stable mode */
+                KALMAN_COEFFS(1e-4, 1e-1), /* medium mode */
+                KALMAN_COEFFS(1e-1, 1e-4), /* reactive mode */
+                6e-4,   /* medium threshold  */
+                15e-4); /* reactive threshold  */
+    }
 
     tc->ref_level = INT_MAX;
     tc->bitstream = 0;
@@ -659,18 +673,32 @@ static void process_sample(struct timecoder *tc,
         }
     }
 
-    /* If any axis has been crossed, register movement using the pitch
-     * counters */
+    /*
+     * If any axis has been crossed, register movement using the pitch
+     * counters. This occurs four time per cycle of the sinusoid.
+     */
 
     if (!tc->primary.swapped && !tc->secondary.swapped)
-	pitch_dt_observation(&tc->pitch, 0.0);
+        if (tc->use_legacy_pitch_filter)
+            pitch_dt_observation(&tc->pitch, 0.0);
+        else
+            pitch_kalman_update(&tc->pitch_kalman, 0.0);
     else {
-	double dx;
+        double dx;
 
-	dx = 1.0 / tc->def->resolution / 4;
-	if (!tc->forwards)
-	    dx = -dx;
-	pitch_dt_observation(&tc->pitch, dx);
+        /*
+         * Assumption: We advance 1 / carrier_frequency / 4, which
+         * is exactly a quarter of the cycle
+         */
+
+        dx = 1.0 / tc->def->resolution / 4;
+        if (!tc->forwards)
+            dx = -dx;
+
+        if (tc->use_legacy_pitch_filter)
+            pitch_dt_observation(&tc->pitch, dx);
+        else
+            pitch_kalman_update(&tc->pitch_kalman, dx);
     }
 
     /* If we have crossed the primary channel in the right polarity,

--- a/lib/xwax/timecoder.h
+++ b/lib/xwax/timecoder.h
@@ -26,6 +26,7 @@
 #include "lut.h"
 #include "lut_mk2.h"
 #include "pitch.h"
+#include "pitch_kalman.h"
 #include "delayline.h"
 
 #define TIMECODER_CHANNELS 2
@@ -100,7 +101,10 @@ struct timecoder {
 
     bool forwards;
     struct timecoder_channel primary, secondary;
+
+    bool use_legacy_pitch_filter;
     struct pitch pitch;
+    struct pitch_kalman pitch_kalman;
 
     /* Numerical timecode */
 
@@ -151,7 +155,10 @@ static inline struct timecode_def* timecoder_get_definition(struct timecoder *tc
 
 static inline double timecoder_get_pitch(struct timecoder *tc)
 {
-    return pitch_current(&tc->pitch) / tc->speed;
+    if (tc->use_legacy_pitch_filter)
+        return pitch_current(&tc->pitch) / tc->speed;
+    else
+        return pitch_kalman_current(&tc->pitch_kalman) / tc->speed;
 }
 
 /*

--- a/lib/xwax/timecoder.h
+++ b/lib/xwax/timecoder.h
@@ -130,7 +130,7 @@ struct timecode_def* timecoder_find_definition(const char *name, const char *lut
 void timecoder_free_lookup(void);
 
 void timecoder_init(struct timecoder *tc, struct timecode_def *def,
-                    double speed, unsigned int sample_rate, bool phono);
+                    double speed, unsigned int sample_rate, bool phono, bool pitch_estimator);
 void timecoder_clear(struct timecoder *tc);
 
 int timecoder_monitor_init(struct timecoder *tc, int size);

--- a/lib/xwax/timecoder_mk2.c
+++ b/lib/xwax/timecoder_mk2.c
@@ -326,8 +326,8 @@ void mk2_process_carrier(struct timecoder *tc, signed int primary, signed int se
     tc->gain_compensation = (double)tc->secondary.mk2.rms / tc->secondary.mk2.rms_deriv;
 
     /* Without this limit pitch becomes too sensitive */
-    if (tc->gain_compensation > 30.0)
-        tc->gain_compensation = 30.0;
+    if (tc->gain_compensation > 25.0)
+        tc->gain_compensation = 25.0;
 
     tc->dB = 20 * log10((double)tc->secondary.mk2.rms / INT_MAX);
 

--- a/src/preferences/dialog/dlgprefvinyl.cpp
+++ b/src/preferences/dialog/dlgprefvinyl.cpp
@@ -65,6 +65,15 @@ DlgPrefVinyl::DlgPrefVinyl(
         box->addItem(MIXXX_VINYL_SPEED_45);
     }
 
+    m_vcPitchEstimatorBoxes = {ComboBoxPitchEstimator1,
+            ComboBoxPitchEstimator2,
+            ComboBoxPitchEstimator3,
+            ComboBoxPitchEstimator4};
+    for (auto* box : std::as_const(m_vcPitchEstimatorBoxes)) {
+        box->addItem(MIXXX_VINYL_PITCH_FILTER_KALMAN);
+        box->addItem(MIXXX_VINYL_PITCH_FILTER_LEGACY);
+    }
+
     m_vcLeadInBoxes = {LeadinTime1, LeadinTime2, LeadinTime3, LeadinTime4};
     for (auto* box : std::as_const(m_vcLeadInBoxes)) {
         box->setSuffix(" s");
@@ -73,6 +82,7 @@ DlgPrefVinyl::DlgPrefVinyl(
     DEBUG_ASSERT(m_vcLabels.length() == kMaximumVinylControlInputs);
     DEBUG_ASSERT(m_vcTypeBoxes.length() == kMaximumVinylControlInputs);
     DEBUG_ASSERT(m_vcSpeedBoxes.length() == kMaximumVinylControlInputs);
+    DEBUG_ASSERT(m_vcPitchEstimatorBoxes.length() == kMaximumVinylControlInputs);
     DEBUG_ASSERT(m_vcLeadInBoxes.length() == kMaximumVinylControlInputs);
 
     for (int i = 0; i < kMaximumVinylControlInputs; ++i) {
@@ -201,6 +211,14 @@ void DlgPrefVinyl::slotUpdate() {
             m_vcSpeedBoxes[i]->setCurrentIndex(comboIndex);
         }
 
+        // Set pitch filter types
+        comboIndex =
+                m_vcPitchEstimatorBoxes[i]->findText(config->getValueString(
+                        ConfigKey(group, "vinylcontrol_pitch_estimator_type")));
+        if (comboIndex != -1) {
+            m_vcPitchEstimatorBoxes[i]->setCurrentIndex(comboIndex);
+        }
+
         // set lead-in time
         int leadIn = config->getValue(
                 ConfigKey(group, "vinylcontrol_lead_in_time"),
@@ -263,6 +281,8 @@ void DlgPrefVinyl::slotApply() {
                 ConfigValue(m_vcTypeBoxes[i]->currentText()));
         config->set(ConfigKey(group, "vinylcontrol_speed_type"),
                 ConfigValue(m_vcSpeedBoxes[i]->currentText()));
+        config->set(ConfigKey(group, "vinylcontrol_pitch_estimator_type"),
+                ConfigValue(m_vcPitchEstimatorBoxes[i]->currentText()));
         verifyAndSaveLeadInTime(i, group);
 
         m_signalWidgets[i]->setVinylActive(m_pVCManager->vinylInputConnected(i));
@@ -315,12 +335,14 @@ void DlgPrefVinyl::setDeckWidgetsVisible(int deck, bool visible) {
         m_vcLabels[deck]->show();
         m_vcTypeBoxes[deck]->show();
         m_vcSpeedBoxes[deck]->show();
+        m_vcPitchEstimatorBoxes[deck]->show();
         m_vcLeadInBoxes[deck]->show();
         m_signalWidgets[deck]->show();
     } else {
         m_vcLabels[deck]->hide();
         m_vcTypeBoxes[deck]->hide();
         m_vcSpeedBoxes[deck]->hide();
+        m_vcPitchEstimatorBoxes[deck]->hide();
         m_vcLeadInBoxes[deck]->hide();
         m_signalWidgets[deck]->hide();
     }

--- a/src/preferences/dialog/dlgprefvinyl.h
+++ b/src/preferences/dialog/dlgprefvinyl.h
@@ -46,6 +46,7 @@ class DlgPrefVinyl : public DlgPreferencePage, Ui::DlgPrefVinylDlg  {
     QList<QLabel*> m_vcLabels;
     QList<QComboBox*> m_vcTypeBoxes;
     QList<QComboBox*> m_vcSpeedBoxes;
+    QList<QComboBox*> m_vcPitchEstimatorBoxes;
     QList<QSpinBox*> m_vcLeadInBoxes;
     QList<VinylControlSignalWidget*> m_signalWidgets;
 

--- a/src/preferences/dialog/dlgprefvinyldlg.ui
+++ b/src/preferences/dialog/dlgprefvinyldlg.ui
@@ -187,6 +187,30 @@
        </widget>
       </item>
 
+      <item row="0" column="4">
+       <widget class="QLabel" name="PitchEstimatorLabel">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="leftMargin">
+         <number>3</number>
+        </property>
+        <property name="text">
+         <string>Pitch estimator</string>
+        </property>
+        <property name="wordWrap">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+
+
       <item row="1" column="0">
        <widget class="QLabel" name="VinylLabel1">
         <property name="enabled">
@@ -542,6 +566,123 @@
         </property>
        </widget>
       </item>
+
+      <item row="1" column="4">
+       <widget class="QComboBox" name="ComboBoxPitchEstimator1">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="font">
+         <font/>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>200</width>
+          <height>16777215</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+
+      <item row="2" column="4">
+       <widget class="QComboBox" name="ComboBoxPitchEstimator2">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="font">
+         <font/>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>200</width>
+          <height>16777215</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+
+      <item row="3" column="4">
+       <widget class="QComboBox" name="ComboBoxPitchEstimator3">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="font">
+         <font/>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>200</width>
+          <height>16777215</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+
+      <item row="4" column="4">
+       <widget class="QComboBox" name="ComboBoxPitchEstimator4">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="font">
+         <font/>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>200</width>
+          <height>16777215</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+
 
       <item row="1" column="4" rowspan="4">
        <spacer name="horizontalSpacer_3">

--- a/src/test/co_dumps/co_dump_inital.csv
+++ b/src/test/co_dumps/co_dump_inital.csv
@@ -5028,6 +5028,7 @@
 [Channel2],hotcue_11_activate_preview,0
 [Sampler1],hotcue_27_enabled,0
 [Channel3],vinylcontrol_speed_type,33.3
+[Channel3],vinylcontrol_pitch_estimator_type,"Kalman filter (accurate)"
 [Sampler3],beatloop_0.0625_enabled,0
 [Channel3],hotcue_19_set,0
 [EqualizerRack1_[Channel2]],enabled,1
@@ -5038,6 +5039,7 @@
 [Channel1],playposition_up,0
 [EqualizerRack1_[Channel2]_Effect1],parameter6_set_default,0
 [Channel4],vinylcontrol_speed_type,33.3
+[Channel4],vinylcontrol_pitch_estimator_type,"Kalman filter (accurate)"
 [PreviewDeck1],hotcue_4_enabled,0
 [Channel4],hotcue_19_set,0
 [EqualizerRack1_[Channel4]_Effect1],parameter15_set_zero,0
@@ -5200,6 +5202,7 @@
 [Channel2],hotcue_20_gotoandstop,0
 [EffectRack1_EffectUnit3_Effect1],parameter12_set_default,0
 [Channel1],vinylcontrol_speed_type,33.3
+[Channel1],vinylcontrol_pitch_estimator_type,"Kalman filter (accurate)"
 [QuickEffectRack1_[Channel4]_Effect1],parameter6_up,0
 [EqualizerRack1_[Channel1]_Effect1],parameter6_down,0
 [PreviewDeck1],hotcue_8_goto,0
@@ -5211,6 +5214,7 @@
 [Channel3],hotcue_20_gotoandstop,0
 [QuickEffectRack1_[Channel3]_Effect1],parameter3_set_minus_one,0
 [Channel2],vinylcontrol_speed_type,33.3
+[Channel2],vinylcontrol_pitch_estimator_type,"Kalman filter (accurate)"
 [PreviewDeck1],hotcue_27_activate_preview,0
 [EffectRack1_EffectUnit2],loaded,1
 [EqualizerRack1_[Channel4]_Effect1],parameter8_link_inverse,0

--- a/src/vinylcontrol/defs_vinylcontrol.h
+++ b/src/vinylcontrol/defs_vinylcontrol.h
@@ -53,6 +53,9 @@ constexpr int VINYL_STATUS_ERROR = 3;
 #define MIXXX_VINYL_SPEED_33 "33.3 RPM"
 #define MIXXX_VINYL_SPEED_45 "45 RPM"
 
+#define MIXXX_VINYL_PITCH_FILTER_LEGACY "Alpha-Beta filter (fast)"
+#define MIXXX_VINYL_PITCH_FILTER_KALMAN "Kalman filter (accurate)"
+
 #define MIXXX_VINYL_SPEED_33_NUM (100.0 / 3.0)
 #define MIXXX_VINYL_SPEED_45_NUM 45.0
 

--- a/src/vinylcontrol/vinylcontrolxwax.cpp
+++ b/src/vinylcontrol/vinylcontrolxwax.cpp
@@ -53,7 +53,6 @@ VinylControlXwax::VinylControlXwax(UserSettingsPointer pConfig, const QString& g
           m_iPitchRingSize(0),
           m_iPitchRingPos(0),
           m_iPitchRingFilled(0),
-          m_dDisplayPitch(0.0),
           m_pSteadySubtle(nullptr),
           m_pSteadyGross(nullptr),
           m_bCDControl(false),
@@ -604,28 +603,11 @@ void VinylControlXwax::analyzeSamples(CSAMPLE* pSamples, size_t nFrames) {
         }
 
         if (uiUpdateTime(filePosition)) {
-            double pitch_difference = averagePitch - m_dDisplayPitch;
 
-            // The true pitch can show a misleading amount of variance --
-            // differences of .1% or less can show up as 1 or 2 bpm changes.
-            // Therefore we react slowly to bpm changes to show a more steady
-            // number to the user.
-            if (fabs(pitch_difference) > 0.5) {
-                // For large changes in pitch (start/stop, usually), immediately
-                // update the display.
-                m_dDisplayPitch = averagePitch;
-            } else if (fabs(pitch_difference) > 0.005) {
-                // For medium changes in pitch, take 4 callback loops to
-                // converge on the correct amount.
-                m_dDisplayPitch += pitch_difference * .25;
-            } else {
-                // For extremely small changes, converge very slowly.
-                m_dDisplayPitch += pitch_difference * .01;
-            }
             // Don't show extremely high or low speeds in the UI.
             if (reportedPlayButton && !scratching->toBool() &&
-                    m_dDisplayPitch < 1.9 && m_dDisplayPitch > 0.2) {
-                m_pRateRatio->set(m_dDisplayPitch);
+                    dVinylPitch < 1.9 && dVinylPitch > 0.2) {
+                m_pRateRatio->set(dVinylPitch);
             } else {
                 m_pRateRatio->set(1.0);
             }

--- a/src/vinylcontrol/vinylcontrolxwax.cpp
+++ b/src/vinylcontrol/vinylcontrolxwax.cpp
@@ -76,6 +76,8 @@ VinylControlXwax::VinylControlXwax(UserSettingsPointer pConfig, const QString& g
         ConfigKey(group,"vinylcontrol_vinyl_type"));
     QString strVinylSpeed = m_pConfig->getValueString(
         ConfigKey(group,"vinylcontrol_speed_type"));
+    QString strPitchEstimator = m_pConfig->getValueString(
+            ConfigKey(group, "vinylcontrol_pitch_estimator_type"));
 
     // libxwax indexes by C-strings so we pass libxwax string literals so we
     // don't have to deal with freeing the strings later
@@ -170,7 +172,14 @@ VinylControlXwax::VinylControlXwax(UserSettingsPointer pConfig, const QString& g
     // do this once across the VinylControlXwax instances.
     s_xwaxLUTMutex.lock();
 
-    timecoder_init(&timecoder, tc_def, speed, sampleRate.value(), /* phono */ false);
+    const bool use_legacy_pitch_filter = strPitchEstimator == MIXXX_VINYL_PITCH_FILTER_LEGACY;
+
+    timecoder_init(&timecoder,
+            tc_def,
+            speed,
+            sampleRate.value(),
+            /* phono */ false,
+            use_legacy_pitch_filter);
     timecoder_monitor_init(&timecoder, MIXXX_VINYL_SCOPE_SIZE);
     //Note that timecoder_init will not double-malloc the LUTs, and after this we are guaranteed
     //that the LUT has been generated unless we ran out of memory.
@@ -603,7 +612,6 @@ void VinylControlXwax::analyzeSamples(CSAMPLE* pSamples, size_t nFrames) {
         }
 
         if (uiUpdateTime(filePosition)) {
-
             // Don't show extremely high or low speeds in the UI.
             if (reportedPlayButton && !scratching->toBool() &&
                     dVinylPitch < 1.9 && dVinylPitch > 0.2) {

--- a/src/vinylcontrol/vinylcontrolxwax.h
+++ b/src/vinylcontrol/vinylcontrolxwax.h
@@ -112,8 +112,6 @@ class VinylControlXwax : public VinylControl {
     // How much of the pitch ring buffer is "filled" versus empty (used before
     // it fills up completely).
     int m_iPitchRingFilled;
-    // A smoothed pitch value to show to the user.
-    double m_dDisplayPitch;
 
     // Steady pitch trackers.  "Subtle" will be more likely to return true,
     // so it is used to set the play button.  "Gross" is more likely to return


### PR DESCRIPTION
Adds a simple Kalman filter with a constant velocity model as alternative pitch estimator. The model assumes constant playback, which is realized by assuming that every zero-crossing corresponds to a quarter revolution of the sinusoid. The quarter revolution is fed as displacement into the filter and the new velocity (pitch) is estimated.

The results are much better than with the Alpha-Beta filter, yet not perfect. It would probably be best to take the time to statistically model the filter better. For now definitely an improvement though!

Adds a selection in the vinylcontrol panel to choose between pitch estimators for people who don't trust the new filter just yet.