### PR TITLE
Reloop Mixtour: initial implementation

### DIFF
--- a/res/controllers/Reloop Mixtour.midi.xml
+++ b/res/controllers/Reloop Mixtour.midi.xml
@@ -375,7 +375,7 @@
                 <status>0x90</status>
                 <midino>0x08</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>
@@ -385,7 +385,7 @@
                 <status>0x90</status>
                 <midino>0x47</midino>
                 <options>
-                    <normal/>
+                    <script-binding/>
                 </options>
             </control>
             <control>

--- a/res/controllers/Reloop Mixtour.midi.xml
+++ b/res/controllers/Reloop Mixtour.midi.xml
@@ -1,0 +1,753 @@
+<?xml version='1.0' encoding='utf-8'?>
+<MixxxControllerPreset schemaVersion="1" mixxxVersion="2.0.0+">
+    <info>
+        <name>Reloop Mixtour</name>
+        <author>Rene (mixxx at absorb.it), zfhrp</author>
+        <description>Reloop Mixtour mapping (2-deck with support for 4-deck)</description>
+        <forum>https://mixxx.discourse.group/t/new-mapping-for-reloop-mixtour/33093</forum>
+        <manual>reloop_mixtour</manual>
+    </info>
+  <settings>
+    <option
+      variable="leftControls"
+      type="enum"
+      label="Left Controls will">
+      <value label="be used for Deck 1" default="true">1</value>
+      <value label="be used for Deck 2">2</value>
+      <value label="be used for Deck 3">3</value>
+      <value label="be used for Deck 4">4</value>
+      <value label="follow Deck 1 or 3 selection">0</value>
+      <description>This specifies which Decks the left side of the controller should represent. Usually it will be used for Deck 1, but you can choose to use it for the other Decks as well. Or it can follow the selection of the active Deck (1 or 3) from another controller (if the controller implementation supports deck/mixer highlighting).</description>
+    </option>
+    <option
+      variable="rightControls"
+      type="enum"
+      label="Right Controls will">
+      <value label="be used for Deck 1">1</value>
+      <value label="be used for Deck 2" default="true">2</value>
+      <value label="be used for Deck 3">3</value>
+      <value label="be used for Deck 4">4</value>
+      <value label="follow Deck 2 or 4 selection">0</value>
+      <description>This specifies which Decks the right side of the controller should represent. Usually it will be used for Deck 2, but you can choose to use it for the other Decks as well. Or it can follow the selection of the active Deck (2 or 4) from another controller (if the controller implementation supports deck/mixer highlighting).</description>
+    </option>
+    <option
+      variable="fxButton"
+      type="enum"
+      label="FX Button will activate">
+      <value label="FX 1">1</value>
+      <value label="FX 2">2</value>
+      <value label="FX 3">3</value>
+      <value label="FX 4">4</value>
+      <value label="FX for Deck number" default="true">0</value>
+      <description>This specifies which FX is activated for tehe current Deck when FX button is pressed.</description>
+    </option>
+</settings >
+    <controller id="Reloop Mixtour">
+        <scriptfiles>
+            <file filename="midi-components-0.0.js" />
+            <file filename="Reloop-Mixtour-scripts.js" functionprefix="ReloopMixtour"/>
+        </scriptfiles>
+        <controls>
+            <control>
+                <group>[Master]</group>
+                <key>ReloopMixtour.shiftButton.input</key>
+                <description>Shift pressed</description>
+                <status>0x90</status>
+                <midino>0x06</midino>
+                <options>
+                <script-binding />
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>ReloopMixtour.mixer.left.gain.input</key>
+                <description>[GAIN] ch1 gain</description>
+                <status>0xB0</status>
+                <midino>0x00</midino>
+                <options>
+                    <script-binding />
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>ReloopMixtour.mixer.right.gain.input</key>
+                <description>[GAIN] ch2 gain</description>
+                <status>0xB1</status>
+                <midino>0x00</midino>
+                <options>
+                    <script-binding />
+                </options>
+            </control>
+            <control>
+                <group>[Master]</group>
+                <key>gain</key>
+                <description>[GAIN]main gain</description>
+                <status>0xB4</status>
+                <midino>0x00</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>ReloopMixtour.mixer.left.effect.input</key>
+                <description>[FX]FX</description>
+                <status>0x90</status>
+                <midino>0x01</midino>
+                <options>
+                    <script-binding />
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>ReloopMixtour.mixer.right.effect.input</key>
+                <description>[FX]FX</description>
+                <status>0x91</status>
+                <midino>0x01</midino>
+                <options>
+                    <script-binding />
+                </options>
+            </control>
+            <control>
+                <group>[EqualizerRack1_[Channel1]_Effect1]</group>
+                <key>ReloopMixtour.mixer.left.highEq.input</key>
+                <description>[HIGH_EQ]high_eq</description>
+                <status>0xB0</status>
+                <midino>0x01</midino>
+                <options>
+                    <script-binding />
+                </options>
+            </control>
+            <control>
+                <group>[EqualizerRack1_[Channel2]_Effect1]</group>
+                <key>ReloopMixtour.mixer.right.highEq.input</key>
+                <description>[HIGH_EQ]high_eq</description>
+                <status>0xB1</status>
+                <midino>0x01</midino>
+                <options>
+                    <script-binding />
+                </options>
+            </control>
+            <control>
+                <group>[Master]</group>
+                <key>headGain</key>
+                <description>[HEADPHONE GAIN]headphone gain</description>
+                <status>0xB4</status>
+                <midino>0x01</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>ReloopMixtour.decks.left.load.input</key>
+                <description>[LOAD]load selected track</description>
+                <status>0x90</status>
+                <midino>0x02</midino>
+                <options>
+                    <script-binding />
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>ReloopMixtour.decks.left.load.input</key>
+                <description>Shift [LOAD]</description>
+                <status>0x90</status>
+                <midino>0x42</midino>
+                <options>
+                    <script-binding />
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>ReloopMixtour.decks.right.load.input</key>
+                <description>[LOAD]load selected track</description>
+                <status>0x91</status>
+                <midino>0x02</midino>
+                <options>
+                    <script-binding />
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>ReloopMixtour.decks.right.load.input</key>
+                <description>Shift [LOAD]</description>
+                <status>0x91</status>
+                <midino>0x42</midino>
+                <options>
+                    <script-binding />
+                </options>
+            </control>
+            <control>
+                <group>[EqualizerRack1_[Channel1]_Effect1]</group>
+                <key>ReloopMixtour.mixer.left.midEq.input</key>
+                <description>[MID_EQ]mid_eq</description>
+                <status>0xB0</status>
+                <midino>0x02</midino>
+                <options>
+                    <script-binding />
+                </options>
+            </control>
+            <control>
+                <group>[EqualizerRack1_[Channel2]_Effect1]</group>
+                <key>ReloopMixtour.mixer.right.midEq.input</key>
+                <description>[MID_EQ]mid_eq</description>
+                <status>0xB1</status>
+                <midino>0x02</midino>
+                <options>
+                    <script-binding />
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>ReloopMixtour.decks.left.pfl.input</key>
+                <description>[Headphone]Headphone Listen</description>
+                <status>0x90</status>
+                <midino>0x03</midino>
+                <options>
+                    <script-binding />
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>ReloopMixtour.decks.right.pfl.input</key>
+                <description>[Headphone]Headphone Listen</description>
+                <status>0x91</status>
+                <midino>0x03</midino>
+                <options>
+                    <script-binding />
+                </options>
+            </control><control>
+                <group>[Channel1]</group>
+                <key>ReloopMixtour.decks.left.pfl.input</key>
+                <description>[Headphone]Preview</description>
+                <status>0x90</status>
+                <midino>0x43</midino>
+                <options>
+                    <script-binding />
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>ReloopMixtour.decks.right.pfl.input</key>
+                <description>[Headphone]Preview</description>
+                <status>0x91</status>
+                <midino>0x43</midino>
+                <options>
+                    <script-binding />
+                </options>
+            </control>
+            <control>
+                <group>[EqualizerRack1_[Channel1]_Effect1]</group>
+                <key>ReloopMixtour.mixer.left.lowEq.input</key>
+                <description>[MID_EQ]low_eq</description>
+                <status>0xB0</status>
+                <midino>0x03</midino>
+                <options>
+                    <script-binding />
+                </options>
+            </control>
+            <control>
+                <group>[EqualizerRack1_[Channel2]_Effect1]</group>
+                <key>ReloopMixtour.mixer.right.lowEq.input</key>
+                <description>[MID_EQ]low_eq</description>
+                <status>0xB1</status>
+                <midino>0x03</midino>
+                <options>
+                    <script-binding />
+                </options>
+            </control>
+            <control>
+                <group>[QuickEffectRack1_[Channel1]]</group>
+                <key>ReloopMixtour.mixer.left.fxKnob.input</key>
+                <description>[FX Knob]FX Knob</description>
+                <status>0xB0</status>
+                <midino>0x04</midino>
+                <options>
+                    <script-binding />
+                    <soft-takeover/>
+                </options>
+            </control>
+            <control>
+                <group>[QuickEffectRack1_[Channel2]]</group>
+                <key>ReloopMixtour.mixer.right.fxKnob.input</key>
+                <description>[FX Knob]FX Knob</description>
+                <status>0xB1</status>
+                <midino>0x04</midino>
+                <options>
+                    <script-binding />
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>ReloopMixtour.mixer.left.volumeFader.input</key>
+                <description>[VOLUME_FADER]Volume Fader</description>
+                <status>0xB0</status>
+                <midino>0x05</midino>
+                <options>
+                    <script-binding />
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>ReloopMixtour.mixer.right.volumeFader.input</key>
+                <description>[VOLUME_FADER]Volume Fader</description>
+                <status>0xB1</status>
+                <midino>0x05</midino>
+                <options>
+                    <script-binding />
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>ReloopMixtour.mixer.left.faderStart.input</key>
+                <description>[VOLUME_FADER] 0 -- 1 </description>
+                <status>0x90</status>
+                <midino>0x14</midino>
+                <options>
+                    <script-binding />
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>ReloopMixtour.mixer.right.faderStart.input</key>
+                <description>[VOLUME_FADER] 0 -- 1 </description>
+                <status>0x91</status>
+                <midino>0x14</midino>
+                <options>
+                    <script-binding />
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>ReloopMixtour.mixer.left.faderStop.input</key>
+                <description>[VOLUME_FADER] 1 -- 0 </description>
+                <status>0x90</status>
+                <midino>0x13</midino>
+                <options>
+                    <script-binding />
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>ReloopMixtour.mixer.right.faderStop.input</key>
+                <description>[VOLUME_FADER] 1 -- 0 </description>
+                <status>0x91</status>
+                <midino>0x13</midino>
+                <options>
+                    <script-binding />
+                </options>
+            </control>
+            <control>
+                <group>[Master]</group>
+                <key>headMix</key>
+                <description>[HEADPHONE_MIX]</description>
+                <status>0xB0</status>
+                <midino>0x06</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Library]</group>
+                <key>ReloopMixtour.rotarySelector.inputPress</key>
+                <description>[SEEK_PUSH]</description>
+                <status>0x90</status>
+                <midino>0x07</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Library]</group>
+                <key>ReloopMixtour.rotarySelector.input</key>
+                <description>[SEEK]</description>
+                <status>0xB0</status>
+                <midino>0x07</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Library]</group>
+                <key>ReloopMixtour.backBtn.input</key>
+                <description>[BACK]</description>
+                <status>0x90</status>
+                <midino>0x08</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Library]</group>
+                <key>ReloopMixtour.backBtn.input</key>
+                <description>Shift [BACK]</description>
+                <status>0x90</status>
+                <midino>0x47</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Library]</group>
+                <key>ReloopMixtour.rotarySelector.inputPress</key>
+                <description>Shift [SEEK_PUSH]</description>
+                <status>0x90</status>
+                <midino>0x46</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Library]</group>
+                <key>ReloopMixtour.rotarySelector.input</key>
+                <description>Shift [SEEK]</description>
+                <status>0xB0</status>
+                <midino>0x47</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Library]</group>
+                <key>ReloopMixtour.backBtn.input</key>
+                <description>Shift [BACK]</description>
+                <status>0x90</status>
+                <midino>0x47</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Master]</group>
+                <key>crossfader</key>
+                <description>[CROSSFADER]crossfader</description>
+                <status>0xB0</status>
+                <midino>0x08</midino>
+                <options>
+                    <normal/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>ReloopMixtour.decks.left.loop.input</key>
+                <description>[LOOP]</description>
+                <status>0x90</status>
+                <midino>0x09</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>ReloopMixtour.decks.right.loop.input</key>
+                <description>[LOOP]</description>
+                <status>0x91</status>
+                <midino>0x09</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>ReloopMixtour.decks.left.loop.input</key>
+                <description>[LOOP]</description>
+                <status>0x90</status>
+                <midino>0x48</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>ReloopMixtour.decks.right.loop.input</key>
+                <description>[LOOP]</description>
+                <status>0x91</status>
+                <midino>0x48</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>ReloopMixtour.decks.left.cue.input</key>
+                <description>[CUE]cue</description>
+                <status>0x90</status>
+                <midino>0x0B</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>ReloopMixtour.decks.right.cue.input</key>
+                <description>[CUE]cue</description>
+                <status>0x91</status>
+                <midino>0x0B</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>ReloopMixtour.decks.left.cue.input</key>
+                <description>[CUE]cue</description>
+                <status>0x90</status>
+                <midino>0x4A</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>ReloopMixtour.decks.right.cue.input</key>
+                <description>[CUE]cue</description>
+                <status>0x91</status>
+                <midino>0x4A</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>ReloopMixtour.decks.left.play.input</key>
+                <description>[PLAY]play</description>
+                <status>0x90</status>
+                <midino>0x0C</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>ReloopMixtour.decks.right.play.input</key>
+                <description>[PLAY]play</description>
+                <status>0x91</status>
+                <midino>0x0C</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>ReloopMixtour.decks.left.play.input</key>
+                <description>[PLAY]play</description>
+                <status>0x90</status>
+                <midino>0x4B</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>ReloopMixtour.decks.right.play.input</key>
+                <description>[PLAY]play</description>
+                <status>0x91</status>
+                <midino>0x4B</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>ReloopMixtour.decks.left.hotcue1.input</key>
+                <description>[C1] hotcue 1</description>
+                <status>0x90</status>
+                <midino>0x0D</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>ReloopMixtour.decks.right.hotcue1.input</key>
+                <description>[C1] hotcue 1</description>
+                <status>0x91</status>
+                <midino>0x0D</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>ReloopMixtour.decks.left.hotcue2.input</key>
+                <description>[C2] hotcue 2</description>
+                <status>0x90</status>
+                <midino>0x0E</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>ReloopMixtour.decks.right.hotcueBtn.input</key>
+                <description>[C2] hotcue 2</description>
+                <status>0x91</status>
+                <midino>0x0E</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>ReloopMixtour.decks.left.hotcue3.input</key>
+                <description>[C3] hotcue 3</description>
+                <status>0x90</status>
+                <midino>0x0F</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>ReloopMixtour.decks.right.hotcue3.input</key>
+                <description>[C3] hotcue 3</description>
+                <status>0x91</status>
+                <midino>0x0F</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>ReloopMixtour.decks.left.hotcue4.input</key>
+                <description>[C4] hotcue 4</description>
+                <status>0x90</status>
+                <midino>0x10</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>ReloopMixtour.decks.right.hotcue4.input</key>
+                <description>[C4] hotcue 4</description>
+                <status>0x91</status>
+                <midino>0x10</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>ReloopMixtour.decks.left.beatSync.input</key>
+                <description>SYNC button</description>
+                <status>0x90</status>
+                <midino>0x0A</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>ReloopMixtour.decks.left.beatSync.input</key>
+                <description>[Shift+SYNC]</description>
+                <status>0x90</status>
+                <midino>0x49</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>ReloopMixtour.decks.right.beatSync.input</key>
+                <description>SYNC button</description>
+                <status>0x91</status>
+                <midino>0x0A</midino>
+                <options>
+                    <script-binding/>
+                </options>
+             </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>ReloopMixtour.decks.right.beatSync.input</key>
+                <description>[Shift+SYNC]</description>
+                <status>0x91</status>
+                <midino>0x49</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>ReloopMixtour.decks.left.hotcue1.input</key>
+                <description>[Shift+C1]</description>
+                <status>0x90</status>
+                <midino>0x4C</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>ReloopMixtour.decks.right.hotcue1.input</key>
+                <description>[Shift+C1]</description>
+                <status>0x91</status>
+                <midino>0x4C</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>ReloopMixtour.decks.left.hotcue2.input</key>
+                <description>[Shift+C2]</description>
+                <status>0x90</status>
+                <midino>0x4D</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>ReloopMixtour.decks.right.hotcue2.input</key>
+                <description>[Shift+C2]</description>
+                <status>0x91</status>
+                <midino>0x4D</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>ReloopMixtour.decks.left.hotcue3.input</key>
+                <description>[Shift+C3]</description>
+                <status>0x90</status>
+                <midino>0x4E</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>ReloopMixtour.decks.right.hotcue3.input</key>
+                <description>[Shift+C3]</description>
+                <status>0x91</status>
+                <midino>0x4E</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>ReloopMixtour.decks.left.hotcue4.input</key>
+                <description>[Shift+C4]</description>
+                <status>0x90</status>
+                <midino>0x4F</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>ReloopMixtour.decks.right.hotcue4.input</key>
+                <description>[Shift+C4]</description>
+                <status>0x91</status>
+                <midino>0x4F</midino>
+                <options>
+                    <script-binding/>
+                </options>
+            </control>
+        </controls>
+    </controller>
+</MixxxControllerPreset>

