### PR TITLE
Fix deadlock with mappings for display controllers

### DIFF
--- a/src/controllers/controllermanager.cpp
+++ b/src/controllers/controllermanager.cpp
@@ -354,7 +354,7 @@ void ControllerManager::slotPollDevices() {
     // we are cooperative a skip the next cycle to free at least some
     // CPU time
     //
-    // Some random test data form a i5-3317U CPU @ 1.70GHz Running
+    // Some random test data from a i5-3317U CPU @ 1.70GHz Running
     // Ubuntu Trusty:
     // * Idle poll: ~5 µs.
     // * 5 messages burst (full midi bandwidth): ~872 µs.
@@ -412,6 +412,8 @@ void ControllerManager::closeController(Controller* pController) {
             ConfigKey("[Controller]", sanitizeDeviceName(pController->getName())), 0);
 }
 
+// This needs to be called in a Qt::BlockingQueuedConnection so that the
+// signaling thread can't alter the LegacyControllerMapping during applying
 void ControllerManager::slotApplyMapping(Controller* pController,
         std::shared_ptr<LegacyControllerMapping> pMapping,
         bool bEnabled) {
@@ -434,7 +436,6 @@ void ControllerManager::slotApplyMapping(Controller* pController,
         qWarning() << "Mapping is dirty, changes might be lost on restart!";
     }
 
-
     // Save the file path/name in the config so it can be auto-loaded at
     // startup next time
     m_pConfig->set(key, pMapping->filePath());
@@ -442,11 +443,19 @@ void ControllerManager::slotApplyMapping(Controller* pController,
     pController->setMapping(std::move(pMapping));
 
     if (bEnabled) {
-        openController(pController);
         emit mappingApplied(pController->isMappable());
     } else {
         emit mappingApplied(false);
+        return;
     }
+
+    // Note: openController() may call ControllerRenderingEngine::setup()
+    // Which has a blocking invokeMethod() call for QOffscreenSurface::create()
+    // That why we need to return from this blocking call first.
+    QMetaObject::invokeMethod(
+            this,
+            [this, pController]() { openController(pController); },
+            Qt::QueuedConnection);
 }
 
 // static


### PR DESCRIPTION
This fixed the deadlock introduced via merging 2.5 to 2.6 that contains the incompatible "concurrent access crasher fix" #14159 and the "controller screen rendering" #11407

This the solution with the second slot called non blocking as discussed in #14606.