### PR TITLE
(feat/keyboard) Tracks: Shift+Space sorts by current column / toggles sort order

### DIFF
--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -1240,6 +1240,26 @@ void WTrackTableView::keyPressEvent(QKeyEvent* event) {
         }
         return;
     }
+    case Qt::Key_Space: {
+        if (event->modifiers() & Qt::ShiftModifier) {
+            // Sort by focused column
+            TrackModel::SortColumnId sortColumnId = getColumnIdFromCurrentIndex();
+            if (sortColumnId == TrackModel::SortColumnId::Invalid) {
+                return;
+            }
+
+            if (static_cast<int>(sortColumnId) != static_cast<int>(m_pSortColumn->get())) {
+                m_pSortColumn->set(static_cast<int>(sortColumnId));
+            } else {
+                // Already sorted by this column, invert sort order
+                m_pSortOrder->set((m_pSortOrder->get() == 0) ? 1.0 : 0.0);
+            }
+
+            applySortingIfVisible();
+            return;
+        }
+        break;
+    }
     default:
         break;
     }


### PR DESCRIPTION
A convenient shortcut, especially when managin/rearranging playlists where you'd need to switch back'n'forth between sorted by # and sorted by artist/BPM/..



For context, currently we have
* `Space` for big library (default, can be changed via Custom.kbd.cfg)
* `Ctrl`+`Space` for toggling Played & BPM checkboxes (Qt default?)
* `Ctrl`+`Return` for Track Properties (hard-coded in c++)

First I tried `Alt`+`Space` but, like other Alt combos on my distro/WM, this is bound to window actions, here: 'Toggle Window Menu'.