### PR TITLE
Support dynamic binding components with midiIn and midiOut

### DIFF
--- a/res/controllers/midi-components-0.0.js
+++ b/res/controllers/midi-components-0.0.js
@@ -27,13 +27,49 @@
  */
 
 (function(global) {
+    /**
+     * @typedef {[number, number] | [[number, number], [number, number]]} MidiBytesVariations
+     *
+     * @typedef {object} ComponentOptions
+     * @property {MidiBytesVariations} [midi] MIDI events
+     * @property {MidiBytesVariations} [midiIn] MIDI events
+     * @property {MidiBytesVariations} [midiOut] MIDI events
+     */
+
     const NO_TIMER = 0;
+
+    /**
+     * @param {ComponentOptions | [number, number]} options Component configuration
+     * @class
+     */
     const Component = function(options) {
-        if (Array.isArray(options) && typeof options[0] === "number") {
-            this.midi = options;
-        } else {
-            Object.assign(this, options);
+        this.normalizeMidi = (midiBytesVar) => {
+            if (!Array.isArray(midiBytesVar)) {
+                return [];
+            }
+
+            const [first, second] = midiBytesVar;
+
+            if (Array.isArray(first) && Array.isArray(second)) { // long form
+                return midiBytesVar;
+            } else {
+                return [midiBytesVar];
+            }
+        };
+
+        if (Array.isArray(options)) {
+            const [midiStatus, midiNo] = options;
+            options = {midiOut: [midiStatus, midiNo]};
+        } else if (Array.isArray(options.midi)) {
+            console.warn("Passing `midi` configuration is deprecated in favor `midiOut`");
+            options.midiOut = options.midi;
+            delete options.midi;
         }
+
+        options.midiIn = this.normalizeMidi(options.midiIn);
+        options.midiOut = this.normalizeMidi(options.midiOut);
+
+        Object.assign(this, options);
 
         if (typeof this.unshift === "function") {
             this.unshift();
@@ -46,6 +82,9 @@
             this.inKey = options.key;
             this.outKey = options.key;
         }
+
+        /** @type {MidiInputHandlerController[]} */
+        this.inputHandlers = [];
 
         if (this.outConnect && this.group !== undefined && this.outKey !== undefined) {
             this.connect();
@@ -77,6 +116,23 @@
         outTrigger: true,
 
         max: 127, // for MIDI. When adapting for HID this may change.
+
+        /**
+         * @deprecated
+         * @returns {[number, number]}
+         */
+        get midi() {
+            console.warn("`midi` property is deprecated, please use `midiOut` instead");
+            return this.midiOut.length > 0 ? this.midiOut[0] : undefined;
+        },
+        /**
+         * @deprecated
+         * @param {MidiBytesVariations} value New midi value
+         */
+        set midi(value) {
+            console.warn("`midi` property is deprecated, please use `midiOut` instead");
+            this.midiOut = this.normalizeMidi(value);
+        },
 
         // common functions
         // In most cases, you should not overwrite these.
@@ -112,13 +168,13 @@
             this.outSetValue(!this.outGetValue());
         },
 
-        connect: function() {
+        connectMidiOut() {
             /**
-            Override this method with a custom one to connect multiple Mixxx COs for a single Component.
-            Add the connection objects to the this.connections array so they all get disconnected just
-            by calling this.disconnect(). This can be helpful for multicolor LEDs that show a
-            different color depending on the state of different Mixxx COs. Refer to
-            SamplerButton.connect() and SamplerButton.output() for an example.
+             Override this method with a custom one to connect multiple Mixxx COs for a single Component.
+             Add the connection objects to the this.connections array so they all get disconnected just
+             by calling this.disconnect(). This can be helpful for multicolor LEDs that show a
+             different color depending on the state of different Mixxx COs. Refer to
+             SamplerButton.connect() and SamplerButton.output() for an example.
              */
             if (undefined !== this.group &&
                 undefined !== this.outKey &&
@@ -127,11 +183,23 @@
                 this.connections[0] = engine.makeConnection(this.group, this.outKey, this.output.bind(this));
             }
         },
+        connectMidiIn() {
+            for (const [midiStatus, midino] of this.midiIn) {
+                this.inputHandlers.push(midi.makeInputHandler(midiStatus, midino, this.input.bind(this)));
+            }
+        },
+        connect: function() {
+            this.connectMidiIn();
+            this.connectMidiOut();
+        },
         disconnect: function() {
             if (this.connections[0] !== undefined) {
                 this.connections.forEach(function(conn) {
                     conn.disconnect();
                 });
+            }
+            for (const inputHandler of this.inputHandlers) {
+                inputHandler.disconnect();
             }
         },
         trigger: function() {
@@ -146,15 +214,18 @@
         shiftChannel: false,
         shiftControl: false,
         send: function(value) {
-            if (this.midi === undefined || this.midi[0] === undefined || this.midi[1] === undefined) {
+            if (this.midiOut.length <= 0) {
                 return;
             }
-            midi.sendShortMsg(this.midi[0], this.midi[1], value);
+            for (const [midiStatus, midino] in this.midiOut) {
+                midi.sendShortMsg(midiStatus, midino, value);
+            }
+
             if (this.sendShifted) {
                 if (this.shiftChannel) {
-                    midi.sendShortMsg(this.midi[0] + this.shiftOffset, this.midi[1], value);
+                    midi.sendShortMsg(this.midiOut[0][0] + this.shiftOffset, this.midiOut[0][1], value);
                 } else if (this.shiftControl) {
-                    midi.sendShortMsg(this.midi[0], this.midi[1] + this.shiftOffset, value);
+                    midi.sendShortMsg(this.midiOut[0][0], this.midiOut[0][1] + this.shiftOffset, value);
                 }
             }
         },
@@ -844,6 +915,17 @@
                 "Please bind jogwheel-related messages to inputWheel and inputTouch!\n";
         },
         reset() {},
+
+        connectMidiIn() {
+            if (this.midiIn.length >= 1) {
+                const [midiStatus, midino] = this.midiIn[0];
+                this.inputHandlers.push(midi.makeInputHandler(midiStatus, midino, this.inputTouch.bind(this)));
+            }
+            if (this.midiIn.length === 2) {
+                const [midiStatus, midino] = this.midiIn[1];
+                this.inputHandlers.push(midi.makeInputHandler(midiStatus, midino, this.inputWheel.bind(this)));
+            }
+        },
     });
 
     const EffectUnit = function(unitNumbers, allowFocusWhenParametersHidden, colors) {
@@ -1266,7 +1348,7 @@
             this.effectFocusButton.trigger();
 
             this.enableOnChannelButtons.forEachComponent(function(button) {
-                if (button.midi !== undefined) {
+                if (button.midiOut !== undefined) {
                     button.disconnect();
                     button.connect();
                     button.trigger();


### PR DESCRIPTION
Based on the https://github.com/mixxxdj/mixxx/pull/15030 PR.
Forked from [christophehenry](https://github.com/christophehenry) and added the changes as discussed in that PR.

Provides the ability to connect midi controls in javascript without the need to define the <control> elements in the .xml file.