### PR TITLE
refact(RhythmBoxFeature): Simplified library detection

### DIFF
--- a/src/library/rhythmbox/rhythmboxfeature.cpp
+++ b/src/library/rhythmbox/rhythmboxfeature.cpp
@@ -287,7 +287,8 @@ TreeItem* RhythmboxFeature::importPlaylists() {
 QString RhythmboxFeature::maybeDatabaseFolder(void) {
     const QStringList paths = {
             QDir::homePath() + "/.gnome2/rhythmbox/",
-            QDir::homePath() + "/.local/share/rhythmbox/"};
+            QDir::homePath() + "/.local/share/rhythmbox/",
+            QDir::homePath() + "/.var/app/org.gnome.Rhythmbox3/data/rhythmbox/"};
 
     for (const auto& path : paths) {
         if (QDir(path).exists()) {

--- a/src/library/rhythmbox/rhythmboxfeature.h
+++ b/src/library/rhythmbox/rhythmboxfeature.h
@@ -36,6 +36,11 @@ class RhythmboxFeature : public BaseExternalLibraryFeature {
             const QVariant& playlist_name) override;
 
   private:
+    // returns the path to the database parts if they exist or an empty string
+    static QString maybeDatabaseFolder(void);
+    static QString maybeDatabaseFilePath(void);
+    static QString maybePlaylistsFilePath(void);
+
     // Removes all rows from a given table
     void clearTable(const QString& table_name);
     // reads the properties of a track and executes a SQL statement


### PR DESCRIPTION
Unified the method used to detect the library behind maybeDatabaseFilePath() and playlists behind maybePlaylistsFilePath() to make sure code wouldn't be duplicated.

Added support for Rythmbox3 when installed as flatpak