### PR TITLE
(fix) Library preferences: reset library font/row height when closing without apply

### DIFF
--- a/src/preferences/dialog/dlgpreflibrary.cpp
+++ b/src/preferences/dialog/dlgpreflibrary.cpp
@@ -171,6 +171,7 @@ void DlgPrefLibrary::slotShow() {
 }
 
 void DlgPrefLibrary::slotHide() {
+    resetLibraryFont();
     if (!m_bAddedDirectory) {
         return;
     }
@@ -348,6 +349,7 @@ void DlgPrefLibrary::slotUpdate() {
             kEnableSearchHistoryShortcutsConfigKey,
             WSearchLineEdit::kHistoryShortcutsEnabledDefault));
 
+    // Library reads font from config during construction
     m_originalTrackTableFont = m_pLibrary->getTrackTableFont();
     m_iOriginalTrackTableRowHeight = m_pLibrary->getTrackTableRowHeight();
     spinBox_row_height->setValue(m_iOriginalTrackTableRowHeight);
@@ -384,6 +386,10 @@ void DlgPrefLibrary::slotUpdate() {
 }
 
 void DlgPrefLibrary::slotCancel() {
+    resetLibraryFont();
+}
+
+void DlgPrefLibrary::resetLibraryFont() {
     // Undo any changes in the library font or row height.
     m_pLibrary->setFont(m_originalTrackTableFont);
     m_pLibrary->setRowHeight(m_iOriginalTrackTableRowHeight);
@@ -572,12 +578,14 @@ void DlgPrefLibrary::slotApply() {
     if (m_originalTrackTableFont != font) {
         m_pConfig->set(ConfigKey("[Library]", "Font"),
                        ConfigValue(font.toString()));
+        m_originalTrackTableFont = font;
     }
 
     int rowHeight = spinBox_row_height->value();
     if (m_iOriginalTrackTableRowHeight != rowHeight) {
         m_pConfig->set(ConfigKey("[Library]","RowHeight"),
                        ConfigValue(rowHeight));
+        m_iOriginalTrackTableRowHeight = rowHeight;
     }
 
     BaseTrackTableModel::setApplyPlayedTrackColor(

--- a/src/preferences/dialog/dlgpreflibrary.h
+++ b/src/preferences/dialog/dlgpreflibrary.h
@@ -71,6 +71,7 @@ class DlgPrefLibrary : public DlgPreferencePage, public Ui::DlgPrefLibraryDlg  {
   private:
     void populateDirList();
     void setLibraryFont(const QFont& font);
+    void resetLibraryFont();
     void updateSearchLineEditHistoryOptions();
     void setSeratoMetadataEnabled(bool shouldSyncTrackMetadata);
 


### PR DESCRIPTION
The library font is applied instantly to give a preview.
However, if it's not applied it persists in the library, but not in the config. It'll be reset after next start.

Simply reset it when closing the dialog if it's not applied immediatly.