### PR TITLE
Track Info: swap ReplayGain/Date, add file size

### DIFF
--- a/src/library/dlgtrackinfo.cpp
+++ b/src/library/dlgtrackinfo.cpp
@@ -394,6 +394,13 @@ void DlgTrackInfo::replaceTrackRecord(
                     mixxx::localDateTimeFromUtc(
                             m_trackRecord.getDateAdded())));
 
+    QFileInfo info(trackLocation);
+    if (info.exists() && info.isFile()) {
+        int size = info.size();
+        QString sizeStr = QLocale().formattedDataSize(size);
+        txtFileSize->setText(sizeStr);
+    }
+
     updateTrackMetadataFields();
 }
 

--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -632,6 +632,30 @@
            </widget>
           </item>
 
+          <item row="3" column="2">
+           <widget class="QLabel" name="lblFileSize">
+            <property name="text">
+             <string>Filesize:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="3">
+           <widget class="QLabel" name="txtFileSize">
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+
           <item row="4" column="0">
            <widget class="QLabel" name="lblLocation">
             <property name="text">

--- a/src/library/dlgtrackinfo.ui
+++ b/src/library/dlgtrackinfo.ui
@@ -564,14 +564,14 @@
           </item>
 
           <item row="2" column="0">
-           <widget class="QLabel" name="lblDateAdded">
+           <widget class="QLabel" name="lblReplayGain">
             <property name="text">
-             <string>Date added:</string>
+             <string>ReplayGain:</string>
             </property>
            </widget>
           </item>
           <item row="2" column="1">
-           <widget class="QLabel" name="txtDateAdded">
+           <widget class="QLabel" name="txtReplayGain">
             <property name="font">
              <font>
               <weight>75</weight>
@@ -609,14 +609,14 @@
           </item>
 
           <item row="3" column="0">
-           <widget class="QLabel" name="lblReplayGain">
+           <widget class="QLabel" name="lblDateAdded">
             <property name="text">
-             <string>ReplayGain:</string>
+             <string>Date added:</string>
             </property>
            </widget>
           </item>
           <item row="3" column="1">
-           <widget class="QLabel" name="txtReplayGain">
+           <widget class="QLabel" name="txtDateAdded">
             <property name="font">
              <font>
               <weight>75</weight>


### PR DESCRIPTION
Musical properties are now consolidated, date is closer to file location.
And file size is helpful to compare versions of the same song.

<img width="595" height="360" alt="image" src="https://github.com/user-attachments/assets/4201024e-b131-4009-80e3-cae11eff66aa" />
