### PR TITLE
SoundSourceFFmpeg: serialize filename to utf-8 bytearray

### DIFF
--- a/src/sources/soundsourceffmpeg.cpp
+++ b/src/sources/soundsourceffmpeg.cpp
@@ -290,7 +290,7 @@ AVFormatContext* SoundSourceFFmpeg::openInputFile(
     // Open input file and allocate/initialize AVFormatContext
     const int avformat_open_input_result =
             avformat_open_input(
-                    &pavInputFormatContext, fileName.toLocal8Bit().constData(), nullptr, nullptr);
+                    &pavInputFormatContext, fileName.toUtf8().constData(), nullptr, nullptr);
     if (avformat_open_input_result != 0) {
         DEBUG_ASSERT(avformat_open_input_result < 0);
         kLogger.warning().noquote()


### PR DESCRIPTION
Backport of #13784

Maybe fixes #15681, where filenames like _J.Córdova - Mueve2Cool0h ♱⋆ཋྀ ˚_ (not sure about the extension)
fail on Debian Bookworm.