### PR TITLE
Restore EQ scaling for RGB and HSV waveforms.  

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -11,3 +11,4 @@ ReflectIn
 bufferIn
 indexIn
 allLocations
+allRight

--- a/res/shaders/filteredsignal.frag
+++ b/res/shaders/filteredsignal.frag
@@ -44,9 +44,7 @@ void main(void) {
     bool lowShowing = false;
     bool midShowing = false;
     bool highShowing = false;
-    bool lowShowingUnscaled = false;
-    bool midShowingUnscaled = false;
-    bool highShowingUnscaled = false;
+    bool maxShowingUnscaled = false;
     // We don't exit early if the waveform data is not valid because we may want
     // to show other things (e.g. the axes lines) even when we are on a pixel
     // that does not have valid waveform data.
@@ -71,6 +69,9 @@ void main(void) {
       lowShowing = signalDistance.x >= 0.0;
       midShowing = signalDistance.y >= 0.0;
       highShowing = signalDistance.z >= 0.0;
+      maxShowingUnscaled = new_currentDataUnscaled.x - ourDistance >= 0.0 ||
+              new_currentDataUnscaled.y - ourDistance >= 0.0 ||
+              new_currentDataUnscaled.z - ourDistance >= 0.0;
     }
 
     // Draw the axes color as the lowest item on the screen.
@@ -78,8 +79,10 @@ void main(void) {
     // rendered even when the waveform is fairly short.  Really this
     // value should be based on the size of the widget.
     if (abs(framebufferSize.y / 2 - pixel.y) <= 4) {
-      outputColor.xyz = mix(outputColor.xyz, axesColor.xyz, axesColor.w);
-      outputColor.w = 1.0;
+        outputColor = axesColor;
+    } else if (maxShowingUnscaled) {
+        outputColor.xyz = axesColor.xyz;
+        outputColor.w = axesColor.w * 0.2;
     }
 
     if (lowShowing) {

--- a/res/shaders/rgbsignal.frag
+++ b/res/shaders/rgbsignal.frag
@@ -37,7 +37,6 @@ void main(void) {
 
     vec4 outputColor = vec4(0.0, 0.0, 0.0, 0.0);
     bool showing = false;
-    bool showingUnscaled = false;
     vec4 showingColor = vec4(0.0, 0.0, 0.0, 0.0);
     vec4 showingUnscaledColor = vec4(0.0, 0.0, 0.0, 0.0);
 
@@ -56,28 +55,33 @@ void main(void) {
             new_currentDataUnscaled = max(leftDataUnscaled, rightDataUnscaled) * allGain;
         }
 
-      vec4 new_currentData = new_currentDataUnscaled;
-      new_currentData.x *= lowGain;
-      new_currentData.y *= midGain;
-      new_currentData.z *= highGain;
+        vec4 new_currentData = new_currentDataUnscaled;
+        new_currentData.x *= lowGain;
+        new_currentData.y *= midGain;
+        new_currentData.z *= highGain;
 
-      // ourDistance represents the [0, 1] distance of this pixel from the
-      // center line. If ourDistance is smaller than the signalDistance, show
-      // the pixel.
-      float ourDistance = abs((uv.y - 0.5) * 2.0);
-      float signalDistance = new_currentData.w;
-      showing = (signalDistance - ourDistance) >= 0.0;
+        // ourDistance represents the [0, 1] distance of this pixel from the
+        // center line. If ourDistance is smaller than the signalDistance, show
+        // the pixel.
+        float ourDistance = abs((uv.y - 0.5) * 2.0);
+        float signalDistance = new_currentData.w;
+        signalDistance /= (new_currentDataUnscaled.x + new_currentDataUnscaled.y + new_currentDataUnscaled.z);
+        signalDistance *= (new_currentData.x + new_currentData.y + new_currentData.z);
 
-      // Linearly combine the low, mid, and high colors according to the low,
-      // mid, and high components.
-      showingColor = lowColor * new_currentData.x +
-                     midColor * new_currentData.y +
-                     highColor * new_currentData.z;
+        showing = (signalDistance - ourDistance) >= 0.0;
 
-      // Re-scale the color by the maximum component.
-      float showingMax = max(showingColor.x, max(showingColor.y, showingColor.z));
-      showingColor = showingColor / showingMax;
-      showingColor.w = 1.0;
+        // Linearly combine the low, mid, and high colors according to the low,
+        // mid, and high components.
+        showingColor = lowColor * new_currentData.x +
+                midColor * new_currentData.y +
+                highColor * new_currentData.z;
+
+        // Re-scale the color by the maximum component.
+        float showingMax = max(showingColor.x, max(showingColor.y, showingColor.z));
+        if (showingMax > 0.0) {
+            showingColor = showingColor / showingMax;
+            showingColor.w = 1.0;
+        }
     }
 
     // Draw the axes color as the lowest item on the screen.

--- a/res/shaders/rgbsignal.frag
+++ b/res/shaders/rgbsignal.frag
@@ -30,74 +30,82 @@ vec4 getWaveformData(float index) {
 
 void main(void) {
     vec2 uv = gl_TexCoord[0].st;
-    vec4 pixel = gl_FragCoord;
+    float pixelY = gl_FragCoord.y;
 
-    float new_currentIndex = floor(firstVisualIndex + uv.x *
-                                   (lastVisualIndex - firstVisualIndex)) * 2;
+    float indexRange = lastVisualIndex - firstVisualIndex;
+    float currentIndex = floor(firstVisualIndex + uv.x * indexRange) * 2.0;
 
     vec4 outputColor = vec4(0.0, 0.0, 0.0, 0.0);
-    bool showing = false;
-    vec4 showingColor = vec4(0.0, 0.0, 0.0, 0.0);
-    vec4 showingUnscaledColor = vec4(0.0, 0.0, 0.0, 0.0);
 
-    // We don't exit early if the waveform data is not valid because we may want
-    // to show other things (e.g. the axes lines) even when we are on a pixel
-    // that does not have valid waveform data.
-    if (new_currentIndex >= 0 && new_currentIndex <= waveformLength - 1) {
-        vec4 new_currentDataUnscaled;
+    bool showing = false;
+    bool shadow = false;
+
+    if (currentIndex >= 0.0 && currentIndex <= float(waveformLength - 1)) {
+        vec4 dataUnscaled;
+
         if (splitStereoSignal) {
             // Texture coordinates put (0,0) at the bottom left, so show the right
             // channel if we are in the bottom half.
-            new_currentDataUnscaled = getWaveformData(uv.y < 0.5 ? new_currentIndex + 1 : new_currentIndex) * allGain;
+            float stereoIndex = (uv.y < 0.5) ? currentIndex + 1.0 : currentIndex;
+            dataUnscaled = getWaveformData(stereoIndex);
         } else {
-            vec4 leftDataUnscaled = getWaveformData(new_currentIndex);
-            vec4 rightDataUnscaled = getWaveformData(new_currentIndex + 1);
-            new_currentDataUnscaled = max(leftDataUnscaled, rightDataUnscaled) * allGain;
+            vec4 left = getWaveformData(currentIndex);
+            vec4 right = getWaveformData(currentIndex + 1.0);
+            dataUnscaled = max(left, right);
         }
 
-        vec4 new_currentData = new_currentDataUnscaled;
-        new_currentData.x *= lowGain;
-        new_currentData.y *= midGain;
-        new_currentData.z *= highGain;
+        dataUnscaled *= allGain;
+        vec3 data = dataUnscaled.xyz * vec3(lowGain, midGain, highGain);
 
         // ourDistance represents the [0, 1] distance of this pixel from the
         // center line. If ourDistance is smaller than the signalDistance, show
         // the pixel.
-        float ourDistance = abs((uv.y - 0.5) * 2.0);
-        float signalDistance = new_currentData.w;
-        signalDistance /= (new_currentDataUnscaled.x + new_currentDataUnscaled.y + new_currentDataUnscaled.z);
-        signalDistance *= (new_currentData.x + new_currentData.y + new_currentData.z);
+        float ourDistance = abs(uv.y - 0.5) * 2.0;
 
-        showing = (signalDistance - ourDistance) >= 0.0;
+        float sumUnscaled = dataUnscaled.x + dataUnscaled.y + dataUnscaled.z;
+        float sumScaled = data.x + data.y + data.z;
+
+        float signalDistance = dataUnscaled.w;
+        if (sumUnscaled > 0.0) {
+            signalDistance *= sumScaled / sumUnscaled;
+        }
+
+        showing = signalDistance >= ourDistance;
+        shadow = !showing && (dataUnscaled.w >= ourDistance);
 
         // Linearly combine the low, mid, and high colors according to the low,
         // mid, and high components.
-        showingColor = lowColor * new_currentData.x +
-                midColor * new_currentData.y +
-                highColor * new_currentData.z;
+        if (showing) {
+            outputColor =
+                    lowColor * data.x +
+                    midColor * data.y +
+                    highColor * data.z;
+        } else if (shadow) {
+            outputColor =
+                    lowColor * dataUnscaled.x +
+                    midColor * dataUnscaled.y +
+                    highColor * dataUnscaled.z;
+        }
 
-        // Re-scale the color by the maximum component.
-        float showingMax = max(showingColor.x, max(showingColor.y, showingColor.z));
-        if (showingMax > 0.0) {
-            showingColor = showingColor / showingMax;
-            showingColor.w = 1.0;
+        float maxComponent = max(outputColor.x,
+                max(outputColor.y, outputColor.z));
+
+        if (maxComponent > 0.0) {
+            outputColor.xyz /= maxComponent;
         }
     }
 
-    // Draw the axes color as the lowest item on the screen.
-    // TODO(owilliams): The "4" in this line makes sure the axis gets
-    // rendered even when the waveform is fairly short.  Really this
-    // value should be based on the size of the widget.
-    if (abs(framebufferSize.y / 2 - pixel.y) <= 4) {
-        outputColor.xyz = mix(outputColor.xyz, axesColor.xyz, axesColor.w);
-        outputColor.w = 1.0;
-    }
-
     if (showing) {
-        float alpha = 1.0;
-        outputColor.xyz = mix(outputColor.xyz, showingColor.xyz, alpha);
         outputColor.w = 1.0;
+    } else if (abs(framebufferSize.y / 2 - pixelY) <= 4.0) {
+        // Draw the axes color as the lowest item on the screen.
+        // TODO(owilliams): The "4" in this line makes sure the axis gets
+        // rendered even when the waveform is fairly short.  Really this
+        // value should be based on the size of the widget.
+        outputColor = axesColor;
+    } else if (shadow) {
+        outputColor.w = 0.4;
     }
-    gl_FragColor = outputColor;
 
+    gl_FragColor = outputColor;
 }

--- a/src/waveform/renderers/allshader/waveformrendererrgb.cpp
+++ b/src/waveform/renderers/allshader/waveformrendererrgb.cpp
@@ -105,7 +105,10 @@ bool WaveformRendererRGB::preprocessInner() {
     }
 
     // Per-band gain from the EQ knobs.
-    float allGain(1.0), lowGain(1.0), midGain(1.0), highGain(1.0);
+    float allGain = 1.0f;
+    float lowGain = 1.0f;
+    float midGain = 1.0f;
+    float highGain = 1.0f;
     getGains(&allGain, &lowGain, &midGain, &highGain);
 
     const float breadth = static_cast<float>(m_waveformRenderer->getBreadth());
@@ -192,14 +195,20 @@ bool WaveformRendererRGB::preprocessInner() {
                 chn < (splitLeftRight && !m_isSlipRenderer ? 2 : 1);
                 chn++) {
             // Cast to float
-            float maxLow = static_cast<float>(u8maxLow[chn]);
-            float maxMid = static_cast<float>(u8maxMid[chn]);
-            float maxHigh = static_cast<float>(u8maxHigh[chn]);
+            float maxLowU = static_cast<float>(u8maxLow[chn]);
+            float maxMidU = static_cast<float>(u8maxMid[chn]);
+            float maxHighU = static_cast<float>(u8maxHigh[chn]);
 
             // Apply the gains
-            maxLow *= lowGain;
-            maxMid *= midGain;
-            maxHigh *= highGain;
+            float maxLow = maxLowU * lowGain;
+            float maxMid = maxMidU * midGain;
+            float maxHigh = maxHighU * highGain;
+
+            float allUnscaled = maxLowU + maxMidU + maxHighU;
+            float eqGain = 1.0f;
+            if (allUnscaled > 0.0f) {
+                eqGain = (maxLow + maxMid + maxHigh) / allUnscaled;
+            }
 
             // Use the gained maxLow, maxMid and maxHigh values to calculate the color components
             float red = maxLow * low_r + maxMid * mid_r + maxHigh * high_r;
@@ -222,22 +231,24 @@ bool WaveformRendererRGB::preprocessInner() {
 
             // Lines are thin rectangles
             if (!splitLeftRight) {
-                vertexUpdater.addRectangle({fpos - halfPixelSize,
-                                                   halfBreadth - heightFactorAbs * maxAllChn[chn]},
+                vertexUpdater.addRectangle(
+                        {fpos - halfPixelSize,
+                                halfBreadth -
+                                        heightFactorAbs * eqGain *
+                                                maxAllChn[chn]},
                         {fpos + halfPixelSize,
-                                m_isSlipRenderer
-                                        ? halfBreadth
-                                        : halfBreadth + heightFactorAbs * maxAllChn[chn]},
-                        {red,
-                                green,
-                                blue});
+                                m_isSlipRenderer ? halfBreadth
+                                                 : halfBreadth +
+                                                heightFactorAbs * eqGain *
+                                                        maxAllChn[chn]},
+                        {red, green, blue});
             } else {
                 // note: heightFactor is the same for left and right,
                 // but negative for left (chn 0) and positive for right (chn 1)
                 vertexUpdater.addRectangle({fpos - halfPixelSize,
                                                    halfBreadth},
                         {fpos + halfPixelSize,
-                                halfBreadth + heightFactor[chn] * maxAllChn[chn]},
+                                halfBreadth + heightFactor[chn] * eqGain * maxAllChn[chn]},
                         {red,
                                 green,
                                 blue});

--- a/src/waveform/renderers/waveformrendererhsv.cpp
+++ b/src/waveform/renderers/waveformrendererhsv.cpp
@@ -135,10 +135,10 @@ void WaveformRendererHSV::draw(
         int visualIndexStart = visualFrameStart * 2;
         int visualIndexStop = visualFrameStop * 2;
 
-        int maxLow[2] = {0, 0};
-        int maxHigh[2] = {0, 0};
-        int maxMid[2] = {0, 0};
-        int maxAll[2] = {0, 0};
+        float maxLow[2] = {0.0f, 0.0f};
+        float maxHigh[2] = {0.0f, 0.0f};
+        float maxMid[2] = {0.0f, 0.0f};
+        float maxAll[2] = {0.0f, 0.0f};
 
         for (int i = visualIndexStart;
                 i >= 0 && i + 1 < dataSize && i + 1 <= visualIndexStop;
@@ -146,23 +146,39 @@ void WaveformRendererHSV::draw(
             const WaveformData& waveformDataLeft = *(data + i);
             const WaveformData& waveformDataRight = *(data + i + 1);
             maxLow[0] = math_max(maxLow[0],
-                    static_cast<int>(waveformDataLeft.filtered.low * lowGain));
+                    static_cast<float>(waveformDataLeft.filtered.low));
             maxLow[1] = math_max(maxLow[1],
-                    static_cast<int>(waveformDataRight.filtered.low * lowGain));
+                    static_cast<float>(waveformDataRight.filtered.low));
             maxMid[0] = math_max(maxMid[0],
-                    static_cast<int>(waveformDataLeft.filtered.mid * midGain));
+                    static_cast<float>(waveformDataLeft.filtered.mid));
             maxMid[1] = math_max(maxMid[1],
-                    static_cast<int>(waveformDataRight.filtered.mid * midGain));
+                    static_cast<float>(waveformDataRight.filtered.mid));
             maxHigh[0] = math_max(maxHigh[0],
-                    static_cast<int>(waveformDataLeft.filtered.high * highGain));
+                    static_cast<float>(waveformDataLeft.filtered.high));
             maxHigh[1] = math_max(maxHigh[1],
-                    static_cast<int>(
-                            waveformDataRight.filtered.high * highGain));
-            maxAll[0] = math_max(maxAll[0], static_cast<int>(waveformDataLeft.filtered.all));
-            maxAll[1] = math_max(maxAll[1], static_cast<int>(waveformDataRight.filtered.all));
+                    static_cast<float>(waveformDataRight.filtered.high));
+            maxAll[0] = math_max(maxAll[0], static_cast<float>(waveformDataLeft.filtered.all));
+            maxAll[1] = math_max(maxAll[1], static_cast<float>(waveformDataRight.filtered.all));
         }
 
-        if (maxAll[0] && maxAll[1]) {
+        float allUnscaledLeft = maxLow[0] + maxMid[0] + maxHigh[0];
+        float allUnscaledRight = maxLow[1] + maxMid[1] + maxHigh[1];
+        maxLow[0] *= lowGain;
+        maxLow[1] *= lowGain;
+        maxMid[0] *= midGain;
+        maxMid[1] *= midGain;
+        maxHigh[0] *= highGain;
+        maxHigh[1] *= highGain;
+
+        float eqGain[2] = {1.0f, 1.0f};
+        if (allUnscaledLeft > 0.0f) {
+            eqGain[0] = (maxLow[0] + maxMid[0] + maxHigh[0]) / allUnscaledLeft;
+        }
+        if (allUnscaledRight > 0.0f) {
+            eqGain[1] = (maxLow[1] + maxMid[1] + maxHigh[1]) / allUnscaledRight;
+        }
+
+        if (maxAll[0] > 0.0f && maxAll[1] > 0.0f) {
             // Calculate sum, to normalize
             // Also multiply on 1.2 to prevent very dark or light color
             total = (maxLow[0] + maxLow[1] + maxMid[0] + maxMid[1] +
@@ -191,7 +207,7 @@ void WaveformRendererHSV::draw(
                             breadth,
                             x,
                             breadth -
-                                    static_cast<int>(heightFactor *
+                                    static_cast<int>(heightFactor * math_max(eqGain[0], eqGain[1]) *
                                             (float)math_max(
                                                     maxAll[0], maxAll[1])));
                     break;
@@ -200,16 +216,16 @@ void WaveformRendererHSV::draw(
                     painter->drawLine(x,
                             0,
                             x,
-                            static_cast<int>(heightFactor *
+                            static_cast<int>(heightFactor * math_max(eqGain[0], eqGain[1]) *
                                     (float)math_max(maxAll[0], maxAll[1])));
                     break;
                 default :
                     painter->drawLine(x,
                             static_cast<int>(halfBreadth -
-                                    heightFactor * (float)maxAll[0]),
+                                    heightFactor * eqGain[0] * (float)maxAll[0]),
                             x,
                             static_cast<int>(halfBreadth +
-                                    heightFactor * (float)maxAll[1]));
+                                    heightFactor * eqGain[1] * (float)maxAll[1]));
             }
         }
     }

--- a/src/waveform/renderers/waveformrendererhsv.cpp
+++ b/src/waveform/renderers/waveformrendererhsv.cpp
@@ -78,7 +78,10 @@ void WaveformRendererHSV::draw(
     const double gain = (lastVisualIndex - firstVisualIndex) / length;
     const auto* pColors = m_waveformRenderer->getWaveformSignalColors();
 
-    float allGain(1.0), lowGain(1.0), midGain(1.0), highGain(1.0);
+    float allGain = 1.0;
+    float lowGain = 1.0;
+    float midGain = 1.0;
+    float highGain = 1.0;
     getGains(&allGain, &lowGain, &midGain, &highGain);
 
     // Get base color of waveform in the HSV format (s and v isn't use)
@@ -140,21 +143,23 @@ void WaveformRendererHSV::draw(
         for (int i = visualIndexStart;
                 i >= 0 && i + 1 < dataSize && i + 1 <= visualIndexStop;
                 i += 2) {
-            const WaveformData& waveformData = *(data + i);
-            const WaveformData& waveformDataNext = *(data + i + 1);
-            maxLow[0] = math_max(maxLow[0], static_cast<int>(waveformData.filtered.low * lowGain));
+            const WaveformData& waveformDataLeft = *(data + i);
+            const WaveformData& waveformDataRight = *(data + i + 1);
+            maxLow[0] = math_max(maxLow[0],
+                    static_cast<int>(waveformDataLeft.filtered.low * lowGain));
             maxLow[1] = math_max(maxLow[1],
-                    static_cast<int>(waveformDataNext.filtered.low * lowGain));
-            maxMid[0] = math_max(maxMid[0], static_cast<int>(waveformData.filtered.mid * midGain));
+                    static_cast<int>(waveformDataRight.filtered.low * lowGain));
+            maxMid[0] = math_max(maxMid[0],
+                    static_cast<int>(waveformDataLeft.filtered.mid * midGain));
             maxMid[1] = math_max(maxMid[1],
-                    static_cast<int>(waveformDataNext.filtered.mid * midGain));
+                    static_cast<int>(waveformDataRight.filtered.mid * midGain));
             maxHigh[0] = math_max(maxHigh[0],
-                    static_cast<int>(waveformData.filtered.high * highGain));
+                    static_cast<int>(waveformDataLeft.filtered.high * highGain));
             maxHigh[1] = math_max(maxHigh[1],
                     static_cast<int>(
-                            waveformDataNext.filtered.high * highGain));
-            maxAll[0] = math_max(maxAll[0], static_cast<int>(waveformData.filtered.all));
-            maxAll[1] = math_max(maxAll[1], static_cast<int>(waveformDataNext.filtered.all));
+                            waveformDataRight.filtered.high * highGain));
+            maxAll[0] = math_max(maxAll[0], static_cast<int>(waveformDataLeft.filtered.all));
+            maxAll[1] = math_max(maxAll[1], static_cast<int>(waveformDataRight.filtered.all));
         }
 
         if (maxAll[0] && maxAll[1]) {

--- a/src/waveform/renderers/waveformrendererrgb.cpp
+++ b/src/waveform/renderers/waveformrendererrgb.cpp
@@ -76,7 +76,10 @@ void WaveformRendererRGB::draw(
     const double gain = (lastVisualIndex - firstVisualIndex) / length;
 
     // Per-band gain from the EQ knobs.
-    float allGain(1.0), lowGain(1.0), midGain(1.0), highGain(1.0);
+    float allGain = 1.0f;
+    float lowGain = 1.0f;
+    float midGain = 1.0f;
+    float highGain = 1.0f;
     getGains(&allGain, &lowGain, &midGain, &highGain);
 
     QColor color;
@@ -129,21 +132,27 @@ void WaveformRendererRGB::draw(
         unsigned char maxLow  = 0;
         unsigned char maxMid  = 0;
         unsigned char maxHigh = 0;
-        float maxAll = 0.;
-        float maxAllNext = 0.;
+        float maxAllLeft = 0.;
+        float maxAllRight = 0.;
 
         for (int i = visualIndexStart;
              i >= 0 && i + 1 < dataSize && i + 1 <= visualIndexStop; i += 2) {
-            const WaveformData& waveformData = data[i];
-            const WaveformData& waveformDataNext = data[i + 1];
+            const WaveformData& waveformDataLeft = data[i];
+            const WaveformData& waveformDataRight = data[i + 1];
 
-            maxLow  = math_max3(maxLow,  waveformData.filtered.low,  waveformDataNext.filtered.low);
-            maxMid  = math_max3(maxMid,  waveformData.filtered.mid,  waveformDataNext.filtered.mid);
-            maxHigh = math_max3(maxHigh, waveformData.filtered.high, waveformDataNext.filtered.high);
-            float all = waveformData.filtered.all;
-            maxAll = math_max(maxAll, all);
-            float allNext = waveformDataNext.filtered.all;
-            maxAllNext = math_max(maxAllNext, allNext);
+            maxLow = math_max3(maxLow,
+                    waveformDataLeft.filtered.low,
+                    waveformDataRight.filtered.low);
+            maxMid = math_max3(maxMid,
+                    waveformDataLeft.filtered.mid,
+                    waveformDataRight.filtered.mid);
+            maxHigh = math_max3(maxHigh,
+                    waveformDataLeft.filtered.high,
+                    waveformDataRight.filtered.high);
+            float allLeft = waveformDataLeft.filtered.all;
+            maxAllLeft = math_max(maxAllLeft, allLeft);
+            float allRight = waveformDataRight.filtered.all;
+            maxAllRight = math_max(maxAllRight, allRight);
         }
 
         float maxLowF = maxLow * lowGain;
@@ -176,18 +185,21 @@ void WaveformRendererRGB::draw(
                             x,
                             breadth -
                                     static_cast<int>(heightFactor *
-                                            math_max(maxAll, maxAllNext)));
+                                            math_max(maxAllLeft, maxAllRight)));
                     break;
                 case Qt::AlignTop:
                 case Qt::AlignLeft:
-                    painter->drawLine(
-                            x, 0, x, static_cast<int>(heightFactor * math_max(maxAll, maxAllNext)));
+                    painter->drawLine(x,
+                            0,
+                            x,
+                            static_cast<int>(heightFactor *
+                                    math_max(maxAllLeft, maxAllRight)));
                     break;
                 default:
                     painter->drawLine(x,
-                            static_cast<int>(halfBreadth - heightFactor * maxAll),
+                            static_cast<int>(halfBreadth - heightFactor * maxAllLeft),
                             x,
-                            static_cast<int>(halfBreadth + heightFactor * maxAllNext));
+                            static_cast<int>(halfBreadth + heightFactor * maxAllRight));
             }
         }
     }

