### PR TITLE
Tuning detection for Queen Mary Key detector 

### DIFF
--- a/lib/qm-dsp/dsp/chromagram/ConstantQ.cpp
+++ b/lib/qm-dsp/dsp/chromagram/ConstantQ.cpp
@@ -64,12 +64,14 @@ void ConstantQ::sparsekernel()
 
         const double samplesPerCycle =
             m_FS / (m_FMin * pow(2, (double)j / (double)m_BPO));
-        int windowLength = (int)ceil(m_dQ * samplesPerCycle);
+        int windowLength = (int)ceil(m_dQ * samplesPerCycle / 2) * 2;
 
-        int origin = m_FFTLength/2 - windowLength/2;
+        int origin = m_FFTLength / 2 - windowLength / 2;
+        double center = (windowLength - 1) / 2.0;
 
         for (int i = 0; i < windowLength; ++i) {
-            double angle = (2.0 * M_PI * i) / samplesPerCycle;
+            double centered_i = i - center;
+            double angle = (2.0 * M_PI * centered_i) / samplesPerCycle;
             windowRe[origin + i] = cos(angle);
             windowIm[origin + i] = sin(angle);
         }

--- a/lib/qm-dsp/dsp/keydetection/GetKeyMode.cpp
+++ b/lib/qm-dsp/dsp/keydetection/GetKeyMode.cpp
@@ -110,7 +110,15 @@ double getGaussianPeak(double* pChromaBuffer, int peakBin) {
     if (denom == 0) {
         return peakBin;
     }
-    return peakBin + (y0 - y2) / (2 * denom);
+    double gausianPeak = peakBin + (y0 - y2) / (2 * denom);
+
+    // Handle under and overflow for [-0.5...35.5[
+    if (gausianPeak < -0.5) {
+        gausianPeak+= kBinsPerOctave;
+    } else if (gausianPeak >= kBinsPerOctave - 0.5) {
+        gausianPeak -= kBinsPerOctave;
+    }
+    return gausianPeak;
 }
 
 } // namespace

--- a/lib/qm-dsp/dsp/keydetection/GetKeyMode.cpp
+++ b/lib/qm-dsp/dsp/keydetection/GetKeyMode.cpp
@@ -94,7 +94,7 @@ double getGaussianPeak(double* pChromaBuffer, int peakBin) {
         if (modPeak == 0) {
             peakBin -= 1;
         } else if (modPeak == 1) {
-            peakBin -= 1;
+            peakBin += 1;
         }
     }
 

--- a/lib/qm-dsp/dsp/keydetection/GetKeyMode.cpp
+++ b/lib/qm-dsp/dsp/keydetection/GetKeyMode.cpp
@@ -24,6 +24,7 @@
 #include "base/Pitch.h"
 
 #include <algorithm>
+#include <cmath>
 #include <iostream>
 
 #include <cstring>
@@ -211,10 +212,10 @@ GetKeyMode::GetKeyMode(Config config) :
     }
 
     m_medianFilterBuffer = new double[ m_medianWinSize ];
-    memset( m_medianFilterBuffer, 0, sizeof(int)*m_medianWinSize);
+    memset( m_medianFilterBuffer, 0, sizeof(double)*m_medianWinSize);
     
     m_sortedBuffer = new double[ m_medianWinSize ];
-    memset( m_sortedBuffer, 0, sizeof(int)*m_medianWinSize);
+    memset( m_sortedBuffer, 0, sizeof(double)*m_medianWinSize);
     
     m_decimator = new Decimator( m_chromaFrameSize * m_decimationFactor,
                                  m_decimationFactor );

--- a/lib/qm-dsp/dsp/keydetection/GetKeyMode.h
+++ b/lib/qm-dsp/dsp/keydetection/GetKeyMode.h
@@ -51,7 +51,7 @@ public:
      * Return a key index in the range 0-24, where 0 indicates no key
      * detected, 1 is C major, and 13 is C minor.
      */
