### PR TITLE
chore(S4MK3): add controller setting color

### DIFF
--- a/res/controllers/Traktor Kontrol S4 MK3.hid.xml
+++ b/res/controllers/Traktor Kontrol S4 MK3.hid.xml
@@ -16,77 +16,89 @@
                     variable="deckA"
                     type="enum"
                     label="Deck A">
-                    <value label="Aqua">aqua</value>
-                    <value label="Azalea">azalea</value>
-                    <value label="Blue">blue</value>
-                    <value label="Celeste">celeste</value>
-                    <value label="Fuscia">fuscia</value>
-                    <value label="Green">green</value>
-                    <value label="Lime">lime</value>
-                    <value label="Orange">orange</value>
-                    <value label="Purple">purple</value>
-                    <value label="Red" default="true">red</value>
-                    <value label="Salmon">salmon</value>
-                    <value label="Sky">sky</value>
-                    <value label="White">white</value>
-                    <value label="Yellow">yellow</value>
+                    <value label="Aqua" color="#00FF49">aqua</value>
+                    <value label="Azalea" color="#FF477E">azalea</value>
+                    <value label="Blue" color="#0000FF">blue</value>
+                    <value label="Carrot" color="#FF5E00">carrot</value>
+                    <value label="Celeste" color="#00FFFF">celeste</value>
+                    <value label="Fuscia" color="#FF0091">fuscia</value>
+                    <value label="Green" color="#00FF00">green</value>
+                    <value label="Honey" color="#FF9200">honey</value>
+                    <value label="Lime" color="#81FF00">lime</value>
+                    <value label="Magenta" color="#FF0079">magenta</value>
+                    <value label="Orange" color="#FF7800">orange</value>
+                    <value label="Purple" color="#FF00FF">purple</value>
+                    <value label="Red" color="#FF0000" default="true">red</value>
+                    <value label="Salmon" color="#FF4761">salmon</value>
+                    <value label="Sky" color="#0091FF">sky</value>
+                    <value label="White" color="#FFFFFF">white</value>
+                    <value label="Yellow" color="#FFFF00">yellow</value>
                 </option>
                 <option
                     variable="deckB"
                     type="enum"
                     label="Deck B">
-                    <value label="Aqua">aqua</value>
-                    <value label="Azalea">azalea</value>
-                    <value label="Blue" default="true">blue</value>
-                    <value label="Celeste">celeste</value>
-                    <value label="Fuscia">fuscia</value>
-                    <value label="Green">green</value>
-                    <value label="Lime">lime</value>
-                    <value label="Orange">orange</value>
-                    <value label="Purple">purple</value>
-                    <value label="Red">red</value>
-                    <value label="Salmon">salmon</value>
-                    <value label="Sky">sky</value>
-                    <value label="White">white</value>
-                    <value label="Yellow">yellow</value>
+                    <value label="Aqua" color="#00FF49">aqua</value>
+                    <value label="Azalea" color="#FF477E">azalea</value>
+                    <value label="Blue" color="#0000FF" default="true">blue</value>
+                    <value label="Carrot" color="#FF5E00">carrot</value>
+                    <value label="Celeste" color="#00FFFF">celeste</value>
+                    <value label="Fuscia" color="#FF0091">fuscia</value>
+                    <value label="Green" color="#00FF00">green</value>
+                    <value label="Honey" color="#FF9200">honey</value>
+                    <value label="Lime" color="#81FF00">lime</value>
+                    <value label="Magenta" color="#FF0079">magenta</value>
+                    <value label="Orange" color="#FF7800">orange</value>
+                    <value label="Purple" color="#FF00FF">purple</value>
+                    <value label="Red" color="#FF0000">red</value>
+                    <value label="Salmon" color="#FF4761">salmon</value>
+                    <value label="Sky" color="#0091FF">sky</value>
+                    <value label="White" color="#FFFFFF">white</value>
+                    <value label="Yellow" color="#FFFF00">yellow</value>
                 </option>
                 <option
                     variable="deckC"
                     type="enum"
                     label="Deck C">
