### PR TITLE
(fix) Waveforms: cancel scratching / bending on cursor leave event

### DIFF
--- a/src/widget/openglwindow.cpp
+++ b/src/widget/openglwindow.cpp
@@ -135,9 +135,26 @@ bool OpenGLWindow::event(QEvent* pEv) {
         // container widget that contains this QOpenGLWindow. With this mouse
         // events, keyboard events, etc all arrive as intended, including the
         // events for the WWaveformViewer that contains the waveform widget.
-        QMouseEvent* pME = static_cast<QMouseEvent*>(pEv);
-        if (pME) {
+        if (t == QEvent::MouseButtonPress ||
+                t == QEvent::MouseButtonRelease ||
+                t == QEvent::MouseButtonDblClick ||
+                t == QEvent::MouseMove) {
+            QMouseEvent* pME = static_cast<QMouseEvent*>(pEv);
             qWarning() << "-- OpenGLWindow" << pEv;
+            qWarning() << "-- OpenGLWindow" << pME;
+            // Map to parent's coordinate system
+            QPointF globalPos = pME->globalPosition();
+            QPointF parentLocalPos = m_pWidget->mapFromGlobal(globalPos.toPoint());
+
+            // Create FRESH event with parent's coordinates
+            QMouseEvent pNewME(pME->type(),
+                    parentLocalPos,
+                    globalPos,
+                    pME->button(),
+                    pME->buttons(),
+                    pME->modifiers());
+            QApplication::sendEvent(m_pWidget, &pNewME);
+            return result;
         }
         QApplication::sendEvent(m_pWidget, pEv);
     }

--- a/src/widget/openglwindow.cpp
+++ b/src/widget/openglwindow.cpp
@@ -135,6 +135,10 @@ bool OpenGLWindow::event(QEvent* pEv) {
         // container widget that contains this QOpenGLWindow. With this mouse
         // events, keyboard events, etc all arrive as intended, including the
         // events for the WWaveformViewer that contains the waveform widget.
+        QMouseEvent* pME = static_cast<QMouseEvent*>(pEv);
+        if (pME) {
+            qWarning() << "-- OpenGLWindow" << pEv;
+        }
         QApplication::sendEvent(m_pWidget, pEv);
     }
 

--- a/src/widget/wwaveformviewer.cpp
+++ b/src/widget/wwaveformviewer.cpp
@@ -81,6 +81,8 @@ void WWaveformViewer::mousePressEvent(QMouseEvent* event) {
         return;
     }
 
+    qWarning() << "---- WWaveformViewer::mouse PRESS" << event;
+
     m_mouseAnchor = event->pos();
 
     if (event->button() == Qt::LeftButton) {
@@ -132,6 +134,8 @@ void WWaveformViewer::mouseMoveEvent(QMouseEvent* event) {
         return;
     }
 
+    qWarning() << "---- WWaveformViewer::mouse MOVE" << event;
+
     // Only send signals for mouse moving if the left button is pressed
     if (m_bScratching) {
         int eventPosValue = m_waveformWidget->getOrientation() == Qt::Horizontal ?
@@ -177,7 +181,9 @@ void WWaveformViewer::mouseMoveEvent(QMouseEvent* event) {
     }
 }
 
-void WWaveformViewer::mouseReleaseEvent(QMouseEvent* /*event*/) {
+void WWaveformViewer::mouseReleaseEvent(QMouseEvent* event) {
+    qWarning() << "---- WWaveformViewer::mouse RELEASE" << event;
+
     if (m_bScratching) {
         m_pScratchPositionEnable->set(0.0);
         m_bScratching = false;


### PR DESCRIPTION
Should fix #14492

Also adds logging for OpenGLWindow' dragLeave event.
So if the fix doesn't work, check the log for
`warning: OpenGLWindow: dragLeave event`

Though I'm not familiar with QOpenGL and its event handling.
@m0dB and @acolombier are the pros here.