### PR TITLE
Fixes different scaling of scrolling waveforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1629,6 +1629,7 @@ add_library(
   src/waveform/renderers/waveformrendererpreroll.cpp
   src/waveform/renderers/waveformrendererrgb.cpp
   src/waveform/renderers/waveformrenderersignalbase.cpp
+  src/waveform/renderers/waveformrenderersimplesignal.cpp
   src/waveform/renderers/waveformrendermark.cpp
   src/waveform/renderers/waveformrendermarkbase.cpp
   src/waveform/renderers/waveformrendermarkrange.cpp
@@ -1645,6 +1646,7 @@ add_library(
   src/waveform/widgets/emptywaveformwidget.cpp
   src/waveform/widgets/hsvwaveformwidget.cpp
   src/waveform/widgets/rgbwaveformwidget.cpp
+  src/waveform/widgets/simplesignalwaveformwidget.cpp
   src/waveform/widgets/softwarewaveformwidget.cpp
   src/waveform/widgets/waveformwidgetabstract.cpp
   src/waveform/widgets/glwaveformwidgetabstract.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -327,7 +327,11 @@ option(QT6 "Build with Qt6" ON)
 # Once this is fixed we can revert the commit introducing this.
 option(QML "Build with QML" OFF)
 
-option(QOPENGL "Use QOpenGLWindow based widget instead of QGLWidget" ON)
+if(QT6)
+  set(QOPENGL ON CACHE INTERNAL "Forced ON because QT6=ON")
+else()
+  option(QOPENGL "Use QOpenGLWindow based widget instead of QGLWidget" ON)
+endif()
 
 if(QOPENGL)
   add_compile_definitions(MIXXX_USE_QOPENGL)

--- a/res/shaders/filteredsignal.frag
+++ b/res/shaders/filteredsignal.frag
@@ -71,13 +71,6 @@ void main(void) {
       lowShowing = signalDistance.x >= 0.0;
       midShowing = signalDistance.y >= 0.0;
       highShowing = signalDistance.z >= 0.0;
-
-      // Now do it all over again for the unscaled version of the waveform,
-      // which we will draw at very low opacity.
-      vec4 signalDistanceUnscaled = new_currentDataUnscaled - ourDistance;
-      lowShowingUnscaled = signalDistanceUnscaled.x >= 0.0;
-      midShowingUnscaled = signalDistanceUnscaled.y >= 0.0;
-      highShowingUnscaled = signalDistanceUnscaled.z >= 0.0;
     }
 
     // Draw the axes color as the lowest item on the screen.
@@ -86,22 +79,6 @@ void main(void) {
     // value should be based on the size of the widget.
     if (abs(framebufferSize.y / 2 - pixel.y) <= 4) {
       outputColor.xyz = mix(outputColor.xyz, axesColor.xyz, axesColor.w);
-      outputColor.w = 1.0;
-    }
-
-    if (lowShowingUnscaled) {
-      float lowAlpha = 0.2;
-      outputColor.xyz = mix(outputColor.xyz, lowColor.xyz, lowAlpha);
-      outputColor.w = 1.0;
-    }
-    if (midShowingUnscaled) {
-      float midAlpha = 0.2;
-      outputColor.xyz = mix(outputColor.xyz, midColor.xyz, midAlpha);
-      outputColor.w = 1.0;
-    }
-    if (highShowingUnscaled) {
-      float highAlpha = 0.2;
-      outputColor.xyz = mix(outputColor.xyz, highColor.xyz, highAlpha);
       outputColor.w = 1.0;
     }
 

--- a/res/shaders/rgbsignal.frag
+++ b/res/shaders/rgbsignal.frag
@@ -61,23 +61,11 @@ void main(void) {
       new_currentData.y *= midGain;
       new_currentData.z *= highGain;
 
-      //(vrince) debug see pre-computed signal
-      //gl_FragColor = new_currentData;
-      //return;
-
-      // Represents the [-1, 1] distance of this pixel. Subtracting this from
-      // the signal data in new_currentData, we can tell if a signal band should
-      // show in this pixel if the component is > 0.
+      // ourDistance represents the [0, 1] distance of this pixel from the
+      // center line. If ourDistance is smaller than the signalDistance, show
+      // the pixel.
       float ourDistance = abs((uv.y - 0.5) * 2.0);
-
-      // Since the magnitude of the (low, mid, high) vector is used as the
-      // waveform height, re-scale the maximum height to 1.
-      const float scaleFactor = 1.0 / sqrt(3.0);
-
-      float signalDistance = sqrt(new_currentData.x * new_currentData.x +
-                                  new_currentData.y * new_currentData.y +
-                                  new_currentData.z * new_currentData.z) *
-                             scaleFactor;
+      float signalDistance = new_currentData.w;
       showing = (signalDistance - ourDistance) >= 0.0;
 
       // Linearly combine the low, mid, and high colors according to the low,
@@ -97,8 +85,8 @@ void main(void) {
     // rendered even when the waveform is fairly short.  Really this
     // value should be based on the size of the widget.
     if (abs(framebufferSize.y / 2 - pixel.y) <= 4) {
-      outputColor.xyz = mix(outputColor.xyz, axesColor.xyz, axesColor.w);
-      outputColor.w = 1.0;
+        outputColor.xyz = mix(outputColor.xyz, axesColor.xyz, axesColor.w);
+        outputColor.w = 1.0;
     }
 
     if (showing) {

--- a/res/shaders/rgbsignal.frag
+++ b/res/shaders/rgbsignal.frag
@@ -90,24 +90,6 @@ void main(void) {
       float showingMax = max(showingColor.x, max(showingColor.y, showingColor.z));
       showingColor = showingColor / showingMax;
       showingColor.w = 1.0;
-
-      // Now do it all over again for the unscaled version of the waveform,
-      // which we will draw at very low opacity.
-      float signalDistanceUnscaled = sqrt(new_currentDataUnscaled.x * new_currentDataUnscaled.x +
-                                          new_currentDataUnscaled.y * new_currentDataUnscaled.y +
-                                          new_currentDataUnscaled.z * new_currentDataUnscaled.z) * scaleFactor;
-      showingUnscaled = (signalDistanceUnscaled - ourDistance) >= 0.0;
-
-      // Linearly combine the low, mid, and high colors according to the
-      // original low, mid, and high components.
-      showingUnscaledColor = lowColor * new_currentDataUnscaled.x +
-                             midColor * new_currentDataUnscaled.y +
-                             highColor * new_currentDataUnscaled.z;
-
-      // Re-scale the color by the maximum component.
-      float showingUnscaledMax = max(showingUnscaledColor.x, max(showingUnscaledColor.y, showingUnscaledColor.z));
-      showingUnscaledColor = showingUnscaledColor / showingUnscaledMax;
-      showingUnscaledColor.w = 1.0;
     }
 
     // Draw the axes color as the lowest item on the screen.
@@ -119,16 +101,10 @@ void main(void) {
       outputColor.w = 1.0;
     }
 
-    if (showingUnscaled) {
-      float alpha = 0.4;
-      outputColor.xyz = mix(outputColor.xyz, showingUnscaledColor.xyz, alpha);
-      outputColor.w = 1.0;
-    }
-
     if (showing) {
-      float alpha = 0.8;
-      outputColor.xyz = mix(outputColor.xyz, showingColor.xyz, alpha);
-      outputColor.w = 1.0;
+        float alpha = 1.0;
+        outputColor.xyz = mix(outputColor.xyz, showingColor.xyz, alpha);
+        outputColor.w = 1.0;
     }
     gl_FragColor = outputColor;
 

--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -390,10 +390,10 @@ void DlgPrefWaveform::slotResetToDefaults() {
                     WaveformWidgetFactory::defaultType()),
             true);
 
-    allVisualGain->setValue(1.0);
-    lowVisualGain->setValue(1.0);
-    midVisualGain->setValue(1.0);
-    highVisualGain->setValue(1.0);
+    allVisualGain->setValue(WaveformWidgetFactory::getVisualGainDefault(BandIndex::AllBand));
+    lowVisualGain->setValue(WaveformWidgetFactory::getVisualGainDefault(BandIndex::Low));
+    midVisualGain->setValue(WaveformWidgetFactory::getVisualGainDefault(BandIndex::Mid));
+    highVisualGain->setValue(WaveformWidgetFactory::getVisualGainDefault(BandIndex::High));
 
     // Default zoom level is 3 in WaveformWidgetFactory.
     defaultZoomComboBox->setCurrentIndex(3 + 1);
@@ -408,7 +408,7 @@ void DlgPrefWaveform::slotResetToDefaults() {
     overviewMinuteMarkersCheckBox->setChecked(true);
 
     // Use "Global" waveform gain + ReplayGain if enabled
-    overview_scale_allReplayGain->setChecked(true);
+    overview_scale_allReplayGain->setChecked(!WaveformWidgetFactory::isOverviewNormalizedDefault());
 
     // 60FPS is the default
     frameRateSlider->setValue(60);

--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -538,16 +538,16 @@ void DlgPrefWaveform::updateWaveformTypeOptions(bool useWaveform,
     }
 
     splitLeftRightCheckBox->setEnabled(useWaveform &&
-            supportedOption &
-                    allshader::WaveformRendererSignalBase::Option::SplitStereoSignal);
+            (supportedOption &
+                    allshader::WaveformRendererSignalBase::Option::SplitStereoSignal));
     highDetailCheckBox->setEnabled(useWaveform &&
-            supportedOption &
-                    allshader::WaveformRendererSignalBase::Option::HighDetail);
+            (supportedOption &
+                    allshader::WaveformRendererSignalBase::Option::HighDetail));
     splitLeftRightCheckBox->setChecked(splitLeftRightCheckBox->isEnabled() &&
-            currentOptions &
-                    allshader::WaveformRendererSignalBase::Option::SplitStereoSignal);
+            (currentOptions &
+                    allshader::WaveformRendererSignalBase::Option::SplitStereoSignal));
     highDetailCheckBox->setChecked(highDetailCheckBox->isEnabled() &&
-            currentOptions & allshader::WaveformRendererSignalBase::Option::HighDetail);
+            (currentOptions & allshader::WaveformRendererSignalBase::Option::HighDetail));
 #else
     splitLeftRightCheckBox->setVisible(false);
     highDetailCheckBox->setVisible(false);

--- a/src/waveform/renderers/allshader/waveformrendererfiltered.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererfiltered.cpp
@@ -81,7 +81,7 @@ bool WaveformRendererFiltered::preprocessInner() {
     // Per-band gain from the EQ knobs.
     float allGain(1.0);
     float bandGain[3] = {1.0, 1.0, 1.0};
-    getGains(&allGain, true, &bandGain[0], &bandGain[1], &bandGain[2]);
+    getGains(&allGain, &bandGain[0], &bandGain[1], &bandGain[2]);
 
     const float breadth = static_cast<float>(m_waveformRenderer->getBreadth());
     const float halfBreadth = breadth / 2.0f;

--- a/src/waveform/renderers/allshader/waveformrendererhsv.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererhsv.cpp
@@ -77,7 +77,7 @@ bool WaveformRendererHSV::preprocessInner() {
             (lastVisualFrame - firstVisualFrame) / static_cast<double>(pixelLength);
 
     float allGain(1.0);
-    getGains(&allGain, false, nullptr, nullptr, nullptr);
+    getGains(&allGain, nullptr, nullptr, nullptr);
 
     // Get base color of waveform in the HSV format (s and v isn't use)
     float h, s, v;

--- a/src/waveform/renderers/allshader/waveformrendererhsv.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererhsv.cpp
@@ -76,8 +76,8 @@ bool WaveformRendererHSV::preprocessInner() {
     const double visualIncrementPerPixel =
             (lastVisualFrame - firstVisualFrame) / static_cast<double>(pixelLength);
 
-    float allGain(1.0);
-    getGains(&allGain, nullptr, nullptr, nullptr);
+    float allGain(1.0), lowGain(1.0), midGain(1.0), highGain(1.0);
+    getGains(&allGain, &lowGain, &midGain, &highGain);
 
     // Get base color of waveform in the HSV format (s and v isn't use)
     float h, s, v;
@@ -137,9 +137,15 @@ bool WaveformRendererHSV::preprocessInner() {
             for (int i = visualIndexStart + chn; i < visualIndexStop + chn; i += 2) {
                 const WaveformData& waveformData = data[i];
 
-                u8maxLow = math_max(u8maxLow, waveformData.filtered.low);
-                u8maxMid = math_max(u8maxMid, waveformData.filtered.mid);
-                u8maxHigh = math_max(u8maxHigh, waveformData.filtered.high);
+                u8maxLow = math_max(u8maxLow,
+                        static_cast<uchar>(
+                                waveformData.filtered.low * lowGain));
+                u8maxMid = math_max(u8maxMid,
+                        static_cast<uchar>(
+                                waveformData.filtered.mid * midGain));
+                u8maxHigh = math_max(u8maxHigh,
+                        static_cast<uchar>(
+                                waveformData.filtered.high * highGain));
                 u8maxAll = math_max(u8maxAll, waveformData.filtered.all);
             }
 

--- a/src/waveform/renderers/allshader/waveformrendererrgb.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererrgb.cpp
@@ -107,8 +107,7 @@ bool WaveformRendererRGB::preprocessInner() {
 
     // Per-band gain from the EQ knobs.
     float allGain(1.0), lowGain(1.0), midGain(1.0), highGain(1.0);
-    // applyCompensation = false, as we scale to match filtered.all
-    getGains(&allGain, false, &lowGain, &midGain, &highGain);
+    getGains(&allGain, &lowGain, &midGain, &highGain);
 
     const float breadth = static_cast<float>(m_waveformRenderer->getBreadth());
     const float halfBreadth = breadth / 2.0f;

--- a/src/waveform/renderers/allshader/waveformrendererrgb.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererrgb.cpp
@@ -12,12 +12,6 @@ using namespace rendergraph;
 
 namespace allshader {
 
-namespace {
-inline float math_pow2(float x) {
-    return x * x;
-}
-} // namespace
-
 WaveformRendererRGB::WaveformRendererRGB(WaveformWidgetRenderer* waveformWidget,
         ::WaveformRendererAbstract::PositionSource type,
         WaveformRendererSignalBase::Options options)
@@ -197,30 +191,10 @@ bool WaveformRendererRGB::preprocessInner() {
             float maxMid = static_cast<float>(u8maxMid[chn]);
             float maxHigh = static_cast<float>(u8maxHigh[chn]);
 
-            // Calculate the squared magnitude of the maxLow, maxMid and maxHigh values.
-            // We take the square root to get the magnitude below.
-            const float sum = math_pow2(maxLow) + math_pow2(maxMid) + math_pow2(maxHigh);
-
             // Apply the gains
             maxLow *= lowGain;
             maxMid *= midGain;
             maxHigh *= highGain;
-
-            // Calculate the squared magnitude of the gained maxLow, maxMid and maxHigh values
-            // We take the square root to get the magnitude below.
-            const float sumGained = math_pow2(maxLow) + math_pow2(maxMid) + math_pow2(maxHigh);
-
-            // The maxAll values will be used to draw the amplitude. We scale them according to
-            // magnitude of the gained maxLow, maxMid and maxHigh values
-            if (sum != 0.f) {
-                // magnitude = sqrt(sum) and magnitudeGained = sqrt(sumGained), and
-                // factor = magnitudeGained / magnitude, but we can do with a single sqrt:
-                const float factor = std::sqrt(sumGained / sum);
-                maxAllChn[chn] *= factor;
-                if (!splitLeftRight) {
-                    maxAllChn[chn + 1] *= factor;
-                }
-            }
 
             // Use the gained maxLow, maxMid and maxHigh values to calculate the color components
             float red = maxLow * low_r + maxMid * mid_r + maxHigh * high_r;

--- a/src/waveform/renderers/allshader/waveformrenderersimple.cpp
+++ b/src/waveform/renderers/allshader/waveformrenderersimple.cpp
@@ -83,7 +83,7 @@ bool WaveformRendererSimple::preprocessInner() {
     // Per-band gain from the EQ knobs.
     float allGain{1.0};
     float bandGain[3] = {1.0, 1.0, 1.0};
-    getGains(&allGain, false, &bandGain[0], &bandGain[1], &bandGain[2]);
+    getGains(&allGain, &bandGain[0], &bandGain[1], &bandGain[2]);
 
     const float breadth = static_cast<float>(m_waveformRenderer->getBreadth());
     const float halfBreadth = breadth / 2.0f;

--- a/src/waveform/renderers/allshader/waveformrendererstem.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererstem.cpp
@@ -155,8 +155,7 @@ bool WaveformRendererStem::preprocessInner() {
 
     // Per-band gain from the EQ knobs.
     float allGain(1.0);
-    // applyCompensation = false, as we scale to match filtered.all
-    getGains(&allGain, false, nullptr, nullptr, nullptr);
+    getGains(&allGain, nullptr, nullptr, nullptr);
 
     const float breadth = static_cast<float>(m_waveformRenderer->getBreadth());
     const float stemBreadth = m_splitStemTracks ? breadth / 4.0f : 0;

--- a/src/waveform/renderers/allshader/waveformrenderertextured.cpp
+++ b/src/waveform/renderers/allshader/waveformrenderertextured.cpp
@@ -327,7 +327,7 @@ void WaveformRendererTextured::paintGL() {
 
     // Per-band gain from the EQ knobs.
     float lowGain(1.0), midGain(1.0), highGain(1.0), allGain(1.0);
-    getGains(&allGain, true, &lowGain, &midGain, &highGain);
+    getGains(&allGain, &lowGain, &midGain, &highGain);
 
     const auto firstVisualIndex = static_cast<GLfloat>(
             m_waveformRenderer->getFirstDisplayedPosition(positionType) * trackSamples /

--- a/src/waveform/renderers/waveformrendererfilteredsignal.cpp
+++ b/src/waveform/renderers/waveformrendererfilteredsignal.cpp
@@ -172,20 +172,29 @@ void WaveformRendererFilteredSignal::draw(QPainter* painter,
             switch (m_alignment) {
                 case Qt::AlignBottom :
                 case Qt::AlignRight :
-                    m_lowLines[actualLowLineNumber].setLine(
-                        x, breadth,
-                        x, breadth - (int)(heightFactor*lowGain*(float)math_max(maxLow[0],maxLow[1])));
+                    m_lowLines[actualLowLineNumber].setLine(x,
+                            breadth,
+                            x,
+                            breadth -
+                                    static_cast<int>(heightFactor * lowGain *
+                                            (float)math_max(
+                                                    maxLow[0], maxLow[1])));
                     break;
                 case Qt::AlignTop :
                 case Qt::AlignLeft :
-                    m_lowLines[actualLowLineNumber].setLine(
-                        x, 0,
-                        x, (int)(heightFactor*lowGain*(float)math_max(maxLow[0],maxLow[1])));
+                    m_lowLines[actualLowLineNumber].setLine(x,
+                            0,
+                            x,
+                            static_cast<int>(heightFactor * lowGain *
+                                    (float)math_max(maxLow[0], maxLow[1])));
                     break;
                 default :
-                    m_lowLines[actualLowLineNumber].setLine(
-                        x, (int)(halfBreadth-heightFactor*(float)maxLow[0]*lowGain),
-                        x, (int)(halfBreadth+heightFactor*(float)maxLow[1]*lowGain));
+                    m_lowLines[actualLowLineNumber].setLine(x,
+                            static_cast<int>(halfBreadth -
+                                    heightFactor * (float)maxLow[0] * lowGain),
+                            x,
+                            static_cast<int>(halfBreadth +
+                                    heightFactor * (float)maxLow[1] * lowGain));
                     break;
             }
             actualLowLineNumber++;
@@ -194,20 +203,29 @@ void WaveformRendererFilteredSignal::draw(QPainter* painter,
             switch (m_alignment) {
                 case Qt::AlignBottom :
                 case Qt::AlignRight :
-                    m_midLines[actualMidLineNumber].setLine(
-                        x, breadth,
-                        x, breadth - (int)(heightFactor*midGain*(float)math_max(maxMid[0],maxMid[1])));
+                    m_midLines[actualMidLineNumber].setLine(x,
+                            breadth,
+                            x,
+                            breadth -
+                                    static_cast<int>(heightFactor * midGain *
+                                            (float)math_max(
+                                                    maxMid[0], maxMid[1])));
                     break;
                 case Qt::AlignTop :
                 case Qt::AlignLeft :
-                    m_midLines[actualMidLineNumber].setLine(
-                        x, 0,
-                        x, (int)(heightFactor*midGain*(float)math_max(maxMid[0],maxMid[1])));
+                    m_midLines[actualMidLineNumber].setLine(x,
+                            0,
+                            x,
+                            static_cast<int>(heightFactor * midGain *
+                                    (float)math_max(maxMid[0], maxMid[1])));
                     break;
                 default :
-                    m_midLines[actualMidLineNumber].setLine(
-                        x, (int)(halfBreadth-heightFactor*(float)maxMid[0]*midGain),
-                        x, (int)(halfBreadth+heightFactor*(float)maxMid[1]*midGain));
+                    m_midLines[actualMidLineNumber].setLine(x,
+                            static_cast<int>(halfBreadth -
+                                    heightFactor * (float)maxMid[0] * midGain),
+                            x,
+                            static_cast<int>(halfBreadth +
+                                    heightFactor * (float)maxMid[1] * midGain));
                     break;
             }
             actualMidLineNumber++;
@@ -216,20 +234,31 @@ void WaveformRendererFilteredSignal::draw(QPainter* painter,
             switch (m_alignment) {
                 case Qt::AlignBottom :
                 case Qt::AlignRight :
-                    m_highLines[actualHighLineNumber].setLine(
-                        x, breadth,
-                        x, breadth - (int)(heightFactor*highGain*(float)math_max(maxHigh[0],maxHigh[1])));
+                    m_highLines[actualHighLineNumber].setLine(x,
+                            breadth,
+                            x,
+                            breadth -
+                                    static_cast<int>(heightFactor * highGain *
+                                            (float)math_max(
+                                                    maxHigh[0], maxHigh[1])));
                     break;
                 case Qt::AlignTop :
                 case Qt::AlignLeft :
-                    m_highLines[actualHighLineNumber].setLine(
-                        x, 0,
-                        x, (int)(heightFactor*highGain*(float)math_max(maxHigh[0],maxHigh[1])));
+                    m_highLines[actualHighLineNumber].setLine(x,
+                            0,
+                            x,
+                            static_cast<int>(heightFactor * highGain *
+                                    (float)math_max(maxHigh[0], maxHigh[1])));
                     break;
                 default :
-                    m_highLines[actualHighLineNumber].setLine(
-                        x, (int)(halfBreadth-heightFactor*(float)maxHigh[0]*highGain),
-                        x, (int)(halfBreadth+heightFactor*(float)maxHigh[1]*highGain));
+                    m_highLines[actualHighLineNumber].setLine(x,
+                            static_cast<int>(halfBreadth -
+                                    heightFactor * (float)maxHigh[0] *
+                                            highGain),
+                            x,
+                            static_cast<int>(halfBreadth +
+                                    heightFactor * (float)maxHigh[1] *
+                                            highGain));
                     break;
             }
             actualHighLineNumber++;

--- a/src/waveform/renderers/waveformrendererfilteredsignal.cpp
+++ b/src/waveform/renderers/waveformrendererfilteredsignal.cpp
@@ -85,7 +85,7 @@ void WaveformRendererFilteredSignal::draw(QPainter* painter,
 
     // Per-band gain from the EQ knobs.
     float allGain(1.0), lowGain(1.0), midGain(1.0), highGain(1.0);
-    getGains(&allGain, true, &lowGain, &midGain, &highGain);
+    getGains(&allGain, &lowGain, &midGain, &highGain);
 
     const float breadth = m_waveformRenderer->getBreadth();
     const float halfBreadth = breadth / 2.0f;

--- a/src/waveform/renderers/waveformrendererhsv.cpp
+++ b/src/waveform/renderers/waveformrendererhsv.cpp
@@ -78,8 +78,8 @@ void WaveformRendererHSV::draw(
     const double gain = (lastVisualIndex - firstVisualIndex) / length;
     const auto* pColors = m_waveformRenderer->getWaveformSignalColors();
 
-    float allGain(1.0);
-    getGains(&allGain, nullptr, nullptr, nullptr);
+    float allGain(1.0), lowGain(1.0), midGain(1.0), highGain(1.0);
+    getGains(&allGain, &lowGain, &midGain, &highGain);
 
     // Get base color of waveform in the HSV format (s and v isn't use)
     float h, s, v;
@@ -142,14 +142,19 @@ void WaveformRendererHSV::draw(
                 i += 2) {
             const WaveformData& waveformData = *(data + i);
             const WaveformData& waveformDataNext = *(data + i + 1);
-            maxLow[0] = math_max(maxLow[0], (int)waveformData.filtered.low);
-            maxLow[1] = math_max(maxLow[1], (int)waveformDataNext.filtered.low);
-            maxMid[0] = math_max(maxMid[0], (int)waveformData.filtered.mid);
-            maxMid[1] = math_max(maxMid[1], (int)waveformDataNext.filtered.mid);
-            maxHigh[0] = math_max(maxHigh[0], (int)waveformData.filtered.high);
-            maxHigh[1] = math_max(maxHigh[1], (int)waveformDataNext.filtered.high);
-            maxAll[0] = math_max(maxAll[0], (int)waveformData.filtered.all);
-            maxAll[1] = math_max(maxAll[1], (int)waveformDataNext.filtered.all);
+            maxLow[0] = math_max(maxLow[0], static_cast<int>(waveformData.filtered.low * lowGain));
+            maxLow[1] = math_max(maxLow[1],
+                    static_cast<int>(waveformDataNext.filtered.low * lowGain));
+            maxMid[0] = math_max(maxMid[0], static_cast<int>(waveformData.filtered.mid * midGain));
+            maxMid[1] = math_max(maxMid[1],
+                    static_cast<int>(waveformDataNext.filtered.mid * midGain));
+            maxHigh[0] = math_max(maxHigh[0],
+                    static_cast<int>(waveformData.filtered.high * highGain));
+            maxHigh[1] = math_max(maxHigh[1],
+                    static_cast<int>(
+                            waveformDataNext.filtered.high * highGain));
+            maxAll[0] = math_max(maxAll[0], static_cast<int>(waveformData.filtered.all));
+            maxAll[1] = math_max(maxAll[1], static_cast<int>(waveformDataNext.filtered.all));
         }
 
         if (maxAll[0] && maxAll[1]) {

--- a/src/waveform/renderers/waveformrendererhsv.cpp
+++ b/src/waveform/renderers/waveformrendererhsv.cpp
@@ -79,7 +79,7 @@ void WaveformRendererHSV::draw(
     const auto* pColors = m_waveformRenderer->getWaveformSignalColors();
 
     float allGain(1.0);
-    getGains(&allGain, false, nullptr, nullptr, nullptr);
+    getGains(&allGain, nullptr, nullptr, nullptr);
 
     // Get base color of waveform in the HSV format (s and v isn't use)
     float h, s, v;

--- a/src/waveform/renderers/waveformrendererhsv.cpp
+++ b/src/waveform/renderers/waveformrendererhsv.cpp
@@ -182,20 +182,29 @@ void WaveformRendererHSV::draw(
             switch (m_alignment) {
                 case Qt::AlignBottom :
                 case Qt::AlignRight :
-                    painter->drawLine(
-                        x, breadth,
-                        x, breadth - (int)(heightFactor * (float)math_max(maxAll[0],maxAll[1])));
+                    painter->drawLine(x,
+                            breadth,
+                            x,
+                            breadth -
+                                    static_cast<int>(heightFactor *
+                                            (float)math_max(
+                                                    maxAll[0], maxAll[1])));
                     break;
                 case Qt::AlignTop :
                 case Qt::AlignLeft :
-                    painter->drawLine(
-                        x, 0,
-                        x, (int)(heightFactor * (float)math_max(maxAll[0],maxAll[1])));
+                    painter->drawLine(x,
+                            0,
+                            x,
+                            static_cast<int>(heightFactor *
+                                    (float)math_max(maxAll[0], maxAll[1])));
                     break;
                 default :
-                    painter->drawLine(
-                        x, (int)(halfBreadth - heightFactor * (float)maxAll[0]),
-                        x, (int)(halfBreadth + heightFactor * (float)maxAll[1]));
+                    painter->drawLine(x,
+                            static_cast<int>(halfBreadth -
+                                    heightFactor * (float)maxAll[0]),
+                            x,
+                            static_cast<int>(halfBreadth +
+                                    heightFactor * (float)maxAll[1]));
             }
         }
     }

--- a/src/waveform/renderers/waveformrendererrgb.cpp
+++ b/src/waveform/renderers/waveformrendererrgb.cpp
@@ -88,7 +88,8 @@ void WaveformRendererRGB::draw(
     const int breadth = m_waveformRenderer->getBreadth();
     const float halfBreadth = static_cast<float>(breadth) / 2.0f;
 
-    const float heightFactor = allGain * halfBreadth / sqrtf(255 * 255 * 3);
+    // A reference full scale pink noise has value 60 for each band
+    float heightFactor = allGain * halfBreadth / 255;
 
     // Draw reference line
     painter->setPen(m_waveformRenderer->getWaveformSignalColors()->getAxesColor());
@@ -139,13 +140,9 @@ void WaveformRendererRGB::draw(
             maxLow  = math_max3(maxLow,  waveformData.filtered.low,  waveformDataNext.filtered.low);
             maxMid  = math_max3(maxMid,  waveformData.filtered.mid,  waveformDataNext.filtered.mid);
             maxHigh = math_max3(maxHigh, waveformData.filtered.high, waveformDataNext.filtered.high);
-            float all = static_cast<float>(pow(waveformData.filtered.low * lowGain, 2) +
-                    pow(waveformData.filtered.mid * midGain, 2) +
-                    pow(waveformData.filtered.high * highGain, 2));
+            float all = waveformData.filtered.all;
             maxAll = math_max(maxAll, all);
-            float allNext = static_cast<float>(pow(waveformDataNext.filtered.low * lowGain, 2) +
-                    pow(waveformDataNext.filtered.mid * midGain, 2) +
-                    pow(waveformDataNext.filtered.high * highGain, 2));
+            float allNext = waveformDataNext.filtered.all;
             maxAllNext = math_max(maxAllNext, allNext);
         }
 
@@ -174,20 +171,23 @@ void WaveformRendererRGB::draw(
             switch (m_alignment) {
                 case Qt::AlignBottom:
                 case Qt::AlignRight:
-                    painter->drawLine(
-                        x, breadth,
-                        x, breadth - (int)(heightFactor * sqrtf(math_max(maxAll, maxAllNext))));
+                    painter->drawLine(x,
+                            breadth,
+                            x,
+                            breadth -
+                                    (int)(heightFactor *
+                                            math_max(maxAll, maxAllNext)));
                     break;
                 case Qt::AlignTop:
                 case Qt::AlignLeft:
                     painter->drawLine(
-                        x, 0,
-                        x, (int)(heightFactor * sqrtf(math_max(maxAll, maxAllNext))));
+                            x, 0, x, (int)(heightFactor * math_max(maxAll, maxAllNext)));
                     break;
                 default:
-                    painter->drawLine(
-                        x, (int)(halfBreadth - heightFactor * sqrtf(maxAll)),
-                        x, (int)(halfBreadth + heightFactor * sqrtf(maxAllNext)));
+                    painter->drawLine(x,
+                            (int)(halfBreadth - heightFactor * maxAll),
+                            x,
+                            (int)(halfBreadth + heightFactor * maxAllNext));
             }
         }
     }

--- a/src/waveform/renderers/waveformrendererrgb.cpp
+++ b/src/waveform/renderers/waveformrendererrgb.cpp
@@ -175,19 +175,19 @@ void WaveformRendererRGB::draw(
                             breadth,
                             x,
                             breadth -
-                                    (int)(heightFactor *
+                                    static_cast<int>(heightFactor *
                                             math_max(maxAll, maxAllNext)));
                     break;
                 case Qt::AlignTop:
                 case Qt::AlignLeft:
                     painter->drawLine(
-                            x, 0, x, (int)(heightFactor * math_max(maxAll, maxAllNext)));
+                            x, 0, x, static_cast<int>(heightFactor * math_max(maxAll, maxAllNext)));
                     break;
                 default:
                     painter->drawLine(x,
-                            (int)(halfBreadth - heightFactor * maxAll),
+                            static_cast<int>(halfBreadth - heightFactor * maxAll),
                             x,
-                            (int)(halfBreadth + heightFactor * maxAllNext));
+                            static_cast<int>(halfBreadth + heightFactor * maxAllNext));
             }
         }
     }

--- a/src/waveform/renderers/waveformrendererrgb.cpp
+++ b/src/waveform/renderers/waveformrendererrgb.cpp
@@ -77,7 +77,7 @@ void WaveformRendererRGB::draw(
 
     // Per-band gain from the EQ knobs.
     float allGain(1.0), lowGain(1.0), midGain(1.0), highGain(1.0);
-    getGains(&allGain, true, &lowGain, &midGain, &highGain);
+    getGains(&allGain, &lowGain, &midGain, &highGain);
 
     QColor color;
 

--- a/src/waveform/renderers/waveformrenderersignalbase.cpp
+++ b/src/waveform/renderers/waveformrenderersignalbase.cpp
@@ -179,13 +179,12 @@ void WaveformRendererSignalBase::setup(const QDomNode& node,
 }
 
 void WaveformRendererSignalBase::getGains(float* pAllGain,
-        bool applyCompensation,
         float* pLowGain,
         float* pMidGain,
         float* pHighGain) {
     if (pAllGain) {
         *pAllGain = static_cast<CSAMPLE_GAIN>(
-                            m_waveformRenderer->getGain(applyCompensation)) *
+                            m_waveformRenderer->getGain()) *
                 m_allChannelVisualGain;
         ;
     }

--- a/src/waveform/renderers/waveformrenderersignalbase.h
+++ b/src/waveform/renderers/waveformrenderersignalbase.h
@@ -42,7 +42,6 @@ class WaveformRendererSignalBase : public QObject, public WaveformRendererAbstra
     void deleteControls();
 
     void getGains(float* pAllGain,
-            bool applyCompensation,
             float* pLowGain,
             float* pMidGain,
             float* highGain);

--- a/src/waveform/renderers/waveformrenderersimplesignal.cpp
+++ b/src/waveform/renderers/waveformrenderersimplesignal.cpp
@@ -1,0 +1,171 @@
+#include "waveformrenderersimplesignal.h"
+
+#include "util/math.h"
+#include "util/painterscope.h"
+#include "waveform/waveform.h"
+#include "waveformwidgetrenderer.h"
+
+WaveformRendererSimpleSignal::WaveformRendererSimpleSignal(
+        WaveformWidgetRenderer* waveformWidgetRenderer)
+        : WaveformRendererSignalBase(waveformWidgetRenderer) {
+}
+
+WaveformRendererSimpleSignal::~WaveformRendererSimpleSignal() {
+}
+
+void WaveformRendererSimpleSignal::onSetup(const QDomNode& /* node */) {
+}
+
+void WaveformRendererSimpleSignal::draw(
+        QPainter* painter,
+        QPaintEvent* /*event*/) {
+    ConstWaveformPointer pWaveform = m_waveformRenderer->getWaveform();
+    if (pWaveform.isNull()) {
+        return;
+    }
+
+    const double audioVisualRatio = pWaveform->getAudioVisualRatio();
+    if (audioVisualRatio <= 0) {
+        return;
+    }
+
+    const float devicePixelRatio = m_waveformRenderer->getDevicePixelRatio();
+
+    const int dataSize = pWaveform->getDataSize();
+    if (dataSize <= 1) {
+        return;
+    }
+
+    const WaveformData* data = pWaveform->data();
+    if (data == nullptr) {
+        return;
+    }
+
+    const double trackSamples = m_waveformRenderer->getTrackSamples();
+    if (trackSamples <= 0) {
+        return;
+    }
+
+    PainterScope PainterScope(painter);
+
+    painter->setRenderHints(QPainter::Antialiasing, false);
+    painter->setRenderHints(QPainter::SmoothPixmapTransform, false);
+    painter->setWorldMatrixEnabled(false);
+    painter->resetTransform();
+
+    // Rotate if drawing vertical waveforms
+    // and revert devicePixelRatio scaling in x direction.
+    if (m_waveformRenderer->getOrientation() == Qt::Vertical) {
+        painter->setTransform(QTransform(0, 1 / devicePixelRatio, 1, 0, 0, 0));
+    } else {
+        painter->setTransform(QTransform(1 / devicePixelRatio, 0, 0, 1, 0, 0));
+    }
+
+    const double firstVisualIndex =
+            m_waveformRenderer->getFirstDisplayedPosition() * trackSamples /
+            audioVisualRatio;
+    const double lastVisualIndex =
+            m_waveformRenderer->getLastDisplayedPosition() * trackSamples /
+            audioVisualRatio;
+
+    const double offset = firstVisualIndex;
+
+    const float length = m_waveformRenderer->getLength() * devicePixelRatio;
+
+    // Represents the # of waveform data points per horizontal pixel.
+    const double gain = (lastVisualIndex - firstVisualIndex) / length;
+
+    float allGain(1.0);
+    getGains(&allGain, nullptr, nullptr, nullptr);
+
+    QColor color;
+    color.setRgbF(
+            m_signalColor_r,
+            m_signalColor_g,
+            m_signalColor_b,
+            0.9f);
+
+    QPen pen;
+    pen.setCapStyle(Qt::FlatCap);
+    pen.setWidthF(math_max(1.0, 1.0 / m_waveformRenderer->getVisualSamplePerPixel()));
+
+    const int breadth = m_waveformRenderer->getBreadth();
+    const float halfBreadth = static_cast<float>(breadth) / 2.0f;
+
+    // A reference full scale pink noise has value 60 for each band
+    float heightFactor = allGain * halfBreadth / 255;
+
+    // Draw reference line
+    painter->setPen(m_waveformRenderer->getWaveformSignalColors()->getAxesColor());
+    painter->drawLine(QLineF(0, halfBreadth, m_waveformRenderer->getLength(), halfBreadth));
+
+    for (int x = 0; x < static_cast<int>(length); ++x) {
+        // Width of the x position in visual indices.
+        const double xSampleWidth = gain * x;
+
+        // Effective visual index of x
+        const double xVisualSampleIndex = xSampleWidth + offset;
+
+        // Our current pixel (x) corresponds to a number of visual samples
+        // (visualSamplerPerPixel) in our waveform object. We take the max of
+        // all the data points on either side of xVisualSampleIndex within a
+        // window of 'maxSamplingRange' visual samples to measure the maximum
+        // data point contained by this pixel.
+        double maxSamplingRange = gain / 2.0;
+
+        // Since xVisualSampleIndex is in visual-samples (e.g. R,L,R,L) we want
+        // to check +/- maxSamplingRange frames, not samples. To do this, divide
+        // xVisualSampleIndex by 2. Since frames indices are integers, we round
+        // to the nearest integer by adding 0.5 before casting to int.
+        int visualFrameStart = int(xVisualSampleIndex / 2.0 - maxSamplingRange + 0.5);
+        int visualFrameStop = int(xVisualSampleIndex / 2.0 + maxSamplingRange + 0.5);
+        const int lastVisualFrame = dataSize / 2 - 1;
+
+        // We now know that some subset of [visualFrameStart, visualFrameStop]
+        // lies within the valid range of visual frames. Clamp
+        // visualFrameStart/Stop to within [0, lastVisualFrame].
+        visualFrameStart = math_clamp(visualFrameStart, 0, lastVisualFrame);
+        visualFrameStop = math_clamp(visualFrameStop, 0, lastVisualFrame);
+
+        int visualIndexStart = visualFrameStart * 2;
+        int visualIndexStop = visualFrameStop * 2;
+
+        float maxAll = 0.;
+        float maxAllNext = 0.;
+
+        for (int i = visualIndexStart;
+                i >= 0 && i + 1 < dataSize && i + 1 <= visualIndexStop;
+                i += 2) {
+            const WaveformData& waveformData = data[i];
+            const WaveformData& waveformDataNext = data[i + 1];
+            float all = waveformData.filtered.all;
+            maxAll = math_max(maxAll, all);
+            float allNext = waveformDataNext.filtered.all;
+            maxAllNext = math_max(maxAllNext, allNext);
+        }
+
+        pen.setColor(color);
+        painter->setPen(pen);
+        switch (m_alignment) {
+        case Qt::AlignBottom:
+        case Qt::AlignRight:
+            painter->drawLine(x,
+                    breadth,
+                    x,
+                    breadth -
+                            static_cast<int>(heightFactor *
+                                    math_max(maxAll, maxAllNext)));
+            break;
+        case Qt::AlignTop:
+        case Qt::AlignLeft:
+            painter->drawLine(
+                    x, 0, x, static_cast<int>(heightFactor * math_max(maxAll, maxAllNext)));
+            break;
+        default:
+            painter->drawLine(x,
+                    static_cast<int>(halfBreadth - heightFactor * maxAll),
+                    x,
+                    static_cast<int>(halfBreadth + heightFactor * maxAllNext));
+        }
+    }
+}

--- a/src/waveform/renderers/waveformrenderersimplesignal.h
+++ b/src/waveform/renderers/waveformrenderersimplesignal.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "util/class.h"
+#include "waveformrenderersignalbase.h"
+
+class WaveformRendererSimpleSignal : public WaveformRendererSignalBase {
+  public:
+    explicit WaveformRendererSimpleSignal(
+            WaveformWidgetRenderer* waveformWidget);
+    virtual ~WaveformRendererSimpleSignal();
+
+    virtual void onSetup(const QDomNode& node);
+    virtual void draw(QPainter* painter, QPaintEvent* event);
+
+  private:
+    DISALLOW_COPY_AND_ASSIGN(WaveformRendererSimpleSignal);
+};

--- a/src/waveform/renderers/waveformwidgetrenderer.h
+++ b/src/waveform/renderers/waveformwidgetrenderer.h
@@ -127,21 +127,8 @@ class WaveformWidgetRenderer {
     double getZoom() const {
         return m_zoomFactor;
     }
-    double getGain(bool applyCompensation) const {
-        // m_gain was always multiplied by 2.0, according to a comment:
-        //
-        //   "This gain adjustment compensates for an arbitrary /2 gain chop in
-        //   EnginePregain. See the comment there."
-        //
-        // However, no comment there seems to explain this, and it resulted
-        // in renderers that use the filtered.all data for the amplitude, to
-        // be twice the expected value.
-        // But without this compensation, renderers that use the combined
-        // lo, mid, hi values became much lower than expected. By making this
-        // optional we move the decision to each renderer whether to apply the
-        // compensation or not, in order to have a more similar amplitude across
-        // waveform renderers
-        return applyCompensation ? m_gain * 2.f : m_gain;
+    double getGain() const {
+        return m_gain;
     }
     double getTrackSamples() const {
         return m_trackSamples;

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -33,6 +33,7 @@
 #include "waveform/widgets/emptywaveformwidget.h"
 #include "waveform/widgets/hsvwaveformwidget.h"
 #include "waveform/widgets/rgbwaveformwidget.h"
+#include "waveform/widgets/simplesignalwaveformwidget.h"
 #include "waveform/widgets/softwarewaveformwidget.h"
 #include "waveform/widgets/waveformwidgetabstract.h"
 #include "widget/wvumeterbase.h"
@@ -988,6 +989,7 @@ void WaveformWidgetFactory::evaluateWidgets() {
             addHandle(collectedHandles, type, allshader::WaveformWidget::vars());
             supportedOptions[type] = allshader::WaveformWidget::supportedOptions(type);
 #endif
+            addHandle(collectedHandles, type, waveformWidgetVars<SimpleSignalWaveformWidget>());
             break;
         case WaveformWidgetType::Filtered:
 #ifdef MIXXX_USE_QOPENGL
@@ -1009,11 +1011,11 @@ void WaveformWidgetFactory::evaluateWidgets() {
             addHandle(collectedHandles, type, waveformWidgetVars<RGBWaveformWidget>());
             break;
         case WaveformWidgetType::HSV:
-            addHandle(collectedHandles, type, waveformWidgetVars<HSVWaveformWidget>());
 #ifdef MIXXX_USE_QOPENGL
             addHandle(collectedHandles, type, allshader::WaveformWidget::vars());
             supportedOptions[type] = allshader::WaveformWidget::supportedOptions(type);
 #endif
+            addHandle(collectedHandles, type, waveformWidgetVars<HSVWaveformWidget>());
             break;
         case WaveformWidgetType::Stacked:
 #ifdef MIXXX_USE_QOPENGL
@@ -1117,7 +1119,7 @@ WaveformWidgetAbstract* WaveformWidgetFactory::createSimpleWaveformWidget(WWavef
         return createAllshaderWaveformWidget(WaveformWidgetType::Type::Simple, viewer);
 #endif
     default:
-        return new EmptyWaveformWidget(viewer->getGroup(), viewer);
+        return new SimpleSignalWaveformWidget(viewer->getGroup(), viewer);
     }
 }
 

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -40,6 +40,12 @@
 #include "widget/wwaveformviewer.h"
 
 namespace {
+
+// We use an AllBand gain default of 2, because default ReplayGain is "enabled" at -18 LUFS
+// which gives at least 6 dB headroom with modern pop tracks.
+constexpr double kVisualGainDefault[] = {2, 1, 1, 1};
+constexpr bool kOverviewNormalizedDefault = false;
+
 // Returns true if the given waveform should be rendered.
 bool shouldRenderWaveform(WaveformWidgetAbstract* pWaveformWidget) {
     if (pWaveformWidget == nullptr ||
@@ -119,7 +125,7 @@ WaveformWidgetFactory::WaveformWidgetFactory()
           m_endOfTrackWarningTime(30),
           m_defaultZoom(WaveformWidgetRenderer::s_waveformDefaultZoom),
           m_zoomSync(true),
-          m_overviewNormalized(false),
+          m_overviewNormalized(kOverviewNormalizedDefault),
           m_untilMarkShowBeats(false),
           m_untilMarkShowTime(false),
           m_untilMarkAlign(Qt::AlignVCenter),
@@ -135,10 +141,10 @@ WaveformWidgetFactory::WaveformWidgetFactory()
           m_frameCnt(0),
           m_actualFrameRate(0),
           m_playMarkerPosition(WaveformWidgetRenderer::s_defaultPlayMarkerPosition) {
-    m_visualGain[AllBand] = 1.0;
-    m_visualGain[Low] = 1.0;
-    m_visualGain[Mid] = 1.0;
-    m_visualGain[High] = 1.0;
+    m_visualGain[AllBand] = kVisualGainDefault[AllBand];
+    m_visualGain[Low] = kVisualGainDefault[Low];
+    m_visualGain[Mid] = kVisualGainDefault[Mid];
+    m_visualGain[High] = kVisualGainDefault[High];
 
 #ifdef MIXXX_USE_QOPENGL
     WGLWidget* widget = SharedGLContext::getWidget();
@@ -395,25 +401,18 @@ bool WaveformWidgetFactory::setConfig(UserSettingsPointer config) {
     }
 
     for (int i = 0; i < BandCount; i++) {
-        double visualGain = m_config->getValueString(visualGainKey(i)).toDouble(&ok);
-        if (ok) {
-            // TODO validate value? 0 < value < 5.0
-            setVisualGain(BandIndex(i), visualGain);
-        } else {
-            m_config->setValue(visualGainKey(i), m_visualGain[i]);
-        }
+        m_visualGain[i] = m_config->getValue(visualGainKey(i), kVisualGainDefault[i]);
     }
+    m_overviewNormalized = m_config->getValue(
+            ConfigKey(kWaveformGroup, QStringLiteral("OverviewNormalized")),
+            kOverviewNormalizedDefault);
 
-    int overviewNormalized =
-            m_config->getValueString(
-                            ConfigKey(kWaveformGroup, QStringLiteral("OverviewNormalized")))
-                    .toInt(&ok);
-    if (ok) {
-        setOverviewNormalized(static_cast<bool>(overviewNormalized));
-    } else {
-        m_config->set(ConfigKey(kWaveformGroup, QStringLiteral("OverviewNormalized")),
-                ConfigValue(m_overviewNormalized));
-    }
+    emit visualGainChanged(
+            m_visualGain[BandIndex::AllBand],
+            m_visualGain[BandIndex::Low],
+            m_visualGain[BandIndex::Mid],
+            m_visualGain[BandIndex::High]);
+    emit overviewScalingChanged();
 
     m_playMarkerPosition =
             m_config->getValue(ConfigKey(kWaveformGroup, QStringLiteral("PlayMarkerPosition")),
@@ -725,6 +724,11 @@ double WaveformWidgetFactory::getVisualGain(BandIndex index) const {
     return m_visualGain[index];
 }
 
+// static
+double WaveformWidgetFactory::getVisualGainDefault(BandIndex index) {
+    return kVisualGainDefault[index];
+}
+
 void WaveformWidgetFactory::setOverviewNormalized(bool normalize) {
     m_overviewNormalized = normalize;
     if (m_config) {
@@ -732,6 +736,11 @@ void WaveformWidgetFactory::setOverviewNormalized(bool normalize) {
                 ConfigValue(m_overviewNormalized));
     }
     emit overviewScalingChanged();
+}
+
+// static
+bool WaveformWidgetFactory::isOverviewNormalizedDefault() {
+    return kOverviewNormalizedDefault;
 }
 
 void WaveformWidgetFactory::setPlayMarkerPosition(double position) {

--- a/src/waveform/waveformwidgetfactory.h
+++ b/src/waveform/waveformwidgetfactory.h
@@ -210,9 +210,13 @@ class WaveformWidgetFactory : public QObject,
 
     void setVisualGain(BandIndex index, double gain);
     double getVisualGain(BandIndex index) const;
+    static double getVisualGainDefault(BandIndex index);
 
     void setOverviewNormalized(bool normalize);
-    int isOverviewNormalized() const { return m_overviewNormalized;}
+    bool isOverviewNormalized() const {
+        return m_overviewNormalized;
+    }
+    static bool isOverviewNormalizedDefault();
 
     const QVector<WaveformWidgetAbstractHandle>& getAvailableTypes() const {
         return m_waveformWidgetHandles;

--- a/src/waveform/widgets/simplesignalwaveformwidget.cpp
+++ b/src/waveform/widgets/simplesignalwaveformwidget.cpp
@@ -1,0 +1,40 @@
+#include "simplesignalwaveformwidget.h"
+
+#include <QPainter>
+
+#include "moc_simplesignalwaveformwidget.cpp"
+#include "waveform/renderers/waveformrenderbackground.h"
+#include "waveform/renderers/waveformrenderbeat.h"
+#include "waveform/renderers/waveformrendererendoftrack.h"
+#include "waveform/renderers/waveformrendererpreroll.h"
+#include "waveform/renderers/waveformrenderersimplesignal.h"
+#include "waveform/renderers/waveformrendermark.h"
+#include "waveform/renderers/waveformrendermarkrange.h"
+
+SimpleSignalWaveformWidget::SimpleSignalWaveformWidget(const QString& group, QWidget* parent)
+        : NonGLWaveformWidgetAbstract(group, parent) {
+    addRenderer<WaveformRenderBackground>();
+    addRenderer<WaveformRendererEndOfTrack>();
+    addRenderer<WaveformRendererPreroll>();
+    addRenderer<WaveformRenderMarkRange>();
+    addRenderer<WaveformRendererSimpleSignal>();
+    addRenderer<WaveformRenderBeat>();
+    addRenderer<WaveformRenderMark>();
+
+    setAttribute(Qt::WA_NoSystemBackground);
+    setAttribute(Qt::WA_OpaquePaintEvent);
+
+    m_initSuccess = init();
+}
+
+SimpleSignalWaveformWidget::~SimpleSignalWaveformWidget() {
+}
+
+void SimpleSignalWaveformWidget::castToQWidget() {
+    m_widget = this;
+}
+
+void SimpleSignalWaveformWidget::paintEvent(QPaintEvent* event) {
+    QPainter painter(this);
+    draw(&painter, event);
+}

--- a/src/waveform/widgets/simplesignalwaveformwidget.h
+++ b/src/waveform/widgets/simplesignalwaveformwidget.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "nonglwaveformwidgetabstract.h"
+
+class QWidget;
+
+class SimpleSignalWaveformWidget : public NonGLWaveformWidgetAbstract {
+    Q_OBJECT
+  public:
+    virtual ~SimpleSignalWaveformWidget();
+
+    virtual WaveformWidgetType::Type getType() const {
+        return WaveformWidgetType::RGB;
+    }
+
+    static inline bool useOpenGl() {
+        return false;
+    }
+    static inline bool useOpenGles() {
+        return false;
+    }
+    static inline bool useOpenGLShaders() {
+        return false;
+    }
+    static inline bool useTextureForWaveform() {
+        return false;
+    }
+    static inline WaveformWidgetCategory category() {
+        return WaveformWidgetCategory::Software;
+    }
+
+  protected:
+    virtual void castToQWidget();
+    virtual void paintEvent(QPaintEvent* event);
+
+  private:
+    SimpleSignalWaveformWidget(const QString& group, QWidget* parent);
+    friend class WaveformWidgetFactory;
+};


### PR DESCRIPTION
fixes #15322 



Before: 
440 Hz sine: 
<img width="263" height="92" alt="Image" src="https://github.com/user-attachments/assets/57af5579-ee11-4cd7-a7be-24f2850470af" />

Noise: 
<img width="202" height="95" alt="Image" src="https://github.com/user-attachments/assets/76e6f620-7ee9-40c6-bdcb-38268f013e3c" />


After: 
<img width="220" height="184" alt="Image" src="https://github.com/user-attachments/assets/004e519c-366f-4096-861b-76dbe4aa2f6b" />

Since after is significant smaller than before, I have added a default visual Gain of 2.0 
