### PR TITLE
Pioneer DDJ-200: fix for hotcue issues, rewrite

### DIFF
--- a/res/controllers/Pioneer DDJ-200.midi.xml
+++ b/res/controllers/Pioneer DDJ-200.midi.xml
@@ -427,7 +427,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.decks.left.playButton.inputFaderStart</key>
+        <key>DDJ200.decks.left.faderStartButton.input</key>
         <description>Deck 1: Shift and Fader start</description>
         <status>0x90</status>
         <midino>0x66</midino>
@@ -437,7 +437,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.decks.right.playButton.inputFaderStart</key>
+        <key>DDJ200.decks.right.faderStartButton.input</key>
         <description>Deck 2: Shift and Fader start</description>
         <status>0x91</status>
         <midino>0x66</midino>
@@ -467,7 +467,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.decks.left.cueButton.inputFaderStop</key>
+        <key>DDJ200.decks.left.faderStopButton.input</key>
         <description>Deck 1: Shift and Fader stop</description>
         <status>0x90</status>
         <midino>0x52</midino>
@@ -477,7 +477,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.decks.right.cueButton.inputFaderStop</key>
+        <key>DDJ200.decks.right.faderStopButton.input</key>
         <description>Deck 2: Shift and Fader stop</description>
         <status>0x91</status>
         <midino>0x52</midino>

--- a/res/controllers/Pioneer DDJ-200.midi.xml
+++ b/res/controllers/Pioneer DDJ-200.midi.xml
@@ -7,6 +7,48 @@
     <forum>https://mixxx.discourse.group/t/new-mapping-for-pioneer-ddj-200/31164</forum>
     <manual>pioneer_ddj_200</manual>
   </info>
+  <settings>
+    <option
+      variable="defaultLoopRootSize"
+      type="enum"
+      label="Loop size of the smallest Pad in Loop Padmode">
+      <!-- values are actually exponents 2**n-->
+      <value label="1/32">-5</value>
+      <value label="1/16">-4</value>
+      <value label="1/8" default="true">-3</value>
+      <value label="1/4">-2</value>
+      <value label="1/2">-1</value>
+      <value label="1">0</value>
+      <value label="2">1</value>
+      <value label="4">2</value>
+      <value label="8">3</value>
+      <value label="16">4</value>
+      <value label="32">5</value>
+      <value label="64">6</value>
+      <value label="128">7</value>
+      <description>This specifies the smallest loop size, the larger loopsizes are automatically available on the other pads. This can also be changed on the fly using :hwbtn:SHIFT + "parameter adjust"</description>
+    </option>
+    <option
+      variable="defaultBeatJumpRootSize"
+      type="enum"
+      label="Loop size of the smallest Pad in BeatJump Padmode">
+      <!-- values are actually exponents 2**n-->
+      <value label="1/32">-5</value>
+      <value label="1/16">-4</value>
+      <value label="1/8">-3</value>
+      <value label="1/4">-2</value>
+      <value label="1/2">-1</value>
+      <value label="1" default="true">0</value>
+      <value label="2">1</value>
+      <value label="4">2</value>
+      <value label="8">3</value>
+      <value label="16">4</value>
+      <value label="32">5</value>
+      <value label="64">6</value>
+      <value label="128">7</value>
+      <description>This specifies the smallest loop size, the larger loopsizes are automatically available on the other pads. This can also be changed on the fly using :hwbtn:SHIFT + "parameter adjust"</description>
+    </option>
+  </settings>
   <controller id="DDJ-200 ALT">
     <scriptfiles>
       <file filename="midi-components-0.0.js" />
@@ -15,7 +57,7 @@
     <controls>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.shiftButton.input</key>
+        <key>DDJ200.Decks.left.shiftButton.input</key>
         <description>Deck 1: Shift pressed</description>
         <status>0x90</status>
         <midino>0x3F</midino>
@@ -25,7 +67,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.shiftButton.input</key>
+        <key>DDJ200.Decks.right.shiftButton.input</key>
         <description>Deck 2: Shift pressed</description>
         <status>0x91</status>
         <midino>0x3F</midino>
@@ -77,7 +119,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.leftDeck.pflButton.input</key>
+        <key>DDJ200.Decks.left.pflButton.input</key>
         <description>Deck 1: Headphone listen (pfl) button</description>
         <status>0x90</status>
         <midino>0x54</midino>
@@ -87,7 +129,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.leftDeck.loadTrack.input</key>
+        <key>DDJ200.Decks.left.loadTrack.input</key>
         <description>Deck 1: Headphone (pfl) + shift</description>
         <status>0x90</status>
         <midino>0x68</midino>
@@ -97,7 +139,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.rightDeck.pflButton.input</key>
+        <key>DDJ200.Decks.right.pflButton.input</key>
         <description>Deck 2: Headphone listen (pfl) button</description>
         <status>0x91</status>
         <midino>0x54</midino>
@@ -107,7 +149,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.rightDeck.loadTrack.input</key>
+        <key>DDJ200.Decks.right.loadTrack.input</key>
         <description>Deck 2: Headphone (pfl) + shift</description>
         <status>0x91</status>
         <midino>0x68</midino>
@@ -117,7 +159,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.leftDeck.syncButton.input</key>
+        <key>DDJ200.Decks.left.syncButton.input</key>
         <description>Deck 1: Tap to sync tempo (and phase with quantize enabled), hold to enable permanent sync</description>
         <status>0x90</status>
         <midino>0x58</midino>
@@ -127,7 +169,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.rightDeck.syncButton.input</key>
+        <key>DDJ200.Decks.right.syncButton.input</key>
         <description>Deck 2: Tap to sync tempo (and phase with quantize enabled), hold to enable permanent sync</description>
         <status>0x91</status>
         <midino>0x58</midino>
@@ -137,7 +179,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.leftDeck.syncButton.inputLongPress</key>
+        <key>DDJ200.Decks.left.syncButton.inputLongPress</key>
         <description>Deck 1: Long Press to enable permanent sync</description>
         <status>0x90</status>
         <midino>0x5C</midino>
@@ -147,7 +189,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.rightDeck.syncButton.inputLongPress</key>
+        <key>DDJ200.Decks.right.syncButton.inputLongPress</key>
         <description>Deck 2: Long Press to enable permanent sync</description>
         <status>0x91</status>
         <midino>0x5C</midino>
@@ -157,7 +199,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.leftDeck.syncButton.shiftedInput</key>
+        <key>DDJ200.Decks.left.syncButton.shiftedInput</key>
         <description>Deck 1: Shift Tap to sync tempo (and phase with quantize enabled), hold to enable permanent sync</description>
         <status>0x90</status>
         <midino>0x60</midino>
@@ -167,7 +209,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.rightDeck.syncButton.shiftedInput</key>
+        <key>DDJ200.Decks.right.syncButton.shiftedInput</key>
         <description>Deck 2: Shift Tap to sync tempo (and phase with quantize enabled), hold to enable permanent sync</description>
         <status>0x91</status>
         <midino>0x60</midino>
@@ -177,7 +219,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.leftDeck.jogWheel.inputSeek</key>
+        <key>DDJ200.Decks.left.jogWheel.inputSeek</key>
         <description>Deck 1: Seek</description>
         <status>0xB0</status>
         <midino>0x29</midino>
@@ -187,7 +229,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.rightDeck.jogWheel.inputSeek</key>
+        <key>DDJ200.Decks.right.jogWheel.inputSeek</key>
         <description>Deck 2: Seek</description>
         <status>0xB1</status>
         <midino>0x29</midino>
@@ -207,7 +249,7 @@
       </control>
       <control>
         <group>[AutoDJ]</group>
-        <key>DDJ200.transFxButton.input</key>
+        <key>DDJ200.transFxButton.shiftedInput</key>
         <description>Change Pad mode</description>
         <status>0x96</status>
         <midino>0x5A</midino>
@@ -217,7 +259,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.leftDeck.jogWheel.inputTouch</key>
+        <key>DDJ200.Decks.left.jogWheel.inputTouch</key>
         <description>Deck 1: Touch</description>
         <status>0x90</status>
         <midino>0x36</midino>
@@ -227,7 +269,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.rightDeck.jogWheel.inputTouch</key>
+        <key>DDJ200.Decks.right.jogWheel.inputTouch</key>
         <description>Deck 2: Touch</description>
         <status>0x91</status>
         <midino>0x36</midino>
@@ -237,7 +279,7 @@
       </control>
       <control>
         <group>[EqualizerRack1_[Channel1]_Effect1]</group>
-        <key>DDJ200.leftDeck.eqKnob[0].input</key>
+        <key>DDJ200.Decks.left.eqKnob[0].input</key>
         <description>Deck 1: Adjust Low EQ</description>
         <status>0xB0</status>
         <midino>0x0F</midino>
@@ -247,7 +289,7 @@
       </control>
       <control>
         <group>[EqualizerRack1_[Channel1]_Effect1]</group>
-        <key>DDJ200.leftDeck.eqKnob[1].input</key>
+        <key>DDJ200.Decks.left.eqKnob[1].input</key>
         <description>Deck 1: Adjust Mid EQ</description>
         <status>0xB0</status>
         <midino>0x0B</midino>
@@ -257,7 +299,7 @@
       </control>
       <control>
         <group>[EqualizerRack1_[Channel1]_Effect1]</group>
-        <key>DDJ200.leftDeck.eqKnob[2].input</key>
+        <key>DDJ200.Decks.left.eqKnob[2].input</key>
         <description>Deck 1: Adjust High EQ</description>
         <status>0xB0</status>
         <midino>0x07</midino>
@@ -267,7 +309,7 @@
       </control>
       <control>
         <group>[QuickEffectRack1_[Channel1]]</group>
-        <key>DDJ200.leftDeck.super1.input</key>
+        <key>DDJ200.Decks.left.super1.input</key>
         <description>Super Knob (msb): control linked effect</description>
         <status>0xB6</status>
         <midino>0x17</midino>
@@ -277,7 +319,7 @@
       </control>
       <control>
         <group>[EqualizerRack1_[Channel2]_Effect1]</group>
-        <key>DDJ200.rightDeck.eqKnob[0].input</key>
+        <key>DDJ200.Decks.right.eqKnob[0].input</key>
         <description>Deck 2: Adjust Low EQ</description>
         <status>0xB1</status>
         <midino>0x0F</midino>
@@ -287,7 +329,7 @@
       </control>
       <control>
         <group>[EqualizerRack1_[Channel2]_Effect1]</group>
-        <key>DDJ200.rightDeck.eqKnob[1].input</key>
+        <key>DDJ200.Decks.right.eqKnob[1].input</key>
         <description>Deck 2: Adjust Mid EQ</description>
         <status>0xB1</status>
         <midino>0x0B</midino>
@@ -297,7 +339,7 @@
       </control>
       <control>
         <group>[EqualizerRack1_[Channel2]_Effect1]</group>
-        <key>DDJ200.rightDeck.eqKnob[2].input</key>
+        <key>DDJ200.Decks.right.eqKnob[2].input</key>
         <description>Deck 2: Adjust High EQ</description>
         <status>0xB1</status>
         <midino>0x07</midino>
@@ -307,7 +349,7 @@
       </control>
       <control>
         <group>[QuickEffectRack1_[Channel2]]</group>
-        <key>DDJ200.rightDeck.super1.input</key>
+        <key>DDJ200.Decks.right.super1.input</key>
         <description>Quick Effect: Quick Effect Super Knob (control linked effect parameters)</description>
         <status>0xB6</status>
         <midino>0x18</midino>
@@ -317,7 +359,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.leftDeck.volume.inputMSB</key>
+        <key>DDJ200.Decks.left.volume.inputMSB</key>
         <description>Deck 1: Volume Fader</description>
         <status>0xB0</status>
         <midino>0x13</midino>
@@ -327,7 +369,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.leftDeck.volume.inputLSB</key>
+        <key>DDJ200.Decks.left.volume.inputLSB</key>
         <description>Deck 1: Volume Fader</description>
         <status>0xB0</status>
         <midino>0x33</midino>
@@ -337,7 +379,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.rightDeck.volume.inputMSB</key>
+        <key>DDJ200.Decks.right.volume.inputMSB</key>
         <description>Deck 2: Volume Fader</description>
         <status>0xB1</status>
         <midino>0x13</midino>
@@ -347,7 +389,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.rightDeck.volume.inputLSB</key>
+        <key>DDJ200.Decks.right.volume.inputLSB</key>
         <description>Deck 2: Volume Fader</description>
         <status>0xB1</status>
         <midino>0x33</midino>
@@ -357,7 +399,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.leftDeck.playButton.input</key>
+        <key>DDJ200.Decks.left.playButton.input</key>
         <description>Deck 1: Play button</description>
         <status>0x90</status>
         <midino>0x0B</midino>
@@ -367,7 +409,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.rightDeck.playButton.input</key>
+        <key>DDJ200.Decks.right.playButton.input</key>
         <description>Deck 2: Play button</description>
         <status>0x91</status>
         <midino>0x0B</midino>
@@ -377,7 +419,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.leftDeck.playButton.inputFaderStart</key>
+        <key>DDJ200.Decks.left.playButton.inputFaderStart</key>
         <description>Deck 1: Shift and Fader start</description>
         <status>0x90</status>
         <midino>0x66</midino>
@@ -387,7 +429,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.rightDeck.playButton.inputFaderStart</key>
+        <key>DDJ200.Decks.right.playButton.inputFaderStart</key>
         <description>Deck 2: Shift and Fader start</description>
         <status>0x91</status>
         <midino>0x66</midino>
@@ -397,7 +439,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.leftDeck.cueButton.input</key>
+        <key>DDJ200.Decks.left.cueButton.input</key>
         <description>Deck 1: Cue button</description>
         <status>0x90</status>
         <midino>0x0C</midino>
@@ -407,7 +449,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.rightDeck.cueButton.input</key>
+        <key>DDJ200.Decks.right.cueButton.input</key>
         <description>Deck 2: Cue button</description>
         <status>0x91</status>
         <midino>0x0C</midino>
@@ -417,7 +459,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.leftDeck.cueButton.inputFaderStop</key>
+        <key>DDJ200.Decks.left.cueButton.inputFaderStop</key>
         <description>Deck 1: Shift and Fader stop</description>
         <status>0x90</status>
         <midino>0x52</midino>
@@ -427,7 +469,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.rightDeck.cueButton.inputFaderStop</key>
+        <key>DDJ200.Decks.right.cueButton.inputFaderStop</key>
         <description>Deck 2: Shift and Fader stop</description>
         <status>0x91</status>
         <midino>0x52</midino>
@@ -437,7 +479,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.leftDeck.cueButton.input</key>
+        <key>DDJ200.Decks.left.cueButton.input</key>
         <description>Deck 1: Go to cue point and stop</description>
         <status>0x90</status>
         <midino>0x48</midino>
@@ -447,7 +489,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.rightDeck.cueButton.input</key>
+        <key>DDJ200.Decks.right.cueButton.input</key>
         <description>Deck 2: Go to cue point and stop</description>
         <status>0x91</status>
         <midino>0x48</midino>
@@ -457,7 +499,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.leftDeck.rate.inputMSB</key>
+        <key>DDJ200.Decks.left.rate.inputMSB</key>
         <description>Deck 1: Playback speed control</description>
         <status>0xB0</status>
         <midino>0x00</midino>
@@ -468,7 +510,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.leftDeck.rate.inputLSB</key>
+        <key>DDJ200.Decks.left.rate.inputLSB</key>
         <description>Deck 1: Playback speed control</description>
         <status>0xB0</status>
         <midino>0x20</midino>
@@ -479,7 +521,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.rightDeck.rate.inputMSB</key>
+        <key>DDJ200.Decks.right.rate.inputMSB</key>
         <description>Deck 2: Playback speed control</description>
         <status>0xB1</status>
         <midino>0x00</midino>
@@ -489,7 +531,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.rightDeck.rate.inputLSB</key>
+        <key>DDJ200.Decks.right.rate.inputLSB</key>
         <description>Deck 2: Playback speed control</description>
         <status>0xB1</status>
         <midino>0x20</midino>
@@ -499,7 +541,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.leftDeck.jogWheel.inputWheel</key>
+        <key>DDJ200.Decks.left.jogWheel.inputWheel</key>
         <description>Deck 1: Jog</description>
         <status>0xB0</status>
         <midino>0x21</midino>
@@ -509,7 +551,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.rightDeck.jogWheel.inputWheel</key>
+        <key>DDJ200.Decks.right.jogWheel.inputWheel</key>
         <description>Deck 2: Jog</description>
         <status>0xB1</status>
         <midino>0x21</midino>
@@ -519,7 +561,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.rightDeck.jogWheel.inputWheel</key>
+        <key>DDJ200.Decks.right.jogWheel.inputWheel</key>
         <description>Deck 2: Scratch</description>
         <status>0xB1</status>
         <midino>0x22</midino>
@@ -529,7 +571,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.leftDeck.jogWheel.inputWheel</key>
+        <key>DDJ200.Decks.left.jogWheel.inputWheel</key>
         <description>Deck 1: Scratch</description>
         <status>0xB0</status>
         <midino>0x22</midino>
@@ -539,7 +581,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.rightDeck.jogWheel.inputWheel</key>
+        <key>DDJ200.Decks.right.jogWheel.inputWheel</key>
         <description>Deck 2: Scratch</description>
         <status>0xB1</status>
         <midino>0x23</midino>
@@ -549,7 +591,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.leftDeck.jogWheel.inputWheel</key>
+        <key>DDJ200.Decks.left.jogWheel.inputWheel</key>
         <description>Deck 1: Scratch</description>
         <status>0xB0</status>
         <midino>0x23</midino>
@@ -559,7 +601,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.leftDeck.playButton.input</key>
+        <key>DDJ200.Decks.left.playButton.input</key>
         <description>Deck 1: Shift Play</description>
         <status>0x90</status>
         <midino>0x47</midino>
@@ -569,7 +611,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.rightDeck.playButton.input</key>
+        <key>DDJ200.Decks.right.playButton.input</key>
         <description>Deck 2: Shift Play</description>
         <status>0x91</status>
         <midino>0x47</midino>
@@ -580,7 +622,7 @@
       <!-- ##### Hotcues ##### -->
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.leftDeck.pads[0].input</key>
+        <key>DDJ200.Decks.left.padUnit.choosenPadInstance.pads[0].input</key>
         <description>Hotcue 1, Deck 1: Set, preview, jump to</description>
         <status>0x97</status>
         <midino>0x00</midino>
@@ -590,7 +632,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.leftDeck.pads[1].input</key>
+        <key>DDJ200.Decks.left.padUnit.choosenPadInstance.pads[1].input</key>
         <description>Hotcue 2, Deck 1: Set, preview, jump to</description>
         <status>0x97</status>
         <midino>0x01</midino>
@@ -600,7 +642,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.leftDeck.pads[2].input</key>
+        <key>DDJ200.Decks.left.padUnit.choosenPadInstance.pads[2].input</key>
         <description>Hotcue 3, Deck 1: Set, preview, jump to</description>
         <status>0x97</status>
         <midino>0x02</midino>
@@ -610,7 +652,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.leftDeck.pads[3].input</key>
+        <key>DDJ200.Decks.left.padUnit.choosenPadInstance.pads[3].input</key>
         <description>Hotcue 4, Deck 1: Set, preview, jump to</description>
         <status>0x97</status>
         <midino>0x03</midino>
@@ -620,7 +662,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.leftDeck.pads[4].input</key>
+        <key>DDJ200.Decks.left.padUnit.choosenPadInstance.pads[4].input</key>
         <description>Hotcue 5, Deck 1: Set, preview, jump to</description>
         <status>0x97</status>
         <midino>0x04</midino>
