### PR TITLE
Added controller bindings for assigning a track a 1-5 star rating

### DIFF
--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -1568,6 +1568,31 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
             tr("Decrease the track rating by one star"),
             pGuiMenu);
 
+    addDeckAndPreviewDeckControl("stars_one",
+            tr("Star Rating 1"),
+            tr("Gives the track a 1 star rating"),
+            pGuiMenu);
+
+    addDeckAndPreviewDeckControl("stars_two",
+            tr("Star Rating 2"),
+            tr("Gives the track a 2 star rating"),
+            pGuiMenu);
+
+    addDeckAndPreviewDeckControl("stars_three",
+            tr("Star Rating 3"),
+            tr("Gives the track a 3 star rating"),
+            pGuiMenu);
+
+    addDeckAndPreviewDeckControl("stars_four",
+            tr("Star Rating 4"),
+            tr("Gives the track a 4 star rating"),
+            pGuiMenu);
+
+    addDeckAndPreviewDeckControl("stars_five",
+            tr("Star Rating 5"),
+            tr("Gives the track a 5 star rating"),
+            pGuiMenu);
+
     // Controls to change a deck's loaded track color
     addDeckAndPreviewDeckControl("track_color_next",
             tr("Select Next Color Available"),

--- a/src/mixer/basetrackplayer.cpp
+++ b/src/mixer/basetrackplayer.cpp
@@ -156,6 +156,56 @@ BaseTrackPlayerImpl::BaseTrackPlayerImpl(
                 }
             });
 
+    m_pStarsOne = std::make_unique<ControlPushButton>(ConfigKey(getGroup(), "stars_one"));
+    connect(m_pStarsOne.get(),
+            &ControlObject::valueChanged,
+            this,
+            [this](double value) {
+                if (value > 0) {
+                    slotTrackRatingChangeRequest(1);
+                }
+            });
+
+    m_pStarsTwo = std::make_unique<ControlPushButton>(ConfigKey(getGroup(), "stars_two"));
+    connect(m_pStarsTwo.get(),
+            &ControlObject::valueChanged,
+            this,
+            [this](double value) {
+                if (value > 0) {
+                    slotTrackRatingChangeRequest(2);
+                }
+            });
+
+    m_pStarsThree = std::make_unique<ControlPushButton>(ConfigKey(getGroup(), "stars_three"));
+    connect(m_pStarsThree.get(),
+            &ControlObject::valueChanged,
+            this,
+            [this](double value) {
+                if (value > 0) {
+                    slotTrackRatingChangeRequest(3);
+                }
+            });
+
+    m_pStarsFour = std::make_unique<ControlPushButton>(ConfigKey(getGroup(), "stars_four"));
+    connect(m_pStarsFour.get(),
+            &ControlObject::valueChanged,
+            this,
+            [this](double value) {
+                if (value > 0) {
+                    slotTrackRatingChangeRequest(4);
+                }
+            });
+
+    m_pStarsFive = std::make_unique<ControlPushButton>(ConfigKey(getGroup(), "stars_five"));
+    connect(m_pStarsFive.get(),
+            &ControlObject::valueChanged,
+            this,
+            [this](double value) {
+                if (value > 0) {
+                    slotTrackRatingChangeRequest(5);
+                }
+            });
+
     // Deck cloning
     m_pCloneFromDeck = std::make_unique<ControlObject>(
             ConfigKey(getGroup(), "CloneFromDeck"),

--- a/src/mixer/basetrackplayer.h
+++ b/src/mixer/basetrackplayer.h
@@ -226,6 +226,12 @@ class BaseTrackPlayerImpl : public BaseTrackPlayer {
     std::unique_ptr<ControlPushButton> m_pStarsUp;
     std::unique_ptr<ControlPushButton> m_pStarsDown;
 
+    std::unique_ptr<ControlPushButton> m_pStarsOne;
+    std::unique_ptr<ControlPushButton> m_pStarsTwo;
+    std::unique_ptr<ControlPushButton> m_pStarsThree;
+    std::unique_ptr<ControlPushButton> m_pStarsFour;
+    std::unique_ptr<ControlPushButton> m_pStarsFive;
+
     std::unique_ptr<ControlObject> m_pUpdateReplayGainFromPregain;
 
     parented_ptr<ControlProxy> m_pReplayGain;


### PR DESCRIPTION
This patch allows the user to map "assign track ratings 1-5" to a MIDI controller, similar on how "Rating up" and "Rating down" currently works.

<details>
<summary>Scenario and technical implementation</summary>

## Scenario
In my scenario, I'm using [OpenDeck](https://github.com/nekename/OpenDeck) to load the next library track, play it, and then being able to assign track ratings while working on other things.

## Technical implementation

OpenDeck executes [sendmidi](https://github.com/gbevin/SendMIDI), sending MIDI CC to Mixxx' MIDI Through implementation thankfully implemented in #13909

![20251217_211055](https://github.com/user-attachments/assets/6961c960-a4e5-43b7-a8ee-adcb31be4a69)
</details>

This might be useful in conjunction with #15506 


