### PR TITLE
fix(LateNight): hide stem control if the track has no stems

### DIFF
--- a/res/skins/LateNight/skin_settings.xml
+++ b/res/skins/LateNight/skin_settings.xml
@@ -242,27 +242,49 @@ Description:
                     <SetVariable name="Width">190me</SetVariable>
                   </Template>
 
-                  <!-- Cue shift buttons in beatgrid editing section -->
                   <WidgetGroup>
                     <ObjectName>SkinSettingsCategory</ObjectName>
                     <SizePolicy>me,f</SizePolicy>
-                    <Layout>stacked</Layout>
+                    <Layout>vertical</Layout>
                     <Children>
-                      <!-- translucent cover when waveforms are hidden -->
-                      <Template src="skins:LateNight/helpers/skin_settings_cover_inverted.xml">
-                        <SetVariable name="Setting">[Skin],show_waveforms</SetVariable>
-                      </Template>
 
-                      <!-- translucent cover when beatgrid controls are hidden -->
-                      <Template src="skins:LateNight/helpers/skin_settings_cover_inverted.xml">
-                        <SetVariable name="Setting">[Skin],show_beatgrid_controls</SetVariable>
-                      </Template>
+                      <!-- Cue shift buttons in beatgrid editing section -->
+                      <WidgetGroup>
+                        <Layout>stacked</Layout>
+                        <Size>-1me,18f</Size>
+                        <Children>
+                          <!-- translucent cover when waveforms are hidden -->
+                          <Template src="skins:LateNight/helpers/skin_settings_cover_inverted.xml">
+                            <SetVariable name="Setting">[Skin],show_waveforms</SetVariable>
+                          </Template>
+                          <!-- translucent cover when beatgrid controls are hidden -->
+                          <Template src="skins:LateNight/helpers/skin_settings_cover_inverted.xml">
+                            <SetVariable name="Setting">[Skin],show_beatgrid_controls</SetVariable>
+                          </Template>
+                          <Template src="skins:LateNight/helpers/skin_settings_button_2state.xml">
+                            <SetVariable name="TooltipId">show_intro_outro_cues</SetVariable>
+                            <SetVariable name="Text">Hotcue Shift Buttons</SetVariable>
+                            <SetVariable name="Setting">[Skin],timing_shift_buttons</SetVariable>
+                          </Template>
+                        </Children>
+                      </WidgetGroup>
 
-                      <Template src="skins:LateNight/helpers/skin_settings_button_2state.xml">
-                        <SetVariable name="TooltipId">show_intro_outro_cues</SetVariable>
-                        <SetVariable name="Text">Hotcue Shift Buttons</SetVariable>
-                        <SetVariable name="Setting">[Skin],timing_shift_buttons</SetVariable>
-                      </Template>
+                      <!-- Keep same height for all waveforms -->
+                      <WidgetGroup>
+                        <Layout>stacked</Layout>
+                        <Size>-1me,18f</Size>
+                        <Children>
+                          <!-- translucent cover when waveforms are hidden -->
+                          <Template src="skins:LateNight/helpers/skin_settings_cover_inverted.xml">
+                            <SetVariable name="Setting">[Skin],show_waveforms</SetVariable>
+                          </Template>
+                          <Template src="skins:LateNight/helpers/skin_settings_button_2state.xml">
+                            <SetVariable name="TooltipId">keep_consistent_waveform_heights</SetVariable>
+                            <SetVariable name="Text">Enforce equal heights</SetVariable>
+                            <SetVariable name="Setting">[Skin],keep_consistent_waveform_heights</SetVariable>
+                          </Template>
+                        </Children>
+                      </WidgetGroup>
 
                     </Children>
                   </WidgetGroup>

--- a/res/skins/LateNight/style_classic.qss
+++ b/res/skins/LateNight/style_classic.qss
@@ -1975,6 +1975,10 @@ WPushButton#BpmLockToggle[value="1"] {
     image: url(skins:LateNight/classic/buttons/btn__stem_controls_collapse.svg) no-repeat center center;
   }
 
+#NoStemLabel {
+  color: #f0bb2b;
+}
+
   #BpmLockToggle[value="1"] {
     image: url(skins:LateNight/classic/buttons/btn__bpm_locked.svg);
     }

--- a/res/skins/LateNight/style_palemoon.qss
+++ b/res/skins/LateNight/style_palemoon.qss
@@ -2401,6 +2401,10 @@ WPushButton#PlayDeck[value="0"] {
     image: url(skins:LateNight/palemoon/buttons/btn__stem_controls_collapse.svg) no-repeat center center;
   }
 
