### PR TITLE
(fix) Cover Art: reset track's CoverInfo if metadata image doesn't exist anymore

### DIFF
--- a/src/library/coverartcache.cpp
+++ b/src/library/coverartcache.cpp
@@ -222,6 +222,21 @@ CoverArtCache::FutureResult CoverArtCache::loadCover(
             // or downsize the image for efficiency.
             loadedImage.image = resizeImageWidth(loadedImage.image, desiredWidth);
         }
+    } else {
+        kLogger.warning() << "loaded image is NULL";
+        if (pTrack && coverInfo.type == CoverInfo::Type::METADATA) {
+            // The image was supposed to be in the track's metadata but is not.
+            // Removed form file? Database corruption?
+            // Either way this can cause repeated lookups by CoverArtDelegate
+            // which are affecting the GUI and cause massive framerate drop,
+            // see https://github.com/mixxxdj/mixxx/issues/15199
+            // In order to avoid this we reset the track's cover info.
+            // On next cover request we'll try to guess the cover again, so we
+            // either find a cover in the track directory or mark CoverInfo empty.
+            kLogger.warning() << "image was expected to be in metadata, but it's not. "
+                                 "Reset track's cover info";
+            pTrack->setCoverInfo(CoverInfoRelative());
+        }
     }
 
     res.coverArt = CoverArt(


### PR DESCRIPTION
Fixes #15199 for me.

Avoids potential framerate drop caused by repetetive cover lookup by CoverArtDelegate when tracks' CoverInfo is
`{"METADATA","GUESSED",,"","",someId}`
= image is expected in track file metadata
but there's no image in the file.

Resetting the CoverInfo makes CoverArtDelegate / CoverArtCache re-read/re-guess the cover art and either finds a cover in the track directory or marks the CoverInfo empty.

Still have no clue what has caused this..
This is the commit I used to trace the delegate and cache interaction c60e883dd5