### PR TITLE
(fix) LateNight: revert xfader buttons to one (cycling) toggle

### DIFF
--- a/res/skins/LateNight/controls/button_xfader_aux.xml
+++ b/res/skins/LateNight/controls/button_xfader_aux.xml
@@ -16,83 +16,120 @@
     <Layout>horizontal</Layout>
     <SizePolicy>max,min</SizePolicy>
     <Children>
-<!-- L -->
-      <PushButton>
-        <ObjectName>CrossfaderButton</ObjectName>
-        <TooltipId>orientation</TooltipId>
-        <Size>11f,13f</Size>
-        <NumberStates>2</NumberStates>
-        <RightClickIsPushButton>false</RightClickIsPushButton>
-        <State>
-          <Number>0</Number>
-          <Pressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_aux_left_off.svg</Pressed>
-          <Unpressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_aux_left_off.svg</Unpressed>
-        </State>
-        <State>
-          <Number>1</Number>
-          <Pressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_aux_left.svg</Pressed>
-          <Unpressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_aux_left.svg</Unpressed>
-        </State>
-        <Connection>
-          <ConfigKey><Variable name="Group"/>,orientation</ConfigKey>
-          <Transform>
-            <IsEqual>0</IsEqual>
-          </Transform>
-          <ButtonState>LeftButton</ButtonState>
-        </Connection>
-      </PushButton>
-<!-- M -->
-      <PushButton>
-        <ObjectName>CrossfaderButton</ObjectName>
-        <TooltipId>orientation</TooltipId>
-        <Size>11f,13f</Size>
-        <NumberStates>2</NumberStates>
-        <RightClickIsPushButton>false</RightClickIsPushButton>
-        <State>
-          <Number>0</Number>
-          <Pressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_aux_mid_off.svg</Pressed>
-          <Unpressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_aux_mid_off.svg</Unpressed>
-        </State>
-        <State>
-          <Number>1</Number>
-          <Pressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_aux_mid.svg</Pressed>
-          <Unpressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_aux_mid.svg</Unpressed>
-        </State>
-        <Connection>
-          <ConfigKey><Variable name="Group"/>,orientation</ConfigKey>
-          <Transform>
-            <Add>-1</Add>
-            <IsEqual>0</IsEqual>
-          </Transform>
-          <ButtonState>LeftButton</ButtonState>
-        </Connection>
-      </PushButton>
-<!-- R -->
-      <PushButton>
-        <ObjectName>CrossfaderButton</ObjectName>
-        <TooltipId>orientation</TooltipId>
-        <Size>11f,13f</Size>
-        <NumberStates>2</NumberStates>
-        <RightClickIsPushButton>false</RightClickIsPushButton>
-        <State>
-          <Number>0</Number>
-          <Pressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_aux_right_off.svg</Pressed>
-          <Unpressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_aux_right_off.svg</Unpressed>
-        </State>
-        <State>
-          <Number>1</Number>
-          <Pressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_aux_right.svg</Pressed>
-          <Unpressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_aux_right.svg</Unpressed>
-        </State>
-        <Connection>
-          <ConfigKey><Variable name="Group"/>,orientation</ConfigKey>
-          <Transform>
-            <Add>-2</Add>
-            <IsEqual>0</IsEqual>
-          </Transform>
-          <ButtonState>LeftButton</ButtonState>
-        </Connection>
-      </PushButton>
+
+      <WidgetGroup>
+        <Layout>stacked</Layout>
+        <SizePolicy>min,min</SizePolicy>
+        <Children>
+          <!-- invisible button = actual control -->
+          <PushButton>
+            <ObjectName>Blank</ObjectName>
+            <TooltipId>orientation</TooltipId>
+            <Size>33me,15f</Size>
+            <NumberStates>3</NumberStates>
+            <RightClickIsPushButton>false</RightClickIsPushButton>
+            <State>
+              <Number>0</Number>
+            </State>
+            <State>
+              <Number>1</Number>
+            </State>
+            <State>
+              <Number>2</Number>
+            </State>
+            <Connection>
+              <ConfigKey><Variable name="Group"/>,orientation</ConfigKey>
+              <ButtonState>LeftButton</ButtonState>
+            </Connection>
+          </PushButton>
+
+          <WidgetGroup><!-- button row / icons -->
+            <Layout>horizontal</Layout>
+            <SizePolicy>min,min</SizePolicy>
+            <Children>
+              <!-- L -->
+              <PushButton>
+                <ObjectName>CrossfaderButton</ObjectName>
+                <TooltipId>orientation</TooltipId>
+                <Size>11f,13f</Size>
+                <NumberStates>2</NumberStates>
+                <RightClickIsPushButton>false</RightClickIsPushButton>
+                <State>
+                  <Number>0</Number>
+                  <Pressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_aux_left_off.svg</Pressed>
+                  <Unpressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_aux_left_off.svg</Unpressed>
+                </State>
+                <State>
+                  <Number>1</Number>
+                  <Pressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_aux_left.svg</Pressed>
+                  <Unpressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_aux_left.svg</Unpressed>
+                </State>
+                <Connection>
+                  <ConfigKey><Variable name="Group"/>,orientation</ConfigKey>
+                  <Transform>
+                    <IsEqual>0</IsEqual>
+                  </Transform>
+                  <ButtonState>LeftButton</ButtonState>
+                </Connection>
+              </PushButton>
+              <!-- M -->
+              <PushButton>
+                <ObjectName>CrossfaderButton</ObjectName>
+                <TooltipId>orientation</TooltipId>
+                <Size>11f,13f</Size>
+                <NumberStates>2</NumberStates>
+                <RightClickIsPushButton>false</RightClickIsPushButton>
+                <State>
+                  <Number>0</Number>
+                  <Pressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_aux_mid_off.svg</Pressed>
+                  <Unpressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_aux_mid_off.svg</Unpressed>
+                </State>
+                <State>
+                  <Number>1</Number>
+                  <Pressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_aux_mid.svg</Pressed>
+                  <Unpressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_aux_mid.svg</Unpressed>
+                </State>
+                <Connection>
+                  <ConfigKey><Variable name="Group"/>,orientation</ConfigKey>
+                  <Transform>
+                    <Add>-1</Add>
+                    <IsEqual>0</IsEqual>
+                  </Transform>
+                  <ButtonState>LeftButton</ButtonState>
+                </Connection>
+              </PushButton>
+              <!-- R -->
+              <PushButton>
+                <ObjectName>CrossfaderButton</ObjectName>
+                <TooltipId>orientation</TooltipId>
+                <Size>11f,13f</Size>
+                <NumberStates>2</NumberStates>
+                <RightClickIsPushButton>false</RightClickIsPushButton>
+                <State>
+                  <Number>0</Number>
+                  <Pressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_aux_right_off.svg</Pressed>
+                  <Unpressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_aux_right_off.svg</Unpressed>
+                </State>
+                <State>
+                  <Number>1</Number>
+                  <Pressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_aux_right.svg</Pressed>
+                  <Unpressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_aux_right.svg</Unpressed>
+                </State>
+                <Connection>
+                  <ConfigKey><Variable name="Group"/>,orientation</ConfigKey>
+                  <Transform>
+                    <Add>-2</Add>
+                    <IsEqual>0</IsEqual>
+                  </Transform>
+                  <ButtonState>LeftButton</ButtonState>
+                </Connection>
+              </PushButton>
+            </Children>
+          </WidgetGroup><!-- button row / icons -->
+
+        </Children>
+      </WidgetGroup><!-- stacked wrapper -->
+
     </Children>
   </WidgetGroup>
 </Template>

