### PR TITLE
(fix) Library scanner: make Cancel button work again

### DIFF
--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -497,6 +497,8 @@ void LibraryScanner::queueTask(ScannerTask* pTask) {
     //kLogger.debug() << "queueTask" << pTask;
     ScopedTimer timer(u"LibraryScanner::queueTask");
     if (m_scannerGlobal.isNull() || m_scannerGlobal->shouldCancel()) {
+        delete pTask;
+        m_pool.clear();
         return;
     }
     m_scannerGlobal->getTaskWatcher().watchTask();

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -574,6 +574,17 @@ void LibraryScanner::slotTrackExists(const QString& trackPath) {
 
 void LibraryScanner::slotAddNewTrack(const QString& trackPath) {
     // kLogger.debug() << "slotAddNewTrack" << trackPath;
+    if (!m_scannerGlobal || m_scannerGlobal->shouldCancel()) {
+        // Fix/workaround for Cancel not cancelling the entire scan process
+        // https://github.com/mixxxdj/mixxx/issues/14940
+        // Pretty quickly after starting the scan, many ImportFilesTask queue
+        // many addNewTrack() signals connected to this slot. When cancelling the
+        // scan via Cancel button in the progress dialog, all signals are usually
+        // already queued, hence Cancel has no effect on these calls and Mixxx
+        // keeps adding/analyzing tracks as if nothing happened.
+        // Simply abort here does the trick.
+        return;
+    }
     ScopedTimer timer(u"LibraryScanner::addNewTrack");
     // For statistics tracking and to detect moved tracks
     TrackPointer pTrack = m_trackDao.addTracksAddFile(

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -138,7 +138,8 @@ LibraryScanner::LibraryScanner(
     connect(m_pProgressDlg.data(),
             &LibraryScannerDlg::scanCancelled,
             this,
-            &LibraryScanner::slotCancel);
+            &LibraryScanner::slotCancel,
+            Qt::DirectConnection);
     connect(&m_trackDao,
             &TrackDAO::progressVerifyTracksOutside,
             m_pProgressDlg.data(),


### PR DESCRIPTION
Closes #14940 

Extracted fixes from #15156 which traces the scan flow.

1. **Cancel button "doesn't work"**
Pretty quickly after starting the scan, many ImportFilesTask (separate thread(s)) queue many `addNewTrack()` signals.
So when cancelling the scan via Cancel button, the `cancel` signal is at the end of the queue and is not processed immediately.
Fix: use explicit Qt:DirectConnection
2. **Even if, with fix 1., the dialog is closed, but the track import keeps running in the background**
`ScannerGlobal::shouldCancel()` is considered only when/before each file import task is processing a file and queing signals, and as mentioned, that happens almost immediately after starting the scan.
= Cancel has currently no effect in `slotAddTrack()` calls and Mixxx continues processing the queued signals and keeps adding/analyzing tracks as if nothing happened.
Fix: check `shouldCancel()` when entering `slotAddTrack()` and return if it's true.


