### PR TITLE
(fix) BaseTrackCache: fix filterAndSort() to avoid unwanted extra tracks with extraFilter

### DIFF
--- a/src/library/analysis/analysislibrarytablemodel.cpp
+++ b/src/library/analysis/analysislibrarytablemodel.cpp
@@ -1,10 +1,23 @@
 #include "library/analysis/analysislibrarytablemodel.h"
 
+#include <QDateTime>
+
 #include "moc_analysislibrarytablemodel.cpp"
+#include "util/datetime.h"
 
 namespace {
 
-const QString RECENT_FILTER = "datetime_added > datetime('now', '-7 days')";
+inline QString recentFilter() {
+    // Create a user-formatted query equal to SQL query
+    // datetime_added > datetime('now', '-7 days')
+    QDateTime dt(QDateTime::currentDateTimeUtc());
+    dt = dt.addDays(-7);
+    const QString dateStr = QLocale::system().toString(dt.date(), QLocale::ShortFormat);
+
+    // FIXME alternatively, use "added:-days" and add the respective
+    // literal parser to DateAddedFilterNode
+    return QStringLiteral("added:>%1").arg(dateStr);
+}
 
 } // anonymous namespace
 
@@ -13,12 +26,12 @@ AnalysisLibraryTableModel::AnalysisLibraryTableModel(QObject* parent,
         : LibraryTableModel(parent, pTrackCollectionManager,
                             "mixxx.db.model.prepare") {
     // Default to showing recent tracks.
-    setSearch("", RECENT_FILTER);
+    setSearch("", recentFilter());
 }
 
 void AnalysisLibraryTableModel::showRecentSongs() {
     // Search with the recent filter.
-    search(currentSearch(), RECENT_FILTER);
+    search(currentSearch(), recentFilter());
 }
 
 void AnalysisLibraryTableModel::showAllSongs() {
@@ -27,5 +40,5 @@ void AnalysisLibraryTableModel::showAllSongs() {
 }
 
 void AnalysisLibraryTableModel::searchCurrentTrackSet(const QString& text, bool useRecentFilter) {
-    search(text, useRecentFilter ? RECENT_FILTER : "");
+    search(text, useRecentFilter ? recentFilter() : "");
 }

--- a/src/library/basesqltablemodel.cpp
+++ b/src/library/basesqltablemodel.cpp
@@ -422,6 +422,9 @@ void BaseSqlTableModel::setSearch(const QString& searchText, const QString& extr
         return;
     }
 
+    // Note: don't use SQL strings as extraFilter, this will cause issues in
+    // BaseTrackCache::filterAndSort() which is responsible for adding/removing
+    // dirty tracks from the view.
     m_currentSearch = searchText;
     m_currentSearchFilter = extraFilter;
 }

--- a/src/library/basetrackcache.cpp
+++ b/src/library/basetrackcache.cpp
@@ -458,30 +458,35 @@ void BaseTrackCache::filterAndSort(const QSet<TrackId>& trackIds,
         buildIndex();
     }
 
+    // The id string we need for our QSqlQuery
     QStringList idStrings;
+    // The id set we need for removing/adding dirty tracks
+    QSet<TrackId> ids;
     // TODO(rryan) consider making this the data passed in and a separate
     // QVector for output
     QSet<TrackId> dirtyTracks;
-    for (const auto& trackId: trackIds) {
+    for (const auto& trackId : trackIds) {
         idStrings << trackId.toString();
+        ids << trackId;
         if (m_dirtyTracks.contains(trackId)) {
             dirtyTracks.insert(trackId);
         }
     }
 
-    QStringList queryFragments;
-    if (!extraFilter.isNull() && extraFilter != "") {
-        queryFragments << QString("(%1)").arg(extraFilter);
+    // Note: don't use the extraFilter for m_pQueryParser->parseQuery(), just
+    // append it to searchQuery if not empty and let the parser construct
+    // a SQL query from it.
+    // The issue with the extraFilter is that the parser is assuming the input
+    // is a SQL string and creates a SqlNode from it, and the issue with that is
+    // that SqlNode::match(TrackPointer) always returns true -- which leads to
+    // false positive matches when we iterate over the dirty tracks below.
+    QString searchPlusExtraFilter = searchQuery;
+    if (!extraFilter.isEmpty()) {
+        searchPlusExtraFilter += ' ';
+        searchPlusExtraFilter += extraFilter;
     }
-    if (idStrings.size() > 0) {
-        queryFragments << QString("%1 in (%2)")
-                .arg(m_idColumn, idStrings.join(","));
-    }
-
     const std::unique_ptr<QueryNode> pQuery =
-            m_pQueryParser->parseQuery(
-                    searchQuery,
-                    queryFragments.join(" AND "));
+            m_pQueryParser->parseQuery(searchPlusExtraFilter, QString());
 
     QString filter = pQuery->toSql();
     if (!filter.isEmpty()) {
@@ -539,18 +544,20 @@ void BaseTrackCache::filterAndSort(const QSet<TrackId>& trackIds,
     }
 
     for (TrackId trackId : std::as_const(dirtyTracks)) {
-        // Only get the track if it is in the cache. Tracks that
-        // are not cached in memory cannot be dirty.
+        // Only get the track if it is in the cache.
+        // Tracks that are not cached in memory cannot be dirty.
         // Bypass getCachedTrack() to not invalidate m_recentTrackId
         TrackPointer pTrack = GlobalTrackCacheLocker().lookupTrackById(trackId);
         if (!pTrack) {
             continue;
         }
 
-        // The track should be in the result set if the search is empty or the
-        // track matches the search.
-        bool shouldBeInResultSet = searchQuery.isEmpty() ||
-                pQuery->match(pTrack);
+        // The track should be in the result set if
+        // the search and extra filter are empty
+        // or
+        // the track matches the search and ids (if not empty) contains its id
+        bool shouldBeInResultSet = searchPlusExtraFilter.isEmpty() ||
+                ((ids.isEmpty() || ids.contains(trackId)) && pQuery->match(pTrack));
 
         // If the track is in this result set.
         bool isInResultSet = trackToIndex->contains(trackId);


### PR DESCRIPTION
Another take to fix #14873 and similar symptoms in #14687 for me.

### The issue:
#14873: unrelated (older) tracks show up with the 'New' filter in the Analyze view.
With #14687 'dirty' tracks pop up in the Computer directory views that use LibraryTableModel.

### Root cause:
So called "extra filters" are sent to [`SearchQueryParser::parseQuery(query, extraFilter)` where `extraFilter` is wrapped as SqlNode](https://github.com/mixxxdj/mixxx/blob/086f48e8a11e4c35748bced4ab39dfa799d55402/src/library/searchqueryparser.cpp#L351).
In BaseTrackCache we add dirty tracks to the current view if they are missing but match the query -- however the extraFilter [`SqlNode::match(pTrack)` always returns true](https://github.com/mixxxdj/mixxx/blob/086f48e8a11e4c35748bced4ab39dfa799d55402/src/library/searchquery.h#L263-L267), making the check pointless because it adds dirty tracks even if they don't belong into the view.

### (Quick) Fix:
Don't use `extraFilter`.
Actually **Analyze** is the only view that makes use of it for the New filter (get only tracks added during last week), so we can
* use a _user-formatted_ filter like we'd use in the search bar
* append it to the search string (user input)
* let the query parser construct a proper query
* whose `match(TrackPointer)` function really does a per-track match

and
* do the TrackId match with a `QSet<TrackId>` (not with a SqlNode)

Works fine for me in Analyze, no dirty tracks anymore.