### PR TITLE
Remove not working fix for dependencies of trusted-signing-action #15239

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -408,8 +408,7 @@ jobs:
         env:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
         if: runner.os == 'Windows' && env.AZURE_TENANT_ID
-        # Pinned to commit, to fix a caching issue https://github.com/Azure/trusted-signing-action/issues/62
-        uses: azure/trusted-signing-action@0d74250c661747df006298d0fb49944c10f16e03
+        uses: azure/trusted-signing-action@v0.5.10
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}


### PR DESCRIPTION
The issue form #15239 is back. I can not confirm this in my local branch. Interestingly a different widows runner (minior version) is used there for some reasons. So the fix was not the trick. 

Lets update to the latest version instead: v0.5.10

And see what is happening. 
