### PR TITLE
Update macOS runner image before planned shutdown of the current

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,8 +62,8 @@ jobs:
             artifacts_path: build/*.deb
             artifacts_slug: ubuntu-jammy
             qt_qpa_platform: offscreen
-          - name: macOS 13 x64
-            os: macos-13
+          - name: macOS 15 x64
+            os: macos-15-intel
             cmake_args: >-
               -DBULK=ON
               -DCOREAUDIO=ON
@@ -85,8 +85,8 @@ jobs:
             artifacts_path: build/*.dmg
             artifacts_slug: macos-macosintel
             qt_qpa_platform: offscreen
-          - name: macOS 13 arm64
-            os: macos-13
+          - name: macOS 15 arm64
+            os: macos-15-intel
             cmake_args: >-
               -DBULK=ON
               -DCOREAUDIO=ON

--- a/src/effects/backends/audiounit/audiouniteffectprocessor.mm
+++ b/src/effects/backends/audiounit/audiouniteffectprocessor.mm
@@ -13,6 +13,7 @@
 #include "engine/effects/engineeffectparameter.h"
 #include "engine/engine.h"
 #include "util/assert.h"
+#include "util/fpclassify.h"
 
 AudioUnitEffectGroupState::AudioUnitEffectGroupState(
         const mixxx::EngineParameters& engineParameters)
@@ -185,8 +186,8 @@ void AudioUnitEffectProcessor::syncParameters() {
     int i = 0;
     for (auto parameter : m_parameters) {
         if (m_lastValues.size() < i) {
-            m_lastValues.push_back(
-                    std::numeric_limits<AudioUnitParameterValue>::quiet_NaN());
+            static_assert(sizeof(AudioUnitParameterValue) == sizeof(float));
+            m_lastValues.push_back(util_float_nan());
         }
         DEBUG_ASSERT(m_lastValues.size() >= i);
 

--- a/src/effects/backends/audiounit/audiouniteffectprocessor.mm
+++ b/src/effects/backends/audiounit/audiouniteffectprocessor.mm
@@ -5,7 +5,9 @@
 
 #include <QMutex>
 #include <QtGlobal>
+
 #include <algorithm>
+#include <limits>
 
 #include "effects/backends/audiounit/audiouniteffectprocessor.h"
 #include "engine/effects/engineeffectparameter.h"
@@ -183,7 +185,8 @@ void AudioUnitEffectProcessor::syncParameters() {
     int i = 0;
     for (auto parameter : m_parameters) {
         if (m_lastValues.size() < i) {
-            m_lastValues.push_back(NAN);
+            m_lastValues.push_back(
+                    std::numeric_limits<AudioUnitParameterValue>::quiet_NaN());
         }
         DEBUG_ASSERT(m_lastValues.size() >= i);
 

--- a/src/test/mathutiltest.cpp
+++ b/src/test/mathutiltest.cpp
@@ -42,11 +42,11 @@ TEST_F(MathUtilTest, MathClampUnsafe) {
 TEST_F(MathUtilTest, IsNaN) {
     // Test floats can be recognized as nan.
     EXPECT_FALSE(util_isnan(0.0f));
-    EXPECT_TRUE(util_isnan(std::numeric_limits<float>::quiet_NaN()));
+    EXPECT_TRUE(util_isnan(util_float_nan()));
 
     // Test doubles can be recognized as nan.
     EXPECT_FALSE(util_isnan(0.0));
-    EXPECT_TRUE(util_isnan(std::numeric_limits<double>::quiet_NaN()));
+    EXPECT_TRUE(util_isnan(util_double_nan()));
 }
 
 TEST_F(MathUtilTest, IsInf) {

--- a/src/util/fpclassify.cpp
+++ b/src/util/fpclassify.cpp
@@ -10,28 +10,12 @@
 #include <cmath>
 #include <limits>
 
-int util_fpclassify(float x) {
-    return std::fpclassify(x);
-}
-
-bool util_isfinite(float x) {
-    return std::isfinite(x);
-}
-
-bool util_isnormal(float x) {
-    return std::isnormal(x);
-}
-
 int util_isnan(float x) {
     return std::isnan(x);
 }
 
 int util_isinf(float x) {
     return std::isinf(x);
-}
-
-int util_fpclassify(double x) {
-    return std::fpclassify(x);
 }
 
 bool util_isfinite(double x) {
@@ -56,4 +40,12 @@ float util_float_infinity() {
 
 double util_double_infinity() {
     return std::numeric_limits<double>::infinity();
+}
+
+float util_float_nan() {
+    return std::numeric_limits<double>::quiet_NaN();
+}
+
+double util_double_nan() {
+    return std::numeric_limits<double>::quiet_NaN();
 }

--- a/src/util/fpclassify.h
+++ b/src/util/fpclassify.h
@@ -10,20 +10,27 @@
  * avoided because they don't work as expected!!!
  */
 
-int util_fpclassify(float x);
-int util_fpclassify(double x);
-
-bool util_isfinite(float x);
 bool util_isfinite(double x);
+// Delete all other overloads to avoid accidental usage of them.
+template<typename T>
+bool util_isfinite(T x) = delete;
 
-bool util_isnormal(float x);
 bool util_isnormal(double x);
+// Delete all other overloads to avoid accidental usage of them.
+template<typename T>
+bool util_isnormal(T x) = delete;
 
 int util_isnan(float x);
 int util_isnan(double x);
+// Delete all other overloads to avoid accidental usage of them.
+template<typename T>
+bool util_isnan(T x) = delete;
 
 int util_isinf(float x);
 int util_isinf(double x);
+// Delete all other overloads to avoid accidental usage of them.
+template<typename T>
+bool util_isinf(T x) = delete;
 
 // The following functions are only used in testing code.
 // Don't use them in other -ffast-math code to avoid undefined behavior in
@@ -32,3 +39,6 @@ int util_isinf(double x);
 // values use the appropiated function above.
 float util_float_infinity();
 double util_double_infinity();
+
+float util_float_nan();
+double util_double_nan();

--- a/src/util/math.h
+++ b/src/util/math.h
@@ -5,7 +5,6 @@
 #include <type_traits>
 
 #include "util/assert.h"
-#include "util/fpclassify.h"
 
 #if __has_include(<bit>)
 #include <bit>


### PR DESCRIPTION
The macOS 13 Intel GitHub runner will be shut of soon: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

This PR updates to the new macos-15-intel runner image.

This upgrades XCode to 16.4 which has more floating-point optimizations and a new Wnan-infinity-disabled warning. To make Mixxx compile with this compiler, I had to adjust the AudiUnit code and the MathUtil testcase. To reduce the exposure of the fragile fpclassify code, I removed unused functions and added guards that prevent overloading of the remaining.