### PR TITLE
(fix) LateNight: work around style bug in Qt 6.9.2

### DIFF
--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -1129,6 +1129,12 @@ WLibrarySidebar QMenu,
 WTrackTableViewHeader QMenu,
 WTrackTableViewHeader QMenu QCheckBox,
 WLibraryTextBrowser QMenu,
+/* Workaround for https://github.com/mixxxdj/mixxx/issues/15351, happening with Qt 6.9.2 on Linux:
+   #Deck1 #Keytext { color: ...;} won't be applied if #Keytext or WStarRating are in SingletonContainers.
+   Only `color` seems to be affected.
+   Just set the font by widget type for all decks here and override below with working Qt versions. */
+WKey, WStarRating,
+/* end fix */
 WTrackMenu,
 WTrackMenu QMenu,
 WTrackMenu QMenu QCheckBox,

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -1229,6 +1229,12 @@ WLibrarySidebar QMenu,
 WTrackTableViewHeader QMenu,
 WTrackTableViewHeader QMenu QCheckBox,
 WLibraryTextBrowser QMenu,
+/* Workaround for https://github.com/mixxxdj/mixxx/issues/15351, happening with Qt 6.9.2 on Linux:
+   #Deck1 #Keytext { color: ...;} won't be applied if #Keytext or WStarRating are in SingletonContainers.
+   Only `color` seems to be affected.
+   Just set the font by widget type for all decks here and override below with working Qt versions. */
+WKey, WStarRating,
+/* end fix */
 WTrackMenu,
 WTrackMenu QMenu,
 WTrackMenu QMenu QCheckBox,


### PR DESCRIPTION
Closes #15351 

### Issue
with Qt 6.9.2 (on Linux at least) seems to be that we can not set the **font color** on widgets anymore by **objectName()** like this
`#Deck1 #Widget { color: blue; }`
if
* `#Deck1` is a Widget(Group) inside a SingletonContainer and
* `#Widget` is also inside a SingletonContainer
-> WKey and WStarRating widgets

Still works for icons and background-color though.

### Fix
Set color for key and rating widgets in all decks, and let working Qt versions override for decks 3/4.

Minor drawback/inconsistency: same rating/key color in all decks with Qt 6.9.2+ (until they fixed it)