+#NoStemLabel {
+  color: #444;
+}
+
 #BeatgridControlsToggle[displayValue="0"] {
   image: url(skins:LateNight/palemoon/buttons/btn__beatgrid_controls_expand.svg) no-repeat center center;
   }

--- a/res/skins/LateNight/waveform.xml
+++ b/res/skins/LateNight/waveform.xml
@@ -23,7 +23,7 @@
         <RequiresStem>true</RequiresStem>
         <ObjectName>StemControls</ObjectName>
         <Layout>vertical</Layout>
-        <SizePolicy>max,me</SizePolicy>
+        <Size>240f,0me</Size>
         <Children>
           <WidgetGroup>
             <Size>0me,1me</Size>
@@ -108,8 +108,37 @@
               <!-- /StemControls 4ch -->
 
             </Children>
+            <Connection>
+              <ConfigKey persist="true">[Channel<Variable name="ChanNum"/>],stem_count</ConfigKey>
+              <BindProperty>visible</BindProperty>
+            </Connection>
           </WidgetGroup>
           <!-- /StemControlsInner -->
+
+          <WidgetGroup>
+            <!-- NoStemLabel -->
+            <Layout>horizontal</Layout>
+            <SizePolicy>me,f</SizePolicy>
+            <Children>
+              <WidgetGroup>
+                <Size>1me,3f</Size>
+              </WidgetGroup>
+              <Label>
+                <SizePolicy>min,me</SizePolicy>
+                <ObjectName>NoStemLabel</ObjectName>
+                <Text>Track has no STEMs</Text>
+              </Label>
+              <WidgetGroup>
+                <Size>1me,3f</Size>
+              </WidgetGroup>
+            </Children>
+            <Connection>
+              <ConfigKey persist="true">[Channel<Variable name="ChanNum"/>],stem_count</ConfigKey>
+              <Transform><Not/></Transform>
+              <BindProperty>visible</BindProperty>
+            </Connection>
+          </WidgetGroup>
+          <!-- /NoStemLabel -->
 
           <WidgetGroup>
             <Size>1me,1me</Size>
@@ -125,7 +154,7 @@
       <WidgetGroup>
         <ObjectName>WaveformBox<Variable name="ChanNum"/></ObjectName>
         <Layout>horizontal</Layout>
-        <SizePolicy>me,me</SizePolicy>
+        <Size>me,30min</Size>
         <Children>
           <Visual>
             <TooltipId>waveform_display</TooltipId>

--- a/res/skins/LateNight/waveform.xml
+++ b/res/skins/LateNight/waveform.xml
@@ -131,6 +131,15 @@
               <WidgetGroup>
                 <Size>1me,3f</Size>
               </WidgetGroup>
+              <!-- WaveformMinSizeConstrain -->
+              <WidgetGroup>
+                <Size>0f,110f</Size>
+                <Connection>
+                  <ConfigKey persist="true">[Skin],keep_consistent_waveform_heights</ConfigKey>
+                  <BindProperty>visible</BindProperty>
+                </Connection>
+              </WidgetGroup>
+              <!-- /WaveformMinSizeConstrain -->
             </Children>
             <Connection>
               <ConfigKey persist="true">[Channel<Variable name="ChanNum"/>],stem_count</ConfigKey>

--- a/src/skin/legacy/tooltips.cpp
+++ b/src/skin/legacy/tooltips.cpp
@@ -1005,6 +1005,12 @@ void Tooltips::addStandardTooltips() {
     add("show_intro_outro_cues")
             << tr("Show/hide intro & outro markers and associated buttons.");
 
+    add("keep_consistent_waveform_heights") << tr(
+            "Ensure all waveforms to have the same height across all channels. "
+            "By default, when displaying the stem controls, waveform for "
+            "channel that have no stem may render with a shorter height in "
+            "order to honor the waveform container size you have requested..");
+
     add("intro_start")
             << tr("Intro Start Marker")
             << QString("%1: %2").arg(leftClick, tr("If marker is set, jumps to the marker."))


### PR DESCRIPTION
Fixes #14242

<img width="1021" height="370" alt="image" src="https://github.com/user-attachments/assets/309a2eb3-c3b5-492a-bd1e-f7d1950fa3df" />


Note that I initially tried to close entirely the stem control, but this leads to waveform  having offset between them so I went with a more "naive" solution.