### PR TITLE
Traktor S4MK3: New preference for FX button order

### DIFF
--- a/res/controllers/Traktor Kontrol S4 MK3.hid.xml
+++ b/res/controllers/Traktor Kontrol S4 MK3.hid.xml
@@ -241,6 +241,15 @@
                 </description>
             </option>
             <option
+                variable="filterIsFirstQuickEffect"
+                type="boolean"
+                default="false"
+                label="Assign the first QuickEffect to the :hwbtn:`FILTER` button instead of button :hwbtn:`1`">
+                <description>
+                    This option is useful if you are used to Filter being the primary quickeffect and have it at the top of your QuickEfect list.
+                </description>
+            </option>
+            <option
                 variable="defaultPadLayout"
                 type="enum"
                 label="Default Pad Layout">

--- a/res/controllers/Traktor-Kontrol-S4-MK3.js
+++ b/res/controllers/Traktor-Kontrol-S4-MK3.js
@@ -141,6 +141,8 @@ const MixerControlsMixAuxOnShift = !!engine.getSetting("mixerControlsMicAuxOnShi
 // Default: false
 const UseBeatloopRollInsteadOfSampler = !!engine.getSetting("useBeatloopRollInsteadOfSampler");
 
+const FilterIsFirstQuickEffect = !!engine.getSetting("filterIsFirstQuickEffect");
+
 // Predefined beatlooproll sizes.
 const BeatLoopRolls = [
     engine.getSetting("beatLoopRollsSize1") || 1/8,
@@ -1498,16 +1500,20 @@ class Mixer extends ComponentContainer {
         this.secondPressedFxSelector = null;
         this.comboSelected = false;
 
+        // FX SELECT buttons: Filter, 1, 2, 3, 4
         const fxSelectsInputs = [
+            {inByte: 8, inBit: 7},
             {inByte: 8, inBit: 5},
             {inByte: 8, inBit: 1},
             {inByte: 8, inBit: 6},
             {inByte: 8, inBit: 0},
-            {inByte: 8, inBit: 7},
         ];
+        if (!FilterIsFirstQuickEffect) {
+            // FX SELECT buttons: 1, 2, 3, 4, Filter
+            fxSelectsInputs.push(fxSelectsInputs.shift());
+        }
         this.fxSelects = [];
-        // FX SELECT buttons: Filter, 1, 2, 3, 4
-        for (const i of [0, 1, 2, 3, 4]) {
+        for (let i = 0; i < fxSelectsInputs.length; i++) {
             this.fxSelects[i] = new FXSelect(
                 Object.assign(fxSelectsInputs[i], {
                     number: i + 1,


### PR DESCRIPTION
Optionally, make "filter" the first quickeffect instead of button 1.

This better aligns with how I think about the buttons -- Filter as the primary quickeffect, and the others as extra optional effects.