### PR TITLE
Fixed rhythmbox imports

### DIFF
--- a/src/library/rhythmbox/rhythmboxfeature.cpp
+++ b/src/library/rhythmbox/rhythmboxfeature.cpp
@@ -97,8 +97,8 @@ RhythmboxFeature::~RhythmboxFeature() {
 }
 
 std::unique_ptr<BaseSqlTableModel>
-RhythmboxFeature::createPlaylistModelForPlaylist(const QVariant& data) {
-    VERIFY_OR_DEBUG_ASSERT(data.canConvert<QString>()) {
+RhythmboxFeature::createPlaylistModelForPlaylist(const QVariant& playlist_name) {
+    VERIFY_OR_DEBUG_ASSERT(playlist_name.canConvert<QString>()) {
         return {};
     }
     auto pModel = std::make_unique<BaseExternalPlaylistModel>(this,
@@ -107,7 +107,7 @@ RhythmboxFeature::createPlaylistModelForPlaylist(const QVariant& data) {
             "rhythmbox_playlists",
             "rhythmbox_playlist_tracks",
             m_trackSource);
-    pModel->setPlaylist(data.toString());
+    pModel->setPlaylist(playlist_name.toString());
     return pModel;
 }
 
@@ -251,7 +251,8 @@ TreeItem* RhythmboxFeature::importPlaylists() {
                 QString playlist_name = attr.value("name").toString();
 
                 //Construct the childmodel
-                rootItem->appendChild(playlist_name);
+                //For Rhythmbox, the playlist name _is_ the unique identifier, so we're using it for both the label and data.
+                rootItem->appendChild(playlist_name, playlist_name);
 
                 //Execute SQL statement
                 query_insert_to_playlists.bindValue(":name", playlist_name);

--- a/src/library/rhythmbox/rhythmboxfeature.cpp
+++ b/src/library/rhythmbox/rhythmboxfeature.cpp
@@ -266,7 +266,9 @@ TreeItem* RhythmboxFeature::importPlaylists() {
                 int playlist_id = query_insert_to_playlists.lastInsertId().toInt();
 
                 //Process playlist entries
+                ScopedTransaction transaction(m_database);
                 importPlaylist(xml, query_insert_to_playlist_tracks, playlist_id);
+                transaction.commit();
             }
         }
     }

--- a/src/library/rhythmbox/rhythmboxfeature.cpp
+++ b/src/library/rhythmbox/rhythmboxfeature.cpp
@@ -250,8 +250,9 @@ TreeItem* RhythmboxFeature::importPlaylists() {
             if (attr.value("type").toString() == "static") {
                 QString playlist_name = attr.value("name").toString();
 
-                //Construct the childmodel
-                //For Rhythmbox, the playlist name _is_ the unique identifier, so we're using it for both the label and data.
+                // Construct the childmodel
+                // For Rhythmbox, the playlist name _is_ the unique identifier,
+                // so we're using it for both the label and data.
                 rootItem->appendChild(playlist_name, playlist_name);
 
                 //Execute SQL statement

--- a/src/library/rhythmbox/rhythmboxfeature.h
+++ b/src/library/rhythmbox/rhythmboxfeature.h
@@ -33,7 +33,7 @@ class RhythmboxFeature : public BaseExternalLibraryFeature {
 
   protected:
     std::unique_ptr<BaseSqlTableModel> createPlaylistModelForPlaylist(
-            const QVariant& data) override;
+            const QVariant& playlist_name) override;
 
   private:
     // Removes all rows from a given table


### PR DESCRIPTION
This MR fixes (among other things?) the "right click > import as Playlist" feature, which was broken so far (for Rhtyhmbox playlists) given that `RhythmboxFeature::createPlaylistModelForPlaylist` was not passed any playlist name in the `QVariant& data`.

It also makes importing a Rhythmbox library waaaaaaay faster.

Successfully tested on Ubuntu 24, based on an up-to-date `main`  branch.