### PR TITLE
Library sidebar: expand items to full width to maximize click-responsive area -- v2

### DIFF
--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -420,6 +420,31 @@ void WLibrarySidebar::focusSelectedIndex() {
 bool WLibrarySidebar::event(QEvent* pEvent) {
     if (pEvent->type() == QEvent::ToolTip) {
         updateTooltip();
+    } else if (pEvent->type() == QEvent::LayoutRequest ||
+            pEvent->type() == QEvent::Resize) {
+        // Force-resize the header to expand the item's clickable area.
+        //
+        // Reason:
+        // Currently, the sidebar header expands to the width of the widest item.
+        // If the sidebar is wider than that, there's some space right next to
+        // items that does not respond to clicks. This is somewhat frustration as
+        // it is perceived inconsistent with the state when e.g. Playlist are
+        // expanded and the entire 'Tracks' row responds to clicks.
+        //
+        // Desired appearance & behavior:
+        // * full-width items (for click success)
+        // * full item text (no elide)
+        // * show horizontal scrollbars as needed
+        //
+        // Unfortunately, there's no combination of
+        //   header()->setStretchLastSection(bool);
+        //   header()->setSectionResizeMode(QHeaderView::ResizeMode);
+        // to achieve that.
+        //
+        // Though we can listen to LayoutRequest and adjust the headers minimum
+        // section size to viewport width (-1 for section separator?).
+        // This event occurs after Show, Resize or model data change.
+        header()->setMinimumSectionSize(viewport()->width() - 1);
     }
     return QTreeView::event(pEvent);
 }


### PR DESCRIPTION
A small UX helper. Works fine without glitches.
Simple alternative to #11708


### Issue
Currently, the sidebar header expands to the width of the widest item.
If the sidebar is wider than that, there's some space right next to items that is not responsive to clicks. This is somewhat frustration as it is perceived inconsistent with the state when e.g. Playlist are expanded and the entire 'Tracks' row responds to clicks.

Desired:
* full-width items
* full item text (no elide)
* show scrollbars as needed

Unfortunately, there's no combination of 
`header()->setStretchLastSection(true);`
`header()->setSectionResizeMode(QHeaderView::ResizeMode);`
to achieve that* 
*<sub>at least not when set in the constructor. If set later on, e.g. on `QResizeEvent`, it works as desired, though only with collapsed rows. go figure...</sub>

Probably a Qt issue, or just a use case they didn't know/care about.
(tested with Qt5. I didn't test again with Qt6, but I don't expect a fix tbh, given this is low prio and Qt is very slow with fixing such QWidget bugs)

### Fix
Adjust header minimum width to viewport width on each layout change.
This covers initial show, manual resize and item width changes after model data changes.

Only downside is that the horizontal scrollbars is visile briefly when shrinking the sidebar in width.