### PR TITLE
(fix) TrackDAO: add required column `fs_deleted` in verifyRemainingTracks()

### DIFF
--- a/src/library/dao/trackdao.cpp
+++ b/src/library/dao/trackdao.cpp
@@ -2078,9 +2078,10 @@ bool TrackDAO::verifyRemainingTracks(
     // check if it exists.
     // TODO(kain88) check if all others are marked with 0 again
     query.setForwardOnly(true);
-    query.prepare("SELECT location "
-                  "FROM track_locations "
-                  "WHERE needs_verification = 1");
+    query.prepare(
+            "SELECT location, fs_deleted "
+            "FROM track_locations "
+            "WHERE needs_verification = 1");
     if (!query.exec()) {
         LOG_FAILED_QUERY(query);
         DEBUG_ASSERT(!"Failed query");


### PR DESCRIPTION
fixup for #14250 :grimacing: 
Not sure if it's fixing #15345 but at least the warning
`QSqlQuery::value: not positioned on a valid record`
is not logged anymore.

Might also be related to false missing tracks after rescan? :man_shrugging: 