### PR TITLE
fix: reset the quickfx stem effect on track load when auto reset is enabled

### DIFF
--- a/src/effects/effectchain.cpp
+++ b/src/effects/effectchain.cpp
@@ -219,6 +219,16 @@ void EffectChain::loadChainPreset(EffectChainPresetPointer pChainPreset) {
     setControlLoadedPresetIndex(presetIndex());
 }
 
+void EffectChain::resetToDefault() {
+    m_pControlChainEnabled->set(true);
+    if (m_presetName.isEmpty() || !presetIndex()) {
+        // If no preset is selected, reset the super knob to a mid position, as it is by default.
+        setSuperParameter(0.5, true);
+        return;
+    }
+    setSuperParameter(m_pControlChainSuperParameter->defaultValue(), true);
+}
+
 bool EffectChain::isEmpty() {
     for (const auto& pEffectSlot : std::as_const(m_effectSlots)) {
         if (pEffectSlot->isLoaded()) {

--- a/src/effects/effectchain.h
+++ b/src/effects/effectchain.h
@@ -39,6 +39,7 @@ class EffectChain : public QObject {
     virtual ~EffectChain();
 
     QString group() const;
+    void resetToDefault();
 
     EffectSlotPointer getEffectSlot(unsigned int slotNumber);
 

--- a/src/effects/effectsmanager.cpp
+++ b/src/effects/effectsmanager.cpp
@@ -164,6 +164,19 @@ void EffectsManager::addStem(const ChannelHandleAndGroup& stemHandleGroup) {
     }
 }
 
+void EffectsManager::resetStemQuickFxKnob(const ChannelHandleAndGroup& stemHandleGroup) {
+    VERIFY_OR_DEBUG_ASSERT(m_quickStemEffectChains.contains(stemHandleGroup.name())) {
+        return;
+    }
+    auto pChainSlot = m_quickStemEffectChains[stemHandleGroup.name()];
+
+    VERIFY_OR_DEBUG_ASSERT(pChainSlot) {
+        return;
+    }
+
+    pChainSlot->resetToDefault();
+}
+
 void EffectsManager::addEqualizerEffectChain(const ChannelHandleAndGroup& deckHandleGroup) {
     VERIFY_OR_DEBUG_ASSERT(!m_equalizerEffectChains.contains(
             EqualizerEffectChain::formatEffectChainGroup(deckHandleGroup.name()))) {

--- a/src/effects/effectsmanager.h
+++ b/src/effects/effectsmanager.h
@@ -28,6 +28,7 @@ class EffectsManager {
     void setup();
     void addDeck(const ChannelHandleAndGroup& deckHandleGroup);
     void addStem(const ChannelHandleAndGroup& stemHandleGroup);
+    void resetStemQuickFxKnob(const ChannelHandleAndGroup& stemHandleGroup);
 
     void loadDefaultEqsAndQuickEffects();
 

--- a/src/engine/enginemixer.h
+++ b/src/engine/enginemixer.h
@@ -55,6 +55,11 @@ class EngineMixer : public QObject, public AudioSource {
                    m_pChannelHandleFactory->getOrCreateHandle(group), group);
     }
 
+    ChannelHandleAndGroup getChannelGroup(const QString& group) {
+        return ChannelHandleAndGroup(
+                m_pChannelHandleFactory->handleForGroup(group), group);
+    }
+
     // Register the sound I/O that does not correspond to any EngineChannel object
     void registerNonEngineChannelSoundIO(gsl::not_null<SoundManager*> pSoundManager);
 

--- a/src/mixer/playermanager.cpp
+++ b/src/mixer/playermanager.cpp
@@ -715,6 +715,21 @@ void PlayerManager::slotLoadTrackToPlayer(
             // so clone another playing deck instead of loading the selected track
             clone = true;
         }
+
+#ifdef __STEM__
+        // Reset the QuickFx of stem to their default value
+        if (m_pConfig->getValue(
+                    ConfigKey("[Mixer Profile]", "stem_auto_reset"), true)) {
+            ChannelHandleAndGroup handleGroup =
+                    m_pEngine->getChannelGroup(groupForDeck(m_decks.count()));
+            // Setup stem QuickEffect chain for this deck
+            for (int stemIdx = 0; stemIdx < mixxx::kMaxSupportedStems; stemIdx++) {
+                ChannelHandleAndGroup stemHandleGroup =
+                        m_pEngine->registerChannelGroup(groupForDeckStem(group, stemIdx));
+                m_pEffectsManager->resetStemQuickFxKnob(stemHandleGroup);
+            }
+        }
+#endif
     } else if (isPreviewDeckGroup(group) && play) {
         // This extends/overrides the behaviour of [PreviewDeckN],LoadSelectedTrackAndPlay:
         // if the track is already loaded, toggle play/pause.
@@ -785,6 +800,20 @@ void PlayerManager::slotLoadTrackIntoNextAvailableDeck(TrackPointer pTrack) {
         qDebug() << "PlayerManager: No stopped deck found, not loading track!";
         return;
     }
+#ifdef __STEM__
+    // Reset the QuickFx of stem to their default value
+    if (m_pConfig->getValue(
+                ConfigKey("[Mixer Profile]", "stem_auto_reset"), true)) {
+        ChannelHandleAndGroup handleGroup =
+                m_pEngine->getChannelGroup(groupForDeck(m_decks.count()));
+        // Setup stem QuickEffect chain for this deck
+        for (int stemIdx = 0; stemIdx < mixxx::kMaxSupportedStems; stemIdx++) {
+            ChannelHandleAndGroup stemHandleGroup =
+                    m_pEngine->registerChannelGroup(groupForDeckStem(pDeck->getGroup(), stemIdx));
+            m_pEffectsManager->resetStemQuickFxKnob(stemHandleGroup);
+        }
+    }
+#endif
 
     pDeck->slotLoadTrack(pTrack,
 #ifdef __STEM__

--- a/src/mixer/playermanager.h
+++ b/src/mixer/playermanager.h
@@ -157,8 +157,15 @@ class PlayerManager : public QObject, public PlayerManagerInterface {
 #ifdef __STEM__
     // Returns the group for the deck and stem where deckIndex and stemInde are zero based
     static QString groupForDeckStem(int deckIdx, int stemIdx) {
-        DEBUG_ASSERT(deckIdx >= 0 && stemIdx >= 0 && stemIdx < 4);
+        DEBUG_ASSERT(deckIdx >= 0 && stemIdx >= 0 && stemIdx < mixxx::kMaxSupportedStems);
         return QStringLiteral("[Channel") + QString::number(deckIdx + 1) +
+                QStringLiteral("_Stem") + QChar('1' + stemIdx) + QChar(']');
+    }
+
+    // Returns the group for the deck and stem where deckIndex and stemInde are zero based
+    static QString groupForDeckStem(const QString& channel, int stemIdx) {
+        DEBUG_ASSERT(!channel.isEmpty() && stemIdx >= 0 && stemIdx < mixxx::kMaxSupportedStems);
+        return channel.chopped(1) +
                 QStringLiteral("_Stem") + QChar('1' + stemIdx) + QChar(']');
     }
 #endif


### PR DESCRIPTION
Currently, when loading a new track on a deck, stem quickfx super knob don't reset when `[Mixer Profile],stem_auto_reset`. This leads to very undesired result, where you would load your next track on deck, and have the bad surprise of still have a filter or echo being enabled on stem.

This fix reset the knob to the default position if  `[Mixer Profile],stem_auto_reset` is enabled, or keep the current knob position if disabled, as the current behaviour.