### PR TITLE
feat(components): JogwheelBasic: Disable scratching when leaving `vinylMode`

### DIFF
--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -766,7 +766,7 @@
     };
 
     JogWheelBasic.prototype = new Component({
-        vinylMode: true,
+        _vinylMode: true, // private, accessible via setters defined below
         isPress: Button.prototype.isPress,
         inValueScale: function(value) {
             // default implementation for converting signed ints
@@ -802,6 +802,19 @@
             Component.prototype.connect.call(this);
             this.deck = parseInt(script.channelRegEx.exec(this.group)[1]);
         }
+    });
+    Object.defineProperty(JogWheelBasic.prototype, "vinylMode", {
+        get() {
+            return this._vinylMode;
+        },
+        set(vinylMode) {
+            // Disable scratching immediately when disabling vinylMode in case
+            // the touch surface malfunctions
+            if (!vinylMode && engine.isScratching(this.deck)) {
+                engine.scratchDisable(this.deck);
+            }
+            this._vinylMode = vinylMode;
+        },
     });
 
     const EffectUnit = function(unitNumbers, allowFocusWhenParametersHidden, colors) {


### PR DESCRIPTION
Since I don't think its common to disable vinylMode while having your hand still on the platter and expecting to still scratch, disable scratching as soon as `vinylMode` has been disabled. This also helps in the case where a platter may be malfunctioning (leaving a touch as registered even though you released it). In that case, the track remains paused and there is nothing the user can do about it. With this patch, they can workaround the issue by disabling vinylMode, getting the deck unstuck.