@@ -630,7 +672,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.leftDeck.pads[5].input</key>
+        <key>DDJ200.Decks.left.padUnit.choosenPadInstance.pads[5].input</key>
         <description>Hotcue 6, Deck 1: Set, preview, jump to</description>
         <status>0x97</status>
         <midino>0x05</midino>
@@ -640,7 +682,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.leftDeck.pads[6].input</key>
+        <key>DDJ200.Decks.left.padUnit.choosenPadInstance.pads[6].input</key>
         <description>Hotcue 7, Deck 1: Set, preview, jump to</description>
         <status>0x97</status>
         <midino>0x06</midino>
@@ -650,7 +692,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.leftDeck.pads[7].input</key>
+        <key>DDJ200.Decks.left.padUnit.choosenPadInstance.pads[7].input</key>
         <description>Hotcue 8, Deck 1: Set, preview, jump to</description>
         <status>0x97</status>
         <midino>0x07</midino>
@@ -660,7 +702,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.rightDeck.pads[0].input</key>
+        <key>DDJ200.Decks.right.padUnit.choosenPadInstance.pads[0].input</key>
         <description>Hotcue 1, Deck 2: Set, preview, jump to</description>
         <status>0x99</status>
         <midino>0x00</midino>
@@ -670,7 +712,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.rightDeck.pads[1].input</key>
+        <key>DDJ200.Decks.right.padUnit.choosenPadInstance.pads[1].input</key>
         <description>Hotcue 2, Deck 2: Set, preview, jump to</description>
         <status>0x99</status>
         <midino>0x01</midino>
@@ -680,7 +722,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.rightDeck.pads[2].input</key>
+        <key>DDJ200.Decks.right.padUnit.choosenPadInstance.pads[2].input</key>
         <description>Hotcue 3, Deck 2: Set, preview, jump to</description>
         <status>0x99</status>
         <midino>0x02</midino>
@@ -690,7 +732,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.rightDeck.pads[3].input</key>
+        <key>DDJ200.Decks.right.padUnit.choosenPadInstance.pads[3].input</key>
         <description>Hotcue 4, Deck 2: Set, preview, jump to</description>
         <status>0x99</status>
         <midino>0x03</midino>
@@ -700,7 +742,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.rightDeck.pads[4].input</key>
+        <key>DDJ200.Decks.right.padUnit.choosenPadInstance.pads[4].input</key>
         <description>Hotcue 5, Deck 2: Set, preview, jump to</description>
         <status>0x99</status>
         <midino>0x04</midino>
@@ -710,7 +752,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.rightDeck.pads[5].input</key>
+        <key>DDJ200.Decks.right.padUnit.choosenPadInstance.pads[5].input</key>
         <description>Hotcue 6, Deck 2: Set, preview, jump to</description>
         <status>0x99</status>
         <midino>0x05</midino>
@@ -720,7 +762,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.rightDeck.pads[6].input</key>
+        <key>DDJ200.Decks.right.padUnit.choosenPadInstance.pads[6].input</key>
         <description>Hotcue 7, Deck 2: Set, preview, jump to</description>
         <status>0x99</status>
         <midino>0x06</midino>
@@ -730,7 +772,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.rightDeck.pads[7].input</key>
+        <key>DDJ200.Decks.right.padUnit.choosenPadInstance.pads[7].input</key>
         <description>Hotcue 8, Deck 2: Set, preview, jump to</description>
         <status>0x99</status>
         <midino>0x07</midino>
@@ -740,7 +782,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.leftDeck.pads[0].shiftedInput</key>
+        <key>DDJ200.Decks.left.padUnit.choosenPadInstance.pads[0].input</key>
         <description>Hotcue 1, Deck 1: Clear</description>
         <status>0x98</status>
         <midino>0x00</midino>
@@ -750,7 +792,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.leftDeck.pads[1].shiftedInput</key>
+        <key>DDJ200.Decks.left.padUnit.choosenPadInstance.pads[1].input</key>
         <description>Hotcue 2, Deck 1: Clear</description>
         <status>0x98</status>
         <midino>0x01</midino>
@@ -760,7 +802,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.leftDeck.pads[2].shiftedInput</key>
+        <key>DDJ200.Decks.left.padUnit.choosenPadInstance.pads[2].input</key>
         <description>Hotcue 3, Deck 1: Clear</description>
         <status>0x98</status>
         <midino>0x02</midino>
@@ -770,7 +812,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.leftDeck.pads[3].shiftedInput</key>
+        <key>DDJ200.Decks.left.padUnit.choosenPadInstance.pads[3].input</key>
         <description>Hotcue 4, Deck 1: Clear</description>
         <status>0x98</status>
         <midino>0x03</midino>
@@ -780,7 +822,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.leftDeck.pads[4].shiftedInput</key>
+        <key>DDJ200.Decks.left.padUnit.choosenPadInstance.pads[4].input</key>
         <description>Hotcue 5, Deck 1: Clear</description>
         <status>0x98</status>
         <midino>0x04</midino>
@@ -790,7 +832,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.leftDeck.pads[5].shiftedInput</key>
+        <key>DDJ200.Decks.left.padUnit.choosenPadInstance.pads[5].input</key>
         <description>Hotcue 6, Deck 1: Clear</description>
         <status>0x98</status>
         <midino>0x05</midino>
@@ -800,7 +842,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.leftDeck.pads[6].shiftedInput</key>
+        <key>DDJ200.Decks.left.padUnit.choosenPadInstance.pads[6].input</key>
         <description>Hotcue 7, Deck 1: Clear</description>
         <status>0x98</status>
         <midino>0x06</midino>
@@ -810,7 +852,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.leftDeck.pads[7].shiftedInput</key>
+        <key>DDJ200.Decks.left.padUnit.choosenPadInstance.pads[7].input</key>
         <description>Hotcue 8, Deck 1: Clear</description>
         <status>0x98</status>
         <midino>0x07</midino>
@@ -820,7 +862,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.rightDeck.pads[0].shiftedInput</key>
+        <key>DDJ200.Decks.right.padUnit.choosenPadInstance.pads[0].input</key>
         <description>Hotcue 1, Deck 2: Clear</description>
         <status>0x9A</status>
         <midino>0x00</midino>
@@ -830,7 +872,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.rightDeck.pads[1].shiftedInput</key>
+        <key>DDJ200.Decks.right.padUnit.choosenPadInstance.pads[1].input</key>
         <description>Hotcue 2, Deck 2: Clear</description>
         <status>0x9A</status>
         <midino>0x01</midino>
@@ -840,7 +882,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.rightDeck.pads[2].shiftedInput</key>
+        <key>DDJ200.Decks.right.padUnit.choosenPadInstance.pads[2].input</key>
         <description>Hotcue 3, Deck 2: Clear</description>
         <status>0x9A</status>
         <midino>0x02</midino>
@@ -850,7 +892,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.rightDeck.pads[3].shiftedInput</key>
+        <key>DDJ200.Decks.right.padUnit.choosenPadInstance.pads[3].input</key>
         <description>Hotcue 4, Deck 2: Clear</description>
         <status>0x9A</status>
         <midino>0x03</midino>
@@ -860,7 +902,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.rightDeck.pads[4].shiftedInput</key>
+        <key>DDJ200.Decks.right.padUnit.choosenPadInstance.pads[4].input</key>
         <description>Hotcue 5, Deck 2: Clear</description>
         <status>0x9A</status>
         <midino>0x04</midino>
@@ -870,7 +912,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.rightDeck.pads[5].shiftedInput</key>
+        <key>DDJ200.Decks.right.padUnit.choosenPadInstance.pads[5].input</key>
         <description>Hotcue 6, Deck 2: Clear</description>
         <status>0x9A</status>
         <midino>0x05</midino>
@@ -880,7 +922,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.rightDeck.pads[6].shiftedInput</key>
+        <key>DDJ200.Decks.right.padUnit.choosenPadInstance.pads[6].input</key>
         <description>Hotcue 7, Deck 2: Clear</description>
         <status>0x9A</status>
         <midino>0x06</midino>
@@ -890,7 +932,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.rightDeck.pads[7].shiftedInput</key>
+        <key>DDJ200.Decks.right.padUnit.choosenPadInstance.pads[7].input</key>
         <description>Hotcue 8, Deck 2: Clear</description>
         <status>0x9A</status>
         <midino>0x07</midino>

