### PR TITLE
Fix setting engine thread name

### DIFF
--- a/src/engine/enginemixer.cpp
+++ b/src/engine/enginemixer.cpp
@@ -162,6 +162,7 @@ EngineMixer::EngineMixer(UserSettingsPointer pConfig,
     m_bBusOutputConnected[EngineChannel::CENTER] = false;
     m_bBusOutputConnected[EngineChannel::RIGHT] = false;
     m_bExternalRecordBroadcastInputConnected = false;
+    m_pWorkerScheduler->setObjectName("Engine");
     m_pWorkerScheduler->start(QThread::HighPriority);
 
     m_pSampleRate->addAlias(ConfigKey(group, QStringLiteral("samplerate")));
@@ -361,11 +362,6 @@ void EngineMixer::processChannels(std::size_t bufferSize) {
 void EngineMixer::process(const std::size_t bufferSize) {
     DEBUG_ASSERT(bufferSize <= static_cast<int>(kMaxEngineSamples));
 
-    static bool haveSetName = false;
-    if (!haveSetName) {
-        QThread::currentThread()->setObjectName("Engine");
-        haveSetName = true;
-    }
     // Trace t("EngineMixer::process");
 
     bool mainEnabled = m_pMainEnabled->toBool();


### PR DESCRIPTION
## Background
Mixxx sets an OS-visible thread name which facilitates performance monitoring and debugging.

## Problem
Mixxx sets the engine thread name after the thread has started, which is contrary to the QThread documentation that says that the [thread name must be set before the thread is started](https://doc.qt.io/qt-6/qthread.html). As a result, the engine thread does not have a name on FreeBSD. Unclear whether or not this affects Linux.

## Fix
Set the thread name before starting the thread.