### PR TITLE
(fix) Playlists: avoid no-op select() when activating a playlist

### DIFF
--- a/src/library/dao/playlistdao.cpp
+++ b/src/library/dao/playlistdao.cpp
@@ -577,9 +577,16 @@ void PlaylistDAO::removeHiddenTracks(const int playlistId) {
         return;
     }
 
+    bool anyTracksRemoved = false;
     while (query.next()) {
         int position = query.value(query.record().indexOf("position")).toInt();
         removeTracksFromPlaylistInner(playlistId, position);
+        anyTracksRemoved = true;
+    }
+
+    // Avoid no-op select() if we didn't remove any tracks
+    if (!anyTracksRemoved) {
+        return;
     }
 
     transaction.commit();

--- a/src/library/playlisttablemodel.cpp
+++ b/src/library/playlisttablemodel.cpp
@@ -145,8 +145,6 @@ void PlaylistTableModel::selectPlaylist(int playlistId) {
         }
     }
 
-    m_iPlaylistId = playlistId;
-
     if (!m_keepHiddenTracks) {
         // From Mixxx 2.1 we drop tracks that have been explicitly deleted
         // in the library (mixxx_deleted = 0) from playlists.
@@ -154,6 +152,12 @@ void PlaylistTableModel::selectPlaylist(int playlistId) {
         // a source user of confusion in the past.
         m_pTrackCollectionManager->internalCollection()->getPlaylistDAO().removeHiddenTracks(m_iPlaylistId);
     }
+
+    // Note: don't set m_iPlaylistId = playlistId before removing hidden tracks,
+    // else (if tracks are removed) PlaylistDAO::tracksRemoved would trigger
+    // playlistsChanged() which would call select() -- which is simply not required
+    // because we'll trigger that ourselves later on.
+    m_iPlaylistId = playlistId;
 
     QString playlistTableName = "playlist_" + QString::number(m_iPlaylistId);
     QSqlQuery query(m_database);


### PR DESCRIPTION
In #15463 I noticed that there is an mysterious `select()` call when we switch from one playlist to another.

This happens because
* the `removeHiddenTracks()` call (for the new playlist) in `PlaylistTableModel::selectPlaylist()`
* `PlaylistDAO::removeHiddenTracks()` emits `tracksRemoved` signal (regardless if tracks have actually been removed)
* this triggers `PlaylistTableModel::playlistsChanged()` which calls `select()` (while the old playlist is still selected)
* as well as a unneeded call of `BasePlaylistFeature::updateChildModel()`

Fixes:
1) Make `PlaylistDAO::removeHiddenTracks()` emit signals only if tracks have been removed.
2) don't set `m_iPlaylistId = playlistId` before removing hidden tracks