### PR TITLE
Pioneer DDJ-FLX4: Support for stems

### DIFF
--- a/res/controllers/Pioneer-DDJ-FLX4-script.js
+++ b/res/controllers/Pioneer-DDJ-FLX4-script.js
@@ -824,8 +824,8 @@ PioneerDDJFLX4.stemMutePadPressed = function(_channel, control, value, _status, 
         return;
     }
 
-    const nbStems = engine.getValue(group, "stem_count");
-    if (control - PioneerDDJFLX4.stemMutePadsFirstControl + 1 > nbStems) {
+    const stemCount = engine.getValue(group, "stem_count");
+    if (control - PioneerDDJFLX4.stemMutePadsFirstControl + 1 > stemCount) {
         return;
     }
 
@@ -843,15 +843,15 @@ PioneerDDJFLX4.stemMutePadShiftPressed = function(_channel, control, value, _sta
         return;
     }
 
-    const nbStems = engine.getValue(group, "stem_count");
-    if (control - PioneerDDJFLX4.stemMutePadsFirstControl + 1 > nbStems) {
+    const stemCount = engine.getValue(group, "stem_count");
+    if (control - PioneerDDJFLX4.stemMutePadsFirstControl + 1 > stemCount) {
         return;
     }
 
-    for (let i=1; i<=nbStems; i++) {
-        const stemGroup = `[${group.substring(1, group.length-1)}_Stem${i}]`;
+    for (let stemIdx=1; stemIdx<=stemCount; stemIdx++) {
+        const stemGroup = `[${group.substring(1, group.length-1)}_Stem${stemIdx}]`;
 
-        if (i + PioneerDDJFLX4.stemMutePadsFirstControl - 1 === control) {
+        if (stemIdx + PioneerDDJFLX4.stemMutePadsFirstControl - 1 === control) {
             engine.setValue(stemGroup, "mute", 0);
         } else {
             engine.setValue(stemGroup, "mute", 1);
@@ -916,10 +916,10 @@ PioneerDDJFLX4.stemMuteChanged = function(value, group, _control) {
     const stem = Number(channelStem[2]);
     const channel = `[Channel${deck}]`;
 
-    const nbStems = engine.getValue(channel, "stem_count");
+    const stemCount = engine.getValue(channel, "stem_count");
 
     let code = 0x00;
-    if (stem <= nbStems && value <= 0.5) {
+    if (stem <= stemCount && value <= 0.5) {
         code = 0x7f;
     }
 
@@ -938,7 +938,6 @@ PioneerDDJFLX4.stemFxChanged = function(value, group, _control) {
     const stem = Number(channelStem[2]);
     const channel = `[Channel${deck}]`;
 
-    console.log(`value=0x${value.toString(16)}, group=${group}, deck=${deck}, stem=${stem}, channel=${channel}`);
     for (let i=0; i<PioneerDDJFLX4.stemsPadsModesStatus[channel].length; i++) {
         midi.sendShortMsg(
             PioneerDDJFLX4.stemsPadsModesStatus[channel][i],

--- a/res/controllers/Pioneer-DDJ-FLX4-script.js
+++ b/res/controllers/Pioneer-DDJ-FLX4-script.js
@@ -824,7 +824,8 @@ PioneerDDJFLX4.stemMutePadPressed = function(_channel, control, value, _status, 
         return;
     }
 
-    const stemCount = engine.getValue(group, "stem_count");
+    const stemCount = Math.min(engine.getValue(group, "stem_count"), 4);
+
     if (control - PioneerDDJFLX4.stemMutePadsFirstControl + 1 > stemCount) {
         return;
     }
@@ -843,7 +844,8 @@ PioneerDDJFLX4.stemMutePadShiftPressed = function(_channel, control, value, _sta
         return;
     }
 
-    const stemCount = engine.getValue(group, "stem_count");
+    const stemCount = Math.min(engine.getValue(group, "stem_count"), 4);
+
     if (control - PioneerDDJFLX4.stemMutePadsFirstControl + 1 > stemCount) {
         return;
     }
@@ -891,7 +893,7 @@ PioneerDDJFLX4.stemFxPadShiftPressed = function(_channel, control, value, _statu
     engine.setValue(stemGroup, "next_chain_preset", 1);
 };
 
-PioneerDDJFLX4.stemCountChanged = function(value, group, _control) {
+PioneerDDJFLX4.stemCountChanged = function(_value, group, _control) {
 
     for (let stem=1; stem<=4; stem++) {
         // Stem mute pads
@@ -916,6 +918,10 @@ PioneerDDJFLX4.stemMuteChanged = function(value, group, _control) {
     const stem = Number(channelStem[2]);
     const channel = `[Channel${deck}]`;
 
+    if (stem > 4) {
+        return;
+    }
+
     const stemCount = engine.getValue(channel, "stem_count");
 
     let code = 0x00;
@@ -937,6 +943,10 @@ PioneerDDJFLX4.stemFxChanged = function(value, group, _control) {
     const deck = Number(channelStem[1]);
     const stem = Number(channelStem[2]);
     const channel = `[Channel${deck}]`;
+
+    if (stem > 4) {
+        return;
+    }
 
     for (let i=0; i<PioneerDDJFLX4.stemsPadsModesStatus[channel].length; i++) {
         midi.sendShortMsg(

--- a/res/controllers/Pioneer-DDJ-FLX4.midi.xml
+++ b/res/controllers/Pioneer-DDJ-FLX4.midi.xml
@@ -2269,7 +2269,7 @@
             <control>
                 <description>PAD 1 (DECK1) KEYSHIFT MODE - press - Toggle Stem 1</description>
                 <group>[Channel1]</group>
-                <key>PioneerDDJFLX4.keyShiftPadPressed</key>
+                <key>PioneerDDJFLX4.stemMutePadPressed</key>
                 <status>0x97</status>
                 <midino>0x70</midino>
                 <options>
@@ -2279,7 +2279,7 @@
             <control>
                 <description>PAD 1 +SHIFT (DECK1) KEYSHIFT MODE - press - Only Stem 1 active</description>
                 <group>[Channel1]</group>
-                <key>PioneerDDJFLX4.keyShiftPadShiftPressed</key>
+                <key>PioneerDDJFLX4.stemMutePadShiftPressed</key>
                 <status>0x98</status>
                 <midino>0x70</midino>
                 <options>
@@ -2289,7 +2289,7 @@
             <control>
                 <description>PAD 1 (DECK2) KEYSHIFT MODE - press - Toggle Stem 1</description>
                 <group>[Channel2]</group>
-                <key>PioneerDDJFLX4.keyShiftPadPressed</key>
+                <key>PioneerDDJFLX4.stemMutePadPressed</key>
                 <status>0x99</status>
                 <midino>0x70</midino>
                 <options>
@@ -2299,7 +2299,7 @@
             <control>
                 <description>PAD 1 +SHIFT (DECK2) KEYSHIFT MODE - press - Only Stem 1 active</description>
                 <group>[Channel2]</group>
-                <key>PioneerDDJFLX4.keyShiftPadShiftPressed</key>
+                <key>PioneerDDJFLX4.stemMutePadShiftPressed</key>
                 <status>0x9A</status>
                 <midino>0x70</midino>
                 <options>
@@ -2309,7 +2309,7 @@
             <control>
                 <description>PAD 2 (DECK1) KEYSHIFT MODE - press - Toggle Stem 2</description>
                 <group>[Channel1]</group>
-                <key>PioneerDDJFLX4.keyShiftPadPressed</key>
+                <key>PioneerDDJFLX4.stemMutePadPressed</key>
                 <status>0x97</status>
                 <midino>0x71</midino>
                 <options>
@@ -2319,7 +2319,7 @@
             <control>
                 <description>PAD 2 +SHIFT (DECK1) KEYSHIFT MODE - press - Only Stem 2 active</description>
                 <group>[Channel1]</group>
-                <key>PioneerDDJFLX4.keyShiftPadShiftPressed</key>
+                <key>PioneerDDJFLX4.stemMutePadShiftPressed</key>
                 <status>0x98</status>
                 <midino>0x71</midino>
                 <options>
@@ -2329,7 +2329,7 @@
             <control>
                 <description>PAD 2 (DECK2) KEYSHIFT MODE - press - Toggle Stem 2</description>
                 <group>[Channel2]</group>
-                <key>PioneerDDJFLX4.keyShiftPadPressed</key>
+                <key>PioneerDDJFLX4.stemMutePadPressed</key>
                 <status>0x99</status>
                 <midino>0x71</midino>
                 <options>
@@ -2339,7 +2339,7 @@
             <control>
                 <description>PAD 2 +SHIFT (DECK2) KEYSHIFT MODE - press - Only Stem 2 active</description>
                 <group>[Channel2]</group>
-                <key>PioneerDDJFLX4.keyShiftPadShiftPressed</key>
+                <key>PioneerDDJFLX4.stemMutePadShiftPressed</key>
                 <status>0x9A</status>
                 <midino>0x71</midino>
                 <options>
@@ -2349,7 +2349,7 @@
             <control>
                 <description>PAD 3 (DECK1) KEYSHIFT MODE - press - Toggle Stem 3</description>
                 <group>[Channel1]</group>
-                <key>PioneerDDJFLX4.keyShiftPadPressed</key>
+                <key>PioneerDDJFLX4.stemMutePadPressed</key>
                 <status>0x97</status>
                 <midino>0x72</midino>
                 <options>
@@ -2359,7 +2359,7 @@
             <control>
                 <description>PAD 3 +SHIFT (DECK1) KEYSHIFT MODE - press - Only Stem 3 active</description>
                 <group>[Channel1]</group>
-                <key>PioneerDDJFLX4.keyShiftPadShiftPressed</key>
+                <key>PioneerDDJFLX4.stemMutePadShiftPressed</key>
                 <status>0x98</status>
                 <midino>0x72</midino>
                 <options>
@@ -2369,7 +2369,7 @@
             <control>
                 <description>PAD 3 (DECK2) KEYSHIFT MODE - press - Toggle Stem 3</description>
                 <group>[Channel2]</group>
-                <key>PioneerDDJFLX4.keyShiftPadPressed</key>
+                <key>PioneerDDJFLX4.stemMutePadPressed</key>
                 <status>0x99</status>
                 <midino>0x72</midino>
                 <options>
@@ -2379,7 +2379,7 @@
             <control>
                 <description>PAD 3 +SHIFT (DECK2) KEYSHIFT MODE - press - Only Stem 3 active</description>
                 <group>[Channel2]</group>
-                <key>PioneerDDJFLX4.keyShiftPadShiftPressed</key>
+                <key>PioneerDDJFLX4.stemMutePadShiftPressed</key>
                 <status>0x9A</status>
                 <midino>0x72</midino>
                 <options>
@@ -2389,7 +2389,7 @@
             <control>
                 <description>PAD 4 (DECK1) KEYSHIFT MODE - press - Toggle Stem 4</description>
                 <group>[Channel1]</group>
-                <key>PioneerDDJFLX4.keyShiftPadPressed</key>
+                <key>PioneerDDJFLX4.stemMutePadPressed</key>
                 <status>0x97</status>
                 <midino>0x73</midino>
                 <options>
@@ -2399,7 +2399,7 @@
             <control>
                 <description>PAD 4 +SHIFT (DECK1) KEYSHIFT MODE - press - Only Stem 4 active</description>
                 <group>[Channel1]</group>
-                <key>PioneerDDJFLX4.keyShiftPadShiftPressed</key>
+                <key>PioneerDDJFLX4.stemMutePadShiftPressed</key>
                 <status>0x98</status>
                 <midino>0x73</midino>
                 <options>
@@ -2409,7 +2409,7 @@
             <control>
                 <description>PAD 4 (DECK2) KEYSHIFT MODE - press - Toggle Stem 4</description>
                 <group>[Channel2]</group>
-                <key>PioneerDDJFLX4.keyShiftPadPressed</key>
+                <key>PioneerDDJFLX4.stemMutePadPressed</key>
                 <status>0x99</status>
                 <midino>0x73</midino>
                 <options>
@@ -2419,7 +2419,7 @@
             <control>
                 <description>PAD 4 +SHIFT (DECK2) KEYSHIFT MODE - press - Only Stem 4 active</description>
                 <group>[Channel2]</group>
-                <key>PioneerDDJFLX4.keyShiftPadShiftPressed</key>
+                <key>PioneerDDJFLX4.stemMutePadShiftPressed</key>
                 <status>0x9A</status>
                 <midino>0x73</midino>
                 <options>
@@ -2427,9 +2427,9 @@
                 </options>
             </control>
             <control>
-                <description>PAD 5 (DECK1) KEYSHIFT MODE - press - Toggle Stem 1</description>
+                <description>PAD 5 (DECK1) KEYSHIFT MODE - press - Toggle Stem 1 FX</description>
                 <group>[Channel1]</group>
-                <key>PioneerDDJFLX4.keyShiftPadPressed</key>
+                <key>PioneerDDJFLX4.stemFxPadPressed</key>
                 <status>0x97</status>
                 <midino>0x74</midino>
                 <options>
@@ -2437,9 +2437,9 @@
                 </options>
             </control>
             <control>
-                <description>PAD 5 +SHIFT (DECK1) KEYSHIFT MODE - press - Only Stem 1 active</description>
+                <description>PAD 5 +SHIFT (DECK1) KEYSHIFT MODE - press - Only Stem 1 FX active</description>
                 <group>[Channel1]</group>
-                <key>PioneerDDJFLX4.keyShiftPadShiftPressed</key>
+                <key>PioneerDDJFLX4.stemFxPadShiftPressed</key>
                 <status>0x98</status>
                 <midino>0x74</midino>
                 <options>
@@ -2447,9 +2447,9 @@
                 </options>
             </control>
             <control>
-                <description>PAD 5 (DECK2) KEYSHIFT MODE - press - Toggle Stem 1</description>
+                <description>PAD 5 (DECK2) KEYSHIFT MODE - press - Toggle Stem 1 FX</description>
                 <group>[Channel2]</group>
-                <key>PioneerDDJFLX4.keyShiftPadPressed</key>
+                <key>PioneerDDJFLX4.stemFxPadPressed</key>
                 <status>0x99</status>
                 <midino>0x74</midino>
                 <options>
@@ -2457,9 +2457,9 @@
                 </options>
             </control>
             <control>
-                <description>PAD 5 +SHIFT (DECK2) KEYSHIFT MODE - press - Only Stem 1 active</description>
+                <description>PAD 5 +SHIFT (DECK2) KEYSHIFT MODE - press - Only Stem 1 FX active</description>
                 <group>[Channel2]</group>
-                <key>PioneerDDJFLX4.keyShiftPadShiftPressed</key>
+                <key>PioneerDDJFLX4.stemFxPadShiftPressed</key>
                 <status>0x9A</status>
                 <midino>0x74</midino>
                 <options>
@@ -2467,9 +2467,9 @@
                 </options>
             </control>
             <control>
-                <description>PAD 6 (DECK1) KEYSHIFT MODE - press - Toggle Stem 2</description>
+                <description>PAD 6 (DECK1) KEYSHIFT MODE - press - Toggle Stem 2 FX</description>
                 <group>[Channel1]</group>
-                <key>PioneerDDJFLX4.keyShiftPadPressed</key>
+                <key>PioneerDDJFLX4.stemFxPadPressed</key>
                 <status>0x97</status>
                 <midino>0x75</midino>
                 <options>
@@ -2477,9 +2477,9 @@
                 </options>
             </control>
             <control>
-                <description>PAD 6 +SHIFT (DECK1) KEYSHIFT MODE - press - Only Stem 2 active</description>
+                <description>PAD 6 +SHIFT (DECK1) KEYSHIFT MODE - press - Only Stem 2 FX active</description>
                 <group>[Channel1]</group>
-                <key>PioneerDDJFLX4.keyShiftPadShiftPressed</key>
+                <key>PioneerDDJFLX4.stemFxPadShiftPressed</key>
                 <status>0x98</status>
                 <midino>0x75</midino>
                 <options>
@@ -2487,9 +2487,9 @@
                 </options>
             </control>
             <control>
-                <description>PAD 6 (DECK2) KEYSHIFT MODE - press - Toggle Stem 2</description>
+                <description>PAD 6 (DECK2) KEYSHIFT MODE - press - Toggle Stem 2 FX</description>
                 <group>[Channel2]</group>
-                <key>PioneerDDJFLX4.keyShiftPadPressed</key>
+                <key>PioneerDDJFLX4.stemFxPadPressed</key>
                 <status>0x99</status>
                 <midino>0x75</midino>
                 <options>
@@ -2497,9 +2497,9 @@
                 </options>
             </control>
             <control>
-                <description>PAD 6 +SHIFT (DECK2) KEYSHIFT MODE - press - Only Stem 2 active</description>
+                <description>PAD 6 +SHIFT (DECK2) KEYSHIFT MODE - press - Only Stem 2 FX active</description>
                 <group>[Channel2]</group>
-                <key>PioneerDDJFLX4.keyShiftPadShiftPressed</key>
+                <key>PioneerDDJFLX4.stemFxPadShiftPressed</key>
                 <status>0x9A</status>
                 <midino>0x75</midino>
                 <options>
@@ -2507,9 +2507,9 @@
                 </options>
             </control>
             <control>
-                <description>PAD 7 (DECK1) KEYSHIFT MODE - press - Toggle Stem 3</description>
+                <description>PAD 7 (DECK1) KEYSHIFT MODE - press - Toggle Stem 3 FX</description>
                 <group>[Channel1]</group>
-                <key>PioneerDDJFLX4.keyShiftPadPressed</key>
+                <key>PioneerDDJFLX4.stemFxPadPressed</key>
                 <status>0x97</status>
                 <midino>0x76</midino>
                 <options>
@@ -2517,9 +2517,9 @@
                 </options>
             </control>
             <control>
-                <description>PAD 7 +SHIFT (DECK1) KEYSHIFT MODE - press - Only Stem 3 active</description>
+                <description>PAD 7 +SHIFT (DECK1) KEYSHIFT MODE - press - Only Stem 3 FX active</description>
                 <group>[Channel1]</group>
-                <key>PioneerDDJFLX4.keyShiftPadShiftPressed</key>
+                <key>PioneerDDJFLX4.stemFxPadShiftPressed</key>
                 <status>0x98</status>
                 <midino>0x76</midino>
                 <options>
@@ -2527,9 +2527,9 @@
                 </options>
             </control>
             <control>
-                <description>PAD 7 (DECK2) KEYSHIFT MODE - press - Toggle Stem 3</description>
+                <description>PAD 7 (DECK2) KEYSHIFT MODE - press - Toggle Stem 3 FX</description>
                 <group>[Channel2]</group>
-                <key>PioneerDDJFLX4.keyShiftPadPressed</key>
+                <key>PioneerDDJFLX4.stemFxPadPressed</key>
                 <status>0x99</status>
                 <midino>0x76</midino>
                 <options>
@@ -2537,9 +2537,9 @@
                 </options>
             </control>
             <control>
-                <description>PAD 7 +SHIFT (DECK2) KEYSHIFT MODE - press - Only Stem 3 active</description>
+                <description>PAD 7 +SHIFT (DECK2) KEYSHIFT MODE - press - Only Stem 3 FX active</description>
                 <group>[Channel2]</group>
-                <key>PioneerDDJFLX4.keyShiftPadShiftPressed</key>
+                <key>PioneerDDJFLX4.stemFxPadShiftPressed</key>
                 <status>0x9A</status>
                 <midino>0x76</midino>
                 <options>
@@ -2547,9 +2547,9 @@
                 </options>
             </control>
             <control>
-                <description>PAD 8 (DECK1) KEYSHIFT MODE - press - Toggle Stem 4</description>
+                <description>PAD 8 (DECK1) KEYSHIFT MODE - press - Toggle Stem 4 FX</description>
                 <group>[Channel1]</group>
-                <key>PioneerDDJFLX4.keyShiftPadPressed</key>
+                <key>PioneerDDJFLX4.stemFxPadPressed</key>
                 <status>0x97</status>
                 <midino>0x77</midino>
                 <options>
@@ -2557,9 +2557,9 @@
                 </options>
             </control>
             <control>
-                <description>PAD 8 +SHIFT (DECK1) KEYSHIFT MODE - press - Only Stem 4 active</description>
+                <description>PAD 8 +SHIFT (DECK1) KEYSHIFT MODE - press - Only Stem 4 FX active</description>
                 <group>[Channel1]</group>
-                <key>PioneerDDJFLX4.keyShiftPadShiftPressed</key>
+                <key>PioneerDDJFLX4.stemFxPadShiftPressed</key>
                 <status>0x98</status>
                 <midino>0x77</midino>
                 <options>
@@ -2567,9 +2567,9 @@
                 </options>
             </control>
             <control>
-                <description>PAD 8 (DECK2) KEYSHIFT MODE - press - Toggle Stem 4</description>
+                <description>PAD 8 (DECK2) KEYSHIFT MODE - press - Toggle Stem 4 FX</description>
                 <group>[Channel2]</group>
-                <key>PioneerDDJFLX4.keyShiftPadPressed</key>
+                <key>PioneerDDJFLX4.stemFxPadPressed</key>
                 <status>0x99</status>
                 <midino>0x77</midino>
                 <options>
@@ -2577,9 +2577,9 @@
                 </options>
             </control>
             <control>
-                <description>PAD 8 +SHIFT (DECK2) KEYSHIFT MODE - press - Only Stem 4 active</description>
+                <description>PAD 8 +SHIFT (DECK2) KEYSHIFT MODE - press - Only Stem 4 FX active</description>
                 <group>[Channel2]</group>
-                <key>PioneerDDJFLX4.keyShiftPadShiftPressed</key>
+                <key>PioneerDDJFLX4.stemFxPadShiftPressed</key>
                 <status>0x9A</status>
                 <midino>0x77</midino>
                 <options>

--- a/res/controllers/Pioneer-DDJ-FLX4.midi.xml
+++ b/res/controllers/Pioneer-DDJ-FLX4.midi.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<MixxxMIDIPreset schemaVersion="1" mixxxVersion="2.3">
+<MixxxControllerPreset schemaVersion="1" mixxxVersion="2.6">
     <info>
         <name>Pioneer DDJ-FLX4</name>
         <author>Robert904</author>
-        <description>Midi Mapping for the Pioneer DDJ-FLX4 (based on DDJ-400 mapping)</description>
+        <description>Controller Midi Mapping for the Pioneer DDJ-FLX4 (based on DDJ-400 mapping)</description>
         <manual>pioneer_ddj_FLX4</manual>
         <forums>https://mixxx.discourse.group/t/pioneer-ddj-flx4</forums>
     </info>
@@ -2265,6 +2265,328 @@
             </control>
             <!-- SAMPLER MODE END -->
 
+            <!-- KEYSHIFT MODE START -->
+            <control>
+                <description>PAD 1 (DECK1) KEYSHIFT MODE - press - Toggle Stem 1</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.keyShiftPadPressed</key>
+                <status>0x97</status>
+                <midino>0x70</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 1 +SHIFT (DECK1) KEYSHIFT MODE - press - Only Stem 1 active</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.keyShiftPadShiftPressed</key>
+                <status>0x98</status>
+                <midino>0x70</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 1 (DECK2) KEYSHIFT MODE - press - Toggle Stem 1</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.keyShiftPadPressed</key>
+                <status>0x99</status>
+                <midino>0x70</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 1 +SHIFT (DECK2) KEYSHIFT MODE - press - Only Stem 1 active</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.keyShiftPadShiftPressed</key>
+                <status>0x9A</status>
+                <midino>0x70</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 2 (DECK1) KEYSHIFT MODE - press - Toggle Stem 2</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.keyShiftPadPressed</key>
+                <status>0x97</status>
+                <midino>0x71</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 2 +SHIFT (DECK1) KEYSHIFT MODE - press - Only Stem 2 active</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.keyShiftPadShiftPressed</key>
+                <status>0x98</status>
+                <midino>0x71</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 2 (DECK2) KEYSHIFT MODE - press - Toggle Stem 2</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.keyShiftPadPressed</key>
+                <status>0x99</status>
+                <midino>0x71</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 2 +SHIFT (DECK2) KEYSHIFT MODE - press - Only Stem 2 active</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.keyShiftPadShiftPressed</key>
+                <status>0x9A</status>
+                <midino>0x71</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 3 (DECK1) KEYSHIFT MODE - press - Toggle Stem 3</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.keyShiftPadPressed</key>
+                <status>0x97</status>
+                <midino>0x72</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 3 +SHIFT (DECK1) KEYSHIFT MODE - press - Only Stem 3 active</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.keyShiftPadShiftPressed</key>
+                <status>0x98</status>
+                <midino>0x72</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 3 (DECK2) KEYSHIFT MODE - press - Toggle Stem 3</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.keyShiftPadPressed</key>
+                <status>0x99</status>
+                <midino>0x72</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 3 +SHIFT (DECK2) KEYSHIFT MODE - press - Only Stem 3 active</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.keyShiftPadShiftPressed</key>
+                <status>0x9A</status>
+                <midino>0x72</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 4 (DECK1) KEYSHIFT MODE - press - Toggle Stem 4</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.keyShiftPadPressed</key>
+                <status>0x97</status>
+                <midino>0x73</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 4 +SHIFT (DECK1) KEYSHIFT MODE - press - Only Stem 4 active</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.keyShiftPadShiftPressed</key>
+                <status>0x98</status>
+                <midino>0x73</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 4 (DECK2) KEYSHIFT MODE - press - Toggle Stem 4</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.keyShiftPadPressed</key>
+                <status>0x99</status>
+                <midino>0x73</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 4 +SHIFT (DECK2) KEYSHIFT MODE - press - Only Stem 4 active</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.keyShiftPadShiftPressed</key>
+                <status>0x9A</status>
+                <midino>0x73</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 5 (DECK1) KEYSHIFT MODE - press - Toggle Stem 1</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.keyShiftPadPressed</key>
+                <status>0x97</status>
+                <midino>0x74</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 5 +SHIFT (DECK1) KEYSHIFT MODE - press - Only Stem 1 active</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.keyShiftPadShiftPressed</key>
+                <status>0x98</status>
+                <midino>0x74</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 5 (DECK2) KEYSHIFT MODE - press - Toggle Stem 1</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.keyShiftPadPressed</key>
+                <status>0x99</status>
+                <midino>0x74</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 5 +SHIFT (DECK2) KEYSHIFT MODE - press - Only Stem 1 active</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.keyShiftPadShiftPressed</key>
+                <status>0x9A</status>
+                <midino>0x74</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 6 (DECK1) KEYSHIFT MODE - press - Toggle Stem 2</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.keyShiftPadPressed</key>
+                <status>0x97</status>
+                <midino>0x75</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 6 +SHIFT (DECK1) KEYSHIFT MODE - press - Only Stem 2 active</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.keyShiftPadShiftPressed</key>
+                <status>0x98</status>
+                <midino>0x75</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 6 (DECK2) KEYSHIFT MODE - press - Toggle Stem 2</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.keyShiftPadPressed</key>
+                <status>0x99</status>
+                <midino>0x75</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 6 +SHIFT (DECK2) KEYSHIFT MODE - press - Only Stem 2 active</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.keyShiftPadShiftPressed</key>
+                <status>0x9A</status>
+                <midino>0x75</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 7 (DECK1) KEYSHIFT MODE - press - Toggle Stem 3</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.keyShiftPadPressed</key>
+                <status>0x97</status>
+                <midino>0x76</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 7 +SHIFT (DECK1) KEYSHIFT MODE - press - Only Stem 3 active</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.keyShiftPadShiftPressed</key>
+                <status>0x98</status>
+                <midino>0x76</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 7 (DECK2) KEYSHIFT MODE - press - Toggle Stem 3</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.keyShiftPadPressed</key>
+                <status>0x99</status>
+                <midino>0x76</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 7 +SHIFT (DECK2) KEYSHIFT MODE - press - Only Stem 3 active</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.keyShiftPadShiftPressed</key>
+                <status>0x9A</status>
+                <midino>0x76</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 8 (DECK1) KEYSHIFT MODE - press - Toggle Stem 4</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.keyShiftPadPressed</key>
+                <status>0x97</status>
+                <midino>0x77</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 8 +SHIFT (DECK1) KEYSHIFT MODE - press - Only Stem 4 active</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.keyShiftPadShiftPressed</key>
+                <status>0x98</status>
+                <midino>0x77</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 8 (DECK2) KEYSHIFT MODE - press - Toggle Stem 4</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.keyShiftPadPressed</key>
+                <status>0x99</status>
+                <midino>0x77</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 8 +SHIFT (DECK2) KEYSHIFT MODE - press - Only Stem 4 active</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.keyShiftPadShiftPressed</key>
+                <status>0x9A</status>
+                <midino>0x77</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+
             <!-- PAD Section END -->
         </controls>
         <outputs>
@@ -3203,4 +3525,4 @@
             <!-- SAMPLER Mode Pads end-->
         </outputs>
     </controller>
-</MixxxMIDIPreset>
+</MixxxControllerPreset>


### PR DESCRIPTION
This PR implement a mapping to mute/unmute specific stems for "stem.mp4" files.
It therefore requires Mixxx 2.6

- It maps the pads of the controller in "KeyShift" mode to individual stems.
- Pads are lit up at song loading on a deck when the related stem exists
- pushing on the pad mutes the stem and turns off the light, pushing again unmutes it and turns on the light back.
- Shift-pad unmutes the selected one and mutes all the other.

Some comments:
- It has been tested using version 2.6-beta-92-g649873701f on windows
- The code does not assume the maximum number of stems, it could support up to 8 of them even if Mixx seems to support maximum 4 for the time being
- A related PR is done as well for the documentation update
- The mapping has just been posted on the [related controller forum thread](https://mixxx.discourse.group/t/pioneer-ddj-flx4/26553/54?u=robert904) to allow testing by others

