### PR TITLE
Network clock underrun compensation 

### DIFF
--- a/src/engine/sidechain/enginenetworkstream.cpp
+++ b/src/engine/sidechain/enginenetworkstream.cpp
@@ -43,7 +43,6 @@ EngineNetworkStream::EngineNetworkStream(int numOutputChannels,
           m_numInputChannels(numInputChannels),
           m_sampleRate(),
           m_inputStreamStartTimeUs(-1),
-          m_inputStreamFramesWritten(0),
           m_inputStreamFramesRead(0),
           m_outputWorkers(BROADCAST_MAX_CONNECTIONS) {
     if (numInputChannels) {
@@ -77,7 +76,6 @@ EngineNetworkStream::~EngineNetworkStream() {
 void EngineNetworkStream::startStream(mixxx::audio::SampleRate sampleRate) {
     m_sampleRate = sampleRate;
     m_inputStreamStartTimeUs = getNetworkTimeUs();
-    m_inputStreamFramesWritten = 0;
 
     for (NetworkOutputStreamWorkerPtr worker : std::as_const(m_outputWorkers)) {
         if (worker.isNull()) {

--- a/src/engine/sidechain/enginenetworkstream.h
+++ b/src/engine/sidechain/enginenetworkstream.h
@@ -49,7 +49,6 @@ class EngineNetworkStream {
     mixxx::audio::ChannelCount m_numInputChannels;
     mixxx::audio::SampleRate m_sampleRate;
     qint64 m_inputStreamStartTimeUs;
-    qint64 m_inputStreamFramesWritten;
     qint64 m_inputStreamFramesRead;
 
     // EngineNetworkStream can't use locking mechanisms to protect its

--- a/src/soundio/sounddevicenetwork.cpp
+++ b/src/soundio/sounddevicenetwork.cpp
@@ -1,6 +1,7 @@
 #include "soundio/sounddevicenetwork.h"
 
 #include <QtDebug>
+#include <atomic>
 
 #include "control/controlobject.h"
 #include "engine/sidechain/enginenetworkstream.h"
@@ -29,6 +30,19 @@ constexpr int kNetworkLatencyFrames = 8192; // 185 ms @ 44100 Hz
 const mixxx::Logger kLogger("SoundDeviceNetwork");
 
 const QString kAppGroup = QStringLiteral("[App]");
+
+bool updateIfGreater(std::atomic_int* pAtomic, int newValue) {
+    int current = pAtomic->load(std::memory_order_relaxed);
+    while (newValue > current &&
+            pAtomic->compare_exchange_weak(
+                    current, // non const reference, updated each call
+                    newValue)) {
+        // pAtomic has now newValue
+        return true;
+    }
+    return false;
+}
+
 } // namespace
 
 SoundDeviceNetwork::SoundDeviceNetwork(
@@ -327,7 +341,10 @@ void SoundDeviceNetwork::workerWriteProcess(NetworkOutputStreamWorkerPtr pWorker
         workerWriteSilence(pWorker, silenceFrames);
         // Inform the engine cycle about the extra frames written to avoid
         // underflows in other code paths.
-        m_targetTime += static_cast<qint64>(silenceFrames / m_sampleRate.toDouble() * 1000000);
+        // Note, this is called for each pWorker (broadcats connection) all
+        // running at the same network clock. The value is used for shifting
+        // the m_targetTime and then reset to 0.
+        updateIfGreater(&m_extraFramesWritten, silenceFrames);
         m_pSoundManager->underflowHappened(24);
     } else if (writeExpected - readAvailable > outChunkSize / 2) {
         // try to keep PAs buffer filled up to 0.5 chunks
@@ -522,7 +539,8 @@ void SoundDeviceNetwork::callbackProcessClkRef() {
 void SoundDeviceNetwork::updateCallbackEntryToDacTime(SINT framesPerBuffer) {
     m_clkRefTimer.start();
     qint64 currentTime = m_pNetworkStream->getInputStreamTimeUs();
-    // This deadline for the next buffer in microseconds since the Unix epoch
+    // Calculate the deadline for the next buffer in microseconds since the Unix epoch
+    framesPerBuffer += m_extraFramesWritten.exchange(0, std::memory_order_relaxed);
     m_targetTime += static_cast<qint64>(framesPerBuffer / m_sampleRate.toDouble() * 1000000);
     double callbackEntrytoDacSecs = (m_targetTime - currentTime) / 1000000.0;
     callbackEntrytoDacSecs = math_max(callbackEntrytoDacSecs, 0.0001);

--- a/src/soundio/sounddevicenetwork.h
+++ b/src/soundio/sounddevicenetwork.h
@@ -67,6 +67,7 @@ class SoundDeviceNetwork : public SoundDevice {
     bool m_denormals;
     /// The deadline for the next buffer, in microseconds since the Unix epoch.
     qint64 m_targetTime;
+    std::atomic_int m_extraFramesWritten;
     PerformanceTimer m_clkRefTimer;
 };
 

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -811,7 +811,7 @@ int SoundDevicePortAudio::callbackProcessDrift(
 
     // In case of delayed engine calls we do not immediately write audible
     // silence. Instead we sleep a bit, but return always before the time
-    // of a whole cunk expires. It turns out that a real hw underflow has a
+    // of a whole chunk expires. It turns out that a real hw underflow has a
     // bigger impact than silence padding in Mixxx
     // sound API has its own measure to deal with the second.
     constexpr double kMaxSleepchunks = 0.5;

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -764,7 +764,7 @@ int SoundDevicePortAudio::callbackProcessDrift(
     // Since we are on the non Clock reference device and may have an independent
     // crystal clock, a jitter compensation and drift correction is required.
     //
-    // Depending in the underlying API, sound hardware and CPU load, there is a
+    // Depending on the underlying API, sound hardware and CPU load, there is a
     // jitter (delayed call) by up to two buffer sizes compared to the engine
     // call running Clock Reference callback. It happens that the second one
     // fires two times and then the first one fires two time as well to catch
@@ -781,7 +781,7 @@ int SoundDevicePortAudio::callbackProcessDrift(
     // dropouts or clicks.
     //
     // So that's why we need a Fifo of 3 chunks (kFifoSize = 3)
-    // The buffer however is 4 chunks, because it is rounded up to pwer of 2
+    // The buffer however is 4 chunks, because it is rounded up to power of 2
     //
     // Normal buffer situation when entering this function:
     // Input buffer:

--- a/src/soundio/sounddeviceportaudio.cpp
+++ b/src/soundio/sounddeviceportaudio.cpp
@@ -861,7 +861,7 @@ int SoundDevicePortAudio::callbackProcessDrift(
                     kMaxSleepchunks / kMaxSleepSteps);
             for (; sleepSteps > 0; --sleepSteps) {
                 QThread::msleep(sleepMs);
-                writeAvailable = m_inputFifo->readAvailable();
+                writeAvailable = m_inputFifo->writeAvailable();
                 if (writeAvailable >= inChunkSize) {
                     break;
                 }

--- a/src/soundio/sounddeviceportaudio.h
+++ b/src/soundio/sounddeviceportaudio.h
@@ -76,8 +76,8 @@ class SoundDevicePortAudio : public SoundDevice {
     PaStreamParameters m_inputParams;
     std::unique_ptr<FIFO<CSAMPLE>> m_outputFifo;
     std::unique_ptr<FIFO<CSAMPLE>> m_inputFifo;
-    bool m_outputDrift;
-    bool m_inputDrift;
+    int m_outputDrift;
+    int m_inputDrift;
 
     // A string describing the last PortAudio error to occur.
     QString m_lastError;


### PR DESCRIPTION
I have tested intensively with two soundcards and the network clock. 
It turns out that it worked flawlessly, when the APIs work like expected with a single buffer swapping approach. However when underflow happens Mixxx was pedantic and immediately inserts silence or skips samples. This has a bigger impact than necessary. 

Now Mixxx is more relaxed making use of possible buffering in the underlying API like ASIO or Pipewire. 

This has been testes with ALSA Pipewrire and Jack. The test with ASIO is still pending. 