### PR TITLE
fix Reloop Beatmix controller overriding persisted fx routing

### DIFF
--- a/res/controllers/Reloop-Beatmix-2-4-scripts.js
+++ b/res/controllers/Reloop-Beatmix-2-4-scripts.js
@@ -172,10 +172,7 @@ ReloopBeatmix24.connectControls = function() {
             ReloopBeatmix24.loopDefined);
         engine.trigger(group, "loop_end_position");
         engine.softTakeover(group, "rate", true);
-        engine.setValue("[EffectRack1_EffectUnit1]",
-            "group_" + group + "_enable", 0);
-        engine.setValue("[EffectRack1_EffectUnit2]",
-            "group_" + group + "_enable", 0);
+        // Update Fx controls from the state that is restored from fx config
         engine.trigger("[EffectRack1_EffectUnit1]", `group_${ group }_enable`);
         engine.trigger("[EffectRack1_EffectUnit2]", `group_${ group }_enable`);
         channelPlaying[group] = !!engine.getValue(group, "play");
@@ -192,10 +189,6 @@ ReloopBeatmix24.connectControls = function() {
             ReloopBeatmix24.SamplerPlay);
         engine.trigger(group, "play");
     }
-
-    // Effects reset
-    engine.setValue("[EffectRack1_EffectUnit1]", "group_[Master]_enable", 0);
-    engine.setValue("[EffectRack1_EffectUnit2]", "group_[Master]_enable", 0);
 };
 
 ReloopBeatmix24.init = function(id, _debug) {


### PR DESCRIPTION
the Reloop Beatmix 2/4 controller script was explicitly setting fx routing to disabled on init, overriding the persisted settings from usersettings.

fx routing for decks 3/4 appeared to work because those channels were registered later, after the controller script ran. decks 1/2 were registered first and then immediately overridden by the controller script.

removed the engine.setValue calls that forced fx routing to 0, keeping only the trigger calls needed to sync controller leds with the actual (now persisted) state.

fixes #14917