### PR TITLE
Library Scan dialog: add progress bar, plus some improvements

### DIFF
--- a/src/library/scanner/importfilestask.h
+++ b/src/library/scanner/importfilestask.h
@@ -22,6 +22,10 @@ class ImportFilesTask : public ScannerTask {
 
     virtual void run();
 
+    int numFilesToImport() const {
+        return static_cast<int>(m_filesToImport.size());
+    }
+
   private:
     const QString m_dirPath;
     const bool m_prevHashExists;

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -3,6 +3,7 @@
 #include "library/coverartutils.h"
 #include "library/library_decl.h"
 #include "library/queryutil.h"
+#include "library/scanner/importfilestask.h"
 #include "library/scanner/libraryscannerdlg.h"
 #include "library/scanner/recursivescandirectorytask.h"
 #include "library/scanner/scannertask.h"
@@ -553,6 +554,21 @@ void LibraryScanner::queueTask(ScannerTask* pTask) {
         m_pool.clear();
         return;
     }
+
+    // Fetch number of files to be processed and add them to the total tasks
+    // for the progress dialog to set the value of the progress bar later on.
+    // Note that there may also be an unknown number of tasks for files
+    // outside the library directories. We deal with that in DlgLibraryScanProgress.
+    ImportFilesTask* pFileTask = qobject_cast<ImportFilesTask*>(pTask);
+    if (pFileTask) {
+        // Track and cover files
+        int numFiles = pFileTask->numFilesToImport();
+        m_pProgressDlg->addQueuedTasks(numFiles);
+    } else {
+        // RecursiveScanDirectoryTask, queues exactly one directory
+        m_pProgressDlg->addQueuedTasks(1);
+    }
+
     m_scannerGlobal->getTaskWatcher().watchTask();
     connect(pTask,
             &ScannerTask::queueTask,

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -104,6 +104,7 @@ LibraryScanner::LibraryScanner(
           m_stateSema(1), // only one transaction is possible at a time
           m_state(IDLE),
           m_numRelocatedTracks(0),
+          m_pProgressDlg(std::make_unique<LibraryScannerDlg>()),
           m_manualScan(true) {
     // Move LibraryScanner to its own thread so that our signals/slots will
     // queue to our event loop.
@@ -119,35 +120,34 @@ LibraryScanner::LibraryScanner(
     // connect them to our slots to run the command on the scanner thread.
     connect(this, &LibraryScanner::startScan, this, &LibraryScanner::slotStartScan);
 
-    m_pProgressDlg.reset(new LibraryScannerDlg());
     connect(this,
             &LibraryScanner::progressLoading,
-            m_pProgressDlg.data(),
+            m_pProgressDlg.get(),
             &LibraryScannerDlg::slotUpdate);
     connect(this,
             &LibraryScanner::progressHashing,
-            m_pProgressDlg.data(),
+            m_pProgressDlg.get(),
             &LibraryScannerDlg::slotUpdate);
     connect(this,
             &LibraryScanner::scanStarted,
-            m_pProgressDlg.data(),
+            m_pProgressDlg.get(),
             &LibraryScannerDlg::slotScanStarted);
     connect(this,
             &LibraryScanner::scanFinished,
-            m_pProgressDlg.data(),
+            m_pProgressDlg.get(),
             &LibraryScannerDlg::slotScanFinished);
-    connect(m_pProgressDlg.data(),
+    connect(m_pProgressDlg.get(),
             &LibraryScannerDlg::scanCancelled,
             this,
             &LibraryScanner::slotCancel,
             Qt::DirectConnection);
     connect(&m_trackDao,
             &TrackDAO::progressVerifyTracksOutside,
-            m_pProgressDlg.data(),
+            m_pProgressDlg.get(),
             &LibraryScannerDlg::slotUpdate);
     connect(&m_trackDao,
             &TrackDAO::progressCoverArt,
-            m_pProgressDlg.data(),
+            m_pProgressDlg.get(),
             &LibraryScannerDlg::slotUpdateCover);
 }
 

--- a/src/library/scanner/libraryscanner.cpp
+++ b/src/library/scanner/libraryscanner.cpp
@@ -575,17 +575,6 @@ void LibraryScanner::queueTask(ScannerTask* pTask) {
             this,
             &LibraryScanner::slotAddNewTrack);
 
-    // Progress signals.
-    // Pass directly to the main thread
-    connect(pTask,
-            &ScannerTask::progressLoading,
-            this,
-            &LibraryScanner::progressLoading);
-    connect(pTask,
-            &ScannerTask::progressHashing,
-            this,
-            &LibraryScanner::progressHashing);
-
     m_pool.start(pTask);
 }
 

--- a/src/library/scanner/libraryscanner.h
+++ b/src/library/scanner/libraryscanner.h
@@ -127,7 +127,7 @@ class LibraryScanner : public QThread {
     int m_numRelocatedTracks;
 
     QList<mixxx::FileInfo> m_libraryRootDirs;
-    QScopedPointer<LibraryScannerDlg> m_pProgressDlg;
+    std::unique_ptr<LibraryScannerDlg> m_pProgressDlg;
 
     bool m_manualScan;
 };

--- a/src/library/scanner/libraryscannerdlg.cpp
+++ b/src/library/scanner/libraryscannerdlg.cpp
@@ -1,26 +1,49 @@
 #include "library/scanner/libraryscannerdlg.h"
 
-#include <QLabel>
 #include <QPushButton>
 #include <QVBoxLayout>
-#include <QtDebug>
 
 #include "defs_urls.h"
 #include "moc_libraryscannerdlg.cpp"
 
 LibraryScannerDlg::LibraryScannerDlg(QWidget* pParent)
         : QDialog(pParent),
-          m_bCancelled(false) {
+          m_pLabelCurrent(make_parented<QLabel>(this)),
+          m_pProgressBar(make_parented<QProgressBar>(this)),
+          m_bCancelled(false),
+          m_tasksDone(0),
+          m_tasksTotal(0),
+          m_showNoTasksQueuedWarning(true) {
     setWindowIcon(QIcon(MIXXX_ICON_PATH));
-
-    QVBoxLayout* pLayout = new QVBoxLayout(this);
-
     setWindowTitle(tr("Library Scanner"));
-    QLabel* pLabel = new QLabel(tr("It's taking Mixxx a minute to scan your music library, please wait..."),this);
-    pLayout->addWidget(pLabel);
 
-    QPushButton* pCancel = new QPushButton(tr("Cancel"), this);
-    connect(pCancel,
+    // This is the widest item initially so it sets the dialog's minimum width.
+    auto pLabel = make_parented<QLabel>(
+            tr("It's taking Mixxx a minute to scan your music library, please wait..."),
+            this);
+
+    // Add some margin between label and progress bar
+    auto pSpacer = make_parented<QWidget>(this);
+    pSpacer->setFixedSize(10, 10);
+
+    m_pLabelCurrent->setAlignment(Qt::AlignTop);
+    m_pLabelCurrent->setWordWrap(true);
+    // Allow the label to expand horizontally if the dialog is expanded manually
+    // and vertically if required by the text. `Ignored` means the label will not
+    // force-expand the dialog.
+    m_pLabelCurrent->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::MinimumExpanding);
+
+    // Try not let the dialog expand beyond the screen's bottom edge, this would
+    // push the Cancel button off screen.
+    // The dialog is initially shown centered with a height of ~180 px. If we
+    // assume a minimum screen height of 768 px, 400 px seems to be safe.
+    // Tests on 1920x1080, 96 dpi with system default font (11 pt) have shown
+    // that the label can show moore than 7 lines before it is clamped. If users
+    // really need to see the full path then they can expand the dialog horizontally.
+    setMaximumHeight(400);
+
+    auto pCancel = make_parented<QPushButton>(tr("Cancel"), this);
+    connect(pCancel.get(),
             &QPushButton::clicked,
             this,
             &LibraryScannerDlg::slotCancel);
@@ -30,37 +53,85 @@ LibraryScannerDlg::LibraryScannerDlg(QWidget* pParent)
             this,
             &LibraryScannerDlg::slotCancel);
 
-    QLabel* pCurrent = new QLabel(this);
-    pCurrent->setAlignment(Qt::AlignTop);
-    pCurrent->setMaximumWidth(600);
-    pCurrent->setFixedHeight(this->fontMetrics().height());
-    pCurrent->setWordWrap(true);
-    connect(this, &LibraryScannerDlg::progress, pCurrent, &QLabel::setText);
-    pLayout->addWidget(pCurrent);
-    setLayout(pLayout);
+    auto pLayout = make_parented<QVBoxLayout>(this);
+    pLayout->addWidget(pLabel.get());
+    pLayout->addWidget(pSpacer.get());
+    pLayout->addWidget(m_pProgressBar);
+    pLayout->addWidget(m_pLabelCurrent);
+    pLayout->addWidget(pCancel.get());
+    setLayout(pLayout.get());
+}
+
+void LibraryScannerDlg::resetTaskCount() {
+    m_tasksDone = 0;
+    m_tasksTotal = 0;
+    m_pProgressBar->reset();
+}
+
+void LibraryScannerDlg::addQueuedTasks(int num) {
+    m_tasksTotal += num;
+}
+
+void LibraryScannerDlg::updateProgressBar() {
+    // The scanner does three things:
+    // 1) hash library directories and subdirectories
+    // 2) analyze track and cover files in those directories
+    // 3) analyze files outside library directories
+    // For 1 and 2 we know the count in advance when ScannerTasks are queued and
+    // store the total in m_tasksTotal.
+    // For 3 we don't know the count before we are notified in slotUpdate() for
+    // each, so at one point m_tasksDone can become bigger than m_tasksTotal.
+    // To avoid the confusing situation of showing 100% (or more) on the progress
+    // bar and label while the dialog is still updated at high rate,
+    // we clamp to 99 %. 100 % will only be shown for a glimpse anyway before
+    // the diaoge is closed so this is okay.
+    //
+    // Protect against division by zero. This may happen if we have no watched
+    // library directories, i.e. only case 3)
+    if (m_tasksTotal == 0) {
+        if (m_showNoTasksQueuedWarning) {
+            m_showNoTasksQueuedWarning = false;
+            qWarning() << "LibraryScannerDlg::updateProgressBar(): received "
+                          "scan progress update while we don't have any tasks queued.";
+        }
+        return;
+    }
+
+    int percent = static_cast<int>(m_tasksDone * 100.0 / m_tasksTotal);
+    if (percent > 99) {
+        return;
+    }
+
+    m_pProgressBar->setValue(percent);
 }
 
 void LibraryScannerDlg::slotUpdate(const QString& path) {
-    //qDebug() << "LibraryScannerDlg slotUpdate" << m_timer.elapsed().formatMillisWithUnit() << path;
+    // qDebug() << "LibraryScannerDlg slotUpdate" <<
+    // m_timer.elapsed().formatMillisWithUnit() << path;
     if (!m_bCancelled && m_timer.elapsed() > mixxx::Duration::fromSeconds(2)) {
        setVisible(true);
     }
 
+    m_tasksDone++;
+
     if (isVisible()) {
-        QString status = tr("Scanning: ") + path;
-        emit progress(status);
+        updateProgressBar();
+        m_pLabelCurrent->setText(tr("Scanning: ") + path);
     }
 }
 
 void LibraryScannerDlg::slotUpdateCover(const QString& path) {
-    //qDebug() << "LibraryScannerDlg slotUpdate" << m_timer.elapsed() << path;
+    // qDebug() << "LibraryScannerDlg slotUpdate" << m_timer.elapsed() << path;
     if (!m_bCancelled && m_timer.elapsed() > mixxx::Duration::fromSeconds(2)) {
        setVisible(true);
     }
 
+    m_tasksDone++;
     if (isVisible()) {
-        QString status = QString("%1: %2").arg(tr("Scanning cover art (safe to cancel)"), path);
-        emit progress(status);
+        updateProgressBar();
+        const QString status = QStringLiteral("%1: %2").arg(
+                tr("Scanning cover art (safe to cancel)"), path);
+        m_pLabelCurrent->setText(status);
     }
 }
 
@@ -69,6 +140,7 @@ void LibraryScannerDlg::slotCancel() {
     m_bCancelled = true;
     emit scanCancelled();
     hide();
+    resetTaskCount();
 }
 
 void LibraryScannerDlg::slotScanStarted() {
@@ -82,4 +154,5 @@ void LibraryScannerDlg::slotScanFinished() {
     m_bCancelled = true;
 
     hide();
+    resetTaskCount();
 }

--- a/src/library/scanner/libraryscannerdlg.cpp
+++ b/src/library/scanner/libraryscannerdlg.cpp
@@ -24,7 +24,11 @@ LibraryScannerDlg::LibraryScannerDlg(QWidget* pParent)
             &QPushButton::clicked,
             this,
             &LibraryScannerDlg::slotCancel);
-    pLayout->addWidget(pCancel);
+    // Also cancel when closing by click on X window button
+    connect(this,
+            &QDialog::rejected,
+            this,
+            &LibraryScannerDlg::slotCancel);
 
     QLabel* pCurrent = new QLabel(this);
     pCurrent->setAlignment(Qt::AlignTop);

--- a/src/library/scanner/libraryscannerdlg.cpp
+++ b/src/library/scanner/libraryscannerdlg.cpp
@@ -8,8 +8,8 @@
 #include "defs_urls.h"
 #include "moc_libraryscannerdlg.cpp"
 
-LibraryScannerDlg::LibraryScannerDlg(QWidget* parent, Qt::WindowFlags f)
-        : QWidget(parent, f),
+LibraryScannerDlg::LibraryScannerDlg(QWidget* pParent)
+        : QDialog(pParent),
           m_bCancelled(false) {
     setWindowIcon(QIcon(MIXXX_ICON_PATH));
 
@@ -34,9 +34,6 @@ LibraryScannerDlg::LibraryScannerDlg(QWidget* parent, Qt::WindowFlags f)
     connect(this, &LibraryScannerDlg::progress, pCurrent, &QLabel::setText);
     pLayout->addWidget(pCurrent);
     setLayout(pLayout);
-}
-
-LibraryScannerDlg::~LibraryScannerDlg() {
 }
 
 void LibraryScannerDlg::slotUpdate(const QString& path) {

--- a/src/library/scanner/libraryscannerdlg.h
+++ b/src/library/scanner/libraryscannerdlg.h
@@ -1,13 +1,19 @@
 #pragma once
 
 #include <QDialog>
+#include <QLabel>
+#include <QProgressBar>
 
+#include "util/parented_ptr.h"
 #include "util/performancetimer.h"
 
 class LibraryScannerDlg : public QDialog {
     Q_OBJECT
   public:
     LibraryScannerDlg(QWidget* pParent = nullptr);
+
+    void resetTaskCount();
+    void addQueuedTasks(int num);
 
   public slots:
     void slotUpdate(const QString& path);
@@ -18,9 +24,17 @@ class LibraryScannerDlg : public QDialog {
 
   signals:
     void scanCancelled();
-    void progress(const QString&);
 
   private:
+    void updateProgressBar();
+
     PerformanceTimer m_timer;
+
+    parented_ptr<QLabel> m_pLabelCurrent;
+    parented_ptr<QProgressBar> m_pProgressBar;
+
     bool m_bCancelled;
+    int m_tasksDone;
+    int m_tasksTotal;
+    bool m_showNoTasksQueuedWarning;
 };

--- a/src/library/scanner/libraryscannerdlg.h
+++ b/src/library/scanner/libraryscannerdlg.h
@@ -1,16 +1,13 @@
 #pragma once
 
-#include <QWidget>
+#include <QDialog>
 
 #include "util/performancetimer.h"
 
-class QString;
-
-class LibraryScannerDlg : public QWidget {
+class LibraryScannerDlg : public QDialog {
     Q_OBJECT
   public:
-    LibraryScannerDlg(QWidget* parent = NULL, Qt::WindowFlags f = Qt::Dialog);
-    virtual ~LibraryScannerDlg();
+    LibraryScannerDlg(QWidget* pParent = nullptr);
 
   public slots:
     void slotUpdate(const QString& path);

--- a/src/library/scanner/scannertask.h
+++ b/src/library/scanner/scannertask.h
@@ -25,10 +25,6 @@ class ScannerTask : public QObject, public QRunnable {
     void trackExists(const QString& filePath);
     void addNewTrack(const QString& filePath);
 
-    // Feedback to GUI
-    void progressLoading(const QString& fileName);
-    void progressHashing(const QString& directoryPath);
-
   protected:
     void setSuccess(bool success) {
         m_success = success;


### PR DESCRIPTION
<img width="496" height="256" alt="image" src="https://github.com/user-attachments/assets/dc51972c-d78f-46ad-bb51-ee28ce661f95" />

Adds a progress bar and allows to show the full path of the current (actually previous) task.
As before, the dialog should automatically grow in width but can still be expanded manually.
It grows in height if the file/directory paths require it. (previously paths were truncated even if the dialog was expanded)

Requires a small hack to not show 100% prematurely (and potentially for a confusing long time)  because we don't know the total of all tasks in advance. See inline comments for details.

**Fix:** cancel scan when clicking X window button
_____
I'm tempted to target 2.6 because IMO it's a nice UX fix, but I won't insist.