### PR TITLE
Interface preferences: separate user & built-in skins in drop-down

### DIFF
--- a/src/preferences/dialog/dlgprefinterface.h
+++ b/src/preferences/dialog/dlgprefinterface.h
@@ -40,6 +40,7 @@ class DlgPrefInterface : public DlgPreferencePage, public Ui::DlgPrefControlsDlg
     void slotSetScheme(int);
     void slotSetSkinDescription();
     void slotSetSkinPreview();
+    void slotUpdateSkins();
     void slotUpdateSchemes();
 
   signals:

--- a/src/skin/skinloader.h
+++ b/src/skin/skinloader.h
@@ -32,12 +32,16 @@ class SkinLoader : public QObject {
     SkinPointer getConfiguredSkin() const;
     QString getDefaultSkinName() const;
     QList<QDir> getSkinSearchPaths() const;
-    QList<SkinPointer> getSkins() const;
+    QDir getUserSkinDir() const;
+    QDir getSytemSkinDir() const;
+    QList<SkinPointer> getUserSkins() const;
+    QList<SkinPointer> getSystemSkins() const;
 
   private slots:
     void slotNumMicsChanged(double numMics);
 
   private:
+    QList<SkinPointer> getSkinsFromDir(const QDir& dir) const;
     QString pickResizableSkin(const QString& oldSkin) const;
     SkinPointer skinFromDirectory(const QDir& dir) const;
 


### PR DESCRIPTION
Closes #15545 

Looks like this now:
<img width="532" height="308" alt="image" src="https://github.com/user-attachments/assets/23344abc-3273-4304-8772-6dcebe5cd867" />

Extra: skins are re-scanned every time the preferences are opened
= no need to restart Mixxx to include a new skin