### PR TITLE
fix(QML): improve library performance

### DIFF
--- a/res/qml/Library/TrackList.qml
+++ b/res/qml/Library/TrackList.qml
@@ -184,7 +184,8 @@ Rectangle {
         anchors.bottom: parent.bottom
         anchors.margins: 5
         clip: true
-        reuseItems: true
+        selectionBehavior: TableView.SelectionDisabled
+        pointerNavigationEnabled: false
         Keys.onUpPressed: this.selectionModel.moveSelectionVertical(-1)
         Keys.onDownPressed: this.selectionModel.moveSelectionVertical(1)
         Keys.onEnterPressed: this.loadSelectedTrackIntoNextAvailableDeck(false)
@@ -233,6 +234,9 @@ Rectangle {
                 }
                 const newRow = Mixxx.MathUtils.positiveModulo(row, rowCount);
                 this.select(this.model.index(newRow, 0), ItemSelectionModel.Rows | ItemSelectionModel.Select | ItemSelectionModel.Clear | ItemSelectionModel.Current);
+                if (!view.isRowLoaded(newRow)) {
+                    view.positionViewAtRow(newRow, TableView.Visible | TableView.AlignVCenter)
+                }
             }
 
             function moveSelectionVertical(value) {
@@ -278,18 +282,11 @@ Rectangle {
                 property var capabilities: root.model ? root.model.getCapabilities() : Mixxx.LibraryTrackListModel.Capability.None
                 sourceComponent: delegate
                 focus: true
+                asynchronous: true
+                opacity: loader.status == Loader.Ready
 
-                onLoaded: {
-                // Workaround needed for WaveformOverview column to load the data
-                //     if (track)
-                //         Mixxx.Library.analyze(track)
-                }
+                Behavior on opacity { NumberAnimation { duration: 100; easing.type: Easing.Linear} }
             }
-            // Workaround needed for WaveformOverview column to load the data
-            // TableView.onReused: {
-            //     if (track)
-            //         Mixxx.Library.analyze(track)
-            // }
         }
     }
 }

--- a/src/qml/qmltrackproxy.cpp
+++ b/src/qml/qmltrackproxy.cpp
@@ -106,6 +106,14 @@ QmlTrackProxy::QmlTrackProxy(TrackPointer track, QObject* parent)
             &Track::durationChanged,
             this,
             &QmlTrackProxy::durationChanged);
+    connect(m_pTrack.get(),
+            &Track::waveformSummaryUpdated,
+            this,
+            &QmlTrackProxy::hasWaveformChanged);
+    connect(m_pTrack.get(),
+            &Track::waveformUpdated,
+            this,
+            &QmlTrackProxy::hasWaveformChanged);
 #ifdef __STEM__
     connect(m_pTrack.get(),
             &Track::stemsUpdated,
@@ -181,6 +189,16 @@ PROPERTY_IMPL(QString, trackTotal, getTrackTotal, setTrackTotal)
 PROPERTY_IMPL(QString, comment, getComment, setComment)
 PROPERTY_IMPL(QString, keyText, getKeyText, setKeyText)
 
+QColor QmlTrackProxy::getKeyColor(const QmlConfigProxy* pConfig) const {
+    if (m_pTrack == nullptr) {
+        return QColor();
+    }
+    ColorPaletteSettings colorPaletteSettings(pConfig->get());
+    ColorPalette keyColorPalette = colorPaletteSettings.getConfigKeyColorPalette();
+
+    return KeyUtils::keyToColor(m_pTrack->getKey(), keyColorPalette);
+}
+
 QColor QmlTrackProxy::getColor() const {
     if (m_pTrack == nullptr) {
         return QColor();
@@ -238,6 +256,16 @@ QUrl QmlTrackProxy::getTrackLocationUrl() const {
     }
 
     return QUrl::fromLocalFile(m_pTrack->getLocation());
+}
+
+bool QmlTrackProxy::hasWaveform() const {
+    if (m_pTrack == nullptr) {
+        return false;
+    }
+    const auto& waveform = m_pTrack->getWaveform();
+    const auto& waveformSummary = m_pTrack->getWaveformSummary();
+    return waveform && waveform->getDataSize() > 0 && waveformSummary &&
+            waveformSummary->getDataSize() > 0;
 }
 
 } // namespace qml

--- a/src/qml/qmltrackproxy.h
+++ b/src/qml/qmltrackproxy.h
@@ -11,6 +11,7 @@
 #include "qml/qmlbeatsmodel.h"
 #include "qml/qmlcuesmodel.h"
 #include "qml/qmlstemsmodel.h"
+#include "qmlconfigproxy.h"
 #include "track/track_decl.h"
 #include "util/parented_ptr.h"
 
@@ -40,6 +41,7 @@ class QmlTrackProxy : public QObject {
     Q_PROPERTY(int sampleRate READ getSampleRate NOTIFY sampleRateChanged)
     Q_PROPERTY(QUrl coverArtUrl READ getCoverArtUrl NOTIFY coverArtUrlChanged)
     Q_PROPERTY(QUrl trackLocationUrl READ getTrackLocationUrl NOTIFY trackLocationUrlChanged)
+    Q_PROPERTY(bool hasWaveform READ hasWaveform STORED false NOTIFY hasWaveformChanged)
 
     Q_PROPERTY(mixxx::qml::QmlBeatsModel* beatsModel READ getBeatsModel CONSTANT);
     Q_PROPERTY(mixxx::qml::QmlCuesModel* hotcuesModel READ getCuesModel CONSTANT);
@@ -66,6 +68,7 @@ class QmlTrackProxy : public QObject {
     QString getTrackTotal() const;
     QString getComment() const;
     QString getKeyText() const;
+    Q_INVOKABLE QColor getKeyColor(const mixxx::qml::QmlConfigProxy* pConfig) const;
     QColor getColor() const;
     double getDuration() const;
     int getSampleRate() const;
@@ -85,6 +88,8 @@ class QmlTrackProxy : public QObject {
         return m_pStemsModel.get();
     }
 #endif
+
+    bool hasWaveform() const;
 
     TrackPointer internal() const {
         return m_pTrack;
@@ -134,6 +139,7 @@ class QmlTrackProxy : public QObject {
 #ifdef __STEM__
     void stemsChanged();
 #endif
+    void hasWaveformChanged();
 
   private:
     TrackPointer m_pTrack;


### PR DESCRIPTION
This will improve the library performance by making the cell rendering to use the asynchronous loader. There is further work that could be done to help with the library loading, but this should already provide some help with the current performance drop when scrolling through the library