### PR TITLE
ci: interpolate auto sync issue message at scheduling instead of runtime

### DIFF
--- a/.github/workflows/sync_branches.yml
+++ b/.github/workflows/sync_branches.yml
@@ -86,7 +86,7 @@ jobs:
           COMMIT_MERGE="$(git show --no-patch --format="%h" "${SYNC_BRANCH}")"
           git status
           echo "::endgroup::"
-          conflictIssueNumber=$(gh issue list --label sync-branches --search '"'${CONFLICT_ISSUE_TITLE}'"' --json number --state all | jq -r .[].number)
+          conflictIssueNumber=$(gh issue list --label sync-branches --search '"${{env.CONFLICT_ISSUE_TITLE}}"' --json number --state all | jq -r .[].number)
           if [ "${COMMIT_ORIGINAL}" = "${COMMIT_MERGE}" ]; then
             if [ -z "$(git status --porcelain)" ]; then
               echo "No changes, skipping push and PR creation."


### PR DESCRIPTION
This meant to be the fix I intent to submit in #15634...

> It looks like the sh interpolation is being tricky to work around so using GH interpolation.
>
> This will fix the issue duplicate that keeps being created!
