### PR TITLE
autodj: Add missing space between sentence breaks

### DIFF
--- a/src/library/autodj/autodjfeature.cpp
+++ b/src/library/autodj/autodjfeature.cpp
@@ -199,7 +199,7 @@ void AutoDJFeature::activate() {
 void AutoDJFeature::clear() {
     QMessageBox::StandardButton btn = QMessageBox::question(nullptr,
             tr("Confirmation Clear"),
-            tr("Do you really want to remove all tracks from the Auto DJ queue?") +
+            tr("Do you really want to remove all tracks from the Auto DJ queue? ") +
                     tr("This can not be undone."),
             QMessageBox::Yes | QMessageBox::No,
             QMessageBox::No);


### PR DESCRIPTION
Presently, the message is displayed as:

> Do you really want to remove all tracks from the Auto DJ queue?This can not be undone.