### PR TITLE
Improve: Find on web 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1648,6 +1648,7 @@ add_library(
   src/waveform/widgets/glvsynctestwidget.cpp
   src/widget/controlwidgetconnection.cpp
   src/widget/findonwebmenufactory.cpp
+  src/widget/findonweblast.cpp
   src/widget/findonwebmenuservices/findonwebmenudiscogs.cpp
   src/widget/findonwebmenuservices/findonwebmenulastfm.cpp
   src/widget/findonwebmenuservices/findonwebmenusoundcloud.cpp

--- a/src/widget/findonweblast.cpp
+++ b/src/widget/findonweblast.cpp
@@ -1,0 +1,66 @@
+#include "findonweblast.h"
+
+#include <QtDebug>
+
+#include "moc_findonweblast.cpp"
+#include "track/track.h"
+#include "util/desktophelper.h"
+
+namespace {
+const QString kLibraryGroup = QStringLiteral("[Library]");
+const QString kFindOnWebLastActionKey = QStringLiteral("find_on_web_last_action");
+} // namespace
+
+FindOnWebLast::FindOnWebLast(QWidget* pParent, UserSettingsPointer pConfig)
+        : QAction(pParent),
+          m_pConfig(std::move(pConfig)) {
+    m_lastActionKey = m_pConfig->getValueString(
+            ConfigKey(kLibraryGroup, kFindOnWebLastActionKey));
+}
+
+void FindOnWebLast::openInBrowser(const QUrl& url) {
+    if (!mixxx::DesktopHelper::openUrl(url)) {
+        qWarning() << "DesktopHelper::openUrl() failed for " << url;
+        DEBUG_ASSERT(!"openInBrowser() failed");
+    }
+}
+
+void FindOnWebLast::update(
+        const QString& actionId,
+        const QString& actionText,
+        const QUrl& serviceUrl) {
+    if (m_lastActionKey != actionId) {
+        setAction(actionId, actionText, serviceUrl);
+        m_pConfig->setValue(
+                ConfigKey(kLibraryGroup, kFindOnWebLastActionKey), actionId);
+        m_lastActionKey = actionId;
+    }
+}
+
+void FindOnWebLast::init(
+        const QString& actionId,
+        const QString& actionText,
+        const QUrl& serviceUrl) {
+    if (m_lastActionKey == actionId) {
+        setAction(actionId, actionText, serviceUrl);
+    }
+}
+
+void FindOnWebLast::setAction(
+        const QString& actionId,
+        const QString& actionText,
+        const QUrl& serviceUrl) {
+    int firstCommaPos = actionId.indexOf(',');
+    VERIFY_OR_DEBUG_ASSERT(firstCommaPos >= 0) {
+        return;
+    }
+
+    QStringView service = QStringView(actionId).left(firstCommaPos);
+    //: Menu entry like "Find Artist on Wikipedia"
+    setText(tr("Find %1 on %2").arg(actionText, service));
+    disconnect();
+    connect(this, &QAction::triggered, this, [this, serviceUrl] {
+        openInBrowser(serviceUrl);
+    });
+    setVisible(true);
+}

--- a/src/widget/findonweblast.h
+++ b/src/widget/findonweblast.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <QAction>
+
+#include "preferences/usersettings.h"
+
+class Track;
+
+class FindOnWebLast : public QAction {
+    Q_OBJECT
+  public:
+    explicit FindOnWebLast(QWidget* pParent, UserSettingsPointer pConfig);
+    ~FindOnWebLast() override = default;
+
+    void update(
+            const QString& actionId,
+            const QString& actionText,
+            const QUrl& serviceUrl);
+
+    void init(
+            const QString& actionId,
+            const QString& actionText,
+            const QUrl& serviceUrl);
+
+  private:
+    void setAction(
+            const QString& actionId,
+            const QString& actionText,
+            const QUrl& serviceUrl);
+    void openInBrowser(const QUrl& url);
+    UserSettingsPointer m_pConfig;
+    QString m_lastActionKey;
+};

--- a/src/widget/findonwebmenufactory.cpp
+++ b/src/widget/findonwebmenufactory.cpp
@@ -12,9 +12,9 @@ namespace mixxx {
 namespace library {
 
 void createFindOnWebSubmenus(QMenu* pFindOnWebMenu, const Track& track) {
-    make_parented<FindOnWebMenuSoundcloud>(pFindOnWebMenu, track);
     make_parented<FindOnWebMenuDiscogs>(pFindOnWebMenu, track);
     make_parented<FindOnWebMenuLastfm>(pFindOnWebMenu, track);
+    make_parented<FindOnWebMenuSoundcloud>(pFindOnWebMenu, track);
 }
 
 } // namespace library

--- a/src/widget/findonwebmenufactory.cpp
+++ b/src/widget/findonwebmenufactory.cpp
@@ -11,8 +11,8 @@ namespace mixxx {
 
 namespace library {
 
-void createFindOnWebSubmenus(QMenu* pFindOnWebMenu,
-        FindOnWebLast* pFindOnWebLast,
+void createFindOnWebSubmenus(const QPointer<QMenu>& pFindOnWebMenu,
+        const QPointer<FindOnWebLast>& pFindOnWebLast,
         const Track& track) {
     make_parented<FindOnWebMenuDiscogs>(pFindOnWebMenu, pFindOnWebLast, track);
     make_parented<FindOnWebMenuLastfm>(pFindOnWebMenu, pFindOnWebLast, track);

--- a/src/widget/findonwebmenufactory.cpp
+++ b/src/widget/findonwebmenufactory.cpp
@@ -11,10 +11,12 @@ namespace mixxx {
 
 namespace library {
 
-void createFindOnWebSubmenus(QMenu* pFindOnWebMenu, const Track& track) {
-    make_parented<FindOnWebMenuDiscogs>(pFindOnWebMenu, track);
-    make_parented<FindOnWebMenuLastfm>(pFindOnWebMenu, track);
-    make_parented<FindOnWebMenuSoundcloud>(pFindOnWebMenu, track);
+void createFindOnWebSubmenus(QMenu* pFindOnWebMenu,
+        FindOnWebLast* pFindOnWebLast,
+        const Track& track) {
+    make_parented<FindOnWebMenuDiscogs>(pFindOnWebMenu, pFindOnWebLast, track);
+    make_parented<FindOnWebMenuLastfm>(pFindOnWebMenu, pFindOnWebLast, track);
+    make_parented<FindOnWebMenuSoundcloud>(pFindOnWebMenu, pFindOnWebLast, track);
 }
 
 } // namespace library

--- a/src/widget/findonwebmenufactory.h
+++ b/src/widget/findonwebmenufactory.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "QPointer"
+
 class Track;
 class QMenu;
 class FindOnWebLast;
@@ -8,8 +10,8 @@ namespace mixxx {
 
 namespace library {
 
-void createFindOnWebSubmenus(QMenu* pFindOnWebMenu,
-        FindOnWebLast* pFindOnWebLast,
+void createFindOnWebSubmenus(const QPointer<QMenu>& pFindOnWebMenu,
+        const QPointer<FindOnWebLast>& pFindOnWebLast,
         const Track& track);
 
 } // namespace library

--- a/src/widget/findonwebmenufactory.h
+++ b/src/widget/findonwebmenufactory.h
@@ -2,12 +2,15 @@
 
 class Track;
 class QMenu;
+class FindOnWebLast;
 
 namespace mixxx {
 
 namespace library {
 
-void createFindOnWebSubmenus(QMenu* pFindOnWebMenu, const Track& track);
+void createFindOnWebSubmenus(QMenu* pFindOnWebMenu,
+        FindOnWebLast* pFindOnWebLast,
+        const Track& track);
 
 } // namespace library
 

--- a/src/widget/findonwebmenuservices/findonwebmenudiscogs.cpp
+++ b/src/widget/findonwebmenuservices/findonwebmenudiscogs.cpp
@@ -42,6 +42,7 @@ FindOnWebMenuDiscogs::FindOnWebMenuDiscogs(QMenu* pFindOnWebMenu, const Track& t
             const QUrl discogsUrlArtistWithTrackTitle = composeDiscogsUrl(
                     kSearchUrl, composeSearchQuery(artist, trackTitle), kQueryTypeRelease);
             addActionToServiceMenu(
+                    kServiceTitle + QStringLiteral(",Artist,Title"),
                     tr("Artist + Title"),
                     discogsUrlArtistWithTrackTitle);
         }
@@ -50,23 +51,30 @@ FindOnWebMenuDiscogs::FindOnWebMenuDiscogs(QMenu* pFindOnWebMenu, const Track& t
             const QUrl discogsUrlArtistWithAlbum = composeDiscogsUrl(
                     kSearchUrl, composeSearchQuery(artist, album), kQueryTypeRelease);
             addActionToServiceMenu(
+                    kServiceTitle + QStringLiteral(",Artist,Album"),
                     tr("Artist + Album"),
                     discogsUrlArtistWithAlbum);
         }
 
         const QUrl discogsUrlArtist = composeDiscogsUrl(kSearchUrl, artist, kQueryTypeArtist);
         addActionToServiceMenu(
-                tr("Artist"), discogsUrlArtist);
+                kServiceTitle + QStringLiteral(",Artist"),
+                tr("Artist"),
+                discogsUrlArtist);
     }
     if (!album.isEmpty() && artist.isEmpty()) {
         const QUrl discogsUrlAlbum = composeDiscogsUrl(kSearchUrl, album, kQueryTypeRelease);
         addActionToServiceMenu(
-                tr("Album"), discogsUrlAlbum);
+                kServiceTitle + QStringLiteral(",Artist,Album"),
+                tr("Album"),
+                discogsUrlAlbum);
     }
     if (!trackTitle.isEmpty()) {
         const QUrl discogsUrlTrackTitle =
                 composeDiscogsUrl(kSearchUrl, trackTitle, kQueryTypeRelease);
         addActionToServiceMenu(
-                tr("Title"), discogsUrlTrackTitle);
+                kServiceTitle + QStringLiteral(",Title"),
+                tr("Title"),
+                discogsUrlTrackTitle);
     }
 }

--- a/src/widget/findonwebmenuservices/findonwebmenudiscogs.cpp
+++ b/src/widget/findonwebmenuservices/findonwebmenudiscogs.cpp
@@ -29,8 +29,10 @@ const QUrl composeDiscogsUrl(const QString& serviceDefaultUrl,
 }
 } //namespace
 
-FindOnWebMenuDiscogs::FindOnWebMenuDiscogs(QMenu* pFindOnWebMenu, const Track& track)
-        : WFindOnWebMenu(pFindOnWebMenu) {
+FindOnWebMenuDiscogs::FindOnWebMenuDiscogs(QMenu* pFindOnWebMenu,
+        FindOnWebLast* pFindOnWebLast,
+        const Track& track)
+        : WFindOnWebMenu(pFindOnWebMenu, pFindOnWebLast) {
     const QString artist = track.getArtist();
     const QString trackTitle = track.getTitle();
     const QString album = track.getAlbum();

--- a/src/widget/findonwebmenuservices/findonwebmenudiscogs.cpp
+++ b/src/widget/findonwebmenuservices/findonwebmenudiscogs.cpp
@@ -39,40 +39,34 @@ FindOnWebMenuDiscogs::FindOnWebMenuDiscogs(QMenu* pFindOnWebMenu, const Track& t
     addSeparator();
     if (!artist.isEmpty()) {
         if (!trackTitle.isEmpty()) {
-            const QString artistWithTrackTitle = composeSearchQuery(artist, trackTitle);
             const QUrl discogsUrlArtistWithTrackTitle = composeDiscogsUrl(
-                    kSearchUrl, artistWithTrackTitle, kQueryTypeRelease);
+                    kSearchUrl, composeSearchQuery(artist, trackTitle), kQueryTypeRelease);
             addActionToServiceMenu(
-                    composeActionText(
-                            tr("Artist + Title"), artistWithTrackTitle),
+                    tr("Artist + Title"),
                     discogsUrlArtistWithTrackTitle);
         }
 
         if (!album.isEmpty()) {
-            const QString artistWithAlbum = composeSearchQuery(artist, album);
             const QUrl discogsUrlArtistWithAlbum = composeDiscogsUrl(
-                    kSearchUrl, artistWithAlbum, kQueryTypeRelease);
+                    kSearchUrl, composeSearchQuery(artist, album), kQueryTypeRelease);
             addActionToServiceMenu(
-                    composeActionText(tr("Artist + Album"), artistWithAlbum),
+                    tr("Artist + Album"),
                     discogsUrlArtistWithAlbum);
         }
 
         const QUrl discogsUrlArtist = composeDiscogsUrl(kSearchUrl, artist, kQueryTypeArtist);
         addActionToServiceMenu(
-                composeActionText(tr("Artist"), artist),
-                discogsUrlArtist);
+                tr("Artist"), discogsUrlArtist);
     }
     if (!album.isEmpty() && artist.isEmpty()) {
         const QUrl discogsUrlAlbum = composeDiscogsUrl(kSearchUrl, album, kQueryTypeRelease);
         addActionToServiceMenu(
-                composeActionText(tr("Album"), album),
-                discogsUrlAlbum);
+                tr("Album"), discogsUrlAlbum);
     }
     if (!trackTitle.isEmpty()) {
         const QUrl discogsUrlTrackTitle =
                 composeDiscogsUrl(kSearchUrl, trackTitle, kQueryTypeRelease);
         addActionToServiceMenu(
-                composeActionText(tr("Title"), trackTitle),
-                discogsUrlTrackTitle);
+                tr("Title"), discogsUrlTrackTitle);
     }
 }

--- a/src/widget/findonwebmenuservices/findonwebmenudiscogs.cpp
+++ b/src/widget/findonwebmenuservices/findonwebmenudiscogs.cpp
@@ -38,13 +38,7 @@ FindOnWebMenuDiscogs::FindOnWebMenuDiscogs(QMenu* pFindOnWebMenu, const Track& t
     pFindOnWebMenu->addMenu(this);
     addSeparator();
     if (!artist.isEmpty()) {
-        const QUrl discogsUrlArtist = composeDiscogsUrl(kSearchUrl, artist, kQueryTypeArtist);
-        addActionToServiceMenu(
-                composeActionText(tr("Artist"), artist),
-                discogsUrlArtist);
-    }
-    if (!trackTitle.isEmpty()) {
-        if (!artist.isEmpty()) {
+        if (!trackTitle.isEmpty()) {
             const QString artistWithTrackTitle = composeSearchQuery(artist, trackTitle);
             const QUrl discogsUrlArtistWithTrackTitle = composeDiscogsUrl(
                     kSearchUrl, artistWithTrackTitle, kQueryTypeRelease);
@@ -53,25 +47,32 @@ FindOnWebMenuDiscogs::FindOnWebMenuDiscogs(QMenu* pFindOnWebMenu, const Track& t
                             tr("Artist + Title"), artistWithTrackTitle),
                     discogsUrlArtistWithTrackTitle);
         }
-        const QUrl discogsUrlTrackTitle =
-                composeDiscogsUrl(kSearchUrl, trackTitle, kQueryTypeRelease);
-        addActionToServiceMenu(
-                composeActionText(tr("Title"), trackTitle),
-                discogsUrlTrackTitle);
-    }
-    if (!album.isEmpty()) {
-        if (!artist.isEmpty()) {
+
+        if (!album.isEmpty()) {
             const QString artistWithAlbum = composeSearchQuery(artist, album);
             const QUrl discogsUrlArtistWithAlbum = composeDiscogsUrl(
                     kSearchUrl, artistWithAlbum, kQueryTypeRelease);
             addActionToServiceMenu(
                     composeActionText(tr("Artist + Album"), artistWithAlbum),
                     discogsUrlArtistWithAlbum);
-        } else {
-            const QUrl discogsUrlAlbum = composeDiscogsUrl(kSearchUrl, album, kQueryTypeRelease);
-            addActionToServiceMenu(
-                    composeActionText(tr("Album"), album),
-                    discogsUrlAlbum);
         }
+
+        const QUrl discogsUrlArtist = composeDiscogsUrl(kSearchUrl, artist, kQueryTypeArtist);
+        addActionToServiceMenu(
+                composeActionText(tr("Artist"), artist),
+                discogsUrlArtist);
+    }
+    if (!album.isEmpty() && artist.isEmpty()) {
+        const QUrl discogsUrlAlbum = composeDiscogsUrl(kSearchUrl, album, kQueryTypeRelease);
+        addActionToServiceMenu(
+                composeActionText(tr("Album"), album),
+                discogsUrlAlbum);
+    }
+    if (!trackTitle.isEmpty()) {
+        const QUrl discogsUrlTrackTitle =
+                composeDiscogsUrl(kSearchUrl, trackTitle, kQueryTypeRelease);
+        addActionToServiceMenu(
+                composeActionText(tr("Title"), trackTitle),
+                discogsUrlTrackTitle);
     }
 }

--- a/src/widget/findonwebmenuservices/findonwebmenudiscogs.cpp
+++ b/src/widget/findonwebmenuservices/findonwebmenudiscogs.cpp
@@ -6,6 +6,7 @@
 #include "moc_findonwebmenudiscogs.cpp"
 #include "track/track.h"
 #include "util/parented_ptr.h"
+#include "widget/findonweblast.h"
 
 namespace {
 const QString kServiceTitle = QStringLiteral("Discogs");
@@ -29,10 +30,10 @@ const QUrl composeDiscogsUrl(const QString& serviceDefaultUrl,
 }
 } //namespace
 
-FindOnWebMenuDiscogs::FindOnWebMenuDiscogs(QMenu* pFindOnWebMenu,
-        FindOnWebLast* pFindOnWebLast,
+FindOnWebMenuDiscogs::FindOnWebMenuDiscogs(const QPointer<QMenu>& pFindOnWebMenu,
+        QPointer<FindOnWebLast> pFindOnWebLast,
         const Track& track)
-        : WFindOnWebMenu(pFindOnWebMenu, pFindOnWebLast) {
+        : WFindOnWebMenu(pFindOnWebMenu, std::move(pFindOnWebLast)) {
     const QString artist = track.getArtist();
     const QString trackTitle = track.getTitle();
     const QString album = track.getAlbum();

--- a/src/widget/findonwebmenuservices/findonwebmenudiscogs.h
+++ b/src/widget/findonwebmenuservices/findonwebmenudiscogs.h
@@ -4,9 +4,10 @@
 
 class QMenu;
 class Track;
+class FindOnWebLast;
 
 class FindOnWebMenuDiscogs : public WFindOnWebMenu {
     Q_OBJECT
   public:
-    FindOnWebMenuDiscogs(QMenu* pFindOnWebMenu, const Track& track);
+    FindOnWebMenuDiscogs(QMenu* pFindOnWebMenu, FindOnWebLast* pFindOnWebLast, const Track& track);
 };

--- a/src/widget/findonwebmenuservices/findonwebmenudiscogs.h
+++ b/src/widget/findonwebmenuservices/findonwebmenudiscogs.h
@@ -9,5 +9,7 @@ class FindOnWebLast;
 class FindOnWebMenuDiscogs : public WFindOnWebMenu {
     Q_OBJECT
   public:
-    FindOnWebMenuDiscogs(QMenu* pFindOnWebMenu, FindOnWebLast* pFindOnWebLast, const Track& track);
+    FindOnWebMenuDiscogs(const QPointer<QMenu>& pFindOnWebMenu,
+            QPointer<FindOnWebLast> pFindOnWebLast,
+            const Track& track);
 };

--- a/src/widget/findonwebmenuservices/findonwebmenulastfm.cpp
+++ b/src/widget/findonwebmenuservices/findonwebmenulastfm.cpp
@@ -40,12 +40,14 @@ FindOnWebMenuLastfm::FindOnWebMenuLastfm(QMenu* pFindOnWebMenu, const Track& tra
             const QUrl lastfmUrlArtistWithTrackTitle =
                     composeLastfmUrl(kSearchUrlTitle, composeSearchQuery(artist, trackTitle));
             addActionToServiceMenu(
+                    kServiceTitle + QStringLiteral(",Artist,Title"),
                     tr("Artist + Title"),
                     lastfmUrlArtistWithTrackTitle);
         }
 
         const QUrl lastfmUrlArtist = composeLastfmUrl(kSearchUrlArtist, artist);
         addActionToServiceMenu(
+                kServiceTitle + QStringLiteral(",Artist"),
                 tr("Artist"),
                 lastfmUrlArtist);
     }
@@ -53,12 +55,15 @@ FindOnWebMenuLastfm::FindOnWebMenuLastfm(QMenu* pFindOnWebMenu, const Track& tra
     if (!album.isEmpty()) {
         const QUrl lastfmUrlAlbum = composeLastfmUrl(kSearchUrlAlbum, album);
         addActionToServiceMenu(
+                kServiceTitle + QStringLiteral(",Album"),
                 tr("Album"),
                 lastfmUrlAlbum);
     }
     if (!trackTitle.isEmpty()) {
         const QUrl lastfmUrlTrackTitle = composeLastfmUrl(kSearchUrlTitle, trackTitle);
         addActionToServiceMenu(
-                tr("Title"), lastfmUrlTrackTitle);
+                kServiceTitle + QStringLiteral(",Title"),
+                tr("Title"),
+                lastfmUrlTrackTitle);
     }
 }

--- a/src/widget/findonwebmenuservices/findonwebmenulastfm.cpp
+++ b/src/widget/findonwebmenuservices/findonwebmenulastfm.cpp
@@ -46,25 +46,16 @@ FindOnWebMenuLastfm::FindOnWebMenuLastfm(QMenu* pFindOnWebMenu, const Track& tra
                     lastfmUrlArtistWithTrackTitle);
         }
 
-        if (!album.isEmpty()) {
-            const QString artistWithAlbum = composeSearchQuery(artist, album);
-            const QUrl lastfmUrlArtistWithAlbum =
-                    composeLastfmUrl(kSearchUrlAlbum, artistWithAlbum);
-            addActionToServiceMenu(
-                    composeActionText(tr("Artist + Album"), artistWithAlbum),
-                    lastfmUrlArtistWithAlbum);
-        }
-
         const QUrl lastfmUrlArtist = composeLastfmUrl(kSearchUrlArtist, artist);
         addActionToServiceMenu(
                 composeActionText(tr("Artist"), artist),
                 lastfmUrlArtist);
     }
 
-    if (!album.isEmpty() && artist.isEmpty()) {
+    if (!album.isEmpty()) {
         const QUrl lastfmUrlAlbum = composeLastfmUrl(kSearchUrlAlbum, album);
         addActionToServiceMenu(
-                composeActionText(tr("Album"), album),
+                tr("Album"),
                 lastfmUrlAlbum);
     }
     if (!trackTitle.isEmpty()) {

--- a/src/widget/findonwebmenuservices/findonwebmenulastfm.cpp
+++ b/src/widget/findonwebmenuservices/findonwebmenulastfm.cpp
@@ -6,6 +6,7 @@
 #include "moc_findonwebmenulastfm.cpp"
 #include "track/track.h"
 #include "util/parented_ptr.h"
+#include "widget/findonweblast.h"
 
 namespace {
 const QString kServiceTitle = QStringLiteral("LastFm");
@@ -27,10 +28,10 @@ const QUrl composeLastfmUrl(const QString& serviceSearchUrl,
 
 } //namespace
 
-FindOnWebMenuLastfm::FindOnWebMenuLastfm(QMenu* pFindOnWebMenu,
-        FindOnWebLast* pFindOnWebLast,
+FindOnWebMenuLastfm::FindOnWebMenuLastfm(const QPointer<QMenu>& pFindOnWebMenu,
+        QPointer<FindOnWebLast> pFindOnWebLast,
         const Track& track)
-        : WFindOnWebMenu(pFindOnWebMenu, pFindOnWebLast) {
+        : WFindOnWebMenu(pFindOnWebMenu, std::move(pFindOnWebLast)) {
     const QString artist = track.getArtist();
     const QString trackTitle = track.getTitle();
     const QString album = track.getAlbum();

--- a/src/widget/findonwebmenuservices/findonwebmenulastfm.cpp
+++ b/src/widget/findonwebmenuservices/findonwebmenulastfm.cpp
@@ -36,12 +36,6 @@ FindOnWebMenuLastfm::FindOnWebMenuLastfm(QMenu* pFindOnWebMenu, const Track& tra
     pFindOnWebMenu->addMenu(this);
     addSeparator();
     if (!artist.isEmpty()) {
-        const QUrl lastfmUrlArtist = composeLastfmUrl(kSearchUrlArtist, artist);
-        addActionToServiceMenu(
-                composeActionText(tr("Artist"), artist),
-                lastfmUrlArtist);
-    }
-    if (!trackTitle.isEmpty()) {
         if (!artist.isEmpty()) {
             const QString artistWithTrackTitle = composeSearchQuery(artist, trackTitle);
             const QUrl lastfmUrlArtistWithTrackTitle =
@@ -51,24 +45,32 @@ FindOnWebMenuLastfm::FindOnWebMenuLastfm(QMenu* pFindOnWebMenu, const Track& tra
                             tr("Artist + Title"), artistWithTrackTitle),
                     lastfmUrlArtistWithTrackTitle);
         }
-        const QUrl lastfmUrlTrackTitle = composeLastfmUrl(kSearchUrlTitle, trackTitle);
-        addActionToServiceMenu(
-                composeActionText(tr("Title"), trackTitle),
-                lastfmUrlTrackTitle);
-    }
-    if (!album.isEmpty()) {
-        if (!artist.isEmpty()) {
+
+        if (!album.isEmpty()) {
             const QString artistWithAlbum = composeSearchQuery(artist, album);
             const QUrl lastfmUrlArtistWithAlbum =
                     composeLastfmUrl(kSearchUrlAlbum, artistWithAlbum);
             addActionToServiceMenu(
                     composeActionText(tr("Artist + Album"), artistWithAlbum),
                     lastfmUrlArtistWithAlbum);
-        } else {
-            const QUrl lastfmUrlAlbum = composeLastfmUrl(kSearchUrlAlbum, album);
-            addActionToServiceMenu(
-                    composeActionText(tr("Album"), album),
-                    lastfmUrlAlbum);
         }
+
+        const QUrl lastfmUrlArtist = composeLastfmUrl(kSearchUrlArtist, artist);
+        addActionToServiceMenu(
+                composeActionText(tr("Artist"), artist),
+                lastfmUrlArtist);
+    }
+
+    if (!album.isEmpty() && artist.isEmpty()) {
+        const QUrl lastfmUrlAlbum = composeLastfmUrl(kSearchUrlAlbum, album);
+        addActionToServiceMenu(
+                composeActionText(tr("Album"), album),
+                lastfmUrlAlbum);
+    }
+    if (!trackTitle.isEmpty()) {
+        const QUrl lastfmUrlTrackTitle = composeLastfmUrl(kSearchUrlTitle, trackTitle);
+        addActionToServiceMenu(
+                composeActionText(tr("Title"), trackTitle),
+                lastfmUrlTrackTitle);
     }
 }

--- a/src/widget/findonwebmenuservices/findonwebmenulastfm.cpp
+++ b/src/widget/findonwebmenuservices/findonwebmenulastfm.cpp
@@ -27,8 +27,10 @@ const QUrl composeLastfmUrl(const QString& serviceSearchUrl,
 
 } //namespace
 
-FindOnWebMenuLastfm::FindOnWebMenuLastfm(QMenu* pFindOnWebMenu, const Track& track)
-        : WFindOnWebMenu(pFindOnWebMenu) {
+FindOnWebMenuLastfm::FindOnWebMenuLastfm(QMenu* pFindOnWebMenu,
+        FindOnWebLast* pFindOnWebLast,
+        const Track& track)
+        : WFindOnWebMenu(pFindOnWebMenu, pFindOnWebLast) {
     const QString artist = track.getArtist();
     const QString trackTitle = track.getTitle();
     const QString album = track.getAlbum();

--- a/src/widget/findonwebmenuservices/findonwebmenulastfm.cpp
+++ b/src/widget/findonwebmenuservices/findonwebmenulastfm.cpp
@@ -37,18 +37,16 @@ FindOnWebMenuLastfm::FindOnWebMenuLastfm(QMenu* pFindOnWebMenu, const Track& tra
     addSeparator();
     if (!artist.isEmpty()) {
         if (!artist.isEmpty()) {
-            const QString artistWithTrackTitle = composeSearchQuery(artist, trackTitle);
             const QUrl lastfmUrlArtistWithTrackTitle =
-                    composeLastfmUrl(kSearchUrlTitle, artistWithTrackTitle);
+                    composeLastfmUrl(kSearchUrlTitle, composeSearchQuery(artist, trackTitle));
             addActionToServiceMenu(
-                    composeActionText(
-                            tr("Artist + Title"), artistWithTrackTitle),
+                    tr("Artist + Title"),
                     lastfmUrlArtistWithTrackTitle);
         }
 
         const QUrl lastfmUrlArtist = composeLastfmUrl(kSearchUrlArtist, artist);
         addActionToServiceMenu(
-                composeActionText(tr("Artist"), artist),
+                tr("Artist"),
                 lastfmUrlArtist);
     }
 
@@ -61,7 +59,6 @@ FindOnWebMenuLastfm::FindOnWebMenuLastfm(QMenu* pFindOnWebMenu, const Track& tra
     if (!trackTitle.isEmpty()) {
         const QUrl lastfmUrlTrackTitle = composeLastfmUrl(kSearchUrlTitle, trackTitle);
         addActionToServiceMenu(
-                composeActionText(tr("Title"), trackTitle),
-                lastfmUrlTrackTitle);
+                tr("Title"), lastfmUrlTrackTitle);
     }
 }

--- a/src/widget/findonwebmenuservices/findonwebmenulastfm.h
+++ b/src/widget/findonwebmenuservices/findonwebmenulastfm.h
@@ -9,5 +9,7 @@ class FindOnWebLast;
 class FindOnWebMenuLastfm : public WFindOnWebMenu {
     Q_OBJECT
   public:
-    FindOnWebMenuLastfm(QMenu* pFindOnWebMenu, FindOnWebLast* pFindOnWebLast, const Track& track);
+    FindOnWebMenuLastfm(const QPointer<QMenu>& pFindOnWebMenu,
+            QPointer<FindOnWebLast> pFindOnWebLast,
+            const Track& track);
 };

--- a/src/widget/findonwebmenuservices/findonwebmenulastfm.h
+++ b/src/widget/findonwebmenuservices/findonwebmenulastfm.h
@@ -4,9 +4,10 @@
 
 class QMenu;
 class Track;
+class FindOnWebLast;
 
 class FindOnWebMenuLastfm : public WFindOnWebMenu {
     Q_OBJECT
   public:
-    FindOnWebMenuLastfm(QMenu* pFindOnWebMenu, const Track& track);
+    FindOnWebMenuLastfm(QMenu* pFindOnWebMenu, FindOnWebLast* pFindOnWebLast, const Track& track);
 };

--- a/src/widget/findonwebmenuservices/findonwebmenusoundcloud.cpp
+++ b/src/widget/findonwebmenuservices/findonwebmenusoundcloud.cpp
@@ -27,8 +27,8 @@ const QUrl composeSoundcloudUrl(const QString& serviceSearchUrl,
 } // namespace
 
 FindOnWebMenuSoundcloud::FindOnWebMenuSoundcloud(
-        QMenu* pFindOnWebMenu, const Track& track)
-        : WFindOnWebMenu(pFindOnWebMenu) {
+        QMenu* pFindOnWebMenu, FindOnWebLast* pFindOnWebLast, const Track& track)
+        : WFindOnWebMenu(pFindOnWebMenu, pFindOnWebLast) {
     const QString artist = track.getArtist();
     const QString trackTitle = track.getTitle();
     const QString album = track.getAlbum();

--- a/src/widget/findonwebmenuservices/findonwebmenusoundcloud.cpp
+++ b/src/widget/findonwebmenuservices/findonwebmenusoundcloud.cpp
@@ -6,6 +6,7 @@
 #include "moc_findonwebmenusoundcloud.cpp"
 #include "track/track.h"
 #include "util/parented_ptr.h"
+#include "widget/findonweblast.h"
 
 namespace {
 const QString kServiceTitle = QStringLiteral("Soundcloud");
@@ -27,8 +28,10 @@ const QUrl composeSoundcloudUrl(const QString& serviceSearchUrl,
 } // namespace
 
 FindOnWebMenuSoundcloud::FindOnWebMenuSoundcloud(
-        QMenu* pFindOnWebMenu, FindOnWebLast* pFindOnWebLast, const Track& track)
-        : WFindOnWebMenu(pFindOnWebMenu, pFindOnWebLast) {
+        const QPointer<QMenu>& pFindOnWebMenu,
+        QPointer<FindOnWebLast> pFindOnWebLast,
+        const Track& track)
+        : WFindOnWebMenu(pFindOnWebMenu, std::move(pFindOnWebLast)) {
     const QString artist = track.getArtist();
     const QString trackTitle = track.getTitle();
     const QString album = track.getAlbum();

--- a/src/widget/findonwebmenuservices/findonwebmenusoundcloud.cpp
+++ b/src/widget/findonwebmenuservices/findonwebmenusoundcloud.cpp
@@ -37,37 +37,31 @@ FindOnWebMenuSoundcloud::FindOnWebMenuSoundcloud(
     addSeparator();
     if (!artist.isEmpty()) {
         if (!trackTitle.isEmpty()) {
-            const QString artistWithTrackTitle = composeSearchQuery(artist, trackTitle);
             const QUrl SoundcloudUrlArtistWithTrackTitle =
-                    composeSoundcloudUrl(kSearchUrlTitle, artistWithTrackTitle);
+                    composeSoundcloudUrl(kSearchUrlTitle, composeSearchQuery(artist, trackTitle));
             addActionToServiceMenu(
-                    composeActionText(
-                            tr("Artist + Title"), artistWithTrackTitle),
+                    tr("Artist + Title"),
                     SoundcloudUrlArtistWithTrackTitle);
         }
         if (!album.isEmpty()) {
-            const QString artistWithAlbum = composeSearchQuery(artist, album);
             const QUrl SoundcloudUrlArtistWithAlbum =
-                    composeSoundcloudUrl(kSearchUrlAlbum, artistWithAlbum);
+                    composeSoundcloudUrl(kSearchUrlAlbum, composeSearchQuery(artist, album));
             addActionToServiceMenu(
-                    composeActionText(tr("Artist + Album"), artistWithAlbum),
+                    tr("Artist + Album"),
                     SoundcloudUrlArtistWithAlbum);
         }
         const QUrl SoundcloudUrlArtist = composeSoundcloudUrl(kSearchUrlArtist, artist);
         addActionToServiceMenu(
-                composeActionText(tr("Artist"), artist),
-                SoundcloudUrlArtist);
+                tr("Artist"), SoundcloudUrlArtist);
     }
     if (!album.isEmpty() && artist.isEmpty()) {
         const QUrl SoundcloudUrlAlbum = composeSoundcloudUrl(kSearchUrlAlbum, album);
         addActionToServiceMenu(
-                composeActionText(tr("Album"), album),
-                SoundcloudUrlAlbum);
+                tr("Album"), SoundcloudUrlAlbum);
     }
     if (!trackTitle.isEmpty()) {
         const QUrl SoundcloudUrlTrackTitle = composeSoundcloudUrl(kSearchUrlTitle, trackTitle);
         addActionToServiceMenu(
-                composeActionText(tr("Title"), trackTitle),
-                SoundcloudUrlTrackTitle);
+                tr("Title"), SoundcloudUrlTrackTitle);
     }
 }

--- a/src/widget/findonwebmenuservices/findonwebmenusoundcloud.cpp
+++ b/src/widget/findonwebmenuservices/findonwebmenusoundcloud.cpp
@@ -40,6 +40,7 @@ FindOnWebMenuSoundcloud::FindOnWebMenuSoundcloud(
             const QUrl SoundcloudUrlArtistWithTrackTitle =
                     composeSoundcloudUrl(kSearchUrlTitle, composeSearchQuery(artist, trackTitle));
             addActionToServiceMenu(
+                    kServiceTitle + QStringLiteral(",Artist,Title"),
                     tr("Artist + Title"),
                     SoundcloudUrlArtistWithTrackTitle);
         }
@@ -47,21 +48,28 @@ FindOnWebMenuSoundcloud::FindOnWebMenuSoundcloud(
             const QUrl SoundcloudUrlArtistWithAlbum =
                     composeSoundcloudUrl(kSearchUrlAlbum, composeSearchQuery(artist, album));
             addActionToServiceMenu(
+                    kServiceTitle + QStringLiteral(",Artist,Album"),
                     tr("Artist + Album"),
                     SoundcloudUrlArtistWithAlbum);
         }
         const QUrl SoundcloudUrlArtist = composeSoundcloudUrl(kSearchUrlArtist, artist);
         addActionToServiceMenu(
-                tr("Artist"), SoundcloudUrlArtist);
+                kServiceTitle + QStringLiteral(",Artist"),
+                tr("Artist"),
+                SoundcloudUrlArtist);
     }
     if (!album.isEmpty() && artist.isEmpty()) {
         const QUrl SoundcloudUrlAlbum = composeSoundcloudUrl(kSearchUrlAlbum, album);
         addActionToServiceMenu(
-                tr("Album"), SoundcloudUrlAlbum);
+                kServiceTitle + QStringLiteral(",Artist,Album"),
+                tr("Album"),
+                SoundcloudUrlAlbum);
     }
     if (!trackTitle.isEmpty()) {
         const QUrl SoundcloudUrlTrackTitle = composeSoundcloudUrl(kSearchUrlTitle, trackTitle);
         addActionToServiceMenu(
-                tr("Title"), SoundcloudUrlTrackTitle);
+                kServiceTitle + QStringLiteral(",Title"),
+                tr("Title"),
+                SoundcloudUrlTrackTitle);
     }
 }

--- a/src/widget/findonwebmenuservices/findonwebmenusoundcloud.cpp
+++ b/src/widget/findonwebmenuservices/findonwebmenusoundcloud.cpp
@@ -36,13 +36,7 @@ FindOnWebMenuSoundcloud::FindOnWebMenuSoundcloud(
     pFindOnWebMenu->addMenu(this);
     addSeparator();
     if (!artist.isEmpty()) {
-        const QUrl SoundcloudUrlArtist = composeSoundcloudUrl(kSearchUrlArtist, artist);
-        addActionToServiceMenu(
-                composeActionText(tr("Artist"), artist),
-                SoundcloudUrlArtist);
-    }
-    if (!trackTitle.isEmpty()) {
-        if (!artist.isEmpty()) {
+        if (!trackTitle.isEmpty()) {
             const QString artistWithTrackTitle = composeSearchQuery(artist, trackTitle);
             const QUrl SoundcloudUrlArtistWithTrackTitle =
                     composeSoundcloudUrl(kSearchUrlTitle, artistWithTrackTitle);
@@ -51,24 +45,29 @@ FindOnWebMenuSoundcloud::FindOnWebMenuSoundcloud(
                             tr("Artist + Title"), artistWithTrackTitle),
                     SoundcloudUrlArtistWithTrackTitle);
         }
-        const QUrl SoundcloudUrlTrackTitle = composeSoundcloudUrl(kSearchUrlTitle, trackTitle);
-        addActionToServiceMenu(
-                composeActionText(tr("Title"), trackTitle),
-                SoundcloudUrlTrackTitle);
-    }
-    if (!album.isEmpty()) {
-        if (!artist.isEmpty()) {
+        if (!album.isEmpty()) {
             const QString artistWithAlbum = composeSearchQuery(artist, album);
             const QUrl SoundcloudUrlArtistWithAlbum =
                     composeSoundcloudUrl(kSearchUrlAlbum, artistWithAlbum);
             addActionToServiceMenu(
                     composeActionText(tr("Artist + Album"), artistWithAlbum),
                     SoundcloudUrlArtistWithAlbum);
-        } else {
-            const QUrl SoundcloudUrlAlbum = composeSoundcloudUrl(kSearchUrlAlbum, album);
-            addActionToServiceMenu(
-                    composeActionText(tr("Album"), album),
-                    SoundcloudUrlAlbum);
         }
+        const QUrl SoundcloudUrlArtist = composeSoundcloudUrl(kSearchUrlArtist, artist);
+        addActionToServiceMenu(
+                composeActionText(tr("Artist"), artist),
+                SoundcloudUrlArtist);
+    }
+    if (!album.isEmpty() && artist.isEmpty()) {
+        const QUrl SoundcloudUrlAlbum = composeSoundcloudUrl(kSearchUrlAlbum, album);
+        addActionToServiceMenu(
+                composeActionText(tr("Album"), album),
+                SoundcloudUrlAlbum);
+    }
+    if (!trackTitle.isEmpty()) {
+        const QUrl SoundcloudUrlTrackTitle = composeSoundcloudUrl(kSearchUrlTitle, trackTitle);
+        addActionToServiceMenu(
+                composeActionText(tr("Title"), trackTitle),
+                SoundcloudUrlTrackTitle);
     }
 }

--- a/src/widget/findonwebmenuservices/findonwebmenusoundcloud.h
+++ b/src/widget/findonwebmenuservices/findonwebmenusoundcloud.h
@@ -8,7 +8,7 @@ class FindOnWebLast;
 class FindOnWebMenuSoundcloud : public WFindOnWebMenu {
     Q_OBJECT
   public:
-    FindOnWebMenuSoundcloud(QMenu* pFindOnWebMenu,
-            FindOnWebLast* pFindOnWebLast,
+    FindOnWebMenuSoundcloud(const QPointer<QMenu>& pFindOnWebMenu,
+            QPointer<FindOnWebLast> pFindOnWebLast,
             const Track& track);
 };

--- a/src/widget/findonwebmenuservices/findonwebmenusoundcloud.h
+++ b/src/widget/findonwebmenuservices/findonwebmenusoundcloud.h
@@ -3,9 +3,12 @@
 #include "widget/wfindonwebmenu.h"
 
 class Track;
+class FindOnWebLast;
 
 class FindOnWebMenuSoundcloud : public WFindOnWebMenu {
     Q_OBJECT
   public:
-    FindOnWebMenuSoundcloud(QMenu* pFindOnWebMenu, const Track& track);
+    FindOnWebMenuSoundcloud(QMenu* pFindOnWebMenu,
+            FindOnWebLast* pFindOnWebLast,
+            const Track& track);
 };

--- a/src/widget/wcoverartmenu.cpp
+++ b/src/widget/wcoverartmenu.cpp
@@ -20,8 +20,7 @@ WCoverArtMenu::~WCoverArtMenu() {
 }
 
 void WCoverArtMenu::createActions() {
-    m_pChange = new QAction(tr("Choose new cover",
-            "change cover art location"), this);
+    m_pChange = new QAction(tr("Choose file", "change cover art location"), this);
     connect(m_pChange, &QAction::triggered, this, &WCoverArtMenu::slotChange);
     addAction(m_pChange);
 

--- a/src/widget/wfindonwebmenu.cpp
+++ b/src/widget/wfindonwebmenu.cpp
@@ -26,10 +26,6 @@ void WFindOnWebMenu::addActionToServiceMenu(
             });
 }
 
-QString WFindOnWebMenu::composeActionText(const QString& prefix, const QString& trackProperty) {
-    return prefix + QStringLiteral(" | ") + trackProperty;
-}
-
 QString WFindOnWebMenu::composeSearchQuery(
         const QString& artist, const QString& trackAlbumOrTitle) {
     return artist + QStringLiteral(" ") + trackAlbumOrTitle;

--- a/src/widget/wfindonwebmenu.cpp
+++ b/src/widget/wfindonwebmenu.cpp
@@ -8,7 +8,7 @@
 #include "util/desktophelper.h"
 
 WFindOnWebMenu::WFindOnWebMenu(QWidget* parent)
-        : QMenu(tr("Find on Web"), parent) {
+        : QMenu(parent) {
 }
 
 bool WFindOnWebMenu::hasEntriesForTrack(const Track& track) {

--- a/src/widget/wfindonwebmenu.cpp
+++ b/src/widget/wfindonwebmenu.cpp
@@ -6,9 +6,11 @@
 #include "moc_wfindonwebmenu.cpp"
 #include "track/track.h"
 #include "util/desktophelper.h"
+#include "widget/findonweblast.h"
 
-WFindOnWebMenu::WFindOnWebMenu(QWidget* parent)
-        : QMenu(parent) {
+WFindOnWebMenu::WFindOnWebMenu(QWidget* parent, FindOnWebLast* pFindOnWebLast)
+        : QMenu(parent),
+          m_pFindOnWebLast(pFindOnWebLast) {
 }
 
 bool WFindOnWebMenu::hasEntriesForTrack(const Track& track) {
@@ -23,9 +25,11 @@ void WFindOnWebMenu::addActionToServiceMenu(
         const QUrl& serviceUrl) {
     addAction(actionText,
             this,
-            [this, serviceUrl] {
+            [this, actionId, actionText, serviceUrl] {
                 openInBrowser(serviceUrl);
+                m_pFindOnWebLast->update(actionId, actionText, serviceUrl);
             });
+    m_pFindOnWebLast->init(actionId, actionText, serviceUrl);
 }
 
 QString WFindOnWebMenu::composeSearchQuery(

--- a/src/widget/wfindonwebmenu.cpp
+++ b/src/widget/wfindonwebmenu.cpp
@@ -8,9 +8,10 @@
 #include "util/desktophelper.h"
 #include "widget/findonweblast.h"
 
-WFindOnWebMenu::WFindOnWebMenu(QWidget* parent, FindOnWebLast* pFindOnWebLast)
-        : QMenu(parent),
-          m_pFindOnWebLast(pFindOnWebLast) {
+WFindOnWebMenu::WFindOnWebMenu(
+        const QPointer<QMenu>& pParent, QPointer<FindOnWebLast> pFindOnWebLast)
+        : QMenu(pParent),
+          m_pFindOnWebLast(std::move(pFindOnWebLast)) {
 }
 
 bool WFindOnWebMenu::hasEntriesForTrack(const Track& track) {

--- a/src/widget/wfindonwebmenu.cpp
+++ b/src/widget/wfindonwebmenu.cpp
@@ -18,7 +18,9 @@ bool WFindOnWebMenu::hasEntriesForTrack(const Track& track) {
 }
 
 void WFindOnWebMenu::addActionToServiceMenu(
-        const QString& actionText, const QUrl& serviceUrl) {
+        const QString& actionId,
+        const QString& actionText,
+        const QUrl& serviceUrl) {
     addAction(actionText,
             this,
             [this, serviceUrl] {

--- a/src/widget/wfindonwebmenu.h
+++ b/src/widget/wfindonwebmenu.h
@@ -7,8 +7,7 @@ class Track;
 class WFindOnWebMenu : public QMenu {
     Q_OBJECT
   public:
-    explicit WFindOnWebMenu(
-            QWidget* parent = nullptr);
+    explicit WFindOnWebMenu(QWidget* pParent);
     ~WFindOnWebMenu() override = default;
 
     void addActionToServiceMenu(
@@ -18,9 +17,6 @@ class WFindOnWebMenu : public QMenu {
     static bool hasEntriesForTrack(const Track& track);
 
   protected:
-    QString composeActionText(const QString& prefix, const QString& trackProperty);
-
     QString composeSearchQuery(const QString& artist, const QString& trackAlbumOrTitle);
-
     void openInBrowser(const QUrl& url);
 };

--- a/src/widget/wfindonwebmenu.h
+++ b/src/widget/wfindonwebmenu.h
@@ -11,6 +11,7 @@ class WFindOnWebMenu : public QMenu {
     ~WFindOnWebMenu() override = default;
 
     void addActionToServiceMenu(
+            const QString& actionId,
             const QString& actionText,
             const QUrl& serviceUrl);
 

--- a/src/widget/wfindonwebmenu.h
+++ b/src/widget/wfindonwebmenu.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QMenu>
+#include <QPointer>
 
 class Track;
 class FindOnWebLast;
@@ -8,7 +9,7 @@ class FindOnWebLast;
 class WFindOnWebMenu : public QMenu {
     Q_OBJECT
   public:
-    explicit WFindOnWebMenu(QWidget* pParent, FindOnWebLast* pFindOnWebLast);
+    explicit WFindOnWebMenu(const QPointer<QMenu>& pParent, QPointer<FindOnWebLast> pFindOnWebLast);
     ~WFindOnWebMenu() override = default;
 
     void addActionToServiceMenu(
@@ -23,5 +24,5 @@ class WFindOnWebMenu : public QMenu {
     void openInBrowser(const QUrl& url);
 
   private:
-    FindOnWebLast* m_pFindOnWebLast;
+    const QPointer<FindOnWebLast> m_pFindOnWebLast;
 };

--- a/src/widget/wfindonwebmenu.h
+++ b/src/widget/wfindonwebmenu.h
@@ -3,11 +3,12 @@
 #include <QMenu>
 
 class Track;
+class FindOnWebLast;
 
 class WFindOnWebMenu : public QMenu {
     Q_OBJECT
   public:
-    explicit WFindOnWebMenu(QWidget* pParent);
+    explicit WFindOnWebMenu(QWidget* pParent, FindOnWebLast* pFindOnWebLast);
     ~WFindOnWebMenu() override = default;
 
     void addActionToServiceMenu(
@@ -20,4 +21,7 @@ class WFindOnWebMenu : public QMenu {
   protected:
     QString composeSearchQuery(const QString& artist, const QString& trackAlbumOrTitle);
     void openInBrowser(const QUrl& url);
+
+  private:
+    FindOnWebLast* m_pFindOnWebLast;
 };

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -1234,8 +1234,8 @@ void WTrackMenu::updateMenus() {
         const bool enableMenu = pTrack ? WFindOnWebMenu::hasEntriesForTrack(*pTrack) : false;
         if (enableMenu) {
             mixxx::library::createFindOnWebSubmenus(
-                    m_pFindOnWebMenu,
-                    m_pFindOnWebLastAct,
+                    m_pFindOnWebMenu.toWeakRef(),
+                    m_pFindOnWebLastAct.toWeakRef(),
                     *pTrack);
         }
         m_pFindOnWebMenu->setEnabled(!m_pFindOnWebMenu->isEmpty());

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -681,8 +681,10 @@ void WTrackMenu::setupActions() {
 
     if (featureIsEnabled(Feature::Metadata)) {
         m_pMetadataMenu->addAction(m_pImportMetadataFromFileAct);
-        m_pMetadataMenu->addAction(m_pImportMetadataFromMusicBrainzAct);
         m_pMetadataMenu->addAction(m_pExportMetadataAct);
+        m_pMetadataMenu->addMenu(m_pCoverMenu);
+
+        m_pMetadataMenu->addAction(m_pImportMetadataFromMusicBrainzAct);
 
         for (const auto& updateInExternalTrackCollection :
                 std::as_const(m_updateInExternalTrackCollections)) {
@@ -707,7 +709,6 @@ void WTrackMenu::setupActions() {
                     });
         }
 
-        m_pMetadataMenu->addMenu(m_pCoverMenu);
         if (featureIsEnabled(Feature::FindOnWeb)) {
             m_pMetadataMenu->addMenu(m_pFindOnWebMenu);
         }
@@ -1115,7 +1116,6 @@ void WTrackMenu::updateMenus() {
         // We use the last selected track for the cover art context to be
         // consistent with selectionChanged above.
         m_pCoverMenu->setCoverArt(getCoverInfoOfLastTrack());
-        m_pMetadataMenu->addMenu(m_pCoverMenu);
     }
 
     if (featureIsEnabled(Feature::Analyze)) {

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -268,7 +268,7 @@ void WTrackMenu::createMenus() {
 
     if (featureIsEnabled(Feature::FindOnWeb)) {
         DEBUG_ASSERT(!m_pFindOnWebMenu);
-        m_pFindOnWebMenu = make_parented<WFindOnWebMenu>(this);
+        m_pFindOnWebMenu = make_parented<QMenu>(tr("Find on Web"), this);
         connect(m_pFindOnWebMenu,
                 &QMenu::aboutToShow,
                 this,

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -269,20 +269,6 @@ void WTrackMenu::createMenus() {
     if (featureIsEnabled(Feature::FindOnWeb)) {
         DEBUG_ASSERT(!m_pFindOnWebMenu);
         m_pFindOnWebMenu = make_parented<QMenu>(tr("Find on Web"), this);
-        connect(m_pFindOnWebMenu,
-                &QMenu::aboutToShow,
-                this,
-                [this] {
-                    m_pFindOnWebMenu->clear();
-                    const auto pTrack = getFirstTrackPointer();
-                    if (pTrack) {
-                        mixxx::library::createFindOnWebSubmenus(
-                                m_pFindOnWebMenu,
-                                *pTrack);
-                    }
-                    m_pFindOnWebMenu->setEnabled(
-                            !m_pFindOnWebMenu->isEmpty());
-                });
     }
 
     if (featureIsEnabled(Feature::RemoveFromDisk)) {
@@ -1238,8 +1224,15 @@ void WTrackMenu::updateMenus() {
     }
 
     if (featureIsEnabled(Feature::FindOnWeb)) {
+        // We have a new Track
+        m_pFindOnWebMenu->clear();
         const auto pTrack = getFirstTrackPointer();
         const bool enableMenu = pTrack ? WFindOnWebMenu::hasEntriesForTrack(*pTrack) : false;
+        if (enableMenu) {
+            mixxx::library::createFindOnWebSubmenus(
+                    m_pFindOnWebMenu,
+                    *pTrack);
+        }
         m_pFindOnWebMenu->setEnabled(enableMenu);
     }
 }

--- a/src/widget/wtrackmenu.cpp
+++ b/src/widget/wtrackmenu.cpp
@@ -41,6 +41,7 @@
 #include "util/parented_ptr.h"
 #include "util/qt.h"
 #include "util/widgethelper.h"
+#include "widget/findonweblast.h"
 #include "widget/findonwebmenufactory.h"
 #include "widget/wcolorpickeraction.h"
 #include "widget/wcoverartlabel.h"
@@ -269,6 +270,7 @@ void WTrackMenu::createMenus() {
     if (featureIsEnabled(Feature::FindOnWeb)) {
         DEBUG_ASSERT(!m_pFindOnWebMenu);
         m_pFindOnWebMenu = make_parented<QMenu>(tr("Find on Web"), this);
+        m_pFindOnWebLastAct = make_parented<FindOnWebLast>(this, m_pConfig);
     }
 
     if (featureIsEnabled(Feature::RemoveFromDisk)) {
@@ -696,6 +698,7 @@ void WTrackMenu::setupActions() {
         }
 
         if (featureIsEnabled(Feature::FindOnWeb)) {
+            m_pMetadataMenu->addAction(m_pFindOnWebLastAct);
             m_pMetadataMenu->addMenu(m_pFindOnWebMenu);
         }
 
@@ -1226,14 +1229,16 @@ void WTrackMenu::updateMenus() {
     if (featureIsEnabled(Feature::FindOnWeb)) {
         // We have a new Track
         m_pFindOnWebMenu->clear();
+        m_pFindOnWebLastAct->setVisible(false);
         const auto pTrack = getFirstTrackPointer();
         const bool enableMenu = pTrack ? WFindOnWebMenu::hasEntriesForTrack(*pTrack) : false;
         if (enableMenu) {
             mixxx::library::createFindOnWebSubmenus(
                     m_pFindOnWebMenu,
+                    m_pFindOnWebLastAct,
                     *pTrack);
         }
-        m_pFindOnWebMenu->setEnabled(enableMenu);
+        m_pFindOnWebMenu->setEnabled(!m_pFindOnWebMenu->isEmpty());
     }
 }
 

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -22,6 +22,7 @@ class DlgTrackInfo;
 class DlgTrackInfoMulti;
 //class DlgDeleteFilesConfirmation;
 class ExternalTrackCollection;
+class FindOnWebLast;
 class Library;
 class TrackModel;
 class WColorPickerAction;
@@ -298,6 +299,7 @@ class WTrackMenu : public QMenu {
     parented_ptr<WCoverArtMenu> m_pCoverMenu;
     parented_ptr<WSearchRelatedTracksMenu> m_pSearchRelatedMenu;
     parented_ptr<QMenu> m_pFindOnWebMenu;
+    parented_ptr<FindOnWebLast> m_pFindOnWebLastAct;
 #if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
     QMenu* m_pRemoveFromDiskMenu{};
 #endif

--- a/src/widget/wtrackmenu.h
+++ b/src/widget/wtrackmenu.h
@@ -297,7 +297,7 @@ class WTrackMenu : public QMenu {
     parented_ptr<QMenu> m_pColorMenu;
     parented_ptr<WCoverArtMenu> m_pCoverMenu;
     parented_ptr<WSearchRelatedTracksMenu> m_pSearchRelatedMenu;
-    parented_ptr<WFindOnWebMenu> m_pFindOnWebMenu;
+    parented_ptr<QMenu> m_pFindOnWebMenu;
 #if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
     QMenu* m_pRemoveFromDiskMenu{};
 #endif


### PR DESCRIPTION
I was annoyed form by the Discogs lookup burried to deep in the track menu. The fix is to ad a "Last used" entry that is two levels above. Now the menu looks like this: 

<img width="747" height="290" alt="image" src="https://github.com/user-attachments/assets/ca918f12-508a-43dd-88d5-f557d91f1ce5" />

I have also removed the literal title and artist form the menu. That feels like clutter when using it. 
I had an intermediate version with a tooltip instead but that was also disturbing.  

What's next: 
All these URL land on a ranked search result page. This requires an unnecessary extra click if there is a full match. Instead of going there we may do an API call and check if we have a full match and than proceed to the result immediately. 

Now that a overpopulated "Find on Web" menu is mitigated, I am also tempted to add Youtube Music and Spotfy to it, because I am using it on regular basis. Is this OK do we want a plug in interface? 

Genius, Shazam and Spotalike are also candidatures. 






