### PR TITLE
Adds optional setting to auto-start recording when Live Broadcasting begins

### DIFF
--- a/res/controllers/TraktorKontrolS4MK3Screens/S4MK3/AdvancedScreen/ViewModels/DeckInfo.qml
+++ b/res/controllers/TraktorKontrolS4MK3Screens/S4MK3/AdvancedScreen/ViewModels/DeckInfo.qml
@@ -114,7 +114,7 @@ Item {
             default:
                 console.error(`Unknown deck ${deckId}. Defaulting to D`);
             case 4:
-                return "D";
+                    return "D";
         }
     }
 

--- a/res/controllers/TraktorKontrolS4MK3Screens/S4MK3/AdvancedScreen/Widgets/TempoAdjust.qml
+++ b/res/controllers/TraktorKontrolS4MK3Screens/S4MK3/AdvancedScreen/Widgets/TempoAdjust.qml
@@ -16,23 +16,23 @@ Item {
             case 0:
                 return "";
             case 1:
-                return "Master BPM";
+                    return "Master BPM";
             case 2:
                 return "BPM";
             case 3:
-                return "Tempo";
+                    return "Tempo";
             case 4:
                 return "BPM Offset";
             case 5:
-                return "Tempo Offset";
+                    return "Tempo Offset";
             case 6:
                 return "Master Deck";
             case 7:
-                return "Tempo Range";
+                    return "Tempo Range";
             case 8:
                 return "Key";
             case 9:
-                return "Original BPM";
+                    return "Original BPM";
         }
     }
 
@@ -41,23 +41,23 @@ Item {
             case 0:
                 return "";
             case 1:
-                return deckInfo.masterBPMShort;
+                    return deckInfo.masterBPMShort;
             case 2:
                 return deckInfo.bpmString;
             case 3:
-                return deckInfo.tempoStringPer;
+                    return deckInfo.tempoStringPer;
             case 4:
                 return (deckInfo.masterDeck == tempoAdjust.deckId) ? "0.00" : deckInfo.bpmOffset;
             case 5:
-                return (deckInfo.masterDeck == tempoAdjust.deckId) ? "0.00%" : deckInfo.tempoNeededString;
+                    return (deckInfo.masterDeck == tempoAdjust.deckId) ? "0.00%" : deckInfo.tempoNeededString;
             case 6:
                 return deckInfo.masterDeckLetter
             case 7:
-                return deckInfo.tempoRange
+                    return deckInfo.tempoRange
             case 8:
                 return deckInfo.hasKey && (deckInfo.keyAdjustString != "-0") && (deckInfo.keyAdjustString != "+0") ? (settings.camelotKey ? utils.camelotConvert(deckInfo.keyString) : deckInfo.keyString) + deckInfo.keyAdjustString : deckInfo.hasKey ? (settings.camelotKey ? utils.camelotConvert(deckInfo.keyString) : deckInfo.keyString) : "No key";
             case 9:
-                return deckInfo.songBPM
+                    return deckInfo.songBPM
         }
     }
 
@@ -66,23 +66,23 @@ Item {
             case 0:
                 return "white";
             case 1:
-                return settings.enableMasterBpmTextColor ? ((deckInfo.masterDeck == deckInfo.deckId) ? colors.loopActiveColor : colors.lightOrange) : "white";
+                    return settings.enableMasterBpmTextColor ? ((deckInfo.masterDeck == deckInfo.deckId) ? colors.loopActiveColor : colors.lightOrange) : "white";
             case 2:
                 return settings.enableBpmTextColor ? ((deckInfo.masterDeck == tempoAdjust.deckId) || ((deckInfo.bpmOffset <= 0.05) && (deckInfo.bpmOffset >= - 0.05)) ? colors.loopActiveColor : colors.lightOrange) : "white";
             case 3:
-                return settings.enableTempoTextColor ? ((deckInfo.tempoString <= 0.05) && (deckInfo.tempoString >= - 0.05) ? colors.loopActiveColor : colors.lightOrange) : "white";
+                    return settings.enableTempoTextColor ? ((deckInfo.tempoString <= 0.05) && (deckInfo.tempoString >= - 0.05) ? colors.loopActiveColor : colors.lightOrange) : "white";
             case 4:
                 return settings.enableBpmOffsetTextColor ? ((deckInfo.masterDeck == tempoAdjust.deckId) || ((deckInfo.bpmOffset <= 0.05) && (deckInfo.bpmOffset >= - 0.05)) ? colors.loopActiveColor : colors.lightOrange) : "white";
             case 5:
-                return settings.enableTempoOffsetTextColor ? ((deckInfo.masterDeck == tempoAdjust.deckId) || ((deckInfo.tempoNeededVal <= 0.05) && (deckInfo.tempoNeededVal >= - 0.05)) ? colors.loopActiveColor : colors.lightOrange) : "white";
+                    return settings.enableTempoOffsetTextColor ? ((deckInfo.masterDeck == tempoAdjust.deckId) || ((deckInfo.tempoNeededVal <= 0.05) && (deckInfo.tempoNeededVal >= - 0.05)) ? colors.loopActiveColor : colors.lightOrange) : "white";
             case 6:
                 return settings.enableMasterDeckTextColor ? ((deckInfo.masterDeck == deckInfo.deckId) ? colors.loopActiveColor : colors.lightOrange) : "white";
             case 7:
-                return "white"
+                    return "white"
             case 8:
                 return deckInfo.isKeyLockOn ? colors.musicalKeyColors[deckInfo.keyIndex] : "white"
             case 9:
-                return "white"
+                    return "white"
         }
     }
 

