### PR TITLE
Follow Ubuntu libstdc++6 and libgcc-s1 updates

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -120,7 +120,7 @@ jobs:
         run: |
           sudo rm -f /etc/apt/sources.list.d/ubuntu-toolchain-r-ubuntu-test-jammy.list
           sudo apt-get update
-          sudo apt-get install -y --allow-downgrades libc6=2.35* libc6-dev=2.35* libstdc++6=12.3.0-1ubuntu1~22.04 libgcc-s1=12.3.0-1ubuntu1~22.04
+          sudo apt-get install -y --allow-downgrades libc6=2.35* libc6-dev=2.35* libstdc++6=12.3.0* libgcc-s1=12.3.0*
       - name: Build
         # Do not abort on errors and build/check the whole project
         run: cmake --build . -j $(nproc) -- --keep-going


### PR DESCRIPTION
This fixes: 
```
E: Version '12.3.0-1ubuntu1~22.04' for 'libstdc++6' was not found
E: Version '12.3.0-1ubuntu1~22.04' for 'libgcc-s1' was not found
```

here: 
https://github.com/mixxxdj/mixxx/actions/runs/17279385378/job/49044173678