### PR TITLE
STEM: Allow pre-mastered stream not to match stem streams properties

### DIFF
--- a/src/sources/soundsourcestem.cpp
+++ b/src/sources/soundsourcestem.cpp
@@ -344,7 +344,8 @@ SoundSource::OpenResult SoundSourceSTEM::tryOpen(
         return OpenResult::Failed;
     }
 
-    AVStream* firstAudioStream = nullptr;
+    bool foundPremixedStream = false;
+    AVStream* firstStem = nullptr;
     int stemCount = 0;
     uint selectedStemMask = params.stemMask();
     VERIFY_OR_DEBUG_ASSERT(selectedStemMask <= 2 << mixxx::kMaxSupportedStems) {
@@ -372,26 +373,44 @@ SoundSource::OpenResult SoundSourceSTEM::tryOpen(
             return OpenResult::Failed;
         }
 
-        if (!firstAudioStream) {
-            firstAudioStream = pavInputFormatContext->streams[streamIdx];
-            // The main mix is only used to detect the stream parameters
+        if (!foundPremixedStream) {
+            // We can currently allow this, as we NEVER LOAD the pre-mastered
+            // track, as we do not have analyzer data for it.
+            // This is because we only support one set of metadata for the whole
+            // STEM file, where we determine the track parameters from an
+            // on-the-fly mix of all 4 stems. Especially the replaygain differs
+            // between the on-the-fly mix and the pre-mastered track, because we
+            // do not apply DSP (limiter, equalizer, compressor) to the
+            // on-the-fly mix. If this ever gets changed, we should set
+            // `initSampleRateOnce` and `initBitrateOnce` to match the stem
+            // sample rate and bit rate, such that
+            // SoundSourceFFmpeg::resampleDecodedAVFrame will take care to
+            // resample the main stream, in order to use the same time scale and
+            // keep a working grid/cue definition
+            foundPremixedStream = true;
             continue;
+        }
+
+        stemCount++;
+
+        if (!firstStem) {
+            // We always keep track of the stem to verify that stem stream properties are matching
+            firstStem = pavInputFormatContext->streams[streamIdx];
         } else {
             if (pavInputFormatContext->streams[streamIdx]->codecpar->codec_id !=
-                    firstAudioStream->codecpar->codec_id) {
+                    firstStem->codecpar->codec_id) {
                 kLogger.warning().noquote()
-                        << "stream at position" << streamIdx << "is using a different codec";
+                        << "Stem at position" << streamIdx << "is using a different codec";
                 return OpenResult::Failed;
             }
 
             if (pavInputFormatContext->streams[streamIdx]
                             ->codecpar->sample_rate !=
-                    firstAudioStream->codecpar->sample_rate) {
+                    firstStem->codecpar->sample_rate) {
                 kLogger.warning().noquote()
-                        << "stream at position" << streamIdx << "is using a different sample rate";
+                        << "Stem at position" << streamIdx << "is using a different sample rate";
                 return OpenResult::Failed;
             }
-            stemCount++;
         }
 
         // StemIdx is equal to StreamIdx -1 (the main mix)

--- a/src/waveform/renderers/allshader/waveformrendererstem.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererstem.cpp
@@ -223,11 +223,18 @@ bool WaveformRendererStem::preprocessInner() {
 
                 // Apply the gains
                 if (layerIdx) {
-                    max *= m_pStemMute[stemIdx]->toBool() ||
-                                    (selectedStems &&
-                                            !(selectedStems & 1 << stemIdx))
-                            ? 0.f
-                            : static_cast<float>(m_pStemGain[stemIdx]->get());
+                    if (selectedStems) {
+                        max *= !(selectedStems & 1 << stemIdx)
+                                ? 0.f
+                                : 1.f;
+                    } else if (!m_pStemMute.empty() && m_pStemMute[stemIdx]->toBool()) {
+                        max = 0;
+                    } else {
+                        float volume = m_pStemGain.empty()
+                                ? 1.f
+                                : static_cast<float>(m_pStemGain[stemIdx]->get());
+                        max *= volume;
+                    }
                 }
 
                 // Lines are thin rectangles


### PR DESCRIPTION
This fixes #14572

Also spotted a bug leading the waveform to react to STEM CO even loaded as pre-mixed, fixed as 0c32d1cd223b4be5a8c1731b3984febdeaa6fbbf