### PR TITLE
Add Auto Dj transition mode: cue to track end

### DIFF
--- a/src/library/autodj/autodjprocessor.cpp
+++ b/src/library/autodj/autodjprocessor.cpp
@@ -1493,6 +1493,23 @@ void AutoDJProcessor::calculateTransition(DeckAttributes* pFromDeck,
                 getLastSoundSecond(pFromDeck),
                 toDeckStartSecond);
     } break;
+    case TransitionMode::FixedCueToTrackEnd: {
+        double startPoint = toDeckPositionSeconds;
+        pToDeck->fadeBeginPos = toDeckEndPosition;
+        if (seekToStartPoint || toDeckPositionSeconds >= pToDeck->fadeBeginPos) {
+            // toDeckPosition >= pToDeck->fadeBeginPos happens when the
+            // user has seeked or played the to track behind fadeBeginPos of
+            // the fade after the next.
+            // In this case we recue the track just before the transition.
+            CuePointer pMainCue = pToDeck->getLoadedTrack()->findCueByType(mixxx::CueType::MainCue);
+            if (pMainCue) {
+                startPoint = framePositionToSeconds(pMainCue->getPosition(), pToDeck);
+            } else {
+                startPoint = 0.0;
+            }
+        }
+        useFixedFadeTime(pFromDeck, pToDeck, fromDeckPosition, fromDeckEndPosition, startPoint);
+    } break;
     case TransitionMode::FixedFullTrack:
     default: {
         double startPoint;

--- a/src/library/autodj/autodjprocessor.h
+++ b/src/library/autodj/autodjprocessor.h
@@ -163,6 +163,7 @@ class AutoDJProcessor : public QObject {
         FullIntroOutro,
         FadeAtOutroStart,
         FixedFullTrack,
+        FixedCueToTrackEnd,
         FixedSkipSilence,
         FixedStartCenterSkipSilence
     };

--- a/src/library/autodj/dlgautodj.cpp
+++ b/src/library/autodj/dlgautodj.cpp
@@ -142,6 +142,11 @@ DlgAutoDJ::DlgAutoDJ(WLibrary* parent,
             "seconds before the end of the track. A negative crossfade time adds\n"
             "silence between tracks.\n"
             "\n"
+            "Cue to Track End:\n"
+            "Play the track from the main cue point to the end of the track. Begin\n"
+            "crossfading from the selected number of seconds before the end of the\n"
+            "track. A negative crossfade time adds silence between tracks.\n"
+            "\n"
             "Skip Silence:\n"
             "Play the whole track except for silence at the beginning and end.\n"
             "Begin crossfading from the selected number of seconds before the\n"
@@ -180,6 +185,8 @@ DlgAutoDJ::DlgAutoDJ(WLibrary* parent,
             static_cast<int>(AutoDJProcessor::TransitionMode::FadeAtOutroStart));
     fadeModeCombobox->addItem(tr("Full Track"),
             static_cast<int>(AutoDJProcessor::TransitionMode::FixedFullTrack));
+    fadeModeCombobox->addItem(tr("Cue to Track End"),
+            static_cast<int>(AutoDJProcessor::TransitionMode::FixedCueToTrackEnd));
     fadeModeCombobox->addItem(tr("Skip Silence"),
             static_cast<int>(AutoDJProcessor::TransitionMode::FixedSkipSilence));
     fadeModeCombobox->addItem(tr("Skip Silence Start Full Volume"),


### PR DESCRIPTION
Adds a new Auto DJ transition mode "Cue to Track End" which behaves just like Full Track, except playback starts at the main cue stored on the track or the beginning if no cue point is stored.