### PR TITLE
Fix README: Add missing dependency information for issue #15273

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ corresponding command for your operating system:
 
 To build Mixxx, run
 
+    $ cd tools
+    $ ./debian_buildenv.sh setup
+    $ cd ..
     $ mkdir build
     $ cd build
     $ cmake ..


### PR DESCRIPTION
Added 3 lines to first run `./debian_buildenv.sh setup` before cmake