### PR TITLE
Fix BPM validation checks to prevent invalid value access

### DIFF
--- a/src/engine/controls/bpmcontrol.cpp
+++ b/src/engine/controls/bpmcontrol.cpp
@@ -283,7 +283,9 @@ void BpmControl::adjustBeatsBpm(double deltaBpm) {
 
     const mixxx::Bpm bpm = pBeats->getBpmInRange(
             mixxx::audio::kStartFramePos, frameInfo().trackEndPosition);
-    // FIXME: calling bpm.value() without checking bpm.isValid()
+    if (!bpm.isValid()) {
+        return;
+    }
     const auto centerBpm = mixxx::Bpm(math_max(kBpmAdjustMin, bpm.value() + deltaBpm));
     mixxx::Bpm adjustedBpm = BeatUtils::roundBpmWithinRange(
             centerBpm - kBpmAdjustStep / 2, centerBpm, centerBpm + kBpmAdjustStep / 2);

--- a/src/track/beatutils.cpp
+++ b/src/track/beatutils.cpp
@@ -306,6 +306,9 @@ mixxx::Bpm BeatUtils::makeConstBpm(
     //qDebug() << "minRoundBpm" << minRoundBpm;
     //qDebug() << "maxRoundBpm" << maxRoundBpm;
     const mixxx::Bpm roundBpm = roundBpmWithinRange(minRoundBpm, centerBpm, maxRoundBpm);
+    if (!roundBpm.isValid()) {
+        return {};
+    }
 
     if (pFirstBeat) {
         // Move the first beat as close to the start of the track as we can. This is
@@ -336,8 +339,13 @@ std::optional<mixxx::Bpm> BeatUtils::trySnap(mixxx::Bpm minBpm,
 // static
 mixxx::Bpm BeatUtils::roundBpmWithinRange(
         mixxx::Bpm minBpm, mixxx::Bpm centerBpm, mixxx::Bpm maxBpm) {
+    // If any BPM is invalid, return the centerBpm as-is to avoid
+    // unexpected results in the following calculations
+    if (!minBpm.isValid() || !centerBpm.isValid() || !maxBpm.isValid()) {
+        return centerBpm;
+    }
+
     // First try to snap to a full integer BPM
-    // FIXME: calling bpm.value() without checking bpm.isValid()
     std::optional<mixxx::Bpm> snapBpm = trySnap(minBpm, centerBpm, maxBpm, 1.0);
     if (snapBpm) {
         return *snapBpm;
@@ -405,7 +413,10 @@ mixxx::audio::FramePos BeatUtils::adjustPhase(
         mixxx::Bpm bpm,
         mixxx::audio::SampleRate sampleRate,
         const QVector<mixxx::audio::FramePos>& beats) {
-    // FIXME: calling bpm.value() without checking bpm.isValid()
+    if (!bpm.isValid()) {
+        return firstBeat;
+    }
+
     const double beatLength = 60 * sampleRate / bpm.value();
     const mixxx::audio::FramePos startOffset =
             mixxx::audio::FramePos(fmod(firstBeat.value(), beatLength));


### PR DESCRIPTION
Fixes 3 critical issues where `mixxx::Bpm::value()` was accessed without `isValid()` checks, risking debug assertions and undefined behavior.

### Changes
*   **beatutils.cpp**: Added validation in `roundBpmWithinRange` to return early if inputs are invalid.
*   **beatutils.cpp**: Added check in `adjustPhase` to prevent division by zero/invalid BPM.
*   **bpmcontrol.cpp**: Added validation in `adjustBeatsBpm` before value access.

### Verification
*   **Static Check**: Verified all new `value()` calls are guarded by `isValid()`.
*   **Logic**: Confirmed invalid inputs trigger safe fallbacks/returns.
*   **Build**: Compiles successfully; no logic breaking changes.