--- a/res/controllers/Pioneer DDJ-200.midi.xml
+++ b/res/controllers/Pioneer DDJ-200.midi.xml
@@ -1,959 +1,903 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <MixxxControllerPreset schemaVersion="1" mixxxVersion="2.0.0+">
-    <info>
-        <name>Pioneer DDJ-200</name>
-        <author>Dan Giddins, Frank.Breitling at gmx.de</author>
-        <description>2-deck USB and Bluetooth MIDI controller with support for 4-deck mode.</description>
-        <forum>https://mixxx.discourse.group/t/pioneer-ddj-200-mapping/18259</forum>
-        <manual>pioneer_ddj_200</manual>
-    </info>
-    <controller id="DDJ-200">
-        <scriptfiles>
-            <file functionprefix="DDJ200" filename="Pioneer-DDJ-200-scripts.js"/>
-        </scriptfiles>
-        <controls>
-            <control>
-                <group>[Master]</group>
-                <key>crossfader</key>
-                <description>Master crossfader</description>
-                <status>0xB6</status>
-                <midino>0x1F</midino>
-                <options>
-                    <soft-takeover/>
-                    <fourteen-bit-msb/>
-                </options>
-            </control>
-            <control>
-                <group>[Master]</group>
-                <key>crossfader</key>
-                <description>Master crossfader</description>
-                <status>0xB6</status>
-                <midino>0x3F</midino>
-                <options>
-                    <soft-takeover/>
-                    <fourteen-bit-lsb/>
-                </options>
-            </control>
-
-            <control>
-                <group>[Master]</group>
-                <key>DDJ200.headmix</key>
-                <description>Headphones master as headMix knob</description>
-                <status>0x96</status>
-                <midino>0x63</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Master]</group>
-                <key>DDJ200.toggleFourDeckMode</key>
-                <description>Headphones master + shift</description>
-                <status>0x96</status>
-                <midino>0x78</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-
-            <control>
-                <group>[Channel1]</group>
-                <key>DDJ200.shiftLeft</key>
-                <description>Deck 1: Shift pressed</description>
-                <status>0x90</status>
-                <midino>0x3F</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>DDJ200.shiftRight</key>
-                <description>Deck 2: Shift pressed</description>
-                <status>0x91</status>
-                <midino>0x3F</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-
-            <control>
-                <group>[Channel1]</group>
-                <key>DDJ200.pfl</key>
-                <description>Deck 1: Headphone listen (pfl) button</description>
-                <status>0x90</status>
-                <midino>0x54</midino>
-                <options>
-                     <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>DDJ200.toggleDeck</key>
-                <description>Deck 1: Headphone (pfl) + shift</description>
-                <status>0x90</status>
-                <midino>0x68</midino>
-                <options>
-                     <script-binding/>
-                </options>
-            </control>
-
-            <control>
-                <group>[Channel2]</group>
-                <key>DDJ200.pfl</key>
-                <description>Deck 2: Headphone listen (pfl) button</description>
-                <status>0x91</status>
-                <midino>0x54</midino>
-                <options>
-                     <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>DDJ200.toggleDeck</key>
-                <description>Deck 2: Headphone (pfl) + shift</description>
-                <status>0x91</status>
-                <midino>0x68</midino>
-                <options>
-                     <script-binding/>
-                </options>
-            </control>
-
-            <control>
-                <group>[Channel1]</group>
-                <key>DDJ200.syncEnabled</key>
-                <description>Deck 1: Tap to sync tempo (and phase with quantize enabled), hold to enable permanent sync</description>
-                <status>0x90</status>
-                <midino>0x58</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>DDJ200.syncEnabled</key>
-                <description>Deck 2: Tap to sync tempo (and phase with quantize enabled), hold to enable permanent sync</description>
-                <status>0x91</status>
-                <midino>0x58</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-
-            <control>
-                <group>[Channel2]</group>
-                <key>DDJ200.seek</key>
-                <description>Deck 2: Seek</description>
-                <status>0xB1</status>
-                <midino>0x29</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>DDJ200.seek</key>
-                <description>Deck 1: Seek</description>
-                <status>0xB0</status>
-                <midino>0x29</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-
-            <control>
-                <group>[AutoDJ]</group>
-                <key>enabled</key>
-                <description>Toggle Auto DJ On/Off</description>
-                <status>0x96</status>
-                <midino>0x59</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[AutoDJ]</group>
-                <key>fade_now</key>
-                <description>Trigger the transition to the next track</description>
-                <status>0x96</status>
-                <midino>0x5A</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-
-            <control>
-                <group>[Channel2]</group>
-                <key>DDJ200.touch</key>
-                <description>Deck 2: Touch</description>
-                <status>0x91</status>
-                <midino>0x36</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>DDJ200.touch</key>
-                <description>Deck 1: Touch</description>
-                <status>0x90</status>
-                <midino>0x36</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-
-
-            <control>
-                <group>[EqualizerRack1_[Channel1]_Effect1]</group>
-                <!--key>parameter1</key-->
-                <key>DDJ200.eq</key>
-                <description>Deck 1: Adjust Low EQ</description>
-                <status>0xB0</status>
-                <midino>0x0F</midino>
-                <options>
-                    <script-binding/>
-                    <!--fourteen-bit-msb/-->
-                </options>
-            </control>
-            <!--control>
-                <group>[EqualizerRack1_[Channel1]_Effect1]</group>
-                <key>parameter1</key>
-                <description>Deck 1: Adjust Low EQ</description>
-                <status>0xB0</status>
-                <midino>0x2F</midino>
-                <options>
-                    <fourteen-bit-lsb/>
-                </options>
-            </control-->
-            <control>
-                <group>[EqualizerRack1_[Channel1]_Effect1]</group>
-                <!--key>parameter2</key-->
-                <key>DDJ200.eq</key>
-                <description>Deck 1: Adjust Mid EQ</description>
-                <status>0xB0</status>
-                <midino>0x0B</midino>
-                <options>
-                    <script-binding/>
-                    <!--fourteen-bit-msb/-->
-                </options>
-            </control>
-            <!--control>
-                <group>[EqualizerRack1_[Channel1]_Effect1]</group>
-                <key>parameter2</key>
-                <description>Deck 1: Adjust Mid EQ</description>
-                <status>0xB0</status>
-                <midino>0x2B</midino>
-                <options>
-                    <fourteen-bit-lsb/>
-                </options>
-            </control-->
-            <control>
-                <group>[EqualizerRack1_[Channel1]_Effect1]</group>
-                <key>DDJ200.eq</key>
-                <!--key>parameter3</key-->
-                <description>Deck 1: Adjust High EQ</description>
-                <status>0xB0</status>
-                <midino>0x07</midino>
-                <options>
-                    <script-binding/>
-                    <!--fourteen-bit-msb/-->
-                </options>
-            </control>
-            <!--control>
-                <group>[EqualizerRack1_[Channel1]_Effect1]</group>
-                <key>parameter3</key>
-                <description>Deck 1: Adjust High EQ</description>
-                <status>0xB0</status>
-                <midino>0x27</midino>
-                <options>
-                    <fourteen-bit-lsb/>
-                </options>
-            </control-->
-
-            <control>
-                <group>[QuickEffectRack1_[Channel1]]</group>
-                <key>DDJ200.super1</key>
-                <description>Super Knob (msb): control linked effect</description>
-                <status>0xB6</status>
-                <midino>0x17</midino>
-                <!--midino>lsb: 0x37</midino-->
-                <options>
-                    <script-binding/>
-                    <!--fourteen-bit-msb/-->
-                </options>
-            </control>
-
-            <control>
-                <group>[EqualizerRack1_[Channel2]_Effect1]</group>
-                <!--key>parameter1</key-->
-                <key>DDJ200.eq</key>
-                <description>Deck 2: Adjust Low EQ</description>
-                <status>0xB1</status>
-                <midino>0x0F</midino>
-                <options>
-                    <script-binding/>
-                    <!--fourteen-bit-msb/-->
-                </options>
-            </control>
-            <!--control>
-                <group>[EqualizerRack1_[Channel1]_Effect1]</group>
-                <key>parameter1</key>
-                <description>Deck 2: Adjust Low EQ</description>
-                <status>0xB1</status>
-                <midino>0x2F</midino>
-                <options>
-                    <fourteen-bit-lsb/>
-                </options>
-            </control-->
-            <control>
-                <group>[EqualizerRack1_[Channel2]_Effect1]</group>
-                <!--key>parameter2</key-->
-                <key>DDJ200.eq</key>
-                <description>Deck 2: Adjust Mid EQ</description>
-                <status>0xB1</status>
-                <midino>0x0B</midino>
-                <options>
-                    <script-binding/>
-                    <!--fourteen-bit-msb/-->
-                </options>
-            </control>
-            <!--control>
-                <group>[EqualizerRack1_[Channel2]_Effect1]</group>
-                <key>parameter2</key>
-                <description>Deck 2: Adjust Mid EQ</description>
-                <status>0xB1</status>
-                <midino>0x2B</midino>
-                <options>
-                    <fourteen-bit-lsb/>
-                </options>
-            </control-->
-            <control>
-                <group>[EqualizerRack1_[Channel2]_Effect1]</group>
-                <!--key>parameter3</key-->
-                <key>DDJ200.eq</key>
-                <description>Deck 2: Adjust High EQ</description>
-                <status>0xB1</status>
-                <midino>0x07</midino>
-                <options>
-                    <script-binding/>
-                    <!--fourteen-bit-msb/-->
-                </options>
-            </control>
-            <!--control>
-                <group>[EqualizerRack1_[Channel2]_Effect1]</group>
-                <key>parameter3</key>
-                <description>Deck 2: Adjust High EQ</description>
-                <status>0xB1</status>
-                <midino>0x27</midino>
-                <options>
-                    <fourteen-bit-lsb/>
-                </options>
-            </control-->
-
-            <control>
-                <group>[QuickEffectRack1_[Channel2]]</group>
-                <key>DDJ200.super1</key>
-                <description>Quick Effect: Quick Effect Super Knob (control linked effect parameters)</description>
-                <status>0xB6</status>
-                <midino>0x18</midino>
-                <options>
-                    <script-binding/>
-                    <!--fourteen-bit-msb/-->
-                </options>
-            </control>
-
-            <control>
-                <group>[Channel1]</group>
-                <key>bpm_tap</key>
-                <description>Deck 1: BPM tap button</description>
-                <status>0x90</status>
-                <midino>0x60</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>bpm_tap</key>
-                <description>Deck 2: BPM tap button</description>
-                <status>0x91</status>
-                <midino>0x60</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-
-            <control>
-                <group>[Channel1]</group>
-                <!--key>volume</key-->
-                <key>DDJ200.volumeMSB</key>
-                <description>Deck 1: Volume Fader</description>
-                <status>0xB0</status>
-                <midino>0x13</midino>
-                <options>
-                    <script-binding/>
-                    <!--fourteen-bit-msb/-->
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>DDJ200.volumeLSB</key>
-                <description>Deck 1: Volume Fader</description>
-                <status>0xB0</status>
-                <midino>0x33</midino>
-                <options>
-                    <script-binding/>
-                    <!--fourteen-bit-lsb/-->
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>DDJ200.volumeMSB</key>
-                <description>Deck 2: Volume Fader</description>
-                <status>0xB1</status>
-                <midino>0x13</midino>
-                <options>
-                    <script-binding/>
-                    <!--fourteen-bit-msb/-->
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>DDJ200.volumeLSB</key>
-                <description>Deck 2: Volume Fader</description>
-                <status>0xB1</status>
-                <midino>0x33</midino>
-                <options>
-                    <script-binding/>
-                    <!--fourteen-bit-lsb/-->
-                </options>
-            </control>
-
-            <control>
-                <group>[Channel1]</group>
-                <key>DDJ200.play</key>
-                <description>Deck 1: Play button</description>
-                <status>0x90</status>
-                <midino>0x0B</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>DDJ200.play</key>
-                <description>Deck 2: Play button</description>
-                <status>0x91</status>
-                <midino>0x0B</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-
-            <control>
-                <group>[Channel1]</group>
-                <!--key>cue_default</key-->
-                <key>DDJ200.cueDefault</key>
-                <description>Deck 1: Cue button</description>
-                <status>0x90</status>
-                <midino>0x0C</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>DDJ200.cueDefault</key>
-                <description>Deck 2:  Cue button</description>
-                <status>0x91</status>
-                <midino>0x0C</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>DDJ200.cueGotoandstop</key>
-                <description>Deck 1: Go to cue point and stop</description>
-                <status>0x90</status>
-                <midino>0x48</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>DDJ200.cueGotoandstop</key>
-                <description>Deck 2: Go to cue point and stop</description>
-                <status>0x91</status>
-                <midino>0x48</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-
-            <control>
-                <group>[Channel1]</group>
-                <key>DDJ200.rateMSB</key>
-                <description>Deck 1: Playback speed control</description>
-                <status>0xB0</status>
-                <midino>0x00</midino>
-                <options>
-                    <script-binding/>
-                    <soft-takeover/>
-                    <!--fourteen-bit-msb/-->
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>DDJ200.rateLSB</key>
-                <description>Deck 1: Playback speed control</description>
-                <status>0xB0</status>
-                <midino>0x20</midino>
-                <options>
-                    <soft-takeover/>
-                    <script-binding/>
-                    <!--fourteen-bit-lsb/-->
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>DDJ200.rateMSB</key>
-                <description>Deck 2: Playback speed control</description>
-                <status>0xB1</status>
-                <midino>0x00</midino>
-                <options>
-                    <script-binding/>
-                    <!--fourteen-bit-msb/-->
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>DDJ200.rateLSB</key>
-                <description>Deck 2: Playback speed control</description>
-                <status>0xB1</status>
-                <midino>0x20</midino>
-                <options>
-                    <script-binding/>
-                    <!--fourteen-bit-lsb/-->
-                </options>
-            </control>
-
-            <control>
-                <group>[Channel2]</group>
-                <key>DDJ200.jog</key>
-                <description>Deck 2: Jog</description>
-                <status>0xB1</status>
-                <midino>0x21</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>DDJ200.jog</key>
-                <description>Deck 1: Jog</description>
-                <status>0xB0</status>
-                <midino>0x21</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>DDJ200.scratch</key>
-                <description>Deck 2: Scratch</description>
-                <status>0xB1</status>
-                <midino>0x22</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>DDJ200.scratch</key>
-                <description>Deck 1: Scratch</description>
-                <status>0xB0</status>
-                <midino>0x22</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-
-
-            <control>
-                <group>[Channel2]</group>
-                <key>cue_set</key>
-                <description>Deck 2: Set cue point</description>
-                <status>0x91</status>
-                <midino>0x47</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>cue_set</key>
-                <description>Deck 1: Set cue point</description>
-                <status>0x90</status>
-                <midino>0x47</midino>
-                <options>
-                    <normal/>
-                </options>
-            </control>
-
-<!-- ##### Hotcues ##### -->
-            <control>
-                <group>[Channel1]</group>
-                <key>DDJ200.hotcueNActivate</key>
-                <description>Hotcue 1, Deck 1: Set, preview, jump to</description>
-                <status>0x97</status>
-                <midino>0x00</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>DDJ200.hotcueNActivate</key>
-                <description>Hotcue 2, Deck 1: Set, preview, jump to</description>
-                <status>0x97</status>
-                <midino>0x01</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>DDJ200.hotcueNActivate</key>
-                <description>Hotcue 3, Deck 1: Set, preview, jump to</description>
-                <status>0x97</status>
-                <midino>0x02</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>DDJ200.hotcueNActivate</key>
-                <description>Hotcue 4, Deck 1: Set, preview, jump to</description>
-                <status>0x97</status>
-                <midino>0x03</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>DDJ200.hotcueNActivate</key>
-                <description>Hotcue 5, Deck 1: Set, preview, jump to</description>
-                <status>0x97</status>
-                <midino>0x04</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>DDJ200.hotcueNActivate</key>
-                <description>Hotcue 6, Deck 1: Set, preview, jump to</description>
-                <status>0x97</status>
-                <midino>0x05</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>DDJ200.hotcueNActivate</key>
-                <description>Hotcue 7, Deck 1: Set, preview, jump to</description>
-                <status>0x97</status>
-                <midino>0x06</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>DDJ200.hotcueNActivate</key>
-                <description>Hotcue 8, Deck 1: Set, preview, jump to</description>
-                <status>0x97</status>
-                <midino>0x07</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-
-
-            <control>
-                <group>[Channel2]</group>
-                <key>DDJ200.hotcueNActivate</key>
-                <description>Hotcue 1, Deck 2: Set, preview, jump to</description>
-                <status>0x99</status>
-                <midino>0x00</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>DDJ200.hotcueNActivate</key>
-                <description>Hotcue 2, Deck 2: Set, preview, jump to</description>
-                <status>0x99</status>
-                <midino>0x01</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>DDJ200.hotcueNActivate</key>
-                <description>Hotcue 3, Deck 2: Set, preview, jump to</description>
-                <status>0x99</status>
-                <midino>0x02</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>DDJ200.hotcueNActivate</key>
-                <description>Hotcue 4, Deck 2: Set, preview, jump to</description>
-                <status>0x99</status>
-                <midino>0x03</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>DDJ200.hotcueNActivate</key>
-                <description>Hotcue 5, Deck 2: Set, preview, jump to</description>
-                <status>0x99</status>
-                <midino>0x04</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>DDJ200.hotcueNActivate</key>
-                <description>Hotcue 6, Deck 2: Set, preview, jump to</description>
-                <status>0x99</status>
-                <midino>0x05</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>DDJ200.hotcueNActivate</key>
-                <description>Hotcue 7, Deck 2: Set, preview, jump to</description>
-                <status>0x99</status>
-                <midino>0x06</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>DDJ200.hotcueNActivate</key>
-                <description>Hotcue 8, Deck 2: Set, preview, jump to</description>
-                <status>0x99</status>
-                <midino>0x07</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-
-            <control>
-                <group>[Channel1]</group>
-                <!--key>hotcue_1_clear</key-->
-                <key>DDJ200.hotcueNClear</key>
-                <description>Hotcue 1, Deck 1: Clear</description>
-                <status>0x98</status>
-                <midino>0x00</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>DDJ200.hotcueNClear</key>
-                <description>Hotcue 2, Deck 1: Clear</description>
-                <status>0x98</status>
-                <midino>0x01</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>DDJ200.hotcueNClear</key>
-                <description>Hotcue 3, Deck 1: Clear</description>
-                <status>0x98</status>
-                <midino>0x02</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>DDJ200.hotcueNClear</key>
-                <description>Hotcue 4, Deck 1: Clear</description>
-                <status>0x98</status>
-                <midino>0x03</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>DDJ200.hotcueNClear</key>
-                <description>Hotcue 5, Deck 1: Clear</description>
-                <status>0x98</status>
-                <midino>0x04</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>DDJ200.hotcueNClear</key>
-                <description>Hotcue 6, Deck 1: Clear</description>
-                <status>0x98</status>
-                <midino>0x05</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>DDJ200.hotcueNClear</key>
-                <description>Hotcue 7, Deck 1: Clear</description>
-                <status>0x98</status>
-                <midino>0x06</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel1]</group>
-                <key>DDJ200.hotcueNClear</key>
-                <description>Hotcue 8, Deck 1: Clear</description>
-                <status>0x98</status>
-                <midino>0x07</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-
-            <control>
-                <group>[Channel2]</group>
-                <!--key>hotcue_1_clear</key-->
-                <key>DDJ200.hotcueNClear</key>
-                <description>Hotcue 1, Deck 2: Clear</description>
-                <status>0x9A</status>
-                <midino>0x00</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>DDJ200.hotcueNClear</key>
-                <description>Hotcue 2, Deck 2: Clear</description>
-                <status>0x9A</status>
-                <midino>0x01</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>DDJ200.hotcueNClear</key>
-                <description>Hotcue 3, Deck 2: Clear</description>
-                <status>0x9A</status>
-                <midino>0x02</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>DDJ200.hotcueNClear</key>
-                <description>Hotcue 4, Deck 2: Clear</description>
-                <status>0x9A</status>
-                <midino>0x03</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>DDJ200.hotcueNClear</key>
-                <description>Hotcue 5, Deck 2: Clear</description>
-                <status>0x9A</status>
-                <midino>0x04</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>DDJ200.hotcueNClear</key>
-                <description>Hotcue 6, Deck 2: Clear</description>
-                <status>0x9A</status>
-                <midino>0x05</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>DDJ200.hotcueNClear</key>
-                <description>Hotcue 7, Deck 2: Clear</description>
-                <status>0x9A</status>
-                <midino>0x06</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-            <control>
-                <group>[Channel2]</group>
-                <key>DDJ200.hotcueNClear</key>
-                <description>Hotcue 8, Deck 2: Clear</description>
-                <status>0x9A</status>
-                <midino>0x07</midino>
-                <options>
-                    <script-binding/>
-                </options>
-            </control>
-        </controls>
-
-
-        <outputs>
-            <!--output>
-                <group>[Channel1]</group>
-                <key>pfl</key>
-                <description>Deck 1: Headphone listen (pfl) LED</description>
-                <status>0x90</status>
-                <midino>0x54</midino>
-                <on>0x7F</on>
-                <off>0x00</off>
-                <minimum>0.5</minimum>
-            </output>
-            <output>
-                <group>[Channel2]</group>
-                <key>pfl</key>
-                <description>Deck 2: Headphone listen (pfl) LED</description>
-                <status>0x91</status>
-                <midino>0x54</midino>
-                <on>0x7F</on>
-                <off>0x00</off>
-                <minimum>0.5</minimum>
-            </output-->
-          </outputs>
-      </controller>
+  <info>
+    <name>Pioneer DDJ-200</name>
+    <author>Rene (mixxx at absorb.it), Dan Giddins, Frank.Breitling at gmx.de, Geovanni Pacheco</author>
+    <description>2-deck USB and Bluetooth MIDI controller with support for 4-deck mode.</description>
+    <forum>https://mixxx.discourse.group/t/new-mapping-for-pioneer-ddj-200/31164</forum>
+    <manual>pioneer_ddj_200</manual>
+  </info>
+  <controller id="DDJ-200 ALT">
+    <scriptfiles>
+      <file filename="midi-components-0.0.js" />
+      <file functionprefix="DDJ200" filename="Pioneer-DDJ-200-scripts.js" />
+    </scriptfiles>
+    <controls>
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.shiftButton.input</key>
+        <description>Deck 1: Shift pressed</description>
+        <status>0x90</status>
+        <midino>0x3F</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.shiftButton.input</key>
+        <description>Deck 2: Shift pressed</description>
+        <status>0x91</status>
+        <midino>0x3F</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Master]</group>
+        <key>crossfader</key>
+        <description>Master crossfader</description>
+        <status>0xB6</status>
+        <midino>0x1F</midino>
+        <options>
+          <soft-takeover />
+          <fourteen-bit-msb />
+        </options>
+      </control>
+      <control>
+        <group>[Master]</group>
+        <key>crossfader</key>
+        <description>Master crossfader</description>
+        <status>0xB6</status>
+        <midino>0x3F</midino>
+        <options>
+          <soft-takeover />
+          <fourteen-bit-lsb />
+        </options>
+      </control>
+      <control>
+        <group>[Master]</group>
+        <key>DDJ200.headMixButton.input</key>
+        <description>Headphones master as headMix knob</description>
+        <status>0x96</status>
+        <midino>0x63</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Master]</group>
+        <key>DDJ200.headMixButton.shiftedInput</key>
+        <description>Headphones master + shift</description>
+        <status>0x96</status>
+        <midino>0x78</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.leftDeck.pflButton.input</key>
+        <description>Deck 1: Headphone listen (pfl) button</description>
+        <status>0x90</status>
+        <midino>0x54</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.leftDeck.loadTrack.input</key>
+        <description>Deck 1: Headphone (pfl) + shift</description>
+        <status>0x90</status>
+        <midino>0x68</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.rightDeck.pflButton.input</key>
+        <description>Deck 2: Headphone listen (pfl) button</description>
+        <status>0x91</status>
+        <midino>0x54</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.rightDeck.loadTrack.input</key>
+        <description>Deck 2: Headphone (pfl) + shift</description>
+        <status>0x91</status>
+        <midino>0x68</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.leftDeck.syncButton.input</key>
+        <description>Deck 1: Tap to sync tempo (and phase with quantize enabled), hold to enable permanent sync</description>
+        <status>0x90</status>
+        <midino>0x58</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.rightDeck.syncButton.input</key>
+        <description>Deck 2: Tap to sync tempo (and phase with quantize enabled), hold to enable permanent sync</description>
+        <status>0x91</status>
+        <midino>0x58</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.leftDeck.syncButton.inputLongPress</key>
+        <description>Deck 1: Long Press to enable permanent sync</description>
+        <status>0x90</status>
+        <midino>0x5C</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.rightDeck.syncButton.inputLongPress</key>
+        <description>Deck 2: Long Press to enable permanent sync</description>
+        <status>0x91</status>
+        <midino>0x5C</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.leftDeck.syncButton.shiftedInput</key>
+        <description>Deck 1: Shift Tap to sync tempo (and phase with quantize enabled), hold to enable permanent sync</description>
+        <status>0x90</status>
+        <midino>0x60</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.rightDeck.syncButton.shiftedInput</key>
+        <description>Deck 2: Shift Tap to sync tempo (and phase with quantize enabled), hold to enable permanent sync</description>
+        <status>0x91</status>
+        <midino>0x60</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.leftDeck.jogWheel.inputSeek</key>
+        <description>Deck 1: Seek</description>
+        <status>0xB0</status>
+        <midino>0x29</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.rightDeck.jogWheel.inputSeek</key>
+        <description>Deck 2: Seek</description>
+        <status>0xB1</status>
+        <midino>0x29</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[AutoDJ]</group>
+        <key>DDJ200.transFxButton.input</key>
+        <description>Change Pad mode</description>
+        <status>0x96</status>
+        <midino>0x59</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[AutoDJ]</group>
+        <key>DDJ200.transFxButton.input</key>
+        <description>Change Pad mode</description>
+        <status>0x96</status>
+        <midino>0x5A</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.leftDeck.jogWheel.inputTouch</key>
+        <description>Deck 1: Touch</description>
+        <status>0x90</status>
+        <midino>0x36</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.rightDeck.jogWheel.inputTouch</key>
+        <description>Deck 2: Touch</description>
+        <status>0x91</status>
+        <midino>0x36</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[EqualizerRack1_[Channel1]_Effect1]</group>
+        <key>DDJ200.leftDeck.eqKnob[0].input</key>
+        <description>Deck 1: Adjust Low EQ</description>
+        <status>0xB0</status>
+        <midino>0x0F</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[EqualizerRack1_[Channel1]_Effect1]</group>
+        <key>DDJ200.leftDeck.eqKnob[1].input</key>
+        <description>Deck 1: Adjust Mid EQ</description>
+        <status>0xB0</status>
+        <midino>0x0B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[EqualizerRack1_[Channel1]_Effect1]</group>
+        <key>DDJ200.leftDeck.eqKnob[2].input</key>
+        <description>Deck 1: Adjust High EQ</description>
+        <status>0xB0</status>
+        <midino>0x07</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[QuickEffectRack1_[Channel1]]</group>
+        <key>DDJ200.leftDeck.super1.input</key>
+        <description>Super Knob (msb): control linked effect</description>
+        <status>0xB6</status>
+        <midino>0x17</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[EqualizerRack1_[Channel2]_Effect1]</group>
+        <key>DDJ200.rightDeck.eqKnob[0].input</key>
+        <description>Deck 2: Adjust Low EQ</description>
+        <status>0xB1</status>
+        <midino>0x0F</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[EqualizerRack1_[Channel2]_Effect1]</group>
+        <key>DDJ200.rightDeck.eqKnob[1].input</key>
+        <description>Deck 2: Adjust Mid EQ</description>
+        <status>0xB1</status>
+        <midino>0x0B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[EqualizerRack1_[Channel2]_Effect1]</group>
+        <key>DDJ200.rightDeck.eqKnob[2].input</key>
+        <description>Deck 2: Adjust High EQ</description>
+        <status>0xB1</status>
+        <midino>0x07</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[QuickEffectRack1_[Channel2]]</group>
+        <key>DDJ200.rightDeck.super1.input</key>
+        <description>Quick Effect: Quick Effect Super Knob (control linked effect parameters)</description>
+        <status>0xB6</status>
+        <midino>0x18</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.leftDeck.volume.inputMSB</key>
+        <description>Deck 1: Volume Fader</description>
+        <status>0xB0</status>
+        <midino>0x13</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.leftDeck.volume.inputLSB</key>
+        <description>Deck 1: Volume Fader</description>
+        <status>0xB0</status>
+        <midino>0x33</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.rightDeck.volume.inputMSB</key>
+        <description>Deck 2: Volume Fader</description>
+        <status>0xB1</status>
+        <midino>0x13</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.rightDeck.volume.inputLSB</key>
+        <description>Deck 2: Volume Fader</description>
+        <status>0xB1</status>
+        <midino>0x33</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.leftDeck.playButton.input</key>
+        <description>Deck 1: Play button</description>
+        <status>0x90</status>
+        <midino>0x0B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.rightDeck.playButton.input</key>
+        <description>Deck 2: Play button</description>
+        <status>0x91</status>
+        <midino>0x0B</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.leftDeck.playButton.inputFaderStart</key>
+        <description>Deck 1: Shift and Fader start</description>
+        <status>0x90</status>
+        <midino>0x66</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.rightDeck.playButton.inputFaderStart</key>
+        <description>Deck 2: Shift and Fader start</description>
+        <status>0x91</status>
+        <midino>0x66</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.leftDeck.cueButton.input</key>
+        <description>Deck 1: Cue button</description>
+        <status>0x90</status>
+        <midino>0x0C</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.rightDeck.cueButton.input</key>
+        <description>Deck 2: Cue button</description>
+        <status>0x91</status>
+        <midino>0x0C</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.leftDeck.cueButton.inputFaderStop</key>
+        <description>Deck 1: Shift and Fader stop</description>
+        <status>0x90</status>
+        <midino>0x52</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.rightDeck.cueButton.inputFaderStop</key>
+        <description>Deck 2: Shift and Fader stop</description>
+        <status>0x91</status>
+        <midino>0x52</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.leftDeck.cueButton.input</key>
+        <description>Deck 1: Go to cue point and stop</description>
+        <status>0x90</status>
+        <midino>0x48</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.rightDeck.cueButton.input</key>
+        <description>Deck 2: Go to cue point and stop</description>
+        <status>0x91</status>
+        <midino>0x48</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.leftDeck.rate.inputMSB</key>
+        <description>Deck 1: Playback speed control</description>
+        <status>0xB0</status>
+        <midino>0x00</midino>
+        <options>
+          <script-binding />
+          <soft-takeover />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.leftDeck.rate.inputLSB</key>
+        <description>Deck 1: Playback speed control</description>
+        <status>0xB0</status>
+        <midino>0x20</midino>
+        <options>
+          <soft-takeover />
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.rightDeck.rate.inputMSB</key>
+        <description>Deck 2: Playback speed control</description>
+        <status>0xB1</status>
+        <midino>0x00</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.rightDeck.rate.inputLSB</key>
+        <description>Deck 2: Playback speed control</description>
+        <status>0xB1</status>
+        <midino>0x20</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.leftDeck.jogWheel.inputWheel</key>
+        <description>Deck 1: Jog</description>
+        <status>0xB0</status>
+        <midino>0x21</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.rightDeck.jogWheel.inputWheel</key>
+        <description>Deck 2: Jog</description>
+        <status>0xB1</status>
+        <midino>0x21</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.rightDeck.jogWheel.inputWheel</key>
+        <description>Deck 2: Scratch</description>
+        <status>0xB1</status>
+        <midino>0x22</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.leftDeck.jogWheel.inputWheel</key>
+        <description>Deck 1: Scratch</description>
+        <status>0xB0</status>
+        <midino>0x22</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.rightDeck.jogWheel.inputWheel</key>
+        <description>Deck 2: Scratch</description>
+        <status>0xB1</status>
+        <midino>0x23</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.leftDeck.jogWheel.inputWheel</key>
+        <description>Deck 1: Scratch</description>
+        <status>0xB0</status>
+        <midino>0x23</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.leftDeck.playButton.input</key>
+        <description>Deck 1: Shift Play</description>
+        <status>0x90</status>
+        <midino>0x47</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.rightDeck.playButton.input</key>
+        <description>Deck 2: Shift Play</description>
+        <status>0x91</status>
+        <midino>0x47</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <!-- ##### Hotcues ##### -->
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.leftDeck.pads[0].input</key>
+        <description>Hotcue 1, Deck 1: Set, preview, jump to</description>
+        <status>0x97</status>
+        <midino>0x00</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.leftDeck.pads[1].input</key>
+        <description>Hotcue 2, Deck 1: Set, preview, jump to</description>
+        <status>0x97</status>
+        <midino>0x01</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.leftDeck.pads[2].input</key>
+        <description>Hotcue 3, Deck 1: Set, preview, jump to</description>
+        <status>0x97</status>
+        <midino>0x02</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.leftDeck.pads[3].input</key>
+        <description>Hotcue 4, Deck 1: Set, preview, jump to</description>
+        <status>0x97</status>
+        <midino>0x03</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.leftDeck.pads[4].input</key>
+        <description>Hotcue 5, Deck 1: Set, preview, jump to</description>
+        <status>0x97</status>
+        <midino>0x04</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.leftDeck.pads[5].input</key>
+        <description>Hotcue 6, Deck 1: Set, preview, jump to</description>
+        <status>0x97</status>
+        <midino>0x05</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.leftDeck.pads[6].input</key>
+        <description>Hotcue 7, Deck 1: Set, preview, jump to</description>
+        <status>0x97</status>
+        <midino>0x06</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.leftDeck.pads[7].input</key>
+        <description>Hotcue 8, Deck 1: Set, preview, jump to</description>
+        <status>0x97</status>
+        <midino>0x07</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.rightDeck.pads[0].input</key>
+        <description>Hotcue 1, Deck 2: Set, preview, jump to</description>
+        <status>0x99</status>
+        <midino>0x00</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.rightDeck.pads[1].input</key>
+        <description>Hotcue 2, Deck 2: Set, preview, jump to</description>
+        <status>0x99</status>
+        <midino>0x01</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.rightDeck.pads[2].input</key>
+        <description>Hotcue 3, Deck 2: Set, preview, jump to</description>
+        <status>0x99</status>
+        <midino>0x02</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.rightDeck.pads[3].input</key>
+        <description>Hotcue 4, Deck 2: Set, preview, jump to</description>
+        <status>0x99</status>
+        <midino>0x03</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.rightDeck.pads[4].input</key>
+        <description>Hotcue 5, Deck 2: Set, preview, jump to</description>
+        <status>0x99</status>
+        <midino>0x04</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.rightDeck.pads[5].input</key>
+        <description>Hotcue 6, Deck 2: Set, preview, jump to</description>
+        <status>0x99</status>
+        <midino>0x05</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.rightDeck.pads[6].input</key>
+        <description>Hotcue 7, Deck 2: Set, preview, jump to</description>
+        <status>0x99</status>
+        <midino>0x06</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.rightDeck.pads[7].input</key>
+        <description>Hotcue 8, Deck 2: Set, preview, jump to</description>
+        <status>0x99</status>
+        <midino>0x07</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.leftDeck.pads[0].shiftedInput</key>
+        <description>Hotcue 1, Deck 1: Clear</description>
+        <status>0x98</status>
+        <midino>0x00</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.leftDeck.pads[1].shiftedInput</key>
+        <description>Hotcue 2, Deck 1: Clear</description>
+        <status>0x98</status>
+        <midino>0x01</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.leftDeck.pads[2].shiftedInput</key>
+        <description>Hotcue 3, Deck 1: Clear</description>
+        <status>0x98</status>
+        <midino>0x02</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.leftDeck.pads[3].shiftedInput</key>
+        <description>Hotcue 4, Deck 1: Clear</description>
+        <status>0x98</status>
+        <midino>0x03</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.leftDeck.pads[4].shiftedInput</key>
+        <description>Hotcue 5, Deck 1: Clear</description>
+        <status>0x98</status>
+        <midino>0x04</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.leftDeck.pads[5].shiftedInput</key>
+        <description>Hotcue 6, Deck 1: Clear</description>
+        <status>0x98</status>
+        <midino>0x05</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.leftDeck.pads[6].shiftedInput</key>
+        <description>Hotcue 7, Deck 1: Clear</description>
+        <status>0x98</status>
+        <midino>0x06</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel1]</group>
+        <key>DDJ200.leftDeck.pads[7].shiftedInput</key>
+        <description>Hotcue 8, Deck 1: Clear</description>
+        <status>0x98</status>
+        <midino>0x07</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.rightDeck.pads[0].shiftedInput</key>
+        <description>Hotcue 1, Deck 2: Clear</description>
+        <status>0x9A</status>
+        <midino>0x00</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.rightDeck.pads[1].shiftedInput</key>
+        <description>Hotcue 2, Deck 2: Clear</description>
+        <status>0x9A</status>
+        <midino>0x01</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.rightDeck.pads[2].shiftedInput</key>
+        <description>Hotcue 3, Deck 2: Clear</description>
+        <status>0x9A</status>
+        <midino>0x02</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.rightDeck.pads[3].shiftedInput</key>
+        <description>Hotcue 4, Deck 2: Clear</description>
+        <status>0x9A</status>
+        <midino>0x03</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.rightDeck.pads[4].shiftedInput</key>
+        <description>Hotcue 5, Deck 2: Clear</description>
+        <status>0x9A</status>
+        <midino>0x04</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.rightDeck.pads[5].shiftedInput</key>
+        <description>Hotcue 6, Deck 2: Clear</description>
+        <status>0x9A</status>
+        <midino>0x05</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.rightDeck.pads[6].shiftedInput</key>
+        <description>Hotcue 7, Deck 2: Clear</description>
+        <status>0x9A</status>
+        <midino>0x06</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+      <control>
+        <group>[Channel2]</group>
+        <key>DDJ200.rightDeck.pads[7].shiftedInput</key>
+        <description>Hotcue 8, Deck 2: Clear</description>
+        <status>0x9A</status>
+        <midino>0x07</midino>
+        <options>
+          <script-binding />
+        </options>
+      </control>
+    </controls>
+  </controller>
 </MixxxControllerPreset>

