### PR TITLE
LateNight: Fixed FxToggleButton style

### DIFF
--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -1728,7 +1728,7 @@ WPushButton#VinylStatus[displayValue="1"], /* enabled, OK */
   }
 /* Blue for Fx buttons 3/4 */
 #FxUnit3 #FxToggleButton[displayValue="1"],
-#FxUnit4 #FxToggleButton[displayValue="1"]
+#FxUnit4 #FxToggleButton[displayValue="1"],
 WBeatSpinBox::up-button:pressed,
 WBeatSpinBox::down-button:pressed,
 #spinBoxTransition::up-button:pressed,


### PR DESCRIPTION
comma was missing for FxToggleButton. FxUnit4 was not colored if active. Same as [15464](https://github.com/mixxxdj/mixxx/pull/15464) , but with better commit message
