### PR TITLE
Playlists: allow to adopt current order (sorted) as playlist order

### DIFF
--- a/src/library/dao/playlistdao.cpp
+++ b/src/library/dao/playlistdao.cpp
@@ -1116,6 +1116,45 @@ int PlaylistDAO::tracksInPlaylist(const int playlistId) const {
     return count;
 }
 
+void PlaylistDAO::orderTracksByCurrPos(const int playlistId,
+        QList<std::pair<TrackId, int>>& newOrder) {
+    if (newOrder.isEmpty() ||
+            playlistId == kInvalidPlaylistId ||
+            isPlaylistLocked(playlistId) ||
+            newOrder.size() != tracksInPlaylist(playlistId)) {
+        return;
+    }
+
+    ScopedTransaction transaction(m_database);
+    QSqlQuery query(m_database);
+    query.prepare(QStringLiteral(
+            "UPDATE PlaylistTracks "
+            "SET position=:new_pos "
+            "WHERE position=:old_pos AND "
+            "track_id=:track_id AND "
+            "playlist_id=:pl_id"));
+    int newPos = 1;
+    for (auto [trackId, oldPos] : newOrder) {
+        VERIFY_OR_DEBUG_ASSERT(trackId.isValid()) {
+            return;
+        }
+        query.bindValue(":new_pos", newPos++);
+        query.bindValue(":old_pos", oldPos);
+        query.bindValue(":track_id", trackId.toVariant());
+        query.bindValue(":pl_id", playlistId);
+        if (!query.exec()) {
+            // We temporarily have duplicate positions, so abort the entire operation
+            // to not leave the playlist with an invalid state.
+            LOG_FAILED_QUERY(query);
+            return;
+        }
+    }
+
+    transaction.commit();
+
+    emit tracksMoved(QSet<int>{playlistId});
+}
+
 void PlaylistDAO::moveTrack(const int playlistId, const int oldPosition, const int newPosition) {
     ScopedTransaction transaction(m_database);
     QSqlQuery query(m_database);

--- a/src/library/dao/playlistdao.h
+++ b/src/library/dao/playlistdao.h
@@ -110,6 +110,10 @@ class PlaylistDAO : public QObject, public virtual DAO {
     bool copyPlaylistTracks(const int sourcePlaylistID, const int targetPlaylistID);
     // Returns the number of tracks in the given playlist.
     int tracksInPlaylist(const int playlistId) const;
+    // This receives a track list that represents the current order (sorted by BPM for example)
+    // and adopts this order for `position` in the playlist.
+    // Returns true on success.
+    void orderTracksByCurrPos(const int playlistId, QList<std::pair<TrackId, int>>& newOrder);
     // moved Track to a new position
     void moveTrack(const int playlistId,
             const int oldPosition, const int newPosition);

--- a/src/library/playlisttablemodel.cpp
+++ b/src/library/playlisttablemodel.cpp
@@ -315,7 +315,7 @@ void PlaylistTableModel::shuffleTracks(const QModelIndexList& shuffle, const QMo
     int numOfTracks = rowCount();
     if (shuffle.count() > 1) {
         // if there is more then one track selected, shuffle selection only
-        foreach (QModelIndex shuffleIndex, shuffle) {
+        for (const QModelIndex& shuffleIndex : std::as_const(shuffle)) {
             int oldPosition = shuffleIndex.sibling(shuffleIndex.row(), positionColumn).data().toInt();
             if (oldPosition != excludePos) {
                 positions.append(oldPosition);
@@ -337,6 +337,23 @@ void PlaylistTableModel::shuffleTracks(const QModelIndexList& shuffle, const QMo
         allIds.insert(position, trackId);
     }
     m_pTrackCollectionManager->internalCollection()->getPlaylistDAO().shuffleTracks(m_iPlaylistId, positions, allIds);
+}
+
+void PlaylistTableModel::orderTracksByCurrPos() {
+    QList<std::pair<TrackId, int>> idPosList;
+    int numOfTracks = rowCount();
+    idPosList.reserve(numOfTracks);
+    const int positionColumn = fieldIndex(ColumnCache::COLUMN_PLAYLISTTRACKSTABLE_POSITION);
+    const int idColumn = fieldIndex(ColumnCache::COLUMN_LIBRARYTABLE_ID);
+    // Set up list of all IDs
+    for (int i = 0; i < numOfTracks; i++) {
+        TrackId trackId(index(i, idColumn).data());
+        int oldPosition = index(i, positionColumn).data().toInt();
+        idPosList.append(std::make_pair(trackId, oldPosition));
+    }
+    m_pTrackCollectionManager->internalCollection()
+            ->getPlaylistDAO()
+            .orderTracksByCurrPos(m_iPlaylistId, idPosList);
 }
 
 const QList<int> PlaylistTableModel::getSelectedPositions(const QModelIndexList& indices) const {

--- a/src/library/playlisttablemodel.h
+++ b/src/library/playlisttablemodel.h
@@ -21,7 +21,9 @@ class PlaylistTableModel final : public TrackSetTableModel {
     bool appendTrack(TrackId trackId);
     void moveTrack(const QModelIndex& sourceIndex, const QModelIndex& destIndex) override;
     void removeTrack(const QModelIndex& index);
-    void shuffleTracks(const QModelIndexList& shuffle, const QModelIndex& exclude);
+    void shuffleTracks(const QModelIndexList& shuffle = QModelIndexList(),
+            const QModelIndex& exclude = QModelIndex());
+    void orderTracksByCurrPos();
 
     bool isColumnInternal(int column) final;
     bool isColumnHiddenByDefault(int column) final;

--- a/src/library/trackset/playlistfeature.h
+++ b/src/library/trackset/playlistfeature.h
@@ -37,6 +37,7 @@ class PlaylistFeature : public BasePlaylistFeature {
     void slotPlaylistContentOrLockChanged(const QSet<int>& playlistIds) override;
     void slotPlaylistTableRenamed(int playlistId, const QString& newName) override;
     void slotShufflePlaylist();
+    void slotOrderTracksByCurrentPosition();
     void slotUnlockAllPlaylists();
     void slotDeleteAllUnlockedPlaylists();
 
@@ -49,6 +50,7 @@ class PlaylistFeature : public BasePlaylistFeature {
     QString getRootViewHtml() const override;
 
     parented_ptr<QAction> m_pShufflePlaylistAction;
+    parented_ptr<QAction> m_pOrderByCurrentPosAction;
     parented_ptr<QAction> m_pUnlockPlaylistsAction;
     parented_ptr<QAction> m_pDeleteAllUnlockedPlaylistsAction;
 };


### PR DESCRIPTION
Closes #15315 

* select a playlist with 2++ tracks, ensure # colummn is visible (just for feedback)
* sort playlist by BPM (or key or whatever, just not by # obviously)
* open track table header menu, click "Adopt sort order"
* tracks' # is now ascending, sort by # and BPM are ascending

![playlist-adopt-sort-order](https://github.com/user-attachments/assets/3ff1dc53-cf6f-4df6-ac41-905b4b65f5b5)

I decided for a separate function instead of doing multiple `moveTrack`.
