### PR TITLE
fix: Turn on `[ChannelN], quantize` by default

### DIFF
--- a/src/engine/controls/quantizecontrol.cpp
+++ b/src/engine/controls/quantizecontrol.cpp
@@ -10,8 +10,7 @@
 QuantizeControl::QuantizeControl(const QString& group,
         UserSettingsPointer pConfig)
         : EngineControl(group, pConfig) {
-    // Turn quantize OFF by default. See Bug #898213
-    m_pCOQuantizeEnabled = new ControlPushButton(ConfigKey(group, "quantize"), true);
+    m_pCOQuantizeEnabled = new ControlPushButton(ConfigKey(group, "quantize"), true, 1.0);
     m_pCOQuantizeEnabled->setButtonMode(ControlPushButton::TOGGLE);
     m_pCONextBeat = new ControlObject(ConfigKey(group, "beat_next"));
     m_pCONextBeat->setKbdRepeatable(true);

--- a/src/test/beatstranslatetest.cpp
+++ b/src/test/beatstranslatetest.cpp
@@ -7,6 +7,8 @@ class BeatsTranslateTest : public MockedEngineBackendTest {
 };
 
 TEST_F(BeatsTranslateTest, SimpleTranslateMatch) {
+    ControlObject::set(ConfigKey(m_sGroup1, QStringLiteral("quantize")), 0);
+    ControlObject::set(ConfigKey(m_sGroup2, QStringLiteral("quantize")), 0);
     // Set up BeatGrids for decks 1 and 2.
     const auto bpm = mixxx::Bpm(60.0);
     constexpr auto firstBeat = mixxx::audio::kStartFramePos;

--- a/src/test/cuecontrol_test.cpp
+++ b/src/test/cuecontrol_test.cpp
@@ -365,6 +365,7 @@ TEST_F(CueControlTest, SeekOnLoadDefault_CueInPreroll) {
 }
 
 TEST_F(CueControlTest, FollowCueOnQuantize) {
+    m_pQuantizeEnabled->set(0);
     config()->set(ConfigKey("[Controls]", "CueRecall"),
             ConfigValue(static_cast<int>(SeekOnLoadMode::MainCue)));
     TrackPointer pTrack = createTestTrack();

--- a/src/test/enginesynctest.cpp
+++ b/src/test/enginesynctest.cpp
@@ -2141,9 +2141,11 @@ TEST_F(EngineSyncTest, SetFileBpmUpdatesLocalBpm) {
 }
 
 TEST_F(EngineSyncTest, SyncPhaseToPlayingNonSyncDeck) {
+    // Turn off quantize for both decks
+    ControlObject::set(ConfigKey(m_sGroup1, "quantize"), 0);
+    ControlObject::set(ConfigKey(m_sGroup2, "quantize"), 0);
     // If we press play on a sync deck, we will only sync phase to a non-sync
     // deck if there are no sync decks and the non-sync deck is playing.
-
     auto pButtonSyncEnabled1 =
             std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
     mixxx::BeatsPointer pBeats1 = mixxx::Beats::fromConstTempo(
@@ -2596,6 +2598,8 @@ TEST_F(EngineSyncTest, ZeroBpmNaturalRate) {
 }
 
 TEST_F(EngineSyncTest, QuantizeImpliesSyncPhase) {
+    ControlObject::set(ConfigKey(m_sGroup1, QStringLiteral("quantize")), 0);
+    ControlObject::set(ConfigKey(m_sGroup2, QStringLiteral("quantize")), 0);
     auto pButtonSyncEnabled1 = std::make_unique<ControlProxy>(m_sGroup1, "sync_enabled");
     auto pButtonBeatsync1 = std::make_unique<ControlProxy>(m_sGroup1, "beatsync");
     auto pButtonBeatsyncPhase1 = std::make_unique<ControlProxy>(m_sGroup1, "beatsync_phase");

--- a/src/test/hotcuecontrol_test.cpp
+++ b/src/test/hotcuecontrol_test.cpp
@@ -1158,6 +1158,7 @@ TEST_F(HotcueControlTest, SavedLoopToggleDoesNotSeek) {
 }
 
 TEST_F(HotcueControlTest, SavedLoopActivate) {
+    m_pQuantizeEnabled->set(0);
     // Setup fake track with 120 bpm and calculate loop size
     TrackPointer pTrack = loadTestTrackWithBpm(120.0);
 
@@ -1338,6 +1339,7 @@ TEST_F(HotcueControlTest, SavedLoopBeatLoopSizeRestore) {
 }
 
 TEST_F(HotcueControlTest, SavedLoopBeatLoopSizeRestoreDoesNotJump) {
+    m_pQuantizeEnabled->set(0);
     // Setup fake track with 120 bpm and calculate loop size
     TrackPointer pTrack = loadTestTrackWithBpm(120.0);
 
@@ -1472,6 +1474,7 @@ TEST_F(HotcueControlTest, SavedLoopUnloadTrackWhileActive) {
 }
 
 TEST_F(HotcueControlTest, SavedLoopUseLoopInOutWhileActive) {
+    m_pQuantizeEnabled->set(0);
     std::unique_ptr<ControlProxy> pLoopIn = std::make_unique<ControlProxy>(m_sGroup1, "loop_in");
     std::unique_ptr<ControlProxy> pLoopOut = std::make_unique<ControlProxy>(m_sGroup1, "loop_out");
 


### PR DESCRIPTION
_continuation of #15221 with fixed tests_

This seems to be the expected default behavior of many users and the quantize button is currently very hard to find for new users. This turns it on by default to improve the experience for new users that expect the sync button to phase match by default.
.