### PR TITLE
fix: Map the shiftbutton messages to decks 1/3 and 2/4 on Numark NS6II

### DIFF
--- a/res/controllers/Numark NS6II.midi.xml
+++ b/res/controllers/Numark NS6II.midi.xml
@@ -3925,7 +3925,7 @@
             <control>
                 <group>[Channel3]</group>
                 <key>NS6II.decks[2].shiftButton.input</key>
-                <status>0x82</status>
+                <status>0x80</status>
                 <midino>0x20</midino>
                 <options>
                     <script-binding/>
@@ -3934,7 +3934,7 @@
             <control>
                 <group>[Channel4]</group>
                 <key>NS6II.decks[3].shiftButton.input</key>
-                <status>0x83</status>
+                <status>0x81</status>
                 <midino>0x20</midino>
                 <options>
                     <script-binding/>
@@ -4015,7 +4015,7 @@
             <control>
                 <group>[Channel3]</group>
                 <key>NS6II.decks[2].shiftButton.input</key>
-                <status>0x92</status>
+                <status>0x90</status>
                 <midino>0x20</midino>
                 <options>
                     <script-binding/>
@@ -4024,7 +4024,7 @@
             <control>
                 <group>[Channel4]</group>
                 <key>NS6II.decks[3].shiftButton.input</key>
-                <status>0x93</status>
+                <status>0x91</status>
                 <midino>0x20</midino>
                 <options>
                     <script-binding/>


### PR DESCRIPTION
I previously assumed the shift button sent messages on a per-deck basis. While learning to DJ on 4 decks simultanously, I noticed that the shift button doesn't work on decks 3 and 4. It turns out that regardless of the currently active deck on each side, the shift button doesn't change the channel it originates from and thus it would be interpreted as Decks 1/2 being shifted instead of the currently active decks 3/4. This may also be a firmware bug.

The easiest fix is just to dispatch the shift button to both decks on each side.