### PR TITLE
fix: phase detection for inverted vinyl codes

### DIFF
--- a/lib/xwax/timecoder.c
+++ b/lib/xwax/timecoder.c
@@ -562,9 +562,10 @@ static void track_quadrature_phase(struct timecoder *tc, bool direction_changed)
     tc->direction_changed = direction_changed;
 
     bool pos = tc->primary.swapped ? tc->primary.positive : tc->secondary.positive;
+    pos ^= !(tc->def->flags & SWITCH_PHASE);
     bool add = tc->secondary.swapped ? 0b1 : 0b0;
 
-    tc->quadrant = (!pos << 1) | add;
+    tc->quadrant = (pos << 1) | add;
 }
 
 /*


### PR DESCRIPTION
Alternative to #15283 that fixes this upstream rather than downstream. Fix confirmation by @ywwg pending.