### PR TITLE
(fix) Menu checkbox consistency & cleanup

### DIFF
--- a/src/widget/wmenucheckbox.cpp
+++ b/src/widget/wmenucheckbox.cpp
@@ -15,12 +15,24 @@ WMenuCheckBox::WMenuCheckBox(const QString& label, QWidget* pParent)
 
 bool WMenuCheckBox::eventFilter(QObject* pObj, QEvent* pEvent) {
     if (isEnabled() && pEvent->type() == QEvent::HoverEnter) {
+        // Highlights the entire parent QWidgetAction
         setFocus(Qt::MouseFocusReason);
     } else if (pEvent->type() == QEvent::HoverLeave) {
-        // Also explicitly clear focus. This is required when we have other
-        // Q[Widget]Actions in the same menu which have a 'selected' but no
-        // 'focus' property.
+        // Also explicitly clear focus to remove the highlight. This is required
+        // when we have other Q[Widget]Actions in the same menu which have a
+        // 'selected' but no 'focus' property.
         clearFocus();
+    } else if (isEnabled() && pEvent->type() == QEvent::MouseButtonRelease) {
+        // Note: QCheckBox/QAbstractButton and QMenu act on release, not on click.
+        // With the original QCheckBox/QAbstractButton in QWidgetAction implementation,
+        // the click (release) on the area that is not the text and not the box
+        // (indicator), the click would be forwarded to the parent (go figure..).
+        // The QWidgetAction would then emit the `triggered()` signal which causes
+        // the parent menu to close.
+        // For consistency with clicks on the text or box, we need to prevent that.
+        // Just toggle the box and swallow the event.
+        toggle();
+        return true;
     } else if (pEvent->type() == QEvent::MouseButtonDblClick) {
         return true;
     }

--- a/src/widget/wsearchrelatedtracksmenu.cpp
+++ b/src/widget/wsearchrelatedtracksmenu.cpp
@@ -382,7 +382,8 @@ void WSearchRelatedTracksMenu::addActionsForTrack(
 }
 
 bool WSearchRelatedTracksMenu::eventFilter(QObject* pObj, QEvent* e) {
-    if (e->type() == QEvent::MouseButtonPress) {
+    if (e->type() == QEvent::MouseButtonRelease) {
+        // Note: QCheckBox/QAbstractButton and QMenu act on release, not on click.
         // Since we want tp provide a toggle function that allows to check multiple
         // criteria (ie. don't auto-close the menu on first click) we need to
         // figure the intended click target.

--- a/src/widget/wtracktableviewheader.cpp
+++ b/src/widget/wtracktableviewheader.cpp
@@ -193,9 +193,8 @@ void WTrackTableViewHeader::setModel(QAbstractItemModel* pModel) {
         connect(pAction,
                 &QAction::triggered,
                 this,
-                [this, pCheckBox{pCheckBox.get()}, i] {
+                [pCheckBox{pCheckBox.get()}] {
                     pCheckBox->toggle();
-                    showOrHideColumn(i);
                 });
         m_menu.addAction(pAction);
 

--- a/src/widget/wtracktableviewheader.cpp
+++ b/src/widget/wtracktableviewheader.cpp
@@ -22,8 +22,9 @@ HeaderViewState::HeaderViewState(const QHeaderView& headers) {
         header_state->set_size(headers.sectionSize(li));
         header_state->set_logical_index(li);
         header_state->set_visual_index(vi);
-        QString column_name = model->headerData(
-                li, Qt::Horizontal, TrackModel::kHeaderNameRole).toString();
+        const QString column_name = model->headerData(
+                                                 li, Qt::Horizontal, TrackModel::kHeaderNameRole)
+                                            .toString();
         // If there was some sort of error getting the column id,
         // we have to skip this one. (Happens with non-displayed columns)
         if (column_name.isEmpty()) {
@@ -61,9 +62,9 @@ QString HeaderViewState::saveState() const {
     return QString(array.toBase64());
 }
 
-void HeaderViewState::restoreState(QHeaderView* headers) {
+void HeaderViewState::restoreState(QHeaderView* pHeaders) {
     const int max_columns =
-            math_min(headers->count(), m_view_state.header_state_size());
+            math_min(pHeaders->count(), m_view_state.header_state_size());
 
     typedef QMap<QString, mixxx::library::HeaderViewState::HeaderState*> state_map;
     state_map map;
@@ -73,11 +74,11 @@ void HeaderViewState::restoreState(QHeaderView* headers) {
     }
 
     // First set all sections to be hidden and update logical indexes.
-    for (int li = 0; li < headers->count(); ++li) {
-        headers->setSectionHidden(li, true);
-        auto it = map.find(headers->model()->headerData(
-                                                   li, Qt::Horizontal, TrackModel::kHeaderNameRole)
-                                   .toString());
+    for (int li = 0; li < pHeaders->count(); ++li) {
+        pHeaders->setSectionHidden(li, true);
+        auto it = map.find(pHeaders->model()->headerData(
+                                                    li, Qt::Horizontal, TrackModel::kHeaderNameRole)
+                        .toString());
         if (it != map.end()) {
             it.value()->set_logical_index(li);
         }
@@ -88,40 +89,40 @@ void HeaderViewState::restoreState(QHeaderView* headers) {
         const mixxx::library::HeaderViewState::HeaderState& header =
                 m_view_state.header_state(vi);
         const int li = header.logical_index();
-        headers->setSectionHidden(li, header.hidden());
-        headers->resizeSection(li, header.size());
-        headers->moveSection(headers->visualIndex(li), vi);
+        pHeaders->setSectionHidden(li, header.hidden());
+        pHeaders->resizeSection(li, header.size());
+        pHeaders->moveSection(pHeaders->visualIndex(li), vi);
     }
     if (m_view_state.sort_indicator_shown()) {
-        headers->setSortIndicator(
+        pHeaders->setSortIndicator(
                 m_view_state.sort_indicator_section(),
                 static_cast<Qt::SortOrder>(m_view_state.sort_order()));
     }
 }
 
 WTrackTableViewHeader::WTrackTableViewHeader(Qt::Orientation orientation,
-                                             QWidget* parent)
-        : QHeaderView(orientation, parent),
+        QWidget* pParent)
+        : QHeaderView(orientation, pParent),
           m_menu(tr("Show or hide columns."), this) {
 }
 
-void WTrackTableViewHeader::contextMenuEvent(QContextMenuEvent* event) {
-    event->accept();
-    m_menu.popup(event->globalPos());
+void WTrackTableViewHeader::contextMenuEvent(QContextMenuEvent* pEvent) {
+    pEvent->accept();
+    m_menu.popup(pEvent->globalPos());
 }
 
-void WTrackTableViewHeader::setModel(QAbstractItemModel* model) {
-    TrackModel* oldTrackModel = getTrackModel();
+void WTrackTableViewHeader::setModel(QAbstractItemModel* pModel) {
+    TrackModel* pOldTrackModel = getTrackModel();
 
-    if (dynamic_cast<QAbstractItemModel*>(oldTrackModel) == model) {
+    if (dynamic_cast<QAbstractItemModel*>(pOldTrackModel) == pModel) {
         // If the models are the same, do nothing but the redundant call.
-        QHeaderView::setModel(model);
+        QHeaderView::setModel(pModel);
         return;
     }
 
     // Won't happen in practice since the WTrackTableView new's a new
     // WTrackTableViewHeader each time a new TrackModel is loaded.
-    // if (oldTrackModel) {
+    // if (pOldTrackModel) {
     //     saveHeaderState();
     // }
 
@@ -129,12 +130,12 @@ void WTrackTableViewHeader::setModel(QAbstractItemModel* model) {
     clearActions();
 
     // Now set the header view to show the new model
-    QHeaderView::setModel(model);
+    QHeaderView::setModel(pModel);
 
     // Now build actions for the new TrackModel
-    TrackModel* trackModel = dynamic_cast<TrackModel*>(model);
+    TrackModel* pTrackModel = dynamic_cast<TrackModel*>(pModel);
 
-    if (!trackModel) {
+    if (!pTrackModel) {
         return;
     }
 
@@ -157,13 +158,13 @@ void WTrackTableViewHeader::setModel(QAbstractItemModel* model) {
     // * toggle a box with mouse click or Space on a selected box (via keyboard,
     //   not just hovered by mouse pointer)
     // * toggle and close by pressing Return on a selected box
-    int columns = model->columnCount();
+    int columns = pModel->columnCount();
     for (int i = 0; i < columns; ++i) {
-        if (trackModel->isColumnInternal(i)) {
+        if (pTrackModel->isColumnInternal(i)) {
             continue;
         }
 
-        QString title = model->headerData(i, orientation()).toString();
+        const QString title = pModel->headerData(i, orientation()).toString();
 
         // Custom QCheckBox with fixed hover behavior
         auto pCheckBox = make_parented<WMenuCheckBox>(title, &m_menu);
@@ -179,7 +180,7 @@ void WTrackTableViewHeader::setModel(QAbstractItemModel* model) {
         // due to database schema evolution we gonna hide all columns that may
         // contain a potential large number of NULL values.  Here we uncheck
         // the items that are hidden by default (e.g., key column).
-        if (!hasPersistedHeaderState() && trackModel->isColumnHiddenByDefault(i)) {
+        if (!hasPersistedHeaderState() && pTrackModel->isColumnHiddenByDefault(i)) {
             pCheckBox->setChecked(false);
         } else {
             pCheckBox->setChecked(!isSectionHidden(i));
@@ -216,24 +217,24 @@ void WTrackTableViewHeader::setModel(QAbstractItemModel* model) {
 }
 
 void WTrackTableViewHeader::saveHeaderState() {
-    TrackModel* track_model = getTrackModel();
-    if (!track_model) {
+    TrackModel* pTrackModel = getTrackModel();
+    if (!pTrackModel) {
         return;
     }
     // Convert the QByteArray to a Base64 string and save it.
     HeaderViewState view_state(*this);
-    track_model->setModelSetting("header_state_pb", view_state.saveState());
+    pTrackModel->setModelSetting("header_state_pb", view_state.saveState());
     //qDebug() << "Saving old header state:" << result << headerState;
 }
 
 void WTrackTableViewHeader::restoreHeaderState() {
-    TrackModel* track_model = getTrackModel();
+    TrackModel* pTrackModel = getTrackModel();
 
-    if (!track_model) {
+    if (!pTrackModel) {
         return;
     }
 
-    QString headerStateString = track_model->getModelSetting("header_state_pb");
+    const QString headerStateString = pTrackModel->getModelSetting("header_state_pb");
     if (headerStateString.isNull()) {
         loadDefaultHeaderState();
     } else {
@@ -251,10 +252,11 @@ void WTrackTableViewHeader::restoreHeaderState() {
 
 void WTrackTableViewHeader::loadDefaultHeaderState() {
     // TODO: isColumnHiddenByDefault logic probably belongs here now.
-    QAbstractItemModel* m = model();
+    QAbstractItemModel* pModel = model();
     for (int i = 0; i < count(); ++i) {
-        int header_size = m->headerData(
-                i, orientation(), TrackModel::kHeaderWidthRole).toInt();
+        int header_size = pModel->headerData(
+                                        i, orientation(), TrackModel::kHeaderWidthRole)
+                                  .toInt();
         if (header_size > 0) {
             resizeSection(i, header_size);
         }
@@ -262,11 +264,11 @@ void WTrackTableViewHeader::loadDefaultHeaderState() {
 }
 
 bool WTrackTableViewHeader::hasPersistedHeaderState() {
-    TrackModel* track_model = getTrackModel();
-    if (!track_model) {
+    TrackModel* pTrackModel = getTrackModel();
+    if (!pTrackModel) {
         return false;
     }
-    QString headerStateString = track_model->getModelSetting("header_state_pb");
+    const QString headerStateString = pTrackModel->getModelSetting("header_state_pb");
     return !headerStateString.isNull();
 }
 
@@ -312,6 +314,6 @@ int WTrackTableViewHeader::hiddenCount() {
 }
 
 TrackModel* WTrackTableViewHeader::getTrackModel() {
-    TrackModel* trackModel = dynamic_cast<TrackModel*>(model());
-    return trackModel;
+    TrackModel* pTrackModel = dynamic_cast<TrackModel*>(model());
+    return pTrackModel;
 }

--- a/src/widget/wtracktableviewheader.h
+++ b/src/widget/wtracktableviewheader.h
@@ -32,7 +32,7 @@ public:
     QString saveState() const;
     // Apply the state to the provided view.  The data in the object may be
     // changed if the header format has changed.
-    void restoreState(QHeaderView* headers);
+    void restoreState(QHeaderView* pHeaders);
 
     // returns false if no headers are listed to be shown.
     bool healthy() const {
@@ -55,7 +55,7 @@ private:
 class WTrackTableViewHeader : public QHeaderView {
     Q_OBJECT
   public:
-    explicit WTrackTableViewHeader(Qt::Orientation orientation, QWidget* parent = nullptr);
+    explicit WTrackTableViewHeader(Qt::Orientation orientation, QWidget* pParent = nullptr);
 
     void contextMenuEvent(QContextMenuEvent* event) override;
     void setModel(QAbstractItemModel* model) override;


### PR DESCRIPTION
Two fixes:
1. avoid double trigger in track header menu
2. Finally: clicking space next to checkbox text is not closing the menu
affects track column menu and Crates menu
<sub>works around an annoying QCheckBox quirk (in menu) where clicking this area would not toggle the box but pass the click to its parent (here: QWidgetAction) and thereby close the menu -- which is inconstinent with wider checkboxes, especially now that we have the full-width hover effect</sub>

Extracted from #15331 which is apparently not very inviting to review due to the big diff of the column width fix.