### PR TITLE
Library sidebar: enable internal drag, eg. playlist/directory to Auto DJ

### DIFF
--- a/src/library/analysis/analysisfeature.cpp
+++ b/src/library/analysis/analysisfeature.cpp
@@ -235,12 +235,12 @@ void AnalysisFeature::onTrackAnalysisSchedulerFinished() {
     emit analysisActive(false);
 }
 
-bool AnalysisFeature::dropAccept(const QList<QUrl>& urls, QObject* pSource) {
+bool AnalysisFeature::dropAccept(const QList<QUrl>& urls) {
     const QList<mixxx::FileInfo> fileInfos =
             // collect all tracks, accept playlist files
             DragAndDropHelper::supportedTracksFromUrls(urls, false, true);
     const QList<TrackId> trackIds =
-            m_pLibrary->trackCollectionManager()->resolveTrackIds(fileInfos, pSource);
+            m_pLibrary->trackCollectionManager()->resolveTrackIds(fileInfos);
     QList<AnalyzerScheduledTrack> tracks;
     for (auto trackId : trackIds) {
         tracks.append(trackId);

--- a/src/library/analysis/analysisfeature.h
+++ b/src/library/analysis/analysisfeature.h
@@ -24,7 +24,7 @@ class AnalysisFeature : public LibraryFeature {
         return m_title;
     }
 
-    bool dropAccept(const QList<QUrl>& urls, QObject* pSource) override;
+    bool dropAccept(const QList<QUrl>& urls) override;
     bool dragMoveAccept(const QList<QUrl>& urls) override;
     void bindLibraryWidget(WLibrary* libraryWidget,
                     KeyboardEventFilter* keyboard) override;

--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -229,7 +229,7 @@ void AutoDJFeature::removeCrateFromAutoDj(CrateId crateId) {
     m_pTrackCollection->updateAutoDjCrate(crateId, false);
 }
 
-bool AutoDJFeature::dropAccept(const QList<QUrl>& urls, QObject* pSource) {
+bool AutoDJFeature::dropAccept(const QList<QUrl>& urls) {
     // If a track is dropped onto the Auto DJ tree node, but the track isn't in the
     // library, then add the track to the library before adding it to the
     // Auto DJ playlist.
@@ -239,7 +239,7 @@ bool AutoDJFeature::dropAccept(const QList<QUrl>& urls, QObject* pSource) {
             // collect all tracks, accept playlist files
             DragAndDropHelper::supportedTracksFromUrls(urls, false, true);
     const QList<TrackId> trackIds =
-            m_pLibrary->trackCollectionManager()->resolveTrackIds(fileInfos, pSource);
+            m_pLibrary->trackCollectionManager()->resolveTrackIds(fileInfos);
     if (trackIds.isEmpty()) {
         return false;
     }

--- a/src/library/autodj/autodjfeature.h
+++ b/src/library/autodj/autodjfeature.h
@@ -36,7 +36,7 @@ class AutoDJFeature : public LibraryFeature {
     void paste() override;
     void deleteItem(const QModelIndex& index) override;
 
-    bool dropAccept(const QList<QUrl>& urls, QObject* pSource) override;
+    bool dropAccept(const QList<QUrl>& urls) override;
     bool dragMoveAccept(const QList<QUrl>& urls) override;
 
     void bindLibraryWidget(WLibrary* libraryWidget,

--- a/src/library/browse/browsefeature.cpp
+++ b/src/library/browse/browsefeature.cpp
@@ -173,6 +173,29 @@ QVariant BrowseFeature::title() {
     return QVariant(tr("Computer"));
 }
 
+QList<QUrl> BrowseFeature::collectTrackUrls(const QModelIndex& index) {
+    if (!index.isValid()) {
+        return {};
+    }
+    TreeItem* pItem = static_cast<TreeItem*>(index.internalPointer());
+    if (!pItem || !pItem->getData().isValid()) {
+        return {};
+    }
+
+    const QString path = pItem->getData().toString();
+    if (path.isEmpty() || path == QUICK_LINK_NODE || path == DEVICE_NODE) {
+        return {};
+    }
+
+    mixxx::FileInfo dirInfo(path);
+    if (!dirInfo.hasLocation() || !dirInfo.isDir()) {
+        return {};
+    }
+
+    // Just return the directory and the receiver will resolve urls recursively
+    return QList<QUrl>{dirInfo.toQUrl()};
+}
+
 void BrowseFeature::slotAddQuickLink() {
     const QString path = getLastRightClickedPath();
     if (path.isEmpty()) {

--- a/src/library/browse/browsefeature.h
+++ b/src/library/browse/browsefeature.h
@@ -37,6 +37,8 @@ class BrowseFeature : public LibraryFeature {
 
     TreeItemModel* sidebarModel() const override;
 
+    QList<QUrl> collectTrackUrls(const QModelIndex& index) override;
+
     void releaseBrowseThread();
 
   public slots:

--- a/src/library/libraryfeature.h
+++ b/src/library/libraryfeature.h
@@ -48,17 +48,13 @@ class LibraryFeature : public QObject {
         return m_icon;
     }
 
-    virtual bool dropAccept(const QList<QUrl>& urls, QObject* pSource) {
+    virtual bool dropAccept(const QList<QUrl>& urls) {
         Q_UNUSED(urls);
-        Q_UNUSED(pSource);
         return false;
     }
-    virtual bool dropAcceptChild(const QModelIndex& index,
-            const QList<QUrl>& urls,
-            QObject* pSource) {
+    virtual bool dropAcceptChild(const QModelIndex& index, const QList<QUrl>& urls) {
         Q_UNUSED(index);
         Q_UNUSED(urls);
-        Q_UNUSED(pSource);
         return false;
     }
     virtual bool dragMoveAccept(const QList<QUrl>& urls) {
@@ -83,6 +79,11 @@ class LibraryFeature : public QObject {
                             KeyboardEventFilter* /* keyboard */) {}
     virtual void bindSidebarWidget(WLibrarySidebar* /* sidebar widget */) {}
     virtual TreeItemModel* sidebarModel() const = 0;
+
+    virtual QList<QUrl> collectTrackUrls(const QModelIndex& index) {
+        Q_UNUSED(index);
+        return {};
+    }
 
     virtual bool hasTrackTable() {
         return false;

--- a/src/library/mixxxlibraryfeature.cpp
+++ b/src/library/mixxxlibraryfeature.cpp
@@ -221,18 +221,12 @@ void MixxxLibraryFeature::activateChild(const QModelIndex& index) {
     emit enableCoverArtDisplay(true);
 }
 
-bool MixxxLibraryFeature::dropAccept(const QList<QUrl>& urls, QObject* pSource) {
-    if (pSource) {
-        // We don't accept internal drags onto Tracks as all tracks with a
-        // source are already in the library.
-        return false;
-    }
-
+bool MixxxLibraryFeature::dropAccept(const QList<QUrl>& urls) {
     const QList<mixxx::FileInfo> fileInfos =
             // collect all tracks, accept playlist files
             DragAndDropHelper::supportedTracksFromUrls(urls, false, true);
     const QList<TrackId> trackIds =
-            m_pLibrary->trackCollectionManager()->resolveTrackIds(fileInfos, nullptr);
+            m_pLibrary->trackCollectionManager()->resolveTrackIds(fileInfos);
     if (trackIds.size() == 0) {
         return false;
     }

--- a/src/library/mixxxlibraryfeature.h
+++ b/src/library/mixxxlibraryfeature.h
@@ -28,7 +28,7 @@ class MixxxLibraryFeature final : public LibraryFeature {
     ~MixxxLibraryFeature() override = default;
 
     QVariant title() override;
-    bool dropAccept(const QList<QUrl>& urls, QObject* pSource) override;
+    bool dropAccept(const QList<QUrl>& urls) override;
     bool dragMoveAccept(const QList<QUrl>& urls) override;
     TreeItemModel* sidebarModel() const override;
     void bindLibraryWidget(WLibrary* pLibrary,

--- a/src/library/sidebarmodel.cpp
+++ b/src/library/sidebarmodel.cpp
@@ -34,6 +34,19 @@ SidebarModel::SidebarModel(
             &SidebarModel::slotPressedUntilClickedTimeout);
 }
 
+Qt::ItemFlags SidebarModel::flags(const QModelIndex& index) const {
+    Qt::ItemFlags flags = QAbstractItemModel::flags(index);
+    if (!index.isValid()) {
+        return flags;
+        // Note: this would prohibit dragging of root items.
+        // Which we do not want, see comment in WLibrarySidebar::startDrag()
+        // } else if (index.internalPointer() == this) {
+        //        return flags | Qt::ItemIsDropEnabled;
+    } else {
+        return flags | Qt::ItemIsDragEnabled | Qt::ItemIsDropEnabled;
+    }
+}
+
 void SidebarModel::addLibraryFeature(LibraryFeature* pFeature) {
     m_sFeatures.push_back(pFeature);
     connect(pFeature,
@@ -437,7 +450,7 @@ void SidebarModel::deleteItem(const QModelIndex& index) {
     }
 }
 
-bool SidebarModel::dropAccept(const QModelIndex& index, const QList<QUrl>& urls, QObject* pSource) {
+bool SidebarModel::dropAccept(const QModelIndex& index, const QList<QUrl>& urls) {
     if constexpr (kDebug) {
         qDebug() << "SidebarModel::dropAccept() index=" << index << urls;
     }
@@ -446,14 +459,14 @@ bool SidebarModel::dropAccept(const QModelIndex& index, const QList<QUrl>& urls,
     }
 
     if (index.internalPointer() == this) {
-        return m_sFeatures[index.row()]->dropAccept(urls, pSource);
+        return m_sFeatures[index.row()]->dropAccept(urls);
     } else {
         TreeItem* pTreeItem = static_cast<TreeItem*>(index.internalPointer());
         if (!pTreeItem) {
             return false;
         }
         LibraryFeature* pFeature = pTreeItem->feature();
-        return pFeature->dropAcceptChild(index, urls, pSource);
+        return pFeature->dropAcceptChild(index, urls);
     }
 }
 
@@ -485,6 +498,29 @@ bool SidebarModel::dragMoveAccept(const QModelIndex& index, const QList<QUrl>& u
         }
         return pFeature->dragMoveAcceptChild(index, urls);
     }
+}
+
+/// Collects track urls from the model connected to the index
+QList<QUrl> SidebarModel::collectTrackUrls(const QModelIndex& index) const {
+    // qDebug() << "SidebarModel::getItemUrls" << index;
+    // FIXME could as well be mimeData(indexes) so we don't need
+    // WLibrarySidebar::startDrag() ??
+    if (!index.isValid()) {
+        return {};
+    }
+    if (index.internalPointer() == this) {
+        return {};
+    }
+
+    TreeItem* pTreeItem = static_cast<TreeItem*>(index.internalPointer());
+    if (!pTreeItem) {
+        return {};
+    }
+    LibraryFeature* pFeature = pTreeItem->feature();
+    VERIFY_OR_DEBUG_ASSERT(pFeature) {
+        return {};
+    }
+    return pFeature->collectTrackUrls(index);
 }
 
 /// Translates an index from the child models to an index of the sidebar models

--- a/src/library/sidebarmodel.h
+++ b/src/library/sidebarmodel.h
@@ -25,6 +25,7 @@ class SidebarModel : public QAbstractItemModel {
             QObject* parent = nullptr);
     ~SidebarModel() override = default;
 
+    Qt::ItemFlags flags(const QModelIndex& index) const override;
     void addLibraryFeature(LibraryFeature* feature);
     QModelIndex getDefaultSelection();
     void setDefaultSelection(unsigned int index);
@@ -38,8 +39,9 @@ class SidebarModel : public QAbstractItemModel {
     int columnCount(const QModelIndex& parent = QModelIndex()) const override;
     QVariant data(const QModelIndex& index,
                   int role = Qt::DisplayRole) const override;
-    bool dropAccept(const QModelIndex& index, const QList<QUrl>& urls, QObject* pSource);
+    bool dropAccept(const QModelIndex& index, const QList<QUrl>& urls);
     bool dragMoveAccept(const QModelIndex& index, const QList<QUrl>& urls) const;
+    QList<QUrl> collectTrackUrls(const QModelIndex& index) const;
     bool hasChildren(const QModelIndex& parent = QModelIndex()) const override;
     bool hasTrackTable(const QModelIndex& index) const;
     QModelIndex translateChildIndex(const QModelIndex& index) {

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -130,7 +130,7 @@ class TrackCollection : public QObject,
             TrackDAO::ResolveTrackIdFlags flags);
     QList<TrackId> resolveTrackIds(
             const QList<mixxx::FileInfo>& trackFiles,
-            QObject* pSource);
+            QObject* pSource = nullptr);
     QList<TrackId> resolveTrackIds(
             const QList<QUrl>& urls,
             TrackDAO::ResolveTrackIdFlags flags);

--- a/src/library/trackcollectionmanager.h
+++ b/src/library/trackcollectionmanager.h
@@ -54,7 +54,7 @@ class TrackCollectionManager: public QObject,
             const TrackRef& trackRef) const;
     QList<TrackId> resolveTrackIds(
             const QList<mixxx::FileInfo>& fileInfos,
-            QObject* pSource) const;
+            QObject* pSource = nullptr) const;
     QList<TrackId> resolveTrackIdsFromUrls(
             const QList<QUrl>& urls,
             bool addMissing) const;

--- a/src/library/trackset/baseplaylistfeature.h
+++ b/src/library/trackset/baseplaylistfeature.h
@@ -38,6 +38,7 @@ class BasePlaylistFeature : public BaseTrackSetFeature {
     void bindSidebarWidget(WLibrarySidebar* pSidebarWidget) override;
     void selectPlaylistInSidebar(int playlistId, bool select = true);
     int getSiblingPlaylistIdOf(QModelIndex& start);
+    QList<QUrl> collectTrackUrls(const QModelIndex& index) override;
 
   public slots:
     void activateChild(const QModelIndex& index) override;

--- a/src/library/trackset/crate/cratefeature.h
+++ b/src/library/trackset/crate/cratefeature.h
@@ -30,9 +30,7 @@ class CrateFeature : public BaseTrackSetFeature {
 
     QVariant title() override;
 
-    bool dropAcceptChild(const QModelIndex& index,
-            const QList<QUrl>& urls,
-            QObject* pSource) override;
+    bool dropAcceptChild(const QModelIndex& index, const QList<QUrl>& urls) override;
     bool dragMoveAcceptChild(const QModelIndex& index, const QList<QUrl>& urls) override;
 
     void bindLibraryWidget(WLibrary* libraryWidget,
@@ -40,6 +38,8 @@ class CrateFeature : public BaseTrackSetFeature {
     void bindSidebarWidget(WLibrarySidebar* pSidebarWidget) override;
 
     TreeItemModel* sidebarModel() const override;
+
+    QList<QUrl> collectTrackUrls(const QModelIndex& index) override;
 
   public slots:
     void activate() override;

--- a/src/library/trackset/playlistfeature.cpp
+++ b/src/library/trackset/playlistfeature.cpp
@@ -126,7 +126,7 @@ void PlaylistFeature::onRightClickChild(
 }
 
 bool PlaylistFeature::dropAcceptChild(
-        const QModelIndex& index, const QList<QUrl>& urls, QObject* pSource) {
+        const QModelIndex& index, const QList<QUrl>& urls) {
     int playlistId = playlistIdFromIndex(index);
     VERIFY_OR_DEBUG_ASSERT(playlistId != kInvalidPlaylistId) {
         return false;
@@ -143,7 +143,7 @@ bool PlaylistFeature::dropAcceptChild(
             // collect all tracks, accept playlist files
             DragAndDropHelper::supportedTracksFromUrls(urls, false, true);
     const QList<TrackId> trackIds =
-            m_pLibrary->trackCollectionManager()->resolveTrackIds(fileInfos, pSource);
+            m_pLibrary->trackCollectionManager()->resolveTrackIds(fileInfos);
     if (trackIds.isEmpty()) {
         return false;
     }

--- a/src/library/trackset/playlistfeature.h
+++ b/src/library/trackset/playlistfeature.h
@@ -23,9 +23,7 @@ class PlaylistFeature : public BasePlaylistFeature {
 
     QVariant title() override;
 
-    bool dropAcceptChild(const QModelIndex& index,
-            const QList<QUrl>& urls,
-            QObject* pSource) override;
+    bool dropAcceptChild(const QModelIndex& index, const QList<QUrl>& urls) override;
     bool dragMoveAcceptChild(const QModelIndex& index, const QList<QUrl>& urls) override;
 
   public slots:

--- a/src/library/trackset/setlogfeature.cpp
+++ b/src/library/trackset/setlogfeature.cpp
@@ -131,6 +131,19 @@ void SetlogFeature::bindLibraryWidget(
     m_pLibraryWidget = QPointer(pLibraryWidget);
 }
 
+QList<QUrl> SetlogFeature::collectTrackUrls(const QModelIndex& index) {
+    if (!index.isValid()) {
+        return {};
+    }
+    int playlistId = playlistIdFromIndex(index);
+    if (playlistId == kInvalidPlaylistId || m_yearNodeId) {
+        return {};
+    } else {
+        // regular setlog, use the base implementation
+        return BasePlaylistFeature::collectTrackUrls(index);
+    }
+}
+
 void SetlogFeature::deleteAllUnlockedPlaylistsWithFewerTracks() {
     ScopedTransaction transaction(m_pLibrary->trackCollectionManager()
                                           ->internalCollection()

--- a/src/library/trackset/setlogfeature.h
+++ b/src/library/trackset/setlogfeature.h
@@ -22,6 +22,8 @@ class SetlogFeature : public BasePlaylistFeature {
             KeyboardEventFilter* keyboard) override;
     void activatePlaylist(int playlistId) override;
 
+    QList<QUrl> collectTrackUrls(const QModelIndex& index) override;
+
   public slots:
     void onRightClick(const QPoint& globalPos) override;
     void onRightClickChild(const QPoint& globalPos, const QModelIndex& index) override;

--- a/src/library/treeitemmodel.cpp
+++ b/src/library/treeitemmodel.cpp
@@ -89,7 +89,9 @@ bool TreeItemModel::setData(const QModelIndex &a_rIndex,
 
 Qt::ItemFlags TreeItemModel::flags(const QModelIndex &index) const {
     if (index.isValid()) {
-        return Qt::ItemIsEnabled | Qt::ItemIsSelectable;
+        // Set Qt::ItemIsDragEnabled, else we can "drag" it but hovering
+        // another sidebar (root) item would not trigger the expand timer
+        return Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsDragEnabled;
     } else {
         return Qt::NoItemFlags;
     }

--- a/src/widget/wlibrarysidebar.h
+++ b/src/widget/wlibrarysidebar.h
@@ -16,6 +16,7 @@ class WLibrarySidebar : public QTreeView, public WBaseWidget {
     explicit WLibrarySidebar(QWidget* parent = nullptr);
 
     void contextMenuEvent(QContextMenuEvent* pEvent) override;
+    void startDrag(Qt::DropActions actions) override;
     void dragMoveEvent(QDragMoveEvent* pEvent) override;
     void dragEnterEvent(QDragEnterEvent* pEvent) override;
     void dragLeaveEvent(QDragLeaveEvent* pEvent) override;


### PR DESCRIPTION
Fixes #5100

Works flawlessly for playlists, crates and Computer folders.
I won't take care of external feature like iTunes and Banshee -- if someone needs this, please build on top of this branch.