### PR TITLE
(fix) avoid empty waveform with invalid config - refactor waveform factory/preferences

### DIFF
--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -92,6 +92,9 @@ DlgPrefWaveform::DlgPrefWaveform(
     untilMarkTextHeightLimitComboBox->addItem(tr("1/3 of waveform viewer"));
     untilMarkTextHeightLimitComboBox->addItem(tr("Entire waveform viewer"));
 
+    // Adopt tr string from first GLSL hint
+    requiresGLSLLabel2->setText(requiresGLSLLabel->text());
+
     // The GUI is not fully setup so connecting signals before calling
     // slotUpdate can generate rebootMixxxView calls.
     // TODO(XXX): Improve this awkwardness.
@@ -300,6 +303,7 @@ void DlgPrefWaveform::slotUpdate() {
     waveformTypeComboBox->setEnabled(useWaveform);
     updateEnableUntilMark();
     updateWaveformGeneralOptionsEnabled();
+    updateStemOptionsEnabled();
 
     frameRateSpinBox->setValue(factory->getFrameRate());
     frameRateSlider->setValue(factory->getFrameRate());
@@ -472,6 +476,7 @@ void DlgPrefWaveform::slotSetWaveformType(int index) {
             allshader::WaveformRendererSignalBase::Option::None);
     updateWaveformTypeOptions(true, backend, currentOptions);
     updateEnableUntilMark();
+    updateStemOptionsEnabled();
 }
 
 void DlgPrefWaveform::slotSetWaveformEnabled(bool checked) {
@@ -508,6 +513,7 @@ void DlgPrefWaveform::slotSetWaveformAcceleration(bool checked) {
             allshader::WaveformRendererSignalBase::Option::None);
     updateWaveformTypeOptions(true, backend, currentOptions);
     updateEnableUntilMark();
+    updateStemOptionsEnabled();
 }
 
 void DlgPrefWaveform::updateWaveformAcceleration(
@@ -613,6 +619,25 @@ void DlgPrefWaveform::updateWaveformGeneralOptionsEnabled() {
     defaultZoomComboBox->setEnabled(enabled);
     synchronizeZoomCheckBox->setEnabled(enabled);
     updateWaveformGainEnabled();
+    updateStemOptionsEnabled();
+}
+
+void DlgPrefWaveform::updateStemOptionsEnabled() {
+#ifndef MIXXX_USE_QOPENGL
+    const bool stemsSupported = false;
+#else
+    WaveformWidgetFactory* factory = WaveformWidgetFactory::instance();
+    const bool stemsSupported =
+            factory->widgetTypeSupportsStems() &&
+            factory->getBackendFromConfig() == WaveformWidgetBackend::AllShader;
+#endif
+    bool enabled = useWaveformCheckBox->isChecked();
+    stemOpacityMainLabel->setEnabled(stemsSupported && enabled);
+    stemOpacityOutlineLabel->setEnabled(stemsSupported && enabled);
+    stemReorderLayerOnChangedCheckBox->setEnabled(stemsSupported && enabled);
+    stemOpacitySpinBox->setEnabled(stemsSupported && enabled);
+    stemOutlineOpacitySpinBox->setEnabled(stemsSupported && enabled);
+    requiresGLSLLabel2->setVisible(!stemsSupported && enabled);
 }
 
 void DlgPrefWaveform::updateWaveformGainEnabled() {

--- a/src/preferences/dialog/dlgprefwaveform.h
+++ b/src/preferences/dialog/dlgprefwaveform.h
@@ -80,6 +80,7 @@ class DlgPrefWaveform : public DlgPreferencePage, public Ui::DlgPrefWaveformDlg 
             WaveformWidgetType::Type type, WaveformWidgetBackend backend);
     void updateWaveformGeneralOptionsEnabled();
     void updateWaveformGainEnabled();
+    void updateStemOptionsEnabled();
 
     std::unique_ptr<ControlPushButton> m_pTypeControl;
     std::unique_ptr<ControlObject> m_pOverviewMinuteMarkersControl;

--- a/src/preferences/dialog/dlgprefwaveformdlg.ui
+++ b/src/preferences/dialog/dlgprefwaveformdlg.ui
@@ -679,6 +679,14 @@ Select from different types of displays for the waveform, which differ primarily
       </layout>
      </item>
 
+     <item row="15" column="1" colspan="4">
+      <widget class="QLabel" name="requiresGLSLLabel2">
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+
     </layout>
    </widget>
   </item><!-- waveform groupbox -->

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -589,13 +589,23 @@ bool WaveformWidgetFactory::setWidgetType(
 bool WaveformWidgetFactory::widgetTypeSupportsUntilMark() const {
     switch (m_configType) {
     case WaveformWidgetType::RGB:
-        return true;
     case WaveformWidgetType::Filtered:
-        return true;
     case WaveformWidgetType::Simple:
-        return true;
     case WaveformWidgetType::HSV:
+    case WaveformWidgetType::Stacked:
         return true;
+    default:
+        break;
+    }
+    return false;
+}
+
+bool WaveformWidgetFactory::widgetTypeSupportsStems() const {
+    switch (m_configType) {
+    case WaveformWidgetType::RGB:
+    case WaveformWidgetType::Filtered:
+    case WaveformWidgetType::Simple:
+    case WaveformWidgetType::HSV:
     case WaveformWidgetType::Stacked:
         return true;
     default:

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -1241,6 +1241,24 @@ int WaveformWidgetFactory::findHandleIndexFromType(WaveformWidgetType::Type type
     return -1;
 }
 
+bool WaveformWidgetFactory::widgetTypeSupportsAcceleration(WaveformWidgetType::Type type) {
+    for (const auto& handle : std::as_const(m_waveformWidgetHandles)) {
+        if (handle.m_type == type) {
+            return handle.supportAcceleration();
+        }
+    }
+    return false;
+}
+
+bool WaveformWidgetFactory::widgetTypeSupportsSoftware(WaveformWidgetType::Type type) {
+    for (const auto& handle : std::as_const(m_waveformWidgetHandles)) {
+        if (handle.m_type == type) {
+            return handle.supportSoftware();
+        }
+    }
+    return false;
+}
+
 WaveformWidgetBackend WaveformWidgetFactory::getBackendFromConfig() const {
     // On the UI, hardware acceleration is a boolean (0 => software rendering, 1
     // => hardware acceleration), but in the setting, we keep the granularity so
@@ -1266,9 +1284,17 @@ WaveformWidgetBackend WaveformWidgetFactory::preferredBackend() const {
     return WaveformWidgetBackend::None;
 }
 
-// Static
+void WaveformWidgetFactory::setDefaultBackend() {
+    m_config->setValue(kHardwareAccelerationKey, preferredBackend());
+}
+
 QString WaveformWidgetAbstractHandle::getDisplayName() const {
-    switch (m_type) {
+    return getDisplayName(m_type);
+}
+
+// Static
+QString WaveformWidgetAbstractHandle::getDisplayName(WaveformWidgetType::Type type) {
+    switch (type) {
     case WaveformWidgetType::Empty:
         return QObject::tr("Empty");
     case WaveformWidgetType::Simple:

--- a/src/waveform/waveformwidgetfactory.h
+++ b/src/waveform/waveformwidgetfactory.h
@@ -158,6 +158,8 @@ class WaveformWidgetFactory : public QObject,
     bool widgetTypeSupportsAcceleration(WaveformWidgetType::Type type);
     bool widgetTypeSupportsSoftware(WaveformWidgetType::Type type);
     bool widgetTypeSupportsUntilMark() const;
+    bool widgetTypeSupportsStems() const;
+
     void setUntilMarkShowBeats(bool value);
     void setUntilMarkShowTime(bool value);
     void setUntilMarkAlign(Qt::Alignment align);

--- a/src/waveform/waveformwidgetfactory.h
+++ b/src/waveform/waveformwidgetfactory.h
@@ -70,6 +70,7 @@ class WaveformWidgetAbstractHandle {
 #endif
 
     QString getDisplayName() const;
+    static QString getDisplayName(WaveformWidgetType::Type type);
 
   private:
     WaveformWidgetType::Type m_type;
@@ -135,6 +136,7 @@ class WaveformWidgetFactory : public QObject,
     static WaveformWidgetType::Type defaultType() {
         return WaveformWidgetType::RGB;
     }
+    void setDefaultBackend();
 
     /// Sets the widget type and saves it to configuration.
     /// Returns false and sets EmtpyWaveform if type is invalid
@@ -146,10 +148,15 @@ class WaveformWidgetFactory : public QObject,
     /// dialog.
     bool setWidgetTypeFromHandle(int handleIndex, bool force = false);
     WaveformWidgetType::Type getType() const { return m_type;}
+    QString getTypeDisplayName() const {
+        return WaveformWidgetAbstractHandle::getDisplayName(m_type);
+    }
     int getHandleIndex() {
         return findHandleIndexFromType(m_type);
     }
     int findHandleIndexFromType(WaveformWidgetType::Type type);
+    bool widgetTypeSupportsAcceleration(WaveformWidgetType::Type type);
+    bool widgetTypeSupportsSoftware(WaveformWidgetType::Type type);
     bool widgetTypeSupportsUntilMark() const;
     void setUntilMarkShowBeats(bool value);
     void setUntilMarkShowTime(bool value);


### PR DESCRIPTION
Fixes #15338

**Update:** 
This is now just the fix for #15338 and for disabling Stem options when Stems are not supported by waveform type.
I moved the refactoring to another branch, PR will follow asap
_________
DlgPreferencesWaveform was a bit more complicated than necessary. I took the opportunity to clean it up and make it a frontend for WaveformWidgetFactory. I hope commits are isolated enough to ease review.

--> next step is refactoring the overview settings as well, so that all waveform/overview settings are managed by WaveformWidgetFactory. Should allow to drop some COs/proxies
**edit:** not possible, or if it would be quite elaborate to forward the factory signal to OverviewDelegate