--- a/res/qml/MicrophoneDuckingPanel.qml
+++ b/res/qml/MicrophoneDuckingPanel.qml
@@ -40,7 +40,7 @@ Column {
                     case MicrophoneDuckingPanel.DuckingMode.Auto:
                         return "Auto";
                     case MicrophoneDuckingPanel.DuckingMode.Manual:
-                        return "Manual";
+                            return "Manual";
                     default:
                         return "Off";
                 }

--- a/res/qml/Mixxx/Controls/Knob.qml
+++ b/res/qml/Mixxx/Controls/Knob.qml
@@ -27,7 +27,7 @@ Item {
             case Knob.ArcStart.Minimum:
                 return min;
             case Knob.ArcStart.Maximum:
-                return max;
+                    return max;
             default:
                 return valueCenter;
         }

--- a/res/qml/SyncButton.qml
+++ b/res/qml/SyncButton.qml
@@ -28,7 +28,7 @@ Skin.Button {
             case SyncButton.SyncMode.ImplicitLeader:
                 return Theme.yellow;
             case SyncButton.SyncMode.ExplicitLeader:
-                return Theme.red;
+                    return Theme.red;
             default:
                 return Theme.deckActiveColor;
         }
@@ -36,8 +36,8 @@ Skin.Button {
     text: {
         switch (mode) {
             case SyncButton.SyncMode.ImplicitLeader:
-                case SyncButton.SyncMode.ExplicitLeader:
-                    return "Leader";
+            case SyncButton.SyncMode.ExplicitLeader:
+                return "Leader";
             default:
                 return "Sync";
         }

--- a/src/broadcast/broadcastmanager.h
+++ b/src/broadcast/broadcastmanager.h
@@ -11,6 +11,10 @@ class ControlPushButton;
 class EngineNetworkStream;
 class SettingsManager;
 
+class ControlObject;
+class ControlProxy;
+
+
 class BroadcastManager : public QObject {
     Q_OBJECT
   public:
@@ -55,4 +59,10 @@ class BroadcastManager : public QObject {
 
     ControlPushButton* m_pBroadcastEnabled;
     ControlObject* m_pStatusCO;
+    
+    // NEW: recording control objects
+    ControlProxy* m_pRecordingStatus;
+    ControlProxy* m_pRecordingToggle;
+    bool m_autoStartedRecording = false;
+    
 };

--- a/src/mixxxmainwindow.cpp
+++ b/src/mixxxmainwindow.cpp
@@ -443,6 +443,12 @@ void MixxxMainWindow::initialize() {
             &MixxxMainWindow::slotUpdateWindowTitle);
 
     // Start Auto DJ if the cmdline arg is passed.
+    if (CmdlineArgs::Instance().getStartAutoRecord()) { qDebug("Enabling Auto Recording from 
+        CLI flag."); ControlObject::set(ConfigKey("[Recording]"), 
+        "toggle_recording"), 1.0);
+    }
+}
+
     if (CmdlineArgs::Instance().getStartAutoDJ()) {
         qDebug("Enabling Auto DJ from CLI flag.");
         ControlObject::set(ConfigKey("[AutoDJ]", "enabled"), 1.0);

--- a/src/preferences/dialog/dlgprefbroadcast.cpp
+++ b/src/preferences/dialog/dlgprefbroadcast.cpp
@@ -183,6 +183,11 @@ void DlgPrefBroadcast::slotUpdate() {
     updateModel();
     connectOnApply->setChecked(false);
 
+    // Load auto-record preference
+    bool autoRecord = m_pBroadcastSettings->getValue(ConfigKey(BROADCAST_PREF_KEY,
+            "auto_record_on_live")).toBool();
+    autoRecordOnLive->setChecked(autoRecord);
+
     // Force select an item to have the current selection
     // set to a profile pointer belonging to the model
     selectConnectionRow(0);
@@ -195,6 +200,8 @@ void DlgPrefBroadcast::slotUpdate() {
     btnRemoveConnection->setEnabled(!enabled);
     btnRenameConnection->setEnabled(!enabled);
     connectOnApply->setEnabled(!enabled);
+    autoRecordOnLive->setEnabled(!enabled);
+
 
     btnDisconnectAll->setEnabled(enabled);
 }
@@ -213,6 +220,7 @@ void DlgPrefBroadcast::slotApply() {
     if (m_pProfileListSelection) {
         setValuesToProfile(m_pProfileListSelection);
     }
+
 
     // Make sure the currently selected connection gets saved as expected.
     // Reject if the password contains invalid characters.
@@ -283,6 +291,10 @@ void DlgPrefBroadcast::slotApply() {
         connectOnApply->setChecked(false);
     }
 
+    // Save auto-record preference
+    m_pBroadcastSettings->setValue(ConfigKey(BROADCAST_PREF_KEY, "auto_record_on_live"),
+        autoRecordOnLive->isChecked());
+
     // Don't let user modify information if
     // sending is enabled.
     bool enabled = m_pBroadcastEnabled->toBool();
@@ -291,6 +303,8 @@ void DlgPrefBroadcast::slotApply() {
     btnRemoveConnection->setEnabled(!enabled);
     btnRenameConnection->setEnabled(!enabled);
     connectOnApply->setEnabled(!enabled);
+    autoRecordOnLive->setEnabled(!enabled);
+
 
     btnDisconnectAll->setEnabled(enabled);
 }
@@ -304,6 +318,8 @@ void DlgPrefBroadcast::broadcastEnabledChanged(double value) {
     btnRemoveConnection->setEnabled(!enabled);
     btnRenameConnection->setEnabled(!enabled);
     connectOnApply->setEnabled(!enabled);
+    autoRecordOnLive->setEnabled(!enabled);
+
 
     btnDisconnectAll->setEnabled(enabled);
 }

--- a/src/preferences/dialog/dlgprefbroadcastdlg.ui
+++ b/src/preferences/dialog/dlgprefbroadcastdlg.ui
@@ -128,6 +128,17 @@
         </property>
        </widget>
       </item>
+      <!-- NEW Checkbox for Auto Recording -->
+      <item>
+        <widget class="QCheckBox" name="autoRecordOnLive">
+          <property name="text">
+              <string>Automatically start recording when going live</string>
+          </property>
+          <property name="checked">
+              <bool>false</bool>
+          </property>
+        </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/util/cmdlineargs.cpp
+++ b/src/util/cmdlineargs.cpp
@@ -55,6 +55,7 @@ CmdlineArgs::CmdlineArgs()
           m_controllerDebug(false),
           m_controllerAbortOnWarning(false),
           m_developer(false),
+          m_startAutoRecord(false),
 #ifdef MIXXX_USE_QML
           m_qml(false),
 #endif
@@ -186,6 +187,12 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
                             : QString(),
             QStringLiteral("locale"));
     parser.addOption(locale);
+
+    const QCommandLineOption startAutoRecord(QStringLiteral("start-autorecord"),
+            forUserFeedback ? QCoreApplication::translate("CmdLineArgs",
+                                      "Starts auto recording when Mixxx is launched.")
+                            : QString());
+    parser.addOption(startAutoRecord);
 
     const QCommandLineOption startAutoDJ(QStringLiteral("start-autodj"),
             forUserFeedback ? QCoreApplication::translate("CmdlineArgs",
@@ -436,6 +443,10 @@ bool CmdlineArgs::parse(const QStringList& arguments, CmdlineArgs::ParseMode mod
 
     if (parser.isSet(locale)) {
         m_locale = parser.value(locale);
+    }
+
+    if (parser.isSet(startAutoRecord)) {
+        m_startAutoRecord = true;
     }
 
     if (parser.isSet(startAutoDJ)) {

--- a/src/util/cmdlineargs.h
+++ b/src/util/cmdlineargs.h
@@ -33,6 +33,10 @@ class CmdlineArgs final {
     bool getStartAutoDJ() const {
         return m_startAutoDJ;
     }
+    bool getStartAutoRecord() const {
+        return m_startAutoRecord;
+    }
+
     bool getRescanLibrary() const {
         return m_rescanLibrary;
     }
@@ -102,6 +106,7 @@ class CmdlineArgs final {
     QList<QString> m_musicFiles;    // List of files to load into players at startup
     bool m_startInFullscreen;       // Start in fullscreen mode
     bool m_startAutoDJ;
+    bool m_startAutoRecord; // Start recording immediately
     bool m_rescanLibrary;
     bool m_controllerDebug;
     bool m_controllerPreviewScreens;


### PR DESCRIPTION
Fixes #15569

**Behavior overview:**
- When the option is enabled and Live Broadcasting starts, Mixxx begins recording if no active recording exists.
- Mixxx tracks whether a recording was auto-started and stops it when broadcasting ends.
- Manually started recordings are never stopped automatically.
- Default behavior remains unchanged unless the user opts in.

