### PR TITLE
Pioneer DDJ-FLX4: Implement Key Shift

### DIFF
--- a/res/controllers/Pioneer-DDJ-FLX4-script.js
+++ b/res/controllers/Pioneer-DDJ-FLX4-script.js
@@ -15,6 +15,7 @@
 //      * Beat Loop Mode
 //      * Beat Jump Mode
 //      * Sampler Mode
+//      * Keyshift mode
 //
 //  Custom (Mixxx specific mappings):
 //      * BeatFX: Assigned Effect Unit 1
@@ -40,7 +41,6 @@
 //        * Keyboard mode
 //        * Pad FX1
 //        * Pad FX2
-//        * Keyshift mode
 //
 //  Not implemented yet (but might be in the future):
 //      * Smart CFX
@@ -217,6 +217,15 @@ PioneerDDJFLX4.stemMutePadsFirstControl = 0x40;
 // Stems (KEYBOARD) pad 5 control (pad control = [this value] + [pad  number] - 1)
 PioneerDDJFLX4.stemFxPadsFirstControl = 0x44;
 
+// Pitch shift (KEY SHIFT) pads mode status for deck 1 and 2, without or with SHIFT pressed
+PioneerDDJFLX4.pitchPadsModesStatus = {
+    "[Channel1]": [0x97, 0x98],
+    "[Channel2]": [0x99, 0x9a],
+};
+
+// Pitch shift (KEY SHIFT) pad 1 control (pad control = [this value] + [pad  number] - 1)
+PioneerDDJFLX4.pitchPadsFirstControl = 0x70;
+
 PioneerDDJFLX4.quickJumpSize = 32;
 
 // Used for tempo slider
@@ -294,6 +303,14 @@ PioneerDDJFLX4.init = function() {
             engine.makeConnection(`[QuickEffectRack1_[Channel${deck}_Stem${stem}]]`, "enabled", PioneerDDJFLX4.stemFxChanged);
         }
     }
+
+    // Register callbacks for each deck, when a file is loaded to reset pitch shift
+    engine.makeConnection("[Channel1]", "track_loaded", PioneerDDJFLX4.pitchAdjusted);
+    engine.makeConnection("[Channel2]", "track_loaded", PioneerDDJFLX4.pitchAdjusted);
+
+    // Register callbacks for each deck, when the pitch shift is modified
+    engine.makeConnection("[Channel1]", "pitch_adjust", PioneerDDJFLX4.pitchAdjusted);
+    engine.makeConnection("[Channel2]", "pitch_adjust", PioneerDDJFLX4.pitchAdjusted);
 
     PioneerDDJFLX4.keepAliveTimer = engine.beginTimer(200, PioneerDDJFLX4.sendKeepAlive);
 
@@ -956,6 +973,136 @@ PioneerDDJFLX4.stemFxChanged = function(value, group, _control) {
         );
     }
 };
