### PR TITLE
Fix Unittest on Launchpad by partially reverting #15656

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -137,8 +137,6 @@ jobs:
         run: ctest --timeout 45
         working-directory: build
         env:
-          # Render analyzer waveform tests to an offscreen buffer
-          QT_QPA_PLATFORM: offscreen
           GTEST_COLOR: 1
           # Only use single thread to prevent *.gcna files from overwriting each other
           CTEST_PARALLEL_LEVEL: 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2833,6 +2833,14 @@ if(BUILD_TESTING)
     DISCOVERY_MODE PRE_TEST
   )
 
+  # Default to offscreen rendering during tests.
+  # This is required if the build system like Fedora koji/mock does not
+  # allow to pass environment variables into the ctest macro expansion.
+  set_tests_properties(
+    ${testsuite}
+    PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+  )
+
   if(BUILD_BENCH)
     # Benchmarking
     add_custom_target(


### PR DESCRIPTION
The comments sound like that requiring "QT_QPA_PLATFORM=offscreen" before running ctest is not always possible. 
I have reverted the change to keep this environment variable as CMake property.