### PR TITLE
Add a hint regarding pick up position of deck and bus outputs

### DIFF
--- a/src/defs_urls.h
+++ b/src/defs_urls.h
@@ -77,5 +77,7 @@
     MIXXX_MANUAL_URL "/chapters/vinyl_control.html#troubleshooting"
 #define MIXXX_MANUAL_SETTINGS_DIRECTORY_URL \
     MIXXX_MANUAL_URL "/chapters/appendix.html#settings-directory"
+#define MIXXX_MANUAL_OUTPUT_AND_INPUT_DEVICES \
+    MIXXX_MANUAL_URL "/chapters/preferences/sound_hardware#output-and-input-devices"
 #define MIXXX_MANUAL_FILENAME   "Mixxx-Manual.pdf"
 #define MIXXX_KBD_SHORTCUTS_FILENAME "Mixxx-Keyboard-Shortcuts.pdf"

--- a/src/preferences/dialog/dlgprefsound.cpp
+++ b/src/preferences/dialog/dlgprefsound.cpp
@@ -283,6 +283,13 @@ DlgPrefSound::DlgPrefSound(QWidget* pParent,
                             m_pLinkColor,
                             tr("Mixxx DJ Hardware Guide"),
                             MIXXX_WIKI_HARDWARE_COMPATIBILITY_URL)));
+
+    QString deckBusHintStr = deckBusHint->text();
+    deckBusHintStr += " " +
+            coloredLinkString(m_pLinkColor,
+                    tr("Find details in the Mixxx user manual"),
+                    MIXXX_MANUAL_OUTPUT_AND_INPUT_DEVICES);
+    deckBusHint->setText(deckBusHintStr);
 }
 
 /// Slot called when the preferences dialog is opened.

--- a/src/preferences/dialog/dlgprefsounddlg.ui
+++ b/src/preferences/dialog/dlgprefsounddlg.ui
@@ -329,6 +329,16 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_6">
       <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="deckBusHint">
+        <property name="text">
+         <string>Deck and Bus outputs are for external mixers. They are post-fader and include effects and crossfader (for Auto DJ). For external mixing, make sure all Mixxx faders and EQ knobs are set to their default position (right- or double-click). </string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
        <widget class="QLabel" name="underflowCounterHint">
         <property name="text">
          <string>Enlarge your audio buffer if the underflow counter is increasing or you hear pops during playback.</string>
@@ -338,7 +348,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0" colspan="2">
+      <item row="2" column="0" colspan="2">
        <widget class="QLabel" name="audioBufferHint">
         <property name="text">
          <string>Downsize your audio buffer to improve Mixxx's responsiveness.</string>

--- a/src/preferences/dialog/dlgprefsounddlg.ui
+++ b/src/preferences/dialog/dlgprefsounddlg.ui
@@ -336,6 +336,9 @@
         <property name="wordWrap">
          <bool>true</bool>
         </property>
+        <property name="openExternalLinks">
+         <bool>true</bool>
+        </property>
        </widget>
       </item>
       <item row="1" column="0" colspan="2">


### PR DESCRIPTION
The related manual PR is here: 
https://github.com/mixxxdj/manual/pull/789

This will be a good band-aid until we have a less confusing option in #14814