+
+//
+// Pitch Shift mode
+//
+
+PioneerDDJFLX4.pitchAdjusted = function(_value, group, _control) {
+    const pitchAdjust = engine.getValue(group, "pitch_adjust");
+    let lights = 0b00000000;
+
+    if (pitchAdjust === 0) {
+        lights = 0b10000001;
+    } else if (pitchAdjust === 1) {
+        lights = 0b01000000;
+    } else if (pitchAdjust === 2) {
+        lights = 0b00100000;
+    } else if (pitchAdjust === 3) {
+        lights = 0b00010000;
+    } else if (pitchAdjust === 4) {
+        lights = 0b10010000;
+    } else if (pitchAdjust === 5) {
+        lights = 0b01010000;
+    } else if (pitchAdjust === 6) {
+        lights = 0b00110000;
+    } else if (pitchAdjust === 7) {
+        lights = 0b10110000;
+    } else if (pitchAdjust === 8) {
+        lights = 0b01110000;
+    } else if (pitchAdjust > 8) {
+        lights = 0b11110000;
+    } else if (pitchAdjust === -1) {
+        lights = 0b00000010;
+    } else if (pitchAdjust === -2) {
+        lights = 0b00000100;
+    } else if (pitchAdjust === -3) {
+        lights = 0b00001000;
+    } else if (pitchAdjust === -4) {
+        lights = 0b00001001;
+    } else if (pitchAdjust === -5) {
+        lights = 0b00001010;
+    } else if (pitchAdjust === -6) {
+        lights = 0b00001100;
+    } else if (pitchAdjust === -7) {
+        lights = 0b00001101;
+    } else if (pitchAdjust === -8) {
+        lights = 0b00001110;
+    } else if (pitchAdjust < -8) {
+        lights = 0b00001111;
+    } else {
+        lights = 0b11111111;
+    }
+
+    for (let i=0; i<8; i++) {
+        let code = 0x00;
+        const pad = 0b10000000 >>> i;
+
+        if (lights & pad) {
+            code = 0x7f;
+        } else {
+            code = 0x00;
+        }
+
+        PioneerDDJFLX4.pitchPadsModesStatus[group].forEach(
+            (padMode) => midi.sendShortMsg(
+                padMode,
+                PioneerDDJFLX4.pitchPadsFirstControl + i,
+                code,
+            )
+        );
+    }
+};
+
+PioneerDDJFLX4.pitchPadPressed = function(_channel, control, value, _status, group) {
+    if (value !== 0x7f) {
+        return;
+    }
+
+    const pad = control - this.pitchPadsFirstControl;
+    let pitch = 0;
+
+    if (pad === 0) {
+        pitch = 0;
+    } else if (pad === 1) {
+        pitch = 1;
+    } else if (pad === 2) {
+        pitch = 2;
+    } else if (pad === 3) {
+        pitch = 3;
+    } else if (pad === 4) {
+        pitch = -3;
+    } else if (pad === 5) {
+        pitch = -2;
+    } else if (pad === 6) {
+        pitch = -1;
+    } else if (pad === 7) {
+        pitch = 0;
+    }
+
+    engine.setValue(group, "pitch_adjust", pitch);
+};
+
+PioneerDDJFLX4.pitchPadShiftPressed = function(_channel, control, value, _status, group) {
+    if (value !== 0x7f) {
+        return;
+    }
+
+    const pad = control - this.pitchPadsFirstControl;
+
+    let currentPitch = engine.getValue(group, "pitch_adjust");
+
+    if (pad === 0) {
+        currentPitch += 1;
+    } else if (pad === 1) {
+        currentPitch += 2;
+    } else if (pad === 2) {
+        currentPitch += 3;
+    } else if (pad === 3) {
+        currentPitch += 4;
+    } else if (pad === 4) {
+        currentPitch += -4;
+    } else if (pad === 5) {
+        currentPitch += -3;
+    } else if (pad === 6) {
+        currentPitch += -2;
+    } else if (pad === 7) {
+        currentPitch += -1;
+    }
+
+    engine.setValue(group, "pitch_adjust", currentPitch);
+};
+
 
 //
 // Shutdown