--- a/res/controllers/Pioneer DDJ-200.midi.xml
+++ b/res/controllers/Pioneer DDJ-200.midi.xml
@@ -15,7 +15,7 @@
     <controls>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.shiftButton.input</key>
+        <key>DDJ200.leftDeck.shiftButton.input</key>
         <description>Deck 1: Shift pressed</description>
         <status>0x90</status>
         <midino>0x3F</midino>
@@ -25,7 +25,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.shiftButton.input</key>
+        <key>DDJ200.rightDeck.shiftButton.input</key>
         <description>Deck 2: Shift pressed</description>
         <status>0x91</status>
         <midino>0x3F</midino>

--- a/res/controllers/Pioneer DDJ-200.midi.xml
+++ b/res/controllers/Pioneer DDJ-200.midi.xml
@@ -56,6 +56,30 @@
         There is no hardware "Gain" knob on the Pioneer DDJ-200. When enabled, the "Quick Effect" knob can be used to control the gain of the respective deck instead.
       </description>
     </option>
+    <option variable="useLeftShiftAsLibraryScroll"
+      type="boolean"
+      label="Use Left Shift and Jog Wheel (Top) to scroll through Library"
+      default="false">
+      <description>
+        Usually pressing shift will allow you to scratch through your track faster. When enabled, the Left Shift together with Jog Wheel (top) can be used to scroll through your library.
+      </description>
+    </option>
+    <option variable="useRightShiftAsLibraryScroll"
+      type="boolean"
+      label="Use Right Shift and Jog Wheel (Top) to scroll through Library"
+      default="false">
+      <description>
+        Usually pressing shift will allow you to scratch through your track faster. When enabled, the Right Shift together with Jog Wheel (top) can be used to scroll through your library.
+      </description>
+    </option>
+    <option variable="useSuperAsGain"
+      type="boolean"
+      label="Use Quick Effect Controller Button as Gain Knob"
+      default="false">
+      <description>
+        There is no hardware "Gain" knob on the Pioneer DDJ-200. When enabled, the "Quick Effect" knob can be used to control the gain of the respective deck instead.
+      </description>
+    </option>
   </settings>
   <controller id="DDJ-200 ALT">
     <scriptfiles>

--- a/res/controllers/Pioneer DDJ-200.midi.xml
+++ b/res/controllers/Pioneer DDJ-200.midi.xml
@@ -72,14 +72,6 @@
         Usually pressing shift will allow you to scratch through your track faster. When enabled, the Right Shift together with Jog Wheel (top) can be used to scroll through your library.
       </description>
     </option>
-    <option variable="useSuperAsGain"
-      type="boolean"
-      label="Use Quick Effect Controller Button as Gain Knob"
-      default="false">
-      <description>
-        There is no hardware "Gain" knob on the Pioneer DDJ-200. When enabled, the "Quick Effect" knob can be used to control the gain of the respective deck instead.
-      </description>
-    </option>
   </settings>
   <controller id="DDJ-200 ALT">
     <scriptfiles>

--- a/res/controllers/Pioneer DDJ-200.midi.xml
+++ b/res/controllers/Pioneer DDJ-200.midi.xml
@@ -630,7 +630,7 @@
       <!-- ##### Hotcues ##### -->
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.decks.left.padUnit.choosenPadInstance.pads[0].input</key>
+        <key>DDJ200.decks.left.padUnit.input</key>
         <description>Hotcue 1, Deck 1: Set, preview, jump to</description>
         <status>0x97</status>
         <midino>0x00</midino>
@@ -640,7 +640,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.decks.left.padUnit.choosenPadInstance.pads[1].input</key>
+        <key>DDJ200.decks.left.padUnit.input</key>
         <description>Hotcue 2, Deck 1: Set, preview, jump to</description>
         <status>0x97</status>
         <midino>0x01</midino>
@@ -650,7 +650,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.decks.left.padUnit.choosenPadInstance.pads[2].input</key>
+        <key>DDJ200.decks.left.padUnit.input</key>
         <description>Hotcue 3, Deck 1: Set, preview, jump to</description>
         <status>0x97</status>
         <midino>0x02</midino>
@@ -660,7 +660,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.decks.left.padUnit.choosenPadInstance.pads[3].input</key>
+        <key>DDJ200.decks.left.padUnit.input</key>
         <description>Hotcue 4, Deck 1: Set, preview, jump to</description>
         <status>0x97</status>
         <midino>0x03</midino>
@@ -670,7 +670,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.decks.left.padUnit.choosenPadInstance.pads[4].input</key>
+        <key>DDJ200.decks.left.padUnit.input</key>
         <description>Hotcue 5, Deck 1: Set, preview, jump to</description>
         <status>0x97</status>
         <midino>0x04</midino>
@@ -680,7 +680,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.decks.left.padUnit.choosenPadInstance.pads[5].input</key>
+        <key>DDJ200.decks.left.padUnit.input</key>
         <description>Hotcue 6, Deck 1: Set, preview, jump to</description>
         <status>0x97</status>
         <midino>0x05</midino>
@@ -690,7 +690,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.decks.left.padUnit.choosenPadInstance.pads[6].input</key>
+        <key>DDJ200.decks.left.padUnit.input</key>
         <description>Hotcue 7, Deck 1: Set, preview, jump to</description>
         <status>0x97</status>
         <midino>0x06</midino>
@@ -700,7 +700,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.decks.left.padUnit.choosenPadInstance.pads[7].input</key>
+        <key>DDJ200.decks.left.padUnit.input</key>
         <description>Hotcue 8, Deck 1: Set, preview, jump to</description>
         <status>0x97</status>
         <midino>0x07</midino>
@@ -710,7 +710,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.decks.right.padUnit.choosenPadInstance.pads[0].input</key>
+        <key>DDJ200.decks.right.padUnit.input</key>
         <description>Hotcue 1, Deck 2: Set, preview, jump to</description>
         <status>0x99</status>
         <midino>0x00</midino>
@@ -720,7 +720,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.decks.right.padUnit.choosenPadInstance.pads[1].input</key>
+        <key>DDJ200.decks.right.padUnit.input</key>
         <description>Hotcue 2, Deck 2: Set, preview, jump to</description>
         <status>0x99</status>
         <midino>0x01</midino>
@@ -730,7 +730,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.decks.right.padUnit.choosenPadInstance.pads[2].input</key>
+        <key>DDJ200.decks.right.padUnit.input</key>
         <description>Hotcue 3, Deck 2: Set, preview, jump to</description>
         <status>0x99</status>
         <midino>0x02</midino>
@@ -740,7 +740,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.decks.right.padUnit.choosenPadInstance.pads[3].input</key>
+        <key>DDJ200.decks.right.padUnit.input</key>
         <description>Hotcue 4, Deck 2: Set, preview, jump to</description>
         <status>0x99</status>
         <midino>0x03</midino>
@@ -750,7 +750,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.decks.right.padUnit.choosenPadInstance.pads[4].input</key>
+        <key>DDJ200.decks.right.padUnit.input</key>
         <description>Hotcue 5, Deck 2: Set, preview, jump to</description>
         <status>0x99</status>
         <midino>0x04</midino>
@@ -760,7 +760,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.decks.right.padUnit.choosenPadInstance.pads[5].input</key>
+        <key>DDJ200.decks.right.padUnit.input</key>
         <description>Hotcue 6, Deck 2: Set, preview, jump to</description>
         <status>0x99</status>
         <midino>0x05</midino>
@@ -770,7 +770,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.decks.right.padUnit.choosenPadInstance.pads[6].input</key>
+        <key>DDJ200.decks.right.padUnit.input</key>
         <description>Hotcue 7, Deck 2: Set, preview, jump to</description>
         <status>0x99</status>
         <midino>0x06</midino>
@@ -780,7 +780,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.decks.right.padUnit.choosenPadInstance.pads[7].input</key>
+        <key>DDJ200.decks.right.padUnit.input</key>
         <description>Hotcue 8, Deck 2: Set, preview, jump to</description>
         <status>0x99</status>
         <midino>0x07</midino>
@@ -790,7 +790,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.decks.left.padUnit.choosenPadInstance.pads[0].input</key>
+        <key>DDJ200.decks.left.padUnit.input</key>
         <description>Hotcue 1, Deck 1: Clear</description>
         <status>0x98</status>
         <midino>0x00</midino>
@@ -800,7 +800,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.decks.left.padUnit.choosenPadInstance.pads[1].input</key>
+        <key>DDJ200.decks.left.padUnit.input</key>
         <description>Hotcue 2, Deck 1: Clear</description>
         <status>0x98</status>
         <midino>0x01</midino>
@@ -810,7 +810,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.decks.left.padUnit.choosenPadInstance.pads[2].input</key>
+        <key>DDJ200.decks.left.padUnit.input</key>
         <description>Hotcue 3, Deck 1: Clear</description>
         <status>0x98</status>
         <midino>0x02</midino>
@@ -820,7 +820,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.decks.left.padUnit.choosenPadInstance.pads[3].input</key>
+        <key>DDJ200.decks.left.padUnit.input</key>
         <description>Hotcue 4, Deck 1: Clear</description>
         <status>0x98</status>
         <midino>0x03</midino>
@@ -830,7 +830,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.decks.left.padUnit.choosenPadInstance.pads[4].input</key>
+        <key>DDJ200.decks.left.padUnit.input</key>
         <description>Hotcue 5, Deck 1: Clear</description>
         <status>0x98</status>
         <midino>0x04</midino>
@@ -840,7 +840,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.decks.left.padUnit.choosenPadInstance.pads[5].input</key>
+        <key>DDJ200.decks.left.padUnit.input</key>
         <description>Hotcue 6, Deck 1: Clear</description>
         <status>0x98</status>
         <midino>0x05</midino>
@@ -850,7 +850,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.decks.left.padUnit.choosenPadInstance.pads[6].input</key>
+        <key>DDJ200.decks.left.padUnit.input</key>
         <description>Hotcue 7, Deck 1: Clear</description>
         <status>0x98</status>
         <midino>0x06</midino>
@@ -860,7 +860,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.decks.left.padUnit.choosenPadInstance.pads[7].input</key>
+        <key>DDJ200.decks.left.padUnit.input</key>
         <description>Hotcue 8, Deck 1: Clear</description>
         <status>0x98</status>
         <midino>0x07</midino>
@@ -870,7 +870,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.decks.right.padUnit.choosenPadInstance.pads[0].input</key>
+        <key>DDJ200.decks.right.padUnit.input</key>
         <description>Hotcue 1, Deck 2: Clear</description>
         <status>0x9A</status>
         <midino>0x00</midino>
@@ -880,7 +880,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.decks.right.padUnit.choosenPadInstance.pads[1].input</key>
+        <key>DDJ200.decks.right.padUnit.input</key>
         <description>Hotcue 2, Deck 2: Clear</description>
         <status>0x9A</status>
         <midino>0x01</midino>
@@ -890,7 +890,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.decks.right.padUnit.choosenPadInstance.pads[2].input</key>
+        <key>DDJ200.decks.right.padUnit.input</key>
         <description>Hotcue 3, Deck 2: Clear</description>
         <status>0x9A</status>
         <midino>0x02</midino>
@@ -900,7 +900,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.decks.right.padUnit.choosenPadInstance.pads[3].input</key>
+        <key>DDJ200.decks.right.padUnit.input</key>
         <description>Hotcue 4, Deck 2: Clear</description>
         <status>0x9A</status>
         <midino>0x03</midino>
@@ -910,7 +910,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.decks.right.padUnit.choosenPadInstance.pads[4].input</key>
+        <key>DDJ200.decks.right.padUnit.input</key>
         <description>Hotcue 5, Deck 2: Clear</description>
         <status>0x9A</status>
         <midino>0x04</midino>
@@ -920,7 +920,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.decks.right.padUnit.choosenPadInstance.pads[5].input</key>
+        <key>DDJ200.decks.right.padUnit.input</key>
         <description>Hotcue 6, Deck 2: Clear</description>
         <status>0x9A</status>
         <midino>0x05</midino>
