### PR TITLE
rename Reloop Beatmix MK2 controller files to denote they are for the MK2

### DIFF
--- a/res/controllers/Reloop-Beatmix-2-4-MK2-scripts.js
+++ b/res/controllers/Reloop-Beatmix-2-4-MK2-scripts.js
@@ -13,7 +13,7 @@ const JogFlashCriticalTime = 15; // number of seconds to quickly blink at the en
 
 
 /************************  GPL v2 licence  *****************************
- * Reloop Beatmix 2/4 controller script
+ * Reloop Beatmix 2/4 MK2 controller script
  * Author: Sébastien Blaisot <sebastien@blaisot.org>
  *
  **********************************************************************
@@ -39,7 +39,7 @@ const JogFlashCriticalTime = 15; // number of seconds to quickly blink at the en
  ***********************************************************************
  *                           GPL v2 licence
  *                           --------------
- * Reloop Beatmix controller script script 2.0.0 for Mixxx 2.4+
+ * Reloop Beatmix 2/4 MK2 controller script 2.0.0 for Mixxx 2.4+
  * Copyright (C) 2016 Sébastien Blaisot
  *
  * This program is free software; you can redistribute it and/or

--- a/res/controllers/Reloop-Beatmix-2-4-MK2.midi.xml
+++ b/res/controllers/Reloop-Beatmix-2-4-MK2.midi.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <MixxxControllerPreset mixxxVersion="2.0.0+" schemaVersion="1">
     <info>
-        <name>Reloop Beatmix 2/4</name>
+        <name>Reloop Beatmix 2/4 MK2</name>
         <author>Sébastien Blaisot &lt;sebastien@blaisot.org&gt;</author>
-        <description>Controller mapping for the Reloop Beatmix 2/4.</description>
+        <description>Controller mapping for the Reloop Beatmix 2/4 MK2.</description>
         <forums>https://mixxx.discourse.group/t/reloop-beatmix-2-4-mapping/16049</forums>
         <manual>reloop_beatmix_2</manual>
     </info>
-    <controller id="Reloop Beatmix 2/4">
+    <controller id="Reloop Beatmix 2/4 MK2">
         <scriptfiles>
-            <file functionprefix="ReloopBeatmix24" filename="Reloop-Beatmix-2-4-scripts.js"/>
+            <file functionprefix="ReloopBeatmix24" filename="Reloop-Beatmix-2-4-MK2-scripts.js"/>
         </scriptfiles>
         <controls>
             <!--


### PR DESCRIPTION
off the back of discussion on https://github.com/mixxxdj/mixxx/pull/12422

if the MK1 files get called that, the current MK2 filenames will be too ambiguous