### PR TITLE
Finetune Kalman filter coefficients

### DIFF
--- a/lib/xwax/timecoder.c
+++ b/lib/xwax/timecoder.c
@@ -462,10 +462,10 @@ void timecoder_init(struct timecoder *tc, struct timecode_def *def,
         pitch_kalman_init(&tc->pitch_kalman,
                           tc->dt,
                           KALMAN_COEFFS(1e-8, 10.0), /* stable mode */
-                          KALMAN_COEFFS(1e-4, 1e-1), /* adjust mode */
-                          KALMAN_COEFFS(1e-3, 1e-2), /* reactive mode */
+                          KALMAN_COEFFS(1e-4, 1e-2), /* adjust mode */
+                          KALMAN_COEFFS(1e-2, 1e-3), /* reactive mode */
                           KALMAN_COEFFS(1e-1, 1e-4), /* scratch mode */
-                          6e-4, /* adjust threshold */
+                          1e-3, /* adjust threshold */
                           25e-4, /* reactive threshold */
                           40e-4, /* scratch threshold */
                           false);


### PR DESCRIPTION
This improves the scratch feeling of the filter while still maintaining smooth and stable pitch while not scratching. 

Not sure if this is worth merging now. Tuning the filter values is just a small improvement. I am currently working on completely reworking the pitch detection by using and instantaneous frequency detector, which would update on every sample and not only the zero crossings. This would make for a 5-7x higher resolution and immensely improve scratching. I want to merge this reworked pitch detector only when I have also solved the sticker drift though.