### PR TITLE
focus tracks view when selecting a track via deck track menu

### DIFF
--- a/src/widget/wlibrary.cpp
+++ b/src/widget/wlibrary.cpp
@@ -127,7 +127,7 @@ bool WLibrary::isTrackInCurrentView(const TrackId& trackId) {
 }
 
 void WLibrary::slotSelectTrackInActiveTrackView(const TrackId& trackId) {
-    //qDebug() << "WLibrary::slotSelectTrackInActiveTrackView" << trackId;
+    // qDebug() << "WLibrary::slotSelectTrackInActiveTrackView" << trackId;
     if (!trackId.isValid()) {
         return;
     }
@@ -135,7 +135,10 @@ void WLibrary::slotSelectTrackInActiveTrackView(const TrackId& trackId) {
     if (!pTracksView) {
         return;
     }
-    pTracksView->selectTrack(trackId);
+    if (pTracksView->isTrackInCurrentView(trackId)) {
+        pTracksView->selectTrack(trackId);
+        pTracksView->setFocus();
+    }
 }
 
 void WLibrary::saveCurrentViewState() const {


### PR DESCRIPTION
This saves a few controller clicks if the focus is currently in the searchbar or tree view.