### PR TITLE
(fix) RateControl: initialize `m_pVCEnabled` with nullptr for samplers

### DIFF
--- a/src/engine/controls/ratecontrol.cpp
+++ b/src/engine/controls/ratecontrol.cpp
@@ -100,6 +100,7 @@ RateControl::RateControl(const QString& group, UserSettingsPointer pConfig)
                   ConfigKey(group, QStringLiteral("jog")))),
           // FIXME: The filter length should be dependent on sample rate/block size or something
           m_pJogFilter(std::make_unique<Rotary>(25)),
+          m_pVCEnabled(nullptr),
           m_syncMode(group, QStringLiteral("sync_mode")),
           m_slipEnabled(group, QStringLiteral("slip_enabled")),
           m_wrapAroundCount(0),


### PR DESCRIPTION
Closes #15288 
Mixxx crashes in RateControl when loading `samplers.txt` during startup

Fixup for #15175

