### PR TITLE
add hotkey to edit track comment in deck, take 2

### DIFF
--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -866,6 +866,24 @@ bool BaseTrackPlayerImpl::isTrackMenuControlAvailable() {
     }
 }
 
+bool BaseTrackPlayerImpl::isTrackCommentEditControlAvailable() {
+    if (m_pTrackCommentEditControl == nullptr) {
+        // Create the control and return true so LegacySkinParser knows it should
+        // connect our signal to WTrackProperty.
+        m_pTrackCommentEditControl = std::make_unique<ControlPushButton>(
+                ConfigKey(getGroup(), "edit_track_comment"));
+        qWarning() << "--- created comment edit control for" << getGroup();
+        m_pTrackCommentEditControl->connectValueChangeRequest(
+                this,
+                [this](double value) {
+                    if (value > 0) {
+                        emit trackCommentEditRequest();
+                    }
+                });
+    }
+    return true;
+}
+
 void BaseTrackPlayerImpl::slotSetAndConfirmTrackMenuControl(bool visible) {
     VERIFY_OR_DEBUG_ASSERT(m_pShowTrackMenuControl) {
         return;

--- a/src/mixer/basetrackplayer.h
+++ b/src/mixer/basetrackplayer.h
@@ -47,6 +47,9 @@ class BaseTrackPlayer : public BasePlayer {
     virtual bool isTrackMenuControlAvailable() {
         return false;
     };
+    virtual bool isTrackCommentEditControlAvailable() {
+        return false;
+    };
 
   public slots:
 #ifdef __STEM__
@@ -74,6 +77,8 @@ class BaseTrackPlayer : public BasePlayer {
     void noVinylControlInputConfigured();
     void trackRatingChanged(int rating);
     void trackMenuChangeRequest(bool show);
+    void trackCommentEditRequest();
+    void trackFileRemoveRequest();
 };
 
 class BaseTrackPlayerImpl : public BaseTrackPlayer {
@@ -103,6 +108,8 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
     /// PushButtons persist skin reload, connected widgets don't, i.e. the
     /// connection is removed on skin reload and available again afterwards.
     bool isTrackMenuControlAvailable() final;
+    /// Same for the 'edit track comment' control
+    bool isTrackCommentEditControlAvailable() final;
     /// For testing, loads a fake track.
     TrackPointer loadFakeTrack(bool bPlay, double filebpm);
 
@@ -222,6 +229,7 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
     std::unique_ptr<ControlObject> m_pShiftCues;
 
     std::unique_ptr<ControlPushButton> m_pShowTrackMenuControl;
+    std::unique_ptr<ControlPushButton> m_pTrackCommentEditControl;
 
     std::unique_ptr<ControlPushButton> m_pStarsUp;
     std::unique_ptr<ControlPushButton> m_pStarsDown;

--- a/src/skin/legacy/legacyskinparser.cpp
+++ b/src/skin/legacy/legacyskinparser.cpp
@@ -1202,6 +1202,16 @@ QWidget* LegacySkinParser::parseTrackProperty(const QDomElement& node) {
                     &BaseTrackPlayer::slotSetAndConfirmTrackMenuControl,
                     Qt::DirectConnection);
         }
+        // For editing the track comment tag we connect every 'comment' WTrackProperty.
+        // Only the visible one will attempt to open the editor.
+        if (pTrackProperty->isComment() && pPlayer->isTrackCommentEditControlAvailable()) {
+            qWarning() << "--- parser: connect comment edit control for" << group;
+            connect(pPlayer,
+                    &BaseTrackPlayer::trackCommentEditRequest,
+                    pTrackProperty,
+                    &WTrackProperty::slotEditTrackComment,
+                    Qt::DirectConnection);
+        }
     }
 
     // Relay for the label's WTrackMenu (which is created only on demand):

--- a/src/widget/wtrackproperty.cpp
+++ b/src/widget/wtrackproperty.cpp
@@ -333,6 +333,11 @@ void WTrackProperty::slotCommitEditorData(const QString& text) {
     const QString trackText = getPropertyStringFromTrack(m_editProperty);
     QString editorText = text;
     if (m_isComment) {
+        // Transform ALL occurrences of \n into linebreaks.
+        // Existing linebreaks are not affected.
+        QString cr(QChar::CarriageReturn);
+        cr.append(QChar::LineFeed);
+        editorText.replace("\\n", cr);
         // For multi-line comments, the editor received only the first line.
         // In order to keep the other lines, we need to replace
         // the first line of the original text with the editor text.

--- a/src/widget/wtrackproperty.h
+++ b/src/widget/wtrackproperty.h
@@ -93,6 +93,7 @@ class WTrackProperty : public WLabel, public TrackDropTarget {
     const UserSettingsPointer m_pConfig;
     Library* m_pLibrary;
     const bool m_isMainDeck;
+    bool m_isComment;
     TrackPointer m_pCurrentTrack;
 
     QString m_displayProperty;

--- a/src/widget/wtrackproperty.h
+++ b/src/widget/wtrackproperty.h
@@ -56,6 +56,10 @@ class WTrackProperty : public WLabel, public TrackDropTarget {
 
     void setup(const QDomNode& node, const SkinContext& context) override;
 
+    bool isComment() {
+        return m_isComment;
+    }
+
   signals:
     void trackDropped(const QString& filename, const QString& group) override;
     void cloneDeck(const QString& sourceGroup, const QString& targetGroup) override;
@@ -68,6 +72,7 @@ class WTrackProperty : public WLabel, public TrackDropTarget {
     void slotTrackLoaded(TrackPointer pTrack);
     void slotLoadingTrack(TrackPointer pNewTrack, TrackPointer pOldTrack);
     void slotShowTrackMenuChangeRequest(bool show);
+    void slotEditTrackComment();
 
   protected:
     void contextMenuEvent(QContextMenuEvent* event) override;
@@ -86,6 +91,7 @@ class WTrackProperty : public WLabel, public TrackDropTarget {
 
     void updateLabel();
     const QString getPropertyStringFromTrack(QString& property) const;
+    void openEditor();
     void restyleAndRepaint();
 
     void ensureTrackMenuIsCreated();


### PR DESCRIPTION
This is a retake of #15521 which has accidentally been merged prematurely
____
Here's yet another small mod I find very helpful for preparing/editing tracks while using only the keyboard (+ controller).
If you use a skin that has a comment widget in decks (WTrackProperty), ~~press `Alt`+[deck number] to open the property editor.~~
bind `[ChannelN],edit_track_comment` to a key in Custom.kbd.cfg

It's implemented like the track menu control, except that not **all** track comment widgets receive the signal and only the visible one opens the editor.
It is failproof in the sense that there should be no issue with even multiple comment labels visible for one deck.

So the workflow is simply this, no mouse/trackpad involved:
* press the [edit key/combo] for deck 1
* edit text
* Enter, done
_____
Plus these mods:
* show only first comment line in editor
allows to add tag-like comments to the first line while keeping stuff like lyrics or release info out of sight
(in the library only the first line is displayed anyway)
* add linebreak with `\n`
allows to push above mentioned extra info down

