### PR TITLE
feat: add `[Main], pfl` CO to send main output to PFL channel

### DIFF
--- a/src/engine/enginemixer.h
+++ b/src/engine/enginemixer.h
@@ -318,6 +318,7 @@ class EngineMixer : public QObject, public AudioSource {
     std::unique_ptr<ControlPotmeter> m_pXFaderCalibration;
     std::unique_ptr<ControlPushButton> m_pXFaderReverse;
     std::unique_ptr<ControlPushButton> m_pHeadSplitEnabled;
+    std::unique_ptr<ControlPushButton> m_pMainPfl;
     std::unique_ptr<ControlObject> m_pKeylockEngine;
 
     PflGainCalculator m_headphoneGain;


### PR DESCRIPTION
Fixes #15412

I didn't find a good way to add a button for this to LateNight, I'm hoping you have an idea @ronso0 