### PR TITLE
fix(QML): prevent static allocation from being freed

### DIFF
--- a/src/waveform/renderers/allshader/digitsrenderer.cpp
+++ b/src/waveform/renderers/allshader/digitsrenderer.cpp
@@ -186,12 +186,12 @@ void allshader::DigitsRenderNode::updateTexture(rendergraph::Context* pContext,
         blur->setBlurRadius(static_cast<float>(m_penWidth) / 3);
 
         QGraphicsScene scene;
-        QGraphicsPixmapItem item;
-        item.setPixmap(QPixmap::fromImage(image));
-        item.setGraphicsEffect(blur.release());
+        auto item = std::make_unique<QGraphicsPixmapItem>();
+        item->setPixmap(QPixmap::fromImage(image));
+        item->setGraphicsEffect(blur.release());
         image.fill(Qt::transparent);
         QPainter painter(&image);
-        scene.addItem(&item);
+        scene.addItem(item.release());
         scene.render(&painter, QRectF(), QRectF(0, 0, image.width(), image.height()));
     }
 


### PR DESCRIPTION
As per the doc for [QGraphicsScene::addItem](https://doc.qt.io/qt-6/qgraphicsscene.html#addItem)

> This scene takes ownership of the item

This fix prevents the invalid free operation, which seem to impact aarch64 only (Android)