--- a/res/controllers/Reloop Mixtour.midi.xml
+++ b/res/controllers/Reloop Mixtour.midi.xml
@@ -580,7 +580,7 @@
             </control>
             <control>
                 <group>[Channel2]</group>
-                <key>ReloopMixtour.decks.right.hotcueBtn.input</key>
+                <key>ReloopMixtour.decks.right.hotcue2.input</key>
                 <description>[C2] hotcue 2</description>
                 <status>0x91</status>
                 <midino>0x0E</midino>

--- a/res/controllers/Reloop Mixtour.midi.xml
+++ b/res/controllers/Reloop Mixtour.midi.xml
@@ -30,17 +30,6 @@
       <value label="follow Deck 2 or 4 selection">0</value>
       <description>This specifies which Decks the right side of the controller should represent. Usually it will be used for Deck 2, but you can choose to use it for the other Decks as well. Or it can follow the selection of the active Deck (2 or 4) from another controller (if the controller implementation supports deck/mixer highlighting).</description>
     </option>
-    <option
-      variable="fxButton"
-      type="enum"
-      label="FX Button will activate">
-      <value label="FX 1">1</value>
-      <value label="FX 2">2</value>
-      <value label="FX 3">3</value>
-      <value label="FX 4">4</value>
-      <value label="FX for Deck number" default="true">0</value>
-      <description>This specifies which FX is activated for tehe current Deck when FX button is pressed.</description>
-    </option>
 </settings >
     <controller id="Reloop Mixtour">
         <scriptfiles>
