### PR TITLE
SoundDeviceNetwork: Fix writing wrong number of silence after a long underrun

### DIFF
--- a/src/soundio/sounddevicenetwork.cpp
+++ b/src/soundio/sounddevicenetwork.cpp
@@ -318,7 +318,7 @@ void SoundDeviceNetwork::workerWriteProcess(NetworkOutputStreamWorkerPtr pWorker
             //                 << "Catch up with silence:" << writeExpected - copyCount
             //                 << "streamTime" << pWorker->getStreamTimeFrames();;
             // catch up by filling buffer until we are synced
-            workerWriteSilence(pWorker, writeExpected - copyCount);
+            workerWriteSilence(pWorker, (writeExpected - copyCount) / m_numOutputChannels);
             m_pSoundManager->underflowHappened(24);
         } else if (writeExpected - copyCount > outChunkSize / 2) {
             // try to keep PAs buffer filled up to 0.5 chunks


### PR DESCRIPTION
This happens due to samples vs. frames issue. Now workerWrite() and workerWriteSilence() are using samples.

This saves one sample to frames roundtrip. 

This issue happens if the engine is blocked for more than one cycle. In that case silence it written. 
Before it was double of silence written, which needed later reduced frame by frame unit everything was in sync. 
Now SoundDeviceNetwork is immediately in sync which its internal clock. 