### PR TITLE
fix: screensaver.cpp macro if undefined error

### DIFF
--- a/src/util/screensaver.cpp
+++ b/src/util/screensaver.cpp
@@ -283,7 +283,7 @@ void ScreenSaverHelper::uninhibitInternal()
     }
 }
 
-#elif HAS_XWINDOW_SCREENSAVER
+#elif defined(HAS_XWINDOW_SCREENSAVER) && HAS_XWINDOW_SCREENSAVER
 // This is untested.
 struct LibXtst : public library {
   function<int (Display*, unsigned int, Bool, unsigned long)> XTestFakeKeyEvent;


### PR DESCRIPTION
#15296