### PR TITLE
Remove #include <qqmlintegration.h>

### DIFF
--- a/src/qml/qmlsoundmanagerproxy.h
+++ b/src/qml/qmlsoundmanagerproxy.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <qglobal.h>
-#include <qqmlintegration.h>
 #include <qtmetamacros.h>
 
 #include <QDialog>


### PR DESCRIPTION
This seems to to be unecessary and it is not available with QT 6.2