### PR TITLE
add quick access to controller learning wizard via options menu

### DIFF
--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -27,6 +27,7 @@
 #include "controllers/scripting/legacy/controllerscriptenginelegacy.h"
 #include "defs_urls.h"
 #include "moc_dlgprefcontroller.cpp"
+#include "preferences/dialog/dlgpreferences.h"
 #include "preferences/usersettings.h"
 #include "util/cmdlineargs.h"
 #include "util/desktophelper.h"
@@ -88,7 +89,7 @@ DlgPrefController::DlgPrefController(
           m_pOutputProxyModel(nullptr),
           m_GuiInitialized(false),
           m_bDirty(false),
-          m_bSuppressPrefsDialogOnClose(false),
+          m_bPrefsDialogWasVisible(false),
           m_inputMappingsTabIndex(-1),
           m_outputMappingsTabIndex(-1),
           m_settingsTabIndex(-1),
@@ -366,8 +367,13 @@ void DlgPrefController::slotRecreateControlPickerMenu() {
 }
 
 void DlgPrefController::showLearningWizard(bool suppressPrefsDialogOnClose) {
-    m_bSuppressPrefsDialogOnClose = suppressPrefsDialogOnClose;
-    
+    Q_UNUSED(suppressPrefsDialogOnClose);
+    QWidget* pPrefsDialog = this;
+    while (pPrefsDialog && !qobject_cast<DlgPreferences*>(pPrefsDialog)) {
+        pPrefsDialog = pPrefsDialog->parentWidget();
+    }
+    m_bPrefsDialogWasVisible = pPrefsDialog && pPrefsDialog->isVisible();
+
     if (isDirty()) {
         QMessageBox::StandardButton result = QMessageBox::question(this,
                 tr("Apply device settings?"),
@@ -417,7 +423,9 @@ void DlgPrefController::showLearningWizard(bool suppressPrefsDialogOnClose) {
             this,
             &DlgPrefController::midiInputMappingsLearned);
 
-    emit mappingStarted();
+    if (m_bPrefsDialogWasVisible) {
+        emit mappingStarted();
+    }
     connect(m_pDlgControllerLearning,
             &DlgControllerLearning::stopLearning,
             this,
@@ -426,10 +434,10 @@ void DlgPrefController::showLearningWizard(bool suppressPrefsDialogOnClose) {
 
 void DlgPrefController::slotStopLearning() {
     VERIFY_OR_DEBUG_ASSERT(m_pMapping) {
-        if (!m_bSuppressPrefsDialogOnClose) {
+        if (m_bPrefsDialogWasVisible) {
             emit mappingEnded();
         }
-        m_bSuppressPrefsDialogOnClose = false;
+        m_bPrefsDialogWasVisible = false;
         return;
     }
 
@@ -461,11 +469,10 @@ void DlgPrefController::slotStopLearning() {
         }
     }
 
-    // Only emit mappingEnded if not launched from menu
-    if (!m_bSuppressPrefsDialogOnClose) {
+    if (m_bPrefsDialogWasVisible) {
         emit mappingEnded();
     }
-    m_bSuppressPrefsDialogOnClose = false;
+    m_bPrefsDialogWasVisible = false;
 }
 
 void DlgPrefController::midiInputMappingsLearned(

--- a/src/controllers/dlgprefcontroller.cpp
+++ b/src/controllers/dlgprefcontroller.cpp
@@ -398,6 +398,11 @@ void DlgPrefController::showLearningWizard(bool suppressPrefsDialogOnClose) {
         showMapping(m_pMapping);
     }
 
+    // Hide the prefs dialog before showing the wizard. The wizard is parented
+    // to this page (a child of the prefs dialog), so hiding the prefs dialog
+    // after show() would cascade-hide the wizard too.
+    emit mappingStarted();
+
     // Note that DlgControllerLearning is set to delete itself on close using
     // the Qt::WA_DeleteOnClose attribute (so this "new" doesn't leak memory)
     m_pDlgControllerLearning =
@@ -422,10 +427,6 @@ void DlgPrefController::showLearningWizard(bool suppressPrefsDialogOnClose) {
             &DlgControllerLearning::inputMappingsLearned,
             this,
             &DlgPrefController::midiInputMappingsLearned);
-
-    if (m_bPrefsDialogWasVisible) {
-        emit mappingStarted();
-    }
     connect(m_pDlgControllerLearning,
             &DlgControllerLearning::stopLearning,
             this,

--- a/src/controllers/dlgprefcontroller.h
+++ b/src/controllers/dlgprefcontroller.h
@@ -42,6 +42,14 @@ class DlgPrefController : public DlgPreferencePage {
     QUrl helpUrl() const override;
     void keyPressEvent(QKeyEvent* pEvent) override;
 
+    Controller* controller() const {
+        return m_pController;
+    }
+
+    // Open the MIDI learning wizard for this controller
+    // suppressPrefsDialogOnClose: if true, don't show preferences dialog when wizard closes
+    void showLearningWizard(bool suppressPrefsDialogOnClose = false);
+
   public slots:
     /// Called when the preference dialog (not this page) is shown to the user.
     void slotUpdate() override;
@@ -83,7 +91,6 @@ class DlgPrefController : public DlgPreferencePage {
 
     // Input mappings
     void addInputMapping();
-    void showLearningWizard();
     void removeInputMappings();
     void clearAllInputMappings();
 
@@ -150,6 +157,7 @@ class DlgPrefController : public DlgPreferencePage {
     ControllerMappingTableProxyModel* m_pOutputProxyModel;
     bool m_GuiInitialized;
     bool m_bDirty;
+    bool m_bSuppressPrefsDialogOnClose;
     int m_inputMappingsTabIndex;  // Index of the input mappings tab
     int m_outputMappingsTabIndex; // Index of the output mappings tab
     int m_settingsTabIndex;       // Index of the settings tab

--- a/src/controllers/dlgprefcontroller.h
+++ b/src/controllers/dlgprefcontroller.h
@@ -157,7 +157,7 @@ class DlgPrefController : public DlgPreferencePage {
     ControllerMappingTableProxyModel* m_pOutputProxyModel;
     bool m_GuiInitialized;
     bool m_bDirty;
-    bool m_bSuppressPrefsDialogOnClose;
+    bool m_bPrefsDialogWasVisible;
     int m_inputMappingsTabIndex;  // Index of the input mappings tab
     int m_outputMappingsTabIndex; // Index of the output mappings tab
     int m_settingsTabIndex;       // Index of the settings tab

--- a/src/controllers/dlgprefcontrollers.cpp
+++ b/src/controllers/dlgprefcontrollers.cpp
@@ -120,19 +120,19 @@ void DlgPrefControllers::slotUpdate() {
 }
 
 void DlgPrefControllers::slotCancel() {
-    for (DlgPrefController* pControllerDlg : std::as_const(m_controllerPages)) {
+    for (DlgPrefController* pControllerDlg : m_controllerPages) {
         pControllerDlg->slotCancel();
     }
 }
 
 void DlgPrefControllers::slotApply() {
-    for (DlgPrefController* pControllerDlg : std::as_const(m_controllerPages)) {
+    for (DlgPrefController* pControllerDlg : m_controllerPages) {
         pControllerDlg->slotApply();
     }
 }
 
 void DlgPrefControllers::slotResetToDefaults() {
-    for (DlgPrefController* pControllerDlg : std::as_const(m_controllerPages)) {
+    for (DlgPrefController* pControllerDlg : m_controllerPages) {
         pControllerDlg->slotResetToDefaults();
     }
 }
@@ -172,7 +172,7 @@ void DlgPrefControllers::destroyControllerWidgets() {
     // to keep this dialog and the controllermanager consistent.
     QList<Controller*> controllerList =
             m_pControllerManager->getControllerList(false, true);
-    for (auto* pController : std::as_const(controllerList)) {
+    for (auto* pController : controllerList) {
         pController->disconnect(this);
     }
     while (!m_controllerPages.isEmpty()) {
@@ -203,7 +203,7 @@ void DlgPrefControllers::setupControllerWidgets() {
 
     std::sort(controllerList.begin(), controllerList.end(), controllerCompare);
 
-    for (auto* pController : std::as_const(controllerList)) {
+    for (auto* pController : controllerList) {
         auto pControllerDlg = make_parented<DlgPrefController>(
                 this, pController, m_pControllerManager, m_pConfig);
         connect(pControllerDlg,

--- a/src/controllers/dlgprefcontrollers.cpp
+++ b/src/controllers/dlgprefcontrollers.cpp
@@ -288,3 +288,19 @@ void DlgPrefControllers::slotMidiThroughChanged(bool checked) {
 }
 #endif
 #endif
+
+void DlgPrefControllers::openLearningWizard(Controller* pController) {
+    if (!pController) {
+        return;
+    }
+
+    // Find the DlgPrefController for this controller by matching the controller pointer
+    for (int i = 0; i < m_controllerPages.size(); ++i) {
+        DlgPrefController* pControllerDlg = m_controllerPages.at(i);
+        if (pControllerDlg && pControllerDlg->controller() == pController) {
+            // Pass true to suppress preferences dialog when wizard closes
+            pControllerDlg->showLearningWizard(true);
+            return;
+        }
+    }
+}

--- a/src/controllers/dlgprefcontrollers.cpp
+++ b/src/controllers/dlgprefcontrollers.cpp
@@ -120,19 +120,19 @@ void DlgPrefControllers::slotUpdate() {
 }
 
 void DlgPrefControllers::slotCancel() {
-    for (DlgPrefController* pControllerDlg : m_controllerPages) {
+    for (DlgPrefController* pControllerDlg : std::as_const(m_controllerPages)) {
         pControllerDlg->slotCancel();
     }
 }
 
 void DlgPrefControllers::slotApply() {
-    for (DlgPrefController* pControllerDlg : m_controllerPages) {
+    for (DlgPrefController* pControllerDlg : std::as_const(m_controllerPages)) {
         pControllerDlg->slotApply();
     }
 }
 
 void DlgPrefControllers::slotResetToDefaults() {
-    for (DlgPrefController* pControllerDlg : m_controllerPages) {
+    for (DlgPrefController* pControllerDlg : std::as_const(m_controllerPages)) {
         pControllerDlg->slotResetToDefaults();
     }
 }
@@ -172,7 +172,7 @@ void DlgPrefControllers::destroyControllerWidgets() {
     // to keep this dialog and the controllermanager consistent.
     QList<Controller*> controllerList =
             m_pControllerManager->getControllerList(false, true);
-    for (auto* pController : controllerList) {
+    for (auto* pController : std::as_const(controllerList)) {
         pController->disconnect(this);
     }
     while (!m_controllerPages.isEmpty()) {
@@ -203,7 +203,7 @@ void DlgPrefControllers::setupControllerWidgets() {
 
     std::sort(controllerList.begin(), controllerList.end(), controllerCompare);
 
-    for (auto* pController : controllerList) {
+    for (auto* pController : std::as_const(controllerList)) {
         auto pControllerDlg = make_parented<DlgPrefController>(
                 this, pController, m_pControllerManager, m_pConfig);
         connect(pControllerDlg,
@@ -295,7 +295,7 @@ void DlgPrefControllers::openLearningWizard(Controller* pController) {
     }
 
     // Find the DlgPrefController for this controller by matching the controller pointer
-    for (auto* pControllerDlg : m_controllerPages) {
+    for (auto* pControllerDlg : std::as_const(m_controllerPages)) {
         if (pControllerDlg->controller() == pController) {
             pControllerDlg->showLearningWizard(true);
             return;

--- a/src/controllers/dlgprefcontrollers.cpp
+++ b/src/controllers/dlgprefcontrollers.cpp
@@ -295,10 +295,8 @@ void DlgPrefControllers::openLearningWizard(Controller* pController) {
     }
 
     // Find the DlgPrefController for this controller by matching the controller pointer
-    for (int i = 0; i < m_controllerPages.size(); ++i) {
-        DlgPrefController* pControllerDlg = m_controllerPages.at(i);
-        if (pControllerDlg && pControllerDlg->controller() == pController) {
-            // Pass true to suppress preferences dialog when wizard closes
+    for (auto* pControllerDlg : m_controllerPages) {
+        if (pControllerDlg->controller() == pController) {
             pControllerDlg->showLearningWizard(true);
             return;
         }

--- a/src/controllers/dlgprefcontrollers.h
+++ b/src/controllers/dlgprefcontrollers.h
@@ -7,6 +7,7 @@
 #include "preferences/usersettings.h"
 #include "util/parented_ptr.h"
 
+class Controller;
 class ControlProxy;
 class DlgPreferences;
 class DlgPrefController;
@@ -28,6 +29,7 @@ class DlgPrefControllers : public DlgPreferencePage, public Ui::DlgPrefControlle
 
     bool handleTreeItemClick(QTreeWidgetItem* clickedItem);
     QUrl helpUrl() const override;
+    void openLearningWizard(Controller* pController);
 
   public slots:
     /// Called when the preference dialog (not this page) is shown to the user.

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -956,6 +956,13 @@ void MixxxMainWindow::connectMenuBar() {
                 this,
                 &MixxxMainWindow::slotControllersChanged,
                 Qt::UniqueConnection);
+        // mappingApplied fires after a controller is opened post-startup
+        // (devicesChanged is only emitted once, on startup)
+        connect(m_pCoreServices->getControllerManager().get(),
+                &ControllerManager::mappingApplied,
+                this,
+                &MixxxMainWindow::slotUpdateControllerLearningMenu,
+                Qt::UniqueConnection);
         connect(m_pMenuBar,
                 &WMainMenuBar::openControllerLearningWizard,
                 this,

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -966,17 +966,16 @@ void MixxxMainWindow::connectMenuBar() {
     // Controller learning wizard menu
     if (m_pCoreServices->getControllerManager()) {
         connect(m_pCoreServices->getControllerManager().get(),
-                &ControllerManager::mappingApplied,
+                &ControllerManager::devicesChanged,
                 this,
-                &MixxxMainWindow::slotUpdateControllerLearningMenu,
+                &MixxxMainWindow::slotControllersChanged,
                 Qt::UniqueConnection);
         connect(m_pMenuBar,
                 &WMainMenuBar::openControllerLearningWizard,
                 this,
                 &MixxxMainWindow::slotOpenControllerLearningWizard,
                 Qt::UniqueConnection);
-        // Initialize the menu with current controllers
-        slotUpdateControllerLearningMenu();
+        slotControllersChanged();
     }
 
     if (m_pCoreServices->getTrackCollectionManager()) {
@@ -1179,12 +1178,41 @@ void MixxxMainWindow::slotNoVinylControlInputConfigured() {
     }
 }
 
+void MixxxMainWindow::slotControllersChanged() {
+    if (!m_pCoreServices->getControllerManager()) {
+        return;
+    }
+
+    QList<Controller*> allControllers =
+            m_pCoreServices->getControllerManager()->getControllerList(
+                    false, true);
+
+    QList<Controller*> trackedControllers = m_controllerConnections.keys();
+    for (Controller* pController : std::as_const(trackedControllers)) {
+        if (!allControllers.contains(pController)) {
+            disconnect(m_controllerConnections.value(pController));
+            m_controllerConnections.remove(pController);
+        }
+    }
+
+    for (Controller* pController : std::as_const(allControllers)) {
+        if (pController && !m_controllerConnections.contains(pController)) {
+            QMetaObject::Connection conn = connect(pController,
+                    &Controller::openChanged,
+                    this,
+                    &MixxxMainWindow::slotUpdateControllerLearningMenu);
+            m_controllerConnections.insert(pController, conn);
+        }
+    }
+
+    slotUpdateControllerLearningMenu();
+}
+
 void MixxxMainWindow::slotUpdateControllerLearningMenu() {
     if (!m_pCoreServices->getControllerManager()) {
         return;
     }
-    // Only show enabled/opened input controllers
-    // Use getControllerList(false, true) to get input devices only
+
     QList<Controller*> allControllers =
             m_pCoreServices->getControllerManager()->getControllerList(
                     false, true);

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -23,6 +23,8 @@
 #include "widget/winitialglwidget.h"
 #endif
 
+#include "controllers/controller.h"
+#include "controllers/controllermanager.h"
 #include "controllers/keyboard/keyboardeventfilter.h"
 #include "coreservices.h"
 #include "defs_urls.h"
@@ -961,6 +963,22 @@ void MixxxMainWindow::connectMenuBar() {
         m_pMenuBar->onNumberOfDecksChanged(pPlayerManager->numberOfDecks());
     }
 
+    // Controller learning wizard menu
+    if (m_pCoreServices->getControllerManager()) {
+        connect(m_pCoreServices->getControllerManager().get(),
+                &ControllerManager::mappingApplied,
+                this,
+                &MixxxMainWindow::slotUpdateControllerLearningMenu,
+                Qt::UniqueConnection);
+        connect(m_pMenuBar,
+                &WMainMenuBar::openControllerLearningWizard,
+                this,
+                &MixxxMainWindow::slotOpenControllerLearningWizard,
+                Qt::UniqueConnection);
+        // Initialize the menu with current controllers
+        slotUpdateControllerLearningMenu();
+    }
+
     if (m_pCoreServices->getTrackCollectionManager()) {
         connect(m_pMenuBar,
                 &WMainMenuBar::rescanLibrary,
@@ -1159,6 +1177,32 @@ void MixxxMainWindow::slotNoVinylControlInputConfigured() {
         m_pPrefDlg->show();
         m_pPrefDlg->showSoundHardwarePage(mixxx::preferences::SoundHardwareTab::Input);
     }
+}
+
+void MixxxMainWindow::slotUpdateControllerLearningMenu() {
+    if (!m_pCoreServices->getControllerManager()) {
+        return;
+    }
+    // Only show enabled/opened input controllers
+    // Use getControllerList(false, true) to get input devices only
+    QList<Controller*> allControllers =
+            m_pCoreServices->getControllerManager()->getControllerList(
+                    false, true);
+    QList<Controller*> enabledControllers;
+    for (Controller* pController : std::as_const(allControllers)) {
+        if (pController && pController->isOpen()) {
+            enabledControllers.append(pController);
+        }
+    }
+    m_pMenuBar->onControllersChanged(enabledControllers);
+}
+
+void MixxxMainWindow::slotOpenControllerLearningWizard(Controller* pController) {
+    if (!pController) {
+        return;
+    }
+    // Open the learning wizard directly for this controller
+    m_pPrefDlg->openControllerLearningWizard(pController);
 }
 
 void MixxxMainWindow::slotNoDeckPassthroughInputConfigured() {

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -970,6 +970,13 @@ void MixxxMainWindow::connectMenuBar() {
                 this,
                 &MixxxMainWindow::slotControllersChanged,
                 Qt::UniqueConnection);
+        // mappingApplied fires after a controller is opened post-startup
+        // (devicesChanged is only emitted once, on startup)
+        connect(m_pCoreServices->getControllerManager().get(),
+                &ControllerManager::mappingApplied,
+                this,
+                &MixxxMainWindow::slotUpdateControllerLearningMenu,
+                Qt::UniqueConnection);
         connect(m_pMenuBar,
                 &WMainMenuBar::openControllerLearningWizard,
                 this,

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -23,6 +23,8 @@
 #include "widget/winitialglwidget.h"
 #endif
 
+#include "controllers/controller.h"
+#include "controllers/controllermanager.h"
 #include "controllers/keyboard/keyboardeventfilter.h"
 #include "coreservices.h"
 #include "defs_urls.h"
@@ -947,6 +949,22 @@ void MixxxMainWindow::connectMenuBar() {
         m_pMenuBar->onNumberOfDecksChanged(pPlayerManager->numberOfDecks());
     }
 
+    // Controller learning wizard menu
+    if (m_pCoreServices->getControllerManager()) {
+        connect(m_pCoreServices->getControllerManager().get(),
+                &ControllerManager::mappingApplied,
+                this,
+                &MixxxMainWindow::slotUpdateControllerLearningMenu,
+                Qt::UniqueConnection);
+        connect(m_pMenuBar,
+                &WMainMenuBar::openControllerLearningWizard,
+                this,
+                &MixxxMainWindow::slotOpenControllerLearningWizard,
+                Qt::UniqueConnection);
+        // Initialize the menu with current controllers
+        slotUpdateControllerLearningMenu();
+    }
+
     if (m_pCoreServices->getTrackCollectionManager()) {
         connect(m_pMenuBar,
                 &WMainMenuBar::rescanLibrary,
@@ -1145,6 +1163,32 @@ void MixxxMainWindow::slotNoVinylControlInputConfigured() {
         m_pPrefDlg->show();
         m_pPrefDlg->showSoundHardwarePage(mixxx::preferences::SoundHardwareTab::Input);
     }
+}
+
+void MixxxMainWindow::slotUpdateControllerLearningMenu() {
+    if (!m_pCoreServices->getControllerManager()) {
+        return;
+    }
+    // Only show enabled/opened input controllers
+    // Use getControllerList(false, true) to get input devices only
+    QList<Controller*> allControllers =
+            m_pCoreServices->getControllerManager()->getControllerList(
+                    false, true);
+    QList<Controller*> enabledControllers;
+    for (Controller* pController : std::as_const(allControllers)) {
+        if (pController && pController->isOpen()) {
+            enabledControllers.append(pController);
+        }
+    }
+    m_pMenuBar->onControllersChanged(enabledControllers);
+}
+
+void MixxxMainWindow::slotOpenControllerLearningWizard(Controller* pController) {
+    if (!pController) {
+        return;
+    }
+    // Open the learning wizard directly for this controller
+    m_pPrefDlg->openControllerLearningWizard(pController);
 }
 
 void MixxxMainWindow::slotNoDeckPassthroughInputConfigured() {

--- a/src/mixxxmainwindow.h
+++ b/src/mixxxmainwindow.h
@@ -83,6 +83,7 @@ class MixxxMainWindow : public QMainWindow {
     void slotNoDeckPassthroughInputConfigured();
     void slotNoVinylControlInputConfigured();
     /// Controller learning wizard menu management
+    void slotControllersChanged();
     void slotUpdateControllerLearningMenu();
     void slotOpenControllerLearningWizard(Controller* pController);
 #ifndef __APPLE__
@@ -166,4 +167,5 @@ class MixxxMainWindow : public QMainWindow {
     mixxx::preferences::ScreenSaver m_inhibitScreensaver;
 
     QSet<ControlObject*> m_skinCreatedControls;
+    QHash<Controller*, QMetaObject::Connection> m_controllerConnections;
 };

--- a/src/mixxxmainwindow.h
+++ b/src/mixxxmainwindow.h
@@ -10,6 +10,7 @@
 #include "util/parented_ptr.h"
 
 class ControlObject;
+class Controller;
 class DlgDeveloperTools;
 class DlgPreferences;
 class DlgKeywheel;
@@ -81,6 +82,9 @@ class MixxxMainWindow : public QMainWindow {
     void slotNoAuxiliaryInputConfigured();
     void slotNoDeckPassthroughInputConfigured();
     void slotNoVinylControlInputConfigured();
+    /// Controller learning wizard menu management
+    void slotUpdateControllerLearningMenu();
+    void slotOpenControllerLearningWizard(Controller* pController);
 #ifndef __APPLE__
     /// Update whether the menubar is toggled pressing the Alt key and show/hide
     /// it accordingly

--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -12,6 +12,7 @@
 #include <QStyle>
 #include <QtGlobal>
 
+#include "controllers/controller.h"
 #include "controllers/dlgprefcontrollers.h"
 #include "library/library.h"
 #include "library/trackcollectionmanager.h"
@@ -316,8 +317,14 @@ void DlgPreferences::showSoundHardwarePage(
         std::optional<mixxx::preferences::SoundHardwareTab> tab) {
     switchToPage(m_soundPage.pTreeItem->text(0), m_soundPage.pDlg);
     contentsTreeWidget->setCurrentItem(m_soundPage.pTreeItem);
-    if (tab.has_value()) {
+    if (tab) {
         m_pSoundDlg->selectIOTab(*tab);
+    }
+}
+
+void DlgPreferences::openControllerLearningWizard(Controller* pController) {
+    if (m_pControllersDlg) {
+        m_pControllersDlg->openLearningWizard(pController);
     }
 }
 

--- a/src/preferences/dialog/dlgpreferences.cpp
+++ b/src/preferences/dialog/dlgpreferences.cpp
@@ -12,6 +12,7 @@
 #include <QStyle>
 #include <QtGlobal>
 
+#include "controllers/controller.h"
 #include "controllers/dlgprefcontrollers.h"
 #include "library/library.h"
 #include "library/trackcollectionmanager.h"
@@ -316,13 +317,19 @@ void DlgPreferences::showSoundHardwarePage(
         std::optional<mixxx::preferences::SoundHardwareTab> tab) {
     switchToPage(m_soundPage.pTreeItem->text(0), m_soundPage.pDlg);
     contentsTreeWidget->setCurrentItem(m_soundPage.pTreeItem);
-    if (tab.has_value()) {
+    if (tab) {
         m_pSoundDlg->selectIOTab(*tab);
     }
 }
 
 void DlgPreferences::showSoundHardwareInputPage() {
     showSoundHardwarePage(mixxx::preferences::SoundHardwareTab::Input);
+}
+
+void DlgPreferences::openControllerLearningWizard(Controller* pController) {
+    if (m_pControllersDlg) {
+        m_pControllersDlg->openLearningWizard(pController);
+    }
 }
 
 bool DlgPreferences::eventFilter(QObject* o, QEvent* e) {

--- a/src/preferences/dialog/dlgpreferences.h
+++ b/src/preferences/dialog/dlgpreferences.h
@@ -14,6 +14,7 @@
 #include "preferences/settingsmanager.h"
 #include "preferences/usersettings.h"
 
+class Controller;
 class ControllerManager;
 class DlgPrefControllers;
 class DlgPrefSound;
@@ -68,6 +69,7 @@ class DlgPreferences : public QDialog, public Ui::DlgPreferencesDlg {
     void showSoundHardwarePage(
             std::optional<mixxx::preferences::SoundHardwareTab> tab =
                     std::nullopt);
+    void openControllerLearningWizard(Controller* pController);
     void slotButtonPressed(QAbstractButton* pButton);
   signals:
     void closeDlg();

--- a/src/preferences/dialog/dlgpreferences.h
+++ b/src/preferences/dialog/dlgpreferences.h
@@ -14,6 +14,7 @@
 #include "preferences/settingsmanager.h"
 #include "preferences/usersettings.h"
 
+class Controller;
 class ControllerManager;
 class DlgPrefControllers;
 class DlgPrefSound;
@@ -69,6 +70,7 @@ class DlgPreferences : public QDialog, public Ui::DlgPreferencesDlg {
             std::optional<mixxx::preferences::SoundHardwareTab> tab =
                     std::nullopt);
     void showSoundHardwareInputPage();
+    void openControllerLearningWizard(Controller* pController);
     void slotButtonPressed(QAbstractButton* pButton);
   signals:
     void closeDlg();

--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -8,6 +8,7 @@
 
 #include "config.h"
 #include "control/controlproxy.h"
+#include "controllers/controller.h"
 #include "controllers/keyboard/keyboardeventfilter.h"
 #include "defs_urls.h"
 #include "moc_wmainmenubar.cpp"
@@ -474,6 +475,17 @@ void WMainMenuBar::initialize() {
     pOptionsMenu->addMenu(pVinylControlMenu);
     pOptionsMenu->addSeparator();
 #endif
+
+    // Controller Learning submenu
+    m_pControllerLearningMenu = new QMenu(tr("&Controller Learning Wizard"), this);
+    QString controllerLearningText = tr(
+            "Open the MIDI learning wizard for an enabled controller");
+    m_pControllerLearningMenu->setStatusTip(controllerLearningText);
+    m_pControllerLearningMenu->setWhatsThis(buildWhatsThis(
+            tr("Controller Learning Wizard"), controllerLearningText));
+    // Menu will be populated dynamically with enabled controllers
+    pOptionsMenu->addMenu(m_pControllerLearningMenu);
+    pOptionsMenu->addSeparator();
 
     QString recordTitle = tr("&Record Mix");
     QString recordText = tr("Record your mix to a file");
@@ -1006,4 +1018,31 @@ void VisibilityControlConnection::slotActionToggled(bool toggle) {
     if (m_pControl) {
         m_pControl->set(toggle ? 1.0 : 0.0);
     }
+}
+
+void WMainMenuBar::onControllersChanged(const QList<Controller*>& controllers) {
+    // Clear existing actions
+    for (QAction* pAction : std::as_const(m_controllerLearningActions)) {
+        m_pControllerLearningMenu->removeAction(pAction);
+        delete pAction;
+    }
+    m_controllerLearningActions.clear();
+
+    // Add menu item for each controller
+    for (Controller* pController : controllers) {
+        if (!pController) {
+            continue;
+        }
+        QString controllerName = pController->getName();
+        auto* pAction = new QAction(controllerName, this);
+        pAction->setStatusTip(tr("Open learning wizard for %1").arg(controllerName));
+        connect(pAction, &QAction::triggered, this, [this, pController]() {
+            emit openControllerLearningWizard(pController);
+        });
+        m_pControllerLearningMenu->addAction(pAction);
+        m_controllerLearningActions.append(pAction);
+    }
+
+    // Hide menu when no controllers are enabled to avoid disabled action issue on Qt 6.2.3
+    m_pControllerLearningMenu->menuAction()->setVisible(!m_controllerLearningActions.isEmpty());
 }

--- a/src/widget/wmainmenubar.h
+++ b/src/widget/wmainmenubar.h
@@ -9,8 +9,9 @@
 #include "preferences/configobject.h"
 #include "preferences/usersettings.h"
 
-class QAction;
+class Controller;
 class KeyboardEventFilter;
+class QAction;
 
 class VisibilityControlConnection : public QObject {
     Q_OBJECT
@@ -56,6 +57,7 @@ class WMainMenuBar : public QMenuBar {
     void onVinylControlDeckEnabledStateChange(int deck, bool enabled);
     void onNumberOfDecksChanged(int decks);
     void onKeywheelChange(int state);
+    void onControllersChanged(const QList<Controller*>& controllers);
 #ifndef __APPLE__
     void slotToggleMenuBar();
 #endif
@@ -82,6 +84,7 @@ class WMainMenuBar : public QMenuBar {
     void toggleBroadcasting(bool toggle);
     void toggleRecording(bool enabled);
     void toggleVinylControl(int deck);
+    void openControllerLearningWizard(Controller* pController);
     void visitUrl(const QString& url);
     void quit();
 
@@ -118,4 +121,6 @@ class WMainMenuBar : public QMenuBar {
     std::shared_ptr<KeyboardEventFilter> m_pKeyboard;
     QList<QAction*> m_loadToDeckActions;
     QList<QAction*> m_vinylControlEnabledActions;
+    QMenu* m_pControllerLearningMenu;
+    QList<QAction*> m_controllerLearningActions;
 };


### PR DESCRIPTION
implements feature request from issue #12262 to provide quicker access to the midi controller learning wizard.

## changes

### options menu submenu
- added "controller learning wizard" submenu under options menu
- dynamically populated with enabled controllers only
- shows "no controllers enabled" when no controllers are enabled
- updates automatically when controllers are enabled/disabled

### navigation
- clicking a controller menu item opens preferences dialog
- automatically navigates to that specific controller's page
- expands the controllers tree and selects the correct item
- user can then click the "learning wizard" button on that page

### implementation
- wmainmenubar: added menu creation and signal emission
- mixxxmainwindow: connected signals, filters to show only enabled controllers
- dlgprefcontrollers: added method to navigate to specific controller
- dlgpreferences: added method to delegate to controllers dialog

follows the same architectural pattern as the existing vinyl control menu implementation for consistency.

fixes #12262