-                    <value label="Aqua">aqua</value>
-                    <value label="Azalea">azalea</value>
-                    <value label="Blue">blue</value>
-                    <value label="Celeste">celeste</value>
-                    <value label="Fuscia">fuscia</value>
-                    <value label="Green">green</value>
-                    <value label="Lime">lime</value>
-                    <value label="Orange">orange</value>
-                    <value label="Purple">purple</value>
-                    <value label="Red">red</value>
-                    <value label="Salmon">salmon</value>
-                    <value label="Sky">sky</value>
-                    <value label="White">white</value>
-                    <value label="Yellow" default="true">yellow</value>
+                    <value label="Aqua" color="#00FF49">aqua</value>
+                    <value label="Azalea" color="#FF477E">azalea</value>
+                    <value label="Blue" color="#0000FF">blue</value>
+                    <value label="Carrot" color="#FF5E00">carrot</value>
+                    <value label="Celeste" color="#00FFFF">celeste</value>
+                    <value label="Fuscia" color="#FF0091">fuscia</value>
+                    <value label="Green" color="#00FF00">green</value>
+                    <value label="Honey" color="#FF9200">honey</value>
+                    <value label="Lime" color="#81FF00">lime</value>
+                    <value label="Magenta" color="#FF0079">magenta</value>
+                    <value label="Orange" color="#FF7800">orange</value>
+                    <value label="Purple" color="#FF00FF">purple</value>
+                    <value label="Red" color="#FF0000">red</value>
+                    <value label="Salmon" color="#FF4761">salmon</value>
+                    <value label="Sky" color="#0091FF">sky</value>
+                    <value label="White" color="#FFFFFF">white</value>
+                    <value label="Yellow" color="#FFFF00" default="true">yellow</value>
                 </option>
                 <option
                     variable="deckD"
                     type="enum"
                     label="Deck D">
-                    <value label="Aqua">aqua</value>
-                    <value label="Azalea">azalea</value>
-                    <value label="Blue">blue</value>
-                    <value label="Celeste">celeste</value>
-                    <value label="Fuscia">fuscia</value>
-                    <value label="Green">green</value>
-                    <value label="Lime">lime</value>
-                    <value label="Orange">orange</value>
-                    <value label="Purple" default="true">purple</value>
-                    <value label="Red">red</value>
-                    <value label="Salmon">salmon</value>
-                    <value label="Sky">sky</value>
-                    <value label="White">white</value>
-                    <value label="Yellow">yellow</value>
+                    <value label="Aqua" color="#00FF49">aqua</value>
+                    <value label="Azalea" color="#FF477E">azalea</value>
+                    <value label="Blue" color="#0000FF">blue</value>
+                    <value label="Carrot" color="#FF5E00">carrot</value>
+                    <value label="Celeste" color="#00FFFF">celeste</value>
+                    <value label="Fuscia" color="#FF0091">fuscia</value>
+                    <value label="Green" color="#00FF00">green</value>
+                    <value label="Honey" color="#FF9200">honey</value>
+                    <value label="Lime" color="#81FF00">lime</value>
+                    <value label="Magenta" color="#FF0079">magenta</value>
+                    <value label="Orange" color="#FF7800">orange</value>
+                    <value label="Purple" color="#FF00FF" default="true">purple</value>
+                    <value label="Red" color="#FF0000">red</value>
+                    <value label="Salmon" color="#FF4761">salmon</value>
+                    <value label="Sky" color="#0091FF">sky</value>
+                    <value label="White" color="#FFFFFF">white</value>
+                    <value label="Yellow" color="#FFFF00">yellow</value>
                 </option>
             </row>
             <option


### PR DESCRIPTION
This is adding the colour indicator next the deck colour combobox in the settings for the S4 Mk3