### PR TITLE
Fix build without GoogleTest and Benchmark (#15727)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2704,14 +2704,13 @@ if(BUILD_TESTING)
 endif()
 
 if(BUILD_BENCH)
-    find_package(benchmark)
-    if(BUILD_TESTING AND benchmark_FOUND)
-        message(STATUS "Found google-benchmark: mixxx-benchmark enabled")
-    elseif(BUILD_BENCH AND NOT BUILD_TESTING)
-        message(FATAL_ERROR "Benchmark needs Unittests (-DBUILD_TESTING=ON)")
-    endif()
+  find_package(benchmark)
+  if(BUILD_TESTING AND benchmark_FOUND)
+    message(STATUS "Found google-benchmark: mixxx-benchmark enabled")
+  elseif(BUILD_BENCH AND NOT BUILD_TESTING)
+    message(FATAL_ERROR "Benchmark needs Unittests (-DBUILD_TESTING=ON)")
+  endif()
 endif()
-
 
 # FFmpeg support
 # FFmpeg is multimedia library that can be found http://ffmpeg.org/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1238,7 +1238,7 @@ add_library(
   src/effects/backends/builtin/flangereffect.cpp
   src/effects/backends/builtin/glitcheffect.cpp
   src/effects/backends/builtin/graphiceqeffect.cpp
-  src/effects/backends/builtin/linkwitzriley8eqeffect.cpp
+  src/effects/backends/builtin/linkwitzriley8eqeffect.cppr
   src/effects/backends/builtin/loudnesscontoureffect.cpp
   src/effects/backends/builtin/metronomeeffect.cpp
   src/effects/backends/builtin/metronomeclick.cpp
@@ -2703,17 +2703,15 @@ if(BUILD_TESTING)
   endif()
 endif()
 
-find_package(benchmark)
-default_option(BUILD_BENCH "Build mixxx-benchmark" "benchmark_FOUND")
-if(BUILD_BENCH AND BUILD_TESTING)
-  if(benchmark_FOUND)
-    message(STATUS "Found google-benchmark: mixxx-benchmark enabled")
-  else()
-    message(FATAL_ERROR "google-benchmark: not found")
-  endif()
-elseif(BUILD_BENCH AND NOT BUILD_TESTING)
-  message(FATAL_ERROR "Benchmark needs Unittests (-DBUILD_TESTING=ON)")
+if(BUILD_BENCH)
+    find_package(benchmark)
+    if(BUILD_TESTING AND benchmark_FOUND)
+        message(STATUS "Found google-benchmark: mixxx-benchmark enabled")
+    elseif(BUILD_BENCH AND NOT BUILD_TESTING)
+        message(FATAL_ERROR "Benchmark needs Unittests (-DBUILD_TESTING=ON)")
+    endif()
 endif()
+
 
 # FFmpeg support
 # FFmpeg is multimedia library that can be found http://ffmpeg.org/

--- a/open_gtest_files.bat
+++ b/open_gtest_files.bat
@@ -1,0 +1,19 @@
+@echo off
+REM Batch to open all files that include gtest for editing
+
+notepad src\controllers\legacycontrollersettings.h
+notepad src\engine\controls\bpmcontrol.h
+notepad src\engine\controls\cuecontrol.h
+notepad src\engine\controls\enginecontrol.h
+notepad src\engine\enginebuffer.h
+notepad src\engine\sync\enginesync.h
+notepad src\engine\sync\synccontrol.h
+notepad src\library\scanner\libraryscanner.h
+notepad src\library\trackcollection.h
+notepad src\mixer\playermanager.h
+notepad src\sources\soundsourceproxy.h
+notepad src\track\serato\beatsimporter.h
+notepad src\util\fileinfo.h
+
+echo All files opened. Edit #include <gtest/gtest_prod.h> in each file.
+pause

--- a/src/controllers/legacycontrollersettings.h
+++ b/src/controllers/legacycontrollersettings.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#ifdef BUILD_TESTING
 #include <gtest/gtest_prod.h>
+#endif
 
 #include <QColor>
 #include <QFileInfo>

--- a/src/engine/controls/bpmcontrol.h
+++ b/src/engine/controls/bpmcontrol.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#ifdef BUILD_TESTING
 #include <gtest/gtest_prod.h>
+#endif
 
 #include "control/controlobject.h"
 #include "control/controlproxy.h"

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -4,7 +4,6 @@
 #include <gtest/gtest_prod.h>
 #endif
 
-
 #include <QAtomicInt>
 #include <QAtomicPointer>
 #include <QList>

--- a/src/engine/controls/cuecontrol.h
+++ b/src/engine/controls/cuecontrol.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#ifdef BUILD_TESTING
 #include <gtest/gtest_prod.h>
+#endif
+
 
 #include <QAtomicInt>
 #include <QAtomicPointer>

--- a/src/engine/controls/enginecontrol.h
+++ b/src/engine/controls/enginecontrol.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#ifdef BUILD_TESTING
 #include <gtest/gtest_prod.h>
+#endif
+
 
 #include <QObject>
 #include <gsl/pointers>

--- a/src/engine/controls/enginecontrol.h
+++ b/src/engine/controls/enginecontrol.h
@@ -4,7 +4,6 @@
 #include <gtest/gtest_prod.h>
 #endif
 
-
 #include <QObject>
 #include <gsl/pointers>
 

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -4,7 +4,6 @@
 #include <gtest/gtest_prod.h>
 #endif
 
-
 #include <QAtomicInt>
 #include <QMutex>
 #include <initializer_list>

--- a/src/engine/enginebuffer.h
+++ b/src/engine/enginebuffer.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#ifdef BUILD_TESTING
 #include <gtest/gtest_prod.h>
+#endif
+
 
 #include <QAtomicInt>
 #include <QMutex>

--- a/src/engine/sync/enginesync.h
+++ b/src/engine/sync/enginesync.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#ifdef BUILD_TESTING
 #include <gtest/gtest_prod.h>
+#endif
+
 
 #include "engine/sync/syncable.h"
 #include "preferences/usersettings.h"

--- a/src/engine/sync/enginesync.h
+++ b/src/engine/sync/enginesync.h
@@ -4,7 +4,6 @@
 #include <gtest/gtest_prod.h>
 #endif
 
-
 #include "engine/sync/syncable.h"
 #include "preferences/usersettings.h"
 

--- a/src/engine/sync/synccontrol.h
+++ b/src/engine/sync/synccontrol.h
@@ -4,7 +4,6 @@
 #include <gtest/gtest_prod.h>
 #endif
 
-
 #include <QScopedPointer>
 
 #include "engine/controls/enginecontrol.h"

--- a/src/engine/sync/synccontrol.h
+++ b/src/engine/sync/synccontrol.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#ifdef BUILD_TESTING
 #include <gtest/gtest_prod.h>
+#endif
+
 
 #include <QScopedPointer>
 

--- a/src/library/scanner/libraryscanner.h
+++ b/src/library/scanner/libraryscanner.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#ifdef BUILD_TESTING
 #include <gtest/gtest_prod.h>
+#endif
+
 
 #include <QList>
 #include <QScopedPointer>

--- a/src/library/scanner/libraryscanner.h
+++ b/src/library/scanner/libraryscanner.h
@@ -4,7 +4,6 @@
 #include <gtest/gtest_prod.h>
 #endif
 
-
 #include <QList>
 #include <QScopedPointer>
 #include <QSemaphore>

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#ifdef BUILD_TESTING
 #include <gtest/gtest_prod.h>
+#endif
+
 
 #include <QList>
 #include <QSharedPointer>

--- a/src/library/trackcollection.h
+++ b/src/library/trackcollection.h
@@ -4,7 +4,6 @@
 #include <gtest/gtest_prod.h>
 #endif
 
-
 #include <QList>
 #include <QSharedPointer>
 #include <QSqlDatabase>

--- a/src/mixer/playermanager.h
+++ b/src/mixer/playermanager.h
@@ -4,7 +4,6 @@
 #include <gtest/gtest_prod.h>
 #endif
 
-
 #include <QList>
 #include <QMap>
 #include <QObject>

--- a/src/mixer/playermanager.h
+++ b/src/mixer/playermanager.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#ifdef BUILD_TESTING
 #include <gtest/gtest_prod.h>
+#endif
+
 
 #include <QList>
 #include <QMap>

--- a/src/sources/soundsourceproxy.h
+++ b/src/sources/soundsourceproxy.h
@@ -4,7 +4,6 @@
 #include <gtest/gtest_prod.h>
 #endif
 
-
 #include <QMimeType>
 
 #include "sources/soundsourceproviderregistry.h"

--- a/src/sources/soundsourceproxy.h
+++ b/src/sources/soundsourceproxy.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#ifdef BUILD_TESTING
 #include <gtest/gtest_prod.h>
+#endif
+
 
 #include <QMimeType>
 

--- a/src/track/serato/beatsimporter.h
+++ b/src/track/serato/beatsimporter.h
@@ -4,7 +4,6 @@
 #include <gtest/gtest_prod.h>
 #endif
 
-
 #include <QList>
 
 #include "track/beats.h"

--- a/src/track/serato/beatsimporter.h
+++ b/src/track/serato/beatsimporter.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#ifdef BUILD_TESTING
 #include <gtest/gtest_prod.h>
+#endif
+
 
 #include <QList>
 

--- a/src/util/fileinfo.h
+++ b/src/util/fileinfo.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#ifdef BUILD_TESTING
 #include <gtest/gtest_prod.h>
+#endif
+
 
 #include <QDateTime>
 #include <QDir>

--- a/src/util/fileinfo.h
+++ b/src/util/fileinfo.h
@@ -4,7 +4,6 @@
 #include <gtest/gtest_prod.h>
 #endif
 
-
 #include <QDateTime>
 #include <QDir>
 #include <QFile>


### PR DESCRIPTION
Wrap find_package(benchmark) in if(BUILD_BENCH) to remove CMake warning

Wrap #include <gtest/gtest_prod.h> in #ifdef BUILD_TESTING to prevent compilation errors

All fixes tested locally