### PR TITLE
fix Computer -> "Refresh directory tree" slot

### DIFF
--- a/src/library/treeitemmodel.cpp
+++ b/src/library/treeitemmodel.cpp
@@ -176,7 +176,10 @@ void TreeItemModel::insertTreeItemRows(
     }
 
     TreeItem* pParentItem = getItem(parent);
-    DEBUG_ASSERT(pParentItem != nullptr);
+    VERIFY_OR_DEBUG_ASSERT(pParentItem != nullptr) {
+        qWarning() << "TreeItemModel::insertTreeItemRows: parent item invalid, abort.";
+        return;
+    }
 
     beginInsertRows(parent, position, position + static_cast<int>(rows.size()) - 1);
     pParentItem->insertChildren(position, std::move(rows));


### PR DESCRIPTION
Reported here https://github.com/mixxxdj/mixxx/issues/13989#issuecomment-3250626307
confirmed.

"Refresh directory tree" is broken since dfb2328f6faf76329d5615cd36c0859d4e323be8, the child items that are supposed to be added to the clicked item are now added to the top level, and only a restart fixes this.

I dived a bit into QModelIndex, c++ reference and tried to understand the bug.
I'll try to explain it. let's see if I got it right:

#### The root cause
* we right-click a path item in the sidebar, its index is stored in `m_lastRightClickedIndex`
* in case of "Refresh directory tree" we then call `onLazyChildExpandation()`
= pass `m_lastRightClickedIndex` by reference
* `onLazyChildExpandation()` first removes the items children
-> since dfb2328f6faf76329d5615cd36c0859d4e323be8 `rowsAboutToBeRemoved` causes `m_lastRightClickedIndex` to be invalidated
* now the reference to `m_lastRightClickedIndex` used in `onLazyChildExpandation()` is also invalid
= `TreeItemModel::insertTreeItemRows()` is now being called with an invalid index
= items are added to the root item = bug [#13989 comment](https://github.com/mixxxdj/mixxx/issues/13989#issuecomment-3250626307)

#### Working fixes:
1. in `onLazyChildExpandation()`, copy index. The copy would now hold a pointer to the original sidebar index and we can safely work with the copy even if we invalidate `m_lastRightClickedIndex`.
2. Use [`QPersistentModelIndex`](https://doc.qt.io/qt-6/qpersistentmodelindex.html#details)
Same as the copy but with extra benefits (which don't really need in `onLazyChildExpandation()`)
   > Unlike the [QModelIndex](https://doc.qt.io/qt-6/qmodelindex.html) class, it is safe to store a QPersistentModelIndex since the model will ensure that references to items will continue to be valid as long as they can be accessed by the model.
