### PR TITLE
(fix) Computer feature: stop model population when switching to another feature

### DIFF
--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -49,6 +49,10 @@ BrowseFeature::BrowseFeature(
           m_proxyModel(&m_browseModel, true),
           m_pSidebarModel(new FolderTreeModel(this)) {
     connect(&m_browseModel,
+            &BrowseTableModel::saveModelState,
+            this,
+            &LibraryFeature::saveModelState);
+    connect(&m_browseModel,
             &BrowseTableModel::restoreModelState,
             this,
             &LibraryFeature::restoreModelState);

--- a/src/library/browse/browsetablemodel.cpp
+++ b/src/library/browse/browsetablemodel.cpp
@@ -368,10 +368,10 @@ void BrowseTableModel::slotClear(BrowseTableModel* caller_object) {
 
 void BrowseTableModel::slotInsert(const QList<QList<QStandardItem*>>& rows,
         BrowseTableModel* caller_object) {
-    // There exists more than one BrowseTableModel in Mixxx We only want to
-    // receive items here, this object has 'ordered' by the BrowserThread
-    // (singleton)
+    // There exists more than one BrowseTableModel in Mixxx and we only want to
+    // receive items this object has 'ordered' from the BrowseThread (singleton)
     if (caller_object == this) {
+        emit saveModelState();
         //qDebug() << "BrowseTableModel::slotInsert";
         for (int i = 0; i < rows.size(); ++i) {
             appendRow(rows.at(i));

--- a/src/library/browse/browsetablemodel.cpp
+++ b/src/library/browse/browsetablemodel.cpp
@@ -208,10 +208,11 @@ void BrowseTableModel::setPath(mixxx::FileAccess path) {
 
     if (path.info().hasLocation() && path.info().isDir()) {
         m_currentDirectory = path.info().location();
+        m_pBrowseThread->executePopulation(std::move(path), this);
     } else {
-        m_currentDirectory = QString();
+        m_currentDirectory = {};
+        m_pBrowseThread->executePopulation({}, this);
     }
-    m_pBrowseThread->executePopulation(std::move(path), this);
 }
 
 TrackPointer BrowseTableModel::getTrack(const QModelIndex& index) const {

--- a/src/library/browse/browsetablemodel.h
+++ b/src/library/browse/browsetablemodel.h
@@ -103,6 +103,7 @@ class BrowseTableModel final : public QStandardItemModel, public virtual TrackMo
     void releaseBrowseThread();
 
   signals:
+    void saveModelState();
     void restoreModelState();
 
   public slots:

--- a/src/library/browse/browsetablemodel.h
+++ b/src/library/browse/browsetablemodel.h
@@ -56,6 +56,14 @@ class BrowseTableModel final : public QStandardItemModel, public virtual TrackMo
     // initiate table population, store path
     void setPath(mixxx::FileAccess path);
 
+    /// Stop the BrowseThread, potentially still running and population
+    /// the model, by setting an empty path in order to avoid its update
+    /// signals still affecting the selection in the shared WTrackTableView
+    /// before another model is loaded to it.
+    void stopBrowseThread() {
+        setPath({});
+    };
+
     TrackPointer getTrack(const QModelIndex& index) const override;
     TrackPointer getTrackByRef(const TrackRef& trackRef) const override;
     TrackModel::Capabilities getCapabilities() const override;

--- a/src/library/proxytrackmodel.cpp
+++ b/src/library/proxytrackmodel.cpp
@@ -1,5 +1,6 @@
 #include "library/proxytrackmodel.h"
 
+#include "library/browse/browsetablemodel.h"
 #include "library/searchqueryparser.h"
 #include "moc_proxytrackmodel.cpp"
 #include "util/assert.h"
@@ -20,6 +21,17 @@ ProxyTrackModel::ProxyTrackModel(QAbstractItemModel* pTrackModel,
 
 ProxyTrackModel::~ProxyTrackModel() {
 }
+
+void ProxyTrackModel::maybeStopModelPopulation() {
+    // If the source model is a BrowseTableModel we tell it to stop its
+    // BrowseThread. In case that is still running and population the model
+    // chunk by chunk, its update signals would still affect the selection in the
+    // shared WTrackTableView even if another model is loaded.
+    BrowseTableModel* pBrowseModel = static_cast<BrowseTableModel*>(sourceModel());
+    if (pBrowseModel) {
+        pBrowseModel->stopBrowseThread();
+    }
+};
 
 TrackModel::SortColumnId ProxyTrackModel::sortColumnIdFromColumnIndex(int index) const {
     return m_pTrackModel ? m_pTrackModel->sortColumnIdFromColumnIndex(index)

--- a/src/library/proxytrackmodel.h
+++ b/src/library/proxytrackmodel.h
@@ -22,6 +22,8 @@ class ProxyTrackModel : public QSortFilterProxyModel, public TrackModel {
     explicit ProxyTrackModel(QAbstractItemModel* pTrackModel, bool bHandleSearches = true);
     ~ProxyTrackModel() override;
 
+    void maybeStopModelPopulation() override;
+
     // Inherited from TrackModel
     Capabilities getCapabilities() const final;
     TrackPointer getTrack(const QModelIndex& index) const final;

--- a/src/library/trackmodel.h
+++ b/src/library/trackmodel.h
@@ -243,6 +243,11 @@ class TrackModel {
     virtual void select() {
     }
 
+    /// This is an interface to stop any potentially running
+    /// model population when switching models in WTrackTableView.
+    /// Only implemented in ProxyTrackModel.
+    virtual void maybeStopModelPopulation() {};
+
     /// @brief modelKey returns a unique identifier for the model
     /// @param noSearch don't include the current search in the key
     virtual QString modelKey(bool noSearch) const = 0;

--- a/src/widget/wtracktableview.cpp
+++ b/src/widget/wtracktableview.cpp
@@ -186,22 +186,23 @@ void WTrackTableView::pasteFromSidebar() {
 }
 
 // slot
-void WTrackTableView::loadTrackModel(QAbstractItemModel* model, bool restoreState) {
-    qDebug() << "WTrackTableView::loadTrackModel()" << model;
+void WTrackTableView::loadTrackModel(QAbstractItemModel* pNewModel, bool restoreState) {
+    qDebug() << "WTrackTableView::loadTrackModel()" << pNewModel;
 
-    VERIFY_OR_DEBUG_ASSERT(model) {
+    VERIFY_OR_DEBUG_ASSERT(pNewModel) {
         return;
     }
-    TrackModel* pTrackModel = dynamic_cast<TrackModel*>(model);
-    VERIFY_OR_DEBUG_ASSERT(pTrackModel) {
+    TrackModel* pNewTrackModel = dynamic_cast<TrackModel*>(pNewModel);
+    VERIFY_OR_DEBUG_ASSERT(pNewTrackModel) {
         return;
     }
 
-    m_sorting = pTrackModel->hasCapabilities(TrackModel::Capability::Sorting);
+    m_sorting = pNewTrackModel->hasCapabilities(TrackModel::Capability::Sorting);
 
     // If the model has not changed there's no need to exchange the headers
     // which would cause a small GUI freeze
-    if (getTrackModel() == pTrackModel) {
+    TrackModel* pCurrModel = getTrackModel();
+    if (pCurrModel == pNewTrackModel) {
         // Re-sort the table even if the track model is the same. This triggers
         // a select() if the table is dirty.
         doSortByColumn(horizontalHeader()->sortIndicatorSection(),
@@ -211,6 +212,8 @@ void WTrackTableView::loadTrackModel(QAbstractItemModel* model, bool restoreStat
             restoreCurrentViewState();
         }
         return;
+    } else if (pCurrModel) {
+        pCurrModel->maybeStopModelPopulation();
     }
 
     setVisible(false);
@@ -252,7 +255,7 @@ void WTrackTableView::loadTrackModel(QAbstractItemModel* model, bool restoreStat
     setSortingEnabled(false);
     setHorizontalHeader(tempHeader);
 
-    setModel(model);
+    setModel(pNewModel);
     setHorizontalHeader(header);
     header->setSectionsMovable(true);
     header->setSectionsClickable(true);
@@ -266,10 +269,10 @@ void WTrackTableView::loadTrackModel(QAbstractItemModel* model, bool restoreStat
     header->setDefaultAlignment(Qt::AlignLeft);
 
     // Initialize all column-specific things
-    for (int i = 0; i < model->columnCount(); ++i) {
+    for (int i = 0; i < pNewModel->columnCount(); ++i) {
         // Setup delegates according to what the model tells us
         QAbstractItemDelegate* delegate =
-                pTrackModel->delegateForColumn(i, this);
+                pNewTrackModel->delegateForColumn(i, this);
         // We need to delete the old delegates, since the docs say the view will
         // not take ownership of them.
         QAbstractItemDelegate* old_delegate = itemDelegateForColumn(i);
@@ -278,7 +281,7 @@ void WTrackTableView::loadTrackModel(QAbstractItemModel* model, bool restoreStat
         delete old_delegate;
 
         // Show or hide the column based on whether it should be shown or not.
-        if (pTrackModel->isColumnInternal(i)) {
+        if (pNewTrackModel->isColumnInternal(i)) {
             //qDebug() << "Hiding column" << i;
             horizontalHeader()->hideSection(i);
         }
@@ -286,7 +289,7 @@ void WTrackTableView::loadTrackModel(QAbstractItemModel* model, bool restoreStat
         // due to database schema evolution we gonna hide all columns that may
         // contain a potential large number of NULL values.  This will hide the
         // key column by default unless the user brings it to front
-        if (pTrackModel->isColumnHiddenByDefault(i) &&
+        if (pNewTrackModel->isColumnHiddenByDefault(i) &&
                 !header->hasPersistedHeaderState()) {
             //qDebug() << "Hiding column" << i;
             horizontalHeader()->hideSection(i);
@@ -306,22 +309,24 @@ void WTrackTableView::loadTrackModel(QAbstractItemModel* model, bool restoreStat
 
         Qt::SortOrder sortOrder;
         TrackModel::SortColumnId sortColumn =
-                pTrackModel->sortColumnIdFromColumnIndex(
+                pNewTrackModel->sortColumnIdFromColumnIndex(
                         horizontalHeader()->sortIndicatorSection());
         if (sortColumn != TrackModel::SortColumnId::Invalid) {
             // Sort by the saved sort section and order.
             sortOrder = horizontalHeader()->sortIndicatorOrder();
         } else {
             // No saved order is present. Use the TrackModel's default sort order.
-            sortColumn = pTrackModel->sortColumnIdFromColumnIndex(pTrackModel->defaultSortColumn());
-            sortOrder = pTrackModel->defaultSortOrder();
+            sortColumn = pNewTrackModel->sortColumnIdFromColumnIndex(
+                    pNewTrackModel->defaultSortColumn());
+            sortOrder = pNewTrackModel->defaultSortOrder();
 
             if (sortColumn == TrackModel::SortColumnId::Invalid) {
                 // If the TrackModel has an invalid or internal column as its default
                 // sort, find the first valid sort column and sort by that.
-                const int columnCount = model->columnCount(); // just to avoid an endless while loop
+                // avoid endless while loop
+                const int columnCount = pNewModel->columnCount();
                 for (int sortColumnIndex = 0; sortColumnIndex < columnCount; sortColumnIndex++) {
-                    sortColumn = pTrackModel->sortColumnIdFromColumnIndex(sortColumnIndex);
+                    sortColumn = pNewTrackModel->sortColumnIdFromColumnIndex(sortColumnIndex);
                     if (sortColumn != TrackModel::SortColumnId::Invalid) {
                         break;
                     }
@@ -344,7 +349,7 @@ void WTrackTableView::loadTrackModel(QAbstractItemModel* model, bool restoreStat
     // this.)
     setDragEnabled(true);
 
-    if (pTrackModel->hasCapabilities(TrackModel::Capability::ReceiveDrops)) {
+    if (pNewTrackModel->hasCapabilities(TrackModel::Capability::ReceiveDrops)) {
         setDragDropMode(QAbstractItemView::DragDrop);
         setDropIndicatorShown(true);
         setAcceptDrops(true);


### PR DESCRIPTION
Fixes https://github.com/mixxxdj/mixxx/issues/11445
(or rather: as good as gets with the current state of the library / Computer feature)
___
1 -- Once started, the BrowseThread keeps adding rows to the BrowseTableModel which inturn emits `restoreModelState()` for each chunk. This resets the current track selection and scroll position even if the model is not loaded to the shared tracks view anymore, essentially making the tracks table unusable while BrowseThread is still running in the background.

When switching to another feature (track view) the BrowseThread is now stopped by setting an empty path.

Ideally the BrowseTableModel would know when its view is not exposed anymore and stop the thread. That would also allow to stop the thread when any other view is selected (eg. text browser), but a) such kind of model/view interaction is not desired and b) it's much more complex/complicated than the current quick fix.
___
2 -- While the view is populated by BrowseThread, its view state is saved and restored for each chunk of rows (scroll position and selection **row**, not track!).
Note that this does not preserve the **track** selection like in database-based views that work with TrackId -- it just avoids the constant position reset while loading.
(it does preserve the **track** selection if the Computer view is sorted by filename though)
____
### Testing
1. go to Computer, select a folder whit lots of files where population takes some time (longer than switching to another Tracks and selecting a track there)
-> see track list grow and vertical scrollbar shrink
2. go to Tracks, select a track, scroll down if possible
-> selection and scroll position should persist