-    int process(double *pcmData);
+    double process(double *pcmData);
 
     /**
      * Return a pointer to an internal 24-element array containing the
@@ -101,13 +101,14 @@ protected:
     double* m_decimatedBuffer;
     double* m_chromaBuffer;
     double* m_meanHPCP;
+    double* m_meanNormHPCP;
 
     double* m_majProfileNorm;
     double* m_minProfileNorm;
     double* m_majCorr;
     double* m_minCorr;
-    int* m_medianFilterBuffer;
-    int* m_sortedBuffer;
+    double* m_medianFilterBuffer;
+    double* m_sortedBuffer;
 
     double *m_keyStrengths;
 };

--- a/lib/qm-dsp/dsp/keydetection/GetKeyMode.h
+++ b/lib/qm-dsp/dsp/keydetection/GetKeyMode.h
@@ -48,8 +48,9 @@ public:
      * getBlockSize(). Successive calls should provide overlapped data
      * with an advance of getHopSize() between frames.
      *
-     * Return a key index in the range 0-24, where 0 indicates no key
-     * detected, 1 is C major, and 13 is C minor.
+     * Return a fractional key value for tuning offsets in the range 0 or 
+     * 0.5 - 24.4999, where 0 indicates no key detected, 1 is C major, and 13 
+     * is C minor.
      */
     double process(double *pcmData);
 

--- a/src/analyzer/analyzerkey.cpp
+++ b/src/analyzer/analyzerkey.cpp
@@ -225,8 +225,10 @@ void AnalyzerKey::storeResults(TrackPointer tio) {
     KeyChangeList key_changes = m_pPlugin->getKeyChanges();
     QHash<QString, QString> extraVersionInfo = getExtraVersionInfo(
             m_pluginId, m_bPreferencesFastAnalysisEnabled);
-    Keys track_keys = KeyFactory::makePreferredKeys(
-            key_changes, extraVersionInfo, m_sampleRate, m_totalFrames);
+    Keys track_keys = KeyFactory::makePreferredKeys(key_changes,
+            extraVersionInfo,
+            m_sampleRate,
+            m_totalFrames);
     tio->setKeys(track_keys);
 }
 

--- a/src/analyzer/plugins/analyzerkeyfinder.cpp
+++ b/src/analyzer/plugins/analyzerkeyfinder.cpp
@@ -108,7 +108,7 @@ bool AnalyzerKeyFinder::finalize() {
     m_keyFinder.finalChromagram(m_workspace);
     ChromaticKey finalKey = chromaticKeyFromKeyFinderKeyT(
             m_keyFinder.keyOfChromagram(m_workspace));
-    m_resultKeys.push_back(qMakePair(finalKey, m_currentFrame));
+    m_resultKeys.push_back({finalKey, 0.0, mixxx::audio::FramePos(m_currentFrame)});
     return true;
 }
 

--- a/src/analyzer/plugins/analyzerqueenmarykey.cpp
+++ b/src/analyzer/plugins/analyzerqueenmarykey.cpp
@@ -66,7 +66,7 @@ bool AnalyzerQueenMaryKey::initialize(mixxx::audio::SampleRate sampleRate) {
                 int iKey = static_cast<int>(dKey + 0.5);
 
                 double tuningFrequencyHz = centsToTuningFrequencyHz(dKey - iKey);
-                qWarning() << "tuningFrequencyHz:" << tuningFrequencyHz << dKey << iKey;
+                // qWarning() << "tuningFrequencyHz:" << tuningFrequencyHz << dKey << iKey;
 
                 if (!ChromaticKey_IsValid(iKey)) {
                     qWarning() << "No valid key detected in analyzed window:" << iKey;
@@ -79,7 +79,15 @@ bool AnalyzerQueenMaryKey::initialize(mixxx::audio::SampleRate sampleRate) {
                     m_resultKeys.push_back({key,
                             tuningFrequencyHz,
                             mixxx::audio::FramePos(m_currentFrame)});
+                    m_tuningFrequenciesHz.clear();
+                    m_tuningFrequenciesHz.push_back(tuningFrequencyHz);
                     m_prevKey = key;
+                } else {
+                    m_tuningFrequenciesHz.push_back(tuningFrequencyHz);
+                    double sum = std::accumulate(m_tuningFrequenciesHz.begin(),
+                            m_tuningFrequenciesHz.end(),
+                            0.0);
+                    m_resultKeys.back().tuningFrequencyHz = sum / m_tuningFrequenciesHz.size();
                 }
                 return true;
             });

