### PR TITLE
TraktorFeature: Fixes to Traktor collection importer

### DIFF
--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -435,7 +435,7 @@ TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
 
                 current_path += delimiter;
                 current_path += name;
-                parent = parent->appendChild(QString(name), current_path);
+                parent = parent->appendChild(name.toString(), current_path);
 
                 if (type == QStringLiteral("PLAYLIST")) {
                     // qDebug() << "Playlist: " + current_path << " has parent "

--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -428,7 +428,7 @@ TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
         xml.readNext();
 
         if (xml.isStartElement()) {
-            if (xml.name() == QLatin1StringView("NODE")) {
+            if (xml.name() == QStringLiteral("NODE")) {
                 QXmlStreamAttributes attr = xml.attributes();
                 const QStringView name = attr.value(QStringLiteral("NAME"));
                 const QStringView type = attr.value(QStringLiteral("TYPE"));
@@ -463,7 +463,7 @@ TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
         }
 
         if (xml.isEndElement()) {
-            if (xml.name() == QLatin1StringView("NODE")) {
+            if (xml.name() == QStringLiteral("NODE")) {
                 bool last_non_playlist_was_empty = false;
                 if (!parent->hasChildren() and !playlists.contains(current_path)) {
                     last_non_playlist_was_empty = true;
@@ -484,7 +484,7 @@ TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
                 current_path.remove(lastSlash, path_length - lastSlash);
             }
             // We leave the infinite loop, if we have the closing "PLAYLIST" tag
-            if (xml.name() == QLatin1StringView("PLAYLISTS")) {
+            if (xml.name() == QStringLiteral("PLAYLISTS")) {
                 break;
             }
         }

--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -453,7 +453,7 @@ TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
                             "INSERT INTO traktor_playlist_tracks (playlist_id, track_id, position) "
                             "VALUES (:playlist_id, :track_id, :position)");
 
-                    // process all the entries within the playlist 'name' having path 'current_path'
+                    // Process all the entries within the playlist 'name' having path 'current_path'
                     parsePlaylistEntries(xml,
                             current_path,
                             std::move(query_insert_to_playlists),
@@ -483,7 +483,7 @@ TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
 
                 current_path.remove(lastSlash, path_length - lastSlash);
             }
-            // We leave the infinite loop, if twe have the closing "PLAYLIST" tag
+            // We leave the infinite loop, if we have the closing "PLAYLIST" tag
             if (xml.name() == QLatin1String("PLAYLISTS")) {
                 break;
             }

--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -472,8 +472,9 @@ TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
                 parent = parent->parent();
 
                 if (last_non_playlist_was_empty) {
-                    // If the last node was not a playlist (FOLDER, SMARTLIST, etc... and was empty we remove it
-                    // from the item tree so that it doesn't show for the user.
+                    // If the last node was not a playlist (FOLDER, SMARTLIST,
+                    // etc... and was empty we remove it from the item tree so
+                    // that it doesn't show for the user.
                     parent->removeChildren(parent->children().count() - 1, 1);
                 }
 

--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -407,14 +407,15 @@ void TraktorFeature::parseTrack(QXmlStreamReader &xml, QSqlQuery &query) {
 }
 
 // Purpose: Parsing all the folder and playlists of Traktor
-// This is a complex operation since Traktor uses the concept of folders and playlist.
-// A folder can contain folders and playlists. A playlist contains entries but no folders.
-// In other words, Traktor uses a tree structure to organize music.
-// Inner nodes represent folders while leaves are playlists.
+// This is a complex operation since Traktor uses the concept of folders and
+// playlist. A folder can contain folders and playlists. A playlist contains
+// entries but no folders. In other words, Traktor uses a tree structure to
+// organize music. Inner nodes represent folders while leaves are playlists.
 TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
 
     qDebug() << "Process RootFolder";
-    // Each playlist is unique and can be identified by a path in the tree structure.
+    // Each playlist is unique and can be identified by a path in the
+    // tree structure.
     QString current_path = "";
     QSet<QString> playlists;
 
@@ -430,8 +431,8 @@ TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
 
     QSqlQuery query_insert_to_playlist_tracks(m_database);
     query_insert_to_playlist_tracks.prepare(
-            "INSERT INTO traktor_playlist_tracks (playlist_id, track_id, position) "
-            "VALUES (:playlist_id, :track_id, :position)");
+            "INSERT INTO traktor_playlist_tracks (playlist_id, "
+            "track_id, position) VALUES (:playlist_id, :track_id, :position)");
 
     while (!xml.atEnd() && !m_cancelImport) {
         // Read next XML element
@@ -445,7 +446,8 @@ TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
 
                 current_path += delimiter;
                 current_path += name;
-                parent = parent->appendChild(name.toString(), current_path);
+                parent = parent->appendChild(name.toString(),
+                        current_path);
 
                 if (type == QStringLiteral("PLAYLIST")) {
                     // qDebug() << "Playlist: " + current_path << " has parent "
@@ -453,7 +455,8 @@ TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
 
                     playlists += current_path;
 
-                    // Process all the entries within the playlist 'name' having path 'current_path'
+                    // Process all the entries within the playlist 'name'
+                    // having path 'current_path'
                     parsePlaylistEntries(xml,
                             current_path,
                             &query_insert_to_playlists,
@@ -468,7 +471,8 @@ TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
         if (xml.isEndElement()) {
             if (xml.name() == QStringLiteral("NODE")) {
                 bool last_non_playlist_was_empty = false;
-                if (!parent->hasChildren() and !playlists.contains(current_path)) {
+                if (!parent->hasChildren() and
+                        !playlists.contains(current_path)) {
                     last_non_playlist_was_empty = true;
                 }
 
@@ -478,10 +482,12 @@ TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
                     // If the last node was not a playlist (FOLDER, SMARTLIST,
                     // etc... and was empty we remove it from the item tree so
                     // that it doesn't show for the user.
-                    parent->removeChildren(parent->children().count() - 1, 1);
+                    parent->removeChildren(parent->children().count() - 1,
+                            1);
                 }
 
-                // Whenever we find a closing NODE, remove the last component of the path
+                // Whenever we find a closing NODE, remove the last component
+                // of the path
                 const int lastSlash = current_path.lastIndexOf(delimiter);
                 const int path_length = current_path.size();
 

--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -428,7 +428,7 @@ TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
         xml.readNext();
 
         if (xml.isStartElement()) {
-            if (xml.name() == QLatin1String("NODE")) {
+            if (xml.name() == QLatin1StringView("NODE")) {
                 QXmlStreamAttributes attr = xml.attributes();
                 const QStringView name = attr.value(QStringLiteral("NAME"));
                 const QStringView type = attr.value(QStringLiteral("TYPE"));
@@ -463,7 +463,7 @@ TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
         }
 
         if (xml.isEndElement()) {
-            if (xml.name() == QLatin1String("NODE")) {
+            if (xml.name() == QLatin1StringView("NODE")) {
                 bool last_non_playlist_was_empty = false;
                 if (!parent->hasChildren() and !playlists.contains(current_path)) {
                     last_non_playlist_was_empty = true;
@@ -484,7 +484,7 @@ TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
                 current_path.remove(lastSlash, path_length - lastSlash);
             }
             // We leave the infinite loop, if we have the closing "PLAYLIST" tag
-            if (xml.name() == QLatin1String("PLAYLISTS")) {
+            if (xml.name() == QLatin1StringView("PLAYLISTS")) {
                 break;
             }
         }

--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -414,7 +414,7 @@ void TraktorFeature::parseTrack(QXmlStreamReader &xml, QSqlQuery &query) {
 TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
 
     qDebug() << "Process RootFolder";
-    //Each playlist is unique and can be identified by a path in the tree structure.
+    // Each playlist is unique and can be identified by a path in the tree structure.
     QString current_path = "";
     QSet<QString> playlists;
 
@@ -424,7 +424,7 @@ TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
     TreeItem* parent = rootItem.get();
 
     while (!xml.atEnd() && !m_cancelImport) {
-        //read next XML element
+        // Read next XML element
         xml.readNext();
 
         if (xml.isStartElement()) {
@@ -442,14 +442,14 @@ TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
 
                     playlists += current_path;
 
-                   QSqlQuery query_insert_to_playlists(m_database);
-                   query_insert_to_playlists.prepare("INSERT INTO traktor_playlists (name) "
-                                 "VALUES (:name)");
+                    QSqlQuery query_insert_to_playlists(m_database);
+                    query_insert_to_playlists.prepare("INSERT INTO traktor_playlists (name) "
+                                  "VALUES (:name)");
 
-                   QSqlQuery query_insert_to_playlist_tracks(m_database);
-                   query_insert_to_playlist_tracks.prepare(
-                       "INSERT INTO traktor_playlist_tracks (playlist_id, track_id, position) "
-                       "VALUES (:playlist_id, :track_id, :position)");
+                    QSqlQuery query_insert_to_playlist_tracks(m_database);
+                    query_insert_to_playlist_tracks.prepare(
+                        "INSERT INTO traktor_playlist_tracks (playlist_id, track_id, position) "
+                        "VALUES (:playlist_id, :track_id, :position)");
 
                     // process all the entries within the playlist 'name' having path 'current_path'
                     parsePlaylistEntries(xml,
@@ -481,7 +481,7 @@ TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
 
                 current_path.remove(lastSlash, path_length - lastSlash);
             }
-            //We leave the infinite loop, if twe have the closing "PLAYLIST" tag
+            // We leave the infinite loop, if twe have the closing "PLAYLIST" tag
             if (xml.name() == QLatin1String("PLAYLISTS")) {
                 break;
             }

--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -423,15 +423,6 @@ TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
     std::unique_ptr<TreeItem> rootItem = TreeItem::newRoot(this);
     TreeItem* parent = rootItem.get();
 
-    QSqlQuery query_insert_to_playlists(m_database);
-    query_insert_to_playlists.prepare("INSERT INTO traktor_playlists (name) "
-                  "VALUES (:name)");
-
-    QSqlQuery query_insert_to_playlist_tracks(m_database);
-    query_insert_to_playlist_tracks.prepare(
-        "INSERT INTO traktor_playlist_tracks (playlist_id, track_id, position) "
-        "VALUES (:playlist_id, :track_id, :position)");
-
     while (!xml.atEnd() && !m_cancelImport) {
         //read next XML element
         xml.readNext();
@@ -455,7 +446,16 @@ TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
                     //qDebug() << "Playlist: " +current_path << " has parent " << parent->getData().toString();
                     map.insert(current_path, "PLAYLIST");
 
-                    parent->appendChild(name, current_path);
+                   QSqlQuery query_insert_to_playlists(m_database);
+                   query_insert_to_playlists.prepare("INSERT INTO traktor_playlists (name) "
+                                 "VALUES (:name)");
+
+                   QSqlQuery query_insert_to_playlist_tracks(m_database);
+                   query_insert_to_playlist_tracks.prepare(
+                       "INSERT INTO traktor_playlist_tracks (playlist_id, track_id, position) "
+                       "VALUES (:playlist_id, :track_id, :position)");
+
+                   parent->appendChild(name, current_path);
                     // process all the entries within the playlist 'name' having path 'current_path'
                     parsePlaylistEntries(xml,
                             current_path,

--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -418,7 +418,7 @@ TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
     QString current_path = "";
     QSet<QString> playlists;
 
-    QString delimiter = "-->";
+    const QString delimiter = "-->";
 
     std::unique_ptr<TreeItem> rootItem = TreeItem::newRoot(this);
     TreeItem* parent = rootItem.get();
@@ -430,8 +430,8 @@ TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
         if (xml.isStartElement()) {
             if (xml.name() == QLatin1String("NODE")) {
                 QXmlStreamAttributes attr = xml.attributes();
-                QString name = attr.value("NAME").toString();
-                QString type = attr.value("TYPE").toString();
+                const QString name = attr.value("NAME").toString();
+                const QString type = attr.value("TYPE").toString();
 
                 current_path += delimiter;
                 current_path += name;

--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -437,7 +437,7 @@ TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
                 current_path += name;
                 parent = parent->appendChild(QString(name), current_path);
 
-                if (type == "PLAYLIST") {
+                if (type == QStringLiteral("PLAYLIST")) {
                     // qDebug() << "Playlist: " + current_path << " has parent "
                     // << parent->getData().toString();
 

--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -418,7 +418,7 @@ TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
     QString current_path = "";
     QSet<QString> playlists;
 
-    const QString delimiter = "-->";
+    const QString delimiter = QStringLiteral("-->");
 
     std::unique_ptr<TreeItem> rootItem = TreeItem::newRoot(this);
     TreeItem* parent = rootItem.get();
@@ -430,12 +430,12 @@ TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
         if (xml.isStartElement()) {
             if (xml.name() == QLatin1String("NODE")) {
                 QXmlStreamAttributes attr = xml.attributes();
-                const QString name = attr.value("NAME").toString();
-                const QString type = attr.value("TYPE").toString();
+                const QStringView name = attr.value(QStringLiteral("NAME"));
+                const QStringView type = attr.value(QStringLiteral("TYPE"));
 
                 current_path += delimiter;
                 current_path += name;
-                parent = parent->appendChild(name, current_path);
+                parent = parent->appendChild(QString(name), current_path);
 
                 if (type == "PLAYLIST") {
                     // qDebug() << "Playlist: " + current_path << " has parent "

--- a/src/library/traktor/traktorfeature.cpp
+++ b/src/library/traktor/traktorfeature.cpp
@@ -438,18 +438,20 @@ TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
                 parent = parent->appendChild(name, current_path);
 
                 if (type == "PLAYLIST") {
-                    //qDebug() << "Playlist: " + current_path << " has parent " << parent->getData().toString();
+                    // qDebug() << "Playlist: " + current_path << " has parent "
+                    // << parent->getData().toString();
 
                     playlists += current_path;
 
                     QSqlQuery query_insert_to_playlists(m_database);
-                    query_insert_to_playlists.prepare("INSERT INTO traktor_playlists (name) "
-                                  "VALUES (:name)");
+                    query_insert_to_playlists.prepare(
+                            "INSERT INTO traktor_playlists (name) "
+                            "VALUES (:name)");
 
                     QSqlQuery query_insert_to_playlist_tracks(m_database);
                     query_insert_to_playlist_tracks.prepare(
-                        "INSERT INTO traktor_playlist_tracks (playlist_id, track_id, position) "
-                        "VALUES (:playlist_id, :track_id, :position)");
+                            "INSERT INTO traktor_playlist_tracks (playlist_id, track_id, position) "
+                            "VALUES (:playlist_id, :track_id, :position)");
 
                     // process all the entries within the playlist 'name' having path 'current_path'
                     parsePlaylistEntries(xml,
@@ -476,7 +478,7 @@ TreeItem* TraktorFeature::parsePlaylists(QXmlStreamReader &xml) {
                 }
 
                 // Whenever we find a closing NODE, remove the last component of the path
-                const int lastSlash = current_path.lastIndexOf (delimiter);
+                const int lastSlash = current_path.lastIndexOf(delimiter);
                 const int path_length = current_path.size();
 
                 current_path.remove(lastSlash, path_length - lastSlash);

--- a/src/library/traktor/traktorfeature.h
+++ b/src/library/traktor/traktorfeature.h
@@ -57,8 +57,8 @@ class TraktorFeature : public BaseExternalLibraryFeature {
     // processes a particular playlist
     void parsePlaylistEntries(QXmlStreamReader& xml,
             const QString& playlist_path,
-            QSqlQuery query_insert_into_playlist,
-            QSqlQuery query_insert_into_playlisttracks);
+            QSqlQuery* pQueryInsertIntoPlaylist,
+            QSqlQuery* pQueryInsertIntoPlaylistTracks);
     void clearTable(const QString& table_name);
     static QString getTraktorMusicDatabase();
     // private fields


### PR DESCRIPTION
First PR... be kind :)

Hopefully I'm not misunderstanding some of the intents behind the original code I'm modifying here. If I'm missing some corner cases that this was written done for, let me know.

I tracked down the change that introduced the std::move to a 2022 commit for example. The intent was probably to fix a warning that came with QSqlQuery not being copyable anymore but I'm not sure how the fix ever worked so I'm questioning my understanding of this.