### PR TITLE
POC: Add "Window" element to skinparser

### DIFF
--- a/res/skins/Shade/skin.xml
+++ b/res/skins/Shade/skin.xml
@@ -440,9 +440,19 @@
         <!-- minimal decks, visible with maximized library -->
         <Template src="skin:decks_row_small.xml"/>
 
-        <SingletonContainer>
-          <ObjectName>Library</ObjectName>
-        </SingletonContainer>
+        <WidgetGroup>
+          <SizePolicy>me,me</SizePolicy>
+        </WidgetGroup>
+
+        <Window>
+          <SizePolicy>me,me</SizePolicy>
+          <Layout>vertical</Layout>
+          <Children>
+            <SingletonContainer>
+              <ObjectName>Library</ObjectName>
+            </SingletonContainer>
+          </Children>
+        </Window>
       </Children>
     </WidgetGroup>
   </Children>

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -631,6 +631,8 @@ QList<QWidget*> LegacySkinParser::parseNode(const QDomElement& node) {
         parseSingletonDefinition(node);
     } else if (nodeName == "SingletonContainer") {
         result = wrapWidget(parseStandardWidget<WSingletonContainer>(node));
+    } else if (nodeName == "Window") {
+        result = wrapWidget(parseWindow(node));
     } else {
         SKIN_WARNING(node,
                 *m_pContext,
@@ -749,6 +751,22 @@ QWidget* LegacySkinParser::parseWidgetGroup(const QDomElement& node) {
     pGroup->Init();
     parseChildren(node, pGroup);
     return pGroup;
+}
+
+QWidget* LegacySkinParser::parseWindow(const QDomElement& node) {
+    WWidgetGroup* pWindow = new WWidgetGroup(m_pParent);
+    pWindow->setWindowFlags(Qt::Window);
+    pWindow->setWindowTitle("Mixxx Library");
+    pWindow->show();
+    setupBaseWidget(node, pWindow);
+    setupWidget(node, pWindow->toQWidget());
+    pWindow->setup(node, *m_pContext);
+    // Note: if we call setupConnections earlier and it sets the visible property
+    // to true, the style is not applied correctly
+    setupConnections(node, pWindow);
+    pWindow->Init();
+    parseChildren(node, pWindow);
+    return nullptr;
 }
 
 QWidget* LegacySkinParser::parseWidgetStack(const QDomElement& node) {

--- a/src/skin/legacy/legacyskinparser.h
+++ b/src/skin/legacy/legacyskinparser.h
@@ -101,6 +101,7 @@ class LegacySkinParser : public QObject, public SkinParser {
 
     // Grouping / layout.
     QWidget* parseWidgetGroup(const QDomElement& node);
+    QWidget* parseWindow(const QDomElement& node);
     QWidget* parseTrackWidgetGroup(const QDomElement& node);
     QWidget* parseWidgetStack(const QDomElement& node);
     QWidget* parseSizeAwareStack(const QDomElement& node);


### PR DESCRIPTION
This is just a small POC if a floating library window is possible. It is: 

<img width="1840" height="1131" alt="image" src="https://github.com/user-attachments/assets/5062b1e9-c67c-4a54-9c73-2b3df27f2cd0" />

+32 line. But a lot of tedious polishing left to make it ready for merge. 
