### PR TITLE
change m_seekSamplePos to a FramePos

### DIFF
--- a/src/engine/positionscratchcontroller.h
+++ b/src/engine/positionscratchcontroller.h
@@ -48,7 +48,7 @@ class PositionScratchController : public QObject {
     bool m_isScratching;
     bool m_inertiaEnabled;
     double m_prevSamplePos;
-    double m_seekSamplePos;
+    mixxx::audio::FramePos m_seekFramePos;
     double m_samplePosDeltaSum;
     double m_scratchTargetDelta;
     double m_scratchStartPos;


### PR DESCRIPTION
Bug fix for #15579. My testing led me to this block in [positionscratchcontroller](https://github.com/mixxxdj/mixxx/blob/63dff20f33618b315143224ea846cd98a3935bd1/src/engine/positionscratchcontroller.cpp#L317):
```cpp
    if (!util_isnan(m_seekSamplePos)) {
        // We need to transpose all buffers to compensate the seek
        // in a way that the next process call does not even notice anything
        currentSamplePos = m_seekSamplePos;
        m_seekSamplePos = std::numeric_limits<double>::quiet_NaN();
    }

```
Where for some reason m_seekSamplePos always retained it's value and was never being set to NaN. Even when debugging in VsCode the debugger completely skipped the NaN assignment and I'm not sure why. 

Following the TODO comment about changing the type to `FramePos` seems to have fixed the issue.