### PR TITLE
fix(QML): correctly handle path validation for waveform marker

### DIFF
--- a/src/qml/qmlwaveformrenderer.cpp
+++ b/src/qml/qmlwaveformrenderer.cpp
@@ -18,11 +18,48 @@
 #include "waveform/renderers/allshader/waveformrenderersignalbase.h"
 #include "waveform/renderers/allshader/waveformrenderersimple.h"
 // #include "waveform/renderers/allshader/waveformrenderertextured.h"
+#include "waveform/renderers/waveformmark.h"
 #ifdef __STEM__
 #include "waveform/renderers/allshader/waveformrendererstem.h"
 #endif
 #include "waveform/renderers/allshader/waveformrendermark.h"
 #include "waveform/renderers/allshader/waveformrendermarkrange.h"
+
+namespace {
+QString waveformMarkerErrorToString(
+        const WaveformMark::WaveformMarkConstructionError error,
+        const QString& endIcon,
+        const QString& pixmap,
+        const QString& endPixmap,
+        const QString& icon) {
+    QString errorMessage = QObject::tr("Invalid marker: ");
+    switch (error) {
+    case WaveformMark::WaveformMarkConstructionError::EndIconInvalidArgumentCount:
+        errorMessage.append(
+                QObject::tr("unexpected number of arguments in endIcon: %1")
+                        .arg(endIcon));
+        break;
+    case WaveformMark::WaveformMarkConstructionError::PixmapNotFound:
+        errorMessage.append(QObject::tr("path %1 for pixmap cannot be found").arg(pixmap));
+        break;
+    case WaveformMark::WaveformMarkConstructionError::EndPixmapNotFound:
+        errorMessage.append(
+                QObject::tr("path %1 for end pixmap cannot be found")
+                        .arg(endPixmap));
+        break;
+    case WaveformMark::WaveformMarkConstructionError::IconNotFound:
+        errorMessage.append(QObject::tr("path %1 for icon cannot be found").arg(icon));
+        break;
+    case WaveformMark::WaveformMarkConstructionError::EndIconNotFound:
+        errorMessage.append(QObject::tr("path %1 for end icon cannot be found").arg(endIcon));
+        break;
+    default:
+        DEBUG_ASSERT(!"unreachable");
+        errorMessage.append("unknown error");
+    }
+    return errorMessage;
+}
+} // namespace
 
 namespace mixxx {
 namespace qml {
@@ -352,23 +389,40 @@ QmlWaveformRendererFactory::Renderer QmlWaveformRendererMark::create(
     // The initialisation is closely inspired from WaveformMarkSet::setup
     int priority = 0;
     for (const auto* pMark : std::as_const(m_marks)) {
-        pRenderer->addMark(WaveformMarkPointer(new WaveformMark(
+        const QString pixmap = pMark->pixmap().toLocalFile();
+        const QString icon = pMark->icon().toLocalFile();
+        const QString endPixmap = pMark->endPixmap().toLocalFile();
+        const QString endIcon = pMark->endIcon().toLocalFile();
+        auto maybeMarker = WaveformMark::create(
                 waveformWidget->getGroup(),
                 pMark->control(),
                 pMark->visibilityControl(),
                 pMark->textColor(),
                 pMark->align(),
                 pMark->text(),
-                pMark->pixmap().toLocalFile(),
-                pMark->icon().toLocalFile(),
+                pixmap,
+                icon,
                 pMark->color(),
                 priority,
                 Cue::kNoHotCue,
                 {},
-                pMark->endPixmap().toLocalFile(),
-                pMark->endIcon().toLocalFile(),
+                endPixmap,
+                endIcon,
                 pMark->disabledOpacity(),
-                pMark->enabledOpacity())));
+                pMark->enabledOpacity());
+
+        if (std::holds_alternative<WaveformMark::WaveformMarkConstructionError>(maybeMarker)) {
+            qmlEngine(this)->throwError(waveformMarkerErrorToString(
+                    std::get<WaveformMark::WaveformMarkConstructionError>(
+                            maybeMarker),
+                    endIcon,
+                    pixmap,
+                    endPixmap,
+                    icon));
+            continue;
+        }
+        auto pMarker = std::get<WaveformMarkPointer>(maybeMarker);
+        pRenderer->addMark(pMarker);
         priority--;
     }
     const auto* pMark = defaultMark();
@@ -377,26 +431,7 @@ QmlWaveformRendererFactory::Renderer QmlWaveformRendererMark::create(
         const QString endPixmap = pMark->endPixmap().toLocalFile();
         const QString icon = pMark->icon().toLocalFile();
         const QString endIcon = pMark->endIcon().toLocalFile();
-        // FIXME: the following checks should be done on the WaveformMarker
-        // setter (depends of #14515)
-        if (!pixmap.isEmpty() && !QFileInfo::exists(pixmap)) {
-            qmlEngine(this)->throwError(tr("Cannot find the marker pixmap") + " \"" + pixmap + '"');
-        }
-
-        if (!endPixmap.isEmpty() && !QFileInfo::exists(endPixmap)) {
-            qmlEngine(this)->throwError(tr("Cannot find the marker endPixmap") +
-                    " \"" + endPixmap + '"');
-        }
-
-        if (!icon.isEmpty() && !QFileInfo::exists(icon)) {
-            qmlEngine(this)->throwError(tr("Cannot find the marker icon") + " \"" + icon + '"');
-        }
-
-        if (!endIcon.isEmpty() && !QFileInfo::exists(endIcon)) {
-            qmlEngine(this)->throwError(tr("Cannot find the marker endIcon") +
-                    " \"" + endIcon + '"');
-        }
-        pRenderer->setDefaultMark(
+        auto error = pRenderer->setDefaultMark(
                 waveformWidget->getGroup(),
                 WaveformMarkSet::DefaultMarkerStyle{
                         pMark->control(),
@@ -412,6 +447,10 @@ QmlWaveformRendererFactory::Renderer QmlWaveformRendererMark::create(
                         pMark->enabledOpacity(),
                         pMark->disabledOpacity(),
                 });
+        if (error.has_value()) {
+            qmlEngine(this)->throwError(waveformMarkerErrorToString(
+                    error.value(), endIcon, pixmap, endPixmap, icon));
+        }
     }
     return QmlWaveformRendererFactory::Renderer{pRenderer.get(), std::move(pRenderer)};
 }

--- a/src/waveform/renderers/waveformmark.cpp
+++ b/src/waveform/renderers/waveformmark.cpp
@@ -2,9 +2,13 @@
 
 #include <QOpenGLTexture>
 #include <QPainterPath>
+#include <QRegularExpression>
 #include <QStringLiteral>
 #include <QSvgRenderer>
 #include <QtDebug>
+#include <algorithm>
+#include <memory>
+#include <vector>
 
 #include "skin/legacy/skincontext.h"
 #include "waveform/renderers/waveformsignalcolors.h"
@@ -97,7 +101,7 @@ bool isShowUntilNextPositionControl(const QString& positionControl) {
 
 WaveformMark::WaveformMark(
         const QString& group,
-        QString positionControl,
+        const QString& aPositionControl,
         const QString& visibilityControl,
         const QString& textColor,
         const QString& markAlign,
@@ -127,6 +131,7 @@ WaveformMark::WaveformMark(
           m_iPriority(priority),
           m_iHotCue(hotCue),
           m_showUntilNext{} {
+    QString positionControl = aPositionControl;
     QString endPositionControl;
     QString typeControl;
     QString statusControl;
@@ -270,6 +275,47 @@ WaveformMark::WaveformMark(const QString& group,
 
     m_enabledOpacity = context.selectDouble(node, "EnabledOpacity", 1);
     m_disabledOpacity = context.selectDouble(node, "DisabledOpacity", 0.5);
+}
+
+std::variant<WaveformMarkPointer, WaveformMark::WaveformMarkConstructionError> WaveformMark::create(
+        const QString& group,
+        const QString& positionControl,
+        const QString& visibilityControl,
+        const QString& textColor,
+        const QString& markAlign,
+        const QString& text,
+        const QString& pixmapPath,
+        const QString& iconPath,
+        QColor color,
+        int priority,
+        int hotCue,
+        const WaveformSignalColors& signalColors,
+        const QString& endPixmapPath,
+        const QString& endIconPath,
+        float disabledOpacity,
+        float enabledOpacity) {
+    // Used WaveformMark's ctor variant is private so we must explicitly call
+    // new before wrapping it in a smart pointer
+    WaveformMarkPointer pMark(new WaveformMark(group,
+            positionControl,
+            visibilityControl,
+            textColor,
+            markAlign,
+            text,
+            pixmapPath,
+            iconPath,
+            color,
+            priority,
+            hotCue,
+            signalColors,
+            endPixmapPath,
+            endIconPath,
+            disabledOpacity,
+            enabledOpacity));
+    if (auto err = pMark->validate(); err.has_value()) {
+        return err.value();
+    }
+    return pMark;
 }
 
 WaveformMark::~WaveformMark() = default;
@@ -592,6 +638,47 @@ QImage WaveformMark::performImageGeneration(float devicePixelRatio,
     painter.end();
 
     return image;
+}
+
+std::optional<WaveformMark::WaveformMarkConstructionError> WaveformMark::validate() const {
+    auto checkPath = [](const auto& path) {
+        return !std::get<QString>(path).isEmpty() && !QFileInfo(std::get<QString>(path)).exists();
+    };
+
+    auto addPaths = [](auto* pPathList,
+                            const QString& pathTemplate,
+                            WaveformMark::WaveformMarkConstructionError
+                                    pathErrorType) {
+        static QRegularExpression re("%\\d+");
+        auto argCount = pathTemplate.count(re);
+        switch (argCount) {
+        case 0:
+            pPathList->emplace_back(pathTemplate, pathErrorType);
+            break;
+        case 1:
+            pPathList->emplace_back(pathTemplate.arg(QStringLiteral("forward")), pathErrorType);
+            pPathList->emplace_back(pathTemplate.arg(QStringLiteral("backward")), pathErrorType);
+            break;
+        default:
+            return false;
+        }
+        return true;
+    };
+
+    std::vector<std::pair<QString, WaveformMarkConstructionError>> pathList = {
+            {m_pixmapPath, WaveformMarkConstructionError::PixmapNotFound},
+            {m_endPixmapPath, WaveformMarkConstructionError::EndPixmapNotFound},
+            {m_iconPath, WaveformMarkConstructionError::IconNotFound},
+    };
+    if (!addPaths(&pathList, m_endIconPath, WaveformMarkConstructionError::EndIconNotFound)) {
+        return WaveformMarkConstructionError::EndIconInvalidArgumentCount;
+    }
+
+    auto first_missing_path = std::find_if(pathList.cbegin(), pathList.cend(), checkPath);
+    if (first_missing_path != pathList.cend()) {
+        return std::get<WaveformMarkConstructionError>(*first_missing_path);
+    }
+    return {};
 }
 
 QImage WaveformMark::generateImage(float devicePixelRatio) {

--- a/src/waveform/renderers/waveformmark.h
+++ b/src/waveform/renderers/waveformmark.h
@@ -3,6 +3,8 @@
 #include <QHash>
 #include <QImage>
 #include <memory>
+#include <optional>
+#include <variant>
 
 #include "control/controlproxy.h"
 #include "control/pollingcontrolproxy.h"
@@ -13,6 +15,9 @@
 
 class SkinContext;
 class QOpenGLTexture;
+
+class WaveformMark;
+typedef QSharedPointer<WaveformMark> WaveformMarkPointer;
 
 namespace allshader {
 class WaveformRenderMark;
@@ -43,9 +48,19 @@ class WaveformMark {
             const WaveformSignalColors& signalColors,
             int hotCue = Cue::kNoHotCue);
 
-    WaveformMark(
+    enum class WaveformMarkConstructionError {
+        EndIconInvalidArgumentCount,
+        PixmapNotFound,
+        EndPixmapNotFound,
+        IconNotFound,
+        EndIconNotFound,
+    };
+
+    // FIXME we are using `std::variant` instead of `std::expected` as Mixxx
+    // doesn't yet support C++23.
+    static std::variant<WaveformMarkPointer, WaveformMarkConstructionError> create(
             const QString& group,
-            QString positionControl,
+            const QString& positionControl,
             const QString& visibilityControl,
             const QString& textColor,
             const QString& markAlign,
@@ -60,6 +75,7 @@ class WaveformMark {
             const QString& endIconPath = {},
             float disabledOpacity = 1.0f,
             float enabledOpacity = 1.0f);
+
     ~WaveformMark();
 
     // Disable copying
@@ -245,6 +261,28 @@ class WaveformMark {
     WaveformMarkLabel m_label;
 
   private:
+    WaveformMark(
+            const QString& group,
+            const QString& positionControl,
+            const QString& visibilityControl,
+            const QString& textColor,
+            const QString& markAlign,
+            const QString& text,
+            const QString& pixmapPath,
+            const QString& iconPath,
+            QColor color,
+            int priority,
+            int hotCue = Cue::kNoHotCue,
+            const WaveformSignalColors& signalColors = {},
+            const QString& endPixmapPath = {},
+            const QString& endIconPath = {},
+            float disabledOpacity = 1.0f,
+            float enabledOpacity = 1.0f);
+
+    // Check whether or not there are issues with this marker definition. If
+    // there are issues, the first one is returned
+    std::optional<WaveformMark::WaveformMarkConstructionError> validate() const;
+
     QImage performImageGeneration(float devicePixelRatio,
             const QString& pixmapPath,
             const QString& text,

--- a/src/waveform/renderers/waveformmarkset.cpp
+++ b/src/waveform/renderers/waveformmarkset.cpp
@@ -1,6 +1,8 @@
 #include "waveformmarkset.h"
 
 #include <QtDebug>
+#include <memory>
+#include <optional>
 #include <set>
 
 #include "util/defs.h"
@@ -65,10 +67,11 @@ void WaveformMarkSet::setup(const QString& group, const QDomNode& node,
     }
 }
 
-void WaveformMarkSet::setDefault(const QString& group,
+std::optional<WaveformMark::WaveformMarkConstructionError>
+WaveformMarkSet::setDefault(const QString& group,
         const DefaultMarkerStyle& model,
         const WaveformSignalColors& signalColors) {
-    m_pDefaultMark = WaveformMarkPointer::create(
+    auto mark = WaveformMark::create(
             group,
             model.positionControl,
             model.visibilityControl,
@@ -81,9 +84,14 @@ void WaveformMarkSet::setDefault(const QString& group,
             0,
             Cue::kNoHotCue,
             signalColors);
+    if (std::holds_alternative<WaveformMark::WaveformMarkConstructionError>(mark)) {
+        return std::get<WaveformMark::WaveformMarkConstructionError>(mark);
+    }
+    m_pDefaultMark = std::get<WaveformMarkPointer>(mark);
+
     for (int i = 0; i < kMaxNumberOfHotcues; ++i) {
         if (m_hotCueMarks.value(i).isNull()) {
-            auto pMark = WaveformMarkPointer::create(
+            auto pMaybeMark = WaveformMark::create(
                     group,
                     model.positionControl,
                     model.visibilityControl,
@@ -98,12 +106,17 @@ void WaveformMarkSet::setDefault(const QString& group,
                     signalColors,
                     model.endPixmapPath,
                     model.endIconPath,
-                    model.enabledOpacity,
-                    model.disabledOpacity);
+                    model.disabledOpacity,
+                    model.enabledOpacity);
+            if (std::holds_alternative<WaveformMark::WaveformMarkConstructionError>(pMaybeMark)) {
+                return std::get<WaveformMark::WaveformMarkConstructionError>(pMaybeMark);
+            }
+            auto pMark = std::get<WaveformMarkPointer>(pMaybeMark);
             m_marks.push_front(pMark);
             m_hotCueMarks.insert(pMark->getHotCue(), pMark);
         }
     }
+    return {};
 }
 
 WaveformMarkPointer WaveformMarkSet::getHotCueMark(int hotCue) const {

--- a/src/waveform/renderers/waveformmarkset.h
+++ b/src/waveform/renderers/waveformmarkset.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #include <QList>
+#include <optional>
 
-#include "waveformmark.h"
 #include "skin/legacy/skincontext.h"
-
+#include "waveformmark.h"
 
 // This class helps share code between the WaveformRenderMark and WOverview
 // constructors and allows to iterate over the orders marks that have to be
@@ -85,13 +85,15 @@ class WaveformMarkSet {
     void clear() {
         m_marks.clear();
         m_marksToRender.clear();
+        m_hotCueMarks.clear();
+        m_pDefaultMark.reset();
     }
 
     void addMark(WaveformMarkPointer pMark) {
         m_marks.push_back(pMark);
     }
 
-    void setDefault(const QString& group,
+    std::optional<WaveformMark::WaveformMarkConstructionError> setDefault(const QString& group,
             const DefaultMarkerStyle& model,
             const WaveformSignalColors& signalColors = {});
 

--- a/src/waveform/renderers/waveformrendermarkbase.h
+++ b/src/waveform/renderers/waveformrendermarkbase.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QObject>
+#include <optional>
 
 #include "skin/legacy/skincontext.h"
 #include "util/class.h"
@@ -22,8 +23,14 @@ class WaveformRenderMarkBase : public QObject, public WaveformRendererAbstract {
 
     void onResize() override;
 
-    void setDefaultMark(const QString& group, const WaveformMarkSet::DefaultMarkerStyle& model) {
-        m_marks.setDefault(group, model);
+    void clearMarks() {
+        m_marks.clear();
+    }
+
+    std::optional<WaveformMark::WaveformMarkConstructionError> setDefaultMark(
+            const QString& group,
+            const WaveformMarkSet::DefaultMarkerStyle& model) {
+        return m_marks.setDefault(group, model);
     }
 
     void addMark(WaveformMarkPointer pMark) {


### PR DESCRIPTION
Addresses `FIXME` that was related to #14515