### PR TITLE
New feature for AutoDJ: Start Time + Duration, to allow skipping slow…

### DIFF
--- a/src/library/autodj/autodjprocessor.h
+++ b/src/library/autodj/autodjprocessor.h
@@ -164,7 +164,8 @@ class AutoDJProcessor : public QObject {
         FadeAtOutroStart,
         FixedFullTrack,
         FixedSkipSilence,
-        FixedStartCenterSkipSilence
+        FixedStartCenterSkipSilence,
+        StartTimeDuration
     };
 
     AutoDJProcessor(QObject* pParent,
@@ -186,6 +187,14 @@ class AutoDJProcessor : public QObject {
         return m_transitionMode;
     }
 
+    int getStartTimeSeconds() const {
+        return m_startTimeSeconds;
+    }
+
+    int getDurationSeconds() const {
+        return m_durationSeconds;
+    }
+
     PlaylistTableModel* getTableModel() const {
         return m_pAutoDJTableModel;
     }
@@ -195,6 +204,9 @@ class AutoDJProcessor : public QObject {
     void setTransitionTime(int seconds);
 
     void setTransitionMode(TransitionMode newMode);
+
+    void setStartTimeSeconds(int seconds);
+    void setDurationSeconds(int seconds);
 
     AutoDJError shufflePlaylist(const QModelIndexList& selectedIndices);
     AutoDJError skipNext();
@@ -299,6 +311,9 @@ class AutoDJProcessor : public QObject {
     double m_transitionTime; // the desired value set by the user
     TransitionMode m_transitionMode;
     bool m_crossfaderStartCenter;
+
+    int m_startTimeSeconds;
+    int m_durationSeconds;
 
     QList<DeckAttributes*> m_decks;
 

--- a/src/library/autodj/dlgautodj.ui
+++ b/src/library/autodj/dlgautodj.ui
@@ -139,6 +139,78 @@
        </widget>
       </item>
       <item>
+       <widget class="QLabel" name="labelStartTime">
+        <property name="text">
+         <string>Start</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QSpinBox" name="startTimeSpinBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="frame">
+         <bool>false</bool>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="minimum">
+         <number>0</number>
+        </property>
+        <property name="maximum">
+         <number>100000</number>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="labelStartTimeAppendix">
+        <property name="text">
+         <string>sec.</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="labelDuration">
+        <property name="text">
+         <string>Duration</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QSpinBox" name="durationSpinBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="frame">
+         <bool>false</bool>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>100000</number>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="labelDurationAppendix">
+        <property name="text">
+         <string>sec.</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <spacer name="horizontalSpacer_2">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
A new feature to Auto DJ : Start Time + Duration. In this mode, each track starts at the Start Time (30 seconds default) and plays the track only for the Duration (90 seconds default). This feature allows to skip slow intros in the beginning and moves the next track without playing full track to keep a dance party interesting and fast flowing. People get bored of listening to entire tracks during a dance party. This feature enhanced the AutoDJ to be the dance party DJ.