@@ -91,8 +80,28 @@
             <control>
                 <group>[Channel1]</group>
                 <key>ReloopMixtour.mixer.left.effect.input</key>
-                <description>[FX]FX</description>
+                <description>[FX]ch1 FX</description>
                 <status>0x90</status>
+                <midino>0x01</midino>
+                <options>
+                    <script-binding />
+                </options>
+            </control>
+            <control>
+                <group>[Channel1]</group>
+                <key>ReloopMixtour.mixer.left.effect.input</key>
+                <description>Shift [FX]</description>
+                <status>0x90</status>
+                <midino>0x41</midino>
+                <options>
+                    <script-binding />
+                </options>
+            </control>
+            <control>
+                <group>[Channel2]</group>
+                <key>ReloopMixtour.mixer.right.effect.input</key>
+                <description>[FX]ch2 FX</description>
+                <status>0x91</status>
                 <midino>0x01</midino>
                 <options>
                     <script-binding />
@@ -101,9 +110,9 @@
             <control>
                 <group>[Channel2]</group>
                 <key>ReloopMixtour.mixer.right.effect.input</key>
-                <description>[FX]FX</description>
+                <description>Shift [FX]</description>
                 <status>0x91</status>
-                <midino>0x01</midino>
+                <midino>0x41</midino>
                 <options>
                     <script-binding />
                 </options>

