### PR TITLE
Fix dependencies of trusted-signing-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -335,7 +335,8 @@ jobs:
         env:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
         if: runner.os == 'Windows' && env.AZURE_TENANT_ID
-        uses: azure/trusted-signing-action@v0.5.9
+        # Pinned to commit, to fix a caching issue https://github.com/Azure/trusted-signing-action/issues/62
+        uses: azure/trusted-signing-action@0d74250c661747df006298d0fb49944c10f16e03
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -399,7 +400,8 @@ jobs:
         env:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
         if: runner.os == 'Windows' && env.AZURE_TENANT_ID
-        uses: azure/trusted-signing-action@v0.5.9
+        # Pinned to commit, to fix a caching issue https://github.com/Azure/trusted-signing-action/issues/62
+        uses: azure/trusted-signing-action@0d74250c661747df006298d0fb49944c10f16e03
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}


### PR DESCRIPTION
https://github.com/Azure/trusted-signing-action/issues/62

This hopefully fixed the build errors in the 2.6 branch when cache is used. The error does however not match exactly. 
If we still suffer issue we can try to revert to 5.1  

https://github.com/mixxxdj/mixxx/actions/runs/17121516380/job/48563286515 