### PR TITLE
Set -fno-lto explicit for fpclassify.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2657,6 +2657,8 @@ target_link_libraries(mixxx-lib PRIVATE FLAC::FLAC)
 add_library(FpClassify STATIC EXCLUDE_FROM_ALL src/util/fpclassify.cpp)
 # With gcc >= 14 and -flto some code is inlined to fast-math code and then
 # optimized away. Disable it explicit for all compiler just in case.
+# Note: This does not set -fno-lto to override an external provided -flto=auto like on
+# Launchpad. Setting it explicit below.
 set_target_properties(FpClassify PROPERTIES INTERPROCEDURAL_OPTIMIZATION OFF)
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_SIMULATE_ID MATCHES "MSVC")
@@ -2664,7 +2666,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_SIMULATE_ID MATCHES "MSV
 elseif(GNU_GCC OR LLVM_CLANG)
   # The option `-ffp-contract=on` must precede `-fno-fast-math`
   # to silence a warning on Clang 14
-  target_compile_options(FpClassify PRIVATE -ffp-contract=on -fno-fast-math)
+  target_compile_options(FpClassify PRIVATE -ffp-contract=on -fno-fast-math -fno-lto)
 endif()
 target_link_libraries(mixxx-lib PRIVATE FpClassify)
 


### PR DESCRIPTION
This is required to override external provided -flto flags, like on Launchpad.

See test failure here: 
https://launchpadlibrarian.net/812389799/buildlog_ubuntu-questing-amd64.mixxx_2.6~beta~59~g7ae1630f31-1~questing_BUILDING.txt.gz