--- a/res/controllers/Reloop Mixtour.midi.xml
+++ b/res/controllers/Reloop Mixtour.midi.xml
@@ -2,7 +2,7 @@
 <MixxxControllerPreset schemaVersion="1" mixxxVersion="2.0.0+">
     <info>
         <name>Reloop Mixtour</name>
-        <author>Rene (mixxx at absorb.it), zfhrp</author>
+        <author>Rene (mixxx at absorb.it), András (andras08 at gmail.com), zfhrp</author>
         <description>Reloop Mixtour mapping (2-deck with support for 4-deck)</description>
         <forum>https://mixxx.discourse.group/t/new-mapping-for-reloop-mixtour/33093</forum>
         <manual>reloop_mixtour</manual>

--- a/res/controllers/Reloop-Mixtour-scripts.js
+++ b/res/controllers/Reloop-Mixtour-scripts.js
@@ -1,0 +1,314 @@
+/*
+Reloop Mixtour controller script
+*/
+
+// most buttons use the following shift settings, its easier to correct them for the few others
+components.Component.prototype.shiftOffset = 0x3F;
+components.Component.prototype.shiftControl = true;
+components.Component.prototype.sendShifted = true;
+// the color for most buttons is green, just change for hotcue buttons directly
+components.Button.prototype.on = 0x01;
+// override Component prototype to prevent double connections
+// original connect function will override connections[0] and
+// this way looses control of existing connection
+components.Component.prototype.connect = function() {
+    if (this.connections[0] === undefined &&      // <-- added this condition
+        undefined !== this.group &&
+        undefined !== this.outKey &&
+        undefined !== this.output &&
+        typeof this.output === "function") {
+        this.connections[0] = engine.makeConnection(this.group, this.outKey, this.output.bind(this));
+    }
+};
+// override Component prototype to reset connection after disconnect
+// original disconnect will never reset connections[0] to undefined
+components.Component.prototype.disconnect = function() {
+    if (this.connections[0] !== undefined) {
+        this.connections.forEach(function(conn) {
+            conn.disconnect();
+        });
+    }
+    this.connections[0] = undefined;              // <-- added this
+};
+
+// eslint-disable-next-line no-var
+var ReloopMixtour = {};
+
+ReloopMixtour.init = function() {
+    // initialize Mixxx with current values on control surface
+    const ControllerStatusSysex = [0xF0, 0x26, 0x2D, 0x65, 0x22, 0xF7];
+    midi.sendSysexMsg(ControllerStatusSysex, ControllerStatusSysex.length);
+
+    this.syncGroupSelection = function(elem, type, group) {
+        if (engine.getValue("[Skin]", `highlight_${type}_${group}`) && elem.currentDeck !== group) {
+            elem.setCurrentDeck(group);
+        }
+    };
+
+    this.reSelectDecks = function() {
+        this.syncGroupSelection(this.decks.right, "deck", "[Channel4]");
+        this.syncGroupSelection(this.decks.left, "deck", "[Channel3]");
+        this.syncGroupSelection(this.decks.right, "deck", "[Channel2]");
+        this.syncGroupSelection(this.decks.left, "deck", "[Channel1]");
+    };
+
+    this.reSelectMixer = function() {
+        this.syncGroupSelection(this.mixer.right, "mixer", "[Channel4]");
+        this.syncGroupSelection(this.mixer.left, "mixer", "[Channel3]");
+        this.syncGroupSelection(this.mixer.right, "mixer", "[Channel2]");
+        this.syncGroupSelection(this.mixer.left, "mixer", "[Channel1]");
+    };
+
+    this.connectFourDeckControl = function() {
+        for (let i = 1; i <= 4; i++) {
+            engine.makeConnection("[Skin]", `highlight_deck_[Channel${i}]`, function(_value, _group, _control) {
+                ReloopMixtour.reSelectDecks();
+            });
+            engine.makeConnection("[Skin]", `highlight_mixer_[Channel${i}]`, function(_value, _group, _control) {
+                ReloopMixtour.reSelectMixer();
+            });
+        }
+    };
+
+    const leftDeckConfig = parseInt(engine.getSetting("leftControls"));
+    const rightDeckConfig = parseInt(engine.getSetting("rightControls"));
+    this.decks = new components.ComponentContainer({
+        left: new ReloopMixtour.Deck(leftDeckConfig || [1, 3], 0),
+        right: new ReloopMixtour.Deck(rightDeckConfig || [2, 4], 1),
+    });
+    this.mixer = new components.ComponentContainer({
+        left: new ReloopMixtour.Mixer(leftDeckConfig || [1, 3], 0),
+        right: new ReloopMixtour.Mixer(rightDeckConfig || [2, 4], 1),
+    });
+    if (!leftDeckConfig || !rightDeckConfig) {
+        this.connectFourDeckControl();
+    }
+
+    this.shutdown = function() {
+        ReloopMixtour.decks.shutdown();
+        ReloopMixtour.mixer.shutdown();
+    };
+
+    // there is one shift button, map it to the decks
+    this.shiftButton = new components.Button({
+        input: function(_channel, _control, value, _status, _g) {
+            if (value) {
+                ReloopMixtour.decks.shift();
+                ReloopMixtour.mixer.shift();
+            } else {
+                ReloopMixtour.decks.unshift();
+                ReloopMixtour.mixer.unshift();
+            }
+        },
+    });
+
+    this.backBtn = new components.Button({
+        input: function(_channel, _control, _value, _status, _g) {
+            console.warn("back button has no function yet");
+        },
+    });
+
+    // the rotarySelector only works if mixxx windows is focused, don't be surprised :)
+    this.rotarySelector = new components.Pot({
+        input: function(_channel, control, value, _status, _group) {
+            if (value === 0x01) {
+                engine.setValue("[Library]", (control < 0x40)?"MoveDown":"MoveRight", true);
+            } else {
+                engine.setValue("[Library]", (control < 0x40)?"MoveUp":"MoveLeft", true);
+            }
+        },
+        inputPress: function(_channel, _control, value, _status, _group) {
+            if (value) {
+                engine.setValue("[Library]", "MoveFocusForward", true);
+            }
+        },
+    });
+};
+
+ReloopMixtour.Deck = class extends components.Deck {
+    constructor(deckNumbers, midiChannel) {
+        super(deckNumbers);
+
+        const theDeck = this;
+
+        this.load = new components.Button({
+            midi: [0x90 + midiChannel, 0x02],
+            key: "LoadSelectedTrack",
+            shiftKey: midiChannel?"MoveRight":"MoveLeft",
+            shiftOffset: 0x40,
+            unshift: function() {
+                this.inKey = "LoadSelectedTrack";
+                this.group = theDeck.currentDeck;
+            },
+            shift: function() {
+                this.inKey = this.shiftKey;
+                this.group = "[Library]";
+            },
+        });
+
+        this.pfl = new components.Button({
+            midi: [0x90 + midiChannel, 0x03],
+            key: "pfl",
+            shiftOffset: 0x40,
+            type: components.Button.prototype.types.toggle,
+            unshift: function() {
+                this.inKey = "pfl";
+                this.group = theDeck.currentDeck;
+            },
+            shift: function() {
+                this.inKey = "LoadSelectedTrackAndPlay";
+                this.group = "[PreviewDeck1]";
+            },
+        });
+
+        this.loop = new components.Button({
+            midi: [0x90 + midiChannel, 0x09],
+            inKey: "beatloop_activate",
+            outKey: "loop_enabled",
+            unshift: function() {
+                this.inKey = "beatloop_activate";
+            },
+            shift: function() {
+                this.inKey = "loop_halve";
+            },
+        });
+
+        this.beatSync = new components.Button({
+            midi: [0x90 + midiChannel, 0x0A],
+            type: components.Button.prototype.types.toggle,
+            key: "sync_enabled",
+            unshift: function() {
+                this.inKey = "sync_enabled";
+            },
+            shift: function() {
+                this.inKey = "loop_double";
+            },
+        });
+
+        this.play = new components.PlayButton({
+            midi: [0x90 + midiChannel, 0x0C],
+        });
+
+        this.cue = new components.CueButton({
+            midi: [0x90 + midiChannel, 0x0B],
+        });
+
+        for (let i = 1; i <= 4; i++) {
+            this[`hotcue${i}`] = new components.HotcueButton({
+                midi: [0x90 + midiChannel, 0x0C + i],
+                number: i,
+                on: 0x2B,
+            });
+        };
+
+        this.forEachComponent(function(component) {
+            if (component.group === undefined) {
+                component.group = this.currentDeck;
+            };
+        });
+    }
+};
+
+ReloopMixtour.Mixer = class extends components.Deck {
+    constructor(deckNumbers, midiChannel) {
+        super(deckNumbers);
+
+        const theMixer = this;
+
+        this.gain = new components.Pot({
+            key: "pregain",
+        });
+
+        this.fxKnob = new components.Pot({
+            key: "super1",
+            group: `[QuickEffectRack1_[Channel${midiChannel + 1}]]`,
+        });
+
+        this.fxButton = parseInt(engine.getSetting("fxButton"));
+        this.effect = new components.Button({
+            midi: [0x90 + midiChannel, 0x01],
+            key: `group_[Channel${midiChannel + 1}]_enable`,
+            shiftOffset: 0x40,
+            group: this.fxButton?`[EffectRack1_EffectUnit${this.fxButton}]`:`[EffectRack1_EffectUnit${midiChannel + 1}]`,
+            type: components.Button.prototype.types.toggle,
+            input: function(channel, control, value, status, group) {
+                if (value) {
+                    theMixer.fxKnob.group = this.inGetValue()?`[QuickEffectRack1_${theMixer.currentDeck}]`:this.group;
+                }
+                components.Button.prototype.input.call(this, channel, control, value, status, group);
+            },
+            output: function(value, _group, _control) {
+                theMixer.fxKnob.group = value?this.group:`[QuickEffectRack1_${theMixer.currentDeck}]`;
+                this.send(this.outValueScale(value));
+            },
+            reconnect: function(newGroup) {
+                this.disconnect();
+                this.group = theMixer.fxButton?`[EffectRack1_EffectUnit${theMixer.fxButton}]`:`[EffectRack1_EffectUnit${script.deckFromGroup(newGroup)}]`;
+                this.inKey = `group_${newGroup}_enable`;
+                this.outKey = `group_${newGroup}_enable`;
+                this.connect();
+                this.trigger();
+            },
+        });
+
+        this.highEq = new components.Pot({
+            key: "parameter3",
+            group: `[EqualizerRack1_[Channel${midiChannel + 1}]_Effect1]`,
+        });
+
+        this.midEq = new components.Pot({
+            key: "parameter2",
+            group: `[EqualizerRack1_[Channel${midiChannel + 1}]_Effect1]`,
+        });
+
+        this.lowEq = new components.Pot({
+            key: "parameter1",
+            group: `[EqualizerRack1_[Channel${midiChannel + 1}]_Effect1]`,
+        });
+
+        this.volumeFader = new components.Pot({
+            inKey: "volume",
+        });
+
+        this.faderStart = new components.Button({
+            key: "cue_gotoandplay",
+        });
+
+        this.faderStop = new components.Button({
+            key: "cue_gotoandstop",
+        });
+
+        this.pflMeter = new components.Component({
+            midi: [0x90 + midiChannel, 0x11],
+            key: "vu_meter",
+            max: 0x68
+        });
+
+        this.masterMeter = new components.Component({
+            midi: [0x90 + midiChannel, 0x12],
+            key: (this.currentDeck === "[Channel1]")?"vu_meter_left":"vu_meter_right",
+            group: "[Main]",
+            max: 0x68
+        });
+
+        this.fxIndicator = new components.Component({
+            midi: [0x90 + midiChannel, 0x00],
+            key: "super1",
+            group: `[QuickEffectRack1_[Channel${midiChannel + 1}]]`,
+            outValueScale(value) {
+                return (Math.abs(0.5 - value) > 0.01)?0x7F:0x00;
+            }
+        });
+
+        this.forEachComponent(function(component) {
+            if (component.group === undefined) {
+                component.group = this.currentDeck;
+            };
+        });
+    }
+
+    setCurrentDeck(newGroup) {
+        this.effect.reconnect(newGroup);
+        super.setCurrentDeck(newGroup);
+    }
+};

