### PR TITLE
Fix quantisation of the effects in case of engine samplerate != track samplerate

### DIFF
--- a/src/effects/backends/builtin/autopaneffect.cpp
+++ b/src/effects/backends/builtin/autopaneffect.cpp
@@ -91,7 +91,7 @@ void AutoPanEffect::processChannel(
     if (groupFeatures.beat_length.has_value()) {
         // period is a number of beats
         double beats = std::max(roundToFraction(period, 2), 0.25);
-        period = beats * groupFeatures.beat_length->frames;
+        period = beats * groupFeatures.beat_length->seconds * engineParameters.sampleRate();
 
         // TODO(xxx) sync phase
         //if (groupFeatures.has_beat_fraction) {

--- a/src/effects/backends/builtin/echoeffect.cpp
+++ b/src/effects/backends/builtin/echoeffect.cpp
@@ -131,7 +131,7 @@ void EchoEffect::processChannel(
     const auto feedback_current = static_cast<CSAMPLE_GAIN>(m_pFeedbackParameter->value());
     const auto pingpong_frac = static_cast<CSAMPLE_GAIN>(m_pPingPongParameter->value());
 
-    int delay_frames;
+    double delay_seconds;
     if (groupFeatures.beat_length.has_value()) {
         // period is a number of beats
         if (m_pQuantizeParameter->toBool()) {
@@ -142,17 +142,18 @@ void EchoEffect::processChannel(
         } else if (period < 1 / 8.0) {
             period = 1 / 8.0;
         }
-        delay_frames = static_cast<int>(period * groupFeatures.beat_length->frames);
+        delay_seconds = period * groupFeatures.beat_length->seconds;
     } else {
         // period is a number of seconds
         period = std::max(period, 1 / 8.0);
-        delay_frames = static_cast<int>(period * engineParameters.sampleRate());
+        delay_seconds = period;
     }
-    VERIFY_OR_DEBUG_ASSERT(delay_frames > 0) {
-        delay_frames = 1;
+    VERIFY_OR_DEBUG_ASSERT(delay_seconds > 0) {
+        delay_seconds = 1 / engineParameters.sampleRate();
     }
 
-    int delay_samples = delay_frames * engineParameters.channelCount();
+    int delay_samples = static_cast<int>(delay_seconds *
+            engineParameters.channelCount() * engineParameters.sampleRate());
     VERIFY_OR_DEBUG_ASSERT(delay_samples <= pGroupState->delay_buf.size()) {
         delay_samples = pGroupState->delay_buf.size();
     }

--- a/src/effects/backends/builtin/flangereffect.cpp
+++ b/src/effects/backends/builtin/flangereffect.cpp
@@ -123,7 +123,9 @@ void FlangerEffect::processChannel(
         if (m_pTripletParameter->toBool()) {
             lfoPeriodParameter /= 3.0;
         }
-        lfoPeriodFrames = lfoPeriodParameter * groupFeatures.beat_length->frames;
+        lfoPeriodFrames = lfoPeriodParameter *
+                groupFeatures.beat_length->seconds *
+                engineParameters.sampleRate();
     } else {
         // lfoPeriodParameter is a number of seconds
         lfoPeriodFrames = std::max(lfoPeriodParameter, kMinLfoBeats) *

--- a/src/effects/backends/builtin/glitcheffect.cpp
+++ b/src/effects/backends/builtin/glitcheffect.cpp
@@ -79,7 +79,7 @@ void GlitchEffect::processChannel(
     // The minimum of the parameter is zero so the exact center of the knob is 1 beat.
     double period = m_pDelayParameter->value();
 
-    int delay_frames;
+    double delay_seconds;
     double min_delay;
     if (groupFeatures.beat_length.has_value()) {
         if (m_pQuantizeParameter->toBool()) {
@@ -89,14 +89,14 @@ void GlitchEffect::processChannel(
             }
         }
         period = std::max(period, 1 / 8.0);
-        delay_frames = static_cast<int>(period * groupFeatures.beat_length->frames);
-        min_delay = 1 / 8.0 * groupFeatures.beat_length->frames;
+        delay_seconds = static_cast<int>(period * groupFeatures.beat_length->seconds);
+        min_delay = 1 / 8.0 * groupFeatures.beat_length->seconds;
     } else {
-        delay_frames = static_cast<int>(period * engineParameters.sampleRate());
-        min_delay = 1 / 8.0 * engineParameters.sampleRate();
+        delay_seconds = period;
+        min_delay = 1 / 8.0;
     }
 
-    if (delay_frames < min_delay) {
+    if (delay_seconds < min_delay) {
         SampleUtil::copy(
                 pOutput,
                 pInput,
@@ -104,7 +104,8 @@ void GlitchEffect::processChannel(
         return;
     }
 
-    int delay_samples = delay_frames * engineParameters.channelCount();
+    int delay_samples = static_cast<int>(delay_seconds *
+            engineParameters.channelCount() * engineParameters.sampleRate());
     pGroupState->sample_count += engineParameters.samplesPerBuffer();
     if (pGroupState->sample_count >= delay_samples) {
         // If the delay parameter is at its maximum value, we don't update the `repeat_buf`

--- a/src/effects/backends/builtin/metronomeeffect.cpp
+++ b/src/effects/backends/builtin/metronomeeffect.cpp
@@ -113,7 +113,7 @@ void MetronomeEffect::processChannel(
         // Sync enabled and have a track with beats
         if (groupFeatures.beat_length.has_value() &&
                 groupFeatures.beat_length->scratch_rate != 0.0) {
-            double beatLength = groupFeatures.beat_length->frames /
+            double beatLength = groupFeatures.beat_length->seconds * engineParameters.sampleRate() /
                     groupFeatures.beat_length->scratch_rate;
             double beatToBufferEnd;
             if (beatLength > 0) {

--- a/src/effects/backends/builtin/phasereffect.cpp
+++ b/src/effects/backends/builtin/phasereffect.cpp
@@ -138,7 +138,8 @@ void PhaserEffect::processChannel(
         if (m_pTripletParameter->toBool()) {
             periodParameter /= 3.0;
         }
-        periodSamples = periodParameter * groupFeatures.beat_length->frames;
+        periodSamples = periodParameter * groupFeatures.beat_length->seconds *
+                engineParameters.sampleRate();
     } else {
         // periodParameter is a number of seconds
         periodSamples = std::max(periodParameter, 1 / 4.0) * engineParameters.sampleRate();

--- a/src/effects/backends/builtin/tremoloeffect.cpp
+++ b/src/effects/backends/builtin/tremoloeffect.cpp
@@ -140,7 +140,7 @@ void TremoloEffect::processChannel(
     if (enableState == EffectEnableState::Enabling || quantizeEnabling || tripletDisabling) {
         if (gf.beat_length.has_value() && gf.beat_fraction_buffer_end.has_value()) {
             currentFrame = static_cast<unsigned int>(*gf.beat_fraction_buffer_end *
-                    gf.beat_length->frames);
+                    gf.beat_length->seconds * engineParameters.sampleRate());
         } else {
             currentFrame = 0;
         }
@@ -158,7 +158,8 @@ void TremoloEffect::processChannel(
                 rate *= 3.0;
             }
         }
-        const auto framePerBeat = static_cast<int>(gf.beat_length->frames);
+        const auto framePerBeat = static_cast<int>(
+                gf.beat_length->seconds * engineParameters.sampleRate());
         framePerPeriod = static_cast<int>(framePerBeat / rate);
     } else {
         framePerPeriod = static_cast<int>(engineParameters.sampleRate() / rate);

--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -1298,7 +1298,9 @@ void BpmControl::collectFeatures(GroupFeatureState* pGroupFeatures, double speed
                 &beatFraction)) {
         const double rateRatio = m_pRateRatio->get();
         if (rateRatio != 0.0) {
-            pGroupFeatures->beat_length = {beatLengthFrames / rateRatio, speed / rateRatio};
+            pGroupFeatures->beat_length = {
+                    beatLengthFrames / info.sampleRate.toDouble() / rateRatio,
+                    speed / rateRatio};
         }
         pGroupFeatures->beat_fraction_buffer_end = beatFraction;
     }

--- a/src/engine/effects/groupfeaturestate.h
+++ b/src/engine/effects/groupfeaturestate.h
@@ -4,7 +4,7 @@
 
 struct GroupFeatureBeatLength {
     // Beat length adjusted by the rate slider
-    double frames;
+    double seconds;
     // Rate change by temporary actions like scratching
     // and not the rate slider.
     double scratch_rate;

--- a/src/engine/enginebuffer.cpp
+++ b/src/engine/enginebuffer.cpp
@@ -1124,7 +1124,7 @@ void EngineBuffer::processTrackLocked(
         }
     }
 
-    m_actual_speed = (m_playPos - playpos_old) / (iBufferSize / 2);
+    m_actual_speed = (m_playPos - playpos_old) / (iBufferSize / 2) / baseSampleRate;
     // qDebug() << "Ramped Speed" << m_actual_speed / m_speed_old;
 
     for (const auto& pControl : std::as_const(m_engineControls)) {


### PR DESCRIPTION
This fixes issue #15300 
Now the beat length is reported in seconds, to avoid any samplerate related misunderstandings. 