### PR TITLE
(fix) Skins: use `sync_enabled` for sampler sync buttons

### DIFF
--- a/res/skins/Deere/sampler_controls_row.xml
+++ b/res/skins/Deere/sampler_controls_row.xml
@@ -84,17 +84,15 @@
             <SetVariable name="color">green</SetVariable>
           </Template>
 
-          <Template src="skin:left_right_1state_button.xml">
-            <SetVariable name="TooltipId">beatsync_beatsync_tempo</SetVariable>
+          <Template src="skin:left_right_2state_button.xml">
+            <SetVariable name="TooltipId">sync_enabled</SetVariable>
             <SetVariable name="ObjectName">BeatsyncButton</SetVariable>
             <SetVariable name="MinimumSize">32,22</SetVariable>
             <SetVariable name="MaximumSize"><Variable name="WideButtonMaximumSize"/></SetVariable>
             <SetVariable name="SizePolicy">me,f</SetVariable>
             <SetVariable name="state_0_text">Sync</SetVariable>
-            <SetVariable name="state_0_pressed"></SetVariable>
-            <SetVariable name="state_0_unpressed"></SetVariable>
-            <SetVariable name="left_connection_control"><Variable name="group"/>,beatsync</SetVariable>
-            <SetVariable name="right_connection_control"><Variable name="group"/>,beatsync_tempo</SetVariable>
+            <SetVariable name="state_1_text">Sync</SetVariable>
+            <SetVariable name="left_connection_control"><Variable name="group"/>,sync_enabled</SetVariable>
           </Template>
 
           <Template src="skin:crossfader_orientation_button.xml">

--- a/res/skins/LateNight/classic/buttons/btn__sync_sampler.svg
+++ b/res/skins/LateNight/classic/buttons/btn__sync_sampler.svg
@@ -1,14 +1,10 @@
-<svg width="48" height="48" version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<g fill="none" stroke="#000001" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6">
-				<path d="m5 7.3636 6.955 4.6367-6.955 4.6367z"/>
-				<path d="M 19,7.3633 12.045,12 19,16.6367 Z"/>
-		</g>
-		<g transform="translate(1 -.9997)" fill="none">
-				<path d="M 4,8.3633 10.955,13 4,17.6367 V 8.3633"/>
-				<path d="M 18,8.3633 11.045,13 18,17.6367 V 8.3633"/>
-		</g>
-		<g fill="#d2d2d1">
-				<path d="m5 7.3636 6.955 4.6367-6.955 4.6367z"/>
-				<path d="M 19,7.3633 12.045,12 19,16.6367 Z"/>
-		</g>
+<svg width="48" height="48" version="1.1" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <g fill="none" stroke="#000001" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6">
+    <path d="m5 7.3636 6.955 4.6367-6.955 4.6367z"/>
+    <path d="M 19,7.3633 12.045,12 19,16.6367 Z"/>
+  </g>
+  <g fill="#d2d2d1">
+    <path d="m5 7.3636 6.955 4.6367-6.955 4.6367z"/>
+    <path d="M 19,7.3633 12.045,12 19,16.6367 Z"/>
+  </g>
 </svg>

--- a/res/skins/LateNight/samplers/sampler.xml
+++ b/res/skins/LateNight/samplers/sampler.xml
@@ -366,14 +366,13 @@
             <Layout>horizontal</Layout>
             <SizePolicy>min,min</SizePolicy>
             <Children>
-              <Template src="skins:LateNight/controls/button_2state_right.xml">
-                <SetVariable name="TooltipId">beatsync_beatsync_tempo</SetVariable>
+              <Template src="skins:LateNight/controls/button_2state.xml">
+                <SetVariable name="TooltipId">sync_enabled</SetVariable>
                 <SetVariable name="ObjectName">SyncSampler</SetVariable>
                 <SetVariable name="Size">26f,26f</SetVariable>
                 <SetVariable name="BtnType"><Variable name="TopRegion_BtnType"/></SetVariable>
                 <SetVariable name="BtnSize">square</SetVariable>
-                <SetVariable name="ConfigKey"><Variable name="Group"/>,beatsync</SetVariable>
-                <SetVariable name="ConfigKeyRight"><Variable name="Group"/>,beatsync_tempo</SetVariable>
+                <SetVariable name="ConfigKey"><Variable name="Group"/>,sync_enabled</SetVariable>
               </Template>
             </Children>
           </WidgetGroup>

