### PR TITLE
Library: enable drag'n'drop of directories

### DIFF
--- a/src/library/analysis/analysisfeature.cpp
+++ b/src/library/analysis/analysisfeature.cpp
@@ -250,6 +250,5 @@ bool AnalysisFeature::dropAccept(const QList<QUrl>& urls, QObject* pSource) {
 }
 
 bool AnalysisFeature::dragMoveAccept(const QList<QUrl>& urls) {
-    // stop on first match, don't accept playlist files
-    return !DragAndDropHelper::supportedTracksFromUrls(urls, true, false).isEmpty();
+    return DragAndDropHelper::urlsContainSupportedTrackFiles(urls, false);
 }

--- a/src/library/analysis/analysisfeature.cpp
+++ b/src/library/analysis/analysisfeature.cpp
@@ -10,6 +10,7 @@
 #include "library/trackcollectionmanager.h"
 #include "moc_analysisfeature.cpp"
 #include "sources/soundsourceproxy.h"
+#include "util/dnd.h"
 #include "util/logger.h"
 #include "widget/wlibrary.h"
 
@@ -247,6 +248,7 @@ bool AnalysisFeature::dropAccept(const QList<QUrl>& urls, QObject* pSource) {
     return tracks.size() > 0;
 }
 
-bool AnalysisFeature::dragMoveAccept(const QUrl& url) {
-    return SoundSourceProxy::isUrlSupported(url);
+bool AnalysisFeature::dragMoveAccept(const QList<QUrl>& urls) {
+    // stop on first match, don't accept playlist files
+    return !DragAndDropHelper::supportedTracksFromUrls(urls, true, false).isEmpty();
 }

--- a/src/library/analysis/analysisfeature.cpp
+++ b/src/library/analysis/analysisfeature.cpp
@@ -236,10 +236,11 @@ void AnalysisFeature::onTrackAnalysisSchedulerFinished() {
 }
 
 bool AnalysisFeature::dropAccept(const QList<QUrl>& urls, QObject* pSource) {
+    const QList<mixxx::FileInfo> fileInfos =
+            // collect all tracks, accept playlist files
+            DragAndDropHelper::supportedTracksFromUrls(urls, false, true);
     const QList<TrackId> trackIds =
-            m_pLibrary->trackCollectionManager()->resolveTrackIdsFromUrls(
-                    urls,
-                    !pSource);
+            m_pLibrary->trackCollectionManager()->resolveTrackIds(fileInfos, pSource);
     QList<AnalyzerScheduledTrack> tracks;
     for (auto trackId : trackIds) {
         tracks.append(trackId);

--- a/src/library/analysis/analysisfeature.h
+++ b/src/library/analysis/analysisfeature.h
@@ -25,7 +25,7 @@ class AnalysisFeature : public LibraryFeature {
     }
 
     bool dropAccept(const QList<QUrl>& urls, QObject* pSource) override;
-    bool dragMoveAccept(const QUrl& url) override;
+    bool dragMoveAccept(const QList<QUrl>& urls) override;
     void bindLibraryWidget(WLibrary* libraryWidget,
                     KeyboardEventFilter* keyboard) override;
 

--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -250,9 +250,9 @@ bool AutoDJFeature::dropAccept(const QList<QUrl>& urls, QObject* pSource) {
     return m_playlistDao.appendTracksToPlaylist(trackIds, m_iAutoDJPlaylistId);
 }
 
-bool AutoDJFeature::dragMoveAccept(const QUrl& url) {
-    return SoundSourceProxy::isUrlSupported(url) ||
-            Parser::isPlaylistFilenameSupported(url.toLocalFile());
+bool AutoDJFeature::dragMoveAccept(const QList<QUrl>& urls) {
+    // stop on first match, accept playlist files
+    return !DragAndDropHelper::supportedTracksFromUrls(urls, true, true).isEmpty();
 }
 
 void AutoDJFeature::slotEnableAutoDJ() {

--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -240,8 +240,11 @@ bool AutoDJFeature::dropAccept(const QList<QUrl>& urls, QObject* pSource) {
     // Auto DJ playlist.
     // pSource != nullptr it is a drop from inside Mixxx and indicates all
     // tracks already in the DB
-    QList<TrackId> trackIds = m_pLibrary->trackCollectionManager()->resolveTrackIdsFromUrls(urls,
-            !pSource);
+    const QList<mixxx::FileInfo> fileInfos =
+            // collect all tracks, accept playlist files
+            DragAndDropHelper::supportedTracksFromUrls(urls, false, true);
+    const QList<TrackId> trackIds =
+            m_pLibrary->trackCollectionManager()->resolveTrackIds(fileInfos, pSource);
     if (trackIds.isEmpty()) {
         return false;
     }

--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -254,8 +254,7 @@ bool AutoDJFeature::dropAccept(const QList<QUrl>& urls, QObject* pSource) {
 }
 
 bool AutoDJFeature::dragMoveAccept(const QList<QUrl>& urls) {
-    // stop on first match, accept playlist files
-    return !DragAndDropHelper::supportedTracksFromUrls(urls, true, true).isEmpty();
+    return DragAndDropHelper::urlsContainSupportedTrackFiles(urls, true);
 }
 
 void AutoDJFeature::slotEnableAutoDJ() {

--- a/src/library/autodj/autodjfeature.h
+++ b/src/library/autodj/autodjfeature.h
@@ -37,7 +37,7 @@ class AutoDJFeature : public LibraryFeature {
     void deleteItem(const QModelIndex& index) override;
 
     bool dropAccept(const QList<QUrl>& urls, QObject* pSource) override;
-    bool dragMoveAccept(const QUrl& url) override;
+    bool dragMoveAccept(const QList<QUrl>& urls) override;
 
     void bindLibraryWidget(WLibrary* libraryWidget,
                     KeyboardEventFilter* keyboard) override;

--- a/src/library/libraryfeature.h
+++ b/src/library/libraryfeature.h
@@ -61,13 +61,13 @@ class LibraryFeature : public QObject {
         Q_UNUSED(pSource);
         return false;
     }
-    virtual bool dragMoveAccept(const QUrl& url) {
-        Q_UNUSED(url);
+    virtual bool dragMoveAccept(const QList<QUrl>& urls) {
+        Q_UNUSED(urls);
         return false;
     }
-    virtual bool dragMoveAcceptChild(const QModelIndex& index, const QUrl& url) {
+    virtual bool dragMoveAcceptChild(const QModelIndex& index, const QList<QUrl>& urls) {
         Q_UNUSED(index);
-        Q_UNUSED(url);
+        Q_UNUSED(urls);
         return false;
     }
 

--- a/src/library/mixxxlibraryfeature.cpp
+++ b/src/library/mixxxlibraryfeature.cpp
@@ -206,12 +206,17 @@ void MixxxLibraryFeature::activateChild(const QModelIndex& index) {
 
 bool MixxxLibraryFeature::dropAccept(const QList<QUrl>& urls, QObject* pSource) {
     if (pSource) {
+        // We don't accept internal drags onto Tracks as all tracks with a
+        // source are already in the library.
         return false;
-    } else {
-        QList<TrackId> trackIds = m_pLibrary->trackCollectionManager()->resolveTrackIdsFromUrls(
-                urls, true);
-        return trackIds.size() > 0;
     }
+
+    const QList<mixxx::FileInfo> fileInfos =
+            // collect all tracks, accept playlist files
+            DragAndDropHelper::supportedTracksFromUrls(urls, false, true);
+    const QList<TrackId> trackIds =
+            m_pLibrary->trackCollectionManager()->resolveTrackIds(fileInfos, nullptr);
+    return trackIds.size() > 0;
 }
 
 bool MixxxLibraryFeature::dragMoveAccept(const QList<QUrl>& urls) {

--- a/src/library/mixxxlibraryfeature.cpp
+++ b/src/library/mixxxlibraryfeature.cpp
@@ -220,8 +220,7 @@ bool MixxxLibraryFeature::dropAccept(const QList<QUrl>& urls, QObject* pSource) 
 }
 
 bool MixxxLibraryFeature::dragMoveAccept(const QList<QUrl>& urls) {
-    // stop on first match, accept playlist files
-    return !DragAndDropHelper::supportedTracksFromUrls(urls, true, true).isEmpty();
+    return DragAndDropHelper::urlsContainSupportedTrackFiles(urls, true);
 }
 
 #ifdef __ENGINEPRIME__

--- a/src/library/mixxxlibraryfeature.cpp
+++ b/src/library/mixxxlibraryfeature.cpp
@@ -18,6 +18,7 @@
 #include "library/treeitem.h"
 #include "moc_mixxxlibraryfeature.cpp"
 #include "sources/soundsourceproxy.h"
+#include "util/dnd.h"
 #include "widget/wlibrary.h"
 #ifdef __ENGINEPRIME__
 #include "widget/wlibrarysidebar.h"
@@ -213,9 +214,9 @@ bool MixxxLibraryFeature::dropAccept(const QList<QUrl>& urls, QObject* pSource) 
     }
 }
 
-bool MixxxLibraryFeature::dragMoveAccept(const QUrl& url) {
-    return SoundSourceProxy::isUrlSupported(url) ||
-            Parser::isPlaylistFilenameSupported(url.toLocalFile());
+bool MixxxLibraryFeature::dragMoveAccept(const QList<QUrl>& urls) {
+    // stop on first match, accept playlist files
+    return !DragAndDropHelper::supportedTracksFromUrls(urls, true, true).isEmpty();
 }
 
 #ifdef __ENGINEPRIME__

--- a/src/library/mixxxlibraryfeature.h
+++ b/src/library/mixxxlibraryfeature.h
@@ -29,7 +29,7 @@ class MixxxLibraryFeature final : public LibraryFeature {
 
     QVariant title() override;
     bool dropAccept(const QList<QUrl>& urls, QObject* pSource) override;
-    bool dragMoveAccept(const QUrl& url) override;
+    bool dragMoveAccept(const QList<QUrl>& urls) override;
     TreeItemModel* sidebarModel() const override;
     void bindLibraryWidget(WLibrary* pLibrary,
                     KeyboardEventFilter* pKeyboard) override;

--- a/src/library/sidebarmodel.cpp
+++ b/src/library/sidebarmodel.cpp
@@ -441,19 +441,20 @@ bool SidebarModel::dropAccept(const QModelIndex& index, const QList<QUrl>& urls,
     if constexpr (kDebug) {
         qDebug() << "SidebarModel::dropAccept() index=" << index << urls;
     }
-    bool result = false;
-    if (index.isValid()) {
-        if (index.internalPointer() == this) {
-            result = m_sFeatures[index.row()]->dropAccept(urls, pSource);
-        } else {
-            TreeItem* pTreeItem = static_cast<TreeItem*>(index.internalPointer());
-            if (pTreeItem) {
-                LibraryFeature* pFeature = pTreeItem->feature();
-                result = pFeature->dropAcceptChild(index, urls, pSource);
-            }
-        }
+    if (!index.isValid()) {
+        return false;
     }
-    return result;
+
+    if (index.internalPointer() == this) {
+        return m_sFeatures[index.row()]->dropAccept(urls, pSource);
+    } else {
+        TreeItem* pTreeItem = static_cast<TreeItem*>(index.internalPointer());
+        if (!pTreeItem) {
+            return false;
+        }
+        LibraryFeature* pFeature = pTreeItem->feature();
+        return pFeature->dropAcceptChild(index, urls, pSource);
+    }
 }
 
 bool SidebarModel::hasTrackTable(const QModelIndex& index) const {
@@ -467,20 +468,23 @@ bool SidebarModel::dragMoveAccept(const QModelIndex& index, const QUrl& url) con
     if constexpr (kDebug) {
         qDebug() << "SidebarModel::dragMoveAccept() index=" << index << url;
     }
-    bool result = false;
-
-    if (index.isValid()) {
-        if (index.internalPointer() == this) {
-            result = m_sFeatures[index.row()]->dragMoveAccept(url);
-        } else {
-            TreeItem* pTreeItem = static_cast<TreeItem*>(index.internalPointer());
-            if (pTreeItem) {
-                LibraryFeature* pFeature = pTreeItem->feature();
-                result = pFeature->dragMoveAcceptChild(index, url);
-            }
-        }
+    if (!index.isValid()) {
+        return false;
     }
-    return result;
+
+    if (index.internalPointer() == this) {
+        return m_sFeatures[index.row()]->dragMoveAccept(url);
+    } else {
+        TreeItem* pTreeItem = static_cast<TreeItem*>(index.internalPointer());
+        if (!pTreeItem) {
+            return false;
+        }
+        LibraryFeature* pFeature = pTreeItem->feature();
+        VERIFY_OR_DEBUG_ASSERT(pFeature) {
+            return false;
+        }
+        return pFeature->dragMoveAcceptChild(index, url);
+    }
 }
 
 /// Translates an index from the child models to an index of the sidebar models

--- a/src/library/sidebarmodel.cpp
+++ b/src/library/sidebarmodel.cpp
@@ -464,16 +464,16 @@ bool SidebarModel::hasTrackTable(const QModelIndex& index) const {
     return false;
 }
 
-bool SidebarModel::dragMoveAccept(const QModelIndex& index, const QUrl& url) const {
+bool SidebarModel::dragMoveAccept(const QModelIndex& index, const QList<QUrl>& urls) const {
     if constexpr (kDebug) {
-        qDebug() << "SidebarModel::dragMoveAccept() index=" << index << url;
+        qDebug() << "SidebarModel::dragMoveAccept() index=" << index << urls;
     }
     if (!index.isValid()) {
         return false;
     }
 
     if (index.internalPointer() == this) {
-        return m_sFeatures[index.row()]->dragMoveAccept(url);
+        return m_sFeatures[index.row()]->dragMoveAccept(urls);
     } else {
         TreeItem* pTreeItem = static_cast<TreeItem*>(index.internalPointer());
         if (!pTreeItem) {
@@ -483,7 +483,7 @@ bool SidebarModel::dragMoveAccept(const QModelIndex& index, const QUrl& url) con
         VERIFY_OR_DEBUG_ASSERT(pFeature) {
             return false;
         }
-        return pFeature->dragMoveAcceptChild(index, url);
+        return pFeature->dragMoveAcceptChild(index, urls);
     }
 }
 

--- a/src/library/sidebarmodel.h
+++ b/src/library/sidebarmodel.h
@@ -39,7 +39,7 @@ class SidebarModel : public QAbstractItemModel {
     QVariant data(const QModelIndex& index,
                   int role = Qt::DisplayRole) const override;
     bool dropAccept(const QModelIndex& index, const QList<QUrl>& urls, QObject* pSource);
-    bool dragMoveAccept(const QModelIndex& index, const QUrl& url) const;
+    bool dragMoveAccept(const QModelIndex& index, const QList<QUrl>& urls) const;
     bool hasChildren(const QModelIndex& parent = QModelIndex()) const override;
     bool hasTrackTable(const QModelIndex& index) const;
     QModelIndex translateChildIndex(const QModelIndex& index) {

--- a/src/library/trackcollection.cpp
+++ b/src/library/trackcollection.cpp
@@ -239,6 +239,17 @@ QList<TrackId> TrackCollection::resolveTrackIds(
     return trackIds;
 }
 
+QList<TrackId> TrackCollection::resolveTrackIds(
+        const QList<mixxx::FileInfo>& trackFiles,
+        QObject* pSource) {
+    TrackDAO::ResolveTrackIdFlags flags =
+            TrackDAO::ResolveTrackIdFlag::UnhideHidden;
+    if (!pSource) {
+        flags |= TrackDAO::ResolveTrackIdFlag::AddMissing;
+    }
+    return resolveTrackIds(trackFiles, flags);
+}
+
 QList<TrackId> TrackCollection::resolveTrackIdsFromUrls(
         const QList<QUrl>& urls,
         bool addMissing) {

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -129,6 +129,9 @@ class TrackCollection : public QObject,
             const QList<mixxx::FileInfo>& trackFiles,
             TrackDAO::ResolveTrackIdFlags flags);
     QList<TrackId> resolveTrackIds(
+            const QList<mixxx::FileInfo>& trackFiles,
+            QObject* pSource);
+    QList<TrackId> resolveTrackIds(
             const QList<QUrl>& urls,
             TrackDAO::ResolveTrackIdFlags flags);
     QList<TrackId> resolveTrackIdsFromUrls(

--- a/src/library/trackcollectionmanager.cpp
+++ b/src/library/trackcollectionmanager.cpp
@@ -593,6 +593,14 @@ TrackPointer TrackCollectionManager::getTrackByRef(
             trackRef);
 }
 
+QList<TrackId> TrackCollectionManager::resolveTrackIds(
+        const QList<mixxx::FileInfo>& fileInfos,
+        QObject* pSource) const {
+    return internalCollection()->resolveTrackIds(
+            fileInfos,
+            pSource);
+}
+
 QList<TrackId> TrackCollectionManager::resolveTrackIdsFromUrls(
         const QList<QUrl>& urls,
         bool addMissing) const {

--- a/src/library/trackcollectionmanager.h
+++ b/src/library/trackcollectionmanager.h
@@ -52,6 +52,9 @@ class TrackCollectionManager: public QObject,
             TrackId trackId) const;
     TrackPointer getTrackByRef(
             const TrackRef& trackRef) const;
+    QList<TrackId> resolveTrackIds(
+            const QList<mixxx::FileInfo>& fileInfos,
+            QObject* pSource) const;
     QList<TrackId> resolveTrackIdsFromUrls(
             const QList<QUrl>& urls,
             bool addMissing) const;

--- a/src/library/trackset/crate/cratefeature.cpp
+++ b/src/library/trackset/crate/cratefeature.cpp
@@ -270,8 +270,7 @@ bool CrateFeature::dragMoveAcceptChild(const QModelIndex& index, const QList<QUr
             crate.isLocked()) {
         return false;
     }
-    // stop on first match, accept playlist files
-    return !DragAndDropHelper::supportedTracksFromUrls(urls, true, true).isEmpty();
+    return DragAndDropHelper::urlsContainSupportedTrackFiles(urls, true);
 }
 
 void CrateFeature::bindLibraryWidget(

--- a/src/library/trackset/crate/cratefeature.cpp
+++ b/src/library/trackset/crate/cratefeature.cpp
@@ -22,6 +22,7 @@
 #include "sources/soundsourceproxy.h"
 #include "track/track.h"
 #include "util/defs.h"
+#include "util/dnd.h"
 #include "util/file.h"
 #include "widget/wlibrary.h"
 #include "widget/wlibrarysidebar.h"
@@ -256,7 +257,7 @@ bool CrateFeature::dropAcceptChild(
     return true;
 }
 
-bool CrateFeature::dragMoveAcceptChild(const QModelIndex& index, const QUrl& url) {
+bool CrateFeature::dragMoveAcceptChild(const QModelIndex& index, const QList<QUrl>& urls) {
     CrateId crateId(crateIdFromIndex(index));
     if (!crateId.isValid()) {
         return false;
@@ -266,8 +267,8 @@ bool CrateFeature::dragMoveAcceptChild(const QModelIndex& index, const QUrl& url
             crate.isLocked()) {
         return false;
     }
-    return SoundSourceProxy::isUrlSupported(url) ||
-            Parser::isPlaylistFilenameSupported(url.toLocalFile());
+    // stop on first match, accept playlist files
+    return !DragAndDropHelper::supportedTracksFromUrls(urls, true, true).isEmpty();
 }
 
 void CrateFeature::bindLibraryWidget(

--- a/src/library/trackset/crate/cratefeature.cpp
+++ b/src/library/trackset/crate/cratefeature.cpp
@@ -247,8 +247,11 @@ bool CrateFeature::dropAcceptChild(
     // playlist.
     // pSource != nullptr it is a drop from inside Mixxx and indicates all
     // tracks already in the DB
-    QList<TrackId> trackIds =
-            m_pLibrary->trackCollectionManager()->resolveTrackIdsFromUrls(urls, !pSource);
+    const QList<mixxx::FileInfo> fileInfos =
+            // collect all tracks, accept playlist files
+            DragAndDropHelper::supportedTracksFromUrls(urls, false, true);
+    const QList<TrackId> trackIds =
+            m_pLibrary->trackCollectionManager()->resolveTrackIds(fileInfos, pSource);
     if (trackIds.isEmpty()) {
         return false;
     }

--- a/src/library/trackset/crate/cratefeature.h
+++ b/src/library/trackset/crate/cratefeature.h
@@ -33,7 +33,7 @@ class CrateFeature : public BaseTrackSetFeature {
     bool dropAcceptChild(const QModelIndex& index,
             const QList<QUrl>& urls,
             QObject* pSource) override;
-    bool dragMoveAcceptChild(const QModelIndex& index, const QUrl& url) override;
+    bool dragMoveAcceptChild(const QModelIndex& index, const QList<QUrl>& urls) override;
 
     void bindLibraryWidget(WLibrary* libraryWidget,
             KeyboardEventFilter* keyboard) override;

--- a/src/library/trackset/playlistfeature.cpp
+++ b/src/library/trackset/playlistfeature.cpp
@@ -152,8 +152,7 @@ bool PlaylistFeature::dragMoveAcceptChild(const QModelIndex& index, const QList<
         return false;
     }
 
-    // stop on first match, accept playlist files
-    return !DragAndDropHelper::supportedTracksFromUrls(urls, true, true).isEmpty();
+    return DragAndDropHelper::urlsContainSupportedTrackFiles(urls, true);
 }
 
 QList<BasePlaylistFeature::IdAndLabel> PlaylistFeature::createPlaylistLabels() {

--- a/src/library/trackset/playlistfeature.h
+++ b/src/library/trackset/playlistfeature.h
@@ -26,7 +26,7 @@ class PlaylistFeature : public BasePlaylistFeature {
     bool dropAcceptChild(const QModelIndex& index,
             const QList<QUrl>& urls,
             QObject* pSource) override;
-    bool dragMoveAcceptChild(const QModelIndex& index, const QUrl& url) override;
+    bool dragMoveAcceptChild(const QModelIndex& index, const QList<QUrl>& urls) override;
 
   public slots:
     void onRightClick(const QPoint& globalPos) override;

--- a/src/util/dnd.cpp
+++ b/src/util/dnd.cpp
@@ -138,6 +138,13 @@ bool mouseMoveInitiatesDragHelper(QMouseEvent* pEvent, bool isPress) {
 
 } // anonymous namespace
 
+// static
+bool DragAndDropHelper::urlsContainSupportedTrackFiles(
+        const QList<QUrl>& urls,
+        bool acceptPlaylists) {
+    return !supportedTracksFromUrls(urls, true, acceptPlaylists).isEmpty();
+}
+
 //static
 QList<mixxx::FileInfo> DragAndDropHelper::supportedTracksFromUrls(
         const QList<QUrl>& urls,

--- a/src/util/dnd.cpp
+++ b/src/util/dnd.cpp
@@ -1,5 +1,7 @@
 #include "util/dnd.h"
 
+#include <QDirIterator>
+
 #include "control/controlobject.h"
 #include "library/parser.h"
 #include "mixer/playermanager.h"
@@ -49,7 +51,7 @@ bool addFileToList(
 QList<mixxx::FileInfo> dropEventFiles(
         const QMimeData& mimeData,
         const QString& sourceIdentifier,
-        bool firstOnly,
+        bool stopOnFirstMatch,
         bool acceptPlaylists) {
     qDebug() << "dropEventFiles()" << mimeData.hasUrls() << mimeData.urls();
     qDebug() << "mimeData.hasText()" << mimeData.hasText() << mimeData.text();
@@ -61,7 +63,7 @@ QList<mixxx::FileInfo> dropEventFiles(
 
     return DragAndDropHelper::supportedTracksFromUrls(
             mimeData.urls(),
-            firstOnly,
+            stopOnFirstMatch,
             acceptPlaylists);
 }
 
@@ -139,7 +141,7 @@ bool mouseMoveInitiatesDragHelper(QMouseEvent* pEvent, bool isPress) {
 //static
 QList<mixxx::FileInfo> DragAndDropHelper::supportedTracksFromUrls(
         const QList<QUrl>& urls,
-        bool firstOnly,
+        bool stopOnFirstMatch,
         bool acceptPlaylists) {
     QList<mixxx::FileInfo> fileInfos;
     for (const QUrl& url : urls) {
@@ -164,15 +166,35 @@ QList<mixxx::FileInfo> DragAndDropHelper::supportedTracksFromUrls(
         }
 
         if (acceptPlaylists && Parser::isPlaylistFilenameSupported(file)) {
+            // Url is a playlist file
             const QList<QString> track_list = Parser::parse(file);
             for (const auto& playlistFile : track_list) {
                 addFileToList(mixxx::FileInfo(playlistFile), &fileInfos);
             }
         } else {
-            addFileToList(mixxx::FileInfo::fromQUrl(url), &fileInfos);
+            // Url is a file or a directory
+            mixxx::FileInfo fileInfo = mixxx::FileInfo::fromQUrl(url);
+            if (fileInfo.isFile()) {
+                addFileToList(fileInfo, &fileInfos);
+            } else if (fileInfo.isDir()) {
+                // Collect supported files recursively
+                const QStringList nameFilters = SoundSourceProxy::getSupportedFileNamePatterns();
+
+                QDirIterator fileIt(fileInfo.location(),
+                        nameFilters,
+                        QDir::Files | QDir::NoDotAndDotDot,
+                        QDirIterator::Subdirectories);
+
+                while (fileIt.hasNext()) {
+                    addFileToList(mixxx::FileInfo(fileIt.next()), &fileInfos);
+                    if (stopOnFirstMatch && !fileInfos.isEmpty()) {
+                        break;
+                    }
+                }
+            }
         }
 
-        if (firstOnly && !fileInfos.isEmpty()) {
+        if (stopOnFirstMatch && !fileInfos.isEmpty()) {
             break;
         }
     }
@@ -224,11 +246,12 @@ bool DragAndDropHelper::mouseMoveInitiatesDrag(QMouseEvent* pEvent) {
 bool DragAndDropHelper::dragEnterAccept(
         const QMimeData& mimeData,
         const QString& sourceIdentifier,
-        bool firstOnly,
+        bool stopOnFirstMatch,
         bool acceptPlaylists) {
     // TODO(XXX): This operation blocks the UI when many
     // files are selected!
-    const auto files = dropEventFiles(mimeData, sourceIdentifier, firstOnly, acceptPlaylists);
+    const auto files = dropEventFiles(
+            mimeData, sourceIdentifier, stopOnFirstMatch, acceptPlaylists);
     return !files.isEmpty();
 }
 

--- a/src/util/dnd.h
+++ b/src/util/dnd.h
@@ -16,6 +16,10 @@ class DragAndDropHelper final {
   public:
     DragAndDropHelper() = delete;
 
+    static bool urlsContainSupportedTrackFiles(
+            const QList<QUrl>& urls,
+            bool acceptPlaylists);
+
     static QList<mixxx::FileInfo> supportedTracksFromUrls(
             const QList<QUrl>& urls,
             bool stopOnFirstMatch,

--- a/src/util/dnd.h
+++ b/src/util/dnd.h
@@ -18,7 +18,7 @@ class DragAndDropHelper final {
 
     static QList<mixxx::FileInfo> supportedTracksFromUrls(
             const QList<QUrl>& urls,
-            bool firstOnly,
+            bool stopOnFirstMatch,
             bool acceptPlaylists);
 
     static bool allowDeckCloneAttempt(
@@ -28,7 +28,7 @@ class DragAndDropHelper final {
     static bool dragEnterAccept(
             const QMimeData& mimeData,
             const QString& sourceIdentifier,
-            bool firstOnly,
+            bool stopOnFirstMatch,
             bool acceptPlaylists);
 
     static QDrag* dragTrack(

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -54,9 +54,7 @@ void WLibrarySidebar::dragEnterEvent(QDragEnterEvent* pEvent) {
         // FIXME Unless the cursor is steady after entering the sidebar (which
         // is veryhard to achieve for humans) QDragEnterEvent is followed by one
         // or more QDragMoveEvent, so don't check here at all and rely on dragMove?
-        QList<mixxx::FileInfo> fileInfos = DragAndDropHelper::supportedTracksFromUrls(
-                pEvent->mimeData()->urls(), true, true);
-        if (!fileInfos.isEmpty()) {
+        if (DragAndDropHelper::urlsContainSupportedTrackFiles(pEvent->mimeData()->urls(), true)) {
             pEvent->acceptProposedAction();
             return;
         }
@@ -106,21 +104,11 @@ void WLibrarySidebar::dragMoveEvent(QDragMoveEvent* pEvent) {
         pEvent->ignore();
         return;
     }
-    for (const QUrl& url : urls) {
-        if (pSidebarModel->dragMoveAccept(index, url)) {
-            // We only need one URL to be valid for us
-            // to accept the whole drag...
-            // Consider that we might have a long list of files,
-            // checking all will take a lot of time that stalls
-            // Mixxx and this makes the drop feature useless.
-            // E.g. you may have tried to drag two MP3's and an EXE,
-            // the drop is accepted here, but the EXE is filtered
-            // out later after dropping
-            pEvent->acceptProposedAction();
-            return;
-        }
+    if (pSidebarModel->dragMoveAccept(index, urls)) {
+        pEvent->acceptProposedAction();
+    } else {
+        pEvent->ignore();
     }
-    pEvent->ignore();
 }
 
 void WLibrarySidebar::timerEvent(QTimerEvent* pEvent) {

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -30,46 +30,46 @@ WLibrarySidebar::WLibrarySidebar(QWidget* parent)
     header()->setHorizontalScrollMode(QAbstractItemView::ScrollPerPixel);
 }
 
-void WLibrarySidebar::contextMenuEvent(QContextMenuEvent *event) {
-    //if (event->state() & Qt::RightButton) { //Dis shiz don werk on windowze
-    QModelIndex clickedIndex = indexAt(event->pos());
+void WLibrarySidebar::contextMenuEvent(QContextMenuEvent* pEvent) {
+    // if (pEvent->state() & Qt::RightButton) { //Dis shiz don werk on windowze
+    QModelIndex clickedIndex = indexAt(pEvent->pos());
     if (!clickedIndex.isValid()) {
         return;
     }
     // Use this instead of setCurrentIndex() to keep current selection
     selectionModel()->setCurrentIndex(clickedIndex, QItemSelectionModel::NoUpdate);
-    event->accept();
-    emit rightClicked(event->globalPos(), clickedIndex);
+    pEvent->accept();
+    emit rightClicked(pEvent->globalPos(), clickedIndex);
     //}
 }
 
 /// Drag enter event, happens when a dragged item enters the track sources view
-void WLibrarySidebar::dragEnterEvent(QDragEnterEvent * event) {
-    qDebug() << "WLibrarySidebar::dragEnterEvent" << event->mimeData()->formats();
-    if (event->mimeData()->hasUrls()) {
+void WLibrarySidebar::dragEnterEvent(QDragEnterEvent* pEvent) {
+    qDebug() << "WLibrarySidebar::dragEnterEvent" << pEvent->mimeData()->formats();
+    if (pEvent->mimeData()->hasUrls()) {
         // We don't have a way to ask the LibraryFeatures whether to accept a
         // drag so for now we accept all drags. Since almost every
         // LibraryFeature accepts all files in the drop and accepts playlist
         // drops we default to those flags to DragAndDropHelper.
         QList<mixxx::FileInfo> fileInfos = DragAndDropHelper::supportedTracksFromUrls(
-                event->mimeData()->urls(), false, true);
+                pEvent->mimeData()->urls(), false, true);
         if (!fileInfos.isEmpty()) {
-            event->acceptProposedAction();
+            pEvent->acceptProposedAction();
             return;
         }
     }
-    event->ignore();
-    //QTreeView::dragEnterEvent(event);
+    pEvent->ignore();
+    // QTreeView::dragEnterEvent(pEvent);
 }
 
 /// Drag move event, happens when a dragged item hovers over the track sources view...
-void WLibrarySidebar::dragMoveEvent(QDragMoveEvent * event) {
-    //qDebug() << "dragMoveEvent" << event->mimeData()->formats();
+void WLibrarySidebar::dragMoveEvent(QDragMoveEvent* pEvent) {
+    // qDebug() << "dragMoveEvent" << pEvent->mimeData()->formats();
     // Start a timer to auto-expand sections the user hovers on.
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    QPoint pos = event->position().toPoint();
+    QPoint pos = pEvent->position().toPoint();
 #else
-    QPoint pos = event->pos();
+    QPoint pos = pEvent->pos();
 #endif
     QModelIndex index = indexAt(pos);
     if (m_hoverIndex != index) {
@@ -88,9 +88,9 @@ void WLibrarySidebar::dragMoveEvent(QDragMoveEvent * event) {
             // Do nothing.
             event->ignore();
         } else {
-            SidebarModel* sidebarModel = qobject_cast<SidebarModel*>(model());
+            SidebarModel* pSidebarModel = qobject_cast<SidebarModel*>(model());
             bool accepted = true;
-            if (sidebarModel) {
+            if (pSidebarModel) {
                 accepted = false;
                 for (const QUrl& url : urls) {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
@@ -99,7 +99,7 @@ void WLibrarySidebar::dragMoveEvent(QDragMoveEvent * event) {
                     QPoint pos = event->pos();
 #endif
                     QModelIndex destIndex = indexAt(pos);
-                    if (sidebarModel->dragMoveAccept(destIndex, url)) {
+                    if (pSidebarModel->dragMoveAccept(destIndex, url)) {
                         // We only need one URL to be valid for us
                         // to accept the whole drag...
                         // Consider that we might have a long list of files,
@@ -120,12 +120,12 @@ void WLibrarySidebar::dragMoveEvent(QDragMoveEvent * event) {
             }
         }
     } else {
-        event->ignore();
+        pEvent->ignore();
     }
 }
 
-void WLibrarySidebar::timerEvent(QTimerEvent *event) {
-    if (event->timerId() == m_expandTimer.timerId()) {
+void WLibrarySidebar::timerEvent(QTimerEvent* pEvent) {
+    if (pEvent->timerId() == m_expandTimer.timerId()) {
         QPoint pos = viewport()->mapFromGlobal(QCursor::pos());
         if (viewport()->rect().contains(pos)) {
             QModelIndex index = indexAt(pos);
@@ -136,45 +136,45 @@ void WLibrarySidebar::timerEvent(QTimerEvent *event) {
         m_expandTimer.stop();
         return;
     }
-    QTreeView::timerEvent(event);
+    QTreeView::timerEvent(pEvent);
 }
 
 // Drag-and-drop "drop" event. Occurs when something is dropped onto the track sources view
-void WLibrarySidebar::dropEvent(QDropEvent * event) {
-    if (event->mimeData()->hasUrls()) {
+void WLibrarySidebar::dropEvent(QDropEvent* pEvent) {
+    if (pEvent->mimeData()->hasUrls()) {
         // Drag and drop within this widget
-        if ((event->source() == this)
-                && (event->possibleActions() & Qt::MoveAction)) {
+        if ((pEvent->source() == this)
+                && (pEvent->possibleActions() & Qt::MoveAction)) {
             // Do nothing.
-            event->ignore();
+            pEvent->ignore();
         } else {
             //Reset the selected items (if you had anything highlighted, it clears it)
             //this->selectionModel()->clear();
             //Drag-and-drop from an external application or the track table widget
             //eg. dragging a track from Windows Explorer onto the sidebar
-            SidebarModel* sidebarModel = qobject_cast<SidebarModel*>(model());
-            if (sidebarModel) {
+            SidebarModel* pSidebarModel = qobject_cast<SidebarModel*>(model());
+            if (pSidebarModel) {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-                QPoint pos = event->position().toPoint();
+                QPoint pos = pEvent->position().toPoint();
 #else
-                QPoint pos = event->pos();
+                QPoint pos = pEvent->pos();
 #endif
 
                 QModelIndex destIndex = indexAt(pos);
-                // event->source() will return NULL if something is dropped from
+                // pEvent->source() will return NULL if something is dropped from
                 // a different application
-                const QList<QUrl> urls = event->mimeData()->urls();
-                if (sidebarModel->dropAccept(destIndex, urls, event->source())) {
-                    event->acceptProposedAction();
+                const QList<QUrl> urls = pEvent->mimeData()->urls();
+                if (pSidebarModel->dropAccept(destIndex, urls, pEvent->source())) {
+                    pEvent->acceptProposedAction();
                 } else {
-                    event->ignore();
+                    pEvent->ignore();
                 }
             }
         }
         //emit trackDropped(name);
         //repaintEverything();
     } else {
-        event->ignore();
+        pEvent->ignore();
     }
 }
 
@@ -204,9 +204,9 @@ bool WLibrarySidebar::isLeafNodeSelected() {
         if(!index.model()->hasChildren(index)) {
             return true;
         }
-        const SidebarModel* sidebarModel = qobject_cast<const SidebarModel*>(index.model());
-        if (sidebarModel) {
-            return sidebarModel->hasTrackTable(index);
+        const SidebarModel* pSidebarModel = qobject_cast<const SidebarModel*>(index.model());
+        if (pSidebarModel) {
+            return pSidebarModel->hasTrackTable(index);
         }
     }
     return false;
@@ -218,12 +218,12 @@ bool WLibrarySidebar::isChildIndexSelected(const QModelIndex& index) {
     if (!selIndex.isValid()) {
         return false;
     }
-    SidebarModel* sidebarModel = qobject_cast<SidebarModel*>(model());
-    VERIFY_OR_DEBUG_ASSERT(sidebarModel) {
+    SidebarModel* pSidebarModel = qobject_cast<SidebarModel*>(model());
+    VERIFY_OR_DEBUG_ASSERT(pSidebarModel) {
         // qDebug() << " >> model() is not SidebarModel";
         return false;
     }
-    QModelIndex translated = sidebarModel->translateChildIndex(index);
+    QModelIndex translated = pSidebarModel->translateChildIndex(index);
     if (!translated.isValid()) {
         // qDebug() << " >> index can't be translated";
         return false;
@@ -237,30 +237,30 @@ bool WLibrarySidebar::isFeatureRootIndexSelected(LibraryFeature* pFeature) {
     if (!selIndex.isValid()) {
         return false;
     }
-    SidebarModel* sidebarModel = qobject_cast<SidebarModel*>(model());
-    VERIFY_OR_DEBUG_ASSERT(sidebarModel) {
+    SidebarModel* pSidebarModel = qobject_cast<SidebarModel*>(model());
+    VERIFY_OR_DEBUG_ASSERT(pSidebarModel) {
         return false;
     }
-    const QModelIndex rootIndex = sidebarModel->getFeatureRootIndex(pFeature);
+    const QModelIndex rootIndex = pSidebarModel->getFeatureRootIndex(pFeature);
     return rootIndex == selIndex;
 }
 
 /// Invoked by actual keypresses (requires widget focus) and emulated keypresses
 /// sent by LibraryControl
-void WLibrarySidebar::keyPressEvent(QKeyEvent* event) {
+void WLibrarySidebar::keyPressEvent(QKeyEvent* pEvent) {
     // TODO(XXX) Should first keyEvent ensure previous item has focus? I.e. if the selected
     // item is not focused, require second press to perform the desired action.
 
-    SidebarModel* sidebarModel = qobject_cast<SidebarModel*>(model());
+    SidebarModel* pSidebarModel = qobject_cast<SidebarModel*>(model());
     QModelIndex selIndex = selectedIndex();
-    if (sidebarModel && selIndex.isValid() && event->matches(QKeySequence::Paste)) {
-        sidebarModel->paste(selIndex);
+    if (pSidebarModel && selIndex.isValid() && pEvent->matches(QKeySequence::Paste)) {
+        pSidebarModel->paste(selIndex);
         return;
     }
 
     focusSelectedIndex();
 
-    switch (event->key()) {
+    switch (pEvent->key()) {
     case Qt::Key_Return:
         toggleSelectedItem();
         return;
@@ -271,7 +271,7 @@ void WLibrarySidebar::keyPressEvent(QKeyEvent* event) {
     case Qt::Key_End:
     case Qt::Key_Home: {
         // Let the tree view move up and down for us.
-        QTreeView::keyPressEvent(event);
+        QTreeView::keyPressEvent(pEvent);
         // After the selection changed force-activate (click) the newly selected
         // item to save us from having to push "Enter".
         QModelIndex selIndex = selectedIndex();
@@ -286,10 +286,10 @@ void WLibrarySidebar::keyPressEvent(QKeyEvent* event) {
         return;
     }
     case Qt::Key_Right: {
-        if (event->modifiers() & Qt::ControlModifier) {
+        if (pEvent->modifiers() & Qt::ControlModifier) {
             emit setLibraryFocus(FocusWidget::TracksTable);
         } else {
-            QTreeView::keyPressEvent(event);
+            QTreeView::keyPressEvent(pEvent);
         }
         return;
     }
@@ -301,7 +301,7 @@ void WLibrarySidebar::keyPressEvent(QKeyEvent* event) {
         }
         // collapse knot
         if (isExpanded(selIndex)) {
-            QTreeView::keyPressEvent(event);
+            QTreeView::keyPressEvent(pEvent);
             return;
         }
         // Else jump to its parent and activate it
@@ -322,7 +322,7 @@ void WLibrarySidebar::keyPressEvent(QKeyEvent* event) {
     }
     case kHideRemoveShortcutKey: { // Del (macOS: Cmd+Backspace)
         // Delete crate or playlist (internal, external, history)
-        if (event->modifiers() != kHideRemoveShortcutModifier) {
+        if (pEvent->modifiers() != kHideRemoveShortcutModifier) {
             return;
         }
         QModelIndex selIndex = selectedIndex();
@@ -333,22 +333,22 @@ void WLibrarySidebar::keyPressEvent(QKeyEvent* event) {
         return;
     }
     default:
-        QTreeView::keyPressEvent(event);
+        QTreeView::keyPressEvent(pEvent);
     }
 }
 
-void WLibrarySidebar::mousePressEvent(QMouseEvent* event) {
+void WLibrarySidebar::mousePressEvent(QMouseEvent* pEvent) {
     // handle right click only in contextMenuEvent() to not select the clicked index
-    if (event->buttons().testFlag(Qt::RightButton)) {
+    if (pEvent->buttons().testFlag(Qt::RightButton)) {
         return;
     }
-    QTreeView::mousePressEvent(event);
+    QTreeView::mousePressEvent(pEvent);
 }
 
-void WLibrarySidebar::focusInEvent(QFocusEvent* event) {
+void WLibrarySidebar::focusInEvent(QFocusEvent* pEvent) {
     // Clear the current index, i.e. remove the focus indicator
     selectionModel()->clearCurrentIndex();
-    QTreeView::focusInEvent(event);
+    QTreeView::focusInEvent(pEvent);
 }
 
 void WLibrarySidebar::selectIndex(const QModelIndex& index) {
@@ -371,18 +371,18 @@ void WLibrarySidebar::selectIndex(const QModelIndex& index) {
 
 /// Selects a child index from a feature and ensures visibility
 void WLibrarySidebar::selectChildIndex(const QModelIndex& index, bool selectItem) {
-    SidebarModel* sidebarModel = qobject_cast<SidebarModel*>(model());
-    VERIFY_OR_DEBUG_ASSERT(sidebarModel) {
+    SidebarModel* pSidebarModel = qobject_cast<SidebarModel*>(model());
+    VERIFY_OR_DEBUG_ASSERT(pSidebarModel) {
         qDebug() << "model() is not SidebarModel";
         return;
     }
-    QModelIndex translated = sidebarModel->translateChildIndex(index);
+    QModelIndex translated = pSidebarModel->translateChildIndex(index);
     if (!translated.isValid()) {
         return;
     }
 
     if (selectItem) {
-        auto* pModel = new QItemSelectionModel(sidebarModel);
+        auto* pModel = new QItemSelectionModel(pSidebarModel);
         pModel->select(translated, QItemSelectionModel::Select);
         if (selectionModel()) {
             selectionModel()->deleteLater();

--- a/src/widget/wlibrarysidebar.h
+++ b/src/widget/wlibrarysidebar.h
@@ -15,14 +15,14 @@ class WLibrarySidebar : public QTreeView, public WBaseWidget {
   public:
     explicit WLibrarySidebar(QWidget* parent = nullptr);
 
-    void contextMenuEvent(QContextMenuEvent * event) override;
-    void dragMoveEvent(QDragMoveEvent * event) override;
-    void dragEnterEvent(QDragEnterEvent * event) override;
-    void dropEvent(QDropEvent * event) override;
-    void keyPressEvent(QKeyEvent* event) override;
-    void mousePressEvent(QMouseEvent* event) override;
-    void focusInEvent(QFocusEvent* event) override;
-    void timerEvent(QTimerEvent* event) override;
+    void contextMenuEvent(QContextMenuEvent* pEvent) override;
+    void dragMoveEvent(QDragMoveEvent* pEvent) override;
+    void dragEnterEvent(QDragEnterEvent* pEvent) override;
+    void dropEvent(QDropEvent* pEvent) override;
+    void keyPressEvent(QKeyEvent* pEvent) override;
+    void mousePressEvent(QMouseEvent* pEvent) override;
+    void focusInEvent(QFocusEvent* pEvent) override;
+    void timerEvent(QTimerEvent* pEvent) override;
     void toggleSelectedItem();
     void renameSelectedItem();
     bool isLeafNodeSelected();

--- a/src/widget/wlibrarysidebar.h
+++ b/src/widget/wlibrarysidebar.h
@@ -47,6 +47,9 @@ class WLibrarySidebar : public QTreeView, public WBaseWidget {
     void focusSelectedIndex();
     QModelIndex selectedIndex();
 
+    void resetHoverIndexAndDragMoveResult();
+
     QBasicTimer m_expandTimer;
     QModelIndex m_hoverIndex;
+    bool m_lastDragMoveAccepted;
 };


### PR DESCRIPTION
Fixes #5100 
This allows to drop track directories from file managers onto sidebar items and the tracks view.

Might be the foundation to drag sidebar items as well, #15590 