### PR TITLE
Fix qt warnings #ISSUE 15698

### DIFF
--- a/src/controllers/scripting/legacy/controllerscriptenginelegacy.cpp
+++ b/src/controllers/scripting/legacy/controllerscriptenginelegacy.cpp
@@ -757,8 +757,12 @@ std::unique_ptr<mixxx::qml::QmlMixxxControllerScreen> ControllerScriptEngineLega
     }
 
     QDir dir(m_resourcePath + "/qml/");
+    if (!scene.open(QIODevice::ReadOnly)) {
+        qCWarning(m_logger) << "Unable to open QML scene file:"
+                            << qmlScript.file.absoluteFilePath();
+        return nullptr;
+    }
 
-    scene.open(QIODevice::ReadOnly);
     qmlComponent.setData(scene.readAll(),
             // Obfuscate the scene filename to make it appear in the QML folder.
             // This allows a smooth integration with QML components.

--- a/src/rendergraph/opengl/materialshader.cpp
+++ b/src/rendergraph/opengl/materialshader.cpp
@@ -15,7 +15,11 @@ QString resource(const QString& filename) {
 
 QByteArray loadShaderCodeFromFile(const QString& path) {
     QFile file(path);
-    file.open(QIODeviceBase::ReadOnly);
+    //Fix :Ensure the shader file opened successfully
+    if (!file.open(QIODeviceBase::ReadOnly)) {
+        qWarning() << "Failed to open the shader file:" << path;
+        return QByteArray();
+    }
     QShader qsbShader = QShader::fromSerialized(file.readAll());
     QShaderKey key(QShader::GlslShader, 120);
     return qsbShader.shader(key).shader();
@@ -27,7 +31,11 @@ QString resource(const QString& filename) {
 
 QByteArray loadShaderCodeFromFile(const QString& path) {
     QFile file(path);
-    file.open(QIODeviceBase::ReadOnly);
+     // The FIX : Ensure the shader file opened successfully
+    if (!file.open(QIODeviceBase::ReadOnly)) {
+        qWarning() << "Failed to open shader file:" << path;
+        return QByteArray();
+    }
     return file.readAll();
 }
 #endif

--- a/src/rendergraph/opengl/materialshader.cpp
+++ b/src/rendergraph/opengl/materialshader.cpp
@@ -15,7 +15,6 @@ QString resource(const QString& filename) {
 
 QByteArray loadShaderCodeFromFile(const QString& path) {
     QFile file(path);
-    //Fix :Ensure the shader file opened successfully
     if (!file.open(QIODeviceBase::ReadOnly)) {
         qWarning() << "Failed to open the shader file:" << path;
         return QByteArray();
@@ -31,7 +30,6 @@ QString resource(const QString& filename) {
 
 QByteArray loadShaderCodeFromFile(const QString& path) {
     QFile file(path);
-     // The FIX : Ensure the shader file opened successfully
     if (!file.open(QIODeviceBase::ReadOnly)) {
         qWarning() << "Failed to open shader file:" << path;
         return QByteArray();

--- a/src/test/mixxxtest.cpp
+++ b/src/test/mixxxtest.cpp
@@ -12,7 +12,7 @@ namespace {
 QString makeTestConfigFile(const QString& path) {
     QFile test_cfg(path);
     if (!test_cfg.open(QIODevice::ReadWrite)) {
-        qWarning() << "Failed to open The test config file:" << path;
+        qWarning() << "Failed to open THE test config file:" << path;
         return QString();
     }
     test_cfg.close();

--- a/src/test/mixxxtest.cpp
+++ b/src/test/mixxxtest.cpp
@@ -11,7 +11,10 @@ namespace {
 
 QString makeTestConfigFile(const QString& path) {
     QFile test_cfg(path);
-    test_cfg.open(QIODevice::ReadWrite);
+    if (!test_cfg.open(QIODevice::ReadWrite)) {
+        qWarning() << "Failed to open The test config file:" << path;
+        return QString();
+    }
     test_cfg.close();
     return path;
 }


### PR DESCRIPTION
The Pull Request resolves compiler warnings which are  introduced when building Mixxx with Qt 6.10.

Modified the three affected files to  check the return value of `QFile::open()`,  added  failure handling (using `qWarning()` ) where necessary.

Fixes #15698