### PR TITLE
Overview: add mono option

### DIFF
--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -79,6 +79,11 @@ DlgPrefWaveform::DlgPrefWaveform(
         defaultZoomComboBox->addItem(QString::number(100 / static_cast<double>(i), 'f', 1) + " %");
     }
 
+    m_pOverviewStereoControl = std::make_unique<ControlObject>(
+            ConfigKey(kWaveformGroup,
+                    QStringLiteral("overview_stereo_mode")));
+    m_pOverviewStereoControl->setReadOnly();
+
     m_pOverviewMinuteMarkersControl = std::make_unique<ControlObject>(
             ConfigKey(kWaveformGroup, QStringLiteral("draw_overview_minute_markers")));
     m_pOverviewMinuteMarkersControl->setReadOnly();
@@ -189,6 +194,10 @@ DlgPrefWaveform::DlgPrefWaveform(
             &QCheckBox::toggled,
             this,
             &DlgPrefWaveform::slotSetOverviewMinuteMarkers);
+    connect(overviewStereoCheckBox,
+            &QCheckBox::toggled,
+            this,
+            &DlgPrefWaveform::slotSetOverviewStereoMode);
 
     connect(factory,
             &WaveformWidgetFactory::waveformMeasured,
@@ -345,6 +354,11 @@ void DlgPrefWaveform::slotUpdate() {
         overview_scale_allReplayGain->setChecked(true);
     }
 
+    bool overviewStereo = m_pConfig->getValue(
+            ConfigKey(kWaveformGroup, QStringLiteral("overview_stereo_mode")), true);
+    overviewStereoCheckBox->setChecked(overviewStereo);
+    m_pOverviewStereoControl->forceSet(overviewStereo);
+
     bool drawOverviewMinuteMarkers = m_pConfig->getValue(
             ConfigKey(kWaveformGroup, QStringLiteral("draw_overview_minute_markers")), true);
     overviewMinuteMarkersCheckBox->setChecked(drawOverviewMinuteMarkers);
@@ -403,6 +417,9 @@ void DlgPrefWaveform::slotResetToDefaults() {
     // RGB overview.
     waveformOverviewComboBox->setCurrentIndex(
             waveformOverviewComboBox->findData(QVariant::fromValue(OverviewType::RGB)));
+
+    // Default to overview stereo mode
+    overviewStereoCheckBox->setChecked(true);
 
     // Show minute markers.
     overviewMinuteMarkersCheckBox->setChecked(true);
@@ -668,6 +685,11 @@ void DlgPrefWaveform::slotSetOverviewMinuteMarkers(bool draw) {
                                 QStringLiteral("draw_overview_minute_markers")),
             draw);
     m_pOverviewMinuteMarkersControl->forceSet(draw);
+}
+
+void DlgPrefWaveform::slotSetOverviewStereoMode(bool stereo) {
+    m_pConfig->setValue(ConfigKey(kWaveformGroup, QStringLiteral("overview_stereo_mode")), stereo);
+    m_pOverviewStereoControl->forceSet(stereo);
 }
 
 void DlgPrefWaveform::slotWaveformMeasured(float frameRate, int droppedFrames) {

--- a/src/preferences/dialog/dlgprefwaveform.h
+++ b/src/preferences/dialog/dlgprefwaveform.h
@@ -65,6 +65,7 @@ class DlgPrefWaveform : public DlgPreferencePage, public Ui::DlgPrefWaveformDlg 
     void slotStemOutlineOpacity(float value);
     // overview options
     void slotSetWaveformOverviewType();
+    void slotSetOverviewStereoMode(bool mono);
     void slotSetOverviewMinuteMarkers(bool minuteMarkers);
     void slotSetOverviewScaling();
 
@@ -83,6 +84,7 @@ class DlgPrefWaveform : public DlgPreferencePage, public Ui::DlgPrefWaveformDlg 
 
     std::unique_ptr<ControlPushButton> m_pTypeControl;
     std::unique_ptr<ControlObject> m_pOverviewMinuteMarkersControl;
+    std::unique_ptr<ControlObject> m_pOverviewStereoControl;
 
     UserSettingsPointer m_pConfig;
     std::shared_ptr<Library> m_pLibrary;

--- a/src/preferences/dialog/dlgprefwaveformdlg.ui
+++ b/src/preferences/dialog/dlgprefwaveformdlg.ui
@@ -710,6 +710,14 @@ Select from different types of displays for the waveform overview, which differ 
      </item>
 
      <item row="1" column="1" colspan="4">
+      <widget class="QCheckBox" name="overviewStereoCheckBox">
+       <property name="text">
+        <string>Stereo mode</string>
+       </property>
+      </widget>
+     </item>
+
+     <item row="2" column="1" colspan="4">
       <widget class="QCheckBox" name="overviewMinuteMarkersCheckBox">
        <property name="text">
         <string>Show minute markers on waveform overview</string>
@@ -717,7 +725,7 @@ Select from different types of displays for the waveform overview, which differ 
       </widget>
      </item>
 
-     <item row="2" column="0">
+     <item row="3" column="0">
       <widget class="QLabel" name="overview_gain_label">
        <property name="toolTip">
         <string extracomment="Select a gain mode for the waveform overview."/>
@@ -727,7 +735,7 @@ Select from different types of displays for the waveform overview, which differ 
        </property>
       </widget>
      </item>
-     <item row="2" column="1" colspan="4">
+     <item row="3" column="1" colspan="4">
       <widget class="QRadioButton" name="overview_scale_normalize">
        <property name="text">
         <string>Normalize to peak</string>
@@ -737,7 +745,7 @@ Select from different types of displays for the waveform overview, which differ 
        </attribute>
       </widget>
      </item>
-     <item row="3" column="1" colspan="4">
+     <item row="4" column="1" colspan="4">
       <widget class="QRadioButton" name="overview_scale_allReplayGain">
        <property name="text">
         <string extracomment="'Global' refers to the 'Global' visual gain in the scrolling waveform settings">Use Waveform "Global" gain and ReplayGain (if enabled)</string>
@@ -891,6 +899,7 @@ Select from different types of displays for the waveform overview, which differ 
   <tabstop>untilMarkTextPointSizeSpinBox</tabstop>
   <tabstop>untilMarkTextHeightLimitComboBox</tabstop>
   <tabstop>waveformOverviewComboBox</tabstop>
+  <tabstop>overviewStereoCheckBox</tabstop>
   <tabstop>overviewMinuteMarkersCheckBox</tabstop>
   <tabstop>overview_scale_normalize</tabstop>
   <tabstop>overview_scale_allReplayGain</tabstop>

--- a/src/widget/woverview.cpp
+++ b/src/widget/woverview.cpp
@@ -45,6 +45,7 @@ WOverview::WOverview(
           m_group(group),
           m_pConfig(pConfig),
           m_type(OverviewType::RGB),
+          m_stereo(true),
           m_actualCompletion(0),
           m_pixmapDone(false),
           m_waveformPeak(-1.0),
@@ -96,6 +97,13 @@ WOverview::WOverview(
             this);
     m_pTypeControl->connectValueChanged(this, &WOverview::slotTypeControlChanged);
     slotTypeControlChanged(m_pTypeControl->get());
+
+    m_pStereoControl = make_parented<ControlProxy>(
+            QStringLiteral("[Waveform]"),
+            QStringLiteral("overview_stereo_mode"),
+            this);
+    m_pStereoControl->connectValueChanged(this, &WOverview::slotStereoControlChanged);
+    slotStereoControlChanged(m_pStereoControl->get());
 
     m_pMinuteMarkersControl = make_parented<ControlProxy>(
             QStringLiteral("[Waveform]"),
@@ -465,6 +473,18 @@ void WOverview::slotTypeControlChanged(double v) {
     slotWaveformSummaryUpdated();
 }
 
+void WOverview::slotStereoControlChanged(double v) {
+    bool stereo = v > 0;
+    if (stereo == m_stereo) {
+        return;
+    }
+
+    m_stereo = stereo;
+    // Enforce generation of the new stereo/mono source image
+    m_waveformSourceImage = QImage();
+    slotWaveformSummaryUpdated();
+}
+
 void WOverview::slotMinuteMarkersChanged(bool /*unused*/) {
     update();
 }
@@ -735,6 +755,10 @@ void WOverview::drawEndOfTrackBackground(QPainter* pPainter) {
 }
 
 void WOverview::drawAxis(QPainter* pPainter) {
+    if (!m_stereo) {
+        return;
+    }
+
     PainterScope painterScope(pPainter);
     pPainter->setPen(QPen(m_axesColor, m_scaleFactor));
     if (m_orientation == Qt::Horizontal) {
@@ -779,7 +803,7 @@ void WOverview::drawWaveformPixmap(QPainter* pPainter) {
 
     if (m_diffGain != diffGain || m_waveformImageScaled.isNull()) {
         const QRect sourceRect(0,
-                static_cast<int>(diffGain),
+                (m_stereo ? 1 : 2) * static_cast<int>(diffGain),
                 m_waveformSourceImage.width(),
                 m_waveformSourceImage.height() -
                         2 * static_cast<int>(diffGain));
@@ -829,14 +853,20 @@ void WOverview::drawMinuteMarkers(QPainter* pPainter) {
         if (m_orientation == Qt::Horizontal) {
             line.setLine(currentMarkerXPos, 0.0, currentMarkerXPos, markerHeight);
             pPainter->drawLine(line);
-            line.setLine(currentMarkerXPos, lowerMarkerYPos, currentMarkerXPos, overviewHeight);
-            pPainter->drawLine(line);
+            // Draw bottom markers only in stereo mode
+            if (m_stereo) {
+                line.setLine(currentMarkerXPos, lowerMarkerYPos, currentMarkerXPos, overviewHeight);
+                pPainter->drawLine(line);
+            }
         } else {
             // untested, best effort basis
             line.setLine(0.0, currentMarkerXPos, markerHeight, currentMarkerXPos);
             pPainter->drawLine(line);
-            line.setLine(lowerMarkerYPos, currentMarkerXPos, overviewHeight, currentMarkerXPos);
-            pPainter->drawLine(line);
+            // Draw right markers only in stereo mode
+            if (m_stereo) {
+                line.setLine(lowerMarkerYPos, currentMarkerXPos, overviewHeight, currentMarkerXPos);
+                pPainter->drawLine(line);
+            }
         }
     }
 }
@@ -892,18 +922,21 @@ void WOverview::drawAnalyzerProgress(QPainter* pPainter) {
     if ((m_analyzerProgress >= kAnalyzerProgressNone) &&
             (m_analyzerProgress < kAnalyzerProgressDone)) {
         PainterScope painterScope(pPainter);
-        pPainter->setPen(QPen(m_playPosColor, 3 * m_scaleFactor));
+        double penWidth = 3 * m_scaleFactor;
+        pPainter->setPen(QPen(m_playPosColor, penWidth));
 
         if (m_analyzerProgress > kAnalyzerProgressNone) {
             if (m_orientation == Qt::Horizontal) {
+                double y = m_stereo ? height() / 2 : height() - penWidth / 2;
                 pPainter->drawLine(QLineF(width() * m_analyzerProgress,
-                        height() / 2,
+                        y,
                         width(),
-                        height() / 2));
+                        y));
             } else {
-                pPainter->drawLine(QLineF(width() / 2,
+                double x = m_stereo ? width() / 2 : width() - penWidth / 2;
+                pPainter->drawLine(QLineF(x,
                         height() * m_analyzerProgress,
-                        width() / 2,
+                        x,
                         height()));
             }
         }
@@ -1471,21 +1504,24 @@ bool WOverview::drawNextPixmapPart() {
                 pWaveform,
                 &m_actualCompletion,
                 nextCompletion,
-                m_signalColors);
+                m_signalColors,
+                !m_stereo);
     } else if (m_type == OverviewType::HSV) {
         waveformOverviewRenderer::drawWaveformPartHSV(
                 &painter,
                 pWaveform,
                 &m_actualCompletion,
                 nextCompletion,
-                m_signalColors);
+                m_signalColors,
+                !m_stereo);
     } else { // OverviewType::RGB:
         waveformOverviewRenderer::drawWaveformPartRGB(
                 &painter,
                 pWaveform,
                 &m_actualCompletion,
                 nextCompletion,
-                m_signalColors);
+                m_signalColors,
+                !m_stereo);
     }
 
     m_waveformImageScaled = QImage();

--- a/src/widget/woverview.h
+++ b/src/widget/woverview.h
@@ -68,6 +68,7 @@ class WOverview : public WWidget, public TrackDropTarget {
     void slotCueMenuPopupAboutToHide();
 
     void slotTypeControlChanged(double v);
+    void slotStereoControlChanged(double v);
     void slotMinuteMarkersChanged(bool v);
     void slotScalingChanged();
 
@@ -147,6 +148,7 @@ class WOverview : public WWidget, public TrackDropTarget {
     UserSettingsPointer m_pConfig;
 
     mixxx::OverviewType m_type;
+    bool m_stereo;
     int m_actualCompletion;
     bool m_pixmapDone;
     float m_waveformPeak;
@@ -195,6 +197,7 @@ class WOverview : public WWidget, public TrackDropTarget {
     PollingControlProxy m_playpositionControl;
     parented_ptr<ControlProxy> m_pPassthroughControl;
     parented_ptr<ControlProxy> m_pTypeControl;
+    parented_ptr<ControlProxy> m_pStereoControl;
     parented_ptr<ControlProxy> m_pMinuteMarkersControl;
     // Controls to trigger update of amplitude scaling
     parented_ptr<ControlProxy> m_pReplayGain;


### PR DESCRIPTION
This should allow to show more details, especially in small overviews.

![overview-mono-option](https://github.com/user-attachments/assets/ce3d61d4-bae0-4357-a436-a08e43e28915)
In mono mode
* axis is not drawn
* minute markers only at the top
* "Analyzing" progress bar at the bottom

Based on #14463