### PR TITLE
Fix crackling noise when switching quick effects 

### DIFF
--- a/src/effects/backends/effectprocessor.h
+++ b/src/effects/backends/effectprocessor.h
@@ -167,6 +167,7 @@ class EffectProcessorImpl : public EffectProcessor {
                               "main thread.";
             }
             SampleUtil::copy(pOutput, pInput, engineParameters.samplesPerBuffer());
+            return;
         }
         processChannel(pState, pInput, pOutput, engineParameters, enableState, groupFeatures);
     }

--- a/src/effects/backends/effectprocessor.h
+++ b/src/effects/backends/effectprocessor.h
@@ -155,8 +155,13 @@ class EffectProcessorImpl : public EffectProcessor {
             const mixxx::EngineParameters& engineParameters,
             const EffectEnableState enableState,
             const GroupFeatureState& groupFeatures) final {
-        EffectSpecificState* pState =
-                m_channelStateMatrix[inputHandle][outputHandle].get();
+        EffectSpecificState* pState = nullptr;
+        if (inputHandle < m_channelStateMatrix.size()) {
+            const auto& outputChannelStates = m_channelStateMatrix[inputHandle];
+            if (outputHandle < outputChannelStates.size()) {
+                pState = outputChannelStates[outputHandle].get();
+            }
+        }
         VERIFY_OR_DEBUG_ASSERT(pState != nullptr) {
             if (kEffectDebugOutput) {
                 qWarning() << "EffectProcessorImpl::process could not retrieve"

--- a/src/engine/channelhandle.h
+++ b/src/engine/channelhandle.h
@@ -59,6 +59,14 @@ class ChannelHandle {
     friend class ChannelHandleFactory;
 };
 
+inline bool operator<(const ChannelHandle& h1, const int& h2) {
+    return h1.handle() < h2;
+}
+
+inline bool operator<(const ChannelHandle& h1, const std::size_t& h2) {
+    return static_cast<std::size_t>(h1.handle()) < h2;
+}
+
 inline bool operator>(const ChannelHandle& h1, const ChannelHandle& h2) {
     return h1.handle() > h2.handle();
 }

--- a/src/engine/effects/engineeffect.cpp
+++ b/src/engine/effects/engineeffect.cpp
@@ -68,8 +68,8 @@ void EngineEffect::initalizeInputChannel(ChannelHandle inputChannel) {
     m_pProcessor->initializeInputChannel(inputChannel, engineParameters);
 }
 
-bool EngineEffect::processEffectsRequest(EffectsRequest& message,
-                                         EffectsResponsePipe* pResponsePipe) {
+bool EngineEffect::processEffectsRequest(const EffectsRequest& message,
+        EffectsResponsePipe* pResponsePipe) {
     EngineEffectParameterPointer pParameter;
     EffectsResponse response(message);
 

--- a/src/engine/effects/engineeffect.h
+++ b/src/engine/effects/engineeffect.h
@@ -33,7 +33,7 @@ class EngineEffect final : public EffectsRequestHandler {
 
     /// Called in audio thread
     bool processEffectsRequest(
-            EffectsRequest& message,
+            const EffectsRequest& message,
             EffectsResponsePipe* pResponsePipe) override;
 
     /// Called in audio thread

--- a/src/engine/effects/engineeffectchain.cpp
+++ b/src/engine/effects/engineeffectchain.cpp
@@ -112,9 +112,9 @@ bool EngineEffectChain::processEffectsRequest(const EffectsRequest& message,
     case EffectsRequest::SET_EFFECT_CHAIN_PARAMETERS:
         if (kEffectDebugOutput) {
             qDebug() << debugString() << this << "SET_EFFECT_CHAIN_PARAMETERS"
-                     << "enabled" << message.SetEffectChainParameters.enabled
-                     << "mix" << message.SetEffectChainParameters.mix
-                     << "mix_mode" << static_cast<int>(message.SetEffectChainParameters.mix_mode);
+                     << "enabled =" << message.SetEffectChainParameters.enabled
+                     << "mix =" << message.SetEffectChainParameters.mix
+                     << "mix_mode =" << static_cast<int>(message.SetEffectChainParameters.mix_mode);
         }
         response.success = updateParameters(message);
         break;

--- a/src/engine/effects/engineeffectchain.cpp
+++ b/src/engine/effects/engineeffectchain.cpp
@@ -87,7 +87,7 @@ bool EngineEffectChain::updateParameters(const EffectsRequest& message) {
     return true;
 }
 
-bool EngineEffectChain::processEffectsRequest(EffectsRequest& message,
+bool EngineEffectChain::processEffectsRequest(const EffectsRequest& message,
         EffectsResponsePipe* pResponsePipe) {
     EffectsResponse response(message);
     switch (message.type) {
@@ -301,6 +301,9 @@ bool EngineEffectChain::process(const ChannelHandle& inputHandle,
                         numSamples);
             }
         }
+    } else {
+        qDebug() << m_group << "EngineEffectChain::process 3 "
+                 << (int)m_enableState << (int)effectiveChainEnableState;
     }
 
     channelStatus.oldMixKnob = currentMixKnob;
@@ -319,6 +322,8 @@ bool EngineEffectChain::process(const ChannelHandle& inputHandle,
         // Effect is paused now, ramp up next callback which may happen later
         channelStatus.enableState = EffectEnableState::Enabling;
     }
+
+    qDebug() << m_group << "EngineEffectChain::process 2 " << (int)m_enableState;
 
     if (m_enableState == EffectEnableState::Disabling) {
         m_enableState = EffectEnableState::Disabled;

--- a/src/engine/effects/engineeffectchain.h
+++ b/src/engine/effects/engineeffectchain.h
@@ -32,7 +32,7 @@ class EngineEffectChain final : public EffectsRequestHandler {
 
     /// called from audio thread
     bool processEffectsRequest(
-            EffectsRequest& message,
+            const EffectsRequest& message,
             EffectsResponsePipe* pResponsePipe) override;
 
     /// called from audio thread

--- a/src/engine/effects/engineeffectchain.h
+++ b/src/engine/effects/engineeffectchain.h
@@ -66,7 +66,7 @@ class EngineEffectChain final : public EffectsRequestHandler {
     bool disableForInputChannel(ChannelHandle inputHandle);
 
     QString m_group;
-    EffectEnableState m_enableState;
+    bool m_enableState;
     EffectChainMixMode::Type m_mixMode;
     CSAMPLE m_dMix;
     QList<EngineEffect*> m_effects;

--- a/src/engine/effects/engineeffectsmanager.cpp
+++ b/src/engine/effects/engineeffectsmanager.cpp
@@ -255,7 +255,7 @@ bool EngineEffectsManager::removeEffectChain(EngineEffectChain* pChain,
     return chains.removeAll(pChain) > 0;
 }
 
-bool EngineEffectsManager::processEffectsRequest(EffectsRequest& message,
+bool EngineEffectsManager::processEffectsRequest(const EffectsRequest& message,
         EffectsResponsePipe* pResponsePipe) {
     EffectsResponse response(message);
     switch (message.type) {

--- a/src/engine/effects/engineeffectsmanager.h
+++ b/src/engine/effects/engineeffectsmanager.h
@@ -65,7 +65,7 @@ class EngineEffectsManager final : public EffectsRequestHandler {
             bool fadeout = false);
 
     bool processEffectsRequest(
-            EffectsRequest& message,
+            const EffectsRequest& message,
             EffectsResponsePipe* pResponsePipe) override;
 
   private:

--- a/src/engine/effects/message.h
+++ b/src/engine/effects/message.h
@@ -141,7 +141,7 @@ typedef MessagePipe<EffectsResponse, EffectsRequest*> EffectsResponsePipe;
 class EffectsRequestHandler {
   public:
     virtual bool processEffectsRequest(
-            EffectsRequest& message,
+            const EffectsRequest& message,
             EffectsResponsePipe* pResponsePipe) = 0;
     virtual ~EffectsRequestHandler() = default;
 };

--- a/src/engine/enginemixer.cpp
+++ b/src/engine/enginemixer.cpp
@@ -500,8 +500,7 @@ void EngineMixer::process(const int iBufferSize) {
                 m_sampleRate,
                 busFeatures,
                 CSAMPLE_GAIN_ONE,
-                CSAMPLE_GAIN_ONE,
-                false);
+                CSAMPLE_GAIN_ONE);
     }
 
     switch (m_pTalkoverDucking->getMode()) {
@@ -555,8 +554,7 @@ void EngineMixer::process(const int iBufferSize) {
                 m_sampleRate,
                 busFeatures,
                 CSAMPLE_GAIN_ONE,
-                CSAMPLE_GAIN_ONE,
-                false);
+                CSAMPLE_GAIN_ONE);
         m_pEngineEffectsManager->processPostFaderInPlace(
                 m_busCrossfaderCenterHandle.handle(),
                 m_mainHandle.handle(),
@@ -565,8 +563,7 @@ void EngineMixer::process(const int iBufferSize) {
                 m_sampleRate,
                 busFeatures,
                 CSAMPLE_GAIN_ONE,
-                CSAMPLE_GAIN_ONE,
-                false);
+                CSAMPLE_GAIN_ONE);
         m_pEngineEffectsManager->processPostFaderInPlace(
                 m_busCrossfaderRightHandle.handle(),
                 m_mainHandle.handle(),
@@ -575,8 +572,7 @@ void EngineMixer::process(const int iBufferSize) {
                 m_sampleRate,
                 busFeatures,
                 CSAMPLE_GAIN_ONE,
-                CSAMPLE_GAIN_ONE,
-                false);
+                CSAMPLE_GAIN_ONE);
     }
 
     if (mainEnabled) {
@@ -849,8 +845,7 @@ void EngineMixer::applyMainEffects(int bufferSize) {
                 m_sampleRate,
                 mainFeatures,
                 CSAMPLE_GAIN_ONE,
-                CSAMPLE_GAIN_ONE,
-                false);
+                CSAMPLE_GAIN_ONE);
     }
 }
 


### PR DESCRIPTION
This fixes #15794 

The issue was that the enabling state was maintained only one time. In the first channel that was processed after the change. 
The quick effects are however instantiated for all channels and only one is used. This leads to loss of the enabling disabling states. Now the state is maintained for each instants together with the same sates for the invisible routing switches in m_channelStateMatrix. This even simplifies the code 

before: 
<img width="292" height="287" alt="grafik" src="https://github.com/user-attachments/assets/8b232c2d-cefd-4f4f-973b-343a60bc7710" />


after: 
<img width="247" height="249" alt="grafik" src="https://github.com/user-attachments/assets/f0f327e9-b49f-4fd2-86ef-61d092964b83" />
