### PR TITLE
(feat) Show hotcue tooltip in library

### DIFF
--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -1288,7 +1288,8 @@ QString BaseTrackTableModel::composeHotCueTooltip(
 
     // Sort hotcues by number
     std::sort(hotcues.begin(), hotcues.end(), [](const CuePointer& a, const CuePointer& b) {
-        return a->getHotCue() < b->getHotCue();
+        // sort by position
+        return a->getPosition() < b->getPosition();
     });
 
     double sampleRate = pTrack->getSampleRate();
@@ -1361,6 +1362,14 @@ QString BaseTrackTableModel::composeHotCueTooltip(
             tooltip += QStringLiteral("<td align=center>\u25B8</td>"); // ▸
         }
 
+        // Add label if present, else add --- placeholder
+        const QString label = pHotcue->getLabel();
+        if (label.isEmpty()) {
+            tooltip += QStringLiteral("<td>---</td>");
+        } else {
+            tooltip += QStringLiteral("<td>%1</td>").arg(label.toHtmlEscaped());
+        }
+
         // Cue position - End is jump position, position is target
         // Show in beats if track has beats
         if (pBeats) {
@@ -1375,15 +1384,6 @@ QString BaseTrackTableModel::composeHotCueTooltip(
                     : pos.value();
             tooltip += QStringLiteral("<td>%1</td>")
                                .arg(posOrLengthToSeconds(position, sampleRate));
-        }
-
-        // Add label if present
-        // FIXME Add empty cell or --- placeholder if label is mepty
-        // in order to keep loop/jump durations aligned?
-        // Or show label in last column?
-        const QString label = pHotcue->getLabel();
-        if (!label.isEmpty()) {
-            tooltip += QStringLiteral("<td>%1</td>").arg(label.toHtmlEscaped());
         }
 
         // Add duration for saved loops/jumps

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -1394,19 +1394,19 @@ QString BaseTrackTableModel::composeHotCueTooltip(
             const auto length = pHotcue->getLengthFrames();
             if (length > 0) {
                 if (pBeats) {
-                    tooltip += QStringLiteral("<td>(%1)</td>")
-                                       .arg(posOrLengthToBeats(pBeats, pos, posEnd));
+                    tooltip += QStringLiteral("<td>[%1]</td>")
+                                       .arg(posOrLengthToBeats(pBeats, posEnd, pos));
                 } else {
-                    tooltip += QStringLiteral("<td>(%1)</td>")
+                    tooltip += QStringLiteral("<td>[%1]</td>")
                                        .arg(posOrLengthToSeconds(length, sampleRate));
                 }
             }
         } else if (type == mixxx::CueType::Jump) { // Jump target
             if (pBeats) {
-                tooltip += QStringLiteral("<td>(%1)</td>")
+                tooltip += QStringLiteral("<td>\u2192 %1</td>")
                                    .arg(posOrLengthToBeats(pBeats, pos));
             } else {
-                tooltip += QStringLiteral("<td>(%1)</td>")
+                tooltip += QStringLiteral("<td>\u2192 %1</td>")
                                    .arg(posOrLengthToSeconds(pos.value(), sampleRate));
             }
         }

--- a/src/library/basetracktablemodel.cpp
+++ b/src/library/basetracktablemodel.cpp
@@ -83,7 +83,9 @@ inline QString posOrLengthToSeconds(double posOrLength, double sampleRate) {
         sampleRate = 44100.0;
     }
     double seconds = posOrLength / sampleRate;
-    return mixxx::Duration::formatTime(seconds, mixxx::Duration::Precision::CENTISECONDS);
+    // We don't need centiseconds precision in the overview, it just adds noise.
+    // Deciseconds are sufficient to distinguish very close hotcues.
+    return mixxx::Duration::formatTime(seconds, mixxx::Duration::Precision::DECISECONDS);
 }
 
 inline int posOrLengthToBeats(

--- a/src/library/basetracktablemodel.h
+++ b/src/library/basetracktablemodel.h
@@ -276,6 +276,8 @@ class BaseTrackTableModel : public QAbstractTableModel, public TrackModel {
     QVariant composeCoverArtToolTipHtml(
             const QModelIndex& index) const;
 
+    QString composeHotCueTooltip(const QModelIndex& index, const QString& columnValue) const;
+
     Qt::ItemFlags defaultItemFlags(
             const QModelIndex& index) const;
 

--- a/src/track/beats.cpp
+++ b/src/track/beats.cpp
@@ -742,6 +742,12 @@ audio::FramePos Beats::snapPosToNearBeat(audio::FramePos position) const {
 
 int Beats::numBeatsInRange(audio::FramePos startPosition, audio::FramePos endPosition) const {
     startPosition = snapPosToNearBeat(startPosition);
+    if (startPosition > endPosition) {
+        // May happen if arguments are in the wrong order.
+        // Also helps with Jumpcues so caller doesn't have to swap
+        // positions in case it's a backward jump.
+        std::swap(startPosition, endPosition);
+    }
     audio::FramePos lastPosition = audio::kStartFramePos;
     int i = 1;
     while (lastPosition < endPosition) {

--- a/src/util/duration.cpp
+++ b/src/util/duration.cpp
@@ -42,7 +42,7 @@ QString DurationBase::formatTime(double dSeconds, Precision precision) {
 
     QString formatString =
             (t.hour() > 0 && days < 1 ? QStringLiteral("hh:mm:ss") : QStringLiteral("mm:ss")) +
-            (Precision::SECONDS == precision ? QString() : QStringLiteral(".zzz"));
+            (precision == Precision::SECONDS ? QString() : QStringLiteral(".zzz"));
 
     QString durationString = t.toString(formatString);
     if (days > 0) {
@@ -55,8 +55,8 @@ QString DurationBase::formatTime(double dSeconds, Precision precision) {
 
     // The format string gives us milliseconds but we want
     // centiseconds. Slice one character off.
-    if (Precision::CENTISECONDS == precision) {
-        DEBUG_ASSERT(1 <= durationString.length());
+    if (precision == Precision::CENTISECONDS) {
+        DEBUG_ASSERT(durationString.length() >= 1);
         durationString = durationString.left(durationString.length() - 1);
     }
 
@@ -72,9 +72,9 @@ QString DurationBase::formatSeconds(double dSeconds, Precision precision) {
 
     QString durationString;
 
-    if (Precision::CENTISECONDS == precision) {
+    if (precision == Precision::CENTISECONDS) {
         durationString = QString::number(dSeconds, 'f', 2);
-    } else if (Precision::MILLISECONDS == precision) {
+    } else if (precision == Precision::MILLISECONDS) {
         durationString = QString::number(dSeconds, 'f', 3);
     } else {
         durationString = QString::number(dSeconds, 'f', 0);
@@ -92,7 +92,7 @@ QString DurationBase::formatSecondsLong(double dSeconds, Precision precision) {
 
     QString durationString;
 
-    if (Precision::CENTISECONDS == precision) {
+    if (precision == Precision::CENTISECONDS) {
         durationString = QString::number(dSeconds, 'f', 2)
             .rightJustified(6, QLatin1Char('0'));
     } else if (Precision::MILLISECONDS == precision) {
@@ -122,14 +122,14 @@ QString DurationBase::formatKiloSeconds(double dSeconds, Precision precision) {
                     QString::number(kilos),
                     QString(kDecimalSeparator),
                     QString::number(seconds).rightJustified(3, QLatin1Char('0')));
-    if (Precision::SECONDS != precision) {
-            durationString += kKiloGroupSeparator % QString::number(subs, 'f', 3).right(3);
+    if (precision != Precision::SECONDS) {
+        durationString += kKiloGroupSeparator % QString::number(subs, 'f', 3).right(3);
     }
 
     // The format string gives us milliseconds but we want
     // centiseconds. Slice one character off.
-    if (Precision::CENTISECONDS == precision) {
-        DEBUG_ASSERT(1 <= durationString.length());
+    if (precision == Precision::CENTISECONDS) {
+        DEBUG_ASSERT(durationString.length() >= 1);
         durationString = durationString.left(durationString.length() - 1);
     }
 

--- a/src/util/duration.cpp
+++ b/src/util/duration.cpp
@@ -58,6 +58,9 @@ QString DurationBase::formatTime(double dSeconds, Precision precision) {
     if (precision == Precision::CENTISECONDS) {
         DEBUG_ASSERT(durationString.length() >= 1);
         durationString = durationString.left(durationString.length() - 1);
+    } else if (precision == Precision::DECISECONDS) {
+        DEBUG_ASSERT(durationString.length() >= 2);
+        durationString = durationString.left(durationString.length() - 2);
     }
 
     return durationString;
@@ -72,7 +75,9 @@ QString DurationBase::formatSeconds(double dSeconds, Precision precision) {
 
     QString durationString;
 
-    if (precision == Precision::CENTISECONDS) {
+    if (precision == Precision::DECISECONDS) {
+        durationString = QString::number(dSeconds, 'f', 1);
+    } else if (precision == Precision::CENTISECONDS) {
         durationString = QString::number(dSeconds, 'f', 2);
     } else if (precision == Precision::MILLISECONDS) {
         durationString = QString::number(dSeconds, 'f', 3);
@@ -92,7 +97,10 @@ QString DurationBase::formatSecondsLong(double dSeconds, Precision precision) {
 
     QString durationString;
 
-    if (precision == Precision::CENTISECONDS) {
+    if (precision == Precision::DECISECONDS) {
+        durationString = QString::number(dSeconds, 'f', 1)
+                                 .rightJustified(6, QLatin1Char('0'));
+    } else if (precision == Precision::CENTISECONDS) {
         durationString = QString::number(dSeconds, 'f', 2)
             .rightJustified(6, QLatin1Char('0'));
     } else if (Precision::MILLISECONDS == precision) {
@@ -131,6 +139,9 @@ QString DurationBase::formatKiloSeconds(double dSeconds, Precision precision) {
     if (precision == Precision::CENTISECONDS) {
         DEBUG_ASSERT(durationString.length() >= 1);
         durationString = durationString.left(durationString.length() - 1);
+    } else if (precision == Precision::DECISECONDS) {
+        DEBUG_ASSERT(durationString.length() >= 2);
+        durationString = durationString.left(durationString.length() - 2);
     }
 
     return durationString;

--- a/src/util/duration.h
+++ b/src/util/duration.h
@@ -65,6 +65,7 @@ class DurationBase {
 
     enum class Precision {
         SECONDS,
+        DECISECONDS,
         CENTISECONDS,
         MILLISECONDS
     };


### PR DESCRIPTION
Continuation of #15471

<img width="305" height="224" alt="Screenshot_2025-10-13_11-39-43" src="https://github.com/user-attachments/assets/118284ce-bdf7-4d01-b49b-cc3ef0604e23" />

Looks good IMO, but I'm not sure about the final column order.
On the one hand it's good to see the type icon ▸ / **↺** / **→** next to the hotcue number, then the position, then label.
Otoh it also makes sense to have the type icon followed by the range, but idk, maybe loop length / jump position are too much for the tooltip.
What do you think?

And my feeling is --if we decide to merge it-- that we should make the hotcue tooltip optional (opt out).
Yes, I understand it's nice helper for some, but others (me included) don't need it and may even be annoyed by it (it is currently installed for most text columns).