### PR TITLE
QML settings library

### DIFF
--- a/res/qml/Settings/Library.qml
+++ b/res/qml/Settings/Library.qml
@@ -1,16 +1,1016 @@
 import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls
+import QtQuick.Dialogs
+import Qt.labs.qmlmodels
+import QtCore
+import Qt5Compat.GraphicalEffects
 import Mixxx 1.0 as Mixxx
+import "." as Setting
+import "." as SettingComponents
+import ".." as Skin
+import "../Theme"
 
 Category {
-    label: "Library"
+    id: root
 
-    Mixxx.SettingParameter {
-        label: "A blue square"
+    property bool dirty: false
 
-        Rectangle {
-            color: 'blue'
-            height: 20
-            width: 20
+    function load() {
+        loadSources();
+        integrationRepeater.model = [
+            {
+                service: "Rhythmbox",
+                enabled: Mixxx.Config.libraryRhythmboxEnabled
+            },
+            {
+                service: "Banshee",
+                enabled: Mixxx.Config.libraryBansheeEnabled
+            },
+            {
+                service: "iTunes",
+                enabled: Mixxx.Config.libraryITunesEnabled
+            },
+            {
+                service: "Traktor",
+                enabled: Mixxx.Config.libraryTraktorEnabled
+            },
+            {
+                service: "Rekordbox",
+                enabled: Mixxx.Config.libraryRekordboxEnabled
+            },
+            {
+                service: "Serato",
+                enabled: Mixxx.Config.librarySeratoEnabled
+            },
+        ];
+        metadataSynchroniseEnabled.selected = Mixxx.Config.librarySyncTrackMetadataExport ? "on" : "off";
+        metadataSynchroniseSeratoEnabled.selected = Mixxx.Config.librarySeratoMetadataExport ? "on" : "off";
+        metadataRelativePathEnabled.selected = Mixxx.Config.libraryUseRelativePathOnExport ? "on" : "off";
+        searchCompletionEnabled.selected = Mixxx.Config.librarySearchCompletionsEnable ? "on" : "off";
+        searchHistoryKeyboardEnabled.selected = Mixxx.Config.librarySearchHistoryShortcutsEnable ? "on" : "off";
+        historyDuplicateDistanceInput.value = Mixxx.Config.libraryHistoryTrackDuplicateDistance;
+        historyDeleteLessThanInput.value = Mixxx.Config.libraryHistoryMinTracksToKeep;
+        searchAsYouTypeTimeoutInput.setValue(Mixxx.Config.librarySearchDebouncingTimeout / 1000);
+        pitchSliderFuzzBPMInput.setValue(Mixxx.Config.librarySearchBpmFuzzyRange);
+        root.dirty = false;
+        errorMessage.text = "";
+    }
+    function loadSources() {
+        let rootDirs = [];
+        for (let source of Object.values(Mixxx.Library.sources)) {
+            rootDirs.push({
+                path: source.path,
+                trackCount: source.trackCount,
+                totalMinute: Math.round(source.totalSecond / 60)
+            });
         }
+        sourceListView.model = rootDirs;
+    }
+    function reset() {
+    }
+    function save() {
+        let requestedDirs = [...sourceListView.model];
+        let changed = false;
+
+        for (let source of requestedDirs) {
+            if (source.trackCount === undefined) {
+                // Handle addition
+                switch (Mixxx.Library.addSource(source.path)) {
+                case Mixxx.Library.AddResult.AlreadyWatching:
+                    errorMessage.text = qsTr("This or a parent directory is already in your library.");
+                    return;
+                case Mixxx.Library.AddResult.InvalidOrMissingDirectory:
+                    errorMessage.text = qsTr("This or a listed directory does not exist or is inaccessible.\nAborting the operation to avoid library inconsistencies");
+                    return;
+                case Mixxx.Library.AddResult.UnreadableDirectory:
+                    errorMessage.text = qsTr("This directory can not be read.");
+                    return;
+                case Mixxx.Library.AddResult.SqlError:
+                    errorMessage.text = qsTr("An unknown error occurred.\nAborting the operation to avoid library inconsistencies");
+                    return;
+                }
+            } else if (source.deleting !== undefined) {
+                // Handle removal
+                switch (Mixxx.Library.removeSource(source.path, source.deleting)) {
+                case Mixxx.Library.RemoveResult.NotFound:
+                    errorMessage.text = qsTr("This directory can not be found.");
+                    return;
+                case Mixxx.Library.RemoveResult.SqlError:
+                    errorMessage.text = qsTr("An unknown error occurred.\nAborting the operation to avoid library inconsistencies");
+                    return;
+                }
+            } else if (source.relink) {
+                // Handle relinking
+                switch (Mixxx.Library.relinkSource(source.path, source.relink)) {
+                case Mixxx.Library.RelocateResult.InvalidOrMissingDirectory:
+                    errorMessage.text = qsTr("This or a listed directory does not exist or is inaccessible.\nAborting the operation to avoid library inconsistencies");
+                    return;
+                case Mixxx.Library.RelocateResult.UnreadableDirectory:
+                    errorMessage.text = qsTr("This directory can not be read.");
+                    return;
+                case Mixxx.Library.RelocateResult.SqlError:
+                    errorMessage.text = qsTr("An unknown error occurred.\nAborting the operation to avoid library inconsistencies");
+                    return;
+                }
+            } else {
+                continue;
+            }
+            changed = true;
+        }
+
+        if (changed) {
+            Mixxx.Library.scanner.start();
+        }
+
+        let integrations = {};
+        for (let i = 0; i < integrationRepeater.count; i++) {
+            integrations[integrationRepeater.itemAt(i).modelData.service] = integrationRepeater.itemAt(i).enabled;
+        }
+        Mixxx.Config.libraryRhythmboxEnabled = integrations.Rhythmbox;
+        Mixxx.Config.libraryBansheeEnabled = integrations.Banshee;
+        Mixxx.Config.libraryITunesEnabled = integrations.iTunes;
+        Mixxx.Config.libraryTraktorEnabled = integrations.Traktor;
+        Mixxx.Config.libraryRekordboxEnabled = integrations.Rekordbox;
+        Mixxx.Config.librarySeratoEnabled = integrations.Serato;
+        Mixxx.Config.librarySyncTrackMetadataExport = metadataSynchroniseEnabled.enabled;
+        Mixxx.Config.librarySeratoMetadataExport = metadataSynchroniseSeratoEnabled.enabled;
+        Mixxx.Config.libraryUseRelativePathOnExport = metadataRelativePathEnabled.enabled;
+        Mixxx.Config.librarySearchCompletionsEnable = searchCompletionEnabled.enabled;
+        Mixxx.Config.librarySearchHistoryShortcutsEnable = searchHistoryKeyboardEnabled.enabled;
+        Mixxx.Config.libraryHistoryTrackDuplicateDistance = historyDuplicateDistanceInput.value;
+        Mixxx.Config.libraryHistoryMinTracksToKeep = historyDeleteLessThanInput.value;
+        Mixxx.Config.librarySearchDebouncingTimeout = searchAsYouTypeTimeoutInput.value * 1000;
+        Mixxx.Config.librarySearchBpmFuzzyRange = pitchSliderFuzzBPMInput.value;
+        load();
+    }
+
+    label: qsTr("Library")
+
+    Component.onCompleted: {
+        root.load();
+    }
+
+    ScrollView {
+        id: scrollView
+
+        anchors.bottom: buttonActions.top
+        anchors.bottomMargin: 18
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: parent.top
+        spacing: 0
+
+        ColumnLayout {
+            width: root.width - 10
+
+            RowLayout {
+                Text {
+                    Layout.bottomMargin: 14
+                    Layout.leftMargin: 17
+                    color: Theme.white
+                    font.pixelSize: 16
+                    font.weight: Font.DemiBold
+                    text: qsTr("Sources")
+                }
+            }
+            Mixxx.SettingGroup {
+                Layout.bottomMargin: 6
+                anchors.left: parent.left
+                anchors.right: parent.right
+                implicitHeight: sources.implicitHeight
+                label: qsTr("Sources")
+
+                GridLayout {
+                    id: sources
+
+                    columnSpacing: 20
+                    columns: width > 800 ? 2 : 1
+                    width: parent.width
+
+                    Rectangle {
+                        Layout.fillWidth: true
+                        // anchors.left: parent.left
+                        // anchors.right: parent.right
+                        Layout.minimumWidth: sourcePane.implicitWidth
+                        color: '#0E0E0E'
+                        implicitHeight: sourcePane.implicitHeight + 20
+
+                        ColumnLayout {
+                            id: sourcePane
+
+                            anchors.fill: parent
+                            spacing: 0
+
+                            RowLayout {
+                                Layout.fillWidth: true
+                                Layout.leftMargin: 8
+                                Layout.rightMargin: 8
+                                Layout.topMargin: 10
+
+                                Text {
+                                    Layout.fillWidth: true
+                                    Layout.leftMargin: 17
+                                    color: Theme.white
+                                    font.pixelSize: 14
+                                    font.weight: Font.DemiBold
+                                    text: qsTr('Music Directory')
+                                }
+                                FolderDialog {
+                                    id: addDialog
+
+                                    currentFolder: StandardPaths.writableLocation(StandardPaths.MusicLocation)
+                                    title: qsTr("Choose a music directory")
+
+                                    onAccepted: {
+                                        let model = sourceListView.model;
+                                        let path = addDialog.selectedFolder.toString();
+                                        path = path.replace(/^file:\/{2,3}/, ""); // FIXME does this work on Windows ?
+                                        model.push({
+                                            path: decodeURIComponent(path)
+                                        });
+                                        root.dirty = true;
+                                        sourceListView.model = model;
+                                    }
+                                }
+                                SettingComponents.FormButton {
+                                    activeColor: "#999999"
+                                    backgroundColor: "#3F3F3F"
+                                    opacity: enabled ? 1.0 : 0.5
+                                    text: qsTr("Add")
+
+                                    onPressed: addDialog.open()
+                                }
+                            }
+                            ListView {
+                                id: sourceListView
+
+                                Layout.fillWidth: true
+                                Layout.preferredHeight: 240
+                                clip: true
+                                focus: true
+                                model: []
+
+                                // anchors.fill: parent
+                                // anchors.topMargin: 10
+                                // anchors.bottomMargin: 10
+                                // anchors.leftMargin: 17
+                                // anchors.rightMargin: 17
+
+                                delegate: MouseArea {
+                                    id: mouse
+
+                                    required property int index
+                                    required property var modelData
+                                    readonly property bool selected: ListView.view.currentIndex == index && modelData.deleting === undefined && !modelData.relink && modelData.trackCount !== undefined
+
+                                    height: 34
+                                    hoverEnabled: true
+                                    width: ListView.view.width
+
+                                    onPressed: {
+                                        ListView.view.currentIndex = index;
+                                    }
+                                    onSelectedChanged: {
+                                        removeButton.confirming = false;
+                                    }
+
+                                    Timer {
+                                        id: cancelDeletion
+
+                                        interval: 1000
+                                        running: removeButton.confirming && !mouse.containsMouse
+
+                                        onTriggered: {
+                                            removeButton.confirming = false;
+                                        }
+                                    }
+                                    Rectangle {
+                                        anchors.fill: parent
+                                        color: index % 2 == 0 ? '#3F3F3F' : '#2B2B2B'
+
+                                        // width: 180; height: 40
+                                        RowLayout {
+                                            anchors.fill: parent
+                                            anchors.leftMargin: 8
+                                            anchors.rightMargin: 8
+
+                                            Text {
+                                                text: qsTr("Icon")
+                                                width: 160
+                                            }
+                                            Text {
+                                                Layout.fillWidth: true
+                                                color: Theme.white
+                                                font.pixelSize: 14
+                                                font.weight: Font.Medium
+                                                opacity: modelData.deleting !== undefined ? 0.4 : 1
+                                                text: modelData.path
+                                            }
+                                            FolderDialog {
+                                                id: relinkDialog
+
+                                                currentFolder: StandardPaths.writableLocation(StandardPaths.MusicLocation)
+                                                title: qsTr("Relink music directory to new location")
+
+                                                onAccepted: {
+                                                    let model = sourceListView.model;
+                                                    let path = selectedFolder.toString().replace(/^(file:\/\/)/, ""); // FIXME does this work on Windows ?
+                                                    model[mouse.index].relink = decodeURIComponent(path);
+                                                    root.dirty = true;
+                                                    sourceListView.model = model;
+                                                }
+                                            }
+                                            SettingComponents.FormButton {
+                                                id: relinkButton
+
+                                                activeColor: "#999999"
+                                                backgroundColor: "#3F3F3F"
+                                                opacity: enabled ? 1.0 : 0.5
+                                                text: modelData.relink ? qsTr("Save to proceed") : qsTr("Relink")
+                                                visible: selected && modelData.trackCount !== undefined && !Mixxx.Library.scanner.running
+
+                                                onPressed: {
+                                                    relinkDialog.open();
+                                                }
+                                            }
+                                            Item {
+                                                id: removeButton
+
+                                                property bool confirming: false
+
+                                                clip: true
+                                                implicitHeight: Math.max(actionButton.implicitHeight, removeModeSelector.implicitHeight)
+                                                implicitWidth: removeButton.confirming ? removeModeSelector.implicitWidth : actionButton.implicitWidth
+                                                visible: selected && !Mixxx.Library.scanner.running
+
+                                                Behavior on implicitWidth {
+                                                    PropertyAnimation {
+                                                    }
+                                                }
+
+                                                SettingComponents.FormButton {
+                                                    id: actionButton
+
+                                                    activeColor: "#999999"
+                                                    anchors.centerIn: parent
+                                                    backgroundColor: "#7D3B3B"
+                                                    opacity: enabled ? 1.0 : 0.5
+                                                    text: qsTr("Remove")
+                                                    visible: !removeButton.confirming
+
+                                                    onPressed: {
+                                                        if (modelData.trackCount == 0) {
+                                                            let model = sourceListView.model;
+                                                            model[mouse.index].deleting = Mixxx.Library.PurgeTracks;
+                                                            root.dirty = true;
+                                                            sourceListView.model = model;
+                                                        } else {
+                                                            removeButton.confirming = !removeButton.confirming;
+                                                        }
+                                                    }
+                                                }
+                                                RatioChoice {
+                                                    id: removeModeSelector
+
+                                                    anchors.centerIn: parent
+                                                    inactiveColor: Theme.darkGray4
+                                                    normalizedWidth: false
+                                                    options: ["keep tracks", "hide tracks", "purge tracks"]
+                                                    selected: null
+                                                    visible: removeButton.confirming
+
+                                                    onSelectedChanged: {
+                                                        let model = sourceListView.model;
+                                                        switch (options.indexOf(selected)) {
+                                                        case 0:
+                                                            model[mouse.index].deleting = Mixxx.Library.KeepTracks;
+                                                            break;
+                                                        case 1:
+                                                            model[mouse.index].deleting = Mixxx.Library.HideTracks;
+                                                            break;
+                                                        case 2:
+                                                            model[mouse.index].deleting = Mixxx.Library.PurgeTracks;
+                                                            break;
+                                                        default:
+                                                            console.warn(`unknown value deletion mode ${selected}. Ignoring.`);
+                                                            return;
+                                                        }
+                                                        root.dirty = true;
+                                                        sourceListView.model = model;
+                                                    }
+                                                }
+                                            }
+                                            Text {
+                                                color: '#626262'
+                                                font.italic: modelData.trackCount === undefined || modelData.totalMinute === undefined || !!modelData.relink
+                                                font.pixelSize: 14
+                                                font.weight: Font.Medium
+                                                text: {
+                                                    if (modelData.relink) {
+                                                        return qsTr(`Save to relink to ${modelData.relink}`);
+                                                    } else if (modelData.deleting !== undefined) {
+                                                        let action = {
+                                                            0: qsTr("keep already imported tracks"),
+                                                            1: qsTr("hide imported tracks"),
+                                                            2: qsTr("purge imported tracks")
+                                                        }[modelData.deleting] || 'perform an unknown action';
+                                                        return qsTr(`Save to delete and ${action}`);
+                                                    } else if (modelData.trackCount !== undefined && modelData.totalMinute !== undefined) {
+                                                        return qsTr(`${modelData.trackCount} tracks, ${modelData.totalMinute} minutes`);
+                                                    } else {
+                                                        return qsTr('Save to import new folder');
+                                                    }
+                                                }
+                                                visible: !selected && !Mixxx.Library.scanner.running
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        Rectangle {
+                            anchors.fill: parent
+                            color: Qt.alpha('black', 0.4)
+                            visible: Mixxx.Library.scanner.running
+
+                            MouseArea {
+                                anchors.fill: parent
+                            }
+                            Text {
+                                id: scanProgress
+
+                                color: Theme.white
+                                font.pixelSize: 14
+                                text: qsTr("File scanning...")
+
+                                anchors {
+                                    bottom: parent.bottom
+                                    left: parent.left
+                                    margins: 5
+                                }
+                                Connections {
+                                    function onProgress(currentPath) {
+                                        scanProgress.text = qsTr(`File scanning: ${currentPath}`);
+                                    }
+
+                                    target: Mixxx.Library.scanner
+                                }
+                            }
+                            SettingComponents.FormButton {
+                                activeColor: "#999999"
+                                backgroundColor: Mixxx.Library.scanner.cancelling ? "#999999" : "#3a60be"
+                                enabled: !Mixxx.Library.scanner.cancelling
+                                text: qsTr("Cancel")
+
+                                onPressed: {
+                                    Mixxx.Library.scanner.cancel();
+                                }
+
+                                anchors {
+                                    bottom: parent.bottom
+                                    margins: 5
+                                    right: parent.right
+                                }
+                            }
+                        }
+                    }
+                    ColumnLayout {
+                        Rectangle {
+                            Layout.preferredWidth: root.width * (sources.columns == 2 ? 0.35 : 1)
+                            anchors.left: parent.left
+                            anchors.right: parent.right
+                            color: Theme.darkGray2
+                            implicitHeight: integrationPane.implicitHeight + 20
+
+                            GridLayout {
+                                id: integrationPane
+
+                                anchors.bottomMargin: 10
+                                anchors.fill: parent
+                                anchors.leftMargin: 17
+                                anchors.rightMargin: 17
+                                anchors.topMargin: 10
+                                columns: sources.columns == 2 ? 1 : 2
+
+                                Repeater {
+                                    id: integrationRepeater
+
+                                    RowLayout {
+                                        property alias enabled: integrationEnabled.enabled
+                                        required property var modelData
+
+                                        Layout.preferredWidth: sourcePane.width * 0.5
+
+                                        Mixxx.SettingParameter {
+                                            Layout.fillWidth: true
+                                            label: modelData.service
+
+                                            Text {
+                                                anchors.fill: parent
+                                                color: Theme.white
+                                                font.pixelSize: 14
+                                                font.weight: Font.Medium
+                                                horizontalAlignment: Text.AlignLeft
+                                                text: parent.label
+                                                verticalAlignment: Text.AlignVCenter
+                                            }
+                                        }
+                                        RatioChoice {
+                                            id: integrationEnabled
+
+                                            readonly property bool enabled: selected == "on"
+
+                                            inactiveColor: Theme.darkGray4
+                                            maxWidth: parent.width * 0.5
+                                            options: ["on", "off"]
+                                            selected: modelData.enabled ? "on" : "off"
+
+                                            onSelectedChanged: root.dirty = true
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            Mixxx.SettingGroup {
+                Layout.bottomMargin: 6
+                Layout.topMargin: 40
+                anchors.left: parent.left
+                anchors.right: parent.right
+                implicitHeight: metadataColumn.height
+                label: qsTr("Metadata")
+
+                Column {
+                    id: metadataColumn
+
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+
+                    Text {
+                        color: Theme.white
+                        font.pixelSize: 14
+                        font.weight: Font.DemiBold
+                        text: qsTr("Metadata")
+                    }
+                    Item {
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        height: 10
+                    }
+                    Rectangle {
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        color: Theme.darkGray2
+                        implicitHeight: metadataPane.implicitHeight + 20
+
+                        GridLayout {
+                            id: metadataPane
+
+                            anchors.bottomMargin: 10
+                            anchors.fill: parent
+                            anchors.leftMargin: 17
+                            anchors.rightMargin: 17
+                            anchors.topMargin: 10
+                            columnSpacing: 20
+                            columns: metadataColumn.width < 850 ? 1 : 2
+                            rowSpacing: 15
+
+                            RowLayout {
+                                Layout.preferredWidth: metadataPane.width / metadataPane.columns
+
+                                Mixxx.SettingParameter {
+                                    Layout.fillWidth: true
+                                    label: qsTr("Synchronise metadata with file")
+
+                                    Text {
+                                        anchors.fill: parent
+                                        color: Theme.white
+                                        font.pixelSize: 14
+                                        font.weight: Font.Medium
+                                        horizontalAlignment: Text.AlignLeft
+                                        text: parent.label
+                                        verticalAlignment: Text.AlignVCenter
+                                    }
+                                }
+                                RatioChoice {
+                                    id: metadataSynchroniseEnabled
+
+                                    readonly property bool enabled: selected == "on"
+
+                                    inactiveColor: Theme.darkGray4
+                                    maxWidth: parent.width * 0.5
+                                    options: ["on", "off"]
+
+                                    onSelectedChanged: root.dirty = true
+                                }
+                            }
+                            RowLayout {
+                                Layout.preferredWidth: metadataPane.width / metadataPane.columns
+
+                                Mixxx.SettingParameter {
+                                    Layout.fillWidth: true
+                                    label: qsTr("Synchronise metadata with Serato library")
+
+                                    Text {
+                                        anchors.fill: parent
+                                        color: Theme.white
+                                        font.pixelSize: 14
+                                        font.weight: Font.Medium
+                                        horizontalAlignment: Text.AlignLeft
+                                        text: parent.label
+                                        verticalAlignment: Text.AlignVCenter
+                                    }
+                                }
+                                RatioChoice {
+                                    id: metadataSynchroniseSeratoEnabled
+
+                                    readonly property bool enabled: selected == "on"
+
+                                    inactiveColor: Theme.darkGray4
+                                    maxWidth: parent.width * 0.5
+                                    options: ["on", "off"]
+
+                                    onSelectedChanged: root.dirty = true
+                                }
+                            }
+                            RowLayout {
+                                Layout.preferredWidth: metadataPane.width / metadataPane.columns
+
+                                Mixxx.SettingParameter {
+                                    Layout.fillWidth: true
+                                    label: qsTr("Prefer relative path on playlist export")
+
+                                    Text {
+                                        anchors.fill: parent
+                                        color: Theme.white
+                                        font.pixelSize: 14
+                                        font.weight: Font.Medium
+                                        horizontalAlignment: Text.AlignLeft
+                                        text: parent.label
+                                        verticalAlignment: Text.AlignVCenter
+                                    }
+                                }
+                                RatioChoice {
+                                    id: metadataRelativePathEnabled
+
+                                    readonly property bool enabled: selected == "on"
+
+                                    inactiveColor: Theme.darkGray4
+                                    maxWidth: parent.width * 0.5
+                                    options: ["on", "off"]
+
+                                    onSelectedChanged: root.dirty = true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            Mixxx.SettingGroup {
+                Layout.bottomMargin: 6
+                Layout.topMargin: 40
+                anchors.left: parent.left
+                anchors.right: parent.right
+                implicitHeight: historyColumn.height
+                label: qsTr("History")
+
+                Column {
+                    id: historyColumn
+
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+
+                    Text {
+                        color: Theme.white
+                        font.pixelSize: 14
+                        font.weight: Font.DemiBold
+                        text: qsTr("History")
+                    }
+                    Item {
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        height: 10
+                    }
+                    Rectangle {
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        color: Theme.darkGray2
+                        implicitHeight: historyPane.implicitHeight + 20
+
+                        GridLayout {
+                            id: historyPane
+
+                            anchors.bottomMargin: 10
+                            anchors.fill: parent
+                            anchors.leftMargin: 17
+                            anchors.rightMargin: 17
+                            anchors.topMargin: 10
+                            columnSpacing: 20
+                            columns: historyColumn.width < 800 ? 1 : 2
+                            rowSpacing: 15
+
+                            RowLayout {
+                                Layout.preferredWidth: historyPane.width / historyPane.columns
+
+                                Mixxx.SettingParameter {
+                                    Layout.fillWidth: true
+                                    label: qsTr("Track duplicate distance")
+
+                                    Text {
+                                        anchors.fill: parent
+                                        color: Theme.white
+                                        font.pixelSize: 14
+                                        font.weight: Font.Medium
+                                        horizontalAlignment: Text.AlignLeft
+                                        text: parent.label
+                                        verticalAlignment: Text.AlignVCenter
+                                    }
+                                }
+                                SettingComponents.SpinBox {
+                                    id: historyDuplicateDistanceInput
+
+                                    Layout.alignment: Qt.AlignHCenter
+                                    Layout.leftMargin: 20
+                                    Layout.rightMargin: 20
+                                    max: 1000
+                                    min: 1
+                                    precision: 0
+                                    realValue: 2
+                                    suffix: value > 1 ? qsTr(" tracks") : qsTr(" track")
+
+                                    onValueChanged: root.dirty = true
+                                }
+                            }
+                            RowLayout {
+                                Layout.preferredWidth: historyPane.width / historyPane.columns
+
+                                Mixxx.SettingParameter {
+                                    Layout.fillWidth: true
+                                    label: qsTr("Delete history playlist with less than")
+
+                                    Text {
+                                        anchors.fill: parent
+                                        color: Theme.white
+                                        font.pixelSize: 14
+                                        font.weight: Font.Medium
+                                        horizontalAlignment: Text.AlignLeft
+                                        text: parent.label
+                                        verticalAlignment: Text.AlignVCenter
+                                    }
+                                }
+                                SettingComponents.SpinBox {
+                                    id: historyDeleteLessThanInput
+
+                                    Layout.alignment: Qt.AlignHCenter
+                                    Layout.leftMargin: 20
+                                    Layout.rightMargin: 20
+                                    max: 1000
+                                    min: 1
+                                    precision: 0
+                                    realValue: 2
+                                    suffix: value > 1 ? qsTr(" tracks") : qsTr(" track")
+
+                                    onValueChanged: root.dirty = true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            Mixxx.SettingGroup {
+                Layout.bottomMargin: 6
+                Layout.topMargin: 40
+                anchors.left: parent.left
+                anchors.right: parent.right
+                implicitHeight: searchColumn.height
+                label: qsTr("Search")
+
+                Column {
+                    id: searchColumn
+
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+
+                    Text {
+                        color: Theme.white
+                        font.pixelSize: 14
+                        font.weight: Font.DemiBold
+                        text: qsTr("Search")
+                    }
+                    Item {
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        height: 10
+                    }
+                    Rectangle {
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        color: Theme.darkGray2
+                        implicitHeight: searchPane.implicitHeight + 20
+
+                        GridLayout {
+                            id: searchPane
+
+                            anchors.bottomMargin: 10
+                            anchors.fill: parent
+                            anchors.leftMargin: 17
+                            anchors.rightMargin: 17
+                            anchors.topMargin: 10
+                            columnSpacing: 20
+                            columns: 2
+                            rowSpacing: 15
+
+                            RowLayout {
+                                Layout.preferredWidth: searchPane.width * 0.5
+
+                                Mixxx.SettingParameter {
+                                    Layout.fillWidth: true
+                                    label: qsTr("Search completion")
+
+                                    Text {
+                                        anchors.fill: parent
+                                        color: Theme.white
+                                        font.pixelSize: 14
+                                        font.weight: Font.Medium
+                                        horizontalAlignment: Text.AlignLeft
+                                        text: parent.label
+                                        verticalAlignment: Text.AlignVCenter
+                                    }
+                                }
+                                RatioChoice {
+                                    id: searchCompletionEnabled
+
+                                    readonly property bool enabled: selected == "on"
+
+                                    inactiveColor: Theme.darkGray4
+                                    maxWidth: parent.width * 0.5
+                                    options: ["on", "off"]
+
+                                    onSelectedChanged: root.dirty = true
+                                }
+                            }
+                            RowLayout {
+                                Layout.preferredWidth: searchPane.width * 0.5
+
+                                Mixxx.SettingParameter {
+                                    Layout.fillWidth: true
+                                    label: qsTr("Search history keyboard shortcuts")
+
+                                    Text {
+                                        anchors.fill: parent
+                                        color: Theme.white
+                                        font.pixelSize: 14
+                                        font.weight: Font.Medium
+                                        horizontalAlignment: Text.AlignLeft
+                                        text: parent.label
+                                        verticalAlignment: Text.AlignVCenter
+                                    }
+                                }
+                                RatioChoice {
+                                    id: searchHistoryKeyboardEnabled
+
+                                    readonly property bool enabled: selected == "on"
+
+                                    inactiveColor: Theme.darkGray4
+                                    maxWidth: parent.width * 0.5
+                                    options: ["on", "off"]
+
+                                    onSelectedChanged: root.dirty = true
+                                }
+                            }
+                            RowLayout {
+                                Layout.preferredWidth: searchPane.width * 0.5
+
+                                Mixxx.SettingParameter {
+                                    Layout.fillWidth: true
+                                    label: qsTr("Search-as-you-type timeout")
+
+                                    Text {
+                                        anchors.fill: parent
+                                        color: Theme.white
+                                        font.pixelSize: 14
+                                        font.weight: Font.Medium
+                                        horizontalAlignment: Text.AlignLeft
+                                        text: parent.label
+                                        verticalAlignment: Text.AlignVCenter
+                                    }
+                                }
+                                SettingComponents.Slider {
+                                    id: searchAsYouTypeTimeoutInput
+
+                                    Layout.preferredWidth: 400
+                                    decimals: 1
+                                    markers: [0.1, 0.5, 1, 5, 10]
+                                    max: 10
+                                    min: 0.1
+                                    suffix: qsTr("sec")
+                                    value: 0.3
+
+                                    onValueChanged: root.dirty = true
+                                }
+                            }
+                            RowLayout {
+                                Layout.preferredWidth: searchPane.width * 0.5
+
+                                Mixxx.SettingParameter {
+                                    Layout.fillWidth: true
+                                    label: qsTr("Pitch slider for fuzz BPM search")
+
+                                    Text {
+                                        anchors.fill: parent
+                                        color: Theme.white
+                                        font.pixelSize: 14
+                                        font.weight: Font.Medium
+                                        horizontalAlignment: Text.AlignLeft
+                                        text: parent.label
+                                        verticalAlignment: Text.AlignVCenter
+                                    }
+                                }
+                                SettingComponents.Slider {
+                                    id: pitchSliderFuzzBPMInput
+
+                                    Layout.preferredWidth: 400
+                                    markers: [0, 25, 50, 75, 100]
+                                    max: 100
+                                    min: 0
+                                    suffix: "%"
+                                    value: 8
+
+                                    onValueChanged: root.dirty = true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Item {
+        id: buttonActions
+
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
+        height: 20
+
+        SettingComponents.FormButton {
+            activeColor: "#999999"
+            anchors.left: parent.left
+            backgroundColor: "#7D3B3B"
+            opacity: enabled ? 1.0 : 0.5
+            text: qsTr("Reset")
+
+            onPressed: {
+                root.reset();
+            }
+        }
+        Row {
+            anchors.right: parent.right
+            spacing: 10
+
+            Text {
+                id: errorMessage
+
+                Layout.alignment: Qt.AlignVCenter
+                Layout.rightMargin: 16
+                color: "#7D3B3B"
+                text: ""
+            }
+            SettingComponents.FormButton {
+                activeColor: "#999999"
+                backgroundColor: "#3F3F3F"
+                opacity: enabled ? 1.0 : 0.5
+                text: qsTr("Cancel")
+                visible: root.dirty
+
+                onPressed: {
+                    root.load();
+                }
+            }
+            SettingComponents.FormButton {
+                activeColor: "#999999"
+                backgroundColor: root.dirty ? "#3a60be" : "#3F3F3F"
+                enabled: root.dirty
+                opacity: enabled ? 1.0 : 0.5
+                text: qsTr("Save")
+
+                onPressed: {
+                    errorMessage.text = "";
+                    root.save();
+                }
+            }
+        }
+    }
+    Connections {
+        function onRunningChanged(running) {
+            if (!Mixxx.Library.scanner.running) {
+                root.loadSources();
+            }
+        }
+
+        target: Mixxx.Library.scanner
     }
 }

--- a/res/qml/Settings/RatioChoice.qml
+++ b/res/qml/Settings/RatioChoice.qml
@@ -16,23 +16,14 @@ Item {
     property color inactiveColor: Theme.darkGray2
     property real maxWidth: 0
     property alias metric: fontMetrics
-    property bool normalizedWidth: false
+    property bool normalizedWidth: true
     required property list<string> options
     property var selected: options.length ? options[0] : null
     property real spacing: 9
     property list<var> tooltips: []
 
-    implicitHeight: (contentList.visible ? contentList.height : contentSpin.height)
-    implicitWidth: {
-        let minimumSize = options.reduce((acc, option) => acc + fontMetrics.advanceWidth(option) + root.spacing * 2, 0);
-        let normalizedSize = root.cellSize * root.options.length;
-        let size = root.normalizedWidth ? normalizedSize : minimumSize;
-        if (root.maxWidth > size) {
-            return size + root.spacing;
-        } else {
-            return contentSpin.implicitWidth;
-        }
-    }
+    implicitHeight: (contentList.visible ? contentList.height : contentSpin.height) + dropRatio.radius * 2
+    implicitWidth: (contentList.visible ? contentList.width : contentSpin.width) + dropRatio.radius * 2
 
     onTooltipsChanged: {
         popup.close();
@@ -169,7 +160,7 @@ Item {
             radius: parent.height / 2
         }
         contentItem: Item {
-            width: contentSpin.textWidth + 2 * contentSpin.spacing
+            width: contentSpin.textWidth + 2 * contentSpin.spacing + 20
 
             Rectangle {
                 id: content
@@ -224,6 +215,8 @@ Item {
         }
 
         onValueChanged: {
+            if (!contentSpin.visible)
+                return;
             root.selected = contentSpin.textFromValue(value) ?? "";
             popup.tooltip = root.tooltips[contentSpin.value] ?? "";
             popup.x = contentSpin.width / 2 - popup.width / 2;
@@ -250,8 +243,8 @@ Item {
     DropShadow {
         id: dropRatio
 
-        anchors.fill: contentList.visible ? contentList : contentSpin
-        anchors.margins: 0
+        anchors.fill: root
+        anchors.margins: dropRatio.radius
         color: "#80000000"
         horizontalOffset: 0
         radius: 4.0

--- a/res/qml/Theme/Theme.qml
+++ b/res/qml/Theme/Theme.qml
@@ -2,9 +2,8 @@ pragma Singleton
 import QtQuick 2.12
 
 QtObject {
-    property color accent: "#2D4EA1"
     property color accentColor: "#3a60be"
-    property color backgroundColor: "#1e1e1e"
+    property color backgroundColor: "#1e1e20"
     property color blue: "#01dcfc"
     property color bpmSliderBarColor: blue
     property color buttonActiveColor: white
@@ -14,10 +13,10 @@ QtObject {
     property color crossfaderBarColor: blue
     property color crossfaderOrientationColor: lightGray
     property color darkGray: "#0f0f0f"
-    property color darkGray2: "#242424"
+    property color darkGray2: "#2e2e2e"
     property color darkGray3: "#3F3F3F"
     property color darkGray4: "#202020"
-    property color deckActiveColor: green
+    property color deckActiveColor: white
     property color deckBackgroundColor: darkGray
     property color deckBeatjumpBackgroundColor: midGray3
     property color deckBeatjumpLabelColor: darkGray3
@@ -26,7 +25,7 @@ QtObject {
     property color deckLineColor: darkGray2
     property color deckLoopBackgroundColor: midGray3
     property color deckLoopLabelColor: darkGray3
-    property color deckTextColor: white
+    property color deckTextColor: lightGray2
     property color effectColor: yellow
     property color effectUnitColor: red
     property color embeddedBackgroundColor: "#a0000000"
@@ -69,7 +68,7 @@ QtObject {
     property color red: "#ea2a4e"
     property color samplerColor: blue
     property color sunkenBackgroundColor: "#0C0C0C"
-    property color textColor: white
+    property color textColor: lightGray2
     property int textFontPixelSize: 14
     property color toolbarActiveColor: white
     property color toolbarBackgroundColor: darkGray2

--- a/src/library/dao/directorydao.cpp
+++ b/src/library/dao/directorydao.cpp
@@ -79,13 +79,16 @@ QList<mixxx::FileInfo> DirectoryDAO::loadAllDirectories(
     return allDirs;
 }
 
-QStringList DirectoryDAO::getRootDirStrings() const {
+QList<DirectoryDAO::RootDirectoryInfo> DirectoryDAO::getRootDirectories() const {
     DEBUG_ASSERT(m_database.isOpen());
-    const auto statement =
-            QStringLiteral("SELECT %1 FROM %2")
-                    .arg(
-                            kLocationColumn,
-                            kTable);
+    const auto statement = QStringLiteral(
+            "SELECT d.%1, COUNT(t.directory) AS total_track, SUM(l.duration) "
+            "AS total_runtime FROM %2 d LEFT JOIN track_locations t ON d.%3 = "
+            "t.directory LEFT JOIN library l ON t.id = l.id GROUP BY d.%4;")
+                                   .arg(kLocationColumn,
+                                           kTable,
+                                           kLocationColumn,
+                                           kLocationColumn);
     FwdSqlQuery query(
             m_database,
             statement);
@@ -93,12 +96,19 @@ QStringList DirectoryDAO::getRootDirStrings() const {
         return {};
     }
 
-    QStringList allDirs;
+    QList<DirectoryDAO::RootDirectoryInfo> allDirs;
     const auto locationIndex = query.fieldIndex(kLocationColumn);
+    const auto totalTrackIndex = query.fieldIndex("total_track");
+    const auto totalRuntimeIndex = query.fieldIndex("total_runtime");
     while (query.next()) {
         const auto locationValue =
                 query.fieldValue(locationIndex).toString();
-        allDirs.append(locationValue);
+        const auto totalTrackValue =
+                query.fieldValue(totalTrackIndex).toUInt();
+        const auto totalRuntimeValue =
+                query.fieldValue(totalRuntimeIndex).toUInt();
+        allDirs.append(DirectoryDAO::RootDirectoryInfo{
+                locationValue, totalTrackValue, totalRuntimeValue});
     }
     return allDirs;
 }

--- a/src/library/dao/directorydao.h
+++ b/src/library/dao/directorydao.h
@@ -8,15 +8,21 @@
 
 class DirectoryDAO : public DAO {
   public:
+    struct RootDirectoryInfo {
+        QString path;
+        uint trackCount;
+        uint totalSecond;
+    };
+
     ~DirectoryDAO() override = default;
 
     void repairDatabase(const QSqlDatabase& database);
 
     QList<mixxx::FileInfo> loadAllDirectories(
             bool skipInvalidOrMissing = false) const;
-    /// Same as loadAllDirectories() just with paths as QString.
+    /// Same as loadAllDirectories() just with paths info as RootDirectoryInfo.
     /// See DlgPrefLibrary::populateDirList() for info.
-    QStringList getRootDirStrings() const;
+    QList<RootDirectoryInfo> getRootDirectories() const;
 
     enum class AddResult {
         Ok,

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -122,39 +122,44 @@ LibraryScanner::LibraryScanner(
     // connect them to our slots to run the command on the scanner thread.
     connect(this, &LibraryScanner::startScan, this, &LibraryScanner::slotStartScan);
 
-    connect(this,
-            &LibraryScanner::progressLoading,
-            m_pProgressDlg.get(),
-            &LibraryScannerDlg::slotUpdate);
-    connect(this,
-            &LibraryScanner::progressHashing,
-            m_pProgressDlg.get(),
-            &LibraryScannerDlg::slotUpdate);
-    connect(this,
-            &LibraryScanner::scanStarted,
-            m_pProgressDlg.get(),
-            &LibraryScannerDlg::slotScanStarted);
-    connect(this,
-            &LibraryScanner::scanFinished,
-            m_pProgressDlg.get(),
-            &LibraryScannerDlg::slotScanFinished);
-    connect(m_pProgressDlg.get(),
-            &LibraryScannerDlg::scanCancelled,
-            this,
-            &LibraryScanner::slotCancel,
-            Qt::DirectConnection);
-    connect(&m_trackDao,
-            &TrackDAO::progressVerifyTracksOutside,
-            m_pProgressDlg.get(),
-            &LibraryScannerDlg::slotUpdate);
-    connect(&m_trackDao,
-            &TrackDAO::progressCoverArt,
-            m_pProgressDlg.get(),
-            &LibraryScannerDlg::slotUpdateCover);
-    connect(&m_trackDao,
-            &TrackDAO::progressLookingForSubstituteTracks,
-            m_pProgressDlg.get(),
-            &LibraryScannerDlg::slotUpdateSubstitute);
+#ifdef MIXXX_USE_QML
+    if (!CmdlineArgs::Instance().isQml())
+#endif
+    {
+        connect(this,
+                &LibraryScanner::progressLoading,
+                m_pProgressDlg.get(),
+                &LibraryScannerDlg::slotUpdate);
+        connect(this,
+                &LibraryScanner::progressHashing,
+                m_pProgressDlg.get(),
+                &LibraryScannerDlg::slotUpdate);
+        connect(this,
+                &LibraryScanner::scanStarted,
+                m_pProgressDlg.get(),
+                &LibraryScannerDlg::slotScanStarted);
+        connect(this,
+                &LibraryScanner::scanFinished,
+                m_pProgressDlg.get(),
+                &LibraryScannerDlg::slotScanFinished);
+        connect(m_pProgressDlg.get(),
+                &LibraryScannerDlg::scanCancelled,
+                this,
+                &LibraryScanner::slotCancel,
+                Qt::DirectConnection);
+        connect(&m_trackDao,
+                &TrackDAO::progressVerifyTracksOutside,
+                m_pProgressDlg.get(),
+                &LibraryScannerDlg::slotUpdate);
+        connect(&m_trackDao,
+                &TrackDAO::progressCoverArt,
+                m_pProgressDlg.get(),
+                &LibraryScannerDlg::slotUpdateCover);
+        connect(&m_trackDao,
+                &TrackDAO::progressLookingForSubstituteTracks,
+                m_pProgressDlg.get(),
+                &LibraryScannerDlg::slotUpdateSubstitute);
+    }
 }
 
 LibraryScanner::~LibraryScanner() {
@@ -210,6 +215,7 @@ void LibraryScanner::slotStartScan() {
 
         changeScannerState(IDLE);
         emit scanSummary(result);
+        emit scanFinished();
         return;
     }
     changeScannerState(SCANNING);

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -142,7 +142,15 @@ QList<mixxx::FileInfo> TrackCollection::loadRootDirs(bool skipInvalidOrMissing) 
 }
 
 QStringList TrackCollection::getRootDirStrings() const {
-    return m_directoryDao.getRootDirStrings();
+    QStringList rootDirStrings;
+    for (auto& rootDirectory : m_directoryDao.getRootDirectories()) {
+        rootDirStrings.append(rootDirectory.path);
+    }
+    return rootDirStrings;
+}
+
+QList<DirectoryDAO::RootDirectoryInfo> TrackCollection::getRootDirectories() const {
+    return m_directoryDao.getRootDirectories();
 }
 
 DirectoryDAO::AddResult TrackCollection::addDirectory(const mixxx::FileInfo& rootDir) {

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -46,6 +46,7 @@ class TrackCollection : public QObject,
     QList<mixxx::FileInfo> loadRootDirs(
             bool skipInvalidOrMissing = false) const;
     QStringList getRootDirStrings() const;
+    QList<DirectoryDAO::RootDirectoryInfo> getRootDirectories() const;
 
     const CrateStorage& crates() const {
         DEBUG_ASSERT_QOBJECT_THREAD_AFFINITY(this);

--- a/src/library/trackcollectionmanager.h
+++ b/src/library/trackcollectionmanager.h
@@ -98,6 +98,10 @@ class TrackCollectionManager: public QObject,
     // Same as startLibraryScan() but don't emit the scan summary.
     void startLibraryAutoScan();
 
+    LibraryScanner* scanner() const {
+        return m_pScanner.get();
+    }
+
   signals:
     void libraryScanStarted();
     void libraryScanFinished();

--- a/src/qml/qmlconfigproxy.cpp
+++ b/src/qml/qmlconfigproxy.cpp
@@ -4,6 +4,7 @@
 
 #include "library/basetracktablemodel.h"
 #include "library/library.h"
+#include "library/library_prefs.h"
 #include "moc_qmlconfigproxy.cpp"
 #include "preferences/colorpalettesettings.h"
 #include "preferences/constants.h"
@@ -15,6 +16,9 @@
                 ConfigKey(GROUP, KEY),                        \
                 DEFAULT);                                     \
     }
+
+#define PROPERTY_IMPL_CONFIGKEY(CONFIGKEY, TYPE, NAME, DEFAULT) \
+    PROPERTY_IMPL(CONFIGKEY.group, CONFIGKEY.item, TYPE, NAME, DEFAULT)
 
 #define PROPERTY_IMPL(GROUP, KEY, TYPE, NAME, DEFAULT)                       \
     PROPERTY_IMPL_GETTER(GROUP, KEY, TYPE, NAME, DEFAULT)                    \
@@ -44,6 +48,14 @@ const QString kBpmGroup = QStringLiteral("[BPM]");
 
 const QString kMultiSamplingKey = QStringLiteral("multi_sampling");
 const QString k3DHardwareAccelerationKey = QStringLiteral("force_hardware_acceleration");
+
+// Library group
+const QString kRhythmboxEnabled = QStringLiteral("ShowRhythmboxLibrary");
+const QString kBansheeEnabled = QStringLiteral("ShowBansheeLibrary");
+const QString kITunesEnabled = QStringLiteral("ShowITunesLibrary");
+const QString kTraktorEnabled = QStringLiteral("ShowTraktorLibrary");
+const QString kRekordboxEnabled = QStringLiteral("ShowRekordboxLibrary");
+const QString kSeratoEnabled = QStringLiteral("ShowSeratoLibrary");
 
 // Waveform group
 const QString kZoomSynchronizationKey = QStringLiteral("ZoomSynchronization");
@@ -266,14 +278,61 @@ PROPERTY_IMPL(kLibraryGroup,
 PROPERTY_IMPL(kLibraryGroup,
         kEnableSearchHistoryShortcutsKey,
         bool,
+        librarySearchHistoryShortcutsEnable,
+        true);
+PROPERTY_IMPL_CONFIGKEY(mixxx::library::prefs::kSyncTrackMetadataConfigKey,
+        bool,
+        librarySyncTrackMetadataExport,
+        false);
+PROPERTY_IMPL_CONFIGKEY(mixxx::library::prefs::kSyncSeratoMetadataConfigKey,
+        bool,
+        librarySeratoMetadataExport,
+        false);
+PROPERTY_IMPL_CONFIGKEY(
+        mixxx::library::prefs::kUseRelativePathOnExportConfigKey,
+        bool,
+        libraryUseRelativePathOnExport,
+        false);
+PROPERTY_IMPL_CONFIGKEY(mixxx::library::prefs::kHistoryMinTracksToKeepConfigKey,
+        int,
+        libraryHistoryMinTracksToKeep,
+        1);
+PROPERTY_IMPL_CONFIGKEY(
+        mixxx::library::prefs::kHistoryTrackDuplicateDistanceConfigKey,
+        int,
+        libraryHistoryTrackDuplicateDistance,
+        6);
+PROPERTY_IMPL_CONFIGKEY(mixxx::library::prefs::kSearchBpmFuzzyRangeConfigKey,
+        double,
+        librarySearchBpmFuzzyRange,
+        0.06);
+PROPERTY_IMPL_CONFIGKEY(
+        mixxx::library::prefs::kSearchDebouncingTimeoutMillisConfigKey,
+        int,
+        librarySearchDebouncingTimeout,
+        300);
+PROPERTY_IMPL_CONFIGKEY(
+        mixxx::library::prefs::kEnableSearchCompletionsConfigKey,
+        bool,
+        librarySearchCompletionsEnable,
+        true);
+PROPERTY_IMPL_CONFIGKEY(
+        mixxx::library::prefs::kEnableSearchHistoryShortcutsConfigKey,
+        bool,
         libraryEnableSearchHistoryShortcuts,
         true);
-PROPERTY_IMPL(kLibraryGroup,
-        kBpmColumnPrecisionKey,
+PROPERTY_IMPL_CONFIGKEY(mixxx::library::prefs::kBpmColumnPrecisionConfigKey,
         int,
         libraryBpmColumnPrecision,
         BaseTrackTableModel::kBpmColumnPrecisionDefault);
 PROPERTY_IMPL(kLibraryGroup, kRowHeightKey, double, libraryRowHeight, Library::kDefaultRowHeightPx);
+PROPERTY_IMPL(kLibraryGroup, kRhythmboxEnabled, bool, libraryRhythmboxEnabled, false);
+PROPERTY_IMPL(kLibraryGroup, kBansheeEnabled, bool, libraryBansheeEnabled, false);
+PROPERTY_IMPL(kLibraryGroup, kITunesEnabled, bool, libraryITunesEnabled, false);
+PROPERTY_IMPL(kLibraryGroup, kTraktorEnabled, bool, libraryTraktorEnabled, false);
+PROPERTY_IMPL(kLibraryGroup, kRekordboxEnabled, bool, libraryRekordboxEnabled, false);
+PROPERTY_IMPL(kLibraryGroup, kSeratoEnabled, bool, librarySeratoEnabled, false);
+
 PROPERTY_IMPL(kControlGroup, kHotcueDefaultColorIndexKey, int, controlHotcueDefaultColorIndex, -1);
 PROPERTY_IMPL(kControlGroup, kLoopDefaultColorIndexKey, double, controlLoopDefaultColorIndex, -1);
 PROPERTY_IMPL(kControlGroup, kCueDefaultKey, CueMode, controlCueDefault, CueMode::Mixxx);

--- a/src/qml/qmlconfigproxy.h
+++ b/src/qml/qmlconfigproxy.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <qtmetamacros.h>
+
 #include <QColor>
 #include <QObject>
 #include <QQmlEngine>
@@ -218,6 +220,65 @@ class QmlConfigProxy : public QmlConfigProxyBase {
                     bpmSyncLockAlgorithm WRITE set_bpmSyncLockAlgorithm NOTIFY
                             bpmSyncLockAlgorithmChanged);
 
+    // Library group
+    Q_PROPERTY(bool librarySyncTrackMetadataExport READ
+                    librarySyncTrackMetadataExport WRITE
+                            set_librarySyncTrackMetadataExport NOTIFY
+                                    librarySyncTrackMetadataExportChanged);
+    Q_PROPERTY(bool librarySeratoMetadataExport READ librarySeratoMetadataExport
+                    WRITE set_librarySeratoMetadataExport NOTIFY
+                            librarySeratoMetadataExportChanged);
+    Q_PROPERTY(bool libraryUseRelativePathOnExport READ
+                    libraryUseRelativePathOnExport WRITE
+                            set_libraryUseRelativePathOnExport NOTIFY
+                                    libraryUseRelativePathOnExportChanged);
+    // Count, 0..
+    Q_PROPERTY(
+            int libraryHistoryMinTracksToKeep READ libraryHistoryMinTracksToKeep
+                    WRITE set_libraryHistoryMinTracksToKeep NOTIFY
+                            libraryHistoryMinTracksToKeepChanged);
+    // Count, 0..
+    Q_PROPERTY(int libraryHistoryTrackDuplicateDistance READ
+                    libraryHistoryTrackDuplicateDistance WRITE
+                            set_libraryHistoryTrackDuplicateDistance NOTIFY
+                                    libraryHistoryTrackDuplicateDistanceChanged);
+    // Percent, 0..1.0
+    Q_PROPERTY(double librarySearchBpmFuzzyRange READ librarySearchBpmFuzzyRange
+                    WRITE set_librarySearchBpmFuzzyRange NOTIFY
+                            librarySearchBpmFuzzyRangeChanged);
+    // Duration (ms), 100..9999
+    Q_PROPERTY(int librarySearchDebouncingTimeout READ
+                    librarySearchDebouncingTimeout WRITE
+                            set_librarySearchDebouncingTimeout NOTIFY
+                                    librarySearchDebouncingTimeoutChanged);
+    Q_PROPERTY(bool librarySearchCompletionsEnable READ
+                    librarySearchCompletionsEnable WRITE
+                            set_librarySearchCompletionsEnable NOTIFY
+                                    librarySearchCompletionsEnableChanged);
+    Q_PROPERTY(bool librarySearchHistoryShortcutsEnable READ
+                    librarySearchHistoryShortcutsEnable WRITE
+                            set_librarySearchHistoryShortcutsEnable NOTIFY
+                                    librarySearchHistoryShortcutsEnableChanged);
+    // Integration
+    Q_PROPERTY(bool libraryRhythmboxEnabled READ libraryRhythmboxEnabled WRITE
+                    set_libraryRhythmboxEnabled NOTIFY
+                            libraryRhythmboxEnabledChanged);
+    Q_PROPERTY(bool libraryBansheeEnabled READ libraryBansheeEnabled WRITE
+                    set_libraryBansheeEnabled NOTIFY
+                            libraryBansheeEnabledChanged);
+    Q_PROPERTY(bool libraryITunesEnabled READ libraryITunesEnabled WRITE
+                    set_libraryITunesEnabled NOTIFY
+                            libraryITunesEnabledChanged);
+    Q_PROPERTY(bool libraryTraktorEnabled READ libraryTraktorEnabled WRITE
+                    set_libraryTraktorEnabled NOTIFY
+                            libraryTraktorEnabledChanged);
+    Q_PROPERTY(bool libraryRekordboxEnabled READ libraryRekordboxEnabled WRITE
+                    set_libraryRekordboxEnabled NOTIFY
+                            libraryRekordboxEnabledChanged);
+    Q_PROPERTY(bool librarySeratoEnabled READ librarySeratoEnabled WRITE
+                    set_librarySeratoEnabled NOTIFY
+                            librarySeratoEnabledChanged);
+
     // Colors
     Q_PROPERTY(QVariantList hotcueColorPalette READ hotcueColorPalette NOTIFY
                     hotcueColorPaletteChanged);
@@ -341,6 +402,28 @@ class QmlConfigProxy : public QmlConfigProxyBase {
     // BPM group
     PROPERTY_DECL_ACCESSOR(EngineSync::SyncLockAlgorithm, bpmSyncLockAlgorithm);
 
+    // Library group
+    PROPERTY_DECL_ACCESSOR(bool, librarySyncTrackMetadataExport);
+    PROPERTY_DECL_ACCESSOR(bool, librarySeratoMetadataExport);
+    PROPERTY_DECL_ACCESSOR(bool, libraryUseRelativePathOnExport);
+    // Count, 0..
+    PROPERTY_DECL_ACCESSOR(int, libraryHistoryMinTracksToKeep);
+    // Count, 0..
+    PROPERTY_DECL_ACCESSOR(int, libraryHistoryTrackDuplicateDistance);
+    // Percent, 0..1.0
+    PROPERTY_DECL_ACCESSOR(double, librarySearchBpmFuzzyRange);
+    // Duration (ms), 100..9999
+    PROPERTY_DECL_ACCESSOR(int, librarySearchDebouncingTimeout);
+    PROPERTY_DECL_ACCESSOR(bool, librarySearchCompletionsEnable);
+    PROPERTY_DECL_ACCESSOR(bool, librarySearchHistoryShortcutsEnable);
+    // Integration
+    PROPERTY_DECL_ACCESSOR(bool, libraryRhythmboxEnabled);
+    PROPERTY_DECL_ACCESSOR(bool, libraryBansheeEnabled);
+    PROPERTY_DECL_ACCESSOR(bool, libraryITunesEnabled);
+    PROPERTY_DECL_ACCESSOR(bool, libraryTraktorEnabled);
+    PROPERTY_DECL_ACCESSOR(bool, libraryRekordboxEnabled);
+    PROPERTY_DECL_ACCESSOR(bool, librarySeratoEnabled);
+
     static QmlConfigProxy* create(QQmlEngine* pQmlEngine, QJSEngine* pJsEngine);
     static inline void registerUserSettings(UserSettingsPointer pConfig) {
         s_pUserSettings = std::move(pConfig);
@@ -403,6 +486,21 @@ class QmlConfigProxy : public QmlConfigProxyBase {
     void configStartInFullscreenKeyChanged();
     void configSkinChanged();
     void bpmSyncLockAlgorithmChanged();
+    void librarySyncTrackMetadataExportChanged();
+    void librarySeratoMetadataExportChanged();
+    void libraryUseRelativePathOnExportChanged();
+    void libraryHistoryMinTracksToKeepChanged();
+    void libraryHistoryTrackDuplicateDistanceChanged();
+    void librarySearchBpmFuzzyRangeChanged();
+    void librarySearchDebouncingTimeoutChanged();
+    void librarySearchCompletionsEnableChanged();
+    void librarySearchHistoryShortcutsEnableChanged();
+    void libraryRhythmboxEnabledChanged();
+    void libraryBansheeEnabledChanged();
+    void libraryITunesEnabledChanged();
+    void libraryTraktorEnabledChanged();
+    void libraryRekordboxEnabledChanged();
+    void librarySeratoEnabledChanged();
 
   private:
     template<typename Type, typename Signal>

--- a/src/qml/qmllibraryproxy.cpp
+++ b/src/qml/qmllibraryproxy.cpp
@@ -7,6 +7,8 @@
 #include "control/controlobject.h"
 #include "library/library.h"
 #include "library/librarytablemodel.h"
+#include "library/trackcollection.h"
+#include "library/trackcollectionmanager.h"
 #include "moc_qmllibraryproxy.cpp"
 #include "preferences/colorpalettesettings.h"
 #include "qml/qmlconfigproxy.h"
@@ -99,8 +101,55 @@ mixxx::audio::FramePos getCurrentPlayPositionWithQuantize(
 }
 } // namespace
 
-QmlLibraryProxy::QmlLibraryProxy(QObject* parent)
-        : QObject(parent) {
+QmlLibraryProxy::QmlLibraryProxy(
+        std::shared_ptr<Library> pLibrary, QObject* parent)
+        : QObject(parent),
+          m_pLibrary(pLibrary),
+          m_pModelProperty(new QmlLibraryTrackListModel(
+                  QList<QmlLibraryTrackListColumn*>{}, m_pLibrary->trackTableModel(), this)),
+          m_pScanner(new QmlLibraryScannerProxy(
+                  m_pLibrary->trackCollectionManager()->scanner(), this)) {
+}
+
+QmlLibraryScannerProxy::QmlLibraryScannerProxy(LibraryScanner* libraryScanner, QObject* parent)
+        : QObject(parent),
+          m_pLibraryScanner(libraryScanner),
+          m_running(false),
+          m_cancelling(false) {
+    connect(libraryScanner,
+            &LibraryScanner::progressLoading,
+            this,
+            &QmlLibraryScannerProxy::progress);
+    connect(libraryScanner,
+            &LibraryScanner::scanStarted,
+            this,
+            &QmlLibraryScannerProxy::started);
+    connect(libraryScanner,
+            &LibraryScanner::scanFinished,
+            this,
+            &QmlLibraryScannerProxy::finished);
+    connect(this,
+            &QmlLibraryScannerProxy::requestCancel,
+            libraryScanner,
+            &LibraryScanner::slotCancel);
+
+    // Properties
+    connect(libraryScanner,
+            &LibraryScanner::scanStarted,
+            this,
+            [this]() {
+                m_cancelling = false;
+                m_running = true;
+                emit stateChanged();
+            });
+    connect(libraryScanner,
+            &LibraryScanner::scanFinished,
+            this,
+            [this]() {
+                m_cancelling = false;
+                m_running = false;
+                emit stateChanged();
+            });
 }
 
 QmlLibraryProxy::~QmlLibraryProxy() = default;
@@ -110,7 +159,6 @@ QmlLibraryTrackListModel* QmlLibraryProxy::model() const {
             QList<QmlLibraryTrackListColumn*>{}, s_pLibrary->trackTableModel())
             .get();
 }
-
 void QmlLibraryProxy::analyze(const QmlTrackProxy* track) const {
     VERIFY_OR_DEBUG_ASSERT(track && track->internal()) {
         return;
@@ -266,7 +314,97 @@ QmlLibraryProxy* QmlLibraryProxy::create(QQmlEngine* pQmlEngine, QJSEngine* pJsE
         qWarning() << "Library hasn't been registered yet";
         return nullptr;
     }
-    return new QmlLibraryProxy(pQmlEngine);
+    return new QmlLibraryProxy(s_pLibrary, pQmlEngine);
+}
+
+QmlLibraryProxy::AddResult QmlLibraryProxy::addSource(
+        const QUrl& newPath) {
+    VERIFY_OR_DEBUG_ASSERT(s_pLibrary) {
+        qWarning() << "Library hasn't been registered yet!";
+        return QmlLibraryProxy::AddResult::InvalidOrMissingDirectory;
+    }
+    QDir directory(newPath.toLocalFile());
+    Sandbox::createSecurityTokenForDir(directory);
+    return static_cast<QmlLibraryProxy::AddResult>(
+            s_pLibrary->trackCollectionManager()->addDirectory(
+                    mixxx::FileInfo(newPath.toLocalFile())));
+}
+
+QmlLibraryProxy::RemoveResult QmlLibraryProxy::removeSource(
+        const QUrl& oldPath, SourceRemovalType removalType) {
+    VERIFY_OR_DEBUG_ASSERT(s_pLibrary) {
+        qWarning() << "Library hasn't been registered yet!";
+        return QmlLibraryProxy::RemoveResult::NotFound;
+    }
+
+    DirectoryDAO::RemoveResult result =
+            s_pLibrary->trackCollectionManager()->removeDirectory(
+                    mixxx::FileInfo(oldPath.toLocalFile()));
+    if (result != DirectoryDAO::RemoveResult::Ok) {
+        return static_cast<QmlLibraryProxy::RemoveResult>(result);
+    }
+
+    switch (removalType) {
+    case SourceRemovalType::KeepTracks:
+        break;
+    case SourceRemovalType::HideTracks:
+        // Mark all tracks in this directory as deleted but DON'T purge them
+        // in case the user re-adds them manually.
+        s_pLibrary->trackCollectionManager()->hideAllTracks(oldPath.toLocalFile());
+        break;
+    case SourceRemovalType::PurgeTracks:
+        // The user requested that we purge all metadata.
+        s_pLibrary->trackCollectionManager()->purgeAllTracks(oldPath.toLocalFile());
+        break;
+    default:
+        DEBUG_ASSERT(!"unreachable");
+    }
+    return static_cast<QmlLibraryProxy::RemoveResult>(result);
+}
+
+QmlLibraryProxy::RelocateResult QmlLibraryProxy::relinkSource(
+        const QUrl& oldPath, const QUrl& newPath) {
+    VERIFY_OR_DEBUG_ASSERT(s_pLibrary) {
+        qWarning() << "Library hasn't been registered yet!";
+        return QmlLibraryProxy::RelocateResult::SqlError;
+    }
+    return static_cast<QmlLibraryProxy::RelocateResult>(
+            s_pLibrary->trackCollectionManager()->relocateDirectory(
+                    oldPath.toLocalFile(), newPath.toLocalFile()));
+}
+
+// Static
+qsizetype QmlLibraryProxy::sources_count(QQmlListProperty<QmlLibrarySource>* pList) {
+    QmlLibraryProxy* pLibrary = static_cast<QmlLibraryProxy*>(pList->object);
+    VERIFY_OR_DEBUG_ASSERT(pLibrary) {
+        return 0;
+    }
+    return pLibrary->m_pLibrary->trackCollectionManager()
+            ->internalCollection()
+            ->getRootDirectories()
+            .size();
+}
+
+// Static
+QmlLibrarySource* QmlLibraryProxy::sources_at(
+        QQmlListProperty<QmlLibrarySource>* pList, qsizetype index) {
+    VERIFY_OR_DEBUG_ASSERT(pList && pList->object) {
+        return nullptr;
+    }
+    QmlLibraryProxy* pLibrary = static_cast<QmlLibraryProxy*>(pList->object);
+    VERIFY_OR_DEBUG_ASSERT(pLibrary) {
+        return nullptr;
+    }
+    return make_qml_owned<QmlLibrarySource>(
+            pLibrary->m_pLibrary->trackCollectionManager()
+                    ->internalCollection()
+                    ->getRootDirectories()
+                    .at(index));
+}
+
+// Static
+void QmlLibraryProxy::sources_clear(QQmlListProperty<QmlLibrarySource>*) {
+    DEBUG_ASSERT(!"unsupported operation");
 }
 
 } // namespace qml

--- a/src/qml/qmllibraryproxy.h
+++ b/src/qml/qmllibraryproxy.h
@@ -1,29 +1,127 @@
 #pragma once
+#include <qqmlintegration.h>
+
 #include <QObject>
 #include <QQmlEngine>
 #include <QString>
 #include <Qt>
 #include <memory>
 
-#include "qml_owned_ptr.h"
-#include "qmllibrarytracklistmodel.h"
+#include "library/dao/directorydao.h"
+#include "library/scanner/libraryscanner.h"
+#include "qml/qmllibrarysource.h"
+#include "qml/qmllibrarytracklistmodel.h"
+#include "util/parented_ptr.h"
 
 class Library;
+class LibraryScanner;
 class KeyboardEventFilter;
 
 namespace mixxx {
 namespace qml {
 
-class QmlTrackProxy;
+class QmlLibrarySource : public QObject {
+    Q_OBJECT
+    Q_PROPERTY(QString path MEMBER m_path CONSTANT)
+    Q_PROPERTY(uint totalSecond MEMBER m_totalSecond CONSTANT)
+    Q_PROPERTY(uint trackCount MEMBER m_trackCount CONSTANT)
+    QML_NAMED_ELEMENT(LibrarySource)
+  public:
+    QmlLibrarySource(const DirectoryDAO::RootDirectoryInfo& record)
+            : m_path(record.path),
+              m_totalSecond(record.totalSecond),
+              m_trackCount(record.trackCount) {
+    }
+
+  private:
+    QString m_path;
+    uint m_totalSecond;
+    uint m_trackCount;
+};
+
+class QmlLibraryScannerProxy : public QObject {
+    Q_OBJECT
+    Q_PROPERTY(bool running READ isRunning NOTIFY stateChanged)
+    Q_PROPERTY(bool cancelling READ isCancelling NOTIFY stateChanged)
+    QML_NAMED_ELEMENT(LibraryScanner)
+    QML_UNCREATABLE("Only accessible via Mixxx.Library.scanner")
+  public:
+    QmlLibraryScannerProxy(LibraryScanner* libraryScanner, QObject* parent);
+
+    bool isRunning() const {
+        return m_running;
+    }
+
+    bool isCancelling() const {
+        return m_cancelling;
+    }
+
+    Q_INVOKABLE void start() {
+        m_running = true;
+        m_pLibraryScanner->scan();
+        emit stateChanged();
+    }
+
+    Q_INVOKABLE void cancel() {
+        m_cancelling = true;
+        emit stateChanged();
+        emit requestCancel();
+    }
+
+  signals:
+    void progress(const QString& path);
+    void started();
+    void finished();
+
+    void stateChanged();
+
+    void requestStart();
+    void requestCancel();
+
+  private:
+    LibraryScanner* m_pLibraryScanner;
+    bool m_running;
+    bool m_cancelling;
+};
 
 class QmlLibraryProxy : public QObject {
     Q_OBJECT
-    Q_PROPERTY(mixxx::qml::QmlLibraryTrackListModel* model READ model CONSTANT)
+    Q_PROPERTY(mixxx::qml::QmlLibraryTrackListModel* model MEMBER m_pModelProperty CONSTANT)
+    Q_PROPERTY(QQmlListProperty<QmlLibrarySource> sources READ sources CONSTANT)
+    Q_PROPERTY(mixxx::qml::QmlLibraryScannerProxy* scanner MEMBER m_pScanner CONSTANT)
     QML_NAMED_ELEMENT(Library)
     QML_SINGLETON
 
   public:
-    explicit QmlLibraryProxy(QObject* parent = nullptr);
+    enum class AddResult {
+        Ok,
+        AlreadyWatching,
+        InvalidOrMissingDirectory,
+        UnreadableDirectory,
+        SqlError,
+    };
+    Q_ENUM(AddResult);
+    enum class RemoveResult {
+        Ok,
+        NotFound,
+        SqlError,
+    };
+    Q_ENUM(RemoveResult);
+    enum class RelocateResult {
+        Ok,
+        InvalidOrMissingDirectory,
+        UnreadableDirectory,
+        SqlError,
+    };
+    Q_ENUM(RelocateResult);
+    enum class SourceRemovalType {
+        KeepTracks,
+        HideTracks,
+        PurgeTracks
+    };
+    Q_ENUM(SourceRemovalType);
+
+    explicit QmlLibraryProxy(std::shared_ptr<Library> pLibrary, QObject* parent = nullptr);
     ~QmlLibraryProxy() override;
 
     static QmlLibraryProxy* create(QQmlEngine* pQmlEngine, QJSEngine* pJsEngine);
@@ -34,6 +132,19 @@ class QmlLibraryProxy : public QObject {
     static Library* get() {
         return s_pLibrary.get();
     }
+
+    QQmlListProperty<QmlLibrarySource> sources() {
+        return {this,
+                nullptr,
+                nullptr,
+                &QmlLibraryProxy::sources_count,
+                &QmlLibraryProxy::sources_at,
+                &QmlLibraryProxy::sources_clear};
+    }
+
+    Q_INVOKABLE AddResult addSource(const QUrl& newPath);
+    Q_INVOKABLE RemoveResult removeSource(const QUrl& oldPath, SourceRemovalType type);
+    Q_INVOKABLE RelocateResult relinkSource(const QUrl& oldPath, const QUrl& newPath);
 
     static void registerKeyboardEventFilter(std::shared_ptr<KeyboardEventFilter> pKeyboard) {
         s_pKeyboard = std::move(pKeyboard);
@@ -63,6 +174,17 @@ class QmlLibraryProxy : public QObject {
 
   private:
     static inline std::shared_ptr<Library> s_pLibrary;
+
+    std::shared_ptr<Library> m_pLibrary;
+
+    /// This needs to be a plain pointer because it's used as a `Q_PROPERTY` member variable.
+    QmlLibraryTrackListModel* m_pModelProperty;
+    QmlLibraryScannerProxy* m_pScanner;
+
+    static qsizetype sources_count(QQmlListProperty<QmlLibrarySource>* property);
+    static QmlLibrarySource* sources_at(
+            QQmlListProperty<QmlLibrarySource>* property, qsizetype index);
+    static void sources_clear(QQmlListProperty<QmlLibrarySource>* property);
     static inline std::shared_ptr<KeyboardEventFilter> s_pKeyboard;
 };
 

--- a/src/qml/qmllibrarysource.cpp
+++ b/src/qml/qmllibrarysource.cpp
@@ -36,25 +36,25 @@ void AllTrackLibraryFeature::activate() {
 namespace mixxx {
 namespace qml {
 
-QmlLibrarySource::QmlLibrarySource(
+QmlLibraryAbstractSource::QmlLibraryAbstractSource(
         QObject* parent, const QList<QmlLibraryTrackListColumn*>& columns)
         : QObject(parent),
           m_columns(columns) {
 }
 
-void QmlLibrarySource::slotShowTrackModel(QAbstractItemModel* pModel) {
+void QmlLibraryAbstractSource::slotShowTrackModel(QAbstractItemModel* pModel) {
     emit requestTrackModel(std::make_shared<QmlLibraryTrackListModel>(columns(), pModel));
 }
 
 QmlLibraryAllTrackSource::QmlLibraryAllTrackSource(
         QObject* parent, const QList<QmlLibraryTrackListColumn*>& columns)
-        : QmlLibrarySource(parent, columns),
+        : QmlLibraryAbstractSource(parent, columns),
           m_pLibraryFeature(std::make_unique<AllTrackLibraryFeature>(
                   QmlLibraryProxy::get(), QmlConfigProxy::get())) {
     connect(m_pLibraryFeature.get(),
             &LibraryFeature::showTrackModel,
             this,
-            &QmlLibrarySource::slotShowTrackModel);
+            &QmlLibraryAbstractSource::slotShowTrackModel);
 }
 
 } // namespace qml

--- a/src/qml/qmllibrarysource.h
+++ b/src/qml/qmllibrarysource.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <qobject.h>
-
 #include <QAbstractItemModel>
 #include <QObject>
 #include <QQmlEngine>
@@ -61,16 +59,16 @@ namespace qml {
 
 class QmlLibraryTrackListColumn;
 
-class QmlLibrarySource : public QObject {
+class QmlLibraryAbstractSource : public QObject {
     Q_OBJECT
     Q_PROPERTY(QString label MEMBER m_label)
     Q_PROPERTY(QString icon MEMBER m_icon)
     Q_PROPERTY(QQmlListProperty<mixxx::qml::QmlLibraryTrackListColumn> columns READ columnsQml)
     Q_CLASSINFO("DefaultProperty", "columns")
-    QML_NAMED_ELEMENT(LibrarySource)
+    QML_NAMED_ELEMENT(LibraryAbstractSource)
     QML_UNCREATABLE("Only accessible via its specialization")
   public:
-    explicit QmlLibrarySource(QObject* parent = nullptr,
+    explicit QmlLibraryAbstractSource(QObject* parent = nullptr,
             const QList<QmlLibraryTrackListColumn*>& columns = {});
 
     QQmlListProperty<mixxx::qml::QmlLibraryTrackListColumn> columnsQml() {
@@ -93,7 +91,7 @@ class QmlLibrarySource : public QObject {
     QList<QmlLibraryTrackListColumn*> m_columns;
 };
 
-class QmlLibraryAllTrackSource : public QmlLibrarySource {
+class QmlLibraryAllTrackSource : public QmlLibraryAbstractSource {
     Q_OBJECT
     QML_NAMED_ELEMENT(LibraryAllTrackSource)
   public:

--- a/src/qml/qmllibrarysourcetree.cpp
+++ b/src/qml/qmllibrarysourcetree.cpp
@@ -29,40 +29,40 @@ Q_INVOKABLE QmlLibraryTrackListModel* QmlLibrarySourceTree::allTracks() const {
 };
 
 void QmlLibrarySourceTree::append_source(
-        QQmlListProperty<QmlLibrarySource>* list, QmlLibrarySource* source) {
-    reinterpret_cast<QList<QmlLibrarySource*>*>(list->data)->append(source);
+        QQmlListProperty<QmlLibraryAbstractSource>* list, QmlLibraryAbstractSource* source) {
+    reinterpret_cast<QList<QmlLibraryAbstractSource*>*>(list->data)->append(source);
     QmlLibrarySourceTree* librarySourceTree = qobject_cast<QmlLibrarySourceTree*>(list->object);
     if (librarySourceTree && librarySourceTree->isComponentComplete()) {
         librarySourceTree->m_model->update(librarySourceTree->m_sources);
     }
 }
 
-void QmlLibrarySourceTree::clear_source(QQmlListProperty<QmlLibrarySource>* p) {
-    reinterpret_cast<QList<QmlLibrarySource*>*>(p->data)->clear();
+void QmlLibrarySourceTree::clear_source(QQmlListProperty<QmlLibraryAbstractSource>* p) {
+    reinterpret_cast<QList<QmlLibraryAbstractSource*>*>(p->data)->clear();
     QmlLibrarySourceTree* librarySourceTree = qobject_cast<QmlLibrarySourceTree*>(p->object);
     if (librarySourceTree) {
         librarySourceTree->m_model->update(librarySourceTree->m_sources);
     }
 }
-void QmlLibrarySourceTree::replace_source(QQmlListProperty<QmlLibrarySource>* p,
+void QmlLibrarySourceTree::replace_source(QQmlListProperty<QmlLibraryAbstractSource>* p,
         qsizetype idx,
-        QmlLibrarySource* v) {
-    return reinterpret_cast<QList<QmlLibrarySource*>*>(p->data)->replace(idx, v);
+        QmlLibraryAbstractSource* v) {
+    return reinterpret_cast<QList<QmlLibraryAbstractSource*>*>(p->data)->replace(idx, v);
     QmlLibrarySourceTree* librarySourceTree = qobject_cast<QmlLibrarySourceTree*>(p->object);
     if (librarySourceTree && librarySourceTree->isComponentComplete()) {
         librarySourceTree->m_model->update(librarySourceTree->m_sources);
     }
 }
-void QmlLibrarySourceTree::removeLast_source(QQmlListProperty<QmlLibrarySource>* p) {
-    return reinterpret_cast<QList<QmlLibrarySource*>*>(p->data)->removeLast();
+void QmlLibrarySourceTree::removeLast_source(QQmlListProperty<QmlLibraryAbstractSource>* p) {
+    return reinterpret_cast<QList<QmlLibraryAbstractSource*>*>(p->data)->removeLast();
     QmlLibrarySourceTree* librarySourceTree = qobject_cast<QmlLibrarySourceTree*>(p->object);
     if (librarySourceTree && librarySourceTree->isComponentComplete()) {
         librarySourceTree->m_model->update(librarySourceTree->m_sources);
     }
 }
 
-QQmlListProperty<QmlLibrarySource> QmlLibrarySourceTree::sources() {
-    return QQmlListProperty<QmlLibrarySource>(this,
+QQmlListProperty<QmlLibraryAbstractSource> QmlLibrarySourceTree::sources() {
+    return QQmlListProperty<QmlLibraryAbstractSource>(this,
             &m_sources,
             &QmlLibrarySourceTree::append_source,
             &QmlLibrarySourceTree::count_source,

--- a/src/qml/qmllibrarysourcetree.h
+++ b/src/qml/qmllibrarysourcetree.h
@@ -8,7 +8,6 @@
 #include <QQuickItem>
 #include <QVariant>
 
-#include "qmllibrarysource.h"
 #include "qmllibrarytracklistcolumn.h"
 #include "qmlsidebarmodelproxy.h"
 #include "util/parented_ptr.h"
@@ -19,7 +18,7 @@ namespace qml {
 class QmlLibrarySourceTree : public QQuickItem {
     Q_OBJECT
     Q_INTERFACES(QQmlParserStatus)
-    Q_PROPERTY(QQmlListProperty<mixxx::qml::QmlLibrarySource> sources READ sources)
+    Q_PROPERTY(QQmlListProperty<mixxx::qml::QmlLibraryAbstractSource> sources READ sources)
     Q_PROPERTY(QQmlListProperty<mixxx::qml::QmlLibraryTrackListColumn> defaultColumns READ
                     defaultColumns CONSTANT)
     Q_CLASSINFO("DefaultProperty", "sources")
@@ -36,27 +35,29 @@ class QmlLibrarySourceTree : public QQuickItem {
         return {this, &m_defaultColumns};
     }
 
-    QQmlListProperty<mixxx::qml::QmlLibrarySource> sources();
+    QQmlListProperty<mixxx::qml::QmlLibraryAbstractSource> sources();
     Q_INVOKABLE mixxx::qml::QmlSidebarModelProxy* sidebar() const {
         return m_model.get();
     };
     Q_INVOKABLE mixxx::qml::QmlLibraryTrackListModel* allTracks() const;
 
   private:
-    static void append_source(QQmlListProperty<QmlLibrarySource>* list, QmlLibrarySource* slice);
-    static qsizetype count_source(QQmlListProperty<QmlLibrarySource>* p) {
-        return reinterpret_cast<QList<QmlLibrarySource*>*>(p->data)->size();
+    static void append_source(QQmlListProperty<QmlLibraryAbstractSource>* list,
+            QmlLibraryAbstractSource* slice);
+    static qsizetype count_source(QQmlListProperty<QmlLibraryAbstractSource>* p) {
+        return reinterpret_cast<QList<QmlLibraryAbstractSource*>*>(p->data)->size();
     }
-    static QmlLibrarySource* at_source(QQmlListProperty<QmlLibrarySource>* p, qsizetype idx) {
-        return reinterpret_cast<QList<QmlLibrarySource*>*>(p->data)->at(idx);
+    static QmlLibraryAbstractSource* at_source(
+            QQmlListProperty<QmlLibraryAbstractSource>* p, qsizetype idx) {
+        return reinterpret_cast<QList<QmlLibraryAbstractSource*>*>(p->data)->at(idx);
     }
-    static void clear_source(QQmlListProperty<QmlLibrarySource>* p);
-    static void replace_source(QQmlListProperty<QmlLibrarySource>* p,
+    static void clear_source(QQmlListProperty<QmlLibraryAbstractSource>* p);
+    static void replace_source(QQmlListProperty<QmlLibraryAbstractSource>* p,
             qsizetype idx,
-            QmlLibrarySource* v);
-    static void removeLast_source(QQmlListProperty<QmlLibrarySource>* p);
+            QmlLibraryAbstractSource* v);
+    static void removeLast_source(QQmlListProperty<QmlLibraryAbstractSource>* p);
 
-    QList<QmlLibrarySource*> m_sources;
+    QList<QmlLibraryAbstractSource*> m_sources;
     parented_ptr<QmlSidebarModelProxy> m_model;
     QList<QmlLibraryTrackListColumn*> m_defaultColumns;
 };

--- a/src/qml/qmlsidebarmodelproxy.cpp
+++ b/src/qml/qmlsidebarmodelproxy.cpp
@@ -62,7 +62,7 @@ QmlSidebarModelProxy::QmlSidebarModelProxy(QObject* parent)
 }
 QmlSidebarModelProxy::~QmlSidebarModelProxy() = default;
 
-void QmlSidebarModelProxy::update(const QList<QmlLibrarySource*>& sources) {
+void QmlSidebarModelProxy::update(const QList<QmlLibraryAbstractSource*>& sources) {
     beginResetModel();
     qDeleteAll(m_sFeatures);
     for (const auto& librarySource : sources) {
@@ -70,7 +70,7 @@ void QmlSidebarModelProxy::update(const QList<QmlLibrarySource*>& sources) {
             continue;
         }
         connect(librarySource,
-                &QmlLibrarySource::requestTrackModel,
+                &QmlLibraryAbstractSource::requestTrackModel,
                 this,
                 &QmlSidebarModelProxy::slotShowTrackModel);
         auto* pLibrarySource = librarySource->internal();

--- a/src/qml/qmlsidebarmodelproxy.h
+++ b/src/qml/qmlsidebarmodelproxy.h
@@ -17,7 +17,7 @@
 namespace mixxx {
 namespace qml {
 
-class QmlLibrarySource;
+class QmlLibraryAbstractSource;
 
 class QmlSidebarModelProxy : public SidebarModel {
     Q_OBJECT
@@ -37,7 +37,7 @@ class QmlSidebarModelProxy : public SidebarModel {
         return m_tracklist.get();
     }
 
-    void update(const QList<QmlLibrarySource*>& sources);
+    void update(const QList<QmlLibraryAbstractSource*>& sources);
     QHash<int, QByteArray> roleNames() const override;
     Q_INVOKABLE QVariant get(int row) const;
     Q_INVOKABLE void activate(const QModelIndex& index);

--- a/tools/debian_buildenv.sh
+++ b/tools/debian_buildenv.sh
@@ -141,6 +141,7 @@ case "$1" in
             qt6-base-private-dev \
             qt6-multimedia-dev \
             qml6-module-qt5compat-graphicaleffects \
+            qml6-module-qtcore \
             qml6-module-qtqml-workerscript \
             qml6-module-qtquick-controls \
             qml6-module-qtquick-dialogs \


### PR DESCRIPTION
This PR adds a library settings page for the QML UI and exposes library management functionality to QML.

**Core DAO changes** (`directorydao.cpp/h`):
- `getRootDirStrings()` → `getRootDirectories()` — now returns a `QList<RootDirectoryInfo>` struct containing `path`, `trackCount`, and `totalSecond` (total duration). The SQL query uses a `LEFT JOIN` on `track_locations` and `library` to materialize these statistics at the DAO level instead of computing them ad-hoc in the QML layer.

**LibraryScanner** (`libraryscanner.cpp`):
- Progress dialog connections are now guarded behind `#ifdef MIXXX_USE_QML` / `!isQml()`, so the dialog is skipped when running in QML mode.
- Fixed a missing `emit scanFinished()` on the early-return path when scan result is empty.

**QmlConfigProxy** (`qmlconfigproxy.cpp/h`):
- Exposes ~20 new library settings as QML properties, covering: sync metadata export (track/serato), relative path on export, history (min tracks, duplicate distance), search (BPM fuzzy range, debouncing timeout, completions, history shortcuts), BPM column precision, row height, and integration toggles for Rhythmbox/Banshee/iTunes/Traktor/Rekordbox/Serato.
- Introduced `PROPERTY_IMPL_CONFIGKEY` macro for properties backed by `ConfigKey` structs rather than raw group/key strings.

**QML Library Proxy rewrite** (`qmllibraryproxy.cpp/h`):
- `QmlLibraryProxy` now holds a `shared_ptr<Library>` and owns a `QmlLibraryTrackListModel` plus a `QmlLibraryScannerProxy` as member properties (instead of constructing models on-the-fly).
- Published `sources` as a `QQmlListProperty<QmlLibrarySource>` and `scanner` as a `QmlLibraryScannerProxy*` to QML, plus `addSource`/`removeSource`/`relinkSource` invokable methods.
- `QmlLibraryScannerProxy` wraps `LibraryScanner`, exposing `running`/`cancelling` state, `start()`/`cancel()` invokables, and `progress`/`started`/`finished` signals.

**Renaming** (`qml/qmllibrarysource.h`, `sourcetree.*`, `sidebarmodelproxy.*`):
- The old `QmlLibrarySource` class is renamed to `QmlLibraryAbstractSource` to free the name for the new `QmlLibrarySource` (the concrete data object mapping `RootDirectoryInfo` with `path`/`trackCount`/`totalSecond` properties).
- All consumers updated accordingly.

**TrackCollectionManager** (`trackcollectionmanager.h`):
- Added `scanner()` accessor to get the `LibraryScanner*`, needed by `QmlLibraryScannerProxy`.

The overall goal is to enable the new QML-based settings UI to read/write library preferences and to let the QML library browser manage root directories (add/remove/relocate sources) and control the scanner, replacing the old widget-based dialog.

---

Aims to address [#14540](https://github.com/mixxxdj/mixxx/issues/14540)

https://github.com/user-attachments/assets/09ec3706-1e16-4067-a5b4-8ec4f84594c0


Depends on #15380 