### PR TITLE
Touchscreen on Windows 11: disable touch -> mouse event translation

### DIFF
--- a/src/widget/wwidget.cpp
+++ b/src/widget/wwidget.cpp
@@ -49,6 +49,12 @@ bool WWidget::event(QEvent* e) {
                     static_cast<int>(fonti.pixelSize() * m_scaleFactor));
         }
     } else if (isEnabled()) {
+        // With Qt6 on Windows this touch -> mouse translation is apparently not
+        // required anymore, QMouseEvents are received correctly.
+        // If enabled we receive both QTouch and QMouse events, see
+        // https://github.com/mixxxdj/mixxx/issues/15546
+        // TODO Test with other OS, maybe we can drop it entirely.
+#ifndef __WINDOWS__
         switch(e->type()) {
         case QEvent::TouchBegin:
         case QEvent::TouchUpdate:
@@ -114,6 +120,7 @@ bool WWidget::event(QEvent* e) {
         default:
             break;
         }
+#endif
     }
 
     return QWidget::event(e);


### PR DESCRIPTION
Fixes #15546 on Windows 11 by disabling our QTouchEvent -> QMouseEvent translation 

Apparently Qt receives both the mouse events (from us) as well as Windows' mouse events.
Not sure if any of the devs did test touch after we switched to Qt6?

### TODO
- [x] test on Windows 10
