### PR TITLE
WIP TrackFileCache - Caching the source track from a slower location to a faster location << [POC] RAM-Play (20250928)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,7 +187,6 @@ jobs:
         with:
           # This is necessary for making `git describe` work.
           fetch-depth: 0
-
       - name: "[Arch Linux] Workaround for the 'unsafe repository' issue caused by CVE-2022-24765"
         if: matrix.container != null
         # See https://github.com/actions/checkout/issues/760 for details

--- a/src/engine/cachingreader/cachingreader.h
+++ b/src/engine/cachingreader/cachingreader.h
@@ -1,5 +1,4 @@
 #pragma once
-
 #include <QAtomicInt>
 #include <QHash>
 #include <QList>
@@ -137,6 +136,29 @@ class CachingReader : public QObject {
 
   private:
     const UserSettingsPointer m_pConfig;
+    struct RamPlayConfig {
+        bool enabled;
+        QString ramDiskPath;
+        int maxSizeMB;
+        bool decksEnabled;
+        bool samplersEnabled;
+        bool previewEnabled;
+        bool initialized;
+
+        RamPlayConfig()
+                : enabled(true),
+                  maxSizeMB(512),
+                  decksEnabled(true),
+                  samplersEnabled(true),
+                  previewEnabled(false),
+                  initialized(false) {
+        }
+    };
+
+    static RamPlayConfig s_ramPlayConfig;
+    static QMutex s_configMutex;
+    void initializeRamPlayConfig(UserSettingsPointer pConfig);
+    void createRamPlayConfigVars(UserSettingsPointer pConfig);
 
     // Thread-safe FIFOs for communication between the engine callback and
     // reader thread.

--- a/src/engine/cachingreader/cachingreader.h
+++ b/src/engine/cachingreader/cachingreader.h
@@ -154,6 +154,7 @@ class CachingReader : public QObject {
                   initialized(false) {
         }
     };
+    QString getTrackFileCachePathFromConfig(UserSettingsPointer pConfig);
 
     static TrackFileCacheConfig s_trackFileCacheConfig;
     static QMutex s_configMutex;

--- a/src/engine/cachingreader/cachingreader.h
+++ b/src/engine/cachingreader/cachingreader.h
@@ -136,16 +136,16 @@ class CachingReader : public QObject {
 
   private:
     const UserSettingsPointer m_pConfig;
-    struct RamPlayConfig {
+    struct TrackFileCacheConfig {
         bool enabled;
-        QString ramDiskPath;
+        QString trackFileCacheDiskPath;
         int maxSizeMB;
         bool decksEnabled;
         bool samplersEnabled;
         bool previewEnabled;
         bool initialized;
 
-        RamPlayConfig()
+        TrackFileCacheConfig()
                 : enabled(true),
                   maxSizeMB(512),
                   decksEnabled(true),
@@ -155,10 +155,10 @@ class CachingReader : public QObject {
         }
     };
 
-    static RamPlayConfig s_ramPlayConfig;
+    static TrackFileCacheConfig s_trackFileCacheConfig;
     static QMutex s_configMutex;
-    void initializeRamPlayConfig(UserSettingsPointer pConfig);
-    void createRamPlayConfigVars(UserSettingsPointer pConfig);
+    void initializeTrackFileCacheConfig(UserSettingsPointer pConfig);
+    void createTrackFileCacheConfigVars(UserSettingsPointer pConfig);
 
     // Thread-safe FIFOs for communication between the engine callback and
     // reader thread.

--- a/src/engine/cachingreader/cachingreaderworker.cpp
+++ b/src/engine/cachingreader/cachingreaderworker.cpp
@@ -1,6 +1,13 @@
 #include "engine/cachingreader/cachingreaderworker.h"
 
 #include <QAtomicInt>
+#include <QBuffer>
+#include <QFile>
+#include <QMutex>
+#include <QMutexLocker>
+#include <QRegularExpression>
+#include <QStorageInfo>
+#include <QTemporaryFile>
 #include <QtDebug>
 
 #include "analyzer/analyzersilence.h"
@@ -14,12 +21,12 @@
 #include "util/span.h"
 
 namespace {
-
+const bool sDebugCachingReaderWorker = false;
 mixxx::Logger kLogger("CachingReaderWorker");
 
 // we need the last silence frame and the first sound frame
 constexpr SINT kNumSoundFrameToVerify = 2;
-
+static QRegularExpression s_filenameSanitizeRegex(R"([\/\\\:\*\?\"\<\>\|])");
 } // anonymous namespace
 
 CachingReaderWorker::CachingReaderWorker(
@@ -34,10 +41,23 @@ CachingReaderWorker::CachingReaderWorker(
           m_maxSupportedChannel(maxSupportedChannel) {
 }
 
+QHash<QString, CachingReaderWorker::RamTrackEntry> CachingReaderWorker::s_ramTracks;
+QMutex CachingReaderWorker::s_ramTracksMutex;
+QString CachingReaderWorker::gSessionPrefix = QString("MixxxTemp_%1_")
+                                                      .arg(QDateTime::currentMSecsSinceEpoch());
+
 ReaderStatusUpdate CachingReaderWorker::processReadRequest(
         const CachingReaderChunkReadRequest& request) {
     CachingReaderChunk* pChunk = request.chunk;
     DEBUG_ASSERT(pChunk);
+
+    // EVE
+    // kLogger.debug() << m_group << "Processing read request for chunk"
+    //                << request.chunk->getIndex()
+    //                << "frames:" << request.chunk->frameIndexRange(m_pAudioSource);
+
+    // auto startTime = QDateTime::currentDateTime();
+    //  EVE
 
     // Before trying to read any data we need to check if the audio source
     // is available and if any audio data that is needed by the chunk is
@@ -55,6 +75,13 @@ ReaderStatusUpdate CachingReaderWorker::processReadRequest(
     const mixxx::IndexRange bufferedFrameIndexRange = pChunk->bufferSampleFrames(
             m_pAudioSource,
             mixxx::SampleBuffer::WritableSlice(m_tempReadBuffer));
+
+    // EVE
+    // auto duration = startTime.msecsTo(QDateTime::currentDateTime());
+    // kLogger.debug() << m_group << "Chunk read completed in" << duration << "ms"
+    //                << "buffered frames:" << bufferedFrameIndexRange;
+    // EVE
+
     DEBUG_ASSERT(!m_pAudioSource ||
             bufferedFrameIndexRange.isSubrangeOf(m_pAudioSource->frameIndexRange()));
     // The readable frame range might have changed
@@ -112,6 +139,10 @@ void CachingReaderWorker::newTrack(TrackPointer pTrack) {
 }
 
 void CachingReaderWorker::run() {
+    // EVE
+    // kLogger.debug() << m_group << "Worker thread started";
+    // EVE
+
     // the id of this thread, for debugging purposes
     static auto lastId = QAtomicInt(0);
     const auto id = lastId.fetchAndAddRelaxed(1) + 1;
@@ -123,6 +154,10 @@ void CachingReaderWorker::run() {
         // Request is initialized by reading from FIFO
         CachingReaderChunkReadRequest request;
         if (m_newTrackAvailable.loadAcquire()) {
+            // EVE
+            // kLogger.debug() << m_group << "New track available";
+            // EVE
+
 #ifdef __STEM__
             NewTrackRequest pLoadTrack;
 #else
@@ -147,6 +182,10 @@ void CachingReaderWorker::run() {
                 unloadTrack();
             }
         } else if (m_pChunkReadRequestFIFO->read(&request, 1) == 1) {
+            // EVE
+            // kLogger.trace() << m_group << "Read request from FIFO for chunk"
+            //                << request.chunk->getIndex();
+            // EVE
             // Read the requested chunk and send the result
             const ReaderStatusUpdate update = processReadRequest(request);
             m_pReaderStatusFIFO->writeBlocking(&update, 1);
@@ -156,6 +195,7 @@ void CachingReaderWorker::run() {
             Event::start(m_tag);
         }
     }
+    kLogger.debug() << m_group << "Worker thread stopping";
 }
 
 void CachingReaderWorker::discardAllPendingRequests() {
@@ -175,16 +215,136 @@ void CachingReaderWorker::closeAudioSource() {
         m_pAudioSource.reset();
     }
 
+    // Clean up temporary RAM file, if used
+    if (m_tmpRamFile) {
+        m_tmpRamFile->close();
+        delete m_tmpRamFile;
+        m_tmpRamFile = nullptr;
+    }
+
     // This function has to be called with the engine stopped only
     // to avoid collecting new requests for the old track
     DEBUG_ASSERT(!m_pChunkReadRequestFIFO->readAvailable());
 }
 
-void CachingReaderWorker::unloadTrack() {
-    closeAudioSource();
+// RAM-Play
+void CachingReaderWorker::setRamPlayConfig(bool enabled,
+        const QString& ramDiskPath,
+        int maxRamSizeMB,
+        bool decksEnabled,
+        bool samplersEnabled,
+        bool previewEnabled) {
+    m_ramPlayEnabled = enabled;
+    m_ramDiskPath = ramDiskPath;
+    m_maxRamSizeMB = maxRamSizeMB;
+    m_ramPlayDecks = decksEnabled;
+    m_ramPlaySamplers = samplersEnabled;
+    m_ramPlayPreview = previewEnabled;
+    if (sDebugCachingReaderWorker) {
+        kLogger.debug() << m_group << "[RAM-PLAY] Config - Enabled:" << m_ramPlayEnabled
+                        << "Path:" << m_ramDiskPath
+                        << "MaxSize:" << m_maxRamSizeMB << "MB"
+                        << "RAM-Play for Decks: " << m_ramPlayDecks
+                        << "RAM-Play for Samplers: " << m_ramPlaySamplers
+                        << "RAM-Play for PreviexDeck: " << m_ramPlayPreview;
+    }
+}
 
-    const auto update = ReaderStatusUpdate::trackUnloaded();
-    m_pReaderStatusFIFO->writeBlocking(&update, 1);
+struct RamTrackEntry {
+    QString group;
+    QString filePath;
+};
+
+static QHash<QString, RamTrackEntry> s_ramTracks;
+static QHash<QString, QSet<QString>> s_fileToGroupsMap;
+static QMutex s_ramTracksMutex;
+
+static QString sanitizeFileNamePart(const QString& str) {
+    QString s = str;
+    // Replace any character that is invalid in file names with underscore
+    s.replace(s_filenameSanitizeRegex, "_");
+    return s;
+}
+
+// Generate session prefix once per Mixxx-session
+static QString gSessionPrefix = QString("MixxxTemp_%1_")
+                                        .arg(QDateTime::currentMSecsSinceEpoch());
+
+// Helper function to check if a RAM file is in use in another group
+static bool isRamFileUsedByOtherGroups(const QString& filePath, const QString& currentGroup) {
+    QMutexLocker locker(&s_ramTracksMutex);
+    return s_fileToGroupsMap.contains(filePath) &&
+            (s_fileToGroupsMap[filePath].size() > 1 ||
+                    !s_fileToGroupsMap[filePath].contains(currentGroup));
+}
+
+// Helper function to remove RAM file if not in use in another group
+static void cleanupRamFileIfUnused(const QString& filePath) {
+    QMutexLocker locker(&s_ramTracksMutex);
+
+    // Check if file is in use
+    bool isUsed = false;
+    for (const auto& entry : std::as_const(s_ramTracks)) {
+        if (entry.filePath == filePath) {
+            isUsed = true;
+            break;
+        }
+    }
+
+    // Remove file if not in use
+    if (!isUsed) {
+        QFile file(filePath);
+        if (file.exists()) {
+            if (file.remove()) {
+                kLogger.debug() << "[RAM-Play] -> Removed unused RAM file:" << filePath;
+            } else {
+                kLogger.warning() << "[RAM-Play] -> Failed to remove RAM file:" << filePath;
+            }
+        }
+    }
+}
+
+// Update RAM track for group
+static void updateRamTrackUsage(const QString& group, const QString& filePath) {
+    QString fileToRemove;
+    {
+        QMutexLocker locker(&s_ramTracksMutex);
+        if (s_ramTracks.contains(group)) {
+            QString oldFilePath = s_ramTracks[group].filePath;
+            s_ramTracks.remove(group);
+
+            // Check if file should be removed (if not used by others)
+            bool shouldRemove = !oldFilePath.isEmpty() &&
+                    !isRamFileUsedByOtherGroups(oldFilePath, group);
+            if (shouldRemove) {
+                fileToRemove = oldFilePath;
+            }
+        }
+
+        // Add new entry
+        if (!filePath.isEmpty()) {
+            s_ramTracks.insert(group, {group, filePath});
+        }
+    }
+
+    // Remove file outside critical section
+    if (!fileToRemove.isEmpty()) {
+        QFile::remove(fileToRemove);
+    }
+}
+
+// Remove group from RAM track usage (when deck/sampler is unloaded)
+static void removeRamTrackUsage(const QString& group) {
+    QMutexLocker locker(&s_ramTracksMutex);
+
+    if (s_ramTracks.contains(group)) {
+        const QString filePath = s_ramTracks[group].filePath;
+        s_ramTracks.remove(group);
+
+        // Clean up file if it's not used by other groups
+        locker.unlock();
+        cleanupRamFileIfUnused(filePath);
+    }
 }
 
 #ifdef __STEM__
@@ -193,17 +353,17 @@ void CachingReaderWorker::loadTrack(
 #else
 void CachingReaderWorker::loadTrack(const TrackPointer& pTrack) {
 #endif
-    // This emit is directly connected and returns synchronized
-    // after the engine has been stopped.
+    // Notify UI / engine that track loading started
     emit trackLoading();
 
+    // Close any previous audio source and clean up previous RAM usage
     closeAudioSource();
 
+    // Remove previous RAM track usage for this group
+    removeRamTrackUsage(m_group);
+
     if (!pTrack->getFileInfo().checkFileExists()) {
-        kLogger.warning()
-                << m_group
-                << "File not found"
-                << pTrack->getFileInfo();
+        kLogger.warning() << m_group << "File not found" << pTrack->getFileInfo();
         const auto update = ReaderStatusUpdate::trackUnloaded();
         m_pReaderStatusFIFO->writeBlocking(&update, 1);
         emit trackLoadFailed(pTrack,
@@ -212,93 +372,282 @@ void CachingReaderWorker::loadTrack(const TrackPointer& pTrack) {
         return;
     }
 
+    // Check if RAM play is enabled globally
+    if (!m_ramPlayEnabled) {
+        if (sDebugCachingReaderWorker) {
+            kLogger.debug() << "[RAM-PLAY] -> Player: " << m_group
+                            << " RAM-Play disabled in preferences, playing "
+                               "file from original location";
+        }
+        // Skip RAM-Play and load from original location
+        TrackPointer trackToOpen = pTrack;
+        trackToOpen->setURL(pTrack->getURL());
+        updateRamTrackUsage(m_group, "");
+        openAudioSource(trackToOpen, stemMask);
+        return;
+    }
+
+    // Check Deck/Sampler/PreviewDeck preferences
+    bool componentEnabled = true;
+    QString componentType;
+
+    if (m_group.contains("Channel", Qt::CaseInsensitive)) {
+        componentEnabled = m_ramPlayDecks;
+        componentType = "Deck";
+    } else if (m_group.contains("Sampler", Qt::CaseInsensitive)) {
+        componentEnabled = m_ramPlaySamplers;
+        componentType = "Sampler";
+    } else if (m_group.contains("Preview", Qt::CaseInsensitive)) {
+        componentEnabled = m_ramPlayPreview;
+        componentType = "PreviewDeck";
+    }
+
+    if (!componentEnabled) {
+        if (sDebugCachingReaderWorker) {
+            kLogger.debug() << "[RAM-PLAY] -> Player: " << m_group
+                            << " RAM-Play disabled for " << componentType
+                            << ", playing file from original location";
+        }
+        // Skip RAM-Play and load from original location
+        TrackPointer trackToOpen = pTrack;
+        trackToOpen->setURL(pTrack->getURL());
+        updateRamTrackUsage(m_group, "");
+        openAudioSource(trackToOpen, stemMask);
+        return;
+    }
+
+    // -> 1: Setup RAM-Play storage ///
+    QString tmpPath = m_ramDiskPath;
+    QDir tmpDir(tmpPath);
+
+    // Create directory if it doesn't exist
+    if (!tmpDir.exists()) {
+        if (!tmpDir.mkpath(tmpPath)) {
+            kLogger.warning() << "[RAM-PLAY] -> Failed to create directory:" << tmpPath;
+            // Fall back to original file
+            TrackPointer trackToOpen = pTrack;
+            trackToOpen->setURL(pTrack->getURL());
+            updateRamTrackUsage(m_group, "");
+            openAudioSource(trackToOpen, stemMask);
+            return;
+        }
+        if (sDebugCachingReaderWorker) {
+            kLogger.debug() << "[RAM-PLAY] -> Created directory:" << tmpPath;
+        }
+    }
+
+    QStringList oldFiles = tmpDir.entryList(QStringList() << "MixxxTemp_*", QDir::Files);
+    // keep current session files, delete files from other (earlier) session
+    for (const QString& f : std::as_const(oldFiles)) {
+        if (!f.startsWith(gSessionPrefix)) {
+            QFile::remove(tmpDir.filePath(f));
+        }
+    }
+
+    QString artistSafe = sanitizeFileNamePart(pTrack->getArtist());
+    QString titleSafe = sanitizeFileNamePart(pTrack->getTitle());
+
+    QString combined = artistSafe + "-" + titleSafe;
+    if (combined.length() > 50) {
+        combined = combined.left(50);
+    }
+
+    QString trackIdSafe = sanitizeFileNamePart(pTrack->getId().toString());
+    QString ramFileName = tmpPath + gSessionPrefix + trackIdSafe + "_" + combined + ".tmp";
+    bool useRamCopy = false;
+
+    QFile ramFile(ramFileName);
+    if (ramFile.exists()) {
+        if (sDebugCachingReaderWorker) {
+            kLogger.debug() << "[RAM-PLAY] -> Player: " << m_group
+                            << " Reusing existing RAM file for track:" << ramFileName;
+        }
+        useRamCopy = true;
+    } else {
+        qint64 trackSize = QFileInfo(pTrack->getFileInfo().location()).size();
+        qint64 maxRamBytes = static_cast<qint64>(m_maxRamSizeMB) * 1024 * 1024;
+
+        // Calculate the size of actual Mixxx session files in RAM-Play directory
+        qint64 mixxxSessionSize = 0;
+        QDir tmpDir(tmpPath);
+        if (tmpDir.exists()) {
+            QStringList sessionFiles = tmpDir.entryList(
+                    QStringList() << gSessionPrefix + "*", QDir::Files);
+            for (const QString& filename : std::as_const(sessionFiles)) {
+                QFileInfo fileInfo(tmpDir.filePath(filename));
+                mixxxSessionSize += fileInfo.size();
+            }
+        }
+        if (sDebugCachingReaderWorker) {
+            kLogger.debug() << "[RAM-PLAY] -> Mixxx session size:"
+                            << mixxxSessionSize / (1024 * 1024)
+                            << "MB, Track:" << trackSize / (1024 * 1024)
+                            << "MB, Max allowed:" << m_maxRamSizeMB << "MB";
+        }
+        // Check if adding this track would exceed the Mixxx-specific limit
+        if ((mixxxSessionSize + trackSize) > maxRamBytes) {
+            kLogger.warning() << "[RAM-PLAY] -> Player: " << m_group
+                              << " RAM-Play copy would exceed Mixxx size limit. Track:"
+                              << trackSize / (1024 * 1024) << "MB, Mixxx usage:"
+                              << mixxxSessionSize / (1024 * 1024) << "MB, Max:"
+                              << m_maxRamSizeMB << "MB";
+            useRamCopy = false;
+        } else {
+            useRamCopy = true;
+            if (!ramFile.open(QIODevice::WriteOnly)) {
+                kLogger.warning() << "[RAM-PLAY] -> Player: " << m_group
+                                  << " Cannot open RAM-Play file for writing:" << ramFileName;
+                useRamCopy = false;
+            } else {
+                QFile originalFile(pTrack->getFileInfo().location());
+                if (!originalFile.open(QIODevice::ReadOnly)) {
+                    kLogger.warning()
+                            << "[RAM-PLAY] -> Player: " << m_group
+                            << " Cannot read original track:" << pTrack->getLocation();
+                    useRamCopy = false;
+                } else {
+                    ramFile.write(originalFile.readAll());
+                    ramFile.flush();
+                    ramFile.close();
+                    originalFile.close();
+                    if (sDebugCachingReaderWorker) {
+                        kLogger.debug() << "[RAM-PLAY] -> Player: " << m_group
+                                        << " Track copied to RAM-Play directory:" << ramFileName;
+                    }
+                }
+            }
+        }
+    }
+
+    TrackPointer trackToOpen = pTrack;
+    if (useRamCopy) {
+        trackToOpen->setURL(QUrl::fromLocalFile(ramFileName).toString());
+        m_ramFilesInUse.insert(ramFileName);
+        updateRamTrackUsage(m_group, ramFileName);
+    } else {
+        trackToOpen->setURL(pTrack->getURL());
+        updateRamTrackUsage(m_group, "");
+    }
+
+    // -> 2: Open AudioSource ///
+    openAudioSource(trackToOpen, stemMask);
+}
+
+// Helper function to open audio source (extracted for clarity)
+void CachingReaderWorker::openAudioSource(const TrackPointer& trackToOpen,
+#ifdef __STEM__
+        mixxx::StemChannelSelection stemMask) {
+#else
+) {
+#endif
     mixxx::AudioSource::OpenParams config;
     config.setChannelCount(m_maxSupportedChannel);
+
 #ifdef __STEM__
     config.setStemMask(stemMask);
 #endif
-    m_pAudioSource = SoundSourceProxy(pTrack).openAudioSource(config);
+
+    m_pAudioSource = SoundSourceProxy(trackToOpen).openAudioSource(config);
     if (!m_pAudioSource) {
-        kLogger.warning()
-                << m_group
-                << "Failed to open file"
-                << pTrack->getFileInfo();
-        const auto update = ReaderStatusUpdate::trackUnloaded();
-        m_pReaderStatusFIFO->writeBlocking(&update, 1);
-        emit trackLoadFailed(pTrack,
-                tr("The file '%1' could not be loaded.")
-                        .arg(QDir::toNativeSeparators(pTrack->getLocation())));
+        kLogger.warning() << m_group << "Failed to open track:" << trackToOpen->getFileInfo();
+        emit trackLoadFailed(trackToOpen, tr("Failed to open track."));
         return;
     }
 
-    // It is critical that the audio source doesn't contain more channels than
-    // requested as this could lead to overflow when reading chunks
-    VERIFY_OR_DEBUG_ASSERT(m_pAudioSource->getSignalInfo().getChannelCount() >=
-                    mixxx::audio::ChannelCount::mono() &&
-            m_pAudioSource->getSignalInfo().getChannelCount() <=
-                    m_maxSupportedChannel) {
-        m_pAudioSource.reset(); // Close open file handles
-        const auto update = ReaderStatusUpdate::trackUnloaded();
-        m_pReaderStatusFIFO->writeBlocking(&update, 1);
-        emit trackLoadFailed(pTrack,
-                tr("The file '%1' could not be loaded because it contains %2 "
-                   "channels, and only 1 to %3 are supported.")
-                        .arg(QDir::toNativeSeparators(pTrack->getLocation()),
-                                QString::number(m_pAudioSource->getSignalInfo()
-                                                        .getChannelCount()),
-                                QString::number(m_maxSupportedChannel)));
+    // -> Step 3: Validate audio source ///
+    if (m_pAudioSource->getSignalInfo().getChannelCount() < mixxx::audio::ChannelCount::mono() ||
+            m_pAudioSource->getSignalInfo().getChannelCount() > m_maxSupportedChannel) {
+        kLogger.warning() << m_group
+                          << "Track contains unsupported number of channels:"
+                          << trackToOpen->getFileInfo();
+        m_pAudioSource.reset();
+        emit trackLoadFailed(trackToOpen, tr("Unsupported number of channels."));
         return;
     }
 
-    // Initially assume that the complete content offered by audio source
-    // is available for reading. Later if read errors occur this value will
-    // be decreased to avoid repeated reading of corrupt audio data.
     if (m_pAudioSource->frameIndexRange().empty()) {
-        m_pAudioSource.reset(); // Close open file handles
-        kLogger.warning()
-                << m_group
-                << "Failed to open empty file"
-                << pTrack->getFileInfo();
-        const auto update = ReaderStatusUpdate::trackUnloaded();
-        m_pReaderStatusFIFO->writeBlocking(&update, 1);
-        emit trackLoadFailed(pTrack,
-                tr("The file '%1' is empty and could not be loaded.")
-                        .arg(QDir::toNativeSeparators(pTrack->getLocation())));
+        kLogger.warning() << m_group << "Empty track:" << trackToOpen->getFileInfo();
+        m_pAudioSource.reset();
+        emit trackLoadFailed(trackToOpen, tr("Track is empty."));
         return;
     }
 
-    // Adjust the internal buffer
+    // -> 4: Prepare temp buffer for chunking ///
     const SINT tempReadBufferSize =
-            m_pAudioSource->getSignalInfo().frames2samples(
-                    CachingReaderChunk::kFrames);
+            m_pAudioSource->getSignalInfo().frames2samples(CachingReaderChunk::kFrames);
     if (m_tempReadBuffer.size() != tempReadBufferSize) {
         mixxx::SampleBuffer(tempReadBufferSize).swap(m_tempReadBuffer);
     }
 
-    const auto update =
-            ReaderStatusUpdate::trackLoaded(
-                    m_pAudioSource->frameIndexRange());
+    // -> 5: Notify engine/UI ///
+    const auto update = ReaderStatusUpdate::trackLoaded(m_pAudioSource->frameIndexRange());
     m_pReaderStatusFIFO->writeBlocking(&update, 1);
 
-    // Emit that the track is loaded.
-
-    // This code is a workaround until we have found a better solution to
-    // verify and correct offsets.
-    CuePointer pN60dBSound =
-            pTrack->findCueByType(mixxx::CueType::N60dBSound);
+    CuePointer pN60dBSound = trackToOpen->findCueByType(mixxx::CueType::N60dBSound);
     if (pN60dBSound) {
         m_firstSoundFrameToVerify = pN60dBSound->getPosition();
     }
 
-    // The engine must not request any chunks before receiving the
-    // trackLoaded() signal
     DEBUG_ASSERT(!m_pChunkReadRequestFIFO->readAvailable());
 
     emit trackLoaded(
-            pTrack,
+            trackToOpen,
             m_pAudioSource->getSignalInfo().getSampleRate(),
             m_pAudioSource->getSignalInfo().getChannelCount(),
             mixxx::audio::FramePos(m_pAudioSource->frameLength()));
+}
+
+void CachingReaderWorker::cleanupAllRamFiles(const QString& ramDiskPath) {
+    QMutexLocker locker(&s_ramTracksMutex);
+
+    // Clear all entries
+    s_ramTracks.clear();
+
+    // Remove all RAM files from current session
+    QDir tmpDir(ramDiskPath);
+    if (!tmpDir.exists()) {
+        kLogger.warning()
+                << "[RAM-PLAY] -> Cleanup failed - directory doesn't exist:"
+                << ramDiskPath;
+        return;
+    }
+
+    QStringList sessionFiles = tmpDir.entryList(QStringList() << gSessionPrefix + "*", QDir::Files);
+    if (sDebugCachingReaderWorker) {
+        kLogger.debug() << "[RAM-PLAY] -> Found" << sessionFiles.size()
+                        << "previous session files to clean up";
+    }
+
+    int removedCount = 0;
+    int failedCount = 0;
+
+    for (const QString& filename : std::as_const(sessionFiles)) {
+        QString filePath = tmpDir.filePath(filename);
+        QFile file(filePath);
+        if (file.exists()) {
+            if (file.remove()) {
+                removedCount++;
+                if (sDebugCachingReaderWorker) {
+                    kLogger.debug() << "[RAM-PLAY] -> Removed session RAM-Play file:" << filePath;
+                }
+            } else {
+                failedCount++;
+                kLogger.warning() << "[RAM-PLAY] -> Failed to remove previous "
+                                     "session RAM-Play file:"
+                                  << filePath << "Error:" << file.errorString();
+            }
+        }
+    }
+
+    kLogger.info() << "[RAM-PLAY] Cleanup completed - Removed:" << removedCount
+                   << "files, Failed:" << failedCount << "files";
+}
+
+void CachingReaderWorker::unloadTrack() {
+    closeAudioSource();
+
+    const auto update = ReaderStatusUpdate::trackUnloaded();
+    m_pReaderStatusFIFO->writeBlocking(&update, 1);
 }
 
 void CachingReaderWorker::quitWait() {

--- a/src/engine/cachingreader/cachingreaderworker.h
+++ b/src/engine/cachingreader/cachingreaderworker.h
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <QDateTime>
+#include <QHash>
 #include <QMutex>
 #include <QString>
+#include <QTemporaryFile>
 
 #include "audio/frame.h"
 #include "audio/types.h"
@@ -12,6 +15,8 @@
 
 template<class DataType>
 class FIFO;
+
+struct RamTrackEntry;
 
 // POD with trivial ctor/dtor/copy for passing through FIFO
 typedef struct CachingReaderChunkReadRequest {
@@ -115,6 +120,28 @@ class CachingReaderWorker : public EngineWorker {
     void run() override;
 
     void quitWait();
+    static void cleanupSessionRamFiles();
+
+    struct RamTrackEntry {
+        QString group;    // the deck/sampler group using this track
+        QString filePath; // the RAM file path
+
+        // Optional: Add constructor for convenience
+        RamTrackEntry() = default;
+        RamTrackEntry(const QString& group, const QString& filePath)
+                : group(group),
+                  filePath(filePath) {
+        }
+    };
+    void setRamPlayConfig(
+            bool enabled,
+            const QString& ramDiskPath,
+            int maxRamSizeMB,
+            bool decksEnabled,
+            bool samplersEnabled,
+            bool previewEnabled);
+    // called in mixxxmain to clean up cache
+    static void cleanupAllRamFiles(const QString& ramDiskPath);
 
   signals:
     // Emitted once a new track is loaded and ready to be read from.
@@ -166,6 +193,38 @@ class CachingReaderWorker : public EngineWorker {
 #else
     void loadTrack(const TrackPointer& pTrack);
 #endif
+    // RAM-Play vars
+    bool m_ramPlayEnabled;
+    QString m_ramDiskPath;
+    int m_maxRamSizeMB;
+    bool m_ramPlayDecks;
+    bool m_ramPlaySamplers;
+    bool m_ramPlayPreview;
+
+    enum class GroupType {
+        Deck,
+        Sampler,
+        PreviewDeck,
+        Unknown
+    };
+
+    GroupType getGroupType() const {
+        if (m_group.contains("Channel", Qt::CaseInsensitive)) {
+            return GroupType::Deck;
+        } else if (m_group.contains("Sampler", Qt::CaseInsensitive)) {
+            return GroupType::Sampler;
+        } else if (m_group.contains("Preview", Qt::CaseInsensitive)) {
+            return GroupType::PreviewDeck;
+        }
+        return GroupType::Unknown;
+    }
+
+    void openAudioSource(const TrackPointer& trackToOpen
+#ifdef __STEM__
+            ,
+            mixxx::StemChannelSelection stemMask
+#endif
+    );
 
     ReaderStatusUpdate processReadRequest(
             const CachingReaderChunkReadRequest& request);
@@ -186,4 +245,15 @@ class CachingReaderWorker : public EngineWorker {
     mixxx::audio::ChannelCount m_maxSupportedChannel;
 
     QAtomicInt m_stop;
+
+    QTemporaryFile* m_tmpRamFile = nullptr;
+    QString m_currentTrackURL;
+    QSet<QString> m_ramFilesInUse;
+
+    static QHash<QString, RamTrackEntry> s_ramTracks;
+    static QMutex s_ramTracksMutex;
+    static QString gSessionPrefix;
+
+    static bool isRamFileUsedByOtherGroups(const QString& filePath, const QString& currentGroup);
+    static void cleanupRamFileIfUnused(const QString& filePath);
 };

--- a/src/engine/cachingreader/cachingreaderworker.h
+++ b/src/engine/cachingreader/cachingreaderworker.h
@@ -121,6 +121,7 @@ class CachingReaderWorker : public EngineWorker {
 
     void quitWait();
     static void cleanupSessionTrackFileCacheFiles();
+    static void clearAllTrackFileCacheEntries();
 
     struct TrackFileCacheTrackEntry {
         QString group;    // the deck/sampler group using this track

--- a/src/engine/cachingreader/cachingreaderworker.h
+++ b/src/engine/cachingreader/cachingreaderworker.h
@@ -16,7 +16,7 @@
 template<class DataType>
 class FIFO;
 
-struct RamTrackEntry;
+struct TrackFileCacheTrackEntry;
 
 // POD with trivial ctor/dtor/copy for passing through FIFO
 typedef struct CachingReaderChunkReadRequest {
@@ -120,28 +120,28 @@ class CachingReaderWorker : public EngineWorker {
     void run() override;
 
     void quitWait();
-    static void cleanupSessionRamFiles();
+    static void cleanupSessionTrackFileCacheFiles();
 
-    struct RamTrackEntry {
+    struct TrackFileCacheTrackEntry {
         QString group;    // the deck/sampler group using this track
-        QString filePath; // the RAM file path
+        QString filePath; // the TrackFileCache file path
 
         // Optional: Add constructor for convenience
-        RamTrackEntry() = default;
-        RamTrackEntry(const QString& group, const QString& filePath)
+        TrackFileCacheTrackEntry() = default;
+        TrackFileCacheTrackEntry(const QString& group, const QString& filePath)
                 : group(group),
                   filePath(filePath) {
         }
     };
-    void setRamPlayConfig(
+    void setTrackFileCacheConfig(
             bool enabled,
-            const QString& ramDiskPath,
-            int maxRamSizeMB,
+            const QString& trackFileCacheDiskPath,
+            int maxTrackFileCacheSizeMB,
             bool decksEnabled,
             bool samplersEnabled,
             bool previewEnabled);
     // called in mixxxmain to clean up cache
-    static void cleanupAllRamFiles(const QString& ramDiskPath);
+    static void cleanupAllTrackFileCacheFiles(const QString& trackFileCacheDiskPath);
 
   signals:
     // Emitted once a new track is loaded and ready to be read from.
@@ -193,13 +193,13 @@ class CachingReaderWorker : public EngineWorker {
 #else
     void loadTrack(const TrackPointer& pTrack);
 #endif
-    // RAM-Play vars
-    bool m_ramPlayEnabled;
-    QString m_ramDiskPath;
-    int m_maxRamSizeMB;
-    bool m_ramPlayDecks;
-    bool m_ramPlaySamplers;
-    bool m_ramPlayPreview;
+    // TrackFileCache vars
+    bool m_trackFileCacheEnabled;
+    QString m_trackFileCacheDiskPath;
+    int m_maxTrackFileCacheSizeMB;
+    bool m_trackFileCacheDecks;
+    bool m_trackFileCacheSamplers;
+    bool m_trackFileCachePreview;
 
     enum class GroupType {
         Deck,
@@ -246,14 +246,15 @@ class CachingReaderWorker : public EngineWorker {
 
     QAtomicInt m_stop;
 
-    QTemporaryFile* m_tmpRamFile = nullptr;
+    QTemporaryFile* m_tmpTrackFileCacheFile = nullptr;
     QString m_currentTrackURL;
-    QSet<QString> m_ramFilesInUse;
+    QSet<QString> m_trackFileCacheFilesInUse;
 
-    static QHash<QString, RamTrackEntry> s_ramTracks;
-    static QMutex s_ramTracksMutex;
+    static QHash<QString, TrackFileCacheTrackEntry> s_trackFileCacheTracks;
+    static QMutex s_trackFileCacheTracksMutex;
     static QString gSessionPrefix;
 
-    static bool isRamFileUsedByOtherGroups(const QString& filePath, const QString& currentGroup);
-    static void cleanupRamFileIfUnused(const QString& filePath);
+    static bool isTrackFileCacheFileUsedByOtherGroups(
+            const QString& filePath, const QString& currentGroup);
+    static void cleanupTrackFileCacheFileIfUnused(const QString& filePath);
 };

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -33,6 +33,8 @@
 #include "broadcast/broadcastmanager.h"
 #endif
 #include "control/controlindicatortimer.h"
+// EVE -> clean up RAM-Play cache
+#include "engine/cachingreader/cachingreader.h"
 #include "library/library.h"
 #include "library/library_decl.h"
 #include "library/library_prefs.h"
@@ -458,6 +460,10 @@ void MixxxMainWindow::initialize() {
 MixxxMainWindow::~MixxxMainWindow() {
     Timer t("~MixxxMainWindow");
     t.start();
+
+    // Clean up RAM-Play files only if they were actually used and RAM-Play is enabled
+    // cleanUpRamPlayCache();
+    cleanUpRamPlayCache(m_pCoreServices->getSettings());
 
     // Save the current window state (position, maximized, etc)
     // Note(ronso0): Unfortunately saveGeometry() also stores the fullscreen state.
@@ -1594,4 +1600,51 @@ void MixxxMainWindow::initializationProgressUpdate(int progress, const QString& 
         m_pLaunchImage->progress(progress, serviceName);
     }
     qApp->processEvents();
+}
+
+// void MixxxMainWindow::cleanUpRamPlayCache() {
+void MixxxMainWindow::cleanUpRamPlayCache(UserSettingsPointer pConfig) {
+    if (!pConfig) {
+        return;
+    }
+    // Clean up RAM-Play files only if they were actually used and RAM-Play is enabled
+    bool ramPlayEnabled = pConfig->getValue<bool>(
+            ConfigKey("[RAM-Play]", "Enabled"), false);
+
+    if (!ramPlayEnabled) {
+        qDebug() << "RAM-Play cleanup skipped - disabled in config";
+        return;
+    }
+
+    QString dirName = pConfig->getValueString(
+            ConfigKey("[RAM-Play]", "DirectoryName"));
+    if (dirName.isEmpty()) {
+        dirName = "MixxxTmp"; // Default if empty
+    }
+
+    QString ramPlayPath;
+#ifdef Q_OS_WIN
+    QString driveLetter = pConfig->getValueString(
+            ConfigKey("[RAM-Play]", "WindowsDrive"));
+    driveLetter = driveLetter.replace(QRegularExpression("[^a-zA-Z]"), "").toUpper();
+    if (driveLetter.isEmpty()) {
+        driveLetter = "R"; // Default if empty
+    }
+    ramPlayPath = driveLetter + ":/" + dirName + "/";
+#else
+    QString basePath = pConfig->getValueString(
+            ConfigKey("[RAM-Play]", "LinuxDrive"));
+    if (basePath.isEmpty()) {
+        basePath = "/dev/shm"; // Default if empty
+    }
+    // Remove trailing slashes
+    while (basePath.endsWith('/')) {
+        basePath.chop(1);
+    }
+    ramPlayPath = basePath + "/" + dirName + "/";
+#endif
+
+    qDebug() << "Cleaning up RAM-PLAY files from:" << ramPlayPath;
+
+    CachingReaderWorker::cleanupAllRamFiles(ramPlayPath);
 }

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -33,7 +33,7 @@
 #include "broadcast/broadcastmanager.h"
 #endif
 #include "control/controlindicatortimer.h"
-// EVE -> clean up RAM-Play cache
+// EVE -> clean up TrackFileCache cache
 #include "engine/cachingreader/cachingreader.h"
 #include "library/library.h"
 #include "library/library_decl.h"
@@ -461,9 +461,8 @@ MixxxMainWindow::~MixxxMainWindow() {
     Timer t("~MixxxMainWindow");
     t.start();
 
-    // Clean up RAM-Play files only if they were actually used and RAM-Play is enabled
-    // cleanUpRamPlayCache();
-    cleanUpRamPlayCache(m_pCoreServices->getSettings());
+    // Clean up TrackFileCache files only if they were actually used and TrackFileCache is enabled
+    cleanUpTrackFileCacheCache(m_pCoreServices->getSettings());
 
     // Save the current window state (position, maximized, etc)
     // Note(ronso0): Unfortunately saveGeometry() also stores the fullscreen state.
@@ -1603,37 +1602,37 @@ void MixxxMainWindow::initializationProgressUpdate(int progress, const QString& 
 }
 
 // void MixxxMainWindow::cleanUpRamPlayCache() {
-void MixxxMainWindow::cleanUpRamPlayCache(UserSettingsPointer pConfig) {
+void MixxxMainWindow::cleanUpTrackFileCacheCache(UserSettingsPointer pConfig) {
     if (!pConfig) {
         return;
     }
-    // Clean up RAM-Play files only if they were actually used and RAM-Play is enabled
-    bool ramPlayEnabled = pConfig->getValue<bool>(
-            ConfigKey("[RAM-Play]", "Enabled"), false);
+    // Clean up TrackFileCache files only if they were actually used and TrackFileCache is enabled
+    bool trackFileCacheEnabled = pConfig->getValue<bool>(
+            ConfigKey("[TrackFileCache]", "Enabled"), false);
 
-    if (!ramPlayEnabled) {
-        qDebug() << "RAM-Play cleanup skipped - disabled in config";
+    if (!trackFileCacheEnabled) {
+        qDebug() << "TrackFileCache cleanup skipped - disabled in config";
         return;
     }
 
     QString dirName = pConfig->getValueString(
-            ConfigKey("[RAM-Play]", "DirectoryName"));
+            ConfigKey("[TrackFileCache]", "DirectoryName"));
     if (dirName.isEmpty()) {
         dirName = "MixxxTmp"; // Default if empty
     }
 
-    QString ramPlayPath;
+    QString trackFileCachePath;
 #ifdef Q_OS_WIN
     QString driveLetter = pConfig->getValueString(
-            ConfigKey("[RAM-Play]", "WindowsDrive"));
+            ConfigKey("[TrackFileCache]", "WindowsDrive"));
     driveLetter = driveLetter.replace(QRegularExpression("[^a-zA-Z]"), "").toUpper();
     if (driveLetter.isEmpty()) {
         driveLetter = "R"; // Default if empty
     }
-    ramPlayPath = driveLetter + ":/" + dirName + "/";
+    trackFileCachePath = driveLetter + ":/" + dirName + "/";
 #else
     QString basePath = pConfig->getValueString(
-            ConfigKey("[RAM-Play]", "LinuxDrive"));
+            ConfigKey("[TrackFileCache]", "LinuxDrive"));
     if (basePath.isEmpty()) {
         basePath = "/dev/shm"; // Default if empty
     }
@@ -1641,10 +1640,10 @@ void MixxxMainWindow::cleanUpRamPlayCache(UserSettingsPointer pConfig) {
     while (basePath.endsWith('/')) {
         basePath.chop(1);
     }
-    ramPlayPath = basePath + "/" + dirName + "/";
+    trackFileCachePath = basePath + "/" + dirName + "/";
 #endif
 
-    qDebug() << "Cleaning up RAM-PLAY files from:" << ramPlayPath;
+    qDebug() << "Cleaning up TrackFileCache files from:" << trackFileCachePath;
 
-    CachingReaderWorker::cleanupAllRamFiles(ramPlayPath);
+    CachingReaderWorker::cleanupAllTrackFileCacheFiles(trackFileCachePath);
 }

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -1601,12 +1601,11 @@ void MixxxMainWindow::initializationProgressUpdate(int progress, const QString& 
     qApp->processEvents();
 }
 
-// void MixxxMainWindow::cleanUpRamPlayCache() {
 void MixxxMainWindow::cleanUpTrackFileCacheCache(UserSettingsPointer pConfig) {
     if (!pConfig) {
         return;
     }
-    // Clean up TrackFileCache files only if they were actually used and TrackFileCache is enabled
+
     bool trackFileCacheEnabled = pConfig->getValue<bool>(
             ConfigKey("[TrackFileCache]", "Enabled"), false);
 
@@ -1615,35 +1614,20 @@ void MixxxMainWindow::cleanUpTrackFileCacheCache(UserSettingsPointer pConfig) {
         return;
     }
 
-    QString dirName = pConfig->getValueString(
-            ConfigKey("[TrackFileCache]", "DirectoryName"));
-    if (dirName.isEmpty()) {
-        dirName = "MixxxTmp"; // Default if empty
-    }
-
     QString trackFileCachePath;
 #ifdef Q_OS_WIN
-    QString driveLetter = pConfig->getValueString(
-            ConfigKey("[TrackFileCache]", "WindowsDrive"));
-    driveLetter = driveLetter.replace(QRegularExpression("[^a-zA-Z]"), "").toUpper();
-    if (driveLetter.isEmpty()) {
-        driveLetter = "R"; // Default if empty
-    }
-    trackFileCachePath = driveLetter + ":/" + dirName + "/";
+    trackFileCachePath = pConfig->getValueString(
+            ConfigKey("[TrackFileCache]", "WindowsPath"));
 #else
-    QString basePath = pConfig->getValueString(
-            ConfigKey("[TrackFileCache]", "LinuxDrive"));
-    if (basePath.isEmpty()) {
-        basePath = "/dev/shm"; // Default if empty
-    }
-    // Remove trailing slashes
-    while (basePath.endsWith('/')) {
-        basePath.chop(1);
-    }
-    trackFileCachePath = basePath + "/" + dirName + "/";
+    trackFileCachePath = pConfig->getValueString(
+            ConfigKey("[TrackFileCache]", "UnixPath"));
 #endif
 
-    qDebug() << "Cleaning up TrackFileCache files from:" << trackFileCachePath;
+    if (trackFileCachePath.isEmpty()) {
+        qDebug() << "TrackFileCache cleanup skipped - no path configured";
+        return;
+    }
 
+    qDebug() << "Cleaning up TrackFileCache files from:" << trackFileCachePath;
     CachingReaderWorker::cleanupAllTrackFileCacheFiles(trackFileCachePath);
 }

--- a/src/mixxxmainwindow.h
+++ b/src/mixxxmainwindow.h
@@ -116,6 +116,8 @@ class MixxxMainWindow : public QMainWindow {
 #ifndef __APPLE__
     void alwaysHideMenuBarDlg();
 #endif
+    // void cleanUpRamPlayCache();
+    static void cleanUpRamPlayCache(UserSettingsPointer pConfig);
 
     QDialog::DialogCode soundDeviceErrorDlg(
             const QString &title, const QString &text, bool* retryClicked);

--- a/src/mixxxmainwindow.h
+++ b/src/mixxxmainwindow.h
@@ -116,8 +116,7 @@ class MixxxMainWindow : public QMainWindow {
 #ifndef __APPLE__
     void alwaysHideMenuBarDlg();
 #endif
-    // void cleanUpRamPlayCache();
-    static void cleanUpRamPlayCache(UserSettingsPointer pConfig);
+    static void cleanUpTrackFileCacheCache(UserSettingsPointer pConfig);
 
     QDialog::DialogCode soundDeviceErrorDlg(
             const QString &title, const QString &text, bool* retryClicked);

--- a/src/preferences/dialog/dlgprefdeck.cpp
+++ b/src/preferences/dialog/dlgprefdeck.cpp
@@ -420,7 +420,7 @@ DlgPrefDeck::DlgPrefDeck(QWidget* parent, UserSettingsPointer pConfig)
 
     // TrackFileCache
     connect(checkBoxTrackFileCacheEnabled,
-            &QCheckBox::stateChanged,
+            &QCheckBox::toggled,
             this,
             &DlgPrefDeck::slotTrackFileCacheEnabledChanged);
     connect(pushButtonBrowseTrackFileCacheLocation,
@@ -1003,8 +1003,9 @@ void DlgPrefDeck::loadTrackFileCacheSettings() {
     slotTrackFileCacheEnabledChanged(trackFileCacheEnabled ? Qt::Checked : Qt::Unchecked);
 }
 
-void DlgPrefDeck::slotTrackFileCacheEnabledChanged(int state) {
-    bool enabled = (state == Qt::Checked);
+// void DlgPrefDeck::slotTrackFileCacheEnabledChanged(int state) {
+void DlgPrefDeck::slotTrackFileCacheEnabledChanged(bool enabled) {
+    // bool enabled = (state == Qt::Checked);
 
     lineEditTrackFileCacheLocation->setEnabled(enabled);
     pushButtonBrowseTrackFileCacheLocation->setEnabled(enabled);

--- a/src/preferences/dialog/dlgprefdeck.cpp
+++ b/src/preferences/dialog/dlgprefdeck.cpp
@@ -420,7 +420,7 @@ DlgPrefDeck::DlgPrefDeck(QWidget* parent, UserSettingsPointer pConfig)
 
     // TrackFileCache
     connect(checkBoxTrackFileCacheEnabled,
-            &QCheckBox::checkStateChanged,
+            &QCheckBox::stateChanged,
             this,
             &DlgPrefDeck::slotTrackFileCacheEnabledChanged);
     connect(pushButtonBrowseTrackFileCacheLocation,

--- a/src/preferences/dialog/dlgprefdeck.cpp
+++ b/src/preferences/dialog/dlgprefdeck.cpp
@@ -1000,7 +1000,8 @@ void DlgPrefDeck::loadTrackFileCacheSettings() {
     checkBoxTrackFileCachePreviewDeck->setChecked(trackFileCachePreviewDeckEnabled);
 
     // Enable/disable controls based on main checkbox
-    slotTrackFileCacheEnabledChanged(trackFileCacheEnabled ? Qt::Checked : Qt::Unchecked);
+    // slotTrackFileCacheEnabledChanged(trackFileCacheEnabled ? Qt::Checked : Qt::Unchecked);
+    slotTrackFileCacheEnabledChanged(trackFileCacheEnabled);
 }
 
 // void DlgPrefDeck::slotTrackFileCacheEnabledChanged(int state) {

--- a/src/preferences/dialog/dlgprefdeck.cpp
+++ b/src/preferences/dialog/dlgprefdeck.cpp
@@ -420,17 +420,13 @@ DlgPrefDeck::DlgPrefDeck(QWidget* parent, UserSettingsPointer pConfig)
 
     // TrackFileCache
     connect(checkBoxTrackFileCacheEnabled,
-            &QCheckBox::stateChanged,
+            &QCheckBox::checkStateChanged,
             this,
             &DlgPrefDeck::slotTrackFileCacheEnabledChanged);
     connect(pushButtonBrowseTrackFileCacheLocation,
             &QPushButton::clicked,
             this,
             &DlgPrefDeck::slotBrowseTrackFileCacheLocation);
-    connect(lineEditTrackFileCacheLocation,
-            &QLineEdit::textChanged,
-            this,
-            &DlgPrefDeck::slotUpdateTrackFileCacheLocation);
     populateTrackFileCacheSizeComboBox();
     loadTrackFileCacheSettings();
 }
@@ -1036,18 +1032,5 @@ void DlgPrefDeck::slotBrowseTrackFileCacheLocation() {
 
     if (!dir.isEmpty()) {
         lineEditTrackFileCacheLocation->setText(dir + "/MixxxTmp/");
-    }
-}
-
-void DlgPrefDeck::slotUpdateTrackFileCacheLocation(const QString& path) {
-    // Validate path and update UI if needed
-    validateTrackFileCacheLocation();
-}
-
-void DlgPrefDeck::validateTrackFileCacheLocation() {
-    QString path = lineEditTrackFileCacheLocation->text();
-    // Basic validation - you can add more sophisticated checks
-    if (!path.isEmpty() && !path.endsWith("/")) {
-        lineEditTrackFileCacheLocation->setText(path + "/");
     }
 }

--- a/src/preferences/dialog/dlgprefdeck.h
+++ b/src/preferences/dialog/dlgprefdeck.h
@@ -96,7 +96,8 @@ class DlgPrefDeck : public DlgPreferencePage, public Ui::DlgPrefDeckDlg  {
     void slotUpdatePitchAutoReset(bool);
 
   private slots:
-    void slotTrackFileCacheEnabledChanged(int state);
+    // void slotTrackFileCacheEnabledChanged(int state);
+    void slotTrackFileCacheEnabledChanged(bool enabled);
     void slotBrowseTrackFileCacheLocation();
 
   private:

--- a/src/preferences/dialog/dlgprefdeck.h
+++ b/src/preferences/dialog/dlgprefdeck.h
@@ -95,7 +95,17 @@ class DlgPrefDeck : public DlgPreferencePage, public Ui::DlgPrefDeckDlg  {
     void slotUpdateSpeedAutoReset(bool);
     void slotUpdatePitchAutoReset(bool);
 
+  private slots:
+    void slotTrackFileCacheEnabledChanged(int state);
+    void slotBrowseTrackFileCacheLocation();
+    void slotUpdateTrackFileCacheLocation(const QString& path);
+
   private:
+    void populateTrackFileCacheSizeComboBox();
+    void validateTrackFileCacheLocation();
+    void loadTrackFileCacheSettings();
+    void saveTrackFileCacheSettings();
+
     // Because the CueDefault list is out of order, we have to set the combo
     // box using the user data, not the index.  Returns the index of the item
     // that has the corresponding userData. If the userdata is not in the list,

--- a/src/preferences/dialog/dlgprefdeck.h
+++ b/src/preferences/dialog/dlgprefdeck.h
@@ -98,11 +98,9 @@ class DlgPrefDeck : public DlgPreferencePage, public Ui::DlgPrefDeckDlg  {
   private slots:
     void slotTrackFileCacheEnabledChanged(int state);
     void slotBrowseTrackFileCacheLocation();
-    void slotUpdateTrackFileCacheLocation(const QString& path);
 
   private:
     void populateTrackFileCacheSizeComboBox();
-    void validateTrackFileCacheLocation();
     void loadTrackFileCacheSettings();
     void saveTrackFileCacheSettings();
 

--- a/src/preferences/dialog/dlgprefdeckdlg.ui
+++ b/src/preferences/dialog/dlgprefdeckdlg.ui
@@ -643,7 +643,167 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
      </layout>
     </widget>
    </item>
-   <item row="2" column="0">
+    <!-- TrackFileCache Begin-->
+    <item row="2" column="0">
+      <widget class="QGroupBox" name="groupBoxTrackFileCache">
+        <property name="title">
+          <string>TrackFileCache</string>
+        </property>
+        <property name="toolTip">
+          <string>Copy track files to a cache location for faster loading and reduced disk access during performance</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayoutTrackFileCache">
+          <property name="spacing">
+            <number>10</number>
+          </property>
+
+          <!-- TrackFileCache: Enable  -->
+          <item row="0" column="0" colspan="3">
+            <widget class="QCheckBox" name="checkBoxTrackFileCacheEnabled">
+              <property name="text">
+                <string>Enable Track File Cache</string>
+              </property>
+              <property name="toolTip">
+                <string>Copy tracks to cache location for faster loading</string>
+              </property>
+            </widget>
+          </item>
+
+          <!-- TrackFileCache: Location -->
+          <item row="1" column="0">
+            <widget class="QLabel" name="labelTrackFileCacheLocation">
+              <property name="text">
+                <string>TrackFileCache location</string>
+              </property>
+              <property name="buddy">
+                <cstring>lineEditTrackFileCacheLocation</cstring>
+              </property>
+            </widget>
+          </item>
+          <item row="1" column="1">
+            <widget class="QLineEdit" name="lineEditTrackFileCacheLocation">
+              <property name="toolTip">
+                <string>Location where Mixxx will create the cache folder. Use fast storage like RAM disks or SSDs for best performance.</string>
+              </property>
+            </widget>
+          </item>
+          <item row="1" column="2">
+            <widget class="QPushButton" name="pushButtonBrowseTrackFileCacheLocation">
+              <property name="text">
+                <string>Browse...</string>
+              </property>
+              <property name="toolTip">
+                <string>Select cache location</string>
+              </property>
+            </widget>
+          </item>
+
+          <!-- TrackFileCache Max Size -->
+          <item row="2" column="0" colspan="2">
+           <widget class="QLabel" name="labelMaxTrackFileCacheSize">
+            <property name="text">
+             <string>Max cache size:</string>
+            </property>
+            <property name="buddy">
+             <cstring>comboBoxMaxTrackFileCacheSize</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="2" colspan="1">
+           <widget class="QComboBox" name="comboBoxMaxTrackFileCacheSize">
+            <property name="toolTip">
+             <string>Maximum disk space used by the cache. Larger values allow more tracks to be cached.</string>
+            </property>
+           </widget>
+          </item>
+
+          <!-- TrackFileCache settings for Decks/Samplers/PreviewDeck -->
+          <item row="3" column="0">
+            <widget class="QLabel" name="labelTrackFileCachePlayers">
+              <property name="text">
+                <string>Cache for players</string>
+              </property>
+            </widget>
+          </item>
+          <item row="3" column="1" colspan="2">
+            <layout class="QHBoxLayout" name="horizontalLayoutPlayers">
+              <item>
+                <widget class="QCheckBox" name="checkBoxTrackFileCacheDecks">
+                  <property name="text">
+                    <string>Decks</string>
+                  </property>
+                  <property name="toolTip">
+                    <string>Enable caching of tracks loaded in decks</string>
+                  </property>
+                  <property name="checked">
+                    <bool>true</bool>
+                  </property>
+                </widget>
+              </item>
+              <item>
+                <widget class="QCheckBox" name="checkBoxTrackFileCacheSamplers">
+                  <property name="text">
+                    <string>Samplers</string>
+                  </property>
+                  <property name="toolTip">
+                    <string>Enable caching of tracks loaded in samplers</string>
+                  </property>
+                  <property name="checked">
+                    <bool>true</bool>
+                  </property>
+                </widget>
+              </item>
+              <item>
+                <widget class="QCheckBox" name="checkBoxTrackFileCachePreviewDeck">
+                  <property name="text">
+                    <string>Preview Deck</string>
+                  </property>
+                  <property name="toolTip">
+                    <string>Enable caching of tracks loaded in preview deck</string>
+                  </property>
+                </widget>
+              </item>
+            </layout>
+          </item>
+
+          <!-- TrackFileCache Text -->
+          <item row="4" column="0" colspan="3">
+            <widget class="QLabel" name="labelTrackFileCacheDescription">
+              <property name="text">
+                <string>Track File Cache copies audio files to a fast storage location (RAM disk, SSD) for reduced loading times and improved performance during sets. Tracks are automatically managed and cleaned up when no longer needed.</string>
+              </property>
+              <property name="wordWrap">
+                <bool>true</bool>
+              </property>
+              <property name="alignment">
+                <set>Qt::AlignJustify</set>
+              </property>
+              <property name="styleSheet">
+                <string notr="true">color: #666; font-size: 10px;</string>
+              </property>
+            </widget>
+          </item>
+          <item row="5" column="0" colspan="3">
+            <widget class="QLabel" name="labelCacheWarning">
+              <property name="text">
+                <string>
+                  ⚠️ Note: Enabling/ Disabling the TrackFileCache or changing the location, size or setting requires restarting Mixxx. Manual cleanup of the old cache location may be needed.
+                </string>
+              </property>
+              <property name="wordWrap">
+                <bool>true</bool>
+              </property>
+              <property name="styleSheet">
+                <string notr="true">color: #d35400; background-color: #fef5e7; padding: 8px; border: 1px solid #f39c12; border-radius: 4px;</string>
+              </property>
+            </widget>
+          </item>
+        </layout>
+      </widget>
+    </item>
+    <!-- TrackFileCache End-->
+
+    <item row="6" column="0">
     <spacer name="verticalSpacer2">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -685,6 +845,13 @@ You can always drag-and-drop tracks on screen to clone a deck.</string>
   <tabstop>spinBoxTemporaryRateCoarse</tabstop>
   <tabstop>spinBoxPermanentRateFine</tabstop>
   <tabstop>spinBoxPermanentRateCoarse</tabstop>
+  <tabstop>checkBoxTrackFileCacheEnabled</tabstop>
+  <tabstop>lineEditTrackFileCacheLocation</tabstop>
+  <tabstop>pushButtonBrowseTrackFileCacheLocation</tabstop>
+  <tabstop>comboBoxMaxTrackFileCacheSize</tabstop>
+  <tabstop>checkBoxTrackFileCacheDecks</tabstop>
+  <tabstop>checkBoxTrackFileCacheSamplers</tabstop>
+  <tabstop>checkBoxTrackFileCachePreviewDeck</tabstop>
  </tabstops>
  <resources/>
  <buttongroups>


### PR DESCRIPTION
In this PR is some polishing concerning the stream-play-model.

History:
It started when playing lossless music from my NAS (wireless Lan) with AutoDJ on an older laptop ((i7 3th gen, ssd, 16Gb Ram) with Mixxx on Ubuntu (Asio, latency 21.3ms) when I heard some sound glitches / loss of quality when the files are 'very high' quality (24 192), when the files are stemcontainers the problem gets even worse. Even latency of 85 doen't solve it.

Diving into it:
- tested with bigger buffer (latency), on local disk / external HD & USBKey (USB2/3)
- tested on my live PC with musicfiles on 'older' external HD, USBKey, (wireless) Lan and pushing my PC playing 4 HQ files at the same time from the internal NVMe, stemcontainers, playing samplers...
- experimenting with the use of internal/external soundcard, (dis-)connected controllers.

I could regenerate the audio glitches/loss of quality on my live PC (recent high performance workstation) with the same latency (21.3 is IMO quite high).

I experimented with the buffer settings in cachingreader, setting the 
default 
kNumberOfCachedChunksInMemory = 80  (= 23 ms @ 44.1 kHz)
much higher, experimented with bigger preload ....

The bottleneck is the need to constant read from the source.

I came up with this idea:
instead of constantly reading (streaming) from (slower) sources while playing (which  can cause all kinds of problems), let's stream from the memory, in other words; copy the original file from the original source to the memory and stream play (Mixxx model) from the memory.
Linux already has a 'mounted' memory (dev/shm), with tools like ImDisk on Windows it's possible to create a Ram-Drive (I used that already to locate tempdirs), these locations are accessible at 'blazing' speed.
When dragging a track to a player, and copying the track to the memory it results in a lag depending on the speed of the source media and the file size. It's even possible to drasticly lower the latency settings.

Workflow: load to player = copy original file to memory + change the url of the track with the memory-url.

-> my old laptop 'pre-loads' the biggest HQ files (up to 350Mb if it's a stemscontainer) quite fast after which there are no soundglitches anymore while playing. 


On this foundation the rest of the PR is created:
- logic: creating a temp directory, setting a maximum size (and check before adding another track), adding a Session-Var-Prefix to the track, cleaning up the memory.
What this PR does:
- creating a MixxxTmp directory, on Linux/Mac in dev/shm/MixxxTmp, on Windows the driveletter needs to be set (users can also use the systems internal harddrive when the original source is a slower USBKey) 
- RAM-Tracks with another sessionvar-prefix are removed.
- when a track is loaded,
    * if the RAM-Play option is enabled (else normal stream-play from original source)
	* the RAM-Play name of the file is calculated:
`    MixxxTemp + <mixxx session var prefix> + <trackId> + <(TrackArtist - TrackTitle) = max 50 Chars)>.tmp`
		the name is also escaped from special characters. (Artist & Title can be removed, used in dev to follow proces)
    * in a stringlist we keep the actual loaded files: Group - RAM-Track, if the new calculated file is already in the stringlist, we don't need to copy it again but reuse the existing tmp (if RAM-Play is enabled, if RAM-Play is enabled for playertype).
`    QStringList oldFiles = tmpDir.entryList(QStringList() << "MixxxTemp_*", QDir::Files);`
	This makes cloning super fast and avoids the small delays that occur sometimes. Dragging from samplers to players (vice versa), doesn't imply the recreation of a RAM-track.
	* The stringlist is updated, if the previous created RAM-Track for this group isn't in the stringlist anymore - meaning the track isn't loaded in another player - the precious RAM-Track is deleted.
    * the actual size of the Ram-Temp Directory is calculated if the track is added to the Ram-Temp.
	if the new size is bigger then the config MaxSize -> track is not copied but will be stream-played, if not the file wil be copied and RAM-played.
	* if the file is copied the new filename becomes:
`    MixxxTemp + <mixxx session var prefix> + <trackId> + <(TrackArtist - TrackTitle) = max 50 Chars)>.tmp`
      the name is also escaped from special characters.
    * The url from the new created file replaces the url from the loaded track.
```
           TrackPointer trackToOpen = pTrack;
           if (useRamCopy) {
               trackToOpen->setURL(QUrl::fromLocalFile(ramFileName).toString());
               m_ramFilesInUse.insert(ramFileName);
               updateRamTrackUsage(m_group, ramFileName);
           } else {
               trackToOpen->setURL(pTrack->getURL());
               updateRamTrackUsage(m_group, "");
           }
```    
    * the file is played (streamed) from the RAM (or from another location if configured). 

Config vars (not yet created in preferences):

```
[RAM-Play]
Enabled // default 0 = disabled
DirectoryName // default MixxxTemp
MaxSizeMB // default 512 = max size of tempdir for RAM-play
Decks // default 1 = enable
Samplers // default 1 = enable
PreviewDeck // default 0 = disabled as it would create an unnecessary lag copying the track just for previewing
WindowsDrive // default R
LinuxDrive   // default: /dev/shm

```

Notes: 
- I experimented with the creation of a raw-pcm-tempfile but this takes too many time, not workable for DJ-ing.
- On my old laptop i can DJ with a latency of 5ms, but I kept it on 10.
- On my live PC can DJ with latency of 1ms, even with HQ stems.
- I can imagine this all sounds a bit silly for people playing mostly lossy files on recent hardware, but it can help users to extend the use of older hardware.