### PR TITLE
Deere: add per-channel mute buttons next to gain knobs

### DIFF
--- a/res/skins/Deere/mixer.xml
+++ b/res/skins/Deere/mixer.xml
@@ -130,7 +130,7 @@
                 <Layout>vertical</Layout>
                 <Children>
                   <WidgetGroup>
-                    <Size>0min,2f</Size>
+                    <Size>0min,1me</Size>
                     <Connection>
                       <ConfigKey>[Deere],xfader_buttons_fit</ConfigKey>
                       <BindProperty>visible</BindProperty>
@@ -151,7 +151,7 @@
                     </Connection>
                   </WidgetGroup>
                   <WidgetGroup>
-                    <Size>0min,0e</Size>
+                    <Size>0min,1me</Size>
                     <Connection>
                       <ConfigKey>[Deere],xfader_buttons_fit</ConfigKey>
                       <BindProperty>visible</BindProperty>
@@ -195,7 +195,7 @@
                 <Layout>vertical</Layout>
                 <Children>
                   <WidgetGroup>
-                    <Size>0min,2f</Size>
+                    <Size>0min,1me</Size>
                     <Connection>
                       <ConfigKey>[Deere],xfader_buttons_fit</ConfigKey>
                       <BindProperty>visible</BindProperty>
@@ -216,7 +216,7 @@
                     </Connection>
                   </WidgetGroup>
                   <WidgetGroup>
-                    <Size>0min,0e</Size>
+                    <Size>0min,1me</Size>
                     <Connection>
                       <ConfigKey>[Deere],xfader_buttons_fit</ConfigKey>
                       <BindProperty>visible</BindProperty>

--- a/res/skins/Deere/mixer_column_main_vu_2decks.xml
+++ b/res/skins/Deere/mixer_column_main_vu_2decks.xml
@@ -6,16 +6,6 @@
     <SizePolicy>me,me</SizePolicy>
     <Children>
 
-      <!-- 2 Decks: Spacer sized like channel Gain knob -->
-      <WidgetGroup>
-        <Size>0min,28f</Size>
-        <Connection>
-          <ConfigKey>[Skin],large_vu</ConfigKey>
-          <Transform><Not/></Transform>
-          <BindProperty>visible</BindProperty>
-        </Connection>
-      </WidgetGroup>
-
       <WidgetGroup>
         <Layout>horizontal</Layout>
         <SizePolicy>me,me</SizePolicy>

--- a/res/skins/Deere/mixer_column_pfl_levels.xml
+++ b/res/skins/Deere/mixer_column_pfl_levels.xml
@@ -7,7 +7,7 @@
   <SetVariable name="group">[Channel<Variable name="i"/>]</SetVariable>
   <WidgetGroup>
     <Layout>vertical</Layout>
-    <Size>30f,-1me</Size>
+    <SizePolicy>min,me</SizePolicy>
     <Children>
 
       <WidgetGroup>
@@ -33,13 +33,14 @@
 
       <WidgetGroup>
         <ObjectName>Channel_VU_Container</ObjectName>
-        <Size>22me,50me</Size>
+        <SizePolicy>min,me</SizePolicy>
         <Layout>horizontal</Layout>
         <Children>
           <WidgetGroup>
             <ObjectName>channel_VuMeter_Group</ObjectName>
             <Layout>horizontal</Layout>
-            <MaximumSize>22,150</MaximumSize>
+            <SizePolicy>min,me</SizePolicy>
+            <MinimumSize>22,50</MinimumSize>
             <Children>
               <Template src="skin:vumeter_v.xml">
                 <SetVariable name="group"><Variable name="group"/></SetVariable>
@@ -58,29 +59,6 @@
         </Children>
       </WidgetGroup>
 