--- a/res/controllers/Reloop-Mixtour-scripts.js
+++ b/res/controllers/Reloop-Mixtour-scripts.js
@@ -223,7 +223,7 @@ ReloopMixtour.Mixer = class extends components.Deck {
 
         this.fxKnob = new components.Pot({
             key: "super1",
-            group: `[QuickEffectRack1_[Channel${midiChannel + 1}]]`,
+            group: `[QuickEffectRack1_${theMixer.currentDeck}]`,
         });
 
         this.fxButton = parseInt(engine.getSetting("fxButton"));
@@ -255,17 +255,17 @@ ReloopMixtour.Mixer = class extends components.Deck {
 
         this.highEq = new components.Pot({
             key: "parameter3",
-            group: `[EqualizerRack1_[Channel${midiChannel + 1}]_Effect1]`,
+            group: `[EqualizerRack1_${theMixer.currentDeck}_Effect1]`,
         });
 
         this.midEq = new components.Pot({
             key: "parameter2",
-            group: `[EqualizerRack1_[Channel${midiChannel + 1}]_Effect1]`,
+            group: `[EqualizerRack1_${theMixer.currentDeck}_Effect1]`,
         });
 
         this.lowEq = new components.Pot({
             key: "parameter1",
-            group: `[EqualizerRack1_[Channel${midiChannel + 1}]_Effect1]`,
+            group: `[EqualizerRack1_${theMixer.currentDeck}_Effect1]`,
         });
 
         this.volumeFader = new components.Pot({
@@ -296,7 +296,7 @@ ReloopMixtour.Mixer = class extends components.Deck {
         this.fxIndicator = new components.Component({
             midi: [0x90 + midiChannel, 0x00],
             key: "super1",
-            group: `[QuickEffectRack1_[Channel${midiChannel + 1}]]`,
+            group: `[QuickEffectRack1_${theMixer.currentDeck}]`,
             outValueScale(value) {
                 return (Math.abs(0.5 - value) > 0.01)?0x7F:0x00;
             }

--- a/res/controllers/Reloop-Mixtour-scripts.js
+++ b/res/controllers/Reloop-Mixtour-scripts.js
@@ -103,9 +103,10 @@ ReloopMixtour.init = function() {
     });
 
     this.backBtn = new components.Button({
-        input: function(_channel, _control, _value, _status, _g) {
-            console.warn("back button has no function yet");
-        },
+        midi: [0x90, 0x08],
+        group: "[Skin]",
+        key: "show_maximized_library",
+        type: components.Button.prototype.types.toggle,
     });
 
     // the rotarySelector only works if mixxx windows is focused, don't be surprised :)

--- a/res/controllers/Reloop-Mixtour-scripts.js
+++ b/res/controllers/Reloop-Mixtour-scripts.js
@@ -28,7 +28,7 @@ components.Component.prototype.disconnect = function() {
             conn.disconnect();
         });
     }
-    this.connections[0] = undefined;              // <-- added this
+    this.connections = [];              // <-- added this
 };
 
 // eslint-disable-next-line no-var

--- a/res/controllers/Reloop-Mixtour-scripts.js
+++ b/res/controllers/Reloop-Mixtour-scripts.js
@@ -110,18 +110,19 @@ ReloopMixtour.init = function() {
     });
 
     // the rotarySelector only works if mixxx windows is focused, don't be surprised :)
-    this.rotarySelector = new components.Pot({
-        input: function(_channel, control, value, _status, _group) {
+    this.rotarySelector = new components.Button({
+        group: "[Library]",
+        input: function(channel, control, value, status, group) {
             if (value === 0x01) {
-                engine.setValue("[Library]", (control < 0x40)?"MoveDown":"MoveRight", true);
+                this.inKey = (control < 0x40)?"MoveDown":"MoveRight";
             } else {
-                engine.setValue("[Library]", (control < 0x40)?"MoveUp":"MoveLeft", true);
+                this.inKey = (control < 0x40)?"MoveUp":"MoveLeft";
             }
+            components.Button.prototype.input.call(this, channel, control, 0x7F, status, group);
         },
-        inputPress: function(_channel, _control, value, _status, _group) {
-            if (value) {
-                engine.setValue("[Library]", "MoveFocusForward", true);
-            }
+        inputPress: function(channel, control, value, status, group) {
+            this.inKey = "MoveFocusForward";
+            components.Button.prototype.input.call(this, channel, control, value, status, group);
         },
     });
 };

--- a/res/controllers/Reloop-Mixtour-scripts.js
+++ b/res/controllers/Reloop-Mixtour-scripts.js
@@ -231,7 +231,7 @@ ReloopMixtour.Mixer = class extends components.Deck {
             midi: [0x90 + midiChannel, 0x01],
             key: `group_[Channel${midiChannel + 1}]_enable`,
             shiftOffset: 0x40,
-            group: this.fxButton?`[EffectRack1_EffectUnit${this.fxButton}]`:`[EffectRack1_EffectUnit${midiChannel + 1}]`,
+            group: this.fxButton?`[EffectRack1_EffectUnit${this.fxButton}]`:`[EffectRack1_EffectUnit${script.deckFromGroup(theMixer.currentDeck)}]`,
             type: components.Button.prototype.types.toggle,
             input: function(channel, control, value, status, group) {
                 if (value) {

--- a/res/controllers/Reloop-Mixtour-scripts.js
+++ b/res/controllers/Reloop-Mixtour-scripts.js
@@ -226,30 +226,58 @@ ReloopMixtour.Mixer = class extends components.Deck {
             group: `[QuickEffectRack1_${theMixer.currentDeck}]`,
         });
 
-        this.fxButton = parseInt(engine.getSetting("fxButton"));
+        // loaded_chain_preset - values are a following:
+        // 0 is the empty/passthrough preset
+        // -1 indicates an unsaved preset (no idea if this index can be selected)
+        // 1 should be the default (Filter) preset. This can be configured by the user in the pref dialog
         this.effect = new components.Button({
             midi: [0x90 + midiChannel, 0x01],
-            key: `group_[Channel${midiChannel + 1}]_enable`,
             shiftOffset: 0x40,
-            group: this.fxButton?`[EffectRack1_EffectUnit${this.fxButton}]`:`[EffectRack1_EffectUnit${script.deckFromGroup(theMixer.currentDeck)}]`,
-            type: components.Button.prototype.types.toggle,
-            input: function(channel, control, value, status, group) {
-                if (value) {
-                    theMixer.fxKnob.group = this.inGetValue()?`[QuickEffectRack1_${theMixer.currentDeck}]`:this.group;
+            key: "loaded_chain_preset",
+            secondOutKey: "enabled",
+            group: `[QuickEffectRack1_${theMixer.currentDeck}]`,
+            // set preset to first real fx. if available at all this is number 2
+            fxPreset: (engine.getValue(this.group, "num_chain_presets") > 2)?2:0,
+            nextPreset: function() {
+                const nChainPresets = engine.getValue(this.group, "num_chain_presets");
+                this.fxPreset = (this.fxPreset + 1) % nChainPresets;
+                if (nChainPresets > 2 && this.fxPreset < 2) {
+                    this.fxPreset = 2; // set preset to first real fx.
                 }
-                components.Button.prototype.input.call(this, channel, control, value, status, group);
             },
-            output: function(value, _group, _control) {
-                theMixer.fxKnob.group = value?this.group:`[QuickEffectRack1_${theMixer.currentDeck}]`;
-                this.send(this.outValueScale(value));
+            input: function(_channel, control, value, _status, _group) {
+                // only act on button-press and if fx are available
+                if (value && engine.getValue(this.group, "num_chain_presets") > 2) {
+                    if (control < this.shiftOffset) {
+                        if (this.inGetValue() !== 1) {                  // current FX is not the 'Filter'
+                            this.fxPreset = this.inGetValue() || 2;    // store current FX (but not 0)
+                            this.inSetValue(1);                         // activate the 'Filter'
+                        } else {
+                            this.inSetValue(this.fxPreset);            // activate last stored FX
+                        }
+                    } else {
+                        this.nextPreset();                              // select and store next FX
+                        if (this.inGetValue() !== 1) {                  // if FX is active
+                            this.inSetValue(this.fxPreset);            // activate (new) FX
+                        }
+                    }
+                }
             },
-            reconnect: function(newGroup) {
-                this.disconnect();
-                this.group = theMixer.fxButton?`[EffectRack1_EffectUnit${theMixer.fxButton}]`:`[EffectRack1_EffectUnit${script.deckFromGroup(newGroup)}]`;
-                this.inKey = `group_${newGroup}_enable`;
-                this.outKey = `group_${newGroup}_enable`;
-                this.connect();
-                this.trigger();
+            outValueScale: function(_value) {
+                // activate FX led if any FX is selected (>2) and enabled
+                return (this.outGetValue() >= 2 && engine.getValue(this.group, this.secondOutKey)) ? this.on : this.off;
+            },
+            connect: function() {
+                // use two connections for the LED, one to check for any real FX (id > 2) and the other to check
+                // if effect is enabled
+                if (this.connections[0] === undefined &&
+                undefined !== this.group &&
+                undefined !== this.outKey &&
+                undefined !== this.output &&
+                typeof this.output === "function") {
+                    this.connections[0] = engine.makeConnection(this.group, this.outKey, this.output.bind(this));
+                    this.connections[1] = engine.makeConnection(this.group, this.secondOutKey, this.output.bind(this));
+                }
             },
         });
 
@@ -296,10 +324,23 @@ ReloopMixtour.Mixer = class extends components.Deck {
         this.fxIndicator = new components.Component({
             midi: [0x90 + midiChannel, 0x00],
             key: "super1",
+            secondOutKey: "enabled",
             group: `[QuickEffectRack1_${theMixer.currentDeck}]`,
             outValueScale(value) {
-                return (Math.abs(0.5 - value) > 0.01)?0x7F:0x00;
-            }
+                return (engine.getValue(this.group, this.secondOutKey) && (Math.abs(0.5 - value) > 0.01))?0x7F:0x00;
+            },
+            connect: function() {
+                // use two connections for the LED, one to check for any real FX (id > 2) and the other to check
+                // if effect is enabled
+                if (this.connections[0] === undefined &&
+                undefined !== this.group &&
+                undefined !== this.outKey &&
+                undefined !== this.output &&
+                typeof this.output === "function") {
+                    this.connections[0] = engine.makeConnection(this.group, this.outKey, this.output.bind(this));
+                    this.connections[1] = engine.makeConnection(this.group, this.secondOutKey, this.output.bind(this));
+                }
+            },
         });
 
         this.forEachComponent(function(component) {


### PR DESCRIPTION
This is a implementation for the midi-controller Reloop Mixtour. It is a two deck controller and you configure the Decks for which to use this controller, if you have two of them you can control 4 decks with it.

Related documentation is at https://github.com/mixxxdj/manual/pull/825