### PR TITLE
Add QmlControlProxy::trigger()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2712,6 +2712,7 @@ if(BUILD_TESTING)
       PRIVATE
         src/test/controller_mapping_file_handler_test.cpp
         src/test/controllerrenderingengine_test.cpp
+        src/test/qmlcontrolproxytest.cpp
     )
   endif()
 

--- a/res/qml/Sampler.qml
+++ b/res/qml/Sampler.qml
@@ -165,11 +165,6 @@ Rectangle {
     Mixxx.ControlProxy {
         id: ejectControl
 
-        function trigger() {
-            this.value = 1;
-            this.value = 0;
-        }
-
         group: root.group
         key: "eject"
     }

--- a/src/qml/qmlcontrolproxy.cpp
+++ b/src/qml/qmlcontrolproxy.cpp
@@ -184,8 +184,7 @@ void QmlControlProxy::slotControlProxyValueChanged(double newValue) {
 
 void QmlControlProxy::trigger() {
     setValue(1);
-    // Use a single-shot timer to ensure the event loop processes the change
-    QTimer::singleShot(0, this, [this]() { setValue(0); });
+    setValue(0);
 }
 
 } // namespace qml

--- a/src/qml/qmlcontrolproxy.cpp
+++ b/src/qml/qmlcontrolproxy.cpp
@@ -182,5 +182,11 @@ void QmlControlProxy::slotControlProxyValueChanged(double newValue) {
     emit parameterChanged(m_pControlProxy->getParameter());
 }
 
+void QmlControlProxy::trigger() {
+    setValue(1);
+    // Use a single-shot timer to ensure the event loop processes the change
+    QTimer::singleShot(0, this, [this]() { setValue(0); });
+}
+
 } // namespace qml
 } // namespace mixxx

--- a/src/qml/qmlcontrolproxy.h
+++ b/src/qml/qmlcontrolproxy.h
@@ -57,6 +57,7 @@ class QmlControlProxy : public QObject, public QQmlParserStatus {
 
     /// Reset the control to the default value.
     Q_INVOKABLE void reset();
+    Q_INVOKABLE void trigger();
 
   signals:
     void groupChanged(const QString& group);

--- a/src/test/qmlcontrolproxytest.cpp
+++ b/src/test/qmlcontrolproxytest.cpp
@@ -13,8 +13,6 @@ using namespace mixxx::qml;
 using ::testing::ElementsAre;
 
 namespace {
-constexpr int kTimeoutMillis = 100;
-constexpr int kStepMs = 5;
 
 class QmlControlProxyTest : public MixxxTest {
   protected:
@@ -46,14 +44,7 @@ TEST_F(QmlControlProxyTest, TriggerEmitsValueChanged1Then0) {
     EXPECT_DOUBLE_EQ(m_proxy->getValue(), 0.0);
 
     m_proxy->trigger();
-
-    // Wait up to kTimeoutMillis for at least 2 signals
-    int waited = 0;
-    while (valueSpy.size() < 2 && waited < kTimeoutMillis) {
-        QCoreApplication::processEvents(QEventLoop::AllEvents, kStepMs);
-        QThread::msleep(kStepMs);
-        waited += kStepMs;
-    }
+    QmlControlProxyTest::processEvents();
 
     // The first emission should be 1, the second should be 0
     ASSERT_GE(valueSpy.size(), 2);

--- a/src/test/qmlcontrolproxytest.cpp
+++ b/src/test/qmlcontrolproxytest.cpp
@@ -1,0 +1,67 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <QSignalSpy>
+#include <QTimer>
+#include <memory>
+
+#include "control/controlobject.h"
+#include "qml/qmlcontrolproxy.h"
+#include "test/mixxxtest.h"
+
+using namespace mixxx::qml;
+using ::testing::ElementsAre;
+
+namespace {
+constexpr int kTimeoutMillis = 100;
+constexpr int kStepMs = 5;
+
+class QmlControlProxyTest : public MixxxTest {
+  protected:
+    void SetUp() override {
+        // Use a unique key for this test
+        m_key = ConfigKey("[TestQmlProxy]", "trigger_test");
+        co = std::make_unique<ControlObject>(m_key);
+        m_proxy = std::make_unique<QmlControlProxy>();
+        m_proxy->setGroup(m_key.group);
+        m_proxy->setKey(m_key.item);
+        m_proxy->componentComplete();
+    }
+
+    void processEvents() {
+        // Ensure all queued events are processed
+        application()->processEvents();
+        application()->processEvents();
+    }
+
+    ConfigKey m_key;
+    std::unique_ptr<ControlObject> co;
+    std::unique_ptr<QmlControlProxy> m_proxy;
+};
+
+TEST_F(QmlControlProxyTest, TriggerEmitsValueChanged1Then0) {
+    QSignalSpy valueSpy(m_proxy.get(), &mixxx::qml::QmlControlProxy::valueChanged);
+
+    // Initial value should be 0
+    EXPECT_DOUBLE_EQ(m_proxy->getValue(), 0.0);
+
+    m_proxy->trigger();
+
+    // Wait up to kTimeoutMillis for at least 2 signals
+    int waited = 0;
+    while (valueSpy.size() < 2 && waited < kTimeoutMillis) {
+        QCoreApplication::processEvents(QEventLoop::AllEvents, kStepMs);
+        QThread::msleep(kStepMs);
+        waited += kStepMs;
+    }
+
+    // The first emission should be 1, the second should be 0
+    ASSERT_GE(valueSpy.size(), 2);
+    EXPECT_DOUBLE_EQ(valueSpy.at(0).at(0).toDouble(), 1.0);
+    EXPECT_DOUBLE_EQ(valueSpy.at(1).at(0).toDouble(), 0.0);
+
+    // The final value should be 0
+    EXPECT_DOUBLE_EQ(m_proxy->getValue(), 0.0);
+}
+
+} // namespace


### PR DESCRIPTION
This PR adds a trigger method to QmlControlProxy. This is using a single shot timer with zero interval, to ensure that both updates (1 then 0) will correctly be reported to the CO slots, as two seperate events in the event loop.