### PR TITLE
implement shift+jog wheel seek for Reloop Beatmix 2/4

### DIFF
--- a/res/controllers/Reloop-Beatmix-2-4-scripts.js
+++ b/res/controllers/Reloop-Beatmix-2-4-scripts.js
@@ -409,9 +409,17 @@ ReloopBeatmix24.WheelTouch = function(channel, control, value, status, group) {
 ReloopBeatmix24.WheelTurn = function(channel, control, value, status, group) {
     const newValue = value - 64;
     const deck = parseInt(group.substr(8, 1), 10);
+    const isShifted = (control === 0x70);
 
-    // In either case, register the movement
-    if (engine.isScratching(deck)) {
+    if (isShifted) {
+        // Shift+jog wheel: quick seek through track
+        if (engine.getValue(group, "track_loaded")) {
+            const currentPos = engine.getValue(group, "playposition");
+            // Seek by ~0.5% of track per tick
+            const seekAmount = (newValue / 64) * 0.005;
+            engine.setValue(group, "playposition", Math.max(0, Math.min(1, currentPos + seekAmount)));
+        }
+    } else if (engine.isScratching(deck)) {
         engine.scratchTick(deck, newValue); // Scratch!
     } else {
         engine.setValue(group, "jog", newValue / 5); // Pitch bend


### PR DESCRIPTION
the manual documents that holding shift and turning the jog wheel should quick seek through the track, but this was never implemented. the xml mapping had both normal and shifted jog wheel mapped to the same function which didn't differentiate between them.

added detection of the shifted state (control 0x70 vs 0x60) and implemented seeking by adjusting playposition when shift is held. the seek rate is approximately 0.5% of track length per jog tick, providing smooth and responsive seeking.

fixes #12334