--- a/res/skins/LateNight/controls/button_xfader_deck.xml
+++ b/res/skins/LateNight/controls/button_xfader_deck.xml
@@ -16,81 +16,118 @@
     <Layout>horizontal</Layout>
     <SizePolicy>min,min</SizePolicy>
     <Children>
-      <!-- L -->
-      <PushButton>
-        <ObjectName>CrossfaderButton</ObjectName>
-        <TooltipId>orientation</TooltipId>
-        <Size>11f,15f</Size>
-        <NumberStates>2</NumberStates>
-        <RightClickIsPushButton>false</RightClickIsPushButton>
-        <State>
-          <Number>0</Number>
-          <Pressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_deck_left_off.svg</Pressed>
-          <Unpressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_deck_left_off.svg</Unpressed>
-        </State>
-        <State>
-          <Number>1</Number>
-          <Pressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_deck_left_<Variable name="xfaderLeft"/>.svg</Pressed>
-          <Unpressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_deck_left_<Variable name="xfaderLeft"/>.svg</Unpressed>
-        </State>
-        <Connection>
-          <ConfigKey><Variable name="Group"/>,orientation</ConfigKey>
-          <Transform>
-            <IsEqual>0</IsEqual>
-          </Transform>
-          <ButtonState>LeftButton</ButtonState>
-        </Connection>
-      </PushButton>
-      <!-- M -->
-      <PushButton>
-        <ObjectName>CrossfaderButton</ObjectName>
-        <TooltipId>orientation</TooltipId>
-        <Size>11f,15f</Size>
-        <NumberStates>2</NumberStates>
-        <RightClickIsPushButton>false</RightClickIsPushButton>
-        <State>
-          <Number>0</Number>
-          <Pressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_deck_mid_off.svg</Pressed>
-          <Unpressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_deck_mid_off.svg</Unpressed>
-        </State>
-        <State>
-          <Number>1</Number>
-          <Pressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_deck_mid_warning.svg</Pressed>
-          <Unpressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_deck_mid_warning.svg</Unpressed>
-        </State>
-        <Connection>
-          <ConfigKey><Variable name="Group"/>,orientation</ConfigKey>
-          <Transform>
-            <IsEqual>1</IsEqual>
-          </Transform>
-          <ButtonState>LeftButton</ButtonState>
-        </Connection>
-      </PushButton>
-      <!-- R -->
-      <PushButton>
-        <ObjectName>CrossfaderButton</ObjectName>
-        <TooltipId>orientation</TooltipId>
-        <Size>11f,15f</Size>
-        <NumberStates>2</NumberStates>
-        <RightClickIsPushButton>false</RightClickIsPushButton>
-        <State>
-          <Number>0</Number>
-          <Pressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_deck_right_off.svg</Pressed>
-          <Unpressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_deck_right_off.svg</Unpressed>
-        </State>
-        <State>
-          <Number>1</Number>
-          <Pressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_deck_right_<Variable name="xfaderRight"/>.svg</Pressed>
-          <Unpressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_deck_right_<Variable name="xfaderRight"/>.svg</Unpressed>
-        </State>
-        <Connection>
-          <ConfigKey><Variable name="Group"/>,orientation</ConfigKey>
-          <Transform>
-            <IsEqual>2</IsEqual>
-          </Transform>
-          <ButtonState>LeftButton</ButtonState>
-        </Connection>
-      </PushButton>
+
+      <WidgetGroup>
+        <Layout>stacked</Layout>
+        <SizePolicy>min,min</SizePolicy>
+        <Children>
+          <!-- invisible button = actual control -->
+          <PushButton>
+            <ObjectName>Blank</ObjectName>
+            <TooltipId>orientation</TooltipId>
+            <Size>33me,15f</Size>
+            <NumberStates>3</NumberStates>
+            <RightClickIsPushButton>false</RightClickIsPushButton>
+            <State>
+              <Number>0</Number>
+            </State>
+            <State>
+              <Number>1</Number>
+            </State>
+            <State>
+              <Number>2</Number>
+            </State>
+            <Connection>
+              <ConfigKey><Variable name="Group"/>,orientation</ConfigKey>
+              <ButtonState>LeftButton</ButtonState>
+            </Connection>
+          </PushButton>
+
+          <WidgetGroup><!-- button row / icons -->
+            <Layout>horizontal</Layout>
+            <SizePolicy>min,min</SizePolicy>
+            <Children>
+              <!-- L -->
+              <PushButton>
+                <ObjectName>CrossfaderButton</ObjectName>
+                <TooltipId>orientation</TooltipId>
+                <Size>11f,15f</Size>
+                <NumberStates>2</NumberStates>
+                <RightClickIsPushButton>false</RightClickIsPushButton>
+                <State>
+                  <Number>0</Number>
+                  <Pressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_deck_left_off.svg</Pressed>
+                  <Unpressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_deck_left_off.svg</Unpressed>
+                </State>
+                <State>
+                  <Number>1</Number>
+                  <Pressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_deck_left_<Variable name="xfaderLeft"/>.svg</Pressed>
+                  <Unpressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_deck_left_<Variable name="xfaderLeft"/>.svg</Unpressed>
+                </State>
+                <Connection>
+                  <ConfigKey><Variable name="Group"/>,orientation</ConfigKey>
+                  <Transform>
+                    <IsEqual>0</IsEqual>
+                  </Transform>
+                  <ButtonState>LeftButton</ButtonState>
+                </Connection>
+              </PushButton>
+              <!-- M -->
+              <PushButton>
+                <ObjectName>CrossfaderButton</ObjectName>
+                <TooltipId>orientation</TooltipId>
+                <Size>11f,15f</Size>
+                <NumberStates>2</NumberStates>
+                <RightClickIsPushButton>false</RightClickIsPushButton>
+                <State>
+                  <Number>0</Number>
+                  <Pressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_deck_mid_off.svg</Pressed>
+                  <Unpressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_deck_mid_off.svg</Unpressed>
+                </State>
+                <State>
+                  <Number>1</Number>
+                  <Pressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_deck_mid_warning.svg</Pressed>
+                  <Unpressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_deck_mid_warning.svg</Unpressed>
+                </State>
+                <Connection>
+                  <ConfigKey><Variable name="Group"/>,orientation</ConfigKey>
+                  <Transform>
+                    <IsEqual>1</IsEqual>
+                  </Transform>
+                  <ButtonState>LeftButton</ButtonState>
+                </Connection>
+              </PushButton>
+              <!-- R -->
+              <PushButton>
+                <ObjectName>CrossfaderButton</ObjectName>
+                <TooltipId>orientation</TooltipId>
+                <Size>11f,15f</Size>
+                <NumberStates>2</NumberStates>
+                <RightClickIsPushButton>false</RightClickIsPushButton>
+                <State>
+                  <Number>0</Number>
+                  <Pressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_deck_right_off.svg</Pressed>
+                  <Unpressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_deck_right_off.svg</Unpressed>
+                </State>
+                <State>
+                  <Number>1</Number>
+                  <Pressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_deck_right_<Variable name="xfaderRight"/>.svg</Pressed>
+                  <Unpressed scalemode="STRETCH_ASPECT">skins:LateNight/<Variable name="BtnScheme"/>/buttons/btn__xfader_deck_right_<Variable name="xfaderRight"/>.svg</Unpressed>
+                </State>
+                <Connection>
+                  <ConfigKey><Variable name="Group"/>,orientation</ConfigKey>
+                  <Transform>
+                    <IsEqual>2</IsEqual>
+                  </Transform>
+                  <ButtonState>LeftButton</ButtonState>
+                </Connection>
+              </PushButton>
+            </Children>
+          </WidgetGroup><!-- button row / icons -->
+
+        </Children>
+      </WidgetGroup><!-- stacked wrapper -->
+
     </Children>
   </WidgetGroup><!-- CrossfaderButtonContainer_Deck -->
 </Template>


### PR DESCRIPTION
It seems the current 3 separate xfader buttons create an UX issue:
https://mixxx.discourse.group/t/loving-mixxx-flx4/32733

So while the current 3-button row is nice as it provides direct click -> xfader pos mappings, it's apparently not ideal because its slider look in PaleMoon implies it's ONE control which causes confusion.

**Quick Fix:**
Put an invisible 3-state toggle on top so it works like in Tango and Deere.
This is the eays way that works without elaborate refactoring (creating one button, merging icons, rework deck variables that set the 'warning' icon etc.)

Looks as before in both Classic and PaleMoon.