--- a/src/analyzer/plugins/analyzerqueenmarykey.cpp
+++ b/src/analyzer/plugins/analyzerqueenmarykey.cpp
@@ -63,6 +63,7 @@ bool AnalyzerQueenMaryKey::initialize(mixxx::audio::SampleRate sampleRate) {
     return m_helper.initialize(
             windowSize, stepSize, [this](double* pWindow, size_t) {
                 double dKey = m_pKeyMode->process(pWindow);
+                // dKey is [-0.5...12.5[ / [12.5...24.5[
                 int iKey = static_cast<int>(dKey + 0.5);
 
                 double tuningFrequencyHz = centsToTuningFrequencyHz(dKey - iKey);

--- a/src/analyzer/plugins/analyzerqueenmarykey.cpp
+++ b/src/analyzer/plugins/analyzerqueenmarykey.cpp
@@ -75,7 +75,7 @@ bool AnalyzerQueenMaryKey::initialize(mixxx::audio::SampleRate sampleRate) {
                     return false;
                 }
                 const auto key = static_cast<ChromaticKey>(iKey);
-                if (key != m_prevKey) {
+                if (key != m_prevKey || m_resultKeys.isEmpty()) {
                     // TODO(rryan) reserve?
                     m_resultKeys.push_back({key,
                             tuningFrequencyHz,

--- a/src/analyzer/plugins/analyzerqueenmarykey.cpp
+++ b/src/analyzer/plugins/analyzerqueenmarykey.cpp
@@ -68,8 +68,7 @@ bool AnalyzerQueenMaryKey::initialize(mixxx::audio::SampleRate sampleRate) {
                 const auto key = static_cast<ChromaticKey>(iKey);
                 if (key != m_prevKey) {
                     // TODO(rryan) reserve?
-                    m_resultKeys.push_back(qMakePair(
-                            key, static_cast<double>(m_currentFrame)));
+                    m_resultKeys.push_back({key, 0.0, mixxx::audio::FramePos(m_currentFrame)});
                     m_prevKey = key;
                 }
                 return true;

--- a/src/analyzer/plugins/analyzerqueenmarykey.cpp
+++ b/src/analyzer/plugins/analyzerqueenmarykey.cpp
@@ -1,5 +1,8 @@
 #include <dsp/keydetection/GetKeyMode.h>
 
+#include <cmath>
+#include <numeric>
+
 // Class header comes after library includes here since our preprocessor
 // definitions interfere with qm-dsp's headers.
 #include "analyzer/plugins/analyzerqueenmarykey.h"

--- a/src/analyzer/plugins/analyzerqueenmarykey.h
+++ b/src/analyzer/plugins/analyzerqueenmarykey.h
@@ -44,6 +44,7 @@ class AnalyzerQueenMaryKey : public AnalyzerKeyPlugin {
     size_t m_currentFrame;
     KeyChangeList m_resultKeys;
     mixxx::track::io::key::ChromaticKey m_prevKey;
+    std::vector<double> m_tuningFrequenciesHz;
 };
 
 } // namespace mixxx

--- a/src/test/keyfactorytest.cpp
+++ b/src/test/keyfactorytest.cpp
@@ -12,9 +12,9 @@ class KeyFactoryTest : public testing::Test {
 
 TEST_F(KeyFactoryTest, MakePreferredKeys) {
     KeyChangeList key_changes = {
-            {mixxx::track::io::key::B_MAJOR, 1.0},
-            {mixxx::track::io::key::B_MINOR, 2.0},
-            {mixxx::track::io::key::B_MAJOR, 3.0},
+            {mixxx::track::io::key::B_MAJOR, 440.0, mixxx::audio::FramePos(1.0)},
+            {mixxx::track::io::key::B_MINOR, 440.0, mixxx::audio::FramePos(2.0)},
+            {mixxx::track::io::key::B_MAJOR, 440.0, mixxx::audio::FramePos(3.0)},
     };
     QHash<QString, QString> extraVersionInfo = {{QStringLiteral("a"), QStringLiteral("b")}};
 

--- a/src/test/keyfactorytest.cpp
+++ b/src/test/keyfactorytest.cpp
@@ -24,4 +24,5 @@ TEST_F(KeyFactoryTest, MakePreferredKeys) {
     EXPECT_EQ(track_keys.getGlobalKey(), mixxx::track::io::key::B_MAJOR);
     EXPECT_EQ(track_keys.getGlobalKeyText().toStdString(), "B");
     EXPECT_EQ(track_keys.getSubVersion().toStdString(), "a=b");
+    EXPECT_DOUBLE_EQ(track_keys.getGlobalTuningFrequencyHz(), 440.0);
 }

--- a/src/track/keyfactory.cpp
+++ b/src/track/keyfactory.cpp
@@ -135,10 +135,10 @@ Keys KeyFactory::makePreferredKeys(
                 it != key_changes.constEnd();
                 ++it) {
             // Key position is in frames. Do not accept fractional frames.
-            double frame = floor(it->second);
+            double frame = it->framePos.toLowerFrameBoundary().value();
 
             KeyMap::KeyChange* pChange = key_map.add_key_change();
-            pChange->set_key(it->first);
+            pChange->set_key(it->key);
             pChange->set_frame_position(static_cast<int>(frame));
         }
 

--- a/src/track/keyfactory.cpp
+++ b/src/track/keyfactory.cpp
@@ -125,8 +125,7 @@ Keys KeyFactory::makePreferredKeys(
         const KeyChangeList& key_changes,
         const QHash<QString, QString>& extraVersionInfo,
         const mixxx::audio::SampleRate sampleRate,
-        SINT totalFrames,
-        double tuningFrequencyHz) {
+        SINT totalFrames) {
     const QString version = getPreferredVersion();
     const QString subVersion = getPreferredSubVersion(extraVersionInfo);
 
@@ -151,7 +150,6 @@ Keys KeyFactory::makePreferredKeys(
                 global_key, KeyUtils::KeyNotation::ID3v2);
         key_map.set_global_key_text(global_key_text.toStdString());
         key_map.set_source(mixxx::track::io::key::ANALYZER);
-        key_map.set_global_tuning_frequency_hz(tuningFrequencyHz);
         Keys keys(key_map);
         keys.setSubVersion(subVersion);
         return keys;

--- a/src/track/keyfactory.cpp
+++ b/src/track/keyfactory.cpp
@@ -139,17 +139,19 @@ Keys KeyFactory::makePreferredKeys(
 
             KeyMap::KeyChange* pChange = key_map.add_key_change();
             pChange->set_key(it->key);
+            pChange->set_tuning_frequency_hz(it->tuningFrequencyHz);
             pChange->set_frame_position(static_cast<int>(frame));
         }
 
-        mixxx::track::io::key::ChromaticKey global_key =
+        KeyChange global_key =
                 KeyUtils::calculateGlobalKey(
                         key_changes, totalFrames, sampleRate);
-        key_map.set_global_key(global_key);
+        key_map.set_global_key(global_key.key);
         QString global_key_text = KeyUtils::keyToString(
-                global_key, KeyUtils::KeyNotation::ID3v2);
+                global_key.key, KeyUtils::KeyNotation::ID3v2);
         key_map.set_global_key_text(global_key_text.toStdString());
         key_map.set_source(mixxx::track::io::key::ANALYZER);
+        key_map.set_global_tuning_frequency_hz(global_key.tuningFrequencyHz);
         Keys keys(key_map);
         keys.setSubVersion(subVersion);
         return keys;

--- a/src/track/keyfactory.h
+++ b/src/track/keyfactory.h
@@ -40,6 +40,5 @@ class KeyFactory {
             const KeyChangeList& key_changes,
             const QHash<QString, QString>& extraVersionInfo,
             mixxx::audio::SampleRate sampleRate,
-            SINT totalFrames,
-            double tuningFrequencyHz = 0.0);
+            SINT totalFrames);
 };

--- a/src/track/keys.h
+++ b/src/track/keys.h
@@ -4,11 +4,17 @@
 #include <QList>
 #include <QPair>
 
+#include "audio/frame.h"
 #include "proto/keys.pb.h"
 
 #define KEY_MAP_VERSION "KeyMap-1.0"
 
-typedef QList<QPair<mixxx::track::io::key::ChromaticKey, double>> KeyChangeList;
+struct KeyChange {
+    mixxx::track::io::key::ChromaticKey key;
+    double tuningFrequencyHz;
+    mixxx::audio::FramePos framePos;
+};
+typedef QList<KeyChange> KeyChangeList;
 
 class Keys final {
   public:

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -631,17 +631,17 @@ ChromaticKey KeyUtils::scaleKeySteps(ChromaticKey key, int key_changes) {
 mixxx::track::io::key::ChromaticKey KeyUtils::calculateGlobalKey(
         const KeyChangeList& key_changes, SINT totalFrames, mixxx::audio::SampleRate sampleRate) {
     if (key_changes.size() == 1) {
-        qDebug() << keyDebugName(key_changes[0].first);
-        return key_changes[0].first;
+        qDebug() << keyDebugName(key_changes[0].key);
+        return key_changes[0].key;
     }
     QMap<mixxx::track::io::key::ChromaticKey, double> key_histogram;
 
     for (int i = 0; i < key_changes.size(); ++i) {
-        mixxx::track::io::key::ChromaticKey key = key_changes[i].first;
-        const double start_frame = key_changes[i].second;
+        mixxx::track::io::key::ChromaticKey key = key_changes[i].key;
+        const double start_frame = key_changes[i].framePos.value();
         const double next_frame = (i == key_changes.size() - 1)
                 ? totalFrames
-                : key_changes[i + 1].second;
+                : key_changes[i + 1].framePos.value();
         key_histogram[key] += (next_frame - start_frame);
     }
 

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -648,7 +648,7 @@ KeyChange KeyUtils::calculateGlobalKey(
                     duration_frames * key_changes[i].tuningFrequencyHz;
             key_histogram[key].framePos += duration_frames;
         } else {
-            qDebug() << key_changes[i].key << ": " << key_changes[i].tuningFrequencyHz;
+            // qDebug() << key_changes[i].key << ": " << key_changes[i].tuningFrequencyHz;
             key_histogram[key] = {key_changes[i].key,
                     duration_frames * key_changes[i].tuningFrequencyHz,
                     mixxx::audio::FramePos(duration_frames)};
@@ -661,8 +661,10 @@ KeyChange KeyUtils::calculateGlobalKey(
     for (auto it = key_histogram.constBegin();
          it != key_histogram.constEnd(); ++it) {
         qDebug() << it.key() << ":" << keyDebugName(it.key())
-                 << it.value().tuningFrequencyHz
-                 << it.value().framePos.value() / sampleRate;
+                 << it.value().tuningFrequencyHz / it.value().framePos.value()
+                 << "Hz"
+                 << it.value().framePos.value() / sampleRate
+                 << "s";
         if (it.value().framePos.value() > max_delta) {
             max_key = it.value();
             max_delta = it.value().framePos.value();

--- a/src/track/keyutils.cpp
+++ b/src/track/keyutils.cpp
@@ -668,7 +668,7 @@ KeyChange KeyUtils::calculateGlobalKey(
         if (it.value().framePos.value() > max_delta) {
             max_key = it.value();
             max_delta = it.value().framePos.value();
-            // Calculate the average Tunig Frequency weighted by duration
+            // Calculate the average Tuning Frequency weighted by duration
             max_key.tuningFrequencyHz /= max_delta;
         }
     }

--- a/src/track/keyutils.h
+++ b/src/track/keyutils.h
@@ -97,7 +97,7 @@ class KeyUtils {
 
     static mixxx::track::io::key::ChromaticKey guessKeyFromText(const QString& text);
 
-    static mixxx::track::io::key::ChromaticKey calculateGlobalKey(
+    static KeyChange calculateGlobalKey(
             const KeyChangeList& key_changes,
             SINT totalFrames,
             mixxx::audio::SampleRate sampleRate);


### PR DESCRIPTION
This is on top of https://github.com/mixxxdj/mixxx/pull/15795 which shall be merged first. 

This adds a tuning detector to the Queen Mary Key detector. Every Key has a tuning. Only Keys with the same tuning +-10 cent cn be compared via the key wheel. Tracks with a different tuning are never compatible. This is on the way to make the key feature fully usable. 

I have tested this with sine waves of different frequency and some tracks. The result is pretty precise after a bit of puzzling: 
<img width="287" height="567" alt="grafik" src="https://github.com/user-attachments/assets/5062a1c6-882d-44c7-9576-35e5020a2994" />


