### PR TITLE
Fix `mixxx-test` build to find `mad.h`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3764,7 +3764,7 @@ if(MAD)
   endif()
   target_sources(mixxx-lib PRIVATE src/sources/soundsourcemp3.cpp)
   target_compile_definitions(mixxx-lib PUBLIC __MAD__)
-  target_link_libraries(mixxx-lib PRIVATE MAD::MAD ID3Tag::ID3Tag)
+  target_link_libraries(mixxx-lib PUBLIC MAD::MAD ID3Tag::ID3Tag)
 endif()
 
 # Media Foundation AAC Decoder Plugin


### PR DESCRIPTION
This fixes an error I recived during the build of `mixxx-test`: "fatal error: 'mad.h' file not found".

```text
[1103/1123] Building CXX object CMakeFiles/mixxx-test.dir/src/test/stemtest.cpp.o
FAILED: [code=1] CMakeFiles/mixxx-test.dir/src/test/stemtest.cpp.o
/usr/bin/c++ -DBENCHMARK_STATIC_DEFINE -DGL_SILENCE_DEPRECATION -DMIXXX_BUILD_DEBUG [...]
In file included from src/test/stemtest.cpp:5:
In file included from src/sources/soundsourceproxy.cpp:11:
src/sources/soundsourcemp3.h:11:10: fatal error: 'mad.h' file not found
   11 | #include <mad.h>
      |          ^~~~~~~
1 error generated.
[1114/1123] Building CXX object CMakeFiles/mixxx-test.dir/src/test/stemcontrolobjecttest.cpp.o
ninja: build stopped: subcommand failed.
```

Reported here: https://mixxx.zulipchat.com/#narrow/channel/247620-development-help/topic/macOS.2026.2FTahoe.20dev.20setup.20issues/near/565513629