@@ -930,7 +930,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.decks.right.padUnit.choosenPadInstance.pads[6].input</key>
+        <key>DDJ200.decks.right.padUnit.input</key>
         <description>Hotcue 7, Deck 2: Clear</description>
         <status>0x9A</status>
         <midino>0x06</midino>
@@ -940,7 +940,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.decks.right.padUnit.choosenPadInstance.pads[7].input</key>
+        <key>DDJ200.decks.right.padUnit.input</key>
         <description>Hotcue 8, Deck 2: Clear</description>
         <status>0x9A</status>
         <midino>0x07</midino>

--- a/res/controllers/Pioneer DDJ-200.midi.xml
+++ b/res/controllers/Pioneer DDJ-200.midi.xml
@@ -57,7 +57,7 @@
     <controls>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.shiftButton.input</key>
+        <key>DDJ200.decks.left.shiftButton.input</key>
         <description>Deck 1: Shift pressed</description>
         <status>0x90</status>
         <midino>0x3F</midino>
@@ -67,7 +67,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.shiftButton.input</key>
+        <key>DDJ200.decks.right.shiftButton.input</key>
         <description>Deck 2: Shift pressed</description>
         <status>0x91</status>
         <midino>0x3F</midino>
@@ -119,7 +119,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.pflButton.input</key>
+        <key>DDJ200.decks.left.pflButton.input</key>
         <description>Deck 1: Headphone listen (pfl) button</description>
         <status>0x90</status>
         <midino>0x54</midino>
@@ -129,7 +129,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.loadTrack.input</key>
+        <key>DDJ200.decks.left.loadTrack.input</key>
         <description>Deck 1: Headphone (pfl) + shift</description>
         <status>0x90</status>
         <midino>0x68</midino>
@@ -139,7 +139,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.pflButton.input</key>
+        <key>DDJ200.decks.right.pflButton.input</key>
         <description>Deck 2: Headphone listen (pfl) button</description>
         <status>0x91</status>
         <midino>0x54</midino>
@@ -149,7 +149,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.loadTrack.input</key>
+        <key>DDJ200.decks.right.loadTrack.input</key>
         <description>Deck 2: Headphone (pfl) + shift</description>
         <status>0x91</status>
         <midino>0x68</midino>
@@ -159,7 +159,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.syncButton.input</key>
+        <key>DDJ200.decks.left.syncButton.input</key>
         <description>Deck 1: Tap to sync tempo (and phase with quantize enabled), hold to enable permanent sync</description>
         <status>0x90</status>
         <midino>0x58</midino>
@@ -169,7 +169,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.syncButton.input</key>
+        <key>DDJ200.decks.right.syncButton.input</key>
         <description>Deck 2: Tap to sync tempo (and phase with quantize enabled), hold to enable permanent sync</description>
         <status>0x91</status>
         <midino>0x58</midino>
@@ -179,7 +179,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.syncButton.inputLongPress</key>
+        <key>DDJ200.decks.left.syncButton.inputLongPress</key>
         <description>Deck 1: Long Press to enable permanent sync</description>
         <status>0x90</status>
         <midino>0x5C</midino>
@@ -189,7 +189,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.syncButton.inputLongPress</key>
+        <key>DDJ200.decks.right.syncButton.inputLongPress</key>
         <description>Deck 2: Long Press to enable permanent sync</description>
         <status>0x91</status>
         <midino>0x5C</midino>
@@ -199,7 +199,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.syncButton.shiftedInput</key>
+        <key>DDJ200.decks.left.syncButton.shiftedInput</key>
         <description>Deck 1: Shift Tap to sync tempo (and phase with quantize enabled), hold to enable permanent sync</description>
         <status>0x90</status>
         <midino>0x60</midino>
@@ -209,7 +209,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.syncButton.shiftedInput</key>
+        <key>DDJ200.decks.right.syncButton.shiftedInput</key>
         <description>Deck 2: Shift Tap to sync tempo (and phase with quantize enabled), hold to enable permanent sync</description>
         <status>0x91</status>
         <midino>0x60</midino>
@@ -219,7 +219,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.jogWheel.inputSeek</key>
+        <key>DDJ200.decks.left.jogWheel.inputSeek</key>
         <description>Deck 1: Seek</description>
         <status>0xB0</status>
         <midino>0x29</midino>
@@ -229,7 +229,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.jogWheel.inputSeek</key>
+        <key>DDJ200.decks.right.jogWheel.inputSeek</key>
         <description>Deck 2: Seek</description>
         <status>0xB1</status>
         <midino>0x29</midino>
@@ -259,7 +259,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.jogWheel.inputTouch</key>
+        <key>DDJ200.decks.left.jogWheel.inputTouch</key>
         <description>Deck 1: Touch</description>
         <status>0x90</status>
         <midino>0x36</midino>
@@ -269,7 +269,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.jogWheel.inputTouch</key>
+        <key>DDJ200.decks.right.jogWheel.inputTouch</key>
         <description>Deck 2: Touch</description>
         <status>0x91</status>
         <midino>0x36</midino>
@@ -279,7 +279,7 @@
       </control>
       <control>
         <group>[EqualizerRack1_[Channel1]_Effect1]</group>
-        <key>DDJ200.Decks.left.eqKnob[0].input</key>
+        <key>DDJ200.decks.left.eqKnob[0].input</key>
         <description>Deck 1: Adjust Low EQ</description>
         <status>0xB0</status>
         <midino>0x0F</midino>
@@ -289,7 +289,7 @@
       </control>
       <control>
         <group>[EqualizerRack1_[Channel1]_Effect1]</group>
-        <key>DDJ200.Decks.left.eqKnob[1].input</key>
+        <key>DDJ200.decks.left.eqKnob[1].input</key>
         <description>Deck 1: Adjust Mid EQ</description>
         <status>0xB0</status>
         <midino>0x0B</midino>
@@ -299,7 +299,7 @@
       </control>
       <control>
         <group>[EqualizerRack1_[Channel1]_Effect1]</group>
-        <key>DDJ200.Decks.left.eqKnob[2].input</key>
+        <key>DDJ200.decks.left.eqKnob[2].input</key>
         <description>Deck 1: Adjust High EQ</description>
         <status>0xB0</status>
         <midino>0x07</midino>
@@ -309,7 +309,7 @@
       </control>
       <control>
         <group>[QuickEffectRack1_[Channel1]]</group>
-        <key>DDJ200.Decks.left.super1.input</key>
+        <key>DDJ200.decks.left.super1.input</key>
         <description>Super Knob (msb): control linked effect</description>
         <status>0xB6</status>
         <midino>0x17</midino>
@@ -319,7 +319,7 @@
       </control>
       <control>
         <group>[EqualizerRack1_[Channel2]_Effect1]</group>
-        <key>DDJ200.Decks.right.eqKnob[0].input</key>
+        <key>DDJ200.decks.right.eqKnob[0].input</key>
         <description>Deck 2: Adjust Low EQ</description>
         <status>0xB1</status>
         <midino>0x0F</midino>
@@ -329,7 +329,7 @@
       </control>
       <control>
         <group>[EqualizerRack1_[Channel2]_Effect1]</group>
-        <key>DDJ200.Decks.right.eqKnob[1].input</key>
+        <key>DDJ200.decks.right.eqKnob[1].input</key>
         <description>Deck 2: Adjust Mid EQ</description>
         <status>0xB1</status>
         <midino>0x0B</midino>
@@ -339,7 +339,7 @@
       </control>
       <control>
         <group>[EqualizerRack1_[Channel2]_Effect1]</group>
-        <key>DDJ200.Decks.right.eqKnob[2].input</key>
+        <key>DDJ200.decks.right.eqKnob[2].input</key>
         <description>Deck 2: Adjust High EQ</description>
         <status>0xB1</status>
         <midino>0x07</midino>
@@ -349,7 +349,7 @@
       </control>
       <control>
         <group>[QuickEffectRack1_[Channel2]]</group>
-        <key>DDJ200.Decks.right.super1.input</key>
+        <key>DDJ200.decks.right.super1.input</key>
         <description>Quick Effect: Quick Effect Super Knob (control linked effect parameters)</description>
         <status>0xB6</status>
         <midino>0x18</midino>
@@ -359,7 +359,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.volume.inputMSB</key>
+        <key>DDJ200.decks.left.volume.inputMSB</key>
         <description>Deck 1: Volume Fader</description>
         <status>0xB0</status>
         <midino>0x13</midino>
@@ -369,7 +369,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.volume.inputLSB</key>
+        <key>DDJ200.decks.left.volume.inputLSB</key>
         <description>Deck 1: Volume Fader</description>
         <status>0xB0</status>
         <midino>0x33</midino>
@@ -379,7 +379,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.volume.inputMSB</key>
+        <key>DDJ200.decks.right.volume.inputMSB</key>
         <description>Deck 2: Volume Fader</description>
         <status>0xB1</status>
         <midino>0x13</midino>
@@ -389,7 +389,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.volume.inputLSB</key>
+        <key>DDJ200.decks.right.volume.inputLSB</key>
         <description>Deck 2: Volume Fader</description>
         <status>0xB1</status>
         <midino>0x33</midino>
@@ -399,7 +399,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.playButton.input</key>
+        <key>DDJ200.decks.left.playButton.input</key>
         <description>Deck 1: Play button</description>
         <status>0x90</status>
         <midino>0x0B</midino>
@@ -409,7 +409,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.playButton.input</key>
+        <key>DDJ200.decks.right.playButton.input</key>
         <description>Deck 2: Play button</description>
         <status>0x91</status>
         <midino>0x0B</midino>
@@ -419,7 +419,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.playButton.inputFaderStart</key>
+        <key>DDJ200.decks.left.playButton.inputFaderStart</key>
         <description>Deck 1: Shift and Fader start</description>
         <status>0x90</status>
         <midino>0x66</midino>
@@ -429,7 +429,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.playButton.inputFaderStart</key>
+        <key>DDJ200.decks.right.playButton.inputFaderStart</key>
         <description>Deck 2: Shift and Fader start</description>
         <status>0x91</status>
         <midino>0x66</midino>
@@ -439,7 +439,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.cueButton.input</key>
+        <key>DDJ200.decks.left.cueButton.input</key>
         <description>Deck 1: Cue button</description>
         <status>0x90</status>
         <midino>0x0C</midino>
@@ -449,7 +449,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.cueButton.input</key>
+        <key>DDJ200.decks.right.cueButton.input</key>
         <description>Deck 2: Cue button</description>
         <status>0x91</status>
         <midino>0x0C</midino>
@@ -459,7 +459,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.cueButton.inputFaderStop</key>
+        <key>DDJ200.decks.left.cueButton.inputFaderStop</key>
         <description>Deck 1: Shift and Fader stop</description>
         <status>0x90</status>
         <midino>0x52</midino>
@@ -469,7 +469,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.cueButton.inputFaderStop</key>
+        <key>DDJ200.decks.right.cueButton.inputFaderStop</key>
         <description>Deck 2: Shift and Fader stop</description>
         <status>0x91</status>
         <midino>0x52</midino>
@@ -479,7 +479,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.cueButton.input</key>
+        <key>DDJ200.decks.left.cueButton.input</key>
         <description>Deck 1: Go to cue point and stop</description>
         <status>0x90</status>
         <midino>0x48</midino>
@@ -489,7 +489,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.cueButton.input</key>
+        <key>DDJ200.decks.right.cueButton.input</key>
         <description>Deck 2: Go to cue point and stop</description>
         <status>0x91</status>
         <midino>0x48</midino>
@@ -499,7 +499,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.rate.inputMSB</key>
+        <key>DDJ200.decks.left.rate.inputMSB</key>
         <description>Deck 1: Playback speed control</description>
         <status>0xB0</status>
         <midino>0x00</midino>
@@ -510,7 +510,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.rate.inputLSB</key>
+        <key>DDJ200.decks.left.rate.inputLSB</key>
         <description>Deck 1: Playback speed control</description>
         <status>0xB0</status>
         <midino>0x20</midino>
@@ -521,7 +521,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.rate.inputMSB</key>
+        <key>DDJ200.decks.right.rate.inputMSB</key>
         <description>Deck 2: Playback speed control</description>
         <status>0xB1</status>
         <midino>0x00</midino>
@@ -531,7 +531,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.rate.inputLSB</key>
+        <key>DDJ200.decks.right.rate.inputLSB</key>
         <description>Deck 2: Playback speed control</description>
         <status>0xB1</status>
         <midino>0x20</midino>
@@ -541,7 +541,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.jogWheel.inputWheel</key>
+        <key>DDJ200.decks.left.jogWheel.inputWheel</key>
         <description>Deck 1: Jog</description>
         <status>0xB0</status>
         <midino>0x21</midino>
@@ -551,7 +551,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.jogWheel.inputWheel</key>
+        <key>DDJ200.decks.right.jogWheel.inputWheel</key>
         <description>Deck 2: Jog</description>
         <status>0xB1</status>
         <midino>0x21</midino>
@@ -561,7 +561,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.jogWheel.inputWheel</key>
+        <key>DDJ200.decks.right.jogWheel.inputWheel</key>
         <description>Deck 2: Scratch</description>
         <status>0xB1</status>
         <midino>0x22</midino>
@@ -571,7 +571,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.jogWheel.inputWheel</key>
+        <key>DDJ200.decks.left.jogWheel.inputWheel</key>
         <description>Deck 1: Scratch</description>
         <status>0xB0</status>
         <midino>0x22</midino>
@@ -581,7 +581,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.jogWheel.inputWheel</key>
+        <key>DDJ200.decks.right.jogWheel.inputWheel</key>
         <description>Deck 2: Scratch</description>
         <status>0xB1</status>
         <midino>0x23</midino>
@@ -591,7 +591,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.jogWheel.inputWheel</key>
+        <key>DDJ200.decks.left.jogWheel.inputWheel</key>
         <description>Deck 1: Scratch</description>
         <status>0xB0</status>
         <midino>0x23</midino>
@@ -601,7 +601,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.playButton.input</key>
+        <key>DDJ200.decks.left.playButton.input</key>
         <description>Deck 1: Shift Play</description>
         <status>0x90</status>
         <midino>0x47</midino>
@@ -611,7 +611,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.playButton.input</key>
+        <key>DDJ200.decks.right.playButton.input</key>
         <description>Deck 2: Shift Play</description>
         <status>0x91</status>
         <midino>0x47</midino>
@@ -622,7 +622,7 @@
       <!-- ##### Hotcues ##### -->
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.padUnit.choosenPadInstance.pads[0].input</key>
+        <key>DDJ200.decks.left.padUnit.choosenPadInstance.pads[0].input</key>
         <description>Hotcue 1, Deck 1: Set, preview, jump to</description>
         <status>0x97</status>
         <midino>0x00</midino>
@@ -632,7 +632,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.padUnit.choosenPadInstance.pads[1].input</key>
+        <key>DDJ200.decks.left.padUnit.choosenPadInstance.pads[1].input</key>
         <description>Hotcue 2, Deck 1: Set, preview, jump to</description>
         <status>0x97</status>
         <midino>0x01</midino>
@@ -642,7 +642,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.padUnit.choosenPadInstance.pads[2].input</key>
+        <key>DDJ200.decks.left.padUnit.choosenPadInstance.pads[2].input</key>
         <description>Hotcue 3, Deck 1: Set, preview, jump to</description>
         <status>0x97</status>
         <midino>0x02</midino>
@@ -652,7 +652,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.padUnit.choosenPadInstance.pads[3].input</key>
+        <key>DDJ200.decks.left.padUnit.choosenPadInstance.pads[3].input</key>
         <description>Hotcue 4, Deck 1: Set, preview, jump to</description>
         <status>0x97</status>
         <midino>0x03</midino>
@@ -662,7 +662,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.padUnit.choosenPadInstance.pads[4].input</key>
+        <key>DDJ200.decks.left.padUnit.choosenPadInstance.pads[4].input</key>
         <description>Hotcue 5, Deck 1: Set, preview, jump to</description>
         <status>0x97</status>
         <midino>0x04</midino>
@@ -672,7 +672,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.padUnit.choosenPadInstance.pads[5].input</key>
+        <key>DDJ200.decks.left.padUnit.choosenPadInstance.pads[5].input</key>
         <description>Hotcue 6, Deck 1: Set, preview, jump to</description>
         <status>0x97</status>
         <midino>0x05</midino>
@@ -682,7 +682,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.padUnit.choosenPadInstance.pads[6].input</key>
+        <key>DDJ200.decks.left.padUnit.choosenPadInstance.pads[6].input</key>
         <description>Hotcue 7, Deck 1: Set, preview, jump to</description>
         <status>0x97</status>
         <midino>0x06</midino>
@@ -692,7 +692,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.padUnit.choosenPadInstance.pads[7].input</key>
+        <key>DDJ200.decks.left.padUnit.choosenPadInstance.pads[7].input</key>
         <description>Hotcue 8, Deck 1: Set, preview, jump to</description>
         <status>0x97</status>
         <midino>0x07</midino>
@@ -702,7 +702,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.padUnit.choosenPadInstance.pads[0].input</key>
+        <key>DDJ200.decks.right.padUnit.choosenPadInstance.pads[0].input</key>
         <description>Hotcue 1, Deck 2: Set, preview, jump to</description>
         <status>0x99</status>
         <midino>0x00</midino>
@@ -712,7 +712,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.padUnit.choosenPadInstance.pads[1].input</key>
+        <key>DDJ200.decks.right.padUnit.choosenPadInstance.pads[1].input</key>
         <description>Hotcue 2, Deck 2: Set, preview, jump to</description>
         <status>0x99</status>
         <midino>0x01</midino>
@@ -722,7 +722,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.padUnit.choosenPadInstance.pads[2].input</key>
+        <key>DDJ200.decks.right.padUnit.choosenPadInstance.pads[2].input</key>
         <description>Hotcue 3, Deck 2: Set, preview, jump to</description>
         <status>0x99</status>
         <midino>0x02</midino>
@@ -732,7 +732,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.padUnit.choosenPadInstance.pads[3].input</key>
+        <key>DDJ200.decks.right.padUnit.choosenPadInstance.pads[3].input</key>
         <description>Hotcue 4, Deck 2: Set, preview, jump to</description>
         <status>0x99</status>
         <midino>0x03</midino>
@@ -742,7 +742,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.padUnit.choosenPadInstance.pads[4].input</key>
+        <key>DDJ200.decks.right.padUnit.choosenPadInstance.pads[4].input</key>
         <description>Hotcue 5, Deck 2: Set, preview, jump to</description>
         <status>0x99</status>
         <midino>0x04</midino>
@@ -752,7 +752,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.padUnit.choosenPadInstance.pads[5].input</key>
+        <key>DDJ200.decks.right.padUnit.choosenPadInstance.pads[5].input</key>
         <description>Hotcue 6, Deck 2: Set, preview, jump to</description>
         <status>0x99</status>
         <midino>0x05</midino>
@@ -762,7 +762,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.padUnit.choosenPadInstance.pads[6].input</key>
+        <key>DDJ200.decks.right.padUnit.choosenPadInstance.pads[6].input</key>
         <description>Hotcue 7, Deck 2: Set, preview, jump to</description>
         <status>0x99</status>
         <midino>0x06</midino>
@@ -772,7 +772,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.padUnit.choosenPadInstance.pads[7].input</key>
+        <key>DDJ200.decks.right.padUnit.choosenPadInstance.pads[7].input</key>
         <description>Hotcue 8, Deck 2: Set, preview, jump to</description>
         <status>0x99</status>
         <midino>0x07</midino>