-      <WidgetGroup>
-        <Layout>vertical</Layout>
-        <Children>
-          <WidgetGroup>
-            <Layout>vertical</Layout>
-            <Size>28f,28min</Size>
-            <Children>
-              <Template src="skin:crossfader_orientation_button.xml">
-                <SetVariable name="Unit">Deck<Variable name="i"/></SetVariable>
-              </Template>
-            </Children>
-            <Connection>
-              <ConfigKey>[Deere],xfader_buttons_fit</ConfigKey>
-              <Transform><Not/></Transform>
-              <BindProperty>visible</BindProperty>
-            </Connection>
-          </WidgetGroup>
-        </Children>
-        <Connection>
-          <ConfigKey>[Skin],show_xfader</ConfigKey>
-          <BindProperty>visible</BindProperty>
-        </Connection>
-      </WidgetGroup>
     </Children>
   </WidgetGroup>
 </Template>

--- a/res/skins/Deere/mixer_controls_2decks_left.xml
+++ b/res/skins/Deere/mixer_controls_2decks_left.xml
@@ -11,7 +11,80 @@
     <SizePolicy>min,min</SizePolicy>
     <Children>
       <Template src="skin:mixer_column_eq_left.xml"/>
-      <Template src="skin:mixer_column_volume_gain.xml"/>
+
+      <!-- Fader column with gain/mute above -->
+      <WidgetGroup>
+        <ObjectName>DeckMixer_Column2</ObjectName>
+        <Layout>vertical</Layout>
+        <SizePolicy>max,me</SizePolicy>
+        <Children>
+          <!-- Gain knob and mute button above fader -->
+          <WidgetGroup>
+            <Layout>horizontal</Layout>
+            <SizePolicy>me,min</SizePolicy>
+            <Children>
+              <!-- mute button on outside edge (left) -->
+              <PushButton>
+                <TooltipId>mute</TooltipId>
+                <Size>15f,20f</Size>
+                <ObjectName>EQKillButton</ObjectName>
+                <NumberStates>2</NumberStates>
+                <State>
+                  <Number>0</Number>
+                </State>
+                <State>
+                  <Number>1</Number>
+                </State>
+                <Connection>
+                  <ConfigKey><Variable name="group"/>,mute</ConfigKey>
+                  <ButtonState>LeftButton</ButtonState>
+                </Connection>
+                <Connection>
+                  <ConfigKey>[Skin],show_eq_kill_buttons</ConfigKey>
+                  <BindProperty>visible</BindProperty>
+                </Connection>
+              </PushButton>
+              <!-- Gain knob on inside -->
+              <WidgetGroup>
+                <Layout>vertical</Layout>
+                <Size>40f,-1</Size>
+                <MinimumSize>40,34</MinimumSize>
+                <MaximumSize>40,46</MaximumSize>
+                <Children>
+                  <Template src="skin:knob.xml">
+                    <SetVariable name="TooltipId">pregain</SetVariable>
+                    <SetVariable name="control">pregain</SetVariable>
+                    <SetVariable name="color">green</SetVariable>
+                  </Template>
+                </Children>
+              </WidgetGroup>
+            </Children>
+          </WidgetGroup>
+
+          <WidgetGroup><Size>0min,2f</Size></WidgetGroup>
+
+          <SliderComposed>
+            <TooltipId>channel_volume</TooltipId>
+            <SizePolicy>me,me</SizePolicy>
+            <MinimumSize>40,50</MinimumSize>
+            <MaximumSize>40,150</MaximumSize>
+            <Slider scalemode="STRETCH">slider-vertical.svg</Slider>
+            <Handle scalemode="STRETCH_ASPECT">handle-volume-deck<Variable name="i"/>.svg</Handle>
+            <Horizontal>false</Horizontal>
+            <Connection>
+              <ConfigKey><Variable name="group"/>,volume</ConfigKey>
+              <EmitOnDownPress>false</EmitOnDownPress>
+            </Connection>
+          </SliderComposed>
+
+          <WidgetGroup><Size>0min,5f</Size></WidgetGroup>
+        </Children>
+        <Connection>
+          <ConfigKey>[Skin],show_faders</ConfigKey>
+          <BindProperty>visible</BindProperty>
+        </Connection>
+      </WidgetGroup>
+
       <Template src="skin:mixer_column_pfl_levels.xml"/>
     </Children>
   </WidgetGroup>

