### PR TITLE
add checkbox to hide unenabled controllers in preferences

### DIFF
--- a/src/controllers/defs_controllers.h
+++ b/src/controllers/defs_controllers.h
@@ -32,3 +32,6 @@ const auto kMidiThroughPortPrefix = QLatin1String("MIDI Through Port");
 const ConfigKey kMidiThroughCfgKey =
         ConfigKey(QStringLiteral("[Controller]"), QStringLiteral("midi_through_enabled"));
 #endif
+
+const ConfigKey kHideDisabledControllersCfgKey =
+        ConfigKey(QStringLiteral("[Controller]"), QStringLiteral("hide_disabled_controllers"));

--- a/src/controllers/dlgprefcontroller.h
+++ b/src/controllers/dlgprefcontroller.h
@@ -42,6 +42,10 @@ class DlgPrefController : public DlgPreferencePage {
     QUrl helpUrl() const override;
     void keyPressEvent(QKeyEvent* pEvent) override;
 
+    Controller* controller() const {
+        return m_pController;
+    }
+
   public slots:
     /// Called when the preference dialog (not this page) is shown to the user.
     void slotUpdate() override;

--- a/src/controllers/dlgprefcontrollers.cpp
+++ b/src/controllers/dlgprefcontrollers.cpp
@@ -44,6 +44,18 @@ DlgPrefControllers::DlgPrefControllers(DlgPreferences* pPreferences,
             this,
             &DlgPrefControllers::rescanControllers);
 
+    // Hide disabled controllers checkbox
+    checkBox_hideDisabled->setChecked(
+            m_pConfig->getValue(kHideDisabledControllersCfgKey, false));
+    connect(checkBox_hideDisabled,
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+            &QCheckBox::checkStateChanged,
+#else
+            &QCheckBox::stateChanged,
+#endif
+            this,
+            &DlgPrefControllers::slotHideDisabledChanged);
+
 #ifdef __PORTMIDI__
     checkBox_midithrough->setChecked(m_pConfig->getValue(kMidiThroughCfgKey, false));
     connect(checkBox_midithrough,
@@ -258,6 +270,19 @@ void DlgPrefControllers::setupControllerWidgets() {
         temp.setBold(pController->isOpen());
         pControllerTreeItem->setFont(0, temp);
     }
+
+    // Update visibility based on checkbox state
+    updateControllerVisibility();
+}
+
+void DlgPrefControllers::updateControllerVisibility() {
+    const bool hideDisabled = m_pConfig->getValue(kHideDisabledControllersCfgKey, false);
+
+    for (int i = 0; i < m_controllerTreeItems.size() && i < m_controllerPages.size(); ++i) {
+        QTreeWidgetItem* pTreeItem = m_controllerTreeItems.at(i);
+        DlgPrefController* pControllerDlg = m_controllerPages.at(i);
+        pTreeItem->setHidden(hideDisabled && !pControllerDlg->controller()->isOpen());
+    }
 }
 
 void DlgPrefControllers::slotHighlightDevice(DlgPrefController* pControllerDlg, bool enabled) {
@@ -268,14 +293,28 @@ void DlgPrefControllers::slotHighlightDevice(DlgPrefController* pControllerDlg, 
 
     QTreeWidgetItem* pControllerTreeItem =
             m_controllerTreeItems.at(controllerPageIndex);
-    if (!pControllerTreeItem) {
-        return;
-    }
-
     QFont temp = pControllerTreeItem->font(0);
     temp.setBold(enabled);
     pControllerTreeItem->setFont(0, temp);
+
+    // Update visibility in case the checkbox is checked and this controller's state changed
+    bool hideDisabled = m_pConfig->getValue(kHideDisabledControllersCfgKey, false);
+    if (hideDisabled) {
+        pControllerTreeItem->setHidden(!enabled);
+    }
 }
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+void DlgPrefControllers::slotHideDisabledChanged(Qt::CheckState state) {
+    m_pConfig->setValue(kHideDisabledControllersCfgKey, state != Qt::Unchecked);
+    updateControllerVisibility();
+}
+#else
+void DlgPrefControllers::slotHideDisabledChanged(bool checked) {
+    m_pConfig->setValue(kHideDisabledControllersCfgKey, checked);
+    updateControllerVisibility();
+}
+#endif
 
 #ifdef __PORTMIDI__
 #if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)

--- a/src/controllers/dlgprefcontrollers.h
+++ b/src/controllers/dlgprefcontrollers.h
@@ -41,6 +41,11 @@ class DlgPrefControllers : public DlgPreferencePage, public Ui::DlgPrefControlle
 
   private slots:
     void rescanControllers();
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+    void slotHideDisabledChanged(Qt::CheckState state);
+#else
+    void slotHideDisabledChanged(bool checked);
+#endif
 #ifdef __PORTMIDI__
 #if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
     void slotMidiThroughChanged(Qt::CheckState state);
@@ -53,6 +58,7 @@ class DlgPrefControllers : public DlgPreferencePage, public Ui::DlgPrefControlle
   private:
     void destroyControllerWidgets();
     void setupControllerWidgets();
+    void updateControllerVisibility();
     void openLocalFile(const QString& file);
 
     DlgPreferences* m_pDlgPreferences;

--- a/src/controllers/dlgprefcontrollersdlg.ui
+++ b/src/controllers/dlgprefcontrollersdlg.ui
@@ -71,6 +71,20 @@
       </item>
 
       <item>
+       <widget class="QCheckBox" name="checkBox_hideDisabled">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Hide disabled controllers</string>
+        </property>
+       </widget>
+      </item>
+
+      <item>
        <widget class="Line" name="line_midithrough">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
@@ -224,6 +238,7 @@
   </layout>
  </widget>
  <tabstops>
+  checkBox_hideDisabled
   checkBox_midithrough
   btnOpenUserMappings
  </tabstops>


### PR DESCRIPTION
adds a checkbox in Preferences > Controllers to hide controllers that are not enabled, making it easier for users with many controllers to find the ones they actually use.

the checkbox state is persisted in the config and the controller list visibility is updated efficiently using setHidden() to avoid expensive widget rebuilding.

implementation:
- added checkbox ui element "hide controllers that are not enabled"
- persists state in [controller]/hide_unenabled_controllers config key
- uses lightweight updatecontrollervisibility() method to toggle tree item visibility instead of destroying/rebuilding all widgets
- matches controllers correctly using controller pages in sync with tree items
- updates visibility automatically when controller enabled state changes
- added controller() getter to dlgprefcontroller for proper matching

fixes #14275