@@ -782,7 +782,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.padUnit.choosenPadInstance.pads[0].input</key>
+        <key>DDJ200.decks.left.padUnit.choosenPadInstance.pads[0].input</key>
         <description>Hotcue 1, Deck 1: Clear</description>
         <status>0x98</status>
         <midino>0x00</midino>
@@ -792,7 +792,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.padUnit.choosenPadInstance.pads[1].input</key>
+        <key>DDJ200.decks.left.padUnit.choosenPadInstance.pads[1].input</key>
         <description>Hotcue 2, Deck 1: Clear</description>
         <status>0x98</status>
         <midino>0x01</midino>
@@ -802,7 +802,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.padUnit.choosenPadInstance.pads[2].input</key>
+        <key>DDJ200.decks.left.padUnit.choosenPadInstance.pads[2].input</key>
         <description>Hotcue 3, Deck 1: Clear</description>
         <status>0x98</status>
         <midino>0x02</midino>
@@ -812,7 +812,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.padUnit.choosenPadInstance.pads[3].input</key>
+        <key>DDJ200.decks.left.padUnit.choosenPadInstance.pads[3].input</key>
         <description>Hotcue 4, Deck 1: Clear</description>
         <status>0x98</status>
         <midino>0x03</midino>
@@ -822,7 +822,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.padUnit.choosenPadInstance.pads[4].input</key>
+        <key>DDJ200.decks.left.padUnit.choosenPadInstance.pads[4].input</key>
         <description>Hotcue 5, Deck 1: Clear</description>
         <status>0x98</status>
         <midino>0x04</midino>
@@ -832,7 +832,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.padUnit.choosenPadInstance.pads[5].input</key>
+        <key>DDJ200.decks.left.padUnit.choosenPadInstance.pads[5].input</key>
         <description>Hotcue 6, Deck 1: Clear</description>
         <status>0x98</status>
         <midino>0x05</midino>
@@ -842,7 +842,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.padUnit.choosenPadInstance.pads[6].input</key>
+        <key>DDJ200.decks.left.padUnit.choosenPadInstance.pads[6].input</key>
         <description>Hotcue 7, Deck 1: Clear</description>
         <status>0x98</status>
         <midino>0x06</midino>
@@ -852,7 +852,7 @@
       </control>
       <control>
         <group>[Channel1]</group>
-        <key>DDJ200.Decks.left.padUnit.choosenPadInstance.pads[7].input</key>
+        <key>DDJ200.decks.left.padUnit.choosenPadInstance.pads[7].input</key>
         <description>Hotcue 8, Deck 1: Clear</description>
         <status>0x98</status>
         <midino>0x07</midino>
@@ -862,7 +862,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.padUnit.choosenPadInstance.pads[0].input</key>
+        <key>DDJ200.decks.right.padUnit.choosenPadInstance.pads[0].input</key>
         <description>Hotcue 1, Deck 2: Clear</description>
         <status>0x9A</status>
         <midino>0x00</midino>
@@ -872,7 +872,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.padUnit.choosenPadInstance.pads[1].input</key>
+        <key>DDJ200.decks.right.padUnit.choosenPadInstance.pads[1].input</key>
         <description>Hotcue 2, Deck 2: Clear</description>
         <status>0x9A</status>
         <midino>0x01</midino>
@@ -882,7 +882,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.padUnit.choosenPadInstance.pads[2].input</key>
+        <key>DDJ200.decks.right.padUnit.choosenPadInstance.pads[2].input</key>
         <description>Hotcue 3, Deck 2: Clear</description>
         <status>0x9A</status>
         <midino>0x02</midino>
@@ -892,7 +892,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.padUnit.choosenPadInstance.pads[3].input</key>
+        <key>DDJ200.decks.right.padUnit.choosenPadInstance.pads[3].input</key>
         <description>Hotcue 4, Deck 2: Clear</description>
         <status>0x9A</status>
         <midino>0x03</midino>
@@ -902,7 +902,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.padUnit.choosenPadInstance.pads[4].input</key>
+        <key>DDJ200.decks.right.padUnit.choosenPadInstance.pads[4].input</key>
         <description>Hotcue 5, Deck 2: Clear</description>
         <status>0x9A</status>
         <midino>0x04</midino>
@@ -912,7 +912,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.padUnit.choosenPadInstance.pads[5].input</key>
+        <key>DDJ200.decks.right.padUnit.choosenPadInstance.pads[5].input</key>
         <description>Hotcue 6, Deck 2: Clear</description>
         <status>0x9A</status>
         <midino>0x05</midino>
@@ -922,7 +922,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.padUnit.choosenPadInstance.pads[6].input</key>
+        <key>DDJ200.decks.right.padUnit.choosenPadInstance.pads[6].input</key>
         <description>Hotcue 7, Deck 2: Clear</description>
         <status>0x9A</status>
         <midino>0x06</midino>
@@ -932,7 +932,7 @@
       </control>
       <control>
         <group>[Channel2]</group>
-        <key>DDJ200.Decks.right.padUnit.choosenPadInstance.pads[7].input</key>
+        <key>DDJ200.decks.right.padUnit.choosenPadInstance.pads[7].input</key>
         <description>Hotcue 8, Deck 2: Clear</description>
         <status>0x9A</status>
         <midino>0x07</midino>

--- a/res/controllers/Pioneer DDJ-200.midi.xml
+++ b/res/controllers/Pioneer DDJ-200.midi.xml
@@ -15,8 +15,8 @@
       <!-- values are actually exponents 2**n-->
       <value label="1/32">-5</value>
       <value label="1/16">-4</value>
-      <value label="1/8" default="true">-3</value>
-      <value label="1/4">-2</value>
+      <value label="1/8">-3</value>
+      <value label="1/4" default="true">-2</value>
       <value label="1/2">-1</value>
       <value label="1">0</value>
       <value label="2">1</value>
@@ -26,12 +26,12 @@
       <value label="32">5</value>
       <value label="64">6</value>
       <value label="128">7</value>
-      <description>This specifies the smallest loop size, the larger loopsizes are automatically available on the other pads. This can also be changed on the fly using :hwbtn:SHIFT + "parameter adjust"</description>
+      <description>This specifies the smallest loop size, the larger loopsizes are automatically available on the other pads.</description>
     </option>
     <option
       variable="defaultBeatJumpRootSize"
       type="enum"
-      label="Loop size of the smallest Pad in BeatJump Padmode">
+      label="Jump size of the smallest Pad in BeatJump Padmode">
       <!-- values are actually exponents 2**n-->
       <value label="1/32">-5</value>
       <value label="1/16">-4</value>
@@ -46,7 +46,7 @@
       <value label="32">5</value>
       <value label="64">6</value>
       <value label="128">7</value>
-      <description>This specifies the smallest loop size, the larger loopsizes are automatically available on the other pads. This can also be changed on the fly using :hwbtn:SHIFT + "parameter adjust"</description>
+      <description>This specifies the smallest jump size, the larger jumpsizes are automatically available on the other pads.</description>
     </option>
   </settings>
   <controller id="DDJ-200 ALT">

--- a/res/controllers/Pioneer DDJ-200.midi.xml
+++ b/res/controllers/Pioneer DDJ-200.midi.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<MixxxControllerPreset schemaVersion="1" mixxxVersion="2.0.0+">
+<MixxxControllerPreset schemaVersion="1" mixxxVersion="2.5.3+">
   <info>
     <name>Pioneer DDJ-200</name>
     <author>Rene (mixxx at absorb.it), Dan Giddins, Frank.Breitling at gmx.de, Geovanni Pacheco</author>

--- a/res/controllers/Pioneer DDJ-200.midi.xml
+++ b/res/controllers/Pioneer DDJ-200.midi.xml
@@ -249,7 +249,7 @@
       </control>
       <control>
         <group>[AutoDJ]</group>
-        <key>DDJ200.transFxButton.shiftedInput</key>
+        <key>DDJ200.transFxButton.input</key>
         <description>Change Pad mode</description>
         <status>0x96</status>
         <midino>0x5A</midino>

--- a/res/controllers/Pioneer DDJ-200.midi.xml
+++ b/res/controllers/Pioneer DDJ-200.midi.xml
@@ -48,6 +48,14 @@
       <value label="128">7</value>
       <description>This specifies the smallest jump size, the larger jumpsizes are automatically available on the other pads.</description>
     </option>
+    <option variable="useSuperAsGain"
+      type="boolean"
+      label="Use Quick Effect Controller Button as Gain Knob"
+      default="false">
+      <description>
+        There is no hardware "Gain" knob on the Pioneer DDJ-200. When enabled, the "Quick Effect" knob can be used to control the gain of the respective deck instead.
+      </description>
+    </option>
   </settings>
   <controller id="DDJ-200 ALT">
     <scriptfiles>

--- a/res/controllers/Pioneer DDJ-200.midi.xml
+++ b/res/controllers/Pioneer DDJ-200.midi.xml
@@ -73,7 +73,7 @@
       </description>
     </option>
   </settings>
-  <controller id="DDJ-200 ALT">
+  <controller id="DDJ-200">
     <scriptfiles>
       <file filename="midi-components-0.0.js" />
       <file functionprefix="DDJ200" filename="Pioneer-DDJ-200-scripts.js" />

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -439,6 +439,7 @@ DDJ200.Deck = function(deckNumbers, midiChannel) {
         },
         inKey: "jog",
         jogCounter: 0,
