### PR TITLE
Fix qml install for Windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3092,6 +3092,7 @@ else()
         install(
           IMPORTED_RUNTIME_ARTIFACTS
             Qt${QT_VERSION_MAJOR}::QuickControls2
+            Qt${QT_VERSION_MAJOR}::QuickTemplates2
             DESTINATION
             "${MIXXX_INSTALL_DATADIR}"
             COMPONENT
@@ -3119,14 +3120,6 @@ else()
         Qt${QT_VERSION_MAJOR}::QuickShapesPrivate
         DESTINATION "${MIXXX_INSTALL_DATADIR}"
         COMPONENT applocal)
-
-      if(QT_VERSION VERSION_LESS 6.4)
-        # From Qt 6.4 integrated in QuickControls2
-	    install(IMPORTED_RUNTIME_ARTIFACTS
-	      Qt${QT_VERSION_MAJOR}::QuickTemplates2
-	      DESTINATION "${MIXXX_INSTALL_DATADIR}"
-	      COMPONENT applocal)
-	  endif()
 
       install(IMPORTED_RUNTIME_ARTIFACTS
         Qt${QT_VERSION_MAJOR}::ShaderTools


### PR DESCRIPTION
This fixes starting with the experimental qml skin on windows cause by a missing DLL. 