### PR TITLE
(fix) Broadcast: handle and fix invalid config strings

### DIFF
--- a/res/skins/LateNight/toolbar.xml
+++ b/res/skins/LateNight/toolbar.xml
@@ -276,7 +276,7 @@
         <SetVariable name="state_0_text">      ON AIR</SetVariable>
         <SetVariable name="state_1_text">       ...</SetVariable>
         <SetVariable name="state_2_text">      ON AIR</SetVariable>
-        <SetVariable name="state_3_text">       ---</SetVariable>
+        <SetVariable name="state_3_text">      ERROR</SetVariable>
         <SetVariable name="ConfigKey">[Shoutcast],enabled</SetVariable>
         <SetVariable name="ConfigKeyDisp">[Shoutcast],status</SetVariable>
       </Template>

--- a/src/preferences/broadcastprofile.cpp
+++ b/src/preferences/broadcastprofile.cpp
@@ -83,10 +83,16 @@ const QString kDefaultStreamDesc =
 const QString kDefaultStreamGenre = QObject::tr("Live Mix");
 constexpr bool kDefaultStreamPublic = false;
 
+// Characters not allowed for profile name
 const QRegularExpression kForbiddenChars =
         QRegularExpression(QStringLiteral(
                 "[<>:\"\\/|?*\\\\]|(\\.\\.)"
                 "|CON|AUX|PRN|COM(\\d+)|LPT(\\d+)|NUL"));
+// Characters known to cause trouble for various fields, especially host, login
+// and password.
+// See https://mixxx.discourse.group/t/broadcasting-connection-problems/32861/3
+const QRegularExpression kControlChars =
+        QRegularExpression(QStringLiteral("[\\x00-\\x1F\\x7F]"));
 
 const mixxx::Logger kLogger("BroadcastProfile");
 } // anonymous namespace
@@ -105,9 +111,50 @@ bool BroadcastProfile::validName(const QString& str) {
     return !str.contains(kForbiddenChars);
 }
 
