### PR TITLE
Update Pioneer-DDJ-SB3-scripts.js

### DIFF
--- a/res/controllers/Pioneer-DDJ-SB3-scripts.js
+++ b/res/controllers/Pioneer-DDJ-SB3-scripts.js
@@ -277,7 +277,7 @@ PioneerDDJSB3.init = function() {
     PioneerDDJSB3.initDeck("[Channel4]");
 
     if (PioneerDDJSB3.twinkleVumeterAutodjOn) {
-        PioneerDDJSB3.vuMeterTimer = engine.beginTimer(100, PioneerDDJSB3.vuMeterTwinkle());
+        PioneerDDJSB3.vuMeterTimer = engine.beginTimer(100, PioneerDDJSB3.vuMeterTwinkle);
     }
 
     // request the positions of the knobs and faders from the controller


### PR DESCRIPTION
When I used this script, I got an error from mixxx program saying this:  js:280: Error: Invalid timer callback provided to engine.beginTimer. Valid callbacks are strings and functions. Make sure that your code contains no syntax errors. Wasn't sure what it was so I did some digging and found the error:

if (PioneerDDJSB3.twinkleVumeterAutodjOn) {
    PioneerDDJSB3.vuMeterTimer = engine.beginTimer(100, PioneerDDJSB3.vuMeterTwinkle());
}

This updated version fixes the error in MIXXX for me:

if (PioneerDDJSB3.twinkleVumeterAutodjOn) {
    PioneerDDJSB3.vuMeterTimer = engine.beginTimer(100, PioneerDDJSB3.vuMeterTwinkle);
}

I hope this helps someone else in the future!