### PR TITLE
fix: initialize `allshader::WaveformWidget::m_type`

### DIFF
--- a/src/waveform/widgets/allshader/waveformwidget.cpp
+++ b/src/waveform/widgets/allshader/waveformwidget.cpp
@@ -28,6 +28,7 @@ WaveformWidget::WaveformWidget(QWidget* parent,
         WaveformRendererSignalBase::Options options)
         : WGLWidget(parent),
           WaveformWidgetAbstract(group),
+          m_type(type),
           m_pWaveformRendererSignal(nullptr) {
     auto pTopNode = std::make_unique<rendergraph::Node>();
     auto pOpacityNode = std::make_unique<rendergraph::OpacityNode>();


### PR DESCRIPTION
Otherwise this would not only be a case of using unitialized memory, but even if the memory was 0 by chance (seemed to be the case), the waveform viewer would think the waveform is actually empty and thus refuse any interaction with it. So this fixes both a memory safety issue and a user-facing bug.

Fixes #15374