+bool BroadcastProfile::validPassword() {
+    return validPassword(m_password);
+}
+
+bool BroadcastProfile::validPassword(const QString& input) {
+    // Here we get either the strings decoded from Xml when reading the profile
+    // or the password QString we received from the preferences.
+    return !input.contains(kControlChars);
+}
+
 QString BroadcastProfile::stripForbiddenChars(const QString& str) {
     QString sourceText(str);
     return sourceText.replace(kForbiddenChars, " ");
+}
+
+QString BroadcastProfile::removeControlCharacters(
+        const QString& str,
+        const QString& fieldName,
+        bool* pFixed) {
+    // Remove all control characters like %#d; (\r, Carriage Return)
+    // If the config has been corrupted manually, for example by adding linebreaks,
+    // we may also have literals like \n. We don't care about those because
+    // a) we can't tell whether these are there on purpose
+    // b) in contrast to for example &#xd; these are visible in the Password QLineEdit.
+    QString input(str);
+    input.remove(kControlChars);
+    if (str != input) {
+        qWarning() << "BroadcastProfile: removed invalid characters from"
+                   << fieldName << "field";
+        if (pFixed && !(*pFixed)) {
+            *pFixed = true;
+        }
+    }
+    return input;
+}
+
+QString BroadcastProfile::selectCleanNodeString(
+        const QDomElement& doc,
+        const QString& fieldName,
+        bool* pFixed) {
+    return removeControlCharacters(
+            XmlParse::selectNodeQString(doc, fieldName),
+            fieldName,
+            pFixed);
 }
 
 BroadcastProfilePtr BroadcastProfile::loadFromFile(
@@ -291,15 +338,25 @@ bool BroadcastProfile::loadValues(const QString& filename) {
 
     m_enabled = (bool)XmlParse::selectNodeInt(doc, kEnabled);
 
-    m_host = XmlParse::selectNodeQString(doc, kHost);
+    // Check if we have to remove control chars.
+    // If yes, write the config back to file
+    bool fixedStrings = false;
+    m_host = selectCleanNodeString(doc, kHost, &fixedStrings);
     m_port = XmlParse::selectNodeInt(doc, kPort);
-    m_serverType = XmlParse::selectNodeQString(doc, kServertype);
+    m_serverType = selectCleanNodeString(doc, kServertype, &fixedStrings);
 
-    m_login = XmlParse::selectNodeQString(doc, kLogin);
+    m_login = selectCleanNodeString(doc, kLogin, &fixedStrings);
     if (m_secureCredentials) {
         m_password = getSecurePassword(m_login);
     } else {
         m_password = XmlParse::selectNodeQString(doc, kPassword);
+    }
+    // If password contains invalid characters, for example linebreaks,
+    // we log a warning. When attempting to connect with invalid credentials
+    // users will get a warning popup and need to check Broadcasting
+    // preferences which will notify them, too.
+    if (!validPassword()) {
+        qWarning() << "BroadcastProfile::loadValues: stored password contains invalid characters!";
     }
 
     m_enableReconnect =
@@ -317,17 +374,17 @@ bool BroadcastProfile::loadValues(const QString& filename) {
     m_reconnectFirstDelay =
             XmlParse::selectNodeDouble(doc, kReconnectFirstDelay);
 
-    m_mountpoint = XmlParse::selectNodeQString(doc, kMountPoint);
-    m_streamName = XmlParse::selectNodeQString(doc, kStreamName);
-    m_streamDesc = XmlParse::selectNodeQString(doc, kStreamDesc);
-    m_streamGenre = XmlParse::selectNodeQString(doc, kStreamGenre);
+    m_mountpoint = selectCleanNodeString(doc, kMountPoint, &fixedStrings);
+    m_streamName = selectCleanNodeString(doc, kStreamName, &fixedStrings);
+    m_streamDesc = selectCleanNodeString(doc, kStreamDesc, &fixedStrings);
+    m_streamGenre = selectCleanNodeString(doc, kStreamGenre, &fixedStrings);
     m_streamPublic = (bool)XmlParse::selectNodeInt(doc, kStreamPublic);
-    m_streamWebsite = XmlParse::selectNodeQString(doc, kStreamWebsite);
-    m_streamIRC = XmlParse::selectNodeQString(doc, kStreamIRC);
-    m_streamAIM = XmlParse::selectNodeQString(doc, kStreamAIM);
-    m_streamICQ = XmlParse::selectNodeQString(doc, kStreamICQ);
+    m_streamWebsite = selectCleanNodeString(doc, kStreamWebsite, &fixedStrings);
+    m_streamIRC = selectCleanNodeString(doc, kStreamIRC, &fixedStrings);
+    m_streamAIM = selectCleanNodeString(doc, kStreamAIM, &fixedStrings);
+    m_streamICQ = selectCleanNodeString(doc, kStreamICQ, &fixedStrings);
 
-    m_format = XmlParse::selectNodeQString(doc, kFormat);
+    m_format = selectCleanNodeString(doc, kFormat, &fixedStrings);
     if (m_format == BROADCAST_FORMAT_OV_LEGACY) {
         // Upgrade to have the same codec name than the recording define.
         m_format = ENCODING_OGG;
@@ -336,12 +393,24 @@ bool BroadcastProfile::loadValues(const QString& filename) {
     m_channels = XmlParse::selectNodeInt(doc, kChannels);
 
     m_enableMetadata = (bool)XmlParse::selectNodeInt(doc, kEnableMetadata);
-    m_metadataCharset = XmlParse::selectNodeQString(doc, kMetadataCharset);
-    m_customArtist = XmlParse::selectNodeQString(doc, kCustomArtist);
-    m_customTitle = XmlParse::selectNodeQString(doc, kCustomTitle);
-    m_metadataFormat = XmlParse::selectNodeQString(doc, kMetadataFormat);
+    m_metadataCharset = selectCleanNodeString(doc, kMetadataCharset, &fixedStrings);
+    m_customArtist = selectCleanNodeString(doc, kCustomArtist, &fixedStrings);
+    m_customTitle = selectCleanNodeString(doc, kCustomTitle, &fixedStrings);
+    m_metadataFormat = selectCleanNodeString(doc, kMetadataFormat, &fixedStrings);
     m_oggDynamicUpdate =
             (bool)XmlParse::selectNodeInt(doc, kOggDynamicUpdate);
+
+    if (fixedStrings) {
+        if (save(m_filename)) {
+            qWarning() << "BroadcastProfile::loadValues: wrote config for profile"
+                       << m_profileName
+                       << "with corrected field strings back to file";
+        } else {
+            qWarning() << "BroadcastProfile::loadValues: failed to write config for profile"
+                       << m_profileName
+                       << "with corrected field strings back to file!";
+        }
+    }
 
     return true;
 }
@@ -425,7 +494,7 @@ bool BroadcastProfile::save(const QString& filename) {
 
 void BroadcastProfile::setProfileName(const QString &profileName) {
     QString oldName(m_profileName);
-    m_profileName = QString(profileName);
+    m_profileName = removeControlCharacters(profileName, kProfileName);
 
     emit profileNameChanged(oldName, m_profileName);
 }
@@ -452,6 +521,9 @@ bool BroadcastProfile::secureCredentialStorage() {
 }
 
 bool BroadcastProfile::setSecurePassword(const QString& login, const QString& password) {
+    if (!validPassword(password)) {
+        qWarning() << "BroadcastProfile::setSecurePassword: password contains invalid characters!";
+    }
 #ifdef __QTKEYCHAIN__
     QString serviceName = QString(kKeychainPrefix) + getProfileName();
 
@@ -497,7 +569,14 @@ QString BroadcastProfile::getSecurePassword(const QString& login) {
 
     if (readJob.error() == Error::NoError) {
         kLogger.debug() << "getSecureValue: read successful";
-        return readJob.textData();
+        const QString password = readJob.textData();
+        if (!validPassword(password)) {
+            // Don't alter the password. user will get notified when trying to connect
+            // and when entering invalid characters in the preferences
+            qWarning() << "BroadcastProfile::getSecurePassword: password "
+                          "contains invalid characters!";
+        }
+        return password;
     } else {
         kLogger.warning() << "getSecureValue: read job failed with error:"
                         << readJob.errorString();
@@ -549,7 +628,7 @@ QString BroadcastProfile::getHost() const {
 }
 
 void BroadcastProfile::setHost(const QString& value) {
-    m_host = QString(value);
+    m_host = removeControlCharacters(value, kHost);
 }
 
 int BroadcastProfile::getPort() const {
@@ -578,7 +657,7 @@ QString BroadcastProfile::getLogin() const {
 }
 
 void BroadcastProfile::setLogin(const QString& value) {
-    m_login = QString(value);
+    m_login = removeControlCharacters(value, kLogin);
 }
 
 // TODO(Palakis, June 2nd 2017): implement secure password storage
@@ -587,6 +666,11 @@ QString BroadcastProfile::getPassword() const {
 }
 
 void BroadcastProfile::setPassword(const QString& value) {
+    if (!validPassword(value)) {
+        // Don't alter the password. user will get notified when trying to connect
+        // and when entering invalid characters in the preferences
+        qWarning() << "BroadcastProfile::setPassword: password contains invalid characters!";
+    }
     m_password = QString(value);
 }
 
@@ -643,7 +727,7 @@ QString BroadcastProfile::getMountpoint() const {
 }
 
 void BroadcastProfile::setMountPoint(const QString& value) {
-    m_mountpoint = QString(value);
+    m_mountpoint = removeControlCharacters(value, kMountPoint);
 }
 
 QString BroadcastProfile::getStreamName() const {
@@ -651,7 +735,7 @@ QString BroadcastProfile::getStreamName() const {
 }
 
 void BroadcastProfile::setStreamName(const QString& value) {
-    m_streamName = QString(value);
+    m_streamName = removeControlCharacters(value, kStreamName);
 }
 
 QString BroadcastProfile::getStreamDesc() const {
@@ -659,7 +743,7 @@ QString BroadcastProfile::getStreamDesc() const {
 }
 
 void BroadcastProfile::setStreamDesc(const QString& value) {
-    m_streamDesc = QString(value);
+    m_streamDesc = removeControlCharacters(value, kStreamDesc);
 }
 
 QString BroadcastProfile::getStreamGenre() const {
@@ -667,7 +751,7 @@ QString BroadcastProfile::getStreamGenre() const {
 }
 
 void BroadcastProfile::setStreamGenre(const QString& value) {
-    m_streamGenre = QString(value);
+    m_streamGenre = removeControlCharacters(value, kStreamGenre);
 }
 
 bool BroadcastProfile::getStreamPublic() const {
@@ -683,7 +767,7 @@ QString BroadcastProfile::getStreamWebsite() const {
 }
 
 void BroadcastProfile::setStreamWebsite(const QString& value) {
-    m_streamWebsite = QString(value);
+    m_streamWebsite = removeControlCharacters(value, kStreamWebsite);
 }
 
 QString BroadcastProfile::getStreamIRC() const {
@@ -691,7 +775,7 @@ QString BroadcastProfile::getStreamIRC() const {
 }
 
 void BroadcastProfile::setStreamIRC(const QString& value) {
-    m_streamIRC = value;
+    m_streamIRC = removeControlCharacters(value, kStreamIRC);
 }
 
 QString BroadcastProfile::getStreamAIM() const {
@@ -699,7 +783,7 @@ QString BroadcastProfile::getStreamAIM() const {
 }
 
 void BroadcastProfile::setStreamAIM(const QString& value) {
-    m_streamAIM = value;
+    m_streamAIM = removeControlCharacters(value, kStreamAIM);
 }
 
 QString BroadcastProfile::getStreamICQ() const {
@@ -707,7 +791,7 @@ QString BroadcastProfile::getStreamICQ() const {
 }
 
 void BroadcastProfile::setStreamICQ(const QString& value) {
-    m_streamICQ = value;
+    m_streamICQ = removeControlCharacters(value, kStreamICQ);
 }
 
 QString BroadcastProfile::getFormat() const {
@@ -715,7 +799,7 @@ QString BroadcastProfile::getFormat() const {
 }
 
 void BroadcastProfile::setFormat(const QString& value) {
-    m_format = QString(value);
+    m_format = removeControlCharacters(value, kFormat);
 }
 
 int BroadcastProfile::getBitrate() const {
@@ -747,7 +831,7 @@ QString BroadcastProfile::getMetadataCharset() const {
 }
 
 void BroadcastProfile::setMetadataCharset(const QString& value) {
-    m_metadataCharset = QString(value);
+    m_metadataCharset = removeControlCharacters(value, kMetadataCharset);
 }
 
 QString BroadcastProfile::getCustomArtist() const {
@@ -755,7 +839,7 @@ QString BroadcastProfile::getCustomArtist() const {
 }
 
 void BroadcastProfile::setCustomArtist(const QString& value) {
-    m_customArtist = QString(value);
+    m_customArtist = removeControlCharacters(value, kCustomArtist);
 }
 
 QString BroadcastProfile::getCustomTitle() const {
@@ -763,7 +847,7 @@ QString BroadcastProfile::getCustomTitle() const {
 }
 
 void BroadcastProfile::setCustomTitle(const QString& value) {
-    m_customTitle = QString(value);
+    m_customTitle = removeControlCharacters(value, kCustomTitle);
 }
 
 QString BroadcastProfile::getMetadataFormat() const {
@@ -771,7 +855,7 @@ QString BroadcastProfile::getMetadataFormat() const {
 }
 
 void BroadcastProfile::setMetadataFormat(const QString& value) {
-    m_metadataFormat = QString(value);
+    m_metadataFormat = removeControlCharacters(value, kMetadataFormat);
 }
 
 bool BroadcastProfile::getOggDynamicUpdate() const {

--- a/src/preferences/broadcastprofile.h
+++ b/src/preferences/broadcastprofile.h
@@ -5,6 +5,8 @@
 #include <QString>
 
 class BroadcastProfile;
+class QDomElement;
+
 typedef QSharedPointer<BroadcastProfile> BroadcastProfilePtr;
 Q_DECLARE_METATYPE(BroadcastProfilePtr)
 
@@ -29,7 +31,18 @@ class BroadcastProfile : public QObject {
 
     static BroadcastProfilePtr loadFromFile(const QString& filename);
     static bool validName(const QString& str);
+    bool validPassword();
+    // static so they're accessible for BroadcastProfileTest
+    static bool validPassword(const QString& password);
     static QString stripForbiddenChars(const QString& str);
+    static QString removeControlCharacters(
+            const QString& str,
+            const QString& fieldName,
+            bool* pFixed = nullptr);
+    QString selectCleanNodeString(
+            const QDomElement& doc,
+            const QString& fieldName,
+            bool* pFixed = nullptr);
 
     QString getLastFilename() const;
 

--- a/src/preferences/dialog/dlgprefbroadcast.cpp
+++ b/src/preferences/dialog/dlgprefbroadcast.cpp
@@ -3,7 +3,6 @@
 #include <QHeaderView>
 #include <QInputDialog>
 #include <QMessageBox>
-#include <QtDebug>
 
 // this is needed to define SHOUT_META_* macros used in version guard
 #include <shoutidjc/shout.h>
@@ -23,12 +22,13 @@ constexpr int kColumnName = 1;
 const mixxx::Logger kLogger("DlgPrefBroadcast");
 } // namespace
 
-DlgPrefBroadcast::DlgPrefBroadcast(QWidget *parent,
-                                   BroadcastSettingsPointer pBroadcastSettings)
+DlgPrefBroadcast::DlgPrefBroadcast(QWidget* parent,
+        BroadcastSettingsPointer pBroadcastSettings)
         : DlgPreferencePage(parent),
           m_pBroadcastSettings(pBroadcastSettings),
           m_pSettingsModel(new BroadcastSettingsModel()),
-          m_pProfileListSelection(nullptr) {
+          m_pProfileListSelection(nullptr),
+          m_allProfilesValid(true) {
     setupUi(this);
 
 #ifndef __QTKEYCHAIN__
@@ -204,27 +204,41 @@ QUrl DlgPrefBroadcast::helpUrl() const {
 }
 
 void DlgPrefBroadcast::applyModel() {
-    if (m_pProfileListSelection) {
-        setValuesToProfile(m_pProfileListSelection);
-    }
     m_pBroadcastSettings->applyModel(m_pSettingsModel);
     updateModel();
 }
 
 void DlgPrefBroadcast::slotApply() {
-    // Make sure the currently selected connection
-    // gets saved as expected
-    setValuesToProfile(m_pProfileListSelection);
+    // Save pending changes to profile
+    if (m_pProfileListSelection) {
+        setValuesToProfile(m_pProfileListSelection);
+    }
 
-    // Check for Icecast connections with identical mountpoints on the same host
+    // Make sure the currently selected connection gets saved as expected.
+    // Reject if the password contains invalid characters.
+    // Reject Icecast connections with identical mountpoints on the same host
+    const QString failedStr = tr("Saving settings failed");
     QMap<QString, QString> mountpoints;
     const QList<BroadcastProfilePtr> broadcastProfiles = m_pSettingsModel->profiles();
     for (const auto& profile : broadcastProfiles) {
+        QString profileName = profile->getProfileName();
+        qWarning() << "--> slotApply()" << profileName;
+        if (!profile->validPassword()) {
+            m_allProfilesValid = false;
+            QMessageBox::warning(this,
+                    failedStr,
+                    tr("The password for '%1' contains invalid characters. "
+                       "Please enter it again.\n\n"
+                       "Note: This can for example be invisible linebreaks "
+                       "when using copy/paste.")
+                            .arg(profileName));
+            return;
+        }
+
         if (profile->getServertype() != BROADCAST_SERVER_ICECAST2) {
             continue;
         }
 
-        QString profileName = profile->getProfileName();
         QString profileMountpoint = profile->getMountpoint();
         bool profileEnabled = profile->getEnabled();
 
@@ -241,8 +255,9 @@ void DlgPrefBroadcast::slotApply() {
                                 profile->getPort()
                         // allow same mountpoint if not both connections are enabled
                         && (profileEnabled && profileWithSameMountpoint->getEnabled())) {
+                    m_allProfilesValid = false;
                     QMessageBox::warning(this,
-                            tr("Action failed"),
+                            failedStr,
                             tr("'%1' has the same Icecast mountpoint as '%2'.\n"
                                "Two source connections to the same server "
                                "that have the same mountpoint can not be enabled "
@@ -256,8 +271,10 @@ void DlgPrefBroadcast::slotApply() {
 
         mountpoints.insert(profileName, profileMountpoint);
     }
+    m_allProfilesValid = true;
 
     applyModel();
+
     bool broadcastingEnabled = m_pBroadcastEnabled->toBool();
     if (!broadcastingEnabled && connectOnApply->isChecked()) {
         m_pBroadcastEnabled->set(true);
@@ -661,4 +678,8 @@ void DlgPrefBroadcast::onSectionResized() {
     // The last column is automatically resized to fill
     // the remaining width, thanks to stretchLastSection set to true.
     sender()->blockSignals(false);
+}
+
+bool DlgPrefBroadcast::okayToClose() const {
+    return m_allProfilesValid;
 }

--- a/src/preferences/dialog/dlgprefbroadcast.h
+++ b/src/preferences/dialog/dlgprefbroadcast.h
@@ -15,6 +15,10 @@ class DlgPrefBroadcast : public DlgPreferencePage, public Ui::DlgPrefBroadcastDl
                      BroadcastSettingsPointer pBroadcastSettings);
     virtual ~DlgPrefBroadcast();
 
+    /// False if at least one connection has passwords with invalid
+    /// characters or two Icecast connections have identical mount point
+    bool okayToClose() const override;
+
     QUrl helpUrl() const override;
 
   public slots:
@@ -56,4 +60,5 @@ class DlgPrefBroadcast : public DlgPreferencePage, public Ui::DlgPrefBroadcastDl
     BroadcastSettingsModel* m_pSettingsModel;
     ControlProxy* m_pBroadcastEnabled;
     BroadcastProfilePtr m_pProfileListSelection;
+    bool m_allProfilesValid;
 };

--- a/src/test/broadcastprofile_test.cpp
+++ b/src/test/broadcastprofile_test.cpp
@@ -35,6 +35,23 @@ TEST(BroadcastProfileTest, ForbiddenChars) {
     ASSERT_FALSE(BroadcastProfile::validName("<marquee>Scrolltext<marquee/>"));
     ASSERT_FALSE(BroadcastProfile::validName("It's called a \"profile\"."));
 
+    // Test if validPassword works properly with valid password
+    ASSERT_TRUE(BroadcastProfile::validPassword("superS4f3/&%#pass;word--"));
+
+    // Test if validPassword works properly with invalid password
+    ASSERT_FALSE(BroadcastProfile::validPassword("superS4f3/&%password--\r"));
+
+    // Test if control characters are properly removed
+    bool fixedString = false;
+    const QString invStr = QStringLiteral("yeah.com\r");
+    const QString retStr = BroadcastProfile::removeControlCharacters(
+            invStr,
+            QStringLiteral("someField"),
+            &fixedString);
+    ASSERT_TRUE(fixedString);
+    ASSERT_FALSE(invStr == retStr);
+    ASSERT_TRUE(retStr == QStringLiteral("yeah.com"));
+
     // Test if forbidden chars are properly stripped
     ASSERT_FALSE(BroadcastProfile::stripForbiddenChars(
                         "This is an invalid profile name: ?/").contains("?"));


### PR DESCRIPTION
This should avoid ugly situations like this https://mixxx.discourse.group/t/broadcasting-connection-problems/32861/3
Somehow, presumably due to wrong copy/paste, they got trailing `&#d;` (decoded to `\r`, Carriage Return) in the Host string which is nasty because control characters like this are not visible in the QLineEdit in Broadcast preferences.

Strings like this are now fixed and, when encountered while loading a profile from xml, the fixed profile is written back to disk.

Similar for the password, but it's not fixed by us.
Instead we show a warning when applying the invali config and ask the user to type it again (with a hint to linebreaks / copy/paste).

I also added some tests.
Let me know if you think this is sufficient or if we should extend the Regex.

-- Note: there's already a popup if the xml contains format-breaking characters