--- a/src/waveform/renderers/waveformrendererrgb.cpp
+++ b/src/waveform/renderers/waveformrendererrgb.cpp
@@ -159,6 +159,12 @@ void WaveformRendererRGB::draw(
         float maxMidF = maxMid * midGain;
         float maxHighF = maxHigh * highGain;
 
+        float allUnscaled = maxLow + maxMid + maxHigh;
+        float eqGain = 1.0f;
+        if (allUnscaled > 0.0f) {
+            eqGain = (maxLowF + maxMidF + maxHighF) / allUnscaled;
+        }
+
         float red = maxLowF * m_rgbLowColor_r + maxMidF * m_rgbMidColor_r +
                 maxHighF * m_rgbHighColor_r;
         float green = maxLowF * m_rgbLowColor_g + maxMidF * m_rgbMidColor_g +
@@ -184,7 +190,7 @@ void WaveformRendererRGB::draw(
                             breadth,
                             x,
                             breadth -
-                                    static_cast<int>(heightFactor *
+                                    static_cast<int>(heightFactor * eqGain *
                                             math_max(maxAllLeft, maxAllRight)));
                     break;
                 case Qt::AlignTop:
@@ -192,14 +198,14 @@ void WaveformRendererRGB::draw(
                     painter->drawLine(x,
                             0,
                             x,
-                            static_cast<int>(heightFactor *
+                            static_cast<int>(heightFactor * eqGain *
                                     math_max(maxAllLeft, maxAllRight)));
                     break;
                 default:
                     painter->drawLine(x,
-                            static_cast<int>(halfBreadth - heightFactor * maxAllLeft),
+                            static_cast<int>(halfBreadth - heightFactor * eqGain * maxAllLeft),
                             x,
-                            static_cast<int>(halfBreadth + heightFactor * maxAllRight));
+                            static_cast<int>(halfBreadth + heightFactor * eqGain * maxAllRight));
             }
         }
     }

