### PR TITLE
fix: correctly free reference to m_pSoundManager

### DIFF
--- a/src/coreservices.cpp
+++ b/src/coreservices.cpp
@@ -865,6 +865,7 @@ void CoreServices::finalize() {
     mixxx::qml::QmlPlayerManagerProxy::registerPlayerManager(nullptr);
     mixxx::qml::QmlConfigProxy::registerUserSettings(nullptr);
     mixxx::qml::QmlLibraryProxy::registerLibrary(nullptr);
+    mixxx::qml::QmlSoundManagerProxy::registerManager(nullptr);
 
     ControllerScriptEngineBase::registerTrackCollectionManager(nullptr);
 #endif

--- a/src/qml/qmlwaveformrenderer.cpp
+++ b/src/qml/qmlwaveformrenderer.cpp
@@ -338,7 +338,7 @@ QmlWaveformRendererFactory::Renderer QmlWaveformRendererMark::create(
         const QString endIcon = pMark->endIcon().toLocalFile();
         // FIXME: the following checks should be done on the WaveformMarker
         // setter (depends of #14515)
-        if (!QFileInfo::exists(pixmap)) {
+        if (!pixmap.isEmpty() && !QFileInfo::exists(pixmap)) {
             qmlEngine(this)->throwError(tr("Cannot find the marker pixmap") + " \"" + pixmap + '"');
         }
 


### PR DESCRIPTION
Fix a leak introduced by #14597, that can issue to a segfault. Also fix an exception that get raised in QML engine with `pixmap` is not used in a waveform marker 