### PR TITLE
[POC] add hotkey to edit track comment in deck

### DIFF
--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -380,6 +380,11 @@ void WTrackProperty::slotCommitEditorData(const QString& text) {
     const QString trackText = getPropertyStringFromTrack(m_editProperty);
     QString editorText = text;
     if (m_isComment) {
+        // Transform ALL occurrences of \n into linebreaks.
+        // Existing linebreaks are not affected.
+        QString cr(QChar::CarriageReturn);
+        cr.append(QChar::LineFeed);
+        editorText.replace("\\n", cr);
         // For multi-line comments, the editor received only the first line.
         // In order to keep the other lines, we need to replace
         // the first line of the original text with the editor text.

--- a/src/widget/wtrackproperty.h
+++ b/src/widget/wtrackproperty.h
@@ -88,11 +88,14 @@ class WTrackProperty : public WLabel, public TrackDropTarget {
     const QString getPropertyStringFromTrack(QString& property) const;
     void restyleAndRepaint();
 
+    void openEditor();
+
     void ensureTrackMenuIsCreated();
     const QString m_group;
     const UserSettingsPointer m_pConfig;
     Library* m_pLibrary;
     const bool m_isMainDeck;
+    bool m_isComment;
     TrackPointer m_pCurrentTrack;
 
     QString m_displayProperty;


### PR DESCRIPTION
Here's yet another small mod I find very helpful for preparing/editing tracks while using only the keyboard (+ controller).
If you use a skin that has a comment widget in decks (WTrackProperty), press `Alt`+[deck number] to open the property editor.

So the workflow is simply this, no mouse/trackpad involved:
* `Alt`+`1` for deck 1
* edit text
* Enter, done

Plus these mods:
* show only first comment line in editor
allows to add tag-like comments to the first line while keeping stuff like lyrics or release info out of sight
(in the library only the first line is displayed anyway)
* add linebreak with `\n`
allows to push above mentioned extra info down

The hotkey currently works via QAction in each WTrackProperty dsiplaying the `comment`, as that was the quickest way for me to get this feature.
It is failproof in the sense that there should be no issue with even multiple comment labels visible for one deck.
I'd like to share it, though I am not 100% sure it can/should be integrated as is, simply because the hotkey can not be customized (didn't check if it would overwrite keys from *.kbd.cfg or would be overwritten by such).
