### PR TITLE
changes the script in "tools/debian_buildenv.sh"

### DIFF
--- a/tools/debian_buildenv.sh
+++ b/tools/debian_buildenv.sh
@@ -90,7 +90,7 @@ case "$1" in
             libopusfile-dev \
             libportmidi-dev \
             libprotobuf-dev \
-            libqt6core5compat6-dev\
+            libqt6core5compat6-dev \
             libqt6opengl6-dev \
             libqt6sql6-sqlite \
             libqt6svg6-dev \


### PR DESCRIPTION
In the script "tools/debian_buildenv.sh":
```
libqt6core5compat6-dev\ -> libqt6core5compat6-dev \
``` 
(the space is missing before "\\")


Fixes #15248 