### PR TITLE
Keyboard: add shortcut for Show Auto DJ

### DIFF
--- a/src/widget/wmainmenubar.cpp
+++ b/src/widget/wmainmenubar.cpp
@@ -380,9 +380,9 @@ void WMainMenuBar::initialize() {
     QString autoDJTitle = tr("Show Auto DJ");
     QString autoDJText = tr("Switch to the Auto DJ view.");
     auto* pViewAutoDJ = new QAction(autoDJTitle, this);
-    // pViewAutoDJ->setShortcut(QKeySequence(m_pKbdConfig->getValue(
-    //         ConfigKey("[KeyboardShortcuts]", "ViewMenu_ShowAutoDJ"),
-    //         tr("Ctrl+9", "Menubar|View|Show Auto DJ"))));
+    pViewAutoDJ->setShortcut(QKeySequence(m_pKbdConfig->getValue(
+            ConfigKey("[KeyboardShortcuts]", "ViewMenu_ShowAutoDJ"),
+            tr("Ctrl+9", "Menubar|View|Show Auto DJ"))));
     pViewAutoDJ->setStatusTip(autoDJText);
     pViewAutoDJ->setWhatsThis(buildWhatsThis(autoDJTitle, autoDJText));
     pViewAutoDJ->setCheckable(false);


### PR DESCRIPTION
Follow-up for #12890 because it came up again #15749

Key is `Ctrl`+`9` but I did not yet add it to the default mappings