### PR TITLE
(fix) Library Preferences: compose font style if font has no styleName()

### DIFF
--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -595,11 +595,39 @@ void DlgPrefLibrary::slotRowHeightValueChanged(int height) {
 }
 
 void DlgPrefLibrary::setLibraryFont(const QFont& font) {
-    lineEdit_library_font->setText(
-            QString("%1 %2 %3pt")
-                    .arg(font.family(),
-                            font.styleName(),
-                            QString::number(font.pointSizeF())));
+    // Update the font name/style/size display
+    QString fontDescription = font.family();
+    const QString style = font.styleName();
+    if (!style.isEmpty()) {
+        // Use the style name if available, likely it's translated
+        fontDescription += ' ' + style;
+    } else {
+        // Else we compose the "style" string from weight and italic.
+        // It's not possible to access the translations used in QFontDialog,
+        // but let's can add them to the user translations
+        const auto weight = font.weight();
+        if (weight >= QFont::Bold) {
+            if (weight >= QFont::Black) {
+                fontDescription += ' ' + tr("Black");
+            } else if (weight >= QFont::ExtraBold) {
+                fontDescription += ' ' + tr("ExtraBold");
+            } else if (weight >= QFont::Bold) {
+                fontDescription += ' ' + tr("Bold");
+            }
+        } else if (weight >= QFont::DemiBold) {
+            fontDescription += ' ' + tr("SemiBold");
+        } else if (weight >= QFont::Medium) {
+            fontDescription += ' ' + tr("Medium");
+        } else if (weight >= QFont::Normal) {
+            // Skip "Normal" as it's implied
+        } else {
+            fontDescription += ' ' + tr("Light");
+        }
+    }
+    fontDescription += ' ' + QString::number(font.pointSizeF()) + QStringLiteral("pt");
+    lineEdit_library_font->setText(fontDescription);
+
+    // Apply the font
     m_pLibrary->setFont(font);
 
     // Don't let the font height exceed the row height.


### PR DESCRIPTION
For some fonts `font.styleName()` is empty and the font display doesn't reflect the selected font.
Eg. **Open Sans Semibold** 12pt would be shown as "Open Sans 12pt"

If the style string is empty, let's compose the style manually from `Weight weight()` and `bool italic()`.
Now it's **Open Sans Semibold Italic 12 pt**

The tr strings used in QFontDialog are not available so I made that `tr()`.
Though even untranslated that's better than nothing IMO

___
IIRC that has been reported but I don't find a matching issue. Maybe it was in the forums or on Zulip