--- a/res/skins/Deere/mixer_controls_2decks_right.xml
+++ b/res/skins/Deere/mixer_controls_2decks_right.xml
@@ -11,7 +11,80 @@
     <SizePolicy>min,min</SizePolicy>
     <Children>
       <Template src="skin:mixer_column_pfl_levels.xml"/>
-      <Template src="skin:mixer_column_volume_gain.xml"/>
+
+      <!-- Fader column with gain/mute above -->
+      <WidgetGroup>
+        <ObjectName>DeckMixer_Column2</ObjectName>
+        <Layout>vertical</Layout>
+        <SizePolicy>max,me</SizePolicy>
+        <Children>
+          <!-- Gain knob and mute button above fader -->
+          <WidgetGroup>
+            <Layout>horizontal</Layout>
+            <SizePolicy>me,min</SizePolicy>
+            <Children>
+              <!-- Gain knob on inside -->
+              <WidgetGroup>
+                <Layout>vertical</Layout>
+                <Size>40f,-1</Size>
+                <MinimumSize>40,34</MinimumSize>
+                <MaximumSize>40,46</MaximumSize>
+                <Children>
+                  <Template src="skin:knob.xml">
+                    <SetVariable name="TooltipId">pregain</SetVariable>
+                    <SetVariable name="control">pregain</SetVariable>
+                    <SetVariable name="color">green</SetVariable>
+                  </Template>
+                </Children>
+              </WidgetGroup>
+              <!-- mute button on outside edge (right) -->
+              <PushButton>
+                <TooltipId>mute</TooltipId>
+                <Size>15f,20f</Size>
+                <ObjectName>EQKillButton</ObjectName>
+                <NumberStates>2</NumberStates>
+                <State>
+                  <Number>0</Number>
+                </State>
+                <State>
+                  <Number>1</Number>
+                </State>
+                <Connection>
+                  <ConfigKey><Variable name="group"/>,mute</ConfigKey>
+                  <ButtonState>LeftButton</ButtonState>
+                </Connection>
+                <Connection>
+                  <ConfigKey>[Skin],show_eq_kill_buttons</ConfigKey>
+                  <BindProperty>visible</BindProperty>
+                </Connection>
+              </PushButton>
+            </Children>
+          </WidgetGroup>
+
+          <WidgetGroup><Size>0min,2f</Size></WidgetGroup>
+
+          <SliderComposed>
+            <TooltipId>channel_volume</TooltipId>
+            <SizePolicy>me,me</SizePolicy>
+            <MinimumSize>40,50</MinimumSize>
+            <MaximumSize>40,150</MaximumSize>
+            <Slider scalemode="STRETCH">slider-vertical.svg</Slider>
+            <Handle scalemode="STRETCH_ASPECT">handle-volume-deck<Variable name="i"/>.svg</Handle>
+            <Horizontal>false</Horizontal>
+            <Connection>
+              <ConfigKey><Variable name="group"/>,volume</ConfigKey>
+              <EmitOnDownPress>false</EmitOnDownPress>
+            </Connection>
+          </SliderComposed>
+
+          <WidgetGroup><Size>0min,5f</Size></WidgetGroup>
+        </Children>
+        <Connection>
+          <ConfigKey>[Skin],show_faders</ConfigKey>
+          <BindProperty>visible</BindProperty>
+        </Connection>
+      </WidgetGroup>
+
       <Template src="skin:mixer_column_eq_right.xml"/>
     </Children>
   </WidgetGroup>

