### PR TITLE
Library: also apply library font size(!) to tracks header

### DIFF
--- a/res/skins/LateNight/style.qss
+++ b/res/skins/LateNight/style.qss
@@ -30,7 +30,7 @@ WEffectChainPresetSelector QAbstractScrollArea,
 WTrackTableViewHeader,
 WTrackTableViewHeader::section {
   /* On Linux all weight variants of Open Sans are identified
-  as "Open Sans".
+  as "Open Sans" and we need to set the `font-weight`.
   On Windows however, the semi-bold variant is identified as
   "Open Sans Semibold", so look for that first. */
   font-family: "Open Sans Semibold", "Open Sans";
@@ -314,19 +314,24 @@ WRecordingDuration {
 }
 
 WTrackTableViewHeader::item {
-  /* Don't set a font size to pick up the system font size. */
   border-bottom: 1px solid #000;
   }
-  WTrackTableViewHeader::section {
+/* This is now set in c++ WTrackTableViewHeader::paintSection()
+   which also works around a Qt bug with the sort indicator */
+/*WTrackTableViewHeader::section {
     height: 1.1em;
     border: 0;
     padding: 0.1em;
-  }
-  WTrackTableViewHeader::up-arrow,
+  }*/
+  /*WTrackTableViewHeader::up-arrow,
   WTrackTableViewHeader::down-arrow {
     width: 0.8em;
-    padding: 0 0.15em;
-  }
+    padding: 0 0.3em;
+  }*/
+  /*WTrackTableViewHeader::up-arrow,
+  WTrackTableViewHeader::down-arrow {
+    padding: 0 1px;
+  }*/
 
 /* Prevent OS-style checkbox from being rendered underneath the custom style. */
 #LibraryBPMButton::item,

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -2769,17 +2769,20 @@ WTrackPropertyEditor {
 WTrackTableViewHeader {
   border-bottom-right-radius: 1px solid #000;
   outline: none;
+  /*qproperty-fontToHeightFactor: 1.1;*/
 }
 
 WTrackTableViewHeader::section {
-/* Setting an image causes QHeaderView to reserve space for the sort indicator,
-   i.e. column titles are truncated, even where no indicators are shown.
-   The arrow width and padding are set in style.qss (0.8em + .15em),
-   so let's set a negative padding-right to shift the text. This will push the
-   reserved space out of the visible region, but the actual arrow will still be visible.
-   Now the arrow overlaps the column title again like in Qt5 (bug), so the arrow images
-   could use a background-color to cover the text, or a gradient to fade it out gently. */
-  padding: 2px -0.95em 0px 3px;
+/* Setting an icon for sort arrows causes QHeaderView to reserve space for it
+   even where no indicators are shown (column titles are truncated).
+   Earlier we fixed this here by setting a negative padding-right in order to shift
+   the text (push the reserved space out of the visible region). The arrow will still
+   be painted correctly.
+   Now that the arrow overlaps the column title, up-/down-arrow need a background in
+   order to cover the text underneath. */
+/* This is now fixed in c++ in WTrackTableViewHeader::paintSection() so we can set
+   the usual padding with absolute px values here. */
+  padding: 2px;
   outline: none;
   border-width: 1px 2px 1px 1px;
   border-image: url(skins:LateNight/palemoon/buttons/btn_embedded_library_header.svg) 1 2 1 1;
@@ -2788,7 +2791,7 @@ WTrackTableViewHeader::section {
 WTrackTableViewHeader::up-arrow,
 WTrackTableViewHeader::down-arrow {
   outline: none;
-  /* horizontal gradient to fade out the text */
+  /* horizontal gradient to fade out the text underneath */
   background-color: qlineargradient(x1: 0, y1: 0, x2: 1, y2: 0,
     stop: 0 transparent,
     stop: 0.2 #171719,

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -240,6 +240,14 @@ QVariant BaseTrackTableModel::headerData(
             }
             break;
         }
+        case Qt::TextAlignmentRole: {
+            // Get the headers default alignment and replace any potential v-align
+            // flags with AlignVCenter (it just looks better with latin fonts)
+            QVariant alignVar = QAbstractTableModel::headerData(section, orientation, role);
+            Qt::Alignment alignment = alignVar.value<Qt::Alignment>();
+            alignment = (alignment & ~Qt::AlignVertical_Mask) | Qt::AlignVCenter;
+            return QVariant::fromValue(alignment);
+        }
         default:
             break;
         }

--- a/src/widget/wlibrarytableview.cpp
+++ b/src/widget/wlibrarytableview.cpp
@@ -10,6 +10,7 @@
 
 #include "moc_wlibrarytableview.cpp"
 #include "util/math.h"
+#include "widget/wtracktableviewheader.h"
 
 class QFocusEvent;
 
@@ -185,6 +186,21 @@ void WLibraryTableView::setTrackTableFont(const QFont& font) {
             "height: %1px;"
             "width: %1px;}")
                           .arg(metrics.height() * 0.7));
+
+    // Apply the font to the header as well.
+    // Note: remember to also apply the font to new headers created in
+    // WTrackTableView::loadTrackModel()
+    // Note: since WTrackTableViewHeader::setFont() does not override
+    // QHeaderView::setFont() we need to cast to WTrackTableViewHeader
+    WTrackTableViewHeader* pHeader = qobject_cast<WTrackTableViewHeader*>(horizontalHeader());
+    if (pHeader) {
+        pHeader->setFont(font);
+    } else {
+        // _Might_ happen in case we did not yet WTrackTableView::loadTrackModel()
+        // hence might not have a WTrackTableViewHeader yet but still default QHeaderView.
+        // Header height will not be adjusted correctly now, only after loading the model.
+        horizontalHeader()->setFont(font);
+    }
 }
 
 void WLibraryTableView::setTrackTableRowHeight(int rowHeight) {

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -364,6 +364,9 @@ void WTrackTableView::loadTrackModel(QAbstractItemModel* model, bool restoreStat
     // haven't been able to get it to stop us from using a model as a drag
     // target though, so my hacks above may not be completely unjustified.
 
+    // Now also apply the current font to the new header
+    pHeader->setFont(font());
+
     setVisible(true);
 
     // trigger restoring scrollBar position, selection etc.

--- a/src/widget/wtracktableviewheader.cpp
+++ b/src/widget/wtracktableviewheader.cpp
@@ -2,11 +2,15 @@
 
 #include <QCheckBox>
 #include <QContextMenuEvent>
+#include <QPainter>
+#include <QStyleOptionHeader>
+#include <QTextOption>
 #include <QWidgetAction>
 
 #include "library/trackmodel.h"
 #include "moc_wtracktableviewheader.cpp"
 #include "util/math.h"
+#include "util/painterscope.h"
 #include "util/parented_ptr.h"
 #include "widget/wmenucheckbox.h"
 
@@ -103,7 +107,8 @@ void HeaderViewState::restoreState(QHeaderView* pHeaders) {
 WTrackTableViewHeader::WTrackTableViewHeader(Qt::Orientation orientation,
         QWidget* pParent)
         : QHeaderView(orientation, pParent),
-          m_menu(tr("Show or hide columns."), this) {
+          m_menu(tr("Show or hide columns."), this),
+          m_preferredHeight(-1) {
 }
 
 void WTrackTableViewHeader::contextMenuEvent(QContextMenuEvent* pEvent) {
@@ -328,4 +333,136 @@ int WTrackTableViewHeader::hiddenCount() {
 TrackModel* WTrackTableViewHeader::getTrackModel() {
     TrackModel* pTrackModel = dynamic_cast<TrackModel*>(model());
     return pTrackModel;
+}
+
+void WTrackTableViewHeader::setFont(const QFont& font) {
+    // Note:
+    // This does not necessarily set the "font" -- QStylesheetStyle seems to be
+    // so dominant/persistent that setFont() only adopts font properties which
+    // we did NOT set in qss.
+    // So, for
+    // WTrackTableViewHeader, WTrackTableViewHeader::section {
+    //   font-family: "Open Sans Semibold", "Open Sans";
+    //   font-weight: 500; /* semi-bold */
+    //   font-style: normal;
+    //   text-transform: none;
+    //   but not font-size; }
+    // setFont() does only set font-size.
+    QHeaderView::setFont(font);
+
+    // When we set a new font, QHeaderView's QStyle kind of adopts the stylesheet
+    // we applied (border and padding are intact), but apparently adds some content
+    // margin in QStyle::SE_HeaderLabel which changes the effective text padding.
+    // Since we can't re-apply the stylesheet, we need to calculate the original
+    // text padding (border + padding) in order to get the new preferred height.
+    // This is then used by sizeHint() to return the preferred size.
+    // Note: we don't touch the column width.
+    setHeightForFont();
+
+    // In order to update the view instantly we need to make some update calls.
+    // Note: order of these seems to be crucial. Otherwise we wouldn't get
+    // the new size until we switch the track model (create a new header)
+    updateGeometry(); // Tells layout to re-query sizeHint()
+    adjustSize();     // Resizes to sizeHint()
+    update();         // Repaints the widget
+}
+
+void WTrackTableViewHeader::setHeightForFont() {
+    // Re-calculate the fixed height used by sizeHint().
+    // Subtract content height from frame height to get the
+    // vertical padding, and add that to the font height to get the new ttotal height.
+    QStyleOptionHeader opt;
+    initStyleOption(&opt);
+    const QRect baseRect(QPoint(0, 0), QHeaderView::sizeHint());
+    opt.rect = baseRect;
+    const QRect contentRect = style()->subElementRect(QStyle::SE_HeaderLabel, &opt, this);
+    int vPadding = baseRect.height() - contentRect.height();
+    // This gives the desired result (capital height + ascent + descent).
+    // font().pixelSize() / QFontInfo(font()).pixelSize() will apparently return
+    // something like font(),capHeight() which is not adequate here.
+    QFontMetrics fm(font());
+    m_preferredHeight = fm.height() + vPadding;
+}
+
+QSize WTrackTableViewHeader::sizeHint() const {
+    if (m_preferredHeight == -1) { // no font set by us, yet
+        return QHeaderView::sizeHint();
+    }
+    return QSize(QHeaderView::sizeHint().width(), m_preferredHeight);
+}
+
+void WTrackTableViewHeader::paintSection(
+        QPainter* pPainter,
+        const QRect& rect,
+        int logicalIndex) const {
+    // Work around a Qt bug that occurs when we set sort icons in qss (and we need to
+    // because setting any QHeaderView::section style property clears the default icons):
+    // the style would reserve space for the sort indicator, even in header sections
+    // where it's not visible, and thereby truncate the text.
+    //
+    // Probably this one:
+    // https://bugreports.qt.io/browse/QTBUG-27038
+    // Previous Mixxx workaround which is not applicable anymore since we are now
+    // applying the library font to the header at runtime:
+    // https://github.com/mixxxdj/mixxx/pull/13535
+    //
+    // Fix: draw background & border, then text, then sort indicator.
+    // This is a stripped and fixed adaption of QHeaderView::paintSection()
+    QStyleOptionHeader opt;
+    initStyleOption(&opt);
+    opt.rect = rect;
+    opt.section = logicalIndex;
+
+    // Draw background & border only
+    opt.text = QString(); // prevent style from drawing the text
+    opt.icon = QIcon();   // prevent icon overlap
+    style()->drawControl(QStyle::CE_HeaderSection, &opt, pPainter, this);
+
+    const QRect contentRect = style()->subElementRect(QStyle::SE_HeaderLabel, &opt, this);
+    // Note: contentRect.height() is now actually equal to m_preferredHeight
+
+    { // Draw text. Use PainterScope, just in case...
+        PainterScope painterScope(pPainter);
+
+        // BaseTrackTableModel::headerData(section, orientation, Qt::TextAlignmentRole)
+        // replaces the vertical component of the default alignment flags with VCenter.
+        const Qt::Alignment alignment = model()->headerData(logicalIndex,
+                                                       Qt::Horizontal,
+                                                       Qt::TextAlignmentRole)
+                                                .value<Qt::Alignment>();
+        QTextOption textOption(alignment);
+        textOption.setWrapMode(QTextOption::NoWrap);
+        const QString title =
+                model()->headerData(logicalIndex, orientation(), Qt::DisplayRole).toString();
+        // QPainter still has the old font (size)
+        pPainter->setFont(font());
+        pPainter->setPen(opt.palette.color(QPalette::ButtonText));
+        pPainter->drawText(contentRect, title, textOption);
+    }
+
+    // Draw sort indicator if needed
+    if (isSortIndicatorShown() && sortIndicatorSection() == logicalIndex) {
+        // Use the style's original indicator rect but make width = height
+        const QRect origIndiRect = style()->subElementRect(QStyle::SE_HeaderArrow, &opt, this);
+        int indiWH = origIndiRect.height();
+        int indiRectLeft = layoutDirection() == Qt::LeftToRight
+                ? origIndiRect.right() - indiWH
+                : origIndiRect.left();
+        opt.rect = QRect(indiRectLeft, origIndiRect.top(), indiWH, indiWH);
+
+        // NOTE: Don't use drawPrimitive(PE_IndicatorHeaderArrow) because of its
+        // platform-specific arrow flipping logic in QFusionStyle::drawPrimitive
+        // (ascending = up on Linux, down on Windows/macOS) which is not used by
+        // QHeaderView's default painting via
+        // QStyleSheetStyle::drawControl(CE_Header|CE_HeaderLabel).
+        // Instead, we use the fail-safe method of drawing up/down arrows explicitly
+        // with drawPrimitive(PE_IndicatorArrowUp|Down) for consistent appearance.
+        // This also updates the widget so qss icons are applied immediately.
+        style()->drawPrimitive((sortIndicatorOrder() == Qt::AscendingOrder)
+                        ? QStyle::PE_IndicatorArrowUp
+                        : QStyle::PE_IndicatorArrowDown,
+                &opt,
+                pPainter,
+                this);
+    }
 }

--- a/src/widget/wtracktableviewheader.h
+++ b/src/widget/wtracktableviewheader.h
@@ -63,8 +63,20 @@ class WTrackTableViewHeader : public QHeaderView {
     void saveHeaderState();
     void restoreHeaderState();
     void loadDefaultHeaderState();
-     /** returns false if the header state is stored in the database (on first time usgae) **/
+    // Returns false if the header state is not stored in the database (on first time usage)
     bool hasPersistedHeaderState();
+
+    // Sets the font and ensures the height is adjusted immediately.
+    // From other units this has to be called via WTrackTableViewHeader, not horizontalHeader()
+    // because it does not (and can not) override QWidget::setFont()
+    void setFont(const QFont& font);
+    // We could also catch font change via changeEvent() -> QEvent::FontChange
+    // but that's called way too often with no-ops and causes hilarious effects.
+
+    // Required to set the preferred height with custom padding
+    QSize sizeHint() const override;
+    // Work around Qt6 paint bug with sort indicator
+    void paintSection(QPainter* pPainter, const QRect& rect, int logicalIndex) const override;
 
   signals:
     void shuffle();
@@ -77,6 +89,10 @@ class WTrackTableViewHeader : public QHeaderView {
     void clearActions();
     TrackModel* getTrackModel();
 
+    void setHeightForFont();
+
     QMenu m_menu;
     QMap<int, QCheckBox*> m_columnCheckBoxes;
+
+    int m_preferredHeight;
 };


### PR DESCRIPTION
I already tried this years ago, but failed. Though when the request came up again in the forums recently, I knew immediatly what I missed back then.

### TL;DR
It works now. Note: I decided to adopt the font **size** only. Below I explain why.
I think I managed to make it look like it id before. Sort arrows are also scaled, should be height of 'M'.
**Note:** polished in LateNight PaleMoon only for now

**Question is: Do we want this?**
Primarily I worked on this to help visually impaired users ([forum link](https://mixxx.discourse.group/t/increase-font-size-of-tracks-table-header/32728/2)) and to make the library more consistent, finally. And because it was a nice challenge. 
But for me, the default (system) font size is okay for the header because I _know_ where artist, BPM and comment are, I just increase the table font and row height a bit because I'm usually ~1m away from the screen.
And actually, if you're visually impaired you'd have a large system font anyway which should be picked by the table header as it is for dialogs, menu etc.



### The long story
As expexted, I ran into a few Qt quirks and bugs and I documented them inline, but I'll explain some of them (and the workarounds) here as well in order to demonstrate what rats nest we're poking when trying ot set the header font with our `WTrackTableViewHeader` which is only set when loading a track model to the tracks view.

**Apply the font to the header**
a) when setting a new library font, but also
b) when constructing a new header (when we switch the model of a track table view)

This kind of works.
Though QStylesheetStyle seems to be quite dominant/persistant: setFont() only adopts font properties which we did NOT set in qss. Ie. it does NOT override qss styles.
So, for
```css
WTrackTableViewHeader, WTrackTableViewHeader::section {
  font-family: "Open Sans Semibold", "Open Sans";
  font-weight: 500; /* semi-bold */
  font-style: normal;
  text-transform: none;
  /* we don't set the font size */ }
```
setFont() does only set font **size**.
If we remove the family, style and weight from qss, setFont() fully works as desired.
Note: I did **not** remove these because _Open Sans Semibold_ looks really nice in the header as it matches all other skin buttons and labels. And I consider the header buttons part of the skin, not library _content_.

**Adjust header height to new font**
We can override sizeHint() to use our own preferred height, though this would require creating QFontMetrics on each call which is excessive.
So let's calculate the height in WTrackTableViewHeader::setFont() and reuse it in sizeHint().
<sub>Though, in LibraryTableView we only have horizontalHeader() object and setFont() does not override QHeaderView::setFont() because QHeaderView (which inherits from QWidget) does not declare setFont() as virtual, and the base declaration in QWidget isn't marked as virtual either.
Workaround: qobject_cast<WTrackTableViewHeader*>(horizontalheader())</sub>

Okay, cool. This works reliably and efficiently!

**Oh wait, that Qt bug with qss sort icons again...**
<sub>Remember #13535? Since Qt5(?) the QStyle would reserve space for the sort indicator, even in header sections where it's not visible, and thereby truncate the text when we set sort icons in qss (and we need to because setting any QHeaderView::section style property clears the default icons).</sub>
Fixed by painting the header sections manually.

This was actually easy :tm: but still a PITA since I ran into yet another Qt bug / annoying inconsistency with QStyleSheetStyle vs. QFusionStyle where the latter would flip the sort up/down arrows differently per platform.
Btw I almost gave up at this point, but decided to poke chatGPT for a few hours to help me figure out wtf is going on and point me to the responsible Qt sources. Now it's fail-proof.