--- a/res/skins/Shade/sampler.xml
+++ b/res/skins/Shade/sampler.xml
@@ -298,23 +298,23 @@
                 <Size>204f,32f</Size>
                 <Children>
                   <PushButton>
-                    <TooltipId>beatsync_beatsync_tempo</TooltipId>
-                    <NumberStates>1</NumberStates>
+                    <TooltipId>sync_enabled</TooltipId>
+                    <NumberStates>2</NumberStates>
                     <State>
                       <Number>0</Number>
-                      <Pressed>skin:/btn/btn_sync_sampler_overdown.png</Pressed>
+                      <Pressed>skin:/btn/btn_sync_sampler_down.png</Pressed>
                       <Unpressed>skin:/btn/btn_sync_sampler.png</Unpressed>
+                    </State>
+                    <State>
+                      <Number>1</Number>
+                      <Pressed>skin:/btn/btn_sync_sampler_overdown.png</Pressed>
+                      <Unpressed>skin:/btn/btn_sync_sampler_over.png</Unpressed>
                     </State>
                     <Pos>3,4</Pos>
                     <Connection>
-                      <ConfigKey><Variable name="group"/>,beatsync</ConfigKey>
+                      <ConfigKey><Variable name="group"/>,sync_enabled</ConfigKey>
                       <EmitOnPressAndRelease>true</EmitOnPressAndRelease>
                       <ButtonState>LeftButton</ButtonState>
-                    </Connection>
-                    <Connection>
-                      <ConfigKey><Variable name="group"/>,beatsync_tempo</ConfigKey>
-                      <EmitOnPressAndRelease>true</EmitOnPressAndRelease>
-                      <ButtonState>RightButton</ButtonState>
                     </Connection>
                   </PushButton>
 

--- a/res/skins/Tango/mic_aux_sampler/sampler.xml
+++ b/res/skins/Tango/mic_aux_sampler/sampler.xml
@@ -124,14 +124,15 @@ Variables:
 
               <WidgetGroup><Size>1f,1min</Size></WidgetGroup>
 
-              <Template src="skins:Tango/controls/button_1state_right.xml">
-                <SetVariable name="TooltipId">beatsync_beatsync_tempo</SetVariable>
+              <Template src="skins:Tango/controls/button_2state.xml">
+                <SetVariable name="TooltipId">sync_enabled</SetVariable>
                 <SetVariable name="ObjectName">SamplerSyncButton</SetVariable>
                 <SetVariable name="Size">18f,18f</SetVariable>
                 <SetVariable name="state_0_unpressed">sampler_sync_off.svg</SetVariable>
                 <SetVariable name="state_0_pressed">sampler_sync_on.svg</SetVariable>
-                <SetVariable name="ConfigKey"><Variable name="group"/>,beatsync</SetVariable>
-                <SetVariable name="ConfigKeyRight"><Variable name="group"/>,beatsync_tempo</SetVariable>
+                <SetVariable name="state_1_unpressed">sampler_sync_off.svg</SetVariable>
+                <SetVariable name="state_1_pressed">sampler_sync_on.svg</SetVariable>
+                <SetVariable name="ConfigKey"><Variable name="group"/>,sync_enabled</SetVariable>
               </Template>
 
               <WidgetGroup><Size>1f,1min</Size></WidgetGroup>
@@ -337,7 +338,7 @@ Variables:
           <WidgetGroup><Size>1min,1min</Size></WidgetGroup>
 
           <Template src="skins:Tango/controls/button_1state_right.xml">
-            <SetVariable name="TooltipId">beatsync_beatsync_tempo</SetVariable>
+            <SetVariable name="TooltipId">sync_enabled</SetVariable>
             <SetVariable name="ObjectName">SamplerSyncButton</SetVariable>
             <SetVariable name="Size">18f,18f</SetVariable>
             <SetVariable name="state_0_unpressed">sampler_sync_off.svg</SetVariable>


### PR DESCRIPTION
Rebased & completed version of #13820

Make them work like decks' Sync buttons:
* use `sync_enabled`
* make them 2-state buttons

_____
Btw there's a glitch in LateNight with the sampler sync buttons:
a) there are artifacts/noise when the longpress latching animation runs
b) it seems to restart that animation on longpress RELEASE

I click 3 times, then longpress
(weird, the b) is not happening or not visible anymore)
![sync-sampler-glitch-palemoon](https://github.com/user-attachments/assets/d89b0950-f6e9-4fe3-8908-818d5cea19fe) ![sync-sampler-glitch-classic](https://github.com/user-attachments/assets/ad7fdbb5-c16f-4a70-a287-de459c6ce242)
