### PR TITLE
(fix) Waveform preferences: fix handling of invalid overview config type

### DIFF
--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -40,8 +40,9 @@ DlgPrefWaveform::DlgPrefWaveform(
     int cfgTypeIndex = waveformOverviewComboBox->findData(QVariant::fromValue(overviewType));
     if (cfgTypeIndex == -1) {
         // Invalid config value, set default type RGB and write it to config
-        waveformOverviewComboBox->setCurrentIndex(
-                waveformOverviewComboBox->findData(QVariant::fromValue(WOverview::Type::RGB)));
+        cfgTypeIndex = waveformOverviewComboBox->findData(
+                QVariant::fromValue(WOverview::Type::RGB));
+        waveformOverviewComboBox->setCurrentIndex(cfgTypeIndex);
         m_pConfig->setValue(kOverviewTypeCfgKey, cfgTypeIndex);
     } else {
         waveformOverviewComboBox->setCurrentIndex(cfgTypeIndex);


### PR DESCRIPTION
I guess this was overlooked and we never tested it.
Setting `[Waveform],WaveformOverviewType` to anything else than 0,1,2 would throw an assertion.
Now it silently selects RGB.