### PR TITLE
Reverb effect: Fix memory leak

### DIFF
--- a/lib/reverb/Reverb.h
+++ b/lib/reverb/Reverb.h
@@ -232,9 +232,13 @@ class PlateX2
                            const sample_t previousSend);
 
         void init(float sampleRate) {
-            fs = sampleRate;
             PlateStub::init();
-            PlateStub::activate();
+            setSamplerate(sampleRate);
+        }
+
+        void setSamplerate(float sampleRate) {
+            fs = sampleRate;
+            activate();
         }
  };
 

--- a/lib/reverb/dsp/Delay.h
+++ b/lib/reverb/dsp/Delay.h
@@ -55,6 +55,7 @@ class Delay
 			{
 				size = next_power_of_2 (n);
 				assert (size <= (1 << 20));
+				free (data);
 				data = (sample_t *) calloc (sizeof (sample_t), size);
 				--size; /* used as mask for confining access */
 				write = n;

--- a/src/effects/backends/builtin/reverbeffect.cpp
+++ b/src/effects/backends/builtin/reverbeffect.cpp
@@ -91,13 +91,15 @@ void ReverbEffect::processChannel(
     const auto damping = static_cast<sample_t>(m_pDampingParameter->value());
     const auto sendCurrent = static_cast<sample_t>(m_pSendParameter->value());
 
-    // Reinitialize the effect when turning it on to prevent replaying the old buffer
-    // from the last time the effect was enabled.
-    // Also, update the sample rate if it has changed.
-    if (enableState == EffectEnableState::Enabling ||
-            pState->sampleRate != engineParameters.sampleRate()) {
-        pState->reverb.init(engineParameters.sampleRate());
+    if (pState->sampleRate != engineParameters.sampleRate()) {
+        pState->reverb.setSamplerate(engineParameters.sampleRate());
         pState->sampleRate = engineParameters.sampleRate();
+    }
+
+    // Reinitialize the effect when turning it on to prevent replaying the old buffer
+    // from the last time the effect was enabled..
+    if (enableState == EffectEnableState::Enabling) {
+        pState->reverb.activate();
     }
 
     pState->reverb.processBuffer(pInput,

--- a/src/effects/backends/builtin/reverbeffect.h
+++ b/src/effects/backends/builtin/reverbeffect.h
@@ -17,13 +17,9 @@ class ReverbGroupState : public EffectState {
             : EffectState(engineParameters),
               sampleRate(engineParameters.sampleRate()),
               sendPrevious(0) {
+        reverb.init(sampleRate);
     }
     ~ReverbGroupState() override = default;
-
-    void engineParametersChanged(const mixxx::EngineParameters& engineParameters) {
-        sampleRate = engineParameters.sampleRate();
-        sendPrevious = 0;
-    }
 
     float sampleRate;
     float sendPrevious;


### PR DESCRIPTION
Now the memory is only allocated in the State constructor as it should. In the process call the activate() command is called, which clears all buffers without reallocation.  

fixes https://github.com/mixxxdj/mixxx/issues/15261