### PR TITLE
Library sidebar: customize hover expand delay

### DIFF
--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -339,6 +339,12 @@ void Library::bindSearchboxWidget(WSearchLineEdit* pSearchboxWidget) {
 }
 
 void Library::bindSidebarWidget(WLibrarySidebar* pSidebarWidget) {
+    const auto sidebarHoverExpandDelay =
+            m_pConfig->getValue(
+                    kSidebarHoverExpandDelayConfigKey,
+                    kSidebarHoverExpandDelayDefault);
+    pSidebarWidget->slotSetExpandOnHoverDelay(sidebarHoverExpandDelay);
+
     m_pLibraryControl->bindSidebarWidget(pSidebarWidget);
 
     // Setup the sources view
@@ -384,6 +390,11 @@ void Library::bindSidebarWidget(WLibrarySidebar* pSidebarWidget) {
             &Library::setTrackTableFont,
             pSidebarWidget,
             &WLibrarySidebar::slotSetFont);
+
+    connect(this,
+            &Library::setSidebarHoverExpandDelay,
+            pSidebarWidget,
+            &WLibrarySidebar::slotSetExpandOnHoverDelay);
 
     for (const auto& feature : std::as_const(m_features)) {
         feature->bindSidebarWidget(pSidebarWidget);

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -175,6 +175,8 @@ class Library: public QObject {
     void setTrackTableRowHeight(int rowHeight);
     void setSelectedClick(bool enable);
 
+    void setSidebarHoverExpandDelay(int delay);
+
     void onTrackAnalyzerProgress(TrackId trackId, AnalyzerProgress analyzerProgress);
 
   private slots:

--- a/src/library/library_prefs.cpp
+++ b/src/library/library_prefs.cpp
@@ -119,3 +119,8 @@ const ConfigKey mixxx::library::prefs::kDateFormatConfigKey =
         ConfigKey{
                 mixxx::library::prefs::kConfigGroup,
                 QStringLiteral("DateFormat")};
+
+const ConfigKey mixxx::library::prefs::kSidebarHoverExpandDelayConfigKey =
+        ConfigKey{
+                mixxx::library::prefs::kConfigGroup,
+                QStringLiteral("sidebar_hover_expand_delay")};

--- a/src/library/library_prefs.h
+++ b/src/library/library_prefs.h
@@ -60,6 +60,10 @@ extern const ConfigKey kTagFetcherApplyCoverConfigKey;
 
 extern const ConfigKey kDateFormatConfigKey;
 
+const int kSidebarHoverExpandDelayDefault = 250; // ms
+
+extern const ConfigKey kSidebarHoverExpandDelayConfigKey;
+
 } // namespace prefs
 
 } // namespace library

--- a/src/library/library_prefs.h
+++ b/src/library/library_prefs.h
@@ -60,7 +60,7 @@ extern const ConfigKey kTagFetcherApplyCoverConfigKey;
 
 extern const ConfigKey kDateFormatConfigKey;
 
-const int kSidebarHoverExpandDelayDefault = 250; // ms
+const int kSidebarHoverExpandDelayDefault = 500; // ms
 
 extern const ConfigKey kSidebarHoverExpandDelayConfigKey;
 

--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -299,6 +299,8 @@ void DlgPrefLibrary::slotResetToDefaults() {
         comboBox_dateFormat->setCurrentIndex(0);
     }
 
+    spinBox_sidebar_hover_expand_delay->setValue(kSidebarHoverExpandDelayDefault);
+
     checkBox_show_rhythmbox->setChecked(true);
     checkBox_show_banshee->setChecked(true);
     checkBox_show_itunes->setChecked(true);
@@ -453,9 +455,15 @@ void DlgPrefLibrary::slotUpdate() {
 
     const auto applyPlayedTrackColor =
             m_pConfig->getValue(
-                    mixxx::library::prefs::kApplyPlayedTrackColorConfigKey,
+                    kApplyPlayedTrackColorConfigKey,
                     BaseTrackTableModel::kApplyPlayedTrackColorDefault);
     checkbox_played_track_color->setChecked(applyPlayedTrackColor);
+
+    const auto sidebarHoverExpandDelay =
+            m_pConfig->getValue(
+                    kSidebarHoverExpandDelayConfigKey,
+                    kSidebarHoverExpandDelayDefault);
+    spinBox_sidebar_hover_expand_delay->setValue(sidebarHoverExpandDelay);
 }
 
 void DlgPrefLibrary::slotCancel() {
@@ -672,8 +680,12 @@ void DlgPrefLibrary::slotApply() {
     BaseTrackTableModel::setApplyPlayedTrackColor(
             checkbox_played_track_color->isChecked());
     m_pConfig->set(
-            mixxx::library::prefs::kApplyPlayedTrackColorConfigKey,
+            kApplyPlayedTrackColorConfigKey,
             ConfigValue(checkbox_played_track_color->isChecked()));
+
+    int sidebarHoverExpandDelay = spinBox_sidebar_hover_expand_delay->value();
+    m_pConfig->setValue(kSidebarHoverExpandDelayConfigKey, sidebarHoverExpandDelay);
+    emit m_pLibrary->setSidebarHoverExpandDelay(sidebarHoverExpandDelay);
 
     // TODO(rryan): Don't save here.
     m_pConfig->save();

--- a/src/preferences/dialog/dlgpreflibrarydlg.ui
+++ b/src/preferences/dialog/dlgpreflibrarydlg.ui
@@ -419,6 +419,50 @@
    </item><!-- Search box -->
 
    <item>
+    <widget class="QGroupBox" name="groupBox_sidebar">
+     <property name="title">
+      <string>Sidebar</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_sidebar">
+
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_sidebar_hover_expand_delay">
+        <property name="text">
+         <string>Hover expand delay:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeft|Qt::AlignVCenter</set>
+        </property>
+        <property name="buddy">
+         <cstring>spinBox_sidebar_hover_expand_delay</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1" colspan="2">
+       <widget class="QSpinBox" name="spinBox_sidebar_hover_expand_delay">
+        <property name="suffix">
+         <string> ms</string>
+        </property>
+        <property name="toolTip">
+         <string>The delay until sidebar items are expanded or collapsed hovered during drag'n'drop. -1 disables auto-expand.</string>
+        </property>
+        <property name="minimum">
+         <number>-1</number>
+        </property>
+        <property name="maximum">
+         <number>5000</number>
+        </property>
+        <property name="singleStep">
+         <number>50</number>
+        </property>
+       </widget>
+      </item>
+
+     </layout>
+    </widget>
+   </item>
+
+   <item>
     <widget class="QGroupBox" name="groupBox_History">
      <property name="title">
       <string>Session History</string>
@@ -744,6 +788,7 @@
   <tabstop>checkBox_enable_search_completions</tabstop>
   <tabstop>checkBox_enable_search_history_shortcuts</tabstop>
   <tabstop>comboBox_search_bpm_fuzzy_range</tabstop>
+  <tabstop>spinBox_sidebar_hover_expand_delay</tabstop>
   <tabstop>spinbox_history_track_duplicate_distance</tabstop>
   <tabstop>spinbox_history_min_tracks_to_keep</tabstop>
   <tabstop>checkBox_show_rhythmbox</tabstop>

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -4,16 +4,16 @@
 #include <QUrl>
 #include <QtDebug>
 
+#include "library/library_prefs.h"
 #include "library/sidebarmodel.h"
 #include "moc_wlibrarysidebar.cpp"
 #include "util/defs.h"
 #include "util/dnd.h"
 
-constexpr int expand_time = 250;
-
 WLibrarySidebar::WLibrarySidebar(QWidget* parent)
         : QTreeView(parent),
           WBaseWidget(this),
+          m_hoverExpandDelay(mixxx::library::prefs::kSidebarHoverExpandDelayDefault),
           m_lastDragMoveAccepted(false) {
     qRegisterMetaType<FocusWidget>("FocusWidget");
     //Set some properties
@@ -90,10 +90,13 @@ void WLibrarySidebar::dragMoveEvent(QDragMoveEvent* pEvent) {
         return;
     }
 
-    // Start a timer to auto-expand sections the user hovers on
-    m_expandTimer.stop();
     m_hoverIndex = index;
-    m_expandTimer.start(expand_time, this);
+
+    if (m_hoverExpandDelay >= 0) {
+        // Timeout of < 0 disables auto-expand
+        m_expandTimer.stop();
+        m_expandTimer.start(m_hoverExpandDelay, this);
+    }
 
     // This has to be here instead of after, otherwise all drags will be
     // rejected -- rryan 3/2011
@@ -491,4 +494,8 @@ void WLibrarySidebar::slotSetFont(const QFont& font) {
     // Resize the feature icons to be a bit taller than the label's capital
     int iconSize = static_cast<int>(QFontMetrics(font).height() * 0.8);
     setIconSize(QSize(iconSize, iconSize));
+}
+
+void WLibrarySidebar::slotSetExpandOnHoverDelay(int delay) {
+    m_hoverExpandDelay = delay;
 }

--- a/src/widget/wlibrarysidebar.h
+++ b/src/widget/wlibrarysidebar.h
@@ -34,6 +34,7 @@ class WLibrarySidebar : public QTreeView, public WBaseWidget {
     void selectIndex(const QModelIndex& index, bool scrollToIndex = true);
     void selectChildIndex(const QModelIndex&, bool selectItem = true);
     void slotSetFont(const QFont& font);
+    void slotSetExpandOnHoverDelay(int delay);
 
   signals:
     void rightClicked(const QPoint&, const QModelIndex&);
@@ -53,6 +54,7 @@ class WLibrarySidebar : public QTreeView, public WBaseWidget {
     void resetHoverIndexAndDragMoveResult();
 
     QBasicTimer m_expandTimer;
+    int m_hoverExpandDelay;
     QModelIndex m_hoverIndex;
     bool m_lastDragMoveAccepted;
 };


### PR DESCRIPTION
The default 250 ms is too short for my taste and is a bit annyoing especially when using a trackpad where I not always hit the target on first attempt.
And when this came up in the forums recently I made it customizable.

IMO this is a property like the double-click interval that should be customizable to suits users's needs / capabilities.

Looks like this
<img width="1291" height="118" alt="image" src="https://github.com/user-attachments/assets/7b9e2671-c0de-4193-864a-7f2ce2e2577c" />
