### PR TITLE
Time widget: make ShowSeconds only show seconds, no extra locale info

### DIFF
--- a/src/widget/wtime.cpp
+++ b/src/widget/wtime.cpp
@@ -7,6 +7,11 @@
 #include "moc_wtime.cpp"
 #include "skin/legacy/skincontext.h"
 
+namespace {
+static constexpr short s_iSecondInterval = 100;
+static constexpr short s_iMinuteInterval = 1000;
+} // namespace
+
 WTime::WTime(QWidget* parent)
         : WLabel(parent),
           m_sTimeFormat("h:mm AP"),
@@ -32,19 +37,24 @@ void WTime::setTimeFormat(const QDomNode& node, const SkinContext& context) {
     if (context.hasNodeSelectString(node, "CustomFormat", &customFormat)) {
         // set the time format to the custom format
         m_sTimeFormat = customFormat;
+        // if seconds are to be displayed, use the seconds refresh interval explicitly
+        if (customFormat.contains(QStringLiteral("ss"), Qt::CaseInsensitive)) {
+            m_interval = s_iSecondInterval;
+        }
     } else {
         // check if seconds should be shown
         QString secondsFormat = context.selectString(node, "ShowSeconds");
-        // long format is equivalent to showing seconds
-        QLocale::FormatType format;
         if(secondsFormat == "true" || secondsFormat == "yes") {
-            format = QLocale::LongFormat;
+            // Note: don't use QLocale::LongFormat since that would not only show
+            // seconds but also append other locale-dependent info, eg. time zone
+            // or AM/PM.
+            // Use 'h' (not 'hh') to omit leading zeros.
             m_interval = s_iSecondInterval;
+            m_sTimeFormat = QStringLiteral("h:mm:ss");
         } else {
-            format = QLocale::ShortFormat;
             m_interval = s_iMinuteInterval;
+            m_sTimeFormat = QLocale().timeFormat(QLocale::ShortFormat);
         }
-        m_sTimeFormat = QLocale().timeFormat(format);
     }
 }
 

--- a/src/widget/wtime.h
+++ b/src/widget/wtime.h
@@ -23,8 +23,4 @@ class WTime: public WLabel {
     QString m_sTimeFormat;
     // m_interval defines how often the time will be updated
     short m_interval;
-    // m_interval is set to s_iSecondInterval if seconds are shown
-    // otherwise, m_interval = s_iMinuteInterval
-    static constexpr short s_iSecondInterval = 100;
-    static constexpr short s_iMinuteInterval = 1000;
 };


### PR DESCRIPTION
Fixes #15804 

Simply use the fixed format hh:mm:ss instead of `QLocale::LongFormat`  which, besides showing seconds, obviously also shows locale-dependent extras like AM/PM.