+        deck: deckNumbers[0],
         inputSeek: function(_channel, _control, value, _status, group) {
             if (DDJ200.decks.left.shiftButton.pressed) {
                 this.jogCounter += this.inValueScale(value);

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -410,9 +410,7 @@ DDJ200.init = function() {
     this.shutdown = function() {
         DDJ200.headMixButton.shutdown();
         DDJ200.transFxButton.shutdown();
-        DDJ200.decks.forEachComponentContainer(deck => {
-            deck.shutdown();
-        }, false);
+        DDJ200.decks.shutdown();
         engine.setValue("[Channel3]", "volume", 0);
         engine.setValue("[Channel4]", "volume", 0);
     };

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -95,7 +95,7 @@ DDJ200.PadModeContainers.Hotcue = function(deckOffset) {
     );
 };
 DDJ200.PadModeContainers.Hotcue.prototype = new DDJ200.PadMode({
-    indicatorStyle: 0x00,
+    indicatorStyle: 0,
 });
 
 DDJ200.PadModeContainers.Loop = function(deckOffset) {
@@ -139,7 +139,7 @@ DDJ200.PadModeContainers.Loop = function(deckOffset) {
     );
 };
 DDJ200.PadModeContainers.Loop.prototype = new DDJ200.PadMode({
-    indicatorStyle: 0x7F,
+    indicatorStyle: 1,
 });
 
 DDJ200.PadModeContainers.Effect = function(deckOffset) {

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -165,14 +165,14 @@ DDJ200.PadModeContainers.Effect = function(deckOffset, group) {
         } else {
             return new components.Button({
                 midi: [0x97 + deckOffset, i],
-                input: function(_channel, _control, value, _status, _g) {
+                indicateButtonPress: function(value) {
+                    this.output(value, null, null);
+                },
+                inSetValue: function(value) {
                     if (value) {
                         bpm.tapButton(script.deckFromGroup(this.group));
                     };
-                    this.send(this.outValueScale(value));
-                },
-                trigger: function(_value) {
-                    this.send(0x00);
+                    this.indicateButtonPress(value);
                 },
             });
         };

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -347,7 +347,7 @@ DDJ200.init = function() {
             components.ComponentContainer.prototype.shift();
         },
         unshift: function() {
-            (this.left.padUnit.choosenPadInstance()).unshift();
+            this.left.padUnit.choosenPadInstance().unshift();
             this.right.padUnit.choosenPadInstance().unshift();
             components.ComponentContainer.prototype.unshift();
         }

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -335,25 +335,29 @@ DDJ200.init = function() {
         outValueScale: function(value) {
             return value >= 0 ? this.on : this.off;
         },
+        indicateDeck: function(show_4decks, _group, _control) {
+            if (!show_4decks) {
+                DDJ200.decks.left.setCurrentDeck("[Channel1]");
+                DDJ200.decks.right.setCurrentDeck("[Channel2]");
+                DDJ200.decks.forEachComponentContainer(deck => {
+                    if (deck.syncButton.blinkConnection) {
+                        deck.syncButton.blinkConnection.disconnect();
+                        deck.syncButton.send(deck.syncButton.off);
+                    };
+                }, false);
+            };
+        },
         shiftedInput: function(_channel, _control, value, _status, _g) {
             if (value) {
                 engine.setValue("[Skin]", "show_4decks", !engine.getValue("[Skin]", "show_4decks"));
-                if (!engine.getValue("[Skin]", "show_4decks")) {
-                    DDJ200.decks.left.setCurrentDeck("[Channel1]");
-                    DDJ200.decks.right.setCurrentDeck("[Channel2]");
-                    DDJ200.decks.forEachComponentContainer(deck => {
-                        if (deck.syncButton.blinkConnection) {
-                            deck.syncButton.blinkConnection.disconnect();
-                            deck.syncButton.send(deck.syncButton.off);
-                        };
-                    }, false);
-                };
             };
         },
         shutdown: function() {
             this.send(this.off);
         }
     });
+    engine.makeConnection("[Skin]", "show_4decks", this.headMixButton.indicateDeck);
+
 
     this.transFxButton = new components.Button({
         midi: [0x96, 0x59],

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -371,7 +371,6 @@ DDJ200.init = function() {
         engine.setValue("[Channel3]", "volume", 0);
         engine.setValue("[Channel4]", "volume", 0);
     };
-    this.shutdown();
 
     // query the controller for current control positions on startup
     midi.sendSysexMsg([0xF0, 0x00, 0x40, 0x05, 0x00, 0x00, 0x02, 0x0a, 0x00, 0x03, 0x01, 0xf7], 12);

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -375,8 +375,8 @@ DDJ200.init = function() {
 
     // query the controller for current control positions on startup
     midi.sendSysexMsg([0xF0, 0x00, 0x40, 0x05, 0x00, 0x00, 0x02, 0x0a, 0x00, 0x03, 0x01, 0xf7], 12);
-    // start with focus on library for selecting tracks (delay seems required)
 
+    // start with focus on library for selecting tracks (delay seems required)
     engine.beginTimer(500, function() {
         engine.setValue("[Library]", "MoveFocus", 1);
     }, true);
@@ -536,7 +536,6 @@ DDJ200.Deck = function(deckNumbers, midiChannel) {
             c.group = this.currentDeck;
         };
     });
-
 };
 
 DDJ200.Deck.prototype = new components.Deck();

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -522,8 +522,8 @@ DDJ200.Deck = function(deckNumbers, midiChannel) {
     };
 
     this.super1 = new components.Pot({
-        group: `[QuickEffectRack1_${this.currentDeck}]`,
-        inKey: "super1",
+        group: (engine.getSetting("useSuperAsGain"))?theDeck.currentDeck:`[QuickEffectRack1_${this.currentDeck}]`,
+        inKey: (engine.getSetting("useSuperAsGain"))?"pregain":"super1",
     });
 
     this.reconnectComponents(function(c) {

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -59,11 +59,6 @@ DDJ200.init = function() {
         engine.setValue("[Library]", "MoveFocus", 1);
     }, true);
 
-    engine.setValue("[Channel3]", "volume", 0);
-    engine.setValue("[Channel4]", "volume", 0);
-    for (let i = 1; i <= 8; i++) {
-        engine.setValue(`[Sampler${i}]`, "pregain", 0.2);
-    };
 
     // query the controller for current control positions on startup
     midi.sendSysexMsg([0xF0, 0x00, 0x40, 0x05, 0x00, 0x00, 0x02, 0x0a, 0x00, 0x03, 0x01, 0xf7], 12);

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -405,9 +405,12 @@ DDJ200.Deck = function(deckNumbers, midiChannel) {
     this.jogWheel = new components.JogWheelBasic({
         wheelResolution: 128,   // how many ticks per revolution the jogwheel has
         alpha: 1/8,             // alpha-filter
+        beta: 1/8/32,
+        rpm: 33 + 1/3,
         inValueScale: function(value) {
             return value - 64;
         },
+        inKey: "jog",
         jogCounter: 0,
         inputSeek: function(_channel, _control, value, _status, group) {
             if (DDJ200.Decks.left.shiftButton.pressed) {

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -243,27 +243,31 @@ DDJ200.Deck = function(deckNumbers, midiChannel) {
     });
 
     this.playButton = new components.PlayButton({
+        midi: [0x8F + midiChannel, 0x0B],
+        sendShifted: true,
+        shiftControl: 1,
+        shiftOffset: 0x3C,
         outKey: "play_indicator",
         shift: function() {
             this.inKey = "reverse";
-            this.midi = [0x8F + midiChannel, 0x47];
         },
         inputFaderStart: function(channel, control, value, status, _g) {
             this.inKey = "play";
             this.input(channel, control, value, status, _g);
-            this.inKey = "reverse";
         },
         unshift: function() {
             this.inKey = "play";
-            this.midi = [0x8F + midiChannel, 0x0B];
         },
     });
 
     this.cueButton = new components.CueButton({
+        midi: [0x8F + midiChannel, 0x0C],
+        sendShifted: true,
+        shiftControl: 1,
+        shiftOffset: 0x3C,
         outKey: "cue_indicator",
         shift: function() {
             this.inKey = "cue_gotoandstop";
-            this.midi = [0x8F + midiChannel, 0x48];
         },
         inputFaderStop: function(channel, control, value, status, _g) {
             this.inKey = "cue_set";
@@ -273,7 +277,6 @@ DDJ200.Deck = function(deckNumbers, midiChannel) {
         },
         unshift: function() {
             this.inKey = "cue_default";
-            this.midi = [0x8F + midiChannel, 0x0C];
         },
     });
 

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -592,7 +592,7 @@ DDJ200.Deck = function(deckNumbers, midiChannel) {
         });
     } else {
         this.super1 = new components.Pot({
-            group: `[QuickEffectRack1_${this.currentDeck}]`;
+            group: `[QuickEffectRack1_${this.currentDeck}]`,
             inKey: "super1",
         });
     }

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -581,10 +581,17 @@ DDJ200.Deck = function(deckNumbers, midiChannel) {
         });
     };
 
-    this.super1 = new components.Pot({
-        group: (engine.getSetting("useSuperAsGain"))?theDeck.currentDeck:`[QuickEffectRack1_${this.currentDeck}]`,
-        inKey: (engine.getSetting("useSuperAsGain"))?"pregain":"super1",
-    });
+    if (engine.getSetting("useSuperAsGain")) {
+        this.super1 = new components.Pot({
+            group: theDeck.currentDeck,
+            inKey: "pregain",
+        });
+    } else {
+        this.super1 = new components.Pot({
+            group: `[QuickEffectRack1_${this.currentDeck}]`;
+            inKey: "super1",
+        });
+    }
 
     this.reconnectComponents(function(c) {
         if (c.group === undefined) {

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -311,8 +311,8 @@ DDJ200.Deck = function(deckNumbers, midiChannel) {
                 };
             },
             updateOutKey: function() {
-                this.outKey = this[`outKey${  DDJ200.padModes[DDJ200.padModeIndex]}`];
                 this.disconnect();
+                this.outKey = this[`outKey${  DDJ200.padModes[DDJ200.padModeIndex]}`];
                 this.connect();
                 this.trigger();
             },

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -346,6 +346,7 @@ DDJ200.init = function() {
                     DDJ200.decks.forEachComponentContainer(deck => {
                         if (deck.syncButton.blinkConnection) {
                             deck.syncButton.blinkConnection.disconnect();
+                            deck.syncButton.send(deck.syncButton.off);
                         };
                     }, false);
                 };
@@ -495,6 +496,7 @@ DDJ200.Deck = class extends components.Deck {
                             });
                         } else if (this.blinkConnection) {
                             this.blinkConnection.disconnect();
+                            theDeck.syncButton.send(theDeck.syncButton.off);
                         };
                     } else {
                         const currentRange = engine.getValue(this.group, "rateRange");

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -516,10 +516,6 @@ DDJ200.Deck = function(deckNumbers, midiChannel) {
         shiftChannel: false,
         shiftControl: true,
         shiftOffset: 0x3C,
-        inputFaderStart: function(channel, control, value, status, _g) {
-            this.inKey = "play";
-            this.input(channel, control, value, status, _g);
-        },
     });
 
     this.cueButton = new components.CueButton({
@@ -527,13 +523,26 @@ DDJ200.Deck = function(deckNumbers, midiChannel) {
         shiftChannel: false,
         shiftControl: true,
         shiftOffset: 0x3C,
-        outKey: "cue_indicator",
-        inputFaderStop: function(channel, control, value, status, _g) {
-            this.inKey = "cue_set";
-            this.input(channel, control, value, status, _g);
-            this.inKey = "cue_gotoandstop";
-            this.input(channel, control, value, status, _g);
+    });
+
+    this.faderStartButton = new components.Button({
+        midi: [0x8F + midiChannel, 0x66],
+        key: "cue_gotoandplay",
+        // type: components.Button.prototype.types.toggle,
+        input: function(channel, control, value, status, _g) {
+            console.warn("faderStart");
+            // according the manual:
+            // Playback starts from the cue point
+            // When no cue point is set, playback starts from the beginning of the track.
+            components.Button.prototype.input.call(this, channel, control, value, status, _g);
         },
+    });
+
+    this.faderStopButton = new components.Button({
+        midi: [0x8F + midiChannel, 0x52],
+        // according the manual:
+        // the track instantly jumps back to the cue point and playback pauses
+        key: "cue_gotoandstop",
     });
 
     this.pflButton = new components.Button({

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -438,12 +438,7 @@ DDJ200.Deck = function(deckNumbers, midiChannel) {
 
     this.loadTrack = new components.Button({
         midi: [0x8F + midiChannel, 0x68],
-        type: components.Button.prototype.types.toggle,
-        input: function(_channel, _control, value, _status, _g) {
-            if (value) { // only if button pressed
-                script.triggerControl(this.group, "LoadSelectedTrack", true);
-            };
-        },
+        inKey: "LoadSelectedTrack",
     });
 
     this.volume = new components.Pot({

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -152,11 +152,26 @@ DDJ200.PadModeContainers.Effect = function(deckOffset, group) {
                 number: deckOffset * 2 + i + 1,
             });
         } else if (i < 7) {
-            return new components.Component({
+            return new components.Button({
                 midi: [0x97 + deckOffset, i],
                 group: `[EffectRack1_EffectUnit${ script.deckFromGroup(group) }_Effect${ i - 3 }]`,
                 inKey: "enabled",
                 outKey: "loaded",
+                type: components.Button.prototype.types.toggle,
+                unshift: function() {
+                    if (this.connections) {
+                        this.disconnect();
+                        this.group = this.group.replace("EffectUnit3", "EffectUnit1").replace("EffectUnit4", "EffectUnit2");
+                        this.connect();
+                        this.trigger();
+                    }
+                },
+                shift: function() {
+                    this.disconnect();
+                    this.group = this.group.replace("EffectUnit1", "EffectUnit3").replace("EffectUnit2", "EffectUnit4");
+                    this.connect();
+                    this.trigger();
+                },
             });
         } else {
             return new components.Button({

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -483,8 +483,6 @@ DDJ200.Deck = class extends components.Deck {
             },
             shiftedInput: function(_channel, _control, value, _status, _g) {
                 if (value) {
-                    midi.sendShortMsg(0x9F, (script.deckFromGroup(theDeck.currentDeck) - 1) % 2, 0x7F);
-
                     if (engine.getValue("[Skin]", "show_4decks")) {
                         theDeck.toggle();
                         theDeck.padUnit.updateDeck(theDeck.currentDeck);

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -317,6 +317,10 @@ DDJ200.PadModeContainers.ModeSelector = function(group) {
         });
     };
 
+    this.shift = () => choosenPadInstance.shift();
+    this.unshift = () => choosenPadInstance.unshift();
+    this.shutdown = () => choosenPadInstance.shutdown();
+
     this.choosenPadInstance = function() {
         return choosenPadInstance;
     };
@@ -328,16 +332,6 @@ DDJ200.init = function() {
     this.decks = new components.ComponentContainer({
         left: new DDJ200.Deck([1, 3], 1),
         right: new DDJ200.Deck([2, 4], 2),
-        shift: function() {
-            this.left.padUnit.choosenPadInstance().shift();
-            this.right.padUnit.choosenPadInstance().shift();
-            components.ComponentContainer.prototype.shift();
-        },
-        unshift: function() {
-            this.left.padUnit.choosenPadInstance().unshift();
-            this.right.padUnit.choosenPadInstance().unshift();
-            components.ComponentContainer.prototype.unshift();
-        }
     });
 
     this.headMixButton = new components.Component({
@@ -412,8 +406,6 @@ DDJ200.init = function() {
         DDJ200.headMixButton.shutdown();
         DDJ200.transFxButton.shutdown();
         DDJ200.decks.shutdown();
-        DDJ200.decks.left.padUnit.choosenPadInstance().shutdown();
-        DDJ200.decks.right.padUnit.choosenPadInstance().shutdown();
         engine.setValue("[Channel3]", "volume", 0);
         engine.setValue("[Channel4]", "volume", 0);
     };

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -146,7 +146,7 @@ DDJ200.PadModeContainers.Loop.prototype = new DDJ200.PadMode({
     indicatorStyle: 1,
 });
 
-DDJ200.PadModeContainers.Effect = function(deckOffset) {
+DDJ200.PadModeContainers.Effect = function(deckOffset, group) {
     DDJ200.PadMode.call(this);
 
     this.constructPads(i => {
@@ -156,17 +156,11 @@ DDJ200.PadModeContainers.Effect = function(deckOffset) {
                 number: deckOffset * 2 + i + 1,
             });
         } else if (i < 7) {
-            return new DDJ200.Pad(i, deckOffset, {
+            return new components.Component({
                 midi: [0x97 + deckOffset, i],
-                input: function(_channel, _control, value, _status, _g) {
-                    const effect = `[EffectRack1_EffectUnit${ script.deckFromGroup(this.group) }_Effect${ i - 3 }]`;
-                    engine.setValue(effect, "enabled", value);
-                    this.send(this.outValueScale(value));
-                },
-                outValueScale: function(_value) {
-                    const effect = `[EffectRack1_EffectUnit${ script.deckFromGroup(this.group) }_Effect${ i - 3 }]`;
-                    return engine.getValue(effect, "loaded")?0x7F:0x00;
-                }
+                group: `[EffectRack1_EffectUnit${ script.deckFromGroup(group) }_Effect${ i - 3 }]`,
+                inKey: "enabled",
+                outKey: "loaded",
             });
         } else {
             return new components.Button({
@@ -282,7 +276,7 @@ DDJ200.PadModeContainers.ModeSelector = function(group) {
 
     this.startupModeInstance = new DDJ200.PadModeContainers.Hotcue(deckOffset);
     this.loopInstance = new DDJ200.PadModeContainers.Loop(deckOffset);
-    this.effectInstance = new DDJ200.PadModeContainers.Effect(deckOffset);
+    this.effectInstance = new DDJ200.PadModeContainers.Effect(deckOffset, group);
     this.jumpInstance = new DDJ200.PadModeContainers.Jump(deckOffset);
 
     this.padInstancesBuffer = new DDJ200.DoubleRingBuffer(

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -575,10 +575,9 @@ DDJ200.Deck = class extends components.Deck {
             });
         }
 
-        this.reconnectComponents(function(c) {
-            if (c.group === undefined) {
-                c.group = this.currentDeck;
-            };
+        // this is required, otherwise there is one connection too much per Component
+        this.forEachComponent(function(component) {
+            component.disconnect();
         });
     }
 

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -201,9 +201,6 @@ DDJ200.Deck = function(deckNumbers, midiChannel) {
     components.Deck.call(this, deckNumbers);
     const theDeck = this;
 
-    // set Pioneer CDJ cue mode for all decks
-    engine.setValue(this.currentDeck, "cue_cdj", true);
-
     this.jogWheel = new components.JogWheelBasic({
         wheelResolution: 128, // how many ticks per revolution the jogwheel has
         alpha: 1/8, // alpha-filter

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -142,8 +142,6 @@ DDJ200.PadModeContainers = {
                     return new components.SamplerButton({
                         midi: [0x97 + deckOffset, i],
                         number: deckOffset * 2 + i + 1,
-                        group,
-                        outConnect: false,
                     });
                 } else if (i < 7) {
                     return new components.Button({

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -49,19 +49,6 @@ Deck n = 0/1:                                   Midi in         Midi out
     Viny Mode on/off                            none            9n 17 hh        OFF=0x00, ON=0x7F (default ON)
 */
 
-/*
-    Disabling Demo Mode according to the user manual:
-    1 - Disconnect the USB cable / power supply
-    2 - Hold both the [SHIFT] and [PLAY/PAUSE] buttons and connect USB cable / power supply
-    3 - Use performance pads to change the settings
-        Pad 1 - Demo mode is switched off
-        Pad 2 - Demo mode starts when you don’t use the unit for 1 minute
-        Pad 3 - Demo mode starts when you don’t use the unit for 5 minutes
-        Pad 4 - Demo mode starts when you don’t use the unit for 10 minutes
-        While saving bottom row of Performance Pads is flashing. Wait till it stops.
-    4 - Disconnect the USB cable / power supply
-*/
-
 // eslint-disable-next-line no-var
 var DDJ200 = { };
 

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -78,20 +78,16 @@ DDJ200.PadMode = function(options) {
 };
 DDJ200.PadMode.prototype = new components.ComponentContainer();
 
-DDJ200.Pad = function(pos, deckOffset, options) {
-    options.midi = [0x97 + deckOffset, pos];
-    options.number = pos + 1;
-    components.HotcueButton.call(this, options);
-};
-DDJ200.Pad.prototype = new components.HotcueButton({});
-
 DDJ200.PadModeContainers = {};
 
 DDJ200.PadModeContainers.Hotcue = function(deckOffset) {
     DDJ200.PadMode.call(this);
 
     this.constructPads(i =>
-        new DDJ200.Pad(i, deckOffset, { })
+        new components.HotcueButton({
+            midi: [0x97 + deckOffset, i],
+            number: i + 1,
+        })
     );
 };
 DDJ200.PadModeContainers.Hotcue.prototype = new DDJ200.PadMode({

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -452,7 +452,7 @@ DDJ200.Deck = function(deckNumbers, midiChannel) {
         inKey: "jog",
         jogCounter: 0,
         deck: deckNumbers[0],
-        inputSeek: function(_channel, _control, value, _status, group) {
+        inputSeek: function(_channel, _control, value, _status, _group) {
             if (DDJ200.decks.left.shiftButton.pressed) {
                 this.jogCounter += this.inValueScale(value);
                 if (this.jogCounter > 9) {
@@ -463,6 +463,7 @@ DDJ200.Deck = function(deckNumbers, midiChannel) {
                     this.jogCounter = 0;
                 };
             } else {
+                const group = `[Channel${  this.deck  }]`; // fix for wrong group
                 const oldPos = engine.getValue(group, "playposition");
                 // Since ‘playposition’ is normalized to unity, we need to scale by
                 // song duration in order for the jog wheel to cover the same amount

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -316,11 +316,11 @@ DDJ200.init = function() {
                 if (!engine.getValue("[Skin]", "show_4decks")) {
                     DDJ200.decks.left.setCurrentDeck("[Channel1]");
                     DDJ200.decks.right.setCurrentDeck("[Channel2]");
-                    Object.values(DDJ200.decks).forEach(deck => {
+                    DDJ200.decks.forEachComponentContainer(deck => {
                         if (deck.syncButton.blinkConnection) {
                             deck.syncButton.blinkConnection.disconnect();
                         };
-                    });
+                    }, false);
                 };
             };
         },
@@ -337,9 +337,9 @@ DDJ200.init = function() {
 
         input: function(_channel, control, value, _status, _g) {
             if (value) {
-                Object.values(DDJ200.decks).forEach(deck => {
+                DDJ200.decks.forEachComponentContainer(deck => {
                     deck.padUnit.input((control === 0x5A));
-                });
+                }, false);
                 this.indicatePadMode();
             };
         },
@@ -365,9 +365,9 @@ DDJ200.init = function() {
     this.shutdown = function() {
         DDJ200.headMixButton.shutdown();
         DDJ200.transFxButton.shutdown();
-        Object.values(DDJ200.decks).forEach(deck => {
+        DDJ200.decks.forEachComponentContainer(deck => {
             deck.shutdown();
-        });
+        }, false);
         engine.setValue("[Channel3]", "volume", 0);
         engine.setValue("[Channel4]", "volume", 0);
     };
@@ -423,13 +423,13 @@ DDJ200.Deck = function(deckNumbers, midiChannel) {
         pressed: 0,
         input: function(_channel, _control, value, _status, _g) {
             this.pressed = value;
-            Object.values(DDJ200.decks).forEach(deck => {
+            DDJ200.decks.forEachComponentContainer(deck => {
                 if (value) {
                     deck.shift();
                 } else {
                     deck.unshift();
                 };
-            });
+            }, false);
         },
     });
 

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -498,9 +498,7 @@ DDJ200.Deck = function(deckNumbers, midiChannel) {
             if (value) {
                 if (engine.getValue("[Skin]", "show_4decks")) {
                     theDeck.toggle();
-                    DDJ200.decks.forEachComponentContainer(deck => {
-                        deck.padUnit.updateDeck(deck.currentDeck);
-                    }, false);
+                    theDeck.padUnit.updateDeck(theDeck.currentDeck);
                     if (theDeck.currentDeck === "[Channel3]" || theDeck.currentDeck === "[Channel4]") {
                         this.blinkConnection = engine.makeConnection("[App]", "indicator_250ms", function(value, _group, _control) {
                             theDeck.syncButton.send(theDeck.syncButton.on * value);

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -282,7 +282,7 @@ DDJ200.PadModeContainers.ModeSelector = class extends components.ComponentContai
         this.setPads(this.padInstancesBuffer.current());
     }
 
-    updateDeckHelper(padInstance, newGroup) {
+    setCurrentDeckHelper(padInstance, newGroup) {
         padInstance.forEachComponent(function(component) {
             if (padInstance === this.choosenPadInstance) {
                 component.disconnect();
@@ -300,12 +300,12 @@ DDJ200.PadModeContainers.ModeSelector = class extends components.ComponentContai
         });
     }
 
-    updateDeck(currentDeck) {
+    setCurrentDeck(newGroup) {
         this.padInstancesBuffer.indexable[0].forEach(padInstance => {
-            this.updateDeckHelper(padInstance, currentDeck);
+            this.setCurrentDeckHelper(padInstance, newGroup);
         });
         this.padInstancesBuffer.indexable[1].forEach(padInstance => {
-            this.updateDeckHelper(padInstance, currentDeck);
+            this.setCurrentDeckHelper(padInstance, newGroup);
         });
     }
 
@@ -340,9 +340,7 @@ DDJ200.init = function() {
                 engine.setValue("[Skin]", "show_4decks", !engine.getValue("[Skin]", "show_4decks"));
                 if (!engine.getValue("[Skin]", "show_4decks")) {
                     DDJ200.decks.left.setCurrentDeck("[Channel1]");
-                    DDJ200.decks.left.padUnit.updateDeck("[Channel1]");
                     DDJ200.decks.right.setCurrentDeck("[Channel2]");
-                    DDJ200.decks.right.padUnit.updateDeck("[Channel2]");
                     DDJ200.decks.forEachComponentContainer(deck => {
                         if (deck.syncButton.blinkConnection) {
                             deck.syncButton.blinkConnection.disconnect();
@@ -485,7 +483,6 @@ DDJ200.Deck = class extends components.Deck {
                 if (value) {
                     if (engine.getValue("[Skin]", "show_4decks")) {
                         theDeck.toggle();
-                        theDeck.padUnit.updateDeck(theDeck.currentDeck);
                         if (theDeck.currentDeck === "[Channel3]" || theDeck.currentDeck === "[Channel4]") {
                             this.blinkConnection = engine.makeConnection("[App]", "indicator_250ms", function(value, _group, _control) {
                                 theDeck.syncButton.send(theDeck.syncButton.on * value);
@@ -579,5 +576,10 @@ DDJ200.Deck = class extends components.Deck {
                 c.group = this.currentDeck;
             };
         });
+    }
+
+    setCurrentDeck(newGroup) {
+        this.padUnit.setCurrentDeck(newGroup);
+        super.setCurrentDeck(newGroup);
     }
 };

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -154,13 +154,14 @@ DDJ200.PadModeContainers.Effect = function(deckOffset) {
         } else if (i < 7) {
             return new DDJ200.Pad(i, deckOffset, {
                 midi: [0x97 + deckOffset, i],
-                effect: `[EffectRack1_EffectUnit${  deckOffset / 2 + 1  }_Effect${  i - 3  }]`,
                 input: function(_channel, _control, value, _status, _g) {
-                    engine.setValue(this.effect, "enabled", value);
+                    const effect = `[EffectRack1_EffectUnit${ script.deckFromGroup(this.group) }_Effect${ i - 3 }]`;
+                    engine.setValue(effect, "enabled", value);
                     this.send(this.outValueScale(value));
                 },
                 outValueScale: function(_value) {
-                    return engine.getValue(this.effect, "loaded")?0x7F:0x00;
+                    const effect = `[EffectRack1_EffectUnit${ script.deckFromGroup(this.group) }_Effect${ i - 3 }]`;
+                    return engine.getValue(effect, "loaded")?0x7F:0x00;
                 }
             });
         } else {

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -577,6 +577,9 @@ DDJ200.Deck = class extends components.Deck {
 
         // this is required, otherwise there is one connection too much per Component
         this.forEachComponent(function(component) {
+            if (component.group === undefined) {
+                component.group = this.currentDeck;
+            };
             component.disconnect();
         });
     }

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -45,6 +45,7 @@ Deck n = 0/1:                                   Midi in         Midi out
     PAD 8           press                       9p  07  hh      [midi in]       OFF=0x00, ON=0x7F
 */
 
+// eslint-disable-next-line no-var
 var DDJ200 = { };
 
 DDJ200.init = function() {

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -584,5 +584,4 @@ DDJ200.Deck = function(deckNumbers, midiChannel) {
         };
     });
 };
-
-DDJ200.Deck.prototype = new components.Deck();
+DDJ200.Deck.prototype = new components.Deck(2);

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -52,8 +52,6 @@ DDJ200.init = function() {
     DDJ200.leftDeck = new DDJ200.Deck([1, 3], 1);
     DDJ200.rightDeck = new DDJ200.Deck([2, 4], 2);
 
-    DDJ200.LEDsOff();
-
     // start with focus on library for selecting tracks (delay seems required)
     engine.beginTimer(500, function() {
         engine.setValue("[Library]", "MoveFocus", 1);
@@ -65,33 +63,8 @@ DDJ200.init = function() {
 };
 
 DDJ200.shutdown = function() {
-    DDJ200.LEDsOff();
-};
-
-DDJ200.LEDsOff = function() {                         // turn off LED buttons:
-    for (let i = 0; i <= 1; i++) {
-        midi.sendShortMsg(0x96 + i, 0x63, 0x00);      // set headphone master
-        midi.sendShortMsg(0x90 + i, 0x54, 0x00);      // pfl headphone
-        midi.sendShortMsg(0x90 + i, 0x58, 0x00);      // beat sync
-        midi.sendShortMsg(0x90 + i, 0x0B, 0x00);      // play
-        midi.sendShortMsg(0x90 + i, 0x0C, 0x00);      // cue
-        for (let j = 0; j <= 8; j++) {
-            midi.sendShortMsg(0x97 + 2 * i, j, 0x00); // hotcue
-        };
-    };
-};
-
-DDJ200.padLEDsOff = function() {                         // turn off LED buttons:
-    for (let i = 0; i <= 1; i++) {
-        midi.sendShortMsg(0x96 + i, 0x63, 0x00);      // set headphone master
-        midi.sendShortMsg(0x90 + i, 0x54, 0x00);      // pfl headphone
-        midi.sendShortMsg(0x90 + i, 0x58, 0x00);      // beat sync
-        midi.sendShortMsg(0x90 + i, 0x0B, 0x00);      // play
-        midi.sendShortMsg(0x90 + i, 0x0C, 0x00);      // cue
-        for (let j = 0; j <= 8; j++) {
-            midi.sendShortMsg(0x97 + 2 * i, j, 0x00); // hotcue
-        };
-    };
+    DDJ200.leftDeck.shutdown();
+    DDJ200.rightDeck.shutdown();
 };
 
 DDJ200.padModes = ["Hotcue", "Loop", "Effect", "Jump"];

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -431,7 +431,8 @@ DDJ200.Deck = class extends components.Deck {
             jogCounter: 0,
             deck: deckNumbers[0],
             inputSeek: function(_channel, _control, value, _status, _group) {
-                if (DDJ200.decks.left.shiftButton.pressed) {
+                if ((engine.getSetting("useLeftShiftAsLibraryScroll") && DDJ200.decks.left.shiftButton.pressed) ||
+                    (engine.getSetting("useRightShiftAsLibraryScroll") && DDJ200.decks.right.shiftButton.pressed)) {
                     this.jogCounter += this.inValueScale(value);
                     if (this.jogCounter > 9) {
                         engine.setValue("[Library]", "MoveDown", true);
@@ -459,6 +460,9 @@ DDJ200.Deck = class extends components.Deck {
             input: function(_channel, _control, value, _status, _g) {
                 this.pressed = value;
                 if (value) {
+                    if (DDJ200.decks.left.shiftButton.pressed && DDJ200.decks.right.shiftButton.pressed) {
+                        engine.setValue("[Library]", "MoveFocusForward", true);
+                    }
                     DDJ200.decks.shift();
                 } else {
                     DDJ200.decks.unshift();

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -401,6 +401,7 @@ DDJ200.init = function() {
                     DDJ200.transFxButton.send(DDJ200.transFxButton.on * value);
                 });
             } else {
+                this.blinkConnection = undefined;
                 this.send(this.on * this.indicatorStyle());
             };
         },

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -354,7 +354,9 @@ DDJ200.init = function() {
                 engine.setValue("[Skin]", "show_4decks", !engine.getValue("[Skin]", "show_4decks"));
                 if (!engine.getValue("[Skin]", "show_4decks")) {
                     DDJ200.decks.left.setCurrentDeck("[Channel1]");
+                    DDJ200.decks.left.padUnit.updateDeck("[Channel1]");
                     DDJ200.decks.right.setCurrentDeck("[Channel2]");
+                    DDJ200.decks.right.padUnit.updateDeck("[Channel2]");
                     DDJ200.decks.forEachComponentContainer(deck => {
                         if (deck.syncButton.blinkConnection) {
                             deck.syncButton.blinkConnection.disconnect();

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -493,16 +493,9 @@ DDJ200.Deck = function(deckNumbers, midiChannel) {
         shiftChannel: false,
         shiftControl: true,
         shiftOffset: 0x3C,
-        outKey: "play_indicator",
-        shift: function() {
-            this.inKey = "reverse";
-        },
         inputFaderStart: function(channel, control, value, status, _g) {
             this.inKey = "play";
             this.input(channel, control, value, status, _g);
-        },
-        unshift: function() {
-            this.inKey = "play";
         },
     });
 
@@ -512,17 +505,11 @@ DDJ200.Deck = function(deckNumbers, midiChannel) {
         shiftControl: true,
         shiftOffset: 0x3C,
         outKey: "cue_indicator",
-        shift: function() {
-            this.inKey = "cue_gotoandstop";
-        },
         inputFaderStop: function(channel, control, value, status, _g) {
             this.inKey = "cue_set";
             this.input(channel, control, value, status, _g);
             this.inKey = "cue_gotoandstop";
             this.input(channel, control, value, status, _g);
-        },
-        unshift: function() {
-            this.inKey = "cue_default";
         },
     });
 

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -458,7 +458,7 @@ DDJ200.Deck = class extends components.Deck {
             input: function(_channel, _control, value, _status, _g) {
                 this.pressed = value;
                 if (value) {
-                    if (DDJ200.decks.left.shiftButton.pressed && DDJ200.decks.right.shiftButton.pressed) {
+                    if (theDeck.bothShift()) {
                         engine.setValue("[Library]", "MoveFocusForward", true);
                     }
                     DDJ200.decks.shift();
@@ -490,7 +490,7 @@ DDJ200.Deck = class extends components.Deck {
             },
             shiftedInput: function(_channel, _control, value, _status, _g) {
                 if (value) {
-                    if (engine.getValue("[Skin]", "show_4decks")) {
+                    if (engine.getValue("[Skin]", "show_4decks") && !theDeck.bothShift()) {
                         theDeck.toggle();
                         if (theDeck.currentDeck === "[Channel3]" || theDeck.currentDeck === "[Channel4]") {
                             this.blinkConnection = engine.makeConnection("[App]", "indicator_250ms", function(value, _group, _control) {
@@ -592,5 +592,9 @@ DDJ200.Deck = class extends components.Deck {
     setCurrentDeck(newGroup) {
         this.padUnit.setCurrentDeck(newGroup);
         super.setCurrentDeck(newGroup);
+    }
+
+    bothShift() {
+        return (DDJ200.decks.left.shiftButton.pressed && DDJ200.decks.right.shiftButton.pressed);
     }
 };

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -442,16 +442,16 @@ DDJ200.Deck = function(deckNumbers, midiChannel) {
         shiftOffset: 8,
         input: function(_channel, _control, value, _status, _g) {
             if (value) {
-                if (engine.getValue(this.group, "sync_enabled") === 0) {
+                if (this.inGetValue() === 0) {
                     engine.setValue(this.group, "beatsync", 1);
                 } else {
-                    engine.setValue(this.group, "sync_enabled", 0);
+                    this.inSetValue(0);
                 };
             };
         },
         inputLongPress: function(_channel, _control, value, _status, _g) {
             if (value) {
-                engine.setValue(this.group, "sync_enabled", 1);
+                this.inSetValue(1);
             };
         },
         shiftedInput: function(_channel, _control, value, _status, _g) {
@@ -460,7 +460,7 @@ DDJ200.Deck = function(deckNumbers, midiChannel) {
                     theDeck.toggle();
                     if (theDeck.currentDeck === "[Channel3]" || theDeck.currentDeck === "[Channel4]") {
                         this.blinkConnection = engine.makeConnection("[App]", "indicator_250ms", function(value, _group, _control) {
-                            theDeck.syncButton.send(0x7F * value);
+                            theDeck.syncButton.send(theDeck.syncButton.on * value);
                         });
                     } else if (this.blinkConnection) {
                         this.blinkConnection.disconnect();

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -325,7 +325,7 @@ DDJ200.PadModeContainers.ModeSelector = function(group) {
         padInstancesBuffer.indexable[0].forEach(function(padInstance) {
             updateDeckHelper(padInstance, currentDeck);
         });
-        padInstancesBuffer.indexable[0].forEach(function(padInstance) {
+        padInstancesBuffer.indexable[1].forEach(function(padInstance) {
             updateDeckHelper(padInstance, currentDeck);
         });
     };

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -290,10 +290,10 @@ DDJ200.PadModeContainers.ModeSelector = function(group) {
 DDJ200.PadModeContainers.ModeSelector.prototype = new components.ComponentContainer();
 
 DDJ200.init = function() {
-    this.Decks = {
+    this.decks = new components.ComponentContainer({
         left: new DDJ200.Deck([1, 3], 1),
         right: new DDJ200.Deck([2, 4], 2),
-    };
+    });
 
     this.headMixButton = new components.Component({
         midi: [0x96, 0x63],
@@ -314,9 +314,9 @@ DDJ200.init = function() {
             if (value) {
                 engine.setValue("[Skin]", "show_4decks", !engine.getValue("[Skin]", "show_4decks"));
                 if (!engine.getValue("[Skin]", "show_4decks")) {
-                    DDJ200.Decks.left.setCurrentDeck("[Channel1]");
-                    DDJ200.Decks.right.setCurrentDeck("[Channel2]");
-                    Object.values(DDJ200.Decks).forEach(deck => {
+                    DDJ200.decks.left.setCurrentDeck("[Channel1]");
+                    DDJ200.decks.right.setCurrentDeck("[Channel2]");
+                    Object.values(DDJ200.decks).forEach(deck => {
                         if (deck.syncButton.blinkConnection) {
                             deck.syncButton.blinkConnection.disconnect();
                         };
@@ -337,7 +337,7 @@ DDJ200.init = function() {
 
         input: function(_channel, control, value, _status, _g) {
             if (value) {
-                Object.values(DDJ200.Decks).forEach(deck => {
+                Object.values(DDJ200.decks).forEach(deck => {
                     deck.padUnit.input((control === 0x5A));
                 });
                 this.indicatePadMode();
@@ -345,7 +345,7 @@ DDJ200.init = function() {
         },
         indicatorStyle: function() {
             // use left Deck as reference for selected padInstance
-            return DDJ200.Decks.left.padUnit.choosenPadInstance.indicatorStyle;
+            return DDJ200.decks.left.padUnit.choosenPadInstance.indicatorStyle;
         },
         blinkConnection: undefined,
         indicatePadMode: function() {
@@ -365,7 +365,7 @@ DDJ200.init = function() {
     this.shutdown = function() {
         DDJ200.headMixButton.shutdown();
         DDJ200.transFxButton.shutdown();
-        Object.values(DDJ200.Decks).forEach(deck => {
+        Object.values(DDJ200.decks).forEach(deck => {
             deck.shutdown();
         });
         engine.setValue("[Channel3]", "volume", 0);
@@ -397,7 +397,7 @@ DDJ200.Deck = function(deckNumbers, midiChannel) {
         inKey: "jog",
         jogCounter: 0,
         inputSeek: function(_channel, _control, value, _status, group) {
-            if (DDJ200.Decks.left.shiftButton.pressed) {
+            if (DDJ200.decks.left.shiftButton.pressed) {
                 this.jogCounter += this.inValueScale(value);
                 if (this.jogCounter > 9) {
                     engine.setValue("[Library]", "MoveDown", true);
@@ -423,7 +423,7 @@ DDJ200.Deck = function(deckNumbers, midiChannel) {
         pressed: 0,
         input: function(_channel, _control, value, _status, _g) {
             this.pressed = value;
-            Object.values(DDJ200.Decks).forEach(deck => {
+            Object.values(DDJ200.decks).forEach(deck => {
                 if (value) {
                     deck.shift();
                 } else {

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -295,16 +295,20 @@ DDJ200.init = function() {
         right: new DDJ200.Deck([2, 4], 2),
     };
 
-    this.headMixButton = new components.Button({
+    this.headMixButton = new components.Component({
         midi: [0x96, 0x63],
         key: "headMix",
-        type: components.Button.prototype.types.toggle,
-        input: function(_channel, _control, value, _status, _g) {
+        group: "[Master]",
+        on: 0x7F,
+        off: 0x00,
+        inValueScale: function(value) {
             if (value) {
-                const masterMixEnabled = (engine.getValue("[Master]", "headMix") >= 0);
-                engine.setValue("[Master]", "headMix", masterMixEnabled ? -1 : 0);
-                this.send(masterMixEnabled?0:0x7F); // set LED
-            };
+                return (this.inGetValue() >= 0) ? -1 : 1;
+            }
+            return this.inGetValue();
+        },
+        outValueScale: function(value) {
+            return value >= 0 ? this.on : this.off;
         },
         shiftedInput: function(_channel, _control, value, _status, _g) {
             if (value) {
@@ -320,6 +324,9 @@ DDJ200.init = function() {
                 };
             };
         },
+        shutdown: function() {
+            this.send(this.off);
+        }
     });
 
     this.transFxButton = new components.Button({

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -209,18 +209,14 @@ DDJ200.Deck = function(deckNumbers, midiChannel) {
     this.syncButton = new components.Button({
         midi: [0x8F + midiChannel, 0x58],
         key: "sync_enabled",
-        input: function(_channel, _control, value, _status, _g) {
+        inputLongPress: function(_channel, _control, value, _status, _g) {
             if (value) {
                 if (engine.getValue(this.group, "sync_enabled") === 0) {
                     engine.setValue(this.group, "beatsync", 1);
+                    engine.setValue(this.group, "sync_enabled", 1);
                 } else {
                     engine.setValue(this.group, "sync_enabled", 0);
-                };
-            };
-        },
-        inputLongPress: function(_channel, _control, value, _status, _g) {
-            if (value) {
-                engine.setValue(this.group, "sync_enabled", 1);
+                }
             };
         },
         shiftedInput: function(_channel, _control, value, _status, _g) {
@@ -247,16 +243,10 @@ DDJ200.Deck = function(deckNumbers, midiChannel) {
         sendShifted: true,
         shiftControl: 1,
         shiftOffset: 0x3C,
-        outKey: "play_indicator",
-        shift: function() {
-            this.inKey = "reverse";
-        },
         inputFaderStart: function(channel, control, value, status, _g) {
+            // will trigger "reverse" if not handled separately
             this.inKey = "play";
             this.input(channel, control, value, status, _g);
-        },
-        unshift: function() {
-            this.inKey = "play";
         },
     });
 
@@ -265,18 +255,11 @@ DDJ200.Deck = function(deckNumbers, midiChannel) {
         sendShifted: true,
         shiftControl: 1,
         shiftOffset: 0x3C,
-        outKey: "cue_indicator",
-        shift: function() {
-            this.inKey = "cue_gotoandstop";
-        },
         inputFaderStop: function(channel, control, value, status, _g) {
             this.inKey = "cue_set";
             this.input(channel, control, value, status, _g);
             this.inKey = "cue_gotoandstop";
             this.input(channel, control, value, status, _g);
-        },
-        unshift: function() {
-            this.inKey = "cue_default";
         },
     });
 

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -399,6 +399,10 @@ DDJ200.init = function() {
     // query the controller for current control positions on startup
     midi.sendSysexMsg([0xF0, 0x00, 0x40, 0x05, 0x00, 0x00, 0x02, 0x0a, 0x00, 0x03, 0x01, 0xf7], 12);
 
+    // reset start volume of channels 3 and 4 (can't be read from 2-deck controller)
+    engine.setValue("[Channel3]", "volume", 0);
+    engine.setValue("[Channel4]", "volume", 0);
+
     // start with focus on library for selecting tracks (delay seems required)
     engine.beginTimer(500, function() {
         engine.setValue("[Library]", "MoveFocus", 1);

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -549,12 +549,14 @@ DDJ200.Deck = class extends components.Deck {
 
         this.pflButton = new components.Button({
             midi: [0x8F + midiChannel, 0x54],
+            sendShifted: false,
             key: "pfl",
             type: components.Button.prototype.types.toggle,
         });
 
         this.loadTrack = new components.Button({
             midi: [0x8F + midiChannel, 0x68],
+            sendShifted: false,
             inKey: "LoadSelectedTrack",
         });
 

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -43,6 +43,10 @@ Deck n = 0/1:                                   Midi in         Midi out
     PAD 6           press                       9p  05  hh      [midi in]       OFF=0x00, ON=0x7F
     PAD 7           press                       9p  06  hh      [midi in]       OFF=0x00, ON=0x7F
     PAD 8           press                       9p  07  hh      [midi in]       OFF=0x00, ON=0x7F
+
+    Loaded Deck1                                none            9F 00 7F        blinking PADs 1-4 followed by PADs 5-8
+    Loaded Deck2                                none            9F 01 7F        blinking PADs 1-4 followed by PADs 5-8
+    Viny Mode on/off                            none            9n 17 hh        OFF=0x00, ON=0x7F (default ON)
 */
 
 /*

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -337,6 +337,16 @@ DDJ200.init = function() {
     this.decks = new components.ComponentContainer({
         left: new DDJ200.Deck([1, 3], 1),
         right: new DDJ200.Deck([2, 4], 2),
+        shift: function() {
+            this.left.padUnit.choosenPadInstance().shift();
+            this.right.padUnit.choosenPadInstance().shift();
+            components.ComponentContainer.prototype.shift();
+        },
+        unshift: function() {
+            (this.left.padUnit.choosenPadInstance()).unshift();
+            this.right.padUnit.choosenPadInstance().unshift();
+            components.ComponentContainer.prototype.unshift();
+        }
     });
 
     this.headMixButton = new components.Component({
@@ -411,6 +421,8 @@ DDJ200.init = function() {
         DDJ200.headMixButton.shutdown();
         DDJ200.transFxButton.shutdown();
         DDJ200.decks.shutdown();
+        DDJ200.decks.left.padUnit.choosenPadInstance().shutdown();
+        DDJ200.decks.right.padUnit.choosenPadInstance().shutdown();
         engine.setValue("[Channel3]", "volume", 0);
         engine.setValue("[Channel4]", "volume", 0);
     };

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -468,13 +468,11 @@ DDJ200.Deck = function(deckNumbers, midiChannel) {
         pressed: 0,
         input: function(_channel, _control, value, _status, _g) {
             this.pressed = value;
-            DDJ200.decks.forEachComponentContainer(deck => {
-                if (value) {
-                    deck.shift();
-                } else {
-                    deck.unshift();
-                };
-            }, false);
+            if (value) {
+                DDJ200.decks.shift();
+            } else {
+                DDJ200.decks.unshift();
+            }
         },
     });
 

--- a/res/controllers/Pioneer-DDJ-200-scripts.js
+++ b/res/controllers/Pioneer-DDJ-200-scripts.js
@@ -280,6 +280,11 @@ DDJ200.PadModeContainers.ModeSelector = class extends components.ComponentContai
             this.padInstancesBuffer.next();
         };
         this.setPads(this.padInstancesBuffer.current());
+        if (isShifted) {
+            this.choosenPadInstance.shift();
+        } else {
+            this.choosenPadInstance.unshift();
+        }
     }
 
     setCurrentDeckHelper(padInstance, newGroup) {


### PR DESCRIPTION
The current implementation for this controller has some issues with the hotcue buttons not working as expected.

This is a rewrite of this controller implementation which fixes these issues. Beside all standard features some special things have been taken over from the already existing DDJ-200 script or added:

- 4 Deck control possible
- Select and load tracks from within the controller
- use pad buttons for
  - hotcues (ok, standard)
  - loops
  - effects and samples
  - beatjump

See
- https://github.com/absorb-it/Pioneer-DDJ-200-Mixxx
- https://mixxx.discourse.group/t/new-mapping-for-pioneer-ddj-200/31164/4
- https://mixxx.discourse.group/t/pioneer-ddj-200-mapping/18259/19