### PR TITLE
(fix) Tracks, overview column: draw focus border on top of overview pixmap

### DIFF
--- a/src/library/tabledelegates/overviewdelegate.cpp
+++ b/src/library/tabledelegates/overviewdelegate.cpp
@@ -169,4 +169,9 @@ void OverviewDelegate::paintItem(QPainter* painter,
         pixmap.setDevicePixelRatio(scaleFactor);
         painter->drawPixmap(option.rect, pixmap);
     }
+
+    // Draw a border if the cover art cell has focus
+    if (option.state & QStyle::State_HasFocus) {
+        drawBorder(painter, m_focusBorderColor, option.rect);
+    }
 }


### PR DESCRIPTION
Currently the (cell) focus border is drawn, then we paint the overview image on top.
Not a big deal, but confusing when overview is so dense that it covers even the left/right focus border.

Fix is the same as in Cover Art delegate and others.