--- a/res/controllers/Pioneer-DDJ-FLX4-script.js
+++ b/res/controllers/Pioneer-DDJ-FLX4-script.js
@@ -979,7 +979,7 @@ PioneerDDJFLX4.stemFxChanged = function(value, group, _control) {
 //
 
 PioneerDDJFLX4.pitchAdjusted = function(_value, group, _control) {
-    const pitchAdjust = engine.getValue(group, "pitch_adjust");
+    const pitchAdjust = Math.round(engine.getValue(group, "pitch_adjust"));
     let lights = 0b00000000;
 
     if (pitchAdjust === 0) {

--- a/res/controllers/Pioneer-DDJ-FLX4-script.js
+++ b/res/controllers/Pioneer-DDJ-FLX4-script.js
@@ -27,7 +27,7 @@
 //
 //      * 32 beat jump forward & back (Shift + </> CUE/LOOP CALL arrows)
 //      * Toggle quantize (Shift + channel cue)
-//      * Stems selection using PADs (using controller's KeyShift mode)
+//      * Stems selection using PADs (using controller's Keyboard mode)
 //
 //  Not implemented (after discussion and trial attempts):
 //      * Loop Section:
@@ -205,17 +205,17 @@ PioneerDDJFLX4.beatjumpSizeForPad = {
     0x27: 8   // PAD 8
 };
 
-// Stems (KEY SHIFT) pads mode status for deck 1 and 2, without or with SHIFT pressed
+// Stems (KEYBOARD) pads mode status for deck 1 and 2, without or with SHIFT pressed
 PioneerDDJFLX4.stemsPadsModesStatus = {
     "[Channel1]": [0x97, 0x98],
     "[Channel2]": [0x99, 0x9a],
 };
 
-// Stems (KEY SHIFT) pad 1 control (pad control = [this value] + [pad  number] - 1)
-PioneerDDJFLX4.stemMutePadsFirstControl = 0x70;
+// Stems (KEYBOARD) pad 1 control (pad control = [this value] + [pad  number] - 1)
+PioneerDDJFLX4.stemMutePadsFirstControl = 0x40;
 
-// Stems (KEY SHIFT) pad 5 control (pad control = [this value] + [pad  number] - 1)
-PioneerDDJFLX4.stemFxPadsFirstControl = 0x74;
+// Stems (KEYBOARD) pad 5 control (pad control = [this value] + [pad  number] - 1)
+PioneerDDJFLX4.stemFxPadsFirstControl = 0x44;
 
 PioneerDDJFLX4.quickJumpSize = 32;
 

--- a/res/controllers/Pioneer-DDJ-FLX4.midi.xml
+++ b/res/controllers/Pioneer-DDJ-FLX4.midi.xml
@@ -1572,8 +1572,330 @@
             </control>
             <!-- HOT CUE MODE END -->
 
-            <!-- BEAT LOOP MODE START -->
+            <!-- KEYBOARD MODE START -->
+            <control>
+                <description>PAD 1 (DECK1) KEYBOARD MODE - press - Toggle Stem 1</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.stemMutePadPressed</key>
+                <status>0x97</status>
+                <midino>0x40</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 1 +SHIFT (DECK1) KEYBOARD MODE - press - Only Stem 1 active</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.stemMutePadShiftPressed</key>
+                <status>0x98</status>
+                <midino>0x40</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 1 (DECK2) KEYBOARD MODE - press - Toggle Stem 1</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.stemMutePadPressed</key>
+                <status>0x99</status>
+                <midino>0x40</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 1 +SHIFT (DECK2) KEYBOARD MODE - press - Only Stem 1 active</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.stemMutePadShiftPressed</key>
+                <status>0x9A</status>
+                <midino>0x40</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 2 (DECK1) KEYBOARD MODE - press - Toggle Stem 2</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.stemMutePadPressed</key>
+                <status>0x97</status>
+                <midino>0x41</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 2 +SHIFT (DECK1) KEYBOARD MODE - press - Only Stem 2 active</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.stemMutePadShiftPressed</key>
+                <status>0x98</status>
+                <midino>0x41</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 2 (DECK2) KEYBOARD MODE - press - Toggle Stem 2</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.stemMutePadPressed</key>
+                <status>0x99</status>
+                <midino>0x41</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 2 +SHIFT (DECK2) KEYBOARD MODE - press - Only Stem 2 active</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.stemMutePadShiftPressed</key>
+                <status>0x9A</status>
+                <midino>0x41</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 3 (DECK1) KEYBOARD MODE - press - Toggle Stem 3</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.stemMutePadPressed</key>
+                <status>0x97</status>
+                <midino>0x42</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 3 +SHIFT (DECK1) KEYBOARD MODE - press - Only Stem 3 active</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.stemMutePadShiftPressed</key>
+                <status>0x98</status>
+                <midino>0x42</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 3 (DECK2) KEYBOARD MODE - press - Toggle Stem 3</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.stemMutePadPressed</key>
+                <status>0x99</status>
+                <midino>0x42</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 3 +SHIFT (DECK2) KEYBOARD MODE - press - Only Stem 3 active</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.stemMutePadShiftPressed</key>
+                <status>0x9A</status>
+                <midino>0x42</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 4 (DECK1) KEYBOARD MODE - press - Toggle Stem 4</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.stemMutePadPressed</key>
+                <status>0x97</status>
+                <midino>0x43</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 4 +SHIFT (DECK1) KEYBOARD MODE - press - Only Stem 4 active</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.stemMutePadShiftPressed</key>
+                <status>0x98</status>
+                <midino>0x43</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 4 (DECK2) KEYBOARD MODE - press - Toggle Stem 4</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.stemMutePadPressed</key>
+                <status>0x99</status>
+                <midino>0x43</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 4 +SHIFT (DECK2) KEYBOARD MODE - press - Only Stem 4 active</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.stemMutePadShiftPressed</key>
+                <status>0x9A</status>
+                <midino>0x43</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 5 (DECK1) KEYBOARD MODE - press - Toggle Stem 1 FX</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.stemFxPadPressed</key>
+                <status>0x97</status>
+                <midino>0x44</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 5 +SHIFT (DECK1) KEYBOARD MODE - press - Only Stem 1 FX active</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.stemFxPadShiftPressed</key>
+                <status>0x98</status>
+                <midino>0x44</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 5 (DECK2) KEYBOARD MODE - press - Toggle Stem 1 FX</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.stemFxPadPressed</key>
+                <status>0x99</status>
+                <midino>0x44</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 5 +SHIFT (DECK2) KEYBOARD MODE - press - Only Stem 1 FX active</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.stemFxPadShiftPressed</key>
+                <status>0x9A</status>
+                <midino>0x44</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 6 (DECK1) KEYBOARD MODE - press - Toggle Stem 2 FX</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.stemFxPadPressed</key>
+                <status>0x97</status>
+                <midino>0x45</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 6 +SHIFT (DECK1) KEYBOARD MODE - press - Only Stem 2 FX active</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.stemFxPadShiftPressed</key>
+                <status>0x98</status>
+                <midino>0x45</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 6 (DECK2) KEYBOARD MODE - press - Toggle Stem 2 FX</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.stemFxPadPressed</key>
+                <status>0x99</status>
+                <midino>0x45</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 6 +SHIFT (DECK2) KEYBOARD MODE - press - Only Stem 2 FX active</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.stemFxPadShiftPressed</key>
+                <status>0x9A</status>
+                <midino>0x45</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 7 (DECK1) KEYBOARD MODE - press - Toggle Stem 3 FX</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.stemFxPadPressed</key>
+                <status>0x97</status>
+                <midino>0x46</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 7 +SHIFT (DECK1) KEYBOARD MODE - press - Only Stem 3 FX active</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.stemFxPadShiftPressed</key>
+                <status>0x98</status>
+                <midino>0x46</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 7 (DECK2) KEYBOARD MODE - press - Toggle Stem 3 FX</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.stemFxPadPressed</key>
+                <status>0x99</status>
+                <midino>0x46</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 7 +SHIFT (DECK2) KEYBOARD MODE - press - Only Stem 3 FX active</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.stemFxPadShiftPressed</key>
+                <status>0x9A</status>
+                <midino>0x46</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 8 (DECK1) KEYBOARD MODE - press - Toggle Stem 4 FX</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.stemFxPadPressed</key>
+                <status>0x97</status>
+                <midino>0x47</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 8 +SHIFT (DECK1) KEYBOARD MODE - press - Only Stem 4 FX active</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.stemFxPadShiftPressed</key>
+                <status>0x98</status>
+                <midino>0x47</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 8 (DECK2) KEYBOARD MODE - press - Toggle Stem 4 FX</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.stemFxPadPressed</key>
+                <status>0x99</status>
+                <midino>0x47</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 8 +SHIFT (DECK2) KEYBOARD MODE - press - Only Stem 4 FX active</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.stemFxPadShiftPressed</key>
+                <status>0x9A</status>
+                <midino>0x47</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <!-- KEYBOARD MODE END -->
 
+            <!-- BEAT LOOP MODE START -->
             <control>
                 <description>PAD 1 (DECK1) BEAT LOOP MODE - press - 1/4 Beatloop</description>
                 <group>[Channel1]</group>
@@ -2264,328 +2586,6 @@
                 </options>
             </control>
             <!-- SAMPLER MODE END -->
-
-            <!-- KEYSHIFT MODE START -->
-            <control>
-                <description>PAD 1 (DECK1) KEYSHIFT MODE - press - Toggle Stem 1</description>
-                <group>[Channel1]</group>
-                <key>PioneerDDJFLX4.stemMutePadPressed</key>
-                <status>0x97</status>
-                <midino>0x70</midino>
-                <options>
-                    <Script-Binding/>
-                </options>
-            </control>
-            <control>
-                <description>PAD 1 +SHIFT (DECK1) KEYSHIFT MODE - press - Only Stem 1 active</description>
-                <group>[Channel1]</group>
-                <key>PioneerDDJFLX4.stemMutePadShiftPressed</key>
-                <status>0x98</status>
-                <midino>0x70</midino>
-                <options>
-                    <Script-Binding/>
-                </options>
-            </control>
-            <control>
-                <description>PAD 1 (DECK2) KEYSHIFT MODE - press - Toggle Stem 1</description>
-                <group>[Channel2]</group>
-                <key>PioneerDDJFLX4.stemMutePadPressed</key>
-                <status>0x99</status>
-                <midino>0x70</midino>
-                <options>
-                    <Script-Binding/>
-                </options>
-            </control>
-            <control>
-                <description>PAD 1 +SHIFT (DECK2) KEYSHIFT MODE - press - Only Stem 1 active</description>
-                <group>[Channel2]</group>
-                <key>PioneerDDJFLX4.stemMutePadShiftPressed</key>
-                <status>0x9A</status>
-                <midino>0x70</midino>
-                <options>
-                    <Script-Binding/>
-                </options>
-            </control>
-            <control>
-                <description>PAD 2 (DECK1) KEYSHIFT MODE - press - Toggle Stem 2</description>
-                <group>[Channel1]</group>
-                <key>PioneerDDJFLX4.stemMutePadPressed</key>
-                <status>0x97</status>
-                <midino>0x71</midino>
-                <options>
-                    <Script-Binding/>
-                </options>
-            </control>
-            <control>
-                <description>PAD 2 +SHIFT (DECK1) KEYSHIFT MODE - press - Only Stem 2 active</description>
-                <group>[Channel1]</group>
-                <key>PioneerDDJFLX4.stemMutePadShiftPressed</key>
-                <status>0x98</status>
-                <midino>0x71</midino>
-                <options>
-                    <Script-Binding/>
-                </options>
-            </control>
-            <control>
-                <description>PAD 2 (DECK2) KEYSHIFT MODE - press - Toggle Stem 2</description>
-                <group>[Channel2]</group>
-                <key>PioneerDDJFLX4.stemMutePadPressed</key>
-                <status>0x99</status>
-                <midino>0x71</midino>
-                <options>
-                    <Script-Binding/>
-                </options>
-            </control>
-            <control>
-                <description>PAD 2 +SHIFT (DECK2) KEYSHIFT MODE - press - Only Stem 2 active</description>
-                <group>[Channel2]</group>
-                <key>PioneerDDJFLX4.stemMutePadShiftPressed</key>
-                <status>0x9A</status>
-                <midino>0x71</midino>
-                <options>
-                    <Script-Binding/>
-                </options>
-            </control>
-            <control>
-                <description>PAD 3 (DECK1) KEYSHIFT MODE - press - Toggle Stem 3</description>
-                <group>[Channel1]</group>
-                <key>PioneerDDJFLX4.stemMutePadPressed</key>
-                <status>0x97</status>
-                <midino>0x72</midino>
-                <options>
-                    <Script-Binding/>
-                </options>
-            </control>
-            <control>
-                <description>PAD 3 +SHIFT (DECK1) KEYSHIFT MODE - press - Only Stem 3 active</description>
-                <group>[Channel1]</group>
-                <key>PioneerDDJFLX4.stemMutePadShiftPressed</key>
-                <status>0x98</status>
-                <midino>0x72</midino>
-                <options>
-                    <Script-Binding/>
-                </options>
-            </control>
-            <control>
-                <description>PAD 3 (DECK2) KEYSHIFT MODE - press - Toggle Stem 3</description>
-                <group>[Channel2]</group>
-                <key>PioneerDDJFLX4.stemMutePadPressed</key>
-                <status>0x99</status>
-                <midino>0x72</midino>
-                <options>
-                    <Script-Binding/>
-                </options>
-            </control>
-            <control>
-                <description>PAD 3 +SHIFT (DECK2) KEYSHIFT MODE - press - Only Stem 3 active</description>
-                <group>[Channel2]</group>
-                <key>PioneerDDJFLX4.stemMutePadShiftPressed</key>
-                <status>0x9A</status>
-                <midino>0x72</midino>
-                <options>
-                    <Script-Binding/>
-                </options>
-            </control>
-            <control>
-                <description>PAD 4 (DECK1) KEYSHIFT MODE - press - Toggle Stem 4</description>
-                <group>[Channel1]</group>
-                <key>PioneerDDJFLX4.stemMutePadPressed</key>
-                <status>0x97</status>
-                <midino>0x73</midino>
-                <options>
-                    <Script-Binding/>
-                </options>
-            </control>
-            <control>
-                <description>PAD 4 +SHIFT (DECK1) KEYSHIFT MODE - press - Only Stem 4 active</description>
-                <group>[Channel1]</group>
-                <key>PioneerDDJFLX4.stemMutePadShiftPressed</key>
-                <status>0x98</status>
-                <midino>0x73</midino>
-                <options>
-                    <Script-Binding/>
-                </options>
-            </control>
-            <control>
-                <description>PAD 4 (DECK2) KEYSHIFT MODE - press - Toggle Stem 4</description>
-                <group>[Channel2]</group>
-                <key>PioneerDDJFLX4.stemMutePadPressed</key>
-                <status>0x99</status>
-                <midino>0x73</midino>
-                <options>
-                    <Script-Binding/>
-                </options>
-            </control>
-            <control>
-                <description>PAD 4 +SHIFT (DECK2) KEYSHIFT MODE - press - Only Stem 4 active</description>
-                <group>[Channel2]</group>
-                <key>PioneerDDJFLX4.stemMutePadShiftPressed</key>
-                <status>0x9A</status>
-                <midino>0x73</midino>
-                <options>
-                    <Script-Binding/>
-                </options>
-            </control>
-            <control>
-                <description>PAD 5 (DECK1) KEYSHIFT MODE - press - Toggle Stem 1 FX</description>
-                <group>[Channel1]</group>
-                <key>PioneerDDJFLX4.stemFxPadPressed</key>
-                <status>0x97</status>
-                <midino>0x74</midino>
-                <options>
-                    <Script-Binding/>
-                </options>
-            </control>
-            <control>
-                <description>PAD 5 +SHIFT (DECK1) KEYSHIFT MODE - press - Only Stem 1 FX active</description>
-                <group>[Channel1]</group>
-                <key>PioneerDDJFLX4.stemFxPadShiftPressed</key>
-                <status>0x98</status>
-                <midino>0x74</midino>
-                <options>
-                    <Script-Binding/>
-                </options>
-            </control>
-            <control>
-                <description>PAD 5 (DECK2) KEYSHIFT MODE - press - Toggle Stem 1 FX</description>
-                <group>[Channel2]</group>
-                <key>PioneerDDJFLX4.stemFxPadPressed</key>
-                <status>0x99</status>
-                <midino>0x74</midino>
-                <options>
-                    <Script-Binding/>
-                </options>
-            </control>
-            <control>
-                <description>PAD 5 +SHIFT (DECK2) KEYSHIFT MODE - press - Only Stem 1 FX active</description>
-                <group>[Channel2]</group>
-                <key>PioneerDDJFLX4.stemFxPadShiftPressed</key>
-                <status>0x9A</status>
-                <midino>0x74</midino>
-                <options>
-                    <Script-Binding/>
-                </options>
-            </control>
-            <control>
-                <description>PAD 6 (DECK1) KEYSHIFT MODE - press - Toggle Stem 2 FX</description>
-                <group>[Channel1]</group>
-                <key>PioneerDDJFLX4.stemFxPadPressed</key>
-                <status>0x97</status>
-                <midino>0x75</midino>
-                <options>
-                    <Script-Binding/>
-                </options>
-            </control>
-            <control>
-                <description>PAD 6 +SHIFT (DECK1) KEYSHIFT MODE - press - Only Stem 2 FX active</description>
-                <group>[Channel1]</group>
-                <key>PioneerDDJFLX4.stemFxPadShiftPressed</key>
-                <status>0x98</status>
-                <midino>0x75</midino>
-                <options>
-                    <Script-Binding/>
-                </options>
-            </control>
-            <control>
-                <description>PAD 6 (DECK2) KEYSHIFT MODE - press - Toggle Stem 2 FX</description>
-                <group>[Channel2]</group>
-                <key>PioneerDDJFLX4.stemFxPadPressed</key>
-                <status>0x99</status>
-                <midino>0x75</midino>
-                <options>
-                    <Script-Binding/>
-                </options>
-            </control>
-            <control>
-                <description>PAD 6 +SHIFT (DECK2) KEYSHIFT MODE - press - Only Stem 2 FX active</description>
-                <group>[Channel2]</group>
-                <key>PioneerDDJFLX4.stemFxPadShiftPressed</key>
-                <status>0x9A</status>
-                <midino>0x75</midino>
-                <options>
-                    <Script-Binding/>
-                </options>
-            </control>
-            <control>
-                <description>PAD 7 (DECK1) KEYSHIFT MODE - press - Toggle Stem 3 FX</description>
-                <group>[Channel1]</group>
-                <key>PioneerDDJFLX4.stemFxPadPressed</key>
-                <status>0x97</status>
-                <midino>0x76</midino>
-                <options>
-                    <Script-Binding/>
-                </options>
-            </control>
-            <control>
-                <description>PAD 7 +SHIFT (DECK1) KEYSHIFT MODE - press - Only Stem 3 FX active</description>
-                <group>[Channel1]</group>
-                <key>PioneerDDJFLX4.stemFxPadShiftPressed</key>
-                <status>0x98</status>
-                <midino>0x76</midino>
-                <options>
-                    <Script-Binding/>
-                </options>
-            </control>
-            <control>
-                <description>PAD 7 (DECK2) KEYSHIFT MODE - press - Toggle Stem 3 FX</description>
-                <group>[Channel2]</group>
-                <key>PioneerDDJFLX4.stemFxPadPressed</key>
-                <status>0x99</status>
-                <midino>0x76</midino>
-                <options>
-                    <Script-Binding/>
-                </options>
-            </control>
-            <control>
-                <description>PAD 7 +SHIFT (DECK2) KEYSHIFT MODE - press - Only Stem 3 FX active</description>
-                <group>[Channel2]</group>
-                <key>PioneerDDJFLX4.stemFxPadShiftPressed</key>
-                <status>0x9A</status>
-                <midino>0x76</midino>
-                <options>
-                    <Script-Binding/>
-                </options>
-            </control>
-            <control>
-                <description>PAD 8 (DECK1) KEYSHIFT MODE - press - Toggle Stem 4 FX</description>
-                <group>[Channel1]</group>
-                <key>PioneerDDJFLX4.stemFxPadPressed</key>
-                <status>0x97</status>
-                <midino>0x77</midino>
-                <options>
-                    <Script-Binding/>
-                </options>
-            </control>
-            <control>
-                <description>PAD 8 +SHIFT (DECK1) KEYSHIFT MODE - press - Only Stem 4 FX active</description>
-                <group>[Channel1]</group>
-                <key>PioneerDDJFLX4.stemFxPadShiftPressed</key>
-                <status>0x98</status>
-                <midino>0x77</midino>
-                <options>
-                    <Script-Binding/>
-                </options>
-            </control>
-            <control>
-                <description>PAD 8 (DECK2) KEYSHIFT MODE - press - Toggle Stem 4 FX</description>
-                <group>[Channel2]</group>
-                <key>PioneerDDJFLX4.stemFxPadPressed</key>
-                <status>0x99</status>
-                <midino>0x77</midino>
-                <options>
-                    <Script-Binding/>
-                </options>
-            </control>
-            <control>
-                <description>PAD 8 +SHIFT (DECK2) KEYSHIFT MODE - press - Only Stem 4 FX active</description>
-                <group>[Channel2]</group>
-                <key>PioneerDDJFLX4.stemFxPadShiftPressed</key>
-                <status>0x9A</status>
-                <midino>0x77</midino>
-                <options>
-                    <Script-Binding/>
-                </options>
-            </control>
 
             <!-- PAD Section END -->
         </controls>

--- a/res/controllers/Pioneer-DDJ-FLX4.midi.xml
+++ b/res/controllers/Pioneer-DDJ-FLX4.midi.xml
@@ -2587,6 +2587,329 @@
             </control>
             <!-- SAMPLER MODE END -->
 
+            <!-- KEY SHIFT MODE START -->
+            <control>
+                <description>PAD 1 (DECK1) KEY SHIFT MODE - press - No pitch modification</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.pitchPadPressed</key>
+                <status>0x97</status>
+                <midino>0x70</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 1 +SHIFT (DECK1) KEY SHIFT MODE - press - Increase the pitch by 1 semitone</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.pitchPadShiftPressed</key>
+                <status>0x98</status>
+                <midino>0x70</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 1 (DECK2) KEY SHIFT MODE - press - No pitch modification</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.pitchPadPressed</key>
+                <status>0x99</status>
+                <midino>0x70</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 1 +SHIFT (DECK2) KEY SHIFT MODE - press - Increase the pitch by 1 semitone</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.pitchPadShiftPressed</key>
+                <status>0x9A</status>
+                <midino>0x70</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 2 (DECK1) KEY SHIFT MODE - press - Set pitch to one semitone up</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.pitchPadPressed</key>
+                <status>0x97</status>
+                <midino>0x71</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 2 +SHIFT (DECK1) KEY SHIFT MODE - press - Increase the pitch by 2 semitones</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.pitchPadShiftPressed</key>
+                <status>0x98</status>
+                <midino>0x71</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 2 (DECK2) KEY SHIFT MODE - press - Set pitch to one semitone up</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.pitchPadPressed</key>
+                <status>0x99</status>
+                <midino>0x71</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 2 +SHIFT (DECK2) KEY SHIFT MODE - press - Increase the pitch by 2 semitones</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.pitchPadShiftPressed</key>
+                <status>0x9A</status>
+                <midino>0x71</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 3 (DECK1) KEY SHIFT MODE - press - Set the pitch to 2 semitones up</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.pitchPadPressed</key>
+                <status>0x97</status>
+                <midino>0x72</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 3 +SHIFT (DECK1) KEY SHIFT MODE - press - Increase the pitch by 3 semitones</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.pitchPadShiftPressed</key>
+                <status>0x98</status>
+                <midino>0x72</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 3 (DECK2) KEY SHIFT MODE - press - Set the pitch to 2 semitones up</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.pitchPadPressed</key>
+                <status>0x99</status>
+                <midino>0x72</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 3 +SHIFT (DECK2) KEY SHIFT MODE - press - Increase the pitch by 3 semitones</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.pitchPadShiftPressed</key>
+                <status>0x9A</status>
+                <midino>0x72</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 4 (DECK1) KEY SHIFT MODE - press - Set the pitch to 3 semitones up</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.pitchPadPressed</key>
+                <status>0x97</status>
+                <midino>0x73</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 4 +SHIFT (DECK1) KEY SHIFT MODE - press - Increase the pitch by 4 semitones</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.pitchPadShiftPressed</key>
+                <status>0x98</status>
+                <midino>0x73</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 4 (DECK2) KEY SHIFT MODE - press - Set the pitch to 3 semitones up</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.pitchPadPressed</key>
+                <status>0x99</status>
+                <midino>0x73</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 4 +SHIFT (DECK2) KEY SHIFT MODE - press - Increase the pitch by 4 semitones</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.pitchPadShiftPressed</key>
+                <status>0x9A</status>
+                <midino>0x73</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 5 (DECK1) KEY SHIFT MODE - press - Set the pitch to 3 semitones down</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.pitchPadPressed</key>
+                <status>0x97</status>
+                <midino>0x74</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 5 +SHIFT (DECK1) KEY SHIFT MODE - press - Decrease the pitch by 1 semitons</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.pitchPadShiftPressed</key>
+                <status>0x98</status>
+                <midino>0x74</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 5 (DECK2) KEY SHIFT MODE - press - Set the pitch to 3 semitones down</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.pitchPadPressed</key>
+                <status>0x99</status>
+                <midino>0x74</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 5 +SHIFT (DECK2) KEY SHIFT MODE - press - Decrease the pitch by 1 semitone</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.pitchPadShiftPressed</key>
+                <status>0x9A</status>
+                <midino>0x74</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 6 (DECK1) KEY SHIFT MODE - press - Set the pitch to 2 semitones down</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.pitchPadPressed</key>
+                <status>0x97</status>
+                <midino>0x75</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 6 +SHIFT (DECK1) KEY SHIFT MODE - press - Decrease the pitch by 2 semitones</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.pitchPadShiftPressed</key>
+                <status>0x98</status>
+                <midino>0x75</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 6 (DECK2) KEY SHIFT MODE - press - Set the pitch to 2 semitones down</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.pitchPadPressed</key>
+                <status>0x99</status>
+                <midino>0x75</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 6 +SHIFT (DECK2) KEY SHIFT MODE - press - Decrease the pitch by 2 semitones</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.pitchPadShiftPressed</key>
+                <status>0x9A</status>
+                <midino>0x75</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 7 (DECK1) KEY SHIFT MODE - press - Set the pitch to 1 semitones down</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.pitchPadPressed</key>
+                <status>0x97</status>
+                <midino>0x76</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 7 +SHIFT (DECK1) KEY SHIFT MODE - press - Decrease the pitch by 3 semitones</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.pitchPadShiftPressed</key>
+                <status>0x98</status>
+                <midino>0x76</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 7 (DECK2) KEY SHIFT MODE - press - Set the pitch to 1 semitones down</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.pitchPadPressed</key>
+                <status>0x99</status>
+                <midino>0x76</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 7 +SHIFT (DECK2) KEY SHIFT MODE - press - Decrease the pitch by 3 semitones</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.pitchPadShiftPressed</key>
+                <status>0x9A</status>
+                <midino>0x76</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 8 (DECK1) KEY SHIFT MODE - press - No pitch modification</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.pitchPadPressed</key>
+                <status>0x97</status>
+                <midino>0x77</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 8 +SHIFT (DECK1) KEY SHIFT MODE - press - Decrease the pitch by 4 semitones</description>
+                <group>[Channel1]</group>
+                <key>PioneerDDJFLX4.pitchPadShiftPressed</key>
+                <status>0x98</status>
+                <midino>0x77</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 8 (DECK2) KEY SHIFT MODE - press - No pitch modification</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.pitchPadPressed</key>
+                <status>0x99</status>
+                <midino>0x77</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <control>
+                <description>PAD 8 +SHIFT (DECK2) KEY SHIFT MODE - press - Decrease the pitch by 4 semitones</description>
+                <group>[Channel2]</group>
+                <key>PioneerDDJFLX4.pitchPadShiftPressed</key>
+                <status>0x9A</status>
+                <midino>0x77</midino>
+                <options>
+                    <Script-Binding/>
+                </options>
+            </control>
+            <!-- KEYBOARD MODE END -->
+
             <!-- PAD Section END -->
         </controls>
         <outputs>


### PR DESCRIPTION
This PR implements the "KeyShift" pad mode of the Pioneer DDJ-FLX4 controller.

To use the right Pad mode as written on the physical controller, this PR also move the Stem mode I proposed in PR https://github.com/mixxxdj/mixxx/pull/15528 to the "Keyboard" pad mode (sorry for that...)

The related documentation PR is also proposed.