### PR TITLE
Use the correct number of channels for underflow compensation

### DIFF
--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -718,7 +718,7 @@ void SoundDevicePortAudio::writeProcess(SINT framesPerBuffer) {
                     if (m_outputDrift) {
                         //qDebug() << "SoundDevicePortAudio::writeProcess() skip one frame"
                         //        << (float)writeAvailable / outChunkSize << (float)readAvailable / outChunkSize;
-                        copyCount = qMin(readAvailable, copyCount + m_numOutputChannels);
+                        copyCount = qMin(readAvailable, copyCount + m_outputParams.channelCount);
                     } else {
                         m_outputDrift = true;
                     }


### PR DESCRIPTION
This fixes a crackling noise with "Experimental (no delay)" and soundcards with unused output ports. This noise appears in regular intervals and two soundcards or network clock. 

The fix uses the correct size of a frame for the output instead of the maximum size. 
