### PR TITLE
fix(QueenMaryBeats): correctly clamp the beat count value

### DIFF
--- a/src/analyzer/plugins/analyzerqueenmarybeats.cpp
+++ b/src/analyzer/plugins/analyzerqueenmarybeats.cpp
@@ -82,7 +82,7 @@ bool AnalyzerQueenMaryBeats::finalize() {
         --nonZeroCount;
     }
 
-    std::size_t required_size = std::max(static_cast<std::size_t>(0), nonZeroCount - 2);
+    std::size_t required_size = std::max(static_cast<std::size_t>(2), nonZeroCount) - 2;
 
     std::vector<double> df;
     df.reserve(required_size);


### PR DESCRIPTION
If the analyser detects no beats or 1, a vector will attempt to reserve a very large size (2^64 -2) due to an arithmetic underflow and lead to an exception. This fix makes sure to correctly clamp the value in such a way that the subtraction won't lead to such issue.

