### PR TITLE
(fix) Computer feature: parse artist+title from filename if both tags are empty

### DIFF
--- a/src/library/browse/browsethread.cpp
+++ b/src/library/browse/browsethread.cpp
@@ -178,12 +178,22 @@ void BrowseThread::populateModel() {
             item->setData(item->text(), Qt::UserRole);
             row_data.insert(COLUMN_FILENAME, item);
 
-            item = new QStandardItem(trackMetadata.getTrackInfo().getArtist());
+            QString artist = trackMetadata.getTrackInfo().getArtist();
+            QString title = trackMetadata.getTrackInfo().getTitle();
+            if (artist.isEmpty() && title.isEmpty()) {
+                if (trackMetadata.refTrackInfo().parseArtistTitleFromFileName(
+                            fileAccess.info().fileName(), true)) {
+                    artist = trackMetadata.getTrackInfo().getArtist();
+                    title = trackMetadata.getTrackInfo().getTitle();
+                }
+            }
+
+            item = new QStandardItem(artist);
             item->setToolTip(item->text());
             item->setData(item->text(), Qt::UserRole);
             row_data.insert(COLUMN_ARTIST, item);
 
-            item = new QStandardItem(trackMetadata.getTrackInfo().getTitle());
+            item = new QStandardItem(title);
             item->setToolTip(item->text());
             item->setData(item->text(), Qt::UserRole);
             row_data.insert(COLUMN_TITLE, item);


### PR DESCRIPTION
Fixes the issue reported
here [Zulip #general > Library columns: Rating in "Computer," FileName in "Tracks" @ 💬](https://mixxx.zulipchat.com/#narrow/channel/109122-general/topic/Library.20columns.3A.20Rating.20in.20.22Computer.2C.22.20FileName.20in.20.22Tracks.22/near/537324078)
and here https://mixxx.discourse.group/t/problem-name-attribute-on-directory-browsing-mixxx-252-on-mint-xia/32672

Adopted from the [track import procedure](https://github.com/mixxxdj/mixxx/blob/bdff18d3ce424e79ae1f642d92095d350e07678b/src/sources/soundsourceproxy.cpp#L814)

It works as desired, but I didn't measure performance or anything.