### PR TITLE
(fix) Track view header: avoid narrow columns after restoring header with hidden columns

### DIFF
--- a/src/widget/wtracktableviewheader.cpp
+++ b/src/widget/wtracktableviewheader.cpp
@@ -12,14 +12,34 @@
 
 #define WTTVH_MINIMUM_SECTION_SIZE 20
 
-HeaderViewState::HeaderViewState(const QHeaderView& headers) {
+HeaderViewState::HeaderViewState(const WTrackTableViewHeader& headers) {
     QAbstractItemModel* model = headers.model();
     for (int vi = 0; vi < headers.count(); ++vi) {
         int li = headers.logicalIndex(vi);
         mixxx::library::HeaderViewState::HeaderState* header_state =
                 m_view_state.add_header_state();
         header_state->set_hidden(headers.isSectionHidden(li));
-        header_state->set_size(headers.sectionSize(li));
+        // Unfortunately sectionSize() is always 0 for hidden columns. Though,
+        // QHeaderView keeps track of hidden sizes internally, and we do the same.
+        int size = headers.sectionSize(li);
+        if (headers.isSectionHidden(li) && size == 0) {
+            size = headers.getWidthOfHiddenColumn(li);
+            if (size == 0) {
+                // Indicates a hidden column we didn't enable yet, hence didn't
+                // store its previous width when hiding it.
+                // Let's get the default width from the track model.
+                // If this also returns 0 for some reason, we'll reset to minimum
+                // width when restoring the header.
+                auto* pTrackModel = headers.model();
+                DEBUG_ASSERT(pTrackModel);
+                size = pTrackModel->headerData(
+                                          li,
+                                          headers.orientation(),
+                                          TrackModel::kHeaderWidthRole)
+                               .toInt();
+            }
+        }
+        header_state->set_size(size);
         header_state->set_logical_index(li);
         header_state->set_visual_index(vi);
         const QString column_name = model->headerData(
@@ -62,7 +82,7 @@ QString HeaderViewState::saveState() const {
     return QString(array.toBase64());
 }
 
-void HeaderViewState::restoreState(QHeaderView* pHeaders) {
+void HeaderViewState::restoreState(WTrackTableViewHeader* pHeaders) {
     const int max_columns =
             math_min(pHeaders->count(), m_view_state.header_state_size());
 
@@ -90,7 +110,13 @@ void HeaderViewState::restoreState(QHeaderView* pHeaders) {
                 m_view_state.header_state(vi);
         const int li = header.logical_index();
         pHeaders->setSectionHidden(li, header.hidden());
-        pHeaders->resizeSection(li, header.size());
+        // If the stored size is 0 or less than the minimum column width,
+        // we use the latter. This might happen if  WTTVH_MINIMUM_SECTION_SIZE
+        // has been increased by us or the header state from database was corrupted.
+        // Note: setting the size works even if the column is hidden. Size is stored
+        // by QHeaderView internally and is applied once the column is shown.
+        int size = math_max(header.size(), WTTVH_MINIMUM_SECTION_SIZE);
+        pHeaders->resizeSection(li, size);
         pHeaders->moveSection(pHeaders->visualIndex(li), vi);
     }
     if (m_view_state.sort_indicator_shown()) {
@@ -140,6 +166,7 @@ void WTrackTableViewHeader::setModel(QAbstractItemModel* pModel) {
     }
 
     // Restore saved header state to get sizes, column positioning, etc. back.
+    m_hiddenColumnSizes.clear();
     restoreHeaderState();
 
     // Here we can override values to prevent restoring corrupt values from database
@@ -198,12 +225,6 @@ void WTrackTableViewHeader::setModel(QAbstractItemModel* pModel) {
                 });
         m_menu.addAction(pAction);
 
-        // force the section size to be a least WTTVH_MINIMUM_SECTION_SIZE
-        if (sectionSize(i) <  WTTVH_MINIMUM_SECTION_SIZE) {
-            // This might happen if  WTTVH_MINIMUM_SECTION_SIZ has changed or
-            // the header state from database was corrupt
-            resizeSection(i,WTTVH_MINIMUM_SECTION_SIZE);
-        }
     }
 
     // Safety check against someone getting stuck with all columns hidden
@@ -288,18 +309,31 @@ void WTrackTableViewHeader::showOrHideColumn(int column) {
     QCheckBox* pCheckBox = it.value();
     if (pCheckBox->isChecked()) {
         showSection(column);
+        VERIFY_OR_DEBUG_ASSERT(sectionSize(column) >= WTTVH_MINIMUM_SECTION_SIZE) {
+            resizeSection(column, WTTVH_MINIMUM_SECTION_SIZE);
+        }
+        m_hiddenColumnSizes.remove(column);
     } else {
-        // If the user hides every column then the table will disappear. This
-        // guards against that. NB: hiddenCount reflects checked QAction's so
-        // size-hiddenCount will be zero the moment they uncheck the last
+        // If the user hides every column, the table will disappear. This guards
+        // against that. Note: hiddenCount reflects number of checked QActions,
+        // so size - hiddenCount will be zero the moment they uncheck the last
         // section.
         if (m_columnCheckBoxes.size() - hiddenCount() > 0) {
+            m_hiddenColumnSizes.insert(column, sectionSize(column));
             hideSection(column);
         } else {
             // Otherwise, ignore the request and re-check this QAction.
             pCheckBox->setChecked(true);
         }
     }
+}
+
+int WTrackTableViewHeader::getWidthOfHiddenColumn(int column) const {
+    const auto& it = m_hiddenColumnSizes.find(column);
+    if (it != m_hiddenColumnSizes.constEnd()) {
+        return it.value();
+    }
+    return 0;
 }
 
 int WTrackTableViewHeader::hiddenCount() {

--- a/src/widget/wtracktableviewheader.h
+++ b/src/widget/wtracktableviewheader.h
@@ -11,6 +11,7 @@ class QAction;
 class QCheckBox;
 class QContextMenuEvent;
 class QWidget;
+class WTrackTableViewHeader;
 
 // Thanks to StackOverflow http://stackoverflow.com/questions/1163030/qt-qtableview-and-horizontalheader-restorestate
 // answer with this code snippet: http://codepad.org/2gPIMPYU
@@ -19,7 +20,7 @@ public:
     HeaderViewState() {}
 
     // Populate the object based on the provided live view.
-    explicit HeaderViewState(const QHeaderView& headers);
+    explicit HeaderViewState(const WTrackTableViewHeader& headers);
 
     // Populate from an existing protobuf, mostly for testing.
     explicit HeaderViewState(const mixxx::library::HeaderViewState& pb)
@@ -32,7 +33,7 @@ public:
     QString saveState() const;
     // Apply the state to the provided view.  The data in the object may be
     // changed if the header format has changed.
-    void restoreState(QHeaderView* pHeaders);
+    void restoreState(WTrackTableViewHeader* pHeaders);
 
     // returns false if no headers are listed to be shown.
     bool healthy() const {
@@ -66,6 +67,8 @@ class WTrackTableViewHeader : public QHeaderView {
      /** returns false if the header state is stored in the database (on first time usgae) **/
     bool hasPersistedHeaderState();
 
+    int getWidthOfHiddenColumn(int column) const;
+
   private slots:
     void showOrHideColumn(int);
 
@@ -76,4 +79,5 @@ class WTrackTableViewHeader : public QHeaderView {
 
     QMenu m_menu;
     QMap<int, QCheckBox*> m_columnCheckBoxes;
+    QMap<int, int> m_hiddenColumnSizes;
 };


### PR DESCRIPTION
Fixes an annoying flaw of TrackTableViewHeader / HeaderState, or rather QHeaderView because QAbstractItemView is not expecting that the header view is replaced.

### The Bug
If you enable a column for the first time, it's shown with the correct default width.
Though, if you hide it (or never enable it) switch feature or whatever triggers `saveHeaderState`, and enable it any time afterwards, it's reset to minimal width. The annoying part, besides the resizing, is that after you arranged columns according to your preferences, columns can show up at the far right and resizing usuable width is a pain..

I vaguely remember there was a related bug report by @daschuer but I don't find it.
**edit:** got it. didn't find it due to some funny typos #10325

### Reproduce
1. fresh profile, just in case
2. select Tracks
3. show Comment column -> should be 300 px wide
4. adjust Comment to let's say 234 px
5. hide Comment column
6. show Comment column -> is 234 px wide
7. select a Playlist
8. select Tracks
9. show Comment column -> should be 234 px
= is 0 internally -> minimum size is picked which is ~20px
= if this is the rightmost column, increasing its width is cumbersome..
or it's simply very hard to spot because the title is truncated + ...

### Fix
Store width of hidden columns like QHeaderView does.
Use that when creating the HeaderState. If it's 0 (never shown before), use the column's default width.

### Reason
see inline comments
**TL;DR**
`QHeaderView::sectionSize()` is always 0 for hidden columns by design -- though `QHeaderView` tracks hidden sizes internally, that's why we can restore them if we don't switch features.
When we switch we save the HeaderState, but for the width we use: `sectionSize()`. So we store 0 and restore minimal width.
Additionally, columns that were never shown will be shown later on with minimal width, too.