### PR TITLE
feat(QML): add checks to ensure user run with a dedicated test profile

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -93,6 +93,11 @@ int runMixxx(MixxxApplication* pApp, const CmdlineArgs& args) {
 
         pCoreServices->initialize(pApp);
 
+        if (pCoreServices->getSettings()->getValue(
+                    ConfigKey("[Config]", "did_run_with_unstable"), false)) {
+            qInfo() << "User previously ran the unstable version on this profile";
+        }
+
 #ifdef MIXXX_USE_QOPENGL
         // Will call initialize when the initial wglwidget's
         // qopenglwindow has been exposed

--- a/src/preferences/upgrade.cpp
+++ b/src/preferences/upgrade.cpp
@@ -357,9 +357,20 @@ UserSettingsPointer Upgrade::versionUpgrade(const QString& settingsPath) {
         else {
 #endif
             // This must have been the first run... right? :)
-            qDebug() << "No version number in configuration file. Setting to"
-                     << VersionStore::version();
-            config->set(ConfigKey("[Config]", "Version"), ConfigValue(VersionStore::version()));
+#ifdef MIXXX_USE_QML
+            if (CmdlineArgs::Instance().isQml()) {
+                // If running the QML version (aka 3.0 unstable), we set a dummy
+                // unstable version in the settings. This is used to detect if
+                // the current user profile is being used for testing purpose
+                // and if it is safe for the user to potentially lose their data
+                config->setValue(ConfigKey("[Config]", "Version"), VersionStore::FUTURE_UNSTABLE);
+            } else
+#endif
+            {
+                qDebug() << "No version number in configuration file. Setting to"
+                         << VersionStore::version();
+                config->set(ConfigKey("[Config]", "Version"), ConfigValue(VersionStore::version()));
+            }
             m_bFirstRun = true;
             return config;
 #ifdef __APPLE__

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -285,6 +285,14 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
                                       "Loads experimental QML GUI instead of legacy QWidget skin")
                             : QString());
     parser.addOption(qml);
+    const QCommandLineOption awareOfRisk(
+            QStringLiteral("allow-dangerous-data-corruption-risk"),
+            forUserFeedback
+                    ? QCoreApplication::translate("CmdlineArgs",
+                              "Force Mixxx to load an unstable version with an "
+                              "existing user profile from a stable version")
+                    : QString());
+    parser.addOption(awareOfRisk);
 #endif
     const QCommandLineOption safeMode(QStringLiteral("safe-mode"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
@@ -459,6 +467,7 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
     m_developer = parser.isSet(developer);
 #ifdef MIXXX_USE_QML
     m_qml = parser.isSet(qml);
+    m_awareOfRisk = parser.isSet(awareOfRisk);
 #endif
     m_safeMode = parser.isSet(safeMode) || parser.isSet(safeModeDeprecated);
     m_debugAssertBreak = parser.isSet(debugAssertBreak) || parser.isSet(debugAssertBreakDeprecated);

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -50,6 +50,9 @@ class CmdlineArgs final {
     bool isQml() const {
         return m_qml;
     }
+    bool isAwareOfRisk() const {
+        return m_awareOfRisk;
+    }
 #endif
     bool getSafeMode() const { return m_safeMode; }
     bool useColors() const {
@@ -106,6 +109,7 @@ class CmdlineArgs final {
     bool m_developer; // Developer Mode
 #ifdef MIXXX_USE_QML
     bool m_qml;
+    bool m_awareOfRisk;
 #endif
     bool m_safeMode;
     bool m_useLegacyVuMeter;

--- a/src/util/versionstore.h
+++ b/src/util/versionstore.h
@@ -5,6 +5,9 @@
 #include <QVersionNumber>
 
 namespace VersionStore {
+/// Constant to store the future unreleased Mixxx 3.0
+static QString FUTURE_UNSTABLE = QStringLiteral("3.0-unstable");
+
 /// Returns the current Mixxx version string (e.g. 1.12.0-alpha)
 QString version();
 


### PR DESCRIPTION
This PR adds the safety mechanism we discussed during the monthly catchup.

It will prevent user from running the highly unstable QML interface, and allow us to continue with the fast iteration.

Here is the expected behaviour when running on QML:

- User starts with a new profile -> All good, starting
- User starts with an existing profile from a stable version -> User is presented with an error box and Mixxx stops
- User starts with an existing profile from a stable version but has given their consent to break things -> All good, starting with a critical message in the logs

In the case no 3, a log message and a key will be persisted in the user profile, which might be helpful to track future issues report on `2.x`, tho user can easily remove it.