### PR TITLE
Add control for playback marker horizontal position

### DIFF
--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -1563,6 +1563,11 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
             tr("Reset the waveform zoom level to the default value selected in "
                "Preferences -> Waveforms"),
             pGuiMenu);
+    addControl("[Waveform]",
+            "play_marker_position",
+            tr("Playback Marker Position"),
+            tr("Adjust the position of the playback marker on the waveforms"),
+            pGuiMenu);
 
     pGuiMenu->addSeparator();
 

--- a/src/skin/legacy/tooltips.cpp
+++ b/src/skin/legacy/tooltips.cpp
@@ -73,6 +73,10 @@ void Tooltips::addStandardTooltips() {
             << tr("Waveform Zoom")
             << QString("%1").arg(resetToDefault);
 
+    add("[Waveform],play_marker_position")
+            << tr("Playback Marker Position")
+            << tr("Adjust the position of the playback marker on the waveforms.");
+
     add("spinny")
             << tr("Spinning Vinyl")
             << tr("Rotates during playback and shows the position of a track.")

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -1,5 +1,6 @@
 #include "waveform/waveformwidgetfactory.h"
 
+#include "control/controlpotmeter.h"
 #include "waveform/renderers/waveformrendererabstract.h"
 #include "waveform/waveform.h"
 
@@ -440,6 +441,21 @@ bool WaveformWidgetFactory::setConfig(UserSettingsPointer config) {
                     WaveformWidgetRenderer::s_defaultPlayMarkerPosition);
     setPlayMarkerPosition(m_playMarkerPosition);
 
+    // Create control for playback marker position (0.0 = left, 1.0 = right)
+    if (!m_pPlayMarkerPositionCO) {
+        m_pPlayMarkerPositionCO = std::make_unique<ControlPotmeter>(
+                ConfigKey(kWaveformGroup, QStringLiteral("play_marker_position")),
+                0.0,
+                1.0);
+        connect(m_pPlayMarkerPositionCO.get(),
+                &ControlObject::valueChanged,
+                this,
+                [this](double value) {
+                    setPlayMarkerPosition(value);
+                });
+    }
+    m_pPlayMarkerPositionCO->set(m_playMarkerPosition);
+
     int untilMarkShowBeats =
             m_config->getValueString(
                             ConfigKey(kWaveformGroup, QStringLiteral("UntilMarkShowBeats")))
@@ -800,6 +816,9 @@ void WaveformWidgetFactory::setPlayMarkerPosition(double position) {
     if (m_config) {
         m_config->setValue(ConfigKey(kWaveformGroup, QStringLiteral("PlayMarkerPosition")),
                 m_playMarkerPosition);
+    }
+    if (m_pPlayMarkerPositionCO) {
+        m_pPlayMarkerPositionCO->set(m_playMarkerPosition);
     }
 
     for (const auto& holder : std::as_const(m_waveformWidgetHolders)) {

--- a/src/waveform/waveformwidgetfactory.h
+++ b/src/waveform/waveformwidgetfactory.h
@@ -21,6 +21,7 @@ class WWaveformViewer;
 class WaveformWidgetAbstract;
 class VSyncThread;
 class GuiTick;
+class ControlPotmeter;
 class VisualsManager;
 class ControlObject;
 
@@ -377,4 +378,5 @@ class WaveformWidgetFactory : public QObject,
     double m_actualFrameRate;
     int m_vSyncType;
     double m_playMarkerPosition;
+    std::unique_ptr<ControlPotmeter> m_pPlayMarkerPositionCO;
 };


### PR DESCRIPTION
## Description

Adds a controllable parameter for adjusting the horizontal position of the playback marker/line on waveforms, allowing users to customize where the playback position indicator appears.

## Motivation

Users may prefer different playback marker positions for various workflows:
- DJs mixing may prefer the marker further right to see more upcoming audio
- Radio DJs may prefer it centered or left for different visual reference
- Users with ultrawide monitors may want to adjust position for ergonomics

This addresses feature request #14288.

## Changes

- Adds `[Waveform],play_marker_position` control (range: 0.0 = left, 1.0 = right)
- Implements `ControlPotmeter` in `WaveformWidgetFactory` for smooth value adjustment
- Exposes control in controller picker menu for MIDI/HID mapping
- Adds tooltip documentation for the control
- Preserves existing playback marker position functionality from preferences

## Technical Implementation

The control is implemented as a global waveform setting that:
- Persists across sessions via configuration
- Updates all active waveform widgets when changed
- Integrates with the existing playback marker rendering system in `WaveformWidgetRenderer`
- Follows Mixxx control object patterns (snake_case naming for mappable controls)
- Complements the existing preferences slider without replacing it

## Testing

- [x] Code compiles successfully
- [x] Control is accessible via MIDI/HID mapping
- [x] UI preferences slider continues to work
- [x] Position persists across application restarts
- [x] All waveform widgets update when control changes

## Related Issue

Fixes #14288
