### PR TITLE
(fix/UX) Playlist: disable all modifying actions when locked

### DIFF
--- a/src/library/trackset/baseplaylistfeature.cpp
+++ b/src/library/trackset/baseplaylistfeature.cpp
@@ -448,6 +448,11 @@ void BasePlaylistFeature::slotImportPlaylist() {
     if (playlistId == kInvalidPlaylistId) {
         return;
     }
+    if (m_playlistDao.isPlaylistLocked(playlistId)) {
+        qDebug() << "Can't import a playlist into locked playlist" << playlistId
+                 << m_playlistDao.getPlaylistName(playlistId);
+        return;
+    }
 
     // Update the import/export playlist directory
     QFileInfo fileDirectory(playlistFile);
@@ -460,6 +465,11 @@ void BasePlaylistFeature::slotImportPlaylist() {
 void BasePlaylistFeature::slotImportPlaylistFile(const QString& playlistFile,
         int playlistId) {
     if (playlistFile.isEmpty()) {
+        return;
+    }
+    if (m_playlistDao.isPlaylistLocked(playlistId)) {
+        qDebug() << "Can't import a playlist into locked playlist" << playlistId
+                 << m_playlistDao.getPlaylistName(playlistId);
         return;
     }
     // The user has picked a new directory via a file dialog. This means the

--- a/src/library/trackset/crate/cratefeature.cpp
+++ b/src/library/trackset/crate/cratefeature.cpp
@@ -666,6 +666,13 @@ void CrateFeature::slotImportPlaylist() {
 }
 
 void CrateFeature::slotImportPlaylistFile(const QString& playlistFile, CrateId crateId) {
+    Crate crate;
+    if (!m_pTrackCollection->crates().readCrateById(crateId, &crate)) {
+        return;
+    }
+    if (crate.isLocked()) {
+        return;
+    }
     // The user has picked a new directory via a file dialog. This means the
     // system sandboxer (if we are sandboxed) has granted us permission to this
     // folder. We don't need access to this file on a regular basis so we do not

--- a/src/library/trackset/crate/cratefeature.cpp
+++ b/src/library/trackset/crate/cratefeature.cpp
@@ -386,6 +386,7 @@ void CrateFeature::onRightClickChild(
 
     m_pDeleteCrateAction->setEnabled(!crate.isLocked());
     m_pRenameCrateAction->setEnabled(!crate.isLocked());
+    m_pImportPlaylistAction->setEnabled(!crate.isLocked());
 
     m_pAutoDjTrackSourceAction->setChecked(crate.isAutoDjSource());
 
@@ -403,9 +404,7 @@ void CrateFeature::onRightClickChild(
     menu.addSeparator();
     menu.addAction(m_pAnalyzeCrateAction.get());
     menu.addSeparator();
-    if (!crate.isLocked()) {
-        menu.addAction(m_pImportPlaylistAction.get());
-    }
+    menu.addAction(m_pImportPlaylistAction.get());
     menu.addAction(m_pExportPlaylistAction.get());
     menu.addAction(m_pExportTrackFilesAction.get());
 #ifdef __ENGINEPRIME__

--- a/src/library/trackset/playlistfeature.cpp
+++ b/src/library/trackset/playlistfeature.cpp
@@ -62,6 +62,8 @@ void PlaylistFeature::onRightClickChild(
     bool locked = m_playlistDao.isPlaylistLocked(playlistId);
     m_pDeletePlaylistAction->setEnabled(!locked);
     m_pRenamePlaylistAction->setEnabled(!locked);
+    m_pShufflePlaylistAction->setEnabled(!locked);
+    m_pImportPlaylistAction->setEnabled(!locked);
 
     m_pLockPlaylistAction->setText(locked ? tr("Unlock") : tr("Lock"));
 


### PR DESCRIPTION
another small UX fix off my stash
* extend modification protection of locked Crates & Playlists 
* disable all modifying menu actions for locked Crates & Playlists
(some methods already disallow and throws warnings, but it's not clear from the GUI)
* make Crates menu consistent with Playlists menu