--- a/src/waveform/renderers/waveformrenderersimplesignal.cpp
+++ b/src/waveform/renderers/waveformrenderersimplesignal.cpp
@@ -130,18 +130,18 @@ void WaveformRendererSimpleSignal::draw(
         int visualIndexStart = visualFrameStart * 2;
         int visualIndexStop = visualFrameStop * 2;
 
-        float maxAll = 0.;
-        float maxAllNext = 0.;
+        float maxAllLeft = 0.;
+        float maxAllRight = 0.;
 
         for (int i = visualIndexStart;
                 i >= 0 && i + 1 < dataSize && i + 1 <= visualIndexStop;
                 i += 2) {
-            const WaveformData& waveformData = data[i];
-            const WaveformData& waveformDataNext = data[i + 1];
-            float all = waveformData.filtered.all;
-            maxAll = math_max(maxAll, all);
-            float allNext = waveformDataNext.filtered.all;
-            maxAllNext = math_max(maxAllNext, allNext);
+            const WaveformData& waveformDataLeft = data[i];
+            const WaveformData& waveformDataRight = data[i + 1];
+            float allLeft = waveformDataLeft.filtered.all;
+            maxAllLeft = math_max(maxAllLeft, allLeft);
+            float allRight = waveformDataRight.filtered.all;
+            maxAllRight = math_max(maxAllRight, allRight);
         }
 
         pen.setColor(color);
@@ -154,18 +154,18 @@ void WaveformRendererSimpleSignal::draw(
                     x,
                     breadth -
                             static_cast<int>(heightFactor *
-                                    math_max(maxAll, maxAllNext)));
+                                    math_max(maxAllLeft, maxAllRight)));
             break;
         case Qt::AlignTop:
         case Qt::AlignLeft:
             painter->drawLine(
-                    x, 0, x, static_cast<int>(heightFactor * math_max(maxAll, maxAllNext)));
+                    x, 0, x, static_cast<int>(heightFactor * math_max(maxAllLeft, maxAllRight)));
             break;
         default:
             painter->drawLine(x,
-                    static_cast<int>(halfBreadth - heightFactor * maxAll),
+                    static_cast<int>(halfBreadth - heightFactor * maxAllLeft),
                     x,
-                    static_cast<int>(halfBreadth + heightFactor * maxAllNext));
+                    static_cast<int>(halfBreadth + heightFactor * maxAllRight));
         }
     }
 }


### PR DESCRIPTION
This fixes #15788 a LOW-Kill action, with the new unscaled shadow:  

Here you see a waveform with killed low end and Tango 

<img width="349" height="98" alt="grafik" src="https://github.com/user-attachments/assets/d61120bf-25c5-48fb-abbb-bd9376b11167" />