### PR TITLE
Fix tag detection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
       - "[0-9].[0-9]"
+    tags:
+      - "[0-9].[0-9].[0-9]"
+      - "[0-9].[0-9]-*"
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Check for a tag of the current checkout branch. github.ref does not reliably contain the tag for tagged commits.
This was a major issue during the release process of 2.5.4 