### PR TITLE
Fix the stray colon in waveform preferences when OpenGL is not available.

### DIFF
--- a/src/preferences/dialog/dlgprefwaveform.cpp
+++ b/src/preferences/dialog/dlgprefwaveform.cpp
@@ -279,7 +279,7 @@ void DlgPrefWaveform::slotUpdate() {
                 WaveformWidgetBackend::None;
         useAccelerationCheckBox->setChecked(isAccelerationEnabled);
     } else {
-        openGlStatusData->setText(tr("OpenGL not available") + ": " + factory->getOpenGLVersion());
+        openGlStatusData->setText(tr("OpenGL not available"));
         useAccelerationCheckBox->setEnabled(false);
         useAccelerationCheckBox->setChecked(false);
     }

--- a/src/waveform/waveformwidgetfactory.cpp
+++ b/src/waveform/waveformwidgetfactory.cpp
@@ -183,7 +183,11 @@ WaveformWidgetFactory::WaveformWidgetFactory()
             m_openGLShaderAvailable = QOpenGLShaderProgram::hasOpenGLShaderPrograms(pContext);
 
             m_openGLVersion = pContext->isOpenGLES() ? "ES " : "";
-            m_openGLVersion += majorVersion == 0 ? QString("None") : versionString;
+            if (versionString.isEmpty()) {
+                m_openGLVersion += tr("(None)");
+            } else {
+                m_openGLVersion += versionString;
+            }
 
             // Qt5 requires at least OpenGL 2.1 or OpenGL ES 2.0
             if (pContext->isOpenGLES()) {


### PR DESCRIPTION
Fixes #15748 
When OpenGL is not available, the function getOpenGLVersion() returns an empty string. Previously, ": " was appended after the "OpenGL not available" message, which resulted  in a stray colon in the waveform preferences.
This change removes the concatenation with getOpenGLVersion() and the colon.
So now the "OpenGL not available" message is displayed  without a colon.