--- a/res/skins/Deere/mixer_controls_4decks_left.xml
+++ b/res/skins/Deere/mixer_controls_4decks_left.xml
@@ -87,8 +87,36 @@
         <Layout>horizontal</Layout>
         <SizePolicy>me,min</SizePolicy>
         <Children>
-          <!-- Expanding spacer to push EQ knob to right side -->
-          <WidgetGroup><Size>0me,1min</Size></WidgetGroup>
+          <!-- mute button for gain stage -->
+          <PushButton>
+            <TooltipId>mute</TooltipId>
+            <Size>15f,20f</Size>
+            <ObjectName>EQKillButton</ObjectName>
+            <NumberStates>2</NumberStates>
+            <State>
+              <Number>0</Number>
+            </State>
+            <State>
+              <Number>1</Number>
+            </State>
+            <Connection>
+              <ConfigKey><Variable name="group"/>,mute</ConfigKey>
+              <ButtonState>LeftButton</ButtonState>
+            </Connection>
+            <Connection>
+              <ConfigKey>[Skin],show_eq_kill_buttons</ConfigKey>
+              <BindProperty>visible</BindProperty>
+            </Connection>
+          </PushButton>
+          <!-- expanding spacer to push gain knob to right side when kill buttons hidden -->
+          <WidgetGroup>
+            <Size>0me,1min</Size>
+            <Connection>
+              <ConfigKey>[Skin],show_eq_kill_buttons</ConfigKey>
+              <Transform><Not/></Transform>
+              <BindProperty>visible</BindProperty>
+            </Connection>
+          </WidgetGroup>
           <Template src="skin:knob.xml">
             <SetVariable name="TooltipId">pregain</SetVariable>
             <SetVariable name="control">pregain</SetVariable>

--- a/res/skins/Deere/mixer_controls_4decks_right.xml
+++ b/res/skins/Deere/mixer_controls_4decks_right.xml
@@ -92,8 +92,36 @@
             <SetVariable name="control">pregain</SetVariable>
             <SetVariable name="color">green</SetVariable>
           </Template>
-          <!-- Expanding spacer to push EQ knob to left side -->
-          <WidgetGroup><Size>0me,1min</Size></WidgetGroup>
+          <!-- mute button for gain stage -->
+          <PushButton>
+            <TooltipId>mute</TooltipId>
+            <Size>15f,20f</Size>
+            <ObjectName>EQKillButton</ObjectName>
+            <NumberStates>2</NumberStates>
+            <State>
+              <Number>0</Number>
+            </State>
+            <State>
+              <Number>1</Number>
+            </State>
+            <Connection>
+              <ConfigKey><Variable name="group"/>,mute</ConfigKey>
+              <ButtonState>LeftButton</ButtonState>
+            </Connection>
+            <Connection>
+              <ConfigKey>[Skin],show_eq_kill_buttons</ConfigKey>
+              <BindProperty>visible</BindProperty>
+            </Connection>
+          </PushButton>
+          <!-- expanding spacer to push gain knob to left side when kill buttons hidden -->
+          <WidgetGroup>
+            <Size>0me,1min</Size>
+            <Connection>
+              <ConfigKey>[Skin],show_eq_kill_buttons</ConfigKey>
+              <Transform><Not/></Transform>
+              <BindProperty>visible</BindProperty>
+            </Connection>
+          </WidgetGroup>
         </Children>
       </WidgetGroup>
 

--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -2240,7 +2240,7 @@ WEffectChainPresetSelector:!editable,
   }
   WEffectSelector:!editable,
   #fadeModeCombobox:!editable {
-    font: 15px;
+    font: 14px;
   }
   WEffectChainPresetSelector:!editable {
     font: 13px;


### PR DESCRIPTION
adds mute button next to gain knob in all mixer layouts (2-deck and 4-deck). button uses existing EQKillButton styling and is controlled by show_eq_kill_buttons setting. uses [Channel],mute control for channel muting.

closes #15623