### PR TITLE
Bugfix FxToggleButton qss: comma in palemoon style missing

### DIFF
--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -1728,7 +1728,7 @@ WPushButton#VinylStatus[displayValue="1"], /* enabled, OK */
   }
 /* Blue for Fx buttons 3/4 */
 #FxUnit3 #FxToggleButton[displayValue="1"],
-#FxUnit4 #FxToggleButton[displayValue="1"]
+#FxUnit4 #FxToggleButton[displayValue="1"],
 WBeatSpinBox::up-button:pressed,
 WBeatSpinBox::down-button:pressed,
 #spinBoxTransition::up-button:pressed,


### PR DESCRIPTION
fix for style issue, otherwise EffectUnit 4 Buttons get not visually activated

Without fix (all effects activated), see right lower area:

<img width="1595" height="71" alt="Screenshot_20251008_192421" src="https://github.com/user-attachments/assets/ccea7708-ff4d-4f2e-a51c-35afb0d02b86" />

With fix (all effects activated), see right lower area:

<img width="1595" height="71" alt="Screenshot_20251008_192553" src="https://github.com/user-attachments/assets/455a34fc-e06b-44d4-bdc1-c8c215ce84aa" />

