### PR TITLE
Read and parse HID Report Descriptor on startup

### DIFF
--- a/src/controllers/hid/hidcontroller.cpp
+++ b/src/controllers/hid/hidcontroller.cpp
@@ -8,6 +8,7 @@
 #else
 #include <hidapi.h>
 #endif
+#include <QtConcurrent/QtConcurrentRun>
 
 #include "controllers/defs_controllers.h"
 #include "moc_hidcontroller.cpp"
@@ -30,9 +31,18 @@ HidController::HidController(
     // but a HID can also be input only (e.g. a USB HID mouse)
     setInputDevice(true);
     setOutputDevice(true);
+
+    // Start background fetch of report descriptor to avoid blocking controller
+    // enumeration at startup.
+    fetchReportDescriptorInBackground();
 }
 
 HidController::~HidController() {
+    // Wait for background report descriptor fetching thread to finish if running.
+    if (m_reportDescriptorFuture.isRunning()) {
+        m_reportDescriptorFuture.waitForFinished();
+    }
+
     if (isOpen()) {
         close();
     }
@@ -92,6 +102,11 @@ int HidController::open(const QString& resourcePath) {
         qDebug() << "HID device" << getName() << "already open";
         return -1;
     }
+
+    // Acquire a persistent lock on the m_reportDescriptor/m_deviceUsesReportIds.
+    // The lock is released in close().
+    std::unique_lock<std::mutex> lock(m_reportDescriptorMutex);
+    m_reportDescriptorLock.emplace(std::move(lock));
 
     VERIFY_OR_DEBUG_ASSERT(!m_pHidIoThread) {
         qWarning() << "HidIoThread already present for" << getName();
@@ -233,19 +248,22 @@ int HidController::open(const QString& resourcePath) {
     }
 
 #ifndef Q_OS_ANDROID
-    // When fetching the report descriptor, from m_deviceInfo or if not read yet from the device
-    const std::vector<uint8_t>& rawReportDescriptor =
-            m_deviceInfo.fetchRawReportDescriptor(pHidDevice);
+    if (!m_reportDescriptor || !m_deviceUsesReportIds.has_value()) {
+        // If this is reached, the Report Descriptor wasn't fetched successful before
+        // Try it now, as we have a live device handle
+        const std::vector<uint8_t>& rawReportDescriptor =
+                m_deviceInfo.fetchRawReportDescriptor(pHidDevice);
 
-    if (!rawReportDescriptor.empty()) {
-        m_reportDescriptor =
-                std::make_shared<hid::reportDescriptor::HidReportDescriptor>(
-                        rawReportDescriptor);
-        m_reportDescriptor->parse();
-        m_deviceUsesReportIds = m_reportDescriptor->isDeviceWithReportIds();
-    } else {
-        m_reportDescriptor.reset();
-        m_deviceUsesReportIds = std::nullopt;
+        if (!rawReportDescriptor.empty()) {
+            m_reportDescriptor =
+                    std::make_shared<hid::reportDescriptor::HidReportDescriptor>(
+                            rawReportDescriptor);
+            m_reportDescriptor->parse();
+            m_deviceUsesReportIds = m_reportDescriptor->isDeviceWithReportIds();
+        } else {
+            m_reportDescriptor.reset();
+            m_deviceUsesReportIds = std::nullopt;
+        }
     }
 
 #endif
@@ -293,6 +311,13 @@ int HidController::close() {
     }
 
     qCInfo(m_logBase) << "Shutting down HID device" << getName();
+
+    // Release persistent report descriptor lock acquired in open(), if any.
+    // The requested behaviour is to keep the mutex locked while the device is open
+    // and only release it when close() runs.
+    if (m_reportDescriptorLock.has_value()) {
+        m_reportDescriptorLock.reset();
+    }
 
     // Stop the InputReport polling, but allow sending OutputReports in JavaScript mapping shutdown procedure
     VERIFY_OR_DEBUG_ASSERT(m_pHidIoThread) {
@@ -358,4 +383,49 @@ bool HidController::sendBytes(const QByteArray& data) {
 
 ControllerJSProxy* HidController::jsProxy() {
     return new HidControllerJSProxy(this);
+}
+
+void HidController::fetchReportDescriptorInBackground() {
+#ifndef Q_OS_ANDROID
+    // Launch a concurrent task to open the device and fetch the report descriptor
+    m_reportDescriptorFuture = QtConcurrent::run([this]() {
+        // Try to acquire the mutex. If another thread already
+        // locked the report descriptor mutex, skip the background fetch.
+        std::unique_lock<std::mutex> lock(this->m_reportDescriptorMutex, std::try_to_lock);
+        if (!lock.owns_lock()) {
+            qCWarning(m_logBase) << "HID Report Descriptor structure is locked" << getName();
+            return;
+        }
+
+        hid_device* pHidDevice = hid_open_path(this->m_deviceInfo.pathRaw());
+        if (!pHidDevice) {
+            pHidDevice = hid_open(this->m_deviceInfo.getVendorId(),
+                    this->m_deviceInfo.getProductId(),
+                    this->m_deviceInfo.serialNumberRaw());
+        }
+        if (!pHidDevice) {
+            pHidDevice = hid_open(this->m_deviceInfo.getVendorId(),
+                    this->m_deviceInfo.getProductId(),
+                    nullptr);
+        }
+        if (!pHidDevice) {
+            return;
+        }
+        hid_set_nonblocking(pHidDevice, 1);
+
+        const std::vector<uint8_t>& rawReportDescriptor =
+                this->m_deviceInfo.fetchRawReportDescriptor(pHidDevice);
+
+        if (!rawReportDescriptor.empty()) {
+            m_reportDescriptor = std::make_shared<
+                    hid::reportDescriptor::HidReportDescriptor>(
+                    rawReportDescriptor);
+            m_reportDescriptor->parse();
+            m_deviceUsesReportIds = m_reportDescriptor->isDeviceWithReportIds();
+        }
+        hid_close(pHidDevice);
+    });
+#else
+    Q_UNUSED(m_reportDescriptorFuture);
+#endif
 }


### PR DESCRIPTION
Until now the HID report tab GUI implemented in #14755 only appears if the controller was enabled (which requires a mapping to be assigned) at startup of Mixxx.
This PR changes this. It opens all accessible HID devices in a background thread started during the device enumeration at startup of Mixxx, reads the HID Report Descriptor, and closes the HID device after this operation.
The result is that all HID devices that could be opened at startup show the HID report tab GUI independed of the enabled state.

Note: If the device is not enabled, the GUI shows only the static information gathered from the Report Descriptor, but the column Value still needs the controller to be enabled.