### PR TITLE
(fix) Search: maintain cursor position when saving query

### DIFF
--- a/src/widget/wsearchlineedit.cpp
+++ b/src/widget/wsearchlineedit.cpp
@@ -544,14 +544,17 @@ void WSearchLineEdit::slotTriggerSearch() {
 void WSearchLineEdit::slotSaveSearch() {
     m_saveTimer.stop();
     // Keep original text for UI, potentially with trailing spaces
-    QString cText = currentText();
+    int curPos = lineEdit()->cursorPosition();
+    const QString origText = currentText();
+    QString cText = origText;
     int cIndex = findCurrentTextIndex();
     if (kLogger.traceEnabled()) {
         kLogger.trace()
                 << "save search. Text:"
                 << cText
-                << "Index:"
-                << cIndex;
+                << "| Index:"
+                << cIndex
+                << "| curpos:" << curPos;
     }
     if (cText.isEmpty() || !isEnabled()) {
         return;
@@ -571,8 +574,11 @@ void WSearchLineEdit::slotSaveSearch() {
         removeItem(kMaxSearchEntries);
     }
 
-    // Set the text without spaces for UI
-    setTextBlockSignals(cText);
+    if (currentText() != origText) {
+        // Set the text without spaces for UI
+        setTextBlockSignals(cText);
+        lineEdit()->setCursorPosition(curPos);
+    }
 }
 
 void WSearchLineEdit::slotMoveSelectedHistory(int steps) {


### PR DESCRIPTION
Currently the cursor is reset to the end of the query when it's saved.
This is annoying we you edit the query before it has been saved.

1 only set new text when it changed
2 restore cursor position